### PR TITLE
Add per-tensor data quantization

### DIFF
--- a/burn-book/src/building-blocks/record.md
+++ b/burn-book/src/building-blocks/record.md
@@ -52,6 +52,7 @@ for serialization and deserialization.
 | `DoublePrecisionSettings` | `f64`           | `i64`             |
 | `FullPrecisionSettings`   | `f32`           | `i32`             |
 | `HalfPrecisionSettings`   | `f16`           | `i16`             |
+| `Int8PrecisionSettings`   | `f32`           | `i8`              |
 
 Note that when loading a record into a module, the type conversion is automatically handled, so you
 can't encounter errors. The only crucial aspect is using the same recorder for both serialization

--- a/crates/burn-core/src/record/serde/ser.rs
+++ b/crates/burn-core/src/record/serde/ser.rs
@@ -370,6 +370,6 @@ mod tests {
 
         // Compare the lengths of expected and actual serialized strings because
         // the order of the fields is not guaranteed for HashMaps.
-        assert_eq!(serialized_str.len(), 134);
+        assert_eq!(serialized_str.len(), 165);
     }
 }

--- a/crates/burn-core/src/record/settings.rs
+++ b/crates/burn-core/src/record/settings.rs
@@ -24,6 +24,10 @@ pub struct HalfPrecisionSettings;
 #[derive(Debug, Default, Clone)]
 pub struct DoublePrecisionSettings;
 
