### PR TITLE
Element wise min/max between a pair of tensors

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -201,10 +201,12 @@ Those operations are available for numeric tensor kinds: `Float` and `Int`.
 | `tensor.max()`                                                   | `tensor.max()`                                 |
 | `tensor.max_dim(dim)`                                            | `tensor.max(dim)`                              |
 | `tensor.max_dim_with_indices(dim)`                               | N/A                                            |
+| `tensor.max_pair(other)`                                         | `torch.Tensor.max(a,b)`                        |
 | `tensor.argmin(dim)`                                             | `tensor.argmin(dim)`                           |
 | `tensor.min()`                                                   | `tensor.min()`                                 |
 | `tensor.min_dim(dim)`                                            | `tensor.min(dim)`                              |
 | `tensor.min_dim_with_indices(dim)`                               | N/A                                            |
+| `tensor.min_pair(other)`                                         | `torch.Tensor.min(a,b)`                        |
 | `tensor.clamp(min, max)`                                         | `torch.clamp(tensor, min=min, max=max)`        |
 | `tensor.clamp_min(min)`                                          | `torch.clamp(tensor, min=min)`                 |
 | `tensor.clamp_max(max)`                                          | `torch.clamp(tensor, max=max)`                 |

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -425,7 +425,7 @@ where
     ///
     /// # Returns
     ///
-    /// A tensor `Tensor<B, D, K>` with the same shape as the input tensors containing the minium value found
+    /// A tensor `Tensor<B, D, K>` with the same shape as the input tensors containing the minimum value found
     /// between each element of the two source tensors.
     pub fn min_pair(self, other: Self) -> Self {
         let mask = other.clone().lower(self.clone());

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -357,7 +357,7 @@ where
         (tensor, index)
     }
 
-    /// Find the maximum pair wise values with another Tensor
+    /// Finds the maximum pair wise values with another Tensor
     ///
     /// # Arguments
     ///
@@ -365,7 +365,7 @@ where
     ///
     /// # Returns
     ///
-    /// A tensor `Tensor<B, D, Float>` with the same shape as the input tensors containing the maximum value found
+    /// A tensor with the same shape as the input tensors containing the maximum value found
     /// in the input tensors.
     pub fn max_pair(self, other: Self) -> Self {
         let mask = self.clone().lower(other.clone());
@@ -417,7 +417,7 @@ where
         (tensor, index)
     }
 
-    /// Find the minimum pair wise values with another Tensor
+    /// Finds the minimum pair wise values with another Tensor
     ///
     /// # Arguments
     ///
@@ -425,7 +425,7 @@ where
     ///
     /// # Returns
     ///
-    /// A tensor `Tensor<B, D, K>` with the same shape as the input tensors containing the minimum value found
+    /// A tensor with the same shape as the input tensors containing the minimum value found
     /// between each element of the two source tensors.
     pub fn min_pair(self, other: Self) -> Self {
         let mask = other.clone().lower(self.clone());

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -357,6 +357,21 @@ where
         (tensor, index)
     }
 
+    /// Find the maximum pair wise values with another Tensor
+    ///
+    /// # Arguments
+    ///
+    /// * `other` - Other tensor to find maximum elements with
+    ///
+    /// # Returns
+    ///
+    /// A tensor `Tensor<B, D, Float>` with the same shape as the input tensors containing the maximum value found
+    /// in the input tensors.
+    pub fn max_pair(self, other: Self) -> Self {
+        let mask = self.clone().lower(other.clone());
+        self.mask_where(mask, other)
+    }
+
     /// Applies the argmin function along the given dimension and returns an integer tensor.
     ///
     /// # Example
@@ -400,6 +415,21 @@ where
         let index = Tensor::new(index);
 
         (tensor, index)
+    }
+
+    /// Find the minimum pair wise values with another Tensor
+    ///
+    /// # Arguments
+    ///
+    /// * `other` - Other tensor to find minimum elements with
+    ///
+    /// # Returns
+    ///
+    /// A tensor `Tensor<B, D, K>` with the same shape as the input tensors containing the minium value found
+    /// between each element of the two source tensors.
+    pub fn min_pair(self, other: Self) -> Self {
+        let mask = other.clone().lower(self.clone());
+        self.mask_where(mask, other)
     }
 
     /// Clamp the tensor between the given min and max values.

--- a/crates/burn-tensor/src/tests/ops/maxmin.rs
+++ b/crates/burn-tensor/src/tests/ops/maxmin.rs
@@ -137,4 +137,26 @@ mod tests {
         assert_eq!(output_expected, output_actual.into_data());
         assert_eq!(index_expected, index_actual.into_data());
     }
+
+    #[test]
+    fn test_maximum_pair() {
+        let a = TestTensor::from_floats([1.0, 2.0, 3.0, 4.0], &Default::default());
+        let b = TestTensor::from_floats([2.0, 1.0, 4.0, 5.0], &Default::default());
+
+        let c = a.max_pair(b);
+
+        let expect = Data::from([2.0, 2.0, 4.0, 5.0]);
+        c.to_data().assert_approx_eq(&expect, 1);
+    }
+
+    #[test]
+    fn test_minimum_pair() {
+        let a = TestTensor::from_floats([1.0, 2.0, 3.0, 4.0], &Default::default());
+        let b = TestTensor::from_floats([2.0, 1.0, 4.0, 5.0], &Default::default());
+
+        let c = a.min_pair(b);
+
+        let expect = Data::from([1.0, 1.0, 3.0, 4.0]);
+        c.to_data().assert_approx_eq(&expect, 1);
+    }
 }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
```
[2024-02-29T21:16:10Z INFO  xtask::runchecks] Time elapsed for the current execution: 00:06:31
```

- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

#856 

### Changes

Adds methods `min_pair()` and `max_pair()` to numeric tensors to provide pairwise min/max between a pair of tensors.

### Testing

Unit tests have been added to `minmax.rs`