### PR TITLE
Make Param.id public

### DIFF
--- a/crates/burn-core/src/module/param/base.rs
+++ b/crates/burn-core/src/module/param/base.rs
@@ -31,7 +31,7 @@ use core::ops::Deref;
 /// let module = module.load_record(record);
 /// ```
 pub struct Param<T: Parameter> {
-    /// The unique ID of this parameter. This is used by eg. optimizers to associate a gradient with a specific parameter. ///
+    /// The unique ID of this parameter. This is used by eg. optimizers to associate a gradient with a specific parameter.
     pub id: ParamId,
     state: OnceCell<T>,
     /// The locking is only required because of `lazy_device` and `lazy_is_require_grad`.

--- a/crates/burn-core/src/module/param/base.rs
+++ b/crates/burn-core/src/module/param/base.rs
@@ -31,7 +31,8 @@ use core::ops::Deref;
 /// let module = module.load_record(record);
 /// ```
 pub struct Param<T: Parameter> {
-    pub(crate) id: ParamId,
+    /// The unique ID of this parameter. This is used by eg. optimizers to associate a gradient with a specific parameter. ///
+    pub id: ParamId,
     state: OnceCell<T>,
     /// The locking is only required because of `lazy_device` and `lazy_is_require_grad`.
     ///


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ x] Confirmed that `run-checks all` script has been executed.
- [ x] Made sure the book is up to date with changes in this PR.

### Changes

Make param id public. This can help to setup custom optimizers (by splitting of gradients for a specific param), [and has had some more requests.](https://discord.com/channels/1038839012602941528/1091796857996451942/1246075356616720446).

This could also just be a getter, replacing the id seems a bit wild but might be valid for advanced use cases.

It's also already pseudo public, as it's possible to do something like

```
// read:
let (id, val) = param.comsume()
// "write":
let param = ParamID::new(id, val);
```