### PR TITLE
[CI] Add workflow to group dependabot PRs

### DIFF
--- a/.github/workflows/combine-dependabot-prs.yml
+++ b/.github/workflows/combine-dependabot-prs.yml
@@ -1,0 +1,23 @@
+name: Combine Dependabot PRs
+
+on:
+  schedule:
+    - cron: '0 6 * * MON' # Monday at 6:00am UTC
+  workflow_dispatch: # allows to manually trigger the workflow as well
+
+# The minimum permissions required to run this Action
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+
+jobs:
+  combine-prs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: combine-prs
+        id: combine-prs
+        uses: github/combine-prs@v5.0.0 # where X.X.X is the latest version
+        with:
+          labels: dependencies


### PR DESCRIPTION
This workflow uses the following GitHub action: https://github.com/github/combine-prs

It groups all the pending dependabot PRs into a single one if possible. It is configured to run every Monday at 1am and it can also be triggered on demand. 

We might need additional setup for authorizations.