### PR TITLE
Add stride field to reduce key

### DIFF
--- a/burn-wgpu/benches/reduction.rs
+++ b/burn-wgpu/benches/reduction.rs
@@ -85,17 +85,20 @@ bench_reduce!(
 /// Runs the benchmarks for wgpu matmul implementations
 pub fn bench(device: &WgpuDevice) {
     let num_repeats = 3;
-    let shape = Shape::new([50, 8000, 50]);
-    let dim = 1;
+    let shape = Shape::new([32, 2048, 32]);
+    let dim = 2;
 
     macro_rules! run_reduce_benchmark {
         ($benchmark:ident) => {
-            run_benchmark($benchmark::new(
-                shape.clone(),
-                dim,
-                num_repeats,
-                device.clone(),
-            ));
+            println!(
+                "{}",
+                run_benchmark($benchmark::new(
+                    shape.clone(),
+                    dim,
+                    num_repeats,
+                    device.clone(),
+                ))
+            );
         };
     }
 

--- a/burn-wgpu/src/kernel/reduce/tune/key.rs
+++ b/burn-wgpu/src/kernel/reduce/tune/key.rs
@@ -6,6 +6,7 @@ use burn_tensor::Shape;
 /// Autotune key representative of reduce versions
 pub struct ReduceAutotuneKey {
     reduce_dim_length: usize,
+    reduce_dim_stride: usize,
     others_product: usize,
 }
 
@@ -13,8 +14,8 @@ impl Display for ReduceAutotuneKey {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_str(
             format!(
-                "Reduce - reduce_dim_length: {:?} others_product: {:?}",
-                self.reduce_dim_length, self.others_product
+                "Reduce - reduce_dim_length: {:?} reduce_dim_stride: {:?} others_product: {:?}",
+                self.reduce_dim_length, self.reduce_dim_stride, self.others_product
             )
             .as_str(),
         )
@@ -23,8 +24,9 @@ impl Display for ReduceAutotuneKey {
 
 impl ReduceAutotuneKey {
     /// Create a reduce autotune key from the input shape and reduce dim
-    pub fn new<const D: usize>(shape: &Shape<D>, reduce_dim: usize) -> Self {
+    pub fn new<const D: usize>(shape: &Shape<D>, strides: &[usize; D], reduce_dim: usize) -> Self {
         let reduce_dim_length = shape.dims[reduce_dim];
+        let reduce_dim_stride = strides[reduce_dim];
         let mut others_product = 1;
         for d in 0..D {
             if d != reduce_dim {
@@ -33,6 +35,7 @@ impl ReduceAutotuneKey {
         }
         Self {
             reduce_dim_length: anchor(reduce_dim_length, None),
+            reduce_dim_stride: anchor(reduce_dim_stride, None),
             others_product: anchor(others_product, None),
         }
     }

--- a/burn-wgpu/src/kernel/reduce/tune/mean_dim.rs
+++ b/burn-wgpu/src/kernel/reduce/tune/mean_dim.rs
@@ -27,7 +27,11 @@ pub struct MeanDimAutotuneOperationSet<E: WgpuElement, const D: usize> {
 impl<E: WgpuElement, const D: usize> MeanDimAutotuneOperationSet<E, D> {
     fn new(input: WgpuTensor<E, D>, output: WgpuTensor<E, D>, reduce_dim: usize) -> Self {
         Self {
-            key: WgpuAutotuneKey::MeanDim(ReduceAutotuneKey::new(&input.shape, reduce_dim)),
+            key: WgpuAutotuneKey::MeanDim(ReduceAutotuneKey::new(
+                &input.shape,
+                &input.strides,
+                reduce_dim,
+            )),
             input,
             output,
             reduce_dim,

--- a/burn-wgpu/src/kernel/reduce/tune/sum_dim.rs
+++ b/burn-wgpu/src/kernel/reduce/tune/sum_dim.rs
@@ -27,7 +27,11 @@ pub struct SumDimAutotuneOperationSet<E: WgpuElement, const D: usize> {
 impl<E: WgpuElement, const D: usize> SumDimAutotuneOperationSet<E, D> {
     fn new(input: WgpuTensor<E, D>, output: WgpuTensor<E, D>, reduce_dim: usize) -> Self {
         Self {
-            key: WgpuAutotuneKey::SumDim(ReduceAutotuneKey::new(&input.shape, reduce_dim)),
+            key: WgpuAutotuneKey::SumDim(ReduceAutotuneKey::new(
+                &input.shape,
+                &input.strides,
+                reduce_dim,
+            )),
             input,
             output,
             reduce_dim,


### PR DESCRIPTION
Added a field for strides in autotune as the dimension on which we reduce impacts the strides which impacts data locality. 