### PR TITLE
Feat/backend/list devices

### DIFF
--- a/crates/burn-autodiff/src/backend.rs
+++ b/crates/burn-autodiff/src/backend.rs
@@ -5,6 +5,7 @@ use crate::{
     tensor::AutodiffTensor,
     AutodiffBridge,
 };
+use alloc::vec::Vec;
 use burn_tensor::backend::{AutodiffBackend, Backend};
 use core::marker::PhantomData;
 

--- a/crates/burn-autodiff/src/backend.rs
+++ b/crates/burn-autodiff/src/backend.rs
@@ -46,6 +46,10 @@ impl<B: Backend, C: CheckpointStrategy> Backend for Autodiff<B, C> {
     fn sync(device: &B::Device) {
         B::sync(device);
     }
+
+    fn list_available_devices() -> Vec<Self::Device> {
+        B::list_available_devices()
+    }
 }
 
 impl<B: Backend, C: CheckpointStrategy> AutodiffBackend for Autodiff<B, C> {

--- a/crates/burn-candle/src/backend.rs
+++ b/crates/burn-candle/src/backend.rs
@@ -121,4 +121,18 @@ impl<F: FloatCandleElement, I: IntCandleElement> Backend for Candle<F, I> {
             }
         }
     }
+
+    fn list_available_devices() -> Vec<Self::Device> {
+        let mut devices = vec![CandleDevice::Cpu];
+
+        // Not sure how to get devices count or list?
+        if candle_core::utils::cuda_is_available() {
+            devices.push(CandleDevice::Cuda(0))
+        }
+
+        if candle_core::utils::metal_is_available() {
+            devices.push(CandleDevice::Metal(0))
+        }
+        devices
+    }
 }

--- a/crates/burn-cuda/src/runtime.rs
+++ b/crates/burn-cuda/src/runtime.rs
@@ -21,6 +21,12 @@ pub struct CudaRuntime;
 impl burn_jit::JitRuntime for CudaRuntime {
     type JitDevice = CudaDevice;
     type JitServer = CudaServer<SimpleMemoryManagement<CudaStorage>>;
+
+    fn list_available_devices() -> Vec<Self::JitDevice> {
+        (0..cudarc::driver::result::device::get_count().unwrap() as usize)
+            .map(|id| CudaDevice::new(id))
+            .collect()
+    }
 }
 
 static RUNTIME: ComputeRuntime<CudaDevice, Server, MutexComputeChannel<Server>> =

--- a/crates/burn-cuda/src/runtime.rs
+++ b/crates/burn-cuda/src/runtime.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use burn_common::stub::RwLock;
 use burn_compute::{
     channel::MutexComputeChannel,
@@ -24,7 +25,7 @@ impl burn_jit::JitRuntime for CudaRuntime {
 
     fn list_available_devices() -> Vec<Self::JitDevice> {
         (0..cudarc::driver::result::device::get_count().unwrap() as usize)
-            .map(|id| CudaDevice::new(id))
+            .map(CudaDevice::new)
             .collect()
     }
 }

--- a/crates/burn-fusion/src/backend.rs
+++ b/crates/burn-fusion/src/backend.rs
@@ -54,6 +54,10 @@ impl<B: FusionBackend> Backend for Fusion<B> {
     fn ad_enabled() -> bool {
         false
     }
+
+    fn list_available_devices() -> Vec<Self::Device> {
+        B::list_available_devices()
+    }
 }
 
 /// The status of a [builder](OptimizationBuilder).

--- a/crates/burn-jit/src/backend.rs
+++ b/crates/burn-jit/src/backend.rs
@@ -52,6 +52,10 @@ where
         let client = R::client(device);
         client.sync();
     }
+
+    fn list_available_devices() -> Vec<Self::Device> {
+        R::list_available_devices()
+    }
 }
 
 impl<R: JitRuntime, F: FloatElement, I: IntElement> core::fmt::Debug for JitBackend<R, F, I> {

--- a/crates/burn-jit/src/lib.rs
+++ b/crates/burn-jit/src/lib.rs
@@ -49,4 +49,7 @@ pub trait JitRuntime: Runtime<Device = Self::JitDevice, Server = Self::JitServer
         AutotuneKey = JitAutotuneKey,
         Kernel = Box<dyn CubeTask>,
     >;
+
+    /// List available devices.
+    fn list_available_devices() -> Vec<Self::JitDevice>;
 }

--- a/crates/burn-ndarray/src/backend.rs
+++ b/crates/burn-ndarray/src/backend.rs
@@ -63,4 +63,8 @@ impl<E: FloatNdArrayElement> Backend for NdArray<E> {
         let mut seed = SEED.lock().unwrap();
         *seed = Some(rng);
     }
+
+    fn list_available_devices() -> Vec<Self::Device> {
+        vec![NdArrayDevice::Cpu]
+    }
 }

