### PR TITLE
Add a semantic versioning checker

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -1,0 +1,25 @@
+name: semver-checks
+
+on:
+  schedule:
+    - cron: '0 21 * * THU' # Run every Thursday at 21:00 (UTC)
+  push:
+    tags:
+      - 'v*.*.*' # Run when a new version is being published
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependencies:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: Check semantic versioning violations
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -12,14 +12,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  dependencies:
+  semver-checks:
     runs-on: ubuntu-latest
 
     steps:
-
       - name: checkout
         uses: actions/checkout@v4
 
       - name: Check semantic versioning violations
         uses: obi1kenobi/cargo-semver-checks-action@v2
-
+        with:
+          # cargo-semver-checks uses `all-features` by default, but `burn`
+          # publishes on crates.io with `default-features`
+          feature-group: default-features
+          # Exclude crates which are not published on crates.io
+          exclude: backend-comparison,burn-no-std-tests,onnx-tests,pytorch-tests


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `run-checks all` script has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

A semantic versioning checker lints API changes for semver violations. Even this check will run periodically on CI not to stress a lot the entire infrastracture
