### PR TITLE
Fix: Records no longer require Debug and Clone

### DIFF
--- a/burn-derive/src/record/codegen_struct.rs
+++ b/burn-derive/src/record/codegen_struct.rs
@@ -32,7 +32,7 @@ impl RecordItemCodegen for StructRecordItemCodegen {
         quote! {
 
             /// The record item type for the module.
-            #[derive(Debug, Clone, burn::serde::Serialize, burn::serde::Deserialize)]
+            #[derive(burn::serde::Serialize, burn::serde::Deserialize)]
             #[serde(crate = "burn::serde")]
             #[serde(bound = #bound)]
             pub struct #item_name #generics {


### PR DESCRIPTION
`Clone` and `Debug` are never used on `Record::Item` but were generated within the derive macro. It made it impossible to create a Record generic over another Record.