### PR TITLE
Fix import and type redefinitions in mnist-web-inference example crate

### DIFF
--- a/examples/mnist-inference-web/src/state.rs
+++ b/examples/mnist-inference-web/src/state.rs
@@ -1,6 +1,4 @@
 use crate::model::Model;
-#[cfg(feature = "wgpu")]
-use burn::backend::wgpu::WgpuDevice;
 use burn::module::Module;
 use burn::record::BinBytesRecorder;
 use burn::record::FullPrecisionSettings;
@@ -12,7 +10,7 @@ use burn::backend::wgpu::{compute::init_async, AutoGraphicsApi, Wgpu, WgpuDevice
 #[cfg(feature = "wgpu")]
 pub type Backend = Wgpu<AutoGraphicsApi, f32, i32>;
 
-#[cfg(feature = "ndarray")]
+#[cfg(all(feature = "ndarray", not(feature = "wgpu")))]
 pub type Backend = burn::backend::ndarray::NdArray<f32>;
 
 static STATE_ENCODED: &[u8] = include_bytes!("../model.bin");


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

* Remove the double import for WgpuDevice
* Prioritize wgpu backend over the default ndarray when wgpu feature is set

This fixes `cargo bench --festures wgpu` as `--no-default-features` cannot be used.

### Testing

`run-checks all`, `cargo bench --features wgpu`  and `cargo bench --features ndarray`
