### PR TITLE
Fix book documentation for `tensor.into_scalar()`  

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -134,35 +134,36 @@ for the sake of simplicity, we ignore type signatures. For more details, refer t
 
 Those operations are available for all tensor kinds: `Int`, `Float`, and `Bool`.
 
-| Burn                                  | PyTorch Equivalent                   |
-| ------------------------------------- | ------------------------------------ |
-| `Tensor::cat(tensors, dim)`           | `torch.cat(tensors, dim)`            |
-| `Tensor::empty(shape, device)`        | `torch.empty(shape, device=device)`  |
-| `Tensor::from_primitive(primitive)`   | N/A                                  |
-| `Tensor::stack(tensors, dim)`         | `torch.stack(tensors, dim)`          |
-| `tensor.all()`                        | `tensor.all()`                       |
-| `tensor.all_dim(dim)`                 | `tensor.all(dim)`                    |
-| `tensor.any()`                        | `tensor.any()`                       |
-| `tensor.any_dim(dim)`                 | `tensor.any(dim)`                    |
-| `tensor.chunk(num_chunks, dim)`       | `tensor.chunk(num_chunks, dim)`      |
-| `tensor.device()`                     | `tensor.device`                      |
-| `tensor.dims()`                       | `tensor.size()`                      |
-| `tensor.equal(other)`                 | `x == y`                             |
-| `tensor.flatten(start_dim, end_dim)`  | `tensor.flatten(start_dim, end_dim)` |
-| `tensor.into_data()`                  | N/A                                  |
-| `tensor.into_primitive()`             | N/A                                  |
-| `tensor.narrow(dim, start, length)`   | `tensor.narrow(dim, start, length)`  |
-| `tensor.not_equal(other)`             | `x != y`                             |
-| `tensor.repeat(2, 4)`                 | `tensor.repeat([1, 1, 4])`           |
-| `tensor.reshape(shape)`               | `tensor.view(shape)`                 |
-| `tensor.shape()`                      | `tensor.shape`                       |
-| `tensor.slice(ranges)`                | `tensor[(*ranges,)]`                 |
-| `tensor.slice_assign(ranges, values)` | `tensor[(*ranges,)] = values`        |
-| `tensor.squeeze(dim)`                 | `tensor.squeeze(dim)`                |
-| `tensor.to_data()`                    | N/A                                  |
-| `tensor.to_device(device)`            | `tensor.to(device)`                  |
-| `tensor.unsqueeze()`                  | `tensor.unsqueeze(0)`                |
-| `tensor.unsqueeze_dim(dim)`           | `tensor.unsqueeze(dim)`              |
+| Burn                                  | PyTorch Equivalent                           |
+| ------------------------------------- | -------------------------------------------- |
+| `Tensor::cat(tensors, dim)`           | `torch.cat(tensors, dim)`                    |
+| `Tensor::empty(shape, device)`        | `torch.empty(shape, device=device)`          |
+| `Tensor::from_primitive(primitive)`   | N/A                                          |
+| `Tensor::stack(tensors, dim)`         | `torch.stack(tensors, dim)`                  |
+| `tensor.all()`                        | `tensor.all()`                               |
+| `tensor.all_dim(dim)`                 | `tensor.all(dim)`                            |
+| `tensor.any()`                        | `tensor.any()`                               |
+| `tensor.any_dim(dim)`                 | `tensor.any(dim)`                            |
+| `tensor.chunk(num_chunks, dim)`       | `tensor.chunk(num_chunks, dim)`              |
+| `tensor.device()`                     | `tensor.device`                              |
+| `tensor.dims()`                       | `tensor.size()`                              |
+| `tensor.equal(other)`                 | `x == y`                                     |
+| `tensor.flatten(start_dim, end_dim)`  | `tensor.flatten(start_dim, end_dim)`         |
+| `tensor.into_data()`                  | N/A                                          |
+| `tensor.into_primitive()`             | N/A                                          |
+| `tensor.into_scalar()`                | `tensor.item()` (for single-element tensors) |
+| `tensor.narrow(dim, start, length)`   | `tensor.narrow(dim, start, length)`          |
+| `tensor.not_equal(other)`             | `x != y`                                     |
+| `tensor.repeat(2, 4)`                 | `tensor.repeat([1, 1, 4])`                   |
+| `tensor.reshape(shape)`               | `tensor.view(shape)`                         |
+| `tensor.shape()`                      | `tensor.shape`                               |
+| `tensor.slice(ranges)`                | `tensor[(*ranges,)]`                         |
+| `tensor.slice_assign(ranges, values)` | `tensor[(*ranges,)] = values`                |
+| `tensor.squeeze(dim)`                 | `tensor.squeeze(dim)`                        |
+| `tensor.to_data()`                    | N/A                                          |
+| `tensor.to_device(device)`            | `tensor.to(device)`                          |
+| `tensor.unsqueeze()`                  | `tensor.unsqueeze(0)`                        |
+| `tensor.unsqueeze_dim(dim)`           | `tensor.unsqueeze(dim)`                      |
 
 ### Numeric Operations
 
@@ -191,7 +192,6 @@ Those operations are available for numeric tensor kinds: `Float` and `Int`.
 | `tensor.greater_elem(scalar)`                                   | `tensor.gt(scalar)`                            |
 | `tensor.greater_equal(other)`                                   | `tensor.ge(other)`                             |
 | `tensor.greater_equal_elem(scalar)`                             | `tensor.ge(scalar)`                            |
-| `tensor.into_scalar()`                                          | `tensor.item()` (for single-element tensors)   |
 | `tensor.is_close(other, atol, rtol)`                            | `torch.isclose(tensor, other, atol, rtol)`     |
 | `tensor.lower(other)`                                           | `tensor.lt(other)`                             |
 | `tensor.lower_elem(scalar)`                                     | `tensor.lt(scalar)`                            |


### PR DESCRIPTION
In https://github.com/tracel-ai/burn/pull/1389, `tensor.into_scalar()` was moved to support bool tensors as well. This fixes the documentation.

## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

https://github.com/tracel-ai/burn/pull/1389

### Changes

Update the tensor section

### Testing

```
cargo xtask books burn open
```