### PR TITLE
Update getting-started.md

### DIFF
--- a/burn-book/src/getting-started.md
+++ b/burn-book/src/getting-started.md
@@ -29,10 +29,10 @@ cd my_burn_app
 then add the dependency with
 
 ```console
-cargo add burn --features wgpu
+cargo add burn burn-wgpu
 ```
 
-add `burn-wgpu = "0.10.0"` in Cargo.toml, and compile it by executing
+and compile it by executing
 
 ```console
 cargo build


### PR DESCRIPTION
This change solves the error `no Wgpu in backend` when running the `Getting Started` example on Mac OS with M1 

## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

No related Issues/PRs

### Changes

Change is made in the Book's markdown file

### Testing

Tested on my laptop with Mac OS M1 and there is no error 
