### PR TITLE
Add model saving and loading examples

### DIFF
--- a/burn-book/src/SUMMARY.md
+++ b/burn-book/src/SUMMARY.md
@@ -19,6 +19,7 @@
   - [Record](./building-blocks/record.md)
   - [Dataset](./building-blocks/dataset.md)
 - [Custom Training Loop](./custom-training-loop.md)
+- [Saving & Loading Models](./saving-and-loading.md)
 - [Import ONNX Model](./import/onnx-model.md)
 - [Advanced](./advanced/README.md)
   - [Backend Extension](./advanced/backend-extension/README.md)

--- a/burn-book/src/building-blocks/record.md
+++ b/burn-book/src/building-blocks/record.md
@@ -40,12 +40,19 @@ that the format can also be in-memory, allowing you to save the records directly
 
 Each recorder supports precision settings decoupled from the precision used for training or
 inference. These settings allow you to define the floating-point and integer types that will be used
-for serialization and deserialization. Note that when loading a record into a module, the type
-conversion is automatically handled, so you can't encounter errors. The only crucial aspect is using
-the same recorder for both serialization and deserialization; otherwise, you will encounter loading
-errors.
+for serialization and deserialization.
 
-**Which one should you use?**
+| Setting                   | Float Precision | Integer Precision |
+| ------------------------- | --------------- | ----------------- |
+| `DoublePrecisionSettings` | `f64`           | `i64`             |
+| `FullPrecisionSettings`   | `f32`           | `i32`             |
+| `HalfPrecisionSettings`   | `f16`           | `i16`             |
+
+Note that when loading a record into a module, the type conversion is automatically handled, so you can't encounter errors.
+The only crucial aspect is using the same recorder for both serialization and deserialization; otherwise, you will encounter
+loading errors.
+
+**Which recorder should you use?**
 
 - If you want fast serialization and deserialization, choose a recorder without compression. The one
   with the lowest file size without compression is the binary format; otherwise, the named message
@@ -55,3 +62,5 @@ errors.
 - If you want to debug your model's weights, you can use the pretty JSON format.
 - If you want to deploy with `no-std`, use the in-memory binary format and include the bytes with
   the compiled code.
+
+For examples on saving and loading records, take a look at [Saving and Loading Models](../saving-and-loading.md).

--- a/burn-book/src/building-blocks/record.md
+++ b/burn-book/src/building-blocks/record.md
@@ -14,13 +14,18 @@ the flexibility possible to include any non-serializable field within your modul
 
 **Why not use safetensors?**
 
