### PR TITLE
Tweak/add kind to gelu benchmark name

### DIFF
--- a/backend-comparison/benches/custom_gelu.rs
+++ b/backend-comparison/benches/custom_gelu.rs
@@ -27,10 +27,9 @@ impl<B: Backend, const D: usize> Benchmark for CustomGeluBenchmark<B, D> {
 
     fn name(&self) -> String {
         match self.autodiff {
-            true => "gelu_autodiff",
-            false => "gelu",
+            true => format!("gelu_autodiff_{:?}", self.kind),
+            false => format!("gelu_{:?}", self.kind),
         }
-        .into()
     }
 
     fn options(&self) -> Option<String> {

--- a/backend-comparison/src/persistence/base.rs
+++ b/backend-comparison/src/persistence/base.rs
@@ -242,20 +242,33 @@ pub(crate) struct BenchmarkCollection {
 
 impl Display for BenchmarkCollection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Compute the max length for each column
+        let mut max_name_len = 0;
+        let mut max_backend_len = 0;
+        for record in self.records.iter() {
+            let backend_name = [record.backend.clone(), record.device.clone()].join("-");
+            max_name_len = max_name_len.max(record.results.name.len());
+            max_backend_len = max_backend_len.max(backend_name.len());
+        }
+        // Header
         writeln!(
             f,
-            "| {0:<15}| {1:<35}| {2:<15}|\n|{3:-<16}|{4:-<36}|{5:-<16}|",
-            "Benchmark", "Backend", "Median", "", "", ""
+            "| {:<width_name$} | {:<width_backend$} | Median         |\n|{:->width_name$}--|{:->width_backend$}--|----------------|",
+            "Benchmark", "Backend", "", "", width_name = max_name_len, width_backend = max_backend_len
         )?;
+        // Table entries
         for record in self.records.iter() {
-            let backend = [record.backend.clone(), record.device.clone()].join("-");
+            let backend_name = [record.backend.clone(), record.device.clone()].join("-");
             writeln!(
                 f,
-                "| {0:<15}| {1:<35}| {2:<15.3?}|",
-                record.results.name, backend, record.results.computed.median
+                "| {:<width_name$} | {:<width_backend$} | {:<15.3?}|",
+                record.results.name,
+                backend_name,
+                record.results.computed.median,
+                width_name = max_name_len,
+                width_backend = max_backend_len
             )?;
         }
-
         Ok(())
     }
 }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

[_Provide links to relevant issues and dependent PRs._](https://github.com/tracel-ai/burn/issues/1518)

### Changes

Add the kind to gelu benchmark name. Also compute the space required in each column of the report table. 

This gives the following names:

| Benchmark                      | Backend     | Median         |
|--------------------------------|-------------|----------------|
| gelu_Reference                 | ndarray-Cpu | 126.145ms      |
| gelu_WithReferenceErf          | ndarray-Cpu | 128.295ms      |
| gelu_WithCustomErf             | ndarray-Cpu | 724.286ms      |
| gelu_autodiff_Reference        | ndarray-Cpu | 814.613ms      |
| gelu_autodiff_WithReferenceErf | ndarray-Cpu | 398.498ms      |
| gelu_autodiff_WithCustomErf    | ndarray-Cpu | 2.525s         |


