### PR TITLE
Fix `DataSerialize` conversion for elements of the same type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "backend-comparison"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "arboard",
  "burn",
@@ -427,7 +427,7 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "burn"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn-core",
  "burn-train",
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "burn-autodiff"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn-common",
  "burn-tensor",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "burn-candle"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn-autodiff",
  "burn-tch",
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "burn-common"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -477,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "burn-compute"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn-common",
  "derive-new",
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "burn-core"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "bincode",
  "burn-autodiff",
@@ -525,7 +525,7 @@ dependencies = [
 
 [[package]]
 name = "burn-cube"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn-compute",
  "burn-cube-macros",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "burn-cube-macros"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "derive-new",
  "proc-macro2",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "burn-cuda"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn-common",
  "burn-compute",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "burn-dataset"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn-common",
  "csv",
@@ -597,7 +597,7 @@ dependencies = [
 
 [[package]]
 name = "burn-derive"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "derive-new",
  "proc-macro2",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "burn-fusion"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn-common",
  "burn-tensor",
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "burn-import"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn",
  "bytemuck",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "burn-jit"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn-autodiff",
  "burn-common",
@@ -674,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "burn-ndarray"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "blas-src",
  "burn-autodiff",
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "burn-no-std-tests"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn",
  "burn-ndarray",
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "burn-tch"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn-autodiff",
  "burn-tensor",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "burn-tensor"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn-common",
  "burn-tensor-testgen",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "burn-tensor-testgen"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "burn-train"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn-core",
  "burn-ndarray",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "burn-wgpu"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn-common",
  "burn-compute",
@@ -1353,7 +1353,7 @@ dependencies = [
 
 [[package]]
 name = "custom-csv-dataset"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn",
  "csv",
@@ -1363,7 +1363,7 @@ dependencies = [
 
 [[package]]
 name = "custom-image-dataset"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn",
  "flate2",
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "custom-renderer"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn",
  "bytemuck",
@@ -1384,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "custom-training-loop"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn",
  "bytemuck",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "custom-wgpu-kernel"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn",
  "bytemuck",
@@ -2345,7 +2345,7 @@ dependencies = [
 
 [[package]]
 name = "guide"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn",
  "log",
@@ -2776,7 +2776,7 @@ dependencies = [
 
 [[package]]
 name = "image-classification-web"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn",
  "burn-candle",
@@ -3227,7 +3227,7 @@ dependencies = [
 
 [[package]]
 name = "mnist"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn",
  "log",
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "mnist-inference-web"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn",
  "console_error_panic_hook",
@@ -3299,7 +3299,7 @@ dependencies = [
 
 [[package]]
 name = "named-tensor"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn",
  "serde",
@@ -3628,7 +3628,7 @@ dependencies = [
 
 [[package]]
 name = "onnx-inference"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn",
  "burn-import",
@@ -3637,7 +3637,7 @@ dependencies = [
 
 [[package]]
 name = "onnx-tests"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn",
  "burn-import",
@@ -4047,7 +4047,7 @@ dependencies = [
 
 [[package]]
 name = "pytorch-import"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn",
  "burn-import",
@@ -4056,7 +4056,7 @@ dependencies = [
 
 [[package]]
 name = "pytorch-tests"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn",
  "burn-autodiff",
@@ -4356,7 +4356,7 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "regression"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn",
  "log",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "text-classification"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn",
  "derive-new",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "text-generation"
-version = "0.15.0"
+version = "0.14.0"
 dependencies = [
  "burn",
  "derive-new",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 
 [workspace.package]
 edition = "2021"
-version = "0.15.0"
+version = "0.14.0"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 

--- a/backend-comparison/Cargo.toml
+++ b/backend-comparison/Cargo.toml
@@ -29,9 +29,9 @@ cuda-jit = ["burn-cuda"]
 [dependencies]
 arboard = { workspace = true }
 burn = { path = "../crates/burn", default-features = false }
-burn-common = { path = "../crates/burn-common", version = "0.15.0" }
-burn-wgpu = { path = "../crates/burn-wgpu", default-features = false, version = "0.15.0" }
-burn-cuda = { path = "../crates/burn-cuda", version = "0.15.0", optional = true }
+burn-common = { path = "../crates/burn-common", version = "0.14.0" }
+burn-wgpu = { path = "../crates/burn-wgpu", default-features = false, version = "0.14.0" }
+burn-cuda = { path = "../crates/burn-cuda", version = "0.14.0", optional = true }
 clap = { workspace = true }
 colored = { workspace = true }
 derive-new = { workspace = true }

--- a/burn-book/src/basic-workflow/README.md
+++ b/burn-book/src/basic-workflow/README.md
@@ -14,7 +14,7 @@ automatically add the missing imports as you add the code snippets to your code.
 Be sure to checkout the git branch corresponding to the version of Burn you are using to follow
 this guide.
 
-The current version of Burn is `0.15` and the corresponding branch to checkout is `main`.
+The current version of Burn is `0.14` and the corresponding branch to checkout is `main`.
 </div>
 
 The code for this demo can be executed from Burn's base directory using the command:

--- a/burn-book/src/basic-workflow/model.md
+++ b/burn-book/src/basic-workflow/model.md
@@ -20,7 +20,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-burn = { version = "0.15.0", features = ["train", "wgpu", "vision"] }
+burn = { version = "0.14.0", features = ["train", "wgpu", "vision"] }
 ```
 
 Our goal will be to create a basic convolutional neural network used for image classification. We

--- a/crates/burn-autodiff/Cargo.toml
+++ b/crates/burn-autodiff/Cargo.toml
@@ -17,15 +17,15 @@ std = []
 async = [] # Require std
 
 [dependencies]
-burn-common = { path = "../burn-common", version = "0.15.0" }
-burn-tensor = { path = "../burn-tensor", version = "0.15.0", default-features = false }
-burn-tensor-testgen = { path = "../burn-tensor-testgen", version = "0.15.0", optional = true }
+burn-common = { path = "../burn-common", version = "0.14.0" }
+burn-tensor = { path = "../burn-tensor", version = "0.14.0", default-features = false }
+burn-tensor-testgen = { path = "../burn-tensor-testgen", version = "0.14.0", optional = true }
 
 derive-new = { workspace = true }
 spin = { workspace = true }
 log = { workspace = true }
 
 [dev-dependencies]
-burn-tensor = { path = "../burn-tensor", version = "0.15.0", default-features = false, features = [
+burn-tensor = { path = "../burn-tensor", version = "0.14.0", default-features = false, features = [
   "export_tests",
 ] }

--- a/crates/burn-candle/Cargo.toml
+++ b/crates/burn-candle/Cargo.toml
@@ -21,17 +21,17 @@ accelerate = ["candle-core/accelerate"]
 
 [dependencies]
 derive-new = { workspace = true }
-burn-tensor = { path = "../burn-tensor", version = "0.15.0", default-features = false }
+burn-tensor = { path = "../burn-tensor", version = "0.14.0", default-features = false }
 half = { workspace = true }
 candle-core = { workspace = true }
 
 [dev-dependencies]
-burn-autodiff = { path = "../burn-autodiff", version = "0.15.0", default-features = false, features = [
+burn-autodiff = { path = "../burn-autodiff", version = "0.14.0", default-features = false, features = [
     "export_tests",
 ] }
-burn-tch = { path = "../burn-tch", version = "0.15.0", default-features = false, features = [
+burn-tch = { path = "../burn-tch", version = "0.14.0", default-features = false, features = [
 ] }
-burn-tensor = { path = "../burn-tensor", version = "0.15.0", default-features = false, features = [
+burn-tensor = { path = "../burn-tensor", version = "0.14.0", default-features = false, features = [
     "export_tests",
 ] }
 

--- a/crates/burn-compute/Cargo.toml
+++ b/crates/burn-compute/Cargo.toml
@@ -34,7 +34,7 @@ autotune-persistent-cache = [
 ] # Assume std
 
 [dependencies]
-burn-common = { path = "../burn-common", version = "0.15.0", default-features = false }
+burn-common = { path = "../burn-common", version = "0.14.0", default-features = false }
 derive-new = { workspace = true }
 spin = { workspace = true }
 log = { workspace = true }

--- a/crates/burn-core/Cargo.toml
+++ b/crates/burn-core/Cargo.toml
@@ -99,17 +99,17 @@ test-wgpu = ["wgpu"] # To use wgpu during testing, default uses ndarray.
 
 # ** Please make sure all dependencies support no_std when std is disabled **
 
-burn-common = { path = "../burn-common", version = "0.15.0", default-features = false }
-burn-dataset = { path = "../burn-dataset", version = "0.15.0", optional = true, default-features = false }
-burn-derive = { path = "../burn-derive", version = "0.15.0" }
-burn-tensor = { path = "../burn-tensor", version = "0.15.0", default-features = false }
+burn-common = { path = "../burn-common", version = "0.14.0", default-features = false }
+burn-dataset = { path = "../burn-dataset", version = "0.14.0", optional = true, default-features = false }
+burn-derive = { path = "../burn-derive", version = "0.14.0" }
+burn-tensor = { path = "../burn-tensor", version = "0.14.0", default-features = false }
 
 # Backends
-burn-ndarray = { path = "../burn-ndarray", version = "0.15.0", optional = true, default-features = false }
-burn-wgpu = { path = "../burn-wgpu", version = "0.15.0", optional = true, default-features = false }
-burn-autodiff = { path = "../burn-autodiff", version = "0.15.0", optional = true }
-burn-tch = { path = "../burn-tch", version = "0.15.0", optional = true }
-burn-candle = { path = "../burn-candle", version = "0.15.0", optional = true }
+burn-ndarray = { path = "../burn-ndarray", version = "0.14.0", optional = true, default-features = false }
+burn-wgpu = { path = "../burn-wgpu", version = "0.14.0", optional = true, default-features = false }
+burn-autodiff = { path = "../burn-autodiff", version = "0.14.0", optional = true }
+burn-tch = { path = "../burn-tch", version = "0.14.0", optional = true }
+burn-candle = { path = "../burn-candle", version = "0.14.0", optional = true }
 
 derive-new = { workspace = true }
 log = { workspace = true, optional = true }
@@ -135,12 +135,12 @@ num-traits = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-burn-dataset = { path = "../burn-dataset", version = "0.15.0", features = [
+burn-dataset = { path = "../burn-dataset", version = "0.14.0", features = [
     "fake",
 ] }
 
-burn-ndarray = { path = "../burn-ndarray", version = "0.15.0", default-features = false }
-burn-autodiff = { path = "../burn-autodiff", version = "0.15.0" }
+burn-ndarray = { path = "../burn-ndarray", version = "0.14.0", default-features = false }
+burn-autodiff = { path = "../burn-autodiff", version = "0.14.0" }
 
 [package.metadata.docs.rs]
 features = ["doc"]

--- a/crates/burn-cube/Cargo.toml
+++ b/crates/burn-cube/Cargo.toml
@@ -20,13 +20,13 @@ template = []
 tensor = ["burn-tensor"]
 
 [dependencies]
-burn-compute = { path = "../burn-compute", version = "0.15.0", default-features = false }
-burn-tensor = { path = "../burn-tensor", version = "0.15.0", default-features = false, optional = true }
+burn-compute = { path = "../burn-compute", version = "0.14.0", default-features = false }
+burn-tensor = { path = "../burn-tensor", version = "0.14.0", default-features = false, optional = true }
 
 bytemuck = { workspace = true }
 half = { workspace = true, features = ["bytemuck"] }
 serde = { workspace = true }
-burn-cube-macros = { path = "../burn-cube-macros", version = "0.15.0" }
+burn-cube-macros = { path = "../burn-cube-macros", version = "0.14.0" }
 derive-new = { workspace = true }
 
 log = { workspace = true }

--- a/crates/burn-cuda/Cargo.toml
+++ b/crates/burn-cuda/Cargo.toml
@@ -18,12 +18,12 @@ doc = ["burn-jit/doc"]
 std = ["burn-jit/std"]
 
 [dependencies]
-burn-jit = { path = "../burn-jit", version = "0.15.0", default-features = false }
-burn-compute = { path = "../burn-compute", version = "0.15.0" }
-burn-tensor = { path = "../burn-tensor", version = "0.15.0" }
-burn-common = { path = "../burn-common", version = "0.15.0" }
-burn-cube = { path = "../burn-cube", version = "0.15.0" }
-burn-fusion = { path = "../burn-fusion", version = "0.15.0", optional = true }
+burn-jit = { path = "../burn-jit", version = "0.14.0", default-features = false }
+burn-compute = { path = "../burn-compute", version = "0.14.0" }
+burn-tensor = { path = "../burn-tensor", version = "0.14.0" }
+burn-common = { path = "../burn-common", version = "0.14.0" }
+burn-cube = { path = "../burn-cube", version = "0.14.0" }
+burn-fusion = { path = "../burn-fusion", version = "0.14.0", optional = true }
 
 half = { workspace = true }
 bytemuck = { workspace = true }
@@ -33,7 +33,7 @@ log = { workspace = true }
 derive-new = { workspace = true }
 
 [dev-dependencies]
-burn-jit = { path = "../burn-jit", version = "0.15.0", default-features = false, features = [
+burn-jit = { path = "../burn-jit", version = "0.14.0", default-features = false, features = [
   "export_tests",
 ] }
 

--- a/crates/burn-dataset/Cargo.toml
+++ b/crates/burn-dataset/Cargo.toml
@@ -33,7 +33,7 @@ __sqlite-shared = [
 ]
 
 [dependencies]
-burn-common = { path = "../burn-common", version = "0.15.0", optional = true, features = [
+burn-common = { path = "../burn-common", version = "0.14.0", optional = true, features = [
   "network",
 ] }
 csv = { workspace = true }

--- a/crates/burn-fusion/Cargo.toml
+++ b/crates/burn-fusion/Cargo.toml
@@ -16,8 +16,8 @@ std = ["serde/std"]
 doc = ["default"]
 
 [dependencies]
-burn-tensor = { path = "../burn-tensor", version = "0.15.0" }
-burn-common = { path = "../burn-common", version = "0.15.0" }
+burn-tensor = { path = "../burn-tensor", version = "0.14.0" }
+burn-common = { path = "../burn-common", version = "0.14.0" }
 hashbrown = { workspace = true }
 derive-new = {workspace = true }
 spin = { workspace = true }

--- a/crates/burn-import/Cargo.toml
+++ b/crates/burn-import/Cargo.toml
@@ -19,7 +19,7 @@ onnx = []
 pytorch = ["burn/record-item-custom-serde", "thiserror", "zip"]
 
 [dependencies]
-burn = { path = "../burn", version = "0.15.0", features = ["ndarray"] }
+burn = { path = "../burn", version = "0.14.0", features = ["ndarray"] }
 
 bytemuck = { workspace = true }
 candle-core = { workspace = true }

--- a/crates/burn-jit/Cargo.toml
+++ b/crates/burn-jit/Cargo.toml
@@ -27,10 +27,10 @@ export_tests = [
 ]
 
 [dependencies]
-burn-common = { path = "../burn-common", version = "0.15.0" }
-burn-tensor = { path = "../burn-tensor", version = "0.15.0" }
-burn-cube = { path = "../burn-cube", version = "0.15.0" }
-burn-fusion = { path = "../burn-fusion", version = "0.15.0", optional = true }
+burn-common = { path = "../burn-common", version = "0.14.0" }
+burn-tensor = { path = "../burn-tensor", version = "0.14.0" }
+burn-cube = { path = "../burn-cube", version = "0.14.0" }
+burn-fusion = { path = "../burn-fusion", version = "0.14.0", optional = true }
 
 bytemuck = { workspace = true }
 derive-new = { workspace = true }
@@ -45,16 +45,16 @@ serde = { workspace = true }
 text_placeholder = { workspace = true, features = ["struct_context"] }
 
 hashbrown = { workspace = true }
-burn-compute = { path = "../burn-compute", version = "0.15.0", default-features = false, features = [
+burn-compute = { path = "../burn-compute", version = "0.14.0", default-features = false, features = [
   "channel-mutex",
   "std",
 ] }
-burn-tensor-testgen = { path = "../burn-tensor-testgen", version = "0.15.0", optional = true }
+burn-tensor-testgen = { path = "../burn-tensor-testgen", version = "0.14.0", optional = true }
 
 # When exporting tests
 serial_test = { workspace = true, optional = true }
-burn-autodiff = { path = "../burn-autodiff", version = "0.15.0", default-features = false, optional = true }
-burn-ndarray = { path = "../burn-ndarray", version = "0.15.0", optional = true }
+burn-autodiff = { path = "../burn-autodiff", version = "0.14.0", default-features = false, optional = true }
+burn-ndarray = { path = "../burn-ndarray", version = "0.14.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["doc"]

--- a/crates/burn-ndarray/Cargo.toml
+++ b/crates/burn-ndarray/Cargo.toml
@@ -42,9 +42,9 @@ blas-openblas-system = [
 
 # ** Please make sure all dependencies support no_std when std is disabled **
 
-burn-autodiff = { path = "../burn-autodiff", version = "0.15.0", optional = true }
-burn-common = { path = "../burn-common", version = "0.15.0", default-features = false }
-burn-tensor = { path = "../burn-tensor", version = "0.15.0", default-features = false }
+burn-autodiff = { path = "../burn-autodiff", version = "0.14.0", optional = true }
+burn-common = { path = "../burn-common", version = "0.14.0", default-features = false }
+burn-tensor = { path = "../burn-tensor", version = "0.14.0", default-features = false }
 
 matrixmultiply = { workspace = true, default-features = false }
 rayon = { workspace = true, optional = true }
@@ -58,10 +58,10 @@ rand = { workspace = true }
 spin = { workspace = true }                                                # using in place of use std::sync::Mutex;
 
 [dev-dependencies]
-burn-autodiff = { path = "../burn-autodiff", version = "0.15.0", default-features = false, features = [
+burn-autodiff = { path = "../burn-autodiff", version = "0.14.0", default-features = false, features = [
     "export_tests",
 ] }
-burn-tensor = { path = "../burn-tensor", version = "0.15.0", default-features = false, features = [
+burn-tensor = { path = "../burn-tensor", version = "0.14.0", default-features = false, features = [
     "export_tests",
 ] }
 

--- a/crates/burn-no-std-tests/Cargo.toml
+++ b/crates/burn-no-std-tests/Cargo.toml
@@ -14,7 +14,7 @@ version.workspace = true
 
 # ** Please make sure all dependencies support no_std **
 
-burn = { path = "../burn", version = "0.15.0", default-features = false }
-burn-ndarray = { path = "../burn-ndarray", version = "0.15.0", default-features = false }
+burn = { path = "../burn", version = "0.14.0", default-features = false }
+burn-ndarray = { path = "../burn-ndarray", version = "0.14.0", default-features = false }
 
 serde = { workspace = true }

--- a/crates/burn-tch/Cargo.toml
+++ b/crates/burn-tch/Cargo.toml
@@ -15,7 +15,7 @@ default = []
 doc = ["tch/doc-only"]
 
 [dependencies]
-burn-tensor = { path = "../burn-tensor", version = "0.15.0" }
+burn-tensor = { path = "../burn-tensor", version = "0.14.0" }
 
 half = { workspace = true, features = ["std"] }
 libc = { workspace = true }
@@ -23,10 +23,10 @@ rand = { workspace = true, features = ["std"] }
 tch = { workspace = true, features = ["download-libtorch"] }
 
 [dev-dependencies]
-burn-autodiff = { path = "../burn-autodiff", version = "0.15.0", default-features = false, features = [
+burn-autodiff = { path = "../burn-autodiff", version = "0.14.0", default-features = false, features = [
   "export_tests",
 ] }
-burn-tensor = { path = "../burn-tensor", version = "0.15.0", default-features = false, features = [
+burn-tensor = { path = "../burn-tensor", version = "0.14.0", default-features = false, features = [
   "export_tests",
 ] }
 

--- a/crates/burn-tensor/Cargo.toml
+++ b/crates/burn-tensor/Cargo.toml
@@ -20,8 +20,8 @@ repr = []
 wasm-sync = []
 
 [dependencies]
-burn-common = { path = "../burn-common", version = "0.15.0", default-features = false }
-burn-tensor-testgen = { path = "../burn-tensor-testgen", version = "0.15.0", optional = true }
+burn-common = { path = "../burn-common", version = "0.14.0", default-features = false }
+burn-tensor-testgen = { path = "../burn-tensor-testgen", version = "0.14.0", optional = true }
 
 derive-new = { workspace = true }
 half = { workspace = true }

--- a/crates/burn-tensor/src/tensor/data.rs
+++ b/crates/burn-tensor/src/tensor/data.rs
@@ -1,3 +1,5 @@
+use core::any::{Any, TypeId};
+
 use alloc::format;
 use alloc::string::String;
 use alloc::vec::Vec;
@@ -174,6 +176,12 @@ impl<const D: usize, E: Element> Data<E, D> {
 impl<E: Element> DataSerialize<E> {
     /// Converts the data to a different element type.
     pub fn convert<EOther: Element>(self) -> DataSerialize<EOther> {
+        if TypeId::of::<E>() == TypeId::of::<EOther>() {
+            let cast: Box<dyn Any> = Box::new(self);
+            let cast: Box<DataSerialize<EOther>> = cast.downcast().unwrap();
+            return *cast;
+        }
+
         let value: Vec<EOther> = self.value.into_iter().map(|a| a.elem()).collect();
 
         DataSerialize {

--- a/crates/burn-tensor/src/tensor/data.rs
+++ b/crates/burn-tensor/src/tensor/data.rs
@@ -1,5 +1,6 @@
 use core::any::{Any, TypeId};
 
+use alloc::boxed::Box;
 use alloc::format;
 use alloc::string::String;
 use alloc::vec::Vec;

--- a/crates/burn-train/Cargo.toml
+++ b/crates/burn-train/Cargo.toml
@@ -17,7 +17,7 @@ metrics = ["nvml-wrapper", "sysinfo", "systemstat"]
 tui = ["ratatui", "crossterm"]
 
 [dependencies]
-burn-core = { path = "../burn-core", version = "0.15.0", features = ["dataset"] }
+burn-core = { path = "../burn-core", version = "0.14.0", features = ["dataset"] }
 
 log = { workspace = true }
 tracing-subscriber = { workspace = true }
@@ -38,7 +38,7 @@ derive-new = { workspace = true }
 serde = { workspace = true, features = ["std", "derive"] }
 
 [dev-dependencies]
-burn-ndarray = { path = "../burn-ndarray", version = "0.15.0" }
+burn-ndarray = { path = "../burn-ndarray", version = "0.14.0" }
 
 [package.metadata.docs.rs]
 features = ["doc"]

--- a/crates/burn-wgpu/Cargo.toml
+++ b/crates/burn-wgpu/Cargo.toml
@@ -19,12 +19,12 @@ doc = ["burn-jit/doc"]
 std = ["burn-jit/std"]
 
 [dependencies]
-burn-jit = { path = "../burn-jit", version = "0.15.0", default-features = false }
-burn-compute = { path = "../burn-compute", version = "0.15.0" }
-burn-tensor = { path = "../burn-tensor", version = "0.15.0" }
-burn-common = { path = "../burn-common", version = "0.15.0" }
-burn-fusion = { path = "../burn-fusion", version = "0.15.0", optional = true }
-burn-cube = { path = "../burn-cube", version = "0.15.0" }
+burn-jit = { path = "../burn-jit", version = "0.14.0", default-features = false }
+burn-compute = { path = "../burn-compute", version = "0.14.0" }
+burn-tensor = { path = "../burn-tensor", version = "0.14.0" }
+burn-common = { path = "../burn-common", version = "0.14.0" }
+burn-fusion = { path = "../burn-fusion", version = "0.14.0", optional = true }
+burn-cube = { path = "../burn-cube", version = "0.14.0" }
 
 bytemuck = { workspace = true }
 wgpu = { workspace = true, features = ["fragile-send-sync-non-atomic-wasm"] }
@@ -36,6 +36,6 @@ derive-new = { workspace = true }
 hashbrown = { workspace = true }
 
 [dev-dependencies]
-burn-jit = { path = "../burn-jit", version = "0.15.0", default-features = false, features = [
+burn-jit = { path = "../burn-jit", version = "0.14.0", default-features = false, features = [
   "export_tests",
 ] }

--- a/crates/burn/Cargo.toml
+++ b/crates/burn/Cargo.toml
@@ -68,8 +68,8 @@ record-item-custom-serde = ["burn-core/record-item-custom-serde"]
 
 # ** Please make sure all dependencies support no_std when std is disabled **
 
-burn-core = { path = "../burn-core", version = "0.15.0", default-features = false }
-burn-train = { path = "../burn-train", version = "0.15.0", optional = true, default-features = false }
+burn-core = { path = "../burn-core", version = "0.14.0", default-features = false }
+burn-train = { path = "../burn-train", version = "0.14.0", optional = true, default-features = false }
 
 [package.metadata.docs.rs]
 features = ["doc"]

--- a/examples/image-classification-web/Cargo.toml
+++ b/examples/image-classification-web/Cargo.toml
@@ -14,11 +14,11 @@ default = []
 half_precision = []
 
 [dependencies]
-burn = { path = "../../crates/burn", version = "0.15.0", default-features = false, features = [
+burn = { path = "../../crates/burn", version = "0.14.0", default-features = false, features = [
     "ndarray",
 ] }
-burn-wgpu = { path = "../../crates/burn-wgpu", version = "0.15.0", default-features = false }
-burn-candle = { path = "../../crates/burn-candle", version = "0.15.0", default-features = false }
+burn-wgpu = { path = "../../crates/burn-wgpu", version = "0.14.0", default-features = false }
+burn-candle = { path = "../../crates/burn-candle", version = "0.14.0", default-features = false }
 
 js-sys = { workspace = true }
 log = { workspace = true }

--- a/examples/pytorch-import/Cargo.toml
+++ b/examples/pytorch-import/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 name = "pytorch-import"
 publish = false
-version = "0.15.0"
+version = "0.14.0"
 
 [dependencies]
 burn = { path = "../../crates/burn", features = [


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.

### Related Issues/PRs

Improve record loading speed for [llama-burn](https://github.com/tracel-ai/models/pull/35)

### Changes

- Check origin and destination element type and skip conversion for same type element
- Reverted version to 0.14.0 (erroneously bumped twice since last release)
