### PR TITLE
Jit backend: Fix PRNG bug during autotune

### DIFF
--- a/crates/burn-jit/src/kernel/prng/bernoulli.rs
+++ b/crates/burn-jit/src/kernel/prng/bernoulli.rs
@@ -1,6 +1,6 @@
 use burn_cube::{
     cpa,
-    dialect::{Elem, Scope, Variable},
+    dialect::{Elem, FloatKind, Scope, Variable},
 };
 use burn_tensor::Shape;
 
@@ -33,6 +33,7 @@ impl<E: JitElement> Prng<E> for Bernoulli<E> {
         state_3: Variable,
         output: Variable,
     ) {
+        let float_elem = Elem::Float(FloatKind::F32);
         let prob = args[0];
         cpa!(
             scope,
@@ -47,7 +48,7 @@ impl<E: JitElement> Prng<E> for Bernoulli<E> {
                 cpa!(scope, int_random = int_random ^ state_2);
                 cpa!(scope, int_random = int_random ^ state_3);
 
-                let float_random = scope.create_local(E::cube_elem());
+                let float_random = scope.create_local(float_elem);
                 cast_uint_to_float(scope, int_random, float_random);
 
                 let bernoulli = scope.create_local(Elem::Bool);

--- a/crates/burn-jit/src/kernel/prng/normal.rs
+++ b/crates/burn-jit/src/kernel/prng/normal.rs
@@ -1,6 +1,6 @@
 use burn_cube::{
     cpa,
-    dialect::{Elem, Scope, Variable},
+    dialect::{Elem, FloatKind, Scope, Variable},
 };
 use std::f32::consts::PI;
 
@@ -36,11 +36,11 @@ impl<E: JitElement> Prng<E> for Normal<E> {
         state_3: Variable,
         output: Variable,
     ) {
-        let elem = E::cube_elem();
+        let float_elem = Elem::Float(FloatKind::F32);
         let item = output.item();
         let mean = args[0];
         let std = args[1];
-        let two_pi = scope.create_with_value(2. * PI, elem);
+        let two_pi = scope.create_with_value(2. * PI, float_elem);
         let t_neg = scope.create_with_value(-2.0, item);
         let two: Variable = 2u32.into();
 
@@ -59,7 +59,7 @@ impl<E: JitElement> Prng<E> for Normal<E> {
                 cpa!(scope, int_random = int_random ^ state_2);
                 cpa!(scope, int_random = int_random ^ state_3);
 
-                let unit_0 = scope.create_local(elem);
+                let unit_0 = scope.create_local(float_elem);
                 cast_uint_to_float(scope, int_random, unit_0);
 
                 // Second random uniform integer
@@ -72,7 +72,7 @@ impl<E: JitElement> Prng<E> for Normal<E> {
                 cpa!(scope, int_random = int_random ^ state_2);
                 cpa!(scope, int_random = int_random ^ state_3);
 
-                let unit_1 = scope.create_local(elem);
+                let unit_1 = scope.create_local(float_elem);
                 cast_uint_to_float(scope, int_random, unit_1);
 
                 // Box-Muller transform

--- a/crates/burn-jit/src/kernel/prng/uniform.rs
+++ b/crates/burn-jit/src/kernel/prng/uniform.rs
@@ -1,6 +1,6 @@
 use burn_cube::{
     cpa,
-    dialect::{Elem, Scope, Variable},
+    dialect::{Elem, FloatKind, Scope, Variable},
 };
 use burn_tensor::Shape;
 
@@ -34,7 +34,7 @@ impl<E: JitElement> Prng<E> for Uniform<E> {
         state_3: Variable,
         output: Variable,
     ) {
-        let elem = E::cube_elem();
+        let float_elem = Elem::Float(FloatKind::F32);
         let item = output.item();
         let lower_bound = args[0];
         let upper_bound = args[1];
@@ -54,12 +54,12 @@ impl<E: JitElement> Prng<E> for Uniform<E> {
                 cpa!(scope, int_random = int_random ^ state_2);
                 cpa!(scope, int_random = int_random ^ state_3);
 
-                let float_random = scope.create_local(elem);
-                let float_scale = scope.create_local(elem);
+                let float_random = scope.create_local(float_elem);
+                let float_scale = scope.create_local(float_elem);
                 cast_uint_to_float(scope, int_random, float_random);
                 cpa!(scope, float_scale = cast(scale));
 
-                let uniform_float = scope.create_local(elem);
+                let uniform_float = scope.create_local(float_elem);
                 let uniform = scope.create_local(item);
                 cpa!(scope, uniform_float = float_random * float_scale);
                 cpa!(scope, uniform = cast(uniform_float));

--- a/crates/burn-jit/src/tests/uniform.rs
+++ b/crates/burn-jit/src/tests/uniform.rs
@@ -103,4 +103,13 @@ mod tests {
         assert!(stats[1].count >= 1);
         assert!(stats[2].count >= 1);
     }
+
+    #[test]
+    fn should_not_fail_on_non_float_autotune() {
+        let device = Default::default();
+        let tensor_1 = Tensor::<TestBackend, 2>::from_floats([[1., 2., 3.], [3., 4., 5.]], &device);
+
+        // Autotune of all (reduce) on lower_equal_elem's output calls uniform distribution
+        tensor_1.lower_equal_elem(1.0).all();
+    }
 }


### PR DESCRIPTION
During the element types refactor of #1693 some types in PRNG that really needed to be Float were accidentally replaced with the input's element type. This could cause a type mismatch in the PRNG kernel, which could happen during autotune of int/bool tensors, which call uniform distribution PRNG. 

Fix #1790 