### PR TITLE
Feat: Add `movedim` tensor operator

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -160,6 +160,7 @@ Those operations are available for all tensor kinds: `Int`, `Float`, and `Bool`.
 | `tensor.narrow(dim, start, length)`   | `tensor.narrow(dim, start, length)`  |
 | `tensor.not_equal(other)`             | `x != y`                             |
 | `tensor.permute(axes)`                | `tensor.permute(axes)`               |
+| `tensor.movedim(src, dst)`            | `tensor.movedim(src, dst)`           |
 | `tensor.repeat(2, 4)`                 | `tensor.repeat([1, 1, 4])`           |
 | `tensor.reshape(shape)`               | `tensor.view(shape)`                 |
 | `tensor.shape()`                      | `tensor.shape`                       |

--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -160,7 +160,6 @@ Those operations are available for all tensor kinds: `Int`, `Float`, and `Bool`.
 | `tensor.narrow(dim, start, length)`   | `tensor.narrow(dim, start, length)`  |
 | `tensor.not_equal(other)`             | `x != y`                             |
 | `tensor.permute(axes)`                | `tensor.permute(axes)`               |
-| `tensor.movedim(src, dst)`            | `tensor.movedim(src, dst)`           |
 | `tensor.repeat(2, 4)`                 | `tensor.repeat([1, 1, 4])`           |
 | `tensor.reshape(shape)`               | `tensor.view(shape)`                 |
 | `tensor.shape()`                      | `tensor.shape`                       |
@@ -296,16 +295,16 @@ Those operations are only available for `Int` tensors.
 
 Those operations are only available for `Bool` tensors.
 
-| Burn API                             | PyTorch Equivalent              |
-| ------------------------------------ | ------------------------------- |
-| `Tensor::diag_mask(shape, diagonal)` | N/A                             |
-| `Tensor::tril_mask(shape, diagonal)` | N/A                             |
-| `Tensor::triu_mask(shape, diagonal)` | N/A                             |
-| `tensor.argwhere()`                  | `tensor.argwhere()`             |
-| `tensor.float()`                     | `tensor.to(torch.float)`        |
-| `tensor.int()`                       | `tensor.to(torch.long)`         |
-| `tensor.nonzero()`                   | `tensor.nonzero(as_tuple=True)` |
-| `tensor.not()`                       | `tensor.logical_not()`          |
+| Burn API                            | PyTorch Equivalent              |
+| ----------------------------------- | ------------------------------- |
+| `Tensor::diag_mask(shape, diagonal)`| N/A                             |
+| `Tensor::tril_mask(shape, diagonal)`| N/A                             |
+| `Tensor::triu_mask(shape, diagonal)`| N/A                             |
+| `tensor.argwhere()`                 | `tensor.argwhere()`             |
+| `tensor.float()`                    | `tensor.to(torch.float)`        |
+| `tensor.int()`                      | `tensor.to(torch.long)`         |
+| `tensor.nonzero()`                  | `tensor.nonzero(as_tuple=True)` |
+| `tensor.not()`                      | `tensor.logical_not()`          |
 
 ## Activation Functions
 

--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -160,6 +160,7 @@ Those operations are available for all tensor kinds: `Int`, `Float`, and `Bool`.
 | `tensor.narrow(dim, start, length)`   | `tensor.narrow(dim, start, length)`  |
 | `tensor.not_equal(other)`             | `x != y`                             |
 | `tensor.permute(axes)`                | `tensor.permute(axes)`               |
+| `tensor.movedim(src, dst)`            | `tensor.movedim(src, dst)`           |
 | `tensor.repeat(2, 4)`                 | `tensor.repeat([1, 1, 4])`           |
 | `tensor.reshape(shape)`               | `tensor.view(shape)`                 |
 | `tensor.shape()`                      | `tensor.shape`                       |
@@ -295,16 +296,16 @@ Those operations are only available for `Int` tensors.
 
 Those operations are only available for `Bool` tensors.
 
