### PR TITLE
Add option to flush queue instead of waiting for completion.

### DIFF
--- a/backend-comparison/benches/autodiff.rs
+++ b/backend-comparison/benches/autodiff.rs
@@ -7,7 +7,10 @@ use burn::{
         Distribution, Tensor,
     },
 };
-use burn_common::benchmark::{run_benchmark, Benchmark};
+use burn_common::{
+    benchmark::{run_benchmark, Benchmark},
+    sync_type::SyncType,
+};
 
 pub struct AutodiffOverheadBenchmark<B: AutodiffBackend> {
     config: nn::LstmConfig,
@@ -47,7 +50,7 @@ impl<B: AutodiffBackend> Benchmark for AutodiffOverheadBenchmark<B> {
     }
 
     fn sync(&self) {
-        B::sync(&self.device)
+        B::sync(&self.device, SyncType::Wait)
     }
 }
 

--- a/backend-comparison/benches/binary.rs
+++ b/backend-comparison/benches/binary.rs
@@ -1,6 +1,9 @@
 use backend_comparison::persistence::save;
 use burn::tensor::{backend::Backend, Distribution, Shape, Tensor};
-use burn_common::benchmark::{run_benchmark, Benchmark};
+use burn_common::{
+    benchmark::{run_benchmark, Benchmark},
+    sync_type::SyncType,
+};
 
 pub struct BinaryBenchmark<B: Backend, const D: usize> {
     shape: Shape<D>,
@@ -31,7 +34,7 @@ impl<B: Backend, const D: usize> Benchmark for BinaryBenchmark<B, D> {
     }
 
     fn sync(&self) {
-        B::sync(&self.device)
+        B::sync(&self.device, SyncType::Wait);
     }
 }
 

--- a/backend-comparison/benches/conv2d.rs
+++ b/backend-comparison/benches/conv2d.rs
@@ -2,7 +2,10 @@ use backend_comparison::persistence::save;
 use burn::tensor::{
     backend::Backend, module::conv2d, ops::ConvOptions, Distribution, Shape, Tensor,
 };
-use burn_common::benchmark::{run_benchmark, Benchmark};
+use burn_common::{
+    benchmark::{run_benchmark, Benchmark},
+    sync_type::SyncType,
+};
 
 pub struct Conv2dBenchmark<B: Backend> {
     input_shape: Shape<4>,
@@ -48,7 +51,7 @@ impl<B: Backend> Benchmark for Conv2dBenchmark<B> {
     }
 
     fn sync(&self) {
-        B::sync(&self.device)
+        B::sync(&self.device, SyncType::Wait)
     }
 }
 

--- a/backend-comparison/benches/conv_transpose2d.rs
+++ b/backend-comparison/benches/conv_transpose2d.rs
@@ -3,7 +3,10 @@ use burn::tensor::{
     backend::Backend, module::conv_transpose2d, ops::ConvTransposeOptions, Distribution, Shape,
     Tensor,
 };
-use burn_common::benchmark::{run_benchmark, Benchmark};
+use burn_common::{
+    benchmark::{run_benchmark, Benchmark},
+    sync_type::SyncType,
+};
 
 pub struct ConvTranspose2dBenchmark<B: Backend> {
     input_shape: Shape<4>,
@@ -49,7 +52,7 @@ impl<B: Backend> Benchmark for ConvTranspose2dBenchmark<B> {
     }
 
     fn sync(&self) {
-        B::sync(&self.device)
+        B::sync(&self.device, SyncType::Wait)
     }
 }
 

--- a/backend-comparison/benches/custom_gelu.rs
+++ b/backend-comparison/benches/custom_gelu.rs
@@ -2,6 +2,7 @@ use backend_comparison::persistence::save;
 use burn::backend::Autodiff;
 use burn::tensor::{backend::Backend, Distribution, Shape, Tensor};
 use burn_common::benchmark::{run_benchmark, Benchmark};
+use burn_common::sync_type::SyncType;
 use core::f64::consts::SQRT_2;
 use derive_new::new;
 
