### PR TITLE
Fix ONNX linear bug by not updating shape for linear if not present

### DIFF
--- a/crates/burn-import/src/onnx/dim_inference.rs
+++ b/crates/burn-import/src/onnx/dim_inference.rs
@@ -119,16 +119,17 @@ fn linear_update_outputs(node: &mut Node) {
     // known, we can calculate the output shape.
     if let ArgType::Tensor(tensor) = node_input.clone().ty {
         let mut tensor = tensor.clone();
-        let mut shape = tensor.shape.clone().unwrap();
 
-        if let ArgType::Tensor(weight_tensor) = weight.clone().ty {
-            let last = shape.last_mut().unwrap();
-            *last = *weight_tensor.shape.unwrap().first().unwrap();
-        } else {
-            panic!("Weight must be a tensor");
+        // Update the shape of the output tensor if it's known
+        if let Some(mut shape) = tensor.shape.clone() {
+            if let ArgType::Tensor(weight_tensor) = weight.clone().ty {
+                let last = shape.last_mut().unwrap();
+                *last = *weight_tensor.shape.unwrap().first().unwrap();
+            } else {
+                panic!("Weight must be a tensor");
+            }
+            tensor.shape = Some(shape);
         }
-
-        tensor.shape = Some(shape);
 
         // Update the output tensor
         node.outputs[0].ty = ArgType::Tensor(tensor);


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

#1560

### Changes

Input shapes are not always present, so we skip updating the output if not known.

### Testing

Tested on the user provided ONNX file in #1560
