### PR TITLE
fix multithread progress aggregation in dataloader

### DIFF
--- a/burn-core/src/data/dataloader/base.rs
+++ b/burn-core/src/data/dataloader/base.rs
@@ -2,7 +2,7 @@ pub use crate::data::dataset::{Dataset, DatasetIterator};
 use core::iter::Iterator;
 
 /// A progress struct that can be used to track the progress of a data loader.
-#[derive(Clone, Debug)]
+#[derive(new, Clone, Debug)]
 pub struct Progress {
     /// The number of items that have been processed.
     pub items_processed: usize,
@@ -21,4 +21,7 @@ pub trait DataLoaderIterator<O>: Iterator<Item = O> {
 pub trait DataLoader<O> {
     /// Returns a boxed [iterator](DataLoaderIterator) to iterate over the data loader.
     fn iter<'a>(&'a self) -> Box<dyn DataLoaderIterator<O> + 'a>;
+    /// The number of items (not the number of batches nor the number of iterations),
+    /// corresponding to the items_total of the progress returned by the iterator.
+    fn num_items(&self) -> usize;
 }

--- a/burn-core/src/data/dataloader/batch.rs
+++ b/burn-core/src/data/dataloader/batch.rs
@@ -122,6 +122,10 @@ impl<I: Send + Sync + Clone + 'static, O: Send + Sync> DataLoader<O> for BatchDa
             self.batcher.clone(),
         ))
     }
+
+    fn num_items(&self) -> usize {
+        self.dataset.len()
+    }
 }
 
 impl<I, O> BatchDataloaderIterator<I, O> {
@@ -173,10 +177,7 @@ impl<I, O> Iterator for BatchDataloaderIterator<I, O> {
 
 impl<I, O> DataLoaderIterator<O> for BatchDataloaderIterator<I, O> {
     fn progress(&self) -> Progress {
-        Progress {
-            items_processed: self.current_index,
-            items_total: self.dataset.len(),
-        }
+        Progress::new(self.current_index, self.dataset.len())
     }
 }
 


### PR DESCRIPTION
Fix #1063 
The TUI overflow panic happened when the items considered for warmup exceeded the total of items. 
In theory this should not happen since items from warmup are included in the total. 
But the total of items was wrongly computed in multithread data loader, when not all thread had yet spawned, leading to a total that can be below the warmup items in the first iterations of the second or third epoch. 
