### PR TITLE
Use num-traits for math ops instead of always using libm (for std and no-std)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,7 +434,6 @@ dependencies = [
  "flate2",
  "half",
  "hashbrown 0.14.3",
- "libm",
  "log",
  "num-traits",
  "rand",
@@ -602,7 +601,6 @@ dependencies = [
  "derive-new",
  "half",
  "hashbrown 0.14.3",
- "libm",
  "num-traits",
  "rand",
  "rand_distr",
@@ -1158,10 +1156,7 @@ version = "0.13.0"
 dependencies = [
  "burn",
  "flate2",
- "indicatif",
- "reqwest",
  "tar",
- "tokio",
 ]
 
 [[package]]
@@ -3503,6 +3498,7 @@ name = "pytorch-tests"
 version = "0.13.0"
 dependencies = [
  "burn",
+ "burn-autodiff",
  "burn-import",
  "burn-ndarray",
  "float-cmp",

--- a/crates/burn-core/Cargo.toml
+++ b/crates/burn-core/Cargo.toml
@@ -37,6 +37,7 @@ std = [
     "rmp-serde",
     "serde/std",
     "serde_json/std",
+    "num-traits/std",
 ]
 doc = [
     "std",
@@ -86,7 +87,7 @@ candle = ["burn-candle"]
 wgpu = ["burn-wgpu"]
 
 # Custom deserializer for Record that is helpful for importing data, such as PyTorch pt files.
-record-item-custom-serde = ["thiserror", "regex", "num-traits"]
+record-item-custom-serde = ["thiserror", "regex"]
 
 # Serialization formats
 experimental-named-tensor = ["burn-tensor/experimental-named-tensor"]
@@ -111,9 +112,9 @@ burn-tch = { path = "../burn-tch", version = "0.13.0", optional = true }
 burn-candle = { path = "../burn-candle", version = "0.13.0", optional = true }
 
 derive-new = { workspace = true }
-libm = { workspace = true }
 log = { workspace = true, optional = true }
 rand = { workspace = true, features = ["std_rng"] } # Default enables std
+
 # Using in place of use std::sync::Mutex when std is disabled
 spin = { workspace = true, features = ["mutex", "spin_mutex"] }
 
@@ -130,7 +131,7 @@ rmp-serde = { workspace = true, optional = true }
 serde_json = { workspace = true, features = ["alloc"] } #Default enables std
 thiserror = { workspace = true, optional = true }
 regex = { workspace = true, optional = true }
-num-traits = { workspace = true, optional = true }
+num-traits = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/burn-core/src/nn/attention/mha.rs
+++ b/crates/burn-core/src/nn/attention/mha.rs
@@ -8,7 +8,9 @@ use crate::{
     nn,
     tensor::{activation, backend::Backend, Bool, Tensor},
 };
-use libm::sqrtf;
+
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
 
 /// Configuration to create a [Multi Head Attention](MultiHeadAttention) layer.
 #[derive(Config)]
@@ -35,7 +37,7 @@ pub struct MultiHeadAttentionConfig {
     quiet_softmax: bool,
     /// The type of function used to initialize neural network parameters
     #[config(
-        default = "Initializer::KaimingUniform{gain:1.0/libm::sqrt(3.0), fan_out_only:false}"
+        default = "Initializer::KaimingUniform{gain:1.0/num_traits::Float::sqrt(3.0), fan_out_only:false}"
     )]
     pub initializer: Initializer,
 }
@@ -207,7 +209,7 @@ impl<B: Backend> MultiHeadAttention<B> {
     fn attn_scores(&self, query: Tensor<B, 4>, key: Tensor<B, 4>) -> Tensor<B, 4> {
         let attn_scores = query
             .matmul(key.transpose())
-            .div_scalar(sqrtf(self.d_k as f32));
+            .div_scalar((self.d_k as f32).sqrt());
 
         self.dropout.forward(attn_scores)
     }

--- a/crates/burn-core/src/nn/conv/conv1d.rs
+++ b/crates/burn-core/src/nn/conv/conv1d.rs
@@ -8,7 +8,6 @@ use crate::tensor::backend::Backend;
 use crate::tensor::Tensor;
 use burn_tensor::module::conv1d;
 use burn_tensor::ops::ConvOptions;
-use libm::sqrt;
 
 use super::checks;
 
@@ -37,7 +36,9 @@ pub struct Conv1dConfig {
     #[config(default = true)]
     pub bias: bool,
     /// The type of function used to initialize neural network parameters
-    #[config(default = "Initializer::KaimingUniform{gain:1.0/sqrt(3.0),fan_out_only:false}")]
+    #[config(
+        default = "Initializer::KaimingUniform{gain:1.0/num_traits::Float::sqrt(3.0),fan_out_only:false}"
+    )]
     pub initializer: Initializer,
 }
 
@@ -132,7 +133,7 @@ mod tests {
 
         let config = Conv1dConfig::new(5, 5, 5);
         let k = (config.channels_in * config.kernel_size) as f64;
-        let k = sqrt(config.groups as f64 / k) as f32;
+        let k = (config.groups as f64 / k).sqrt() as f32;
         let conv = config.init::<TestBackend>(&Default::default());
 
         conv.weight.to_data().assert_within_range(-k..k);

--- a/crates/burn-core/src/nn/conv/conv2d.rs
+++ b/crates/burn-core/src/nn/conv/conv2d.rs
@@ -9,7 +9,6 @@ use crate::tensor::backend::Backend;
 use crate::tensor::Tensor;
 use burn_tensor::module::conv2d;
 use burn_tensor::ops::ConvOptions;
-use libm::sqrt;
 
 use super::checks;
 
@@ -36,7 +35,9 @@ pub struct Conv2dConfig {
     #[config(default = true)]
     pub bias: bool,
     /// The type of function used to initialize neural network parameters
-    #[config(default = "Initializer::KaimingUniform{gain:1.0/sqrt(3.0),fan_out_only:false}")]
+    #[config(
+        default = "Initializer::KaimingUniform{gain:1.0/num_traits::Float::sqrt(3.0),fan_out_only:false}"
+    )]
     pub initializer: Initializer,
 }
 
