### PR TITLE
Refactor serialization of benchmarks

### DIFF
--- a/backend-comparison/Cargo.toml
+++ b/backend-comparison/Cargo.toml
@@ -32,7 +32,6 @@ rand = { workspace = true }
 burn-common = { path = "../burn-common", version = "0.12.0" }
 serde_json = { workspace = true }
 dirs = "5.0.1"
-uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
 

--- a/backend-comparison/Cargo.toml
+++ b/backend-comparison/Cargo.toml
@@ -32,6 +32,7 @@ rand = { workspace = true }
 burn-common = { path = "../burn-common", version = "0.12.0" }
 serde_json = { workspace = true }
 dirs = "5.0.1"
+uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
 

--- a/backend-comparison/benches/binary.rs
+++ b/backend-comparison/benches/binary.rs
@@ -12,15 +12,11 @@ impl<B: Backend, const D: usize> Benchmark for BinaryBenchmark<B, D> {
     type Args = (Tensor<B, D>, Tensor<B, D>);
 
     fn name(&self) -> String {
-        "Binary Ops".into()
+        "binary".into()
     }
 
-    fn operation(&self) -> Option<String> {
-        Some("binary".to_string())
-    }
-
-    fn shapes(&self) -> Option<Vec<String>> {
-        Some(vec![format!("{:?}", self.shape.dims)])
+    fn shapes(&self) -> Vec<Vec<usize>> {
+        vec!(self.shape.dims.into())
     }
 
     fn execute(&self, (lhs, rhs): Self::Args) {
@@ -50,7 +46,7 @@ fn bench<B: Backend>(device: &B::Device) {
         device: device.clone(),
     };
 
-    save::<B>("binary", vec![run_benchmark(benchmark)], device).unwrap();
+    save::<B>(vec![run_benchmark(benchmark)], device).unwrap();
 }
 
 fn main() {

--- a/backend-comparison/benches/binary.rs
+++ b/backend-comparison/benches/binary.rs
@@ -16,7 +16,7 @@ impl<B: Backend, const D: usize> Benchmark for BinaryBenchmark<B, D> {
     }
 
     fn shapes(&self) -> Vec<Vec<usize>> {
-        vec!(self.shape.dims.into())
+        vec![self.shape.dims.into()]
     }
 
     fn num_repeats(&self) -> usize {

--- a/backend-comparison/benches/binary.rs
+++ b/backend-comparison/benches/binary.rs
@@ -1,4 +1,4 @@
-use backend_comparison::persistence::Persistence;
+use backend_comparison::persistence::save;
 use burn::tensor::{backend::Backend, Distribution, Shape, Tensor};
 use burn_common::benchmark::{run_benchmark, Benchmark};
 
@@ -13,6 +13,14 @@ impl<B: Backend, const D: usize> Benchmark for BinaryBenchmark<B, D> {
 
     fn name(&self) -> String {
         "Binary Ops".into()
+    }
+
+    fn operation(&self) -> Option<String> {
+        Some("binary".to_string())
+    }
+
+    fn shapes(&self) -> Option<Vec<String>> {
+        Some(vec![format!("{:?}", self.shape.dims)])
     }
 
     fn execute(&self, (lhs, rhs): Self::Args) {
@@ -42,7 +50,7 @@ fn bench<B: Backend>(device: &B::Device) {
         device: device.clone(),
     };
 
-    Persistence::persist::<B>(vec![run_benchmark(benchmark)], device)
+    save::<B>(vec![run_benchmark(benchmark)], device).unwrap();
 }
 
 fn main() {

--- a/backend-comparison/benches/binary.rs
+++ b/backend-comparison/benches/binary.rs
@@ -19,8 +19,12 @@ impl<B: Backend, const D: usize> Benchmark for BinaryBenchmark<B, D> {
         vec!(self.shape.dims.into())
     }
 
+    fn num_repeats(&self) -> usize {
+        self.num_repeats
+    }
+
     fn execute(&self, (lhs, rhs): Self::Args) {
-        for _ in 0..self.num_repeats {
+        for _ in 0..self.num_repeats() {
             // Choice of add is arbitrary
             B::add(lhs.clone().into_primitive(), rhs.clone().into_primitive());
         }

--- a/backend-comparison/benches/binary.rs
+++ b/backend-comparison/benches/binary.rs
@@ -4,7 +4,6 @@ use burn_common::benchmark::{run_benchmark, Benchmark};
 
 pub struct BinaryBenchmark<B: Backend, const D: usize> {
     shape: Shape<D>,
-    num_repeats: usize,
     device: B::Device,
 }
 
@@ -19,15 +18,9 @@ impl<B: Backend, const D: usize> Benchmark for BinaryBenchmark<B, D> {
         vec![self.shape.dims.into()]
     }
 
-    fn num_repeats(&self) -> usize {
-        self.num_repeats
-    }
-
     fn execute(&self, (lhs, rhs): Self::Args) {
-        for _ in 0..self.num_repeats() {
-            // Choice of add is arbitrary
-            B::add(lhs.clone().into_primitive(), rhs.clone().into_primitive());
-        }
+        // Choice of add is arbitrary
+        B::add(lhs.clone().into_primitive(), rhs.clone().into_primitive());
     }
 
     fn prepare(&self) -> Self::Args {
@@ -46,7 +39,6 @@ impl<B: Backend, const D: usize> Benchmark for BinaryBenchmark<B, D> {
 fn bench<B: Backend>(device: &B::Device) {
     let benchmark = BinaryBenchmark::<B, 3> {
         shape: [32, 512, 1024].into(),
-        num_repeats: 10,
         device: device.clone(),
     };
 

--- a/backend-comparison/benches/binary.rs
+++ b/backend-comparison/benches/binary.rs
@@ -50,7 +50,7 @@ fn bench<B: Backend>(device: &B::Device) {
         device: device.clone(),
     };
 
-    save::<B>(vec![run_benchmark(benchmark)], device).unwrap();
+    save::<B>("binary", vec![run_benchmark(benchmark)], device).unwrap();
 }
 
 fn main() {

--- a/backend-comparison/benches/custom_gelu.rs
+++ b/backend-comparison/benches/custom_gelu.rs
@@ -24,8 +24,7 @@ impl<B: Backend, const D: usize> Benchmark for CustomGeluBenchmark<B, D> {
     type Args = Tensor<B, D>;
 
     fn name(&self) -> String {
-        let kindstr = format!("{:?}", self.kind);
-        format!("gelu_{}", kindstr.to_lowercase())
+        "gelu".into()
     }
 
     fn options(&self) -> Option<String> {

--- a/backend-comparison/benches/custom_gelu.rs
+++ b/backend-comparison/benches/custom_gelu.rs
@@ -33,7 +33,7 @@ impl<B: Backend, const D: usize> Benchmark for CustomGeluBenchmark<B, D> {
     }
 
     fn shapes(&self) -> Vec<Vec<usize>> {
-        vec!(self.shape.dims.into())
+        vec![self.shape.dims.into()]
     }
 
     fn execute(&self, args: Self::Args) {

--- a/backend-comparison/benches/custom_gelu.rs
+++ b/backend-comparison/benches/custom_gelu.rs
@@ -24,19 +24,16 @@ impl<B: Backend, const D: usize> Benchmark for CustomGeluBenchmark<B, D> {
     type Args = Tensor<B, D>;
 
     fn name(&self) -> String {
-        format!("Gelu {:?}", self.kind)
+        let kindstr = format!("{:?}", self.kind);
+        format!("gelu_{}", kindstr.to_lowercase())
     }
 
-    fn operation(&self) -> Option<String> {
-        match self.kind {
-            GeluKind::Reference => Some("gelu".to_string()),
-            GeluKind::WithReferenceErf => Some("gelu_custom".to_string()),
-            GeluKind::WithCustomErf => Some("gelu_custom".to_string()),
-        }
+    fn options(&self) -> Option<String> {
+        Some(format!("{:?}", self.kind))
     }
 
-    fn shapes(&self) -> Option<Vec<String>> {
-        Some(vec![format!("{:?}", self.shape.dims)])
+    fn shapes(&self) -> Vec<Vec<usize>> {
+        vec!(self.shape.dims.into())
     }
 
     fn execute(&self, args: Self::Args) {
@@ -109,7 +106,6 @@ fn bench<B: Backend>(device: &B::Device) {
         CustomGeluBenchmark::<B, D>::new(shape, device.clone(), GeluKind::WithCustomErf);
 
     save::<B>(
-        "gelu",
         vec![
             run_benchmark(reference_gelu),
             run_benchmark(reference_erf_gelu),

--- a/backend-comparison/benches/custom_gelu.rs
+++ b/backend-comparison/benches/custom_gelu.rs
@@ -109,6 +109,7 @@ fn bench<B: Backend>(device: &B::Device) {
         CustomGeluBenchmark::<B, D>::new(shape, device.clone(), GeluKind::WithCustomErf);
 
     save::<B>(
+        "gelu",
         vec![
             run_benchmark(reference_gelu),
             run_benchmark(reference_erf_gelu),

--- a/backend-comparison/benches/data.rs
+++ b/backend-comparison/benches/data.rs
@@ -21,8 +21,12 @@ impl<B: Backend, const D: usize> Benchmark for ToDataBenchmark<B, D> {
         vec!(self.shape.dims.into())
     }
 
+    fn num_repeats(&self) -> usize {
+        self.num_repeats
+    }
+
     fn execute(&self, args: Self::Args) {
-        for _ in 0..self.num_repeats {
+        for _ in 0..self.num_repeats() {
             let _data = args.to_data();
         }
     }
@@ -54,8 +58,12 @@ impl<B: Backend, const D: usize> Benchmark for FromDataBenchmark<B, D> {
         vec!(self.shape.dims.into())
     }
 
+    fn num_repeats(&self) -> usize {
+        self.num_repeats
+    }
+
     fn execute(&self, (data, device): Self::Args) {
-        for _ in 0..self.num_repeats {
+        for _ in 0..self.num_repeats() {
             let _data = Tensor::<B, D>::from_data(data.clone(), &device);
         }
     }

--- a/backend-comparison/benches/data.rs
+++ b/backend-comparison/benches/data.rs
@@ -1,4 +1,4 @@
-use backend_comparison::persistence::Persistence;
+use backend_comparison::persistence::save;
 use burn::tensor::{backend::Backend, Data, Distribution, Shape, Tensor};
 use burn_common::benchmark::{run_benchmark, Benchmark};
 use derive_new::new;
@@ -15,6 +15,14 @@ impl<B: Backend, const D: usize> Benchmark for ToDataBenchmark<B, D> {
 
     fn name(&self) -> String {
         format!("to-data-{:?}-{}", self.shape.dims, self.num_repeats)
+    }
+
+    fn operation(&self) -> Option<String> {
+        Some("to_data".to_string())
+    }
+
+    fn shapes(&self) -> Option<Vec<String>> {
+        Some(vec![format!("{:?}", self.shape.dims)])
     }
 
     fn execute(&self, args: Self::Args) {
@@ -44,6 +52,14 @@ impl<B: Backend, const D: usize> Benchmark for FromDataBenchmark<B, D> {
 
     fn name(&self) -> String {
         format!("from-data-{:?}-{}", self.shape.dims, self.num_repeats)
+    }
+
+    fn operation(&self) -> Option<String> {
+        Some("from_data".to_string())
+    }
+
+    fn shapes(&self) -> Option<Vec<String>> {
+        Some(vec![format!("{:?}", self.shape.dims)])
     }
 
     fn execute(&self, (data, device): Self::Args) {
@@ -77,10 +93,11 @@ fn bench<B: Backend>(device: &B::Device) {
     let to_benchmark = ToDataBenchmark::<B, D>::new(shape.clone(), num_repeats, device.clone());
     let from_benchmark = FromDataBenchmark::<B, D>::new(shape, num_repeats, device.clone());
 
-    Persistence::persist::<B>(
+    save::<B>(
         vec![run_benchmark(to_benchmark), run_benchmark(from_benchmark)],
         device,
     )
+    .unwrap();
 }
 
 fn main() {

--- a/backend-comparison/benches/data.rs
+++ b/backend-comparison/benches/data.rs
@@ -94,6 +94,7 @@ fn bench<B: Backend>(device: &B::Device) {
     let from_benchmark = FromDataBenchmark::<B, D>::new(shape, num_repeats, device.clone());
 
     save::<B>(
+        "data",
         vec![run_benchmark(to_benchmark), run_benchmark(from_benchmark)],
         device,
     )

--- a/backend-comparison/benches/data.rs
+++ b/backend-comparison/benches/data.rs
@@ -14,15 +14,11 @@ impl<B: Backend, const D: usize> Benchmark for ToDataBenchmark<B, D> {
     type Args = Tensor<B, D>;
 
     fn name(&self) -> String {
-        format!("to-data-{:?}-{}", self.shape.dims, self.num_repeats)
+        "to_data".into()
     }
 
-    fn operation(&self) -> Option<String> {
-        Some("to_data".to_string())
-    }
-
-    fn shapes(&self) -> Option<Vec<String>> {
-        Some(vec![format!("{:?}", self.shape.dims)])
+    fn shapes(&self) -> Vec<Vec<usize>> {
+        vec!(self.shape.dims.into())
     }
 
     fn execute(&self, args: Self::Args) {
@@ -51,15 +47,11 @@ impl<B: Backend, const D: usize> Benchmark for FromDataBenchmark<B, D> {
     type Args = (Data<B::FloatElem, D>, B::Device);
 
     fn name(&self) -> String {
-        format!("from-data-{:?}-{}", self.shape.dims, self.num_repeats)
+        "from_data".into()
     }
 
-    fn operation(&self) -> Option<String> {
-        Some("from_data".to_string())
-    }
-
-    fn shapes(&self) -> Option<Vec<String>> {
-        Some(vec![format!("{:?}", self.shape.dims)])
+    fn shapes(&self) -> Vec<Vec<usize>> {
+        vec!(self.shape.dims.into())
     }
 
     fn execute(&self, (data, device): Self::Args) {
@@ -94,7 +86,6 @@ fn bench<B: Backend>(device: &B::Device) {
     let from_benchmark = FromDataBenchmark::<B, D>::new(shape, num_repeats, device.clone());
 
     save::<B>(
-        "data",
         vec![run_benchmark(to_benchmark), run_benchmark(from_benchmark)],
         device,
     )

--- a/backend-comparison/benches/data.rs
+++ b/backend-comparison/benches/data.rs
@@ -18,7 +18,7 @@ impl<B: Backend, const D: usize> Benchmark for ToDataBenchmark<B, D> {
     }
 
     fn shapes(&self) -> Vec<Vec<usize>> {
-        vec!(self.shape.dims.into())
+        vec![self.shape.dims.into()]
     }
 
     fn num_repeats(&self) -> usize {
@@ -55,7 +55,7 @@ impl<B: Backend, const D: usize> Benchmark for FromDataBenchmark<B, D> {
     }
 
     fn shapes(&self) -> Vec<Vec<usize>> {
-        vec!(self.shape.dims.into())
+        vec![self.shape.dims.into()]
     }
 
     fn num_repeats(&self) -> usize {

--- a/backend-comparison/benches/data.rs
+++ b/backend-comparison/benches/data.rs
@@ -6,7 +6,6 @@ use derive_new::new;
 #[derive(new)]
 struct ToDataBenchmark<B: Backend, const D: usize> {
     shape: Shape<D>,
-    num_repeats: usize,
     device: B::Device,
 }
 
@@ -21,14 +20,8 @@ impl<B: Backend, const D: usize> Benchmark for ToDataBenchmark<B, D> {
         vec![self.shape.dims.into()]
     }
 
-    fn num_repeats(&self) -> usize {
-        self.num_repeats
-    }
-
     fn execute(&self, args: Self::Args) {
-        for _ in 0..self.num_repeats() {
-            let _data = args.to_data();
-        }
+        let _data = args.to_data();
     }
 
     fn prepare(&self) -> Self::Args {
@@ -43,7 +36,6 @@ impl<B: Backend, const D: usize> Benchmark for ToDataBenchmark<B, D> {
 #[derive(new)]
 struct FromDataBenchmark<B: Backend, const D: usize> {
     shape: Shape<D>,
-    num_repeats: usize,
     device: B::Device,
 }
 
@@ -58,14 +50,8 @@ impl<B: Backend, const D: usize> Benchmark for FromDataBenchmark<B, D> {
         vec![self.shape.dims.into()]
     }
 
-    fn num_repeats(&self) -> usize {
-        self.num_repeats
-    }
-
     fn execute(&self, (data, device): Self::Args) {
-        for _ in 0..self.num_repeats() {
-            let _data = Tensor::<B, D>::from_data(data.clone(), &device);
-        }
+        let _data = Tensor::<B, D>::from_data(data.clone(), &device);
     }
 
     fn prepare(&self) -> Self::Args {
@@ -88,10 +74,9 @@ impl<B: Backend, const D: usize> Benchmark for FromDataBenchmark<B, D> {
 fn bench<B: Backend>(device: &B::Device) {
     const D: usize = 3;
     let shape: Shape<D> = [32, 512, 1024].into();
-    let num_repeats = 10;
 
-    let to_benchmark = ToDataBenchmark::<B, D>::new(shape.clone(), num_repeats, device.clone());
-    let from_benchmark = FromDataBenchmark::<B, D>::new(shape, num_repeats, device.clone());
+    let to_benchmark = ToDataBenchmark::<B, D>::new(shape.clone(), device.clone());
+    let from_benchmark = FromDataBenchmark::<B, D>::new(shape, device.clone());
 
     save::<B>(
         vec![run_benchmark(to_benchmark), run_benchmark(from_benchmark)],

--- a/backend-comparison/benches/matmul.rs
+++ b/backend-comparison/benches/matmul.rs
@@ -26,8 +26,12 @@ impl<B: Backend, const D: usize> Benchmark for MatmulBenchmark<B, D> {
         10
     }
 
+    fn num_repeats(&self) -> usize {
+        self.num_repeats
+    }
+
     fn execute(&self, (lhs, rhs): Self::Args) {
-        for _ in 0..self.num_repeats {
+        for _ in 0..self.num_repeats() {
             lhs.clone().matmul(rhs.clone());
         }
     }

--- a/backend-comparison/benches/matmul.rs
+++ b/backend-comparison/benches/matmul.rs
@@ -15,21 +15,11 @@ impl<B: Backend, const D: usize> Benchmark for MatmulBenchmark<B, D> {
     type Args = (Tensor<B, D>, Tensor<B, D>);
 
     fn name(&self) -> String {
-        format!(
-            "Matmul {:?} x {:?}",
-            self.shape_lhs.dims, self.shape_rhs.dims
-        )
+        "matmul".into()
     }
 
-    fn operation(&self) -> Option<String> {
-        Some("matmul".to_string())
-    }
-
-    fn shapes(&self) -> Option<Vec<String>> {
-        Some(vec![
-            format!("{:?}", self.shape_lhs.dims),
-            format!("{:?}", self.shape_rhs.dims),
-        ])
+    fn shapes(&self) -> Vec<Vec<usize>> {
+        vec!(self.shape_lhs.dims.into(), self.shape_rhs.dims.into())
     }
 
     fn num_samples(&self) -> usize {
@@ -67,7 +57,7 @@ fn bench<B: Backend>(device: &B::Device) {
 
     let benchmark = MatmulBenchmark::<B, D>::new(shape_lhs, shape_rhs, num_repeats, device.clone());
 
-    save::<B>("matmul", vec![run_benchmark(benchmark)], device).unwrap();
+    save::<B>(vec![run_benchmark(benchmark)], device).unwrap();
 }
 
 fn main() {

--- a/backend-comparison/benches/matmul.rs
+++ b/backend-comparison/benches/matmul.rs
@@ -19,7 +19,7 @@ impl<B: Backend, const D: usize> Benchmark for MatmulBenchmark<B, D> {
     }
 
     fn shapes(&self) -> Vec<Vec<usize>> {
-        vec!(self.shape_lhs.dims.into(), self.shape_rhs.dims.into())
+        vec![self.shape_lhs.dims.into(), self.shape_rhs.dims.into()]
     }
 
     fn num_samples(&self) -> usize {

--- a/backend-comparison/benches/matmul.rs
+++ b/backend-comparison/benches/matmul.rs
@@ -67,7 +67,7 @@ fn bench<B: Backend>(device: &B::Device) {
 
     let benchmark = MatmulBenchmark::<B, D>::new(shape_lhs, shape_rhs, num_repeats, device.clone());
 
-    save::<B>(vec![run_benchmark(benchmark)], device).unwrap();
+    save::<B>("matmul", vec![run_benchmark(benchmark)], device).unwrap();
 }
 
 fn main() {

--- a/backend-comparison/benches/matmul.rs
+++ b/backend-comparison/benches/matmul.rs
@@ -1,4 +1,4 @@
-use backend_comparison::persistence::Persistence;
+use backend_comparison::persistence::save;
 use burn::tensor::{backend::Backend, Distribution, Shape, Tensor};
 use burn_common::benchmark::{run_benchmark, Benchmark};
 use derive_new::new;
@@ -19,6 +19,17 @@ impl<B: Backend, const D: usize> Benchmark for MatmulBenchmark<B, D> {
             "Matmul {:?} x {:?}",
             self.shape_lhs.dims, self.shape_rhs.dims
         )
+    }
+
+    fn operation(&self) -> Option<String> {
+        Some("matmul".to_string())
+    }
+
+    fn shapes(&self) -> Option<Vec<String>> {
+        Some(vec![
+            format!("{:?}", self.shape_lhs.dims),
+            format!("{:?}", self.shape_rhs.dims),
+        ])
     }
 
     fn num_samples(&self) -> usize {
@@ -55,7 +66,8 @@ fn bench<B: Backend>(device: &B::Device) {
     let shape_rhs = [batch_size, k, n].into();
 
     let benchmark = MatmulBenchmark::<B, D>::new(shape_lhs, shape_rhs, num_repeats, device.clone());
-    Persistence::persist::<B>(vec![run_benchmark(benchmark)], device)
+
+    save::<B>(vec![run_benchmark(benchmark)], device).unwrap();
 }
 
 fn main() {

--- a/backend-comparison/benches/matmul.rs
+++ b/backend-comparison/benches/matmul.rs
@@ -7,7 +7,6 @@ use derive_new::new;
 struct MatmulBenchmark<B: Backend, const D: usize> {
     shape_lhs: Shape<D>,
     shape_rhs: Shape<D>,
-    num_repeats: usize,
     device: B::Device,
 }
 
@@ -26,14 +25,8 @@ impl<B: Backend, const D: usize> Benchmark for MatmulBenchmark<B, D> {
         10
     }
 
-    fn num_repeats(&self) -> usize {
-        self.num_repeats
-    }
-
     fn execute(&self, (lhs, rhs): Self::Args) {
-        for _ in 0..self.num_repeats() {
-            lhs.clone().matmul(rhs.clone());
-        }
+        lhs.clone().matmul(rhs.clone());
     }
 
     fn prepare(&self) -> Self::Args {
@@ -51,7 +44,6 @@ impl<B: Backend, const D: usize> Benchmark for MatmulBenchmark<B, D> {
 #[allow(dead_code)]
 fn bench<B: Backend>(device: &B::Device) {
     const D: usize = 3;
-    let num_repeats = 3;
     let batch_size = 3;
     let m = 1024;
     let k = 2048;
@@ -59,7 +51,7 @@ fn bench<B: Backend>(device: &B::Device) {
     let shape_lhs = [batch_size, m, k].into();
     let shape_rhs = [batch_size, k, n].into();
 
-    let benchmark = MatmulBenchmark::<B, D>::new(shape_lhs, shape_rhs, num_repeats, device.clone());
+    let benchmark = MatmulBenchmark::<B, D>::new(shape_lhs, shape_rhs, device.clone());
 
     save::<B>(vec![run_benchmark(benchmark)], device).unwrap();
 }

--- a/backend-comparison/benches/unary.rs
+++ b/backend-comparison/benches/unary.rs
@@ -18,7 +18,7 @@ impl<B: Backend, const D: usize> Benchmark for UnaryBenchmark<B, D> {
     }
 
     fn shapes(&self) -> Vec<Vec<usize>> {
-        vec!(self.shape.dims.into())
+        vec![self.shape.dims.into()]
     }
 
     fn num_repeats(&self) -> usize {

--- a/backend-comparison/benches/unary.rs
+++ b/backend-comparison/benches/unary.rs
@@ -14,15 +14,11 @@ impl<B: Backend, const D: usize> Benchmark for UnaryBenchmark<B, D> {
     type Args = Tensor<B, D>;
 
     fn name(&self) -> String {
-        "Unary Ops".into()
+        "unary".into()
     }
 
-    fn operation(&self) -> Option<String> {
-        Some("unary".to_string())
-    }
-
-    fn shapes(&self) -> Option<Vec<String>> {
-        Some(vec![format!("{:?}", self.shape.dims)])
+    fn shapes(&self) -> Vec<Vec<usize>> {
+        vec!(self.shape.dims.into())
     }
 
     fn execute(&self, args: Self::Args) {
@@ -49,7 +45,7 @@ fn bench<B: Backend>(device: &B::Device) {
 
     let benchmark = UnaryBenchmark::<B, D>::new(shape, num_repeats, device.clone());
 
-    save::<B>("unary", vec![run_benchmark(benchmark)], device).unwrap();
+    save::<B>(vec![run_benchmark(benchmark)], device).unwrap();
 }
 
 fn main() {

--- a/backend-comparison/benches/unary.rs
+++ b/backend-comparison/benches/unary.rs
@@ -49,7 +49,7 @@ fn bench<B: Backend>(device: &B::Device) {
 
     let benchmark = UnaryBenchmark::<B, D>::new(shape, num_repeats, device.clone());
 
-    save::<B>(vec![run_benchmark(benchmark)], device).unwrap();
+    save::<B>("unary", vec![run_benchmark(benchmark)], device).unwrap();
 }
 
 fn main() {

--- a/backend-comparison/benches/unary.rs
+++ b/backend-comparison/benches/unary.rs
@@ -1,4 +1,4 @@
-use backend_comparison::persistence::Persistence;
+use backend_comparison::persistence::save;
 use burn::tensor::{backend::Backend, Distribution, Shape, Tensor};
 use burn_common::benchmark::{run_benchmark, Benchmark};
 use derive_new::new;
@@ -15,6 +15,14 @@ impl<B: Backend, const D: usize> Benchmark for UnaryBenchmark<B, D> {
 
     fn name(&self) -> String {
         "Unary Ops".into()
+    }
+
+    fn operation(&self) -> Option<String> {
+        Some("unary".to_string())
+    }
+
+    fn shapes(&self) -> Option<Vec<String>> {
+        Some(vec![format!("{:?}", self.shape.dims)])
     }
 
     fn execute(&self, args: Self::Args) {
@@ -41,7 +49,7 @@ fn bench<B: Backend>(device: &B::Device) {
 
     let benchmark = UnaryBenchmark::<B, D>::new(shape, num_repeats, device.clone());
 
-    Persistence::persist::<B>(vec![run_benchmark(benchmark)], device)
+    save::<B>(vec![run_benchmark(benchmark)], device).unwrap();
 }
 
 fn main() {

--- a/backend-comparison/benches/unary.rs
+++ b/backend-comparison/benches/unary.rs
@@ -21,8 +21,12 @@ impl<B: Backend, const D: usize> Benchmark for UnaryBenchmark<B, D> {
         vec!(self.shape.dims.into())
     }
 
+    fn num_repeats(&self) -> usize {
+        self.num_repeats
+    }
+
     fn execute(&self, args: Self::Args) {
-        for _ in 0..self.num_repeats {
+        for _ in 0..self.num_repeats() {
             // Choice of tanh is arbitrary
             B::tanh(args.clone().into_primitive());
         }

--- a/backend-comparison/benches/unary.rs
+++ b/backend-comparison/benches/unary.rs
@@ -6,7 +6,6 @@ use derive_new::new;
 #[derive(new)]
 struct UnaryBenchmark<B: Backend, const D: usize> {
     shape: Shape<D>,
-    num_repeats: usize,
     device: B::Device,
 }
 
@@ -21,15 +20,9 @@ impl<B: Backend, const D: usize> Benchmark for UnaryBenchmark<B, D> {
         vec![self.shape.dims.into()]
     }
 
-    fn num_repeats(&self) -> usize {
-        self.num_repeats
-    }
-
     fn execute(&self, args: Self::Args) {
-        for _ in 0..self.num_repeats() {
-            // Choice of tanh is arbitrary
-            B::tanh(args.clone().into_primitive());
-        }
+        // Choice of tanh is arbitrary
+        B::tanh(args.clone().into_primitive());
     }
 
     fn prepare(&self) -> Self::Args {
@@ -45,9 +38,8 @@ impl<B: Backend, const D: usize> Benchmark for UnaryBenchmark<B, D> {
 fn bench<B: Backend>(device: &B::Device) {
     const D: usize = 3;
     let shape: Shape<D> = [32, 512, 1024].into();
-    let num_repeats = 10;
 
-    let benchmark = UnaryBenchmark::<B, D>::new(shape, num_repeats, device.clone());
+    let benchmark = UnaryBenchmark::<B, D>::new(shape, device.clone());
 
     save::<B>(vec![run_benchmark(benchmark)], device).unwrap();
 }

--- a/backend-comparison/src/persistence/base.rs
+++ b/backend-comparison/src/persistence/base.rs
@@ -1,7 +1,4 @@
-use std::{
-    fs,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::fs;
 
 use burn::{
     serde::{ser::SerializeStruct, Serialize, Serializer},
@@ -10,6 +7,7 @@ use burn::{
 use burn_common::benchmark::BenchmarkResult;
 use dirs;
 use serde_json;
+use uuid::Uuid;
 
 #[derive(Default)]
 pub struct BenchmarkRecord {
@@ -45,6 +43,7 @@ pub struct BenchmarkRecord {
 /// ]
 /// ```
 pub fn save<B: Backend>(
+    name: &str,
     benches: Vec<BenchmarkResult>,
     device: &B::Device,
 ) -> Result<Vec<BenchmarkRecord>, std::io::Error> {
@@ -57,17 +56,9 @@ pub fn save<B: Backend>(
         fs::create_dir_all(&cache_dir)?;
     }
 
-    let start = SystemTime::now();
-    let since_the_epoch = start
-        .duration_since(UNIX_EPOCH)
-        .expect("Time went backwards");
-    let timestamp = format!(
-        "{}{:03}",
-        since_the_epoch.as_secs(),
-        since_the_epoch.subsec_millis()
-    );
-
-    let file_name = format!("benchmarks_{}.json", timestamp);
+    let uuid = Uuid::new_v4().simple().to_string();
+    let short_uuid = &uuid[..8];
+    let file_name = format!("benchmarks_{}_{}.json", name, short_uuid);
     let file_path = cache_dir.join(file_name);
 
     let records: Vec<BenchmarkRecord> = benches

--- a/backend-comparison/src/persistence/base.rs
+++ b/backend-comparison/src/persistence/base.rs
@@ -46,7 +46,7 @@ pub fn save<B: Backend>(
     device: &B::Device,
 ) -> Result<Vec<BenchmarkRecord>, std::io::Error> {
     let cache_dir = dirs::home_dir()
-        .expect("Could not get home directory")
+        .expect("Home directory should exist")
         .join(".cache")
         .join("backend-comparison");
 
@@ -66,11 +66,12 @@ pub fn save<B: Backend>(
     for record in records.clone() {
         let file_name = format!(
             "bench_{}_{}.json",
-            record.results.name,
-            record.results.timestamp);
+            record.results.name, record.results.timestamp
+        );
         let file_path = cache_dir.join(file_name);
-        let file = fs::File::create(file_path).expect("Unable to create backend comparison file.");
-        serde_json::to_writer_pretty(file, &record).expect("Unable to save benchmark results.");
+        let file = fs::File::create(file_path).expect("Benchmark file should exist or be created");
+        serde_json::to_writer_pretty(file, &record)
+            .expect("Benchmark file should be updated with benchmark results");
     }
 
     Ok(records)

--- a/backend-comparison/src/persistence/base.rs
+++ b/backend-comparison/src/persistence/base.rs
@@ -109,7 +109,6 @@ impl Serialize for BenchmarkRecord {
             ("median", &self.results.computed.median.as_micros()),
             ("min", &self.results.computed.min.as_micros()),
             ("name", &self.results.name),
-            ("numRepeats", &self.results.num_repeats),
             ("numSamples", &self.results.raw.durations.len()),
             ("options", &self.results.options),
             ("rawDurations", &self.results.raw.durations),

--- a/backend-comparison/src/persistence/base.rs
+++ b/backend-comparison/src/persistence/base.rs
@@ -107,6 +107,7 @@ impl Serialize for BenchmarkRecord {
             ("median", &self.results.computed.median.as_micros()),
             ("min", &self.results.computed.min.as_micros()),
             ("name", &self.results.name),
+            ("numRepeats", &self.results.num_repeats),
             ("numSamples", &self.results.raw.durations.len()),
             ("options", &self.results.options),
             ("rawDurations", &self.results.raw.durations),

--- a/backend-comparison/src/persistence/base.rs
+++ b/backend-comparison/src/persistence/base.rs
@@ -48,6 +48,7 @@ pub fn save<B: Backend>(
     let cache_dir = dirs::home_dir()
         .expect("Home directory should exist")
         .join(".cache")
+        .join("burn")
         .join("backend-comparison");
 
     if !cache_dir.exists() {

--- a/burn-common/src/benchmark.rs
+++ b/burn-common/src/benchmark.rs
@@ -128,10 +128,6 @@ pub trait Benchmark {
     fn num_samples(&self) -> usize {
         10
     }
-    /// Number of executions per sample
-    fn num_repeats(&self) -> usize {
-        1
-    }
     /// Name of the benchmark, should be short and it should match the name
     /// defined in the crate Cargo.toml
     fn name(&self) -> String;
@@ -189,8 +185,6 @@ pub struct BenchmarkResult {
     pub git_hash: String,
     /// Name of the benchmark
     pub name: String,
-    /// Number of executions per sample
-    pub num_repeats: usize,
     /// Options passed to the benchmark
     pub options: Option<String>,
     /// Shape dimensions
@@ -236,7 +230,6 @@ where
         computed: BenchmarkComputations::new(&durations),
         git_hash,
         name: benchmark.name(),
-        num_repeats: benchmark.num_repeats(),
         options: benchmark.options(),
         shapes: benchmark.shapes(),
         timestamp,

--- a/burn-common/src/benchmark.rs
+++ b/burn-common/src/benchmark.rs
@@ -127,15 +127,16 @@ pub trait Benchmark {
     fn num_samples(&self) -> usize {
         10
     }
-    /// Name of the benchmark.
+    /// Name of the benchmark, should be short and it should match the name
+    /// defined in the crate Cargo.toml
     fn name(&self) -> String;
-    /// Operation name (i.e. matmul)
-    fn operation(&self) -> Option<String> {
+    /// The options passed to the benchmark.
+    fn options(&self) -> Option<String> {
         None
     }
     /// Shapes dimensions
-    fn shapes(&self) -> Option<Vec<String>> {
-        None
+    fn shapes(&self) -> Vec<Vec<usize>> {
+        vec!()
     }
     /// Wait for computed to be over
     fn sync(&self);
@@ -173,7 +174,7 @@ pub trait Benchmark {
 }
 
 /// Result of a benchmark run, with metadata
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct BenchmarkResult {
     /// Individual raw results of the run
     pub raw: BenchmarkDurations,
@@ -183,10 +184,10 @@ pub struct BenchmarkResult {
     pub git_hash: String,
     /// Name of the benchmark
     pub name: String,
-    /// Operation name
-    pub operation: Option<String>,
+    /// Options passed to the benchmark
+    pub options: Option<String>,
     /// Shape dimensions
-    pub shapes: Option<Vec<String>>,
+    pub shapes: Vec<Vec<usize>>,
     /// Time just before the run
     pub timestamp: u128,
 }
@@ -228,7 +229,7 @@ where
         computed: BenchmarkComputations::new(&durations),
         git_hash,
         name: benchmark.name(),
-        operation: benchmark.operation(),
+        options: benchmark.options(),
         shapes: benchmark.shapes(),
         timestamp,
     }

--- a/burn-common/src/benchmark.rs
+++ b/burn-common/src/benchmark.rs
@@ -140,7 +140,7 @@ pub trait Benchmark {
     }
     /// Shapes dimensions
     fn shapes(&self) -> Vec<Vec<usize>> {
-        vec!()
+        vec![]
     }
     /// Wait for computed to be over
     fn sync(&self);
@@ -235,7 +235,7 @@ where
         computed: BenchmarkComputations::new(&durations),
         git_hash,
         name: benchmark.name(),
-        num_repeats:  benchmark.num_repeats(),
+        num_repeats: benchmark.num_repeats(),
         options: benchmark.options(),
         shapes: benchmark.shapes(),
         timestamp,

--- a/burn-common/src/benchmark.rs
+++ b/burn-common/src/benchmark.rs
@@ -26,8 +26,8 @@ impl BenchmarkDurations {
         sorted.sort();
         let min = *sorted.first().unwrap();
         let max = *sorted.last().unwrap();
-        let var = *sorted.get(sorted.len() / 2).unwrap();
-        (min, max, var)
+        let median = *sorted.get(sorted.len() / 2).unwrap();
+        (min, max, median)
     }
 
     /// Returns the median duration among all durations

--- a/burn-common/src/benchmark.rs
+++ b/burn-common/src/benchmark.rs
@@ -123,9 +123,13 @@ pub trait Benchmark {
     fn prepare(&self) -> Self::Args;
     /// Execute the benchmark and returns the time it took to complete.
     fn execute(&self, args: Self::Args);
-    /// Number of samples required to have a statistical significance.
+    /// Number of samples per run required to have a statistical significance.
     fn num_samples(&self) -> usize {
         10
+    }
+    /// Number of executions per sample
+    fn num_repeats(&self) -> usize {
+        1
     }
     /// Name of the benchmark, should be short and it should match the name
     /// defined in the crate Cargo.toml
@@ -184,6 +188,8 @@ pub struct BenchmarkResult {
     pub git_hash: String,
     /// Name of the benchmark
     pub name: String,
+    /// Number of executions per sample
+    pub num_repeats: usize,
     /// Options passed to the benchmark
     pub options: Option<String>,
     /// Shape dimensions
@@ -229,6 +235,7 @@ where
         computed: BenchmarkComputations::new(&durations),
         git_hash,
         name: benchmark.name(),
+        num_repeats:  benchmark.num_repeats(),
         options: benchmark.options(),
         shapes: benchmark.shapes(),
         timestamp,

--- a/burn-common/src/benchmark.rs
+++ b/burn-common/src/benchmark.rs
@@ -1,5 +1,6 @@
 use alloc::format;
 use alloc::string::String;
+use alloc::vec;
 use alloc::vec::Vec;
 use core::fmt::Display;
 use core::time::Duration;

--- a/burn-common/src/benchmark.rs
+++ b/burn-common/src/benchmark.rs
@@ -282,11 +282,10 @@ mod tests {
                 Duration::new(20, 0),
                 Duration::new(30, 0),
                 Duration::new(40, 0),
-                Duration::new(50, 0),
             ],
         };
         let mean = durations.mean_duration();
-        assert_eq!(mean, Duration::from_secs(30));
+        assert_eq!(mean, Duration::from_secs(25));
     }
 
     #[test]

--- a/burn-compute/src/tune/tune_benchmark.rs
+++ b/burn-compute/src/tune/tune_benchmark.rs
@@ -34,6 +34,10 @@ impl<S: ComputeServer, C: ComputeChannel<S>> Benchmark for TuneBenchmark<S, C> {
         "Autotune".to_string()
     }
 
+    fn operation(&self) -> Option<String> {
+        Some(self.operation.name().to_string())
+    }
+
     fn sync(&self) {
         self.client.sync();
     }

--- a/burn-compute/src/tune/tune_benchmark.rs
+++ b/burn-compute/src/tune/tune_benchmark.rs
@@ -31,11 +31,7 @@ impl<S: ComputeServer, C: ComputeChannel<S>> Benchmark for TuneBenchmark<S, C> {
     }
 
     fn name(&self) -> String {
-        "Autotune".to_string()
-    }
-
-    fn operation(&self) -> Option<String> {
-        Some(self.operation.name().to_string())
+        "autotune".to_string()
     }
 
     fn sync(&self) {

--- a/burn-compute/src/tune/tuner.rs
+++ b/burn-compute/src/tune/tuner.rs
@@ -8,7 +8,7 @@ use core::time::Duration;
 use alloc::boxed::Box;
 use alloc::string::ToString;
 use alloc::vec::Vec;
-use burn_common::benchmark::{Benchmark, BenchmarkDurations};
+use burn_common::benchmark::{Benchmark, BenchmarkComputations, BenchmarkDurations};
 
 use crate::channel::ComputeChannel;
 use crate::client::ComputeClient;
@@ -95,10 +95,10 @@ impl<S: ComputeServer, C: ComputeChannel<S>> Tuner<S, C> {
         let mut fastest_tunable = None;
 
         for (i, result) in results.into_iter().enumerate() {
-            let duration = result.median_duration();
+            let computed = BenchmarkComputations::new(&result);
 
-            if duration < smallest_duration {
-                smallest_duration = duration;
+            if computed.median < smallest_duration {
+                smallest_duration = computed.median;
                 fastest_tunable = Some(i);
             }
         }


### PR DESCRIPTION
See changes below for a list of changes.

I  will add an "upload" function to  the persistence module in a further PR.

The current naming of the saved files need a bit of work, currently I just do `benchmarks_<timestamp>.json` but we could  have some race  condition and get some files overridden. --> We updated it to `bench_<name>_<timestamp>`.

The computed  values are saved in seconds, maybe we should  save them in milliseconds ? --> We  changed to microseconds.

You can see an example of produced file here: https://gist.github.com/syl20bnr/b0fdbbf0c3877b9e4ddf262a9cc388ac

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

- https://github.com/tracel-ai/burn/issues/1072

### Changes

* flatten benchmarks data to make it easier to save documents to a database and query them
* split some information into their own fields like backend and device
* add new serialized info:
  - computed values (mean, median, variance, min, max)
  - number of samples
  - operation name
  - tensor shapes if any
* serialize to separate files, one file per benchmark run
* simplify persistence module to only a save method
* remove remaining `num_repeats` in benches execute functions. 

### Testing

Tested serialization to disk with all the available benchmarks.
