### PR TITLE
[backend-comparison] Add Operating System information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,7 @@ dependencies = [
  "derive-new",
  "dirs 5.0.1",
  "github-device-flow",
+ "os_info",
  "rand",
  "ratatui",
  "reqwest",
@@ -216,6 +217,7 @@ dependencies = [
  "strum_macros",
  "sysinfo",
  "wgpu",
+ "wsl",
 ]
 
 [[package]]
@@ -3191,6 +3193,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "os_info"
+version = "3.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae99c7fa6dd38c7cafe1ec085e804f8f555a2f8659b0dbe03f1f9963a9b51092"
+dependencies = [
+ "log",
+ "serde",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5436,6 +5449,12 @@ dependencies = [
  "quote",
  "syn 2.0.55",
 ]
+
+[[package]]
+name = "wsl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dab7ac864710bdea6594becbea5b5050333cf34fefb0dc319567eb347950d4"
 
 [[package]]
 name = "x11rb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,9 +90,11 @@ text_placeholder = "0.5.0"
 pollster = "0.3"
 wgpu = "0.18.0"
 
-# Burnbench
+# Benchmarks and Burnbench
 arboard = "3.3.2"
 github-device-flow = "0.2.0"
+os_info = "3.8.2"
+wsl = "0.1.0"
 
 bincode = { version = "2.0.0-rc.3", features = [
     "alloc",

--- a/backend-comparison/Cargo.toml
+++ b/backend-comparison/Cargo.toml
@@ -34,7 +34,8 @@ clap = { workspace = true }
 crossterm = { workspace = true, optional = true }
 derive-new = { workspace = true }
 dirs = { workspace = true }
-github-device-flow  = { workspace = true }
+github-device-flow = { workspace = true }
+os_info = { workspace = true }
 rand = { workspace = true }
 ratatui = { workspace = true, optional = true }
 reqwest = {workspace = true, features = ["blocking", "json"]}
@@ -44,6 +45,7 @@ strum = { workspace = true }
 strum_macros = { workspace = true }
 sysinfo = { workspace = true, features = ["serde"] }
 wgpu = { workspace = true }
+wsl = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/backend-comparison/src/persistence/system_info.rs
+++ b/backend-comparison/src/persistence/system_info.rs
@@ -8,8 +8,23 @@ use wgpu;
 pub(crate) struct BenchmarkSystemInfo {
     cpus: Vec<String>,
     gpus: Vec<String>,
-    os_info: os_info::Info,
+    os: BenchmarkOSInfo,
+}
+
+#[derive(Default, Clone, Serialize, Deserialize)]
+pub(crate) struct BenchmarkOSInfo {
+    name: String,
+    #[serde(rename = "wsl")]
     windows_linux_subsystem: bool,
+}
+
+impl From<os_info::Info> for BenchmarkOSInfo {
+    fn from(info: os_info::Info) -> Self {
+        BenchmarkOSInfo {
+            name: format!("{}", info),
+            windows_linux_subsystem: wsl::is_wsl(),
+        }
+    }
 }
 
 impl BenchmarkSystemInfo {
@@ -17,8 +32,7 @@ impl BenchmarkSystemInfo {
         Self {
             cpus: BenchmarkSystemInfo::enumerate_cpus(),
             gpus: BenchmarkSystemInfo::enumerate_gpus(),
-            os_info: os_info::get(),
-            windows_linux_subsystem: wsl::is_wsl(),
+            os: BenchmarkOSInfo::from(os_info::get()),
         }
     }
 

--- a/backend-comparison/src/persistence/system_info.rs
+++ b/backend-comparison/src/persistence/system_info.rs
@@ -8,6 +8,8 @@ use wgpu;
 pub(crate) struct BenchmarkSystemInfo {
     cpus: Vec<String>,
     gpus: Vec<String>,
+    os_info: os_info::Info,
+    windows_linux_subsystem: bool,
 }
 
 impl BenchmarkSystemInfo {
@@ -15,6 +17,8 @@ impl BenchmarkSystemInfo {
         Self {
             cpus: BenchmarkSystemInfo::enumerate_cpus(),
             gpus: BenchmarkSystemInfo::enumerate_gpus(),
+            os_info: os_info::get(),
+            windows_linux_subsystem: wsl::is_wsl(),
         }
     }
 


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

https://github.com/tracel-ai/burn/issues/1519

### Changes

Serialize the operating system information and detect the windows linux subsystem. 

Examples:

- Linux under WSL on Windows:

```json
  "systemInfo": {
    "cpus": [
      "13th Gen Intel(R) Core(TM) i7-13700K"
    ],
    "gpus": [
      "Microsoft Direct3D12 (NVIDIA GeForce RTX 4080)"
    ],
    "os_info": {
      "os_type": "Ubuntu",
      "version": {
        "Semantic": [
          20,
          4,
          0
        ]
      },
      "edition": null,
      "codename": "focal",
      "bitness": "X64",
      "architecture": "x86_64"
    },
    "windows_linux_subsystem": true
  },
```

- Windows

```json
  "systemInfo": {
    "cpus": [
      "13th Gen Intel(R) Core(TM) i7-13700K"
    ],
    "gpus": [
      "NVIDIA GeForce RTX 4080"
    ],
    "os_info": {
      "os_type": "Windows",
      "version": {
        "Semantic": [
          10,
          0,
          22621
        ]
      },
      "edition": "Windows 11 Core",
      "codename": null,
      "bitness": "X64",
      "architecture": "x86_64"
    },
    "windows_linux_subsystem": false
  },
```