@@ -135,7 +136,7 @@ mod tests {
 
         let config = Conv2dConfig::new([5, 1], [5, 5]);
         let k = (config.channels[0] * config.kernel_size[0] * config.kernel_size[1]) as f64;
-        let k = sqrt(config.groups as f64 / k) as f32;
+        let k = (config.groups as f64 / k).sqrt() as f32;
         let device = Default::default();
         let conv = config.init::<TestBackend>(&device);
 
@@ -161,7 +162,7 @@ mod tests {
         TestBackend::seed(0);
 
         let init = Initializer::KaimingUniform {
-            gain: 1.0 / sqrt(3.0),
+            gain: 1.0 / 3.0f64.sqrt(),
             fan_out_only: true, // test that fan_out is passed to `init_with()`
         };
         let device = Default::default();
@@ -176,7 +177,7 @@ mod tests {
         TestBackend::seed(0);
 
         let init = Initializer::KaimingUniform {
-            gain: 1.0 / sqrt(3.0),
+            gain: 1.0 / 3.0f64.sqrt(),
             fan_out_only: true,
         };
         let device = Default::default();

--- a/crates/burn-core/src/nn/conv/conv_transpose1d.rs
+++ b/crates/burn-core/src/nn/conv/conv_transpose1d.rs
@@ -8,7 +8,6 @@ use crate::tensor::backend::Backend;
 use crate::tensor::Tensor;
 use burn_tensor::module::conv_transpose1d;
 use burn_tensor::ops::ConvTransposeOptions;
-use libm::sqrt;
 
 use super::checks;
 
@@ -38,7 +37,9 @@ pub struct ConvTranspose1dConfig {
     #[config(default = true)]
     pub bias: bool,
     /// The type of function used to initialize neural network parameters
-    #[config(default = "Initializer::KaimingUniform{gain:1.0/sqrt(3.0),fan_out_only:false}")]
+    #[config(
+        default = "Initializer::KaimingUniform{gain:1.0/num_traits::Float::sqrt(3.0),fan_out_only:false}"
+    )]
     pub initializer: Initializer,
 }
 
@@ -135,7 +136,7 @@ mod tests {
 
         let config = ConvTranspose1dConfig::new([5, 1], 5);
         let k = (config.channels[1] * config.kernel_size) as f64;
-        let k = sqrt(config.groups as f64 / k) as f32;
+        let k = (config.groups as f64 / k).sqrt() as f32;
         let conv = config.init::<TestBackend>(&Default::default());
 
         conv.weight.to_data().assert_within_range(-k..k);

--- a/crates/burn-core/src/nn/conv/conv_transpose2d.rs
+++ b/crates/burn-core/src/nn/conv/conv_transpose2d.rs
@@ -1,16 +1,15 @@
 use crate as burn;
 
+use super::checks;
 use crate::config::Config;
 use crate::module::Module;
 use crate::module::Param;
 use crate::nn::Initializer;
 use crate::tensor::backend::Backend;
 use crate::tensor::Tensor;
+
 use burn_tensor::module::conv_transpose2d;
 use burn_tensor::ops::ConvTransposeOptions;
-use libm::sqrt;
-
-use super::checks;
 
 /// Configuration to create an [2D transposed convolution](ConvTranspose2d) layer.
 #[derive(Config, Debug)]
@@ -38,7 +37,9 @@ pub struct ConvTranspose2dConfig {
     #[config(default = true)]
     pub bias: bool,
     /// The type of function used to initialize neural network parameters
-    #[config(default = "Initializer::KaimingUniform{gain:1.0/sqrt(3.0),fan_out_only:false}")]
+    #[config(
+        default = "Initializer::KaimingUniform{gain:1.0/num_traits::Float::sqrt(3.0),fan_out_only:false}"
+    )]
     pub initializer: Initializer,
 }
 
