### PR TITLE
[Sponsorship] Add Blaze badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Documentation](https://img.shields.io/badge/docs-latest-blue)](https://burn.dev/docs/burn)
 [![Test Status](https://github.com/tracel-ai/burn/actions/workflows/test.yml/badge.svg)](https://github.com/tracel-ai/burn/actions/workflows/test.yml)
 [![CodeCov](https://codecov.io/gh/tracel-ai/burn/branch/main/graph/badge.svg)](https://codecov.io/gh/tracel-ai/burn)
+![Blaze](https://img.shields.io/badge/Blaze-CI%20Runners-171717)
 [![Rust Version](https://img.shields.io/badge/Rust-1.75.0+-blue)](https://releases.rs/docs/1.75.0)
 ![license](https://shields.io/badge/license-MIT%2FApache--2.0-blue)
 
@@ -605,5 +606,7 @@ issues are likely to be easy to fix, there are no guarantees at this stage.
 Burn is distributed under the terms of both the MIT license and the Apache License (Version 2.0).
 See [LICENSE-APACHE](./LICENSE-APACHE) and [LICENSE-MIT](./LICENSE-MIT) for details. Opening a pull
 request is assumed to signal agreement with these licensing terms.
+
+<br />
 
 </div>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Documentation](https://img.shields.io/badge/docs-latest-blue)](https://burn.dev/docs/burn)
 [![Test Status](https://github.com/tracel-ai/burn/actions/workflows/test.yml/badge.svg)](https://github.com/tracel-ai/burn/actions/workflows/test.yml)
 [![CodeCov](https://codecov.io/gh/tracel-ai/burn/branch/main/graph/badge.svg)](https://codecov.io/gh/tracel-ai/burn)
-![Blaze](https://img.shields.io/badge/Blaze-CI%20Runners-171717)
+[![Blaze](https://runblaze.dev/gh/114041730602611213183421653564341667516/badge.svg)](https://runblaze.dev)
 [![Rust Version](https://img.shields.io/badge/Rust-1.75.0+-blue)](https://releases.rs/docs/1.75.0)
 ![license](https://shields.io/badge/license-MIT%2FApache--2.0-blue)
 
@@ -606,7 +606,5 @@ issues are likely to be easy to fix, there are no guarantees at this stage.
 Burn is distributed under the terms of both the MIT license and the Apache License (Version 2.0).
 See [LICENSE-APACHE](./LICENSE-APACHE) and [LICENSE-MIT](./LICENSE-MIT) for details. Opening a pull
 request is assumed to signal agreement with these licensing terms.
-
-<br />
 
 </div>


### PR DESCRIPTION
First draft for Blaze mention in the README. Feel free to comment and I'll adjust (previews at the end). The badge links to the Sponsors section in the README which in turn has the link to Blaze with the promotion code.

EDIT: I remove the italic in the Sponsors section. See last screenshot.

Blaze offers blazingly fast Apple Silicon runners at a fraction of the GitHub runners price. Double Symmetry offers free runners for Burn CI needs on Apple Silicon.

Thank you to Double Symmetry GmbH for this sponsorship!

### Testing

The links in the PR won't work until the PR is merged. Here are several screenshots with different themes to give a preview of the results (default light and dark and dimmed dark):

Header: 

![Screenshot 2024-04-09 153810](https://github.com/tracel-ai/burn/assets/1243537/d2c02826-f014-4900-80a7-c4390dfb6628)

![Screenshot 2024-04-09 153740](https://github.com/tracel-ai/burn/assets/1243537/dce2405c-8614-46bc-a7b1-49b427497e46)

![Screenshot 2024-04-09 153612](https://github.com/tracel-ai/burn/assets/1243537/cf86ed5e-b064-41f0-a3ef-e4ee9820cfdb)

Footer: 

![Screenshot 2024-04-09 153936](https://github.com/tracel-ai/burn/assets/1243537/7792212f-f9fd-447c-8d6a-c0a73eac330c)

![Screenshot 2024-04-09 153948](https://github.com/tracel-ai/burn/assets/1243537/8d31d433-2f37-4343-8ef5-338757a0d4d5)

![Screenshot 2024-04-09 153858](https://github.com/tracel-ai/burn/assets/1243537/81baed74-653f-4e9a-b9e3-63152fdfcc9c)

No italics:

![image](https://github.com/tracel-ai/burn/assets/1243537/f4e26fa3-d2c8-4ed3-aa65-70923760a77c)
