### PR TITLE
Added parameter trust_remote_code to hf dataset call.

### DIFF
--- a/crates/burn-dataset/examples/hf_dataset.rs
+++ b/crates/burn-dataset/examples/hf_dataset.rs
@@ -1,0 +1,22 @@
+use burn_dataset::HuggingfaceDatasetLoader;
+use burn_dataset::SqliteDataset;
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug, Clone)]
+struct MnistItemRaw {
+    pub _image_bytes: Vec<u8>,
+    pub _label: usize,
+}
+fn main() {
+    // There are some datasets, such as https://huggingface.co/datasets/ylecun/mnist/tree/main that contains a script,
+    // In this cases you must enable trusting remote code execution if you want to use it.
+    let _train_ds: SqliteDataset<MnistItemRaw> = HuggingfaceDatasetLoader::new("mnist")
+        .with_trust_remote_code(true)
+        .dataset("train")
+        .unwrap();
+
+    // However not all dataset requires it https://huggingface.co/datasets/Anthropic/hh-rlhf/tree/main
+    let _train_ds: SqliteDataset<MnistItemRaw> = HuggingfaceDatasetLoader::new("Anthropic/hh-rlhf")
+        .dataset("train")
+        .unwrap();
+}

--- a/crates/burn-dataset/src/source/huggingface/downloader.rs
+++ b/crates/burn-dataset/src/source/huggingface/downloader.rs
@@ -75,7 +75,7 @@ impl HuggingfaceDatasetLoader {
             base_dir: None,
             huggingface_token: None,
             huggingface_cache_dir: None,
-            trust_remote_code: true,
+            trust_remote_code: false,
         }
     }
 
@@ -306,23 +306,4 @@ fn install_python_deps(base_dir: &Path) -> Result<PathBuf, ImporterError> {
     })?;
 
     Ok(venv_python_path)
-}
-
-#[cfg(test)]
-mod test {
-    #[test]
-    pub fn check_import() {
-        use crate::HuggingfaceDatasetLoader;
-        use crate::SqliteDataset;
-        use serde::Deserialize;
-
-        #[derive(Deserialize, Debug, Clone)]
-        struct MnistItemRaw {
-            pub _image_bytes: Vec<u8>,
-            pub _label: usize,
-        }
-        let _train_ds: SqliteDataset<MnistItemRaw> = HuggingfaceDatasetLoader::new("mnist")
-            .dataset("train")
-            .unwrap();
-    }
 }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed. Some tests failed on windows, but are unrelated to the fix, those tests are `tanh_should_not_have_numerical_bugs_on_macos` and `nn::rope_encoding::tests::test_rotary_encoding_forward`.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Fixes #2012

### Changes

The underlying Python that fetches HuggingFace datasets requires an additional parameter or if not provided an input.
Since this parameter was not provided, the input screen kicked in, but it was impossible to pass the command.
What I did was to add said parameter both in the `HuggingfaceDatasetLoader` and to the python script.

### Testing

A test module has been added.
