### PR TITLE
Fix LogEventStore end epoch log

### DIFF
--- a/burn-train/src/metric/store/log.rs
+++ b/burn-train/src/metric/store/log.rs
@@ -44,7 +44,7 @@ impl EventStore for LogEventStore {
                 Split::Valid => self
                     .loggers_valid
                     .iter_mut()
-                    .for_each(|logger| logger.end_epoch(epoch + 1)),
+                    .for_each(|logger| logger.end_epoch(epoch)),
             },
         }
     }


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.

### Issue

Noticed that the reported validation epoch was off by 1 in the logs. For example, if you run the mnist example without early stopping to let it run for the full 10 epochs, you will see in the artifact dir:

```sh
$ ls train/
epoch-1  epoch-10  epoch-2  epoch-3  epoch-4  epoch-5  epoch-6  epoch-7  epoch-8  epoch-9

$ ls valid/
epoch-1  epoch-10  epoch-11  epoch-3  epoch-4  epoch-5  epoch-6  epoch-7  epoch-8  epoch-9
```

Notice how there is no `epoch-2` in `valid/` but the epochs go up to 11.

### Changes

Removed the `epoch + 1` in `logger.end_epoch` call for validation.

Not sure if this was incremented for historical reasons that are no longer relevant, but with this easy fix everything seems to be in order when I check the log folders.

### Testing

Ran the mnist example again after and the epochs match for train and valid:

```sh
$ ls train/
epoch-1  epoch-10  epoch-2  epoch-3  epoch-4  epoch-5  epoch-6  epoch-7  epoch-8  epoch-9

$ ls valid/
epoch-1  epoch-10  epoch-2  epoch-3  epoch-4  epoch-5  epoch-6  epoch-7  epoch-8  epoch-9
```
