### PR TITLE
Fix pow autodiff

### DIFF
--- a/burn-autodiff/src/tests/pow.rs
+++ b/burn-autodiff/src/tests/pow.rs
@@ -29,32 +29,56 @@ mod tests {
 
     #[test]
     fn should_diff_powf() {
-        let data_1 = Data::from([2.0, 7.0]);
-        let data_2 = Data::from([4.0, 2.0]);
-
         let device = Default::default();
-        let tensor_1 = TestAutodiffTensor::from_data(data_1.clone(), &device).require_grad();
-        let tensor_2 = TestAutodiffTensor::from_data(data_2.clone(), &device).require_grad();
+        let tensor_1 = TestAutodiffTensor::from_data([2.0, 7.0], &device).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data([4.0, 2.0], &device).require_grad();
 
         let tensor_3 = tensor_1.clone().powf(tensor_2.clone());
         let grads = tensor_3.backward();
 
         let grad_1 = tensor_1.grad(&grads).unwrap();
         let grad_2 = tensor_2.grad(&grads).unwrap();
-        //equivalent to [4 * 2**3, 2 * 7**1]
+
         grad_1
-            .to_data()
+            .into_data()
             .assert_approx_eq(&Data::from([32.0, 14.0]), 3);
 
         grad_2
-            .to_data()
+            .into_data()
             .assert_approx_eq(&Data::from([11.09, 95.349]), 2);
-        // equivalent to [2**4 * ln(2), 7**2 * ln(7)]
-        //have to use approx_eq due to candle producing
-        //[16.0, 48.999996]
 
         tensor_3
-            .to_data()
+            .into_data()
             .assert_approx_eq(&Data::from([16.0, 49.0]), 3);
+    }
+
+    #[test]
+    fn should_diff_powf_with_untracked_lhs() {
+        let device = Default::default();
+        let tensor_1 = TestAutodiffTensor::from_data([2.0, 7.0], &device);
+        let tensor_2 = TestAutodiffTensor::from_data([4.0, 2.0], &device).require_grad();
+
+        let tensor_3 = tensor_1.clone().powf(tensor_2.clone());
+        let grads = tensor_3.backward();
+
+        let grad_2 = tensor_2.grad(&grads).unwrap();
+        grad_2
+            .to_data()
+            .assert_approx_eq(&Data::from([11.09, 95.349]), 2);
+    }
+
+    #[test]
+    fn should_diff_powf_with_untracked_rhs() {
+        let device = Default::default();
+        let tensor_1 = TestAutodiffTensor::from_data([2.0, 7.0], &device).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data([4.0, 2.0], &device);
+
+        let tensor_3 = tensor_1.clone().powf(tensor_2.clone());
+        let grads = tensor_3.backward();
+
+        let grad_1 = tensor_1.grad(&grads).unwrap();
+        grad_1
+            .into_data()
+            .assert_approx_eq(&Data::from([32.0, 14.0]), 3);
     }
 }


### PR DESCRIPTION
Fix #1224

The problem was that the state wasn't correctly captured based on the tensor autodiff requirements.