### PR TITLE
Add cumulative sum tensor operation

### DIFF
--- a/crates/burn-autodiff/src/ops/int_tensor.rs
+++ b/crates/burn-autodiff/src/ops/int_tensor.rs
@@ -161,6 +161,10 @@ impl<B: Backend, C: CheckpointStrategy> IntTensorOps<Self> for Autodiff<B, C> {
         B::int_sum_dim(tensor, dim)
     }
 
+    fn int_cumsum_dim<const D: usize>(tensor: IntTensor<B, D>, dim: usize) -> IntTensor<B, D> {
+        B::int_cumsum_dim(tensor, dim)
+    }
+
     fn int_mean<const D: usize>(tensor: IntTensor<B, D>) -> IntTensor<B, 1> {
         B::int_mean(tensor)
     }

--- a/crates/burn-autodiff/src/ops/int_tensor.rs
+++ b/crates/burn-autodiff/src/ops/int_tensor.rs
@@ -161,8 +161,8 @@ impl<B: Backend, C: CheckpointStrategy> IntTensorOps<Self> for Autodiff<B, C> {
         B::int_sum_dim(tensor, dim)
     }
 
-    fn int_cumsum_dim<const D: usize>(tensor: IntTensor<B, D>, dim: usize) -> IntTensor<B, D> {
-        B::int_cumsum_dim(tensor, dim)
+    fn int_cumsum<const D: usize>(tensor: IntTensor<B, D>, dim: usize) -> IntTensor<B, D> {
+        B::int_cumsum(tensor, dim)
     }
 
     fn int_mean<const D: usize>(tensor: IntTensor<B, D>) -> IntTensor<B, 1> {

--- a/crates/burn-autodiff/src/ops/tensor.rs
+++ b/crates/burn-autodiff/src/ops/tensor.rs
@@ -1600,7 +1600,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
         }
     }
 
-    fn float_cumsum_dim<const D: usize>(
+    fn float_cumsum<const D: usize>(
         tensor: FloatTensor<Self, D>,
         dim: usize,
     ) -> FloatTensor<Self, D> {
@@ -1619,7 +1619,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                 let (shape, dim) = ops.state;
 
                 unary::<B, D, D, _>(ops.parents, ops.node, grads, |grad| {
-                    let cumsum_grad = B::float_cumsum_dim(grad.clone(), dim);
+                    let cumsum_grad = B::float_cumsum(grad.clone(), dim);
                     B::float_flip(cumsum_grad.clone(), &[dim])
                 });
             }
@@ -1632,9 +1632,9 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
         {
             OpsKind::Tracked(prep) => prep.finish(
                 (B::float_shape(&tensor.primitive), dim),
-                B::float_cumsum_dim(tensor.primitive, dim),
+                B::float_cumsum(tensor.primitive, dim),
             ),
-            OpsKind::UnTracked(prep) => prep.finish(B::float_cumsum_dim(tensor.primitive, dim)),
+            OpsKind::UnTracked(prep) => prep.finish(B::float_cumsum(tensor.primitive, dim)),
         }
     }
 

--- a/crates/burn-autodiff/src/tests/cumsum.rs
+++ b/crates/burn-autodiff/src/tests/cumsum.rs
@@ -1,17 +1,17 @@
-#[burn_tensor_testgen::testgen(ad_cumsum_dim)]
+#[burn_tensor_testgen::testgen(ad_cumsum)]
 mod tests {
     use super::*;
     use burn_tensor::Data;
 
     #[test]
-    fn should_diff_cumsum_dim() {
+    fn should_diff_cumsum() {
         let device = Default::default();
         let data = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]);
         // Original Tensor
         let tensor_0 = TestAutodiffTensor::from_data(data, &device).require_grad();
         // Cumsum Tensor
         let dim = 1;
-        let tensor_1 = tensor_0.clone().cumsum_dim(dim);
+        let tensor_1 = tensor_0.clone().cumsum(dim);
         // Fake loss
         let loss = tensor_1.clone().sum();
         // Gradients with respect to the original tensor

--- a/crates/burn-autodiff/src/tests/cumsum_dim.rs
+++ b/crates/burn-autodiff/src/tests/cumsum_dim.rs
@@ -1,0 +1,25 @@
+#[burn_tensor_testgen::testgen(ad_cumsum_dim)]
+mod tests {
+    use super::*;
+    use burn_tensor::Data;
+
+    #[test]
+    fn should_diff_cumsum_dim() {
+        let device = Default::default();
+        let data = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]);
+        // Original Tensor
+        let tensor_0 = TestAutodiffTensor::from_data(data, &device).require_grad();
+        // Cumsum Tensor
+        let dim = 1;
+        let tensor_1 = tensor_0.clone().cumsum_dim(dim);
+        // Fake loss
+        let loss = tensor_1.clone().sum();
+        // Gradients with respect to the original tensor
+        let grads = loss.backward();
+        // let grads = tensor_1.backward();
+        let grad_0 = tensor_0.grad(&grads).unwrap();
+        // Gradient is correct
+        let grad_0_expected = Data::from([[3., 2., 1.], [3., 2., 1.], [3., 2., 1.]]);
+        grad_0.into_data().assert_approx_eq(&grad_0_expected, 2);
+    }
+}

--- a/crates/burn-autodiff/src/tests/mod.rs
+++ b/crates/burn-autodiff/src/tests/mod.rs
@@ -19,7 +19,7 @@ mod conv_transpose1d;
 mod conv_transpose2d;
 mod cos;
 mod cross_entropy;
