### PR TITLE
Add a link to "Transitioning From PyTorch to Burn" tutorial

### DIFF
--- a/burn-book/src/import/pytorch-model.md
+++ b/burn-book/src/import/pytorch-model.md
@@ -7,13 +7,18 @@ you can import them into Burn. Burn supports importing PyTorch model weights wit
 extension. Compared to ONNX models, `.pt` files only contain the weights of the model, so you will
 need to reconstruct the model architecture in Burn.
 
+Here in this document we will show the full workflow of exporting a PyTorch model and importing it.
+Also you can refer to this
+[Transitioning From PyTorch to Burn](https://dev.to/laggui/transitioning-from-pytorch-to-burn-45m)
+tutorial on importing a more complex model.
+
 ## How to export a PyTorch model
 
 If you have a PyTorch model that you want to import into Burn, you will need to export it first,
 unless you are using a pre-trained published model. To export a PyTorch model, you can use the
 `torch.save` function.
 
-Here is an example of how to export a PyTorch model:
+The following is an example of how to export a PyTorch model:
 
 ```python
 import torch
@@ -40,7 +45,7 @@ if __name__ == "__main__":
 Use [Netron](https://github.com/lutzroeder/netron) to view the exported model. You should see
 something like this:
 
-![image alt >](./conv2d.svg)
+![image alt>](./conv2d.svg)
 
 ## How to import a PyTorch model
 
@@ -187,8 +192,8 @@ fn main() {
 ### Adjusting the source model architecture
 
 If your target model differs structurally from the model you exported, `PyTorchFileRecorder` allows
-changing the attribute names and the order of the attributes. For example, if you exported a model
-with the following structure:
+you to change the attribute names and the order of the attributes. For example, if you exported a
+model with the following structure:
 
 ```python
 class ConvModule(nn.Module):
@@ -225,7 +230,7 @@ pub struct Net<B: Backend> {
 Which produces the following weights structure (viewed in
 [Netron](https://github.com/lutzroeder/netron)):
 
-![image alt >](./key_remap.svg)
+![image alt>](./key_remap.svg)
 
 You can use the `PyTorchFileRecorder` to change the attribute names and the order of the attributes
 by specifying a regular expression (See


### PR DESCRIPTION
### Changes

Add a link to "Transitioning From PyTorch to Burn" in Burn book

### Testing

Rendered the page.
