### PR TITLE
Fix pytorch recorder adapt_linear when using autodiff backend

### DIFF
--- a/crates/burn-import/pytorch-tests/Cargo.toml
+++ b/crates/burn-import/pytorch-tests/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [dev-dependencies]
 burn = { path = "../../burn" }
 burn-ndarray = { path = "../../burn-ndarray" }
+burn-autodiff = { path = "../../burn-autodiff" }
 serde = { workspace = true }
 float-cmp = { workspace = true }
 burn-import = { path = "../", features = ["pytorch"] }

--- a/crates/burn-import/pytorch-tests/tests/complex_nested/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/complex_nested/mod.rs
@@ -12,6 +12,7 @@ use burn::{
         Tensor,
     },
 };
+use burn_autodiff::Autodiff;
 use burn_import::pytorch::{LoadArgs, PyTorchFileRecorder};
 
 #[derive(Module, Debug)]
@@ -162,6 +163,17 @@ fn full_record() {
         .expect("Should decode state successfully");
 
     model_test(record, 8);
+}
+
+#[test]
+fn full_record_autodiff() {
+    let device = Default::default();
+    let record = PyTorchFileRecorder::<FullPrecisionSettings>::default()
+        .load("tests/complex_nested/complex_nested.pt".into(), &device)
+        .expect("Should decode state successfully");
+
+    let device = Default::default();
+    let _model = Net::<Autodiff<TestBackend>>::init(&device).load_record(record);
 }
 
 #[test]

--- a/crates/burn-import/src/pytorch/adapter.rs
+++ b/crates/burn-import/src/pytorch/adapter.rs
@@ -36,7 +36,7 @@ impl<PS: PrecisionSettings, B: Backend> BurnModuleAdapter for PyTorchAdapter<PS,
             .try_into_record::<_, PS, DefaultAdapter, B>(&B::Device::default())
             .expect("Failed to deserialize weight");
 
-        // Do not capture tranpose op when using autodiff backend
+        // Do not capture transpose op when using autodiff backend
         let weight = weight.set_require_grad(false);
         // Transpose the weight tensor.
         let weight_transposed = Param::from_tensor(weight.val().transpose());

--- a/crates/burn-import/src/pytorch/adapter.rs
+++ b/crates/burn-import/src/pytorch/adapter.rs
@@ -36,6 +36,8 @@ impl<PS: PrecisionSettings, B: Backend> BurnModuleAdapter for PyTorchAdapter<PS,
             .try_into_record::<_, PS, DefaultAdapter, B>(&B::Device::default())
             .expect("Failed to deserialize weight");
 
+        // Do not capture tranpose op when using autodiff backend
+        let weight = weight.set_require_grad(false);
         // Transpose the weight tensor.
         let weight_transposed = Param::from_tensor(weight.val().transpose());
 


### PR DESCRIPTION
Stumbled upon this issue when trying to load a record with `PyTorchFileRecorder` for a model using the autodiff backend.

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.

### Changes

The line below would panic with `Can't convert a non leaf tensor into a tracked tensor` when using the autodiff backend.

```rust
Param::from_tensor(weight.val().transpose());
```

That's simply because the parameter is being created from a tensor that is being transposed, an operation that is tracked by autodiff.

Solution: set require grad to false when creating the parameter from the tensor transpose.

### Testing

Added autodiff unit test for complex model that includes a linear layer.
