### PR TITLE
Fix small typos and dead links in README and burn-book

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ It can also be compiled to Web Assembly to run in the browser while leveraging t
 For more information on the benefits of this backend, see [this blog](https://burn.dev/blog/cross-platform-gpu-backend).
 
 The WGPU backend is our first "in-house backend", which means we have complete control over its implementation details.
-It is fully optimized with the [performance characteristics mentioned earlier](#performance), as it serves as our research playgound for a variety of optimizations.
+It is fully optimized with the [performance characteristics mentioned earlier](#performance), as it serves as our research playground for a variety of optimizations.
 
 See the [WGPU Backend README](./burn-wgpu/README.md) for more details.
 
@@ -473,7 +473,7 @@ Why use Rust for Deep Learning? 🦀
 Deep Learning is a special form of software where you need very high level abstractions as well as extremely fast execution time.
 Rust is the perfect candidate for that use case since it provides zero-cost abstractions to easily create neural network modules, and fine-grained control over memory to optimize every detail.
 
-It's important that a framework be easy to use at a high level so that its users can concentrate on innovating in the AI field.
+It's important that a framework be easy to use at a high level so that its users can focus on innovating in the AI field.
 However, since running models relies so heavily on computations, performance can't be neglected.
 
 To this day, the mainstream solution to this problem has been to offer APIs in Python, but rely on bindings to low-level languages such as C/C++.

--- a/burn-book/src/advanced/README.md
+++ b/burn-book/src/advanced/README.md
@@ -4,8 +4,8 @@ In this section, we will go into advanced topics that extend beyond basic usage.
 exceptional flexibility, a lot of advanced use cases become possible.
 
 Before going through this section, we strongly recommend exploring the
-[basic workflow](../basic-workflow/README.md) section and the
-[building blocks](../building-blocks/README.md) section. Establishing a solid understanding of how
+[basic workflow](../basic-workflow/) section and the
+[building blocks](../building-blocks/) section. Establishing a solid understanding of how
 the framework operates is crucial to comprehending the advanced concepts presented here. While you
 have the freedom to explore the advanced sections in any order you prefer, it's important to note
 that this section is not intended to be linear, contrary to preceding sections. Instead, it serves

--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -60,7 +60,7 @@ Those operations are available for all tensor kinds: `Int`, `Float`, and `Bool`.
 | `Tensor::from_data(data, device)`        | N/A                                  |
 | `tensor.into_primitive()`                | N/A                                  |
 | `Tensor::from_primitive(primitive)`      | N/A                                  |
-| `Tensor::stack(tensors, dim)`            | torch.stack(tensors, dim)`           |
+| `Tensor::stack(tensors, dim)`            | `torch.stack(tensors, dim)`           |
 
 ### Numeric Operations
 


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.


### Changes

- Fixed some minor typos in README and burn book
- Fixed dead links to sections in book (../building-blocks/README.md rendered to building-blocks/README.html which is invalid)
- Changed "concentrate" to "focus" (subjective edit, but feels more natural to say)
