### PR TITLE
Add example for custom CSV dataset

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ wasm-bindgen-futures = "0.4.38"
 wasm-logger = "0.2.0"
 wasm-timer = "0.2.5"
 console_error_panic_hook = "0.1.7"
+reqwest = "0.11.23"
 
 
 # WGPU stuff

--- a/burn-dataset/tests/data/dataset-fmt.csv
+++ b/burn-dataset/tests/data/dataset-fmt.csv
@@ -1,0 +1,2 @@
+HI1 1 true 1.0
+HI2 1 false 1.0

--- a/examples/custom-csv-dataset/.gitignore
+++ b/examples/custom-csv-dataset/.gitignore
@@ -1,0 +1,2 @@
+# Ignore downloaded csv file
+*.csv

--- a/examples/custom-csv-dataset/Cargo.toml
+++ b/examples/custom-csv-dataset/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+authors = ["guillaumelagrange <lagrange.guillaume.1@gmail.com>"]
+edition.workspace = true
+license.workspace = true
+name = "custom-csv-dataset"
+description = "Example implementation for loading a custom CSV dataset from disk"
+publish = false
+version.workspace = true
+
+[features]
+default = ["burn/dataset"]
+
+[dependencies]
+burn = {path = "../../burn"}
+
+# File download
+reqwest = {workspace = true, features = ["blocking"]}
+tempfile = {workspace = true}
+# indicatif = {workspace = true}
+
+# CSV parsing
+csv = {workspace = true}
+serde = {workspace = true, features = ["std", "derive"]}

--- a/examples/custom-csv-dataset/Cargo.toml
+++ b/examples/custom-csv-dataset/Cargo.toml
@@ -16,7 +16,6 @@ burn = {path = "../../burn"}
 # File download
 reqwest = {workspace = true, features = ["blocking"]}
 tempfile = {workspace = true}
-# indicatif = {workspace = true}
 
 # CSV parsing
 csv = {workspace = true}

