### PR TITLE
[backend-comparison] Update Github App ID with official application

### DIFF
--- a/backend-comparison/src/burnbenchapp/auth.rs
+++ b/backend-comparison/src/burnbenchapp/auth.rs
@@ -7,7 +7,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-pub(crate) static CLIENT_ID: &str = "Iv1.84002254a02791f3";
+pub(crate) static CLIENT_ID: &str = "Iv1.692f6a61b6086810";
 static GITHUB_API_VERSION_HEADER: &str = "X-GitHub-Api-Version";
 static GITHUB_API_VERSION: &str = "2022-11-28";
 


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

https://github.com/tracel-ai/burn/issues/1072

### Changes

Change the client ID to the official Github App ID.
Official GitHub app link: https://github.com/apps/burnbench