+/// Precision settings optimized for `int8` quantization.
+#[derive(Debug, Default, Clone)]
+pub struct Int8PrecisionSettings;
+
 impl PrecisionSettings for FullPrecisionSettings {
     type FloatElem = f32;
     type IntElem = i32;
@@ -37,4 +41,9 @@ impl PrecisionSettings for DoublePrecisionSettings {
 impl PrecisionSettings for HalfPrecisionSettings {
     type FloatElem = half::f16;
     type IntElem = i16;
+}
+
+impl PrecisionSettings for Int8PrecisionSettings {
+    type FloatElem = f32;
+    type IntElem = i8;
 }

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -2131,6 +2131,7 @@ where
         let serialized: DataSerialize<K::Elem> = DataSerialize {
             value: data.value,
             shape: data.shape.dims.to_vec(),
+            quantization: data.quantization,
         };
         serialized.serialize(serializer)
     }

--- a/crates/burn-tensor/src/tensor/api/sort.rs
+++ b/crates/burn-tensor/src/tensor/api/sort.rs
@@ -87,6 +87,7 @@ where
     <K as BasicOps<B>>::Elem: Element,
 {
     let dims = data.shape.dims;
+    // Note on quantization: the quantized values (in `data.value`) can be used for the sorting operation.
     if D == 1 {
         // 1D sort
         data.value

--- a/crates/burn-tensor/src/tensor/data.rs
+++ b/crates/burn-tensor/src/tensor/data.rs
@@ -518,6 +518,8 @@ impl<E: core::fmt::Debug, const D: usize> core::fmt::Display for Data<E, D> {
 
 #[cfg(test)]
 mod tests {
+    use crate::{AffineQuantization, Quantization};
+
     use super::*;
     use rand::{rngs::StdRng, SeedableRng};
 
@@ -549,6 +551,18 @@ mod tests {
         let data2 = Data::<f32, 2>::from([[3.01, 5.0, 6.0]]);
 
         data1.assert_approx_eq(&data2, 2);
+    }
+
+    #[test]
+    fn should_support_quantization() {
+        let data = Data::<f32, 2>::from([[-1.8, -1.0, 0.0, 0.5]]).with_quantization(
+            QuantizationStrategy::Int8Affine(AffineQuantization::new(-1.8, 0.5)),
+        );
+
+        let expected = Data::<i8, 2>::from([[-128, -39, 72, 127]]);
+
+        assert_eq!(data.value, expected.value);
+        assert_eq!(data.shape, expected.shape);
     }
 
     #[test]

--- a/crates/burn-tensor/src/tensor/data.rs
+++ b/crates/burn-tensor/src/tensor/data.rs
@@ -550,7 +550,7 @@ mod tests {
 
     #[test]
     fn should_support_quantization() {
-        let quant = QuantizationStrategy::Int8Affine(AffineQuantization::new(-1.8, 0.5));
+        let quant = QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::new(-1.8, 0.5));
         let data1 = Data::<f32, 2>::from([[-1.8, -1.0, 0.0, 0.5]]);
         let data2 = data1.clone().with_quantization(quant.clone());
 

--- a/crates/burn-tensor/src/tensor/data.rs
+++ b/crates/burn-tensor/src/tensor/data.rs
@@ -24,7 +24,7 @@ pub struct DataSerialize<E> {
     pub shape: Vec<usize>,
     /// The quantization strategy.
     #[new(value = "None")]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub quantization: Option<QuantizationStrategy>,
 }
 

--- a/crates/burn-tensor/src/tensor/data.rs
+++ b/crates/burn-tensor/src/tensor/data.rs
@@ -148,16 +148,11 @@ impl Distribution {
     }
 }
 
-impl<const D: usize> Data<f32, D> {
-    /// Sets the data quantization strategy and converts the values to a lower precision data type `i8`.
-    pub fn with_quantization(self, quantization: QuantizationStrategy) -> Data<i8, D> {
-        let value = quantization.quantize(&self.value);
-
-        Data {
-            value,
-            shape: self.shape,
-            quantization: Some(quantization),
-        }
+impl<const D: usize, E> Data<E, D> {
+    /// Sets the data quantization strategy.
+    pub fn with_quantization(mut self, quantization: QuantizationStrategy) -> Self {
+        self.quantization = Some(quantization);
+        self
     }
 }
 
@@ -555,14 +550,13 @@ mod tests {
 
     #[test]
     fn should_support_quantization() {
-        let data = Data::<f32, 2>::from([[-1.8, -1.0, 0.0, 0.5]]).with_quantization(
-            QuantizationStrategy::Int8Affine(AffineQuantization::new(-1.8, 0.5)),
-        );
+        let quant = QuantizationStrategy::Int8Affine(AffineQuantization::new(-1.8, 0.5));
+        let data1 = Data::<f32, 2>::from([[-1.8, -1.0, 0.0, 0.5]]);
+        let data2 = data1.clone().with_quantization(quant.clone());
 
-        let expected = Data::<i8, 2>::from([[-128, -39, 72, 127]]);
-
-        assert_eq!(data.value, expected.value);
-        assert_eq!(data.shape, expected.shape);
+        assert_eq!(data1.value, data2.value);
+        assert_eq!(data1.shape, data2.shape);
+        assert_eq!(data2.quantization, Some(quant));
     }
 
     #[test]

--- a/crates/burn-tensor/src/tensor/data.rs
+++ b/crates/burn-tensor/src/tensor/data.rs
@@ -148,10 +148,10 @@ impl Distribution {
     }
 }
 
-impl<const D: usize, E> Data<E, D> {
-    /// Sets the data quantization strategy and converts the values to a lower precision data type `Q`.
-    pub fn with_quantization<Q>(self, quantization: QuantizationStrategy) -> Data<Q, D> {
-        let value = quantization.quantize::<E, Q>(&self.value);
+impl<const D: usize> Data<f32, D> {
+    /// Sets the data quantization strategy and converts the values to a lower precision data type `i8`.
+    pub fn with_quantization(self, quantization: QuantizationStrategy) -> Data<i8, D> {
+        let value = quantization.quantize(&self.value);
 
         Data {
             value,

--- a/crates/burn-tensor/src/tensor/mod.rs
+++ b/crates/burn-tensor/src/tensor/mod.rs
@@ -3,11 +3,13 @@ pub(crate) mod stats;
 mod api;
 mod data;
 mod element;
+mod quantization;
 mod shape;
 
 pub use api::*;
 pub use data::*;
 pub use element::*;
+pub use quantization::*;
 pub use shape::*;
 
 /// The activation module.

--- a/crates/burn-tensor/src/tensor/quantization.rs
+++ b/crates/burn-tensor/src/tensor/quantization.rs
@@ -31,13 +31,13 @@ impl<E: Float, Q: PrimInt, A: PrimInt> Eq for AffineQuantization<E, Q, A> {}
 
 impl<E: Float, Q: PrimInt, A: PrimInt> PartialEq for AffineQuantization<E, Q, A> {
     fn eq(&self, other: &Self) -> bool {
-        match (
-            self.scale.partial_cmp(&other.scale),
-            self.offset.cmp(&other.offset),
-        ) {
-            (Some(Ordering::Equal), Ordering::Equal) => true,
-            _ => false,
-        }
+        matches!(
+            (
+                self.scale.partial_cmp(&other.scale),
+                self.offset.cmp(&other.offset)
+            ),
+            (Some(Ordering::Equal), Ordering::Equal)
+        )
     }
 }
 
@@ -100,10 +100,7 @@ impl<E: Float, Q: PrimInt> Eq for SymmetricQuantization<E, Q> {}
 
 impl<E: Float, Q: PrimInt> PartialEq for SymmetricQuantization<E, Q> {
     fn eq(&self, other: &Self) -> bool {
-        match self.scale.partial_cmp(&other.scale) {
-            Some(Ordering::Equal) => true,
-            _ => false,
-        }
+        matches!(self.scale.partial_cmp(&other.scale), Some(Ordering::Equal))
     }
 }
 

--- a/crates/burn-tensor/src/tensor/quantization.rs
+++ b/crates/burn-tensor/src/tensor/quantization.rs
@@ -116,9 +116,10 @@ impl<E: Float, Q: PrimInt> Quantization<E, Q> for SymmetricQuantization<E, Q> {
         let b = E::from(Q::max_value()).unwrap();
         let a = b.neg();
 
-        // Compute scale to convert a floating point value in range `[alpha, beta]` to the quantized range
+        // Compute scale to convert a floating point value in range `[-alpha, alpha]` to the quantized range
+        let alpha = alpha.abs().max(beta.abs());
         Self {
-            scale: (beta - alpha) / (b - a),
+            scale: (alpha + alpha) / (b - a),
             _q: PhantomData,
         }
     }
@@ -173,6 +174,7 @@ impl QuantizationStrategy {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
     #[test]
     fn test_int8_affine_quantization() {
@@ -193,8 +195,8 @@ mod tests {
     #[test]
     fn test_int8_symmetric_quantization() {
         let x: [f32; 4] = [-1.8, -1.0, 0.0, 0.5];
-        let expected_q = vec![-127, -110, 0, 55];
-        let expected_d = vec![-1.15, -0.996063, 0.0, 0.4980315];
+        let expected_q = vec![-127, -71, 0, 35];
+        let expected_d = vec![-1.8, -1.0062993, 0.0, 0.496063];
 
         let symmetric = QuantizationStrategy::Int8Symmetric(SymmetricQuantization::new(-1.8, 0.5));
 

--- a/crates/burn-tensor/src/tensor/quantization.rs
+++ b/crates/burn-tensor/src/tensor/quantization.rs
@@ -1,5 +1,6 @@
 use core::{cmp::Ordering, marker::PhantomData};
 
+use alloc::vec::Vec;
 use num_traits::{Float, PrimInt};
 use serde::{Deserialize, Serialize};
 

--- a/crates/burn-tensor/src/tensor/quantization.rs
+++ b/crates/burn-tensor/src/tensor/quantization.rs
@@ -1,0 +1,96 @@
+use core::cmp::Ordering;
+
+use serde::{Deserialize, Serialize};
+
+trait Quantization {
+    fn quantize<E, Q>(&self, values: &[E]) -> Vec<Q>;
+    fn dequantize<E, Q>(&self, values: &[Q]) -> Vec<E>;
+}
+
+/// Affine quantization scheme.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AffineQuantization {
+    /// The scaling factor.
+    pub scale: f32,
+    /// The zero-point offset.
+    pub offset: f32,
+}
+
+impl Eq for AffineQuantization {}
+
+impl PartialEq for AffineQuantization {
+    fn eq(&self, other: &Self) -> bool {
+        match (
+            self.scale.total_cmp(&other.scale),
+            self.offset.total_cmp(&other.offset),
+        ) {
+            (Ordering::Equal, Ordering::Equal) => true,
+            _ => false,
+        }
+    }
+}
+
+impl Quantization for AffineQuantization {
+    fn quantize<E, Q>(&self, values: &[E]) -> Vec<Q> {
+        todo!()
+    }
+
+    fn dequantize<E, Q>(&self, values: &[Q]) -> Vec<E> {
+        todo!()
+    }
+}
+
+/// Symmetric quantization scheme.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SymmetricQuantization {
+    /// The scaling factor.
+    pub scale: f32,
+}
+
+impl Eq for SymmetricQuantization {}
+
+impl PartialEq for SymmetricQuantization {
+    fn eq(&self, other: &Self) -> bool {
+        match self.scale.total_cmp(&other.scale) {
+            Ordering::Equal => true,
+            _ => false,
+        }
+    }
+}
+
+impl Quantization for SymmetricQuantization {
+    fn quantize<E, Q>(&self, values: &[E]) -> Vec<Q> {
+        todo!()
+    }
+
+    fn dequantize<E, Q>(&self, values: &[Q]) -> Vec<E> {
+        todo!()
+    }
+}
+
+/// Quantization scheme/strategy.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum QuantizationStrategy {
+    /// Affine/asymmetric quantization.
+    Affine(AffineQuantization),
+    /// Symmetric quantization.
+    Symmetric(SymmetricQuantization),
+}
+
+impl QuantizationStrategy {
+    /// Convert the values to a lower precision data type.
+    pub fn quantize<E, Q>(&self, values: &[E]) -> Vec<Q> {
+        match self {
+            Self::Affine(m) => m.quantize(values),
+            Self::Symmetric(m) => m.quantize(values),
+        }
+    }
+
+    /// Convert the values back to a higher precision data type.
+    pub fn dequantize<E, Q>(&self, values: &[Q]) -> Vec<E> {
+        match self {
+            Self::Affine(m) => m.dequantize(values),
+            Self::Symmetric(m) => m.dequantize(values),
+        }
+    }
+}

--- a/crates/burn-tensor/src/tensor/quantization.rs
+++ b/crates/burn-tensor/src/tensor/quantization.rs
@@ -1,96 +1,210 @@
-use core::cmp::Ordering;
+use core::{cmp::Ordering, marker::PhantomData};
 
+use num_traits::{Float, PrimInt};
 use serde::{Deserialize, Serialize};
 
-trait Quantization {
-    fn quantize<E, Q>(&self, values: &[E]) -> Vec<Q>;
-    fn dequantize<E, Q>(&self, values: &[Q]) -> Vec<E>;
+/// Quantization scheme to convert elements of a higher precision data type `E` to a lower precision
+/// data type `Q` and vice-versa.
+pub trait Quantization<E: Float, Q: PrimInt> {
+    /// Create a new quantization scheme for an input range `[alpha, beta]`.
+    fn new(alpha: E, beta: E) -> Self;
+    /// Convert the values to a lower precision data type.
+    fn quantize(&self, values: &[E]) -> Vec<Q>;
+    /// Convert the values back to a higher precision data type.
+    fn dequantize(&self, values: &[Q]) -> Vec<E>;
 }
 
 /// Affine quantization scheme.
+///
+/// Note that the accumulation type `A` should have a bigger range than quantized type `Q`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AffineQuantization {
+pub struct AffineQuantization<E: Float, Q: PrimInt, A: PrimInt> {
     /// The scaling factor.
-    pub scale: f32,
+    pub scale: E,
     /// The zero-point offset.
-    pub offset: f32,
+    pub offset: Q,
+    /// Accumulation type.
+    _a: PhantomData<A>,
 }
 
-impl Eq for AffineQuantization {}
+impl<E: Float, Q: PrimInt, A: PrimInt> Eq for AffineQuantization<E, Q, A> {}
 
-impl PartialEq for AffineQuantization {
+impl<E: Float, Q: PrimInt, A: PrimInt> PartialEq for AffineQuantization<E, Q, A> {
     fn eq(&self, other: &Self) -> bool {
         match (
-            self.scale.total_cmp(&other.scale),
-            self.offset.total_cmp(&other.offset),
+            self.scale.partial_cmp(&other.scale),
+            self.offset.cmp(&other.offset),
         ) {
-            (Ordering::Equal, Ordering::Equal) => true,
+            (Some(Ordering::Equal), Ordering::Equal) => true,
             _ => false,
         }
     }
 }
 
-impl Quantization for AffineQuantization {
-    fn quantize<E, Q>(&self, values: &[E]) -> Vec<Q> {
-        todo!()
+impl<E: Float, Q: PrimInt, A: PrimInt> Quantization<E, Q> for AffineQuantization<E, Q, A> {
+    fn new(alpha: E, beta: E) -> Self {
+        // Q range `[a, b]`
+        let a = E::from(Q::min_value()).unwrap();
+        let b = E::from(Q::max_value()).unwrap();
+
+        // Compute scale and offset to convert a floating point value in range `[alpha, beta]` to the quantized range
+        let range = beta - alpha;
+        Self {
+            scale: range / (b - a),
+            offset: Q::from(E::round(((beta * a) - (alpha * b)) / range)).unwrap(),
+            _a: PhantomData,
+        }
     }
 
-    fn dequantize<E, Q>(&self, values: &[Q]) -> Vec<E> {
-        todo!()
+    fn quantize(&self, values: &[E]) -> Vec<Q> {
+        // Quantized range `[a, b]`
+        let a = E::from(Q::min_value()).unwrap();
+        let b = E::from(Q::max_value()).unwrap();
+
+        // x_q = clamp(round(x / scale + offset), a, b)
+        let z = E::from(self.offset).unwrap();
+        values
+            .iter()
+            .map(|x| Q::from(x.div(self.scale).add(z).round().clamp(a, b)).unwrap())
+            .collect()
+    }
+
+    fn dequantize(&self, values: &[Q]) -> Vec<E> {
+        // x = scale * (x_q - offset)
+        values
+            .iter()
+            .map(|x_q| {
+                self.scale
+                    * (E::from(
+                        A::from(*x_q)
+                            .unwrap()
+                            .saturating_sub(A::from(self.offset).unwrap()),
+                    )
+                    .unwrap())
+            })
+            .collect()
     }
 }
 
 /// Symmetric quantization scheme.
+///
+/// Note that symmetric quantization is only valid for signed integers.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SymmetricQuantization {
+pub struct SymmetricQuantization<E: Float, Q: PrimInt> {
     /// The scaling factor.
-    pub scale: f32,
+    pub scale: E,
+    _q: PhantomData<Q>,
 }
 
-impl Eq for SymmetricQuantization {}
+impl<E: Float, Q: PrimInt> Eq for SymmetricQuantization<E, Q> {}
 
-impl PartialEq for SymmetricQuantization {
+impl<E: Float, Q: PrimInt> PartialEq for SymmetricQuantization<E, Q> {
     fn eq(&self, other: &Self) -> bool {
-        match self.scale.total_cmp(&other.scale) {
-            Ordering::Equal => true,
+        match self.scale.partial_cmp(&other.scale) {
+            Some(Ordering::Equal) => true,
             _ => false,
         }
     }
 }
 
-impl Quantization for SymmetricQuantization {
-    fn quantize<E, Q>(&self, values: &[E]) -> Vec<Q> {
-        todo!()
+impl<E: Float, Q: PrimInt> Quantization<E, Q> for SymmetricQuantization<E, Q> {
+    fn new(alpha: E, beta: E) -> Self {
+        assert!(
+            !Q::min_value().is_zero(),
+            "Symmetric quantization is only valid for signed integers."
+        );
+
+        // Quantized range `[a, b]`
+        let b = E::from(Q::max_value()).unwrap();
+        let a = b.neg();
+
+        // Compute scale to convert a floating point value in range `[alpha, beta]` to the quantized range
+        Self {
+            scale: (beta - alpha) / (b - a),
+            _q: PhantomData,
+        }
+    }
+    fn quantize(&self, values: &[E]) -> Vec<Q> {
+        // Quantized range [a, b]
+        let b = E::from(Q::max_value()).unwrap();
+        let a = b.neg();
+
+        // x_q = clamp(round(x / scale), a, b)
+        values
+            .iter()
+            .map(|x| Q::from(x.div(self.scale).round().clamp(a, b)).unwrap())
+            .collect()
     }
 
-    fn dequantize<E, Q>(&self, values: &[Q]) -> Vec<E> {
-        todo!()
+    fn dequantize(&self, values: &[Q]) -> Vec<E> {
+        // x = scale * x_q
+        values
+            .iter()
+            .map(|x_q| self.scale * E::from(*x_q).unwrap())
+            .collect()
     }
 }
 
 /// Quantization scheme/strategy.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum QuantizationStrategy {
-    /// Affine/asymmetric quantization.
-    Affine(AffineQuantization),
-    /// Symmetric quantization.
-    Symmetric(SymmetricQuantization),
+    /// `int8` affine/asymmetric quantization.
+    Int8Affine(AffineQuantization<f32, i8, i32>),
+    /// `int8` symmetric quantization.
+    Int8Symmetric(SymmetricQuantization<f32, i8>),
 }
 
 impl QuantizationStrategy {
     /// Convert the values to a lower precision data type.
-    pub fn quantize<E, Q>(&self, values: &[E]) -> Vec<Q> {
+    pub fn quantize(&self, values: &[f32]) -> Vec<i8> {
         match self {
-            Self::Affine(m) => m.quantize(values),
-            Self::Symmetric(m) => m.quantize(values),
+            Self::Int8Affine(m) => m.quantize(values),
+            Self::Int8Symmetric(m) => m.quantize(values),
         }
     }
 
     /// Convert the values back to a higher precision data type.
-    pub fn dequantize<E, Q>(&self, values: &[Q]) -> Vec<E> {
+    pub fn dequantize(&self, values: &[i8]) -> Vec<f32> {
         match self {
-            Self::Affine(m) => m.dequantize(values),
-            Self::Symmetric(m) => m.dequantize(values),
+            Self::Int8Affine(m) => m.dequantize(values),
+            Self::Int8Symmetric(m) => m.dequantize(values),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_int8_affine_quantization() {
+        let x: [f32; 4] = [-1.8, -1.0, 0.0, 0.5];
+        let expected_q = vec![-128, -39, 72, 127];
+        let expected_d = vec![-1.8039216, -1.0011765, 0.0, 0.49607843];
+
+        let affine = QuantizationStrategy::Int8Affine(AffineQuantization::new(-1.8, 0.5));
+
+        let q = affine.quantize(&x);
+        assert_eq!(q, expected_q);
+
+        let d = affine.dequantize(&expected_q);
+
+        assert_eq!(d, expected_d);
+    }
+
+    #[test]
+    fn test_int8_symmetric_quantization() {
+        let x: [f32; 4] = [-1.8, -1.0, 0.0, 0.5];
+        let expected_q = vec![-127, -110, 0, 55];
+        let expected_d = vec![-1.15, -0.996063, 0.0, 0.4980315];
+
+        let symmetric = QuantizationStrategy::Int8Symmetric(SymmetricQuantization::new(-1.8, 0.5));
+
+        let q = symmetric.quantize(&x);
+        assert_eq!(q, expected_q);
+
+        let d = symmetric.dequantize(&expected_q);
+
+        assert_eq!(d, expected_d);
     }
 }

--- a/crates/burn-tensor/src/tensor/quantization.rs
+++ b/crates/burn-tensor/src/tensor/quantization.rs
@@ -147,26 +147,26 @@ impl<E: Float, Q: PrimInt> Quantization<E, Q> for SymmetricQuantization<E, Q> {
 /// Quantization scheme/strategy.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum QuantizationStrategy {
-    /// `int8` affine/asymmetric quantization.
-    Int8Affine(AffineQuantization<f32, i8, i32>),
-    /// `int8` symmetric quantization.
-    Int8Symmetric(SymmetricQuantization<f32, i8>),
+    /// Per-tensor `int8` affine/asymmetric quantization.
+    PerTensorAffineInt8(AffineQuantization<f32, i8, i32>),
+    /// Per-tensor `int8` symmetric quantization.
+    PerTensorSymmetricInt8(SymmetricQuantization<f32, i8>),
 }
 
 impl QuantizationStrategy {
     /// Convert the values to a lower precision data type.
     pub fn quantize(&self, values: &[f32]) -> Vec<i8> {
         match self {
-            Self::Int8Affine(m) => m.quantize(values),
-            Self::Int8Symmetric(m) => m.quantize(values),
+            Self::PerTensorAffineInt8(m) => m.quantize(values),
+            Self::PerTensorSymmetricInt8(m) => m.quantize(values),
         }
     }
 
     /// Convert the values back to a higher precision data type.
     pub fn dequantize(&self, values: &[i8]) -> Vec<f32> {
         match self {
-            Self::Int8Affine(m) => m.dequantize(values),
-            Self::Int8Symmetric(m) => m.dequantize(values),
+            Self::PerTensorAffineInt8(m) => m.dequantize(values),
+            Self::PerTensorSymmetricInt8(m) => m.dequantize(values),
         }
     }
 }
@@ -182,7 +182,7 @@ mod tests {
         let expected_q = vec![-128, -39, 72, 127];
         let expected_d = vec![-1.8039216, -1.0011765, 0.0, 0.49607843];
 
-        let affine = QuantizationStrategy::Int8Affine(AffineQuantization::new(-1.8, 0.5));
+        let affine = QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::new(-1.8, 0.5));
 
         let q = affine.quantize(&x);
         assert_eq!(q, expected_q);
@@ -198,7 +198,8 @@ mod tests {
         let expected_q = vec![-127, -71, 0, 35];
         let expected_d = vec![-1.8, -1.0062993, 0.0, 0.496063];
 
-        let symmetric = QuantizationStrategy::Int8Symmetric(SymmetricQuantization::new(-1.8, 0.5));
+        let symmetric =
+            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::new(-1.8, 0.5));
 
         let q = symmetric.quantize(&x);
         assert_eq!(q, expected_q);


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.

### Related Issues/PRs

Progress towards #464 

### Changes

*Note: the changes in this PR add support for **per-tensor** quantization (one set of quantization params per tensor, as opposed to per-channel quantization where there are multiple sets of quantization params per tensor, i.e. one per channel in the tensor). Other quantization schemes can be added to the enum in the future.*

- Added `QuantizationStrategy` enum and `Quantization` trait w/ concrete implementations for affine and asymmetric
  - Added `Option<QuantizationStrategy>` to `Data` and `DataSerialize` which defaults to none
  - Added `data.with_quantization(...)` method
- Added `Int8PrecisionSettings`

#### :warning: Breaking :warning:
Binary record formats (`BinFileRecorder` and `BinGzFileRecorder`) are not backward compatible.  
Other self-describing formats are ok as the `Option<QuantizationStrategy>` will deserialize to `None` by default.

### Testing

Added unit tests for affine and symmetric int8 quantization

### References

- https://leimao.github.io/article/Neural-Networks-Quantization/
- https://apple.github.io/coremltools/docs-guides/source/quantization-overview.html