--- a/crates/burn-ndarray/src/backend.rs
+++ b/crates/burn-ndarray/src/backend.rs
@@ -1,6 +1,7 @@
 use crate::NdArrayTensor;
 use crate::{element::FloatNdArrayElement, PrecisionBridge};
 use alloc::string::String;
+use alloc::{vec, vec::Vec};
 use burn_common::stub::Mutex;
 use burn_tensor::backend::{Backend, DeviceId, DeviceOps};
 use core::marker::PhantomData;

--- a/crates/burn-tch/src/backend.rs
+++ b/crates/burn-tch/src/backend.rs
@@ -135,8 +135,7 @@ impl<E: TchElement> Backend for LibTorch<E> {
         let mut devices = vec![LibTorchDevice::Cpu];
 
         if tch::utils::has_cuda() {
-            devices
-                .extend((0..tch::Cuda::device_count() as usize).map(|id| LibTorchDevice::Cuda(id)));
+            devices.extend((0..tch::Cuda::device_count() as usize).map(LibTorchDevice::Cuda));
         }
 
         if tch::utils::has_mps() {

--- a/crates/burn-tch/src/backend.rs
+++ b/crates/burn-tch/src/backend.rs
@@ -130,4 +130,23 @@ impl<E: TchElement> Backend for LibTorch<E> {
             }
         }
     }
+
+    fn list_available_devices() -> Vec<Self::Device> {
+        let mut devices = vec![LibTorchDevice::Cpu];
+
+        if tch::utils::has_cuda() {
+            devices
+                .extend((0..tch::Cuda::device_count() as usize).map(|id| LibTorchDevice::Cuda(id)));
+        }
+
+        if tch::utils::has_mps() {
+            devices.push(LibTorchDevice::Mps);
+        }
+
+        if tch::utils::has_vulkan() {
+            devices.push(LibTorchDevice::Vulkan)
+        }
+
+        devices
+    }
 }

--- a/crates/burn-tensor/src/tensor/backend/base.rs
+++ b/crates/burn-tensor/src/tensor/backend/base.rs
@@ -1,4 +1,5 @@
 use alloc::string::String;
+use alloc::vec::Vec;
 
 use crate::ops::*;
 use crate::tensor::Element;
@@ -97,6 +98,9 @@ pub trait Backend:
 
     /// Sync the backend, ensure that all computation are finished.
     fn sync(_device: &Self::Device) {}
+
+    /// List available devices.
+    fn list_available_devices() -> Vec<Self::Device>;
 }
 
 /// Trait that allows a backend to support autodiff.

--- a/crates/burn-wgpu/src/runtime.rs
+++ b/crates/burn-wgpu/src/runtime.rs
@@ -19,7 +19,7 @@ use std::{
     marker::PhantomData,
     sync::atomic::{AtomicBool, Ordering},
 };
-use wgpu::{AdapterInfo, DeviceDescriptor, DeviceType};
+use wgpu::{AdapterInfo, DeviceDescriptor};
 
 /// Runtime that uses the [wgpu] crate with the wgsl compiler.
 ///
@@ -33,7 +33,14 @@ impl<G: GraphicsApi> JitRuntime for WgpuRuntime<G> {
     type JitDevice = WgpuDevice;
     type JitServer = WgpuServer<SimpleMemoryManagement<WgpuStorage>>;
 
+    #[cfg(target_family = "wasm")]
     fn list_available_devices() -> Vec<Self::JitDevice> {
+        vec![WgpuDevice::BestAvailable]
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    fn list_available_devices() -> Vec<Self::JitDevice> {
+        use wgpu::DeviceType;
         let instance = wgpu::Instance::default();
         let mut discrete_cnt = 0;
         let mut integrated_cnt = 0;


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.

### Changes

Added `list_available_devices` to `Backend` and `JitRuntime` trait along with backend-specific implementation

Allows the user to get a list of available devices at runtime, e.g.
```rust
use burn::{
    backend::{Autodiff, LibTorch, NdArray, Wgpu},
    tensor::backend::Backend,
};

fn main() {
    type A = NdArray;
    type B = Wgpu;
    type C = LibTorch;
    type D = Autodiff<B>;

    println!("NdArray: {:?}", A::list_available_devices());

    println!("Wgpu: {:?}", B::list_available_devices());

    println!("Tch: {:?}", C::list_available_devices());

    println!("Autodiff<Wgpu>: {:?}", D::list_available_devices());
}
```

```
NdArray: [Cpu]
Wgpu: [DiscreteGpu(0), IntegratedGpu(0), IntegratedGpu(1)]
Tch: [Cpu, Cuda(0)]
Autodiff<Wgpu>: [DiscreteGpu(0), IntegratedGpu(0), IntegratedGpu(1)]
```