### PR TITLE
Fix inverted epoch - iteration counts in valid progress

### DIFF
--- a/examples/custom-training-loop/src/lib.rs
+++ b/examples/custom-training-loop/src/lib.rs
@@ -95,8 +95,8 @@ pub fn run<B: AutodiffBackend>(device: B::Device) {
 
             println!(
                 "[Valid - Epoch {} - Iteration {}] Loss {} | Accuracy {}",
-                iteration,
                 epoch,
+                iteration,
                 loss.clone().into_scalar(),
                 accuracy,
             );


### PR DESCRIPTION
The iteration and epoch counts are inverted in the custom training loop example.

```
[Valid - Epoch 0 - Iteration 3] Loss 0.2914832 | Accuracy 90.625
[Valid - Epoch 1 - Iteration 3] Loss 0.08417652 | Accuracy 95.3125
[Valid - Epoch 2 - Iteration 3] Loss 0.1853882 | Accuracy 93.75
[Valid - Epoch 3 - Iteration 3] Loss 0.027896263 | Accuracy 100
[Valid - Epoch 4 - Iteration 3] Loss 0.027823677 | Accuracy 100
[Valid - Epoch 5 - Iteration 3] Loss 0.11582196 | Accuracy 96.875
[Valid - Epoch 6 - Iteration 3] Loss 0.08146551 | Accuracy 98.4375
[Valid - Epoch 7 - Iteration 3] Loss 0.09941933 | Accuracy 96.875
```

Found this little mistake while running all the examples for the patch.