### PR TITLE
Fix wasm error as it can't use autotune-persistent-cache

### DIFF
--- a/crates/burn-cuda/Cargo.toml
+++ b/crates/burn-cuda/Cargo.toml
@@ -19,7 +19,7 @@ std = ["burn-jit/std"]
 
 [dependencies]
 burn-jit = { path = "../burn-jit", version = "0.14.0", default-features = false }
-burn-compute = { path = "../burn-compute", version = "0.14.0" }
+burn-compute = { path = "../burn-compute", version = "0.14.0", default-features = false }
 burn-tensor = { path = "../burn-tensor", version = "0.14.0" }
 burn-common = { path = "../burn-common", version = "0.14.0" }
 burn-cube = { path = "../burn-cube", version = "0.14.0" }
@@ -27,7 +27,7 @@ burn-fusion = { path = "../burn-fusion", version = "0.14.0", optional = true }
 
 half = { workspace = true }
 bytemuck = { workspace = true }
-cudarc = { version = "0.11.6", features=["cuda-12030"] }
+cudarc = { version = "0.11.6", features = ["cuda-12030"] }
 
 log = { workspace = true }
 derive-new = { workspace = true }

--- a/crates/burn-wgpu/Cargo.toml
+++ b/crates/burn-wgpu/Cargo.toml
@@ -20,7 +20,7 @@ std = ["burn-jit/std"]
 
 [dependencies]
 burn-jit = { path = "../burn-jit", version = "0.14.0", default-features = false }
-burn-compute = { path = "../burn-compute", version = "0.14.0" }
+burn-compute = { path = "../burn-compute", version = "0.14.0", default-features = false }
 burn-tensor = { path = "../burn-tensor", version = "0.14.0" }
 burn-common = { path = "../burn-common", version = "0.14.0" }
 burn-fusion = { path = "../burn-fusion", version = "0.14.0", optional = true }
@@ -41,4 +41,4 @@ burn-jit = { path = "../burn-jit", version = "0.14.0", default-features = false,
 ] }
 burn-cube = { path = "../burn-cube", version = "0.14.0", features = [
   "export_tests",
-]}
+] }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.

### Changes

Wasm can't use autotune-persistent-cache. However, it's enabled by default, and some burn crates pull in burn-compute with defaults.

Exlude these defaults in some places and instead let the default propogate.

My cargo-fu isn't very good so I'm not entirely sure if this is the preferred way to do this! One alternative for example is to change all cfgs to `and(cfg(feature=persistent), not(target(wasm))`, but I'm not sure.
