### PR TITLE
Fix SQLite tests on Windows

### DIFF
--- a/burn-dataset/src/dataset/sqlite.rs
+++ b/burn-dataset/src/dataset/sqlite.rs
@@ -274,9 +274,7 @@ fn create_conn_pool<P: AsRef<Path>>(
         OpenFlags::SQLITE_OPEN_READ_ONLY
     };
 
-    // Create a connection pool and make sure the connections are read only
     let manager = SqliteConnectionManager::file(db_file).with_flags(sqlite_flags);
-
     Pool::new(manager).map_err(SqliteDatasetError::ConnectionPool)
 }
 

--- a/burn-dataset/src/dataset/sqlite.rs
+++ b/burn-dataset/src/dataset/sqlite.rs
@@ -560,6 +560,13 @@ where
     pub fn set_completed(&mut self) -> Result<()> {
         let mut is_completed = self.is_completed.write().unwrap();
 
+        // Force close the connection pool
+        // This is required on Windows platform where the connection pool prevents
+        // from persisting the db by renaming the temp file.
+        if let Some(pool) = self.conn_pool.take() {
+            std::mem::drop(pool);
+        }
+
         // Rename the database file from tmp to db
         let _file_result = self
             .db_file_tmp


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Fixes #946 

### Changes

Drop the sqlite connection pool so that the database can be persisted on Windows.

### Testing

No new code to test.
Ran all the tests on both Windows 11 and MacOS.
