### PR TITLE
Fix record nested value de/serialization

### DIFF
--- a/crates/burn-core/src/record/serde/de.rs
+++ b/crates/burn-core/src/record/serde/de.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use super::data::NestedValue;
 use super::{adapter::BurnModuleAdapter, error::Error};
 
-use serde::de::value::SeqDeserializer;
 use serde::de::{EnumAccess, VariantAccess};
 use serde::{
     de::{self, DeserializeSeed, IntoDeserializer, MapAccess, SeqAccess, Visitor},
@@ -287,20 +286,27 @@ impl<'de, A: BurnModuleAdapter> serde::Deserializer<'de> for Deserializer<A> {
     where
         V: Visitor<'de>,
     {
-        match self.value {
-            Some(NestedValue::Vec(vec)) => {
-                visitor.visit_seq(VecSeqAccess::<A>::new(vec, self.default_for_missing_fields))
+        if let Some(value) = self.value {
+            match value {
+                NestedValue::Vec(_) => visitor.visit_seq(VecSeqAccess::<A, NestedValue>::new(
+                    value,
+                    self.default_for_missing_fields,
+                )),
+                NestedValue::U16s(_) => visitor.visit_seq(VecSeqAccess::<A, u16>::new(
+                    value,
+                    self.default_for_missing_fields,
+                )),
+                NestedValue::F32s(_) => visitor.visit_seq(VecSeqAccess::<A, f32>::new(
+                    value,
+                    self.default_for_missing_fields,
+                )),
+                _ => Err(de::Error::custom(format!(
+                    "Expected Vec but got {:?}",
+                    value
+                ))),
             }
-            Some(NestedValue::U16s(vec)) => {
-                visitor.visit_seq(SeqDeserializer::new(vec.into_iter()))
-            }
-            Some(NestedValue::F32s(vec)) => {
-                visitor.visit_seq(SeqDeserializer::new(vec.into_iter()))
-            }
-            _ => Err(de::Error::custom(format!(
-                "Expected Vec but got {:?}",
-                self.value
-            ))),
+        } else {
+            Err(de::Error::custom("Expected Vec but got None"))
         }
     }
 
@@ -393,23 +399,56 @@ impl<'de, A: BurnModuleAdapter> serde::Deserializer<'de> for Deserializer<A> {
 }
 
 /// A sequence access for a vector in the nested value data structure.
-struct VecSeqAccess<A: BurnModuleAdapter> {
-    iter: std::vec::IntoIter<NestedValue>,
+struct VecSeqAccess<A: BurnModuleAdapter, I> {
+    iter: Box<dyn Iterator<Item = I>>,
     default_for_missing_fields: bool,
     phantom: std::marker::PhantomData<A>,
 }
 
-impl<A: BurnModuleAdapter> VecSeqAccess<A> {
-    fn new(vec: Vec<NestedValue>, default_for_missing_fields: bool) -> Self {
-        VecSeqAccess {
-            iter: vec.into_iter(),
-            default_for_missing_fields,
-            phantom: std::marker::PhantomData,
+// Concrete implementation for `Vec<NestedValue>`
+impl<A: BurnModuleAdapter> VecSeqAccess<A, NestedValue> {
+    fn new(vec: NestedValue, default_for_missing_fields: bool) -> Self {
+        match vec {
+            NestedValue::Vec(v) => VecSeqAccess {
+                iter: Box::new(v.into_iter()),
+                default_for_missing_fields,
+                phantom: std::marker::PhantomData,
+            },
+            _ => panic!("Invalid vec sequence"),
         }
     }
 }
 
-impl<'de, A> SeqAccess<'de> for VecSeqAccess<A>
+// Concrete implementation for `Vec<u16>`
+impl<A: BurnModuleAdapter> VecSeqAccess<A, u16> {
+    fn new(vec: NestedValue, default_for_missing_fields: bool) -> Self {
+        match vec {
+            NestedValue::U16s(v) => VecSeqAccess {
+                iter: Box::new(v.into_iter()),
+                default_for_missing_fields,
+                phantom: std::marker::PhantomData,
+            },
+            _ => panic!("Invalid vec sequence"),
+        }
+    }
+}
+
+// Concrete implementation for `Vec<f32>`
+impl<A: BurnModuleAdapter> VecSeqAccess<A, f32> {
+    fn new(vec: NestedValue, default_for_missing_fields: bool) -> Self {
+        match vec {
+            NestedValue::F32s(v) => VecSeqAccess {
+                iter: Box::new(v.into_iter()),
+                default_for_missing_fields,
+                phantom: std::marker::PhantomData,
+            },
+            _ => panic!("Invalid vec sequence"),
+        }
+    }
+}
+
+// Concrete implementation for `Vec<NestedValue>`
+impl<'de, A> SeqAccess<'de> for VecSeqAccess<A, NestedValue>
 where
     NestedValueWrapper<A>: IntoDeserializer<'de, Error>,
     A: BurnModuleAdapter,
@@ -427,6 +466,56 @@ where
 
         seed.deserialize(
             NestedValueWrapper::<A>::new(item, self.default_for_missing_fields).into_deserializer(),
+        )
+        .map(Some)
+    }
+}
+
+// Concrete implementation for `Vec<u16>`
+impl<'de, A> SeqAccess<'de> for VecSeqAccess<A, u16>
+where
+    NestedValueWrapper<A>: IntoDeserializer<'de, Error>,
+    A: BurnModuleAdapter,
+{
+    type Error = Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        let item = match self.iter.next() {
+            Some(v) => v,
+            None => return Ok(None),
+        };
+
+        seed.deserialize(
+            NestedValueWrapper::<A>::new(NestedValue::U16(item), self.default_for_missing_fields)
+                .into_deserializer(),
+        )
+        .map(Some)
+    }
+}
+
+// Concrete implementation for `Vec<f32>`
+impl<'de, A> SeqAccess<'de> for VecSeqAccess<A, f32>
+where
+    NestedValueWrapper<A>: IntoDeserializer<'de, Error>,
+    A: BurnModuleAdapter,
+{
+    type Error = Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        let item = match self.iter.next() {
+            Some(v) => v,
+            None => return Ok(None),
+        };
+
+        seed.deserialize(
+            NestedValueWrapper::<A>::new(NestedValue::F32(item), self.default_for_missing_fields)
+                .into_deserializer(),
         )
         .map(Some)
     }

--- a/crates/burn-core/src/record/serde/ser.rs
+++ b/crates/burn-core/src/record/serde/ser.rs
@@ -16,7 +16,7 @@ use serde::{
 /// the actual serialization of modules (although it could be used for that as well if all
 /// primitive types are implemented).
 pub struct Serializer {
-    // The state of the serialization process
+    /// The state of the serialization process
     state: Option<NestedValue>,
 }
 
@@ -254,11 +254,30 @@ impl SerializeSeq for Serializer {
             Some(NestedValue::Vec(ref mut vec)) => {
                 vec.push(serialized_value); // Inserting into the state
             }
+            Some(NestedValue::U16s(ref mut vec)) => {
+                if let NestedValue::U16(val) = serialized_value {
+                    vec.push(val);
+                } else {
+                    panic!("Invalid value type encountered");
+                }
+            }
+            Some(NestedValue::F32s(ref mut vec)) => {
+                if let NestedValue::F32(val) = serialized_value {
+                    vec.push(val);
+                } else {
+                    panic!("Invalid value type encountered");
+                }
+            }
             Some(_) => {
                 panic!("Invalid state encountered");
             }
             None => {
-                self.state = Some(NestedValue::Vec(vec![serialized_value]));
+                let val = match serialized_value {
+                    NestedValue::U16(val) => NestedValue::U16s(vec![val]),
+                    NestedValue::F32(val) => NestedValue::F32s(vec![val]),
+                    _ => NestedValue::Vec(vec![serialized_value]),
+                };
+                self.state = Some(val);
             }
         }
 

--- a/crates/burn-core/src/record/serde/ser.rs
+++ b/crates/burn-core/src/record/serde/ser.rs
@@ -350,7 +350,6 @@ mod tests {
         // the order of the fields is not guaranteed for HashMaps.
         assert_eq!(serialized_str.len(), 135);
     }
-
     #[test]
     fn test_param_serde() {
         type Backend = burn_ndarray::NdArray<f32>;
@@ -371,6 +370,6 @@ mod tests {
 
         // Compare the lengths of expected and actual serialized strings because
         // the order of the fields is not guaranteed for HashMaps.
-        assert_eq!(serialized_str.len(), 149);
+        assert_eq!(serialized_str.len(), 134);
     }
 }


### PR DESCRIPTION
While working on the Llama-3 implementation I stumbled upon a memory issue when importing pytorch weights with `PyTorchFileRecorder`.

When I profiled the memory usage for ResNet-152 (checkpoint is 252MB on disk), I saw a huge peak memory usage for what is supposed to be a relatively small model. Up to ~5GB as pointed out by the [`heaptrack`](https://github.com/KDE/heaptrack) trace below.

Before
![image](https://github.com/tracel-ai/burn/assets/7225623/c6102c85-db40-44ea-9f7f-962aedb839fd)

After
![image](https://github.com/tracel-ai/burn/assets/7225623/27e45316-ac90-436a-bd3f-a3c5ff805e0c)

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.

### Changes

Added `U16s` and `F32s` variants for `NestedValue` so weights can be parsed as a vector of primitive types instead of `Vec<NestedValue>`. For example, a vec of `f32`s is now represented as `Vec[v, v, v, ...]` instead of `Vec[NestedValue::F32(v), NestedValue::F32(v), ...]`. The `NestedValue` enum has a size of 56 bytes so it can grow very rapidly (just imagine for a very large number of parameters like in LLama 8B 🤯 ).

- Handle different vec types in `Serializer` based on the input element type
- Make `VecSeqAccess`'s `iter` generic and add concrete implementations for vec of `NestedValue`, `u16` and `f32`

### Testing

All unit tests pass, including half precision record tests in `burn-import/pytorch-tests`.