### PR TITLE
Fix guide project name in the book

### DIFF
--- a/burn-book/src/basic-workflow/backend.md
+++ b/burn-book/src/basic-workflow/backend.md
@@ -28,9 +28,7 @@ fn main() {
 You might be wondering why we use the `guide` prefix to bring the different modules we just
 implemented into scope. Instead of including the code in the current guide in a single file, we
 separated it into different files which group related code into _modules_. The `guide` is simply the
-name we gave to our _crate_, which contains the different files. If you named your project crate
-as `my-first-burn-model`,
-you can equivalently replace all usages of `guide` above with `my-first-burn-model`. Below is a brief explanation of the
+name we gave to our _crate_, which contains the different files. Below is a brief explanation of the
 different parts of the Rust module system.
 
 A **package** is a bundle of one or more crates that provides a set of functionality. A package
@@ -40,9 +38,9 @@ A **crate** is a compilation unit in Rust. It could be a single file, but it is 
 split up crates into multiple _modules_ and possibly multiple files. A crate can come in one of two
 forms: a binary crate or a library crate. When compiling a crate, the compiler first looks in the
 crate root file (usually `src/lib.rs` for a library crate or `src/main.rs` for a binary crate). Any
-module declared in the crate root file will be inserted in the crate for compilation. For this demo example, we will
-define a library crate where all the individual modules (model, data, training, etc.) are listed inside `src/lib.rs` as
-follows:
+module declared in the crate root file will be inserted in the crate for compilation. For this demo
+example, we will define a library crate where all the individual modules (model, data, training,
+etc.) are listed inside `src/lib.rs` as follows:
 
 ```
 pub mod data;
@@ -52,11 +50,11 @@ pub mod training;
 ```
 
 A **module** lets us organize code within a crate for readability and easy reuse. Modules also allow
-us to control the _privacy_ of items. The `pub` keyword used above, for example, is employed to make a module publicly
-available inside the crate.
+us to control the _privacy_ of items. The `pub` keyword used above, for example, is employed to make
+a module publicly available inside the crate.
 
-The entry point of our program is the `main` function, defined in the `examples/guide.rs` file. The file structure
-for this example is illustrated below:
+The entry point of our program is the `main` function, defined in the `examples/guide.rs` file. The
+file structure for this example is illustrated below:
 
 ```
 guide
@@ -72,8 +70,8 @@ guide
 ```
 
 The source for this guide can be found in our
-[GitHub repository](https://github.com/tracel-ai/burn/tree/main/examples/guide) which can be used to run this basic
-workflow example end-to-end.\
+[GitHub repository](https://github.com/tracel-ai/burn/tree/main/examples/guide) which can be used to
+run this basic workflow example end-to-end.\
 
 </details><br>
 

--- a/burn-book/src/basic-workflow/model.md
+++ b/burn-book/src/basic-workflow/model.md
@@ -4,17 +4,17 @@ The first step is to create a project and add the different Burn dependencies. S
 new project with Cargo:
 
 ```console
-cargo new my-first-burn-model
+cargo new guide
 ```
 
 As [mentioned previously](../getting-started.md#creating-a-burn-application), this will initialize
-your `my-first-burn-model` project directory with a `Cargo.toml` and a `src/main.rs` file.
+your `guide` project directory with a `Cargo.toml` and a `src/main.rs` file.
 
 In the `Cargo.toml` file, add the `burn` dependency with `train`, `wgpu` and `vision` features.
 
 ```toml
 [package]
-name = "my-first-burn-model"
+name = "guide"
 version = "0.1.0"
 edition = "2021"
 
@@ -279,9 +279,10 @@ network modules already built with Burn use the `forward` nomenclature, simply b
 standard in the field.
 
 Similar to neural network modules, the [`Tensor`](../building-blocks/tensor.md) struct given as a
-parameter also takes the Backend trait as a generic argument, alongside its dimensionality. Even if it is not
-used in this specific example, it is possible to add the kind of the tensor as a third generic
-argument. For example, a 3-dimensional Tensor of different data types(float, int, bool) would be defined as following:
+parameter also takes the Backend trait as a generic argument, alongside its dimensionality. Even if
+it is not used in this specific example, it is possible to add the kind of the tensor as a third
+generic argument. For example, a 3-dimensional Tensor of different data types(float, int, bool)
+would be defined as following:
 
 ```rust , ignore
 Tensor<B, 3> // Float tensor (default)


### PR DESCRIPTION
### Checklist

- [x] Made sure the book is up to date with changes in this PR.

### Changes

As pointed out by users on discord, the project name mismatch when getting started might be confusing. I renamed the project name from `my-first-burn-model` to `guide` so it follows the naming of the repository example.