### PR TITLE
Remove GraphicsAPI generic for WgpuRuntime

### DIFF
--- a/backend-comparison/src/lib.rs
+++ b/backend-comparison/src/lib.rs
@@ -62,14 +62,9 @@ macro_rules! bench_on_backend {
 
         #[cfg(feature = "wgpu")]
         {
-            use burn::backend::wgpu::{AutoGraphicsApi, Wgpu, WgpuDevice};
+            use burn::backend::wgpu::{Wgpu, WgpuDevice};
 
-            bench::<Wgpu<AutoGraphicsApi, f32, i32>>(
-                &WgpuDevice::default(),
-                feature_name,
-                url,
-                token,
-            );
+            bench::<Wgpu<f32, i32>>(&WgpuDevice::default(), feature_name, url, token);
         }
 
         #[cfg(feature = "tch-gpu")]

--- a/burn-book/src/advanced/backend-extension/custom-wgpu-kernel.md
+++ b/burn-book/src/advanced/backend-extension/custom-wgpu-kernel.md
@@ -198,7 +198,7 @@ the raw `WgpuBackend` type.
 
 ```rust, ignore
 /// Implement our custom backend trait for the existing backend `WgpuBackend`.
-impl<G: GraphicsApi, F: FloatElement, I: IntElement> Backend for JitBackend<WgpuRuntime<G>, F, I> {
+impl<F: FloatElement, I: IntElement> Backend for JitBackend<WgpuRuntime, F, I> {
     fn fused_matmul_add_relu<const D: usize>(
         lhs: FloatTensor<Self, D>,
         rhs: FloatTensor<Self, D>,

--- a/burn-book/src/basic-workflow/backend.md
+++ b/burn-book/src/basic-workflow/backend.md
@@ -11,13 +11,13 @@ entrypoint of our program, namely the `main` function defined in `src/main.rs`.
 # 
 use crate::{model::ModelConfig, training::TrainingConfig};
 use burn::{
-    backend::{wgpu::AutoGraphicsApi, Autodiff, Wgpu},
+    backend::{Autodiff, Wgpu},
 #     data::dataset::Dataset,
     optim::AdamConfig,
 };
 
 fn main() {
-    type MyBackend = Wgpu<AutoGraphicsApi, f32, i32>;
+    type MyBackend = Wgpu<f32, i32>;
     type MyAutodiffBackend = Autodiff<MyBackend>;
 
     let device = burn::backend::wgpu::WgpuDevice::default();
@@ -32,10 +32,9 @@ fn main() {
 
 In this example, we use the `Wgpu` backend which is compatible with any operating system and will
 use the GPU. For other options, see the Burn README. This backend type takes the graphics API, the
-float type and the int type as generic arguments that will be used during the training. By leaving
-the graphics API as `AutoGraphicsApi`, it should automatically use an API available on your machine.
-The autodiff backend is simply the same backend, wrapped within the `Autodiff` struct which imparts
-differentiability to any backend.
+float type and the int type as generic arguments that will be used during the training. The autodiff 
+backend is simply the same backend, wrapped within the `Autodiff` struct which imparts differentiability \
+to any backend.
 
 We call the `train` function defined earlier with a directory for artifacts, the configuration of
 the model (the number of digit classes is 10 and the hidden dimension is 512), the optimizer

--- a/burn-book/src/basic-workflow/inference.md
+++ b/burn-book/src/basic-workflow/inference.md
@@ -56,13 +56,13 @@ Add the call to `infer` to the `main.rs` file after the `train` function call:
 # 
 # use crate::{model::ModelConfig, training::TrainingConfig};
 # use burn::{
-#     backend::{wgpu::AutoGraphicsApi, Autodiff, Wgpu},
+#     backend::{Autodiff, Wgpu},
 #     data::dataset::Dataset,
 #     optim::AdamConfig,
 # };
 # 
 # fn main() {
-#     type MyBackend = Wgpu<AutoGraphicsApi, f32, i32>;
+#     type MyBackend = Wgpu<f32, i32>;
 #     type MyAutodiffBackend = Autodiff<MyBackend>;
 # 
 #     let device = burn::backend::wgpu::WgpuDevice::default();

--- a/crates/burn-wgpu/README.md
+++ b/crates/burn-wgpu/README.md
@@ -16,12 +16,12 @@ The backend supports Vulkan, Metal, DirectX11/12, OpenGL, WebGPU.
 #[cfg(feature = "wgpu")]
 mod wgpu {
     use burn_autodiff::Autodiff;
-    use burn_wgpu::{AutoGraphicsApi, Wgpu, WgpuDevice};
+    use burn_wgpu::{Wgpu, WgpuDevice};
     use mnist::training;
 
     pub fn run() {
         let device = WgpuDevice::default();
-        training::run::<Autodiff<Wgpu<AutoGraphicsApi, f32, i32>>>(device);
+        training::run::<Autodiff<Wgpu<f32, i32>>>(device);
     }
 }
 ```

--- a/crates/burn-wgpu/src/lib.rs
+++ b/crates/burn-wgpu/src/lib.rs
@@ -37,6 +37,18 @@ pub use burn_jit::{tensor::JitTensor, JitBackend};
 ///   - [Metal] on Apple hardware.
 ///   - [WebGPU](crate::WebGpu) on supported browsers and `wasm` runtimes.
 ///
+/// To configure the wgpu backend, eg. to select what graphics API to use or what memory strategy to use,
+/// you have to manually initialize the runtime. For example:
+///
+/// ```rust
+/// fn custom_init() {
+///     let device = Default::default();
+///     WgpuRuntime::init_sync::<Vulkan>(&device, Default::default());
+/// }
+/// ```
+/// will mean the given device (in this case the default) will be initialized to use Vulkan as the graphics API.
+/// It's also possible to use an existing wgpu device, by using `init_existing_device`.
+///
 /// # Notes
 ///
 /// This version of the [wgpu] backend uses [burn_fusion] to compile and optimize streams of tensor
@@ -55,6 +67,18 @@ pub type Wgpu<F = f32, I = i32> = burn_fusion::Fusion<JitBackend<WgpuRuntime, F,
 ///   - [DirectX 12](crate::Dx12) on Windows.
 ///   - [Metal] on Apple hardware.
 ///   - [WebGPU](crate::WebGpu) on supported browsers and `wasm` runtimes.
+///
+/// To configure the wgpu backend, eg. to select what graphics API to use or what memory strategy to use,
+/// you have to manually initialize the runtime. For example:
+///
+/// ```rust
+/// fn custom_init() {
+///     let device = Default::default();
+///     WgpuRuntime::init_sync::<Vulkan>(&device, Default::default());
+/// }
+/// ```
+/// will mean the given device (in this case the default) will be initialized to use Vulkan as the graphics API.
+/// It's also possible to use an existing wgpu device, by using `init_existing_device`.
 ///
 /// # Notes
 ///

--- a/crates/burn-wgpu/src/lib.rs
+++ b/crates/burn-wgpu/src/lib.rs
@@ -43,7 +43,10 @@ pub use burn_jit::{tensor::JitTensor, JitBackend};
 /// ```rust
 /// fn custom_init() {
 ///     let device = Default::default();
-///     WgpuRuntime::init_sync::<Vulkan>(&device, Default::default());
+///     burn::backend::wgpu::init_sync::<burn::backend::wgpu::Vulkan>(
+///         &device,
+///         Default::default(),
+///     );
 /// }
 /// ```
 /// will mean the given device (in this case the default) will be initialized to use Vulkan as the graphics API.
@@ -74,7 +77,10 @@ pub type Wgpu<F = f32, I = i32> = burn_fusion::Fusion<JitBackend<WgpuRuntime, F,
 /// ```rust
 /// fn custom_init() {
 ///     let device = Default::default();
-///     WgpuRuntime::init_sync::<Vulkan>(&device, Default::default());
+///     burn::backend::wgpu::init_sync::<burn::backend::wgpu::Vulkan>(
+///         &device,
+///         Default::default(),
+///     );
 /// }
 /// ```
 /// will mean the given device (in this case the default) will be initialized to use Vulkan as the graphics API.

--- a/crates/burn-wgpu/src/lib.rs
+++ b/crates/burn-wgpu/src/lib.rs
@@ -44,8 +44,7 @@ pub use burn_jit::{tensor::JitTensor, JitBackend};
 ///
 /// You can disable the `fusion` feature flag to remove that functionality, which might be
 /// necessary on `wasm` for now.
-pub type Wgpu<G = AutoGraphicsApi, F = f32, I = i32> =
-    burn_fusion::Fusion<JitBackend<WgpuRuntime<G>, F, I>>;
+pub type Wgpu<F = f32, I = i32> = burn_fusion::Fusion<JitBackend<WgpuRuntime, F, I>>;
 
 #[cfg(not(feature = "fusion"))]
 /// Tensor backend that uses the [wgpu] crate for executing GPU compute shaders.
@@ -64,13 +63,13 @@ pub type Wgpu<G = AutoGraphicsApi, F = f32, I = i32> =
 ///
 /// You can enable the `fusion` feature flag to add that functionality, which might improve
 /// performance.
-pub type Wgpu<G = AutoGraphicsApi, F = f32, I = i32> = JitBackend<WgpuRuntime<G>, F, I>;
+pub type Wgpu<F = f32, I = i32> = JitBackend<WgpuRuntime, F, I>;
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    pub type TestRuntime = crate::WgpuRuntime<AutoGraphicsApi>;
+    pub type TestRuntime = crate::WgpuRuntime;
 
     burn_jit::testgen_all!();
     burn_cube::testgen_all!();

--- a/crates/burn-wgpu/src/lib.rs
+++ b/crates/burn-wgpu/src/lib.rs
@@ -40,7 +40,7 @@ pub use burn_jit::{tensor::JitTensor, JitBackend};
 /// To configure the wgpu backend, eg. to select what graphics API to use or what memory strategy to use,
 /// you have to manually initialize the runtime. For example:
 ///
-/// ```rust
+/// ```rust, ignore
 /// fn custom_init() {
 ///     let device = Default::default();
 ///     burn::backend::wgpu::init_sync::<burn::backend::wgpu::Vulkan>(
@@ -74,7 +74,7 @@ pub type Wgpu<F = f32, I = i32> = burn_fusion::Fusion<JitBackend<WgpuRuntime, F,
 /// To configure the wgpu backend, eg. to select what graphics API to use or what memory strategy to use,
 /// you have to manually initialize the runtime. For example:
 ///
-/// ```rust
+/// ```rust, ignore
 /// fn custom_init() {
 ///     let device = Default::default();
 ///     burn::backend::wgpu::init_sync::<burn::backend::wgpu::Vulkan>(

--- a/examples/custom-wgpu-kernel/examples/custom-wgpu-kernel.rs
+++ b/examples/custom-wgpu-kernel/examples/custom-wgpu-kernel.rs
@@ -1,5 +1,5 @@
 use burn::{
-    backend::wgpu::{AutoGraphicsApi, WgpuRuntime},
+    backend::wgpu::WgpuRuntime,
     tensor::{Distribution, Tensor},
 };
 use custom_wgpu_kernel::{
@@ -71,7 +71,7 @@ fn autodiff<B: AutodiffBackend>(device: &B::Device) {
 }
 
 fn main() {
-    type MyBackend = burn::backend::wgpu::JitBackend<WgpuRuntime<AutoGraphicsApi>, f32, i32>;
+    type MyBackend = burn::backend::wgpu::JitBackend<WgpuRuntime, f32, i32>;
     type MyAutodiffBackend = burn::backend::Autodiff<MyBackend>;
     let device = Default::default();
     inference::<MyBackend>(&device);

--- a/examples/custom-wgpu-kernel/src/backward.rs
+++ b/examples/custom-wgpu-kernel/src/backward.rs
@@ -9,15 +9,12 @@ use burn::{
             ops::{broadcast_shape, Backward, Ops, OpsKind},
             Autodiff, NodeID,
         },
-        wgpu::{FloatElement, GraphicsApi, IntElement, JitBackend, WgpuRuntime},
+        wgpu::{FloatElement, IntElement, JitBackend, WgpuRuntime},
     },
     tensor::Shape,
 };
 
-impl<G: GraphicsApi, F: FloatElement, I: IntElement> AutodiffBackend
-    for Autodiff<JitBackend<WgpuRuntime<G>, F, I>>
-{
-}
+impl<F: FloatElement, I: IntElement> AutodiffBackend for Autodiff<JitBackend<WgpuRuntime, F, I>> {}
 
 // Implement our custom backend trait for any backend that also implements our custom backend trait.
 //

--- a/examples/custom-wgpu-kernel/src/forward.rs
+++ b/examples/custom-wgpu-kernel/src/forward.rs
@@ -3,8 +3,8 @@ use crate::FloatTensor;
 use super::Backend;
 use burn::{
     backend::wgpu::{
-        build_info, into_contiguous, kernel_wgsl, CubeCount, CubeDim, FloatElement, GraphicsApi,
-        IntElement, JitBackend, JitTensor, KernelSource, SourceKernel, SourceTemplate, WgpuRuntime,
+        build_info, into_contiguous, kernel_wgsl, CubeCount, CubeDim, FloatElement, IntElement,
+        JitBackend, JitTensor, KernelSource, SourceKernel, SourceTemplate, WgpuRuntime,
     },
     tensor::Shape,
 };
@@ -36,7 +36,7 @@ impl<E: FloatElement> KernelSource for FusedMatmulAddRelu<E> {
 }
 
 /// Implement our custom backend trait for the existing backend `WgpuBackend`.
-impl<G: GraphicsApi, F: FloatElement, I: IntElement> Backend for JitBackend<WgpuRuntime<G>, F, I> {
+impl<F: FloatElement, I: IntElement> Backend for JitBackend<WgpuRuntime, F, I> {
     fn fused_matmul_add_relu<const D: usize>(
         lhs: FloatTensor<Self, D>,
         rhs: FloatTensor<Self, D>,

--- a/examples/guide/src/main.rs
+++ b/examples/guide/src/main.rs
@@ -5,13 +5,13 @@ mod training;
 
 use crate::{model::ModelConfig, training::TrainingConfig};
 use burn::{
-    backend::{wgpu::AutoGraphicsApi, Autodiff, Wgpu},
+    backend::{Autodiff, Wgpu},
     data::dataset::Dataset,
     optim::AdamConfig,
 };
 
 fn main() {
-    type MyBackend = Wgpu<AutoGraphicsApi, f32, i32>;
+    type MyBackend = Wgpu<f32, i32>;
     type MyAutodiffBackend = Autodiff<MyBackend>;
 
     let device = burn::backend::wgpu::WgpuDevice::default();

--- a/examples/image-classification-web/src/web.rs
+++ b/examples/image-classification-web/src/web.rs
@@ -34,7 +34,7 @@ pub enum ModelType {
     WithNdArrayBackend(Model<NdArray<f32>>),
 
     /// The model is loaded to the Wgpu backend
-    WithWgpuBackend(Model<Wgpu<AutoGraphicsApi, f32, i32>>),
+    WithWgpuBackend(Model<Wgpu<f32, i32>>),
 }
 
 /// The image is 224x224 pixels with 3 channels (RGB)

--- a/examples/mnist-inference-web/src/state.rs
+++ b/examples/mnist-inference-web/src/state.rs
@@ -8,7 +8,7 @@ use burn::{
 use burn::backend::wgpu::{init_async, AutoGraphicsApi, Wgpu, WgpuDevice};
 
 #[cfg(feature = "wgpu")]
-pub type Backend = Wgpu<AutoGraphicsApi, f32, i32>;
+pub type Backend = Wgpu<f32, i32>;
 
 #[cfg(all(feature = "ndarray", not(feature = "wgpu")))]
 pub type Backend = burn::backend::ndarray::NdArray<f32>;

--- a/examples/text-classification/examples/ag-news-infer.rs
+++ b/examples/text-classification/examples/ag-news-infer.rs
@@ -74,10 +74,10 @@ mod tch_cpu {
 #[cfg(feature = "wgpu")]
 mod wgpu {
     use crate::{launch, ElemType};
-    use burn::backend::wgpu::{AutoGraphicsApi, Wgpu, WgpuDevice};
+    use burn::backend::wgpu::{Wgpu, WgpuDevice};
 
     pub fn run() {
-        launch::<Wgpu<AutoGraphicsApi, ElemType, i32>>(WgpuDevice::default());
+        launch::<Wgpu<ElemType, i32>>(WgpuDevice::default());
     }
 }
 

--- a/examples/text-classification/examples/ag-news-train.rs
+++ b/examples/text-classification/examples/ag-news-train.rs
@@ -85,12 +85,12 @@ mod tch_cpu {
 mod wgpu {
     use crate::{launch, ElemType};
     use burn::backend::{
-        wgpu::{AutoGraphicsApi, Wgpu, WgpuDevice},
+        wgpu::{Wgpu, WgpuDevice},
         Autodiff,
     };
 
     pub fn run() {
-        launch::<Autodiff<Wgpu<AutoGraphicsApi, ElemType, i32>>>(vec![WgpuDevice::default()]);
+        launch::<Autodiff<Wgpu<ElemType, i32>>>(vec![WgpuDevice::default()]);
     }
 }
 

--- a/examples/text-classification/examples/db-pedia-infer.rs
+++ b/examples/text-classification/examples/db-pedia-infer.rs
@@ -82,14 +82,14 @@ mod tch_cpu {
 #[cfg(feature = "wgpu")]
 mod wgpu {
     use burn::backend::{
-        wgpu::{AutoGraphicsApi, Wgpu, WgpuDevice},
+        wgpu::{Wgpu, WgpuDevice},
         Autodiff,
     };
 
     use crate::{launch, ElemType};
 
     pub fn run() {
-        launch::<Autodiff<Wgpu<AutoGraphicsApi, ElemType, i32>>>(WgpuDevice::default());
+        launch::<Autodiff<Wgpu<ElemType, i32>>>(WgpuDevice::default());
     }
 }
 

--- a/examples/text-classification/examples/db-pedia-train.rs
+++ b/examples/text-classification/examples/db-pedia-train.rs
@@ -81,14 +81,14 @@ mod tch_cpu {
 #[cfg(feature = "wgpu")]
 mod wgpu {
     use burn::backend::{
-        wgpu::{AutoGraphicsApi, Wgpu, WgpuDevice},
+        wgpu::{Wgpu, WgpuDevice},
         Autodiff,
     };
 
     use crate::{launch, ElemType};
 
     pub fn run() {
-        launch::<Autodiff<Wgpu<AutoGraphicsApi, ElemType, i32>>>(vec![WgpuDevice::default()]);
+        launch::<Autodiff<Wgpu<ElemType, i32>>>(vec![WgpuDevice::default()]);
     }
 }
 


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

Slightly cheeky PR so bear with me :) 


Ran into some annoying trait bounds while trying to do some stuff and rather than just grumble, felt like I could remove this entirely! A WgpuRuntime is a WgpuRuntime - irregardless of what the graphics API is. This is particularly evident with `runtime::init_existing_device()` - it's possible to register a DX12 device, and yet run it on a BurnRuntime<Vulkan> which just seems wrong!

I understand it's used to manually pick a graphics API, but, you can already do this with

```
runtime::init_sync<Vulkan>();
```

This could also be in RuntimeOptions perhaps, for consistency.


All that said, this is a bit of miscellaneous design change in a PR so thanks for bearing with me :)