### PR TITLE
Fix burn-jit compile error

### DIFF
--- a/crates/burn-jit/src/kernel/reduce/base.rs
+++ b/crates/burn-jit/src/kernel/reduce/base.rs
@@ -35,15 +35,22 @@ pub fn init_reduce_output<R: JitRuntime, EI: JitElement, EO: JitElement, const D
 
 #[derive(Copy, Clone, Debug)]
 #[allow(missing_docs)]
-#[derive(Default)]
 pub enum ReduceStrategy {
-    #[cfg(not(feature = "autotune"))]
-    #[default]
     Naive,
     SharedMemory,
     #[cfg(feature = "autotune")]
-    #[default]
     Autotune,
+}
+
+impl Default for ReduceStrategy {
+    fn default() -> Self {
+        // if autotune is enabled, default to autotune
+        #[cfg(feature = "autotune")]
+        return ReduceStrategy::Autotune;
+
+        #[cfg(not(feature = "autotune"))]
+        ReduceStrategy::Naive
+    }
 }
 
 #[cfg(feature = "autotune")]

--- a/crates/burn-jit/src/kernel/reduce/base.rs
+++ b/crates/burn-jit/src/kernel/reduce/base.rs
@@ -37,6 +37,8 @@ pub fn init_reduce_output<R: JitRuntime, EI: JitElement, EO: JitElement, const D
 #[allow(missing_docs)]
 #[derive(Default)]
 pub enum ReduceStrategy {
+    #[cfg(not(feature = "autotune"))]
+    #[default]
     Naive,
     SharedMemory,
     #[cfg(feature = "autotune")]


### PR DESCRIPTION
Fixes the compile error when trying to build the image-classification-web example. 