### PR TITLE
Numerically stable `log_sigmoid`

### DIFF
--- a/crates/burn-tensor/src/tensor/activation/base.rs
+++ b/crates/burn-tensor/src/tensor/activation/base.rs
@@ -125,13 +125,38 @@ pub fn sigmoid<const D: usize, B: Backend>(tensor: Tensor<B, D>) -> Tensor<B, D>
 
 /// Applies the log sigmoid function.
 pub fn log_sigmoid<const D: usize, B: Backend>(tensor: Tensor<B, D>) -> Tensor<B, D> {
+    /// To avoid overflow, we use the log-sum-exp trick.
+    ///
+    /// ```ignore
+    /// log(sigmoid(x)) = log(1/(1 + exp(-x)))
+    ///                 = log(1) - log(1 + exp(-x))
+    ///                 = -log(1 + exp(-x))
+    ///                 = -log(exp(0) + exp(-x))
+    /// ```
+    /// The `exp(t)` of even a moderate-magnitude positive number can be astronomically huge, so we
+    /// subtract the `max(t, 0)` of each value (where `t = -x` in this case). This results in the
+    /// following equivalence:
+    /// ```ignore
+    /// log(sigmoid(x)) = -(max(-x, 0) + log(exp(-max(-x, 0)) + exp(-x - max(-x, 0))))
+    /// ```
+    ///
+    /// This extends the range of values for which we obtain accurate results.
+    fn numerically_stable_log_sigmoid<const D: usize, B: Backend>(x: Tensor<B, D>) -> Tensor<B, D> {
+        // max(-x, 0)
+        let max_elem = x.clone().neg().max_pair(x.zeros_like());
+
+        // log(exp(-max(-x, 0)) + exp(-x - max(-x, 0)))
+        let z = (max_elem.clone().neg().exp() + (x.neg() - max_elem.clone()).exp()).log();
+
+        z.neg() - max_elem
+    }
     match B::FloatElem::precision() {
         Precision::Half => {
             let tensor_full = tensor.into_full_precision();
-            let tensor_tmp = tensor_full.neg().exp().add_scalar(1.0_f32).log().neg();
+            let tensor_tmp = numerically_stable_log_sigmoid(tensor_full);
             Tensor::from_full_precision(tensor_tmp)
         }
-        _ => tensor.neg().exp().add_scalar(1.0_f32).log().neg(),
+        _ => numerically_stable_log_sigmoid(tensor),
     }
 }
 

--- a/crates/burn-tensor/src/tests/activation/log_sigmoid.rs
+++ b/crates/burn-tensor/src/tests/activation/log_sigmoid.rs
@@ -1,0 +1,33 @@
+#[burn_tensor_testgen::testgen(log_sigmoid)]
+mod tests {
+    use super::*;
+    use burn_tensor::{activation, Data, Tensor};
+
+    #[test]
+    fn test_log_sigmoid() {
+        let tensor = TestTensor::from([[1.0, 7.0], [13.0, -3.0]]);
+
+        let data_actual = activation::log_sigmoid(tensor).into_data();
+
+        let data_expected = Data::from([[-3.132617e-1, -9.114665e-4], [-2.260327e-6, -3.0485873]]);
+        data_actual.assert_approx_eq(&data_expected, 4);
+    }
+
+    #[test]
+    fn test_log_sigmoid_numerical_stability() {
+        let tensor = TestTensor::from([300.0, -300.0]);
+
+        let data_actual = activation::log_sigmoid(tensor).into_data();
+
+        // For large negative values, the previous implementation −log(1 + exp(−x)) would give -inf
+        let data_expected = Data::from([0.0, -300.0]);
+        data_actual.assert_approx_eq(&data_expected, 4);
+
+        let tensor = TestTensor::from([f32::MAX, f32::MIN]);
+
+        let data_actual = activation::log_sigmoid(tensor).into_data();
+
+        let data_expected = Data::from([0.0, f32::MIN]);
+        data_actual.assert_approx_eq(&data_expected, 4);
+    }
+}

--- a/crates/burn-tensor/src/tests/activation/mod.rs
+++ b/crates/burn-tensor/src/tests/activation/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod gelu;
 pub(crate) mod leaky_relu;
+pub(crate) mod log_sigmoid;
 pub(crate) mod mish;
 pub(crate) mod prelu;
 pub(crate) mod relu;

--- a/crates/burn-tensor/src/tests/mod.rs
+++ b/crates/burn-tensor/src/tests/mod.rs
@@ -16,6 +16,7 @@ macro_rules! testgen_all {
         burn_tensor::testgen_softmax!();
         burn_tensor::testgen_softplus!();
         burn_tensor::testgen_sigmoid!();
+        burn_tensor::testgen_log_sigmoid!();
         burn_tensor::testgen_silu!();
         burn_tensor::testgen_tanh_activation!();
 


### PR DESCRIPTION
While making progress on a fine-tuning classification example I stumbled upon an issue with our `log_sigmoid` implementation which returned `-inf` for large negative values.

I first attempted to use this common log-sum-exp trick
```
log(sigmoid(x)) = log(1/(1 + exp(-x)))
                = log(1) - log(1 + exp(-x))
                = -log(1 + exp(-x))
                = x - log(1 + exp(x))
```

Which resulted in this implementation:
```rust
if x >= 0 {
    -log(1 + exp(-x))  // ok for positive values
} else {
    x - log(1 + exp(x)) // ok for negative values
}
```

That worked on wgpu but gave me NaNs for large values near the min and max on ndarray. That's when I stumbled upon the [pytorch implementation](https://github.com/pytorch/pytorch/pull/2211) that goes a step further, as implemented in this PR.

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.

### Changes

Changed our `log_sigmoid` implementation to be numerically stable for large values.

### Testing

Added unit tests for `log_sigmoid`.
