### PR TITLE
Switched arguments in `reshape_args_usize` check

### DIFF
--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -1748,7 +1748,7 @@ impl<const D2: usize> ReshapeArgs<D2> for Shape<D2> {
         self,
         tensor: &Tensor<B, D, K>,
     ) -> Shape<D2> {
-        check!(TensorCheck::reshape_args_usize(&self, &tensor.shape()));
+        check!(TensorCheck::reshape_args_usize(&tensor.shape(), &self));
 
         self
     }
@@ -1760,7 +1760,7 @@ impl<const D2: usize> ReshapeArgs<D2> for [usize; D2] {
     ) -> Shape<D2> {
         let shape = Shape::from(self);
 
-        check!(TensorCheck::reshape_args_usize(&shape, &tensor.shape()));
+        check!(TensorCheck::reshape_args_usize(&tensor.shape(), &shape));
 
         shape
     }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

N/A

### Changes

The call to `TensorCheck::reshape_args_usize` has the arguments passed in the wrong order.

`into_shape` takes takes the orginal shape as the parameter, not self.

 These have been switched in the impls:
- `impl<const D2: usize> ReshapeArgs<D2> for Shape<D2>`
- `impl<const D2: usize> ReshapeArgs<D2> for [usize; D2]`

### Testing

Ran the test scripts. No errors created from my changes.