### PR TITLE
Remainder operator doc

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -228,6 +228,7 @@ Those operations are available for numeric tensor kinds: `Float` and `Int`.
 | `tensor.powf_scalar(scalar)` or `tensor.powi_scalar(intscalar)` | `tensor.pow(scalar)`                           |
 | `tensor.prod()`                                                 | `tensor.prod()`                                |
 | `tensor.prod_dim(dim)`                                          | `tensor.prod(dim, keepdim=True)`               |
+| `tensor.rem(other)` or `tensor % other`                         | `tensor % other`                               |
 | `tensor.scatter(dim, indices, values)`                          | `tensor.scatter_add(dim, indices, values)`     |
 | `tensor.select(dim, indices)`                                   | `tensor.index_select(dim, indices)`            |
 | `tensor.select_assign(dim, indices, values)`                    | N/A                                            |

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -2868,6 +2868,20 @@ where
     }
 }
 
+impl<E, const D: usize, B, K> core::ops::Rem<E> for Tensor<B, D, K>
+where
+    E: ElementConversion,
+    B: Backend,
+    K: Numeric<B>,
+    K::Elem: Element,
+{
+    type Output = Self;
+
+    fn rem(self, other: E) -> Self {
+        Tensor::remainder_scalar(self, other)
+    }
+}
+
 impl<B, const D: usize, K> core::ops::Mul<Tensor<B, D, K>> for Tensor<B, D, K>
 where
     B: Backend,

--- a/crates/burn-tensor/src/tests/ops/remainder.rs
+++ b/crates/burn-tensor/src/tests/ops/remainder.rs
@@ -95,4 +95,17 @@ mod tests {
         let data_expected = Data::from([9.0, 1.0]);
         data_expected.assert_approx_eq(&data_actual, 3);
     }
+
+    #[test]
+    fn should_support_remainder_op() {
+        let data = Data::from([-3.0, -2.0, -1.0, 1.0, 2.0, 3.0]);
+        let device = Default::default();
+        let tensor = Tensor::<TestBackend, 1>::from_data(data, &device);
+
+        let output = tensor % 2.0;
+
+        let data_actual = output.into_data();
+        let data_expected = Data::from([1.0, 0.0, 1.0, 1.0, 0.0, 1.0]);
+        data_expected.assert_approx_eq(&data_actual, 3);
+    }
 }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Related PR: [1726](https://github.com/tracel-ai/burn/pull/1726)

### Changes

Problem: The tensor.remainder_scalar() method has been implemented in a previous PR. However, its not possible to use the % operator, e.g., tensor % 2.0.
Changes: Added ops::Rem trait implementation for Tensor.

### Testing

Added a test for Tensor that makes use of the % operator.