### PR TITLE
Remainder operator

### DIFF
--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -2868,6 +2868,20 @@ where
     }
 }
 
+impl<E, const D: usize, B, K> core::ops::Rem<E> for Tensor<B, D, K>
+where
+    E: ElementConversion,
+    B: Backend,
+    K: Numeric<B>,
+    K::Elem: Element,
+{
+    type Output = Self;
+
+    fn rem(self, other: E) -> Self {
+        Tensor::remainder_scalar(self, other)
+    }
+}
+
 impl<B, const D: usize, K> core::ops::Mul<Tensor<B, D, K>> for Tensor<B, D, K>
 where
     B: Backend,

--- a/crates/burn-tensor/src/tests/ops/remainder.rs
+++ b/crates/burn-tensor/src/tests/ops/remainder.rs
@@ -95,4 +95,17 @@ mod tests {
         let data_expected = Data::from([9.0, 1.0]);
         data_expected.assert_approx_eq(&data_actual, 3);
     }
+
+    #[test]
+    fn should_support_remainder_op() {
+        let data = Data::from([-3.0, -2.0, -1.0, 1.0, 2.0, 3.0]);
+        let device = Default::default();
+        let tensor = Tensor::<TestBackend, 1>::from_data(data, &device);
+
+        let output = tensor % 2.0;
+
+        let data_actual = output.into_data();
+        let data_expected = Data::from([1.0, 0.0, 1.0, 1.0, 0.0, 1.0]);
+        data_expected.assert_approx_eq(&data_actual, 3);
+    }
 }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Related PR: [1597](https://github.com/tracel-ai/burn/pull/1597)
Related Issue: [1510](https://github.com/tracel-ai/burn/issues/1510)

### Changes

Problem: The `tensor.remainder_scalar()` method has been implemented in a previous PR. However, its not possible to use the `%` operator, e.g., `tensor % 2.0`.
Changes: Added `ops::Rem` trait implementation for Tensor.

### Testing
Added a test for Tensor that makes use of the `%` operator.
