### PR TITLE
Speedup client.create for small allocations.

### DIFF
--- a/crates/burn-wgpu/src/compute/server.rs
+++ b/crates/burn-wgpu/src/compute/server.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU64;
+
 use super::WgpuStorage;
 use alloc::{borrow::Cow, sync::Arc};
 use burn_compute::{
@@ -9,9 +11,14 @@ use burn_jit::JitAutotuneKey;
 use burn_tensor::Reader;
 use hashbrown::HashMap;
 use wgpu::{
-    util::{BufferInitDescriptor, DeviceExt},
+    util::{BufferInitDescriptor, DeviceExt, StagingBelt},
     BindGroup, CommandEncoder, ComputePipeline, ShaderModuleDescriptor,
 };
+
+// Allocations with existin data smaller than this can use a staging belt
+// which speeds up the allocation. A higher number here will catch more
+// allocations, but can also increase memory usage.
+const SMALL_ALLOC_SIZE: usize = 512;
 
 /// Wgpu compute server.
 #[derive(Debug)]
@@ -20,6 +27,7 @@ pub struct WgpuServer<MM: MemoryManagement<WgpuStorage>> {
     device: Arc<wgpu::Device>,
     queue: Arc<wgpu::Queue>,
     encoder: CommandEncoder,
+    staging_belt: StagingBelt,
     pipelines: HashMap<String, Arc<ComputePipeline>>,
     tasks_max: usize,
     tasks_count: usize,
@@ -45,6 +53,7 @@ where
             device,
             queue,
             encoder,
+            staging_belt: StagingBelt::new(SMALL_ALLOC_SIZE as u64),
             pipelines: HashMap::new(),
             tasks_max,
             tasks_count: 0,
@@ -52,6 +61,8 @@ where
     }
 
     fn submit(&mut self) {
+        self.staging_belt.finish();
+
         let mut new_encoder = self
             .device
             .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
@@ -62,6 +73,8 @@ where
 
         // Cleanup allocations and deallocations.
         self.memory_management.storage().perform_deallocations();
+
+        self.staging_belt.recall();
     }
 
     fn register_compute(
@@ -212,24 +225,42 @@ where
     /// fully utilize the GPU.
     fn create(&mut self, data: &[u8]) -> server::Handle<Self> {
         let handle = server::Handle::new(self.memory_management.reserve(data.len()));
-        let binding = handle.clone().binding();
+        let non_zero_len = NonZeroU64::new(data.len() as u64);
 
-        let buffer_src = Arc::new(self.device.create_buffer_init(&BufferInitDescriptor {
-            label: Some("Buffer Src"),
-            contents: data,
-            usage: wgpu::BufferUsages::COPY_SRC,
-        }));
+        // If there's nothing to copy, don't need to do any work here.
+        if let Some(len) = non_zero_len {
+            let binding = handle.clone().binding();
+            let resource = self.memory_management.get(binding.memory);
 
-        let resource = self.memory_management.get(binding.memory);
-
-        self.encoder.copy_buffer_to_buffer(
-            &buffer_src,
-            0,
-            &resource.buffer,
-            resource.offset(),
-            buffer_src.size(),
-        );
-        self.tasks_count += 1;
+            if data.len() < SMALL_ALLOC_SIZE {
+                // Use a staging belt if the allocation is small enough. This is faster than allocating a new buffer.
+                // Ideally, we could use queue.write_buffer_with(), which seems to be the recommended method for performance,
+                // but that doesn't seem to work, as we might re-use a buffer multiple times, and need to schedule this
+                // precisely in the encoder.
+                let mut write_buf = self.staging_belt.write_buffer(
+                    &mut self.encoder,
+                    &resource.buffer,
+                    0,
+                    len,
+                    &self.device,
+                );
+                write_buf.copy_from_slice(data);
+            } else {
+                let buffer_src = Arc::new(self.device.create_buffer_init(&BufferInitDescriptor {
+                    label: Some("Buffer Src"),
+                    contents: data,
+                    usage: wgpu::BufferUsages::COPY_SRC,
+                }));
+                self.encoder.copy_buffer_to_buffer(
+                    &buffer_src,
+                    0,
+                    &resource.buffer,
+                    resource.offset(),
+                    buffer_src.size(),
+                );
+            }
+            self.tasks_count += 1;
+        }
 
         handle
     }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x ] Confirmed that `run-checks all` script has been executed.
- [ x] Made sure the book is up to date with changes in this PR.

### Changes

I've noticed client.create() is quite slow when churning through lots of small kernels. It seems allocating a buffer each time is causing some overhead. After poking at WGPU a bit it seems a solution is to use their StagingBelt - effectively a pool.

It seems queue.write_buffer_with() would be even faster - but I couldn't get that to work. As it doesn't live on the encoder, you can't get the order of scheduling right.

What really would be faster though, is a different approach. These small allocations seem to come from the "info" buffers for various kernels. These really might need some special considerations - they should be bound as uniform data, and maybe a kernel could manage it's own "argument buffer" instead of relying on the burn allocator.

I might pursue that in the future, but figured this might be neat anyway for discussion, and who knows maybe other small allocations appear.

### Testing
Here's a comparison of a forward pass before/after. Nb this is just measuring CPU overhead. GPU is likely slightly faster as well.

![traceCompare](https://github.com/tracel-ai/burn/assets/7014262/cf9258bd-7a67-4890-8c2c-3563c6c11a24)