### PR TITLE
Add tensor sorting operations

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -231,8 +231,11 @@ Those operations are available for numeric tensor kinds: `Float` and `Int`.
 | `tensor.tril(diagonal)`                                         | `torch.tril(tensor, diagonal)`                 |
 | `tensor.triu(diagonal)`                                         | `torch.triu(tensor, diagonal)`                 |
 | `tensor.sort(dim)`                                              | `tensor.sort(dim).values`                      |
+| `tensor.sort_descending(dim)`                                   | `tensor.sort(dim, descending=True).values`     |
 | `tensor.sort_with_indices(dim)`                                 | `tensor.sort(dim)`                             |
+| `tensor.sort_descending_with_indices(dim)`                      | `tensor.sort(dim, descending=True)`            |
 | `tensor.argsort(dim)`                                           | `tensor.argsort(dim)`                          |
+| `tensor.argsort_descending(dim)`                                | `tensor.argsort(dim, descending=True)`         |
 
 ### Float Operations
 

--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -230,6 +230,9 @@ Those operations are available for numeric tensor kinds: `Float` and `Int`.
 | `tensor.sum_dim(dim)`                                           | `tensor.sum(dim, keepdim=True)`                |
 | `tensor.tril(diagonal)`                                         | `torch.tril(tensor, diagonal)`                 |
 | `tensor.triu(diagonal)`                                         | `torch.triu(tensor, diagonal)`                 |
+| `tensor.sort(dim)`                                              | `tensor.sort(dim).values`                      |
+| `tensor.sort_with_indices(dim)`                                 | `tensor.sort(dim)`                             |
+| `tensor.argsort(dim)`                                           | `tensor.argsort(dim)`                          |
 
 ### Float Operations
 

--- a/crates/burn-autodiff/src/ops/int_tensor.rs
+++ b/crates/burn-autodiff/src/ops/int_tensor.rs
@@ -364,4 +364,19 @@ impl<B: Backend, C: CheckpointStrategy> IntTensorOps<Self> for Autodiff<B, C> {
     fn int_prod_dim<const D: usize>(tensor: IntTensor<Self, D>, dim: usize) -> IntTensor<Self, D> {
         B::int_prod_dim(tensor, dim)
     }
+
+    fn int_sort<const D: usize>(tensor: IntTensor<Self, D>, dim: usize) -> IntTensor<Self, D> {
+        B::int_sort(tensor, dim)
+    }
+
+    fn int_sort_with_indices<const D: usize>(
+        tensor: IntTensor<Self, D>,
+        dim: usize,
+    ) -> (IntTensor<Self, D>, IntTensor<Self, D>) {
+        B::int_sort_with_indices(tensor, dim)
+    }
+
+    fn int_argsort<const D: usize>(tensor: IntTensor<Self, D>, dim: usize) -> IntTensor<Self, D> {
+        B::int_argsort(tensor, dim)
+    }
 }

--- a/crates/burn-autodiff/src/ops/int_tensor.rs
+++ b/crates/burn-autodiff/src/ops/int_tensor.rs
@@ -365,18 +365,27 @@ impl<B: Backend, C: CheckpointStrategy> IntTensorOps<Self> for Autodiff<B, C> {
         B::int_prod_dim(tensor, dim)
     }
 
