### PR TITLE
Dynamic memory management preset + updated wgpu buffer memory management

### DIFF
--- a/crates/burn-compute/benches/dynamic.rs
+++ b/crates/burn-compute/benches/dynamic.rs
@@ -14,9 +14,8 @@ fn main() {
     let start = std::time::Instant::now();
     let storage = BytesStorage::default();
     let mut mm = DynamicMemoryManagement::new(
-        32,
         storage,
-        DynamicMemoryManagementOptions::preset(2048 * MB),
+        DynamicMemoryManagementOptions::preset(2048 * MB, 32),
     );
     let mut handles = LinkedList::new();
     for _ in 0..100 * 2048 {

--- a/crates/burn-compute/benches/dynamic.rs
+++ b/crates/burn-compute/benches/dynamic.rs
@@ -13,8 +13,11 @@ const MB: usize = 1024 * 1024;
 fn main() {
     let start = std::time::Instant::now();
     let storage = BytesStorage::default();
-    let mut mm =
-        DynamicMemoryManagement::new(storage, DynamicMemoryManagementOptions::preset(2048 * MB));
+    let mut mm = DynamicMemoryManagement::new(
+        32,
+        storage,
+        DynamicMemoryManagementOptions::preset(2048 * MB),
+    );
     let mut handles = LinkedList::new();
     for _ in 0..100 * 2048 {
         if handles.len() >= 4000 {

--- a/crates/burn-compute/benches/dynamic.rs
+++ b/crates/burn-compute/benches/dynamic.rs
@@ -1,15 +1,20 @@
 use std::collections::LinkedList;
 
 use burn_compute::{
-    memory_management::{dynamic::DynamicMemoryManagement, MemoryManagement},
+    memory_management::{
+        dynamic::{DynamicMemoryManagement, DynamicMemoryManagementOptions},
+        MemoryManagement,
+    },
     storage::BytesStorage,
 };
 
 const MB: usize = 1024 * 1024;
+
 fn main() {
     let start = std::time::Instant::now();
     let storage = BytesStorage::default();
-    let mut mm = DynamicMemoryManagement::new(storage);
+    let mut mm =
+        DynamicMemoryManagement::new(storage, DynamicMemoryManagementOptions::preset(2048 * MB));
     let mut handles = LinkedList::new();
     for _ in 0..100 * 2048 {
         if handles.len() >= 4000 {

--- a/crates/burn-compute/src/memory_management/dynamic.rs
+++ b/crates/burn-compute/src/memory_management/dynamic.rs
@@ -9,7 +9,7 @@ use super::MemoryManagement;
 
 /// Reserves and keeps track of chunks of memory in the storage, and slices upon these chunks.
 pub struct DynamicMemoryManagement<Storage> {
-    min_storage_buffer_allignment_offset: usize,
+    min_storage_buffer_alignment_offset: usize,
     small_memory_pool: SmallMemoryPool,
     pools: Vec<MemoryPool>,
     options: Vec<MemoryPoolOptions>,
@@ -99,7 +99,7 @@ impl<Storage: ComputeStorage> DynamicMemoryManagement<Storage> {
             .collect();
 
         Self {
-            min_storage_buffer_allignment_offset,
+            min_storage_buffer_alignment_offset: min_storage_buffer_allignment_offset,
             small_memory_pool: SmallMemoryPool::new(),
             pools,
             options: options.pools,
@@ -139,7 +139,7 @@ impl<Storage: ComputeStorage> MemoryManagement<Storage> for DynamicMemoryManagem
     }
 
     fn reserve<Sync: FnOnce()>(&mut self, size: usize, sync: Sync) -> Self::Handle {
-        if size <= self.min_storage_buffer_allignment_offset {
+        if size <= self.min_storage_buffer_alignment_offset {
             return self
                 .small_memory_pool
                 .reserve(&mut self.storage, size, sync);
@@ -156,7 +156,7 @@ impl<Storage: ComputeStorage> MemoryManagement<Storage> for DynamicMemoryManagem
     }
 
     fn alloc<Sync: FnOnce()>(&mut self, size: usize, sync: Sync) -> Self::Handle {
-        if size <= self.min_storage_buffer_allignment_offset {
+        if size <= self.min_storage_buffer_alignment_offset {
             return self.small_memory_pool.alloc(&mut self.storage, size, sync);
         }
 

--- a/crates/burn-compute/src/memory_management/dynamic.rs
+++ b/crates/burn-compute/src/memory_management/dynamic.rs
@@ -3,6 +3,7 @@ use super::memory_pool::{
     SmallMemoryPool,
 };
 use crate::storage::ComputeStorage;
+use alloc::vec::Vec;
 
 use super::MemoryManagement;
 
@@ -29,7 +30,7 @@ pub struct MemoryPoolOptions {
     ///
     /// Useful when you know in advance how much memory you'll need.
     pub chunk_num_prealloc: usize,
-    /// The max size in byte a slice can take in the pool.
+    /// The max size in bytes a slice can take in the pool.
     pub slice_max_size: usize,
 }
 
@@ -43,11 +44,13 @@ impl DynamicMemoryManagementOptions {
 
         const MB: usize = 1024 * 1024;
 
-        let mut pools = vec![MemoryPoolOptions {
+        let mut pools = Vec::new();
+
+        pools.push(MemoryPoolOptions {
             chunk_size: max_chunk_size,
             chunk_num_prealloc: 0,
             slice_max_size: max_chunk_size,
-        }];
+        });
 
         let mut current = max_chunk_size;
 
@@ -57,7 +60,7 @@ impl DynamicMemoryManagementOptions {
             pools.push(MemoryPoolOptions {
                 chunk_size: current,
                 chunk_num_prealloc: 0,
-                // Creating max slices lower than the chunk size reduces defragmentation.
+                // Creating max slices lower than the chunk size reduces fragmentation.
                 slice_max_size: current / 2usize.pow(pools.len() as u32),
             });
         }

--- a/crates/burn-compute/src/memory_management/dynamic.rs
+++ b/crates/burn-compute/src/memory_management/dynamic.rs
@@ -73,7 +73,7 @@ impl DynamicMemoryManagementOptions {
 impl<Storage: ComputeStorage> DynamicMemoryManagement<Storage> {
     /// Creates a new instance using the given storage, merging_strategy strategy and slice strategy.
     pub fn new(
-        min_storage_buffer_allignment_offset: usize,
+        min_storage_buffer_alignment_offset: usize,
         mut storage: Storage,
         mut options: DynamicMemoryManagementOptions,
     ) -> Self {
@@ -99,7 +99,7 @@ impl<Storage: ComputeStorage> DynamicMemoryManagement<Storage> {
             .collect();
 
         Self {
-            min_storage_buffer_alignment_offset: min_storage_buffer_allignment_offset,
+            min_storage_buffer_alignment_offset,
             small_memory_pool: SmallMemoryPool::new(),
             pools,
             options: options.pools,

--- a/crates/burn-compute/src/memory_management/dynamic.rs
+++ b/crates/burn-compute/src/memory_management/dynamic.rs
@@ -100,7 +100,7 @@ impl<Storage: ComputeStorage> DynamicMemoryManagement<Storage> {
 
         Self {
             min_storage_buffer_alignment_offset,
-            small_memory_pool: SmallMemoryPool::new(),
+            small_memory_pool: SmallMemoryPool::new(min_storage_buffer_alignment_offset),
             pools,
             options: options.pools,
             storage,

--- a/crates/burn-compute/src/memory_management/dynamic.rs
+++ b/crates/burn-compute/src/memory_management/dynamic.rs
@@ -88,6 +88,7 @@ impl<Storage: ComputeStorage> DynamicMemoryManagement<Storage> {
                 let mut pool = MemoryPool::new(
                     MemoryExtensionStrategy::Never,
                     RoundingStrategy::FixedAmount(option.chunk_size),
+                    min_storage_buffer_alignment_offset,
                 );
 
                 for _ in 0..option.chunk_num_prealloc {

--- a/crates/burn-compute/src/memory_management/memory_pool/base.rs
+++ b/crates/burn-compute/src/memory_management/memory_pool/base.rs
@@ -148,6 +148,7 @@ impl RoundingStrategy {
 }
 
 /// The strategy defines the frequency at which merging of free slices (defragmentation) occurs
+#[allow(unused)]
 #[derive(Debug)]
 pub enum MemoryExtensionStrategy {
     /// Once every n calls to reserve.
@@ -161,6 +162,7 @@ pub enum MemoryExtensionStrategy {
     Never,
 }
 
+#[allow(unused)]
 impl MemoryExtensionStrategy {
     /// Create a new strategy with the given period.
     pub fn new_period_tick(period: usize) -> Self {

--- a/crates/burn-compute/src/memory_management/memory_pool/base.rs
+++ b/crates/burn-compute/src/memory_management/memory_pool/base.rs
@@ -112,7 +112,6 @@ impl Slice {
 }
 
 const MIN_SIZE_NEEDED_TO_OFFSET: usize = 16;
-const MB: usize = 1024 * 1024;
 
 pub enum RoundingStrategy {
     FixedAmount(usize),

--- a/crates/burn-compute/src/memory_management/memory_pool/ring.rs
+++ b/crates/burn-compute/src/memory_management/memory_pool/ring.rs
@@ -12,7 +12,7 @@ pub struct RingBuffer<C: MemoryChunk<S>, S: MemorySlice> {
     cursor_chunk: usize,
     _s: PhantomData<S>,
     _c: PhantomData<C>,
-    buffer_alignement: usize,
+    buffer_alignment: usize,
 }
 
 pub trait MemoryChunk<S: MemorySlice> {
@@ -31,7 +31,7 @@ pub trait MemorySlice: Sized {
 }
 
 impl<C: MemoryChunk<S>, S: MemorySlice> RingBuffer<C, S> {
-    pub fn new(buffer_alignement: usize) -> Self {
+    pub fn new(buffer_alignment: usize) -> Self {
         Self {
             queue: Vec::new(),
             chunk_positions: HashMap::new(),
@@ -39,7 +39,7 @@ impl<C: MemoryChunk<S>, S: MemorySlice> RingBuffer<C, S> {
             cursor_chunk: 0,
             _s: PhantomData,
             _c: PhantomData,
-            buffer_alignement,
+            buffer_alignment,
         }
     }
 
@@ -97,7 +97,7 @@ impl<C: MemoryChunk<S>, S: MemorySlice> RingBuffer<C, S> {
 
                 if is_big_enough && is_free {
                     if slice.size() > size {
-                        if let Some(new_slice) = slice.split(size, self.buffer_alignement) {
+                        if let Some(new_slice) = slice.split(size, self.buffer_alignment) {
                             let new_slice_id = new_slice.id();
                             chunk.insert_slice(slice.next_slice_position(), new_slice, slices);
                             slices.get(&new_slice_id).unwrap();
@@ -376,7 +376,7 @@ mod stub {
             self.size
         }
 
-        fn split(&mut self, offset: usize, _buffer_alignement: usize) -> Option<Self> {
+        fn split(&mut self, offset: usize, _buffer_alignment: usize) -> Option<Self> {
             let size_remained = self.size - offset;
             self.size = offset;
 

--- a/crates/burn-compute/src/memory_management/memory_pool/ring.rs
+++ b/crates/burn-compute/src/memory_management/memory_pool/ring.rs
@@ -56,6 +56,8 @@ impl<C: MemoryChunk<S>, S: MemorySlice> RingBuffer<C, S> {
         for (pos, id) in self.queue.iter().enumerate() {
             self.chunk_positions.insert(*id, pos);
         }
+        self.cursor_chunk = 0;
+        self.cursor_slice = 0;
     }
 
     pub fn find_free_slice(

--- a/crates/burn-compute/src/memory_management/memory_pool/ring.rs
+++ b/crates/burn-compute/src/memory_management/memory_pool/ring.rs
@@ -25,7 +25,7 @@ pub trait MemoryChunk<S: MemorySlice> {
 pub trait MemorySlice: Sized {
     fn is_free(&self) -> bool;
     fn size(&self) -> usize;
-    fn split(&mut self, offset: usize, buffer_alignement: usize) -> Option<Self>;
+    fn split(&mut self, offset: usize, buffer_alignment: usize) -> Option<Self>;
     fn id(&self) -> SliceId;
     fn next_slice_position(&self) -> usize;
 }

--- a/crates/burn-wgpu/src/runtime.rs
+++ b/crates/burn-wgpu/src/runtime.rs
@@ -160,9 +160,11 @@ fn create_client(
     let limits = device_wgpu.limits();
     let storage = WgpuStorage::new(device_wgpu.clone(), queue.clone());
     let memory_management = DynamicMemoryManagement::new(
-        limits.min_storage_buffer_offset_alignment as usize,
         storage,
-        DynamicMemoryManagementOptions::preset(limits.max_storage_buffer_binding_size as usize),
+        DynamicMemoryManagementOptions::preset(
+            limits.max_storage_buffer_binding_size as usize,
+            limits.min_storage_buffer_offset_alignment as usize,
+        ),
     );
     let server = WgpuServer::new(memory_management, device_wgpu, queue, options.tasks_max);
     let channel = MutexComputeChannel::new(server);

--- a/crates/burn-wgpu/src/runtime.rs
+++ b/crates/burn-wgpu/src/runtime.rs
@@ -8,7 +8,7 @@ use burn_common::stub::RwLock;
 use burn_compute::{
     channel::MutexComputeChannel,
     client::ComputeClient,
-    memory_management::simple::{DeallocStrategy, SimpleMemoryManagement, SliceStrategy},
+    memory_management::dynamic::{DynamicMemoryManagement, DynamicMemoryManagementOptions},
     tune::Tuner,
     ComputeRuntime,
 };
@@ -25,20 +25,20 @@ pub struct WgpuRuntime {}
 
 impl JitRuntime for WgpuRuntime {
     type JitDevice = WgpuDevice;
-    type JitServer = WgpuServer<SimpleMemoryManagement<WgpuStorage>>;
+    type JitServer = WgpuServer<DynamicMemoryManagement<WgpuStorage>>;
 }
 
 /// The compute instance is shared across all [wgpu runtimes](WgpuRuntime).
 static RUNTIME: ComputeRuntime<WgpuDevice, Server, MutexComputeChannel<Server>> =
     ComputeRuntime::new();
 
-type Server = WgpuServer<SimpleMemoryManagement<WgpuStorage>>;
+type Server = WgpuServer<DynamicMemoryManagement<WgpuStorage>>;
 
 impl Runtime for WgpuRuntime {
     type Compiler = wgsl::WgslCompiler;
-    type Server = WgpuServer<SimpleMemoryManagement<WgpuStorage>>;
+    type Server = WgpuServer<DynamicMemoryManagement<WgpuStorage>>;
 
-    type Channel = MutexComputeChannel<WgpuServer<SimpleMemoryManagement<WgpuStorage>>>;
+    type Channel = MutexComputeChannel<WgpuServer<DynamicMemoryManagement<WgpuStorage>>>;
     type Device = WgpuDevice;
 
     fn client(device: &Self::Device) -> ComputeClient<Self::Server, Self::Channel> {
@@ -79,10 +79,6 @@ impl DeviceOps for WgpuDevice {
 
 /// The values that control how a WGPU Runtime will perform its calculations.
 pub struct RuntimeOptions {
-    /// How the buffers are deallocated.
-    pub dealloc_strategy: DeallocStrategy,
-    /// Control the slicing strategy.
-    pub slice_strategy: SliceStrategy,
     /// Control the amount of compute tasks to be aggregated into a single GPU command.
     pub tasks_max: usize,
 }
@@ -98,11 +94,7 @@ impl Default for RuntimeOptions {
             Err(_) => DEFAULT_MAX_TASKS,
         };
 
-        Self {
-            dealloc_strategy: DeallocStrategy::new_period_tick(tasks_max * 2),
-            slice_strategy: SliceStrategy::Ratio(0.8),
-            tasks_max,
-        }
+        Self { tasks_max }
     }
 }
 
@@ -162,12 +154,15 @@ fn create_client(
     features: Arc<FeatureSet>,
     options: RuntimeOptions,
 ) -> ComputeClient<
-    WgpuServer<SimpleMemoryManagement<WgpuStorage>>,
-    MutexComputeChannel<WgpuServer<SimpleMemoryManagement<WgpuStorage>>>,
+    WgpuServer<DynamicMemoryManagement<WgpuStorage>>,
+    MutexComputeChannel<WgpuServer<DynamicMemoryManagement<WgpuStorage>>>,
 > {
+    let limits = device_wgpu.limits();
     let storage = WgpuStorage::new(device_wgpu.clone(), queue.clone());
-    let memory_management =
-        SimpleMemoryManagement::new(storage, options.dealloc_strategy, options.slice_strategy);
+    let memory_management = DynamicMemoryManagement::new(
+        storage,
+        DynamicMemoryManagementOptions::preset(limits.max_storage_buffer_binding_size as usize),
+    );
     let server = WgpuServer::new(memory_management, device_wgpu, queue, options.tasks_max);
     let channel = MutexComputeChannel::new(server);
     let tuner_device_id = tuner_device_id(adapter.get_info());

--- a/crates/burn-wgpu/src/runtime.rs
+++ b/crates/burn-wgpu/src/runtime.rs
@@ -160,6 +160,7 @@ fn create_client(
     let limits = device_wgpu.limits();
     let storage = WgpuStorage::new(device_wgpu.clone(), queue.clone());
     let memory_management = DynamicMemoryManagement::new(
+        limits.min_storage_buffer_offset_alignment as usize,
         storage,
         DynamicMemoryManagementOptions::preset(limits.max_storage_buffer_binding_size as usize),
     );


### PR DESCRIPTION
It's now more stable and much faster. The maximum memory usage is probably higher than before, but this is because it shows the maximum amount of memory used by the GPU, not the current amount. There is no deallocation, and we allocate in a way that is fragmentation-friendly for better speed, possibly at the cost of slightly higher maximum memory usage.