### PR TITLE
[backend-comparison] Add URL to browse results on burn.dev website

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,7 @@ dependencies = [
  "github-device-flow",
  "indicatif",
  "os_info",
+ "percent-encoding",
  "rand",
  "reqwest",
  "rstest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ proc-macro2 = "1.0.79"
 protobuf = "3.3"
 protobuf-codegen = "3.3"
 quote = "1.0.33"
+percent-encoding = "2.3.1"
 r2d2 = "0.8.10"
 r2d2_sqlite = { version = "0.23.0" }
 rayon = "1.10.0"

--- a/backend-comparison/Cargo.toml
+++ b/backend-comparison/Cargo.toml
@@ -37,6 +37,7 @@ dirs = { workspace = true }
 github-device-flow = { workspace = true }
 os_info = { workspace = true }
 indicatif = { workspace = true }
+percent-encoding = { workspace = true }
 rand = { workspace = true }
 reqwest = {workspace = true, features = ["blocking", "json"]}
 serde = { workspace = true }

--- a/backend-comparison/src/burnbenchapp/mod.rs
+++ b/backend-comparison/src/burnbenchapp/mod.rs
@@ -14,3 +14,11 @@ const USER_BENCHMARK_SERVER_URL: &str = if cfg!(debug_assertions) {
     // production
     "https://user-benchmark-server-gvtbw64teq-nn.a.run.app/"
 };
+
+const USER_BENCHMARK_WEBSITE_URL: &str = if cfg!(debug_assertions) {
+    // development
+    "http://localhost:4321/"
+} else {
+    // production
+    "https://burn.dev/"
+};

--- a/backend-comparison/src/persistence/mod.rs
+++ b/backend-comparison/src/persistence/mod.rs
@@ -1,4 +1,4 @@
 mod base;
-mod system_info;
+pub mod system_info;
 
 pub use base::*;

--- a/backend-comparison/src/persistence/system_info.rs
+++ b/backend-comparison/src/persistence/system_info.rs
@@ -8,12 +8,12 @@ use wgpu;
 pub struct BenchmarkSystemInfo {
     cpus: Vec<String>,
     gpus: Vec<String>,
-    os: BenchmarkOSInfo,
+    pub os: BenchmarkOSInfo,
 }
 
 #[derive(Default, Clone, Serialize, Deserialize)]
-pub(crate) struct BenchmarkOSInfo {
-    name: String,
+pub struct BenchmarkOSInfo {
+    pub name: String,
     #[serde(rename = "wsl")]
     windows_linux_subsystem: bool,
 }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

Output a link at the end of `burnbench` execution to browse the results on `burn.dev`.

### Testing

```
cargo run --release --bin burnbench -- run --benches binary --backends wgpu-fusion candle-cuda ndarray --share
```

![image](https://github.com/tracel-ai/burn/assets/1243537/181ee8d3-cfb4-4348-9ed6-464cbd7dc1b9)

![image](https://github.com/tracel-ai/burn/assets/1243537/e0baaab1-ab44-4d61-8d19-974014d9f47b)
