### PR TITLE
[backend-comparison] Add system information to benchmark results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,7 @@ dependencies = [
  "serial_test",
  "strum",
  "strum_macros",
+ "sysinfo",
 ]
 
 [[package]]
@@ -2090,7 +2091,7 @@ dependencies = [
  "presser",
  "thiserror",
  "winapi",
- "windows",
+ "windows 0.51.1",
 ]
 
 [[package]]
@@ -4394,9 +4395,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.29.11"
+version = "0.30.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd727fc423c2060f6c92d9534cef765c65a6ed3f428a03d7def74a8c4348e666"
+checksum = "0c385888ef380a852a16209afc8cfad22795dd8873d69c9a14d2e2088f118d18"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -4404,7 +4405,8 @@ dependencies = [
  "ntapi",
  "once_cell",
  "rayon",
- "winapi",
+ "serde",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -5249,6 +5251,16 @@ checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
 dependencies = [
  "windows-core 0.51.1",
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "sysinfo",
+ "wgpu",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,7 @@ dependencies = [
  "arboard",
  "burn",
  "burn-common",
+ "burn-wgpu",
  "clap 4.5.2",
  "crossterm",
  "derive-new",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ uuid = { version = "1.5.0", default-features = false }
 libc = "0.2.153"
 tch = "0.15.0"
 nvml-wrapper = "0.9.0"
-sysinfo = "0.29.10"
+sysinfo = "0.30.7"
 systemstat = "0.2.3"
 
 

--- a/backend-comparison/Cargo.toml
+++ b/backend-comparison/Cargo.toml
@@ -29,6 +29,7 @@ wgpu-fusion = ["wgpu", "burn/fusion"]
 arboard = { workspace = true }
 burn = { path = "../crates/burn", default-features = false }
 burn-common = { path = "../crates/burn-common", version = "0.13.0" }
+burn-wgpu = { path = "../crates/burn-wgpu", version = "0.13.0" }
 clap = { workspace = true }
 crossterm = { workspace = true, optional = true }
 derive-new = { workspace = true }

--- a/backend-comparison/Cargo.toml
+++ b/backend-comparison/Cargo.toml
@@ -41,6 +41,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
+sysinfo = { workspace = true, features = ["serde"] }
+wgpu = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/backend-comparison/src/persistence/mod.rs
+++ b/backend-comparison/src/persistence/mod.rs
@@ -1,2 +1,4 @@
 mod base;
+mod system_info;
+
 pub use base::*;

--- a/backend-comparison/src/persistence/system_info.rs
+++ b/backend-comparison/src/persistence/system_info.rs
@@ -1,4 +1,5 @@
 use burn::serde::{Deserialize, Serialize};
+use burn_wgpu::GraphicsApi;
 use std::collections::HashSet;
 use sysinfo;
 use wgpu;
@@ -32,7 +33,7 @@ impl BenchmarkSystemInfo {
     fn enumerate_gpus() -> Vec<String> {
         let instance = wgpu::Instance::default();
         let adapters: Vec<wgpu::Adapter> = instance
-            .enumerate_adapters(wgpu::Backends::all())
+            .enumerate_adapters(burn_wgpu::AutoGraphicsApi::backend().into())
             .filter(|adapter| {
                 let info = adapter.get_info();
                 info.device_type == wgpu::DeviceType::DiscreteGpu

--- a/backend-comparison/src/persistence/system_info.rs
+++ b/backend-comparison/src/persistence/system_info.rs
@@ -36,6 +36,7 @@ impl BenchmarkSystemInfo {
             .filter(|adapter| {
                 let info = adapter.get_info();
                 info.device_type == wgpu::DeviceType::DiscreteGpu
+                    || info.device_type == wgpu::DeviceType::IntegratedGpu
             })
             .collect();
         let gpu_names: HashSet<String> = adapters

--- a/backend-comparison/src/persistence/system_info.rs
+++ b/backend-comparison/src/persistence/system_info.rs
@@ -1,0 +1,50 @@
+use burn::serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use sysinfo;
+use wgpu;
+
+#[derive(Default, Clone, Serialize, Deserialize)]
+pub(crate) struct BenchmarkSystemInfo {
+    cpus: Vec<String>,
+    gpus: Vec<String>,
+}
+
+impl BenchmarkSystemInfo {
+    pub(crate) fn new() -> Self {
+        Self {
+            cpus: BenchmarkSystemInfo::enumerate_cpus(),
+            gpus: BenchmarkSystemInfo::enumerate_gpus(),
+        }
+    }
+
+    fn enumerate_cpus() -> Vec<String> {
+        let system = sysinfo::System::new_with_specifics(
+            sysinfo::RefreshKind::new().with_cpu(sysinfo::CpuRefreshKind::everything()),
+        );
+        let cpu_names: HashSet<String> = system
+            .cpus()
+            .iter()
+            .map(|c| c.brand().to_string())
+            .collect();
+        cpu_names.into_iter().collect()
+    }
+
+    fn enumerate_gpus() -> Vec<String> {
+        let instance = wgpu::Instance::default();
+        let adapters: Vec<wgpu::Adapter> = instance
+            .enumerate_adapters(wgpu::Backends::all())
+            .filter(|adapter| {
+                let info = adapter.get_info();
+                info.device_type == wgpu::DeviceType::DiscreteGpu
+            })
+            .collect();
+        let gpu_names: HashSet<String> = adapters
+            .iter()
+            .map(|adapter| {
+                let info = adapter.get_info();
+                info.name
+            })
+            .collect();
+        gpu_names.into_iter().collect()
+    }
+}

--- a/crates/burn-train/src/metric/cpu_use.rs
+++ b/crates/burn-train/src/metric/cpu_use.rs
@@ -1,7 +1,7 @@
 use super::{MetricMetadata, Numeric};
 use crate::metric::{Metric, MetricEntry};
 use std::time::{Duration, Instant};
-use sysinfo::{CpuExt, CpuRefreshKind, RefreshKind, System, SystemExt};
+use sysinfo::{CpuRefreshKind, RefreshKind, System};
 
 /// General CPU Usage metric
 pub struct CpuUse {

--- a/crates/burn-train/src/metric/memory_use.rs
+++ b/crates/burn-train/src/metric/memory_use.rs
@@ -2,7 +2,7 @@
 use super::{MetricMetadata, Numeric};
 use crate::metric::{Metric, MetricEntry};
 use std::time::{Duration, Instant};
-use sysinfo::{System, SystemExt};
+use sysinfo::System;
 
 /// Memory information
 pub struct CpuMemory {


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

https://github.com/tracel-ai/burn/issues/1072

### Changes

Add system information using `sysinfo` crate for the CPUs and `wgpu` crate for the GPUs.

