### PR TITLE
Add a feature to initialize from an existing wgpu adapter/device/queue

### DIFF
--- a/crates/burn-wgpu/src/compute/server.rs
+++ b/crates/burn-wgpu/src/compute/server.rs
@@ -18,7 +18,7 @@ use wgpu::{
 pub struct WgpuServer<MM: MemoryManagement<WgpuStorage>> {
     memory_management: MM,
     device: Arc<wgpu::Device>,
-    queue: wgpu::Queue,
+    queue: Arc<wgpu::Queue>,
     encoder: CommandEncoder,
     pipelines: HashMap<String, Arc<ComputePipeline>>,
     tasks_max: usize,
@@ -33,7 +33,7 @@ where
     pub fn new(
         memory_management: MM,
         device: Arc<wgpu::Device>,
-        queue: wgpu::Queue,
+        queue: Arc<wgpu::Queue>,
         tasks_max: usize,
     ) -> Self {
         let encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {

--- a/crates/burn-wgpu/src/device.rs
+++ b/crates/burn-wgpu/src/device.rs
@@ -41,6 +41,12 @@ pub enum WgpuDevice {
     /// A device might be identified as [Other](wgpu::DeviceType::Other) by [wgpu](wgpu), in this case, we chose this device over
     /// `IntegratedGpu` since it's often a discrete GPU.
     BestAvailable,
+
+    /// Use an externally created, existing, wgpu setup. This is helpful when using Burn in conjunction
+    /// with some existing wgpu setup (eg. egui or bevy), as resources can be tranferred in & out of Burn.
+    /// 
+    /// The device is indexed by the global wgpu [adapter ID](wgpu::Device::global_id).
+    Existing(wgpu::Id<wgpu::Device>),
 }
 
 impl Default for WgpuDevice {

--- a/crates/burn-wgpu/src/device.rs
+++ b/crates/burn-wgpu/src/device.rs
@@ -43,8 +43,8 @@ pub enum WgpuDevice {
     BestAvailable,
 
     /// Use an externally created, existing, wgpu setup. This is helpful when using Burn in conjunction
-    /// with some existing wgpu setup (eg. egui or bevy), as resources can be tranferred in & out of Burn.
-    /// 
+    /// with some existing wgpu setup (eg. egui or bevy), as resources can be transferred in & out of Burn.
+    ///
     /// The device is indexed by the global wgpu [adapter ID](wgpu::Device::global_id).
     Existing(wgpu::Id<wgpu::Device>),
 }

--- a/crates/burn-wgpu/src/runtime.rs
+++ b/crates/burn-wgpu/src/runtime.rs
@@ -233,7 +233,9 @@ fn select_adapter<G: GraphicsApi>(device: &WgpuDevice) -> wgpu::Adapter {
                 WgpuDevice::VirtualGpu(_) => device_type == DeviceType::VirtualGpu,
                 WgpuDevice::Cpu => device_type == DeviceType::Cpu,
                 WgpuDevice::BestAvailable => true,
-                WgpuDevice::Existing(_) => unreachable!("Cannot select an adapter for an existing device.")
+                WgpuDevice::Existing(_) => {
+                    unreachable!("Cannot select an adapter for an existing device.")
+                }
             };
 
             if is_same_type {
@@ -319,8 +321,8 @@ fn select_adapter<G: GraphicsApi>(device: &WgpuDevice) -> wgpu::Adapter {
                 panic!("No adapter found for graphics API {:?}", G::default());
             }
         }
-        WgpuDevice::Existing(_) => unreachable!("Cannot select an adapter for an existing device.")
-    };  
+        WgpuDevice::Existing(_) => unreachable!("Cannot select an adapter for an existing device."),
+    };
 
     log::info!("Using adapter {:?}", adapter.get_info());
 

--- a/crates/burn-wgpu/src/runtime.rs
+++ b/crates/burn-wgpu/src/runtime.rs
@@ -46,7 +46,8 @@ impl<G: GraphicsApi> Runtime for WgpuRuntime<G> {
 
     fn client(device: &Self::Device) -> ComputeClient<Self::Server, Self::Channel> {
         RUNTIME.client(device, move || {
-            pollster::block_on(create_client::<G>(device, RuntimeOptions::default()))
+            let (adapter, device_wgpu, queue) = pollster::block_on(create_wgpu_setup::<G>(device));
+            create_client(adapter, device_wgpu, queue, RuntimeOptions::default())
         })
     }
 
@@ -63,6 +64,11 @@ impl DeviceOps for WgpuDevice {
             WgpuDevice::VirtualGpu(index) => DeviceId::new(2, *index as u32),
             WgpuDevice::Cpu => DeviceId::new(3, 0),
             WgpuDevice::BestAvailable => DeviceId::new(4, 0),
+            // For an existing device, use the 64 bit wgpu device ID as the burn DeviceID.
+            // We're only storing 32 bits, so wrap the the 64 bit value to 32 bits. This
+            // might collide - but a 1 in 4 billion chance seems ok given there's only a few
+            // devices in flight at any time.
+            WgpuDevice::Existing(id) => DeviceId::new(5, (id.inner() % (u32::MAX as u64)) as u32),
         }
     }
 }
@@ -96,52 +102,68 @@ impl Default for RuntimeOptions {
     }
 }
 
+pub fn init_existing_device(
+    adapter: Arc<wgpu::Adapter>,
+    device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
+    options: RuntimeOptions,
+) -> WgpuDevice {
+    let device_id = WgpuDevice::Existing(device.as_ref().global_id());
+    let client = create_client(adapter, device, queue, options);
+    RUNTIME.register(&device_id, client);
+    device_id
+}
+
 /// Init the client sync, useful to configure the runtime options.
 pub fn init_sync<G: GraphicsApi>(device: &WgpuDevice, options: RuntimeOptions) {
-    let device = Arc::new(device);
-    let client = pollster::block_on(create_client::<G>(&device, options));
-
-    RUNTIME.register(&device, client)
+    let (adapter, device_wgpu, queue) = pollster::block_on(create_wgpu_setup::<G>(device));
+    let client = create_client(adapter, device_wgpu, queue, options);
+    RUNTIME.register(device, client)
 }
 
 /// Init the client async, necessary for wasm.
 pub async fn init_async<G: GraphicsApi>(device: &WgpuDevice, options: RuntimeOptions) {
-    let device = Arc::new(device);
-    let client = create_client::<G>(&device, options).await;
-
-    RUNTIME.register(&device, client)
+    let (adapter, device_wgpu, queue) = create_wgpu_setup::<G>(device).await;
+    let client = create_client(adapter, device_wgpu, queue, options);
+    RUNTIME.register(device, client)
 }
 
-async fn create_client<G: GraphicsApi>(
+async fn create_wgpu_setup<G: GraphicsApi>(
     device: &WgpuDevice,
+) -> (Arc<wgpu::Adapter>, Arc<wgpu::Device>, Arc<wgpu::Queue>) {
+    let (device_wgpu, queue, adapter) = select_device::<G>(device).await;
+
+    log::info!(
+        "Created wgpu compute server on device {:?} => {:?}",
+        device,
+        adapter.get_info()
+    );
+    (Arc::new(adapter), Arc::new(device_wgpu), Arc::new(queue))
+}
+
+fn create_client(
+    adapter: Arc<wgpu::Adapter>,
+    device_wgpu: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     options: RuntimeOptions,
 ) -> ComputeClient<
     WgpuServer<SimpleMemoryManagement<WgpuStorage>>,
     MutexComputeChannel<WgpuServer<SimpleMemoryManagement<WgpuStorage>>>,
 > {
-    let (device_wgpu, queue, info) = select_device::<G>(device).await;
-
-    log::info!(
-        "Created wgpu compute server on device {:?} => {:?}",
-        device,
-        info
-    );
-
-    let device = Arc::new(device_wgpu);
-    let storage = WgpuStorage::new(device.clone());
+    let storage = WgpuStorage::new(device_wgpu.clone());
     let memory_management =
         SimpleMemoryManagement::new(storage, options.dealloc_strategy, options.slice_strategy);
-    let server = WgpuServer::new(memory_management, device, queue, options.tasks_max);
+    let server = WgpuServer::new(memory_management, device_wgpu, queue, options.tasks_max);
     let channel = MutexComputeChannel::new(server);
+    let tuner_device_id = tuner_device_id(adapter.get_info());
 
-    let tuner_device_id = tuner_device_id(info);
     ComputeClient::new(channel, Arc::new(RwLock::new(Tuner::new(&tuner_device_id))))
 }
 
 /// Select the wgpu device and queue based on the provided [device](WgpuDevice).
 pub async fn select_device<G: GraphicsApi>(
     device: &WgpuDevice,
-) -> (wgpu::Device, wgpu::Queue, wgpu::AdapterInfo) {
+) -> (wgpu::Device, wgpu::Queue, wgpu::Adapter) {
     #[cfg(target_family = "wasm")]
     let adapter = select_adapter::<G>(device).await;
 
@@ -169,7 +191,7 @@ pub async fn select_device<G: GraphicsApi>(
         })
         .unwrap();
 
-    (device, queue, adapter.get_info())
+    (device, queue, adapter)
 }
 
 fn tuner_device_id(info: AdapterInfo) -> String {
@@ -211,6 +233,7 @@ fn select_adapter<G: GraphicsApi>(device: &WgpuDevice) -> wgpu::Adapter {
                 WgpuDevice::VirtualGpu(_) => device_type == DeviceType::VirtualGpu,
                 WgpuDevice::Cpu => device_type == DeviceType::Cpu,
                 WgpuDevice::BestAvailable => true,
+                WgpuDevice::Existing(_) => unreachable!("Cannot select an adapter for an existing device.")
             };
 
             if is_same_type {
@@ -296,7 +319,8 @@ fn select_adapter<G: GraphicsApi>(device: &WgpuDevice) -> wgpu::Adapter {
                 panic!("No adapter found for graphics API {:?}", G::default());
             }
         }
-    };
+        WgpuDevice::Existing(_) => unreachable!("Cannot select an adapter for an existing device.")
+    };  
 
     log::info!("Using adapter {:?}", adapter.get_info());
 


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs
Some Discord discussions: https://discord.com/channels/1038839012602941528/1229453567694209105/1230282427629441075

### Changes

This is useful when interacting with other wgpu applications (eg. displaying a burn tensor as a texture in egui). The existing devices are keyed by the wgpu Device ID. Alternatively they could be keyed per adapter which would be more inline with other burn WgpuDevice's (one per adapter), but also there's no real inherent reason to.

This also involves making Queue into an Arc. Alternatively, this could give up ownership of the queue, but it's helpful to be able to synchronize burn operations and custom wgpu operations.

Nb: Even with this feature it's still tricky to say, copy a burn buffer to a wgpu texture, as there's no access to wgpu bindings in the public Burn API. I've got a feature for that locally but not sure what the best way is, might open an issue for it.

### Testing

run-checks all, using this feature in some local development.