### PR TITLE
Move log_sigmoid to activation ops

### DIFF
--- a/crates/burn-autodiff/src/tests/log_sigmoid.rs
+++ b/crates/burn-autodiff/src/tests/log_sigmoid.rs
@@ -1,0 +1,20 @@
+#[burn_tensor_testgen::testgen(ad_log_sigmoid)]
+mod tests {
+    use super::*;
+    use burn_tensor::{activation, Data};
+
+    #[test]
+    fn should_diff_log_sigmoid() {
+        let data = Data::<f32, 2>::from([[0.8762, -0.1423], [-300., 200.]]);
+
+        let device = Default::default();
+        let tensor_1 = TestAutodiffTensor::from_data(data, &device).require_grad();
+        let tensor_2 = activation::log_sigmoid(tensor_1.clone());
+        let grads = tensor_2.backward();
+
+        let grad = tensor_1.grad(&grads).unwrap();
+
+        grad.to_data()
+            .assert_approx_eq(&Data::from([[0.293966, 0.535515], [1.000000, 0.000000]]), 4);
+    }
+}

--- a/crates/burn-autodiff/src/tests/mod.rs
+++ b/crates/burn-autodiff/src/tests/mod.rs
@@ -29,6 +29,7 @@ mod gelu;
 mod gradients;
 mod log;
 mod log1p;
+mod log_sigmoid;
 mod mask;
 mod matmul;
 mod maxmin;
@@ -117,6 +118,7 @@ macro_rules! testgen_all {
         burn_autodiff::testgen_ad_sub!();
         burn_autodiff::testgen_ad_tanh!();
         burn_autodiff::testgen_ad_sigmoid!();
+        burn_autodiff::testgen_ad_log_sigmoid!();
         burn_autodiff::testgen_ad_transpose!();
         burn_autodiff::testgen_ad_permute!();
         burn_autodiff::testgen_ad_flip!();

--- a/crates/burn-tch/src/ops/activation.rs
+++ b/crates/burn-tch/src/ops/activation.rs
@@ -26,4 +26,15 @@ impl<E: TchElement> ActivationOps<Self> for LibTorch<E> {
     fn sigmoid<const D: usize>(tensor: TchTensor<E, D>) -> TchTensor<E, D> {
         tensor.unary_ops(|mut tensor| tensor.sigmoid_(), |tensor| tensor.sigmoid())
     }
+
+    fn log_sigmoid<const D: usize>(tensor: TchTensor<E, D>) -> TchTensor<E, D> {
+        // NOTE: we don't override log_sigmoid_backward because Torch has a special backward
+        // formula that uses a buffer with computed values from the forward pass
+
+        // no in-place log_sigmoid_
+        let storage = tensor.storage.clone();
+        let tensor = tensor.tensor.log_sigmoid();
+
+        TchTensor::from_existing(tensor, storage)
+    }
 }


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.

### Related Issues/PRs

Closes #1549 

### Changes

- Moved `log_sigmoid` implementation to `ActivationOps`
- Added `log_sigmoid_backward` with autodiff usage
- Added `tch` backend `log_sigmoid` to override the default implementation

### Testing

Added backward unit tests.