-    fn int_sort<const D: usize>(tensor: IntTensor<Self, D>, dim: usize) -> IntTensor<Self, D> {
-        B::int_sort(tensor, dim)
+    fn int_sort<const D: usize>(
+        tensor: IntTensor<Self, D>,
+        dim: usize,
+        descending: bool,
+    ) -> IntTensor<Self, D> {
+        B::int_sort(tensor, dim, descending)
     }
 
     fn int_sort_with_indices<const D: usize>(
         tensor: IntTensor<Self, D>,
         dim: usize,
+        descending: bool,
     ) -> (IntTensor<Self, D>, IntTensor<Self, D>) {
-        B::int_sort_with_indices(tensor, dim)
+        B::int_sort_with_indices(tensor, dim, descending)
     }
 
-    fn int_argsort<const D: usize>(tensor: IntTensor<Self, D>, dim: usize) -> IntTensor<Self, D> {
-        B::int_argsort(tensor, dim)
+    fn int_argsort<const D: usize>(
+        tensor: IntTensor<Self, D>,
+        dim: usize,
+        descending: bool,
+    ) -> IntTensor<Self, D> {
+        B::int_argsort(tensor, dim, descending)
     }
 }

--- a/crates/burn-autodiff/src/ops/mod.rs
+++ b/crates/burn-autodiff/src/ops/mod.rs
@@ -7,6 +7,7 @@ mod module;
 mod tensor;
 
 pub(crate) mod maxmin;
+pub(crate) mod sort;
 
 pub use backward::*;
 pub use base::*;

--- a/crates/burn-autodiff/src/ops/sort.rs
+++ b/crates/burn-autodiff/src/ops/sort.rs
@@ -1,0 +1,25 @@
+use super::{unary, Backward, Ops};
+use crate::{checkpoint::base::Checkpointer, grads::Gradients};
+use burn_tensor::{backend::Backend, Shape};
+
+#[derive(Debug)]
+pub(crate) struct SortDim;
+
+impl<B: Backend, const D: usize> Backward<B, D, 1> for SortDim {
+    type State = (B::IntTensorPrimitive<D>, Shape<D>);
+
+    fn backward(
+        self,
+        ops: Ops<Self::State, 1>,
+        grads: &mut Gradients,
+        _checkpointer: &mut Checkpointer,
+    ) {
+        unary::<B, D, D, _>(ops.parents, ops.node, grads, |grad| {
+            let (indices, shape) = ops.state;
+            let device = B::float_device(&grad);
+            let zeros = B::float_zeros(shape, &device);
+
+            B::float_scatter(D - 1, zeros, indices, grad)
+        });
+    }
+}

--- a/crates/burn-autodiff/src/ops/tensor.rs
+++ b/crates/burn-autodiff/src/ops/tensor.rs
@@ -2384,6 +2384,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
     fn float_sort<const D: usize>(
         tensor: FloatTensor<Self, D>,
         dim: usize,
+        descending: bool,
     ) -> FloatTensor<Self, D> {
         match SortDim
             .prepare::<C>([tensor.node], [tensor.graph])
@@ -2392,16 +2393,20 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
         {
             OpsKind::Tracked(prep) => {
                 let shape = B::float_shape(&tensor.primitive);
-                let (tensor, indices) = B::float_sort_with_indices(tensor.primitive, dim);
+                let (tensor, indices) =
+                    B::float_sort_with_indices(tensor.primitive, dim, descending);
                 prep.finish((indices, shape), tensor)
             }
-            OpsKind::UnTracked(prep) => prep.finish(B::float_sort(tensor.primitive, dim)),
+            OpsKind::UnTracked(prep) => {
+                prep.finish(B::float_sort(tensor.primitive, dim, descending))
+            }
         }
     }
 
     fn float_sort_with_indices<const D: usize>(
         tensor: FloatTensor<Self, D>,
         dim: usize,
+        descending: bool,
     ) -> (FloatTensor<Self, D>, IntTensor<B, D>) {
         match SortDim
             .prepare::<C>([tensor.node], [tensor.graph])
@@ -2410,13 +2415,15 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
         {
             OpsKind::Tracked(prep) => {
                 let shape = B::float_shape(&tensor.primitive);
-                let (tensor, indices) = B::float_sort_with_indices(tensor.primitive, dim);
+                let (tensor, indices) =
+                    B::float_sort_with_indices(tensor.primitive, dim, descending);
                 let tensor = prep.finish((indices.clone(), shape), tensor);
 
                 (tensor, indices)
             }
             OpsKind::UnTracked(prep) => {
-                let (tensor, indices) = B::float_sort_with_indices(tensor.primitive, dim);
+                let (tensor, indices) =
+                    B::float_sort_with_indices(tensor.primitive, dim, descending);
                 let tensor = prep.finish(tensor);
 
                 (tensor, indices)
@@ -2424,8 +2431,12 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
         }
     }
 
-    fn float_argsort<const D: usize>(tensor: FloatTensor<Self, D>, dim: usize) -> IntTensor<B, D> {
-        B::float_argsort(tensor.primitive, dim)
+    fn float_argsort<const D: usize>(
+        tensor: FloatTensor<Self, D>,
+        dim: usize,
+        descending: bool,
+    ) -> IntTensor<B, D> {
+        B::float_argsort(tensor.primitive, dim, descending)
     }
 
     // TODO: Implement float_prod and float_sum

--- a/crates/burn-autodiff/src/tests/mod.rs
+++ b/crates/burn-autodiff/src/tests/mod.rs
@@ -47,6 +47,7 @@ mod sign;
 mod sin;
 mod slice;
 mod softmax;
+mod sort;
 mod sqrt;
 mod sub;
 mod tanh;
@@ -116,5 +117,6 @@ macro_rules! testgen_all {
         burn_autodiff::testgen_ad_permute!();
         burn_autodiff::testgen_ad_nonzero!();
         burn_autodiff::testgen_ad_sign!();
+        burn_autodiff::testgen_ad_sort!();
     };
 }

--- a/crates/burn-autodiff/src/tests/sort.rs
+++ b/crates/burn-autodiff/src/tests/sort.rs
@@ -1,0 +1,51 @@
+#[burn_tensor_testgen::testgen(ad_sort)]
+mod tests {
+    use super::*;
+    use burn_tensor::Data;
+
+    #[test]
+    fn should_diff_sort() {
+        let device = Default::default();
+        let tensor_1 =
+            TestAutodiffTensor::from_floats([[1.0, 7.0], [-2.0, -3.0]], &device).require_grad();
+        let tensor_2 =
+            TestAutodiffTensor::from_floats([[4.0, -7.0], [2.0, 3.0]], &device).require_grad();
+
+        let tensor_3 = tensor_1.clone().matmul(tensor_2.clone());
+        let tensor_4 = tensor_1.clone().mul(tensor_3.sort(1));
+        let grads = tensor_4.backward();
+
+        let grad_1 = tensor_1.grad(&grads).unwrap();
+        let grad_2 = tensor_2.grad(&grads).unwrap();
+
+        grad_1
+            .to_data()
+            .assert_approx_eq(&Data::from([[35.0, 35.0], [-1.0, -8.0]]), 5);
+        grad_2
+            .to_data()
+            .assert_approx_eq(&Data::from([[11.0, 7.0], [55.0, 16.0]]), 5);
+    }
+
+    #[test]
+    fn should_diff_sort_with_indices() {
+        let device = Default::default();
+        let tensor_1 =
+            TestAutodiffTensor::from_floats([[1.0, 7.0], [-2.0, -3.0]], &device).require_grad();
+        let tensor_2 =
+            TestAutodiffTensor::from_floats([[4.0, -7.0], [2.0, 3.0]], &device).require_grad();
+
+        let tensor_3 = tensor_1.clone().matmul(tensor_2.clone());
+        let tensor_4 = tensor_1.clone().mul(tensor_3.sort_with_indices(1).0);
+        let grads = tensor_4.backward();
+
+        let grad_1 = tensor_1.grad(&grads).unwrap();
+        let grad_2 = tensor_2.grad(&grads).unwrap();
+
+        grad_1
+            .to_data()
+            .assert_approx_eq(&Data::from([[35.0, 35.0], [-1.0, -8.0]]), 5);
+        grad_2
+            .to_data()
+            .assert_approx_eq(&Data::from([[11.0, 7.0], [55.0, 16.0]]), 5);
+    }
+}

--- a/crates/burn-tch/src/ops/base.rs
+++ b/crates/burn-tch/src/ops/base.rs
@@ -489,11 +489,19 @@ impl<E: tch::kind::Element + Copy + Default> TchOps<E> {
         tensor.unary_ops(|mut tensor| tensor.sign_(), |tensor| tensor.sign())
     }
 
-    pub fn sort<const D: usize>(tensor: TchTensor<E, D>, dim: usize) -> TchTensor<E, D> {
-        TchTensor::new(tensor.tensor.sort(dim as i64, false).0)
+    pub fn sort<const D: usize>(
+        tensor: TchTensor<E, D>,
+        dim: usize,
+        descending: bool,
+    ) -> TchTensor<E, D> {
+        TchTensor::new(tensor.tensor.sort(dim as i64, descending).0)
     }
 
-    pub fn argsort<const D: usize>(tensor: TchTensor<E, D>, dim: usize) -> TchTensor<i64, D> {
-        TchTensor::new(tensor.tensor.argsort(dim as i64, false))
+    pub fn argsort<const D: usize>(
+        tensor: TchTensor<E, D>,
+        dim: usize,
+        descending: bool,
+    ) -> TchTensor<i64, D> {
+        TchTensor::new(tensor.tensor.argsort(dim as i64, descending))
     }
 }

--- a/crates/burn-tch/src/ops/base.rs
+++ b/crates/burn-tch/src/ops/base.rs
@@ -488,4 +488,12 @@ impl<E: tch::kind::Element + Copy + Default> TchOps<E> {
     pub fn sign<const D: usize>(tensor: TchTensor<E, D>) -> TchTensor<E, D> {
         tensor.unary_ops(|mut tensor| tensor.sign_(), |tensor| tensor.sign())
     }
+
+    pub fn sort<const D: usize>(tensor: TchTensor<E, D>, dim: usize) -> TchTensor<E, D> {
+        TchTensor::new(tensor.tensor.sort(dim as i64, false).0)
+    }
+
+    pub fn argsort<const D: usize>(tensor: TchTensor<E, D>, dim: usize) -> TchTensor<i64, D> {
+        TchTensor::new(tensor.tensor.argsort(dim as i64, false))
+    }
 }

--- a/crates/burn-tch/src/ops/int_tensor.rs
+++ b/crates/burn-tch/src/ops/int_tensor.rs
@@ -479,4 +479,18 @@ impl<E: TchElement> IntTensorOps<Self> for LibTorch<E> {
     ) -> <LibTorch<E> as Backend>::IntTensorPrimitive<D> {
         TchOps::sign(tensor)
     }
+
+    fn int_sort<const D: usize>(
+        tensor: <LibTorch<E> as Backend>::IntTensorPrimitive<D>,
+        dim: usize,
+    ) -> <LibTorch<E> as Backend>::IntTensorPrimitive<D> {
+        TchOps::sort(tensor, dim)
+    }
+
+    fn int_argsort<const D: usize>(
+        tensor: <LibTorch<E> as Backend>::IntTensorPrimitive<D>,
+        dim: usize,
+    ) -> <LibTorch<E> as Backend>::IntTensorPrimitive<D> {
+        TchOps::argsort(tensor, dim)
+    }
 }

--- a/crates/burn-tch/src/ops/int_tensor.rs
+++ b/crates/burn-tch/src/ops/int_tensor.rs
@@ -483,14 +483,16 @@ impl<E: TchElement> IntTensorOps<Self> for LibTorch<E> {
     fn int_sort<const D: usize>(
         tensor: <LibTorch<E> as Backend>::IntTensorPrimitive<D>,
         dim: usize,
+        descending: bool,
     ) -> <LibTorch<E> as Backend>::IntTensorPrimitive<D> {
-        TchOps::sort(tensor, dim)
+        TchOps::sort(tensor, dim, descending)
     }
 
     fn int_argsort<const D: usize>(
         tensor: <LibTorch<E> as Backend>::IntTensorPrimitive<D>,
         dim: usize,
+        descending: bool,
     ) -> <LibTorch<E> as Backend>::IntTensorPrimitive<D> {
-        TchOps::argsort(tensor, dim)
+        TchOps::argsort(tensor, dim, descending)
     }
 }

--- a/crates/burn-tch/src/ops/tensor.rs
+++ b/crates/burn-tch/src/ops/tensor.rs
@@ -492,14 +492,16 @@ impl<E: TchElement> FloatTensorOps<Self> for LibTorch<E> {
     fn float_sort<const D: usize>(
         tensor: <LibTorch<E> as Backend>::FloatTensorPrimitive<D>,
         dim: usize,
+        descending: bool,
     ) -> <LibTorch<E> as Backend>::FloatTensorPrimitive<D> {
-        TchOps::sort(tensor, dim)
+        TchOps::sort(tensor, dim, descending)
     }
 
     fn float_argsort<const D: usize>(
         tensor: <LibTorch<E> as Backend>::FloatTensorPrimitive<D>,
         dim: usize,
+        descending: bool,
     ) -> <LibTorch<E> as Backend>::IntTensorPrimitive<D> {
-        TchOps::argsort(tensor, dim)
+        TchOps::argsort(tensor, dim, descending)
     }
 }

--- a/crates/burn-tch/src/ops/tensor.rs
+++ b/crates/burn-tch/src/ops/tensor.rs
@@ -488,4 +488,18 @@ impl<E: TchElement> FloatTensorOps<Self> for LibTorch<E> {
     ) -> <LibTorch<E> as Backend>::FloatTensorPrimitive<D> {
         TchOps::sign(tensor)
     }
+
+    fn float_sort<const D: usize>(
+        tensor: <LibTorch<E> as Backend>::FloatTensorPrimitive<D>,
+        dim: usize,
+    ) -> <LibTorch<E> as Backend>::FloatTensorPrimitive<D> {
+        TchOps::sort(tensor, dim)
+    }
+
+    fn float_argsort<const D: usize>(
+        tensor: <LibTorch<E> as Backend>::FloatTensorPrimitive<D>,
+        dim: usize,
+    ) -> <LibTorch<E> as Backend>::IntTensorPrimitive<D> {
+        TchOps::argsort(tensor, dim)
+    }
 }

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -775,6 +775,21 @@ impl TensorCheck {
         check
     }
 
+    pub(crate) fn sort_dim<const D: usize>(ops: &str, dim: usize) -> Self {
+        let mut check = Self::Ok;
+
+        if dim > D {
+            check = check.register(
+                ops,
+                TensorError::new(format!(
+                    "Can't sort a tensor with ({D}) dimensions on axis ({dim})"
+                )),
+            );
+        }
+
+        check
+    }
+
     /// The goal is to minimize the cost of checks when there are no error, but it's way less
     /// important when an error occurred, crafting a comprehensive error message is more important
     /// than optimizing string manipulation.

--- a/crates/burn-tensor/src/tensor/api/float.rs
+++ b/crates/burn-tensor/src/tensor/api/float.rs
@@ -270,7 +270,7 @@ where
     /// This sort is unstable (i.e., may reorder equal elements).
     #[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
     pub async fn sort(self, dim: usize) -> Tensor<B, D> {
-        Tensor::new(sort::<B, D, Float>(self.primitive, dim).await)
+        Tensor::new(sort::<B, D, Float>(self.primitive, dim, /*descending*/ false).await)
     }
 
     /// Sort the elements by value in ascending order along a given dimension.
@@ -280,7 +280,8 @@ where
     #[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
     pub async fn sort_with_indices(self, dim: usize) -> (Tensor<B, D>, Tensor<B, D, Int>) {
         check!(TensorCheck::sort_dim::<D>("Sort_with_indices", dim));
-        let (values, indices) = sort_with_indices::<B, D, Float>(self.primitive, dim).await;
+        let (values, indices) =
+            sort_with_indices::<B, D, Float>(self.primitive, dim, /*descending*/ false).await;
         (Tensor::new(values), Tensor::new(indices))
     }
 
@@ -290,6 +291,6 @@ where
     #[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
     pub async fn argsort(self, dim: usize) -> Tensor<B, D, Int> {
         check!(TensorCheck::sort_dim::<D>("Argsort", dim));
-        Tensor::new(argsort::<B, D, Float>(self.primitive, dim).await)
+        Tensor::new(argsort::<B, D, Float>(self.primitive, dim, /*descending*/ false).await)
     }
 }

--- a/crates/burn-tensor/src/tensor/api/float.rs
+++ b/crates/burn-tensor/src/tensor/api/float.rs
@@ -9,6 +9,9 @@ use crate::tensor::{Data, Distribution, Shape};
 use crate::Int;
 use crate::Tensor;
 
+#[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
+use crate::{argsort, sort, sort_with_indices, Float};
+
 impl<const D: usize, B> Tensor<B, D>
 where
     B: Backend,
