### PR TITLE
Fix fusion `float_into_int` output tensor dtype

### DIFF
--- a/crates/burn-fusion/src/ops/float.rs
+++ b/crates/burn-fusion/src/ops/float.rs
@@ -218,7 +218,7 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
         let stream = tensor.stream;
         let out = tensor
             .client
-            .tensor_uninitialized(tensor.shape.clone(), B::FloatElem::dtype());
+            .tensor_uninitialized(tensor.shape.clone(), B::IntElem::dtype());
 
         let desc = UnaryOperationDescription {
             input: tensor.into_description(),


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.

### Related Issues/PRs

Fixes #1937

### Changes

Found out when testing the linked issue that `float_into_int` op had the wrong output type.

```
Float(IntoInt(UnaryOperationDescription { input: TensorDescription { id: TensorId { value: 0 }, shape: [0], status: ReadOnly, dtype: F32 }, out: TensorDescription { id: TensorId { value: 1 }, shape: [0], status: NotInit, dtype: F32 } }))
```

Output tensor was previously initialized as float (looks like a copy-pasta error). Changed to `B::IntElem::dtype()`.

### Testing

Used the test case in the linked issue.

Wanted to capture the failure in a unit test but not sure where it should end up with the jit + fusion 🤔 
