### PR TITLE
Book: Fix typos of MessagePack format name in the "Record" page

### DIFF
--- a/burn-book/src/building-blocks/record.md
+++ b/burn-book/src/building-blocks/record.md
@@ -32,16 +32,16 @@ with Gzip compression).
 Recorders are independent of the backend and serialize records with precision and a format. Note
 that the format can also be in-memory, allowing you to save the records directly into bytes.
 
-| Recorder               | Format                    | Compression |
-| ---------------------- | ------------------------- | ----------- |
-| DefaultFileRecorder    | File - Named Message Park | None        |
-| NamedMpkFileRecorder   | File - Named Message Park | None        |
-| NamedMpkGzFileRecorder | File - Named Message Park | Gzip        |
-| BinFileRecorder        | File - Binary             | None        |
-| BinGzFileRecorder      | File - Binary             | Gzip        |
-| JsonGzFileRecorder     | File - Json               | Gzip        |
-| PrettyJsonFileRecorder | File - Pretty Json        | Gzip        |
-| BinBytesRecorder       | In Memory - Binary        | None        |
+| Recorder               | Format                   | Compression |
+| ---------------------- | ------------------------ | ----------- |
+| DefaultFileRecorder    | File - Named MessagePack | None        |
+| NamedMpkFileRecorder   | File - Named MessagePack | None        |
+| NamedMpkGzFileRecorder | File - Named MessagePack | Gzip        |
+| BinFileRecorder        | File - Binary            | None        |
+| BinGzFileRecorder      | File - Binary            | Gzip        |
+| JsonGzFileRecorder     | File - Json              | Gzip        |
+| PrettyJsonFileRecorder | File - Pretty Json       | Gzip        |
+| BinBytesRecorder       | In Memory - Binary       | None        |
 
 Each recorder supports precision settings decoupled from the precision used for training or
 inference. These settings allow you to define the floating-point and integer types that will be used
@@ -60,8 +60,8 @@ and deserialization; otherwise, you will encounter loading errors.
 **Which recorder should you use?**
 
 - If you want fast serialization and deserialization, choose a recorder without compression. The one
-  with the lowest file size without compression is the binary format; otherwise, the named message
-  park could be used.
+  with the lowest file size without compression is the binary format; otherwise, the named
+  MessagePack could be used.
 - If you want to save models for storage, you can use compression, but avoid using the binary
   format, as it may not be backward compatible.
 - If you want to debug your model's weights, you can use the pretty JSON format.


### PR DESCRIPTION
This PR fixes 4 typos of MessagePack format name in [the "Record" page](https://burn.dev/book/building-blocks/record.html) of the Book.

By the way, thank you for the great work :)

## Pull Request Template

### Checklist

- [ ] Confirmed that `run-checks all` script has been executed.
I got several errors from burn-* crates, which stopped the script execution before all checks run, but I didn't touch those crates, and these errors occurred even when I run the checks against the "main" branch.
Could you please tell me if it's fine to ignore them or there are some workaround to finish all the checks despite the errors?

- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs
None.

### Changes
* Problem:
In the "Record" page, there are 4 places where "Pack" is written as "Park."
* Solution:
Changing "Park" to "Pack".
Also, since the official name of the format is in CamelCase, I removed the spaces and captialized the two words in the last place. If the spaces and lowercases are used intentionally, please let me know.

### Testing
`cargo xtask books burn open`
