### PR TITLE
Cube: cleaner use of topology values

### DIFF
--- a/crates/burn-cube-macros/src/analysis.rs
+++ b/crates/burn-cube-macros/src/analysis.rs
@@ -4,6 +4,8 @@ use syn::{PathArguments, Stmt};
 
 use crate::VariableKey;
 
+pub const KEYWORDS: [&str; 1] = ["ABSOLUTE_INDEX"];
+
 #[derive(Debug)]
 /// Information about a single variable's use in Cube code
 /// Information about a single variable's use in Cube code
@@ -200,8 +202,10 @@ impl CodeAnalysisBuilder {
                     .get_ident()
                     .expect("Analysis: only ident path are supported.");
 
-                // Use
-                self.var_uses.push(ident.into());
+                if !KEYWORDS.contains(&ident.to_string().as_str()) {
+                    // Use
+                    self.var_uses.push(ident.into());
+                }
             }
             syn::Expr::Binary(expr) => {
                 self.find_occurrences_in_expr(&expr.left, depth);

--- a/crates/burn-cube-macros/src/codegen/variable.rs
+++ b/crates/burn-cube-macros/src/codegen/variable.rs
@@ -2,7 +2,10 @@ use proc_macro2::TokenStream;
 use quote::ToTokens;
 use syn::Lit;
 
-use crate::{analysis::CodeAnalysis, codegen::base::codegen_expr};
+use crate::{
+    analysis::{CodeAnalysis, KEYWORDS},
+    codegen::base::codegen_expr,
+};
 
 /// Codegen for literals
 pub(crate) fn codegen_lit(lit: &syn::ExprLit) -> TokenStream {
@@ -140,15 +143,21 @@ pub(crate) fn codegen_path_rhs(
         .get_ident()
         .expect("Codegen: Only ident path are supported.");
 
-    let will_be_used_again = variable_analyses.should_clone(ident, loop_level);
-
-    if will_be_used_again {
+    if KEYWORDS.contains(&ident.to_string().as_str()) {
         quote::quote! {
-            #ident.clone()
+            #ident :: expand(context)
         }
     } else {
-        quote::quote! {
-            #ident
+        let will_be_used_again = variable_analyses.should_clone(ident, loop_level);
+
+        if will_be_used_again {
+            quote::quote! {
+                #ident.clone()
+            }
+        } else {
+            quote::quote! {
+                #ident
+            }
         }
     }
 }

--- a/crates/burn-cube/src/language/element/uint.rs
+++ b/crates/burn-cube/src/language/element/uint.rs
@@ -49,7 +49,7 @@ impl<R: Runtime> ArgSettings<R> for u32 {
 impl Numeric for UInt {}
 
 impl UInt {
-    pub fn new(val: u32) -> Self {
+    pub const fn new(val: u32) -> Self {
         Self {
             val,
             vectorization: 1,

--- a/crates/burn-cube/src/language/topology.rs
+++ b/crates/burn-cube/src/language/topology.rs
@@ -1,20 +1,12 @@
-use crate::{unexpanded, CubeContext, CubeType, ExpandElement, UInt};
+use crate::UInt;
 
 /// The index of the working unit in the whole cube kernel, without regards to blocks.
-pub struct AbsoluteIndex {}
+pub const ABSOLUTE_INDEX: UInt = UInt::new(0u32);
 
-impl AbsoluteIndex {
-    /// Obtain the absolute index
-    pub fn get() -> UInt {
-        unexpanded!();
-    }
-
-    /// Obtain the absolute index
-    pub fn get_expand(_context: &mut CubeContext) -> ExpandElement {
+#[allow(non_snake_case)]
+pub mod ABSOLUTE_INDEX {
+    use crate::{CubeContext, ExpandElement};
+    pub fn expand(_context: &mut CubeContext) -> ExpandElement {
         ExpandElement::Plain(crate::dialect::Variable::Id)
     }
-}
-
-impl CubeType for AbsoluteIndex {
-    type ExpandType = ExpandElement;
 }

--- a/crates/burn-cube/src/language/topology.rs
+++ b/crates/burn-cube/src/language/topology.rs
@@ -1,11 +1,16 @@
 use crate::UInt;
 
+/// In this file we use a trick where the constant has the same name as the module containing
+/// the expand function, so that a user implicitly imports the expand function when importing the constant.
+
 /// The index of the working unit in the whole cube kernel, without regards to blocks.
 pub const ABSOLUTE_INDEX: UInt = UInt::new(0u32);
 
 #[allow(non_snake_case)]
 pub mod ABSOLUTE_INDEX {
     use crate::{CubeContext, ExpandElement};
+
+    /// Expanded version of ABSOLUTE_INDEX
     pub fn expand(_context: &mut CubeContext) -> ExpandElement {
         ExpandElement::Plain(crate::dialect::Variable::Id)
     }

--- a/crates/burn-cube/tests/language/mod.rs
+++ b/crates/burn-cube/tests/language/mod.rs
@@ -12,5 +12,6 @@ mod ops;
 mod parenthesis;
 mod reuse;
 mod tensor;
+mod topology;
 mod r#trait;
 mod vectorization;

--- a/crates/burn-cube/tests/language/topology.rs
+++ b/crates/burn-cube/tests/language/topology.rs
@@ -1,0 +1,48 @@
+use burn_cube::{cube, Numeric, Tensor, UInt, ABSOLUTE_INDEX};
+
+#[cube]
+fn topology_kernel<T: Numeric>(input: Tensor<T>) {
+    let id = ABSOLUTE_INDEX + UInt::new(4u32);
+    let _ = input[id];
+}
+
+mod tests {
+    use super::*;
+    use burn_cube::{
+        cpa,
+        dialect::{Item, Variable},
+        CubeContext, CubeElem, UInt, F32,
+    };
+
+    type ElemType = F32;
+
+    #[test]
+    fn cube_support_topology() {
+        let mut context = CubeContext::root();
+        let input = context.input(0, Item::new(ElemType::as_elem()));
+
+        topology_kernel_expand::<ElemType>(&mut context, input);
+        assert_eq!(
+            format!("{:?}", context.into_scope().operations),
+            inline_macro_ref()
+        );
+    }
+
+    fn inline_macro_ref() -> String {
+        let mut context = CubeContext::root();
+        let item = Item::new(ElemType::as_elem());
+        let input = context.input(0, item);
+
+        let mut scope = context.into_scope();
+        let input: Variable = input.into();
+        let x = scope.create_local(Item::new(UInt::as_elem()));
+        let y = scope.create_local(Item::new(UInt::as_elem()));
+        let z = scope.create_local(Item::new(UInt::as_elem()));
+
+        cpa!(&mut scope, x = shape(input, 1u32));
+        cpa!(&mut scope, y = stride(input, 1u32));
+        cpa!(&mut scope, z = len(input));
+
+        format!("{:?}", scope.operations)
+    }
+}

--- a/crates/burn-cube/tests/language/topology.rs
+++ b/crates/burn-cube/tests/language/topology.rs
@@ -2,16 +2,16 @@ use burn_cube::{cube, Numeric, Tensor, UInt, ABSOLUTE_INDEX};
 
 #[cube]
 fn topology_kernel<T: Numeric>(input: Tensor<T>) {
-    let id = ABSOLUTE_INDEX + UInt::new(4u32);
-    let _ = input[id];
+    let x = ABSOLUTE_INDEX + UInt::new(4);
+    let _ = input[x];
 }
 
 mod tests {
     use super::*;
     use burn_cube::{
         cpa,
-        dialect::{Item, Variable},
-        CubeContext, CubeElem, UInt, F32,
+        dialect::{Elem, Item, Variable},
+        CubeContext, CubeElem, F32,
     };
 
     type ElemType = F32;
@@ -35,13 +35,12 @@ mod tests {
 
         let mut scope = context.into_scope();
         let input: Variable = input.into();
-        let x = scope.create_local(Item::new(UInt::as_elem()));
-        let y = scope.create_local(Item::new(UInt::as_elem()));
-        let z = scope.create_local(Item::new(UInt::as_elem()));
+        let x = scope.create_local(Item::new(Elem::UInt));
+        let y = scope.create_local(item);
 
-        cpa!(&mut scope, x = shape(input, 1u32));
-        cpa!(&mut scope, y = stride(input, 1u32));
-        cpa!(&mut scope, z = len(input));
+        let id = Variable::Id;
+        cpa!(&mut scope, x = id + 4u32);
+        cpa!(&mut scope, y = input[x]);
 
         format!("{:?}", scope.operations)
     }

--- a/crates/burn-jit/src/kernel/conv/conv2d.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d.rs
@@ -31,7 +31,7 @@ fn kernel<F: Float>(
     kernel_size_0_unroll: Comptime<Option<UInt>>,
     kernel_size_1_unroll: Comptime<Option<UInt>>,
 ) {
-    if AbsoluteIndex::get() >= output.len() {
+    if ABSOLUTE_INDEX >= output.len() {
         return;
     }
 
@@ -42,10 +42,10 @@ fn kernel<F: Float>(
     let kernel_size_1 = Comptime::unwrap_or_else(kernel_size_1_unroll, || weight.shape(3));
     let unroll_1 = Comptime::is_some(kernel_size_1_unroll);
 
-    let b = AbsoluteIndex::get() / output.stride(0) % output.shape(0);
-    let oc = AbsoluteIndex::get() / output.stride(1) % output.shape(1);
-    let oh = AbsoluteIndex::get() / output.stride(2) % output.shape(2);
-    let ow = AbsoluteIndex::get() / output.stride(3) % output.shape(3);
+    let b = ABSOLUTE_INDEX / output.stride(0) % output.shape(0);
+    let oc = ABSOLUTE_INDEX / output.stride(1) % output.shape(1);
+    let oh = ABSOLUTE_INDEX / output.stride(2) % output.shape(2);
+    let ow = ABSOLUTE_INDEX / output.stride(3) % output.shape(3);
 
     let g = (weight.shape(0) + oc) % groups;
     let ic_start = in_channels * g;
@@ -107,7 +107,7 @@ fn kernel<F: Float>(
         }
     }
 
-    output[AbsoluteIndex::get()] = sum;
+    output[ABSOLUTE_INDEX] = sum;
 }
 
 pub(crate) fn conv2d<R: JitRuntime, E: FloatElement>(


### PR DESCRIPTION
Replaces `AbsoluteIndex::get()` by `ABSOLUTE_INDEX`

For correct expansion of `ABSOLUTE_INDEX`, this token has to be registered as a special keyword in the parser. Also we use a trick for imports: there are both a const and a mod with this name, so importing the const implicitly imports the mod, in which the expand function lies. 