### PR TITLE
Small fix: documentation of Tensor::stack

### DIFF
--- a/burn-tensor/src/tensor/api/base.rs
+++ b/burn-tensor/src/tensor/api/base.rs
@@ -474,7 +474,7 @@ where
     /// # Panics
     ///
     /// If all tensors don't have the same shape.
-    /// Given dimension is not with range of 0..=D2
+    /// Given dimension is not with range of 0..D2
     pub fn stack<const D2: usize>(tensors: Vec<Tensor<B, D, K>>, dim: usize) -> Tensor<B, D2, K> {
         check!(TensorCheck::stack(&tensors, dim));
         let tensors = tensors.into_iter().map(|t| t.unsqueeze_dim(dim)).collect();


### PR DESCRIPTION
### Changes

Changed the documentation on `Tensor::stack` function to be less confusing and misleading.

```rust
use burn::{
    backend::NdArray,
    tensor::{Int, Tensor},
};

fn main() {
    type B = NdArray;

    let v1 = Tensor::<B, 1, Int>::arange(2..5);
    let v2 = Tensor::<B, 1, Int>::arange(1..4);

    // Runtime error, even though `dim: 2` falls in the range of `0..=D2`.
    dbg!(Tensor::stack::<2>(vec![v1, v2], 2));
}
```
This probably must have been a simple typo or misunderstanding, since we index dimensions from 0, so if your tensor has `D2` dimensions, the highest you can index is `D2-1`.