### PR TITLE
Refactor: replace trait TemplateKernel by existing trait JitKernel

### DIFF
--- a/crates/burn-jit/src/compute/kernel.rs
+++ b/crates/burn-jit/src/compute/kernel.rs
@@ -1,7 +1,5 @@
 use std::marker::PhantomData;
 
-#[cfg(feature = "template")]
-use crate::template::TemplateKernel;
 use crate::{
     codegen::CompilerRepresentation, gpu::WorkgroupSize, kernel::GpuComputeShaderPhase, Compiler,
 };
@@ -17,7 +15,7 @@ pub enum Kernel {
     JitGpu(Box<dyn JitKernel>),
     #[cfg(feature = "template")]
     /// A kernel created from source
-    Custom(Box<dyn TemplateKernel>),
+    Custom(Box<dyn JitKernel>),
 }
 
 impl Kernel {

--- a/crates/burn-jit/src/compute/kernel.rs
+++ b/crates/burn-jit/src/compute/kernel.rs
@@ -18,9 +18,9 @@ pub enum Kernel {
     Custom(Box<dyn JitKernel>),
 }
 
-impl Kernel {
+impl JitKernel for Kernel {
     /// ID of the kernel, for caching
-    pub fn id(&self) -> String {
+    fn id(&self) -> String {
         match self {
             Kernel::JitGpu(shader) => shader.id(),
             #[cfg(feature = "template")]
@@ -29,7 +29,7 @@ impl Kernel {
     }
 
     /// Source of the shader
-    pub fn compile(&self) -> CompiledKernel {
+    fn compile(&self) -> CompiledKernel {
         match self {
             Kernel::JitGpu(shader) => shader.compile(),
             #[cfg(feature = "template")]
@@ -38,7 +38,7 @@ impl Kernel {
     }
 
     /// Launch information of the kernel
-    pub fn launch_settings(&self) -> LaunchSettings {
+    fn launch_settings(&self) -> LaunchSettings {
         match self {
             Kernel::JitGpu(shader) => shader.launch_settings(),
             #[cfg(feature = "template")]

--- a/crates/burn-jit/src/template/base.rs
+++ b/crates/burn-jit/src/template/base.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compute::{CompiledKernel, LaunchSettings, WorkGroup},
+    compute::{CompiledKernel, JitKernel, LaunchSettings, WorkGroup},
     element::JitElement,
     gpu::WorkgroupSize,
     tensor::JitTensor,
@@ -14,21 +14,8 @@ pub trait KernelSource: Send + 'static + Sync {
     fn source(&self) -> SourceTemplate;
 }
 
-/// Kernel trait with the [source](SourceTemplate) that will be compiled and cached based on the
-/// provided id.
-///
-/// The kernel will be launched with the given [launch settings](LaunchSettings)
-pub trait TemplateKernel: 'static + Send + Sync {
-    /// Convert to source
-    fn compile(&self) -> CompiledKernel;
-    /// Identifier for the kernel, used for caching kernel compilation.
-    fn id(&self) -> String;
-    /// Launch information.
-    fn launch_settings(&self) -> LaunchSettings;
-}
-
 #[derive(new)]
-/// Wraps a [kernel source](KernelSource) into a [template kernel](TemplateKernel) with launch
+/// Wraps a [kernel source](KernelSource) into a [JIT kernel](JitKernel) with launch
 /// information.
 pub struct SourceKernel<K> {
     kernel_source: K,
@@ -36,7 +23,7 @@ pub struct SourceKernel<K> {
     workgroup_size: WorkgroupSize,
 }
 
-impl<K> TemplateKernel for SourceKernel<K>
+impl<K> JitKernel for SourceKernel<K>
 where
     K: KernelSource + 'static,
 {

--- a/crates/burn-wgpu/src/compute/server.rs
+++ b/crates/burn-wgpu/src/compute/server.rs
@@ -4,7 +4,7 @@ use burn_compute::{
     memory_management::MemoryManagement,
     server::{self, ComputeServer},
 };
-use burn_jit::compute::{JitAutotuneKey, Kernel, WorkGroup};
+use burn_jit::compute::{JitAutotuneKey, JitKernel, Kernel, WorkGroup};
 use burn_tensor::Reader;
 use hashbrown::HashMap;
 use wgpu::{


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

_Provide links to relevant issues and dependent PRs._

Option::None

### Changes

_Summarize the problem being addressed and your solution._

As a fellow Rustacean, I like to read PRs in the Burn project. I like Rust and this project is well structured and it's in Rust.

The other day, I say that the trait JitKernel and TemplateKernel were basically the same thing.

So I removed the trait TemplateKernel, and I healed the Rust code lines in VS Code where rustc and/or rust-analyzer had formulated a complaint to me.

### Testing

_Describe how these changes have been tested._

1. First, I had to run `sudo apt-get install -y libssl-dev` because the crate `openssl-sys` did not do it on Debian 12.
2.  Then, I ran `./run-checks.sh all` in `burn` as it is recommended in the PR template..
3. Then, I ran `cargo test --features template` in `burn/crates/burn-jit/` to test only the crate where I poked things.
4. Then, I ran `cargo test --features template` in `burn` to see that I did not break anything in the wider scope.

In step 2, there are a lot of warnings. They should be fixed with `cargo fix`. But it's outside of the scope of this PR.
Otherwise, "run-checks all" succeeded.


I observed this failure during step 4:

```
---- tests::ad_expand::tests::should_diff_expand stdout ----
thread 'tests::ad_expand::tests::should_diff_expand' panicked at crates/burn-tch/src/ops/base.rs:295:40:
called `Result::unwrap()` on an `Err` value: Torch("unsupported operation: more than one element of the written-to tensor refers to a single memory location. Please clone() the tensor before performing the operation.\nException raised from assert_no_internal_overlap at ../aten/src/ATen/MemoryOverlap.cpp:35 (most recent call first):\nframe #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x6c (0x7a7e8f0dc28c in /home/sebhtml/projects/burn/target/debug/build/torch-sys-80195893739a531c/out/libtorch/libtorch/lib/libc10.so)\nframe #1: c10::detail::torchCheckFail(char const*, char const*, unsigned int, char const*) + 0x84 (0x7a7e8f086070 in /home/sebhtml/projects/burn/target/debug/build/torch-sys-80195893739a531c/out/libtorch/libtorch/lib/libc10.so)\nframe #2: <unknown function> + 0x18921af (0x7a7e78e921af in /home/sebhtml/projects/burn/target/debug/build/torch-sys-80195893739a531c/out/libtorch/libtorch/lib/libtorch_cpu.so)\nframe #3: at::TensorIteratorBase::compute_mem_overlaps(at::TensorIteratorConfig const&) + 0xa0 (0x7a7e78ed00a0 in /home/sebhtml/projects/burn/target/debug/build/torch-sys-80195893739a531c/out/libtorch/libtorch/lib/libtorch_cpu.so)\nframe #4: at::TensorIteratorBase::build(at::TensorIteratorConfig&) + 0x57 (0x7a7e78ed59a7 in /home/sebhtml/projects/burn/target/debug/build/torch-sys-80195893739a531c/out/libtorch/libtorch/lib/libtorch_cpu.so)\nframe #5: at::TensorIteratorBase::build_borrowing_binary_op(at::TensorBase const&, at::TensorBase const&, at::TensorBase const&) + 0xab (0x7a7e78ed6a4b in /home/sebhtml/projects/burn/target/debug/build/torch-sys-80195893739a531c/out/libtorch/libtorch/lib/libtorch_cpu.so)\nframe #6: <unknown function> + 0x2ddafbe (0x7a7e7a3dafbe in /home/sebhtml/projects/burn/target/debug/build/torch-sys-80195893739a531c/out/libtorch/libtorch/lib/libtorch_cpu.so)\nframe #7: <unknown function> + 0x50a13dd (0x7a7e7c6a13dd in /home/sebhtml/projects/burn/target/debug/build/torch-sys-80195893739a531c/out/libtorch/libtorch/lib/libtorch_cpu.so)\nframe #8: <unknown function> + 0x47da410 (0x7a7e7bdda410 in /home/sebhtml/projects/burn/target/debug/build/torch-sys-80195893739a531c/out/libtorch/libtorch/lib/libtorch_cpu.so)\nframe #9: at::_ops::mul__Tensor::call(at::Tensor&, at::Tensor const&) + 0x14a (0x7a7e79b8493a in /home/sebhtml/projects/burn/target/debug/build/torch-sys-80195893739a531c/out/libtorch/libtorch/lib/libtorch_cpu.so)\nframe #10: <unknown function> + 0x50967d (0x55ec1a91667d in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #11: <unknown function> + 0x509561 (0x55ec1a916561 in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #12: <unknown function> + 0x4bfabe (0x55ec1a8ccabe in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #13: <unknown function> + 0xed0cf (0x55ec1a4fa0cf in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #14: <unknown function> + 0x21caf7 (0x55ec1a629af7 in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #15: <unknown function> + 0x2058a9 (0x55ec1a6128a9 in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #16: <unknown function> + 0x218f7d (0x55ec1a625f7d in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #17: <unknown function> + 0xecb9d (0x55ec1a4f9b9d in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #18: <unknown function> + 0x120ead (0x55ec1a52dead in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #19: <unknown function> + 0x22d30c (0x55ec1a63a30c in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #20: <unknown function> + 0x394697 (0x55ec1a7a1697 in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #21: <unknown function> + 0x22d064 (0x55ec1a63a064 in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #22: <unknown function> + 0x64d97 (0x55ec1a471d97 in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #23: <unknown function> + 0x4731a9 (0x55ec1a8801a9 in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #24: <unknown function> + 0x47207d (0x55ec1a87f07d in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #25: <unknown function> + 0x46c0e1 (0x55ec1a8790e1 in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #26: <unknown function> + 0x46c15e (0x55ec1a87915e in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #27: <unknown function> + 0x47317d (0x55ec1a88017d in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #28: <unknown function> + 0x472055 (0x55ec1a87f055 in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #29: <unknown function> + 0x46bfa1 (0x55ec1a878fa1 in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #30: <unknown function> + 0x478af2 (0x55ec1a885af2 in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #31: <unknown function> + 0x478aae (0x55ec1a885aae in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #32: <unknown function> + 0x471395 (0x55ec1a87e395 in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #33: <unknown function> + 0x470fcb (0x55ec1a87dfcb in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #34: <unknown function> + 0x36e6f6 (0x55ec1a77b6f6 in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #35: <unknown function> + 0x2998b6 (0x55ec1a6a68b6 in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #36: <unknown function> + 0x164c95 (0x55ec1a571c95 in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #37: <unknown function> + 0x2f414a (0x55ec1a70114a in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #38: <unknown function> + 0x345103 (0x55ec1a752103 in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #39: <unknown function> + 0x1bc096 (0x55ec1a5c9096 in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #40: <unknown function> + 0x4b320f (0x55ec1a8c020f in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #41: <unknown function> + 0x4b1f91 (0x55ec1a8bef91 in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #42: <unknown function> + 0x479376 (0x55ec1a886376 in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #43: <unknown function> + 0x47e457 (0x55ec1a88b457 in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #44: <unknown function> + 0x588d35 (0x55ec1a995d35 in /home/sebhtml/projects/burn/target/debug/deps/burn_tch-c2cb7eb99d161369)\nframe #45: <unknown function> + 0x94ac3 (0x7a7e76c94ac3 in /lib/x86_64-linux-gnu/libc.so.6)\nframe #46: <unknown function> + 0x126850 (0x7a7e76d26850 in /lib/x86_64-linux-gnu/libc.so.6)\n")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    tests::ad_expand::tests::should_diff_expand

test result: FAILED. 690 passed; 1 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.30s

```

I believe that it is unrelated to my PR.


### Hardware

CPU

```
sebhtml@legion:~/projects/burn$ grep  "model name" /proc/cpuinfo |head -n 1
model name	: AMD Ryzen 7 7840HS w/ Radeon 780M Graphics*
```

GPU

```
sebhtml@legion:~/projects/burn$ nvidia-smi|grep -A 2 "NVIDIA "
|   0  NVIDIA GeForce RTX 4060 ...    Off | 00000000:01:00.0 Off |                  N/A |
| N/A   41C    P3               9W /  60W |      8MiB /  8188MiB |      0%      Default |
|                                         |                      |                  N/A |
```

RAM

```
sebhtml@legion:~/projects/burn$ head -n 1 /proc/meminfo 
MemTotal:       32015780 kB
```