### PR TITLE
chore(ci): run workflow on macOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,8 +107,16 @@ jobs:
           curl -L "$GRCOV_LINK/$GRCOV_VERSION/grcov-x86_64-unknown-linux-musl.tar.bz2" |
           tar xj -C $HOME/.cargo/bin
 
+      - name: Set OS-specific flags
+        run: |
+          if [ "${{ matrix.os }}" = "ubuntu-22.04" ]; then
+            echo "COVERAGE_FLAGS=${{ matrix.coverage_flags }}" >> $GITHUB_ENV
+          else
+            echo "COVERAGE_FLAGS=" >> $GITHUB_ENV
+          fi
+
       - name: run checks & tests
-        run: ${{ matrix.coverage-flags }} CI_RUN=1 cargo xtask run-checks ${{ matrix.test }}
+        run: ${{ env.COVERAGE_FLAGS }} CI_RUN=1 cargo xtask run-checks ${{ matrix.test }}
 
       - name: Codecov upload
         if: matrix.rust == 'stable' && matrix.test == 'std' && runner.os == 'Linux'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-22.04]
+        os: [macos-13, ubuntu-22.04]
         rust: [stable, 1.71.0]
         test: ['std', 'no-std', 'examples']
         include:
@@ -46,6 +46,10 @@ jobs:
             rust: stable
             test: std
             os: ubuntu-22.04
+          - wgpu-flags: DISABLE_WGPU=1
+            rust: stable
+            test: std
+            os: macos-13
         exclude:
           # only need to check this once
           - rust: 1.71.0
@@ -109,7 +113,7 @@ jobs:
           tar xj -C $HOME/.cargo/bin
 
       - name: run checks & tests
-        run: ${{ matrix.coverage-flags }} CI_RUN=1 cargo xtask run-checks ${{ matrix.test }}
+        run: ${{ matrix.coverage-flags }} ${{ matrix.wgpu-flags }} CI_RUN=1 cargo xtask run-checks ${{ matrix.test }}
 
       - name: Codecov upload
         if: matrix.rust == 'stable' && matrix.test == 'std' && runner.os == 'Linux'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,7 @@ jobs:
           - coverage-flags: COVERAGE=1
             rust: stable
             test: std
+            os: ubuntu-22.04
         exclude:
           # only need to check this once
           - rust: 1.71.0
@@ -107,16 +108,8 @@ jobs:
           curl -L "$GRCOV_LINK/$GRCOV_VERSION/grcov-x86_64-unknown-linux-musl.tar.bz2" |
           tar xj -C $HOME/.cargo/bin
 
-      - name: Set OS-specific flags
-        run: |
-          if [ "${{ runner.os }}" = "Linux" ]; then
-            echo "COVERAGE_FLAGS=${{ matrix.coverage_flags }}" >> $GITHUB_ENV
-          else
-            echo "COVERAGE_FLAGS=" >> $GITHUB_ENV
-          fi
-
       - name: run checks & tests
-        run: ${{ env.COVERAGE_FLAGS }} CI_RUN=1 cargo xtask run-checks ${{ matrix.test }}
+        run: ${{ matrix.coverage-flags }} CI_RUN=1 cargo xtask run-checks ${{ matrix.test }}
 
       - name: Codecov upload
         if: matrix.rust == 'stable' && matrix.test == 'std' && runner.os == 'Linux'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,9 @@ jobs:
           # only need to check this once
           - rust: 1.71.0
             test: 'examples'
+          # only need to check this once
+          - os: macos-13
+            test: 'no-std'
 
     steps:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Set OS-specific flags
         run: |
-          if [ "${{ matrix.os }}" = "ubuntu-22.04" ]; then
+          if [ "${{ runner.os }}" = "Linux" ]; then
             echo "COVERAGE_FLAGS=${{ matrix.coverage_flags }}" >> $GITHUB_ENV
           else
             echo "COVERAGE_FLAGS=" >> $GITHUB_ENV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,7 @@ jobs:
           prefix-key: "v5-rust"
 
       - name: free disk space
+        if: runner.os == 'Linux'
         run: |
           df -h
           sudo swapoff -a
@@ -77,6 +78,7 @@ jobs:
           cargo clean --package burn-tch
 
       - name: install llvmpipe and lavapipe
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update -y -qq
           sudo add-apt-repository ppa:kisak/kisak-mesa -y
@@ -84,7 +86,7 @@ jobs:
           sudo apt install -y libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
 
       - name: Run cargo clippy for stable version
-        if: matrix.rust == 'stable' && matrix.test == 'std'
+        if: matrix.rust == 'stable' && matrix.test == 'std' && runner.os == 'Linux'
         uses: giraffate/clippy-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -97,7 +99,7 @@ jobs:
           reporter: github-pr-check
 
       - name: Install grcov
