### PR TITLE
Fix fusion with inplace

### DIFF
--- a/crates/burn-core/src/nn/rnn/lstm.rs
+++ b/crates/burn-core/src/nn/rnn/lstm.rs
@@ -330,6 +330,19 @@ mod tests {
     }
 
     #[test]
+    fn test_batched_forward_pass_batch_of_one() {
+        let device = Default::default();
+        let lstm = LstmConfig::new(64, 1024, true).init(&device);
+        let batched_input =
+            Tensor::<TestBackend, 3>::random([1, 10, 64], Distribution::Default, &device);
+
+        let (cell_state, hidden_state) = lstm.forward(batched_input, None);
+
+        assert_eq!(cell_state.shape().dims, [1, 10, 1024]);
+        assert_eq!(hidden_state.shape().dims, [1, 10, 1024]);
+    }
+
+    #[test]
     #[cfg(feature = "std")]
     fn test_batched_backward_pass() {
         use burn_tensor::Shape;

--- a/crates/burn-jit/src/codegen/compilation.rs
+++ b/crates/burn-jit/src/codegen/compilation.rs
@@ -193,7 +193,10 @@ impl CompilationSettings {
                     if chosen.is_some() {
                         break;
                     }
-                    if desc.shape == desc_input.shape && input.item() == output.item() {
+                    if desc.shape == desc_input.shape
+                        && input.item() == output.item()
+                        && desc.id == desc_input.id
+                    {
                         chosen = Some(index);
                     }
                 }

--- a/crates/burn-jit/src/codegen/compilation.rs
+++ b/crates/burn-jit/src/codegen/compilation.rs
@@ -190,7 +190,8 @@ impl CompilationSettings {
 
                 let mut chosen = None;
                 for (index, (_, desc_input, input)) in potential_inplace.iter().enumerate() {
-                    if chosen.is_some() {
+                    if desc.id == desc_input.id {
+                        chosen = Some(index);
                         break;
                     }
                     if desc.shape == desc_input.shape


### PR DESCRIPTION
The bug in #1656 seems to be caused by fusion when it works on several read-write tensors. 

What happened was rather subtle: if the output of the fused kernel was a mutable tensor, then it was "Readwrite", even if there were only writes to it  in this specific kernel. So while looking to match the outputs with potential inplace inputs it would not find itself and could wrongly assume that another tensor with the same shape could was it. So it did not write to the right tensor. 

Batches of one allowed to detect it, but I think the bug happened with other batch sizes as well. 

@nathanielsimard I'm not sure why this id comparison was not there before. Could adding it break something? 

Fix #1656 