### PR TITLE
Fix burn-compute cargo build command line in no-std

### DIFF
--- a/xtask/src/runchecks.rs
+++ b/xtask/src/runchecks.rs
@@ -236,7 +236,7 @@ fn no_std_checks() {
     build_and_test_no_std("burn-core", []);
     build_and_test_no_std(
         "burn-compute",
-        ["--features", "channel-mutex storage-bytes"],
+        ["--features", "channel-mutex,storage-bytes"],
     );
     build_and_test_no_std("burn-common", []);
     build_and_test_no_std("burn-tensor", []);


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

Simple fix that allows to copy/paste the output of the cargo build command line without formatting error.

