### PR TITLE
[backend-comparison] Compile benches in dedicated target directory

### DIFF
--- a/backend-comparison/src/burnbenchapp/base.rs
+++ b/backend-comparison/src/burnbenchapp/base.rs
@@ -16,6 +16,7 @@ use super::{
 };
 
 const FIVE_SECONDS: time::Duration = time::Duration::new(5, 0);
+const BENCHMARKS_TARGET_DIR: &str = "target/benchmarks";
 const USER_BENCHMARK_SERVER_URL: &str = if cfg!(debug_assertions) {
     // development
     "http://localhost:8000/benchmarks"
@@ -235,6 +236,8 @@ pub(crate) fn run_backend_comparison_benchmarks(
                 &bench_str,
                 "--features",
                 &backend_str,
+                "--target-dir",
+                BENCHMARKS_TARGET_DIR,
             ];
             if let Some(t) = token {
                 args.push("--");


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

This avoids file access denied error on Windows while executing burnbench from cargo with a release build.

### Testing

```
cargo run --release --bin burnbench -- run --benches unary --backends wgpu candle-cpu tch-cpu wgpu-fusion --share
```
