### PR TITLE
[CI] Disable temporarily unnecessary steps on Windows runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,53 +145,61 @@ jobs:
           curl -L "$GRCOV_LINK/$GRCOV_VERSION/grcov-x86_64-unknown-linux-musl.tar.bz2" |
           tar xj -C $HOME/.cargo/bin
 
-      - name: (windows) install dxc
-        # from wgpu repo: https://github.com/gfx-rs/wgpu/blob/trunk/.github/workflows/ci.yml
-        if: runner.os == 'Windows'
-        shell: bash
-        run: |
-          set -e
+      # -----------------------------------------------------------------------------------
+      # BEGIN -- Windows steps disabled as long as DISABLE_WGPU=1 (wgpu tests are disabled)
+      # -----------------------------------------------------------------------------------
 
-          curl.exe -L --retry 5 https://github.com/microsoft/DirectXShaderCompiler/releases/download/$DXC_RELEASE/$DXC_FILENAME -o dxc.zip
-          7z.exe e dxc.zip -odxc bin/x64/{dxc.exe,dxcompiler.dll,dxil.dll}
+      # - name: (windows) install dxc
+      #   # from wgpu repo: https://github.com/gfx-rs/wgpu/blob/trunk/.github/workflows/ci.yml
+      #   if: runner.os == 'Windows'
+      #   shell: bash
+      #   run: |
+      #     set -e
 
-          # We need to use cygpath to convert PWD to a windows path as we're using bash.
-          cygpath --windows "$PWD/dxc" >> "$GITHUB_PATH"
+      #     curl.exe -L --retry 5 https://github.com/microsoft/DirectXShaderCompiler/releases/download/$DXC_RELEASE/$DXC_FILENAME -o dxc.zip
+      #     7z.exe e dxc.zip -odxc bin/x64/{dxc.exe,dxcompiler.dll,dxil.dll}
 
-      - name: (windows) install warp
-        # from wgpu repo: https://github.com/gfx-rs/wgpu/blob/trunk/.github/workflows/ci.yml
-        if: runner.os == 'Windows'
-        shell: bash
-        run: |
-          set -e
+      #     # We need to use cygpath to convert PWD to a windows path as we're using bash.
+      #     cygpath --windows "$PWD/dxc" >> "$GITHUB_PATH"
 
-          # Make sure dxc is in path.
-          dxc --version
+      # - name: (windows) install warp
+      #   # from wgpu repo: https://github.com/gfx-rs/wgpu/blob/trunk/.github/workflows/ci.yml
+      #   if: runner.os == 'Windows'
+      #   shell: bash
+      #   run: |
+      #     set -e
 
-          curl.exe -L --retry 5 https://www.nuget.org/api/v2/package/Microsoft.Direct3D.WARP/$WARP_VERSION -o warp.zip
-          7z.exe e warp.zip -owarp build/native/amd64/d3d10warp.dll
+      #     # Make sure dxc is in path.
+      #     dxc --version
 
-          mkdir -p target/llvm-cov-target/debug/deps
+      #     curl.exe -L --retry 5 https://www.nuget.org/api/v2/package/Microsoft.Direct3D.WARP/$WARP_VERSION -o warp.zip
+      #     7z.exe e warp.zip -owarp build/native/amd64/d3d10warp.dll
 
-          cp -v warp/d3d10warp.dll target/llvm-cov-target/debug/
-          cp -v warp/d3d10warp.dll target/llvm-cov-target/debug/deps
+      #     mkdir -p target/llvm-cov-target/debug/deps
 
-      - name: (windows) install mesa
-        # from wgpu repo: https://github.com/gfx-rs/wgpu/blob/trunk/.github/workflows/ci.yml
-        if: runner.os == 'Windows'
-        shell: bash
-        run: |
-          set -e
+      #     cp -v warp/d3d10warp.dll target/llvm-cov-target/debug/
+      #     cp -v warp/d3d10warp.dll target/llvm-cov-target/debug/deps
 
-          curl.exe -L --retry 5 https://github.com/pal1000/mesa-dist-win/releases/download/$MESA_VERSION/mesa3d-$MESA_VERSION-release-msvc.7z -o mesa.7z
-          7z.exe e mesa.7z -omesa x64/{opengl32.dll,libgallium_wgl.dll,libglapi.dll,vulkan_lvp.dll,lvp_icd.x86_64.json}
+      # - name: (windows) install mesa
+      #   # from wgpu repo: https://github.com/gfx-rs/wgpu/blob/trunk/.github/workflows/ci.yml
+      #   if: runner.os == 'Windows'
+      #   shell: bash
+      #   run: |
+      #     set -e
 
-          cp -v mesa/* target/llvm-cov-target/debug/
-          cp -v mesa/* target/llvm-cov-target/debug/deps
+      #     curl.exe -L --retry 5 https://github.com/pal1000/mesa-dist-win/releases/download/$MESA_VERSION/mesa3d-$MESA_VERSION-release-msvc.7z -o mesa.7z
+      #     7z.exe e mesa.7z -omesa x64/{opengl32.dll,libgallium_wgl.dll,libglapi.dll,vulkan_lvp.dll,lvp_icd.x86_64.json}
 
-          # We need to use cygpath to convert PWD to a windows path as we're using bash.
-          echo "VK_DRIVER_FILES=`cygpath --windows $PWD/mesa/lvp_icd.x86_64.json`" >> "$GITHUB_ENV"
-          echo "GALLIUM_DRIVER=llvmpipe" >> "$GITHUB_ENV"
+      #     cp -v mesa/* target/llvm-cov-target/debug/
+      #     cp -v mesa/* target/llvm-cov-target/debug/deps
+
+      #     # We need to use cygpath to convert PWD to a windows path as we're using bash.
+      #     echo "VK_DRIVER_FILES=`cygpath --windows $PWD/mesa/lvp_icd.x86_64.json`" >> "$GITHUB_ENV"
+      #     echo "GALLIUM_DRIVER=llvmpipe" >> "$GITHUB_ENV"
+
+      # -----------------------------------------------------------------------------------
+      # END -- Windows steps disabled as long as DISABLE_WGPU=1 (wgpu tests are disabled)
+      # -----------------------------------------------------------------------------------
 
       - name: (linux) install vulkan sdk
         # from wgpu repo: https://github.com/gfx-rs/wgpu/blob/trunk/.github/workflows/ci.yml


### PR DESCRIPTION
As wgpu is disabled on windows runners for now we can disable unnecessary steps to save some CI minutes.