--- a/examples/custom-csv-dataset/README.md
+++ b/examples/custom-csv-dataset/README.md
@@ -2,27 +2,10 @@
 
 The [custom-csv-dataset](src/dataset.rs) example implements the `Dataset` trait to retrieve dataset elements from a `.csv` file on disk. For this example, we use the [diabetes dataset](https://scikit-learn.org/stable/datasets/toy_dataset.html#diabetes-dataset) (original [source](https://www4.stat.ncsu.edu/~boos/var.select/diabetes.html)).
 
-While we could use the `InMemDataset::from_csv(path)` method to read the csv file to store the entire dataset elements to a vector (in-memory), the default `csv::Reader` uses the comma `,` as a delimiter. Instead, we implement the `DiabetesDataset::new(path)` method to parse the `.csv` file with `serde` into a vector of `DiabetesPatient` records (struct).
+The dataset only contains 442 records, so we use [`InMemDataset::from_csv(path)`](src/dataset.rs#L80) method to read the csv dataset file into a vector (in-memory) of [`DiabetesPatient`](src/dataset.rs#L13) records (struct) with the help of `serde`.
 
 ## Example Usage
 
 ```sh
 cargo run --example custom-csv-dataset
 ```
-
-
-<!-- ```bash
-git clone https://github.com/tracel-ai/burn.git
-cd burn
-# Use the --release flag to really speed up training.
-echo "Using ndarray backend"
-cargo run --example mnist --release --features ndarray                # CPU NdArray Backend - f32 - single thread
-cargo run --example mnist --release --features ndarray-blas-openblas  # CPU NdArray Backend - f32 - blas with openblas
-cargo run --example mnist --release --features ndarray-blas-netlib    # CPU NdArray Backend - f32 - blas with netlib
-echo "Using tch backend"
-export TORCH_CUDA_VERSION=cu113                                       # Set the cuda version
-cargo run --example mnist --release --features tch-gpu                # GPU Tch Backend - f32
-cargo run --example mnist --release --features tch-cpu                # CPU Tch Backend - f32
-echo "Using wgpu backend"
-cargo run --example mnist --release --features wgpu
-``` -->

--- a/examples/custom-csv-dataset/README.md
+++ b/examples/custom-csv-dataset/README.md
@@ -1,0 +1,28 @@
+# Custom CSV Dataset
+
+The [custom-csv-dataset](src/dataset.rs) example implements the `Dataset` trait to retrieve dataset elements from a `.csv` file on disk. For this example, we use the [diabetes dataset](https://scikit-learn.org/stable/datasets/toy_dataset.html#diabetes-dataset) (original [source](https://www4.stat.ncsu.edu/~boos/var.select/diabetes.html)).
+
+While we could use the `InMemDataset::from_csv(path)` method to read the csv file to store the entire dataset elements to a vector (in-memory), the default `csv::Reader` uses the comma `,` as a delimiter. Instead, we implement the `DiabetesDataset::new(path)` method to parse the `.csv` file with `serde` into a vector of `DiabetesPatient` records (struct).
+
+## Example Usage
+
+```sh
+cargo run --example custom-csv-dataset
+```
+
+
+<!-- ```bash
+git clone https://github.com/tracel-ai/burn.git
+cd burn
+# Use the --release flag to really speed up training.
+echo "Using ndarray backend"
+cargo run --example mnist --release --features ndarray                # CPU NdArray Backend - f32 - single thread
+cargo run --example mnist --release --features ndarray-blas-openblas  # CPU NdArray Backend - f32 - blas with openblas
+cargo run --example mnist --release --features ndarray-blas-netlib    # CPU NdArray Backend - f32 - blas with netlib
+echo "Using tch backend"
+export TORCH_CUDA_VERSION=cu113                                       # Set the cuda version
+cargo run --example mnist --release --features tch-gpu                # GPU Tch Backend - f32
+cargo run --example mnist --release --features tch-cpu                # CPU Tch Backend - f32
+echo "Using wgpu backend"
+cargo run --example mnist --release --features wgpu
+``` -->

--- a/examples/custom-csv-dataset/examples/custom-csv-dataset.rs
+++ b/examples/custom-csv-dataset/examples/custom-csv-dataset.rs
@@ -1,0 +1,14 @@
+use burn::data::dataset::Dataset;
+use custom_csv_dataset::dataset::DiabetesDataset;
+
+fn main() {
+    let dataset = DiabetesDataset::new().expect("Could not load diabetes dataset");
+
+    println!("Dataset loaded with {} rows", dataset.len());
+
+    let item = dataset.get(0).unwrap();
+    println!("First item:\n{:?}", item);
+
+    let item = dataset.get(441).unwrap();
+    println!("Last item:\n{:?}", item);
+}

--- a/examples/custom-csv-dataset/examples/custom-csv-dataset.rs
+++ b/examples/custom-csv-dataset/examples/custom-csv-dataset.rs
@@ -2,6 +2,17 @@ use burn::data::dataset::Dataset;
 use custom_csv_dataset::dataset::DiabetesDataset;
 
 fn main() {
+    // TODO:
+    // - Should the CSV reader be added to parametrize `InMemDataset::from_csv()`? Current implementation does not allow a wide configuration for the csv to read (but maybe this is better like this?)
+    // -> from_csv(path, ReaderBuilder)
+
+    // NEXT:
+    // - Huggingface source
+
+    // - Add another example for images? (similar to `torchvision.datasets.DatasetFolder`)
+    // - Add batcher to complete the example (new)
+
+    // let source = env::args().skip(1).next();
     let dataset = DiabetesDataset::new().expect("Could not load diabetes dataset");
 
     println!("Dataset loaded with {} rows", dataset.len());

--- a/examples/custom-csv-dataset/examples/custom-csv-dataset.rs
+++ b/examples/custom-csv-dataset/examples/custom-csv-dataset.rs
@@ -2,21 +2,11 @@ use burn::data::dataset::Dataset;
 use custom_csv_dataset::dataset::DiabetesDataset;
 
 fn main() {
-    // TODO:
-    // - Should the CSV reader be added to parametrize `InMemDataset::from_csv()`? Current implementation does not allow a wide configuration for the csv to read (but maybe this is better like this?)
-    // -> from_csv(path, ReaderBuilder)
-
-    // NEXT:
-    // - Huggingface source
-
-    // - Add another example for images? (similar to `torchvision.datasets.DatasetFolder`)
-    // - Add batcher to complete the example (new)
-
-    // let source = env::args().skip(1).next();
     let dataset = DiabetesDataset::new().expect("Could not load diabetes dataset");
 
     println!("Dataset loaded with {} rows", dataset.len());
 
+    // Display first and last elements
     let item = dataset.get(0).unwrap();
     println!("First item:\n{:?}", item);
 

--- a/examples/custom-csv-dataset/src/dataset.rs
+++ b/examples/custom-csv-dataset/src/dataset.rs
@@ -1,0 +1,133 @@
+use burn::data::dataset::{Dataset, InMemDataset};
+use serde::{Deserialize, Serialize};
+use std::{
+    fs::File,
+    io::{copy, BufReader},
+    path::{Path, PathBuf},
+};
+
+/// Diabetes patient record.
+/// For each field, we manually specify the expected header name for serde as all names
+/// are capitalized and some field names are not very informative.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct DiabetesPatient {
+    /// Age in years
+    #[serde(rename = "AGE")]
+    pub age: u8,
+
+    /// Sex categorical label
+    #[serde(rename = "SEX")]
+    pub sex: u8,
+
+    /// Body mass index
+    #[serde(rename = "BMI")]
+    pub bmi: f32,
+
+    /// Average blood pressure
+    #[serde(rename = "BP")]
+    pub bp: f32,
+
+    /// S1: total serum cholesterol
+    #[serde(rename = "S1")]
+    pub tc: u16,
+
+    /// S2: low-density lipoproteins
+    #[serde(rename = "S2")]
+    pub ldl: f32,
+
+    /// S3: high-density lipoproteins
+    #[serde(rename = "S3")]
+    pub hdl: f32,
+
+    /// S4: total cholesterol
+    #[serde(rename = "S4")]
+    pub tch: f32,
+
+    /// S5: possibly log of serum triglycerides level
+    #[serde(rename = "S5")]
+    pub ltg: f32,
+
+    /// S6: blood sugar level
+    #[serde(rename = "S6")]
+    pub glu: u8,
+
+    /// Y: quantitative measure of disease progression one year after baseline
+    #[serde(rename = "Y")]
+    pub response: u16,
+}
+
+/// Diabetes patients dataset, also used in [scikit-learn](https://scikit-learn.org/stable/).
+/// See [Diabetes dataset](https://scikit-learn.org/stable/datasets/toy_dataset.html#diabetes-dataset).
+///
+/// The data is parsed from a single csv file (tab as the delimiter).
+/// The dataset contains 10 baseline variables (age, sex, body mass index, average blood pressure and
+/// 6 blood serum measurements for a total of 442 diabetes patients.
+/// For each patient, the response of interest, a quantitative measure of disease progression one year
+/// after baseline, was collected. This represents the target variable.
+pub struct DiabetesDataset {
+    dataset: InMemDataset<DiabetesPatient>,
+}
+
+impl DiabetesDataset {
+    pub fn new() -> Result<Self, std::io::Error> {
+        // Download dataset csv file
+        let path = DiabetesDataset::download();
+
+        let file = File::open(path)?;
+        let reader = BufReader::new(file);
+
+        // Build csv::Reader instance with tab ('\t') delimiter
+        let mut rdr = csv::ReaderBuilder::new()
+            .delimiter(b'\t')
+            .from_reader(reader);
+
+        let mut patients = Vec::new();
+
+        // Read each row into a `DiabetesPatient` instance
+        for result in rdr.deserialize() {
+            let patient: DiabetesPatient = result?;
+            patients.push(patient);
+        }
+
+        let dataset = InMemDataset::new(patients);
+
+        let dataset = Self { dataset };
+
+        Ok(dataset)
+    }
+    /// Download the CSV file from its original source on the web.
+    /// Panics if the download cannot be completed or the content of the file cannot be written to disk.
+    fn download() -> PathBuf {
+        // Point file to current example directory
+        let example_dir = Path::new(file!()).parent().unwrap().parent().unwrap();
+        let file_name = example_dir.join("diabetes.csv");
+
+        if file_name.exists() {
+            println!("File already downloaded at {:?}", file_name);
+        } else {
+            // Get file from web
+            println!("Downloading file to {:?}", file_name);
+            let url = "https://www4.stat.ncsu.edu/~boos/var.select/diabetes.tab.txt";
+            let mut response = reqwest::blocking::get(url).unwrap();
+
+            // Create file to write the downloaded content to
+            let mut file = File::create(&file_name).unwrap();
+
+            // Copy the downloaded contents
+            copy(&mut response, &mut file).unwrap();
+        };
+
+        file_name
+    }
+}
+
+// Implement the `Dataset` trait which requires `get` and `len`
+impl Dataset<DiabetesPatient> for DiabetesDataset {
+    fn get(&self, index: usize) -> Option<DiabetesPatient> {
+        self.dataset.get(index)
+    }
+
+    fn len(&self) -> usize {
+        self.dataset.len()
+    }
+}

--- a/examples/custom-csv-dataset/src/dataset.rs
+++ b/examples/custom-csv-dataset/src/dataset.rs
@@ -2,7 +2,7 @@ use burn::data::dataset::{Dataset, InMemDataset};
 use serde::{Deserialize, Serialize};
 use std::{
     fs::File,
-    io::{copy, BufReader},
+    io::copy,
     path::{Path, PathBuf},
 };
 
@@ -73,23 +73,11 @@ impl DiabetesDataset {
         // Download dataset csv file
         let path = DiabetesDataset::download();
 
-        let file = File::open(path)?;
-        let reader = BufReader::new(file);
+        // Build dataset from csv with tab ('\t') delimiter
+        let mut rdr = csv::ReaderBuilder::new();
+        let rdr = rdr.delimiter(b'\t');
 
-        // Build csv::Reader instance with tab ('\t') delimiter
-        let mut rdr = csv::ReaderBuilder::new()
-            .delimiter(b'\t')
-            .from_reader(reader);
-
-        let mut patients = Vec::new();
-
-        // Read each row into a `DiabetesPatient` instance
-        for result in rdr.deserialize() {
-            let patient: DiabetesPatient = result?;
-            patients.push(patient);
-        }
-
-        let dataset = InMemDataset::new(patients);
+        let dataset = InMemDataset::from_csv(path, rdr).unwrap();
 
         let dataset = Self { dataset };
 

--- a/examples/custom-csv-dataset/src/lib.rs
+++ b/examples/custom-csv-dataset/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod dataset;


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Issue #1082

### Changes

- Refactored `InMemDataset::from_csv()` to accept `csv::ReaderBuilder` for configurable CSV file parsing
- Added another test for `InMemDataset::from_csv()` with a custom CSV file that differs from the default format
- Added an example to load the [diabetes dataset](https://scikit-learn.org/stable/datasets/toy_dataset.html#diabetes-dataset) from disk (automatically downloads the file to the example's working dir)
