### PR TITLE
Fixes to code examples in section 5.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Be sure to follow the coding standards and guidelines used in the rest of the pr
 
 ### Step 6: Run the Pre-Pull Request Script
 
-Before you open a pull request, please run the [`run-checks.sh`](/run-before-pr.sh) script. This
+Before you open a pull request, please run [`./run-checks.sh all`](/run-checks.sh). This
 will ensure that your changes are in line with our project's standards and guidelines. You can run
 this script by opening a terminal, navigating to your local project directory, and typing
 `./run-checks`.

--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -20,7 +20,7 @@ The actual shape of the tensor is inferred from its initialization. For example,
 ```rust, ignore
 let floats = [1.0, 2.0, 3.0, 4.0, 5.0];
 
-//Get the default device
+// Get the default device
 let device = Default::default();
 
 // correct: Tensor is 1-Dimensional with 5 elements

--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -20,7 +20,8 @@ The actual shape of the tensor is inferred from its initialization. For example,
 ```rust, ignore
 let floats = [1.0, 2.0, 3.0, 4.0, 5.0];
 
-let device = burn::backend::wgpu::WgpuDevice::default();
+//Get the default device
+let device = Default::default();
 
 // correct: Tensor is 1-Dimensional with 5 elements
 let tensor_1 = Tensor::<Backend, 1>::from_floats(floats, &device);
@@ -38,8 +39,6 @@ method `.to_data()` should be employed when intending to reuse the tensor afterw
 a tensor from different inputs.
 
 ```rust, ignore
-
-let device = burn::backend::wgpu::WgpuDevice::default();
 
 // Initialization from a given Backend (Wgpu)
 let tensor_1 = Tensor::<Wgpu, 1>::from_data([1.0, 2.0, 3.0], &device);
@@ -88,7 +87,6 @@ times will necessitate cloning it. Let's look at an example to understand the ow
 cloning better. Suppose we want to do a simple min-max normalization of an input tensor.
 
 ```rust, ignore
-let device = burn::backend::wgpu::WgpuDevice::default();
 let input = Tensor::<Wgpu, 1>::from_floats([1.0, 2.0, 3.0, 4.0], &device);
 let min = input.min();
 let max = input.max();
@@ -103,7 +101,6 @@ available for further operations. Burn Tensors like most complex primitives do n
 doing min-max normalization with cloning.
 
 ```rust, ignore
-let device = burn::backend::wgpu::WgpuDevice::default();
 let input = Tensor::<Wgpu, 1>::from_floats([1.0, 2.0, 3.0, 4.0], &device);
 let min = input.clone().min();
 let max = input.clone().max();

--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -20,10 +20,12 @@ The actual shape of the tensor is inferred from its initialization. For example,
 ```rust, ignore
 let floats = [1.0, 2.0, 3.0, 4.0, 5.0];
 
-// correct: Tensor is 1-Dimensional with 5 elements
-let tensor_1 = Tensor::<Backend, 1>::from_floats(floats);
+let device = burn::backend::wgpu::WgpuDevice::default();
 
-// incorrect: let tensor_1 = Tensor::<Backend, 5>::from_floats(floats);
+// correct: Tensor is 1-Dimensional with 5 elements
+let tensor_1 = Tensor::<Backend, 1>::from_floats(floats, &device);
+
+// incorrect: let tensor_1 = Tensor::<Backend, 5>::from_floats(floats, &device);
 // this will lead to an error and is for creating a 5-D tensor
 ```
 
@@ -37,20 +39,22 @@ a tensor from different inputs.
 
 ```rust, ignore
 
+let device = burn::backend::wgpu::WgpuDevice::default();
+
 // Initialization from a given Backend (Wgpu)
-let tensor_1 = Tensor::<Wgpu, 1>::from_data([1.0, 2.0, 3.0]);
+let tensor_1 = Tensor::<Wgpu, 1>::from_data([1.0, 2.0, 3.0], &device);
 
 // Initialization from a generic Backend
