### PR TITLE
Add `argwhere` and `nonzero` boolean tensor ops

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -273,11 +273,13 @@ Those operations are only available for `Int` tensors.
 
 Those operations are only available for `Bool` tensors.
 
-| Burn API         | PyTorch Equivalent                  |
-| ---------------- | ----------------------------------- |
-| `tensor.float()` | Similar to `tensor.to(torch.float)` |
-| `tensor.int()`   | Similar to `tensor.to(torch.long)`  |
-| `tensor.not()`   | `tensor.logical_not()`              |
+| Burn API            | PyTorch Equivalent                  |
+| ------------------- | ----------------------------------- |
+| `tensor.float()`    | Similar to `tensor.to(torch.float)` |
+| `tensor.int()`      | Similar to `tensor.to(torch.long)`  |
+| `tensor.not()`      | `tensor.logical_not()`              |
+| `tensor.argwhere()` | `tensor.argwhere()`                 |
+| `tensor.nonzero()`  | `tensor.nonzero(as_tuple=True)`     |
 
 ## Activation Functions
 

--- a/crates/burn-autodiff/src/ops/bool_tensor.rs
+++ b/crates/burn-autodiff/src/ops/bool_tensor.rs
@@ -109,4 +109,12 @@ impl<B: Backend, C: CheckpointStrategy> BoolTensorOps<Self> for Autodiff<B, C> {
     ) -> Vec<BoolTensor<B, D>> {
         B::bool_chunk(tensor, chunks, dim)
     }
+
+    fn bool_argwhere<const D: usize>(tensor: BoolTensor<B, D>) -> IntTensor<B, 2> {
+        B::bool_argwhere(tensor)
+    }
+
+    fn bool_nonzero<const D: usize>(tensor: BoolTensor<B, D>) -> Vec<IntTensor<B, 1>> {
+        B::bool_nonzero(tensor)
+    }
 }

--- a/crates/burn-autodiff/src/tests/mod.rs
+++ b/crates/burn-autodiff/src/tests/mod.rs
@@ -34,6 +34,7 @@ mod maxpool2d;
 mod mul;
 mod multithread;
 mod neg;
+mod nonzero;
 mod pow;
 mod recip;
 mod relu;
@@ -108,5 +109,6 @@ macro_rules! testgen_all {
         burn_autodiff::testgen_ad_tanh!();
         burn_autodiff::testgen_ad_sigmoid!();
         burn_autodiff::testgen_ad_transpose!();
+        burn_autodiff::testgen_ad_nonzero!();
     };
 }

--- a/crates/burn-autodiff/src/tests/nonzero.rs
+++ b/crates/burn-autodiff/src/tests/nonzero.rs
@@ -1,0 +1,40 @@
+#[burn_tensor_testgen::testgen(ad_nonzero)]
+mod tests {
+    use super::*;
+    use burn_tensor::{Bool, Data, Int, Tensor};
+
+    #[test]
+    fn should_diff_nonzero() {
+        let data_1 = Data::<f32, 2>::from([[1.0, 2.0], [3.0, 4.0]]);
+        let data_2 = Data::<f32, 1>::from([-1.0, 1.0]);
+        let mask = Data::<bool, 2>::from([[false, true], [true, false]]);
+
+        let device = Default::default();
+        let tensor_1 = TestAutodiffTensor::from_data(data_1, &device).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data(data_2, &device).require_grad();
+
+        // Multi-dimensional tensor indexing isn't really supported yet so the easiest way to do
+        // this is to flatten the mask and tensor to get proper indexing. Anyway the returned tensor would
+        // have dimensions different from the input, so this is somewhat equivalent.
+        let mask =
+            Tensor::<TestAutodiffBackend, 2, Bool>::from_bool(mask, &device).flatten::<1>(0, 1);
+        let indices = mask.nonzero();
+        let tensor_3 = tensor_1
+            .clone()
+            .flatten::<1>(0, 1)
+            .select(0, indices[0].clone());
+
+        // Vector dot product not supported (only 2D matmuls) so unsqueeze for test purposes
+        let tensor_4 = tensor_2
+            .clone()
+            .unsqueeze_dim::<2>(0)
+            .matmul(tensor_3.unsqueeze_dim(1));
+        let grads = tensor_4.backward();
+
+        let grad_1 = tensor_1.grad(&grads).unwrap();
+        let grad_2 = tensor_2.grad(&grads).unwrap();
+
+        assert_eq!(grad_1.to_data(), Data::from([[0.0, -1.0], [1.0, 0.0]]));
+        assert_eq!(grad_2.to_data(), Data::from([2.0, 3.0]));
+    }
+}

