### PR TITLE
make `find_owned_graph` iterative

### DIFF
--- a/crates/burn-autodiff/src/runtime/memory_management.rs
+++ b/crates/burn-autodiff/src/runtime/memory_management.rs
@@ -145,18 +145,21 @@ impl GraphMemoryManagement {
         Some(updated_graph_id)
     }
 
-    fn find_owned_graph(&mut self, graph_id: GraphId) -> Option<GraphId> {
-        let graph = match self.graphs.get(&graph_id) {
-            Some(val) => val,
-            None => return None,
-        };
+    fn find_owned_graph(&mut self, mut graph_id: GraphId) -> Option<GraphId> {
+        loop {
+            let graph = match self.graphs.get(&graph_id) {
+                Some(val) => val,
+                None => return None,
+            };
 
-        let merged_graph_id = match graph {
-            GraphState::Merged(graph_id) => graph_id,
-            GraphState::Owned(_) => return Some(graph_id),
-        };
-
-        self.find_owned_graph(*merged_graph_id)
+            match graph {
+                GraphState::Merged(new_graph_id) => {
+                    graph_id = *new_graph_id;
+                    continue;
+                }
+                GraphState::Owned(_) => return Some(graph_id),
+            };
+        }
     }
 }
 


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ ] Confirmed that `run-checks all` script has been executed.
^nnnnnope, ` ./run-checks.sh std` fails on wgpu, probably because I'm on WSL, let's see what CI thinks.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

https://github.com/open-spaced-repetition/fsrs-browser/issues/23

### Changes

While upgrading to 0.13.1, fsrs-browser discovered that the WASM call stack was being blown by `find_owned_graph` because it was recursive. This PR makes `find_owned_graph` iterative.

Me no write Rust good. Plz be not afraid to clean up bad style or fix incorrectness.

### Testing

None.
