### PR TITLE
feat: Make RetroForward public

### DIFF
--- a/crates/burn-autodiff/src/checkpoint/mod.rs
+++ b/crates/burn-autodiff/src/checkpoint/mod.rs
@@ -1,7 +1,8 @@
 /// Checkpointer module
 pub mod base;
 pub(crate) mod builder;
-pub(crate) mod retro_forward;
+/// RetroForward module
+pub mod retro_forward;
 pub(crate) mod state;
 /// CheckpointStrategy module
 pub mod strategy;

--- a/crates/burn-autodiff/src/checkpoint/mod.rs
+++ b/crates/burn-autodiff/src/checkpoint/mod.rs
@@ -3,6 +3,7 @@ pub mod base;
 pub(crate) mod builder;
 /// RetroForward module
 pub mod retro_forward;
-pub(crate) mod state;
+/// BackwardStates module
+pub mod state;
 /// CheckpointStrategy module
 pub mod strategy;

--- a/crates/burn-autodiff/src/checkpoint/retro_forward.rs
+++ b/crates/burn-autodiff/src/checkpoint/retro_forward.rs
@@ -8,6 +8,7 @@ use super::state::{BackwardStates, State};
 /// This is different from the normal forward function because it reads and writes from
 /// the [InnerStates] map instead of having a clear function signature.
 pub trait RetroForward: Debug + Send + 'static {
+    /// Applies the forward pass for retropropagation.
     fn forward(&self, states: &mut BackwardStates, out_node: NodeID);
 }
 

--- a/crates/burn-autodiff/src/checkpoint/retro_forward.rs
+++ b/crates/burn-autodiff/src/checkpoint/retro_forward.rs
@@ -6,7 +6,7 @@ use super::state::{BackwardStates, State};
 
 /// Definition of the forward function of a node, called during retropropagation only.
 /// This is different from the normal forward function because it reads and writes from
-/// the [InnerStates] map instead of having a clear function signature.
+/// the [BackwardStates] map instead of having a clear function signature.
 pub trait RetroForward: Debug + Send + 'static {
     /// Applies the forward pass for retropropagation.
     fn forward(&self, states: &mut BackwardStates, out_node: NodeID);

--- a/crates/burn-autodiff/src/checkpoint/state.rs
+++ b/crates/burn-autodiff/src/checkpoint/state.rs
@@ -60,16 +60,16 @@ impl State {
 }
 
 #[derive(new, Default, Debug)]
-/// Links [NodeID]s to their current [State]
+/// Links [NodeID]s to their current state
 pub struct BackwardStates {
     map: HashMap<NodeID, State>,
 }
 
 impl BackwardStates {
-    /// Returns the output in the [State] of the given [NodeID],
+    /// Returns the output in the state of the given [NodeID],
     /// and decrements the number of times this state is required.
     /// This function always gives ownership of the output, but will clone it if needed for further uses.
-    pub(crate) fn get_state<T>(&mut self, node_id: &NodeID) -> T
+    pub fn get_state<T>(&mut self, node_id: &NodeID) -> T
     where
         T: Clone + Send + 'static,
     {
@@ -117,7 +117,8 @@ impl BackwardStates {
         self.map.insert(node_id, state);
     }
 
-    pub(crate) fn save<T>(&mut self, node_id: NodeID, saved_output: T)
+    /// Saves the output to the state of the given [NodeID].
+    pub fn save<T>(&mut self, node_id: NodeID, saved_output: T)
     where
         T: Clone + Send + 'static,
     {


### PR DESCRIPTION
Currently, RetroForward is private, making it impossible to implement a memory-bound operation.
Here, I made RetroForward and relevant struct/functions available to outside of burn-autodiff.

## Pull Request Template

### Checklist

- [ ] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

`tests::jit_fusion::remainder::tests::should_be_zero` test failed both on main and this branch, therefore I could not confirm the `run-checks all` success.

### Related Issues/PRs

#1358: Implemented RetroForward.

### Changes

- RetroForward and BackwardStates were made public.
- Some of the BackwardStates' functions were also made public.
- Removed reference to State in BackwardStates' doc comment.

### Testing

No unit test was added in this PR, though I confirmed that I now can use `retro_unary` in my project.