### PR TITLE
Enhance slice operation to support more range variation

### DIFF
--- a/crates/burn-import/src/onnx/op_configuration.rs
+++ b/crates/burn-import/src/onnx/op_configuration.rs
@@ -1336,10 +1336,9 @@ pub fn slice_config(node: &Node) -> Vec<Option<(i64, i64)>> {
 
     // If dim is negative, it is counted from the end
     // Negative value means counting dimensions from the back.
-    for i in 0..axes.len() {
-        let axis = axes[i];
-        if axis < 0 {
-            axes[i] = axis + input_dim as i64;
+    for axis in &mut axes {
+        if *axis < 0 {
+            *axis = *axis + input_dim as i64;
         }
     }
 

--- a/crates/burn-import/src/onnx/op_configuration.rs
+++ b/crates/burn-import/src/onnx/op_configuration.rs
@@ -1283,60 +1283,74 @@ pub fn shape_config(curr: &Node) -> (usize, usize) {
     (start_dim as usize, end_dim as usize)
 }
 
-pub fn slice_config(node: &Node) -> (Vec<usize>, Vec<usize>) {
-    fn ensure_1d_tensor(node: &Node, index: usize) {
-        match &node.inputs[index].ty {
-            ArgType::Tensor(tensor) => assert_eq!(tensor.dim, 1, "Slice: tensor must be 1D"),
-            _ => panic!("Only tensor input is valid"),
-        };
-    }
+pub fn slice_config(node: &Node) -> Vec<Option<(i64, i64)>> {
+    fn get_input_values(node: &Node, index: usize) -> Vec<i64> {
+        // If the input is not provided, return an empty vector
+        if node.inputs.get(index).is_none() {
+            return Vec::new();
+        }
 
-    fn get_input_values(node: &Node, index: usize) -> Vec<usize> {
-        let tensor_shape = match &node.inputs[0].ty {
-            ArgType::Tensor(tensor) => tensor.shape.as_ref().unwrap(),
-            _ => panic!("Only tensor input is valid"),
-        };
         match &node.inputs[index].value {
-            Some(Data::Int64s(shape)) => shape
-                .iter()
-                .enumerate()
-                .map(|(i, x)| {
-                    if x.is_negative() {
-                        tensor_shape[i] - x.wrapping_abs() as usize
-                    } else {
-                        *x as usize
-                    }
-                })
-                .collect(),
+            Some(Data::Int64s(shape)) => shape.clone(),
+
             _ => panic!("Tensor data type must be int64"),
         }
     }
 
-    ensure_1d_tensor(node, 1);
-    ensure_1d_tensor(node, 2);
+    let mut starts = get_input_values(node, 1);
+    let mut ends = get_input_values(node, 2);
+    let mut axes = get_input_values(node, 3);
+    let mut steps = get_input_values(node, 4);
 
-    let starts = get_input_values(node, 1);
-    let ends = get_input_values(node, 2);
-
+    // https://burn.dev/docs/burn/prelude/struct.Tensor.html#method.slice
+    // TODO default missing axes ranges to the full range of the corresponding axis
     for (key, value) in node.attrs.iter() {
         match key.as_str() {
-            "axes" => {
-                let mut i = 0;
-                value.clone().into_i64s().iter().for_each(|x| {
-                    assert_eq!(*x, i, "Slice: axes must be consecutive");
-                    i += 1;
-                })
-            }
-            "steps" => value.clone().into_i64s().into_iter().for_each(|x| {
-                if x != 1 {
-                    panic!("Slice: steps other than 1 are not supported");
-                }
-            }),
+            "ends" => starts = value.clone().into_i64s(),
+            "starts" => ends = value.clone().into_i64s(),
+            "axes" => axes = value.clone().into_i64s(),
+            "steps" => steps = value.clone().into_i64s(),
             _ => {}
         }
     }
 
-    (starts, ends)
+    if !steps.is_empty() && steps.iter().any(|&x| x != 1) {
+        panic!("Slice: steps other than 1 are not supported");
+    }
+
+    // Extract the shape of the input tensor
+    let input_dim = match node.inputs.first().unwrap().clone().ty {
+        ArgType::Tensor(tensor) => tensor.dim,
+        _ => panic!("Only tensor input is valid"),
+    };
+
+    // If axes is not provided, it defaults to all axes
+    if axes.is_empty() {
+        axes = (0..starts.len() as i64).collect();
+    }
+
+    // assert len(starts) == len(ends) == len(axes)
+    if starts.len() != ends.len() || starts.len() != axes.len() {
+        panic!("Slice: starts, ends, and axes must have the same length");
+    }
+
+    // If dim is negative, it is counted from the end
+    // Negative value means counting dimensions from the back.
+    for i in 0..axes.len() {
+        let axis = axes[i];
+        if axis < 0 {
+            axes[i] = axis + input_dim as i64;
+        }
+    }
+
+    // convert starts, ends, and axes to ranges. Use None for missing axes ranges
+    let mut ranges: Vec<Option<(i64, i64)>> = vec![None; input_dim];
+    for i in 0..axes.len() {
+        let axis = axes[i] as usize;
+        ranges[axis] = Some((starts[i], ends[i]));
+    }
+
+    ranges
 }
 
 pub fn transpose_config(curr: &Node) -> Vec<i64> {

--- a/crates/burn-import/src/onnx/op_configuration.rs
+++ b/crates/burn-import/src/onnx/op_configuration.rs
@@ -1306,8 +1306,8 @@ pub fn slice_config(node: &Node) -> Vec<Option<(i64, i64)>> {
     // TODO default missing axes ranges to the full range of the corresponding axis
     for (key, value) in node.attrs.iter() {
         match key.as_str() {
-            "ends" => starts = value.clone().into_i64s(),
-            "starts" => ends = value.clone().into_i64s(),
+            "starts" => starts = value.clone().into_i64s(),
+            "ends" => ends = value.clone().into_i64s(),
             "axes" => axes = value.clone().into_i64s(),
             "steps" => steps = value.clone().into_i64s(),
             _ => {}

--- a/crates/burn-import/src/onnx/to_burn.rs
+++ b/crates/burn-import/src/onnx/to_burn.rs
@@ -736,9 +736,9 @@ impl ParsedOnnxGraph {
     fn slice_conversion(node: Node) -> SliceNode {
         let input = TensorType::from(node.inputs.first().unwrap());
         let output = TensorType::from(node.outputs.first().unwrap());
-        let (starts, ends) = slice_config(&node);
+        let ranges = slice_config(&node);
 
-        SliceNode::new(input, output, starts, ends)
+        SliceNode::new(input, output, ranges)
     }
 
     fn sum_conversion(node: Node) -> SumNode {

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -610,7 +610,7 @@ where
     ///     // 1D slicing
     ///     let tensor = Tensor::<B, 1, burn_tensor::Int>::arange(0..5, &device);
     ///     let slice = tensor.slice([1..4]);
-    ///     assert_eq!(slice.into_data().to_vec(), vec![1, 2, 3]);
+    ///     assert_eq!(slice.into_data().to_vec::<i32>().unwrap(), vec![1i32, 2, 3]);
     ///
     ///     // 2D slicing
     ///     let tensor = Tensor::<B, 2>::ones(Shape::new([3, 4]), &device);
@@ -620,10 +620,10 @@ where
     ///     // Using negative indices
     ///     let tensor = Tensor::<B, 1, burn_tensor::Int>::arange(0..5, &device);
     ///     let slice = tensor.slice([(1, -1)]); // Equivalent to 1..4
-    ///     assert_eq!(slice.into_data().to_vec(), vec![1, 2, 3]);
+    ///     assert_eq!(slice.into_data().to_vec::<i32>().unwrap(), vec![1i32, 2, 3]);
     ///
     ///     // Using Option<(i64, i64)>
-    ///     let tensor = Tensor::<B, 2, burn_tensor::Int>::arange(0..12, &device).reshape([3, 4]);
+    ///     let tensor = Tensor::<B, 1, burn_tensor::Int>::arange(0..12, &device).reshape([3, 4]);
     ///     let slice = tensor.slice([Some((1, -1)), None]); // Select rows 1 and 2, all columns
     ///     assert_eq!(slice.dims(), [2, 4]);
     /// }

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -2106,7 +2106,7 @@ impl MovedimArgs for i32 {
 
 /// Trait used for slice arguments
 pub trait RangesArg<const D2: usize> {
-    /// Converts into a set of ranges to [core::ops::Range<usize>; D2] for the `tensor.slice()` function
+    /// Converts into a set of ranges to `[core::ops::Range<usize>; D2]` for the `tensor.slice()` function
     fn into_ranges<const D: usize>(self, shape: Shape<D>) -> [core::ops::Range<usize>; D2];
 
     /// Handles negative index values

--- a/crates/onnx-ir/src/dim_inference.rs
+++ b/crates/onnx-ir/src/dim_inference.rs
@@ -66,7 +66,7 @@ pub fn dim_inference(node: &mut Node) {
         NodeType::Sigmoid => same_as_input(node),
         NodeType::Sign => same_as_input(node),
         NodeType::Sin => same_as_input(node),
-        NodeType::Slice => slice_update_outputs(node),
+        NodeType::Slice => same_as_input(node),
         NodeType::Softmax => same_as_input(node),
         NodeType::Sqrt => same_as_input(node),
         NodeType::Sub => sub_update_outputs(node),
@@ -452,33 +452,6 @@ fn squeeze_update_output(node: &mut Node) {
         shape: None, // shape is tracked and calculated at runtime
         elem_type: output_elem,
     });
-}
-
-fn slice_update_outputs(node: &mut Node) {
-    let shape = match &node.inputs[1].value {
-        Some(value) => match value {
-            Data::Int64s(shape) => Some(shape.clone()),
-            _ => panic!("Slice: invalid input types"),
-        },
-        None => None,
-    };
-
-    if shape.is_none() {
-        panic!("Slice: invalid shape");
-    }
-
-    let output = match &node.outputs[0].ty {
-        ArgType::Tensor(tensor) => tensor.clone(),
-        _ => panic!("Slice: invalid output types"),
-    };
-
-    if let Some(shape) = shape {
-        node.outputs[0].ty = ArgType::Tensor(TensorType {
-            dim: shape.len(),
-            shape: None, // shape is calculated at runtime
-            ..output
-        });
-    }
 }
 
 fn sub_update_outputs(node: &mut Node) {


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

#1915, #1981, #1982, #1983

### Changes

Primarily to support ONNX slice operation and closer PyTorch compatibility.

1. Enhance slice operation to support more range variations: None for a missing rage and negative ranks in ranges.
2. Clamp range start and end to dimension ranks.

### Testing

More unit tests 