-[`safetensors`](https://github.com/huggingface/safetensors) uses serde with the JSON file format and only supports serializing and deserializing
-tensors. The record system in Burn gives you the possibility to serialize any type, which is very
-useful for optimizers that save their state, but also for any non-standard, cutting-edge modeling
-needs you may have. Additionally, the record system performs automatic precision conversion by using
-Rust types, making it more reliable with fewer manual manipulations. 
+[`safetensors`](https://github.com/huggingface/safetensors) uses serde with the JSON file format and
+only supports serializing and deserializing tensors. The record system in Burn gives you the
+possibility to serialize any type, which is very useful for optimizers that save their state, but
+also for any non-standard, cutting-edge modeling needs you may have. Additionally, the record system
+performs automatic precision conversion by using Rust types, making it more reliable with fewer
+manual manipulations.
 
-It is important to note that the `safetensors` format uses the word *safe* to distinguish itself from Pickle, which is vulnerable to Python code injection. On our end, the simple fact that we use Rust already ensures that no code injection is possible. If your storage mechanism doesn't handle data corruption, you might prefer a recorder that performs checksum validation (i.e., any recorder with Gzip compression).
+It is important to note that the `safetensors` format uses the word _safe_ to distinguish itself
+from Pickle, which is vulnerable to Python code injection. On our end, the simple fact that we use
+Rust already ensures that no code injection is possible. If your storage mechanism doesn't handle
+data corruption, you might prefer a recorder that performs checksum validation (i.e., any recorder
+with Gzip compression).
 
 ## Recorder
 
@@ -48,9 +53,9 @@ for serialization and deserialization.
 | `FullPrecisionSettings`   | `f32`           | `i32`             |
 | `HalfPrecisionSettings`   | `f16`           | `i16`             |
 
-Note that when loading a record into a module, the type conversion is automatically handled, so you can't encounter errors.
-The only crucial aspect is using the same recorder for both serialization and deserialization; otherwise, you will encounter
-loading errors.
+Note that when loading a record into a module, the type conversion is automatically handled, so you
+can't encounter errors. The only crucial aspect is using the same recorder for both serialization
+and deserialization; otherwise, you will encounter loading errors.
 
 **Which recorder should you use?**
 
@@ -63,4 +68,5 @@ loading errors.
 - If you want to deploy with `no-std`, use the in-memory binary format and include the bytes with
   the compiled code.
 
-For examples on saving and loading records, take a look at [Saving and Loading Models](../saving-and-loading.md).
+For examples on saving and loading records, take a look at
+[Saving and Loading Models](../saving-and-loading.md).

--- a/burn-book/src/overview.md
+++ b/burn-book/src/overview.md
@@ -12,6 +12,8 @@ advanced user or a beginner. We have crafted some sections for you:
 - [Building Blocks](./building-blocks): Dive deeper into Burn's core components, understanding how
   they fit together. This knowledge forms the basis for more advanced usage and customization.
 
+- [Saving & Loading Models](./saving-and-loading.md): Learn how to easily save and load your trained models.
+
 - [Custom Training Loop](./custom-training-loop.md): Gain the power to customize your training
   loops, fine-tuning your models to meet your specific requirements. This section empowers you to
   harness Burn's flexibility to its fullest.

--- a/burn-book/src/saving-and-loading.md
+++ b/burn-book/src/saving-and-loading.md
@@ -1,0 +1,91 @@
+# Saving and Loading Models
+
+Saving your trained machine learning model to disk is quite easy, no matter the output format you choose. As mentioned in the [Record](./building-blocks/record.md) section, different formats are supported to serialize/deserialize models. By default, we use the `NamedMpkFileRecorder` which uses the [MessagePack](https://msgpack.org/) binary serialization format with the help of [smp_serde](https://docs.rs/rmp-serde/).
+
+```rust, ignore
+// Save model in MessagePack format with full precision
+let recorder = NamedMpkFileRecorder::<FullPrecisionSettings>::new();
+model
+  .save_file(model_path, &recorder)
+  .expect("Could not save model");
+```
+
+Note that the file extension is automatically handled by the recorder depending on the one you choose. Therefore, only the file path and base name can be provided.
+
+Now that you have a trained model saved to your disk, you can easily load it in a similar fashion.
+
+```rust, ignore
+// Load model in full precision from MessagePack file
+let recorder = NamedMpkFileRecorder::<FullPrecisionSettings>::new();
+model
+  .load_file(model_path, &recorder)
+  .expect("Failed to load model file");
+```
+
+## Custom Initialization from Recorded Weights
+
+While the first approach is very straightforward, it does require the model to already be initialized. If instead you would like to skip the initialization and directly load the weights into the modules of your model, you can create a new initialization function. Let's take the following model definition as a simple example.
+
+```rust, ignore
+#[derive(Module, Debug)]
+pub struct Model<B: Backend> {
+    linear_in: Linear<B>,
+    linear_out: Linear<B>,
+    activation: ReLU,
+}
+```
+
+Similar to the [basic workflow inference example](../basic-workflow/inference.md), we can define a new initialization function which initializes the different parts of our model with the record values.
+
+```rust, ignore
+impl<B: Backend> Model<B> {
+    /// Returns the initialized model using the recorded weights.
+    pub fn init_with(record: ModelRecord<B>) -> Model<B> {
+        Model {
+            linear_in: LinearConfig::new(10, 64).init_with(record.linear_in),
+            linear_out: LinearConfig::new(64, 2).init_with(record.linear_out),
+            activation: ReLU::new(),
+        }
+    }
+
+    /// Returns the dummy model with randomly initialized weights.
+    pub fn new(device: &Device<B>) -> Model<B> {
+        let l1 = LinearConfig::new(10, 64).init(device);
+        let l2 = LinearConfig::new(64, 2).init(device);
+        Model {
+            linear_in: l1,
+            linear_out: l2,
+            activation: ReLU::new(),
+        }
+    }
+}
+```
+
+Now, let's save a model that we can load later. In the following snippets, we use `type Backend = NdArray<f32>` but you can use whatever backend you like.
+
+```rust, ignore
+let model_path = Path::new("experiment/model");
+
+// Create a dummy initialized model to save
+let model = Model::<Backend>::new(&Default::default());
+
+// Save model in MessagePack format with full precision
+let recorder = NamedMpkFileRecorder::<FullPrecisionSettings>::new();
+model
+    .save_file(model_path, &recorder)
+    .expect("Could not save model");
+```
+
+Afterwards, the model can just as easily be loaded from the record saved on disk.
+
+```rust, ignore
+let model_path = Path::new("experiment/model");
+
+// Load model record
+let record: ModelRecord<Backend> = NamedMpkFileRecorder::<FullPrecisionSettings>::new()
+    .load(model_path.into())
+    .expect("Could not load model file");
+
+// Directly initialize a new model with the loaded record/weights
+let model = Model::init_with(record);
+```

--- a/burn-book/src/saving-and-loading.md
+++ b/burn-book/src/saving-and-loading.md
@@ -81,7 +81,7 @@ Afterwards, the model can just as easily be loaded from the record saved on disk
 ```rust, ignore
 let model_path = Path::new("experiment/model");
 
-// Load model record
+// Load model record on the backend's default device
 let record: ModelRecord<Backend> = NamedMpkFileRecorder::<FullPrecisionSettings>::new()
     .load(model_path.into())
     .expect("Could not load model file");

--- a/burn-book/src/saving-and-loading.md
+++ b/burn-book/src/saving-and-loading.md
@@ -7,10 +7,10 @@ Saving your trained machine learning model to disk is quite easy, no matter the 
 let recorder = NamedMpkFileRecorder::<FullPrecisionSettings>::new();
 model
   .save_file(model_path, &recorder)
-  .expect("Could not save model");
+  .expect("Should be able to save the model");
 ```
 
-Note that the file extension is automatically handled by the recorder depending on the one you choose. Therefore, only the file path and base name can be provided.
+Note that the file extension is automatically handled by the recorder depending on the one you choose. Therefore, only the file path and base name should be provided.
 
 Now that you have a trained model saved to your disk, you can easily load it in a similar fashion.
 
@@ -19,7 +19,7 @@ Now that you have a trained model saved to your disk, you can easily load it in 
 let recorder = NamedMpkFileRecorder::<FullPrecisionSettings>::new();
 model
   .load_file(model_path, &recorder)
-  .expect("Failed to load model file");
+  .expect("Should be able to load the model weights from the provided file");
 ```
 
 **Note:** models can be saved in different output formats, just make sure you are using the correct recorder type when loading the saved model. Type conversion between different precision settings is automatically handled, but formats are not interchangeable. A model can be loaded from one format and saved to another format, just as long as you load it back with the new recorder type afterwards.
@@ -60,7 +60,7 @@ impl<B: Backend> Model<B> {
             activation: ReLU::new(),
         }
     }
-}
+}``
 ```
 
 Now, let's save a model that we can load later. In the following snippets, we use `type Backend = NdArray<f32>` but you can use whatever backend you like.
@@ -73,7 +73,7 @@ let model = Model::<Backend>::new(&Default::default());
 let recorder = NamedMpkFileRecorder::<FullPrecisionSettings>::new();
 model
     .save_file(model_path, &recorder)
-    .expect("Could not save model");
+    .expect("Should be able to save the model");
 ```
 
 Afterwards, the model can just as easily be loaded from the record saved on disk.
@@ -82,7 +82,7 @@ Afterwards, the model can just as easily be loaded from the record saved on disk
 // Load model record on the backend's default device
 let record: ModelRecord<Backend> = NamedMpkFileRecorder::<FullPrecisionSettings>::new()
     .load(model_path.into())
-    .expect("Could not load model file");
+    .expect("Should be able to load the model weights from the provided file");
 
 // Directly initialize a new model with the loaded record/weights
 let model = Model::init_with(record);

--- a/burn-book/src/saving-and-loading.md
+++ b/burn-book/src/saving-and-loading.md
@@ -66,8 +66,6 @@ impl<B: Backend> Model<B> {
 Now, let's save a model that we can load later. In the following snippets, we use `type Backend = NdArray<f32>` but you can use whatever backend you like.
 
 ```rust, ignore
-let model_path = Path::new("experiment/model");
-
 // Create a dummy initialized model to save
 let model = Model::<Backend>::new(&Default::default());
 
@@ -81,8 +79,6 @@ model
 Afterwards, the model can just as easily be loaded from the record saved on disk.
 
 ```rust, ignore
-let model_path = Path::new("experiment/model");
-
 // Load model record on the backend's default device
 let record: ModelRecord<Backend> = NamedMpkFileRecorder::<FullPrecisionSettings>::new()
     .load(model_path.into())

--- a/burn-book/src/saving-and-loading.md
+++ b/burn-book/src/saving-and-loading.md
@@ -22,6 +22,8 @@ model
   .expect("Failed to load model file");
 ```
 
+**Note:** models can be saved in different output formats, just make sure you are using the correct recorder type when loading the saved model. Type conversion between different precision settings is automatically handled, but formats are not interchangeable. A model can be loaded from one format and saved to another format, just as long as you load it back with the new recorder type afterwards.
+
 ## Custom Initialization from Recorded Weights
 
 While the first approach is very straightforward, it does require the model to already be initialized. If instead you would like to skip the initialization and directly load the weights into the modules of your model, you can create a new initialization function. Let's take the following model definition as a simple example.

--- a/burn-book/src/saving-and-loading.md
+++ b/burn-book/src/saving-and-loading.md
@@ -67,7 +67,8 @@ Now, let's save a model that we can load later. In the following snippets, we us
 
 ```rust, ignore
 // Create a dummy initialized model to save
-let model = Model::<Backend>::new(&Default::default());
+let device = Default::default();
+let model = Model::<Backend>::new(&device);
 
 // Save model in MessagePack format with full precision
 let recorder = NamedMpkFileRecorder::<FullPrecisionSettings>::new();

--- a/burn-book/src/saving-and-loading.md
+++ b/burn-book/src/saving-and-loading.md
@@ -1,6 +1,10 @@
 # Saving and Loading Models
 
-Saving your trained machine learning model to disk is quite easy, no matter the output format you choose. As mentioned in the [Record](./building-blocks/record.md) section, different formats are supported to serialize/deserialize models. By default, we use the `NamedMpkFileRecorder` which uses the [MessagePack](https://msgpack.org/) binary serialization format with the help of [smp_serde](https://docs.rs/rmp-serde/).
+Saving your trained machine learning model is quite easy, no matter the output format you choose. As
+mentioned in the [Record](./building-blocks/record.md) section, different formats are supported to
+serialize/deserialize models. By default, we use the `NamedMpkFileRecorder` which uses the
+[MessagePack](https://msgpack.org/) binary serialization format with the help of
+[smp_serde](https://docs.rs/rmp-serde/).
 
 ```rust, ignore
 // Save model in MessagePack format with full precision
@@ -10,7 +14,8 @@ model
   .expect("Should be able to save the model");
 ```
 
-Note that the file extension is automatically handled by the recorder depending on the one you choose. Therefore, only the file path and base name should be provided.
+Note that the file extension is automatically handled by the recorder depending on the one you
+choose. Therefore, only the file path and base name should be provided.
 
 Now that you have a trained model saved to your disk, you can easily load it in a similar fashion.
 
@@ -22,11 +27,17 @@ model
   .expect("Should be able to load the model weights from the provided file");
 ```
 
-**Note:** models can be saved in different output formats, just make sure you are using the correct recorder type when loading the saved model. Type conversion between different precision settings is automatically handled, but formats are not interchangeable. A model can be loaded from one format and saved to another format, just as long as you load it back with the new recorder type afterwards.
+**Note:** models can be saved in different output formats, just make sure you are using the correct
+recorder type when loading the saved model. Type conversion between different precision settings is
+automatically handled, but formats are not interchangeable. A model can be loaded from one format
+and saved to another format, just as long as you load it back with the new recorder type afterwards.
 
-## Custom Initialization from Recorded Weights
+## Initialization from Recorded Weights
 
-While the first approach is very straightforward, it does require the model to already be initialized. If instead you would like to skip the initialization and directly load the weights into the modules of your model, you can create a new initialization function. Let's take the following model definition as a simple example.
+While the first approach is very straightforward, it does require the model to already be
+initialized. If instead you would like to skip the initialization and directly load the weights into
+the modules of your model, you can create a new initialization function. Let's take the following
+model definition as a simple example.
 
 ```rust, ignore
 #[derive(Module, Debug)]
@@ -37,7 +48,9 @@ pub struct Model<B: Backend> {
 }
 ```
 
-Similar to the [basic workflow inference example](../basic-workflow/inference.md), we can define a new initialization function which initializes the different parts of our model with the record values.
+Similar to the [basic workflow inference example](../basic-workflow/inference.md), we can define a
+new initialization function which initializes the different parts of our model with the record
+values.
 
 ```rust, ignore
 impl<B: Backend> Model<B> {
@@ -63,7 +76,8 @@ impl<B: Backend> Model<B> {
 }``
 ```
 
-Now, let's save a model that we can load later. In the following snippets, we use `type Backend = NdArray<f32>` but you can use whatever backend you like.
+Now, let's save a model that we can load later. In the following snippets, we use
+`type Backend = NdArray<f32>` but you can use whatever backend you like.
 
 ```rust, ignore
 // Create a dummy initialized model to save


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues

Closes #1156

### Changes

- Added precision settings table in the Record section of the book
- Added Saving & Loading Models section with examples
  - Using `save_file()` and `load_file()`
  - Using `init_with(record)` to directly initialize the module with the record weights

If I am missing use cases let me know! I'll add them based on the requested changes.