### PR TITLE
remove JIT "subsequent" PRNG tests

### DIFF
--- a/crates/burn-jit/src/tests/bernoulli.rs
+++ b/crates/burn-jit/src/tests/bernoulli.rs
@@ -13,27 +13,6 @@ mod tests {
 
     #[test]
     #[serial]
-    fn subsequent_calls_give_different_tensors() {
-        TestBackend::seed(0);
-        let shape: Shape<2> = [40, 40].into();
-        let device = Default::default();
-
-        let tensor_1 =
-            Tensor::<TestBackend, 2>::random(shape.clone(), Distribution::Bernoulli(0.5), &device);
-        let tensor_2 =
-            Tensor::<TestBackend, 2>::random(shape.clone(), Distribution::Bernoulli(0.5), &device);
-        let mut diff_exists = false;
-        for i in 0..shape.num_elements() {
-            if tensor_1.to_data().value[i] != tensor_2.to_data().value[i] {
-                diff_exists = true;
-                break;
-            }
-        }
-        assert!(diff_exists);
-    }
-
-    #[test]
-    #[serial]
     fn number_of_1_proportional_to_prob() {
         TestBackend::seed(0);
         let shape: Shape<2> = [40, 40].into();

--- a/crates/burn-jit/src/tests/normal.rs
+++ b/crates/burn-jit/src/tests/normal.rs
@@ -7,22 +7,6 @@ mod tests {
 
     #[test]
     #[serial]
-    fn subsequent_calls_give_different_tensors() {
-        TestBackend::seed(0);
-        let shape = [4, 5];
-        let device = Default::default();
-
-        let tensor_1 =
-            Tensor::<TestBackend, 2>::random(shape, Distribution::Normal(0., 1.), &device);
-        let tensor_2 =
-            Tensor::<TestBackend, 2>::random(shape, Distribution::Normal(0., 1.), &device);
-        for i in 0..20 {
-            assert!(tensor_1.to_data().value[i] != tensor_2.to_data().value[i]);
-        }
-    }
-
-    #[test]
-    #[serial]
     fn empirical_mean_close_to_expectation() {
         TestBackend::seed(0);
         let shape = [100, 100];

--- a/crates/burn-jit/src/tests/uniform.rs
+++ b/crates/burn-jit/src/tests/uniform.rs
@@ -10,20 +10,6 @@ mod tests {
 
     #[test]
     #[serial]
-    fn subsequent_calls_give_different_tensors() {
-        TestBackend::seed(0);
-        let shape = [4, 5];
-        let device = Default::default();
-
-        let tensor_1 = Tensor::<TestBackend, 2>::random(shape, Distribution::Default, &device);
-        let tensor_2 = Tensor::<TestBackend, 2>::random(shape, Distribution::Default, &device);
-        for i in 0..20 {
-            assert!(tensor_1.to_data().value[i] != tensor_2.to_data().value[i]);
-        }
-    }
-
-    #[test]
-    #[serial]
     fn values_all_within_interval_default() {
         TestBackend::seed(0);
         let shape = [24, 24];


### PR DESCRIPTION
I removed the `subsequent_calls_give_different_tensors` tests from JIT PRNG

Their role was simply to ensure that calling random twice gives different results, i.e. calling random changes the rng state. 
This actually happens in the get_seed cpu function, not in the kernels, so it did not even test anything related to the gpu code. 

The problem is that they were flaky tests, because if the seed was modified by some other thread between the two calls to random, it failed. Putting the tests serial was not enough because serial does not guarantee that tests from other modules won't interfere. 

Not a big loss, and should stabilize CI. 
Fix #1648 