### PR TITLE
Add `not_equal` and `not_equal_elem` tensor ops

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -144,6 +144,7 @@ Those operations are available for all tensor kinds: `Int`, `Float`, and `Bool`.
 | `tensor.to_device(device)`            | `tensor.to(device)`                  |
 | `tensor.repeat(2, 4)`                 | `tensor.repeat([1, 1, 4])`           |
 | `tensor.equal(other)`                 | `x == y`                             |
+| `tensor.not_equal(other)`             | `x != y`                             |
 | `tensor.any()`                        | `tensor.any()`                       |
 | `tensor.any_dim(dim)`                 | `tensor.any(dim)`                    |
 | `tensor.all()`                        | `tensor.all()`                       |
@@ -183,6 +184,7 @@ Those operations are available for numeric tensor kinds: `Float` and `Int`.
 | `tensor.mean_dim(dim)`                                           | `tensor.mean(dim)`                             |
 | `tensor.sum_dim(dim)`                                            | `tensor.sum(dim)`                              |
 | `tensor.equal_elem(scalar)`                                      | `tensor.eq(scalar)`                            |
+| `tensor.not_equal_elem(scalar)`                                  | `tensor.ne(scalar)`                            |
 | `tensor.greater(other)`                                          | `tensor.gt(other)`                             |
 | `tensor.greater_elem(scalar)`                                    | `tensor.gt(scalar)`                            |
 | `tensor.greater_equal(other)`                                    | `tensor.ge(other)`                             |

--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -182,7 +182,7 @@ Those operations are available for numeric tensor kinds: `Float` and `Int`.
 | `tensor.sum()`                                                   | `tensor.sum()`                                 |
 | `tensor.mean_dim(dim)`                                           | `tensor.mean(dim)`                             |
 | `tensor.sum_dim(dim)`                                            | `tensor.sum(dim)`                              |
-| `tensor.equal_elem(other)`                                       | `tensor.eq(other)`                             |
+| `tensor.equal_elem(scalar)`                                      | `tensor.eq(scalar)`                            |
 | `tensor.greater(other)`                                          | `tensor.gt(other)`                             |
 | `tensor.greater_elem(scalar)`                                    | `tensor.gt(scalar)`                            |
 | `tensor.greater_equal(other)`                                    | `tensor.ge(other)`                             |

--- a/crates/burn-tch/README.md
+++ b/crates/burn-tch/README.md
@@ -251,7 +251,7 @@ export DYLD_LIBRARY_PATH=/path/to/pytorch/lib:$DYLD_LIBRARY_PATH
 ## Example Usage
 
 For a simple example, check out any of the test programs in [`src/bin/`](./src/bin/). Each program
-sets the device to use and and performs a simple elementwise addition.
+sets the device to use and and performs a simple element-wise addition.
 
 For a more complete example using the `tch` backend, take a loot at the
 [Burn mnist example](https://github.com/tracel-ai/burn/tree/main/examples/mnist).

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -511,7 +511,7 @@ where
         Self::new(K::repeat(self.primitive, dim, times))
     }
 
-    /// Applies element wise equal comparison and returns a boolean tensor.
+    /// Applies element-wise equal comparison and returns a boolean tensor.
     ///
     /// # Panics
     ///
@@ -519,6 +519,16 @@ where
     pub fn equal(self, other: Self) -> Tensor<B, D, Bool> {
         check!(TensorCheck::binary_ops_ew("Equal", &self, &other));
         K::equal(self.primitive, other.primitive)
+    }
+
+    /// Applies element-wise non-equality comparison and returns a boolean tensor.
+    ///
+    /// # Panics
+    ///
+    /// If the two tensors don't have the same shape.
+    pub fn not_equal(self, other: Self) -> Tensor<B, D, Bool> {
+        check!(TensorCheck::binary_ops_ew("NotEqual", &self, &other));
+        K::not_equal(self.primitive, other.primitive)
     }
 
     /// Concatenates all tensors into a new one along the given dimension.
@@ -1262,6 +1272,30 @@ pub trait BasicOps<B: Backend>: TensorKind<B> {
         rhs: Self::Primitive<D>,
     ) -> Tensor<B, D, Bool>;
 