-let tensor_2 = Tensor::<Backend, 1>::from_data(Data::from([1.0, 2.0, 3.0]).convert());
+let tensor_2 = Tensor::<Backend, 1>::from_data(Data::from([1.0, 2.0, 3.0]).convert(), &device);
 
 // Initialization using from_floats (Recommended for f32 ElementType)
 // Will be converted to Data internally.
 // `.convert()` not needed as from_floats() defined for fixed ElementType
-let tensor_3 = Tensor::<Backend, 1>::from_floats([1.0, 2.0, 3.0]);
+let tensor_3 = Tensor::<Backend, 1>::from_floats([1.0, 2.0, 3.0], &device);
 
 // Initialization of Int Tensor from array slices
 let arr: [i32; 6] = [1, 2, 3, 4, 5, 6];
-let tensor_4 = Tensor::<Backend, 1, Int>::from_data(Data::from(&arr[0..3]).convert());
+let tensor_4 = Tensor::<Backend, 1, Int>::from_data(Data::from(&arr[0..3]).convert(), &device);
 
 // Initialization from a custom type
 
@@ -66,7 +70,7 @@ let bmi = BodyMetrics{
         weight: 80.0
     };
 let data  = Data::from([bmi.age as f32, bmi.height as f32, bmi.weight]).convert();
-let tensor_5 = Tensor::<Backend, 1>::from_data(data);
+let tensor_5 = Tensor::<Backend, 1>::from_data(data, &device);
 
 ```
 
@@ -84,7 +88,8 @@ times will necessitate cloning it. Let's look at an example to understand the ow
 cloning better. Suppose we want to do a simple min-max normalization of an input tensor.
 
 ```rust, ignore
-let input = Tensor::<Wgpu, 1>::from_floats([1.0, 2.0, 3.0, 4.0]);
+let device = burn::backend::wgpu::WgpuDevice::default();
+let input = Tensor::<Wgpu, 1>::from_floats([1.0, 2.0, 3.0, 4.0], &device);
 let min = input.min();
 let max = input.max();
 let input = (input - min).div(max - min);
@@ -98,7 +103,8 @@ available for further operations. Burn Tensors like most complex primitives do n
 doing min-max normalization with cloning.
 
 ```rust, ignore
-let input = Tensor::<Wgpu, 1>::from_floats([1.0, 2.0, 3.0, 4.0]);
+let device = burn::backend::wgpu::WgpuDevice::default();
+let input = Tensor::<Wgpu, 1>::from_floats([1.0, 2.0, 3.0, 4.0], &device);
 let min = input.clone().min();
 let max = input.clone().max();
 let input = (input.clone() - min.clone()).div(max - min);


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

None

### Changes

These changes are to the Burn book only. No changes to the code in Burn.

I think The Burn Book may need to be updated . The Tensor [section](https://burn.dev/book/building-blocks/tensor.html)  gives these code examples to create Tensors:

```Rust
let tensor_1 = Tensor::<Backend, 1>::from_floats([1.0, 2.0, 3.0, 4.0, 5.0]);

let tensor_1 = Tensor::<Wgpu, 1>::from_data([1.0, 2.0, 3.0]);
```
```
this function takes 2 arguments but 1 argument was supplied 
main.rs(17, 51): an argument of type `&WgpuDevice` is missing
```

However, I get a compiler error because from_floats and from_data takes an additional argument - the device. One has to do something like below to create a Tensor:

```Rust
let device = burn::backend::wgpu::WgpuDevice::default();
let pos_samples = Tensor::<Wgpu, 1>::from_data([1.0, 2.0, 3.0], &device);
```

### Testing

Since this is a change only to documentation (The Burn Book) I am not sure if running run_check.sh is required. I tried it any way and run_check.sh fails with this error

```
> ./run_check.sh
(base) hrishi@resnet:burn$ ./run-checks.sh 
    Finished dev [unoptimized] target(s) in 0.09s
     Running `target/debug/xtask run-checks`
error: the following required arguments were not provided:
  <ENV>
```

I ran ./run_check.sh std and that passed. I have not tested all other ENV options

