### PR TITLE
Fix unstable tests when run concurrently

### DIFF
--- a/crates/burn-core/src/optim/adagrad.rs
+++ b/crates/burn-core/src/optim/adagrad.rs
@@ -172,7 +172,7 @@ mod tests {
         BinFileRecorder::<FullPrecisionSettings>::default()
             .record(
                 optimizer.to_record(),
-                std::env::temp_dir().as_path().join("test_optim"),
+                std::env::temp_dir().as_path().join("test_optim_adagrad"),
             )
             .unwrap();
 

--- a/crates/burn-core/src/optim/adam.rs
+++ b/crates/burn-core/src/optim/adam.rs
@@ -205,7 +205,7 @@ mod tests {
         BinFileRecorder::<FullPrecisionSettings>::default()
             .record(
                 optimizer.to_record(),
-                std::env::temp_dir().as_path().join("test_optim"),
+                std::env::temp_dir().as_path().join("test_optim_adam"),
             )
             .unwrap();
 

--- a/crates/burn-core/src/optim/adamw.rs
+++ b/crates/burn-core/src/optim/adamw.rs
@@ -217,7 +217,10 @@ mod tests {
         let _linear = optimizer.step(LEARNING_RATE, linear, grads);
         let temp_dir = TempDir::new().unwrap();
         BinFileRecorder::<FullPrecisionSettings>::default()
-            .record(optimizer.to_record(), temp_dir.path().join("test_optim"))
+            .record(
+                optimizer.to_record(),
+                temp_dir.path().join("test_optim_adamw"),
+            )
             .unwrap();
 
         let state_optim_before = optimizer.to_record();

--- a/crates/burn-core/src/optim/rmsprop.rs
+++ b/crates/burn-core/src/optim/rmsprop.rs
@@ -334,7 +334,10 @@ mod tests {
         let _linear = optimizer.step(LEARNING_RATE, linear, grads);
         let temp_dir = TempDir::new().unwrap();
         BinFileRecorder::<FullPrecisionSettings>::default()
-            .record(optimizer.to_record(), temp_dir.path().join("test_optim"))
+            .record(
+                optimizer.to_record(),
+                temp_dir.path().join("test_optim_rmsprop"),
+            )
             .unwrap();
 
         let state_optim_before = optimizer.to_record();


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

None

### Changes

`str2writer` is used to write record files, causing a race condition between optim tests. 

The following line removes the file:
https://github.com/tracel-ai/burn/blob/152509c3787dec1c4dd7d35b1b2bb8f177da0f64/crates/burn-core/src/record/file.rs#L119

And if that happens between another test creating the file, and then trying to access it, the following error occur:
```
---- optim::adam::tests::test_adam_optimizer_save_load_state stdout ----
thread 'optim::adam::tests::test_adam_optimizer_save_load_state' panicked at crates/burn-core/src/optim/adam.rs:210:14:
called `Result::unwrap()` on an `Err` value: Unknown("No such file or directory (os error 2)")
```

Changed to include the specific optimizer in the record path

### Testing

Reproduction on main can be tested using:
`burn/crates/burn-core$ while cargo test; do :; done`
