### PR TITLE
Fix image classifier build failure by upgrading versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,23 +32,24 @@ members = [
 exclude = ["examples/notebook"]
 
 [workspace.dependencies]
-async-trait = "0.1.73"
+async-trait = "0.1.74"
 bytemuck = "1.14"
-const-random = "0.1.15"
+const-random = "0.1.17"
 csv = "1.3.0"
 dashmap = "5.5.3"
 dirs = "5.0.1"
-fake = "2.8.0"
-flate2 = "1.0.27"
+fake = "2.9.1"
+flate2 = "1.0.28"
 float-cmp = "0.9.0"
-getrandom = { version = "0.2.10", default-features = false }
+getrandom = { version = "0.2.11", default-features = false }
 gix-tempfile = { version = "8.0.0", features = ["signals"] }
-hashbrown = "0.14.1"
+hashbrown = "0.14.2"
 indicatif = "0.17.7"
+js-sys = "0.3.65"
 libm = "0.2.8"
 log = { default-features = false, version = "0.4.20" }
 pretty_assertions = "1.4"
-proc-macro2 = "1.0.68"
+proc-macro2 = "1.0.69"
 protobuf-codegen = "3.3"
 quote = "1.0.33"
 r2d2 = "0.8.10"
@@ -59,18 +60,21 @@ rstest = "0.18.2"
 rusqlite = { version = "0.30.0" }
 sanitize-filename = "0.5.0"
 serde_rusqlite = "0.34.0"
+serde-wasm-bindgen = "0.6.1"
 spin = { version = "0.9.8", features = ["mutex", "spin_mutex"] }
 strum = "0.25.0"
-strum_macros = "0.25.2"
+strum_macros = "0.25.3"
 syn = { version = "2.0", features = ["full", "extra-traits"] }
-tempfile = "3.8.0"
-thiserror = "1.0.49"
-tracing-appender = "0.2.2"
-tracing-core = "0.1.31"
-tracing-subscriber = "0.3.17"
-wasm-bindgen = "0.2.87"
-wasm-bindgen-futures = "0.4.37"
+tempfile = "3.8.1"
+thiserror = "1.0.50"
+tracing-appender = "0.2.3"
+tracing-core = "0.1.32"
+tracing-subscriber = "0.3.18"
+wasm-bindgen = "0.2.88"
+wasm-bindgen-futures = "0.4.38"
 wasm-logger = "0.2.0"
+wasm-timer = "0.2.5"
+
 
 # WGPU stuff
 futures-intrusive = "0.5"
@@ -93,19 +97,19 @@ half = { version = "2.3.1", features = [
     "serde",
 ], default-features = false }
 ndarray = { version = "0.15.6", default-features = false }
-num-traits = { version = "0.2.16", default-features = false, features = [
+num-traits = { version = "0.2.17", default-features = false, features = [
     "libm",
 ] } # libm is for no_std
 rand = { version = "0.8.5", default-features = false, features = [
     "std_rng",
 ] } # std_rng is for no_std 
 rand_distr = { version = "0.4.3", default-features = false }
-serde = { version = "1.0.188", default-features = false, features = [
+serde = { version = "1.0.192", default-features = false, features = [
     "derive",
     "alloc",
 ] } # alloc is for no_std, derive is needed
-serde_json = { version = "1.0.107", default-features = false }
-uuid = { version = "1.4.1", default-features = false }
+serde_json = { version = "1.0.108", default-features = false }
+uuid = { version = "1.5.0", default-features = false }
 
 [profile.dev]
 debug = 0 # Speed up compilation time and not necessary.

--- a/burn-tch/Cargo.toml
+++ b/burn-tch/Cargo.toml
@@ -17,7 +17,7 @@ doc = ["tch/doc-only"]
 burn-tensor = {path = "../burn-tensor", version = "0.11.0" }
 
 half = {workspace = true, features = ["std"]}
-libc = "0.2.149"
+libc = "0.2.150"
 rand = {workspace = true, features = ["std"]}
 tch = {version = "0.14.0", features = ["download-libtorch"]}
 

--- a/examples/image-classification-web/Cargo.toml
+++ b/examples/image-classification-web/Cargo.toml
@@ -11,25 +11,31 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
+half_precision = []
 
 [dependencies]
-burn = { path = "../../burn", default-features = false, features = [
+burn = { path = "../../burn", version = "0.11.0", default-features = false, features = [
     "ndarray-no-std",
-    "wgpu",
 ] }
-
+burn-wgpu = { path = "../../burn-wgpu", version = "0.11.0", default-features = false }
 burn-candle = { path = "../../burn-candle", version = "0.11.0", default-features = false }
 
-js-sys = "0.3.64"
+js-sys = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde-wasm-bindgen = "0.6.0"
-wasm-bindgen = "0.2.87"
-wasm-bindgen-futures = "0.4.37"
-wasm-logger = "0.2.0"
-wasm-timer = "0.2.5"
+serde-wasm-bindgen = { workspace = true }
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
+wasm-logger = { workspace = true }
+wasm-timer = { workspace = true }
 
 [build-dependencies]
 # Used to generate code from ONNX model
 burn-import = { path = "../../burn-import" }
+
+[profile.dev]
+lto = "fat"
+
+[profile.release]
+lto = "fat"

--- a/examples/image-classification-web/build-for-web.sh
+++ b/examples/image-classification-web/build-for-web.sh
@@ -10,9 +10,9 @@ fi
 mkdir -p pkg
 
 echo "Building SIMD version of wasm for web ..."
-export RUSTFLAGS="-C lto=fat -C embed-bitcode=yes -C codegen-units=1 -C opt-level=3 -Ctarget-feature=+simd128 --cfg web_sys_unstable_apis"
+export RUSTFLAGS="-C embed-bitcode=yes -C codegen-units=1 -C opt-level=3 -Ctarget-feature=+simd128 --cfg web_sys_unstable_apis"
 wasm-pack build --dev --out-dir pkg/simd --target web --no-typescript
 
 echo "Building Non-SIMD version of wasm for web ..."
-export RUSTFLAGS="-C lto=fat -C embed-bitcode=yes -C codegen-units=1 -C opt-level=3 --cfg web_sys_unstable_apis"
+export RUSTFLAGS="-C embed-bitcode=yes -C codegen-units=1 -C opt-level=3 --cfg web_sys_unstable_apis"
 wasm-pack build --dev --out-dir pkg/no_simd --target web --no-typescript

--- a/examples/image-classification-web/src/web.rs
+++ b/examples/image-classification-web/src/web.rs
@@ -9,13 +9,12 @@ use core::convert::Into;
 use crate::model::{label::LABELS, normalizer::Normalizer, squeezenet::Model as SqueezenetModel};
 
 use burn::{
-    backend::{
-        wgpu::{compute::init_async, AutoGraphicsApi, Wgpu, WgpuDevice},
-        NdArray,
-    },
+    backend::NdArray,
     tensor::{activation::softmax, backend::Backend, Tensor},
 };
+
 use burn_candle::Candle;
+use burn_wgpu::{compute::init_async, AutoGraphicsApi, Wgpu, WgpuDevice};
 
 use serde::Serialize;
 use wasm_bindgen::prelude::*;

--- a/examples/mnist-inference-web/Cargo.toml
+++ b/examples/mnist-inference-web/Cargo.toml
@@ -18,8 +18,9 @@ wgpu = ["burn/wgpu"]
 [dependencies]
 burn = { path = "../../burn", default-features = false }
 serde = { workspace = true }
-wasm-bindgen = { version = "0.2.87" }
-js-sys = "0.3.64"
+wasm-bindgen = { version = "0.2.88" }
+wasm-bindgen-futures = "0.4"
+js-sys = "0.3.65"
 
 [dev-dependencies]
 pollster = { workspace = true }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -8,4 +8,4 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.75"
-clap = { version = "4.4.2", features = ["derive"] }
+clap = { version = "4.4.8", features = ["derive"] }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirm that `run-checks` script has been executed.

### Changes

The image classifier web example was broken because of auto-tune was enabled by default. This fixes by 

### Testing

1. Ran the run-checks all
2. Ran the server and tested on the browser. 
