### PR TITLE
Fix burn version in the Burn book snippet

### DIFF
--- a/burn-book/src/basic-workflow/model.md
+++ b/burn-book/src/basic-workflow/model.md
@@ -11,7 +11,7 @@ name = "my-first-burn-model"
 version = "0.1.0"
 
 [dependencies]
-burn = { version = "0.9.0", features=["train", "wgpu"]}
+burn = { version = "0.10.0", features=["train", "wgpu"]}
 
 # Serialization
 serde = "1"


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed (minus 2 known failed tests on Windows)
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

N/A

### Changes

The book assumes the latest released version of Burn is used which is 0.10.0 at the time of this commit.

### Testing

I did not do any test as it is a trivial doc change.