+    /// Applies element-wise non-equality comparison between the given tensors.
+    ///
+    /// # Arguments
+    ///
+    /// * `lhs` - The left hand side tensor.
+    /// * `rhs` - The right hand side tensor.
+    ///
+    /// # Returns
+    ///
+    /// The tensor of booleans indicating whether the corresponding elements are equal.
+    ///
+    /// # Remarks
+    ///
+    /// This is a low-level function used internally by the library to call different backend functions
+    /// with static dispatch. It is not designed for direct usage by users, and not recommended to import
+    /// or use this function directly.
+    ///
+    /// For non-equality comparison of tensors, users should prefer the [Tensor::not_equal](Tensor::not_equal)
+    /// function, which is more high-level and designed for public use.
+    fn not_equal<const D: usize>(
+        lhs: Self::Primitive<D>,
+        rhs: Self::Primitive<D>,
+    ) -> Tensor<B, D, Bool>;
+
     /// Returns the name of the element type.
     fn elem_type_name() -> &'static str {
         core::any::type_name::<Self::Elem>()
@@ -1431,6 +1465,13 @@ impl<B: Backend> BasicOps<B> for Float {
         Tensor::new(B::float_equal(lhs, rhs))
     }
 
+    fn not_equal<const D: usize>(
+        lhs: Self::Primitive<D>,
+        rhs: Self::Primitive<D>,
+    ) -> Tensor<B, D, Bool> {
+        Tensor::new(B::float_not_equal(lhs, rhs))
+    }
+
     fn any<const D: usize>(tensor: Self::Primitive<D>) -> Tensor<B, 1, Bool> {
         Tensor::new(B::float_any(tensor))
     }
