### PR TITLE
Add persistent cache for autotune

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@ Cargo.lock
 .DS_Store
 .cargo/config.toml
 
+.dir-locals.el
 .idea
 .vscode
-.fleet
 .vs
+.fleet

--- a/burn-common/Cargo.toml
+++ b/burn-common/Cargo.toml
@@ -29,6 +29,7 @@ rand = { workspace = true }
 spin = { workspace = true }       # using in place of use std::sync::Mutex;          
 uuid = { workspace = true }
 derive-new = { workspace = true }
+serde = { workspace = true }
 
 [dev-dependencies]
 dashmap = { workspace = true }

--- a/burn-common/src/benchmark.rs
+++ b/burn-common/src/benchmark.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 use core::fmt::Display;
 use core::time::Duration;
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[cfg(all(not(target_family = "wasm"), feature = "std"))]
 use std::time::Instant;

--- a/burn-common/src/benchmark.rs
+++ b/burn-common/src/benchmark.rs
@@ -4,13 +4,15 @@ use alloc::vec::Vec;
 use core::fmt::Display;
 use core::time::Duration;
 
+use serde::{Serialize, Deserialize};
+
 #[cfg(all(not(target_family = "wasm"), feature = "std"))]
 use std::time::Instant;
 #[cfg(all(target_family = "wasm", feature = "std"))]
 use web_time::Instant;
 
 /// Results of a benchmark run.
-#[derive(new, Debug)]
+#[derive(new, Debug, Clone, Serialize, Deserialize)]
 pub struct BenchmarkDurations {
     /// All durations of the run, in the order they were benchmarked
     pub durations: Vec<Duration>,

--- a/burn-compute/Cargo.toml
+++ b/burn-compute/Cargo.toml
@@ -43,10 +43,10 @@ dirs = { workspace = true , optional = true}
 serde = { workspace = true, optional = true}
 serde_json = { workspace = true, features=["std"], optional = true}
 md5 = { version = "0.7.0", optional = true }
-rand.workspace = true
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 web-time = { version = "0.2.3" }
 
 [dev-dependencies]
 serial_test = "2.0.0"
+rand = { workspace = true }

--- a/burn-compute/Cargo.toml
+++ b/burn-compute/Cargo.toml
@@ -34,6 +34,7 @@ dirs = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["std"] }
 md5 = "0.7.0"
+rand.workspace = true
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 web-time = { version = "0.2.3" }

--- a/burn-compute/Cargo.toml
+++ b/burn-compute/Cargo.toml
@@ -17,12 +17,21 @@ default = [
     "channel-mpsc",
     "channel-cell",
     "storage-bytes",
+    "autotune-persistent-cache",
 ]
-std = ["burn-common/std"]
+std = [
+    "burn-common/std",
+]
 channel-mutex = []
 channel-cell = []
 channel-mpsc = [] # Assume std
 storage-bytes = []
+autotune-persistent-cache = [
+    "dirs",
+    "md5",
+    "serde",
+    "serde_json",
+] # Assume std
 
 [dependencies]
 burn-common = { path = "../burn-common", version = "0.12.0", default-features = false }
@@ -30,10 +39,10 @@ derive-new = { workspace = true }
 spin = { workspace = true }
 log = { workspace = true }
 hashbrown = { workspace = true }
-dirs = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true, features = ["std"] }
-md5 = "0.7.0"
+dirs = { workspace = true , optional = true}
+serde = { workspace = true, optional = true}
+serde_json = { workspace = true, features=["std"], optional = true}
+md5 = { version = "0.7.0", optional = true }
 rand.workspace = true
 
 [target.'cfg(target_family = "wasm")'.dependencies]

--- a/burn-compute/Cargo.toml
+++ b/burn-compute/Cargo.toml
@@ -30,6 +30,10 @@ derive-new = { workspace = true }
 spin = { workspace = true }
 log = { workspace = true }
 hashbrown = { workspace = true }
+dirs = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true, features = ["std"] }
+md5 = "0.7.0"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 web-time = { version = "0.2.3" }

--- a/burn-compute/src/tune/operation.rs
+++ b/burn-compute/src/tune/operation.rs
@@ -3,10 +3,9 @@ use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt::{Debug, Display};
 use core::hash::Hash;
-use serde::de::DeserializeOwned;
-use serde::Serialize;
 
 /// Default checksum for an operation set