--- a/crates/burn-candle/src/lib.rs
+++ b/crates/burn-candle/src/lib.rs
@@ -79,6 +79,7 @@ mod tests {
     burn_tensor::testgen_maxmin!();
     burn_tensor::testgen_mul!();
     burn_tensor::testgen_neg!();
+    burn_tensor::testgen_argwhere_nonzero!();
 
     // TODO: https://github.com/tracel-ai/burn/issues/1237
     //

--- a/crates/burn-tch/src/ops/bool_tensor.rs
+++ b/crates/burn-tch/src/ops/bool_tensor.rs
@@ -131,4 +131,21 @@ impl<E: TchElement> BoolTensorOps<Self> for LibTorch<E> {
     ) -> Vec<TchTensor<bool, D>> {
         TchOps::chunk(tensor, chunks, dim)
     }
+
+    fn bool_argwhere<const D: usize>(
+        tensor: <LibTorch<E> as Backend>::BoolTensorPrimitive<D>,
+    ) -> TchTensor<i64, 2> {
+        TchTensor::new(tensor.tensor.argwhere())
+    }
+
+    fn bool_nonzero<const D: usize>(
+        tensor: <LibTorch<E> as Backend>::BoolTensorPrimitive<D>,
+    ) -> Vec<TchTensor<i64, 1>> {
+        tensor
+            .tensor
+            .nonzero_numpy()
+            .into_iter()
+            .map(TchTensor::new)
+            .collect()
+    }
 }

