### PR TITLE
Add fan_out to `Conv2dConfig::init`

### DIFF
--- a/burn-core/src/nn/conv/conv2d.rs
+++ b/burn-core/src/nn/conv/conv2d.rs
@@ -70,17 +70,22 @@ impl Conv2dConfig {
             self.kernel_size[1],
         ];
 
-        let fan_in = self.channels[0] / self.groups * self.kernel_size.iter().product::<usize>();
+        let k = self.kernel_size.iter().product::<usize>() / self.groups;
+        let fan_in = self.channels[0] * k;
+        let fan_out = self.channels[1] * k;
+
         let weight = self
             .initializer
-            .init_with(shape, Some(fan_in), None, device);
+            .init_with(shape, Some(fan_in), Some(fan_out), device);
         let mut bias = None;
 
         if self.bias {
-            bias = Some(
-                self.initializer
-                    .init_with([self.channels[1]], Some(fan_in), None, device),
-            );
+            bias = Some(self.initializer.init_with(
+                [self.channels[1]],
+                Some(fan_in),
+                Some(fan_out),
+                device,
+            ));
         }
 
         Conv2d {
@@ -160,5 +165,20 @@ mod tests {
         conv.weight
             .to_data()
             .assert_approx_eq(&Data::zeros(conv.weight.shape()), 3);
+    }
+
+    #[test]
+    fn initializer_fan_out() {
+        TestBackend::seed(0);
+
+        let init = Initializer::KaimingUniform {
+            gain: 1.0 / sqrt(3.0),
+            fan_out_only: true, // test that fan_out is passed to `init_with()`
+        };
+        let device = Default::default();
+        let config = Conv2dConfig::new([5, 1], [5, 5]).with_initializer(init.clone());
+        let _ = config.init::<TestBackend>(&device);
+
+        assert_eq!(config.initializer, init);
     }
 }


### PR DESCRIPTION
When using a custom `Initializer` with `fan_out_only: true`, the `Conv2dConfig::init()` panics because we only provide a value for `fan_in`.

```rust
let init = Initializer::KaimingUniform {
    gain: 1.0 / sqrt(3.0),
    fan_out_only: true,
};
let device = Default::default();
let config = Conv2dConfig::new([5, 1], [5, 5]).with_initializer(init.clone());
let _ = config.init::<TestBackend>(&device);
```

This example results in:
```
thread 'main' panicked at burn-core/src/nn/initializer.rs:132:23:
Can't use Kaiming initialization without specifying fan. Use init_with method.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

- Added `fan_out` calculation to `Conv2dConfig::init()` to handle custom `Initializer` w/ `fan_out_only` set to `true`

### Testing

- Added simple `initializer_fan_out()` test to make sure `fan_out` is passed to `Initializer::init_with()` (previously panicked)
