### PR TITLE
LearnerBuilder "with_checkpointing_strategy" should use builder pattern

### DIFF
--- a/crates/burn-train/src/learner/builder.rs
+++ b/crates/burn-train/src/learner/builder.rs
@@ -124,11 +124,12 @@ where
     }
 
     /// Update the checkpointing_strategy.
-    pub fn with_checkpointing_strategy<CS>(&mut self, strategy: CS)
+    pub fn with_checkpointing_strategy<CS>(mut self, strategy: CS) -> Self
     where
         CS: CheckpointingStrategy + 'static,
     {
         self.checkpointer_strategy = Box::new(strategy);
+        self
     }
 
     /// Replace the default CLI renderer with a custom one.


### PR DESCRIPTION
I noticed that the method "with_checkpointing_strategy" from LearnerBuilder does not use the builder pattern like all the other methods of the class.

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Changes

Changed the method "with_checkpointing_strategy" to the builder pattern so that the methods from LearnerBuilder are consistent.