### PR TITLE
JIT: Autotune matmul tiling 2d unroll

### DIFF
--- a/crates/burn-jit/src/kernel/matmul/base.rs
+++ b/crates/burn-jit/src/kernel/matmul/base.rs
@@ -25,6 +25,8 @@ pub struct Tiling2dConfig {
     pub tile_size_m: usize,
     /// Tile size along dimension of rhs
     pub tile_size_n: usize,
+    /// Loop unrolling
+    pub unroll: bool,
 }
 
 impl Tiling2dConfig {
@@ -37,6 +39,7 @@ impl Tiling2dConfig {
         block_size_n: usize,
         tile_size_m: usize,
         tile_size_n: usize,
+        unroll: bool,
     ) -> Self {
         assert!(grid_x == f32::ceil(block_size_m as f32 / tile_size_m as f32) as usize);
         assert!(grid_y == f32::ceil(block_size_n as f32 / tile_size_n as f32) as usize);
@@ -61,6 +64,7 @@ impl Tiling2dConfig {
             block_size_n,
             tile_size_m,
             tile_size_n,
+            unroll,
         }
     }
 }
@@ -75,6 +79,7 @@ impl Default for Tiling2dConfig {
             block_size_n: 64,
             tile_size_m: 4,
             tile_size_n: 4,
+            unroll: false,
         }
     }
 }
@@ -99,11 +104,10 @@ pub enum MatmulStrategy {
     Autotune,
 }
 
-#[cfg(feature = "autotune")]
 #[cfg(not(feature = "autotune"))]
 impl Default for MatmulStrategy {
     fn default() -> Self {
-        MatmulStrategy::Tiling2d
+        MatmulStrategy::Tiling2d(Tiling2dConfig::default())
     }
 }
 

