### PR TITLE
Fix tch view data corruption

### DIFF
--- a/crates/burn-tch/src/tensor.rs
+++ b/crates/burn-tch/src/tensor.rs
@@ -40,7 +40,7 @@ impl Storage {
         }
     }
 
-    /// Get the whote buffer reference.
+    /// Get the whole buffer reference.
     pub fn buffer_ref(&self) -> &StorageRef {
         match self {
             Storage::View {

--- a/crates/burn-tensor/src/tests/ops/reshape.rs
+++ b/crates/burn-tensor/src/tests/ops/reshape.rs
@@ -71,6 +71,18 @@ mod tests {
     }
 
     #[test]
+    fn should_not_corrupt_after_slice() {
+        let zeros = Tensor::<TestBackend, 1>::zeros([2], &Default::default());
+        zeros.clone().slice([1..2]).reshape([1]).exp();
+
+        // May leads to zeroes being equal to [0.0, 1.0]
+        assert_eq!(
+            zeros.to_data(),
+            Tensor::<TestBackend, 1>::zeros([2], &Default::default()).to_data()
+        );
+    }
+
+    #[test]
     #[should_panic]
     fn multiple_neg_ones() {
         let data = Data::from([0.0, 1.0, 2.0]);

--- a/crates/burn-tensor/src/tests/ops/reshape.rs
+++ b/crates/burn-tensor/src/tests/ops/reshape.rs
@@ -75,7 +75,7 @@ mod tests {
         let zeros = Tensor::<TestBackend, 1>::zeros([2], &Default::default());
         zeros.clone().slice([1..2]).reshape([1]).exp();
 
-        // May leads to zeroes being equal to [0.0, 1.0]
+        // May lead to zeroes being equal to [0.0, 1.0]
         assert_eq!(
             zeros.to_data(),
             Tensor::<TestBackend, 1>::zeros([2], &Default::default()).to_data()


### PR DESCRIPTION
When we created a partial view of a tensor, we checked if the view reference was the same as the parent reference, which obviously created a bug. It's now fixed by being explicit about what kind of reference we are tracking.

fix #1430 