### PR TITLE
Refactor/cube/mutability

### DIFF
--- a/crates/burn-cube-macros/src/codegen_function/expr.rs
+++ b/crates/burn-cube-macros/src/codegen_function/expr.rs
@@ -93,6 +93,7 @@ pub(crate) fn codegen_ref(
     loop_level: usize,
     variable_tracker: &mut VariableTracker,
 ) -> TokenStream {
+    // We ignore reference for the expansion.
     let inner = codegen_expr(&reference.expr, loop_level, variable_tracker);
-    quote::quote! { & #inner }
+    quote::quote! { #inner }
 }

--- a/crates/burn-cube-macros/src/codegen_function/launch.rs
+++ b/crates/burn-cube-macros/src/codegen_function/launch.rs
@@ -77,20 +77,17 @@ impl Codegen {
                     }
 
                     if is_output {
-                        let ty = match *ty {
-                            syn::Type::Reference(val) => val.elem,
-                            _ => ty,
-                        };
-                        codegen.state_outputs.push((ident.clone(), *ty));
+                        codegen
+                            .state_outputs
+                            .push((ident.clone(), no_ref(&ty).clone()));
                     } else if comptime {
-                        let ty = first_generic_ty(&ty);
-                        codegen.state_comptimes.push((ty.clone(), ident.clone()));
+                        codegen
+                            .state_comptimes
+                            .push((first_generic_ty(&ty).clone(), ident.clone()));
                     } else {
-                        let ty = match *ty {
-                            syn::Type::Reference(val) => val.elem,
-                            _ => ty,
-                        };
-                        codegen.state_inputs.push((ident.clone(), *ty));
+                        codegen
+                            .state_inputs
+                            .push((ident.clone(), no_ref(&ty).clone()));
                     }
                 }
                 _ => panic!("Only Typed inputs are supported"),

--- a/crates/burn-cube-macros/src/codegen_function/launch.rs
+++ b/crates/burn-cube-macros/src/codegen_function/launch.rs
@@ -145,13 +145,13 @@ impl Codegen {
 
         for (pos, (ident, ty)) in self.state_inputs.iter().enumerate() {
             variables.extend(quote::quote! {
-                let #ident = <&#ty as LaunchDefinition>::define(&mut builder, self.settings.vectorization_input(#pos));
+                let #ident = <&#ty as LaunchArgExpand>::expand(&mut builder, self.settings.vectorization_input(#pos));
             });
         }
 
         for (pos, (ident, ty)) in self.state_outputs.iter().enumerate() {
             variables.extend(quote::quote! {
-                let #ident = <&mut #ty as LaunchDefinition>::define(&mut builder, self.settings.vectorization_output(#pos));
+                let #ident = <&mut #ty as LaunchArgExpand>::expand(&mut builder, self.settings.vectorization_output(#pos));
             });
         }
 

--- a/crates/burn-cube-macros/src/codegen_function/launch.rs
+++ b/crates/burn-cube-macros/src/codegen_function/launch.rs
@@ -39,6 +39,12 @@ impl Codegen {
                                 is_output = true;
                             }
 
+                            if let syn::Type::Reference(ty) = pat.ty.as_ref() {
+                                if ty.mutability.is_some() {
+                                    is_output = true;
+                                }
+                            };
+
                             if let syn::Type::Path(pat) = pat.ty.as_ref() {
                                 if let Some(name) = pat.path.segments.first() {
                                     let name = name.ident.to_string();

--- a/crates/burn-cube-macros/src/codegen_type/base.rs
+++ b/crates/burn-cube-macros/src/codegen_type/base.rs
@@ -153,10 +153,10 @@ impl TypeCodegen {
             let vis = &field.vis;
 
             body_input.extend(quote! {
-                #vis #ident: <&#ty as LaunchDefinition>::define(builder, vectorization),
+                #vis #ident: <&#ty as LaunchArgExpand>::expand(builder, vectorization),
             });
             body_output.extend(quote! {
-                #vis #ident: <&mut #ty as LaunchDefinition>::define(builder, vectorization),
+                #vis #ident: <&mut #ty as LaunchArgExpand>::expand(builder, vectorization),
             });
         }
 
@@ -170,8 +170,8 @@ impl TypeCodegen {
                 type RuntimeArg #runtime_generics_impl = #name_launch #all_generics_use;
             }
 
-            impl #type_generics_impl LaunchDefinition for &#name #type_generics_use {
-                fn define(
+            impl #type_generics_impl LaunchArgExpand for &#name #type_generics_use {
+                fn expand(
                     builder: &mut KernelBuilder,
                     vectorization: burn_cube::ir::Vectorization,
                 ) -> <Self as CubeType>::ExpandType {
@@ -181,8 +181,8 @@ impl TypeCodegen {
                 }
             }
 
-            impl #type_generics_impl LaunchDefinition for &mut #name #type_generics_use {
-                fn define(
+            impl #type_generics_impl LaunchArgExpand for &mut #name #type_generics_use {
+                fn expand(
                     builder: &mut KernelBuilder,
                     vectorization: burn_cube::ir::Vectorization,
                 ) -> <Self as CubeType>::ExpandType {

--- a/crates/burn-cube-macros/src/lib.rs
+++ b/crates/burn-cube-macros/src/lib.rs
@@ -157,6 +157,7 @@ fn expand_sig(
         match input {
             syn::FnArg::Typed(pat) => {
                 let ty = &pat.ty;
+
                 let ident = pat.pat.clone();
 
                 if let syn::Pat::Ident(ident) = ident.as_ref() {

--- a/crates/burn-cube/src/frontend/comptime.rs
+++ b/crates/burn-cube/src/frontend/comptime.rs
@@ -74,7 +74,7 @@ impl<T: Clone + Init> CubeType for Comptime<T> {
 }
 
 impl<T: Vectorized> Comptime<T> {
-    pub fn vectorization(_state: T) -> Comptime<UInt> {
+    pub fn vectorization(_state: &T) -> Comptime<UInt> {
         unexpanded!()
     }
 

--- a/crates/burn-cube/src/frontend/context.rs
+++ b/crates/burn-cube/src/frontend/context.rs
@@ -4,7 +4,7 @@ use alloc::rc::Rc;
 use core::cell::RefCell;
 use std::collections::HashMap;
 
-use super::{CubeElem, SharedMemoryExpand};
+use super::{CubePrimitive, SharedMemoryExpand};
 
 #[derive(Default, Clone)]
 pub struct VariablePool {
@@ -111,7 +111,11 @@ impl CubeContext {
         new
     }
 
-    pub fn create_shared<T: CubeElem>(&mut self, item: Item, size: u32) -> SharedMemoryExpand<T> {
+    pub fn create_shared<T: CubePrimitive>(
+        &mut self,
+        item: Item,
+        size: u32,
+    ) -> SharedMemoryExpand<T> {
         SharedMemoryExpand {
             val: ExpandElement::Plain(self.root.borrow_mut().create_shared(item, size)),
         }

--- a/crates/burn-cube/src/frontend/element/array.rs
+++ b/crates/burn-cube/src/frontend/element/array.rs
@@ -7,7 +7,7 @@ use crate::{
     unexpanded, Runtime,
 };
 
-use super::{ArgSettings, CubeElem, LaunchArg, LaunchArgExpand, TensorHandle, UInt};
+use super::{ArgSettings, CubePrimitive, LaunchArg, LaunchArgExpand, TensorHandle, UInt};
 
 #[derive(new)]
 pub struct Array<E> {
@@ -33,17 +33,17 @@ impl<E: CubeType> Array<E> {
     }
 }
 
-impl<C: CubeElem> LaunchArg for Array<C> {
+impl<C: CubePrimitive> LaunchArg for Array<C> {
     type RuntimeArg<'a, R: Runtime> = ArrayHandle<'a, R>;
 }
 
-impl<C: CubeElem> LaunchArgExpand for &Array<C> {
+impl<C: CubePrimitive> LaunchArgExpand for &Array<C> {
     fn expand(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
         builder.input_array(Item::vectorized(C::as_elem(), vectorization))
     }
 }
 
-impl<C: CubeElem> LaunchArgExpand for &mut Array<C> {
+impl<C: CubePrimitive> LaunchArgExpand for &mut Array<C> {
     fn expand(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
         builder.output_array(Item::vectorized(C::as_elem(), vectorization))
     }

--- a/crates/burn-cube/src/frontend/element/array.rs
+++ b/crates/burn-cube/src/frontend/element/array.rs
@@ -9,7 +9,7 @@ use crate::{
 
 use super::{ArgSettings, CubeElem, LaunchArg, LaunchDefinition, TensorHandle, UInt};
 
-#[derive(new, Clone, Copy)]
+#[derive(new)]
 pub struct Array<E> {
     _val: PhantomData<E>,
 }
@@ -28,7 +28,7 @@ impl<C: CubeType> CubeType for &mut Array<C> {
 
 impl<E: CubeType> Array<E> {
     /// Obtain the array length of input
-    pub fn len(self) -> UInt {
+    pub fn len(&self) -> UInt {
         unexpanded!()
     }
 }

--- a/crates/burn-cube/src/frontend/element/array.rs
+++ b/crates/burn-cube/src/frontend/element/array.rs
@@ -7,7 +7,7 @@ use crate::{
     unexpanded, Runtime,
 };
 
-use super::{ArgSettings, CubeElem, LaunchArg, TensorHandle, UInt};
+use super::{ArgSettings, CubeElem, LaunchArg, LaunchDefinition, TensorHandle, UInt};
 
 #[derive(new, Clone, Copy)]
 pub struct Array<E> {
@@ -15,6 +15,14 @@ pub struct Array<E> {
 }
 
 impl<C: CubeType> CubeType for Array<C> {
+    type ExpandType = ExpandElement;
+}
+
+impl<C: CubeType> CubeType for &Array<C> {
+    type ExpandType = ExpandElement;
+}
+
+impl<C: CubeType> CubeType for &mut Array<C> {
     type ExpandType = ExpandElement;
 }
 
@@ -27,12 +35,16 @@ impl<E: CubeType> Array<E> {
 
 impl<C: CubeElem> LaunchArg for Array<C> {
     type RuntimeArg<'a, R: Runtime> = ArrayHandle<'a, R>;
+}
 
-    fn compile_input(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
+impl<C: CubeElem> LaunchDefinition for &Array<C> {
+    fn define(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
         builder.input_array(Item::vectorized(C::as_elem(), vectorization))
     }
+}
 
-    fn compile_output(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
+impl<C: CubeElem> LaunchDefinition for &mut Array<C> {
+    fn define(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
         builder.output_array(Item::vectorized(C::as_elem(), vectorization))
     }
 }

--- a/crates/burn-cube/src/frontend/element/array.rs
+++ b/crates/burn-cube/src/frontend/element/array.rs
@@ -7,7 +7,7 @@ use crate::{
     unexpanded, Runtime,
 };
 
-use super::{ArgSettings, CubeElem, LaunchArg, LaunchDefinition, TensorHandle, UInt};
+use super::{ArgSettings, CubeElem, LaunchArg, LaunchArgExpand, TensorHandle, UInt};
 
 #[derive(new)]
 pub struct Array<E> {
@@ -37,14 +37,14 @@ impl<C: CubeElem> LaunchArg for Array<C> {
     type RuntimeArg<'a, R: Runtime> = ArrayHandle<'a, R>;
 }
 
-impl<C: CubeElem> LaunchDefinition for &Array<C> {
-    fn define(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
+impl<C: CubeElem> LaunchArgExpand for &Array<C> {
+    fn expand(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
         builder.input_array(Item::vectorized(C::as_elem(), vectorization))
     }
 }
 
-impl<C: CubeElem> LaunchDefinition for &mut Array<C> {
-    fn define(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
+impl<C: CubeElem> LaunchArgExpand for &mut Array<C> {
+    fn expand(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
         builder.output_array(Item::vectorized(C::as_elem(), vectorization))
     }
 }

--- a/crates/burn-cube/src/frontend/element/base.rs
+++ b/crates/burn-cube/src/frontend/element/base.rs
@@ -27,21 +27,28 @@ pub trait Init {
     fn init(self, context: &mut CubeContext) -> Self;
 }
 
+pub trait LaunchDefinition: CubeType {
+    /// Register an input variable during compilation that fill the [KernelBuilder].
+    fn define(
+        builder: &mut KernelBuilder,
+        vectorization: Vectorization,
+    ) -> <Self as CubeType>::ExpandType;
+}
+
 /// Defines a type that can be used as argument to a kernel.
 pub trait LaunchArg: CubeType {
     /// The runtime argument for the kernel.
     type RuntimeArg<'a, R: Runtime>: ArgSettings<R>;
-
-    /// Register an input variable during compilation that fill the [KernelBuilder].
-    fn compile_input(
-        builder: &mut KernelBuilder,
-        vectorization: Vectorization,
-    ) -> <Self as CubeType>::ExpandType;
-    /// Register an output variable during compilation that fill the [KernelBuilder].
-    fn compile_output(
-        builder: &mut KernelBuilder,
-        vectorization: Vectorization,
-    ) -> <Self as CubeType>::ExpandType;
+    // /// Register an input variable during compilation that fill the [KernelBuilder].
+    // fn compile_input(
+    //     builder: &mut KernelBuilder,
+    //     vectorization: Vectorization,
+    // ) -> <Self as CubeType>::ExpandType;
+    // /// Register an output variable during compilation that fill the [KernelBuilder].
+    // fn compile_output(
+    //     builder: &mut KernelBuilder,
+    //     vectorization: Vectorization,
+    // ) -> <Self as CubeType>::ExpandType;
 }
 
 /// Defines the argument settings used to launch a kernel.

--- a/crates/burn-cube/src/frontend/element/base.rs
+++ b/crates/burn-cube/src/frontend/element/base.rs
@@ -27,9 +27,15 @@ pub trait Init {
     fn init(self, context: &mut CubeContext) -> Self;
 }
 
-pub trait LaunchDefinition: CubeType {
+/// Defines how a [launch argument](LaunchArg) can be expanded.
+///
+/// Normally this type should be implemented two times for an argument.
+/// Once for the reference and the other for the mutable reference. Often time, the reference
+/// should expand the argument as an input while the mutable reference should expand the argument
+/// as an output.
+pub trait LaunchArgExpand: CubeType {
     /// Register an input variable during compilation that fill the [KernelBuilder].
-    fn define(
+    fn expand(
         builder: &mut KernelBuilder,
         vectorization: Vectorization,
     ) -> <Self as CubeType>::ExpandType;
@@ -39,16 +45,6 @@ pub trait LaunchDefinition: CubeType {
 pub trait LaunchArg: CubeType {
     /// The runtime argument for the kernel.
     type RuntimeArg<'a, R: Runtime>: ArgSettings<R>;
-    // /// Register an input variable during compilation that fill the [KernelBuilder].
-    // fn compile_input(
-    //     builder: &mut KernelBuilder,
-    //     vectorization: Vectorization,
-    // ) -> <Self as CubeType>::ExpandType;
-    // /// Register an output variable during compilation that fill the [KernelBuilder].
-    // fn compile_output(
-    //     builder: &mut KernelBuilder,
-    //     vectorization: Vectorization,
-    // ) -> <Self as CubeType>::ExpandType;
 }
 
 /// Defines the argument settings used to launch a kernel.

--- a/crates/burn-cube/src/frontend/element/base.rs
+++ b/crates/burn-cube/src/frontend/element/base.rs
@@ -123,3 +123,17 @@ impl<T> Init for Option<T> {
         self
     }
 }
+
+impl<T: CubeType> CubeType for Vec<T> {
+    type ExpandType = Vec<T::ExpandType>;
+}
+
+impl<T: CubeType> CubeType for &mut Vec<T> {
+    type ExpandType = Vec<T::ExpandType>;
+}
+
+impl<T: Init> Init for Vec<T> {
+    fn init(self, context: &mut CubeContext) -> Self {
+        self.into_iter().map(|e| e.init(context)).collect()
+    }
+}

--- a/crates/burn-cube/src/frontend/element/bool.rs
+++ b/crates/burn-cube/src/frontend/element/bool.rs
@@ -1,6 +1,8 @@
 use crate::frontend::{CubeElem, CubeType, ExpandElement};
 use crate::ir::Elem;
 
+use super::Vectorized;
+
 impl CubeType for bool {
     type ExpandType = ExpandElement;
 }
@@ -8,5 +10,15 @@ impl CubeType for bool {
 impl CubeElem for bool {
     fn as_elem() -> Elem {
         Elem::Bool
+    }
+}
+
+impl Vectorized for bool {
+    fn vectorization_factor(&self) -> crate::prelude::UInt {
+        todo!()
+    }
+
+    fn vectorize(self, _factor: crate::prelude::UInt) -> Self {
+        todo!()
     }
 }

--- a/crates/burn-cube/src/frontend/element/bool.rs
+++ b/crates/burn-cube/src/frontend/element/bool.rs
@@ -1,4 +1,4 @@
-use crate::frontend::{CubeElem, CubeType, ExpandElement};
+use crate::frontend::{CubePrimitive, CubeType, ExpandElement};
 use crate::ir::Elem;
 
 use super::Vectorized;
@@ -7,7 +7,7 @@ impl CubeType for bool {
     type ExpandType = ExpandElement;
 }
 
-impl CubeElem for bool {
+impl CubePrimitive for bool {
     fn as_elem() -> Elem {
         Elem::Bool
     }

--- a/crates/burn-cube/src/frontend/element/cast.rs
+++ b/crates/burn-cube/src/frontend/element/cast.rs
@@ -1,10 +1,10 @@
-use crate::frontend::{assign, CubeContext, CubeElem, CubeType};
+use crate::frontend::{assign, CubeContext, CubePrimitive, CubeType};
 use crate::ir::Item;
 use crate::{frontend::ExpandElement, unexpanded};
 
 /// Enable elegant casting from any to any CubeElem
-pub trait Cast: CubeElem {
-    fn cast_from<From: CubeElem>(value: From) -> Self;
+pub trait Cast: CubePrimitive {
+    fn cast_from<From: CubePrimitive>(value: From) -> Self;
 
     fn cast_from_expand<From>(
         context: &mut CubeContext,
@@ -13,14 +13,14 @@ pub trait Cast: CubeElem {
     where
         From: Into<ExpandElement>,
     {
-        let new_var = context.create_local(Item::new(<Self as CubeElem>::as_elem()));
+        let new_var = context.create_local(Item::new(<Self as CubePrimitive>::as_elem()));
         assign::expand(context, value.into(), new_var.clone());
         new_var
     }
 }
 
-impl<P: CubeElem> Cast for P {
-    fn cast_from<From: CubeElem>(_value: From) -> Self {
+impl<P: CubePrimitive> Cast for P {
+    fn cast_from<From: CubePrimitive>(_value: From) -> Self {
         unexpanded!()
     }
 }

--- a/crates/burn-cube/src/frontend/element/cube_elem.rs
+++ b/crates/burn-cube/src/frontend/element/cube_elem.rs
@@ -2,16 +2,20 @@ use crate::frontend::UInt;
 use crate::frontend::{CubeType, ExpandElement};
 use crate::ir::{Elem, Variable};
 
+use super::Vectorized;
+
 /// Form of CubeType that encapsulates all primitive types:
 /// Numeric, UInt, Bool
 pub trait CubeElem:
     CubeType<ExpandType = ExpandElement>
+    + Vectorized
     + core::cmp::Eq
     + core::cmp::PartialEq
     + Send
     + Sync
     + 'static
     + Clone
+    + Copy
 {
     /// Return the element type to use on GPU
     fn as_elem() -> Elem;

--- a/crates/burn-cube/src/frontend/element/cube_elem.rs
+++ b/crates/burn-cube/src/frontend/element/cube_elem.rs
@@ -6,7 +6,7 @@ use super::Vectorized;
 
 /// Form of CubeType that encapsulates all primitive types:
 /// Numeric, UInt, Bool
-pub trait CubeElem:
+pub trait CubePrimitive:
     CubeType<ExpandType = ExpandElement>
     + Vectorized
     + core::cmp::Eq

--- a/crates/burn-cube/src/frontend/element/float.rs
+++ b/crates/burn-cube/src/frontend/element/float.rs
@@ -1,7 +1,7 @@
 use half::{bf16, f16};
 
 use crate::frontend::{Ceil, Cos, Erf, Exp, Floor, Log, Log1p, Powf, Recip, Sin, Sqrt, Tanh};
-use crate::frontend::{CubeContext, CubeElem, CubeType, ExpandElement, Numeric};
+use crate::frontend::{CubeContext, CubePrimitive, CubeType, ExpandElement, Numeric};
 use crate::ir::{Elem, FloatKind, Item, Variable, Vectorization};
 
 use crate::compute::{KernelBuilder, KernelLauncher};
@@ -57,7 +57,7 @@ macro_rules! impl_float {
             type ExpandType = ExpandElement;
         }
 
-        impl CubeElem for $type {
+        impl CubePrimitive for $type {
             /// Return the element type to use on GPU
             fn as_elem() -> Elem {
                 Elem::Float(FloatKind::$type)

--- a/crates/burn-cube/src/frontend/element/float.rs
+++ b/crates/burn-cube/src/frontend/element/float.rs
@@ -8,7 +8,7 @@ use crate::compute::{KernelBuilder, KernelLauncher};
 use crate::prelude::index_assign;
 use crate::{unexpanded, Runtime};
 
-use super::{ArgSettings, LaunchArg, UInt, Vectorized};
+use super::{ArgSettings, LaunchArg, LaunchDefinition, UInt, Vectorized};
 
 /// Floating point numbers. Used as input in float kernels
 pub trait Float:
@@ -46,6 +46,14 @@ macro_rules! impl_float {
         }
 
         impl CubeType for $type {
+            type ExpandType = ExpandElement;
+        }
+
+        impl CubeType for &$type {
+            type ExpandType = ExpandElement;
+        }
+
+        impl CubeType for &mut $type {
             type ExpandType = ExpandElement;
         }
 
@@ -109,24 +117,22 @@ macro_rules! impl_float {
             }
         }
 
+        impl LaunchDefinition for &$type {
+            fn define(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
+                assert_eq!(vectorization, 1, "Attempted to vectorize a scalar");
+                builder.scalar($type::as_elem())
+            }
+        }
+
+        impl LaunchDefinition for &mut $type {
+            fn define(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
+                assert_eq!(vectorization, 1, "Attempted to vectorize a scalar");
+                builder.scalar($type::as_elem())
+            }
+        }
+
         impl LaunchArg for $type {
             type RuntimeArg<'a, R: Runtime> = $primitive;
-
-            fn compile_input(
-                builder: &mut KernelBuilder,
-                vectorization: Vectorization,
-            ) -> ExpandElement {
-                assert_eq!(vectorization, 1, "Attempted to vectorize a scalar");
-                builder.scalar(Self::as_elem())
-            }
-
-            fn compile_output(
-                builder: &mut KernelBuilder,
-                vectorization: Vectorization,
-            ) -> ExpandElement {
-                assert_eq!(vectorization, 1, "Attempted to vectorize a scalar");
-                builder.scalar(Self::as_elem())
-            }
         }
 
         impl Vectorized for $type {

--- a/crates/burn-cube/src/frontend/element/float.rs
+++ b/crates/burn-cube/src/frontend/element/float.rs
@@ -8,7 +8,7 @@ use crate::compute::{KernelBuilder, KernelLauncher};
 use crate::prelude::index_assign;
 use crate::{unexpanded, Runtime};
 
-use super::{ArgSettings, LaunchArg, LaunchDefinition, UInt, Vectorized};
+use super::{ArgSettings, LaunchArg, LaunchArgExpand, UInt, Vectorized};
 
 /// Floating point numbers. Used as input in float kernels
 pub trait Float:
@@ -117,15 +117,15 @@ macro_rules! impl_float {
             }
         }
 
-        impl LaunchDefinition for &$type {
-            fn define(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
+        impl LaunchArgExpand for &$type {
+            fn expand(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
                 assert_eq!(vectorization, 1, "Attempted to vectorize a scalar");
                 builder.scalar($type::as_elem())
             }
         }
 
-        impl LaunchDefinition for &mut $type {
-            fn define(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
+        impl LaunchArgExpand for &mut $type {
+            fn expand(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
                 assert_eq!(vectorization, 1, "Attempted to vectorize a scalar");
                 builder.scalar($type::as_elem())
             }

--- a/crates/burn-cube/src/frontend/element/int.rs
+++ b/crates/burn-cube/src/frontend/element/int.rs
@@ -1,5 +1,5 @@
 use crate::compute::{KernelBuilder, KernelLauncher};
-use crate::frontend::{CubeContext, CubeElem, CubeType, ExpandElement, Numeric};
+use crate::frontend::{CubeContext, CubePrimitive, CubeType, ExpandElement, Numeric};
 use crate::ir::{Elem, IntKind, Item, Variable, Vectorization};
 use crate::prelude::index_assign;
 use crate::Runtime;
@@ -38,7 +38,7 @@ macro_rules! impl_int {
             type ExpandType = ExpandElement;
         }
 
-        impl CubeElem for $type {
+        impl CubePrimitive for $type {
             fn as_elem() -> Elem {
                 Elem::Int(IntKind::$type)
             }

--- a/crates/burn-cube/src/frontend/element/int.rs
+++ b/crates/burn-cube/src/frontend/element/int.rs
@@ -4,7 +4,7 @@ use crate::ir::{Elem, IntKind, Item, Variable, Vectorization};
 use crate::prelude::index_assign;
 use crate::Runtime;
 
-use super::{ArgSettings, LaunchArg, LaunchDefinition, UInt, Vectorized};
+use super::{ArgSettings, LaunchArg, LaunchArgExpand, UInt, Vectorized};
 
 /// Signed integer. Used as input in int kernels
 pub trait Int: Numeric + std::ops::Rem<Output = Self> {
@@ -89,15 +89,15 @@ macro_rules! impl_int {
             }
         }
 
-        impl LaunchDefinition for &$type {
-            fn define(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
+        impl LaunchArgExpand for &$type {
+            fn expand(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
                 assert_eq!(vectorization, 1, "Attempted to vectorize a scalar");
                 builder.scalar($type::as_elem())
             }
         }
 
-        impl LaunchDefinition for &mut $type {
-            fn define(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
+        impl LaunchArgExpand for &mut $type {
+            fn expand(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
                 assert_eq!(vectorization, 1, "Attempted to vectorize a scalar");
                 builder.scalar($type::as_elem())
             }

--- a/crates/burn-cube/src/frontend/element/numeric.rs
+++ b/crates/burn-cube/src/frontend/element/numeric.rs
@@ -5,14 +5,13 @@ use crate::{
     unexpanded,
 };
 
-use super::{LaunchArg, Vectorized};
+use super::Vectorized;
 
 /// Type that encompasses both (unsigned or signed) integers and floats
 /// Used in kernels that should work for both.
 pub trait Numeric:
     Vectorized
     + Copy
-    + LaunchArg
     + CubeElem
     + std::ops::Add<Output = Self>
     + std::ops::AddAssign

--- a/crates/burn-cube/src/frontend/element/numeric.rs
+++ b/crates/burn-cube/src/frontend/element/numeric.rs
@@ -1,4 +1,4 @@
-use crate::frontend::{CubeContext, CubeElem, CubeType, ExpandElement};
+use crate::frontend::{CubeContext, CubePrimitive, CubeType, ExpandElement};
 use crate::ir::{Item, Variable};
 use crate::{
     frontend::{index_assign, Abs, Max, Min, Remainder},
@@ -9,7 +9,7 @@ use crate::{
 /// Used in kernels that should work for both.
 pub trait Numeric:
     Copy
-    + CubeElem
+    + CubePrimitive
     + std::ops::Add<Output = Self>
     + std::ops::AddAssign
     + std::ops::SubAssign

--- a/crates/burn-cube/src/frontend/element/numeric.rs
+++ b/crates/burn-cube/src/frontend/element/numeric.rs
@@ -5,13 +5,10 @@ use crate::{
     unexpanded,
 };
 
-use super::Vectorized;
-
 /// Type that encompasses both (unsigned or signed) integers and floats
 /// Used in kernels that should work for both.
 pub trait Numeric:
-    Vectorized
-    + Copy
+    Copy
     + CubeElem
     + std::ops::Add<Output = Self>
     + std::ops::AddAssign
@@ -45,11 +42,14 @@ pub trait Numeric:
         ExpandElement::Plain(new_var)
     }
 
-    fn from_vec(_vec: &[i64]) -> Self {
+    fn from_vec<const D: usize>(_vec: [i64; D]) -> Self {
         unexpanded!()
     }
 
-    fn from_vec_expand(context: &mut CubeContext, vec: &[i64]) -> <Self as CubeType>::ExpandType {
+    fn from_vec_expand<const D: usize>(
+        context: &mut CubeContext,
+        vec: [i64; D],
+    ) -> <Self as CubeType>::ExpandType {
         let mut new_var = context.create_local(Item::vectorized(Self::as_elem(), vec.len() as u8));
         for (i, element) in vec.iter().enumerate() {
             new_var = index_assign::expand(context, new_var, i, *element);

--- a/crates/burn-cube/src/frontend/element/shared_memory.rs
+++ b/crates/burn-cube/src/frontend/element/shared_memory.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use crate::{
-    frontend::{indexation::Index, CubeContext, CubeElem, CubeType},
+    frontend::{indexation::Index, CubeContext, CubePrimitive, CubeType},
     ir::Item,
 };
 
@@ -13,27 +13,27 @@ pub struct SharedMemory<T: CubeType> {
 }
 
 #[derive(Clone)]
-pub struct SharedMemoryExpand<T: CubeElem> {
+pub struct SharedMemoryExpand<T: CubePrimitive> {
     pub val: <T as CubeType>::ExpandType,
 }
 
-impl<T: CubeElem> From<SharedMemoryExpand<T>> for ExpandElement {
+impl<T: CubePrimitive> From<SharedMemoryExpand<T>> for ExpandElement {
     fn from(shared_memory_expand: SharedMemoryExpand<T>) -> Self {
         shared_memory_expand.val
     }
 }
 
-impl<T: CubeElem> Init for SharedMemoryExpand<T> {
+impl<T: CubePrimitive> Init for SharedMemoryExpand<T> {
     fn init(self, _context: &mut CubeContext) -> Self {
         self
     }
 }
 
-impl<T: CubeElem> CubeType for SharedMemory<T> {
+impl<T: CubePrimitive> CubeType for SharedMemory<T> {
     type ExpandType = SharedMemoryExpand<T>;
 }
 
-impl<T: CubeElem + Clone> SharedMemory<T> {
+impl<T: CubePrimitive + Clone> SharedMemory<T> {
     pub fn new<S: Index>(_size: S) -> Self {
         SharedMemory { _val: PhantomData }
     }

--- a/crates/burn-cube/src/frontend/element/tensor.rs
+++ b/crates/burn-cube/src/frontend/element/tensor.rs
@@ -10,7 +10,7 @@ use std::marker::PhantomData;
 
 use super::LaunchDefinition;
 
-#[derive(new, Clone, Copy)]
+#[derive(new)]
 pub struct Tensor<T: CubeType> {
     pub(crate) factor: u8,
     _val: PhantomData<T>,
@@ -59,17 +59,17 @@ impl<'a, R: Runtime> ArgSettings<R> for TensorHandle<'a, R> {
 
 impl<T: CubeType> Tensor<T> {
     /// Obtain the stride of input at dimension dim
-    pub fn stride<C: Index>(self, _dim: C) -> UInt {
+    pub fn stride<C: Index>(&self, _dim: C) -> UInt {
         unexpanded!()
     }
 
     /// Obtain the shape of input at dimension dim
-    pub fn shape<C: Index>(self, _dim: C) -> UInt {
+    pub fn shape<C: Index>(&self, _dim: C) -> UInt {
         unexpanded!()
     }
 
     /// Obtain the array length of input
-    pub fn len(self) -> UInt {
+    pub fn len(&self) -> UInt {
         unexpanded!()
     }
 

--- a/crates/burn-cube/src/frontend/element/tensor.rs
+++ b/crates/burn-cube/src/frontend/element/tensor.rs
@@ -1,6 +1,6 @@
 use crate::{
     frontend::{
-        indexation::Index, ArgSettings, CubeContext, CubeElem, CubeType, ExpandElement, UInt,
+        indexation::Index, ArgSettings, CubeContext, CubePrimitive, CubeType, ExpandElement, UInt,
     },
     ir::{Elem, Item, Metadata, Variable, Vectorization},
     prelude::{KernelBuilder, KernelLauncher},
@@ -28,19 +28,19 @@ impl<T: CubeType> CubeType for &mut Tensor<T> {
     type ExpandType = ExpandElement;
 }
 
-impl<C: CubeElem> LaunchArgExpand for &Tensor<C> {
+impl<C: CubePrimitive> LaunchArgExpand for &Tensor<C> {
     fn expand(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
         builder.input_array(Item::vectorized(C::as_elem(), vectorization))
     }
 }
 
-impl<C: CubeElem> LaunchArgExpand for &mut Tensor<C> {
+impl<C: CubePrimitive> LaunchArgExpand for &mut Tensor<C> {
     fn expand(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
         builder.output_array(Item::vectorized(C::as_elem(), vectorization))
     }
 }
 
-impl<C: CubeElem> LaunchArg for Tensor<C> {
+impl<C: CubePrimitive> LaunchArg for Tensor<C> {
     type RuntimeArg<'a, R: Runtime> = TensorHandle<'a, R>;
 }
 

--- a/crates/burn-cube/src/frontend/element/tensor.rs
+++ b/crates/burn-cube/src/frontend/element/tensor.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use std::marker::PhantomData;
 
-use super::LaunchDefinition;
+use super::LaunchArgExpand;
 
 #[derive(new)]
 pub struct Tensor<T: CubeType> {
@@ -28,14 +28,14 @@ impl<T: CubeType> CubeType for &mut Tensor<T> {
     type ExpandType = ExpandElement;
 }
 
-impl<C: CubeElem> LaunchDefinition for &Tensor<C> {
-    fn define(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
+impl<C: CubeElem> LaunchArgExpand for &Tensor<C> {
+    fn expand(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
         builder.input_array(Item::vectorized(C::as_elem(), vectorization))
     }
 }
 
-impl<C: CubeElem> LaunchDefinition for &mut Tensor<C> {
-    fn define(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
+impl<C: CubeElem> LaunchArgExpand for &mut Tensor<C> {
+    fn expand(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
         builder.output_array(Item::vectorized(C::as_elem(), vectorization))
     }
 }

--- a/crates/burn-cube/src/frontend/element/tensor.rs
+++ b/crates/burn-cube/src/frontend/element/tensor.rs
@@ -8,6 +8,8 @@ use crate::{
 };
 use std::marker::PhantomData;
 
+use super::LaunchDefinition;
+
 #[derive(new, Clone, Copy)]
 pub struct Tensor<T: CubeType> {
     pub(crate) factor: u8,
@@ -18,16 +20,28 @@ impl<T: CubeType> CubeType for Tensor<T> {
     type ExpandType = ExpandElement;
 }
 
-impl<C: CubeElem> LaunchArg for Tensor<C> {
-    type RuntimeArg<'a, R: Runtime> = TensorHandle<'a, R>;
+impl<T: CubeType> CubeType for &Tensor<T> {
+    type ExpandType = ExpandElement;
+}
 
-    fn compile_input(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
+impl<T: CubeType> CubeType for &mut Tensor<T> {
+    type ExpandType = ExpandElement;
+}
+
+impl<C: CubeElem> LaunchDefinition for &Tensor<C> {
+    fn define(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
         builder.input_array(Item::vectorized(C::as_elem(), vectorization))
     }
+}
 
-    fn compile_output(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
+impl<C: CubeElem> LaunchDefinition for &mut Tensor<C> {
+    fn define(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
         builder.output_array(Item::vectorized(C::as_elem(), vectorization))
     }
+}
+
+impl<C: CubeElem> LaunchArg for Tensor<C> {
+    type RuntimeArg<'a, R: Runtime> = TensorHandle<'a, R>;
 }
 
 #[derive(new)]

--- a/crates/burn-cube/src/frontend/element/tensor.rs
+++ b/crates/burn-cube/src/frontend/element/tensor.rs
@@ -68,7 +68,12 @@ impl<T: CubeType> Tensor<T> {
         unexpanded!()
     }
 
-    /// Obtain the array length of input
+    /// The length of the buffer representing the tensor.
+    ///
+    /// # Warning
+    ///
+    /// The length will be affected by the vectorization factor. To obtain the number of elements,
+    /// you should multiply the length by the vectorization factor.
     pub fn len(&self) -> UInt {
         unexpanded!()
     }

--- a/crates/burn-cube/src/frontend/element/uint.rs
+++ b/crates/burn-cube/src/frontend/element/uint.rs
@@ -6,7 +6,7 @@ use crate::{
     LaunchArg, Runtime,
 };
 
-use super::Vectorized;
+use super::{LaunchDefinition, Vectorized};
 
 #[derive(Clone, Copy, Debug)]
 /// An unsigned int.
@@ -20,6 +20,14 @@ impl CubeType for UInt {
     type ExpandType = ExpandElement;
 }
 
+impl CubeType for &UInt {
+    type ExpandType = ExpandElement;
+}
+
+impl CubeType for &mut UInt {
+    type ExpandType = ExpandElement;
+}
+
 impl CubeElem for UInt {
     fn as_elem() -> Elem {
         Elem::UInt
@@ -28,15 +36,18 @@ impl CubeElem for UInt {
 
 impl LaunchArg for UInt {
     type RuntimeArg<'a, R: Runtime> = u32;
-
-    fn compile_input(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
+}
+impl LaunchDefinition for &UInt {
+    fn define(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
         assert_eq!(vectorization, 1, "Attempted to vectorize a scalar");
-        builder.scalar(Self::as_elem())
+        builder.scalar(UInt::as_elem())
     }
+}
 
-    fn compile_output(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
+impl LaunchDefinition for &mut UInt {
+    fn define(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
         assert_eq!(vectorization, 1, "Attempted to vectorize a scalar");
-        builder.scalar(Self::as_elem())
+        builder.scalar(UInt::as_elem())
     }
 }
 

--- a/crates/burn-cube/src/frontend/element/uint.rs
+++ b/crates/burn-cube/src/frontend/element/uint.rs
@@ -1,4 +1,4 @@
-use crate::frontend::{CubeContext, CubeElem, CubeType, ExpandElement, Numeric};
+use crate::frontend::{CubeContext, CubePrimitive, CubeType, ExpandElement, Numeric};
 use crate::ir::{Elem, Item, Variable, Vectorization};
 use crate::prelude::{index_assign, KernelBuilder, KernelLauncher};
 use crate::{
@@ -28,7 +28,7 @@ impl CubeType for &mut UInt {
     type ExpandType = ExpandElement;
 }
 
-impl CubeElem for UInt {
+impl CubePrimitive for UInt {
     fn as_elem() -> Elem {
         Elem::UInt
     }

--- a/crates/burn-cube/src/frontend/element/uint.rs
+++ b/crates/burn-cube/src/frontend/element/uint.rs
@@ -6,7 +6,7 @@ use crate::{
     LaunchArg, Runtime,
 };
 
-use super::{LaunchDefinition, Vectorized};
+use super::{LaunchArgExpand, Vectorized};
 
 #[derive(Clone, Copy, Debug)]
 /// An unsigned int.
@@ -37,15 +37,16 @@ impl CubeElem for UInt {
 impl LaunchArg for UInt {
     type RuntimeArg<'a, R: Runtime> = u32;
 }
-impl LaunchDefinition for &UInt {
-    fn define(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
+
+impl LaunchArgExpand for &UInt {
+    fn expand(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
         assert_eq!(vectorization, 1, "Attempted to vectorize a scalar");
         builder.scalar(UInt::as_elem())
     }
 }
 
-impl LaunchDefinition for &mut UInt {
-    fn define(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
+impl LaunchArgExpand for &mut UInt {
+    fn expand(builder: &mut KernelBuilder, vectorization: Vectorization) -> ExpandElement {
         assert_eq!(vectorization, 1, "Attempted to vectorize a scalar");
         builder.scalar(UInt::as_elem())
     }

--- a/crates/burn-cube/src/frontend/element/vectorized.rs
+++ b/crates/burn-cube/src/frontend/element/vectorized.rs
@@ -30,3 +30,18 @@ impl Vectorized for ExpandElement {
         todo!()
     }
 }
+
+impl Vectorized for &ExpandElement {
+    fn vectorization_factor(&self) -> UInt {
+        let var = match self {
+            ExpandElement::Managed(var) => var,
+            ExpandElement::Plain(var) => var,
+        };
+
+        UInt::new(var.item().vectorization as u32)
+    }
+
+    fn vectorize(self, _factor: UInt) -> Self {
+        todo!()
+    }
+}

--- a/crates/burn-cube/src/frontend/subcube.rs
+++ b/crates/burn-cube/src/frontend/subcube.rs
@@ -1,4 +1,4 @@
-use super::{CubeContext, CubeElem, ExpandElement};
+use super::{CubeContext, CubePrimitive, ExpandElement};
 use crate::{
     ir::{Elem, InitOperator, Item, Operation, Subcube, UnaryOperator},
     unexpanded,
@@ -9,7 +9,7 @@ pub fn subcube_elect() -> bool {
     unexpanded!()
 }
 
-pub fn subcube_elect_expand<E: CubeElem>(context: &mut CubeContext) -> ExpandElement {
+pub fn subcube_elect_expand<E: CubePrimitive>(context: &mut CubeContext) -> ExpandElement {
     let output = context.create_local(Item::new(Elem::Bool));
 
     let out = *output;
@@ -19,11 +19,11 @@ pub fn subcube_elect_expand<E: CubeElem>(context: &mut CubeContext) -> ExpandEle
     output
 }
 
-pub fn subcube_sum<E: CubeElem>(_elem: E) -> E {
+pub fn subcube_sum<E: CubePrimitive>(_elem: E) -> E {
     unexpanded!()
 }
 
-pub fn subcube_sum_expand<E: CubeElem>(
+pub fn subcube_sum_expand<E: CubePrimitive>(
     context: &mut CubeContext,
     elem: ExpandElement,
 ) -> ExpandElement {
@@ -40,11 +40,11 @@ pub fn subcube_sum_expand<E: CubeElem>(
     output
 }
 
-pub fn subcube_prod<E: CubeElem>(_elem: E) -> E {
+pub fn subcube_prod<E: CubePrimitive>(_elem: E) -> E {
     unexpanded!()
 }
 
-pub fn subcube_prod_expand<E: CubeElem>(
+pub fn subcube_prod_expand<E: CubePrimitive>(
     context: &mut CubeContext,
     elem: ExpandElement,
 ) -> ExpandElement {
@@ -61,11 +61,11 @@ pub fn subcube_prod_expand<E: CubeElem>(
     output
 }
 
-pub fn subcube_max<E: CubeElem>(_elem: E) -> E {
+pub fn subcube_max<E: CubePrimitive>(_elem: E) -> E {
     unexpanded!()
 }
 
-pub fn subcube_max_expand<E: CubeElem>(
+pub fn subcube_max_expand<E: CubePrimitive>(
     context: &mut CubeContext,
     elem: ExpandElement,
 ) -> ExpandElement {
@@ -82,11 +82,11 @@ pub fn subcube_max_expand<E: CubeElem>(
     output
 }
 
-pub fn subcube_min<E: CubeElem>(_elem: E) -> E {
+pub fn subcube_min<E: CubePrimitive>(_elem: E) -> E {
     unexpanded!()
 }
 
-pub fn subcube_min_expand<E: CubeElem>(
+pub fn subcube_min_expand<E: CubePrimitive>(
     context: &mut CubeContext,
     elem: ExpandElement,
 ) -> ExpandElement {
@@ -103,11 +103,11 @@ pub fn subcube_min_expand<E: CubeElem>(
     output
 }
 
-pub fn subcube_all<E: CubeElem>(_elem: E) -> E {
+pub fn subcube_all<E: CubePrimitive>(_elem: E) -> E {
     unexpanded!()
 }
 
-pub fn subcube_all_expand<E: CubeElem>(
+pub fn subcube_all_expand<E: CubePrimitive>(
     context: &mut CubeContext,
     elem: ExpandElement,
 ) -> ExpandElement {

--- a/crates/burn-cube/src/runtime_tests/launch.rs
+++ b/crates/burn-cube/src/runtime_tests/launch.rs
@@ -2,14 +2,14 @@ use crate as burn_cube;
 use burn_cube::prelude::*;
 
 #[cube(launch)]
-pub fn kernel_with_generics<F: Float>(mut output: Array<F>) {
+pub fn kernel_with_generics<F: Float>(output: &mut Array<F>) {
     if UNIT_POS == UInt::new(0) {
         output[0] = F::new(5.0);
     }
 }
 
 #[cube(launch)]
-pub fn kernel_without_generics(mut output: Array<F32>) {
+pub fn kernel_without_generics(output: &mut Array<F32>) {
     if UNIT_POS == UInt::new(0) {
         output[0] = F32::new(5.0);
     }

--- a/crates/burn-cube/src/runtime_tests/subcube.rs
+++ b/crates/burn-cube/src/runtime_tests/subcube.rs
@@ -2,7 +2,7 @@ use crate as burn_cube;
 use burn_cube::prelude::*;
 
 #[cube(launch)]
-pub fn kernel_sum<F: Float>(mut output: Tensor<F>) {
+pub fn kernel_sum<F: Float>(output: &mut Tensor<F>) {
     let val = output[UNIT_POS];
     let val2 = subcube_sum::<F>(val);
 
@@ -12,7 +12,7 @@ pub fn kernel_sum<F: Float>(mut output: Tensor<F>) {
 }
 
 #[cube(launch)]
-pub fn kernel_prod<F: Float>(mut output: Tensor<F>) {
+pub fn kernel_prod<F: Float>(output: &mut Tensor<F>) {
     let val = output[UNIT_POS];
     let val2 = subcube_prod::<F>(val);
 
@@ -22,7 +22,7 @@ pub fn kernel_prod<F: Float>(mut output: Tensor<F>) {
 }
 
 #[cube(launch)]
-pub fn kernel_max<F: Float>(mut output: Tensor<F>) {
+pub fn kernel_max<F: Float>(output: &mut Tensor<F>) {
     let val = output[UNIT_POS];
     let val2 = subcube_max::<F>(val);
 
@@ -32,7 +32,7 @@ pub fn kernel_max<F: Float>(mut output: Tensor<F>) {
 }
 
 #[cube(launch)]
-pub fn kernel_min<F: Float>(mut output: Tensor<F>) {
+pub fn kernel_min<F: Float>(output: &mut Tensor<F>) {
     let val = output[UNIT_POS];
     let val2 = subcube_min::<F>(val);
 

--- a/crates/burn-cube/tests/frontend/array.rs
+++ b/crates/burn-cube/tests/frontend/array.rs
@@ -1,12 +1,12 @@
 use burn_cube::prelude::*;
 
 #[cube]
-fn array_add_assign_simple(mut array: Array<UInt>) {
+fn array_add_assign_simple(array: &mut Array<UInt>) {
     array[UInt::new(1)] += UInt::new(1);
 }
 
 #[cube]
-fn array_add_assign_expr(mut array: Array<UInt>) {
+fn array_add_assign_expr(array: &mut Array<UInt>) {
     array[UInt::new(1) + UInt::new(5)] += UInt::new(1);
 }
 

--- a/crates/burn-cube/tests/frontend/assign.rs
+++ b/crates/burn-cube/tests/frontend/assign.rs
@@ -22,7 +22,7 @@ fn assign_mut_input(mut y: UInt) -> UInt {
 
 #[cube]
 fn assign_vectorized(y: UInt) -> UInt {
-    let vectorization_factor = Comptime::vectorization(y);
+    let vectorization_factor = Comptime::vectorization(&y);
     let x = UInt::vectorized(1, Comptime::get(vectorization_factor));
     x + y
 }

--- a/crates/burn-cube/tests/frontend/cast_elem.rs
+++ b/crates/burn-cube/tests/frontend/cast_elem.rs
@@ -117,7 +117,7 @@ mod tests {
     use super::*;
     use burn_cube::{
         cpa,
-        frontend::{CubeContext, CubeElem},
+        frontend::{CubeContext, CubePrimitive},
         ir::{Elem, Item, Variable},
     };
 

--- a/crates/burn-cube/tests/frontend/cast_kind.rs
+++ b/crates/burn-cube/tests/frontend/cast_kind.rs
@@ -35,7 +35,7 @@ mod tests {
     use super::*;
     use burn_cube::{
         cpa,
-        frontend::{CubeContext, CubeElem, F32, F64, I32, I64},
+        frontend::{CubeContext, CubePrimitive, F32, F64, I32, I64},
         ir::{Item, Variable},
     };
 

--- a/crates/burn-cube/tests/frontend/comptime.rs
+++ b/crates/burn-cube/tests/frontend/comptime.rs
@@ -61,7 +61,7 @@ mod tests {
     use super::*;
     use burn_cube::{
         cpa,
-        frontend::{CubeContext, CubeElem, F32},
+        frontend::{CubeContext, CubePrimitive, F32},
         ir::{Item, Variable},
     };
 

--- a/crates/burn-cube/tests/frontend/for_loop.rs
+++ b/crates/burn-cube/tests/frontend/for_loop.rs
@@ -1,7 +1,7 @@
 use burn_cube::{
     cube,
     frontend::branch::range,
-    frontend::{Array, Comptime, CubeContext, CubeElem, Float, UInt, F32},
+    frontend::{Array, Comptime, CubeContext, CubePrimitive, Float, UInt, F32},
 };
 
 type ElemType = F32;

--- a/crates/burn-cube/tests/frontend/function_call.rs
+++ b/crates/burn-cube/tests/frontend/function_call.rs
@@ -51,7 +51,7 @@ pub fn no_call_with_generics<T: Numeric>(x: T) {
 mod tests {
     use super::*;
     use burn_cube::{
-        frontend::{CubeContext, CubeElem, I64},
+        frontend::{CubeContext, CubePrimitive, I64},
         ir::{Elem, Item},
     };
 

--- a/crates/burn-cube/tests/frontend/generic_kernel.rs
+++ b/crates/burn-cube/tests/frontend/generic_kernel.rs
@@ -8,7 +8,7 @@ pub fn generic_kernel<T: Numeric>(lhs: T) {
 mod tests {
     use burn_cube::{
         cpa,
-        frontend::{CubeContext, CubeElem, F32, I32},
+        frontend::{CubeContext, CubePrimitive, F32, I32},
         ir::{Item, Variable},
     };
 

--- a/crates/burn-cube/tests/frontend/if.rs
+++ b/crates/burn-cube/tests/frontend/if.rs
@@ -27,7 +27,7 @@ pub fn if_then_else<F: Float>(lhs: F) {
 mod tests {
     use burn_cube::{
         cpa,
-        frontend::{CubeContext, CubeElem, F32},
+        frontend::{CubeContext, CubePrimitive, F32},
         ir::{Elem, Item, Variable},
     };
 

--- a/crates/burn-cube/tests/frontend/ops.rs
+++ b/crates/burn-cube/tests/frontend/ops.rs
@@ -86,12 +86,12 @@ fn recip_op<F: Float>(a: F) -> F {
 }
 
 #[cube]
-fn equal_op<T: CubeElem>(a: T, b: T) -> bool {
+fn equal_op<T: CubePrimitive>(a: T, b: T) -> bool {
     a == b
 }
 
 #[cube]
-fn not_equal_op<T: CubeElem>(a: T, b: T) -> bool {
+fn not_equal_op<T: CubePrimitive>(a: T, b: T) -> bool {
     a != b
 }
 

--- a/crates/burn-cube/tests/frontend/tensor.rs
+++ b/crates/burn-cube/tests/frontend/tensor.rs
@@ -1,7 +1,7 @@
 use burn_cube::prelude::*;
 
 #[cube]
-fn kernel<T: Numeric>(input: Tensor<T>) {
+fn kernel<T: Numeric>(input: &Tensor<T>) {
     let _shape = input.shape(1);
     let _stride = input.stride(1);
     let _length = input.len();

--- a/crates/burn-cube/tests/frontend/vectorization.rs
+++ b/crates/burn-cube/tests/frontend/vectorization.rs
@@ -2,12 +2,12 @@ use burn_cube::prelude::*;
 
 #[cube]
 pub fn vectorization_binary<T: Numeric>(lhs: T) {
-    let _ = lhs + T::from_vec(&[4, 5]);
+    let _ = lhs + T::from_vec([4, 5]);
 }
 
 #[cube]
 pub fn vectorization_cmp<T: Numeric>(rhs: T) {
-    let _ = T::from_vec(&[4, 5]) > rhs;
+    let _ = T::from_vec([4, 5]) > rhs;
 }
 
 mod tests {

--- a/crates/burn-cuda/src/compiler/body.rs
+++ b/crates/burn-cuda/src/compiler/body.rs
@@ -37,7 +37,7 @@ impl Display for Body {
         if self.id {
             f.write_str(
                 "
-    uint id = globalInvocationId.y * (blockDim.x * gridDim.x) + globalInvocationId.x;
+    uint id = (globalInvocationId.z * gridDim.x * blockDim.x * gridDim.y * blockDim.y) + (globalInvocationId.y * gridDim.x * blockDim.x) + globalInvocationId.x;
 ",
             )?;
         }

--- a/crates/burn-cuda/src/compiler/instruction.rs
+++ b/crates/burn-cuda/src/compiler/instruction.rs
@@ -225,8 +225,18 @@ for (uint {i} = {start}; {i} < {end}; {i}++) {{
                     Variable::GlobalOutputArray(index, _) => *index as usize + num_inputs,
                     _ => panic!("Can only know the len of a global array."),
                 } + 1;
+                let factor = match input.item() {
+                    super::Item::Vec4(_) => 4,
+                    super::Item::Vec3(_) => 3,
+                    super::Item::Vec2(_) => 2,
+                    super::Item::Scalar(_) => {
+                        return f.write_fmt(format_args!(
+                            "{out} = info[({offset} * 2 * info[0]) + {index}];\n"
+                        ))
+                    }
+                };
                 f.write_fmt(format_args!(
-                    "{out} = info[({offset} * 2 * info[0]) + {index}];\n"
+                    "{out} = info[({offset} * 2 * info[0]) + {index}] / {factor};\n"
                 ))
             }
             Instruction::Wrap(it) => f.write_fmt(format_args!("{it}")),

--- a/crates/burn-jit/src/element.rs
+++ b/crates/burn-jit/src/element.rs
@@ -1,47 +1,54 @@
 use burn_cube::{
-    frontend::{CubeElem, Float, BF16, F16, F32, I32},
+    frontend::{CubePrimitive, Float, Int, UInt, BF16, F16, F32, I32},
     CubeElement,
 };
 
 /// The base element trait for the jit backend.
 pub trait JitElement: burn_tensor::Element + CubeElement {
-    type CubeElement: CubeElem;
+    /// Cube primitive representing the jit element.
+    type Primitive: CubePrimitive;
 }
 
 /// The float element type for the jit backend.
 pub trait FloatElement: JitElement {
-    type CubeElement: Float;
+    /// Cube primitive representing the jit element.
+    type FloatPrimitive: Float;
 }
 
 /// The int element type for the jit backend.
-pub trait IntElement: JitElement {}
+pub trait IntElement: JitElement {
+    /// Cube primitive representing the jit element.
+    type IntPrimitive: Int;
+}
 
 impl JitElement for u32 {
-    type CubeElement = I32;
+    type Primitive = UInt;
 }
 
 impl JitElement for i32 {
-    type CubeElement = I32;
+    type Primitive = I32;
 }
 
 impl JitElement for f32 {
-    type CubeElement = F32;
+    type Primitive = F32;
 }
 
 impl JitElement for half::f16 {
-    type CubeElement = F16;
+    type Primitive = F16;
 }
 
 impl JitElement for half::bf16 {
-    type CubeElement = BF16;
+    type Primitive = BF16;
 }
 impl FloatElement for f32 {
-    type CubeElement = F32;
+    type FloatPrimitive = F32;
 }
 impl FloatElement for half::bf16 {
-    type CubeElement = BF16;
+    type FloatPrimitive = BF16;
 }
 impl FloatElement for half::f16 {
-    type CubeElement = F16;
+    type FloatPrimitive = F16;
 }
-impl IntElement for i32 {}
+impl IntElement for i32 {
+    type IntPrimitive = I32;
+}

--- a/crates/burn-jit/src/element.rs
+++ b/crates/burn-jit/src/element.rs
@@ -1,29 +1,40 @@
 use burn_cube::{
-    frontend::{Float, BF16, F16, F32},
+    frontend::{CubeElem, Float, BF16, F16, F32, I32},
     CubeElement,
 };
 
 /// The base element trait for the jit backend.
-pub trait JitElement: burn_tensor::Element + CubeElement {}
+pub trait JitElement: burn_tensor::Element + CubeElement {
+    type CubeElement: CubeElem;
+}
 
 /// The float element type for the jit backend.
 pub trait FloatElement: JitElement {
-    /// The associated Cube element for Cube kernels
     type CubeElement: Float;
 }
 
 /// The int element type for the jit backend.
 pub trait IntElement: JitElement {}
 
-impl JitElement for u32 {}
+impl JitElement for u32 {
+    type CubeElement = I32;
+}
 
-impl JitElement for i32 {}
+impl JitElement for i32 {
+    type CubeElement = I32;
+}
 
-impl JitElement for f32 {}
+impl JitElement for f32 {
+    type CubeElement = F32;
+}
 
-impl JitElement for half::f16 {}
+impl JitElement for half::f16 {
+    type CubeElement = F16;
+}
 
-impl JitElement for half::bf16 {}
+impl JitElement for half::bf16 {
+    type CubeElement = BF16;
+}
 impl FloatElement for f32 {
     type CubeElement = F32;
 }

--- a/crates/burn-jit/src/kernel/conv/conv2d.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d.rs
@@ -28,11 +28,11 @@ struct Conv2dArgs {
 
 #[cube(launch)]
 fn conv2d_kernel<F: Float>(
-    input: Tensor<F>,
-    weight: Tensor<F>,
-    bias: Tensor<F>,
-    mut output: Tensor<F>,
-    args: Conv2dArgs,
+    input: &Tensor<F>,
+    weight: &Tensor<F>,
+    bias: &Tensor<F>,
+    output: &mut Tensor<F>,
+    args: &Conv2dArgs,
     kernel_size_0_unroll: Comptime<Option<UInt>>,
     kernel_size_1_unroll: Comptime<Option<UInt>>,
 ) {

--- a/crates/burn-jit/src/kernel/conv/conv2d.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d.rs
@@ -166,7 +166,7 @@ pub(crate) fn conv2d<R: JitRuntime, E: FloatElement>(
         .vectorize_input(0, 1)
         .vectorize_output(0, 1);
 
-    conv2d_kernel_launch::<E::CubeElement, R>(
+    conv2d_kernel_launch::<<E as FloatElement>::CubeElement, R>(
         input.client,
         workgroup,
         settings,

--- a/crates/burn-jit/src/kernel/conv/conv2d.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d.rs
@@ -166,7 +166,7 @@ pub(crate) fn conv2d<R: JitRuntime, E: FloatElement>(
         .vectorize_input(0, 1)
         .vectorize_output(0, 1);
 
-    conv2d_kernel_launch::<<E as FloatElement>::CubeElement, R>(
+    conv2d_kernel_launch::<E::FloatPrimitive, R>(
         input.client,
         workgroup,
         settings,

--- a/crates/burn-jit/src/kernel/matmul/simple.rs
+++ b/crates/burn-jit/src/kernel/matmul/simple.rs
@@ -120,7 +120,7 @@ pub fn matmul_simple<R: JitRuntime, E: FloatElement, const D: usize>(
         .vectorize_input(1, vectorization_factor)
         .vectorize_output(0, 1);
 
-    matmul_kernel_launch::<<E as FloatElement>::CubeElement, R>(
+    matmul_kernel_launch::<E::FloatPrimitive, R>(
         lhs.client,
         workgroup,
         settings,

--- a/crates/burn-jit/src/kernel/matmul/simple.rs
+++ b/crates/burn-jit/src/kernel/matmul/simple.rs
@@ -12,9 +12,9 @@ use burn_cube::prelude::*;
 
 #[cube(launch)]
 fn matmul_kernel<F: Float>(
-    lhs: Tensor<F>,
-    rhs: Tensor<F>,
-    mut out: Tensor<F>,
+    lhs: &Tensor<F>,
+    rhs: &Tensor<F>,
+    out: &mut Tensor<F>,
     num_batches: Comptime<Option<UInt>>,
 ) {
     let rank = out.rank();

--- a/crates/burn-jit/src/kernel/matmul/simple.rs
+++ b/crates/burn-jit/src/kernel/matmul/simple.rs
@@ -120,7 +120,7 @@ pub fn matmul_simple<R: JitRuntime, E: FloatElement, const D: usize>(
         .vectorize_input(1, vectorization_factor)
         .vectorize_output(0, 1);
 
-    matmul_kernel_launch::<E::CubeElement, R>(
+    matmul_kernel_launch::<<E as FloatElement>::CubeElement, R>(
         lhs.client,
         workgroup,
         settings,

--- a/crates/burn-wgpu/src/compute/server.rs
+++ b/crates/burn-wgpu/src/compute/server.rs
@@ -88,7 +88,6 @@ where
         }
 
         let compile = kernel.compile();
-        println!("source {}", compile.source);
         let pipeline = self.compile_source(&compile.source);
 
         self.pipelines.insert(kernel_id.clone(), pipeline.clone());

--- a/crates/burn-wgpu/src/compute/server.rs
+++ b/crates/burn-wgpu/src/compute/server.rs
@@ -88,6 +88,7 @@ where
         }
 
         let compile = kernel.compile();
+        println!("source {}", compile.source);
         let pipeline = self.compile_source(&compile.source);
 
         self.pipelines.insert(kernel_id.clone(), pipeline.clone());

--- a/examples/gelu/src/lib.rs
+++ b/examples/gelu/src/lib.rs
@@ -1,7 +1,7 @@
 use burn_cube::prelude::*;
 
 #[cube(launch)]
-fn gelu<F: Float>(input: Array<F>, mut output: Array<F>) {
+fn gelu<F: Float>(input: &Array<F>, output: &mut Array<F>) {
     if ABSOLUTE_POS < input.len() {
         output[ABSOLUTE_POS] = gelu_scalar::<F>(input[ABSOLUTE_POS]);
     }


### PR DESCRIPTION
Now arrays and tensors are passed by reference to functions, since they don't implement copy anymore.