### PR TITLE
Only poll device when reading data instead of blocking

### DIFF
--- a/crates/burn-wgpu/src/compute/server.rs
+++ b/crates/burn-wgpu/src/compute/server.rs
@@ -179,7 +179,7 @@ where
                     .expect("Unable to send buffer slice result to async channel.")
             });
 
-            device.poll(wgpu::Maintain::Wait);
+            device.poll(wgpu::Maintain::Poll);
 
             let result = receiver
                 .recv()


### PR DESCRIPTION

### Changes
According to [wgpu docs](https://docs.rs/wgpu/latest/wgpu/struct.BufferSlice.html#method.map_async), the device only needs to be polled for the map_async to complete at some point. Waiting for the channel does the actual waiting (async or blocking).

This is not very different, but, Maintain::Wait also prevents other threads from submitting commands, leading to stalls in multithreaded scenarios. Here's a before and after of a multithreaded app:


<img width="1171" alt="Screenshot 2024-07-17 at 12 04 06" src="https://github.com/user-attachments/assets/e08a981b-378c-4a5e-a89d-3ea5e88c760d">
<img width="1171" alt="Screenshot 2024-07-17 at 12 04 51" src="https://github.com/user-attachments/assets/d7f14284-8244-4b9d-a56d-b1fe284717bf">

(Send batch is waiting on a read).

