### PR TITLE
Add sub-crates as members of workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ resolver = "2"
 members = [
     "backend-comparison",
     "crates/*",
+    "crates/burn-import/pytorch-tests",
+    "crates/burn-import/onnx-tests",
     "examples/*",
     "examples/pytorch-import/model",
     "xtask",


### PR DESCRIPTION
Sub-crates need to be added separately under members, otherwise they're skip in the build/run-checks. 

## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

Added burn-import sub-crates.

### Testing

run-checks all
