### PR TITLE
Missing `Debug` derive for Group Norm Config

### DIFF
--- a/crates/burn-core/src/nn/norm/group.rs
+++ b/crates/burn-core/src/nn/norm/group.rs
@@ -7,7 +7,7 @@ use crate::tensor::backend::Backend;
 use crate::tensor::Tensor;
 
 /// Configuration to create a [GroupNorm](GroupNorm) layer.
-#[derive(Config)]
+#[derive(Debug,Config)]
 pub struct GroupNormConfig {
     /// The number of groups to separate the channels into
     pub num_groups: usize,

--- a/crates/burn-core/src/nn/norm/group.rs
+++ b/crates/burn-core/src/nn/norm/group.rs
@@ -7,7 +7,7 @@ use crate::tensor::backend::Backend;
 use crate::tensor::Tensor;
 
 /// Configuration to create a [GroupNorm](GroupNorm) layer.
-#[derive(Debug,Config)]
+#[derive(Debug, Config)]
 pub struct GroupNormConfig {
     /// The number of groups to separate the channels into
     pub num_groups: usize,

--- a/crates/burn-core/src/nn/norm/instance.rs
+++ b/crates/burn-core/src/nn/norm/instance.rs
@@ -7,7 +7,7 @@ use crate::tensor::{backend::Backend, Tensor};
 use super::{GroupNorm, GroupNormConfig};
 
 /// Configuration to create a [InstanceNorm](InstanceNorm) layer.
-#[derive(Config)]
+#[derive(Debug, Config)]
 pub struct InstanceNormConfig {
     /// The number of channels expected in the input
     num_channels: usize,

--- a/crates/burn-core/src/nn/norm/layer.rs
+++ b/crates/burn-core/src/nn/norm/layer.rs
@@ -7,7 +7,7 @@ use crate::tensor::backend::Backend;
 use crate::tensor::Tensor;
 
 /// Configuration to create a [LayerNorm](LayerNorm) layer.
-#[derive(Config)]
+#[derive(Debug, Config)]
 pub struct LayerNormConfig {
     /// The size of the input features.
     pub d_model: usize,


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ ] Confirmed that `run-checks all` script has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

I had an Issue pop up while using enums 
```rs
#[derive(Debug,Clone,Serialize,Deserialize)]
pub enum NormalizationType {
    BatchNorm(BatchNormConfig),
    GroupNorm(GroupNormConfig),
}
```
```
1. `GroupNormConfig` doesn't implement `Debug`
   the trait `Debug` is not implemented for `GroupNormConfig`, which is required by `&GroupNormConfig: Debug`
```
So I just added the derive


### Changes

Added Debug to `GroupNormConfig`

### Testing

_Describe how these changes have been tested._