@@ -136,7 +137,7 @@ mod tests {
 
         let config = ConvTranspose2dConfig::new([5, 1], [5, 5]);
         let k = (config.channels[1] * config.kernel_size[0] * config.kernel_size[1]) as f64;
-        let k = sqrt(config.groups as f64 / k) as f32;
+        let k = (config.groups as f64 / k).sqrt() as f32;
         let conv = config.init::<TestBackend>(&Default::default());
 
         conv.weight.to_data().assert_within_range(-k..k);

--- a/crates/burn-core/src/nn/linear.rs
+++ b/crates/burn-core/src/nn/linear.rs
@@ -4,7 +4,6 @@ use crate::config::Config;
 use crate::module::Module;
 use crate::module::Param;
 use crate::tensor::{backend::Backend, Tensor};
-use libm::sqrt;
 
 use super::Initializer;
 
@@ -19,7 +18,9 @@ pub struct LinearConfig {
     #[config(default = true)]
     pub bias: bool,
     /// The type of function used to initialize neural network parameters
-    #[config(default = "Initializer::KaimingUniform{gain:1.0/sqrt(3.0), fan_out_only:false}")]
+    #[config(
+        default = "Initializer::KaimingUniform{gain:1.0/num_traits::Float::sqrt(3.0), fan_out_only:false}"
+    )]
     pub initializer: Initializer,
 }
 
@@ -80,21 +81,20 @@ mod tests {
     use super::*;
     use crate::TestBackend;
     use burn_tensor::{Data, Shape};
-    use libm::sqrt;
 
     #[test]
     fn initializer_default() {
         TestBackend::seed(0);
 
         let config = LinearConfig::new(5, 5);
-        let k = sqrt(1.0 / config.d_input as f64) as f32;
+        let k = (1.0 / config.d_input as f64).sqrt() as f32;
         let device = Default::default();
         let linear = config.init::<TestBackend>(&device);
 
         assert_eq!(
             config.initializer,
             Initializer::KaimingUniform {
-                gain: 1.0 / sqrt(3.0),
+                gain: 1.0 / 3.0f64.sqrt(),
                 fan_out_only: false
             }
         );

--- a/crates/burn-core/src/nn/swiglu.rs
+++ b/crates/burn-core/src/nn/swiglu.rs
@@ -20,7 +20,7 @@ pub struct SwiGluConfig {
     pub bias: bool,
     /// The type of function used to initialize the linear layer parameters
     #[config(
-        default = "Initializer::KaimingUniform{gain:1.0/libm::sqrt(3.0), fan_out_only:false}"
+        default = "Initializer::KaimingUniform{gain:1.0/num_traits::Float::sqrt(3.0), fan_out_only:false}"
     )]
     pub initializer: Initializer,
 }

