### PR TITLE
Use correct name of wgpu backend

### DIFF
--- a/burn-book/src/getting-started.md
+++ b/burn-book/src/getting-started.md
@@ -47,10 +47,10 @@ Now open `src/main.rs` and replace its content with
 
 ```rust, ignore
 use burn::tensor::Tensor;
-use burn::backend::Wgpu;
+use burn::backend::WgpuBackend;
 
 // Type alias for the backend to use.
-type Backend = Wgpu;
+type Backend = WgpuBackend;
 
 fn main() {
     // Creation of two tensors, the first with explicit values and the second one with ones, with the same shape as the first


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ ] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

_Provide links to relevant issues and dependent PRs._

### Changes

Wgpu backend is named 'WgpuBackend', not 'Wgpu'.

### Testing

I'm following the guide, and the original code didn't work, while this one does.