@@ -68,7 +69,7 @@ impl<B: Backend, const D: usize> Benchmark for CustomGeluBenchmark<B, D> {
     }
 
     fn sync(&self) {
-        B::sync(&self.device)
+        B::sync(&self.device, SyncType::Wait)
     }
 
     fn num_samples(&self) -> usize {

--- a/backend-comparison/benches/data.rs
+++ b/backend-comparison/benches/data.rs
@@ -1,6 +1,9 @@
 use backend_comparison::persistence::save;
 use burn::tensor::{backend::Backend, Data, Distribution, Shape, Tensor};
-use burn_common::benchmark::{run_benchmark, Benchmark};
+use burn_common::{
+    benchmark::{run_benchmark, Benchmark},
+    sync_type::SyncType,
+};
 use derive_new::new;
 
 #[derive(new)]
@@ -29,7 +32,7 @@ impl<B: Backend, const D: usize> Benchmark for ToDataBenchmark<B, D> {
     }
 
     fn sync(&self) {
-        B::sync(&self.device)
+        B::sync(&self.device, SyncType::Wait)
     }
 }
 
@@ -66,7 +69,7 @@ impl<B: Backend, const D: usize> Benchmark for FromDataBenchmark<B, D> {
     }
 
     fn sync(&self) {
-        B::sync(&self.device)
+        B::sync(&self.device, SyncType::Wait)
     }
 }
 

--- a/backend-comparison/benches/load_record.rs
+++ b/backend-comparison/benches/load_record.rs
@@ -3,6 +3,7 @@ use burn::tensor::backend::Backend;
 use burn::tensor::Device;
 use burn::{config::Config, module::Module, nn};
 use burn_common::benchmark::{run_benchmark, Benchmark};
+use burn_common::sync_type::SyncType;
 use derive_new::new;
 
 #[derive(Module, Debug)]
@@ -93,7 +94,7 @@ impl<B: Backend> Benchmark for LoadRecordBenchmark<B> {
     }
 
     fn sync(&self) {
-        B::sync(&self.device)
+        B::sync(&self.device, SyncType::Wait)
     }
 }
 

--- a/backend-comparison/benches/matmul.rs
+++ b/backend-comparison/benches/matmul.rs
@@ -1,6 +1,9 @@
 use backend_comparison::persistence::save;
 use burn::tensor::{backend::Backend, Distribution, Shape, Tensor};
-use burn_common::benchmark::{run_benchmark, Benchmark};
+use burn_common::{
+    benchmark::{run_benchmark, Benchmark},
+    sync_type::SyncType,
+};
 use derive_new::new;
 
 #[derive(new)]
@@ -37,7 +40,7 @@ impl<B: Backend, const D: usize> Benchmark for MatmulBenchmark<B, D> {
     }
 
     fn sync(&self) {
-        B::sync(&self.device)
+        B::sync(&self.device, SyncType::Wait)
     }
 }
 

--- a/backend-comparison/benches/max_pool2d.rs
+++ b/backend-comparison/benches/max_pool2d.rs
@@ -1,6 +1,9 @@
 use backend_comparison::persistence::save;
 use burn::tensor::{backend::Backend, module::max_pool2d, Distribution, Shape, Tensor};
-use burn_common::benchmark::{run_benchmark, Benchmark};
+use burn_common::{
+    benchmark::{run_benchmark, Benchmark},
+    sync_type::SyncType,
+};
 
 pub struct MaxPool2dBenchmark<B: Backend> {
     shape: Shape<4>,
@@ -37,7 +40,7 @@ impl<B: Backend> Benchmark for MaxPool2dBenchmark<B> {
     }
 
     fn sync(&self) {
-        B::sync(&self.device)
+        B::sync(&self.device, SyncType::Wait)
     }
 }
 

--- a/backend-comparison/benches/unary.rs
+++ b/backend-comparison/benches/unary.rs
@@ -1,6 +1,9 @@
 use backend_comparison::persistence::save;
 use burn::tensor::{backend::Backend, Distribution, Shape, Tensor};
-use burn_common::benchmark::{run_benchmark, Benchmark};
+use burn_common::{
+    benchmark::{run_benchmark, Benchmark},
+    sync_type::SyncType,
+};
 use derive_new::new;
 
 #[derive(new)]
@@ -30,7 +33,7 @@ impl<B: Backend, const D: usize> Benchmark for UnaryBenchmark<B, D> {
     }
 
     fn sync(&self) {
-        B::sync(&self.device)
+        B::sync(&self.device, SyncType::Wait)
     }
 }
 

