### PR TITLE
Fix FullPrecisionSettings type for integers

### DIFF
--- a/burn-core/src/record/settings.rs
+++ b/burn-core/src/record/settings.rs
@@ -26,7 +26,7 @@ pub struct DoublePrecisionSettings;
 
 impl PrecisionSettings for FullPrecisionSettings {
     type FloatElem = f32;
-    type IntElem = f32;
+    type IntElem = i32;
 }
 
 impl PrecisionSettings for DoublePrecisionSettings {


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

Easiest PR of my life 😄

There was a copy/paste error in the `FullPrecisionSettings` for the integer elements. I switched it from float32 to int32.