### PR TITLE
Import alt design

### DIFF
--- a/crates/burn-import/src/onnx/coalesce.rs
+++ b/crates/burn-import/src/onnx/coalesce.rs
@@ -6,7 +6,7 @@ use super::{
     proto_conversion::convert_node_proto,
     protos::NodeProto,
 };
-use crate::{burn::graph, onnx::ir::{ArgType, Data, TensorType}};
+use crate::onnx::ir::{ArgType, Data, TensorType};
 
 /// The function transforms the graph into a new one where the nodes are coalesced into a single node.
 pub fn coalesce(
@@ -50,7 +50,7 @@ pub(crate) fn convert_gemm_to_linear(node: &mut Node, graph_io: &GraphData) {
         node.attrs.remove("transB");
 
         // Transpose the weights
-        transpose_linear_node_weights(node,graph_io);
+        transpose_linear_node_weights(node, graph_io);
     } else {
         panic!("Full Gemm node not supported yet.");
     }

--- a/crates/burn-import/src/onnx/coalesce.rs
+++ b/crates/burn-import/src/onnx/coalesce.rs
@@ -143,6 +143,7 @@ pub(crate) fn convert_matmul_to_linear(
     // Convert the node to Linear
     node.node_type = NodeType::Linear;
 
+    log::debug!("peeking next node for bias conversion");
     // Check the next node for potential conversion
     if let Some(peek_node) = iter_mut.peek() {
         let peek_node = convert_node_proto(peek_node, graph_data);

--- a/crates/burn-import/src/onnx/coalesce.rs
+++ b/crates/burn-import/src/onnx/coalesce.rs
@@ -122,7 +122,7 @@ fn transpose_flattened<T: Copy>(matrix: Vec<T>, rows: usize, cols: usize) -> Vec
 pub(crate) fn convert_matmul_to_linear(
     node: &mut Node,
     iter_mut: &mut Peekable<Iter<NodeProto>>,
-    graph_io: &GraphData,
+    graph_data: &GraphData,
 ) {
     if node.inputs.len() != 2 {
         panic!("MatMul node must have 2 inputs");
@@ -145,7 +145,7 @@ pub(crate) fn convert_matmul_to_linear(
 
     // Check the next node for potential conversion
     if let Some(peek_node) = iter_mut.peek() {
-        let peek_node = convert_node_proto(peek_node, graph_io).clone();
+        let peek_node = convert_node_proto(peek_node, graph_data);
         if is_add_node_with_bias(&peek_node, node) {
             convert_and_remove_add_node(&peek_node, node);
 

--- a/crates/burn-import/src/onnx/coalesce.rs
+++ b/crates/burn-import/src/onnx/coalesce.rs
@@ -15,7 +15,7 @@ pub fn coalesce(
     graph_data: &GraphData,
 ) {
     match node.node_type {
-        NodeType::Gemm => convert_gemm_to_linear(node, graph_data),
+        NodeType::Gemm => convert_gemm_to_linear(node),
         NodeType::MatMul => {
             convert_matmul_to_linear(node, nodes_iter, graph_data);
         }
@@ -26,7 +26,7 @@ pub fn coalesce(
 /// This function converts a Gemm node into a Linear node
 ///
 /// PyTorch and other frameworks use Gemm node to represent Linear layer.
-pub(crate) fn convert_gemm_to_linear(node: &mut Node, graph_io: &GraphData) {
+pub(crate) fn convert_gemm_to_linear(node: &mut Node) {
     if node.outputs.len() != 1 {
         panic!("Gemm node must have 1 output");
     }
@@ -50,14 +50,14 @@ pub(crate) fn convert_gemm_to_linear(node: &mut Node, graph_io: &GraphData) {
         node.attrs.remove("transB");
 
         // Transpose the weights
-        transpose_linear_node_weights(node, graph_io);
+        transpose_linear_node_weights(node);
     } else {
         panic!("Full Gemm node not supported yet.");
     }
 }
 
 // Transpose linear weights (required for Gemm -> Linear conversion)
-fn transpose_linear_node_weights(node: &mut Node, graph_data: &GraphData) {
+fn transpose_linear_node_weights(node: &mut Node) {
     assert!(
         node.inputs.len() > 1,
         "Linear node must have at least 2 input"

--- a/crates/burn-import/src/onnx/coalesce.rs
+++ b/crates/burn-import/src/onnx/coalesce.rs
@@ -65,8 +65,6 @@ fn transpose_linear_node_weights(node: &mut Node, graph_data: &GraphData) {
 
     assert!(node.inputs[1].value.is_some(), "Input must have a value");
 
-    assert!(graph_data.initializers.contains_key(&node.inputs[1].name), "Currently only initializers are supported for weights.\nPlease open an issue if you encounter this error.");
-
     let weight = node.inputs[1]
         .clone()
         .into_tensor()

--- a/crates/burn-import/src/onnx/dim_inference.rs
+++ b/crates/burn-import/src/onnx/dim_inference.rs
@@ -4,7 +4,6 @@ use core::panic;
 use protobuf::Enum;
 
 use super::{
-    from_onnx::GraphData,
     ir::{ArgType, AttributeValue, Data, ElementType, Node, NodeType, TensorType},
     op_configuration::flatten_config,
     protos::tensor_proto::DataType,

--- a/crates/burn-import/src/onnx/dim_inference.rs
+++ b/crates/burn-import/src/onnx/dim_inference.rs
@@ -11,7 +11,7 @@ use super::{
 };
 
 /// Infer the dimension of each output tensor and update them.
-pub fn dim_inference(node: &mut Node, graph_io: &mut GraphData) {
+pub fn dim_inference(node: &mut Node) {
     match node.node_type {
         NodeType::Add => same_as_input(node),
         NodeType::ArgMax => argmax_update_outputs(node),

--- a/crates/burn-import/src/onnx/dim_inference.rs
+++ b/crates/burn-import/src/onnx/dim_inference.rs
@@ -4,14 +4,14 @@ use core::panic;
 use protobuf::Enum;
 
 use super::{
-    from_onnx::OnnxGraphIO,
+    from_onnx::GraphData,
     ir::{ArgType, AttributeValue, Data, ElementType, Node, NodeType, TensorType},
     op_configuration::flatten_config,
     protos::tensor_proto::DataType,
 };
 
 /// Infer the dimension of each output tensor and update them.
-pub fn dim_inference(node: &mut Node, graph_io: &mut OnnxGraphIO) {
+pub fn dim_inference(node: &mut Node, graph_io: &mut GraphData) {
     match node.node_type {
         NodeType::Add => same_as_input(node),
         NodeType::ArgMax => argmax_update_outputs(node),
@@ -81,8 +81,6 @@ pub fn dim_inference(node: &mut Node, graph_io: &mut OnnxGraphIO) {
         // Intentionally letting outputs leave unchanged but issue a warning so IR file can be generated.
         _ => temporary_pass_through_stub(node),
     }
-
-    graph_io.update_tensor_output(node);
 }
 
 fn constant_update_outputs(node: &mut Node) {

--- a/crates/burn-import/src/onnx/from_onnx.rs
+++ b/crates/burn-import/src/onnx/from_onnx.rs
@@ -7,9 +7,7 @@ use std::{
 use crate::onnx::{node_remap::remap_node_type, proto_conversion::convert_node_proto};
 
 use super::{
-    coalesce::coalesce,
-    ir::{Data, OnnxGraph, TensorType},
-    protos::{ModelProto, NodeProto, TensorProto, ValueInfoProto},
+    coalesce::coalesce, ir::{Data, OnnxGraph, TensorType}, proto_conversion::convert_node_proto2, protos::{ModelProto, NodeProto, TensorProto, ValueInfoProto}
 };
 
 use super::dim_inference::dim_inference;
@@ -37,7 +35,110 @@ pub(crate) enum IOEntry {
     Node(usize),
 }
 
-pub(crate) struct OnnxGraphIO {
+#[derive(Debug, Clone)]
+pub(crate) enum IOEntry2 {
+    In(usize),
+    Node(usize, usize),
+}
+
+pub struct GraphData {
+    pub(crate) processed_nodes: Vec<Node>,
+    pub(crate) inputs: Vec<Argument>,
+    pub(crate) outputs: Vec<Argument>,
+    pub(crate) initializers: HashMap<String, Argument>,
+    pub(crate) input_name_map: HashMap<String, IOEntry2>,
+}
+
+impl GraphData {
+    pub(crate) fn new(inputs: &Vec<ValueInfoProto>,
+        outputs: &Vec<ValueInfoProto>,
+        initializers: &Vec<TensorProto>) -> Self {
+        let mut input_name_map = HashMap::new();
+        let mut in_count = 1;
+        
+        let constants = initializers
+            .iter()
+            .map(|x| (x.name.clone(), Argument::from_initializer(x)))
+            .collect::<HashMap<String, Argument>>();
+        let outputs = outputs
+            .iter()
+            .map(|x| {
+                Argument::try_from(x.clone()).unwrap()
+            })
+            .collect::<Vec<Argument>>();
+        let inputs = inputs
+            .iter()
+            .enumerate()
+            .map(|(i, x)| {
+                let in_name = format!("input{}", in_count);
+                input_name_map.insert(x.name.clone(), IOEntry2::In(i));
+                let mut arg = Argument::try_from(x.clone()).unwrap();
+                if let Some(initial_arg) = constants.get(&x.name) {
+                    if arg.value.is_none() {
+                        arg.copy_value(initial_arg);
+                    }
+                }
+
+                in_count += 1;
+                arg.name = in_name;
+                arg
+            })
+            .collect::<Vec<Argument>>();
+        Self {
+            inputs,
+            outputs,
+            initializers: constants,
+            processed_nodes: Vec::new(),
+            input_name_map,
+        }
+    }
+
+    pub fn init_in(&self, proto_str: &str) -> Argument {
+        match self.input_name_map.get(proto_str) {
+            None => {
+                //NOTE: if initializers are guaranteed to be unique, (I think they are
+                //need to confirm) then we could pop the initializer from the map
+                if let Some(init_arg) = self.initializers.get(proto_str) {
+                    init_arg.clone()
+                } else {
+                  panic!("where did input {:?} come from?", proto_str)  
+                }
+            }
+            Some(IOEntry2::In(i)) => self.inputs[*i].clone(),
+            Some(IOEntry2::Node(i, j)) => {
+                self.processed_nodes[*i].outputs[*j].clone()
+            }
+        }
+    }
+
+    ///This function does two things:
+    /// maps the old output names to the output location
+    /// and updates the output names
+    pub fn add_node(&mut self, mut node: Node) {
+        let mut out_count=1;
+        for output in node.outputs.iter_mut() {
+            self.input_name_map.insert(output.name.clone(), IOEntry2::Node(self.processed_nodes.len(), 0));
+            output.name = format!("{}_out{}", node.name, out_count);
+            out_count+=1;
+        }
+        self.processed_nodes.push(node);
+        
+    }
+
+    fn consume(mut self) -> (Vec<Node>, Vec<Argument>, Vec<Argument>) {
+        self.inputs.retain(|x| x.passed);
+        let outputs = self.outputs.into_iter().filter_map(|x| {
+            match self.input_name_map.get(&x.name) {
+                Some(IOEntry2::Node(_, _)) => Some(x),
+                _ => None
+            }
+        }).collect();
+        (self.processed_nodes, self.inputs, outputs)
+    }
+    
+}
+
+pub(crate) struct GraphIO {
     /// The inputs for the Graph
     pub(crate) inputs: Vec<Argument>,
     /// The outputs for the Graph
@@ -49,7 +150,9 @@ pub(crate) struct OnnxGraphIO {
     pub(crate) old_io_names: HashMap<String, IOEntry>,
 }
 
-impl OnnxGraphIO {
+
+
+impl GraphIO {
     pub(crate) fn new(
         inputs: &Vec<ValueInfoProto>,
         outputs: &Vec<ValueInfoProto>,
@@ -90,10 +193,7 @@ impl OnnxGraphIO {
             })
             .collect::<Vec<Argument>>();
 
-        let constants = initializers
-            .iter()
-            .map(|x| (x.name.clone(), Argument::from_initializer(x)))
-            .collect::<HashMap<String, Argument>>();
+        
 
         Self {
             inputs,
@@ -249,9 +349,11 @@ impl OnnxGraphIO {
 
 #[derive(Default)]
 pub(crate) struct OnnxGraphBuilder {
-    nodes: Vec<Node>,
-    inputs: Vec<Argument>,
-    outputs: Vec<Argument>,
+    processed_nodes: Vec<Node>,
+    // inputs: Vec<Argument>,
+    // outputs: Vec<Argument>,
+    // initializers: HashMap<String, Argument>,
+    //input_name_map: HashMap<String, IOEntry2>,
     /// Counter for node names, used for renaming nodes
     node_name_counter: HashMap<NodeType, usize>,
     /// Nodes to remove
@@ -264,55 +366,93 @@ pub(crate) struct OnnxGraphBuilder {
 }
 
 impl OnnxGraphBuilder {
-    pub(crate) fn node_gen(&mut self, model_proto: &ModelProto) {
+    pub(crate) fn node_gen(mut self, model_proto: &ModelProto) -> OnnxGraph {
         self.constants_types = LIFT_CONSTANTS_FOR_NODE_TYPES.into_iter().collect();
 
-        let mut graph_io = OnnxGraphIO::new(
+        // let mut graph_io = OnnxGraphIO::new(
+        //     &model_proto.graph.input,
+        //     &model_proto.graph.output,
+        //     &model_proto.graph.initializer,
+        // );
+
+        let mut graph_data = GraphData::new(
             &model_proto.graph.input,
             &model_proto.graph.output,
             &model_proto.graph.initializer,
         );
 
-        self.nodes = Vec::with_capacity(model_proto.graph.node.len());
+        self.processed_nodes = Vec::with_capacity(model_proto.graph.node.len());
         let mut and_idx = 0;
         let mut node_iter = model_proto.graph.node.iter().peekable();
 
         while let Some(node_proto) = node_iter.next() {
-            let mut node = convert_node_proto(node_proto, &graph_io);
+            let mut node = convert_node_proto2(node_proto, &graph_data);
 
             remap_node_type(&mut node);
 
-            coalesce(&mut node, &mut node_iter, &graph_io);
+            coalesce(&mut node, &mut node_iter, &graph_data);
             self.handle_node_renaming(&mut node);
+            // NOTE: start of stateful filter functions
+            // args : node, graph_io/data, and_idx
             self.handle_identity(&mut node, and_idx);
-            self.check_constants(&mut node, and_idx, &mut graph_io);
-            self.handle_unsqueeze(&mut node, &graph_io);
+            self.check_constants(&mut node, and_idx, &mut graph_data);
+            
 
-            dim_inference(&mut node, &mut graph_io);
+            self.handle_unsqueeze(&mut node, &graph_data);
 
-            rename_io(&mut node, &mut graph_io);
+            dim_inference(&mut node, &mut graph_data);
 
-            self.nodes.push(node);
+            //rename_io(&mut node, &mut graph_io);
+            graph_data.add_node(node);
+            //self.processed_nodes.push(node);
             and_idx += 1;
         }
 
         let mut i = 0;
-        self.nodes.retain(|_x| {
-            let res = !self.nodes_to_remove.contains(&i);
-            i += 1;
-            res
-        });
-        let OnnxGraphIO {
-            mut inputs,
-            mut outputs,
-            ..
-        } = graph_io;
-
+        
+        let (mut processed_nodes, inputs, outputs) = graph_data.consume();
         // Remove the graph inputs/output that are not used by any node
-        remove_unused_graph_inputs(&mut inputs, &mut outputs);
-        self.inputs = inputs;
-        self.outputs = outputs;
+        //remove_unused_graph_inputs(&mut inputs, &mut outputs);
+        processed_nodes.retain(|_| {let keep = !self.nodes_to_remove.contains(&i); i+=1; keep});
+        OnnxGraph {
+            nodes: processed_nodes,
+            inputs,
+            outputs,
+        }
     }
+
+    // fn init_graph_io(&mut self, inputs: &Vec<ValueInfoProto>, outputs: &Vec<ValueInfoProto>, initializers: &Vec<TensorProto>) -> GraphData {
+    //     let mut in_count = 1;
+        
+    //     let constants = initializers
+    //         .iter()
+    //         .map(|x| (x.name.clone(), Argument::from_initializer(x)))
+    //         .collect::<HashMap<String, Argument>>();
+    //     self.outputs = outputs
+    //         .iter()
+    //         .map(|x| {
+    //             Argument::try_from(x.clone()).unwrap()
+    //         })
+    //         .collect::<Vec<Argument>>();
+    //     self.inputs = inputs
+    //         .iter()
+    //         .enumerate()
+    //         .map(|(i, x)| {
+    //             let in_name = format!("input{}", in_count);
+    //             self.input_name_map.insert(x.name.clone(), IOEntry2::In(i));
+    //             let mut arg = Argument::try_from(x.clone()).unwrap();
+    //             if let Some(initial_arg) = constants.get(&x.name) {
+    //                 if arg.value.is_none() {
+    //                     arg.copy_value(initial_arg);
+    //                 }
+    //             }
+
+    //             in_count += 1;
+    //             arg.name = in_name;
+    //             arg
+    //         })
+    //         .collect::<Vec<Argument>>();
+    // }
 
     fn handle_node_renaming(&mut self, node: &mut Node) {
         log::debug!("renaming node {:?}", &node.name);
@@ -328,7 +468,7 @@ impl OnnxGraphBuilder {
         node.name.clone_from(&new_name);
     }
 
-    fn check_constants(&mut self, node: &mut Node, i: usize, _graph_io: &mut OnnxGraphIO) {
+    fn check_constants(&mut self, node: &mut Node, i: usize, _graph_io: &mut GraphData) {
         if node.node_type == NodeType::Constant
             || (node.node_type == NodeType::Identity && node.inputs[0].value.is_some())
         {
@@ -338,7 +478,7 @@ impl OnnxGraphBuilder {
             for input in node.inputs.iter_mut().skip(1) {
                 log::debug!("checking input {:?} for const", input);
                 if let Some(const_idx) = self.constants_map.get(&input.name) {
-                    let constant = &self.nodes[*const_idx];
+                    let constant = &self.processed_nodes[*const_idx];
                     log::debug!(
                         "input {} matched constant node {}",
                         &input.name,
@@ -362,14 +502,14 @@ impl OnnxGraphBuilder {
     /// Check if the unsqueeze node has a rhs value (rhs is constant) and if not remap it to a reshape
     /// Needs to be called after node renaming to ensure that the rhs name is correct
     /// Needs to be called after constant lifting to ensure that the rhs value exists
-    fn handle_unsqueeze(&mut self, node: &mut Node, graph_io: &OnnxGraphIO) {
+    fn handle_unsqueeze(&mut self, node: &mut Node, graph_io: &GraphData) {
         if node.node_type == NodeType::Unsqueeze
             && node.inputs.len() > 1
             && node.inputs[1].value.is_none()
         {
-            if let Some(in_arg) = graph_io.get_node_output(&node.outputs[0].name) {
-                remap_unsqueeze_to_reshape(node, in_arg);
-            }
+            //if let Some(in_arg) = graph_io.get_node_output(&node.outputs[0].name) {
+                remap_unsqueeze_to_reshape(node);
+            //}
         }
     }
 
@@ -384,7 +524,7 @@ impl OnnxGraphBuilder {
             //in a new function that operates on each input.
             node.inputs.iter_mut().for_each(|x| {
                 if let Some(identity_idx) = self.identity_idx.get(&x.name) {
-                    let input_name = &self.nodes[*identity_idx].inputs[0].name;
+                    let input_name = &self.processed_nodes[*identity_idx].inputs[0].name;
 
                     x.name.clone_from(input_name);
                 }
@@ -431,62 +571,103 @@ pub fn parse_onnx(onnx_path: &Path) -> OnnxGraph {
     );
 
     log::debug!("Number of outputs: {:?}", onnx_model.graph.output.len());
-    let mut builder = OnnxGraphBuilder::default();
-    builder.node_gen(&onnx_model);
+    let builder = OnnxGraphBuilder::default();
+    let graph = builder.node_gen(&onnx_model);
 
-    let OnnxGraphBuilder {
-        nodes,
-        inputs: inner_inputs,
-        outputs: inner_outputs,
-        ..
-    } = builder;
+    // let OnnxGraphBuilder {
+    //     processed_nodes: nodes,
+    //     inputs: inner_inputs,
+    //     outputs: inner_outputs,
+    //     ..
+    // } = builder;
 
     log::info!("Finished parsing ONNX file: {}", onnx_path.display());
 
-    OnnxGraph {
-        nodes,
-        inputs: inner_inputs,
-        outputs: inner_outputs,
-    }
+    // OnnxGraph {
+    //     nodes,
+    //     inputs: inner_inputs,
+    //     outputs: inner_outputs,
+    // }
+    graph
 }
+
 
 /// Remap the unsqueeze node to a reshape node, Should only be called after
 /// node renaming has been done. avoids marking rhs as passed so that it can be
 /// properly deleted if nothing else uses it
-fn remap_unsqueeze_to_reshape(node: &mut Node, out_arg: &Argument) {
-    match node.outputs[0].ty {
-        ArgType::Tensor(ref mut tensor_type) => {
-            if let ArgType::Tensor(arg_tensor) = &out_arg.ty {
-                tensor_type.shape.clone_from(&arg_tensor.shape);
-                let inner = arg_tensor
-                    .shape
-                    .clone()
-                    .unwrap()
-                    .into_iter()
-                    .map(|x| x as i64)
-                    .collect::<Vec<i64>>();
-                let shape_len = inner.len();
-                let new_rhs_value = Some(Data::Int64s(inner));
-                //moving the remap to here
-                let rhs_arg = Argument {
-                    name: format!("{}_generated_const", node.name),
-                    ty: ArgType::Tensor(TensorType {
-                        elem_type: super::ir::ElementType::Int64,
-                        dim: 1,
-                        shape: Some(vec![shape_len]),
-                    }),
-                    value: new_rhs_value,
-                    passed: false,
-                };
-                node.inputs[1] = rhs_arg;
-                node.outputs[0] = out_arg.clone();
-                node.node_type = NodeType::Reshape;
-            }
+/// Remap the unsqueeze node to a reshape node
+pub(crate) fn remap_unsqueeze_to_reshape(node: &mut Node) {
+    match &node.outputs[0].ty {
+        ArgType::Tensor(output_tensor) => {
+            let inner = output_tensor
+                .shape
+                .clone()
+                .unwrap()
+                .into_iter()
+                .map(|x| x as i64)
+                .collect::<Vec<i64>>();
+            let shape_len = inner.len();
+            let new_rhs_value = Some(Data::Int64s(inner));
+            //moving the remap to here
+            let rhs_arg = Argument {
+                name: format!("{}_generated_const", node.name),
+                ty: ArgType::Tensor(TensorType {
+                    elem_type: super::ir::ElementType::Int64,
+                    dim: 1,
+                    shape: Some(vec![shape_len]),
+                }),
+                value: new_rhs_value,
+                passed: false,
+            };
+            // ? should this replace the old input (reuse the old key) or should it be a new key
+            // going with new key for now
+            node.inputs[1] = rhs_arg;
+            node.node_type = NodeType::Reshape;
         }
         _ => {}
     }
 }
+// fn remap_unsqueeze_to_reshape(node: &mut Node) {
+//     match node.outputs[0].ty {
+//         ArgType::Tensor(ref mut tensor_type) => {
+//             if let ArgType::Tensor(arg_tensor) = &out_arg.ty {
+//                 tensor_type.shape.clone_from(&arg_tensor.shape);
+//                 let inner = arg_tensor
+//                     .shape
+//                     .clone()
+//                     .unwrap()
+//                     .into_iter()
+//                     .map(|x| x as i64)
+//                     .collect::<Vec<i64>>();
+//                 let shape_len = inner.len();
+//                 let new_rhs_value = Some(Data::Int64s(inner));
+//                 //moving the remap to here
+//                 let rhs_arg = Argument {
+//                     name: format!("{}_generated_const", node.name),
+//                     ty: ArgType::Tensor(TensorType {
+//                         elem_type: super::ir::ElementType::Int64,
+//                         dim: 1,
+//                         shape: Some(vec![shape_len]),
+//                     }),
+//                     value: new_rhs_value,
+//                     passed: false,
+//                 };
+//                 node.inputs[1] = rhs_arg;
+//                 node.outputs[0] = out_arg.clone();
+//                 node.node_type = NodeType::Reshape;
+//             }
+//         }
+//         _ => {}
+//     }
+// }
 
+fn set_input_passed(node: &Node, graph_data: &mut GraphData) {
+    for input in node.inputs.iter() {
+        if let Some(IOEntry2::In(i)) = graph_data.input_name_map.get(&input.name) {
+            graph_data.inputs[*i].passed = true;
+        }
+    }
+}
 /// Rename the inputs and output in the graph and return a map of
 /// the old names to the new names.
 ///
@@ -495,36 +676,36 @@ fn remap_unsqueeze_to_reshape(node: &mut Node, out_arg: &Argument) {
 /// the naming convention of the nodes and allow to be used as rust identifiers.
 /// Rename the inputs and output in the graph and return a map of
 /// the old names to the new names.
-fn rename_io(node: &mut Node, graph_io: &mut OnnxGraphIO) {
-    log::debug!("checking inputs for node {:?}", &node.name);
-    for node_input in node.inputs.iter_mut() {
-        if let Some(input_name) = graph_io.get_new_name(&node_input.name) {
-            node_input.passed = true;
-            node_input.name.clone_from(&input_name);
-        } else {
-            node_input.name = "".to_string();
-            node_input.passed = false;
-        }
-    }
-    let mut out_count = 1;
-    if node.node_type == NodeType::Constant || node.node_type == NodeType::Identity {
-        let new_name = format!("{}_out{}", node.name, out_count);
-        graph_io.insert(&node.outputs[0], &new_name);
-        node.outputs[0].name.clone_from(&new_name);
-        log::debug!("Found {} constant", new_name);
-    } else {
-        for output in node.outputs.iter_mut() {
-            log::debug!("output name: {}", &output.name);
+// fn rename_io(node: &mut Node, graph_io: &mut GraphData) {
+//     log::debug!("checking inputs for node {:?}", &node.name);
+//     for node_input in node.inputs.iter_mut() {
+//         if let Some(input_name) = graph_io.get_new_name(&node_input.name) {
+//             node_input.passed = true;
+//             node_input.name.clone_from(&input_name);
+//         } else {
+//             node_input.name = "".to_string();
+//             node_input.passed = false;
+//         }
+//     }
+//     let mut out_count = 1;
+//     if node.node_type == NodeType::Constant || node.node_type == NodeType::Identity {
+//         let new_name = format!("{}_out{}", node.name, out_count);
+//         graph_io.insert(&node.outputs[0], &new_name);
+//         node.outputs[0].name.clone_from(&new_name);
+//         log::debug!("Found {} constant", new_name);
+//     } else {
+//         for output in node.outputs.iter_mut() {
+//             log::debug!("output name: {}", &output.name);
 
-            let new_name = format!("{}_out{}", node.name, out_count);
+//             let new_name = format!("{}_out{}", node.name, out_count);
 
-            graph_io.update_name(output, &new_name);
+//             graph_io.update_name(output, &new_name);
 
-            output.name.clone_from(&new_name);
-            out_count += 1;
-        }
-    }
-}
+//             output.name.clone_from(&new_name);
+//             out_count += 1;
+//         }
+//     }
+// }
 
 /// Removes the graph inputs/output that are not used by any node.
 ///
@@ -542,6 +723,7 @@ fn remove_unused_graph_inputs(inputs: &mut Vec<Argument>, outputs: &mut Vec<Argu
     // Remove outputs that are not used by any node
     outputs.retain(|output| output.passed);
 }
+
 
 // Define a trait for topological sorting
 trait TopologicalSortable {

--- a/crates/burn-import/src/onnx/from_onnx.rs
+++ b/crates/burn-import/src/onnx/from_onnx.rs
@@ -109,8 +109,6 @@ impl GraphData {
                 if let Some(init_arg) = self.initializers.get(proto_str) {
                     init_arg.clone()
                 } else {
-                    //should I throw a warning here to support coalesce?, or make a separate function
-                    //that doesn't panic
                     log::warn!(
                         "Input {} not found, should only happen when peeking",
                         proto_str
@@ -140,10 +138,10 @@ impl GraphData {
         });
     }
 
-    ///This function does three things:
-    /// marks the inputs as passed
-    /// maps the old output names to the node output
-    /// renames the node output
+    /// This function does three things:
+    ///     1. marks the inputs as passed
+    ///     2. maps the old output names to the node output
+    ///     3. renames the node output
     fn add_node(&mut self, mut node: Node) {
         log::debug!("adding node {:?}", &node.name);
         self.mark_input_passed(&node);

--- a/crates/burn-import/src/onnx/from_onnx.rs
+++ b/crates/burn-import/src/onnx/from_onnx.rs
@@ -4,10 +4,10 @@ use std::{
     path::Path,
 };
 
-use crate::onnx::{node_remap::remap_node_type, proto_conversion::convert_node_proto};
+use crate::onnx::node_remap::remap_node_type;
 
 use super::{
-    coalesce::coalesce, ir::{Data, OnnxGraph, TensorType}, proto_conversion::convert_node_proto2, protos::{ModelProto, NodeProto, TensorProto, ValueInfoProto}
+    coalesce::coalesce, ir::{Data, OnnxGraph, TensorType}, proto_conversion::convert_node_proto, protos::{ModelProto, NodeProto, TensorProto, ValueInfoProto}
 };
 
 use super::dim_inference::dim_inference;
@@ -28,15 +28,9 @@ const LIFT_CONSTANTS_FOR_NODE_TYPES: [NodeType; 10] = [
     NodeType::Squeeze,
 ];
 
-#[derive(Debug)]
-pub(crate) enum IOEntry {
-    In(usize),
-    Out(usize),
-    Node(usize),
-}
 
 #[derive(Debug, Clone)]
-pub(crate) enum IOEntry2 {
+pub(crate) enum IOEntry {
     In(usize),
     Node(usize, usize),
 }
@@ -46,7 +40,8 @@ pub struct GraphData {
     pub(crate) inputs: Vec<Argument>,
     pub(crate) outputs: Vec<Argument>,
     pub(crate) initializers: HashMap<String, Argument>,
-    pub(crate) input_name_map: HashMap<String, IOEntry2>,
+    pub(crate) input_name_map: HashMap<String, IOEntry>,
+    pub(crate) node_name_counter: HashMap<NodeType, usize>,
 }
 
 impl GraphData {
@@ -54,6 +49,7 @@ impl GraphData {
         outputs: &Vec<ValueInfoProto>,
         initializers: &Vec<TensorProto>) -> Self {
         let mut input_name_map = HashMap::new();
+        let node_name_counter = HashMap::new();
         let mut in_count = 1;
         
         let constants = initializers
@@ -71,7 +67,9 @@ impl GraphData {
             .enumerate()
             .map(|(i, x)| {
                 let in_name = format!("input{}", in_count);
-                input_name_map.insert(x.name.clone(), IOEntry2::In(i));
+                
+                input_name_map.insert(x.name.clone(), IOEntry::In(i));
+                
                 let mut arg = Argument::try_from(x.clone()).unwrap();
                 if let Some(initial_arg) = constants.get(&x.name) {
                     if arg.value.is_none() {
@@ -90,6 +88,7 @@ impl GraphData {
             initializers: constants,
             processed_nodes: Vec::new(),
             input_name_map,
+            node_name_counter,
         }
     }
 
@@ -101,23 +100,65 @@ impl GraphData {
                 if let Some(init_arg) = self.initializers.get(proto_str) {
                     init_arg.clone()
                 } else {
-                  panic!("where did input {:?} come from?", proto_str)  
+                    //should I throw a warning here to support coalesce?, or make a separate function
+                    //that doesn't panic
+                    log::warn!("Input {} not found, should only happen when peeking", proto_str);
+                    Argument::new(proto_str.to_string())
                 }
             }
-            Some(IOEntry2::In(i)) => self.inputs[*i].clone(),
-            Some(IOEntry2::Node(i, j)) => {
+            Some(IOEntry::In(i)) => self.inputs[*i].clone(),
+            Some(IOEntry::Node(i, j)) => {
                 self.processed_nodes[*i].outputs[*j].clone()
             }
         }
     }
 
-    ///This function does two things:
-    /// maps the old output names to the output location
-    /// and updates the output names
+    fn predict_node_name(&self, node_type: &NodeType) -> String {
+        format!("{}{}", node_type, self.node_name_counter.get(node_type).unwrap_or(&0_usize)+1).to_lowercase()
+    }
+
+    /// Used for correctly mapping constants and identity nodes
+    fn predict_out_name(&self, node_type: &NodeType, out_idx: usize) -> String {
+        format!("{}{}_out{}",node_type,self.node_name_counter.get(node_type).unwrap_or(&0_usize)+1, out_idx+1).to_lowercase()
+    }
+        
+            
+    fn rename_node(&mut self, node: &mut Node) {
+        log::debug!("renaming node {:?}", &node.name);
+        self.node_name_counter
+            .entry(node.node_type.clone())
+            .and_modify(|e| *e += 1)
+            .or_insert(1);
+        let new_name = format!(
+            "{}{}",
+            node.node_type, self.node_name_counter[&node.node_type]
+        )
+        .to_lowercase();
+        node.name.clone_from(&new_name);
+    }
+    fn mark_input_passed(&mut self, node: &Node) {
+        //I don't like this, but consider:
+        //1. input names are set from the beginning
+        //2. A node might replace an input (unsqueeze to reshape)
+        //3. graph inputs are generally 1 to 3 arguments
+        for node_input in node.inputs.iter() {
+            for graph_input in self.inputs.iter_mut() {
+                if node_input.name == graph_input.name {
+                    graph_input.passed = true;
+                }
+            }
+        }
+    }
+    ///This function does three things:
+    /// renames the nodes
+    /// marks the inputs as passed
+    /// renames the output and maps the old output names to it
     pub fn add_node(&mut self, mut node: Node) {
+        self.rename_node(&mut node);
+        self.mark_input_passed(&node);
         let mut out_count=1;
         for output in node.outputs.iter_mut() {
-            self.input_name_map.insert(output.name.clone(), IOEntry2::Node(self.processed_nodes.len(), 0));
+            self.input_name_map.insert(output.name.clone(), IOEntry::Node(self.processed_nodes.len(), 0));
             output.name = format!("{}_out{}", node.name, out_count);
             out_count+=1;
         }
@@ -125,237 +166,27 @@ impl GraphData {
         
     }
 
-    fn consume(mut self) -> (Vec<Node>, Vec<Argument>, Vec<Argument>) {
+    pub fn consume(mut self) -> (Vec<Node>, Vec<Argument>, Vec<Argument>) {
+        
         self.inputs.retain(|x| x.passed);
         let outputs = self.outputs.into_iter().filter_map(|x| {
             match self.input_name_map.get(&x.name) {
-                Some(IOEntry2::Node(_, _)) => Some(x),
+                Some(IOEntry::Node(i, j)) => Some(self.processed_nodes[*i].outputs[*j].clone()),
                 _ => None
             }
         }).collect();
         (self.processed_nodes, self.inputs, outputs)
     }
     
+    fn get_graph_output(&self, name: &str) -> Option<&Argument> {
+        self.outputs.iter().find(|x| x.name == name)
+    }
+    
 }
 
-pub(crate) struct GraphIO {
-    /// The inputs for the Graph
-    pub(crate) inputs: Vec<Argument>,
-    /// The outputs for the Graph
-    pub(crate) outputs: Vec<Argument>,
-    /// Initializers
-    pub(crate) initializers: HashMap<String, Argument>,
-    ///updated names of outputs of node not stored in the graph
-    node_out: Vec<Argument>,
-    pub(crate) old_io_names: HashMap<String, IOEntry>,
-}
-
-
-
-impl GraphIO {
-    pub(crate) fn new(
-        inputs: &Vec<ValueInfoProto>,
-        outputs: &Vec<ValueInfoProto>,
-        initializers: &Vec<TensorProto>,
-    ) -> Self {
-        let mut old_io_names = HashMap::new();
-        let mut in_count = 1;
-        let constants = initializers
-            .iter()
-            .map(|x| (x.name.clone(), Argument::from_initializer(x)))
-            .collect::<HashMap<String, Argument>>();
-
-        let inputs = inputs
-            .iter()
-            .enumerate()
-            .map(|(i, x)| {
-                let in_name = format!("input{}", in_count);
-                old_io_names.insert(x.name.clone(), IOEntry::In(i));
-                let mut arg = Argument::try_from(x.clone()).unwrap();
-                if let Some(initial_arg) = constants.get(&x.name) {
-                    if arg.value.is_none() {
-                        arg.copy_value(initial_arg);
-                    }
-                }
-
-                in_count += 1;
-                arg.name = in_name;
-                arg
-            })
-            .collect::<Vec<Argument>>();
-
-        let outputs = outputs
-            .iter()
-            .enumerate()
-            .map(|(i, x)| {
-                old_io_names.insert(x.name.clone(), IOEntry::Out(i));
-                Argument::try_from(x.clone()).unwrap()
-            })
-            .collect::<Vec<Argument>>();
-
-        
-
-        Self {
-            inputs,
-            outputs,
-            initializers: constants,
-            node_out: Vec::new(),
-            old_io_names,
-        }
-    }
-
-    fn update_name(&mut self, arg: &Argument, new_name: &str) {
-        match self.old_io_names.get(&arg.name) {
-            Some(IOEntry::In(_)) => {
-                panic!("input names are set from the beginning");
-            }
-            Some(IOEntry::Out(i)) => {
-                let arg = self.outputs.get_mut(*i).unwrap();
-                arg.name = new_name.to_string();
-            }
-            Some(IOEntry::Node(i)) => {
-                let arg = self.node_out.get_mut(*i).unwrap();
-                arg.name = new_name.to_string();
-            }
-            None => {
-                //Constants, Casts wound up here before API changes
-                panic!(
-                    "Tried to update the name of {} to {} but entry doesn't exist in the map",
-                    arg.name, new_name
-                )
-            }
-        }
-    }
-
-    /// Used to initialize the input arguments for nodes. Names need to remain the same because
-    /// currently the old names are the key for accessing the Argument
-    pub fn init_in(&self, proto_str: String) -> Argument {
-        match self.old_io_names.get(&proto_str) {
-            None => {
-                if let Some(init_arg) = self.initializers.get(&proto_str) {
-                    init_arg.clone()
-                } else {
-                    Argument::new(proto_str)
-                }
-            }
-
-            Some(IOEntry::In(i)) => {
-                let mut arg = self.inputs[*i].clone();
-
-                arg.name = proto_str;
-                arg.passed = true;
-                arg
-            }
-            Some(IOEntry::Node(i)) => {
-                let mut arg = self.node_out[*i].clone();
-                arg.name = proto_str;
-                arg
-            }
-            Some(IOEntry::Out(_)) => {
-                panic!("graph output {} can't be a Node input", &proto_str)
-            }
-        }
-    }
-
-    fn insert(&mut self, arg: &Argument, new_name: &str) {
-        if let Some(idx) = self.old_io_names.get(&arg.name) {
-            if let IOEntry::Node(idx) = idx {
-                if self.node_out[*idx].name == arg.name {
-                    self.node_out[*idx].name = new_name.to_string();
-                    return;
-                }
-            } else {
-                panic!("arg entry with old name {} is a graph IO", &arg.name);
-            }
-        }
-
-        let idx = self.node_out.len();
-        self.old_io_names
-            .insert(arg.name.clone(), IOEntry::Node(idx));
-        self.node_out.push(arg.clone());
-        self.node_out[idx].name = new_name.to_string();
-    }
-
-    /// Copies node outputs to graph IO. Used at the end of dim inference.
-    pub(crate) fn update_tensor_output(&mut self, node: &Node) {
-        for node_output in node.outputs.iter() {
-            match self.old_io_names.get(&node_output.name) {
-                Some(IOEntry::In(i)) => {
-                    let arg = self.inputs.get_mut(*i).unwrap();
-                    arg.copy_value(node_output);
-                }
-                Some(IOEntry::Out(i)) => {
-                    let arg = self.outputs.get_mut(*i).unwrap();
-                    arg.copy_value(node_output);
-                    //Set the output to passed since it's been altered by a Node
-                    arg.passed = true;
-                }
-                Some(IOEntry::Node(_)) => {
-                    panic!("This output is from another node");
-                }
-                None => {
-                    log::debug!("inserting with name {:?}", &node_output.name);
-                    let idx = self.node_out.len();
-                    self.old_io_names
-                        .insert(node_output.name.clone(), IOEntry::Node(idx));
-                    self.node_out.push(node_output.clone());
-                }
-            }
-        }
-    }
-
-    /// Used by handle unsqeeze to remap the output of a node to a new name
-    /// expected match if it exists is either a graph input or graph output
-    pub(crate) fn get_node_output(&self, old_name: &str) -> Option<&Argument> {
-        match self.old_io_names.get(old_name) {
-            Some(IOEntry::In(i)) => self.inputs.get(*i),
-            Some(IOEntry::Out(i)) => self.outputs.get(*i),
-            Some(IOEntry::Node(_)) => panic!("This is a node output"),
-            None => None,
-        }
-    }
-
-    /// Get the updated name of a Node Input, which should be
-    /// either a graph input or a node output.
-    /// Will return None if the it isn't a graph input or node output(like an initializer)
-    /// Will panic if it's a graph output
-    fn get_new_name(&mut self, old_name: &str) -> Option<String> {
-        match self.old_io_names.get(old_name) {
-            Some(IOEntry::In(i)) => {
-                //FIXME: technically in the spec, initializers are default values
-                //for optional inputs, but implementing that would require reworking
-                //the way the graph is built, and it's not clear burn users are using initializers
-                //in that way
-                // see https://github.com/onnx/onnx/issues/2660
-                if self.initializers.contains_key(old_name) {
-                    None
-                } else {
-                    //set the input as passed since a node is referencing it
-                    self.inputs[*i].passed = true;
-                    Some(self.inputs[*i].name.clone())
-                }
-            }
-            Some(IOEntry::Out(_)) => {
-                panic!(
-                    "you just tried to get an updated name on a graph output: {}",
-                    old_name
-                )
-            }
-            Some(IOEntry::Node(i)) => Some(self.node_out[*i].name.clone()),
-            None => None,
-        }
-    }
-}
 
 #[derive(Default)]
 pub(crate) struct OnnxGraphBuilder {
-    processed_nodes: Vec<Node>,
-    // inputs: Vec<Argument>,
-    // outputs: Vec<Argument>,
-    // initializers: HashMap<String, Argument>,
-    //input_name_map: HashMap<String, IOEntry2>,
-    /// Counter for node names, used for renaming nodes
-    node_name_counter: HashMap<NodeType, usize>,
     /// Nodes to remove
     nodes_to_remove: HashSet<usize>,
     /// Map from constant node output names to indices of constant nodes
@@ -369,11 +200,6 @@ impl OnnxGraphBuilder {
     pub(crate) fn node_gen(mut self, model_proto: &ModelProto) -> OnnxGraph {
         self.constants_types = LIFT_CONSTANTS_FOR_NODE_TYPES.into_iter().collect();
 
-        // let mut graph_io = OnnxGraphIO::new(
-        //     &model_proto.graph.input,
-        //     &model_proto.graph.output,
-        //     &model_proto.graph.initializer,
-        // );
 
         let mut graph_data = GraphData::new(
             &model_proto.graph.input,
@@ -381,36 +207,35 @@ impl OnnxGraphBuilder {
             &model_proto.graph.initializer,
         );
 
-        self.processed_nodes = Vec::with_capacity(model_proto.graph.node.len());
         let mut and_idx = 0;
         let mut node_iter = model_proto.graph.node.iter().peekable();
 
         while let Some(node_proto) = node_iter.next() {
-            let mut node = convert_node_proto2(node_proto, &graph_data);
+            let mut node = convert_node_proto(node_proto, &graph_data);
 
             remap_node_type(&mut node);
 
             coalesce(&mut node, &mut node_iter, &graph_data);
-            self.handle_node_renaming(&mut node);
             // NOTE: start of stateful filter functions
             // args : node, graph_io/data, and_idx
-            self.handle_identity(&mut node, and_idx);
-            self.check_constants(&mut node, and_idx, &mut graph_data);
-            
-
+            self.handle_identity(&mut node, and_idx, &graph_data);
+            self.check_constants(&mut node, and_idx, &graph_data);
             self.handle_unsqueeze(&mut node, &graph_data);
 
-            dim_inference(&mut node, &mut graph_data);
+            dim_inference(&mut node);
 
             //rename_io(&mut node, &mut graph_io);
             graph_data.add_node(node);
+
             //self.processed_nodes.push(node);
             and_idx += 1;
         }
 
         let mut i = 0;
-        
+    
         let (mut processed_nodes, inputs, outputs) = graph_data.consume();
+        //println!("processed_nodes: {:#?}", processed_nodes);
+        //println!("inputs: {:#?}", inputs);
         // Remove the graph inputs/output that are not used by any node
         //remove_unused_graph_inputs(&mut inputs, &mut outputs);
         processed_nodes.retain(|_| {let keep = !self.nodes_to_remove.contains(&i); i+=1; keep});
@@ -421,64 +246,19 @@ impl OnnxGraphBuilder {
         }
     }
 
-    // fn init_graph_io(&mut self, inputs: &Vec<ValueInfoProto>, outputs: &Vec<ValueInfoProto>, initializers: &Vec<TensorProto>) -> GraphData {
-    //     let mut in_count = 1;
-        
-    //     let constants = initializers
-    //         .iter()
-    //         .map(|x| (x.name.clone(), Argument::from_initializer(x)))
-    //         .collect::<HashMap<String, Argument>>();
-    //     self.outputs = outputs
-    //         .iter()
-    //         .map(|x| {
-    //             Argument::try_from(x.clone()).unwrap()
-    //         })
-    //         .collect::<Vec<Argument>>();
-    //     self.inputs = inputs
-    //         .iter()
-    //         .enumerate()
-    //         .map(|(i, x)| {
-    //             let in_name = format!("input{}", in_count);
-    //             self.input_name_map.insert(x.name.clone(), IOEntry2::In(i));
-    //             let mut arg = Argument::try_from(x.clone()).unwrap();
-    //             if let Some(initial_arg) = constants.get(&x.name) {
-    //                 if arg.value.is_none() {
-    //                     arg.copy_value(initial_arg);
-    //                 }
-    //             }
+   
 
-    //             in_count += 1;
-    //             arg.name = in_name;
-    //             arg
-    //         })
-    //         .collect::<Vec<Argument>>();
-    // }
-
-    fn handle_node_renaming(&mut self, node: &mut Node) {
-        log::debug!("renaming node {:?}", &node.name);
-        self.node_name_counter
-            .entry(node.node_type.clone())
-            .and_modify(|e| *e += 1)
-            .or_insert(1);
-        let new_name = format!(
-            "{}{}",
-            node.node_type, self.node_name_counter[&node.node_type]
-        )
-        .to_lowercase();
-        node.name.clone_from(&new_name);
-    }
-
-    fn check_constants(&mut self, node: &mut Node, i: usize, _graph_io: &mut GraphData) {
+    fn check_constants(&mut self, node: &mut Node, i: usize, graph_data: &GraphData) {
         if node.node_type == NodeType::Constant
             || (node.node_type == NodeType::Identity && node.inputs[0].value.is_some())
         {
-            self.constants_map.insert(node.outputs[0].name.clone(), i);
+            self.constants_map.insert(graph_data.predict_out_name(&node.node_type, 0), i);
         } else if self.constants_types.contains(&node.node_type) {
             log::debug!("checking node {} for constants", &node.name);
             for input in node.inputs.iter_mut().skip(1) {
                 log::debug!("checking input {:?} for const", input);
                 if let Some(const_idx) = self.constants_map.get(&input.name) {
-                    let constant = &self.processed_nodes[*const_idx];
+                    let constant = &graph_data.processed_nodes[*const_idx];
                     log::debug!(
                         "input {} matched constant node {}",
                         &input.name,
@@ -502,18 +282,19 @@ impl OnnxGraphBuilder {
     /// Check if the unsqueeze node has a rhs value (rhs is constant) and if not remap it to a reshape
     /// Needs to be called after node renaming to ensure that the rhs name is correct
     /// Needs to be called after constant lifting to ensure that the rhs value exists
-    fn handle_unsqueeze(&mut self, node: &mut Node, graph_io: &GraphData) {
+    fn handle_unsqueeze(&mut self, node: &mut Node, graph_data: &GraphData) {
         if node.node_type == NodeType::Unsqueeze
             && node.inputs.len() > 1
             && node.inputs[1].value.is_none()
         {
-            //if let Some(in_arg) = graph_io.get_node_output(&node.outputs[0].name) {
-                remap_unsqueeze_to_reshape(node);
-            //}
+            //if the output has a shape, it's only because it's a graph output
+            if let Some(out_arg) = graph_data.get_graph_output(&node.outputs[0].name) {
+                remap_unsqueeze_to_reshape(node, &out_arg, graph_data);
+            }
         }
     }
 
-    fn handle_identity(&mut self, node: &mut Node, i: usize) {
+    fn handle_identity(&mut self, node: &mut Node, i: usize, graph_data: &GraphData) {
         if node.node_type == NodeType::Identity && node.inputs[0].value.is_none() {
             log::debug!("\nfound identity node:\n{:?}\n", &node);
             //map the output name to check for pass through values
@@ -524,7 +305,7 @@ impl OnnxGraphBuilder {
             //in a new function that operates on each input.
             node.inputs.iter_mut().for_each(|x| {
                 if let Some(identity_idx) = self.identity_idx.get(&x.name) {
-                    let input_name = &self.processed_nodes[*identity_idx].inputs[0].name;
+                    let input_name = &graph_data.processed_nodes[*identity_idx].inputs[0].name;
 
                     x.name.clone_from(input_name);
                 }
@@ -596,8 +377,8 @@ pub fn parse_onnx(onnx_path: &Path) -> OnnxGraph {
 /// node renaming has been done. avoids marking rhs as passed so that it can be
 /// properly deleted if nothing else uses it
 /// Remap the unsqueeze node to a reshape node
-pub(crate) fn remap_unsqueeze_to_reshape(node: &mut Node) {
-    match &node.outputs[0].ty {
+pub(crate) fn remap_unsqueeze_to_reshape(node: &mut Node, out_arg: &Argument,graph_data: &GraphData) {
+    match &out_arg.ty {
         ArgType::Tensor(output_tensor) => {
             let inner = output_tensor
                 .shape
@@ -610,7 +391,7 @@ pub(crate) fn remap_unsqueeze_to_reshape(node: &mut Node) {
             let new_rhs_value = Some(Data::Int64s(inner));
             //moving the remap to here
             let rhs_arg = Argument {
-                name: format!("{}_generated_const", node.name),
+                name: format!("{}_generated_const", graph_data.predict_node_name(&NodeType::Reshape)),
                 ty: ArgType::Tensor(TensorType {
                     elem_type: super::ir::ElementType::Int64,
                     dim: 1,
@@ -622,109 +403,13 @@ pub(crate) fn remap_unsqueeze_to_reshape(node: &mut Node) {
             // ? should this replace the old input (reuse the old key) or should it be a new key
             // going with new key for now
             node.inputs[1] = rhs_arg;
+            node.outputs[0] = out_arg.clone();
             node.node_type = NodeType::Reshape;
         }
-        _ => {}
-    }
-}
-// fn remap_unsqueeze_to_reshape(node: &mut Node) {
-//     match node.outputs[0].ty {
-//         ArgType::Tensor(ref mut tensor_type) => {
-//             if let ArgType::Tensor(arg_tensor) = &out_arg.ty {
-//                 tensor_type.shape.clone_from(&arg_tensor.shape);
-//                 let inner = arg_tensor
-//                     .shape
-//                     .clone()
-//                     .unwrap()
-//                     .into_iter()
-//                     .map(|x| x as i64)
-//                     .collect::<Vec<i64>>();
-//                 let shape_len = inner.len();
-//                 let new_rhs_value = Some(Data::Int64s(inner));
-//                 //moving the remap to here
-//                 let rhs_arg = Argument {
-//                     name: format!("{}_generated_const", node.name),
-//                     ty: ArgType::Tensor(TensorType {
-//                         elem_type: super::ir::ElementType::Int64,
-//                         dim: 1,
-//                         shape: Some(vec![shape_len]),
-//                     }),
-//                     value: new_rhs_value,
-//                     passed: false,
-//                 };
-//                 node.inputs[1] = rhs_arg;
-//                 node.outputs[0] = out_arg.clone();
-//                 node.node_type = NodeType::Reshape;
-//             }
-//         }
-//         _ => {}
-//     }
-// }
-
-fn set_input_passed(node: &Node, graph_data: &mut GraphData) {
-    for input in node.inputs.iter() {
-        if let Some(IOEntry2::In(i)) = graph_data.input_name_map.get(&input.name) {
-            graph_data.inputs[*i].passed = true;
+        _ => {
         }
     }
 }
-/// Rename the inputs and output in the graph and return a map of
-/// the old names to the new names.
-///
-/// The inputs are renamed to be unique and to be in the format of
-/// conv2_in1, conv2_in2, etc. This is done to be consistent with
-/// the naming convention of the nodes and allow to be used as rust identifiers.
-/// Rename the inputs and output in the graph and return a map of
-/// the old names to the new names.
-// fn rename_io(node: &mut Node, graph_io: &mut GraphData) {
-//     log::debug!("checking inputs for node {:?}", &node.name);
-//     for node_input in node.inputs.iter_mut() {
-//         if let Some(input_name) = graph_io.get_new_name(&node_input.name) {
-//             node_input.passed = true;
-//             node_input.name.clone_from(&input_name);
-//         } else {
-//             node_input.name = "".to_string();
-//             node_input.passed = false;
-//         }
-//     }
-//     let mut out_count = 1;
-//     if node.node_type == NodeType::Constant || node.node_type == NodeType::Identity {
-//         let new_name = format!("{}_out{}", node.name, out_count);
-//         graph_io.insert(&node.outputs[0], &new_name);
-//         node.outputs[0].name.clone_from(&new_name);
-//         log::debug!("Found {} constant", new_name);
-//     } else {
-//         for output in node.outputs.iter_mut() {
-//             log::debug!("output name: {}", &output.name);
-
-//             let new_name = format!("{}_out{}", node.name, out_count);
-
-//             graph_io.update_name(output, &new_name);
-
-//             output.name.clone_from(&new_name);
-//             out_count += 1;
-//         }
-//     }
-// }
-
-/// Removes the graph inputs/output that are not used by any node.
-///
-/// In older ONNX models, the inputs and outputs are not always used by the nodes.
-/// For example, the input could be used as a state instead of an input. Since the
-/// inputs with initializers are moved to the states vector, the inputs vector could
-/// contain unused inputs. The same is true for the outputs.
-///
-/// Generally, it's a good idea to remove unused inputs/outputs because it makes the
-/// generated code cleaner and easier to read.
-fn remove_unused_graph_inputs(inputs: &mut Vec<Argument>, outputs: &mut Vec<Argument>) {
-    // Remove inputs that are not used by any node
-    inputs.retain(|input| input.passed);
-
-    // Remove outputs that are not used by any node
-    outputs.retain(|output| output.passed);
-}
-
-
 // Define a trait for topological sorting
 trait TopologicalSortable {
     fn is_top_sorted(&self) -> bool;

--- a/crates/burn-import/src/onnx/from_onnx.rs
+++ b/crates/burn-import/src/onnx/from_onnx.rs
@@ -41,7 +41,8 @@ pub struct GraphData {
     pub(crate) outputs: Vec<Argument>,
     pub(crate) initializers: HashMap<String, Argument>,
     pub(crate) input_name_map: HashMap<String, IOEntry>,
-    pub(crate) node_name_counter: HashMap<NodeType, usize>,
+    graph_input_name_map: HashMap<String, usize>,
+    
 }
 
 impl GraphData {
@@ -49,8 +50,9 @@ impl GraphData {
         outputs: &Vec<ValueInfoProto>,
         initializers: &Vec<TensorProto>) -> Self {
         let mut input_name_map = HashMap::new();
-        let node_name_counter = HashMap::new();
-        let mut in_count = 1;
+        let mut graph_input_name_map = HashMap::new();
+        //let node_name_counter = HashMap::new();
+        
         
         let constants = initializers
             .iter()
@@ -66,9 +68,10 @@ impl GraphData {
             .iter()
             .enumerate()
             .map(|(i, x)| {
-                let in_name = format!("input{}", in_count);
+                let in_name = format!("input{}", i+1);
                 
                 input_name_map.insert(x.name.clone(), IOEntry::In(i));
+                graph_input_name_map.insert(in_name.clone(), i);
                 
                 let mut arg = Argument::try_from(x.clone()).unwrap();
                 if let Some(initial_arg) = constants.get(&x.name) {
@@ -77,7 +80,7 @@ impl GraphData {
                     }
                 }
 
-                in_count += 1;
+                
                 arg.name = in_name;
                 arg
             })
@@ -88,7 +91,8 @@ impl GraphData {
             initializers: constants,
             processed_nodes: Vec::new(),
             input_name_map,
-            node_name_counter,
+            graph_input_name_map,
+            //node_name_counter,
         }
     }
 
@@ -113,48 +117,53 @@ impl GraphData {
         }
     }
 
-    fn predict_node_name(&self, node_type: &NodeType) -> String {
-        format!("{}{}", node_type, self.node_name_counter.get(node_type).unwrap_or(&0_usize)+1).to_lowercase()
-    }
+    // fn predict_node_name(&self, node_type: &NodeType) -> String {
+    //     format!("{}{}", node_type, self.node_name_counter.get(node_type).unwrap_or(&0_usize)+1).to_lowercase()
+    // }
 
-    /// Used for correctly mapping constants and identity nodes
-    fn predict_out_name(&self, node_type: &NodeType, out_idx: usize) -> String {
-        format!("{}{}_out{}",node_type,self.node_name_counter.get(node_type).unwrap_or(&0_usize)+1, out_idx+1).to_lowercase()
-    }
+    // /// Used for correctly mapping constants and identity nodes
+    // fn predict_out_name(&self, node_type: &NodeType, out_idx: usize) -> String {
+    //     format!("{}{}_out{}",node_type,self.node_name_counter.get(node_type).unwrap_or(&0_usize)+1, out_idx+1).to_lowercase()
+    // }
         
             
-    fn rename_node(&mut self, node: &mut Node) {
-        log::debug!("renaming node {:?}", &node.name);
-        self.node_name_counter
-            .entry(node.node_type.clone())
-            .and_modify(|e| *e += 1)
-            .or_insert(1);
-        let new_name = format!(
-            "{}{}",
-            node.node_type, self.node_name_counter[&node.node_type]
-        )
-        .to_lowercase();
-        node.name.clone_from(&new_name);
-    }
+    // fn rename_node(&mut self, node: &mut Node) {
+    //     log::debug!("renaming node {:?}", &node.name);
+    //     self.node_name_counter
+    //         .entry(node.node_type.clone())
+    //         .and_modify(|e| *e += 1)
+    //         .or_insert(1);
+    //     let new_name = format!(
+    //         "{}{}",
+    //         node.node_type, self.node_name_counter[&node.node_type]
+    //     )
+    //     .to_lowercase();
+    //     node.name.clone_from(&new_name);
+    // }
     fn mark_input_passed(&mut self, node: &Node) {
         //I don't like this, but consider:
         //1. input names are set from the beginning
         //2. A node might replace an input (unsqueeze to reshape)
         //3. graph inputs are generally 1 to 3 arguments
-        for node_input in node.inputs.iter() {
-            for graph_input in self.inputs.iter_mut() {
-                if node_input.name == graph_input.name {
-                    graph_input.passed = true;
-                }
+        // for node_input in node.inputs.iter() {
+        //     for graph_input in self.inputs.iter_mut() {
+        //         if node_input.name == graph_input.name {
+        //             graph_input.passed = true;
+        //         }
+        //     }
+        // }
+        node.inputs.iter().for_each(|node_input| {
+            if let Some(idx) = self.graph_input_name_map.get(&node_input.name) {
+                self.inputs[*idx].passed = true;
             }
-        }
+        });
     }
     ///This function does three things:
     /// renames the nodes
     /// marks the inputs as passed
     /// renames the output and maps the old output names to it
     pub fn add_node(&mut self, mut node: Node) {
-        self.rename_node(&mut node);
+        //self.rename_node(&mut node);
         self.mark_input_passed(&node);
         let mut out_count=1;
         for output in node.outputs.iter_mut() {
@@ -194,10 +203,11 @@ pub(crate) struct OnnxGraphBuilder {
     constants_types: HashSet<NodeType>,
     /// Map from identity node output names to indices of identity nodes
     identity_idx: HashMap<String, usize>,
+    node_name_counter: HashMap<NodeType, usize>,
 }
 
 impl OnnxGraphBuilder {
-    pub(crate) fn node_gen(mut self, model_proto: &ModelProto) -> OnnxGraph {
+    pub(crate) fn build(mut self, model_proto: &ModelProto) -> OnnxGraph {
         self.constants_types = LIFT_CONSTANTS_FOR_NODE_TYPES.into_iter().collect();
 
 
@@ -214,7 +224,7 @@ impl OnnxGraphBuilder {
             let mut node = convert_node_proto(node_proto, &graph_data);
 
             remap_node_type(&mut node);
-
+            self.handle_node_renaming(&mut node);
             coalesce(&mut node, &mut node_iter, &graph_data);
             // NOTE: start of stateful filter functions
             // args : node, graph_io/data, and_idx
@@ -246,13 +256,25 @@ impl OnnxGraphBuilder {
         }
     }
 
-   
+    fn handle_node_renaming(&mut self, node: &mut Node) {
+        log::debug!("renaming node {:?}", &node.name);
+        self.node_name_counter
+            .entry(node.node_type.clone())
+            .and_modify(|e| *e += 1)
+            .or_insert(1);
+        let new_name = format!(
+            "{}{}",
+            node.node_type, self.node_name_counter[&node.node_type]
+        )
+        .to_lowercase();
+        node.name.clone_from(&new_name);
+    }
 
     fn check_constants(&mut self, node: &mut Node, i: usize, graph_data: &GraphData) {
         if node.node_type == NodeType::Constant
             || (node.node_type == NodeType::Identity && node.inputs[0].value.is_some())
         {
-            self.constants_map.insert(graph_data.predict_out_name(&node.node_type, 0), i);
+            self.constants_map.insert( format!("{}_out{}",&node.name, 1),i);
         } else if self.constants_types.contains(&node.node_type) {
             log::debug!("checking node {} for constants", &node.name);
             for input in node.inputs.iter_mut().skip(1) {
@@ -289,7 +311,7 @@ impl OnnxGraphBuilder {
         {
             //if the output has a shape, it's only because it's a graph output
             if let Some(out_arg) = graph_data.get_graph_output(&node.outputs[0].name) {
-                remap_unsqueeze_to_reshape(node, &out_arg, graph_data);
+                remap_unsqueeze_to_reshape(node, &out_arg);
             }
         }
     }
@@ -298,7 +320,7 @@ impl OnnxGraphBuilder {
         if node.node_type == NodeType::Identity && node.inputs[0].value.is_none() {
             log::debug!("\nfound identity node:\n{:?}\n", &node);
             //map the output name to check for pass through values
-            self.identity_idx.insert(node.outputs[0].name.clone(), i);
+            self.identity_idx.insert(format!("{}_out1",&node.name), i);
             self.nodes_to_remove.insert(i);
         } else {
             //NOTE: it might be possible to rework the API to handle all "per input" operations
@@ -353,7 +375,7 @@ pub fn parse_onnx(onnx_path: &Path) -> OnnxGraph {
 
     log::debug!("Number of outputs: {:?}", onnx_model.graph.output.len());
     let builder = OnnxGraphBuilder::default();
-    let graph = builder.node_gen(&onnx_model);
+    let graph = builder.build(&onnx_model);
 
     // let OnnxGraphBuilder {
     //     processed_nodes: nodes,
@@ -377,7 +399,7 @@ pub fn parse_onnx(onnx_path: &Path) -> OnnxGraph {
 /// node renaming has been done. avoids marking rhs as passed so that it can be
 /// properly deleted if nothing else uses it
 /// Remap the unsqueeze node to a reshape node
-pub(crate) fn remap_unsqueeze_to_reshape(node: &mut Node, out_arg: &Argument,graph_data: &GraphData) {
+pub(crate) fn remap_unsqueeze_to_reshape(node: &mut Node, out_arg: &Argument) {
     match &out_arg.ty {
         ArgType::Tensor(output_tensor) => {
             let inner = output_tensor
@@ -391,7 +413,7 @@ pub(crate) fn remap_unsqueeze_to_reshape(node: &mut Node, out_arg: &Argument,gra
             let new_rhs_value = Some(Data::Int64s(inner));
             //moving the remap to here
             let rhs_arg = Argument {
-                name: format!("{}_generated_const", graph_data.predict_node_name(&NodeType::Reshape)),
+                name: format!("{}_generated_const", &node.name),
                 ty: ArgType::Tensor(TensorType {
                     elem_type: super::ir::ElementType::Int64,
                     dim: 1,

--- a/crates/burn-import/src/onnx/proto_conversion.rs
+++ b/crates/burn-import/src/onnx/proto_conversion.rs
@@ -2,7 +2,7 @@ use std::str::{from_utf8, FromStr};
 
 use crate::onnx::ir::TensorType;
 
-use super::from_onnx::{GraphData};
+use super::from_onnx::GraphData;
 use super::ir::Dim;
 use super::ir::{
     ArgType, Argument, AttributeValue, Attributes, Data, ElementType, Node, NodeType, Tensor,
@@ -180,8 +180,6 @@ pub fn convert_vec_attrs_proto(attrs: Vec<AttributeProto>) -> Attributes {
     result
 }
 
-
-
 pub fn convert_node_proto(node: &NodeProto, graph_data: &GraphData) -> Node {
     let name = node.name.clone();
 
@@ -189,7 +187,11 @@ pub fn convert_node_proto(node: &NodeProto, graph_data: &GraphData) -> Node {
 
     let inputs = node.input.iter().map(|x| graph_data.init_in(x)).collect();
 
-    let outputs = node.output.iter().map(|x| Argument::new(x.to_string())).collect();
+    let outputs = node
+        .output
+        .iter()
+        .map(|x| Argument::new(x.to_string()))
+        .collect();
 
     let attrs = convert_vec_attrs_proto(node.attribute.clone());
 
@@ -203,11 +205,6 @@ pub fn convert_node_proto(node: &NodeProto, graph_data: &GraphData) -> Node {
         attrs,
     }
 }
-
-
-
-
-
 
 fn to_string(bytes: Vec<u8>) -> String {
     from_utf8(bytes.as_slice()).unwrap().to_string()

--- a/crates/burn-import/src/onnx/proto_conversion.rs
+++ b/crates/burn-import/src/onnx/proto_conversion.rs
@@ -2,7 +2,7 @@ use std::str::{from_utf8, FromStr};
 
 use crate::onnx::ir::TensorType;
 
-use super::from_onnx::OnnxGraphIO;
+use super::from_onnx::{GraphData};
 use super::ir::Dim;
 use super::ir::{
     ArgType, Argument, AttributeValue, Attributes, Data, ElementType, Node, NodeType, Tensor,
@@ -180,7 +180,33 @@ pub fn convert_vec_attrs_proto(attrs: Vec<AttributeProto>) -> Attributes {
     result
 }
 
-pub fn convert_node_proto(node: &NodeProto, graph_io: &OnnxGraphIO) -> Node {
+
+
+pub fn convert_node_proto2(node: &NodeProto, graph_data: &GraphData) -> Node {
+    let name = node.name.clone();
+
+    log::debug!("Converting ONNX node with type {:?}", node.op_type.as_str());
+
+    let inputs = node.input.iter().map(|x| graph_data.init_in(x)).collect();
+
+    let outputs = node.output.iter().map(|x| Argument::new(x.to_string())).collect();
+
+    let attrs = convert_vec_attrs_proto(node.attribute.clone());
+
+    let node_type = NodeType::from_str(node.op_type.as_str()).expect("Unknown node type");
+
+    Node {
+        node_type,
+        name,
+        inputs,
+        outputs,
+        attrs,
+    }
+}
+
+
+
+pub fn convert_node_proto(node: &NodeProto, graph_io: &GraphData) -> Node {
     let name = node.name.clone();
 
     log::debug!("Converting ONNX node with type {:?}", node.op_type.as_str());
@@ -188,7 +214,7 @@ pub fn convert_node_proto(node: &NodeProto, graph_io: &OnnxGraphIO) -> Node {
     let inputs = node
         .input
         .clone()
-        .into_iter()
+        .iter()
         .map(|x| graph_io.init_in(x))
         .collect();
 

--- a/crates/burn-import/src/onnx/proto_conversion.rs
+++ b/crates/burn-import/src/onnx/proto_conversion.rs
@@ -182,7 +182,7 @@ pub fn convert_vec_attrs_proto(attrs: Vec<AttributeProto>) -> Attributes {
 
 
 
-pub fn convert_node_proto2(node: &NodeProto, graph_data: &GraphData) -> Node {
+pub fn convert_node_proto(node: &NodeProto, graph_data: &GraphData) -> Node {
     let name = node.name.clone();
 
     log::debug!("Converting ONNX node with type {:?}", node.op_type.as_str());
@@ -206,32 +206,8 @@ pub fn convert_node_proto2(node: &NodeProto, graph_data: &GraphData) -> Node {
 
 
 
-pub fn convert_node_proto(node: &NodeProto, graph_io: &GraphData) -> Node {
-    let name = node.name.clone();
 
-    log::debug!("Converting ONNX node with type {:?}", node.op_type.as_str());
 
-    let inputs = node
-        .input
-        .clone()
-        .iter()
-        .map(|x| graph_io.init_in(x))
-        .collect();
-
-    let outputs = node.output.clone().into_iter().map(Argument::new).collect();
-
-    let attrs = convert_vec_attrs_proto(node.attribute.clone());
-
-    let node_type = NodeType::from_str(node.op_type.as_str()).expect("Unknown node type");
-
-    Node {
-        node_type,
-        name,
-        inputs,
-        outputs,
-        attrs,
-    }
-}
 
 fn to_string(bytes: Vec<u8>) -> String {
     from_utf8(bytes.as_slice()).unwrap().to_string()


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

#1840
 
### Changes
This was the alternative design I was talking about the other day. It's definitely a different set of compromises compared to #1795. 


1. got rid of `graph_io`, and move renaming to the end, which mostly works
2. I altered how arguments are added to the map, so that it only runs on inputs (which mostly works). 
3. Args are cloned into nodes, so functions that examine inputs or alter outputs don't need a second struct.

#### Problems
- in order to check if inputs are passed, since input names are altered at the beginning, we need to double map them (new_name->old->name->entry). This is both marginally better if a graph has 50+ inputs, and needed to check if the input is also an initializer(both are the case for web inference example).
- In order for unsqueeze to remap to a reshape(if the shape of the lhs is unknown or symbolic), it needs to check if the rhs is a graph output, which right now feels a little bolted on because nothing else needs access to that.

### Testing

testing with existing onnx test, and the minst classification web example. passes the test, both work as expected. 

I figured out why the example was failing before. All but the first input are also initializers.