--- a/crates/burn-autodiff/src/backend.rs
+++ b/crates/burn-autodiff/src/backend.rs
@@ -5,6 +5,7 @@ use crate::{
     tensor::AutodiffTensor,
     AutodiffBridge,
 };
+use burn_common::sync_type::SyncType;
 use burn_tensor::backend::{AutodiffBackend, Backend};
 use core::marker::PhantomData;
 
@@ -43,8 +44,8 @@ impl<B: Backend, C: CheckpointStrategy> Backend for Autodiff<B, C> {
         B::seed(seed)
     }
 
-    fn sync(device: &B::Device) {
-        B::sync(device);
+    fn sync(device: &B::Device, sync_type: SyncType) {
+        B::sync(device, sync_type)
     }
 }
 

--- a/crates/burn-candle/src/backend.rs
+++ b/crates/burn-candle/src/backend.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use burn_tensor::{
-    backend::{Backend, DeviceId, DeviceOps},
+    backend::{Backend, DeviceId, DeviceOps, SyncType},
     Device,
 };
 use candle_core::DeviceLocation;
@@ -105,20 +105,25 @@ impl<F: FloatCandleElement, I: IntCandleElement> Backend for Candle<F, I> {
         panic!("Manual seed not supported by Candle. ")
     }
 
-    fn sync(device: &Device<Self>) {
-        let device: candle_core::Device = (*device).into();
+    fn sync(device: &Device<Self>, sync_type: SyncType) {
+        match sync_type {
+            SyncType::Wait => {
+                let device: candle_core::Device = (*device).into();
 
-        match device {
-            candle_core::Device::Cpu => (),
-            candle_core::Device::Cuda(device) => {
-                #[cfg(feature = "cuda")]
-                device.synchronize().unwrap();
+                match device {
+                    candle_core::Device::Cpu => (),
+                    candle_core::Device::Cuda(device) => {
+                        #[cfg(feature = "cuda")]
+                        device.synchronize().unwrap();
+                    }
+                    candle_core::Device::Metal(device) => {
+                        // For some reason, device.wait_until_completed() does not seem to work,
+                        // and neither does writing and reading a value with into_data
+                        panic!("Device synchronization unavailable with Metal device on Candle backend")
+                    }
+                }
             }
-            candle_core::Device::Metal(device) => {
-                // For some reason, device.wait_until_completed() does not seem to work,
-                // and neither does writing and reading a value with into_data
-                panic!("Device synchronization unavailable with Metal device on Candle backend")
-            }
-        }
+            SyncType::Flush => (), // Nothhing to flush.
+        };
     }
 }

--- a/crates/burn-common/src/lib.rs
+++ b/crates/burn-common/src/lib.rs
@@ -25,6 +25,9 @@ pub mod benchmark;
 /// notation.
 pub mod reader;
 
+/// Synchronization type module, used both by ComputeServer and Backends.
+pub mod sync_type;
+
 extern crate alloc;
 
 /// Network utilities.

--- a/crates/burn-common/src/sync_type.rs
+++ b/crates/burn-common/src/sync_type.rs
@@ -1,0 +1,8 @@
+/// What kind of synchronization to use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncType {
+    /// Submit all outstanding tasks to the task queue if any.
+    Flush,
+    /// Submit all tasks to the task queue and wait for all of them to complete.
+    Wait,
+}

--- a/crates/burn-compute/src/channel/base.rs
+++ b/crates/burn-compute/src/channel/base.rs
@@ -26,6 +26,9 @@ pub trait ComputeChannel<Server: ComputeServer>: Clone + core::fmt::Debug + Send
     /// Executes the `kernel` over the given `bindings`.
     fn execute(&self, kernel: Server::Kernel, bindings: Vec<Binding<Server>>);
 
+    /// Submit the current queued tasks to the server.
+    fn submit(&self);
+
     /// Wait for the completion of every task in the server.
     fn sync(&self);
 }

--- a/crates/burn-compute/src/channel/base.rs
+++ b/crates/burn-compute/src/channel/base.rs
@@ -3,7 +3,7 @@ use crate::{
     storage::ComputeStorage,
 };
 use alloc::vec::Vec;
