### PR TITLE
Fix MNIST reference (no more huggingface)

### DIFF
--- a/burn-book/src/basic-workflow/data.md
+++ b/burn-book/src/basic-workflow/data.md
@@ -1,18 +1,18 @@
 # Data
 
 Typically, one trains a model on some dataset. Burn provides a library of very useful dataset
-sources and transformations. In particular, there are Hugging Face dataset utilities that allow to
-download and store data from Hugging Face into an SQLite database for extremely efficient data
-streaming and storage. For this guide, we will use the MNIST dataset provided by Hugging Face.
+sources and transformations, such as Hugging Face dataset utilities that allow to download and store
+data into an SQLite database for extremely efficient data streaming and storage. For this guide
+though, we will use the MNIST dataset from `burn::data::dataset::vision` which requires no external
+dependency.
 
 To iterate over a dataset efficiently, we will define a struct which will implement the `Batcher`
 trait. The goal of a batcher is to map individual dataset items into a batched tensor that can be
 used as input to our previously defined model.
 
-Let us start by defining our dataset functionalities in a file `src/data.rs`. We shall omit some of the imports for
-brevity,
-but the full code for following this guide can be found
-at `examples/guide/` [directory](https://github.com/tracel-ai/burn/tree/main/examples/guide).
+Let us start by defining our dataset functionalities in a file `src/data.rs`. We shall omit some of
+the imports for brevity, but the full code for following this guide can be found at
+`examples/guide/` [directory](https://github.com/tracel-ai/burn/tree/main/examples/guide).
 
 ```rust , ignore
 use burn::{


### PR DESCRIPTION
### Checklist

- [x] Made sure the book is up to date with changes in this PR.

### Changes

We forgot to rephrase a part of the guide in the book, which still indicated that we pulled the MNIST dataset from Hugging Face.

I still left the small reference to HF utilities though because I think it is still useful for first time users to see that they can use a dataset they might be familiar with from the HF datasets.
