### PR TITLE
fix(book): add missing second parameter to CrosEntropyLoss constructor

### DIFF
--- a/burn-book/src/basic-workflow/training.md
+++ b/burn-book/src/basic-workflow/training.md
@@ -22,7 +22,7 @@ impl<B: Backend> Model<B> {
         targets: Tensor<B, 1, Int>,
     ) -> ClassificationOutput<B> {
         let output = self.forward(images);
-        let loss = CrossEntropyLoss::new(None, &output.device().forward(output.clone(), targets.clone());
+        let loss = CrossEntropyLoss::new(None, &output.device()).forward(output.clone(), targets.clone());
 
         ClassificationOutput::new(loss, output, targets)
     }

--- a/burn-book/src/basic-workflow/training.md
+++ b/burn-book/src/basic-workflow/training.md
@@ -22,7 +22,7 @@ impl<B: Backend> Model<B> {
         targets: Tensor<B, 1, Int>,
     ) -> ClassificationOutput<B> {
         let output = self.forward(images);
-        let loss = CrossEntropyLoss::new(None).forward(output.clone(), targets.clone());
+        let loss = CrossEntropyLoss::new(None, &output.device().forward(output.clone(), targets.clone());
 
         ClassificationOutput::new(loss, output, targets)
     }


### PR DESCRIPTION
CrossEntropyLoss::new() expects two parameters, the pad_index and the device

## Pull Request Template

### Checklist

- [ ] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

None

### Changes

I think the code example in the book is a bit outdated? 
`CrossEntropyLoss::new()` is expecting two parameters, the `pad_index` and `device` 
