### PR TITLE
Get resources from server

### DIFF
--- a/crates/burn-compute/src/channel/base.rs
+++ b/crates/burn-compute/src/channel/base.rs
@@ -1,4 +1,7 @@
-use crate::server::{Binding, ComputeServer, Handle};
+use crate::{
+    server::{Binding, ComputeServer, Handle},
+    storage::ComputeStorage,
+};
 use alloc::vec::Vec;
 use burn_common::reader::Reader;
 
@@ -7,6 +10,12 @@ use burn_common::reader::Reader;
 pub trait ComputeChannel<Server: ComputeServer>: Clone + core::fmt::Debug + Send + Sync {
     /// Given a binding, returns owned resource as bytes
     fn read(&self, binding: Binding<Server>) -> Reader<Vec<u8>>;
+
+    /// Given a resource handle, return the storage resource.
+    fn get_resource(
+        &self,
+        binding: Binding<Server>,
+    ) -> <Server::Storage as ComputeStorage>::Resource;
 
     /// Given a resource as bytes, stores it and returns the resource handle
     fn create(&self, data: &[u8]) -> Handle<Server>;

--- a/crates/burn-compute/src/channel/cell.rs
+++ b/crates/burn-compute/src/channel/cell.rs
@@ -1,5 +1,6 @@
 use super::ComputeChannel;
 use crate::server::{Binding, ComputeServer, Handle};
+use crate::storage::ComputeStorage;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use burn_common::reader::Reader;
@@ -44,6 +45,13 @@ where
 {
     fn read(&self, binding: Binding<Server>) -> Reader<Vec<u8>> {
         self.server.borrow_mut().read(binding)
+    }
+
+    fn get_resource(
+        &self,
+        binding: Binding<Server>,
+    ) -> <Server::Storage as ComputeStorage>::Resource {
+        self.server.borrow_mut().get_resource(binding)
     }
 
     fn create(&self, resource: &[u8]) -> Handle<Server> {

--- a/crates/burn-compute/src/channel/mpsc.rs
+++ b/crates/burn-compute/src/channel/mpsc.rs
@@ -37,7 +37,7 @@ where
     Server: ComputeServer,
 {
     Read(Binding<Server>, Callback<Reader<Vec<u8>>>),
-    ReadResource(
+    GetResource(
         Binding<Server>,
         Callback<<Server::Storage as ComputeStorage>::Resource>,
     ),
@@ -62,7 +62,7 @@ where
                         let data = server.read(binding);
                         callback.send(data).unwrap();
                     }
-                    Message::ReadResource(binding, callback) => {
+                    Message::GetResource(binding, callback) => {
                         let data = server.get_resource(binding);
                         callback.send(data).unwrap();
                     }
@@ -122,7 +122,7 @@ where
 
         self.state
             .sender
-            .send(Message::ReadResource(binding, callback))
+            .send(Message::GetResource(binding, callback))
             .unwrap();
 
         self.response(response)

--- a/crates/burn-compute/src/channel/mpsc.rs
+++ b/crates/burn-compute/src/channel/mpsc.rs
@@ -6,7 +6,10 @@ use std::{
 use burn_common::reader::Reader;
 
 use super::ComputeChannel;
-use crate::server::{Binding, ComputeServer, Handle};
+use crate::{
+    server::{Binding, ComputeServer, Handle},
+    storage::ComputeStorage,
+};
 
 /// Create a channel using the [multi-producer, single-consumer channel](mpsc) to communicate with
 /// the compute server spawn on its own thread.
@@ -34,6 +37,10 @@ where
     Server: ComputeServer,
 {
     Read(Binding<Server>, Callback<Reader<Vec<u8>>>),
+    ReadResource(
+        Binding<Server>,
+        Callback<<Server::Storage as ComputeStorage>::Resource>,
+    ),
     Create(Vec<u8>, Callback<Handle<Server>>),
     Empty(usize, Callback<Handle<Server>>),
     ExecuteKernel(Server::Kernel, Vec<Binding<Server>>),
@@ -53,6 +60,10 @@ where
                 match message {
                     Message::Read(binding, callback) => {
                         let data = server.read(binding);
+                        callback.send(data).unwrap();
+                    }
+                    Message::ReadResource(binding, callback) => {
+                        let data = server.get_resource(binding);
                         callback.send(data).unwrap();
                     }
                     Message::Create(data, callback) => {
@@ -98,6 +109,20 @@ where
         self.state
             .sender
             .send(Message::Read(binding, callback))
+            .unwrap();
+
+        self.response(response)
+    }
+
+    fn get_resource(
+        &self,
+        binding: Binding<Server>,
+    ) -> <Server::Storage as ComputeStorage>::Resource {
+        let (callback, response) = mpsc::channel();
+
+        self.state
+            .sender
+            .send(Message::ReadResource(binding, callback))
             .unwrap();
 
         self.response(response)

--- a/crates/burn-compute/src/channel/mutex.rs
+++ b/crates/burn-compute/src/channel/mutex.rs
@@ -1,5 +1,6 @@
 use super::ComputeChannel;
 use crate::server::{Binding, ComputeServer, Handle};
+use crate::storage::ComputeStorage;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use burn_common::reader::Reader;
@@ -37,6 +38,13 @@ where
 {
     fn read(&self, handle: Binding<Server>) -> Reader<Vec<u8>> {
         self.server.lock().read(handle)
+    }
+
+    fn get_resource(
+        &self,
+        binding: Binding<Server>,
+    ) -> <Server::Storage as ComputeStorage>::Resource {
+        self.server.lock().get_resource(binding)
     }
 
     fn create(&self, data: &[u8]) -> Handle<Server> {

--- a/crates/burn-compute/src/client.rs
+++ b/crates/burn-compute/src/client.rs
@@ -1,6 +1,7 @@
 use crate::{
     channel::ComputeChannel,
     server::{Binding, ComputeServer, Handle},
+    storage::ComputeStorage,
     tune::{AutotuneOperationSet, Tuner},
 };
 use alloc::vec::Vec;
@@ -42,6 +43,14 @@ where
     /// Given a binding, returns owned resource as bytes.
     pub fn read(&self, binding: Binding<Server>) -> Reader<Vec<u8>> {
         self.channel.read(binding)
+    }
+
+    /// Given a resource handle, returns the storage resource.
+    pub fn get_resource(
+        &self,
+        binding: Binding<Server>,
+    ) -> <Server::Storage as ComputeStorage>::Resource {
+        self.channel.get_resource(binding)
     }
 
     /// Given a resource, stores it and returns the resource handle.

--- a/crates/burn-compute/src/server.rs
+++ b/crates/burn-compute/src/server.rs
@@ -27,6 +27,12 @@ where
     /// Given a handle, returns the owned resource as bytes.
     fn read(&mut self, binding: Binding<Self>) -> Reader<Vec<u8>>;
 
+    /// Given a resource handle, returns the storage resource.
+    fn get_resource(
+        &mut self,
+        binding: Binding<Self>,
+    ) -> <Self::Storage as ComputeStorage>::Resource;
+
     /// Given a resource as bytes, stores it and returns the memory handle.
     fn create(&mut self, data: &[u8]) -> Handle<Self>;
 

--- a/crates/burn-compute/tests/dummy/server.rs
+++ b/crates/burn-compute/tests/dummy/server.rs
@@ -2,10 +2,9 @@ use std::sync::Arc;
 
 use burn_common::reader::Reader;
 use burn_compute::{
-    memory_management::simple::SimpleMemoryManagement,
-    memory_management::{MemoryHandle, MemoryManagement},
+    memory_management::{simple::SimpleMemoryManagement, MemoryHandle, MemoryManagement},
     server::{Binding, ComputeServer, Handle},
-    storage::BytesStorage,
+    storage::{BytesResource, BytesStorage},
 };
 use derive_new::new;
 
@@ -31,6 +30,10 @@ where
         let bytes = self.memory_management.get(binding.memory);
 
         Reader::Concrete(bytes.read().to_vec())
+    }
+
+    fn get_resource(&mut self, binding: Binding<Self>) -> BytesResource {
+        self.memory_management.get(binding.memory)
     }
 
     fn create(&mut self, data: &[u8]) -> Handle<Self> {

--- a/crates/burn-cuda/src/compute/server.rs
+++ b/crates/burn-cuda/src/compute/server.rs
@@ -114,6 +114,14 @@ impl<MM: MemoryManagement<CudaStorage>> ComputeServer for CudaServer<MM> {
         let ctx = self.get_context();
         ctx.sync();
     }
+
+    fn get_resource(
+        &mut self,
+        binding: server::Binding<Self>,
+    ) -> <Self::Storage as burn_compute::storage::ComputeStorage>::Resource {
+        let ctx = self.get_context();
+        ctx.memory_management.get(binding.memory)
+    }
 }
 
 impl<MM: MemoryManagement<CudaStorage>> CudaContext<MM> {

--- a/crates/burn-wgpu/src/compute/server.rs
+++ b/crates/burn-wgpu/src/compute/server.rs
@@ -205,6 +205,13 @@ where
         Reader::Concrete(self.buffer_reader(binding).read(&self.device))
     }
 
+    fn get_resource(
+        &mut self,
+        binding: server::Binding<Self>,
+    ) -> <Self::Storage as burn_compute::storage::ComputeStorage>::Resource {
+        self.memory_management.get(binding.memory)
+    }
+
     /// When we create a new handle from existing data, we use custom allocations so that we don't
     /// have to execute the current pending tasks.
     ///


### PR DESCRIPTION
I'm working towards mixing custom WGPU commands & Burn operations.

Now that you can init from an[ existing WGPU device](https://github.com/tracel-ai/burn/commit/e0a1094f894e83f30e04a661d5513cdaa76dbb50), a next step is allowing to get handles to the underlying WGPU resource of a buffer. This *has* to be used with care, but could allow mixing any kind of custom wgpu commands.

One question is - is it better to have a method get_resources(Vec<Binding) -> Vec<Resource> ? That could prevent some synchronization traffic. On the other hand it's a bit more complicated to use and wastes a vector allocation when asking for a single resource, not sure!

Another question could be - read_resource vs get_resource, not sure which is better either :)

After this PR, the one remaining issue is how to synchronize burn - something like client.submit() (client.sync() works but is slower than need be).