--- a/crates/burn-jit/src/kernel/matmul/base.rs
+++ b/crates/burn-jit/src/kernel/matmul/base.rs
@@ -30,7 +30,7 @@ pub struct Tiling2dConfig {
 }
 
 impl Tiling2dConfig {
-    #[allow(unused)]
+    #[allow(unused, clippy::too_many_arguments)]
     fn new<R: Runtime>(
         grid_x: usize,
         grid_y: usize,

--- a/crates/burn-jit/src/kernel/matmul/tiling2d.rs
+++ b/crates/burn-jit/src/kernel/matmul/tiling2d.rs
@@ -45,7 +45,6 @@ impl<R: Runtime> GpuComputeShaderPhase for MatmulTiling2dEagerKernel<R> {
             variables: gpu::BinaryOperator { lhs, rhs, out },
             config: self.config.clone(),
             bounds_check_required: self.bounds_check_required,
-            unroll: true,
         }
         .expand(&mut scope);
 

--- a/crates/burn-jit/src/kernel/matmul/tiling2d_shader/base.rs
+++ b/crates/burn-jit/src/kernel/matmul/tiling2d_shader/base.rs
@@ -9,7 +9,6 @@ pub(crate) struct MatmulTiling2dShader {
     pub variables: BinaryOperator,
     pub config: Tiling2dConfig,
     pub bounds_check_required: bool,
-    pub unroll: bool,
 }
 
 pub(crate) struct Tiling2dState {

--- a/crates/burn-jit/src/kernel/matmul/tiling2d_shader/load_shared_memory.rs
+++ b/crates/burn-jit/src/kernel/matmul/tiling2d_shader/load_shared_memory.rs
@@ -98,7 +98,7 @@ fn load_shared_memory_with_bound_check(
 
     gpu!(
         scope,
-        range(0_u32, 4u32, shader.unroll).for_each(|j, scope| {
+        range(0_u32, 4u32, shader.config.unroll).for_each(|j, scope| {
             gpu!(scope, current = thread_idx_1 + j);
 
             gpu!(scope, aligned_with_shared_memory = current < block_size_k);
@@ -235,7 +235,7 @@ fn load_shared_memory_no_bound_check(
 
     gpu!(
         scope,
-        range(0_u32, 4u32, shader.unroll).for_each(|j, scope| {
+        range(0_u32, 4u32, shader.config.unroll).for_each(|j, scope| {
             gpu!(scope, current = thread_idx_1 + j);
 
             gpu!(scope, aligned_with_shared_memory = current < block_size_k);

--- a/crates/burn-jit/src/kernel/matmul/tiling2d_shader/write_output.rs
+++ b/crates/burn-jit/src/kernel/matmul/tiling2d_shader/write_output.rs
@@ -23,12 +23,12 @@ pub fn write_to_output(
 
         gpu!(
             scope,
-            range(0u32, shader.config.tile_size_m as u32, shader.unroll).for_each(
+            range(0u32, shader.config.tile_size_m as u32, shader.config.unroll).for_each(
                 |res_idx_m, scope| {
                     gpu!(
                         scope,
-                        range(0u32, shader.config.tile_size_n as u32, shader.unroll).for_each(
-                            |res_idx_n, scope| {
+                        range(0u32, shader.config.tile_size_n as u32, shader.config.unroll)
+                            .for_each(|res_idx_n, scope| {
                                 gpu!(scope, row_index = row + res_idx_m);
                                 gpu!(scope, col_index = col + res_idx_n);
 
@@ -47,8 +47,7 @@ pub fn write_to_output(
                                         col_index,
                                     );
                                 }));
-                            }
-                        )
+                            })
                     );
                 }
             )
@@ -56,12 +55,12 @@ pub fn write_to_output(
     } else {
         gpu!(
             scope,
-            range(0u32, shader.config.tile_size_m as u32, shader.unroll).for_each(
+            range(0u32, shader.config.tile_size_m as u32, shader.config.unroll).for_each(
                 |res_idx_m, scope| {
                     gpu!(
                         scope,
-                        range(0u32, shader.config.tile_size_n as u32, shader.unroll).for_each(
-                            |res_idx_n, scope| {
+                        range(0u32, shader.config.tile_size_n as u32, shader.config.unroll)
+                            .for_each(|res_idx_n, scope| {
                                 gpu!(scope, row_index = row + res_idx_m);
                                 gpu!(scope, col_index = col + res_idx_n);
 
@@ -74,8 +73,7 @@ pub fn write_to_output(
                                     row_index,
                                     col_index,
                                 )
-                            }
-                        )
+                            })
                     );
                 }
             )

--- a/crates/burn-jit/src/kernel/matmul/tune/base.rs
+++ b/crates/burn-jit/src/kernel/matmul/tune/base.rs
@@ -132,12 +132,26 @@ matmul_tune_ops!(SimpleMatmul16x16, |lhs, rhs, out| {
     crate::kernel::matmul::matmul_simple(lhs, rhs, out, 16, 16)
 });
 
-// Probably the fastest when fixed sizes.
+// Probably the fastest when fixed size, without loop unrolling
 matmul_tune_ops!(Tiling2dMatmulPadded, |lhs, rhs, out| {
     crate::kernel::matmul::matmul_tiling_2d_padded(lhs, rhs, out, Tiling2dConfig::default())
 });
 
-// Probably the fastest in the general case
+// Probably the fastest when fixed sizes, with loop unrolling
+matmul_tune_ops!(Tiling2dMatmulPaddedUnrolled, |lhs, rhs, out| {
+    let mut config = Tiling2dConfig::default();
+    config.unroll = true;
+    crate::kernel::matmul::matmul_tiling_2d_padded(lhs, rhs, out, config)
+});
+
+// Probably the fastest in the general case, without loop unrolling
 matmul_tune_ops!(Tiling2dMatmul, |lhs, rhs, out| {
     crate::kernel::matmul::matmul_tiling_2d(lhs, rhs, out, Tiling2dConfig::default())
+});
+
+// Probably the fastest in the general case, with loop unrolling
+matmul_tune_ops!(Tiling2dMatmulUnrolled, |lhs, rhs, out| {
+    let mut config = Tiling2dConfig::default();
+    config.unroll = true;
+    crate::kernel::matmul::matmul_tiling_2d(lhs, rhs, out, config)
 });

--- a/crates/burn-jit/src/kernel/matmul/tune/base.rs
+++ b/crates/burn-jit/src/kernel/matmul/tune/base.rs
@@ -139,9 +139,15 @@ matmul_tune_ops!(Tiling2dMatmulPadded, |lhs, rhs, out| {
 
 // Probably the fastest when fixed sizes, with loop unrolling
 matmul_tune_ops!(Tiling2dMatmulPaddedUnrolled, |lhs, rhs, out| {
-    let mut config = Tiling2dConfig::default();
-    config.unroll = true;
-    crate::kernel::matmul::matmul_tiling_2d_padded(lhs, rhs, out, config)
+    crate::kernel::matmul::matmul_tiling_2d_padded(
+        lhs,
+        rhs,
+        out,
+        Tiling2dConfig {
+            unroll: true,
+            ..Default::default()
+        },
+    )
 });
 
 // Probably the fastest in the general case, without loop unrolling
@@ -151,7 +157,13 @@ matmul_tune_ops!(Tiling2dMatmul, |lhs, rhs, out| {
 
 // Probably the fastest in the general case, with loop unrolling
 matmul_tune_ops!(Tiling2dMatmulUnrolled, |lhs, rhs, out| {
-    let mut config = Tiling2dConfig::default();
-    config.unroll = true;
-    crate::kernel::matmul::matmul_tiling_2d(lhs, rhs, out, config)
+    crate::kernel::matmul::matmul_tiling_2d_padded(
+        lhs,
+        rhs,
+        out,
+        Tiling2dConfig {
+            unroll: true,
+            ..Default::default()
+        },
+    )
 });

--- a/crates/burn-jit/src/kernel/matmul/tune/base.rs
+++ b/crates/burn-jit/src/kernel/matmul/tune/base.rs
@@ -65,6 +65,16 @@ impl<R: Runtime, E: JitElement + Element, const D: usize> AutotuneOperationSet<J
                 rhs.clone(),
                 out.clone(),
             )),
+            Box::new(Tiling2dMatmulPaddedUnrolled::new(
+                lhs.clone(),
+                rhs.clone(),
+                out.clone(),
+            )),
+            Box::new(Tiling2dMatmulUnrolled::new(
+                lhs.clone(),
+                rhs.clone(),
+                out.clone(),
+            )),
         ]
     }
 
@@ -74,6 +84,10 @@ impl<R: Runtime, E: JitElement + Element, const D: usize> AutotuneOperationSet<J
             1 => Box::new(SimpleMatmul16x16::new(self.lhs, self.rhs, self.out)),
             2 => Box::new(Tiling2dMatmul::new(self.lhs, self.rhs, self.out)),
             3 => Box::new(Tiling2dMatmulPadded::new(self.lhs, self.rhs, self.out)),
+            4 => Box::new(Tiling2dMatmulPaddedUnrolled::new(
+                self.lhs, self.rhs, self.out,
+            )),
+            5 => Box::new(Tiling2dMatmulUnrolled::new(self.lhs, self.rhs, self.out)),
             _ => panic!("Fastest index is out of bound"),
         }
     }


### PR DESCRIPTION
Loop unrolling was always activated in tiling 2d, which had severe performance deterioration on some devices (metal, namely)
It's now autotuned. 