### PR TITLE
bump candle to 0.3.1 and conv_transpose_1d

### DIFF
--- a/burn-candle/Cargo.toml
+++ b/burn-candle/Cargo.toml
@@ -18,8 +18,8 @@ derive-new = { workspace = true }
 burn-tensor = { path = "../burn-tensor", version = "0.11.0", default-features = false }
 half = { workspace = true }
 
-# TODO remove pinned version ("=") once candle-core is updated to 0.3.1
-candle-core = { version = "=0.3.0" }
+candle-core = { version = "0.3.1" }
+
 
 [dev-dependencies]
 burn-autodiff = { path = "../burn-autodiff", version = "0.11.0", default-features = false, features = [

--- a/burn-candle/src/backend.rs
+++ b/burn-candle/src/backend.rs
@@ -50,6 +50,7 @@ impl From<candle_core::Device> for CandleDevice {
         match device.location() {
             DeviceLocation::Cpu => CandleDevice::Cpu,
             DeviceLocation::Cuda { gpu_id } => CandleDevice::Cuda(gpu_id),
+            DeviceLocation::Metal => panic!("Metal unsupported"),
         }
     }
 }


### PR DESCRIPTION
Little Candle update: 
- v0.3.1 is available. It seems Metal is starting to be supported but it is not stable yet. 
- conv_transpose_1d is now available. 
- I'm trying once again to get slice_assign done, I've filed an issue about it. 