### PR TITLE
[burn-import] Add other DataType by conversion to i32

### DIFF
--- a/burn-import/src/onnx/proto_conversion.rs
+++ b/burn-import/src/onnx/proto_conversion.rs
@@ -34,10 +34,62 @@ impl TryFrom<TensorProto> for Tensor {
                     Data::Float32s(tensor.float_data)
                 },
             ),
-            DataType::INT16 => {
-                // TODO : Add support for int16 by converting to int32
-                todo!("Add support for int16");
-            }
+            DataType::UINT8 => (
+                ElementType::Int32,
+                // Convert the raw data to a vector of ints
+                if !tensor.raw_data.is_empty() {
+                    Data::Int32s(
+                        cast_slice::<u8, u8>(&tensor.raw_data[..])
+                            .iter()
+                            .map(|raw_datum| *raw_datum as i32)
+                            .collect(),
+                    )
+                } else {
+                    Data::Int32s(vec![])
+                },
+            ),
+            DataType::INT8 => (
+                ElementType::Int32,
+                // Convert the raw data to a vector of ints
+                if !tensor.raw_data.is_empty() {
+                    Data::Int32s(
+                        cast_slice::<u8, i8>(&tensor.raw_data[..])
+                            .iter()
+                            .map(|raw_datum| *raw_datum as i32)
+                            .collect(),
+                    )
+                } else {
+                    Data::Int32s(vec![])
+                },
+            ),
+            DataType::UINT16 => (
+                ElementType::Int32,
+                // Convert the raw data to a vector of ints
+                if !tensor.raw_data.is_empty() {
+                    Data::Int32s(
+                        cast_slice::<u8, u16>(&tensor.raw_data[..])
+                            .iter()
+                            .map(|raw_datum| *raw_datum as i32)
+                            .collect(),
+                    )
+                } else {
+                    Data::Int32s(vec![])
+                },
+            ),
+            DataType::INT16 => (
+                ElementType::Int32,
+                // Convert the raw data to a vector of ints
+                if !tensor.raw_data.is_empty() {
+                    Data::Int32s(
+                        cast_slice::<u8, i16>(&tensor.raw_data[..])
+                            .iter()
+                            .map(|raw_datum| *raw_datum as i32)
+                            .collect(),
+                    )
+                } else {
+                    Data::Int32s(vec![])
+                },
+            ),
             DataType::INT32 => (
                 ElementType::Int32,
                 // Convert the raw data to a vector of ints


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ ] Confirm that `run-checks` script has been executed.

### Related Issues/PRs

- None

### Changes

The current burn-import main dosent' implement any other data types than int32. 

Instead it marks it as TODO with a note abour converting to i32

https://github.com/burn-rs/burn/blob/96524d40a1cffc8c13394f70775ce53d5a1abd3b/burn-import/src/onnx/proto_conversion.rs#L37-L40

This fills out that todo by converting to i32.


### Testing

- Not yet, just discussing the changes first to see what is the scope of the PR is and where other changes should be made

Should I also for example make any adjustments to the cast nodes