--- a/crates/burn-core/src/nn/transformer/decoder.rs
+++ b/crates/burn-core/src/nn/transformer/decoder.rs
@@ -44,7 +44,7 @@ pub struct TransformerDecoderConfig {
     pub quiet_softmax: bool,
     /// The type of function used to initialize neural network parameters
     #[config(
-        default = "Initializer::KaimingUniform{gain:1.0/libm::sqrt(3.0), fan_out_only:false}"
+        default = "Initializer::KaimingUniform{gain:1.0/num_traits::Float::sqrt(3.0), fan_out_only:false}"
     )]
     pub initializer: Initializer,
 }

--- a/crates/burn-core/src/nn/transformer/encoder.rs
+++ b/crates/burn-core/src/nn/transformer/encoder.rs
@@ -44,7 +44,7 @@ pub struct TransformerEncoderConfig {
     pub quiet_softmax: bool,
     /// The type of function used to initialize neural network parameters
     #[config(
-        default = "Initializer::KaimingUniform{gain:1.0/libm::sqrt(3.0), fan_out_only:false}"
+        default = "Initializer::KaimingUniform{gain:1.0/num_traits::Float::sqrt(3.0), fan_out_only:false}"
     )]
     pub initializer: Initializer,
 }

--- a/crates/burn-core/src/nn/transformer/pwff.rs
+++ b/crates/burn-core/src/nn/transformer/pwff.rs
@@ -20,7 +20,7 @@ pub struct PositionWiseFeedForwardConfig {
     pub dropout: f64,
     /// The type of function used to initialize neural network parameters
     #[config(
-        default = "Initializer::KaimingUniform{gain:1.0/libm::sqrt(3.0), fan_out_only:false}"
+        default = "Initializer::KaimingUniform{gain:1.0/num_traits::Float::sqrt(3.0), fan_out_only:false}"
     )]
     pub initializer: Initializer,
 }

--- a/crates/burn-ndarray/Cargo.toml
+++ b/crates/burn-ndarray/Cargo.toml
@@ -13,35 +13,29 @@ version.workspace = true
 [features]
 default = ["std"]
 std = [
-  "burn-autodiff",
-  "burn-common/std",
-  "burn-tensor/std",
-  "matrixmultiply/std",
-  "matrixmultiply/threading",
-  "ndarray/rayon",
-  "ndarray/std",
-  "rand/std",
-  "rayon",
+    "burn-autodiff",
+    "burn-common/std",
+    "burn-tensor/std",
+    "matrixmultiply/std",
+    "matrixmultiply/threading",
+    "ndarray/rayon",
+    "ndarray/std",
+    "rand/std",
+    "rayon",
+    "num-traits/std",
 ]
 doc = ["default"]
 
 blas-accelerate = [
-  "blas-src/accelerate",  # Accelerate framework (macOS only)
-  "ndarray/blas",
+    "blas-src/accelerate", # Accelerate framework (macOS only)
+    "ndarray/blas",
 ]
-blas-netlib = [
-  "blas-src/netlib",
-  "ndarray/blas",
-]
-blas-openblas = [
-  "blas-src/openblas",
-  "ndarray/blas",
-  "openblas-src",
-]
+blas-netlib = ["blas-src/netlib", "ndarray/blas"]
+blas-openblas = ["blas-src/openblas", "ndarray/blas", "openblas-src"]
 blas-openblas-system = [
-  "blas-src/openblas",
-  "ndarray/blas",
-  "openblas-src/system",
+    "blas-src/openblas",
+    "ndarray/blas",
+    "openblas-src/system",
 ]
 
 [dependencies]
