### PR TITLE
New default recorder

### DIFF
--- a/burn-book/src/building-blocks/record.md
+++ b/burn-book/src/building-blocks/record.md
@@ -14,13 +14,13 @@ the flexibility possible to include any non-serializable field within your modul
 
 **Why not use safetensors?**
 
-`Safetensors` uses serde with the JSON file format and only supports serializing and deserializing
+[`safetensors`](https://github.com/huggingface/safetensors) uses serde with the JSON file format and only supports serializing and deserializing
 tensors. The record system in Burn gives you the possibility to serialize any type, which is very
 useful for optimizers that save their state, but also for any non-standard, cutting-edge modeling
 needs you may have. Additionally, the record system performs automatic precision conversion by using
 Rust types, making it more reliable with fewer manual manipulations. 
 
-It is important to note that the `safetensors` format uses the word *safe* to distinguish itself from Pickle, which is vulnerable to Python code injection. The safety comes from a checksum mechanism that guarantees that the data suffered no corruption. On our end, the simple fact that we use Rust already ensures that no code injection is possible. To prevent any data corruption, using a recorder with Gzip compression is recommended, as it includes a checksum mechanism.  
+It is important to note that the `safetensors` format uses the word *safe* to distinguish itself from Pickle, which is vulnerable to Python code injection. On our end, the simple fact that we use Rust already ensures that no code injection is possible. To prevent any data corruption, using a recorder with Gzip compression is recommended, as it includes a checksum mechanism.  
 
 ## Recorder
 

--- a/burn-book/src/building-blocks/record.md
+++ b/burn-book/src/building-blocks/record.md
@@ -29,7 +29,7 @@ that the format can also be in-memory, allowing you to save the records directly
 
 | Recorder               | Format                    | Compression |
 | ---------------------- | ------------------------- | ----------- |
-| DefaultFileRecorder    | File - Named Message Park | Gzip        |
+| DefaultFileRecorder    | File - Named Message Park | None        |
 | NamedMpkFileRecorder   | File - Named Message Park | None        |
 | NamedMpkGzFileRecorder | File - Named Message Park | Gzip        |
 | BinFileRecorder        | File - Binary             | None        |

--- a/burn-book/src/building-blocks/record.md
+++ b/burn-book/src/building-blocks/record.md
@@ -20,7 +20,7 @@ useful for optimizers that save their state, but also for any non-standard, cutt
 needs you may have. Additionally, the record system performs automatic precision conversion by using
 Rust types, making it more reliable with fewer manual manipulations. 
 
-It is important to note that the `safetensors` format uses the word *safe* to distinguish itself from Pickle, which is vulnerable to Python code injection. On our end, the simple fact that we use Rust already ensures that no code injection is possible. To prevent any data corruption, using a recorder with Gzip compression is recommended, as it includes a checksum mechanism.  
+It is important to note that the `safetensors` format uses the word *safe* to distinguish itself from Pickle, which is vulnerable to Python code injection. On our end, the simple fact that we use Rust already ensures that no code injection is possible. If your storage mechanism doesn't handle data corruption, you might prefer a recorder that performs checksum validation (i.e., any recorder with Gzip compression).
 
 ## Recorder
 

--- a/burn-core/src/record/file.rs
+++ b/burn-core/src/record/file.rs
@@ -14,7 +14,7 @@ pub trait FileRecorder:
 }
 
 /// Default [file recorder](FileRecorder).
-pub type DefaultFileRecorder<S> = NamedMpkGzFileRecorder<S>;
+pub type DefaultFileRecorder<S> = NamedMpkFileRecorder<S>;
 
 /// File recorder using the [bincode format](bincode).
 #[derive(new, Debug, Default, Clone)]


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues

Closes #1151

### Changes

After a bit of exploration and tests it was decided that we should revert to the `NamedMpkFileRecorder` (no compression) as the default. Any type of compression adds to much overhead and detracts the user experience.

- Changed the `DefaultFileRecorder`
- Updated the Burn book
