### PR TITLE
Allow multiple pattern matches in chain with `PyTorchFileRecorder`

### DIFF
--- a/burn-core/src/record/serde/data.rs
+++ b/burn-core/src/record/serde/data.rs
@@ -177,7 +177,6 @@ pub fn remap<T>(
         for (pattern, replacement) in &key_remap {
             if pattern.is_match(&name) {
                 new_name = pattern.replace_all(&name, replacement.as_str()).to_string();
-                break;
             }
         }
         remapped.insert(new_name, tensor);


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.

### Changes

Changed the record `remap` function to allow multiple pattern matches in chain when using the `PyTorchFileRecorder`

For example, I initially though that providing multiple patterns like this would remap the keys on each match:

```rust
let load_args = LoadArgs::new("resnet18-f37072fd.pth".into())
  // Map *.downsample.0.* -> *.downsample.conv.*
  .with_key_remap("(.+)\\.downsample\\.0\\.(.+)", "$1.downsample.conv.$2")
  // Map *.downsample.1.* -> *.downsample.bn.*
  .with_key_remap("(.+)\\.downsample\\.1\\.(.+)", "$1.downsample.bn.$2")
  // Map layer[i].[j].* -> layer[i].blocks.[j].*
  .with_key_remap("layer[1-4]\\.([0-9])\\.(.+)", "layer$1.blocks.$2.$3");

let record = PyTorchFileRecorder::<FullPrecisionSettings>::new()
    .load(load_args, &device)
    .map_err(|err| format!("Failed to load weights.\nError: {err}"))
    .unwrap();
```
but it does not. Instead it `break`s at the first match.

Stumbled upon this when trying to import the pre-trained ResNet-18 weights from torchvision for my implementation [here](https://github.com/tracel-ai/models/tree/resnet/resnet-burn).

In the residual blocks, we sometimes have a downsample layer that requires more than one portion of the key to be remapped (hence the patterns in chain). For example, `layer1.0.downsample.0.*` should be remapped to `layer1.blocks.0.downsample.conv.*`, which can be decomposed with the patterns presented in the example above.