-mod cumsum_dim;
+mod cumsum;
 mod div;
 mod erf;
 mod exp;
@@ -113,7 +113,7 @@ macro_rules! testgen_all {
         burn_autodiff::testgen_ad_mul!();
         burn_autodiff::testgen_ad_neg!();
         burn_autodiff::testgen_ad_powf!();
-        burn_autodiff::testgen_ad_cumsum_dim!();
+        burn_autodiff::testgen_ad_cumsum!();
         burn_autodiff::testgen_ad_recip!();
         burn_autodiff::testgen_ad_reshape!();
         burn_autodiff::testgen_ad_sin!();

--- a/crates/burn-autodiff/src/tests/mod.rs
+++ b/crates/burn-autodiff/src/tests/mod.rs
@@ -19,6 +19,7 @@ mod conv_transpose1d;
 mod conv_transpose2d;
 mod cos;
 mod cross_entropy;
+mod cumsum_dim;
 mod div;
 mod erf;
 mod exp;
@@ -112,6 +113,7 @@ macro_rules! testgen_all {
         burn_autodiff::testgen_ad_mul!();
         burn_autodiff::testgen_ad_neg!();
         burn_autodiff::testgen_ad_powf!();
+        burn_autodiff::testgen_ad_cumsum_dim!();
         burn_autodiff::testgen_ad_recip!();
         burn_autodiff::testgen_ad_reshape!();
         burn_autodiff::testgen_ad_sin!();

--- a/crates/burn-candle/src/ops/int_tensor.rs
+++ b/crates/burn-candle/src/ops/int_tensor.rs
@@ -321,7 +321,7 @@ impl<F: FloatCandleElement, I: IntCandleElement> IntTensorOps<Self> for Candle<F
         CandleTensor::new(tensor.tensor.sum_keepdim(dim).unwrap())
     }
 
-    fn int_cumsum_dim<const D: usize>(
+    fn int_cumsum<const D: usize>(
         tensor: IntTensor<Self, D>,
         dim: usize,
     ) -> IntTensor<Self, D> {

--- a/crates/burn-candle/src/ops/int_tensor.rs
+++ b/crates/burn-candle/src/ops/int_tensor.rs
@@ -321,6 +321,13 @@ impl<F: FloatCandleElement, I: IntCandleElement> IntTensorOps<Self> for Candle<F
         CandleTensor::new(tensor.tensor.sum_keepdim(dim).unwrap())
     }
 
+    fn int_cumsum_dim<const D: usize>(
+        tensor: IntTensor<Self, D>,
+        dim: usize,
+    ) -> IntTensor<Self, D> {
+        CandleTensor::new(tensor.tensor.cumsum(dim).unwrap())
+    }
+
     fn int_prod<const D: usize>(tensor: IntTensor<Self, D>) -> IntTensor<Self, 1> {
         todo!("prod is not implemented for Candle IntTensor (see https://github.com/tracel-ai/burn/issues/1454)")
     }

--- a/crates/burn-candle/src/ops/tensor.rs
+++ b/crates/burn-candle/src/ops/tensor.rs
@@ -373,6 +373,13 @@ impl<F: FloatCandleElement, I: IntCandleElement> FloatTensorOps<Self> for Candle
         CandleTensor::new(tensor.tensor.sum_keepdim(dim).unwrap())
     }
 
+    fn float_cumsum_dim<const D: usize>(
+        tensor: FloatTensor<Self, D>,
+        dim: usize,
+    ) -> FloatTensor<Self, D> {
+        CandleTensor::new(tensor.tensor.cumsum(dim).unwrap())
+    }
+
     fn float_mean_dim<const D: usize>(
         tensor: FloatTensor<Self, D>,
         dim: usize,

--- a/crates/burn-candle/src/ops/tensor.rs
+++ b/crates/burn-candle/src/ops/tensor.rs
@@ -373,7 +373,7 @@ impl<F: FloatCandleElement, I: IntCandleElement> FloatTensorOps<Self> for Candle
         CandleTensor::new(tensor.tensor.sum_keepdim(dim).unwrap())
     }
 
-    fn float_cumsum_dim<const D: usize>(
+    fn float_cumsum<const D: usize>(
         tensor: FloatTensor<Self, D>,
         dim: usize,
     ) -> FloatTensor<Self, D> {

--- a/crates/burn-import/onnx-tests/build.rs
+++ b/crates/burn-import/onnx-tests/build.rs
@@ -55,6 +55,8 @@ fn main() {
         .input("tests/conv_transpose2d/conv_transpose2d.onnx")
         .input("tests/pow/pow.onnx")
         .input("tests/pow/pow_int.onnx")
+        .input("tests/pow/cumsum.onnx")
+        .input("tests/pow/cumsum_int.onnx")
         .input("tests/unsqueeze/unsqueeze.onnx")
         .input("tests/unsqueeze/unsqueeze_opset16.onnx")
         .input("tests/unsqueeze/unsqueeze_opset11.onnx")

--- a/crates/burn-import/onnx-tests/tests/cumsum/cumsum.py
+++ b/crates/burn-import/onnx-tests/tests/cumsum/cumsum.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+# used to generate model: onnx-tests/tests/cumsum/cumsum.onnx
+
+import torch
+import torch.nn as nn
+
+
+class Model(nn.Module):
+    def __init__(self):
+        super(Model, self).__init__()
+        # self.b = 5.0
+
+    def forward(self, x, d):
+        # cumulative sum of a tensor along dimension d
+        x = x.cumsum(d)
+
+        return x
+
+
+def main():
+    # Export to onnx
+    model = Model()
+    model.eval()
+    device = torch.device("cpu")
+    onnx_name = "cumsum.onnx"
+    dummy_input = torch.tensor([[0,1,2], [3,4,5], [6, 7, 8]], dtype=torch.float32, device=device)
+
+    dim= 1
+
+    torch.onnx.export(
+        model, (dummy_input, dim), onnx_name, verbose=False, opset_version=16
+    )
+
+    print(f"Finished exporting model to {onnx_name}")
+
+    # Output some test data for use in the test
+    test_input = torch.tensor([[0,1,2], [3,4,5], [6, 7, 8]], dtype=torch.float32, device=device)
+
+    print(f"Test input data: {test_input}, {dim}")
+    output = model.forward(test_input, dim)
+    print(f"Test output data: {output}")
+
+    
+
+if __name__ == "__main__":
+    main()

--- a/crates/burn-import/onnx-tests/tests/cumsum/cumsum_int.py
+++ b/crates/burn-import/onnx-tests/tests/cumsum/cumsum_int.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+# used to generate model: onnx-tests/tests/cumsum/cumsum.onnx
+
+import torch
+import torch.nn as nn
+
+
+class Model(nn.Module):
+    def __init__(self):
+        super(Model, self).__init__()
+        # self.b = 5.0
+
+    def forward(self, x, d):
+        # cumulative sum of a tensor along dimension d
+        x = x.cumsum(d)
+
+        return x
+
+
+def main():
+    # Export to onnx
+    model = Model()
+    model.eval()
+    device = torch.device("cpu")
+    onnx_name = "cumsum.onnx"
+    test_input = torch.tensor([[0,1,2], [3,4,5], [6, 7, 8]], dtype=torch.int32, device=device)
+
+    dim= 1
+
+    torch.onnx.export(
+        model, (test_input, dim), onnx_name, verbose=False, opset_version=16
+    )
+
+    print(f"Finished exporting model to {onnx_name}")
+
+
+    print(f"Test input data: {test_input}, {dim}")
+    output = model.forward(test_input, dim)
+    print(f"Test output data: {output}")
+
+    
+
+if __name__ == "__main__":
+    main()

--- a/crates/burn-import/onnx-tests/tests/onnx_tests.rs
+++ b/crates/burn-import/onnx-tests/tests/onnx_tests.rs
@@ -1049,6 +1049,35 @@ mod tests {
 
         assert_eq!(output.to_data(), expected);
     }
+    #[test]
+    fn cumsum() {
+        let device = Default::default();
+        let model: pow::Model<Backend> = cumsum::Model::new(&device);
+
+        let input1 =
+            Tensor::from_floats([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]], &device);
+        let input2 = 1;
+
+        let output = model.forward(input1, input2);
+
+        let expected = Data::from([[0.0, 1.0, 3.0], [3.0, 7.0, 12.0], [6.0, 13.0, 21.0]]);
+
+        assert_eq!(output.to_data(), expected);
+    }
+    #[test]
+    fn cumsum_int() {
+        let device = Default::default();
+        let model: pow::Model<Backend> = cumsum_int::Model::new(&device);
+
+        let input1 = Tensor::from_ints([[0, 1, 2], [3, 4, 5], [6, 7, 8]], &device);
+        let input2 = 1;
+
+        let output = model.forward(input1, input2);
+
+        let expected = Data::from([[0, 1, 3], [3, 7, 12], [6, 13, 21]]);
+
+        assert_eq!(output.to_data(), expected);
+    }
 
     #[test]
     fn unsqueeze() {

--- a/crates/burn-import/src/onnx/dim_inference.rs
+++ b/crates/burn-import/src/onnx/dim_inference.rs
@@ -58,6 +58,7 @@ pub fn dim_inference(node: &mut Node, graph_io: &mut OnnxGraphIO) {
         NodeType::Transpose => same_as_input(node),
         NodeType::Unsqueeze => unsqueeze_update_output(node),
         NodeType::Pow => same_as_input(node),
+        NodeType::CumSum => same_as_input(node),
         NodeType::LeakyRelu => same_as_input(node),
         NodeType::Where => where_update_outputs(node),
         // Intentionally letting outputs leave unchanged but issue a warning so IR file can be generated.

--- a/crates/burn-import/src/onnx/to_burn.rs
+++ b/crates/burn-import/src/onnx/to_burn.rs
@@ -278,6 +278,7 @@ impl OnnxGraph {
                     graph.register(Self::conv_transpose2d_conversion(node))
                 }
                 NodeType::Pow => graph.register(Self::pow_conversion(node)),
+                NodeType::CumSum => graph.register(Self::cumsum_conversion(node)),
                 NodeType::Unsqueeze => graph.register(Self::unsqueeze_conversion(node)),
                 NodeType::Where => graph.register(Self::where_conversion(node)),
                 NodeType::Sign => graph.register(Self::sign_conversion(node)),
@@ -777,6 +778,19 @@ impl OnnxGraph {
                 _ => panic!("pow function requires RHS to be int or float type"),
             },
             _ => panic!("pow function only supports RHS scalar or tensor types"),
+        }
+    }
+    fn cumsum_conversion(node: Node) -> BinaryNode {
+        let lhs = node.inputs.first().unwrap().to_type();
+        let rhs = node.inputs.get(1).unwrap().to_type();
+        let output = node.outputs.first().unwrap().to_type();
+        match &lhs {
+            Type::Tensor(x) => match x.kind {
+                TensorKind::Int => BinaryNode::int_cumsum(lhs, rhs, output),
+                TensorKind::Float => BinaryNode::float_cumsum(lhs, rhs, output),
+                _ => panic!("cumsum function requires LHS to be int or float type"),
+            },
+            _ => panic!("cumsum function only supports LHS tensor type"),
         }
     }
 

--- a/crates/burn-ndarray/src/ops/int_tensor.rs
+++ b/crates/burn-ndarray/src/ops/int_tensor.rs
@@ -286,7 +286,7 @@ impl<E: FloatNdArrayElement> IntTensorOps<Self> for NdArray<E> {
         NdArrayMathOps::sum_dim(tensor, dim)
     }
 
-    fn int_cumsum_dim<const D: usize>(
+    fn int_cumsum<const D: usize>(
         tensor: NdArrayTensor<i64, D>,
         dim: usize,
     ) -> NdArrayTensor<i64, D> {

--- a/crates/burn-ndarray/src/ops/int_tensor.rs
+++ b/crates/burn-ndarray/src/ops/int_tensor.rs
@@ -7,7 +7,7 @@ use burn_tensor::{Distribution, Reader};
 
 use burn_tensor::ElementConversion;
 use core::ops::Range;
-use ndarray::IntoDimension;
+use ndarray::{Axis, IntoDimension};
 
 // Current crate
 use crate::element::ExpElement;
@@ -284,6 +284,17 @@ impl<E: FloatNdArrayElement> IntTensorOps<Self> for NdArray<E> {
         dim: usize,
     ) -> NdArrayTensor<i64, D> {
         NdArrayMathOps::sum_dim(tensor, dim)
+    }
+
+    fn int_cumsum_dim<const D: usize>(
+        tensor: NdArrayTensor<i64, D>,
+        dim: usize,
+    ) -> NdArrayTensor<i64, D> {
+        let mut array = tensor.array.clone().into_owned();
+
+        array.accumulate_axis_inplace(Axis(dim), |&prev, curr| *curr += prev);
+
+        NdArrayTensor::new(array.to_shared())
     }
 
     fn int_prod<const D: usize>(tensor: NdArrayTensor<i64, D>) -> NdArrayTensor<i64, 1> {

--- a/crates/burn-ndarray/src/ops/tensor.rs
+++ b/crates/burn-ndarray/src/ops/tensor.rs
@@ -338,7 +338,7 @@ impl<E: FloatNdArrayElement> FloatTensorOps<Self> for NdArray<E> {
         NdArrayMathOps::sum_dim(tensor, dim)
     }
 
-    fn float_cumsum_dim<const D: usize>(
+    fn float_cumsum<const D: usize>(
         tensor: NdArrayTensor<E, D>,
         dim: usize,
     ) -> NdArrayTensor<E, D> {

--- a/crates/burn-ndarray/src/ops/tensor.rs
+++ b/crates/burn-ndarray/src/ops/tensor.rs
@@ -1,7 +1,7 @@
 // Language
 use alloc::vec::Vec;
 use core::ops::Range;
-use ndarray::IntoDimension;
+use ndarray::{Axis, IntoDimension};
 
 // Current crate
 use super::{matmul::matmul, NdArrayMathOps, NdArrayOps};
@@ -336,6 +336,17 @@ impl<E: FloatNdArrayElement> FloatTensorOps<Self> for NdArray<E> {
         dim: usize,
     ) -> NdArrayTensor<E, D> {
         NdArrayMathOps::sum_dim(tensor, dim)
+    }
+
+    fn float_cumsum_dim<const D: usize>(
+        tensor: NdArrayTensor<E, D>,
+        dim: usize,
+    ) -> NdArrayTensor<E, D> {
+        let mut array = tensor.array.clone().into_owned();
+
+        array.accumulate_axis_inplace(Axis(dim), |&prev, curr| *curr += prev);
+
+        NdArrayTensor::new(array.to_shared())
     }
 
     fn float_argmax<const D: usize>(

--- a/crates/burn-tch/src/ops/base.rs
+++ b/crates/burn-tch/src/ops/base.rs
@@ -335,7 +335,7 @@ impl<E: tch::kind::Element + Copy + Default> TchOps<E> {
         )
     }
 
-    pub fn cumsum_dim<const D: usize>(tensor: TchTensor<E, D>, dim: usize) -> TchTensor<E, D> {
+    pub fn cumsum<const D: usize>(tensor: TchTensor<E, D>, dim: usize) -> TchTensor<E, D> {
         TchTensor::from_existing(tensor.tensor.cumsum(dim as i64, E::KIND), tensor.storage)
     }
 

--- a/crates/burn-tch/src/ops/base.rs
+++ b/crates/burn-tch/src/ops/base.rs
@@ -335,6 +335,10 @@ impl<E: tch::kind::Element + Copy + Default> TchOps<E> {
         )
     }
 
+    pub fn cumsum_dim<const D: usize>(tensor: TchTensor<E, D>, dim: usize) -> TchTensor<E, D> {
+        TchTensor::from_existing(tensor.tensor.cumsum(dim as i64, E::KIND), tensor.storage)
+    }
+
     pub fn prod<const D: usize>(tensor: TchTensor<E, D>) -> TchTensor<E, 1> {
         let tensor = tensor.tensor.prod(E::KIND);
         TchTensor::new(tensor)

--- a/crates/burn-tch/src/ops/int_tensor.rs
+++ b/crates/burn-tch/src/ops/int_tensor.rs
@@ -270,6 +270,10 @@ impl<E: TchElement> IntTensorOps<Self> for LibTorch<E> {
         TchOps::sum_dim(tensor, dim)
     }
 
+    fn int_cumsum_dim<const D: usize>(tensor: TchTensor<i64, D>, dim: usize) -> TchTensor<i64, D> {
+        TchOps::cumsum_dim(tensor, dim)
+    }
+
     fn int_prod<const D: usize>(tensor: TchTensor<i64, D>) -> TchTensor<i64, 1> {
         TchOps::prod(tensor)
     }

--- a/crates/burn-tch/src/ops/int_tensor.rs
+++ b/crates/burn-tch/src/ops/int_tensor.rs
@@ -270,8 +270,8 @@ impl<E: TchElement> IntTensorOps<Self> for LibTorch<E> {
         TchOps::sum_dim(tensor, dim)
     }
 
-    fn int_cumsum_dim<const D: usize>(tensor: TchTensor<i64, D>, dim: usize) -> TchTensor<i64, D> {
-        TchOps::cumsum_dim(tensor, dim)
+    fn int_cumsum<const D: usize>(tensor: TchTensor<i64, D>, dim: usize) -> TchTensor<i64, D> {
+        TchOps::cumsum(tensor, dim)
     }
 
     fn int_prod<const D: usize>(tensor: TchTensor<i64, D>) -> TchTensor<i64, 1> {

--- a/crates/burn-tch/src/ops/tensor.rs
+++ b/crates/burn-tch/src/ops/tensor.rs
@@ -331,8 +331,8 @@ impl<E: TchElement> FloatTensorOps<Self> for LibTorch<E> {
         TchOps::sum_dim(tensor, dim)
     }
 
-    fn float_cumsum_dim<const D: usize>(tensor: TchTensor<E, D>, dim: usize) -> TchTensor<E, D> {
-        TchOps::cumsum_dim(tensor, dim)
+    fn float_cumsum<const D: usize>(tensor: TchTensor<E, D>, dim: usize) -> TchTensor<E, D> {
+        TchOps::cumsum(tensor, dim)
     }
 
     fn float_mean_dim<const D: usize>(tensor: TchTensor<E, D>, dim: usize) -> TchTensor<E, D> {

--- a/crates/burn-tch/src/ops/tensor.rs
+++ b/crates/burn-tch/src/ops/tensor.rs
@@ -331,6 +331,10 @@ impl<E: TchElement> FloatTensorOps<Self> for LibTorch<E> {
         TchOps::sum_dim(tensor, dim)
     }
 
+    fn float_cumsum_dim<const D: usize>(tensor: TchTensor<E, D>, dim: usize) -> TchTensor<E, D> {
+        TchOps::cumsum_dim(tensor, dim)
+    }
+
     fn float_mean_dim<const D: usize>(tensor: TchTensor<E, D>, dim: usize) -> TchTensor<E, D> {
         TchOps::mean_dim(tensor, dim)
     }

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -803,6 +803,22 @@ impl TensorCheck {
         check
     }
 
+    /// Checks running dimension such as cumulative sum
+    pub(crate) fn running_dim<const D: usize>(ops: &str, dim: usize) -> Self {
+        let mut check = Self::Ok;
+
+        if dim > D {
+            check = check.register(
+                ops,
+                TensorError::new(format!(
+                    "Can't perform a running calculation on a tensor with ({D}) dimensions on axis ({dim})"
+                )),
+            );
+        }
+
+        check
+    }
+
     pub(crate) fn sort_dim<const D: usize>(ops: &str, dim: usize) -> Self {
         let mut check = Self::Ok;
 

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -142,6 +142,13 @@ where
         Self::new(K::sum_dim(self.primitive, dim))
     }
 
+    /// Perform a cumulative sum on all elements along the given *dimension* or *axis*
+    /// in the tensor with the sum operation.
+    pub fn cumsum_dim(self, dim: usize) -> Self {
+        check!(TensorCheck::running_dim::<D>("Sum", dim));
+        Self::new(K::cumsum_dim(self.primitive, dim))
+    }
+
     /// Aggregate all elements along the given *dimension* or *axis*
     /// in the tensor with the product operation.
     pub fn prod(self) -> Tensor<B, 1, K> {
@@ -1173,6 +1180,27 @@ where
     /// which is more high-level and designed for public use.
     fn sum_dim<const D: usize>(tensor: Self::Primitive<D>, dim: usize) -> Self::Primitive<D>;
 
+    /// Performs cumulative sum across  all the elements of the tensor along a dimension.
+    ///
+    /// # Arguments
+    ///
+    /// * `tensor` - The tensor to perform cumulative sum on.
+    /// * `dim` - The dimension along which to perform cumulative sum.
+    ///
+    /// # Returns
+    ///
+    /// The cumulative sum of all the elements of the tensor along the specified dimension.
+    ///
+    /// # Remarks
+    ///
+    /// This is a low-level function used internally by the library to call different backend functions
+    /// with static dispatch. It is not designed for direct usage by users, and not recommended to import
+    /// or use this function directly.
+    ///
+    /// For performing cumulative sum across all the elements of a tensor along a dimension, users should prefer the [Tensor::cumsum_dim](Tensor::cumsum_dim) function,
+    /// which is more high-level and designed for public use.
+    fn cumsum_dim<const D: usize>(tensor: Self::Primitive<D>, dim: usize) -> Self::Primitive<D>;
+
     /// Computes the product of all the elements of the tensor.
     ///
     /// # Arguments
@@ -2176,6 +2204,10 @@ impl<B: Backend> Numeric<B> for Int {
         B::int_sum_dim(tensor, dim)
     }
 
+    fn cumsum_dim<const D: usize>(tensor: Self::Primitive<D>, dim: usize) -> Self::Primitive<D> {
+        B::int_cumsum_dim(tensor, dim)
+    }
+
     fn prod<const D: usize>(tensor: Self::Primitive<D>) -> Self::Primitive<1> {
         B::int_prod(tensor)
     }
@@ -2519,6 +2551,10 @@ impl<B: Backend> Numeric<B> for Float {
 
     fn sum_dim<const D: usize>(tensor: Self::Primitive<D>, dim: usize) -> Self::Primitive<D> {
         B::float_sum_dim(tensor, dim)
+    }
+
+    fn cumsum_dim<const D: usize>(tensor: Self::Primitive<D>, dim: usize) -> Self::Primitive<D> {
+        B::float_cumsum_dim(tensor, dim)
     }
 
     fn prod<const D: usize>(tensor: Self::Primitive<D>) -> Self::Primitive<1> {

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -144,9 +144,9 @@ where
 
     /// Perform a cumulative sum on all elements along the given *dimension* or *axis*
     /// in the tensor with the sum operation.
-    pub fn cumsum_dim(self, dim: usize) -> Self {
+    pub fn cumsum(self, dim: usize) -> Self {
         check!(TensorCheck::running_dim::<D>("Sum", dim));
-        Self::new(K::cumsum_dim(self.primitive, dim))
+        Self::new(K::cumsum(self.primitive, dim))
     }
 
     /// Aggregate all elements along the given *dimension* or *axis*
@@ -1197,9 +1197,9 @@ where
     /// with static dispatch. It is not designed for direct usage by users, and not recommended to import
     /// or use this function directly.
     ///
-    /// For performing cumulative sum across all the elements of a tensor along a dimension, users should prefer the [Tensor::cumsum_dim](Tensor::cumsum_dim) function,
+    /// For performing cumulative sum across all the elements of a tensor along a dimension, users should prefer the [Tensor::cumsum](Tensor::cumsum) function,
     /// which is more high-level and designed for public use.
-    fn cumsum_dim<const D: usize>(tensor: Self::Primitive<D>, dim: usize) -> Self::Primitive<D>;
+    fn cumsum<const D: usize>(tensor: Self::Primitive<D>, dim: usize) -> Self::Primitive<D>;
 
     /// Computes the product of all the elements of the tensor.
     ///
@@ -2204,8 +2204,8 @@ impl<B: Backend> Numeric<B> for Int {
         B::int_sum_dim(tensor, dim)
     }
 
-    fn cumsum_dim<const D: usize>(tensor: Self::Primitive<D>, dim: usize) -> Self::Primitive<D> {
-        B::int_cumsum_dim(tensor, dim)
+    fn cumsum<const D: usize>(tensor: Self::Primitive<D>, dim: usize) -> Self::Primitive<D> {
+        B::int_cumsum(tensor, dim)
     }
 
     fn prod<const D: usize>(tensor: Self::Primitive<D>) -> Self::Primitive<1> {
@@ -2553,8 +2553,8 @@ impl<B: Backend> Numeric<B> for Float {
         B::float_sum_dim(tensor, dim)
     }
 
-    fn cumsum_dim<const D: usize>(tensor: Self::Primitive<D>, dim: usize) -> Self::Primitive<D> {
-        B::float_cumsum_dim(tensor, dim)
+    fn cumsum<const D: usize>(tensor: Self::Primitive<D>, dim: usize) -> Self::Primitive<D> {
+        B::float_cumsum(tensor, dim)
     }
 
     fn prod<const D: usize>(tensor: Self::Primitive<D>) -> Self::Primitive<1> {

--- a/crates/burn-tensor/src/tensor/ops/int_tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/int_tensor.rs
@@ -780,7 +780,7 @@ pub trait IntTensorOps<B: Backend> {
     /// # Returns
     ///
     /// A tensor with the cumulative sum of all elements in `tensor` along `dim`.
-    fn int_cumsum_dim<const D: usize>(tensor: IntTensor<B, D>, dim: usize) -> IntTensor<B, D>;
+    fn int_cumsum<const D: usize>(tensor: IntTensor<B, D>, dim: usize) -> IntTensor<B, D>;
 
     /// Computes the product of all elements in the tensor.
     ///

--- a/crates/burn-tensor/src/tensor/ops/int_tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/int_tensor.rs
@@ -770,6 +770,18 @@ pub trait IntTensorOps<B: Backend> {
     /// The sum of all elements in the tensor along the dimension.
     fn int_sum_dim<const D: usize>(tensor: IntTensor<B, D>, dim: usize) -> IntTensor<B, D>;
 
+    /// Cumulative Sum of all elements in a tensor along a dimension.
+    ///
+    /// # Arguments
+    ///
+    /// * `tensor` - The tensor to perform cumulative sum on.
+    /// * `dim` - The dimension along which to perform cumulative sum.
+    ///
+    /// # Returns
+    ///
+    /// A tensor with the cumulative sum of all elements in `tensor` along `dim`.
+    fn int_cumsum_dim<const D: usize>(tensor: IntTensor<B, D>, dim: usize) -> IntTensor<B, D>;
+
     /// Computes the product of all elements in the tensor.
     ///
     /// # Arguments

--- a/crates/burn-tensor/src/tensor/ops/tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/tensor.rs
@@ -842,6 +842,19 @@ pub trait FloatTensorOps<B: Backend> {
     /// A tensor with the sum of all elements in `tensor` along `dim`.
     fn float_sum_dim<const D: usize>(tensor: FloatTensor<B, D>, dim: usize) -> FloatTensor<B, D>;
 
+    /// Cumulative Sum of all elements in a tensor along a dimension.
+    ///
+    /// # Arguments
+    ///
+    /// * `tensor` - The tensor to perform cumulative sum on.
+    /// * `dim` - The dimension along which to perform cumulative sum.
+    ///
+    /// # Returns
+    ///
+    /// A tensor with the cumulative sum of all elements in `tensor` along `dim`.
+    fn float_cumsum_dim<const D: usize>(tensor: FloatTensor<B, D>, dim: usize)
+        -> FloatTensor<B, D>;
+
     /// Product of all elements in a tensor.
     ///
     /// # Arguments
@@ -867,6 +880,20 @@ pub trait FloatTensorOps<B: Backend> {
     /// A tensor with the product of all elements in `tensor` along `dim`.
     fn float_prod_dim<const D: usize>(tensor: FloatTensor<B, D>, dim: usize) -> FloatTensor<B, D> {
         // Product of all elements in a tensor along a dimension
+        B::float_exp(B::float_sum_dim(B::float_log(tensor), dim))
+    }
+
+    /// Cumulative Product of all elements in a tensor along a dimension.
+    ///
+    /// # Arguments
+    ///
+    /// * `tensor` - The tensor to perform cumulative product on.
+    ///
+    /// # Returns
+    ///
+    /// A tensor whose elements are the cumulative product of elements of `tensor` along dimension `dim`
+    fn float_cumprod<const D: usize>(tensor: FloatTensor<B, D>, dim: usize) -> FloatTensor<B, D> {
+        // Cumulative product of all elements in a tensor along a dimension
         B::float_exp(B::float_sum_dim(B::float_log(tensor), dim))
     }
 

--- a/crates/burn-tensor/src/tensor/ops/tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/tensor.rs
@@ -852,7 +852,7 @@ pub trait FloatTensorOps<B: Backend> {
     /// # Returns
     ///
     /// A tensor with the cumulative sum of all elements in `tensor` along `dim`.
-    fn float_cumsum_dim<const D: usize>(tensor: FloatTensor<B, D>, dim: usize)
+    fn float_cumsum<const D: usize>(tensor: FloatTensor<B, D>, dim: usize)
         -> FloatTensor<B, D>;
 
     /// Product of all elements in a tensor.

--- a/crates/burn-tensor/src/tensor/ops/tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/tensor.rs
@@ -883,20 +883,6 @@ pub trait FloatTensorOps<B: Backend> {
         B::float_exp(B::float_sum_dim(B::float_log(tensor), dim))
     }
 
-    /// Cumulative Product of all elements in a tensor along a dimension.
-    ///
-    /// # Arguments
-    ///
-    /// * `tensor` - The tensor to perform cumulative product on.
-    ///
-    /// # Returns
-    ///
-    /// A tensor whose elements are the cumulative product of elements of `tensor` along dimension `dim`
-    fn float_cumprod<const D: usize>(tensor: FloatTensor<B, D>, dim: usize) -> FloatTensor<B, D> {
-        // Cumulative product of all elements in a tensor along a dimension
-        B::float_exp(B::float_sum_dim(B::float_log(tensor), dim))
-    }
-
     /// Mean of all elements in a tensor.
     ///
     /// # Arguments

--- a/crates/burn-tensor/src/tests/mod.rs
+++ b/crates/burn-tensor/src/tests/mod.rs
@@ -50,6 +50,7 @@ macro_rules! testgen_all {
         burn_tensor::testgen_close!();
         burn_tensor::testgen_cos!();
         burn_tensor::testgen_create_like!();
+        burn_tensor::testgen_cumsum_dim!();
         burn_tensor::testgen_div!();
         burn_tensor::testgen_erf!();
         burn_tensor::testgen_exp!();

--- a/crates/burn-tensor/src/tests/mod.rs
+++ b/crates/burn-tensor/src/tests/mod.rs
@@ -50,7 +50,7 @@ macro_rules! testgen_all {
         burn_tensor::testgen_close!();
         burn_tensor::testgen_cos!();
         burn_tensor::testgen_create_like!();
-        burn_tensor::testgen_cumsum_dim!();
+        burn_tensor::testgen_cumsum!();
         burn_tensor::testgen_div!();
         burn_tensor::testgen_erf!();
         burn_tensor::testgen_exp!();

--- a/crates/burn-tensor/src/tests/ops/cumsum.rs
+++ b/crates/burn-tensor/src/tests/ops/cumsum.rs
@@ -1,4 +1,4 @@
-#[burn_tensor_testgen::testgen(cumsum_dim)]
+#[burn_tensor_testgen::testgen(cumsum)]
 mod tests {
     use super::*;
     use burn_tensor::{Data, Int, Tensor};
@@ -10,7 +10,7 @@ mod tests {
 
         let dim = 1;
 
-        let data_actual = tensor.cumsum_dim(dim).into_data();
+        let data_actual = tensor.cumsum(dim).into_data();
         let data_expected = Data::from([[0.0, 1.0, 3.0], [3.0, 7.0, 12.0], [6.0, 13.0, 21.0]]);
 
         data_expected.assert_approx_eq(&data_actual, 3);

--- a/crates/burn-tensor/src/tests/ops/cumsum_dim.rs
+++ b/crates/burn-tensor/src/tests/ops/cumsum_dim.rs
@@ -1,0 +1,31 @@
+#[burn_tensor_testgen::testgen(cumsum_dim)]
+mod tests {
+    use super::*;
+    use burn_tensor::{Data, Int, Tensor};
+
+    #[test]
+    fn should_cumsum_over_dim() {
+        let data = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]);
+        let tensor = Tensor::<TestBackend, 2>::from_data(data, &Default::default());
+
+        let dim = 1;
+
+        let data_actual = tensor.cumsum_dim(dim).into_data();
+        dbg!(data_actual.clone());
+        let data_expected = Data::from([[0.0, 1.0, 3.0], [3.0, 7.0, 12.0], [6.0, 13.0, 21.0]]);
+
+        data_expected.assert_approx_eq(&data_actual, 3);
+    }
+
+    // #[test]
+    // #[should_panic(expected = "attempt to add with overflow")]
+    // fn should_panic_on_int_overflow() {
+    //     let data = Data::from([[std::i64::MAX, 1], [std::i64::MAX, 2]]);
+    //     let tensor = Tensor::<TestBackend, 2, Int>::from_data(data, &Default::default());
+
+    //     let dim = 1;
+
+    //     // This should trigger an overflow panic when cumulating sums
+    //     let _ = tensor.cumsum_dim(dim).into_data();
+    // }
+}

--- a/crates/burn-tensor/src/tests/ops/cumsum_dim.rs
+++ b/crates/burn-tensor/src/tests/ops/cumsum_dim.rs
@@ -16,16 +16,4 @@ mod tests {
 
         data_expected.assert_approx_eq(&data_actual, 3);
     }
-
-    // #[test]
-    // #[should_panic(expected = "attempt to add with overflow")]
-    // fn should_panic_on_int_overflow() {
-    //     let data = Data::from([[std::i64::MAX, 1], [std::i64::MAX, 2]]);
-    //     let tensor = Tensor::<TestBackend, 2, Int>::from_data(data, &Default::default());
-
-    //     let dim = 1;
-
-    //     // This should trigger an overflow panic when cumulating sums
-    //     let _ = tensor.cumsum_dim(dim).into_data();
-    // }
 }

--- a/crates/burn-tensor/src/tests/ops/cumsum_dim.rs
+++ b/crates/burn-tensor/src/tests/ops/cumsum_dim.rs
@@ -11,7 +11,6 @@ mod tests {
         let dim = 1;
 
         let data_actual = tensor.cumsum_dim(dim).into_data();
-        dbg!(data_actual.clone());
         let data_expected = Data::from([[0.0, 1.0, 3.0], [3.0, 7.0, 12.0], [6.0, 13.0, 21.0]]);
 
         data_expected.assert_approx_eq(&data_actual, 3);

--- a/crates/burn-tensor/src/tests/ops/mod.rs
+++ b/crates/burn-tensor/src/tests/ops/mod.rs
@@ -15,7 +15,7 @@ mod clamp;
 mod close;
 mod cos;
 mod create_like;
-mod cumsum_dim;
+mod cumsum;
 mod div;
 mod erf;
 mod exp;

--- a/crates/burn-tensor/src/tests/ops/mod.rs
+++ b/crates/burn-tensor/src/tests/ops/mod.rs
@@ -15,6 +15,7 @@ mod clamp;
 mod close;
 mod cos;
 mod create_like;
+mod cumsum_dim;
 mod div;
 mod erf;
 mod exp;


### PR DESCRIPTION
## Pull Request Template

Starting a draft PR to align on a few things with maintainers as I dive into this.

Context:  Per [this convo](https://discord.com/channels/1038839012602941528/1038839013735399547/1234609825619644477), I wanted to add a cumulative product operation to burn.

My plan is to start with a cumulative sum operation.  Then cumulative product can be developed using cumulative sum, log, and exp.

@nathanielsimard, Items to align on upfront:
-  The name of the function should be `cumsum_dim`.  `cumsum` aligns with the pytorch api.  In burn, operations that take an explicit dim argument seem to have a `_dim` suffix.  Alternatively we could remove the suffix.
- The function should be implemented for Float and Int tensorkinds, but not bool.
- Backends:  While the implementations for tch, candle, and ndarray seem straightforward, I have questions about jit.  For jit, I cannot find a existing WGSL implementation for cumulative sum.  Is the right approach in this situation to create a WGSL compute shader for it?  Cumulative sum is probably hard to do well GPUs given the dependencies between elements, but I'm open to trying.  I'm new to WGSL.

### Checklist

- [ ] Confirmed that `run-checks all` script has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

_Provide links to relevant issues and dependent PRs._

### Changes

_Summarize the problem being addressed and your solution._

### Testing

_Describe how these changes have been tested._