@@ -260,5 +263,33 @@ where
             .transpose()
             .matmul(centered)
             .div_scalar(n as f32 - correction_factor as f32)
+    }
+
+    /// Sort the elements by value in ascending order along a given dimension.
+    ///
+    /// This sort is unstable (i.e., may reorder equal elements).
+    #[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
+    pub async fn sort(self, dim: usize) -> Tensor<B, D> {
+        Tensor::new(sort::<B, D, Float>(self.primitive, dim).await)
+    }
+
+    /// Sort the elements by value in ascending order along a given dimension.
+    /// Also returns the indices.
+    ///
+    /// This sort is unstable (i.e., may reorder equal elements).
+    #[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
+    pub async fn sort_with_indices(self, dim: usize) -> (Tensor<B, D>, Tensor<B, D, Int>) {
+        check!(TensorCheck::sort_dim::<D>("Sort_with_indices", dim));
+        let (values, indices) = sort_with_indices::<B, D, Float>(self.primitive, dim).await;
+        (Tensor::new(values), Tensor::new(indices))
+    }
+
+    /// Returns the indices that sort the elements by value in ascending order along a given dimension.
+    ///
+    /// This sort is unstable (i.e., may reorder equal elements).
+    #[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
+    pub async fn argsort(self, dim: usize) -> Tensor<B, D, Int> {
+        check!(TensorCheck::sort_dim::<D>("Argsort", dim));
+        Tensor::new(argsort::<B, D, Float>(self.primitive, dim).await)
     }
 }

--- a/crates/burn-tensor/src/tensor/api/int.rs
+++ b/crates/burn-tensor/src/tensor/api/int.rs
@@ -70,31 +70,36 @@ where
         Tensor::new(B::int_into_float(self.primitive))
     }
 
-    /// Sort the elements by value in ascending order along a given dimension.
+    /// Sort the elements by value along a given dimension.
     ///
     /// This sort is unstable (i.e., may reorder equal elements).
     #[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
