### PR TITLE
Indices Operator

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -285,6 +285,7 @@ Those operations are only available for `Int` tensors.
 | ------------------------------------------------ | ------------------------------------------------------- |
 | `tensor.arange(5..10, device)       `            | `tensor.arange(start=5, end=10, device=device)`         |
 | `tensor.arange_step(5..10, 2, device)`           | `tensor.arange(start=5, end=10, step=2, device=device)` |
+| `tensor.indices(shape, device)`                  | `torch.meshgrid(tensors)`                               |
 | `tensor.float()`                                 | `tensor.to(torch.float)`                                |
 | `tensor.from_ints(ints)`                         | N/A                                                     |
 | `tensor.int_random(shape, distribution, device)` | N/A                                                     |

--- a/crates/burn-tensor/src/tests/mod.rs
+++ b/crates/burn-tensor/src/tests/mod.rs
@@ -97,6 +97,7 @@ macro_rules! testgen_all {
         burn_tensor::testgen_sort_argsort!();
         burn_tensor::testgen_topk!();
         burn_tensor::testgen_remainder!();
+        burn_tensor::testgen_indices!();
 
         // test stats
         burn_tensor::testgen_var!();

--- a/crates/burn-tensor/src/tests/ops/indices.rs
+++ b/crates/burn-tensor/src/tests/ops/indices.rs
@@ -1,0 +1,22 @@
+#[burn_tensor_testgen::testgen(indices)]
+mod tests {
+    use super::*;
+    use burn_tensor::backend::Backend;
+    use burn_tensor::{Data, Int, Shape, Tensor};
+
+    #[test]
+    fn test_arange() {
+        let device = <TestBackend as Backend>::Device::default();
+
+        // Test a single element tensor
+        let tensor = Tensor::<TestBackend, 1, Int>::indices::<2>(Shape { dims: [1] }, &device);
+        assert_eq!(tensor.into_data(), Data::from([[0]]));
+
+        // Test for a 2x2 tensor
+        let tensor = Tensor::<TestBackend, 2, Int>::indices::<3>(Shape { dims: [2, 2] }, &device);
+        assert_eq!(
+            tensor.into_data(),
+            Data::from([[[0, 0], [0, 1]], [[1, 0], [1, 1]]])
+        );
+    }
+}

--- a/crates/burn-tensor/src/tests/ops/mod.rs
+++ b/crates/burn-tensor/src/tests/ops/mod.rs
@@ -23,6 +23,7 @@ mod flatten;
 mod flip;
 mod full;
 mod gather_scatter;
+mod indices;
 mod init;
 mod iter_dim;
 mod log;


### PR DESCRIPTION
## Indices Operator for Int Tensors
### Checklist

- [ x ] Confirmed that `run-checks all` script has been executed.
- [ x ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs
None

### Changes

Added a indices function for int tensors. This is similar to pytorches `meshgrid`, or numpys `indices` functions though with slightly different arrangement. For example, the output of `Tensor::<B, 2, Int>::indices::<3>(Shape { dims: [2, 3] }, &device);` would be:

```
[[[0, 0],  [0, 1],  [0, 2]],
 [[1, 0],  [1, 1],  [1, 2]]],
```

### Testing

Added a super basic but functional test to make sure indices produces some expected typical outputs.