--- a/crates/burn-tensor/src/tensor/api/argwhere.rs
+++ b/crates/burn-tensor/src/tensor/api/argwhere.rs
@@ -67,7 +67,7 @@ fn argwhere_data<B: Backend, const D: usize>(
     let dims = data.shape.dims;
     let count_nonzero = data.value.iter().filter(|&v| *v).count();
 
-    /// Converts a flat index into a vector of indices for the
+    /// Converts a flat index into a vector of indices for the specified tensor shape
     fn unravel_index<B: Backend, const D: usize>(
         index: usize,
         shape: &[usize; D],

--- a/crates/burn-tensor/src/tensor/api/argwhere.rs
+++ b/crates/burn-tensor/src/tensor/api/argwhere.rs
@@ -1,10 +1,11 @@
 use crate::{
     backend::Backend,
     ops::{BoolTensor, IntTensor},
-    Data, ElementConversion, Shape,
+    Data, Device, ElementConversion, Shape,
 };
 use alloc::vec::Vec;
 
+#[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
 /// Compute the indices of the elements that are non-zero, grouped by element.
 ///
 /// # Arguments
@@ -25,8 +26,44 @@ use alloc::vec::Vec;
 pub fn argwhere<B: Backend, const D: usize>(tensor: BoolTensor<B, D>) -> IntTensor<B, 2> {
     // Size of each output tensor is variable (= number of nonzero elements in the tensor).
     // Reading the data to count the number of truth values might cause sync but is required.
+    // let dims = B::bool_shape(&tensor).dims;
     let device = B::bool_device(&tensor);
     let data = B::bool_into_data(tensor).read();
+
+    argwhere_data::<B, D>(data, &device)
+}
+
+#[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
+/// Compute the indices of the elements that are non-zero, grouped by element.
+///
+/// # Arguments
+///
+/// * `tensor` - The input tensor.
+///
+/// # Returns
+///
+/// A vector of tensors, one for each dimension of the given tensor, containing the indices of
+/// the non-zero elements in that dimension.
+///
+/// # Remarks
+///
+/// This is a fallback solution that used only when the backend doesn't have the corresponding implementation.
+/// Ideally, it is supposed to be implemented by the backend and the backend implementation will be resolved
+/// by static dispatch. It is not designed for direct usage by users, and not recommended to import
+/// or use this function directly.
+pub async fn argwhere<B: Backend, const D: usize>(tensor: BoolTensor<B, D>) -> IntTensor<B, 2> {
+    // Size of each output tensor is variable (= number of nonzero elements in the tensor).
+    // Reading the data to count the number of truth values might cause sync but is required.
+    let device = B::bool_device(&tensor);
+    let data = B::bool_into_data(tensor).read().await;
+
+    argwhere_data::<B, D>(data, &device)
+}
+
+fn argwhere_data<B: Backend, const D: usize>(
+    data: Data<bool, D>,
+    device: &Device<B>,
+) -> IntTensor<B, 2> {
     let dims = data.shape.dims;
     let count_nonzero = data.value.iter().filter(|&v| *v).count();
 
@@ -58,5 +95,5 @@ pub fn argwhere<B: Backend, const D: usize>(tensor: BoolTensor<B, D>) -> IntTens
         .collect::<Vec<_>>()
         .concat();
 
-    B::int_from_data(Data::new(indices, Shape::new([count_nonzero, D])), &device)
+    B::int_from_data(Data::new(indices, Shape::new([count_nonzero, D])), device)
 }

--- a/crates/burn-tensor/src/tensor/api/argwhere.rs
+++ b/crates/burn-tensor/src/tensor/api/argwhere.rs
@@ -1,0 +1,62 @@
+use crate::{
+    backend::Backend,
+    ops::{BoolTensor, IntTensor},
+    Data, ElementConversion, Shape,
+};
+use alloc::vec::Vec;
+
+/// Compute the indices of the elements that are non-zero, grouped by element.
+///
+/// # Arguments
+///
+/// * `tensor` - The input tensor.
+///
+/// # Returns
+///
+/// A vector of tensors, one for each dimension of the given tensor, containing the indices of
+/// the non-zero elements in that dimension.
+///
+/// # Remarks
+///
+/// This is a fallback solution that used only when the backend doesn't have the corresponding implementation.
+/// Ideally, it is supposed to be implemented by the backend and the backend implementation will be resolved
+/// by static dispatch. It is not designed for direct usage by users, and not recommended to import
+/// or use this function directly.
+pub fn argwhere<B: Backend, const D: usize>(tensor: BoolTensor<B, D>) -> IntTensor<B, 2> {
+    // Size of each output tensor is variable (= number of nonzero elements in the tensor).
+    // Reading the data to count the number of truth values might cause sync but is required.
+    let device = B::bool_device(&tensor);
+    let data = B::bool_into_data(tensor).read();
+    let dims = data.shape.dims;
+    let count_nonzero = data.value.iter().filter(|&v| *v).count();
+
+    /// Converts a flat index into a vector of indices for the
+    fn unravel_index<B: Backend, const D: usize>(
+        index: usize,
+        shape: &[usize; D],
+    ) -> Vec<B::IntElem> {
+        shape
+            .iter()
+            .rev()
+            .scan(index, |i, size| {
+                let dim_idx = *i % size;
+                *i /= size;
+                Some((dim_idx as i64).elem())
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect()
+    }
+
+    let indices = data
+        .value
+        .iter()
+        .enumerate()
+        .filter_map(|(index, &v)| if v { Some(index) } else { None })
+        .map(|index| unravel_index::<B, D>(index, &dims))
+        .collect::<Vec<_>>()
+        .concat();
+
+    B::int_from_data(Data::new(indices, Shape::new([count_nonzero, D])), &device)
+}

--- a/crates/burn-tensor/src/tensor/api/argwhere.rs
+++ b/crates/burn-tensor/src/tensor/api/argwhere.rs
@@ -5,7 +5,6 @@ use crate::{
 };
 use alloc::vec::Vec;
 
-#[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
 /// Compute the indices of the elements that are non-zero, grouped by element.
 ///
 /// # Arguments
@@ -23,6 +22,7 @@ use alloc::vec::Vec;
 /// Ideally, it is supposed to be implemented by the backend and the backend implementation will be resolved
 /// by static dispatch. It is not designed for direct usage by users, and not recommended to import
 /// or use this function directly.
+#[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
 pub fn argwhere<B: Backend, const D: usize>(tensor: BoolTensor<B, D>) -> IntTensor<B, 2> {
     // Size of each output tensor is variable (= number of nonzero elements in the tensor).
     // Reading the data to count the number of truth values might cause sync but is required.
@@ -33,7 +33,6 @@ pub fn argwhere<B: Backend, const D: usize>(tensor: BoolTensor<B, D>) -> IntTens
     argwhere_data::<B, D>(data, &device)
 }
 
-#[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
 /// Compute the indices of the elements that are non-zero, grouped by element.
 ///
 /// # Arguments
@@ -51,6 +50,7 @@ pub fn argwhere<B: Backend, const D: usize>(tensor: BoolTensor<B, D>) -> IntTens
 /// Ideally, it is supposed to be implemented by the backend and the backend implementation will be resolved
 /// by static dispatch. It is not designed for direct usage by users, and not recommended to import
 /// or use this function directly.
+#[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
 pub async fn argwhere<B: Backend, const D: usize>(tensor: BoolTensor<B, D>) -> IntTensor<B, 2> {
     // Size of each output tensor is variable (= number of nonzero elements in the tensor).
     // Reading the data to count the number of truth values might cause sync but is required.

--- a/crates/burn-tensor/src/tensor/api/bool.rs
+++ b/crates/burn-tensor/src/tensor/api/bool.rs
@@ -1,4 +1,5 @@
 use crate::{backend::Backend, Bool, Data, Int, Tensor};
+use alloc::vec::Vec;
 
 impl<B, const D: usize> Tensor<B, D, Bool>
 where
@@ -22,5 +23,28 @@ where
     /// Inverses boolean values.
     pub fn bool_not(self) -> Self {
         Tensor::new(B::bool_not(self.primitive))
+    }
+
+    /// Compute the indices of the elements that are non-zero.
+    ///
+    /// # Returns
+    ///
+    /// A vector of tensors, one for each dimension of the given tensor, containing the indices of
+    /// the non-zero elements in that dimension.
+    pub fn nonzero(self) -> Vec<Tensor<B, 1, Int>> {
+        B::bool_nonzero(self.primitive)
+            .into_iter()
+            .map(|t| Tensor::new(t))
+            .collect()
+    }
+
+    /// Compute the indices of the elements that are non-zero, grouped by element.
+    ///
+    /// # Returns
+    ///
+    /// A tensor containing the indices of all non-zero elements of the given tensor. Each row in the
+    /// result contains the indices of a non-zero element.
+    pub fn argwhere(self) -> Tensor<B, 2, Int> {
+        Tensor::new(B::bool_argwhere(self.primitive))
     }
 }

--- a/crates/burn-tensor/src/tensor/api/bool.rs
+++ b/crates/burn-tensor/src/tensor/api/bool.rs
@@ -28,13 +28,13 @@ where
         Tensor::new(B::bool_not(self.primitive))
     }
 
-    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     /// Compute the indices of the elements that are non-zero.
     ///
     /// # Returns
     ///
     /// A vector of tensors, one for each dimension of the given tensor, containing the indices of
     /// the non-zero elements in that dimension.
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     pub fn nonzero(self) -> Vec<Tensor<B, 1, Int>> {
         B::bool_nonzero(self.primitive)
             .into_iter()
@@ -42,13 +42,13 @@ where
             .collect()
     }
 
-    #[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
     /// Compute the indices of the elements that are non-zero.
     ///
     /// # Returns
     ///
     /// A vector of tensors, one for each dimension of the given tensor, containing the indices of
     /// the non-zero elements in that dimension.
+    #[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
     pub async fn nonzero(self) -> Vec<Tensor<B, 1, Int>> {
         let indices = self.argwhere().await.primitive;
         let dims = B::int_shape(&indices).dims;
@@ -59,24 +59,24 @@ where
             .collect()
     }
 
-    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     /// Compute the indices of the elements that are non-zero, grouped by element.
     ///
     /// # Returns
     ///
     /// A tensor containing the indices of all non-zero elements of the given tensor. Each row in the
     /// result contains the indices of a non-zero element.
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     pub fn argwhere(self) -> Tensor<B, 2, Int> {
         Tensor::new(B::bool_argwhere(self.primitive))
     }
 
-    #[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
     /// Compute the indices of the elements that are non-zero, grouped by element.
     ///
     /// # Returns
     ///
     /// A tensor containing the indices of all non-zero elements of the given tensor. Each row in the
     /// result contains the indices of a non-zero element.
+    #[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
     pub async fn argwhere(self) -> Tensor<B, 2, Int> {
         Tensor::new(argwhere::<B, D>(self.primitive).await)
     }

--- a/crates/burn-tensor/src/tensor/api/mod.rs
+++ b/crates/burn-tensor/src/tensor/api/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod check;
 
+mod argwhere;
 mod autodiff;
 mod base;
 mod bool;
@@ -10,6 +11,7 @@ mod kind;
 mod narrow;
 mod numeric;
 
+pub use argwhere::argwhere;
 pub use autodiff::*;
 pub use base::*;
 pub use chunk::chunk;

--- a/crates/burn-tensor/src/tensor/ops/bool_tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/bool_tensor.rs
@@ -389,7 +389,6 @@ pub trait BoolTensorOps<B: Backend> {
         B::int_equal_elem(sum, (num_elems as i32).elem())
     }
 
-    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     /// Compute the indices of the elements that are non-zero, grouped by element.
     ///
     /// # Arguments
@@ -400,11 +399,11 @@ pub trait BoolTensorOps<B: Backend> {
     ///
     /// A vector of tensors, one for each dimension of the given tensor, containing the indices of
     /// the non-zero elements in that dimension.
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     fn bool_argwhere<const D: usize>(tensor: BoolTensor<B, D>) -> IntTensor<B, 2> {
         argwhere::<B, D>(tensor)
     }
 
-    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     /// Compute the indices of the elements that are non-zero.
     ///
     /// # Arguments
@@ -415,6 +414,7 @@ pub trait BoolTensorOps<B: Backend> {
     ///
     /// A vector of tensors, one for each dimension of the given tensor, containing the indices of
     /// the non-zero elements in that dimension.
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     fn bool_nonzero<const D: usize>(tensor: BoolTensor<B, D>) -> Vec<IntTensor<B, 1>> {
         let indices = B::bool_argwhere(tensor);
         let dims = B::int_shape(&indices).dims;

--- a/crates/burn-tensor/src/tensor/ops/bool_tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/bool_tensor.rs
@@ -1,5 +1,7 @@
 use super::{BoolTensor, Device, FloatTensor, IntTensor};
-use crate::{backend::Backend, chunk, narrow, tensor::Shape, Bool, Data, ElementConversion};
+use crate::{
+    argwhere, backend::Backend, chunk, narrow, tensor::Shape, Bool, Data, ElementConversion,
+};
 use alloc::vec::Vec;
 use burn_common::reader::Reader;
 use core::ops::Range;
@@ -312,7 +314,6 @@ pub trait BoolTensorOps<B: Backend> {
     /// # Returns
     ///
     /// A vectors of tensors
-    ///
     fn bool_chunk<const D: usize>(
         tensor: BoolTensor<B, D>,
         chunks: usize,
@@ -386,5 +387,38 @@ pub trait BoolTensorOps<B: Backend> {
         let num_elems = B::bool_shape(&tensor).dims[dim];
         let sum = B::int_sum_dim(B::bool_into_int(tensor), dim);
         B::int_equal_elem(sum, (num_elems as i32).elem())
+    }
+
+    /// Compute the indices of the elements that are non-zero, grouped by element.
+    ///
+    /// # Arguments
+    ///
+    /// * `tensor` - The input tensor.
+    ///
+    /// # Returns
+    ///
+    /// A vector of tensors, one for each dimension of the given tensor, containing the indices of
+    /// the non-zero elements in that dimension.
+    fn bool_argwhere<const D: usize>(tensor: BoolTensor<B, D>) -> IntTensor<B, 2> {
+        argwhere::<B, D>(tensor)
+    }
+
+    /// Compute the indices of the elements that are non-zero.
+    ///
+    /// # Arguments
+    ///
+    /// * `tensor` - The input tensor.
+    ///
+    /// # Returns
+    ///
+    /// A vector of tensors, one for each dimension of the given tensor, containing the indices of
+    /// the non-zero elements in that dimension.
+    fn bool_nonzero<const D: usize>(tensor: BoolTensor<B, D>) -> Vec<IntTensor<B, 1>> {
+        let indices = B::bool_argwhere(tensor);
+        let dims = B::int_shape(&indices).dims;
+        B::int_chunk(indices, dims[1], 1)
+            .into_iter()
+            .map(|t| B::int_reshape(t, Shape::new([dims[0]])))
+            .collect()
     }
 }

--- a/crates/burn-tensor/src/tensor/ops/bool_tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/bool_tensor.rs
@@ -389,6 +389,7 @@ pub trait BoolTensorOps<B: Backend> {
         B::int_equal_elem(sum, (num_elems as i32).elem())
     }
 
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     /// Compute the indices of the elements that are non-zero, grouped by element.
     ///
     /// # Arguments
@@ -403,6 +404,7 @@ pub trait BoolTensorOps<B: Backend> {
         argwhere::<B, D>(tensor)
     }
 
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     /// Compute the indices of the elements that are non-zero.
     ///
     /// # Arguments

--- a/crates/burn-tensor/src/tests/mod.rs
+++ b/crates/burn-tensor/src/tests/mod.rs
@@ -85,6 +85,7 @@ macro_rules! testgen_all {
         burn_tensor::testgen_powf!();
         burn_tensor::testgen_any!();
         burn_tensor::testgen_all_op!();
+        burn_tensor::testgen_argwhere_nonzero!();
 
         // test stats
         burn_tensor::testgen_var!();

--- a/crates/burn-tensor/src/tests/ops/argwhere_nonzero.rs
+++ b/crates/burn-tensor/src/tests/ops/argwhere_nonzero.rs
@@ -1,0 +1,82 @@
+#[burn_tensor_testgen::testgen(argwhere_nonzero)]
+mod tests {
+    use super::*;
+    use burn_tensor::{Data, Tensor};
+
+    #[test]
+    fn test_argwhere_1d() {
+        // 1-D tensor
+        let tensor = TestTensorBool::from([false, true, false, true, true]);
+        let data_actual = tensor.argwhere().into_data();
+        let data_expected = Data::from([[1], [3], [4]]);
+        assert_eq!(data_expected, data_actual);
+    }
+
+    #[test]
+    fn test_argwhere_2d() {
+        // 2-D tensor
+        let tensor = TestTensorBool::from([[false, false], [false, true], [true, true]]);
+        let data_actual = tensor.argwhere().into_data();
+        // let data_expected = vec![Data::from([1, 2, 2]), Data::from([1, 0, 1])];
+        let data_expected = Data::from([[1, 1], [2, 0], [2, 1]]);
+        assert_eq!(data_expected, data_actual);
+    }
+
+    #[test]
+    fn test_argwhere_3d() {
+        // 3-D tensor
+        let tensor = TestTensorBool::from([
+            [[false, false, false], [false, true, false]],
+            [[true, false, true], [true, true, false]],
+        ]);
+        let data_actual = tensor.argwhere().into_data();
+        let data_expected = Data::from([[0, 1, 1], [1, 0, 0], [1, 0, 2], [1, 1, 0], [1, 1, 1]]);
+        assert_eq!(data_expected, data_actual);
+    }
+
+    #[test]
+    fn test_nonzero_1d() {
+        // 1-D tensor
+        let tensor = TestTensorBool::from([false, true, false, true, true]);
+        let data_actual = tensor
+            .nonzero()
+            .into_iter()
+            .map(|t| t.into_data())
+            .collect::<Vec<_>>();
+        let data_expected = vec![Data::from([1, 3, 4])];
+        assert_eq!(data_expected, data_actual);
+    }
+
+    #[test]
+    fn test_nonzero_2d() {
+        // 2-D tensor
+        let tensor = TestTensorBool::from([[false, false], [false, true], [true, true]]);
+        let data_actual = tensor
+            .nonzero()
+            .into_iter()
+            .map(|t| t.into_data())
+            .collect::<Vec<_>>();
+        let data_expected = vec![Data::from([1, 2, 2]), Data::from([1, 0, 1])];
+        assert_eq!(data_expected, data_actual);
+    }
+
+    #[test]
+    fn test_nonzero_3d() {
+        // 3-D tensor
+        let tensor = TestTensorBool::from([
+            [[false, false, false], [false, true, false]],
+            [[true, false, true], [true, true, false]],
+        ]);
+        let data_actual = tensor
+            .nonzero()
+            .into_iter()
+            .map(|t| t.into_data())
+            .collect::<Vec<_>>();
+        let data_expected = vec![
+            Data::from([0, 1, 1, 1, 1]),
+            Data::from([1, 0, 0, 1, 1]),
+            Data::from([1, 0, 2, 0, 1]),
+        ];
+        assert_eq!(data_expected, data_actual);
+    }
+}

--- a/crates/burn-tensor/src/tests/ops/argwhere_nonzero.rs
+++ b/crates/burn-tensor/src/tests/ops/argwhere_nonzero.rs
@@ -1,6 +1,7 @@
 #[burn_tensor_testgen::testgen(argwhere_nonzero)]
 mod tests {
     use super::*;
+    use alloc::vec::Vec;
     use burn_tensor::{Data, Tensor};
 
     #[test]

--- a/crates/burn-tensor/src/tests/ops/mod.rs
+++ b/crates/burn-tensor/src/tests/ops/mod.rs
@@ -6,6 +6,7 @@ mod any;
 mod arange;
 mod arange_step;
 mod arg;
+mod argwhere_nonzero;
 mod cast;
 mod cat;
 mod chunk;


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Fixes #1373

### Changes

New `bool_argwhere` and `bool_nonzero` boolean tensor ops.

- Added default `argwhere` implementation
- Added default `nonzero` implementation that reuses `argwhere`
- Added `argwhere` and `nonzero` for existing `tch` ops

### Testing

Added unit tests.

Note on autodiff tests: as opposed to nonzero, argwhere cannot be used for indexing tensors so it wasn't clear to me if anything should be tested.
