### PR TITLE
bool cast kernel

### DIFF
--- a/crates/burn-tensor/src/tests/ops/all.rs
+++ b/crates/burn-tensor/src/tests/ops/all.rs
@@ -58,4 +58,15 @@ mod tests {
         let data_expected = Data::from([[false], [true]]);
         assert_eq!(data_expected, data_actual);
     }
+
+    #[test]
+    fn test_all_with_bool_from_lower_equal() {
+        let tensor1 = TestTensor::from([[0.0, 1.0, 0.0], [1.0, -1.0, 1.0]]) + 1e-6;
+        let tensor2 = TestTensor::from([[0.0, 1.0, 0.0], [1.0, -1.0, 1.0]]) + 1e-6;
+
+        let ge = tensor1.lower_equal(tensor2);
+        let all = ge.clone().all();
+
+        assert_eq!(Data::from([true]), all.clone().into_data());
+    }
 }


### PR DESCRIPTION
In wgpu, bools are u32, where false is zero and true is anything else. 
Sometimes it can be an optimization to not change the bits, for instance in
passing from 1_f32 which has bit representation 00111111 10000000 00000000 00000000 
to the bool true and using afterwards for inplace operations, it's practical to not have to change the bits to 00000000 00000000 00000000 00000001

However, when we explicitly casted bool to something else, we used a kernel that did not know we were using bool, it just knew it had a u32, so it was treated like an integer. 

Hence, 1_f32 became true, which in turn became 1065353216 or 1065353216.0 (which is 00111111 10000000 00000000 00000000 as a u32). 

The fix is to call a new cast kernel who explicitly knows it must consider its u32 inputs as bools. 

Fix #1315 
Fix #1388 