-| Burn API                            | PyTorch Equivalent              |
-| ----------------------------------- | ------------------------------- |
-| `Tensor::diag_mask(shape, diagonal)`| N/A                             |
-| `Tensor::tril_mask(shape, diagonal)`| N/A                             |
-| `Tensor::triu_mask(shape, diagonal)`| N/A                             |
-| `tensor.argwhere()`                 | `tensor.argwhere()`             |
-| `tensor.float()`                    | `tensor.to(torch.float)`        |
-| `tensor.int()`                      | `tensor.to(torch.long)`         |
-| `tensor.nonzero()`                  | `tensor.nonzero(as_tuple=True)` |
-| `tensor.not()`                      | `tensor.logical_not()`          |
+| Burn API                             | PyTorch Equivalent              |
+| ------------------------------------ | ------------------------------- |
+| `Tensor::diag_mask(shape, diagonal)` | N/A                             |
+| `Tensor::tril_mask(shape, diagonal)` | N/A                             |
+| `Tensor::triu_mask(shape, diagonal)` | N/A                             |
+| `tensor.argwhere()`                  | `tensor.argwhere()`             |
+| `tensor.float()`                     | `tensor.to(torch.float)`        |
+| `tensor.int()`                       | `tensor.to(torch.long)`         |
+| `tensor.nonzero()`                   | `tensor.nonzero(as_tuple=True)` |
+| `tensor.not()`                       | `tensor.logical_not()`          |
 
 ## Activation Functions
 

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -9,6 +9,8 @@ use alloc::string::String;
 #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
 use alloc::vec;
 
+use hashbrown::HashMap;
+
 use burn_common::{reader::Reader, stub::Mutex};
 use core::{fmt::Debug, isize, ops::Range};
 use core::{iter::repeat, usize};
@@ -198,7 +200,7 @@ where
         ));
         let rank = self.dims().len();
 
-        let mut m = std::collections::HashMap::new();
+        let mut m = HashMap::new();
         for (d, s) in destination_dims.iter().zip(source_dims.iter()) {
             m.insert(*d, *s);
         }
