### PR TITLE
Repeat ops autodiff & fusion + fix autodiff ones & zeros

### DIFF
--- a/crates/burn-autodiff/src/ops/bool_tensor.rs
+++ b/crates/burn-autodiff/src/ops/bool_tensor.rs
@@ -135,4 +135,12 @@ impl<B: Backend, C: CheckpointStrategy> BoolTensorOps<Self> for Autodiff<B, C> {
     ) -> BoolTensor<B, D2> {
         B::bool_expand(tensor, shape)
     }
+
+    fn bool_repeat<const D: usize>(
+        tensor: BoolTensor<B, D>,
+        dim: usize,
+        times: usize,
+    ) -> BoolTensor<B, D> {
+        B::bool_repeat(tensor, dim, times)
+    }
 }

--- a/crates/burn-autodiff/src/ops/tensor.rs
+++ b/crates/burn-autodiff/src/ops/tensor.rs
@@ -40,11 +40,11 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
     }
 
     fn float_zeros<const D: usize>(shape: Shape<D>, device: &Device<Self>) -> FloatTensor<Self, D> {
-        Self::float_from_data(Data::zeros(shape), device)
+        AutodiffTensor::new(B::float_zeros(shape, device))
     }
 
     fn float_ones<const D: usize>(shape: Shape<D>, device: &Device<Self>) -> FloatTensor<Self, D> {
-        Self::float_from_data(Data::ones(shape), device)
+        AutodiffTensor::new(B::float_ones(shape, device))
     }
 
     fn float_shape<const D: usize>(tensor: &FloatTensor<Self, D>) -> Shape<D> {
@@ -2412,6 +2412,14 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
 
     // TODO: Implement float_prod and float_sum
     // https://github.com/tracel-ai/burn/issues/1458
+
+    fn float_repeat<const D: usize>(
+        tensor: FloatTensor<Self, D>,
+        dim: usize,
+        times: usize,
+    ) -> FloatTensor<Self, D> {
+        AutodiffTensor::new(B::float_repeat(tensor.primitive, dim, times))
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/burn-autodiff/src/tests/mod.rs
+++ b/crates/burn-autodiff/src/tests/mod.rs
@@ -44,6 +44,7 @@ mod permute;
 mod pow;
 mod recip;
 mod relu;
+mod repeat;
 mod reshape;
 mod select;
 mod sigmoid;
@@ -126,5 +127,6 @@ macro_rules! testgen_all {
         burn_autodiff::testgen_ad_sign!();
         burn_autodiff::testgen_ad_expand!();
         burn_autodiff::testgen_ad_sort!();
+        burn_autodiff::testgen_ad_repeat!();
     };
 }

--- a/crates/burn-autodiff/src/tests/repeat.rs
+++ b/crates/burn-autodiff/src/tests/repeat.rs
@@ -1,0 +1,24 @@
+#[burn_tensor_testgen::testgen(ad_repeat)]
+mod tests {
+    use super::*;
+    use burn_tensor::{activation, Data};
+
+    #[test]
+    fn should_diff_repeat() {
+        let data_1 = Data::<f32, 2>::from([[1.0, 7.0], [-2.0, -3.0]]);
+        let data_2 = Data::<f32, 2>::from([[4.0], [2.0]]);
+
+        let device = Default::default();
+        let tensor_1 = TestAutodiffTensor::from_data(data_1, &device).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data(data_2, &device).require_grad();
+
+        let tensor_3 = tensor_2.clone().repeat(1, 3);
+
+        let tensor_3 = tensor_1.matmul(tensor_3);
+        let grads = tensor_3.backward();
+
+        let grad_2 = tensor_2.grad(&grads).unwrap();
+
+        assert_eq!(grad_2.to_data(), Data::from([[-3.0], [12.0]]));
+    }
+}


### PR DESCRIPTION
I implemented the backward pass for repeat, enabling it to use the jit kernel of repeat instead of the fallback implementation with slice assign. 
I also added fusion support for repeat

Also fixed ones and zeros in autodiff which were mistakingly cpu-bound