-use burn_common::reader::Reader;
+use burn_common::{reader::Reader, sync_type::SyncType};
 
 /// The ComputeChannel trait links the ComputeClient to the ComputeServer
 /// while ensuring thread-safety
@@ -26,9 +26,6 @@ pub trait ComputeChannel<Server: ComputeServer>: Clone + core::fmt::Debug + Send
     /// Executes the `kernel` over the given `bindings`.
     fn execute(&self, kernel: Server::Kernel, bindings: Vec<Binding<Server>>);
 
-    /// Submit the current queued tasks to the server.
-    fn submit(&self);
-
-    /// Wait for the completion of every task in the server.
-    fn sync(&self);
+    /// Perform some synchronization of commands on the server.
+    fn sync(&self, sync_type: SyncType);
 }

--- a/crates/burn-compute/src/channel/cell.rs
+++ b/crates/burn-compute/src/channel/cell.rs
@@ -68,6 +68,10 @@ where
             .execute(kernel_description, bindings)
     }
 
+    fn submit(&self) {
+        self.server.borrow_mut().submit()
+    }
+
     fn sync(&self) {
         self.server.borrow_mut().sync()
     }

--- a/crates/burn-compute/src/channel/cell.rs
+++ b/crates/burn-compute/src/channel/cell.rs
@@ -4,6 +4,7 @@ use crate::storage::ComputeStorage;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use burn_common::reader::Reader;
+use burn_common::sync_type::SyncType;
 
 /// A channel using a [ref cell](core::cell::RefCell) to access the server with mutability.
 ///
@@ -68,12 +69,8 @@ where
             .execute(kernel_description, bindings)
     }
 
-    fn submit(&self) {
-        self.server.borrow_mut().submit()
-    }
-
-    fn sync(&self) {
-        self.server.borrow_mut().sync()
+    fn sync(&self, sync_type: SyncType) {
+        self.server.borrow_mut().sync(sync_type)
     }
 }
 

--- a/crates/burn-compute/src/channel/mpsc.rs
+++ b/crates/burn-compute/src/channel/mpsc.rs
@@ -44,6 +44,7 @@ where
     Create(Vec<u8>, Callback<Handle<Server>>),
     Empty(usize, Callback<Handle<Server>>),
     ExecuteKernel(Server::Kernel, Vec<Binding<Server>>),
+    Submit(Callback<()>),
     Sync(Callback<()>),
 }
 
@@ -79,6 +80,10 @@ where
                     }
                     Message::Sync(callback) => {
                         server.sync();
+                        callback.send(()).unwrap();
+                    }
+                    Message::Submit(callback) => {
+                        server.submit();
                         callback.send(()).unwrap();
                     }
                 };
@@ -159,9 +164,13 @@ where
 
     fn sync(&self) {
         let (callback, response) = mpsc::channel();
-
         self.state.sender.send(Message::Sync(callback)).unwrap();
+        self.response(response)
+    }
 
+    fn submit(&self) {
+        let (callback, response) = mpsc::channel();
+        self.state.sender.send(Message::Submit(callback)).unwrap();
         self.response(response)
     }
 }

--- a/crates/burn-compute/src/channel/mutex.rs
+++ b/crates/burn-compute/src/channel/mutex.rs
@@ -4,6 +4,7 @@ use crate::storage::ComputeStorage;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use burn_common::reader::Reader;
+use burn_common::sync_type::SyncType;
 use spin::Mutex;
 
 /// The MutexComputeChannel ensures thread-safety by locking the server
@@ -59,11 +60,7 @@ where
         self.server.lock().execute(kernel, handles)
     }
 
-    fn submit(&self) {
-        self.server.lock().submit()
-    }
-
-    fn sync(&self) {
-        self.server.lock().sync()
+    fn sync(&self, sync_type: SyncType) {
+        self.server.lock().sync(sync_type)
     }
 }

--- a/crates/burn-compute/src/channel/mutex.rs
+++ b/crates/burn-compute/src/channel/mutex.rs
@@ -59,6 +59,10 @@ where
         self.server.lock().execute(kernel, handles)
     }
 
