### PR TITLE
Extend affine quantization [min, max] range to ensure zero-point

### DIFF
--- a/crates/burn-tensor/src/tests/quantization/scheme.rs
+++ b/crates/burn-tensor/src/tests/quantization/scheme.rs
@@ -25,7 +25,7 @@ mod tests {
             .offset
             .unwrap()
             .into_data()
-            .assert_eq(&TensorData::from([72]), false);
+            .assert_eq(&TensorData::from([71]), false);
     }
 
     #[test]


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.

### Changes

While adding unit q_* ops for the current float ops I realized affine quantization must ensure that the input range includes zero to enforce the zero-point representation. By definition, the zero-point value corresponds to the value 0 in the float32 realm.

### Testing

Added zero-point unit test and adjusted other unit tests values to reflect these changes.