@@ -1315,18 +1317,6 @@ pub trait BasicOps<B: Backend>: TensorKind<B> {
     ///
     /// The tensor with the dimensions permuted.
     fn permute<const D: usize>(tensor: Self::Primitive<D>, axes: [usize; D]) -> Self::Primitive<D>;
-
-    fn movedim<const D: usize>(
-        tensor: Self::Primitive<D>,
-        source: Vec<usize>,
-        dest: Vec<usize>,
-    ) -> Self::Primitive<D> {
-        let mut axes = (0..D).collect::<Vec<usize>>();
-        for (s, d) in source.iter().zip(dest.iter()) {
-            axes.swap(*s, *d);
-        }
-        Self::permute(tensor, axes.try_into().unwrap())
-    }
 
     /// Flips the tensor along the given axes.
     ///

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -196,7 +196,7 @@ where
     /// The tensor with the dimensions moved.
     // This is a semantic sugar for `permute`. It is used widely enough, so we define a separate Op
     // for it
-    pub fn movedim<S: MovedimArgs>(self, src: S, dst: S) -> Tensor<B, D, K> {
+    pub fn movedim<S1: MovedimArgs, S2: MovedimArgs>(self, src: S1, dst: S2) -> Tensor<B, D, K> {
         let source_dims = src.into_dim_vec::<D>();
         let destination_dims = dst.into_dim_vec::<D>();
 

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -12,8 +12,8 @@ use alloc::vec;
 use hashbrown::HashMap;
 
 use burn_common::{reader::Reader, stub::Mutex};
-use core::{fmt::Debug, isize, ops::Range};
-use core::{iter::repeat, usize};
+use core::iter::repeat;
+use core::{fmt::Debug, ops::Range};
 use serde::{Deserialize, Deserializer};
 
 #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
@@ -180,19 +180,25 @@ where
     ///
     /// # Arguments
     ///
-    /// * `source` - The dimension(s) to move. The values must be unique and in the range of the number of dimensions.
+    /// * `src` - The dimension(s) to move. The values must be unique and in the range of the number of dimensions.
     ///              The values can be negative, in which case they are used as an offset from the end.
     ///
-    /// * `destination` - Destination positions for each of the original dims. These must also be unique.
+    /// * `dst` - Destination positions for each of the original dims. These must also be unique.
+    ///
+    /// # Panics
+    ///
+    /// - If the source and destination dimensions are not of the same length.
+    /// - If the source and destination vectors contain duplicate values.
+    /// - If the source and destination vectors contain values that are out of bounds.
     ///
     /// # Returns
     ///
     /// The tensor with the dimensions moved.
     // This is a semantic sugar for `permute`. It is used widely enough, so we define a separate Op
     // for it
-    pub fn movedim<S: MovedimArgs>(self, source: S, destination: S) -> Tensor<B, D, K> {
-        let source_dims = source.into_dim_vec::<D>();
-        let destination_dims = destination.into_dim_vec::<D>();
+    pub fn movedim<S: MovedimArgs>(self, src: S, dst: S) -> Tensor<B, D, K> {
+        let source_dims = src.into_dim_vec::<D>();
+        let destination_dims = dst.into_dim_vec::<D>();
 
         check!(TensorCheck::movedim_args_length(
             &source_dims,

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -2066,14 +2066,19 @@ impl MovedimArgs for Vec<usize> {
 }
 
 impl MovedimArgs for usize {
+    #[allow(clippy::vec_init_then_push)]
     fn into_dim_vec<const D: usize>(self) -> Vec<usize> {
         check!(TensorCheck::movedim_args_usize::<D>(self));
 
-        vec![self]
+        let mut set = Vec::with_capacity(1);
+        set.push(self);
+
+        set
     }
 }
 
 impl MovedimArgs for i32 {
+    #[allow(clippy::vec_init_then_push)]
     fn into_dim_vec<const D: usize>(self) -> Vec<usize> {
         check!(TensorCheck::movedim_args_i32::<D>(self));
 
@@ -2083,7 +2088,10 @@ impl MovedimArgs for i32 {
             self as usize
         };
 
-        vec![dim]
+        let mut set = Vec::with_capacity(1);
+        set.push(dim);
+
+        set
     }
 }
 

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -9,8 +9,6 @@ use alloc::string::String;
 #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
 use alloc::vec;
 
-use hashbrown::HashMap;
-
 use burn_common::{reader::Reader, stub::Mutex};
 use core::iter::repeat;
 use core::{fmt::Debug, ops::Range};
@@ -204,17 +202,16 @@ where
             &source_dims,
             &destination_dims
         ));
-        let rank = self.dims().len();
 
-        let mut m = HashMap::new();
-        for (d, s) in destination_dims.iter().zip(source_dims.iter()) {
-            m.insert(*d, *s);
+        let mut m = [-1; D];
+        for (&d, &s) in destination_dims.iter().zip(source_dims.iter()) {
+            m[d] = s as isize;
         }
         let mut axes: [isize; D] = [0; D];
         let mut source_i = 0;
-        for (dest_i, item) in axes.iter_mut().enumerate().take(rank) {
-            *item = if let Some(&s) = m.get(&dest_i) {
-                s as isize
+        for (dest_i, item) in axes.iter_mut().enumerate().take(D) {
+            *item = if m[dest_i] != -1 {
+                m[dest_i]
             } else {
                 while source_dims.contains(&source_i) {
                     source_i += 1;

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -12,7 +12,6 @@ use alloc::vec;
 use burn_common::{reader::Reader, stub::Mutex};
 use core::{fmt::Debug, isize, ops::Range};
 use core::{iter::repeat, usize};
-use num_traits::PrimInt;
 use serde::{Deserialize, Deserializer};
 
 #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
@@ -2065,13 +2064,13 @@ impl MovedimArgs for BTreeSet<isize> {
     fn into_dim_set<const D: usize>(self) -> BTreeSet<usize> {
         let mut set = BTreeSet::new();
         for dim in self {
-            set.insert(dim.into_dim_set::<D>().into_iter().next().unwrap());
+            set.insert((dim as i32).into_dim_set::<D>().into_iter().next().unwrap());
         }
         set
     }
 }
 
-impl MovedimArgs for Vec<isize> {
+impl MovedimArgs for Vec<i32> {
     fn into_dim_set<const D: usize>(self) -> BTreeSet<usize> {
         let mut set = BTreeSet::new();
         for dim in self {
@@ -2100,12 +2099,12 @@ impl MovedimArgs for usize {
     }
 }
 
-impl MovedimArgs for isize {
+impl MovedimArgs for i32 {
     fn into_dim_set<const D: usize>(self) -> BTreeSet<usize> {
-        check!(TensorCheck::movedim_args_isize::<D>(self));
+        check!(TensorCheck::movedim_args_i32::<D>(self as i32));
 
         let dim = if self < 0 {
-            (D as isize + self) as usize
+            (D as i32 + self) as usize
         } else {
             self as usize
         };

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -2101,7 +2101,7 @@ impl MovedimArgs for usize {
 
 impl MovedimArgs for i32 {
     fn into_dim_set<const D: usize>(self) -> BTreeSet<usize> {
-        check!(TensorCheck::movedim_args_i32::<D>(self as i32));
+        check!(TensorCheck::movedim_args_i32::<D>(self));
 
         let dim = if self < 0 {
             (D as i32 + self) as usize
@@ -2115,6 +2115,7 @@ impl MovedimArgs for i32 {
         set
     }
 }
+
 /// Trait used for reshape arguments.
 pub trait ReshapeArgs<const D2: usize> {
     /// Converts to a shape.

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -172,9 +172,31 @@ where
         Tensor::new(K::permute(self.primitive, transformed_axes))
     }
 
+    /// Moves the dimension(s) of input at the position(s) in source to the position(s) in destination.
+    ///
+    /// Other dimensions of input that are not explicitly moved remain in their original order and appear
+    /// at the positions not specified in destination.
+    ///
+    /// # Arguments
+    ///
+    /// * `source` - The dimension(s) to move. The values must be unique and in the range of the number of dimensions.
+    ///              The values can be negative, in which case they are used as an offset from the end.
+    ///
+    /// * `destination` - Destination positions for each of the original dims. These must also be unique.
+    ///
+    /// # Returns
+    ///
+    /// The tensor with the dimensions moved.
+    // This is a semantic sugar for `permute`. It is used widely enough, so we define a separate Op
+    // for it
     pub fn movedim<S: MovedimArgs>(self, source: S, destination: S) -> Tensor<B, D, K> {
         let source_dims: BTreeSet<_> = source.into_dim_set::<D>();
         let destination_dims: BTreeSet<_> = destination.into_dim_set::<D>();
+
+        check!(TensorCheck::movedim_args_length(
+            &source_dims,
+            &destination_dims
+        ));
         let rank = self.dims().len();
 
         let mut m = std::collections::HashMap::new();

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -190,10 +190,10 @@ impl TensorCheck {
         check
     }
 
-    pub(crate) fn movedim_args_isize<const D: usize>(dim: isize) -> Self {
+    pub(crate) fn movedim_args_i32<const D: usize>(dim: i32) -> Self {
         let mut check = Self::Ok;
 
-        if dim < -(D as isize) || dim >= D as isize {
+        if dim < -(D as i32) || dim >= D as i32 {
             check = check.register(
                 "Movedim",
                 TensorError::new(

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -1,8 +1,8 @@
 use crate::{backend::Backend, BasicOps, Shape, Tensor};
-use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
+use alloc::{collections::BTreeSet, format};
 use core::ops::Range;
 
 /// The struct should always be used with the [check](crate::check) macro.
@@ -203,6 +203,28 @@ impl TensorCheck {
                     "Current tensor has {D} dimensions, but the given dimension is {dim}.",
                 )),
             );
+        }
+
+        check
+    }
+
+    pub(crate) fn movedim_args_length(
+        source_dims: &BTreeSet<usize>,
+        destination_dims: &BTreeSet<usize>,
+    ) -> Self {
+        let mut check = Self::Ok;
+
+        if source_dims.len() != destination_dims.len() {
+            check = check.register(
+                "Movedim",
+                TensorError::new(
+                    "The number of dimensions in source and destination must be equal.",
+                )
+                .details(format!(
+                    "Source dimensions: {:?}, Destination dimensions: {:?}.",
+                    source_dims, destination_dims
+                )),
+            )
         }
 
         check

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -172,6 +172,42 @@ impl TensorCheck {
         check
     }
 
+    pub(crate) fn movedim_args_usize<const D: usize>(dim: usize) -> Self {
+        let mut check = Self::Ok;
+
+        if dim >= D {
+            check = check.register(
+                "Movedim",
+                TensorError::new(
+                    "The given dimension exceeds the number of dimensions of the current tensor.",
+                )
+                .details(format!(
+                    "Current tensor has {D} dimensions, but the given dimension is {dim}.",
+                )),
+            );
+        }
+
+        check
+    }
+
+    pub(crate) fn movedim_args_isize<const D: usize>(dim: isize) -> Self {
+        let mut check = Self::Ok;
+
+        if dim < -(D as isize) || dim >= D as isize {
+            check = check.register(
+                "Movedim",
+                TensorError::new(
+                    "The given dimension is out of bounds for the current tensor dimensions.",
+                )
+                .details(format!(
+                    "Current tensor has {D} dimensions, but the given dimension is {dim}.",
+                )),
+            );
+        }
+
+        check
+    }
+
     pub(crate) fn flatten<const D1: usize, const D2: usize>(
         start_dim: usize,
         end_dim: usize,

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -4,7 +4,6 @@ use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
 use core::ops::Range;
-use hashbrown::HashSet;
 
 /// The struct should always be used with the [check](crate::check) macro.
 ///
@@ -224,16 +223,20 @@ impl TensorCheck {
         }
 
         // Check there are no duplicates
-        let mut uniq = HashSet::new();
-        let duplicates = dims.iter().find(|&&x| !uniq.insert(x));
-        if let Some(duplicate) = duplicates {
-            check = check.register(
-                "Movedim",
-                TensorError::new("The given dimensions contain duplicates.").details(format!(
-                    "The dimension {} is duplicated in the given dimensions {:?}.",
-                    duplicate, dims
-                )),
-            );
+        for (i, &dim_i) in dims.iter().enumerate() {
+            for &dim_j in dims.iter().skip(i + 1) {
+                if dim_i == dim_j {
+                    check = check.register(
+                        "Movedim",
+                        TensorError::new("The given dimensions contain duplicates.").details(
+                            format!(
+                                "The dimension {} is duplicated in the given dimensions {:?}.",
+                                dim_i, dims
+                            ),
+                        ),
+                    );
+                }
+            }
         }
 
         check

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -1193,4 +1193,42 @@ mod tests {
             &8
         ));
     }
+
+    #[test]
+    #[should_panic]
+    fn movedim_args_out_of_bounds() {
+        check!(TensorCheck::movedim_args_usize::<3>(5));
+    }
+
+    #[test]
+    fn movedim_args_i32() {
+        check!(TensorCheck::movedim_args_i32::<3>(-3));
+    }
+
+    #[test]
+    #[should_panic]
+    fn movedim_args_too_negative() {
+        check!(TensorCheck::movedim_args_i32::<3>(-4));
+    }
+
+    #[test]
+    #[should_panic]
+    fn movedim_args_vec_out_of_bounds() {
+        check!(TensorCheck::movedim_args_vec::<3>(&vec![0, 1, 3]));
+    }
+
+    #[test]
+    #[should_panic]
+    fn movedim_args_vec_duplicates() {
+        check!(TensorCheck::movedim_args_vec::<3>(&vec![0, 1, 1]));
+    }
+
+    #[test]
+    #[should_panic]
+    fn movedim_args_length() {
+        check!(TensorCheck::movedim_args_length(
+            &vec![0, 1],
+            &vec![0, 1, 2]
+        ));
+    }
 }

--- a/crates/burn-tensor/src/tests/mod.rs
+++ b/crates/burn-tensor/src/tests/mod.rs
@@ -88,6 +88,7 @@ macro_rules! testgen_all {
         burn_tensor::testgen_any!();
         burn_tensor::testgen_all_op!();
         burn_tensor::testgen_permute!();
+        burn_tensor::testgen_movedim!();
         burn_tensor::testgen_flip!();
         burn_tensor::testgen_bool!();
         burn_tensor::testgen_argwhere_nonzero!();

--- a/crates/burn-tensor/src/tests/ops/mod.rs
+++ b/crates/burn-tensor/src/tests/ops/mod.rs
@@ -32,6 +32,7 @@ mod map_comparison;
 mod mask;
 mod matmul;
 mod maxmin;
+mod movedim;
 mod mul;
 mod narrow;
 mod neg;

--- a/crates/burn-tensor/src/tests/ops/movedim.rs
+++ b/crates/burn-tensor/src/tests/ops/movedim.rs
@@ -1,0 +1,190 @@
+#[burn_tensor_testgen::testgen(movedim)]
+mod tests {
+    use super::*;
+    use burn_tensor::backend::Backend;
+    use burn_tensor::{Data, Device, Int, Shape, Tensor};
+
+    #[test]
+    fn normal_int() {
+        let device = Default::default();
+        let tensor = Tensor::<TestBackend, 1, Int>::arange(0..24, &device).reshape([2, 3, 4]);
+
+        let permuted = tensor.clone().movedim(0, 2);
+
+        // from pytorch:
+        // import torch; torch.arange(0, 24).reshape(2, 3, 4).movedim(0, 2)
+        let data_expected = Data::from([
+            [[0, 12], [1, 13], [2, 14], [3, 15]],
+            [[4, 16], [5, 17], [6, 18], [7, 19]],
+            [[8, 20], [9, 21], [10, 22], [11, 23]],
+        ]);
+
+        assert_eq!(data_expected, permuted.into_data());
+
+        // Test with negative axis
+        let permuted = tensor.clone().movedim(0, -1);
+        assert_eq!(data_expected, permuted.into_data());
+
+        // Test with the same axis
+        let permuted = tensor.clone().movedim(0, 0);
+        assert_eq!(tensor.into_data(), permuted.into_data());
+    }
+
+    #[test]
+    fn normal_float() {
+        let device = Default::default();
+        let tensor = Tensor::<TestBackend, 1, Int>::arange(0..24, &device)
+            .reshape([2, 3, 4])
+            .float();
+
+        let permuted = tensor.clone().movedim(0, 2);
+
+        // from pytorch:
+        // import torch; torch.arange(0, 24).reshape(2, 3, 4).movedim(0, 2).float()
+        let data_expected = Data::from([
+            [[0., 12.], [1., 13.], [2., 14.], [3., 15.]],
+            [[4., 16.], [5., 17.], [6., 18.], [7., 19.]],
+            [[8., 20.], [9., 21.], [10., 22.], [11., 23.]],
+        ]);
+
+        assert_eq!(data_expected, permuted.into_data());
+
+        // Test with negative axis
+        let permuted = tensor.clone().movedim(0, -1);
+        assert_eq!(data_expected, permuted.into_data());
+
+        // Test with the same axis
+        let permuted = tensor.clone().movedim(0, 0);
+        assert_eq!(tensor.into_data(), permuted.into_data());
+    }
+
+    #[test]
+    fn normal_bool() {
+        let device = Default::default();
+        let tensor = Tensor::<TestBackend, 1, Int>::arange(0..24, &device)
+            .reshape([2, 3, 4])
+            .greater_elem(10);
+
+        let permuted = tensor.clone().movedim(0, 2);
+
+        // from pytorch:
+        // import torch; torch.arange(0, 24).reshape(2, 3, 4).movedim(0, 2).gt(10)
+        let data_expected = Data::from([
+            [[false, true], [false, true], [false, true], [false, true]],
+            [[false, true], [false, true], [false, true], [false, true]],
+            [[false, true], [false, true], [false, true], [true, true]],
+        ]);
+
+        assert_eq!(data_expected, permuted.into_data());
+
+        // Test with negative axis
+        let permuted = tensor.clone().movedim(0, -1);
+        assert_eq!(data_expected, permuted.into_data());
+
+        // Test with the same axis
+        let permuted = tensor.clone().movedim(0, 0);
+        assert_eq!(tensor.into_data(), permuted.into_data());
+    }
+
+    #[test]
+    fn vec_input_int() {
+        let device = Default::default();
+        let tensor = Tensor::<TestBackend, 1, Int>::arange(0..24, &device).reshape([2, 3, 4]);
+
+        let permuted = tensor.clone().movedim(vec![0, 1], vec![1, 0]);
+
+        // from pytorch
+        // import torch; torch.arange(0, 24).reshape(2, 3, 4).movedim([0, 1], [1, 0])
+        let data_expected = Data::from([
+            [[0, 1, 2, 3], [12, 13, 14, 15]],
+            [[4, 5, 6, 7], [16, 17, 18, 19]],
+            [[8, 9, 10, 11], [20, 21, 22, 23]],
+        ]);
+
+        assert_eq!(data_expected, permuted.into_data());
+
+        // Test with negative axes
+        let permuted = tensor.clone().movedim(vec![-3, -2], vec![-2, -3]);
+        assert_eq!(data_expected, permuted.into_data());
+
+        // Test with the same axes
+        let permuted = tensor.clone().movedim(vec![0, 1], vec![0, 1]);
+        assert_eq!(tensor.into_data(), permuted.into_data());
+    }
+
+    #[test]
+    fn vec_input_float() {
+        let device = Default::default();
+        let tensor = Tensor::<TestBackend, 1, Int>::arange(0..24, &device)
+            .reshape([2, 3, 4])
+            .float();
+
+        let permuted = tensor.clone().movedim(vec![0, 1], vec![1, 0]);
+
+        // from pytorch
+        // import torch; torch.arange(0, 24).reshape(2, 3, 4).movedim([0, 1], [1, 0]).float()
+        let data_expected = Data::from([
+            [[0., 1., 2., 3.], [12., 13., 14., 15.]],
+            [[4., 5., 6., 7.], [16., 17., 18., 19.]],
+            [[8., 9., 10., 11.], [20., 21., 22., 23.]],
+        ]);
+
+        assert_eq!(data_expected, permuted.into_data());
+
+        // Test with negative axes
+        let permuted = tensor.clone().movedim(vec![-3, -2], vec![-2, -3]);
+        assert_eq!(data_expected, permuted.into_data());
+
+        // Test with the same axes
+        let permuted = tensor.clone().movedim(vec![0, 1], vec![0, 1]);
+        assert_eq!(tensor.into_data(), permuted.into_data());
+    }
+
+    #[test]
+    fn vec_input_bool() {
+        let device = Default::default();
+        let tensor = Tensor::<TestBackend, 1, Int>::arange(0..24, &device)
+            .reshape([2, 3, 4])
+            .greater_elem(10);
+
+        let permuted = tensor.clone().movedim(vec![0, 1], vec![1, 0]);
+
+        // from pytorch
+        // import torch; torch.arange(0, 24).reshape(2, 3, 4).movedim([0, 1], [1, 0]).gt(10)
+        let data_expected = Data::from([
+            [[false, false, false, false], [true, true, true, true]],
+            [[false, false, false, false], [true, true, true, true]],
+            [[false, false, false, true], [true, true, true, true]],
+        ]);
+
+        assert_eq!(data_expected, permuted.into_data());
+
+        // Test with negative axes
+        let permuted = tensor.clone().movedim(vec![-3, -2], vec![-2, -3]);
+        assert_eq!(data_expected, permuted.into_data());
+
+        // Test with the same axes
+        let permuted = tensor.clone().movedim(vec![0, 1], vec![0, 1]);
+        assert_eq!(tensor.into_data(), permuted.into_data());
+    }
+
+    #[test]
+    #[should_panic]
+    fn edge_different_sizes() {
+        let device = Default::default();
+        let tensor = Tensor::<TestBackend, 1, Int>::arange(0..24, &device).reshape([2, 3, 4]);
+
+        // Test with a repeated axis
+        let _ = tensor.clone().movedim(vec![0, 1], vec![0]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn edge_out_of_bound_axis() {
+        let device = Default::default();
+        let tensor = Tensor::<TestBackend, 1, Int>::arange(0..24, &device).reshape([2, 3, 4]);
+
+        // Test with an out of bound axis
+        let _ = tensor.clone().movedim(0, 100);
+    }
+}

--- a/crates/burn-tensor/src/tests/ops/movedim.rs
+++ b/crates/burn-tensor/src/tests/ops/movedim.rs
@@ -197,4 +197,14 @@ mod tests {
         // Test with a repeated axis
         let _ = tensor.clone().movedim(vec![0, 1, 1, 1, 1], vec![0, 0, 1]);
     }
+
+    #[test]
+    #[should_panic]
+    fn edge_out_of_bound_axis_vec() {
+        let device = Default::default();
+        let tensor = Tensor::<TestBackend, 1, Int>::arange(0..24, &device).reshape([2, 3, 4]);
+
+        // Test with an out of bound axis
+        let _ = tensor.clone().movedim(vec![0, 100], vec![0, 1]);
+    }
 }

--- a/crates/burn-tensor/src/tests/ops/movedim.rs
+++ b/crates/burn-tensor/src/tests/ops/movedim.rs
@@ -187,4 +187,14 @@ mod tests {
         // Test with an out of bound axis
         let _ = tensor.clone().movedim(0, 100);
     }
+
+    #[test]
+    #[should_panic]
+    fn edge_vec_is_not_a_set() {
+        let device = Default::default();
+        let tensor = Tensor::<TestBackend, 1, Int>::arange(0..24, &device).reshape([2, 3, 4]);
+
+        // Test with a repeated axis
+        let _ = tensor.clone().movedim(vec![0, 1, 1, 1, 1], vec![0, 0, 1]);
+    }
 }

--- a/crates/burn-tensor/src/tests/ops/movedim.rs
+++ b/crates/burn-tensor/src/tests/ops/movedim.rs
@@ -169,6 +169,34 @@ mod tests {
     }
 
     #[test]
+    fn different_input_types() {
+        let device = Default::default();
+        let tensor = Tensor::<TestBackend, 1, Int>::arange(0..24, &device)
+            .reshape([2, 3, 4])
+            .float();
+
+        let permuted = tensor.clone().movedim(0_usize, 2_i32);
+
+        // from pytorch:
+        // import torch; torch.arange(0, 24).reshape(2, 3, 4).movedim(0, 2).float()
+        let data_expected = Data::from([
+            [[0., 12.], [1., 13.], [2., 14.], [3., 15.]],
+            [[4., 16.], [5., 17.], [6., 18.], [7., 19.]],
+            [[8., 20.], [9., 21.], [10., 22.], [11., 23.]],
+        ]);
+
+        assert_eq!(data_expected, permuted.into_data());
+
+        // Test with negative axis
+        let permuted = tensor.clone().movedim(0_usize, -1);
+        assert_eq!(data_expected, permuted.into_data());
+
+        // Test with the same axis
+        let permuted = tensor.clone().movedim(0_i32, 0_usize);
+        assert_eq!(tensor.into_data(), permuted.into_data());
+    }
+
+    #[test]
     #[should_panic]
     fn edge_different_sizes() {
         let device = Default::default();


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

None

### Changes

Added `movedim` default implementation. Mirrors the [PyTorch one](https://pytorch.org/docs/stable/generated/torch.movedim.html).

This just wraps a call to permute with sanity checks, but moving one/few axes while keeping all others inbound is a common enough operation to warrant its specific convenient syntactic sugar.

### Testing

Added unit tests.