+    fn submit(&self) {
+        self.server.lock().submit()
+    }
+
     fn sync(&self) {
         self.server.lock().sync()
     }

--- a/crates/burn-compute/src/client.rs
+++ b/crates/burn-compute/src/client.rs
@@ -6,8 +6,8 @@ use crate::{
 };
 use alloc::vec::Vec;
 use alloc::{boxed::Box, sync::Arc};
-use burn_common::reader::Reader;
 use burn_common::stub::RwLock;
+use burn_common::{reader::Reader, sync_type::SyncType};
 
 /// The ComputeClient is the entry point to require tasks from the ComputeServer.
 /// It should be obtained for a specific device via the Compute struct.
@@ -69,8 +69,8 @@ where
     }
 
     /// Wait for the completion of every task in the server.
-    pub fn sync(&self) {
-        self.channel.sync()
+    pub fn sync(&self, sync_type: SyncType) {
+        self.channel.sync(sync_type)
     }
 
     /// Executes the fastest kernel in the autotune operation, using (cached) runtime benchmarks

--- a/crates/burn-compute/src/server.rs
+++ b/crates/burn-compute/src/server.rs
@@ -45,6 +45,9 @@ where
     /// and are responsible of determining which should be read or written.
     fn execute(&mut self, kernel: Self::Kernel, bindings: Vec<Binding<Self>>);
 
+    /// Submit the current queued tasks to the server.
+    fn submit(&mut self);
+
     /// Wait for the completion of every task in the server.
     fn sync(&mut self);
 }

--- a/crates/burn-compute/src/server.rs
+++ b/crates/burn-compute/src/server.rs
@@ -4,7 +4,7 @@ use crate::{
     tune::AutotuneKey,
 };
 use alloc::vec::Vec;
-use burn_common::reader::Reader;
+use burn_common::{reader::Reader, sync_type::SyncType};
 use core::fmt::Debug;
 
 /// The compute server is responsible for handling resources and computations over resources.
@@ -45,11 +45,8 @@ where
     /// and are responsible of determining which should be read or written.
     fn execute(&mut self, kernel: Self::Kernel, bindings: Vec<Binding<Self>>);
 
-    /// Submit the current queued tasks to the server.
-    fn submit(&mut self);
-
     /// Wait for the completion of every task in the server.
-    fn sync(&mut self);
+    fn sync(&mut self, command: SyncType);
 }
 
 /// Server handle containing the [memory handle](MemoryManagement::Handle).

--- a/crates/burn-compute/src/tune/tune_benchmark.rs
+++ b/crates/burn-compute/src/tune/tune_benchmark.rs
@@ -1,4 +1,5 @@
 use burn_common::benchmark::Benchmark;
+use burn_common::sync_type::SyncType;
 
 use crate::channel::ComputeChannel;
 use crate::client::ComputeClient;
@@ -41,6 +42,7 @@ impl<S: ComputeServer, C: ComputeChannel<S>> Benchmark for TuneBenchmark<S, C> {
     }
 
     fn sync(&self) {
-        self.client.sync();
+        // For benchmarks - we need to wait for all tasks to complete before returning.
+        self.client.sync(SyncType::Wait);
     }
 }

--- a/crates/burn-compute/tests/dummy/server.rs
+++ b/crates/burn-compute/tests/dummy/server.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use burn_common::reader::Reader;
+use burn_common::{reader::Reader, sync_type::SyncType};
 use burn_compute::{
     memory_management::{simple::SimpleMemoryManagement, MemoryHandle, MemoryManagement},
     server::{Binding, ComputeServer, Handle},
@@ -62,11 +62,7 @@ where
         kernel.compute(&mut resources);
     }
 
-    fn submit(&mut self) {
-        // Nothing to do with dummy backend.
-    }
-
-    fn sync(&mut self) {
+    fn sync(&mut self, _: SyncType) {
         // Nothing to do with dummy backend.
     }
 }

--- a/crates/burn-compute/tests/dummy/server.rs
+++ b/crates/burn-compute/tests/dummy/server.rs
@@ -62,6 +62,10 @@ where
         kernel.compute(&mut resources);
     }
 
+    fn submit(&mut self) {
+        // Nothing to do with dummy backend.
+    }
+
     fn sync(&mut self) {
         // Nothing to do with dummy backend.
     }