-        if: matrix.rust == 'stable' && matrix.test == 'std'
+        if: matrix.rust == 'stable' && matrix.test == 'std' && runner.os == 'Linux'
         env:
           GRCOV_LINK: https://github.com/mozilla/grcov/releases/download
           GRCOV_VERSION: v0.8.18
@@ -109,7 +111,7 @@ jobs:
         run: ${{ matrix.coverage-flags }} CI_RUN=1 cargo xtask run-checks ${{ matrix.test }}
 
       - name: Codecov upload
-        if: matrix.rust == 'stable' && matrix.test == 'std'
+        if: matrix.rust == 'stable' && matrix.test == 'std' && runner.os == 'Linux'
         uses: codecov/codecov-action@v3
         with:
           files: lcov.info

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,9 +31,10 @@ concurrency:
 
 jobs:
   tests:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [macos-latest, ubuntu-22.04]
         rust: [stable, 1.71.0]
         test: ['std', 'no-std', 'examples']
         include:

--- a/xtask/src/runchecks.rs
+++ b/xtask/src/runchecks.rs
@@ -231,7 +231,7 @@ fn burn_core_std() {
 
     // Run cargo test --features test-wgpu
     // Disabled for macOS in CI due to unavailable Metal device
-    if std::env::var("CI_RUN").is_err() && !cfg!(target_os = "macos") {
+    if !(std::env::var("CI_RUN").is_ok() && cfg!(target_os = "macos")) {
         cargo_test(["-p", "burn-core", "--features", "test-wgpu"].into());
     }
 }
@@ -267,7 +267,12 @@ fn std_checks() {
     cargo_clippy();
 
     // Build each workspace
-    cargo_build(["--workspace", "--exclude=xtask"].into());
+    // Disabled burn-wgpu for macOS in CI due to unavailable Metal device
+    if std::env::var("CI_RUN").is_ok() && cfg!(target_os = "macos") {
+        cargo_build(["--workspace", "--exclude=xtask", "--exclude=burn-wgpu"].into());
+    } else {
+        cargo_build(["--workspace", "--exclude=xtask"].into());
+    }
 
     // Produce documentation for each workspace
     cargo_doc(["--workspace"].into());

--- a/xtask/src/runchecks.rs
+++ b/xtask/src/runchecks.rs
@@ -230,7 +230,10 @@ fn burn_core_std() {
     cargo_test(["-p", "burn-core", "--features", "test-tch"].into());
 
     // Run cargo test --features test-wgpu
-    cargo_test(["-p", "burn-core", "--features", "test-wgpu"].into());
+    // Disabled for macOS in CI due to unavailable Metal device
+    if std::env::var("CI_RUN").is_err() && !cfg!(target_os = "macos") {
+        cargo_test(["-p", "burn-core", "--features", "test-wgpu"].into());
+    }
 }
 
 // Test burn-dataset features

--- a/xtask/src/runchecks.rs
+++ b/xtask/src/runchecks.rs
@@ -230,8 +230,7 @@ fn burn_core_std() {
     cargo_test(["-p", "burn-core", "--features", "test-tch"].into());
 
     // Run cargo test --features test-wgpu
-    // Disabled for macOS in CI due to unavailable Metal device
-    if !(std::env::var("CI_RUN").is_ok() && cfg!(target_os = "macos")) {
+    if std::env::var("DISABLE_WGPU").is_err() {
         cargo_test(["-p", "burn-core", "--features", "test-wgpu"].into());
     }
 }
@@ -257,6 +256,7 @@ fn std_checks() {
 
     // Check if COVERAGE environment variable is set
     let is_coverage = std::env::var("COVERAGE").is_ok();
+    let disable_wgpu = std::env::var("DISABLE_WGPU").is_ok();
 
     println!("Running std checks");
 
@@ -267,8 +267,7 @@ fn std_checks() {
     cargo_clippy();
 
     // Build each workspace
-    // Disabled burn-wgpu for macOS in CI due to unavailable Metal device
-    if std::env::var("CI_RUN").is_ok() && cfg!(target_os = "macos") {
+    if disable_wgpu {
         cargo_build(["--workspace", "--exclude=xtask", "--exclude=burn-wgpu"].into());
     } else {
         cargo_build(["--workspace", "--exclude=xtask"].into());


### PR DESCRIPTION
Adds macos to the CI workflow pipeline. Makes some steps like clippy reporting and coverage uploading happen only on Linux as we don't need that to happen multiple times.

Also disables wgpu testing for macOS until either runners support metal or if we start using a self-hosted runner that has a metal device available. In this case I think that's acceptable, we're still going from no macos coverage to mostly covered.


### Related Issues/PRs

Will be useful for testing things such as #1009 

### Changes

Runs tests also on macOS machines
