### PR TITLE
Fix ONNX and PyTorch import section links in burn book

### DIFF
--- a/burn-book/src/import/README.md
+++ b/burn-book/src/import/README.md
@@ -3,8 +3,8 @@
 The Burn project supports the import of models from various frameworks, emphasizing efficiency and
 compatibility. Currently, it handles two primary model formats:
 
-1. [ONNX](./onnx-model): Facilitates direct import, ensuring the model's performance and structure
+1. [ONNX](./onnx-model.md): Facilitates direct import, ensuring the model's performance and structure
    are maintained.
 
-2. [PyTorch](./pytorch-model): Enables the loading of PyTorch model weights into Burn’s native model
+2. [PyTorch](./pytorch-model.md): Enables the loading of PyTorch model weights into Burn’s native model
    architecture, ensuring seamless integration.


### PR DESCRIPTION
Links are invalid, so the user is redirected to the burn.dev homepage.

### Related Issues/PRs

Fixes #1671 