### PR TITLE
remove manual option matching

### DIFF
--- a/crates/burn-compute/src/memory_management/memory_pool/base.rs
+++ b/crates/burn-compute/src/memory_management/memory_pool/base.rs
@@ -319,12 +319,7 @@ impl MemoryPool {
 
         let slice_id =
             self.ring
-                .find_free_slice(effective_size, &mut self.chunks, &mut self.slices);
-
-        let slice_id = match slice_id {
-            Some(val) => val,
-            None => return None,
-        };
+                .find_free_slice(effective_size, &mut self.chunks, &mut self.slices)?;
 
         let slice = self.slices.get_mut(&slice_id).unwrap();
         let old_slice_size = slice.effective_size();

--- a/crates/burn-compute/src/memory_management/memory_pool/small.rs
+++ b/crates/burn-compute/src/memory_management/memory_pool/small.rs
@@ -151,12 +151,7 @@ impl SmallMemoryPool {
     /// Finds a free slice that can contain the given size
     /// Returns the chunk's id and size.
     fn get_free_slice(&mut self, size: usize) -> Option<SliceHandle> {
-        let slice_id = self.find_free_slice();
-
-        let slice_id = match slice_id {
-            Some(val) => val,
-            None => return None,
-        };
+        let slice_id = self.find_free_slice()?;
 
         let slice = self.slices.get_mut(&slice_id).unwrap();
         let old_slice_size = slice.effective_size();

--- a/crates/burn-compute/src/tune/tune_cache.rs
+++ b/crates/burn-compute/src/tune/tune_cache.rs
@@ -96,12 +96,7 @@ impl<K: AutotuneKey> TuneCache<K> {
     }
 
     pub(crate) fn find_fastest(&self, key: &K) -> Option<usize> {
-        let result = self.in_memory_cache.get(key);
-
-        let val = match result {
-            Some(val) => val,
-            None => return None,
-        };
+        let val = self.in_memory_cache.get(key)?;
 
         #[cfg(feature = "autotune-persistent-cache")]
         if val.checksum_checked {

--- a/crates/burn-cube/src/frontend/context.rs
+++ b/crates/burn-cube/src/frontend/context.rs
@@ -17,10 +17,7 @@ impl VariablePool {
         let map = self.map.borrow();
 
         // Filter for candidate variables of the same Item
-        let variables = match map.get(&item) {
-            Some(val) => val,
-            None => return None,
-        };
+        let variables = map.get(&item)?;
 
         // Among the candidates, take a variable if it's only referenced by the map
         // Arbitrarily takes the first it finds in reverse order.

--- a/crates/burn-dataset/src/transform/random.rs
+++ b/crates/burn-dataset/src/transform/random.rs
@@ -42,10 +42,7 @@ where
     I: Clone + Send + Sync,
 {
     fn get(&self, index: usize) -> Option<I> {
-        let index = match self.indices.get(index) {
-            Some(index) => index,
-            None => return None,
-        };
+        let index = self.indices.get(index)?;
         self.dataset.get(*index)
     }
 

--- a/crates/burn-tensor/src/tensor/container.rs
+++ b/crates/burn-tensor/src/tensor/container.rs
@@ -42,10 +42,7 @@ where
     where
         B: Backend,
     {
-        let grad = match self.tensors.get(id) {
-            Some(grad) => grad,
-            None => return None,
-        };
+        let grad = self.tensors.get(id)?;
 
         let tensor = grad
             .downcast_ref::<TensorPrimitive<B, D>>()

--- a/crates/burn-train/src/renderer/tui/progress.rs
+++ b/crates/burn-train/src/renderer/tui/progress.rs
@@ -116,10 +116,7 @@ impl ProgressEstimate {
     }
 
     fn secs(&self) -> Option<u64> {
-        let eta = match self.started_after_warmup {
-            Some(started) => started.elapsed(),
-            None => return None,
-        };
+        let eta = self.started_after_warmup?.elapsed();
 
         let total_estimated = (eta.as_secs() as f64) / self.progress;
 


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

This is small change. Does not address any issues.

### Changes

Removes unnecessary lines of code.

### Testing

Ran run-checks all. Getting an error that appears on the commit preceding mine.

```
error: struct `ThreadId` is never constructed
  --> crates/burn-common/src/stub.rs:99:12
   |
99 | pub struct ThreadId(core::num::NonZeroU64);
   |            ^^^^^^^^
   |
   = note: `-D dead-code` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(dead_code)]`
```
