### PR TITLE
Test for max_dim/min_dim

### DIFF
--- a/burn-tensor/src/tensor/ops/tensor.rs
+++ b/burn-tensor/src/tensor/ops/tensor.rs
@@ -1001,7 +1001,7 @@ pub trait TensorOps<B: Backend> {
     fn max_dim<const D: usize>(tensor: FloatTensor<B, D>, dim: usize) -> FloatTensor<B, D> {
         let index = B::argmax(tensor.clone(), dim);
 
-        B::gather(D - 1, tensor, index)
+        B::gather(dim, tensor, index)
     }
 
     /// Gets the maximum elements of a tensor along an axis and their indices.
@@ -1019,7 +1019,7 @@ pub trait TensorOps<B: Backend> {
         dim: usize,
     ) -> (FloatTensor<B, D>, IntTensor<B, D>) {
         let index = B::argmax(tensor.clone(), dim);
-        let values = B::gather(D - 1, tensor, index.clone());
+        let values = B::gather(dim, tensor, index.clone());
 
         (values, index)
     }
@@ -1053,7 +1053,7 @@ pub trait TensorOps<B: Backend> {
     fn min_dim<const D: usize>(tensor: FloatTensor<B, D>, dim: usize) -> FloatTensor<B, D> {
         let index = B::argmin(tensor.clone(), dim);
 
-        B::gather(D - 1, tensor, index)
+        B::gather(dim, tensor, index)
     }
 
     /// Gets the minimum elements of a tensor along an axis and their indices.
@@ -1071,7 +1071,7 @@ pub trait TensorOps<B: Backend> {
         dim: usize,
     ) -> (FloatTensor<B, D>, IntTensor<B, D>) {
         let index = B::argmin(tensor.clone(), dim);
-        let values = B::gather(D - 1, tensor, index.clone());
+        let values = B::gather(dim, tensor, index.clone());
 
         (values, index)
     }

--- a/burn-tensor/src/tests/ops/maxmin.rs
+++ b/burn-tensor/src/tests/ops/maxmin.rs
@@ -14,6 +14,19 @@ mod tests {
     }
 
     #[test]
+    fn test_max_dim_with_indices_2d_with_dim_0th() {
+        let tensor = TestTensor::from_floats([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+
+        let (output_actual, index_actual) = tensor.max_dim_with_indices(0);
+
+        let output_expected = Data::from([[3., 4., 5.]]);
+        let index_expected = Data::from([[1, 1, 1]]);
+
+        assert_eq!(output_expected, output_actual.into_data());
+        assert_eq!(index_expected, index_actual.into_data());
+    }
+
+    #[test]
     fn test_max_dim_with_indices_2d() {
         let tensor = TestTensor::from_floats([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
@@ -44,6 +57,68 @@ mod tests {
 
         let output_expected = Data::from([[0.], [3.]]);
         let index_expected = Data::from([[0], [0]]);
+
+        assert_eq!(output_expected, output_actual.into_data());
+        assert_eq!(index_expected, index_actual.into_data());
+    }
+
+    #[test]
+    fn test_sum_dim_2d() {
+        let tensor = TestTensor::from_floats([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+
+        let output_actual = tensor.clone().sum_dim(1);
+
+        let output_expected = Data::from([[3.], [12.]]);
+        assert_eq!(output_expected, output_actual.into_data());
+
+        let output_actual = tensor.sum_dim(0);
+
+        let output_expected = Data::from([[3., 5., 7.]]);
+        assert_eq!(output_expected, output_actual.into_data());
+    }
+
+    #[test]
+    fn test_mean_dim_2d() {
+        let tensor = TestTensor::from_floats([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+
+        let output_actual = tensor.clone().mean_dim(1);
+
+        let output_expected = Data::from([[1.], [4.]]);
+        assert_eq!(output_expected, output_actual.into_data());
+
+        let output_actual = tensor.mean_dim(0);
+
+        let output_expected = Data::from([[1.5, 2.5, 3.5]]);
+        assert_eq!(output_expected, output_actual.into_data());
+    }
+
+    #[test]
+    fn test_min_dim_2d_with_0th_dim() {
+        let tensor = TestTensor::from_floats([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let output_actual = tensor.min_dim(0);
+
+        let output_expected = Data::from([[0., 1., 2.]]);
+        assert_eq!(output_expected, output_actual.into_data());
+    }
+
+    #[test]
+    fn test_max_dim_2d_with_0th_dim() {
+        let tensor = TestTensor::from_floats([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+
+        let output_actual = tensor.max_dim(0);
+
+        let output_expected = Data::from([[3., 4., 5.]]);
+        assert_eq!(output_expected, output_actual.into_data());
+    }
+
+    #[test]
+    fn test_min_dim_with_indices_2d_with_0th_dim() {
+        let tensor = TestTensor::from_floats([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+
+        let (output_actual, index_actual) = tensor.min_dim_with_indices(0);
+
+        let output_expected = Data::from([[0., 1., 2.]]);
+        let index_expected = Data::from([[0, 0, 0]]);
 
         assert_eq!(output_expected, output_actual.into_data());
         assert_eq!(index_expected, index_actual.into_data());


### PR DESCRIPTION
To prove, that if the dimension is set to 0, the calculation fails. The testcases are disabled

## Pull Request Template

### Checklist

- [ ] Confirmed that `run-checks all` script has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs


### Changes

I've tried to use tensor.max_dim(0) and noticed, that it doesn't work - as opposed to tensor.sum_dim(0) or tensor.mean_dim(0).
This doesn't change any code, just adds more tests - currently the broken tests are disabled.

### Testing

_Describe how these changes have been tested._