--- a/crates/burn-compute/tests/integration_test.rs
+++ b/crates/burn-compute/tests/integration_test.rs
@@ -246,6 +246,8 @@ fn autotune_cache_different_keys_return_a_cache_miss() {
 #[serial]
 #[cfg(feature = "std")]
 fn autotune_cache_different_checksums_return_a_cache_miss() {
+    use burn_common::sync_type::SyncType;
+
     type Runtime = ComputeRuntime<DummyDevice, dummy::DummyServer, dummy::DummyChannel>;
     let runtime = Runtime::new();
     let client = runtime.client(&DummyDevice, dummy::init_client);
@@ -260,7 +262,7 @@ fn autotune_cache_different_checksums_return_a_cache_miss() {
     let cache_test_autotune_kernel_1 =
         dummy::CacheTestAutotuneOperationSet::new(client.clone(), shapes_1, handles_1);
     client.autotune_execute(Box::new(cache_test_autotune_kernel_1));
-    client.sync();
+    client.sync(SyncType::Wait);
 
     // we use a second compute client in order to have freshly initialized autotune cache
     // and test invalidation of the cache when the checksum of the operation set is
@@ -278,7 +280,7 @@ fn autotune_cache_different_checksums_return_a_cache_miss() {
         dummy::CacheTestAutotuneOperationSet::new(client.clone(), shapes_2, handles_2);
     cache_test_autotune_kernel_2.generate_random_checksum = true;
     client.autotune_execute(Box::new(cache_test_autotune_kernel_2));
-    client.sync();
+    client.sync(SyncType::Wait);
 
     let obtained_resource = client.read(out_2.binding());
 

--- a/crates/burn-cuda/src/compute/server.rs
+++ b/crates/burn-cuda/src/compute/server.rs
@@ -110,6 +110,11 @@ impl<MM: MemoryManagement<CudaStorage>> ComputeServer for CudaServer<MM> {
         // self.memory_management.storage().perform_deallocations();
     }
 
+    fn submit(&mut self) {
+        // Nothing to do here for the cuda backend.
+        //execute() is sent to the CUDA stream straight away.
+    }
+
     fn sync(&mut self) {
         let ctx = self.get_context();
         ctx.sync();

--- a/crates/burn-cuda/src/compute/server.rs
+++ b/crates/burn-cuda/src/compute/server.rs
@@ -7,6 +7,7 @@ use burn_compute::{
 use burn_cube::ir::CubeDim;
 use burn_cube::prelude::*;
 use burn_jit::JitAutotuneKey;
+use burn_tensor::backend::SyncType;
 use cudarc::driver::sys::CUctx_st;
 use cudarc::driver::sys::CUfunc_st;
 use std::collections::HashMap;
@@ -110,14 +111,16 @@ impl<MM: MemoryManagement<CudaStorage>> ComputeServer for CudaServer<MM> {
         // self.memory_management.storage().perform_deallocations();
     }
 
-    fn submit(&mut self) {
-        // Nothing to do here for the cuda backend.
-        //execute() is sent to the CUDA stream straight away.
-    }
-
-    fn sync(&mut self) {
-        let ctx = self.get_context();
-        ctx.sync();
+    fn sync(&mut self, sync_type: SyncType) {
+        match sync_type {
+            // Synchronize the stream if waiting.
+            SyncType::Wait => {
+                let ctx = self.get_context();
+                ctx.sync();
+            }
+            // Nothing to do - all tasks are already submitted to the stream.
+            SyncType::Flush => (),
+        }
     }
 
     fn get_resource(

--- a/crates/burn-fusion/src/backend.rs
+++ b/crates/burn-fusion/src/backend.rs
@@ -2,7 +2,7 @@ use crate::{
     client::FusionClient, stream::Context, FusionClientLocator, FusionTensor, PrecisionBridge,
 };
 use burn_tensor::{
-    backend::{Backend, DeviceOps},
+    backend::{Backend, DeviceOps, SyncType},
     ops::FloatTensor,
     repr::{OperationDescription, ReprBackend},
     Device,
@@ -45,10 +45,10 @@ impl<B: FusionBackend> Backend for Fusion<B> {
         B::seed(seed);
     }
 
-    fn sync(device: &Self::Device) {
+    fn sync(device: &Self::Device, sync_type: SyncType) {
         let client = CLIENTS.client::<B::FusionRuntime>(&device.clone());
         client.drain();
-        B::sync(device)
+        B::sync(device, sync_type);
     }
 
     fn ad_enabled() -> bool {

--- a/crates/burn-jit/src/backend.rs
+++ b/crates/burn-jit/src/backend.rs
@@ -2,7 +2,7 @@ use crate::{
     tensor::JitTensor, FloatElement, IntElement, JitAutotuneKey, JitRuntime, PrecisionBridge,
 };
 use burn_compute::server::ComputeServer;
-use burn_tensor::backend::Backend;
+use burn_tensor::backend::{Backend, SyncType};
 use rand::{rngs::StdRng, SeedableRng};
 use std::{marker::PhantomData, sync::Mutex};
 
@@ -48,9 +48,9 @@ where
         false
     }
 
-    fn sync(device: &Self::Device) {
+    fn sync(device: &Self::Device, sync_type: SyncType) {
         let client = R::client(device);
-        client.sync();
+        client.sync(sync_type);
     }
 }
 

--- a/crates/burn-tensor/src/tensor/backend/base.rs
+++ b/crates/burn-tensor/src/tensor/backend/base.rs
@@ -1,4 +1,5 @@
 use alloc::string::String;
+pub use burn_common::sync_type::SyncType;
 
 use crate::ops::*;
 use crate::tensor::Element;
@@ -96,7 +97,7 @@ pub trait Backend:
     fn seed(seed: u64);
 
     /// Sync the backend, ensure that all computation are finished.
-    fn sync(_device: &Self::Device) {}
+    fn sync(_device: &Self::Device, _sync_type: SyncType) {}
 }
 
 /// Trait that allows a backend to support autodiff.

--- a/crates/burn-wgpu/src/compute/server.rs
+++ b/crates/burn-wgpu/src/compute/server.rs
@@ -60,23 +60,6 @@ where
         }
     }
 
-    fn submit(&mut self) {
-        self.staging_belt.finish();
-
-        let mut new_encoder = self
-            .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
-        core::mem::swap(&mut new_encoder, &mut self.encoder);
-
-        self.queue.submit(Some(new_encoder.finish()));
-        self.tasks_count = 0;
-
-        // Cleanup allocations and deallocations.
-        self.memory_management.storage().perform_deallocations();
-
-        self.staging_belt.recall();
-    }
-
     fn register_compute(
         &mut self,
         pipeline: Arc<ComputePipeline>,
@@ -306,6 +289,23 @@ where
         if self.tasks_count >= self.tasks_max {
             self.submit();
         }
+    }
+
+    fn submit(&mut self) {
+        self.staging_belt.finish();
+
+        let mut new_encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        core::mem::swap(&mut new_encoder, &mut self.encoder);
+
+        self.queue.submit(Some(new_encoder.finish()));
+        self.tasks_count = 0;
+
+        // Cleanup allocations and deallocations.
+        self.memory_management.storage().perform_deallocations();
+
+        self.staging_belt.recall();
     }
 
     fn sync(&mut self) {


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.

### Related Issues/PRs

This adds the last bit of infrastructure needed for custom burn<->wgpu interop, after initializing from an existing wgpu server (#1788), and getting WGPU resources (#1861).

### Changes
After this PR, the setup for custom interop roughly looks like:

```
init_existing_device(adapter, device, wgpu_queue);

// Do some burn operations.
let x = Tensor::from_floats();
let y = x * 2 + 5.0; // Some calculations we really need in our wgpu code.

// Or however you have access to the client.
let client = y.into_primitive().client;

// Flush burn operations - they now live on the wgpu queue.
client.submit();

// Get a reference to y binding.
let y_wgpu_binding= client.get_resource(y);

// Run custom commands on the queue. wgpu makes guarantees that any resources have been
// calculated up to this point.
run_my_custom_wgpu_code(wgpu_queue, y_wgpu_binding);
```

This does require a seperate encoder for your custom wgpu code. I think that's ok - a custom wgpu app might have it's own already anyway - but in the future we could expose some notion of the servers encoder to share resources.