+#[cfg(feature = "autotune-persistent-cache")]
 pub fn compute_checksum(autotunables: &[Box<dyn AutotuneOperation>]) -> String {
     let mut checksum = String::new();
     autotunables.iter().for_each(|op| {
@@ -29,6 +28,7 @@ pub trait AutotuneOperationSet<K>: Send {
     fn fastest(self: Box<Self>, fastest_index: usize) -> Box<dyn AutotuneOperation>;
 
     /// Compute checksum for the set by concatenating the op names together
+    #[cfg(feature = "autotune-persistent-cache")]
     fn compute_checksum(&self) -> String {
         compute_checksum(&self.autotunables())
     }
@@ -48,9 +48,13 @@ pub trait AutotuneOperation {
     fn clone(&self) -> Box<dyn AutotuneOperation>;
 }
 
-/// Trait alias
+#[cfg(feature = "autotune-persistent-cache")]
+/// Trait alias with support for persistent caching
 pub trait AutotuneKey:
-    Clone + Debug + PartialEq + Eq + Hash + Display + Serialize + DeserializeOwned
+    Clone + Debug + PartialEq + Eq + Hash + Display + serde::Serialize + serde::de::DeserializeOwned
 {
 }
+#[cfg(not(feature = "autotune-persistent-cache"))]
+/// Trait alias
+pub trait AutotuneKey: Clone + Debug + PartialEq + Eq + Hash + Display {}
 impl AutotuneKey for String {}

--- a/burn-compute/src/tune/operation.rs
+++ b/burn-compute/src/tune/operation.rs
@@ -1,7 +1,8 @@
 use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::vec::Vec;
-use serde::{Serialize, Deserialize};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
 use core::fmt::{Debug, Display};
 use core::hash::Hash;
 
@@ -43,5 +44,5 @@ pub trait AutotuneOperation {
 }
 
 /// Trait alias
-pub trait AutotuneKey: Clone + Debug + PartialEq + Eq + Hash + Display + Serialize + for<'de> Deserialize<'de> {}
+pub trait AutotuneKey: Clone + Debug + PartialEq + Eq + Hash + Display + Serialize + DeserializeOwned {}
 impl AutotuneKey for String {}

--- a/burn-compute/src/tune/operation.rs
+++ b/burn-compute/src/tune/operation.rs
@@ -1,6 +1,7 @@
 use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::vec::Vec;
+use serde::{Serialize, Deserialize};
 use core::fmt::{Debug, Display};
 use core::hash::Hash;
 
@@ -16,6 +17,15 @@ pub trait AutotuneOperationSet<K>: Send {
     /// Returns the operation for the given index, matching the order
     /// returned by autotunables. Operation obtained here runs on original tensors
     fn fastest(self: Box<Self>, fastest_index: usize) -> Box<dyn AutotuneOperation>;
+
+    /// Compute checksum for the set by concatenating the op names together
+    fn compute_checksum (&self) -> String {
+        let mut checksum = String::new();
+        self.autotunables().iter().for_each(|op| {
+            checksum += op.name();
+        });
+        format!("{:x}", md5::compute(checksum))
+    }
 }
 
 /// Contains operation to run and inputs on which to run it
@@ -33,5 +43,5 @@ pub trait AutotuneOperation {
 }
 
 /// Trait alias
-pub trait AutotuneKey: Clone + Debug + PartialEq + Eq + Hash + Display {}
+pub trait AutotuneKey: Clone + Debug + PartialEq + Eq + Hash + Display + Serialize + for<'de> Deserialize<'de> {}
 impl AutotuneKey for String {}

--- a/burn-compute/src/tune/operation.rs
+++ b/burn-compute/src/tune/operation.rs
@@ -27,7 +27,7 @@ pub trait AutotuneOperationSet<K>: Send {
     /// returned by autotunables. Operation obtained here runs on original tensors
     fn fastest(self: Box<Self>, fastest_index: usize) -> Box<dyn AutotuneOperation>;
 
-    /// Compute checksum for the set by concatenating the op names together
+    /// Compute a checksum that can invalidate outdated cached auto-tune results.
     #[cfg(feature = "autotune-persistent-cache")]
     fn compute_checksum(&self) -> String {
         compute_checksum(&self.autotunables())

--- a/burn-compute/src/tune/tune_cache.rs
+++ b/burn-compute/src/tune/tune_cache.rs
@@ -190,11 +190,18 @@ impl<K: AutotuneKey> TuneCache<K> {
     #[cfg(feature = "autotune-persistent-cache")]
     pub(crate) fn save(&self) {
         let file_path = get_persistent_cache_file_path();
-        let expect_msg = format!(
+        if let Some(parent_dir) = file_path.parent() {
+            if !parent_dir.exists() {
+                fs::create_dir_all(parent_dir).expect(&format!(
+                    "Should be able to create directory '{}' for autotune persistent cache file",
+                    parent_dir.to_str().unwrap()
+                ));
+            }
+        }
+        let file = File::create(file_path.clone()).expect(&format!(
             "Should be able to open autotune persistent cache file: {:?}",
             &file_path.to_str().unwrap()
-        );
-        let file = File::create(file_path).expect(&expect_msg);
+        ));
         let data = self.persistent_cache.iter().collect::<Vec<_>>();
         serde_json::to_writer_pretty(file, &data)
             .expect("Should be able to write to autotune persistent cache");

--- a/burn-compute/src/tune/tune_cache.rs
+++ b/burn-compute/src/tune/tune_cache.rs
@@ -50,7 +50,7 @@ impl<K: AutotuneKey> TuneCache<K> {
                 persistent_cache: HashMap::new(),
             };
             if let Err(e) = cache.load() {
-                eprintln!(
+                log::warn!(
                     "Unable to load autotune cache. Cache will be ignored ({}).",
                     e
                 );

--- a/burn-compute/src/tune/tune_cache.rs
+++ b/burn-compute/src/tune/tune_cache.rs
@@ -19,7 +19,7 @@ use hashbrown::HashMap;
 /// Return the file path for the persistent cache on disk
 #[cfg(feature = "autotune-persistent-cache")]
 pub fn get_persistent_cache_file_path() -> PathBuf {
-    let home_dir = dirs::home_dir().expect("Could not get home directory");
+    let home_dir = dirs::home_dir().expect("An home directory should exist");
     let path_dir = home_dir.join(".cache").join("burn").join("autotune");
     let path = Path::new(&path_dir);
     path.join("autotune-cache.json")
@@ -151,12 +151,12 @@ impl<K: AutotuneKey> TuneCache<K> {
     pub(crate) fn save(&self) {
         let file_path = get_persistent_cache_file_path();
         let expect_msg = format!(
-            "Unable to open autotune persistent cache file: {:?}",
+            "Should be able to open autotune persistent cache file: {:?}",
             &file_path.to_str().unwrap()
         );
         let file = File::create(file_path).expect(&expect_msg);
         let data = self.persistent_cache.iter().collect::<Vec<_>>();
         serde_json::to_writer_pretty(file, &data)
-            .expect("Unable to write to autotune persistent cache");
+            .expect("Should be able to write to autotune persistent cache");
     }
 }

--- a/burn-compute/src/tune/tune_cache.rs
+++ b/burn-compute/src/tune/tune_cache.rs
@@ -63,7 +63,10 @@ pub enum TuneCacheResult<K> {
 }
 
 impl<K: AutotuneKey> TuneCache<K> {
-    pub(crate) fn new(device_id: &str) -> Self {
+    pub(crate) fn new(
+        #[cfg_attr(not(feature = "autotune-persistent-cache"), allow(unused_variables))]
+        device_id: &str,
+    ) -> Self {
         #[cfg(feature = "autotune-persistent-cache")]
         {
             let mut cache = TuneCache {

--- a/burn-compute/src/tune/tune_cache.rs
+++ b/burn-compute/src/tune/tune_cache.rs
@@ -150,7 +150,11 @@ impl<K: AutotuneKey> TuneCache<K> {
     #[cfg(feature = "autotune-persistent-cache")]
     pub(crate) fn save(&self) {
         let file_path = get_persistent_cache_file_path();
-        let file = File::create(file_path).expect("Unable to open autotune persistent cache file");
+        let expect_msg = format!(
+            "Unable to open autotune persistent cache file: {:?}",
+            &file_path.to_str().unwrap()
+        );
+        let file = File::create(file_path).expect(&expect_msg);
         let data = self.persistent_cache.iter().collect::<Vec<_>>();
         serde_json::to_writer_pretty(file, &data)
             .expect("Unable to write to autotune persistent cache");

--- a/burn-compute/src/tune/tune_cache.rs
+++ b/burn-compute/src/tune/tune_cache.rs
@@ -27,11 +27,14 @@ pub enum TuneCacheResult<K> {
 
 impl<K: AutotuneKey> TuneCache<K> {
     pub(crate) fn new() -> Self {
-        let mut cache =  TuneCache {
+        let mut cache = TuneCache {
             cache: HashMap::new(),
             persistent_cache: HashMap::new(),
         };
-        cache.load();
+        if let Err(e) = cache.load() {
+            eprintln!(
+                "Unable to load autotune cache. Cache will be ignored ({}).", e);
+        }
         cache
     }
 

--- a/burn-compute/src/tune/tune_cache.rs
+++ b/burn-compute/src/tune/tune_cache.rs
@@ -196,18 +196,19 @@ impl<K: AutotuneKey> TuneCache<K> {
         let file_path = self.get_persistent_cache_file_path();
         if let Some(parent_dir) = file_path.parent() {
             if !parent_dir.exists() {
-                let msg = format!(
+                fs::create_dir_all(parent_dir).unwrap_or_else(|_| {
+                    panic!(
                     "Should be able to create directory '{}' for autotune persistent cache file",
-                    parent_dir.to_str().unwrap()
-                );
-                fs::create_dir_all(parent_dir).expect(&msg);
+                    parent_dir.to_str().unwrap())
+                });
             }
         }
-        let msg = format!(
-            "Should be able to open autotune persistent cache file: {:?}",
-            &file_path.to_str().unwrap()
-        );
-        let file = File::create(file_path.clone()).expect(&msg);
+        let file = File::create(file_path.clone()).unwrap_or_else(|_| {
+            panic!(
+                "Should be able to open autotune persistent cache file '{}'",
+                file_path.to_str().unwrap()
+            )
+        });
         let data = self.persistent_cache.iter().collect::<Vec<_>>();
         serde_json::to_writer_pretty(file, &data)
             .expect("Should be able to write to autotune persistent cache");

--- a/burn-compute/src/tune/tune_cache.rs
+++ b/burn-compute/src/tune/tune_cache.rs
@@ -66,7 +66,6 @@ impl<K: AutotuneKey> TuneCache<K> {
         }
     }
 
-    #[allow(clippy::borrowed_box)]
     pub(crate) fn try_cache(
         &mut self,
         autotune_operation_set: Box<dyn AutotuneOperationSet<K>>,

--- a/burn-compute/src/tune/tune_cache.rs
+++ b/burn-compute/src/tune/tune_cache.rs
@@ -1,3 +1,9 @@
+use std::fs;
+use std::fs::File;
+use std::io;
+use std::path::Path;
+use std::path::PathBuf;
+
 use super::AutotuneKey;
 use super::AutotuneOperation;
 use super::AutotuneOperationSet;
@@ -7,7 +13,8 @@ use hashbrown::HashMap;
 /// Use to find and reuse the best kernel for some input
 #[derive(Debug, Default)]
 pub(crate) struct TuneCache<K> {
-    cache: HashMap<K, usize>,
+    cache: HashMap<K, (bool, usize)>,
+    persistent_cache: HashMap<String, (String, usize)>,
 }
 
 /// Result of the cache try
@@ -22,22 +29,69 @@ impl<K: AutotuneKey> TuneCache<K> {
     pub(crate) fn new() -> Self {
         TuneCache {
             cache: HashMap::new(),
+            persistent_cache: HashMap::new(),
         }
     }
 
     #[allow(clippy::borrowed_box)]
     pub(crate) fn try_cache(
-        &self,
+        &mut self,
         autotune_operation_set: Box<dyn AutotuneOperationSet<K>>,
     ) -> TuneCacheResult<K> {
-        let index = self.cache.get(&autotune_operation_set.key());
-        if let Some(&i) = index {
-            return TuneCacheResult::Hit(autotune_operation_set.fastest(i));
+        let key = autotune_operation_set.key();
+        let result = self.cache.get_mut(&key);
+        println!("result {:?}", result);
+        if let Some((is_checked, index)) = result {
+            if !*is_checked {
+                let checksum = autotune_operation_set.compute_checksum();
+                let (expected_checksum, _) = self
+                    .persistent_cache
+                    .get(&key.to_string())
+                    .expect("Both caches should be in sync");
+                println!("{} -- {}", checksum, expected_checksum);
+                if &checksum != expected_checksum {
+                    return TuneCacheResult::Miss(autotune_operation_set);
+                }
+                *is_checked = true;
+            }
+            return TuneCacheResult::Hit(autotune_operation_set.fastest(*index));
         }
         TuneCacheResult::Miss(autotune_operation_set)
     }
 
-    pub(crate) fn cache_insert(&mut self, key: K, fastest_index: usize) {
-        self.cache.insert(key, fastest_index);
+    pub(crate) fn cache_insert(&mut self, key: K, fastest_index: usize, checksum: String) {
+        self.persistent_cache.insert(key.to_string(), (checksum, fastest_index));
+        self.cache.insert(key, (true, fastest_index));
+    }
+
+    /// Load the persistent cache data from disk
+    pub(crate) fn load(&mut self) -> Result<(), io::Error> {
+        let file_path  = TuneCache::<K>::get_persistent_cache_file_path();
+        // note: reading file ro memory is faster than using
+        // serde from_reader with a buffered reader
+        // see issue:
+        // https://github.com/serde-rs/json/issues/160
+        let data = fs::read_to_string(file_path)?;
+        self.persistent_cache = serde_json::from_str(&data)?;
+        dbg!(&self.persistent_cache);
+        Ok(())
+    }
+
+    /// Save the persistent cache on disk
+    pub(crate) fn save(&self) {
+        let file_path  = TuneCache::<K>::get_persistent_cache_file_path();
+        let file = File::create(&file_path).expect(
+            "Unable to open autotune persistent cache file");
+        serde_json::to_writer_pretty(file, &self.persistent_cache)
+            .expect("Unable to write to autotune persistent cache");
+    }
+
+    /// Return the file path for the persistent cache on disk
+    fn get_persistent_cache_file_path() -> PathBuf {
+        let home_dir = dirs::home_dir().expect("Could not get home directory");
+        let path_dir = home_dir.join(".cache").join("burn").join("autotune");
+        let path = Path::new(&path_dir);
+        let file_path = path.join("autotune-cache.json");
+        file_path
     }
 }

--- a/burn-compute/src/tune/tune_cache.rs
+++ b/burn-compute/src/tune/tune_cache.rs
@@ -119,7 +119,7 @@ impl<K: AutotuneKey> TuneCache<K> {
     #[cfg(feature = "autotune-persistent-cache")]
     pub(crate) fn load(&mut self) -> Result<(), io::Error> {
         let file_path = get_persistent_cache_file_path();
-        // note: reading file ro memory is faster than using
+        // note: reading file from memory is faster than using
         // serde from_reader with a buffered reader
         // see issue:
         // https://github.com/serde-rs/json/issues/160

--- a/burn-compute/src/tune/tuner.rs
+++ b/burn-compute/src/tune/tuner.rs
@@ -25,9 +25,9 @@ pub struct Tuner<S: ComputeServer, C> {
 #[allow(clippy::new_without_default)]
 impl<S: ComputeServer, C: ComputeChannel<S>> Tuner<S, C> {
     /// Returns a tuner with cache initialized from persistent cache
-    pub fn new() -> Self {
+    pub fn new(device_id: &str) -> Self {
         Self {
-            tune_cache: TuneCache::new(),
+            tune_cache: TuneCache::new(device_id),
             _channel: PhantomData,
         }
     }

--- a/burn-compute/src/tune/tuner.rs
+++ b/burn-compute/src/tune/tuner.rs
@@ -18,12 +18,13 @@ use crate::tune::{AutotuneOperation, AutotuneOperationSet, TuneBenchmark, TuneCa
 #[derive(Debug)]
 /// Executes autotune benchmarking and caching
 pub struct Tuner<S: ComputeServer, C> {
-    tune_cache: TuneCache::<S::AutotuneKey>,
+    tune_cache: TuneCache<S::AutotuneKey>,
     _channel: PhantomData<C>,
 }
 
+#[allow(clippy::new_without_default)]
 impl<S: ComputeServer, C: ComputeChannel<S>> Tuner<S, C> {
-    /// Returns a tuner with empty cache
+    /// Returns a tuner with cache initialized from persistent cache
     pub fn new() -> Self {
         Self {
             tune_cache: TuneCache::new(),
@@ -52,8 +53,6 @@ impl<S: ComputeServer, C: ComputeChannel<S>> Tuner<S, C> {
         let key = autotune_operation_set.key();
         let autotunables = autotune_operation_set.autotunables();
         let mut names = Vec::with_capacity(autotunables.len());
-
-        println!("Running autotune...");
 
         let results: Vec<BenchmarkDurations> = autotunables
             .into_iter()

--- a/burn-compute/tests/dummy/compute.rs
+++ b/burn-compute/tests/dummy/compute.rs
@@ -17,6 +17,7 @@ pub type DummyChannel = MutexComputeChannel<DummyServer>;
 pub type DummyClient = ComputeClient<DummyServer, DummyChannel>;
 
 static COMPUTE: Compute<DummyDevice, DummyServer, DummyChannel> = Compute::new();
+pub static TUNER_DEVICE_ID: &str = "tests/dummy-device";
 
 pub fn init_client() -> ComputeClient<DummyServer, MutexComputeChannel<DummyServer>> {
     let storage = BytesStorage::default();
@@ -24,7 +25,7 @@ pub fn init_client() -> ComputeClient<DummyServer, MutexComputeChannel<DummyServ
         SimpleMemoryManagement::new(storage, DeallocStrategy::Never, SliceStrategy::Never);
     let server = DummyServer::new(memory_management);
     let channel = MutexComputeChannel::new(server);
-    let tuner = Arc::new(Mutex::new(Tuner::new()));
+    let tuner = Arc::new(Mutex::new(Tuner::new(TUNER_DEVICE_ID)));
     ComputeClient::new(channel, tuner)
 }
 

--- a/burn-compute/tests/dummy/compute.rs
+++ b/burn-compute/tests/dummy/compute.rs
@@ -17,9 +17,23 @@ pub type DummyChannel = MutexComputeChannel<DummyServer>;
 pub type DummyClient = ComputeClient<DummyServer, DummyChannel>;
 
 static COMPUTE: Compute<DummyDevice, DummyServer, DummyChannel> = Compute::new();
+static COMPUTE2: Compute<DummyDevice, DummyServer, DummyChannel> = Compute::new();
 
 pub fn client(device: &DummyDevice) -> DummyClient {
     COMPUTE.client(device, || {
+        let storage = BytesStorage::default();
+        let memory_management =
+            SimpleMemoryManagement::new(storage, DeallocStrategy::Never, SliceStrategy::Never);
+        let server = DummyServer::new(memory_management);
+        let channel = MutexComputeChannel::new(server);
+        let tuner = Arc::new(Mutex::new(Tuner::new()));
+
+        ComputeClient::new(channel, tuner)
+    })
+}
+
+pub fn client2(device: &DummyDevice) -> DummyClient {
+    COMPUTE2.client(device, || {
         let storage = BytesStorage::default();
         let memory_management =
             SimpleMemoryManagement::new(storage, DeallocStrategy::Never, SliceStrategy::Never);

--- a/burn-compute/tests/dummy/compute.rs
+++ b/burn-compute/tests/dummy/compute.rs
@@ -17,30 +17,17 @@ pub type DummyChannel = MutexComputeChannel<DummyServer>;
 pub type DummyClient = ComputeClient<DummyServer, DummyChannel>;
 
 static COMPUTE: Compute<DummyDevice, DummyServer, DummyChannel> = Compute::new();
-static COMPUTE2: Compute<DummyDevice, DummyServer, DummyChannel> = Compute::new();
 
-pub fn client(device: &DummyDevice) -> DummyClient {
-    COMPUTE.client(device, || {
-        let storage = BytesStorage::default();
-        let memory_management =
-            SimpleMemoryManagement::new(storage, DeallocStrategy::Never, SliceStrategy::Never);
-        let server = DummyServer::new(memory_management);
-        let channel = MutexComputeChannel::new(server);
-        let tuner = Arc::new(Mutex::new(Tuner::new()));
-
-        ComputeClient::new(channel, tuner)
-    })
+pub fn init_client() -> ComputeClient<DummyServer, MutexComputeChannel<DummyServer>> {
+    let storage = BytesStorage::default();
+    let memory_management =
+        SimpleMemoryManagement::new(storage, DeallocStrategy::Never, SliceStrategy::Never);
+    let server = DummyServer::new(memory_management);
+    let channel = MutexComputeChannel::new(server);
+    let tuner = Arc::new(Mutex::new(Tuner::new()));
+    ComputeClient::new(channel, tuner)
 }
 
-pub fn client2(device: &DummyDevice) -> DummyClient {
-    COMPUTE2.client(device, || {
-        let storage = BytesStorage::default();
-        let memory_management =
-            SimpleMemoryManagement::new(storage, DeallocStrategy::Never, SliceStrategy::Never);
-        let server = DummyServer::new(memory_management);
-        let channel = MutexComputeChannel::new(server);
-        let tuner = Arc::new(Mutex::new(Tuner::new()));
-
-        ComputeClient::new(channel, tuner)
-    })
+pub fn client(device: &DummyDevice) -> DummyClient {
+    COMPUTE.client(device, init_client)
 }

--- a/burn-compute/tests/dummy/tune/mod.rs
+++ b/burn-compute/tests/dummy/tune/mod.rs
@@ -4,4 +4,5 @@ mod operation_sets;
 
 pub use autotune_operations::*;
 pub use kernels::*;
+#[allow(unused)]
 pub use operation_sets::*;

--- a/burn-compute/tests/dummy/tune/operation_sets.rs
+++ b/burn-compute/tests/dummy/tune/operation_sets.rs
@@ -1,9 +1,11 @@
 use rand::{distributions::Alphanumeric, Rng};
 use std::sync::Arc;
 
+#[cfg(feature = "autotune-persistent-cache")]
+use burn_compute::tune::compute_checksum;
 use burn_compute::{
     server::Handle,
-    tune::{compute_checksum, AutotuneOperation, AutotuneOperationSet},
+    tune::{AutotuneOperation, AutotuneOperationSet},
 };
 
 use crate::dummy::{
@@ -161,6 +163,7 @@ impl AutotuneOperationSet<String> for CacheTestAutotuneOperationSet {
         self.autotunables()[fastest_index].clone()
     }
 
+    #[cfg(feature = "std")]
     fn compute_checksum(&self) -> String {
         if self.generate_random_checksum {
             let rand_string: String = rand::thread_rng()

--- a/burn-compute/tests/dummy/tune/operation_sets.rs
+++ b/burn-compute/tests/dummy/tune/operation_sets.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "autotune-persistent-cache")]
 use rand::{distributions::Alphanumeric, Rng};
 use std::sync::Arc;
 
@@ -24,6 +25,7 @@ pub struct AdditionAutotuneOperationSet {
 }
 
 impl AdditionAutotuneOperationSet {
+    #[allow(dead_code)]
     pub fn new(
         client: DummyClient,
         shapes: Vec<Vec<usize>>,
@@ -73,6 +75,7 @@ pub struct MultiplicationAutotuneOperationSet {
 }
 
 impl MultiplicationAutotuneOperationSet {
+    #[allow(dead_code)]
     pub fn new(
         client: DummyClient,
         shapes: Vec<Vec<usize>>,
@@ -122,6 +125,7 @@ pub struct CacheTestAutotuneOperationSet {
 }
 
 impl CacheTestAutotuneOperationSet {
+    #[allow(dead_code)]
     pub fn new(
         client: DummyClient,
         shapes: Vec<Vec<usize>>,

--- a/burn-compute/tests/integration_test.rs
+++ b/burn-compute/tests/integration_test.rs
@@ -2,7 +2,9 @@ mod dummy;
 
 use std::sync::Arc;
 
-use crate::dummy::{client, client2, DummyDevice, DummyElementwiseAddition};
+use burn_compute::Compute;
+
+use crate::dummy::{client, DummyDevice, DummyElementwiseAddition};
 
 use serial_test::serial;
 
@@ -197,7 +199,8 @@ fn autotune_cache_different_keys_return_a_cache_miss() {
 fn autotune_cache_different_checksums_return_a_cache_miss() {
     // we use two clients in order to have freshly initialized autotune caches
     let client1 = client(&DummyDevice);
-    let client2 = client2(&DummyDevice);
+    let compute: Compute<DummyDevice, dummy::DummyServer, dummy::DummyChannel> = Compute::new();
+    let client2 = compute.client(&DummyDevice, dummy::init_client);
 
     // in this test both shapes [1,3] and [1,4] end up with the same key name
     // which is 'cache_test-1,4'

--- a/burn-compute/tests/integration_test.rs
+++ b/burn-compute/tests/integration_test.rs
@@ -2,7 +2,7 @@ mod dummy;
 
 use std::sync::Arc;
 
-use crate::dummy::{client, DummyDevice, DummyElementwiseAddition};
+use crate::dummy::{client, client2, DummyDevice, DummyElementwiseAddition};
 
 use serial_test::serial;
 
@@ -88,9 +88,14 @@ fn autotune_basic_multiplication_execution() {
 #[test]
 #[serial]
 #[cfg(feature = "std")]
-fn autotune_cache_hit_test() {
+fn autotune_cache_same_key_return_a_cache_hit() {
     let client = client(&DummyDevice);
 
+    // note: the key name depends on the shapes of the operation set
+    // see log_shape_input_key for more info.
+
+    // in this test both shapes [1,3] and [1,4] end up with the same key name
+    // which is 'cache_test-1,4'
     let shapes_1 = vec![vec![1, 3], vec![1, 3], vec![1, 3]];
     let lhs_1 = client.create(&[0, 1, 2]);
     let rhs_1 = client.create(&[4, 4, 4]);
@@ -119,9 +124,15 @@ fn autotune_cache_hit_test() {
 #[test]
 #[serial]
 #[cfg(feature = "std")]
-fn autotune_cache_miss_test() {
+fn autotune_cache_empty_cache_return_a_cache_miss() {
+    // delete the cache file
+    let file_path = burn_compute::tune::get_persistent_cache_file_path();
+    let _ = std::fs::remove_file(file_path);
+
     let client = client(&DummyDevice);
 
+    // in this test shapes [1,3] and [1,5] ends up with different key names
+    // which are 'cache_test-1,4' and 'cache_test-1,8'
     let shapes_1 = vec![vec![1, 3], vec![1, 3], vec![1, 3]];
     let lhs_1 = client.create(&[0, 1, 2]);
     let rhs_1 = client.create(&[4, 4, 4]);
@@ -145,4 +156,75 @@ fn autotune_cache_miss_test() {
 
     // Cache should be missed, so CacheTestSlowOn3 (but faster on 5) should be used, returning rhs
     assert_eq!(obtained_resource.read(), Vec::from([5, 6, 7, 8, 9]));
+}
+
+#[test]
+#[serial]
+#[cfg(feature = "std")]
+fn autotune_cache_different_keys_return_a_cache_miss() {
+    let client = client(&DummyDevice);
+
+    // in this test shapes [1,3] and [1,5] ends up with different key names
+    // which are 'cache_test-1,4' and 'cache_test-1,8'
+    let shapes_1 = vec![vec![1, 3], vec![1, 3], vec![1, 3]];
+    let lhs_1 = client.create(&[0, 1, 2]);
+    let rhs_1 = client.create(&[4, 4, 4]);
+    let out_1 = client.empty(3);
+    let handles_1 = vec![lhs_1, rhs_1, out_1];
+
+    let shapes_2 = vec![vec![1, 5], vec![1, 5], vec![1, 5]];
+    let lhs_2 = client.create(&[0, 1, 2, 3, 4]);
+    let rhs_2 = client.create(&[5, 6, 7, 8, 9]);
+    let out_2 = client.empty(5);
+    let handles_2 = vec![lhs_2, rhs_2, out_2.clone()];
+
+    let cache_test_autotune_kernel_1 =
+        dummy::CacheTestAutotuneOperationSet::new(client.clone(), shapes_1, handles_1);
+    let cache_test_autotune_kernel_2 =
+        dummy::CacheTestAutotuneOperationSet::new(client.clone(), shapes_2, handles_2);
+    client.execute_autotune(Box::new(cache_test_autotune_kernel_1));
+    client.execute_autotune(Box::new(cache_test_autotune_kernel_2));
+
+    let obtained_resource = client.read(&out_2);
+
+    // Cache should be missed, so CacheTestSlowOn3 (but faster on 5) should be used, returning rhs
+    assert_eq!(obtained_resource.read(), Vec::from([5, 6, 7, 8, 9]));
+}
+
+#[test]
+#[serial]
+#[cfg(feature = "std")]
+fn autotune_cache_different_checksums_return_a_cache_miss() {
+    // we use two clients in order to have freshly initialized autotune caches
+    let client1 = client(&DummyDevice);
+    let client2 = client2(&DummyDevice);
+
+    // in this test both shapes [1,3] and [1,4] end up with the same key name
+    // which is 'cache_test-1,4'
+    let shapes_1 = vec![vec![1, 3], vec![1, 3], vec![1, 3]];
+    let lhs_1 = client1.create(&[0, 1, 2]);
+    let rhs_1 = client1.create(&[4, 4, 4]);
+    let out_1 = client1.empty(3);
+    let handles_1 = vec![lhs_1, rhs_1, out_1];
+
+    let shapes_2 = vec![vec![1, 4], vec![1, 4], vec![1, 4]];
+    let lhs_2 = client2.create(&[0, 1, 2, 3]);
+    let rhs_2 = client2.create(&[5, 6, 7, 8]);
+    let out_2 = client2.empty(4);
+    let handles_2 = vec![lhs_2, rhs_2, out_2.clone()];
+
+    let cache_test_autotune_kernel_1 =
+        dummy::CacheTestAutotuneOperationSet::new(client1.clone(), shapes_1, handles_1);
+    let mut cache_test_autotune_kernel_2 =
+        dummy::CacheTestAutotuneOperationSet::new(client2.clone(), shapes_2, handles_2);
+    client1.execute_autotune(Box::new(cache_test_autotune_kernel_1));
+    cache_test_autotune_kernel_2.generate_random_checksum = true;
+    client2.execute_autotune(Box::new(cache_test_autotune_kernel_2));
+
+    let obtained_resource = client2.read(&out_2);
+
+    // Cache should be missed because the checksum on 4 is generated randomly
+    // and thus is always different,
+    // so CacheTestSlowOn3 (but faster on 4) should be used, returning rhs
+    assert_eq!(obtained_resource.read(), Vec::from([5, 6, 7, 8]));
 }

--- a/burn-compute/tests/integration_test.rs
+++ b/burn-compute/tests/integration_test.rs
@@ -2,10 +2,9 @@ mod dummy;
 
 use std::sync::Arc;
 
-use burn_compute::Compute;
+use crate::dummy::{client, DummyDevice, DummyElementwiseAddition};
 
-use crate::dummy::{client, DummyDevice, DummyElementwiseAddition, TUNER_DEVICE_ID};
-
+#[allow(unused)]
 use serial_test::serial;
 
 #[test]
@@ -91,7 +90,8 @@ fn autotune_basic_multiplication_execution() {
 #[serial]
 #[cfg(feature = "std")]
 fn autotune_cache_same_key_return_a_cache_hit() {
-    let compute: Compute<DummyDevice, dummy::DummyServer, dummy::DummyChannel> = Compute::new();
+    let compute: burn_compute::Compute<DummyDevice, dummy::DummyServer, dummy::DummyChannel> =
+        burn_compute::Compute::new();
     let client = compute.client(&DummyDevice, dummy::init_client);
 
     // note: the key name depends on the shapes of the operation set
@@ -129,10 +129,12 @@ fn autotune_cache_same_key_return_a_cache_hit() {
 #[cfg(feature = "std")]
 fn autotune_cache_no_cache_on_disk_return_a_cache_miss() {
     // delete the cache file
-    let file_path = burn_compute::tune::get_persistent_cache_file_path(TUNER_DEVICE_ID);
+    let file_path =
+        burn_compute::tune::get_persistent_cache_file_path(crate::dummy::TUNER_DEVICE_ID);
     let _ = std::fs::remove_file(file_path);
 
-    let compute: Compute<DummyDevice, dummy::DummyServer, dummy::DummyChannel> = Compute::new();
+    let compute: burn_compute::Compute<DummyDevice, dummy::DummyServer, dummy::DummyChannel> =
+        burn_compute::Compute::new();
     let client = compute.client(&DummyDevice, dummy::init_client);
 
     // in this test shapes [1,3] and [1,5] ends up with different key names
@@ -168,14 +170,16 @@ fn autotune_cache_no_cache_on_disk_return_a_cache_miss() {
 #[cfg(feature = "std")]
 fn autotune_cache_file_path_creation_works_when_path_does_not_exist_yet() {
     // delete the cache file
-    let file_path = burn_compute::tune::get_persistent_cache_file_path(TUNER_DEVICE_ID);
+    let file_path =
+        burn_compute::tune::get_persistent_cache_file_path(crate::dummy::TUNER_DEVICE_ID);
     let parent_dir = file_path
         .parent()
         .expect("Cache file should have a parent directory");
     // Delete the cache file's parent directory
     let _ = std::fs::remove_dir_all(parent_dir);
 
-    let compute: Compute<DummyDevice, dummy::DummyServer, dummy::DummyChannel> = Compute::new();
+    let compute: burn_compute::Compute<DummyDevice, dummy::DummyServer, dummy::DummyChannel> =
+        burn_compute::Compute::new();
     let client = compute.client(&DummyDevice, dummy::init_client);
 
     // in this test shapes [1,3] and [1,5] ends up with different key names
@@ -236,7 +240,8 @@ fn autotune_cache_different_keys_return_a_cache_miss() {
 #[serial]
 #[cfg(feature = "std")]
 fn autotune_cache_different_checksums_return_a_cache_miss() {
-    let compute: Compute<DummyDevice, dummy::DummyServer, dummy::DummyChannel> = Compute::new();
+    let compute: burn_compute::Compute<DummyDevice, dummy::DummyServer, dummy::DummyChannel> =
+        burn_compute::Compute::new();
     let client = compute.client(&DummyDevice, dummy::init_client);
 
     // in this test both shapes [1,3] and [1,4] end up with the same key name
@@ -254,7 +259,8 @@ fn autotune_cache_different_checksums_return_a_cache_miss() {
     // we use a second compute client in order to have freshly initialized autotune cache
     // and test invalidation of the cache when the checksum of the operation set is
     // different
-    let compute: Compute<DummyDevice, dummy::DummyServer, dummy::DummyChannel> = Compute::new();
+    let compute: burn_compute::Compute<DummyDevice, dummy::DummyServer, dummy::DummyChannel> =
+        burn_compute::Compute::new();
     let client = compute.client(&DummyDevice, dummy::init_client);
 
     let shapes_2 = vec![vec![1, 4], vec![1, 4], vec![1, 4]];

--- a/burn-compute/tests/integration_test.rs
+++ b/burn-compute/tests/integration_test.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use burn_compute::Compute;
 
-use crate::dummy::{client, DummyDevice, DummyElementwiseAddition};
+use crate::dummy::{client, DummyDevice, DummyElementwiseAddition, TUNER_DEVICE_ID};
 
 use serial_test::serial;
 
@@ -128,7 +128,7 @@ fn autotune_cache_same_key_return_a_cache_hit() {
 #[cfg(feature = "std")]
 fn autotune_cache_empty_cache_return_a_cache_miss() {
     // delete the cache file
-    let file_path = burn_compute::tune::get_persistent_cache_file_path();
+    let file_path = burn_compute::tune::get_persistent_cache_file_path(TUNER_DEVICE_ID);
     let _ = std::fs::remove_file(file_path);
 
     let client = client(&DummyDevice);
@@ -165,7 +165,7 @@ fn autotune_cache_empty_cache_return_a_cache_miss() {
 #[cfg(feature = "std")]
 fn autotune_cache_file_path_creation_works_when_path_does_not_exist_yet() {
     // delete the cache file
-    let file_path = burn_compute::tune::get_persistent_cache_file_path();
+    let file_path = burn_compute::tune::get_persistent_cache_file_path(TUNER_DEVICE_ID);
     let parent_dir = file_path
         .parent()
         .expect("Cache file should have a parent directory");

--- a/burn-train/Cargo.toml
+++ b/burn-train/Cargo.toml
@@ -11,7 +11,8 @@ repository = "https://github.com/tracel-ai/burn/tree/main/burn-train"
 version.workspace = true
 
 [features]
-default = ["metrics", "tui"]
+default = ["metrics"]
+# default = ["metrics", "tui"]
 metrics = ["nvml-wrapper", "sysinfo", "systemstat"]
 tui = ["ratatui", "crossterm"]
 

--- a/burn-train/Cargo.toml
+++ b/burn-train/Cargo.toml
@@ -11,8 +11,7 @@ repository = "https://github.com/tracel-ai/burn/tree/main/burn-train"
 version.workspace = true
 
 [features]
-default = ["metrics"]
-# default = ["metrics", "tui"]
+default = ["metrics", "tui"]
 metrics = ["nvml-wrapper", "sysinfo", "systemstat"]
 tui = ["ratatui", "crossterm"]
 

--- a/burn-train/src/renderer/cli.rs
+++ b/burn-train/src/renderer/cli.rs
@@ -3,6 +3,7 @@ use crate::renderer::{MetricState, MetricsRenderer, TrainingProgress};
 /// A simple renderer for when the cli feature is not enabled.
 pub struct CliMetricsRenderer;
 
+#[allow(clippy::new_without_default)]
 impl CliMetricsRenderer {
     /// Create a new instance.
     pub fn new() -> Self {

--- a/burn-wgpu/src/compute/tune_key.rs
+++ b/burn-wgpu/src/compute/tune_key.rs
@@ -1,5 +1,5 @@
+use serde::{Deserialize, Serialize};
 use std::fmt::Display;
-use serde::{Serialize, Deserialize};
 
 use burn_compute::tune::AutotuneKey;
 

--- a/burn-wgpu/src/compute/tune_key.rs
+++ b/burn-wgpu/src/compute/tune_key.rs
@@ -1,10 +1,11 @@
 use std::fmt::Display;
+use serde::{Serialize, Deserialize};
 
 use burn_compute::tune::AutotuneKey;
 
 use crate::kernel::{matmul::MatmulAutotuneKey, reduce::ReduceAutotuneKey};
 
-#[derive(Hash, Eq, PartialEq, Debug, Clone)]
+#[derive(Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
 /// Key for all autotune-enabled operations
 pub enum WgpuAutotuneKey {
     /// Key for matmul operation

--- a/burn-wgpu/src/kernel/matmul/tune/key.rs
+++ b/burn-wgpu/src/kernel/matmul/tune/key.rs
@@ -1,12 +1,13 @@
 use burn_tensor::Shape;
 use core::fmt::Debug;
+use serde::{Serialize, Deserialize};
 use std::{
     cmp::{max, min},
     fmt::Display,
     hash::Hash,
 };
 
-#[derive(Hash, Eq, PartialEq, Debug, Clone)]
+#[derive(Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
 /// Autotune key representative of matmul versions
 pub struct MatmulAutotuneKey {
     round: bool,     // True when all matmul dims are multiples of 64

--- a/burn-wgpu/src/kernel/matmul/tune/key.rs
+++ b/burn-wgpu/src/kernel/matmul/tune/key.rs
@@ -1,6 +1,6 @@
 use burn_tensor::Shape;
 use core::fmt::Debug;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use std::{
     cmp::{max, min},
     fmt::Display,

--- a/burn-wgpu/src/kernel/reduce/tune/key.rs
+++ b/burn-wgpu/src/kernel/reduce/tune/key.rs
@@ -1,5 +1,5 @@
+use serde::{Deserialize, Serialize};
 use std::{cmp::min, fmt::Display};
-use serde::{Serialize, Deserialize};
 
 use burn_tensor::Shape;
 

--- a/burn-wgpu/src/kernel/reduce/tune/key.rs
+++ b/burn-wgpu/src/kernel/reduce/tune/key.rs
@@ -1,8 +1,9 @@
 use std::{cmp::min, fmt::Display};
+use serde::{Serialize, Deserialize};
 
 use burn_tensor::Shape;
 
-#[derive(Hash, Eq, PartialEq, Debug, Clone)]
+#[derive(Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
 /// Autotune key representative of reduce versions
 pub struct ReduceAutotuneKey {
     reduce_dim_length: usize,


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

This PR fixes #911 

### Changes

- This PR adds a new persistent hash map to the TuneCache type.
- It serializes the persistent hash map as a vector to disk in location `~/.cache/burn/autotune/autotune-cache.json`.
- A checksum is computed to detect changes in operation sets such as key change or operations order changes
- the original in-memory cache is kept and it is initialized from the persistent cache at load time
- the first cache key lookup from the in-memory cache verifies that the checksums from the persistent cache and the current operation set are still the same

### Testing

Tested manually then added new integration tests to validate the checksum behavior and persistent cache invalidation.

