### PR TITLE
Fix invalid links in README and CONTRIBUTING documents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ idea of what kind of work is currently being planned or is in progress.
 
 ### Step 2: Get Familiar with the Project Architecture
 
-It's crucial to have an understanding of the [project's architecture](/ARCHITECTURE.md). Familiarize
+It's crucial to have an understanding of the [project's architecture](https://github.com/tracel-ai/burn/tree/main/contributor-book/src/project-architecture). Familiarize
 yourself with the structure of the project, the purpose of different components, and how they
 interact with each other. This will give you the context needed to make meaningful contributions.
 

--- a/README.md
+++ b/README.md
@@ -591,9 +591,9 @@ any background. You can ask your questions and share what you built with the com
 
 Before contributing, please take a moment to review our
 [code of conduct](https://github.com/tracel-ai/burn/tree/main/CODE-OF-CONDUCT.md). It's also highly
-recommended to read our
-[architecture document](https://github.com/tracel-ai/burn/tree/main/ARCHITECTURE.md), which explains
-some of our architectural decisions. Refer to out [contributing guide](/CONTRIBUTING.md) for more
+recommended to read the
+[architecture overview](https://github.com/tracel-ai/burn/tree/main/contributor-book/src/project-architecture), which explains
+some of our architectural decisions. Refer to our [contributing guide](/CONTRIBUTING.md) for more
 details.
 
 ## Status


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

N/A

### Changes

Edited the links pointing to [CONTRIBUTING.md](https://github.com/tracel-ai/burn/blob/main/ARCHITECTURE.md), which no longer exists, to point to the [architecture overview](https://github.com/tracel-ai/burn/tree/main/contributor-book/src/project-architecture) in the contributor book.

### Testing

N/A
