### PR TITLE
modify broken link src of ide image

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ You may also want to enable debugging by creating a `.vscode/settings.json` file
 3. Now you can enable breakpoint on code through IDE and then start debugging the library/binary you want, such as the following example:
 
 <div align="center">
-<img src="./assets/debug-options-vscode.png" width="700px"/>
+<img src="./contributor-book/src/getting-started/debug-options-vscode.png" width="700px"/>
 <div align="left">
 
 4. If you're creating a new library or binary, keep in mind to repeat the step 2 to always keep a fresh list of targets.


### PR DESCRIPTION
## Pull Request Template

Hi developers,

Appreciate your efforts and cool projects.

BTW, The img link of IDE in [CONTRIBUTING.md](https://github.com/tracel-ai/burn/blob/main/CONTRIBUTING.md) is incorrect as follows.

<img width="1314" alt="image" src="https://github.com/user-attachments/assets/5890ebf1-0883-4f73-8e9a-30720f5bcb14">

I will submit a PR to fix it. If ok, merge it to fix it.  This is a minor change but I hope it will improve users' feelings.

Thank you.

### Checklist

- [ ] Confirmed that `run-checks all` script has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

https://github.com/tracel-ai/burn/issues/2078

### Changes

Fixed the link. This incorrect link happened by re-structuring repository and carving out some resources to `contribute-book` directory. So, if you have some plans to integrate it in other ways, please let me know it and I will withdraw this PR and issue or am happy to fix it in other ways.

### Testing

Checked the image as below.
Link is [here at my repo](https://github.com/tiruka/burn/blob/modify-ide-image-src-link/CONTRIBUTING.md)
<img width="1226" alt="image" src="https://github.com/user-attachments/assets/b563f745-ac77-4938-b043-4c45758f50b9">
