### PR TITLE
remove exit

### DIFF
--- a/examples/image-classification-web/build-for-web.sh
+++ b/examples/image-classification-web/build-for-web.sh
@@ -4,7 +4,6 @@ rustup target add wasm32-unknown-unknown
 if ! command -v wasm-pack &>/dev/null; then
     echo "wasm-pack could not be found. Installing ..."
     cargo install wasm-pack
-    exit
 fi
 
 mkdir -p pkg

--- a/examples/mnist-inference-web/build-for-web.sh
+++ b/examples/mnist-inference-web/build-for-web.sh
@@ -7,7 +7,6 @@ if ! command -v wasm-pack &> /dev/null
 then
     echo "wasm-pack could not be found. Installing ..."
     cargo install wasm-pack
-    exit
 fi
 
 # Set optimization flags


### PR DESCRIPTION
## Pull Request Template

^ deleted because this is a trivial PR.

I deleted `exit` from `build-for-web.sh` because I'm not sure why you'd exit after installing `wasm-pack`. It was added in these PRs https://github.com/tracel-ai/burn/pull/228 https://github.com/tracel-ai/burn/pull/840 Perhaps it was a left over copypate from `echo "python3 could not be found. Running server requires python3."`? Tagging @antimora because I think he'll know best