### PR TITLE
Bump gix-tempfile to fix RUSTSEC-2024-0350

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2206,9 +2206,9 @@ dependencies = [
 
 [[package]]
 name = "gix-features"
-version = "0.38.1"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4254037d20a247a0367aa79333750146a369719f0c6617fec4f5752cc62b37"
+checksum = "ac7045ac9fe5f9c727f38799d002a7ed3583cd777e3322a7c4b43e3cf437dc69"
 dependencies = [
  "gix-hash",
  "gix-trace",
@@ -2218,10 +2218,11 @@ dependencies = [
 
 [[package]]
 name = "gix-fs"
-version = "0.10.2"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2184c40e7910529677831c8b481acf788ffd92427ed21fad65b6aa637e631b8"
+checksum = "c3338ff92a2164f5209f185ec0cd316f571a72676bb01d27e22f2867ba69f77a"
 dependencies = [
+ "fastrand",
  "gix-features",
  "gix-utils",
 ]
@@ -2238,9 +2239,9 @@ dependencies = [
 
 [[package]]
 name = "gix-tempfile"
-version = "13.1.1"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a761d76594f4443b675e85928e4902dec333273836bd386906f01e7e346a0d11"
+checksum = "d3b0e276cd08eb2a22e9f286a4f13a222a01be2defafa8621367515375644b99"
 dependencies = [
  "dashmap",
  "gix-fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ fake = "2.9.2"
 flate2 = "1.0.30"
 float-cmp = "0.9.0"
 getrandom = { version = "0.2.15", default-features = false }
-gix-tempfile = { version = "13.1.1", features = ["signals"] }
+gix-tempfile = { version = "14.0.0", features = ["signals"] }
 globwalk = "0.9.1"
 hashbrown = "0.14.5"
 hound = "3.5.1"


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

Fixes audit error reporting `RUSTSEC-2024-0350`

![image](https://github.com/user-attachments/assets/08a0edae-5a9c-498c-a8d4-ccdf5d3d703d)