@@ -54,21 +48,21 @@ burn-tensor = { path = "../burn-tensor", version = "0.13.0", default-features = 
 
 matrixmultiply = { workspace = true, default-features = false }
 rayon = { workspace = true, optional = true }
-blas-src = { workspace = true, default-features = false, optional = true } # no-std compatible         
+blas-src = { workspace = true, default-features = false, optional = true } # no-std compatible
 derive-new = { workspace = true }
 libm = { workspace = true }
 ndarray = { workspace = true }
 num-traits = { workspace = true }
 openblas-src = { workspace = true, optional = true }
 rand = { workspace = true }
-spin = { workspace = true }                            # using in place of use std::sync::Mutex;
+spin = { workspace = true }                                                # using in place of use std::sync::Mutex;
 
 [dev-dependencies]
 burn-autodiff = { path = "../burn-autodiff", version = "0.13.0", default-features = false, features = [
-  "export_tests",
+    "export_tests",
 ] }
 burn-tensor = { path = "../burn-tensor", version = "0.13.0", default-features = false, features = [
-  "export_tests",
+    "export_tests",
 ] }
 
 [package.metadata.docs.rs]

--- a/crates/burn-ndarray/src/element.rs
+++ b/crates/burn-ndarray/src/element.rs
@@ -1,9 +1,14 @@
 use burn_tensor::Element;
-use libm::{exp, fabs, log, log1p, pow, sqrt};
-use libm::{expf, fabsf, log1pf, logf, powf, sqrtf};
 use ndarray::LinalgScalar;
 use num_traits::One;
 use num_traits::Signed;
+
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
+
+use num_traits::Pow;
+
+use libm::{log1p, log1pf};
 
 /// A float element for ndarray backend.
 pub trait FloatNdArrayElement: NdArrayElement + LinalgScalar + Signed
@@ -51,12 +56,12 @@ macro_rules! make_elem {
         impl ExpElement for $ty {
             #[inline(always)]
             fn exp_elem(self) -> Self {
-                exp(self as f64) as $ty
+                (self as f64).exp() as $ty
             }
 
             #[inline(always)]
             fn log_elem(self) -> Self {
-                log(self as f64) as $ty
+                (self as f64).ln() as $ty
             }
 
             #[inline(always)]
@@ -66,7 +71,7 @@ macro_rules! make_elem {
 
             #[inline(always)]
             fn powf_elem(self, value: f32) -> Self {
-                pow(self as f64, value.into()) as $ty
+                (self as f64).pow(value) as $ty
             }
 
             #[inline(always)]
@@ -82,12 +87,12 @@ macro_rules! make_elem {
 
             #[inline(always)]
             fn sqrt_elem(self) -> Self {
-                sqrt(self as f64) as $ty
+                (self as f64).sqrt() as $ty
             }
 
             #[inline(always)]
             fn abs_elem(self) -> Self {
-                fabs(self as f64) as $ty
+                (self as f64).abs() as $ty
             }
 
             #[inline(always)]
@@ -105,12 +110,12 @@ macro_rules! make_elem {
         impl ExpElement for $ty {
             #[inline(always)]
             fn exp_elem(self) -> Self {
-                expf(self as f32) as $ty
+                (self as f32).exp() as $ty
             }
 
             #[inline(always)]
             fn log_elem(self) -> Self {
-                logf(self as f32) as $ty
+                (self as f32).ln() as $ty
             }
 
             #[inline(always)]
@@ -120,7 +125,7 @@ macro_rules! make_elem {
 
             #[inline(always)]
             fn powf_elem(self, value: f32) -> Self {
-                powf(self as f32, value.into()) as $ty
+                (self as f32).pow(value) as $ty
             }
 
             #[inline(always)]
@@ -136,12 +141,12 @@ macro_rules! make_elem {
 
             #[inline(always)]
             fn sqrt_elem(self) -> Self {
-                sqrtf(self as f32) as $ty
+                (self as f32).sqrt() as $ty
             }
 
             #[inline(always)]
             fn abs_elem(self) -> Self {
-                fabsf(self as f32) as $ty
+                (self as f32).abs() as $ty
             }
 
             #[inline(always)]

--- a/crates/burn-ndarray/src/ops/adaptive_avgpool.rs
+++ b/crates/burn-ndarray/src/ops/adaptive_avgpool.rs
@@ -5,6 +5,9 @@ use crate::{
 use burn_tensor::ElementConversion;
 use ndarray::Array4;
 
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
+
 pub(crate) fn adaptive_avg_pool2d<E: FloatNdArrayElement>(
     x: NdArrayTensor<E, 4>,
     output_size: [usize; 2],
@@ -91,13 +94,12 @@ pub(crate) fn adaptive_avg_pool2d_backward<E: FloatNdArrayElement>(
 }
 
 fn start_index(output_size_index: usize, output_size: usize, input_size: usize) -> usize {
-    libm::floorf((output_size_index as f32 * input_size as f32) / output_size as f32) as usize
+    ((output_size_index as f32 * input_size as f32) / output_size as f32).floor() as usize
 }
 
 fn end_index(output_size_index: usize, output_size: usize, input_size: usize) -> usize {
     let index =
-        libm::ceilf(((output_size_index + 1) as f32 * input_size as f32) / output_size as f32)
-            as usize;
+        (((output_size_index + 1) as f32 * input_size as f32) / output_size as f32).ceil() as usize;
 
     usize::min(index, input_size)
 }

--- a/crates/burn-ndarray/src/ops/interpolate.rs
+++ b/crates/burn-ndarray/src/ops/interpolate.rs
@@ -83,7 +83,7 @@ pub(crate) fn nearest_interpolate_backward<E: FloatNdArrayElement>(
 }
 
 fn start_index(output_size_index: usize, output_size: usize, input_size: usize) -> usize {
-    libm::floorf((output_size_index as f32 * input_size as f32) / output_size as f32) as usize
+    ((output_size_index as f32 * input_size as f32) / output_size as f32).floor() as usize
 }
 
 pub(crate) fn bilinear_interpolate<E: FloatNdArrayElement>(

--- a/crates/burn-ndarray/src/ops/tensor.rs
+++ b/crates/burn-ndarray/src/ops/tensor.rs
@@ -14,12 +14,11 @@ use burn_common::rand::get_seeded_rng;
 use burn_tensor::{backend::Backend, ops::FloatTensorOps, Data, ElementConversion, Shape};
 use burn_tensor::{Distribution, Reader};
 
-// External crates
-use libm::{cos, erf, sin, tanh};
-
 #[cfg(not(feature = "std"))]
 #[allow(unused_imports)]
 use num_traits::Float;
+
+use libm::erf;
 
 impl<E: FloatNdArrayElement> FloatTensorOps<Self> for NdArray<E> {
     fn float_from_data<const D: usize>(
@@ -400,7 +399,7 @@ impl<E: FloatNdArrayElement> FloatTensorOps<Self> for NdArray<E> {
     fn float_cos<const D: usize>(tensor: NdArrayTensor<E, D>) -> NdArrayTensor<E, D> {
         let array = tensor
             .array
-            .mapv_into(|a| cos(a.to_f64().unwrap()).elem())
+            .mapv_into(|a| (a.to_f64().unwrap()).cos().elem())
             .into_shared();
 
         NdArrayTensor::new(array)
@@ -409,7 +408,7 @@ impl<E: FloatNdArrayElement> FloatTensorOps<Self> for NdArray<E> {
     fn float_sin<const D: usize>(tensor: NdArrayTensor<E, D>) -> NdArrayTensor<E, D> {
         let array = tensor
             .array
-            .mapv_into(|a| sin(a.to_f64().unwrap()).elem())
+            .mapv_into(|a| (a.to_f64().unwrap()).sin().elem())
             .into_shared();
 
         NdArrayTensor::new(array)
@@ -418,7 +417,7 @@ impl<E: FloatNdArrayElement> FloatTensorOps<Self> for NdArray<E> {
     fn float_tanh<const D: usize>(tensor: NdArrayTensor<E, D>) -> NdArrayTensor<E, D> {
         let array = tensor
             .array
-            .mapv_into(|a| tanh(a.to_f64().unwrap()).elem())
+            .mapv_into(|a| (a.to_f64().unwrap()).tanh().elem())
             .into_shared();
 
         NdArrayTensor::new(array)

--- a/crates/burn-tensor/Cargo.toml
+++ b/crates/burn-tensor/Cargo.toml
@@ -15,7 +15,7 @@ default = ["std"]
 doc = ["default"]
 experimental-named-tensor = []
 export_tests = ["burn-tensor-testgen"]
-std = ["rand/std", "half/std"]
+std = ["rand/std", "half/std", "num-traits/std"]
 wasm-sync = []
 
 [dependencies]
@@ -24,7 +24,6 @@ burn-tensor-testgen = { path = "../burn-tensor-testgen", version = "0.13.0", opt
 
 derive-new = { workspace = true }
 half = { workspace = true }
-libm = { workspace = true }       # no_std is supported by default
 num-traits = { workspace = true }
 rand = { workspace = true }
 rand_distr = { workspace = true } # use instead of statrs because it supports no_std

--- a/crates/burn-tensor/src/tensor/data.rs
+++ b/crates/burn-tensor/src/tensor/data.rs
@@ -4,6 +4,12 @@ use alloc::vec::Vec;
 
 use crate::{tensor::Shape, Element, ElementConversion};
 
+use num_traits::pow::Pow;
+
+#[cfg(not(feature = "std"))]
+#[allow(unused_imports)]
+use num_traits::Float;
+
 use rand::{distributions::Standard, Rng, RngCore};
 
 /// Data structure for serializing and deserializing tensor data.
@@ -280,7 +286,7 @@ impl<E: Into<f64> + Clone + core::fmt::Debug + PartialEq, const D: usize> Data<E
     /// Panics if the data is not approximately equal.
     #[track_caller]
     pub fn assert_approx_eq(&self, other: &Self, precision: usize) {
-        let tolerance = libm::pow(0.1, precision as f64);
+        let tolerance = 0.1.pow(precision as f64);
 
         self.assert_approx_eq_diff(other, tolerance)
     }
@@ -324,7 +330,7 @@ impl<E: Into<f64> + Clone + core::fmt::Debug + PartialEq, const D: usize> Data<E
                 continue;
             }
 
-            let err = libm::sqrt(libm::pow(a - b, 2.0));
+            let err = ((a - b).pow(2.0f64)).sqrt();
 
             if err > tolerance || err.is_nan() {
                 // Only print the first 5 different values.

--- a/crates/burn-tensor/src/tensor/ops/modules/conv.rs
+++ b/crates/burn-tensor/src/tensor/ops/modules/conv.rs
@@ -1,7 +1,9 @@
 #![allow(clippy::single_range_in_vec_init)]
 use super::{Conv1dBackward, Conv2dBackward, ConvOptions, ConvTransposeOptions};
 use crate::{backend::Backend, ops::FloatTensor, Shape};
-use libm::ceilf;
+
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
 
 /// Calculate the expected padding size required when applying a convolution.
 pub fn calculate_conv_padding(
@@ -16,7 +18,7 @@ pub fn calculate_conv_padding(
     let size_out = size_out as f32;
 
     let padding = stride * (size_out - 1.) - size_in + kernel_size;
-    let padding = ceilf(padding / 2.);
+    let padding = (padding / 2.).ceil();
 
     padding as usize
 }
@@ -677,9 +679,9 @@ fn calculate_padding_out(
         return 0;
     }
 
-    let out = 1 + libm::ceil(
-        (size_in + 2 * padding - dilation * (kernel_size - 1) - 1) as f64 / stride as f64,
-    ) as usize;
+    let out = 1
+        + ((size_in + 2 * padding - dilation * (kernel_size - 1) - 1) as f64 / stride as f64).ceil()
+            as usize;
     i64::max(0, out as i64 - size_out as i64) as usize
 }
 


### PR DESCRIPTION
When I converted core, tensor and ndarray to be no-std compatible, I used libm functions for std and no-std regardless. I think it would be better if we used std linked functions if it's `std` flag, otherwise to use `libm`, which is how num_traits actually operates. This can potentially enhance performance if there are math libs take advantage of specific architecture, whereas libm is arch is generic. Also bundle size will be smaller.

## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

https://github.com/tracel-ai/burn/issues/168

### Changes

Use num-traits for all math ops 

### Testing

1. `run-checks.sh all`
2. [Benchmark comparisons before and after running std](https://burn.dev/benchmarks/community-benchmarks/?version1=e84c97220aecb2e6e6cb2e0427c616ddcbeae798&versionLabel1=Version+1&version2=1b09bc47b34065621acd0d600ce61bdd6f6b7b26&versionLabel2=Version+2&backend=ndarray&device=All&name=All&os=Mac+OS+14.4.1+%5B64-bit%5D&sysHardware=Any&user=SolarUnerringness&search=true) 