@@ -1528,6 +1569,13 @@ impl<B: Backend> BasicOps<B> for Int {
         rhs: Self::Primitive<D>,
     ) -> Tensor<B, D, Bool> {
         Tensor::new(B::int_equal(lhs, rhs))
+    }
+
+    fn not_equal<const D: usize>(
+        lhs: Self::Primitive<D>,
+        rhs: Self::Primitive<D>,
+    ) -> Tensor<B, D, Bool> {
+        Tensor::new(B::int_not_equal(lhs, rhs))
     }
 
     fn cat<const D: usize>(vectors: Vec<Self::Primitive<D>>, dim: usize) -> Self::Primitive<D> {
@@ -1631,6 +1679,13 @@ impl<B: Backend> BasicOps<B> for Bool {
         rhs: Self::Primitive<D>,
     ) -> Tensor<B, D, Bool> {
         Tensor::new(B::bool_equal(lhs, rhs))
+    }
+
+    fn not_equal<const D: usize>(
+        lhs: Self::Primitive<D>,
+        rhs: Self::Primitive<D>,
+    ) -> Tensor<B, D, Bool> {
+        Tensor::new(B::bool_not_equal(lhs, rhs))
     }
 
     fn cat<const D: usize>(vectors: Vec<Self::Primitive<D>>, dim: usize) -> Self::Primitive<D> {

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -151,6 +151,11 @@ where
         K::equal_elem::<D>(self.primitive, other.elem())
     }
 
+    /// Applies element wise non-equality comparison and returns a boolean tensor.
+    pub fn not_equal_elem<E: Element>(self, other: E) -> Tensor<B, D, Bool> {
+        K::not_equal_elem::<D>(self.primitive, other.elem())
+    }
+
     /// Applies element wise greater comparison and returns a boolean tensor.
     ///
     /// # Panics
@@ -966,8 +971,34 @@ where
     /// with static dispatch. It is not designed for direct usage by users, and not recommended to import
     /// or use this function directly.
     ///
-    /// For element-wise equality between two tensors, users should prefer the [Tensor::equal_elem](Tensor::equal_elem) function,
+    /// For element-wise equality between two tensors, users should prefer the [Tensor::equal_elem](Tensor::equal_elem)
+    /// function, which is more high-level and designed for public use.
     fn equal_elem<const D: usize>(lhs: Self::Primitive<D>, rhs: Self::Elem) -> Tensor<B, D, Bool>;
+
+    /// Element-wise non-equality between two tensors.
+    ///
+    /// # Arguments
+    ///
+    /// * `lhs` - The left hand side tensor.
+    /// * `rhs` - The right hand side tensor.
+    ///
+    /// # Returns
+    ///
+    /// A boolean tensor with the same shape as the input tensors, where each element is true if the
+    /// corresponding elements of the input tensors are equal, and false otherwise.
+    ///
+    /// # Remarks
+    ///
+    /// This is a low-level function used internally by the library to call different backend functions
+    /// with static dispatch. It is not designed for direct usage by users, and not recommended to import
+    /// or use this function directly.
+    ///
+    /// For element-wise non-equality between two tensors, users should prefer the [Tensor::not_equal_elem](Tensor::not_equal_elem)
+    /// function, which is more high-level and designed for public use.
+    fn not_equal_elem<const D: usize>(
+        lhs: Self::Primitive<D>,
+        rhs: Self::Elem,
+    ) -> Tensor<B, D, Bool>;
 
     /// Element-wise greater than comparison between two tensors.
     ///
@@ -1728,6 +1759,12 @@ impl<B: Backend> Numeric<B> for Int {
     fn equal_elem<const D: usize>(lhs: Self::Primitive<D>, rhs: Self::Elem) -> Tensor<B, D, Bool> {
         Tensor::new(B::int_equal_elem(lhs, rhs))
     }
+    fn not_equal_elem<const D: usize>(
+        lhs: Self::Primitive<D>,
+        rhs: Self::Elem,
+    ) -> Tensor<B, D, Bool> {
+        Tensor::new(B::int_not_equal_elem(lhs, rhs))
+    }
     fn greater<const D: usize>(
         lhs: Self::Primitive<D>,
         rhs: Self::Primitive<D>,
@@ -2009,6 +2046,12 @@ impl<B: Backend> Numeric<B> for Float {
 
     fn equal_elem<const D: usize>(lhs: Self::Primitive<D>, rhs: Self::Elem) -> Tensor<B, D, Bool> {
         Tensor::new(B::float_equal_elem(lhs, rhs))
+    }
+    fn not_equal_elem<const D: usize>(
+        lhs: Self::Primitive<D>,
+        rhs: Self::Elem,
+    ) -> Tensor<B, D, Bool> {
+        Tensor::new(B::float_not_equal_elem(lhs, rhs))
     }
     fn greater<const D: usize>(
         lhs: Self::Primitive<D>,

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -1641,7 +1641,7 @@ where
     /// which is more high-level and designed for public use.
     fn abs<const D: usize>(tensor: Self::Primitive<D>) -> Self::Primitive<D>;
 
-    /// elementwise power of a tensor to a float tensor
+    /// Element-wise power of a tensor to a float tensor
     ///
     /// # Arguments
     /// * `tensor` - The tensor to apply power to.
@@ -1649,7 +1649,7 @@ where
     fn powf<const D: usize>(lhs: Self::Primitive<D>, rhs: Self::Primitive<D>)
         -> Self::Primitive<D>;
 
-    /// elementwise power of a tensor
+    /// Element-wise power of a tensor
     ///
     /// # Arguments
     /// * `tensor` - The tensor to apply power to.
@@ -1657,7 +1657,7 @@ where
     fn powi<const D: usize>(lhs: Self::Primitive<D>, rhs: Self::Primitive<D>)
         -> Self::Primitive<D>;
 
-    /// elementwise power of a tensor to a scalar float
+    /// Element-wise power of a tensor to a scalar float
     ///
     /// # Arguments
     /// * `tensor` - The tensor to apply power to.
@@ -1667,7 +1667,7 @@ where
         rhs: E,
     ) -> Self::Primitive<D>;
 
-    /// elementwise power of a tensor to a scalar int
+    /// Element-wise power of a tensor to a scalar int
     ///
     /// # Arguments
     /// * `tensor` - The tensor to apply power to.

--- a/crates/burn-tensor/src/tensor/ops/bool_tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/bool_tensor.rs
@@ -218,6 +218,24 @@ pub trait BoolTensorOps<B: Backend> {
     fn bool_equal<const D: usize>(lhs: BoolTensor<B, D>, rhs: BoolTensor<B, D>)
         -> BoolTensor<B, D>;
 
+    /// Elementwise non-equality comparison.
+    ///
+    /// # Arguments
+    ///
+    /// * `lhs` - The left hand side tensor.
+    /// * `rhs` - The right hand side tensor.
+    ///
+    /// # Returns
+    ///
+    /// The tensor with the result of the comparison.
+    fn bool_not_equal<const D: usize>(
+        lhs: BoolTensor<B, D>,
+        rhs: BoolTensor<B, D>,
+    ) -> BoolTensor<B, D> {
+        let equal_tensor = B::bool_equal(lhs, rhs);
+        B::bool_not(equal_tensor)
+    }
+
     /// Inverses boolean values.
     ///
     /// # Arguments

--- a/crates/burn-tensor/src/tensor/ops/bool_tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/bool_tensor.rs
@@ -218,7 +218,7 @@ pub trait BoolTensorOps<B: Backend> {
     fn bool_equal<const D: usize>(lhs: BoolTensor<B, D>, rhs: BoolTensor<B, D>)
         -> BoolTensor<B, D>;
 
-    /// Elementwise non-equality comparison.
+    /// Element-wise non-equality comparison.
     ///
     /// # Arguments
     ///

--- a/crates/burn-tensor/src/tensor/ops/int_tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/int_tensor.rs
@@ -301,7 +301,7 @@ pub trait IntTensorOps<B: Backend> {
     /// The concatenated tensor.
     fn int_cat<const D: usize>(tensors: Vec<IntTensor<B, D>>, dim: usize) -> IntTensor<B, D>;
 
-    /// Elementwise equality comparison.
+    /// Element-wise equality comparison.
     ///
     /// # Arguments
     ///
@@ -313,7 +313,7 @@ pub trait IntTensorOps<B: Backend> {
     /// The boolean tensor with the result of the comparison.
     fn int_equal<const D: usize>(lhs: IntTensor<B, D>, rhs: IntTensor<B, D>) -> BoolTensor<B, D>;
 
-    /// Elementwise non-equality comparison.
+    /// Element-wise non-equality comparison.
     ///
     /// # Arguments
     ///
@@ -331,7 +331,7 @@ pub trait IntTensorOps<B: Backend> {
         B::bool_not(equal_tensor)
     }
 
-    /// Elementwise equality comparison with a scalar.
+    /// Element-wise equality comparison with a scalar.
     ///
     /// # Arguments
     ///
@@ -343,7 +343,7 @@ pub trait IntTensorOps<B: Backend> {
     /// The boolean tensor with the result of the comparison.
     fn int_equal_elem<const D: usize>(lhs: IntTensor<B, D>, rhs: IntElem<B>) -> BoolTensor<B, D>;
 
-    /// Elementwise non-equality comparison with a scalar.
+    /// Element-wise non-equality comparison with a scalar.
     ///
     /// # Arguments
     ///
@@ -361,7 +361,7 @@ pub trait IntTensorOps<B: Backend> {
         B::bool_not(equal_tensor)
     }
 
-    /// Elementwise greater than comparison.
+    /// Element-wise greater than comparison.
     ///
     /// # Arguments
     ///
@@ -373,7 +373,7 @@ pub trait IntTensorOps<B: Backend> {
     /// The boolean tensor with the result of the comparison.
     fn int_greater<const D: usize>(lhs: IntTensor<B, D>, rhs: IntTensor<B, D>) -> BoolTensor<B, D>;
 
-    /// Elementwise greater than comparison with a scalar.
+    /// Element-wise greater than comparison with a scalar.
     ///
     /// # Arguments
     ///
@@ -385,7 +385,7 @@ pub trait IntTensorOps<B: Backend> {
     /// The boolean tensor with the result of the comparison.
     fn int_greater_elem<const D: usize>(lhs: IntTensor<B, D>, rhs: IntElem<B>) -> BoolTensor<B, D>;
 
-    /// Elementwise greater than or equal comparison.
+    /// Element-wise greater than or equal comparison.
     ///
     /// # Arguments
     ///
@@ -400,7 +400,7 @@ pub trait IntTensorOps<B: Backend> {
         rhs: IntTensor<B, D>,
     ) -> BoolTensor<B, D>;
 
-    /// Elementwise greater than or equal comparison with a scalar.
+    /// Element-wise greater than or equal comparison with a scalar.
     ///
     /// # Arguments
     ///
@@ -415,7 +415,7 @@ pub trait IntTensorOps<B: Backend> {
         rhs: IntElem<B>,
     ) -> BoolTensor<B, D>;
 
-    /// Elementwise less than comparison.
+    /// Element-wise less than comparison.
     ///
     /// # Arguments
     ///
@@ -427,7 +427,7 @@ pub trait IntTensorOps<B: Backend> {
     /// The boolean tensor with the result of the comparison.
     fn int_lower<const D: usize>(lhs: IntTensor<B, D>, rhs: IntTensor<B, D>) -> BoolTensor<B, D>;
 
-    /// Elementwise less than comparison with a scalar.
+    /// Element-wise less than comparison with a scalar.
     ///
     /// # Arguments
     ///
@@ -439,7 +439,7 @@ pub trait IntTensorOps<B: Backend> {
     /// The boolean tensor with the result of the comparison.
     fn int_lower_elem<const D: usize>(lhs: IntTensor<B, D>, rhs: IntElem<B>) -> BoolTensor<B, D>;
 
-    /// Elementwise less than or equal comparison.
+    /// Element-wise less than or equal comparison.
     ///
     /// # Arguments
     ///
@@ -454,7 +454,7 @@ pub trait IntTensorOps<B: Backend> {
         rhs: IntTensor<B, D>,
     ) -> BoolTensor<B, D>;
 
-    /// Elementwise less than or equal comparison with a scalar.
+    /// Element-wise less than or equal comparison with a scalar.
     ///
     /// # Arguments
     ///
@@ -471,7 +471,7 @@ pub trait IntTensorOps<B: Backend> {
 
     // ====  NUMERIC ==== //
 
-    /// Elementwise addition.
+    /// Element-wise addition.
     ///
     /// # Arguments
     ///
@@ -483,7 +483,7 @@ pub trait IntTensorOps<B: Backend> {
     /// The result of the addition.
     fn int_add<const D: usize>(lhs: IntTensor<B, D>, rhs: IntTensor<B, D>) -> IntTensor<B, D>;
 
-    /// Elementwise addition with a scalar.
+    /// Element-wise addition with a scalar.
     ///
     /// # Arguments
     ///
@@ -495,7 +495,7 @@ pub trait IntTensorOps<B: Backend> {
     /// The result of the addition.
     fn int_add_scalar<const D: usize>(lhs: IntTensor<B, D>, rhs: IntElem<B>) -> IntTensor<B, D>;
 
-    /// Elementwise power with a IntTensor.
+    /// Element-wise power with a IntTensor.
     ///
     /// # Arguments
     ///
@@ -512,7 +512,7 @@ pub trait IntTensorOps<B: Backend> {
         ))
     }
 
-    /// Elementwise power with a floatTensor.
+    /// Element-wise power with a floatTensor.
     ///
     /// # Arguments
     ///
@@ -526,7 +526,7 @@ pub trait IntTensorOps<B: Backend> {
         B::float_into_int(B::float_powf(B::int_into_float(lhs), rhs))
     }
 
-    /// Elementwise power with a scalar.
+    /// Element-wise power with a scalar.
     ///
     /// # Arguments
     ///
@@ -543,7 +543,7 @@ pub trait IntTensorOps<B: Backend> {
         ))
     }
 
-    /// Elementwise power with a floatTensor.
+    /// Element-wise power with a floatTensor.
     ///
     /// # Arguments
     ///
@@ -606,7 +606,7 @@ pub trait IntTensorOps<B: Backend> {
         Self::int_clamp_min(Self::int_clamp_max(tensor, max), min)
     }
 
-    /// Elementwise subtraction.
+    /// Element-wise subtraction.
     ///
     /// # Arguments
     ///
@@ -618,7 +618,7 @@ pub trait IntTensorOps<B: Backend> {
     /// The result of the subtraction.
     fn int_sub<const D: usize>(lhs: IntTensor<B, D>, rhs: IntTensor<B, D>) -> IntTensor<B, D>;
 
-    /// Elementwise subtraction with a scalar.
+    /// Element-wise subtraction with a scalar.
     ///
     /// # Arguments
     ///
@@ -630,7 +630,7 @@ pub trait IntTensorOps<B: Backend> {
     /// The result of the subtraction.
     fn int_sub_scalar<const D: usize>(lhs: IntTensor<B, D>, rhs: IntElem<B>) -> IntTensor<B, D>;
 
-    /// Elementwise multiplication.
+    /// Element-wise multiplication.
     ///
     /// # Arguments
     ///
@@ -642,7 +642,7 @@ pub trait IntTensorOps<B: Backend> {
     /// The result of the multiplication.
     fn int_mul<const D: usize>(lhs: IntTensor<B, D>, rhs: IntTensor<B, D>) -> IntTensor<B, D>;
 
-    /// Elementwise multiplication with a scalar.
+    /// Element-wise multiplication with a scalar.
     ///
     /// # Arguments
     ///
@@ -654,7 +654,7 @@ pub trait IntTensorOps<B: Backend> {
     /// The result of the multiplication.
     fn int_mul_scalar<const D: usize>(lhs: IntTensor<B, D>, rhs: IntElem<B>) -> IntTensor<B, D>;
 
-    /// Elementwise division.
+    /// Element-wise division.
     ///
     /// # Arguments
     ///
@@ -666,7 +666,7 @@ pub trait IntTensorOps<B: Backend> {
     /// The result of the division.
     fn int_div<const D: usize>(lhs: IntTensor<B, D>, rhs: IntTensor<B, D>) -> IntTensor<B, D>;
 
-    /// Elementwise division with a scalar.
+    /// Element-wise division with a scalar.
     ///
     /// # Arguments
     ///
@@ -678,7 +678,7 @@ pub trait IntTensorOps<B: Backend> {
     /// The result of the division.
     fn int_div_scalar<const D: usize>(lhs: IntTensor<B, D>, rhs: IntElem<B>) -> IntTensor<B, D>;
 
-    /// Elementwise negation.
+    /// Element-wise negation.
     ///
     /// # Arguments
     ///

--- a/crates/burn-tensor/src/tensor/ops/int_tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/int_tensor.rs
@@ -313,6 +313,24 @@ pub trait IntTensorOps<B: Backend> {
     /// The boolean tensor with the result of the comparison.
     fn int_equal<const D: usize>(lhs: IntTensor<B, D>, rhs: IntTensor<B, D>) -> BoolTensor<B, D>;
 
+    /// Elementwise non-equality comparison.
+    ///
+    /// # Arguments
+    ///
+    /// * `lhs` - The left hand side tensor.
+    /// * `rhs` - The right hand side tensor.
+    ///
+    /// # Returns
+    ///
+    /// The boolean tensor with the result of the comparison.
+    fn int_not_equal<const D: usize>(
+        lhs: IntTensor<B, D>,
+        rhs: IntTensor<B, D>,
+    ) -> BoolTensor<B, D> {
+        let equal_tensor = B::int_equal(lhs, rhs);
+        B::bool_not(equal_tensor)
+    }
+
     /// Elementwise equality comparison with a scalar.
     ///
     /// # Arguments
@@ -324,6 +342,24 @@ pub trait IntTensorOps<B: Backend> {
     ///
     /// The boolean tensor with the result of the comparison.
     fn int_equal_elem<const D: usize>(lhs: IntTensor<B, D>, rhs: IntElem<B>) -> BoolTensor<B, D>;
+
+    /// Elementwise non-equality comparison with a scalar.
+    ///
+    /// # Arguments
+    ///
+    /// * `lhs` - The left hand side tensor.
+    /// * `rhs` - The right hand side scalar.
+    ///
+    /// # Returns
+    ///
+    /// The boolean tensor with the result of the comparison.
+    fn int_not_equal_elem<const D: usize>(
+        lhs: IntTensor<B, D>,
+        rhs: IntElem<B>,
+    ) -> BoolTensor<B, D> {
+        let equal_tensor = B::int_equal_elem(lhs, rhs);
+        B::bool_not(equal_tensor)
+    }
 
     /// Elementwise greater than comparison.
     ///

--- a/crates/burn-tensor/src/tensor/ops/tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/tensor.rs
@@ -602,6 +602,24 @@ pub trait FloatTensorOps<B: Backend> {
         rhs: FloatTensor<B, D>,
     ) -> BoolTensor<B, D>;
 
+    /// Elementwise non-equality comparison.
+    ///
+    /// # Arguments
+    ///
+    /// * `lhs` - The left hand side tensor.
+    /// * `rhs` - The right hand side tensor.
+    ///
+    /// # Returns
+    ///
+    /// A boolean tensor with the result of the comparison.
+    fn float_not_equal<const D: usize>(
+        lhs: FloatTensor<B, D>,
+        rhs: FloatTensor<B, D>,
+    ) -> BoolTensor<B, D> {
+        let equal_tensor = B::float_equal(lhs, rhs);
+        B::bool_not(equal_tensor)
+    }
+
     /// Equal comparison of a tensor and a scalar.
     ///
     /// # Arguments
@@ -616,6 +634,24 @@ pub trait FloatTensorOps<B: Backend> {
         lhs: FloatTensor<B, D>,
         rhs: FloatElem<B>,
     ) -> BoolTensor<B, D>;
+
+    /// Elementwise non-equality comparison with a scalar.
+    ///
+    /// # Arguments
+    ///
+    /// * `lhs` - The left hand side tensor.
+    /// * `rhs` - The right hand side scalar.
+    ///
+    /// # Returns
+    ///
+    /// A boolean tensor with the result of the comparison.
+    fn float_not_equal_elem<const D: usize>(
+        lhs: FloatTensor<B, D>,
+        rhs: FloatElem<B>,
+    ) -> BoolTensor<B, D> {
+        let equal_tensor = B::float_equal_elem(lhs, rhs);
+        B::bool_not(equal_tensor)
+    }
 
     /// Greater than comparison of two tensors.
     ///

--- a/crates/burn-tensor/src/tensor/ops/tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/tensor.rs
@@ -400,7 +400,7 @@ pub trait FloatTensorOps<B: Backend> {
         Self::float_mul_scalar(tensor, (-1.0_f32).elem::<FloatElem<B>>())
     }
 
-    /// Calculates the reciprocals elementwise
+    /// Calculates the reciprocals element-wise
     fn float_recip<const D: usize>(tensor: FloatTensor<B, D>) -> FloatTensor<B, D>;
 
     /// Transposes a tensor.
@@ -602,7 +602,7 @@ pub trait FloatTensorOps<B: Backend> {
         rhs: FloatTensor<B, D>,
     ) -> BoolTensor<B, D>;
 
-    /// Elementwise non-equality comparison.
+    /// Element-wise non-equality comparison.
     ///
     /// # Arguments
     ///
@@ -635,7 +635,7 @@ pub trait FloatTensorOps<B: Backend> {
         rhs: FloatElem<B>,
     ) -> BoolTensor<B, D>;
 
-    /// Elementwise non-equality comparison with a scalar.
+    /// Element-wise non-equality comparison with a scalar.
     ///
     /// # Arguments
     ///
@@ -902,7 +902,7 @@ pub trait FloatTensorOps<B: Backend> {
     /// A tensor with the same shape as `tensor` with logarithm values of (1 + Xi).
     fn float_log1p<const D: usize>(tensor: FloatTensor<B, D>) -> FloatTensor<B, D>;
 
-    /// Elementwise power with a FloatTensor.
+    /// Element-wise power with a FloatTensor.
     ///
     /// # Arguments
     ///
@@ -917,7 +917,7 @@ pub trait FloatTensorOps<B: Backend> {
         rhs: FloatTensor<B, D>,
     ) -> FloatTensor<B, D>;
 
-    /// Elementwise power with an IntTensor.
+    /// Element-wise power with an IntTensor.
     ///
     /// # Arguments
     ///

--- a/crates/burn-tensor/src/tests/clone_invariance.rs
+++ b/crates/burn-tensor/src/tests/clone_invariance.rs
@@ -293,6 +293,10 @@ mod tests {
             ops_float: |tensor: TestTensor<2>| tensor.equal_elem(0.5)
         );
         clone_invariance_test!(
+            unary: NotEqualElem,
+            ops_float: |tensor: TestTensor<2>| tensor.not_equal_elem(0.5)
+        );
+        clone_invariance_test!(
             unary: GreaterElem,
             ops_float: |tensor: TestTensor<2>| tensor.greater_elem(0.5)
         );
@@ -573,6 +577,10 @@ mod tests {
             ops_int: |tensor: TestTensorInt<2>| tensor.equal_elem(25)
         );
         clone_invariance_test!(
+            unary: NotEqualElem,
+            ops_int: |tensor: TestTensorInt<2>| tensor.not_equal_elem(25)
+        );
+        clone_invariance_test!(
             unary: GreaterElem,
             ops_int: |tensor: TestTensorInt<2>| tensor.greater_elem(25)
         );
@@ -677,6 +685,10 @@ mod tests {
         clone_invariance_test!(
             binary: Equal,
             ops_int: |lhs: TestTensorInt<2>, rhs: TestTensorInt<2>| lhs.equal(rhs)
+        );
+        clone_invariance_test!(
+            binary: NotEqual,
+            ops_int: |lhs: TestTensorInt<2>, rhs: TestTensorInt<2>| lhs.not_equal(rhs)
         );
         clone_invariance_test!(
             binary: Greater,

--- a/crates/burn-tensor/src/tests/ops/map_comparison.rs
+++ b/crates/burn-tensor/src/tests/ops/map_comparison.rs
@@ -17,6 +17,15 @@ mod tests {
     fn test_int_equal() {
         equal::<Int, IntElem>()
     }
+    #[test]
+    fn test_not_equal() {
+        not_equal::<Float, FloatElem>()
+    }
+
+    #[test]
+    fn test_int_not_equal() {
+        not_equal::<Int, IntElem>()
+    }
 
     #[test]
     fn test_equal_elem() {
@@ -26,6 +35,16 @@ mod tests {
     #[test]
     fn test_int_equal_elem() {
         equal_elem::<Int, IntElem>()
+    }
+
+    #[test]
+    fn test_not_equal_elem() {
+        not_equal_elem::<Float, FloatElem>()
+    }
+
+    #[test]
+    fn test_int_not_equal_elem() {
+        not_equal_elem::<Int, IntElem>()
     }
 
     #[test]
@@ -127,6 +146,25 @@ mod tests {
         assert_eq!(data_expected, data_actual_inplace.into_data());
     }
 
+    fn not_equal<K, E>()
+    where
+        K: Numeric<TestBackend, Elem = E> + BasicOps<TestBackend, Elem = E>,
+        E: Element,
+    {
+        let data_1 = Data::<f32, 2>::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]).convert();
+        let data_2 = Data::<f32, 2>::from([[1.0, 1.0, 1.0], [4.0, 3.0, 5.0]]).convert();
+        let device = Default::default();
+        let tensor_1 = Tensor::<TestBackend, 2, K>::from_data(data_1, &device);
+        let tensor_2 = Tensor::<TestBackend, 2, K>::from_data(data_2, &device);
+
+        let data_actual_cloned = tensor_1.clone().not_equal(tensor_2.clone());
+        let data_actual_inplace = tensor_1.not_equal(tensor_2);
+
+        let data_expected = Data::from([[true, false, true], [true, true, false]]);
+        assert_eq!(data_expected, data_actual_cloned.into_data());
+        assert_eq!(data_expected, data_actual_inplace.into_data());
+    }
+
     fn equal_elem<K, E>()
     where
         K: Numeric<TestBackend, Elem = E> + BasicOps<TestBackend, Elem = E>,
@@ -139,6 +177,22 @@ mod tests {
         let data_actual_inplace = tensor_1.equal_elem(2);
 
         let data_expected = Data::from([[false, false, true], [false, true, false]]);
+        assert_eq!(data_expected, data_actual_cloned.into_data());
+        assert_eq!(data_expected, data_actual_inplace.into_data());
+    }
+
+    fn not_equal_elem<K, E>()
+    where
+        K: Numeric<TestBackend, Elem = E> + BasicOps<TestBackend, Elem = E>,
+        E: Element,
+    {
+        let data_1 = Data::<f32, 2>::from([[0.0, 1.0, 2.0], [3.0, 2.0, 5.0]]).convert();
+        let tensor_1 = Tensor::<TestBackend, 2, K>::from_data(data_1, &Default::default());
+
+        let data_actual_cloned = tensor_1.clone().not_equal_elem(2);
+        let data_actual_inplace = tensor_1.not_equal_elem(2);
+
+        let data_expected = Data::from([[true, true, false], [true, false, true]]);
         assert_eq!(data_expected, data_actual_cloned.into_data());
         assert_eq!(data_expected, data_actual_inplace.into_data());
     }

--- a/crates/burn-tensor/src/tests/ops/map_comparison.rs
+++ b/crates/burn-tensor/src/tests/ops/map_comparison.rs
@@ -354,6 +354,22 @@ mod tests {
     }
 
     #[test]
+    fn should_support_bool_not_equal() {
+        let data_1 = Data::from([[false, true, true], [true, false, true]]);
+        let data_2 = Data::from([[false, false, true], [false, true, true]]);
+        let device = Default::default();
+        let tensor_1 = Tensor::<TestBackend, 2, Bool>::from_data(data_1, &device);
+        let tensor_2 = Tensor::<TestBackend, 2, Bool>::from_data(data_2, &device);
+
+        let data_actual_cloned = tensor_1.clone().not_equal(tensor_2.clone());
+        let data_actual_inplace = tensor_1.not_equal(tensor_2);
+
+        let data_expected = Data::from([[false, true, false], [true, true, false]]);
+        assert_eq!(data_expected, data_actual_cloned.into_data());
+        assert_eq!(data_expected, data_actual_inplace.into_data());
+    }
+
+    #[test]
     fn should_support_bool_not() {
         let data_1 = Data::from([[false, true, true], [true, true, false]]);
         let tensor_1 = Tensor::<TestBackend, 2, Bool>::from_data(data_1, &Default::default());


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

- Added `not_equal` basic op
- Added `not_equal_elem` numeric op
- Fixed "element-wise" word usage in docs for correctness (and uniformity)

The implementation makes use of the already existing `equal` + `bool_not` ops.

### Testing

Added unit tests
