### PR TITLE
Book: Fix the link to burn-train in "Learner" page

### DIFF
--- a/burn-book/src/building-blocks/learner.md
+++ b/burn-book/src/building-blocks/learner.md
@@ -1,12 +1,12 @@
 # Learner
 
-The [burn-train](https://github.com/tracel-ai/burn/tree/main/burn-train) crate encapsulates multiple
-utilities for training deep learning models. The goal of the crate is to provide users with a
-well-crafted and flexible training loop, so that projects do not have to write such components from
-the ground up. Most of the interactions with `burn-train` will be with the `LearnerBuilder` struct,
-briefly presented in the previous [training section](../basic-workflow/training.md). This struct
-enables you to configure the training loop, offering support for registering metrics, enabling
-logging, checkpointing states, using multiple devices, and so on.
+The [burn-train](https://github.com/tracel-ai/burn/tree/main/crates/burn-train) crate encapsulates
+multiple utilities for training deep learning models. The goal of the crate is to provide users with
+a well-crafted and flexible training loop, so that projects do not have to write such components
+from the ground up. Most of the interactions with `burn-train` will be with the `LearnerBuilder`
+struct, briefly presented in the previous [training section](../basic-workflow/training.md). This
+struct enables you to configure the training loop, offering support for registering metrics,
+enabling logging, checkpointing states, using multiple devices, and so on.
 
 There are still some assumptions in the current provided APIs, which may make them inappropriate for
 your learning requirements. Indeed, they assume your model will learn from a training dataset and be


### PR DESCRIPTION
## Pull Request Template

### Checklist
- [ ] Confirmed that `run-checks all` script has been executed.
          I couldn't run through all the checks due to errors from compiling "burn-autodiff".
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs
None.

### Changes
* Problem:
    The "crates" directory part is missing in the link to the burn-train crate in the "Learner" page.
* Solution:
    Add the missing "crates/" to the link.

### Testing
* `cargo xtask books burn open`
* Unwrapping the paragraph into one line and ensuring by diff that the only actual change is "crates/" being added.


