### PR TITLE
slice assign in candle

### DIFF
--- a/burn-candle/Cargo.toml
+++ b/burn-candle/Cargo.toml
@@ -18,7 +18,7 @@ derive-new = { workspace = true }
 burn-tensor = { path = "../burn-tensor", version = "0.11.0", default-features = false }
 half = { workspace = true }
 
-candle-core = { version = "0.3.1" }
+candle-core = { git = "https://github.com/huggingface/candle", rev = "481c45d" }
 
 
 [dev-dependencies]

--- a/burn-candle/src/backend.rs
+++ b/burn-candle/src/backend.rs
@@ -50,7 +50,7 @@ impl From<candle_core::Device> for CandleDevice {
         match device.location() {
             DeviceLocation::Cpu => CandleDevice::Cpu,
             DeviceLocation::Cuda { gpu_id } => CandleDevice::Cuda(gpu_id),
-            DeviceLocation::Metal => panic!("Metal unsupported"),
+            DeviceLocation::Metal { gpu_id } => todo!(),
         }
     }
 }

--- a/burn-candle/src/lib.rs
+++ b/burn-candle/src/lib.rs
@@ -76,11 +76,11 @@ mod tests {
     burn_tensor::testgen_neg!();
     burn_tensor::testgen_powf!();
     burn_tensor::testgen_random!();
-    // burn_tensor::testgen_repeat!();
+    burn_tensor::testgen_repeat!();
     burn_tensor::testgen_reshape!();
     burn_tensor::testgen_select!();
     burn_tensor::testgen_sin!();
-    // burn_tensor::testgen_slice!();
+    burn_tensor::testgen_slice!();
     burn_tensor::testgen_sqrt!();
     burn_tensor::testgen_abs!();
     burn_tensor::testgen_squeeze!();
@@ -124,7 +124,7 @@ mod tests {
     burn_autodiff::testgen_ad_div!();
     burn_autodiff::testgen_ad_erf!();
     burn_autodiff::testgen_ad_exp!();
-    // burn_autodiff::testgen_ad_slice!();
+    burn_autodiff::testgen_ad_slice!();
     burn_autodiff::testgen_ad_gather_scatter!();
     burn_autodiff::testgen_ad_select!();
     burn_autodiff::testgen_ad_log!();

--- a/burn-candle/src/ops/base.rs
+++ b/burn-candle/src/ops/base.rs
@@ -86,5 +86,5 @@ pub fn slice_assign<E: CandleElement, const D1: usize, const D2: usize>(
     ranges: [std::ops::Range<usize>; D2],
     value: CandleTensor<E, D1>,
 ) -> CandleTensor<E, D1> {
-    panic!("slice_assign not supported by Candle")
+    CandleTensor::new(tensor.tensor.slice_assign(&ranges, &value.tensor).unwrap())
 }


### PR DESCRIPTION
Candle finally made slice_assign, so I've updated the candle backend. 
I put this PR as draft because slice_assign is only on Candle main, not an official version, and we won't be able to publish if we rely on github rather than crates.io. 
So this is pending until candle releases its next version: https://crates.io/crates/candle-core (v0.3.1 at the moment)

fix #976 