### PR TITLE
Regex fix pytorch

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -44,7 +44,7 @@ let tensor_2 = Tensor::<Backend, 1>::from_data(Data::from([1.0, 2.0, 3.0]).conve
 // Will be converted to Data internally. `.convert()` not needed as from_floats() defined for fixed ElementType
 let tensor_3 = Tensor::<Backend, 1>::from_floats([1.0, 2.0, 3.0]);
 
-// Initalization of Int Tensor from array slices 
+// Initialization of Int Tensor from array slices
 let arr: [i32; 6] = [1, 2, 3, 4, 5, 6];
 let tensor_4 = Tensor::<Backend, 1, Int>::from_data(Data::from(&arr[0..3]).convert());
 
@@ -97,10 +97,10 @@ a working example of doing min-max normalization with cloning.
     let max = input.clone().max();
     let input = (input.clone() - min.clone()).div(max - min);
     println!("{:?}", input.to_data());      // Success: [0.0, 0.33333334, 0.6666667, 1.0]
-    
+
     // Notice that max, min have been moved in last operation so the below print will give an error.
     // If we want to use them for further operations, they will need to be cloned in similar fashion.
-    // println!("{:?}", min.to_data());    
+    // println!("{:?}", min.to_data());
 ```
 
 We don't need to be worried about memory overhead because with cloning, the tensor's buffer isn't copied,

--- a/burn-import/src/pytorch/recorder.rs
+++ b/burn-import/src/pytorch/recorder.rs
@@ -110,7 +110,7 @@ impl LoadArgs {
     /// [Replacement](https://docs.rs/regex/latest/regex/struct.Regex.html#method.replace) for the
     /// replacement syntax.
     pub fn with_key_remap(mut self, pattern: &str, replacement: &str) -> Self {
-        let regex = Regex::new(&format!("^{}$", pattern)).unwrap();
+        let regex = Regex::new(pattern).expect("Valid regex");
 
         self.key_remap.push((regex, replacement.into()));
         self


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

https://github.com/tracel-ai/burn/pull/1085

### Changes

* Remove `^` and `$` regex wrapping per user's request:

> I don't think it's a good idea to insert `^` and `$` in this place, it will mislead the user.
And there are many use cases where `^` and `$` need to be removed. For example I tried to rename all keys like `conv.0` to `conv0` because I used some workaround to implement PyTorch's `Sequential` in Burn. I want to do this for the whole model, it would be convenient if I could use `.with_key_remap(r#"([a-z]+)\.(\d+)"#, "$1$2")`.

### Testing

Unit testing and run-checks all.
