### PR TITLE
Add vision feature for MNIST in book guide

### DIFF
--- a/burn-book/src/basic-workflow/model.md
+++ b/burn-book/src/basic-workflow/model.md
@@ -10,7 +10,7 @@ cargo new my-first-burn-model
 As [mentioned previously](../getting-started.md#creating-a-burn-application), this will initialize
 your `my-first-burn-model` project directory with a `Cargo.toml` and a `src/main.rs` file.
 
-In the `Cargo.toml` file, add the `burn` dependency with `train` and `wgpu` features.
+In the `Cargo.toml` file, add the `burn` dependency with `train`, `wgpu` and `vision` features.
 
 ```toml
 [package]
@@ -19,7 +19,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-burn = { version = "0.13.0", features = ["train", "wgpu"] }
+burn = { version = "0.13.0", features = ["train", "wgpu", "vision"] }
 ```
 
 Our goal will be to create a basic convolutional neural network used for image classification. We


### PR DESCRIPTION
### Checklist

- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

As mentioned by Shankpotumus on discord

### Changes

Added the missing `vision` feature in the book guide.

With the MNIST refactor the corresponding changes were made everywhere else but the book's Cargo.toml directions fell through the cracks. Following the example step by step would give you this:

```
error[E0432]: unresolved import burn::data::dataset::vision
 --> src/data.rs:1:26
  |
1 | use burn::data::dataset::vision::MNISTItem;
  |                          ^^^^^^ could not find vision in dataset
```
