### PR TITLE
Explicit device tensors for #518

### DIFF
--- a/backend-comparison/benches/data.rs
+++ b/backend-comparison/benches/data.rs
@@ -47,7 +47,7 @@ impl<B: Backend, const D: usize> Benchmark for FromDataBenchmark<B, D> {
 
     fn execute(&self, (data, device): Self::Args) {
         for _ in 0..self.num_repeats {
-            let _data = Tensor::<B, D>::from_data_device(data.clone(), &device);
+            let _data = Tensor::<B, D>::from_data(data.clone(), &device);
         }
     }
 

--- a/burn-autodiff/src/tests/abs.rs
+++ b/burn-autodiff/src/tests/abs.rs
@@ -8,8 +8,8 @@ mod tests {
         let data_1 = Data::<f32, 2>::from([[0.0, -1.0], [3.0, 4.0]]);
         let data_2 = Data::<f32, 2>::from([[6.0, 7.0], [9.0, -10.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone().abs());
         let tensor_4 = tensor_3.matmul(tensor_2.clone());

--- a/burn-autodiff/src/tests/adaptive_avgpool1d.rs
+++ b/burn-autodiff/src/tests/adaptive_avgpool1d.rs
@@ -13,7 +13,7 @@ mod tests {
             output_size: 3,
         };
 
-        test.assert_output(TestTensor::from_floats([[
+        test.assert_output(TestTensor::from_floats_default([[
             [0.5000, 0.8333, 0.3333, 0.8333, 0.5000],
             [0.5000, 0.8333, 0.3333, 0.8333, 0.5000],
         ]]));
@@ -29,8 +29,8 @@ mod tests {
     impl AdaptiveAvgPool1dTestCase {
         fn assert_output(self, x_grad: TestTensor<3>) {
             let shape_x = Shape::new([self.batch_size, self.channels, self.length]);
-            let x = TestAutodiffTensor::from_data(
-                TestTensorInt::arange(0..shape_x.num_elements())
+            let x = TestAutodiffTensor::from_data_default(
+                TestTensorInt::arange_default(0..shape_x.num_elements())
                     .reshape(shape_x)
                     .into_data()
                     .convert(),

--- a/burn-autodiff/src/tests/adaptive_avgpool2d.rs
+++ b/burn-autodiff/src/tests/adaptive_avgpool2d.rs
@@ -15,7 +15,7 @@ mod tests {
             output_size_2: 2,
         };
 
-        test.assert_output(TestTensor::from_floats([[
+        test.assert_output(TestTensor::from_floats_default([[
             [
                 [0.2500, 0.5000, 0.2500],
                 [0.4167, 0.8333, 0.4167],
@@ -45,8 +45,8 @@ mod tests {
     impl AdaptiveAvgPool2dTestCase {
         fn assert_output(self, x_grad: TestTensor<4>) {
             let shape_x = Shape::new([self.batch_size, self.channels, self.height, self.width]);
-            let x = TestAutodiffTensor::from_data(
-                TestTensorInt::arange(0..shape_x.num_elements())
+            let x = TestAutodiffTensor::from_data_default(
+                TestTensorInt::arange_default(0..shape_x.num_elements())
                     .reshape(shape_x)
                     .into_data()
                     .convert(),

--- a/burn-autodiff/src/tests/add.rs
+++ b/burn-autodiff/src/tests/add.rs
@@ -5,8 +5,8 @@ mod tests {
 
     #[test]
     fn should_diff_add() {
-        let tensor_1 = TestAutodiffTensor::from_floats([2.0, 5.0]).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_floats([4.0, 1.0]).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_floats_default([2.0, 5.0]).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_floats_default([4.0, 1.0]).require_grad();
 
         let tensor_3 = tensor_1.clone() + tensor_2.clone();
         let grads = tensor_3.backward();
@@ -23,7 +23,7 @@ mod tests {
     fn should_diff_add_scalar() {
         let data = Data::from([2.0, 10.0]);
 
-        let tensor = TestAutodiffTensor::from_data(data).require_grad();
+        let tensor = TestAutodiffTensor::from_data_default(data).require_grad();
         let tensor_out = tensor.clone().add_scalar(5.0);
         let grads = tensor_out.backward();
 
@@ -39,9 +39,9 @@ mod tests {
         let data_2: Data<f32, 2> = Data::from([[4.0, 7.0], [2.0, 3.0]]);
         let data_3: Data<f32, 2> = Data::from([[2.0, 2.0], [2.0, 2.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
-        let tensor_3 = TestAutodiffTensor::from_data(data_3).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
+        let tensor_3 = TestAutodiffTensor::from_data_default(data_3).require_grad();
 
         let tensor_4 = tensor_1.clone().add(tensor_2.clone());
         let tensor_5 = tensor_4

--- a/burn-autodiff/src/tests/aggregation.rs
+++ b/burn-autodiff/src/tests/aggregation.rs
@@ -8,8 +8,8 @@ mod tests {
         let data_1 = Data::<f32, 2>::from([[1.0, 7.0], [-2.0, -3.0]]);
         let data_2 = Data::<f32, 2>::from([[4.0, -7.0], [2.0, 3.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone());
         let tensor_4 = tensor_1.clone().mul(tensor_3.mean().unsqueeze());
@@ -31,8 +31,8 @@ mod tests {
         let data_1 = Data::<f32, 2>::from([[1.0, 7.0], [-2.0, -3.0]]);
         let data_2 = Data::<f32, 2>::from([[4.0, -7.0], [2.0, 3.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone());
         let tensor_4 = tensor_1.clone().mul(tensor_3.sum().unsqueeze());
@@ -54,8 +54,8 @@ mod tests {
         let data_1 = Data::from([[0.0, 1.0], [3.0, 4.0]]);
         let data_2 = Data::from([[6.0, 7.0], [9.0, 10.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone());
         let tensor_4 = tensor_3.clone().sum_dim(1);
@@ -78,8 +78,8 @@ mod tests {
         let data_1 = Data::<f32, 2>::from([[1.0, 7.0], [-2.0, -3.0]]);
         let data_2 = Data::<f32, 2>::from([[4.0, -7.0], [2.0, 3.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone());
         let tensor_4 = tensor_1.clone().mul(tensor_3.mean_dim(1).unsqueeze());
@@ -101,8 +101,8 @@ mod tests {
         let data_1 = Data::<f32, 2>::from([[1.0, 7.0], [-2.0, -3.0]]);
         let data_2 = Data::<f32, 2>::from([[4.0, -7.0], [2.0, 3.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone());
         let tensor_4 = tensor_1.clone().mul(tensor_3.sum_dim(1).unsqueeze());

--- a/burn-autodiff/src/tests/avgpool1d.rs
+++ b/burn-autodiff/src/tests/avgpool1d.rs
@@ -16,7 +16,7 @@ mod tests {
             count_include_pad: true,
         };
 
-        test.assert_output(TestTensor::from_floats([[[
+        test.assert_output(TestTensor::from_floats_default([[[
             0.3333, 0.6667, 1.0000, 1.0000, 0.6667, 0.3333,
         ]]]));
     }
@@ -33,7 +33,7 @@ mod tests {
             count_include_pad: true,
         };
 
-        test.assert_output(TestTensor::from_floats([[
+        test.assert_output(TestTensor::from_floats_default([[
             [0.3333, 0.6667, 0.3333, 0.6667, 0.3333, 0.3333],
             [0.3333, 0.6667, 0.3333, 0.6667, 0.3333, 0.3333],
         ]]));
@@ -51,7 +51,7 @@ mod tests {
             count_include_pad: false,
         };
 
-        test.assert_output(TestTensor::from_floats([[
+        test.assert_output(TestTensor::from_floats_default([[
             [0.5000, 0.8333, 0.3333, 0.6667, 0.3333, 0.3333],
             [0.5000, 0.8333, 0.3333, 0.6667, 0.3333, 0.3333],
         ]]));
@@ -70,8 +70,8 @@ mod tests {
     impl AvgPool1dTestCase {
         fn assert_output(self, x_grad: TestTensor<3>) {
             let shape_x = Shape::new([self.batch_size, self.channels, self.length]);
-            let x = TestAutodiffTensor::from_data(
-                TestTensorInt::arange(0..shape_x.num_elements())
+            let x = TestAutodiffTensor::from_data_default(
+                TestTensorInt::arange_default(0..shape_x.num_elements())
                     .reshape(shape_x)
                     .into_data()
                     .convert(),

--- a/burn-autodiff/src/tests/avgpool2d.rs
+++ b/burn-autodiff/src/tests/avgpool2d.rs
@@ -20,7 +20,7 @@ mod tests {
             count_include_pad: true,
         };
 
-        test.assert_output(TestTensor::from_floats([[[
+        test.assert_output(TestTensor::from_floats_default([[[
             [0.1111, 0.2222, 0.3333, 0.3333, 0.2222, 0.1111],
             [0.2222, 0.4444, 0.6667, 0.6667, 0.4444, 0.2222],
             [0.3333, 0.6667, 1.0000, 1.0000, 0.6667, 0.3333],
@@ -46,7 +46,7 @@ mod tests {
             count_include_pad: true,
         };
 
-        test.assert_output(TestTensor::from_floats([[[
+        test.assert_output(TestTensor::from_floats_default([[[
             [0.3333, 0.3333, 0.3333, 0.3333, 0.3333, 0.3333],
             [0.5000, 0.5000, 0.5000, 0.5000, 0.5000, 0.5000],
             [0.5000, 0.5000, 0.5000, 0.5000, 0.5000, 0.5000],
@@ -70,7 +70,7 @@ mod tests {
             count_include_pad: false,
         };
 
-        test.assert_output(TestTensor::from_floats([[[
+        test.assert_output(TestTensor::from_floats_default([[[
             [0.6250, 0.6250, 0.4167, 0.4167, 0.6250, 0.6250],
             [0.8750, 0.8750, 0.5833, 0.5833, 0.8750, 0.8750],
             [0.8750, 0.8750, 0.5833, 0.5833, 0.8750, 0.8750],
@@ -95,8 +95,8 @@ mod tests {
     impl AvgPool2dTestCase {
         fn assert_output(self, x_grad: TestTensor<4>) {
             let shape_x = Shape::new([self.batch_size, self.channels, self.height, self.width]);
-            let x = TestAutodiffTensor::from_data(
-                TestTensorInt::arange(0..shape_x.num_elements())
+            let x = TestAutodiffTensor::from_data_default(
+                TestTensorInt::arange_default(0..shape_x.num_elements())
                     .reshape(shape_x)
                     .into_data()
                     .convert(),

--- a/burn-autodiff/src/tests/backward.rs
+++ b/burn-autodiff/src/tests/backward.rs
@@ -11,9 +11,9 @@ mod tests {
             [[1.0, 2.0], [4.0, 5.0], [3.0, 4.0]],
             [[4.0, 5.0], [8.0, 5.0], [1.0, 9.0]],
         ]);
-        let weights = Tensor::<TestAutodiffBackend, 2>::from_data(weights).require_grad();
-        let indices = Tensor::<TestAutodiffBackend, 2, Int>::from_data(indices);
-        let x = Tensor::<TestAutodiffBackend, 3>::from_data(x).require_grad();
+        let weights = Tensor::<TestAutodiffBackend, 2>::from_data_default(weights).require_grad();
+        let indices = Tensor::<TestAutodiffBackend, 2, Int>::from_data_default(indices);
+        let x = Tensor::<TestAutodiffBackend, 3>::from_data_default(x).require_grad();
 
         let output = embedding(weights.clone(), indices);
         let output = output.matmul(x);

--- a/burn-autodiff/src/tests/broadcast.rs
+++ b/burn-autodiff/src/tests/broadcast.rs
@@ -37,8 +37,8 @@ mod tests {
     where
         F: Fn(TestAutodiffTensor<3>, TestAutodiffTensor<3>) -> TestAutodiffTensor<3>,
     {
-        let w = TestAutodiffTensor::zeros([16, 5, 5]).require_grad();
-        let x = TestAutodiffTensor::zeros([4, 5, 5]).require_grad();
+        let w = TestAutodiffTensor::zeros_default([16, 5, 5]).require_grad();
+        let x = TestAutodiffTensor::zeros_default([4, 5, 5]).require_grad();
 
         // Slice isn't a broadcastable operation, so it will fail when the previous backward pass
         // of an operation that support broadcast doesn't support it during the backward pass.

--- a/burn-autodiff/src/tests/cat.rs
+++ b/burn-autodiff/src/tests/cat.rs
@@ -5,8 +5,10 @@ mod tests {
 
     #[test]
     fn should_diff_cat() {
-        let tensor_1 = TestAutodiffTensor::from_data_default([[2.0, -1.0], [5.0, 2.0]]).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data_default([[5.0, 4.0], [-1.0, 4.0]]).require_grad();
+        let tensor_1 =
+            TestAutodiffTensor::from_data_default([[2.0, -1.0], [5.0, 2.0]]).require_grad();
+        let tensor_2 =
+            TestAutodiffTensor::from_data_default([[5.0, 4.0], [-1.0, 4.0]]).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone());
         let grads = tensor_3.backward();
@@ -57,9 +59,10 @@ mod tests {
 
     #[test]
     fn should_diff_cat_more_than_1_dim() {
-        let tensor_1 = TestAutodiffTensor::from_data_default([[2.0, -1.0], [5.0, 2.0]]).require_grad();
-        let tensor_2 =
-            TestAutodiffTensor::from_data_default([[5.0, 4.0], [-1.0, 4.0], [4.0, 1.0]]).require_grad();
+        let tensor_1 =
+            TestAutodiffTensor::from_data_default([[2.0, -1.0], [5.0, 2.0]]).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default([[5.0, 4.0], [-1.0, 4.0], [4.0, 1.0]])
+            .require_grad();
 
         // Concat a tensor [2, 2] with another tensor [3, 2] along dim 0.
         // The resulting tensor should be [5, 2]

--- a/burn-autodiff/src/tests/cat.rs
+++ b/burn-autodiff/src/tests/cat.rs
@@ -5,8 +5,8 @@ mod tests {
 
     #[test]
     fn should_diff_cat() {
-        let tensor_1 = TestAutodiffTensor::from_data([[2.0, -1.0], [5.0, 2.0]]).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data([[5.0, 4.0], [-1.0, 4.0]]).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default([[2.0, -1.0], [5.0, 2.0]]).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default([[5.0, 4.0], [-1.0, 4.0]]).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone());
         let grads = tensor_3.backward();
@@ -57,9 +57,9 @@ mod tests {
 
     #[test]
     fn should_diff_cat_more_than_1_dim() {
-        let tensor_1 = TestAutodiffTensor::from_data([[2.0, -1.0], [5.0, 2.0]]).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default([[2.0, -1.0], [5.0, 2.0]]).require_grad();
         let tensor_2 =
-            TestAutodiffTensor::from_data([[5.0, 4.0], [-1.0, 4.0], [4.0, 1.0]]).require_grad();
+            TestAutodiffTensor::from_data_default([[5.0, 4.0], [-1.0, 4.0], [4.0, 1.0]]).require_grad();
 
         // Concat a tensor [2, 2] with another tensor [3, 2] along dim 0.
         // The resulting tensor should be [5, 2]

--- a/burn-autodiff/src/tests/complex.rs
+++ b/burn-autodiff/src/tests/complex.rs
@@ -8,8 +8,8 @@ mod tests {
         let data_1: Data<f32, 2> = Data::from([[1.0, 7.0], [13.0, -3.0]]);
         let data_2: Data<f32, 2> = Data::from([[4.0, 7.0], [2.0, 3.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone());
         let tensor_4 = tensor_3.matmul(tensor_1.clone());
@@ -35,8 +35,8 @@ mod tests {
         let data_1: Data<f32, 2> = Data::from([[1.0, 7.0], [13.0, -3.0]]);
         let data_2: Data<f32, 2> = Data::from([[4.0, 7.0], [2.0, 3.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone());
         let tensor_4 = tensor_3.matmul(tensor_1.clone());
@@ -59,8 +59,8 @@ mod tests {
         let data_1: Data<f32, 2> = Data::from([[1.0, 7.0], [13.0, -3.0]]);
         let data_2: Data<f32, 2> = Data::from([[4.0, 7.0], [2.0, 3.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone());
         let tensor_4 = tensor_3.matmul(tensor_1.clone());

--- a/burn-autodiff/src/tests/conv1d.rs
+++ b/burn-autodiff/src/tests/conv1d.rs
@@ -17,15 +17,15 @@ mod tests {
             length: 4,
         };
         let grads = Grads {
-            x: TestTensor::from_floats([
+            x: TestTensor::from_floats_default([
                 [[14., 24., 24., 18.], [26., 42., 42., 30.]],
                 [[14., 24., 24., 18.], [26., 42., 42., 30.]],
             ]),
-            weight: TestTensor::from_floats([
+            weight: TestTensor::from_floats_default([
                 [[30., 44., 36.], [54., 76., 60.]],
                 [[30., 44., 36.], [54., 76., 60.]],
             ]),
-            bias: TestTensor::from_floats([8., 8.]),
+            bias: TestTensor::from_floats_default([8., 8.]),
         };
         test.assert_grads(grads);
     }
@@ -44,16 +44,16 @@ mod tests {
             length: 4,
         };
         let grads = Grads {
-            x: TestTensor::from_floats([
+            x: TestTensor::from_floats_default([
                 [[39., 63., 63., 45.], [57., 90., 90., 63.]],
                 [[39., 63., 63., 45.], [57., 90., 90., 63.]],
             ]),
-            weight: TestTensor::from_floats([
+            weight: TestTensor::from_floats_default([
                 [[30., 44., 36.], [54., 76., 60.]],
                 [[30., 44., 36.], [54., 76., 60.]],
                 [[30., 44., 36.], [54., 76., 60.]],
             ]),
-            bias: TestTensor::from_floats([8., 8., 8.]),
+            bias: TestTensor::from_floats_default([8., 8., 8.]),
         };
         test.assert_grads(grads);
     }
@@ -72,15 +72,15 @@ mod tests {
             length: 4,
         };
         let grads = Grads {
-            x: TestTensor::from_floats([
+            x: TestTensor::from_floats_default([
                 [[24., 24., 24., 24.], [42., 42., 42., 42.]],
                 [[24., 24., 24., 24.], [42., 42., 42., 42.]],
             ]),
-            weight: TestTensor::from_floats([
+            weight: TestTensor::from_floats_default([
                 [[44., 44., 44.], [76., 76., 76.]],
                 [[44., 44., 44.], [76., 76., 76.]],
             ]),
-            bias: TestTensor::from_floats([12., 12.]),
+            bias: TestTensor::from_floats_default([12., 12.]),
         };
         test.assert_grads(grads);
     }
@@ -99,15 +99,15 @@ mod tests {
             length: 4,
         };
         let grads = Grads {
-            x: TestTensor::from_floats([
+            x: TestTensor::from_floats_default([
                 [[8., 16., 8., 10.], [14., 28., 14., 16.]],
                 [[8., 16., 8., 10.], [14., 28., 14., 16.]],
             ]),
-            weight: TestTensor::from_floats([
+            weight: TestTensor::from_floats_default([
                 [[10., 20., 24.], [18., 36., 40.]],
                 [[10., 20., 24.], [18., 36., 40.]],
             ]),
-            bias: TestTensor::from_floats([4., 4.]),
+            bias: TestTensor::from_floats_default([4., 4.]),
         };
         test.assert_grads(grads);
     }
@@ -126,15 +126,15 @@ mod tests {
             length: 4,
         };
         let grads = Grads {
-            x: TestTensor::from_floats([
+            x: TestTensor::from_floats_default([
                 [[6., 8., 8., 10.], [12., 14., 14., 16.]],
                 [[6., 8., 8., 10.], [12., 14., 14., 16.]],
             ]),
-            weight: TestTensor::from_floats([
+            weight: TestTensor::from_floats_default([
                 [[8., 22., 14.], [16., 38., 22.]],
                 [[8., 22., 14.], [16., 38., 22.]],
             ]),
-            bias: TestTensor::from_floats([4., 4.]),
+            bias: TestTensor::from_floats_default([4., 4.]),
         };
         test.assert_grads(grads);
     }
@@ -153,12 +153,12 @@ mod tests {
             length: 4,
         };
         let grads = Grads {
-            x: TestTensor::from_floats([
+            x: TestTensor::from_floats_default([
                 [[1., 3., 3., 3.], [7., 12., 12., 9.]],
                 [[1., 3., 3., 3.], [7., 12., 12., 9.]],
             ]),
-            weight: TestTensor::from_floats([[[30., 44., 36.]], [[54., 76., 60.]]]),
-            bias: TestTensor::from_floats([8., 8.]),
+            weight: TestTensor::from_floats_default([[[30., 44., 36.]], [[54., 76., 60.]]]),
+            bias: TestTensor::from_floats_default([8., 8.]),
         };
         test.assert_grads(grads);
     }
@@ -189,21 +189,21 @@ mod tests {
                 self.channels_in / self.groups,
                 self.kernel_size,
             ]);
-            let weight = TestAutodiffTensor::from_data(
-                TestTensorInt::arange(0..shape_weight.num_elements())
+            let weight = TestAutodiffTensor::from_data_default(
+                TestTensorInt::arange_default(0..shape_weight.num_elements())
                     .reshape(shape_weight)
                     .into_data()
                     .convert(),
             )
             .require_grad();
-            let bias = TestAutodiffTensor::from_data(
-                TestTensorInt::arange(0..self.channels_out)
+            let bias = TestAutodiffTensor::from_data_default(
+                TestTensorInt::arange_default(0..self.channels_out)
                     .into_data()
                     .convert(),
             )
             .require_grad();
-            let x = TestAutodiffTensor::from_data(
-                TestTensorInt::arange(0..shape_x.num_elements())
+            let x = TestAutodiffTensor::from_data_default(
+                TestTensorInt::arange_default(0..shape_x.num_elements())
                     .reshape(shape_x)
                     .into_data()
                     .convert(),

--- a/burn-autodiff/src/tests/conv2d.rs
+++ b/burn-autodiff/src/tests/conv2d.rs
@@ -22,7 +22,7 @@ mod tests {
             width: 4,
         };
         let grads = Grads {
-            x: TestTensor::from_floats([
+            x: TestTensor::from_floats_default([
                 [
                     [
                         [88., 138., 138., 96.],
@@ -52,7 +52,7 @@ mod tests {
                     ],
                 ],
             ]),
-            weight: TestTensor::from_floats([
+            weight: TestTensor::from_floats_default([
                 [
                     [[378., 516., 396.], [552., 752., 576.], [450., 612., 468.]],
                     [[666., 900., 684.], [936., 1264., 960.], [738., 996., 756.]],
@@ -62,7 +62,7 @@ mod tests {
                     [[666., 900., 684.], [936., 1264., 960.], [738., 996., 756.]],
                 ],
             ]),
-            bias: TestTensor::from_floats([32., 32.]),
+            bias: TestTensor::from_floats_default([32., 32.]),
         };
         test.assert_grads(grads);
     }
@@ -86,7 +86,7 @@ mod tests {
             width: 4,
         };
         let grads = Grads {
-            x: TestTensor::from_floats([
+            x: TestTensor::from_floats_default([
                 [
                     [
                         [240., 369., 369., 252.],
@@ -116,7 +116,7 @@ mod tests {
                     ],
                 ],
             ]),
-            weight: TestTensor::from_floats([
+            weight: TestTensor::from_floats_default([
                 [
                     [[378., 516., 396.], [552., 752., 576.], [450., 612., 468.]],
                     [[666., 900., 684.], [936., 1264., 960.], [738., 996., 756.]],
@@ -130,7 +130,7 @@ mod tests {
                     [[666., 900., 684.], [936., 1264., 960.], [738., 996., 756.]],
                 ],
             ]),
-            bias: TestTensor::from_floats([32., 32., 32.]),
+            bias: TestTensor::from_floats_default([32., 32., 32.]),
         };
         test.assert_grads(grads);
     }
@@ -154,7 +154,7 @@ mod tests {
             width: 4,
         };
         let grads = Grads {
-            x: TestTensor::from_floats([[
+            x: TestTensor::from_floats_default([[
                 [
                     [116., 180., 192., 132.],
                     [198., 306., 324., 222.],
@@ -168,7 +168,7 @@ mod tests {
                     [244., 372., 384., 260.],
                 ],
             ]]),
-            weight: TestTensor::from_floats([
+            weight: TestTensor::from_floats_default([
                 [
                     [
                         [27., 45., 54., 39.],
@@ -194,7 +194,7 @@ mod tests {
                     ],
                 ],
             ]),
-            bias: TestTensor::from_floats([12., 12.]),
+            bias: TestTensor::from_floats_default([12., 12.]),
         };
         test.assert_grads(grads);
     }
@@ -218,7 +218,7 @@ mod tests {
             width: 4,
         };
         let grads = Grads {
-            x: TestTensor::from_floats([[
+            x: TestTensor::from_floats_default([[
                 [
                     [138., 138., 138., 138.],
                     [234., 234., 234., 234.],
@@ -232,7 +232,7 @@ mod tests {
                     [282., 282., 282., 282.],
                 ],
             ]]),
-            weight: TestTensor::from_floats([
+            weight: TestTensor::from_floats_default([
                 [
                     [[66., 66., 66.], [120., 120., 120.], [114., 114., 114.]],
                     [[258., 258., 258.], [376., 376., 376.], [306., 306., 306.]],
@@ -242,7 +242,7 @@ mod tests {
                     [[258., 258., 258.], [376., 376., 376.], [306., 306., 306.]],
                 ],
             ]),
-            bias: TestTensor::from_floats([24., 24.]),
+            bias: TestTensor::from_floats_default([24., 24.]),
         };
         test.assert_grads(grads);
     }
@@ -266,7 +266,7 @@ mod tests {
             width: 5,
         };
         let grads = Grads {
-            x: TestTensor::from_floats([[
+            x: TestTensor::from_floats_default([[
                 [
                     [88., 138., 138., 138., 96.],
                     [150., 234., 234., 234., 162.],
@@ -280,7 +280,7 @@ mod tests {
                     [184., 282., 282., 282., 192.],
                 ],
             ]]),
-            weight: TestTensor::from_floats([
+            weight: TestTensor::from_floats_default([
                 [
                     [[78., 105., 90.], [144., 190., 160.], [138., 180., 150.]],
                     [[318., 405., 330.], [464., 590., 480.], [378., 480., 390.]],
@@ -290,7 +290,7 @@ mod tests {
                     [[318., 405., 330.], [464., 590., 480.], [378., 480., 390.]],
                 ],
             ]),
-            bias: TestTensor::from_floats([20., 20.]),
+            bias: TestTensor::from_floats_default([20., 20.]),
         };
         test.assert_grads(grads);
     }
@@ -314,7 +314,7 @@ mod tests {
             width: 6,
         };
         let grads = Grads {
-            x: TestTensor::from_floats([[
+            x: TestTensor::from_floats_default([[
                 [
                     [26., 52., 26., 52., 26., 28.],
                     [52., 104., 52., 104., 52., 56.],
@@ -332,7 +332,7 @@ mod tests {
                     [50., 100., 50., 100., 50., 52.],
                 ],
             ]]),
-            weight: TestTensor::from_floats([
+            weight: TestTensor::from_floats_default([
                 [
                     [[56., 84., 90.], [84., 126., 135.], [120., 180., 189.]],
                     [[200., 300., 306.], [300., 450., 459.], [336., 504., 513.]],
@@ -342,7 +342,7 @@ mod tests {
                     [[200., 300., 306.], [300., 450., 459.], [336., 504., 513.]],
                 ],
             ]),
-            bias: TestTensor::from_floats([9., 9.]),
+            bias: TestTensor::from_floats_default([9., 9.]),
         };
         test.assert_grads(grads);
     }
@@ -366,7 +366,7 @@ mod tests {
             width: 8,
         };
         let grads = Grads {
-            x: TestTensor::from_floats([[
+            x: TestTensor::from_floats_default([[
                 [
                     [50., 78., 78., 78., 78., 78., 78., 54.],
                     [62., 96., 96., 96., 96., 96., 96., 66.],
@@ -388,7 +388,7 @@ mod tests {
                     [98., 150., 150., 150., 150., 150., 150., 102.],
                 ],
             ]]),
-            weight: TestTensor::from_floats([
+            weight: TestTensor::from_floats_default([
                 [
                     [[434., 504., 448.], [567., 660., 588.], [735., 852., 756.]],
                     [
@@ -406,7 +406,7 @@ mod tests {
                     ],
                 ],
             ]),
-            bias: TestTensor::from_floats([24., 24.]),
+            bias: TestTensor::from_floats_default([24., 24.]),
         };
         test.assert_grads(grads);
     }
@@ -430,7 +430,7 @@ mod tests {
             width: 6,
         };
         let grads = Grads {
-            x: TestTensor::from_floats([[
+            x: TestTensor::from_floats_default([[
                 [
                     [18., 38., 38., 42., 42., 22.],
                     [42., 88., 88., 96., 96., 50.],
@@ -448,7 +448,7 @@ mod tests {
                     [48., 98., 98., 102., 102., 52.],
                 ],
             ]]),
-            weight: TestTensor::from_floats([
+            weight: TestTensor::from_floats_default([
                 [
                     [[63., 102., 90.], [192., 280., 228.], [225., 318., 252.]],
                     [[387., 534., 414.], [624., 856., 660.], [549., 750., 576.]],
@@ -458,7 +458,7 @@ mod tests {
                     [[387., 534., 414.], [624., 856., 660.], [549., 750., 576.]],
                 ],
             ]),
-            bias: TestTensor::from_floats([16., 16.]),
+            bias: TestTensor::from_floats_default([16., 16.]),
         };
         test.assert_grads(grads);
     }
@@ -482,7 +482,7 @@ mod tests {
             width: 6,
         };
         let grads = Grads {
-            x: TestTensor::from_floats([[
+            x: TestTensor::from_floats_default([[
                 [
                     [18., 0., 20., 20., 0., 22.],
                     [42., 0., 46., 46., 0., 50.],
@@ -500,7 +500,7 @@ mod tests {
                     [48., 0., 50., 50., 0., 52.],
                 ],
             ]]),
-            weight: TestTensor::from_floats([
+            weight: TestTensor::from_floats_default([
                 [
                     [[18., 51., 33.], [60., 140., 80.], [72., 159., 87.]],
                     [[126., 267., 141.], [204., 428., 224.], [180., 375., 195.]],
@@ -510,7 +510,7 @@ mod tests {
                     [[126., 267., 141.], [204., 428., 224.], [180., 375., 195.]],
                 ],
             ]),
-            bias: TestTensor::from_floats([8., 8.]),
+            bias: TestTensor::from_floats_default([8., 8.]),
         };
         test.assert_grads(grads);
     }
@@ -534,7 +534,7 @@ mod tests {
             width: 5,
         };
         let grads = Grads {
-            x: TestTensor::from_floats([[
+            x: TestTensor::from_floats_default([[
                 [
                     [0., 1., 3., 3., 2.],
                     [3., 8., 15., 12., 7.],
@@ -550,11 +550,11 @@ mod tests {
                     [15., 31., 48., 33., 17.],
                 ],
             ]]),
-            weight: TestTensor::from_floats([
+            weight: TestTensor::from_floats_default([
                 [[[54., 63., 72.], [99., 108., 117.], [144., 153., 162.]]],
                 [[[279., 288., 297.], [324., 333., 342.], [369., 378., 387.]]],
             ]),
-            bias: TestTensor::from_floats([9., 9.]),
+            bias: TestTensor::from_floats_default([9., 9.]),
         };
         test.assert_grads(grads);
     }
@@ -578,7 +578,7 @@ mod tests {
             width: 4,
         };
         let grads = Grads {
-            x: TestTensor::from_floats([[
+            x: TestTensor::from_floats_default([[
                 [
                     [9., 20., 24., 13.],
                     [24., 52., 60., 32.],
@@ -598,7 +598,7 @@ mod tests {
                     [93., 188., 192., 97.],
                 ],
             ]]),
-            weight: TestTensor::from_floats([
+            weight: TestTensor::from_floats_default([
                 [[[10., 14., 18.], [26., 30., 34.], [42., 46., 50.]]],
                 [[[10., 14., 18.], [26., 30., 34.], [42., 46., 50.]]],
                 [[[74., 78., 82.], [90., 94., 98.], [106., 110., 114.]]],
@@ -606,7 +606,7 @@ mod tests {
                 [[[138., 142., 146.], [154., 158., 162.], [170., 174., 178.]]],
                 [[[138., 142., 146.], [154., 158., 162.], [170., 174., 178.]]],
             ]),
-            bias: TestTensor::from_floats([4., 4., 4., 4., 4., 4.]),
+            bias: TestTensor::from_floats_default([4., 4., 4., 4., 4., 4.]),
         };
         test.assert_grads(grads);
     }
@@ -630,7 +630,7 @@ mod tests {
             width: 5,
         };
         let grads = Grads {
-            x: TestTensor::from_floats([[
+            x: TestTensor::from_floats_default([[
                 [
                     [36., 39., 0., 39., 42.],
                     [81., 87., 0., 87., 93.],
@@ -644,7 +644,7 @@ mod tests {
                     [63., 66., 0., 66., 69.],
                 ],
             ]]),
-            weight: TestTensor::from_floats([
+            weight: TestTensor::from_floats_default([
                 [
                     [[15., 42., 27.], [30., 72., 42.]],
                     [[75., 162., 87.], [90., 192., 102.]],
@@ -658,7 +658,7 @@ mod tests {
                     [[75., 162., 87.], [90., 192., 102.]],
                 ],
             ]),
-            bias: TestTensor::from_floats([8., 8., 8.]),
+            bias: TestTensor::from_floats_default([8., 8., 8.]),
         };
         test.assert_grads(grads);
     }
@@ -695,21 +695,21 @@ mod tests {
                 self.kernel_size_1,
                 self.kernel_size_2,
             ]);
-            let weight = TestAutodiffTensor::from_data(
-                TestTensorInt::arange(0..shape_weight.num_elements())
+            let weight = TestAutodiffTensor::from_data_default(
+                TestTensorInt::arange_default(0..shape_weight.num_elements())
                     .reshape(shape_weight)
                     .into_data()
                     .convert(),
             )
             .require_grad();
-            let bias = TestAutodiffTensor::from_data(
-                TestTensorInt::arange(0..self.channels_out)
+            let bias = TestAutodiffTensor::from_data_default(
+                TestTensorInt::arange_default(0..self.channels_out)
                     .into_data()
                     .convert(),
             )
             .require_grad();
-            let x = TestAutodiffTensor::from_data(
-                TestTensorInt::arange(0..shape_x.num_elements())
+            let x = TestAutodiffTensor::from_data_default(
+                TestTensorInt::arange_default(0..shape_x.num_elements())
                     .reshape(shape_x)
                     .into_data()
                     .convert(),

--- a/burn-autodiff/src/tests/conv_transpose1d.rs
+++ b/burn-autodiff/src/tests/conv_transpose1d.rs
@@ -17,15 +17,15 @@ mod tests {
             size: 4,
         };
         let grads = Grads {
-            x: TestTensor::from_floats([
+            x: TestTensor::from_floats_default([
                 [[15.0, 15.0, 15.0, 15.0], [51.0, 51.0, 51.0, 51.0]],
                 [[15.0, 15.0, 15.0, 15.0], [51.0, 51.0, 51.0, 51.0]],
             ]),
-            weight: TestTensor::from_floats([
+            weight: TestTensor::from_floats_default([
                 [[44.0, 44.0, 44.0], [44.0, 44.0, 44.0]],
                 [[76.0, 76.0, 76.0], [76.0, 76.0, 76.0]],
             ]),
-            bias: TestTensor::from_floats([12., 12.]),
+            bias: TestTensor::from_floats_default([12., 12.]),
         };
         test.assert_grads(grads);
     }
@@ -44,15 +44,15 @@ mod tests {
             size: 4,
         };
         let grads = Grads {
-            x: TestTensor::from_floats([
+            x: TestTensor::from_floats_default([
                 [[7., 12., 8., 3.], [19., 36., 32., 15.]],
                 [[7., 12., 8., 3.], [19., 36., 32., 15.]],
             ]),
-            weight: TestTensor::from_floats([
+            weight: TestTensor::from_floats_default([
                 [[26., 22., 18.], [26., 22., 18.]],
                 [[42., 38., 34.], [42., 38., 34.]],
             ]),
-            bias: TestTensor::from_floats([4., 4.]),
+            bias: TestTensor::from_floats_default([4., 4.]),
         };
         test.assert_grads(grads);
     }
@@ -71,15 +71,15 @@ mod tests {
             size: 4,
         };
         let grads = Grads {
-            x: TestTensor::from_floats([
+            x: TestTensor::from_floats_default([
                 [[15., 15., 15., 15.], [51., 51., 51., 51.]],
                 [[15., 15., 15., 15.], [51., 51., 51., 51.]],
             ]),
-            weight: TestTensor::from_floats([
+            weight: TestTensor::from_floats_default([
                 [[44., 44., 44.], [44., 44., 44.]],
                 [[76., 76., 76.], [76., 76., 76.]],
             ]),
-            bias: TestTensor::from_floats([18., 18.]),
+            bias: TestTensor::from_floats_default([18., 18.]),
         };
         test.assert_grads(grads);
     }
@@ -98,15 +98,15 @@ mod tests {
             size: 4,
         };
         let grads = Grads {
-            x: TestTensor::from_floats([
+            x: TestTensor::from_floats_default([
                 [[15., 15., 15., 15.], [51., 51., 51., 51.]],
                 [[15., 15., 15., 15.], [51., 51., 51., 51.]],
             ]),
-            weight: TestTensor::from_floats([
+            weight: TestTensor::from_floats_default([
                 [[44., 44., 44.], [44., 44., 44.]],
                 [[76., 76., 76.], [76., 76., 76.]],
             ]),
-            bias: TestTensor::from_floats([20., 20.]),
+            bias: TestTensor::from_floats_default([20., 20.]),
         };
         test.assert_grads(grads);
     }
@@ -125,15 +125,15 @@ mod tests {
             size: 4,
         };
         let grads = Grads {
-            x: TestTensor::from_floats([
+            x: TestTensor::from_floats_default([
                 [[15., 15., 15., 15.], [51., 51., 51., 51.]],
                 [[15., 15., 15., 15.], [51., 51., 51., 51.]],
             ]),
-            weight: TestTensor::from_floats([
+            weight: TestTensor::from_floats_default([
                 [[44., 44., 44.], [44., 44., 44.]],
                 [[76., 76., 76.], [76., 76., 76.]],
             ]),
-            bias: TestTensor::from_floats([16., 16.]),
+            bias: TestTensor::from_floats_default([16., 16.]),
         };
         test.assert_grads(grads);
     }
@@ -152,7 +152,7 @@ mod tests {
             size: 8,
         };
         let grads = Grads {
-            x: TestTensor::from_floats([
+            x: TestTensor::from_floats_default([
                 [
                     [12.0, 15.0, 15.0, 15.0, 15.0, 15.0, 15.0, 15.0],
                     [36.0, 51.0, 51.0, 51.0, 51.0, 51.0, 51.0, 51.0],
@@ -162,11 +162,11 @@ mod tests {
                     [36.0, 51.0, 51.0, 51.0, 51.0, 51.0, 51.0, 51.0],
                 ],
             ]),
-            weight: TestTensor::from_floats([
+            weight: TestTensor::from_floats_default([
                 [[168.0, 184.0, 184.0], [168.0, 184.0, 184.0]],
                 [[280.0, 312.0, 312.0], [280.0, 312.0, 312.0]],
             ]),
-            bias: TestTensor::from_floats([36.0, 36.0, 36.0, 36.0]),
+            bias: TestTensor::from_floats_default([36.0, 36.0, 36.0, 36.0]),
         };
         test.assert_grads(grads);
     }
@@ -197,21 +197,21 @@ mod tests {
                 self.channels[1] / self.groups,
                 self.kernel_size,
             ]);
-            let weight = TestAutodiffTensor::from_data(
-                TestTensorInt::arange(0..shape_weight.num_elements())
+            let weight = TestAutodiffTensor::from_data_default(
+                TestTensorInt::arange_default(0..shape_weight.num_elements())
                     .reshape(shape_weight)
                     .into_data()
                     .convert(),
             )
             .require_grad();
-            let bias = TestAutodiffTensor::from_data(
-                TestTensorInt::arange(0..self.channels[1])
+            let bias = TestAutodiffTensor::from_data_default(
+                TestTensorInt::arange_default(0..self.channels[1])
                     .into_data()
                     .convert(),
             )
             .require_grad();
-            let x = TestAutodiffTensor::from_data(
-                TestTensorInt::arange(0..shape_x.num_elements())
+            let x = TestAutodiffTensor::from_data_default(
+                TestTensorInt::arange_default(0..shape_x.num_elements())
                     .reshape(shape_x)
                     .into_data()
                     .convert(),

--- a/burn-autodiff/src/tests/conv_transpose2d.rs
+++ b/burn-autodiff/src/tests/conv_transpose2d.rs
@@ -17,7 +17,7 @@ mod tests {
             size: [4, 4],
         };
         let grads = Grads {
-            x: TestTensor::from_floats([
+            x: TestTensor::from_floats_default([
                 [
                     [
                         [153., 153., 153., 153.],
@@ -47,7 +47,7 @@ mod tests {
                     ],
                 ],
             ]),
-            weight: TestTensor::from_floats([
+            weight: TestTensor::from_floats_default([
                 [
                     [[752., 752., 752.], [752., 752., 752.], [752., 752., 752.]],
                     [[752., 752., 752.], [752., 752., 752.], [752., 752., 752.]],
@@ -65,7 +65,7 @@ mod tests {
                     ],
                 ],
             ]),
-            bias: TestTensor::from_floats([72., 72.]),
+            bias: TestTensor::from_floats_default([72., 72.]),
         };
         test.assert_grads(grads);
     }
@@ -84,18 +84,18 @@ mod tests {
             size: [4, 4],
         };
         let grads = Grads {
-            x: TestTensor::from_floats([[[
+            x: TestTensor::from_floats_default([[[
                 [13., 24., 20., 9.],
                 [15., 27., 21., 9.],
                 [15., 27., 21., 9.],
                 [7., 12., 8., 3.],
             ]]]),
-            weight: TestTensor::from_floats([[[
+            weight: TestTensor::from_floats_default([[[
                 [63., 57., 51.],
                 [68., 60., 52.],
                 [39., 33., 27.],
             ]]]),
-            bias: TestTensor::from_floats([8.]),
+            bias: TestTensor::from_floats_default([8.]),
         };
         test.assert_grads(grads);
     }
@@ -114,18 +114,18 @@ mod tests {
             size: [4, 4],
         };
         let grads = Grads {
-            x: TestTensor::from_floats([[[
+            x: TestTensor::from_floats_default([[[
                 [36., 36., 36., 36.],
                 [36., 36., 36., 36.],
                 [36., 36., 36., 36.],
                 [36., 36., 36., 36.],
             ]]]),
-            weight: TestTensor::from_floats([[[
+            weight: TestTensor::from_floats_default([[[
                 [120., 120., 120.],
                 [120., 120., 120.],
                 [120., 120., 120.],
             ]]]),
-            bias: TestTensor::from_floats([108.]),
+            bias: TestTensor::from_floats_default([108.]),
         };
         test.assert_grads(grads);
     }
@@ -144,18 +144,18 @@ mod tests {
             size: [4, 4],
         };
         let grads = Grads {
-            x: TestTensor::from_floats([[[
+            x: TestTensor::from_floats_default([[[
                 [36., 36., 36., 36.],
                 [36., 36., 36., 36.],
                 [36., 36., 36., 36.],
                 [36., 36., 36., 36.],
             ]]]),
-            weight: TestTensor::from_floats([[[
+            weight: TestTensor::from_floats_default([[[
                 [120., 120., 120.],
                 [120., 120., 120.],
                 [120., 120., 120.],
             ]]]),
-            bias: TestTensor::from_floats([140.]),
+            bias: TestTensor::from_floats_default([140.]),
         };
         test.assert_grads(grads);
     }
@@ -174,18 +174,18 @@ mod tests {
             size: [4, 4],
         };
         let grads = Grads {
-            x: TestTensor::from_floats([[[
+            x: TestTensor::from_floats_default([[[
                 [36., 36., 36., 36.],
                 [36., 36., 36., 36.],
                 [36., 36., 36., 36.],
                 [36., 36., 36., 36.],
             ]]]),
-            weight: TestTensor::from_floats([[[
+            weight: TestTensor::from_floats_default([[[
                 [120., 120., 120.],
                 [120., 120., 120.],
                 [120., 120., 120.],
             ]]]),
-            bias: TestTensor::from_floats([80.]),
+            bias: TestTensor::from_floats_default([80.]),
         };
         test.assert_grads(grads);
     }
@@ -204,7 +204,7 @@ mod tests {
             size: [4, 4],
         };
         let grads = Grads {
-            x: TestTensor::from_floats([[
+            x: TestTensor::from_floats_default([[
                 [
                     [351., 351., 351., 351.],
                     [351., 351., 351., 351.],
@@ -218,7 +218,7 @@ mod tests {
                     [1080., 1080., 1080., 1080.],
                 ],
             ]]),
-            weight: TestTensor::from_floats([
+            weight: TestTensor::from_floats_default([
                 [
                     [[120., 120., 120.], [120., 120., 120.], [120., 120., 120.]],
                     [[120., 120., 120.], [120., 120., 120.], [120., 120., 120.]],
@@ -230,7 +230,7 @@ mod tests {
                     [[376., 376., 376.], [376., 376., 376.], [376., 376., 376.]],
                 ],
             ]),
-            bias: TestTensor::from_floats([36., 36., 36.]),
+            bias: TestTensor::from_floats_default([36., 36., 36.]),
         };
         test.assert_grads(grads);
     }
@@ -249,7 +249,7 @@ mod tests {
             size: [6, 6],
         };
         let grads = Grads {
-            x: TestTensor::from_floats([[[
+            x: TestTensor::from_floats_default([[[
                 [105., 105., 105., 105., 105., 105.],
                 [105., 105., 105., 105., 105., 105.],
                 [105., 105., 105., 105., 105., 105.],
@@ -257,12 +257,12 @@ mod tests {
                 [105., 105., 105., 105., 105., 105.],
                 [105., 105., 105., 105., 105., 105.],
             ]]]),
-            weight: TestTensor::from_floats([[[
+            weight: TestTensor::from_floats_default([[[
                 [630., 630., 630., 630., 630.],
                 [630., 630., 630., 630., 630.],
                 [630., 630., 630., 630., 630.],
             ]]]),
-            bias: TestTensor::from_floats([80.]),
+            bias: TestTensor::from_floats_default([80.]),
         };
         test.assert_grads(grads);
     }
@@ -281,7 +281,7 @@ mod tests {
             size: [4, 4],
         };
         let grads = Grads {
-            x: TestTensor::from_floats([[
+            x: TestTensor::from_floats_default([[
                 [
                     [36., 36., 36., 36.],
                     [36., 36., 36., 36.],
@@ -295,11 +295,11 @@ mod tests {
                     [117., 117., 117., 117.],
                 ],
             ]]),
-            weight: TestTensor::from_floats([
+            weight: TestTensor::from_floats_default([
                 [[[120., 120., 120.], [120., 120., 120.], [120., 120., 120.]]],
                 [[[376., 376., 376.], [376., 376., 376.], [376., 376., 376.]]],
             ]),
-            bias: TestTensor::from_floats([36., 36.]),
+            bias: TestTensor::from_floats_default([36., 36.]),
         };
         test.assert_grads(grads);
     }
@@ -318,7 +318,7 @@ mod tests {
             size: [6, 8],
         };
         let grads = Grads {
-            x: TestTensor::from_floats([
+            x: TestTensor::from_floats_default([
                 [
                     [
                         [600., 735., 735., 735., 735., 735., 735., 735.],
@@ -356,7 +356,7 @@ mod tests {
                     ],
                 ],
             ]),
-            weight: TestTensor::from_floats([
+            weight: TestTensor::from_floats_default([
                 [
                     [
                         [5320., 6040., 6040., 6040., 6040.],
@@ -392,7 +392,7 @@ mod tests {
                     ],
                 ],
             ]),
-            bias: TestTensor::from_floats([896., 896., 896.]),
+            bias: TestTensor::from_floats_default([896., 896., 896.]),
         };
         test.assert_grads(grads);
     }
@@ -411,7 +411,7 @@ mod tests {
             size: [10, 10],
         };
         let grads = Grads {
-            x: TestTensor::from_floats([[
+            x: TestTensor::from_floats_default([[
                 [
                     [30., 42., 42., 42., 42., 42., 42., 42., 42., 42.],
                     [48., 66., 66., 66., 66., 66., 66., 66., 66., 66.],
@@ -461,7 +461,7 @@ mod tests {
                     [336., 498., 498., 498., 498., 498., 498., 498., 498., 498.],
                 ],
             ]]),
-            weight: TestTensor::from_floats([
+            weight: TestTensor::from_floats_default([
                 [
                     [[4455., 4905., 4905.], [4500., 4950., 4950.]],
                     [[4455., 4905., 4905.], [4500., 4950., 4950.]],
@@ -479,7 +479,7 @@ mod tests {
                     [[28755., 31905., 31905.], [31500., 34950., 34950.]],
                 ],
             ]),
-            bias: TestTensor::from_floats([570., 570.]),
+            bias: TestTensor::from_floats_default([570., 570.]),
         };
         test.assert_grads(grads);
     }
@@ -498,7 +498,7 @@ mod tests {
             size: [10, 10],
         };
         let grads = Grads {
-            x: TestTensor::from_floats([[
+            x: TestTensor::from_floats_default([[
                 [
                     [9., 12., 12., 12., 12., 12., 12., 12., 12., 12.],
                     [12., 15., 15., 15., 15., 15., 15., 15., 15., 15.],
@@ -548,13 +548,13 @@ mod tests {
                     [84., 123., 123., 123., 123., 123., 123., 123., 123., 123.],
                 ],
             ]]),
-            weight: TestTensor::from_floats([
+            weight: TestTensor::from_floats_default([
                 [[[4455., 4905., 4905.], [4500., 4950., 4950.]]],
                 [[[12555., 13905., 13905.], [13500., 14950., 14950.]]],
                 [[[20655., 22905., 22905.], [22500., 24950., 24950.]]],
                 [[[28755., 31905., 31905.], [31500., 34950., 34950.]]],
             ]),
-            bias: TestTensor::from_floats([570., 570.]),
+            bias: TestTensor::from_floats_default([570., 570.]),
         };
         test.assert_grads(grads);
     }
@@ -591,21 +591,21 @@ mod tests {
                 self.kernel_size[0],
                 self.kernel_size[1],
             ]);
-            let weight = TestAutodiffTensor::from_data(
-                TestTensorInt::arange(0..shape_weight.num_elements())
+            let weight = TestAutodiffTensor::from_data_default(
+                TestTensorInt::arange_default(0..shape_weight.num_elements())
                     .reshape(shape_weight)
                     .into_data()
                     .convert(),
             )
             .require_grad();
-            let bias = TestAutodiffTensor::from_data(
-                TestTensorInt::arange(0..self.channels[1])
+            let bias = TestAutodiffTensor::from_data_default(
+                TestTensorInt::arange_default(0..self.channels[1])
                     .into_data()
                     .convert(),
             )
             .require_grad();
-            let x = TestAutodiffTensor::from_data(
-                TestTensorInt::arange(0..shape_x.num_elements())
+            let x = TestAutodiffTensor::from_data_default(
+                TestTensorInt::arange_default(0..shape_x.num_elements())
                     .reshape(shape_x)
                     .into_data()
                     .convert(),

--- a/burn-autodiff/src/tests/cos.rs
+++ b/burn-autodiff/src/tests/cos.rs
@@ -8,8 +8,8 @@ mod tests {
         let data_1 = Data::<f32, 2>::from([[0.0, 1.0], [3.0, 4.0]]);
         let data_2 = Data::<f32, 2>::from([[6.0, 7.0], [9.0, 10.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone().cos());
         let tensor_4 = tensor_3.matmul(tensor_2.clone());

--- a/burn-autodiff/src/tests/cross_entropy.rs
+++ b/burn-autodiff/src/tests/cross_entropy.rs
@@ -9,10 +9,10 @@ mod tests {
         let data_2 = Data::from([[6.0, 7.0], [9.0, 10.0]]);
         let data_targets = Data::from([[0.8, 0.2], [0.9, 0.1]]);
 
-        let tensor_1 = Tensor::<TestAutodiffBackend, 2>::from_data(data_1).require_grad();
-        let tensor_2 = Tensor::<TestAutodiffBackend, 2>::from_data(data_2).require_grad();
+        let tensor_1 = Tensor::<TestAutodiffBackend, 2>::from_data_default(data_1).require_grad();
+        let tensor_2 = Tensor::<TestAutodiffBackend, 2>::from_data_default(data_2).require_grad();
         let tensor_targets =
-            Tensor::<TestAutodiffBackend, 2>::from_data(data_targets).require_grad();
+            Tensor::<TestAutodiffBackend, 2>::from_data_default(data_targets).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone());
         let tensor_4 = loss::cross_entropy_with_logits(tensor_3, tensor_targets);

--- a/burn-autodiff/src/tests/div.rs
+++ b/burn-autodiff/src/tests/div.rs
@@ -8,8 +8,8 @@ mod tests {
         let data_1 = Data::from([1.0, 7.0]);
         let data_2 = Data::from([4.0, 7.0]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
 
         let tensor_3 = tensor_1.clone().div(tensor_2.clone());
         let grads = tensor_3.backward();
@@ -29,7 +29,7 @@ mod tests {
     fn should_diff_div_scalar() {
         let data = Data::from([1.0, 7.0]);
 
-        let tensor = TestAutodiffTensor::from_data(data).require_grad();
+        let tensor = TestAutodiffTensor::from_data_default(data).require_grad();
         let tensor_out = tensor.clone().div_scalar(4.0);
 
         let grads = tensor_out.backward();
@@ -44,9 +44,9 @@ mod tests {
         let data_2: Data<f32, 2> = Data::from([[4.0, 7.0], [2.0, 3.0]]);
         let data_3: Data<f32, 2> = Data::from([[2.0, 2.0], [2.0, 2.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
-        let tensor_3 = TestAutodiffTensor::from_data(data_3).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
+        let tensor_3 = TestAutodiffTensor::from_data_default(data_3).require_grad();
 
         let tensor_4 = tensor_1.clone().div(tensor_2.clone());
         let tensor_5 = tensor_4.div(tensor_3);
@@ -69,8 +69,8 @@ mod tests {
         let data_1 = Data::from([[0.0, 1.0], [3.0, 4.0]]);
         let data_2 = Data::from([[6.0, 7.0], [9.0, 10.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone());
         let tensor_4 = tensor_3.div(tensor_2.clone());

--- a/burn-autodiff/src/tests/erf.rs
+++ b/burn-autodiff/src/tests/erf.rs
@@ -8,8 +8,8 @@ mod tests {
         let data_1 = Data::<f32, 2>::from([[0.0, 1.0], [3.0, 4.0]]);
         let data_2 = Data::<f32, 2>::from([[6.0, 7.0], [9.0, 10.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone().erf());
         let tensor_4 = tensor_3.matmul(tensor_2.clone());

--- a/burn-autodiff/src/tests/exp.rs
+++ b/burn-autodiff/src/tests/exp.rs
@@ -8,8 +8,8 @@ mod tests {
         let data_1 = Data::<f32, 2>::from([[1.0, 7.0], [-2.0, -3.0]]);
         let data_2 = Data::<f32, 2>::from([[4.0, -7.0], [2.0, 3.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone().exp());
         let grads = tensor_3.backward();

--- a/burn-autodiff/src/tests/gather_scatter.rs
+++ b/burn-autodiff/src/tests/gather_scatter.rs
@@ -6,9 +6,9 @@ mod tests {
     #[test]
     fn test_gather_grad() {
         let tensor_1 =
-            TestAutodiffTensor::from_data(Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]))
+            TestAutodiffTensor::from_data_default(Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]))
                 .require_grad();
-        let indices = Tensor::<TestAutodiffBackend, 2, Int>::from_data(Data::from([
+        let indices = Tensor::<TestAutodiffBackend, 2, Int>::from_data_default(Data::from([
             [2, 1, 0, 1, 2],
             [1, 0, 2, 1, 0],
         ]));
@@ -30,12 +30,12 @@ mod tests {
     #[test]
     fn test_scatter_grad() {
         let tensor_1 =
-            TestAutodiffTensor::from_data(Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]))
+            TestAutodiffTensor::from_data_default(Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]))
                 .require_grad();
-        let values = TestAutodiffTensor::from_data(Data::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
+        let values = TestAutodiffTensor::from_data_default(Data::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
             .require_grad();
         let indices =
-            Tensor::<TestAutodiffBackend, 2, Int>::from_data(Data::from([[2, 1, 0], [2, 0, 1]]));
+            Tensor::<TestAutodiffBackend, 2, Int>::from_data_default(Data::from([[2, 1, 0], [2, 0, 1]]));
 
         let tensor_2 = tensor_1.clone().matmul(tensor_1.clone().transpose());
         let tensor_3 = tensor_1.clone().scatter(1, indices, values.clone());

--- a/burn-autodiff/src/tests/gather_scatter.rs
+++ b/burn-autodiff/src/tests/gather_scatter.rs
@@ -32,10 +32,13 @@ mod tests {
         let tensor_1 =
             TestAutodiffTensor::from_data_default(Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]))
                 .require_grad();
-        let values = TestAutodiffTensor::from_data_default(Data::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
-            .require_grad();
-        let indices =
-            Tensor::<TestAutodiffBackend, 2, Int>::from_data_default(Data::from([[2, 1, 0], [2, 0, 1]]));
+        let values =
+            TestAutodiffTensor::from_data_default(Data::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
+                .require_grad();
+        let indices = Tensor::<TestAutodiffBackend, 2, Int>::from_data_default(Data::from([
+            [2, 1, 0],
+            [2, 0, 1],
+        ]));
 
         let tensor_2 = tensor_1.clone().matmul(tensor_1.clone().transpose());
         let tensor_3 = tensor_1.clone().scatter(1, indices, values.clone());

--- a/burn-autodiff/src/tests/gelu.rs
+++ b/burn-autodiff/src/tests/gelu.rs
@@ -5,8 +5,10 @@ mod tests {
 
     #[test]
     fn should_diff_gelu() {
-        let tensor_1 = TestAutodiffTensor::from_floats_default([[0.0, 1.0], [-3.0, 4.0]]).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_floats_default([[6.0, -0.5], [9.0, 10.0]]).require_grad();
+        let tensor_1 =
+            TestAutodiffTensor::from_floats_default([[0.0, 1.0], [-3.0, 4.0]]).require_grad();
+        let tensor_2 =
+            TestAutodiffTensor::from_floats_default([[6.0, -0.5], [9.0, 10.0]]).require_grad();
 
         let x = tensor_1.clone().matmul(activation::gelu(tensor_2.clone()));
         let x = tensor_1.clone().matmul(x);

--- a/burn-autodiff/src/tests/gelu.rs
+++ b/burn-autodiff/src/tests/gelu.rs
@@ -5,8 +5,8 @@ mod tests {
 
     #[test]
     fn should_diff_gelu() {
-        let tensor_1 = TestAutodiffTensor::from_floats([[0.0, 1.0], [-3.0, 4.0]]).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_floats([[6.0, -0.5], [9.0, 10.0]]).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_floats_default([[0.0, 1.0], [-3.0, 4.0]]).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_floats_default([[6.0, -0.5], [9.0, 10.0]]).require_grad();
 
         let x = tensor_1.clone().matmul(activation::gelu(tensor_2.clone()));
         let x = tensor_1.clone().matmul(x);

--- a/burn-autodiff/src/tests/gradients.rs
+++ b/burn-autodiff/src/tests/gradients.rs
@@ -5,8 +5,9 @@ mod tests {
 
     #[test]
     fn should_update_tensor_when_grad_replace() {
-        let tensor_1 = TestAutodiffTensor::random([32, 32], Distribution::Default).require_grad();
-        let tensor_2 = TestAutodiffTensor::random([32, 32], Distribution::Default);
+        let tensor_1 =
+            TestAutodiffTensor::random_default([32, 32], Distribution::Default).require_grad();
+        let tensor_2 = TestAutodiffTensor::random_default([32, 32], Distribution::Default);
 
         let x = tensor_1.clone().matmul(activation::gelu(tensor_2));
         let mut grads = x.backward();
@@ -14,7 +15,7 @@ mod tests {
         let grad_1 = tensor_1.grad(&grads).unwrap();
 
         let grad_1_updated =
-            TestAutodiffTensor::random([32, 32], Distribution::Default).require_grad();
+            TestAutodiffTensor::random_default([32, 32], Distribution::Default).require_grad();
         tensor_1.grad_replace(&mut grads, grad_1_updated.clone().inner());
 
         let grad_1_new = tensor_1.grad(&grads).unwrap();

--- a/burn-autodiff/src/tests/log.rs
+++ b/burn-autodiff/src/tests/log.rs
@@ -8,8 +8,8 @@ mod tests {
         let data_1 = Data::<f32, 2>::from([[0.0, 1.0], [3.0, 4.0]]);
         let data_2 = Data::<f32, 2>::from([[6.0, 7.0], [9.0, 10.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone().log());
         let tensor_4 = tensor_3.matmul(tensor_2.clone());

--- a/burn-autodiff/src/tests/log1p.rs
+++ b/burn-autodiff/src/tests/log1p.rs
@@ -8,8 +8,8 @@ mod tests {
         let data_1 = Data::<f32, 2>::from([[0.0, 1.0], [3.0, 4.0]]);
         let data_2 = Data::<f32, 2>::from([[6.0, 7.0], [9.0, 10.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone().log1p());
         let tensor_4 = tensor_3.matmul(tensor_2.clone());

--- a/burn-autodiff/src/tests/mask.rs
+++ b/burn-autodiff/src/tests/mask.rs
@@ -9,9 +9,9 @@ mod tests {
         let data_2 = Data::<f32, 2>::from([[4.0, 7.0], [2.0, 3.0]]);
         let mask = Data::<bool, 2>::from([[true, false], [false, true]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
-        let mask = Tensor::<TestAutodiffBackend, 2, Bool>::from_bool(mask);
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
+        let mask = Tensor::<TestAutodiffBackend, 2, Bool>::from_bool_default(mask);
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone());
         let tensor_4 = tensor_3.mask_fill(mask, 2.0);
@@ -26,11 +26,11 @@ mod tests {
 
     #[test]
     fn should_diff_mask_where() {
-        let tensor_1 = TestAutodiffTensor::from_data([[1.0, 7.0], [2.0, 3.0]]).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data([[4.0, 7.0], [2.0, 3.0]]).require_grad();
-        let tensor_3 = TestAutodiffTensor::from_data([[8.8, 9.8], [10.8, 11.8]]).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default([[1.0, 7.0], [2.0, 3.0]]).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default([[4.0, 7.0], [2.0, 3.0]]).require_grad();
+        let tensor_3 = TestAutodiffTensor::from_data_default([[8.8, 9.8], [10.8, 11.8]]).require_grad();
         let mask =
-            Tensor::<TestAutodiffBackend, 2, Bool>::from_data([[true, false], [false, true]]);
+            Tensor::<TestAutodiffBackend, 2, Bool>::from_data_default([[true, false], [false, true]]);
 
         let tensor_4 = tensor_1.clone().matmul(tensor_2.clone());
         let tensor_5 = tensor_4.clone().matmul(tensor_3.clone());

--- a/burn-autodiff/src/tests/mask.rs
+++ b/burn-autodiff/src/tests/mask.rs
@@ -26,11 +26,16 @@ mod tests {
 
     #[test]
     fn should_diff_mask_where() {
-        let tensor_1 = TestAutodiffTensor::from_data_default([[1.0, 7.0], [2.0, 3.0]]).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data_default([[4.0, 7.0], [2.0, 3.0]]).require_grad();
-        let tensor_3 = TestAutodiffTensor::from_data_default([[8.8, 9.8], [10.8, 11.8]]).require_grad();
-        let mask =
-            Tensor::<TestAutodiffBackend, 2, Bool>::from_data_default([[true, false], [false, true]]);
+        let tensor_1 =
+            TestAutodiffTensor::from_data_default([[1.0, 7.0], [2.0, 3.0]]).require_grad();
+        let tensor_2 =
+            TestAutodiffTensor::from_data_default([[4.0, 7.0], [2.0, 3.0]]).require_grad();
+        let tensor_3 =
+            TestAutodiffTensor::from_data_default([[8.8, 9.8], [10.8, 11.8]]).require_grad();
+        let mask = Tensor::<TestAutodiffBackend, 2, Bool>::from_data_default([
+            [true, false],
+            [false, true],
+        ]);
 
         let tensor_4 = tensor_1.clone().matmul(tensor_2.clone());
         let tensor_5 = tensor_4.clone().matmul(tensor_3.clone());

--- a/burn-autodiff/src/tests/matmul.rs
+++ b/burn-autodiff/src/tests/matmul.rs
@@ -8,8 +8,8 @@ mod tests {
         let data_1: Data<f32, 2> = Data::from([[1.0, 7.0], [2.0, 3.0]]);
         let data_2: Data<f32, 2> = Data::from([[4.0, 7.0], [2.0, 3.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone());
         let grads = tensor_3.backward();
@@ -31,9 +31,9 @@ mod tests {
         let data_2: Data<f32, 2> = Data::from([[4.0, 7.0], [2.0, 3.0]]);
         let data_3: Data<f32, 2> = Data::from([[2.0, 2.0], [2.0, 2.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
-        let tensor_3 = TestAutodiffTensor::from_data(data_3).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
+        let tensor_3 = TestAutodiffTensor::from_data_default(data_3).require_grad();
 
         let tensor_4 = tensor_1.clone().matmul(tensor_2.clone());
         let tensor_5 = tensor_4.matmul(tensor_3);
@@ -53,9 +53,9 @@ mod tests {
         let data_2: Data<f32, 2> = Data::from([[4.0, 7.0], [2.0, 3.0]]);
         let data_3: Data<f32, 2> = Data::from([[2.0, 2.0], [2.0, 2.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
-        let tensor_3 = TestAutodiffTensor::from_data(data_3).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
+        let tensor_3 = TestAutodiffTensor::from_data_default(data_3).require_grad();
 
         let tensor_4 = tensor_1.clone().matmul(tensor_2.clone());
         let tensor_5 = tensor_4.matmul(tensor_3.clone());

--- a/burn-autodiff/src/tests/maxmin.rs
+++ b/burn-autodiff/src/tests/maxmin.rs
@@ -5,8 +5,10 @@ mod tests {
 
     #[test]
     fn should_diff_max_dim() {
-        let tensor_1 = TestAutodiffTensor::from_floats_default([[1.0, 7.0], [-2.0, -3.0]]).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_floats_default([[4.0, -7.0], [2.0, 3.0]]).require_grad();
+        let tensor_1 =
+            TestAutodiffTensor::from_floats_default([[1.0, 7.0], [-2.0, -3.0]]).require_grad();
+        let tensor_2 =
+            TestAutodiffTensor::from_floats_default([[4.0, -7.0], [2.0, 3.0]]).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone());
         let tensor_4 = tensor_1.clone().mul(tensor_3.max_dim(1).unsqueeze());
@@ -25,8 +27,10 @@ mod tests {
 
     #[test]
     fn should_diff_min_dim() {
-        let tensor_1 = TestAutodiffTensor::from_floats_default([[1.0, 7.0], [-2.0, -3.0]]).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_floats_default([[4.0, -7.0], [2.0, 3.0]]).require_grad();
+        let tensor_1 =
+            TestAutodiffTensor::from_floats_default([[1.0, 7.0], [-2.0, -3.0]]).require_grad();
+        let tensor_2 =
+            TestAutodiffTensor::from_floats_default([[4.0, -7.0], [2.0, 3.0]]).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone());
         let tensor_4 = tensor_1.clone().mul(tensor_3.min_dim(1).unsqueeze());

--- a/burn-autodiff/src/tests/maxmin.rs
+++ b/burn-autodiff/src/tests/maxmin.rs
@@ -5,8 +5,8 @@ mod tests {
 
     #[test]
     fn should_diff_max_dim() {
-        let tensor_1 = TestAutodiffTensor::from_floats([[1.0, 7.0], [-2.0, -3.0]]).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_floats([[4.0, -7.0], [2.0, 3.0]]).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_floats_default([[1.0, 7.0], [-2.0, -3.0]]).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_floats_default([[4.0, -7.0], [2.0, 3.0]]).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone());
         let tensor_4 = tensor_1.clone().mul(tensor_3.max_dim(1).unsqueeze());
@@ -25,8 +25,8 @@ mod tests {
 
     #[test]
     fn should_diff_min_dim() {
-        let tensor_1 = TestAutodiffTensor::from_floats([[1.0, 7.0], [-2.0, -3.0]]).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_floats([[4.0, -7.0], [2.0, 3.0]]).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_floats_default([[1.0, 7.0], [-2.0, -3.0]]).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_floats_default([[4.0, -7.0], [2.0, 3.0]]).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone());
         let tensor_4 = tensor_1.clone().mul(tensor_3.min_dim(1).unsqueeze());

--- a/burn-autodiff/src/tests/maxpool1d.rs
+++ b/burn-autodiff/src/tests/maxpool1d.rs
@@ -11,9 +11,9 @@ mod tests {
         let dilation = 1;
 
         let x =
-            TestAutodiffTensor::from_floats([[[0.9861, 0.5474, 0.4477, 0.0732, 0.3548, 0.8221]]])
+            TestAutodiffTensor::from_floats_default([[[0.9861, 0.5474, 0.4477, 0.0732, 0.3548, 0.8221]]])
                 .require_grad();
-        let x_grad_expected = TestAutodiffTensor::from_floats([[[1., 1., 0., 0., 0., 1.]]]);
+        let x_grad_expected = TestAutodiffTensor::from_floats_default([[[1., 1., 0., 0., 0., 1.]]]);
 
         let output = max_pool1d(x.clone(), kernel_size, stride, padding, dilation);
         let grads = output.backward();
@@ -32,13 +32,13 @@ mod tests {
         let stride = 1;
         let dilation = 2;
 
-        let x = TestAutodiffTensor::from_floats([[[
+        let x = TestAutodiffTensor::from_floats_default([[[
             0.5388, 0.0676, 0.7122, 0.8316, 0.0653, 0.9154, 0.1536, 0.9089, 0.8016, 0.7518, 0.2073,
             0.0501, 0.8811, 0.5604, 0.5075, 0.4384, 0.9963, 0.9698, 0.4988, 0.2609, 0.3391, 0.2230,
             0.4610, 0.5365, 0.6880,
         ]]])
         .require_grad();
-        let x_grad_expected = TestAutodiffTensor::from_floats([[[
+        let x_grad_expected = TestAutodiffTensor::from_floats_default([[[
             0., 0., 1., 0., 0., 3., 0., 1., 2., 1., 0., 0., 2., 0., 0., 0., 4., 4., 0., 0., 0., 0.,
             0., 0., 1.,
         ]]]);
@@ -60,13 +60,13 @@ mod tests {
         let stride = 1;
         let dilation = 1;
 
-        let x = TestAutodiffTensor::from_floats([[[
+        let x = TestAutodiffTensor::from_floats_default([[[
             0.5388, 0.0676, 0.7122, 0.8316, 0.0653, 0.9154, 0.1536, 0.9089, 0.8016, 0.7518, 0.2073,
             0.0501, 0.8811, 0.5604, 0.5075, 0.4384, 0.9963, 0.9698, 0.4988, 0.2609, 0.3391, 0.2230,
             0.4610, 0.5365, 0.6880,
         ]]])
         .require_grad();
-        let x_grad_expected = TestAutodiffTensor::from_floats([[[
+        let x_grad_expected = TestAutodiffTensor::from_floats_default([[[
             0., 0., 0., 2., 0., 4., 0., 2., 1., 0., 0., 0., 4., 0., 0., 0., 4., 1., 1., 0., 0., 0.,
             1., 1., 1.,
         ]]]);
@@ -88,13 +88,13 @@ mod tests {
         let stride = 1;
         let dilation = 1;
 
-        let x = TestAutodiffTensor::from_floats([[[
+        let x = TestAutodiffTensor::from_floats_default([[[
             0.5388, 0.0676, 0.7122, 0.8316, 0.0653, 0.9154, 0.1536, 0.9089, 0.8016, 0.7518, 0.2073,
             0.0501, 0.8811, 0.5604, 0.5075, 0.4384, 0.9963, 0.9698, 0.4988, 0.2609, 0.3391, 0.2230,
             0.4610, 0.5365, 0.6880,
         ]]])
         .require_grad();
-        let x_grad_expected = TestAutodiffTensor::from_floats([[[
+        let x_grad_expected = TestAutodiffTensor::from_floats_default([[[
             1., 0., 1., 2., 0., 4., 0., 2., 1., 0., 0., 0., 4., 0., 0., 0., 4., 1., 1., 0., 0., 0.,
             1., 1., 3.,
         ]]]);

--- a/burn-autodiff/src/tests/maxpool1d.rs
+++ b/burn-autodiff/src/tests/maxpool1d.rs
@@ -10,9 +10,10 @@ mod tests {
         let stride = 1;
         let dilation = 1;
 
-        let x =
-            TestAutodiffTensor::from_floats_default([[[0.9861, 0.5474, 0.4477, 0.0732, 0.3548, 0.8221]]])
-                .require_grad();
+        let x = TestAutodiffTensor::from_floats_default([[[
+            0.9861, 0.5474, 0.4477, 0.0732, 0.3548, 0.8221,
+        ]]])
+        .require_grad();
         let x_grad_expected = TestAutodiffTensor::from_floats_default([[[1., 1., 0., 0., 0., 1.]]]);
 
         let output = max_pool1d(x.clone(), kernel_size, stride, padding, dilation);

--- a/burn-autodiff/src/tests/maxpool2d.rs
+++ b/burn-autodiff/src/tests/maxpool2d.rs
@@ -14,14 +14,14 @@ mod tests {
         let dilation_1 = 1;
         let dilation_2 = 1;
 
-        let x = TestAutodiffTensor::from_floats([[[
+        let x = TestAutodiffTensor::from_floats_default([[[
             [0.2479, 0.6386, 0.3166, 0.5742],
             [0.7065, 0.1940, 0.6305, 0.8959],
             [0.5416, 0.8602, 0.8129, 0.1662],
             [0.3358, 0.3059, 0.8293, 0.0990],
         ]]])
         .require_grad();
-        let x_grad_expected = TestAutodiffTensor::from_floats([[[
+        let x_grad_expected = TestAutodiffTensor::from_floats_default([[[
             [0.0, 0.0, 0.0, 0.0],
             [0.0, 0.0, 0.0, 2.0],
             [0.0, 2.0, 0.0, 0.0],
@@ -55,14 +55,14 @@ mod tests {
         let dilation_1 = 1;
         let dilation_2 = 1;
 
-        let x = TestAutodiffTensor::from_floats([[[
+        let x = TestAutodiffTensor::from_floats_default([[[
             [0.2479, 0.6386, 0.3166, 0.5742],
             [0.7065, 0.1940, 0.6305, 0.8959],
             [0.5416, 0.8602, 0.8129, 0.1662],
             [0.3358, 0.3059, 0.8293, 0.0990],
         ]]])
         .require_grad();
-        let x_grad_expected = TestAutodiffTensor::from_floats([[[
+        let x_grad_expected = TestAutodiffTensor::from_floats_default([[[
             [1., 3., 0., 2.],
             [3., 0., 0., 4.],
             [1., 4., 0., 1.],
@@ -96,14 +96,14 @@ mod tests {
         let dilation_1 = 2;
         let dilation_2 = 2;
 
-        let x = TestAutodiffTensor::from_floats([[[
+        let x = TestAutodiffTensor::from_floats_default([[[
             [0.2479, 0.6386, 0.3166, 0.5742],
             [0.7065, 0.1940, 0.6305, 0.8959],
             [0.5416, 0.8602, 0.8129, 0.1662],
             [0.3358, 0.3059, 0.8293, 0.0990],
         ]]])
         .require_grad();
-        let x_grad_expected = TestAutodiffTensor::from_floats([[[
+        let x_grad_expected = TestAutodiffTensor::from_floats_default([[[
             [0., 0., 0., 0.],
             [1., 1., 1., 2.],
             [0., 4., 4., 0.],
@@ -137,7 +137,7 @@ mod tests {
         let dilation_1 = 1;
         let dilation_2 = 1;
 
-        let x = TestAutodiffTensor::from_floats([[[
+        let x = TestAutodiffTensor::from_floats_default([[[
             [0.5388, 0.0676, 0.7122, 0.8316, 0.0653],
             [0.9154, 0.1536, 0.9089, 0.8016, 0.7518],
             [0.2073, 0.0501, 0.8811, 0.5604, 0.5075],
@@ -145,7 +145,7 @@ mod tests {
             [0.3391, 0.2230, 0.4610, 0.5365, 0.6880],
         ]]])
         .require_grad();
-        let x_grad_expected = TestAutodiffTensor::from_floats([[[
+        let x_grad_expected = TestAutodiffTensor::from_floats_default([[[
             [0., 0., 0., 3., 0.],
             [4., 0., 2., 1., 0.],
             [0., 0., 0., 0., 0.],

--- a/burn-autodiff/src/tests/mul.rs
+++ b/burn-autodiff/src/tests/mul.rs
@@ -8,8 +8,8 @@ mod tests {
         let data_1 = Data::from([1.0, 7.0]);
         let data_2 = Data::from([4.0, 7.0]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1.clone()).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2.clone()).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1.clone()).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2.clone()).require_grad();
 
         let tensor_3 = tensor_1.clone().mul(tensor_2.clone());
         let grads = tensor_3.backward();
@@ -26,7 +26,7 @@ mod tests {
     fn should_diff_mul_scalar() {
         let data = Data::from([2.0, 5.0]);
 
-        let tensor = TestAutodiffTensor::from_data(data).require_grad();
+        let tensor = TestAutodiffTensor::from_data_default(data).require_grad();
         let tensor_out = tensor.clone().mul_scalar(4.0);
 
         let grads = tensor_out.backward();
@@ -42,9 +42,9 @@ mod tests {
         let data_2: Data<f32, 2> = Data::from([[4.0, 7.0], [2.0, 3.0]]);
         let data_3: Data<f32, 2> = Data::from([[2.0, 2.0], [2.0, 2.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
-        let tensor_3 = TestAutodiffTensor::from_data(data_3).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
+        let tensor_3 = TestAutodiffTensor::from_data_default(data_3).require_grad();
 
         let tensor_4 = tensor_1.clone().mul(tensor_2.clone());
         let tensor_5 = tensor_4.mul(tensor_3);

--- a/burn-autodiff/src/tests/multithread.rs
+++ b/burn-autodiff/src/tests/multithread.rs
@@ -9,8 +9,8 @@ mod tests {
         let data_2: Data<f32, 2> = Data::from([[4.0, 7.0], [2.0, 3.0]]);
 
         let with_move = || {
-            let tensor_1 = TestAutodiffTensor::from_data(data_1.clone()).require_grad();
-            let tensor_2 = TestAutodiffTensor::from_data(data_2.clone()).require_grad();
+            let tensor_1 = TestAutodiffTensor::from_data_default(data_1.clone()).require_grad();
+            let tensor_2 = TestAutodiffTensor::from_data_default(data_2.clone()).require_grad();
 
             let tensor_3 = tensor_1.clone().matmul(tensor_2.clone());
             let tensor_4 = tensor_3.clone().matmul(tensor_2.clone());
@@ -51,8 +51,8 @@ mod tests {
             (grad_1, grad_2)
         };
         let without_move = || {
-            let tensor_1 = TestAutodiffTensor::from_data(data_1.clone()).require_grad();
-            let tensor_2 = TestAutodiffTensor::from_data(data_2.clone()).require_grad();
+            let tensor_1 = TestAutodiffTensor::from_data_default(data_1.clone()).require_grad();
+            let tensor_2 = TestAutodiffTensor::from_data_default(data_2.clone()).require_grad();
 
             let tensor_3 = tensor_1.clone().matmul(tensor_2.clone());
             let tensor_4 = tensor_3.clone().matmul(tensor_2.clone());

--- a/burn-autodiff/src/tests/neg.rs
+++ b/burn-autodiff/src/tests/neg.rs
@@ -8,8 +8,8 @@ mod tests {
         let data_1 = Data::<f32, 2>::from([[1.0, 7.0], [2.0, 3.0]]);
         let data_2 = Data::<f32, 2>::from([[4.0, 7.0], [2.0, 3.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone().neg());
         let tensor_4 = tensor_3.neg();

--- a/burn-autodiff/src/tests/pow.rs
+++ b/burn-autodiff/src/tests/pow.rs
@@ -8,8 +8,8 @@ mod tests {
         let data_1 = Data::<f32, 2>::from([[0.0, 1.0], [3.0, 4.0]]);
         let data_2 = Data::<f32, 2>::from([[6.0, 7.0], [9.0, 10.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone().powf(0.4));
         let tensor_4 = tensor_3.matmul(tensor_2.clone());

--- a/burn-autodiff/src/tests/relu.rs
+++ b/burn-autodiff/src/tests/relu.rs
@@ -8,8 +8,8 @@ mod tests {
         let data_1 = Data::<f32, 2>::from([[1.0, 7.0], [-2.0, -3.0]]);
         let data_2 = Data::<f32, 2>::from([[4.0, -7.0], [2.0, 3.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone());
         let tensor_4 = activation::relu(tensor_3);

--- a/burn-autodiff/src/tests/reshape.rs
+++ b/burn-autodiff/src/tests/reshape.rs
@@ -8,8 +8,8 @@ mod tests {
         let data_1: Data<f32, 2> = Data::from([[1.0, 7.0], [2.0, 3.0]]);
         let data_2: Data<f32, 1> = Data::from([4.0, 7.0, 2.0, 3.0]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
 
         let tensor_3 = tensor_2.clone().reshape([2, 2]);
         let tensor_4 = tensor_1.clone().matmul(tensor_3);

--- a/burn-autodiff/src/tests/select.rs
+++ b/burn-autodiff/src/tests/select.rs
@@ -29,8 +29,9 @@ mod tests {
         let tensor_1 =
             TestAutodiffTensor::from_data_default(Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]))
                 .require_grad();
-        let values = TestAutodiffTensor::from_data_default(Data::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
-            .require_grad();
+        let values =
+            TestAutodiffTensor::from_data_default(Data::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
+                .require_grad();
         let indices = Tensor::<TestAutodiffBackend, 1, Int>::from_data_default(Data::from([1, 0]));
 
         let tensor_2 = tensor_1.clone().matmul(tensor_1.clone().transpose());

--- a/burn-autodiff/src/tests/select.rs
+++ b/burn-autodiff/src/tests/select.rs
@@ -6,9 +6,9 @@ mod tests {
     #[test]
     fn test_select_grad() {
         let tensor_1 =
-            TestAutodiffTensor::from_data(Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]))
+            TestAutodiffTensor::from_data_default(Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]))
                 .require_grad();
-        let indices = Tensor::<TestAutodiffBackend, 1, Int>::from_data(Data::from([1, 0]));
+        let indices = Tensor::<TestAutodiffBackend, 1, Int>::from_data_default(Data::from([1, 0]));
 
         let tensor_2 = tensor_1.clone().matmul(tensor_1.clone().transpose());
         let tensor_3 = tensor_1.clone().select(0, indices);
@@ -27,11 +27,11 @@ mod tests {
     #[test]
     fn test_select_assign_grad() {
         let tensor_1 =
-            TestAutodiffTensor::from_data(Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]))
+            TestAutodiffTensor::from_data_default(Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]))
                 .require_grad();
-        let values = TestAutodiffTensor::from_data(Data::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
+        let values = TestAutodiffTensor::from_data_default(Data::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
             .require_grad();
-        let indices = Tensor::<TestAutodiffBackend, 1, Int>::from_data(Data::from([1, 0]));
+        let indices = Tensor::<TestAutodiffBackend, 1, Int>::from_data_default(Data::from([1, 0]));
 
         let tensor_2 = tensor_1.clone().matmul(tensor_1.clone().transpose());
         let tensor_3 = tensor_1.clone().select_assign(0, indices, values.clone());

--- a/burn-autodiff/src/tests/sin.rs
+++ b/burn-autodiff/src/tests/sin.rs
@@ -8,8 +8,8 @@ mod tests {
         let data_1 = Data::<f32, 2>::from([[0.0, 1.0], [3.0, 4.0]]);
         let data_2 = Data::<f32, 2>::from([[6.0, 7.0], [9.0, 10.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone().sin());
         let tensor_4 = tensor_3.matmul(tensor_2.clone());

--- a/burn-autodiff/src/tests/slice.rs
+++ b/burn-autodiff/src/tests/slice.rs
@@ -8,8 +8,8 @@ mod tests {
         let data_1: Data<f32, 2> = Data::from([[1.0, 7.0], [2.0, 3.0]]);
         let data_2: Data<f32, 2> = Data::from([[4.0, 7.0, 100.0], [2.0, 3.0, 15.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
 
         let tensor_3 = tensor_2.clone().slice([0..2, 0..2]);
         let tensor_4 = tensor_1.clone().matmul(tensor_3);
@@ -31,9 +31,9 @@ mod tests {
         let data_2: Data<f32, 2> = Data::from([[4.0, 7.0], [2.0, 3.0]]);
         let data_assigned: Data<f32, 2> = Data::from([[9.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
-        let tensor_assigned = TestAutodiffTensor::from_data(data_assigned).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
+        let tensor_assigned = TestAutodiffTensor::from_data_default(data_assigned).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone());
         let tensor_4 = tensor_3.slice_assign([0..1, 0..1], tensor_assigned);
@@ -54,9 +54,9 @@ mod tests {
         let data_2: Data<f32, 2> = Data::from([[4.0, 7.0], [2.0, 3.0]]);
         let data_3: Data<f32, 2> = Data::from([[9.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
-        let tensor_3 = TestAutodiffTensor::from_data(data_3).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
+        let tensor_3 = TestAutodiffTensor::from_data_default(data_3).require_grad();
 
         let tensor_4 = tensor_1.clone().matmul(tensor_2.clone());
         let tensor_5 = tensor_2.clone().slice([0..1, 0..1]);

--- a/burn-autodiff/src/tests/softmax.rs
+++ b/burn-autodiff/src/tests/softmax.rs
@@ -7,8 +7,8 @@ mod tests {
     fn test_softmax_grad() {
         let data_1 = Data::from([[0.0, 1.0], [3.0, 4.0]]);
         let data_2 = Data::from([[6.0, 7.0], [9.0, 10.0]]);
-        let tensor_1 = Tensor::<TestAutodiffBackend, 2>::from_data(data_1).require_grad();
-        let tensor_2 = Tensor::<TestAutodiffBackend, 2>::from_data(data_2).require_grad();
+        let tensor_1 = Tensor::<TestAutodiffBackend, 2>::from_data_default(data_1).require_grad();
+        let tensor_2 = Tensor::<TestAutodiffBackend, 2>::from_data_default(data_2).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone());
         let tensor_4 = activation::softmax(tensor_3, 1).matmul(tensor_2.clone());
@@ -29,8 +29,8 @@ mod tests {
     fn test_log_softmax_grad() {
         let data_1 = Data::from([[0.0, 1.0], [3.0, 4.0]]);
         let data_2 = Data::from([[6.0, 7.0], [9.0, 10.0]]);
-        let tensor_1 = Tensor::<TestAutodiffBackend, 2>::from_data(data_1).require_grad();
-        let tensor_2 = Tensor::<TestAutodiffBackend, 2>::from_data(data_2).require_grad();
+        let tensor_1 = Tensor::<TestAutodiffBackend, 2>::from_data_default(data_1).require_grad();
+        let tensor_2 = Tensor::<TestAutodiffBackend, 2>::from_data_default(data_2).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone());
         let tensor_4 = activation::log_softmax(tensor_3, 1).matmul(tensor_2.clone());

--- a/burn-autodiff/src/tests/sqrt.rs
+++ b/burn-autodiff/src/tests/sqrt.rs
@@ -8,8 +8,8 @@ mod tests {
         let data_1 = Data::<f32, 2>::from([[0.0, 1.0], [3.0, 4.0]]);
         let data_2 = Data::<f32, 2>::from([[6.0, 7.0], [9.0, 10.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone().sqrt());
         let tensor_4 = tensor_3.matmul(tensor_2.clone());

--- a/burn-autodiff/src/tests/sub.rs
+++ b/burn-autodiff/src/tests/sub.rs
@@ -8,8 +8,8 @@ mod tests {
         let data_1 = Data::from([2.0, 5.0]);
         let data_2 = Data::from([4.0, 1.0]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
 
         let tensor_3 = tensor_1.clone().sub(tensor_2.clone());
         let grads = tensor_3.backward();
@@ -25,7 +25,7 @@ mod tests {
     #[test]
     fn should_diff_sub_scalar() {
         let data = Data::from([2.0, 10.0]);
-        let tensor = TestAutodiffTensor::from_data(data).require_grad();
+        let tensor = TestAutodiffTensor::from_data_default(data).require_grad();
         let tensor_out = tensor.clone().sub_scalar(5.0);
         let grads = tensor_out.backward();
 
@@ -41,9 +41,9 @@ mod tests {
         let data_2: Data<f32, 2> = Data::from([[4.0, 7.0], [2.0, 3.0]]);
         let data_3: Data<f32, 2> = Data::from([[2.0, 2.0], [2.0, 2.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
-        let tensor_3 = TestAutodiffTensor::from_data(data_3).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
+        let tensor_3 = TestAutodiffTensor::from_data_default(data_3).require_grad();
 
         let tensor_4 = tensor_1.clone().sub(tensor_2.clone());
         let tensor_5 = tensor_4.sub(tensor_3).sub_scalar(5.0);

--- a/burn-autodiff/src/tests/tanh.rs
+++ b/burn-autodiff/src/tests/tanh.rs
@@ -8,8 +8,8 @@ mod tests {
         let data_1 = Data::<f32, 2>::from([[0.0, 1.0], [3.0, 4.0]]);
         let data_2 = Data::<f32, 2>::from([[6.0, 7.0], [9.0, 10.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone().tanh());
         let tensor_4 = tensor_3.matmul(tensor_2.clone());

--- a/burn-autodiff/src/tests/transpose.rs
+++ b/burn-autodiff/src/tests/transpose.rs
@@ -8,8 +8,8 @@ mod tests {
         let data_1 = Data::<f32, 2>::from([[1.0, 7.0], [2.0, 3.0]]);
         let data_2 = Data::<f32, 2>::from([[4.0, 7.0], [2.0, 3.0]]);
 
-        let tensor_1 = TestAutodiffTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data_default(data_1).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data_default(data_2).require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone().transpose());
         let tensor_4 = tensor_3.transpose();
@@ -25,10 +25,10 @@ mod tests {
     #[test]
     fn should_diff_swap_dims() {
         let tensor_1 =
-            TestAutodiffTensor::from_floats([[[0.0, 1.0], [3.0, 4.0]], [[6.0, 7.0], [9.0, 10.0]]])
+            TestAutodiffTensor::from_floats_default([[[0.0, 1.0], [3.0, 4.0]], [[6.0, 7.0], [9.0, 10.0]]])
                 .require_grad();
         let tensor_2 =
-            TestAutodiffTensor::from_floats([[[1.0, 4.0], [2.0, 5.0]], [[7.0, 10.0], [8.0, 11.0]]])
+            TestAutodiffTensor::from_floats_default([[[1.0, 4.0], [2.0, 5.0]], [[7.0, 10.0], [8.0, 11.0]]])
                 .require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone().swap_dims(0, 2));

--- a/burn-autodiff/src/tests/transpose.rs
+++ b/burn-autodiff/src/tests/transpose.rs
@@ -24,12 +24,16 @@ mod tests {
 
     #[test]
     fn should_diff_swap_dims() {
-        let tensor_1 =
-            TestAutodiffTensor::from_floats_default([[[0.0, 1.0], [3.0, 4.0]], [[6.0, 7.0], [9.0, 10.0]]])
-                .require_grad();
-        let tensor_2 =
-            TestAutodiffTensor::from_floats_default([[[1.0, 4.0], [2.0, 5.0]], [[7.0, 10.0], [8.0, 11.0]]])
-                .require_grad();
+        let tensor_1 = TestAutodiffTensor::from_floats_default([
+            [[0.0, 1.0], [3.0, 4.0]],
+            [[6.0, 7.0], [9.0, 10.0]],
+        ])
+        .require_grad();
+        let tensor_2 = TestAutodiffTensor::from_floats_default([
+            [[1.0, 4.0], [2.0, 5.0]],
+            [[7.0, 10.0], [8.0, 11.0]],
+        ])
+        .require_grad();
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone().swap_dims(0, 2));
         let tensor_4 = tensor_3.matmul(tensor_2.clone().swap_dims(1, 2));

--- a/burn-book/src/basic-workflow/data.md
+++ b/burn-book/src/basic-workflow/data.md
@@ -47,7 +47,7 @@ impl<B: Backend> Batcher<MNISTItem, MNISTBatch<B>> for MNISTBatcher<B> {
         let images = items
             .iter()
             .map(|item| Data::<f32, 2>::from(item.image))
-            .map(|data| Tensor::<B, 2>::from_data(data.convert()))
+            .map(|data| Tensor::<B, 2>::from_data_default(data.convert()))
             .map(|tensor| tensor.reshape([1, 28, 28]))
             // Normalize: make between [0,1] and make the mean=0 and std=1
             // values mean=0.1307,std=0.3081 are from the PyTorch MNIST example
@@ -57,7 +57,7 @@ impl<B: Backend> Batcher<MNISTItem, MNISTBatch<B>> for MNISTBatcher<B> {
 
         let targets = items
             .iter()
-            .map(|item| Tensor::<B, 1, Int>::from_data(Data::from([(item.label as i64).elem()])))
+            .map(|item| Tensor::<B, 1, Int>::from_data_default(Data::from([(item.label as i64).elem()])))
             .collect();
 
         let images = Tensor::cat(images, 0).to_device(&self.device);

--- a/burn-book/src/basic-workflow/model.md
+++ b/burn-book/src/basic-workflow/model.md
@@ -78,14 +78,14 @@ pub struct ModelConfig {
 
 impl ModelConfig {
     /// Returns the initialized model.
-    pub fn init<B: Backend>(&self) -> Model<B> {
+    pub fn init<B: Backend>(&self, device: &B::Device) -> Model<B> {
         Model {
-            conv1: Conv2dConfig::new([1, 8], [3, 3]).init(),
-            conv2: Conv2dConfig::new([8, 16], [3, 3]).init(),
+            conv1: Conv2dConfig::new([1, 8], [3, 3]).init(device),
+            conv2: Conv2dConfig::new([8, 16], [3, 3]).init(device),
             pool: AdaptiveAvgPool2dConfig::new([8, 8]).init(),
             activation: ReLU::new(),
-            linear1: LinearConfig::new(16 * 8 * 8, self.hidden_size).init(),
-            linear2: LinearConfig::new(self.hidden_size, self.num_classes).init(),
+            linear1: LinearConfig::new(16 * 8 * 8, self.hidden_size).init(device),
+            linear2: LinearConfig::new(self.hidden_size, self.num_classes).init(device),
             dropout: DropoutConfig::new(self.dropout).init(),
         }
     }

--- a/burn-book/src/building-blocks/config.md
+++ b/burn-book/src/building-blocks/config.md
@@ -47,9 +47,9 @@ config. In that optic, initialization methods should be implemented on the confi
 ```rust, ignore
 impl MyModuleConfig {
     /// Create a module with random weights.
-    pub fn init(&self) -> MyModule {
+    pub fn init<B: Backend>(&self, device: &B::Device) -> MyModule {
         MyModule {
-            linear: LinearConfig::new(self.d_model, self.d_ff).init(),
+            linear: LinearConfig::new(self.d_model, self.d_ff).init(device),
             dropout: DropoutConfig::new(self.dropout).init(),
         }
     }
@@ -70,5 +70,7 @@ impl MyModuleConfig {
 Then we could add this line to the above `main`:
 
 ```rust, ignore
-let my_module = config.init()
+use burn::backend::Wgpu;
+let device = Default::default();
+let my_module = config.init::<Wgpu>(&device);
 ```

--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -55,8 +55,8 @@ Those operations are available for all tensor kinds: `Int`, `Float`, and `Bool`.
 | `Tensor::cat(tensors, dim)`              | `torch.cat(tensors, dim)`            |
 | `tensor.into_data()`                     | N/A                                  |
 | `tensor.to_data()`                       | N/A                                  |
-| `Tensor::from_data(data)`                | N/A                                  |
-| `Tensor::from_data_device(data, device)` | N/A                                  |
+| `Tensor::from_data_default(data)`                | N/A                                  |
+| `Tensor::from_data_default(data, device)` | N/A                                  |
 | `tensor.into_primitive()`                | N/A                                  |
 | `Tensor::from_primitive(primitive)`      | N/A                                  |
 
@@ -78,7 +78,7 @@ Those operations are available for numeric tensor kinds: `Float` and `Int`.
 | `-tensor` or `tensor.neg()`                      | `-tensor`                                      |
 | `Tensor::zeros(shape)`                           | `torch.zeros(shape)`                           |
 | `Tensor::zeros_device(shape, device)`            | `torch.zeros(shape, device=device)`            |
-| `Tensor::ones(shape)`                            | `torch.ones(shape)`                            |
+| `Tensor::ones_default(shape)`                            | `torch.ones_default(shape)`                            |
 | `Tensor::ones_device(shape, device)`             | `torch.ones(shape, device=device)`             |
 | `Tensor::full(shape, fill_value)`                | `torch.full(shape, fill_value)`                |
 | `Tensor::full_device(shape, fill_value, device)` | `torch.full(shape, fill_value, device=device)` |
@@ -129,7 +129,7 @@ Those operations are only available for `Float` tensors.
 | `tensor.cos()`                                      | `tensor.cos()`                     |
 | `tensor.sin()`                                      | `tensor.sin()`                     |
 | `tensor.tanh()`                                     | `tensor.tanh()`                    |
-| `tensor.from_floats(floats)`                        | N/A                                |
+| `tensor.from_floats_default(floats)`                        | N/A                                |
 | `tensor.int()`                                      | Similar to `tensor.to(torch.long)` |
 | `tensor.zeros_like()`                               | `torch.zeros_like(tensor)`         |
 | `tensor.ones_like()`                                | `torch.ones_like(tensor)`          |
@@ -155,10 +155,10 @@ Those operations are only available for `Int` tensors.
 | --------------------------------------------- | ------------------------------------------------------- |
 | `tensor.from_ints(ints)`                      | N/A                                                     |
 | `tensor.float()`                              | Similar to `tensor.to(torch.float)`                     |
-| `tensor.arange(5..10)`                        | `tensor.arange(start=5, end=10)`                        |
-| `tensor.arange_device(5..10, device)`         | `tensor.arange(start=5, end=10, device=device)`         |
-| `tensor.arange_step(5..10, 2)`                | `tensor.arange(start=5, end=10, step=2)`                |
-| `tensor.arange_step_device(5..10, 2, device)` | `tensor.arange(start=5, end=10, step=2, device=device)` |
+| `tensor.arange_default(5..10)`                | `tensor.arange(start=5, end=10)`                        |
+| `tensor.arange(5..10, device)       `         | `tensor.arange(start=5, end=10, device=device)`         |
+| `tensor.arange_step_default(5..10, 2)`        | `tensor.arange(start=5, end=10, step=2)`                |
+| `tensor.arange_step(5..10, 2, device)`        | `tensor.arange(start=5, end=10, step=2, device=device)` |
 
 # Bool Operations
 

--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -38,8 +38,8 @@ Those operations are available for all tensor kinds: `Int`, `Float`, and `Bool`.
 
 | Burn                                     | PyTorch Equivalent                   |
 | ---------------------------------------- | ------------------------------------ |
-| `Tensor::empty(shape)`                   | `torch.empty(shape)`                 |
-| `Tensor::empty_device(shape, device)`    | `torch.empty(shape, device=device)`  |
+| `Tensor::empty_default(shape)`           | `torch.empty(shape)`                 |
+| `Tensor::empty(shape, device)`           | `torch.empty(shape, device=device)`  |
 | `tensor.dims()`                          | `tensor.size()`                      |
 | `tensor.shape()`                         | `tensor.shape`                       |
 | `tensor.reshape(shape)`                  | `tensor.view(shape)`                 |
@@ -55,8 +55,8 @@ Those operations are available for all tensor kinds: `Int`, `Float`, and `Bool`.
 | `Tensor::cat(tensors, dim)`              | `torch.cat(tensors, dim)`            |
 | `tensor.into_data()`                     | N/A                                  |
 | `tensor.to_data()`                       | N/A                                  |
-| `Tensor::from_data_default(data)`                | N/A                                  |
-| `Tensor::from_data_default(data, device)` | N/A                                  |
+| `Tensor::from_data_default(data)`        | N/A                                  |
+| `Tensor::from_data(data, device)`        | N/A                                  |
 | `tensor.into_primitive()`                | N/A                                  |
 | `Tensor::from_primitive(primitive)`      | N/A                                  |
 
@@ -77,11 +77,11 @@ Those operations are available for numeric tensor kinds: `Float` and `Int`.
 | `tensor * scalar` or `tensor.mul_scalar(scalar)` | `tensor * scalar`                              |
 | `-tensor` or `tensor.neg()`                      | `-tensor`                                      |
 | `Tensor::zeros(shape)`                           | `torch.zeros(shape)`                           |
-| `Tensor::zeros_device(shape, device)`            | `torch.zeros(shape, device=device)`            |
-| `Tensor::ones_default(shape)`                            | `torch.ones_default(shape)`                            |
-| `Tensor::ones_device(shape, device)`             | `torch.ones(shape, device=device)`             |
-| `Tensor::full(shape, fill_value)`                | `torch.full(shape, fill_value)`                |
-| `Tensor::full_device(shape, fill_value, device)` | `torch.full(shape, fill_value, device=device)` |
+| `Tensor::zeros(shape, device)`                   | `torch.zeros(shape, device=device)`            |
+| `Tensor::ones_default(shape)`                    | `torch.ones(shape)`                            |
+| `Tensor::ones(shape, device)`                    | `torch.ones(shape, device=device)`             |
+| `Tensor::full_default(shape, fill_value)`        | `torch.full(shape, fill_value)`                |
+| `Tensor::full(shape, fill_value, device)`        | `torch.full(shape, fill_value, device=device)` |
 | `tensor.mean()`                                  | `tensor.mean()`                                |
 | `tensor.sum()`                                   | `tensor.sum()`                                 |
 | `tensor.mean_dim(dim)`                           | `tensor.mean(dim)`                             |
@@ -129,7 +129,8 @@ Those operations are only available for `Float` tensors.
 | `tensor.cos()`                                      | `tensor.cos()`                     |
 | `tensor.sin()`                                      | `tensor.sin()`                     |
 | `tensor.tanh()`                                     | `tensor.tanh()`                    |
-| `tensor.from_floats_default(floats)`                        | N/A                                |
+| `tensor.from_floats_default(floats)`                | N/A                                |
+| `tensor.from_floats(floats, device)`                | N/A                                |
 | `tensor.int()`                                      | Similar to `tensor.to(torch.long)` |
 | `tensor.zeros_like()`                               | `torch.zeros_like(tensor)`         |
 | `tensor.ones_like()`                                | `torch.ones_like(tensor)`          |
@@ -142,8 +143,8 @@ Those operations are only available for `Float` tensors.
 | `tensor.var_bias(dim)`                              | N/A                                |
 | `tensor.var_mean(dim)`                              | N/A                                |
 | `tensor.var_mean_bias(dim)`                         | N/A                                |
-| `tensor.random(shape, distribution)`                | N/A                                |
-| `tensor.random_device(shape, distribution, device)` | N/A                                |
+| `tensor.random_default(shape, distribution)`        | N/A                                |
+| `tensor.random(shape, distribution, device)`        | N/A                                |
 | `tensor.to_full_precision()`                        | `tensor.to(torch.float)`           |
 | `tensor.from_full_precision(tensor)`                | N/A                                |
 

--- a/burn-book/src/custom-training-loop.md
+++ b/burn-book/src/custom-training-loop.md
@@ -27,7 +27,7 @@ pub struct MnistTrainingConfig {
     pub optimizer: AdamConfig,
 }
 
-pub fn run<B: AutodiffBackend>(device: B::Device) {
+pub fn run<B: AutodiffBackend>(device: &B::Device) {
     // Create the configuration.
     let config_model = ModelConfig::new(10, 1024);
     let config_optimizer = AdamConfig::new();
@@ -36,7 +36,7 @@ pub fn run<B: AutodiffBackend>(device: B::Device) {
     B::seed(config.seed);
 
     // Create the model and optimizer.
-    let mut model = config.model.init();
+    let mut model = config.model.init(device);
     let mut optim = config.optimizer.init();
 
     // Create the batcher.

--- a/burn-book/src/getting-started.md
+++ b/burn-book/src/getting-started.md
@@ -54,7 +54,7 @@ type Backend = Wgpu;
 
 fn main() {
     // Creation of two tensors, the first with explicit values and the second one with ones, with the same shape as the first
-    let tensor_1 = Tensor::<Backend, 2>::from_data([[2., 3.], [4., 5.]]);
+    let tensor_1 = Tensor::<Backend, 2>::from_data_default([[2., 3.], [4., 5.]]);
     let tensor_2 = Tensor::<Backend, 2>::ones_like(&tensor_1);
 
     // Print the element-wise addition (done with the WGPU backend) of the two tensors.

--- a/burn-book/src/import/onnx-model.md
+++ b/burn-book/src/import/onnx-model.md
@@ -102,15 +102,16 @@ Here's how to use the imported model in your application:
 mod model;
 
 use burn::tensor;
-use burn_ndarray::NdArray;
+use burn_ndarray::{NdArray, NdArrayDevice};
 use model::mnist::Model;
 
 fn main() {
     // Initialize a new model instance
-    let model: Model<NdArray<f32>> = Model::new();
+    let device = NdArrayDevice::default();
+    let model: Model<NdArray<f32>> = Model::new(&device);
 
     // Create a sample input tensor (zeros for demonstration)
-    let input = tensor::Tensor::<NdArray<f32>, 4>::zeros([1, 1, 28, 28]);
+    let input = tensor::Tensor::<NdArray<f32>, 4>::zeros([1, 1, 28, 28], &device);
 
     // Perform inference
     let output = model.forward(input);

--- a/burn-candle/src/ops/tensor.rs
+++ b/burn-candle/src/ops/tensor.rs
@@ -133,9 +133,15 @@ impl<F: FloatCandleElement, I: IntCandleElement> TensorOps<Self> for Candle<F, I
     }
 
     fn matmul<const D: usize>(
-        lhs: FloatTensor<Self, D>,
-        rhs: FloatTensor<Self, D>,
+        mut lhs: FloatTensor<Self, D>,
+        mut rhs: FloatTensor<Self, D>,
     ) -> FloatTensor<Self, D> {
+        if !lhs.tensor.is_contiguous() {
+            lhs.tensor = lhs.tensor.contiguous().unwrap();
+        }
+        if !rhs.tensor.is_contiguous() {
+            rhs.tensor = rhs.tensor.contiguous().unwrap();
+        }
         CandleTensor::new(lhs.tensor.broadcast_matmul(&rhs.tensor).unwrap())
     }
 

--- a/burn-core/src/grad_clipping/base.rs
+++ b/burn-core/src/grad_clipping/base.rs
@@ -113,7 +113,7 @@ mod tests {
 
     #[test]
     fn test_clip_by_value() {
-        let gradient: Tensor<TestBackend, 2> = Tensor::from_floats([
+        let gradient: Tensor<TestBackend, 2> = Tensor::from_floats_default([
             [0.6294, 0.0940, 0.8176, 0.8824, 0.5228, 0.4310],
             [0.7152, 0.9559, 0.7893, 0.5684, 0.5939, 0.8883],
         ]);
@@ -128,7 +128,7 @@ mod tests {
 
     #[test]
     fn test_clip_by_norm() {
-        let gradient: Tensor<TestBackend, 2> = Tensor::from_floats([
+        let gradient: Tensor<TestBackend, 2> = Tensor::from_floats_default([
             [0.6294, 0.0940, 0.8176, 0.8824, 0.5228, 0.4310],
             [0.7152, 0.9559, 0.7893, 0.5684, 0.5939, 0.8883],
         ]);

--- a/burn-core/src/module/param/constant.rs
+++ b/burn-core/src/module/param/constant.rs
@@ -199,7 +199,7 @@ mod tests {
 
     #[test]
     fn tensor_load_record_setting() {
-        let tensor = Tensor::<TestAutodiffBackend, 2>::ones([3, 3]);
+        let tensor = Tensor::<TestAutodiffBackend, 2>::ones_default([3, 3]);
 
         let byte_recorder = BinBytesRecorder::<FullPrecisionSettings>::default();
         let bytes = byte_recorder

--- a/burn-core/src/module/param/tensor.rs
+++ b/burn-core/src/module/param/tensor.rs
@@ -66,7 +66,7 @@ mod tests {
 
     #[test]
     fn test_load_record_setting() {
-        let tensor = Tensor::<TestAutodiffBackend, 2>::ones([3, 3]);
+        let tensor = Tensor::<TestAutodiffBackend, 2>::ones_default([3, 3]);
 
         let byte_recorder = BinBytesRecorder::<FullPrecisionSettings>::default();
         let bytes = byte_recorder

--- a/burn-core/src/module/param/tensor.rs
+++ b/burn-core/src/module/param/tensor.rs
@@ -91,7 +91,8 @@ mod tests {
     #[test]
     fn test_init_with_record_setting() {
         let config = LinearConfig::new(32, 32);
-        let module_init = config.init::<TestAutodiffBackend>();
+        let device = Default::default();
+        let module_init = config.init::<TestAutodiffBackend>(&device);
 
         let record = module_init.clone().into_record();
         let module_init_with = config.init_with::<TestAutodiffBackend>(record);

--- a/burn-core/src/nn/attention/mask.rs
+++ b/burn-core/src/nn/attention/mask.rs
@@ -10,10 +10,10 @@ pub fn generate_autoregressive_mask<B: Backend>(
     seq_length: usize,
     device: &B::Device,
 ) -> Tensor<B, 3, Bool> {
-    let mut mask = Tensor::<B, 3, Int>::zeros([1, seq_length, seq_length]);
+    let mut mask = Tensor::<B, 3, Int>::zeros([1, seq_length, seq_length], device);
 
     for i in 0..(seq_length - 1) {
-        let values = Tensor::<B, 3, Int>::ones([1, 1, seq_length - (i + 1)]);
+        let values = Tensor::<B, 3, Int>::ones_default([1, 1, seq_length - (i + 1)]);
         mask = mask.slice_assign([0..1, i..i + 1, i + 1..seq_length], values);
     }
 
@@ -54,7 +54,7 @@ pub fn generate_padding_mask<B: Backend>(
         }
     }
 
-    let mut tensor = Tensor::zeros([batch_size, max_size]);
+    let mut tensor = Tensor::zeros([batch_size, max_size], device);
     tensor = tensor.add_scalar(pad_token as i64);
 
     for (index, tokens) in tokens_list.into_iter().enumerate() {
@@ -70,7 +70,7 @@ pub fn generate_padding_mask<B: Backend>(
 
         tensor = tensor.slice_assign(
             [index..index + 1, 0..tokens.len()],
-            Tensor::from_data(Data::new(
+            Tensor::from_data_default(Data::new(
                 tokens.into_iter().map(|e| (e as i64).elem()).collect(),
                 Shape::new([1, seq_length]),
             )),

--- a/burn-core/src/nn/attention/mha.rs
+++ b/burn-core/src/nn/attention/mha.rs
@@ -327,7 +327,7 @@ mod tests {
         let [batch_size, seq_length, d_model, n_heads] = [7, 13, 32, 4];
         let mha = MultiHeadAttentionConfig::new(d_model, n_heads)
             .init::<TestBackend>(&Default::default());
-        let input = MhaInput::self_attn(Tensor::random(
+        let input = MhaInput::self_attn(Tensor::random_default(
             [batch_size, seq_length, d_model],
             Distribution::Default,
         ));
@@ -352,9 +352,9 @@ mod tests {
         let mha = MultiHeadAttentionConfig::new(d_model, n_heads)
             .init::<TestBackend>(&Default::default());
         let input = MhaInput::new(
-            Tensor::random([batch_size, seq_length_1, d_model], Distribution::Default),
-            Tensor::random([batch_size, seq_length_2, d_model], Distribution::Default),
-            Tensor::random([batch_size, seq_length_2, d_model], Distribution::Default),
+            Tensor::random_default([batch_size, seq_length_1, d_model], Distribution::Default),
+            Tensor::random_default([batch_size, seq_length_2, d_model], Distribution::Default),
+            Tensor::random_default([batch_size, seq_length_2, d_model], Distribution::Default),
         );
 
         let output = mha.forward(input);
@@ -378,14 +378,15 @@ mod tests {
         let mha = MultiHeadAttentionConfig::new(d_model, n_heads).init::<TestBackend>(&device);
 
         // Create a padding mask
-        let mask_pad: Tensor<TestBackend, 2, Int> = Tensor::zeros([batch_size, seq_length]);
+        let mask_pad: Tensor<TestBackend, 2, Int> =
+            Tensor::zeros([batch_size, seq_length], &device);
         let mask_pad = mask_pad.slice_assign(
             [0..batch_size, seq_length - num_padded..seq_length],
-            Tensor::ones([batch_size, num_padded]),
+            Tensor::ones_default([batch_size, num_padded]),
         );
         let mask_pad = mask_pad.equal_elem(1).to_device(&device);
 
-        let tensor_1 = Tensor::<TestBackend, 3>::random_device(
+        let tensor_1 = Tensor::<TestBackend, 3>::random(
             [batch_size, seq_length, d_model],
             Distribution::Default,
             &device,
@@ -397,7 +398,11 @@ mod tests {
                 seq_length - num_padded..seq_length,
                 0..d_model,
             ],
-            Tensor::random([batch_size, num_padded, d_model], Distribution::Default),
+            Tensor::random(
+                [batch_size, num_padded, d_model],
+                Distribution::Default,
+                &device,
+            ),
         );
 
         let input_1 = MhaInput::self_attn(tensor_1).mask_pad(mask_pad.clone());
@@ -429,6 +434,7 @@ mod tests {
         let tensor = Tensor::<TestBackend, 3>::random(
             [batch_size, seq_length, d_model],
             Distribution::Default,
+            &device,
         );
         let mask_attn = generate_autoregressive_mask(batch_size, seq_length, &tensor.device());
         let input = MhaInput::self_attn(tensor.clone()).mask_attn(mask_attn);

--- a/burn-core/src/nn/conv/conv1d.rs
+++ b/burn-core/src/nn/conv/conv1d.rs
@@ -61,7 +61,7 @@ pub struct Conv1d<B: Backend> {
 
 impl Conv1dConfig {
     /// Initialize a new [conv1d](Conv1d) module.
-    pub fn init<B: Backend>(&self) -> Conv1d<B> {
+    pub fn init<B: Backend>(&self, device: &B::Device) -> Conv1d<B> {
         checks::checks_channels_div_groups(self.channels_in, self.channels_out, self.groups);
 
         let shape = [
@@ -71,14 +71,17 @@ impl Conv1dConfig {
         ];
 
         let fan_in: usize = self.channels_in / self.groups * self.kernel_size;
-        let weight = self.initializer.init_with(shape, Some(fan_in), None);
+        let weight = self
+            .initializer
+            .init_with(shape, Some(fan_in), None, device);
         let mut bias = None;
 
         if self.bias {
-            bias = Some(
-                self.initializer
-                    .init_with([self.channels_out], Some(fan_in), None),
-            );
+            bias =
+                Some(
+                    self.initializer
+                        .init_with([self.channels_out], Some(fan_in), None, device),
+                );
         }
 
         Conv1d {
@@ -140,7 +143,7 @@ mod tests {
         let config = Conv1dConfig::new(5, 5, 5);
         let k = (config.channels_in * config.kernel_size) as f64;
         let k = sqrt(config.groups as f64 / k) as f32;
-        let conv = config.init::<TestBackend>();
+        let conv = config.init::<TestBackend>(&Default::default());
 
         conv.weight.to_data().assert_within_range(-k..k);
     }
@@ -150,7 +153,7 @@ mod tests {
         TestBackend::seed(0);
 
         let config = Conv1dConfig::new(5, 5, 5).with_initializer(Initializer::Zeros);
-        let conv = config.init::<TestBackend>();
+        let conv = config.init::<TestBackend>(&Default::default());
 
         assert_eq!(config.initializer, Initializer::Zeros);
         conv.weight

--- a/burn-core/src/nn/conv/conv2d.rs
+++ b/burn-core/src/nn/conv/conv2d.rs
@@ -60,7 +60,7 @@ pub struct Conv2d<B: Backend> {
 
 impl Conv2dConfig {
     /// Initialize a new [conv2d](Conv2d) module.
-    pub fn init<B: Backend>(&self) -> Conv2d<B> {
+    pub fn init<B: Backend>(&self, device: &B::Device) -> Conv2d<B> {
         checks::checks_channels_div_groups(self.channels[0], self.channels[1], self.groups);
 
         let shape = [
@@ -71,13 +71,15 @@ impl Conv2dConfig {
         ];
 
         let fan_in = self.channels[0] / self.groups * self.kernel_size.iter().product::<usize>();
-        let weight = self.initializer.init_with(shape, Some(fan_in), None);
+        let weight = self
+            .initializer
+            .init_with(shape, Some(fan_in), None, device);
         let mut bias = None;
 
         if self.bias {
             bias = Some(
                 self.initializer
-                    .init_with([self.channels[1]], Some(fan_in), None),
+                    .init_with([self.channels[1]], Some(fan_in), None, device),
             );
         }
 
@@ -140,7 +142,8 @@ mod tests {
         let config = Conv2dConfig::new([5, 1], [5, 5]);
         let k = (config.channels[0] * config.kernel_size[0] * config.kernel_size[1]) as f64;
         let k = sqrt(config.groups as f64 / k) as f32;
-        let conv = config.init::<TestBackend>();
+        let device = Default::default();
+        let conv = config.init::<TestBackend>(&device);
 
         conv.weight.to_data().assert_within_range(-k..k);
     }
@@ -150,7 +153,8 @@ mod tests {
         TestBackend::seed(0);
 
         let config = Conv2dConfig::new([5, 2], [5, 5]).with_initializer(Initializer::Zeros);
-        let conv = config.init::<TestBackend>();
+        let device = Default::default();
+        let conv = config.init::<TestBackend>(&device);
 
         assert_eq!(config.initializer, Initializer::Zeros);
         conv.weight

--- a/burn-core/src/nn/conv/conv_transpose2d.rs
+++ b/burn-core/src/nn/conv/conv_transpose2d.rs
@@ -63,7 +63,7 @@ pub struct ConvTranspose2d<B: Backend> {
 
 impl ConvTranspose2dConfig {
     /// Initialize a new [conv transpose 2d](ConvTranspose2d) module.
-    pub fn init<B: Backend>(&self) -> ConvTranspose2d<B> {
+    pub fn init<B: Backend>(&self, device: &B::Device) -> ConvTranspose2d<B> {
         checks::checks_channels_div_groups(self.channels[0], self.channels[1], self.groups);
 
         let shape = [
@@ -74,13 +74,15 @@ impl ConvTranspose2dConfig {
         ];
 
         let fan_in = self.channels[1] / self.groups * self.kernel_size.iter().product::<usize>();
-        let weight = self.initializer.init_with(shape, Some(fan_in), None);
+        let weight = self
+            .initializer
+            .init_with(shape, Some(fan_in), None, device);
         let mut bias = None;
 
         if self.bias {
             bias = Some(
                 self.initializer
-                    .init_with([self.channels[1]], Some(fan_in), None),
+                    .init_with([self.channels[1]], Some(fan_in), None, device),
             );
         }
 
@@ -147,7 +149,7 @@ mod tests {
         let config = ConvTranspose2dConfig::new([5, 1], [5, 5]);
         let k = (config.channels[1] * config.kernel_size[0] * config.kernel_size[1]) as f64;
         let k = sqrt(config.groups as f64 / k) as f32;
-        let conv = config.init::<TestBackend>();
+        let conv = config.init::<TestBackend>(&Default::default());
 
         conv.weight.to_data().assert_within_range(-k..k);
     }
@@ -158,7 +160,7 @@ mod tests {
 
         let config =
             ConvTranspose2dConfig::new([5, 2], [5, 5]).with_initializer(Initializer::Zeros);
-        let conv = config.init::<TestBackend>();
+        let conv = config.init::<TestBackend>(&Default::default());
 
         assert_eq!(config.initializer, Initializer::Zeros);
         conv.weight

--- a/burn-core/src/nn/dropout.rs
+++ b/burn-core/src/nn/dropout.rs
@@ -64,7 +64,7 @@ mod tests {
     #[cfg(feature = "std")]
     #[test]
     fn with_ad_backend_should_mark_input() {
-        let tensor = Tensor::<TestAutodiffBackend, 2>::ones(Shape::new([100, 100]));
+        let tensor = Tensor::<TestAutodiffBackend, 2>::ones_default(Shape::new([100, 100]));
         let dropout = DropoutConfig::new(0.5).init();
 
         let output = dropout.forward(tensor.clone());
@@ -74,7 +74,7 @@ mod tests {
 
     #[test]
     fn without_ad_backend_should_not_change_input() {
-        let tensor = Tensor::<TestBackend, 2>::ones(Shape::new([100, 100]));
+        let tensor = Tensor::<TestBackend, 2>::ones_default(Shape::new([100, 100]));
         let dropout = DropoutConfig::new(0.5).init();
 
         let output = dropout.forward(tensor.clone());

--- a/burn-core/src/nn/embedding.rs
+++ b/burn-core/src/nn/embedding.rs
@@ -33,10 +33,10 @@ pub struct Embedding<B: Backend> {
 
 impl EmbeddingConfig {
     /// Initialize a new [embedding](Embedding) module.
-    pub fn init<B: Backend>(&self) -> Embedding<B> {
+    pub fn init<B: Backend>(&self, device: &B::Device) -> Embedding<B> {
         let weight = self
             .initializer
-            .init([self.n_embedding, self.d_model])
+            .init([self.n_embedding, self.d_model], device)
             .require_grad();
 
         Embedding {
@@ -74,7 +74,7 @@ mod tests {
         TestBackend::seed(0);
 
         let config = EmbeddingConfig::new(100, 10);
-        let embed = config.init::<TestBackend>();
+        let embed = config.init::<TestBackend>(&Default::default());
         let weights = embed.weight.val().reshape([1000]);
         let (var_act, mean_act) = weights.var_mean(0);
 
@@ -96,7 +96,7 @@ mod tests {
         TestBackend::seed(0);
 
         let config = EmbeddingConfig::new(5, 5).with_initializer(Initializer::Zeros);
-        let embed = config.init::<TestBackend>();
+        let embed = config.init::<TestBackend>(&Default::default());
 
         assert_eq!(config.initializer, Initializer::Zeros);
         embed

--- a/burn-core/src/nn/initializer.rs
+++ b/burn-core/src/nn/initializer.rs
@@ -98,9 +98,9 @@ impl Initializer {
     ) -> Tensor<B, D> {
         let shape = shape.into();
         match self {
-            Initializer::Constant { value } => Tensor::<B, D>::full_device(shape, *value, device),
-            Initializer::Ones => Tensor::<B, D>::ones_device(shape, device),
-            Initializer::Zeros => Tensor::<B, D>::zeros_device(shape, device),
+            Initializer::Constant { value } => Tensor::<B, D>::full(shape, *value, device),
+            Initializer::Ones => Tensor::<B, D>::ones(shape, device),
+            Initializer::Zeros => Tensor::<B, D>::zeros(shape, device),
             Initializer::Uniform { min, max } => uniform_draw(shape, *min, *max, device),
             Initializer::Normal { mean, std } => normal_draw(shape, *mean, *std, device),
             Initializer::KaimingUniform { gain, fan_out_only } => {
@@ -155,7 +155,7 @@ fn uniform_draw<B: Backend, const D: usize, S: Into<Shape<D>>>(
 ) -> Tensor<B, D> {
     let distribution =
         Distribution::Uniform(low.elem::<B::FloatElem>(), high.elem::<B::FloatElem>());
-    Tensor::<B, D>::random_device(shape, distribution, device)
+    Tensor::<B, D>::random(shape, distribution, device)
 }
 
 fn normal_draw<B: Backend, const D: usize, S: Into<Shape<D>>>(
@@ -165,7 +165,7 @@ fn normal_draw<B: Backend, const D: usize, S: Into<Shape<D>>>(
     device: &B::Device,
 ) -> Tensor<B, D> {
     let distribution = Distribution::Normal(mean, std);
-    Tensor::<B, D>::random_device(shape, distribution, device)
+    Tensor::<B, D>::random(shape, distribution, device)
 }
 
 #[cfg(test)]

--- a/burn-core/src/nn/linear.rs
+++ b/burn-core/src/nn/linear.rs
@@ -138,9 +138,9 @@ mod tests {
         let device = Default::default();
         let linear = config.init::<TestBackend>(&device);
 
-        let input = Tensor::<TestBackend, 2>::ones_device(Shape::new([1, 2]), &device);
+        let input = Tensor::<TestBackend, 2>::ones(Shape::new([1, 2]), &device);
         let result = linear.forward(input);
-        let expected_result = Tensor::<TestBackend, 2>::from_data_device([[4., 4., 4.]], &device);
+        let expected_result = Tensor::<TestBackend, 2>::from_data([[4., 4., 4.]], &device);
 
         assert_eq!(result.into_data(), expected_result.into_data());
     }
@@ -155,9 +155,9 @@ mod tests {
         let config = LinearConfig::new(2, 3).with_initializer(Initializer::Constant { value });
         let linear = config.init::<TestBackend>(&device);
 
-        let input = Tensor::<TestBackend, 2>::ones_device(Shape::new([1, 2]), &device);
+        let input = Tensor::<TestBackend, 2>::ones(Shape::new([1, 2]), &device);
         let result = linear.forward(input);
-        let expected_result = Tensor::<TestBackend, 2>::from_data_device([[6., 6., 6.]], &device);
+        let expected_result = Tensor::<TestBackend, 2>::from_data([[6., 6., 6.]], &device);
 
         assert_eq!(result.into_data(), expected_result.into_data());
     }

--- a/burn-core/src/nn/linear.rs
+++ b/burn-core/src/nn/linear.rs
@@ -38,16 +38,17 @@ pub struct Linear<B: Backend> {
 
 impl LinearConfig {
     /// Initialize a new [linear](Linear) module.
-    pub fn init<B: Backend>(&self) -> Linear<B> {
+    pub fn init<B: Backend>(&self, device: &B::Device) -> Linear<B> {
         let shape = [self.d_input, self.d_output];
-        let weight = self
-            .initializer
-            .init_with(shape, Some(self.d_input), Some(self.d_output));
+        let weight =
+            self.initializer
+                .init_with(shape, Some(self.d_input), Some(self.d_output), device);
         let bias = if self.bias {
             Some(self.initializer.init_with(
                 [self.d_output],
                 Some(self.d_input),
                 Some(self.d_output),
+                device,
             ))
         } else {
             None
@@ -98,7 +99,8 @@ mod tests {
 
         let config = LinearConfig::new(5, 5);
         let k = sqrt(1.0 / config.d_input as f64) as f32;
-        let linear = config.init::<TestBackend>();
+        let device = Default::default();
+        let linear = config.init::<TestBackend>(&device);
 
         assert_eq!(
             config.initializer,
@@ -115,7 +117,8 @@ mod tests {
         TestBackend::seed(0);
 
         let config = LinearConfig::new(5, 5).with_initializer(Initializer::Zeros);
-        let linear = config.init::<TestBackend>();
+        let device = Default::default();
+        let linear = config.init::<TestBackend>(&device);
 
         assert_eq!(config.initializer, Initializer::Zeros);
         linear
@@ -132,11 +135,12 @@ mod tests {
         let config = LinearConfig::new(2, 3)
             .with_initializer(Initializer::Constant { value })
             .with_bias(false);
-        let linear = config.init();
+        let device = Default::default();
+        let linear = config.init::<TestBackend>(&device);
 
-        let input = Tensor::<TestBackend, 2>::ones(Shape::new([1, 2]));
+        let input = Tensor::<TestBackend, 2>::ones_device(Shape::new([1, 2]), &device);
         let result = linear.forward(input);
-        let expected_result = Tensor::<TestBackend, 2>::from_data([[4., 4., 4.]]);
+        let expected_result = Tensor::<TestBackend, 2>::from_data_device([[4., 4., 4.]], &device);
 
         assert_eq!(result.into_data(), expected_result.into_data());
     }
@@ -145,13 +149,15 @@ mod tests {
     fn test_linear_forward_with_bias() {
         TestBackend::seed(0);
 
+        let device = Default::default();
+
         let value = 2.;
         let config = LinearConfig::new(2, 3).with_initializer(Initializer::Constant { value });
-        let linear = config.init();
+        let linear = config.init::<TestBackend>(&device);
 
-        let input = Tensor::<TestBackend, 2>::ones(Shape::new([1, 2]));
+        let input = Tensor::<TestBackend, 2>::ones_device(Shape::new([1, 2]), &device);
         let result = linear.forward(input);
-        let expected_result = Tensor::<TestBackend, 2>::from_data([[6., 6., 6.]]);
+        let expected_result = Tensor::<TestBackend, 2>::from_data_device([[6., 6., 6.]], &device);
 
         assert_eq!(result.into_data(), expected_result.into_data());
     }

--- a/burn-core/src/nn/loss/binary_cross_entropy.rs
+++ b/burn-core/src/nn/loss/binary_cross_entropy.rs
@@ -36,7 +36,7 @@ impl BinaryCrossEntropyLossConfig {
             weights: self
                 .weights
                 .as_ref()
-                .map(|e| Tensor::<B, 1>::from_floats(e.as_slice())),
+                .map(|e| Tensor::<B, 1>::from_floats_default(e.as_slice())),
             smoothing: self.smoothing,
             logits: self.logits,
         }
@@ -122,8 +122,9 @@ mod tests {
     #[test]
     fn test_binary_cross_entropy() {
         let [batch_size] = [4];
-        let logits = Tensor::<TestBackend, 1>::random([batch_size], Distribution::Normal(0., 1.0));
-        let targets = Tensor::<TestBackend, 1, Int>::from_data(Data::from([0, 1, 0, 1]));
+        let logits =
+            Tensor::<TestBackend, 1>::random_default([batch_size], Distribution::Normal(0., 1.0));
+        let targets = Tensor::<TestBackend, 1, Int>::from_data_default(Data::from([0, 1, 0, 1]));
 
         let loss_1 = BinaryCrossEntropyLossConfig::new()
             .init()
@@ -138,8 +139,9 @@ mod tests {
     #[test]
     fn test_binary_cross_entropy_with_weights() {
         let [batch_size] = [4];
-        let logits = Tensor::<TestBackend, 1>::random([batch_size], Distribution::Normal(0., 1.0));
-        let targets = Tensor::<TestBackend, 1, Int>::from_data(Data::from([0, 1, 0, 1]));
+        let logits =
+            Tensor::<TestBackend, 1>::random_default([batch_size], Distribution::Normal(0., 1.0));
+        let targets = Tensor::<TestBackend, 1, Int>::from_data_default(Data::from([0, 1, 0, 1]));
         let weights = [3., 7.];
 
         let loss_1 = BinaryCrossEntropyLossConfig::new()
@@ -150,7 +152,7 @@ mod tests {
         let loss_2 = targets.clone().float() * logits.clone().log()
             + (-targets.float() + 1) * (-logits + 1).log();
 
-        let loss_2 = loss_2 * Tensor::from_floats([3., 7., 3., 7.]);
+        let loss_2 = loss_2 * Tensor::from_floats_default([3., 7., 3., 7.]);
         let loss_2 = loss_2.neg().sum() / (3. + 3. + 7. + 7.);
         loss_1.into_data().assert_approx_eq(&loss_2.into_data(), 3);
     }
@@ -158,8 +160,9 @@ mod tests {
     #[test]
     fn test_binary_cross_entropy_with_smoothing() {
         let [batch_size] = [4];
-        let logits = Tensor::<TestBackend, 1>::random([batch_size], Distribution::Normal(0., 1.0));
-        let targets = Tensor::<TestBackend, 1, Int>::from_data(Data::from([0, 1, 0, 1]));
+        let logits =
+            Tensor::<TestBackend, 1>::random_default([batch_size], Distribution::Normal(0., 1.0));
+        let targets = Tensor::<TestBackend, 1, Int>::from_data_default(Data::from([0, 1, 0, 1]));
 
         let loss_1 = BinaryCrossEntropyLossConfig::new()
             .with_smoothing(Some(0.1))

--- a/burn-core/src/nn/loss/cross_entropy.rs
+++ b/burn-core/src/nn/loss/cross_entropy.rs
@@ -44,7 +44,7 @@ impl CrossEntropyLossConfig {
             weights: self
                 .weights
                 .as_ref()
-                .map(|e| Tensor::<B, 1>::from_floats(e.as_slice())),
+                .map(|e| Tensor::<B, 1>::from_floats_default(e.as_slice())),
             smoothing: self.smoothing,
             logits: self.logits,
         }
@@ -167,10 +167,10 @@ impl<B: Backend> CrossEntropyLoss<B> {
     ) -> Tensor<B, 2> {
         let [batch_size, nr_classes] = shape;
         let device = &targets.device();
-        let targets_matrix = Tensor::<B, 2>::zeros_device(shape, device).scatter(
+        let targets_matrix = Tensor::<B, 2>::zeros(shape, device).scatter(
             1,
             targets.reshape([batch_size, 1]),
-            Tensor::ones_device([batch_size, 1], device),
+            Tensor::ones([batch_size, 1], device),
         );
         targets_matrix * (1. - alpha) + alpha / nr_classes as f32
     }
@@ -226,12 +226,13 @@ mod tests {
     macro_rules! setup {
         () => {{
             let [batch_size, num_targets] = [4, 5];
-            let logits = Tensor::<TestBackend, 2>::random(
+            let logits = Tensor::<TestBackend, 2>::random_default(
                 [batch_size, num_targets],
                 Distribution::Normal(0., 1.0),
             );
-            let targets = Tensor::<TestBackend, 1, Int>::from_data(Data::from([2, 0, 4, 1]));
-            let targets_logits = Tensor::<TestBackend, 2>::from_data(Data::from([
+            let targets =
+                Tensor::<TestBackend, 1, Int>::from_data_default(Data::from([2, 0, 4, 1]));
+            let targets_logits = Tensor::<TestBackend, 2>::from_data_default(Data::from([
                 [0.0, 0.0, 1.0, 0.0, 0.0],
                 [1.0, 0.0, 0.0, 0.0, 0.0],
                 [0.0, 0.0, 0.0, 0.0, 1.0],
@@ -244,14 +245,14 @@ mod tests {
     macro_rules! setup_padded {
         () => {{
             let [batch_size, num_targets, pad_index] = [4, 5, 1];
-            let logits = Tensor::<TestBackend, 2>::random(
+            let logits = Tensor::<TestBackend, 2>::random_default(
                 [batch_size, num_targets],
                 Distribution::Normal(0., 1.0),
             );
-            let targets = Tensor::<TestBackend, 1, Int>::from_data(
+            let targets = Tensor::<TestBackend, 1, Int>::from_data_default(
                 Data::<i64, 1>::from([2, 0, 4, pad_index as i64]).convert(),
             );
-            let targets_logits = Tensor::<TestBackend, 2>::from_data(Data::from([
+            let targets_logits = Tensor::<TestBackend, 2>::from_data_default(Data::from([
                 [0.0, 0.0, 0.0, 0.0, 0.0],
                 [1.0, 0.0, 0.0, 0.0, 0.0],
                 [0.0, 0.0, 0.0, 0.0, 1.0],
@@ -272,7 +273,7 @@ mod tests {
         let tensor = log_softmax(logits, 1);
         let loss_2 = tensor
             * targets_logits
-            * Tensor::<TestBackend, 1>::from_floats(weights.as_slice())
+            * Tensor::<TestBackend, 1>::from_floats_default(weights.as_slice())
                 .unsqueeze()
                 .repeat(0, 4);
         let loss_2 = loss_2.sum().neg() / (1. + 2. + 3. + 5.);
@@ -357,7 +358,7 @@ mod tests {
         let (logits, targets, _) = setup!();
         let smoothed_targets =
             CrossEntropyLoss::compute_smoothed_targets(logits.dims(), targets, 0.05);
-        let targets_logits = Tensor::<TestBackend, 2>::from_data(Data::from([
+        let targets_logits = Tensor::<TestBackend, 2>::from_data_default(Data::from([
             [0.01, 0.01, 0.96, 0.01, 0.01],
             [0.96, 0.01, 0.01, 0.01, 0.01],
             [0.01, 0.01, 0.01, 0.01, 0.96],
@@ -375,7 +376,7 @@ mod tests {
             .with_smoothing(Some(0.05))
             .init()
             .forward(logits.clone(), targets);
-        let targets_logits = Tensor::<TestBackend, 2>::from_data(Data::from([
+        let targets_logits = Tensor::<TestBackend, 2>::from_data_default(Data::from([
             [0.01, 0.01, 0.96, 0.01, 0.01],
             [0.96, 0.01, 0.01, 0.01, 0.01],
             [0.01, 0.01, 0.01, 0.01, 0.96],

--- a/burn-core/src/nn/loss/mse.rs
+++ b/burn-core/src/nn/loss/mse.rs
@@ -60,9 +60,9 @@ mod tests {
 
     #[test]
     fn test_mse_loss() {
-        let logits = Tensor::<TestBackend, 2>::from_data(Data::from([[1.0, 2.0], [3.0, 4.0]]));
+        let logits = Tensor::<TestBackend, 2>::from_data_default(Data::from([[1.0, 2.0], [3.0, 4.0]]));
 
-        let targets = Tensor::<TestBackend, 2>::from_data(Data::from([[2.0, 1.0], [3.0, 2.0]]));
+        let targets = Tensor::<TestBackend, 2>::from_data_default(Data::from([[2.0, 1.0], [3.0, 2.0]]));
 
         let mse = MSELoss::new();
         let loss_no_reduction = mse.forward_no_reduction(logits.clone(), targets.clone());

--- a/burn-core/src/nn/loss/mse.rs
+++ b/burn-core/src/nn/loss/mse.rs
@@ -60,9 +60,11 @@ mod tests {
 
     #[test]
     fn test_mse_loss() {
-        let logits = Tensor::<TestBackend, 2>::from_data_default(Data::from([[1.0, 2.0], [3.0, 4.0]]));
+        let logits =
+            Tensor::<TestBackend, 2>::from_data_default(Data::from([[1.0, 2.0], [3.0, 4.0]]));
 
-        let targets = Tensor::<TestBackend, 2>::from_data_default(Data::from([[2.0, 1.0], [3.0, 2.0]]));
+        let targets =
+            Tensor::<TestBackend, 2>::from_data_default(Data::from([[2.0, 1.0], [3.0, 2.0]]));
 
         let mse = MSELoss::new();
         let loss_no_reduction = mse.forward_no_reduction(logits.clone(), targets.clone());

--- a/burn-core/src/nn/norm/batch.rs
+++ b/burn-core/src/nn/norm/batch.rs
@@ -34,12 +34,12 @@ pub struct BatchNorm<B: Backend, const D: usize> {
 
 impl BatchNormConfig {
     /// Initialize a new [batch norm](BatchNorm) module.
-    pub fn init<B: Backend, const D: usize>(&self) -> BatchNorm<B, D> {
-        let gamma = Tensor::ones([self.num_features]);
-        let beta = Tensor::zeros([self.num_features]);
+    pub fn init<B: Backend, const D: usize>(&self, device: &B::Device) -> BatchNorm<B, D> {
+        let gamma = Tensor::ones_device([self.num_features], device);
+        let beta = Tensor::zeros_device([self.num_features], device);
 
-        let running_mean = Tensor::zeros([self.num_features]);
-        let running_var = Tensor::ones([self.num_features]);
+        let running_mean = Tensor::zeros_device([self.num_features], device);
+        let running_var = Tensor::ones_device([self.num_features], device);
 
         BatchNorm {
             gamma: Param::from(gamma),
@@ -179,9 +179,10 @@ mod tests_1d {
 
     #[test]
     fn batch_norm_forward_train() {
-        let module = BatchNormConfig::new(3).init::<TestAutodiffBackend, 1>();
+        let device = Default::default();
+        let module = BatchNormConfig::new(3).init::<TestAutodiffBackend, 1>(&device);
 
-        let output = module.forward(input_tensor());
+        let output = module.forward(input_tensor(&device));
 
         output.to_data().assert_approx_eq(
             &Data::from([
@@ -202,11 +203,12 @@ mod tests_1d {
 
     #[test]
     fn batch_norm_forward_inference() {
-        let module = BatchNormConfig::new(3).init::<TestAutodiffBackend, 1>();
+        let device = Default::default();
+        let module = BatchNormConfig::new(3).init::<TestAutodiffBackend, 1>(&device);
 
-        module.forward(input_tensor());
+        module.forward(input_tensor(&device));
         let module = module.valid();
-        let output = module.forward(input_tensor());
+        let output = module.forward(input_tensor(&device));
 
         output.to_data().assert_approx_eq(
             &Data::from([
@@ -217,11 +219,14 @@ mod tests_1d {
         );
     }
 
-    fn input_tensor<B: Backend>() -> Tensor<B, 3> {
-        Tensor::<B, 3>::from_floats([
-            [[0.9601, 0.7277], [0.6272, 0.9034], [0.9378, 0.7230]],
-            [[0.6356, 0.1362], [0.0249, 0.9509], [0.6600, 0.5945]],
-        ])
+    fn input_tensor<B: Backend>(device: &B::Device) -> Tensor<B, 3> {
+        Tensor::<B, 3>::from_floats_device(
+            [
+                [[0.9601, 0.7277], [0.6272, 0.9034], [0.9378, 0.7230]],
+                [[0.6356, 0.1362], [0.0249, 0.9509], [0.6600, 0.5945]],
+            ],
+            device,
+        )
     }
 }
 
@@ -234,9 +239,10 @@ mod tests_2d {
 
     #[test]
     fn batch_norm_forward_train() {
-        let module = BatchNormConfig::new(3).init::<TestAutodiffBackend, 2>();
+        let device = Default::default();
+        let module = BatchNormConfig::new(3).init::<TestAutodiffBackend, 2>(&device);
 
-        let output = module.forward(input_tensor());
+        let output = module.forward(input_tensor(&device));
 
         output.to_data().assert_approx_eq(
             &Data::from([
@@ -257,11 +263,12 @@ mod tests_2d {
 
     #[test]
     fn batch_norm_forward_inference() {
-        let module = BatchNormConfig::new(3).init::<TestAutodiffBackend, 2>();
+        let device = Default::default();
+        let module = BatchNormConfig::new(3).init::<TestAutodiffBackend, 2>(&device);
 
-        module.forward(input_tensor());
+        module.forward(input_tensor(&device));
         let module = module.valid();
-        let output = module.forward(input_tensor());
+        let output = module.forward(input_tensor(&device));
 
         output.to_data().assert_approx_eq(
             &Data::from([
@@ -282,9 +289,10 @@ mod tests_2d {
 
     #[test]
     fn batch_norm_running_mean() {
-        let module = BatchNormConfig::new(3).init::<TestAutodiffBackend, 2>();
+        let device = Default::default();
+        let module = BatchNormConfig::new(3).init::<TestAutodiffBackend, 2>(&device);
 
-        let _output = module.forward(input_tensor());
+        let _output = module.forward(input_tensor(&device));
 
         let running_mean = module.running_mean.value_sync();
 
@@ -296,9 +304,10 @@ mod tests_2d {
 
     #[test]
     fn batch_norm_running_var() {
-        let module = BatchNormConfig::new(3).init::<TestAutodiffBackend, 2>();
+        let device = Default::default();
+        let module = BatchNormConfig::new(3).init::<TestAutodiffBackend, 2>(&device);
 
-        let _output = module.forward(input_tensor());
+        let _output = module.forward(input_tensor(&device));
 
         let running_var = module.running_var.value_sync();
 
@@ -310,9 +319,10 @@ mod tests_2d {
 
     #[test]
     fn batch_norm_running_mean_inner_module() {
-        let module = BatchNormConfig::new(3).init::<TestAutodiffBackend, 2>();
+        let device = Default::default();
+        let module = BatchNormConfig::new(3).init::<TestAutodiffBackend, 2>(&device);
 
-        let _output = module.forward(input_tensor());
+        let _output = module.forward(input_tensor(&device));
 
         let module_valid = module.valid();
         let running_mean = module_valid.running_mean.value();
@@ -325,8 +335,9 @@ mod tests_2d {
 
     #[test]
     fn batch_norm_grads() {
-        let module = BatchNormConfig::new(3).init::<TestAutodiffBackend, 2>();
-        let input = input_tensor().require_grad();
+        let device = Default::default();
+        let module = BatchNormConfig::new(3).init::<TestAutodiffBackend, 2>(&device);
+        let input = input_tensor(&device).require_grad();
 
         let output = module.forward(input.clone());
 
@@ -365,18 +376,21 @@ mod tests_2d {
         );
     }
 
-    fn input_tensor<B: Backend>() -> Tensor<B, 4> {
-        Tensor::<B, 4>::from_floats([
+    fn input_tensor<B: Backend>(device: &B::Device) -> Tensor<B, 4> {
+        Tensor::<B, 4>::from_floats_device(
             [
-                [[0.9601, 0.7277], [0.1270, 0.5441]],
-                [[0.6272, 0.9034], [0.4066, 0.7179]],
-                [[0.9378, 0.7230], [0.3544, 0.9591]],
+                [
+                    [[0.9601, 0.7277], [0.1270, 0.5441]],
+                    [[0.6272, 0.9034], [0.4066, 0.7179]],
+                    [[0.9378, 0.7230], [0.3544, 0.9591]],
+                ],
+                [
+                    [[0.6356, 0.1362], [0.1333, 0.7287]],
+                    [[0.0249, 0.9509], [0.3791, 0.2481]],
+                    [[0.6600, 0.5945], [0.5424, 0.4767]],
+                ],
             ],
-            [
-                [[0.6356, 0.1362], [0.1333, 0.7287]],
-                [[0.0249, 0.9509], [0.3791, 0.2481]],
-                [[0.6600, 0.5945], [0.5424, 0.4767]],
-            ],
-        ])
+            device,
+        )
     }
 }

--- a/burn-core/src/nn/norm/batch.rs
+++ b/burn-core/src/nn/norm/batch.rs
@@ -35,11 +35,11 @@ pub struct BatchNorm<B: Backend, const D: usize> {
 impl BatchNormConfig {
     /// Initialize a new [batch norm](BatchNorm) module.
     pub fn init<B: Backend, const D: usize>(&self, device: &B::Device) -> BatchNorm<B, D> {
-        let gamma = Tensor::ones_device([self.num_features], device);
-        let beta = Tensor::zeros_device([self.num_features], device);
+        let gamma = Tensor::ones([self.num_features], device);
+        let beta = Tensor::zeros([self.num_features], device);
 
-        let running_mean = Tensor::zeros_device([self.num_features], device);
-        let running_var = Tensor::ones_device([self.num_features], device);
+        let running_mean = Tensor::zeros([self.num_features], device);
+        let running_var = Tensor::ones([self.num_features], device);
 
         BatchNorm {
             gamma: Param::from(gamma),
@@ -220,7 +220,7 @@ mod tests_1d {
     }
 
     fn input_tensor<B: Backend>(device: &B::Device) -> Tensor<B, 3> {
-        Tensor::<B, 3>::from_floats_device(
+        Tensor::<B, 3>::from_floats(
             [
                 [[0.9601, 0.7277], [0.6272, 0.9034], [0.9378, 0.7230]],
                 [[0.6356, 0.1362], [0.0249, 0.9509], [0.6600, 0.5945]],
@@ -377,7 +377,7 @@ mod tests_2d {
     }
 
     fn input_tensor<B: Backend>(device: &B::Device) -> Tensor<B, 4> {
-        Tensor::<B, 4>::from_floats_device(
+        Tensor::<B, 4>::from_floats(
             [
                 [
                     [[0.9601, 0.7277], [0.1270, 0.5441]],

--- a/burn-core/src/nn/norm/layer.rs
+++ b/burn-core/src/nn/norm/layer.rs
@@ -28,9 +28,9 @@ pub struct LayerNorm<B: Backend> {
 
 impl LayerNormConfig {
     /// Initialize a new [layer norm](LayerNorm) module.
-    pub fn init<B: Backend>(&self) -> LayerNorm<B> {
-        let gamma = Tensor::ones([self.d_model]);
-        let beta = Tensor::zeros([self.d_model]);
+    pub fn init<B: Backend>(&self, device: &B::Device) -> LayerNorm<B> {
+        let gamma = Tensor::ones_device([self.d_model], device);
+        let beta = Tensor::zeros_device([self.d_model], device);
 
         LayerNorm {
             gamma: Param::from(gamma),
@@ -80,10 +80,14 @@ mod tests {
 
     #[test]
     fn layer_norm_forward() {
-        let module = LayerNormConfig::new(10).init::<TestBackend>();
-        let input = Tensor::from_data(Data::from([[
-            -0.6897, -2.7106, 2.2222, -1.0330, -0.8933, 1.1765, 0.0601, 1.5252, -0.3630, 0.6728,
-        ]]));
+        let device = Default::default();
+        let module = LayerNormConfig::new(10).init::<TestBackend>(&device);
+        let input = Tensor::from_data_device(
+            Data::from([[
+                -0.6897, -2.7106, 2.2222, -1.0330, -0.8933, 1.1765, 0.0601, 1.5252, -0.3630, 0.6728,
+            ]]),
+            &device,
+        );
 
         let output = module.forward(input);
 
@@ -98,13 +102,18 @@ mod tests {
     #[cfg(feature = "std")]
     #[test]
     fn layer_norm_backward() {
-        let module = LayerNormConfig::new(2).init::<TestAutodiffBackend>();
-        let tensor_1 =
-            Tensor::<TestAutodiffBackend, 2>::from_data(Data::from([[0.0, 1.0], [3.0, 4.0]]))
-                .require_grad();
-        let tensor_2 =
-            Tensor::<TestAutodiffBackend, 2>::from_data(Data::from([[6.0, 7.0], [9.0, 10.0]]))
-                .require_grad();
+        let device = Default::default();
+        let module = LayerNormConfig::new(2).init::<TestAutodiffBackend>(&device);
+        let tensor_1 = Tensor::<TestAutodiffBackend, 2>::from_data_device(
+            Data::from([[0.0, 1.0], [3.0, 4.0]]),
+            &device,
+        )
+        .require_grad();
+        let tensor_2 = Tensor::<TestAutodiffBackend, 2>::from_data_device(
+            Data::from([[6.0, 7.0], [9.0, 10.0]]),
+            &device,
+        )
+        .require_grad();
 
         let x = tensor_1.clone().matmul(tensor_2.clone());
 

--- a/burn-core/src/nn/norm/layer.rs
+++ b/burn-core/src/nn/norm/layer.rs
@@ -29,8 +29,8 @@ pub struct LayerNorm<B: Backend> {
 impl LayerNormConfig {
     /// Initialize a new [layer norm](LayerNorm) module.
     pub fn init<B: Backend>(&self, device: &B::Device) -> LayerNorm<B> {
-        let gamma = Tensor::ones_device([self.d_model], device);
-        let beta = Tensor::zeros_device([self.d_model], device);
+        let gamma = Tensor::ones([self.d_model], device);
+        let beta = Tensor::zeros([self.d_model], device);
 
         LayerNorm {
             gamma: Param::from(gamma),
@@ -82,7 +82,7 @@ mod tests {
     fn layer_norm_forward() {
         let device = Default::default();
         let module = LayerNormConfig::new(10).init::<TestBackend>(&device);
-        let input = Tensor::from_data_device(
+        let input = Tensor::from_data(
             Data::from([[
                 -0.6897, -2.7106, 2.2222, -1.0330, -0.8933, 1.1765, 0.0601, 1.5252, -0.3630, 0.6728,
             ]]),
@@ -104,12 +104,12 @@ mod tests {
     fn layer_norm_backward() {
         let device = Default::default();
         let module = LayerNormConfig::new(2).init::<TestAutodiffBackend>(&device);
-        let tensor_1 = Tensor::<TestAutodiffBackend, 2>::from_data_device(
+        let tensor_1 = Tensor::<TestAutodiffBackend, 2>::from_data(
             Data::from([[0.0, 1.0], [3.0, 4.0]]),
             &device,
         )
         .require_grad();
-        let tensor_2 = Tensor::<TestAutodiffBackend, 2>::from_data_device(
+        let tensor_2 = Tensor::<TestAutodiffBackend, 2>::from_data(
             Data::from([[6.0, 7.0], [9.0, 10.0]]),
             &device,
         )

--- a/burn-core/src/nn/pos_encoding.rs
+++ b/burn-core/src/nn/pos_encoding.rs
@@ -145,7 +145,7 @@ pub fn generate_sinusoids<B: Backend>(
         [length, d_model].into(),
     );
 
-    Tensor::<B, 2>::from_data(data.convert())
+    Tensor::<B, 2>::from_data_default(data.convert())
 }
 
 #[cfg(test)]
@@ -165,13 +165,13 @@ mod tests {
 
         // Use a tensor of zeros as input for easy verification of the output
         // The output should be the sinusoids broadcasted to the input shape
-        let tensor = Tensor::zeros([batch_size, length, d_model]);
+        let tensor = Tensor::zeros_default([batch_size, length, d_model]);
 
         let output = pe.forward(tensor);
 
         assert_eq!(output.shape().dims, [batch_size, length, d_model]);
 
-        let expected = Tensor::<TestBackend, 3>::from_floats([
+        let expected = Tensor::<TestBackend, 3>::from_floats_default([
             [
                 [0.00000, 1.00000, 0.00000, 1.00000, 0.00000, 1.00000],
                 [0.84147, 0.54030, 0.04640, 0.99892, 0.00215, 1.00000],
@@ -192,7 +192,7 @@ mod tests {
         let sinusoids = generate_sinusoids::<TestBackend>(12, 6, 10_000);
 
         // The values are taken from the pytorch reference implementation
-        let expected = Tensor::<TestBackend, 2>::from_floats([
+        let expected = Tensor::<TestBackend, 2>::from_floats_default([
             [0.00000, 1.00000, 0.00000, 1.00000, 0.00000, 1.00000],
             [0.84147, 0.54030, 0.04640, 0.99892, 0.00215, 1.00000],
             [0.90930, -0.41615, 0.09270, 0.99569, 0.00431, 0.99999],
@@ -214,7 +214,7 @@ mod tests {
     fn d_model_input_should_match() {
         let d_model = 8;
         let pe = PositionalEncodingConfig::new(d_model).init::<TestBackend>();
-        let input = Tensor::zeros([1, 5, 10]);
+        let input = Tensor::zeros_default([1, 5, 10]);
         let _output = pe.forward(input);
     }
 
@@ -223,7 +223,7 @@ mod tests {
     fn input_length_should_be_less_than_max_len() {
         let d_model = 8;
         let pe = PositionalEncodingConfig::new(d_model).init::<TestBackend>();
-        let input = Tensor::zeros([1, 6_000, d_model]);
+        let input = Tensor::zeros_default([1, 6_000, d_model]);
         let _output = pe.forward(input);
     }
 }

--- a/burn-core/src/nn/rnn/gate_controller.rs
+++ b/burn-core/src/nn/rnn/gate_controller.rs
@@ -23,7 +23,13 @@ pub struct GateController<B: Backend> {
 
 impl<B: Backend> GateController<B> {
     /// Initialize a new [gate_controller](GateController) module.
-    pub fn new(d_input: usize, d_output: usize, bias: bool, initializer: Initializer) -> Self {
+    pub fn new(
+        d_input: usize,
+        d_output: usize,
+        bias: bool,
+        initializer: Initializer,
+        device: &B::Device,
+    ) -> Self {
         Self {
             input_transform: LinearConfig {
                 d_input,
@@ -31,14 +37,14 @@ impl<B: Backend> GateController<B> {
                 bias,
                 initializer: initializer.clone(),
             }
-            .init(),
+            .init(device),
             hidden_transform: LinearConfig {
                 d_input: d_output,
                 d_output,
                 bias,
                 initializer,
             }
-            .init(),
+            .init(device),
         }
     }
 

--- a/burn-core/src/nn/rnn/gru.rs
+++ b/burn-core/src/nn/rnn/gru.rs
@@ -113,7 +113,7 @@ impl<B: Backend> Gru<B> {
 
         let mut hidden_state = match state {
             Some(state) => state,
-            None => Tensor::zeros_device(
+            None => Tensor::zeros(
                 [batch_size, seq_length, self.d_hidden],
                 &batched_input.device(),
             ),
@@ -228,11 +228,8 @@ mod tests {
             device: &<TestBackend as Backend>::Device,
         ) -> GateController<TestBackend> {
             let record = LinearRecord {
-                weight: Param::from(Tensor::from_data_device(Data::from([[weights]]), device)),
-                bias: Some(Param::from(Tensor::from_data_device(
-                    Data::from([biases]),
-                    device,
-                ))),
+                weight: Param::from(Tensor::from_data(Data::from([[weights]]), device)),
+                bias: Some(Param::from(Tensor::from_data(Data::from([biases]), device))),
             };
             gate_controller::GateController::create_with_weights(
                 d_input,
@@ -272,13 +269,11 @@ mod tests {
             &device,
         );
 
-        let input = Tensor::<TestBackend, 3>::from_data_device(Data::from([[[0.1]]]), &device);
+        let input = Tensor::<TestBackend, 3>::from_data(Data::from([[[0.1]]]), &device);
 
         let state = gru.forward(input, None);
 
-        let output = state
-            .select(0, Tensor::arange_device(0..1, &device))
-            .squeeze(0);
+        let output = state.select(0, Tensor::arange(0..1, &device)).squeeze(0);
 
         output.to_data().assert_approx_eq(&Data::from([[0.034]]), 3);
     }
@@ -288,7 +283,7 @@ mod tests {
         let device = Default::default();
         let gru = GruConfig::new(64, 1024, true).init::<TestBackend>(&device);
         let batched_input =
-            Tensor::<TestBackend, 3>::random_device([8, 10, 64], Distribution::Default, &device);
+            Tensor::<TestBackend, 3>::random([8, 10, 64], Distribution::Default, &device);
 
         let hidden_state = gru.forward(batched_input, None);
 

--- a/burn-core/src/nn/transformer/decoder.rs
+++ b/burn-core/src/nn/transformer/decoder.rs
@@ -53,9 +53,9 @@ pub struct TransformerDecoder<B: Backend> {
 
 impl TransformerDecoderConfig {
     /// Initialize a new [Transformer Decoder](TransformerDecoder) module.
-    pub fn init<B: Backend>(&self) -> TransformerDecoder<B> {
+    pub fn init<B: Backend>(&self, device: &B::Device) -> TransformerDecoder<B> {
         let layers = (0..self.n_layers)
-            .map(|_| TransformerDecoderLayer::new(self))
+            .map(|_| TransformerDecoderLayer::new(self, device))
             .collect::<Vec<_>>();
 
         TransformerDecoder { layers }
@@ -182,23 +182,23 @@ impl<B: Backend> TransformerDecoderAutoregressiveCache<B> {
 }
 
 impl<B: Backend> TransformerDecoderLayer<B> {
-    fn new(config: &TransformerDecoderConfig) -> Self {
+    fn new(config: &TransformerDecoderConfig, device: &B::Device) -> Self {
         let self_attn = MultiHeadAttentionConfig::new(config.d_model, config.n_heads)
             .with_initializer(config.initializer.clone())
             .with_dropout(config.dropout)
-            .init();
+            .init(device);
 
         let cross_attn = MultiHeadAttentionConfig::new(config.d_model, config.n_heads)
             .with_initializer(config.initializer.clone())
             .with_dropout(config.dropout)
-            .init();
-        let norm_1 = LayerNormConfig::new(config.d_model).init();
-        let norm_2 = LayerNormConfig::new(config.d_model).init();
-        let norm_3 = LayerNormConfig::new(config.d_model).init();
+            .init(device);
+        let norm_1 = LayerNormConfig::new(config.d_model).init(device);
+        let norm_2 = LayerNormConfig::new(config.d_model).init(device);
+        let norm_3 = LayerNormConfig::new(config.d_model).init(device);
         let dropout = DropoutConfig::new(config.dropout).init();
         let pwff = PositionWiseFeedForwardConfig::new(config.d_model, config.d_ff)
             .with_dropout(config.dropout)
-            .init();
+            .init(device);
 
         Self {
             cross_attn,
@@ -407,16 +407,19 @@ mod tests {
     }
 
     fn test_autoregressive(config: TransformerDecoderConfig) {
+        let device = Default::default();
         let [batch_size, seq_length, d_model] = [3, 4, config.d_model];
-        let transformer = config.init();
+        let transformer = config.init(&device);
 
-        let memory = Tensor::<TestBackend, 3>::random(
+        let memory = Tensor::<TestBackend, 3>::random_device(
             [batch_size, seq_length, d_model],
             Distribution::Default,
+            &device,
         );
-        let target = Tensor::<TestBackend, 3>::random(
+        let target = Tensor::<TestBackend, 3>::random_device(
             [batch_size, seq_length, d_model],
             Distribution::Default,
+            &device,
         );
         let mask_attn = generate_autoregressive_mask(batch_size, seq_length, &target.device());
         let input = TransformerDecoderInput::new(target.clone(), memory.clone())

--- a/burn-core/src/nn/transformer/decoder.rs
+++ b/burn-core/src/nn/transformer/decoder.rs
@@ -411,12 +411,12 @@ mod tests {
         let [batch_size, seq_length, d_model] = [3, 4, config.d_model];
         let transformer = config.init(&device);
 
-        let memory = Tensor::<TestBackend, 3>::random_device(
+        let memory = Tensor::<TestBackend, 3>::random(
             [batch_size, seq_length, d_model],
             Distribution::Default,
             &device,
         );
-        let target = Tensor::<TestBackend, 3>::random_device(
+        let target = Tensor::<TestBackend, 3>::random(
             [batch_size, seq_length, d_model],
             Distribution::Default,
             &device,

--- a/burn-core/src/nn/transformer/encoder.rs
+++ b/burn-core/src/nn/transformer/encoder.rs
@@ -357,7 +357,7 @@ mod tests {
         let device = Default::default();
         let transformer = config.init(&device);
 
-        let tensor = Tensor::<TestBackend, 3>::random_device(
+        let tensor = Tensor::<TestBackend, 3>::random(
             [batch_size, seq_length, d_model],
             Distribution::Default,
             &device,

--- a/burn-core/src/nn/transformer/pwff.rs
+++ b/burn-core/src/nn/transformer/pwff.rs
@@ -41,14 +41,14 @@ pub struct PositionWiseFeedForward<B: Backend> {
 
 impl PositionWiseFeedForwardConfig {
     /// Initialize a new [position-wise feed-forward](PositionWiseFeedForward) module.
-    pub fn init<B: Backend>(&self) -> PositionWiseFeedForward<B> {
+    pub fn init<B: Backend>(&self, device: &B::Device) -> PositionWiseFeedForward<B> {
         PositionWiseFeedForward {
             linear_inner: LinearConfig::new(self.d_model, self.d_ff)
                 .with_initializer(self.initializer.clone())
-                .init(),
+                .init(device),
             linear_outer: LinearConfig::new(self.d_ff, self.d_model)
                 .with_initializer(self.initializer.clone())
-                .init(),
+                .init(device),
             dropout: DropoutConfig::new(self.dropout).init(),
             gelu: GELU::new(),
         }

--- a/burn-core/src/optim/adagrad.rs
+++ b/burn-core/src/optim/adagrad.rs
@@ -162,8 +162,10 @@ mod tests {
 
     #[test]
     fn test_adagrad_optimizer_save_load_state() {
-        let linear = nn::LinearConfig::new(6, 6).init();
-        let x = Tensor::<TestAutodiffBackend, 2>::random([2, 6], Distribution::Default);
+        let device = Default::default();
+        let linear = nn::LinearConfig::new(6, 6).init(&device);
+        let x =
+            Tensor::<TestAutodiffBackend, 2>::random_device([2, 6], Distribution::Default, &device);
         let mut optimizer = create_adagrad();
         let grads = linear.forward(x).backward();
         let grads = GradientsParams::from_grads(grads, &linear);

--- a/burn-core/src/optim/adagrad.rs
+++ b/burn-core/src/optim/adagrad.rs
@@ -164,8 +164,7 @@ mod tests {
     fn test_adagrad_optimizer_save_load_state() {
         let device = Default::default();
         let linear = nn::LinearConfig::new(6, 6).init(&device);
-        let x =
-            Tensor::<TestAutodiffBackend, 2>::random_device([2, 6], Distribution::Default, &device);
+        let x = Tensor::<TestAutodiffBackend, 2>::random([2, 6], Distribution::Default, &device);
         let mut optimizer = create_adagrad();
         let grads = linear.forward(x).backward();
         let grads = GradientsParams::from_grads(grads, &linear);
@@ -197,12 +196,12 @@ mod tests {
             ]),
             Data::from([-0.3905, 0.0884, -0.0970, 0.1176, 0.1366, 0.0130]),
         );
-        let x_1 = Tensor::from_floats([
+        let x_1 = Tensor::from_floats_default([
             [0.6294, 0.0940, 0.8176, 0.8824, 0.5228, 0.4310],
             [0.7152, 0.9559, 0.7893, 0.5684, 0.5939, 0.8883],
         ])
         .require_grad();
-        let x_2 = Tensor::from_floats([
+        let x_2 = Tensor::from_floats_default([
             [0.8491, 0.2108, 0.8939, 0.4433, 0.5527, 0.2528],
             [0.3270, 0.0412, 0.5538, 0.9605, 0.3195, 0.9085],
         ])
@@ -256,8 +255,8 @@ mod tests {
         bias: Data<f32, 1>,
     ) -> nn::Linear<TestAutodiffBackend> {
         let record = nn::LinearRecord {
-            weight: Param::from(Tensor::from_data(weight)),
-            bias: Some(Param::from(Tensor::from_data(bias))),
+            weight: Param::from(Tensor::from_data_default(weight)),
+            bias: Some(Param::from(Tensor::from_data_default(bias))),
         };
 
         nn::LinearConfig::new(6, 6).init_with(record)

--- a/burn-core/src/optim/adam.rs
+++ b/burn-core/src/optim/adam.rs
@@ -195,8 +195,10 @@ mod tests {
 
     #[test]
     fn test_adam_optimizer_save_load_state() {
-        let linear = nn::LinearConfig::new(6, 6).init();
-        let x = Tensor::<TestAutodiffBackend, 2>::random([2, 6], Distribution::Default);
+        let device = Default::default();
+        let linear = nn::LinearConfig::new(6, 6).init(&device);
+        let x =
+            Tensor::<TestAutodiffBackend, 2>::random_device([2, 6], Distribution::Default, &device);
         let mut optimizer = create_adam();
         let grads = linear.forward(x).backward();
         let grads = GradientsParams::from_grads(grads, &linear);

--- a/burn-core/src/optim/adam.rs
+++ b/burn-core/src/optim/adam.rs
@@ -197,8 +197,7 @@ mod tests {
     fn test_adam_optimizer_save_load_state() {
         let device = Default::default();
         let linear = nn::LinearConfig::new(6, 6).init(&device);
-        let x =
-            Tensor::<TestAutodiffBackend, 2>::random_device([2, 6], Distribution::Default, &device);
+        let x = Tensor::<TestAutodiffBackend, 2>::random([2, 6], Distribution::Default, &device);
         let mut optimizer = create_adam();
         let grads = linear.forward(x).backward();
         let grads = GradientsParams::from_grads(grads, &linear);
@@ -230,12 +229,12 @@ mod tests {
             ]),
             Data::from([-0.3905, 0.0884, -0.0970, 0.1176, 0.1366, 0.0130]),
         );
-        let x_1 = Tensor::from_floats([
+        let x_1 = Tensor::from_floats_default([
             [0.6294, 0.0940, 0.8176, 0.8824, 0.5228, 0.4310],
             [0.7152, 0.9559, 0.7893, 0.5684, 0.5939, 0.8883],
         ])
         .require_grad();
-        let x_2 = Tensor::from_floats([
+        let x_2 = Tensor::from_floats_default([
             [0.8491, 0.2108, 0.8939, 0.4433, 0.5527, 0.2528],
             [0.3270, 0.0412, 0.5538, 0.9605, 0.3195, 0.9085],
         ])
@@ -300,7 +299,7 @@ mod tests {
             Data::from([-0.3905, 0.0884, -0.0970, 0.1176, 0.1366, 0.0130]),
         );
 
-        let x = Tensor::from_floats([
+        let x = Tensor::from_floats_default([
             [0.8491, 0.2108, 0.8939, 0.4433, 0.5527, 0.2528],
             [0.3270, 0.0412, 0.5538, 0.9605, 0.3195, 0.9085],
         ])
@@ -330,8 +329,8 @@ mod tests {
         bias: Data<f32, 1>,
     ) -> nn::Linear<TestAutodiffBackend> {
         let record = nn::LinearRecord {
-            weight: Param::from(Tensor::from_data(weight)),
-            bias: Some(Param::from(Tensor::from_data(bias))),
+            weight: Param::from(Tensor::from_data_default(weight)),
+            bias: Some(Param::from(Tensor::from_data_default(bias))),
         };
 
         nn::LinearConfig::new(6, 6).init_with(record)

--- a/burn-core/src/optim/adam.rs
+++ b/burn-core/src/optim/adam.rs
@@ -197,7 +197,8 @@ mod tests {
     fn test_adam_optimizer_save_load_state() {
         let device = Default::default();
         let linear = nn::LinearConfig::new(6, 6).init(&device);
-        let x = Tensor::<TestAutodiffBackend, 2>::random([2, 6], Distribution::Default, &device);
+        let x =
+            Tensor::<TestAutodiffBackend, 2>::random_device([2, 6], Distribution::Default, &device);
         let mut optimizer = create_adam();
         let grads = linear.forward(x).backward();
         let grads = GradientsParams::from_grads(grads, &linear);
@@ -329,8 +330,8 @@ mod tests {
         bias: Data<f32, 1>,
     ) -> nn::Linear<TestAutodiffBackend> {
         let record = nn::LinearRecord {
-            weight: Param::from(Tensor::from_data_default(weight)),
-            bias: Some(Param::from(Tensor::from_data_default(bias))),
+            weight: Param::from(Tensor::from_data(weight)),
+            bias: Some(Param::from(Tensor::from_data(bias))),
         };
 
         nn::LinearConfig::new(6, 6).init_with(record)

--- a/burn-core/src/optim/adamw.rs
+++ b/burn-core/src/optim/adamw.rs
@@ -208,8 +208,10 @@ mod tests {
 
     #[test]
     fn test_adamw_optimizer_save_load_state() {
-        let linear = nn::LinearConfig::new(6, 6).init();
-        let x = Tensor::<TestAutodiffBackend, 2>::random([2, 6], Distribution::Default);
+        let device = Default::default();
+        let linear = nn::LinearConfig::new(6, 6).init(&device);
+        let x =
+            Tensor::<TestAutodiffBackend, 2>::random_device([2, 6], Distribution::Default, &device);
         let mut optimizer = create_adamw();
         let grads = linear.forward(x).backward();
         let grads = GradientsParams::from_grads(grads, &linear);

--- a/burn-core/src/optim/adamw.rs
+++ b/burn-core/src/optim/adamw.rs
@@ -210,8 +210,7 @@ mod tests {
     fn test_adamw_optimizer_save_load_state() {
         let device = Default::default();
         let linear = nn::LinearConfig::new(6, 6).init(&device);
-        let x =
-            Tensor::<TestAutodiffBackend, 2>::random_device([2, 6], Distribution::Default, &device);
+        let x = Tensor::<TestAutodiffBackend, 2>::random([2, 6], Distribution::Default, &device);
         let mut optimizer = create_adamw();
         let grads = linear.forward(x).backward();
         let grads = GradientsParams::from_grads(grads, &linear);
@@ -245,12 +244,12 @@ mod tests {
             ]),
             Data::from([-0.3905, 0.0884, -0.0970, 0.1176, 0.1366, 0.0130]),
         );
-        let x_1 = Tensor::from_floats([
+        let x_1 = Tensor::from_floats_default([
             [0.6294, 0.0940, 0.8176, 0.8824, 0.5228, 0.4310],
             [0.7152, 0.9559, 0.7893, 0.5684, 0.5939, 0.8883],
         ])
         .require_grad();
-        let x_2 = Tensor::from_floats([
+        let x_2 = Tensor::from_floats_default([
             [0.8491, 0.2108, 0.8939, 0.4433, 0.5527, 0.2528],
             [0.3270, 0.0412, 0.5538, 0.9605, 0.3195, 0.9085],
         ])
@@ -315,7 +314,7 @@ mod tests {
             Data::from([-0.3905, 0.0884, -0.0970, 0.1176, 0.1366, 0.0130]),
         );
 
-        let x = Tensor::from_floats([
+        let x = Tensor::from_floats_default([
             [0.8491, 0.2108, 0.8939, 0.4433, 0.5527, 0.2528],
             [0.3270, 0.0412, 0.5538, 0.9605, 0.3195, 0.9085],
         ])
@@ -345,8 +344,8 @@ mod tests {
         bias: Data<f32, 1>,
     ) -> nn::Linear<TestAutodiffBackend> {
         let record = nn::LinearRecord {
-            weight: Param::from(Tensor::from_data(weight)),
-            bias: Some(Param::from(Tensor::from_data(bias))),
+            weight: Param::from(Tensor::from_data_default(weight)),
+            bias: Some(Param::from(Tensor::from_data_default(bias))),
         };
 
         nn::LinearConfig::new(6, 6).init_with(record)

--- a/burn-core/src/optim/grad_accum.rs
+++ b/burn-core/src/optim/grad_accum.rs
@@ -81,13 +81,14 @@ mod tests {
         nn::{Linear, LinearConfig},
         TestAutodiffBackend,
     };
-    use burn_tensor::Distribution;
+    use burn_tensor::{backend::Backend, Distribution};
 
     #[test]
     fn test_accumulate_gradients_one_step() {
+        let device = Default::default();
         let mut accumulator = GradientsAccumulator::new();
-        let layer = layer();
-        let loss = layer.forward(random_tensor());
+        let layer = layer::<TestAutodiffBackend>(&device);
+        let loss = layer.forward(random_tensor::<TestAutodiffBackend>(&device));
         let grads = GradientsParams::from_grads(loss.backward(), &layer);
 
         accumulator.accumulate(&layer, grads);
@@ -98,10 +99,11 @@ mod tests {
 
     #[test]
     fn test_accumulate_gradients_two_steps() {
+        let device = Default::default();
         let mut accumulator = GradientsAccumulator::new();
-        let layer = layer();
-        let loss_1 = layer.forward(random_tensor());
-        let loss_2 = layer.forward(random_tensor());
+        let layer = layer::<TestAutodiffBackend>(&device);
+        let loss_1 = layer.forward(random_tensor(&device));
+        let loss_2 = layer.forward(random_tensor(&device));
         let grads_1 = GradientsParams::from_grads(loss_1.backward(), &layer);
         let grads_2 = GradientsParams::from_grads(loss_2.backward(), &layer);
 
@@ -112,11 +114,11 @@ mod tests {
         assert_eq!(grads.len(), 2)
     }
 
-    fn layer() -> Linear<TestAutodiffBackend> {
-        LinearConfig::new(20, 20).with_bias(true).init()
+    fn layer<B: Backend>(device: &B::Device) -> Linear<B> {
+        LinearConfig::new(20, 20).with_bias(true).init(device)
     }
 
-    fn random_tensor() -> Tensor<TestAutodiffBackend, 2> {
-        Tensor::<TestAutodiffBackend, 2>::random([2, 20], Distribution::Default)
+    fn random_tensor<B: Backend>(device: &B::Device) -> Tensor<B, 2> {
+        Tensor::<B, 2>::random_device([2, 20], Distribution::Default, device)
     }
 }

--- a/burn-core/src/optim/grad_accum.rs
+++ b/burn-core/src/optim/grad_accum.rs
@@ -119,6 +119,6 @@ mod tests {
     }
 
     fn random_tensor<B: Backend>(device: &B::Device) -> Tensor<B, 2> {
-        Tensor::<B, 2>::random_device([2, 20], Distribution::Default, device)
+        Tensor::<B, 2>::random([2, 20], Distribution::Default, device)
     }
 }

--- a/burn-core/src/optim/grads.rs
+++ b/burn-core/src/optim/grads.rs
@@ -121,6 +121,6 @@ mod tests {
     }
 
     fn random_tensor<B: Backend>(device: &B::Device) -> Tensor<B, 2> {
-        Tensor::<B, 2>::random_device([2, 20], Distribution::Default, &device)
+        Tensor::<B, 2>::random([2, 20], Distribution::Default, &device)
     }
 }

--- a/burn-core/src/optim/grads.rs
+++ b/burn-core/src/optim/grads.rs
@@ -99,11 +99,12 @@ mod tests {
 
     #[test]
     fn test_convert_grads() {
-        let layer_1 = layer();
+        let device = Default::default();
+        let layer_1 = layer::<TestAutodiffBackend>(&device);
         let mut layer_2 = layer_1.clone();
-        layer_2 = layer_2.fork(&<TestAutodiffBackend as Backend>::Device::default());
-        let loss_1 = layer_1.forward(random_tensor());
-        let loss_2 = layer_2.forward(random_tensor());
+        layer_2 = layer_2.fork(&device);
+        let loss_1 = layer_1.forward(random_tensor(&device));
+        let loss_2 = layer_2.forward(random_tensor(&device));
         let grads_1 = GradientsParams::from_grads(loss_1.backward(), &layer_1);
         let grads_2 = GradientsParams::from_grads(loss_2.backward(), &layer_2);
 
@@ -115,11 +116,11 @@ mod tests {
         assert_eq!(grads_2.len(), param_ids_2.len());
     }
 
-    fn layer() -> Linear<TestAutodiffBackend> {
-        LinearConfig::new(20, 20).with_bias(true).init()
+    fn layer<B: Backend>(device: &B::Device) -> Linear<B> {
+        LinearConfig::new(20, 20).with_bias(true).init(device)
     }
 
-    fn random_tensor() -> Tensor<TestAutodiffBackend, 2> {
-        Tensor::<TestAutodiffBackend, 2>::random([2, 20], Distribution::Default)
+    fn random_tensor<B: Backend>(device: &B::Device) -> Tensor<B, 2> {
+        Tensor::<B, 2>::random_device([2, 20], Distribution::Default, &device)
     }
 }

--- a/burn-core/src/optim/rmsprop.rs
+++ b/burn-core/src/optim/rmsprop.rs
@@ -325,8 +325,10 @@ mod tests {
 
     #[test]
     fn test_rmsprop_optimizer_save_load_state() {
-        let linear = nn::LinearConfig::new(6, 6).init();
-        let x = Tensor::<TestAutodiffBackend, 2>::random([2, 6], Distribution::Default);
+        let device = Default::default();
+        let linear = nn::LinearConfig::new(6, 6).init(&device);
+        let x =
+            Tensor::<TestAutodiffBackend, 2>::random_device([2, 6], Distribution::Default, &device);
         let mut optimizer = create_rmsprop();
         let grads = linear.forward(x).backward();
         let grads = GradientsParams::from_grads(grads, &linear);

--- a/burn-core/src/optim/rmsprop.rs
+++ b/burn-core/src/optim/rmsprop.rs
@@ -327,8 +327,7 @@ mod tests {
     fn test_rmsprop_optimizer_save_load_state() {
         let device = Default::default();
         let linear = nn::LinearConfig::new(6, 6).init(&device);
-        let x =
-            Tensor::<TestAutodiffBackend, 2>::random_device([2, 6], Distribution::Default, &device);
+        let x = Tensor::<TestAutodiffBackend, 2>::random([2, 6], Distribution::Default, &device);
         let mut optimizer = create_rmsprop();
         let grads = linear.forward(x).backward();
         let grads = GradientsParams::from_grads(grads, &linear);
@@ -361,12 +360,12 @@ mod tests {
             ]),
             Data::from([0.5, 0.5, 0.5, 0.5, 0.5, 0.5]),
         );
-        let x_1 = Tensor::from_floats([
+        let x_1 = Tensor::from_floats_default([
             [0.6294, 0.0940, 0.8176, 0.8824, 0.5228, 0.4310],
             [0.7152, 0.9559, 0.7893, 0.5684, 0.5939, 0.8883],
         ])
         .require_grad();
-        let x_2 = Tensor::from_floats([
+        let x_2 = Tensor::from_floats_default([
             [0.8491, 0.2108, 0.8939, 0.4433, 0.5527, 0.2528],
             [0.3270, 0.0412, 0.5538, 0.9605, 0.3195, 0.9085],
         ])
@@ -429,12 +428,12 @@ mod tests {
             ]),
             Data::from([-0.3905, 0.0884, -0.0970, 0.1176, 0.1366, 0.0130]),
         );
-        let x_1 = Tensor::from_floats([
+        let x_1 = Tensor::from_floats_default([
             [0.6294, 0.0940, 0.8176, 0.8824, 0.5228, 0.4310],
             [0.7152, 0.9559, 0.7893, 0.5684, 0.5939, 0.8883],
         ])
         .require_grad();
-        let x_2 = Tensor::from_floats([
+        let x_2 = Tensor::from_floats_default([
             [0.8491, 0.2108, 0.8939, 0.4433, 0.5527, 0.2528],
             [0.3270, 0.0412, 0.5538, 0.9605, 0.3195, 0.9085],
         ])
@@ -498,8 +497,8 @@ mod tests {
         bias: Data<f32, 1>,
     ) -> nn::Linear<TestAutodiffBackend> {
         let record = nn::LinearRecord {
-            weight: Param::from(Tensor::from_data(weight)),
-            bias: Some(Param::from(Tensor::from_data(bias))),
+            weight: Param::from(Tensor::from_data_default(weight)),
+            bias: Some(Param::from(Tensor::from_data_default(bias))),
         };
 
         nn::LinearConfig::new(6, 6).init_with(record)
@@ -507,7 +506,7 @@ mod tests {
 
     #[allow(dead_code)]
     fn create_random_tensor() -> Tensor<TestAutodiffBackend, 2> {
-        Tensor::<TestAutodiffBackend, 2>::random(Shape::new([2, 20]), Distribution::Default)
+        Tensor::<TestAutodiffBackend, 2>::random_default(Shape::new([2, 20]), Distribution::Default)
     }
 
     fn create_rmsprop(

--- a/burn-core/src/optim/sgd.rs
+++ b/burn-core/src/optim/sgd.rs
@@ -108,9 +108,10 @@ mod tests {
 
     #[test]
     fn with_updated_params_should_have_state() {
-        let layer = layer();
+        let device = Default::default();
+        let layer = layer::<TestAutodiffBackend>(&device);
         let mut optim = sgd_with_all();
-        let loss = layer.forward(random_tensor());
+        let loss = layer.forward(random_tensor::<TestAutodiffBackend>(&device));
         let grads = loss.backward();
         let grads = GradientsParams::from_grads(grads, &layer);
         let _layer = optim.step(LEARNING_RATE, layer, grads);
@@ -135,9 +136,10 @@ mod tests {
 
     #[test]
     fn should_load_state() {
-        let layer = layer();
+        let device = Default::default();
+        let layer = layer::<TestAutodiffBackend>(&device);
         let mut optim = sgd_with_all();
-        let loss = layer.forward(random_tensor());
+        let loss = layer.forward(random_tensor(&device));
         let grads = loss.backward();
         let grads = GradientsParams::from_grads(grads, &layer);
         let _layer = optim.step(LEARNING_RATE, layer, grads);
@@ -152,12 +154,12 @@ mod tests {
         assert_eq!(record.len(), state_restored.len());
     }
 
-    fn random_tensor() -> Tensor<TestAutodiffBackend, 2> {
-        Tensor::<TestAutodiffBackend, 2>::random(Shape::new([2, 20]), Distribution::Default)
+    fn random_tensor<B: Backend>(device: &B::Device) -> Tensor<B, 2> {
+        Tensor::<B, 2>::random_device(Shape::new([2, 20]), Distribution::Default, device)
     }
 
-    fn layer() -> Linear<TestAutodiffBackend> {
-        LinearConfig::new(20, 20).with_bias(true).init()
+    fn layer<B: Backend>(device: &B::Device) -> Linear<B> {
+        LinearConfig::new(20, 20).with_bias(true).init(device)
     }
 
     fn sgd_with_all(

--- a/burn-core/src/optim/sgd.rs
+++ b/burn-core/src/optim/sgd.rs
@@ -155,7 +155,7 @@ mod tests {
     }
 
     fn random_tensor<B: Backend>(device: &B::Device) -> Tensor<B, 2> {
-        Tensor::<B, 2>::random_device(Shape::new([2, 20]), Distribution::Default, device)
+        Tensor::<B, 2>::random(Shape::new([2, 20]), Distribution::Default, device)
     }
 
     fn layer<B: Backend>(device: &B::Device) -> Linear<B> {

--- a/burn-core/src/record/file.rs
+++ b/burn-core/src/record/file.rs
@@ -342,12 +342,14 @@ mod tests {
     }
 
     fn test_can_save_and_load<Recorder: FileRecorder>(recorder: Recorder) {
-        let model_before = create_model();
+        let device = Default::default();
+        let model_before = create_model(&device);
         recorder
             .record(model_before.clone().into_record(), FILE_PATH.into())
             .unwrap();
 
-        let model_after = create_model().load_record(recorder.load(FILE_PATH.into()).unwrap());
+        let model_after =
+            create_model(&device).load_record(recorder.load(FILE_PATH.into()).unwrap());
 
         let byte_recorder = BinBytesRecorder::<FullPrecisionSettings>::default();
         let model_bytes_before = byte_recorder
@@ -365,10 +367,10 @@ mod tests {
         phantom: core::marker::PhantomData<B>,
     }
 
-    pub fn create_model() -> Model<TestBackend> {
-        let conv2d1 = Conv2dConfig::new([1, 8], [3, 3]).init();
+    pub fn create_model(device: &<TestBackend as Backend>::Device) -> Model<TestBackend> {
+        let conv2d1 = Conv2dConfig::new([1, 8], [3, 3]).init(device);
 
-        let linear1 = LinearConfig::new(32, 32).with_bias(true).init();
+        let linear1 = LinearConfig::new(32, 32).with_bias(true).init(device);
 
         Model {
             conv2d1,

--- a/burn-core/src/record/memory.rs
+++ b/burn-core/src/record/memory.rs
@@ -72,7 +72,9 @@ impl<S: PrecisionSettings> Recorder for NamedMpkBytesRecorder<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{module::Module, nn, record::FullPrecisionSettings, TestBackend};
+    use crate::{
+        module::Module, nn, record::FullPrecisionSettings, tensor::backend::Backend, TestBackend,
+    };
 
     #[test]
     fn test_can_save_and_load_bin_format() {
@@ -86,8 +88,9 @@ mod tests {
     }
 
     fn test_can_save_and_load<Recorder: BytesRecorder>(recorder: Recorder) {
-        let model1 = create_model();
-        let model2 = create_model();
+        let device = Default::default();
+        let model1 = create_model::<TestBackend>(&device);
+        let model2 = create_model::<TestBackend>(&device);
         let bytes1 = recorder.record(model1.into_record(), ()).unwrap();
         let bytes2 = recorder.record(model2.clone().into_record(), ()).unwrap();
 
@@ -98,7 +101,7 @@ mod tests {
         assert_eq!(bytes1, bytes2_after);
     }
 
-    pub fn create_model() -> nn::Linear<TestBackend> {
-        nn::LinearConfig::new(32, 32).with_bias(true).init()
+    pub fn create_model<B: Backend>(device: &B::Device) -> nn::Linear<B> {
+        nn::LinearConfig::new(32, 32).with_bias(true).init(device)
     }
 }

--- a/burn-core/src/record/tensor.rs
+++ b/burn-core/src/record/tensor.rs
@@ -97,7 +97,7 @@ impl<B: Backend, const D: usize> Record for Tensor<B, D> {
     }
 
     fn from_item<S: PrecisionSettings>(item: Self::Item<S>) -> Self {
-        Tensor::from_data(item.data.convert::<B::FloatElem>())
+        Tensor::from_data_default(item.data.convert::<B::FloatElem>())
     }
 }
 
@@ -113,7 +113,7 @@ impl<B: Backend, const D: usize> Record for Tensor<B, D, Int> {
     }
 
     fn from_item<S: PrecisionSettings>(item: Self::Item<S>) -> Self {
-        Tensor::from_data(item.data.convert())
+        Tensor::from_data_default(item.data.convert())
     }
 }
 
@@ -129,6 +129,6 @@ impl<B: Backend, const D: usize> Record for Tensor<B, D, Bool> {
     }
 
     fn from_item<S: PrecisionSettings>(item: Self::Item<S>) -> Self {
-        Tensor::from_data(item.data)
+        Tensor::from_data_default(item.data)
     }
 }

--- a/burn-core/tests/derive_module.rs
+++ b/burn-core/tests/derive_module.rs
@@ -13,8 +13,8 @@ pub struct ModuleBasic<B: Backend> {
 }
 
 impl<B: Backend> ModuleBasic<B> {
-    fn new() -> Self {
-        let weight_basic = Tensor::random(Shape::new([20, 20]), Distribution::Default);
+    fn new(device: &B::Device) -> Self {
+        let weight_basic = Tensor::random(Shape::new([20, 20]), Distribution::Default, device);
         Self {
             weight_basic: Param::from(weight_basic),
         }
@@ -28,11 +28,11 @@ pub struct ModuleComposed<B: Backend> {
 }
 
 impl<B: Backend> ModuleComposed<B> {
-    fn new() -> Self {
-        let weight = Tensor::random(Shape::new([20, 20]), Distribution::Default);
+    fn new(device: &B::Device) -> Self {
+        let weight = Tensor::random(Shape::new([20, 20]), Distribution::Default, device);
         Self {
             weight: Param::from(weight),
-            basic: ModuleBasic::new(),
+            basic: ModuleBasic::new(device),
         }
     }
 }
@@ -42,8 +42,9 @@ mod state {
 
     #[test]
     fn should_load_from_record_basic() {
-        let module_1 = ModuleBasic::<TestBackend>::new();
-        let mut module_2 = ModuleBasic::<TestBackend>::new();
+        let device = <TestBackend as Backend>::Device::default();
+        let module_1 = ModuleBasic::<TestBackend>::new(&device);
+        let mut module_2 = ModuleBasic::<TestBackend>::new(&device);
         let state_1 = module_1.clone().into_record();
 
         assert_ne!(
@@ -61,8 +62,9 @@ mod state {
 
     #[test]
     fn should_load_from_record_compose() {
-        let module_1 = ModuleComposed::<TestBackend>::new();
-        let mut module_2 = ModuleComposed::<TestBackend>::new();
+        let device = <TestBackend as Backend>::Device::default();
+        let module_1 = ModuleComposed::<TestBackend>::new(&device);
+        let mut module_2 = ModuleComposed::<TestBackend>::new(&device);
         assert_ne!(module_1.weight.to_data(), module_2.weight.to_data());
         assert_ne!(
             module_1.basic.weight_basic.to_data(),
@@ -85,13 +87,15 @@ mod num_params {
 
     #[test]
     fn should_calculate_num_params_basic() {
-        let module = ModuleBasic::<TestBackend>::new();
+        let device = <TestBackend as Backend>::Device::default();
+        let module = ModuleBasic::<TestBackend>::new(&device);
         assert_eq!(20 * 20, module.num_params());
     }
 
     #[test]
     fn should_output_state_composed() {
-        let module = ModuleComposed::<TestBackend>::new();
+        let device = <TestBackend as Backend>::Device::default();
+        let module = ModuleComposed::<TestBackend>::new(&device);
         assert_eq!(2 * 20 * 20, module.num_params());
     }
 }
@@ -104,7 +108,8 @@ mod require_grad {
 
     #[test]
     fn should_have_grad_by_default() {
-        let module = ModuleBasic::<TestAutodiffBackend>::new();
+        let device = <TestBackend as Backend>::Device::default();
+        let module = ModuleBasic::<TestAutodiffBackend>::new(&device);
         let mut grads = calculate_grads(&module);
 
         let grad_x = module.weight_basic.grad_remove(&mut grads);
@@ -114,7 +119,8 @@ mod require_grad {
 
     #[test]
     fn should_have_no_grad_after_no_grad() {
-        let module = ModuleBasic::<TestAutodiffBackend>::new().no_grad();
+        let device = <TestAutodiffBackend as Backend>::Device::default();
+        let module = ModuleBasic::<TestAutodiffBackend>::new(&device).no_grad();
         let mut grads = calculate_grads(&module);
 
         let grad_x = module.weight_basic.grad_remove(&mut grads);
@@ -124,7 +130,8 @@ mod require_grad {
 
     #[test]
     fn should_have_grad_when_from_record() {
-        let module = ModuleBasic::<TestAutodiffBackend>::new();
+        let device = <TestAutodiffBackend as Backend>::Device::default();
+        let module = ModuleBasic::<TestAutodiffBackend>::new(&device);
         let record = ModuleBasicRecord {
             weight_basic: module.weight_basic.clone(), // Even when param is no_grad,
         };
@@ -139,7 +146,7 @@ mod require_grad {
     fn calculate_grads(
         module: &ModuleBasic<TestAutodiffBackend>,
     ) -> <TestAutodiffBackend as AutodiffBackend>::Gradients {
-        let x = Tensor::ones([20, 20]).require_grad();
+        let x = Tensor::ones_default([20, 20]).require_grad();
         let y = module.weight_basic.val().matmul(x);
 
         y.backward()

--- a/burn-core/tests/record_resilience.rs
+++ b/burn-core/tests/record_resilience.rs
@@ -179,12 +179,13 @@ mod tests {
     where
         R: FileRecorder,
     {
+        let device = Default::default();
         let file_path: PathBuf = format!("/tmp/deserialize_with_new_optional_field-{name}").into();
         let model = Model {
             single_const: 32.0,
-            linear1: nn::LinearConfig::new(20, 20).init::<TestBackend>(),
+            linear1: nn::LinearConfig::new(20, 20).init::<TestBackend>(&device),
             array_const: [2, 2],
-            linear2: nn::LinearConfig::new(20, 20).init::<TestBackend>(),
+            linear2: nn::LinearConfig::new(20, 20).init::<TestBackend>(&device),
         };
 
         recorder
@@ -204,13 +205,14 @@ mod tests {
     where
         R: FileRecorder,
     {
+        let device = Default::default();
         let file_path: PathBuf =
             format!("/tmp/deserialize_with_removed_optional_field-{name}").into();
         let model = ModelNewOptionalField {
             single_const: 32.0,
-            linear1: nn::LinearConfig::new(20, 20).init::<TestBackend>(),
+            linear1: nn::LinearConfig::new(20, 20).init::<TestBackend>(&device),
             array_const: [2, 2],
-            linear2: nn::LinearConfig::new(20, 20).init::<TestBackend>(),
+            linear2: nn::LinearConfig::new(20, 20).init::<TestBackend>(&device),
             new_field: None,
         };
 
@@ -228,12 +230,13 @@ mod tests {
     where
         R: FileRecorder,
     {
+        let device = Default::default();
         let file_path: PathBuf = format!("/tmp/deserialize_with_new_constant_field-{name}").into();
         let model = Model {
             single_const: 32.0,
             array_const: [2, 2],
-            linear1: nn::LinearConfig::new(20, 20).init::<TestBackend>(),
-            linear2: nn::LinearConfig::new(20, 20).init::<TestBackend>(),
+            linear1: nn::LinearConfig::new(20, 20).init::<TestBackend>(&device),
+            linear2: nn::LinearConfig::new(20, 20).init::<TestBackend>(&device),
         };
 
         recorder
@@ -253,13 +256,14 @@ mod tests {
     where
         R: FileRecorder,
     {
+        let device = Default::default();
         let file_path: PathBuf =
             format!("/tmp/deserialize_with_removed_constant_field-{name}").into();
         let model = ModelNewConstantField {
             single_const: 32.0,
             array_const: [2, 2],
-            linear1: nn::LinearConfig::new(20, 20).init::<TestBackend>(),
-            linear2: nn::LinearConfig::new(20, 20).init::<TestBackend>(),
+            linear1: nn::LinearConfig::new(20, 20).init::<TestBackend>(&device),
+            linear2: nn::LinearConfig::new(20, 20).init::<TestBackend>(&device),
             new_field: 0,
         };
 
@@ -277,12 +281,13 @@ mod tests {
     where
         R: FileRecorder,
     {
+        let device = Default::default();
         let file_path: PathBuf = format!("/tmp/deserialize_with_new_field_order-{name}").into();
         let model = Model {
             array_const: [2, 2],
             single_const: 32.0,
-            linear1: nn::LinearConfig::new(20, 20).init::<TestBackend>(),
-            linear2: nn::LinearConfig::new(20, 20).init::<TestBackend>(),
+            linear1: nn::LinearConfig::new(20, 20).init::<TestBackend>(&device),
+            linear2: nn::LinearConfig::new(20, 20).init::<TestBackend>(&device),
         };
 
         recorder

--- a/burn-import/onnx-tests/tests/onnx_tests.rs
+++ b/burn-import/onnx-tests/tests/onnx_tests.rs
@@ -127,10 +127,11 @@ mod tests {
     #[test]
     fn div_tensor_by_scalar_and_tensor_by_tensor() {
         // Initialize the model without weights (because the exported file does not contain them)
-        let model: div::Model<Backend> = div::Model::new();
+        let device = Default::default();
+        let model: div::Model<Backend> = div::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats([[[[3., 6., 6., 9.]]]]);
+        let input = Tensor::<Backend, 4>::from_floats_device([[[[3., 6., 6., 9.]]]], &device);
         let scalar1 = 9.0f64;
         let scalar2 = 3.0f64;
         let output = model.forward(input, scalar1, scalar2);
@@ -142,10 +143,11 @@ mod tests {
     #[test]
     fn concat_tensors() {
         // Initialize the model
-        let model: concat::Model<Backend> = concat::Model::new();
+        let device = Default::default();
+        let model: concat::Model<Backend> = concat::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::zeros([1, 2, 3, 5]);
+        let input = Tensor::<Backend, 4>::zeros_device([1, 2, 3, 5], &device);
 
         let output = model.forward(input);
 
@@ -275,13 +277,17 @@ mod tests {
     #[test]
     fn softmax() {
         // Initialize the model without weights (because the exported file does not contain them)
-        let model: softmax::Model<Backend> = softmax::Model::new();
+        let device = Default::default();
+        let model: softmax::Model<Backend> = softmax::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 2>::from_floats([
-            [0.33669037, 0.128_809_4, 0.23446237],
-            [0.23033303, -1.122_856_4, -0.18632829],
-        ]);
+        let input = Tensor::<Backend, 2>::from_floats_device(
+            [
+                [0.33669037, 0.128_809_4, 0.23446237],
+                [0.23033303, -1.122_856_4, -0.18632829],
+            ],
+            &device,
+        );
         let output = model.forward(input);
         let expected = Data::from([
             [0.36830685, 0.29917702, 0.33251613],
@@ -294,13 +300,17 @@ mod tests {
     #[test]
     fn log_softmax() {
         // Initialize the model without weights (because the exported file does not contain them)
-        let model: log_softmax::Model<Backend> = log_softmax::Model::new();
+        let device = Default::default();
+        let model: log_softmax::Model<Backend> = log_softmax::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 2>::from_floats([
-            [0.33669037, 0.128_809_4, 0.23446237],
-            [0.23033303, -1.122_856_4, -0.18632829],
-        ]);
+        let input = Tensor::<Backend, 2>::from_floats_device(
+            [
+                [0.33669037, 0.128_809_4, 0.23446237],
+                [0.23033303, -1.122_856_4, -0.18632829],
+            ],
+            &device,
+        );
         let output = model.forward(input);
         let expected = Data::from([
             [-0.998_838_9, -1.206_719_9, -1.101_067],
@@ -313,16 +323,20 @@ mod tests {
     #[test]
     fn maxpool2d() {
         // Initialize the model without weights (because the exported file does not contain them)
-        let model: maxpool2d::Model<Backend> = maxpool2d::Model::new();
+        let device = Default::default();
+        let model: maxpool2d::Model<Backend> = maxpool2d::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats([[[
-            [1.927, 1.487, 0.901, -2.106, 0.678],
-            [-1.235, -0.043, -1.605, -0.752, -0.687],
-            [-0.493, 0.241, -1.111, 0.092, -2.317],
-            [-0.217, -1.385, -0.396, 0.803, -0.622],
-            [-0.592, -0.063, -0.829, 0.331, -1.558],
-        ]]]);
+        let input = Tensor::<Backend, 4>::from_floats_device(
+            [[[
+                [1.927, 1.487, 0.901, -2.106, 0.678],
+                [-1.235, -0.043, -1.605, -0.752, -0.687],
+                [-0.493, 0.241, -1.111, 0.092, -2.317],
+                [-0.217, -1.385, -0.396, 0.803, -0.622],
+                [-0.592, -0.063, -0.829, 0.331, -1.558],
+            ]]],
+            &device,
+        );
         let output = model.forward(input);
         let expected = Data::from([[[
             [0.901, 1.927, 1.487, 0.901],
@@ -336,16 +350,20 @@ mod tests {
     #[test]
     fn avg_pool2d() {
         // Initialize the model without weights (because the exported file does not contain them)
-        let model: avg_pool2d::Model<Backend> = avg_pool2d::Model::new();
+        let device = Default::default();
+        let model: avg_pool2d::Model<Backend> = avg_pool2d::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats([[[
-            [-0.077, 0.360, -0.782, 0.072, 0.665],
-            [-0.287, 1.621, -1.597, -0.052, 0.611],
-            [0.760, -0.034, -0.345, 0.494, -0.078],
-            [-1.805, -0.476, 0.205, 0.338, 1.353],
-            [0.374, 0.013, 0.774, -0.109, -0.271],
-        ]]]);
+        let input = Tensor::<Backend, 4>::from_floats_device(
+            [[[
+                [-0.077, 0.360, -0.782, 0.072, 0.665],
+                [-0.287, 1.621, -1.597, -0.052, 0.611],
+                [0.760, -0.034, -0.345, 0.494, -0.078],
+                [-1.805, -0.476, 0.205, 0.338, 1.353],
+                [0.374, 0.013, 0.774, -0.109, -0.271],
+            ]]],
+            &device,
+        );
         let output = model.forward(input);
         let expected = Data::from([[[[0.008, -0.131, -0.208, 0.425]]]]);
 
@@ -355,10 +373,11 @@ mod tests {
     #[test]
     fn reshape() {
         // Initialize the model without weights (because the exported file does not contain them)
-        let model: reshape::Model<Backend> = reshape::Model::new();
+        let device = Default::default();
+        let model: reshape::Model<Backend> = reshape::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 1>::from_floats([0., 1., 2., 3.]);
+        let input = Tensor::<Backend, 1>::from_floats_device([0., 1., 2., 3.], &device);
         let output = model.forward(input);
         let expected = Data::from([[0., 1., 2., 3.]]);
 
@@ -368,10 +387,11 @@ mod tests {
     #[test]
     fn flatten() {
         // Initialize the model without weights (because the exported file does not contain them)
-        let model: flatten::Model<Backend> = flatten::Model::new();
+        let device = Default::default();
+        let model: flatten::Model<Backend> = flatten::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 3>::ones([1, 5, 15]);
+        let input = Tensor::<Backend, 3>::ones_device([1, 5, 15], &device);
         let output = model.forward(input);
 
         let expected_shape = Shape::from([1, 75]);
@@ -397,13 +417,17 @@ mod tests {
     #[test]
     fn relu() {
         // Initialize the model without weights (because the exported file does not contain them)
-        let model: relu::Model<Backend> = relu::Model::new();
+        let device = Default::default();
+        let model: relu::Model<Backend> = relu::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 2>::from_floats([
-            [0.33669037, 0.128_809_4, 0.23446237],
-            [0.23033303, -1.122_856_4, -0.18632829],
-        ]);
+        let input = Tensor::<Backend, 2>::from_floats_device(
+            [
+                [0.33669037, 0.128_809_4, 0.23446237],
+                [0.23033303, -1.122_856_4, -0.18632829],
+            ],
+            &device,
+        );
         let output = model.forward(input);
         let expected = Data::from([
             [0.33669037, 0.128_809_4, 0.23446237],
@@ -416,13 +440,17 @@ mod tests {
     #[test]
     fn sigmoid() {
         // Initialize the model without weights (because the exported file does not contain them)
-        let model: sigmoid::Model<Backend> = sigmoid::Model::new();
+        let device = Default::default();
+        let model: sigmoid::Model<Backend> = sigmoid::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 2>::from_floats([
-            [0.33669037, 0.128_809_4, 0.23446237],
-            [0.23033303, -1.122_856_4, -0.18632829],
-        ]);
+        let input = Tensor::<Backend, 2>::from_floats_device(
+            [
+                [0.33669037, 0.128_809_4, 0.23446237],
+                [0.23033303, -1.122_856_4, -0.18632829],
+            ],
+            &device,
+        );
         let output = model.forward(input);
         let expected = Data::from([
             [0.58338636, 0.532_157_9, 0.55834854],
@@ -435,13 +463,17 @@ mod tests {
     #[test]
     fn transpose() {
         // Initialize the model without weights (because the exported file does not contain them)
-        let model: transpose::Model<Backend> = transpose::Model::new();
+        let device = Default::default();
+        let model: transpose::Model<Backend> = transpose::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 2>::from_floats([
-            [0.33669037, 0.128_809_4, 0.23446237],
-            [0.23033303, -1.122_856_4, -0.18632829],
-        ]);
+        let input = Tensor::<Backend, 2>::from_floats_device(
+            [
+                [0.33669037, 0.128_809_4, 0.23446237],
+                [0.23033303, -1.122_856_4, -0.18632829],
+            ],
+            &device,
+        );
         let output = model.forward(input);
         let expected = Data::from([
             [0.33669037, 0.23033303],
@@ -472,17 +504,21 @@ mod tests {
     #[test]
     fn clip_opset16() {
         // Initialize the model without weights (because the exported file does not contain them)
-        let model: clip_opset16::Model<Backend> = clip_opset16::Model::new();
+        let device = Default::default();
+        let model: clip_opset16::Model<Backend> = clip_opset16::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 1>::from_floats([
-            0.88226926,
-            0.91500396,
-            0.38286376,
-            0.95930564,
-            0.390_448_2,
-            0.60089535,
-        ]);
+        let input = Tensor::<Backend, 1>::from_floats_device(
+            [
+                0.88226926,
+                0.91500396,
+                0.38286376,
+                0.95930564,
+                0.390_448_2,
+                0.60089535,
+            ],
+            &device,
+        );
         let (output1, output2, output3) = model.forward(input);
         let expected1 = Data::from([
             0.88226926,
@@ -503,17 +539,21 @@ mod tests {
     #[test]
     fn clip_opset7() {
         // Initialize the model without weights (because the exported file does not contain them)
-        let model: clip_opset7::Model<Backend> = clip_opset7::Model::new();
+        let device = Default::default();
+        let model: clip_opset7::Model<Backend> = clip_opset7::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 1>::from_floats([
-            0.88226926,
-            0.91500396,
-            0.38286376,
-            0.95930564,
-            0.390_448_2,
-            0.60089535,
-        ]);
+        let input = Tensor::<Backend, 1>::from_floats_device(
+            [
+                0.88226926,
+                0.91500396,
+                0.38286376,
+                0.95930564,
+                0.390_448_2,
+                0.60089535,
+            ],
+            &device,
+        );
         let (output1, output2, output3) = model.forward(input);
         let expected1 = Data::from([
             0.88226926,
@@ -567,10 +607,11 @@ mod tests {
     #[test]
     fn tanh() {
         // Initialize the model
-        let model = tanh::Model::<Backend>::new();
+        let device = Default::default();
+        let model = tanh::Model::<Backend>::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats([[[[1., 2., 3., 4.]]]]);
+        let input = Tensor::<Backend, 4>::from_floats_device([[[[1., 2., 3., 4.]]]], &device);
         let output = model.forward(input);
         // data from pyTorch
         let expected = Data::from([[[[0.7616, 0.9640, 0.9951, 0.9993]]]]);

--- a/burn-import/onnx-tests/tests/onnx_tests.rs
+++ b/burn-import/onnx-tests/tests/onnx_tests.rs
@@ -61,7 +61,7 @@ mod tests {
         let model: add::Model<Backend> = add::Model::default();
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats([[[[1., 2., 3., 4.]]]]);
+        let input = Tensor::<Backend, 4>::from_floats_default([[[[1., 2., 3., 4.]]]]);
         let scalar = 2f64;
         let output = model.forward(input, scalar);
         let expected = Data::from([[[[9., 10., 11., 12.]]]]);
@@ -75,7 +75,7 @@ mod tests {
         let model: add_int::Model<Backend> = add_int::Model::default();
 
         // Run the model
-        let input = Tensor::<Backend, 4, Int>::from_ints([[[[1, 2, 3, 4]]]]);
+        let input = Tensor::<Backend, 4, Int>::from_ints_default([[[[1, 2, 3, 4]]]]);
         let scalar = 2;
         let output = model.forward(input, scalar);
         let expected = Data::from([[[[9, 11, 13, 15]]]]);
@@ -89,7 +89,7 @@ mod tests {
         let model: sub::Model<Backend> = sub::Model::default();
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats([[[[1., 2., 3., 4.]]]]);
+        let input = Tensor::<Backend, 4>::from_floats_default([[[[1., 2., 3., 4.]]]]);
         let scalar = 3.0f64;
         let output = model.forward(input, scalar);
         let expected = Data::from([[[[6., 7., 8., 9.]]]]);
@@ -103,7 +103,7 @@ mod tests {
         let model: sub_int::Model<Backend> = sub_int::Model::default();
 
         // Run the model
-        let input = Tensor::<Backend, 4, Int>::from_ints([[[[1, 2, 3, 4]]]]);
+        let input = Tensor::<Backend, 4, Int>::from_ints_default([[[[1, 2, 3, 4]]]]);
         let scalar = 3;
         let output = model.forward(input, scalar);
         let expected = Data::from([[[[6, 6, 6, 6]]]]);
@@ -116,7 +116,7 @@ mod tests {
         let model: mul::Model<Backend> = mul::Model::default();
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats([[[[1., 2., 3., 4.]]]]);
+        let input = Tensor::<Backend, 4>::from_floats_default([[[[1., 2., 3., 4.]]]]);
         let scalar = 6.0f64;
         let output = model.forward(input, scalar);
         let expected = Data::from([[[[126., 252., 378., 504.]]]]);
@@ -131,7 +131,7 @@ mod tests {
         let model: div::Model<Backend> = div::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats_device([[[[3., 6., 6., 9.]]]], &device);
+        let input = Tensor::<Backend, 4>::from_floats([[[[3., 6., 6., 9.]]]], &device);
         let scalar1 = 9.0f64;
         let scalar2 = 3.0f64;
         let output = model.forward(input, scalar1, scalar2);
@@ -147,7 +147,7 @@ mod tests {
         let model: concat::Model<Backend> = concat::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::zeros_device([1, 2, 3, 5], &device);
+        let input = Tensor::<Backend, 4>::zeros([1, 2, 3, 5], &device);
 
         let output = model.forward(input);
 
@@ -162,7 +162,7 @@ mod tests {
         let model: conv1d::Model<Backend> = conv1d::Model::default();
 
         // Run the model with pi as input for easier testing
-        let input = Tensor::<Backend, 3>::full([6, 4, 10], consts::PI);
+        let input = Tensor::<Backend, 3>::full_default([6, 4, 10], consts::PI);
 
         let output = model.forward(input);
 
@@ -183,7 +183,7 @@ mod tests {
         let model: conv2d::Model<Backend> = conv2d::Model::default();
 
         // Run the model with ones as input for easier testing
-        let input = Tensor::<Backend, 4>::ones([2, 4, 10, 15]);
+        let input = Tensor::<Backend, 4>::ones_default([2, 4, 10, 15]);
 
         let output = model.forward(input);
 
@@ -204,7 +204,7 @@ mod tests {
         let model: dropout_opset16::Model<Backend> = dropout_opset16::Model::default();
 
         // Run the model with ones as input for easier testing
-        let input = Tensor::<Backend, 4>::ones([2, 4, 10, 15]);
+        let input = Tensor::<Backend, 4>::ones_default([2, 4, 10, 15]);
 
         let output = model.forward(input);
 
@@ -223,7 +223,7 @@ mod tests {
         let model: dropout_opset7::Model<Backend> = dropout_opset7::Model::default();
 
         // Run the model with ones as input for easier testing
-        let input = Tensor::<Backend, 4>::ones([2, 4, 10, 15]);
+        let input = Tensor::<Backend, 4>::ones_default([2, 4, 10, 15]);
 
         let output = model.forward(input);
 
@@ -241,9 +241,10 @@ mod tests {
     fn erf() {
         let model: erf::Model<Backend> = erf::Model::default();
 
-        let input = Tensor::<Backend, 4>::from_data([[[[1.0, 2.0, 3.0, 4.0]]]]);
+        let input = Tensor::<Backend, 4>::from_data_default([[[[1.0, 2.0, 3.0, 4.0]]]]);
         let output = model.forward(input);
-        let expected = Tensor::<Backend, 4>::from_data([[[[0.8427, 0.9953, 1.0000, 1.0000]]]]);
+        let expected =
+            Tensor::<Backend, 4>::from_data_default([[[[0.8427, 0.9953, 1.0000, 1.0000]]]]);
 
         output.to_data().assert_approx_eq(&expected.to_data(), 4);
     }
@@ -254,8 +255,8 @@ mod tests {
         let model: global_avr_pool::Model<Backend> = global_avr_pool::Model::default();
 
         // Run the model with ones as input for easier testing
-        let input_1d = Tensor::<Backend, 3>::ones([2, 4, 10]);
-        let input_2d = Tensor::<Backend, 4>::ones([3, 10, 3, 15]);
+        let input_1d = Tensor::<Backend, 3>::ones_default([2, 4, 10]);
+        let input_2d = Tensor::<Backend, 4>::ones_default([3, 10, 3, 15]);
 
         let (output_1d, output_2d) = model.forward(input_1d, input_2d);
 
@@ -281,7 +282,7 @@ mod tests {
         let model: softmax::Model<Backend> = softmax::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 2>::from_floats_device(
+        let input = Tensor::<Backend, 2>::from_floats(
             [
                 [0.33669037, 0.128_809_4, 0.23446237],
                 [0.23033303, -1.122_856_4, -0.18632829],
@@ -304,7 +305,7 @@ mod tests {
         let model: log_softmax::Model<Backend> = log_softmax::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 2>::from_floats_device(
+        let input = Tensor::<Backend, 2>::from_floats(
             [
                 [0.33669037, 0.128_809_4, 0.23446237],
                 [0.23033303, -1.122_856_4, -0.18632829],
@@ -327,7 +328,7 @@ mod tests {
         let model: maxpool2d::Model<Backend> = maxpool2d::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats_device(
+        let input = Tensor::<Backend, 4>::from_floats(
             [[[
                 [1.927, 1.487, 0.901, -2.106, 0.678],
                 [-1.235, -0.043, -1.605, -0.752, -0.687],
@@ -354,7 +355,7 @@ mod tests {
         let model: avg_pool2d::Model<Backend> = avg_pool2d::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats_device(
+        let input = Tensor::<Backend, 4>::from_floats(
             [[[
                 [-0.077, 0.360, -0.782, 0.072, 0.665],
                 [-0.287, 1.621, -1.597, -0.052, 0.611],
@@ -377,7 +378,7 @@ mod tests {
         let model: reshape::Model<Backend> = reshape::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 1>::from_floats_device([0., 1., 2., 3.], &device);
+        let input = Tensor::<Backend, 1>::from_floats([0., 1., 2., 3.], &device);
         let output = model.forward(input);
         let expected = Data::from([[0., 1., 2., 3.]]);
 
@@ -391,7 +392,7 @@ mod tests {
         let model: flatten::Model<Backend> = flatten::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 3>::ones_device([1, 5, 15], &device);
+        let input = Tensor::<Backend, 3>::ones([1, 5, 15], &device);
         let output = model.forward(input);
 
         let expected_shape = Shape::from([1, 75]);
@@ -403,7 +404,7 @@ mod tests {
         let model: batch_norm::Model<Backend> = batch_norm::Model::default();
 
         // Run the model with ones as input for easier testing
-        let input = Tensor::<Backend, 3>::ones([1, 20, 1]);
+        let input = Tensor::<Backend, 3>::ones_default([1, 20, 1]);
         let output = model.forward(input);
 
         let expected_shape = Shape::from([1, 5, 2, 2]);
@@ -421,7 +422,7 @@ mod tests {
         let model: relu::Model<Backend> = relu::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 2>::from_floats_device(
+        let input = Tensor::<Backend, 2>::from_floats(
             [
                 [0.33669037, 0.128_809_4, 0.23446237],
                 [0.23033303, -1.122_856_4, -0.18632829],
@@ -444,7 +445,7 @@ mod tests {
         let model: sigmoid::Model<Backend> = sigmoid::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 2>::from_floats_device(
+        let input = Tensor::<Backend, 2>::from_floats(
             [
                 [0.33669037, 0.128_809_4, 0.23446237],
                 [0.23033303, -1.122_856_4, -0.18632829],
@@ -467,7 +468,7 @@ mod tests {
         let model: transpose::Model<Backend> = transpose::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 2>::from_floats_device(
+        let input = Tensor::<Backend, 2>::from_floats(
             [
                 [0.33669037, 0.128_809_4, 0.23446237],
                 [0.23033303, -1.122_856_4, -0.18632829],
@@ -490,7 +491,7 @@ mod tests {
         let model: equal::Model<Backend> = equal::Model::default();
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats([[[[1., 1., 1., 1.]]]]);
+        let input = Tensor::<Backend, 4>::from_floats_default([[[[1., 1., 1., 1.]]]]);
 
         let scalar = 2f64;
         let (tensor_out, scalar_out) = model.forward(input, scalar);
@@ -508,7 +509,7 @@ mod tests {
         let model: clip_opset16::Model<Backend> = clip_opset16::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 1>::from_floats_device(
+        let input = Tensor::<Backend, 1>::from_floats(
             [
                 0.88226926,
                 0.91500396,
@@ -543,7 +544,7 @@ mod tests {
         let model: clip_opset7::Model<Backend> = clip_opset7::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 1>::from_floats_device(
+        let input = Tensor::<Backend, 1>::from_floats(
             [
                 0.88226926,
                 0.91500396,
@@ -575,9 +576,9 @@ mod tests {
     fn linear() {
         // Initialize the model with weights (loaded from the exported file)
         let model: linear::Model<Backend> = linear::Model::default();
-        let input1 = Tensor::<Backend, 2>::full([4, 3], 3.14);
-        let input2 = Tensor::<Backend, 2>::full([2, 5], 3.14);
-        let input3 = Tensor::<Backend, 3>::full([3, 2, 7], 3.14);
+        let input1 = Tensor::<Backend, 2>::full_default([4, 3], 3.14);
+        let input2 = Tensor::<Backend, 2>::full_default([2, 5], 3.14);
+        let input3 = Tensor::<Backend, 3>::full_default([3, 2, 7], 3.14);
 
         let (output1, output2, output3) = model.forward(input1, input2, input3);
 
@@ -611,7 +612,7 @@ mod tests {
         let model = tanh::Model::<Backend>::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats_device([[[[1., 2., 3., 4.]]]], &device);
+        let input = Tensor::<Backend, 4>::from_floats([[[[1., 2., 3., 4.]]]], &device);
         let output = model.forward(input);
         // data from pyTorch
         let expected = Data::from([[[[0.7616, 0.9640, 0.9951, 0.9993]]]]);

--- a/burn-import/onnx-tests/tests/record_type_tests.rs
+++ b/burn-import/onnx-tests/tests/record_type_tests.rs
@@ -25,7 +25,7 @@ macro_rules! test_model {
             let model: $mod_name::Model<Backend> = $mod_name::Model::default();
 
             // Run the model with pi as input for easier testing
-            let input = Tensor::<Backend, 3>::full([6, 4, 10], consts::PI);
+            let input = Tensor::<Backend, 3>::full_default([6, 4, 10], consts::PI);
 
             let output = model.forward(input);
 

--- a/burn-import/src/burn/graph.rs
+++ b/burn-import/src/burn/graph.rs
@@ -446,7 +446,7 @@ impl<PS: PrecisionSettings> BurnGraph<PS> {
 
         quote! {
             #[allow(dead_code)]
-            pub fn new() -> Self {
+            pub fn new(device: &B::Device) -> Self {
                 #body
 
                 Self {

--- a/burn-import/src/burn/node/batch_norm.rs
+++ b/burn-import/src/burn/node/batch_norm.rs
@@ -122,7 +122,7 @@ impl<PS: PrecisionSettings> NodeCodegen<PS> for BatchNormNode<PS> {
                 init_with(record.#name);
             },
             false => quote! {
-                init();
+                init(device);
             },
         };
 

--- a/burn-import/src/burn/node/batch_norm.rs
+++ b/burn-import/src/burn/node/batch_norm.rs
@@ -80,19 +80,19 @@ macro_rules! batch_norm_serialize {
         BatchNormRecord {
             gamma: Param::new(
                 ParamId::new(),
-                Tensor::from_data($self.gamma.clone().convert()),
+                Tensor::from_data_default($self.gamma.clone().convert()),
             ),
             beta: Param::new(
                 ParamId::new(),
-                Tensor::from_data($self.beta.clone().convert()),
+                Tensor::from_data_default($self.beta.clone().convert()),
             ),
             running_mean: Param::new(
                 ParamId::new(),
-                Tensor::from_data($self.running_mean.clone().convert()),
+                Tensor::from_data_default($self.running_mean.clone().convert()),
             ),
             running_var: Param::new(
                 ParamId::new(),
-                Tensor::from_data($self.running_var.clone().convert()),
+                Tensor::from_data_default($self.running_var.clone().convert()),
             ),
             epsilon: ConstantRecord::new(),
             momentum: ConstantRecord::new(),

--- a/burn-import/src/burn/node/constant.rs
+++ b/burn-import/src/burn/node/constant.rs
@@ -137,7 +137,7 @@ impl<PS: PrecisionSettings> NodeCodegen<PS> for ConstantNode<PS> {
                     Some(quote! {
                         let #name: burn::module::Param<#ty> = burn::module::Param::new(
                             burn::module::ParamId::new(),
-                            Tensor::<B, #dim>::zeros(#shape).set_require_grad(false),
+                            Tensor::<B, #dim>::zeros(#shape, device).set_require_grad(false),
                         );
                     })
                 }

--- a/burn-import/src/burn/node/conv1d.rs
+++ b/burn-import/src/burn/node/conv1d.rs
@@ -72,7 +72,7 @@ impl<PS: PrecisionSettings> NodeCodegen<PS> for Conv1dNode<PS> {
                 init_with(record.#name);
             },
             false => quote! {
-                init();
+                init(device);
             },
         };
 

--- a/burn-import/src/burn/node/conv1d.rs
+++ b/burn-import/src/burn/node/conv1d.rs
@@ -95,10 +95,12 @@ impl<PS: PrecisionSettings> NodeCodegen<PS> for Conv1dNode<PS> {
                 ParamId::new(),
                 Tensor::from_data_default(self.data_weights.clone().convert()),
             ),
-            bias: self
-                .data_bias
-                .as_ref()
-                .map(|bias| Param::new(ParamId::new(), Tensor::from_data_default(bias.clone().convert()))),
+            bias: self.data_bias.as_ref().map(|bias| {
+                Param::new(
+                    ParamId::new(),
+                    Tensor::from_data_default(bias.clone().convert()),
+                )
+            }),
             stride: ConstantRecord::new(),
             kernel_size: ConstantRecord::new(),
             dilation: ConstantRecord::new(),

--- a/burn-import/src/burn/node/conv1d.rs
+++ b/burn-import/src/burn/node/conv1d.rs
@@ -93,12 +93,12 @@ impl<PS: PrecisionSettings> NodeCodegen<PS> for Conv1dNode<PS> {
         let record = Conv1dRecord::<SerializationBackend> {
             weight: Param::new(
                 ParamId::new(),
-                Tensor::from_data(self.data_weights.clone().convert()),
+                Tensor::from_data_default(self.data_weights.clone().convert()),
             ),
             bias: self
                 .data_bias
                 .as_ref()
-                .map(|bias| Param::new(ParamId::new(), Tensor::from_data(bias.clone().convert()))),
+                .map(|bias| Param::new(ParamId::new(), Tensor::from_data_default(bias.clone().convert()))),
             stride: ConstantRecord::new(),
             kernel_size: ConstantRecord::new(),
             dilation: ConstantRecord::new(),

--- a/burn-import/src/burn/node/conv2d.rs
+++ b/burn-import/src/burn/node/conv2d.rs
@@ -94,10 +94,12 @@ impl<PS: PrecisionSettings> NodeCodegen<PS> for Conv2dNode<PS> {
                 ParamId::new(),
                 Tensor::from_data_default(self.data_weights.clone().convert()),
             ),
-            bias: self
-                .data_bias
-                .as_ref()
-                .map(|bias| Param::new(ParamId::new(), Tensor::from_data_default(bias.clone().convert()))),
+            bias: self.data_bias.as_ref().map(|bias| {
+                Param::new(
+                    ParamId::new(),
+                    Tensor::from_data_default(bias.clone().convert()),
+                )
+            }),
             stride: [ConstantRecord::new(); 2],
             kernel_size: [ConstantRecord::new(); 2],
             dilation: [ConstantRecord::new(); 2],

--- a/burn-import/src/burn/node/conv2d.rs
+++ b/burn-import/src/burn/node/conv2d.rs
@@ -71,7 +71,7 @@ impl<PS: PrecisionSettings> NodeCodegen<PS> for Conv2dNode<PS> {
                 init_with(record.#name);
             },
             false => quote! {
-                init();
+                init(device);
             },
         };
 

--- a/burn-import/src/burn/node/conv2d.rs
+++ b/burn-import/src/burn/node/conv2d.rs
@@ -92,12 +92,12 @@ impl<PS: PrecisionSettings> NodeCodegen<PS> for Conv2dNode<PS> {
         let record = Conv2dRecord::<SerializationBackend> {
             weight: Param::new(
                 ParamId::new(),
-                Tensor::from_data(self.data_weights.clone().convert()),
+                Tensor::from_data_default(self.data_weights.clone().convert()),
             ),
             bias: self
                 .data_bias
                 .as_ref()
-                .map(|bias| Param::new(ParamId::new(), Tensor::from_data(bias.clone().convert()))),
+                .map(|bias| Param::new(ParamId::new(), Tensor::from_data_default(bias.clone().convert()))),
             stride: [ConstantRecord::new(); 2],
             kernel_size: [ConstantRecord::new(); 2],
             dilation: [ConstantRecord::new(); 2],

--- a/burn-import/src/burn/node/linear.rs
+++ b/burn-import/src/burn/node/linear.rs
@@ -68,7 +68,7 @@ impl<PS: PrecisionSettings> NodeCodegen<PS> for LinearNode<PS> {
                 init_with(record.#name);
             },
             false => quote! {
-                init();
+                init(device);
             },
         };
 

--- a/burn-import/src/burn/node/linear.rs
+++ b/burn-import/src/burn/node/linear.rs
@@ -87,10 +87,12 @@ impl<PS: PrecisionSettings> NodeCodegen<PS> for LinearNode<PS> {
                 ParamId::new(),
                 Tensor::from_data_default(self.data_weights.clone().convert()),
             ),
-            bias: self
-                .data_bias
-                .as_ref()
-                .map(|bias| Param::new(ParamId::new(), Tensor::from_data_default(bias.clone().convert()))),
+            bias: self.data_bias.as_ref().map(|bias| {
+                Param::new(
+                    ParamId::new(),
+                    Tensor::from_data_default(bias.clone().convert()),
+                )
+            }),
         };
 
         let item = Record::into_item::<PS>(record);

--- a/burn-import/src/burn/node/linear.rs
+++ b/burn-import/src/burn/node/linear.rs
@@ -85,12 +85,12 @@ impl<PS: PrecisionSettings> NodeCodegen<PS> for LinearNode<PS> {
         let record = LinearRecord::<SerializationBackend> {
             weight: Param::new(
                 ParamId::new(),
-                Tensor::from_data(self.data_weights.clone().convert()),
+                Tensor::from_data_default(self.data_weights.clone().convert()),
             ),
             bias: self
                 .data_bias
                 .as_ref()
-                .map(|bias| Param::new(ParamId::new(), Tensor::from_data(bias.clone().convert()))),
+                .map(|bias| Param::new(ParamId::new(), Tensor::from_data_default(bias.clone().convert()))),
         };
 
         let item = Record::into_item::<PS>(record);

--- a/burn-import/src/burn/node/unary.rs
+++ b/burn-import/src/burn/node/unary.rs
@@ -161,7 +161,7 @@ impl UnaryNode {
                 // TODO: Implement this after tensor Int is implemented (@antimora 8/2/2023)
                 // TODO: If the input is scalar and the output type is a tensor,
                 // we should generate another code block. (@antimora 8/4/2023)
-                // Tensor::from_data(Data::from([#input]).convert()).unsqueeze();
+                // Tensor::from_data_default(Data::from([#input]).convert()).unsqueeze();
                 todo!()
             }
 

--- a/burn-no-std-tests/src/conv.rs
+++ b/burn-no-std-tests/src/conv.rs
@@ -22,10 +22,10 @@ pub struct ConvBlockConfig {
 }
 
 impl<B: Backend> ConvBlock<B> {
-    pub fn new(config: &ConvBlockConfig) -> Self {
+    pub fn new(config: &ConvBlockConfig, device: &B::Device) -> Self {
         let conv = nn::conv::Conv2dConfig::new(config.channels, config.kernel_size)
             .with_padding(nn::PaddingConfig2d::Same)
-            .init();
+            .init(device);
         let pool = nn::pool::MaxPool2dConfig::new(config.kernel_size)
             .with_padding(nn::PaddingConfig2d::Same)
             .init();

--- a/burn-no-std-tests/src/mlp.rs
+++ b/burn-no-std-tests/src/mlp.rs
@@ -33,11 +33,11 @@ pub struct Mlp<B: Backend> {
 
 impl<B: Backend> Mlp<B> {
     /// Create the module from the given configuration.
-    pub fn new(config: &MlpConfig) -> Self {
+    pub fn new(config: &MlpConfig, device: &B::Device) -> Self {
         let mut linears = Vec::with_capacity(config.num_layers);
 
         for _ in 0..config.num_layers {
-            linears.push(nn::LinearConfig::new(config.d_model, config.d_model).init());
+            linears.push(nn::LinearConfig::new(config.d_model, config.d_model).init(device));
         }
 
         Self {

--- a/burn-no-std-tests/src/model.rs
+++ b/burn-no-std-tests/src/model.rs
@@ -36,11 +36,11 @@ pub struct Model<B: Backend> {
 }
 
 impl<B: Backend> Model<B> {
-    pub fn new(config: &MnistConfig) -> Self {
-        let mlp = Mlp::new(&config.mlp);
-        let input = nn::LinearConfig::new(config.input_size, config.mlp.d_model).init();
-        let output = nn::LinearConfig::new(config.mlp.d_model, config.output_size).init();
-        let conv = ConvBlock::new(&ConvBlockConfig::new([1, 1]));
+    pub fn new(config: &MnistConfig, device: &B::Device) -> Self {
+        let mlp = Mlp::new(&config.mlp, device);
+        let input = nn::LinearConfig::new(config.input_size, config.mlp.d_model).init(device);
+        let output = nn::LinearConfig::new(config.mlp.d_model, config.output_size).init(device);
+        let conv = ConvBlock::new(&ConvBlockConfig::new([1, 1]), device);
 
         Self {
             mlp,

--- a/burn-no-std-tests/tests/integration_test.rs
+++ b/burn-no-std-tests/tests/integration_test.rs
@@ -3,7 +3,7 @@
 use burn_no_std_tests::mlp::*;
 use burn_no_std_tests::model::*;
 
-use burn::tensor::{backend::Backend, Distribution::Default, Tensor};
+use burn::tensor::{backend::Backend, Distribution, Tensor};
 use burn_ndarray::NdArray;
 
 #[test]
@@ -11,16 +11,17 @@ fn test_mnist_model_with_random_input() {
     type Backend = NdArray<f32>;
 
     // Model configurations
+    let device = Default::default();
     let mlp_config = MlpConfig::new();
     let mnist_config = MnistConfig::new(mlp_config);
-    let mnist_model: Model<Backend> = Model::new(&mnist_config);
+    let mnist_model: Model<Backend> = Model::new(&mnist_config, &device);
 
     // Pass a fixed seed for random, otherwise a build generated random seed is used
     Backend::seed(mnist_config.seed);
 
     // Some random input
     let input_shape = [1, 28, 28];
-    let input = Tensor::<Backend, 3>::random(input_shape, Default);
+    let input = Tensor::<Backend, 3>::random_device(input_shape, Distribution::Default, &device);
 
     // Run through the model
     let output = mnist_model.forward(input);

--- a/burn-no-std-tests/tests/integration_test.rs
+++ b/burn-no-std-tests/tests/integration_test.rs
@@ -21,7 +21,7 @@ fn test_mnist_model_with_random_input() {
 
     // Some random input
     let input_shape = [1, 28, 28];
-    let input = Tensor::<Backend, 3>::random_device(input_shape, Distribution::Default, &device);
+    let input = Tensor::<Backend, 3>::random(input_shape, Distribution::Default, &device);
 
     // Run through the model
     let output = mnist_model.forward(input);

--- a/burn-tch/src/tensor.rs
+++ b/burn-tch/src/tensor.rs
@@ -261,7 +261,7 @@ mod tests {
 
     #[test]
     fn should_not_update_inplace_after_reshape() {
-        let tensor_1 = Tensor::<LibTorch<f32>, 1>::from_floats([4.0, 4.0]);
+        let tensor_1 = Tensor::<LibTorch<f32>, 1>::from_floats_default([4.0, 4.0]);
         let tensor_2 = tensor_1.clone();
 
         let tensor_3 = tensor_2.reshape([1, 2]).add_scalar(2.0);
@@ -271,7 +271,7 @@ mod tests {
 
     #[test]
     fn should_not_update_inplace_after_slice() {
-        let tensor_1 = Tensor::<LibTorch<f32>, 1>::from_floats([4.0, 4.0]);
+        let tensor_1 = Tensor::<LibTorch<f32>, 1>::from_floats_default([4.0, 4.0]);
         let tensor_2 = tensor_1.clone();
 
         let tensor_3 = tensor_2.slice([0..2]).add_scalar(2.0);

--- a/burn-tensor/src/tensor/api/base.rs
+++ b/burn-tensor/src/tensor/api/base.rs
@@ -42,12 +42,12 @@ where
     }
 
     /// Create an empty tensor of the given shape.
-    pub fn empty<S: Into<Shape<D>>>(shape: S) -> Self {
-        Self::empty_device(shape, &B::Device::default())
+    pub fn empty_default<S: Into<Shape<D>>>(shape: S) -> Self {
+        Self::empty(shape, &B::Device::default())
     }
 
     /// Create an empty tensor of the given shape.
-    pub fn empty_device<S: Into<Shape<D>>>(shape: S, device: &B::Device) -> Self {
+    pub fn empty<S: Into<Shape<D>>>(shape: S, device: &B::Device) -> Self {
         Self::new(K::empty(shape.into(), device))
     }
 
@@ -88,7 +88,7 @@ where
     /// use burn_tensor::Tensor;
     ///
     /// fn example<B: Backend>() {
-    ///    let tensor = Tensor::<B, 3>::ones([2, 3, 4]);
+    ///    let tensor = Tensor::<B, 3>::ones_default([2, 3, 4]);
     ///    // Given a 3D tensor with dimensions (2, 3, 4), reshape it to (2, 12)
     ///    let reshaped_tensor: Tensor::<B, 2> = tensor.reshape([2, -1]);
     ///    // The resulting tensor will have dimensions (2, 12).
@@ -155,7 +155,7 @@ where
     /// use burn_tensor::{Tensor, Shape};
     ///
     /// fn example<B: Backend>() {
-    ///     let tensor = Tensor::<B, 3>::ones(Shape::new([2, 3, 4]));
+    ///     let tensor = Tensor::<B, 3>::ones_default(Shape::new([2, 3, 4]));
     ///
     ///     // Given a 3D tensor with dimensions (2, 3, 4), flatten the dimensions between indices 1 and 2:
     ///     let flattened_tensor: Tensor::<B, 2> = tensor.flatten(1, 2);
@@ -206,7 +206,7 @@ where
     /// use burn_tensor::{Tensor, Shape};
     ///
     /// fn example<B: Backend>() {
-    ///     let tensor = Tensor::<B, 3>::ones(Shape::new([2, 1, 4]));
+    ///     let tensor = Tensor::<B, 3>::ones_default(Shape::new([2, 1, 4]));
     ///
     ///     // Given a 3D tensor with dimensions (2, 1, 4), squeeze the dimension 1
     ///     let squeezed_tensor: Tensor::<B, 2> = tensor.squeeze(1);
@@ -238,7 +238,7 @@ where
     /// use burn_tensor::{Tensor, Shape};
     ///
     /// fn example<B: Backend>() {
-    ///     let tensor = Tensor::<B, 2>::ones(Shape::new([3, 3]));
+    ///     let tensor = Tensor::<B, 2>::ones_default(Shape::new([3, 3]));
     ///     let tensor = tensor.unsqueeze::<4>();
     ///     println!("{:?}", tensor.shape());
     ///     // Shape { dims: [1, 1, 3, 3] }
@@ -270,7 +270,7 @@ where
     /// use burn_tensor::{Tensor, Shape};
     ///
     /// fn example<B: Backend>() {
-    ///     let tensor = Tensor::<B, 3>::ones(Shape::new([2, 3, 3]));
+    ///     let tensor = Tensor::<B, 3>::ones_default(Shape::new([2, 3, 3]));
     ///     let tensor_slices = tensor.slice([0..1, 0..3, 1..2]);
     ///     println!("{:?}", tensor_slices.dims()); // [1, 3, 2]
     ///     
@@ -296,8 +296,8 @@ where
     /// use burn_tensor::Tensor;
     ///
     /// fn example<B: Backend>() {
-    ///     let tensor = Tensor::<B, 3>::ones([2, 3, 3]);
-    ///     let values = Tensor::<B, 3>::zeros([1, 1, 1]);
+    ///     let tensor = Tensor::<B, 3>::ones_default([2, 3, 3]);
+    ///     let values = Tensor::<B, 3>::zeros_default([1, 1, 1]);
     ///     let tensor_sliced = tensor.slice_assign([0..1, 0..1, 0..1], values);
     ///     println!("{:?}", tensor_sliced.dims()); // [2, 3, 3]
     /// }
@@ -350,15 +350,15 @@ where
     }
 
     /// Create a tensor from the given data.
-    pub fn from_data<T>(data: T) -> Self
+    pub fn from_data_default<T>(data: T) -> Self
     where
         T: Into<Data<K::Elem, D>>,
     {
-        Self::from_data_device(data, &B::Device::default())
+        Self::from_data(data, &B::Device::default())
     }
 
     /// Create a tensor from the given data on the given device.
-    pub fn from_data_device<T>(data: T, device: &B::Device) -> Self
+    pub fn from_data<T>(data: T, device: &B::Device) -> Self
     where
         T: Into<Data<K::Elem, D>>,
     {
@@ -673,7 +673,7 @@ where
 /// use burn_tensor::{Tensor, T};
 ///
 /// fn example<B: Backend>() {
-///     let tensor = Tensor::<B, 2>::from_floats([[1.0, 2.0], [3.0, 4.0]]);
+///     let tensor = Tensor::<B, 2>::from_floats_default([[1.0, 2.0], [3.0, 4.0]]);
 ///     let transposed = tensor^T;
 /// }
 /// ```

--- a/burn-tensor/src/tensor/api/bool.rs
+++ b/burn-tensor/src/tensor/api/bool.rs
@@ -5,12 +5,12 @@ where
     B: Backend,
 {
     /// Create a boolean tensor from data.
-    pub fn from_bool(data: Data<bool, D>) -> Self {
+    pub fn from_bool_default(data: Data<bool, D>) -> Self {
         Self::new(B::bool_from_data(data, &B::Device::default()))
     }
 
     /// Create a boolean tensor from data on the given device.
-    pub fn from_bool_device(data: Data<bool, D>, device: &B::Device) -> Self {
+    pub fn from_bool(data: Data<bool, D>, device: &B::Device) -> Self {
         Self::new(B::bool_from_data(data, device))
     }
 

--- a/burn-tensor/src/tensor/api/float.rs
+++ b/burn-tensor/src/tensor/api/float.rs
@@ -104,6 +104,24 @@ where
         Self::from_data(floats.into().convert())
     }
 
+    /// Create a tensor from floats (f32) on a given device.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use burn_tensor::backend::Backend;
+    /// use burn_tensor::Tensor;
+    ///
+    /// fn example<B: Backend>() {
+    ///     let device = B::Device::default();
+    ///     let _ = Tensor::<B, 1>::from_floats_device([1.0, 2.0], &device);
+    ///     let _ = Tensor::<B, 2>::from_floats_device([[1.0, 2.0], [3.0, 4.0]], &device);
+    /// }
+    /// ```
+    pub fn from_floats_device<A: Into<Data<f32, D>>>(floats: A, device: &B::Device) -> Self {
+        Self::from_data_device(floats.into().convert(), device)
+    }
+
     /// Returns a new tensor with the same shape and device as the current tensor and the data
     /// casted to Integer.
     ///

--- a/burn-tensor/src/tensor/api/float.rs
+++ b/burn-tensor/src/tensor/api/float.rs
@@ -25,7 +25,7 @@ where
     /// want to mutate a tensor by using owned operations. A plausible usage would be to
     /// update the weights of a mutable model reference.
     pub fn inplace<F: FnOnce(Self) -> Self>(&mut self, func: F) {
-        let mut tensor_owned = Tensor::empty([0; D]);
+        let mut tensor_owned = Tensor::empty([0; D], &self.device());
         core::mem::swap(&mut tensor_owned, self);
 
         let mut tensor_new = func(tensor_owned);
@@ -96,12 +96,12 @@ where
     /// use burn_tensor::Tensor;
     ///
     /// fn example<B: Backend>() {
-    ///     let _ = Tensor::<B, 1>::from_floats([1.0, 2.0]);
-    ///     let _ = Tensor::<B, 2>::from_floats([[1.0, 2.0], [3.0, 4.0]]);
+    ///     let _ = Tensor::<B, 1>::from_floats_default([1.0, 2.0]);
+    ///     let _ = Tensor::<B, 2>::from_floats_default([[1.0, 2.0], [3.0, 4.0]]);
     /// }
     /// ```
-    pub fn from_floats<A: Into<Data<f32, D>>>(floats: A) -> Self {
-        Self::from_data(floats.into().convert())
+    pub fn from_floats_default<A: Into<Data<f32, D>>>(floats: A) -> Self {
+        Self::from_data_default(floats.into().convert())
     }
 
     /// Create a tensor from floats (f32) on a given device.
@@ -114,12 +114,12 @@ where
     ///
     /// fn example<B: Backend>() {
     ///     let device = B::Device::default();
-    ///     let _ = Tensor::<B, 1>::from_floats_device([1.0, 2.0], &device);
-    ///     let _ = Tensor::<B, 2>::from_floats_device([[1.0, 2.0], [3.0, 4.0]], &device);
+    ///     let _ = Tensor::<B, 1>::from_floats([1.0, 2.0], &device);
+    ///     let _ = Tensor::<B, 2>::from_floats([[1.0, 2.0], [3.0, 4.0]], &device);
     /// }
     /// ```
-    pub fn from_floats_device<A: Into<Data<f32, D>>>(floats: A, device: &B::Device) -> Self {
-        Self::from_data_device(floats.into().convert(), device)
+    pub fn from_floats<A: Into<Data<f32, D>>>(floats: A, device: &B::Device) -> Self {
+        Self::from_data(floats.into().convert(), device)
     }
 
     /// Returns a new tensor with the same shape and device as the current tensor and the data
@@ -132,7 +132,7 @@ where
     /// use burn_tensor::Tensor;
     ///
     /// fn example<B: Backend>() {
-    ///     let float_tensor = Tensor::<B, 1>::from_floats([1.0, 2.0]);
+    ///     let float_tensor = Tensor::<B, 1>::from_floats_default([1.0, 2.0]);
     ///     let int_tensor = float_tensor.int();
     /// }
     /// ```
@@ -175,11 +175,11 @@ where
         dims[D - 1] = num_classes;
         let shape = Shape::new(dims);
         let ranges: Vec<_> = shape.dims.iter().map(|dim| 0..*dim).collect();
-        let tensor = Tensor::zeros(shape);
+        let tensor = Tensor::zeros_default(shape);
         let mut ranges: [core::ops::Range<usize>; D] = ranges.try_into().unwrap();
         ranges[D - 1] = index..index + 1;
 
-        tensor.slice_assign(ranges, Tensor::ones(Shape::new([1; D])))
+        tensor.slice_assign(ranges, Tensor::ones_default(Shape::new([1; D])))
     }
 
     /// Applies the matrix multiplication operation.
@@ -220,14 +220,17 @@ where
 
     /// Create a random tensor of the given shape where each element is sampled from the given
     /// distribution.
-    pub fn random<S: Into<Shape<D>>>(shape: S, distribution: Distribution<B::FloatElem>) -> Self {
+    pub fn random_default<S: Into<Shape<D>>>(
+        shape: S,
+        distribution: Distribution<B::FloatElem>,
+    ) -> Self {
         let tensor = B::random(shape.into(), distribution, &B::Device::default());
         Self::new(tensor)
     }
 
     /// Create a random tensor of the given shape on the given device where each element is
     /// sampled from the given distribution.
-    pub fn random_device<S: Into<Shape<D>>>(
+    pub fn random<S: Into<Shape<D>>>(
         shape: S,
         distribution: Distribution<B::FloatElem>,
         device: &B::Device,

--- a/burn-tensor/src/tensor/api/int.rs
+++ b/burn-tensor/src/tensor/api/int.rs
@@ -1,4 +1,4 @@
-use crate::{backend::Backend, Data, Device, Float, Int, Tensor};
+use crate::{backend::Backend, Data, Float, Int, Tensor};
 use core::ops::Range;
 
 impl<B> Tensor<B, 1, Int>

--- a/burn-tensor/src/tensor/api/int.rs
+++ b/burn-tensor/src/tensor/api/int.rs
@@ -1,4 +1,4 @@
-use crate::{backend::Backend, Data, Float, Int, Tensor};
+use crate::{backend::Backend, Data, Device, Float, Int, Tensor};
 use core::ops::Range;
 
 impl<B> Tensor<B, 1, Int>
@@ -10,7 +10,7 @@ where
     /// # Arguments
     ///
     /// * `range` - The range of values to generate.
-    pub fn arange(range: Range<usize>) -> Self {
+    pub fn arange_default(range: Range<usize>) -> Self {
         Tensor::new(B::arange(range, &B::Device::default()))
     }
 
@@ -20,7 +20,7 @@ where
     ///
     /// * `range` - The range of values to generate.
     /// * `step` - The step between each value.
-    pub fn arange_step(range: Range<usize>, step: usize) -> Self {
+    pub fn arange_step_default(range: Range<usize>, step: usize) -> Self {
         Tensor::new(B::arange_step(range, step, &B::Device::default()))
     }
 
@@ -30,7 +30,7 @@ where
     ///
     /// * `range` - The range of values to generate.
     /// * `device` - The device to create the tensor on.
-    pub fn arange_device(range: Range<usize>, device: &B::Device) -> Self {
+    pub fn arange(range: Range<usize>, device: &B::Device) -> Self {
         Tensor::new(B::arange(range, device))
     }
 
@@ -40,7 +40,7 @@ where
     ///
     /// * `range` - The range of values to generate.
     /// * `step` - The step between each value.
-    pub fn arange_step_device(range: Range<usize>, step: usize, device: &B::Device) -> Self {
+    pub fn arange_step(range: Range<usize>, step: usize, device: &B::Device) -> Self {
         Tensor::new(B::arange_step(range, step, device))
     }
 }
@@ -58,12 +58,30 @@ where
     /// use burn_tensor::{Tensor, Int};
     ///
     /// fn example<B: Backend>() {
-    ///     let _x: Tensor<B, 1, Int> = Tensor::from_ints([1, 2]);
-    ///     let _y: Tensor<B, 2, Int> = Tensor::from_ints([[1, 2], [3, 4]]);
+    ///     let _x: Tensor<B, 1, Int> = Tensor::from_ints_default([1, 2]);
+    ///     let _y: Tensor<B, 2, Int> = Tensor::from_ints_default([[1, 2], [3, 4]]);
     /// }
     /// ```
-    pub fn from_ints<A: Into<Data<i32, D>>>(ints: A) -> Self {
-        Self::from_data(ints.into().convert())
+    pub fn from_ints_default<A: Into<Data<i32, D>>>(ints: A) -> Self {
+        Self::from_data_default(ints.into().convert())
+    }
+
+    /// Create a tensor from integers (i32), placing it on a given device.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use burn_tensor::backend::Backend;
+    /// use burn_tensor::{Tensor, Int};
+    ///
+    /// fn example<B: Backend>() {
+    ///     let device = B::Device::default();
+    ///     let _x: Tensor<B, 1, Int> = Tensor::from_ints([1, 2], &device);
+    ///     let _y: Tensor<B, 2, Int> = Tensor::from_ints([[1, 2], [3, 4]], &device);
+    /// }
+    /// ```
+    pub fn from_ints<A: Into<Data<i32, D>>>(ints: A, device: &B::Device) -> Self {
+        Self::from_data(ints.into().convert(), device)
     }
 
     /// Returns a new tensor with the same shape and device as the current tensor and the data
@@ -76,7 +94,7 @@ where
     /// use burn_tensor::{Int, Tensor};
     ///
     /// fn example<B: Backend>() {
-    ///     let int_tensor = Tensor::<B, 1, Int>::arange(0..5);
+    ///     let int_tensor = Tensor::<B, 1, Int>::arange_default(0..5);
     ///     let float_tensor = int_tensor.float();
     /// }
     /// ```

--- a/burn-tensor/src/tensor/api/numeric.rs
+++ b/burn-tensor/src/tensor/api/numeric.rs
@@ -477,8 +477,8 @@ where
     /// * `size` - The size of the square matrix.
     pub fn diagonal(size: usize, device: &B::Device) -> Self {
         let indices = Tensor::<B, 1, Int>::arange(0..size, device).unsqueeze();
-        let ones = K::ones([1, size].into(), &device);
-        let zeros = K::zeros([size, size].into(), &device);
+        let ones = K::ones([1, size].into(), device);
+        let zeros = K::zeros([size, size].into(), device);
         Self::new(K::scatter(0, zeros, indices, ones))
     }
 }

--- a/burn-tensor/src/tensor/api/numeric.rs
+++ b/burn-tensor/src/tensor/api/numeric.rs
@@ -106,32 +106,32 @@ where
     }
 
     /// Create a tensor of the given shape where each element is zero.
-    pub fn zeros<S: Into<Shape<D>>>(shape: S) -> Self {
-        Self::zeros_device(shape, &B::Device::default())
+    pub fn zeros_default<S: Into<Shape<D>>>(shape: S) -> Self {
+        Self::zeros(shape, &B::Device::default())
     }
 
     /// Create a tensor of the given shape where each element is zero.
-    pub fn zeros_device<S: Into<Shape<D>>>(shape: S, device: &B::Device) -> Self {
+    pub fn zeros<S: Into<Shape<D>>>(shape: S, device: &B::Device) -> Self {
         Self::new(K::zeros(shape.into(), device))
     }
 
     /// Create a tensor of the given shape where each element is one.
-    pub fn ones<S: Into<Shape<D>>>(shape: S) -> Self {
-        Self::ones_device(shape, &B::Device::default())
+    pub fn ones_default<S: Into<Shape<D>>>(shape: S) -> Self {
+        Self::ones(shape, &B::Device::default())
     }
 
     /// Create a tensor of the given shape where each element is one.
-    pub fn ones_device<S: Into<Shape<D>>>(shape: S, device: &B::Device) -> Self {
+    pub fn ones<S: Into<Shape<D>>>(shape: S, device: &B::Device) -> Self {
         Self::new(K::ones(shape.into(), device))
     }
 
     /// Create a tensor of the given shape where each element is equal to the provided value.
-    pub fn full<S: Into<Shape<D>>, E: ElementConversion>(shape: S, fill_value: E) -> Self {
-        Self::full_device(shape, fill_value, &B::Device::default())
+    pub fn full_default<S: Into<Shape<D>>, E: ElementConversion>(shape: S, fill_value: E) -> Self {
+        Self::full(shape, fill_value, &B::Device::default())
     }
 
     /// Create a tensor of the given shape where each element is equal to the provided value.
-    pub fn full_device<S: Into<Shape<D>>, E: ElementConversion>(
+    pub fn full<S: Into<Shape<D>>, E: ElementConversion>(
         shape: S,
         fill_value: E,
         device: &B::Device,
@@ -335,7 +335,7 @@ where
     /// use burn_tensor::{Tensor, Shape};
     ///
     /// fn example<B: Backend>() {
-    ///     let tensor = Tensor::<B, 3>::ones(Shape::new([2, 3, 3]));
+    ///     let tensor = Tensor::<B, 3>::ones_default(Shape::new([2, 3, 3]));
     ///     let tensor = tensor.argmax(1);
     ///     println!("{:?}", tensor.shape());
     ///     // Shape { dims: [2, 1, 3] }
@@ -380,7 +380,7 @@ where
     /// use burn_tensor::{Tensor, Shape};
     ///
     /// fn example<B: Backend>() {
-    ///     let tensor = Tensor::<B, 3>::ones(Shape::new([2, 3, 3]));
+    ///     let tensor = Tensor::<B, 3>::ones_default(Shape::new([2, 3, 3]));
     ///     let tensor = tensor.argmin(1);
     ///     println!("{:?}", tensor.shape());
     ///     // Shape { dims: [2, 1, 3] }
@@ -475,10 +475,10 @@ where
     /// # Arguments
     ///
     /// * `size` - The size of the square matrix.
-    pub fn diagonal(size: usize) -> Self {
-        let indices = Tensor::<B, 1, Int>::arange(0..size).unsqueeze();
-        let ones = K::ones([1, size].into(), &B::Device::default());
-        let zeros = K::zeros([size, size].into(), &B::Device::default());
+    pub fn diagonal(size: usize, device: &B::Device) -> Self {
+        let indices = Tensor::<B, 1, Int>::arange(0..size, device).unsqueeze();
+        let ones = K::ones([1, size].into(), &device);
+        let zeros = K::zeros([size, size].into(), &device);
         Self::new(K::scatter(0, zeros, indices, ones))
     }
 }

--- a/burn-tensor/src/tensor/named/base.rs
+++ b/burn-tensor/src/tensor/named/base.rs
@@ -49,8 +49,21 @@ where
 
     /// Create a random named tensor of the given shape where each element is sampled from
     /// the given distribution.
-    pub fn random<S: Into<Shape<D>>>(shape: S, distribution: Distribution<B::FloatElem>) -> Self {
-        Self::from_tensor(Tensor::random(shape, distribution))
+    pub fn random<S: Into<Shape<D>>>(
+        shape: S,
+        distribution: Distribution<B::FloatElem>,
+        device: &B::Device,
+    ) -> Self {
+        Self::from_tensor(Tensor::random(shape, distribution, device))
+    }
+
+    /// Create a random named tensor of the given shape where each element is sampled from
+    /// the given distribution. Tensor will be placed on the default device of the backend.
+    pub fn random_default<S: Into<Shape<D>>>(
+        shape: S,
+        distribution: Distribution<B::FloatElem>,
+    ) -> Self {
+        Self::from_tensor(Tensor::random_default(shape, distribution))
     }
 
     /// Returns the shape of the current tensor.

--- a/burn-tensor/src/tests/activation/gelu.rs
+++ b/burn-tensor/src/tests/activation/gelu.rs
@@ -8,7 +8,7 @@ mod tests {
         let data = Data::from([[
             0.5447, 0.9809, 0.4114, 0.1398, 0.8045, 0.4103, 0.2388, 0.5262, 0.6677, 0.6737,
         ]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data).clone().clone();
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data).clone().clone();
 
         let data_actual = activation::gelu(tensor).to_data();
 

--- a/burn-tensor/src/tests/activation/gelu.rs
+++ b/burn-tensor/src/tests/activation/gelu.rs
@@ -8,7 +8,9 @@ mod tests {
         let data = Data::from([[
             0.5447, 0.9809, 0.4114, 0.1398, 0.8045, 0.4103, 0.2388, 0.5262, 0.6677, 0.6737,
         ]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data_default(data).clone().clone();
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data)
+            .clone()
+            .clone();
 
         let data_actual = activation::gelu(tensor).to_data();
 

--- a/burn-tensor/src/tests/activation/relu.rs
+++ b/burn-tensor/src/tests/activation/relu.rs
@@ -6,7 +6,7 @@ mod tests {
     #[test]
     fn test_relu_d2() {
         let data = Data::from([[0.0, -1.0, 2.0], [3.0, -4.0, 5.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = activation::relu(tensor).to_data();
 

--- a/burn-tensor/src/tests/activation/sigmoid.rs
+++ b/burn-tensor/src/tests/activation/sigmoid.rs
@@ -6,7 +6,7 @@ mod tests {
     #[test]
     fn test_sigmoid() {
         let data = Data::from([[1.0, 7.0], [13.0, -3.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = activation::sigmoid(tensor).to_data();
 
@@ -17,7 +17,7 @@ mod tests {
     #[test]
     fn test_sigmoid_overflow() {
         let data = Data::from([f32::MAX, f32::MIN]);
-        let tensor = Tensor::<TestBackend, 1>::from_data(data);
+        let tensor = Tensor::<TestBackend, 1>::from_data_default(data);
 
         let data_actual = activation::sigmoid(tensor).to_data();
 

--- a/burn-tensor/src/tests/activation/silu.rs
+++ b/burn-tensor/src/tests/activation/silu.rs
@@ -6,7 +6,7 @@ mod tests {
     #[test]
     fn test_silu() {
         let data = Data::from([[1.0, 2.0], [3.0, 4.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = activation::silu(tensor).to_data();
 

--- a/burn-tensor/src/tests/activation/softmax.rs
+++ b/burn-tensor/src/tests/activation/softmax.rs
@@ -6,7 +6,7 @@ mod tests {
     #[test]
     fn test_softmax_d2() {
         let data = Data::from([[1.0, 7.0], [13.0, -3.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = activation::softmax(tensor, 1).to_data();
 

--- a/burn-tensor/src/tests/activation/tanh_activation.rs
+++ b/burn-tensor/src/tests/activation/tanh_activation.rs
@@ -6,7 +6,7 @@ mod tests {
     #[test]
     fn test_tanh() {
         let data = Data::from([[1., 2.], [3., 4.]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = activation::tanh(tensor).to_data();
 

--- a/burn-tensor/src/tests/clone_invariance.rs
+++ b/burn-tensor/src/tests/clone_invariance.rs
@@ -39,13 +39,13 @@ mod tests {
                     type Args = Data<f32, 2>;
 
                     fn args(&self) -> Self::Args {
-                        TestTensor::random([32, 32], Distribution::Default)
+                        TestTensor::random_default([32, 32], Distribution::Default)
                             .into_data()
                             .convert()
                     }
 
                     fn run(&self, args: &Self::Args, inplace: bool) -> Data<f32, 2> {
-                        let lhs = TestTensor::from_data(args.clone().convert());
+                        let lhs = TestTensor::from_data_default(args.clone().convert());
 
                         if inplace {
                             $ops(lhs).into_data().convert()
@@ -72,19 +72,19 @@ mod tests {
 
                     fn args(&self) -> Self::Args {
                         (
-                            TestTensor::random([32, 32], Distribution::Default)
+                            TestTensor::random_default([32, 32], Distribution::Default)
                                 .into_data()
                                 .convert(),
                             // Avoid div by zero.
-                            TestTensor::random([32, 32], Distribution::Uniform(1., 3.))
+                            TestTensor::random_default([32, 32], Distribution::Uniform(1., 3.))
                                 .into_data()
                                 .convert(),
                         )
                     }
 
                     fn run(&self, (lhs_arg, rhs_arg): &Self::Args, inplace: bool) -> Data<f32, 2> {
-                        let lhs = TestTensor::from_data(lhs_arg.clone().convert());
-                        let rhs = TestTensor::from_data(rhs_arg.clone().convert());
+                        let lhs = TestTensor::from_data_default(lhs_arg.clone().convert());
+                        let rhs = TestTensor::from_data_default(rhs_arg.clone().convert());
 
                         if inplace {
                             $ops(lhs, rhs).into_data().convert()
@@ -113,13 +113,13 @@ mod tests {
                     type Args = Data<i32, 2>;
 
                     fn args(&self) -> Self::Args {
-                        TestTensor::random([32, 32], Distribution::Uniform(0.0, 50.0))
+                        TestTensor::random_default([32, 32], Distribution::Uniform(0.0, 50.0))
                             .into_data()
                             .convert()
                     }
 
                     fn run(&self, args: &Self::Args, inplace: bool) -> Data<f32, 2> {
-                        let lhs = TestTensorInt::from_data(args.clone().convert());
+                        let lhs = TestTensorInt::from_data_default(args.clone().convert());
 
                         if inplace {
                             $ops(lhs).into_data().convert()
@@ -146,19 +146,19 @@ mod tests {
 
                     fn args(&self) -> Self::Args {
                         (
-                            TestTensor::random([32, 32], Distribution::Uniform(0., 50.))
+                            TestTensor::random_default([32, 32], Distribution::Uniform(0., 50.))
                                 .into_data()
                                 .convert(),
                             // Avoid div by zero.
-                            TestTensor::random([32, 32], Distribution::Uniform(1., 51.))
+                            TestTensor::random_default([32, 32], Distribution::Uniform(1., 51.))
                                 .into_data()
                                 .convert(),
                         )
                     }
 
                     fn run(&self, (lhs_arg, rhs_arg): &Self::Args, inplace: bool) -> Data<f32, 2> {
-                        let lhs = TestTensorInt::from_data(lhs_arg.clone().convert());
-                        let rhs = TestTensorInt::from_data(rhs_arg.clone().convert());
+                        let lhs = TestTensorInt::from_data_default(lhs_arg.clone().convert());
+                        let rhs = TestTensorInt::from_data_default(rhs_arg.clone().convert());
 
                         if inplace {
                             $ops(lhs, rhs).into_data().convert()
@@ -348,14 +348,14 @@ mod tests {
             unary: Gatter,
             ops_float: |tensor: TestTensor<2>| {
                 let shape = tensor.shape();
-                let indices = TestTensorInt::ones(shape);
+                let indices = TestTensorInt::ones_default(shape);
                 tensor.gather(0, indices)
             }
         );
         clone_invariance_test!(
             unary: Select,
             ops_float: |tensor: TestTensor<2>| {
-                let indices = TestTensorInt::from_ints([1, 2, 0, 5]);
+                let indices = TestTensorInt::from_ints_default([1, 2, 0, 5]);
                 tensor.select(0, indices)
             }
         );
@@ -455,7 +455,7 @@ mod tests {
             binary: Scatter,
             ops_float: |tensor: TestTensor<2>, values: TestTensor<2>| {
                 let shape = tensor.shape();
-                let indices = TestTensorInt::ones(shape);
+                let indices = TestTensorInt::ones_default(shape);
                 tensor.scatter(0, indices, values)
             }
         );
@@ -475,7 +475,7 @@ mod tests {
         clone_invariance_test!(
             binary: SelectAssign,
             ops_float: |tensor: TestTensor<2>, values: TestTensor<2>| {
-                let indices = TestTensorInt::from_ints([1, 2, 0, 5]);
+                let indices = TestTensorInt::from_ints_default([1, 2, 0, 5]);
                 let values = values.select(0, indices.clone());
                 tensor.select_assign(0, indices, values)
             }
@@ -620,14 +620,14 @@ mod tests {
             unary: Gatter,
             ops_int: |tensor: TestTensorInt<2>| {
                 let shape = tensor.shape();
-                let indices = TestTensorInt::ones(shape);
+                let indices = TestTensorInt::ones_default(shape);
                 tensor.gather(0, indices)
             }
         );
         clone_invariance_test!(
             unary: Select,
             ops_int: |tensor: TestTensorInt<2>| {
-                let indices = TestTensorInt::from_ints([1, 2, 0, 5]);
+                let indices = TestTensorInt::from_ints_default([1, 2, 0, 5]);
                 tensor.select(0, indices)
             }
         );
@@ -689,7 +689,7 @@ mod tests {
             binary: Scatter,
             ops_int: |tensor: TestTensorInt<2>, values: TestTensorInt<2>| {
                 let shape = tensor.shape();
-                let indices = TestTensorInt::ones(shape);
+                let indices = TestTensorInt::ones_default(shape);
                 tensor.scatter(0, indices, values)
             }
         );
@@ -709,7 +709,7 @@ mod tests {
         clone_invariance_test!(
             binary: SelectAssign,
             ops_int: |tensor: TestTensorInt<2>, values: TestTensorInt<2>| {
-                let indices = TestTensorInt::from_ints([1, 2, 0, 5]);
+                let indices = TestTensorInt::from_ints_default([1, 2, 0, 5]);
                 let values = values.select(0, indices.clone());
                 tensor.select_assign(0, indices, values)
             }

--- a/burn-tensor/src/tests/module/adaptive_avgpool1d.rs
+++ b/burn-tensor/src/tests/module/adaptive_avgpool1d.rs
@@ -13,7 +13,7 @@ mod tests {
             length_out: 4,
         };
 
-        test.assert_output(TestTensor::from_floats([[
+        test.assert_output(TestTensor::from_floats_default([[
             [0.5, 2.5, 4.5, 6.5],
             [8.5, 10.5, 12.5, 14.5],
         ]]));
@@ -28,7 +28,7 @@ mod tests {
             length_out: 3,
         };
 
-        test.assert_output(TestTensor::from_floats([[
+        test.assert_output(TestTensor::from_floats_default([[
             [1.0, 3.0, 5.0],
             [8.0, 10.0, 12.0],
         ]]));
@@ -43,7 +43,7 @@ mod tests {
             length_out: 8,
         };
 
-        test.assert_output(TestTensor::from_floats([[
+        test.assert_output(TestTensor::from_floats_default([[
             [0.0, 0.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0],
             [4.0, 4.0, 5.0, 5.0, 6.0, 6.0, 7.0, 7.0],
         ]]));
@@ -59,8 +59,8 @@ mod tests {
     impl AdaptiveAvgPool1dTestCase {
         fn assert_output(self, y: TestTensor<3>) {
             let shape_x = Shape::new([self.batch_size, self.channels, self.length]);
-            let x = TestTensor::from_data(
-                TestTensorInt::arange(0..shape_x.num_elements())
+            let x = TestTensor::from_data_default(
+                TestTensorInt::arange_default(0..shape_x.num_elements())
                     .reshape(shape_x)
                     .into_data()
                     .convert(),

--- a/burn-tensor/src/tests/module/adaptive_avgpool2d.rs
+++ b/burn-tensor/src/tests/module/adaptive_avgpool2d.rs
@@ -15,7 +15,7 @@ mod tests {
             width_out: 4,
         };
 
-        test.assert_output(TestTensor::from_floats([[
+        test.assert_output(TestTensor::from_floats_default([[
             [
                 [3.5000, 4.5000, 6.5000, 7.5000],
                 [15.5000, 16.5000, 18.5000, 19.5000],
@@ -42,7 +42,7 @@ mod tests {
             width_out: 2,
         };
 
-        test.assert_output(TestTensor::from_floats([[
+        test.assert_output(TestTensor::from_floats_default([[
             [[5.0000, 8.0000], [15.5000, 18.5000], [26.0000, 29.0000]],
             [[40.0000, 43.0000], [50.5000, 53.5000], [61.0000, 64.0000]],
         ]]));
@@ -59,7 +59,7 @@ mod tests {
             width_out: 4,
         };
 
-        test.assert_output(TestTensor::from_floats([[
+        test.assert_output(TestTensor::from_floats_default([[
             [
                 [0.0000, 0.5000, 1.5000, 2.0000],
                 [1.5000, 2.0000, 3.0000, 3.5000],
@@ -89,8 +89,8 @@ mod tests {
     impl AdaptiveAvgPool2dTestCase {
         fn assert_output(self, y: TestTensor<4>) {
             let shape_x = Shape::new([self.batch_size, self.channels, self.height, self.width]);
-            let x = TestTensor::from_data(
-                TestTensorInt::arange(0..shape_x.num_elements())
+            let x = TestTensor::from_data_default(
+                TestTensorInt::arange_default(0..shape_x.num_elements())
                     .reshape(shape_x)
                     .into_data()
                     .convert(),

--- a/burn-tensor/src/tests/module/avgpool1d.rs
+++ b/burn-tensor/src/tests/module/avgpool1d.rs
@@ -16,7 +16,7 @@ mod tests {
             count_include_pad: true,
         };
 
-        test.assert_output(TestTensor::from_floats([[[1., 2., 3., 4.]]]));
+        test.assert_output(TestTensor::from_floats_default([[[1., 2., 3., 4.]]]));
     }
 
     #[test]
@@ -31,7 +31,7 @@ mod tests {
             count_include_pad: true,
         };
 
-        test.assert_output(TestTensor::from_floats([[
+        test.assert_output(TestTensor::from_floats_default([[
             [0.3333, 2.0000, 4.0000],
             [4.3333, 8.0000, 10.0000],
         ]]));
@@ -49,7 +49,7 @@ mod tests {
             count_include_pad: false,
         };
 
-        test.assert_output(TestTensor::from_floats([[
+        test.assert_output(TestTensor::from_floats_default([[
             [0.5000, 2.0000, 4.0000],
             [6.5000, 8.0000, 10.0000],
         ]]));
@@ -68,8 +68,8 @@ mod tests {
     impl AvgPool1dTestCase {
         fn assert_output(self, y: TestTensor<3>) {
             let shape_x = Shape::new([self.batch_size, self.channels, self.length]);
-            let x = TestTensor::from_data(
-                TestTensorInt::arange(0..shape_x.num_elements())
+            let x = TestTensor::from_data_default(
+                TestTensorInt::arange_default(0..shape_x.num_elements())
                     .reshape(shape_x)
                     .into_data()
                     .convert(),

--- a/burn-tensor/src/tests/module/avgpool2d.rs
+++ b/burn-tensor/src/tests/module/avgpool2d.rs
@@ -20,7 +20,7 @@ mod tests {
             count_include_pad: true,
         };
 
-        test.assert_output(TestTensor::from_floats([[[
+        test.assert_output(TestTensor::from_floats_default([[[
             [7., 8., 9., 10.],
             [13., 14., 15., 16.],
             [19., 20., 21., 22.],
@@ -44,7 +44,7 @@ mod tests {
             count_include_pad: true,
         };
 
-        test.assert_output(TestTensor::from_floats([[[
+        test.assert_output(TestTensor::from_floats_default([[[
             [1.1667, 3.0000, 4.3333, 2.5000],
             [3.2500, 7.5000, 9.5000, 5.2500],
             [6.2500, 13.5000, 15.5000, 8.2500],
@@ -68,7 +68,7 @@ mod tests {
             count_include_pad: false,
         };
 
-        test.assert_output(TestTensor::from_floats([[[
+        test.assert_output(TestTensor::from_floats_default([[[
             [3.5000, 4.5000, 6.5000, 7.5000],
             [6.5000, 7.5000, 9.5000, 10.5000],
             [12.5000, 13.5000, 15.5000, 16.5000],
@@ -93,8 +93,8 @@ mod tests {
     impl AvgPool2dTestCase {
         fn assert_output(self, y: TestTensor<4>) {
             let shape_x = Shape::new([self.batch_size, self.channels, self.height, self.width]);
-            let x = TestTensor::from_data(
-                TestTensorInt::arange(0..shape_x.num_elements())
+            let x = TestTensor::from_data_default(
+                TestTensorInt::arange_default(0..shape_x.num_elements())
                     .reshape(shape_x)
                     .into_data()
                     .convert(),

--- a/burn-tensor/src/tests/module/conv1d.rs
+++ b/burn-tensor/src/tests/module/conv1d.rs
@@ -19,7 +19,7 @@ mod tests {
             length: 4,
         };
 
-        test.assert_output(TestTensor::from_floats([
+        test.assert_output(TestTensor::from_floats_default([
             [[43., 67., 82., 49.], [104., 176., 227., 158.]],
             [[139., 187., 202., 113.], [392., 584., 635., 414.]],
         ]));
@@ -39,7 +39,7 @@ mod tests {
             length: 4,
         };
 
-        test.assert_output(TestTensor::from_floats([
+        test.assert_output(TestTensor::from_floats_default([
             [[62., 38.], [159., 111.]],
             [[158., 102.], [447., 367.]],
         ]));
@@ -59,7 +59,7 @@ mod tests {
             length: 4,
         };
 
-        test.assert_output(TestTensor::from_floats([
+        test.assert_output(TestTensor::from_floats_default([
             [[2., 5., 8., 3.], [42., 63., 75., 47.]],
             [[26., 29., 32., 11.], [114., 159., 171., 103.]],
         ]));
@@ -79,7 +79,7 @@ mod tests {
             length: 4,
         };
 
-        test.assert_output(TestTensor::from_floats([
+        test.assert_output(TestTensor::from_floats_default([
             [[171., 294.], [415., 781.], [659., 1268.], [903., 1755.]],
             [[495., 726.], [1387., 2185.], [2279., 3644.], [3171., 5103.]],
         ]));
@@ -105,19 +105,19 @@ mod tests {
                 self.channels_in / self.groups,
                 self.kernel_size,
             ]);
-            let weight = TestTensor::from_data(
-                TestTensorInt::arange(0..shape_weight.num_elements())
+            let weight = TestTensor::from_data_default(
+                TestTensorInt::arange_default(0..shape_weight.num_elements())
                     .reshape(shape_weight)
                     .into_data()
                     .convert(),
             );
-            let bias = TestTensor::from_data(
-                TestTensorInt::arange(0..self.channels_out)
+            let bias = TestTensor::from_data_default(
+                TestTensorInt::arange_default(0..self.channels_out)
                     .into_data()
                     .convert(),
             );
-            let x = TestTensor::from_data(
-                TestTensorInt::arange(0..shape_x.num_elements())
+            let x = TestTensor::from_data_default(
+                TestTensorInt::arange_default(0..shape_x.num_elements())
                     .reshape(shape_x)
                     .into_data()
                     .convert(),

--- a/burn-tensor/src/tests/module/conv2d.rs
+++ b/burn-tensor/src/tests/module/conv2d.rs
@@ -24,7 +24,7 @@ mod tests {
             width: 4,
         };
 
-        test.assert_output(TestTensor::from_floats([[
+        test.assert_output(TestTensor::from_floats_default([[
             [
                 [1196., 1796., 1916., 1264.],
                 [1881., 2793., 2946., 1923.],
@@ -59,7 +59,7 @@ mod tests {
             width: 5,
         };
 
-        test.assert_output(TestTensor::from_floats([[
+        test.assert_output(TestTensor::from_floats_default([[
             [[312., 348., 384.], [492., 528., 564.], [672., 708., 744.]],
             [
                 [3724., 3841., 3958.],
@@ -88,7 +88,7 @@ mod tests {
             width: 5,
         };
 
-        test.assert_output(TestTensor::from_floats([
+        test.assert_output(TestTensor::from_floats_default([
             [
                 [[1845., 3789., 1926.], [3210., 6465., 3228.]],
                 [[4276., 9082., 4789.], [8071., 16834., 8737.]],
@@ -130,19 +130,19 @@ mod tests {
                 self.kernel_size_1,
                 self.kernel_size_2,
             ]);
-            let weight = TestTensor::from_data(
-                TestTensorInt::arange(0..shape_weight.num_elements())
+            let weight = TestTensor::from_data_default(
+                TestTensorInt::arange_default(0..shape_weight.num_elements())
                     .reshape(shape_weight)
                     .into_data()
                     .convert(),
             );
-            let bias = TestTensor::from_data(
-                TestTensorInt::arange(0..self.channels_out)
+            let bias = TestTensor::from_data_default(
+                TestTensorInt::arange_default(0..self.channels_out)
                     .into_data()
                     .convert(),
             );
-            let x = TestTensor::from_data(
-                TestTensorInt::arange(0..shape_x.num_elements())
+            let x = TestTensor::from_data_default(
+                TestTensorInt::arange_default(0..shape_x.num_elements())
                     .reshape(shape_x)
                     .into_data()
                     .convert(),

--- a/burn-tensor/src/tests/module/conv_transpose1d.rs
+++ b/burn-tensor/src/tests/module/conv_transpose1d.rs
@@ -20,7 +20,7 @@ mod tests {
             length: 4,
         };
 
-        test.assert_output(TestTensor::from_floats([[
+        test.assert_output(TestTensor::from_floats_default([[
             [270., 453., 516., 387.],
             [352., 589., 679., 505.],
         ]]));
@@ -41,7 +41,7 @@ mod tests {
             length: 4,
         };
 
-        test.assert_output(TestTensor::from_floats([[
+        test.assert_output(TestTensor::from_floats_default([[
             [28., 62., 36., 78., 44., 94., 52., 62.],
             [41., 93., 55., 121., 69., 149., 83., 93.],
         ]]));
@@ -62,7 +62,7 @@ mod tests {
             length: 4,
         };
 
-        test.assert_output(TestTensor::from_floats([[
+        test.assert_output(TestTensor::from_floats_default([[
             [30., 64., 78., 76., 94., 52.],
             [49., 101., 127., 113., 143., 77.],
         ]]));
@@ -83,7 +83,7 @@ mod tests {
             length: 4,
         };
 
-        test.assert_output(TestTensor::from_floats([[
+        test.assert_output(TestTensor::from_floats_default([[
             [0., 1., 4., 7.],
             [32., 59., 71., 59.],
         ]]));
@@ -110,19 +110,19 @@ mod tests {
                 self.channels_out / self.groups,
                 self.kernel_size,
             ]);
-            let weights = TestTensor::from_data(
-                TestTensorInt::arange(0..shape_weights.num_elements())
+            let weights = TestTensor::from_data_default(
+                TestTensorInt::arange_default(0..shape_weights.num_elements())
                     .reshape(shape_weights)
                     .into_data()
                     .convert(),
             );
-            let bias = TestTensor::from_data(
-                TestTensorInt::arange(0..self.channels_out)
+            let bias = TestTensor::from_data_default(
+                TestTensorInt::arange_default(0..self.channels_out)
                     .into_data()
                     .convert(),
             );
-            let x = TestTensor::from_data(
-                TestTensorInt::arange(0..shape_x.num_elements())
+            let x = TestTensor::from_data_default(
+                TestTensorInt::arange_default(0..shape_x.num_elements())
                     .reshape(shape_x)
                     .into_data()
                     .convert(),

--- a/burn-tensor/src/tests/module/conv_transpose2d.rs
+++ b/burn-tensor/src/tests/module/conv_transpose2d.rs
@@ -26,7 +26,10 @@ mod tests {
             width: 2,
         };
 
-        test.assert_output(TestTensor::from_floats([[[[5.0, 11.0], [23.0, 29.0]]]]));
+        test.assert_output(TestTensor::from_floats_default([[[
+            [5.0, 11.0],
+            [23.0, 29.0],
+        ]]]));
     }
     #[test]
     fn test_conv_transpose2d_simple_2() {
@@ -49,7 +52,7 @@ mod tests {
             width: 4,
         };
 
-        test.assert_output(TestTensor::from_floats([[
+        test.assert_output(TestTensor::from_floats_default([[
             [
                 [9855., 15207., 15738., 10797.],
                 [16290., 25119., 25956., 17793.],
@@ -92,7 +95,7 @@ mod tests {
             width: 2,
         };
 
-        test.assert_output(TestTensor::from_floats([[[
+        test.assert_output(TestTensor::from_floats_default([[[
             [0.0, 0.0, 0.0, 1.0],
             [0.0, 0.0, 2.0, 3.0],
             [0.0, 2.0, 0.0, 3.0],
@@ -121,7 +124,7 @@ mod tests {
             width: 2,
         };
 
-        test.assert_output(TestTensor::from_floats([[
+        test.assert_output(TestTensor::from_floats_default([[
             [
                 [126., 116., 136., 124., 146.],
                 [108., 88., 114., 92., 120.],
@@ -160,7 +163,7 @@ mod tests {
             width: 4,
         };
 
-        test.assert_output(TestTensor::from_floats([[
+        test.assert_output(TestTensor::from_floats_default([[
             [
                 [352., 728., 378., 780., 404., 832., 430., 452.],
                 [784., 1616., 836., 1720., 888., 1824., 940., 992.],
@@ -205,7 +208,7 @@ mod tests {
             width: 2,
         };
 
-        test.assert_output(TestTensor::from_floats([[
+        test.assert_output(TestTensor::from_floats_default([[
             [[5., 11.], [23., 29.]],
             [[236., 258.], [302., 324.]],
         ]]));
@@ -232,7 +235,7 @@ mod tests {
             width: 2,
         };
 
-        test.assert_output(TestTensor::from_floats([[
+        test.assert_output(TestTensor::from_floats_default([[
             [
                 [0.0000e+00, 0.0000e+00, 1.0000e+00, 2.0000e+00],
                 [0.0000e+00, 5.0000e+00, 1.1000e+01, 1.1000e+01],
@@ -300,19 +303,19 @@ mod tests {
                 self.kernel_size_1,
                 self.kernel_size_2,
             ]);
-            let weights = TestTensor::from_data(
-                TestTensorInt::arange(0..shape_weights.num_elements())
+            let weights = TestTensor::from_data_default(
+                TestTensorInt::arange_default(0..shape_weights.num_elements())
                     .reshape(shape_weights)
                     .into_data()
                     .convert(),
             );
-            let bias = TestTensor::from_data(
-                TestTensorInt::arange(0..self.channels_out)
+            let bias = TestTensor::from_data_default(
+                TestTensorInt::arange_default(0..self.channels_out)
                     .into_data()
                     .convert(),
             );
-            let x = TestTensor::from_data(
-                TestTensorInt::arange(0..shape_x.num_elements())
+            let x = TestTensor::from_data_default(
+                TestTensorInt::arange_default(0..shape_x.num_elements())
                     .reshape(shape_x)
                     .into_data()
                     .convert(),

--- a/burn-tensor/src/tests/module/forward.rs
+++ b/burn-tensor/src/tests/module/forward.rs
@@ -7,8 +7,8 @@ mod tests {
     fn test_embedding_forward() {
         let weights = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
         let indices = Data::from([[0, 1], [1, 1]]);
-        let weights = Tensor::<TestBackend, 2>::from_data(weights);
-        let indices = Tensor::<TestBackend, 2, Int>::from_data(indices);
+        let weights = Tensor::<TestBackend, 2>::from_data_default(weights);
+        let indices = Tensor::<TestBackend, 2, Int>::from_data_default(indices);
 
         let output = embedding(weights, indices);
         let expected = Data::from([

--- a/burn-tensor/src/tests/module/maxpool1d.rs
+++ b/burn-tensor/src/tests/module/maxpool1d.rs
@@ -105,7 +105,8 @@ mod tests {
 
         let x = TestTensor::from_floats_default([[[0.5388, 0.0676, 0.7122, 0.8316, 0.0653]]]);
         let indices = Data::<IntElem, 3>::from([[[0, 2, 3, 3, 3, 3]]]);
-        let y = TestTensor::from_floats_default([[[0.5388, 0.7122, 0.8316, 0.8316, 0.8316, 0.8316]]]);
+        let y =
+            TestTensor::from_floats_default([[[0.5388, 0.7122, 0.8316, 0.8316, 0.8316, 0.8316]]]);
 
         let (output, output_indices) =
             max_pool1d_with_indices(x, kernel_size, stride, padding, dilation);

--- a/burn-tensor/src/tests/module/maxpool1d.rs
+++ b/burn-tensor/src/tests/module/maxpool1d.rs
@@ -13,11 +13,11 @@ mod tests {
         let stride = 1;
         let dilation = 1;
 
-        let x = TestTensor::from_floats([[
+        let x = TestTensor::from_floats_default([[
             [0.9861, 0.5474, 0.4477, 0.0732, 0.3548, 0.8221],
             [0.8148, 0.5474, 0.9490, 0.7890, 0.5537, 0.5689],
         ]]);
-        let y = TestTensor::from_floats([[
+        let y = TestTensor::from_floats_default([[
             [0.9861, 0.5474, 0.4477, 0.8221],
             [0.949, 0.949, 0.949, 0.789],
         ]]);
@@ -34,8 +34,8 @@ mod tests {
         let stride = 2;
         let dilation = 1;
 
-        let x = TestTensor::from_floats([[[0.6309, 0.6112, 0.6998, 0.4708]]]);
-        let y = TestTensor::from_floats([[[0.6309, 0.6998]]]);
+        let x = TestTensor::from_floats_default([[[0.6309, 0.6112, 0.6998, 0.4708]]]);
+        let y = TestTensor::from_floats_default([[[0.6309, 0.6998]]]);
 
         let output = max_pool1d(x, kernel_size, stride, padding, dilation);
 
@@ -49,8 +49,8 @@ mod tests {
         let stride = 1;
         let dilation = 1;
 
-        let x = TestTensor::from_floats([[[-0.6309, -0.6112, -0.6998, -0.4708]]]);
-        let y = TestTensor::from_floats([[[-0.6112, -0.6112, -0.4708, -0.4708]]]);
+        let x = TestTensor::from_floats_default([[[-0.6309, -0.6112, -0.6998, -0.4708]]]);
+        let y = TestTensor::from_floats_default([[[-0.6112, -0.6112, -0.4708, -0.4708]]]);
 
         let output = max_pool1d(x, kernel_size, stride, padding, dilation);
 
@@ -64,11 +64,11 @@ mod tests {
         let stride = 1;
         let dilation = 2;
 
-        let x = TestTensor::from_floats([[
+        let x = TestTensor::from_floats_default([[
             [0.9861, 0.5474, 0.4477, 0.0732, 0.3548, 0.8221],
             [0.8148, 0.5474, 0.9490, 0.7890, 0.5537, 0.5689],
         ]]);
-        let y = TestTensor::from_floats([[
+        let y = TestTensor::from_floats_default([[
             [0.5474, 0.9861, 0.5474, 0.4477, 0.8221, 0.3548],
             [0.5474, 0.9490, 0.7890, 0.9490, 0.7890, 0.5537],
         ]]);
@@ -85,9 +85,9 @@ mod tests {
         let stride = 1;
         let dilation = 1;
 
-        let x = TestTensor::from_floats([[[0.2479, 0.6386, 0.3166, 0.5742]]]);
+        let x = TestTensor::from_floats_default([[[0.2479, 0.6386, 0.3166, 0.5742]]]);
         let indices = Data::<IntElem, 3>::from([[[1, 1, 3]]]);
-        let y = TestTensor::from_floats([[[0.6386, 0.6386, 0.5742]]]);
+        let y = TestTensor::from_floats_default([[[0.6386, 0.6386, 0.5742]]]);
 
         let (output, output_indices) =
             max_pool1d_with_indices(x, kernel_size, stride, padding, dilation);
@@ -103,9 +103,9 @@ mod tests {
         let stride = 1;
         let dilation = 1;
 
-        let x = TestTensor::from_floats([[[0.5388, 0.0676, 0.7122, 0.8316, 0.0653]]]);
+        let x = TestTensor::from_floats_default([[[0.5388, 0.0676, 0.7122, 0.8316, 0.0653]]]);
         let indices = Data::<IntElem, 3>::from([[[0, 2, 3, 3, 3, 3]]]);
-        let y = TestTensor::from_floats([[[0.5388, 0.7122, 0.8316, 0.8316, 0.8316, 0.8316]]]);
+        let y = TestTensor::from_floats_default([[[0.5388, 0.7122, 0.8316, 0.8316, 0.8316, 0.8316]]]);
 
         let (output, output_indices) =
             max_pool1d_with_indices(x, kernel_size, stride, padding, dilation);

--- a/burn-tensor/src/tests/module/maxpool2d.rs
+++ b/burn-tensor/src/tests/module/maxpool2d.rs
@@ -19,7 +19,7 @@ mod tests {
         let dilation_1 = 1;
         let dilation_2 = 1;
 
-        let x = TestTensor::from_floats([
+        let x = TestTensor::from_floats_default([
             [
                 [
                     [0.9861, 0.5474, 0.4477, 0.0732, 0.3548, 0.8221],
@@ -57,7 +57,7 @@ mod tests {
                 ],
             ],
         ]);
-        let y = TestTensor::from_floats([
+        let y = TestTensor::from_floats_default([
             [
                 [
                     [0.9861, 0.9861, 0.9490, 0.9490, 0.8221, 0.8221],
@@ -120,7 +120,7 @@ mod tests {
         let dilation_1 = 1;
         let dilation_2 = 1;
 
-        let x = TestTensor::from_floats([[[
+        let x = TestTensor::from_floats_default([[[
             [0.6309, 0.6112, 0.6998],
             [0.4708, 0.9161, 0.5402],
             [0.4577, 0.7397, 0.9870],
@@ -128,7 +128,7 @@ mod tests {
             [0.6277, 0.5139, 0.4525],
             [0.9333, 0.9846, 0.5006],
         ]]]);
-        let y = TestTensor::from_floats([[[
+        let y = TestTensor::from_floats_default([[[
             [0.6309, 0.6998],
             [0.6309, 0.9870],
             [0.6380, 0.9870],
@@ -161,7 +161,7 @@ mod tests {
         let dilation_1 = 1;
         let dilation_2 = 1;
 
-        let x = TestTensor::from_floats([[[
+        let x = TestTensor::from_floats_default([[[
             [0.6309, 0.6112, 0.6998],
             [0.4708, 0.9161, 0.5402],
             [0.4577, 0.7397, 0.9870],
@@ -170,7 +170,7 @@ mod tests {
             [0.9333, 0.9846, 0.5006],
         ]]])
         .neg();
-        let y = TestTensor::from_floats([[[
+        let y = TestTensor::from_floats_default([[[
             [-0.4708, -0.4708, -0.5402],
             [-0.4577, -0.4577, -0.5402],
             [-0.4352, -0.4352, -0.4352],
@@ -203,7 +203,7 @@ mod tests {
         let dilation_1 = 2;
         let dilation_2 = 2;
 
-        let x = TestTensor::from_floats([[[
+        let x = TestTensor::from_floats_default([[[
             [0.9861, 0.9861, 0.9490, 0.9490, 0.8221, 0.8221],
             [0.9861, 0.9861, 0.9490, 0.9490, 0.8221, 0.8221],
             [0.9540, 0.9540, 0.9540, 0.9490, 0.7890, 0.7111],
@@ -211,7 +211,7 @@ mod tests {
             [0.9540, 0.9540, 0.9540, 0.9432, 0.8855, 0.8855],
             [0.5063, 0.9432, 0.9432, 0.9432, 0.8855, 0.8855],
         ]]]);
-        let y = TestTensor::from_floats([[[
+        let y = TestTensor::from_floats_default([[[
             [0.9861, 0.9861, 0.9540, 0.9490],
             [0.9861, 0.9861, 0.9540, 0.9490],
             [0.9540, 0.9540, 0.9540, 0.9490],
@@ -241,7 +241,7 @@ mod tests {
         let dilation_1 = 1;
         let dilation_2 = 1;
 
-        let x = TestTensor::from_floats([[[
+        let x = TestTensor::from_floats_default([[[
             [0.2479, 0.6386, 0.3166, 0.5742],
             [0.7065, 0.1940, 0.6305, 0.8959],
             [0.5416, 0.8602, 0.8129, 0.1662],
@@ -254,7 +254,7 @@ mod tests {
             [8, 9, 9, 14, 11],
             [12, 12, 14, 14, 15],
         ]]]);
-        let y = TestTensor::from_floats([[[
+        let y = TestTensor::from_floats_default([[[
             [0.2479, 0.6386, 0.6386, 0.5742, 0.5742],
             [0.7065, 0.7065, 0.6386, 0.8959, 0.8959],
             [0.7065, 0.8602, 0.8602, 0.8959, 0.8959],
@@ -287,7 +287,7 @@ mod tests {
         let dilation_1 = 1;
         let dilation_2 = 1;
 
-        let x = TestTensor::from_floats([[[
+        let x = TestTensor::from_floats_default([[[
             [0.5388, 0.0676, 0.7122, 0.8316, 0.0653],
             [0.9154, 0.1536, 0.9089, 0.8016, 0.7518],
             [0.2073, 0.0501, 0.8811, 0.5604, 0.5075],
@@ -302,7 +302,7 @@ mod tests {
             [15, 16, 24],
             [15, 16, 24],
         ]]]);
-        let y = TestTensor::from_floats([[[
+        let y = TestTensor::from_floats_default([[[
             [0.9154, 0.9089, 0.8316],
             [0.9154, 0.9089, 0.8316],
             [0.9154, 0.9963, 0.8316],

--- a/burn-tensor/src/tests/module/unfold4d.rs
+++ b/burn-tensor/src/tests/module/unfold4d.rs
@@ -34,7 +34,7 @@ mod tests {
             width: 4,
         };
 
-        test.assert_output(TestTensor::from_data([[
+        test.assert_output(TestTensor::from_data_default([[
             [0., 1., 2., 4., 5., 6., 8., 9., 10.],
             [1., 2., 3., 5., 6., 7., 9., 10., 11.],
             [4., 5., 6., 8., 9., 10., 12., 13., 14.],
@@ -59,7 +59,7 @@ mod tests {
             width: 4,
         };
 
-        test.assert_output(TestTensor::from_data([[
+        test.assert_output(TestTensor::from_data_default([[
             [0., 0.],
             [1., 5.],
             [3., 7.],
@@ -89,8 +89,8 @@ mod tests {
     impl Unfold4dTestCase {
         fn assert_shape(self, expected_shape: [usize; 3]) {
             let shape_x = Shape::new([self.batch_size, self.channels_in, self.height, self.width]);
-            let x = TestTensor::from_data(
-                TestTensorInt::arange(0..shape_x.num_elements())
+            let x = TestTensor::from_data_default(
+                TestTensorInt::arange_default(0..shape_x.num_elements())
                     .reshape(shape_x)
                     .into_data()
                     .convert(),
@@ -111,8 +111,8 @@ mod tests {
 
         fn assert_output(self, expected: TestTensor<3>) {
             let shape_x = Shape::new([self.batch_size, self.channels_in, self.height, self.width]);
-            let x = TestTensor::from_data(
-                TestTensorInt::arange(0..shape_x.num_elements())
+            let x = TestTensor::from_data_default(
+                TestTensorInt::arange_default(0..shape_x.num_elements())
                     .reshape(shape_x)
                     .into_data()
                     .convert(),

--- a/burn-tensor/src/tests/ops/abs.rs
+++ b/burn-tensor/src/tests/ops/abs.rs
@@ -6,7 +6,7 @@ mod tests {
     #[test]
     fn should_support_abs_ops_float() {
         let data = Data::from([[0.0, -1.0, 2.0], [3.0, 4.0, -5.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = tensor.abs().into_data();
 
@@ -17,7 +17,7 @@ mod tests {
     #[test]
     fn should_support_abs_ops_int() {
         let data = Data::from([[0, -1, 2], [3, 4, -5]]);
-        let tensor = Tensor::<TestBackend, 2, Int>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2, Int>::from_data_default(data);
 
         let data_actual = tensor.abs().into_data();
 

--- a/burn-tensor/src/tests/ops/add.rs
+++ b/burn-tensor/src/tests/ops/add.rs
@@ -7,8 +7,8 @@ mod tests {
     fn test_add_d2() {
         let data_1 = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
         let data_2 = Data::from([[6.0, 7.0, 8.0], [9.0, 10.0, 11.0]]);
-        let tensor_1 = Tensor::<TestBackend, 2>::from_data(data_1);
-        let tensor_2 = Tensor::<TestBackend, 2>::from_data(data_2);
+        let tensor_1 = Tensor::<TestBackend, 2>::from_data_default(data_1);
+        let tensor_2 = Tensor::<TestBackend, 2>::from_data_default(data_2);
 
         let data_actual = (tensor_1 + tensor_2).into_data();
 
@@ -20,8 +20,8 @@ mod tests {
     fn test_add_broadcast() {
         let data_1 = Data::from([[0.0, 1.0, 2.0]]);
         let data_2 = Data::from([[3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]);
-        let tensor_1 = Tensor::<TestBackend, 2>::from_data(data_1);
-        let tensor_2 = Tensor::<TestBackend, 2>::from_data(data_2);
+        let tensor_1 = Tensor::<TestBackend, 2>::from_data_default(data_1);
+        let tensor_2 = Tensor::<TestBackend, 2>::from_data_default(data_2);
 
         let data_actual = (tensor_1 + tensor_2).into_data();
 
@@ -33,7 +33,7 @@ mod tests {
     fn should_support_add_scalar_ops() {
         let data = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
         let scalar = 2.0;
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let output = tensor + scalar;
 
@@ -46,8 +46,8 @@ mod tests {
     fn test_add_d2_int() {
         let data_1 = Data::from([[0, 1, 2], [3, 4, 5]]);
         let data_2 = Data::from([[6, 7, 8], [9, 10, 11]]);
-        let tensor_1 = Tensor::<TestBackend, 2, Int>::from_data(data_1);
-        let tensor_2 = Tensor::<TestBackend, 2, Int>::from_data(data_2);
+        let tensor_1 = Tensor::<TestBackend, 2, Int>::from_data_default(data_1);
+        let tensor_2 = Tensor::<TestBackend, 2, Int>::from_data_default(data_2);
 
         let data_actual = (tensor_1 + tensor_2).into_data();
 
@@ -59,8 +59,8 @@ mod tests {
     fn test_add_broadcast_int() {
         let data_1 = Data::from([[0, 1, 2]]);
         let data_2 = Data::from([[3, 4, 5], [6, 7, 8]]);
-        let tensor_1 = Tensor::<TestBackend, 2, Int>::from_data(data_1);
-        let tensor_2 = Tensor::<TestBackend, 2, Int>::from_data(data_2);
+        let tensor_1 = Tensor::<TestBackend, 2, Int>::from_data_default(data_1);
+        let tensor_2 = Tensor::<TestBackend, 2, Int>::from_data_default(data_2);
 
         let data_actual = (tensor_1 + tensor_2).into_data();
 
@@ -72,7 +72,7 @@ mod tests {
     fn should_support_add_scalar_ops_int() {
         let data = Data::from([[0, 1, 2], [3, 4, 5]]);
         let scalar = 2;
-        let tensor = Tensor::<TestBackend, 2, Int>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2, Int>::from_data_default(data);
 
         let output = tensor + scalar;
 

--- a/burn-tensor/src/tests/ops/aggregation.rs
+++ b/burn-tensor/src/tests/ops/aggregation.rs
@@ -5,7 +5,7 @@ mod tests {
 
     #[test]
     fn test_should_mean() {
-        let tensor = TestTensor::from_data([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = TestTensor::from_data_default([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let data_actual = tensor.mean().to_data();
 
@@ -14,7 +14,7 @@ mod tests {
 
     #[test]
     fn test_should_mean_int() {
-        let tensor = TestTensorInt::from_data([[2, 2, 2], [3, 4, 5]]);
+        let tensor = TestTensorInt::from_data_default([[2, 2, 2], [3, 4, 5]]);
 
         let data_actual = tensor.mean().to_data();
 
@@ -23,7 +23,7 @@ mod tests {
 
     #[test]
     fn test_should_sum() {
-        let tensor = TestTensor::from_data([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = TestTensor::from_data_default([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let data_actual = tensor.sum().to_data();
 
@@ -32,7 +32,7 @@ mod tests {
 
     #[test]
     fn test_should_sum_int() {
-        let tensor = TestTensorInt::from_data([[0, 1, 2], [3, 4, 5]]);
+        let tensor = TestTensorInt::from_data_default([[0, 1, 2], [3, 4, 5]]);
 
         let data_actual = tensor.sum().to_data();
 
@@ -41,7 +41,7 @@ mod tests {
 
     #[test]
     fn test_should_mean_last_dim() {
-        let tensor = TestTensor::from_data([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = TestTensor::from_data_default([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let data_actual = tensor.mean_dim(1).to_data();
 
@@ -50,7 +50,7 @@ mod tests {
 
     #[test]
     fn test_should_sum_last_dim() {
-        let tensor = TestTensor::from_data([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = TestTensor::from_data_default([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let data_actual = tensor.sum_dim(1).to_data();
 
@@ -59,7 +59,7 @@ mod tests {
 
     #[test]
     fn test_should_mean_last_dim_int() {
-        let tensor = TestTensorInt::from_data([[0, 1, 2], [3, 4, 5]]);
+        let tensor = TestTensorInt::from_data_default([[0, 1, 2], [3, 4, 5]]);
 
         let data_actual = tensor.mean_dim(1).to_data();
 
@@ -68,7 +68,7 @@ mod tests {
 
     #[test]
     fn test_should_sum_last_dim_int() {
-        let tensor = TestTensorInt::from_data([[0, 1, 2], [3, 4, 5]]);
+        let tensor = TestTensorInt::from_data_default([[0, 1, 2], [3, 4, 5]]);
 
         let data_actual = tensor.sum_dim(1).to_data();
 
@@ -77,7 +77,7 @@ mod tests {
 
     #[test]
     fn test_should_sum_first_dim() {
-        let tensor = TestTensor::from_data([[3.0, 1.0, 2.0], [4.0, 2.0, 3.0]]);
+        let tensor = TestTensor::from_data_default([[3.0, 1.0, 2.0], [4.0, 2.0, 3.0]]);
 
         let data_actual = tensor.sum_dim(0).to_data();
 
@@ -86,7 +86,7 @@ mod tests {
 
     #[test]
     fn test_should_mean_first_dim() {
-        let tensor = TestTensor::from_data([[3.0, 1.0, 2.0], [4.0, 2.0, 3.0]]);
+        let tensor = TestTensor::from_data_default([[3.0, 1.0, 2.0], [4.0, 2.0, 3.0]]);
 
         let data_actual = tensor.mean_dim(0).to_data();
 
@@ -95,7 +95,7 @@ mod tests {
 
     #[test]
     fn test_should_sum_mid_dim_3d_non_contiguous_1() {
-        let tensor = TestTensor::from_data([
+        let tensor = TestTensor::from_data_default([
             [[2.0, 4.0, 1.0], [7.0, -5.0, 3.0]],
             [[3.0, 1.0, 2.0], [4.0, 2.0, 3.0]],
         ]);
@@ -110,7 +110,7 @@ mod tests {
 
     #[test]
     fn test_should_sum_mid_dim_3d_non_contiguous_2() {
-        let tensor = TestTensor::from_data([
+        let tensor = TestTensor::from_data_default([
             [[2.0, 4.0, 1.0], [7.0, -5.0, 3.0]],
             [[3.0, 1.0, 2.0], [4.0, 2.0, 3.0]],
         ]);

--- a/burn-tensor/src/tests/ops/arange.rs
+++ b/burn-tensor/src/tests/ops/arange.rs
@@ -5,16 +5,15 @@ mod tests {
     use burn_tensor::{Data, Int, Tensor};
 
     #[test]
-    fn test_arange() {
-        let tensor = Tensor::<TestBackend, 1, Int>::arange(2..5);
+    fn test_arange_default() {
+        let tensor = Tensor::<TestBackend, 1, Int>::arange_default(2..5);
         assert_eq!(tensor.into_data(), Data::from([2, 3, 4]));
     }
 
     #[test]
-    fn test_arange_device() {
+    fn test_arange() {
         let device = <TestBackend as Backend>::Device::default();
-
-        let tensor = Tensor::<TestBackend, 1, Int>::arange_device(2..5, &device);
+        let tensor = Tensor::<TestBackend, 1, Int>::arange(2..5, &device);
         assert_eq!(tensor.clone().into_data(), Data::from([2, 3, 4]));
         assert_eq!(tensor.device(), device);
     }

--- a/burn-tensor/src/tests/ops/arange_step.rs
+++ b/burn-tensor/src/tests/ops/arange_step.rs
@@ -5,34 +5,34 @@ mod tests {
     use burn_tensor::{Data, Int, Tensor};
 
     #[test]
-    fn test_arange_step() {
+    fn test_arange_step_default() {
         // Test correct sequence of numbers when the range is 0..9 and the step is 1
-        let tensor = Tensor::<TestBackend, 1, Int>::arange_step(0..9, 1);
+        let tensor = Tensor::<TestBackend, 1, Int>::arange_step_default(0..9, 1);
         assert_eq!(tensor.into_data(), Data::from([0, 1, 2, 3, 4, 5, 6, 7, 8]));
 
         // Test correct sequence of numbers when the range is 0..3 and the step is 2
-        let tensor = Tensor::<TestBackend, 1, Int>::arange_step(0..3, 2);
+        let tensor = Tensor::<TestBackend, 1, Int>::arange_step_default(0..3, 2);
         assert_eq!(tensor.into_data(), Data::from([0, 2]));
 
         // Test correct sequence of numbers when the range is 0..2 and the step is 5
-        let tensor = Tensor::<TestBackend, 1, Int>::arange_step(0..2, 5);
+        let tensor = Tensor::<TestBackend, 1, Int>::arange_step_default(0..2, 5);
         assert_eq!(tensor.into_data(), Data::from([0]));
     }
 
     #[test]
-    fn test_arange_step_device() {
+    fn test_arange_step() {
         let device = <TestBackend as Backend>::Device::default();
 
         // Test correct sequence of numbers when the range is 0..9 and the step is 1
-        let tensor = Tensor::<TestBackend, 1, Int>::arange_step_device(0..9, 1, &device);
+        let tensor = Tensor::<TestBackend, 1, Int>::arange_step(0..9, 1, &device);
         assert_eq!(tensor.into_data(), Data::from([0, 1, 2, 3, 4, 5, 6, 7, 8]));
 
         // Test correct sequence of numbers when the range is 0..3 and the step is 2
-        let tensor = Tensor::<TestBackend, 1, Int>::arange_step_device(0..3, 2, &device);
+        let tensor = Tensor::<TestBackend, 1, Int>::arange_step(0..3, 2, &device);
         assert_eq!(tensor.into_data(), Data::from([0, 2]));
 
         // Test correct sequence of numbers when the range is 0..2 and the step is 5
-        let tensor = Tensor::<TestBackend, 1, Int>::arange_step_device(0..2, 5, &device);
+        let tensor = Tensor::<TestBackend, 1, Int>::arange_step(0..2, 5, &device);
         assert_eq!(tensor.clone().into_data(), Data::from([0]));
         assert_eq!(tensor.device(), device);
     }
@@ -40,7 +40,8 @@ mod tests {
     #[test]
     #[should_panic]
     fn should_panic_when_step_is_zero() {
+        let device = <TestBackend as Backend>::Device::default();
         // Test that arange_step panics when the step is 0
-        let _tensor = Tensor::<TestBackend, 1, Int>::arange_step(0..3, 0);
+        let _tensor = Tensor::<TestBackend, 1, Int>::arange_step(0..3, 0, &device);
     }
 }

--- a/burn-tensor/src/tests/ops/arg.rs
+++ b/burn-tensor/src/tests/ops/arg.rs
@@ -6,7 +6,7 @@ mod tests {
     #[test]
     fn test_argmax_2d_dim0() {
         let data = Data::from([[10.0, 11.0, 2.0], [3.0, 4.0, 5.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = tensor.argmax(0);
 
@@ -17,7 +17,7 @@ mod tests {
     #[test]
     fn test_argmin_2d_dim0() {
         let data = Data::from([[10.0, 11.0, 2.0], [30.0, 4.0, 5.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = tensor.argmin(0);
 
@@ -28,7 +28,7 @@ mod tests {
     #[test]
     fn test_argmax_2d_dim0_int() {
         let data = Data::from([[10, 11, 2], [3, 4, 5]]);
-        let tensor = Tensor::<TestBackend, 2, Int>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2, Int>::from_data_default(data);
 
         let data_actual = tensor.argmax(0);
 
@@ -39,7 +39,7 @@ mod tests {
     #[test]
     fn test_argmin_2d_dim0_int() {
         let data = Data::from([[10, 11, 2], [30, 4, 5]]);
-        let tensor = Tensor::<TestBackend, 2, Int>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2, Int>::from_data_default(data);
 
         let data_actual = tensor.argmin(0);
 
@@ -50,7 +50,7 @@ mod tests {
     #[test]
     fn test_argmax_2d_dim1() {
         let data = Data::from([[10.0, 11.0, 2.0], [3.0, 4.0, 5.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = tensor.argmax(1);
 
@@ -61,7 +61,7 @@ mod tests {
     #[test]
     fn test_argmin_2d_dim1() {
         let data = Data::from([[10.0, 11.0, 2.0], [30.0, 4.0, 5.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = tensor.argmin(1);
 

--- a/burn-tensor/src/tests/ops/cast.rs
+++ b/burn-tensor/src/tests/ops/cast.rs
@@ -5,7 +5,7 @@ mod tests {
 
     #[test]
     fn cast_float_to_int() {
-        let tensor = Tensor::<TestBackend, 2>::from_data([[1.0, 2.0, 3.0], [4.4, 5.5, 6.6]]);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default([[1.0, 2.0, 3.0], [4.4, 5.5, 6.6]]);
 
         let actual = tensor.int().into_data();
         let expected = Data::from([[1, 2, 3], [4, 5, 6]]);
@@ -14,7 +14,7 @@ mod tests {
 
     #[test]
     fn cast_int_to_float_tensor() {
-        let tensor = Tensor::<TestBackend, 2, Int>::from_data([[1, 2, 3], [4, 5, 6]]);
+        let tensor = Tensor::<TestBackend, 2, Int>::from_data_default([[1, 2, 3], [4, 5, 6]]);
 
         let actual = tensor.float().into_data();
         let expected = Data::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
@@ -24,7 +24,7 @@ mod tests {
     #[test]
     fn cast_bool_to_int_tensor() {
         let tensor =
-            Tensor::<TestBackend, 2, Bool>::from_data([[true, false, true], [false, false, true]]);
+            Tensor::<TestBackend, 2, Bool>::from_data_default([[true, false, true], [false, false, true]]);
 
         let actual = tensor.int().into_data();
         let expected = Data::from([[1, 0, 1], [0, 0, 1]]);
@@ -34,7 +34,7 @@ mod tests {
     #[test]
     fn cast_bool_to_float_tensor() {
         let tensor =
-            Tensor::<TestBackend, 2, Bool>::from_data([[true, false, true], [false, false, true]]);
+            Tensor::<TestBackend, 2, Bool>::from_data_default([[true, false, true], [false, false, true]]);
 
         let actual = tensor.float().into_data();
         let expected = Data::from([[1., 0., 1.], [0., 0., 1.]]);

--- a/burn-tensor/src/tests/ops/cast.rs
+++ b/burn-tensor/src/tests/ops/cast.rs
@@ -5,7 +5,8 @@ mod tests {
 
     #[test]
     fn cast_float_to_int() {
-        let tensor = Tensor::<TestBackend, 2>::from_data_default([[1.0, 2.0, 3.0], [4.4, 5.5, 6.6]]);
+        let tensor =
+            Tensor::<TestBackend, 2>::from_data_default([[1.0, 2.0, 3.0], [4.4, 5.5, 6.6]]);
 
         let actual = tensor.int().into_data();
         let expected = Data::from([[1, 2, 3], [4, 5, 6]]);
@@ -23,8 +24,10 @@ mod tests {
 
     #[test]
     fn cast_bool_to_int_tensor() {
-        let tensor =
-            Tensor::<TestBackend, 2, Bool>::from_data_default([[true, false, true], [false, false, true]]);
+        let tensor = Tensor::<TestBackend, 2, Bool>::from_data_default([
+            [true, false, true],
+            [false, false, true],
+        ]);
 
         let actual = tensor.int().into_data();
         let expected = Data::from([[1, 0, 1], [0, 0, 1]]);
@@ -33,8 +36,10 @@ mod tests {
 
     #[test]
     fn cast_bool_to_float_tensor() {
-        let tensor =
-            Tensor::<TestBackend, 2, Bool>::from_data_default([[true, false, true], [false, false, true]]);
+        let tensor = Tensor::<TestBackend, 2, Bool>::from_data_default([
+            [true, false, true],
+            [false, false, true],
+        ]);
 
         let actual = tensor.float().into_data();
         let expected = Data::from([[1., 0., 1.], [0., 0., 1.]]);

--- a/burn-tensor/src/tests/ops/cat.rs
+++ b/burn-tensor/src/tests/ops/cat.rs
@@ -5,8 +5,8 @@ mod tests {
     use burn_tensor::{Bool, Data, Int, Tensor};
     #[test]
     fn should_support_cat_ops_2d_dim0() {
-        let tensor_1 = TestTensor::from_data([[1.0, 2.0, 3.0]]);
-        let tensor_2 = TestTensor::from_data([[4.0, 5.0, 6.0]]);
+        let tensor_1 = TestTensor::from_data_default([[1.0, 2.0, 3.0]]);
+        let tensor_2 = TestTensor::from_data_default([[4.0, 5.0, 6.0]]);
 
         let data_actual = TestTensor::cat(vec![tensor_1, tensor_2], 0).into_data();
 
@@ -16,8 +16,8 @@ mod tests {
 
     #[test]
     fn should_support_cat_ops_int() {
-        let tensor_1 = Tensor::<TestBackend, 2, Int>::from_data([[1, 2, 3]]);
-        let tensor_2 = Tensor::<TestBackend, 2, Int>::from_data([[4, 5, 6]]);
+        let tensor_1 = Tensor::<TestBackend, 2, Int>::from_data_default([[1, 2, 3]]);
+        let tensor_2 = Tensor::<TestBackend, 2, Int>::from_data_default([[4, 5, 6]]);
 
         let data_actual = Tensor::cat(vec![tensor_1, tensor_2], 0).into_data();
 
@@ -27,8 +27,8 @@ mod tests {
 
     #[test]
     fn should_support_cat_ops_bool() {
-        let tensor_1 = Tensor::<TestBackend, 2, Bool>::from_data([[false, true, true]]);
-        let tensor_2 = Tensor::<TestBackend, 2, Bool>::from_data([[true, true, false]]);
+        let tensor_1 = Tensor::<TestBackend, 2, Bool>::from_data_default([[false, true, true]]);
+        let tensor_2 = Tensor::<TestBackend, 2, Bool>::from_data_default([[true, true, false]]);
 
         let data_actual = Tensor::cat(vec![tensor_1, tensor_2], 0).into_data();
 
@@ -38,8 +38,8 @@ mod tests {
 
     #[test]
     fn should_support_cat_ops_2d_dim1() {
-        let tensor_1 = TestTensor::from_data([[1.0, 2.0, 3.0]]);
-        let tensor_2 = TestTensor::from_data([[4.0, 5.0, 6.0]]);
+        let tensor_1 = TestTensor::from_data_default([[1.0, 2.0, 3.0]]);
+        let tensor_2 = TestTensor::from_data_default([[4.0, 5.0, 6.0]]);
 
         let data_actual = TestTensor::cat(vec![tensor_1, tensor_2], 1).into_data();
 
@@ -49,8 +49,8 @@ mod tests {
 
     #[test]
     fn should_support_cat_ops_3d() {
-        let tensor_1 = TestTensor::from_data([[[1.0, 2.0, 3.0]], [[1.1, 2.1, 3.1]]]);
-        let tensor_2 = TestTensor::from_data([[[4.0, 5.0, 6.0]]]);
+        let tensor_1 = TestTensor::from_data_default([[[1.0, 2.0, 3.0]], [[1.1, 2.1, 3.1]]]);
+        let tensor_2 = TestTensor::from_data_default([[[4.0, 5.0, 6.0]]]);
 
         let data_actual = TestTensor::cat(vec![tensor_1, tensor_2], 0).into_data();
 
@@ -61,8 +61,8 @@ mod tests {
     #[test]
     #[should_panic]
     fn should_panic_when_dimensions_are_not_the_same() {
-        let tensor_1 = TestTensor::from_data([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]]);
-        let tensor_2 = TestTensor::from_data([[4.0, 5.0]]);
+        let tensor_1 = TestTensor::from_data_default([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]]);
+        let tensor_2 = TestTensor::from_data_default([[4.0, 5.0]]);
 
         TestTensor::cat(vec![tensor_1, tensor_2], 0).into_data();
     }
@@ -77,8 +77,8 @@ mod tests {
     #[test]
     #[should_panic]
     fn should_panic_when_cat_exceeds_dimension() {
-        let tensor_1 = TestTensor::from_data([[[1.0, 2.0, 3.0]], [[1.1, 2.1, 3.1]]]);
-        let tensor_2 = TestTensor::from_data([[[4.0, 5.0, 6.0]]]);
+        let tensor_1 = TestTensor::from_data_default([[[1.0, 2.0, 3.0]], [[1.1, 2.1, 3.1]]]);
+        let tensor_2 = TestTensor::from_data_default([[[4.0, 5.0, 6.0]]]);
 
         TestTensor::cat(vec![tensor_1, tensor_2], 3).into_data();
     }

--- a/burn-tensor/src/tests/ops/clamp.rs
+++ b/burn-tensor/src/tests/ops/clamp.rs
@@ -7,7 +7,7 @@ mod tests {
     fn clamp_min() {
         // test float tensor
         let data = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = tensor.clamp_min(2.0).into_data();
 
@@ -16,7 +16,7 @@ mod tests {
 
         // test int tensor
         let data = Data::from([[0, 1, 2], [3, 4, 5]]);
-        let tensor = Tensor::<TestBackend, 2, Int>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2, Int>::from_data_default(data);
         let data_actual = tensor.clamp_min(2).into_data();
         let data_expected = Data::from([[2, 2, 2], [3, 4, 5]]);
         assert_eq!(data_expected, data_actual);
@@ -26,7 +26,7 @@ mod tests {
     fn clamp_max() {
         // test float tensor
         let data = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = tensor.clamp_max(2.0).into_data();
 
@@ -35,7 +35,7 @@ mod tests {
 
         // test int tensor
         let data = Data::from([[0, 1, 2], [3, 4, 5]]);
-        let tensor = Tensor::<TestBackend, 2, Int>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2, Int>::from_data_default(data);
         let data_actual = tensor.clamp_max(4).into_data();
         let data_expected = Data::from([[0, 1, 2], [3, 4, 4]]);
         assert_eq!(data_expected, data_actual);
@@ -45,14 +45,14 @@ mod tests {
     fn clamp_min_max() {
         // test float tensor
         let data = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
         let data_actual = tensor.clamp(1.0, 4.0).into_data();
         let data_expected = Data::from([[1.0, 1.0, 2.0], [3.0, 4.0, 4.0]]);
         assert_eq!(data_expected, data_actual);
 
         // test int tensor
         let data = Data::from([[0, 1, 2], [3, 4, 5]]);
-        let tensor = Tensor::<TestBackend, 2, Int>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2, Int>::from_data_default(data);
         let data_actual = tensor.clamp(1, 4).into_data();
         let data_expected = Data::from([[1, 1, 2], [3, 4, 4]]);
         assert_eq!(data_expected, data_actual);

--- a/burn-tensor/src/tests/ops/cos.rs
+++ b/burn-tensor/src/tests/ops/cos.rs
@@ -6,7 +6,7 @@ mod tests {
     #[test]
     fn should_support_cos_ops() {
         let data = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = tensor.cos().into_data();
 

--- a/burn-tensor/src/tests/ops/create_like.rs
+++ b/burn-tensor/src/tests/ops/create_like.rs
@@ -5,7 +5,7 @@ mod tests {
 
     #[test]
     fn should_support_zeros_like() {
-        let tensor = TestTensor::from_floats([
+        let tensor = TestTensor::from_floats_default([
             [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]],
             [[6.0, 7.0, 8.0], [9.0, 10.0, 11.0]],
         ]);
@@ -20,7 +20,7 @@ mod tests {
 
     #[test]
     fn should_support_ones_like() {
-        let tensor = TestTensor::from_floats([
+        let tensor = TestTensor::from_floats_default([
             [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]],
             [[6.0, 7.0, 8.0], [9.0, 10.0, 11.0]],
         ]);
@@ -35,7 +35,7 @@ mod tests {
 
     #[test]
     fn should_support_randoms_like() {
-        let tensor = TestTensor::from_floats([
+        let tensor = TestTensor::from_floats_default([
             [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]],
             [[6.0, 7.0, 8.0], [9.0, 10.0, 11.0]],
         ]);

--- a/burn-tensor/src/tests/ops/div.rs
+++ b/burn-tensor/src/tests/ops/div.rs
@@ -7,8 +7,8 @@ mod tests {
     fn should_support_div_ops() {
         let data_1 = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
         let data_2 = Data::from([[1.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let tensor_1 = Tensor::<TestBackend, 2>::from_data(data_1);
-        let tensor_2 = Tensor::<TestBackend, 2>::from_data(data_2);
+        let tensor_1 = Tensor::<TestBackend, 2>::from_data_default(data_1);
+        let tensor_2 = Tensor::<TestBackend, 2>::from_data_default(data_2);
 
         let output = tensor_1 / tensor_2;
 
@@ -21,8 +21,8 @@ mod tests {
     fn test_div_broadcast() {
         let data_1 = Data::from([[0.0, 1.0, 2.0]]);
         let data_2 = Data::from([[1.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let tensor_1 = Tensor::<TestBackend, 2>::from_data(data_1);
-        let tensor_2 = Tensor::<TestBackend, 2>::from_data(data_2);
+        let tensor_1 = Tensor::<TestBackend, 2>::from_data_default(data_1);
+        let tensor_2 = Tensor::<TestBackend, 2>::from_data_default(data_2);
 
         let data_actual = (tensor_1 / tensor_2).into_data();
 
@@ -34,7 +34,7 @@ mod tests {
     fn should_support_div_scalar_ops() {
         let data = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
         let scalar = 2.0;
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let output = tensor / scalar;
 
@@ -47,8 +47,8 @@ mod tests {
     fn should_support_div_ops_int() {
         let data_1 = Data::from([[0, 1, 2], [3, 4, 5]]);
         let data_2 = Data::from([[1, 1, 2], [1, 1, 2]]);
-        let tensor_1 = Tensor::<TestBackend, 2, Int>::from_data(data_1);
-        let tensor_2 = Tensor::<TestBackend, 2, Int>::from_data(data_2);
+        let tensor_1 = Tensor::<TestBackend, 2, Int>::from_data_default(data_1);
+        let tensor_2 = Tensor::<TestBackend, 2, Int>::from_data_default(data_2);
 
         let output = tensor_1 / tensor_2;
 
@@ -61,8 +61,8 @@ mod tests {
     fn test_div_broadcast_int() {
         let data_1 = Data::from([[0, 1, 2]]);
         let data_2 = Data::from([[1, 1, 2], [3, 4, 5]]);
-        let tensor_1 = Tensor::<TestBackend, 2, Int>::from_data(data_1);
-        let tensor_2 = Tensor::<TestBackend, 2, Int>::from_data(data_2);
+        let tensor_1 = Tensor::<TestBackend, 2, Int>::from_data_default(data_1);
+        let tensor_2 = Tensor::<TestBackend, 2, Int>::from_data_default(data_2);
 
         let data_actual = (tensor_1 / tensor_2).into_data();
 
@@ -74,7 +74,7 @@ mod tests {
     fn should_support_div_scalar_ops_int() {
         let data = Data::from([[0, 1, 2], [3, 4, 5]]);
         let scalar = 2;
-        let tensor = Tensor::<TestBackend, 2, Int>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2, Int>::from_data_default(data);
 
         let output = tensor / scalar;
 

--- a/burn-tensor/src/tests/ops/erf.rs
+++ b/burn-tensor/src/tests/ops/erf.rs
@@ -6,7 +6,7 @@ mod tests {
     #[test]
     fn should_support_erf_ops() {
         let data = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = tensor.erf().into_data();
 
@@ -17,7 +17,7 @@ mod tests {
     #[test]
     fn should_support_erf_ops_with_negative_number() {
         let data = Data::from([[-0.056, -0.043, -0.089], [3.0, 4.0, 5.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = tensor.erf().into_data();
 

--- a/burn-tensor/src/tests/ops/exp.rs
+++ b/burn-tensor/src/tests/ops/exp.rs
@@ -6,7 +6,7 @@ mod tests {
     #[test]
     fn should_support_exp_ops() {
         let data = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = tensor.exp().into_data();
 

--- a/burn-tensor/src/tests/ops/flatten.rs
+++ b/burn-tensor/src/tests/ops/flatten.rs
@@ -6,7 +6,7 @@ mod tests {
     /// Test if the function can successfully flatten a 4D tensor to a 1D tensor.
     #[test]
     fn should_flatten_to_1d() {
-        let tensor = Tensor::<TestBackend, 4>::ones(Shape::new([2, 3, 4, 5]));
+        let tensor = Tensor::<TestBackend, 4>::ones_default(Shape::new([2, 3, 4, 5]));
         let flattened_tensor: Tensor<TestBackend, 1> = tensor.flatten(0, 3);
         let expected_shape = Shape::new([120]);
         assert_eq!(flattened_tensor.shape(), expected_shape);
@@ -15,7 +15,7 @@ mod tests {
     /// Test if the function can successfully flatten the middle dimensions of a 4D tensor.
     #[test]
     fn should_flatten_middle() {
-        let tensor = Tensor::<TestBackend, 4>::ones(Shape::new([2, 3, 4, 5]));
+        let tensor = Tensor::<TestBackend, 4>::ones_default(Shape::new([2, 3, 4, 5]));
         let flattened_tensor: Tensor<TestBackend, 3> = tensor.flatten(1, 2);
         let expected_shape = Shape::new([2, 12, 5]);
         assert_eq!(flattened_tensor.shape(), expected_shape);
@@ -24,7 +24,7 @@ mod tests {
     /// Test if the function can successfully flatten the first dimensions of a 4D tensor.
     #[test]
     fn should_flatten_begin() {
-        let tensor = Tensor::<TestBackend, 4>::ones(Shape::new([2, 3, 4, 5]));
+        let tensor = Tensor::<TestBackend, 4>::ones_default(Shape::new([2, 3, 4, 5]));
         let flattened_tensor: Tensor<TestBackend, 2> = tensor.flatten(0, 2);
         let expected_shape = Shape::new([24, 5]);
         assert_eq!(flattened_tensor.shape(), expected_shape);
@@ -33,7 +33,7 @@ mod tests {
     /// Test if the function can successfully flatten the last dimensions of a 4D tensor.
     #[test]
     fn should_flatten_end() {
-        let tensor = Tensor::<TestBackend, 4>::ones(Shape::new([2, 3, 4, 5]));
+        let tensor = Tensor::<TestBackend, 4>::ones_default(Shape::new([2, 3, 4, 5]));
         let flattened_tensor: Tensor<TestBackend, 2> = tensor.flatten(1, 3);
         let expected_shape = Shape::new([2, 60]);
         assert_eq!(flattened_tensor.shape(), expected_shape);
@@ -43,14 +43,14 @@ mod tests {
     #[test]
     #[should_panic]
     fn should_flatten_panic() {
-        let tensor = Tensor::<TestBackend, 4>::ones(Shape::new([2, 3, 4, 5]));
+        let tensor = Tensor::<TestBackend, 4>::ones_default(Shape::new([2, 3, 4, 5]));
         let flattened_tensor: Tensor<TestBackend, 2> = tensor.flatten(2, 0);
     }
 
     #[test]
     #[should_panic]
     fn not_enough_destination_dimension() {
-        let tensor = Tensor::<TestBackend, 3>::ones(Shape::new([1, 5, 15]));
+        let tensor = Tensor::<TestBackend, 3>::ones_default(Shape::new([1, 5, 15]));
         let flattened_tensor: Tensor<TestBackend, 1> = tensor.flatten(1, 2);
         let expected_shape = Shape::new([75]);
         assert_eq!(flattened_tensor.shape(), expected_shape);

--- a/burn-tensor/src/tests/ops/full.rs
+++ b/burn-tensor/src/tests/ops/full.rs
@@ -13,12 +13,12 @@ mod tests {
     #[test]
     fn test_tensor_full() {
         // Test full with f32
-        let tensor = Tensor::<TestBackend, 2>::full([2, 3], 2.1);
+        let tensor = Tensor::<TestBackend, 2>::full_default([2, 3], 2.1);
         let data_expected = Data::from([[2.1, 2.1, 2.1], [2.1, 2.1, 2.1]]);
         assert_eq!(data_expected, tensor.into_data());
 
         // Test full with Int
-        let int_tensor = Tensor::<TestBackend, 2, Int>::full([2, 2], 2);
+        let int_tensor = Tensor::<TestBackend, 2, Int>::full_default([2, 2], 2);
         let data_expected = Data::from([[2, 2], [2, 2]]);
         assert_eq!(data_expected, int_tensor.into_data());
     }

--- a/burn-tensor/src/tests/ops/gather_scatter.rs
+++ b/burn-tensor/src/tests/ops/gather_scatter.rs
@@ -5,8 +5,8 @@ mod tests {
 
     #[test]
     fn should_gather_1d_dim0() {
-        let tensor = TestTensor::from_floats([0.0, 1.0, 2.0]);
-        let indices = TestTensorInt::from_ints([1, 1, 0, 1, 2]);
+        let tensor = TestTensor::from_floats_default([0.0, 1.0, 2.0]);
+        let indices = TestTensorInt::from_ints_default([1, 1, 0, 1, 2]);
 
         let output = tensor.gather(0, indices);
 
@@ -15,8 +15,8 @@ mod tests {
 
     #[test]
     fn should_gather_1d_dim0_int() {
-        let tensor = TestTensorInt::from_ints([5, 6, 7]);
-        let indices = TestTensorInt::from_ints([1, 1, 0, 1, 2]);
+        let tensor = TestTensorInt::from_ints_default([5, 6, 7]);
+        let indices = TestTensorInt::from_ints_default([1, 1, 0, 1, 2]);
 
         let output = tensor.gather(0, indices);
 
@@ -25,8 +25,8 @@ mod tests {
 
     #[test]
     fn should_gather_2d_dim0() {
-        let tensor = TestTensor::from_floats([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let indices = TestTensorInt::from_ints([[0, 1, 0], [1, 0, 1]]);
+        let tensor = TestTensor::from_floats_default([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let indices = TestTensorInt::from_ints_default([[0, 1, 0], [1, 0, 1]]);
 
         let output = tensor.gather(0, indices);
 
@@ -38,8 +38,8 @@ mod tests {
 
     #[test]
     fn should_gather_2d_dim1() {
-        let tensor = TestTensor::from_floats([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let indices = TestTensorInt::from_ints([[2, 1, 0, 0], [2, 0, 1, 2]]);
+        let tensor = TestTensor::from_floats_default([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let indices = TestTensorInt::from_ints_default([[2, 1, 0, 0], [2, 0, 1, 2]]);
 
         let output = tensor.gather(1, indices);
 
@@ -51,11 +51,12 @@ mod tests {
 
     #[test]
     fn should_gather_3d_dim1() {
-        let tensor = TestTensor::from_floats([
+        let tensor = TestTensor::from_floats_default([
             [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]],
             [[6.0, 7.0, 8.0], [9.0, 10.0, 11.0]],
         ]);
-        let indices = TestTensorInt::from_ints([[[1, 0, 0], [0, 1, 0]], [[0, 0, 1], [0, 1, 1]]]);
+        let indices =
+            TestTensorInt::from_ints_default([[[1, 0, 0], [0, 1, 0]], [[0, 0, 1], [0, 1, 1]]]);
 
         let output = tensor.gather(1, indices);
 
@@ -70,8 +71,8 @@ mod tests {
 
     #[test]
     fn should_gather_2d_only_1dim() {
-        let tensor = TestTensor::from_floats([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let indices = TestTensorInt::from_ints([[1, 2]]).reshape([2, 1]);
+        let tensor = TestTensor::from_floats_default([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let indices = TestTensorInt::from_ints_default([[1, 2]]).reshape([2, 1]);
 
         let output = tensor.gather(1, indices);
 
@@ -80,9 +81,9 @@ mod tests {
 
     #[test]
     fn should_scatter_1d() {
-        let tensor = TestTensor::from_floats([0.0, 0.0, 0.0]);
-        let values = TestTensor::from_floats([5.0, 4.0, 3.0]);
-        let indices = TestTensorInt::from_ints([1, 0, 2]);
+        let tensor = TestTensor::from_floats_default([0.0, 0.0, 0.0]);
+        let values = TestTensor::from_floats_default([5.0, 4.0, 3.0]);
+        let indices = TestTensorInt::from_ints_default([1, 0, 2]);
 
         let output = tensor.scatter(0, indices, values);
 
@@ -91,9 +92,9 @@ mod tests {
 
     #[test]
     fn should_scatter_1d_int() {
-        let tensor = TestTensorInt::from_ints([0, 0, 0]);
-        let values = TestTensorInt::from_ints([5, 4, 3]);
-        let indices = TestTensorInt::from_ints([1, 0, 2]);
+        let tensor = TestTensorInt::from_ints_default([0, 0, 0]);
+        let values = TestTensorInt::from_ints_default([5, 4, 3]);
+        let indices = TestTensorInt::from_ints_default([1, 0, 2]);
 
         let output = tensor.scatter(0, indices, values);
 
@@ -102,9 +103,9 @@ mod tests {
 
     #[test]
     fn should_scatter_2d_dim0() {
-        let tensor = TestTensor::from_floats([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]);
-        let values = TestTensor::from_floats([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
-        let indices = TestTensorInt::from_ints([[1, 0, 1], [1, 1, 0]]);
+        let tensor = TestTensor::from_floats_default([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]);
+        let values = TestTensor::from_floats_default([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+        let indices = TestTensorInt::from_ints_default([[1, 0, 1], [1, 1, 0]]);
 
         let output = tensor.scatter(0, indices, values);
 
@@ -116,9 +117,9 @@ mod tests {
 
     #[test]
     fn should_scatter_2d_dim1() {
-        let tensor = TestTensor::from_floats([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]);
-        let values = TestTensor::from_floats([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
-        let indices = TestTensorInt::from_ints([[1, 0, 2], [1, 2, 0]]);
+        let tensor = TestTensor::from_floats_default([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]);
+        let values = TestTensor::from_floats_default([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+        let indices = TestTensorInt::from_ints_default([[1, 0, 2], [1, 2, 0]]);
 
         let output = tensor.scatter(1, indices, values);
 
@@ -130,15 +131,16 @@ mod tests {
 
     #[test]
     fn should_scatter_3d_dim1() {
-        let tensor = TestTensor::from_floats([
+        let tensor = TestTensor::from_floats_default([
             [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]],
             [[6.0, 7.0, 8.0], [9.0, 10.0, 11.0]],
         ]);
-        let values = TestTensor::from_floats([
+        let values = TestTensor::from_floats_default([
             [[12.0, 13.0, 14.0], [15.0, 16.0, 17.0]],
             [[18.0, 19.0, 20.0], [21.0, 22.0, 23.0]],
         ]);
-        let indices = TestTensorInt::from_ints([[[1, 0, 0], [0, 1, 0]], [[0, 0, 1], [0, 1, 1]]]);
+        let indices =
+            TestTensorInt::from_ints_default([[[1, 0, 0], [0, 1, 0]], [[0, 0, 1], [0, 1, 1]]]);
 
         let output = tensor.scatter(1, indices, values);
 
@@ -153,9 +155,9 @@ mod tests {
 
     #[test]
     fn should_scatter_2d_dim1_diff_shape() {
-        let tensor = TestTensor::from_floats([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]);
-        let values = TestTensor::from_floats([[1.0], [4.0]]);
-        let indices = TestTensorInt::from_ints([[1], [2]]);
+        let tensor = TestTensor::from_floats_default([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]);
+        let values = TestTensor::from_floats_default([[1.0], [4.0]]);
+        let indices = TestTensorInt::from_ints_default([[1], [2]]);
 
         let output = tensor.scatter(1, indices, values);
 
@@ -168,9 +170,9 @@ mod tests {
     #[test]
     #[should_panic]
     fn scatter_should_panic_on_mismatch_of_shapes() {
-        let tensor = TestTensor::from_floats([0.0, 0.0, 0.0]);
-        let values = TestTensor::from_floats([5.0, 4.0]);
-        let indices = TestTensorInt::from_ints([1, 0, 2]);
+        let tensor = TestTensor::from_floats_default([0.0, 0.0, 0.0]);
+        let values = TestTensor::from_floats_default([5.0, 4.0]);
+        let indices = TestTensorInt::from_ints_default([1, 0, 2]);
 
         tensor.scatter(0, indices, values);
     }

--- a/burn-tensor/src/tests/ops/init.rs
+++ b/burn-tensor/src/tests/ops/init.rs
@@ -6,21 +6,21 @@ mod tests {
     #[test]
     fn should_support_float_empty() {
         let shape = [2, 2];
-        let tensor = Tensor::<TestBackend, 2>::empty(shape);
+        let tensor = Tensor::<TestBackend, 2>::empty_default(shape);
         assert_eq!(tensor.shape(), shape.into())
     }
 
     #[test]
     fn should_support_int_empty() {
         let shape = [2, 2];
-        let tensor = Tensor::<TestBackend, 2, Int>::empty(shape);
+        let tensor = Tensor::<TestBackend, 2, Int>::empty_default(shape);
         assert_eq!(tensor.shape(), shape.into())
     }
 
     #[test]
     fn should_support_float_zeros() {
         let shape = [2, 2];
-        let tensor = Tensor::<TestBackend, 2>::zeros(shape);
+        let tensor = Tensor::<TestBackend, 2>::zeros_default(shape);
         assert_eq!(tensor.shape(), shape.into());
         assert_eq!(tensor.to_data(), Data::from([[0., 0.], [0., 0.]]))
     }
@@ -28,7 +28,7 @@ mod tests {
     #[test]
     fn should_support_int_zeros() {
         let shape = [2, 2];
-        let tensor = Tensor::<TestBackend, 2, Int>::zeros(shape);
+        let tensor = Tensor::<TestBackend, 2, Int>::zeros_default(shape);
         assert_eq!(tensor.shape(), shape.into());
         assert_eq!(tensor.to_data(), Data::from([[0, 0], [0, 0]]))
     }
@@ -36,7 +36,7 @@ mod tests {
     #[test]
     fn should_support_float_ones() {
         let shape = [2, 2];
-        let tensor = Tensor::<TestBackend, 2>::ones(shape);
+        let tensor = Tensor::<TestBackend, 2>::ones_default(shape);
         assert_eq!(tensor.shape(), shape.into());
         assert_eq!(tensor.to_data(), Data::from([[1., 1.], [1., 1.]]))
     }
@@ -44,7 +44,7 @@ mod tests {
     #[test]
     fn should_support_int_ones() {
         let shape = [2, 2];
-        let tensor = Tensor::<TestBackend, 2, Int>::ones(shape);
+        let tensor = Tensor::<TestBackend, 2, Int>::ones_default(shape);
         assert_eq!(tensor.shape(), shape.into());
         assert_eq!(tensor.to_data(), Data::from([[1, 1], [1, 1]]))
     }
@@ -52,7 +52,7 @@ mod tests {
     #[test]
     fn should_support_bool_empty() {
         let shape = [2, 2];
-        let tensor = Tensor::<TestBackend, 2, Bool>::empty(shape);
+        let tensor = Tensor::<TestBackend, 2, Bool>::empty_default(shape);
         assert_eq!(tensor.shape(), shape.into())
     }
 }

--- a/burn-tensor/src/tests/ops/iter_dim.rs
+++ b/burn-tensor/src/tests/ops/iter_dim.rs
@@ -6,9 +6,9 @@ mod test {
     #[test]
     fn test_1d_iter_last_item() {
         let data = [1, 2, 3, 4];
-        let tensor = Tensor::<TestBackend, 1, Int>::from_ints(data);
+        let tensor = Tensor::<TestBackend, 1, Int>::from_ints_default(data);
         assert_eq!(
-            Tensor::<TestBackend, 1, Int>::from_ints([4]).into_data(),
+            Tensor::<TestBackend, 1, Int>::from_ints_default([4]).into_data(),
             tensor.iter_dim(0).last().unwrap().into_data()
         )
     }
@@ -16,7 +16,7 @@ mod test {
     #[test]
     #[should_panic]
     fn test_too_high_dimension() {
-        Tensor::<TestBackend, 1>::zeros([10]).iter_dim(1);
+        Tensor::<TestBackend, 1>::zeros_default([10]).iter_dim(1);
     }
 
     #[test]
@@ -26,7 +26,7 @@ mod test {
             [4., 5., 6., 1., 2.],
             [7., 8., 9., 1., 2.],
         ];
-        let tensor = Tensor::<TestBackend, 2>::from_floats(data);
+        let tensor = Tensor::<TestBackend, 2>::from_floats_default(data);
         let lhs = tensor.clone().slice([1..2, 0..5]);
         let rhs = tensor.transpose().iter_dim(1).nth(1).unwrap();
         assert_eq!(lhs.into_data().value, rhs.into_data().value);
@@ -38,7 +38,7 @@ mod test {
             [4., 5., 6., 1., 2.],
             [7., 8., 9., 1., 2.],
         ]; 5];
-        let tensor = Tensor::<TestBackend, 3>::from_floats(data);
+        let tensor = Tensor::<TestBackend, 3>::from_floats_default(data);
         let lhs = tensor.iter_dim(2).nth(1).unwrap();
         let rhs = Data::from([2., 5., 8.]);
         assert_eq!(lhs.into_data().value, rhs.value);

--- a/burn-tensor/src/tests/ops/log.rs
+++ b/burn-tensor/src/tests/ops/log.rs
@@ -6,7 +6,7 @@ mod tests {
     #[test]
     fn should_support_log_ops() {
         let data = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = tensor.log().into_data();
 

--- a/burn-tensor/src/tests/ops/log1p.rs
+++ b/burn-tensor/src/tests/ops/log1p.rs
@@ -6,7 +6,7 @@ mod tests {
     #[test]
     fn should_support_exp_log1p() {
         let data = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = tensor.log1p().into_data();
 

--- a/burn-tensor/src/tests/ops/map_comparison.rs
+++ b/burn-tensor/src/tests/ops/map_comparison.rs
@@ -115,8 +115,8 @@ mod tests {
     {
         let data_1 = Data::<f32, 2>::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]).convert();
         let data_2 = Data::<f32, 2>::from([[1.0, 1.0, 1.0], [4.0, 3.0, 5.0]]).convert();
-        let tensor_1 = Tensor::<TestBackend, 2, K>::from_data(data_1);
-        let tensor_2 = Tensor::<TestBackend, 2, K>::from_data(data_2);
+        let tensor_1 = Tensor::<TestBackend, 2, K>::from_data_default(data_1);
+        let tensor_2 = Tensor::<TestBackend, 2, K>::from_data_default(data_2);
 
         let data_actual_cloned = tensor_1.clone().equal(tensor_2.clone());
         let data_actual_inplace = tensor_1.equal(tensor_2);
@@ -132,7 +132,7 @@ mod tests {
         E: Element,
     {
         let data_1 = Data::<f32, 2>::from([[0.0, 1.0, 2.0], [3.0, 2.0, 5.0]]).convert();
-        let tensor_1 = Tensor::<TestBackend, 2, K>::from_data(data_1);
+        let tensor_1 = Tensor::<TestBackend, 2, K>::from_data_default(data_1);
 
         let data_actual_cloned = tensor_1.clone().equal_elem(2);
         let data_actual_inplace = tensor_1.equal_elem(2);
@@ -148,7 +148,7 @@ mod tests {
         E: Element,
     {
         let data_1 = Data::<f32, 2>::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]).convert();
-        let tensor_1 = Tensor::<TestBackend, 2, K>::from_data(data_1);
+        let tensor_1 = Tensor::<TestBackend, 2, K>::from_data_default(data_1);
 
         let data_actual_cloned = tensor_1.clone().greater_elem(4);
         let data_actual_inplace = tensor_1.greater_elem(4);
@@ -164,7 +164,7 @@ mod tests {
         E: Element,
     {
         let data_1 = Data::<f32, 2>::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]).convert();
-        let tensor_1 = Tensor::<TestBackend, 2, K>::from_data(data_1);
+        let tensor_1 = Tensor::<TestBackend, 2, K>::from_data_default(data_1);
 
         let data_actual_cloned = tensor_1.clone().greater_equal_elem(4.0);
         let data_actual_inplace = tensor_1.greater_equal_elem(4.0);
@@ -181,8 +181,8 @@ mod tests {
     {
         let data_1 = Data::<f32, 2>::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]).convert();
         let data_2 = Data::<f32, 2>::from([[1.0, 1.0, 1.0], [4.0, 3.0, 50.0]]).convert();
-        let tensor_1 = Tensor::<TestBackend, 2, K>::from_data(data_1);
-        let tensor_2 = Tensor::<TestBackend, 2, K>::from_data(data_2);
+        let tensor_1 = Tensor::<TestBackend, 2, K>::from_data_default(data_1);
+        let tensor_2 = Tensor::<TestBackend, 2, K>::from_data_default(data_2);
 
         let data_actual_cloned = tensor_1.clone().greater(tensor_2.clone());
         let data_actual_inplace = tensor_1.greater(tensor_2);
@@ -199,8 +199,8 @@ mod tests {
     {
         let data_1 = Data::<f32, 2>::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]).convert();
         let data_2 = Data::<f32, 2>::from([[1.0, 1.0, 1.0], [4.0, 3.0, 50.0]]).convert();
-        let tensor_1 = Tensor::<TestBackend, 2, K>::from_data(data_1);
-        let tensor_2 = Tensor::<TestBackend, 2, K>::from_data(data_2);
+        let tensor_1 = Tensor::<TestBackend, 2, K>::from_data_default(data_1);
+        let tensor_2 = Tensor::<TestBackend, 2, K>::from_data_default(data_2);
 
         let data_actual_cloned = tensor_1.clone().greater_equal(tensor_2.clone());
         let data_actual_inplace = tensor_1.greater_equal(tensor_2);
@@ -216,7 +216,7 @@ mod tests {
         E: Element,
     {
         let data_1 = Data::<f32, 2>::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]).convert();
-        let tensor_1 = Tensor::<TestBackend, 2, K>::from_data(data_1);
+        let tensor_1 = Tensor::<TestBackend, 2, K>::from_data_default(data_1);
 
         let data_actual_cloned = tensor_1.clone().lower_elem(4.0);
         let data_actual_inplace = tensor_1.lower_elem(4.0);
@@ -232,7 +232,7 @@ mod tests {
         E: Element,
     {
         let data_1 = Data::<f32, 2>::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]).convert();
-        let tensor_1 = Tensor::<TestBackend, 2, K>::from_data(data_1);
+        let tensor_1 = Tensor::<TestBackend, 2, K>::from_data_default(data_1);
 
         let data_actual_cloned = tensor_1.clone().lower_equal_elem(4.0);
         let data_actual_inplace = tensor_1.lower_equal_elem(4.0);
@@ -249,8 +249,8 @@ mod tests {
     {
         let data_1 = Data::<f32, 2>::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]).convert();
         let data_2 = Data::<f32, 2>::from([[1.0, 1.0, 1.0], [4.0, 3.0, 50.0]]).convert();
-        let tensor_1 = Tensor::<TestBackend, 2, K>::from_data(data_1);
-        let tensor_2 = Tensor::<TestBackend, 2, K>::from_data(data_2);
+        let tensor_1 = Tensor::<TestBackend, 2, K>::from_data_default(data_1);
+        let tensor_2 = Tensor::<TestBackend, 2, K>::from_data_default(data_2);
 
         let data_actual_cloned = tensor_1.clone().lower(tensor_2.clone());
         let data_actual_inplace = tensor_1.lower(tensor_2);
@@ -267,8 +267,8 @@ mod tests {
     {
         let data_1 = Data::<f32, 2>::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]).convert();
         let data_2 = Data::<f32, 2>::from([[1.0, 1.0, 1.0], [4.0, 3.0, 50.0]]).convert();
-        let tensor_1 = Tensor::<TestBackend, 2, K>::from_data(data_1);
-        let tensor_2 = Tensor::<TestBackend, 2, K>::from_data(data_2);
+        let tensor_1 = Tensor::<TestBackend, 2, K>::from_data_default(data_1);
+        let tensor_2 = Tensor::<TestBackend, 2, K>::from_data_default(data_2);
 
         let data_actual_cloned = tensor_1.clone().lower_equal(tensor_2.clone());
         let data_actual_inplace = tensor_1.lower_equal(tensor_2);
@@ -282,8 +282,8 @@ mod tests {
     fn should_support_bool_equal() {
         let data_1 = Data::from([[false, true, true], [true, false, true]]);
         let data_2 = Data::from([[false, false, true], [false, true, true]]);
-        let tensor_1 = Tensor::<TestBackend, 2, Bool>::from_data(data_1);
-        let tensor_2 = Tensor::<TestBackend, 2, Bool>::from_data(data_2);
+        let tensor_1 = Tensor::<TestBackend, 2, Bool>::from_data_default(data_1);
+        let tensor_2 = Tensor::<TestBackend, 2, Bool>::from_data_default(data_2);
 
         let data_actual_cloned = tensor_1.clone().equal(tensor_2.clone());
         let data_actual_inplace = tensor_1.equal(tensor_2);
@@ -296,7 +296,7 @@ mod tests {
     #[test]
     fn should_support_bool_not() {
         let data_1 = Data::from([[false, true, true], [true, true, false]]);
-        let tensor_1 = Tensor::<TestBackend, 2, Bool>::from_data(data_1);
+        let tensor_1 = Tensor::<TestBackend, 2, Bool>::from_data_default(data_1);
 
         let data_actual_cloned = tensor_1.clone().bool_not();
         let data_actual_inplace = tensor_1.bool_not();

--- a/burn-tensor/src/tests/ops/mask.rs
+++ b/burn-tensor/src/tests/ops/mask.rs
@@ -5,10 +5,12 @@ mod tests {
 
     #[test]
     fn should_support_mask_where_ops() {
-        let tensor = TestTensor::from_data([[1.0, 7.0], [2.0, 3.0]]);
-        let mask =
-            Tensor::<TestBackend, 2, Bool>::from_bool(Data::from([[true, false], [false, true]]));
-        let value = Tensor::<TestBackend, 2>::from_data(Data::from([[1.8, 2.8], [3.8, 4.8]]));
+        let tensor = TestTensor::from_data_default([[1.0, 7.0], [2.0, 3.0]]);
+        let mask = Tensor::<TestBackend, 2, Bool>::from_bool_default(Data::from([
+            [true, false],
+            [false, true],
+        ]));
+        let value = Tensor::<TestBackend, 2>::from_data_default(Data::from([[1.8, 2.8], [3.8, 4.8]]));
 
         let data_actual = tensor.mask_where(mask, value).into_data();
 
@@ -18,9 +20,11 @@ mod tests {
 
     #[test]
     fn should_support_mask_fill_ops() {
-        let tensor = TestTensor::from_data([[1.0, 7.0], [2.0, 3.0]]);
-        let mask =
-            Tensor::<TestBackend, 2, Bool>::from_bool(Data::from([[true, false], [false, true]]));
+        let tensor = TestTensor::from_data_default([[1.0, 7.0], [2.0, 3.0]]);
+        let mask = Tensor::<TestBackend, 2, Bool>::from_bool_default(Data::from([
+            [true, false],
+            [false, true],
+        ]));
 
         let data_actual = tensor.mask_fill(mask, 2.0).to_data();
 
@@ -30,10 +34,12 @@ mod tests {
 
     #[test]
     fn should_support_int_mask_where_ops() {
-        let tensor = Tensor::<TestBackend, 2, Int>::from_data([[1, 7], [2, 3]]);
-        let mask =
-            Tensor::<TestBackend, 2, Bool>::from_bool(Data::from([[true, false], [false, true]]));
-        let value = Tensor::<TestBackend, 2, Int>::from_data(Data::from([[8, 9], [10, 11]]));
+        let tensor = Tensor::<TestBackend, 2, Int>::from_data_default([[1, 7], [2, 3]]);
+        let mask = Tensor::<TestBackend, 2, Bool>::from_bool_default(Data::from([
+            [true, false],
+            [false, true],
+        ]));
+        let value = Tensor::<TestBackend, 2, Int>::from_data_default(Data::from([[8, 9], [10, 11]]));
 
         let data_actual = tensor.mask_where(mask, value).into_data();
 
@@ -43,9 +49,11 @@ mod tests {
 
     #[test]
     fn should_support_int_mask_fill_ops() {
-        let tensor = Tensor::<TestBackend, 2, Int>::from_data([[1, 7], [2, 3]]);
-        let mask =
-            Tensor::<TestBackend, 2, Bool>::from_bool(Data::from([[true, false], [false, true]]));
+        let tensor = Tensor::<TestBackend, 2, Int>::from_data_default([[1, 7], [2, 3]]);
+        let mask = Tensor::<TestBackend, 2, Bool>::from_bool_default(Data::from([
+            [true, false],
+            [false, true],
+        ]));
 
         let data_actual = tensor.mask_fill(mask, 9).to_data();
 

--- a/burn-tensor/src/tests/ops/mask.rs
+++ b/burn-tensor/src/tests/ops/mask.rs
@@ -10,7 +10,8 @@ mod tests {
             [true, false],
             [false, true],
         ]));
-        let value = Tensor::<TestBackend, 2>::from_data_default(Data::from([[1.8, 2.8], [3.8, 4.8]]));
+        let value =
+            Tensor::<TestBackend, 2>::from_data_default(Data::from([[1.8, 2.8], [3.8, 4.8]]));
 
         let data_actual = tensor.mask_where(mask, value).into_data();
 
@@ -39,7 +40,8 @@ mod tests {
             [true, false],
             [false, true],
         ]));
-        let value = Tensor::<TestBackend, 2, Int>::from_data_default(Data::from([[8, 9], [10, 11]]));
+        let value =
+            Tensor::<TestBackend, 2, Int>::from_data_default(Data::from([[8, 9], [10, 11]]));
 
         let data_actual = tensor.mask_where(mask, value).into_data();
 

--- a/burn-tensor/src/tests/ops/matmul.rs
+++ b/burn-tensor/src/tests/ops/matmul.rs
@@ -5,8 +5,8 @@ mod tests {
 
     #[test]
     fn test_matmul_d2() {
-        let tensor_1 = TestTensor::from_floats([[1.0, 7.0], [2.0, 3.0], [1.0, 5.0]]);
-        let tensor_2 = TestTensor::from_floats([[4.0, 7.0, 5.0], [2.0, 3.0, 5.0]]);
+        let tensor_1 = TestTensor::from_floats_default([[1.0, 7.0], [2.0, 3.0], [1.0, 5.0]]);
+        let tensor_2 = TestTensor::from_floats_default([[4.0, 7.0, 5.0], [2.0, 3.0, 5.0]]);
 
         let tensor_3 = tensor_1.matmul(tensor_2);
 
@@ -18,8 +18,8 @@ mod tests {
 
     #[test]
     fn test_matmul_d3() {
-        let tensor_1 = TestTensor::from_floats([[[1.0, 7.0], [2.0, 3.0]]]);
-        let tensor_2 = TestTensor::from_floats([[[4.0, 7.0], [2.0, 3.0]]]);
+        let tensor_1 = TestTensor::from_floats_default([[[1.0, 7.0], [2.0, 3.0]]]);
+        let tensor_2 = TestTensor::from_floats_default([[[4.0, 7.0], [2.0, 3.0]]]);
 
         let tensor_3 = tensor_1.matmul(tensor_2);
 
@@ -31,9 +31,9 @@ mod tests {
 
     #[test]
     fn test_matmul_broadcast_1() {
-        let tensor_1 = TestTensor::from_floats([[[1.0, 7.0], [2.0, 3.0]]]);
+        let tensor_1 = TestTensor::from_floats_default([[[1.0, 7.0], [2.0, 3.0]]]);
         let tensor_2 =
-            TestTensor::from_floats([[[4.0, 7.0], [2.0, 3.0]], [[2.0, 5.0], [6.0, 3.0]]]);
+            TestTensor::from_floats_default([[[4.0, 7.0], [2.0, 3.0]], [[2.0, 5.0], [6.0, 3.0]]]);
 
         let tensor_3 = tensor_1.matmul(tensor_2);
 
@@ -45,8 +45,8 @@ mod tests {
 
     #[test]
     fn test_matmul_simple_1() {
-        let tensor_1 = TestTensor::from_floats([[5.0, 14.0], [14.0, 50.0]]);
-        let tensor_2 = TestTensor::from_floats([[3.0, 4.0, 5.0], [0.0, 1.0, 2.0]]);
+        let tensor_1 = TestTensor::from_floats_default([[5.0, 14.0], [14.0, 50.0]]);
+        let tensor_2 = TestTensor::from_floats_default([[3.0, 4.0, 5.0], [0.0, 1.0, 2.0]]);
 
         let tensor_3 = tensor_1.matmul(tensor_2);
 
@@ -58,8 +58,8 @@ mod tests {
 
     #[test]
     fn test_matmul_simple_2() {
-        let tensor_1 = TestTensor::from_floats([[1.0, 2.0, 3.0, 4.0]]);
-        let tensor_2 = TestTensor::from_floats([[3.0], [4.0], [5.0], [6.0]]);
+        let tensor_1 = TestTensor::from_floats_default([[1.0, 2.0, 3.0, 4.0]]);
+        let tensor_2 = TestTensor::from_floats_default([[3.0], [4.0], [5.0], [6.0]]);
 
         let tensor_3 = tensor_1.matmul(tensor_2);
 
@@ -69,9 +69,9 @@ mod tests {
     #[test]
     fn test_matmul_simple_3() {
         let tensor_1 =
-            TestTensor::from_floats([[3., 3., 3.], [4., 4., 4.], [5., 5., 5.], [6., 6., 6.]]);
+            TestTensor::from_floats_default([[3., 3., 3.], [4., 4., 4.], [5., 5., 5.], [6., 6., 6.]]);
         let tensor_2 =
-            TestTensor::from_floats([[1., 2., 3., 4.], [1., 2., 3., 4.], [1., 2., 3., 4.]]);
+            TestTensor::from_floats_default([[1., 2., 3., 4.], [1., 2., 3., 4.], [1., 2., 3., 4.]]);
 
         let tensor_3 = tensor_1.matmul(tensor_2);
 
@@ -89,9 +89,9 @@ mod tests {
     #[test]
     #[should_panic]
     fn should_panic_when_inner_dimensions_are_not_equal() {
-        let tensor_1 = TestTensor::from_floats([[3., 3.], [4., 4.], [5., 5.], [6., 6.]]);
+        let tensor_1 = TestTensor::from_floats_default([[3., 3.], [4., 4.], [5., 5.], [6., 6.]]);
         let tensor_2 =
-            TestTensor::from_floats([[1., 2., 3., 4.], [1., 2., 3., 4.], [1., 2., 3., 4.]]);
+            TestTensor::from_floats_default([[1., 2., 3., 4.], [1., 2., 3., 4.], [1., 2., 3., 4.]]);
 
         let tensor_3 = tensor_1.matmul(tensor_2);
 

--- a/burn-tensor/src/tests/ops/matmul.rs
+++ b/burn-tensor/src/tests/ops/matmul.rs
@@ -68,8 +68,12 @@ mod tests {
 
     #[test]
     fn test_matmul_simple_3() {
-        let tensor_1 =
-            TestTensor::from_floats_default([[3., 3., 3.], [4., 4., 4.], [5., 5., 5.], [6., 6., 6.]]);
+        let tensor_1 = TestTensor::from_floats_default([
+            [3., 3., 3.],
+            [4., 4., 4.],
+            [5., 5., 5.],
+            [6., 6., 6.],
+        ]);
         let tensor_2 =
             TestTensor::from_floats_default([[1., 2., 3., 4.], [1., 2., 3., 4.], [1., 2., 3., 4.]]);
 

--- a/burn-tensor/src/tests/ops/maxmin.rs
+++ b/burn-tensor/src/tests/ops/maxmin.rs
@@ -5,7 +5,7 @@ mod tests {
 
     #[test]
     fn test_max_dim_2d() {
-        let tensor = TestTensor::from_floats([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = TestTensor::from_floats_default([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output_actual = tensor.max_dim(1);
 
@@ -15,7 +15,7 @@ mod tests {
 
     #[test]
     fn test_max_dim_with_indices_2d() {
-        let tensor = TestTensor::from_floats([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = TestTensor::from_floats_default([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let (output_actual, index_actual) = tensor.max_dim_with_indices(1);
 
@@ -28,7 +28,7 @@ mod tests {
 
     #[test]
     fn test_min_dim_2d() {
-        let tensor = TestTensor::from_floats([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = TestTensor::from_floats_default([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output_actual = tensor.min_dim(1);
 
@@ -38,7 +38,7 @@ mod tests {
 
     #[test]
     fn test_min_dim_with_indices_2d() {
-        let tensor = TestTensor::from_floats([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = TestTensor::from_floats_default([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let (output_actual, index_actual) = tensor.min_dim_with_indices(1);
 

--- a/burn-tensor/src/tests/ops/mul.rs
+++ b/burn-tensor/src/tests/ops/mul.rs
@@ -7,8 +7,8 @@ mod tests {
     fn should_support_mul_ops() {
         let data_1 = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
         let data_2 = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let tensor_1 = Tensor::<TestBackend, 2>::from_data(data_1);
-        let tensor_2 = Tensor::<TestBackend, 2>::from_data(data_2);
+        let tensor_1 = Tensor::<TestBackend, 2>::from_data_default(data_1);
+        let tensor_2 = Tensor::<TestBackend, 2>::from_data_default(data_2);
 
         let output = tensor_1 * tensor_2;
 
@@ -21,8 +21,8 @@ mod tests {
     fn test_mul_broadcast() {
         let data_1 = Data::from([[0.0, 1.0, 2.0]]);
         let data_2 = Data::from([[3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]);
-        let tensor_1 = Tensor::<TestBackend, 2>::from_data(data_1);
-        let tensor_2 = Tensor::<TestBackend, 2>::from_data(data_2);
+        let tensor_1 = Tensor::<TestBackend, 2>::from_data_default(data_1);
+        let tensor_2 = Tensor::<TestBackend, 2>::from_data_default(data_2);
 
         let data_actual = (tensor_1 * tensor_2).into_data();
 
@@ -34,7 +34,7 @@ mod tests {
     fn should_support_mul_scalar_ops() {
         let data = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
         let scalar = 2.0;
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let output = tensor * scalar;
 
@@ -47,8 +47,8 @@ mod tests {
     fn should_support_mul_ops_int() {
         let data_1 = Data::from([[0, 1, 2], [3, 4, 5]]);
         let data_2 = Data::from([[0, 1, 2], [3, 4, 5]]);
-        let tensor_1 = Tensor::<TestBackend, 2, Int>::from_data(data_1);
-        let tensor_2 = Tensor::<TestBackend, 2, Int>::from_data(data_2);
+        let tensor_1 = Tensor::<TestBackend, 2, Int>::from_data_default(data_1);
+        let tensor_2 = Tensor::<TestBackend, 2, Int>::from_data_default(data_2);
 
         let output = tensor_1 * tensor_2;
 
@@ -61,8 +61,8 @@ mod tests {
     fn test_mul_broadcast_int() {
         let data_1 = Data::from([[0, 1, 2]]);
         let data_2 = Data::from([[3, 4, 5], [6, 7, 8]]);
-        let tensor_1 = Tensor::<TestBackend, 2, Int>::from_data(data_1);
-        let tensor_2 = Tensor::<TestBackend, 2, Int>::from_data(data_2);
+        let tensor_1 = Tensor::<TestBackend, 2, Int>::from_data_default(data_1);
+        let tensor_2 = Tensor::<TestBackend, 2, Int>::from_data_default(data_2);
 
         let data_actual = (tensor_1 * tensor_2).into_data();
 
@@ -74,7 +74,7 @@ mod tests {
     fn should_support_mul_scalar_ops_int() {
         let data = Data::from([[0, 1, 2], [3, 4, 5]]);
         let scalar = 2;
-        let tensor = Tensor::<TestBackend, 2, Int>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2, Int>::from_data_default(data);
 
         let output = tensor * scalar;
 

--- a/burn-tensor/src/tests/ops/neg.rs
+++ b/burn-tensor/src/tests/ops/neg.rs
@@ -6,7 +6,7 @@ mod tests {
     #[test]
     fn should_support_neg_ops() {
         let data = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = tensor.neg().into_data();
 

--- a/burn-tensor/src/tests/ops/powf.rs
+++ b/burn-tensor/src/tests/ops/powf.rs
@@ -6,7 +6,7 @@ mod tests {
     #[test]
     fn should_support_powf_ops() {
         let data = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = tensor.powf(0.71).into_data();
 
@@ -17,7 +17,7 @@ mod tests {
     #[test]
     fn should_support_neg_power() {
         let data = Data::from([[1.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = tensor.powf(-0.33).into_data();
 
@@ -28,7 +28,7 @@ mod tests {
     #[test]
     fn should_support_neg_values_with_even_power() {
         let data = Data::from([[0.0, -1.0, -2.0], [-3.0, -4.0, -5.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = tensor.powf(4.0).into_data();
 
@@ -39,7 +39,7 @@ mod tests {
     #[test]
     fn should_support_neg_values_with_odd_power() {
         let data = Data::from([[0.0, -1.0, -2.0], [-3.0, -4.0, -5.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = tensor.powf(3.0).into_data();
 

--- a/burn-tensor/src/tests/ops/random.rs
+++ b/burn-tensor/src/tests/ops/random.rs
@@ -5,7 +5,7 @@ mod tests {
 
     #[test]
     fn rand_default() {
-        let tensor = Tensor::<TestBackend, 1>::random([20], Distribution::Default);
+        let tensor = Tensor::<TestBackend, 1>::random_default([20], Distribution::Default);
 
         // check that the tensor is within the range of [0..1) (1 is exclusive)
         tensor.into_data().assert_within_range(0.0..1.0);
@@ -13,14 +13,14 @@ mod tests {
 
     #[test]
     fn rand_uniform() {
-        let tensor = Tensor::<TestBackend, 1>::random([20], Distribution::Uniform(4., 5.));
+        let tensor = Tensor::<TestBackend, 1>::random_default([20], Distribution::Uniform(4., 5.));
 
         tensor.into_data().assert_within_range(4.0..5.0);
     }
 
     #[test]
     fn rand_bernoulli() {
-        let tensor = Tensor::<TestBackend, 1>::random([20], Distribution::Bernoulli(1.));
+        let tensor = Tensor::<TestBackend, 1>::random_default([20], Distribution::Bernoulli(1.));
 
         assert_eq!(tensor.into_data(), [1.; 20].into());
     }

--- a/burn-tensor/src/tests/ops/repeat.rs
+++ b/burn-tensor/src/tests/ops/repeat.rs
@@ -6,7 +6,7 @@ mod tests {
     #[test]
     fn should_support_repeat_ops() {
         let data = Data::from([[0.0, 1.0, 2.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = tensor.repeat(0, 4).into_data();
 

--- a/burn-tensor/src/tests/ops/reshape.rs
+++ b/burn-tensor/src/tests/ops/reshape.rs
@@ -6,7 +6,7 @@ mod tests {
     #[test]
     fn should_support_reshape_1d() {
         let data = Data::from([0.0, 1.0, 2.0]);
-        let tensor = Tensor::<TestBackend, 1>::from_data(data);
+        let tensor = Tensor::<TestBackend, 1>::from_data_default(data);
 
         let data_actual = tensor.clone().reshape([1, 3]).into_data();
         let data_expected = Data::from([[0.0, 1.0, 2.0]]);
@@ -16,7 +16,7 @@ mod tests {
     #[test]
     fn should_support_reshape_int() {
         let data = Data::from([0, 1, 2]);
-        let tensor = Tensor::<TestBackend, 1, Int>::from_data(data);
+        let tensor = Tensor::<TestBackend, 1, Int>::from_data_default(data);
 
         let data_actual = tensor.clone().reshape([1, 3]).into_data();
         let data_expected = Data::from([[0, 1, 2]]);
@@ -26,7 +26,7 @@ mod tests {
     #[test]
     fn should_support_reshape_bool() {
         let data = Data::from([false, true, false]);
-        let tensor = Tensor::<TestBackend, 1, Bool>::from_data(data);
+        let tensor = Tensor::<TestBackend, 1, Bool>::from_data_default(data);
 
         let data_actual = tensor.clone().reshape([1, 3]).into_data();
         let data_expected = Data::from([[false, true, false]]);
@@ -36,7 +36,7 @@ mod tests {
     #[test]
     fn should_support_reshape_2d() {
         let data = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = tensor.clone().reshape([6]).into_data();
         let data_expected = Data::from([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]);
@@ -51,7 +51,7 @@ mod tests {
             [6.0, 7.0, 8.0],
             [9.0, 10.0, 11.0],
         ]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         // Infer the dimension via -1
         let reshaped = tensor.clone().reshape([2, -1]);
@@ -74,7 +74,7 @@ mod tests {
     #[should_panic]
     fn multiple_neg_ones() {
         let data = Data::from([0.0, 1.0, 2.0]);
-        let tensor = Tensor::<TestBackend, 1>::from_data(data);
+        let tensor = Tensor::<TestBackend, 1>::from_data_default(data);
         let data_actual = tensor.reshape([-1, -1]).into_data();
     }
 
@@ -82,7 +82,7 @@ mod tests {
     #[should_panic]
     fn neg_value() {
         let data = Data::from([0.0, 1.0, 2.0]);
-        let tensor = Tensor::<TestBackend, 1>::from_data(data);
+        let tensor = Tensor::<TestBackend, 1>::from_data_default(data);
         let data_actual = tensor.reshape([-2, -1]).into_data();
     }
 }

--- a/burn-tensor/src/tests/ops/select.rs
+++ b/burn-tensor/src/tests/ops/select.rs
@@ -5,8 +5,8 @@ mod tests {
 
     #[test]
     fn should_select_1d() {
-        let tensor = TestTensor::from_data([0.0, 1.0, 2.0]);
-        let indices = TestTensorInt::from_data([1, 1, 0, 1, 2]);
+        let tensor = TestTensor::from_data_default([0.0, 1.0, 2.0]);
+        let indices = TestTensorInt::from_data_default([1, 1, 0, 1, 2]);
 
         let output = tensor.select(0, indices);
 
@@ -15,8 +15,8 @@ mod tests {
 
     #[test]
     fn should_select_1d_int() {
-        let tensor = TestTensorInt::from_data([5, 6, 7]);
-        let indices = TestTensorInt::from_data([1, 1, 0, 1, 2]);
+        let tensor = TestTensorInt::from_data_default([5, 6, 7]);
+        let indices = TestTensorInt::from_data_default([1, 1, 0, 1, 2]);
 
         let output = tensor.select(0, indices);
 
@@ -25,8 +25,8 @@ mod tests {
 
     #[test]
     fn should_select_2d_dim0_same_num_dim() {
-        let tensor = TestTensor::from_data([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let indices = TestTensorInt::from_data(([1, 0]));
+        let tensor = TestTensor::from_data_default([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let indices = TestTensorInt::from_data_default(([1, 0]));
 
         let output = tensor.select(0, indices);
 
@@ -38,8 +38,8 @@ mod tests {
 
     #[test]
     fn should_select_2d_dim0_more_num_dim() {
-        let tensor = TestTensor::from_data([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let indices = TestTensorInt::from_data([1, 0, 1, 1]);
+        let tensor = TestTensor::from_data_default([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let indices = TestTensorInt::from_data_default([1, 0, 1, 1]);
 
         let output = tensor.select(0, indices);
 
@@ -56,8 +56,8 @@ mod tests {
 
     #[test]
     fn should_select_2d_dim1() {
-        let tensor = TestTensor::from_data([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let indices = TestTensorInt::from_data([1, 1, 0, 1, 2]);
+        let tensor = TestTensor::from_data_default([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let indices = TestTensorInt::from_data_default([1, 1, 0, 1, 2]);
 
         let output = tensor.select(1, indices);
 
@@ -69,9 +69,9 @@ mod tests {
 
     #[test]
     fn should_select_assign_1d() {
-        let tensor = TestTensor::from_data([0.0, 1.0, 2.0]);
-        let values = TestTensor::from_data([5.0, 4.0, 3.0, 2.0, 1.0]);
-        let indices = TestTensorInt::from_data(Data::from([1, 1, 0, 1, 2]));
+        let tensor = TestTensor::from_data_default([0.0, 1.0, 2.0]);
+        let values = TestTensor::from_data_default([5.0, 4.0, 3.0, 2.0, 1.0]);
+        let indices = TestTensorInt::from_data_default(Data::from([1, 1, 0, 1, 2]));
 
         let output = tensor.select_assign(0, indices, values);
 
@@ -80,9 +80,9 @@ mod tests {
 
     #[test]
     fn should_select_assign_1d_int() {
-        let tensor = TestTensorInt::from_data([7, 8, 9]);
-        let values = TestTensorInt::from_data([5, 4, 3, 2, 1]);
-        let indices = TestTensorInt::from_data(Data::from([1, 1, 0, 1, 2]));
+        let tensor = TestTensorInt::from_data_default([7, 8, 9]);
+        let values = TestTensorInt::from_data_default([5, 4, 3, 2, 1]);
+        let indices = TestTensorInt::from_data_default(Data::from([1, 1, 0, 1, 2]));
 
         let output = tensor.select_assign(0, indices, values);
 
@@ -91,9 +91,9 @@ mod tests {
 
     #[test]
     fn should_select_assign_2d_dim0() {
-        let tensor = TestTensor::from_data([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let values = TestTensor::from_data([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
-        let indices = TestTensorInt::from_data(Data::from([1, 0]));
+        let tensor = TestTensor::from_data_default([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let values = TestTensor::from_data_default([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+        let indices = TestTensorInt::from_data_default(Data::from([1, 0]));
 
         let output = tensor.select_assign(0, indices, values);
 
@@ -105,9 +105,9 @@ mod tests {
 
     #[test]
     fn should_select_assign_2d_dim1() {
-        let tensor = TestTensor::from_data([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let values = TestTensor::from_data([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
-        let indices = TestTensorInt::from_data(Data::from([1, 0, 2]));
+        let tensor = TestTensor::from_data_default([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let values = TestTensor::from_data_default([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+        let indices = TestTensorInt::from_data_default(Data::from([1, 0, 2]));
 
         let output = tensor.select_assign(1, indices, values);
 
@@ -120,8 +120,8 @@ mod tests {
     #[test]
     #[should_panic]
     fn should_select_panic_invalid_dimension() {
-        let tensor = TestTensor::from_data([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let indices = TestTensorInt::from_data([1, 1, 0, 1, 2]);
+        let tensor = TestTensor::from_data_default([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let indices = TestTensorInt::from_data_default([1, 1, 0, 1, 2]);
 
         tensor.select(10, indices);
     }

--- a/burn-tensor/src/tests/ops/sin.rs
+++ b/burn-tensor/src/tests/ops/sin.rs
@@ -6,7 +6,7 @@ mod tests {
     #[test]
     fn should_support_sin_ops() {
         let data = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = tensor.sin().into_data();
 

--- a/burn-tensor/src/tests/ops/slice.rs
+++ b/burn-tensor/src/tests/ops/slice.rs
@@ -6,7 +6,7 @@ mod tests {
     #[test]
     fn should_support_full_sliceing_1d() {
         let data = Data::from([0.0, 1.0, 2.0]);
-        let tensor = Tensor::<TestBackend, 1>::from_data(data.clone());
+        let tensor = Tensor::<TestBackend, 1>::from_data_default(data.clone());
 
         let data_actual = tensor.slice([0..3]).into_data();
 
@@ -16,7 +16,7 @@ mod tests {
     #[test]
     fn should_support_partial_sliceing_1d() {
         let data = Data::from([0.0, 1.0, 2.0]);
-        let tensor = Tensor::<TestBackend, 1>::from_data(data);
+        let tensor = Tensor::<TestBackend, 1>::from_data_default(data);
 
         let data_actual = tensor.slice([1..3]).into_data();
 
@@ -27,7 +27,7 @@ mod tests {
     #[test]
     fn should_support_full_sliceing_2d() {
         let data = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data.clone());
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data.clone());
 
         let data_actual_1 = tensor.clone().slice([0..2]).into_data();
         let data_actual_2 = tensor.slice([0..2, 0..3]).into_data();
@@ -39,7 +39,7 @@ mod tests {
     #[test]
     fn should_support_partial_sliceing_2d() {
         let data = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = tensor.slice([0..2, 0..2]).into_data();
 
@@ -49,7 +49,7 @@ mod tests {
 
     #[test]
     fn should_support_partial_sliceing_3d() {
-        let tensor = TestTensor::from_floats([
+        let tensor = TestTensor::from_floats_default([
             [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]],
             [[6.0, 7.0, 8.0], [9.0, 10.0, 11.0]],
         ]);
@@ -62,7 +62,7 @@ mod tests {
 
     #[test]
     fn should_support_partial_sliceing_3d_non_contiguous() {
-        let tensor = TestTensor::from_floats([
+        let tensor = TestTensor::from_floats_default([
             [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]],
             [[6.0, 7.0, 8.0], [9.0, 10.0, 11.0]],
         ]);
@@ -78,8 +78,8 @@ mod tests {
         let data = Data::from([0.0, 1.0, 2.0]);
         let data_assigned = Data::from([10.0, 5.0]);
 
-        let tensor = Tensor::<TestBackend, 1>::from_data(data);
-        let tensor_assigned = Tensor::<TestBackend, 1>::from_data(data_assigned);
+        let tensor = Tensor::<TestBackend, 1>::from_data_default(data);
+        let tensor_assigned = Tensor::<TestBackend, 1>::from_data_default(data_assigned);
 
         let data_actual = tensor.slice_assign([0..2], tensor_assigned).into_data();
 
@@ -92,8 +92,8 @@ mod tests {
         let data = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
         let data_assigned = Data::from([[10.0, 5.0]]);
 
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
-        let tensor_assigned = Tensor::<TestBackend, 2>::from_data(data_assigned);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
+        let tensor_assigned = Tensor::<TestBackend, 2>::from_data_default(data_assigned);
 
         let data_actual = tensor
             .slice_assign([1..2, 0..2], tensor_assigned)
@@ -107,7 +107,7 @@ mod tests {
     #[should_panic]
     fn should_panic_when_slice_exceeds_dimension() {
         let data = Data::from([0.0, 1.0, 2.0]);
-        let tensor = Tensor::<TestBackend, 1>::from_data(data.clone());
+        let tensor = Tensor::<TestBackend, 1>::from_data_default(data.clone());
 
         let data_actual = tensor.slice([0..4]).into_data();
 
@@ -118,7 +118,7 @@ mod tests {
     #[should_panic]
     fn should_panic_when_slice_with_too_many_dimensions() {
         let data = Data::from([0.0, 1.0, 2.0]);
-        let tensor = Tensor::<TestBackend, 1>::from_data(data.clone());
+        let tensor = Tensor::<TestBackend, 1>::from_data_default(data.clone());
 
         let data_actual = tensor.slice([0..1, 0..1]).into_data();
 
@@ -129,7 +129,7 @@ mod tests {
     #[should_panic]
     fn should_panic_when_slice_is_desc() {
         let data = Data::from([0.0, 1.0, 2.0]);
-        let tensor = Tensor::<TestBackend, 1>::from_data(data.clone());
+        let tensor = Tensor::<TestBackend, 1>::from_data_default(data.clone());
 
         let data_actual = tensor.slice([2..1]).into_data();
 
@@ -140,7 +140,7 @@ mod tests {
     #[should_panic]
     fn should_panic_when_slice_is_equal() {
         let data = Data::from([0.0, 1.0, 2.0]);
-        let tensor = Tensor::<TestBackend, 1>::from_data(data.clone());
+        let tensor = Tensor::<TestBackend, 1>::from_data_default(data.clone());
 
         let data_actual = tensor.slice([1..1]).into_data();
 

--- a/burn-tensor/src/tests/ops/sqrt.rs
+++ b/burn-tensor/src/tests/ops/sqrt.rs
@@ -7,7 +7,7 @@ mod tests {
     #[test]
     fn should_support_sqrt_ops() {
         let data = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = tensor.sqrt().into_data();
 

--- a/burn-tensor/src/tests/ops/squeeze.rs
+++ b/burn-tensor/src/tests/ops/squeeze.rs
@@ -6,7 +6,7 @@ mod tests {
     /// Test if the function can successfully squeeze the size 1 dimension of a 3D tensor.
     #[test]
     fn should_squeeze() {
-        let tensor = Tensor::<TestBackend, 3>::ones(Shape::new([2, 1, 4]));
+        let tensor = Tensor::<TestBackend, 3>::ones_default(Shape::new([2, 1, 4]));
         let squeezed_tensor: Tensor<TestBackend, 2> = tensor.squeeze(1);
         let expected_shape = Shape::new([2, 4]);
         assert_eq!(squeezed_tensor.shape(), expected_shape);
@@ -14,7 +14,7 @@ mod tests {
     /// Test if the function can successfully squeeze the first size 1 dimension of a 4D tensor.
     #[test]
     fn should_squeeze_first() {
-        let tensor = Tensor::<TestBackend, 4>::ones(Shape::new([1, 3, 4, 5]));
+        let tensor = Tensor::<TestBackend, 4>::ones_default(Shape::new([1, 3, 4, 5]));
         let squeezed_tensor: Tensor<TestBackend, 3> = tensor.squeeze(0);
         let expected_shape = Shape::new([3, 4, 5]);
         assert_eq!(squeezed_tensor.shape(), expected_shape);
@@ -22,7 +22,7 @@ mod tests {
     /// Test if the function can successfully squeeze the last size 1 dimension of a 4D tensor.
     #[test]
     fn should_squeeze_last() {
-        let tensor = Tensor::<TestBackend, 4>::ones(Shape::new([2, 3, 4, 1]));
+        let tensor = Tensor::<TestBackend, 4>::ones_default(Shape::new([2, 3, 4, 1]));
         let squeezed_tensor: Tensor<TestBackend, 3> = tensor.squeeze(3);
         let expected_shape = Shape::new([2, 3, 4]);
         assert_eq!(squeezed_tensor.shape(), expected_shape);
@@ -31,7 +31,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn should_squeeze_panic() {
-        let tensor = Tensor::<TestBackend, 4>::ones(Shape::new([2, 3, 4, 5]));
+        let tensor = Tensor::<TestBackend, 4>::ones_default(Shape::new([2, 3, 4, 5]));
         let squeezed_tensor: Tensor<TestBackend, 3> = tensor.squeeze(2);
     }
 }

--- a/burn-tensor/src/tests/ops/sub.rs
+++ b/burn-tensor/src/tests/ops/sub.rs
@@ -8,8 +8,8 @@ mod tests {
         let data_1 = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
         let data_2 = Data::from([[6.0, 7.0, 8.0], [9.0, 10.0, 11.0]]);
         let data_expected = Data::from([[-6.0, -6.0, -6.0], [-6.0, -6.0, -6.0]]);
-        let tensor_1 = Tensor::<TestBackend, 2>::from_data(data_1);
-        let tensor_2 = Tensor::<TestBackend, 2>::from_data(data_2);
+        let tensor_1 = Tensor::<TestBackend, 2>::from_data_default(data_1);
+        let tensor_2 = Tensor::<TestBackend, 2>::from_data_default(data_2);
 
         let data_actual = (tensor_1 - tensor_2).into_data();
 
@@ -20,8 +20,8 @@ mod tests {
     fn test_sub_broadcast() {
         let data_1 = Data::from([[0.0, 1.0, 2.0]]);
         let data_2 = Data::from([[3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]);
-        let tensor_1 = Tensor::<TestBackend, 2>::from_data(data_1);
-        let tensor_2 = Tensor::<TestBackend, 2>::from_data(data_2);
+        let tensor_1 = Tensor::<TestBackend, 2>::from_data_default(data_1);
+        let tensor_2 = Tensor::<TestBackend, 2>::from_data_default(data_2);
 
         let data_actual = (tensor_1 - tensor_2).into_data();
 
@@ -33,7 +33,7 @@ mod tests {
     fn should_support_sub_scalar_ops() {
         let data = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
         let scalar = 2.0;
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let output = tensor - scalar;
 
@@ -47,8 +47,8 @@ mod tests {
         let data_1 = Data::from([[0, 1, 2], [3, 4, 5]]);
         let data_2 = Data::from([[6, 7, 8], [9, 10, 11]]);
         let data_expected = Data::from([[-6, -6, -6], [-6, -6, -6]]);
-        let tensor_1 = Tensor::<TestBackend, 2, Int>::from_data(data_1);
-        let tensor_2 = Tensor::<TestBackend, 2, Int>::from_data(data_2);
+        let tensor_1 = Tensor::<TestBackend, 2, Int>::from_data_default(data_1);
+        let tensor_2 = Tensor::<TestBackend, 2, Int>::from_data_default(data_2);
 
         let data_actual = (tensor_1 - tensor_2).into_data();
 
@@ -59,8 +59,8 @@ mod tests {
     fn test_sub_broadcast_int() {
         let data_1 = Data::from([[0, 1, 2]]);
         let data_2 = Data::from([[3, 4, 5], [6, 7, 8]]);
-        let tensor_1 = Tensor::<TestBackend, 2, Int>::from_data(data_1);
-        let tensor_2 = Tensor::<TestBackend, 2, Int>::from_data(data_2);
+        let tensor_1 = Tensor::<TestBackend, 2, Int>::from_data_default(data_1);
+        let tensor_2 = Tensor::<TestBackend, 2, Int>::from_data_default(data_2);
 
         let data_actual = (tensor_1 - tensor_2).into_data();
 
@@ -72,7 +72,7 @@ mod tests {
     fn should_support_sub_scalar_ops_int() {
         let data = Data::from([[0, 1, 2], [3, 4, 5]]);
         let scalar = 2;
-        let tensor = Tensor::<TestBackend, 2, Int>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2, Int>::from_data_default(data);
 
         let output = tensor - scalar;
 

--- a/burn-tensor/src/tests/ops/tanh.rs
+++ b/burn-tensor/src/tests/ops/tanh.rs
@@ -6,7 +6,7 @@ mod tests {
     #[test]
     fn should_support_tanh_ops() {
         let data = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = tensor.tanh().into_data();
 

--- a/burn-tensor/src/tests/ops/transpose.rs
+++ b/burn-tensor/src/tests/ops/transpose.rs
@@ -5,7 +5,7 @@ mod tests {
 
     #[test]
     fn should_support_transpose_ops() {
-        let tensor = TestTensor::from_floats([
+        let tensor = TestTensor::from_floats_default([
             [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]],
             [[6.0, 7.0, 8.0], [9.0, 10.0, 11.0]],
         ]);
@@ -21,7 +21,7 @@ mod tests {
 
     #[test]
     fn should_support_swap_dims() {
-        let tensor = TestTensor::from_floats([
+        let tensor = TestTensor::from_floats_default([
             [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]],
             [[6.0, 7.0, 8.0], [9.0, 10.0, 11.0]],
         ]);
@@ -38,7 +38,7 @@ mod tests {
 
     #[test]
     fn should_support_transpose_ops_int() {
-        let tensor = Tensor::<TestBackend, 3, Int>::from_data([
+        let tensor = Tensor::<TestBackend, 3, Int>::from_data_default([
             [[0, 1, 2], [3, 4, 5]],
             [[6, 7, 8], [9, 10, 11]],
         ]);
@@ -51,7 +51,7 @@ mod tests {
 
     #[test]
     fn should_support_swap_dims_int() {
-        let tensor = Tensor::<TestBackend, 3, Int>::from_data([
+        let tensor = Tensor::<TestBackend, 3, Int>::from_data_default([
             [[0, 1, 2], [3, 4, 5]],
             [[6, 7, 8], [9, 10, 11]],
         ]);
@@ -64,7 +64,7 @@ mod tests {
 
     #[test]
     fn should_support_transpose_bool() {
-        let tensor = Tensor::<TestBackend, 3, Bool>::from_data([
+        let tensor = Tensor::<TestBackend, 3, Bool>::from_data_default([
             [[false, true, false], [false, false, false]],
             [[false, false, true], [false, false, true]],
         ]);
@@ -80,7 +80,7 @@ mod tests {
 
     #[test]
     fn should_support_swap_dims_bool() {
-        let tensor = Tensor::<TestBackend, 3, Bool>::from_data([
+        let tensor = Tensor::<TestBackend, 3, Bool>::from_data_default([
             [[false, true, false], [false, false, false]],
             [[false, false, true], [false, false, true]],
         ]);

--- a/burn-tensor/src/tests/stats/cov.rs
+++ b/burn-tensor/src/tests/stats/cov.rs
@@ -10,7 +10,7 @@ mod tests {
     #[test]
     fn test_cov_1() {
         let data = Data::from([[0.5, 1.8, 0.2, -2.0], [3.0, -4.0, 5.0, 0.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = tensor.cov(1, 1).into_data();
 
@@ -21,7 +21,7 @@ mod tests {
     #[test]
     fn test_cov_4() {
         let data = Data::from([[0.5, 1.8, 0.2, -2.0], [3.0, -4.0, 5.0, 0.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = tensor.cov(1, 0).into_data();
 
@@ -32,7 +32,7 @@ mod tests {
     #[test]
     fn test_cov_2() {
         let data = Data::from([[0.5, 1.8], [0.2, -2.0], [3.0, -4.0], [5.0, 0.0]]);
-        let tensor = Tensor::<TestBackend, 2>::from_data(data);
+        let tensor = Tensor::<TestBackend, 2>::from_data_default(data);
 
         let data_actual = tensor.cov(1, 1).into_data();
 
@@ -53,9 +53,9 @@ mod tests {
             [[0.5, 1.8, 0.2, -2.0], [3.0, -4.0, 5.0, 0.0]],
             [[0.5, 1.8, 0.2, -2.0], [3.0, -4.0, 5.0, 0.0]],
         ]);
-        let tensor = Tensor::<TestBackend, 3>::from_data(data);
+        let tensor = Tensor::<TestBackend, 3>::from_data_default(data);
         let data_actual = tensor.cov(0, 1).into_data();
-        let data_expected = Tensor::<TestBackend, 3>::zeros([4, 4, 4]).to_data();
+        let data_expected = Tensor::<TestBackend, 3>::zeros_default([4, 4, 4]).to_data();
         data_expected.assert_approx_eq(&data_actual, 3);
     }
 }

--- a/burn-tensor/src/tests/stats/diagonal.rs
+++ b/burn-tensor/src/tests/stats/diagonal.rs
@@ -10,9 +10,10 @@ mod tests {
 
     #[test]
     fn test_diagonal() {
+        let device = <TestBackend as Backend>::Device::default();
         let data = [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]];
-        let lhs = Tensor::<TestBackend, 2>::from_floats(data);
-        let rhs = Tensor::<TestBackend, 2>::diagonal(3);
+        let lhs = Tensor::<TestBackend, 2>::from_floats(data, &device);
+        let rhs = Tensor::<TestBackend, 2>::diagonal(3, &device);
         lhs.to_data().assert_approx_eq(&rhs.to_data(), 3);
     }
 }

--- a/burn-tensor/src/tests/stats/display.rs
+++ b/burn-tensor/src/tests/stats/display.rs
@@ -11,7 +11,7 @@ mod tests {
     fn test_display_2d_int_tensor() {
         let int_data = Data::from([[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
         let tensor_int: burn_tensor::Tensor<TestBackend, 2, burn_tensor::Int> =
-            Tensor::from_data(int_data);
+            Tensor::from_data_default(int_data);
 
         let output = format!("{}", tensor_int);
         let expected = format!(
@@ -37,7 +37,7 @@ mod tests {
     fn test_display_2d_float_tensor() {
         let float_data = Data::from([[1.1, 2.2, 3.3], [4.4, 5.5, 6.6], [7.7, 8.8, 9.9]]);
         let tensor_float: burn_tensor::Tensor<TestBackend, 2, burn_tensor::Float> =
-            Tensor::from_data(float_data);
+            Tensor::from_data_default(float_data);
 
         let output = format!("{}", tensor_float);
         let expected = format!(
@@ -67,7 +67,7 @@ mod tests {
             [false, true, true],
         ]);
         let tensor_bool: burn_tensor::Tensor<TestBackend, 2, burn_tensor::Bool> =
-            Tensor::from_data(bool_data);
+            Tensor::from_data_default(bool_data);
 
         let output = format!("{}", tensor_bool);
         let expected = format!(
@@ -94,7 +94,8 @@ mod tests {
             [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]],
             [[13, 14, 15, 16], [17, 18, 19, 20], [21, 22, 23, 24]],
         ]);
-        let tensor: burn_tensor::Tensor<TestBackend, 3, burn_tensor::Int> = Tensor::from_data(data);
+        let tensor: burn_tensor::Tensor<TestBackend, 3, burn_tensor::Int> =
+            Tensor::from_data_default(data);
 
         let output = format!("{}", tensor);
         let expected = format!(
@@ -126,7 +127,8 @@ mod tests {
             [[[13, 14, 15], [16, 17, 18]], [[19, 20, 21], [22, 23, 24]]],
         ]);
 
-        let tensor: burn_tensor::Tensor<TestBackend, 4, burn_tensor::Int> = Tensor::from_data(data);
+        let tensor: burn_tensor::Tensor<TestBackend, 4, burn_tensor::Int> =
+            Tensor::from_data_default(data);
 
         let output = format!("{}", tensor);
         let expected = format!(
@@ -156,7 +158,7 @@ mod tests {
     #[test]
     fn test_display_tensor_summarize_1() {
         let tensor: burn_tensor::Tensor<TestBackend, 4, burn_tensor::Float> =
-            Tensor::zeros(Shape::new([2, 2, 2, 1000]));
+            Tensor::zeros_default(Shape::new([2, 2, 2, 1000]));
 
         let output = format!("{}", tensor);
         let expected = format!(
@@ -185,7 +187,7 @@ mod tests {
     #[test]
     fn test_display_tensor_summarize_2() {
         let tensor: burn_tensor::Tensor<TestBackend, 4, burn_tensor::Float> =
-            Tensor::zeros(Shape::new([2, 2, 20, 100]));
+            Tensor::zeros_default(Shape::new([2, 2, 20, 100]));
 
         let output = format!("{}", tensor);
         let expected = format!(
@@ -234,7 +236,7 @@ mod tests {
     #[test]
     fn test_display_tensor_summarize_3() {
         let tensor: burn_tensor::Tensor<TestBackend, 4, burn_tensor::Float> =
-            Tensor::zeros(Shape::new([2, 2, 200, 6]));
+            Tensor::zeros_default(Shape::new([2, 2, 200, 6]));
 
         let output = format!("{}", tensor);
         let expected = format!(

--- a/burn-tensor/src/tests/stats/var.rs
+++ b/burn-tensor/src/tests/stats/var.rs
@@ -9,7 +9,7 @@ mod tests {
 
     #[test]
     fn test_var() {
-        let tensor = TestTensor::from_data([[0.5, 1.8, 0.2, -2.0], [3.0, -4.0, 5.0, 0.0]]);
+        let tensor = TestTensor::from_data_default([[0.5, 1.8, 0.2, -2.0], [3.0, -4.0, 5.0, 0.0]]);
 
         let data_actual = tensor.var(1).into_data();
 
@@ -19,7 +19,7 @@ mod tests {
 
     #[test]
     fn test_var_mean() {
-        let tensor = TestTensor::from_data([[0.5, 1.8, 0.2, -2.0], [3.0, -4.0, 5.0, 0.0]]);
+        let tensor = TestTensor::from_data_default([[0.5, 1.8, 0.2, -2.0], [3.0, -4.0, 5.0, 0.0]]);
 
         let (var, mean) = tensor.var_mean(1);
 
@@ -32,7 +32,7 @@ mod tests {
 
     #[test]
     fn test_var_bias() {
-        let tensor = TestTensor::from_data([[0.5, 1.8, 0.2, -2.0], [3.0, -4.0, 5.0, 0.0]]);
+        let tensor = TestTensor::from_data_default([[0.5, 1.8, 0.2, -2.0], [3.0, -4.0, 5.0, 0.0]]);
 
         let data_actual = tensor.var_bias(1).into_data();
 
@@ -42,7 +42,7 @@ mod tests {
 
     #[test]
     fn test_var_mean_bias() {
-        let tensor = TestTensor::from_data([[0.5, 1.8, 0.2, -2.0], [3.0, -4.0, 5.0, 0.0]]);
+        let tensor = TestTensor::from_data_default([[0.5, 1.8, 0.2, -2.0], [3.0, -4.0, 5.0, 0.0]]);
 
         let (var, mean) = tensor.var_mean_bias(1);
 

--- a/burn-train/src/metric/acc.rs
+++ b/burn-train/src/metric/acc.rs
@@ -94,13 +94,13 @@ mod tests {
     fn test_accuracy_without_padding() {
         let mut metric = AccuracyMetric::<TestBackend>::new();
         let input = AccuracyInput::new(
-            Tensor::from_data([
+            Tensor::from_data_default([
                 [0.0, 0.2, 0.8], // 2
                 [1.0, 2.0, 0.5], // 1
                 [0.4, 0.1, 0.2], // 0
                 [0.6, 0.7, 0.2], // 1
             ]),
-            Tensor::from_data([2, 2, 1, 1]),
+            Tensor::from_data_default([2, 2, 1, 1]),
         );
 
         let _entry = metric.update(&input, &MetricMetadata::fake());
@@ -111,7 +111,7 @@ mod tests {
     fn test_accuracy_with_padding() {
         let mut metric = AccuracyMetric::<TestBackend>::new().with_pad_token(3);
         let input = AccuracyInput::new(
-            Tensor::from_data([
+            Tensor::from_data_default([
                 [0.0, 0.2, 0.8, 0.0], // 2
                 [1.0, 2.0, 0.5, 0.0], // 1
                 [0.4, 0.1, 0.2, 0.0], // 0
@@ -120,7 +120,7 @@ mod tests {
                 [0.0, 0.1, 0.2, 0.0], // Error on padding should not count
                 [0.6, 0.0, 0.2, 0.0], // Error on padding should not count
             ]),
-            Tensor::from_data([2, 2, 1, 1, 3, 3, 3]),
+            Tensor::from_data_default([2, 2, 1, 1, 3, 3, 3]),
         );
 
         let _entry = metric.update(&input, &MetricMetadata::fake());

--- a/burn-train/src/metric/processor/mod.rs
+++ b/burn-train/src/metric/processor/mod.rs
@@ -20,7 +20,7 @@ pub(crate) mod test_utils {
 
     impl<B: Backend> Adaptor<LossInput<B>> for f64 {
         fn adapt(&self) -> LossInput<B> {
-            LossInput::new(Tensor::from_data([self.elem()]))
+            LossInput::new(Tensor::from_data_default([self.elem()]))
         }
     }
 

--- a/burn-wgpu/benches/matmul.rs
+++ b/burn-wgpu/benches/matmul.rs
@@ -57,10 +57,8 @@ where
     }
 
     fn prepare(&self) -> Self::Args {
-        let lhs =
-            WTensor::random_device(self.shape_lhs.clone(), Distribution::Default, &self.device);
-        let rhs =
-            WTensor::random_device(self.shape_rhs.clone(), Distribution::Default, &self.device);
+        let lhs = WTensor::random(self.shape_lhs.clone(), Distribution::Default, &self.device);
+        let rhs = WTensor::random(self.shape_rhs.clone(), Distribution::Default, &self.device);
 
         (lhs, rhs)
     }

--- a/burn-wgpu/src/kernel/binary_elemwise.rs
+++ b/burn-wgpu/src/kernel/binary_elemwise.rs
@@ -145,10 +145,10 @@ mod tests {
 
     #[test]
     fn binary_should_work_with_multiple_invocations() {
-        let lhs = Tensor::<TestBackend, 2>::random([6, 256], Distribution::Default);
-        let rhs = Tensor::<TestBackend, 2>::random([6, 256], Distribution::Default);
-        let lhs_ref = Tensor::<ReferenceBackend, 2>::from_data(lhs.to_data());
-        let rhs_ref = Tensor::<ReferenceBackend, 2>::from_data(rhs.to_data());
+        let lhs = Tensor::<TestBackend, 2>::random_default([6, 256], Distribution::Default);
+        let rhs = Tensor::<TestBackend, 2>::random_default([6, 256], Distribution::Default);
+        let lhs_ref = Tensor::<ReferenceBackend, 2>::from_data_default(lhs.to_data());
+        let rhs_ref = Tensor::<ReferenceBackend, 2>::from_data_default(rhs.to_data());
 
         let actual =
             binary_elemwise::<TestKernel, _, 2, 16>(lhs.into_primitive(), rhs.into_primitive());
@@ -162,10 +162,10 @@ mod tests {
 
     #[test]
     fn binary_inplace_should_work_with_multiple_invocations() {
-        let lhs = Tensor::<TestBackend, 2>::random([6, 256], Distribution::Default);
-        let rhs = Tensor::<TestBackend, 2>::random([6, 256], Distribution::Default);
-        let lhs_ref = Tensor::<ReferenceBackend, 2>::from_data(lhs.to_data());
-        let rhs_ref = Tensor::<ReferenceBackend, 2>::from_data(rhs.to_data());
+        let lhs = Tensor::<TestBackend, 2>::random_default([6, 256], Distribution::Default);
+        let rhs = Tensor::<TestBackend, 2>::random_default([6, 256], Distribution::Default);
+        let lhs_ref = Tensor::<ReferenceBackend, 2>::from_data_default(lhs.to_data());
+        let rhs_ref = Tensor::<ReferenceBackend, 2>::from_data_default(rhs.to_data());
 
         let actual = binary_elemwise_inplace::<TestKernelInplace, _, 2, 16>(
             lhs.into_primitive(),

--- a/burn-wgpu/src/kernel/cast.rs
+++ b/burn-wgpu/src/kernel/cast.rs
@@ -70,7 +70,7 @@ mod tests {
         const START: usize = 0;
         const END: usize = 100;
 
-        let tensor = Tensor::<TestBackend, 1, Int>::arange(START..END);
+        let tensor = Tensor::<TestBackend, 1, Int>::arange_default(START..END);
         let tensor_float = cast::<i32, f32, 1>(tensor.clone().into_primitive());
 
         let data_int = tensor.into_data();

--- a/burn-wgpu/src/kernel/cat.rs
+++ b/burn-wgpu/src/kernel/cat.rs
@@ -77,11 +77,11 @@ mod tests {
     fn test_same_as_reference(shape: [usize; 2], num_tensors: usize, dim: usize) {
         TestBackend::seed(0);
         let tensors = (0..num_tensors)
-            .map(|_| Tensor::<TestBackend, 2>::random(shape, Distribution::Default))
+            .map(|_| Tensor::<TestBackend, 2>::random_default(shape, Distribution::Default))
             .collect::<Vec<_>>();
         let tensors_ref = tensors
             .iter()
-            .map(|tensor| Tensor::<ReferenceBackend, 2>::from_data(tensor.to_data()))
+            .map(|tensor| Tensor::<ReferenceBackend, 2>::from_data_default(tensor.to_data()))
             .collect::<Vec<_>>();
 
         let tensor = Tensor::<TestBackend, 2>::cat(tensors, dim);

--- a/burn-wgpu/src/kernel/clamp.rs
+++ b/burn-wgpu/src/kernel/clamp.rs
@@ -82,8 +82,8 @@ mod tests {
 
     #[test]
     fn clamp_min_should_match_reference() {
-        let input = Tensor::<TestBackend, 4>::random([1, 5, 32, 32], Distribution::Default);
-        let input_ref = Tensor::<ReferenceBackend, 4>::from_data(input.to_data());
+        let input = Tensor::<TestBackend, 4>::random_default([1, 5, 32, 32], Distribution::Default);
+        let input_ref = Tensor::<ReferenceBackend, 4>::from_data_default(input.to_data());
 
         let output = input.clamp_min(0.5);
 
@@ -94,8 +94,8 @@ mod tests {
 
     #[test]
     fn clamp_max_should_match_reference() {
-        let input = Tensor::<TestBackend, 4>::random([1, 5, 32, 32], Distribution::Default);
-        let input_ref = Tensor::<ReferenceBackend, 4>::from_data(input.to_data());
+        let input = Tensor::<TestBackend, 4>::random_default([1, 5, 32, 32], Distribution::Default);
+        let input_ref = Tensor::<ReferenceBackend, 4>::from_data_default(input.to_data());
 
         let output = input.clamp_max(0.5);
 
@@ -106,8 +106,8 @@ mod tests {
 
     #[test]
     fn clamp_should_match_reference() {
-        let input = Tensor::<TestBackend, 4>::random([1, 5, 32, 32], Distribution::Default);
-        let input_ref = Tensor::<ReferenceBackend, 4>::from_data(input.to_data());
+        let input = Tensor::<TestBackend, 4>::random_default([1, 5, 32, 32], Distribution::Default);
+        let input_ref = Tensor::<ReferenceBackend, 4>::from_data_default(input.to_data());
 
         let output = input.clamp(0.3, 0.7);
 

--- a/burn-wgpu/src/kernel/comparison/binary.rs
+++ b/burn-wgpu/src/kernel/comparison/binary.rs
@@ -167,10 +167,12 @@ mod tests {
         Tensor<ReferenceBackend, 3>,
     ) {
         TestBackend::seed(0);
-        let lhs = Tensor::<TestBackend, 3>::random([2, 6, 256], Distribution::Uniform(0.0, 1.0));
-        let rhs = Tensor::<TestBackend, 3>::random([2, 6, 256], Distribution::Uniform(0.0, 1.0));
-        let lhs_ref = Tensor::<ReferenceBackend, 3>::from_data(lhs.to_data());
-        let rhs_ref = Tensor::<ReferenceBackend, 3>::from_data(rhs.to_data());
+        let lhs =
+            Tensor::<TestBackend, 3>::random_default([2, 6, 256], Distribution::Uniform(0.0, 1.0));
+        let rhs =
+            Tensor::<TestBackend, 3>::random_default([2, 6, 256], Distribution::Uniform(0.0, 1.0));
+        let lhs_ref = Tensor::<ReferenceBackend, 3>::from_data_default(lhs.to_data());
+        let rhs_ref = Tensor::<ReferenceBackend, 3>::from_data_default(rhs.to_data());
 
         (lhs, rhs, lhs_ref, rhs_ref)
     }

--- a/burn-wgpu/src/kernel/comparison/elem.rs
+++ b/burn-wgpu/src/kernel/comparison/elem.rs
@@ -133,8 +133,9 @@ mod tests {
     #[allow(clippy::type_complexity)]
     fn inputs() -> (Tensor<TestBackend, 3>, Tensor<ReferenceBackend, 3>, f32) {
         TestBackend::seed(0);
-        let lhs = Tensor::<TestBackend, 3>::random([2, 6, 256], Distribution::Uniform(0.0, 1.0));
-        let lhs_ref = Tensor::<ReferenceBackend, 3>::from_data(lhs.to_data());
+        let lhs =
+            Tensor::<TestBackend, 3>::random_default([2, 6, 256], Distribution::Uniform(0.0, 1.0));
+        let lhs_ref = Tensor::<ReferenceBackend, 3>::from_data_default(lhs.to_data());
 
         (lhs, lhs_ref, 5.0)
     }

--- a/burn-wgpu/src/kernel/conv/conv2d.rs
+++ b/burn-wgpu/src/kernel/conv/conv2d.rs
@@ -90,12 +90,13 @@ mod tests {
 
     #[test]
     fn conv2d_should_work_with_multiple_invocations() {
-        let input = Tensor::<TestBackend, 4>::random([6, 16, 32, 32], Distribution::Default);
-        let weight = Tensor::<TestBackend, 4>::random([12, 8, 3, 3], Distribution::Default);
-        let bias = Tensor::<TestBackend, 1>::random([12], Distribution::Default);
-        let input_ref = Tensor::<ReferenceBackend, 4>::from_data(input.to_data());
-        let weight_ref = Tensor::<ReferenceBackend, 4>::from_data(weight.to_data());
-        let bias_ref = Tensor::<ReferenceBackend, 1>::from_data(bias.to_data());
+        let input =
+            Tensor::<TestBackend, 4>::random_default([6, 16, 32, 32], Distribution::Default);
+        let weight = Tensor::<TestBackend, 4>::random_default([12, 8, 3, 3], Distribution::Default);
+        let bias = Tensor::<TestBackend, 1>::random_default([12], Distribution::Default);
+        let input_ref = Tensor::<ReferenceBackend, 4>::from_data_default(input.to_data());
+        let weight_ref = Tensor::<ReferenceBackend, 4>::from_data_default(weight.to_data());
+        let bias_ref = Tensor::<ReferenceBackend, 1>::from_data_default(bias.to_data());
         let options = burn_tensor::ops::ConvOptions::new([2, 3], [2, 3], [2, 3], 2);
 
         let output = module::conv2d(input, weight, Some(bias), options.clone());

--- a/burn-wgpu/src/kernel/conv/conv_transpose2d.rs
+++ b/burn-wgpu/src/kernel/conv/conv_transpose2d.rs
@@ -92,11 +92,11 @@ mod tests {
         let options =
             burn_tensor::ops::ConvTransposeOptions::new([1, 1], [1, 1], [0, 0], [1, 1], 1);
 
-        let input = Tensor::<TestBackend, 4>::random(
+        let input = Tensor::<TestBackend, 4>::random_default(
             [batch_size, in_channels, height, width],
             Distribution::Default,
         );
-        let weight = Tensor::<TestBackend, 4>::random(
+        let weight = Tensor::<TestBackend, 4>::random_default(
             [
                 in_channels,
                 out_channels / options.groups,
@@ -105,10 +105,10 @@ mod tests {
             ],
             Distribution::Default,
         );
-        let bias = Tensor::<TestBackend, 1>::random([out_channels], Distribution::Default);
-        let input_ref = Tensor::<ReferenceBackend, 4>::from_data(input.to_data());
-        let weight_ref = Tensor::<ReferenceBackend, 4>::from_data(weight.to_data());
-        let bias_ref = Tensor::<ReferenceBackend, 1>::from_data(bias.to_data());
+        let bias = Tensor::<TestBackend, 1>::random_default([out_channels], Distribution::Default);
+        let input_ref = Tensor::<ReferenceBackend, 4>::from_data_default(input.to_data());
+        let weight_ref = Tensor::<ReferenceBackend, 4>::from_data_default(weight.to_data());
+        let bias_ref = Tensor::<ReferenceBackend, 1>::from_data_default(bias.to_data());
 
         let output = module::conv_transpose2d(input, weight, Some(bias), options.clone());
         let output_ref = module::conv_transpose2d(input_ref, weight_ref, Some(bias_ref), options);

--- a/burn-wgpu/src/kernel/index/gather.rs
+++ b/burn-wgpu/src/kernel/index/gather.rs
@@ -60,9 +60,9 @@ mod tests {
         TestBackend::seed(0);
         let max = shape[dim];
         let shape = Shape::new(shape);
-        let tensor = Tensor::<TestBackend, D>::random(shape.clone(), Distribution::Default);
-        let indices = Tensor::<TestBackend, 1, Int>::from_data(
-            Tensor::<TestBackend, 1>::random(
+        let tensor = Tensor::<TestBackend, D>::random_default(shape.clone(), Distribution::Default);
+        let indices = Tensor::<TestBackend, 1, Int>::from_data_default(
+            Tensor::<TestBackend, 1>::random_default(
                 [shape.num_elements()],
                 Distribution::Uniform(0., max as f32),
             )
@@ -70,9 +70,9 @@ mod tests {
             .convert(),
         )
         .reshape(shape);
-        let tensor_ref = Tensor::<ReferenceBackend, D>::from_data(tensor.to_data());
+        let tensor_ref = Tensor::<ReferenceBackend, D>::from_data_default(tensor.to_data());
         let indices_ref =
-            Tensor::<ReferenceBackend, D, Int>::from_data(indices.to_data().convert());
+            Tensor::<ReferenceBackend, D, Int>::from_data_default(indices.to_data().convert());
 
         let actual = Tensor::<TestBackend, D>::from_primitive(gather(
             dim,

--- a/burn-wgpu/src/kernel/index/scatter.rs
+++ b/burn-wgpu/src/kernel/index/scatter.rs
@@ -106,10 +106,10 @@ mod tests {
         shape2: [usize; D],
     ) {
         TestBackend::seed(0);
-        let tensor = Tensor::<TestBackend, D>::random(shape1, Distribution::Default);
-        let value = Tensor::<TestBackend, D>::random(shape2, Distribution::Default);
-        let indices = Tensor::<TestBackend, 1, Int>::from_data(
-            Tensor::<TestBackend, 1>::random(
+        let tensor = Tensor::<TestBackend, D>::random_default(shape1, Distribution::Default);
+        let value = Tensor::<TestBackend, D>::random_default(shape2, Distribution::Default);
+        let indices = Tensor::<TestBackend, 1, Int>::from_data_default(
+            Tensor::<TestBackend, 1>::random_default(
                 [shape2.iter().product()],
                 Distribution::Uniform(0., shape2[dim] as f32),
             )
@@ -117,10 +117,10 @@ mod tests {
             .convert(),
         )
         .reshape(shape2);
-        let tensor_ref = Tensor::<ReferenceBackend, D>::from_data(tensor.to_data());
-        let value_ref = Tensor::<ReferenceBackend, D>::from_data(value.to_data());
+        let tensor_ref = Tensor::<ReferenceBackend, D>::from_data_default(tensor.to_data());
+        let value_ref = Tensor::<ReferenceBackend, D>::from_data_default(value.to_data());
         let indices_ref =
-            Tensor::<ReferenceBackend, D, Int>::from_data(indices.to_data().convert());
+            Tensor::<ReferenceBackend, D, Int>::from_data_default(indices.to_data().convert());
 
         let actual = Tensor::<TestBackend, D>::from_primitive(scatter(
             dim,

--- a/burn-wgpu/src/kernel/index/select.rs
+++ b/burn-wgpu/src/kernel/index/select.rs
@@ -105,11 +105,11 @@ mod tests {
 
     #[test]
     fn select_should_work_with_multiple_workgroups() {
-        let tensor = Tensor::<TestBackend, 2>::random([6, 256], Distribution::Default);
-        let indices = Tensor::<TestBackend, 1, Int>::arange(0..100);
-        let tensor_ref = Tensor::<ReferenceBackend, 2>::from_data(tensor.to_data());
+        let tensor = Tensor::<TestBackend, 2>::random_default([6, 256], Distribution::Default);
+        let indices = Tensor::<TestBackend, 1, Int>::arange_default(0..100);
+        let tensor_ref = Tensor::<ReferenceBackend, 2>::from_data_default(tensor.to_data());
         let indices_ref =
-            Tensor::<ReferenceBackend, 1, Int>::from_data(indices.to_data().convert());
+            Tensor::<ReferenceBackend, 1, Int>::from_data_default(indices.to_data().convert());
 
         let actual = select(tensor.into_primitive(), 1, indices.into_primitive());
         let expected = tensor_ref.select(1, indices_ref);
@@ -147,20 +147,20 @@ mod tests {
 
     fn select_assign_same_as_ref<const D: usize>(dim: usize, shape: [usize; D]) {
         TestBackend::seed(0);
-        let tensor = Tensor::<TestBackend, D>::random(shape, Distribution::Default);
-        let value = Tensor::<TestBackend, D>::random(shape, Distribution::Default);
-        let indices = Tensor::<TestBackend, 1, Int>::from_data(
-            Tensor::<TestBackend, 1>::random(
+        let tensor = Tensor::<TestBackend, D>::random_default(shape, Distribution::Default);
+        let value = Tensor::<TestBackend, D>::random_default(shape, Distribution::Default);
+        let indices = Tensor::<TestBackend, 1, Int>::from_data_default(
+            Tensor::<TestBackend, 1>::random_default(
                 [shape[dim]],
                 Distribution::Uniform(0., shape[dim] as f32),
             )
             .into_data()
             .convert(),
         );
-        let tensor_ref = Tensor::<ReferenceBackend, D>::from_data(tensor.to_data());
-        let value_ref = Tensor::<ReferenceBackend, D>::from_data(value.to_data());
+        let tensor_ref = Tensor::<ReferenceBackend, D>::from_data_default(tensor.to_data());
+        let value_ref = Tensor::<ReferenceBackend, D>::from_data_default(value.to_data());
         let indices_ref =
-            Tensor::<ReferenceBackend, 1, Int>::from_data(indices.to_data().convert());
+            Tensor::<ReferenceBackend, 1, Int>::from_data_default(indices.to_data().convert());
 
         let actual = Tensor::<TestBackend, D>::from_primitive(select_assign(
             tensor.into_primitive(),

--- a/burn-wgpu/src/kernel/index/slice.rs
+++ b/burn-wgpu/src/kernel/index/slice.rs
@@ -96,9 +96,9 @@ mod tests {
 
     #[test]
     fn slice_should_work_with_multiple_workgroups() {
-        let tensor = Tensor::<TestBackend, 2>::random([6, 256], Distribution::Default);
+        let tensor = Tensor::<TestBackend, 2>::random_default([6, 256], Distribution::Default);
         let indices = [3..5, 45..256];
-        let tensor_ref = Tensor::<ReferenceBackend, 2>::from_data(tensor.to_data());
+        let tensor_ref = Tensor::<ReferenceBackend, 2>::from_data_default(tensor.to_data());
 
         let actual = slice(tensor.into_primitive(), indices.clone());
         let expected = tensor_ref.slice(indices);
@@ -111,11 +111,11 @@ mod tests {
 
     #[test]
     fn slice_assign_should_work_with_multiple_workgroups() {
-        let tensor = Tensor::<TestBackend, 2>::random([6, 256], Distribution::Default);
-        let value = Tensor::<TestBackend, 2>::random([2, 211], Distribution::Default);
+        let tensor = Tensor::<TestBackend, 2>::random_default([6, 256], Distribution::Default);
+        let value = Tensor::<TestBackend, 2>::random_default([2, 211], Distribution::Default);
         let indices = [3..5, 45..256];
-        let tensor_ref = Tensor::<ReferenceBackend, 2>::from_data(tensor.to_data());
-        let value_ref = Tensor::<ReferenceBackend, 2>::from_data(value.to_data());
+        let tensor_ref = Tensor::<ReferenceBackend, 2>::from_data_default(tensor.to_data());
+        let value_ref = Tensor::<ReferenceBackend, 2>::from_data_default(value.to_data());
 
         let actual = slice_assign(
             tensor.into_primitive(),

--- a/burn-wgpu/src/kernel/mask/mask_fill.rs
+++ b/burn-wgpu/src/kernel/mask/mask_fill.rs
@@ -111,11 +111,12 @@ mod tests {
         Tensor<ReferenceBackend, 3>,
         Tensor<ReferenceBackend, 3, Bool>,
     ) {
-        let tensor = Tensor::<TestBackend, 3>::random([2, 6, 256], Distribution::Default);
-        let mask = Tensor::<TestBackend, 3>::random([2, 6, 256], Distribution::Uniform(0., 1.))
-            .lower_equal_elem(0.5);
-        let tensor_ref = Tensor::<ReferenceBackend, 3>::from_data(tensor.to_data());
-        let mask_ref = Tensor::<ReferenceBackend, 3, Bool>::from_data(mask.to_data());
+        let tensor = Tensor::<TestBackend, 3>::random_default([2, 6, 256], Distribution::Default);
+        let mask =
+            Tensor::<TestBackend, 3>::random_default([2, 6, 256], Distribution::Uniform(0., 1.))
+                .lower_equal_elem(0.5);
+        let tensor_ref = Tensor::<ReferenceBackend, 3>::from_data_default(tensor.to_data());
+        let mask_ref = Tensor::<ReferenceBackend, 3, Bool>::from_data_default(mask.to_data());
 
         (tensor, mask, tensor_ref, mask_ref)
     }

--- a/burn-wgpu/src/kernel/mask/mask_where.rs
+++ b/burn-wgpu/src/kernel/mask/mask_where.rs
@@ -136,13 +136,14 @@ mod tests {
         Tensor<ReferenceBackend, 3, Bool>,
     ) {
         TestBackend::seed(0);
-        let tensor = Tensor::<TestBackend, 3>::random([2, 6, 256], Distribution::Default);
-        let value = Tensor::<TestBackend, 3>::random([2, 6, 256], Distribution::Default);
-        let mask = Tensor::<TestBackend, 3>::random([2, 6, 256], Distribution::Uniform(0., 1.))
-            .lower_equal_elem(0.5);
-        let tensor_ref = Tensor::<ReferenceBackend, 3>::from_data(tensor.to_data());
-        let value_ref = Tensor::<ReferenceBackend, 3>::from_data(value.to_data());
-        let mask_ref = Tensor::<ReferenceBackend, 3, Bool>::from_data(mask.to_data());
+        let tensor = Tensor::<TestBackend, 3>::random_default([2, 6, 256], Distribution::Default);
+        let value = Tensor::<TestBackend, 3>::random_default([2, 6, 256], Distribution::Default);
+        let mask =
+            Tensor::<TestBackend, 3>::random_default([2, 6, 256], Distribution::Uniform(0., 1.))
+                .lower_equal_elem(0.5);
+        let tensor_ref = Tensor::<ReferenceBackend, 3>::from_data_default(tensor.to_data());
+        let value_ref = Tensor::<ReferenceBackend, 3>::from_data_default(value.to_data());
+        let mask_ref = Tensor::<ReferenceBackend, 3, Bool>::from_data_default(mask.to_data());
         assert_eq!(mask.to_data(), mask_ref.to_data());
 
         (tensor, value, mask, tensor_ref, value_ref, mask_ref)

--- a/burn-wgpu/src/kernel/matmul/tiling2d/padding.rs
+++ b/burn-wgpu/src/kernel/matmul/tiling2d/padding.rs
@@ -108,7 +108,7 @@ mod tests {
         let row_divisor = 5;
         let col = 12;
         let col_divisor = 3;
-        let tensor = TestTensor::random([row, col], burn_tensor::Distribution::Default);
+        let tensor = TestTensor::random_default([row, col], burn_tensor::Distribution::Default);
         let expected_shape = [row, col].into();
 
         let padded = pad_round(tensor.into_primitive(), row_divisor, col_divisor).into_tensor();
@@ -122,7 +122,7 @@ mod tests {
         let row_divisor = 5;
         let col = 12;
         let col_divisor = 3;
-        let tensor = TestTensor::random([row, col], burn_tensor::Distribution::Default);
+        let tensor = TestTensor::random_default([row, col], burn_tensor::Distribution::Default);
 
         let padded = pad_round(tensor.clone().into_primitive(), row_divisor, col_divisor);
 
@@ -136,7 +136,7 @@ mod tests {
         let row_divisor = 6;
         let col = 12;
         let col_divisor = 5;
-        let tensor = TestTensor::random([row, col], burn_tensor::Distribution::Default);
+        let tensor = TestTensor::random_default([row, col], burn_tensor::Distribution::Default);
         let expected_shape = [12, 15].into();
 
         let padded = pad_round(tensor.into_primitive(), row_divisor, col_divisor).into_tensor();
@@ -150,7 +150,7 @@ mod tests {
         let row_divisor = 6;
         let col = 12;
         let col_divisor = 5;
-        let tensor = TestTensor::random([row, col], burn_tensor::Distribution::Default);
+        let tensor = TestTensor::random_default([row, col], burn_tensor::Distribution::Default);
 
         let padded =
             pad_round(tensor.clone().into_primitive(), row_divisor, col_divisor).into_tensor();
@@ -170,7 +170,7 @@ mod tests {
         let row_divisor = 6;
         let col = 12;
         let col_divisor = 5;
-        let tensor = TestTensor::random([row, col], burn_tensor::Distribution::Default);
+        let tensor = TestTensor::random_default([row, col], burn_tensor::Distribution::Default);
 
         let padded = pad_round(tensor.into_primitive(), row_divisor, col_divisor).into_tensor();
         let padded = TestTensor::from_primitive(padded).to_data();
@@ -195,7 +195,8 @@ mod tests {
         let row_divisor = 4;
         let col = 12;
         let col_divisor = 5;
-        let tensor = TestTensor::random([2, 3, row, col], burn_tensor::Distribution::Default);
+        let tensor =
+            TestTensor::random_default([2, 3, row, col], burn_tensor::Distribution::Default);
         let expected_shape = [2, 3, 12, 15].into();
 
         let padded = pad_round(tensor.into_primitive(), row_divisor, col_divisor).into_tensor();
@@ -209,7 +210,7 @@ mod tests {
         let row_divisor = 32;
         let col = 4;
         let col_divisor = 3;
-        let tensor = TestTensor::random([row, col], burn_tensor::Distribution::Default);
+        let tensor = TestTensor::random_default([row, col], burn_tensor::Distribution::Default);
         let expected_shape = [row_divisor, 2 * col_divisor].into();
 
         let padded = pad_round(tensor.into_primitive(), row_divisor, col_divisor).into_tensor();
@@ -223,7 +224,7 @@ mod tests {
         let row_divisor = 32;
         let col = 4;
         let col_divisor = 64;
-        let tensor = TestTensor::random([row, col], burn_tensor::Distribution::Default);
+        let tensor = TestTensor::random_default([row, col], burn_tensor::Distribution::Default);
         let expected_shape = [32, 64].into();
 
         let padded = pad_round(tensor.into_primitive(), row_divisor, col_divisor).into_tensor();
@@ -235,12 +236,12 @@ mod tests {
     fn crop_same_shape_should_be_unchanged_shape() {
         let row = 10;
         let col = 12;
-        let tensor = TestTensor::random([row, col], burn_tensor::Distribution::Default);
+        let tensor = TestTensor::random_default([row, col], burn_tensor::Distribution::Default);
         let expected_shape = [row, col].into();
 
         let unpadded = crop(
             tensor.clone().into_primitive(),
-            TestTensor::empty([row, col]).into_primitive(),
+            TestTensor::empty_default([row, col]).into_primitive(),
         );
 
         assert!(unpadded.shape == expected_shape);
@@ -250,11 +251,11 @@ mod tests {
     fn crop_same_shape_should_have_unchanged_values() {
         let row = 10;
         let col = 12;
-        let tensor = TestTensor::random([row, col], burn_tensor::Distribution::Default);
+        let tensor = TestTensor::random_default([row, col], burn_tensor::Distribution::Default);
 
         let unpadded = crop(
             tensor.clone().into_primitive(),
-            TestTensor::empty([row, col]).into_primitive(),
+            TestTensor::empty_default([row, col]).into_primitive(),
         );
 
         let unpadded = TestTensor::from_primitive(unpadded).to_data();
@@ -272,12 +273,12 @@ mod tests {
         let keep_rows = 8;
         let col = 12;
         let keep_cols = 10;
-        let tensor = TestTensor::random([row, col], burn_tensor::Distribution::Default);
+        let tensor = TestTensor::random_default([row, col], burn_tensor::Distribution::Default);
         let expected_shape = [keep_rows, keep_cols].into();
 
         let unpadded = crop(
             tensor.clone().into_primitive(),
-            TestTensor::empty([keep_rows, keep_cols]).into_primitive(),
+            TestTensor::empty_default([keep_rows, keep_cols]).into_primitive(),
         );
 
         assert!(unpadded.shape == expected_shape);
@@ -289,11 +290,11 @@ mod tests {
         let keep_rows = 3;
         let col = 4;
         let keep_cols = 3;
-        let tensor = TestTensor::random([row, col], burn_tensor::Distribution::Default);
+        let tensor = TestTensor::random_default([row, col], burn_tensor::Distribution::Default);
 
         let unpadded = crop(
             tensor.clone().into_primitive(),
-            TestTensor::empty([keep_rows, keep_cols]).into_primitive(),
+            TestTensor::empty_default([keep_rows, keep_cols]).into_primitive(),
         );
 
         let unpadded = TestTensor::from_primitive(unpadded).to_data();

--- a/burn-wgpu/src/kernel/matmul/utils.rs
+++ b/burn-wgpu/src/kernel/matmul/utils.rs
@@ -40,11 +40,17 @@ pub(crate) mod tests {
         F: Fn(WgpuTensor<f32, D>, WgpuTensor<f32, D>, WgpuTensor<f32, D>) -> WgpuTensor<f32, D>,
         S: Into<Shape<D>>,
     {
-        let x = ReferenceTensor::random(shape_lhs, burn_tensor::Distribution::Uniform(-1.0, 1.0));
-        let y = ReferenceTensor::random(shape_rhs, burn_tensor::Distribution::Uniform(-1.0, 1.0));
+        let x = ReferenceTensor::random_default(
+            shape_lhs,
+            burn_tensor::Distribution::Uniform(-1.0, 1.0),
+        );
+        let y = ReferenceTensor::random_default(
+            shape_rhs,
+            burn_tensor::Distribution::Uniform(-1.0, 1.0),
+        );
 
-        let x_wgpu = TestTensor::from_data(x.to_data()).into_primitive();
-        let y_wgpu = TestTensor::from_data(y.to_data()).into_primitive();
+        let x_wgpu = TestTensor::from_data_default(x.to_data()).into_primitive();
+        let y_wgpu = TestTensor::from_data_default(y.to_data()).into_primitive();
 
         let z_reference = x.matmul(y);
 
@@ -65,11 +71,17 @@ pub(crate) mod tests {
         F: Fn(WgpuTensor<f32, D>, WgpuTensor<f32, D>, WgpuTensor<f32, D>) -> WgpuTensor<f32, D>,
         S: Into<Shape<D>>,
     {
-        let x = ReferenceTensor::random(shape_lhs, burn_tensor::Distribution::Uniform(-1.0, 1.0));
-        let y = ReferenceTensor::random(shape_rhs, burn_tensor::Distribution::Uniform(-1.0, 1.0));
+        let x = ReferenceTensor::random_default(
+            shape_lhs,
+            burn_tensor::Distribution::Uniform(-1.0, 1.0),
+        );
+        let y = ReferenceTensor::random_default(
+            shape_rhs,
+            burn_tensor::Distribution::Uniform(-1.0, 1.0),
+        );
 
-        let x_wgpu = TestTensor::from_data(x.to_data()).swap_dims(swap_lhs[0], swap_lhs[1]);
-        let y_wgpu = TestTensor::from_data(y.to_data()).swap_dims(swap_rhs[0], swap_rhs[1]);
+        let x_wgpu = TestTensor::from_data_default(x.to_data()).swap_dims(swap_lhs[0], swap_lhs[1]);
+        let y_wgpu = TestTensor::from_data_default(y.to_data()).swap_dims(swap_rhs[0], swap_rhs[1]);
 
         let z_reference = x
             .swap_dims(swap_lhs[0], swap_lhs[1])

--- a/burn-wgpu/src/kernel/pool/avg_pool2d.rs
+++ b/burn-wgpu/src/kernel/pool/avg_pool2d.rs
@@ -107,8 +107,9 @@ mod tests {
 
     #[test]
     fn avg_pool2d_should_work_with_multiple_invocations() {
-        let tensor = Tensor::<TestBackend, 4>::random([32, 32, 32, 32], Distribution::Default);
-        let tensor_ref = Tensor::<ReferenceBackend, 4>::from_data(tensor.to_data());
+        let tensor =
+            Tensor::<TestBackend, 4>::random_default([32, 32, 32, 32], Distribution::Default);
+        let tensor_ref = Tensor::<ReferenceBackend, 4>::from_data_default(tensor.to_data());
         let kernel_size = [3, 4];
         let stride = [1, 2];
         let padding = [1, 2];
@@ -127,8 +128,9 @@ mod tests {
     fn avg_pool2d_backward_should_work_with_multiple_invocations() {
         TestBackend::seed(0);
         ReferenceBackend::seed(0);
-        let tensor = Tensor::<TestBackend, 4>::random([32, 32, 32, 32], Distribution::Default);
-        let tensor_ref = Tensor::<ReferenceBackend, 4>::from_data(tensor.to_data());
+        let tensor =
+            Tensor::<TestBackend, 4>::random_default([32, 32, 32, 32], Distribution::Default);
+        let tensor_ref = Tensor::<ReferenceBackend, 4>::from_data_default(tensor.to_data());
         let kernel_size = [3, 3];
         let stride = [1, 1];
         let padding = [1, 1];
@@ -142,8 +144,10 @@ mod tests {
             count_include_pad,
         )
         .shape();
-        let grad_output = Tensor::<TestBackend, 4>::random(shape_out, Distribution::Default);
-        let grad_output_ref = Tensor::<ReferenceBackend, 4>::from_data(grad_output.to_data());
+        let grad_output =
+            Tensor::<TestBackend, 4>::random_default(shape_out, Distribution::Default);
+        let grad_output_ref =
+            Tensor::<ReferenceBackend, 4>::from_data_default(grad_output.to_data());
 
         let grad: Tensor<TestBackend, 4> =
             Tensor::from_primitive(TestBackend::avg_pool2d_backward(

--- a/burn-wgpu/src/kernel/pool/max_pool2d.rs
+++ b/burn-wgpu/src/kernel/pool/max_pool2d.rs
@@ -108,8 +108,9 @@ mod tests {
 
     #[test]
     pub fn max_pool2d_should_work_with_multiple_invocations() {
-        let tensor = Tensor::<TestBackend, 4>::random([32, 32, 32, 32], Distribution::Default);
-        let tensor_ref = Tensor::<ReferenceBackend, 4>::from_data(tensor.to_data());
+        let tensor =
+            Tensor::<TestBackend, 4>::random_default([32, 32, 32, 32], Distribution::Default);
+        let tensor_ref = Tensor::<ReferenceBackend, 4>::from_data_default(tensor.to_data());
         let kernel_size = [3, 3];
         let stride = [2, 2];
         let padding = [1, 1];
@@ -125,8 +126,9 @@ mod tests {
 
     #[test]
     pub fn max_pool2d_with_indices_should_work_with_multiple_invocations() {
-        let tensor = Tensor::<TestBackend, 4>::random([32, 32, 32, 32], Distribution::Default);
-        let tensor_ref = Tensor::<ReferenceBackend, 4>::from_data(tensor.to_data());
+        let tensor =
+            Tensor::<TestBackend, 4>::random_default([32, 32, 32, 32], Distribution::Default);
+        let tensor_ref = Tensor::<ReferenceBackend, 4>::from_data_default(tensor.to_data());
         let kernel_size = [3, 3];
         let stride = [2, 2];
         let padding = [1, 1];
@@ -145,10 +147,13 @@ mod tests {
 
     #[test]
     pub fn max_pool2d_with_indices_backward_should_work_with_multiple_invocations() {
-        let tensor = Tensor::<TestBackend, 4>::random([32, 32, 32, 32], Distribution::Default);
-        let grad_output = Tensor::<TestBackend, 4>::random([32, 32, 16, 16], Distribution::Default);
-        let tensor_ref = Tensor::<ReferenceBackend, 4>::from_data(tensor.to_data());
-        let grad_output_ref = Tensor::<ReferenceBackend, 4>::from_data(grad_output.to_data());
+        let tensor =
+            Tensor::<TestBackend, 4>::random_default([32, 32, 32, 32], Distribution::Default);
+        let grad_output =
+            Tensor::<TestBackend, 4>::random_default([32, 32, 16, 16], Distribution::Default);
+        let tensor_ref = Tensor::<ReferenceBackend, 4>::from_data_default(tensor.to_data());
+        let grad_output_ref =
+            Tensor::<ReferenceBackend, 4>::from_data_default(grad_output.to_data());
         let kernel_size = [3, 3];
         let stride = [2, 2];
         let padding = [1, 1];

--- a/burn-wgpu/src/kernel/prng/bernoulli.rs
+++ b/burn-wgpu/src/kernel/prng/bernoulli.rs
@@ -68,16 +68,10 @@ mod tests {
         let shape: Shape<2> = [40, 40].into();
         let device = WgpuDevice::default();
 
-        let tensor_1 = Tensor::<TestBackend, 2>::random_device(
-            shape.clone(),
-            Distribution::Bernoulli(0.5),
-            &device,
-        );
-        let tensor_2 = Tensor::<TestBackend, 2>::random_device(
-            shape.clone(),
-            Distribution::Bernoulli(0.5),
-            &device,
-        );
+        let tensor_1 =
+            Tensor::<TestBackend, 2>::random(shape.clone(), Distribution::Bernoulli(0.5), &device);
+        let tensor_2 =
+            Tensor::<TestBackend, 2>::random(shape.clone(), Distribution::Bernoulli(0.5), &device);
         let mut diff_exists = false;
         for i in 0..shape.num_elements() {
             if tensor_1.to_data().value[i] != tensor_2.to_data().value[i] {
@@ -96,11 +90,8 @@ mod tests {
         let device = WgpuDevice::default();
         let prob = 0.7;
 
-        let tensor_1 = Tensor::<TestBackend, 2>::random_device(
-            shape.clone(),
-            Distribution::Bernoulli(prob),
-            &device,
-        );
+        let tensor_1 =
+            Tensor::<TestBackend, 2>::random(shape.clone(), Distribution::Bernoulli(prob), &device);
 
         // High bound slightly over 1 so 1.0 is included in second bin
         let bin_stats = calculate_bin_stats(tensor_1.into_data().value, 2, 0., 1.1);
@@ -116,8 +107,7 @@ mod tests {
         TestBackend::seed(0);
         let shape = Shape::new([512, 512]);
         let device = WgpuDevice::default();
-        let tensor =
-            Tensor::<TestBackend, 2>::random_device(shape, Distribution::Bernoulli(0.5), &device);
+        let tensor = Tensor::<TestBackend, 2>::random(shape, Distribution::Bernoulli(0.5), &device);
 
         let numbers = tensor.into_data().value;
         let stats = calculate_bin_stats(numbers, 2, 0., 1.1);

--- a/burn-wgpu/src/kernel/prng/normal.rs
+++ b/burn-wgpu/src/kernel/prng/normal.rs
@@ -72,9 +72,9 @@ mod tests {
         let device = WgpuDevice::default();
 
         let tensor_1 =
-            Tensor::<TestBackend, 2>::random_device(shape, Distribution::Normal(0., 1.), &device);
+            Tensor::<TestBackend, 2>::random(shape, Distribution::Normal(0., 1.), &device);
         let tensor_2 =
-            Tensor::<TestBackend, 2>::random_device(shape, Distribution::Normal(0., 1.), &device);
+            Tensor::<TestBackend, 2>::random(shape, Distribution::Normal(0., 1.), &device);
         for i in 0..20 {
             assert!(tensor_1.to_data().value[i] != tensor_2.to_data().value[i]);
         }
@@ -88,7 +88,7 @@ mod tests {
         let device = WgpuDevice::default();
         let mean = 10.;
         let tensor =
-            Tensor::<TestBackend, 2>::random_device(shape, Distribution::Normal(mean, 2.), &device);
+            Tensor::<TestBackend, 2>::random(shape, Distribution::Normal(mean, 2.), &device);
         let empirical_mean = tensor.mean().into_data();
         empirical_mean.assert_approx_eq(&Data::from([mean as f32]), 1);
     }
@@ -101,11 +101,8 @@ mod tests {
         let device = WgpuDevice::default();
         let mu = 0.;
         let s = 1.;
-        let tensor = Tensor::<TestBackend, 2>::random_device(
-            shape.clone(),
-            Distribution::Normal(mu, s),
-            &device,
-        );
+        let tensor =
+            Tensor::<TestBackend, 2>::random(shape.clone(), Distribution::Normal(mu, s), &device);
         let stats = calculate_bin_stats(
             tensor.into_data().value,
             6,

--- a/burn-wgpu/src/kernel/prng/uniform.rs
+++ b/burn-wgpu/src/kernel/prng/uniform.rs
@@ -93,10 +93,8 @@ mod tests {
         let shape = [4, 5];
         let device = WgpuDevice::default();
 
-        let tensor_1 =
-            Tensor::<TestBackend, 2>::random_device(shape, Distribution::Default, &device);
-        let tensor_2 =
-            Tensor::<TestBackend, 2>::random_device(shape, Distribution::Default, &device);
+        let tensor_1 = Tensor::<TestBackend, 2>::random(shape, Distribution::Default, &device);
+        let tensor_2 = Tensor::<TestBackend, 2>::random(shape, Distribution::Default, &device);
         for i in 0..20 {
             assert!(tensor_1.to_data().value[i] != tensor_2.to_data().value[i]);
         }
@@ -109,7 +107,7 @@ mod tests {
         let shape = [24, 24];
         let device = WgpuDevice::default();
 
-        let tensor = Tensor::<TestBackend, 2>::random_device(shape, Distribution::Default, &device);
+        let tensor = Tensor::<TestBackend, 2>::random(shape, Distribution::Default, &device);
         tensor.to_data().assert_within_range(0..1);
     }
 
@@ -121,7 +119,7 @@ mod tests {
         let device = WgpuDevice::default();
 
         let tensor =
-            Tensor::<TestBackend, 2>::random_device(shape, Distribution::Uniform(5., 17.), &device);
+            Tensor::<TestBackend, 2>::random(shape, Distribution::Uniform(5., 17.), &device);
         tensor.to_data().assert_within_range(5..17);
     }
 
@@ -132,11 +130,8 @@ mod tests {
         let shape = [64, 64];
         let device = WgpuDevice::default();
 
-        let tensor = Tensor::<TestBackend, 2>::random_device(
-            shape,
-            Distribution::Uniform(-5., 10.),
-            &device,
-        );
+        let tensor =
+            Tensor::<TestBackend, 2>::random(shape, Distribution::Uniform(-5., 10.), &device);
         let numbers = tensor.into_data().value;
         let stats = calculate_bin_stats(numbers, 3, -5., 10.);
         assert!(stats[0].count >= 1);
@@ -150,7 +145,7 @@ mod tests {
         TestBackend::seed(0);
         let shape = Shape::new([512, 512]);
         let device = WgpuDevice::default();
-        let tensor = Tensor::<TestBackend, 2>::random_device(shape, Distribution::Default, &device);
+        let tensor = Tensor::<TestBackend, 2>::random(shape, Distribution::Default, &device);
 
         let numbers = tensor.into_data().value;
         let stats = calculate_bin_stats(numbers, 2, 0., 1.);

--- a/burn-wgpu/src/kernel/reduction.rs
+++ b/burn-wgpu/src/kernel/reduction.rs
@@ -179,8 +179,8 @@ mod tests {
 
     #[test]
     fn reduction_sum_should_work_with_multiple_invocations() {
-        let tensor = Tensor::<TestBackend, 2>::random([6, 256], Distribution::Default);
-        let tensor_ref = Tensor::<ReferenceBackend, 2>::from_data(tensor.to_data());
+        let tensor = Tensor::<TestBackend, 2>::random_default([6, 256], Distribution::Default);
+        let tensor_ref = Tensor::<ReferenceBackend, 2>::from_data_default(tensor.to_data());
 
         let val = Tensor::<TestBackend, 1>::from_primitive(sum(tensor.into_primitive()));
         let val_ref = tensor_ref.sum();
@@ -190,8 +190,8 @@ mod tests {
 
     #[test]
     fn reduction_sum_dim_should_work_with_multiple_invocations() {
-        let tensor = Tensor::<TestBackend, 2>::random([6, 1024], Distribution::Default);
-        let tensor_ref = Tensor::<ReferenceBackend, 2>::from_data(tensor.to_data());
+        let tensor = Tensor::<TestBackend, 2>::random_default([6, 1024], Distribution::Default);
+        let tensor_ref = Tensor::<ReferenceBackend, 2>::from_data_default(tensor.to_data());
 
         let val = Tensor::<TestBackend, 2>::from_primitive(reduction_dim::<SumDim, f32, 2>(
             tensor.into_primitive(),
@@ -204,8 +204,8 @@ mod tests {
 
     #[test]
     fn reduction_args_dim_should_work_with_multiple_invocations() {
-        let tensor = Tensor::<TestBackend, 2>::random([6, 1024], Distribution::Default);
-        let tensor_ref = Tensor::<ReferenceBackend, 2>::from_data(tensor.to_data());
+        let tensor = Tensor::<TestBackend, 2>::random_default([6, 1024], Distribution::Default);
+        let tensor_ref = Tensor::<ReferenceBackend, 2>::from_data_default(tensor.to_data());
 
         let val = Tensor::<TestBackend, 2, Int>::from_primitive(argmax(tensor.into_primitive(), 1));
         let val_ref = tensor_ref.argmax(1);

--- a/burn-wgpu/src/kernel/unary.rs
+++ b/burn-wgpu/src/kernel/unary.rs
@@ -159,8 +159,8 @@ mod tests {
 
     #[test]
     fn unary_should_work_with_multiple_invocations() {
-        let tensor = Tensor::<TestBackend, 2>::random([6, 256], Distribution::Default);
-        let tensor_ref = Tensor::<ReferenceBackend, 2>::from_data(tensor.to_data());
+        let tensor = Tensor::<TestBackend, 2>::random_default([6, 256], Distribution::Default);
+        let tensor_ref = Tensor::<ReferenceBackend, 2>::from_data_default(tensor.to_data());
 
         let actual = unary::<TestKernel, _, 2, 16>(tensor.into_primitive());
         let expected = tensor_ref.log();
@@ -173,8 +173,8 @@ mod tests {
 
     #[test]
     fn unary_inplace_should_work_with_multiple_invocations() {
-        let tensor = Tensor::<TestBackend, 2>::random([6, 256], Distribution::Default);
-        let tensor_ref = Tensor::<ReferenceBackend, 2>::from_data(tensor.to_data());
+        let tensor = Tensor::<TestBackend, 2>::random_default([6, 256], Distribution::Default);
+        let tensor_ref = Tensor::<ReferenceBackend, 2>::from_data_default(tensor.to_data());
 
         let actual = unary_inplace::<TestKernelInplace, _, 2, 16>(tensor.into_primitive());
         let expected = tensor_ref.log();
@@ -188,7 +188,7 @@ mod tests {
     #[test]
     fn tanh_should_not_have_numerical_bugs_on_macos() {
         fn tanh_one_value(input: f32) -> f32 {
-            let tensor = Tensor::<TestBackend, 1>::ones([1]) * input;
+            let tensor = Tensor::<TestBackend, 1>::ones_default([1]) * input;
             let output = tensor.tanh().into_primitive();
             Tensor::<TestBackend, 1>::from_primitive(output)
                 .into_data()

--- a/burn-wgpu/src/kernel/unary_scalar.rs
+++ b/burn-wgpu/src/kernel/unary_scalar.rs
@@ -191,8 +191,8 @@ mod tests {
 
     #[test]
     fn unary_scalar_should_work_with_multiple_invocations() {
-        let tensor = Tensor::<TestBackend, 2>::random([6, 256], Distribution::Default);
-        let tensor_ref = Tensor::<ReferenceBackend, 2>::from_data(tensor.to_data());
+        let tensor = Tensor::<TestBackend, 2>::random_default([6, 256], Distribution::Default);
+        let tensor_ref = Tensor::<ReferenceBackend, 2>::from_data_default(tensor.to_data());
 
         let actual = unary_scalar::<TestKernel, _, 2, 16>(tensor.into_primitive(), 5.0);
         let expected = tensor_ref.mul_scalar(5.0);
@@ -205,8 +205,8 @@ mod tests {
 
     #[test]
     fn unary_scalar_inplace_should_work_with_multiple_invocations() {
-        let tensor = Tensor::<TestBackend, 2>::random([6, 256], Distribution::Default);
-        let tensor_ref = Tensor::<ReferenceBackend, 2>::from_data(tensor.to_data());
+        let tensor = Tensor::<TestBackend, 2>::random_default([6, 256], Distribution::Default);
+        let tensor_ref = Tensor::<ReferenceBackend, 2>::from_data_default(tensor.to_data());
 
         let actual =
             unary_scalar_inplace::<TestKernelInplace, _, 2, 16>(tensor.into_primitive(), 5.0);

--- a/examples/custom-renderer/src/lib.rs
+++ b/examples/custom-renderer/src/lib.rs
@@ -48,7 +48,7 @@ pub fn run<B: AutodiffBackend>(device: B::Device) {
     B::seed(config.seed);
 
     // Create the model and optimizer.
-    let model = config.model.init();
+    let model = config.model.init(&device);
     let optim = config.optimizer.init();
 
     // Create the batcher.

--- a/examples/custom-training-loop/src/lib.rs
+++ b/examples/custom-training-loop/src/lib.rs
@@ -42,7 +42,7 @@ pub fn run<B: AutodiffBackend>(device: B::Device) {
     B::seed(config.seed);
 
     // Create the model and optimizer.
-    let mut model = config.model.init();
+    let mut model = config.model.init(&device);
     let mut optim = config.optimizer.init();
 
     // Create the batcher.

--- a/examples/custom-wgpu-kernel/examples/custom-wgpu-kernel.rs
+++ b/examples/custom-wgpu-kernel/examples/custom-wgpu-kernel.rs
@@ -4,9 +4,9 @@ use custom_wgpu_kernel::{
 };
 
 fn inference<B: Backend>() {
-    let lhs = Tensor::<B, 3>::random([1, 32, 32], Distribution::Default);
-    let rhs = Tensor::random([32, 32, 32], Distribution::Default);
-    let bias = Tensor::random([32, 32, 32], Distribution::Default);
+    let lhs = Tensor::<B, 3>::random_default([1, 32, 32], Distribution::Default);
+    let rhs = Tensor::random_default([32, 32, 32], Distribution::Default);
+    let bias = Tensor::random_default([32, 32, 32], Distribution::Default);
 
     let reference = matmul_add_relu_reference(lhs.clone(), rhs.clone(), bias.clone())
         .into_data()
@@ -21,9 +21,9 @@ fn inference<B: Backend>() {
 }
 
 fn autodiff<B: AutodiffBackend>() {
-    let lhs = Tensor::<B, 3>::random([1, 32, 32], Distribution::Default).require_grad();
-    let rhs = Tensor::random([32, 32, 32], Distribution::Default).require_grad();
-    let bias = Tensor::random([32, 32, 32], Distribution::Default).require_grad();
+    let lhs = Tensor::<B, 3>::random_default([1, 32, 32], Distribution::Default).require_grad();
+    let rhs = Tensor::random_default([32, 32, 32], Distribution::Default).require_grad();
+    let bias = Tensor::random_default([32, 32, 32], Distribution::Default).require_grad();
 
     let reference = matmul_add_relu_reference(lhs.clone(), rhs.clone(), bias.clone());
 

--- a/examples/guide/src/data.rs
+++ b/examples/guide/src/data.rs
@@ -24,7 +24,7 @@ impl<B: Backend> Batcher<MNISTItem, MNISTBatch<B>> for MNISTBatcher<B> {
         let images = items
             .iter()
             .map(|item| Data::<f32, 2>::from(item.image))
-            .map(|data| Tensor::<B, 2>::from_data(data.convert()))
+            .map(|data| Tensor::<B, 2>::from_data_default(data.convert()))
             .map(|tensor| tensor.reshape([1, 28, 28]))
             // normalize: make between [0,1] and make the mean =  0 and std = 1
             // values mean=0.1307,std=0.3081 were copied from Pytorch Mist Example
@@ -34,7 +34,7 @@ impl<B: Backend> Batcher<MNISTItem, MNISTBatch<B>> for MNISTBatcher<B> {
 
         let targets = items
             .iter()
-            .map(|item| Tensor::<B, 1, Int>::from_data([(item.label as i64).elem()]))
+            .map(|item| Tensor::<B, 1, Int>::from_data_default([(item.label as i64).elem()]))
             .collect();
 
         let images = Tensor::cat(images, 0).to_device(&self.device);

--- a/examples/guide/src/model.rs
+++ b/examples/guide/src/model.rs
@@ -30,14 +30,14 @@ pub struct ModelConfig {
 
 impl ModelConfig {
     /// Returns the initialized model.
-    pub fn init<B: Backend>(&self) -> Model<B> {
+    pub fn init<B: Backend>(&self, device: &B::Device) -> Model<B> {
         Model {
-            conv1: Conv2dConfig::new([1, 8], [3, 3]).init(),
-            conv2: Conv2dConfig::new([8, 16], [3, 3]).init(),
+            conv1: Conv2dConfig::new([1, 8], [3, 3]).init(device),
+            conv2: Conv2dConfig::new([8, 16], [3, 3]).init(device),
             pool: AdaptiveAvgPool2dConfig::new([8, 8]).init(),
             activation: ReLU::new(),
-            linear1: LinearConfig::new(16 * 8 * 8, self.hidden_size).init(),
-            linear2: LinearConfig::new(self.hidden_size, self.num_classes).init(),
+            linear1: LinearConfig::new(16 * 8 * 8, self.hidden_size).init(device),
+            linear2: LinearConfig::new(self.hidden_size, self.num_classes).init(device),
             dropout: DropoutConfig::new(self.dropout).init(),
         }
     }

--- a/examples/guide/src/training.rs
+++ b/examples/guide/src/training.rs
@@ -93,10 +93,10 @@ pub fn train<B: AutodiffBackend>(artifact_dir: &str, config: TrainingConfig, dev
         .metric_train_numeric(LossMetric::new())
         .metric_valid_numeric(LossMetric::new())
         .with_file_checkpointer(CompactRecorder::new())
-        .devices(vec![device])
+        .devices(vec![device.clone()])
         .num_epochs(config.num_epochs)
         .build(
-            config.model.init::<B>(),
+            config.model.init::<B>(&device),
             config.optimizer.init(),
             config.learning_rate,
         );

--- a/examples/image-classification-web/src/model/normalizer.rs
+++ b/examples/image-classification-web/src/model/normalizer.rs
@@ -14,8 +14,8 @@ pub struct Normalizer<B: Backend> {
 impl<B: Backend> Normalizer<B> {
     /// Creates a new normalizer.
     pub fn new() -> Self {
-        let mean = Tensor::from_floats(MEAN).reshape([1, 3, 1, 1]);
-        let std = Tensor::from_floats(STD).reshape([1, 3, 1, 1]);
+        let mean = Tensor::from_floats_default(MEAN).reshape([1, 3, 1, 1]);
+        let std = Tensor::from_floats_default(STD).reshape([1, 3, 1, 1]);
         Self { mean, std }
     }
 

--- a/examples/image-classification-web/src/web.rs
+++ b/examples/image-classification-web/src/web.rs
@@ -135,7 +135,7 @@ impl<B: Backend> Model<B> {
     /// Normalizes input and runs inference on the image
     pub async fn forward(&self, input: &[f32]) -> Vec<f32> {
         // Reshape from the 1D array to 3d tensor [ width, height, channels]
-        let input: Tensor<B, 4> = Tensor::from_floats(input).reshape([1, CHANNELS, HEIGHT, WIDTH]);
+        let input: Tensor<B, 4> = Tensor::from_floats_default(input).reshape([1, CHANNELS, HEIGHT, WIDTH]);
 
         // Normalize input: make between [-1,1] and make the mean=0 and std=1
         let input = self.normalizer.normalize(input);

--- a/examples/image-classification-web/src/web.rs
+++ b/examples/image-classification-web/src/web.rs
@@ -135,7 +135,8 @@ impl<B: Backend> Model<B> {
     /// Normalizes input and runs inference on the image
     pub async fn forward(&self, input: &[f32]) -> Vec<f32> {
         // Reshape from the 1D array to 3d tensor [ width, height, channels]
-        let input: Tensor<B, 4> = Tensor::from_floats_default(input).reshape([1, CHANNELS, HEIGHT, WIDTH]);
+        let input: Tensor<B, 4> =
+            Tensor::from_floats_default(input).reshape([1, CHANNELS, HEIGHT, WIDTH]);
 
         // Normalize input: make between [-1,1] and make the mean=0 and std=1
         let input = self.normalizer.normalize(input);

--- a/examples/mnist-inference-web/src/model.rs
+++ b/examples/mnist-inference-web/src/model.rs
@@ -22,17 +22,17 @@ pub struct Model<B: Backend> {
 const NUM_CLASSES: usize = 10;
 
 impl<B: Backend> Model<B> {
-    pub fn new() -> Self {
-        let conv1 = ConvBlock::new([1, 8], [3, 3]); // out: [Batch,8,26,26]
-        let conv2 = ConvBlock::new([8, 16], [3, 3]); // out: [Batch,16,24x24]
-        let conv3 = ConvBlock::new([16, 24], [3, 3]); // out: [Batch,24,22x22]
+    pub fn new(device: &B::Device) -> Self {
+        let conv1 = ConvBlock::new([1, 8], [3, 3], device); // out: [Batch,8,26,26]
+        let conv2 = ConvBlock::new([8, 16], [3, 3], device); // out: [Batch,16,24x24]
+        let conv3 = ConvBlock::new([16, 24], [3, 3], device); // out: [Batch,24,22x22]
         let hidden_size = 24 * 22 * 22;
         let fc1 = nn::LinearConfig::new(hidden_size, 32)
             .with_bias(false)
-            .init();
+            .init(device);
         let fc2 = nn::LinearConfig::new(32, NUM_CLASSES)
             .with_bias(false)
-            .init();
+            .init(device);
 
         let dropout = nn::DropoutConfig::new(0.5).init();
 
@@ -74,11 +74,11 @@ pub struct ConvBlock<B: Backend> {
 }
 
 impl<B: Backend> ConvBlock<B> {
-    pub fn new(channels: [usize; 2], kernel_size: [usize; 2]) -> Self {
+    pub fn new(channels: [usize; 2], kernel_size: [usize; 2], device: &B::Device) -> Self {
         let conv = nn::conv::Conv2dConfig::new(channels, kernel_size)
             .with_padding(PaddingConfig2d::Valid)
-            .init();
-        let norm = nn::BatchNormConfig::new(channels[1]).init();
+            .init(device);
+        let norm = nn::BatchNormConfig::new(channels[1]).init(device);
 
         Self {
             conv,

--- a/examples/mnist-inference-web/src/state.rs
+++ b/examples/mnist-inference-web/src/state.rs
@@ -1,4 +1,5 @@
 use crate::model::Model;
+use burn::backend::wgpu::WgpuDevice;
 use burn::module::Module;
 use burn::record::BinBytesRecorder;
 use burn::record::FullPrecisionSettings;
@@ -20,7 +21,7 @@ pub async fn build_and_load_model() -> Model<Backend> {
     #[cfg(feature = "wgpu")]
     init_async::<AutoGraphicsApi>(&WgpuDevice::default()).await;
 
-    let model: Model<Backend> = Model::new();
+    let model: Model<Backend> = Model::new(&Default::default());
     let record = BinBytesRecorder::<FullPrecisionSettings>::default()
         .load(STATE_ENCODED.to_vec())
         .expect("Failed to decode state");

--- a/examples/mnist-inference-web/src/web.rs
+++ b/examples/mnist-inference-web/src/web.rs
@@ -46,7 +46,7 @@ impl Mnist {
         let model = self.model.as_ref().unwrap();
 
         // Reshape from the 1D array to 3d tensor [batch, height, width]
-        let input: Tensor<Backend, 3> = Tensor::from_floats(input).reshape([1, 28, 28]);
+        let input: Tensor<Backend, 3> = Tensor::from_floats_default(input).reshape([1, 28, 28]);
 
         // Normalize input: make between [0,1] and make the mean=0 and std=1
         // values mean=0.1307,std=0.3081 were copied from Pytorch Mist Example

--- a/examples/mnist/src/data.rs
+++ b/examples/mnist/src/data.rs
@@ -34,7 +34,9 @@ impl<B: Backend> Batcher<MNISTItem, MNISTBatch<B>> for MNISTBatcher<B> {
 
         let targets = items
             .iter()
-            .map(|item| Tensor::<B, 1, Int>::from_data_default(Data::from([(item.label as i64).elem()])))
+            .map(|item| {
+                Tensor::<B, 1, Int>::from_data_default(Data::from([(item.label as i64).elem()]))
+            })
             .collect();
 
         let images = Tensor::cat(images, 0).to_device(&self.device);

--- a/examples/mnist/src/data.rs
+++ b/examples/mnist/src/data.rs
@@ -24,7 +24,7 @@ impl<B: Backend> Batcher<MNISTItem, MNISTBatch<B>> for MNISTBatcher<B> {
         let images = items
             .iter()
             .map(|item| Data::<f32, 2>::from(item.image))
-            .map(|data| Tensor::<B, 2>::from_data(data.convert()))
+            .map(|data| Tensor::<B, 2>::from_data_default(data.convert()))
             .map(|tensor| tensor.reshape([1, 28, 28]))
             // normalize: make between [0,1] and make the mean =  0 and std = 1
             // values mean=0.1307,std=0.3081 were copied from Pytorch Mist Example
@@ -34,7 +34,7 @@ impl<B: Backend> Batcher<MNISTItem, MNISTBatch<B>> for MNISTBatcher<B> {
 
         let targets = items
             .iter()
-            .map(|item| Tensor::<B, 1, Int>::from_data(Data::from([(item.label as i64).elem()])))
+            .map(|item| Tensor::<B, 1, Int>::from_data_default(Data::from([(item.label as i64).elem()])))
             .collect();
 
         let images = Tensor::cat(images, 0).to_device(&self.device);

--- a/examples/mnist/src/model.rs
+++ b/examples/mnist/src/model.rs
@@ -22,24 +22,25 @@ pub struct Model<B: Backend> {
 
 impl<B: Backend> Default for Model<B> {
     fn default() -> Self {
-        Self::new()
+        let device = B::Device::default();
+        Self::new(&device)
     }
 }
 
 const NUM_CLASSES: usize = 10;
 
 impl<B: Backend> Model<B> {
-    pub fn new() -> Self {
-        let conv1 = ConvBlock::new([1, 8], [3, 3]); // out: [Batch,8,26,26]
-        let conv2 = ConvBlock::new([8, 16], [3, 3]); // out: [Batch,16,24x24]
-        let conv3 = ConvBlock::new([16, 24], [3, 3]); // out: [Batch,24,22x22]
+    pub fn new(device: &B::Device) -> Self {
+        let conv1 = ConvBlock::new([1, 8], [3, 3], device); // out: [Batch,8,26,26]
+        let conv2 = ConvBlock::new([8, 16], [3, 3], device); // out: [Batch,16,24x24]
+        let conv3 = ConvBlock::new([16, 24], [3, 3], device); // out: [Batch,24,22x22]
         let hidden_size = 24 * 22 * 22;
         let fc1 = nn::LinearConfig::new(hidden_size, 32)
             .with_bias(false)
-            .init();
+            .init(device);
         let fc2 = nn::LinearConfig::new(32, NUM_CLASSES)
             .with_bias(false)
-            .init();
+            .init(device);
 
         let dropout = nn::DropoutConfig::new(0.5).init();
 
@@ -94,11 +95,11 @@ pub struct ConvBlock<B: Backend> {
 }
 
 impl<B: Backend> ConvBlock<B> {
-    pub fn new(channels: [usize; 2], kernel_size: [usize; 2]) -> Self {
+    pub fn new(channels: [usize; 2], kernel_size: [usize; 2], device: &B::Device) -> Self {
         let conv = nn::conv::Conv2dConfig::new(channels, kernel_size)
             .with_padding(PaddingConfig2d::Valid)
-            .init();
-        let norm = nn::BatchNormConfig::new(channels[1]).init();
+            .init(device);
+        let norm = nn::BatchNormConfig::new(channels[1]).init(device);
 
         Self {
             conv,

--- a/examples/mnist/src/training.rs
+++ b/examples/mnist/src/training.rs
@@ -77,9 +77,9 @@ pub fn run<B: AutodiffBackend>(device: B::Device) {
             Split::Valid,
             StoppingCondition::NoImprovementSince { n_epochs: 1 },
         ))
-        .devices(vec![device])
+        .devices(vec![device.clone()])
         .num_epochs(config.num_epochs)
-        .build(Model::new(), config.optimizer.init(), 1e-4);
+        .build(Model::new(&device), config.optimizer.init(), 1e-4);
 
     let model_trained = learner.fit(dataloader_train, dataloader_test);
 

--- a/examples/named-tensor/src/lib.rs
+++ b/examples/named-tensor/src/lib.rs
@@ -10,12 +10,12 @@ pub fn run<B: Backend>() {
     let seq_length = 48;
     let d_model = 24;
 
-    let weights = NamedTensor::<B, (Batch, DModel, DModel)>::random(
+    let weights = NamedTensor::<B, (Batch, DModel, DModel)>::random_default(
         [1, d_model, d_model],
         Distribution::Default,
     );
 
-    let input = NamedTensor::<B, (Batch, SeqLength, DModel)>::random(
+    let input = NamedTensor::<B, (Batch, SeqLength, DModel)>::random_default(
         [batch_size, seq_length, d_model],
         Distribution::Default,
     );

--- a/examples/notebook/basic-tensor-op.ipynb
+++ b/examples/notebook/basic-tensor-op.ipynb
@@ -97,7 +97,7 @@
     "println!(\"Empty tensor: {}\", tensor);\n",
     "\n",
     "// Create a tensor from a slice of floats\n",
-    "let tensor: Tensor<B, 2> = Tensor::from_floats([1.0, 2.0, 3.0, 4.0]).reshape([2, 2]);\n",
+    "let tensor: Tensor<B, 2> = Tensor::from_floats_default([1.0, 2.0, 3.0, 4.0]).reshape([2, 2]);\n",
     "println!(\"Tensor from slice: {}\", tensor);\n",
     "\n",
     "// Create a random tensor\n",
@@ -108,7 +108,7 @@
     "// Create a tensor using fill values, zeros, or ones\n",
     "let tensor: Tensor<B,2> = Tensor::full([2, 2], 7.0);\n",
     "let tensor: Tensor<B,2> = Tensor::zeros([2, 2]);\n",
-    "let tensor: Tensor<B,2> = Tensor::ones([2, 2]);\n"
+    "let tensor: Tensor<B,2> = Tensor::ones_default([2, 2]);\n"
    ]
   },
   {
@@ -143,7 +143,7 @@
     }
    ],
    "source": [
-    "let x1: Tensor<B,2> = Tensor::ones([2, 2]);\n",
+    "let x1: Tensor<B,2> = Tensor::ones_default([2, 2]);\n",
     "let x2: Tensor<B,2> = Tensor::full([2, 2], 7.0);\n",
     "\n",
     "let x3 = x1 + x2;\n",

--- a/examples/onnx-inference/README.md
+++ b/examples/onnx-inference/README.md
@@ -77,7 +77,7 @@ https://datasets-server.huggingface.co/assets/mnist/--/mnist/test/15/image/image
        let model: Model<Backend> = Model::new().load_state();
 
        // Create a new input tensor (all zeros for demonstration purposes)
-       let input = tensor::Tensor::<NdArray<f32>, 4>::zeros([1, 1, 28, 28]);
+       let input = tensor::Tensor::<NdArray<f32>, 4>::zeros_default([1, 1, 28, 28]);
 
        // Run the model
        let output = model.forward(input);

--- a/examples/onnx-inference/src/bin/mnist_inference.rs
+++ b/examples/onnx-inference/src/bin/mnist_inference.rs
@@ -37,7 +37,7 @@ fn main() {
     // Create a tensor from the image data
     let image_data = item.image.iter().copied().flatten().collect::<Vec<f32>>();
     let mut input: Tensor<Backend, 4> =
-        Tensor::from_floats(image_data.as_slice()).reshape([1, 1, 28, 28]);
+        Tensor::from_floats_default(image_data.as_slice()).reshape([1, 1, 28, 28]);
 
     // Normalize the input
     input = ((input / 255) - 0.1307) / 0.3081;

--- a/examples/text-classification/src/data/batcher.rs
+++ b/examples/text-classification/src/data/batcher.rs
@@ -53,7 +53,9 @@ impl<B: Backend> Batcher<TextClassificationItem, TextClassificationTrainingBatch
         // Tokenize text and create label tensor for each item
         for item in items {
             tokens_list.push(self.tokenizer.encode(&item.text));
-            labels_list.push(Tensor::from_data_default(Data::from([(item.label as i64).elem()])));
+            labels_list.push(Tensor::from_data_default(Data::from([
+                (item.label as i64).elem()
+            ])));
         }
 
         // Generate padding mask for tokenized text

--- a/examples/text-classification/src/data/batcher.rs
+++ b/examples/text-classification/src/data/batcher.rs
@@ -53,7 +53,7 @@ impl<B: Backend> Batcher<TextClassificationItem, TextClassificationTrainingBatch
         // Tokenize text and create label tensor for each item
         for item in items {
             tokens_list.push(self.tokenizer.encode(&item.text));
-            labels_list.push(Tensor::from_data(Data::from([(item.label as i64).elem()])));
+            labels_list.push(Tensor::from_data_default(Data::from([(item.label as i64).elem()])));
         }
 
         // Generate padding mask for tokenized text

--- a/examples/text-classification/src/model.rs
+++ b/examples/text-classification/src/model.rs
@@ -40,13 +40,13 @@ pub struct TextClassificationModel<B: Backend> {
 // Define functions for model initialization
 impl TextClassificationModelConfig {
     /// Initializes a model with default weights
-    pub fn init<B: Backend>(&self) -> TextClassificationModel<B> {
-        let output = LinearConfig::new(self.transformer.d_model, self.n_classes).init();
-        let transformer = self.transformer.init();
+    pub fn init<B: Backend>(&self, device: &B::Device) -> TextClassificationModel<B> {
+        let output = LinearConfig::new(self.transformer.d_model, self.n_classes).init(device);
+        let transformer = self.transformer.init(device);
         let embedding_token =
-            EmbeddingConfig::new(self.vocab_size, self.transformer.d_model).init();
+            EmbeddingConfig::new(self.vocab_size, self.transformer.d_model).init(device);
         let embedding_pos =
-            EmbeddingConfig::new(self.max_seq_length, self.transformer.d_model).init();
+            EmbeddingConfig::new(self.max_seq_length, self.transformer.d_model).init(device);
 
         TextClassificationModel {
             transformer,

--- a/examples/text-classification/src/model.rs
+++ b/examples/text-classification/src/model.rs
@@ -96,7 +96,7 @@ impl<B: Backend> TextClassificationModel<B> {
         let mask_pad = item.mask_pad.to_device(device);
 
         // Calculate token and position embeddings, and combine them
-        let index_positions = Tensor::arange_device(0..seq_length, device)
+        let index_positions = Tensor::arange(0..seq_length, device)
             .reshape([1, seq_length])
             .repeat(0, batch_size);
         let embedding_positions = self.embedding_pos.forward(index_positions);
@@ -135,7 +135,7 @@ impl<B: Backend> TextClassificationModel<B> {
         let mask_pad = item.mask_pad.to_device(device);
 
         // Calculate token and position embeddings, and combine them
-        let index_positions = Tensor::arange_device(0..seq_length, device)
+        let index_positions = Tensor::arange(0..seq_length, device)
             .reshape([1, seq_length])
             .repeat(0, batch_size);
         let embedding_positions = self.embedding_pos.forward(index_positions);

--- a/examples/text-classification/src/training.rs
+++ b/examples/text-classification/src/training.rs
@@ -68,7 +68,7 @@ pub fn train<B: AutodiffBackend, D: TextClassificationDataset + 'static>(
         tokenizer.vocab_size(),
         config.max_seq_length,
     )
-    .init();
+    .init(&device);
 
     // Initialize data loaders for training and testing data
     let dataloader_train = DataLoaderBuilder::new(batcher_train)

--- a/examples/text-generation/src/model.rs
+++ b/examples/text-generation/src/model.rs
@@ -64,7 +64,7 @@ impl<B: Backend> TextGenerationModel<B> {
         let targets = item.targets.to_device(device);
         let mask_pad = item.mask_pad.to_device(device);
 
-        let index_positions = Tensor::arange_device(0..seq_length, device)
+        let index_positions = Tensor::arange(0..seq_length, device)
             .reshape([1, seq_length])
             .repeat(0, batch_size);
 

--- a/examples/text-generation/src/model.rs
+++ b/examples/text-generation/src/model.rs
@@ -33,13 +33,13 @@ pub struct TextGenerationModel<B: Backend> {
 }
 
 impl TextGenerationModelConfig {
-    pub fn init<B: Backend>(&self) -> TextGenerationModel<B> {
-        let output = LinearConfig::new(self.transformer.d_model, self.vocab_size).init();
-        let transformer = self.transformer.init();
+    pub fn init<B: Backend>(&self, device: &B::Device) -> TextGenerationModel<B> {
+        let output = LinearConfig::new(self.transformer.d_model, self.vocab_size).init(device);
+        let transformer = self.transformer.init(device);
         let embedding_token =
-            EmbeddingConfig::new(self.vocab_size, self.transformer.d_model).init();
+            EmbeddingConfig::new(self.vocab_size, self.transformer.d_model).init(device);
         let embedding_pos =
-            EmbeddingConfig::new(self.max_seq_length, self.transformer.d_model).init();
+            EmbeddingConfig::new(self.max_seq_length, self.transformer.d_model).init(device);
 
         TextGenerationModel {
             transformer,

--- a/examples/text-generation/src/training.rs
+++ b/examples/text-generation/src/training.rs
@@ -48,7 +48,7 @@ pub fn train<B: AutodiffBackend, D: Dataset<TextGenerationItem> + 'static>(
         tokenizer.pad_token(),
         config.max_seq_length,
     )
-    .init::<B>();
+    .init::<B>(&device);
 
     let dataloader_train = DataLoaderBuilder::new(batcher_train)
         .batch_size(config.batch_size)


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [X] Confirmed that `run-checks all` script has been executed.
- [X] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Covers renaming and related refactoring described in https://github.com/tracel-ai/burn/issues/518

### Changes

Allows for explicit creation of tensors on specific devices. All public interfaces (of layers, models, etc.) have been refactored accordingly, and now allow to specify a `Backend::Device` during initialization. Onnx macroses support generation of device-aware models too.

### Testing

All the tests I could run are passing, including

- `cargo test`
- `./run-checks.sh std`
- `./run-checks.sh no-std`
- `./run-checks.sh typos`
- `./run-checks.sh examples`
