### PR TITLE
[Refactor] Just-In-Time Backend

### DIFF
--- a/burn-compute/src/channel/base.rs
+++ b/burn-compute/src/channel/base.rs
@@ -4,7 +4,7 @@ use burn_common::reader::Reader;
 
 /// The ComputeChannel trait links the ComputeClient to the ComputeServer
 /// while ensuring thread-safety
-pub trait ComputeChannel<Server: ComputeServer>: Clone + core::fmt::Debug {
+pub trait ComputeChannel<Server: ComputeServer>: Clone + core::fmt::Debug + Send + Sync {
     /// Given a handle, returns owned resource as bytes
     fn read(&self, handle: &Handle<Server>) -> Reader<Vec<u8>>;
 

--- a/burn-compute/src/channel/cell.rs
+++ b/burn-compute/src/channel/cell.rs
@@ -64,3 +64,6 @@ where
         self.server.borrow_mut().sync()
     }
 }
+
+unsafe impl<Server: ComputeServer> Send for RefCellComputeChannel<Server> {}
+unsafe impl<Server: ComputeServer> Sync for RefCellComputeChannel<Server> {}

--- a/burn-compute/src/channel/cell.rs
+++ b/burn-compute/src/channel/cell.rs
@@ -65,7 +65,7 @@ where
     }
 }
 
-/// This is unsafe, since no concurency is supported by the `RefCell` channel.
+/// This is unsafe, since no concurrency is supported by the `RefCell` channel.
 /// However using this channel should only be done in single threaded environments such as `no-std`.
 unsafe impl<Server: ComputeServer> Send for RefCellComputeChannel<Server> {}
 unsafe impl<Server: ComputeServer> Sync for RefCellComputeChannel<Server> {}

--- a/burn-compute/src/channel/cell.rs
+++ b/burn-compute/src/channel/cell.rs
@@ -65,5 +65,7 @@ where
     }
 }
 
+/// This is unsafe, since no concurency is supported by the `RefCell` channel.
+/// However using this channel should only be done in single threaded environments such as `no-std`.
 unsafe impl<Server: ComputeServer> Send for RefCellComputeChannel<Server> {}
 unsafe impl<Server: ComputeServer> Sync for RefCellComputeChannel<Server> {}

--- a/burn-compute/src/client.rs
+++ b/burn-compute/src/client.rs
@@ -7,7 +7,6 @@ use alloc::vec::Vec;
 use alloc::{boxed::Box, sync::Arc};
 use burn_common::reader::Reader;
 use burn_common::stub::RwLock;
-use core::marker::PhantomData;
 
 /// The ComputeClient is the entry point to require tasks from the ComputeServer.
 /// It should be obtained for a specific device via the Compute struct.
@@ -15,7 +14,6 @@ use core::marker::PhantomData;
 pub struct ComputeClient<Server: ComputeServer, Channel> {
     channel: Channel,
     tuner: Arc<RwLock<Tuner<Server, Channel>>>,
-    _server: PhantomData<Server>,
 }
 
 impl<S, C> Clone for ComputeClient<S, C>
@@ -27,7 +25,6 @@ where
         Self {
             channel: self.channel.clone(),
             tuner: self.tuner.clone(),
-            _server: PhantomData,
         }
     }
 }
@@ -39,11 +36,7 @@ where
 {
     /// Create a new client.
     pub fn new(channel: Channel, tuner: Arc<RwLock<Tuner<Server, Channel>>>) -> Self {
-        Self {
-            channel,
-            tuner,
-            _server: PhantomData,
-        }
+        Self { channel, tuner }
     }
 
     /// Given a handle, returns owned resource as bytes.

--- a/burn-compute/src/compute.rs
+++ b/burn-compute/src/compute.rs
@@ -4,11 +4,11 @@ use hashbrown::HashMap;
 
 /// The compute type has the responsibility to retrieve the correct compute client based on the
 /// given device.
-pub struct Compute<Device, Server: ComputeServer, Channel> {
+pub struct ComputeRuntime<Device, Server: ComputeServer, Channel> {
     clients: spin::Mutex<Option<HashMap<Device, ComputeClient<Server, Channel>>>>,
 }
 
-impl<Device, Server, Channel> Compute<Device, Server, Channel>
+impl<Device, Server, Channel> ComputeRuntime<Device, Server, Channel>
 where
     Device: core::hash::Hash + PartialEq + Eq + Clone + core::fmt::Debug,
     Server: ComputeServer,

--- a/burn-compute/src/memory_management/base.rs
+++ b/burn-compute/src/memory_management/base.rs
@@ -5,7 +5,7 @@ use crate::storage::ComputeStorage;
 ///
 /// It is responsible for determining if the memory segment can be mutated,
 /// for instance by keeping track of a reference count
-pub trait MemoryHandle: Clone + Send + core::fmt::Debug {
+pub trait MemoryHandle: Clone + Sync + Send + core::fmt::Debug {
     /// Checks if the underlying memory can be safely mutated.
     fn can_mut(&self) -> bool;
 }
@@ -15,7 +15,7 @@ pub trait MemoryHandle: Clone + Send + core::fmt::Debug {
 ///
 /// The MemoryManagement can only reserve memory space or get the resource located at a space.
 /// Modification of the resource data should be done directly on the resource.
-pub trait MemoryManagement<Storage: ComputeStorage>: Send + core::fmt::Debug {
+pub trait MemoryManagement<Storage: ComputeStorage>: Sync + Send + core::fmt::Debug {
     /// The associated type Handle must implement MemoryHandle
     type Handle: MemoryHandle;
 

--- a/burn-compute/src/memory_management/base.rs
+++ b/burn-compute/src/memory_management/base.rs
@@ -5,7 +5,7 @@ use crate::storage::ComputeStorage;
 ///
 /// It is responsible for determining if the memory segment can be mutated,
 /// for instance by keeping track of a reference count
-pub trait MemoryHandle: Clone + Sync + Send + core::fmt::Debug {
+pub trait MemoryHandle: Clone + Send + Sync + core::fmt::Debug {
     /// Checks if the underlying memory can be safely mutated.
     fn can_mut(&self) -> bool;
 }
@@ -15,7 +15,7 @@ pub trait MemoryHandle: Clone + Sync + Send + core::fmt::Debug {
 ///
 /// The MemoryManagement can only reserve memory space or get the resource located at a space.
 /// Modification of the resource data should be done directly on the resource.
-pub trait MemoryManagement<Storage: ComputeStorage>: Sync + Send + core::fmt::Debug {
+pub trait MemoryManagement<Storage: ComputeStorage>: Send + core::fmt::Debug {
     /// The associated type Handle must implement MemoryHandle
     type Handle: MemoryHandle;
 

--- a/burn-compute/src/server.rs
+++ b/burn-compute/src/server.rs
@@ -12,12 +12,12 @@ use burn_common::reader::Reader;
 ///
 /// Everything in the server is mutable, therefore it should be solely accessed through the
 /// [compute channel](crate::channel::ComputeChannel) for thread safety.
-pub trait ComputeServer: Send + core::fmt::Debug
+pub trait ComputeServer: Sync + Send + core::fmt::Debug
 where
     Self: Sized,
 {
     /// The kernel type defines the computation algorithms.
-    type Kernel: Send;
+    type Kernel: Sync + Send;
     /// The [storage](ComputeStorage) type defines how data is stored and accessed.
     type Storage: ComputeStorage;
     /// The [memory management](MemoryManagement) type defines strategies for allocation in the [storage](ComputeStorage) type.

--- a/burn-compute/src/server.rs
+++ b/burn-compute/src/server.rs
@@ -12,12 +12,12 @@ use burn_common::reader::Reader;
 ///
 /// Everything in the server is mutable, therefore it should be solely accessed through the
 /// [compute channel](crate::channel::ComputeChannel) for thread safety.
-pub trait ComputeServer: Sync + Send + core::fmt::Debug
+pub trait ComputeServer: Send + core::fmt::Debug
 where
     Self: Sized,
 {
     /// The kernel type defines the computation algorithms.
-    type Kernel: Sync + Send;
+    type Kernel: Send;
     /// The [storage](ComputeStorage) type defines how data is stored and accessed.
     type Storage: ComputeStorage;
     /// The [memory management](MemoryManagement) type defines strategies for allocation in the [storage](ComputeStorage) type.

--- a/burn-compute/src/storage/base.rs
+++ b/burn-compute/src/storage/base.rs
@@ -32,10 +32,10 @@ impl StorageHandle {
 }
 
 /// Storage types are responsible for allocating and deallocating memory.
-pub trait ComputeStorage: Send {
+pub trait ComputeStorage: Send + Sync {
     /// The resource associated type determines the way data is implemented and how
     /// it can be accessed by kernels.
-    type Resource: Send;
+    type Resource: Send + Sync;
 
     /// Returns the underlying resource for a specified storage handle
     fn get(&mut self, handle: &StorageHandle) -> Self::Resource;

--- a/burn-compute/src/storage/base.rs
+++ b/burn-compute/src/storage/base.rs
@@ -32,10 +32,10 @@ impl StorageHandle {
 }
 
 /// Storage types are responsible for allocating and deallocating memory.
-pub trait ComputeStorage: Send + Sync {
+pub trait ComputeStorage: Send {
     /// The resource associated type determines the way data is implemented and how
     /// it can be accessed by kernels.
-    type Resource: Send + Sync;
+    type Resource: Send;
 
     /// Returns the underlying resource for a specified storage handle
     fn get(&mut self, handle: &StorageHandle) -> Self::Resource;

--- a/burn-compute/src/storage/bytes_cpu.rs
+++ b/burn-compute/src/storage/bytes_cpu.rs
@@ -17,6 +17,8 @@ impl core::fmt::Debug for BytesStorage {
 /// Can send to other threads.
 unsafe impl Send for BytesStorage {}
 unsafe impl Send for BytesResource {}
+unsafe impl Sync for BytesStorage {}
+unsafe impl Sync for BytesResource {}
 
 /// This struct is a pointer to a memory chunk or slice.
 pub struct BytesResource {

--- a/burn-compute/src/storage/bytes_cpu.rs
+++ b/burn-compute/src/storage/bytes_cpu.rs
@@ -17,8 +17,6 @@ impl core::fmt::Debug for BytesStorage {
 /// Can send to other threads.
 unsafe impl Send for BytesStorage {}
 unsafe impl Send for BytesResource {}
-unsafe impl Sync for BytesStorage {}
-unsafe impl Sync for BytesResource {}
 
 /// This struct is a pointer to a memory chunk or slice.
 pub struct BytesResource {

--- a/burn-compute/src/tune/operation.rs
+++ b/burn-compute/src/tune/operation.rs
@@ -51,7 +51,16 @@ pub trait AutotuneOperation {
 #[cfg(feature = "autotune-persistent-cache")]
 /// Trait alias with support for persistent caching
 pub trait AutotuneKey:
-    Clone + Debug + PartialEq + Eq + Hash + Display + serde::Serialize + serde::de::DeserializeOwned
+    Clone
+    + Debug
+    + PartialEq
+    + Eq
+    + Hash
+    + Display
+    + serde::Serialize
+    + serde::de::DeserializeOwned
+    + Send
+    + Sync
 {
 }
 #[cfg(not(feature = "autotune-persistent-cache"))]

--- a/burn-compute/tests/dummy/compute.rs
+++ b/burn-compute/tests/dummy/compute.rs
@@ -7,7 +7,7 @@ use burn_compute::client::ComputeClient;
 use burn_compute::memory_management::{DeallocStrategy, SimpleMemoryManagement, SliceStrategy};
 use burn_compute::storage::BytesStorage;
 use burn_compute::tune::Tuner;
-use burn_compute::Compute;
+use burn_compute::ComputeRuntime;
 
 /// The dummy device.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
@@ -16,7 +16,7 @@ pub struct DummyDevice;
 pub type DummyChannel = MutexComputeChannel<DummyServer>;
 pub type DummyClient = ComputeClient<DummyServer, DummyChannel>;
 
-static COMPUTE: Compute<DummyDevice, DummyServer, DummyChannel> = Compute::new();
+static RUNTIME: ComputeRuntime<DummyDevice, DummyServer, DummyChannel> = ComputeRuntime::new();
 pub static TUNER_DEVICE_ID: &str = "tests/dummy-device";
 
 pub fn init_client() -> ComputeClient<DummyServer, MutexComputeChannel<DummyServer>> {
@@ -30,5 +30,5 @@ pub fn init_client() -> ComputeClient<DummyServer, MutexComputeChannel<DummyServ
 }
 
 pub fn client(device: &DummyDevice) -> DummyClient {
-    COMPUTE.client(device, init_client)
+    RUNTIME.client(device, init_client)
 }

--- a/burn-compute/tests/integration_test.rs
+++ b/burn-compute/tests/integration_test.rs
@@ -3,6 +3,7 @@ mod dummy;
 use std::sync::Arc;
 
 use crate::dummy::{client, DummyDevice, DummyElementwiseAddition};
+use burn_compute::ComputeRuntime;
 
 #[allow(unused)]
 use serial_test::serial;
@@ -90,9 +91,10 @@ fn autotune_basic_multiplication_execution() {
 #[serial]
 #[cfg(feature = "std")]
 fn autotune_cache_same_key_return_a_cache_hit() {
-    let compute: burn_compute::Compute<DummyDevice, dummy::DummyServer, dummy::DummyChannel> =
-        burn_compute::Compute::new();
-    let client = compute.client(&DummyDevice, dummy::init_client);
+    type Runtime = ComputeRuntime<DummyDevice, dummy::DummyServer, dummy::DummyChannel>;
+    let runtime = Runtime::new();
+
+    let client = runtime.client(&DummyDevice, dummy::init_client);
 
     // note: the key name depends on the shapes of the operation set
     // see log_shape_input_key for more info.
@@ -133,8 +135,9 @@ fn autotune_cache_no_cache_on_disk_return_a_cache_miss() {
         burn_compute::tune::get_persistent_cache_file_path(crate::dummy::TUNER_DEVICE_ID);
     let _ = std::fs::remove_file(file_path);
 
-    let compute: burn_compute::Compute<DummyDevice, dummy::DummyServer, dummy::DummyChannel> =
-        burn_compute::Compute::new();
+    type Runtime = ComputeRuntime<DummyDevice, dummy::DummyServer, dummy::DummyChannel>;
+    let compute = Runtime::new();
+
     let client = compute.client(&DummyDevice, dummy::init_client);
 
     // in this test shapes [1,3] and [1,5] ends up with different key names
@@ -178,9 +181,9 @@ fn autotune_cache_file_path_creation_works_when_path_does_not_exist_yet() {
     // Delete the cache file's parent directory
     let _ = std::fs::remove_dir_all(parent_dir);
 
-    let compute: burn_compute::Compute<DummyDevice, dummy::DummyServer, dummy::DummyChannel> =
-        burn_compute::Compute::new();
-    let client = compute.client(&DummyDevice, dummy::init_client);
+    type Runtime = ComputeRuntime<DummyDevice, dummy::DummyServer, dummy::DummyChannel>;
+    let runtime = Runtime::new();
+    let client = runtime.client(&DummyDevice, dummy::init_client);
 
     // in this test shapes [1,3] and [1,5] ends up with different key names
     // which are 'cache_test-1,4' and 'cache_test-1,8'
@@ -240,9 +243,9 @@ fn autotune_cache_different_keys_return_a_cache_miss() {
 #[serial]
 #[cfg(feature = "std")]
 fn autotune_cache_different_checksums_return_a_cache_miss() {
-    let compute: burn_compute::Compute<DummyDevice, dummy::DummyServer, dummy::DummyChannel> =
-        burn_compute::Compute::new();
-    let client = compute.client(&DummyDevice, dummy::init_client);
+    type Runtime = ComputeRuntime<DummyDevice, dummy::DummyServer, dummy::DummyChannel>;
+    let runtime = Runtime::new();
+    let client = runtime.client(&DummyDevice, dummy::init_client);
 
     // in this test both shapes [1,3] and [1,4] end up with the same key name
     // which is 'cache_test-1,4'
@@ -259,9 +262,8 @@ fn autotune_cache_different_checksums_return_a_cache_miss() {
     // we use a second compute client in order to have freshly initialized autotune cache
     // and test invalidation of the cache when the checksum of the operation set is
     // different
-    let compute: burn_compute::Compute<DummyDevice, dummy::DummyServer, dummy::DummyChannel> =
-        burn_compute::Compute::new();
-    let client = compute.client(&DummyDevice, dummy::init_client);
+    let runtime = Runtime::new();
+    let client = runtime.client(&DummyDevice, dummy::init_client);
 
     let shapes_2 = vec![vec![1, 4], vec![1, 4], vec![1, 4]];
     let lhs_2 = client.create(&[0, 1, 2, 3]);

--- a/burn-core/src/lib.rs
+++ b/burn-core/src/lib.rs
@@ -51,10 +51,10 @@ pub type TestBackend = burn_ndarray::NdArray<f32>;
 pub type TestBackend = burn_tch::LibTorch<f32>;
 
 #[cfg(all(test, feature = "test-wgpu", not(target_os = "macos")))]
-pub type TestBackend = burn_wgpu::GpuBackend<burn_wgpu::Vulkan, f32, i32>;
+pub type TestBackend = burn_wgpu::JitBackend<burn_wgpu::Vulkan, f32, i32>;
 
 #[cfg(all(test, feature = "test-wgpu", target_os = "macos"))]
-pub type TestBackend = burn_wgpu::GpuBackend<burn_wgpu::Metal, f32, i32>;
+pub type TestBackend = burn_wgpu::JitBackend<burn_wgpu::Metal, f32, i32>;
 
 #[cfg(feature = "std")]
 #[cfg(test)]

--- a/burn-core/src/lib.rs
+++ b/burn-core/src/lib.rs
@@ -51,10 +51,10 @@ pub type TestBackend = burn_ndarray::NdArray<f32>;
 pub type TestBackend = burn_tch::LibTorch<f32>;
 
 #[cfg(all(test, feature = "test-wgpu", not(target_os = "macos")))]
-pub type TestBackend = burn_wgpu::WgpuBackend<burn_wgpu::Vulkan, f32, i32>;
+pub type TestBackend = burn_wgpu::GpuBackend<burn_wgpu::Vulkan, f32, i32>;
 
 #[cfg(all(test, feature = "test-wgpu", target_os = "macos"))]
-pub type TestBackend = burn_wgpu::WgpuBackend<burn_wgpu::Metal, f32, i32>;
+pub type TestBackend = burn_wgpu::GpuBackend<burn_wgpu::Metal, f32, i32>;
 
 #[cfg(feature = "std")]
 #[cfg(test)]

--- a/burn-core/src/lib.rs
+++ b/burn-core/src/lib.rs
@@ -50,11 +50,8 @@ pub type TestBackend = burn_ndarray::NdArray<f32>;
 #[cfg(all(test, feature = "test-tch"))]
 pub type TestBackend = burn_tch::LibTorch<f32>;
 
-#[cfg(all(test, feature = "test-wgpu", not(target_os = "macos")))]
-pub type TestBackend = burn_wgpu::JitBackend<burn_wgpu::Vulkan, f32, i32>;
-
-#[cfg(all(test, feature = "test-wgpu", target_os = "macos"))]
-pub type TestBackend = burn_wgpu::JitBackend<burn_wgpu::Metal, f32, i32>;
+#[cfg(all(test, feature = "test-wgpu"))]
+pub type TestBackend = burn_wgpu::Wgpu;
 
 #[cfg(feature = "std")]
 #[cfg(test)]

--- a/burn-wgpu/benches/fused_elemwise.rs
+++ b/burn-wgpu/benches/fused_elemwise.rs
@@ -2,7 +2,7 @@ use burn_common::benchmark::{run_benchmark, Benchmark};
 use burn_tensor::backend::Backend;
 use burn_tensor::{Distribution, Shape, Tensor};
 use burn_wgpu::compute::WgpuJitGpuBackend;
-use burn_wgpu::{AutoGraphicsApi, GpuBackend, Wgpu, WgpuDevice};
+use burn_wgpu::{AutoGraphicsApi, GpuBackend, WgpuDevice};
 use derive_new::new;
 use std::marker::PhantomData;
 

--- a/burn-wgpu/benches/fused_elemwise.rs
+++ b/burn-wgpu/benches/fused_elemwise.rs
@@ -1,7 +1,8 @@
 use burn_common::benchmark::{run_benchmark, Benchmark};
 use burn_tensor::backend::Backend;
 use burn_tensor::{Distribution, Shape, Tensor};
-use burn_wgpu::{Wgpu, WgpuDevice};
+use burn_wgpu::compute::WgpuJitGpuBackend;
+use burn_wgpu::{AutoGraphicsApi, GpuBackend, Wgpu, WgpuDevice};
 use derive_new::new;
 use std::marker::PhantomData;
 
@@ -55,7 +56,8 @@ impl<B: Backend> Benchmark for ElemWiseBenchmark<B> {
 #[allow(dead_code)]
 /// Runs the benchmarks for wgpu matmul implementations
 pub fn bench(device: &WgpuDevice) {
-    let result = run_benchmark(ElemWiseBenchmark::<Wgpu>::new(
+    type Backend = GpuBackend<WgpuJitGpuBackend<AutoGraphicsApi, f32, i32>>;
+    let result = run_benchmark(ElemWiseBenchmark::<Backend>::new(
         Shape::new([256, 256, 1024]),
         device.clone(),
         10,

--- a/burn-wgpu/benches/fused_elemwise.rs
+++ b/burn-wgpu/benches/fused_elemwise.rs
@@ -1,7 +1,7 @@
 use burn_common::benchmark::{run_benchmark, Benchmark};
 use burn_tensor::backend::Backend;
 use burn_tensor::{Distribution, Shape, Tensor};
-use burn_wgpu::compute::WgpuJitGpuBackend;
+use burn_wgpu::compute::WgpuJitBackend;
 use burn_wgpu::{AutoGraphicsApi, GpuBackend, WgpuDevice};
 use derive_new::new;
 use std::marker::PhantomData;
@@ -56,7 +56,7 @@ impl<B: Backend> Benchmark for ElemWiseBenchmark<B> {
 #[allow(dead_code)]
 /// Runs the benchmarks for wgpu matmul implementations
 pub fn bench(device: &WgpuDevice) {
-    type Backend = GpuBackend<WgpuJitGpuBackend<AutoGraphicsApi, f32, i32>>;
+    type Backend = GpuBackend<WgpuJitBackend<AutoGraphicsApi, f32, i32>>;
     let result = run_benchmark(ElemWiseBenchmark::<Backend>::new(
         Shape::new([256, 256, 1024]),
         device.clone(),

--- a/burn-wgpu/benches/fused_elemwise.rs
+++ b/burn-wgpu/benches/fused_elemwise.rs
@@ -1,8 +1,8 @@
 use burn_common::benchmark::{run_benchmark, Benchmark};
 use burn_tensor::backend::Backend;
 use burn_tensor::{Distribution, Shape, Tensor};
-use burn_wgpu::compute::WgpuJitBackend;
-use burn_wgpu::{AutoGraphicsApi, GpuBackend, WgpuDevice};
+use burn_wgpu::compute::WgpuRuntime;
+use burn_wgpu::{AutoGraphicsApi, JitBackend, WgpuDevice};
 use derive_new::new;
 use std::marker::PhantomData;
 
@@ -56,7 +56,7 @@ impl<B: Backend> Benchmark for ElemWiseBenchmark<B> {
 #[allow(dead_code)]
 /// Runs the benchmarks for wgpu matmul implementations
 pub fn bench(device: &WgpuDevice) {
-    type Backend = GpuBackend<WgpuJitBackend<AutoGraphicsApi, f32, i32>>;
+    type Backend = JitBackend<WgpuRuntime<AutoGraphicsApi, f32, i32>>;
     let result = run_benchmark(ElemWiseBenchmark::<Backend>::new(
         Shape::new([256, 256, 1024]),
         device.clone(),

--- a/burn-wgpu/benches/matmul.rs
+++ b/burn-wgpu/benches/matmul.rs
@@ -1,6 +1,7 @@
 use burn_common::benchmark::{run_benchmark, Benchmark};
 use burn_tensor::backend::Backend;
 use burn_tensor::{Distribution, Shape, Tensor};
+use burn_wgpu::compute::WgpuJitGpuBackend;
 use burn_wgpu::kernel::matmul::init_matmul_output;
 use burn_wgpu::kernel::matmul::unpadded::matmul_tiling_2d_unpadded;
 use burn_wgpu::kernel::matmul::vec4::matmul_tiling_2d_vec4;
@@ -12,12 +13,11 @@ use std::marker::PhantomData;
 
 use burn_wgpu::{
     kernel::matmul::{matmul_mem_coalescing_default, matmul_naive_default},
-    wgsl::Compiler,
     GraphicsApi,
 };
 
-type WBackend<G> = GpuBackend<G, Compiler<f32, i32>>;
-type WTensor<G, const D: usize> = Tensor<GpuBackend<G, Compiler<f32, i32>>, D>;
+type WBackend<G> = GpuBackend<WgpuJitGpuBackend<G, f32, i32>>;
+type WTensor<G, const D: usize> = Tensor<WBackend<G>, D>;
 
 #[derive(new)]
 struct MatmulBenchmark<B: Backend, F, const D: usize> {

--- a/burn-wgpu/benches/matmul.rs
+++ b/burn-wgpu/benches/matmul.rs
@@ -1,7 +1,7 @@
 use burn_common::benchmark::{run_benchmark, Benchmark};
 use burn_tensor::backend::Backend;
 use burn_tensor::{Distribution, Shape, Tensor};
-use burn_wgpu::compute::WgpuJitGpuBackend;
+use burn_wgpu::compute::WgpuJitBackend;
 use burn_wgpu::kernel::matmul::init_matmul_output;
 use burn_wgpu::kernel::matmul::unpadded::matmul_tiling_2d_unpadded;
 use burn_wgpu::kernel::matmul::vec4::matmul_tiling_2d_vec4;
@@ -16,7 +16,7 @@ use burn_wgpu::{
     GraphicsApi,
 };
 
-type WBackend<G> = GpuBackend<WgpuJitGpuBackend<G, f32, i32>>;
+type WBackend<G> = GpuBackend<WgpuJitBackend<G, f32, i32>>;
 type WTensor<G, const D: usize> = Tensor<WBackend<G>, D>;
 
 #[derive(new)]

--- a/burn-wgpu/benches/matmul.rs
+++ b/burn-wgpu/benches/matmul.rs
@@ -1,13 +1,13 @@
 use burn_common::benchmark::{run_benchmark, Benchmark};
 use burn_tensor::backend::Backend;
 use burn_tensor::{Distribution, Shape, Tensor};
-use burn_wgpu::compute::WgpuJitBackend;
+use burn_wgpu::compute::WgpuRuntime;
 use burn_wgpu::kernel::matmul::init_matmul_output;
 use burn_wgpu::kernel::matmul::unpadded::matmul_tiling_2d_unpadded;
 use burn_wgpu::kernel::matmul::vec4::matmul_tiling_2d_vec4;
 use burn_wgpu::kernel::matmul::vec4_lhs::matmul_tiling_2d_vec4_lhs;
 use burn_wgpu::WgpuDevice;
-use burn_wgpu::{AutoGraphicsApi, GpuBackend};
+use burn_wgpu::{AutoGraphicsApi, JitBackend};
 use derive_new::new;
 use std::marker::PhantomData;
 
@@ -16,7 +16,7 @@ use burn_wgpu::{
     GraphicsApi,
 };
 
-type WBackend<G> = GpuBackend<WgpuJitBackend<G, f32, i32>>;
+type WBackend<G> = JitBackend<WgpuRuntime<G, f32, i32>>;
 type WTensor<G, const D: usize> = Tensor<WBackend<G>, D>;
 
 #[derive(new)]

--- a/burn-wgpu/benches/matmul.rs
+++ b/burn-wgpu/benches/matmul.rs
@@ -6,7 +6,7 @@ use burn_wgpu::kernel::matmul::unpadded::matmul_tiling_2d_unpadded;
 use burn_wgpu::kernel::matmul::vec4::matmul_tiling_2d_vec4;
 use burn_wgpu::kernel::matmul::vec4_lhs::matmul_tiling_2d_vec4_lhs;
 use burn_wgpu::WgpuDevice;
-use burn_wgpu::{AutoGraphicsApi, WgpuBackend};
+use burn_wgpu::{AutoGraphicsApi, GpuBackend};
 use derive_new::new;
 use std::marker::PhantomData;
 
@@ -15,7 +15,7 @@ use burn_wgpu::{
     GraphicsApi,
 };
 
-type WTensor<G, const D: usize> = Tensor<WgpuBackend<G, f32, i32>, D>;
+type WTensor<G, const D: usize> = Tensor<GpuBackend<G, f32, i32>, D>;
 
 #[derive(new)]
 struct MatmulBenchmark<B: Backend, F, const D: usize> {
@@ -30,7 +30,7 @@ trait MatmulFunction<G: GraphicsApi, const D: usize> {
     fn run(lhs: WTensor<G, D>, rhs: WTensor<G, D>) -> WTensor<G, D>;
 }
 
-impl<F, const D: usize, G> Benchmark for MatmulBenchmark<WgpuBackend<G, f32, i32>, F, D>
+impl<F, const D: usize, G> Benchmark for MatmulBenchmark<GpuBackend<G, f32, i32>, F, D>
 where
     F: MatmulFunction<G, D>,
     G: GraphicsApi,
@@ -64,7 +64,7 @@ where
     }
 
     fn sync(&self) {
-        WgpuBackend::<G, f32, i32>::sync(&self.device)
+        GpuBackend::<G, f32, i32>::sync(&self.device)
     }
 }
 

--- a/burn-wgpu/benches/reduction.rs
+++ b/burn-wgpu/benches/reduction.rs
@@ -1,16 +1,15 @@
 use burn_common::benchmark::{run_benchmark, Benchmark};
 use burn_tensor::backend::Backend;
 use burn_tensor::{Distribution, Shape, Tensor};
+use burn_wgpu::compute::WgpuJitGpuBackend;
 use burn_wgpu::kernel::reduce::{init_reduce_output, sum_dim, sum_dim_shared_memory};
-use burn_wgpu::wgsl::Compiler;
+use burn_wgpu::GraphicsApi;
 use burn_wgpu::WgpuDevice;
 use burn_wgpu::{AutoGraphicsApi, GpuBackend};
 use derive_new::new;
 use std::marker::PhantomData;
 
-use burn_wgpu::GraphicsApi;
-
-type WBackend<G> = GpuBackend<G, Compiler<f32, i32>>;
+type WBackend<G> = GpuBackend<WgpuJitGpuBackend<G, f32, i32>>;
 type WTensor<G, const D: usize> = Tensor<WBackend<G>, D>;
 
 #[derive(new)]

--- a/burn-wgpu/benches/reduction.rs
+++ b/burn-wgpu/benches/reduction.rs
@@ -1,15 +1,15 @@
 use burn_common::benchmark::{run_benchmark, Benchmark};
 use burn_tensor::backend::Backend;
 use burn_tensor::{Distribution, Shape, Tensor};
-use burn_wgpu::compute::WgpuJitBackend;
+use burn_wgpu::compute::WgpuRuntime;
 use burn_wgpu::kernel::reduce::{init_reduce_output, sum_dim, sum_dim_shared_memory};
 use burn_wgpu::GraphicsApi;
 use burn_wgpu::WgpuDevice;
-use burn_wgpu::{AutoGraphicsApi, GpuBackend};
+use burn_wgpu::{AutoGraphicsApi, JitBackend};
 use derive_new::new;
 use std::marker::PhantomData;
 
-type WBackend<G> = GpuBackend<WgpuJitBackend<G, f32, i32>>;
+type WBackend<G> = JitBackend<WgpuRuntime<G, f32, i32>>;
 type WTensor<G, const D: usize> = Tensor<WBackend<G>, D>;
 
 #[derive(new)]

--- a/burn-wgpu/benches/reduction.rs
+++ b/burn-wgpu/benches/reduction.rs
@@ -3,13 +3,13 @@ use burn_tensor::backend::Backend;
 use burn_tensor::{Distribution, Shape, Tensor};
 use burn_wgpu::kernel::reduce::{init_reduce_output, sum_dim, sum_dim_shared_memory};
 use burn_wgpu::WgpuDevice;
-use burn_wgpu::{AutoGraphicsApi, WgpuBackend};
+use burn_wgpu::{AutoGraphicsApi, GpuBackend};
 use derive_new::new;
 use std::marker::PhantomData;
 
 use burn_wgpu::GraphicsApi;
 
-type WTensor<G, const D: usize> = Tensor<WgpuBackend<G, f32, i32>, D>;
+type WTensor<G, const D: usize> = Tensor<GpuBackend<G, f32, i32>, D>;
 
 #[derive(new)]
 struct ReduceBenchmark<B: Backend, F, const D: usize> {
@@ -24,7 +24,7 @@ trait ReduceFunction<G: GraphicsApi, const D: usize> {
     fn run(input: WTensor<G, D>, dim: usize) -> WTensor<G, D>;
 }
 
-impl<F, const D: usize, G> Benchmark for ReduceBenchmark<WgpuBackend<G, f32, i32>, F, D>
+impl<F, const D: usize, G> Benchmark for ReduceBenchmark<GpuBackend<G, f32, i32>, F, D>
 where
     F: ReduceFunction<G, D>,
     G: GraphicsApi,
@@ -55,7 +55,7 @@ where
     }
 
     fn sync(&self) {
-        WgpuBackend::<G, f32, i32>::sync(&self.device)
+        GpuBackend::<G, f32, i32>::sync(&self.device)
     }
 }
 

--- a/burn-wgpu/benches/reduction.rs
+++ b/burn-wgpu/benches/reduction.rs
@@ -1,7 +1,7 @@
 use burn_common::benchmark::{run_benchmark, Benchmark};
 use burn_tensor::backend::Backend;
 use burn_tensor::{Distribution, Shape, Tensor};
-use burn_wgpu::compute::WgpuJitGpuBackend;
+use burn_wgpu::compute::WgpuJitBackend;
 use burn_wgpu::kernel::reduce::{init_reduce_output, sum_dim, sum_dim_shared_memory};
 use burn_wgpu::GraphicsApi;
 use burn_wgpu::WgpuDevice;
@@ -9,7 +9,7 @@ use burn_wgpu::{AutoGraphicsApi, GpuBackend};
 use derive_new::new;
 use std::marker::PhantomData;
 
-type WBackend<G> = GpuBackend<WgpuJitGpuBackend<G, f32, i32>>;
+type WBackend<G> = GpuBackend<WgpuJitBackend<G, f32, i32>>;
 type WTensor<G, const D: usize> = Tensor<WBackend<G>, D>;
 
 #[derive(new)]

--- a/burn-wgpu/src/backend.rs
+++ b/burn-wgpu/src/backend.rs
@@ -30,7 +30,7 @@ where
     C::Int: IntElement,
 {
     type Device = WgpuDevice;
-    type FullPrecisionBackend = GpuBackend<G, C>;
+    type FullPrecisionBackend = GpuBackend<G, C::FullPrecisionCompiler>;
 
     type FullPrecisionElem = f32;
     type FloatElem = C::Float;

--- a/burn-wgpu/src/backend.rs
+++ b/burn-wgpu/src/backend.rs
@@ -1,4 +1,4 @@
-use crate::{codegen::Compiler, tensor::WgpuTensor, WgpuDevice};
+use crate::{codegen::Compiler, compute::WgpuAutotuneKey, tensor::WgpuTensor, WgpuDevice};
 use burn_compute::{channel::ComputeChannel, client::ComputeClient, server::ComputeServer};
 use burn_fusion::FusionDevice;
 use burn_tensor::backend::Backend;
@@ -36,7 +36,10 @@ pub trait JitGpuBackend: Send + Sync + 'static {
         Device = Self::Device,
     >;
     type Compiler: Compiler;
-    type Server: ComputeServer;
+    type Server: ComputeServer<
+        Kernel = Box<dyn crate::compute::Kernel>,
+        AutotuneKey = WgpuAutotuneKey,
+    >;
     type Channel: ComputeChannel<Self::Server>;
     type Device: FusionDevice
         + Default

--- a/burn-wgpu/src/backend.rs
+++ b/burn-wgpu/src/backend.rs
@@ -8,29 +8,30 @@ use std::{marker::PhantomData, sync::Mutex};
 pub(crate) static SEED: Mutex<Option<StdRng>> = Mutex::new(None);
 
 /// Tensor backend that uses the [wgpu] crate for executing GPU compute shaders.
-pub struct GpuBackend<B: JitGpuBackend> {
+pub struct GpuBackend<B: JitRuntime> {
     _b: PhantomData<B>,
 }
 
-impl<B: JitGpuBackend> core::fmt::Debug for GpuBackend<B> {
+impl<B: JitRuntime> core::fmt::Debug for GpuBackend<B> {
     fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         todo!()
     }
 }
 
-impl<B: JitGpuBackend> Clone for GpuBackend<B> {
+impl<B: JitRuntime> Clone for GpuBackend<B> {
     fn clone(&self) -> Self {
         todo!()
     }
 }
 
-impl<B: JitGpuBackend> Default for GpuBackend<B> {
+impl<B: JitRuntime> Default for GpuBackend<B> {
     fn default() -> Self {
         todo!()
     }
 }
 
-pub trait JitGpuBackend: Send + Sync + 'static {
+/// Trait that defines a backend with a Just-In-Time compiler.
+pub trait JitRuntime: Send + Sync + 'static {
     type Compiler: Compiler;
     type Server: ComputeServer<
         Kernel = Box<dyn crate::compute::Kernel>,
@@ -47,7 +48,7 @@ pub trait JitGpuBackend: Send + Sync + 'static {
         + Sync
         + Send;
 
-    type FullPrecisionBackend: JitGpuBackend<
+    type FullPrecisionBackend: JitRuntime<
         Compiler = <Self::Compiler as Compiler>::FullPrecisionCompiler,
         Device = Self::Device,
         Server = Self::Server,
@@ -57,7 +58,7 @@ pub trait JitGpuBackend: Send + Sync + 'static {
     fn client(device: &Self::Device) -> ComputeClient<Self::Server, Self::Channel>;
 }
 
-impl<B: JitGpuBackend> Backend for GpuBackend<B> {
+impl<B: JitRuntime> Backend for GpuBackend<B> {
     type Device = B::Device;
     type FullPrecisionBackend = GpuBackend<B::FullPrecisionBackend>;
 

--- a/burn-wgpu/src/backend.rs
+++ b/burn-wgpu/src/backend.rs
@@ -1,6 +1,4 @@
-use crate::{codegen::Compiler, compute::WgpuAutotuneKey, tensor::WgpuTensor};
-use burn_compute::{channel::ComputeChannel, client::ComputeClient, server::ComputeServer};
-use burn_fusion::FusionDevice;
+use crate::{codegen::Compiler, tensor::JitTensor, Runtime};
 use burn_tensor::backend::Backend;
 use rand::{rngs::StdRng, SeedableRng};
 use std::{marker::PhantomData, sync::Mutex};
@@ -8,67 +6,39 @@ use std::{marker::PhantomData, sync::Mutex};
 pub(crate) static SEED: Mutex<Option<StdRng>> = Mutex::new(None);
 
 /// Tensor backend that uses the [wgpu] crate for executing GPU compute shaders.
-pub struct GpuBackend<R: Runtime> {
+pub struct JitBackend<R: Runtime> {
     _b: PhantomData<R>,
 }
 
-impl<R: Runtime> core::fmt::Debug for GpuBackend<R> {
+impl<R: Runtime> core::fmt::Debug for JitBackend<R> {
     fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         todo!()
     }
 }
 
-impl<R: Runtime> Clone for GpuBackend<R> {
+impl<R: Runtime> Clone for JitBackend<R> {
     fn clone(&self) -> Self {
         todo!()
     }
 }
 
-impl<R: Runtime> Default for GpuBackend<R> {
+impl<R: Runtime> Default for JitBackend<R> {
     fn default() -> Self {
         todo!()
     }
 }
 
-/// Trait that defines a backend with a Just-In-Time compiler.
-pub trait Runtime: Send + Sync + 'static {
-    type Compiler: Compiler;
-    type Server: ComputeServer<
-        Kernel = Box<dyn crate::compute::Kernel>,
-        AutotuneKey = WgpuAutotuneKey,
-    >;
-    type Channel: ComputeChannel<Self::Server>;
-    type Device: FusionDevice
-        + Default
-        + core::hash::Hash
-        + PartialEq
-        + Eq
-        + Clone
-        + core::fmt::Debug
-        + Sync
-        + Send;
-
-    type FullPrecisionBackend: Runtime<
-        Compiler = <Self::Compiler as Compiler>::FullPrecisionCompiler,
-        Device = Self::Device,
-        Server = Self::Server,
-        Channel = Self::Channel,
-    >;
-
-    fn client(device: &Self::Device) -> ComputeClient<Self::Server, Self::Channel>;
-}
-
-impl<R: Runtime> Backend for GpuBackend<R> {
+impl<R: Runtime> Backend for JitBackend<R> {
     type Device = R::Device;
-    type FullPrecisionBackend = GpuBackend<R::FullPrecisionBackend>;
+    type FullPrecisionBackend = JitBackend<R::FullPrecisionRuntime>;
 
     type FullPrecisionElem = f32;
     type FloatElem = <R::Compiler as Compiler>::Float;
     type IntElem = <R::Compiler as Compiler>::Int;
 
-    type FloatTensorPrimitive<const D: usize> = WgpuTensor<R, Self::FloatElem, D>;
-    type IntTensorPrimitive<const D: usize> = WgpuTensor<R, Self::IntElem, D>;
-    type BoolTensorPrimitive<const D: usize> = WgpuTensor<R, u32, D>;
+    type FloatTensorPrimitive<const D: usize> = JitTensor<R, Self::FloatElem, D>;
+    type IntTensorPrimitive<const D: usize> = JitTensor<R, Self::IntElem, D>;
+    type BoolTensorPrimitive<const D: usize> = JitTensor<R, u32, D>;
 
     fn name() -> String {
         String::from("wgpu")

--- a/burn-wgpu/src/backend.rs
+++ b/burn-wgpu/src/backend.rs
@@ -1,9 +1,5 @@
 use crate::{
-    codegen::Compiler,
-    compute::compute_client,
-    element::{FloatElement, IntElement},
-    tensor::WgpuTensor,
-    GraphicsApi, WgpuDevice,
+    codegen::Compiler, compute::compute_client, tensor::WgpuTensor, GraphicsApi, WgpuDevice,
 };
 use burn_tensor::backend::Backend;
 use rand::{rngs::StdRng, SeedableRng};
@@ -26,8 +22,6 @@ impl<G, C> Backend for GpuBackend<G, C>
 where
     G: GraphicsApi + 'static,
     C: Compiler,
-    C::Float: FloatElement,
-    C::Int: IntElement,
 {
     type Device = WgpuDevice;
     type FullPrecisionBackend = GpuBackend<G, C::FullPrecisionCompiler>;

--- a/burn-wgpu/src/backend.rs
+++ b/burn-wgpu/src/backend.rs
@@ -1,4 +1,4 @@
-use crate::{codegen::Compiler, compute::WgpuAutotuneKey, tensor::WgpuTensor, WgpuDevice};
+use crate::{codegen::Compiler, compute::WgpuAutotuneKey, tensor::WgpuTensor};
 use burn_compute::{channel::ComputeChannel, client::ComputeClient, server::ComputeServer};
 use burn_fusion::FusionDevice;
 use burn_tensor::backend::Backend;
@@ -13,7 +13,7 @@ pub struct GpuBackend<B: JitGpuBackend> {
 }
 
 impl<B: JitGpuBackend> core::fmt::Debug for GpuBackend<B> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         todo!()
     }
 }

--- a/burn-wgpu/src/backend.rs
+++ b/burn-wgpu/src/backend.rs
@@ -31,10 +31,6 @@ impl<B: JitGpuBackend> Default for GpuBackend<B> {
 }
 
 pub trait JitGpuBackend: Send + Sync + 'static {
-    type FullPrecisionBackend: JitGpuBackend<
-        Compiler = <Self::Compiler as Compiler>::FullPrecisionCompiler,
-        Device = Self::Device,
-    >;
     type Compiler: Compiler;
     type Server: ComputeServer<
         Kernel = Box<dyn crate::compute::Kernel>,
@@ -51,9 +47,14 @@ pub trait JitGpuBackend: Send + Sync + 'static {
         + Sync
         + Send;
 
-    fn client(device: &Self::Device) -> ComputeClient<Self::Server, Self::Channel> {
-        todo!();
-    }
+    type FullPrecisionBackend: JitGpuBackend<
+        Compiler = <Self::Compiler as Compiler>::FullPrecisionCompiler,
+        Device = Self::Device,
+        Server = Self::Server,
+        Channel = Self::Channel,
+    >;
+
+    fn client(device: &Self::Device) -> ComputeClient<Self::Server, Self::Channel>;
 }
 
 impl<B: JitGpuBackend> Backend for GpuBackend<B> {

--- a/burn-wgpu/src/backend.rs
+++ b/burn-wgpu/src/backend.rs
@@ -6,26 +6,9 @@ use std::{marker::PhantomData, sync::Mutex};
 pub(crate) static SEED: Mutex<Option<StdRng>> = Mutex::new(None);
 
 /// Tensor backend that uses the [wgpu] crate for executing GPU compute shaders.
+#[derive(new)]
 pub struct JitBackend<R: Runtime> {
-    _b: PhantomData<R>,
-}
-
-impl<R: Runtime> core::fmt::Debug for JitBackend<R> {
-    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        todo!()
-    }
-}
-
-impl<R: Runtime> Clone for JitBackend<R> {
-    fn clone(&self) -> Self {
-        todo!()
-    }
-}
-
-impl<R: Runtime> Default for JitBackend<R> {
-    fn default() -> Self {
-        todo!()
-    }
+    _runtime: PhantomData<R>,
 }
 
 impl<R: Runtime> Backend for JitBackend<R> {
@@ -41,7 +24,7 @@ impl<R: Runtime> Backend for JitBackend<R> {
     type BoolTensorPrimitive<const D: usize> = JitTensor<R, u32, D>;
 
     fn name() -> String {
-        String::from("wgpu")
+        format!("jit<{}>", R::name())
     }
 
     fn seed(seed: u64) {
@@ -57,5 +40,23 @@ impl<R: Runtime> Backend for JitBackend<R> {
     fn sync(device: &Self::Device) {
         let client = R::client(device);
         client.sync();
+    }
+}
+
+impl<R: Runtime> core::fmt::Debug for JitBackend<R> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("JitBackend {{ runtime: {}}}", R::name()))
+    }
+}
+
+impl<R: Runtime> Clone for JitBackend<R> {
+    fn clone(&self) -> Self {
+        Self::new()
+    }
+}
+
+impl<R: Runtime> Default for JitBackend<R> {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/burn-wgpu/src/codegen/compiler.rs
+++ b/burn-wgpu/src/codegen/compiler.rs
@@ -1,8 +1,11 @@
 use super::dialect::gpu;
+use crate::{FloatElement, IntElement};
 use std::fmt::Display;
 
 pub trait Compiler: Sync + Send + 'static {
     type Representation: Display;
+    type Float: FloatElement;
+    type Int: IntElement;
 
     fn compile(shader: gpu::ComputeShader) -> Self::Representation;
     fn elem_size(elem: gpu::Elem) -> usize;

--- a/burn-wgpu/src/codegen/compiler.rs
+++ b/burn-wgpu/src/codegen/compiler.rs
@@ -2,10 +2,15 @@ use super::dialect::gpu;
 use crate::{FloatElement, IntElement};
 use std::fmt::Display;
 
-pub trait Compiler: Sync + Send + 'static {
+pub trait Compiler: Sync + Send + 'static + Clone + Default + core::fmt::Debug {
     type Representation: Display;
     type Float: FloatElement;
     type Int: IntElement;
+    type FullPrecisionCompiler: Compiler<
+        Representation = Self::Representation,
+        Float = f32,
+        Int = i32,
+    >;
 
     fn compile(shader: gpu::ComputeShader) -> Self::Representation;
     fn elem_size(elem: gpu::Elem) -> usize;

--- a/burn-wgpu/src/codegen/dialect/mod.rs
+++ b/burn-wgpu/src/codegen/dialect/mod.rs
@@ -7,4 +7,4 @@
 pub(crate) mod gpu;
 /// WGSL dialect module that contains a representation that can be compiled to WebGPU shading
 /// language (wgsl).
-pub(crate) mod wgsl;
+pub mod wgsl;

--- a/burn-wgpu/src/codegen/dialect/wgsl/compiler.rs
+++ b/burn-wgpu/src/codegen/dialect/wgsl/compiler.rs
@@ -15,6 +15,8 @@ pub struct Compiler<F: WgpuElement, I: WgpuElement> {
 
 impl<F: WgpuElement, I: WgpuElement> compiler::Compiler for Compiler<F, I> {
     type Representation = ComputeShader;
+    type Float = F;
+    type Int = I;
 
     fn compile(shader: gpu::ComputeShader) -> Self::Representation {
         Self::compile_shader(shader)

--- a/burn-wgpu/src/codegen/dialect/wgsl/compiler.rs
+++ b/burn-wgpu/src/codegen/dialect/wgsl/compiler.rs
@@ -4,19 +4,37 @@ use crate::{
         compiler,
         dialect::{gpu, wgsl},
     },
-    element::WgpuElement,
+    FloatElement, IntElement,
 };
 use std::marker::PhantomData;
 
-pub struct Compiler<F: WgpuElement, I: WgpuElement> {
+/// Wgsl Compiler.
+#[derive(Clone)]
+pub struct Compiler<F: FloatElement, I: IntElement> {
     _float: PhantomData<F>,
     _int: PhantomData<I>,
 }
 
-impl<F: WgpuElement, I: WgpuElement> compiler::Compiler for Compiler<F, I> {
+impl<F: FloatElement, I: IntElement> core::fmt::Debug for Compiler<F, I> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("WgslCompiler")
+    }
+}
+
+impl<F: FloatElement, I: IntElement> Default for Compiler<F, I> {
+    fn default() -> Self {
+        Self {
+            _float: PhantomData,
+            _int: PhantomData,
+        }
+    }
+}
+
+impl<F: FloatElement, I: IntElement> compiler::Compiler for Compiler<F, I> {
     type Representation = ComputeShader;
     type Float = F;
     type Int = I;
+    type FullPrecisionCompiler = Compiler<f32, i32>;
 
     fn compile(shader: gpu::ComputeShader) -> Self::Representation {
         Self::compile_shader(shader)
@@ -27,7 +45,7 @@ impl<F: WgpuElement, I: WgpuElement> compiler::Compiler for Compiler<F, I> {
     }
 }
 
-impl<F: WgpuElement, I: WgpuElement> Compiler<F, I> {
+impl<F: FloatElement, I: IntElement> Compiler<F, I> {
     fn compile_item(item: gpu::Item) -> Item {
         match item {
             gpu::Item::Vec4(elem) => wgsl::Item::Vec4(Self::compile_elem(elem)),

--- a/burn-wgpu/src/codegen/dialect/wgsl/mod.rs
+++ b/burn-wgpu/src/codegen/dialect/wgsl/mod.rs
@@ -7,7 +7,7 @@ mod shader;
 
 pub(crate) use base::*;
 pub(crate) use body::*;
-pub(crate) use compiler::*;
+pub use compiler::*;
 pub(crate) use extension::*;
 pub(crate) use operations::*;
 pub(crate) use shader::*;

--- a/burn-wgpu/src/codegen/kernel.rs
+++ b/burn-wgpu/src/codegen/kernel.rs
@@ -8,7 +8,7 @@ use crate::codegen::dialect::gpu::{
 use crate::compute::StaticKernel;
 use crate::element::WgpuElement;
 use crate::kernel::{elemwise_workgroup, StaticKernelSource, WORKGROUP_DEFAULT};
-use crate::JitRuntime;
+use crate::Runtime;
 use std::marker::PhantomData;
 
 /// Kernel creation input phase, see [kernel codegen](ElemWiseKernelCodegen) for more details.
@@ -340,8 +340,8 @@ impl ElemWiseKernelCodegen<CompilationPhase> {
 }
 
 #[derive(new)]
-pub struct StaticHandle<'a, B: JitRuntime> {
-    handle: &'a burn_compute::server::Handle<B::Server>,
+pub struct StaticHandle<'a, R: Runtime> {
+    handle: &'a burn_compute::server::Handle<R::Server>,
     strides: &'a [usize],
     shape: &'a [usize],
 }
@@ -357,12 +357,12 @@ pub enum WorkgroupLaunch {
 ///
 /// The limitation from this method is that you can't launch a kernel with multiple types of
 /// scalar.
-pub fn execute_static<B: JitRuntime, K, E: WgpuElement>(
-    inputs: &[StaticHandle<B>],
-    outputs: &[StaticHandle<B>],
+pub fn execute_static<R: Runtime, K, E: WgpuElement>(
+    inputs: &[StaticHandle<R>],
+    outputs: &[StaticHandle<R>],
     scalar_elems: Option<&[E]>,
     launch: WorkgroupLaunch,
-    client: ComputeClient<B::Server, B::Channel>,
+    client: ComputeClient<R::Server, R::Channel>,
 ) where
     K: StaticKernelSource + 'static,
 {

--- a/burn-wgpu/src/codegen/kernel.rs
+++ b/burn-wgpu/src/codegen/kernel.rs
@@ -8,7 +8,7 @@ use crate::codegen::dialect::gpu::{
 use crate::compute::StaticKernel;
 use crate::element::WgpuElement;
 use crate::kernel::{elemwise_workgroup, StaticKernelSource, WORKGROUP_DEFAULT};
-use crate::JitGpuBackend;
+use crate::JitRuntime;
 use std::marker::PhantomData;
 
 /// Kernel creation input phase, see [kernel codegen](ElemWiseKernelCodegen) for more details.
@@ -340,7 +340,7 @@ impl ElemWiseKernelCodegen<CompilationPhase> {
 }
 
 #[derive(new)]
-pub struct StaticHandle<'a, B: JitGpuBackend> {
+pub struct StaticHandle<'a, B: JitRuntime> {
     handle: &'a burn_compute::server::Handle<B::Server>,
     strides: &'a [usize],
     shape: &'a [usize],
@@ -357,7 +357,7 @@ pub enum WorkgroupLaunch {
 ///
 /// The limitation from this method is that you can't launch a kernel with multiple types of
 /// scalar.
-pub fn execute_static<B: JitGpuBackend, K, E: WgpuElement>(
+pub fn execute_static<B: JitRuntime, K, E: WgpuElement>(
     inputs: &[StaticHandle<B>],
     outputs: &[StaticHandle<B>],
     scalar_elems: Option<&[E]>,

--- a/burn-wgpu/src/codegen/kernel.rs
+++ b/burn-wgpu/src/codegen/kernel.rs
@@ -6,7 +6,7 @@ use crate::codegen::dialect::gpu::{
     WorkgroupSize,
 };
 use crate::compute::StaticKernel;
-use crate::element::WgpuElement;
+use crate::element::JitElement;
 use crate::kernel::{elemwise_workgroup, StaticKernelSource, WORKGROUP_DEFAULT};
 use crate::Runtime;
 use std::marker::PhantomData;
@@ -357,7 +357,7 @@ pub enum WorkgroupLaunch {
 ///
 /// The limitation from this method is that you can't launch a kernel with multiple types of
 /// scalar.
-pub fn execute_static<R: Runtime, K, E: WgpuElement>(
+pub fn execute_static<R: Runtime, K, E: JitElement>(
     inputs: &[StaticHandle<R>],
     outputs: &[StaticHandle<R>],
     scalar_elems: Option<&[E]>,

--- a/burn-wgpu/src/codegen/kernel.rs
+++ b/burn-wgpu/src/codegen/kernel.rs
@@ -1,11 +1,14 @@
+use burn_compute::client::ComputeClient;
+
 use crate::codegen::dialect::gpu::{
     Binding, Body, ComputeShader, Elem, Item, Location, Operation, ReadGlobalOperation,
     ReadGlobalWithLayoutOperation, UnaryOperation, Variable, Vectorization, Visibility,
     WorkgroupSize,
 };
-use crate::compute::{StaticKernel, WgpuComputeClient, WgpuHandle};
+use crate::compute::StaticKernel;
 use crate::element::WgpuElement;
 use crate::kernel::{elemwise_workgroup, StaticKernelSource, WORKGROUP_DEFAULT};
+use crate::JitGpuBackend;
 use std::marker::PhantomData;
 
 /// Kernel creation input phase, see [kernel codegen](ElemWiseKernelCodegen) for more details.
@@ -337,8 +340,8 @@ impl ElemWiseKernelCodegen<CompilationPhase> {
 }
 
 #[derive(new)]
-pub struct StaticHandle<'a> {
-    handle: &'a WgpuHandle,
+pub struct StaticHandle<'a, B: JitGpuBackend> {
+    handle: &'a burn_compute::server::Handle<B::Server>,
     strides: &'a [usize],
     shape: &'a [usize],
 }
@@ -354,12 +357,12 @@ pub enum WorkgroupLaunch {
 ///
 /// The limitation from this method is that you can't launch a kernel with multiple types of
 /// scalar.
-pub fn execute_static<K, E: WgpuElement>(
-    inputs: &[StaticHandle],
-    outputs: &[StaticHandle],
+pub fn execute_static<B: JitGpuBackend, K, E: WgpuElement>(
+    inputs: &[StaticHandle<B>],
+    outputs: &[StaticHandle<B>],
     scalar_elems: Option<&[E]>,
     launch: WorkgroupLaunch,
-    client: WgpuComputeClient,
+    client: ComputeClient<B::Server, B::Channel>,
 ) where
     K: StaticKernelSource + 'static,
 {

--- a/burn-wgpu/src/compute/base.rs
+++ b/burn-wgpu/src/compute/base.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use super::WgpuServer;
 use crate::{
-    compute::WgpuStorage, wgsl, FloatElement, GraphicsApi, IntElement, JitGpuBackend, WgpuDevice,
+    compute::WgpuStorage, wgsl, FloatElement, GraphicsApi, IntElement, JitRuntime, WgpuDevice,
 };
 use alloc::sync::Arc;
 use burn_common::stub::RwLock;
@@ -37,14 +37,14 @@ fn compute_client<G: GraphicsApi>(device: &WgpuDevice) -> ComputeClient<Server, 
     })
 }
 
-pub struct WgpuJitGpuBackend<G: GraphicsApi, F: FloatElement, I: IntElement> {
+pub struct WgpuJitBackend<G: GraphicsApi, F: FloatElement, I: IntElement> {
     _g: PhantomData<G>,
     _f: PhantomData<F>,
     _i: PhantomData<I>,
 }
 
-impl<G: GraphicsApi, F: FloatElement, I: IntElement> JitGpuBackend for WgpuJitGpuBackend<G, F, I> {
-    type FullPrecisionBackend = WgpuJitGpuBackend<G, f32, i32>;
+impl<G: GraphicsApi, F: FloatElement, I: IntElement> JitRuntime for WgpuJitBackend<G, F, I> {
+    type FullPrecisionBackend = WgpuJitBackend<G, f32, i32>;
     type Compiler = wgsl::Compiler<F, I>;
     type Server = Server;
 

--- a/burn-wgpu/src/compute/base.rs
+++ b/burn-wgpu/src/compute/base.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use super::WgpuServer;
 use crate::{
-    compute::WgpuStorage, wgsl, FloatElement, GraphicsApi, IntElement, JitRuntime, WgpuDevice,
+    compute::WgpuStorage, wgsl, FloatElement, GraphicsApi, IntElement, Runtime, WgpuDevice,
 };
 use alloc::sync::Arc;
 use burn_common::stub::RwLock;
@@ -43,7 +43,7 @@ pub struct WgpuJitBackend<G: GraphicsApi, F: FloatElement, I: IntElement> {
     _i: PhantomData<I>,
 }
 
-impl<G: GraphicsApi, F: FloatElement, I: IntElement> JitRuntime for WgpuJitBackend<G, F, I> {
+impl<G: GraphicsApi, F: FloatElement, I: IntElement> Runtime for WgpuJitBackend<G, F, I> {
     type FullPrecisionBackend = WgpuJitBackend<G, f32, i32>;
     type Compiler = wgsl::Compiler<F, I>;
     type Server = Server;

--- a/burn-wgpu/src/compute/base.rs
+++ b/burn-wgpu/src/compute/base.rs
@@ -37,14 +37,14 @@ fn compute_client<G: GraphicsApi>(device: &WgpuDevice) -> ComputeClient<Server, 
     })
 }
 
-pub struct WgpuJitBackend<G: GraphicsApi, F: FloatElement, I: IntElement> {
+pub struct WgpuRuntime<G: GraphicsApi, F: FloatElement, I: IntElement> {
     _g: PhantomData<G>,
     _f: PhantomData<F>,
     _i: PhantomData<I>,
 }
 
-impl<G: GraphicsApi, F: FloatElement, I: IntElement> Runtime for WgpuJitBackend<G, F, I> {
-    type FullPrecisionBackend = WgpuJitBackend<G, f32, i32>;
+impl<G: GraphicsApi, F: FloatElement, I: IntElement> Runtime for WgpuRuntime<G, F, I> {
+    type FullPrecisionRuntime = WgpuRuntime<G, f32, i32>;
     type Compiler = wgsl::Compiler<F, I>;
     type Server = Server;
 

--- a/burn-wgpu/src/compute/base.rs
+++ b/burn-wgpu/src/compute/base.rs
@@ -20,11 +20,6 @@ type MemoryManagement = SimpleMemoryManagement<WgpuStorage>;
 pub type Server = WgpuServer<MemoryManagement>;
 type Channel = MutexComputeChannel<Server>;
 
-/// Wgpu [compute client](ComputeClient) to communicate with the [compute server](WgpuServer).
-type WgpuComputeClient = ComputeClient<Server, Channel>;
-/// Wgpu [server handle](burn_compute::server::Handle).
-type WgpuHandle = burn_compute::server::Handle<Server>;
-
 /// Compute handle for the wgpu backend.
 static COMPUTE: Compute<WgpuDevice, WgpuServer<MemoryManagement>, Channel> = Compute::new();
 

--- a/burn-wgpu/src/compute/base.rs
+++ b/burn-wgpu/src/compute/base.rs
@@ -41,6 +41,10 @@ impl<G: GraphicsApi, F: FloatElement, I: IntElement> Runtime for WgpuRuntime<G, 
             pollster::block_on(create_client::<G>(device))
         })
     }
+
+    fn name() -> &'static str {
+        "wgpu"
+    }
 }
 
 /// Init the client async, necessary for wasm.

--- a/burn-wgpu/src/compute/base.rs
+++ b/burn-wgpu/src/compute/base.rs
@@ -25,11 +25,8 @@ pub struct WgpuRuntime<G: GraphicsApi, F: FloatElement, I: IntElement> {
 }
 
 /// The compute instance is shared across all [wgpu runtimes](WgpuRuntime).
-static COMPUTE: Compute<
-    WgpuDevice,
-    WgpuServer<SimpleMemoryManagement<WgpuStorage>>,
-    MutexComputeChannel<WgpuServer<SimpleMemoryManagement<WgpuStorage>>>,
-> = Compute::new();
+static COMPUTE: Compute<WgpuDevice, Server, MutexComputeChannel<Server>> = Compute::new();
+type Server = WgpuServer<SimpleMemoryManagement<WgpuStorage>>;
 
 impl<G: GraphicsApi, F: FloatElement, I: IntElement> Runtime for WgpuRuntime<G, F, I> {
     type FullPrecisionRuntime = WgpuRuntime<G, f32, i32>;
@@ -40,8 +37,8 @@ impl<G: GraphicsApi, F: FloatElement, I: IntElement> Runtime for WgpuRuntime<G, 
     type Device = WgpuDevice;
 
     fn client(device: &Self::Device) -> ComputeClient<Self::Server, Self::Channel> {
-        COMPUTE.client(&device, move || {
-            pollster::block_on(create_client::<G>(&device))
+        COMPUTE.client(device, move || {
+            pollster::block_on(create_client::<G>(device))
         })
     }
 }

--- a/burn-wgpu/src/compute/kernel.rs
+++ b/burn-wgpu/src/compute/kernel.rs
@@ -76,10 +76,9 @@ mod tests {
     use crate::{
         binary,
         codegen::dialect::gpu::{BinaryOperation, Elem, Item, Operation, Variable},
-        compute::compute_client,
         kernel::{KernelSettings, WORKGROUP_DEFAULT},
-        tests::TestCompiler,
-        AutoGraphicsApi, WgpuDevice,
+        tests::{TestCompiler, TestJitGpuBackend},
+        WgpuDevice,
     };
 
     #[test]
@@ -95,7 +94,7 @@ mod tests {
             elem_out: f32
         );
 
-        let client = compute_client::<AutoGraphicsApi>(&WgpuDevice::default());
+        let client = TestJitGpuBackend::client(&WgpuDevice::default());
 
         let lhs: Vec<f32> = vec![0., 1., 2., 3., 4., 5., 6., 7.];
         let rhs: Vec<f32> = vec![10., 11., 12., 6., 7., 3., 1., 0.];

--- a/burn-wgpu/src/compute/kernel.rs
+++ b/burn-wgpu/src/compute/kernel.rs
@@ -78,7 +78,7 @@ mod tests {
         codegen::dialect::gpu::{BinaryOperation, Elem, Item, Operation, Variable},
         kernel::{KernelSettings, WORKGROUP_DEFAULT},
         tests::{TestCompiler, TestJitRuntime},
-        JitRuntime, WgpuDevice,
+        Runtime, WgpuDevice,
     };
 
     #[test]

--- a/burn-wgpu/src/compute/kernel.rs
+++ b/burn-wgpu/src/compute/kernel.rs
@@ -77,8 +77,8 @@ mod tests {
         binary,
         codegen::dialect::gpu::{BinaryOperation, Elem, Item, Operation, Variable},
         kernel::{KernelSettings, WORKGROUP_DEFAULT},
-        tests::{TestCompiler, TestJitGpuBackend},
-        JitGpuBackend, WgpuDevice,
+        tests::{TestCompiler, TestJitRuntime},
+        JitRuntime, WgpuDevice,
     };
 
     #[test]
@@ -94,7 +94,7 @@ mod tests {
             elem_out: f32
         );
 
-        let client = TestJitGpuBackend::client(&WgpuDevice::default());
+        let client = TestJitRuntime::client(&WgpuDevice::default());
 
         let lhs: Vec<f32> = vec![0., 1., 2., 3., 4., 5., 6., 7.];
         let rhs: Vec<f32> = vec![10., 11., 12., 6., 7., 3., 1., 0.];

--- a/burn-wgpu/src/compute/kernel.rs
+++ b/burn-wgpu/src/compute/kernel.rs
@@ -78,7 +78,7 @@ mod tests {
         codegen::dialect::gpu::{BinaryOperation, Elem, Item, Operation, Variable},
         kernel::{KernelSettings, WORKGROUP_DEFAULT},
         tests::{TestCompiler, TestJitGpuBackend},
-        WgpuDevice,
+        JitGpuBackend, WgpuDevice,
     };
 
     #[test]

--- a/burn-wgpu/src/compute/kernel.rs
+++ b/burn-wgpu/src/compute/kernel.rs
@@ -77,7 +77,7 @@ mod tests {
         binary,
         codegen::dialect::gpu::{BinaryOperation, Elem, Item, Operation, Variable},
         kernel::{KernelSettings, WORKGROUP_DEFAULT},
-        tests::{TestCompiler, TestJitRuntime},
+        tests::{TestCompiler, TestRuntime},
         Runtime, WgpuDevice,
     };
 
@@ -94,7 +94,7 @@ mod tests {
             elem_out: f32
         );
 
-        let client = TestJitRuntime::client(&WgpuDevice::default());
+        let client = TestRuntime::client(&WgpuDevice::default());
 
         let lhs: Vec<f32> = vec![0., 1., 2., 3., 4., 5., 6., 7.];
         let rhs: Vec<f32> = vec![10., 11., 12., 6., 7., 3., 1., 0.];

--- a/burn-wgpu/src/compute/server.rs
+++ b/burn-wgpu/src/compute/server.rs
@@ -1,4 +1,4 @@
-use super::{WgpuAutotuneKey, WgpuStorage, WorkGroup};
+use super::{JitAutotuneKey, WgpuStorage, WorkGroup};
 use crate::kernel::SourceTemplate;
 use alloc::{borrow::Cow, sync::Arc};
 use burn_compute::{
@@ -286,7 +286,7 @@ where
     type Kernel = Box<dyn Kernel>;
     type Storage = WgpuStorage;
     type MemoryManagement = MM;
-    type AutotuneKey = WgpuAutotuneKey;
+    type AutotuneKey = JitAutotuneKey;
 
     fn read(&mut self, handle: &server::Handle<Self>) -> Reader<Vec<u8>> {
         #[cfg(target_family = "wasm")]

--- a/burn-wgpu/src/compute/tune_key.rs
+++ b/burn-wgpu/src/compute/tune_key.rs
@@ -8,7 +8,7 @@ use crate::fusion::FusionElemWiseAutotuneKey;
 
 #[derive(Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
 /// Key for all autotune-enabled operations
-pub enum WgpuAutotuneKey {
+pub enum JitAutotuneKey {
     /// Key for matmul operation
     Matmul(MatmulAutotuneKey),
     /// Key for sum_dim operations
@@ -20,16 +20,16 @@ pub enum WgpuAutotuneKey {
     FusionElemWise(FusionElemWiseAutotuneKey),
 }
 
-impl Display for WgpuAutotuneKey {
+impl Display for JitAutotuneKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            WgpuAutotuneKey::Matmul(matmul_key) => std::fmt::Display::fmt(&matmul_key, f),
-            WgpuAutotuneKey::SumDim(reduce_key) => std::fmt::Display::fmt(&reduce_key, f),
-            WgpuAutotuneKey::MeanDim(reduce_key) => std::fmt::Display::fmt(&reduce_key, f),
+            JitAutotuneKey::Matmul(matmul_key) => std::fmt::Display::fmt(&matmul_key, f),
+            JitAutotuneKey::SumDim(reduce_key) => std::fmt::Display::fmt(&reduce_key, f),
+            JitAutotuneKey::MeanDim(reduce_key) => std::fmt::Display::fmt(&reduce_key, f),
             #[cfg(any(feature = "fusion", test))]
-            WgpuAutotuneKey::FusionElemWise(reduce_key) => std::fmt::Display::fmt(&reduce_key, f),
+            JitAutotuneKey::FusionElemWise(reduce_key) => std::fmt::Display::fmt(&reduce_key, f),
         }
     }
 }
 
-impl AutotuneKey for WgpuAutotuneKey {}
+impl AutotuneKey for JitAutotuneKey {}

--- a/burn-wgpu/src/element.rs
+++ b/burn-wgpu/src/element.rs
@@ -2,7 +2,7 @@ use crate::codegen::dialect::{gpu, wgsl};
 use burn_tensor::Element;
 
 /// The base element trait for the wgou backend.
-pub trait WgpuElement:
+pub trait JitElement:
     burn_tensor::Element + core::fmt::Debug + Send + Sync + 'static + Clone + bytemuck::Pod
 where
     Self: Sized,
@@ -15,12 +15,12 @@ where
 }
 
 /// The float element type for the wgpu backend.
-pub trait FloatElement: WgpuElement + Element {}
+pub trait FloatElement: JitElement + Element {}
 
 /// The int element type for the wgpu backend.
-pub trait IntElement: WgpuElement + Element {}
+pub trait IntElement: JitElement + Element {}
 
-impl WgpuElement for u32 {
+impl JitElement for u32 {
     fn type_name() -> &'static str {
         "u32"
     }
@@ -38,7 +38,7 @@ impl WgpuElement for u32 {
     }
 }
 
-impl WgpuElement for i32 {
+impl JitElement for i32 {
     fn type_name() -> &'static str {
         "i32"
     }
@@ -56,7 +56,7 @@ impl WgpuElement for i32 {
     }
 }
 
-impl WgpuElement for f32 {
+impl JitElement for f32 {
     fn type_name() -> &'static str {
         "f32"
     }

--- a/burn-wgpu/src/fusion/base.rs
+++ b/burn-wgpu/src/fusion/base.rs
@@ -5,7 +5,7 @@ use crate::{
     element::WgpuElement,
     fusion::ElementWiseBuilder,
     tensor::WgpuTensor,
-    FloatElement, GpuBackend, GraphicsApi, IntElement, WgpuDevice,
+    GpuBackend, GraphicsApi, WgpuDevice,
 };
 use burn_fusion::{client::MutexFusionClient, DeviceId, FusionBackend, FusionDevice};
 use burn_tensor::Shape;

--- a/burn-wgpu/src/fusion/base.rs
+++ b/burn-wgpu/src/fusion/base.rs
@@ -137,7 +137,7 @@ pub struct WgpuFusionHandle<B: JitGpuBackend> {
 }
 
 impl<B: JitGpuBackend> core::fmt::Debug for WgpuFusionHandle<B> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         todo!()
     }
 }

--- a/burn-wgpu/src/fusion/base.rs
+++ b/burn-wgpu/src/fusion/base.rs
@@ -125,7 +125,6 @@ pub fn strides_dyn_rank(shape: &[usize]) -> Vec<usize> {
     strides
 }
 
-#[derive(new, Debug)]
 /// Handle to be used when fusing operations.
 pub struct WgpuFusionHandle<B: JitGpuBackend> {
     /// Compute client for wgpu.
@@ -135,6 +134,12 @@ pub struct WgpuFusionHandle<B: JitGpuBackend> {
     /// The device of the current tensor.
     pub device: B::Device,
     pub(crate) strides: Vec<usize>,
+}
+
+impl<B: JitGpuBackend> core::fmt::Debug for WgpuFusionHandle<B> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        todo!()
+    }
 }
 
 impl<B: JitGpuBackend> Clone for WgpuFusionHandle<B> {

--- a/burn-wgpu/src/fusion/elemwise/builder.rs
+++ b/burn-wgpu/src/fusion/elemwise/builder.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     element::WgpuElement,
     fusion::WgpuOptimization,
-    GpuBackend, JitGpuBackend,
+    GpuBackend, JitRuntime,
 };
 use burn_fusion::{
     stream::{
@@ -26,7 +26,7 @@ use burn_tensor::{
 use hashbrown::HashMap;
 
 /// Fused element wise operations that are normally memory bound.
-pub(crate) struct ElementWiseBuilder<B: JitGpuBackend> {
+pub(crate) struct ElementWiseBuilder<B: JitRuntime> {
     pub(crate) inputs: Vec<TensorDescription>,
     pub(crate) locals: HashMap<TensorId, u16>,
     pub(crate) tensors: HashMap<TensorId, (TensorDescription, Elem)>,
@@ -40,7 +40,7 @@ pub(crate) struct ElementWiseBuilder<B: JitGpuBackend> {
     pub(crate) device: B::Device,
 }
 
-impl<B: JitGpuBackend> OptimizationBuilder<WgpuOptimization<B>> for ElementWiseBuilder<B> {
+impl<B: JitRuntime> OptimizationBuilder<WgpuOptimization<B>> for ElementWiseBuilder<B> {
     fn register(&mut self, ops: &OperationDescription) {
         if let OptimizationStatus::Closed = self.status {
             return;
@@ -138,7 +138,7 @@ impl<B: JitGpuBackend> OptimizationBuilder<WgpuOptimization<B>> for ElementWiseB
     }
 }
 
-impl<B: JitGpuBackend> ElementWiseBuilder<B> {
+impl<B: JitRuntime> ElementWiseBuilder<B> {
     pub fn new(device: Device<GpuBackend<B>>) -> Self {
         Self {
             inputs: Vec::new(),

--- a/burn-wgpu/src/fusion/elemwise/builder.rs
+++ b/burn-wgpu/src/fusion/elemwise/builder.rs
@@ -7,9 +7,9 @@ use crate::{
         },
         Compiler,
     },
-    element::WgpuElement,
+    element::JitElement,
     fusion::WgpuOptimization,
-    GpuBackend, Runtime,
+    JitBackend, Runtime,
 };
 use burn_fusion::{
     stream::{
@@ -48,31 +48,31 @@ impl<R: Runtime> OptimizationBuilder<WgpuOptimization<R>> for ElementWiseBuilder
 
         match ops {
             OperationDescription::BaseFloat(ops) => {
-                if !self.register_base::<FloatElem<GpuBackend<R>>>(ops) {
+                if !self.register_base::<FloatElem<JitBackend<R>>>(ops) {
                     self.status = OptimizationStatus::Closed;
                     return;
                 }
             }
             OperationDescription::BaseInt(ops) => {
-                if !self.register_base::<IntElem<GpuBackend<R>>>(ops) {
+                if !self.register_base::<IntElem<JitBackend<R>>>(ops) {
                     self.status = OptimizationStatus::Closed;
                     return;
                 }
             }
             OperationDescription::Float(ops) => {
-                if !self.register_float::<FloatElem<GpuBackend<R>>>(ops) {
+                if !self.register_float::<FloatElem<JitBackend<R>>>(ops) {
                     self.status = OptimizationStatus::Closed;
                     return;
                 }
             }
             OperationDescription::NumericFloat(ops) => {
-                if !self.register_numeric::<FloatElem<GpuBackend<R>>, _>(ops) {
+                if !self.register_numeric::<FloatElem<JitBackend<R>>, _>(ops) {
                     self.status = OptimizationStatus::Closed;
                     return;
                 }
             }
             OperationDescription::NumericInt(ops) => {
-                if !self.register_numeric::<IntElem<GpuBackend<R>>, _>(ops) {
+                if !self.register_numeric::<IntElem<JitBackend<R>>, _>(ops) {
                     self.status = OptimizationStatus::Closed;
                     return;
                 }
@@ -139,7 +139,7 @@ impl<R: Runtime> OptimizationBuilder<WgpuOptimization<R>> for ElementWiseBuilder
 }
 
 impl<R: Runtime> ElementWiseBuilder<R> {
-    pub fn new(device: Device<GpuBackend<R>>) -> Self {
+    pub fn new(device: Device<JitBackend<R>>) -> Self {
         Self {
             inputs: Vec::new(),
             locals: HashMap::new(),
@@ -398,7 +398,7 @@ impl<R: Runtime> ElementWiseBuilder<R> {
         Variable::Local(local_index, Item::Scalar(elem))
     }
 
-    fn register_base<E: WgpuElement>(&mut self, ops: &BaseOperationDescription) -> bool {
+    fn register_base<E: JitElement>(&mut self, ops: &BaseOperationDescription) -> bool {
         match ops {
             BaseOperationDescription::Equal(desc) => self.register_binary_ops(
                 desc,
@@ -409,7 +409,7 @@ impl<R: Runtime> ElementWiseBuilder<R> {
         }
     }
 
-    fn register_float<E: WgpuElement>(&mut self, ops: &FloatOperationDescription) -> bool {
+    fn register_float<E: JitElement>(&mut self, ops: &FloatOperationDescription) -> bool {
         match ops {
             FloatOperationDescription::Exp(desc) => {
                 self.register_unary_ops(desc, (E::gpu_elem(), E::gpu_elem()), |input, out| {
@@ -460,7 +460,7 @@ impl<R: Runtime> ElementWiseBuilder<R> {
         }
     }
 
-    fn register_numeric<E: WgpuElement, EDesc: WgpuElement>(
+    fn register_numeric<E: JitElement, EDesc: JitElement>(
         &mut self,
         ops: &NumericOperationDescription<EDesc>,
     ) -> bool {

--- a/burn-wgpu/src/fusion/elemwise/builder.rs
+++ b/burn-wgpu/src/fusion/elemwise/builder.rs
@@ -1,11 +1,8 @@
 use super::{optimization::ElementWise, CompilationPhase, Scalars};
 use crate::{
-    codegen::{
-        dialect::gpu::{
-            BinaryOperation, ConditionalAssignOperation, Elem, Item, Operation, UnaryOperation,
-            Variable,
-        },
-        Compiler,
+    codegen::dialect::gpu::{
+        BinaryOperation, ConditionalAssignOperation, Elem, Item, Operation, UnaryOperation,
+        Variable,
     },
     element::JitElement,
     fusion::WgpuOptimization,

--- a/burn-wgpu/src/fusion/elemwise/kernel.rs
+++ b/burn-wgpu/src/fusion/elemwise/kernel.rs
@@ -56,7 +56,7 @@ impl<B: JitGpuBackend> FusionKernel<B> for VecElementWise<B> {
         inputs: &[&TensorDescription],
         _outputs: &[&TensorDescription],
     ) -> Priority {
-        let is_unavailable_input = |handle: &WgpuFusionHandle, desc: &TensorDescription| {
+        let is_unavailable_input = |handle: &WgpuFusionHandle<B>, desc: &TensorDescription| {
             let rank = handle.strides.len();
 
             // Last dimension strides should be 1, otherwise vecX won't be contiguous.

--- a/burn-wgpu/src/fusion/elemwise/kernel.rs
+++ b/burn-wgpu/src/fusion/elemwise/kernel.rs
@@ -7,20 +7,20 @@ use crate::{
         WgpuFusionHandle,
     },
     kernel::elemwise_workgroup,
-    JitGpuBackend,
+    JitRuntime,
 };
 use burn_fusion::TensorDescription;
 use std::sync::Arc;
 
-pub struct ScalarElementWise<B: JitGpuBackend> {
+pub struct ScalarElementWise<B: JitRuntime> {
     source: ElementWiseSource<B>,
 }
 
-pub struct VecElementWise<B: JitGpuBackend> {
+pub struct VecElementWise<B: JitRuntime> {
     source: ElementWiseSource<B>,
 }
 
-impl<B: JitGpuBackend> FusionKernel<B> for ScalarElementWise<B> {
+impl<B: JitRuntime> FusionKernel<B> for ScalarElementWise<B> {
     fn kernel(
         &self,
         handles_inputs: &[WgpuFusionHandle<B>],
@@ -40,7 +40,7 @@ impl<B: JitGpuBackend> FusionKernel<B> for ScalarElementWise<B> {
     }
 }
 
-impl<B: JitGpuBackend> FusionKernel<B> for VecElementWise<B> {
+impl<B: JitRuntime> FusionKernel<B> for VecElementWise<B> {
     fn kernel(
         &self,
         handles_inputs: &[WgpuFusionHandle<B>],
@@ -93,7 +93,7 @@ impl<B: JitGpuBackend> FusionKernel<B> for VecElementWise<B> {
     }
 }
 
-impl<B: JitGpuBackend> ElementWiseSource<B> {
+impl<B: JitRuntime> ElementWiseSource<B> {
     fn kernel(
         &self,
         handles_inputs: &[WgpuFusionHandle<B>],
@@ -153,7 +153,7 @@ impl<B: JitGpuBackend> ElementWiseSource<B> {
     }
 }
 
-struct ElementWiseSource<B: JitGpuBackend> {
+struct ElementWiseSource<B: JitRuntime> {
     source_normal: Arc<GpuKernelSource<B::Compiler>>,
     source_inplace: Arc<GpuKernelSource<B::Compiler>>,
     mappings: Vec<InplaceMapping>,
@@ -161,7 +161,7 @@ struct ElementWiseSource<B: JitGpuBackend> {
     factor: usize,
 }
 
-impl<B: JitGpuBackend> ElementWiseSource<B> {
+impl<B: JitRuntime> ElementWiseSource<B> {
     pub fn new(
         normal: GpuKernelSource<B::Compiler>,
         inplace: GpuKernelSource<B::Compiler>,
@@ -185,7 +185,7 @@ impl<B: JitGpuBackend> ElementWiseSource<B> {
     }
 }
 
-impl<B: JitGpuBackend> ScalarElementWise<B> {
+impl<B: JitRuntime> ScalarElementWise<B> {
     pub fn new(
         normal: GpuKernelSource<B::Compiler>,
         inplace: GpuKernelSource<B::Compiler>,
@@ -198,7 +198,7 @@ impl<B: JitGpuBackend> ScalarElementWise<B> {
     }
 }
 
-impl<B: JitGpuBackend> VecElementWise<B> {
+impl<B: JitRuntime> VecElementWise<B> {
     pub fn new(
         normal: GpuKernelSource<B::Compiler>,
         inplace: GpuKernelSource<B::Compiler>,
@@ -212,7 +212,7 @@ impl<B: JitGpuBackend> VecElementWise<B> {
     }
 }
 
-fn inplace_available<B: JitGpuBackend>(
+fn inplace_available<B: JitRuntime>(
     mappings: &[InplaceMapping],
     handles_inputs: &[WgpuFusionHandle<B>],
 ) -> bool {

--- a/burn-wgpu/src/fusion/elemwise/kernel.rs
+++ b/burn-wgpu/src/fusion/elemwise/kernel.rs
@@ -7,22 +7,23 @@ use crate::{
         WgpuFusionHandle,
     },
     kernel::elemwise_workgroup,
+    JitGpuBackend,
 };
 use burn_fusion::TensorDescription;
 use std::sync::Arc;
 
-pub struct ScalarElementWise<C: Compiler> {
-    source: ElementWiseSource<C>,
+pub struct ScalarElementWise<B: JitGpuBackend> {
+    source: ElementWiseSource<B>,
 }
 
-pub struct VecElementWise<C: Compiler> {
-    source: ElementWiseSource<C>,
+pub struct VecElementWise<B: JitGpuBackend> {
+    source: ElementWiseSource<B>,
 }
 
-impl<C: Compiler> FusionKernel for ScalarElementWise<C> {
+impl<B: JitGpuBackend> FusionKernel<B> for ScalarElementWise<B> {
     fn kernel(
         &self,
-        handles_inputs: &[WgpuFusionHandle],
+        handles_inputs: &[WgpuFusionHandle<B>],
         inputs: &[&TensorDescription],
         outputs: &[&TensorDescription],
     ) -> SelectedKernel {
@@ -31,7 +32,7 @@ impl<C: Compiler> FusionKernel for ScalarElementWise<C> {
 
     fn priority(
         &self,
-        _handles_inputs: &[WgpuFusionHandle],
+        _handles_inputs: &[WgpuFusionHandle<B>],
         _inputs: &[&TensorDescription],
         _outputs: &[&TensorDescription],
     ) -> Priority {
@@ -39,10 +40,10 @@ impl<C: Compiler> FusionKernel for ScalarElementWise<C> {
     }
 }
 
-impl<C: Compiler> FusionKernel for VecElementWise<C> {
+impl<B: JitGpuBackend> FusionKernel<B> for VecElementWise<B> {
     fn kernel(
         &self,
-        handles_inputs: &[WgpuFusionHandle],
+        handles_inputs: &[WgpuFusionHandle<B>],
         inputs: &[&TensorDescription],
         outputs: &[&TensorDescription],
     ) -> SelectedKernel {
@@ -51,7 +52,7 @@ impl<C: Compiler> FusionKernel for VecElementWise<C> {
 
     fn priority(
         &self,
-        handles_inputs: &[WgpuFusionHandle],
+        handles_inputs: &[WgpuFusionHandle<B>],
         inputs: &[&TensorDescription],
         _outputs: &[&TensorDescription],
     ) -> Priority {
@@ -92,10 +93,10 @@ impl<C: Compiler> FusionKernel for VecElementWise<C> {
     }
 }
 
-impl<C: Compiler> ElementWiseSource<C> {
+impl<B: JitGpuBackend> ElementWiseSource<B> {
     fn kernel(
         &self,
-        handles_inputs: &[WgpuFusionHandle],
+        handles_inputs: &[WgpuFusionHandle<B>],
         inputs: &[&TensorDescription],
         outputs: &[&TensorDescription],
     ) -> SelectedKernel {
@@ -127,7 +128,7 @@ impl<C: Compiler> ElementWiseSource<C> {
                                 let elem =
                                     self.source_normal.shader.outputs[output_pos].item.elem();
                                 let size = calculate_num_elems_dyn_rank(&outputs[output_pos].shape)
-                                    * C::elem_size(elem);
+                                    * <B::Compiler as Compiler>::elem_size(elem);
                                 OutputInfo::Array { size }
                             }
                         });
@@ -141,7 +142,8 @@ impl<C: Compiler> ElementWiseSource<C> {
                 let kernel = Box::new(DynamicKernel::new(self.source_normal.clone(), workgroup));
                 let output_infos = outputs.iter().enumerate().map(|(pos, tensor)| {
                     let elem = self.source_normal.shader.outputs[pos].item.elem();
-                    let size = calculate_num_elems_dyn_rank(&tensor.shape) * C::elem_size(elem);
+                    let size = calculate_num_elems_dyn_rank(&tensor.shape)
+                        * <B::Compiler as Compiler>::elem_size(elem);
                     OutputInfo::Array { size }
                 });
 
@@ -151,18 +153,18 @@ impl<C: Compiler> ElementWiseSource<C> {
     }
 }
 
-struct ElementWiseSource<C: Compiler> {
-    source_normal: Arc<GpuKernelSource<C>>,
-    source_inplace: Arc<GpuKernelSource<C>>,
+struct ElementWiseSource<B: JitGpuBackend> {
+    source_normal: Arc<GpuKernelSource<B::Compiler>>,
+    source_inplace: Arc<GpuKernelSource<B::Compiler>>,
     mappings: Vec<InplaceMapping>,
     inplace_output2input: Vec<Option<usize>>,
     factor: usize,
 }
 
-impl<C: Compiler> ElementWiseSource<C> {
+impl<B: JitGpuBackend> ElementWiseSource<B> {
     pub fn new(
-        normal: GpuKernelSource<C>,
-        inplace: GpuKernelSource<C>,
+        normal: GpuKernelSource<B::Compiler>,
+        inplace: GpuKernelSource<B::Compiler>,
         mappings: Vec<InplaceMapping>,
         num_output: usize,
         factor: usize,
@@ -183,10 +185,10 @@ impl<C: Compiler> ElementWiseSource<C> {
     }
 }
 
-impl<C: Compiler> ScalarElementWise<C> {
+impl<B: JitGpuBackend> ScalarElementWise<B> {
     pub fn new(
-        normal: GpuKernelSource<C>,
-        inplace: GpuKernelSource<C>,
+        normal: GpuKernelSource<B::Compiler>,
+        inplace: GpuKernelSource<B::Compiler>,
         mappings: Vec<InplaceMapping>,
         num_output: usize,
     ) -> Self {
@@ -196,10 +198,10 @@ impl<C: Compiler> ScalarElementWise<C> {
     }
 }
 
-impl<C: Compiler> VecElementWise<C> {
+impl<B: JitGpuBackend> VecElementWise<B> {
     pub fn new(
-        normal: GpuKernelSource<C>,
-        inplace: GpuKernelSource<C>,
+        normal: GpuKernelSource<B::Compiler>,
+        inplace: GpuKernelSource<B::Compiler>,
         mappings: Vec<InplaceMapping>,
         num_output: usize,
         factor: usize,
@@ -210,7 +212,10 @@ impl<C: Compiler> VecElementWise<C> {
     }
 }
 
-fn inplace_available(mappings: &[InplaceMapping], handles_inputs: &[WgpuFusionHandle]) -> bool {
+fn inplace_available<B: JitGpuBackend>(
+    mappings: &[InplaceMapping],
+    handles_inputs: &[WgpuFusionHandle<B>],
+) -> bool {
     if mappings.is_empty() {
         return false;
     }

--- a/burn-wgpu/src/fusion/elemwise/optimization.rs
+++ b/burn-wgpu/src/fusion/elemwise/optimization.rs
@@ -140,14 +140,14 @@ impl<B: JitGpuBackend> ElementWise<B, CompilationPhase> {
             })
             .collect::<Vec<_>>();
 
-        let kernel_set_1 = build_kernel_set::<B::Compiler>(
+        let kernel_set_1 = build_kernel_set::<B>(
             &inputs,
             &outputs,
             &self.operators,
             &mappings,
             WorkgroupSize::default(),
         );
-        let kernel_set_2 = build_kernel_set::<B::Compiler>(
+        let kernel_set_2 = build_kernel_set::<B>(
             &inputs,
             &outputs,
             &self.operators,
@@ -276,7 +276,7 @@ impl<B: JitGpuBackend> ElementWise<B, ExecutionPhase<B>> {
         &[]
     }
 
-    pub(crate) fn from_state(device: &WgpuDevice, state: ElementWiseState) -> Self {
+    pub(crate) fn from_state(device: &B::Device, state: ElementWiseState) -> Self {
         // We don't save the compiled kernel structs since it's quick to compile and the output is
         // very large.
         //
@@ -312,7 +312,7 @@ fn build_kernel_set<B: JitGpuBackend>(
     mappings: &[InplaceMapping],
     workgroup_size: WorkgroupSize,
 ) -> FusionKernelSet<B> {
-    let scalar = ScalarElementWise::<B::Compiler>::new(
+    let scalar = ScalarElementWise::<B>::new(
         GpuKernelSource::new(
             IdGenerator::generate(),
             ElemWiseKernelCodegen::new()
@@ -336,7 +336,7 @@ fn build_kernel_set<B: JitGpuBackend>(
         outputs.len(),
     );
 
-    let vec2 = VecElementWise::<B::Compiler>::new(
+    let vec2 = VecElementWise::<B>::new(
         GpuKernelSource::new(
             IdGenerator::generate(),
             ElemWiseKernelCodegen::new()
@@ -362,7 +362,7 @@ fn build_kernel_set<B: JitGpuBackend>(
         outputs.len(),
         2,
     );
-    let vec4 = VecElementWise::<B::Compiler>::new(
+    let vec4 = VecElementWise::<B>::new(
         GpuKernelSource::new(
             IdGenerator::generate(),
             ElemWiseKernelCodegen::new()

--- a/burn-wgpu/src/fusion/elemwise/optimization.rs
+++ b/burn-wgpu/src/fusion/elemwise/optimization.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     compute::WgpuAutotuneKey,
     fusion::{kernel::FusionKernelSet, source::GpuKernelSource},
-    GpuBackend, JitGpuBackend, WgpuDevice,
+    GpuBackend, JitGpuBackend,
 };
 use burn_common::id::IdGenerator;
 use burn_compute::client::ComputeClient;

--- a/burn-wgpu/src/fusion/elemwise/optimization.rs
+++ b/burn-wgpu/src/fusion/elemwise/optimization.rs
@@ -5,9 +5,7 @@ use super::{
 };
 use crate::{
     codegen::dialect::gpu::{Elem, Item, Operation, Vectorization, Visibility, WorkgroupSize},
-    codegen::{
-        compiler::Compiler, ElemWiseKernelCodegen, InplaceMapping, Input, Output, ReadingStrategy,
-    },
+    codegen::{ElemWiseKernelCodegen, InplaceMapping, Input, Output, ReadingStrategy},
     compute::JitAutotuneKey,
     fusion::{kernel::FusionKernelSet, source::GpuKernelSource},
     JitBackend, Runtime,

--- a/burn-wgpu/src/fusion/elemwise/tune.rs
+++ b/burn-wgpu/src/fusion/elemwise/tune.rs
@@ -1,15 +1,17 @@
 use std::fmt::Display;
 
-use crate::{compute::WgpuAutotuneKey, fusion::kernel::AutotunableKernel, tune::anchor};
+use crate::{
+    compute::WgpuAutotuneKey, fusion::kernel::AutotunableKernel, tune::anchor, JitGpuBackend,
+};
 use burn_compute::tune::{AutotuneOperation, AutotuneOperationSet};
 use serde::{Deserialize, Serialize};
 
 #[derive(new)]
-pub struct ElementWiseAutotuneOperationSet {
+pub struct ElementWiseAutotuneOperationSet<B: JitGpuBackend> {
     key: WgpuAutotuneKey,
-    kernel_1: AutotunableKernel,
-    kernel_2: AutotunableKernel,
-    kernel_default: AutotunableKernel,
+    kernel_1: AutotunableKernel<B>,
+    kernel_2: AutotunableKernel<B>,
+    kernel_default: AutotunableKernel<B>,
 }
 
 #[derive(Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
@@ -31,7 +33,9 @@ impl Display for FusionElemWiseAutotuneKey {
     }
 }
 
-impl AutotuneOperationSet<WgpuAutotuneKey> for ElementWiseAutotuneOperationSet {
+impl<B: JitGpuBackend> AutotuneOperationSet<WgpuAutotuneKey>
+    for ElementWiseAutotuneOperationSet<B>
+{
     fn key(&self) -> WgpuAutotuneKey {
         self.key.clone()
     }

--- a/burn-wgpu/src/fusion/elemwise/tune.rs
+++ b/burn-wgpu/src/fusion/elemwise/tune.rs
@@ -1,17 +1,15 @@
 use std::fmt::Display;
 
-use crate::{
-    compute::WgpuAutotuneKey, fusion::kernel::AutotunableKernel, tune::anchor, JitRuntime,
-};
+use crate::{compute::WgpuAutotuneKey, fusion::kernel::AutotunableKernel, tune::anchor, Runtime};
 use burn_compute::tune::{AutotuneOperation, AutotuneOperationSet};
 use serde::{Deserialize, Serialize};
 
 #[derive(new)]
-pub struct ElementWiseAutotuneOperationSet<B: JitRuntime> {
+pub struct ElementWiseAutotuneOperationSet<R: Runtime> {
     key: WgpuAutotuneKey,
-    kernel_1: AutotunableKernel<B>,
-    kernel_2: AutotunableKernel<B>,
-    kernel_default: AutotunableKernel<B>,
+    kernel_1: AutotunableKernel<R>,
+    kernel_2: AutotunableKernel<R>,
+    kernel_default: AutotunableKernel<R>,
 }
 
 #[derive(Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
@@ -33,9 +31,7 @@ impl Display for FusionElemWiseAutotuneKey {
     }
 }
 
-impl<B: JitRuntime> AutotuneOperationSet<WgpuAutotuneKey>
-    for ElementWiseAutotuneOperationSet<B>
-{
+impl<R: Runtime> AutotuneOperationSet<WgpuAutotuneKey> for ElementWiseAutotuneOperationSet<R> {
     fn key(&self) -> WgpuAutotuneKey {
         self.key.clone()
     }

--- a/burn-wgpu/src/fusion/elemwise/tune.rs
+++ b/burn-wgpu/src/fusion/elemwise/tune.rs
@@ -1,13 +1,13 @@
 use std::fmt::Display;
 
 use crate::{
-    compute::WgpuAutotuneKey, fusion::kernel::AutotunableKernel, tune::anchor, JitGpuBackend,
+    compute::WgpuAutotuneKey, fusion::kernel::AutotunableKernel, tune::anchor, JitRuntime,
 };
 use burn_compute::tune::{AutotuneOperation, AutotuneOperationSet};
 use serde::{Deserialize, Serialize};
 
 #[derive(new)]
-pub struct ElementWiseAutotuneOperationSet<B: JitGpuBackend> {
+pub struct ElementWiseAutotuneOperationSet<B: JitRuntime> {
     key: WgpuAutotuneKey,
     kernel_1: AutotunableKernel<B>,
     kernel_2: AutotunableKernel<B>,
@@ -33,7 +33,7 @@ impl Display for FusionElemWiseAutotuneKey {
     }
 }
 
-impl<B: JitGpuBackend> AutotuneOperationSet<WgpuAutotuneKey>
+impl<B: JitRuntime> AutotuneOperationSet<WgpuAutotuneKey>
     for ElementWiseAutotuneOperationSet<B>
 {
     fn key(&self) -> WgpuAutotuneKey {

--- a/burn-wgpu/src/fusion/elemwise/tune.rs
+++ b/burn-wgpu/src/fusion/elemwise/tune.rs
@@ -1,12 +1,12 @@
 use std::fmt::Display;
 
-use crate::{compute::WgpuAutotuneKey, fusion::kernel::AutotunableKernel, tune::anchor, Runtime};
+use crate::{compute::JitAutotuneKey, fusion::kernel::AutotunableKernel, tune::anchor, Runtime};
 use burn_compute::tune::{AutotuneOperation, AutotuneOperationSet};
 use serde::{Deserialize, Serialize};
 
 #[derive(new)]
 pub struct ElementWiseAutotuneOperationSet<R: Runtime> {
-    key: WgpuAutotuneKey,
+    key: JitAutotuneKey,
     kernel_1: AutotunableKernel<R>,
     kernel_2: AutotunableKernel<R>,
     kernel_default: AutotunableKernel<R>,
@@ -31,8 +31,8 @@ impl Display for FusionElemWiseAutotuneKey {
     }
 }
 
-impl<R: Runtime> AutotuneOperationSet<WgpuAutotuneKey> for ElementWiseAutotuneOperationSet<R> {
-    fn key(&self) -> WgpuAutotuneKey {
+impl<R: Runtime> AutotuneOperationSet<JitAutotuneKey> for ElementWiseAutotuneOperationSet<R> {
+    fn key(&self) -> JitAutotuneKey {
         self.key.clone()
     }
 

--- a/burn-wgpu/src/fusion/kernel.rs
+++ b/burn-wgpu/src/fusion/kernel.rs
@@ -1,7 +1,8 @@
+use crate::codegen::Compiler;
 use crate::compute::{Kernel, WgpuComputeClient, WgpuHandle};
 use crate::fusion::strides_dyn_rank;
 use crate::fusion::WgpuFusionHandle;
-use crate::{FloatElement, GraphicsApi, IntElement, WgpuBackend};
+use crate::{GpuBackend, GraphicsApi};
 use burn_compute::tune::AutotuneOperation;
 use burn_fusion::stream::Context;
 use burn_fusion::{TensorDescription, TensorStatus};
@@ -117,14 +118,14 @@ pub trait FusionKernel: Send + Sync {
 impl FusionKernelSet {
     /// Select the best kernel based on the given information.
     #[allow(clippy::too_many_arguments)]
-    pub fn select<G: GraphicsApi, F: FloatElement, I: IntElement>(
+    pub fn select<G: GraphicsApi, C: Compiler>(
         &self,
         inputs: &[&TensorDescription],
         outputs: &[&TensorDescription],
         scalars_f32: usize,
         scalars_i32: usize,
-        context: &mut Context<'_, WgpuBackend<G, F, I>>,
-        device: Device<WgpuBackend<G, F, I>>,
+        context: &mut Context<'_, GpuBackend<G, C>>,
+        device: Device<GpuBackend<G, C>>,
         client: WgpuComputeClient,
         stateful: bool,
     ) -> ExecutableKernel {
@@ -260,10 +261,10 @@ fn register_info_tensor(
     }
 }
 
-fn process_inputs_outputs<'a, G: GraphicsApi, F: FloatElement, I: IntElement>(
+fn process_inputs_outputs<'a, G: GraphicsApi, C: Compiler>(
     inputs: &[&TensorDescription],
     outputs: &[&TensorDescription],
-    context: &'a mut Context<'_, WgpuBackend<G, F, I>>,
+    context: &'a mut Context<'_, GpuBackend<G, C>>,
     stateful: bool,
 ) -> (
     Vec<WgpuFusionHandle>,

--- a/burn-wgpu/src/fusion/kernel.rs
+++ b/burn-wgpu/src/fusion/kernel.rs
@@ -1,7 +1,7 @@
 use crate::compute::Kernel;
 use crate::fusion::strides_dyn_rank;
 use crate::fusion::WgpuFusionHandle;
-use crate::GpuBackend;
+use crate::JitBackend;
 use crate::Runtime;
 use burn_compute::client::ComputeClient;
 use burn_compute::server::Handle;
@@ -126,8 +126,8 @@ impl<R: Runtime> FusionKernelSet<R> {
         outputs: &[&TensorDescription],
         scalars_f32: usize,
         scalars_i32: usize,
-        context: &mut Context<'_, GpuBackend<R>>,
-        device: Device<GpuBackend<R>>,
+        context: &mut Context<'_, JitBackend<R>>,
+        device: Device<JitBackend<R>>,
         client: ComputeClient<R::Server, R::Channel>,
         stateful: bool,
     ) -> ExecutableKernel<R> {
@@ -266,7 +266,7 @@ fn register_info_tensor<R: Runtime>(
 fn process_inputs_outputs<'a, R: Runtime>(
     inputs: &[&TensorDescription],
     outputs: &[&TensorDescription],
-    context: &'a mut Context<'_, GpuBackend<R>>,
+    context: &'a mut Context<'_, JitBackend<R>>,
     stateful: bool,
 ) -> (
     Vec<WgpuFusionHandle<R>>,

--- a/burn-wgpu/src/fusion/kernel.rs
+++ b/burn-wgpu/src/fusion/kernel.rs
@@ -1,9 +1,8 @@
-use crate::codegen::Compiler;
 use crate::compute::Kernel;
 use crate::fusion::strides_dyn_rank;
 use crate::fusion::WgpuFusionHandle;
+use crate::GpuBackend;
 use crate::JitGpuBackend;
-use crate::{GpuBackend, GraphicsApi};
 use burn_compute::client::ComputeClient;
 use burn_compute::server::Handle;
 use burn_compute::tune::AutotuneOperation;

--- a/burn-wgpu/src/kernel/base.rs
+++ b/burn-wgpu/src/kernel/base.rs
@@ -1,9 +1,12 @@
+use burn_compute::{client::ComputeClient, server::Handle};
+
 use super::SourceTemplate;
 use crate::{
-    compute::{StaticKernel, WgpuComputeClient, WgpuHandle, WorkGroup},
+    compute::{StaticKernel, WorkGroup},
     element::WgpuElement,
     kernel,
     tensor::WgpuTensor,
+    JitGpuBackend,
 };
 use std::marker::PhantomData;
 
@@ -48,9 +51,9 @@ macro_rules! kernel_wgsl {
 kernel_wgsl!(ContiguousRaw, "../template/contiguous.wgsl");
 
 /// Make a wgpu tensor contiguous.
-pub fn into_contiguous<E: WgpuElement, const D: usize>(
-    tensor: WgpuTensor<E, D>,
-) -> WgpuTensor<E, D> {
+pub fn into_contiguous<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    tensor: WgpuTensor<B, E, D>,
+) -> WgpuTensor<B, E, D> {
     if tensor.is_contiguous() {
         return tensor;
     }
@@ -78,15 +81,15 @@ pub fn into_contiguous<E: WgpuElement, const D: usize>(
 }
 
 /// Similar to [into contiguous](into_contiguous) but with dynamic rank.
-pub fn into_contiguous_dyn<E: WgpuElement>(
-    client: WgpuComputeClient,
-    input: WgpuHandle,
+pub fn into_contiguous_dyn<B: JitGpuBackend, E: WgpuElement>(
+    client: ComputeClient<B::Server, B::Channel>,
+    input: Handle<B::Server>,
     input_shape: &[usize],
     input_strides: &[usize],
     output_shape: &[usize],
     output_strides: &[usize],
     num_elems: usize,
-) -> WgpuHandle {
+) -> Handle<B::Server> {
     let handle = client.empty(num_elems * core::mem::size_of::<E>());
     let info = kernel::build_info_dyn::<E>(
         &[input_shape, output_shape],
@@ -192,7 +195,9 @@ impl<K: StaticKernelSource, E: WgpuElement, I: WgpuElement> DynamicKernelSource
 /// |     (D + 1)..(2 * D + 1) | rhs strides |
 /// | (2 * D + 1)..(3 * D + 1) | lhs shape   |
 /// | (3 * D + 1)..(4 * D + 1) | rhs shape   |
-pub fn build_info<E: WgpuElement, const D: usize>(tensors: &[&WgpuTensor<E, D>]) -> Vec<u32> {
+pub fn build_info<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    tensors: &[&WgpuTensor<B, E, D>],
+) -> Vec<u32> {
     let mut info: Vec<u32> = vec![0; tensors.len() * 2 * D + 1];
     info[0] = D as u32;
 

--- a/burn-wgpu/src/kernel/base.rs
+++ b/burn-wgpu/src/kernel/base.rs
@@ -6,7 +6,7 @@ use crate::{
     element::WgpuElement,
     kernel,
     tensor::WgpuTensor,
-    JitGpuBackend,
+    JitRuntime,
 };
 use std::marker::PhantomData;
 
@@ -51,7 +51,7 @@ macro_rules! kernel_wgsl {
 kernel_wgsl!(ContiguousRaw, "../template/contiguous.wgsl");
 
 /// Make a wgpu tensor contiguous.
-pub fn into_contiguous<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn into_contiguous<B: JitRuntime, E: WgpuElement, const D: usize>(
     tensor: WgpuTensor<B, E, D>,
 ) -> WgpuTensor<B, E, D> {
     if tensor.is_contiguous() {
@@ -81,7 +81,7 @@ pub fn into_contiguous<B: JitGpuBackend, E: WgpuElement, const D: usize>(
 }
 
 /// Similar to [into contiguous](into_contiguous) but with dynamic rank.
-pub fn into_contiguous_dyn<B: JitGpuBackend, E: WgpuElement>(
+pub fn into_contiguous_dyn<B: JitRuntime, E: WgpuElement>(
     client: ComputeClient<B::Server, B::Channel>,
     input: Handle<B::Server>,
     input_shape: &[usize],
@@ -195,7 +195,7 @@ impl<K: StaticKernelSource, E: WgpuElement, I: WgpuElement> DynamicKernelSource
 /// |     (D + 1)..(2 * D + 1) | rhs strides |
 /// | (2 * D + 1)..(3 * D + 1) | lhs shape   |
 /// | (3 * D + 1)..(4 * D + 1) | rhs shape   |
-pub fn build_info<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn build_info<B: JitRuntime, E: WgpuElement, const D: usize>(
     tensors: &[&WgpuTensor<B, E, D>],
 ) -> Vec<u32> {
     let mut info: Vec<u32> = vec![0; tensors.len() * 2 * D + 1];

--- a/burn-wgpu/src/kernel/binary.rs
+++ b/burn-wgpu/src/kernel/binary.rs
@@ -2,6 +2,7 @@ use crate::{
     codegen::{execute_static, StaticHandle, WorkgroupLaunch},
     element::WgpuElement,
     tensor::WgpuTensor,
+    JitGpuBackend,
 };
 use burn_tensor::Shape;
 
@@ -149,11 +150,11 @@ macro_rules! binary {
 }
 
 /// Launch an binary operation.
-pub fn binary<Kernel, KernelInplaceLhs, KernelInplaceRhs, E, const D: usize>(
-    lhs: WgpuTensor<E, D>,
-    rhs: WgpuTensor<E, D>,
+pub fn binary<Kernel, KernelInplaceLhs, KernelInplaceRhs, B: JitGpuBackend, E, const D: usize>(
+    lhs: WgpuTensor<B, E, D>,
+    rhs: WgpuTensor<B, E, D>,
     inplace_enabled: bool,
-) -> WgpuTensor<E, D>
+) -> WgpuTensor<B, E, D>
 where
     Kernel: crate::kernel::StaticKernelSource,
     KernelInplaceLhs: crate::kernel::StaticKernelSource,

--- a/burn-wgpu/src/kernel/binary.rs
+++ b/burn-wgpu/src/kernel/binary.rs
@@ -2,7 +2,7 @@ use crate::{
     codegen::{execute_static, StaticHandle, WorkgroupLaunch},
     element::WgpuElement,
     tensor::WgpuTensor,
-    JitGpuBackend,
+    JitRuntime,
 };
 use burn_tensor::Shape;
 
@@ -15,12 +15,12 @@ macro_rules! binary {
         input: $lhs:expr; $rhs:expr,
         elem: $elem:ty
     ) => {{
-        binary!(operation: $ops, compiler: <$backend as JitGpuBackend>::Compiler, elem_in: $elem, elem_out: $elem);
+        binary!(operation: $ops, compiler: <$backend as JitRuntime>::Compiler, elem_in: $elem, elem_out: $elem);
 
         $crate::kernel::binary::<
-            Ops<<$backend as JitGpuBackend>::Compiler, $elem, $elem>,
-            OpsInplaceLhs<<$backend as JitGpuBackend>::Compiler, $elem, $elem>,
-            OpsInplaceRhs<<$backend as JitGpuBackend>::Compiler, $elem, $elem>,
+            Ops<<$backend as JitRuntime>::Compiler, $elem, $elem>,
+            OpsInplaceLhs<<$backend as JitRuntime>::Compiler, $elem, $elem>,
+            OpsInplaceRhs<<$backend as JitRuntime>::Compiler, $elem, $elem>,
             $backend,
             $elem,
             D
@@ -155,7 +155,7 @@ macro_rules! binary {
 }
 
 /// Launch an binary operation.
-pub fn binary<Kernel, KernelInplaceLhs, KernelInplaceRhs, B: JitGpuBackend, E, const D: usize>(
+pub fn binary<Kernel, KernelInplaceLhs, KernelInplaceRhs, B: JitRuntime, E, const D: usize>(
     lhs: WgpuTensor<B, E, D>,
     rhs: WgpuTensor<B, E, D>,
     inplace_enabled: bool,

--- a/burn-wgpu/src/kernel/cast.rs
+++ b/burn-wgpu/src/kernel/cast.rs
@@ -1,7 +1,7 @@
 use super::{KernelSettings, SourceTemplate, StaticKernelSource, WORKGROUP_DEFAULT};
 use crate::{
     compute::StaticKernel, element::WgpuElement, kernel::elemwise_workgroup, kernel_wgsl,
-    tensor::WgpuTensor,
+    tensor::WgpuTensor, JitGpuBackend,
 };
 use std::{any::TypeId, marker::PhantomData};
 
@@ -23,9 +23,9 @@ impl<InputElem: WgpuElement, OutputElem: WgpuElement> StaticKernelSource
 }
 
 /// Cast a tensor to the given element type.
-pub fn cast<InputElem: WgpuElement, OutputElem: WgpuElement, const D: usize>(
-    tensor: WgpuTensor<InputElem, D>,
-) -> WgpuTensor<OutputElem, D> {
+pub fn cast<B: JitGpuBackend, InputElem: WgpuElement, OutputElem: WgpuElement, const D: usize>(
+    tensor: WgpuTensor<B, InputElem, D>,
+) -> WgpuTensor<B, OutputElem, D> {
     if TypeId::of::<InputElem>() == TypeId::of::<OutputElem>() {
         return WgpuTensor::new(tensor.client, tensor.device, tensor.shape, tensor.handle);
     }

--- a/burn-wgpu/src/kernel/cast.rs
+++ b/burn-wgpu/src/kernel/cast.rs
@@ -1,7 +1,7 @@
 use super::{KernelSettings, SourceTemplate, StaticKernelSource, WORKGROUP_DEFAULT};
 use crate::{
     compute::StaticKernel, element::WgpuElement, kernel::elemwise_workgroup, kernel_wgsl,
-    tensor::WgpuTensor, JitRuntime,
+    tensor::WgpuTensor, Runtime,
 };
 use std::{any::TypeId, marker::PhantomData};
 
@@ -23,9 +23,9 @@ impl<InputElem: WgpuElement, OutputElem: WgpuElement> StaticKernelSource
 }
 
 /// Cast a tensor to the given element type.
-pub fn cast<B: JitRuntime, InputElem: WgpuElement, OutputElem: WgpuElement, const D: usize>(
-    tensor: WgpuTensor<B, InputElem, D>,
-) -> WgpuTensor<B, OutputElem, D> {
+pub fn cast<R: Runtime, InputElem: WgpuElement, OutputElem: WgpuElement, const D: usize>(
+    tensor: WgpuTensor<R, InputElem, D>,
+) -> WgpuTensor<R, OutputElem, D> {
     if TypeId::of::<InputElem>() == TypeId::of::<OutputElem>() {
         return WgpuTensor::new(tensor.client, tensor.device, tensor.shape, tensor.handle);
     }

--- a/burn-wgpu/src/kernel/cast.rs
+++ b/burn-wgpu/src/kernel/cast.rs
@@ -1,7 +1,7 @@
 use super::{KernelSettings, SourceTemplate, StaticKernelSource, WORKGROUP_DEFAULT};
 use crate::{
     compute::StaticKernel, element::WgpuElement, kernel::elemwise_workgroup, kernel_wgsl,
-    tensor::WgpuTensor, JitGpuBackend,
+    tensor::WgpuTensor, JitRuntime,
 };
 use std::{any::TypeId, marker::PhantomData};
 
@@ -23,7 +23,7 @@ impl<InputElem: WgpuElement, OutputElem: WgpuElement> StaticKernelSource
 }
 
 /// Cast a tensor to the given element type.
-pub fn cast<B: JitGpuBackend, InputElem: WgpuElement, OutputElem: WgpuElement, const D: usize>(
+pub fn cast<B: JitRuntime, InputElem: WgpuElement, OutputElem: WgpuElement, const D: usize>(
     tensor: WgpuTensor<B, InputElem, D>,
 ) -> WgpuTensor<B, OutputElem, D> {
     if TypeId::of::<InputElem>() == TypeId::of::<OutputElem>() {
@@ -62,7 +62,7 @@ pub fn cast<B: JitGpuBackend, InputElem: WgpuElement, OutputElem: WgpuElement, c
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::{TestBackend, TestJitGpuBackend};
+    use crate::tests::{TestBackend, TestJitRuntime};
     use burn_tensor::{Int, Tensor};
 
     #[test]
@@ -72,7 +72,7 @@ mod tests {
 
         let device = Default::default();
         let tensor = Tensor::<TestBackend, 1, Int>::arange(START as i64..END as i64, &device);
-        let tensor_float = cast::<TestJitGpuBackend, i32, f32, 1>(tensor.clone().into_primitive());
+        let tensor_float = cast::<TestJitRuntime, i32, f32, 1>(tensor.clone().into_primitive());
 
         let data_int = tensor.into_data();
         let data_float = Tensor::<TestBackend, 1>::from_primitive(tensor_float).into_data();

--- a/burn-wgpu/src/kernel/cast.rs
+++ b/burn-wgpu/src/kernel/cast.rs
@@ -62,7 +62,7 @@ pub fn cast<B: JitGpuBackend, InputElem: WgpuElement, OutputElem: WgpuElement, c
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::TestBackend;
+    use crate::tests::{TestBackend, TestJitGpuBackend};
     use burn_tensor::{Int, Tensor};
 
     #[test]
@@ -72,7 +72,7 @@ mod tests {
 
         let device = Default::default();
         let tensor = Tensor::<TestBackend, 1, Int>::arange(START as i64..END as i64, &device);
-        let tensor_float = cast::<i32, f32, 1>(tensor.clone().into_primitive());
+        let tensor_float = cast::<TestJitGpuBackend, i32, f32, 1>(tensor.clone().into_primitive());
 
         let data_int = tensor.into_data();
         let data_float = Tensor::<TestBackend, 1>::from_primitive(tensor_float).into_data();

--- a/burn-wgpu/src/kernel/cast.rs
+++ b/burn-wgpu/src/kernel/cast.rs
@@ -1,18 +1,18 @@
 use super::{KernelSettings, SourceTemplate, StaticKernelSource, WORKGROUP_DEFAULT};
 use crate::{
-    compute::StaticKernel, element::WgpuElement, kernel::elemwise_workgroup, kernel_wgsl,
-    tensor::WgpuTensor, Runtime,
+    compute::StaticKernel, element::JitElement, kernel::elemwise_workgroup, kernel_wgsl,
+    tensor::JitTensor, Runtime,
 };
 use std::{any::TypeId, marker::PhantomData};
 
 kernel_wgsl!(CastRaw, "../template/cast.wgsl");
 
-struct Cast<InputElem: WgpuElement, OutputElem: WgpuElement> {
+struct Cast<InputElem: JitElement, OutputElem: JitElement> {
     _i: PhantomData<InputElem>,
     _o: PhantomData<OutputElem>,
 }
 
-impl<InputElem: WgpuElement, OutputElem: WgpuElement> StaticKernelSource
+impl<InputElem: JitElement, OutputElem: JitElement> StaticKernelSource
     for Cast<InputElem, OutputElem>
 {
     fn source() -> SourceTemplate {
@@ -23,11 +23,11 @@ impl<InputElem: WgpuElement, OutputElem: WgpuElement> StaticKernelSource
 }
 
 /// Cast a tensor to the given element type.
-pub fn cast<R: Runtime, InputElem: WgpuElement, OutputElem: WgpuElement, const D: usize>(
-    tensor: WgpuTensor<R, InputElem, D>,
-) -> WgpuTensor<R, OutputElem, D> {
+pub fn cast<R: Runtime, InputElem: JitElement, OutputElem: JitElement, const D: usize>(
+    tensor: JitTensor<R, InputElem, D>,
+) -> JitTensor<R, OutputElem, D> {
     if TypeId::of::<InputElem>() == TypeId::of::<OutputElem>() {
-        return WgpuTensor::new(tensor.client, tensor.device, tensor.shape, tensor.handle);
+        return JitTensor::new(tensor.client, tensor.device, tensor.shape, tensor.handle);
     }
 
     let num_elems = tensor.shape.num_elements();
@@ -45,7 +45,7 @@ pub fn cast<R: Runtime, InputElem: WgpuElement, OutputElem: WgpuElement, const D
     let handle = tensor
         .client
         .empty(num_elems * core::mem::size_of::<OutputElem>());
-    let output = WgpuTensor::new(
+    let output = JitTensor::new(
         tensor.client.clone(),
         tensor.device,
         tensor.shape.clone(),
@@ -62,7 +62,7 @@ pub fn cast<R: Runtime, InputElem: WgpuElement, OutputElem: WgpuElement, const D
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::{TestBackend, TestJitRuntime};
+    use crate::tests::{TestBackend, TestRuntime};
     use burn_tensor::{Int, Tensor};
 
     #[test]
@@ -72,7 +72,7 @@ mod tests {
 
         let device = Default::default();
         let tensor = Tensor::<TestBackend, 1, Int>::arange(START as i64..END as i64, &device);
-        let tensor_float = cast::<TestJitRuntime, i32, f32, 1>(tensor.clone().into_primitive());
+        let tensor_float = cast::<TestRuntime, i32, f32, 1>(tensor.clone().into_primitive());
 
         let data_int = tensor.into_data();
         let data_float = Tensor::<TestBackend, 1>::from_primitive(tensor_float).into_data();

--- a/burn-wgpu/src/kernel/cat.rs
+++ b/burn-wgpu/src/kernel/cat.rs
@@ -1,9 +1,9 @@
 use crate::{
     compute::StaticKernel,
-    element::WgpuElement,
+    element::JitElement,
     kernel::{build_info, elemwise_workgroup, KernelSettings},
     kernel_wgsl,
-    tensor::WgpuTensor,
+    tensor::JitTensor,
     Runtime,
 };
 
@@ -11,10 +11,10 @@ use super::WORKGROUP_DEFAULT;
 
 kernel_wgsl!(Cat, "../template/cat.wgsl");
 
-pub fn cat<R: Runtime, E: WgpuElement, const D: usize>(
-    inputs: Vec<WgpuTensor<R, E, D>>,
+pub fn cat<R: Runtime, E: JitElement, const D: usize>(
+    inputs: Vec<JitTensor<R, E, D>>,
     dim: usize,
-) -> WgpuTensor<R, E, D> {
+) -> JitTensor<R, E, D> {
     let first_input = inputs.first().unwrap();
     let client = &first_input.client;
     let mut shape_output = first_input.shape.clone();
@@ -24,7 +24,7 @@ pub fn cat<R: Runtime, E: WgpuElement, const D: usize>(
         .client
         .empty(shape_output.num_elements() * std::mem::size_of::<E>());
 
-    let output = WgpuTensor::new(
+    let output = JitTensor::new(
         client.clone(),
         first_input.device.clone(),
         shape_output,

--- a/burn-wgpu/src/kernel/cat.rs
+++ b/burn-wgpu/src/kernel/cat.rs
@@ -4,14 +4,14 @@ use crate::{
     kernel::{build_info, elemwise_workgroup, KernelSettings},
     kernel_wgsl,
     tensor::WgpuTensor,
-    JitGpuBackend,
+    JitRuntime,
 };
 
 use super::WORKGROUP_DEFAULT;
 
 kernel_wgsl!(Cat, "../template/cat.wgsl");
 
-pub fn cat<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn cat<B: JitRuntime, E: WgpuElement, const D: usize>(
     inputs: Vec<WgpuTensor<B, E, D>>,
     dim: usize,
 ) -> WgpuTensor<B, E, D> {

--- a/burn-wgpu/src/kernel/cat.rs
+++ b/burn-wgpu/src/kernel/cat.rs
@@ -4,17 +4,17 @@ use crate::{
     kernel::{build_info, elemwise_workgroup, KernelSettings},
     kernel_wgsl,
     tensor::WgpuTensor,
-    JitRuntime,
+    Runtime,
 };
 
 use super::WORKGROUP_DEFAULT;
 
 kernel_wgsl!(Cat, "../template/cat.wgsl");
 
-pub fn cat<B: JitRuntime, E: WgpuElement, const D: usize>(
-    inputs: Vec<WgpuTensor<B, E, D>>,
+pub fn cat<R: Runtime, E: WgpuElement, const D: usize>(
+    inputs: Vec<WgpuTensor<R, E, D>>,
     dim: usize,
-) -> WgpuTensor<B, E, D> {
+) -> WgpuTensor<R, E, D> {
     let first_input = inputs.first().unwrap();
     let client = &first_input.client;
     let mut shape_output = first_input.shape.clone();

--- a/burn-wgpu/src/kernel/cat.rs
+++ b/burn-wgpu/src/kernel/cat.rs
@@ -4,16 +4,17 @@ use crate::{
     kernel::{build_info, elemwise_workgroup, KernelSettings},
     kernel_wgsl,
     tensor::WgpuTensor,
+    JitGpuBackend,
 };
 
 use super::WORKGROUP_DEFAULT;
 
 kernel_wgsl!(Cat, "../template/cat.wgsl");
 
-pub fn cat<E: WgpuElement, const D: usize>(
-    inputs: Vec<WgpuTensor<E, D>>,
+pub fn cat<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    inputs: Vec<WgpuTensor<B, E, D>>,
     dim: usize,
-) -> WgpuTensor<E, D> {
+) -> WgpuTensor<B, E, D> {
     let first_input = inputs.first().unwrap();
     let client = &first_input.client;
     let mut shape_output = first_input.shape.clone();

--- a/burn-wgpu/src/kernel/clamp.rs
+++ b/burn-wgpu/src/kernel/clamp.rs
@@ -3,10 +3,10 @@ use crate::{
     codegen::dialect::gpu::{ClampOperation, Item, Operation, Variable},
     element::WgpuElement,
     tensor::WgpuTensor,
-    unary, JitGpuBackend,
+    unary, JitRuntime,
 };
 
-pub(crate) fn clamp<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub(crate) fn clamp<B: JitRuntime, E: WgpuElement, const D: usize>(
     input: WgpuTensor<B, E, D>,
     min_value: E,
     max_value: E,

--- a/burn-wgpu/src/kernel/clamp.rs
+++ b/burn-wgpu/src/kernel/clamp.rs
@@ -1,9 +1,6 @@
 use super::unary;
 use crate::{
-    codegen::{
-        dialect::gpu::{ClampOperation, Item, Operation, Variable},
-        Compiler,
-    },
+    codegen::dialect::gpu::{ClampOperation, Item, Operation, Variable},
     element::WgpuElement,
     tensor::WgpuTensor,
     unary, JitGpuBackend,
@@ -25,7 +22,7 @@ pub(crate) fn clamp<B: JitGpuBackend, E: WgpuElement, const D: usize>(
         scalar 2
     );
 
-    unary::<Ops<B::Compiler, E>, OpsInplace<B::Compiler, E>, E, D>(
+    unary::<Ops<B::Compiler, E>, OpsInplace<B::Compiler, E>, B, E, D>(
         input,
         Some(&[min_value, max_value]),
         true,

--- a/burn-wgpu/src/kernel/clamp.rs
+++ b/burn-wgpu/src/kernel/clamp.rs
@@ -1,16 +1,16 @@
 use super::unary;
 use crate::{
     codegen::dialect::gpu::{ClampOperation, Item, Operation, Variable},
-    element::WgpuElement,
-    tensor::WgpuTensor,
+    element::JitElement,
+    tensor::JitTensor,
     unary, Runtime,
 };
 
-pub(crate) fn clamp<R: Runtime, E: WgpuElement, const D: usize>(
-    input: WgpuTensor<R, E, D>,
+pub(crate) fn clamp<R: Runtime, E: JitElement, const D: usize>(
+    input: JitTensor<R, E, D>,
     min_value: E,
     max_value: E,
-) -> WgpuTensor<R, E, D> {
+) -> JitTensor<R, E, D> {
     unary!(
         operation: |elem| Operation::Clamp(ClampOperation {
             input: Variable::Input(0, Item::Scalar(elem)),

--- a/burn-wgpu/src/kernel/clamp.rs
+++ b/burn-wgpu/src/kernel/clamp.rs
@@ -3,14 +3,14 @@ use crate::{
     codegen::dialect::gpu::{ClampOperation, Item, Operation, Variable},
     element::WgpuElement,
     tensor::WgpuTensor,
-    unary, JitRuntime,
+    unary, Runtime,
 };
 
-pub(crate) fn clamp<B: JitRuntime, E: WgpuElement, const D: usize>(
-    input: WgpuTensor<B, E, D>,
+pub(crate) fn clamp<R: Runtime, E: WgpuElement, const D: usize>(
+    input: WgpuTensor<R, E, D>,
     min_value: E,
     max_value: E,
-) -> WgpuTensor<B, E, D> {
+) -> WgpuTensor<R, E, D> {
     unary!(
         operation: |elem| Operation::Clamp(ClampOperation {
             input: Variable::Input(0, Item::Scalar(elem)),
@@ -18,11 +18,11 @@ pub(crate) fn clamp<B: JitRuntime, E: WgpuElement, const D: usize>(
             max_value: Variable::Scalar(1, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(elem)),
         }),
-        compiler: B::Compiler,
+        compiler: R::Compiler,
         scalar 2
     );
 
-    unary::<Ops<B::Compiler, E>, OpsInplace<B::Compiler, E>, B, E, D>(
+    unary::<Ops<R::Compiler, E>, OpsInplace<R::Compiler, E>, R, E, D>(
         input,
         Some(&[min_value, max_value]),
         true,

--- a/burn-wgpu/src/kernel/comparison.rs
+++ b/burn-wgpu/src/kernel/comparison.rs
@@ -6,7 +6,7 @@ use crate::{
     kernel::StaticKernelSource,
     kernel::{binary::binary, unary::unary},
     tensor::WgpuTensor,
-    unary,
+    unary, JitGpuBackend,
 };
 use std::mem;
 
@@ -34,170 +34,170 @@ macro_rules! comparison {
     }};
 }
 
-pub fn equal<C: Compiler, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<E, D>,
-    rhs: WgpuTensor<E, D>,
-) -> WgpuTensor<u32, D> {
+pub fn equal<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    lhs: WgpuTensor<B, E, D>,
+    rhs: WgpuTensor<B, E, D>,
+) -> WgpuTensor<B, u32, D> {
     comparison!(
         binary: |elem: Elem| Operation::Equal(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
             rhs: Variable::Input(1, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(Elem::Bool)),
         }),
-        compiler: C,
+        compiler: B::Compiler,
         input: lhs; rhs,
         elem: E
     )
 }
 
-pub fn greater<C: Compiler, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<E, D>,
-    rhs: WgpuTensor<E, D>,
-) -> WgpuTensor<u32, D> {
+pub fn greater<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    lhs: WgpuTensor<B, E, D>,
+    rhs: WgpuTensor<B, E, D>,
+) -> WgpuTensor<B, u32, D> {
     comparison!(
         binary: |elem: Elem| Operation::Greater(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
             rhs: Variable::Input(1, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(Elem::Bool)),
         }),
-        compiler: C,
+        compiler: B::Compiler,
         input: lhs; rhs,
         elem: E
     )
 }
 
-pub fn greater_equal<C: Compiler, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<E, D>,
-    rhs: WgpuTensor<E, D>,
-) -> WgpuTensor<u32, D> {
+pub fn greater_equal<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    lhs: WgpuTensor<B, E, D>,
+    rhs: WgpuTensor<B, E, D>,
+) -> WgpuTensor<B, u32, D> {
     comparison!(
         binary: |elem: Elem| Operation::GreaterEqual(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
             rhs: Variable::Input(1, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(Elem::Bool)),
         }),
-        compiler: C,
+        compiler: B::Compiler,
         input: lhs; rhs,
         elem: E
     )
 }
 
-pub fn lower<C: Compiler, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<E, D>,
-    rhs: WgpuTensor<E, D>,
-) -> WgpuTensor<u32, D> {
+pub fn lower<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    lhs: WgpuTensor<B, E, D>,
+    rhs: WgpuTensor<B, E, D>,
+) -> WgpuTensor<B, u32, D> {
     comparison!(
         binary: |elem: Elem| Operation::Lower(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
             rhs: Variable::Input(1, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(Elem::Bool)),
         }),
-        compiler: C,
+        compiler: B::Compiler,
         input: lhs; rhs,
         elem: E
     )
 }
 
-pub fn lower_equal<C: Compiler, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<E, D>,
-    rhs: WgpuTensor<E, D>,
-) -> WgpuTensor<u32, D> {
+pub fn lower_equal<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    lhs: WgpuTensor<B, E, D>,
+    rhs: WgpuTensor<B, E, D>,
+) -> WgpuTensor<B, u32, D> {
     comparison!(
         binary: |elem: Elem| Operation::LowerEqual(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
             rhs: Variable::Input(1, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(Elem::Bool)),
         }),
-        compiler: C,
+        compiler: B::Compiler,
         input: lhs; rhs,
         elem: E
     )
 }
 
-pub fn equal_elem<C: Compiler, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<E, D>,
+pub fn equal_elem<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    lhs: WgpuTensor<B, E, D>,
     rhs: E,
-) -> WgpuTensor<u32, D> {
+) -> WgpuTensor<B, u32, D> {
     comparison!(
         unary: |elem: Elem| Operation::Equal(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
             rhs: Variable::Scalar(0, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(Elem::Bool)),
         }),
-        compiler: C,
+        compiler: B::Compiler,
         input: lhs; rhs,
         elem: E
     )
 }
 
-pub fn greater_elem<C: Compiler, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<E, D>,
+pub fn greater_elem<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    lhs: WgpuTensor<B, E, D>,
     rhs: E,
-) -> WgpuTensor<u32, D> {
+) -> WgpuTensor<B, u32, D> {
     comparison!(
         unary: |elem: Elem| Operation::Greater(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
             rhs: Variable::Scalar(0, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(Elem::Bool)),
         }),
-        compiler: C,
+        compiler: B::Compiler,
         input: lhs; rhs,
         elem: E
     )
 }
 
-pub fn lower_elem<C: Compiler, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<E, D>,
+pub fn lower_elem<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    lhs: WgpuTensor<B, E, D>,
     rhs: E,
-) -> WgpuTensor<u32, D> {
+) -> WgpuTensor<B, u32, D> {
     comparison!(
         unary: |elem: Elem| Operation::Lower(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
             rhs: Variable::Scalar(0, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(Elem::Bool)),
         }),
-        compiler: C,
+        compiler: B::Compiler,
         input: lhs; rhs,
         elem: E
     )
 }
 
-pub fn greater_equal_elem<C: Compiler, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<E, D>,
+pub fn greater_equal_elem<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    lhs: WgpuTensor<B, E, D>,
     rhs: E,
-) -> WgpuTensor<u32, D> {
+) -> WgpuTensor<B, u32, D> {
     comparison!(
         unary: |elem: Elem| Operation::GreaterEqual(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
             rhs: Variable::Scalar(0, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(Elem::Bool)),
         }),
-        compiler: C,
+        compiler: B::Compiler,
         input: lhs; rhs,
         elem: E
     )
 }
 
-pub fn lower_equal_elem<C: Compiler, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<E, D>,
+pub fn lower_equal_elem<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    lhs: WgpuTensor<B, E, D>,
     rhs: E,
-) -> WgpuTensor<u32, D> {
+) -> WgpuTensor<B, u32, D> {
     comparison!(
         unary: |elem: Elem| Operation::LowerEqual(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
             rhs: Variable::Scalar(0, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(Elem::Bool)),
         }),
-        compiler: C,
+        compiler: B::Compiler,
         input: lhs; rhs,
         elem: E
     )
 }
 
-fn launch_binary<Kernel, KernelInplaceLhs, KernelInplaceRhs, E, const D: usize>(
-    lhs: WgpuTensor<E, D>,
-    rhs: WgpuTensor<E, D>,
-) -> WgpuTensor<u32, D>
+fn launch_binary<Kernel, KernelInplaceLhs, KernelInplaceRhs, B: JitGpuBackend, E, const D: usize>(
+    lhs: WgpuTensor<B, E, D>,
+    rhs: WgpuTensor<B, E, D>,
+) -> WgpuTensor<B, u32, D>
 where
     Kernel: StaticKernelSource,
     KernelInplaceLhs: StaticKernelSource,
@@ -213,10 +213,10 @@ where
     WgpuTensor::new(output.client, output.device, output.shape, output.handle)
 }
 
-fn launch_unary<Kernel, KernelInplace, E, const D: usize>(
-    tensor: WgpuTensor<E, D>,
+fn launch_unary<Kernel, KernelInplace, E, B: JitGpuBackend, const D: usize>(
+    tensor: WgpuTensor<B, E, D>,
     scalars: E,
-) -> WgpuTensor<u32, D>
+) -> WgpuTensor<B, u32, D>
 where
     Kernel: StaticKernelSource,
     KernelInplace: StaticKernelSource,

--- a/burn-wgpu/src/kernel/comparison.rs
+++ b/burn-wgpu/src/kernel/comparison.rs
@@ -5,7 +5,7 @@ use crate::{
     kernel::StaticKernelSource,
     kernel::{binary::binary, unary::unary},
     tensor::WgpuTensor,
-    unary, JitGpuBackend,
+    unary, JitRuntime,
 };
 use std::mem;
 
@@ -16,12 +16,12 @@ macro_rules! comparison {
         input: $lhs:expr; $rhs:expr,
         elem: $elem:ty
     ) => {{
-        binary!(operation: $ops, compiler: <$backend as JitGpuBackend>::Compiler, elem_in: $elem, elem_out: $elem);
+        binary!(operation: $ops, compiler: <$backend as JitRuntime>::Compiler, elem_in: $elem, elem_out: $elem);
 
         launch_binary::<
-            Ops<<$backend as JitGpuBackend>::Compiler, E, u32>,
-            OpsInplaceLhs<<$backend as JitGpuBackend>::Compiler, E, u32>,
-            OpsInplaceRhs<<$backend as JitGpuBackend>::Compiler, E, u32>,
+            Ops<<$backend as JitRuntime>::Compiler, E, u32>,
+            OpsInplaceLhs<<$backend as JitRuntime>::Compiler, E, u32>,
+            OpsInplaceRhs<<$backend as JitRuntime>::Compiler, E, u32>,
             $backend,
             E,
             D
@@ -34,11 +34,11 @@ macro_rules! comparison {
         input: $lhs:expr; $rhs:expr,
         elem: $elem:ty
     ) => {{
-        unary!(operation: $ops, compiler: <$backend as JitGpuBackend>::Compiler, scalar 1);
+        unary!(operation: $ops, compiler: <$backend as JitRuntime>::Compiler, scalar 1);
 
         launch_unary::<
-            Ops<<$backend as JitGpuBackend>::Compiler, E>,
-            OpsInplace<<$backend as JitGpuBackend>::Compiler, E>,
+            Ops<<$backend as JitRuntime>::Compiler, E>,
+            OpsInplace<<$backend as JitRuntime>::Compiler, E>,
             $backend,
             E,
             D
@@ -46,7 +46,7 @@ macro_rules! comparison {
     }};
 }
 
-pub fn equal<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn equal<B: JitRuntime, E: WgpuElement, const D: usize>(
     lhs: WgpuTensor<B, E, D>,
     rhs: WgpuTensor<B, E, D>,
 ) -> WgpuTensor<B, u32, D> {
@@ -62,7 +62,7 @@ pub fn equal<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn greater<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn greater<B: JitRuntime, E: WgpuElement, const D: usize>(
     lhs: WgpuTensor<B, E, D>,
     rhs: WgpuTensor<B, E, D>,
 ) -> WgpuTensor<B, u32, D> {
@@ -78,7 +78,7 @@ pub fn greater<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn greater_equal<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn greater_equal<B: JitRuntime, E: WgpuElement, const D: usize>(
     lhs: WgpuTensor<B, E, D>,
     rhs: WgpuTensor<B, E, D>,
 ) -> WgpuTensor<B, u32, D> {
@@ -94,7 +94,7 @@ pub fn greater_equal<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn lower<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn lower<B: JitRuntime, E: WgpuElement, const D: usize>(
     lhs: WgpuTensor<B, E, D>,
     rhs: WgpuTensor<B, E, D>,
 ) -> WgpuTensor<B, u32, D> {
@@ -110,7 +110,7 @@ pub fn lower<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn lower_equal<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn lower_equal<B: JitRuntime, E: WgpuElement, const D: usize>(
     lhs: WgpuTensor<B, E, D>,
     rhs: WgpuTensor<B, E, D>,
 ) -> WgpuTensor<B, u32, D> {
@@ -126,7 +126,7 @@ pub fn lower_equal<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn equal_elem<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn equal_elem<B: JitRuntime, E: WgpuElement, const D: usize>(
     lhs: WgpuTensor<B, E, D>,
     rhs: E,
 ) -> WgpuTensor<B, u32, D> {
@@ -142,7 +142,7 @@ pub fn equal_elem<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn greater_elem<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn greater_elem<B: JitRuntime, E: WgpuElement, const D: usize>(
     lhs: WgpuTensor<B, E, D>,
     rhs: E,
 ) -> WgpuTensor<B, u32, D> {
@@ -158,7 +158,7 @@ pub fn greater_elem<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn lower_elem<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn lower_elem<B: JitRuntime, E: WgpuElement, const D: usize>(
     lhs: WgpuTensor<B, E, D>,
     rhs: E,
 ) -> WgpuTensor<B, u32, D> {
@@ -174,7 +174,7 @@ pub fn lower_elem<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn greater_equal_elem<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn greater_equal_elem<B: JitRuntime, E: WgpuElement, const D: usize>(
     lhs: WgpuTensor<B, E, D>,
     rhs: E,
 ) -> WgpuTensor<B, u32, D> {
@@ -190,7 +190,7 @@ pub fn greater_equal_elem<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn lower_equal_elem<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn lower_equal_elem<B: JitRuntime, E: WgpuElement, const D: usize>(
     lhs: WgpuTensor<B, E, D>,
     rhs: E,
 ) -> WgpuTensor<B, u32, D> {
@@ -206,7 +206,7 @@ pub fn lower_equal_elem<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     )
 }
 
-fn launch_binary<Kernel, KernelInplaceLhs, KernelInplaceRhs, B: JitGpuBackend, E, const D: usize>(
+fn launch_binary<Kernel, KernelInplaceLhs, KernelInplaceRhs, B: JitRuntime, E, const D: usize>(
     lhs: WgpuTensor<B, E, D>,
     rhs: WgpuTensor<B, E, D>,
 ) -> WgpuTensor<B, u32, D>
@@ -228,7 +228,7 @@ where
     WgpuTensor::new(output.client, output.device, output.shape, output.handle)
 }
 
-fn launch_unary<Kernel, KernelInplace, B: JitGpuBackend, E, const D: usize>(
+fn launch_unary<Kernel, KernelInplace, B: JitRuntime, E, const D: usize>(
     tensor: WgpuTensor<B, E, D>,
     scalars: E,
 ) -> WgpuTensor<B, u32, D>

--- a/burn-wgpu/src/kernel/comparison.rs
+++ b/burn-wgpu/src/kernel/comparison.rs
@@ -1,10 +1,10 @@
 use crate::{
     binary,
     codegen::dialect::gpu::{BinaryOperation, Elem, Item, Operation, Variable},
-    element::WgpuElement,
+    element::JitElement,
     kernel::StaticKernelSource,
     kernel::{binary::binary, unary::unary},
-    tensor::WgpuTensor,
+    tensor::JitTensor,
     unary, Runtime,
 };
 use std::mem;
@@ -46,10 +46,10 @@ macro_rules! comparison {
     }};
 }
 
-pub fn equal<R: Runtime, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<R, E, D>,
-    rhs: WgpuTensor<R, E, D>,
-) -> WgpuTensor<R, u32, D> {
+pub fn equal<R: Runtime, E: JitElement, const D: usize>(
+    lhs: JitTensor<R, E, D>,
+    rhs: JitTensor<R, E, D>,
+) -> JitTensor<R, u32, D> {
     comparison!(
         binary: |elem: Elem| Operation::Equal(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
@@ -62,10 +62,10 @@ pub fn equal<R: Runtime, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn greater<R: Runtime, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<R, E, D>,
-    rhs: WgpuTensor<R, E, D>,
-) -> WgpuTensor<R, u32, D> {
+pub fn greater<R: Runtime, E: JitElement, const D: usize>(
+    lhs: JitTensor<R, E, D>,
+    rhs: JitTensor<R, E, D>,
+) -> JitTensor<R, u32, D> {
     comparison!(
         binary: |elem: Elem| Operation::Greater(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
@@ -78,10 +78,10 @@ pub fn greater<R: Runtime, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn greater_equal<R: Runtime, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<R, E, D>,
-    rhs: WgpuTensor<R, E, D>,
-) -> WgpuTensor<R, u32, D> {
+pub fn greater_equal<R: Runtime, E: JitElement, const D: usize>(
+    lhs: JitTensor<R, E, D>,
+    rhs: JitTensor<R, E, D>,
+) -> JitTensor<R, u32, D> {
     comparison!(
         binary: |elem: Elem| Operation::GreaterEqual(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
@@ -94,10 +94,10 @@ pub fn greater_equal<R: Runtime, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn lower<R: Runtime, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<R, E, D>,
-    rhs: WgpuTensor<R, E, D>,
-) -> WgpuTensor<R, u32, D> {
+pub fn lower<R: Runtime, E: JitElement, const D: usize>(
+    lhs: JitTensor<R, E, D>,
+    rhs: JitTensor<R, E, D>,
+) -> JitTensor<R, u32, D> {
     comparison!(
         binary: |elem: Elem| Operation::Lower(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
@@ -110,10 +110,10 @@ pub fn lower<R: Runtime, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn lower_equal<R: Runtime, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<R, E, D>,
-    rhs: WgpuTensor<R, E, D>,
-) -> WgpuTensor<R, u32, D> {
+pub fn lower_equal<R: Runtime, E: JitElement, const D: usize>(
+    lhs: JitTensor<R, E, D>,
+    rhs: JitTensor<R, E, D>,
+) -> JitTensor<R, u32, D> {
     comparison!(
         binary: |elem: Elem| Operation::LowerEqual(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
@@ -126,10 +126,10 @@ pub fn lower_equal<R: Runtime, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn equal_elem<R: Runtime, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<R, E, D>,
+pub fn equal_elem<R: Runtime, E: JitElement, const D: usize>(
+    lhs: JitTensor<R, E, D>,
     rhs: E,
-) -> WgpuTensor<R, u32, D> {
+) -> JitTensor<R, u32, D> {
     comparison!(
         unary: |elem: Elem| Operation::Equal(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
@@ -142,10 +142,10 @@ pub fn equal_elem<R: Runtime, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn greater_elem<R: Runtime, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<R, E, D>,
+pub fn greater_elem<R: Runtime, E: JitElement, const D: usize>(
+    lhs: JitTensor<R, E, D>,
     rhs: E,
-) -> WgpuTensor<R, u32, D> {
+) -> JitTensor<R, u32, D> {
     comparison!(
         unary: |elem: Elem| Operation::Greater(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
@@ -158,10 +158,10 @@ pub fn greater_elem<R: Runtime, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn lower_elem<R: Runtime, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<R, E, D>,
+pub fn lower_elem<R: Runtime, E: JitElement, const D: usize>(
+    lhs: JitTensor<R, E, D>,
     rhs: E,
-) -> WgpuTensor<R, u32, D> {
+) -> JitTensor<R, u32, D> {
     comparison!(
         unary: |elem: Elem| Operation::Lower(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
@@ -174,10 +174,10 @@ pub fn lower_elem<R: Runtime, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn greater_equal_elem<R: Runtime, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<R, E, D>,
+pub fn greater_equal_elem<R: Runtime, E: JitElement, const D: usize>(
+    lhs: JitTensor<R, E, D>,
     rhs: E,
-) -> WgpuTensor<R, u32, D> {
+) -> JitTensor<R, u32, D> {
     comparison!(
         unary: |elem: Elem| Operation::GreaterEqual(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
@@ -190,10 +190,10 @@ pub fn greater_equal_elem<R: Runtime, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn lower_equal_elem<R: Runtime, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<R, E, D>,
+pub fn lower_equal_elem<R: Runtime, E: JitElement, const D: usize>(
+    lhs: JitTensor<R, E, D>,
     rhs: E,
-) -> WgpuTensor<R, u32, D> {
+) -> JitTensor<R, u32, D> {
     comparison!(
         unary: |elem: Elem| Operation::LowerEqual(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
@@ -207,14 +207,14 @@ pub fn lower_equal_elem<R: Runtime, E: WgpuElement, const D: usize>(
 }
 
 fn launch_binary<Kernel, KernelInplaceLhs, KernelInplaceRhs, R: Runtime, E, const D: usize>(
-    lhs: WgpuTensor<R, E, D>,
-    rhs: WgpuTensor<R, E, D>,
-) -> WgpuTensor<R, u32, D>
+    lhs: JitTensor<R, E, D>,
+    rhs: JitTensor<R, E, D>,
+) -> JitTensor<R, u32, D>
 where
     Kernel: StaticKernelSource,
     KernelInplaceLhs: StaticKernelSource,
     KernelInplaceRhs: StaticKernelSource,
-    E: WgpuElement,
+    E: JitElement,
 {
     let can_be_used_as_bool = mem::size_of::<E>() == mem::size_of::<u32>();
 
@@ -225,17 +225,17 @@ where
     );
 
     // We recast the tensor type.
-    WgpuTensor::new(output.client, output.device, output.shape, output.handle)
+    JitTensor::new(output.client, output.device, output.shape, output.handle)
 }
 
 fn launch_unary<Kernel, KernelInplace, R: Runtime, E, const D: usize>(
-    tensor: WgpuTensor<R, E, D>,
+    tensor: JitTensor<R, E, D>,
     scalars: E,
-) -> WgpuTensor<R, u32, D>
+) -> JitTensor<R, u32, D>
 where
     Kernel: StaticKernelSource,
     KernelInplace: StaticKernelSource,
-    E: WgpuElement,
+    E: JitElement,
 {
     let can_be_used_as_bool = mem::size_of::<E>() == mem::size_of::<u32>();
 
@@ -243,5 +243,5 @@ where
         unary::<Kernel, KernelInplace, R, E, D>(tensor, Some(&[scalars]), can_be_used_as_bool);
 
     // We recast the tensor type.
-    WgpuTensor::new(output.client, output.device, output.shape, output.handle)
+    JitTensor::new(output.client, output.device, output.shape, output.handle)
 }

--- a/burn-wgpu/src/kernel/conv/conv2d.rs
+++ b/burn-wgpu/src/kernel/conv/conv2d.rs
@@ -5,6 +5,7 @@ use crate::{
     kernel_wgsl,
     ops::numeric::empty_device,
     tensor::WgpuTensor,
+    JitGpuBackend,
 };
 use burn_tensor::{
     ops::{conv::calculate_conv_output_size, ConvOptions},
@@ -13,12 +14,12 @@ use burn_tensor::{
 
 kernel_wgsl!(Conv2d, "../../template/conv/conv2d.wgsl");
 
-pub(crate) fn conv2d<E: WgpuElement + Element>(
-    input: WgpuTensor<E, 4>,
-    weight: WgpuTensor<E, 4>,
-    bias: Option<WgpuTensor<E, 1>>,
+pub(crate) fn conv2d<B: JitGpuBackend, E: WgpuElement + Element>(
+    input: WgpuTensor<B, E, 4>,
+    weight: WgpuTensor<B, E, 4>,
+    bias: Option<WgpuTensor<B, E, 1>>,
     options: ConvOptions<2>,
-) -> WgpuTensor<E, 4> {
+) -> WgpuTensor<B, E, 4> {
     let input = kernel::into_contiguous(input);
     let weight = kernel::into_contiguous(weight);
     let [batch_size, _, in_height, in_width] = input.shape.dims;

--- a/burn-wgpu/src/kernel/conv/conv2d.rs
+++ b/burn-wgpu/src/kernel/conv/conv2d.rs
@@ -1,10 +1,10 @@
 use crate::{
     compute::StaticKernel,
-    element::WgpuElement,
+    element::JitElement,
     kernel::{self, build_info, elemwise_workgroup, KernelSettings, WORKGROUP_DEFAULT},
     kernel_wgsl,
     ops::numeric::empty_device,
-    tensor::WgpuTensor,
+    tensor::JitTensor,
     Runtime,
 };
 use burn_tensor::{
@@ -14,12 +14,12 @@ use burn_tensor::{
 
 kernel_wgsl!(Conv2d, "../../template/conv/conv2d.wgsl");
 
-pub(crate) fn conv2d<R: Runtime, E: WgpuElement + Element>(
-    input: WgpuTensor<R, E, 4>,
-    weight: WgpuTensor<R, E, 4>,
-    bias: Option<WgpuTensor<R, E, 1>>,
+pub(crate) fn conv2d<R: Runtime, E: JitElement + Element>(
+    input: JitTensor<R, E, 4>,
+    weight: JitTensor<R, E, 4>,
+    bias: Option<JitTensor<R, E, 1>>,
     options: ConvOptions<2>,
-) -> WgpuTensor<R, E, 4> {
+) -> JitTensor<R, E, 4> {
     let input = kernel::into_contiguous(input);
     let weight = kernel::into_contiguous(weight);
     let [batch_size, _, in_height, in_width] = input.shape.dims;

--- a/burn-wgpu/src/kernel/conv/conv2d.rs
+++ b/burn-wgpu/src/kernel/conv/conv2d.rs
@@ -5,7 +5,7 @@ use crate::{
     kernel_wgsl,
     ops::numeric::empty_device,
     tensor::WgpuTensor,
-    JitRuntime,
+    Runtime,
 };
 use burn_tensor::{
     ops::{conv::calculate_conv_output_size, ConvOptions},
@@ -14,12 +14,12 @@ use burn_tensor::{
 
 kernel_wgsl!(Conv2d, "../../template/conv/conv2d.wgsl");
 
-pub(crate) fn conv2d<B: JitRuntime, E: WgpuElement + Element>(
-    input: WgpuTensor<B, E, 4>,
-    weight: WgpuTensor<B, E, 4>,
-    bias: Option<WgpuTensor<B, E, 1>>,
+pub(crate) fn conv2d<R: Runtime, E: WgpuElement + Element>(
+    input: WgpuTensor<R, E, 4>,
+    weight: WgpuTensor<R, E, 4>,
+    bias: Option<WgpuTensor<R, E, 1>>,
     options: ConvOptions<2>,
-) -> WgpuTensor<B, E, 4> {
+) -> WgpuTensor<R, E, 4> {
     let input = kernel::into_contiguous(input);
     let weight = kernel::into_contiguous(weight);
     let [batch_size, _, in_height, in_width] = input.shape.dims;

--- a/burn-wgpu/src/kernel/conv/conv2d.rs
+++ b/burn-wgpu/src/kernel/conv/conv2d.rs
@@ -5,7 +5,7 @@ use crate::{
     kernel_wgsl,
     ops::numeric::empty_device,
     tensor::WgpuTensor,
-    JitGpuBackend,
+    JitRuntime,
 };
 use burn_tensor::{
     ops::{conv::calculate_conv_output_size, ConvOptions},
@@ -14,7 +14,7 @@ use burn_tensor::{
 
 kernel_wgsl!(Conv2d, "../../template/conv/conv2d.wgsl");
 
-pub(crate) fn conv2d<B: JitGpuBackend, E: WgpuElement + Element>(
+pub(crate) fn conv2d<B: JitRuntime, E: WgpuElement + Element>(
     input: WgpuTensor<B, E, 4>,
     weight: WgpuTensor<B, E, 4>,
     bias: Option<WgpuTensor<B, E, 1>>,

--- a/burn-wgpu/src/kernel/conv/conv_transpose2d.rs
+++ b/burn-wgpu/src/kernel/conv/conv_transpose2d.rs
@@ -1,22 +1,22 @@
 use crate::{
     compute::StaticKernel,
-    element::WgpuElement,
+    element::JitElement,
     kernel::{self, build_info, elemwise_workgroup, KernelSettings, WORKGROUP_DEFAULT},
     kernel_wgsl,
     ops::numeric::empty_device,
-    tensor::WgpuTensor,
+    tensor::JitTensor,
     Runtime,
 };
 use burn_tensor::{ops::ConvTransposeOptions, Element, ElementConversion, Shape};
 
 kernel_wgsl!(ConvTranspose2d, "../../template/conv/conv_transpose2d.wgsl");
 
-pub(crate) fn conv_transpose2d<R: Runtime, E: WgpuElement + Element>(
-    input: WgpuTensor<R, E, 4>,
-    weight: WgpuTensor<R, E, 4>,
-    bias: Option<WgpuTensor<R, E, 1>>,
+pub(crate) fn conv_transpose2d<R: Runtime, E: JitElement + Element>(
+    input: JitTensor<R, E, 4>,
+    weight: JitTensor<R, E, 4>,
+    bias: Option<JitTensor<R, E, 1>>,
     options: ConvTransposeOptions<2>,
-) -> WgpuTensor<R, E, 4> {
+) -> JitTensor<R, E, 4> {
     let input = kernel::into_contiguous(input);
     let weight = kernel::into_contiguous(weight);
     let [batch_size, _, in_height, in_width] = input.shape.dims;

--- a/burn-wgpu/src/kernel/conv/conv_transpose2d.rs
+++ b/burn-wgpu/src/kernel/conv/conv_transpose2d.rs
@@ -5,13 +5,13 @@ use crate::{
     kernel_wgsl,
     ops::numeric::empty_device,
     tensor::WgpuTensor,
-    JitGpuBackend,
+    JitRuntime,
 };
 use burn_tensor::{ops::ConvTransposeOptions, Element, ElementConversion, Shape};
 
 kernel_wgsl!(ConvTranspose2d, "../../template/conv/conv_transpose2d.wgsl");
 
-pub(crate) fn conv_transpose2d<B: JitGpuBackend, E: WgpuElement + Element>(
+pub(crate) fn conv_transpose2d<B: JitRuntime, E: WgpuElement + Element>(
     input: WgpuTensor<B, E, 4>,
     weight: WgpuTensor<B, E, 4>,
     bias: Option<WgpuTensor<B, E, 1>>,

--- a/burn-wgpu/src/kernel/conv/conv_transpose2d.rs
+++ b/burn-wgpu/src/kernel/conv/conv_transpose2d.rs
@@ -5,17 +5,18 @@ use crate::{
     kernel_wgsl,
     ops::numeric::empty_device,
     tensor::WgpuTensor,
+    JitGpuBackend,
 };
 use burn_tensor::{ops::ConvTransposeOptions, Element, ElementConversion, Shape};
 
 kernel_wgsl!(ConvTranspose2d, "../../template/conv/conv_transpose2d.wgsl");
 
-pub(crate) fn conv_transpose2d<E: WgpuElement + Element>(
-    input: WgpuTensor<E, 4>,
-    weight: WgpuTensor<E, 4>,
-    bias: Option<WgpuTensor<E, 1>>,
+pub(crate) fn conv_transpose2d<B: JitGpuBackend, E: WgpuElement + Element>(
+    input: WgpuTensor<B, E, 4>,
+    weight: WgpuTensor<B, E, 4>,
+    bias: Option<WgpuTensor<B, E, 1>>,
     options: ConvTransposeOptions<2>,
-) -> WgpuTensor<E, 4> {
+) -> WgpuTensor<B, E, 4> {
     let input = kernel::into_contiguous(input);
     let weight = kernel::into_contiguous(weight);
     let [batch_size, _, in_height, in_width] = input.shape.dims;

--- a/burn-wgpu/src/kernel/conv/conv_transpose2d.rs
+++ b/burn-wgpu/src/kernel/conv/conv_transpose2d.rs
@@ -5,18 +5,18 @@ use crate::{
     kernel_wgsl,
     ops::numeric::empty_device,
     tensor::WgpuTensor,
-    JitRuntime,
+    Runtime,
 };
 use burn_tensor::{ops::ConvTransposeOptions, Element, ElementConversion, Shape};
 
 kernel_wgsl!(ConvTranspose2d, "../../template/conv/conv_transpose2d.wgsl");
 
-pub(crate) fn conv_transpose2d<B: JitRuntime, E: WgpuElement + Element>(
-    input: WgpuTensor<B, E, 4>,
-    weight: WgpuTensor<B, E, 4>,
-    bias: Option<WgpuTensor<B, E, 1>>,
+pub(crate) fn conv_transpose2d<R: Runtime, E: WgpuElement + Element>(
+    input: WgpuTensor<R, E, 4>,
+    weight: WgpuTensor<R, E, 4>,
+    bias: Option<WgpuTensor<R, E, 1>>,
     options: ConvTransposeOptions<2>,
-) -> WgpuTensor<B, E, 4> {
+) -> WgpuTensor<R, E, 4> {
     let input = kernel::into_contiguous(input);
     let weight = kernel::into_contiguous(weight);
     let [batch_size, _, in_height, in_width] = input.shape.dims;

--- a/burn-wgpu/src/kernel/index/gather.rs
+++ b/burn-wgpu/src/kernel/index/gather.rs
@@ -1,20 +1,20 @@
 use crate::{
     compute::StaticKernel,
-    element::WgpuElement,
+    element::JitElement,
     kernel::{self, build_info, elemwise_workgroup, KernelSettings, WORKGROUP_DEFAULT},
     kernel_wgsl,
     ops::numeric::empty_device,
-    tensor::WgpuTensor,
+    tensor::JitTensor,
     Runtime,
 };
 
 kernel_wgsl!(Gather, "../../template/index/gather.wgsl");
 
-pub(crate) fn gather<R: Runtime, E: WgpuElement, I: WgpuElement, const D: usize>(
+pub(crate) fn gather<R: Runtime, E: JitElement, I: JitElement, const D: usize>(
     dim: usize,
-    tensor: WgpuTensor<R, E, D>,
-    indices: WgpuTensor<R, I, D>,
-) -> WgpuTensor<R, E, D> {
+    tensor: JitTensor<R, E, D>,
+    indices: JitTensor<R, I, D>,
+) -> JitTensor<R, E, D> {
     let shape_output = indices.shape.clone();
     let num_elems = shape_output.num_elements();
     let indices = kernel::into_contiguous(indices);

--- a/burn-wgpu/src/kernel/index/gather.rs
+++ b/burn-wgpu/src/kernel/index/gather.rs
@@ -5,12 +5,12 @@ use crate::{
     kernel_wgsl,
     ops::numeric::empty_device,
     tensor::WgpuTensor,
-    JitGpuBackend,
+    JitRuntime,
 };
 
 kernel_wgsl!(Gather, "../../template/index/gather.wgsl");
 
-pub(crate) fn gather<B: JitGpuBackend, E: WgpuElement, I: WgpuElement, const D: usize>(
+pub(crate) fn gather<B: JitRuntime, E: WgpuElement, I: WgpuElement, const D: usize>(
     dim: usize,
     tensor: WgpuTensor<B, E, D>,
     indices: WgpuTensor<B, I, D>,

--- a/burn-wgpu/src/kernel/index/gather.rs
+++ b/burn-wgpu/src/kernel/index/gather.rs
@@ -5,15 +5,16 @@ use crate::{
     kernel_wgsl,
     ops::numeric::empty_device,
     tensor::WgpuTensor,
+    JitGpuBackend,
 };
 
 kernel_wgsl!(Gather, "../../template/index/gather.wgsl");
 
-pub(crate) fn gather<E: WgpuElement, I: WgpuElement, const D: usize>(
+pub(crate) fn gather<B: JitGpuBackend, E: WgpuElement, I: WgpuElement, const D: usize>(
     dim: usize,
-    tensor: WgpuTensor<E, D>,
-    indices: WgpuTensor<I, D>,
-) -> WgpuTensor<E, D> {
+    tensor: WgpuTensor<B, E, D>,
+    indices: WgpuTensor<B, I, D>,
+) -> WgpuTensor<B, E, D> {
     let shape_output = indices.shape.clone();
     let num_elems = shape_output.num_elements();
     let indices = kernel::into_contiguous(indices);

--- a/burn-wgpu/src/kernel/index/gather.rs
+++ b/burn-wgpu/src/kernel/index/gather.rs
@@ -5,16 +5,16 @@ use crate::{
     kernel_wgsl,
     ops::numeric::empty_device,
     tensor::WgpuTensor,
-    JitRuntime,
+    Runtime,
 };
 
 kernel_wgsl!(Gather, "../../template/index/gather.wgsl");
 
-pub(crate) fn gather<B: JitRuntime, E: WgpuElement, I: WgpuElement, const D: usize>(
+pub(crate) fn gather<R: Runtime, E: WgpuElement, I: WgpuElement, const D: usize>(
     dim: usize,
-    tensor: WgpuTensor<B, E, D>,
-    indices: WgpuTensor<B, I, D>,
-) -> WgpuTensor<B, E, D> {
+    tensor: WgpuTensor<R, E, D>,
+    indices: WgpuTensor<R, I, D>,
+) -> WgpuTensor<R, E, D> {
     let shape_output = indices.shape.clone();
     let num_elems = shape_output.num_elements();
     let indices = kernel::into_contiguous(indices);

--- a/burn-wgpu/src/kernel/index/repeat.rs
+++ b/burn-wgpu/src/kernel/index/repeat.rs
@@ -4,16 +4,16 @@ use crate::{
     kernel::{build_info, elemwise_workgroup, KernelSettings, WORKGROUP_DEFAULT},
     kernel_wgsl,
     tensor::WgpuTensor,
-    JitRuntime,
+    Runtime,
 };
 
 kernel_wgsl!(RepeatRaw, "../../template/index/repeat.wgsl");
 
-pub(crate) fn repeat<B: JitRuntime, E: WgpuElement, const D1: usize>(
-    input: WgpuTensor<B, E, D1>,
+pub(crate) fn repeat<R: Runtime, E: WgpuElement, const D1: usize>(
+    input: WgpuTensor<R, E, D1>,
     dim: usize,
     times: usize,
-) -> WgpuTensor<B, E, D1> {
+) -> WgpuTensor<R, E, D1> {
     let mut shape = input.shape.clone();
     if shape.dims[dim] != 1 {
         panic!("Can only repeat dimension with dim=1");

--- a/burn-wgpu/src/kernel/index/repeat.rs
+++ b/burn-wgpu/src/kernel/index/repeat.rs
@@ -1,19 +1,19 @@
 use crate::{
     compute::StaticKernel,
-    element::WgpuElement,
+    element::JitElement,
     kernel::{build_info, elemwise_workgroup, KernelSettings, WORKGROUP_DEFAULT},
     kernel_wgsl,
-    tensor::WgpuTensor,
+    tensor::JitTensor,
     Runtime,
 };
 
 kernel_wgsl!(RepeatRaw, "../../template/index/repeat.wgsl");
 
-pub(crate) fn repeat<R: Runtime, E: WgpuElement, const D1: usize>(
-    input: WgpuTensor<R, E, D1>,
+pub(crate) fn repeat<R: Runtime, E: JitElement, const D1: usize>(
+    input: JitTensor<R, E, D1>,
     dim: usize,
     times: usize,
-) -> WgpuTensor<R, E, D1> {
+) -> JitTensor<R, E, D1> {
     let mut shape = input.shape.clone();
     if shape.dims[dim] != 1 {
         panic!("Can only repeat dimension with dim=1");
@@ -25,7 +25,7 @@ pub(crate) fn repeat<R: Runtime, E: WgpuElement, const D1: usize>(
     let handle = input
         .client
         .empty(num_elems_output * core::mem::size_of::<E>());
-    let output = WgpuTensor::new(
+    let output = JitTensor::new(
         input.client.clone(),
         input.device.clone(),
         shape.clone(),

--- a/burn-wgpu/src/kernel/index/repeat.rs
+++ b/burn-wgpu/src/kernel/index/repeat.rs
@@ -4,12 +4,12 @@ use crate::{
     kernel::{build_info, elemwise_workgroup, KernelSettings, WORKGROUP_DEFAULT},
     kernel_wgsl,
     tensor::WgpuTensor,
-    JitGpuBackend,
+    JitRuntime,
 };
 
 kernel_wgsl!(RepeatRaw, "../../template/index/repeat.wgsl");
 
-pub(crate) fn repeat<B: JitGpuBackend, E: WgpuElement, const D1: usize>(
+pub(crate) fn repeat<B: JitRuntime, E: WgpuElement, const D1: usize>(
     input: WgpuTensor<B, E, D1>,
     dim: usize,
     times: usize,

--- a/burn-wgpu/src/kernel/index/repeat.rs
+++ b/burn-wgpu/src/kernel/index/repeat.rs
@@ -4,15 +4,16 @@ use crate::{
     kernel::{build_info, elemwise_workgroup, KernelSettings, WORKGROUP_DEFAULT},
     kernel_wgsl,
     tensor::WgpuTensor,
+    JitGpuBackend,
 };
 
 kernel_wgsl!(RepeatRaw, "../../template/index/repeat.wgsl");
 
-pub(crate) fn repeat<E: WgpuElement, const D1: usize>(
-    input: WgpuTensor<E, D1>,
+pub(crate) fn repeat<B: JitGpuBackend, E: WgpuElement, const D1: usize>(
+    input: WgpuTensor<B, E, D1>,
     dim: usize,
     times: usize,
-) -> WgpuTensor<E, D1> {
+) -> WgpuTensor<B, E, D1> {
     let mut shape = input.shape.clone();
     if shape.dims[dim] != 1 {
         panic!("Can only repeat dimension with dim=1");

--- a/burn-wgpu/src/kernel/index/scatter.rs
+++ b/burn-wgpu/src/kernel/index/scatter.rs
@@ -68,7 +68,7 @@ pub(crate) fn scatter<B: JitGpuBackend, E: WgpuElement, I: WgpuElement, const D:
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::{ReferenceBackend, TestBackend, TestCompiler};
+    use crate::tests::{ReferenceBackend, TestBackend, TestCompiler, TestJitGpuBackend};
     use burn_tensor::{backend::Backend, Distribution, Int, Tensor};
 
     #[test]
@@ -127,12 +127,13 @@ mod tests {
         let indices_ref =
             Tensor::<ReferenceBackend, D, Int>::from_data(indices.to_data().convert(), &ref_device);
 
-        let actual = Tensor::<TestBackend, D>::from_primitive(scatter::<TestCompiler, _, _, D>(
-            dim,
-            tensor.into_primitive(),
-            indices.into_primitive(),
-            value.into_primitive(),
-        ));
+        let actual =
+            Tensor::<TestBackend, D>::from_primitive(scatter::<TestJitGpuBackend, _, _, D>(
+                dim,
+                tensor.into_primitive(),
+                indices.into_primitive(),
+                value.into_primitive(),
+            ));
         let expected = tensor_ref.scatter(dim, indices_ref, value_ref);
 
         expected

--- a/burn-wgpu/src/kernel/index/scatter.rs
+++ b/burn-wgpu/src/kernel/index/scatter.rs
@@ -1,27 +1,27 @@
 use crate::{
-    codegen::Compiler,
     compute::StaticKernel,
     element::WgpuElement,
     kernel::{self, build_info, elemwise_workgroup, KernelSettings, WORKGROUP_DEFAULT},
     kernel_wgsl,
     tensor::WgpuTensor,
+    JitGpuBackend,
 };
 
 kernel_wgsl!(Scatter, "../../template/index/scatter.wgsl");
 
-pub(crate) fn scatter<C: Compiler, E: WgpuElement, I: WgpuElement, const D: usize>(
+pub(crate) fn scatter<B: JitGpuBackend, E: WgpuElement, I: WgpuElement, const D: usize>(
     dim: usize,
-    tensor: WgpuTensor<E, D>,
-    indices: WgpuTensor<I, D>,
-    value: WgpuTensor<E, D>,
-) -> WgpuTensor<E, D> {
+    tensor: WgpuTensor<B, E, D>,
+    indices: WgpuTensor<B, I, D>,
+    value: WgpuTensor<B, E, D>,
+) -> WgpuTensor<B, E, D> {
     let indices = kernel::into_contiguous(indices);
     let tensor = kernel::into_contiguous(tensor);
     let value = kernel::into_contiguous(value);
 
     let tensor = match tensor.can_mut() {
         true => tensor,
-        false => tensor.copy::<C>(),
+        false => tensor.copy(),
     };
 
     let mut info = build_info(&[&tensor, &value]);

--- a/burn-wgpu/src/kernel/index/scatter.rs
+++ b/burn-wgpu/src/kernel/index/scatter.rs
@@ -1,20 +1,20 @@
 use crate::{
     compute::StaticKernel,
-    element::WgpuElement,
+    element::JitElement,
     kernel::{self, build_info, elemwise_workgroup, KernelSettings, WORKGROUP_DEFAULT},
     kernel_wgsl,
-    tensor::WgpuTensor,
+    tensor::JitTensor,
     Runtime,
 };
 
 kernel_wgsl!(Scatter, "../../template/index/scatter.wgsl");
 
-pub(crate) fn scatter<R: Runtime, E: WgpuElement, I: WgpuElement, const D: usize>(
+pub(crate) fn scatter<R: Runtime, E: JitElement, I: JitElement, const D: usize>(
     dim: usize,
-    tensor: WgpuTensor<R, E, D>,
-    indices: WgpuTensor<R, I, D>,
-    value: WgpuTensor<R, E, D>,
-) -> WgpuTensor<R, E, D> {
+    tensor: JitTensor<R, E, D>,
+    indices: JitTensor<R, I, D>,
+    value: JitTensor<R, E, D>,
+) -> JitTensor<R, E, D> {
     let indices = kernel::into_contiguous(indices);
     let tensor = kernel::into_contiguous(tensor);
     let value = kernel::into_contiguous(value);
@@ -68,7 +68,7 @@ pub(crate) fn scatter<R: Runtime, E: WgpuElement, I: WgpuElement, const D: usize
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::{ReferenceBackend, TestBackend, TestJitRuntime};
+    use crate::tests::{ReferenceBackend, TestBackend, TestRuntime};
     use burn_tensor::{backend::Backend, Distribution, Int, Tensor};
 
     #[test]
@@ -127,7 +127,7 @@ mod tests {
         let indices_ref =
             Tensor::<ReferenceBackend, D, Int>::from_data(indices.to_data().convert(), &ref_device);
 
-        let actual = Tensor::<TestBackend, D>::from_primitive(scatter::<TestJitRuntime, _, _, D>(
+        let actual = Tensor::<TestBackend, D>::from_primitive(scatter::<TestRuntime, _, _, D>(
             dim,
             tensor.into_primitive(),
             indices.into_primitive(),

--- a/burn-wgpu/src/kernel/index/scatter.rs
+++ b/burn-wgpu/src/kernel/index/scatter.rs
@@ -4,12 +4,12 @@ use crate::{
     kernel::{self, build_info, elemwise_workgroup, KernelSettings, WORKGROUP_DEFAULT},
     kernel_wgsl,
     tensor::WgpuTensor,
-    JitGpuBackend,
+    JitRuntime,
 };
 
 kernel_wgsl!(Scatter, "../../template/index/scatter.wgsl");
 
-pub(crate) fn scatter<B: JitGpuBackend, E: WgpuElement, I: WgpuElement, const D: usize>(
+pub(crate) fn scatter<B: JitRuntime, E: WgpuElement, I: WgpuElement, const D: usize>(
     dim: usize,
     tensor: WgpuTensor<B, E, D>,
     indices: WgpuTensor<B, I, D>,
@@ -68,7 +68,7 @@ pub(crate) fn scatter<B: JitGpuBackend, E: WgpuElement, I: WgpuElement, const D:
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::{ReferenceBackend, TestBackend, TestJitGpuBackend};
+    use crate::tests::{ReferenceBackend, TestBackend, TestJitRuntime};
     use burn_tensor::{backend::Backend, Distribution, Int, Tensor};
 
     #[test]
@@ -128,7 +128,7 @@ mod tests {
             Tensor::<ReferenceBackend, D, Int>::from_data(indices.to_data().convert(), &ref_device);
 
         let actual =
-            Tensor::<TestBackend, D>::from_primitive(scatter::<TestJitGpuBackend, _, _, D>(
+            Tensor::<TestBackend, D>::from_primitive(scatter::<TestJitRuntime, _, _, D>(
                 dim,
                 tensor.into_primitive(),
                 indices.into_primitive(),

--- a/burn-wgpu/src/kernel/index/scatter.rs
+++ b/burn-wgpu/src/kernel/index/scatter.rs
@@ -68,7 +68,7 @@ pub(crate) fn scatter<B: JitGpuBackend, E: WgpuElement, I: WgpuElement, const D:
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::{ReferenceBackend, TestBackend, TestCompiler, TestJitGpuBackend};
+    use crate::tests::{ReferenceBackend, TestBackend, TestJitGpuBackend};
     use burn_tensor::{backend::Backend, Distribution, Int, Tensor};
 
     #[test]

--- a/burn-wgpu/src/kernel/index/select.rs
+++ b/burn-wgpu/src/kernel/index/select.rs
@@ -101,7 +101,7 @@ pub(crate) fn select_assign<B: JitGpuBackend, E: WgpuElement, I: WgpuElement, co
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::{ReferenceBackend, TestBackend, TestCompiler, TestJitGpuBackend};
+    use crate::tests::{ReferenceBackend, TestBackend, TestJitGpuBackend};
     use burn_tensor::{backend::Backend, Distribution, Int, Tensor};
 
     #[test]

--- a/burn-wgpu/src/kernel/index/select.rs
+++ b/burn-wgpu/src/kernel/index/select.rs
@@ -5,7 +5,7 @@ use crate::{
     kernel_wgsl,
     ops::numeric::empty_device,
     tensor::WgpuTensor,
-    JitRuntime,
+    Runtime,
 };
 
 kernel_wgsl!(IndexSelect, "../../template/index/select.wgsl");
@@ -14,11 +14,11 @@ kernel_wgsl!(
     "../../template/index/select_assign_inplace.wgsl"
 );
 
-pub(crate) fn select<B: JitRuntime, E: WgpuElement, I: WgpuElement, const D: usize>(
-    tensor: WgpuTensor<B, E, D>,
+pub(crate) fn select<R: Runtime, E: WgpuElement, I: WgpuElement, const D: usize>(
+    tensor: WgpuTensor<R, E, D>,
     dim: usize,
-    indices: WgpuTensor<B, I, 1>,
-) -> WgpuTensor<B, E, D> {
+    indices: WgpuTensor<R, I, 1>,
+) -> WgpuTensor<R, E, D> {
     let mut output_shape = tensor.shape.clone();
     output_shape.dims[dim] = indices.shape.dims[0];
 
@@ -46,12 +46,12 @@ pub(crate) fn select<B: JitRuntime, E: WgpuElement, I: WgpuElement, const D: usi
     output
 }
 
-pub(crate) fn select_assign<B: JitRuntime, E: WgpuElement, I: WgpuElement, const D: usize>(
-    tensor: WgpuTensor<B, E, D>,
+pub(crate) fn select_assign<R: Runtime, E: WgpuElement, I: WgpuElement, const D: usize>(
+    tensor: WgpuTensor<R, E, D>,
     dim: usize,
-    indices: WgpuTensor<B, I, 1>,
-    value: WgpuTensor<B, E, D>,
-) -> WgpuTensor<B, E, D> {
+    indices: WgpuTensor<R, I, 1>,
+    value: WgpuTensor<R, E, D>,
+) -> WgpuTensor<R, E, D> {
     let tensor = match tensor.can_mut() {
         true => tensor,
         false => tensor.copy(),

--- a/burn-wgpu/src/kernel/index/select.rs
+++ b/burn-wgpu/src/kernel/index/select.rs
@@ -5,7 +5,7 @@ use crate::{
     kernel_wgsl,
     ops::numeric::empty_device,
     tensor::WgpuTensor,
-    JitGpuBackend,
+    JitRuntime,
 };
 
 kernel_wgsl!(IndexSelect, "../../template/index/select.wgsl");
@@ -14,7 +14,7 @@ kernel_wgsl!(
     "../../template/index/select_assign_inplace.wgsl"
 );
 
-pub(crate) fn select<B: JitGpuBackend, E: WgpuElement, I: WgpuElement, const D: usize>(
+pub(crate) fn select<B: JitRuntime, E: WgpuElement, I: WgpuElement, const D: usize>(
     tensor: WgpuTensor<B, E, D>,
     dim: usize,
     indices: WgpuTensor<B, I, 1>,
@@ -46,7 +46,7 @@ pub(crate) fn select<B: JitGpuBackend, E: WgpuElement, I: WgpuElement, const D: 
     output
 }
 
-pub(crate) fn select_assign<B: JitGpuBackend, E: WgpuElement, I: WgpuElement, const D: usize>(
+pub(crate) fn select_assign<B: JitRuntime, E: WgpuElement, I: WgpuElement, const D: usize>(
     tensor: WgpuTensor<B, E, D>,
     dim: usize,
     indices: WgpuTensor<B, I, 1>,
@@ -101,7 +101,7 @@ pub(crate) fn select_assign<B: JitGpuBackend, E: WgpuElement, I: WgpuElement, co
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::{ReferenceBackend, TestBackend, TestJitGpuBackend};
+    use crate::tests::{ReferenceBackend, TestBackend, TestJitRuntime};
     use burn_tensor::{backend::Backend, Distribution, Int, Tensor};
 
     #[test]
@@ -176,7 +176,7 @@ mod tests {
         );
 
         let actual =
-            Tensor::<TestBackend, D>::from_primitive(select_assign::<TestJitGpuBackend, _, _, D>(
+            Tensor::<TestBackend, D>::from_primitive(select_assign::<TestJitRuntime, _, _, D>(
                 tensor.into_primitive(),
                 dim,
                 indices.into_primitive(),

--- a/burn-wgpu/src/kernel/index/select.rs
+++ b/burn-wgpu/src/kernel/index/select.rs
@@ -101,7 +101,7 @@ pub(crate) fn select_assign<B: JitGpuBackend, E: WgpuElement, I: WgpuElement, co
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::{ReferenceBackend, TestBackend, TestCompiler};
+    use crate::tests::{ReferenceBackend, TestBackend, TestCompiler, TestJitGpuBackend};
     use burn_tensor::{backend::Backend, Distribution, Int, Tensor};
 
     #[test]
@@ -176,7 +176,7 @@ mod tests {
         );
 
         let actual =
-            Tensor::<TestBackend, D>::from_primitive(select_assign::<TestCompiler, _, _, D>(
+            Tensor::<TestBackend, D>::from_primitive(select_assign::<TestJitGpuBackend, _, _, D>(
                 tensor.into_primitive(),
                 dim,
                 indices.into_primitive(),

--- a/burn-wgpu/src/kernel/index/slice.rs
+++ b/burn-wgpu/src/kernel/index/slice.rs
@@ -1,5 +1,4 @@
 use crate::{
-    codegen::Compiler,
     compute::StaticKernel,
     element::WgpuElement,
     kernel::{build_info, elemwise_workgroup, KernelSettings, WORKGROUP_DEFAULT},
@@ -98,7 +97,7 @@ pub(crate) fn slice_assign<B: JitGpuBackend, E: WgpuElement, const D1: usize, co
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::{ReferenceBackend, TestBackend, TestCompiler, TestJitGpuBackend};
+    use crate::tests::{ReferenceBackend, TestBackend, TestJitGpuBackend};
     use burn_tensor::{Distribution, Tensor};
 
     #[test]

--- a/burn-wgpu/src/kernel/index/slice.rs
+++ b/burn-wgpu/src/kernel/index/slice.rs
@@ -5,7 +5,7 @@ use crate::{
     kernel_wgsl,
     ops::numeric::empty_device,
     tensor::WgpuTensor,
-    JitRuntime,
+    Runtime,
 };
 use burn_tensor::Shape;
 use std::ops::Range;
@@ -16,10 +16,10 @@ kernel_wgsl!(
     "../../template/index/slice_assign_inplace.wgsl"
 );
 
-pub(crate) fn slice<B: JitRuntime, E: WgpuElement, const D1: usize, const D2: usize>(
-    tensor: WgpuTensor<B, E, D1>,
+pub(crate) fn slice<R: Runtime, E: WgpuElement, const D1: usize, const D2: usize>(
+    tensor: WgpuTensor<R, E, D1>,
     indices: [Range<usize>; D2],
-) -> WgpuTensor<B, E, D1> {
+) -> WgpuTensor<R, E, D1> {
     let mut dims = tensor.shape.dims;
     for i in 0..D2 {
         dims[i] = indices[i].end - indices[i].start;
@@ -29,16 +29,11 @@ pub(crate) fn slice<B: JitRuntime, E: WgpuElement, const D1: usize, const D2: us
     slice_on_output(tensor, output, indices)
 }
 
-pub(crate) fn slice_on_output<
-    B: JitRuntime,
-    E: WgpuElement,
-    const D1: usize,
-    const D2: usize,
->(
-    tensor: WgpuTensor<B, E, D1>,
-    output: WgpuTensor<B, E, D1>,
+pub(crate) fn slice_on_output<R: Runtime, E: WgpuElement, const D1: usize, const D2: usize>(
+    tensor: WgpuTensor<R, E, D1>,
+    output: WgpuTensor<R, E, D1>,
     indices: [Range<usize>; D2],
-) -> WgpuTensor<B, E, D1> {
+) -> WgpuTensor<R, E, D1> {
     let mut info = build_info(&[&tensor, &output]);
 
     for i in 0..D1 {
@@ -63,11 +58,11 @@ pub(crate) fn slice_on_output<
     output
 }
 
-pub(crate) fn slice_assign<B: JitRuntime, E: WgpuElement, const D1: usize, const D2: usize>(
-    tensor: WgpuTensor<B, E, D1>,
+pub(crate) fn slice_assign<R: Runtime, E: WgpuElement, const D1: usize, const D2: usize>(
+    tensor: WgpuTensor<R, E, D1>,
     indices: [Range<usize>; D2],
-    value: WgpuTensor<B, E, D1>,
-) -> WgpuTensor<B, E, D1> {
+    value: WgpuTensor<R, E, D1>,
+) -> WgpuTensor<R, E, D1> {
     let tensor = match tensor.can_mut() {
         true => tensor,
         false => tensor.copy(),

--- a/burn-wgpu/src/kernel/index/slice.rs
+++ b/burn-wgpu/src/kernel/index/slice.rs
@@ -98,7 +98,7 @@ pub(crate) fn slice_assign<B: JitGpuBackend, E: WgpuElement, const D1: usize, co
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::{ReferenceBackend, TestBackend, TestCompiler};
+    use crate::tests::{ReferenceBackend, TestBackend, TestCompiler, TestJitGpuBackend};
     use burn_tensor::{Distribution, Tensor};
 
     #[test]
@@ -130,7 +130,7 @@ mod tests {
         let value_ref =
             Tensor::<ReferenceBackend, 2>::from_data(value.to_data(), &Default::default());
 
-        let actual = slice_assign::<TestCompiler, _, 2, 2>(
+        let actual = slice_assign::<TestJitGpuBackend, _, 2, 2>(
             tensor.into_primitive(),
             indices.clone(),
             value.into_primitive(),

--- a/burn-wgpu/src/kernel/index/slice.rs
+++ b/burn-wgpu/src/kernel/index/slice.rs
@@ -6,6 +6,7 @@ use crate::{
     kernel_wgsl,
     ops::numeric::empty_device,
     tensor::WgpuTensor,
+    JitGpuBackend,
 };
 use burn_tensor::Shape;
 use std::ops::Range;
@@ -16,10 +17,10 @@ kernel_wgsl!(
     "../../template/index/slice_assign_inplace.wgsl"
 );
 
-pub(crate) fn slice<E: WgpuElement, const D1: usize, const D2: usize>(
-    tensor: WgpuTensor<E, D1>,
+pub(crate) fn slice<B: JitGpuBackend, E: WgpuElement, const D1: usize, const D2: usize>(
+    tensor: WgpuTensor<B, E, D1>,
     indices: [Range<usize>; D2],
-) -> WgpuTensor<E, D1> {
+) -> WgpuTensor<B, E, D1> {
     let mut dims = tensor.shape.dims;
     for i in 0..D2 {
         dims[i] = indices[i].end - indices[i].start;
@@ -29,11 +30,16 @@ pub(crate) fn slice<E: WgpuElement, const D1: usize, const D2: usize>(
     slice_on_output(tensor, output, indices)
 }
 
-pub(crate) fn slice_on_output<E: WgpuElement, const D1: usize, const D2: usize>(
-    tensor: WgpuTensor<E, D1>,
-    output: WgpuTensor<E, D1>,
+pub(crate) fn slice_on_output<
+    B: JitGpuBackend,
+    E: WgpuElement,
+    const D1: usize,
+    const D2: usize,
+>(
+    tensor: WgpuTensor<B, E, D1>,
+    output: WgpuTensor<B, E, D1>,
     indices: [Range<usize>; D2],
-) -> WgpuTensor<E, D1> {
+) -> WgpuTensor<B, E, D1> {
     let mut info = build_info(&[&tensor, &output]);
 
     for i in 0..D1 {
@@ -58,14 +64,14 @@ pub(crate) fn slice_on_output<E: WgpuElement, const D1: usize, const D2: usize>(
     output
 }
 
-pub(crate) fn slice_assign<C: Compiler, E: WgpuElement, const D1: usize, const D2: usize>(
-    tensor: WgpuTensor<E, D1>,
+pub(crate) fn slice_assign<B: JitGpuBackend, E: WgpuElement, const D1: usize, const D2: usize>(
+    tensor: WgpuTensor<B, E, D1>,
     indices: [Range<usize>; D2],
-    value: WgpuTensor<E, D1>,
-) -> WgpuTensor<E, D1> {
+    value: WgpuTensor<B, E, D1>,
+) -> WgpuTensor<B, E, D1> {
     let tensor = match tensor.can_mut() {
         true => tensor,
-        false => tensor.copy::<C>(),
+        false => tensor.copy(),
     };
     let num_elems = tensor.shape.num_elements();
     let mut info = build_info(&[&tensor, &value]);

--- a/burn-wgpu/src/kernel/index/slice.rs
+++ b/burn-wgpu/src/kernel/index/slice.rs
@@ -5,7 +5,7 @@ use crate::{
     kernel_wgsl,
     ops::numeric::empty_device,
     tensor::WgpuTensor,
-    JitGpuBackend,
+    JitRuntime,
 };
 use burn_tensor::Shape;
 use std::ops::Range;
@@ -16,7 +16,7 @@ kernel_wgsl!(
     "../../template/index/slice_assign_inplace.wgsl"
 );
 
-pub(crate) fn slice<B: JitGpuBackend, E: WgpuElement, const D1: usize, const D2: usize>(
+pub(crate) fn slice<B: JitRuntime, E: WgpuElement, const D1: usize, const D2: usize>(
     tensor: WgpuTensor<B, E, D1>,
     indices: [Range<usize>; D2],
 ) -> WgpuTensor<B, E, D1> {
@@ -30,7 +30,7 @@ pub(crate) fn slice<B: JitGpuBackend, E: WgpuElement, const D1: usize, const D2:
 }
 
 pub(crate) fn slice_on_output<
-    B: JitGpuBackend,
+    B: JitRuntime,
     E: WgpuElement,
     const D1: usize,
     const D2: usize,
@@ -63,7 +63,7 @@ pub(crate) fn slice_on_output<
     output
 }
 
-pub(crate) fn slice_assign<B: JitGpuBackend, E: WgpuElement, const D1: usize, const D2: usize>(
+pub(crate) fn slice_assign<B: JitRuntime, E: WgpuElement, const D1: usize, const D2: usize>(
     tensor: WgpuTensor<B, E, D1>,
     indices: [Range<usize>; D2],
     value: WgpuTensor<B, E, D1>,
@@ -97,7 +97,7 @@ pub(crate) fn slice_assign<B: JitGpuBackend, E: WgpuElement, const D1: usize, co
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::{ReferenceBackend, TestBackend, TestJitGpuBackend};
+    use crate::tests::{ReferenceBackend, TestBackend, TestJitRuntime};
     use burn_tensor::{Distribution, Tensor};
 
     #[test]
@@ -129,7 +129,7 @@ mod tests {
         let value_ref =
             Tensor::<ReferenceBackend, 2>::from_data(value.to_data(), &Default::default());
 
-        let actual = slice_assign::<TestJitGpuBackend, _, 2, 2>(
+        let actual = slice_assign::<TestJitRuntime, _, 2, 2>(
             tensor.into_primitive(),
             indices.clone(),
             value.into_primitive(),

--- a/burn-wgpu/src/kernel/mask/base.rs
+++ b/burn-wgpu/src/kernel/mask/base.rs
@@ -1,7 +1,7 @@
-use crate::{element::WgpuElement, tensor::WgpuTensor, JitGpuBackend};
+use crate::{element::WgpuElement, tensor::WgpuTensor, JitRuntime};
 
 /// Execute the mask fill kernel.
-pub fn mask_fill<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn mask_fill<B: JitRuntime, E: WgpuElement, const D: usize>(
     tensor: WgpuTensor<B, E, D>,
     mask: WgpuTensor<B, u32, D>,
     value: E,
@@ -14,7 +14,7 @@ pub fn mask_fill<B: JitGpuBackend, E: WgpuElement, const D: usize>(
 }
 
 /// Execute the mask where kernel.
-pub fn mask_where<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn mask_where<B: JitRuntime, E: WgpuElement, const D: usize>(
     tensor: WgpuTensor<B, E, D>,
     mask: WgpuTensor<B, u32, D>,
     value: WgpuTensor<B, E, D>,

--- a/burn-wgpu/src/kernel/mask/base.rs
+++ b/burn-wgpu/src/kernel/mask/base.rs
@@ -1,11 +1,11 @@
-use crate::{element::WgpuElement, tensor::WgpuTensor, JitRuntime};
+use crate::{element::WgpuElement, tensor::WgpuTensor, Runtime};
 
 /// Execute the mask fill kernel.
-pub fn mask_fill<B: JitRuntime, E: WgpuElement, const D: usize>(
-    tensor: WgpuTensor<B, E, D>,
-    mask: WgpuTensor<B, u32, D>,
+pub fn mask_fill<R: Runtime, E: WgpuElement, const D: usize>(
+    tensor: WgpuTensor<R, E, D>,
+    mask: WgpuTensor<R, u32, D>,
     value: E,
-) -> WgpuTensor<B, E, D> {
+) -> WgpuTensor<R, E, D> {
     if tensor.can_mut() {
         return super::mask_fill::mask_fill_inplace(tensor, mask, value);
     }
@@ -14,11 +14,11 @@ pub fn mask_fill<B: JitRuntime, E: WgpuElement, const D: usize>(
 }
 
 /// Execute the mask where kernel.
-pub fn mask_where<B: JitRuntime, E: WgpuElement, const D: usize>(
-    tensor: WgpuTensor<B, E, D>,
-    mask: WgpuTensor<B, u32, D>,
-    value: WgpuTensor<B, E, D>,
-) -> WgpuTensor<B, E, D> {
+pub fn mask_where<R: Runtime, E: WgpuElement, const D: usize>(
+    tensor: WgpuTensor<R, E, D>,
+    mask: WgpuTensor<R, u32, D>,
+    value: WgpuTensor<R, E, D>,
+) -> WgpuTensor<R, E, D> {
     if tensor.can_mut_broadcast(&value) {
         return super::mask_where::mask_where_inplace(tensor, mask, value, false);
     }

--- a/burn-wgpu/src/kernel/mask/base.rs
+++ b/burn-wgpu/src/kernel/mask/base.rs
@@ -1,11 +1,11 @@
-use crate::{element::WgpuElement, tensor::WgpuTensor, Runtime};
+use crate::{element::JitElement, tensor::JitTensor, Runtime};
 
 /// Execute the mask fill kernel.
-pub fn mask_fill<R: Runtime, E: WgpuElement, const D: usize>(
-    tensor: WgpuTensor<R, E, D>,
-    mask: WgpuTensor<R, u32, D>,
+pub fn mask_fill<R: Runtime, E: JitElement, const D: usize>(
+    tensor: JitTensor<R, E, D>,
+    mask: JitTensor<R, u32, D>,
     value: E,
-) -> WgpuTensor<R, E, D> {
+) -> JitTensor<R, E, D> {
     if tensor.can_mut() {
         return super::mask_fill::mask_fill_inplace(tensor, mask, value);
     }
@@ -14,11 +14,11 @@ pub fn mask_fill<R: Runtime, E: WgpuElement, const D: usize>(
 }
 
 /// Execute the mask where kernel.
-pub fn mask_where<R: Runtime, E: WgpuElement, const D: usize>(
-    tensor: WgpuTensor<R, E, D>,
-    mask: WgpuTensor<R, u32, D>,
-    value: WgpuTensor<R, E, D>,
-) -> WgpuTensor<R, E, D> {
+pub fn mask_where<R: Runtime, E: JitElement, const D: usize>(
+    tensor: JitTensor<R, E, D>,
+    mask: JitTensor<R, u32, D>,
+    value: JitTensor<R, E, D>,
+) -> JitTensor<R, E, D> {
     if tensor.can_mut_broadcast(&value) {
         return super::mask_where::mask_where_inplace(tensor, mask, value, false);
     }

--- a/burn-wgpu/src/kernel/mask/base.rs
+++ b/burn-wgpu/src/kernel/mask/base.rs
@@ -1,11 +1,11 @@
-use crate::{element::WgpuElement, tensor::WgpuTensor};
+use crate::{element::WgpuElement, tensor::WgpuTensor, JitGpuBackend};
 
 /// Execute the mask fill kernel.
-pub fn mask_fill<E: WgpuElement, const D: usize>(
-    tensor: WgpuTensor<E, D>,
-    mask: WgpuTensor<u32, D>,
+pub fn mask_fill<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    tensor: WgpuTensor<B, E, D>,
+    mask: WgpuTensor<B, u32, D>,
     value: E,
-) -> WgpuTensor<E, D> {
+) -> WgpuTensor<B, E, D> {
     if tensor.can_mut() {
         return super::mask_fill::mask_fill_inplace(tensor, mask, value);
     }
@@ -14,11 +14,11 @@ pub fn mask_fill<E: WgpuElement, const D: usize>(
 }
 
 /// Execute the mask where kernel.
-pub fn mask_where<E: WgpuElement, const D: usize>(
-    tensor: WgpuTensor<E, D>,
-    mask: WgpuTensor<u32, D>,
-    value: WgpuTensor<E, D>,
-) -> WgpuTensor<E, D> {
+pub fn mask_where<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    tensor: WgpuTensor<B, E, D>,
+    mask: WgpuTensor<B, u32, D>,
+    value: WgpuTensor<B, E, D>,
+) -> WgpuTensor<B, E, D> {
     if tensor.can_mut_broadcast(&value) {
         return super::mask_where::mask_where_inplace(tensor, mask, value, false);
     }

--- a/burn-wgpu/src/kernel/mask/mask_fill.rs
+++ b/burn-wgpu/src/kernel/mask/mask_fill.rs
@@ -70,18 +70,19 @@ pub fn mask_fill_inplace<B: JitGpuBackend, E: WgpuElement, const D: usize>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::{ReferenceBackend, TestBackend};
+    use crate::tests::{ReferenceBackend, TestBackend, TestJitGpuBackend};
     use burn_tensor::{Bool, Distribution, Tensor};
 
     #[test]
     fn mask_fill_should_work_with_multiple_invocations() {
         let (tensor, mask, tensor_ref, mask_ref) = inputs_mask_fill();
 
-        let actual = Tensor::<TestBackend, 3>::from_primitive(mask_fill::<f32, 3>(
-            tensor.into_primitive(),
-            mask.into_primitive(),
-            4.0,
-        ));
+        let actual =
+            Tensor::<TestBackend, 3>::from_primitive(mask_fill::<TestJitGpuBackend, f32, 3>(
+                tensor.into_primitive(),
+                mask.into_primitive(),
+                4.0,
+            ));
         let expected = tensor_ref.mask_fill(mask_ref, 4.0);
 
         expected
@@ -93,11 +94,14 @@ mod tests {
     fn mask_fill_inplace_should_work_with_multiple_invocations() {
         let (tensor, mask, tensor_ref, mask_ref) = inputs_mask_fill();
 
-        let actual = Tensor::<TestBackend, 3>::from_primitive(mask_fill_inplace::<f32, 3>(
-            tensor.into_primitive(),
-            mask.into_primitive(),
-            4.0,
-        ));
+        let actual =
+            Tensor::<TestBackend, 3>::from_primitive(
+                mask_fill_inplace::<TestJitGpuBackend, f32, 3>(
+                    tensor.into_primitive(),
+                    mask.into_primitive(),
+                    4.0,
+                ),
+            );
         let expected = tensor_ref.mask_fill(mask_ref, 4.0);
 
         expected

--- a/burn-wgpu/src/kernel/mask/mask_fill.rs
+++ b/burn-wgpu/src/kernel/mask/mask_fill.rs
@@ -5,16 +5,17 @@ use crate::{
     kernel_wgsl,
     ops::numeric::empty_device,
     tensor::WgpuTensor,
+    JitGpuBackend,
 };
 
 kernel_wgsl!(MaskFill, "../../template/mask/fill.wgsl");
 kernel_wgsl!(MaskFillInplace, "../../template/mask/fill_inplace.wgsl");
 
-pub fn mask_fill<E: WgpuElement, const D: usize>(
-    input: WgpuTensor<E, D>,
-    mask: WgpuTensor<u32, D>,
+pub fn mask_fill<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    input: WgpuTensor<B, E, D>,
+    mask: WgpuTensor<B, u32, D>,
     value: E,
-) -> WgpuTensor<E, D> {
+) -> WgpuTensor<B, E, D> {
     let num_elems = input.shape.num_elements();
     let output = empty_device(
         input.client.clone(),
@@ -44,11 +45,11 @@ pub fn mask_fill<E: WgpuElement, const D: usize>(
     output
 }
 
-pub fn mask_fill_inplace<E: WgpuElement, const D: usize>(
-    input: WgpuTensor<E, D>,
-    mask: WgpuTensor<u32, D>,
+pub fn mask_fill_inplace<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    input: WgpuTensor<B, E, D>,
+    mask: WgpuTensor<B, u32, D>,
     value: E,
-) -> WgpuTensor<E, D> {
+) -> WgpuTensor<B, E, D> {
     let num_elems = input.shape.num_elements();
     let value_handle = input.client.create(E::as_bytes(&[value]));
     let kernel = StaticKernel::<

--- a/burn-wgpu/src/kernel/mask/mask_fill.rs
+++ b/burn-wgpu/src/kernel/mask/mask_fill.rs
@@ -5,13 +5,13 @@ use crate::{
     kernel_wgsl,
     ops::numeric::empty_device,
     tensor::WgpuTensor,
-    JitGpuBackend,
+    JitRuntime,
 };
 
 kernel_wgsl!(MaskFill, "../../template/mask/fill.wgsl");
 kernel_wgsl!(MaskFillInplace, "../../template/mask/fill_inplace.wgsl");
 
-pub fn mask_fill<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn mask_fill<B: JitRuntime, E: WgpuElement, const D: usize>(
     input: WgpuTensor<B, E, D>,
     mask: WgpuTensor<B, u32, D>,
     value: E,
@@ -45,7 +45,7 @@ pub fn mask_fill<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     output
 }
 
-pub fn mask_fill_inplace<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn mask_fill_inplace<B: JitRuntime, E: WgpuElement, const D: usize>(
     input: WgpuTensor<B, E, D>,
     mask: WgpuTensor<B, u32, D>,
     value: E,
@@ -70,7 +70,7 @@ pub fn mask_fill_inplace<B: JitGpuBackend, E: WgpuElement, const D: usize>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::{ReferenceBackend, TestBackend, TestJitGpuBackend};
+    use crate::tests::{ReferenceBackend, TestBackend, TestJitRuntime};
     use burn_tensor::{Bool, Distribution, Tensor};
 
     #[test]
@@ -78,7 +78,7 @@ mod tests {
         let (tensor, mask, tensor_ref, mask_ref) = inputs_mask_fill();
 
         let actual =
-            Tensor::<TestBackend, 3>::from_primitive(mask_fill::<TestJitGpuBackend, f32, 3>(
+            Tensor::<TestBackend, 3>::from_primitive(mask_fill::<TestJitRuntime, f32, 3>(
                 tensor.into_primitive(),
                 mask.into_primitive(),
                 4.0,
@@ -96,7 +96,7 @@ mod tests {
 
         let actual =
             Tensor::<TestBackend, 3>::from_primitive(
-                mask_fill_inplace::<TestJitGpuBackend, f32, 3>(
+                mask_fill_inplace::<TestJitRuntime, f32, 3>(
                     tensor.into_primitive(),
                     mask.into_primitive(),
                     4.0,

--- a/burn-wgpu/src/kernel/mask/mask_where.rs
+++ b/burn-wgpu/src/kernel/mask/mask_where.rs
@@ -5,13 +5,13 @@ use crate::{
     kernel_wgsl,
     ops::numeric::empty_device,
     tensor::WgpuTensor,
-    JitGpuBackend,
+    JitRuntime,
 };
 
 kernel_wgsl!(MaskWhere, "../../template/mask/where.wgsl");
 kernel_wgsl!(MaskWhereInplace, "../../template/mask/where_inplace.wgsl");
 
-pub fn mask_where<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn mask_where<B: JitRuntime, E: WgpuElement, const D: usize>(
     input: WgpuTensor<B, E, D>,
     mask: WgpuTensor<B, u32, D>,
     value: WgpuTensor<B, E, D>,
@@ -44,7 +44,7 @@ pub fn mask_where<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     output
 }
 
-pub fn mask_where_inplace<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn mask_where_inplace<B: JitRuntime, E: WgpuElement, const D: usize>(
     input: WgpuTensor<B, E, D>,
     mask: WgpuTensor<B, u32, D>,
     value: WgpuTensor<B, E, D>,
@@ -75,7 +75,7 @@ pub fn mask_where_inplace<B: JitGpuBackend, E: WgpuElement, const D: usize>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::{ReferenceBackend, TestBackend, TestJitGpuBackend};
+    use crate::tests::{ReferenceBackend, TestBackend, TestJitRuntime};
     use burn_tensor::{backend::Backend, Bool, Distribution, Tensor};
 
     #[test]
@@ -83,7 +83,7 @@ mod tests {
         let (tensor, value, mask, tensor_ref, value_ref, mask_ref) = inputs_mask_where();
 
         let actual =
-            Tensor::<TestBackend, 3>::from_primitive(mask_where::<TestJitGpuBackend, f32, 3>(
+            Tensor::<TestBackend, 3>::from_primitive(mask_where::<TestJitRuntime, f32, 3>(
                 tensor.into_primitive(),
                 mask.into_primitive(),
                 value.into_primitive(),
@@ -100,7 +100,7 @@ mod tests {
 
         let actual =
             Tensor::<TestBackend, 3>::from_primitive(
-                mask_where_inplace::<TestJitGpuBackend, f32, 3>(
+                mask_where_inplace::<TestJitRuntime, f32, 3>(
                     tensor.into_primitive(),
                     mask.into_primitive(),
                     value.into_primitive(),
@@ -120,7 +120,7 @@ mod tests {
 
         let actual =
             Tensor::<TestBackend, 3>::from_primitive(
-                mask_where_inplace::<TestJitGpuBackend, f32, 3>(
+                mask_where_inplace::<TestJitRuntime, f32, 3>(
                     value.into_primitive(),
                     mask.into_primitive(),
                     tensor.into_primitive(),

--- a/burn-wgpu/src/kernel/mask/mask_where.rs
+++ b/burn-wgpu/src/kernel/mask/mask_where.rs
@@ -75,18 +75,19 @@ pub fn mask_where_inplace<B: JitGpuBackend, E: WgpuElement, const D: usize>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::{ReferenceBackend, TestBackend};
+    use crate::tests::{ReferenceBackend, TestBackend, TestJitGpuBackend};
     use burn_tensor::{backend::Backend, Bool, Distribution, Tensor};
 
     #[test]
     fn mask_where_should_work_with_multiple_invocations() {
         let (tensor, value, mask, tensor_ref, value_ref, mask_ref) = inputs_mask_where();
 
-        let actual = Tensor::<TestBackend, 3>::from_primitive(mask_where::<f32, 3>(
-            tensor.into_primitive(),
-            mask.into_primitive(),
-            value.into_primitive(),
-        ));
+        let actual =
+            Tensor::<TestBackend, 3>::from_primitive(mask_where::<TestJitGpuBackend, f32, 3>(
+                tensor.into_primitive(),
+                mask.into_primitive(),
+                value.into_primitive(),
+            ));
         let expected = tensor_ref.mask_where(mask_ref, value_ref);
 
         expected
@@ -97,12 +98,15 @@ mod tests {
     fn mask_where_inplace_direction_1_should_work_with_multiple_invocations() {
         let (tensor, value, mask, tensor_ref, value_ref, mask_ref) = inputs_mask_where();
 
-        let actual = Tensor::<TestBackend, 3>::from_primitive(mask_where_inplace::<f32, 3>(
-            tensor.into_primitive(),
-            mask.into_primitive(),
-            value.into_primitive(),
-            false,
-        ));
+        let actual =
+            Tensor::<TestBackend, 3>::from_primitive(
+                mask_where_inplace::<TestJitGpuBackend, f32, 3>(
+                    tensor.into_primitive(),
+                    mask.into_primitive(),
+                    value.into_primitive(),
+                    false,
+                ),
+            );
         let expected = tensor_ref.mask_where(mask_ref, value_ref);
 
         expected
@@ -114,12 +118,15 @@ mod tests {
     fn mask_where_inplace_direction_0_should_work_with_multiple_invocation() {
         let (tensor, value, mask, tensor_ref, value_ref, mask_ref) = inputs_mask_where();
 
-        let actual = Tensor::<TestBackend, 3>::from_primitive(mask_where_inplace::<f32, 3>(
-            value.into_primitive(),
-            mask.into_primitive(),
-            tensor.into_primitive(),
-            true,
-        ));
+        let actual =
+            Tensor::<TestBackend, 3>::from_primitive(
+                mask_where_inplace::<TestJitGpuBackend, f32, 3>(
+                    value.into_primitive(),
+                    mask.into_primitive(),
+                    tensor.into_primitive(),
+                    true,
+                ),
+            );
         let expected = tensor_ref.mask_where(mask_ref, value_ref);
 
         expected

--- a/burn-wgpu/src/kernel/mask/mask_where.rs
+++ b/burn-wgpu/src/kernel/mask/mask_where.rs
@@ -82,12 +82,11 @@ mod tests {
     fn mask_where_should_work_with_multiple_invocations() {
         let (tensor, value, mask, tensor_ref, value_ref, mask_ref) = inputs_mask_where();
 
-        let actual =
-            Tensor::<TestBackend, 3>::from_primitive(mask_where::<TestRuntime, f32, 3>(
-                tensor.into_primitive(),
-                mask.into_primitive(),
-                value.into_primitive(),
-            ));
+        let actual = Tensor::<TestBackend, 3>::from_primitive(mask_where::<TestRuntime, f32, 3>(
+            tensor.into_primitive(),
+            mask.into_primitive(),
+            value.into_primitive(),
+        ));
         let expected = tensor_ref.mask_where(mask_ref, value_ref);
 
         expected

--- a/burn-wgpu/src/kernel/mask/mask_where.rs
+++ b/burn-wgpu/src/kernel/mask/mask_where.rs
@@ -5,16 +5,17 @@ use crate::{
     kernel_wgsl,
     ops::numeric::empty_device,
     tensor::WgpuTensor,
+    JitGpuBackend,
 };
 
 kernel_wgsl!(MaskWhere, "../../template/mask/where.wgsl");
 kernel_wgsl!(MaskWhereInplace, "../../template/mask/where_inplace.wgsl");
 
-pub fn mask_where<E: WgpuElement, const D: usize>(
-    input: WgpuTensor<E, D>,
-    mask: WgpuTensor<u32, D>,
-    value: WgpuTensor<E, D>,
-) -> WgpuTensor<E, D> {
+pub fn mask_where<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    input: WgpuTensor<B, E, D>,
+    mask: WgpuTensor<B, u32, D>,
+    value: WgpuTensor<B, E, D>,
+) -> WgpuTensor<B, E, D> {
     let num_elems = input.shape.num_elements();
     let output = empty_device(
         input.client.clone(),
@@ -43,12 +44,12 @@ pub fn mask_where<E: WgpuElement, const D: usize>(
     output
 }
 
-pub fn mask_where_inplace<E: WgpuElement, const D: usize>(
-    input: WgpuTensor<E, D>,
-    mask: WgpuTensor<u32, D>,
-    value: WgpuTensor<E, D>,
+pub fn mask_where_inplace<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    input: WgpuTensor<B, E, D>,
+    mask: WgpuTensor<B, u32, D>,
+    value: WgpuTensor<B, E, D>,
     reverse: bool,
-) -> WgpuTensor<E, D> {
+) -> WgpuTensor<B, E, D> {
     let kernel = StaticKernel::<
         KernelSettings<MaskWhereInplace, E, i32, WORKGROUP_DEFAULT, WORKGROUP_DEFAULT, 1>,
     >::new(elemwise_workgroup(

--- a/burn-wgpu/src/kernel/matmul/mem_coalescing.rs
+++ b/burn-wgpu/src/kernel/matmul/mem_coalescing.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     kernel_wgsl,
     tensor::WgpuTensor,
-    JitRuntime,
+    Runtime,
 };
 
 kernel_wgsl!(
@@ -40,22 +40,22 @@ impl<E: WgpuElement> DynamicKernelSource for MatmulMemCoalescing<E> {
 }
 
 /// Matrix multiplication using memory coalescing algorithm with workgroups of size 16
-pub fn matmul_mem_coalescing_default<B: JitRuntime, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<B, E, D>,
-    rhs: WgpuTensor<B, E, D>,
-    out: WgpuTensor<B, E, D>,
-) -> WgpuTensor<B, E, D> {
-    matmul_mem_coalescing::<B, E, D>(lhs, rhs, out, WORKGROUP_DEFAULT, WORKGROUP_DEFAULT)
+pub fn matmul_mem_coalescing_default<R: Runtime, E: WgpuElement, const D: usize>(
+    lhs: WgpuTensor<R, E, D>,
+    rhs: WgpuTensor<R, E, D>,
+    out: WgpuTensor<R, E, D>,
+) -> WgpuTensor<R, E, D> {
+    matmul_mem_coalescing::<R, E, D>(lhs, rhs, out, WORKGROUP_DEFAULT, WORKGROUP_DEFAULT)
 }
 
 /// Matrix multiplication using memory coalescing algorithm with custom workgroup sizes
-pub fn matmul_mem_coalescing<B: JitRuntime, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<B, E, D>,
-    rhs: WgpuTensor<B, E, D>,
-    output: WgpuTensor<B, E, D>,
+pub fn matmul_mem_coalescing<R: Runtime, E: WgpuElement, const D: usize>(
+    lhs: WgpuTensor<R, E, D>,
+    rhs: WgpuTensor<R, E, D>,
+    output: WgpuTensor<R, E, D>,
     workgroup_size_x: usize,
     workgroup_size_y: usize,
-) -> WgpuTensor<B, E, D> {
+) -> WgpuTensor<R, E, D> {
     lhs.assert_is_on_same_device(&rhs);
 
     let lhs = into_contiguous(lhs);

--- a/burn-wgpu/src/kernel/matmul/mem_coalescing.rs
+++ b/burn-wgpu/src/kernel/matmul/mem_coalescing.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     kernel_wgsl,
     tensor::WgpuTensor,
-    JitGpuBackend,
+    JitRuntime,
 };
 
 kernel_wgsl!(
@@ -40,7 +40,7 @@ impl<E: WgpuElement> DynamicKernelSource for MatmulMemCoalescing<E> {
 }
 
 /// Matrix multiplication using memory coalescing algorithm with workgroups of size 16
-pub fn matmul_mem_coalescing_default<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn matmul_mem_coalescing_default<B: JitRuntime, E: WgpuElement, const D: usize>(
     lhs: WgpuTensor<B, E, D>,
     rhs: WgpuTensor<B, E, D>,
     out: WgpuTensor<B, E, D>,
@@ -49,7 +49,7 @@ pub fn matmul_mem_coalescing_default<B: JitGpuBackend, E: WgpuElement, const D: 
 }
 
 /// Matrix multiplication using memory coalescing algorithm with custom workgroup sizes
-pub fn matmul_mem_coalescing<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn matmul_mem_coalescing<B: JitRuntime, E: WgpuElement, const D: usize>(
     lhs: WgpuTensor<B, E, D>,
     rhs: WgpuTensor<B, E, D>,
     output: WgpuTensor<B, E, D>,
@@ -112,7 +112,7 @@ mod tests {
     use super::*;
     use crate::{
         kernel::matmul::utils::tests::{same_as_reference, same_as_reference_swapped_dims},
-        tests::TestJitGpuBackend,
+        tests::TestJitRuntime,
     };
 
     #[test]
@@ -168,7 +168,7 @@ mod tests {
         batch_2: usize,
     ) {
         let func = |lhs, rhs, out| {
-            matmul_mem_coalescing::<TestJitGpuBackend, f32, 4>(
+            matmul_mem_coalescing::<TestJitRuntime, f32, 4>(
                 lhs,
                 rhs,
                 out,
@@ -184,7 +184,7 @@ mod tests {
     #[test]
     fn test_matmul_naive_swapped_batches_no_padding() {
         let matmul_func =
-            |lhs, rhs, out| matmul_mem_coalescing::<TestJitGpuBackend, f32, 4>(lhs, rhs, out, 2, 2);
+            |lhs, rhs, out| matmul_mem_coalescing::<TestJitRuntime, f32, 4>(lhs, rhs, out, 2, 2);
         let swap = [0, 1];
         let shape_lhs = [3, 2, 4, 4];
         let shape_rhs = [3, 2, 4, 4];
@@ -194,7 +194,7 @@ mod tests {
     #[test]
     fn test_matmul_naive_swapped_row_col_no_padding() {
         let matmul_func =
-            |lhs, rhs, out| matmul_mem_coalescing::<TestJitGpuBackend, f32, 4>(lhs, rhs, out, 2, 2);
+            |lhs, rhs, out| matmul_mem_coalescing::<TestJitRuntime, f32, 4>(lhs, rhs, out, 2, 2);
         let swap_lhs = [0, 0];
         let swap_rhs = [2, 3];
         let shape_lhs = [3, 2, 4, 4];
@@ -205,7 +205,7 @@ mod tests {
     #[test]
     fn test_matmul_naive_swapped_row_with_batch_no_padding() {
         let matmul_func =
-            |lhs, rhs, out| matmul_mem_coalescing::<TestJitGpuBackend, f32, 4>(lhs, rhs, out, 2, 2);
+            |lhs, rhs, out| matmul_mem_coalescing::<TestJitRuntime, f32, 4>(lhs, rhs, out, 2, 2);
         let swap_lhs = [0, 3];
         let swap_rhs = [0, 2];
         let shape_lhs = [4, 4, 4, 4];

--- a/burn-wgpu/src/kernel/matmul/mem_coalescing.rs
+++ b/burn-wgpu/src/kernel/matmul/mem_coalescing.rs
@@ -45,7 +45,7 @@ pub fn matmul_mem_coalescing_default<B: JitGpuBackend, E: WgpuElement, const D: 
     rhs: WgpuTensor<B, E, D>,
     out: WgpuTensor<B, E, D>,
 ) -> WgpuTensor<B, E, D> {
-    matmul_mem_coalescing::<E, D>(lhs, rhs, out, WORKGROUP_DEFAULT, WORKGROUP_DEFAULT)
+    matmul_mem_coalescing::<B, E, D>(lhs, rhs, out, WORKGROUP_DEFAULT, WORKGROUP_DEFAULT)
 }
 
 /// Matrix multiplication using memory coalescing algorithm with custom workgroup sizes
@@ -110,7 +110,10 @@ fn matmul_mem_coalescing_kernel<E: WgpuElement, const D: usize>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::kernel::matmul::utils::tests::{same_as_reference, same_as_reference_swapped_dims};
+    use crate::{
+        kernel::matmul::utils::tests::{same_as_reference, same_as_reference_swapped_dims},
+        tests::TestJitGpuBackend,
+    };
 
     #[test]
     pub fn test_matmul_mem_coalescing_straightforward() {
@@ -165,7 +168,13 @@ mod tests {
         batch_2: usize,
     ) {
         let func = |lhs, rhs, out| {
-            matmul_mem_coalescing::<f32, 4>(lhs, rhs, out, WORKGROUP_SIZE_X, WORKGROUP_SIZE_Y)
+            matmul_mem_coalescing::<TestJitGpuBackend, f32, 4>(
+                lhs,
+                rhs,
+                out,
+                WORKGROUP_SIZE_X,
+                WORKGROUP_SIZE_Y,
+            )
         };
         let shape_lhs = [batch_1, batch_2, m, k];
         let shape_rhs = [batch_1, batch_2, k, n];
@@ -174,7 +183,8 @@ mod tests {
 
     #[test]
     fn test_matmul_naive_swapped_batches_no_padding() {
-        let matmul_func = |lhs, rhs, out| matmul_mem_coalescing::<f32, 4>(lhs, rhs, out, 2, 2);
+        let matmul_func =
+            |lhs, rhs, out| matmul_mem_coalescing::<TestJitGpuBackend, f32, 4>(lhs, rhs, out, 2, 2);
         let swap = [0, 1];
         let shape_lhs = [3, 2, 4, 4];
         let shape_rhs = [3, 2, 4, 4];
@@ -183,7 +193,8 @@ mod tests {
 
     #[test]
     fn test_matmul_naive_swapped_row_col_no_padding() {
-        let matmul_func = |lhs, rhs, out| matmul_mem_coalescing::<f32, 4>(lhs, rhs, out, 2, 2);
+        let matmul_func =
+            |lhs, rhs, out| matmul_mem_coalescing::<TestJitGpuBackend, f32, 4>(lhs, rhs, out, 2, 2);
         let swap_lhs = [0, 0];
         let swap_rhs = [2, 3];
         let shape_lhs = [3, 2, 4, 4];
@@ -193,7 +204,8 @@ mod tests {
 
     #[test]
     fn test_matmul_naive_swapped_row_with_batch_no_padding() {
-        let matmul_func = |lhs, rhs, out| matmul_mem_coalescing::<f32, 4>(lhs, rhs, out, 2, 2);
+        let matmul_func =
+            |lhs, rhs, out| matmul_mem_coalescing::<TestJitGpuBackend, f32, 4>(lhs, rhs, out, 2, 2);
         let swap_lhs = [0, 3];
         let swap_rhs = [0, 2];
         let shape_lhs = [4, 4, 4, 4];

--- a/burn-wgpu/src/kernel/matmul/mem_coalescing.rs
+++ b/burn-wgpu/src/kernel/matmul/mem_coalescing.rs
@@ -10,6 +10,7 @@ use crate::{
     },
     kernel_wgsl,
     tensor::WgpuTensor,
+    JitGpuBackend,
 };
 
 kernel_wgsl!(
@@ -39,22 +40,22 @@ impl<E: WgpuElement> DynamicKernelSource for MatmulMemCoalescing<E> {
 }
 
 /// Matrix multiplication using memory coalescing algorithm with workgroups of size 16
-pub fn matmul_mem_coalescing_default<E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<E, D>,
-    rhs: WgpuTensor<E, D>,
-    out: WgpuTensor<E, D>,
-) -> WgpuTensor<E, D> {
+pub fn matmul_mem_coalescing_default<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    lhs: WgpuTensor<B, E, D>,
+    rhs: WgpuTensor<B, E, D>,
+    out: WgpuTensor<B, E, D>,
+) -> WgpuTensor<B, E, D> {
     matmul_mem_coalescing::<E, D>(lhs, rhs, out, WORKGROUP_DEFAULT, WORKGROUP_DEFAULT)
 }
 
 /// Matrix multiplication using memory coalescing algorithm with custom workgroup sizes
-pub fn matmul_mem_coalescing<E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<E, D>,
-    rhs: WgpuTensor<E, D>,
-    output: WgpuTensor<E, D>,
+pub fn matmul_mem_coalescing<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    lhs: WgpuTensor<B, E, D>,
+    rhs: WgpuTensor<B, E, D>,
+    output: WgpuTensor<B, E, D>,
     workgroup_size_x: usize,
     workgroup_size_y: usize,
-) -> WgpuTensor<E, D> {
+) -> WgpuTensor<B, E, D> {
     lhs.assert_is_on_same_device(&rhs);
 
     let lhs = into_contiguous(lhs);

--- a/burn-wgpu/src/kernel/matmul/naive.rs
+++ b/burn-wgpu/src/kernel/matmul/naive.rs
@@ -85,7 +85,10 @@ pub fn matmul_naive<
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::kernel::matmul::utils::tests::{same_as_reference, same_as_reference_swapped_dims};
+    use crate::{
+        kernel::matmul::utils::tests::{same_as_reference, same_as_reference_swapped_dims},
+        tests::TestJitGpuBackend,
+    };
 
     #[test]
     pub fn test_matmul_naive_straightforward() {
@@ -139,7 +142,7 @@ mod tests {
         batch_1: usize,
         batch_2: usize,
     ) {
-        let func = matmul_naive::<f32, 4, WORKGROUP_SIZE_X, WORKGROUP_SIZE_Y>;
+        let func = matmul_naive::<TestJitGpuBackend, f32, 4, WORKGROUP_SIZE_X, WORKGROUP_SIZE_Y>;
         let shape_lhs = [batch_1, batch_2, m, k];
         let shape_rhs = [batch_1, batch_2, k, n];
         same_as_reference(func, shape_lhs, shape_rhs);
@@ -147,7 +150,7 @@ mod tests {
 
     #[test]
     fn test_matmul_naive_swapped_batches_no_padding() {
-        let matmul_func = matmul_naive::<f32, 4, 2, 2>;
+        let matmul_func = matmul_naive::<TestJitGpuBackend, f32, 4, 2, 2>;
         let swap = [0, 1];
         let shape_lhs = [3, 2, 4, 4];
         let shape_rhs = [3, 2, 4, 4];
@@ -156,7 +159,7 @@ mod tests {
 
     #[test]
     fn test_matmul_naive_swapped_row_col_no_padding() {
-        let matmul_func = matmul_naive::<f32, 4, 2, 2>;
+        let matmul_func = matmul_naive::<TestJitGpuBackend, f32, 4, 2, 2>;
         let swap_lhs = [0, 0];
         let swap_rhs = [2, 3];
         let shape_lhs = [3, 2, 4, 4];
@@ -166,7 +169,7 @@ mod tests {
 
     #[test]
     fn test_matmul_naive_swapped_row_with_batch_no_padding() {
-        let matmul_func = matmul_naive::<f32, 4, 2, 2>;
+        let matmul_func = matmul_naive::<TestJitGpuBackend, f32, 4, 2, 2>;
         let swap_lhs = [0, 3];
         let swap_rhs = [0, 2];
         let shape_lhs = [4, 4, 4, 4];

--- a/burn-wgpu/src/kernel/matmul/naive.rs
+++ b/burn-wgpu/src/kernel/matmul/naive.rs
@@ -4,7 +4,7 @@ use crate::{
     kernel::{build_info, into_contiguous, KernelSettings, SourceTemplate, StaticKernelSource},
     kernel_wgsl,
     tensor::WgpuTensor,
-    JitRuntime,
+    Runtime,
 };
 
 kernel_wgsl!(MatmulNaiveRaw, "../../template/matmul/naive.wgsl");
@@ -22,26 +22,26 @@ impl<const WORKGROUP_SIZE_X: usize, const WORKGROUP_SIZE_Y: usize> StaticKernelS
 }
 
 /// Matrix multiplication using naive algorithm with workgroups of size 16
-pub fn matmul_naive_default<B: JitRuntime, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<B, E, D>,
-    rhs: WgpuTensor<B, E, D>,
-    output: WgpuTensor<B, E, D>,
-) -> WgpuTensor<B, E, D> {
-    matmul_naive::<B, E, D, 16, 16>(lhs, rhs, output)
+pub fn matmul_naive_default<R: Runtime, E: WgpuElement, const D: usize>(
+    lhs: WgpuTensor<R, E, D>,
+    rhs: WgpuTensor<R, E, D>,
+    output: WgpuTensor<R, E, D>,
+) -> WgpuTensor<R, E, D> {
+    matmul_naive::<R, E, D, 16, 16>(lhs, rhs, output)
 }
 
 /// Matrix multiplication using naive algorithm with custom workgroup sizes
 pub fn matmul_naive<
-    B: JitRuntime,
+    R: Runtime,
     E: WgpuElement,
     const D: usize,
     const WORKGROUP_SIZE_X: usize,
     const WORKGROUP_SIZE_Y: usize,
 >(
-    lhs: WgpuTensor<B, E, D>,
-    rhs: WgpuTensor<B, E, D>,
-    output: WgpuTensor<B, E, D>,
-) -> WgpuTensor<B, E, D> {
+    lhs: WgpuTensor<R, E, D>,
+    rhs: WgpuTensor<R, E, D>,
+    output: WgpuTensor<R, E, D>,
+) -> WgpuTensor<R, E, D> {
     lhs.assert_is_on_same_device(&rhs);
 
     let lhs = into_contiguous(lhs);

--- a/burn-wgpu/src/kernel/matmul/naive.rs
+++ b/burn-wgpu/src/kernel/matmul/naive.rs
@@ -4,6 +4,7 @@ use crate::{
     kernel::{build_info, into_contiguous, KernelSettings, SourceTemplate, StaticKernelSource},
     kernel_wgsl,
     tensor::WgpuTensor,
+    JitGpuBackend,
 };
 
 kernel_wgsl!(MatmulNaiveRaw, "../../template/matmul/naive.wgsl");
@@ -21,25 +22,26 @@ impl<const WORKGROUP_SIZE_X: usize, const WORKGROUP_SIZE_Y: usize> StaticKernelS
 }
 
 /// Matrix multiplication using naive algorithm with workgroups of size 16
-pub fn matmul_naive_default<E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<E, D>,
-    rhs: WgpuTensor<E, D>,
-    output: WgpuTensor<E, D>,
-) -> WgpuTensor<E, D> {
-    matmul_naive::<E, D, 16, 16>(lhs, rhs, output)
+pub fn matmul_naive_default<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    lhs: WgpuTensor<B, E, D>,
+    rhs: WgpuTensor<B, E, D>,
+    output: WgpuTensor<B, E, D>,
+) -> WgpuTensor<B, E, D> {
+    matmul_naive::<B, E, D, 16, 16>(lhs, rhs, output)
 }
 
 /// Matrix multiplication using naive algorithm with custom workgroup sizes
 pub fn matmul_naive<
+    B: JitGpuBackend,
     E: WgpuElement,
     const D: usize,
     const WORKGROUP_SIZE_X: usize,
     const WORKGROUP_SIZE_Y: usize,
 >(
-    lhs: WgpuTensor<E, D>,
-    rhs: WgpuTensor<E, D>,
-    output: WgpuTensor<E, D>,
-) -> WgpuTensor<E, D> {
+    lhs: WgpuTensor<B, E, D>,
+    rhs: WgpuTensor<B, E, D>,
+    output: WgpuTensor<B, E, D>,
+) -> WgpuTensor<B, E, D> {
     lhs.assert_is_on_same_device(&rhs);
 
     let lhs = into_contiguous(lhs);

--- a/burn-wgpu/src/kernel/matmul/naive.rs
+++ b/burn-wgpu/src/kernel/matmul/naive.rs
@@ -4,7 +4,7 @@ use crate::{
     kernel::{build_info, into_contiguous, KernelSettings, SourceTemplate, StaticKernelSource},
     kernel_wgsl,
     tensor::WgpuTensor,
-    JitGpuBackend,
+    JitRuntime,
 };
 
 kernel_wgsl!(MatmulNaiveRaw, "../../template/matmul/naive.wgsl");
@@ -22,7 +22,7 @@ impl<const WORKGROUP_SIZE_X: usize, const WORKGROUP_SIZE_Y: usize> StaticKernelS
 }
 
 /// Matrix multiplication using naive algorithm with workgroups of size 16
-pub fn matmul_naive_default<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn matmul_naive_default<B: JitRuntime, E: WgpuElement, const D: usize>(
     lhs: WgpuTensor<B, E, D>,
     rhs: WgpuTensor<B, E, D>,
     output: WgpuTensor<B, E, D>,
@@ -32,7 +32,7 @@ pub fn matmul_naive_default<B: JitGpuBackend, E: WgpuElement, const D: usize>(
 
 /// Matrix multiplication using naive algorithm with custom workgroup sizes
 pub fn matmul_naive<
-    B: JitGpuBackend,
+    B: JitRuntime,
     E: WgpuElement,
     const D: usize,
     const WORKGROUP_SIZE_X: usize,
@@ -87,7 +87,7 @@ mod tests {
     use super::*;
     use crate::{
         kernel::matmul::utils::tests::{same_as_reference, same_as_reference_swapped_dims},
-        tests::TestJitGpuBackend,
+        tests::TestJitRuntime,
     };
 
     #[test]
@@ -142,7 +142,7 @@ mod tests {
         batch_1: usize,
         batch_2: usize,
     ) {
-        let func = matmul_naive::<TestJitGpuBackend, f32, 4, WORKGROUP_SIZE_X, WORKGROUP_SIZE_Y>;
+        let func = matmul_naive::<TestJitRuntime, f32, 4, WORKGROUP_SIZE_X, WORKGROUP_SIZE_Y>;
         let shape_lhs = [batch_1, batch_2, m, k];
         let shape_rhs = [batch_1, batch_2, k, n];
         same_as_reference(func, shape_lhs, shape_rhs);
@@ -150,7 +150,7 @@ mod tests {
 
     #[test]
     fn test_matmul_naive_swapped_batches_no_padding() {
-        let matmul_func = matmul_naive::<TestJitGpuBackend, f32, 4, 2, 2>;
+        let matmul_func = matmul_naive::<TestJitRuntime, f32, 4, 2, 2>;
         let swap = [0, 1];
         let shape_lhs = [3, 2, 4, 4];
         let shape_rhs = [3, 2, 4, 4];
@@ -159,7 +159,7 @@ mod tests {
 
     #[test]
     fn test_matmul_naive_swapped_row_col_no_padding() {
-        let matmul_func = matmul_naive::<TestJitGpuBackend, f32, 4, 2, 2>;
+        let matmul_func = matmul_naive::<TestJitRuntime, f32, 4, 2, 2>;
         let swap_lhs = [0, 0];
         let swap_rhs = [2, 3];
         let shape_lhs = [3, 2, 4, 4];
@@ -169,7 +169,7 @@ mod tests {
 
     #[test]
     fn test_matmul_naive_swapped_row_with_batch_no_padding() {
-        let matmul_func = matmul_naive::<TestJitGpuBackend, f32, 4, 2, 2>;
+        let matmul_func = matmul_naive::<TestJitRuntime, f32, 4, 2, 2>;
         let swap_lhs = [0, 3];
         let swap_rhs = [0, 2];
         let shape_lhs = [4, 4, 4, 4];

--- a/burn-wgpu/src/kernel/matmul/tiling2d/base.rs
+++ b/burn-wgpu/src/kernel/matmul/tiling2d/base.rs
@@ -1,6 +1,5 @@
 use super::padding::{crop, pad_round, PaddingOutput};
 use crate::{
-    codegen::Compiler,
     compute::{DynamicKernel, WorkGroup},
     element::WgpuElement,
     kernel::{build_info, into_contiguous, matmul::utils::shape_out, DynamicKernelSource},

--- a/burn-wgpu/src/kernel/matmul/tiling2d/base.rs
+++ b/burn-wgpu/src/kernel/matmul/tiling2d/base.rs
@@ -5,7 +5,7 @@ use crate::{
     kernel::{build_info, into_contiguous, matmul::utils::shape_out, DynamicKernelSource},
     ops::numeric::empty_device,
     tensor::WgpuTensor,
-    JitRuntime,
+    Runtime,
 };
 use burn_compute::server::Handle;
 use burn_tensor::Shape;
@@ -26,39 +26,39 @@ pub(super) fn make_workgroup<const D: usize>(output_shape: &Shape<D>) -> WorkGro
     WorkGroup::new(num_blocks_x, num_blocks_y, num_blocks_z as u32)
 }
 
-pub(super) fn make_info_handle<B: JitRuntime, E: WgpuElement, const D: usize>(
-    lhs: &WgpuTensor<B, E, D>,
-    rhs: &WgpuTensor<B, E, D>,
-    output: &WgpuTensor<B, E, D>,
-) -> Handle<B::Server> {
+pub(super) fn make_info_handle<R: Runtime, E: WgpuElement, const D: usize>(
+    lhs: &WgpuTensor<R, E, D>,
+    rhs: &WgpuTensor<R, E, D>,
+    output: &WgpuTensor<R, E, D>,
+) -> Handle<R::Server> {
     let info = build_info(&[lhs, rhs, output]);
     rhs.client.create(bytemuck::cast_slice(&info))
 }
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn matmul_tiling_2d_launch<
-    B: JitRuntime,
+    R: Runtime,
     E: WgpuElement,
     const D: usize,
     K: DynamicKernelSource + 'static,
 >(
-    lhs: WgpuTensor<B, E, D>,
-    rhs: WgpuTensor<B, E, D>,
-    output: WgpuTensor<B, E, D>,
+    lhs: WgpuTensor<R, E, D>,
+    rhs: WgpuTensor<R, E, D>,
+    output: WgpuTensor<R, E, D>,
     kernel: K,
-) -> WgpuTensor<B, E, D> {
+) -> WgpuTensor<R, E, D> {
     // A tensor may need to be padded, in which case it will implicitly become contiguous
     // If not needed, it is only turned into contiguous if some batch dim has been swapped with row or col dim.
     // If batches were swapped among themselves, or if the last two dims are transposed, the underlying
     // kernel handles it without needing to turn it into contiguous.
-    let round_lhs = pad_round::<B, E, D>(lhs, B_M, B_K);
+    let round_lhs = pad_round::<R, E, D>(lhs, B_M, B_K);
     let lhs = match round_lhs {
         PaddingOutput::Unchanged(tensor) if tensor.batch_swapped_with_row_col() => {
             into_contiguous(tensor)
         }
         _ => round_lhs.into_tensor(),
     };
-    let round_rhs = pad_round::<B, E, D>(rhs, B_K, B_N);
+    let round_rhs = pad_round::<R, E, D>(rhs, B_K, B_N);
     let rhs = match round_rhs {
         PaddingOutput::Unchanged(tensor) if tensor.batch_swapped_with_row_col() => {
             into_contiguous(tensor)

--- a/burn-wgpu/src/kernel/matmul/tiling2d/base.rs
+++ b/burn-wgpu/src/kernel/matmul/tiling2d/base.rs
@@ -5,7 +5,7 @@ use crate::{
     kernel::{build_info, into_contiguous, matmul::utils::shape_out, DynamicKernelSource},
     ops::numeric::empty_device,
     tensor::WgpuTensor,
-    JitGpuBackend,
+    JitRuntime,
 };
 use burn_compute::server::Handle;
 use burn_tensor::Shape;
@@ -26,7 +26,7 @@ pub(super) fn make_workgroup<const D: usize>(output_shape: &Shape<D>) -> WorkGro
     WorkGroup::new(num_blocks_x, num_blocks_y, num_blocks_z as u32)
 }
 
-pub(super) fn make_info_handle<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub(super) fn make_info_handle<B: JitRuntime, E: WgpuElement, const D: usize>(
     lhs: &WgpuTensor<B, E, D>,
     rhs: &WgpuTensor<B, E, D>,
     output: &WgpuTensor<B, E, D>,
@@ -37,7 +37,7 @@ pub(super) fn make_info_handle<B: JitGpuBackend, E: WgpuElement, const D: usize>
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn matmul_tiling_2d_launch<
-    B: JitGpuBackend,
+    B: JitRuntime,
     E: WgpuElement,
     const D: usize,
     K: DynamicKernelSource + 'static,

--- a/burn-wgpu/src/kernel/matmul/tiling2d/padding.rs
+++ b/burn-wgpu/src/kernel/matmul/tiling2d/padding.rs
@@ -3,21 +3,21 @@ use std::ops::Range;
 use burn_tensor::{Element, Shape};
 
 use crate::{
-    element::WgpuElement,
+    element::JitElement,
     kernel::{slice_assign, slice_on_output},
     ops::numeric::zeros_device,
-    tensor::WgpuTensor,
+    tensor::JitTensor,
     Runtime,
 };
 
 // Output of the pad_round function. Allows to know explicitly if early return occurred
-pub(super) enum PaddingOutput<R: Runtime, E: WgpuElement, const D: usize> {
-    Padded(WgpuTensor<R, E, D>),
-    Unchanged(WgpuTensor<R, E, D>),
+pub(super) enum PaddingOutput<R: Runtime, E: JitElement, const D: usize> {
+    Padded(JitTensor<R, E, D>),
+    Unchanged(JitTensor<R, E, D>),
 }
 
-impl<R: Runtime, E: WgpuElement, const D: usize> PaddingOutput<R, E, D> {
-    pub fn into_tensor(self) -> WgpuTensor<R, E, D> {
+impl<R: Runtime, E: JitElement, const D: usize> PaddingOutput<R, E, D> {
+    pub fn into_tensor(self) -> JitTensor<R, E, D> {
         match self {
             PaddingOutput::Padded(tensor) => tensor,
             PaddingOutput::Unchanged(tensor) => tensor,
@@ -29,8 +29,8 @@ impl<R: Runtime, E: WgpuElement, const D: usize> PaddingOutput<R, E, D> {
 /// divisible by some quantity.
 /// For instance tensor of shape [1000, 1000] with divisors 64 and 64
 /// will be padded to [1024, 1024] with the last 24 elements being zeros
-pub(super) fn pad_round<R: Runtime, E: WgpuElement, const D: usize>(
-    tensor: WgpuTensor<R, E, D>,
+pub(super) fn pad_round<R: Runtime, E: JitElement, const D: usize>(
+    tensor: JitTensor<R, E, D>,
     row_divisor: usize,
     col_divisor: usize,
 ) -> PaddingOutput<R, E, D> {
@@ -62,10 +62,10 @@ pub(super) fn pad_round<R: Runtime, E: WgpuElement, const D: usize>(
 }
 
 /// Pads tensor by adding zeros when padded dim is larger than tensor dim
-fn padding<R: Runtime, E: WgpuElement + Element, const D: usize>(
-    tensor: WgpuTensor<R, E, D>,
+fn padding<R: Runtime, E: JitElement + Element, const D: usize>(
+    tensor: JitTensor<R, E, D>,
     padded_shape: Shape<D>,
-) -> WgpuTensor<R, E, D> {
+) -> JitTensor<R, E, D> {
     let ranges = padded_shape
         .dims
         .iter()
@@ -82,10 +82,10 @@ fn padding<R: Runtime, E: WgpuElement + Element, const D: usize>(
 }
 
 /// Crops tensor by deleting values when cropped dim is smaller than tensor dim
-pub(super) fn crop<R: Runtime, E: WgpuElement, const D: usize>(
-    tensor: WgpuTensor<R, E, D>,
-    output: WgpuTensor<R, E, D>,
-) -> WgpuTensor<R, E, D> {
+pub(super) fn crop<R: Runtime, E: JitElement, const D: usize>(
+    tensor: JitTensor<R, E, D>,
+    output: JitTensor<R, E, D>,
+) -> JitTensor<R, E, D> {
     let ranges = output
         .shape
         .dims

--- a/burn-wgpu/src/kernel/matmul/tiling2d/padding.rs
+++ b/burn-wgpu/src/kernel/matmul/tiling2d/padding.rs
@@ -94,7 +94,7 @@ pub(super) fn crop<B: JitGpuBackend, E: WgpuElement, const D: usize>(
         .collect::<Vec<Range<usize>>>()
         .try_into()
         .unwrap();
-    slice_on_output::<E, D, D>(tensor, output, ranges)
+    slice_on_output::<B, E, D, D>(tensor, output, ranges)
 }
 
 #[cfg(test)]
@@ -116,9 +116,7 @@ mod tests {
         );
         let expected_shape = [row, col].into();
 
-        let padded =
-            pad_round::<TestCompiler, _, 2>(tensor.into_primitive(), row_divisor, col_divisor)
-                .into_tensor();
+        let padded = pad_round(tensor.into_primitive(), row_divisor, col_divisor).into_tensor();
 
         assert!(padded.shape == expected_shape);
     }
@@ -135,11 +133,7 @@ mod tests {
             &Default::default(),
         );
 
-        let padded = pad_round::<TestCompiler, _, 2>(
-            tensor.clone().into_primitive(),
-            row_divisor,
-            col_divisor,
-        );
+        let padded = pad_round(tensor.clone().into_primitive(), row_divisor, col_divisor);
 
         let padded = TestTensor::from_primitive(padded.into_tensor());
         padded.into_data().assert_approx_eq(&tensor.into_data(), 3);
@@ -158,9 +152,7 @@ mod tests {
         );
         let expected_shape = [12, 15].into();
 
-        let padded =
-            pad_round::<TestCompiler, _, 2>(tensor.into_primitive(), row_divisor, col_divisor)
-                .into_tensor();
+        let padded = pad_round(tensor.into_primitive(), row_divisor, col_divisor).into_tensor();
 
         assert!(padded.shape == expected_shape);
     }
@@ -177,12 +169,8 @@ mod tests {
             &Default::default(),
         );
 
-        let padded = pad_round::<TestCompiler, _, 2>(
-            tensor.clone().into_primitive(),
-            row_divisor,
-            col_divisor,
-        )
-        .into_tensor();
+        let padded =
+            pad_round(tensor.clone().into_primitive(), row_divisor, col_divisor).into_tensor();
 
         let padded = TestTensor::from_primitive(padded).to_data();
         let tensor = tensor.into_data();
@@ -205,9 +193,7 @@ mod tests {
             &Default::default(),
         );
 
-        let padded =
-            pad_round::<TestCompiler, _, 2>(tensor.into_primitive(), row_divisor, col_divisor)
-                .into_tensor();
+        let padded = pad_round(tensor.into_primitive(), row_divisor, col_divisor).into_tensor();
         let padded = TestTensor::from_primitive(padded).to_data();
 
         // check right of matrix
@@ -237,9 +223,7 @@ mod tests {
         );
         let expected_shape = [2, 3, 12, 15].into();
 
-        let padded =
-            pad_round::<TestCompiler, _, 4>(tensor.into_primitive(), row_divisor, col_divisor)
-                .into_tensor();
+        let padded = pad_round(tensor.into_primitive(), row_divisor, col_divisor).into_tensor();
 
         assert!(padded.shape == expected_shape);
     }
@@ -257,9 +241,7 @@ mod tests {
         );
         let expected_shape = [row_divisor, 2 * col_divisor].into();
 
-        let padded =
-            pad_round::<TestCompiler, _, 2>(tensor.into_primitive(), row_divisor, col_divisor)
-                .into_tensor();
+        let padded = pad_round(tensor.into_primitive(), row_divisor, col_divisor).into_tensor();
 
         assert!(padded.shape == expected_shape);
     }
@@ -277,9 +259,7 @@ mod tests {
         );
         let expected_shape = [32, 64].into();
 
-        let padded =
-            pad_round::<TestCompiler, _, 2>(tensor.into_primitive(), row_divisor, col_divisor)
-                .into_tensor();
+        let padded = pad_round(tensor.into_primitive(), row_divisor, col_divisor).into_tensor();
 
         assert!(padded.shape == expected_shape);
     }

--- a/burn-wgpu/src/kernel/matmul/tiling2d/padding.rs
+++ b/burn-wgpu/src/kernel/matmul/tiling2d/padding.rs
@@ -7,16 +7,16 @@ use crate::{
     kernel::{slice_assign, slice_on_output},
     ops::numeric::zeros_device,
     tensor::WgpuTensor,
-    JitGpuBackend,
+    JitRuntime,
 };
 
 // Output of the pad_round function. Allows to know explicitly if early return occurred
-pub(super) enum PaddingOutput<B: JitGpuBackend, E: WgpuElement, const D: usize> {
+pub(super) enum PaddingOutput<B: JitRuntime, E: WgpuElement, const D: usize> {
     Padded(WgpuTensor<B, E, D>),
     Unchanged(WgpuTensor<B, E, D>),
 }
 
-impl<B: JitGpuBackend, E: WgpuElement, const D: usize> PaddingOutput<B, E, D> {
+impl<B: JitRuntime, E: WgpuElement, const D: usize> PaddingOutput<B, E, D> {
     pub fn into_tensor(self) -> WgpuTensor<B, E, D> {
         match self {
             PaddingOutput::Padded(tensor) => tensor,
@@ -29,7 +29,7 @@ impl<B: JitGpuBackend, E: WgpuElement, const D: usize> PaddingOutput<B, E, D> {
 /// divisible by some quantity.
 /// For instance tensor of shape [1000, 1000] with divisors 64 and 64
 /// will be padded to [1024, 1024] with the last 24 elements being zeros
-pub(super) fn pad_round<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub(super) fn pad_round<B: JitRuntime, E: WgpuElement, const D: usize>(
     tensor: WgpuTensor<B, E, D>,
     row_divisor: usize,
     col_divisor: usize,
@@ -62,7 +62,7 @@ pub(super) fn pad_round<B: JitGpuBackend, E: WgpuElement, const D: usize>(
 }
 
 /// Pads tensor by adding zeros when padded dim is larger than tensor dim
-fn padding<B: JitGpuBackend, E: WgpuElement + Element, const D: usize>(
+fn padding<B: JitRuntime, E: WgpuElement + Element, const D: usize>(
     tensor: WgpuTensor<B, E, D>,
     padded_shape: Shape<D>,
 ) -> WgpuTensor<B, E, D> {
@@ -82,7 +82,7 @@ fn padding<B: JitGpuBackend, E: WgpuElement + Element, const D: usize>(
 }
 
 /// Crops tensor by deleting values when cropped dim is smaller than tensor dim
-pub(super) fn crop<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub(super) fn crop<B: JitRuntime, E: WgpuElement, const D: usize>(
     tensor: WgpuTensor<B, E, D>,
     output: WgpuTensor<B, E, D>,
 ) -> WgpuTensor<B, E, D> {

--- a/burn-wgpu/src/kernel/matmul/tiling2d/padding.rs
+++ b/burn-wgpu/src/kernel/matmul/tiling2d/padding.rs
@@ -101,7 +101,7 @@ pub(super) fn crop<B: JitGpuBackend, E: WgpuElement, const D: usize>(
 mod tests {
 
     use super::*;
-    use crate::tests::{TestCompiler, TestTensor};
+    use crate::tests::TestTensor;
 
     #[test]
     fn padding_already_round_should_have_same_shape() {

--- a/burn-wgpu/src/kernel/matmul/tiling2d/unpadded.rs
+++ b/burn-wgpu/src/kernel/matmul/tiling2d/unpadded.rs
@@ -5,7 +5,7 @@ use crate::{
     element::WgpuElement,
     kernel::{into_contiguous, DynamicKernelSource, SourceTemplate, StaticKernelSource},
     tensor::WgpuTensor,
-    JitGpuBackend,
+    JitRuntime,
 };
 use std::marker::PhantomData;
 
@@ -45,7 +45,7 @@ impl<E: WgpuElement> DynamicKernelSource for MatmulTiling2DUnpadded<E> {
 
 /// Matrix multiplication using tiling 2d algorithm with
 /// vec4 primitive on both lhs and rhs, with no padding needed
-pub fn matmul_tiling_2d_unpadded<B: JitGpuBackend, E: WgpuElement + Element, const D: usize>(
+pub fn matmul_tiling_2d_unpadded<B: JitRuntime, E: WgpuElement + Element, const D: usize>(
     lhs: WgpuTensor<B, E, D>,
     rhs: WgpuTensor<B, E, D>,
     out: WgpuTensor<B, E, D>,

--- a/burn-wgpu/src/kernel/matmul/tiling2d/unpadded.rs
+++ b/burn-wgpu/src/kernel/matmul/tiling2d/unpadded.rs
@@ -2,9 +2,9 @@ use burn_tensor::Element;
 
 use crate::{
     compute::DynamicKernel,
-    element::WgpuElement,
+    element::JitElement,
     kernel::{into_contiguous, DynamicKernelSource, SourceTemplate, StaticKernelSource},
-    tensor::WgpuTensor,
+    tensor::JitTensor,
     Runtime,
 };
 use std::marker::PhantomData;
@@ -19,11 +19,11 @@ kernel_wgsl!(
 );
 
 #[derive(new, Debug)]
-struct MatmulTiling2DUnpadded<E: WgpuElement> {
+struct MatmulTiling2DUnpadded<E: JitElement> {
     _elem: PhantomData<E>,
 }
 
-impl<E: WgpuElement> DynamicKernelSource for MatmulTiling2DUnpadded<E> {
+impl<E: JitElement> DynamicKernelSource for MatmulTiling2DUnpadded<E> {
     fn source(&self) -> SourceTemplate {
         MatmulTiling2DUnpaddedRaw::source()
             .register("b_m", B_M.to_string())
@@ -45,11 +45,11 @@ impl<E: WgpuElement> DynamicKernelSource for MatmulTiling2DUnpadded<E> {
 
 /// Matrix multiplication using tiling 2d algorithm with
 /// vec4 primitive on both lhs and rhs, with no padding needed
-pub fn matmul_tiling_2d_unpadded<R: Runtime, E: WgpuElement + Element, const D: usize>(
-    lhs: WgpuTensor<R, E, D>,
-    rhs: WgpuTensor<R, E, D>,
-    out: WgpuTensor<R, E, D>,
-) -> WgpuTensor<R, E, D> {
+pub fn matmul_tiling_2d_unpadded<R: Runtime, E: JitElement + Element, const D: usize>(
+    lhs: JitTensor<R, E, D>,
+    rhs: JitTensor<R, E, D>,
+    out: JitTensor<R, E, D>,
+) -> JitTensor<R, E, D> {
     let lhs = match lhs.batch_swapped_with_row_col() {
         true => into_contiguous(lhs),
         false => lhs,

--- a/burn-wgpu/src/kernel/matmul/tiling2d/unpadded.rs
+++ b/burn-wgpu/src/kernel/matmul/tiling2d/unpadded.rs
@@ -5,7 +5,7 @@ use crate::{
     element::WgpuElement,
     kernel::{into_contiguous, DynamicKernelSource, SourceTemplate, StaticKernelSource},
     tensor::WgpuTensor,
-    JitRuntime,
+    Runtime,
 };
 use std::marker::PhantomData;
 
@@ -45,11 +45,11 @@ impl<E: WgpuElement> DynamicKernelSource for MatmulTiling2DUnpadded<E> {
 
 /// Matrix multiplication using tiling 2d algorithm with
 /// vec4 primitive on both lhs and rhs, with no padding needed
-pub fn matmul_tiling_2d_unpadded<B: JitRuntime, E: WgpuElement + Element, const D: usize>(
-    lhs: WgpuTensor<B, E, D>,
-    rhs: WgpuTensor<B, E, D>,
-    out: WgpuTensor<B, E, D>,
-) -> WgpuTensor<B, E, D> {
+pub fn matmul_tiling_2d_unpadded<R: Runtime, E: WgpuElement + Element, const D: usize>(
+    lhs: WgpuTensor<R, E, D>,
+    rhs: WgpuTensor<R, E, D>,
+    out: WgpuTensor<R, E, D>,
+) -> WgpuTensor<R, E, D> {
     let lhs = match lhs.batch_swapped_with_row_col() {
         true => into_contiguous(lhs),
         false => lhs,

--- a/burn-wgpu/src/kernel/matmul/tiling2d/unpadded.rs
+++ b/burn-wgpu/src/kernel/matmul/tiling2d/unpadded.rs
@@ -5,6 +5,7 @@ use crate::{
     element::WgpuElement,
     kernel::{into_contiguous, DynamicKernelSource, SourceTemplate, StaticKernelSource},
     tensor::WgpuTensor,
+    JitGpuBackend,
 };
 use std::marker::PhantomData;
 
@@ -44,11 +45,11 @@ impl<E: WgpuElement> DynamicKernelSource for MatmulTiling2DUnpadded<E> {
 
 /// Matrix multiplication using tiling 2d algorithm with
 /// vec4 primitive on both lhs and rhs, with no padding needed
-pub fn matmul_tiling_2d_unpadded<E: WgpuElement + Element, const D: usize>(
-    lhs: WgpuTensor<E, D>,
-    rhs: WgpuTensor<E, D>,
-    out: WgpuTensor<E, D>,
-) -> WgpuTensor<E, D> {
+pub fn matmul_tiling_2d_unpadded<B: JitGpuBackend, E: WgpuElement + Element, const D: usize>(
+    lhs: WgpuTensor<B, E, D>,
+    rhs: WgpuTensor<B, E, D>,
+    out: WgpuTensor<B, E, D>,
+) -> WgpuTensor<B, E, D> {
     let lhs = match lhs.batch_swapped_with_row_col() {
         true => into_contiguous(lhs),
         false => lhs,

--- a/burn-wgpu/src/kernel/matmul/tiling2d/vec4.rs
+++ b/burn-wgpu/src/kernel/matmul/tiling2d/vec4.rs
@@ -1,8 +1,8 @@
 use super::base::{matmul_tiling_2d_launch, B_K, B_M, B_N, WORKGROUP_SIZE};
 use crate::{
-    element::WgpuElement,
+    element::JitElement,
     kernel::{DynamicKernelSource, SourceTemplate, StaticKernelSource},
-    tensor::WgpuTensor,
+    tensor::JitTensor,
 };
 use crate::{kernel_wgsl, Runtime};
 use std::marker::PhantomData;
@@ -13,11 +13,11 @@ kernel_wgsl!(
 );
 
 #[derive(new, Debug)]
-struct MatmulTiling2Dvec4<E: WgpuElement> {
+struct MatmulTiling2Dvec4<E: JitElement> {
     _elem: PhantomData<E>,
 }
 
-impl<E: WgpuElement> DynamicKernelSource for MatmulTiling2Dvec4<E> {
+impl<E: JitElement> DynamicKernelSource for MatmulTiling2Dvec4<E> {
     fn source(&self) -> SourceTemplate {
         MatmulTiling2Dvec4Raw::source()
             .register("b_m", B_M.to_string())
@@ -39,11 +39,11 @@ impl<E: WgpuElement> DynamicKernelSource for MatmulTiling2Dvec4<E> {
 
 /// Matrix multiplication using tiling 2d algorithm with
 /// vec4 primitive on both lhs and rhs
-pub fn matmul_tiling_2d_vec4<R: Runtime, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<R, E, D>,
-    rhs: WgpuTensor<R, E, D>,
-    out: WgpuTensor<R, E, D>,
-) -> WgpuTensor<R, E, D> {
+pub fn matmul_tiling_2d_vec4<R: Runtime, E: JitElement, const D: usize>(
+    lhs: JitTensor<R, E, D>,
+    rhs: JitTensor<R, E, D>,
+    out: JitTensor<R, E, D>,
+) -> JitTensor<R, E, D> {
     let kernel = MatmulTiling2Dvec4::<E>::new();
     // TODO: don't hardcode the compiler.
     matmul_tiling_2d_launch::<R, _, D, _>(lhs, rhs, out, kernel)

--- a/burn-wgpu/src/kernel/matmul/tiling2d/vec4.rs
+++ b/burn-wgpu/src/kernel/matmul/tiling2d/vec4.rs
@@ -4,7 +4,7 @@ use crate::{
     kernel::{DynamicKernelSource, SourceTemplate, StaticKernelSource},
     tensor::WgpuTensor,
 };
-use crate::{kernel_wgsl, JitRuntime};
+use crate::{kernel_wgsl, Runtime};
 use std::marker::PhantomData;
 
 kernel_wgsl!(
@@ -39,14 +39,14 @@ impl<E: WgpuElement> DynamicKernelSource for MatmulTiling2Dvec4<E> {
 
 /// Matrix multiplication using tiling 2d algorithm with
 /// vec4 primitive on both lhs and rhs
-pub fn matmul_tiling_2d_vec4<B: JitRuntime, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<B, E, D>,
-    rhs: WgpuTensor<B, E, D>,
-    out: WgpuTensor<B, E, D>,
-) -> WgpuTensor<B, E, D> {
+pub fn matmul_tiling_2d_vec4<R: Runtime, E: WgpuElement, const D: usize>(
+    lhs: WgpuTensor<R, E, D>,
+    rhs: WgpuTensor<R, E, D>,
+    out: WgpuTensor<R, E, D>,
+) -> WgpuTensor<R, E, D> {
     let kernel = MatmulTiling2Dvec4::<E>::new();
     // TODO: don't hardcode the compiler.
-    matmul_tiling_2d_launch::<B, _, D, _>(lhs, rhs, out, kernel)
+    matmul_tiling_2d_launch::<R, _, D, _>(lhs, rhs, out, kernel)
 }
 
 #[cfg(test)]

--- a/burn-wgpu/src/kernel/matmul/tiling2d/vec4.rs
+++ b/burn-wgpu/src/kernel/matmul/tiling2d/vec4.rs
@@ -4,7 +4,7 @@ use crate::{
     kernel::{DynamicKernelSource, SourceTemplate, StaticKernelSource},
     tensor::WgpuTensor,
 };
-use crate::{kernel_wgsl, JitGpuBackend};
+use crate::{kernel_wgsl, JitRuntime};
 use std::marker::PhantomData;
 
 kernel_wgsl!(
@@ -39,7 +39,7 @@ impl<E: WgpuElement> DynamicKernelSource for MatmulTiling2Dvec4<E> {
 
 /// Matrix multiplication using tiling 2d algorithm with
 /// vec4 primitive on both lhs and rhs
-pub fn matmul_tiling_2d_vec4<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn matmul_tiling_2d_vec4<B: JitRuntime, E: WgpuElement, const D: usize>(
     lhs: WgpuTensor<B, E, D>,
     rhs: WgpuTensor<B, E, D>,
     out: WgpuTensor<B, E, D>,

--- a/burn-wgpu/src/kernel/matmul/tiling2d/vec4.rs
+++ b/burn-wgpu/src/kernel/matmul/tiling2d/vec4.rs
@@ -1,6 +1,5 @@
 use super::base::{matmul_tiling_2d_launch, B_K, B_M, B_N, WORKGROUP_SIZE};
 use crate::{
-    codegen::dialect::wgsl,
     element::WgpuElement,
     kernel::{DynamicKernelSource, SourceTemplate, StaticKernelSource},
     tensor::WgpuTensor,

--- a/burn-wgpu/src/kernel/matmul/tiling2d/vec4.rs
+++ b/burn-wgpu/src/kernel/matmul/tiling2d/vec4.rs
@@ -1,11 +1,11 @@
 use super::base::{matmul_tiling_2d_launch, B_K, B_M, B_N, WORKGROUP_SIZE};
-use crate::kernel_wgsl;
 use crate::{
     codegen::dialect::wgsl,
     element::WgpuElement,
     kernel::{DynamicKernelSource, SourceTemplate, StaticKernelSource},
     tensor::WgpuTensor,
 };
+use crate::{kernel_wgsl, JitGpuBackend};
 use std::marker::PhantomData;
 
 kernel_wgsl!(
@@ -40,14 +40,14 @@ impl<E: WgpuElement> DynamicKernelSource for MatmulTiling2Dvec4<E> {
 
 /// Matrix multiplication using tiling 2d algorithm with
 /// vec4 primitive on both lhs and rhs
-pub fn matmul_tiling_2d_vec4<E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<E, D>,
-    rhs: WgpuTensor<E, D>,
-    out: WgpuTensor<E, D>,
-) -> WgpuTensor<E, D> {
+pub fn matmul_tiling_2d_vec4<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    lhs: WgpuTensor<B, E, D>,
+    rhs: WgpuTensor<B, E, D>,
+    out: WgpuTensor<B, E, D>,
+) -> WgpuTensor<B, E, D> {
     let kernel = MatmulTiling2Dvec4::<E>::new();
     // TODO: don't hardcode the compiler.
-    matmul_tiling_2d_launch::<wgsl::Compiler<f32, i32>, _, D, _>(lhs, rhs, out, kernel)
+    matmul_tiling_2d_launch::<B, _, D, _>(lhs, rhs, out, kernel)
 }
 
 #[cfg(test)]

--- a/burn-wgpu/src/kernel/matmul/tiling2d/vec4_lhs.rs
+++ b/burn-wgpu/src/kernel/matmul/tiling2d/vec4_lhs.rs
@@ -5,6 +5,7 @@ use crate::{
     element::WgpuElement,
     kernel::{DynamicKernelSource, SourceTemplate, StaticKernelSource},
     tensor::WgpuTensor,
+    JitGpuBackend,
 };
 use std::marker::PhantomData;
 
@@ -44,14 +45,13 @@ impl<E: WgpuElement> DynamicKernelSource for MatmulTiling2DVec4Lhs<E> {
 
 /// Matrix multiplication using tiling 2d algorithm with
 /// vec4 primitive on lhs only
-pub fn matmul_tiling_2d_vec4_lhs<E: WgpuElement + Element, const D: usize>(
-    lhs: WgpuTensor<E, D>,
-    rhs: WgpuTensor<E, D>,
-    out: WgpuTensor<E, D>,
-) -> WgpuTensor<E, D> {
+pub fn matmul_tiling_2d_vec4_lhs<B: JitGpuBackend, E: WgpuElement + Element, const D: usize>(
+    lhs: WgpuTensor<B, E, D>,
+    rhs: WgpuTensor<B, E, D>,
+    out: WgpuTensor<B, E, D>,
+) -> WgpuTensor<B, E, D> {
     let kernel = MatmulTiling2DVec4Lhs::<E>::new();
-    // TODO: don't hardcode the compiler.
-    matmul_tiling_2d_launch::<wgsl::Compiler<f32, i32>, _, D, _>(lhs, rhs, out, kernel)
+    matmul_tiling_2d_launch(lhs, rhs, out, kernel)
 }
 
 #[cfg(test)]

--- a/burn-wgpu/src/kernel/matmul/tiling2d/vec4_lhs.rs
+++ b/burn-wgpu/src/kernel/matmul/tiling2d/vec4_lhs.rs
@@ -1,9 +1,9 @@
 use burn_tensor::Element;
 
 use crate::{
-    element::WgpuElement,
+    element::JitElement,
     kernel::{DynamicKernelSource, SourceTemplate, StaticKernelSource},
-    tensor::WgpuTensor,
+    tensor::JitTensor,
     Runtime,
 };
 use std::marker::PhantomData;
@@ -18,11 +18,11 @@ kernel_wgsl!(
 );
 
 #[derive(new, Debug)]
-struct MatmulTiling2DVec4Lhs<E: WgpuElement> {
+struct MatmulTiling2DVec4Lhs<E: JitElement> {
     _elem: PhantomData<E>,
 }
 
-impl<E: WgpuElement> DynamicKernelSource for MatmulTiling2DVec4Lhs<E> {
+impl<E: JitElement> DynamicKernelSource for MatmulTiling2DVec4Lhs<E> {
     fn source(&self) -> SourceTemplate {
         MatmulTiling2DVec4LhsRaw::source()
             .register("b_m", B_M.to_string())
@@ -44,11 +44,11 @@ impl<E: WgpuElement> DynamicKernelSource for MatmulTiling2DVec4Lhs<E> {
 
 /// Matrix multiplication using tiling 2d algorithm with
 /// vec4 primitive on lhs only
-pub fn matmul_tiling_2d_vec4_lhs<R: Runtime, E: WgpuElement + Element, const D: usize>(
-    lhs: WgpuTensor<R, E, D>,
-    rhs: WgpuTensor<R, E, D>,
-    out: WgpuTensor<R, E, D>,
-) -> WgpuTensor<R, E, D> {
+pub fn matmul_tiling_2d_vec4_lhs<R: Runtime, E: JitElement + Element, const D: usize>(
+    lhs: JitTensor<R, E, D>,
+    rhs: JitTensor<R, E, D>,
+    out: JitTensor<R, E, D>,
+) -> JitTensor<R, E, D> {
     let kernel = MatmulTiling2DVec4Lhs::<E>::new();
     matmul_tiling_2d_launch(lhs, rhs, out, kernel)
 }

--- a/burn-wgpu/src/kernel/matmul/tiling2d/vec4_lhs.rs
+++ b/burn-wgpu/src/kernel/matmul/tiling2d/vec4_lhs.rs
@@ -4,7 +4,7 @@ use crate::{
     element::WgpuElement,
     kernel::{DynamicKernelSource, SourceTemplate, StaticKernelSource},
     tensor::WgpuTensor,
-    JitRuntime,
+    Runtime,
 };
 use std::marker::PhantomData;
 
@@ -44,11 +44,11 @@ impl<E: WgpuElement> DynamicKernelSource for MatmulTiling2DVec4Lhs<E> {
 
 /// Matrix multiplication using tiling 2d algorithm with
 /// vec4 primitive on lhs only
-pub fn matmul_tiling_2d_vec4_lhs<B: JitRuntime, E: WgpuElement + Element, const D: usize>(
-    lhs: WgpuTensor<B, E, D>,
-    rhs: WgpuTensor<B, E, D>,
-    out: WgpuTensor<B, E, D>,
-) -> WgpuTensor<B, E, D> {
+pub fn matmul_tiling_2d_vec4_lhs<R: Runtime, E: WgpuElement + Element, const D: usize>(
+    lhs: WgpuTensor<R, E, D>,
+    rhs: WgpuTensor<R, E, D>,
+    out: WgpuTensor<R, E, D>,
+) -> WgpuTensor<R, E, D> {
     let kernel = MatmulTiling2DVec4Lhs::<E>::new();
     matmul_tiling_2d_launch(lhs, rhs, out, kernel)
 }

--- a/burn-wgpu/src/kernel/matmul/tiling2d/vec4_lhs.rs
+++ b/burn-wgpu/src/kernel/matmul/tiling2d/vec4_lhs.rs
@@ -1,7 +1,6 @@
 use burn_tensor::Element;
 
 use crate::{
-    codegen::dialect::wgsl,
     element::WgpuElement,
     kernel::{DynamicKernelSource, SourceTemplate, StaticKernelSource},
     tensor::WgpuTensor,

--- a/burn-wgpu/src/kernel/matmul/tiling2d/vec4_lhs.rs
+++ b/burn-wgpu/src/kernel/matmul/tiling2d/vec4_lhs.rs
@@ -4,7 +4,7 @@ use crate::{
     element::WgpuElement,
     kernel::{DynamicKernelSource, SourceTemplate, StaticKernelSource},
     tensor::WgpuTensor,
-    JitGpuBackend,
+    JitRuntime,
 };
 use std::marker::PhantomData;
 
@@ -44,7 +44,7 @@ impl<E: WgpuElement> DynamicKernelSource for MatmulTiling2DVec4Lhs<E> {
 
 /// Matrix multiplication using tiling 2d algorithm with
 /// vec4 primitive on lhs only
-pub fn matmul_tiling_2d_vec4_lhs<B: JitGpuBackend, E: WgpuElement + Element, const D: usize>(
+pub fn matmul_tiling_2d_vec4_lhs<B: JitRuntime, E: WgpuElement + Element, const D: usize>(
     lhs: WgpuTensor<B, E, D>,
     rhs: WgpuTensor<B, E, D>,
     out: WgpuTensor<B, E, D>,

--- a/burn-wgpu/src/kernel/matmul/tune/base.rs
+++ b/burn-wgpu/src/kernel/matmul/tune/base.rs
@@ -50,27 +50,27 @@ impl<B: JitGpuBackend, E: WgpuElement + Element, const D: usize>
         );
 
         vec![
-            Box::new(MemoryCoalescingMatmulDefault::<E, D>::new(
+            Box::new(MemoryCoalescingMatmulDefault::new(
                 lhs.clone(),
                 rhs.clone(),
                 out.clone(),
             )),
-            Box::new(MemoryCoalescingMatmulW16x16::<E, D>::new(
+            Box::new(MemoryCoalescingMatmulW16x16::new(
                 lhs.clone(),
                 rhs.clone(),
                 out.clone(),
             )),
-            Box::new(Vec4TilingMatmulDefault::<E, D>::new(
+            Box::new(Vec4TilingMatmulDefault::new(
                 lhs.clone(),
                 rhs.clone(),
                 out.clone(),
             )),
-            Box::new(Vec4TilingMatmulUnpaddedDefault::<E, D>::new(
+            Box::new(Vec4TilingMatmulUnpaddedDefault::new(
                 lhs.clone(),
                 rhs.clone(),
                 out.clone(),
             )),
-            Box::new(Vec4LhsOnlyTilingMatmulDefault::<E, D>::new(
+            Box::new(Vec4LhsOnlyTilingMatmulDefault::new(
                 lhs.clone(),
                 rhs.clone(),
                 out.clone(),
@@ -80,19 +80,17 @@ impl<B: JitGpuBackend, E: WgpuElement + Element, const D: usize>
 
     fn fastest(self: Box<Self>, fastest_index: usize) -> Box<dyn AutotuneOperation> {
         match fastest_index {
-            0 => Box::new(MemoryCoalescingMatmulDefault::<E, D>::new(
+            0 => Box::new(MemoryCoalescingMatmulDefault::new(
                 self.lhs, self.rhs, self.out,
             )),
-            1 => Box::new(MemoryCoalescingMatmulW16x16::<E, D>::new(
+            1 => Box::new(MemoryCoalescingMatmulW16x16::new(
                 self.lhs, self.rhs, self.out,
             )),
-            2 => Box::new(Vec4TilingMatmulDefault::<E, D>::new(
+            2 => Box::new(Vec4TilingMatmulDefault::new(self.lhs, self.rhs, self.out)),
+            3 => Box::new(Vec4TilingMatmulUnpaddedDefault::new(
                 self.lhs, self.rhs, self.out,
             )),
-            3 => Box::new(Vec4TilingMatmulUnpaddedDefault::<E, D>::new(
-                self.lhs, self.rhs, self.out,
-            )),
-            4 => Box::new(Vec4LhsOnlyTilingMatmulDefault::<E, D>::new(
+            4 => Box::new(Vec4LhsOnlyTilingMatmulDefault::new(
                 self.lhs, self.rhs, self.out,
             )),
             _ => panic!("Fastest index is out of bound"),
@@ -109,11 +107,7 @@ pub fn matmul_autotune<B: JitGpuBackend, E: WgpuElement + Element, const D: usiz
 
     let output = init_matmul_output(&lhs, &rhs);
 
-    let operation_set = Box::new(MatmulAutotuneOperationSet::<E, D>::new(
-        lhs,
-        rhs,
-        output.clone(),
-    ));
+    let operation_set = Box::new(MatmulAutotuneOperationSet::new(lhs, rhs, output.clone()));
 
     client.autotune_execute(operation_set);
 

--- a/burn-wgpu/src/kernel/matmul/tune/base.rs
+++ b/burn-wgpu/src/kernel/matmul/tune/base.rs
@@ -7,20 +7,21 @@ use crate::{
     kernel::{matmul::utils::init_matmul_output, prng::random_like_uniform},
     ops::numeric::empty_device,
     tensor::WgpuTensor,
+    JitGpuBackend,
 };
 
 use super::key::MatmulAutotuneKey;
 
 /// Set of matmul implementations available for autotune
 /// Autotune key is given by concatenating the closest upper power of 2 of m, k and n
-pub struct MatmulAutotuneOperationSet<E: WgpuElement, const D: usize> {
+pub struct MatmulAutotuneOperationSet<B: JitGpuBackend, E: WgpuElement, const D: usize> {
     key: WgpuAutotuneKey,
-    lhs: WgpuTensor<E, D>,
-    rhs: WgpuTensor<E, D>,
-    out: WgpuTensor<E, D>,
+    lhs: WgpuTensor<B, E, D>,
+    rhs: WgpuTensor<B, E, D>,
+    out: WgpuTensor<B, E, D>,
 }
-impl<E: WgpuElement, const D: usize> MatmulAutotuneOperationSet<E, D> {
-    fn new(lhs: WgpuTensor<E, D>, rhs: WgpuTensor<E, D>, out: WgpuTensor<E, D>) -> Self {
+impl<B: JitGpuBackend, E: WgpuElement, const D: usize> MatmulAutotuneOperationSet<B, E, D> {
+    fn new(lhs: WgpuTensor<B, E, D>, rhs: WgpuTensor<B, E, D>, out: WgpuTensor<B, E, D>) -> Self {
         Self {
             key: WgpuAutotuneKey::Matmul(MatmulAutotuneKey::new(&lhs.shape, &rhs.shape)),
             lhs,
@@ -30,8 +31,8 @@ impl<E: WgpuElement, const D: usize> MatmulAutotuneOperationSet<E, D> {
     }
 }
 
-impl<E: WgpuElement + Element, const D: usize> AutotuneOperationSet<WgpuAutotuneKey>
-    for MatmulAutotuneOperationSet<E, D>
+impl<B: JitGpuBackend, E: WgpuElement + Element, const D: usize>
+    AutotuneOperationSet<WgpuAutotuneKey> for MatmulAutotuneOperationSet<B, E, D>
 {
     fn key(&self) -> WgpuAutotuneKey {
         self.key.clone()
@@ -100,10 +101,10 @@ impl<E: WgpuElement + Element, const D: usize> AutotuneOperationSet<WgpuAutotune
 }
 
 /// Executes autotune on matmul operations
-pub fn matmul_autotune<E: WgpuElement + Element, const D: usize>(
-    lhs: WgpuTensor<E, D>,
-    rhs: WgpuTensor<E, D>,
-) -> WgpuTensor<E, D> {
+pub fn matmul_autotune<B: JitGpuBackend, E: WgpuElement + Element, const D: usize>(
+    lhs: WgpuTensor<B, E, D>,
+    rhs: WgpuTensor<B, E, D>,
+) -> WgpuTensor<B, E, D> {
     let client = lhs.client.clone();
 
     let output = init_matmul_output(&lhs, &rhs);
@@ -122,13 +123,15 @@ pub fn matmul_autotune<E: WgpuElement + Element, const D: usize>(
 macro_rules! matmul_tune_ops {
     ($name:ident, $func:expr) => {
         #[derive(new)]
-        pub(crate) struct $name<E: WgpuElement, const D: usize> {
-            lhs: WgpuTensor<E, D>,
-            rhs: WgpuTensor<E, D>,
-            out: WgpuTensor<E, D>,
+        pub(crate) struct $name<B: JitGpuBackend, E: WgpuElement, const D: usize> {
+            lhs: WgpuTensor<B, E, D>,
+            rhs: WgpuTensor<B, E, D>,
+            out: WgpuTensor<B, E, D>,
         }
 
-        impl<E: WgpuElement, const D: usize> AutotuneOperation for $name<E, D> {
+        impl<B: JitGpuBackend, E: WgpuElement, const D: usize> AutotuneOperation
+            for $name<B, E, D>
+        {
             fn execute(self: Box<Self>) {
                 #[allow(clippy::redundant_closure_call)]
                 $func(self.lhs, self.rhs, self.out);

--- a/burn-wgpu/src/kernel/matmul/utils.rs
+++ b/burn-wgpu/src/kernel/matmul/utils.rs
@@ -1,17 +1,17 @@
-use crate::{element::WgpuElement, ops::numeric::empty_device, tensor::WgpuTensor, JitRuntime};
+use crate::{element::WgpuElement, ops::numeric::empty_device, tensor::WgpuTensor, Runtime};
 use burn_tensor::Shape;
 
 /// Creates an empty output tensor with matmul output shape
-pub fn init_matmul_output<B: JitRuntime, E: WgpuElement, const D: usize>(
-    lhs: &WgpuTensor<B, E, D>,
-    rhs: &WgpuTensor<B, E, D>,
-) -> WgpuTensor<B, E, D> {
+pub fn init_matmul_output<R: Runtime, E: WgpuElement, const D: usize>(
+    lhs: &WgpuTensor<R, E, D>,
+    rhs: &WgpuTensor<R, E, D>,
+) -> WgpuTensor<R, E, D> {
     empty_device(lhs.client.clone(), lhs.device.clone(), shape_out(lhs, rhs))
 }
 
-pub(crate) fn shape_out<B: JitRuntime, E: WgpuElement, const D: usize>(
-    lhs: &WgpuTensor<B, E, D>,
-    rhs: &WgpuTensor<B, E, D>,
+pub(crate) fn shape_out<R: Runtime, E: WgpuElement, const D: usize>(
+    lhs: &WgpuTensor<R, E, D>,
+    rhs: &WgpuTensor<R, E, D>,
 ) -> Shape<D> {
     let mut shape_out = [0; D];
     lhs.shape

--- a/burn-wgpu/src/kernel/matmul/utils.rs
+++ b/burn-wgpu/src/kernel/matmul/utils.rs
@@ -1,17 +1,17 @@
-use crate::{element::WgpuElement, ops::numeric::empty_device, tensor::WgpuTensor, Runtime};
+use crate::{element::JitElement, ops::numeric::empty_device, tensor::JitTensor, Runtime};
 use burn_tensor::Shape;
 
 /// Creates an empty output tensor with matmul output shape
-pub fn init_matmul_output<R: Runtime, E: WgpuElement, const D: usize>(
-    lhs: &WgpuTensor<R, E, D>,
-    rhs: &WgpuTensor<R, E, D>,
-) -> WgpuTensor<R, E, D> {
+pub fn init_matmul_output<R: Runtime, E: JitElement, const D: usize>(
+    lhs: &JitTensor<R, E, D>,
+    rhs: &JitTensor<R, E, D>,
+) -> JitTensor<R, E, D> {
     empty_device(lhs.client.clone(), lhs.device.clone(), shape_out(lhs, rhs))
 }
 
-pub(crate) fn shape_out<R: Runtime, E: WgpuElement, const D: usize>(
-    lhs: &WgpuTensor<R, E, D>,
-    rhs: &WgpuTensor<R, E, D>,
+pub(crate) fn shape_out<R: Runtime, E: JitElement, const D: usize>(
+    lhs: &JitTensor<R, E, D>,
+    rhs: &JitTensor<R, E, D>,
 ) -> Shape<D> {
     let mut shape_out = [0; D];
     lhs.shape
@@ -29,21 +29,21 @@ pub(crate) fn shape_out<R: Runtime, E: WgpuElement, const D: usize>(
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use crate::tensor::WgpuTensor;
-    use crate::tests::{ReferenceTensor, TestJitRuntime, TestTensor};
+    use crate::tensor::JitTensor;
+    use crate::tests::{ReferenceTensor, TestRuntime, TestTensor};
     use burn_tensor::Shape;
 
     use super::init_matmul_output;
 
-    type TB = TestJitRuntime;
+    type TB = TestRuntime;
 
     pub(crate) fn same_as_reference<F, const D: usize, S>(func: F, shape_lhs: S, shape_rhs: S)
     where
         F: Fn(
-            WgpuTensor<TB, f32, D>,
-            WgpuTensor<TB, f32, D>,
-            WgpuTensor<TB, f32, D>,
-        ) -> WgpuTensor<TB, f32, D>,
+            JitTensor<TB, f32, D>,
+            JitTensor<TB, f32, D>,
+            JitTensor<TB, f32, D>,
+        ) -> JitTensor<TB, f32, D>,
         S: Into<Shape<D>>,
     {
         let ref_tensor_device = Default::default();
@@ -79,10 +79,10 @@ pub(crate) mod tests {
         shape_rhs: S,
     ) where
         F: Fn(
-            WgpuTensor<TB, f32, D>,
-            WgpuTensor<TB, f32, D>,
-            WgpuTensor<TB, f32, D>,
-        ) -> WgpuTensor<TB, f32, D>,
+            JitTensor<TB, f32, D>,
+            JitTensor<TB, f32, D>,
+            JitTensor<TB, f32, D>,
+        ) -> JitTensor<TB, f32, D>,
         S: Into<Shape<D>>,
     {
         let x = ReferenceTensor::random(

--- a/burn-wgpu/src/kernel/matmul/utils.rs
+++ b/burn-wgpu/src/kernel/matmul/utils.rs
@@ -1,15 +1,15 @@
-use crate::{element::WgpuElement, ops::numeric::empty_device, tensor::WgpuTensor, JitGpuBackend};
+use crate::{element::WgpuElement, ops::numeric::empty_device, tensor::WgpuTensor, JitRuntime};
 use burn_tensor::Shape;
 
 /// Creates an empty output tensor with matmul output shape
-pub fn init_matmul_output<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn init_matmul_output<B: JitRuntime, E: WgpuElement, const D: usize>(
     lhs: &WgpuTensor<B, E, D>,
     rhs: &WgpuTensor<B, E, D>,
 ) -> WgpuTensor<B, E, D> {
     empty_device(lhs.client.clone(), lhs.device.clone(), shape_out(lhs, rhs))
 }
 
-pub(crate) fn shape_out<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub(crate) fn shape_out<B: JitRuntime, E: WgpuElement, const D: usize>(
     lhs: &WgpuTensor<B, E, D>,
     rhs: &WgpuTensor<B, E, D>,
 ) -> Shape<D> {
@@ -30,12 +30,12 @@ pub(crate) fn shape_out<B: JitGpuBackend, E: WgpuElement, const D: usize>(
 #[cfg(test)]
 pub(crate) mod tests {
     use crate::tensor::WgpuTensor;
-    use crate::tests::{ReferenceTensor, TestJitGpuBackend, TestTensor};
+    use crate::tests::{ReferenceTensor, TestJitRuntime, TestTensor};
     use burn_tensor::Shape;
 
     use super::init_matmul_output;
 
-    type TB = TestJitGpuBackend;
+    type TB = TestJitRuntime;
 
     pub(crate) fn same_as_reference<F, const D: usize, S>(func: F, shape_lhs: S, shape_rhs: S)
     where

--- a/burn-wgpu/src/kernel/pool/adaptive_avg_pool2d.rs
+++ b/burn-wgpu/src/kernel/pool/adaptive_avg_pool2d.rs
@@ -1,10 +1,10 @@
 use crate::{
     compute::StaticKernel,
-    element::WgpuElement,
+    element::JitElement,
     kernel::{elemwise_workgroup, KernelSettings, WORKGROUP_DEFAULT},
     kernel_wgsl,
     ops::numeric::empty_device,
-    tensor::WgpuTensor,
+    tensor::JitTensor,
     Runtime,
 };
 use burn_compute::server::Handle;
@@ -19,10 +19,10 @@ kernel_wgsl!(
     "../../template/pool/adaptive_avg_pool2d_backward.wgsl"
 );
 
-pub(crate) fn adaptive_avg_pool2d<R: Runtime, E: WgpuElement>(
-    x: WgpuTensor<R, E, 4>,
+pub(crate) fn adaptive_avg_pool2d<R: Runtime, E: JitElement>(
+    x: JitTensor<R, E, 4>,
     output_size: [usize; 2],
-) -> WgpuTensor<R, E, 4> {
+) -> JitTensor<R, E, 4> {
     let [batch_size, channels, _, _] = x.shape.dims;
 
     let output_shape = Shape::new([batch_size, channels, output_size[0], output_size[1]]);
@@ -42,14 +42,14 @@ pub(crate) fn adaptive_avg_pool2d<R: Runtime, E: WgpuElement>(
     output
 }
 
-pub(crate) fn adaptive_avg_pool2d_backward<R: Runtime, E: WgpuElement>(
-    x: WgpuTensor<R, E, 4>,
-    out_grad: WgpuTensor<R, E, 4>,
-) -> WgpuTensor<R, E, 4> {
+pub(crate) fn adaptive_avg_pool2d_backward<R: Runtime, E: JitElement>(
+    x: JitTensor<R, E, 4>,
+    out_grad: JitTensor<R, E, 4>,
+) -> JitTensor<R, E, 4> {
     let output_shape = x.shape.clone();
     let num_elems = output_shape.num_elements();
     let output_buffer = x.client.empty(num_elems * core::mem::size_of::<E>());
-    let output = WgpuTensor::new(
+    let output = JitTensor::new(
         x.client.clone(),
         x.device.clone(),
         output_shape,
@@ -73,9 +73,9 @@ pub(crate) fn adaptive_avg_pool2d_backward<R: Runtime, E: WgpuElement>(
     output
 }
 
-fn build_info<R: Runtime, E: WgpuElement>(
-    x: &WgpuTensor<R, E, 4>,
-    output: &WgpuTensor<R, E, 4>,
+fn build_info<R: Runtime, E: JitElement>(
+    x: &JitTensor<R, E, 4>,
+    output: &JitTensor<R, E, 4>,
 ) -> Handle<R::Server> {
     let mut info: [u32; 16] = [0; 16];
     info[0] = x.strides[0] as u32;

--- a/burn-wgpu/src/kernel/pool/adaptive_avg_pool2d.rs
+++ b/burn-wgpu/src/kernel/pool/adaptive_avg_pool2d.rs
@@ -5,7 +5,7 @@ use crate::{
     kernel_wgsl,
     ops::numeric::empty_device,
     tensor::WgpuTensor,
-    JitRuntime,
+    Runtime,
 };
 use burn_compute::server::Handle;
 use burn_tensor::Shape;
@@ -19,10 +19,10 @@ kernel_wgsl!(
     "../../template/pool/adaptive_avg_pool2d_backward.wgsl"
 );
 
-pub(crate) fn adaptive_avg_pool2d<B: JitRuntime, E: WgpuElement>(
-    x: WgpuTensor<B, E, 4>,
+pub(crate) fn adaptive_avg_pool2d<R: Runtime, E: WgpuElement>(
+    x: WgpuTensor<R, E, 4>,
     output_size: [usize; 2],
-) -> WgpuTensor<B, E, 4> {
+) -> WgpuTensor<R, E, 4> {
     let [batch_size, channels, _, _] = x.shape.dims;
 
     let output_shape = Shape::new([batch_size, channels, output_size[0], output_size[1]]);
@@ -42,10 +42,10 @@ pub(crate) fn adaptive_avg_pool2d<B: JitRuntime, E: WgpuElement>(
     output
 }
 
-pub(crate) fn adaptive_avg_pool2d_backward<B: JitRuntime, E: WgpuElement>(
-    x: WgpuTensor<B, E, 4>,
-    out_grad: WgpuTensor<B, E, 4>,
-) -> WgpuTensor<B, E, 4> {
+pub(crate) fn adaptive_avg_pool2d_backward<R: Runtime, E: WgpuElement>(
+    x: WgpuTensor<R, E, 4>,
+    out_grad: WgpuTensor<R, E, 4>,
+) -> WgpuTensor<R, E, 4> {
     let output_shape = x.shape.clone();
     let num_elems = output_shape.num_elements();
     let output_buffer = x.client.empty(num_elems * core::mem::size_of::<E>());
@@ -73,10 +73,10 @@ pub(crate) fn adaptive_avg_pool2d_backward<B: JitRuntime, E: WgpuElement>(
     output
 }
 
-fn build_info<B: JitRuntime, E: WgpuElement>(
-    x: &WgpuTensor<B, E, 4>,
-    output: &WgpuTensor<B, E, 4>,
-) -> Handle<B::Server> {
+fn build_info<R: Runtime, E: WgpuElement>(
+    x: &WgpuTensor<R, E, 4>,
+    output: &WgpuTensor<R, E, 4>,
+) -> Handle<R::Server> {
     let mut info: [u32; 16] = [0; 16];
     info[0] = x.strides[0] as u32;
     info[1] = x.strides[1] as u32;

--- a/burn-wgpu/src/kernel/pool/adaptive_avg_pool2d.rs
+++ b/burn-wgpu/src/kernel/pool/adaptive_avg_pool2d.rs
@@ -5,7 +5,7 @@ use crate::{
     kernel_wgsl,
     ops::numeric::empty_device,
     tensor::WgpuTensor,
-    JitGpuBackend,
+    JitRuntime,
 };
 use burn_compute::server::Handle;
 use burn_tensor::Shape;
@@ -19,7 +19,7 @@ kernel_wgsl!(
     "../../template/pool/adaptive_avg_pool2d_backward.wgsl"
 );
 
-pub(crate) fn adaptive_avg_pool2d<B: JitGpuBackend, E: WgpuElement>(
+pub(crate) fn adaptive_avg_pool2d<B: JitRuntime, E: WgpuElement>(
     x: WgpuTensor<B, E, 4>,
     output_size: [usize; 2],
 ) -> WgpuTensor<B, E, 4> {
@@ -42,7 +42,7 @@ pub(crate) fn adaptive_avg_pool2d<B: JitGpuBackend, E: WgpuElement>(
     output
 }
 
-pub(crate) fn adaptive_avg_pool2d_backward<B: JitGpuBackend, E: WgpuElement>(
+pub(crate) fn adaptive_avg_pool2d_backward<B: JitRuntime, E: WgpuElement>(
     x: WgpuTensor<B, E, 4>,
     out_grad: WgpuTensor<B, E, 4>,
 ) -> WgpuTensor<B, E, 4> {
@@ -73,7 +73,7 @@ pub(crate) fn adaptive_avg_pool2d_backward<B: JitGpuBackend, E: WgpuElement>(
     output
 }
 
-fn build_info<B: JitGpuBackend, E: WgpuElement>(
+fn build_info<B: JitRuntime, E: WgpuElement>(
     x: &WgpuTensor<B, E, 4>,
     output: &WgpuTensor<B, E, 4>,
 ) -> Handle<B::Server> {

--- a/burn-wgpu/src/kernel/pool/avg_pool2d.rs
+++ b/burn-wgpu/src/kernel/pool/avg_pool2d.rs
@@ -9,7 +9,7 @@ use crate::{
     kernel_wgsl,
     ops::numeric::empty_device,
     tensor::WgpuTensor,
-    JitGpuBackend,
+    JitRuntime,
 };
 
 kernel_wgsl!(AvgPool2dRaw, "../../template/pool/avg_pool2d.wgsl");
@@ -33,7 +33,7 @@ impl<const COUNT_INCLUDE_PAD: bool> StaticKernelSource for AvgPool2d<COUNT_INCLU
     }
 }
 
-pub(crate) fn avg_pool2d<B: JitGpuBackend, E: WgpuElement>(
+pub(crate) fn avg_pool2d<B: JitRuntime, E: WgpuElement>(
     x: WgpuTensor<B, E, 4>,
     kernel_size: [usize; 2],
     stride: [usize; 2],
@@ -59,7 +59,7 @@ pub(crate) fn avg_pool2d<B: JitGpuBackend, E: WgpuElement>(
     output
 }
 
-pub(crate) fn avg_pool2d_backward<B: JitGpuBackend, E: WgpuElement>(
+pub(crate) fn avg_pool2d_backward<B: JitRuntime, E: WgpuElement>(
     x: WgpuTensor<B, E, 4>,
     grad: WgpuTensor<B, E, 4>,
     kernel_size: [usize; 2],

--- a/burn-wgpu/src/kernel/pool/avg_pool2d.rs
+++ b/burn-wgpu/src/kernel/pool/avg_pool2d.rs
@@ -1,6 +1,6 @@
 use crate::{
     compute::{Kernel, StaticKernel},
-    element::WgpuElement,
+    element::JitElement,
     kernel::{
         self, elemwise_workgroup,
         pool::{build_output_and_info_pool2d, build_pool2d_info},
@@ -8,7 +8,7 @@ use crate::{
     },
     kernel_wgsl,
     ops::numeric::empty_device,
-    tensor::WgpuTensor,
+    tensor::JitTensor,
     Runtime,
 };
 
@@ -33,13 +33,13 @@ impl<const COUNT_INCLUDE_PAD: bool> StaticKernelSource for AvgPool2d<COUNT_INCLU
     }
 }
 
-pub(crate) fn avg_pool2d<R: Runtime, E: WgpuElement>(
-    x: WgpuTensor<R, E, 4>,
+pub(crate) fn avg_pool2d<R: Runtime, E: JitElement>(
+    x: JitTensor<R, E, 4>,
     kernel_size: [usize; 2],
     stride: [usize; 2],
     padding: [usize; 2],
     count_include_pad: bool,
-) -> WgpuTensor<R, E, 4> {
+) -> JitTensor<R, E, 4> {
     let (info_handle, output) =
         build_output_and_info_pool2d(&x, kernel_size, stride, padding, [1, 1]);
 
@@ -59,14 +59,14 @@ pub(crate) fn avg_pool2d<R: Runtime, E: WgpuElement>(
     output
 }
 
-pub(crate) fn avg_pool2d_backward<R: Runtime, E: WgpuElement>(
-    x: WgpuTensor<R, E, 4>,
-    grad: WgpuTensor<R, E, 4>,
+pub(crate) fn avg_pool2d_backward<R: Runtime, E: JitElement>(
+    x: JitTensor<R, E, 4>,
+    grad: JitTensor<R, E, 4>,
     kernel_size: [usize; 2],
     stride: [usize; 2],
     padding: [usize; 2],
     count_include_pad: bool,
-) -> WgpuTensor<R, E, 4> {
+) -> JitTensor<R, E, 4> {
     let grad = kernel::into_contiguous(grad);
     let output = empty_device(x.client.clone(), x.device.clone(), x.shape.clone());
     let info_handle = build_pool2d_info(&x, &grad, kernel_size, stride, padding, [1, 1]);

--- a/burn-wgpu/src/kernel/pool/avg_pool2d.rs
+++ b/burn-wgpu/src/kernel/pool/avg_pool2d.rs
@@ -9,6 +9,7 @@ use crate::{
     kernel_wgsl,
     ops::numeric::empty_device,
     tensor::WgpuTensor,
+    JitGpuBackend,
 };
 
 kernel_wgsl!(AvgPool2dRaw, "../../template/pool/avg_pool2d.wgsl");
@@ -32,13 +33,13 @@ impl<const COUNT_INCLUDE_PAD: bool> StaticKernelSource for AvgPool2d<COUNT_INCLU
     }
 }
 
-pub(crate) fn avg_pool2d<E: WgpuElement>(
-    x: WgpuTensor<E, 4>,
+pub(crate) fn avg_pool2d<B: JitGpuBackend, E: WgpuElement>(
+    x: WgpuTensor<B, E, 4>,
     kernel_size: [usize; 2],
     stride: [usize; 2],
     padding: [usize; 2],
     count_include_pad: bool,
-) -> WgpuTensor<E, 4> {
+) -> WgpuTensor<B, E, 4> {
     let (info_handle, output) =
         build_output_and_info_pool2d(&x, kernel_size, stride, padding, [1, 1]);
 
@@ -58,14 +59,14 @@ pub(crate) fn avg_pool2d<E: WgpuElement>(
     output
 }
 
-pub(crate) fn avg_pool2d_backward<E: WgpuElement>(
-    x: WgpuTensor<E, 4>,
-    grad: WgpuTensor<E, 4>,
+pub(crate) fn avg_pool2d_backward<B: JitGpuBackend, E: WgpuElement>(
+    x: WgpuTensor<B, E, 4>,
+    grad: WgpuTensor<B, E, 4>,
     kernel_size: [usize; 2],
     stride: [usize; 2],
     padding: [usize; 2],
     count_include_pad: bool,
-) -> WgpuTensor<E, 4> {
+) -> WgpuTensor<B, E, 4> {
     let grad = kernel::into_contiguous(grad);
     let output = empty_device(x.client.clone(), x.device.clone(), x.shape.clone());
     let info_handle = build_pool2d_info(&x, &grad, kernel_size, stride, padding, [1, 1]);

--- a/burn-wgpu/src/kernel/pool/avg_pool2d.rs
+++ b/burn-wgpu/src/kernel/pool/avg_pool2d.rs
@@ -9,7 +9,7 @@ use crate::{
     kernel_wgsl,
     ops::numeric::empty_device,
     tensor::WgpuTensor,
-    JitRuntime,
+    Runtime,
 };
 
 kernel_wgsl!(AvgPool2dRaw, "../../template/pool/avg_pool2d.wgsl");
@@ -33,13 +33,13 @@ impl<const COUNT_INCLUDE_PAD: bool> StaticKernelSource for AvgPool2d<COUNT_INCLU
     }
 }
 
-pub(crate) fn avg_pool2d<B: JitRuntime, E: WgpuElement>(
-    x: WgpuTensor<B, E, 4>,
+pub(crate) fn avg_pool2d<R: Runtime, E: WgpuElement>(
+    x: WgpuTensor<R, E, 4>,
     kernel_size: [usize; 2],
     stride: [usize; 2],
     padding: [usize; 2],
     count_include_pad: bool,
-) -> WgpuTensor<B, E, 4> {
+) -> WgpuTensor<R, E, 4> {
     let (info_handle, output) =
         build_output_and_info_pool2d(&x, kernel_size, stride, padding, [1, 1]);
 
@@ -59,14 +59,14 @@ pub(crate) fn avg_pool2d<B: JitRuntime, E: WgpuElement>(
     output
 }
 
-pub(crate) fn avg_pool2d_backward<B: JitRuntime, E: WgpuElement>(
-    x: WgpuTensor<B, E, 4>,
-    grad: WgpuTensor<B, E, 4>,
+pub(crate) fn avg_pool2d_backward<R: Runtime, E: WgpuElement>(
+    x: WgpuTensor<R, E, 4>,
+    grad: WgpuTensor<R, E, 4>,
     kernel_size: [usize; 2],
     stride: [usize; 2],
     padding: [usize; 2],
     count_include_pad: bool,
-) -> WgpuTensor<B, E, 4> {
+) -> WgpuTensor<R, E, 4> {
     let grad = kernel::into_contiguous(grad);
     let output = empty_device(x.client.clone(), x.device.clone(), x.shape.clone());
     let info_handle = build_pool2d_info(&x, &grad, kernel_size, stride, padding, [1, 1]);

--- a/burn-wgpu/src/kernel/pool/base.rs
+++ b/burn-wgpu/src/kernel/pool/base.rs
@@ -1,15 +1,15 @@
-use crate::{element::WgpuElement, ops::numeric::empty_device, tensor::WgpuTensor, Runtime};
+use crate::{element::JitElement, ops::numeric::empty_device, tensor::JitTensor, Runtime};
 use burn_compute::server::Handle;
 use burn_tensor::Shape;
 
 /// Build basic info to launch pool 2d kernels.
-pub fn build_output_and_info_pool2d<R: Runtime, E: WgpuElement>(
-    x: &WgpuTensor<R, E, 4>,
+pub fn build_output_and_info_pool2d<R: Runtime, E: JitElement>(
+    x: &JitTensor<R, E, 4>,
     kernel_size: [usize; 2],
     stride: [usize; 2],
     padding: [usize; 2],
     dilation: [usize; 2],
-) -> (Handle<R::Server>, WgpuTensor<R, E, 4>) {
+) -> (Handle<R::Server>, JitTensor<R, E, 4>) {
     let [kernel_height, kernel_width] = kernel_size;
     let [padding_height, padding_width] = padding;
     let [stride_height, stride_width] = stride;
@@ -30,9 +30,9 @@ pub fn build_output_and_info_pool2d<R: Runtime, E: WgpuElement>(
     (info_buffer, output)
 }
 
-pub fn build_pool2d_info<R: Runtime, E: WgpuElement>(
-    input: &WgpuTensor<R, E, 4>,
-    output: &WgpuTensor<R, E, 4>,
+pub fn build_pool2d_info<R: Runtime, E: JitElement>(
+    input: &JitTensor<R, E, 4>,
+    output: &JitTensor<R, E, 4>,
     kernel_size: [usize; 2],
     stride: [usize; 2],
     padding: [usize; 2],

--- a/burn-wgpu/src/kernel/pool/base.rs
+++ b/burn-wgpu/src/kernel/pool/base.rs
@@ -1,16 +1,15 @@
-use crate::{
-    compute::WgpuHandle, element::WgpuElement, ops::numeric::empty_device, tensor::WgpuTensor,
-};
+use crate::{element::WgpuElement, ops::numeric::empty_device, tensor::WgpuTensor, JitGpuBackend};
+use burn_compute::server::Handle;
 use burn_tensor::Shape;
 
 /// Build basic info to launch pool 2d kernels.
-pub fn build_output_and_info_pool2d<E: WgpuElement>(
-    x: &WgpuTensor<E, 4>,
+pub fn build_output_and_info_pool2d<B: JitGpuBackend, E: WgpuElement>(
+    x: &WgpuTensor<B, E, 4>,
     kernel_size: [usize; 2],
     stride: [usize; 2],
     padding: [usize; 2],
     dilation: [usize; 2],
-) -> (WgpuHandle, WgpuTensor<E, 4>) {
+) -> (Handle<B::Server>, WgpuTensor<B, E, 4>) {
     let [kernel_height, kernel_width] = kernel_size;
     let [padding_height, padding_width] = padding;
     let [stride_height, stride_width] = stride;
@@ -31,14 +30,14 @@ pub fn build_output_and_info_pool2d<E: WgpuElement>(
     (info_buffer, output)
 }
 
-pub fn build_pool2d_info<E: WgpuElement>(
-    input: &WgpuTensor<E, 4>,
-    output: &WgpuTensor<E, 4>,
+pub fn build_pool2d_info<B: JitGpuBackend, E: WgpuElement>(
+    input: &WgpuTensor<B, E, 4>,
+    output: &WgpuTensor<B, E, 4>,
     kernel_size: [usize; 2],
     stride: [usize; 2],
     padding: [usize; 2],
     dilation: [usize; 2],
-) -> WgpuHandle {
+) -> Handle<B::Server> {
     let mut info: [u32; 24] = [0; 24];
     info[0] = input.strides[0] as u32;
     info[1] = input.strides[1] as u32;

--- a/burn-wgpu/src/kernel/pool/base.rs
+++ b/burn-wgpu/src/kernel/pool/base.rs
@@ -1,15 +1,15 @@
-use crate::{element::WgpuElement, ops::numeric::empty_device, tensor::WgpuTensor, JitRuntime};
+use crate::{element::WgpuElement, ops::numeric::empty_device, tensor::WgpuTensor, Runtime};
 use burn_compute::server::Handle;
 use burn_tensor::Shape;
 
 /// Build basic info to launch pool 2d kernels.
-pub fn build_output_and_info_pool2d<B: JitRuntime, E: WgpuElement>(
-    x: &WgpuTensor<B, E, 4>,
+pub fn build_output_and_info_pool2d<R: Runtime, E: WgpuElement>(
+    x: &WgpuTensor<R, E, 4>,
     kernel_size: [usize; 2],
     stride: [usize; 2],
     padding: [usize; 2],
     dilation: [usize; 2],
-) -> (Handle<B::Server>, WgpuTensor<B, E, 4>) {
+) -> (Handle<R::Server>, WgpuTensor<R, E, 4>) {
     let [kernel_height, kernel_width] = kernel_size;
     let [padding_height, padding_width] = padding;
     let [stride_height, stride_width] = stride;
@@ -30,14 +30,14 @@ pub fn build_output_and_info_pool2d<B: JitRuntime, E: WgpuElement>(
     (info_buffer, output)
 }
 
-pub fn build_pool2d_info<B: JitRuntime, E: WgpuElement>(
-    input: &WgpuTensor<B, E, 4>,
-    output: &WgpuTensor<B, E, 4>,
+pub fn build_pool2d_info<R: Runtime, E: WgpuElement>(
+    input: &WgpuTensor<R, E, 4>,
+    output: &WgpuTensor<R, E, 4>,
     kernel_size: [usize; 2],
     stride: [usize; 2],
     padding: [usize; 2],
     dilation: [usize; 2],
-) -> Handle<B::Server> {
+) -> Handle<R::Server> {
     let mut info: [u32; 24] = [0; 24];
     info[0] = input.strides[0] as u32;
     info[1] = input.strides[1] as u32;

--- a/burn-wgpu/src/kernel/pool/base.rs
+++ b/burn-wgpu/src/kernel/pool/base.rs
@@ -1,9 +1,9 @@
-use crate::{element::WgpuElement, ops::numeric::empty_device, tensor::WgpuTensor, JitGpuBackend};
+use crate::{element::WgpuElement, ops::numeric::empty_device, tensor::WgpuTensor, JitRuntime};
 use burn_compute::server::Handle;
 use burn_tensor::Shape;
 
 /// Build basic info to launch pool 2d kernels.
-pub fn build_output_and_info_pool2d<B: JitGpuBackend, E: WgpuElement>(
+pub fn build_output_and_info_pool2d<B: JitRuntime, E: WgpuElement>(
     x: &WgpuTensor<B, E, 4>,
     kernel_size: [usize; 2],
     stride: [usize; 2],
@@ -30,7 +30,7 @@ pub fn build_output_and_info_pool2d<B: JitGpuBackend, E: WgpuElement>(
     (info_buffer, output)
 }
 
-pub fn build_pool2d_info<B: JitGpuBackend, E: WgpuElement>(
+pub fn build_pool2d_info<B: JitRuntime, E: WgpuElement>(
     input: &WgpuTensor<B, E, 4>,
     output: &WgpuTensor<B, E, 4>,
     kernel_size: [usize; 2],

--- a/burn-wgpu/src/kernel/pool/max_pool2d.rs
+++ b/burn-wgpu/src/kernel/pool/max_pool2d.rs
@@ -9,7 +9,7 @@ use crate::{
     kernel_wgsl,
     ops::numeric::empty_device,
     tensor::WgpuTensor,
-    JitGpuBackend,
+    JitRuntime,
 };
 
 kernel_wgsl!(MaxPool2d, "../../template/pool/max_pool2d.wgsl");
@@ -22,7 +22,7 @@ kernel_wgsl!(
     "../../template/pool/max_pool2d_with_indices.wgsl"
 );
 
-pub(crate) fn max_pool2d<B: JitGpuBackend, E: WgpuElement>(
+pub(crate) fn max_pool2d<B: JitRuntime, E: WgpuElement>(
     x: WgpuTensor<B, E, 4>,
     kernel_size: [usize; 2],
     stride: [usize; 2],
@@ -44,7 +44,7 @@ pub(crate) fn max_pool2d<B: JitGpuBackend, E: WgpuElement>(
     output
 }
 
-pub(crate) fn max_pool2d_with_indices<B: JitGpuBackend, E: WgpuElement, I: WgpuElement>(
+pub(crate) fn max_pool2d_with_indices<B: JitRuntime, E: WgpuElement, I: WgpuElement>(
     x: WgpuTensor<B, E, 4>,
     kernel_size: [usize; 2],
     stride: [usize; 2],
@@ -70,7 +70,7 @@ pub(crate) fn max_pool2d_with_indices<B: JitGpuBackend, E: WgpuElement, I: WgpuE
     (output, indices)
 }
 
-pub(crate) fn max_pool2d_with_indices_backward<B: JitGpuBackend, E: WgpuElement, I: WgpuElement>(
+pub(crate) fn max_pool2d_with_indices_backward<B: JitRuntime, E: WgpuElement, I: WgpuElement>(
     x: WgpuTensor<B, E, 4>,
     grad: WgpuTensor<B, E, 4>,
     indices: WgpuTensor<B, I, 4>,

--- a/burn-wgpu/src/kernel/pool/max_pool2d.rs
+++ b/burn-wgpu/src/kernel/pool/max_pool2d.rs
@@ -9,6 +9,7 @@ use crate::{
     kernel_wgsl,
     ops::numeric::empty_device,
     tensor::WgpuTensor,
+    JitGpuBackend,
 };
 
 kernel_wgsl!(MaxPool2d, "../../template/pool/max_pool2d.wgsl");
@@ -21,13 +22,13 @@ kernel_wgsl!(
     "../../template/pool/max_pool2d_with_indices.wgsl"
 );
 
-pub(crate) fn max_pool2d<E: WgpuElement>(
-    x: WgpuTensor<E, 4>,
+pub(crate) fn max_pool2d<B: JitGpuBackend, E: WgpuElement>(
+    x: WgpuTensor<B, E, 4>,
     kernel_size: [usize; 2],
     stride: [usize; 2],
     padding: [usize; 2],
     dilation: [usize; 2],
-) -> WgpuTensor<E, 4> {
+) -> WgpuTensor<B, E, 4> {
     let (info_handle, output) =
         build_output_and_info_pool2d(&x, kernel_size, stride, padding, dilation);
     let kernel = StaticKernel::<
@@ -43,13 +44,13 @@ pub(crate) fn max_pool2d<E: WgpuElement>(
     output
 }
 
-pub(crate) fn max_pool2d_with_indices<E: WgpuElement, I: WgpuElement>(
-    x: WgpuTensor<E, 4>,
+pub(crate) fn max_pool2d_with_indices<B: JitGpuBackend, E: WgpuElement, I: WgpuElement>(
+    x: WgpuTensor<B, E, 4>,
     kernel_size: [usize; 2],
     stride: [usize; 2],
     padding: [usize; 2],
     dilation: [usize; 2],
-) -> (WgpuTensor<E, 4>, WgpuTensor<I, 4>) {
+) -> (WgpuTensor<B, E, 4>, WgpuTensor<B, I, 4>) {
     let (info_handle, output) =
         build_output_and_info_pool2d(&x, kernel_size, stride, padding, dilation);
     let indices = empty_device(x.client.clone(), x.device, output.shape.clone());
@@ -69,15 +70,15 @@ pub(crate) fn max_pool2d_with_indices<E: WgpuElement, I: WgpuElement>(
     (output, indices)
 }
 
-pub(crate) fn max_pool2d_with_indices_backward<E: WgpuElement, I: WgpuElement>(
-    x: WgpuTensor<E, 4>,
-    grad: WgpuTensor<E, 4>,
-    indices: WgpuTensor<I, 4>,
+pub(crate) fn max_pool2d_with_indices_backward<B: JitGpuBackend, E: WgpuElement, I: WgpuElement>(
+    x: WgpuTensor<B, E, 4>,
+    grad: WgpuTensor<B, E, 4>,
+    indices: WgpuTensor<B, I, 4>,
     kernel_size: [usize; 2],
     stride: [usize; 2],
     padding: [usize; 2],
     dilation: [usize; 2],
-) -> WgpuTensor<E, 4> {
+) -> WgpuTensor<B, E, 4> {
     let grad = kernel::into_contiguous(grad);
     let indices = kernel::into_contiguous(indices);
 

--- a/burn-wgpu/src/kernel/pool/max_pool2d.rs
+++ b/burn-wgpu/src/kernel/pool/max_pool2d.rs
@@ -9,7 +9,7 @@ use crate::{
     kernel_wgsl,
     ops::numeric::empty_device,
     tensor::WgpuTensor,
-    JitRuntime,
+    Runtime,
 };
 
 kernel_wgsl!(MaxPool2d, "../../template/pool/max_pool2d.wgsl");
@@ -22,13 +22,13 @@ kernel_wgsl!(
     "../../template/pool/max_pool2d_with_indices.wgsl"
 );
 
-pub(crate) fn max_pool2d<B: JitRuntime, E: WgpuElement>(
-    x: WgpuTensor<B, E, 4>,
+pub(crate) fn max_pool2d<R: Runtime, E: WgpuElement>(
+    x: WgpuTensor<R, E, 4>,
     kernel_size: [usize; 2],
     stride: [usize; 2],
     padding: [usize; 2],
     dilation: [usize; 2],
-) -> WgpuTensor<B, E, 4> {
+) -> WgpuTensor<R, E, 4> {
     let (info_handle, output) =
         build_output_and_info_pool2d(&x, kernel_size, stride, padding, dilation);
     let kernel = StaticKernel::<
@@ -44,13 +44,13 @@ pub(crate) fn max_pool2d<B: JitRuntime, E: WgpuElement>(
     output
 }
 
-pub(crate) fn max_pool2d_with_indices<B: JitRuntime, E: WgpuElement, I: WgpuElement>(
-    x: WgpuTensor<B, E, 4>,
+pub(crate) fn max_pool2d_with_indices<R: Runtime, E: WgpuElement, I: WgpuElement>(
+    x: WgpuTensor<R, E, 4>,
     kernel_size: [usize; 2],
     stride: [usize; 2],
     padding: [usize; 2],
     dilation: [usize; 2],
-) -> (WgpuTensor<B, E, 4>, WgpuTensor<B, I, 4>) {
+) -> (WgpuTensor<R, E, 4>, WgpuTensor<R, I, 4>) {
     let (info_handle, output) =
         build_output_and_info_pool2d(&x, kernel_size, stride, padding, dilation);
     let indices = empty_device(x.client.clone(), x.device, output.shape.clone());
@@ -70,15 +70,15 @@ pub(crate) fn max_pool2d_with_indices<B: JitRuntime, E: WgpuElement, I: WgpuElem
     (output, indices)
 }
 
-pub(crate) fn max_pool2d_with_indices_backward<B: JitRuntime, E: WgpuElement, I: WgpuElement>(
-    x: WgpuTensor<B, E, 4>,
-    grad: WgpuTensor<B, E, 4>,
-    indices: WgpuTensor<B, I, 4>,
+pub(crate) fn max_pool2d_with_indices_backward<R: Runtime, E: WgpuElement, I: WgpuElement>(
+    x: WgpuTensor<R, E, 4>,
+    grad: WgpuTensor<R, E, 4>,
+    indices: WgpuTensor<R, I, 4>,
     kernel_size: [usize; 2],
     stride: [usize; 2],
     padding: [usize; 2],
     dilation: [usize; 2],
-) -> WgpuTensor<B, E, 4> {
+) -> WgpuTensor<R, E, 4> {
     let grad = kernel::into_contiguous(grad);
     let indices = kernel::into_contiguous(indices);
 

--- a/burn-wgpu/src/kernel/prng/base.rs
+++ b/burn-wgpu/src/kernel/prng/base.rs
@@ -1,4 +1,4 @@
-use crate::{element::WgpuElement, kernel_wgsl, JitRuntime, SEED};
+use crate::{element::WgpuElement, kernel_wgsl, Runtime, SEED};
 use burn_common::rand::get_seeded_rng;
 use burn_compute::{client::ComputeClient, server::Handle};
 use rand::Rng;
@@ -19,19 +19,19 @@ pub(crate) fn get_seeds() -> Vec<u32> {
     seeds
 }
 
-pub(crate) fn make_info_buffer<B: JitRuntime>(
-    client: ComputeClient<B::Server, B::Channel>,
+pub(crate) fn make_info_buffer<R: Runtime>(
+    client: ComputeClient<R::Server, R::Channel>,
     n_values_per_thread: usize,
-) -> Handle<B::Server> {
+) -> Handle<R::Server> {
     let mut info = get_seeds();
     info.insert(0, n_values_per_thread as u32);
     client.create(bytemuck::cast_slice(&info))
 }
 
-pub(crate) fn make_args_buffer<B: JitRuntime, E: WgpuElement>(
-    client: ComputeClient<B::Server, B::Channel>,
+pub(crate) fn make_args_buffer<R: Runtime, E: WgpuElement>(
+    client: ComputeClient<R::Server, R::Channel>,
     args: &[E],
-) -> Handle<B::Server> {
+) -> Handle<R::Server> {
     client.create(E::as_bytes(args))
 }
 

--- a/burn-wgpu/src/kernel/prng/base.rs
+++ b/burn-wgpu/src/kernel/prng/base.rs
@@ -1,4 +1,4 @@
-use crate::{element::WgpuElement, kernel_wgsl, JitGpuBackend, SEED};
+use crate::{element::WgpuElement, kernel_wgsl, JitRuntime, SEED};
 use burn_common::rand::get_seeded_rng;
 use burn_compute::{client::ComputeClient, server::Handle};
 use rand::Rng;
@@ -19,7 +19,7 @@ pub(crate) fn get_seeds() -> Vec<u32> {
     seeds
 }
 
-pub(crate) fn make_info_buffer<B: JitGpuBackend>(
+pub(crate) fn make_info_buffer<B: JitRuntime>(
     client: ComputeClient<B::Server, B::Channel>,
     n_values_per_thread: usize,
 ) -> Handle<B::Server> {
@@ -28,7 +28,7 @@ pub(crate) fn make_info_buffer<B: JitGpuBackend>(
     client.create(bytemuck::cast_slice(&info))
 }
 
-pub(crate) fn make_args_buffer<B: JitGpuBackend, E: WgpuElement>(
+pub(crate) fn make_args_buffer<B: JitRuntime, E: WgpuElement>(
     client: ComputeClient<B::Server, B::Channel>,
     args: &[E],
 ) -> Handle<B::Server> {

--- a/burn-wgpu/src/kernel/prng/base.rs
+++ b/burn-wgpu/src/kernel/prng/base.rs
@@ -1,4 +1,4 @@
-use crate::{element::WgpuElement, kernel_wgsl, Runtime, SEED};
+use crate::{element::JitElement, kernel_wgsl, Runtime, SEED};
 use burn_common::rand::get_seeded_rng;
 use burn_compute::{client::ComputeClient, server::Handle};
 use rand::Rng;
@@ -28,7 +28,7 @@ pub(crate) fn make_info_buffer<R: Runtime>(
     client.create(bytemuck::cast_slice(&info))
 }
 
-pub(crate) fn make_args_buffer<R: Runtime, E: WgpuElement>(
+pub(crate) fn make_args_buffer<R: Runtime, E: JitElement>(
     client: ComputeClient<R::Server, R::Channel>,
     args: &[E],
 ) -> Handle<R::Server> {

--- a/burn-wgpu/src/kernel/prng/bernoulli.rs
+++ b/burn-wgpu/src/kernel/prng/bernoulli.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     ops::numeric::empty_device,
     tensor::WgpuTensor,
-    JitGpuBackend,
+    JitRuntime,
 };
 use burn_tensor::Shape;
 
@@ -28,7 +28,7 @@ impl StaticKernelSource for BernoulliPrng {
 }
 
 /// Pseudo-random generator for bernoulli
-pub fn random_bernoulli<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn random_bernoulli<B: JitRuntime, E: WgpuElement, const D: usize>(
     shape: Shape<D>,
     device: &B::Device,
     prob: E,

--- a/burn-wgpu/src/kernel/prng/bernoulli.rs
+++ b/burn-wgpu/src/kernel/prng/bernoulli.rs
@@ -30,15 +30,15 @@ impl StaticKernelSource for BernoulliPrng {
 /// Pseudo-random generator for bernoulli
 pub fn random_bernoulli<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     shape: Shape<D>,
-    device: &WgpuDevice,
+    device: &B::Device,
     prob: E,
 ) -> WgpuTensor<B, E, D> {
     const N_VALUES_PER_THREAD: usize = 128;
 
     let client = B::client(device);
     let output = empty_device(client.clone(), device.clone(), shape.clone());
-    let info_handle = make_info_buffer(client.clone(), N_VALUES_PER_THREAD);
-    let args_handle = make_args_buffer(client.clone(), &[prob]);
+    let info_handle = make_info_buffer::<B>(client.clone(), N_VALUES_PER_THREAD);
+    let args_handle = make_args_buffer::<B, E>(client.clone(), &[prob]);
     let workgroup = prng_workgroup(shape.num_elements(), WORKGROUP_DEFAULT, N_VALUES_PER_THREAD);
     let kernel = StaticKernel::<
         KernelSettings<BernoulliPrng, E, i32, WORKGROUP_DEFAULT, WORKGROUP_DEFAULT, 1>,

--- a/burn-wgpu/src/kernel/prng/bernoulli.rs
+++ b/burn-wgpu/src/kernel/prng/bernoulli.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     ops::numeric::empty_device,
     tensor::WgpuTensor,
-    JitGpuBackend, WgpuDevice,
+    JitGpuBackend,
 };
 use burn_tensor::Shape;
 

--- a/burn-wgpu/src/kernel/prng/bernoulli.rs
+++ b/burn-wgpu/src/kernel/prng/bernoulli.rs
@@ -1,12 +1,12 @@
 use crate::{
     compute::StaticKernel,
-    element::WgpuElement,
+    element::JitElement,
     kernel::{
         prng::base::{make_args_buffer, make_info_buffer},
         prng_workgroup, KernelSettings, SourceTemplate, StaticKernelSource, WORKGROUP_DEFAULT,
     },
     ops::numeric::empty_device,
-    tensor::WgpuTensor,
+    tensor::JitTensor,
     Runtime,
 };
 use burn_tensor::Shape;
@@ -28,11 +28,11 @@ impl StaticKernelSource for BernoulliPrng {
 }
 
 /// Pseudo-random generator for bernoulli
-pub fn random_bernoulli<R: Runtime, E: WgpuElement, const D: usize>(
+pub fn random_bernoulli<R: Runtime, E: JitElement, const D: usize>(
     shape: Shape<D>,
     device: &R::Device,
     prob: E,
-) -> WgpuTensor<R, E, D> {
+) -> JitTensor<R, E, D> {
     const N_VALUES_PER_THREAD: usize = 128;
 
     let client = R::client(device);

--- a/burn-wgpu/src/kernel/prng/bernoulli.rs
+++ b/burn-wgpu/src/kernel/prng/bernoulli.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compute::{compute_client, StaticKernel},
+    compute::StaticKernel,
     element::WgpuElement,
     kernel::{
         prng::base::{make_args_buffer, make_info_buffer},
@@ -7,7 +7,7 @@ use crate::{
     },
     ops::numeric::empty_device,
     tensor::WgpuTensor,
-    GraphicsApi, WgpuDevice,
+    JitGpuBackend, WgpuDevice,
 };
 use burn_tensor::Shape;
 
@@ -28,14 +28,14 @@ impl StaticKernelSource for BernoulliPrng {
 }
 
 /// Pseudo-random generator for bernoulli
-pub fn random_bernoulli<G: GraphicsApi, E: WgpuElement, const D: usize>(
+pub fn random_bernoulli<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     shape: Shape<D>,
     device: &WgpuDevice,
     prob: E,
-) -> WgpuTensor<E, D> {
+) -> WgpuTensor<B, E, D> {
     const N_VALUES_PER_THREAD: usize = 128;
 
-    let client = compute_client::<G>(device);
+    let client = B::client(device);
     let output = empty_device(client.clone(), device.clone(), shape.clone());
     let info_handle = make_info_buffer(client.clone(), N_VALUES_PER_THREAD);
     let args_handle = make_args_buffer(client.clone(), &[prob]);

--- a/burn-wgpu/src/kernel/prng/normal.rs
+++ b/burn-wgpu/src/kernel/prng/normal.rs
@@ -2,13 +2,13 @@ use burn_tensor::Shape;
 
 use crate::{
     compute::StaticKernel,
-    element::WgpuElement,
+    element::JitElement,
     kernel::{
         prng::base::{make_args_buffer, make_info_buffer},
         prng_workgroup, KernelSettings, SourceTemplate, StaticKernelSource, WORKGROUP_DEFAULT,
     },
     ops::numeric::empty_device,
-    tensor::WgpuTensor,
+    tensor::JitTensor,
     Runtime,
 };
 
@@ -31,12 +31,12 @@ impl StaticKernelSource for NormalPrng {
 }
 
 /// Pseudo-random generaJitBackendl distribution
-pub fn random_normal<R: Runtime, E: WgpuElement, const D: usize>(
+pub fn random_normal<R: Runtime, E: JitElement, const D: usize>(
     shape: Shape<D>,
     device: &R::Device,
     mean: E,
     std: E,
-) -> WgpuTensor<R, E, D> {
+) -> JitTensor<R, E, D> {
     const N_VALUES_PER_THREAD: usize = 128; // must be even
 
     let client = R::client(device);

--- a/burn-wgpu/src/kernel/prng/normal.rs
+++ b/burn-wgpu/src/kernel/prng/normal.rs
@@ -33,7 +33,7 @@ impl StaticKernelSource for NormalPrng {
 /// Pseudo-random generator for normal distribution
 pub fn random_normal<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     shape: Shape<D>,
-    device: &WgpuDevice,
+    device: &B::Device,
     mean: E,
     std: E,
 ) -> WgpuTensor<B, E, D> {
@@ -41,8 +41,8 @@ pub fn random_normal<B: JitGpuBackend, E: WgpuElement, const D: usize>(
 
     let client = B::client(device);
     let output = empty_device(client.clone(), device.clone(), shape.clone());
-    let info_handle = make_info_buffer(client.clone(), N_VALUES_PER_THREAD);
-    let args_handle = make_args_buffer(client.clone(), &[mean, std]);
+    let info_handle = make_info_buffer::<B>(client.clone(), N_VALUES_PER_THREAD);
+    let args_handle = make_args_buffer::<B, E>(client.clone(), &[mean, std]);
     let workgroup = prng_workgroup(shape.num_elements(), WORKGROUP_DEFAULT, N_VALUES_PER_THREAD);
     let kernel = StaticKernel::<
         KernelSettings<NormalPrng, E, i32, WORKGROUP_DEFAULT, WORKGROUP_DEFAULT, 1>,

--- a/burn-wgpu/src/kernel/prng/normal.rs
+++ b/burn-wgpu/src/kernel/prng/normal.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     ops::numeric::empty_device,
     tensor::WgpuTensor,
-    JitRuntime,
+    Runtime,
 };
 
 use super::base::Prng;
@@ -31,18 +31,18 @@ impl StaticKernelSource for NormalPrng {
 }
 
 /// Pseudo-random generaJitBackendl distribution
-pub fn random_normal<B: JitRuntime, E: WgpuElement, const D: usize>(
+pub fn random_normal<R: Runtime, E: WgpuElement, const D: usize>(
     shape: Shape<D>,
-    device: &B::Device,
+    device: &R::Device,
     mean: E,
     std: E,
-) -> WgpuTensor<B, E, D> {
+) -> WgpuTensor<R, E, D> {
     const N_VALUES_PER_THREAD: usize = 128; // must be even
 
-    let client = B::client(device);
+    let client = R::client(device);
     let output = empty_device(client.clone(), device.clone(), shape.clone());
-    let info_handle = make_info_buffer::<B>(client.clone(), N_VALUES_PER_THREAD);
-    let args_handle = make_args_buffer::<B, E>(client.clone(), &[mean, std]);
+    let info_handle = make_info_buffer::<R>(client.clone(), N_VALUES_PER_THREAD);
+    let args_handle = make_args_buffer::<R, E>(client.clone(), &[mean, std]);
     let workgroup = prng_workgroup(shape.num_elements(), WORKGROUP_DEFAULT, N_VALUES_PER_THREAD);
     let kernel = StaticKernel::<
         KernelSettings<NormalPrng, E, i32, WORKGROUP_DEFAULT, WORKGROUP_DEFAULT, 1>,

--- a/burn-wgpu/src/kernel/prng/normal.rs
+++ b/burn-wgpu/src/kernel/prng/normal.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     ops::numeric::empty_device,
     tensor::WgpuTensor,
-    JitGpuBackend,
+    JitRuntime,
 };
 
 use super::base::Prng;
@@ -30,8 +30,8 @@ impl StaticKernelSource for NormalPrng {
     }
 }
 
-/// Pseudo-random generator for normal distribution
-pub fn random_normal<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+/// Pseudo-random generaJitBackendl distribution
+pub fn random_normal<B: JitRuntime, E: WgpuElement, const D: usize>(
     shape: Shape<D>,
     device: &B::Device,
     mean: E,

--- a/burn-wgpu/src/kernel/prng/normal.rs
+++ b/burn-wgpu/src/kernel/prng/normal.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     ops::numeric::empty_device,
     tensor::WgpuTensor,
-    GraphicsApi, JitGpuBackend, WgpuDevice,
+    JitGpuBackend,
 };
 
 use super::base::Prng;

--- a/burn-wgpu/src/kernel/prng/uniform.rs
+++ b/burn-wgpu/src/kernel/prng/uniform.rs
@@ -3,13 +3,13 @@ use burn_tensor::Shape;
 
 use crate::{
     compute::StaticKernel,
-    element::WgpuElement,
+    element::JitElement,
     kernel::{
         prng::base::{make_args_buffer, make_info_buffer},
         prng_workgroup, KernelSettings, SourceTemplate, StaticKernelSource, WORKGROUP_DEFAULT,
     },
     ops::numeric::empty_device,
-    tensor::WgpuTensor,
+    tensor::JitTensor,
     Runtime,
 };
 
@@ -27,23 +27,23 @@ impl StaticKernelSource for UniformPrng {
 }
 
 /// Pseudo-random generatJitBackendm distribution
-pub fn random_uniform<R: Runtime, E: WgpuElement, const D: usize>(
+pub fn random_uniform<R: Runtime, E: JitElement, const D: usize>(
     shape: Shape<D>,
     device: &R::Device,
     low: E,
     high: E,
-) -> WgpuTensor<R, E, D> {
+) -> JitTensor<R, E, D> {
     let client = R::client(device);
     uniform_kernel(client, device, &shape, low, high)
 }
 
 /// Pseudo-random generator for uniform distribution, based on
 /// another tensor's client, dJitBackendpe
-pub fn random_like_uniform<R: Runtime, E: WgpuElement, const D: usize>(
-    tensor: &WgpuTensor<R, E, D>,
+pub fn random_like_uniform<R: Runtime, E: JitElement, const D: usize>(
+    tensor: &JitTensor<R, E, D>,
     low: E,
     high: E,
-) -> WgpuTensor<R, E, D> {
+) -> JitTensor<R, E, D> {
     uniform_kernel(
         tensor.client.clone(),
         &tensor.device,
@@ -53,13 +53,13 @@ pub fn random_like_uniform<R: Runtime, E: WgpuElement, const D: usize>(
     )
 }
 
-fn uniform_kernel<R: Runtime, E: WgpuElement, const D: usize>(
+fn uniform_kernel<R: Runtime, E: JitElement, const D: usize>(
     client: ComputeClient<R::Server, R::Channel>,
     device: &R::Device,
     shape: &Shape<D>,
     low: E,
     high: E,
-) -> WgpuTensor<R, E, D> {
+) -> JitTensor<R, E, D> {
     const N_VALUES_PER_THREAD: usize = 128;
 
     let output = empty_device(client.clone(), device.clone(), shape.clone());

--- a/burn-wgpu/src/kernel/prng/uniform.rs
+++ b/burn-wgpu/src/kernel/prng/uniform.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     ops::numeric::empty_device,
     tensor::WgpuTensor,
-    GraphicsApi, JitGpuBackend, WgpuDevice,
+    JitGpuBackend,
 };
 
 use super::base::Prng;

--- a/burn-wgpu/src/kernel/prng/uniform.rs
+++ b/burn-wgpu/src/kernel/prng/uniform.rs
@@ -63,8 +63,8 @@ fn uniform_kernel<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     const N_VALUES_PER_THREAD: usize = 128;
 
     let output = empty_device(client.clone(), device.clone(), shape.clone());
-    let info_handle = make_info_buffer(client.clone(), N_VALUES_PER_THREAD);
-    let args_handle = make_args_buffer(client.clone(), &[low, high]);
+    let info_handle = make_info_buffer::<B>(client.clone(), N_VALUES_PER_THREAD);
+    let args_handle = make_args_buffer::<B, E>(client.clone(), &[low, high]);
     let workgroup = prng_workgroup(shape.num_elements(), WORKGROUP_DEFAULT, N_VALUES_PER_THREAD);
     let kernel = StaticKernel::<
         KernelSettings<UniformPrng, E, i32, WORKGROUP_DEFAULT, WORKGROUP_DEFAULT, 1>,

--- a/burn-wgpu/src/kernel/prng/uniform.rs
+++ b/burn-wgpu/src/kernel/prng/uniform.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     ops::numeric::empty_device,
     tensor::WgpuTensor,
-    JitGpuBackend,
+    JitRuntime,
 };
 
 use super::base::Prng;
@@ -26,8 +26,8 @@ impl StaticKernelSource for UniformPrng {
     }
 }
 
-/// Pseudo-random generator for uniform distribution
-pub fn random_uniform<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+/// Pseudo-random generatJitBackendm distribution
+pub fn random_uniform<B: JitRuntime, E: WgpuElement, const D: usize>(
     shape: Shape<D>,
     device: &B::Device,
     low: E,
@@ -38,8 +38,8 @@ pub fn random_uniform<B: JitGpuBackend, E: WgpuElement, const D: usize>(
 }
 
 /// Pseudo-random generator for uniform distribution, based on
-/// another tensor's client, device and shape
-pub fn random_like_uniform<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+/// another tensor's client, dJitBackendpe
+pub fn random_like_uniform<B: JitRuntime, E: WgpuElement, const D: usize>(
     tensor: &WgpuTensor<B, E, D>,
     low: E,
     high: E,
@@ -53,7 +53,7 @@ pub fn random_like_uniform<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     )
 }
 
-fn uniform_kernel<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+fn uniform_kernel<B: JitRuntime, E: WgpuElement, const D: usize>(
     client: ComputeClient<B::Server, B::Channel>,
     device: &B::Device,
     shape: &Shape<D>,

--- a/burn-wgpu/src/kernel/prng/uniform.rs
+++ b/burn-wgpu/src/kernel/prng/uniform.rs
@@ -26,7 +26,7 @@ impl StaticKernelSource for UniformPrng {
     }
 }
 
-/// Pseudo-random generatJitBackendm distribution
+/// Pseudo-random generator for the uniform distribution.
 pub fn random_uniform<R: Runtime, E: JitElement, const D: usize>(
     shape: Shape<D>,
     device: &R::Device,
@@ -38,7 +38,7 @@ pub fn random_uniform<R: Runtime, E: JitElement, const D: usize>(
 }
 
 /// Pseudo-random generator for uniform distribution, based on
-/// another tensor's client, dJitBackendpe
+/// another tensor.
 pub fn random_like_uniform<R: Runtime, E: JitElement, const D: usize>(
     tensor: &JitTensor<R, E, D>,
     low: E,

--- a/burn-wgpu/src/kernel/reduce/base.rs
+++ b/burn-wgpu/src/kernel/reduce/base.rs
@@ -1,10 +1,10 @@
-use crate::{element::WgpuElement, tensor::WgpuTensor, Runtime};
+use crate::{element::JitElement, tensor::JitTensor, Runtime};
 
 /// Creates an empty output tensor with reduce output shape
-pub fn init_reduce_output<R: Runtime, E: WgpuElement, const D: usize>(
-    input: &WgpuTensor<R, E, D>,
+pub fn init_reduce_output<R: Runtime, E: JitElement, const D: usize>(
+    input: &JitTensor<R, E, D>,
     reduce_dim: usize,
-) -> WgpuTensor<R, E, D> {
+) -> JitTensor<R, E, D> {
     let mut shape_out = input.shape.clone();
     shape_out.dims[reduce_dim] = 1;
 
@@ -13,7 +13,7 @@ pub fn init_reduce_output<R: Runtime, E: WgpuElement, const D: usize>(
     let handle = input
         .client
         .empty(num_elems_output * core::mem::size_of::<E>());
-    WgpuTensor::new(
+    JitTensor::new(
         input.client.clone(),
         input.device.clone(),
         shape_out.clone(),

--- a/burn-wgpu/src/kernel/reduce/base.rs
+++ b/burn-wgpu/src/kernel/reduce/base.rs
@@ -1,10 +1,10 @@
-use crate::{element::WgpuElement, tensor::WgpuTensor, JitRuntime};
+use crate::{element::WgpuElement, tensor::WgpuTensor, Runtime};
 
 /// Creates an empty output tensor with reduce output shape
-pub fn init_reduce_output<B: JitRuntime, E: WgpuElement, const D: usize>(
-    input: &WgpuTensor<B, E, D>,
+pub fn init_reduce_output<R: Runtime, E: WgpuElement, const D: usize>(
+    input: &WgpuTensor<R, E, D>,
     reduce_dim: usize,
-) -> WgpuTensor<B, E, D> {
+) -> WgpuTensor<R, E, D> {
     let mut shape_out = input.shape.clone();
     shape_out.dims[reduce_dim] = 1;
 

--- a/burn-wgpu/src/kernel/reduce/base.rs
+++ b/burn-wgpu/src/kernel/reduce/base.rs
@@ -1,10 +1,10 @@
-use crate::{element::WgpuElement, tensor::WgpuTensor};
+use crate::{element::WgpuElement, tensor::WgpuTensor, JitGpuBackend};
 
 /// Creates an empty output tensor with reduce output shape
-pub fn init_reduce_output<E: WgpuElement, const D: usize>(
-    input: &WgpuTensor<E, D>,
+pub fn init_reduce_output<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    input: &WgpuTensor<B, E, D>,
     reduce_dim: usize,
-) -> WgpuTensor<E, D> {
+) -> WgpuTensor<B, E, D> {
     let mut shape_out = input.shape.clone();
     shape_out.dims[reduce_dim] = 1;
 

--- a/burn-wgpu/src/kernel/reduce/base.rs
+++ b/burn-wgpu/src/kernel/reduce/base.rs
@@ -1,7 +1,7 @@
-use crate::{element::WgpuElement, tensor::WgpuTensor, JitGpuBackend};
+use crate::{element::WgpuElement, tensor::WgpuTensor, JitRuntime};
 
 /// Creates an empty output tensor with reduce output shape
-pub fn init_reduce_output<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn init_reduce_output<B: JitRuntime, E: WgpuElement, const D: usize>(
     input: &WgpuTensor<B, E, D>,
     reduce_dim: usize,
 ) -> WgpuTensor<B, E, D> {

--- a/burn-wgpu/src/kernel/reduce/reduction.rs
+++ b/burn-wgpu/src/kernel/reduce/reduction.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     kernel_wgsl,
     tensor::WgpuTensor,
-    JitGpuBackend,
+    JitRuntime,
 };
 use burn_tensor::Shape;
 
@@ -58,7 +58,7 @@ impl StaticKernelSource for ArgsMin {
 }
 
 /// Sum all elements in the input buffer.
-pub fn sum<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn sum<B: JitRuntime, E: WgpuElement, const D: usize>(
     input: WgpuTensor<B, E, D>,
 ) -> WgpuTensor<B, E, 1> {
     let mut input_handle = input.handle;
@@ -88,7 +88,7 @@ pub fn sum<B: JitGpuBackend, E: WgpuElement, const D: usize>(
 }
 
 /// Execute the sum dim kernel.
-pub fn sum_dim<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn sum_dim<B: JitRuntime, E: WgpuElement, const D: usize>(
     input: WgpuTensor<B, E, D>,
     output: WgpuTensor<B, E, D>,
     dim: usize,
@@ -97,7 +97,7 @@ pub fn sum_dim<B: JitGpuBackend, E: WgpuElement, const D: usize>(
 }
 
 /// Execute the mean dim kernel.
-pub fn mean_dim<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn mean_dim<B: JitRuntime, E: WgpuElement, const D: usize>(
     input: WgpuTensor<B, E, D>,
     output: WgpuTensor<B, E, D>,
     dim: usize,
@@ -105,7 +105,7 @@ pub fn mean_dim<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     reduction_dim::<MeanDim, B, E, D>(input, output, dim)
 }
 
-fn reduction_dim<K: StaticKernelSource, B: JitGpuBackend, E: WgpuElement, const D: usize>(
+fn reduction_dim<K: StaticKernelSource, B: JitRuntime, E: WgpuElement, const D: usize>(
     input: WgpuTensor<B, E, D>,
     output: WgpuTensor<B, E, D>,
     dim: usize,
@@ -128,7 +128,7 @@ fn reduction_dim<K: StaticKernelSource, B: JitGpuBackend, E: WgpuElement, const 
 }
 
 /// Execute the argmax kernel.
-pub fn argmax<B: JitGpuBackend, E: WgpuElement, I: WgpuElement, const D: usize>(
+pub fn argmax<B: JitRuntime, E: WgpuElement, I: WgpuElement, const D: usize>(
     input: WgpuTensor<B, E, D>,
     dim: usize,
 ) -> WgpuTensor<B, I, D> {
@@ -136,7 +136,7 @@ pub fn argmax<B: JitGpuBackend, E: WgpuElement, I: WgpuElement, const D: usize>(
 }
 
 /// Execute the argmin kernel.
-pub fn argmin<B: JitGpuBackend, E: WgpuElement, I: WgpuElement, const D: usize>(
+pub fn argmin<B: JitRuntime, E: WgpuElement, I: WgpuElement, const D: usize>(
     input: WgpuTensor<B, E, D>,
     dim: usize,
 ) -> WgpuTensor<B, I, D> {
@@ -145,7 +145,7 @@ pub fn argmin<B: JitGpuBackend, E: WgpuElement, I: WgpuElement, const D: usize>(
 
 fn reduction_args_dim<
     K: StaticKernelSource,
-    B: JitGpuBackend,
+    B: JitRuntime,
     E: WgpuElement,
     I: WgpuElement,
     const D: usize,
@@ -185,7 +185,7 @@ mod tests {
     use super::*;
     use crate::{
         kernel::reduce::init_reduce_output,
-        tests::{ReferenceBackend, TestBackend, TestJitGpuBackend},
+        tests::{ReferenceBackend, TestBackend, TestJitRuntime},
     };
     use burn_tensor::{Distribution, Int, Tensor};
 
@@ -214,7 +214,7 @@ mod tests {
         let val =
             Tensor::<TestBackend, 2>::from_primitive(reduction_dim::<
                 SumDim,
-                TestJitGpuBackend,
+                TestJitRuntime,
                 f32,
                 2,
             >(

--- a/burn-wgpu/src/kernel/reduce/reduction.rs
+++ b/burn-wgpu/src/kernel/reduce/reduction.rs
@@ -212,13 +212,11 @@ mod tests {
         let output = init_reduce_output(&tensor.clone().into_primitive(), reduce_dim);
 
         let val =
-            Tensor::<TestBackend, 2>::from_primitive(
-                reduction_dim::<SumDim, TestRuntime, f32, 2>(
-                    tensor.into_primitive(),
-                    output,
-                    reduce_dim,
-                ),
-            );
+            Tensor::<TestBackend, 2>::from_primitive(reduction_dim::<SumDim, TestRuntime, f32, 2>(
+                tensor.into_primitive(),
+                output,
+                reduce_dim,
+            ));
         let val_ref = tensor_ref.sum_dim(1);
 
         val_ref.into_data().assert_approx_eq(&val.into_data(), 3);

--- a/burn-wgpu/src/kernel/reduce/reduction_shared_memory.rs
+++ b/burn-wgpu/src/kernel/reduce/reduction_shared_memory.rs
@@ -4,7 +4,7 @@ use crate::{
     kernel::{build_info, KernelSettings, SourceTemplate, StaticKernelSource, WORKGROUP_DEFAULT},
     kernel_wgsl,
     tensor::WgpuTensor,
-    JitRuntime,
+    Runtime,
 };
 
 kernel_wgsl!(
@@ -52,35 +52,35 @@ impl StaticKernelSource for MeanDimSharedMemory {
 /// Execute the sum dim kernel leveraging shared memory
 /// Probably more efficient on tensors where the dimension to reduced
 /// is much larger than the others
-pub fn sum_dim_shared_memory<B: JitRuntime, E: WgpuElement, const D: usize>(
-    input: WgpuTensor<B, E, D>,
-    output: WgpuTensor<B, E, D>,
+pub fn sum_dim_shared_memory<R: Runtime, E: WgpuElement, const D: usize>(
+    input: WgpuTensor<R, E, D>,
+    output: WgpuTensor<R, E, D>,
     dim: usize,
-) -> WgpuTensor<B, E, D> {
-    reduction_dim_shared_memory::<SumDimSharedMemory, B, E, D>(input, output, dim)
+) -> WgpuTensor<R, E, D> {
+    reduction_dim_shared_memory::<SumDimSharedMemory, R, E, D>(input, output, dim)
 }
 
 /// Execute the mean dim kernel leveraging shared memory
 /// Probably more efficient on tensors where the dimension to reduced
 /// is much larger than the others
-pub fn mean_dim_shared_memory<B: JitRuntime, E: WgpuElement, const D: usize>(
-    input: WgpuTensor<B, E, D>,
-    output: WgpuTensor<B, E, D>,
+pub fn mean_dim_shared_memory<R: Runtime, E: WgpuElement, const D: usize>(
+    input: WgpuTensor<R, E, D>,
+    output: WgpuTensor<R, E, D>,
     dim: usize,
-) -> WgpuTensor<B, E, D> {
-    reduction_dim_shared_memory::<MeanDimSharedMemory, B, E, D>(input, output, dim)
+) -> WgpuTensor<R, E, D> {
+    reduction_dim_shared_memory::<MeanDimSharedMemory, R, E, D>(input, output, dim)
 }
 
 fn reduction_dim_shared_memory<
     K: StaticKernelSource,
-    B: JitRuntime,
+    R: Runtime,
     E: WgpuElement,
     const D: usize,
 >(
-    input: WgpuTensor<B, E, D>,
-    output: WgpuTensor<B, E, D>,
+    input: WgpuTensor<R, E, D>,
+    output: WgpuTensor<R, E, D>,
     reduce_dim: usize,
-) -> WgpuTensor<B, E, D> {
+) -> WgpuTensor<R, E, D> {
     let num_elems_output = output.shape.num_elements();
     let n_workgroups_x = f32::ceil(f32::sqrt(num_elems_output as f32));
     let n_workgroups_y = f32::ceil(num_elems_output as f32 / n_workgroups_x);

--- a/burn-wgpu/src/kernel/reduce/reduction_shared_memory.rs
+++ b/burn-wgpu/src/kernel/reduce/reduction_shared_memory.rs
@@ -1,9 +1,9 @@
 use crate::{
     compute::{StaticKernel, WorkGroup},
-    element::WgpuElement,
+    element::JitElement,
     kernel::{build_info, KernelSettings, SourceTemplate, StaticKernelSource, WORKGROUP_DEFAULT},
     kernel_wgsl,
-    tensor::WgpuTensor,
+    tensor::JitTensor,
     Runtime,
 };
 
@@ -52,35 +52,35 @@ impl StaticKernelSource for MeanDimSharedMemory {
 /// Execute the sum dim kernel leveraging shared memory
 /// Probably more efficient on tensors where the dimension to reduced
 /// is much larger than the others
-pub fn sum_dim_shared_memory<R: Runtime, E: WgpuElement, const D: usize>(
-    input: WgpuTensor<R, E, D>,
-    output: WgpuTensor<R, E, D>,
+pub fn sum_dim_shared_memory<R: Runtime, E: JitElement, const D: usize>(
+    input: JitTensor<R, E, D>,
+    output: JitTensor<R, E, D>,
     dim: usize,
-) -> WgpuTensor<R, E, D> {
+) -> JitTensor<R, E, D> {
     reduction_dim_shared_memory::<SumDimSharedMemory, R, E, D>(input, output, dim)
 }
 
 /// Execute the mean dim kernel leveraging shared memory
 /// Probably more efficient on tensors where the dimension to reduced
 /// is much larger than the others
-pub fn mean_dim_shared_memory<R: Runtime, E: WgpuElement, const D: usize>(
-    input: WgpuTensor<R, E, D>,
-    output: WgpuTensor<R, E, D>,
+pub fn mean_dim_shared_memory<R: Runtime, E: JitElement, const D: usize>(
+    input: JitTensor<R, E, D>,
+    output: JitTensor<R, E, D>,
     dim: usize,
-) -> WgpuTensor<R, E, D> {
+) -> JitTensor<R, E, D> {
     reduction_dim_shared_memory::<MeanDimSharedMemory, R, E, D>(input, output, dim)
 }
 
 fn reduction_dim_shared_memory<
     K: StaticKernelSource,
     R: Runtime,
-    E: WgpuElement,
+    E: JitElement,
     const D: usize,
 >(
-    input: WgpuTensor<R, E, D>,
-    output: WgpuTensor<R, E, D>,
+    input: JitTensor<R, E, D>,
+    output: JitTensor<R, E, D>,
     reduce_dim: usize,
-) -> WgpuTensor<R, E, D> {
+) -> JitTensor<R, E, D> {
     let num_elems_output = output.shape.num_elements();
     let n_workgroups_x = f32::ceil(f32::sqrt(num_elems_output as f32));
     let n_workgroups_y = f32::ceil(num_elems_output as f32 / n_workgroups_x);

--- a/burn-wgpu/src/kernel/reduce/reduction_shared_memory.rs
+++ b/burn-wgpu/src/kernel/reduce/reduction_shared_memory.rs
@@ -71,12 +71,7 @@ pub fn mean_dim_shared_memory<R: Runtime, E: JitElement, const D: usize>(
     reduction_dim_shared_memory::<MeanDimSharedMemory, R, E, D>(input, output, dim)
 }
 
-fn reduction_dim_shared_memory<
-    K: StaticKernelSource,
-    R: Runtime,
-    E: JitElement,
-    const D: usize,
->(
+fn reduction_dim_shared_memory<K: StaticKernelSource, R: Runtime, E: JitElement, const D: usize>(
     input: JitTensor<R, E, D>,
     output: JitTensor<R, E, D>,
     reduce_dim: usize,

--- a/burn-wgpu/src/kernel/reduce/reduction_shared_memory.rs
+++ b/burn-wgpu/src/kernel/reduce/reduction_shared_memory.rs
@@ -4,7 +4,7 @@ use crate::{
     kernel::{build_info, KernelSettings, SourceTemplate, StaticKernelSource, WORKGROUP_DEFAULT},
     kernel_wgsl,
     tensor::WgpuTensor,
-    JitGpuBackend,
+    JitRuntime,
 };
 
 kernel_wgsl!(
@@ -52,7 +52,7 @@ impl StaticKernelSource for MeanDimSharedMemory {
 /// Execute the sum dim kernel leveraging shared memory
 /// Probably more efficient on tensors where the dimension to reduced
 /// is much larger than the others
-pub fn sum_dim_shared_memory<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn sum_dim_shared_memory<B: JitRuntime, E: WgpuElement, const D: usize>(
     input: WgpuTensor<B, E, D>,
     output: WgpuTensor<B, E, D>,
     dim: usize,
@@ -63,7 +63,7 @@ pub fn sum_dim_shared_memory<B: JitGpuBackend, E: WgpuElement, const D: usize>(
 /// Execute the mean dim kernel leveraging shared memory
 /// Probably more efficient on tensors where the dimension to reduced
 /// is much larger than the others
-pub fn mean_dim_shared_memory<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn mean_dim_shared_memory<B: JitRuntime, E: WgpuElement, const D: usize>(
     input: WgpuTensor<B, E, D>,
     output: WgpuTensor<B, E, D>,
     dim: usize,
@@ -73,7 +73,7 @@ pub fn mean_dim_shared_memory<B: JitGpuBackend, E: WgpuElement, const D: usize>(
 
 fn reduction_dim_shared_memory<
     K: StaticKernelSource,
-    B: JitGpuBackend,
+    B: JitRuntime,
     E: WgpuElement,
     const D: usize,
 >(

--- a/burn-wgpu/src/kernel/reduce/reduction_shared_memory.rs
+++ b/burn-wgpu/src/kernel/reduce/reduction_shared_memory.rs
@@ -57,7 +57,7 @@ pub fn sum_dim_shared_memory<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     output: WgpuTensor<B, E, D>,
     dim: usize,
 ) -> WgpuTensor<B, E, D> {
-    reduction_dim_shared_memory::<SumDimSharedMemory, E, D>(input, output, dim)
+    reduction_dim_shared_memory::<SumDimSharedMemory, B, E, D>(input, output, dim)
 }
 
 /// Execute the mean dim kernel leveraging shared memory

--- a/burn-wgpu/src/kernel/reduce/tune/base.rs
+++ b/burn-wgpu/src/kernel/reduce/tune/base.rs
@@ -3,13 +3,13 @@
 macro_rules! reduce_tune_ops {
     ($name:ident, $func:expr) => {
         #[derive(new)]
-        pub(crate) struct $name<R: Runtime, E: WgpuElement, const D: usize> {
-            input: WgpuTensor<R, E, D>,
-            output: WgpuTensor<R, E, D>,
+        pub(crate) struct $name<R: Runtime, E: JitElement, const D: usize> {
+            input: JitTensor<R, E, D>,
+            output: JitTensor<R, E, D>,
             reduce_dim: usize,
         }
 
-        impl<R: Runtime, E: WgpuElement, const D: usize> AutotuneOperation for $name<R, E, D> {
+        impl<R: Runtime, E: JitElement, const D: usize> AutotuneOperation for $name<R, E, D> {
             fn execute(self: Box<Self>) {
                 #[allow(clippy::redundant_closure_call)]
                 $func(self.input, self.output, self.reduce_dim);

--- a/burn-wgpu/src/kernel/reduce/tune/base.rs
+++ b/burn-wgpu/src/kernel/reduce/tune/base.rs
@@ -3,13 +3,15 @@
 macro_rules! reduce_tune_ops {
     ($name:ident, $func:expr) => {
         #[derive(new)]
-        pub(crate) struct $name<E: WgpuElement, const D: usize> {
-            input: WgpuTensor<E, D>,
-            output: WgpuTensor<E, D>,
+        pub(crate) struct $name<B: JitGpuBackend, E: WgpuElement, const D: usize> {
+            input: WgpuTensor<B, E, D>,
+            output: WgpuTensor<B, E, D>,
             reduce_dim: usize,
         }
 
-        impl<E: WgpuElement, const D: usize> AutotuneOperation for $name<E, D> {
+        impl<B: JitGpuBackend, E: WgpuElement, const D: usize> AutotuneOperation
+            for $name<B, E, D>
+        {
             fn execute(self: Box<Self>) {
                 #[allow(clippy::redundant_closure_call)]
                 $func(self.input, self.output, self.reduce_dim);

--- a/burn-wgpu/src/kernel/reduce/tune/base.rs
+++ b/burn-wgpu/src/kernel/reduce/tune/base.rs
@@ -3,13 +3,13 @@
 macro_rules! reduce_tune_ops {
     ($name:ident, $func:expr) => {
         #[derive(new)]
-        pub(crate) struct $name<B: JitRuntime, E: WgpuElement, const D: usize> {
-            input: WgpuTensor<B, E, D>,
-            output: WgpuTensor<B, E, D>,
+        pub(crate) struct $name<R: Runtime, E: WgpuElement, const D: usize> {
+            input: WgpuTensor<R, E, D>,
+            output: WgpuTensor<R, E, D>,
             reduce_dim: usize,
         }
 
-        impl<B: JitRuntime, E: WgpuElement, const D: usize> AutotuneOperation for $name<B, E, D> {
+        impl<R: Runtime, E: WgpuElement, const D: usize> AutotuneOperation for $name<R, E, D> {
             fn execute(self: Box<Self>) {
                 #[allow(clippy::redundant_closure_call)]
                 $func(self.input, self.output, self.reduce_dim);

--- a/burn-wgpu/src/kernel/reduce/tune/base.rs
+++ b/burn-wgpu/src/kernel/reduce/tune/base.rs
@@ -3,15 +3,13 @@
 macro_rules! reduce_tune_ops {
     ($name:ident, $func:expr) => {
         #[derive(new)]
-        pub(crate) struct $name<B: JitGpuBackend, E: WgpuElement, const D: usize> {
+        pub(crate) struct $name<B: JitRuntime, E: WgpuElement, const D: usize> {
             input: WgpuTensor<B, E, D>,
             output: WgpuTensor<B, E, D>,
             reduce_dim: usize,
         }
 
-        impl<B: JitGpuBackend, E: WgpuElement, const D: usize> AutotuneOperation
-            for $name<B, E, D>
-        {
+        impl<B: JitRuntime, E: WgpuElement, const D: usize> AutotuneOperation for $name<B, E, D> {
             fn execute(self: Box<Self>) {
                 #[allow(clippy::redundant_closure_call)]
                 $func(self.input, self.output, self.reduce_dim);

--- a/burn-wgpu/src/kernel/reduce/tune/mean_dim.rs
+++ b/burn-wgpu/src/kernel/reduce/tune/mean_dim.rs
@@ -2,15 +2,15 @@ use burn_compute::tune::{AutotuneOperation, AutotuneOperationSet};
 use burn_tensor::{Element, ElementConversion};
 
 use crate::{
-    compute::WgpuAutotuneKey,
-    element::WgpuElement,
+    compute::JitAutotuneKey,
+    element::JitElement,
     kernel::{
         prng::random_like_uniform,
         reduce::{init_reduce_output, mean_dim, mean_dim_shared_memory},
     },
     ops::numeric::empty_device,
     reduce_tune_ops,
-    tensor::WgpuTensor,
+    tensor::JitTensor,
     Runtime,
 };
 
@@ -19,16 +19,16 @@ use super::ReduceAutotuneKey;
 /// Set of mean_dim implementations available for autotune
 /// Autotune key is given by concatenating the closest upper power of 2 of
 /// dim to reduce, and product of others
-pub struct MeanDimAutotuneOperationSet<R: Runtime, E: WgpuElement, const D: usize> {
-    key: WgpuAutotuneKey,
-    input: WgpuTensor<R, E, D>,
-    output: WgpuTensor<R, E, D>,
+pub struct MeanDimAutotuneOperationSet<R: Runtime, E: JitElement, const D: usize> {
+    key: JitAutotuneKey,
+    input: JitTensor<R, E, D>,
+    output: JitTensor<R, E, D>,
     reduce_dim: usize,
 }
-impl<R: Runtime, E: WgpuElement, const D: usize> MeanDimAutotuneOperationSet<R, E, D> {
-    fn new(input: WgpuTensor<R, E, D>, output: WgpuTensor<R, E, D>, reduce_dim: usize) -> Self {
+impl<R: Runtime, E: JitElement, const D: usize> MeanDimAutotuneOperationSet<R, E, D> {
+    fn new(input: JitTensor<R, E, D>, output: JitTensor<R, E, D>, reduce_dim: usize) -> Self {
         Self {
-            key: WgpuAutotuneKey::MeanDim(ReduceAutotuneKey::new(
+            key: JitAutotuneKey::MeanDim(ReduceAutotuneKey::new(
                 &input.shape,
                 &input.strides,
                 reduce_dim,
@@ -40,10 +40,10 @@ impl<R: Runtime, E: WgpuElement, const D: usize> MeanDimAutotuneOperationSet<R, 
     }
 }
 
-impl<R: Runtime, E: WgpuElement + Element, const D: usize> AutotuneOperationSet<WgpuAutotuneKey>
+impl<R: Runtime, E: JitElement + Element, const D: usize> AutotuneOperationSet<JitAutotuneKey>
     for MeanDimAutotuneOperationSet<R, E, D>
 {
-    fn key(&self) -> WgpuAutotuneKey {
+    fn key(&self) -> JitAutotuneKey {
         self.key.clone()
     }
 
@@ -91,10 +91,10 @@ impl<R: Runtime, E: WgpuElement + Element, const D: usize> AutotuneOperationSet<
 }
 
 /// Executes autotune on mean_dim operation
-pub fn mean_dim_autotune<R: Runtime, E: WgpuElement + Element, const D: usize>(
-    input: WgpuTensor<R, E, D>,
+pub fn mean_dim_autotune<R: Runtime, E: JitElement + Element, const D: usize>(
+    input: JitTensor<R, E, D>,
     reduce_dim: usize,
-) -> WgpuTensor<R, E, D> {
+) -> JitTensor<R, E, D> {
     let client = input.client.clone();
 
     let output = init_reduce_output(&input, reduce_dim);

--- a/burn-wgpu/src/kernel/reduce/tune/mean_dim.rs
+++ b/burn-wgpu/src/kernel/reduce/tune/mean_dim.rs
@@ -11,7 +11,7 @@ use crate::{
     ops::numeric::empty_device,
     reduce_tune_ops,
     tensor::WgpuTensor,
-    JitRuntime,
+    Runtime,
 };
 
 use super::ReduceAutotuneKey;
@@ -19,14 +19,14 @@ use super::ReduceAutotuneKey;
 /// Set of mean_dim implementations available for autotune
 /// Autotune key is given by concatenating the closest upper power of 2 of
 /// dim to reduce, and product of others
-pub struct MeanDimAutotuneOperationSet<B: JitRuntime, E: WgpuElement, const D: usize> {
+pub struct MeanDimAutotuneOperationSet<R: Runtime, E: WgpuElement, const D: usize> {
     key: WgpuAutotuneKey,
-    input: WgpuTensor<B, E, D>,
-    output: WgpuTensor<B, E, D>,
+    input: WgpuTensor<R, E, D>,
+    output: WgpuTensor<R, E, D>,
     reduce_dim: usize,
 }
-impl<B: JitRuntime, E: WgpuElement, const D: usize> MeanDimAutotuneOperationSet<B, E, D> {
-    fn new(input: WgpuTensor<B, E, D>, output: WgpuTensor<B, E, D>, reduce_dim: usize) -> Self {
+impl<R: Runtime, E: WgpuElement, const D: usize> MeanDimAutotuneOperationSet<R, E, D> {
+    fn new(input: WgpuTensor<R, E, D>, output: WgpuTensor<R, E, D>, reduce_dim: usize) -> Self {
         Self {
             key: WgpuAutotuneKey::MeanDim(ReduceAutotuneKey::new(
                 &input.shape,
@@ -40,8 +40,8 @@ impl<B: JitRuntime, E: WgpuElement, const D: usize> MeanDimAutotuneOperationSet<
     }
 }
 
-impl<B: JitRuntime, E: WgpuElement + Element, const D: usize>
-    AutotuneOperationSet<WgpuAutotuneKey> for MeanDimAutotuneOperationSet<B, E, D>
+impl<R: Runtime, E: WgpuElement + Element, const D: usize> AutotuneOperationSet<WgpuAutotuneKey>
+    for MeanDimAutotuneOperationSet<R, E, D>
 {
     fn key(&self) -> WgpuAutotuneKey {
         self.key.clone()
@@ -91,10 +91,10 @@ impl<B: JitRuntime, E: WgpuElement + Element, const D: usize>
 }
 
 /// Executes autotune on mean_dim operation
-pub fn mean_dim_autotune<B: JitRuntime, E: WgpuElement + Element, const D: usize>(
-    input: WgpuTensor<B, E, D>,
+pub fn mean_dim_autotune<R: Runtime, E: WgpuElement + Element, const D: usize>(
+    input: WgpuTensor<R, E, D>,
     reduce_dim: usize,
-) -> WgpuTensor<B, E, D> {
+) -> WgpuTensor<R, E, D> {
     let client = input.client.clone();
 
     let output = init_reduce_output(&input, reduce_dim);

--- a/burn-wgpu/src/kernel/reduce/tune/mean_dim.rs
+++ b/burn-wgpu/src/kernel/reduce/tune/mean_dim.rs
@@ -58,12 +58,12 @@ impl<B: JitGpuBackend, E: WgpuElement + Element, const D: usize>
         );
 
         vec![
-            Box::new(MeanDimAutotune::<E, D>::new(
+            Box::new(MeanDimAutotune::new(
                 input.clone(),
                 output.clone(),
                 self.reduce_dim,
             )),
-            Box::new(MeanDimSharedMemoryAutotune::<E, D>::new(
+            Box::new(MeanDimSharedMemoryAutotune::new(
                 input.clone(),
                 output.clone(),
                 self.reduce_dim,
@@ -75,12 +75,12 @@ impl<B: JitGpuBackend, E: WgpuElement + Element, const D: usize>
         // Warning: since AutotuneOperationSet shares his key with SumDimAutotuneOperationSet
         // we must make sure the order here is correlated with SumDim
         match fastest_index {
-            0 => Box::new(MeanDimAutotune::<E, D>::new(
+            0 => Box::new(MeanDimAutotune::new(
                 self.input,
                 self.output,
                 self.reduce_dim,
             )),
-            1 => Box::new(MeanDimSharedMemoryAutotune::<E, D>::new(
+            1 => Box::new(MeanDimSharedMemoryAutotune::new(
                 self.input,
                 self.output,
                 self.reduce_dim,
@@ -99,7 +99,7 @@ pub fn mean_dim_autotune<B: JitGpuBackend, E: WgpuElement + Element, const D: us
 
     let output = init_reduce_output(&input, reduce_dim);
 
-    let operation_set = Box::new(MeanDimAutotuneOperationSet::<E, D>::new(
+    let operation_set = Box::new(MeanDimAutotuneOperationSet::new(
         input,
         output.clone(),
         reduce_dim,

--- a/burn-wgpu/src/kernel/reduce/tune/mean_dim.rs
+++ b/burn-wgpu/src/kernel/reduce/tune/mean_dim.rs
@@ -11,7 +11,7 @@ use crate::{
     ops::numeric::empty_device,
     reduce_tune_ops,
     tensor::WgpuTensor,
-    JitGpuBackend,
+    JitRuntime,
 };
 
 use super::ReduceAutotuneKey;
@@ -19,13 +19,13 @@ use super::ReduceAutotuneKey;
 /// Set of mean_dim implementations available for autotune
 /// Autotune key is given by concatenating the closest upper power of 2 of
 /// dim to reduce, and product of others
-pub struct MeanDimAutotuneOperationSet<B: JitGpuBackend, E: WgpuElement, const D: usize> {
+pub struct MeanDimAutotuneOperationSet<B: JitRuntime, E: WgpuElement, const D: usize> {
     key: WgpuAutotuneKey,
     input: WgpuTensor<B, E, D>,
     output: WgpuTensor<B, E, D>,
     reduce_dim: usize,
 }
-impl<B: JitGpuBackend, E: WgpuElement, const D: usize> MeanDimAutotuneOperationSet<B, E, D> {
+impl<B: JitRuntime, E: WgpuElement, const D: usize> MeanDimAutotuneOperationSet<B, E, D> {
     fn new(input: WgpuTensor<B, E, D>, output: WgpuTensor<B, E, D>, reduce_dim: usize) -> Self {
         Self {
             key: WgpuAutotuneKey::MeanDim(ReduceAutotuneKey::new(
@@ -40,7 +40,7 @@ impl<B: JitGpuBackend, E: WgpuElement, const D: usize> MeanDimAutotuneOperationS
     }
 }
 
-impl<B: JitGpuBackend, E: WgpuElement + Element, const D: usize>
+impl<B: JitRuntime, E: WgpuElement + Element, const D: usize>
     AutotuneOperationSet<WgpuAutotuneKey> for MeanDimAutotuneOperationSet<B, E, D>
 {
     fn key(&self) -> WgpuAutotuneKey {
@@ -91,7 +91,7 @@ impl<B: JitGpuBackend, E: WgpuElement + Element, const D: usize>
 }
 
 /// Executes autotune on mean_dim operation
-pub fn mean_dim_autotune<B: JitGpuBackend, E: WgpuElement + Element, const D: usize>(
+pub fn mean_dim_autotune<B: JitRuntime, E: WgpuElement + Element, const D: usize>(
     input: WgpuTensor<B, E, D>,
     reduce_dim: usize,
 ) -> WgpuTensor<B, E, D> {

--- a/burn-wgpu/src/kernel/reduce/tune/sum_dim.rs
+++ b/burn-wgpu/src/kernel/reduce/tune/sum_dim.rs
@@ -58,12 +58,12 @@ impl<B: JitGpuBackend, E: WgpuElement + Element, const D: usize>
         );
 
         vec![
-            Box::new(SumDimAutotune::<E, D>::new(
+            Box::new(SumDimAutotune::new(
                 input.clone(),
                 output.clone(),
                 self.reduce_dim,
             )),
-            Box::new(SumDimSharedMemoryAutotune::<E, D>::new(
+            Box::new(SumDimSharedMemoryAutotune::new(
                 input.clone(),
                 output.clone(),
                 self.reduce_dim,
@@ -75,12 +75,12 @@ impl<B: JitGpuBackend, E: WgpuElement + Element, const D: usize>
         // Warning: since AutotuneOperationSet shares his key with MeanDimAutotuneOperationSet
         // we must make sure the order here is correlated with MeanDim
         match fastest_index {
-            0 => Box::new(SumDimAutotune::<E, D>::new(
+            0 => Box::new(SumDimAutotune::new(
                 self.input,
                 self.output,
                 self.reduce_dim,
             )),
-            1 => Box::new(SumDimSharedMemoryAutotune::<E, D>::new(
+            1 => Box::new(SumDimSharedMemoryAutotune::new(
                 self.input,
                 self.output,
                 self.reduce_dim,
@@ -99,7 +99,7 @@ pub fn sum_dim_autotune<B: JitGpuBackend, E: WgpuElement + Element, const D: usi
 
     let output = init_reduce_output(&input, reduce_dim);
 
-    let operation_set = Box::new(SumDimAutotuneOperationSet::<E, D>::new(
+    let operation_set = Box::new(SumDimAutotuneOperationSet::new(
         input,
         output.clone(),
         reduce_dim,

--- a/burn-wgpu/src/kernel/reduce/tune/sum_dim.rs
+++ b/burn-wgpu/src/kernel/reduce/tune/sum_dim.rs
@@ -11,6 +11,7 @@ use crate::{
     ops::numeric::empty_device,
     reduce_tune_ops,
     tensor::WgpuTensor,
+    JitGpuBackend,
 };
 
 use super::ReduceAutotuneKey;
@@ -18,14 +19,14 @@ use super::ReduceAutotuneKey;
 /// Set of sum_dim implementations available for autotune
 /// Autotune key is given by concatenating the closest upper power of 2 of
 /// dim to reduce, and product of others
-pub struct SumDimAutotuneOperationSet<E: WgpuElement, const D: usize> {
+pub struct SumDimAutotuneOperationSet<B: JitGpuBackend, E: WgpuElement, const D: usize> {
     key: WgpuAutotuneKey,
-    input: WgpuTensor<E, D>,
-    output: WgpuTensor<E, D>,
+    input: WgpuTensor<B, E, D>,
+    output: WgpuTensor<B, E, D>,
     reduce_dim: usize,
 }
-impl<E: WgpuElement, const D: usize> SumDimAutotuneOperationSet<E, D> {
-    fn new(input: WgpuTensor<E, D>, output: WgpuTensor<E, D>, reduce_dim: usize) -> Self {
+impl<B: JitGpuBackend, E: WgpuElement, const D: usize> SumDimAutotuneOperationSet<B, E, D> {
+    fn new(input: WgpuTensor<B, E, D>, output: WgpuTensor<B, E, D>, reduce_dim: usize) -> Self {
         Self {
             key: WgpuAutotuneKey::SumDim(ReduceAutotuneKey::new(
                 &input.shape,
@@ -39,8 +40,8 @@ impl<E: WgpuElement, const D: usize> SumDimAutotuneOperationSet<E, D> {
     }
 }
 
-impl<E: WgpuElement + Element, const D: usize> AutotuneOperationSet<WgpuAutotuneKey>
-    for SumDimAutotuneOperationSet<E, D>
+impl<B: JitGpuBackend, E: WgpuElement + Element, const D: usize>
+    AutotuneOperationSet<WgpuAutotuneKey> for SumDimAutotuneOperationSet<B, E, D>
 {
     fn key(&self) -> WgpuAutotuneKey {
         self.key.clone()
@@ -90,10 +91,10 @@ impl<E: WgpuElement + Element, const D: usize> AutotuneOperationSet<WgpuAutotune
 }
 
 /// Executes autotune on sum_dim operation
-pub fn sum_dim_autotune<E: WgpuElement + Element, const D: usize>(
-    input: WgpuTensor<E, D>,
+pub fn sum_dim_autotune<B: JitGpuBackend, E: WgpuElement + Element, const D: usize>(
+    input: WgpuTensor<B, E, D>,
     reduce_dim: usize,
-) -> WgpuTensor<E, D> {
+) -> WgpuTensor<B, E, D> {
     let client = input.client.clone();
 
     let output = init_reduce_output(&input, reduce_dim);

--- a/burn-wgpu/src/kernel/reduce/tune/sum_dim.rs
+++ b/burn-wgpu/src/kernel/reduce/tune/sum_dim.rs
@@ -2,15 +2,15 @@ use burn_compute::tune::{AutotuneOperation, AutotuneOperationSet};
 use burn_tensor::{Element, ElementConversion};
 
 use crate::{
-    compute::WgpuAutotuneKey,
-    element::WgpuElement,
+    compute::JitAutotuneKey,
+    element::JitElement,
     kernel::{
         prng::random_like_uniform,
         reduce::{init_reduce_output, sum_dim, sum_dim_shared_memory},
     },
     ops::numeric::empty_device,
     reduce_tune_ops,
-    tensor::WgpuTensor,
+    tensor::JitTensor,
     Runtime,
 };
 
@@ -19,16 +19,16 @@ use super::ReduceAutotuneKey;
 /// Set of sum_dim implementations available for autotune
 /// Autotune key is given by concatenating the closest upper power of 2 of
 /// dim to reduce, and product of others
-pub struct SumDimAutotuneOperationSet<R: Runtime, E: WgpuElement, const D: usize> {
-    key: WgpuAutotuneKey,
-    input: WgpuTensor<R, E, D>,
-    output: WgpuTensor<R, E, D>,
+pub struct SumDimAutotuneOperationSet<R: Runtime, E: JitElement, const D: usize> {
+    key: JitAutotuneKey,
+    input: JitTensor<R, E, D>,
+    output: JitTensor<R, E, D>,
     reduce_dim: usize,
 }
-impl<R: Runtime, E: WgpuElement, const D: usize> SumDimAutotuneOperationSet<R, E, D> {
-    fn new(input: WgpuTensor<R, E, D>, output: WgpuTensor<R, E, D>, reduce_dim: usize) -> Self {
+impl<R: Runtime, E: JitElement, const D: usize> SumDimAutotuneOperationSet<R, E, D> {
+    fn new(input: JitTensor<R, E, D>, output: JitTensor<R, E, D>, reduce_dim: usize) -> Self {
         Self {
-            key: WgpuAutotuneKey::SumDim(ReduceAutotuneKey::new(
+            key: JitAutotuneKey::SumDim(ReduceAutotuneKey::new(
                 &input.shape,
                 &input.strides,
                 reduce_dim,
@@ -40,10 +40,10 @@ impl<R: Runtime, E: WgpuElement, const D: usize> SumDimAutotuneOperationSet<R, E
     }
 }
 
-impl<R: Runtime, E: WgpuElement + Element, const D: usize> AutotuneOperationSet<WgpuAutotuneKey>
+impl<R: Runtime, E: JitElement + Element, const D: usize> AutotuneOperationSet<JitAutotuneKey>
     for SumDimAutotuneOperationSet<R, E, D>
 {
-    fn key(&self) -> WgpuAutotuneKey {
+    fn key(&self) -> JitAutotuneKey {
         self.key.clone()
     }
 
@@ -91,10 +91,10 @@ impl<R: Runtime, E: WgpuElement + Element, const D: usize> AutotuneOperationSet<
 }
 
 /// Executes autotune on sum_dim operation
-pub fn sum_dim_autotune<R: Runtime, E: WgpuElement + Element, const D: usize>(
-    input: WgpuTensor<R, E, D>,
+pub fn sum_dim_autotune<R: Runtime, E: JitElement + Element, const D: usize>(
+    input: JitTensor<R, E, D>,
     reduce_dim: usize,
-) -> WgpuTensor<R, E, D> {
+) -> JitTensor<R, E, D> {
     let client = input.client.clone();
 
     let output = init_reduce_output(&input, reduce_dim);

--- a/burn-wgpu/src/kernel/reduce/tune/sum_dim.rs
+++ b/burn-wgpu/src/kernel/reduce/tune/sum_dim.rs
@@ -11,7 +11,7 @@ use crate::{
     ops::numeric::empty_device,
     reduce_tune_ops,
     tensor::WgpuTensor,
-    JitRuntime,
+    Runtime,
 };
 
 use super::ReduceAutotuneKey;
@@ -19,14 +19,14 @@ use super::ReduceAutotuneKey;
 /// Set of sum_dim implementations available for autotune
 /// Autotune key is given by concatenating the closest upper power of 2 of
 /// dim to reduce, and product of others
-pub struct SumDimAutotuneOperationSet<B: JitRuntime, E: WgpuElement, const D: usize> {
+pub struct SumDimAutotuneOperationSet<R: Runtime, E: WgpuElement, const D: usize> {
     key: WgpuAutotuneKey,
-    input: WgpuTensor<B, E, D>,
-    output: WgpuTensor<B, E, D>,
+    input: WgpuTensor<R, E, D>,
+    output: WgpuTensor<R, E, D>,
     reduce_dim: usize,
 }
-impl<B: JitRuntime, E: WgpuElement, const D: usize> SumDimAutotuneOperationSet<B, E, D> {
-    fn new(input: WgpuTensor<B, E, D>, output: WgpuTensor<B, E, D>, reduce_dim: usize) -> Self {
+impl<R: Runtime, E: WgpuElement, const D: usize> SumDimAutotuneOperationSet<R, E, D> {
+    fn new(input: WgpuTensor<R, E, D>, output: WgpuTensor<R, E, D>, reduce_dim: usize) -> Self {
         Self {
             key: WgpuAutotuneKey::SumDim(ReduceAutotuneKey::new(
                 &input.shape,
@@ -40,8 +40,8 @@ impl<B: JitRuntime, E: WgpuElement, const D: usize> SumDimAutotuneOperationSet<B
     }
 }
 
-impl<B: JitRuntime, E: WgpuElement + Element, const D: usize>
-    AutotuneOperationSet<WgpuAutotuneKey> for SumDimAutotuneOperationSet<B, E, D>
+impl<R: Runtime, E: WgpuElement + Element, const D: usize> AutotuneOperationSet<WgpuAutotuneKey>
+    for SumDimAutotuneOperationSet<R, E, D>
 {
     fn key(&self) -> WgpuAutotuneKey {
         self.key.clone()
@@ -91,10 +91,10 @@ impl<B: JitRuntime, E: WgpuElement + Element, const D: usize>
 }
 
 /// Executes autotune on sum_dim operation
-pub fn sum_dim_autotune<B: JitRuntime, E: WgpuElement + Element, const D: usize>(
-    input: WgpuTensor<B, E, D>,
+pub fn sum_dim_autotune<R: Runtime, E: WgpuElement + Element, const D: usize>(
+    input: WgpuTensor<R, E, D>,
     reduce_dim: usize,
-) -> WgpuTensor<B, E, D> {
+) -> WgpuTensor<R, E, D> {
     let client = input.client.clone();
 
     let output = init_reduce_output(&input, reduce_dim);

--- a/burn-wgpu/src/kernel/reduce/tune/sum_dim.rs
+++ b/burn-wgpu/src/kernel/reduce/tune/sum_dim.rs
@@ -11,7 +11,7 @@ use crate::{
     ops::numeric::empty_device,
     reduce_tune_ops,
     tensor::WgpuTensor,
-    JitGpuBackend,
+    JitRuntime,
 };
 
 use super::ReduceAutotuneKey;
@@ -19,13 +19,13 @@ use super::ReduceAutotuneKey;
 /// Set of sum_dim implementations available for autotune
 /// Autotune key is given by concatenating the closest upper power of 2 of
 /// dim to reduce, and product of others
-pub struct SumDimAutotuneOperationSet<B: JitGpuBackend, E: WgpuElement, const D: usize> {
+pub struct SumDimAutotuneOperationSet<B: JitRuntime, E: WgpuElement, const D: usize> {
     key: WgpuAutotuneKey,
     input: WgpuTensor<B, E, D>,
     output: WgpuTensor<B, E, D>,
     reduce_dim: usize,
 }
-impl<B: JitGpuBackend, E: WgpuElement, const D: usize> SumDimAutotuneOperationSet<B, E, D> {
+impl<B: JitRuntime, E: WgpuElement, const D: usize> SumDimAutotuneOperationSet<B, E, D> {
     fn new(input: WgpuTensor<B, E, D>, output: WgpuTensor<B, E, D>, reduce_dim: usize) -> Self {
         Self {
             key: WgpuAutotuneKey::SumDim(ReduceAutotuneKey::new(
@@ -40,7 +40,7 @@ impl<B: JitGpuBackend, E: WgpuElement, const D: usize> SumDimAutotuneOperationSe
     }
 }
 
-impl<B: JitGpuBackend, E: WgpuElement + Element, const D: usize>
+impl<B: JitRuntime, E: WgpuElement + Element, const D: usize>
     AutotuneOperationSet<WgpuAutotuneKey> for SumDimAutotuneOperationSet<B, E, D>
 {
     fn key(&self) -> WgpuAutotuneKey {
@@ -91,7 +91,7 @@ impl<B: JitGpuBackend, E: WgpuElement + Element, const D: usize>
 }
 
 /// Executes autotune on sum_dim operation
-pub fn sum_dim_autotune<B: JitGpuBackend, E: WgpuElement + Element, const D: usize>(
+pub fn sum_dim_autotune<B: JitRuntime, E: WgpuElement + Element, const D: usize>(
     input: WgpuTensor<B, E, D>,
     reduce_dim: usize,
 ) -> WgpuTensor<B, E, D> {

--- a/burn-wgpu/src/kernel/unary.rs
+++ b/burn-wgpu/src/kernel/unary.rs
@@ -3,7 +3,7 @@ use crate::{
     codegen::{execute_static, StaticHandle, WorkgroupLaunch},
     element::WgpuElement,
     tensor::WgpuTensor,
-    JitGpuBackend,
+    JitRuntime,
 };
 
 /// Creates a unary kernel.
@@ -15,11 +15,11 @@ macro_rules! unary {
         input: $input:expr,
         elem: $elem:ty
     ) => {{
-        unary!(operation: $ops, compiler: <$backend as JitGpuBackend>::Compiler);
+        unary!(operation: $ops, compiler: <$backend as JitRuntime>::Compiler);
 
         $crate::kernel::unary::<
-            Ops<<$backend as JitGpuBackend>::Compiler, $elem>,
-            OpsInplace<<$backend as JitGpuBackend>::Compiler, $elem>,
+            Ops<<$backend as JitRuntime>::Compiler, $elem>,
+            OpsInplace<<$backend as JitRuntime>::Compiler, $elem>,
             $backend,
             $elem,
             D
@@ -31,11 +31,11 @@ macro_rules! unary {
         input: $input:expr; $scalar:expr,
         elem: $elem:ty
     ) => {{
-        unary!(operation: $ops, compiler: <$backend as JitGpuBackend>::Compiler, scalar 1);
+        unary!(operation: $ops, compiler: <$backend as JitRuntime>::Compiler, scalar 1);
 
         $crate::kernel::unary::<
-            Ops<<$backend as JitGpuBackend>::Compiler, $elem>,
-            OpsInplace<<$backend as JitGpuBackend>::Compiler, $elem>,
+            Ops<<$backend as JitRuntime>::Compiler, $elem>,
+            OpsInplace<<$backend as JitRuntime>::Compiler, $elem>,
             $backend,
             $elem,
             D
@@ -186,7 +186,7 @@ macro_rules! unary {
 }
 
 /// Launch an unary operation.
-pub fn unary<Kernel, KernelInplace, B: JitGpuBackend, E, const D: usize>(
+pub fn unary<Kernel, KernelInplace, B: JitRuntime, E, const D: usize>(
     tensor: WgpuTensor<B, E, D>,
     scalars: Option<&[E]>,
     inplace_enabled: bool,
@@ -244,7 +244,7 @@ where
 mod tests {
     use super::*;
     use crate::codegen::dialect::gpu::{Item, Operation, UnaryOperation, Variable};
-    use crate::tests::{ReferenceBackend, TestBackend, TestCompiler, TestJitGpuBackend};
+    use crate::tests::{ReferenceBackend, TestBackend, TestCompiler, TestJitRuntime};
     use burn_tensor::{Distribution, Tensor};
 
     unary!(
@@ -265,7 +265,7 @@ mod tests {
         let actual = unary::<
             Ops<TestCompiler, f32>,
             OpsInplace<TestCompiler, f32>,
-            TestJitGpuBackend,
+            TestJitRuntime,
             f32,
             2,
         >(tensor.into_primitive(), None, true);
@@ -287,7 +287,7 @@ mod tests {
         let actual = unary::<
             Ops<TestCompiler, f32>,
             OpsInplace<TestCompiler, f32>,
-            TestJitGpuBackend,
+            TestJitRuntime,
             f32,
             2,
         >(tensor.into_primitive(), None, true);

--- a/burn-wgpu/src/kernel/unary.rs
+++ b/burn-wgpu/src/kernel/unary.rs
@@ -3,6 +3,7 @@ use crate::{
     codegen::{execute_static, StaticHandle, WorkgroupLaunch},
     element::WgpuElement,
     tensor::WgpuTensor,
+    JitGpuBackend,
 };
 
 /// Creates a unary kernel.
@@ -173,11 +174,11 @@ macro_rules! unary {
 }
 
 /// Launch an unary operation.
-pub fn unary<Kernel, KernelInplace, E, const D: usize>(
-    tensor: WgpuTensor<E, D>,
+pub fn unary<Kernel, KernelInplace, B: JitGpuBackend, E, const D: usize>(
+    tensor: WgpuTensor<B, E, D>,
     scalars: Option<&[E]>,
     inplace_enabled: bool,
-) -> WgpuTensor<E, D>
+) -> WgpuTensor<B, E, D>
 where
     Kernel: StaticKernelSource,
     KernelInplace: StaticKernelSource,

--- a/burn-wgpu/src/lib.rs
+++ b/burn-wgpu/src/lib.rs
@@ -20,7 +20,7 @@ pub(crate) mod tune;
 
 mod element;
 pub use codegen::dialect::wgsl;
-use compute::WgpuJitBackend;
+use compute::WgpuRuntime;
 pub use element::{FloatElement, IntElement};
 
 mod device;
@@ -28,6 +28,8 @@ pub use device::*;
 
 mod backend;
 pub use backend::*;
+mod runtime;
+pub use runtime::*;
 
 mod graphics;
 pub use graphics::*;
@@ -53,7 +55,7 @@ mod fusion;
 /// You can disable the `fusion` feature flag to remove that functionality, which might be
 /// necessary on `wasm` for now.
 pub type Wgpu<G = AutoGraphicsApi, F = f32, I = i32> =
-    burn_fusion::Fusion<GpuBackend<WgpuJitBackend<G, F, I>>>;
+    burn_fusion::Fusion<JitBackend<WgpuRuntime<G, F, I>>>;
 
 #[cfg(not(feature = "fusion"))]
 /// Tensor backend that uses the [wgpu] crate for executing GPU compute shaders.
@@ -72,16 +74,16 @@ pub type Wgpu<G = AutoGraphicsApi, F = f32, I = i32> =
 ///
 /// You can enable the `fusion` feature flag to add that functionality, which might improve
 /// performance.
-pub type Wgpu<G = AutoGraphicsApi, F = f32, I = i32> = GpuBackend<WgpuJitBackend<G, F, I>>;
+pub type Wgpu<G = AutoGraphicsApi, F = f32, I = i32> = JitBackend<WgpuRuntime<G, F, I>>;
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compute::WgpuJitBackend;
+    use crate::compute::WgpuRuntime;
 
     pub type TestCompiler = wgsl::Compiler<f32, i32>;
-    pub type TestJitRuntime = WgpuJitBackend<AutoGraphicsApi, f32, i32>;
-    pub type TestBackend = GpuBackend<TestJitRuntime>;
+    pub type TestRuntime = WgpuRuntime<AutoGraphicsApi, f32, i32>;
+    pub type TestBackend = JitBackend<TestRuntime>;
     pub type ReferenceBackend = burn_ndarray::NdArray<f32>;
 
     pub type TestTensor<const D: usize> = burn_tensor::Tensor<TestBackend, D>;

--- a/burn-wgpu/src/lib.rs
+++ b/burn-wgpu/src/lib.rs
@@ -19,7 +19,7 @@ pub(crate) mod codegen;
 pub(crate) mod tune;
 
 mod element;
-use codegen::dialect::wgsl;
+pub use codegen::dialect::wgsl;
 pub use element::{FloatElement, IntElement};
 
 mod device;

--- a/burn-wgpu/src/lib.rs
+++ b/burn-wgpu/src/lib.rs
@@ -20,6 +20,7 @@ pub(crate) mod tune;
 
 mod element;
 pub use codegen::dialect::wgsl;
+use compute::WgpuJitGpuBackend;
 pub use element::{FloatElement, IntElement};
 
 mod device;
@@ -52,7 +53,7 @@ mod fusion;
 /// You can disable the `fusion` feature flag to remove that functionality, which might be
 /// necessary on `wasm` for now.
 pub type Wgpu<G = AutoGraphicsApi, F = f32, I = i32> =
-    burn_fusion::Fusion<GpuBackend<G, wgsl::Compiler<F, I>>>;
+    burn_fusion::Fusion<WgpuJitGpuBackend<G, F, I>>;
 
 #[cfg(not(feature = "fusion"))]
 /// Tensor backend that uses the [wgpu] crate for executing GPU compute shaders.
@@ -71,14 +72,16 @@ pub type Wgpu<G = AutoGraphicsApi, F = f32, I = i32> =
 ///
 /// You can enable the `fusion` feature flag to add that functionality, which might improve
 /// performance.
-pub type Wgpu<G = AutoGraphicsApi, F = f32, I = i32> = GpuBackend<G, wgsl::Compiler<F, I>>;
+pub type Wgpu<G = AutoGraphicsApi, F = f32, I = i32> = GpuBackend<WgpuJitGpuBackend<G, F, I>>;
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::compute::WgpuJitGpuBackend;
 
     pub type TestCompiler = wgsl::Compiler<f32, i32>;
-    pub type TestBackend = GpuBackend<AutoGraphicsApi, TestCompiler>;
+    pub type TestJitGpuBackend = WgpuJitGpuBackend<AutoGraphicsApi, f32, i32>;
+    pub type TestBackend = GpuBackend<TestJitGpuBackend>;
     pub type ReferenceBackend = burn_ndarray::NdArray<f32>;
 
     pub type TestTensor<const D: usize> = burn_tensor::Tensor<TestBackend, D>;

--- a/burn-wgpu/src/lib.rs
+++ b/burn-wgpu/src/lib.rs
@@ -19,6 +19,7 @@ pub(crate) mod codegen;
 pub(crate) mod tune;
 
 mod element;
+use codegen::dialect::wgsl;
 pub use element::{FloatElement, IntElement};
 
 mod device;
@@ -50,7 +51,8 @@ mod fusion;
 ///
 /// You can disable the `fusion` feature flag to remove that functionality, which might be
 /// necessary on `wasm` for now.
-pub type Wgpu<G = AutoGraphicsApi, F = f32, I = i32> = burn_fusion::Fusion<WgpuBackend<G, F, I>>;
+pub type Wgpu<G = AutoGraphicsApi, F = f32, I = i32> =
+    burn_fusion::Fusion<GpuBackend<G, wgsl::Compiler<F, I>>>;
 
 #[cfg(not(feature = "fusion"))]
 /// Tensor backend that uses the [wgpu] crate for executing GPU compute shaders.
@@ -69,16 +71,16 @@ pub type Wgpu<G = AutoGraphicsApi, F = f32, I = i32> = burn_fusion::Fusion<WgpuB
 ///
 /// You can enable the `fusion` feature flag to add that functionality, which might improve
 /// performance.
-pub type Wgpu<G = AutoGraphicsApi, F = f32, I = i32> = WgpuBackend<G, F, I>;
+pub type Wgpu<G = AutoGraphicsApi, F = f32, I = i32> = GpuBackend<G, wgsl::Compiler<F, I>>;
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    pub type TestBackend = WgpuBackend;
+    pub type TestCompiler = wgsl::Compiler<f32, i32>;
+    pub type TestBackend = GpuBackend<AutoGraphicsApi, TestCompiler>;
     pub type ReferenceBackend = burn_ndarray::NdArray<f32>;
 
-    pub type TestCompiler = crate::codegen::dialect::wgsl::Compiler<f32, i32>;
     pub type TestTensor<const D: usize> = burn_tensor::Tensor<TestBackend, D>;
     pub type TestTensorInt<const D: usize> = burn_tensor::Tensor<TestBackend, D, burn_tensor::Int>;
     pub type TestTensorBool<const D: usize> =

--- a/burn-wgpu/src/lib.rs
+++ b/burn-wgpu/src/lib.rs
@@ -20,7 +20,7 @@ pub(crate) mod tune;
 
 mod element;
 pub use codegen::dialect::wgsl;
-use compute::WgpuJitGpuBackend;
+use compute::WgpuJitBackend;
 pub use element::{FloatElement, IntElement};
 
 mod device;
@@ -53,7 +53,7 @@ mod fusion;
 /// You can disable the `fusion` feature flag to remove that functionality, which might be
 /// necessary on `wasm` for now.
 pub type Wgpu<G = AutoGraphicsApi, F = f32, I = i32> =
-    burn_fusion::Fusion<GpuBackend<WgpuJitGpuBackend<G, F, I>>>;
+    burn_fusion::Fusion<GpuBackend<WgpuJitBackend<G, F, I>>>;
 
 #[cfg(not(feature = "fusion"))]
 /// Tensor backend that uses the [wgpu] crate for executing GPU compute shaders.
@@ -72,16 +72,16 @@ pub type Wgpu<G = AutoGraphicsApi, F = f32, I = i32> =
 ///
 /// You can enable the `fusion` feature flag to add that functionality, which might improve
 /// performance.
-pub type Wgpu<G = AutoGraphicsApi, F = f32, I = i32> = GpuBackend<WgpuJitGpuBackend<G, F, I>>;
+pub type Wgpu<G = AutoGraphicsApi, F = f32, I = i32> = GpuBackend<WgpuJitBackend<G, F, I>>;
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compute::WgpuJitGpuBackend;
+    use crate::compute::WgpuJitBackend;
 
     pub type TestCompiler = wgsl::Compiler<f32, i32>;
-    pub type TestJitGpuBackend = WgpuJitGpuBackend<AutoGraphicsApi, f32, i32>;
-    pub type TestBackend = GpuBackend<TestJitGpuBackend>;
+    pub type TestJitRuntime = WgpuJitBackend<AutoGraphicsApi, f32, i32>;
+    pub type TestBackend = GpuBackend<TestJitRuntime>;
     pub type ReferenceBackend = burn_ndarray::NdArray<f32>;
 
     pub type TestTensor<const D: usize> = burn_tensor::Tensor<TestBackend, D>;

--- a/burn-wgpu/src/lib.rs
+++ b/burn-wgpu/src/lib.rs
@@ -53,7 +53,7 @@ mod fusion;
 /// You can disable the `fusion` feature flag to remove that functionality, which might be
 /// necessary on `wasm` for now.
 pub type Wgpu<G = AutoGraphicsApi, F = f32, I = i32> =
-    burn_fusion::Fusion<WgpuJitGpuBackend<G, F, I>>;
+    burn_fusion::Fusion<GpuBackend<WgpuJitGpuBackend<G, F, I>>>;
 
 #[cfg(not(feature = "fusion"))]
 /// Tensor backend that uses the [wgpu] crate for executing GPU compute shaders.

--- a/burn-wgpu/src/ops/activation_ops.rs
+++ b/burn-wgpu/src/ops/activation_ops.rs
@@ -1,9 +1,4 @@
-use crate::{codegen::Compiler, GpuBackend, GraphicsApi};
+use crate::{GpuBackend, JitGpuBackend};
 use burn_tensor::ops::ActivationOps;
 
-impl<G, C> ActivationOps<GpuBackend<G, C>> for GpuBackend<G, C>
-where
-    G: GraphicsApi + 'static,
-    C: Compiler,
-{
-}
+impl<B: JitGpuBackend> ActivationOps<Self> for GpuBackend<B> {}

--- a/burn-wgpu/src/ops/activation_ops.rs
+++ b/burn-wgpu/src/ops/activation_ops.rs
@@ -1,4 +1,4 @@
-use crate::{GpuBackend, JitGpuBackend};
+use crate::{GpuBackend, JitRuntime};
 use burn_tensor::ops::ActivationOps;
 
-impl<B: JitGpuBackend> ActivationOps<Self> for GpuBackend<B> {}
+impl<B: JitRuntime> ActivationOps<Self> for GpuBackend<B> {}

--- a/burn-wgpu/src/ops/activation_ops.rs
+++ b/burn-wgpu/src/ops/activation_ops.rs
@@ -1,4 +1,4 @@
-use crate::{GpuBackend, Runtime};
+use crate::{JitBackend, Runtime};
 use burn_tensor::ops::ActivationOps;
 
-impl<R: Runtime> ActivationOps<Self> for GpuBackend<R> {}
+impl<R: Runtime> ActivationOps<Self> for JitBackend<R> {}

--- a/burn-wgpu/src/ops/activation_ops.rs
+++ b/burn-wgpu/src/ops/activation_ops.rs
@@ -1,13 +1,9 @@
-use crate::{
-    element::{FloatElement, IntElement},
-    GraphicsApi, WgpuBackend,
-};
+use crate::{codegen::Compiler, GpuBackend, GraphicsApi};
 use burn_tensor::ops::ActivationOps;
 
-impl<G, F, I> ActivationOps<WgpuBackend<G, F, I>> for WgpuBackend<G, F, I>
+impl<G, C> ActivationOps<GpuBackend<G, C>> for GpuBackend<G, C>
 where
     G: GraphicsApi + 'static,
-    F: FloatElement,
-    I: IntElement,
+    C: Compiler,
 {
 }

--- a/burn-wgpu/src/ops/activation_ops.rs
+++ b/burn-wgpu/src/ops/activation_ops.rs
@@ -1,4 +1,4 @@
-use crate::{GpuBackend, JitRuntime};
+use crate::{GpuBackend, Runtime};
 use burn_tensor::ops::ActivationOps;
 
-impl<B: JitRuntime> ActivationOps<Self> for GpuBackend<B> {}
+impl<R: Runtime> ActivationOps<Self> for GpuBackend<R> {}

--- a/burn-wgpu/src/ops/base.rs
+++ b/burn-wgpu/src/ops/base.rs
@@ -1,20 +1,19 @@
-use crate::{
-    compute::compute_client, element::WgpuElement, kernel, tensor::WgpuTensor, GraphicsApi,
-    WgpuDevice,
-};
+use crate::{element::WgpuElement, kernel, tensor::WgpuTensor, JitGpuBackend};
 use burn_tensor::{Data, Reader, Shape};
 
-pub fn from_data<G: GraphicsApi, E: WgpuElement, const D: usize>(
+pub fn from_data<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     data: Data<E, D>,
-    device: &WgpuDevice,
-) -> WgpuTensor<E, D> {
-    let client = compute_client::<G>(device);
+    device: &B::Device,
+) -> WgpuTensor<B, E, D> {
+    let client = B::client(device);
     let buffer = client.create(E::as_bytes(&data.value));
 
     WgpuTensor::new(client, device.clone(), data.shape, buffer)
 }
 
-pub fn into_data<E: WgpuElement, const D: usize>(tensor: WgpuTensor<E, D>) -> Reader<Data<E, D>> {
+pub fn into_data<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    tensor: WgpuTensor<B, E, D>,
+) -> Reader<Data<E, D>> {
     let tensor = kernel::into_contiguous(tensor);
 
     tensor
@@ -23,7 +22,9 @@ pub fn into_data<E: WgpuElement, const D: usize>(tensor: WgpuTensor<E, D>) -> Re
         .map(|bytes| Data::new(E::from_bytes(&bytes).to_vec(), tensor.shape))
 }
 
-pub fn bool_into_data<const D: usize>(tensor: WgpuTensor<u32, D>) -> Reader<Data<bool, D>> {
+pub fn bool_into_data<B: JitGpuBackend, const D: usize>(
+    tensor: WgpuTensor<B, u32, D>,
+) -> Reader<Data<bool, D>> {
     let tensor = kernel::into_contiguous(tensor);
 
     tensor.client.read(&tensor.handle).map(|bytes| {
@@ -34,43 +35,43 @@ pub fn bool_into_data<const D: usize>(tensor: WgpuTensor<u32, D>) -> Reader<Data
     })
 }
 
-pub fn to_device<G: GraphicsApi, E: WgpuElement, const D: usize>(
-    tensor: WgpuTensor<E, D>,
-    device: &WgpuDevice,
-) -> WgpuTensor<E, D> {
+pub fn to_device<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    tensor: WgpuTensor<B, E, D>,
+    device: &B::Device,
+) -> WgpuTensor<B, E, D> {
     if &tensor.device == device {
         return tensor;
     }
 
-    let client = compute_client::<G>(device);
+    let client = B::client(device);
     tensor.to_client(client, device.clone())
 }
 
-pub fn empty<G: GraphicsApi, E: WgpuElement, const D: usize>(
+pub fn empty<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     shape: Shape<D>,
-    device: &WgpuDevice,
-) -> WgpuTensor<E, D> {
-    let client = compute_client::<G>(device);
+    device: &B::Device,
+) -> WgpuTensor<B, E, D> {
+    let client = B::client(device);
     let buffer = client.empty(shape.num_elements() * core::mem::size_of::<E>());
 
     WgpuTensor::new(client, device.clone(), shape, buffer)
 }
 
-pub fn swap_dims<E: WgpuElement, const D: usize>(
-    mut tensor: WgpuTensor<E, D>,
+pub fn swap_dims<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    mut tensor: WgpuTensor<B, E, D>,
     dim1: usize,
     dim2: usize,
-) -> WgpuTensor<E, D> {
+) -> WgpuTensor<B, E, D> {
     tensor.strides.swap(dim1, dim2);
     tensor.shape.dims.swap(dim1, dim2);
 
     tensor
 }
 
-pub fn reshape<E: WgpuElement, const D1: usize, const D2: usize>(
-    tensor: WgpuTensor<E, D1>,
+pub fn reshape<B: JitGpuBackend, E: WgpuElement, const D1: usize, const D2: usize>(
+    tensor: WgpuTensor<B, E, D1>,
     shape: Shape<D2>,
-) -> WgpuTensor<E, D2> {
+) -> WgpuTensor<B, E, D2> {
     // TODO: Not force standard layout all the time (improve performance).
     let tensor = kernel::into_contiguous(tensor);
 

--- a/burn-wgpu/src/ops/base.rs
+++ b/burn-wgpu/src/ops/base.rs
@@ -1,18 +1,18 @@
-use crate::{element::WgpuElement, kernel, tensor::WgpuTensor, JitRuntime};
+use crate::{element::WgpuElement, kernel, tensor::WgpuTensor, Runtime};
 use burn_tensor::{Data, Reader, Shape};
 
-pub fn from_data<B: JitRuntime, E: WgpuElement, const D: usize>(
+pub fn from_data<R: Runtime, E: WgpuElement, const D: usize>(
     data: Data<E, D>,
-    device: &B::Device,
-) -> WgpuTensor<B, E, D> {
-    let client = B::client(device);
+    device: &R::Device,
+) -> WgpuTensor<R, E, D> {
+    let client = R::client(device);
     let buffer = client.create(E::as_bytes(&data.value));
 
     WgpuTensor::new(client, device.clone(), data.shape, buffer)
 }
 
-pub fn into_data<B: JitRuntime, E: WgpuElement, const D: usize>(
-    tensor: WgpuTensor<B, E, D>,
+pub fn into_data<R: Runtime, E: WgpuElement, const D: usize>(
+    tensor: WgpuTensor<R, E, D>,
 ) -> Reader<Data<E, D>> {
     let tensor = kernel::into_contiguous(tensor);
 
@@ -22,8 +22,8 @@ pub fn into_data<B: JitRuntime, E: WgpuElement, const D: usize>(
         .map(|bytes| Data::new(E::from_bytes(&bytes).to_vec(), tensor.shape))
 }
 
-pub fn bool_into_data<B: JitRuntime, const D: usize>(
-    tensor: WgpuTensor<B, u32, D>,
+pub fn bool_into_data<R: Runtime, const D: usize>(
+    tensor: WgpuTensor<R, u32, D>,
 ) -> Reader<Data<bool, D>> {
     let tensor = kernel::into_contiguous(tensor);
 
@@ -35,43 +35,43 @@ pub fn bool_into_data<B: JitRuntime, const D: usize>(
     })
 }
 
-pub fn to_device<B: JitRuntime, E: WgpuElement, const D: usize>(
-    tensor: WgpuTensor<B, E, D>,
-    device: &B::Device,
-) -> WgpuTensor<B, E, D> {
+pub fn to_device<R: Runtime, E: WgpuElement, const D: usize>(
+    tensor: WgpuTensor<R, E, D>,
+    device: &R::Device,
+) -> WgpuTensor<R, E, D> {
     if &tensor.device == device {
         return tensor;
     }
 
-    let client = B::client(device);
+    let client = R::client(device);
     tensor.to_client(client, device.clone())
 }
 
-pub fn empty<B: JitRuntime, E: WgpuElement, const D: usize>(
+pub fn empty<R: Runtime, E: WgpuElement, const D: usize>(
     shape: Shape<D>,
-    device: &B::Device,
-) -> WgpuTensor<B, E, D> {
-    let client = B::client(device);
+    device: &R::Device,
+) -> WgpuTensor<R, E, D> {
+    let client = R::client(device);
     let buffer = client.empty(shape.num_elements() * core::mem::size_of::<E>());
 
     WgpuTensor::new(client, device.clone(), shape, buffer)
 }
 
-pub fn swap_dims<B: JitRuntime, E: WgpuElement, const D: usize>(
-    mut tensor: WgpuTensor<B, E, D>,
+pub fn swap_dims<R: Runtime, E: WgpuElement, const D: usize>(
+    mut tensor: WgpuTensor<R, E, D>,
     dim1: usize,
     dim2: usize,
-) -> WgpuTensor<B, E, D> {
+) -> WgpuTensor<R, E, D> {
     tensor.strides.swap(dim1, dim2);
     tensor.shape.dims.swap(dim1, dim2);
 
     tensor
 }
 
-pub fn reshape<B: JitRuntime, E: WgpuElement, const D1: usize, const D2: usize>(
-    tensor: WgpuTensor<B, E, D1>,
+pub fn reshape<R: Runtime, E: WgpuElement, const D1: usize, const D2: usize>(
+    tensor: WgpuTensor<R, E, D1>,
     shape: Shape<D2>,
-) -> WgpuTensor<B, E, D2> {
+) -> WgpuTensor<R, E, D2> {
     // TODO: Not force standard layout all the time (improve performance).
     let tensor = kernel::into_contiguous(tensor);
 

--- a/burn-wgpu/src/ops/base.rs
+++ b/burn-wgpu/src/ops/base.rs
@@ -1,7 +1,7 @@
-use crate::{element::WgpuElement, kernel, tensor::WgpuTensor, JitGpuBackend};
+use crate::{element::WgpuElement, kernel, tensor::WgpuTensor, JitRuntime};
 use burn_tensor::{Data, Reader, Shape};
 
-pub fn from_data<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn from_data<B: JitRuntime, E: WgpuElement, const D: usize>(
     data: Data<E, D>,
     device: &B::Device,
 ) -> WgpuTensor<B, E, D> {
@@ -11,7 +11,7 @@ pub fn from_data<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     WgpuTensor::new(client, device.clone(), data.shape, buffer)
 }
 
-pub fn into_data<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn into_data<B: JitRuntime, E: WgpuElement, const D: usize>(
     tensor: WgpuTensor<B, E, D>,
 ) -> Reader<Data<E, D>> {
     let tensor = kernel::into_contiguous(tensor);
@@ -22,7 +22,7 @@ pub fn into_data<B: JitGpuBackend, E: WgpuElement, const D: usize>(
         .map(|bytes| Data::new(E::from_bytes(&bytes).to_vec(), tensor.shape))
 }
 
-pub fn bool_into_data<B: JitGpuBackend, const D: usize>(
+pub fn bool_into_data<B: JitRuntime, const D: usize>(
     tensor: WgpuTensor<B, u32, D>,
 ) -> Reader<Data<bool, D>> {
     let tensor = kernel::into_contiguous(tensor);
@@ -35,7 +35,7 @@ pub fn bool_into_data<B: JitGpuBackend, const D: usize>(
     })
 }
 
-pub fn to_device<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn to_device<B: JitRuntime, E: WgpuElement, const D: usize>(
     tensor: WgpuTensor<B, E, D>,
     device: &B::Device,
 ) -> WgpuTensor<B, E, D> {
@@ -47,7 +47,7 @@ pub fn to_device<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     tensor.to_client(client, device.clone())
 }
 
-pub fn empty<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn empty<B: JitRuntime, E: WgpuElement, const D: usize>(
     shape: Shape<D>,
     device: &B::Device,
 ) -> WgpuTensor<B, E, D> {
@@ -57,7 +57,7 @@ pub fn empty<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     WgpuTensor::new(client, device.clone(), shape, buffer)
 }
 
-pub fn swap_dims<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn swap_dims<B: JitRuntime, E: WgpuElement, const D: usize>(
     mut tensor: WgpuTensor<B, E, D>,
     dim1: usize,
     dim2: usize,
@@ -68,7 +68,7 @@ pub fn swap_dims<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     tensor
 }
 
-pub fn reshape<B: JitGpuBackend, E: WgpuElement, const D1: usize, const D2: usize>(
+pub fn reshape<B: JitRuntime, E: WgpuElement, const D1: usize, const D2: usize>(
     tensor: WgpuTensor<B, E, D1>,
     shape: Shape<D2>,
 ) -> WgpuTensor<B, E, D2> {

--- a/burn-wgpu/src/ops/base.rs
+++ b/burn-wgpu/src/ops/base.rs
@@ -1,18 +1,18 @@
-use crate::{element::WgpuElement, kernel, tensor::WgpuTensor, Runtime};
+use crate::{element::JitElement, kernel, tensor::JitTensor, Runtime};
 use burn_tensor::{Data, Reader, Shape};
 
-pub fn from_data<R: Runtime, E: WgpuElement, const D: usize>(
+pub fn from_data<R: Runtime, E: JitElement, const D: usize>(
     data: Data<E, D>,
     device: &R::Device,
-) -> WgpuTensor<R, E, D> {
+) -> JitTensor<R, E, D> {
     let client = R::client(device);
     let buffer = client.create(E::as_bytes(&data.value));
 
-    WgpuTensor::new(client, device.clone(), data.shape, buffer)
+    JitTensor::new(client, device.clone(), data.shape, buffer)
 }
 
-pub fn into_data<R: Runtime, E: WgpuElement, const D: usize>(
-    tensor: WgpuTensor<R, E, D>,
+pub fn into_data<R: Runtime, E: JitElement, const D: usize>(
+    tensor: JitTensor<R, E, D>,
 ) -> Reader<Data<E, D>> {
     let tensor = kernel::into_contiguous(tensor);
 
@@ -23,7 +23,7 @@ pub fn into_data<R: Runtime, E: WgpuElement, const D: usize>(
 }
 
 pub fn bool_into_data<R: Runtime, const D: usize>(
-    tensor: WgpuTensor<R, u32, D>,
+    tensor: JitTensor<R, u32, D>,
 ) -> Reader<Data<bool, D>> {
     let tensor = kernel::into_contiguous(tensor);
 
@@ -35,10 +35,10 @@ pub fn bool_into_data<R: Runtime, const D: usize>(
     })
 }
 
-pub fn to_device<R: Runtime, E: WgpuElement, const D: usize>(
-    tensor: WgpuTensor<R, E, D>,
+pub fn to_device<R: Runtime, E: JitElement, const D: usize>(
+    tensor: JitTensor<R, E, D>,
     device: &R::Device,
-) -> WgpuTensor<R, E, D> {
+) -> JitTensor<R, E, D> {
     if &tensor.device == device {
         return tensor;
     }
@@ -47,33 +47,33 @@ pub fn to_device<R: Runtime, E: WgpuElement, const D: usize>(
     tensor.to_client(client, device.clone())
 }
 
-pub fn empty<R: Runtime, E: WgpuElement, const D: usize>(
+pub fn empty<R: Runtime, E: JitElement, const D: usize>(
     shape: Shape<D>,
     device: &R::Device,
-) -> WgpuTensor<R, E, D> {
+) -> JitTensor<R, E, D> {
     let client = R::client(device);
     let buffer = client.empty(shape.num_elements() * core::mem::size_of::<E>());
 
-    WgpuTensor::new(client, device.clone(), shape, buffer)
+    JitTensor::new(client, device.clone(), shape, buffer)
 }
 
-pub fn swap_dims<R: Runtime, E: WgpuElement, const D: usize>(
-    mut tensor: WgpuTensor<R, E, D>,
+pub fn swap_dims<R: Runtime, E: JitElement, const D: usize>(
+    mut tensor: JitTensor<R, E, D>,
     dim1: usize,
     dim2: usize,
-) -> WgpuTensor<R, E, D> {
+) -> JitTensor<R, E, D> {
     tensor.strides.swap(dim1, dim2);
     tensor.shape.dims.swap(dim1, dim2);
 
     tensor
 }
 
-pub fn reshape<R: Runtime, E: WgpuElement, const D1: usize, const D2: usize>(
-    tensor: WgpuTensor<R, E, D1>,
+pub fn reshape<R: Runtime, E: JitElement, const D1: usize, const D2: usize>(
+    tensor: JitTensor<R, E, D1>,
     shape: Shape<D2>,
-) -> WgpuTensor<R, E, D2> {
+) -> JitTensor<R, E, D2> {
     // TODO: Not force standard layout all the time (improve performance).
     let tensor = kernel::into_contiguous(tensor);
 
-    WgpuTensor::new(tensor.client, tensor.device, shape, tensor.handle)
+    JitTensor::new(tensor.client, tensor.device, shape, tensor.handle)
 }

--- a/burn-wgpu/src/ops/bool_ops.rs
+++ b/burn-wgpu/src/ops/bool_ops.rs
@@ -1,12 +1,12 @@
-use crate::{kernel, tensor::WgpuTensor, GpuBackend, JitRuntime};
+use crate::{kernel, tensor::WgpuTensor, GpuBackend, Runtime};
 use burn_tensor::ops::{BoolTensor, Device, FloatTensor, IntElem, IntTensor};
 use burn_tensor::{ops::BoolTensorOps, Data, Shape};
 use burn_tensor::{ops::IntTensorOps, Reader};
 use std::ops::Range;
 
-impl<B: JitRuntime> BoolTensorOps<Self> for GpuBackend<B> {
+impl<R: Runtime> BoolTensorOps<Self> for GpuBackend<R> {
     fn bool_empty<const D: usize>(shape: Shape<D>, device: &Device<Self>) -> BoolTensor<Self, D> {
-        super::empty::<B, u32, D>(shape, device)
+        super::empty(shape, device)
     }
 
     fn bool_shape<const D: usize>(tensor: &BoolTensor<Self, D>) -> Shape<D> {
@@ -31,7 +31,7 @@ impl<B: JitRuntime> BoolTensorOps<Self> for GpuBackend<B> {
                 .collect(),
             data.shape,
         );
-        super::from_data::<B, u32, D>(data, device)
+        super::from_data(data, device)
     }
 
     fn bool_into_int<const D: usize>(tensor: BoolTensor<Self, D>) -> IntTensor<Self, D> {
@@ -56,7 +56,7 @@ impl<B: JitRuntime> BoolTensorOps<Self> for GpuBackend<B> {
         tensor: BoolTensor<Self, D>,
         device: &Device<Self>,
     ) -> BoolTensor<Self, D> {
-        super::to_device::<B, u32, D>(tensor, device)
+        super::to_device(tensor, device)
     }
 
     fn bool_reshape<const D1: usize, const D2: usize>(
@@ -78,7 +78,7 @@ impl<B: JitRuntime> BoolTensorOps<Self> for GpuBackend<B> {
         ranges: [Range<usize>; D2],
         value: BoolTensor<Self, D1>,
     ) -> BoolTensor<Self, D1> {
-        kernel::slice_assign::<B, _, D1, D2>(tensor, ranges, value)
+        kernel::slice_assign(tensor, ranges, value)
     }
 
     fn bool_cat<const D: usize>(
@@ -92,11 +92,11 @@ impl<B: JitRuntime> BoolTensorOps<Self> for GpuBackend<B> {
         lhs: BoolTensor<Self, D>,
         rhs: BoolTensor<Self, D>,
     ) -> BoolTensor<Self, D> {
-        kernel::equal::<B, _, D>(lhs, rhs)
+        kernel::equal(lhs, rhs)
     }
 
     fn bool_not<const D: usize>(tensor: BoolTensor<Self, D>) -> BoolTensor<Self, D> {
-        kernel::equal_elem::<B, _, D>(tensor, 0)
+        kernel::equal_elem(tensor, 0)
     }
 
     fn bool_into_float<const D: usize>(tensor: BoolTensor<Self, D>) -> FloatTensor<Self, D> {

--- a/burn-wgpu/src/ops/bool_ops.rs
+++ b/burn-wgpu/src/ops/bool_ops.rs
@@ -1,10 +1,10 @@
-use crate::{kernel, tensor::WgpuTensor, GpuBackend, Runtime};
+use crate::{kernel, tensor::JitTensor, JitBackend, Runtime};
 use burn_tensor::ops::{BoolTensor, Device, FloatTensor, IntElem, IntTensor};
 use burn_tensor::{ops::BoolTensorOps, Data, Shape};
 use burn_tensor::{ops::IntTensorOps, Reader};
 use std::ops::Range;
 
-impl<R: Runtime> BoolTensorOps<Self> for GpuBackend<R> {
+impl<R: Runtime> BoolTensorOps<Self> for JitBackend<R> {
     fn bool_empty<const D: usize>(shape: Shape<D>, device: &Device<Self>) -> BoolTensor<Self, D> {
         super::empty(shape, device)
     }
@@ -36,7 +36,7 @@ impl<R: Runtime> BoolTensorOps<Self> for GpuBackend<R> {
 
     fn bool_into_int<const D: usize>(tensor: BoolTensor<Self, D>) -> IntTensor<Self, D> {
         if std::mem::size_of::<IntElem<Self>>() == std::mem::size_of::<u32>() {
-            return WgpuTensor::new(tensor.client, tensor.device, tensor.shape, tensor.handle);
+            return JitTensor::new(tensor.client, tensor.device, tensor.shape, tensor.handle);
         }
 
         let device = Self::bool_device(&tensor);

--- a/burn-wgpu/src/ops/bool_ops.rs
+++ b/burn-wgpu/src/ops/bool_ops.rs
@@ -1,24 +1,12 @@
-use crate::{
-    codegen::Compiler,
-    element::{FloatElement, IntElement},
-    kernel,
-    tensor::WgpuTensor,
-    GpuBackend, GraphicsApi,
-};
-use burn_tensor::ops::{BoolTensor, Device, FloatTensor, IntTensor};
+use crate::{kernel, tensor::WgpuTensor, GpuBackend, JitGpuBackend};
+use burn_tensor::ops::{BoolTensor, Device, FloatTensor, IntElem, IntTensor};
 use burn_tensor::{ops::BoolTensorOps, Data, Shape};
 use burn_tensor::{ops::IntTensorOps, Reader};
 use std::ops::Range;
 
-impl<G, C> BoolTensorOps<GpuBackend<G, C>> for GpuBackend<G, C>
-where
-    G: GraphicsApi + 'static,
-    C: Compiler,
-    C::Float: FloatElement,
-    C::Int: IntElement,
-{
+impl<B: JitGpuBackend> BoolTensorOps<Self> for GpuBackend<B> {
     fn bool_empty<const D: usize>(shape: Shape<D>, device: &Device<Self>) -> BoolTensor<Self, D> {
-        super::empty::<G, u32, D>(shape, device)
+        super::empty::<B, u32, D>(shape, device)
     }
 
     fn bool_shape<const D: usize>(tensor: &BoolTensor<Self, D>) -> Shape<D> {
@@ -43,11 +31,11 @@ where
                 .collect(),
             data.shape,
         );
-        super::from_data::<G, u32, D>(data, device)
+        super::from_data::<B, u32, D>(data, device)
     }
 
     fn bool_into_int<const D: usize>(tensor: BoolTensor<Self, D>) -> IntTensor<Self, D> {
-        if std::mem::size_of::<C::Int>() == std::mem::size_of::<u32>() {
+        if std::mem::size_of::<IntElem<B>>() == std::mem::size_of::<u32>() {
             return WgpuTensor::new(tensor.client, tensor.device, tensor.shape, tensor.handle);
         }
 
@@ -55,7 +43,7 @@ where
         let data = Self::bool_into_data(tensor)
             .read_sync()
             .expect("Can't convert bool to int with a different type size async")
-            .convert::<C::Int>();
+            .convert::<IntElem<Self>>();
 
         Self::int_from_data(data, &device)
     }
@@ -68,7 +56,7 @@ where
         tensor: BoolTensor<Self, D>,
         device: &Device<Self>,
     ) -> BoolTensor<Self, D> {
-        super::to_device::<G, u32, D>(tensor, device)
+        super::to_device::<B, u32, D>(tensor, device)
     }
 
     fn bool_reshape<const D1: usize, const D2: usize>(
@@ -90,7 +78,7 @@ where
         ranges: [Range<usize>; D2],
         value: BoolTensor<Self, D1>,
     ) -> BoolTensor<Self, D1> {
-        kernel::slice_assign::<C, _, D1, D2>(tensor, ranges, value)
+        kernel::slice_assign::<B, _, D1, D2>(tensor, ranges, value)
     }
 
     fn bool_cat<const D: usize>(
@@ -104,11 +92,11 @@ where
         lhs: BoolTensor<Self, D>,
         rhs: BoolTensor<Self, D>,
     ) -> BoolTensor<Self, D> {
-        kernel::equal::<C, _, D>(lhs, rhs)
+        kernel::equal::<B, _, D>(lhs, rhs)
     }
 
     fn bool_not<const D: usize>(tensor: BoolTensor<Self, D>) -> BoolTensor<Self, D> {
-        kernel::equal_elem::<C, _, D>(tensor, 0)
+        kernel::equal_elem::<B, _, D>(tensor, 0)
     }
 
     fn bool_into_float<const D: usize>(tensor: BoolTensor<Self, D>) -> FloatTensor<Self, D> {

--- a/burn-wgpu/src/ops/bool_ops.rs
+++ b/burn-wgpu/src/ops/bool_ops.rs
@@ -35,7 +35,7 @@ impl<B: JitGpuBackend> BoolTensorOps<Self> for GpuBackend<B> {
     }
 
     fn bool_into_int<const D: usize>(tensor: BoolTensor<Self, D>) -> IntTensor<Self, D> {
-        if std::mem::size_of::<IntElem<B>>() == std::mem::size_of::<u32>() {
+        if std::mem::size_of::<IntElem<Self>>() == std::mem::size_of::<u32>() {
             return WgpuTensor::new(tensor.client, tensor.device, tensor.shape, tensor.handle);
         }
 

--- a/burn-wgpu/src/ops/bool_ops.rs
+++ b/burn-wgpu/src/ops/bool_ops.rs
@@ -1,10 +1,10 @@
-use crate::{kernel, tensor::WgpuTensor, GpuBackend, JitGpuBackend};
+use crate::{kernel, tensor::WgpuTensor, GpuBackend, JitRuntime};
 use burn_tensor::ops::{BoolTensor, Device, FloatTensor, IntElem, IntTensor};
 use burn_tensor::{ops::BoolTensorOps, Data, Shape};
 use burn_tensor::{ops::IntTensorOps, Reader};
 use std::ops::Range;
 
-impl<B: JitGpuBackend> BoolTensorOps<Self> for GpuBackend<B> {
+impl<B: JitRuntime> BoolTensorOps<Self> for GpuBackend<B> {
     fn bool_empty<const D: usize>(shape: Shape<D>, device: &Device<Self>) -> BoolTensor<Self, D> {
         super::empty::<B, u32, D>(shape, device)
     }

--- a/burn-wgpu/src/ops/float_ops.rs
+++ b/burn-wgpu/src/ops/float_ops.rs
@@ -13,6 +13,7 @@ use crate::kernel::prng::{random_bernoulli, random_normal, random_uniform};
 #[cfg(not(feature = "autotune"))]
 use crate::kernel::reduce::init_reduce_output;
 use crate::kernel::{self, reduce};
+use crate::tensor::WgpuTensor;
 use crate::JitGpuBackend;
 use crate::{unary, GpuBackend};
 use burn_tensor::ops::{
@@ -351,13 +352,17 @@ impl<B: JitGpuBackend> FloatTensorOps<Self> for GpuBackend<B> {
     fn float_to_full_precision<const D: usize>(
         tensor: &FloatTensor<Self, D>,
     ) -> FloatTensor<FullPrecisionBackend<Self>, D> {
-        kernel::cast(tensor.clone())
+        let tensor = kernel::cast::<B, FloatElem<Self>, f32, D>(tensor.clone());
+        // The line bellow does the backend type cast.
+        WgpuTensor::new(tensor.client, tensor.device, tensor.shape, tensor.handle)
     }
 
     fn float_from_full_precision<const D: usize>(
         tensor: FloatTensor<FullPrecisionBackend<Self>, D>,
     ) -> FloatTensor<Self, D> {
-        kernel::cast(tensor)
+        let tensor = kernel::cast::<B::FullPrecisionBackend, f32, FloatElem<Self>, D>(tensor);
+        // The line bellow does the backend type cast.
+        WgpuTensor::new(tensor.client, tensor.device, tensor.shape, tensor.handle)
     }
 
     fn float_exp<const D: usize>(tensor: FloatTensor<Self, D>) -> FloatTensor<Self, D> {
@@ -366,7 +371,7 @@ impl<B: JitGpuBackend> FloatTensorOps<Self> for GpuBackend<B> {
                 input: Variable::Input(0, Item::Scalar(elem)),
                 out: Variable::Local(0, Item::Scalar(elem)),
             }),
-            compiler: B::Compiler,
+            backend: B,
             input: tensor,
             elem: FloatElem<Self>
         )
@@ -378,7 +383,7 @@ impl<B: JitGpuBackend> FloatTensorOps<Self> for GpuBackend<B> {
                 input: Variable::Input(0, Item::Scalar(elem)),
                 out: Variable::Local(0, Item::Scalar(elem)),
             }),
-            compiler: B::Compiler,
+            backend: B,
             input: tensor,
             elem: FloatElem<Self>
         )
@@ -390,7 +395,7 @@ impl<B: JitGpuBackend> FloatTensorOps<Self> for GpuBackend<B> {
                 input: Variable::Input(0, Item::Scalar(elem)),
                 out: Variable::Local(0, Item::Scalar(elem)),
             }),
-            compiler: B::Compiler,
+            backend: B,
             input: tensor,
             elem: FloatElem<Self>
         )
@@ -406,7 +411,7 @@ impl<B: JitGpuBackend> FloatTensorOps<Self> for GpuBackend<B> {
                 rhs: Variable::Scalar(0, Item::Scalar(elem)),
                 out: Variable::Local(0, Item::Scalar(elem)),
             }),
-            compiler: B::Compiler,
+            backend: B,
             input: lhs; rhs.elem(),
             elem: FloatElem<Self>
         )
@@ -418,7 +423,7 @@ impl<B: JitGpuBackend> FloatTensorOps<Self> for GpuBackend<B> {
                 input: Variable::Input(0, Item::Scalar(elem)),
                 out: Variable::Local(0, Item::Scalar(elem)),
             }),
-            compiler: B::Compiler,
+            backend: B,
             input: tensor,
             elem: FloatElem<Self>
         )
@@ -430,7 +435,7 @@ impl<B: JitGpuBackend> FloatTensorOps<Self> for GpuBackend<B> {
                 input: Variable::Input(0, Item::Scalar(elem)),
                 out: Variable::Local(0, Item::Scalar(elem)),
             }),
-            compiler: B::Compiler,
+            backend: B,
             input: tensor,
             elem: FloatElem<Self>
         )
@@ -442,7 +447,7 @@ impl<B: JitGpuBackend> FloatTensorOps<Self> for GpuBackend<B> {
                 input: Variable::Input(0, Item::Scalar(elem)),
                 out: Variable::Local(0, Item::Scalar(elem)),
             }),
-            compiler: B::Compiler,
+            backend: B,
             input: tensor,
             elem: FloatElem<Self>
         )
@@ -454,7 +459,7 @@ impl<B: JitGpuBackend> FloatTensorOps<Self> for GpuBackend<B> {
                 input: Variable::Input(0, Item::Scalar(elem)),
                 out: Variable::Local(0, Item::Scalar(elem)),
             }),
-            compiler: B::Compiler,
+            backend: B,
             input: tensor,
             elem: FloatElem<Self>
         )
@@ -466,7 +471,7 @@ impl<B: JitGpuBackend> FloatTensorOps<Self> for GpuBackend<B> {
                 input: Variable::Input(0, Item::Scalar(elem)),
                 out: Variable::Local(0, Item::Scalar(elem)),
             }),
-            compiler: B::Compiler,
+            backend: B,
             input: tensor,
             elem: FloatElem<Self>
         )
@@ -478,7 +483,7 @@ impl<B: JitGpuBackend> FloatTensorOps<Self> for GpuBackend<B> {
                 input: Variable::Input(0, Item::Scalar(elem)),
                 out: Variable::Local(0, Item::Scalar(elem)),
             }),
-            compiler: B::Compiler,
+            backend: B,
             input: tensor,
             elem: FloatElem<Self>
         )
@@ -523,7 +528,7 @@ impl<B: JitGpuBackend> FloatTensorOps<Self> for GpuBackend<B> {
                 input: Variable::Input(0, Item::Scalar(elem)),
                 out: Variable::Local(0, Item::Scalar(elem)),
             }),
-            compiler: B::Compiler,
+            backend: B,
             input: tensor,
             elem: FloatElem<Self>
         )

--- a/burn-wgpu/src/ops/float_ops.rs
+++ b/burn-wgpu/src/ops/float_ops.rs
@@ -14,7 +14,7 @@ use crate::kernel::prng::{random_bernoulli, random_normal, random_uniform};
 use crate::kernel::reduce::init_reduce_output;
 use crate::kernel::{self, reduce};
 use crate::tensor::WgpuTensor;
-use crate::JitGpuBackend;
+use crate::JitRuntime;
 use crate::{unary, GpuBackend};
 use burn_tensor::ops::{
     BoolTensor, Device, FloatElem, FloatTensor, FullPrecisionBackend, IntTensor,
@@ -23,7 +23,7 @@ use burn_tensor::{ops::FloatTensorOps, Data, Distribution, Shape};
 use burn_tensor::{ElementConversion, Reader};
 use std::ops::Range;
 
-impl<B: JitGpuBackend> FloatTensorOps<Self> for GpuBackend<B> {
+impl<B: JitRuntime> FloatTensorOps<Self> for GpuBackend<B> {
     fn float_from_data<const D: usize>(
         data: Data<FloatElem<Self>, D>,
         device: &Device<Self>,

--- a/burn-wgpu/src/ops/float_ops.rs
+++ b/burn-wgpu/src/ops/float_ops.rs
@@ -2,7 +2,6 @@ use super::numeric;
 use crate::codegen::dialect::gpu::{
     BinaryOperation, Elem, Item, Operation, UnaryOperation, Variable,
 };
-use crate::codegen::Compiler;
 #[cfg(not(feature = "autotune"))]
 use crate::kernel::matmul::init_matmul_output;
 #[cfg(feature = "autotune")]

--- a/burn-wgpu/src/ops/int_ops.rs
+++ b/burn-wgpu/src/ops/int_ops.rs
@@ -1,22 +1,19 @@
 use super::numeric;
 use crate::codegen::dialect::gpu::{Elem, Item, Operation, UnaryOperation, Variable};
 use crate::codegen::dialect::wgsl;
+use crate::codegen::Compiler;
 use crate::kernel::reduce::{self, init_reduce_output};
-use crate::{
-    element::{FloatElement, IntElement},
-    kernel, unary, GraphicsApi, WgpuBackend,
-};
+use crate::{kernel, unary, GpuBackend, GraphicsApi};
 use burn_tensor::ops::{BoolTensor, Device, FloatTensor, IntElem, IntTensor};
 
 use burn_tensor::Reader;
 use burn_tensor::{ops::IntTensorOps, Data, Shape};
 use std::ops::Range;
 
-impl<G, F, I> IntTensorOps<WgpuBackend<G, F, I>> for WgpuBackend<G, F, I>
+impl<G, C> IntTensorOps<GpuBackend<G, C>> for GpuBackend<G, C>
 where
     G: GraphicsApi + 'static,
-    F: FloatElement,
-    I: IntElement,
+    C: Compiler,
 {
     fn int_empty<const D: usize>(shape: Shape<D>, device: &Device<Self>) -> IntTensor<Self, D> {
         super::empty::<G, I, D>(shape, device)

--- a/burn-wgpu/src/ops/int_ops.rs
+++ b/burn-wgpu/src/ops/int_ops.rs
@@ -1,6 +1,5 @@
 use super::numeric;
 use crate::codegen::dialect::gpu::{Elem, Item, Operation, UnaryOperation, Variable};
-use crate::codegen::dialect::wgsl;
 use crate::codegen::Compiler;
 use crate::kernel::reduce::{self, init_reduce_output};
 use crate::{kernel, unary, GpuBackend, GraphicsApi};
@@ -16,22 +15,22 @@ where
     C: Compiler,
 {
     fn int_empty<const D: usize>(shape: Shape<D>, device: &Device<Self>) -> IntTensor<Self, D> {
-        super::empty::<G, I, D>(shape, device)
+        super::empty::<G, C::Int, D>(shape, device)
     }
 
     fn int_shape<const D: usize>(tensor: &IntTensor<Self, D>) -> Shape<D> {
         tensor.shape.clone()
     }
 
-    fn int_into_data<const D: usize>(tensor: IntTensor<Self, D>) -> Reader<Data<I, D>> {
+    fn int_into_data<const D: usize>(tensor: IntTensor<Self, D>) -> Reader<Data<C::Int, D>> {
         super::into_data(tensor)
     }
 
     fn int_from_data<const D: usize>(
-        data: Data<I, D>,
+        data: Data<C::Int, D>,
         device: &Device<Self>,
     ) -> IntTensor<Self, D> {
-        super::from_data::<G, I, D>(data, device)
+        super::from_data::<G, C::Int, D>(data, device)
     }
 
     fn int_device<const D: usize>(tensor: &IntTensor<Self, D>) -> Device<Self> {
@@ -42,7 +41,7 @@ where
         tensor: IntTensor<Self, D>,
         device: &Device<Self>,
     ) -> IntTensor<Self, D> {
-        super::to_device::<G, I, D>(tensor, device)
+        super::to_device::<G, C::Int, D>(tensor, device)
     }
 
     fn int_reshape<const D1: usize, const D2: usize>(
@@ -64,7 +63,7 @@ where
         ranges: [Range<usize>; D2],
         value: IntTensor<Self, D1>,
     ) -> IntTensor<Self, D1> {
-        kernel::slice_assign::<wgsl::Compiler<F, I>, _, D1, D2>(tensor, ranges, value)
+        kernel::slice_assign::<C, _, D1, D2>(tensor, ranges, value)
     }
 
     fn int_mask_where<const D: usize>(
@@ -97,7 +96,7 @@ where
         indices: IntTensor<Self, D>,
         value: IntTensor<Self, D>,
     ) -> IntTensor<Self, D> {
-        kernel::scatter::<wgsl::Compiler<F, I>, _, _, D>(dim, tensor, indices, value)
+        kernel::scatter::<C, _, _, D>(dim, tensor, indices, value)
     }
 
     fn int_select<const D: usize>(
@@ -114,7 +113,7 @@ where
         indices: IntTensor<Self, 1>,
         value: IntTensor<Self, D>,
     ) -> IntTensor<Self, D> {
-        kernel::select_assign::<wgsl::Compiler<F, I>, _, _, D>(tensor, dim, indices, value)
+        kernel::select_assign::<C, _, _, D>(tensor, dim, indices, value)
     }
 
     fn int_cat<const D: usize>(tensors: Vec<IntTensor<Self, D>>, dim: usize) -> IntTensor<Self, D> {
@@ -125,134 +124,134 @@ where
         lhs: IntTensor<Self, D>,
         rhs: IntTensor<Self, D>,
     ) -> BoolTensor<Self, D> {
-        kernel::equal::<wgsl::Compiler<F, I>, _, D>(lhs, rhs)
+        kernel::equal::<C, _, D>(lhs, rhs)
     }
 
     fn int_equal_elem<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntElem<Self>,
     ) -> BoolTensor<Self, D> {
-        kernel::equal_elem::<wgsl::Compiler<F, I>, _, D>(lhs, rhs)
+        kernel::equal_elem::<C, _, D>(lhs, rhs)
     }
 
     fn int_greater<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntTensor<Self, D>,
     ) -> BoolTensor<Self, D> {
-        kernel::greater::<wgsl::Compiler<F, I>, _, D>(lhs, rhs)
+        kernel::greater::<C, _, D>(lhs, rhs)
     }
 
     fn int_greater_elem<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntElem<Self>,
     ) -> BoolTensor<Self, D> {
-        kernel::greater_elem::<wgsl::Compiler<F, I>, _, D>(lhs, rhs)
+        kernel::greater_elem::<C, _, D>(lhs, rhs)
     }
 
     fn int_greater_equal<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntTensor<Self, D>,
     ) -> BoolTensor<Self, D> {
-        kernel::greater_equal::<wgsl::Compiler<F, I>, _, D>(lhs, rhs)
+        kernel::greater_equal::<C, _, D>(lhs, rhs)
     }
 
     fn int_greater_equal_elem<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntElem<Self>,
     ) -> BoolTensor<Self, D> {
-        kernel::greater_equal_elem::<wgsl::Compiler<F, I>, _, D>(lhs, rhs)
+        kernel::greater_equal_elem::<C, _, D>(lhs, rhs)
     }
 
     fn int_lower<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntTensor<Self, D>,
     ) -> BoolTensor<Self, D> {
-        kernel::lower::<wgsl::Compiler<F, I>, _, D>(lhs, rhs)
+        kernel::lower::<C, _, D>(lhs, rhs)
     }
 
     fn int_lower_elem<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntElem<Self>,
     ) -> BoolTensor<Self, D> {
-        kernel::lower_elem::<wgsl::Compiler<F, I>, _, D>(lhs, rhs)
+        kernel::lower_elem::<C, _, D>(lhs, rhs)
     }
 
     fn int_lower_equal<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntTensor<Self, D>,
     ) -> BoolTensor<Self, D> {
-        kernel::lower_equal::<wgsl::Compiler<F, I>, _, D>(lhs, rhs)
+        kernel::lower_equal::<C, _, D>(lhs, rhs)
     }
 
     fn int_lower_equal_elem<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntElem<Self>,
     ) -> BoolTensor<Self, D> {
-        kernel::lower_equal_elem::<wgsl::Compiler<F, I>, _, D>(lhs, rhs)
+        kernel::lower_equal_elem::<C, _, D>(lhs, rhs)
     }
 
     fn int_add<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntTensor<Self, D>,
     ) -> IntTensor<Self, D> {
-        numeric::add::<wgsl::Compiler<F, I>, I, D>(lhs, rhs)
+        numeric::add::<C, _, D>(lhs, rhs)
     }
 
     fn int_add_scalar<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntElem<Self>,
     ) -> IntTensor<Self, D> {
-        numeric::add_scalar::<wgsl::Compiler<F, I>, _, D>(lhs, rhs)
+        numeric::add_scalar::<C, _, D>(lhs, rhs)
     }
 
     fn int_sub<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntTensor<Self, D>,
     ) -> IntTensor<Self, D> {
-        numeric::sub::<wgsl::Compiler<F, I>, I, D>(lhs, rhs)
+        numeric::sub::<C, _, D>(lhs, rhs)
     }
 
     fn int_sub_scalar<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntElem<Self>,
     ) -> IntTensor<Self, D> {
-        numeric::sub_scalar::<wgsl::Compiler<F, I>, _, D>(lhs, rhs)
+        numeric::sub_scalar::<C, _, D>(lhs, rhs)
     }
 
     fn int_mul<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntTensor<Self, D>,
     ) -> IntTensor<Self, D> {
-        numeric::mul::<wgsl::Compiler<F, I>, I, D>(lhs, rhs)
+        numeric::mul::<C, _, D>(lhs, rhs)
     }
 
     fn int_mul_scalar<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntElem<Self>,
     ) -> IntTensor<Self, D> {
-        numeric::mul_scalar::<wgsl::Compiler<F, I>, _, D>(lhs, rhs)
+        numeric::mul_scalar::<C, _, D>(lhs, rhs)
     }
 
     fn int_div<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntTensor<Self, D>,
     ) -> IntTensor<Self, D> {
-        numeric::div::<wgsl::Compiler<F, I>, I, D>(lhs, rhs)
+        numeric::div::<C, _, D>(lhs, rhs)
     }
 
     fn int_div_scalar<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntElem<Self>,
     ) -> IntTensor<Self, D> {
-        numeric::div_scalar::<wgsl::Compiler<F, I>, I, D>(lhs, rhs)
+        numeric::div_scalar::<C, _, D>(lhs, rhs)
     }
 
     fn int_zeros<const D: usize>(shape: Shape<D>, device: &Device<Self>) -> IntTensor<Self, D> {
-        numeric::zeros::<wgsl::Compiler<F, I>, G, I, D>(shape, device)
+        numeric::zeros::<C, G, _, D>(shape, device)
     }
 
     fn int_ones<const D: usize>(shape: Shape<D>, device: &Device<Self>) -> IntTensor<Self, D> {
-        numeric::ones::<wgsl::Compiler<F, I>, G, I, D>(shape, device)
+        numeric::ones::<C, G, _, D>(shape, device)
     }
 
     fn int_sum<const D: usize>(tensor: IntTensor<Self, D>) -> IntTensor<Self, 1> {
@@ -282,7 +281,7 @@ where
         min: IntElem<Self>,
         max: IntElem<Self>,
     ) -> IntTensor<Self, D> {
-        kernel::clamp::<wgsl::Compiler<F, I>, _, D>(tensor, min, max)
+        kernel::clamp::<C, _, D>(tensor, min, max)
     }
 
     fn int_abs<const D: usize>(tensor: IntTensor<Self, D>) -> IntTensor<Self, D> {
@@ -291,9 +290,9 @@ where
                 input: Variable::Input(0, Item::Scalar(elem)),
                 out: Variable::Local(0, Item::Scalar(elem)),
             }),
-            compiler: wgsl::Compiler<F, I>,
+            compiler: C,
             input: tensor,
-            elem: I
+            elem: C::Int
         )
     }
 

--- a/burn-wgpu/src/ops/int_ops.rs
+++ b/burn-wgpu/src/ops/int_ops.rs
@@ -286,7 +286,7 @@ impl<B: JitGpuBackend> IntTensorOps<Self> for GpuBackend<B> {
                 input: Variable::Input(0, Item::Scalar(elem)),
                 out: Variable::Local(0, Item::Scalar(elem)),
             }),
-            compiler: B::Compiler,
+            backend: B,
             input: tensor,
             elem: IntElem<Self>
         )

--- a/burn-wgpu/src/ops/int_ops.rs
+++ b/burn-wgpu/src/ops/int_ops.rs
@@ -2,16 +2,16 @@ use super::numeric;
 use crate::codegen::dialect::gpu::{Elem, Item, Operation, UnaryOperation, Variable};
 use crate::codegen::Compiler;
 use crate::kernel::reduce::{self, init_reduce_output};
-use crate::{kernel, unary, GpuBackend, JitRuntime};
+use crate::{kernel, unary, GpuBackend, Runtime};
 use burn_tensor::ops::{BoolTensor, Device, FloatTensor, IntElem, IntTensor};
 
 use burn_tensor::Reader;
 use burn_tensor::{ops::IntTensorOps, Data, Shape};
 use std::ops::Range;
 
-impl<B: JitRuntime> IntTensorOps<Self> for GpuBackend<B> {
+impl<R: Runtime> IntTensorOps<Self> for GpuBackend<R> {
     fn int_empty<const D: usize>(shape: Shape<D>, device: &Device<Self>) -> IntTensor<Self, D> {
-        super::empty::<B, _, D>(shape, device)
+        super::empty(shape, device)
     }
 
     fn int_shape<const D: usize>(tensor: &IntTensor<Self, D>) -> Shape<D> {
@@ -26,7 +26,7 @@ impl<B: JitRuntime> IntTensorOps<Self> for GpuBackend<B> {
         data: Data<IntElem<Self>, D>,
         device: &Device<Self>,
     ) -> IntTensor<Self, D> {
-        super::from_data::<B, _, D>(data, device)
+        super::from_data(data, device)
     }
 
     fn int_device<const D: usize>(tensor: &IntTensor<Self, D>) -> Device<Self> {
@@ -37,7 +37,7 @@ impl<B: JitRuntime> IntTensorOps<Self> for GpuBackend<B> {
         tensor: IntTensor<Self, D>,
         device: &Device<Self>,
     ) -> IntTensor<Self, D> {
-        super::to_device::<B, _, D>(tensor, device)
+        super::to_device(tensor, device)
     }
 
     fn int_reshape<const D1: usize, const D2: usize>(
@@ -59,7 +59,7 @@ impl<B: JitRuntime> IntTensorOps<Self> for GpuBackend<B> {
         ranges: [Range<usize>; D2],
         value: IntTensor<Self, D1>,
     ) -> IntTensor<Self, D1> {
-        kernel::slice_assign::<B, _, D1, D2>(tensor, ranges, value)
+        kernel::slice_assign(tensor, ranges, value)
     }
 
     fn int_mask_where<const D: usize>(
@@ -92,7 +92,7 @@ impl<B: JitRuntime> IntTensorOps<Self> for GpuBackend<B> {
         indices: IntTensor<Self, D>,
         value: IntTensor<Self, D>,
     ) -> IntTensor<Self, D> {
-        kernel::scatter::<B, _, _, D>(dim, tensor, indices, value)
+        kernel::scatter(dim, tensor, indices, value)
     }
 
     fn int_select<const D: usize>(
@@ -109,7 +109,7 @@ impl<B: JitRuntime> IntTensorOps<Self> for GpuBackend<B> {
         indices: IntTensor<Self, 1>,
         value: IntTensor<Self, D>,
     ) -> IntTensor<Self, D> {
-        kernel::select_assign::<B, _, _, D>(tensor, dim, indices, value)
+        kernel::select_assign(tensor, dim, indices, value)
     }
 
     fn int_cat<const D: usize>(tensors: Vec<IntTensor<Self, D>>, dim: usize) -> IntTensor<Self, D> {
@@ -120,134 +120,134 @@ impl<B: JitRuntime> IntTensorOps<Self> for GpuBackend<B> {
         lhs: IntTensor<Self, D>,
         rhs: IntTensor<Self, D>,
     ) -> BoolTensor<Self, D> {
-        kernel::equal::<B, _, D>(lhs, rhs)
+        kernel::equal(lhs, rhs)
     }
 
     fn int_equal_elem<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntElem<Self>,
     ) -> BoolTensor<Self, D> {
-        kernel::equal_elem::<B, _, D>(lhs, rhs)
+        kernel::equal_elem(lhs, rhs)
     }
 
     fn int_greater<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntTensor<Self, D>,
     ) -> BoolTensor<Self, D> {
-        kernel::greater::<B, _, D>(lhs, rhs)
+        kernel::greater(lhs, rhs)
     }
 
     fn int_greater_elem<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntElem<Self>,
     ) -> BoolTensor<Self, D> {
-        kernel::greater_elem::<B, _, D>(lhs, rhs)
+        kernel::greater_elem(lhs, rhs)
     }
 
     fn int_greater_equal<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntTensor<Self, D>,
     ) -> BoolTensor<Self, D> {
-        kernel::greater_equal::<B, _, D>(lhs, rhs)
+        kernel::greater_equal(lhs, rhs)
     }
 
     fn int_greater_equal_elem<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntElem<Self>,
     ) -> BoolTensor<Self, D> {
-        kernel::greater_equal_elem::<B, _, D>(lhs, rhs)
+        kernel::greater_equal_elem(lhs, rhs)
     }
 
     fn int_lower<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntTensor<Self, D>,
     ) -> BoolTensor<Self, D> {
-        kernel::lower::<B, _, D>(lhs, rhs)
+        kernel::lower(lhs, rhs)
     }
 
     fn int_lower_elem<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntElem<Self>,
     ) -> BoolTensor<Self, D> {
-        kernel::lower_elem::<B, _, D>(lhs, rhs)
+        kernel::lower_elem(lhs, rhs)
     }
 
     fn int_lower_equal<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntTensor<Self, D>,
     ) -> BoolTensor<Self, D> {
-        kernel::lower_equal::<B, _, D>(lhs, rhs)
+        kernel::lower_equal(lhs, rhs)
     }
 
     fn int_lower_equal_elem<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntElem<Self>,
     ) -> BoolTensor<Self, D> {
-        kernel::lower_equal_elem::<B, _, D>(lhs, rhs)
+        kernel::lower_equal_elem(lhs, rhs)
     }
 
     fn int_add<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntTensor<Self, D>,
     ) -> IntTensor<Self, D> {
-        numeric::add::<B, _, D>(lhs, rhs)
+        numeric::add(lhs, rhs)
     }
 
     fn int_add_scalar<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntElem<Self>,
     ) -> IntTensor<Self, D> {
-        numeric::add_scalar::<B, _, D>(lhs, rhs)
+        numeric::add_scalar(lhs, rhs)
     }
 
     fn int_sub<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntTensor<Self, D>,
     ) -> IntTensor<Self, D> {
-        numeric::sub::<B, _, D>(lhs, rhs)
+        numeric::sub(lhs, rhs)
     }
 
     fn int_sub_scalar<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntElem<Self>,
     ) -> IntTensor<Self, D> {
-        numeric::sub_scalar::<B, _, D>(lhs, rhs)
+        numeric::sub_scalar(lhs, rhs)
     }
 
     fn int_mul<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntTensor<Self, D>,
     ) -> IntTensor<Self, D> {
-        numeric::mul::<B, _, D>(lhs, rhs)
+        numeric::mul(lhs, rhs)
     }
 
     fn int_mul_scalar<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntElem<Self>,
     ) -> IntTensor<Self, D> {
-        numeric::mul_scalar::<B, _, D>(lhs, rhs)
+        numeric::mul_scalar(lhs, rhs)
     }
 
     fn int_div<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntTensor<Self, D>,
     ) -> IntTensor<Self, D> {
-        numeric::div::<B, _, D>(lhs, rhs)
+        numeric::div(lhs, rhs)
     }
 
     fn int_div_scalar<const D: usize>(
         lhs: IntTensor<Self, D>,
         rhs: IntElem<Self>,
     ) -> IntTensor<Self, D> {
-        numeric::div_scalar::<B, _, D>(lhs, rhs)
+        numeric::div_scalar(lhs, rhs)
     }
 
     fn int_zeros<const D: usize>(shape: Shape<D>, device: &Device<Self>) -> IntTensor<Self, D> {
-        numeric::zeros::<B, _, D>(shape, device)
+        numeric::zeros(shape, device)
     }
 
     fn int_ones<const D: usize>(shape: Shape<D>, device: &Device<Self>) -> IntTensor<Self, D> {
-        numeric::ones::<B, _, D>(shape, device)
+        numeric::ones(shape, device)
     }
 
     fn int_sum<const D: usize>(tensor: IntTensor<Self, D>) -> IntTensor<Self, 1> {
@@ -277,7 +277,7 @@ impl<B: JitRuntime> IntTensorOps<Self> for GpuBackend<B> {
         min: IntElem<Self>,
         max: IntElem<Self>,
     ) -> IntTensor<Self, D> {
-        kernel::clamp::<B, _, D>(tensor, min, max)
+        kernel::clamp(tensor, min, max)
     }
 
     fn int_abs<const D: usize>(tensor: IntTensor<Self, D>) -> IntTensor<Self, D> {
@@ -286,7 +286,7 @@ impl<B: JitRuntime> IntTensorOps<Self> for GpuBackend<B> {
                 input: Variable::Input(0, Item::Scalar(elem)),
                 out: Variable::Local(0, Item::Scalar(elem)),
             }),
-            backend: B,
+            runtime: R,
             input: tensor,
             elem: IntElem<Self>
         )

--- a/burn-wgpu/src/ops/int_ops.rs
+++ b/burn-wgpu/src/ops/int_ops.rs
@@ -2,14 +2,14 @@ use super::numeric;
 use crate::codegen::dialect::gpu::{Elem, Item, Operation, UnaryOperation, Variable};
 use crate::codegen::Compiler;
 use crate::kernel::reduce::{self, init_reduce_output};
-use crate::{kernel, unary, GpuBackend, Runtime};
+use crate::{kernel, unary, JitBackend, Runtime};
 use burn_tensor::ops::{BoolTensor, Device, FloatTensor, IntElem, IntTensor};
 
 use burn_tensor::Reader;
 use burn_tensor::{ops::IntTensorOps, Data, Shape};
 use std::ops::Range;
 
-impl<R: Runtime> IntTensorOps<Self> for GpuBackend<R> {
+impl<R: Runtime> IntTensorOps<Self> for JitBackend<R> {
     fn int_empty<const D: usize>(shape: Shape<D>, device: &Device<Self>) -> IntTensor<Self, D> {
         super::empty(shape, device)
     }

--- a/burn-wgpu/src/ops/int_ops.rs
+++ b/burn-wgpu/src/ops/int_ops.rs
@@ -2,14 +2,14 @@ use super::numeric;
 use crate::codegen::dialect::gpu::{Elem, Item, Operation, UnaryOperation, Variable};
 use crate::codegen::Compiler;
 use crate::kernel::reduce::{self, init_reduce_output};
-use crate::{kernel, unary, GpuBackend, JitGpuBackend};
+use crate::{kernel, unary, GpuBackend, JitRuntime};
 use burn_tensor::ops::{BoolTensor, Device, FloatTensor, IntElem, IntTensor};
 
 use burn_tensor::Reader;
 use burn_tensor::{ops::IntTensorOps, Data, Shape};
 use std::ops::Range;
 
-impl<B: JitGpuBackend> IntTensorOps<Self> for GpuBackend<B> {
+impl<B: JitRuntime> IntTensorOps<Self> for GpuBackend<B> {
     fn int_empty<const D: usize>(shape: Shape<D>, device: &Device<Self>) -> IntTensor<Self, D> {
         super::empty::<B, _, D>(shape, device)
     }

--- a/burn-wgpu/src/ops/int_ops.rs
+++ b/burn-wgpu/src/ops/int_ops.rs
@@ -1,6 +1,5 @@
 use super::numeric;
 use crate::codegen::dialect::gpu::{Elem, Item, Operation, UnaryOperation, Variable};
-use crate::codegen::Compiler;
 use crate::kernel::reduce::{self, init_reduce_output};
 use crate::{kernel, unary, JitBackend, Runtime};
 use burn_tensor::ops::{BoolTensor, Device, FloatTensor, IntElem, IntTensor};

--- a/burn-wgpu/src/ops/module_ops.rs
+++ b/burn-wgpu/src/ops/module_ops.rs
@@ -4,12 +4,12 @@ use burn_tensor::ops::{
 
 use crate::{
     element::{FloatElement, IntElement},
-    kernel, GraphicsApi, WgpuBackend,
+    kernel, GpuBackend, GraphicsApi,
 };
 
 use burn_tensor::ops::{FloatTensor, IntTensor};
 
-impl<G, F, I> ModuleOps<Self> for WgpuBackend<G, F, I>
+impl<G, F, I> ModuleOps<Self> for GpuBackend<G, F, I>
 where
     G: GraphicsApi + 'static,
     F: FloatElement,
@@ -70,7 +70,7 @@ where
         stride: [usize; 2],
         padding: [usize; 2],
         dilation: [usize; 2],
-    ) -> MaxPool2dWithIndices<WgpuBackend<G, F, I>> {
+    ) -> MaxPool2dWithIndices<GpuBackend<G, F, I>> {
         let (output, indices) =
             kernel::pool::max_pool2d_with_indices(x, kernel_size, stride, padding, dilation);
 
@@ -85,7 +85,7 @@ where
         dilation: [usize; 2],
         output_grad: FloatTensor<Self, 4>,
         indices: IntTensor<Self, 4>,
-    ) -> MaxPool2dBackward<WgpuBackend<G, F, I>> {
+    ) -> MaxPool2dBackward<GpuBackend<G, F, I>> {
         MaxPool2dBackward::new(kernel::pool::max_pool2d_with_indices_backward(
             x,
             output_grad,

--- a/burn-wgpu/src/ops/module_ops.rs
+++ b/burn-wgpu/src/ops/module_ops.rs
@@ -1,10 +1,10 @@
-use crate::{kernel, GpuBackend, Runtime};
+use crate::{kernel, JitBackend, Runtime};
 use burn_tensor::ops::{
     ConvOptions, ConvTransposeOptions, MaxPool2dBackward, MaxPool2dWithIndices, ModuleOps,
 };
 use burn_tensor::ops::{FloatTensor, IntTensor};
 
-impl<R: Runtime> ModuleOps<Self> for GpuBackend<R> {
+impl<R: Runtime> ModuleOps<Self> for JitBackend<R> {
     fn conv2d(
         x: FloatTensor<Self, 4>,
         weight: FloatTensor<Self, 4>,

--- a/burn-wgpu/src/ops/module_ops.rs
+++ b/burn-wgpu/src/ops/module_ops.rs
@@ -1,10 +1,10 @@
-use crate::{kernel, GpuBackend, JitRuntime};
+use crate::{kernel, GpuBackend, Runtime};
 use burn_tensor::ops::{
     ConvOptions, ConvTransposeOptions, MaxPool2dBackward, MaxPool2dWithIndices, ModuleOps,
 };
 use burn_tensor::ops::{FloatTensor, IntTensor};
 
-impl<B: JitRuntime> ModuleOps<Self> for GpuBackend<B> {
+impl<R: Runtime> ModuleOps<Self> for GpuBackend<R> {
     fn conv2d(
         x: FloatTensor<Self, 4>,
         weight: FloatTensor<Self, 4>,

--- a/burn-wgpu/src/ops/module_ops.rs
+++ b/burn-wgpu/src/ops/module_ops.rs
@@ -1,16 +1,10 @@
+use crate::{kernel, GpuBackend, JitGpuBackend};
 use burn_tensor::ops::{
     ConvOptions, ConvTransposeOptions, MaxPool2dBackward, MaxPool2dWithIndices, ModuleOps,
 };
-
-use crate::{codegen::Compiler, kernel, GpuBackend, GraphicsApi};
-
 use burn_tensor::ops::{FloatTensor, IntTensor};
 
-impl<G, C> ModuleOps<Self> for GpuBackend<G, C>
-where
-    G: GraphicsApi + 'static,
-    C: Compiler,
-{
+impl<B: JitGpuBackend> ModuleOps<Self> for GpuBackend<B> {
     fn conv2d(
         x: FloatTensor<Self, 4>,
         weight: FloatTensor<Self, 4>,

--- a/burn-wgpu/src/ops/module_ops.rs
+++ b/burn-wgpu/src/ops/module_ops.rs
@@ -2,18 +2,14 @@ use burn_tensor::ops::{
     ConvOptions, ConvTransposeOptions, MaxPool2dBackward, MaxPool2dWithIndices, ModuleOps,
 };
 
-use crate::{
-    element::{FloatElement, IntElement},
-    kernel, GpuBackend, GraphicsApi,
-};
+use crate::{codegen::Compiler, kernel, GpuBackend, GraphicsApi};
 
 use burn_tensor::ops::{FloatTensor, IntTensor};
 
-impl<G, F, I> ModuleOps<Self> for GpuBackend<G, F, I>
+impl<G, C> ModuleOps<Self> for GpuBackend<G, C>
 where
     G: GraphicsApi + 'static,
-    F: FloatElement,
-    I: IntElement,
+    C: Compiler,
 {
     fn conv2d(
         x: FloatTensor<Self, 4>,
@@ -70,7 +66,7 @@ where
         stride: [usize; 2],
         padding: [usize; 2],
         dilation: [usize; 2],
-    ) -> MaxPool2dWithIndices<GpuBackend<G, F, I>> {
+    ) -> MaxPool2dWithIndices<Self> {
         let (output, indices) =
             kernel::pool::max_pool2d_with_indices(x, kernel_size, stride, padding, dilation);
 
@@ -85,7 +81,7 @@ where
         dilation: [usize; 2],
         output_grad: FloatTensor<Self, 4>,
         indices: IntTensor<Self, 4>,
-    ) -> MaxPool2dBackward<GpuBackend<G, F, I>> {
+    ) -> MaxPool2dBackward<Self> {
         MaxPool2dBackward::new(kernel::pool::max_pool2d_with_indices_backward(
             x,
             output_grad,

--- a/burn-wgpu/src/ops/module_ops.rs
+++ b/burn-wgpu/src/ops/module_ops.rs
@@ -1,10 +1,10 @@
-use crate::{kernel, GpuBackend, JitGpuBackend};
+use crate::{kernel, GpuBackend, JitRuntime};
 use burn_tensor::ops::{
     ConvOptions, ConvTransposeOptions, MaxPool2dBackward, MaxPool2dWithIndices, ModuleOps,
 };
 use burn_tensor::ops::{FloatTensor, IntTensor};
 
-impl<B: JitGpuBackend> ModuleOps<Self> for GpuBackend<B> {
+impl<B: JitRuntime> ModuleOps<Self> for GpuBackend<B> {
     fn conv2d(
         x: FloatTensor<Self, 4>,
         weight: FloatTensor<Self, 4>,

--- a/burn-wgpu/src/ops/numeric.rs
+++ b/burn-wgpu/src/ops/numeric.rs
@@ -2,27 +2,27 @@ use crate::codegen::dialect::gpu::{
     BinaryOperation, Elem, Item, Operation, UnaryOperation, Variable,
 };
 use crate::codegen::Compiler;
-use crate::compute::{compute_client, WgpuComputeClient};
-use crate::{binary, GraphicsApi, WgpuDevice};
+use crate::{binary, JitGpuBackend};
 use crate::{element::WgpuElement, tensor::WgpuTensor, unary};
+use burn_compute::client::ComputeClient;
 use burn_tensor::{ElementConversion, Shape};
 
-pub fn full<C: Compiler, G: GraphicsApi, E: WgpuElement, const D: usize>(
+pub fn full<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     shape: Shape<D>,
-    device: &WgpuDevice,
+    device: &B::Device,
     value: E,
-) -> WgpuTensor<E, D> {
-    let client = compute_client::<G>(device);
+) -> WgpuTensor<B, E, D> {
+    let client = B::client(device);
 
-    full_device::<C, E, D>(client, shape, device.clone(), value)
+    full_device::<B, E, D>(client, shape, device.clone(), value)
 }
 
-pub fn full_device<C: Compiler, E: WgpuElement, const D: usize>(
-    client: WgpuComputeClient,
+pub fn full_device<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    client: ComputeClient<B::Server, B::Channel>,
     shape: Shape<D>,
-    device: WgpuDevice,
+    device: B::Device,
     value: E,
-) -> WgpuTensor<E, D> {
+) -> WgpuTensor<B, E, D> {
     let empty = empty_device(client, device, shape);
 
     unary!(
@@ -30,195 +30,195 @@ pub fn full_device<C: Compiler, E: WgpuElement, const D: usize>(
             input: Variable::Scalar(0, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(elem)),
         }),
-        compiler: C,
+        compiler: B::Compiler,
         input: empty; value,
         elem: E
     )
 }
 
-pub fn zeros<C: Compiler, G: GraphicsApi, E: WgpuElement, const D: usize>(
+pub fn zeros<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     shape: Shape<D>,
-    device: &WgpuDevice,
-) -> WgpuTensor<E, D> {
-    let client = compute_client::<G>(device);
+    device: &B::Device,
+) -> WgpuTensor<B, E, D> {
+    let client = B::client(device);
 
-    zeros_device::<C, E, D>(client, device.clone(), shape)
+    zeros_device::<B, E, D>(client, device.clone(), shape)
 }
 
-pub fn zeros_device<C: Compiler, E: WgpuElement, const D: usize>(
-    client: WgpuComputeClient,
-    device: WgpuDevice,
+pub fn zeros_device<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    client: ComputeClient<B::Server, B::Channel>,
+    device: B::Device,
     shape: Shape<D>,
-) -> WgpuTensor<E, D> {
-    full_device::<C, E, D>(client, shape, device, 0.elem())
+) -> WgpuTensor<B, E, D> {
+    full_device::<B, E, D>(client, shape, device, 0.elem())
 }
 
-pub fn ones<C: Compiler, G: GraphicsApi, E: WgpuElement, const D: usize>(
+pub fn ones<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     shape: Shape<D>,
-    device: &WgpuDevice,
-) -> WgpuTensor<E, D> {
-    let client = compute_client::<G>(device);
+    device: &B::Device,
+) -> WgpuTensor<B, E, D> {
+    let client = B::client(device);
 
-    ones_device::<C, E, D>(client, device.clone(), shape)
+    ones_device::<B, E, D>(client, device.clone(), shape)
 }
 
-pub fn ones_device<C: Compiler, E: WgpuElement, const D: usize>(
-    client: WgpuComputeClient,
-    device: WgpuDevice,
+pub fn ones_device<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    client: ComputeClient<B::Server, B::Channel>,
+    device: B::Device,
     shape: Shape<D>,
-) -> WgpuTensor<E, D> {
-    full_device::<C, E, D>(client, shape, device, 1.elem())
+) -> WgpuTensor<B, E, D> {
+    full_device::<B, E, D>(client, shape, device, 1.elem())
 }
 
-pub fn empty_device<E: WgpuElement, const D: usize>(
-    client: WgpuComputeClient,
-    device: WgpuDevice,
+pub fn empty_device<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    client: ComputeClient<B::Server, B::Channel>,
+    device: B::Device,
     shape: Shape<D>,
-) -> WgpuTensor<E, D> {
+) -> WgpuTensor<B, E, D> {
     let buffer = client.empty(shape.num_elements() * core::mem::size_of::<E>());
 
     WgpuTensor::new(client, device, shape, buffer)
 }
 
-pub fn add<C: Compiler, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<E, D>,
-    rhs: WgpuTensor<E, D>,
-) -> WgpuTensor<E, D> {
+pub fn add<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    lhs: WgpuTensor<B, E, D>,
+    rhs: WgpuTensor<B, E, D>,
+) -> WgpuTensor<B, E, D> {
     binary!(
         operation: |elem: Elem| Operation::Add(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
             rhs: Variable::Input(1, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(elem)),
         }),
-        compiler: C,
+        compiler: B::Compiler,
         input: lhs; rhs,
         elem: E
     )
 }
 
-pub fn add_scalar<C: Compiler, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<E, D>,
+pub fn add_scalar<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    lhs: WgpuTensor<B, E, D>,
     rhs: E,
-) -> WgpuTensor<E, D> {
+) -> WgpuTensor<B, E, D> {
     unary!(
         operation: |elem: Elem| Operation::Add(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
             rhs: Variable::Scalar(0, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(elem)),
         }),
-        compiler: C,
+        compiler: B::Compiler,
         input: lhs; rhs,
         elem: E
     )
 }
 
-pub fn sub<C: Compiler, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<E, D>,
-    rhs: WgpuTensor<E, D>,
-) -> WgpuTensor<E, D> {
+pub fn sub<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    lhs: WgpuTensor<B, E, D>,
+    rhs: WgpuTensor<B, E, D>,
+) -> WgpuTensor<B, E, D> {
     binary!(
         operation: |elem: Elem| Operation::Sub(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
             rhs: Variable::Input(1, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(elem)),
         }),
-        compiler: C,
+        compiler: B::Compiler,
         input: lhs; rhs,
         elem: E
     )
 }
 
-pub fn sub_scalar<C: Compiler, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<E, D>,
+pub fn sub_scalar<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    lhs: WgpuTensor<B, E, D>,
     rhs: E,
-) -> WgpuTensor<E, D> {
+) -> WgpuTensor<B, E, D> {
     unary!(
         operation: |elem: Elem| Operation::Sub(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
             rhs: Variable::Scalar(0, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(elem)),
         }),
-        compiler: C,
+        compiler: B::Compiler,
         input: lhs; rhs,
         elem: E
     )
 }
 
-pub fn mul<C: Compiler, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<E, D>,
-    rhs: WgpuTensor<E, D>,
-) -> WgpuTensor<E, D> {
+pub fn mul<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    lhs: WgpuTensor<B, E, D>,
+    rhs: WgpuTensor<B, E, D>,
+) -> WgpuTensor<B, E, D> {
     binary!(
         operation: |elem: Elem| Operation::Mul(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
             rhs: Variable::Input(1, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(elem)),
         }),
-        compiler: C,
+        compiler: B::Compiler,
         input: lhs; rhs,
         elem: E
     )
 }
 
-pub fn mul_scalar<C: Compiler, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<E, D>,
+pub fn mul_scalar<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    lhs: WgpuTensor<B, E, D>,
     rhs: E,
-) -> WgpuTensor<E, D> {
+) -> WgpuTensor<B, E, D> {
     unary!(
         operation: |elem: Elem| Operation::Mul(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
             rhs: Variable::Scalar(0, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(elem)),
         }),
-        compiler: C,
+        compiler: B::Compiler,
         input: lhs; rhs,
         elem: E
     )
 }
 
-pub fn div<C: Compiler, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<E, D>,
-    rhs: WgpuTensor<E, D>,
-) -> WgpuTensor<E, D> {
+pub fn div<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    lhs: WgpuTensor<B, E, D>,
+    rhs: WgpuTensor<B, E, D>,
+) -> WgpuTensor<B, E, D> {
     binary!(
         operation: |elem: Elem| Operation::Div(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
             rhs: Variable::Input(1, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(elem)),
         }),
-        compiler: C,
+        compiler: B::Compiler,
         input: lhs; rhs,
         elem: E
     )
 }
 
-pub fn div_scalar<C: Compiler, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<E, D>,
+pub fn div_scalar<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    lhs: WgpuTensor<B, E, D>,
     rhs: E,
-) -> WgpuTensor<E, D> {
+) -> WgpuTensor<B, E, D> {
     unary!(
         operation: |elem: Elem| Operation::Div(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
             rhs: Variable::Scalar(0, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(elem)),
         }),
-        compiler: C,
+        compiler: B::Compiler,
         input: lhs; rhs,
         elem: E
     )
 }
 
-pub fn pow<C: Compiler, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<E, D>,
-    rhs: WgpuTensor<E, D>,
-) -> WgpuTensor<E, D> {
+pub fn pow<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+    lhs: WgpuTensor<B, E, D>,
+    rhs: WgpuTensor<B, E, D>,
+) -> WgpuTensor<B, E, D> {
     binary!(
         operation: |elem: Elem| Operation::Powf(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
             rhs: Variable::Input(1, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(elem)),
         }),
-        compiler: C,
+        compiler: B::Compiler,
         input: lhs; rhs,
         elem: E
     )

--- a/burn-wgpu/src/ops/numeric.rs
+++ b/burn-wgpu/src/ops/numeric.rs
@@ -2,12 +2,12 @@ use crate::codegen::dialect::gpu::{
     BinaryOperation, Elem, Item, Operation, UnaryOperation, Variable,
 };
 use crate::codegen::Compiler;
-use crate::{binary, JitGpuBackend};
+use crate::{binary, JitRuntime};
 use crate::{element::WgpuElement, tensor::WgpuTensor, unary};
 use burn_compute::client::ComputeClient;
 use burn_tensor::{ElementConversion, Shape};
 
-pub fn full<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn full<B: JitRuntime, E: WgpuElement, const D: usize>(
     shape: Shape<D>,
     device: &B::Device,
     value: E,
@@ -17,7 +17,7 @@ pub fn full<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     full_device::<B, E, D>(client, shape, device.clone(), value)
 }
 
-pub fn full_device<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn full_device<B: JitRuntime, E: WgpuElement, const D: usize>(
     client: ComputeClient<B::Server, B::Channel>,
     shape: Shape<D>,
     device: B::Device,
@@ -36,7 +36,7 @@ pub fn full_device<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn zeros<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn zeros<B: JitRuntime, E: WgpuElement, const D: usize>(
     shape: Shape<D>,
     device: &B::Device,
 ) -> WgpuTensor<B, E, D> {
@@ -45,7 +45,7 @@ pub fn zeros<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     zeros_device::<B, E, D>(client, device.clone(), shape)
 }
 
-pub fn zeros_device<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn zeros_device<B: JitRuntime, E: WgpuElement, const D: usize>(
     client: ComputeClient<B::Server, B::Channel>,
     device: B::Device,
     shape: Shape<D>,
@@ -53,7 +53,7 @@ pub fn zeros_device<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     full_device::<B, E, D>(client, shape, device, 0.elem())
 }
 
-pub fn ones<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn ones<B: JitRuntime, E: WgpuElement, const D: usize>(
     shape: Shape<D>,
     device: &B::Device,
 ) -> WgpuTensor<B, E, D> {
@@ -62,7 +62,7 @@ pub fn ones<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     ones_device::<B, E, D>(client, device.clone(), shape)
 }
 
-pub fn ones_device<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn ones_device<B: JitRuntime, E: WgpuElement, const D: usize>(
     client: ComputeClient<B::Server, B::Channel>,
     device: B::Device,
     shape: Shape<D>,
@@ -70,7 +70,7 @@ pub fn ones_device<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     full_device::<B, E, D>(client, shape, device, 1.elem())
 }
 
-pub fn empty_device<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn empty_device<B: JitRuntime, E: WgpuElement, const D: usize>(
     client: ComputeClient<B::Server, B::Channel>,
     device: B::Device,
     shape: Shape<D>,
@@ -80,7 +80,7 @@ pub fn empty_device<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     WgpuTensor::new(client, device, shape, buffer)
 }
 
-pub fn add<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn add<B: JitRuntime, E: WgpuElement, const D: usize>(
     lhs: WgpuTensor<B, E, D>,
     rhs: WgpuTensor<B, E, D>,
 ) -> WgpuTensor<B, E, D> {
@@ -96,7 +96,7 @@ pub fn add<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn add_scalar<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn add_scalar<B: JitRuntime, E: WgpuElement, const D: usize>(
     lhs: WgpuTensor<B, E, D>,
     rhs: E,
 ) -> WgpuTensor<B, E, D> {
@@ -112,7 +112,7 @@ pub fn add_scalar<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn sub<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn sub<B: JitRuntime, E: WgpuElement, const D: usize>(
     lhs: WgpuTensor<B, E, D>,
     rhs: WgpuTensor<B, E, D>,
 ) -> WgpuTensor<B, E, D> {
@@ -128,7 +128,7 @@ pub fn sub<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn sub_scalar<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn sub_scalar<B: JitRuntime, E: WgpuElement, const D: usize>(
     lhs: WgpuTensor<B, E, D>,
     rhs: E,
 ) -> WgpuTensor<B, E, D> {
@@ -144,7 +144,7 @@ pub fn sub_scalar<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn mul<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn mul<B: JitRuntime, E: WgpuElement, const D: usize>(
     lhs: WgpuTensor<B, E, D>,
     rhs: WgpuTensor<B, E, D>,
 ) -> WgpuTensor<B, E, D> {
@@ -160,7 +160,7 @@ pub fn mul<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn mul_scalar<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn mul_scalar<B: JitRuntime, E: WgpuElement, const D: usize>(
     lhs: WgpuTensor<B, E, D>,
     rhs: E,
 ) -> WgpuTensor<B, E, D> {
@@ -176,7 +176,7 @@ pub fn mul_scalar<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn div<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn div<B: JitRuntime, E: WgpuElement, const D: usize>(
     lhs: WgpuTensor<B, E, D>,
     rhs: WgpuTensor<B, E, D>,
 ) -> WgpuTensor<B, E, D> {
@@ -192,7 +192,7 @@ pub fn div<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn div_scalar<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn div_scalar<B: JitRuntime, E: WgpuElement, const D: usize>(
     lhs: WgpuTensor<B, E, D>,
     rhs: E,
 ) -> WgpuTensor<B, E, D> {
@@ -208,7 +208,7 @@ pub fn div_scalar<B: JitGpuBackend, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn pow<B: JitGpuBackend, E: WgpuElement, const D: usize>(
+pub fn pow<B: JitRuntime, E: WgpuElement, const D: usize>(
     lhs: WgpuTensor<B, E, D>,
     rhs: WgpuTensor<B, E, D>,
 ) -> WgpuTensor<B, E, D> {

--- a/burn-wgpu/src/ops/numeric.rs
+++ b/burn-wgpu/src/ops/numeric.rs
@@ -30,7 +30,7 @@ pub fn full_device<B: JitGpuBackend, E: WgpuElement, const D: usize>(
             input: Variable::Scalar(0, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(elem)),
         }),
-        compiler: B::Compiler,
+        backend: B,
         input: empty; value,
         elem: E
     )
@@ -90,7 +90,7 @@ pub fn add<B: JitGpuBackend, E: WgpuElement, const D: usize>(
             rhs: Variable::Input(1, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(elem)),
         }),
-        compiler: B::Compiler,
+        backend: B,
         input: lhs; rhs,
         elem: E
     )
@@ -106,7 +106,7 @@ pub fn add_scalar<B: JitGpuBackend, E: WgpuElement, const D: usize>(
             rhs: Variable::Scalar(0, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(elem)),
         }),
-        compiler: B::Compiler,
+        backend: B,
         input: lhs; rhs,
         elem: E
     )
@@ -122,7 +122,7 @@ pub fn sub<B: JitGpuBackend, E: WgpuElement, const D: usize>(
             rhs: Variable::Input(1, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(elem)),
         }),
-        compiler: B::Compiler,
+        backend: B,
         input: lhs; rhs,
         elem: E
     )
@@ -138,7 +138,7 @@ pub fn sub_scalar<B: JitGpuBackend, E: WgpuElement, const D: usize>(
             rhs: Variable::Scalar(0, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(elem)),
         }),
-        compiler: B::Compiler,
+        backend: B,
         input: lhs; rhs,
         elem: E
     )
@@ -154,7 +154,7 @@ pub fn mul<B: JitGpuBackend, E: WgpuElement, const D: usize>(
             rhs: Variable::Input(1, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(elem)),
         }),
-        compiler: B::Compiler,
+        backend: B,
         input: lhs; rhs,
         elem: E
     )
@@ -170,7 +170,7 @@ pub fn mul_scalar<B: JitGpuBackend, E: WgpuElement, const D: usize>(
             rhs: Variable::Scalar(0, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(elem)),
         }),
-        compiler: B::Compiler,
+        backend: B,
         input: lhs; rhs,
         elem: E
     )
@@ -186,7 +186,7 @@ pub fn div<B: JitGpuBackend, E: WgpuElement, const D: usize>(
             rhs: Variable::Input(1, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(elem)),
         }),
-        compiler: B::Compiler,
+        backend: B,
         input: lhs; rhs,
         elem: E
     )
@@ -202,7 +202,7 @@ pub fn div_scalar<B: JitGpuBackend, E: WgpuElement, const D: usize>(
             rhs: Variable::Scalar(0, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(elem)),
         }),
-        compiler: B::Compiler,
+        backend: B,
         input: lhs; rhs,
         elem: E
     )
@@ -218,7 +218,7 @@ pub fn pow<B: JitGpuBackend, E: WgpuElement, const D: usize>(
             rhs: Variable::Input(1, Item::Scalar(elem)),
             out: Variable::Local(0, Item::Scalar(elem)),
         }),
-        compiler: B::Compiler,
+        backend: B,
         input: lhs; rhs,
         elem: E
     )

--- a/burn-wgpu/src/ops/numeric.rs
+++ b/burn-wgpu/src/ops/numeric.rs
@@ -3,26 +3,26 @@ use crate::codegen::dialect::gpu::{
 };
 use crate::codegen::Compiler;
 use crate::{binary, Runtime};
-use crate::{element::WgpuElement, tensor::WgpuTensor, unary};
+use crate::{element::JitElement, tensor::JitTensor, unary};
 use burn_compute::client::ComputeClient;
 use burn_tensor::{ElementConversion, Shape};
 
-pub fn full<R: Runtime, E: WgpuElement, const D: usize>(
+pub fn full<R: Runtime, E: JitElement, const D: usize>(
     shape: Shape<D>,
     device: &R::Device,
     value: E,
-) -> WgpuTensor<R, E, D> {
+) -> JitTensor<R, E, D> {
     let client = R::client(device);
 
     full_device::<R, E, D>(client, shape, device.clone(), value)
 }
 
-pub fn full_device<R: Runtime, E: WgpuElement, const D: usize>(
+pub fn full_device<R: Runtime, E: JitElement, const D: usize>(
     client: ComputeClient<R::Server, R::Channel>,
     shape: Shape<D>,
     device: R::Device,
     value: E,
-) -> WgpuTensor<R, E, D> {
+) -> JitTensor<R, E, D> {
     let empty = empty_device(client, device, shape);
 
     unary!(
@@ -36,54 +36,54 @@ pub fn full_device<R: Runtime, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn zeros<R: Runtime, E: WgpuElement, const D: usize>(
+pub fn zeros<R: Runtime, E: JitElement, const D: usize>(
     shape: Shape<D>,
     device: &R::Device,
-) -> WgpuTensor<R, E, D> {
+) -> JitTensor<R, E, D> {
     let client = R::client(device);
 
     zeros_device(client, device.clone(), shape)
 }
 
-pub fn zeros_device<R: Runtime, E: WgpuElement, const D: usize>(
+pub fn zeros_device<R: Runtime, E: JitElement, const D: usize>(
     client: ComputeClient<R::Server, R::Channel>,
     device: R::Device,
     shape: Shape<D>,
-) -> WgpuTensor<R, E, D> {
+) -> JitTensor<R, E, D> {
     full_device::<R, E, D>(client, shape, device, 0.elem())
 }
 
-pub fn ones<R: Runtime, E: WgpuElement, const D: usize>(
+pub fn ones<R: Runtime, E: JitElement, const D: usize>(
     shape: Shape<D>,
     device: &R::Device,
-) -> WgpuTensor<R, E, D> {
+) -> JitTensor<R, E, D> {
     let client = R::client(device);
 
     ones_device::<R, E, D>(client, device.clone(), shape)
 }
 
-pub fn ones_device<R: Runtime, E: WgpuElement, const D: usize>(
+pub fn ones_device<R: Runtime, E: JitElement, const D: usize>(
     client: ComputeClient<R::Server, R::Channel>,
     device: R::Device,
     shape: Shape<D>,
-) -> WgpuTensor<R, E, D> {
+) -> JitTensor<R, E, D> {
     full_device::<R, E, D>(client, shape, device, 1.elem())
 }
 
-pub fn empty_device<R: Runtime, E: WgpuElement, const D: usize>(
+pub fn empty_device<R: Runtime, E: JitElement, const D: usize>(
     client: ComputeClient<R::Server, R::Channel>,
     device: R::Device,
     shape: Shape<D>,
-) -> WgpuTensor<R, E, D> {
+) -> JitTensor<R, E, D> {
     let buffer = client.empty(shape.num_elements() * core::mem::size_of::<E>());
 
-    WgpuTensor::new(client, device, shape, buffer)
+    JitTensor::new(client, device, shape, buffer)
 }
 
-pub fn add<R: Runtime, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<R, E, D>,
-    rhs: WgpuTensor<R, E, D>,
-) -> WgpuTensor<R, E, D> {
+pub fn add<R: Runtime, E: JitElement, const D: usize>(
+    lhs: JitTensor<R, E, D>,
+    rhs: JitTensor<R, E, D>,
+) -> JitTensor<R, E, D> {
     binary!(
         operation: |elem: Elem| Operation::Add(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
@@ -96,10 +96,10 @@ pub fn add<R: Runtime, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn add_scalar<R: Runtime, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<R, E, D>,
+pub fn add_scalar<R: Runtime, E: JitElement, const D: usize>(
+    lhs: JitTensor<R, E, D>,
     rhs: E,
-) -> WgpuTensor<R, E, D> {
+) -> JitTensor<R, E, D> {
     unary!(
         operation: |elem: Elem| Operation::Add(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
@@ -112,10 +112,10 @@ pub fn add_scalar<R: Runtime, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn sub<R: Runtime, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<R, E, D>,
-    rhs: WgpuTensor<R, E, D>,
-) -> WgpuTensor<R, E, D> {
+pub fn sub<R: Runtime, E: JitElement, const D: usize>(
+    lhs: JitTensor<R, E, D>,
+    rhs: JitTensor<R, E, D>,
+) -> JitTensor<R, E, D> {
     binary!(
         operation: |elem: Elem| Operation::Sub(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
@@ -128,10 +128,10 @@ pub fn sub<R: Runtime, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn sub_scalar<R: Runtime, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<R, E, D>,
+pub fn sub_scalar<R: Runtime, E: JitElement, const D: usize>(
+    lhs: JitTensor<R, E, D>,
     rhs: E,
-) -> WgpuTensor<R, E, D> {
+) -> JitTensor<R, E, D> {
     unary!(
         operation: |elem: Elem| Operation::Sub(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
@@ -144,10 +144,10 @@ pub fn sub_scalar<R: Runtime, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn mul<R: Runtime, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<R, E, D>,
-    rhs: WgpuTensor<R, E, D>,
-) -> WgpuTensor<R, E, D> {
+pub fn mul<R: Runtime, E: JitElement, const D: usize>(
+    lhs: JitTensor<R, E, D>,
+    rhs: JitTensor<R, E, D>,
+) -> JitTensor<R, E, D> {
     binary!(
         operation: |elem: Elem| Operation::Mul(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
@@ -160,10 +160,10 @@ pub fn mul<R: Runtime, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn mul_scalar<R: Runtime, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<R, E, D>,
+pub fn mul_scalar<R: Runtime, E: JitElement, const D: usize>(
+    lhs: JitTensor<R, E, D>,
     rhs: E,
-) -> WgpuTensor<R, E, D> {
+) -> JitTensor<R, E, D> {
     unary!(
         operation: |elem: Elem| Operation::Mul(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
@@ -176,10 +176,10 @@ pub fn mul_scalar<R: Runtime, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn div<R: Runtime, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<R, E, D>,
-    rhs: WgpuTensor<R, E, D>,
-) -> WgpuTensor<R, E, D> {
+pub fn div<R: Runtime, E: JitElement, const D: usize>(
+    lhs: JitTensor<R, E, D>,
+    rhs: JitTensor<R, E, D>,
+) -> JitTensor<R, E, D> {
     binary!(
         operation: |elem: Elem| Operation::Div(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
@@ -192,10 +192,10 @@ pub fn div<R: Runtime, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn div_scalar<R: Runtime, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<R, E, D>,
+pub fn div_scalar<R: Runtime, E: JitElement, const D: usize>(
+    lhs: JitTensor<R, E, D>,
     rhs: E,
-) -> WgpuTensor<R, E, D> {
+) -> JitTensor<R, E, D> {
     unary!(
         operation: |elem: Elem| Operation::Div(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),
@@ -208,10 +208,10 @@ pub fn div_scalar<R: Runtime, E: WgpuElement, const D: usize>(
     )
 }
 
-pub fn pow<R: Runtime, E: WgpuElement, const D: usize>(
-    lhs: WgpuTensor<R, E, D>,
-    rhs: WgpuTensor<R, E, D>,
-) -> WgpuTensor<R, E, D> {
+pub fn pow<R: Runtime, E: JitElement, const D: usize>(
+    lhs: JitTensor<R, E, D>,
+    rhs: JitTensor<R, E, D>,
+) -> JitTensor<R, E, D> {
     binary!(
         operation: |elem: Elem| Operation::Powf(BinaryOperation {
             lhs: Variable::Input(0, Item::Scalar(elem)),

--- a/burn-wgpu/src/ops/numeric.rs
+++ b/burn-wgpu/src/ops/numeric.rs
@@ -1,7 +1,6 @@
 use crate::codegen::dialect::gpu::{
     BinaryOperation, Elem, Item, Operation, UnaryOperation, Variable,
 };
-use crate::codegen::Compiler;
 use crate::{binary, Runtime};
 use crate::{element::JitElement, tensor::JitTensor, unary};
 use burn_compute::client::ComputeClient;

--- a/burn-wgpu/src/runtime.rs
+++ b/burn-wgpu/src/runtime.rs
@@ -1,0 +1,32 @@
+use burn_compute::{channel::ComputeChannel, client::ComputeClient, server::ComputeServer};
+use burn_fusion::FusionDevice;
+
+use crate::{codegen::Compiler, compute::JitAutotuneKey};
+
+/// Just-In-Time runtime.
+pub trait Runtime: Send + Sync + 'static {
+    type Compiler: Compiler;
+    type Server: ComputeServer<
+        Kernel = Box<dyn crate::compute::Kernel>,
+        AutotuneKey = JitAutotuneKey,
+    >;
+    type Channel: ComputeChannel<Self::Server>;
+    type Device: FusionDevice
+        + Default
+        + core::hash::Hash
+        + PartialEq
+        + Eq
+        + Clone
+        + core::fmt::Debug
+        + Sync
+        + Send;
+
+    type FullPrecisionRuntime: Runtime<
+        Compiler = <Self::Compiler as Compiler>::FullPrecisionCompiler,
+        Device = Self::Device,
+        Server = Self::Server,
+        Channel = Self::Channel,
+    >;
+
+    fn client(device: &Self::Device) -> ComputeClient<Self::Server, Self::Channel>;
+}

--- a/burn-wgpu/src/runtime.rs
+++ b/burn-wgpu/src/runtime.rs
@@ -1,16 +1,21 @@
+use crate::{codegen::Compiler, compute::JitAutotuneKey};
 use burn_compute::{channel::ComputeChannel, client::ComputeClient, server::ComputeServer};
 use burn_fusion::FusionDevice;
 
-use crate::{codegen::Compiler, compute::JitAutotuneKey};
-
-/// Just-In-Time runtime.
+/// Runtime for the [just-in-time backend](crate::JitBackend).
 pub trait Runtime: Send + Sync + 'static {
+    /// The compiler used to compile the
+    /// [inner representation](crate::codegen::dialect::gpu::ComputeShader).
+    /// into tokens.
     type Compiler: Compiler;
+    /// The compute server used to run kernels and perform autotuning.
     type Server: ComputeServer<
         Kernel = Box<dyn crate::compute::Kernel>,
         AutotuneKey = JitAutotuneKey,
     >;
+    /// The channel used to communicate with the compute server.
     type Channel: ComputeChannel<Self::Server>;
+    /// The device used to retrieve the compute client.
     type Device: FusionDevice
         + Default
         + core::hash::Hash
@@ -21,6 +26,10 @@ pub trait Runtime: Send + Sync + 'static {
         + Sync
         + Send;
 
+    /// A version of the runtime that supports full precision.
+    ///
+    /// Note that the runtime should share all other runtime components.
+    /// This way, it's possible to share the same handles for both runtimes and reduce data copies to a minimum.
     type FullPrecisionRuntime: Runtime<
         Compiler = <Self::Compiler as Compiler>::FullPrecisionCompiler,
         Device = Self::Device,
@@ -28,5 +37,6 @@ pub trait Runtime: Send + Sync + 'static {
         Channel = Self::Channel,
     >;
 
+    /// Retrieve the compute client from the runtime device.
     fn client(device: &Self::Device) -> ComputeClient<Self::Server, Self::Channel>;
 }

--- a/burn-wgpu/src/runtime.rs
+++ b/burn-wgpu/src/runtime.rs
@@ -3,9 +3,7 @@ use burn_compute::{channel::ComputeChannel, client::ComputeClient, server::Compu
 
 /// Runtime for the [just-in-time backend](crate::JitBackend).
 pub trait Runtime: Send + Sync + 'static {
-    /// The compiler used to compile the
-    /// [inner representation](crate::codegen::dialect::gpu::ComputeShader).
-    /// into tokens.
+    /// The compiler used to compile the inner representation into tokens.
     type Compiler: Compiler;
     /// The compute server used to run kernels and perform autotuning.
     type Server: ComputeServer<
@@ -15,7 +13,7 @@ pub trait Runtime: Send + Sync + 'static {
     /// The channel used to communicate with the compute server.
     type Channel: ComputeChannel<Self::Server>;
     /// The device used to retrieve the compute client.
-    #[cfg(feature = "fusion")]
+    #[cfg(any(feature = "fusion", test))]
     type Device: burn_fusion::FusionDevice
         + Default
         + core::hash::Hash
@@ -26,7 +24,7 @@ pub trait Runtime: Send + Sync + 'static {
         + Sync
         + Send;
     /// The device used to retrieve the compute client.
-    #[cfg(not(feature = "fusion"))]
+    #[cfg(not(any(feature = "fusion", test)))]
     type Device: Default
         + core::hash::Hash
         + PartialEq
@@ -51,7 +49,5 @@ pub trait Runtime: Send + Sync + 'static {
     fn client(device: &Self::Device) -> ComputeClient<Self::Server, Self::Channel>;
 
     /// The runtime name.
-    fn name() -> &'static str {
-        core::any::type_name::<Self>()
-    }
+    fn name() -> &'static str;
 }

--- a/burn-wgpu/src/tensor/base.rs
+++ b/burn-wgpu/src/tensor/base.rs
@@ -84,7 +84,7 @@ impl<B: JitGpuBackend, E: WgpuElement, const D: usize> WgpuTensor<B, E, D> {
     pub fn to_client(
         &self,
         client: ComputeClient<B::Server, B::Channel>,
-        device: WgpuDevice,
+        device: B::Device,
     ) -> Self {
         let bytes = self
             .client
@@ -135,7 +135,7 @@ impl<B: JitGpuBackend, E: WgpuElement, const D: usize> WgpuTensor<B, E, D> {
                 input: Variable::Input(0, Item::Scalar(elem)),
                 out: Variable::Local(0, Item::Scalar(elem)),
             }),
-            compiler: B::Compiler,
+            backend: B,
             input: self.clone(),
             elem: E
         )

--- a/burn-wgpu/src/tensor/base.rs
+++ b/burn-wgpu/src/tensor/base.rs
@@ -1,8 +1,6 @@
 use crate::codegen::dialect::gpu::{Elem, Item, Operation, UnaryOperation, Variable};
-use crate::codegen::Compiler;
 use crate::element::WgpuElement;
-use crate::unary;
-use crate::JitGpuBackend;
+use crate::{unary, JitRuntime};
 use burn_compute::client::ComputeClient;
 use burn_compute::server::Handle;
 use burn_tensor::Shape;
@@ -11,7 +9,7 @@ use std::marker::PhantomData;
 /// The basic tensor primitive struct.
 pub struct WgpuTensor<B, E, const D: usize>
 where
-    B: JitGpuBackend,
+    B: JitRuntime,
     E: WgpuElement,
 {
     /// Compute client for wgpu.
@@ -27,16 +25,16 @@ where
     pub(crate) elem: PhantomData<E>,
 }
 
-unsafe impl<B: JitGpuBackend, E: WgpuElement, const D: usize> Send for WgpuTensor<B, E, D> {}
-unsafe impl<B: JitGpuBackend, E: WgpuElement, const D: usize> Sync for WgpuTensor<B, E, D> {}
+unsafe impl<B: JitRuntime, E: WgpuElement, const D: usize> Send for WgpuTensor<B, E, D> {}
+unsafe impl<B: JitRuntime, E: WgpuElement, const D: usize> Sync for WgpuTensor<B, E, D> {}
 
-impl<B: JitGpuBackend, E: WgpuElement, const D: usize> core::fmt::Debug for WgpuTensor<B, E, D> {
+impl<B: JitRuntime, E: WgpuElement, const D: usize> core::fmt::Debug for WgpuTensor<B, E, D> {
     fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         todo!()
     }
 }
 
-impl<B: JitGpuBackend, E: WgpuElement, const D: usize> Clone for WgpuTensor<B, E, D> {
+impl<B: JitRuntime, E: WgpuElement, const D: usize> Clone for WgpuTensor<B, E, D> {
     fn clone(&self) -> Self {
         Self {
             client: self.client.clone(),
@@ -49,7 +47,7 @@ impl<B: JitGpuBackend, E: WgpuElement, const D: usize> Clone for WgpuTensor<B, E
     }
 }
 
-impl<B: JitGpuBackend, E: WgpuElement, const D: usize> WgpuTensor<B, E, D> {
+impl<B: JitRuntime, E: WgpuElement, const D: usize> WgpuTensor<B, E, D> {
     /// Create a new tensor.
     pub fn new(
         client: ComputeClient<B::Server, B::Channel>,

--- a/burn-wgpu/src/tensor/base.rs
+++ b/burn-wgpu/src/tensor/base.rs
@@ -1,8 +1,8 @@
 use crate::codegen::dialect::gpu::{Elem, Item, Operation, UnaryOperation, Variable};
 use crate::codegen::Compiler;
 use crate::element::WgpuElement;
+use crate::unary;
 use crate::JitGpuBackend;
-use crate::{unary, WgpuDevice};
 use burn_compute::client::ComputeClient;
 use burn_compute::server::Handle;
 use burn_tensor::Shape;
@@ -31,7 +31,7 @@ unsafe impl<B: JitGpuBackend, E: WgpuElement, const D: usize> Send for WgpuTenso
 unsafe impl<B: JitGpuBackend, E: WgpuElement, const D: usize> Sync for WgpuTensor<B, E, D> {}
 
 impl<B: JitGpuBackend, E: WgpuElement, const D: usize> core::fmt::Debug for WgpuTensor<B, E, D> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         todo!()
     }
 }
@@ -43,7 +43,7 @@ impl<B: JitGpuBackend, E: WgpuElement, const D: usize> Clone for WgpuTensor<B, E
             handle: self.handle.clone(),
             shape: self.shape.clone(),
             device: self.device.clone(),
-            strides: self.strides.clone(),
+            strides: self.strides,
             elem: PhantomData,
         }
     }

--- a/burn-wgpu/src/tensor/base.rs
+++ b/burn-wgpu/src/tensor/base.rs
@@ -1,5 +1,5 @@
 use crate::codegen::dialect::gpu::{Elem, Item, Operation, UnaryOperation, Variable};
-use crate::element::WgpuElement;
+use crate::element::JitElement;
 use crate::{unary, Runtime};
 use burn_compute::client::ComputeClient;
 use burn_compute::server::Handle;
@@ -7,10 +7,10 @@ use burn_tensor::Shape;
 use std::marker::PhantomData;
 
 /// The basic tensor primitive struct.
-pub struct WgpuTensor<R, E, const D: usize>
+pub struct JitTensor<R, E, const D: usize>
 where
     R: Runtime,
-    E: WgpuElement,
+    E: JitElement,
 {
     /// Compute client for wgpu.
     pub client: ComputeClient<R::Server, R::Channel>,
@@ -25,16 +25,16 @@ where
     pub(crate) elem: PhantomData<E>,
 }
 
-unsafe impl<R: Runtime, E: WgpuElement, const D: usize> Send for WgpuTensor<R, E, D> {}
-unsafe impl<R: Runtime, E: WgpuElement, const D: usize> Sync for WgpuTensor<R, E, D> {}
+unsafe impl<R: Runtime, E: JitElement, const D: usize> Send for JitTensor<R, E, D> {}
+unsafe impl<R: Runtime, E: JitElement, const D: usize> Sync for JitTensor<R, E, D> {}
 
-impl<R: Runtime, E: WgpuElement, const D: usize> core::fmt::Debug for WgpuTensor<R, E, D> {
+impl<R: Runtime, E: JitElement, const D: usize> core::fmt::Debug for JitTensor<R, E, D> {
     fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         todo!()
     }
 }
 
-impl<R: Runtime, E: WgpuElement, const D: usize> Clone for WgpuTensor<R, E, D> {
+impl<R: Runtime, E: JitElement, const D: usize> Clone for JitTensor<R, E, D> {
     fn clone(&self) -> Self {
         Self {
             client: self.client.clone(),
@@ -47,7 +47,7 @@ impl<R: Runtime, E: WgpuElement, const D: usize> Clone for WgpuTensor<R, E, D> {
     }
 }
 
-impl<R: Runtime, E: WgpuElement, const D: usize> WgpuTensor<R, E, D> {
+impl<R: Runtime, E: JitElement, const D: usize> JitTensor<R, E, D> {
     /// Create a new tensor.
     pub fn new(
         client: ComputeClient<R::Server, R::Channel>,

--- a/burn-wgpu/src/tensor/base.rs
+++ b/burn-wgpu/src/tensor/base.rs
@@ -16,7 +16,7 @@ where
     pub client: ComputeClient<R::Server, R::Channel>,
     /// The buffer where the data are stored.
     pub handle: Handle<R::Server>,
-    /// The shape of the ctensor.
+    /// The shape of the tensor.
     pub shape: Shape<D>,
     /// The device of the tensor.
     pub device: R::Device,

--- a/burn-wgpu/src/tensor/base.rs
+++ b/burn-wgpu/src/tensor/base.rs
@@ -12,29 +12,41 @@ where
     R: Runtime,
     E: JitElement,
 {
-    /// Compute client for wgpu.
+    /// Compute client for the [runtime](Runtime).
     pub client: ComputeClient<R::Server, R::Channel>,
     /// The buffer where the data are stored.
     pub handle: Handle<R::Server>,
-    /// The shape of the current tensor.
+    /// The shape of the ctensor.
     pub shape: Shape<D>,
-    /// The device of the current tensor.
+    /// The device of the tensor.
     pub device: R::Device,
-    /// The strides of the current tensor.
+    /// The strides of the tensor.
     pub strides: [usize; D],
     pub(crate) elem: PhantomData<E>,
 }
 
-unsafe impl<R: Runtime, E: JitElement, const D: usize> Send for JitTensor<R, E, D> {}
-unsafe impl<R: Runtime, E: JitElement, const D: usize> Sync for JitTensor<R, E, D> {}
-
-impl<R: Runtime, E: JitElement, const D: usize> core::fmt::Debug for JitTensor<R, E, D> {
-    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        todo!()
+impl<R, E, const D: usize> core::fmt::Debug for JitTensor<R, E, D>
+where
+    R: Runtime,
+    E: JitElement,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!(
+            "JitTensor {{ shape: {:?}, device: {:?}, strides: {:?}, elem: {}, runtime: {}}}",
+            self.shape,
+            self.device,
+            self.strides,
+            E::type_name(),
+            R::name(),
+        ))
     }
 }
 
-impl<R: Runtime, E: JitElement, const D: usize> Clone for JitTensor<R, E, D> {
+impl<R, E, const D: usize> Clone for JitTensor<R, E, D>
+where
+    R: Runtime,
+    E: JitElement,
+{
     fn clone(&self) -> Self {
         Self {
             client: self.client.clone(),
@@ -47,8 +59,12 @@ impl<R: Runtime, E: JitElement, const D: usize> Clone for JitTensor<R, E, D> {
     }
 }
 
-impl<R: Runtime, E: JitElement, const D: usize> JitTensor<R, E, D> {
-    /// Create a new tensor.
+impl<R, E, const D: usize> JitTensor<R, E, D>
+where
+    R: Runtime,
+    E: JitElement,
+{
+    /// Create a new tensor with a contiguous memory layout.
     pub fn new(
         client: ComputeClient<R::Server, R::Channel>,
         device: R::Device,

--- a/examples/custom-wgpu-kernel/examples/custom-wgpu-kernel.rs
+++ b/examples/custom-wgpu-kernel/examples/custom-wgpu-kernel.rs
@@ -1,4 +1,7 @@
-use burn::tensor::{Distribution, Tensor};
+use burn::{
+    backend::wgpu::{wgsl, AutoGraphicsApi},
+    tensor::{Distribution, Tensor},
+};
 use custom_wgpu_kernel::{
     matmul_add_relu_custom, matmul_add_relu_reference, AutodiffBackend, Backend,
 };
@@ -68,7 +71,7 @@ fn autodiff<B: AutodiffBackend>(device: &B::Device) {
 }
 
 fn main() {
-    type MyBackend = burn::backend::wgpu::GpuBackend;
+    type MyBackend = burn::backend::wgpu::GpuBackend<AutoGraphicsApi, wgsl::Compiler<f32, i32>>;
     type MyAutodiffBackend = burn::backend::Autodiff<MyBackend>;
     let device = Default::default();
     inference::<MyBackend>(&device);

--- a/examples/custom-wgpu-kernel/examples/custom-wgpu-kernel.rs
+++ b/examples/custom-wgpu-kernel/examples/custom-wgpu-kernel.rs
@@ -1,5 +1,5 @@
 use burn::{
-    backend::wgpu::{wgsl, AutoGraphicsApi},
+    backend::wgpu::{compute::WgpuJitGpuBackend, wgsl, AutoGraphicsApi},
     tensor::{Distribution, Tensor},
 };
 use custom_wgpu_kernel::{
@@ -71,7 +71,7 @@ fn autodiff<B: AutodiffBackend>(device: &B::Device) {
 }
 
 fn main() {
-    type MyBackend = burn::backend::wgpu::GpuBackend<AutoGraphicsApi, wgsl::Compiler<f32, i32>>;
+    type MyBackend = burn::backend::wgpu::GpuBackend<WgpuJitGpuBackend<AutoGraphicsApi, f32, i32>>;
     type MyAutodiffBackend = burn::backend::Autodiff<MyBackend>;
     let device = Default::default();
     inference::<MyBackend>(&device);

--- a/examples/custom-wgpu-kernel/examples/custom-wgpu-kernel.rs
+++ b/examples/custom-wgpu-kernel/examples/custom-wgpu-kernel.rs
@@ -1,5 +1,5 @@
 use burn::{
-    backend::wgpu::{compute::WgpuJitBackend, AutoGraphicsApi},
+    backend::wgpu::{compute::WgpuRuntime, AutoGraphicsApi},
     tensor::{Distribution, Tensor},
 };
 use custom_wgpu_kernel::{
@@ -71,7 +71,7 @@ fn autodiff<B: AutodiffBackend>(device: &B::Device) {
 }
 
 fn main() {
-    type MyBackend = burn::backend::wgpu::GpuBackend<WgpuJitBackend<AutoGraphicsApi, f32, i32>>;
+    type MyBackend = burn::backend::wgpu::JitBackend<WgpuRuntime<AutoGraphicsApi, f32, i32>>;
     type MyAutodiffBackend = burn::backend::Autodiff<MyBackend>;
     let device = Default::default();
     inference::<MyBackend>(&device);

--- a/examples/custom-wgpu-kernel/examples/custom-wgpu-kernel.rs
+++ b/examples/custom-wgpu-kernel/examples/custom-wgpu-kernel.rs
@@ -68,7 +68,7 @@ fn autodiff<B: AutodiffBackend>(device: &B::Device) {
 }
 
 fn main() {
-    type MyBackend = burn::backend::wgpu::WgpuBackend;
+    type MyBackend = burn::backend::wgpu::GpuBackend;
     type MyAutodiffBackend = burn::backend::Autodiff<MyBackend>;
     let device = Default::default();
     inference::<MyBackend>(&device);

--- a/examples/custom-wgpu-kernel/examples/custom-wgpu-kernel.rs
+++ b/examples/custom-wgpu-kernel/examples/custom-wgpu-kernel.rs
@@ -1,5 +1,5 @@
 use burn::{
-    backend::wgpu::{compute::WgpuJitGpuBackend, wgsl, AutoGraphicsApi},
+    backend::wgpu::{compute::WgpuJitBackend, AutoGraphicsApi},
     tensor::{Distribution, Tensor},
 };
 use custom_wgpu_kernel::{
@@ -71,7 +71,7 @@ fn autodiff<B: AutodiffBackend>(device: &B::Device) {
 }
 
 fn main() {
-    type MyBackend = burn::backend::wgpu::GpuBackend<WgpuJitGpuBackend<AutoGraphicsApi, f32, i32>>;
+    type MyBackend = burn::backend::wgpu::GpuBackend<WgpuJitBackend<AutoGraphicsApi, f32, i32>>;
     type MyAutodiffBackend = burn::backend::Autodiff<MyBackend>;
     let device = Default::default();
     inference::<MyBackend>(&device);

--- a/examples/custom-wgpu-kernel/src/backward.rs
+++ b/examples/custom-wgpu-kernel/src/backward.rs
@@ -1,16 +1,19 @@
 use crate::FloatTensor;
 
 use super::{AutodiffBackend, Backend};
-use burn::backend::autodiff::{
-    grads::Gradients,
-    ops::{broadcast_shape, Backward, Ops, OpsKind},
-    Autodiff,
-};
 use burn::backend::wgpu::{FloatElement, GpuBackend, GraphicsApi, IntElement};
+use burn::backend::{
+    autodiff::{
+        grads::Gradients,
+        ops::{broadcast_shape, Backward, Ops, OpsKind},
+        Autodiff,
+    },
+    wgpu::wgsl,
+};
 use burn::tensor::Shape;
 
 impl<G: GraphicsApi, F: FloatElement, I: IntElement> AutodiffBackend
-    for Autodiff<GpuBackend<G, F, I>>
+    for Autodiff<GpuBackend<G, wgsl::Compiler<F, I>>>
 {
 }
 

--- a/examples/custom-wgpu-kernel/src/backward.rs
+++ b/examples/custom-wgpu-kernel/src/backward.rs
@@ -7,7 +7,7 @@ use burn::backend::autodiff::{
     Autodiff,
 };
 use burn::backend::wgpu::compute::WgpuRuntime;
-use burn::backend::wgpu::{FloatElement, JitBackend, GraphicsApi, IntElement};
+use burn::backend::wgpu::{FloatElement, GraphicsApi, IntElement, JitBackend};
 use burn::tensor::Shape;
 
 impl<G: GraphicsApi, F: FloatElement, I: IntElement> AutodiffBackend

--- a/examples/custom-wgpu-kernel/src/backward.rs
+++ b/examples/custom-wgpu-kernel/src/backward.rs
@@ -6,12 +6,12 @@ use burn::backend::autodiff::{
     ops::{broadcast_shape, Backward, Ops, OpsKind},
     Autodiff,
 };
-use burn::backend::wgpu::compute::WgpuJitGpuBackend;
+use burn::backend::wgpu::compute::WgpuJitBackend;
 use burn::backend::wgpu::{FloatElement, GpuBackend, GraphicsApi, IntElement};
 use burn::tensor::Shape;
 
 impl<G: GraphicsApi, F: FloatElement, I: IntElement> AutodiffBackend
-    for Autodiff<GpuBackend<WgpuJitGpuBackend<G, F, I>>>
+    for Autodiff<GpuBackend<WgpuJitBackend<G, F, I>>>
 {
 }
 

--- a/examples/custom-wgpu-kernel/src/backward.rs
+++ b/examples/custom-wgpu-kernel/src/backward.rs
@@ -1,19 +1,17 @@
 use crate::FloatTensor;
 
 use super::{AutodiffBackend, Backend};
-use burn::backend::wgpu::{FloatElement, GpuBackend, GraphicsApi, IntElement};
-use burn::backend::{
-    autodiff::{
-        grads::Gradients,
-        ops::{broadcast_shape, Backward, Ops, OpsKind},
-        Autodiff,
-    },
-    wgpu::wgsl,
+use burn::backend::autodiff::{
+    grads::Gradients,
+    ops::{broadcast_shape, Backward, Ops, OpsKind},
+    Autodiff,
 };
+use burn::backend::wgpu::compute::WgpuJitGpuBackend;
+use burn::backend::wgpu::{FloatElement, GpuBackend, GraphicsApi, IntElement};
 use burn::tensor::Shape;
 
 impl<G: GraphicsApi, F: FloatElement, I: IntElement> AutodiffBackend
-    for Autodiff<GpuBackend<G, wgsl::Compiler<F, I>>>
+    for Autodiff<GpuBackend<WgpuJitGpuBackend<G, F, I>>>
 {
 }
 

--- a/examples/custom-wgpu-kernel/src/backward.rs
+++ b/examples/custom-wgpu-kernel/src/backward.rs
@@ -6,11 +6,11 @@ use burn::backend::autodiff::{
     ops::{broadcast_shape, Backward, Ops, OpsKind},
     Autodiff,
 };
-use burn::backend::wgpu::{FloatElement, GraphicsApi, IntElement, WgpuBackend};
+use burn::backend::wgpu::{FloatElement, GpuBackend, GraphicsApi, IntElement};
 use burn::tensor::Shape;
 
 impl<G: GraphicsApi, F: FloatElement, I: IntElement> AutodiffBackend
-    for Autodiff<WgpuBackend<G, F, I>>
+    for Autodiff<GpuBackend<G, F, I>>
 {
 }
 

--- a/examples/custom-wgpu-kernel/src/backward.rs
+++ b/examples/custom-wgpu-kernel/src/backward.rs
@@ -6,12 +6,12 @@ use burn::backend::autodiff::{
     ops::{broadcast_shape, Backward, Ops, OpsKind},
     Autodiff,
 };
-use burn::backend::wgpu::compute::WgpuJitBackend;
-use burn::backend::wgpu::{FloatElement, GpuBackend, GraphicsApi, IntElement};
+use burn::backend::wgpu::compute::WgpuRuntime;
+use burn::backend::wgpu::{FloatElement, JitBackend, GraphicsApi, IntElement};
 use burn::tensor::Shape;
 
 impl<G: GraphicsApi, F: FloatElement, I: IntElement> AutodiffBackend
-    for Autodiff<GpuBackend<WgpuJitBackend<G, F, I>>>
+    for Autodiff<JitBackend<WgpuRuntime<G, F, I>>>
 {
 }
 

--- a/examples/custom-wgpu-kernel/src/forward.rs
+++ b/examples/custom-wgpu-kernel/src/forward.rs
@@ -8,7 +8,7 @@ use burn::backend::wgpu::{
     },
     kernel_wgsl,
     tensor::WgpuTensor,
-    FloatElement, GraphicsApi, IntElement, WgpuBackend,
+    FloatElement, GpuBackend, GraphicsApi, IntElement,
 };
 use burn::tensor::Shape;
 use derive_new::new;
@@ -43,7 +43,7 @@ impl<E: FloatElement> DynamicKernelSource for FusedMatmulAddRelu<E> {
 }
 
 /// Implement our custom backend trait for the existing backend `WgpuBackend`.
-impl<G: GraphicsApi, F: FloatElement, I: IntElement> Backend for WgpuBackend<G, F, I> {
+impl<G: GraphicsApi, F: FloatElement, I: IntElement> Backend for GpuBackend<G, F, I> {
     fn fused_matmul_add_relu<const D: usize>(
         lhs: FloatTensor<Self, D>,
         rhs: FloatTensor<Self, D>,

--- a/examples/custom-wgpu-kernel/src/forward.rs
+++ b/examples/custom-wgpu-kernel/src/forward.rs
@@ -2,7 +2,7 @@ use crate::FloatTensor;
 
 use super::Backend;
 use burn::backend::wgpu::{
-    compute::{DynamicKernel, WgpuJitGpuBackend, WorkGroup},
+    compute::{DynamicKernel, WgpuJitBackend, WorkGroup},
     kernel::{
         build_info, into_contiguous, DynamicKernelSource, SourceTemplate, StaticKernelSource,
     },
@@ -44,7 +44,7 @@ impl<E: FloatElement> DynamicKernelSource for FusedMatmulAddRelu<E> {
 
 /// Implement our custom backend trait for the existing backend `WgpuBackend`.
 impl<G: GraphicsApi, F: FloatElement, I: IntElement> Backend
-    for GpuBackend<WgpuJitGpuBackend<G, F, I>>
+    for GpuBackend<WgpuJitBackend<G, F, I>>
 {
     fn fused_matmul_add_relu<const D: usize>(
         lhs: FloatTensor<Self, D>,

--- a/examples/custom-wgpu-kernel/src/forward.rs
+++ b/examples/custom-wgpu-kernel/src/forward.rs
@@ -2,13 +2,13 @@ use crate::FloatTensor;
 
 use super::Backend;
 use burn::backend::wgpu::{
-    compute::{DynamicKernel, WorkGroup},
+    compute::{DynamicKernel, WgpuJitGpuBackend, WorkGroup},
     kernel::{
         build_info, into_contiguous, DynamicKernelSource, SourceTemplate, StaticKernelSource,
     },
     kernel_wgsl,
     tensor::WgpuTensor,
-    wgsl, FloatElement, GpuBackend, GraphicsApi, IntElement,
+    FloatElement, GpuBackend, GraphicsApi, IntElement,
 };
 use burn::tensor::Shape;
 use derive_new::new;
@@ -44,13 +44,13 @@ impl<E: FloatElement> DynamicKernelSource for FusedMatmulAddRelu<E> {
 
 /// Implement our custom backend trait for the existing backend `WgpuBackend`.
 impl<G: GraphicsApi, F: FloatElement, I: IntElement> Backend
-    for GpuBackend<G, wgsl::Compiler<F, I>>
+    for GpuBackend<WgpuJitGpuBackend<G, F, I>>
 {
     fn fused_matmul_add_relu<const D: usize>(
         lhs: FloatTensor<Self, D>,
         rhs: FloatTensor<Self, D>,
         bias: FloatTensor<Self, D>,
-    ) -> WgpuTensor<F, D> {
+    ) -> FloatTensor<Self, D> {
         // Define workgroup size, hardcoded for simplicity.
         let workgroup_size_x = 16;
         let workgroup_size_y = 16;

--- a/examples/custom-wgpu-kernel/src/forward.rs
+++ b/examples/custom-wgpu-kernel/src/forward.rs
@@ -8,7 +8,7 @@ use burn::backend::wgpu::{
     },
     kernel_wgsl,
     tensor::JitTensor,
-    FloatElement, JitBackend, GraphicsApi, IntElement,
+    FloatElement, GraphicsApi, IntElement, JitBackend,
 };
 use burn::tensor::Shape;
 use derive_new::new;
@@ -43,9 +43,7 @@ impl<E: FloatElement> DynamicKernelSource for FusedMatmulAddRelu<E> {
 }
 
 /// Implement our custom backend trait for the existing backend `WgpuBackend`.
-impl<G: GraphicsApi, F: FloatElement, I: IntElement> Backend
-    for JitBackend<WgpuRuntime<G, F, I>>
-{
+impl<G: GraphicsApi, F: FloatElement, I: IntElement> Backend for JitBackend<WgpuRuntime<G, F, I>> {
     fn fused_matmul_add_relu<const D: usize>(
         lhs: FloatTensor<Self, D>,
         rhs: FloatTensor<Self, D>,

--- a/examples/custom-wgpu-kernel/src/forward.rs
+++ b/examples/custom-wgpu-kernel/src/forward.rs
@@ -8,7 +8,7 @@ use burn::backend::wgpu::{
     },
     kernel_wgsl,
     tensor::WgpuTensor,
-    FloatElement, GpuBackend, GraphicsApi, IntElement,
+    wgsl, FloatElement, GpuBackend, GraphicsApi, IntElement,
 };
 use burn::tensor::Shape;
 use derive_new::new;
@@ -43,7 +43,9 @@ impl<E: FloatElement> DynamicKernelSource for FusedMatmulAddRelu<E> {
 }
 
 /// Implement our custom backend trait for the existing backend `WgpuBackend`.
-impl<G: GraphicsApi, F: FloatElement, I: IntElement> Backend for GpuBackend<G, F, I> {
+impl<G: GraphicsApi, F: FloatElement, I: IntElement> Backend
+    for GpuBackend<G, wgsl::Compiler<F, I>>
+{
     fn fused_matmul_add_relu<const D: usize>(
         lhs: FloatTensor<Self, D>,
         rhs: FloatTensor<Self, D>,


### PR DESCRIPTION
Refactor the `burn-wgpu` crate by introducing a `Runtime` trait. The new trait is composed of all the necessary types to be implemented so that a backend can be made out of it. The `WgpuBackend` has been renamed to the `JitBackend` where the runtime can be passed as an argument as such `JitBackend<WgpuRuntime<GraphicsApi, Float, Int>>`.

For now, some operations don't use the `wgsl::Compiler` but are already defined as a String (with WGSL syntax), so the backend isn't ready to be split into a new crate `burn-jit`. Following PRs will extract the remaining operations into the `gpu::Operation` dialect, and the `wgsl` tokens are going to be defined in the `Display` implementation of the `wgsl` representation. After that, we could start to introduce new Runtimes with their own compute server and compiler.