### PR TITLE
Fix bug: Filling tensor containing f32::NEG_INFINITY will result in NaN for burn-ndarray

### DIFF
--- a/crates/burn-ndarray/src/ops/base.rs
+++ b/crates/burn-ndarray/src/ops/base.rs
@@ -418,13 +418,16 @@ where
         mask: NdArrayTensor<bool, D>,
         value: E,
     ) -> NdArrayTensor<E, D> {
-        let array = tensor.array.mapv(|x| x);
-        let masked_array =
-            Zip::from(&array)
-                .and(&mask.array)
-                .map_collect(|&x, &m| if m { value } else { x });
-
-        NdArrayTensor::new(masked_array.into_shared())
+        let mut output = tensor.array.clone();
+        let broadcast_mask = mask.array.broadcast(output.dim()).unwrap();
+        Zip::from(&mut output)
+            .and(&broadcast_mask)
+            .for_each(|out, &mask_val| {
+                if mask_val {
+                    *out = value;
+                }
+            });
+        NdArrayTensor::new(output.into_shared())
     }
 
     fn gather_batch_size<const D: usize>(

--- a/crates/burn-tensor/src/tests/ops/mask.rs
+++ b/crates/burn-tensor/src/tests/ops/mask.rs
@@ -68,4 +68,25 @@ mod tests {
 
         output.into_data().assert_eq(&expected, false);
     }
+
+    #[test]
+    fn float_mask_fill_infinit() {
+        let device = Default::default();
+        let tensor = Tensor::<TestBackend, 2>::from_data(
+            [
+                [f32::NEG_INFINITY, f32::NEG_INFINITY],
+                [f32::NEG_INFINITY, f32::NEG_INFINITY],
+            ],
+            &device,
+        );
+        let mask = Tensor::<TestBackend, 2, Bool>::from_bool(
+            TensorData::from([[true, false], [false, true]]),
+            &device,
+        );
+
+        let output = tensor.mask_fill(mask, 10.0f32);
+        let expected = TensorData::from([[10f32, f32::NEG_INFINITY], [f32::NEG_INFINITY, 10f32]]);
+
+        output.into_data().assert_eq(&expected, false);
+    }
 }

--- a/crates/burn-tensor/src/tests/ops/mask.rs
+++ b/crates/burn-tensor/src/tests/ops/mask.rs
@@ -70,7 +70,7 @@ mod tests {
     }
 
     #[test]
-    fn float_mask_fill_infinit() {
+    fn float_mask_fill_infinite() {
         let device = Default::default();
         let tensor = Tensor::<TestBackend, 2>::from_data(
             [


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Fixes #2094

### Changes

1. Fixed mask_fill burn-ndarray method
2. Added regression test

### Testing

New regression test
