### PR TITLE
chore(tensors): fix narrow error messages

### DIFF
--- a/burn-tensor/src/tensor/api/base.rs
+++ b/burn-tensor/src/tensor/api/base.rs
@@ -482,6 +482,7 @@ where
     ///
     /// A new tensor with the given dimension narrowed to the given range.
     pub fn narrow(self, dim: usize, start: usize, length: usize) -> Self {
+        check!(TensorCheck::dim_ops::<D>("narrow", dim));
         check!(TensorCheck::narrow(&self, dim, start, length));
 
         let ranges: Vec<_> = (0..D)

--- a/burn-tensor/src/tensor/api/check.rs
+++ b/burn-tensor/src/tensor/api/check.rs
@@ -88,16 +88,6 @@ impl TensorCheck {
     ) -> Self {
         let mut check = Self::Ok;
 
-        if dim >= D {
-            check = check.register(
-                "Unsqueeze",
-                TensorError::new(format!(
-                    "Can't unsqueeze at dimension {}, exceeds tensor dimensions (D={})",
-                    dim, D
-                )),
-            );
-        }
-
         if length == 0 {
             check = check.register(
                 "Narrow",
@@ -112,8 +102,8 @@ impl TensorCheck {
             check = check.register(
                 "Narrow",
                 TensorError::new(format!(
-                    "Can't narrow at dimension {}, start exceeds tensor dimensions (D={})",
-                    dim, D
+                    "Can't narrow at dimension {}, start exceeds the size of the tensor along this dimension (Size={})",
+                    dim, tensor.shape().dims[dim]
                 )),
             );
         }
@@ -122,8 +112,8 @@ impl TensorCheck {
             check = check.register(
                 "Narrow",
                 TensorError::new(format!(
-                    "Can't narrow at dimension {}, start + length exceeds tensor dimensions (D={})",
-                    dim, D
+                    "Can't narrow at dimension {}, start + length exceeds the size of the tensor along this dimension (Size={})",
+                    dim, tensor.shape().dims[dim]
                 )),
             );
         }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Set out to fix a typo in the error messaged returned by `narrow` - also improves the message for start and dim to be more clear about what's out of bounds.
