### PR TITLE
Feat/remainder

### DIFF
--- a/crates/burn-autodiff/src/ops/int_tensor.rs
+++ b/crates/burn-autodiff/src/ops/int_tensor.rs
@@ -126,6 +126,13 @@ impl<B: Backend, C: CheckpointStrategy> IntTensorOps<Self> for Autodiff<B, C> {
         B::int_div_scalar(lhs, rhs)
     }
 
+    fn int_remainder_scalar<const D: usize>(
+        lhs: IntTensor<B, D>,
+        rhs: B::IntElem,
+    ) -> IntTensor<B, D> {
+        B::int_remainder_scalar(lhs, rhs)
+    }
+
     fn int_neg<const D: usize>(tensor: IntTensor<B, D>) -> IntTensor<B, D> {
         B::int_neg(tensor)
     }

--- a/crates/burn-candle/src/ops/int_tensor.rs
+++ b/crates/burn-candle/src/ops/int_tensor.rs
@@ -289,6 +289,14 @@ impl<F: FloatCandleElement, I: IntCandleElement> IntTensorOps<Self> for Candle<F
         panic!("Not supported by Candle")
     }
 
+    fn int_remainder_scalar<const D: usize>(
+        lhs: IntTensor<Self, D>,
+        rhs: IntElem<Self>,
+    ) -> IntTensor<Self, D> {
+        // Same problem as int_div_scalar.
+        panic!("Not supported by Candle")
+    }
+
     fn int_zeros<const D: usize>(shape: Shape<D>, device: &Device<Self>) -> IntTensor<Self, D> {
         CandleTensor::new(
             candle_core::Tensor::zeros(&shape.dims, I::DTYPE, &(*device).into()).unwrap(),

--- a/crates/burn-candle/src/ops/tensor.rs
+++ b/crates/burn-candle/src/ops/tensor.rs
@@ -138,6 +138,18 @@ impl<F: FloatCandleElement, I: IntCandleElement> FloatTensorOps<Self> for Candle
         CandleTensor::new((lhs.tensor / rhs.elem::<f64>()).unwrap())
     }
 
+    fn float_remainder_scalar<const D: usize>(
+        lhs: FloatTensor<Self, D>,
+        rhs: FloatElem<Self>,
+    ) -> FloatTensor<Self, D> {
+        // In PyTorch, remainder can also be defined as torch.remainder(a, b) == a - a.div(b, rounding_mode="floor") * b
+        let rhs_val = rhs.elem::<f64>();
+        let division_result = (lhs.tensor.clone() / rhs_val).unwrap().floor().unwrap();
+        let product = division_result * rhs_val;
+
+        CandleTensor::new((lhs.tensor - product).unwrap())
+    }
+
     fn float_matmul<const D: usize>(
         lhs: FloatTensor<Self, D>,
         rhs: FloatTensor<Self, D>,

--- a/crates/burn-fusion/src/ops/float.rs
+++ b/crates/burn-fusion/src/ops/float.rs
@@ -502,7 +502,7 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
         };
         out.client.register(
             vec![stream],
-            OperationDescription::NumericFloat(NumericOperationDescription::ModScalar(
+            OperationDescription::NumericFloat(NumericOperationDescription::RemScalar(
                 desc.clone(),
             )),
             ModOps::<D>::new(desc),

--- a/crates/burn-fusion/src/ops/float.rs
+++ b/crates/burn-fusion/src/ops/float.rs
@@ -486,6 +486,31 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
         out
     }
 
+    fn float_remainder_scalar<const D: usize>(
+        lhs: FloatTensor<Self, D>,
+        rhs: FloatElem<Self>,
+    ) -> FloatTensor<Self, D> {
+        scalar_float_ops!(ModOps, B::float_remainder_scalar);
+
+        let stream = lhs.stream;
+        let out = lhs.client.tensor_uninitialized(lhs.shape.clone());
+
+        let desc = ScalarOperationDescription {
+            lhs: lhs.into_description(),
+            rhs: rhs.elem(),
+            out: out.to_description_out(),
+        };
+        out.client.register(
+            vec![stream],
+            OperationDescription::NumericFloat(NumericOperationDescription::ModScalar(
+                desc.clone(),
+            )),
+            ModOps::<D>::new(desc),
+        );
+
+        out
+    }
+
     fn float_matmul<const D: usize>(
         lhs: FloatTensor<Self, D>,
         rhs: FloatTensor<Self, D>,

--- a/crates/burn-fusion/src/ops/int.rs
+++ b/crates/burn-fusion/src/ops/int.rs
@@ -962,6 +962,31 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
         out
     }
 
+    fn int_remainder_scalar<const D: usize>(
+        lhs: IntTensor<Self, D>,
+        rhs: IntElem<Self>,
+    ) -> IntTensor<Self, D> {
+        scalar_int_ops!(ModOps, B::int_remainder_scalar);
+
+        let stream = lhs.stream;
+        let out = lhs.client.tensor_uninitialized(lhs.shape.clone());
+
+        let desc = ScalarOperationDescription {
+            lhs: lhs.into_description(),
+            rhs: rhs.elem(),
+            out: out.to_description_out(),
+        };
+        out.client.register(
+            vec![stream],
+            stream::OperationDescription::NumericInt(NumericOperationDescription::ModScalar(
+                desc.clone(),
+            )),
+            ModOps::<D>::new(desc),
+        );
+
+        out
+    }
+
     fn int_zeros<const D: usize>(shape: Shape<D>, device: &Device<Self>) -> IntTensor<Self, D> {
         #[derive(new)]
         struct ZerosOps<const D: usize> {

--- a/crates/burn-fusion/src/ops/int.rs
+++ b/crates/burn-fusion/src/ops/int.rs
@@ -978,7 +978,7 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
         };
         out.client.register(
             vec![stream],
-            stream::OperationDescription::NumericInt(NumericOperationDescription::ModScalar(
+            stream::OperationDescription::NumericInt(NumericOperationDescription::RemScalar(
                 desc.clone(),
             )),
             ModOps::<D>::new(desc),

--- a/crates/burn-fusion/src/stream/context.rs
+++ b/crates/burn-fusion/src/stream/context.rs
@@ -509,8 +509,8 @@ impl<E: Element> NumericOperationDescription<E> {
                     out: desc.out.to_relative(converter),
                 })
             }
-            NumericOperationDescription::ModScalar(desc) => {
-                NumericOperationDescription::ModScalar(ScalarOperationDescription {
+            NumericOperationDescription::RemScalar(desc) => {
+                NumericOperationDescription::RemScalar(ScalarOperationDescription {
                     lhs: desc.lhs.to_relative(converter),
                     rhs: local_elem(converter, &desc.rhs),
                     out: desc.out.to_relative(converter),

--- a/crates/burn-fusion/src/stream/context.rs
+++ b/crates/burn-fusion/src/stream/context.rs
@@ -509,6 +509,13 @@ impl<E: Element> NumericOperationDescription<E> {
                     out: desc.out.to_relative(converter),
                 })
             }
+            NumericOperationDescription::ModScalar(desc) => {
+                NumericOperationDescription::ModScalar(ScalarOperationDescription {
+                    lhs: desc.lhs.to_relative(converter),
+                    rhs: local_elem(converter, &desc.rhs),
+                    out: desc.out.to_relative(converter),
+                })
+            }
             NumericOperationDescription::Mul(desc) => {
                 NumericOperationDescription::Mul(BinaryOperationDescription {
                     lhs: desc.lhs.to_relative(converter),

--- a/crates/burn-fusion/src/stream/operation.rs
+++ b/crates/burn-fusion/src/stream/operation.rs
@@ -236,6 +236,11 @@ pub enum NumericOperationDescription<E> {
     DivScalar(ScalarOperationDescription<E>),
     /// Operation corresponding to:
     ///
+    /// Float => [div](burn_tensor::ops::FloatTensorOps::float_remainder_scalar).
+    /// Int => [div](burn_tensor::ops::IntTensorOps::int_remainder_scalar).
+    ModScalar(ScalarOperationDescription<E>),
+    /// Operation corresponding to:
+    ///
     /// Float => [mul](burn_tensor::ops::FloatTensorOps::float_mul).
     /// Int => [mul](burn_tensor::ops::IntTensorOps::int_mul).
     Mul(BinaryOperationDescription),
@@ -1132,6 +1137,9 @@ impl<E: Element> NumericOperationDescription<E> {
             NumericOperationDescription::DivScalar(desc) => {
                 vec![&desc.lhs, &desc.out]
             }
+            NumericOperationDescription::ModScalar(desc) => {
+                vec![&desc.lhs, &desc.out]
+            }
             NumericOperationDescription::Ones(desc) => vec![desc],
             NumericOperationDescription::Gather(desc) => {
                 vec![&desc.tensor, &desc.indices, &desc.out]
@@ -1411,6 +1419,7 @@ impl<E> core::hash::Hash for NumericOperationDescription<E> {
             NumericOperationDescription::SubScalar(desc) => desc.hash(state),
             NumericOperationDescription::Div(desc) => desc.hash(state),
             NumericOperationDescription::DivScalar(desc) => desc.hash(state),
+            NumericOperationDescription::ModScalar(desc) => desc.hash(state),
             NumericOperationDescription::Mul(desc) => desc.hash(state),
             NumericOperationDescription::MulScalar(desc) => desc.hash(state),
             NumericOperationDescription::Abs(desc) => desc.hash(state),

--- a/crates/burn-fusion/src/stream/operation.rs
+++ b/crates/burn-fusion/src/stream/operation.rs
@@ -238,7 +238,7 @@ pub enum NumericOperationDescription<E> {
     ///
     /// Float => [div](burn_tensor::ops::FloatTensorOps::float_remainder_scalar).
     /// Int => [div](burn_tensor::ops::IntTensorOps::int_remainder_scalar).
-    ModScalar(ScalarOperationDescription<E>),
+    RemScalar(ScalarOperationDescription<E>),
     /// Operation corresponding to:
     ///
     /// Float => [mul](burn_tensor::ops::FloatTensorOps::float_mul).
@@ -1137,7 +1137,7 @@ impl<E: Element> NumericOperationDescription<E> {
             NumericOperationDescription::DivScalar(desc) => {
                 vec![&desc.lhs, &desc.out]
             }
-            NumericOperationDescription::ModScalar(desc) => {
+            NumericOperationDescription::RemScalar(desc) => {
                 vec![&desc.lhs, &desc.out]
             }
             NumericOperationDescription::Ones(desc) => vec![desc],
@@ -1419,7 +1419,7 @@ impl<E> core::hash::Hash for NumericOperationDescription<E> {
             NumericOperationDescription::SubScalar(desc) => desc.hash(state),
             NumericOperationDescription::Div(desc) => desc.hash(state),
             NumericOperationDescription::DivScalar(desc) => desc.hash(state),
-            NumericOperationDescription::ModScalar(desc) => desc.hash(state),
+            NumericOperationDescription::RemScalar(desc) => desc.hash(state),
             NumericOperationDescription::Mul(desc) => desc.hash(state),
             NumericOperationDescription::MulScalar(desc) => desc.hash(state),
             NumericOperationDescription::Abs(desc) => desc.hash(state),

--- a/crates/burn-jit/src/codegen/dialect/gpu/operation.rs
+++ b/crates/burn-jit/src/codegen/dialect/gpu/operation.rs
@@ -60,6 +60,7 @@ pub enum Operator {
     BitwiseXor(BinaryOperator),
     ShiftLeft(BinaryOperator),
     ShiftRight(BinaryOperator),
+    Remainder(BinaryOperator),
 }
 
 /// All metadata that can be access in a shader.

--- a/crates/burn-jit/src/codegen/dialect/gpu/vectorization.rs
+++ b/crates/burn-jit/src/codegen/dialect/gpu/vectorization.rs
@@ -81,6 +81,7 @@ impl Operator {
             Operator::BitwiseXor(op) => Operator::BitwiseXor(op.vectorize(vectorization)),
             Operator::ShiftLeft(op) => Operator::ShiftLeft(op.vectorize(vectorization)),
             Operator::ShiftRight(op) => Operator::ShiftRight(op.vectorize(vectorization)),
+            Operator::Remainder(op) => Operator::Remainder(op.vectorize(vectorization)),
         }
     }
 }

--- a/crates/burn-jit/src/fusion/tracing/builder.rs
+++ b/crates/burn-jit/src/fusion/tracing/builder.rs
@@ -361,6 +361,11 @@ impl TraceBuilder {
                         &mut local_tensor_ids_input,
                         &mut local_tensor_ids_output,
                     ),
+                    gpu::Operator::Remainder(op) => mark_binary(
+                        op,
+                        &mut local_tensor_ids_input,
+                        &mut local_tensor_ids_output,
+                    ),
                 },
                 Operation::Procedure(proc) => {
                     match proc {

--- a/crates/burn-jit/src/ops/float_ops.rs
+++ b/crates/burn-jit/src/ops/float_ops.rs
@@ -132,6 +132,13 @@ impl<R: Runtime> FloatTensorOps<Self> for JitBackend<R> {
         numeric::div_scalar(lhs, rhs)
     }
 
+    fn float_remainder_scalar<const D: usize>(
+        lhs: FloatTensor<Self, D>,
+        rhs: FloatElem<Self>,
+    ) -> FloatTensor<Self, D> {
+        numeric::remainder_scalar(lhs, rhs)
+    }
+
     fn float_matmul<const D: usize>(
         lhs: FloatTensor<Self, D>,
         rhs: FloatTensor<Self, D>,

--- a/crates/burn-jit/src/ops/int_ops.rs
+++ b/crates/burn-jit/src/ops/int_ops.rs
@@ -235,6 +235,13 @@ impl<R: Runtime> IntTensorOps<Self> for JitBackend<R> {
         numeric::div_scalar(lhs, rhs)
     }
 
+    fn int_remainder_scalar<const D: usize>(
+        lhs: IntTensor<Self, D>,
+        rhs: IntElem<Self>,
+    ) -> IntTensor<Self, D> {
+        numeric::remainder_scalar(lhs, rhs)
+    }
+
     fn int_zeros<const D: usize>(shape: Shape<D>, device: &Device<Self>) -> IntTensor<Self, D> {
         numeric::zeros(shape, device)
     }

--- a/crates/burn-jit/src/ops/numeric.rs
+++ b/crates/burn-jit/src/ops/numeric.rs
@@ -215,7 +215,7 @@ pub fn remainder_scalar<R: Runtime, E: JitElement, const D: usize>(
     let rhs_tensor = full::<R, E, D>(shape, &device, rhs);
 
     binary!(
-        operation: |scope: &mut Scope, elem: Elem| Operator::Modulo(BinaryOperator {
+        operation: |scope: &mut Scope, elem: Elem| Operator::Remainder(BinaryOperator {
             lhs: scope.read_array(0, elem),
             rhs: scope.read_array(1, elem),
             out: scope.create_local(elem),

--- a/crates/burn-jit/src/ops/numeric.rs
+++ b/crates/burn-jit/src/ops/numeric.rs
@@ -205,6 +205,22 @@ pub fn div_scalar<R: Runtime, E: JitElement, const D: usize>(
     )
 }
 
+pub fn remainder_scalar<R: Runtime, E: JitElement, const D: usize>(
+    lhs: JitTensor<R, E, D>,
+    rhs: E,
+) -> JitTensor<R, E, D> {
+    unary!(
+        operation: |scope: &mut Scope, elem: Elem| Operator::Div(BinaryOperator {
+            lhs: scope.read_array(0, elem),
+            rhs: scope.read_array(1, elem),
+            out: scope.create_local(elem),
+        }),
+        runtime: R,
+        input: lhs; rhs,
+        elem: E
+    )
+}
+
 pub fn pow<R: Runtime, E: JitElement, const D: usize>(
     lhs: JitTensor<R, E, D>,
     rhs: JitTensor<R, E, D>,

--- a/crates/burn-jit/src/ops/numeric.rs
+++ b/crates/burn-jit/src/ops/numeric.rs
@@ -209,14 +209,19 @@ pub fn remainder_scalar<R: Runtime, E: JitElement, const D: usize>(
     lhs: JitTensor<R, E, D>,
     rhs: E,
 ) -> JitTensor<R, E, D> {
-    unary!(
-        operation: |scope: &mut Scope, elem: Elem| Operator::Div(BinaryOperator {
+    let shape = lhs.shape.clone();
+    let device = lhs.device.clone();
+
+    let rhs_tensor = full::<R, E, D>(shape, &device, rhs);
+
+    binary!(
+        operation: |scope: &mut Scope, elem: Elem| Operator::Modulo(BinaryOperator {
             lhs: scope.read_array(0, elem),
             rhs: scope.read_array(1, elem),
             out: scope.create_local(elem),
         }),
         runtime: R,
-        input: lhs; rhs,
+        input: lhs; rhs_tensor,
         elem: E
     )
 }

--- a/crates/burn-ndarray/src/ops/base.rs
+++ b/crates/burn-ndarray/src/ops/base.rs
@@ -232,6 +232,16 @@ where
         NdArrayTensor { array }
     }
 
+    pub fn remainder_scalar<const D: usize>(lhs: NdArrayTensor<E, D>, rhs: E) -> NdArrayTensor<E, D>
+    where
+        E: core::ops::Rem<Output = E>,
+    {
+        let array = lhs.array.mapv(|x| x % rhs);
+        let array = array.into_shared();
+
+        NdArrayTensor { array }
+    }
+
     pub fn recip<const D: usize>(tensor: NdArrayTensor<E, D>) -> NdArrayTensor<E, D> {
         let array = tensor.array.map(|x| 1.elem::<E>() / *x);
         let array = array.into_shared();

--- a/crates/burn-ndarray/src/ops/base.rs
+++ b/crates/burn-ndarray/src/ops/base.rs
@@ -236,7 +236,7 @@ where
     where
         E: core::ops::Rem<Output = E>,
     {
-        let array = lhs.array.mapv(|x| x % rhs);
+        let array = lhs.array.mapv(|x| ((x % rhs) + rhs) % rhs);
         let array = array.into_shared();
 
         NdArrayTensor { array }

--- a/crates/burn-ndarray/src/ops/int_tensor.rs
+++ b/crates/burn-ndarray/src/ops/int_tensor.rs
@@ -242,6 +242,13 @@ impl<E: FloatNdArrayElement> IntTensorOps<Self> for NdArray<E> {
         NdArrayMathOps::div_scalar(lhs, rhs)
     }
 
+    fn int_remainder_scalar<const D: usize>(
+        lhs: NdArrayTensor<i64, D>,
+        rhs: i64,
+    ) -> NdArrayTensor<i64, D> {
+        NdArrayMathOps::remainder_scalar(lhs, rhs)
+    }
+
     fn int_neg<const D: usize>(tensor: NdArrayTensor<i64, D>) -> NdArrayTensor<i64, D> {
         Self::int_mul_scalar(tensor, -1)
     }

--- a/crates/burn-ndarray/src/ops/tensor.rs
+++ b/crates/burn-ndarray/src/ops/tensor.rs
@@ -119,6 +119,13 @@ impl<E: FloatNdArrayElement> FloatTensorOps<Self> for NdArray<E> {
         NdArrayMathOps::div_scalar(lhs, rhs)
     }
 
+    fn float_remainder_scalar<const D: usize>(
+        lhs: NdArrayTensor<E, D>,
+        rhs: E,
+    ) -> NdArrayTensor<E, D> {
+        NdArrayMathOps::remainder_scalar(lhs, rhs)
+    }
+
     fn float_matmul<const D: usize>(
         lhs: NdArrayTensor<E, D>,
         rhs: NdArrayTensor<E, D>,

--- a/crates/burn-tch/src/ops/int_tensor.rs
+++ b/crates/burn-tch/src/ops/int_tensor.rs
@@ -216,6 +216,13 @@ impl<E: TchElement> IntTensorOps<Self> for LibTorch<E> {
         TchTensor::<i64, D>::new(out.tensor.to_dtype(tch::Kind::Int64, non_blocking, copy))
     }
 
+    fn int_remainder_scalar<const D: usize>(lhs: TchTensor<i64, D>, rhs: i64) -> TchTensor<i64, D> {
+        lhs.unary_ops(
+            |mut tensor| tensor.f_remainder(rhs).unwrap(),
+            |tensor| tensor.f_remainder(rhs).unwrap(),
+        )
+    }
+
     fn int_neg<const D: usize>(tensor: TchTensor<i64, D>) -> TchTensor<i64, D> {
         Self::int_mul_scalar(tensor, -1)
     }

--- a/crates/burn-tch/src/ops/int_tensor.rs
+++ b/crates/burn-tch/src/ops/int_tensor.rs
@@ -218,7 +218,7 @@ impl<E: TchElement> IntTensorOps<Self> for LibTorch<E> {
 
     fn int_remainder_scalar<const D: usize>(lhs: TchTensor<i64, D>, rhs: i64) -> TchTensor<i64, D> {
         lhs.unary_ops(
-            |mut tensor| tensor.f_remainder(rhs).unwrap(),
+            |tensor| tensor.f_remainder(rhs).unwrap(),
             |tensor| tensor.f_remainder(rhs).unwrap(),
         )
     }

--- a/crates/burn-tch/src/ops/tensor.rs
+++ b/crates/burn-tch/src/ops/tensor.rs
@@ -152,6 +152,15 @@ impl<E: TchElement> FloatTensorOps<Self> for LibTorch<E> {
         )
     }
 
+    fn float_remainder_scalar<const D: usize>(lhs: TchTensor<E, D>, rhs: E) -> TchTensor<E, D> {
+        let rhs: f64 = rhs.elem();
+
+        lhs.unary_ops(
+            |mut tensor| tensor.f_remainder(rhs).unwrap(),
+            |tensor| tensor.f_remainder(rhs).unwrap(),
+        )
+    }
+
     fn float_matmul<const D: usize>(lhs: TchTensor<E, D>, rhs: TchTensor<E, D>) -> TchTensor<E, D> {
         let tensor = lhs.tensor.matmul(&rhs.tensor);
         TchTensor::new(tensor)

--- a/crates/burn-tch/src/ops/tensor.rs
+++ b/crates/burn-tch/src/ops/tensor.rs
@@ -156,7 +156,7 @@ impl<E: TchElement> FloatTensorOps<Self> for LibTorch<E> {
         let rhs: f64 = rhs.elem();
 
         lhs.unary_ops(
-            |mut tensor| tensor.f_remainder(rhs).unwrap(),
+            |tensor| tensor.f_remainder(rhs).unwrap(),
             |tensor| tensor.f_remainder(rhs).unwrap(),
         )
     }

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -61,7 +61,15 @@ where
     pub fn div_scalar<E: ElementConversion>(self, other: E) -> Self {
         Self::new(K::div_scalar(self.primitive, other))
     }
+
+    /// Applies element wise the remainder operation with a scalar.
     ///
+    /// `y = x2 % x1`
+    #[allow(clippy::should_implement_trait)]
+    pub fn remainder_scalar<E: ElementConversion>(self, other: E) -> Self {
+        Self::new(K::remainder_scalar(self.primitive, other))
+    }
+
     /// Applies element wise multiplication operation.
     ///
     /// `y = x2 * x1`
@@ -942,6 +950,31 @@ where
     /// For dividing a tensor by a scalar, users should prefer the [Tensor::div_scalar](Tensor::div_scalar) function,
     /// which is more high-level and designed for public use.
     fn div_scalar<const D: usize, E: ElementConversion>(
+        lhs: Self::Primitive<D>,
+        rhs: E,
+    ) -> Self::Primitive<D>;
+
+    /// Computes the modulus element-wise. The result has the same sign as the divisor rhs and its absolute value is
+    /// less than that of the divisor.
+    ///
+    /// # Arguments
+    ///
+    /// * `lhs` - The dividend.
+    /// * `rhs` - The divisor.
+    ///
+    /// # Returns
+    ///
+    /// The modulus of the input tensor with the divisor.
+    ///
+    /// # Remarks
+    ///
+    /// This is a low-level function used internally by the library to call different backend functions
+    /// with static dispatch. It is not designed for direct usage by users, and not recommended to import
+    /// or use this function directly.
+    ///
+    /// For performing the modulus operation, users should prefer the [Tensor::remainder_scalar](Tensor::remainder_scalar) function,
+    /// which is more high-level and designed for public use.
+    fn remainder_scalar<const D: usize, E: ElementConversion>(
         lhs: Self::Primitive<D>,
         rhs: E,
     ) -> Self::Primitive<D>;
@@ -2100,6 +2133,12 @@ impl<B: Backend> Numeric<B> for Int {
     ) -> Self::Primitive<D> {
         B::int_div_scalar(lhs, rhs.elem())
     }
+    fn remainder_scalar<const D: usize, E: ElementConversion>(
+        lhs: Self::Primitive<D>,
+        rhs: E,
+    ) -> Self::Primitive<D> {
+        B::int_remainder_scalar(lhs, rhs.elem())
+    }
     fn mul<const D: usize>(
         lhs: Self::Primitive<D>,
         rhs: Self::Primitive<D>,
@@ -2437,6 +2476,12 @@ impl<B: Backend> Numeric<B> for Float {
         rhs: E,
     ) -> Self::Primitive<D> {
         B::float_div_scalar(lhs, rhs.elem())
+    }
+    fn remainder_scalar<const D: usize, E: ElementConversion>(
+        lhs: Self::Primitive<D>,
+        rhs: E,
+    ) -> Self::Primitive<D> {
+        B::float_remainder_scalar(lhs, rhs.elem())
     }
     fn mul<const D: usize>(
         lhs: Self::Primitive<D>,

--- a/crates/burn-tensor/src/tensor/ops/int_tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/int_tensor.rs
@@ -692,6 +692,20 @@ pub trait IntTensorOps<B: Backend> {
     /// The result of the division.
     fn int_div_scalar<const D: usize>(lhs: IntTensor<B, D>, rhs: IntElem<B>) -> IntTensor<B, D>;
 
+    /// Element-wise modulus with a scalar.
+    ///
+    /// # Arguments
+    /// * `lhs` - The left hand side tensor.
+    /// * `rhs` - The right hand side scalar.
+    ///
+    /// # Returns
+    ///
+    /// The result of applying the modulus of the scalar to the tensor.
+    fn int_remainder_scalar<const D: usize>(
+        lhs: IntTensor<B, D>,
+        rhs: IntElem<B>,
+    ) -> IntTensor<B, D>;
+
     /// Element-wise negation.
     ///
     /// # Arguments

--- a/crates/burn-tensor/src/tensor/ops/tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/tensor.rs
@@ -386,6 +386,20 @@ pub trait FloatTensorOps<B: Backend> {
         rhs: FloatElem<B>,
     ) -> FloatTensor<B, D>;
 
+    /// Computes the modulus of a tensor given a scalar.
+    ///
+    /// # Arguments
+    /// * `lhs` - The left hand side tensor.
+    /// * `rhs` - The right hand side scalar.
+    ///
+    /// # Returns
+    ///
+    /// The result of applying the modulus of the scalar to the tensor.
+    fn float_remainder_scalar<const D: usize>(
+        lhs: FloatTensor<B, D>,
+        rhs: FloatElem<B>,
+    ) -> FloatTensor<B, D>;
+
     /// Multiplies two tensors together using matrix multiplication.
     ///
     /// # Arguments

--- a/crates/burn-tensor/src/tests/mod.rs
+++ b/crates/burn-tensor/src/tests/mod.rs
@@ -96,6 +96,7 @@ macro_rules! testgen_all {
         burn_tensor::testgen_tri_mask!();
         burn_tensor::testgen_sort_argsort!();
         burn_tensor::testgen_topk!();
+        burn_tensor::testgen_remainder!();
 
         // test stats
         burn_tensor::testgen_var!();

--- a/crates/burn-tensor/src/tests/ops/mod.rs
+++ b/crates/burn-tensor/src/tests/ops/mod.rs
@@ -41,6 +41,7 @@ mod powf;
 mod powf_scalar;
 mod random;
 mod recip;
+mod remainder;
 mod repeat;
 mod reshape;
 mod select;

--- a/crates/burn-tensor/src/tests/ops/remainder.rs
+++ b/crates/burn-tensor/src/tests/ops/remainder.rs
@@ -1,0 +1,31 @@
+#[burn_tensor_testgen::testgen(remainder)]
+mod tests {
+    use super::*;
+    use burn_tensor::{Data, Int, Tensor};
+
+    #[test]
+    fn should_support_remainder_basic() {
+        let data = Data::from([-3.0, -2.0, -1.0, 1.0, 2.0, 3.0]);
+        let device = Default::default();
+        let tensor = Tensor::<TestBackend, 1>::from_data(data, &device);
+
+        let output = tensor.remainder_scalar(2.0);
+
+        let data_actual = output.into_data();
+        let data_expected = Data::from([1.0, 0.0, 1.0, 1.0, 0.0, 1.0]);
+        data_expected.assert_approx_eq(&data_actual, 3);
+    }
+
+    #[test]
+    fn should_support_remainder_float() {
+        let data = Data::from([1.0, 2.0, 3.0, 4.0, 5.0]);
+        let device = Default::default();
+        let tensor = Tensor::<TestBackend, 1>::from_data(data, &device);
+
+        let output = tensor.remainder_scalar(-1.5);
+
+        let data_actual = output.into_data();
+        let data_expected = Data::from([-0.5, -1.0, 0.0, -0.5, -1.0]);
+        data_expected.assert_approx_eq(&data_actual, 3);
+    }
+}

--- a/crates/burn-tensor/src/tests/ops/remainder.rs
+++ b/crates/burn-tensor/src/tests/ops/remainder.rs
@@ -3,6 +3,7 @@ mod tests {
     use super::*;
     use burn_tensor::{Data, Int, Tensor};
 
+    /// From https://pytorch.org/docs/stable/generated/torch.remainder.html
     #[test]
     fn should_support_remainder_basic() {
         let data = Data::from([-3.0, -2.0, -1.0, 1.0, 2.0, 3.0]);
@@ -16,6 +17,7 @@ mod tests {
         data_expected.assert_approx_eq(&data_actual, 3);
     }
 
+    /// Also from https://pytorch.org/docs/stable/generated/torch.remainder.html
     #[test]
     fn should_support_remainder_float() {
         let data = Data::from([1.0, 2.0, 3.0, 4.0, 5.0]);

--- a/crates/burn-tensor/src/tests/ops/remainder.rs
+++ b/crates/burn-tensor/src/tests/ops/remainder.rs
@@ -28,4 +28,69 @@ mod tests {
         let data_expected = Data::from([-0.5, -1.0, 0.0, -0.5, -1.0]);
         data_expected.assert_approx_eq(&data_actual, 3);
     }
+
+    #[test]
+    fn should_be_zero() {
+        let data = Data::from([0.0, 0.0, 0.0]);
+        let device = Default::default();
+        let tensor = Tensor::<TestBackend, 1>::from_data(data, &device);
+
+        let output = tensor.remainder_scalar(3.5);
+
+        let data_actual = output.into_data();
+        let data_expected = Data::from([0.0, 0.0, 0.0]);
+        data_expected.assert_approx_eq(&data_actual, 3);
+    }
+
+    #[test]
+    fn should_have_no_remainder() {
+        let data = Data::from([-4.0, 4.0]);
+        let device = Default::default();
+        let tensor = Tensor::<TestBackend, 1>::from_data(data, &device);
+
+        let output = tensor.remainder_scalar(4.0);
+
+        let data_actual = output.into_data();
+        let data_expected = Data::from([-0.0, 0.0]);
+        data_expected.assert_approx_eq(&data_actual, 3);
+    }
+
+    #[test]
+    fn should_be_negative() {
+        let data = Data::from([-7.0, -3.0, 2.0, 6.0]);
+        let device = Default::default();
+        let tensor = Tensor::<TestBackend, 1>::from_data(data, &device);
+
+        let output = tensor.remainder_scalar(-2.5);
+
+        let data_actual = output.into_data();
+        let data_expected = Data::from([-2.0, -0.50, -0.50, -1.5]);
+        data_expected.assert_approx_eq(&data_actual, 3);
+    }
+
+    #[test]
+    fn should_support_fp_dividends() {
+        let data = Data::from([-7.5, -2.5, 2.5, 7.5]);
+        let device = Default::default();
+        let tensor = Tensor::<TestBackend, 1>::from_data(data, &device);
+
+        let output = tensor.remainder_scalar(3.0);
+
+        let data_actual = output.into_data();
+        let data_expected = Data::from([1.5, 0.5, 2.5, 1.5]);
+        data_expected.assert_approx_eq(&data_actual, 3);
+    }
+
+    #[test]
+    fn should_support_large_divisor() {
+        let data = Data::from([-1.0, 1.0]);
+        let device = Default::default();
+        let tensor = Tensor::<TestBackend, 1>::from_data(data, &device);
+
+        let output = tensor.remainder_scalar(10.0);
+
+        let data_actual = output.into_data();
+        let data_expected = Data::from([9.0, 1.0]);
+        data_expected.assert_approx_eq(&data_actual, 3);
+    }
 }

--- a/crates/burn-wgpu/src/compiler/wgsl/compiler.rs
+++ b/crates/burn-wgpu/src/compiler/wgsl/compiler.rs
@@ -556,6 +556,11 @@ impl<F: FloatElement, I: IntElement> WgslCompiler<F, I> {
                 rhs: self.compile_variable(op.rhs),
                 out: self.compile_variable(op.out),
             },
+            gpu::Operator::Remainder(op) => wgsl::Instruction::Remainder {
+                lhs: self.compile_variable(op.lhs),
+                rhs: self.compile_variable(op.rhs),
+                out: self.compile_variable(op.out),
+            },
         }
     }
 

--- a/crates/burn-wgpu/src/compiler/wgsl/instructions.rs
+++ b/crates/burn-wgpu/src/compiler/wgsl/instructions.rs
@@ -248,7 +248,7 @@ impl Display for Instruction {
                 f.write_fmt(format_args!("{out} = {item}({lhs}[{rhs}]);\n"))
             }
             Instruction::Modulo { lhs, rhs, out } => {
-                f.write_fmt(format_args!("{out} = {lhs} % {rhs};\n"))
+                f.write_fmt(format_args!("{out} = (({lhs} % {rhs}) + {rhs}) % {rhs};\n"))
             }
             Instruction::Sub { lhs, rhs, out } => {
                 f.write_fmt(format_args!("{out} = {lhs} - {rhs};\n"))

--- a/crates/burn-wgpu/src/compiler/wgsl/instructions.rs
+++ b/crates/burn-wgpu/src/compiler/wgsl/instructions.rs
@@ -218,6 +218,11 @@ pub enum Instruction {
         input: Variable,
         out: Variable,
     },
+    Remainder {
+        lhs: Variable,
+        rhs: Variable,
+        out: Variable,
+    },
 }
 
 impl Display for Instruction {
@@ -248,6 +253,9 @@ impl Display for Instruction {
                 f.write_fmt(format_args!("{out} = {item}({lhs}[{rhs}]);\n"))
             }
             Instruction::Modulo { lhs, rhs, out } => {
+                f.write_fmt(format_args!("{out} = (({lhs} % {rhs}) + {rhs}) % {rhs};\n"))
+            }
+            Instruction::Remainder { lhs, rhs, out } => {
                 f.write_fmt(format_args!("{out} = (({lhs} % {rhs}) + {rhs}) % {rhs};\n"))
             }
             Instruction::Sub { lhs, rhs, out } => {

--- a/crates/burn-wgpu/src/compiler/wgsl/instructions.rs
+++ b/crates/burn-wgpu/src/compiler/wgsl/instructions.rs
@@ -253,7 +253,7 @@ impl Display for Instruction {
                 f.write_fmt(format_args!("{out} = {item}({lhs}[{rhs}]);\n"))
             }
             Instruction::Modulo { lhs, rhs, out } => {
-                f.write_fmt(format_args!("{out} = (({lhs} % {rhs}) + {rhs}) % {rhs};\n"))
+                f.write_fmt(format_args!("{out} = {lhs} % {rhs};\n"))
             }
             Instruction::Remainder { lhs, rhs, out } => {
                 f.write_fmt(format_args!("{out} = (({lhs} % {rhs}) + {rhs}) % {rhs};\n"))


### PR DESCRIPTION
## Pull Request Template
I was doing some playing around and noticed this wasn't included, also I believe there's an open issue about this in #1510.

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR (the contributor-book needs to be updated though).

### Related Issues/PRs

#1510 

### Changes

Added the equivalent of PyTorch's [remainder](https://pytorch.org/docs/stable/generated/torch.remainder.html) operation

### Testing

Added new tests to `burn-tensor`, will add more later once wgpu is figured out.

For `burn-jit`, I redirected the remainder to the modulo operator because in WGSL, it *should* be the same as PyTorch's definition. Here, the [%](https://math.hws.edu/graphicsbook/c6/s3.html#webgl.3.4) for WGSL is defined as

>  The return value is computed as x − y*floor(x/y). As with min and max, y can be either a vector or a float. The mod function can be used as a substitute for the % operator

In PyTorch, the remainder is defined as
> torch.remainder(a, b) == a - a.div(b, rounding_mode="floor") * b

So they should be equivalent, but there's some errors in the wgpu tests that I'll have to look into. I probably set something up wrong in  `numeric.rs` in `burn-jit`. The other backends seem to work. If anyone has any ideas though here is the test output:

```bash
---- tests::jit_fusion::remainder::tests::should_support_remainder_basic stdout ----
thread 'tests::jit_fusion::remainder::tests::should_support_remainder_basic' panicked at crates/burn-wgpu/src/lib.rs:78:5:
Tensors are not approx eq:
  => Position 0: 1 != -1 | difference 2 > tolerance 0.0010000000000000002
  => Position 2: 1 != -1 | difference 2 > tolerance 0.0010000000000000002

---- tests::jit_fusion::remainder::tests::should_support_remainder_float stdout ----
thread 'tests::jit_fusion::remainder::tests::should_support_remainder_float' panicked at crates/burn-wgpu/src/lib.rs:78:5:
Tensors are not approx eq:
  => Position 0: -0.5 != 1 | difference 1.5 > tolerance 0.0010000000000000002
  => Position 1: -1 != 0.5 | difference 1.5 > tolerance 0.0010000000000000002
  => Position 3: -0.5 != 1 | difference 1.5 > tolerance 0.0010000000000000002
  => Position 4: -1 != 0.5 | difference 1.5 > tolerance 0.0010000000000000002

failures:
    tests::jit::remainder::tests::should_support_remainder_basic 
    tests::jit::remainder::tests::should_support_remainder_float // this and the one above looks exactly like the below two
    tests::jit_fusion::remainder::tests::should_support_remainder_basic
    tests::jit_fusion::remainder::tests::should_support_remainder_float
```
