### PR TITLE
Refactor/fusion/graph

### DIFF
--- a/burn-autodiff/src/ops/tensor.rs
+++ b/burn-autodiff/src/ops/tensor.rs
@@ -27,7 +27,7 @@ impl<B: Backend> TensorOps<Self> for Autodiff<B> {
 
     fn random<const D: usize>(
         shape: Shape<D>,
-        distribution: burn_tensor::Distribution<FloatElem<B>>,
+        distribution: burn_tensor::Distribution,
         device: &Device<Self>,
     ) -> FloatTensor<Self, D> {
         AutodiffTensor::new(B::random(shape, distribution, device))

--- a/burn-candle/src/ops/tensor.rs
+++ b/burn-candle/src/ops/tensor.rs
@@ -25,13 +25,13 @@ impl<F: FloatCandleElement, I: IntCandleElement> TensorOps<Self> for Candle<F, I
         let device = &(*device).into();
         match distribution {
             Distribution::Default => CandleTensor::new(
-                candle_core::Tensor::rand(0., 1., shape, device)
+                candle_core::Tensor::rand(0.elem::<F>(), 1.elem::<F>(), shape, device)
                     .unwrap()
                     .to_dtype(F::DTYPE)
                     .unwrap(),
             ),
             Distribution::Bernoulli(prob) => CandleTensor::new(
-                candle_core::Tensor::rand(0., 1., shape, device)
+                candle_core::Tensor::rand(0.elem::<F>(), 1.elem::<F>(), shape, device)
                     .unwrap()
                     .to_dtype(F::DTYPE)
                     .unwrap()
@@ -40,12 +40,13 @@ impl<F: FloatCandleElement, I: IntCandleElement> TensorOps<Self> for Candle<F, I
                     .to_dtype(F::DTYPE)
                     .unwrap(),
             ),
-            Distribution::Uniform(from, to) => {
-                CandleTensor::new(candle_core::Tensor::rand(from, to, shape, device).unwrap())
-            }
-            Distribution::Normal(mean, std) => {
-                CandleTensor::new(candle_core::Tensor::randn(mean, std, shape, device).unwrap())
-            }
+            Distribution::Uniform(from, to) => CandleTensor::new(
+                candle_core::Tensor::rand(from.elem::<F>(), to.elem::<F>(), shape, device).unwrap(),
+            ),
+            Distribution::Normal(mean, std) => CandleTensor::new(
+                candle_core::Tensor::randn(mean.elem::<F>(), std.elem::<F>(), shape, device)
+                    .unwrap(),
+            ),
         }
     }
 

--- a/burn-candle/src/ops/tensor.rs
+++ b/burn-candle/src/ops/tensor.rs
@@ -18,7 +18,7 @@ impl<F: FloatCandleElement, I: IntCandleElement> TensorOps<Self> for Candle<F, I
 
     fn random<const D: usize>(
         shape: Shape<D>,
-        distribution: Distribution<F>,
+        distribution: Distribution,
         device: &Device<Self>,
     ) -> FloatTensor<Self, D> {
         let shape = &shape.dims;

--- a/burn-core/src/nn/initializer.rs
+++ b/burn-core/src/nn/initializer.rs
@@ -164,7 +164,7 @@ fn normal_draw<B: Backend, const D: usize, S: Into<Shape<D>>>(
 mod tests {
     use super::*;
 
-    use burn_tensor::Data;
+    use burn_tensor::{Data, ElementConversion};
 
     pub type TB = burn_ndarray::NdArray<f32>;
 

--- a/burn-core/src/nn/initializer.rs
+++ b/burn-core/src/nn/initializer.rs
@@ -3,7 +3,7 @@ use libm::sqrt;
 
 use crate::config::Config;
 use crate::tensor::backend::Backend;
-use crate::tensor::{Distribution, ElementConversion, Tensor};
+use crate::tensor::{Distribution, Tensor};
 
 use crate as burn;
 
@@ -147,8 +147,7 @@ fn uniform_draw<B: Backend, const D: usize, S: Into<Shape<D>>>(
     low: f64,
     high: f64,
 ) -> Tensor<B, D> {
-    let distribution =
-        Distribution::Uniform(low.elem::<B::FloatElem>(), high.elem::<B::FloatElem>());
+    let distribution = Distribution::Uniform(low, high);
     Tensor::<B, D>::random(shape, distribution)
 }
 

--- a/burn-fusion/src/backend.rs
+++ b/burn-fusion/src/backend.rs
@@ -4,7 +4,6 @@ use crate::{
 };
 use burn_tensor::{backend::Backend, Device, Shape};
 use core::marker::PhantomData;
-use std::sync::Arc;
 
 pub(crate) static CLIENTS: FusionClientLocator = FusionClientLocator::new();
 
@@ -88,7 +87,7 @@ pub trait FusionOps<B: FusionBackend>: Send {
     /// When [closed](FusionStatus::Closed), it's assumed that no more operation can be added
     /// to the current fusion operation. No [tensor operation](TensorOpsDescription) can be
     /// ignored, they are either accepted or rejected, and the [status](FusionStatus) describes it.
-    fn register(&mut self, ops: Arc<TensorOpsDescription>) -> FusionStatus;
+    fn register(&mut self, ops: &TensorOpsDescription) -> FusionStatus;
     /// Execute the operation.
     fn execute(&mut self, handles: &mut HandleContainer<B>);
     /// Reset the state.

--- a/burn-fusion/src/backend.rs
+++ b/burn-fusion/src/backend.rs
@@ -88,7 +88,7 @@ pub trait FusionOps<B: FusionBackend>: Send {
     /// When [closed](FusionStatus::Closed), it's assumed that no more operation can be added
     /// to the current fusion operation. No [tensor operation](TensorOpsDescription) can be
     /// ignored, they are either accepted or rejected, and the [status](FusionStatus) describes it.
-    fn register(&mut self, ops: Arc<TensorOpsDescription<B>>) -> FusionStatus;
+    fn register(&mut self, ops: Arc<TensorOpsDescription>) -> FusionStatus;
     /// Execute the operation.
     fn execute(&mut self, handles: &mut HandleContainer<B>);
     /// Reset the state.

--- a/burn-fusion/src/client/base.rs
+++ b/burn-fusion/src/client/base.rs
@@ -17,7 +17,11 @@ pub trait FusionClient: Send + Sync + Clone {
     /// Create a new client for the given [fusion device](FusionBackend::FusionDevice).
     fn new(device: <Self::FusionBackend as FusionBackend>::FusionDevice) -> Self;
     /// Register a new [tensor operation description](TensorOpsDescription).
-    fn register<O: Ops<Self::FusionBackend>>(&self, description: TensorOpsDescription, ops: O);
+    fn register<O: Ops<Self::FusionBackend> + 'static>(
+        &self,
+        description: TensorOpsDescription,
+        ops: O,
+    );
     /// Register all lazy computation.
     fn drain_graph(&self);
     /// Get the current device used by all operations handled by this client.

--- a/burn-fusion/src/client/base.rs
+++ b/burn-fusion/src/client/base.rs
@@ -1,5 +1,5 @@
 use crate::{
-    graph::{GraphExecution, TensorOpsDescription},
+    graph::{GraphExecution, Ops, TensorOpsDescription},
     FusionBackend, FusionTensor, Handle, TensorDescription, TensorId,
 };
 use burn_tensor::{
@@ -17,7 +17,7 @@ pub trait FusionClient: Send + Sync + Clone {
     /// Create a new client for the given [fusion device](FusionBackend::FusionDevice).
     fn new(device: <Self::FusionBackend as FusionBackend>::FusionDevice) -> Self;
     /// Register a new [tensor operation description](TensorOpsDescription).
-    fn register(&self, ops: TensorOpsDescription<Self::FusionBackend>);
+    fn register<O: Ops<Self::FusionBackend>>(&self, description: TensorOpsDescription, ops: O);
     /// Register all lazy computation.
     fn drain_graph(&self);
     /// Get the current device used by all operations handled by this client.

--- a/burn-fusion/src/client/mutex.rs
+++ b/burn-fusion/src/client/mutex.rs
@@ -45,8 +45,12 @@ where
         }
     }
 
-    fn register(&self, ops: TensorOpsDescription<B>) {
-        self.server.lock().register(ops);
+    fn register<O: crate::graph::Ops<Self::FusionBackend>>(
+        &self,
+        description: TensorOpsDescription,
+        ops: O,
+    ) {
+        self.server.lock().register(description, ops)
     }
 
     fn drain_graph(&self) {

--- a/burn-fusion/src/client/mutex.rs
+++ b/burn-fusion/src/client/mutex.rs
@@ -45,7 +45,7 @@ where
         }
     }
 
-    fn register<O: crate::graph::Ops<Self::FusionBackend>>(
+    fn register<O: crate::graph::Ops<Self::FusionBackend> + 'static>(
         &self,
         description: TensorOpsDescription,
         ops: O,

--- a/burn-fusion/src/client/mutex.rs
+++ b/burn-fusion/src/client/mutex.rs
@@ -50,7 +50,7 @@ where
         description: TensorOpsDescription,
         ops: O,
     ) {
-        self.server.lock().register(description, ops)
+        self.server.lock().register(description, Box::new(ops))
     }
 
     fn drain_graph(&self) {

--- a/burn-fusion/src/graph/base.rs
+++ b/burn-fusion/src/graph/base.rs
@@ -17,7 +17,8 @@ impl<B: FusionBackend> Graph<B> {
         }
     }
     pub(crate) fn add(&mut self, description: Arc<TensorOpsDescription>, ops: Box<dyn Ops<B>>) {
-        self.operations.push(ops);
+        self.operations.push(description);
+        self.ops.push(ops);
     }
 
     /// The size of the graph.

--- a/burn-fusion/src/graph/base.rs
+++ b/burn-fusion/src/graph/base.rs
@@ -85,12 +85,12 @@ pub struct Optimization<B: FusionBackend> {
 }
 
 impl<B: FusionBackend> Optimization<B> {
-    pub(crate) fn register(&mut self, ops: &Arc<TensorOpsDescription>) {
+    pub(crate) fn register(&mut self, ops: &TensorOpsDescription) {
         if let FusionStatus::Closed(_) = self.status {
             return;
         }
 
-        self.status = self.ops.register(ops.clone());
+        self.status = self.ops.register(ops);
     }
 
     pub(crate) fn reset(&mut self) {

--- a/burn-fusion/src/graph/base.rs
+++ b/burn-fusion/src/graph/base.rs
@@ -1,19 +1,22 @@
+use super::Ops;
 use super::TensorOpsDescription;
 use crate::{FusionBackend, FusionOps, FusionProperties, FusionStatus, HandleContainer};
-use std::{ops::RangeBounds, sync::Arc, vec::Drain};
+use std::{ops::RangeBounds, sync::Arc};
 
 /// The computational graph containing a list of [tensor operation descriptions](TensorOpsDescription).
 pub struct Graph<B: FusionBackend> {
-    operations: Vec<Arc<TensorOpsDescription<B>>>,
+    operations: Vec<Arc<TensorOpsDescription>>,
+    ops: Vec<Box<dyn Ops<B>>>,
 }
 
 impl<B: FusionBackend> Graph<B> {
     pub(crate) fn new() -> Self {
         Self {
             operations: Vec::new(),
+            ops: Vec::new(),
         }
     }
-    pub(crate) fn add(&mut self, ops: Arc<TensorOpsDescription<B>>) {
+    pub(crate) fn add(&mut self, description: Arc<TensorOpsDescription>, ops: Box<dyn Ops<B>>) {
         self.operations.push(ops);
     }
 
@@ -27,20 +30,14 @@ impl<B: FusionBackend> Graph<B> {
         self.operations.len() == 0
     }
 
-    fn drain<R>(&mut self, range: R) -> Drain<'_, Arc<TensorOpsDescription<B>>>
-    where
-        R: RangeBounds<usize>,
-    {
-        self.operations.drain(range)
-    }
-
     fn remove<R: RangeBounds<usize>>(&mut self, range: R, handles: &mut HandleContainer<B>) {
         for ops in self.operations.drain(range) {
             ops.cleanup_tensor(handles)
         }
+        self.ops.drain(range);
     }
 
-    fn nodes(&self) -> &[Arc<TensorOpsDescription<B>>] {
+    fn nodes(&self) -> &[Arc<TensorOpsDescription>] {
         &self.operations
     }
 
@@ -66,9 +63,9 @@ impl<B: FusionBackend> Graph<B> {
     }
 
     pub(crate) fn execute(&mut self, handles: &mut HandleContainer<B>) {
-        for ops in self.drain(..) {
+        for (description, ops) in self.operations.drain(..).zip(self.ops.drain(..)) {
             ops.execute(handles);
-            ops.cleanup_tensor(handles);
+            description.cleanup_tensor(handles);
         }
     }
 }
@@ -83,7 +80,7 @@ pub struct Optimization<B: FusionBackend> {
 }
 
 impl<B: FusionBackend> Optimization<B> {
-    pub(crate) fn register(&mut self, ops: &Arc<TensorOpsDescription<B>>) {
+    pub(crate) fn register(&mut self, ops: &Arc<TensorOpsDescription>) {
         if let FusionStatus::Closed(_) = self.status {
             return;
         }

--- a/burn-fusion/src/graph/base.rs
+++ b/burn-fusion/src/graph/base.rs
@@ -31,8 +31,12 @@ impl<B: FusionBackend> Graph<B> {
         self.operations.len() == 0
     }
 
-    fn remove<R: RangeBounds<usize>>(&mut self, range: R, handles: &mut HandleContainer<B>) {
-        for ops in self.operations.drain(range) {
+    fn remove<R: RangeBounds<usize> + Clone>(
+        &mut self,
+        range: R,
+        handles: &mut HandleContainer<B>,
+    ) {
+        for ops in self.operations.drain(range.clone()) {
             ops.cleanup_tensor(handles)
         }
         self.ops.drain(range);

--- a/burn-fusion/src/graph/ops.rs
+++ b/burn-fusion/src/graph/ops.rs
@@ -1,6 +1,5 @@
 use crate::FusionBackend;
 use crate::{HandleContainer, TensorDescription};
-use burn_tensor::ops::FloatElem;
 use burn_tensor::{
     ops::{ConvOptions, ConvTransposeOptions},
     Distribution, Element,
@@ -10,647 +9,398 @@ use std::ops::Range;
 
 /// General trait to abstract how a single operation is executed.
 pub trait Ops<B: FusionBackend>: Send + Sync {
-    /// The argument necessary for the execution to happen.
-    type Args: Send + Sync;
-
     /// Execute the operation.
-    fn execute(&self, args: &Self::Args, handles: &mut HandleContainer<B>);
+    fn execute(self: Box<Self>, handles: &mut HandleContainer<B>);
 }
 
 /// Describe all tensor operations possible.
-pub enum TensorOpsDescription<B: FusionBackend> {
+pub enum TensorOpsDescription {
     /// Basic operation on a float tensor.
-    BaseOpsFloat(BaseOpsDescription<B>),
+    BaseOpsFloat(BaseOpsDescription),
     /// Basic operation on an int tensor.
-    BaseOpsInt(BaseOpsDescription<B>),
+    BaseOpsInt(BaseOpsDescription),
     /// Basic operation on a bool tensor.
-    BaseOpsBool(BaseOpsDescription<B>),
+    BaseOpsBool(BaseOpsDescription),
     /// Numeric operation on a float tensor.
-    NumericOpsFloat(NumericOpsDescription<B, B::FloatElem>),
+    NumericOpsFloat(NumericOpsDescription<f32>),
     /// Numeric operation on an int tensor.
-    NumericOpsInt(NumericOpsDescription<B, B::IntElem>),
+    NumericOpsInt(NumericOpsDescription<i32>),
     /// Operation specific to a bool tensor.
-    BoolOps(BoolOpsDescription<B>),
+    BoolOps(BoolOpsDescription),
     /// Operation specific to an int tensor.
-    IntOps(IntOpsDescription<B>),
+    IntOps(IntOpsDescription),
     /// Operation specific to a float tensor.
-    FloatOps(FloatOpsDescription<B>),
+    FloatOps(FloatOpsDescription),
     /// Module operation.
-    ModuleOps(ModuleOpsDescription<B>),
+    ModuleOps(ModuleOpsDescription),
 }
 
 /// Operation description specific to a float tensor.
-pub enum FloatOpsDescription<B: FusionBackend> {
+pub enum FloatOpsDescription {
     /// Operation corresponding to [exp](burn_tensor::ops::TensorOps::exp).
-    Exp(
-        UnaryOpsDescription,
-        Box<dyn Ops<B, Args = UnaryOpsDescription>>,
-    ),
+    Exp(UnaryOpsDescription),
     /// Operation corresponding to [log](burn_tensor::ops::TensorOps::log).
-    Log(
-        UnaryOpsDescription,
-        Box<dyn Ops<B, Args = UnaryOpsDescription>>,
-    ),
+    Log(UnaryOpsDescription),
     /// Operation corresponding to [log1p](burn_tensor::ops::TensorOps::log1p).
-    Log1p(
-        UnaryOpsDescription,
-        Box<dyn Ops<B, Args = UnaryOpsDescription>>,
-    ),
+    Log1p(UnaryOpsDescription),
     /// Operation corresponding to [erf](burn_tensor::ops::TensorOps::erf).
-    Erf(
-        UnaryOpsDescription,
-        Box<dyn Ops<B, Args = UnaryOpsDescription>>,
-    ),
+    Erf(UnaryOpsDescription),
     /// Operation corresponding to [powf](burn_tensor::ops::TensorOps::powf).
-    Powf(
-        ScalarOpsDescription<f32>,
-        Box<dyn Ops<B, Args = ScalarOpsDescription<f32>>>,
-    ),
+    Powf(ScalarOpsDescription<f32>),
     /// Operation corresponding to [sqrt](burn_tensor::ops::TensorOps::sqrt).
-    Sqrt(
-        UnaryOpsDescription,
-        Box<dyn Ops<B, Args = UnaryOpsDescription>>,
-    ),
+    Sqrt(UnaryOpsDescription),
     /// Operation corresponding to [cos](burn_tensor::ops::TensorOps::cos).
-    Cos(
-        UnaryOpsDescription,
-        Box<dyn Ops<B, Args = UnaryOpsDescription>>,
-    ),
+    Cos(UnaryOpsDescription),
     /// Operation corresponding to [sin](burn_tensor::ops::TensorOps::sin).
-    Sin(
-        UnaryOpsDescription,
-        Box<dyn Ops<B, Args = UnaryOpsDescription>>,
-    ),
+    Sin(UnaryOpsDescription),
     /// Operation corresponding to [tanh](burn_tensor::ops::TensorOps::tanh).
-    Tanh(
-        UnaryOpsDescription,
-        Box<dyn Ops<B, Args = UnaryOpsDescription>>,
-    ),
+    Tanh(UnaryOpsDescription),
     /// Operation corresponding to [into_int](burn_tensor::ops::TensorOps::into_int).
-    IntoInt(
-        UnaryOpsDescription,
-        Box<dyn Ops<B, Args = UnaryOpsDescription>>,
-    ),
+    IntoInt(UnaryOpsDescription),
     /// Operation corresponding to [matmul](burn_tensor::ops::TensorOps::matmul).
-    Matmul(
-        BinaryOpsDescription,
-        Box<dyn Ops<B, Args = BinaryOpsDescription>>,
-    ),
+    Matmul(BinaryOpsDescription),
     /// Operation corresponding to [random](burn_tensor::ops::TensorOps::random).
-    Random(
-        (TensorDescription, Distribution<FloatElem<B>>),
-        Box<dyn Ops<B, Args = (TensorDescription, Distribution<FloatElem<B>>)>>,
-    ),
+    Random((TensorDescription, Distribution<f32>)),
     /// Operation corresponding to [recip](burn_tensor::ops::TensorOps::recip).
-    Recip(
-        UnaryOpsDescription,
-        Box<dyn Ops<B, Args = UnaryOpsDescription>>,
-    ),
+    Recip(UnaryOpsDescription),
 }
 
 /// Operation description specific to module.
-pub enum ModuleOpsDescription<B: FusionBackend> {
+pub enum ModuleOpsDescription {
     /// Operation corresponding to [embedding](burn_tensor::ops::ModuleOps::embedding).
-    Embedding(
-        EmbeddingDescription,
-        Box<dyn Ops<B, Args = EmbeddingDescription>>,
-    ),
+    Embedding(EmbeddingDescription),
     /// Operation corresponding to [embedding_backward](burn_tensor::ops::ModuleOps::embedding_backward).
-    EmbeddingBackward(
-        EmbeddingBackwardDescription,
-        Box<dyn Ops<B, Args = EmbeddingBackwardDescription>>,
-    ),
+    EmbeddingBackward(EmbeddingBackwardDescription),
     /// Operation corresponding to [conv1d](burn_tensor::ops::ModuleOps::conv1d).
-    Conv1d(Conv1dDescription, Box<dyn Ops<B, Args = Conv1dDescription>>),
+    Conv1d(Conv1dDescription),
     /// Operation corresponding to [conv2d](burn_tensor::ops::ModuleOps::conv2d).
-    Conv2d(Conv2dDescription, Box<dyn Ops<B, Args = Conv2dDescription>>),
+    Conv2d(Conv2dDescription),
     /// Operation corresponding to [conv transpose 1d](burn_tensor::ops::ModuleOps::conv_transpose1d).
-    ConvTranspose1d(
-        ConvTranspose1dDescription,
-        Box<dyn Ops<B, Args = ConvTranspose1dDescription>>,
-    ),
+    ConvTranspose1d(ConvTranspose1dDescription),
     /// Operation corresponding to [conv transpose 2d](burn_tensor::ops::ModuleOps::conv_transpose2d).
-    ConvTranspose2d(
-        ConvTranspose2dDescription,
-        Box<dyn Ops<B, Args = ConvTranspose2dDescription>>,
-    ),
+    ConvTranspose2d(ConvTranspose2dDescription),
     /// Operation corresponding to [avg pool 1d](burn_tensor::ops::ModuleOps::avg_pool1d).
-    AvgPool1d(
-        AvgPool1dDescription,
-        Box<dyn Ops<B, Args = AvgPool1dDescription>>,
-    ),
+    AvgPool1d(AvgPool1dDescription),
     /// Operation corresponding to [avg pool 2d](burn_tensor::ops::ModuleOps::avg_pool2d).
-    AvgPool2d(
-        AvgPool2dDescription,
-        Box<dyn Ops<B, Args = AvgPool2dDescription>>,
-    ),
+    AvgPool2d(AvgPool2dDescription),
     /// Operation corresponding to
     /// [avg pool 1d backward](burn_tensor::ops::ModuleOps::avg_pool1d_backward).
-    AvgPool1dBackward(
-        AvgPool1dBackwardDescription,
-        Box<dyn Ops<B, Args = AvgPool1dBackwardDescription>>,
-    ),
+    AvgPool1dBackward(AvgPool1dBackwardDescription),
     /// Operation corresponding to
     /// [avg pool 2d backward](burn_tensor::ops::ModuleOps::avg_pool2d_backward).
-    AvgPool2dBackward(
-        AvgPool2dBackwardDescription,
-        Box<dyn Ops<B, Args = AvgPool2dBackwardDescription>>,
-    ),
+    AvgPool2dBackward(AvgPool2dBackwardDescription),
     /// Operation corresponding to
     /// [adaptive avg pool 1d](burn_tensor::ops::ModuleOps::adaptive_avg_pool1d).
-    AdaptiveAvgPool1d(
-        AdaptiveAvgPool1dDescription,
-        Box<dyn Ops<B, Args = AdaptiveAvgPool1dDescription>>,
-    ),
+    AdaptiveAvgPool1d(AdaptiveAvgPool1dDescription),
     /// Operation corresponding to
     /// [adaptive avg pool 2d](burn_tensor::ops::ModuleOps::adaptive_avg_pool2d).
-    AdaptiveAvgPool2d(
-        AdaptiveAvgPool2dDescription,
-        Box<dyn Ops<B, Args = AdaptiveAvgPool2dDescription>>,
-    ),
+    AdaptiveAvgPool2d(AdaptiveAvgPool2dDescription),
     /// Operation corresponding to
     /// [adaptive avg pool 1d backward](burn_tensor::ops::ModuleOps::adaptive_avg_pool1d_backward).
-    AdaptiveAvgPool1dBackward(
-        AdaptiveAvgPool1dBackwardDescription,
-        Box<dyn Ops<B, Args = AdaptiveAvgPool1dBackwardDescription>>,
-    ),
+    AdaptiveAvgPool1dBackward(AdaptiveAvgPool1dBackwardDescription),
     /// Operation corresponding to
     /// [adaptive avg pool 2d backward](burn_tensor::ops::ModuleOps::adaptive_avg_pool2d_backward).
-    AdaptiveAvgPool2dBackward(
-        AdaptiveAvgPool2dBackwardDescription,
-        Box<dyn Ops<B, Args = AdaptiveAvgPool2dBackwardDescription>>,
-    ),
+    AdaptiveAvgPool2dBackward(AdaptiveAvgPool2dBackwardDescription),
     /// Operation corresponding to
     /// [max pool 1d](burn_tensor::ops::ModuleOps::max_pool1d).
-    MaxPool1d(
-        MaxPool1dDescription,
-        Box<dyn Ops<B, Args = MaxPool1dDescription>>,
-    ),
+    MaxPool1d(MaxPool1dDescription),
     /// Operation corresponding to
     /// [max pool 1d with indices](burn_tensor::ops::ModuleOps::max_pool1d_with_indices).
-    MaxPool1dWithIndices(
-        MaxPool1dWithIndicesDescription,
-        Box<dyn Ops<B, Args = MaxPool1dWithIndicesDescription>>,
-    ),
+    MaxPool1dWithIndices(MaxPool1dWithIndicesDescription),
     /// Operation corresponding to
     /// [max pool 1d with indices backward](burn_tensor::ops::ModuleOps::max_pool1d_with_indices_backward).
-    MaxPool1dWithIndicesBackward(
-        MaxPool1dWithIndicesBackwardDescription,
-        Box<dyn Ops<B, Args = MaxPool1dWithIndicesBackwardDescription>>,
-    ),
+    MaxPool1dWithIndicesBackward(MaxPool1dWithIndicesBackwardDescription),
     /// Operation corresponding to
     /// [max pool 2d](burn_tensor::ops::ModuleOps::max_pool1d).
-    MaxPool2d(
-        MaxPool2dDescription,
-        Box<dyn Ops<B, Args = MaxPool2dDescription>>,
-    ),
+    MaxPool2d(MaxPool2dDescription),
     /// Operation corresponding to
     /// [max pool 2d with indices](burn_tensor::ops::ModuleOps::max_pool2d_with_indices).
-    MaxPool2dWithIndices(
-        MaxPool2dWithIndicesDescription,
-        Box<dyn Ops<B, Args = MaxPool2dWithIndicesDescription>>,
-    ),
+    MaxPool2dWithIndices(MaxPool2dWithIndicesDescription),
     /// Operation corresponding to
     /// [max pool 2d with indices backward](burn_tensor::ops::ModuleOps::max_pool2d_with_indices_backward).
-    MaxPool2dWithIndicesBackward(
-        MaxPool2dWithIndicesBackwardDescription,
-        Box<dyn Ops<B, Args = MaxPool2dWithIndicesBackwardDescription>>,
-    ),
+    MaxPool2dWithIndicesBackward(MaxPool2dWithIndicesBackwardDescription),
 }
 
 /// Basic operations that can be done on any tensor type.
-pub enum BaseOpsDescription<B: FusionBackend> {
+pub enum BaseOpsDescription {
     /// Operation corresponding to:
     ///
     /// Float => [to device](burn_tensor::ops::TensorOps::to_device).
     /// Int => [to device](burn_tensor::ops::IntTensorOps::int_to_device).
     /// Bool => [to device](burn_tensor::ops::BoolTensorOps::bool_to_device).
-    ToDevice(
-        (TensorDescription, B::Device),
-        Box<dyn Ops<B, Args = (TensorDescription, B::Device)>>,
-    ),
+    ToDevice(TensorDescription),
     /// Operation corresponding to:
     ///
     /// Float => [reshape](burn_tensor::ops::TensorOps::reshape).
     /// Int => [reshape](burn_tensor::ops::IntTensorOps::int_reshape).
     /// Bool => [reshape](burn_tensor::ops::BoolTensorOps::bool_reshape).
-    Reshape(
-        ReshapeDescription,
-        Box<dyn Ops<B, Args = ReshapeDescription>>,
-    ),
+    Reshape(ReshapeDescription),
     /// Operation corresponding to:
     ///
     /// Float => [swap_dims](burn_tensor::ops::TensorOps::swap_dims).
     /// Int => [swap_dims](burn_tensor::ops::IntTensorOps::int_swap_dims).
     /// Bool => [swap_dims](burn_tensor::ops::BoolTensorOps::bool_swap_dims).
-    SwapDims(
-        SwapDimsDescription,
-        Box<dyn Ops<B, Args = SwapDimsDescription>>,
-    ),
+    SwapDims(SwapDimsDescription),
     /// Operation corresponding to:
     ///
     /// Float => [slice](burn_tensor::ops::TensorOps::slice).
     /// Int => [slice](burn_tensor::ops::IntTensorOps::int_slice).
     /// Bool => [slice](burn_tensor::ops::BoolTensorOps::bool_slice).
-    Slice(
-        SliceOpsDescription,
-        Box<dyn Ops<B, Args = SliceOpsDescription>>,
-    ),
+    Slice(SliceOpsDescription),
     /// Operation corresponding to:
     ///
     /// Float => [slice assign](burn_tensor::ops::TensorOps::slice_assign).
     /// Int => [slice assign](burn_tensor::ops::IntTensorOps::int_slice_assign).
     /// Bool => [slice assign](burn_tensor::ops::BoolTensorOps::bool_slice_assign).
-    SliceAssign(
-        SliceAssignOpsDescription,
-        Box<dyn Ops<B, Args = SliceAssignOpsDescription>>,
-    ),
+    SliceAssign(SliceAssignOpsDescription),
     /// Operation corresponding to:
     ///
     /// Float => [equal](burn_tensor::ops::TensorOps::equal).
     /// Int => [equal](burn_tensor::ops::IntTensorOps::int_equal).
     /// Bool => [equal](burn_tensor::ops::BoolTensorOps::bool_equal).
-    Equal(
-        BinaryOpsDescription,
-        Box<dyn Ops<B, Args = BinaryOpsDescription>>,
-    ),
+    Equal(BinaryOpsDescription),
     /// Operation corresponding to:
     ///
     /// Float => [repeat](burn_tensor::ops::TensorOps::repeat).
     /// Int => [repeat](burn_tensor::ops::IntTensorOps::int_repeat).
     /// Bool => [repeat](burn_tensor::ops::BoolTensorOps::bool_repeat).
-    Repeat(
-        RepeatOpsDescription,
-        Box<dyn Ops<B, Args = RepeatOpsDescription>>,
-    ),
+    Repeat(RepeatOpsDescription),
     /// Operation corresponding to:
     ///
     /// Float => [cat](burn_tensor::ops::TensorOps::cat).
     /// Int => [cat](burn_tensor::ops::IntTensorOps::int_cat).
     /// Bool => [cat](burn_tensor::ops::BoolTensorOps::bool_cat).
-    Cat(CatOpsDescription, Box<dyn Ops<B, Args = CatOpsDescription>>),
+    Cat(CatOpsDescription),
 }
 
 /// Numeric operations on int and float tensors.
-pub enum NumericOpsDescription<B: FusionBackend, E: Element> {
+pub enum NumericOpsDescription<E: Element> {
     /// Operation corresponding to:
     ///
     /// Float => [add](burn_tensor::ops::TensorOps::add).
     /// Int => [add](burn_tensor::ops::IntTensorOps::int_add).
-    Add(
-        BinaryOpsDescription,
-        Box<dyn Ops<B, Args = BinaryOpsDescription>>,
-    ),
+    Add(BinaryOpsDescription),
     /// Operation corresponding to:
     ///
     /// Float => [add scalar](burn_tensor::ops::TensorOps::add_scalar).
     /// Int => [add scalar](burn_tensor::ops::IntTensorOps::int_add_scalar).
-    AddScalar(
-        ScalarOpsDescription<E>,
-        Box<dyn Ops<B, Args = ScalarOpsDescription<E>>>,
-    ),
+    AddScalar(ScalarOpsDescription<E>),
     /// Operation corresponding to:
     ///
     /// Float => [sub](burn_tensor::ops::TensorOps::sub).
     /// Int => [sub](burn_tensor::ops::IntTensorOps::int_sub).
-    Sub(
-        BinaryOpsDescription,
-        Box<dyn Ops<B, Args = BinaryOpsDescription>>,
-    ),
+    Sub(BinaryOpsDescription),
     /// Operation corresponding to:
     ///
     /// Float => [sub scalar](burn_tensor::ops::TensorOps::sub_scalar).
     /// Int => [sub scalar](burn_tensor::ops::IntTensorOps::int_sub_scalar).
-    SubScalar(
-        ScalarOpsDescription<E>,
-        Box<dyn Ops<B, Args = ScalarOpsDescription<E>>>,
-    ),
+    SubScalar(ScalarOpsDescription<E>),
     /// Operation corresponding to:
     ///
     /// Float => [div](burn_tensor::ops::TensorOps::div).
     /// Int => [div](burn_tensor::ops::IntTensorOps::int_div).
-    Div(
-        BinaryOpsDescription,
-        Box<dyn Ops<B, Args = BinaryOpsDescription>>,
-    ),
+    Div(BinaryOpsDescription),
     /// Operation corresponding to:
     ///
     /// Float => [div scalar](burn_tensor::ops::TensorOps::div_scalar).
     /// Int => [div scalar](burn_tensor::ops::IntTensorOps::int_div_scalar).
-    DivScalar(
-        ScalarOpsDescription<E>,
-        Box<dyn Ops<B, Args = ScalarOpsDescription<E>>>,
-    ),
+    DivScalar(ScalarOpsDescription<E>),
     /// Operation corresponding to:
     ///
     /// Float => [mul](burn_tensor::ops::TensorOps::mul).
     /// Int => [mul](burn_tensor::ops::IntTensorOps::int_mul).
-    Mul(
-        BinaryOpsDescription,
-        Box<dyn Ops<B, Args = BinaryOpsDescription>>,
-    ),
+    Mul(BinaryOpsDescription),
     /// Operation corresponding to:
     ///
     /// Float => [mul scalar](burn_tensor::ops::TensorOps::mul_scalar).
     /// Int => [mul scalar](burn_tensor::ops::IntTensorOps::int_mul_scalar).
-    MulScalar(
-        ScalarOpsDescription<E>,
-        Box<dyn Ops<B, Args = ScalarOpsDescription<E>>>,
-    ),
+    MulScalar(ScalarOpsDescription<E>),
     /// Operation corresponding to:
     ///
     /// Float => [abs](burn_tensor::ops::TensorOps::abs).
     /// Int => [abs](burn_tensor::ops::IntTensorOps::int_abs).
-    Abs(
-        UnaryOpsDescription,
-        Box<dyn Ops<B, Args = UnaryOpsDescription>>,
-    ),
+    Abs(UnaryOpsDescription),
     /// Operation corresponding to:
     ///
     /// Float => [ones](burn_tensor::ops::TensorOps::ones).
     /// Int => [ones](burn_tensor::ops::IntTensorOps::int_ones).
-    Ones(TensorDescription, Box<dyn Ops<B, Args = TensorDescription>>),
+    Ones(TensorDescription),
     /// Operation corresponding to:
     ///
     /// Float => [zeros](burn_tensor::ops::TensorOps::zeros).
     /// Int => [zeros](burn_tensor::ops::IntTensorOps::int_zeros).
-    Zeros(TensorDescription, Box<dyn Ops<B, Args = TensorDescription>>),
+    Zeros(TensorDescription),
     /// Operation corresponding to:
     ///
     /// Float => [full](burn_tensor::ops::TensorOps::full).
     /// Int => [full](burn_tensor::ops::IntTensorOps::int_full).
-    Full(
-        (TensorDescription, E),
-        Box<dyn Ops<B, Args = (TensorDescription, E)>>,
-    ),
+    Full((TensorDescription, E)),
     /// Operation corresponding to:
     ///
     /// Float => [gather](burn_tensor::ops::TensorOps::gather).
     /// Int => [gather](burn_tensor::ops::IntTensorOps::int_gather).
-    Gather(
-        GatherOpsDescription,
-        Box<dyn Ops<B, Args = GatherOpsDescription>>,
-    ),
+    Gather(GatherOpsDescription),
     /// Operation corresponding to:
     ///
     /// Float => [scatter](burn_tensor::ops::TensorOps::scatter).
     /// Int => [scatter](burn_tensor::ops::IntTensorOps::int_scatter).
-    Scatter(
-        ScatterOpsDescription,
-        Box<dyn Ops<B, Args = ScatterOpsDescription>>,
-    ),
+    Scatter(ScatterOpsDescription),
     /// Operation corresponding to:
     ///
     /// Float => [select](burn_tensor::ops::TensorOps::select).
     /// Int => [select](burn_tensor::ops::IntTensorOps::int_select).
-    Select(
-        SelectOpsDescription,
-        Box<dyn Ops<B, Args = SelectOpsDescription>>,
-    ),
+    Select(SelectOpsDescription),
     /// Operation corresponding to:
     ///
     /// Float => [select assign](burn_tensor::ops::TensorOps::select_assign).
     /// Int => [select assign](burn_tensor::ops::IntTensorOps::int_select_assign).
-    SelectAssign(
-        SelectAssignOpsDescription,
-        Box<dyn Ops<B, Args = SelectAssignOpsDescription>>,
-    ),
+    SelectAssign(SelectAssignOpsDescription),
     /// Operation corresponding to:
     ///
     /// Float => [mask where](burn_tensor::ops::TensorOps::mask_where).
     /// Int => [mask where](burn_tensor::ops::IntTensorOps::int_mask_where).
-    MaskWhere(
-        MaskWhereOpsDescription,
-        Box<dyn Ops<B, Args = MaskWhereOpsDescription>>,
-    ),
+    MaskWhere(MaskWhereOpsDescription),
     /// Operation corresponding to:
     ///
     /// Float => [mask fill](burn_tensor::ops::TensorOps::mask_fill).
     /// Int => [mask fill](burn_tensor::ops::IntTensorOps::int_mask_fill).
-    MaskFill(
-        MaskFillOpsDescription<E>,
-        Box<dyn Ops<B, Args = MaskFillOpsDescription<E>>>,
-    ),
+    MaskFill(MaskFillOpsDescription<E>),
     /// Operation corresponding to:
     ///
     /// Float => [mean dim](burn_tensor::ops::TensorOps::mean_dim).
     /// Int => [mean dim](burn_tensor::ops::IntTensorOps::int_mean_dim).
-    MeanDim(
-        ScalarOpsDescription<usize>,
-        Box<dyn Ops<B, Args = ScalarOpsDescription<usize>>>,
-    ),
+    MeanDim(ScalarOpsDescription<usize>),
     /// Operation corresponding to:
     ///
     /// Float => [mean](burn_tensor::ops::TensorOps::mean).
     /// Int => [mean](burn_tensor::ops::IntTensorOps::int_mean).
-    Mean(
-        UnaryOpsDescription,
-        Box<dyn Ops<B, Args = UnaryOpsDescription>>,
-    ),
+    Mean(UnaryOpsDescription),
     /// Operation corresponding to:
     ///
     /// Float => [sum](burn_tensor::ops::TensorOps::sum).
     /// Int => [sum](burn_tensor::ops::IntTensorOps::int_sum).
-    Sum(
-        UnaryOpsDescription,
-        Box<dyn Ops<B, Args = UnaryOpsDescription>>,
-    ),
+    Sum(UnaryOpsDescription),
     /// Operation corresponding to:
     ///
     /// Float => [sum dim](burn_tensor::ops::TensorOps::sum_dim).
     /// Int => [sum dim](burn_tensor::ops::IntTensorOps::int_sum_dim).
-    SumDim(
-        ScalarOpsDescription<usize>,
-        Box<dyn Ops<B, Args = ScalarOpsDescription<usize>>>,
-    ),
+    SumDim(ScalarOpsDescription<usize>),
     /// Operation corresponding to:
     ///
     /// Float => [equal elem](burn_tensor::ops::TensorOps::equal_elem).
     /// Int => [equal elem](burn_tensor::ops::IntTensorOps::int_equal_elem).
-    EqualElem(
-        ScalarOpsDescription<E>,
-        Box<dyn Ops<B, Args = ScalarOpsDescription<E>>>,
-    ),
+    EqualElem(ScalarOpsDescription<E>),
     /// Operation corresponding to:
     ///
     /// Float => [greater](burn_tensor::ops::TensorOps::greater).
     /// Int => [greater](burn_tensor::ops::IntTensorOps::int_greater).
-    Greater(
-        BinaryOpsDescription,
-        Box<dyn Ops<B, Args = BinaryOpsDescription>>,
-    ),
+    Greater(BinaryOpsDescription),
     /// Operation corresponding to:
     ///
     /// Float => [greater elem](burn_tensor::ops::TensorOps::greater_elem).
     /// Int => [greater elem](burn_tensor::ops::IntTensorOps::int_greater_elem).
-    GreaterElem(
-        ScalarOpsDescription<E>,
-        Box<dyn Ops<B, Args = ScalarOpsDescription<E>>>,
-    ),
+    GreaterElem(ScalarOpsDescription<E>),
     /// Operation corresponding to:
     ///
     /// Float => [greater equal](burn_tensor::ops::TensorOps::greater_elem).
     /// Int => [greater elem](burn_tensor::ops::IntTensorOps::int_greater_elem).
-    GreaterEqual(
-        BinaryOpsDescription,
-        Box<dyn Ops<B, Args = BinaryOpsDescription>>,
-    ),
+    GreaterEqual(BinaryOpsDescription),
     /// Operation corresponding to:
     ///
     /// Float => [greater equal elem](burn_tensor::ops::TensorOps::greater_equal_elem).
     /// Int => [greater equal elem](burn_tensor::ops::IntTensorOps::int_greater_equal_elem).
-    GreaterEqualElem(
-        ScalarOpsDescription<E>,
-        Box<dyn Ops<B, Args = ScalarOpsDescription<E>>>,
-    ),
+    GreaterEqualElem(ScalarOpsDescription<E>),
     /// Operation corresponding to:
     ///
     /// Float => [lower](burn_tensor::ops::TensorOps::lower).
     /// Int => [lower](burn_tensor::ops::IntTensorOps::int_lower).
-    Lower(
-        BinaryOpsDescription,
-        Box<dyn Ops<B, Args = BinaryOpsDescription>>,
-    ),
+    Lower(BinaryOpsDescription),
     /// Operation corresponding to:
     ///
     /// Float => [lower elem](burn_tensor::ops::TensorOps::lower_elem).
     /// Int => [lower elem](burn_tensor::ops::IntTensorOps::int_lower_elem).
-    LowerElem(
-        ScalarOpsDescription<E>,
-        Box<dyn Ops<B, Args = ScalarOpsDescription<E>>>,
-    ),
+    LowerElem(ScalarOpsDescription<E>),
     /// Operation corresponding to:
     ///
     /// Float => [lower equal](burn_tensor::ops::TensorOps::lower_equal).
     /// Int => [lower equal](burn_tensor::ops::IntTensorOps::int_lower_equal).
-    LowerEqual(
-        BinaryOpsDescription,
-        Box<dyn Ops<B, Args = BinaryOpsDescription>>,
-    ),
+    LowerEqual(BinaryOpsDescription),
     /// Operation corresponding to:
     ///
     /// Float => [lower equal elem](burn_tensor::ops::TensorOps::lower_equal_elem).
     /// Int => [lower equal elem](burn_tensor::ops::IntTensorOps::int_lower_equal_elem).
-    LowerEqualElem(
-        ScalarOpsDescription<E>,
-        Box<dyn Ops<B, Args = ScalarOpsDescription<E>>>,
-    ),
+    LowerEqualElem(ScalarOpsDescription<E>),
     /// Operation corresponding to:
     ///
     /// Float => [argmax](burn_tensor::ops::TensorOps::argmax).
     /// Int => [argmax](burn_tensor::ops::IntTensorOps::int_argmax).
-    ArgMax(
-        ScalarOpsDescription<usize>,
-        Box<dyn Ops<B, Args = ScalarOpsDescription<usize>>>,
-    ),
+    ArgMax(ScalarOpsDescription<usize>),
     /// Operation corresponding to:
     ///
     /// Float => [argmin](burn_tensor::ops::TensorOps::argmin).
     /// Int => [argmin](burn_tensor::ops::IntTensorOps::int_argmin).
-    ArgMin(
-        ScalarOpsDescription<usize>,
-        Box<dyn Ops<B, Args = ScalarOpsDescription<usize>>>,
-    ),
+    ArgMin(ScalarOpsDescription<usize>),
     /// Operation corresponding to:
     ///
     /// Float => [max](burn_tensor::ops::TensorOps::max).
     /// Int => [max](burn_tensor::ops::IntTensorOps::int_max).
-    Max(
-        UnaryOpsDescription,
-        Box<dyn Ops<B, Args = UnaryOpsDescription>>,
-    ),
+    Max(UnaryOpsDescription),
     /// Operation corresponding to:
     ///
     /// Float => [max dim with indices](burn_tensor::ops::TensorOps::max_dim_with_indices).
     /// Int => [max dim with indices](burn_tensor::ops::IntTensorOps::int_max_dim_with_indices).
-    MaxDimWithIndices(
-        ReduceDimWithIndicesDescription,
-        Box<dyn Ops<B, Args = ReduceDimWithIndicesDescription>>,
-    ),
+    MaxDimWithIndices(ReduceDimWithIndicesDescription),
     /// Operation corresponding to:
     ///
     /// Float => [min dim with indices](burn_tensor::ops::TensorOps::min_dim_with_indices).
     /// Int => [min dim with indices](burn_tensor::ops::IntTensorOps::int_min_dim_with_indices).
-    MinDimWithIndices(
-        ReduceDimWithIndicesDescription,
-        Box<dyn Ops<B, Args = ReduceDimWithIndicesDescription>>,
-    ),
+    MinDimWithIndices(ReduceDimWithIndicesDescription),
     /// Operation corresponding to:
     ///
     /// Float => [min](burn_tensor::ops::TensorOps::min).
     /// Int => [min](burn_tensor::ops::IntTensorOps::int_min).
-    Min(
-        UnaryOpsDescription,
-        Box<dyn Ops<B, Args = UnaryOpsDescription>>,
-    ),
+    Min(UnaryOpsDescription),
     /// Operation corresponding to:
     ///
     /// Float => [max dim](burn_tensor::ops::TensorOps::max_dim).
     /// Int => [max dim](burn_tensor::ops::IntTensorOps::int_max_dim).
-    MaxDim(
-        ScalarOpsDescription<usize>,
-        Box<dyn Ops<B, Args = ScalarOpsDescription<usize>>>,
-    ),
+    MaxDim(ScalarOpsDescription<usize>),
     /// Operation corresponding to:
     ///
     /// Float => [min dim](burn_tensor::ops::TensorOps::min_dim).
     /// Int => [min dim](burn_tensor::ops::IntTensorOps::int_min_dim).
-    MinDim(
-        ScalarOpsDescription<usize>,
-        Box<dyn Ops<B, Args = ScalarOpsDescription<usize>>>,
-    ),
+    MinDim(ScalarOpsDescription<usize>),
     /// Operation corresponding to:
     ///
     /// Float => [clamp](burn_tensor::ops::TensorOps::clamp).
     /// Int => [clamp](burn_tensor::ops::IntTensorOps::int_clamp).
-    Clamp(
-        ClampOpsDescription<E>,
-        Box<dyn Ops<B, Args = ClampOpsDescription<E>>>,
-    ),
+    Clamp(ClampOpsDescription<E>),
     /// Operation corresponding to:
     ///
     /// Float => [clamp max](burn_tensor::ops::TensorOps::clamp_max).
     /// Int => [clamp max](burn_tensor::ops::IntTensorOps::int_clamp_max).
-    ClampMax(
-        ScalarOpsDescription<E>,
-        Box<dyn Ops<B, Args = ScalarOpsDescription<E>>>,
-    ),
+    ClampMax(ScalarOpsDescription<E>),
     /// Operation corresponding to:
     ///
     /// Float => [clamp min](burn_tensor::ops::TensorOps::clamp_min).
     /// Int => [cleamp min](burn_tensor::ops::IntTensorOps::int_clamp_min).
-    ClampMin(
-        ScalarOpsDescription<E>,
-        Box<dyn Ops<B, Args = ScalarOpsDescription<E>>>,
-    ),
+    ClampMin(ScalarOpsDescription<E>),
 }
 
 /// Operation description specific to an int tensor.
-pub enum IntOpsDescription<B: FusionBackend> {
+pub enum IntOpsDescription {
     /// Operation corresponding to [into float](burn_tensor::ops::IntTensorOps::int_into_float).
-    IntoFloat(
-        UnaryOpsDescription,
-        Box<dyn Ops<B, Args = UnaryOpsDescription>>,
-    ),
+    IntoFloat(UnaryOpsDescription),
 }
 
 /// Operation description specific to a bool tensor.
-pub enum BoolOpsDescription<B: FusionBackend> {
+pub enum BoolOpsDescription {
     /// Operation corresponding to [into float](burn_tensor::ops::BoolTensorOps::bool_into_float).
-    IntoFloat(
-        UnaryOpsDescription,
-        Box<dyn Ops<B, Args = UnaryOpsDescription>>,
-    ),
+    IntoFloat(UnaryOpsDescription),
     /// Operation corresponding to [into int](burn_tensor::ops::BoolTensorOps::bool_into_int).
-    IntoInt(
-        UnaryOpsDescription,
-        Box<dyn Ops<B, Args = UnaryOpsDescription>>,
-    ),
+    IntoInt(UnaryOpsDescription),
     /// Operation corresponding to [not](burn_tensor::ops::BoolTensorOps::bool_not).
-    Not(
-        UnaryOpsDescription,
-        Box<dyn Ops<B, Args = UnaryOpsDescription>>,
-    ),
+    Not(UnaryOpsDescription),
 }
 
 #[derive(Hash)]
@@ -1009,9 +759,9 @@ pub struct MaxPool2dWithIndicesBackwardDescription {
     pub out: TensorDescription,
 }
 
-impl<B: FusionBackend> TensorOpsDescription<B> {
+impl TensorOpsDescription {
     /// Cleanup the remaining tensor handles that have not been used.
-    pub(crate) fn cleanup_tensor(&self, handles: &mut HandleContainer<B>) {
+    pub(crate) fn cleanup_tensor<B: FusionBackend>(&self, handles: &mut HandleContainer<B>) {
         match self {
             TensorOpsDescription::BaseOpsFloat(ops) => ops.cleanup_tensor(handles),
             TensorOpsDescription::BaseOpsInt(ops) => ops.cleanup_tensor(handles),
@@ -1027,349 +777,247 @@ impl<B: FusionBackend> TensorOpsDescription<B> {
         // Cleanup tensor handles that were outputted, but ignored.
         handles.cleanup_orphans();
     }
-    /// Execute the operation.
-    pub(crate) fn execute(&self, handles: &mut HandleContainer<B>) {
-        match self {
-            TensorOpsDescription::BaseOpsFloat(ops) => ops.execute(handles),
-            TensorOpsDescription::BaseOpsInt(ops) => ops.execute(handles),
-            TensorOpsDescription::BaseOpsBool(ops) => ops.execute(handles),
-            TensorOpsDescription::NumericOpsFloat(ops) => ops.execute(handles),
-            TensorOpsDescription::NumericOpsInt(ops) => ops.execute(handles),
-            TensorOpsDescription::BoolOps(ops) => ops.execute(handles),
-            TensorOpsDescription::IntOps(ops) => ops.execute(handles),
-            TensorOpsDescription::FloatOps(ops) => ops.execute(handles),
-            TensorOpsDescription::ModuleOps(ops) => ops.execute(handles),
-        }
-    }
 }
 
-impl<B: FusionBackend> BaseOpsDescription<B> {
-    fn cleanup_tensor(&self, handles: &mut HandleContainer<B>) {
+impl BaseOpsDescription {
+    fn cleanup_tensor<B: FusionBackend>(&self, handles: &mut HandleContainer<B>) {
         match self {
-            BaseOpsDescription::ToDevice(_, _) => (),
-            BaseOpsDescription::Reshape(desc, _) => {
+            BaseOpsDescription::ToDevice(_) => (),
+            BaseOpsDescription::Reshape(desc) => {
                 handles.cleanup(&desc.input);
             }
-            BaseOpsDescription::SwapDims(desc, _) => {
+            BaseOpsDescription::SwapDims(desc) => {
                 handles.cleanup(&desc.input);
             }
-            BaseOpsDescription::Slice(desc, _) => {
+            BaseOpsDescription::Slice(desc) => {
                 handles.cleanup(&desc.tensor);
             }
-            BaseOpsDescription::SliceAssign(desc, _) => {
+            BaseOpsDescription::SliceAssign(desc) => {
                 handles.cleanup(&desc.tensor);
                 handles.cleanup(&desc.value);
             }
-            BaseOpsDescription::Equal(desc, _) => {
+            BaseOpsDescription::Equal(desc) => {
                 handles.cleanup(&desc.lhs);
                 handles.cleanup(&desc.rhs);
             }
-            BaseOpsDescription::Repeat(desc, _) => {
+            BaseOpsDescription::Repeat(desc) => {
                 handles.cleanup(&desc.tensor);
             }
-            BaseOpsDescription::Cat(desc, _) => {
+            BaseOpsDescription::Cat(desc) => {
                 for t in desc.tensors.iter() {
                     handles.cleanup(t);
                 }
             }
         }
     }
-    fn execute(&self, handles: &mut HandleContainer<B>) {
-        match self {
-            BaseOpsDescription::ToDevice(desc, ops) => ops.execute(desc, handles),
-            BaseOpsDescription::Reshape(desc, ops) => ops.execute(desc, handles),
-            BaseOpsDescription::SwapDims(desc, ops) => ops.execute(desc, handles),
-            BaseOpsDescription::Slice(desc, ops) => ops.execute(desc, handles),
-            BaseOpsDescription::SliceAssign(desc, ops) => ops.execute(desc, handles),
-            BaseOpsDescription::Equal(desc, ops) => ops.execute(desc, handles),
-            BaseOpsDescription::Repeat(desc, ops) => ops.execute(desc, handles),
-            BaseOpsDescription::Cat(desc, ops) => ops.execute(desc, handles),
-        }
-    }
 }
 
-impl<B: FusionBackend, E: Element> NumericOpsDescription<B, E> {
-    fn cleanup_tensor(&self, handles: &mut HandleContainer<B>) {
+impl<E: Element> NumericOpsDescription<E> {
+    fn cleanup_tensor<B: FusionBackend>(&self, handles: &mut HandleContainer<B>) {
         match self {
-            NumericOpsDescription::Add(desc, _) => {
+            NumericOpsDescription::Add(desc) => {
                 handles.cleanup(&desc.lhs);
                 handles.cleanup(&desc.rhs);
             }
-            NumericOpsDescription::AddScalar(desc, _) => {
+            NumericOpsDescription::AddScalar(desc) => {
                 handles.cleanup(&desc.lhs);
             }
-            NumericOpsDescription::Sub(desc, _) => {
-                handles.cleanup(&desc.lhs);
-                handles.cleanup(&desc.rhs);
-            }
-            NumericOpsDescription::SubScalar(desc, _) => {
-                handles.cleanup(&desc.lhs);
-            }
-            NumericOpsDescription::Mul(desc, _) => {
+            NumericOpsDescription::Sub(desc) => {
                 handles.cleanup(&desc.lhs);
                 handles.cleanup(&desc.rhs);
             }
-            NumericOpsDescription::MulScalar(desc, _) => {
+            NumericOpsDescription::SubScalar(desc) => {
                 handles.cleanup(&desc.lhs);
             }
-            NumericOpsDescription::Div(desc, _) => {
+            NumericOpsDescription::Mul(desc) => {
                 handles.cleanup(&desc.lhs);
                 handles.cleanup(&desc.rhs);
             }
-            NumericOpsDescription::DivScalar(desc, _) => {
+            NumericOpsDescription::MulScalar(desc) => {
                 handles.cleanup(&desc.lhs);
             }
-            NumericOpsDescription::Ones(_, _) => {}
-            NumericOpsDescription::Gather(desc, _) => {
+            NumericOpsDescription::Div(desc) => {
+                handles.cleanup(&desc.lhs);
+                handles.cleanup(&desc.rhs);
+            }
+            NumericOpsDescription::DivScalar(desc) => {
+                handles.cleanup(&desc.lhs);
+            }
+            NumericOpsDescription::Ones(_) => {}
+            NumericOpsDescription::Gather(desc) => {
                 handles.cleanup(&desc.tensor);
                 handles.cleanup(&desc.indices);
             }
-            NumericOpsDescription::Scatter(desc, _) => {
-                handles.cleanup(&desc.tensor);
-                handles.cleanup(&desc.indices);
-                handles.cleanup(&desc.value);
-            }
-            NumericOpsDescription::Select(desc, _) => {
-                handles.cleanup(&desc.tensor);
-                handles.cleanup(&desc.indices);
-            }
-            NumericOpsDescription::SelectAssign(desc, _) => {
+            NumericOpsDescription::Scatter(desc) => {
                 handles.cleanup(&desc.tensor);
                 handles.cleanup(&desc.indices);
                 handles.cleanup(&desc.value);
             }
-            NumericOpsDescription::MaskWhere(desc, _) => {
+            NumericOpsDescription::Select(desc) => {
+                handles.cleanup(&desc.tensor);
+                handles.cleanup(&desc.indices);
+            }
+            NumericOpsDescription::SelectAssign(desc) => {
+                handles.cleanup(&desc.tensor);
+                handles.cleanup(&desc.indices);
+                handles.cleanup(&desc.value);
+            }
+            NumericOpsDescription::MaskWhere(desc) => {
                 handles.cleanup(&desc.tensor);
                 handles.cleanup(&desc.value);
                 handles.cleanup(&desc.mask);
             }
-            NumericOpsDescription::MaskFill(desc, _) => {
+            NumericOpsDescription::MaskFill(desc) => {
                 handles.cleanup(&desc.tensor);
                 handles.cleanup(&desc.mask);
             }
-            NumericOpsDescription::EqualElem(desc, _) => {
+            NumericOpsDescription::EqualElem(desc) => {
                 handles.cleanup(&desc.lhs);
             }
-            NumericOpsDescription::GreaterElem(desc, _) => {
+            NumericOpsDescription::GreaterElem(desc) => {
                 handles.cleanup(&desc.lhs);
             }
-            NumericOpsDescription::GreaterEqualElem(desc, _) => {
+            NumericOpsDescription::GreaterEqualElem(desc) => {
                 handles.cleanup(&desc.lhs);
             }
-            NumericOpsDescription::LowerElem(desc, _) => {
+            NumericOpsDescription::LowerElem(desc) => {
                 handles.cleanup(&desc.lhs);
             }
-            NumericOpsDescription::LowerEqualElem(desc, _) => {
+            NumericOpsDescription::LowerEqualElem(desc) => {
                 handles.cleanup(&desc.lhs);
             }
-            NumericOpsDescription::Greater(desc, _) => {
-                handles.cleanup(&desc.lhs);
-                handles.cleanup(&desc.rhs);
-            }
-            NumericOpsDescription::GreaterEqual(desc, _) => {
+            NumericOpsDescription::Greater(desc) => {
                 handles.cleanup(&desc.lhs);
                 handles.cleanup(&desc.rhs);
             }
-            NumericOpsDescription::Lower(desc, _) => {
+            NumericOpsDescription::GreaterEqual(desc) => {
                 handles.cleanup(&desc.lhs);
                 handles.cleanup(&desc.rhs);
             }
-            NumericOpsDescription::LowerEqual(desc, _) => {
+            NumericOpsDescription::Lower(desc) => {
                 handles.cleanup(&desc.lhs);
                 handles.cleanup(&desc.rhs);
             }
-            NumericOpsDescription::ArgMax(desc, _) => {
+            NumericOpsDescription::LowerEqual(desc) => {
+                handles.cleanup(&desc.lhs);
+                handles.cleanup(&desc.rhs);
+            }
+            NumericOpsDescription::ArgMax(desc) => {
                 handles.cleanup(&desc.lhs);
             }
-            NumericOpsDescription::ArgMin(desc, _) => {
+            NumericOpsDescription::ArgMin(desc) => {
                 handles.cleanup(&desc.lhs);
             }
-            NumericOpsDescription::Clamp(desc, _) => {
+            NumericOpsDescription::Clamp(desc) => {
                 handles.cleanup(&desc.tensor);
             }
-            NumericOpsDescription::ClampMin(desc, _) => {
+            NumericOpsDescription::ClampMin(desc) => {
                 handles.cleanup(&desc.lhs);
             }
-            NumericOpsDescription::ClampMax(desc, _) => {
+            NumericOpsDescription::ClampMax(desc) => {
                 handles.cleanup(&desc.lhs);
             }
-            NumericOpsDescription::Abs(desc, _) => {
+            NumericOpsDescription::Abs(desc) => {
                 handles.cleanup(&desc.input);
             }
-            NumericOpsDescription::Zeros(_, _) => {}
-            NumericOpsDescription::Full(_, _) => {}
-            NumericOpsDescription::MeanDim(desc, _) => {
+            NumericOpsDescription::Zeros(_) => {}
+            NumericOpsDescription::Full(_) => {}
+            NumericOpsDescription::MeanDim(desc) => {
                 handles.cleanup(&desc.lhs);
             }
-            NumericOpsDescription::Mean(desc, _) => {
+            NumericOpsDescription::Mean(desc) => {
                 handles.cleanup(&desc.input);
             }
-            NumericOpsDescription::Sum(desc, _) => {
+            NumericOpsDescription::Sum(desc) => {
                 handles.cleanup(&desc.input);
             }
-            NumericOpsDescription::SumDim(desc, _) => {
+            NumericOpsDescription::SumDim(desc) => {
                 handles.cleanup(&desc.lhs);
             }
-            NumericOpsDescription::Max(desc, _) => {
+            NumericOpsDescription::Max(desc) => {
                 handles.cleanup(&desc.input);
             }
-            NumericOpsDescription::MaxDimWithIndices(desc, _) => {
+            NumericOpsDescription::MaxDimWithIndices(desc) => {
                 handles.cleanup(&desc.tensor);
             }
-            NumericOpsDescription::MinDimWithIndices(desc, _) => {
+            NumericOpsDescription::MinDimWithIndices(desc) => {
                 handles.cleanup(&desc.tensor);
             }
-            NumericOpsDescription::Min(desc, _) => {
+            NumericOpsDescription::Min(desc) => {
                 handles.cleanup(&desc.input);
             }
-            NumericOpsDescription::MaxDim(desc, _) => {
+            NumericOpsDescription::MaxDim(desc) => {
                 handles.cleanup(&desc.lhs);
             }
-            NumericOpsDescription::MinDim(desc, _) => {
+            NumericOpsDescription::MinDim(desc) => {
                 handles.cleanup(&desc.lhs);
             }
-        }
-    }
-
-    fn execute(&self, handles: &mut HandleContainer<B>) {
-        match self {
-            NumericOpsDescription::Add(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::AddScalar(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::Sub(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::SubScalar(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::Div(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::DivScalar(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::Mul(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::MulScalar(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::Ones(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::Gather(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::Scatter(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::Select(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::SelectAssign(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::MaskWhere(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::MaskFill(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::EqualElem(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::Greater(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::GreaterElem(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::GreaterEqual(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::GreaterEqualElem(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::Lower(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::LowerElem(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::LowerEqual(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::LowerEqualElem(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::ArgMax(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::ArgMin(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::Clamp(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::ClampMin(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::ClampMax(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::Abs(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::Zeros(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::Full(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::MeanDim(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::Mean(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::Sum(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::SumDim(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::Max(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::MaxDimWithIndices(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::MinDimWithIndices(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::Min(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::MaxDim(desc, ops) => ops.execute(desc, handles),
-            NumericOpsDescription::MinDim(desc, ops) => ops.execute(desc, handles),
         }
     }
 }
 
-impl<B: FusionBackend> FloatOpsDescription<B> {
-    fn cleanup_tensor(&self, handles: &mut HandleContainer<B>) {
+impl FloatOpsDescription {
+    fn cleanup_tensor<B: FusionBackend>(&self, handles: &mut HandleContainer<B>) {
         match self {
-            FloatOpsDescription::Matmul(desc, _) => {
+            FloatOpsDescription::Matmul(desc) => {
                 handles.cleanup(&desc.lhs);
                 handles.cleanup(&desc.rhs);
             }
-            FloatOpsDescription::Random(_, _) => {}
-            FloatOpsDescription::Exp(desc, _) => handles.cleanup(&desc.input),
-            FloatOpsDescription::Log(desc, _) => handles.cleanup(&desc.input),
-            FloatOpsDescription::Log1p(desc, _) => handles.cleanup(&desc.input),
-            FloatOpsDescription::Erf(desc, _) => handles.cleanup(&desc.input),
-            FloatOpsDescription::Recip(desc, _) => handles.cleanup(&desc.input),
-            FloatOpsDescription::Powf(desc, _) => handles.cleanup(&desc.lhs),
-            FloatOpsDescription::Sqrt(desc, _) => handles.cleanup(&desc.input),
-            FloatOpsDescription::Cos(desc, _) => handles.cleanup(&desc.input),
-            FloatOpsDescription::Sin(desc, _) => handles.cleanup(&desc.input),
-            FloatOpsDescription::Tanh(desc, _) => handles.cleanup(&desc.input),
-            FloatOpsDescription::IntoInt(desc, _) => handles.cleanup(&desc.input),
-        }
-    }
-    fn execute(&self, handles: &mut HandleContainer<B>) {
-        match self {
-            FloatOpsDescription::Matmul(desc, ops) => ops.execute(desc, handles),
-            FloatOpsDescription::Random(desc, ops) => ops.execute(desc, handles),
-            FloatOpsDescription::Exp(desc, ops) => ops.execute(desc, handles),
-            FloatOpsDescription::Log(desc, ops) => ops.execute(desc, handles),
-            FloatOpsDescription::Log1p(desc, ops) => ops.execute(desc, handles),
-            FloatOpsDescription::Erf(desc, ops) => ops.execute(desc, handles),
-            FloatOpsDescription::Recip(desc, ops) => ops.execute(desc, handles),
-            FloatOpsDescription::Powf(desc, ops) => ops.execute(desc, handles),
-            FloatOpsDescription::Sqrt(desc, ops) => ops.execute(desc, handles),
-            FloatOpsDescription::Cos(desc, ops) => ops.execute(desc, handles),
-            FloatOpsDescription::Sin(desc, ops) => ops.execute(desc, handles),
-            FloatOpsDescription::Tanh(desc, ops) => ops.execute(desc, handles),
-            FloatOpsDescription::IntoInt(desc, ops) => ops.execute(desc, handles),
+            FloatOpsDescription::Random(_) => {}
+            FloatOpsDescription::Exp(desc) => handles.cleanup(&desc.input),
+            FloatOpsDescription::Log(desc) => handles.cleanup(&desc.input),
+            FloatOpsDescription::Log1p(desc) => handles.cleanup(&desc.input),
+            FloatOpsDescription::Erf(desc) => handles.cleanup(&desc.input),
+            FloatOpsDescription::Recip(desc) => handles.cleanup(&desc.input),
+            FloatOpsDescription::Powf(desc) => handles.cleanup(&desc.lhs),
+            FloatOpsDescription::Sqrt(desc) => handles.cleanup(&desc.input),
+            FloatOpsDescription::Cos(desc) => handles.cleanup(&desc.input),
+            FloatOpsDescription::Sin(desc) => handles.cleanup(&desc.input),
+            FloatOpsDescription::Tanh(desc) => handles.cleanup(&desc.input),
+            FloatOpsDescription::IntoInt(desc) => handles.cleanup(&desc.input),
         }
     }
 }
 
-impl<B: FusionBackend> IntOpsDescription<B> {
-    fn cleanup_tensor(&self, handles: &mut HandleContainer<B>) {
+impl IntOpsDescription {
+    fn cleanup_tensor<B: FusionBackend>(&self, handles: &mut HandleContainer<B>) {
         match self {
-            IntOpsDescription::IntoFloat(desc, _) => {
+            IntOpsDescription::IntoFloat(desc) => {
                 handles.cleanup(&desc.input);
             }
-        }
-    }
-    fn execute(&self, handles: &mut HandleContainer<B>) {
-        match self {
-            IntOpsDescription::IntoFloat(desc, ops) => ops.execute(desc, handles),
         }
     }
 }
 
-impl<B: FusionBackend> BoolOpsDescription<B> {
-    fn cleanup_tensor(&self, handles: &mut HandleContainer<B>) {
+impl BoolOpsDescription {
+    fn cleanup_tensor<B: FusionBackend>(&self, handles: &mut HandleContainer<B>) {
         match self {
-            BoolOpsDescription::IntoFloat(desc, _) => {
+            BoolOpsDescription::IntoFloat(desc) => {
                 handles.cleanup(&desc.input);
             }
-            BoolOpsDescription::IntoInt(desc, _) => {
+            BoolOpsDescription::IntoInt(desc) => {
                 handles.cleanup(&desc.input);
             }
-            BoolOpsDescription::Not(desc, _) => {
+            BoolOpsDescription::Not(desc) => {
                 handles.cleanup(&desc.input);
             }
-        }
-    }
-    fn execute(&self, handles: &mut HandleContainer<B>) {
-        match self {
-            BoolOpsDescription::IntoFloat(desc, ops) => ops.execute(desc, handles),
-            BoolOpsDescription::IntoInt(desc, ops) => ops.execute(desc, handles),
-            BoolOpsDescription::Not(desc, ops) => ops.execute(desc, handles),
         }
     }
 }
 
-impl<B: FusionBackend> ModuleOpsDescription<B> {
-    fn cleanup_tensor(&self, handles: &mut HandleContainer<B>) {
+impl ModuleOpsDescription {
+    fn cleanup_tensor<B: FusionBackend>(&self, handles: &mut HandleContainer<B>) {
         match self {
-            ModuleOpsDescription::Embedding(desc, _) => {
+            ModuleOpsDescription::Embedding(desc) => {
                 handles.cleanup(&desc.weights);
                 handles.cleanup(&desc.indices);
             }
-            ModuleOpsDescription::EmbeddingBackward(desc, _) => {
+            ModuleOpsDescription::EmbeddingBackward(desc) => {
                 handles.cleanup(&desc.weights);
                 handles.cleanup(&desc.out_grad);
                 handles.cleanup(&desc.indices);
             }
-            ModuleOpsDescription::Conv1d(desc, _) => {
+            ModuleOpsDescription::Conv1d(desc) => {
                 handles.cleanup(&desc.x);
                 handles.cleanup(&desc.weight);
 
@@ -1377,7 +1025,7 @@ impl<B: FusionBackend> ModuleOpsDescription<B> {
                     handles.cleanup(bias);
                 }
             }
-            ModuleOpsDescription::Conv2d(desc, _) => {
+            ModuleOpsDescription::Conv2d(desc) => {
                 handles.cleanup(&desc.x);
                 handles.cleanup(&desc.weight);
 
@@ -1385,7 +1033,7 @@ impl<B: FusionBackend> ModuleOpsDescription<B> {
                     handles.cleanup(bias);
                 }
             }
-            ModuleOpsDescription::ConvTranspose1d(desc, _) => {
+            ModuleOpsDescription::ConvTranspose1d(desc) => {
                 handles.cleanup(&desc.x);
                 handles.cleanup(&desc.weight);
 
@@ -1393,7 +1041,7 @@ impl<B: FusionBackend> ModuleOpsDescription<B> {
                     handles.cleanup(bias);
                 }
             }
-            ModuleOpsDescription::ConvTranspose2d(desc, _) => {
+            ModuleOpsDescription::ConvTranspose2d(desc) => {
                 handles.cleanup(&desc.x);
                 handles.cleanup(&desc.weight);
 
@@ -1401,87 +1049,55 @@ impl<B: FusionBackend> ModuleOpsDescription<B> {
                     handles.cleanup(bias);
                 }
             }
-            ModuleOpsDescription::AvgPool1d(desc, _) => {
+            ModuleOpsDescription::AvgPool1d(desc) => {
                 handles.cleanup(&desc.x);
             }
-            ModuleOpsDescription::AvgPool2d(desc, _) => {
+            ModuleOpsDescription::AvgPool2d(desc) => {
                 handles.cleanup(&desc.x);
             }
-            ModuleOpsDescription::AvgPool1dBackward(desc, _) => {
-                handles.cleanup(&desc.x);
-                handles.cleanup(&desc.grad);
-            }
-            ModuleOpsDescription::AvgPool2dBackward(desc, _) => {
+            ModuleOpsDescription::AvgPool1dBackward(desc) => {
                 handles.cleanup(&desc.x);
                 handles.cleanup(&desc.grad);
             }
-            ModuleOpsDescription::AdaptiveAvgPool1d(desc, _) => {
-                handles.cleanup(&desc.x);
-            }
-            ModuleOpsDescription::AdaptiveAvgPool2d(desc, _) => {
-                handles.cleanup(&desc.x);
-            }
-            ModuleOpsDescription::AdaptiveAvgPool1dBackward(desc, _) => {
+            ModuleOpsDescription::AvgPool2dBackward(desc) => {
                 handles.cleanup(&desc.x);
                 handles.cleanup(&desc.grad);
             }
-            ModuleOpsDescription::AdaptiveAvgPool2dBackward(desc, _) => {
+            ModuleOpsDescription::AdaptiveAvgPool1d(desc) => {
+                handles.cleanup(&desc.x);
+            }
+            ModuleOpsDescription::AdaptiveAvgPool2d(desc) => {
+                handles.cleanup(&desc.x);
+            }
+            ModuleOpsDescription::AdaptiveAvgPool1dBackward(desc) => {
                 handles.cleanup(&desc.x);
                 handles.cleanup(&desc.grad);
             }
-            ModuleOpsDescription::MaxPool1d(desc, _) => {
+            ModuleOpsDescription::AdaptiveAvgPool2dBackward(desc) => {
+                handles.cleanup(&desc.x);
+                handles.cleanup(&desc.grad);
+            }
+            ModuleOpsDescription::MaxPool1d(desc) => {
                 handles.cleanup(&desc.x);
             }
-            ModuleOpsDescription::MaxPool1dWithIndices(desc, _) => {
+            ModuleOpsDescription::MaxPool1dWithIndices(desc) => {
                 handles.cleanup(&desc.x);
             }
-            ModuleOpsDescription::MaxPool1dWithIndicesBackward(desc, _) => {
+            ModuleOpsDescription::MaxPool1dWithIndicesBackward(desc) => {
                 handles.cleanup(&desc.x);
                 handles.cleanup(&desc.grad);
                 handles.cleanup(&desc.indices);
             }
-            ModuleOpsDescription::MaxPool2d(desc, _) => {
+            ModuleOpsDescription::MaxPool2d(desc) => {
                 handles.cleanup(&desc.x);
             }
-            ModuleOpsDescription::MaxPool2dWithIndices(desc, _) => {
+            ModuleOpsDescription::MaxPool2dWithIndices(desc) => {
                 handles.cleanup(&desc.x);
             }
-            ModuleOpsDescription::MaxPool2dWithIndicesBackward(desc, _) => {
+            ModuleOpsDescription::MaxPool2dWithIndicesBackward(desc) => {
                 handles.cleanup(&desc.x);
                 handles.cleanup(&desc.grad);
                 handles.cleanup(&desc.indices);
-            }
-        }
-    }
-    fn execute(&self, handles: &mut HandleContainer<B>) {
-        match self {
-            ModuleOpsDescription::Embedding(desc, ops) => ops.execute(desc, handles),
-            ModuleOpsDescription::EmbeddingBackward(desc, ops) => ops.execute(desc, handles),
-            ModuleOpsDescription::Conv1d(desc, ops) => ops.execute(desc, handles),
-            ModuleOpsDescription::Conv2d(desc, ops) => ops.execute(desc, handles),
-            ModuleOpsDescription::ConvTranspose1d(desc, ops) => ops.execute(desc, handles),
-            ModuleOpsDescription::ConvTranspose2d(desc, ops) => ops.execute(desc, handles),
-            ModuleOpsDescription::AvgPool1d(desc, ops) => ops.execute(desc, handles),
-            ModuleOpsDescription::AvgPool2d(desc, ops) => ops.execute(desc, handles),
-            ModuleOpsDescription::AvgPool1dBackward(desc, ops) => ops.execute(desc, handles),
-            ModuleOpsDescription::AvgPool2dBackward(desc, ops) => ops.execute(desc, handles),
-            ModuleOpsDescription::AdaptiveAvgPool1d(desc, ops) => ops.execute(desc, handles),
-            ModuleOpsDescription::AdaptiveAvgPool2d(desc, ops) => ops.execute(desc, handles),
-            ModuleOpsDescription::AdaptiveAvgPool1dBackward(desc, ops) => {
-                ops.execute(desc, handles)
-            }
-            ModuleOpsDescription::AdaptiveAvgPool2dBackward(desc, ops) => {
-                ops.execute(desc, handles)
-            }
-            ModuleOpsDescription::MaxPool1d(desc, ops) => ops.execute(desc, handles),
-            ModuleOpsDescription::MaxPool1dWithIndices(desc, ops) => ops.execute(desc, handles),
-            ModuleOpsDescription::MaxPool1dWithIndicesBackward(desc, ops) => {
-                ops.execute(desc, handles)
-            }
-            ModuleOpsDescription::MaxPool2d(desc, ops) => ops.execute(desc, handles),
-            ModuleOpsDescription::MaxPool2dWithIndices(desc, ops) => ops.execute(desc, handles),
-            ModuleOpsDescription::MaxPool2dWithIndicesBackward(desc, ops) => {
-                ops.execute(desc, handles)
             }
         }
     }

--- a/burn-fusion/src/graph/ops.rs
+++ b/burn-fusion/src/graph/ops.rs
@@ -4,7 +4,6 @@ use burn_tensor::{
     ops::{ConvOptions, ConvTransposeOptions},
     Distribution, Element,
 };
-use core::hash::Hash;
 use std::ops::Range;
 
 /// General trait to abstract how a single operation is executed.
@@ -14,6 +13,7 @@ pub trait Ops<B: FusionBackend>: Send + Sync {
 }
 
 /// Describe all tensor operations possible.
+#[derive(Clone, Debug)]
 pub enum TensorOpsDescription {
     /// Basic operation on a float tensor.
     BaseOpsFloat(BaseOpsDescription),
@@ -36,6 +36,7 @@ pub enum TensorOpsDescription {
 }
 
 /// Operation description specific to a float tensor.
+#[derive(Clone, Debug)]
 pub enum FloatOpsDescription {
     /// Operation corresponding to [exp](burn_tensor::ops::TensorOps::exp).
     Exp(UnaryOpsDescription),
@@ -60,12 +61,13 @@ pub enum FloatOpsDescription {
     /// Operation corresponding to [matmul](burn_tensor::ops::TensorOps::matmul).
     Matmul(BinaryOpsDescription),
     /// Operation corresponding to [random](burn_tensor::ops::TensorOps::random).
-    Random((TensorDescription, Distribution<f32>)),
+    Random((TensorDescription, Distribution)),
     /// Operation corresponding to [recip](burn_tensor::ops::TensorOps::recip).
     Recip(UnaryOpsDescription),
 }
 
 /// Operation description specific to module.
+#[derive(Clone, Debug)]
 pub enum ModuleOpsDescription {
     /// Operation corresponding to [embedding](burn_tensor::ops::ModuleOps::embedding).
     Embedding(EmbeddingDescription),
@@ -122,6 +124,7 @@ pub enum ModuleOpsDescription {
 }
 
 /// Basic operations that can be done on any tensor type.
+#[derive(Clone, Debug)]
 pub enum BaseOpsDescription {
     /// Operation corresponding to:
     ///
@@ -174,6 +177,7 @@ pub enum BaseOpsDescription {
 }
 
 /// Numeric operations on int and float tensors.
+#[derive(Clone, Debug)]
 pub enum NumericOpsDescription<E: Element> {
     /// Operation corresponding to:
     ///
@@ -388,12 +392,14 @@ pub enum NumericOpsDescription<E: Element> {
 }
 
 /// Operation description specific to an int tensor.
+#[derive(Clone, Debug)]
 pub enum IntOpsDescription {
     /// Operation corresponding to [into float](burn_tensor::ops::IntTensorOps::int_into_float).
     IntoFloat(UnaryOpsDescription),
 }
 
 /// Operation description specific to a bool tensor.
+#[derive(Clone, Debug)]
 pub enum BoolOpsDescription {
     /// Operation corresponding to [into float](burn_tensor::ops::BoolTensorOps::bool_into_float).
     IntoFloat(UnaryOpsDescription),
@@ -403,7 +409,7 @@ pub enum BoolOpsDescription {
     Not(UnaryOpsDescription),
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 /// Swap dim operation description.
 pub struct SwapDimsDescription {
     /// Input tensor description.
@@ -416,7 +422,7 @@ pub struct SwapDimsDescription {
     pub dim2: usize,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct ReshapeDescription {
     pub input: TensorDescription,
@@ -424,7 +430,7 @@ pub struct ReshapeDescription {
     pub shape: Vec<usize>,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct BinaryOpsDescription {
     pub lhs: TensorDescription,
@@ -432,13 +438,14 @@ pub struct BinaryOpsDescription {
     pub out: TensorDescription,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct UnaryOpsDescription {
     pub input: TensorDescription,
     pub out: TensorDescription,
 }
 
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct ScalarOpsDescription<E> {
     pub lhs: TensorDescription,
@@ -446,7 +453,7 @@ pub struct ScalarOpsDescription<E> {
     pub out: TensorDescription,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct GatherOpsDescription {
     pub tensor: TensorDescription,
@@ -455,7 +462,7 @@ pub struct GatherOpsDescription {
     pub out: TensorDescription,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct ScatterOpsDescription {
     pub tensor: TensorDescription,
@@ -465,7 +472,7 @@ pub struct ScatterOpsDescription {
     pub out: TensorDescription,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct SelectOpsDescription {
     pub tensor: TensorDescription,
@@ -474,7 +481,7 @@ pub struct SelectOpsDescription {
     pub out: TensorDescription,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct SelectAssignOpsDescription {
     pub tensor: TensorDescription,
@@ -484,7 +491,7 @@ pub struct SelectAssignOpsDescription {
     pub out: TensorDescription,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct SliceOpsDescription {
     pub tensor: TensorDescription,
@@ -492,7 +499,7 @@ pub struct SliceOpsDescription {
     pub out: TensorDescription,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct SliceAssignOpsDescription {
     pub tensor: TensorDescription,
@@ -501,7 +508,7 @@ pub struct SliceAssignOpsDescription {
     pub out: TensorDescription,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct MaskWhereOpsDescription {
     pub tensor: TensorDescription,
@@ -510,6 +517,7 @@ pub struct MaskWhereOpsDescription {
     pub out: TensorDescription,
 }
 
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct MaskFillOpsDescription<E> {
     pub tensor: TensorDescription,
@@ -518,6 +526,7 @@ pub struct MaskFillOpsDescription<E> {
     pub out: TensorDescription,
 }
 
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct ClampOpsDescription<E> {
     pub tensor: TensorDescription,
@@ -526,6 +535,7 @@ pub struct ClampOpsDescription<E> {
     pub out: TensorDescription,
 }
 
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct RepeatOpsDescription {
     pub tensor: TensorDescription,
@@ -535,7 +545,7 @@ pub struct RepeatOpsDescription {
     pub out: TensorDescription,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct CatOpsDescription {
     pub tensors: Vec<TensorDescription>,
@@ -543,7 +553,7 @@ pub struct CatOpsDescription {
     pub out: TensorDescription,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct ReduceDimWithIndicesDescription {
     pub tensor: TensorDescription,
@@ -552,7 +562,7 @@ pub struct ReduceDimWithIndicesDescription {
     pub out_indices: TensorDescription,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct EmbeddingDescription {
     pub weights: TensorDescription,
@@ -560,7 +570,7 @@ pub struct EmbeddingDescription {
     pub out: TensorDescription,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct EmbeddingBackwardDescription {
     pub weights: TensorDescription,
@@ -569,7 +579,7 @@ pub struct EmbeddingBackwardDescription {
     pub out: TensorDescription,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct Conv1dDescription {
     pub x: TensorDescription,
@@ -579,7 +589,7 @@ pub struct Conv1dDescription {
     pub out: TensorDescription,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct Conv2dDescription {
     pub x: TensorDescription,
@@ -589,7 +599,7 @@ pub struct Conv2dDescription {
     pub out: TensorDescription,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct ConvTranspose1dDescription {
     pub x: TensorDescription,
@@ -599,7 +609,7 @@ pub struct ConvTranspose1dDescription {
     pub out: TensorDescription,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct ConvTranspose2dDescription {
     pub x: TensorDescription,
@@ -609,7 +619,7 @@ pub struct ConvTranspose2dDescription {
     pub out: TensorDescription,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct AvgPool1dDescription {
     pub x: TensorDescription,
@@ -620,7 +630,7 @@ pub struct AvgPool1dDescription {
     pub out: TensorDescription,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct AvgPool2dDescription {
     pub x: TensorDescription,
@@ -631,7 +641,7 @@ pub struct AvgPool2dDescription {
     pub out: TensorDescription,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct AvgPool1dBackwardDescription {
     pub x: TensorDescription,
@@ -643,7 +653,7 @@ pub struct AvgPool1dBackwardDescription {
     pub out: TensorDescription,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct AvgPool2dBackwardDescription {
     pub x: TensorDescription,
@@ -655,7 +665,7 @@ pub struct AvgPool2dBackwardDescription {
     pub out: TensorDescription,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct AdaptiveAvgPool1dDescription {
     pub x: TensorDescription,
@@ -663,7 +673,7 @@ pub struct AdaptiveAvgPool1dDescription {
     pub out: TensorDescription,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct AdaptiveAvgPool2dDescription {
     pub x: TensorDescription,
@@ -671,7 +681,7 @@ pub struct AdaptiveAvgPool2dDescription {
     pub out: TensorDescription,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct AdaptiveAvgPool1dBackwardDescription {
     pub x: TensorDescription,
@@ -679,7 +689,7 @@ pub struct AdaptiveAvgPool1dBackwardDescription {
     pub out: TensorDescription,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct AdaptiveAvgPool2dBackwardDescription {
     pub x: TensorDescription,
@@ -687,7 +697,7 @@ pub struct AdaptiveAvgPool2dBackwardDescription {
     pub out: TensorDescription,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct MaxPool1dDescription {
     pub x: TensorDescription,
@@ -698,7 +708,7 @@ pub struct MaxPool1dDescription {
     pub out: TensorDescription,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct MaxPool1dWithIndicesDescription {
     pub x: TensorDescription,
@@ -710,7 +720,7 @@ pub struct MaxPool1dWithIndicesDescription {
     pub out_indices: TensorDescription,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct MaxPool1dWithIndicesBackwardDescription {
     pub x: TensorDescription,
@@ -723,7 +733,7 @@ pub struct MaxPool1dWithIndicesBackwardDescription {
     pub out: TensorDescription,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct MaxPool2dDescription {
     pub x: TensorDescription,
@@ -734,7 +744,7 @@ pub struct MaxPool2dDescription {
     pub out: TensorDescription,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct MaxPool2dWithIndicesDescription {
     pub x: TensorDescription,
@@ -746,7 +756,7 @@ pub struct MaxPool2dWithIndicesDescription {
     pub out_indices: TensorDescription,
 }
 
-#[derive(Hash)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct MaxPool2dWithIndicesBackwardDescription {
     pub x: TensorDescription,

--- a/burn-fusion/src/ops/binary.rs
+++ b/burn-fusion/src/ops/binary.rs
@@ -5,17 +5,18 @@ macro_rules! binary_float_ops {
         $name:ident,
         $ops:expr
     ) => {
-        struct $name<const D: usize>;
+        #[derive(new)]
+        struct $name<const D: usize> {
+            desc: BinaryOpsDescription,
+        }
 
         impl<const D: usize, B: FusionBackend> Ops<B> for $name<D> {
-            type Args = BinaryOpsDescription;
-
-            fn execute(&self, args: &Self::Args, handles: &mut $crate::HandleContainer<B>) {
-                let lhs = handles.get_float_tensor::<D>(&args.lhs);
-                let rhs = handles.get_float_tensor(&args.rhs);
+            fn execute(self: Box<Self>, handles: &mut $crate::HandleContainer<B>) {
+                let lhs = handles.get_float_tensor::<D>(&self.desc.lhs);
+                let rhs = handles.get_float_tensor(&self.desc.rhs);
                 let output = $ops(lhs, rhs);
 
-                handles.register_float_tensor(&args.out.id, output);
+                handles.register_float_tensor(&self.desc.out.id, output);
             }
         }
     };
@@ -28,17 +29,18 @@ macro_rules! binary_float_cmp_ops {
         $name:ident,
         $ops:expr
     ) => {
-        struct $name<const D: usize>;
+        #[derive(new)]
+        struct $name<const D: usize> {
+            desc: BinaryOpsDescription,
+        }
 
         impl<const D: usize, B: FusionBackend> Ops<B> for $name<D> {
-            type Args = BinaryOpsDescription;
-
-            fn execute(&self, args: &Self::Args, handles: &mut $crate::HandleContainer<B>) {
-                let lhs = handles.get_float_tensor::<D>(&args.lhs);
-                let rhs = handles.get_float_tensor(&args.rhs);
+            fn execute(self: Box<Self>, handles: &mut $crate::HandleContainer<B>) {
+                let lhs = handles.get_float_tensor::<D>(&self.desc.lhs);
+                let rhs = handles.get_float_tensor(&self.desc.rhs);
                 let output = $ops(lhs, rhs);
 
-                handles.register_bool_tensor(&args.out.id, output);
+                handles.register_bool_tensor(&self.desc.out.id, output);
             }
         }
     };
@@ -51,17 +53,18 @@ macro_rules! binary_int_cmp_ops {
         $name:ident,
         $ops:expr
     ) => {
-        struct $name<const D: usize>;
+        #[derive(new)]
+        struct $name<const D: usize> {
+            desc: BinaryOpsDescription,
+        }
 
         impl<const D: usize, B: FusionBackend> Ops<B> for $name<D> {
-            type Args = BinaryOpsDescription;
-
-            fn execute(&self, args: &Self::Args, handles: &mut $crate::HandleContainer<B>) {
-                let lhs = handles.get_int_tensor::<D>(&args.lhs);
-                let rhs = handles.get_int_tensor(&args.rhs);
+            fn execute(self: Box<Self>, handles: &mut $crate::HandleContainer<B>) {
+                let lhs = handles.get_int_tensor::<D>(&self.desc.lhs);
+                let rhs = handles.get_int_tensor(&self.desc.rhs);
                 let output = $ops(lhs, rhs);
 
-                handles.register_bool_tensor(&args.out.id, output);
+                handles.register_bool_tensor(&self.desc.out.id, output);
             }
         }
     };
@@ -84,17 +87,18 @@ macro_rules! binary_int_ops {
         $name:ident,
         $ops:expr
     ) => {
-        struct $name<const D: usize>;
+        #[derive(new)]
+        struct $name<const D: usize> {
+            desc: BinaryOpsDescription,
+        }
 
         impl<const D: usize, B: FusionBackend> Ops<B> for $name<D> {
-            type Args = BinaryOpsDescription;
-
-            fn execute(&self, args: &Self::Args, handles: &mut $crate::HandleContainer<B>) {
-                let lhs = handles.get_int_tensor::<D>(&args.lhs);
-                let rhs = handles.get_int_tensor(&args.rhs);
+            fn execute(self: Box<Self>, handles: &mut $crate::HandleContainer<B>) {
+                let lhs = handles.get_int_tensor::<D>(&self.desc.lhs);
+                let rhs = handles.get_int_tensor(&self.desc.rhs);
                 let output = $ops(lhs, rhs);
 
-                handles.register_int_tensor(&args.out.id, output);
+                handles.register_int_tensor(&self.desc.out.id, output);
             }
         }
     };

--- a/burn-fusion/src/ops/boolean.rs
+++ b/burn-fusion/src/ops/boolean.rs
@@ -46,28 +46,27 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
     fn bool_into_int<const D: usize>(
         tensor: BoolTensor<Self, D>,
     ) -> burn_tensor::ops::IntTensor<Self, D> {
-        struct IntoIntOps<const D: usize>;
+        struct IntoIntOps<const D: usize> {
+            desc: UnaryOpsDescription,
+        }
 
         impl<const D: usize, B: FusionBackend> Ops<B> for IntoIntOps<D> {
-            type Args = UnaryOpsDescription;
-
-            fn execute(&self, args: &Self::Args, handles: &mut crate::HandleContainer<B>) {
-                let input = handles.get_bool_tensor::<D>(&args.input);
+            fn execute(self: Box<Self>, handles: &mut crate::HandleContainer<B>) {
+                let input = handles.get_bool_tensor::<D>(&self.desc.input);
                 let output = B::bool_into_int(input);
-                handles.register_int_tensor(&args.out.id, output);
+                handles.register_int_tensor(&self.desc.out.id, output);
             }
         }
 
         let out = tensor.client.tensor_uninitialized(tensor.shape.clone());
 
-        out.client
-            .register(TensorOpsDescription::BoolOps(BoolOpsDescription::IntoInt(
-                UnaryOpsDescription {
-                    input: tensor.into_description(),
-                    out: out.to_description_out(),
-                },
-                Box::new(IntoIntOps::<D>),
-            )));
+        out.client.register(
+            TensorOpsDescription::BoolOps(BoolOpsDescription::IntoInt(UnaryOpsDescription {
+                input: tensor.into_description(),
+                out: out.to_description_out(),
+            })),
+            todo!(),
+        );
 
         out
     }
@@ -75,29 +74,27 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
     fn bool_into_float<const D: usize>(
         tensor: BoolTensor<Self, D>,
     ) -> burn_tensor::ops::FloatTensor<Self, D> {
-        struct IntoFloatOps<const D: usize>;
+        struct IntoFloatOps<const D: usize> {
+            desc: UnaryOpsDescription,
+        }
 
         impl<const D: usize, B: FusionBackend> Ops<B> for IntoFloatOps<D> {
-            type Args = UnaryOpsDescription;
-
-            fn execute(&self, args: &Self::Args, handles: &mut crate::HandleContainer<B>) {
-                let input = handles.get_bool_tensor::<D>(&args.input);
+            fn execute(self: Box<Self>, handles: &mut crate::HandleContainer<B>) {
+                let input = handles.get_bool_tensor::<D>(&self.desc.input);
                 let output = B::bool_into_float(input);
-                handles.register_float_tensor(&args.out.id, output);
+                handles.register_float_tensor(&self.desc.out.id, output);
             }
         }
 
         let out = tensor.client.tensor_uninitialized(tensor.shape.clone());
 
-        out.client.register(TensorOpsDescription::BoolOps(
-            BoolOpsDescription::IntoFloat(
-                UnaryOpsDescription {
-                    input: tensor.into_description(),
-                    out: out.to_description_out(),
-                },
-                Box::new(IntoFloatOps::<D>),
-            ),
-        ));
+        out.client.register(
+            TensorOpsDescription::BoolOps(BoolOpsDescription::IntoFloat(UnaryOpsDescription {
+                input: tensor.into_description(),
+                out: out.to_description_out(),
+            })),
+            todo!(),
+        );
 
         out
     }
@@ -129,34 +126,29 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
         tensor: BoolTensor<Self, D1>,
         shape: Shape<D2>,
     ) -> BoolTensor<Self, D2> {
-        struct ReshapeDimsOps<const D1: usize, const D2: usize>;
+        struct ReshapeDimsOps<const D1: usize, const D2: usize> {
+            desc: ReshapeDescription,
+        }
 
         impl<const D1: usize, const D2: usize, B: FusionBackend> Ops<B> for ReshapeDimsOps<D1, D2> {
-            type Args = ReshapeDescription;
-
-            fn execute(&self, args: &Self::Args, handles: &mut crate::HandleContainer<B>) {
-                let input = handles.get_bool_tensor::<D1>(&args.input);
-                let output = B::bool_reshape::<D1, D2>(input, Shape::from(&args.shape));
-                handles.register_bool_tensor(&args.out.id, output);
+            fn execute(self: Box<Self>, handles: &mut crate::HandleContainer<B>) {
+                let input = handles.get_bool_tensor::<D1>(&self.desc.input);
+                let output = B::bool_reshape::<D1, D2>(input, Shape::from(&self.desc.shape));
+                handles.register_bool_tensor(&self.desc.out.id, output);
             }
         }
 
         let shape: Vec<usize> = shape.dims.into();
         let out = tensor.client.tensor_uninitialized(shape.clone());
 
-        tensor
-            .client
-            .clone()
-            .register(TensorOpsDescription::BaseOpsBool(
-                BaseOpsDescription::Reshape(
-                    ReshapeDescription {
-                        input: tensor.into_description(),
-                        shape,
-                        out: out.to_description_out(),
-                    },
-                    Box::new(ReshapeDimsOps::<D1, D2>),
-                ),
-            ));
+        tensor.client.clone().register(
+            TensorOpsDescription::BaseOpsBool(BaseOpsDescription::Reshape(ReshapeDescription {
+                input: tensor.into_description(),
+                shape,
+                out: out.to_description_out(),
+            })),
+            todo!(),
+        );
 
         out
     }
@@ -165,18 +157,18 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
         tensor: BoolTensor<Self, D1>,
         ranges: [std::ops::Range<usize>; D2],
     ) -> BoolTensor<Self, D1> {
-        struct SliceOps<const D1: usize, const D2: usize>;
+        struct SliceOps<const D1: usize, const D2: usize> {
+            desc: SliceOpsDescription,
+        }
 
         impl<const D1: usize, const D2: usize, B: FusionBackend> Ops<B> for SliceOps<D1, D2> {
-            type Args = SliceOpsDescription;
-
-            fn execute(&self, args: &Self::Args, handles: &mut crate::HandleContainer<B>) {
-                let tensor = handles.get_bool_tensor::<D1>(&args.tensor);
+            fn execute(self: Box<Self>, handles: &mut crate::HandleContainer<B>) {
+                let tensor = handles.get_bool_tensor::<D1>(&self.desc.tensor);
 
                 let output =
-                    B::bool_slice::<D1, D2>(tensor, args.ranges.clone().try_into().unwrap());
+                    B::bool_slice::<D1, D2>(tensor, self.desc.ranges.clone().try_into().unwrap());
 
-                handles.register_bool_tensor(&args.out.id, output);
+                handles.register_bool_tensor(&self.desc.out.id, output);
             }
         }
 
@@ -188,19 +180,14 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
 
         let out = tensor.client.tensor_uninitialized(shape);
 
-        tensor
-            .client
-            .clone()
-            .register(TensorOpsDescription::BaseOpsBool(
-                BaseOpsDescription::Slice(
-                    SliceOpsDescription {
-                        tensor: tensor.into_description(),
-                        ranges: ranges.into(),
-                        out: out.to_description_out(),
-                    },
-                    Box::new(SliceOps::<D1, D2>),
-                ),
-            ));
+        tensor.client.clone().register(
+            TensorOpsDescription::BaseOpsBool(BaseOpsDescription::Slice(SliceOpsDescription {
+                tensor: tensor.into_description(),
+                ranges: ranges.into(),
+                out: out.to_description_out(),
+            })),
+            todo!(),
+        );
 
         out
     }
@@ -210,42 +197,39 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
         ranges: [std::ops::Range<usize>; D2],
         value: BoolTensor<Self, D1>,
     ) -> BoolTensor<Self, D1> {
-        struct SliceAssignOps<const D1: usize, const D2: usize>;
+        struct SliceAssignOps<const D1: usize, const D2: usize> {
+            desc: SliceAssignOpsDescription,
+        }
 
         impl<const D1: usize, const D2: usize, B: FusionBackend> Ops<B> for SliceAssignOps<D1, D2> {
-            type Args = SliceAssignOpsDescription;
-
-            fn execute(&self, args: &Self::Args, handles: &mut crate::HandleContainer<B>) {
-                let tensor = handles.get_bool_tensor::<D1>(&args.tensor);
-                let value = handles.get_bool_tensor::<D1>(&args.value);
+            fn execute(self: Box<Self>, handles: &mut crate::HandleContainer<B>) {
+                let tensor = handles.get_bool_tensor::<D1>(&self.desc.tensor);
+                let value = handles.get_bool_tensor::<D1>(&self.desc.value);
 
                 let output = B::bool_slice_assign::<D1, D2>(
                     tensor,
-                    args.ranges.clone().try_into().unwrap(),
+                    self.desc.ranges.clone().try_into().unwrap(),
                     value,
                 );
 
-                handles.register_bool_tensor(&args.out.id, output);
+                handles.register_bool_tensor(&self.desc.out.id, output);
             }
         }
 
         let shape: Vec<usize> = tensor.shape.clone();
         let out = tensor.client.tensor_uninitialized(shape);
 
-        tensor
-            .client
-            .clone()
-            .register(TensorOpsDescription::BaseOpsBool(
-                BaseOpsDescription::SliceAssign(
-                    SliceAssignOpsDescription {
-                        tensor: tensor.into_description(),
-                        ranges: ranges.into(),
-                        value: value.into_description(),
-                        out: out.to_description_out(),
-                    },
-                    Box::new(SliceAssignOps::<D1, D2>),
-                ),
-            ));
+        tensor.client.clone().register(
+            TensorOpsDescription::BaseOpsBool(BaseOpsDescription::SliceAssign(
+                SliceAssignOpsDescription {
+                    tensor: tensor.into_description(),
+                    ranges: ranges.into(),
+                    value: value.into_description(),
+                    out: out.to_description_out(),
+                },
+            )),
+            todo!(),
+        );
 
         out
     }
@@ -254,21 +238,21 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
         tensors: Vec<BoolTensor<Self, D>>,
         dim: usize,
     ) -> BoolTensor<Self, D> {
-        struct CatOps<const D: usize>;
+        struct CatOps<const D: usize> {
+            desc: CatOpsDescription,
+        }
 
         impl<const D: usize, B: FusionBackend> Ops<B> for CatOps<D> {
-            type Args = CatOpsDescription;
-
-            fn execute(&self, args: &Self::Args, handles: &mut crate::HandleContainer<B>) {
+            fn execute(self: Box<Self>, handles: &mut crate::HandleContainer<B>) {
                 let tensors = args
                     .tensors
                     .iter()
                     .map(|tensor| handles.get_bool_tensor(tensor))
                     .collect();
 
-                let output = B::bool_cat::<D>(tensors, args.dim);
+                let output = B::bool_cat::<D>(tensors, self.desc.dim);
 
-                handles.register_bool_tensor(&args.out.id, output);
+                handles.register_bool_tensor(&self.desc.out.id, output);
             }
         }
 
@@ -284,14 +268,14 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
 
         let out = client.tensor_uninitialized(shape);
 
-        client.register(TensorOpsDescription::BaseOpsBool(BaseOpsDescription::Cat(
-            CatOpsDescription {
+        client.register(
+            TensorOpsDescription::BaseOpsBool(BaseOpsDescription::Cat(CatOpsDescription {
                 tensors: tensors.into_iter().map(|t| t.into_description()).collect(),
                 dim,
                 out: out.to_description_out(),
-            },
-            Box::new(CatOps::<D>),
-        )));
+            })),
+            todo!(),
+        );
 
         out
     }
@@ -300,16 +284,16 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
         lhs: BoolTensor<Self, D>,
         rhs: BoolTensor<Self, D>,
     ) -> BoolTensor<Self, D> {
-        struct EqualOps<const D: usize>;
+        struct EqualOps<const D: usize> {
+            desc: BinaryOpsDescription,
+        }
 
         impl<const D: usize, B: FusionBackend> Ops<B> for EqualOps<D> {
-            type Args = BinaryOpsDescription;
-
-            fn execute(&self, args: &Self::Args, handles: &mut crate::HandleContainer<B>) {
-                let lhs = handles.get_bool_tensor::<D>(&args.lhs);
-                let rhs = handles.get_bool_tensor(&args.rhs);
+            fn execute(self: Box<Self>, handles: &mut crate::HandleContainer<B>) {
+                let lhs = handles.get_bool_tensor::<D>(&self.desc.lhs);
+                let rhs = handles.get_bool_tensor(&self.desc.rhs);
                 let output = B::bool_equal(lhs, rhs);
-                handles.register_bool_tensor(&args.out.id, output);
+                handles.register_bool_tensor(&self.desc.out.id, output);
             }
         }
 
@@ -317,44 +301,42 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
             .client
             .tensor_uninitialized(binary_ops_shape(&lhs.shape, &rhs.shape));
 
-        out.client.register(TensorOpsDescription::BaseOpsBool(
-            BaseOpsDescription::Equal(
-                BinaryOpsDescription {
-                    lhs: lhs.into_description(),
-                    rhs: rhs.into_description(),
-                    out: out.to_description_out(),
-                },
-                Box::new(EqualOps::<D>),
-            ),
-        ));
+        out.client.register(
+            TensorOpsDescription::BaseOpsBool(BaseOpsDescription::Equal(BinaryOpsDescription {
+                lhs: lhs.into_description(),
+                rhs: rhs.into_description(),
+                out: out.to_description_out(),
+            })),
+            todo!(),
+        );
 
         out
     }
 
     fn bool_not<const D: usize>(tensor: BoolTensor<Self, D>) -> BoolTensor<Self, D> {
-        struct NotOps<const D: usize>;
+        struct NotOps<const D: usize> {
+            desc: UnaryOpsDescription,
+        }
 
         impl<const D: usize, B: FusionBackend> Ops<B> for NotOps<D> {
-            type Args = UnaryOpsDescription;
-
-            fn execute(&self, args: &Self::Args, handles: &mut crate::HandleContainer<B>) {
-                let input = handles.get_bool_tensor::<D>(&args.input);
+            fn execute(self: Box<Self>, handles: &mut crate::HandleContainer<B>) {
+                let input = handles.get_bool_tensor::<D>(&self.desc.input);
                 let output = B::bool_not(input);
-                handles.register_bool_tensor(&args.out.id, output);
+                handles.register_bool_tensor(&self.desc.out.id, output);
             }
         }
 
         let out = tensor.client.tensor_uninitialized(tensor.shape.clone());
 
-        out.client.register(TensorOpsDescription::BoolOps(
-            crate::graph::BoolOpsDescription::Not(
+        out.client.register(
+            TensorOpsDescription::BoolOps(crate::graph::BoolOpsDescription::Not(
                 UnaryOpsDescription {
                     input: tensor.into_description(),
                     out: out.to_description_out(),
                 },
-                Box::new(NotOps::<D>),
-            ),
-        ));
+            )),
+            todo!(),
+        );
 
         out
     }
@@ -364,15 +346,15 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
         dim1: usize,
         dim2: usize,
     ) -> BoolTensor<Self, D> {
-        struct SwapDimsOps<const D: usize>;
+        struct SwapDimsOps<const D: usize> {
+            desc: SwapDimsDescription,
+        }
 
         impl<const D: usize, B: FusionBackend> Ops<B> for SwapDimsOps<D> {
-            type Args = SwapDimsDescription;
-
-            fn execute(&self, args: &Self::Args, handles: &mut crate::HandleContainer<B>) {
-                let input = handles.get_bool_tensor::<D>(&args.input);
-                let output = B::bool_swap_dims(input, args.dim1, args.dim2);
-                handles.register_bool_tensor(&args.out.id, output);
+            fn execute(self: Box<Self>, handles: &mut crate::HandleContainer<B>) {
+                let input = handles.get_bool_tensor::<D>(&self.desc.input);
+                let output = B::bool_swap_dims(input, self.desc.dim1, self.desc.dim2);
+                handles.register_bool_tensor(&self.desc.out.id, output);
             }
         }
 
@@ -382,20 +364,15 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
 
         let out = tensor.client.tensor_uninitialized(shape);
 
-        tensor
-            .client
-            .clone()
-            .register(TensorOpsDescription::BaseOpsBool(
-                BaseOpsDescription::SwapDims(
-                    SwapDimsDescription {
-                        input: tensor.into_description(),
-                        dim1,
-                        dim2,
-                        out: out.to_description_out(),
-                    },
-                    Box::new(SwapDimsOps::<D>),
-                ),
-            ));
+        tensor.client.clone().register(
+            TensorOpsDescription::BaseOpsBool(BaseOpsDescription::SwapDims(SwapDimsDescription {
+                input: tensor.into_description(),
+                dim1,
+                dim2,
+                out: out.to_description_out(),
+            })),
+            todo!(),
+        );
 
         out
     }

--- a/burn-fusion/src/ops/boolean.rs
+++ b/burn-fusion/src/ops/boolean.rs
@@ -151,7 +151,7 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
             shape,
             out: out.to_description_out(),
         };
-        tensor.client.clone().register(
+        out.client.register(
             TensorOpsDescription::BaseOpsBool(BaseOpsDescription::Reshape(desc.clone())),
             ReshapeDimsOps::<D1, D2>::new(desc),
         );
@@ -192,7 +192,7 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
             ranges: ranges.into(),
             out: out.to_description_out(),
         };
-        tensor.client.clone().register(
+        out.client.register(
             TensorOpsDescription::BaseOpsBool(BaseOpsDescription::Slice(desc.clone())),
             SliceOps::<D1, D2>::new(desc),
         );
@@ -235,7 +235,7 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
             out: out.to_description_out(),
         };
 
-        tensor.client.clone().register(
+        out.client.register(
             TensorOpsDescription::BaseOpsBool(BaseOpsDescription::SliceAssign(desc.clone())),
             SliceAssignOps::<D1, D2>::new(desc),
         );
@@ -386,7 +386,7 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
             dim2,
             out: out.to_description_out(),
         };
-        tensor.client.clone().register(
+        out.client.register(
             TensorOpsDescription::BaseOpsBool(BaseOpsDescription::SwapDims(desc.clone())),
             SwapDimsOps::<D>::new(desc),
         );

--- a/burn-fusion/src/ops/boolean.rs
+++ b/burn-fusion/src/ops/boolean.rs
@@ -46,6 +46,7 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
     fn bool_into_int<const D: usize>(
         tensor: BoolTensor<Self, D>,
     ) -> burn_tensor::ops::IntTensor<Self, D> {
+        #[derive(new)]
         struct IntoIntOps<const D: usize> {
             desc: UnaryOpsDescription,
         }
@@ -60,12 +61,13 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
 
         let out = tensor.client.tensor_uninitialized(tensor.shape.clone());
 
+        let desc = UnaryOpsDescription {
+            input: tensor.into_description(),
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::BoolOps(BoolOpsDescription::IntoInt(UnaryOpsDescription {
-                input: tensor.into_description(),
-                out: out.to_description_out(),
-            })),
-            todo!(),
+            TensorOpsDescription::BoolOps(BoolOpsDescription::IntoInt(desc.clone())),
+            IntoIntOps::<D>::new(desc),
         );
 
         out
@@ -74,6 +76,7 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
     fn bool_into_float<const D: usize>(
         tensor: BoolTensor<Self, D>,
     ) -> burn_tensor::ops::FloatTensor<Self, D> {
+        #[derive(new)]
         struct IntoFloatOps<const D: usize> {
             desc: UnaryOpsDescription,
         }
@@ -88,12 +91,13 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
 
         let out = tensor.client.tensor_uninitialized(tensor.shape.clone());
 
+        let desc = UnaryOpsDescription {
+            input: tensor.into_description(),
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::BoolOps(BoolOpsDescription::IntoFloat(UnaryOpsDescription {
-                input: tensor.into_description(),
-                out: out.to_description_out(),
-            })),
-            todo!(),
+            TensorOpsDescription::BoolOps(BoolOpsDescription::IntoFloat(desc.clone())),
+            IntoFloatOps::<D>::new(desc),
         );
 
         out
@@ -126,6 +130,7 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
         tensor: BoolTensor<Self, D1>,
         shape: Shape<D2>,
     ) -> BoolTensor<Self, D2> {
+        #[derive(new)]
         struct ReshapeDimsOps<const D1: usize, const D2: usize> {
             desc: ReshapeDescription,
         }
@@ -141,13 +146,14 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
         let shape: Vec<usize> = shape.dims.into();
         let out = tensor.client.tensor_uninitialized(shape.clone());
 
+        let desc = ReshapeDescription {
+            input: tensor.into_description(),
+            shape,
+            out: out.to_description_out(),
+        };
         tensor.client.clone().register(
-            TensorOpsDescription::BaseOpsBool(BaseOpsDescription::Reshape(ReshapeDescription {
-                input: tensor.into_description(),
-                shape,
-                out: out.to_description_out(),
-            })),
-            todo!(),
+            TensorOpsDescription::BaseOpsBool(BaseOpsDescription::Reshape(desc.clone())),
+            ReshapeDimsOps::<D1, D2>::new(desc),
         );
 
         out
@@ -157,6 +163,7 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
         tensor: BoolTensor<Self, D1>,
         ranges: [std::ops::Range<usize>; D2],
     ) -> BoolTensor<Self, D1> {
+        #[derive(new)]
         struct SliceOps<const D1: usize, const D2: usize> {
             desc: SliceOpsDescription,
         }
@@ -180,13 +187,14 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
 
         let out = tensor.client.tensor_uninitialized(shape);
 
+        let desc = SliceOpsDescription {
+            tensor: tensor.into_description(),
+            ranges: ranges.into(),
+            out: out.to_description_out(),
+        };
         tensor.client.clone().register(
-            TensorOpsDescription::BaseOpsBool(BaseOpsDescription::Slice(SliceOpsDescription {
-                tensor: tensor.into_description(),
-                ranges: ranges.into(),
-                out: out.to_description_out(),
-            })),
-            todo!(),
+            TensorOpsDescription::BaseOpsBool(BaseOpsDescription::Slice(desc.clone())),
+            SliceOps::<D1, D2>::new(desc),
         );
 
         out
@@ -197,6 +205,7 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
         ranges: [std::ops::Range<usize>; D2],
         value: BoolTensor<Self, D1>,
     ) -> BoolTensor<Self, D1> {
+        #[derive(new)]
         struct SliceAssignOps<const D1: usize, const D2: usize> {
             desc: SliceAssignOpsDescription,
         }
@@ -219,16 +228,16 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
         let shape: Vec<usize> = tensor.shape.clone();
         let out = tensor.client.tensor_uninitialized(shape);
 
+        let desc = SliceAssignOpsDescription {
+            tensor: tensor.into_description(),
+            ranges: ranges.into(),
+            value: value.into_description(),
+            out: out.to_description_out(),
+        };
+
         tensor.client.clone().register(
-            TensorOpsDescription::BaseOpsBool(BaseOpsDescription::SliceAssign(
-                SliceAssignOpsDescription {
-                    tensor: tensor.into_description(),
-                    ranges: ranges.into(),
-                    value: value.into_description(),
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::BaseOpsBool(BaseOpsDescription::SliceAssign(desc.clone())),
+            SliceAssignOps::<D1, D2>::new(desc),
         );
 
         out
@@ -238,13 +247,15 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
         tensors: Vec<BoolTensor<Self, D>>,
         dim: usize,
     ) -> BoolTensor<Self, D> {
+        #[derive(new)]
         struct CatOps<const D: usize> {
             desc: CatOpsDescription,
         }
 
         impl<const D: usize, B: FusionBackend> Ops<B> for CatOps<D> {
             fn execute(self: Box<Self>, handles: &mut crate::HandleContainer<B>) {
-                let tensors = args
+                let tensors = self
+                    .desc
                     .tensors
                     .iter()
                     .map(|tensor| handles.get_bool_tensor(tensor))
@@ -268,13 +279,14 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
 
         let out = client.tensor_uninitialized(shape);
 
+        let desc = CatOpsDescription {
+            tensors: tensors.into_iter().map(|t| t.into_description()).collect(),
+            dim,
+            out: out.to_description_out(),
+        };
         client.register(
-            TensorOpsDescription::BaseOpsBool(BaseOpsDescription::Cat(CatOpsDescription {
-                tensors: tensors.into_iter().map(|t| t.into_description()).collect(),
-                dim,
-                out: out.to_description_out(),
-            })),
-            todo!(),
+            TensorOpsDescription::BaseOpsBool(BaseOpsDescription::Cat(desc.clone())),
+            CatOps::<D>::new(desc),
         );
 
         out
@@ -284,6 +296,7 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
         lhs: BoolTensor<Self, D>,
         rhs: BoolTensor<Self, D>,
     ) -> BoolTensor<Self, D> {
+        #[derive(new)]
         struct EqualOps<const D: usize> {
             desc: BinaryOpsDescription,
         }
@@ -301,19 +314,21 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
             .client
             .tensor_uninitialized(binary_ops_shape(&lhs.shape, &rhs.shape));
 
+        let desc = BinaryOpsDescription {
+            lhs: lhs.into_description(),
+            rhs: rhs.into_description(),
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::BaseOpsBool(BaseOpsDescription::Equal(BinaryOpsDescription {
-                lhs: lhs.into_description(),
-                rhs: rhs.into_description(),
-                out: out.to_description_out(),
-            })),
-            todo!(),
+            TensorOpsDescription::BaseOpsBool(BaseOpsDescription::Equal(desc.clone())),
+            EqualOps::<D>::new(desc),
         );
 
         out
     }
 
     fn bool_not<const D: usize>(tensor: BoolTensor<Self, D>) -> BoolTensor<Self, D> {
+        #[derive(new)]
         struct NotOps<const D: usize> {
             desc: UnaryOpsDescription,
         }
@@ -328,14 +343,14 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
 
         let out = tensor.client.tensor_uninitialized(tensor.shape.clone());
 
+        let desc = UnaryOpsDescription {
+            input: tensor.into_description(),
+            out: out.to_description_out(),
+        };
+
         out.client.register(
-            TensorOpsDescription::BoolOps(crate::graph::BoolOpsDescription::Not(
-                UnaryOpsDescription {
-                    input: tensor.into_description(),
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::BoolOps(crate::graph::BoolOpsDescription::Not(desc.clone())),
+            NotOps::<D>::new(desc),
         );
 
         out
@@ -346,6 +361,7 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
         dim1: usize,
         dim2: usize,
     ) -> BoolTensor<Self, D> {
+        #[derive(new)]
         struct SwapDimsOps<const D: usize> {
             desc: SwapDimsDescription,
         }
@@ -364,14 +380,15 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
 
         let out = tensor.client.tensor_uninitialized(shape);
 
+        let desc = SwapDimsDescription {
+            input: tensor.into_description(),
+            dim1,
+            dim2,
+            out: out.to_description_out(),
+        };
         tensor.client.clone().register(
-            TensorOpsDescription::BaseOpsBool(BaseOpsDescription::SwapDims(SwapDimsDescription {
-                input: tensor.into_description(),
-                dim1,
-                dim2,
-                out: out.to_description_out(),
-            })),
-            todo!(),
+            TensorOpsDescription::BaseOpsBool(BaseOpsDescription::SwapDims(desc.clone())),
+            SwapDimsOps::<D>::new(desc),
         );
 
         out

--- a/burn-fusion/src/ops/float.rs
+++ b/burn-fusion/src/ops/float.rs
@@ -350,15 +350,14 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
             .client
             .tensor_uninitialized(binary_ops_shape(&lhs.shape, &rhs.shape));
 
+        let desc = BinaryOpsDescription {
+            lhs: lhs.into_description(),
+            rhs: rhs.into_description(),
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::Sub(
-                BinaryOpsDescription {
-                    lhs: lhs.into_description(),
-                    rhs: rhs.into_description(),
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::Sub(desc.clone())),
+            SubOps::<D>::new(desc),
         );
 
         out
@@ -371,16 +370,15 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
         scalar_float_ops!(SubOps, B::sub_scalar);
 
         let out = lhs.client.tensor_uninitialized(lhs.shape.clone());
+        let desc = ScalarOpsDescription {
+            lhs: lhs.into_description(),
+            rhs: rhs.elem(),
+            out: out.to_description_out(),
+        };
 
         out.client.register(
-            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::SubScalar(
-                ScalarOpsDescription {
-                    lhs: lhs.into_description(),
-                    rhs,
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::SubScalar(desc.clone())),
+            SubOps::<D>::new(desc),
         );
 
         out
@@ -396,15 +394,14 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
             .client
             .tensor_uninitialized(binary_ops_shape(&lhs.shape, &rhs.shape));
 
+        let desc = BinaryOpsDescription {
+            lhs: lhs.into_description(),
+            rhs: rhs.into_description(),
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::Mul(
-                BinaryOpsDescription {
-                    lhs: lhs.into_description(),
-                    rhs: rhs.into_description(),
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::Mul(desc.clone())),
+            MulOps::<D>::new(desc),
         );
 
         out
@@ -418,15 +415,14 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
 
         let out = lhs.client.tensor_uninitialized(lhs.shape.clone());
 
+        let desc = ScalarOpsDescription {
+            lhs: lhs.into_description(),
+            rhs: rhs.elem(),
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::MulScalar(
-                ScalarOpsDescription {
-                    lhs: lhs.into_description(),
-                    rhs,
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::MulScalar(desc.clone())),
+            MulOps::<D>::new(desc),
         );
 
         out
@@ -442,15 +438,14 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
             .client
             .tensor_uninitialized(binary_ops_shape(&lhs.shape, &rhs.shape));
 
+        let desc = BinaryOpsDescription {
+            lhs: lhs.into_description(),
+            rhs: rhs.into_description(),
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::Div(
-                BinaryOpsDescription {
-                    lhs: lhs.into_description(),
-                    rhs: rhs.into_description(),
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::Div(desc.clone())),
+            DivOps::<D>::new(desc),
         );
 
         out
@@ -464,15 +459,14 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
 
         let out = lhs.client.tensor_uninitialized(lhs.shape.clone());
 
+        let desc = ScalarOpsDescription {
+            lhs: lhs.into_description(),
+            rhs: rhs.elem(),
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::DivScalar(
-                ScalarOpsDescription {
-                    lhs: lhs.into_description(),
-                    rhs,
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::DivScalar(desc.clone())),
+            DivOps::<D>::new(desc),
         );
 
         out
@@ -490,14 +484,15 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
         shape[D - 1] = rhs.shape[D - 1];
 
         let out = lhs.client.tensor_uninitialized(shape);
+        let desc = BinaryOpsDescription {
+            lhs: lhs.into_description(),
+            rhs: rhs.into_description(),
+            out: out.to_description_out(),
+        };
 
         out.client.register(
-            TensorOpsDescription::FloatOps(FloatOpsDescription::Matmul(BinaryOpsDescription {
-                lhs: lhs.into_description(),
-                rhs: rhs.into_description(),
-                out: out.to_description_out(),
-            })),
-            MatmulOps::new(todo!()),
+            TensorOpsDescription::FloatOps(FloatOpsDescription::Matmul(desc.clone())),
+            MatmulOps::<D>::new(desc),
         );
 
         out
@@ -508,6 +503,7 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
         dim1: usize,
         dim2: usize,
     ) -> FloatTensor<Self, D> {
+        #[derive(new)]
         struct SwapDimsOps<const D: usize> {
             desc: SwapDimsDescription,
         }
@@ -526,14 +522,15 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
 
         let out = tensor.client.tensor_uninitialized(shape);
 
+        let desc = SwapDimsDescription {
+            input: tensor.into_description(),
+            dim1,
+            dim2,
+            out: out.to_description_out(),
+        };
         tensor.client.clone().register(
-            TensorOpsDescription::BaseOpsFloat(BaseOpsDescription::SwapDims(SwapDimsDescription {
-                input: tensor.into_description(),
-                dim1,
-                dim2,
-                out: out.to_description_out(),
-            })),
-            todo!(),
+            TensorOpsDescription::BaseOpsFloat(BaseOpsDescription::SwapDims(desc.clone())),
+            SwapDimsOps::<D>::new(desc),
         );
 
         out
@@ -543,6 +540,7 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
         tensor: FloatTensor<Self, D1>,
         shape: Shape<D2>,
     ) -> FloatTensor<Self, D2> {
+        #[derive(new)]
         struct ReshapeDimsOps<const D1: usize, const D2: usize> {
             desc: ReshapeDescription,
         }
@@ -558,13 +556,14 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
         let shape: Vec<usize> = shape.dims.into();
         let out = tensor.client.tensor_uninitialized(shape.clone());
 
+        let desc = ReshapeDescription {
+            input: tensor.into_description(),
+            shape,
+            out: out.to_description_out(),
+        };
         tensor.client.clone().register(
-            TensorOpsDescription::BaseOpsFloat(BaseOpsDescription::Reshape(ReshapeDescription {
-                input: tensor.into_description(),
-                shape,
-                out: out.to_description_out(),
-            })),
-            todo!(),
+            TensorOpsDescription::BaseOpsFloat(BaseOpsDescription::Reshape(desc.clone())),
+            ReshapeDimsOps::<D1, D2>::new(desc),
         );
 
         out
@@ -575,6 +574,7 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
         tensor: FloatTensor<Self, D>,
         indices: IntTensor<Self, D>,
     ) -> FloatTensor<Self, D> {
+        #[derive(new)]
         struct GatherOps<const D: usize> {
             desc: GatherOpsDescription,
         }
@@ -592,16 +592,15 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
         let shape: Vec<usize> = indices.shape.clone();
         let out = tensor.client.tensor_uninitialized(shape);
 
+        let desc = GatherOpsDescription {
+            tensor: tensor.into_description(),
+            dim,
+            indices: indices.into_description(),
+            out: out.to_description_out(),
+        };
         tensor.client.clone().register(
-            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::Gather(
-                GatherOpsDescription {
-                    tensor: tensor.into_description(),
-                    dim,
-                    indices: indices.into_description(),
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::Gather(desc.clone())),
+            GatherOps::<D>::new(desc),
         );
 
         out
@@ -613,6 +612,7 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
         indices: IntTensor<Self, D>,
         value: FloatTensor<Self, D>,
     ) -> FloatTensor<Self, D> {
+        #[derive(new)]
         struct ScatterOps<const D: usize> {
             desc: ScatterOpsDescription,
         }
@@ -632,17 +632,17 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
         let shape: Vec<usize> = tensor.shape.clone();
         let out = tensor.client.tensor_uninitialized(shape);
 
+        let desc = ScatterOpsDescription {
+            tensor: tensor.into_description(),
+            dim,
+            indices: indices.into_description(),
+            value: value.into_description(),
+            out: out.to_description_out(),
+        };
+
         tensor.client.clone().register(
-            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::Scatter(
-                ScatterOpsDescription {
-                    tensor: tensor.into_description(),
-                    dim,
-                    indices: indices.into_description(),
-                    value: value.into_description(),
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::Scatter(desc.clone())),
+            ScatterOps::<D>::new(desc),
         );
 
         out
@@ -653,6 +653,7 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
         dim: usize,
         indices: IntTensor<Self, 1>,
     ) -> FloatTensor<Self, D> {
+        #[derive(new)]
         struct SelectOps<const D: usize> {
             desc: SelectOpsDescription,
         }
@@ -671,17 +672,15 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
         let mut shape: Vec<usize> = tensor.shape.clone();
         shape[dim] = indices.shape[0];
         let out = tensor.client.tensor_uninitialized(shape);
-
+        let desc = SelectOpsDescription {
+            tensor: tensor.into_description(),
+            dim,
+            indices: indices.into_description(),
+            out: out.to_description_out(),
+        };
         tensor.client.clone().register(
-            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::Select(
-                SelectOpsDescription {
-                    tensor: tensor.into_description(),
-                    dim,
-                    indices: indices.into_description(),
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::Select(desc.clone())),
+            SelectOps::<D>::new(desc),
         );
 
         out
@@ -693,6 +692,7 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
         indices: IntTensor<Self, 1>,
         value: FloatTensor<Self, D>,
     ) -> FloatTensor<Self, D> {
+        #[derive(new)]
         struct SelectAssignOps<const D: usize> {
             desc: SelectAssignOpsDescription,
         }
@@ -712,17 +712,18 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
         let shape: Vec<usize> = tensor.shape.clone();
         let out = tensor.client.tensor_uninitialized(shape);
 
+        let desc = SelectAssignOpsDescription {
+            tensor: tensor.into_description(),
+            dim,
+            indices: indices.into_description(),
+            value: value.into_description(),
+            out: out.to_description_out(),
+        };
         tensor.client.clone().register(
             TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::SelectAssign(
-                SelectAssignOpsDescription {
-                    tensor: tensor.into_description(),
-                    dim,
-                    indices: indices.into_description(),
-                    value: value.into_description(),
-                    out: out.to_description_out(),
-                },
+                desc.clone(),
             )),
-            todo!(),
+            SelectAssignOps::<D>::new(desc),
         );
 
         out
@@ -732,6 +733,7 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
         tensor: FloatTensor<Self, D1>,
         ranges: [Range<usize>; D2],
     ) -> FloatTensor<Self, D1> {
+        #[derive(new)]
         struct SliceOps<const D1: usize, const D2: usize> {
             desc: SliceOpsDescription,
         }
@@ -755,13 +757,14 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
 
         let out = tensor.client.tensor_uninitialized(shape);
 
+        let desc = SliceOpsDescription {
+            tensor: tensor.into_description(),
+            ranges: ranges.into(),
+            out: out.to_description_out(),
+        };
         tensor.client.clone().register(
-            TensorOpsDescription::BaseOpsFloat(BaseOpsDescription::Slice(SliceOpsDescription {
-                tensor: tensor.into_description(),
-                ranges: ranges.into(),
-                out: out.to_description_out(),
-            })),
-            todo!(),
+            TensorOpsDescription::BaseOpsFloat(BaseOpsDescription::Slice(desc.clone())),
+            SliceOps::<D1, D2>::new(desc),
         );
 
         out
@@ -772,6 +775,7 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
         ranges: [Range<usize>; D2],
         value: FloatTensor<Self, D1>,
     ) -> FloatTensor<Self, D1> {
+        #[derive(new)]
         struct SliceAssignOps<const D1: usize, const D2: usize> {
             desc: SliceAssignOpsDescription,
         }
@@ -794,16 +798,15 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
         let shape: Vec<usize> = tensor.shape.clone();
         let out = tensor.client.tensor_uninitialized(shape);
 
+        let desc = SliceAssignOpsDescription {
+            tensor: tensor.into_description(),
+            ranges: ranges.into(),
+            value: value.into_description(),
+            out: out.to_description_out(),
+        };
         tensor.client.clone().register(
-            TensorOpsDescription::BaseOpsFloat(BaseOpsDescription::SliceAssign(
-                SliceAssignOpsDescription {
-                    tensor: tensor.into_description(),
-                    ranges: ranges.into(),
-                    value: value.into_description(),
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::BaseOpsFloat(BaseOpsDescription::SliceAssign(desc.clone())),
+            SliceAssignOps::<D1, D2>::new(desc),
         );
 
         out
@@ -814,6 +817,7 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
         mask: BoolTensor<Self, D>,
         value: FloatTensor<Self, D>,
     ) -> FloatTensor<Self, D> {
+        #[derive(new)]
         struct MaskWhereOps<const D: usize> {
             desc: MaskWhereOpsDescription,
         }
@@ -833,16 +837,15 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
         let shape: Vec<usize> = tensor.shape.clone();
         let out = tensor.client.tensor_uninitialized(shape);
 
+        let desc = MaskWhereOpsDescription {
+            tensor: tensor.into_description(),
+            value: value.into_description(),
+            mask: mask.into_description(),
+            out: out.to_description_out(),
+        };
         tensor.client.clone().register(
-            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::MaskWhere(
-                MaskWhereOpsDescription {
-                    tensor: tensor.into_description(),
-                    value: value.into_description(),
-                    mask: mask.into_description(),
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::MaskWhere(desc.clone())),
+            MaskWhereOps::<D>::new(desc),
         );
 
         out
@@ -853,6 +856,7 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
         mask: BoolTensor<Self, D>,
         value: FloatElem<Self>,
     ) -> FloatTensor<Self, D> {
+        #[derive(new)]
         struct MaskFillOps<const D: usize> {
             desc: MaskFillOpsDescription<f32>,
         }
@@ -862,7 +866,7 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
                 let tensor = handles.get_float_tensor::<D>(&self.desc.tensor);
                 let mask = handles.get_bool_tensor(&self.desc.mask);
 
-                let output = B::mask_fill(tensor, mask, self.desc.value);
+                let output = B::mask_fill(tensor, mask, self.desc.value.elem());
 
                 handles.register_float_tensor(&self.desc.out.id, output);
             }
@@ -870,17 +874,15 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
 
         let shape: Vec<usize> = tensor.shape.clone();
         let out = tensor.client.tensor_uninitialized(shape);
-
+        let desc = MaskFillOpsDescription {
+            tensor: tensor.into_description(),
+            value: value.elem(),
+            mask: mask.into_description(),
+            out: out.to_description_out(),
+        };
         tensor.client.clone().register(
-            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::MaskFill(
-                MaskFillOpsDescription {
-                    tensor: tensor.into_description(),
-                    value,
-                    mask: mask.into_description(),
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::MaskFill(desc.clone())),
+            MaskFillOps::<D>::new(desc),
         );
 
         out
@@ -896,13 +898,14 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
             .client
             .tensor_uninitialized(binary_ops_shape(&lhs.shape, &rhs.shape));
 
+        let desc = BinaryOpsDescription {
+            lhs: lhs.into_description(),
+            rhs: rhs.into_description(),
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::BaseOpsFloat(BaseOpsDescription::Equal(BinaryOpsDescription {
-                lhs: lhs.into_description(),
-                rhs: rhs.into_description(),
-                out: out.to_description_out(),
-            })),
-            todo!(),
+            TensorOpsDescription::BaseOpsFloat(BaseOpsDescription::Equal(desc.clone())),
+            EqualOps::<D>::new(desc),
         );
 
         out
@@ -916,15 +919,14 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
 
         let out = lhs.client.tensor_uninitialized(lhs.shape.clone());
 
+        let desc = ScalarOpsDescription {
+            lhs: lhs.into_description(),
+            rhs: rhs.elem(),
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::EqualElem(
-                ScalarOpsDescription {
-                    lhs: lhs.into_description(),
-                    rhs,
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::EqualElem(desc.clone())),
+            EqualElemOps::<D>::new(desc),
         );
 
         out
@@ -940,15 +942,14 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
             .client
             .tensor_uninitialized(binary_ops_shape(&lhs.shape, &rhs.shape));
 
+        let desc = BinaryOpsDescription {
+            lhs: lhs.into_description(),
+            rhs: rhs.into_description(),
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::Greater(
-                BinaryOpsDescription {
-                    lhs: lhs.into_description(),
-                    rhs: rhs.into_description(),
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::Greater(desc.clone())),
+            GreaterOps::<D>::new(desc),
         );
 
         out
@@ -962,15 +963,14 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
 
         let out = lhs.client.tensor_uninitialized(lhs.shape.clone());
 
+        let desc = ScalarOpsDescription {
+            lhs: lhs.into_description(),
+            rhs: rhs.elem(),
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::GreaterElem(
-                ScalarOpsDescription {
-                    lhs: lhs.into_description(),
-                    rhs,
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::GreaterElem(desc.clone())),
+            GreaterElemOps::<D>::new(desc),
         );
 
         out
@@ -986,15 +986,16 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
             .client
             .tensor_uninitialized(binary_ops_shape(&lhs.shape, &rhs.shape));
 
+        let desc = BinaryOpsDescription {
+            lhs: lhs.into_description(),
+            rhs: rhs.into_description(),
+            out: out.to_description_out(),
+        };
         out.client.register(
             TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::GreaterEqual(
-                BinaryOpsDescription {
-                    lhs: lhs.into_description(),
-                    rhs: rhs.into_description(),
-                    out: out.to_description_out(),
-                },
+                desc.clone(),
             )),
-            todo!(),
+            GreaterEqualOps::<D>::new(desc),
         );
 
         out
@@ -1008,15 +1009,16 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
 
         let out = lhs.client.tensor_uninitialized(lhs.shape.clone());
 
+        let desc = ScalarOpsDescription {
+            lhs: lhs.into_description(),
+            rhs: rhs.elem(),
+            out: out.to_description_out(),
+        };
         out.client.register(
             TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::GreaterEqualElem(
-                ScalarOpsDescription {
-                    lhs: lhs.into_description(),
-                    rhs,
-                    out: out.to_description_out(),
-                },
+                desc.clone(),
             )),
-            todo!(),
+            GreaterEqualElemOps::<D>::new(desc),
         );
 
         out
@@ -1032,15 +1034,14 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
             .client
             .tensor_uninitialized(binary_ops_shape(&lhs.shape, &rhs.shape));
 
+        let desc = BinaryOpsDescription {
+            lhs: lhs.into_description(),
+            rhs: rhs.into_description(),
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::Lower(
-                BinaryOpsDescription {
-                    lhs: lhs.into_description(),
-                    rhs: rhs.into_description(),
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::Lower(desc.clone())),
+            LowerOps::<D>::new(desc),
         );
 
         out
@@ -1054,15 +1055,14 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
 
         let out = lhs.client.tensor_uninitialized(lhs.shape.clone());
 
+        let desc = ScalarOpsDescription {
+            lhs: lhs.into_description(),
+            rhs: rhs.elem(),
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::LowerElem(
-                ScalarOpsDescription {
-                    lhs: lhs.into_description(),
-                    rhs,
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::LowerElem(desc.clone())),
+            LowerElemOps::<D>::new(desc),
         );
 
         out
@@ -1078,15 +1078,14 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
             .client
             .tensor_uninitialized(binary_ops_shape(&lhs.shape, &rhs.shape));
 
+        let desc = BinaryOpsDescription {
+            lhs: lhs.into_description(),
+            rhs: rhs.into_description(),
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::LowerEqual(
-                BinaryOpsDescription {
-                    lhs: lhs.into_description(),
-                    rhs: rhs.into_description(),
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::LowerEqual(desc.clone())),
+            LowerEqualOps::<D>::new(desc),
         );
 
         out
@@ -1100,15 +1099,16 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
 
         let out = lhs.client.tensor_uninitialized(lhs.shape.clone());
 
+        let desc = ScalarOpsDescription {
+            lhs: lhs.into_description(),
+            rhs: rhs.elem(),
+            out: out.to_description_out(),
+        };
         out.client.register(
             TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::LowerEqualElem(
-                ScalarOpsDescription {
-                    lhs: lhs.into_description(),
-                    rhs,
-                    out: out.to_description_out(),
-                },
+                desc.clone(),
             )),
-            todo!(),
+            LowerEqualElemOps::<D>::new(desc),
         );
 
         out
@@ -1119,35 +1119,33 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
 
         let out = tensor.client.tensor_uninitialized(vec![1]);
 
+        let desc = UnaryOpsDescription {
+            input: tensor.into_description(),
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::Sum(
-                UnaryOpsDescription {
-                    input: tensor.into_description(),
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::Sum(desc.clone())),
+            SumOps::<D>::new(desc),
         );
 
         out
     }
 
     fn sum_dim<const D: usize>(tensor: FloatTensor<Self, D>, dim: usize) -> FloatTensor<Self, D> {
-        scalar_float_ops!(SumDimOps, B::sum_dim, usize);
+        scalar_float_ops!(SumDimOps, B::sum_dim, usize, noconvert);
 
         let mut shape = tensor.shape.clone();
         shape[dim] = 1;
         let out = tensor.client.tensor_uninitialized(shape);
 
+        let desc = ScalarOpsDescription {
+            lhs: tensor.into_description(),
+            rhs: dim,
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::SumDim(
-                ScalarOpsDescription {
-                    lhs: tensor.into_description(),
-                    rhs: dim,
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::SumDim(desc.clone())),
+            SumDimOps::<D>::new(desc),
         );
 
         out
@@ -1158,35 +1156,33 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
 
         let out = tensor.client.tensor_uninitialized(vec![1]);
 
+        let desc = UnaryOpsDescription {
+            input: tensor.into_description(),
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::Mean(
-                UnaryOpsDescription {
-                    input: tensor.into_description(),
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::Mean(desc.clone())),
+            MeanOps::<D>::new(desc),
         );
 
         out
     }
 
     fn mean_dim<const D: usize>(tensor: FloatTensor<Self, D>, dim: usize) -> FloatTensor<Self, D> {
-        scalar_float_ops!(MeanDimOps, B::mean_dim, usize);
+        scalar_float_ops!(MeanDimOps, B::mean_dim, usize, noconvert);
 
         let mut shape = tensor.shape.clone();
         shape[dim] = 1;
         let out = tensor.client.tensor_uninitialized(shape);
 
+        let desc = ScalarOpsDescription {
+            lhs: tensor.into_description(),
+            rhs: dim,
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::MeanDim(
-                ScalarOpsDescription {
-                    lhs: tensor.into_description(),
-                    rhs: dim,
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::MeanDim(desc.clone())),
+            MeanDimOps::<D>::new(desc),
         );
 
         out
@@ -1209,12 +1205,13 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
 
         let out = lhs.client.tensor_uninitialized(lhs.shape.clone());
 
+        let desc = UnaryOpsDescription {
+            input: lhs.into_description(),
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::FloatOps(FloatOpsDescription::Exp(UnaryOpsDescription {
-                input: lhs.into_description(),
-                out: out.to_description_out(),
-            })),
-            todo!(),
+            TensorOpsDescription::FloatOps(FloatOpsDescription::Exp(desc.clone())),
+            ExpOps::<D>::new(desc),
         );
 
         out
@@ -1225,12 +1222,13 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
 
         let out = tensor.client.tensor_uninitialized(tensor.shape.clone());
 
+        let desc = UnaryOpsDescription {
+            input: tensor.into_description(),
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::FloatOps(FloatOpsDescription::Log(UnaryOpsDescription {
-                input: tensor.into_description(),
-                out: out.to_description_out(),
-            })),
-            todo!(),
+            TensorOpsDescription::FloatOps(FloatOpsDescription::Log(desc.clone())),
+            LogOps::<D>::new(desc),
         );
 
         out
@@ -1241,12 +1239,13 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
 
         let out = tensor.client.tensor_uninitialized(tensor.shape.clone());
 
+        let desc = UnaryOpsDescription {
+            input: tensor.into_description(),
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::FloatOps(FloatOpsDescription::Log1p(UnaryOpsDescription {
-                input: tensor.into_description(),
-                out: out.to_description_out(),
-            })),
-            todo!(),
+            TensorOpsDescription::FloatOps(FloatOpsDescription::Log1p(desc.clone())),
+            Log1pOps::<D>::new(desc),
         );
 
         out
@@ -1257,13 +1256,14 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
 
         let out = lhs.client.tensor_uninitialized(lhs.shape.clone());
 
+        let desc = ScalarOpsDescription {
+            lhs: lhs.into_description(),
+            rhs,
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::FloatOps(FloatOpsDescription::Powf(ScalarOpsDescription {
-                lhs: lhs.into_description(),
-                rhs,
-                out: out.to_description_out(),
-            })),
-            todo!(),
+            TensorOpsDescription::FloatOps(FloatOpsDescription::Powf(desc.clone())),
+            PowfOps::<D>::new(desc),
         );
 
         out
@@ -1274,12 +1274,13 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
 
         let out = tensor.client.tensor_uninitialized(tensor.shape.clone());
 
+        let desc = UnaryOpsDescription {
+            input: tensor.into_description(),
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::FloatOps(FloatOpsDescription::Sqrt(UnaryOpsDescription {
-                input: tensor.into_description(),
-                out: out.to_description_out(),
-            })),
-            todo!(),
+            TensorOpsDescription::FloatOps(FloatOpsDescription::Sqrt(desc.clone())),
+            SqrtOps::<D>::new(desc),
         );
 
         out
@@ -1290,14 +1291,13 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
 
         let out = tensor.client.tensor_uninitialized(tensor.shape.clone());
 
+        let desc = UnaryOpsDescription {
+            input: tensor.into_description(),
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::Abs(
-                UnaryOpsDescription {
-                    input: tensor.into_description(),
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::Abs(desc.clone())),
+            AbsOps::<D>::new(desc),
         );
 
         out
@@ -1308,12 +1308,13 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
 
         let out = tensor.client.tensor_uninitialized(tensor.shape.clone());
 
+        let desc = UnaryOpsDescription {
+            input: tensor.into_description(),
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::FloatOps(FloatOpsDescription::Cos(UnaryOpsDescription {
-                input: tensor.into_description(),
-                out: out.to_description_out(),
-            })),
-            todo!(),
+            TensorOpsDescription::FloatOps(FloatOpsDescription::Cos(desc.clone())),
+            CosOps::<D>::new(desc),
         );
 
         out
@@ -1324,12 +1325,13 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
 
         let out = tensor.client.tensor_uninitialized(tensor.shape.clone());
 
+        let desc = UnaryOpsDescription {
+            input: tensor.into_description(),
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::FloatOps(FloatOpsDescription::Sin(UnaryOpsDescription {
-                input: tensor.into_description(),
-                out: out.to_description_out(),
-            })),
-            todo!(),
+            TensorOpsDescription::FloatOps(FloatOpsDescription::Sin(desc.clone())),
+            SinOps::<D>::new(desc),
         );
 
         out
@@ -1340,12 +1342,13 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
 
         let out = tensor.client.tensor_uninitialized(tensor.shape.clone());
 
+        let desc = UnaryOpsDescription {
+            input: tensor.into_description(),
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::FloatOps(FloatOpsDescription::Tanh(UnaryOpsDescription {
-                input: tensor.into_description(),
-                out: out.to_description_out(),
-            })),
-            todo!(),
+            TensorOpsDescription::FloatOps(FloatOpsDescription::Tanh(desc.clone())),
+            TanhOps::<D>::new(desc),
         );
 
         out
@@ -1355,13 +1358,15 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
         unary_float_ops!(Recip, B::recip);
 
         let out = tensor.client.tensor_uninitialized(tensor.shape.clone());
+        let desc = UnaryOpsDescription {
+            input: tensor.into_description(),
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::FloatOps(FloatOpsDescription::Recip(UnaryOpsDescription {
-                input: tensor.into_description(),
-                out: out.to_description_out(),
-            })),
-            todo!(),
+            TensorOpsDescription::FloatOps(FloatOpsDescription::Recip(desc.clone())),
+            Recip::<D>::new(desc),
         );
+
         out
     }
 
@@ -1370,18 +1375,20 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
 
         let out = tensor.client.tensor_uninitialized(tensor.shape.clone());
 
+        let desc = UnaryOpsDescription {
+            input: tensor.into_description(),
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::FloatOps(FloatOpsDescription::Erf(UnaryOpsDescription {
-                input: tensor.into_description(),
-                out: out.to_description_out(),
-            })),
-            todo!(),
+            TensorOpsDescription::FloatOps(FloatOpsDescription::Erf(desc.clone())),
+            TanhOps::<D>::new(desc),
         );
 
         out
     }
 
     fn cat<const D: usize>(tensors: Vec<FloatTensor<Self, D>>, dim: usize) -> FloatTensor<Self, D> {
+        #[derive(new)]
         struct CatOps<const D: usize> {
             desc: CatOpsDescription,
         }
@@ -1420,7 +1427,7 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
         };
         client.register(
             TensorOpsDescription::BaseOpsFloat(BaseOpsDescription::Cat(desc.clone())),
-            todo!(),
+            CatOps::<D>::new(desc),
         );
 
         out
@@ -1433,15 +1440,14 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
         shape[dim] = 1;
         let out = tensor.client.tensor_uninitialized(shape);
 
+        let desc = ScalarOpsDescription {
+            lhs: tensor.into_description(),
+            rhs: dim,
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::ArgMax(
-                ScalarOpsDescription {
-                    lhs: tensor.into_description(),
-                    rhs: dim,
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::ArgMax(desc.clone())),
+            ArgMaxOps::<D>::new(desc),
         );
 
         out
@@ -1454,15 +1460,14 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
         shape[dim] = 1;
         let out = tensor.client.tensor_uninitialized(shape);
 
+        let desc = ScalarOpsDescription {
+            lhs: tensor.into_description(),
+            rhs: dim,
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::ArgMin(
-                ScalarOpsDescription {
-                    lhs: tensor.into_description(),
-                    rhs: dim,
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::ArgMin(desc.clone())),
+            ArgMinOps::<D>::new(desc),
         );
 
         out
@@ -1473,35 +1478,33 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
 
         let out = tensor.client.tensor_uninitialized(vec![1]);
 
+        let desc = UnaryOpsDescription {
+            input: tensor.into_description(),
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::Max(
-                UnaryOpsDescription {
-                    input: tensor.into_description(),
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::Max(desc.clone())),
+            MaxOps::<D>::new(desc),
         );
 
         out
     }
 
     fn max_dim<const D: usize>(tensor: FloatTensor<Self, D>, dim: usize) -> FloatTensor<Self, D> {
-        scalar_float_ops!(MaxDimOps, B::max_dim, usize);
+        scalar_float_ops!(MaxDimOps, B::max_dim, usize, noconvert);
 
         let mut shape = tensor.shape.clone();
         shape[dim] = 1;
         let out = tensor.client.tensor_uninitialized(shape);
 
+        let desc = ScalarOpsDescription {
+            lhs: tensor.into_description(),
+            rhs: dim,
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::MaxDim(
-                ScalarOpsDescription {
-                    lhs: tensor.into_description(),
-                    rhs: dim,
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::MaxDim(desc.clone())),
+            MaxDimOps::<D>::new(desc),
         );
 
         out
@@ -1511,6 +1514,7 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
         tensor: FloatTensor<Self, D>,
         dim: usize,
     ) -> (FloatTensor<Self, D>, IntTensor<Self, D>) {
+        #[derive(new)]
         struct MaxDimWithIndicesOps<const D: usize> {
             desc: ReduceDimWithIndicesDescription,
         }
@@ -1531,16 +1535,17 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
         let out = client.tensor_uninitialized(shape.clone());
         let out_indices = client.tensor_uninitialized(shape);
 
+        let desc = ReduceDimWithIndicesDescription {
+            tensor: tensor.into_description(),
+            dim,
+            out: out.to_description_out(),
+            out_indices: out_indices.to_description_out(),
+        };
         client.register(
             TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::MaxDimWithIndices(
-                ReduceDimWithIndicesDescription {
-                    tensor: tensor.into_description(),
-                    dim,
-                    out: out.to_description_out(),
-                    out_indices: out_indices.to_description_out(),
-                },
+                desc.clone(),
             )),
-            todo!(),
+            MaxDimWithIndicesOps::<D>::new(desc),
         );
 
         (out, out_indices)
@@ -1551,35 +1556,33 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
 
         let out = tensor.client.tensor_uninitialized(vec![1]);
 
+        let desc = UnaryOpsDescription {
+            input: tensor.into_description(),
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::Min(
-                UnaryOpsDescription {
-                    input: tensor.into_description(),
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::Min(desc.clone())),
+            MinOps::<D>::new(desc),
         );
 
         out
     }
 
     fn min_dim<const D: usize>(tensor: FloatTensor<Self, D>, dim: usize) -> FloatTensor<Self, D> {
-        scalar_float_ops!(MinDimOps, B::min_dim, usize);
+        scalar_float_ops!(MinDimOps, B::min_dim, usize, noconvert);
 
         let mut shape = tensor.shape.clone();
         shape[dim] = 1;
         let out = tensor.client.tensor_uninitialized(shape);
 
+        let desc = ScalarOpsDescription {
+            lhs: tensor.into_description(),
+            rhs: dim,
+            out: out.to_description_out(),
+        };
         out.client.register(
-            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::MinDim(
-                ScalarOpsDescription {
-                    lhs: tensor.into_description(),
-                    rhs: dim,
-                    out: out.to_description_out(),
-                },
-            )),
-            todo!(),
+            TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::MinDim(desc.clone())),
+            MinDimOps::<D>::new(desc),
         );
 
         out
@@ -1589,6 +1592,7 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
         tensor: FloatTensor<Self, D>,
         dim: usize,
     ) -> (FloatTensor<Self, D>, IntTensor<Self, D>) {
+        #[derive(new)]
         struct MinDimWithIndicesOps<const D: usize> {
             desc: ReduceDimWithIndicesDescription,
         }
@@ -1609,16 +1613,17 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
         let out = client.tensor_uninitialized(shape.clone());
         let out_indices = client.tensor_uninitialized(shape);
 
+        let desc = ReduceDimWithIndicesDescription {
+            tensor: tensor.into_description(),
+            dim,
+            out: out.to_description_out(),
+            out_indices: out_indices.to_description_out(),
+        };
         client.register(
             TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::MinDimWithIndices(
-                ReduceDimWithIndicesDescription {
-                    tensor: tensor.into_description(),
-                    dim,
-                    out: out.to_description_out(),
-                    out_indices: out_indices.to_description_out(),
-                },
+                desc.clone(),
             )),
-            todo!(),
+            MinDimWithIndicesOps::<D>::new(desc),
         );
 
         (out, out_indices)

--- a/burn-fusion/src/ops/float.rs
+++ b/burn-fusion/src/ops/float.rs
@@ -528,7 +528,7 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
             dim2,
             out: out.to_description_out(),
         };
-        tensor.client.clone().register(
+        out.client.register(
             TensorOpsDescription::BaseOpsFloat(BaseOpsDescription::SwapDims(desc.clone())),
             SwapDimsOps::<D>::new(desc),
         );
@@ -561,7 +561,7 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
             shape,
             out: out.to_description_out(),
         };
-        tensor.client.clone().register(
+        out.client.register(
             TensorOpsDescription::BaseOpsFloat(BaseOpsDescription::Reshape(desc.clone())),
             ReshapeDimsOps::<D1, D2>::new(desc),
         );
@@ -598,7 +598,7 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
             indices: indices.into_description(),
             out: out.to_description_out(),
         };
-        tensor.client.clone().register(
+        out.client.register(
             TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::Gather(desc.clone())),
             GatherOps::<D>::new(desc),
         );
@@ -640,7 +640,7 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
             out: out.to_description_out(),
         };
 
-        tensor.client.clone().register(
+        out.client.register(
             TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::Scatter(desc.clone())),
             ScatterOps::<D>::new(desc),
         );
@@ -678,7 +678,7 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
             indices: indices.into_description(),
             out: out.to_description_out(),
         };
-        tensor.client.clone().register(
+        out.client.register(
             TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::Select(desc.clone())),
             SelectOps::<D>::new(desc),
         );
@@ -719,7 +719,7 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
             value: value.into_description(),
             out: out.to_description_out(),
         };
-        tensor.client.clone().register(
+        out.client.register(
             TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::SelectAssign(
                 desc.clone(),
             )),
@@ -762,7 +762,7 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
             ranges: ranges.into(),
             out: out.to_description_out(),
         };
-        tensor.client.clone().register(
+        out.client.register(
             TensorOpsDescription::BaseOpsFloat(BaseOpsDescription::Slice(desc.clone())),
             SliceOps::<D1, D2>::new(desc),
         );
@@ -804,7 +804,7 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
             value: value.into_description(),
             out: out.to_description_out(),
         };
-        tensor.client.clone().register(
+        out.client.register(
             TensorOpsDescription::BaseOpsFloat(BaseOpsDescription::SliceAssign(desc.clone())),
             SliceAssignOps::<D1, D2>::new(desc),
         );
@@ -843,7 +843,7 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
             mask: mask.into_description(),
             out: out.to_description_out(),
         };
-        tensor.client.clone().register(
+        out.client.register(
             TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::MaskWhere(desc.clone())),
             MaskWhereOps::<D>::new(desc),
         );
@@ -880,7 +880,7 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
             mask: mask.into_description(),
             out: out.to_description_out(),
         };
-        tensor.client.clone().register(
+        out.client.register(
             TensorOpsDescription::NumericOpsFloat(NumericOpsDescription::MaskFill(desc.clone())),
             MaskFillOps::<D>::new(desc),
         );

--- a/burn-fusion/src/ops/float.rs
+++ b/burn-fusion/src/ops/float.rs
@@ -34,16 +34,16 @@ impl<B: FusionBackend> TensorOps<Self> for Fusion<B> {
 
     fn random<const D: usize>(
         shape: Shape<D>,
-        distribution: Distribution<FloatElem<Self>>,
+        distribution: Distribution,
         device: &Device<Self>,
     ) -> FloatTensor<Self, D> {
         #[derive(new)]
-        struct RandomOps<const D: usize, B: FusionBackend> {
+        struct RandomOps<const D: usize> {
             out: TensorDescription,
-            distribution: Distribution<FloatElem<B>>,
+            distribution: Distribution,
         }
 
-        impl<const D: usize, B: FusionBackend> Ops<B> for RandomOps<D, B> {
+        impl<const D: usize, B: FusionBackend> Ops<B> for RandomOps<D> {
             fn execute(self: Box<Self>, handles: &mut crate::HandleContainer<B>) {
                 let shape = Shape::from(self.out.shape.clone());
                 let output: B::TensorPrimitive<D> =

--- a/burn-fusion/src/ops/int.rs
+++ b/burn-fusion/src/ops/int.rs
@@ -94,7 +94,7 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
             shape,
             out: out.to_description_out(),
         };
-        tensor.client.clone().register(
+        out.client.register(
             TensorOpsDescription::BaseOpsInt(BaseOpsDescription::Reshape(desc.clone())),
             ReshapeDimsOps::<D1, D2>::new(desc),
         );
@@ -135,7 +135,7 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
             ranges: ranges.into(),
             out: out.to_description_out(),
         };
-        tensor.client.clone().register(
+        out.client.register(
             TensorOpsDescription::BaseOpsInt(BaseOpsDescription::Slice(desc.clone())),
             SliceOps::<D1, D2>::new(desc),
         );
@@ -176,7 +176,7 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
             value: value.into_description(),
             out: out.to_description_out(),
         };
-        tensor.client.clone().register(
+        out.client.register(
             TensorOpsDescription::BaseOpsInt(BaseOpsDescription::SliceAssign(desc.clone())),
             SliceAssignOps::<D1, D2>::new(desc),
         );
@@ -215,7 +215,7 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
             mask: mask.into_description(),
             out: out.to_description_out(),
         };
-        tensor.client.clone().register(
+        out.client.register(
             TensorOpsDescription::NumericOpsInt(NumericOpsDescription::MaskWhere(desc.clone())),
             MaskWhereOps::<D>::new(desc),
         );
@@ -252,7 +252,7 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
             mask: mask.into_description(),
             out: out.to_description_out(),
         };
-        tensor.client.clone().register(
+        out.client.register(
             TensorOpsDescription::NumericOpsInt(NumericOpsDescription::MaskFill(desc.clone())),
             MaskFillOps::<D>::new(desc),
         );
@@ -288,7 +288,7 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
             indices: indices.into_description(),
             out: out.to_description_out(),
         };
-        tensor.client.clone().register(
+        out.client.register(
             TensorOpsDescription::NumericOpsInt(NumericOpsDescription::Gather(desc.clone())),
             GatherOps::<D>::new(desc),
         );
@@ -328,7 +328,7 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
             value: value.into_description(),
             out: out.to_description_out(),
         };
-        tensor.client.clone().register(
+        out.client.register(
             TensorOpsDescription::NumericOpsInt(NumericOpsDescription::Scatter(desc.clone())),
             ScatterOps::<D>::new(desc),
         );
@@ -366,7 +366,7 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
             indices: indices.into_description(),
             out: out.to_description_out(),
         };
-        tensor.client.clone().register(
+        out.client.register(
             TensorOpsDescription::NumericOpsInt(NumericOpsDescription::Select(desc.clone())),
             SelectOps::<D>::new(desc),
         );
@@ -406,7 +406,7 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
             value: value.into_description(),
             out: out.to_description_out(),
         };
-        tensor.client.clone().register(
+        out.client.register(
             TensorOpsDescription::NumericOpsInt(NumericOpsDescription::SelectAssign(desc.clone())),
             SelectAssignOps::<D>::new(desc),
         );
@@ -1185,7 +1185,7 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
             dim2,
             out: out.to_description_out(),
         };
-        tensor.client.clone().register(
+        out.client.register(
             TensorOpsDescription::BaseOpsInt(BaseOpsDescription::SwapDims(desc.clone())),
             SwapDimsOps::<D>::new(desc),
         );

--- a/burn-fusion/src/ops/module.rs
+++ b/burn-fusion/src/ops/module.rs
@@ -30,6 +30,7 @@ macro_rules! make_ops {
 
         impl<B: FusionBackend> Ops<B> for $name {
             fn execute(self: Box<Self>, handles: &mut crate::HandleContainer<B>) {
+                #[allow(clippy::redundant_closure_call)]
                 $fn(self.desc, handles)
             }
         }

--- a/burn-fusion/src/ops/unary.rs
+++ b/burn-fusion/src/ops/unary.rs
@@ -20,7 +20,7 @@ macro_rules! scalar_float_ops {
         impl<const D: usize, B: FusionBackend> Ops<B> for $name<D> {
             fn execute(self: Box<Self>, handles: &mut $crate::HandleContainer<B>) {
                 let lhs = handles.get_float_tensor::<D>(&self.desc.lhs);
-                let output = $ops(lhs, self.desc.rhs);
+                let output = $ops(lhs, burn_tensor::ElementConversion::elem(self.desc.rhs));
 
                 handles.register_float_tensor(&self.desc.out.id, output);
             }
@@ -113,7 +113,7 @@ macro_rules! scalar_float_cmp_ops {
         impl<const D: usize, B: FusionBackend> Ops<B> for $name<D> {
             fn execute(self: Box<Self>, handles: &mut $crate::HandleContainer<B>) {
                 let lhs = handles.get_float_tensor::<D>(&self.desc.lhs);
-                let output = $ops(lhs, self.desc.rhs.clone());
+                let output = $ops(lhs, burn_tensor::ElementConversion::elem(self.desc.rhs));
 
                 handles.register_bool_tensor(&self.desc.out.id, output);
             }
@@ -136,7 +136,7 @@ macro_rules! scalar_int_cmp_ops {
         impl<const D: usize, B: FusionBackend> Ops<B> for $name<D> {
             fn execute(self: Box<Self>, handles: &mut $crate::HandleContainer<B>) {
                 let lhs = handles.get_int_tensor::<D>(&self.desc.lhs);
-                let output = $ops(lhs, self.desc.rhs.clone());
+                let output = $ops(lhs, burn_tensor::ElementConversion::elem(self.desc.rhs));
 
                 handles.register_bool_tensor(&self.desc.out.id, output);
             }
@@ -166,7 +166,7 @@ macro_rules! scalar_int_ops {
         impl<const D: usize, B: FusionBackend> Ops<B> for $name<D> {
             fn execute(self: Box<Self>, handles: &mut $crate::HandleContainer<B>) {
                 let lhs = handles.get_int_tensor::<D>(&self.desc.lhs);
-                let output = $ops(lhs, self.desc.rhs.clone());
+                let output = $ops(lhs, burn_tensor::ElementConversion::elem(self.desc.rhs));
 
                 handles.register_int_tensor(&self.desc.out.id, output);
             }

--- a/burn-fusion/src/ops/unary.rs
+++ b/burn-fusion/src/ops/unary.rs
@@ -5,23 +5,24 @@ macro_rules! scalar_float_ops {
         $name:ident,
         $ops:expr
     ) => {
-        scalar_float_ops!($name, $ops, FloatElem<B>);
+        scalar_float_ops!($name, $ops, f32);
     };
     (
         $name:ident,
         $ops:expr,
         $elem:ty
     ) => {
-        struct $name<const D: usize>;
+        #[derive(new)]
+        struct $name<const D: usize> {
+            desc: ScalarOpsDescription<$elem>,
+        }
 
         impl<const D: usize, B: FusionBackend> Ops<B> for $name<D> {
-            type Args = ScalarOpsDescription<$elem>;
+            fn execute(self: Box<Self>, handles: &mut $crate::HandleContainer<B>) {
+                let lhs = handles.get_float_tensor::<D>(&self.desc.lhs);
+                let output = $ops(lhs, self.desc.rhs);
 
-            fn execute(&self, args: &Self::Args, handles: &mut $crate::HandleContainer<B>) {
-                let lhs = handles.get_float_tensor::<D>(&args.lhs);
-                let output = $ops(lhs, args.rhs.clone());
-
-                handles.register_float_tensor(&args.out.id, output);
+                handles.register_float_tensor(&self.desc.out.id, output);
             }
         }
     };
@@ -35,16 +36,17 @@ macro_rules! scalar_float2int_ops {
         $ops:expr,
         $elem:ty
     ) => {
-        struct $name<const D: usize>;
+        #[derive(new)]
+        struct $name<const D: usize> {
+            desc: ScalarOpsDescription<$elem>,
+        }
 
         impl<const D: usize, B: FusionBackend> Ops<B> for $name<D> {
-            type Args = ScalarOpsDescription<$elem>;
+            fn execute(self: Box<Self>, handles: &mut $crate::HandleContainer<B>) {
+                let lhs = handles.get_float_tensor::<D>(&self.desc.lhs);
+                let output = $ops(lhs, self.desc.rhs.clone());
 
-            fn execute(&self, args: &Self::Args, handles: &mut $crate::HandleContainer<B>) {
-                let lhs = handles.get_float_tensor::<D>(&args.lhs);
-                let output = $ops(lhs, args.rhs.clone());
-
-                handles.register_int_tensor(&args.out.id, output);
+                handles.register_int_tensor(&self.desc.out.id, output);
             }
         }
     };
@@ -57,16 +59,17 @@ macro_rules! unary_float_ops {
         $name:ident,
         $ops:expr
     ) => {
-        struct $name<const D: usize>;
+        #[derive(new)]
+        struct $name<const D: usize> {
+            desc: UnaryOpsDescription,
+        }
 
         impl<const D: usize, B: FusionBackend> Ops<B> for $name<D> {
-            type Args = UnaryOpsDescription;
-
-            fn execute(&self, args: &Self::Args, handles: &mut $crate::HandleContainer<B>) {
-                let input = handles.get_float_tensor::<D>(&args.input);
+            fn execute(self: Box<Self>, handles: &mut $crate::HandleContainer<B>) {
+                let input = handles.get_float_tensor::<D>(&self.desc.input);
                 let output = $ops(input);
 
-                handles.register_float_tensor(&args.out.id, output);
+                handles.register_float_tensor(&self.desc.out.id, output);
             }
         }
     };
@@ -79,16 +82,17 @@ macro_rules! unary_int_ops {
         $name:ident,
         $ops:expr
     ) => {
-        struct $name<const D: usize>;
+        #[derive(new)]
+        struct $name<const D: usize> {
+            desc: UnaryOpsDescription,
+        }
 
         impl<const D: usize, B: FusionBackend> Ops<B> for $name<D> {
-            type Args = UnaryOpsDescription;
-
-            fn execute(&self, args: &Self::Args, handles: &mut $crate::HandleContainer<B>) {
-                let input = handles.get_int_tensor::<D>(&args.input);
+            fn execute(self: Box<Self>, handles: &mut $crate::HandleContainer<B>) {
+                let input = handles.get_int_tensor::<D>(&self.desc.input);
                 let output = $ops(input);
 
-                handles.register_int_tensor(&args.out.id, output);
+                handles.register_int_tensor(&self.desc.out.id, output);
             }
         }
     };
@@ -101,16 +105,17 @@ macro_rules! scalar_float_cmp_ops {
         $name:ident,
         $ops:expr
     ) => {
-        struct $name<const D: usize>;
+        #[derive(new)]
+        struct $name<const D: usize> {
+            desc: ScalarOpsDescription<f32>,
+        }
 
         impl<const D: usize, B: FusionBackend> Ops<B> for $name<D> {
-            type Args = ScalarOpsDescription<FloatElem<B>>;
+            fn execute(self: Box<Self>, handles: &mut $crate::HandleContainer<B>) {
+                let lhs = handles.get_float_tensor::<D>(&self.desc.lhs);
+                let output = $ops(lhs, self.desc.rhs.clone());
 
-            fn execute(&self, args: &Self::Args, handles: &mut $crate::HandleContainer<B>) {
-                let lhs = handles.get_float_tensor::<D>(&args.lhs);
-                let output = $ops(lhs, args.rhs.clone());
-
-                handles.register_bool_tensor(&args.out.id, output);
+                handles.register_bool_tensor(&self.desc.out.id, output);
             }
         }
     };
@@ -123,16 +128,17 @@ macro_rules! scalar_int_cmp_ops {
         $name:ident,
         $ops:expr
     ) => {
-        struct $name<const D: usize>;
+        #[derive(new)]
+        struct $name<const D: usize> {
+            desc: ScalarOpsDescription<i32>,
+        }
 
         impl<const D: usize, B: FusionBackend> Ops<B> for $name<D> {
-            type Args = ScalarOpsDescription<IntElem<B>>;
+            fn execute(self: Box<Self>, handles: &mut $crate::HandleContainer<B>) {
+                let lhs = handles.get_int_tensor::<D>(&self.desc.lhs);
+                let output = $ops(lhs, self.desc.rhs.clone());
 
-            fn execute(&self, args: &Self::Args, handles: &mut $crate::HandleContainer<B>) {
-                let lhs = handles.get_int_tensor::<D>(&args.lhs);
-                let output = $ops(lhs, args.rhs.clone());
-
-                handles.register_bool_tensor(&args.out.id, output);
+                handles.register_bool_tensor(&self.desc.out.id, output);
             }
         }
     };
@@ -145,23 +151,24 @@ macro_rules! scalar_int_ops {
         $name:ident,
         $ops:expr
     ) => {
-        scalar_int_ops!($name, $ops, IntElem<B>);
+        scalar_int_ops!($name, $ops, i32);
     };
     (
         $name:ident,
         $ops:expr,
         $elem:ty
     ) => {
-        struct $name<const D: usize>;
+        #[derive(new)]
+        struct $name<const D: usize> {
+            desc: ScalarOpsDescription<$elem>,
+        }
 
         impl<const D: usize, B: FusionBackend> Ops<B> for $name<D> {
-            type Args = ScalarOpsDescription<$elem>;
+            fn execute(self: Box<Self>, handles: &mut $crate::HandleContainer<B>) {
+                let lhs = handles.get_int_tensor::<D>(&self.desc.lhs);
+                let output = $ops(lhs, self.desc.rhs.clone());
 
-            fn execute(&self, args: &Self::Args, handles: &mut $crate::HandleContainer<B>) {
-                let lhs = handles.get_int_tensor::<D>(&args.lhs);
-                let output = $ops(lhs, args.rhs.clone());
-
-                handles.register_int_tensor(&args.out.id, output);
+                handles.register_int_tensor(&self.desc.out.id, output);
             }
         }
     };

--- a/burn-fusion/src/ops/unary.rs
+++ b/burn-fusion/src/ops/unary.rs
@@ -26,6 +26,26 @@ macro_rules! scalar_float_ops {
             }
         }
     };
+    (
+        $name:ident,
+        $ops:expr,
+        $elem:ty,
+        noconvert
+    ) => {
+        #[derive(new)]
+        struct $name<const D: usize> {
+            desc: ScalarOpsDescription<$elem>,
+        }
+
+        impl<const D: usize, B: FusionBackend> Ops<B> for $name<D> {
+            fn execute(self: Box<Self>, handles: &mut $crate::HandleContainer<B>) {
+                let lhs = handles.get_float_tensor::<D>(&self.desc.lhs);
+                let output = $ops(lhs, self.desc.rhs);
+
+                handles.register_float_tensor(&self.desc.out.id, output);
+            }
+        }
+    };
 }
 
 #[allow(missing_docs)]
@@ -167,6 +187,26 @@ macro_rules! scalar_int_ops {
             fn execute(self: Box<Self>, handles: &mut $crate::HandleContainer<B>) {
                 let lhs = handles.get_int_tensor::<D>(&self.desc.lhs);
                 let output = $ops(lhs, burn_tensor::ElementConversion::elem(self.desc.rhs));
+
+                handles.register_int_tensor(&self.desc.out.id, output);
+            }
+        }
+    };
+    (
+        $name:ident,
+        $ops:expr,
+        $elem:ty,
+        noconvert
+    ) => {
+        #[derive(new)]
+        struct $name<const D: usize> {
+            desc: ScalarOpsDescription<$elem>,
+        }
+
+        impl<const D: usize, B: FusionBackend> Ops<B> for $name<D> {
+            fn execute(self: Box<Self>, handles: &mut $crate::HandleContainer<B>) {
+                let lhs = handles.get_int_tensor::<D>(&self.desc.lhs);
+                let output = $ops(lhs, self.desc.rhs);
 
                 handles.register_int_tensor(&self.desc.out.id, output);
             }

--- a/burn-fusion/src/server.rs
+++ b/burn-fusion/src/server.rs
@@ -1,5 +1,5 @@
 use crate::{
-    graph::{Graph, GraphExecution, Optimization, TensorOpsDescription},
+    graph::{Graph, GraphExecution, Ops, Optimization, TensorOpsDescription},
     FusionBackend, FusionProperties, FusionStatus, HandleContainer, TensorId,
 };
 use burn_tensor::ops::{FloatElem, IntElem};
@@ -37,9 +37,9 @@ where
         }
     }
 
-    pub fn register(&mut self, ops: TensorOpsDescription<B>) {
+    pub fn register(&mut self, ops: TensorOpsDescription, op: Box<dyn Ops<B>>) {
         let ops = Arc::new(ops);
-        self.graph.add(ops.clone());
+        self.graph.add(ops.clone(), ops);
 
         self.optimizations
             .iter_mut()

--- a/burn-fusion/src/server.rs
+++ b/burn-fusion/src/server.rs
@@ -37,9 +37,9 @@ where
         }
     }
 
-    pub fn register(&mut self, ops: TensorOpsDescription, op: Box<dyn Ops<B>>) {
-        let ops = Arc::new(ops);
-        self.graph.add(ops.clone(), ops);
+    pub fn register(&mut self, desc: TensorOpsDescription, op: Box<dyn Ops<B>>) {
+        let ops = Arc::new(desc);
+        self.graph.add(ops.clone(), op);
 
         self.optimizations
             .iter_mut()

--- a/burn-ndarray/src/ops/tensor.rs
+++ b/burn-ndarray/src/ops/tensor.rs
@@ -27,7 +27,7 @@ impl<E: FloatNdArrayElement> TensorOps<Self> for NdArray<E> {
 
     fn random<const D: usize>(
         shape: Shape<D>,
-        distribution: Distribution<E>,
+        distribution: Distribution,
         device: &NdArrayDevice,
     ) -> NdArrayTensor<E, D> {
         let mut seed = SEED.lock().unwrap();

--- a/burn-tch/src/ops/tensor.rs
+++ b/burn-tch/src/ops/tensor.rs
@@ -30,9 +30,7 @@ impl<E: TchElement> TensorOps<Self> for LibTorch<E> {
             }
             Distribution::Uniform(from, to) => {
                 let mut tensor = TchTensor::<E, D>::empty(shape, *device);
-                tensor
-                    .mut_ops(|tensor| tensor.uniform_(from.to_f64().unwrap(), to.to_f64().unwrap()))
-                    .unwrap()
+                tensor.mut_ops(|tensor| tensor.uniform_(from, to)).unwrap()
             }
             Distribution::Normal(mean, std) => {
                 let mut tensor = TchTensor::<E, D>::empty(shape, *device);

--- a/burn-tch/src/ops/tensor.rs
+++ b/burn-tch/src/ops/tensor.rs
@@ -12,7 +12,7 @@ impl<E: TchElement> TensorOps<Self> for LibTorch<E> {
 
     fn random<const D: usize>(
         shape: Shape<D>,
-        distribution: Distribution<E>,
+        distribution: Distribution,
         device: &LibTorchDevice,
     ) -> TchTensor<E, D> {
         match distribution {

--- a/burn-tensor/src/tensor/api/float.rs
+++ b/burn-tensor/src/tensor/api/float.rs
@@ -139,7 +139,7 @@ where
 
     /// Returns a new tensor with the same shape and device as the current tensor filled random
     /// values sampled from the given distribution.
-    pub fn random_like(&self, distribution: Distribution<B::FloatElem>) -> Self {
+    pub fn random_like(&self, distribution: Distribution) -> Self {
         Tensor::new(B::random(self.shape(), distribution, &self.device()))
     }
 
@@ -207,7 +207,7 @@ where
 
     /// Create a random tensor of the given shape where each element is sampled from the given
     /// distribution.
-    pub fn random<S: Into<Shape<D>>>(shape: S, distribution: Distribution<B::FloatElem>) -> Self {
+    pub fn random<S: Into<Shape<D>>>(shape: S, distribution: Distribution) -> Self {
         let tensor = B::random(shape.into(), distribution, &B::Device::default());
         Self::new(tensor)
     }
@@ -216,7 +216,7 @@ where
     /// sampled from the given distribution.
     pub fn random_device<S: Into<Shape<D>>>(
         shape: S,
-        distribution: Distribution<B::FloatElem>,
+        distribution: Distribution,
         device: &B::Device,
     ) -> Self {
         let tensor = B::random(shape.into(), distribution, device);

--- a/burn-tensor/src/tensor/element.rs
+++ b/burn-tensor/src/tensor/element.rs
@@ -48,7 +48,7 @@ pub trait ElementRandom {
     /// # Returns
     ///
     /// The random value.
-    fn random<R: RngCore>(distribution: Distribution<Self>, rng: &mut R) -> Self
+    fn random<R: RngCore>(distribution: Distribution, rng: &mut R) -> Self
     where
         Self: Sized;
 }
@@ -103,7 +103,7 @@ macro_rules! make_element {
         }
 
         impl ElementRandom for $type {
-            fn random<R: RngCore>(distribution: Distribution<Self>, rng: &mut R) -> Self {
+            fn random<R: RngCore>(distribution: Distribution, rng: &mut R) -> Self {
                 #[allow(clippy::redundant_closure_call)]
                 $random(distribution, rng)
             }
@@ -114,66 +114,64 @@ macro_rules! make_element {
 make_element!(
     ty f64 Precision::Double,
     convert |elem: &dyn ToPrimitive| elem.to_f64().unwrap(),
-    random |distribution: Distribution<f64>, rng: &mut R| distribution.sampler(rng).sample()
+    random |distribution: Distribution, rng: &mut R| distribution.sampler(rng).sample()
 );
 
 make_element!(
     ty f32 Precision::Full,
     convert |elem: &dyn ToPrimitive| elem.to_f32().unwrap(),
-    random |distribution: Distribution<f32>, rng: &mut R| distribution.sampler(rng).sample()
+    random |distribution: Distribution, rng: &mut R| distribution.sampler(rng).sample()
 );
 
 make_element!(
     ty i64 Precision::Double,
     convert |elem: &dyn ToPrimitive| elem.to_i64().unwrap(),
-    random |distribution: Distribution<i64>, rng: &mut R| distribution.sampler(rng).sample()
+    random |distribution: Distribution, rng: &mut R| distribution.sampler(rng).sample()
 );
 
 make_element!(
     ty i32 Precision::Full,
     convert |elem: &dyn ToPrimitive| elem.to_i32().unwrap(),
-    random |distribution: Distribution<i32>, rng: &mut R| distribution.sampler(rng).sample()
+    random |distribution: Distribution, rng: &mut R| distribution.sampler(rng).sample()
 );
 
 make_element!(
     ty u32 Precision::Full,
     convert |elem: &dyn ToPrimitive| elem.to_u32().unwrap(),
-    random |distribution: Distribution<u32>, rng: &mut R| distribution.sampler(rng).sample()
+    random |distribution: Distribution, rng: &mut R| distribution.sampler(rng).sample()
 );
 
 make_element!(
     ty i16 Precision::Half,
     convert |elem: &dyn ToPrimitive| elem.to_i16().unwrap(),
-    random |distribution: Distribution<i16>, rng: &mut R| distribution.sampler(rng).sample()
+    random |distribution: Distribution, rng: &mut R| distribution.sampler(rng).sample()
 );
 
 make_element!(
     ty i8 Precision::Other,
     convert |elem: &dyn ToPrimitive| elem.to_i8().unwrap(),
-    random |distribution: Distribution<i8>, rng: &mut R| distribution.sampler(rng).sample()
+    random |distribution: Distribution, rng: &mut R| distribution.sampler(rng).sample()
 );
 
 make_element!(
     ty u8 Precision::Other,
     convert |elem: &dyn ToPrimitive| elem.to_u8().unwrap(),
-    random |distribution: Distribution<u8>, rng: &mut R| distribution.sampler(rng).sample()
+    random |distribution: Distribution, rng: &mut R| distribution.sampler(rng).sample()
 );
 
 make_element!(
     ty f16 Precision::Half,
     convert |elem: &dyn ToPrimitive| f16::from_f32(elem.to_f32().unwrap()),
-    random |distribution: Distribution<f16>, rng: &mut R| {
-        let distribution: Distribution<f32> = distribution.convert();
-        let sample = distribution.sampler(rng).sample();
+    random |distribution: Distribution, rng: &mut R| {
+        let sample: f32 = distribution.sampler(rng).sample();
         f16::from_elem(sample)
     }
 );
 make_element!(
     ty bf16 Precision::Half,
     convert |elem: &dyn ToPrimitive| bf16::from_f32(elem.to_f32().unwrap()),
-    random |distribution: Distribution<bf16>, rng: &mut R| {
-        let distribution: Distribution<f32> = distribution.convert();
-        let sample = distribution.sampler(rng).sample();
+    random |distribution: Distribution, rng: &mut R| {
+        let sample: f32 = distribution.sampler(rng).sample();
         bf16::from_elem(sample)
     }
 );

--- a/burn-tensor/src/tensor/named/base.rs
+++ b/burn-tensor/src/tensor/named/base.rs
@@ -49,7 +49,7 @@ where
 
     /// Create a random named tensor of the given shape where each element is sampled from
     /// the given distribution.
-    pub fn random<S: Into<Shape<D>>>(shape: S, distribution: Distribution<B::FloatElem>) -> Self {
+    pub fn random<S: Into<Shape<D>>>(shape: S, distribution: Distribution) -> Self {
         Self::from_tensor(Tensor::random(shape, distribution))
     }
 

--- a/burn-tensor/src/tensor/ops/tensor.rs
+++ b/burn-tensor/src/tensor/ops/tensor.rs
@@ -34,7 +34,7 @@ pub trait TensorOps<B: Backend> {
     /// The tensor with the given shape and random values.
     fn random<const D: usize>(
         shape: Shape<D>,
-        distribution: Distribution<FloatElem<B>>,
+        distribution: Distribution,
         device: &Device<B>,
     ) -> FloatTensor<B, D>;
 

--- a/burn-wgpu/src/fusion/elemwise/ops.rs
+++ b/burn-wgpu/src/fusion/elemwise/ops.rs
@@ -13,7 +13,6 @@ use burn_fusion::{
 };
 use burn_tensor::{Device, Element};
 use hashbrown::HashMap;
-use std::sync::Arc;
 
 /// Fused element wise operations that are normally memory bound.
 pub struct FloatElementWiseFusionOps<G, F, I>
@@ -35,10 +34,10 @@ where
 impl<G: GraphicsApi + 'static, F: FloatElement, I: IntElement> FusionOps<Wgpu<G, F, I>>
     for FloatElementWiseFusionOps<G, F, I>
 {
-    fn register(&mut self, ops: Arc<TensorOpsDescription<Wgpu<G, F, I>>>) -> FusionStatus {
-        match ops.as_ref() {
+    fn register(&mut self, ops: &TensorOpsDescription) -> FusionStatus {
+        match ops {
             TensorOpsDescription::FloatOps(ops) => {
-                if !self.register_float(ops) {
+                if !self.register_float::<Wgpu<G, F, I>>(ops) {
                     return FusionStatus::Closed(self.properties);
                 }
             }
@@ -287,69 +286,66 @@ where
         Variable::Local(local_index)
     }
 
-    fn register_float<B: FusionBackend>(&mut self, ops: &FloatOpsDescription<B>) -> bool {
+    fn register_float<B: FusionBackend>(&mut self, ops: &FloatOpsDescription) -> bool {
         match ops {
-            FloatOpsDescription::Exp(desc, _) => {
+            FloatOpsDescription::Exp(desc) => {
                 self.register_unary_ops(desc, |input, out| Operator::Exp { input, out })
             }
-            FloatOpsDescription::Log(desc, _) => {
+            FloatOpsDescription::Log(desc) => {
                 self.register_unary_ops(desc, |input, out| Operator::Log { input, out })
             }
-            FloatOpsDescription::Log1p(desc, _) => {
+            FloatOpsDescription::Log1p(desc) => {
                 self.register_unary_ops(desc, |input, out| Operator::Log1p { input, out })
             }
-            FloatOpsDescription::Cos(desc, _) => {
+            FloatOpsDescription::Cos(desc) => {
                 self.register_unary_ops(desc, |input, out| Operator::Cos { input, out })
             }
-            FloatOpsDescription::Sin(desc, _) => {
+            FloatOpsDescription::Sin(desc) => {
                 self.register_unary_ops(desc, |input, out| Operator::Sin { input, out })
             }
-            FloatOpsDescription::Powf(desc, _) => {
+            FloatOpsDescription::Powf(desc) => {
                 self.register_scalar_ops(desc, |lhs, rhs, out| Operator::Powf { lhs, rhs, out })
             }
-            FloatOpsDescription::Tanh(desc, _) => {
+            FloatOpsDescription::Tanh(desc) => {
                 self.register_unary_ops(desc, |input, out| Operator::Tanh { input, out })
             }
-            FloatOpsDescription::Erf(desc, _) => {
+            FloatOpsDescription::Erf(desc) => {
                 self.register_unary_ops(desc, |input, out| Operator::Erf { input, out })
             }
-            FloatOpsDescription::Recip(desc, _) => {
+            FloatOpsDescription::Recip(desc) => {
                 self.register_unary_ops(desc, |input, out| Operator::Recip { input, out })
             }
             _ => false,
         }
     }
 
-    fn register_numeric<B: FusionBackend, E: Element>(
-        &mut self,
-        ops: &NumericOpsDescription<B, E>,
-    ) -> bool {
+    fn register_numeric<E: Element>(&mut self, ops: &NumericOpsDescription<E>) -> bool {
         match ops {
-            NumericOpsDescription::Add(desc, _) => {
+            NumericOpsDescription::Add(desc) => {
                 self.register_binary_ops(desc, |lhs, rhs, out| Operator::Add { lhs, rhs, out })
             }
-            NumericOpsDescription::AddScalar(desc, _) => {
+            NumericOpsDescription::AddScalar(desc) => {
                 self.register_scalar_ops(desc, |lhs, rhs, out| Operator::Add { lhs, rhs, out })
             }
-            NumericOpsDescription::Sub(desc, _) => {
+            NumericOpsDescription::Sub(desc) => {
                 self.register_binary_ops(desc, |lhs, rhs, out| Operator::Sub { lhs, rhs, out })
             }
-            NumericOpsDescription::SubScalar(desc, _) => {
+            NumericOpsDescription::SubScalar(desc) => {
                 self.register_scalar_ops(desc, |lhs, rhs, out| Operator::Sub { lhs, rhs, out })
             }
-            NumericOpsDescription::Mul(desc, _) => {
+            NumericOpsDescription::Mul(desc) => {
                 self.register_binary_ops(desc, |lhs, rhs, out| Operator::Mul { lhs, rhs, out })
             }
-            NumericOpsDescription::MulScalar(desc, _) => {
+            NumericOpsDescription::MulScalar(desc) => {
                 self.register_scalar_ops(desc, |lhs, rhs, out| Operator::Mul { lhs, rhs, out })
             }
-            NumericOpsDescription::Div(desc, _) => {
+            NumericOpsDescription::Div(desc) => {
                 self.register_binary_ops(desc, |lhs, rhs, out| Operator::Div { lhs, rhs, out })
             }
-            NumericOpsDescription::DivScalar(desc, _) => {
+            NumericOpsDescription::DivScalar(desc) => {
                 self.register_scalar_ops(desc, |lhs, rhs, out| Operator::Div { lhs, rhs, out })
             }
-            NumericOpsDescription::Abs(desc, _) => {
+            NumericOpsDescription::Abs(desc) => {
                 self.register_unary_ops(desc, |input, out| Operator::Abs { input, out })
             }
             _ => false,
@@ -425,16 +421,14 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use burn_fusion::graph::{BinaryOpsDescription, Ops};
+    use burn_fusion::graph::Ops;
     use burn_fusion::Fusion;
     use burn_tensor::Tensor;
 
     struct FakeAddOps;
 
     impl<B: FusionBackend> Ops<B> for FakeAddOps {
-        type Args = BinaryOpsDescription;
-
-        fn execute(&self, _: &Self::Args, _: &mut HandleContainer<B>) {
+        fn execute(self: Box<Self>, _: &mut HandleContainer<B>) {
             todo!()
         }
     }

--- a/burn-wgpu/src/fusion/elemwise/ops.rs
+++ b/burn-wgpu/src/fusion/elemwise/ops.rs
@@ -421,7 +421,7 @@ where
 mod tests {
     use super::*;
     use burn_fusion::graph::Ops;
-    use burn_fusion::Fusion;
+    use burn_fusion::{Fusion, FusionBackend};
     use burn_tensor::Tensor;
 
     struct FakeAddOps;

--- a/burn-wgpu/src/fusion/elemwise/ops.rs
+++ b/burn-wgpu/src/fusion/elemwise/ops.rs
@@ -8,8 +8,7 @@ use burn_fusion::{
         BinaryOpsDescription, FloatOpsDescription, NumericOpsDescription, ScalarOpsDescription,
         TensorOpsDescription, UnaryOpsDescription,
     },
-    FusionBackend, FusionOps, FusionProperties, FusionStatus, HandleContainer, TensorDescription,
-    TensorId,
+    FusionOps, FusionProperties, FusionStatus, HandleContainer, TensorDescription, TensorId,
 };
 use burn_tensor::{Device, Element};
 use hashbrown::HashMap;
@@ -37,7 +36,7 @@ impl<G: GraphicsApi + 'static, F: FloatElement, I: IntElement> FusionOps<Wgpu<G,
     fn register(&mut self, ops: &TensorOpsDescription) -> FusionStatus {
         match ops {
             TensorOpsDescription::FloatOps(ops) => {
-                if !self.register_float::<Wgpu<G, F, I>>(ops) {
+                if !self.register_float(ops) {
                     return FusionStatus::Closed(self.properties);
                 }
             }
@@ -286,7 +285,7 @@ where
         Variable::Local(local_index)
     }
 
-    fn register_float<B: FusionBackend>(&mut self, ops: &FloatOpsDescription) -> bool {
+    fn register_float(&mut self, ops: &FloatOpsDescription) -> bool {
         match ops {
             FloatOpsDescription::Exp(desc) => {
                 self.register_unary_ops(desc, |input, out| Operator::Exp { input, out })

--- a/burn-wgpu/src/kernel/index/gather.rs
+++ b/burn-wgpu/src/kernel/index/gather.rs
@@ -64,7 +64,7 @@ mod tests {
         let indices = Tensor::<TestBackend, 1, Int>::from_data(
             Tensor::<TestBackend, 1>::random(
                 [shape.num_elements()],
-                Distribution::Uniform(0., max as f32),
+                Distribution::Uniform(0., max as f64),
             )
             .into_data()
             .convert(),

--- a/burn-wgpu/src/kernel/index/scatter.rs
+++ b/burn-wgpu/src/kernel/index/scatter.rs
@@ -111,7 +111,7 @@ mod tests {
         let indices = Tensor::<TestBackend, 1, Int>::from_data(
             Tensor::<TestBackend, 1>::random(
                 [shape2.iter().product()],
-                Distribution::Uniform(0., shape2[dim] as f32),
+                Distribution::Uniform(0., shape2[dim] as f64),
             )
             .into_data()
             .convert(),

--- a/burn-wgpu/src/kernel/index/select.rs
+++ b/burn-wgpu/src/kernel/index/select.rs
@@ -152,7 +152,7 @@ mod tests {
         let indices = Tensor::<TestBackend, 1, Int>::from_data(
             Tensor::<TestBackend, 1>::random(
                 [shape[dim]],
-                Distribution::Uniform(0., shape[dim] as f32),
+                Distribution::Uniform(0., shape[dim] as f64),
             )
             .into_data()
             .convert(),

--- a/burn-wgpu/src/ops/float_ops.rs
+++ b/burn-wgpu/src/ops/float_ops.rs
@@ -37,12 +37,14 @@ where
 
     fn random<const D: usize>(
         shape: Shape<D>,
-        distribution: Distribution<FloatElem<Self>>,
+        distribution: Distribution,
         device: &Device<Self>,
     ) -> FloatTensor<Self, D> {
         match distribution {
             Distribution::Default => random_uniform::<G, F, D>(shape, device, 0.elem(), 1.elem()),
-            Distribution::Uniform(low, high) => random_uniform::<G, F, D>(shape, device, low, high),
+            Distribution::Uniform(low, high) => {
+                random_uniform::<G, F, D>(shape, device, low.elem(), high.elem())
+            }
             Distribution::Bernoulli(prob) => {
                 random_bernoulli::<G, F, D>(shape, device, prob.elem())
             }


### PR DESCRIPTION
The goal of this PR is to remove the operation from the graph description, it's going to be needed when we will need to compute an ID for a graph description with a global and local graph version. It also simplifies a bit the code.

I had to modify the Distribution struct to remove the element generic, now it's more consistent.