### PR TITLE
Fix weight params in `conv1d` and `conv2d`

### DIFF
--- a/burn-core/src/nn/conv/conv1d.rs
+++ b/burn-core/src/nn/conv/conv1d.rs
@@ -50,7 +50,9 @@ pub struct Conv1dConfig {
 /// - bias:   Tensor of shape `[channels_out]`
 #[derive(Module, Debug)]
 pub struct Conv1d<B: Backend> {
+    /// Tensor of shape [channels_out, channels_in / groups, kernel_size]
     pub weight: Param<Tensor<B, 3>>,
+    /// Tensor of shape `[channels_out]`
     pub bias: Option<Param<Tensor<B, 1>>>,
     stride: usize,
     kernel_size: usize,

--- a/burn-core/src/nn/conv/conv1d.rs
+++ b/burn-core/src/nn/conv/conv1d.rs
@@ -50,8 +50,8 @@ pub struct Conv1dConfig {
 /// - bias:   Tensor of shape `[channels_out]`
 #[derive(Module, Debug)]
 pub struct Conv1d<B: Backend> {
-    weight: Param<Tensor<B, 3>>,
-    bias: Option<Param<Tensor<B, 1>>>,
+    pub weight: Param<Tensor<B, 3>>,
+    pub bias: Option<Param<Tensor<B, 1>>>,
     stride: usize,
     kernel_size: usize,
     dilation: usize,

--- a/burn-core/src/nn/conv/conv2d.rs
+++ b/burn-core/src/nn/conv/conv2d.rs
@@ -49,7 +49,9 @@ pub struct Conv2dConfig {
 /// - bias:   Tensor of shape `[channels_out]`
 #[derive(Module, Debug)]
 pub struct Conv2d<B: Backend> {
+    /// Tensor of shape `[channels_out, channels_in / groups, kernel_size_1, kernel_size_2]`
     pub weight: Param<Tensor<B, 4>>,
+    /// Tensor of shape `[channels_out]`
     pub bias: Option<Param<Tensor<B, 1>>>,
     stride: [usize; 2],
     kernel_size: [usize; 2],

--- a/burn-core/src/nn/conv/conv2d.rs
+++ b/burn-core/src/nn/conv/conv2d.rs
@@ -49,8 +49,8 @@ pub struct Conv2dConfig {
 /// - bias:   Tensor of shape `[channels_out]`
 #[derive(Module, Debug)]
 pub struct Conv2d<B: Backend> {
-    weight: Param<Tensor<B, 4>>,
-    bias: Option<Param<Tensor<B, 1>>>,
+    pub weight: Param<Tensor<B, 4>>,
+    pub bias: Option<Param<Tensor<B, 1>>>,
     stride: [usize; 2],
     kernel_size: [usize; 2],
     dilation: [usize; 2],

--- a/burn-core/src/nn/conv/conv_transpose1d.rs
+++ b/burn-core/src/nn/conv/conv_transpose1d.rs
@@ -51,7 +51,9 @@ pub struct ConvTranspose1dConfig {
 /// - bias:   Tensor of shape `[channels_out]`
 #[derive(Module, Debug)]
 pub struct ConvTranspose1d<B: Backend> {
+    /// Tensor of shape `[channels_in, channels_out / groups, kernel_size]`
     pub weight: Param<Tensor<B, 3>>,
+    /// Tensor of shape `[channels_out]`
     pub bias: Option<Param<Tensor<B, 1>>>,
     stride: usize,
     kernel_size: usize,

--- a/burn-core/src/nn/conv/conv_transpose1d.rs
+++ b/burn-core/src/nn/conv/conv_transpose1d.rs
@@ -51,8 +51,8 @@ pub struct ConvTranspose1dConfig {
 /// - bias:   Tensor of shape `[channels_out]`
 #[derive(Module, Debug)]
 pub struct ConvTranspose1d<B: Backend> {
-    weight: Param<Tensor<B, 3>>,
-    bias: Option<Param<Tensor<B, 1>>>,
+    pub weight: Param<Tensor<B, 3>>,
+    pub bias: Option<Param<Tensor<B, 1>>>,
     stride: usize,
     kernel_size: usize,
     dilation: usize,

--- a/burn-core/src/nn/conv/conv_transpose2d.rs
+++ b/burn-core/src/nn/conv/conv_transpose2d.rs
@@ -51,8 +51,8 @@ pub struct ConvTranspose2dConfig {
 /// - bias:   Tensor of shape `[channels_out]`
 #[derive(Module, Debug)]
 pub struct ConvTranspose2d<B: Backend> {
-    weight: Param<Tensor<B, 4>>,
-    bias: Option<Param<Tensor<B, 1>>>,
+    pub weight: Param<Tensor<B, 4>>,
+    pub bias: Option<Param<Tensor<B, 1>>>,
     stride: [usize; 2],
     kernel_size: [usize; 2],
     dilation: [usize; 2],

--- a/burn-core/src/nn/conv/conv_transpose2d.rs
+++ b/burn-core/src/nn/conv/conv_transpose2d.rs
@@ -51,7 +51,9 @@ pub struct ConvTranspose2dConfig {
 /// - bias:   Tensor of shape `[channels_out]`
 #[derive(Module, Debug)]
 pub struct ConvTranspose2d<B: Backend> {
+    /// Tensor of shape `[channels_in, channels_out / groups, kernel_size_1, kernel_size_2]`
     pub weight: Param<Tensor<B, 4>>,
+    /// Tensor of shape `[channels_out]`
     pub bias: Option<Param<Tensor<B, 1>>>,
     stride: [usize; 2],
     kernel_size: [usize; 2],


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Changes

Make weights in `conv1d` and `conv2d` public 
