### PR TITLE
Truncate debug display for NestedValue

### DIFF
--- a/crates/burn-core/src/record/serde/data.rs
+++ b/crates/burn-core/src/record/serde/data.rs
@@ -7,6 +7,7 @@ use super::ser::Serializer;
 use crate::record::{PrecisionSettings, Record};
 use crate::tensor::backend::Backend;
 
+use alloc::fmt;
 use num_traits::cast::ToPrimitive;
 use regex::Regex;
 use serde::Deserialize;
@@ -14,7 +15,7 @@ use serde::Deserialize;
 /// The main data structure used for deserialization.
 ///
 /// It can hold tree-like structures of nested maps and vectors.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum NestedValue {
     /// The default value, which actually does not hold any value and it is used to indicate that
     /// the value should be populated with the default value. It contains an optional string with
@@ -283,4 +284,34 @@ where
     }
 
     Ok(result)
+}
+
+impl fmt::Debug for NestedValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            NestedValue::Vec(vec) if vec.len() > 3 => {
+                write!(f, "Vec([")?;
+                for (i, v) in vec.iter().take(3).enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{:?}", v)?;
+                }
+                write!(f, ", ...] len={})", vec.len())
+            }
+            // Handle other variants as usual
+            NestedValue::Default(origin) => f.debug_tuple("Default").field(origin).finish(),
+            NestedValue::Bool(b) => f.debug_tuple("Bool").field(b).finish(),
+            NestedValue::String(s) => f.debug_tuple("String").field(s).finish(),
+            NestedValue::F32(val) => f.debug_tuple("F32").field(val).finish(),
+            NestedValue::F64(val) => f.debug_tuple("F64").field(val).finish(),
+            NestedValue::I16(val) => f.debug_tuple("I16").field(val).finish(),
+            NestedValue::I32(val) => f.debug_tuple("I32").field(val).finish(),
+            NestedValue::I64(val) => f.debug_tuple("I64").field(val).finish(),
+            NestedValue::U16(val) => f.debug_tuple("U16").field(val).finish(),
+            NestedValue::U64(val) => f.debug_tuple("U64").field(val).finish(),
+            NestedValue::Map(map) => f.debug_map().entries(map.iter()).finish(),
+            NestedValue::Vec(vec) => f.debug_list().entries(vec.iter()).finish(),
+        }
+    }
 }


### PR DESCRIPTION
## Pull Request Template

### Related Issues/PRs

Fixes #1390

### Changes

Truncate vector values to 3 items. 

### Testing

Confirmed by running:

```
[burn]% cd crates/burn-import/pytorch-tests
[pytorch-tests]% ct remap -- --nocapture
```


```
Should decode state successfully: DeserializeError("Serde error: failed to deserialize: Expected struct but got [{\"conv\": {\"weight\": {\"id\": String(\"56fd5f5d-4b85-42cc-a499-4753fb4bc891\"), \"param\": {\"value\": Vec([F32(0.052517086), F32(-0.35977077), F32(0.17137794), ...] len=36), \"shape\": Vec([U64(6), U64(6), U64(1), ...] len=4)}}}, \"bn\": {\"bias\": {\"id\": String(\"ef0eac24-ad4d-48f1-bf2a-07864e5064b7\"), \"param\": {\"shape\": [U64(6)], \"value\": Vec([F32(0.0), F32(0.0), F32(0.0), ...] len=6)}}, \"num_batches_tracked\": {\"param\": {\"shape\": [], \"value\": [I32(1)]}, \"id\": String(\"b5a08364-4bc9-4e54-ba3e-6fbef6cc31bf\")}, \"running_mean\": {\"id\": String(\"7785c157-c6df-4728-b376-be54eee4e6b0\"), \"param\": {\"shape\": [U64(6)], \"value\": Vec([F32(-7.4505807e-10), F32(1.4901161e-9), F32(0.0), ...] len=6)}}, \"weight\": {\"id\": String(\"bd1fa6a2-11b9-4a12-9b81-a24112774b6c\"), \"param\": {\"value\": Vec([F32(1.0), F32(1.0), F32(1.0), ...] len=6), \"shape\": [U64(6)]}}, \"running_var\": {\"id\": String(\"3f24371f-6a9b-4c99-8ba9-6b9bc4375110\"), \"param\": {\"value\": Vec([F32(0.9346978), F32(0.90944827), F32(0.9705064), ...] len=6), \"shape\": [U64(6)]}}}}, {\"bn\": {\"bias\": {\"id\": String(\"84acf71c-d996-4609-b011-da30c0e66e21\"), \"param\": {\"shape\": [U64(6)], \"value\": Vec([F32(0.0), F32(0.0), F32(0.0), ...] len=6)}}, \"num_batches_tracked\": {\"param\": {\"value\": [I32(1)], \"shape\": []}, \"id\": String(\"0e4c2311-137d-4dc6-a7d9-cdeff080528a\")}, \"weight\": {\"id\": String(\"a7e9a867-0de6-4866-b22c-bd123510440f\"), \"param\": {\"shape\": [U64(6)], \"value\": Vec([F32(1.0), F32(1.0), F32(1.0), ...] len=6)}}, \"running_var\": {\"id\": String(\"65f9d478-4c92-44ea-af3f-7e306747ac1b\"), \"param\": {\"shape\": [U64(6)], \"value\": Vec([F32(0.9271742), F32(0.9247047), F32(0.93186325), ...] len=6)}}, \"running_mean\": {\"param\": {\"shape\": [U64(6)], \"value\": Vec([F32(1.8626452e-10), F32(7.4505807e-10), F32(-1.3038516e-9), ...] len=6)}, \"id\": String(\"7b69a7bf-2fe7-4958-85c6-29f6959eb4d0\")}}, \"conv\": {\"weight\": {\"param\": {\"value\": Vec([F32(0.0981475), F32(0.1144049), F32(-0.3707943), ...] len=36), \"shape\": Vec([U64(6), U64(6), U64(1), ...] len=4)}, \"id\": String(\"f31f281d-c11f-43a1-b08b-56bb1fc2c6af\")}}}]")

```