### PR TITLE
fix(docs): fix docs.rs compilation

### DIFF
--- a/burn/Cargo.toml
+++ b/burn/Cargo.toml
@@ -65,7 +65,13 @@ features = [
     "default",
     "std",
     "train",
-    "train-tui",
-    "train-metrics",
-    "dataset-sqlite",
+    "tui",
+    "metrics",
+    "sqlite",
+    "ndarray",
+    "tch",
+    "wgpu",
+    "candle",
+    "fusion",
+    "experimental-named-tensor"
 ]


### PR DESCRIPTION
Along with fixing the docs, this adds a few more features that were missing which should allow the documentation to be more complete:
- ndarray
- tch
- wgpu
- candle
- fusion
- experimental-named-tensor

It may be that `experimental-named-tensor` and `candle` we don't want to promote yet in the docs. But IMO, if its available, then why not.

## Testing
I have verified using the same command `docs.rs` uses:
```rust
cargo rustdoc --lib -Zrustdoc-map --features dataset default std ndarray tch wgpu candle fusion train tui metrics sqlite experimental-named-tensor --
```