### PR TITLE
Ci/Use Ubuntu 22.04 instead of latest version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ concurrency:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         rust: [stable, 1.71.0]


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

Since `ubuntu-latest` does not have `sudo add-apt-repository ppa:kisak/kisak-mesa -y`, it is mandatory to set `ubuntu-22.04` as CI version

### Testing

_Describe how these changes have been tested._
