### PR TITLE
Update Cargo.lock workflow to trigger commit checks

### DIFF
--- a/.github/workflows/update-cargo-lock.yml
+++ b/.github/workflows/update-cargo-lock.yml
@@ -13,13 +13,26 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      # we use a GitHub app token so that other workflows can react to the
+      # creation of the Pull Request.
+      # Following these guidelines -> https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#authenticating-with-github-app-generated-tokens
+      # For additional info -> https://github.com/tibdex/github-app-token?tab=readme-ov-file#github-app-token
+      - name: generate GitHub app token
+        id: generate-app-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.UPDATE_CARGO_LOCK_APP_ID }}
+          private_key: ${{ secrets.UPDATE_CARGO_LOCK_APP_PRIVATE_KEY }}
       - name: cargo update
         run: cargo update
-      - name: pull-request
+      - name: create pull request
         uses: peter-evans/create-pull-request@v6
         with:
+          token: ${{ steps.generate-app-token.outputs.token }}
           branch: "create-pull-request/update-cargo-lock"
           title: "Cargo.lock update"
+          body: |
+            This PR has been automatically created by the [update-cargo-lock.yml](https://github.com/tracel-ai/burn/blob/main/.github/workflows/update-cargo-lock.yml) workflow.
           commit-message: |
             Update Cargo.lock
 


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

https://github.com/tracel-ai/burn/issues/1349

### Changes

A token used to execute an action cannot be reused in another workflow to prevent infinite chain of workflow execution.

This commit uses a token from a special GitHub app in the tracel organization so that commit checks (created by the test workflow which uses the generic GITHUB_TOKEN) can be triggered upon creation of a Pull Request by this workflow.

