### PR TITLE
Fix doc build on docs.rs

### DIFF
--- a/burn-tch/Cargo.toml
+++ b/burn-tch/Cargo.toml
@@ -29,3 +29,6 @@ burn-autodiff = { path = "../burn-autodiff", version = "0.12.0", default-feature
 burn-tensor = { path = "../burn-tensor", version = "0.12.0", default-features = false, features = [
   "export_tests",
 ] }
+
+[package.metadata.docs.rs]
+features = [ "doc" ]


### PR DESCRIPTION
Should fix https://github.com/tracel-ai/burn/issues/1141

Unfortunately I was not able to test it properly because the docs.rs documentation is very sparse and I encountered several obstacles (even in an Ubuntu VM). I'll try to make it work before the release if I can get good support on zulip.

While I cannot guarantee that it will fix the issue, a local `cargo doc` seems to skip the `torch-sys` build with these added metadata (even if the name is related to `docs.rs`). So high chance we will be good 🙂 

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.


