### PR TITLE
Trying add a simple Image Accuracy metric for tests

### DIFF
--- a/burn-train/src/learner/regression.rs
+++ b/burn-train/src/learner/regression.rs
@@ -1,4 +1,4 @@
-use crate::metric::{Adaptor, LossInput};
+use crate::metric::{Adaptor, ImageAccuracyInput, LossInput};
 use burn_core::tensor::backend::Backend;
 use burn_core::tensor::Tensor;
 
@@ -13,6 +13,12 @@ pub struct RegressionOutput<B: Backend> {
 
     /// The targets.
     pub targets: Tensor<B, 2>,
+}
+
+impl<B: Backend> Adaptor<ImageAccuracyInput<B>> for RegressionOutput<B> {
+    fn adapt(&self) -> ImageAccuracyInput<B> {
+        ImageAccuracyInput::new(self.output.clone(), self.targets.clone())
+    }
 }
 
 impl<B: Backend> Adaptor<LossInput<B>> for RegressionOutput<B> {

--- a/burn-train/src/metric/acc.rs
+++ b/burn-train/src/metric/acc.rs
@@ -119,8 +119,7 @@ impl<B: Backend> Metric for ImageAccuracyMetric<B> {
         let outputs = input.outputs.clone().to_device(&input.outputs.device());
         let targets = input.targets.clone().to_device(&input.outputs.device());
 
-        let difference = outputs.sub(targets).abs(); 
-        
+        let difference = outputs.sub(targets).abs();
         // --- Matches For True ---
         let mask_correct = difference.clone().lower_equal_elem(self.threshold);
         let matches_correct = difference.clone().int().mask_fill(mask_correct, 1);
@@ -129,7 +128,8 @@ impl<B: Backend> Metric for ImageAccuracyMetric<B> {
         let matches_wrong = difference.int().mask_fill(mask_wrong, 0);
 
         let correct = matches_correct.add(matches_wrong);
-        let accuracy = correct.sum().into_scalar().elem::<f64>() / (num_pixels*batch_size ) as f64;
+
+        let accuracy = correct.sum().into_scalar().elem::<f64>() / (num_pixels * batch_size) as f64;
 
         self.state.update(
             100.0 * accuracy,
@@ -197,7 +197,7 @@ mod tests {
         let _entry = metric.update(&input, &MetricMetadata::fake());
         assert_eq!(50.0, metric.value());
     }
-    
+
     //? Need tests for ImageAccuracyMetric
     #[test]
     fn test_image_accuracy() {
@@ -209,9 +209,9 @@ mod tests {
                     [0.1, 0.2, 0.0], // 1 on 3 ( |outputs - targets| <= threshold )
                     [0.1, 0.3, 0.1], // 2 on 3
                     [0.5, 0.2, 0.0], // 1 on 3
-                    [0.0, 0.0, 0.0], // 2 on 3 >> 6 correct on 12 total 
+                    [0.0, 0.0, 0.0], // 2 on 3 >> 6 correct on 12 total
                 ],
-                &device
+                &device,
             ),
             Tensor::from_data(
                 [
@@ -219,7 +219,8 @@ mod tests {
                     [0.1, 0.0, 0.1],
                     [0.4, 0.2, 0.6],
                     [0.0, 0.1, 0.0],
-                ], &device
+                ],
+                &device,
             ),
         );
         let _entry = metric.update(&input, &MetricMetadata::fake());


### PR DESCRIPTION
## Pull Request Template

### Checklist
- [ ] Confirmed that `run-checks all` script has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Changes

I want to be able to somehow compare the accuracy of the generated graphics with the expected ones using a threshold, e.g. 0.001.
In the forward_classification function for the test network, I calculated the error in this simple way, i.e. all pixels from all channels in one dimension.
```rs
pub fn forward_classification(
         &self,
         batch: MNISTBatch<B>,
     ) -> RegressionOutput<B> {
         let output = self.forward(batch.images.clone());
        
         let [batch_img_out, channel_img_out, height_img_out, width_img_out] = output.dims();
         let logits = output.reshape([batch_img_out, channel_img_out * height_img_out * width_img_out]);
         let targets = batch.targets.reshape([batch_img_out, channel_img_out * height_img_out*width_img_out]);
         let loss = MSELoss::new().forward(logits.clone(), targets.clone(), burn::nn::loss::Reduction::Mean);
         // let loss = Tensor::log(Tensor::ones_like(&pre_loss).div(pre_loss.sqrt())).mul_scalar(20.0); // PSNR <-- impl
         RegressionOutput::new(loss, logits, targets)
     }
```

Despite passing the tests in burn-train, I tested it on the network with the output image and I know that the results are bad, i.e. ImageAccuracy is e.g. 72490, I don't know if the counting function itself is bad (it's definitely not the best) or if it wrong updates the state. Overall, at this stage I don't really know what to do next, so I need help here. I wrote as much as I could at this stage of understanding the burn library and RUST itself. I will be grateful for help and tips, maybe it will also be useful for someone else, that's why I decided to make a pull request.

### Testing

`cargo test` into burn-reain folder:
```sh
running 16 tests
test checkpoint::strategy::composed::tests::should_delete_when_both_deletes ... ok
test metric::acc::tests::test_accuracy_with_padding ... ok
test metric::acc::tests::test_accuracy_without_padding ... ok
test metric::acc::tests::test_image_accuracy ... ok
test checkpoint::strategy::lastn::tests::should_always_delete_lastn_epoch_if_higher_than_one ... ok
test checkpoint::strategy::metric::tests::always_keep_the_best_epoch ... ok
test renderer::tui::progress::tests::calculate_progress_for_eta ... ok
test renderer::tui::progress::tests::calculate_progress_for_eta_with_warmup ... ok
test renderer::tui::progress::tests::test_format_eta ... ok
test learner::early_stopping::tests::early_stop_when_stays_equal ... ok
test renderer::tui::recent_history::tests::test_push_update_bounds_max_y ... ok
test learner::early_stopping::tests::early_stop_when_no_improvement_since_two_epochs ... ok
test renderer::tui::recent_history::tests::test_push_update_bounds_min_y ... ok
test renderer::tui::full_history::tests::test_points ... ok
test learner::early_stopping::tests::never_early_stop_while_it_is_improving ... ok
test metric::store::aggregate::tests::should_find_epoch ... ok

test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests burn-train

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

```
