### PR TITLE
fix: `window` -> `pub window` in `dataset/mod.rs`

### DIFF
--- a/crates/burn-dataset/src/dataset/mod.rs
+++ b/crates/burn-dataset/src/dataset/mod.rs
@@ -12,5 +12,6 @@ pub use self::fake::*;
 pub use base::*;
 pub use in_memory::*;
 pub use iterator::*;
+pub use window::*;
 #[cfg(any(feature = "sqlite", feature = "sqlite-bundled"))]
 pub use sqlite::*;

--- a/crates/burn-dataset/src/dataset/mod.rs
+++ b/crates/burn-dataset/src/dataset/mod.rs
@@ -12,6 +12,6 @@ pub use self::fake::*;
 pub use base::*;
 pub use in_memory::*;
 pub use iterator::*;
-pub use window::*;
 #[cfg(any(feature = "sqlite", feature = "sqlite-bundled"))]
 pub use sqlite::*;
+pub use window::*;

--- a/crates/burn-dataset/src/dataset/window.rs
+++ b/crates/burn-dataset/src/dataset/window.rs
@@ -9,7 +9,7 @@ impl<'a, I> WindowDataset<'a, I> {
     /// # Parameters
     ///
     /// - `dataset`: The dataset over which windows will be created.
-    /// - `size`: The size of the window.
+    /// - `size`: The size of the windows.
     ///
     /// # Returns
     ///
@@ -24,6 +24,7 @@ impl<'a, I> WindowDataset<'a, I> {
 
 /// Dataset designed to work with overlapping windows of data.
 pub struct WindowDataset<'a, I> {
+    /// The size of the windows.
     pub size: NonZeroUsize,
     dataset: &'a dyn Dataset<I>,
 }


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

- Should've been part of https://github.com/tracel-ai/burn/pull/1553

### Changes

- Makes `window::*` public, so that the `WindowDataset` struct can be imported.
- Docs improved for: `pub size: NonZeroUsize`/`WindowDataset`.

### Testing

Tested in https://github.com/tracel-ai/burn/pull/1532
