### PR TITLE
Exclude burn-cuda from workspace to avoid build error for some users

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,22 +462,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "burn-cuda"
-version = "0.14.0"
-dependencies = [
- "burn-common",
- "burn-compute",
- "burn-fusion",
- "burn-jit",
- "burn-tensor",
- "bytemuck",
- "cudarc",
- "derive-new",
- "half",
- "log",
-]
-
-[[package]]
 name = "burn-dataset"
 version = "0.14.0"
 dependencies = [
@@ -3790,6 +3774,14 @@ dependencies = [
  "getrandom",
  "libredox",
  "thiserror",
+]
+
+[[package]]
+name = "refactor"
+version = "0.14.0"
+dependencies = [
+ "burn",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,10 @@ members = [
     "xtask",
 ]
 
-exclude = ["examples/notebook"]
+exclude = [
+    "examples/notebook",
+    "crates/burn-cuda"     # comment this line to work on burn-cuda
+]
 
 [workspace.package]
 edition = "2021"


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

Temporary stop gap measures to avoid burn build errors.

This PR excludes `burn-cuda` from the workspace members to avoid build errors with `cargo build` for users without any CUDA toolkit installed. As `burn-cuda` is not yet operational it seems not convenient to force user to install a toolkit for it.

Contributors willing to work on `burn-cuda` should opt-it and remove the package from the excluded members in the `cargo.toml` file.

