### PR TITLE
Bump rust minimal version to 1.79

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,13 +67,13 @@ jobs:
       matrix:
         os: [blaze/macos-14, ubuntu-22.04, windows-2022]
         # We support both the latest Rust toolchain and the preceding version.
-        rust: [stable, 1.75.0]
+        rust: [stable, 1.79.0]
         test: ['std', 'no-std', 'examples']
         include:
           - cache: stable
             rust: stable
-          - cache: 1-75-0
-            rust: 1.75.0
+          - cache: 1-79-0
+            rust: 1.79.0
           - os: ubuntu-22.04
             coverage-flags: COVERAGE=1
             rust: stable
@@ -88,7 +88,7 @@ jobs:
             # auto-graphics-backend-flags: "AUTO_GRAPHICS_BACKEND=dx12";'
         exclude:
           # only need to check this once
-          - rust: 1.75.0
+          - rust: 1.79.0
             test: 'examples'
           # Do not run no-std tests on macos
           - os: blaze/macos-14

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Test Status](https://github.com/tracel-ai/burn/actions/workflows/test.yml/badge.svg)](https://github.com/tracel-ai/burn/actions/workflows/test.yml)
 [![CodeCov](https://codecov.io/gh/tracel-ai/burn/branch/main/graph/badge.svg)](https://codecov.io/gh/tracel-ai/burn)
 [![Blaze](https://runblaze.dev/gh/114041730602611213183421653564341667516/badge.svg)](https://runblaze.dev)
-[![Rust Version](https://img.shields.io/badge/Rust-1.75.0+-blue)](https://releases.rs/docs/1.75.0)
+[![Rust Version](https://img.shields.io/badge/Rust-1.79.0+-blue)](https://releases.rs/docs/1.79.0)
 ![license](https://shields.io/badge/license-MIT%2FApache--2.0-blue)
 
 ---

--- a/crates/burn-cube/README.md
+++ b/crates/burn-cube/README.md
@@ -4,7 +4,7 @@
 <br />
 <br />
 
-[![Rust Version](https://img.shields.io/badge/Rust-1.75.0+-blue)](https://releases.rs/docs/1.75.0)
+[![Rust Version](https://img.shields.io/badge/Rust-1.79.0+-blue)](https://releases.rs/docs/1.79.0)
 ![license](https://shields.io/badge/license-MIT%2FApache--2.0-blue)
 
 ---

--- a/crates/burn/Cargo.toml
+++ b/crates/burn/Cargo.toml
@@ -9,7 +9,7 @@ name = "burn"
 readme.workspace = true
 repository = "https://github.com/tracel-ai/burn"
 version.workspace = true
-rust-version = "1.75"
+rust-version = "1.79"
 
 [features]
 default = ["burn-core/default", "burn-train?/default", "std"]


### PR DESCRIPTION
Because `bitstream-io`, a dependency of `rav1e` which is used by the `image` crate in `burn-dataset`, started using a feature only in Rust 1.79.

