### PR TITLE
cleanup less often

### DIFF
--- a/burn-fusion/src/graph/base.rs
+++ b/burn-fusion/src/graph/base.rs
@@ -61,6 +61,9 @@ impl<B: FusionBackend> Graph<B> {
         optimization.execute(&mut context);
 
         self.cleanup_partial(0..num_keep, handles);
+
+        // Cleanup tensor handles that were outputted, but ignored.
+        handles.cleanup_orphans();
     }
 
     pub(crate) fn execute_operations(&mut self, handles: &mut HandleContainer<B>) {
@@ -69,6 +72,9 @@ impl<B: FusionBackend> Graph<B> {
             description.cleanup_tensor(handles);
         }
         self.cleanup_relative_graph();
+
+        // Cleanup tensor handles that were outputted, but ignored.
+        handles.cleanup_orphans();
     }
 
     fn cleanup_partial<R: RangeBounds<usize> + Clone>(

--- a/burn-fusion/src/graph/ops.rs
+++ b/burn-fusion/src/graph/ops.rs
@@ -788,9 +788,6 @@ impl TensorOpsDescription {
             TensorOpsDescription::FloatOps(ops) => ops.cleanup_tensor(handles),
             TensorOpsDescription::ModuleOps(ops) => ops.cleanup_tensor(handles),
         }
-
-        // Cleanup tensor handles that were outputted, but ignored.
-        handles.cleanup_orphans();
     }
 }
 


### PR DESCRIPTION
In fusion, 
Cleanup of orphans seems to happen a bit too early in some very rare cases. 
By cleaning them less often it seems it does not happen anymore