### PR TITLE
Fix missing ticks in Burn book and remove unused example dependency

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -113,8 +113,8 @@ Those operations are available for numeric tensor kinds: `Float` and `Int`.
 | `tensor.clamp_min(min)`                          | `torch.clamp(tensor, min=min)`                 |
 | `tensor.clamp_max(max)`                          | `torch.clamp(tensor, max=max)`                 |
 | `tensor.abs()`                                   | `torch.abs(tensor)`                            |
-| `tensor.triu(diagonal)                           | `torch.triu(tensor, diagonal)`                 |
-| `tensor.tril(diagonal)                           | `torch.tril(tensor, diagonal)`                 |
+| `tensor.triu(diagonal)`                           | `torch.triu(tensor, diagonal)`                 |
+| `tensor.tril(diagonal)`                           | `torch.tril(tensor, diagonal)`                 |
 
 ### Float Operations
 

--- a/examples/custom-csv-dataset/Cargo.toml
+++ b/examples/custom-csv-dataset/Cargo.toml
@@ -15,7 +15,6 @@ burn = {path = "../../burn"}
 
 # File download
 reqwest = {workspace = true, features = ["blocking"]}
-tempfile = {workspace = true}
 
 # CSV parsing
 csv = {workspace = true}


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

Very minor change. Realized we had other small typos in the book while browsing the `Tensor` reference (missing ticks `).

Also removed an unused dependency from the `custom-csv-dataset` example.
