### PR TITLE
Fix Cargo.toml repository links

### DIFF
--- a/crates/burn-autodiff/Cargo.toml
+++ b/crates/burn-autodiff/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["deep-learning", "machine-learning", "data"]
 license.workspace = true
 name = "burn-autodiff"
 readme.workspace = true
-repository = "https://github.com/tracel-ai/burn/tree/main/burn-autodiff"
+repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-autodiff"
 version.workspace = true
 
 [features]

--- a/crates/burn-candle/Cargo.toml
+++ b/crates/burn-candle/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["deep-learning", "machine-learning", "data"]
 license.workspace = true
 name = "burn-candle"
 readme.workspace = true
-repository = "https://github.com/tracel-ai/burn/tree/main/burn-candle"
+repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-candle"
 version.workspace = true
 
 [features]

--- a/crates/burn-common/Cargo.toml
+++ b/crates/burn-common/Cargo.toml
@@ -7,7 +7,7 @@ keywords = []
 license.workspace = true
 name = "burn-common"
 readme.workspace = true
-repository = "https://github.com/tracel-ai/burn/tree/main/burn-common"
+repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-common"
 version.workspace = true
 
 [features]

--- a/crates/burn-compute/Cargo.toml
+++ b/crates/burn-compute/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["deep-learning", "machine-learning", "data"]
 license.workspace = true
 name = "burn-compute"
 readme.workspace = true
-repository = "https://github.com/tracel-ai/burn/tree/main/burn-compute"
+repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-compute"
 version.workspace = true
 
 [features]

--- a/crates/burn-core/Cargo.toml
+++ b/crates/burn-core/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["deep-learning", "machine-learning", "tensor", "pytorch", "ndarray"]
 license.workspace = true
 name = "burn-core"
 readme.workspace = true
-repository = "https://github.com/tracel-ai/burn/tree/main/burn-core"
+repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-core"
 version.workspace = true
 
 [features]

--- a/crates/burn-cuda/Cargo.toml
+++ b/crates/burn-cuda/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["deep-learning", "machine-learning", "gpu", "cuda"]
 license.workspace = true
 name = "burn-cuda"
 readme.workspace = true
-repository = "https://github.com/tracel-ai/burn/tree/main/burn-cuda"
+repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-cuda"
 version.workspace = true
 
 [features]

--- a/crates/burn-dataset/Cargo.toml
+++ b/crates/burn-dataset/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["deep-learning", "machine-learning", "data"]
 license.workspace = true
 name = "burn-dataset"
 readme.workspace = true
-repository = "https://github.com/tracel-ai/burn/tree/main/burn-dataset"
+repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-dataset"
 version.workspace = true
 
 [features]

--- a/crates/burn-derive/Cargo.toml
+++ b/crates/burn-derive/Cargo.toml
@@ -7,7 +7,7 @@ keywords = []
 license.workspace = true
 name = "burn-derive"
 readme.workspace = true
-repository = "https://github.com/tracel-ai/burn/tree/main/burn-derive"
+repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-derive"
 version.workspace = true
 
 [lib]

--- a/crates/burn-fusion/Cargo.toml
+++ b/crates/burn-fusion/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["deep-learning", "machine-learning", "data"]
 license.workspace = true
 name = "burn-fusion"
 readme.workspace = true
-repository = "https://github.com/tracel-ai/burn/tree/main/burn-fusion"
+repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-fusion"
 version.workspace = true
 
 [features]

--- a/crates/burn-import/Cargo.toml
+++ b/crates/burn-import/Cargo.toml
@@ -8,7 +8,7 @@ edition.workspace = true
 license.workspace = true
 name = "burn-import"
 readme.workspace = true
-repository = "https://github.com/tracel-ai/burn/tree/main/burn-import"
+repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-import"
 version.workspace = true
 
 default-run = "onnx2burn"

--- a/crates/burn-jit/Cargo.toml
+++ b/crates/burn-jit/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["deep-learning", "machine-learning", "gpu"]
 license.workspace = true
 name = "burn-jit"
 readme.workspace = true
-repository = "https://github.com/tracel-ai/burn/tree/main/burn-jit"
+repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-jit"
 version.workspace = true
 
 [features]

--- a/crates/burn-ndarray/Cargo.toml
+++ b/crates/burn-ndarray/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["deep-learning", "machine-learning", "data"]
 license.workspace = true
 name = "burn-ndarray"
 readme.workspace = true
-repository = "https://github.com/tracel-ai/burn/tree/main/burn-ndarray"
+repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-ndarray"
 version.workspace = true
 
 [features]

--- a/crates/burn-no-std-tests/Cargo.toml
+++ b/crates/burn-no-std-tests/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 license.workspace = true
 name = "burn-no-std-tests"
 readme.workspace = true
-repository = "https://github.com/tracel-ai/burn/tree/main/burn-no-std-tests"
+repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-no-std-tests"
 version.workspace = true
 
 [dependencies]

--- a/crates/burn-tch/Cargo.toml
+++ b/crates/burn-tch/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["deep-learning", "machine-learning", "data"]
 license.workspace = true
 name = "burn-tch"
 readme.workspace = true
-repository = "https://github.com/tracel-ai/burn/tree/main/burn-tch"
+repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-tch"
 version.workspace = true
 
 [features]

--- a/crates/burn-tensor-testgen/Cargo.toml
+++ b/crates/burn-tensor-testgen/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 name = "burn-tensor-testgen"
 readme.workspace = true
-repository = "https://github.com/tracel-ai/burn/tree/main/burn-tensor-testgen"
+repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-tensor-testgen"
 version.workspace = true
 
 [lib]

--- a/crates/burn-tensor/Cargo.toml
+++ b/crates/burn-tensor/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["deep-learning", "machine-learning", "tensor", "pytorch", "ndarray"]
 license.workspace = true
 name = "burn-tensor"
 readme.workspace = true
-repository = "https://github.com/tracel-ai/burn/tree/main/burn-tensor"
+repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-tensor"
 version.workspace = true
 
 [features]

--- a/crates/burn-train/Cargo.toml
+++ b/crates/burn-train/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["deep-learning", "machine-learning", "tensor", "pytorch", "ndarray"]
 license.workspace = true
 name = "burn-train"
 readme.workspace = true
-repository = "https://github.com/tracel-ai/burn/tree/main/burn-train"
+repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-train"
 version.workspace = true
 
 [features]

--- a/crates/burn-wgpu/Cargo.toml
+++ b/crates/burn-wgpu/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["deep-learning", "machine-learning", "gpu", "wgpu", "webgpu"]
 license.workspace = true
 name = "burn-wgpu"
 readme.workspace = true
-repository = "https://github.com/tracel-ai/burn/tree/main/burn-wgpu"
+repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-wgpu"
 version.workspace = true
 
 [features]


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.

### Changes

Changed the links in the Cargo.toml files for the crates to the right links (they were missing the /crates/ in the link so they did not work).

### Testing

All of the modified links were tested to be sure they directed to the right page.