-    pub async fn sort(self, dim: usize) -> Tensor<B, D, Int> {
-        Tensor::new(sort::<B, D, Int>(self.primitive, dim).await)
+    pub async fn sort(self, dim: usize, descending: bool) -> Tensor<B, D, Int> {
+        Tensor::new(sort::<B, D, Int>(self.primitive, dim, descending).await)
     }
 
-    /// Sort the elements by value in ascending order along a given dimension.
+    /// Sort the elements by value along a given dimension.
     /// Also returns the indices.
     ///
     /// This sort is unstable (i.e., may reorder equal elements).
     #[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
-    pub async fn sort_with_indices(self, dim: usize) -> (Tensor<B, D, Int>, Tensor<B, D, Int>) {
+    pub async fn sort_with_indices(
+        self,
+        dim: usize,
+        descending: bool,
+    ) -> (Tensor<B, D, Int>, Tensor<B, D, Int>) {
         check!(TensorCheck::sort_dim::<D>("Sort_with_indices", dim));
-        let (values, indices) = sort_with_indices::<B, D, Int>(self.primitive, dim).await;
+        let (values, indices) =
+            sort_with_indices::<B, D, Int>(self.primitive, dim, descending).await;
         (Tensor::new(values), Tensor::new(indices))
     }
 
-    /// Returns the indices that sort the elements by value in ascending order along a given dimension.
+    /// Returns the indices that sort the elements by value along a given dimension.
     ///
     /// This sort is unstable (i.e., may reorder equal elements).
     #[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
-    pub async fn argsort(self, dim: usize) -> Tensor<B, D, Int> {
+    pub async fn argsort(self, dim: usize, descending: bool) -> Tensor<B, D, Int> {
         check!(TensorCheck::sort_dim::<D>("Argsort", dim));
-        Tensor::new(argsort::<B, D, Int>(self.primitive, dim).await)
+        Tensor::new(argsort::<B, D, Int>(self.primitive, dim, descending).await)
     }
 }

--- a/crates/burn-tensor/src/tensor/api/mod.rs
+++ b/crates/burn-tensor/src/tensor/api/mod.rs
@@ -10,6 +10,7 @@ mod int;
 mod kind;
 mod narrow;
 mod numeric;
+mod sort;
 
 pub use argwhere::argwhere;
 pub use autodiff::*;
@@ -18,3 +19,4 @@ pub use chunk::chunk;
 pub use kind::*;
 pub use narrow::narrow;
 pub use numeric::*;
+pub use sort::{argsort, sort, sort_with_indices};

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -662,6 +662,7 @@ where
     /// Sort the elements by value in ascending order along a given dimension.
     ///
     /// This sort is unstable (i.e., may reorder equal elements).
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     pub fn sort(self, dim: usize) -> Tensor<B, D, K> {
         check!(TensorCheck::sort_dim::<D>("Sort", dim));
         Tensor::new(K::sort(self.primitive, dim))
@@ -671,6 +672,7 @@ where
     /// Also returns the indices.
     ///
     /// This sort is unstable (i.e., may reorder equal elements).
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     pub fn sort_with_indices(self, dim: usize) -> (Tensor<B, D, K>, Tensor<B, D, Int>) {
         check!(TensorCheck::sort_dim::<D>("Sort_with_indices", dim));
         let (values, indices) = K::sort_with_indices(self.primitive, dim);
@@ -680,6 +682,7 @@ where
     /// Returns the indices that sort the elements by value in ascending order along a given dimension.
     ///
     /// This sort is unstable (i.e., may reorder equal elements).
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     pub fn argsort(self, dim: usize) -> Tensor<B, D, Int> {
         check!(TensorCheck::sort_dim::<D>("Argsort", dim));
         Tensor::new(K::argsort(self.primitive, dim))
@@ -1899,6 +1902,7 @@ where
     ///
     /// Users should prefer the [Tensor::sort](Tensor::sort) function,
     /// which is more high-level and designed for public use.
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     fn sort<const D: usize>(tensor: Self::Primitive<D>, dim: usize) -> Self::Primitive<D>;
 
     /// Sort the elements of the input `tensor` by value in ascending order along a given dimension.
@@ -1923,6 +1927,7 @@ where
     /// For sorting the elements of a tensor, users should prefer the
     /// [Tensor::sort_with_indices](Tensor::sort_with_indices) function, which is more high-level
     /// and designed for public use.
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     fn sort_with_indices<const D: usize>(
         tensor: Self::Primitive<D>,
         dim: usize,
@@ -1949,6 +1954,7 @@ where
     ///
     /// Users should prefer the [Tensor::argsort](Tensor::argsort) function,
     /// which is more high-level and designed for public use.
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     fn argsort<const D: usize>(
         tensor: Self::Primitive<D>,
         dim: usize,
@@ -2265,10 +2271,12 @@ impl<B: Backend> Numeric<B> for Int {
         B::int_sign(tensor)
     }
 
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     fn sort<const D: usize>(tensor: Self::Primitive<D>, dim: usize) -> Self::Primitive<D> {
         B::int_sort(tensor, dim)
     }
 
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     fn sort_with_indices<const D: usize>(
         tensor: Self::Primitive<D>,
         dim: usize,
@@ -2276,6 +2284,7 @@ impl<B: Backend> Numeric<B> for Int {
         B::int_sort_with_indices(tensor, dim)
     }
 
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     fn argsort<const D: usize>(
         tensor: Self::Primitive<D>,
         dim: usize,
@@ -2597,10 +2606,12 @@ impl<B: Backend> Numeric<B> for Float {
         B::float_sign(tensor)
     }
 
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     fn sort<const D: usize>(tensor: Self::Primitive<D>, dim: usize) -> Self::Primitive<D> {
         B::float_sort(tensor, dim)
     }
 
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     fn sort_with_indices<const D: usize>(
         tensor: Self::Primitive<D>,
         dim: usize,
@@ -2608,6 +2619,7 @@ impl<B: Backend> Numeric<B> for Float {
         B::float_sort_with_indices(tensor, dim)
     }
 
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     fn argsort<const D: usize>(
         tensor: Self::Primitive<D>,
         dim: usize,

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -658,6 +658,32 @@ where
     ) -> Self {
         Self::new(K::random(shape.into(), distribution, device))
     }
+
+    /// Sort the elements by value in ascending order along a given dimension.
+    ///
+    /// This sort is unstable (i.e., may reorder equal elements).
+    pub fn sort(self, dim: usize) -> Tensor<B, D, K> {
+        check!(TensorCheck::sort_dim::<D>("Sort", dim));
+        Tensor::new(K::sort(self.primitive, dim))
+    }
+
+    /// Sort the elements by value in ascending order along a given dimension.
+    /// Also returns the indices.
+    ///
+    /// This sort is unstable (i.e., may reorder equal elements).
+    pub fn sort_with_indices(self, dim: usize) -> (Tensor<B, D, K>, Tensor<B, D, Int>) {
+        check!(TensorCheck::sort_dim::<D>("Sort_with_indices", dim));
+        let (values, indices) = K::sort_with_indices(self.primitive, dim);
+        (Tensor::new(values), Tensor::new(indices))
+    }
+
+    /// Returns the indices that sort the elements by value in ascending order along a given dimension.
+    ///
+    /// This sort is unstable (i.e., may reorder equal elements).
+    pub fn argsort(self, dim: usize) -> Tensor<B, D, Int> {
+        check!(TensorCheck::sort_dim::<D>("Argsort", dim));
+        Tensor::new(K::argsort(self.primitive, dim))
+    }
 }
 
 impl<B, K> Tensor<B, 2, K>
@@ -1852,6 +1878,81 @@ where
         distribution: Distribution,
         device: &B::Device,
     ) -> Self::Primitive<D>;
+
+    /// Sort the elements of the input `tensor` by value in ascending order along a given dimension.
+    ///
+    /// This sort is unstable (i.e., may reorder equal elements).
+    ///
+    /// # Arguments
+    ///
+    /// * `tensor` - The input tensor.
+    /// * `dim` - The axis along which to sort.
+    ///
+    /// # Returns
+    ///
+    /// A tensor with the same shape as the input tensor, where the elements are sorted by value.
+    ///
+    /// # Remarks
+    /// This is a low-level function used internally by the library to call different backend functions
+    /// with static dispatch. It is not designed for direct usage by users, and not recommended to import
+    /// or use this function directly.
+    ///
+    /// Users should prefer the [Tensor::sort](Tensor::sort) function,
+    /// which is more high-level and designed for public use.
+    fn sort<const D: usize>(tensor: Self::Primitive<D>, dim: usize) -> Self::Primitive<D>;
+
+    /// Sort the elements of the input `tensor` by value in ascending order along a given dimension.
+    ///
+    /// This sort is unstable (i.e., may reorder equal elements).
+    ///
+    /// # Arguments
+    ///
+    /// * `tensor` - The input tensor.
+    /// * `dim` - The axis along which to sort.
+    ///
+    /// # Returns
+    ///
+    /// A tensor with the same shape as the input tensor and corresponding indices, where
+    /// the elements are sorted by value and the indices map back to the original input tensor.
+    ///
+    /// # Remarks
+    /// This is a low-level function used internally by the library to call different backend functions
+    /// with static dispatch. It is not designed for direct usage by users, and not recommended to import
+    /// or use this function directly.
+    ///
+    /// For sorting the elements of a tensor, users should prefer the
+    /// [Tensor::sort_with_indices](Tensor::sort_with_indices) function, which is more high-level
+    /// and designed for public use.
+    fn sort_with_indices<const D: usize>(
+        tensor: Self::Primitive<D>,
+        dim: usize,
+    ) -> (Self::Primitive<D>, <Int as TensorKind<B>>::Primitive<D>);
+
+    /// Returns the indices that sort the elements of the input `tensor` by value in ascending order
+    /// along a given dimension.
+    ///
+    /// This sort is unstable (i.e., may reorder equal elements).
+    ///
+    /// # Arguments
+    ///
+    /// * `tensor` - The input tensor.
+    /// * `dim` - The axis along which to sort.
+    ///
+    /// # Returns
+    ///
+    /// A tensor with the same shape as the input tensor the indices map back to the original input tensor.
+    ///
+    /// # Remarks
+    /// This is a low-level function used internally by the library to call different backend functions
+    /// with static dispatch. It is not designed for direct usage by users, and not recommended to import
+    /// or use this function directly.
+    ///
+    /// Users should prefer the [Tensor::argsort](Tensor::argsort) function,
+    /// which is more high-level and designed for public use.
+    fn argsort<const D: usize>(
+        tensor: Self::Primitive<D>,
+        dim: usize,
+    ) -> <Int as TensorKind<B>>::Primitive<D>;
 }
 
 impl<B: Backend> Numeric<B> for Int {
@@ -2162,6 +2263,24 @@ impl<B: Backend> Numeric<B> for Int {
 
     fn sign<const D: usize>(tensor: Self::Primitive<D>) -> Self::Primitive<D> {
         B::int_sign(tensor)
+    }
+
+    fn sort<const D: usize>(tensor: Self::Primitive<D>, dim: usize) -> Self::Primitive<D> {
+        B::int_sort(tensor, dim)
+    }
+
+    fn sort_with_indices<const D: usize>(
+        tensor: Self::Primitive<D>,
+        dim: usize,
+    ) -> (Self::Primitive<D>, <Int as TensorKind<B>>::Primitive<D>) {
+        B::int_sort_with_indices(tensor, dim)
+    }
+
+    fn argsort<const D: usize>(
+        tensor: Self::Primitive<D>,
+        dim: usize,
+    ) -> <Int as TensorKind<B>>::Primitive<D> {
+        B::int_argsort(tensor, dim)
     }
 }
 
@@ -2476,6 +2595,24 @@ impl<B: Backend> Numeric<B> for Float {
 
     fn sign<const D: usize>(tensor: Self::Primitive<D>) -> Self::Primitive<D> {
         B::float_sign(tensor)
+    }
+
+    fn sort<const D: usize>(tensor: Self::Primitive<D>, dim: usize) -> Self::Primitive<D> {
+        B::float_sort(tensor, dim)
+    }
+
+    fn sort_with_indices<const D: usize>(
+        tensor: Self::Primitive<D>,
+        dim: usize,
+    ) -> (Self::Primitive<D>, <Int as TensorKind<B>>::Primitive<D>) {
+        B::float_sort_with_indices(tensor, dim)
+    }
+
+    fn argsort<const D: usize>(
+        tensor: Self::Primitive<D>,
+        dim: usize,
+    ) -> <Int as TensorKind<B>>::Primitive<D> {
+        B::float_argsort(tensor, dim)
     }
 }
 

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -1912,7 +1912,7 @@ where
         device: &B::Device,
     ) -> Self::Primitive<D>;
 
-    /// Sort the elements of the input `tensor` by value in ascending order along a given dimension.
+    /// Sort the elements of the input `tensor` by value along a given dimension.
     ///
     /// This sort is unstable (i.e., may reorder equal elements).
     ///
@@ -1940,7 +1940,7 @@ where
         descending: bool,
     ) -> Self::Primitive<D>;
 
-    /// Sort the elements of the input `tensor` by value in ascending order along a given dimension.
+    /// Sort the elements of the input `tensor` by value along a given dimension.
     ///
     /// This sort is unstable (i.e., may reorder equal elements).
     ///
@@ -1970,8 +1970,7 @@ where
         descending: bool,
     ) -> (Self::Primitive<D>, <Int as TensorKind<B>>::Primitive<D>);
 
-    /// Returns the indices that sort the elements of the input `tensor` by value in ascending order
-    /// along a given dimension.
+    /// Returns the indices that sort the elements of the input `tensor` by value along a given dimension.
     ///
     /// This sort is unstable (i.e., may reorder equal elements).
     ///

--- a/crates/burn-tensor/src/tensor/api/sort.rs
+++ b/crates/burn-tensor/src/tensor/api/sort.rs
@@ -302,8 +302,9 @@ fn sort_slice<B: Backend, const D: usize, K: BasicOps<B>>(
         .map(|(_, d)| d)
         .product();
 
-    // TODO:     run_par!(|| {
-    // iter_par!(output.axis_iter_mut(Axis(0)))
+    // TODO: run each sort in parallel
+    // run_par!(|| {
+    //     iter_range_par!(0, num_sorts).for_each(|id| {...})
     for id in 0..num_sorts {
         let mut index_offset = 0;
         let mut stride_dim = 0;

--- a/crates/burn-tensor/src/tensor/api/sort.rs
+++ b/crates/burn-tensor/src/tensor/api/sort.rs
@@ -467,8 +467,8 @@ fn dim_indices<B: Backend, const D: usize>(dims: &[usize; D], dim: usize) -> Vec
 /// Compare two elements
 fn compare<E: ElementComparison>(a: &E, b: &E, descending: bool) -> Ordering {
     if descending {
-        b.cmp(&a)
+        b.cmp(a)
     } else {
-        a.cmp(&b)
+        a.cmp(b)
     }
 }

--- a/crates/burn-tensor/src/tensor/api/sort.rs
+++ b/crates/burn-tensor/src/tensor/api/sort.rs
@@ -1,0 +1,273 @@
+use crate::{
+    backend::Backend,
+    ops::{IntElem, IntTensor},
+    BasicOps, Data, Element, ElementComparison, ElementConversion, TensorKind,
+};
+use alloc::vec::Vec;
+
+/// Sort the elements of the input `tensor` by value in ascending order along a given dimension.
+///
+/// This sort is unstable (i.e., may reorder equal elements).
+///
+/// # Arguments
+///
+/// * `tensor` - The input tensor.
+/// * `dim` - The axis along which to sort.
+///
+/// # Returns
+///
+/// A tensor with the same shape as the input tensor, where the elements are sorted by value.
+///
+/// # Remarks
+///
+/// This is a fallback solution that used only when the backend doesn't have the corresponding implementation.
+/// Ideally, it is supposed to be implemented by the backend and the backend implementation will be resolved
+/// by static dispatch. It is not designed for direct usage by users, and not recommended to import
+/// or use this function directly.
+pub fn sort<B: Backend, const D: usize, K: TensorKind<B> + BasicOps<B>>(
+    tensor: K::Primitive<D>,
+    dim: usize,
+) -> K::Primitive<D>
+where
+    <K as BasicOps<B>>::Elem: Element,
+{
+    let dims = K::shape(&tensor).dims;
+    let device = K::device(&tensor);
+    let mut data = K::into_data(tensor).read();
+
+    if D == 1 {
+        // 1D sort
+        data.value.sort_unstable_by(|&a, &b| a.cmp(&b));
+    } else {
+        sort_data::<B, D, K>(&mut data.value, &dims, dim, None, false);
+    }
+
+    K::from_data(data, &device)
+}
+
+/// Sort the elements of the input `tensor` by value in ascending order along a given dimension.
+///
+/// This sort is unstable (i.e., may reorder equal elements).
+///
+/// # Arguments
+///
+/// * `tensor` - The input tensor.
+/// * `dim` - The axis along which to sort.
+///
+/// # Returns
+///
+/// A tensor with the same shape as the input tensor and corresponding indices, where
+/// the elements are sorted by value and the indices map back to the original input tensor.
+///
+/// # Remarks
+///
+/// This is a fallback solution that used only when the backend doesn't have the corresponding implementation.
+/// Ideally, it is supposed to be implemented by the backend and the backend implementation will be resolved
+/// by static dispatch. It is not designed for direct usage by users, and not recommended to import
+/// or use this function directly.
+pub fn sort_with_indices<B: Backend, const D: usize, K: TensorKind<B> + BasicOps<B>>(
+    tensor: K::Primitive<D>,
+    dim: usize,
+) -> (K::Primitive<D>, IntTensor<B, D>)
+where
+    <K as BasicOps<B>>::Elem: Element,
+{
+    let dims = K::shape(&tensor).dims;
+    let device = K::device(&tensor);
+    let mut data = K::into_data(tensor).read();
+
+    let mut indices_data = if D == 1 {
+        (0..dims[dim])
+            .map(|i| (i as i64).elem::<IntElem<B>>())
+            .collect::<Vec<_>>()
+    } else {
+        // Dimension indices tensor
+        let numel_leading_dims: usize = dims[..dim].iter().product();
+        let numel_trailing_dims: usize = dims[dim + 1..].iter().product();
+        (0..dims[dim])
+            .map(|i| [(i as i64).elem::<IntElem<B>>()].repeat(numel_trailing_dims))
+            .collect::<Vec<_>>()
+            .concat()
+            .repeat(numel_leading_dims)
+    };
+
+    if D == 1 {
+        // 1D sort
+        indices_data.sort_unstable_by(|&a, &b| {
+            data.value[a.elem::<i64>() as usize].cmp(&data.value[b.elem::<i64>() as usize])
+        });
+    } else {
+        sort_data::<B, D, K>(&mut data.value, &dims, dim, Some(&mut indices_data), true);
+    }
+
+    let shape = data.shape.clone();
+    (
+        K::from_data(data, &device),
+        B::int_from_data(Data::new(indices_data, shape), &device),
+    )
+}
+
+/// Returns the indices that sort the elements of the input `tensor` along a given dimension.
+///
+/// This sort is unstable (i.e., may reorder equal elements).
+///
+/// # Arguments
+///
+/// * `tensor` - The input tensor.
+/// * `dim` - The axis along which to sort.
+///
+/// # Returns
+///
+/// A tensor with the same shape as the input tensor the indices map back to the original input tensor.
+///
+/// # Remarks
+///
+/// This is a fallback solution that used only when the backend doesn't have the corresponding implementation.
+/// Ideally, it is supposed to be implemented by the backend and the backend implementation will be resolved
+/// by static dispatch. It is not designed for direct usage by users, and not recommended to import
+/// or use this function directly.
+pub fn argsort<B: Backend, const D: usize, K: TensorKind<B> + BasicOps<B>>(
+    tensor: K::Primitive<D>,
+    dim: usize,
+) -> IntTensor<B, D>
+where
+    <K as BasicOps<B>>::Elem: Element,
+{
+    let dims = K::shape(&tensor).dims;
+    let device = K::device(&tensor);
+    let mut data = K::into_data(tensor).read();
+
+    let mut indices_data = if D == 1 {
+        (0..dims[dim])
+            .map(|i| (i as i64).elem::<IntElem<B>>())
+            .collect::<Vec<_>>()
+    } else {
+        // Dimension indices tensor
+        let numel_leading_dims: usize = dims[..dim].iter().product();
+        let numel_trailing_dims: usize = dims[dim + 1..].iter().product();
+        (0..dims[dim])
+            .map(|i| [(i as i64).elem::<IntElem<B>>()].repeat(numel_trailing_dims))
+            .collect::<Vec<_>>()
+            .concat()
+            .repeat(numel_leading_dims)
+    };
+
+    if D == 1 {
+        // 1D sort
+        indices_data.sort_unstable_by(|&a, &b| {
+            data.value[a.elem::<i64>() as usize].cmp(&data.value[b.elem::<i64>() as usize])
+        });
+    } else {
+        sort_data::<B, D, K>(&mut data.value, &dims, dim, Some(&mut indices_data), false);
+    }
+
+    B::int_from_data(Data::new(indices_data, data.shape), &device)
+}
+
+/// Sort the elements by value in ascending order along a given dimension.
+///
+/// When `indices` are not provided, the `data` is sorted.
+/// Otherwise, the `indices` are sorted based on the value of the elements in `data`.
+///
+/// This sort is unstable (i.e., may reorder equal elements).
+fn sort_data<B: Backend, const D: usize, K: BasicOps<B>>(
+    data: &mut [<K as BasicOps<B>>::Elem],
+    dims: &[usize; D],
+    dim: usize,
+    mut indices: Option<&mut [IntElem<B>]>,
+    permute_both: bool,
+) where
+    <K as BasicOps<B>>::Elem: Element,
+{
+    let strides = compute_strides(dims);
+    // Dimensions to access elements to sort
+    let mut sort_dims = *dims;
+    sort_dims[dim] = 1;
+    let strides_out = compute_strides(&sort_dims);
+
+    // Number of groups to sort
+    let num_sorts: usize = dims
+        .iter()
+        .enumerate()
+        .filter(|&(i, _)| i != dim)
+        .map(|(_, d)| d)
+        .product();
+
+    // TODO:     run_par!(|| {
+    // iter_par!(output.axis_iter_mut(Axis(0)))
+    for id in 0..num_sorts {
+        let mut index_offset = 0;
+        let mut stride_dim = 0;
+        let mut shape_dim = 0;
+        for d in 0..D {
+            let stride_input = strides[d];
+            let stride_output = strides_out[d];
+            let shape_output = sort_dims[d];
+
+            let num_block = id / stride_output % shape_output;
+
+            if d != dim {
+                index_offset += num_block * stride_input;
+            } else {
+                let shape_input = dims[d];
+                stride_dim = stride_input;
+                shape_dim = shape_input;
+                index_offset += num_block;
+            }
+        }
+
+        // For each group, sort the indices based on the element values
+        // NOTE: Sorting methods like `sort_unstable_by_key` are in-place but we need to sort
+        // different views/groups of the underlying data, so the swap is performed on the elements
+        // of the (flat index, element value) collection.
+        let mut elements = (0..shape_dim)
+            .map(|d| {
+                let flat_index = d * stride_dim + index_offset;
+                let elem = data[flat_index];
+                (d, flat_index, elem)
+            })
+            .collect::<Vec<_>>();
+
+        elements.sort_unstable_by(|&(_, _, a), &(_, _, b)| a.cmp(&b));
+
+        // Permute data in-place by the sorted indices
+        for idx in 0..elements.len() {
+            if elements[idx].0 != idx {
+                let mut current_idx = idx;
+                loop {
+                    let target_idx = elements[current_idx].0;
+                    elements[current_idx].0 = current_idx;
+                    if elements[target_idx].0 == target_idx {
+                        // correct position
+                        break;
+                    }
+
+                    if indices.is_none() || permute_both {
+                        // Permute data by indices
+                        data.swap(elements[current_idx].1, elements[target_idx].1);
+                    }
+
+                    if let Some(ref mut indices_data) = indices {
+                        // Permute data element indices
+                        indices_data.swap(elements[current_idx].1, elements[target_idx].1);
+                    }
+
+                    current_idx = target_idx;
+                }
+            }
+        }
+    }
+}
+
+/// Computes the steps for each dimension when traversing an array.
+fn compute_strides<const D: usize>(dims: &[usize; D]) -> [usize; D] {
+    let mut strides = [0; D];
+    let mut current = 1;
+
+    dims.iter().enumerate().rev().for_each(|(index, val)| {
+        strides[index] = current;
+        current *= val;
+    });
+
+    strides
+}

--- a/crates/burn-tensor/src/tensor/ops/bool_tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/bool_tensor.rs
@@ -1,10 +1,13 @@
 use super::{cat::cat_with_slice_assign, BoolTensor, Device, FloatTensor, IntTensor};
 use crate::{
-    argwhere, backend::Backend, chunk, narrow, tensor::Shape, Bool, Data, ElementConversion, Tensor,
+    backend::Backend, chunk, narrow, tensor::Shape, Bool, Data, ElementConversion, Tensor,
 };
 use alloc::vec::Vec;
 use burn_common::reader::Reader;
 use core::ops::Range;
+
+#[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
+use crate::argwhere;
 
 /// Bool Tensor API for basic operations, see [tensor](crate::Tensor)
 /// for documentation on each function.

--- a/crates/burn-tensor/src/tensor/ops/bool_tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/bool_tensor.rs
@@ -334,7 +334,7 @@ pub trait BoolTensorOps<B: Backend> {
     ///
     /// # Returns
     ///
-    /// A vectors of tensors
+    /// A vector of tensors
     fn bool_chunk<const D: usize>(
         tensor: BoolTensor<B, D>,
         chunks: usize,

--- a/crates/burn-tensor/src/tensor/ops/int_tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/int_tensor.rs
@@ -1,13 +1,15 @@
 use super::cat::cat_with_slice_assign;
 use super::{BoolTensor, Device, FloatTensor, IntElem, IntTensor};
 use crate::Tensor;
-use crate::{argsort, sort, sort_with_indices};
 use crate::{backend::Backend, tensor::Shape, Data, Distribution, ElementConversion, Int};
 use crate::{tensor::api::chunk, tensor::api::narrow};
 use alloc::vec::Vec;
 use burn_common::reader::Reader;
 use core::ops::Range;
 use num_traits::ToPrimitive;
+
+#[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
+use crate::{argsort, sort, sort_with_indices};
 
 /// Int Tensor API for basic and numeric operations, see [tensor](crate::Tensor)
 /// for documentation on each function.
@@ -1199,6 +1201,7 @@ pub trait IntTensorOps<B: Backend> {
     /// # Returns
     ///
     /// A tensor with the same shape as the input tensor, where the elements are sorted by value.
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     fn int_sort<const D: usize>(tensor: IntTensor<B, D>, dim: usize) -> IntTensor<B, D> {
         sort::<B, D, Int>(tensor, dim)
     }
@@ -1216,6 +1219,7 @@ pub trait IntTensorOps<B: Backend> {
     ///
     /// A tensor with the same shape as the input tensor and corresponding indices, where
     /// the elements are sorted by value and the indices map back to the original input tensor.
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     fn int_sort_with_indices<const D: usize>(
         tensor: IntTensor<B, D>,
         dim: usize,
@@ -1236,6 +1240,7 @@ pub trait IntTensorOps<B: Backend> {
     /// # Returns
     ///
     /// A tensor with the same shape as the input tensor the indices map back to the original input tensor.
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     fn int_argsort<const D: usize>(tensor: IntTensor<B, D>, dim: usize) -> IntTensor<B, D> {
         argsort::<B, D, Int>(tensor, dim)
     }

--- a/crates/burn-tensor/src/tensor/ops/int_tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/int_tensor.rs
@@ -1,6 +1,7 @@
 use super::cat::cat_with_slice_assign;
 use super::{BoolTensor, Device, FloatTensor, IntElem, IntTensor};
 use crate::Tensor;
+use crate::{argsort, sort, sort_with_indices};
 use crate::{backend::Backend, tensor::Shape, Data, Distribution, ElementConversion, Int};
 use crate::{tensor::api::chunk, tensor::api::narrow};
 use alloc::vec::Vec;
@@ -1030,8 +1031,7 @@ pub trait IntTensorOps<B: Backend> {
     ///
     /// # Returns
     ///
-    /// A vectors of tensors
-    ///
+    /// A vector of tensors
     fn int_chunk<const D: usize>(
         tensor: IntTensor<B, D>,
         chunks: usize,
@@ -1123,7 +1123,6 @@ pub trait IntTensorOps<B: Backend> {
     /// A boolean tensor `Tensor<B, D, Bool>` with the same size as input `tensor`, except in the `dim` axis
     /// where the size is 1. The elem in the `dim` axis is True if any element along this dim in the input
     /// evaluates to True, False otherwise.
-
     fn int_any_dim<const D: usize>(tensor: IntTensor<B, D>, dim: usize) -> BoolTensor<B, D> {
         let bool_tensor = B::int_equal_elem(tensor, 0.elem());
         let bool_tensor = B::bool_not(bool_tensor);
@@ -1186,5 +1185,58 @@ pub trait IntTensorOps<B: Backend> {
         let mut result = B::int_mask_fill(zeros, less_than_zero, (-1.0f32).elem());
         result = B::int_mask_fill(result, greater_than_zero, 1.0f32.elem());
         result
+    }
+
+    /// Sort the elements of the input `tensor` by value in ascending order along a given dimension.
+    ///
+    /// This sort is unstable (i.e., may reorder equal elements).
+    ///
+    /// # Arguments
+    ///
+    /// * `tensor` - The input tensor.
+    /// * `dim` - The axis along which to sort.
+    ///
+    /// # Returns
+    ///
+    /// A tensor with the same shape as the input tensor, where the elements are sorted by value.
+    fn int_sort<const D: usize>(tensor: IntTensor<B, D>, dim: usize) -> IntTensor<B, D> {
+        sort::<B, D, Int>(tensor, dim)
+    }
+
+    /// Sort the elements of the input `tensor` by value in ascending order along a given dimension.
+    ///
+    /// This sort is unstable (i.e., may reorder equal elements).
+    ///
+    /// # Arguments
+    ///
+    /// * `tensor` - The input tensor.
+    /// * `dim` - The axis along which to sort.
+    ///
+    /// # Returns
+    ///
+    /// A tensor with the same shape as the input tensor and corresponding indices, where
+    /// the elements are sorted by value and the indices map back to the original input tensor.
+    fn int_sort_with_indices<const D: usize>(
+        tensor: IntTensor<B, D>,
+        dim: usize,
+    ) -> (IntTensor<B, D>, IntTensor<B, D>) {
+        sort_with_indices::<B, D, Int>(tensor, dim)
+    }
+
+    /// Returns the indices that sort the elements of the input `tensor` by value in ascending order
+    /// along a given dimension.
+    ///
+    /// This sort is unstable (i.e., may reorder equal elements).
+    ///
+    /// # Arguments
+    ///
+    /// * `tensor` - The input tensor.
+    /// * `dim` - The axis along which to sort.
+    ///
+    /// # Returns
+    ///
+    /// A tensor with the same shape as the input tensor the indices map back to the original input tensor.
+    fn int_argsort<const D: usize>(tensor: IntTensor<B, D>, dim: usize) -> IntTensor<B, D> {
+        argsort::<B, D, Int>(tensor, dim)
     }
 }

--- a/crates/burn-tensor/src/tensor/ops/int_tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/int_tensor.rs
@@ -1189,7 +1189,7 @@ pub trait IntTensorOps<B: Backend> {
         result
     }
 
-    /// Sort the elements of the input `tensor` by value in ascending order along a given dimension.
+    /// Sort the elements of the input `tensor` by value along a given dimension.
     ///
     /// This sort is unstable (i.e., may reorder equal elements).
     ///
@@ -1197,16 +1197,21 @@ pub trait IntTensorOps<B: Backend> {
     ///
     /// * `tensor` - The input tensor.
     /// * `dim` - The axis along which to sort.
+    /// * `descending` - The sorting order.
     ///
     /// # Returns
     ///
     /// A tensor with the same shape as the input tensor, where the elements are sorted by value.
     #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
-    fn int_sort<const D: usize>(tensor: IntTensor<B, D>, dim: usize) -> IntTensor<B, D> {
-        sort::<B, D, Int>(tensor, dim)
+    fn int_sort<const D: usize>(
+        tensor: IntTensor<B, D>,
+        dim: usize,
+        descending: bool,
+    ) -> IntTensor<B, D> {
+        sort::<B, D, Int>(tensor, dim, descending)
     }
 
-    /// Sort the elements of the input `tensor` by value in ascending order along a given dimension.
+    /// Sort the elements of the input `tensor` by value along a given dimension.
     ///
     /// This sort is unstable (i.e., may reorder equal elements).
     ///
@@ -1223,11 +1228,12 @@ pub trait IntTensorOps<B: Backend> {
     fn int_sort_with_indices<const D: usize>(
         tensor: IntTensor<B, D>,
         dim: usize,
+        descending: bool,
     ) -> (IntTensor<B, D>, IntTensor<B, D>) {
-        sort_with_indices::<B, D, Int>(tensor, dim)
+        sort_with_indices::<B, D, Int>(tensor, dim, descending)
     }
 
-    /// Returns the indices that sort the elements of the input `tensor` by value in ascending order
+    /// Returns the indices that sort the elements of the input `tensor` by value
     /// along a given dimension.
     ///
     /// This sort is unstable (i.e., may reorder equal elements).
@@ -1236,12 +1242,17 @@ pub trait IntTensorOps<B: Backend> {
     ///
     /// * `tensor` - The input tensor.
     /// * `dim` - The axis along which to sort.
+    /// * `descending` - The sorting order.
     ///
     /// # Returns
     ///
     /// A tensor with the same shape as the input tensor the indices map back to the original input tensor.
     #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
-    fn int_argsort<const D: usize>(tensor: IntTensor<B, D>, dim: usize) -> IntTensor<B, D> {
-        argsort::<B, D, Int>(tensor, dim)
+    fn int_argsort<const D: usize>(
+        tensor: IntTensor<B, D>,
+        dim: usize,
+        descending: bool,
+    ) -> IntTensor<B, D> {
+        argsort::<B, D, Int>(tensor, dim, descending)
     }
 }

--- a/crates/burn-tensor/src/tensor/ops/tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/tensor.rs
@@ -1371,13 +1371,18 @@ pub trait FloatTensorOps<B: Backend> {
     ///
     /// * `tensor` - The input tensor.
     /// * `dim` - The axis along which to sort.
+    /// * `descending` - The sorting order.
     ///
     /// # Returns
     ///
     /// A tensor with the same shape as the input tensor, where the elements are sorted by value.
     #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
-    fn float_sort<const D: usize>(tensor: FloatTensor<B, D>, dim: usize) -> FloatTensor<B, D> {
-        sort::<B, D, Float>(tensor, dim)
+    fn float_sort<const D: usize>(
+        tensor: FloatTensor<B, D>,
+        dim: usize,
+        descending: bool,
+    ) -> FloatTensor<B, D> {
+        sort::<B, D, Float>(tensor, dim, descending)
     }
 
     /// Sort the elements of the input `tensor` by value in ascending order along a given dimension.
@@ -1388,6 +1393,7 @@ pub trait FloatTensorOps<B: Backend> {
     ///
     /// * `tensor` - The input tensor.
     /// * `dim` - The axis along which to sort.
+    /// * `descending` - The sorting order.
     ///
     /// # Returns
     ///
@@ -1397,8 +1403,9 @@ pub trait FloatTensorOps<B: Backend> {
     fn float_sort_with_indices<const D: usize>(
         tensor: FloatTensor<B, D>,
         dim: usize,
+        descending: bool,
     ) -> (FloatTensor<B, D>, IntTensor<B, D>) {
-        sort_with_indices::<B, D, Float>(tensor, dim)
+        sort_with_indices::<B, D, Float>(tensor, dim, descending)
     }
 
     /// Returns the indices that sort the elements of the input `tensor` by value in ascending order
@@ -1410,12 +1417,17 @@ pub trait FloatTensorOps<B: Backend> {
     ///
     /// * `tensor` - The input tensor.
     /// * `dim` - The axis along which to sort.
+    /// * `descending` - The sorting order.
     ///
     /// # Returns
     ///
     /// A tensor with the same shape as the input tensor the indices map back to the original input tensor.
     #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
-    fn float_argsort<const D: usize>(tensor: FloatTensor<B, D>, dim: usize) -> IntTensor<B, D> {
-        argsort::<B, D, Float>(tensor, dim)
+    fn float_argsort<const D: usize>(
+        tensor: FloatTensor<B, D>,
+        dim: usize,
+        descending: bool,
+    ) -> IntTensor<B, D> {
+        argsort::<B, D, Float>(tensor, dim, descending)
     }
 }

--- a/crates/burn-tensor/src/tensor/ops/tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/tensor.rs
@@ -1363,7 +1363,7 @@ pub trait FloatTensorOps<B: Backend> {
         result
     }
 
-    /// Sort the elements of the input `tensor` by value in ascending order along a given dimension.
+    /// Sort the elements of the input `tensor` by value in along a given dimension.
     ///
     /// This sort is unstable (i.e., may reorder equal elements).
     ///
@@ -1385,7 +1385,7 @@ pub trait FloatTensorOps<B: Backend> {
         sort::<B, D, Float>(tensor, dim, descending)
     }
 
-    /// Sort the elements of the input `tensor` by value in ascending order along a given dimension.
+    /// Sort the elements of the input `tensor` by value in along a given dimension.
     ///
     /// This sort is unstable (i.e., may reorder equal elements).
     ///
@@ -1408,8 +1408,7 @@ pub trait FloatTensorOps<B: Backend> {
         sort_with_indices::<B, D, Float>(tensor, dim, descending)
     }
 
-    /// Returns the indices that sort the elements of the input `tensor` by value in ascending order
-    /// along a given dimension.
+    /// Returns the indices that sort the elements of the input `tensor` by value along a given dimension.
     ///
     /// This sort is unstable (i.e., may reorder equal elements).
     ///

--- a/crates/burn-tensor/src/tensor/ops/tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/tensor.rs
@@ -1,13 +1,15 @@
 use super::cat::cat_with_slice_assign;
 use super::{BoolTensor, Device, FloatElem, FloatTensor, FullPrecisionBackend, IntElem, IntTensor};
 use crate::Tensor;
-use crate::{argsort, sort, sort_with_indices};
 use crate::{backend::Backend, tensor::Shape, Data, Distribution, ElementConversion, Float};
 use crate::{tensor::api::chunk, tensor::api::narrow};
 use alloc::vec::Vec;
 use burn_common::reader::Reader;
 use core::ops::Range;
 use num_traits::ToPrimitive;
+
+#[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
+use crate::{argsort, sort, sort_with_indices};
 
 /// Operations on float tensors.
 pub trait FloatTensorOps<B: Backend> {
@@ -1373,6 +1375,7 @@ pub trait FloatTensorOps<B: Backend> {
     /// # Returns
     ///
     /// A tensor with the same shape as the input tensor, where the elements are sorted by value.
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     fn float_sort<const D: usize>(tensor: FloatTensor<B, D>, dim: usize) -> FloatTensor<B, D> {
         sort::<B, D, Float>(tensor, dim)
     }
@@ -1390,6 +1393,7 @@ pub trait FloatTensorOps<B: Backend> {
     ///
     /// A tensor with the same shape as the input tensor and corresponding indices, where
     /// the elements are sorted by value and the indices map back to the original input tensor.
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     fn float_sort_with_indices<const D: usize>(
         tensor: FloatTensor<B, D>,
         dim: usize,
@@ -1410,6 +1414,7 @@ pub trait FloatTensorOps<B: Backend> {
     /// # Returns
     ///
     /// A tensor with the same shape as the input tensor the indices map back to the original input tensor.
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     fn float_argsort<const D: usize>(tensor: FloatTensor<B, D>, dim: usize) -> IntTensor<B, D> {
         argsort::<B, D, Float>(tensor, dim)
     }

--- a/crates/burn-tensor/src/tests/mod.rs
+++ b/crates/burn-tensor/src/tests/mod.rs
@@ -90,6 +90,7 @@ macro_rules! testgen_all {
         burn_tensor::testgen_argwhere_nonzero!();
         burn_tensor::testgen_sign!();
         burn_tensor::testgen_tri_mask!();
+        burn_tensor::testgen_sort_argsort!();
 
         // test stats
         burn_tensor::testgen_var!();

--- a/crates/burn-tensor/src/tests/ops/mod.rs
+++ b/crates/burn-tensor/src/tests/ops/mod.rs
@@ -44,6 +44,7 @@ mod select;
 mod sign;
 mod sin;
 mod slice;
+mod sort_argsort;
 mod sqrt;
 mod squeeze;
 mod stack;

--- a/crates/burn-tensor/src/tests/ops/sort_argsort.rs
+++ b/crates/burn-tensor/src/tests/ops/sort_argsort.rs
@@ -1,0 +1,290 @@
+#[burn_tensor_testgen::testgen(sort_argsort)]
+mod tests {
+    use super::*;
+    use burn_tensor::{Data, Shape, Tensor};
+
+    #[test]
+    fn test_sort_1d_int() {
+        let tensor = TestTensorInt::from([1, 4, 7, 2, 5, 6, 3, 0, 9, 8, 2, 8, -10, 42, 1000]);
+
+        // Sort along dim=0
+        let values = tensor.sort(0);
+        let values_actual = values.into_data();
+
+        let values_expected = Data::from([-10, 0, 1, 2, 2, 3, 4, 5, 6, 7, 8, 8, 9, 42, 1000]);
+        assert_eq!(values_expected, values_actual);
+    }
+
+    #[test]
+    fn test_argsort_1d_int() {
+        let tensor = TestTensorInt::from([1, 4, 7, 2, 5, 6, 3, 0, 9, 8, -10, 42, 1000]);
+
+        // Sort along dim=0
+        let indices = tensor.argsort(0);
+        let indices_actual = indices.into_data();
+
+        let indices_expected = Data::from([10, 7, 0, 3, 6, 1, 4, 5, 2, 9, 8, 11, 12]);
+        assert_eq!(indices_expected, indices_actual);
+    }
+
+    #[test]
+    fn test_sort_int() {
+        let tensor = TestTensorInt::from([[[1, 4, 7], [2, 5, 6]], [[3, 0, 9], [8, 2, 8]]]);
+
+        // Sort along dim=0
+        let values = tensor.clone().sort(0);
+        let values_actual = values.into_data();
+
+        let values_expected = Data::from([[[1, 0, 7], [2, 2, 6]], [[3, 4, 9], [8, 5, 8]]]);
+        assert_eq!(values_expected, values_actual);
+
+        // Sort along dim=1
+        let values = tensor.clone().sort(1);
+        let values_actual = values.into_data();
+
+        let values_expected = Data::from([[[1, 4, 6], [2, 5, 7]], [[3, 0, 8], [8, 2, 9]]]);
+        assert_eq!(values_expected, values_actual);
+
+        // Sort along dim=2
+        let values = tensor.sort(2);
+        let values_actual = values.into_data();
+
+        let values_expected = Data::from([[[1, 4, 7], [2, 5, 6]], [[0, 3, 9], [2, 8, 8]]]);
+        assert_eq!(values_expected, values_actual);
+    }
+
+    #[test]
+    fn test_sort_with_indices_int() {
+        let tensor = TestTensorInt::from([[[1, 4, 7], [2, 5, 6]], [[3, 0, 9], [8, 2, 8]]]);
+
+        // Sort along dim=0
+        let (values, indices) = tensor.clone().sort_with_indices(0);
+        let values_actual = values.into_data();
+        let indices_actual = indices.into_data();
+
+        let values_expected = Data::from([[[1, 0, 7], [2, 2, 6]], [[3, 4, 9], [8, 5, 8]]]);
+        assert_eq!(values_expected, values_actual);
+
+        let indices_expected = Data::from([[[0, 1, 0], [0, 1, 0]], [[1, 0, 1], [1, 0, 1]]]);
+        assert_eq!(indices_expected, indices_actual);
+
+        // Sort along dim=1
+        let (values, indices) = tensor.clone().sort_with_indices(1);
+        let values_actual = values.into_data();
+        let indices_actual = indices.into_data();
+
+        let values_expected = Data::from([[[1, 4, 6], [2, 5, 7]], [[3, 0, 8], [8, 2, 9]]]);
+        assert_eq!(values_expected, values_actual);
+
+        let indices_expected = Data::from([[[0, 0, 1], [1, 1, 0]], [[0, 0, 1], [1, 1, 0]]]);
+        assert_eq!(indices_expected, indices_actual);
+
+        // Sort along dim=2
+        let (values, indices) = tensor.sort_with_indices(2);
+        let values_actual = values.into_data();
+        let indices_actual = indices.into_data();
+
+        let values_expected = Data::from([[[1, 4, 7], [2, 5, 6]], [[0, 3, 9], [2, 8, 8]]]);
+        assert_eq!(values_expected, values_actual);
+
+        // unstable sort could return [1, 0, 2] or [1, 2, 0] since it doesn't guarantee original order
+        let indices_expected = Data::from([[[0, 1, 2], [0, 1, 2]], [[1, 0, 2], [1, 0, 2]]]);
+        if indices_expected != indices_actual {
+            assert_eq!(
+                Data::from([[[0, 1, 2], [0, 1, 2]], [[1, 0, 2], [1, 2, 0]]]),
+                indices_actual
+            );
+        }
+    }
+
+    #[test]
+    fn test_argsort_int() {
+        let tensor = TestTensorInt::from([[[1, 4, 7], [2, 5, 6]], [[3, 0, 9], [8, 2, 8]]]);
+
+        // Sort along dim=0
+        let indices = tensor.clone().argsort(0);
+        let indices_actual = indices.into_data();
+
+        let indices_expected = Data::from([[[0, 1, 0], [0, 1, 0]], [[1, 0, 1], [1, 0, 1]]]);
+        assert_eq!(indices_expected, indices_actual);
+
+        // Sort along dim=1
+        let indices = tensor.clone().argsort(1);
+        let indices_actual = indices.into_data();
+
+        let indices_expected = Data::from([[[0, 0, 1], [1, 1, 0]], [[0, 0, 1], [1, 1, 0]]]);
+        assert_eq!(indices_expected, indices_actual);
+
+        // Sort along dim=2
+        let indices = tensor.argsort(2);
+        let indices_actual = indices.into_data();
+
+        // unstable sort could return [1, 0, 2] or [1, 2, 0] since it doesn't guarantee original order
+        let indices_expected = Data::from([[[0, 1, 2], [0, 1, 2]], [[1, 0, 2], [1, 0, 2]]]);
+        if indices_expected != indices_actual {
+            assert_eq!(
+                Data::from([[[0, 1, 2], [0, 1, 2]], [[1, 0, 2], [1, 2, 0]]]),
+                indices_actual
+            );
+        }
+    }
+
+    #[test]
+    fn test_sort_1d_float() {
+        let tensor = TestTensor::from([
+            0.5, 1.2, -0.21, 0., 2.1, 0.94, -0.3, 2.3, 199.412, 4., 0.99, 3., -8.1,
+        ]);
+
+        // Sort along dim=0
+        let values = tensor.sort(0);
+        let values_actual = values.into_data();
+
+        let values_expected = Data::from([
+            -8.1, -0.3, -0.21, 0., 0.5, 0.94, 0.99, 1.2, 2.1, 2.3, 3., 4., 199.412,
+        ]);
+        values_expected.assert_approx_eq(&values_actual, 5);
+    }
+
+    #[test]
+    fn test_argsort_1d_float() {
+        let tensor = TestTensor::from([
+            0.5, 1.2, -0.21, 0., 2.1, 0.94, -0.3, 2.3, 199.412, 4., 0.99, 3., -8.1,
+        ]);
+
+        // Sort along dim=0
+        let indices = tensor.argsort(0);
+        let indices_actual = indices.into_data();
+
+        let indices_expected = Data::from([12, 6, 2, 3, 0, 5, 10, 1, 4, 7, 11, 9, 8]);
+        assert_eq!(indices_expected, indices_actual);
+    }
+
+    #[test]
+    fn test_sort_float() {
+        let tensor = TestTensor::from([
+            [[-0.5, 1.2, -0.21], [0., 2.1, 0.94]],
+            [[-0.3, 2.3, 4.], [0.99, 3., -8.1]],
+        ]);
+
+        // Sort along dim=0
+        let values = tensor.clone().sort(0);
+        let values_actual = values.into_data();
+
+        let values_expected = Data::from([
+            [[-0.5, 1.2, -0.21], [0., 2.1, -8.1]],
+            [[-0.3, 2.3, 4.], [0.99, 3., 0.94]],
+        ]);
+        values_expected.assert_approx_eq(&values_actual, 5);
+
+        // Sort along dim=1
+        let values = tensor.clone().sort(1);
+        let values_actual = values.into_data();
+
+        let values_expected = Data::from([
+            [[-0.5, 1.2, -0.21], [0., 2.1, 0.94]],
+            [[-0.3, 2.3, -8.1], [0.99, 3., 4.]],
+        ]);
+        values_expected.assert_approx_eq(&values_actual, 5);
+
+        // Sort along dim=2
+        let values = tensor.sort(2);
+        let values_actual = values.into_data();
+
+        let values_expected = Data::from([
+            [[-0.5, -0.21, 1.2], [0., 0.94, 2.1]],
+            [[-0.3, 2.3, 4.], [-8.1, 0.99, 3.]],
+        ]);
+        values_expected.assert_approx_eq(&values_actual, 5);
+    }
+
+    #[test]
+    fn test_sort_with_indices_float() {
+        let tensor = TestTensor::from([
+            [[-0.5, 1.2, -0.21], [0., 2.1, 0.94]],
+            [[-0.3, 2.3, 4.], [0.99, 3., -8.1]],
+        ]);
+
+        // Sort along dim=0
+        let (values, indices) = tensor.clone().sort_with_indices(0);
+        let values_actual = values.into_data();
+        let indices_actual = indices.into_data();
+
+        let values_expected = Data::from([
+            [[-0.5, 1.2, -0.21], [0., 2.1, -8.1]],
+            [[-0.3, 2.3, 4.], [0.99, 3., 0.94]],
+        ]);
+        values_expected.assert_approx_eq(&values_actual, 5);
+
+        let indices_expected = Data::from([[[0, 0, 0], [0, 0, 1]], [[1, 1, 1], [1, 1, 0]]]);
+        assert_eq!(indices_expected, indices_actual);
+
+        // Sort along dim=1
+        let (values, indices) = tensor.clone().sort_with_indices(1);
+        let values_actual = values.into_data();
+        let indices_actual = indices.into_data();
+
+        let values_expected = Data::from([
+            [[-0.5, 1.2, -0.21], [0., 2.1, 0.94]],
+            [[-0.3, 2.3, -8.1], [0.99, 3., 4.]],
+        ]);
+        values_expected.assert_approx_eq(&values_actual, 5);
+
+        let indices_expected = Data::from([[[0, 0, 0], [1, 1, 1]], [[0, 0, 1], [1, 1, 0]]]);
+        assert_eq!(indices_expected, indices_actual);
+
+        // Sort along dim=2
+        let (values, indices) = tensor.sort_with_indices(2);
+        let values_actual = values.into_data();
+        let indices_actual = indices.into_data();
+
+        let values_expected = Data::from([
+            [[-0.5, -0.21, 1.2], [0., 0.94, 2.1]],
+            [[-0.3, 2.3, 4.], [-8.1, 0.99, 3.]],
+        ]);
+        values_expected.assert_approx_eq(&values_actual, 5);
+
+        let indices_expected = Data::from([[[0, 2, 1], [0, 2, 1]], [[0, 1, 2], [2, 0, 1]]]);
+        assert_eq!(indices_expected, indices_actual);
+    }
+
+    #[test]
+    fn test_argsort_float() {
+        let tensor = TestTensor::from([
+            [[-0.5, 1.2, -0.21], [0., 2.1, 0.94]],
+            [[-0.3, 2.3, 4.], [0.99, 3., -8.1]],
+        ]);
+
+        // Sort along dim=0
+        let indices = tensor.clone().argsort(0);
+        let indices_actual = indices.into_data();
+
+        let indices_expected = Data::from([[[0, 0, 0], [0, 0, 1]], [[1, 1, 1], [1, 1, 0]]]);
+        assert_eq!(indices_expected, indices_actual);
+
+        // Sort along dim=1
+        let indices = tensor.clone().argsort(1);
+        let indices_actual = indices.into_data();
+
+        let indices_expected = Data::from([[[0, 0, 0], [1, 1, 1]], [[0, 0, 1], [1, 1, 0]]]);
+        assert_eq!(indices_expected, indices_actual);
+
+        // Sort along dim=2
+        let indices = tensor.argsort(2);
+        let indices_actual = indices.into_data();
+
+        let indices_expected = Data::from([[[0, 2, 1], [0, 2, 1]], [[0, 1, 2], [2, 0, 1]]]);
+        assert_eq!(indices_expected, indices_actual);
+    }
+
+    #[test]
+    fn test_sort_float_nan() {
+        let tensor = TestTensor::from([[-0.5, f32::NAN], [0., 0.94], [-0.3, f32::NAN]]);
+
+        // Sort along dim=0
+        let values = tensor.sort(0);
+        let values_actual = values.into_data();
+
+        let values_expected = Data::from([[-0.5, 0.94], [-0.3, f32::NAN], [0., f32::NAN]]);
+        values_expected.assert_approx_eq(&values_actual, 5);
+    }
+}

--- a/crates/burn-tensor/src/tests/ops/sort_argsort.rs
+++ b/crates/burn-tensor/src/tests/ops/sort_argsort.rs
@@ -28,6 +28,37 @@ mod tests {
     }
 
     #[test]
+    fn test_sort_with_indices_descending_int() {
+        // 1D
+        let tensor = TestTensorInt::from([1, 4, 7, 2, 5, 6, 3, 0, 9, 8, -10, 42, 1000]);
+
+        // Sort along dim=0
+        let (values, indices) = tensor.sort_descending_with_indices(0);
+        let values_actual = values.into_data();
+        let indices_actual = indices.into_data();
+
+        let values_expected = Data::from([1000, 42, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -10]);
+        assert_eq!(values_expected, values_actual);
+
+        let indices_expected = Data::from([12, 11, 8, 9, 2, 5, 4, 1, 6, 3, 0, 7, 10]);
+        assert_eq!(indices_expected, indices_actual);
+
+        // 2D
+        let tensor = TestTensorInt::from([[[1, 4, 7], [2, 5, 6]], [[3, 0, 9], [8, 2, 8]]]);
+
+        // Sort along dim=1
+        let (values, indices) = tensor.sort_descending_with_indices(1);
+        let values_actual = values.into_data();
+        let indices_actual = indices.into_data();
+
+        let values_expected = Data::from([[[2, 5, 7], [1, 4, 6]], [[8, 2, 9], [3, 0, 8]]]);
+        assert_eq!(values_expected, values_actual);
+
+        let indices_expected = Data::from([[[1, 1, 0], [0, 0, 1]], [[1, 1, 0], [0, 0, 1]]]);
+        assert_eq!(indices_expected, indices_actual);
+    }
+
+    #[test]
     fn test_sort_int() {
         let tensor = TestTensorInt::from([[[1, 4, 7], [2, 5, 6]], [[3, 0, 9], [8, 2, 8]]]);
 
@@ -156,6 +187,47 @@ mod tests {
         let indices_actual = indices.into_data();
 
         let indices_expected = Data::from([12, 6, 2, 3, 0, 5, 10, 1, 4, 7, 11, 9, 8]);
+        assert_eq!(indices_expected, indices_actual);
+    }
+
+    #[test]
+    fn test_sort_with_indices_descending_float() {
+        // 1D
+        let tensor = TestTensor::from([
+            0.5, 1.2, -0.21, 0., 2.1, 0.94, -0.3, 2.3, 199.412, 4., 0.99, 3., -8.1,
+        ]);
+
+        // Sort along dim=0
+        let (values, indices) = tensor.sort_descending_with_indices(0);
+        let values_actual = values.into_data();
+        let indices_actual = indices.into_data();
+
+        let values_expected = Data::from([
+            199.412, 4., 3., 2.3, 2.1, 1.2, 0.99, 0.94, 0.5, 0., -0.21, -0.3, -8.1,
+        ]);
+        values_expected.assert_approx_eq(&values_actual, 5);
+
+        let indices_expected = Data::from([8, 9, 11, 7, 4, 1, 10, 5, 0, 3, 2, 6, 12]);
+        assert_eq!(indices_expected, indices_actual);
+
+        // 2D
+        let tensor = TestTensor::from([
+            [[-0.5, 1.2, -0.21], [0., 2.1, 0.94]],
+            [[-0.3, 2.3, 4.], [0.99, 3., -8.1]],
+        ]);
+
+        // Sort along dim=1
+        let (values, indices) = tensor.sort_descending_with_indices(1);
+        let values_actual = values.into_data();
+        let indices_actual = indices.into_data();
+
+        let values_expected = Data::from([
+            [[0., 2.1, 0.94], [-0.5, 1.2, -0.21]],
+            [[0.99, 3., 4.], [-0.3, 2.3, -8.1]],
+        ]);
+        values_expected.assert_approx_eq(&values_actual, 5);
+
+        let indices_expected = Data::from([[[1, 1, 1], [0, 0, 0]], [[1, 1, 0], [0, 0, 1]]]);
         assert_eq!(indices_expected, indices_actual);
     }
 


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Closes #1369
Unblocks easy implementation for `topk` issue #1421

### Changes

Added `sort(dim)`, `sort_with_indices(dim)` and `argsort(dim)` numeric tensor ops.
Also added `sort_descending(dim)`, `sort_descending_with_indices(dim)` and `argsort_descending(dim)` for sorting in descending order.

- Added `ElementComparison` trait for `Element` so elements can return an ordering (as required by `sort` methods)
- Implemented default tensor ops for all backends
- Implemented for `tch` backend
- Added autodiff backward

**TODO**
- [ ] Parallelize default implementation loop with rayon
  - *Note: we have `run_par`, `iter_par` and `iter_range_par` macros defined in burn-ndarray*

### Testing

Forward and backward unit tests.
