### PR TITLE
Modify contributing md scripts to solve conflicts between doc and scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,7 @@ The `environment` argument can assume **ONLY** the following values:
 - `examples` to check the examples compile
 
 If no `environment` value has been passed, run all checks except examples.
+If you have an error related to `torch` installation, see [Burn Torch Backend Installation](./crates/burn-tch/README.md#Installation)
 
 ## Continuous Deployment
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ You may also want to enable debugging by creating a `.vscode/settings.json` file
 On Unix systems, run `run-checks.sh` using this command
 
 ```
-run-checks.sh environment
+./run-checks.sh environment
 ```
 
 On Windows systems, run `run-checks.ps1` using this command:
@@ -106,9 +106,11 @@ run-checks.ps1 environment
 The `environment` argument can assume **ONLY** the following values:
 
 - `std` to perform checks using `libstd`
-- `no_std` to perform checks on an embedded environment using `libcore`
+- `no-std` to perform checks on an embedded environment using `libcore`
+- `typos` to check for typos in the codebase
+- `examples` to check the examples compile
 
-If no `environment` value has been passed, run both `std` and `no_std` checks.
+If no `environment` value has been passed, run all checks except examples.
 
 ## Continuous Deployment
 

--- a/run-checks.ps1
+++ b/run-checks.ps1
@@ -8,7 +8,7 @@
 # where `environment` can assume **ONLY** the following values:
 #
 # - `std` to perform checks using `libstd`
-# - `no_std` to perform checks on an embedded environment using `libcore`
+# - `no-std` to perform checks on an embedded environment using `libcore`
 # - `typos` to check for typos in the codebase
 # - `examples` to check the examples compile
 # If no `environment` value has been passed, run all checks except examples.

--- a/run-checks.sh
+++ b/run-checks.sh
@@ -13,7 +13,7 @@ set -e
 # where `environment` can assume **ONLY** the following values:
 #
 # - `std` to perform checks using `libstd`
-# - `no_std` to perform checks on an embedded environment using `libcore`
+# - `no-std` to perform checks on an embedded environment using `libcore`
 # - `typos` to check for typos in the codebase
 # - `examples` to check the examples compile
 #

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -35,6 +35,7 @@ enum Command {
     /// Run the specified `burn` tests and checks locally.
     RunChecks {
         /// The environment to run checks against
+        #[clap(value_enum, default_value_t = runchecks::CheckType::default())]
         env: runchecks::CheckType,
     },
     /// Run the specified vulnerability check locally. These commands must be called with 'cargo +nightly'.

--- a/xtask/src/runchecks.rs
+++ b/xtask/src/runchecks.rs
@@ -26,7 +26,6 @@ const ARM_TARGET: &str = "thumbv7m-none-eabi";
 #[derive(clap::ValueEnum, Default, Copy, Clone, PartialEq, Eq)]
 pub(crate) enum CheckType {
     /// Run all checks.
-    #[default]
     All,
     /// Run `std` environment checks
     Std,
@@ -36,6 +35,9 @@ pub(crate) enum CheckType {
     Typos,
     /// Test the examples
     Examples,
+    /// No args are provided
+    #[default]
+    NoArgs,
 }
 
 impl CheckType {
@@ -59,6 +61,12 @@ impl CheckType {
             Self::Examples => check_examples(),
             Self::All => {
                 /* Run all checks */
+                check_typos();
+                std_checks();
+                no_std_checks();
+                check_examples();
+            }
+            Self::NoArgs => {
                 check_typos();
                 std_checks();
                 no_std_checks();

--- a/xtask/src/runchecks.rs
+++ b/xtask/src/runchecks.rs
@@ -51,7 +51,7 @@ impl CheckType {
         // Depending on the input argument, the respective environment checks
         // are run.
         //
-        // If no environment has been passed, run all checks.
+        // If no `environment` value has been passed, run all checks except examples.
         match self {
             Self::Std => std_checks(),
             Self::NoStd => no_std_checks(),
@@ -62,7 +62,6 @@ impl CheckType {
                 check_typos();
                 std_checks();
                 no_std_checks();
-                check_examples();
             }
         }
 

--- a/xtask/src/runchecks.rs
+++ b/xtask/src/runchecks.rs
@@ -25,7 +25,8 @@ const ARM_TARGET: &str = "thumbv7m-none-eabi";
 
 #[derive(clap::ValueEnum, Default, Copy, Clone, PartialEq, Eq)]
 pub(crate) enum CheckType {
-    /// Run all checks.
+    /// Run all checks except examples
+    #[default]
     All,
     /// Run `std` environment checks
     Std,
@@ -35,9 +36,6 @@ pub(crate) enum CheckType {
     Typos,
     /// Test the examples
     Examples,
-    /// No args are provided
-    #[default]
-    NoArgs,
 }
 
 impl CheckType {
@@ -61,12 +59,6 @@ impl CheckType {
             Self::Examples => check_examples(),
             Self::All => {
                 /* Run all checks */
-                check_typos();
-                std_checks();
-                no_std_checks();
-                check_examples();
-            }
-            Self::NoArgs => {
                 check_typos();
                 std_checks();
                 no_std_checks();


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Fixes #2106

### Changes

1.no_std is typo, but it should be no-std

no_std is typo, but it should be no-std

The doc tell that there are only two environment of std and no-std, but it now includes four environments due to script.

```rust
% ./run-checks.sh no_std
    Finished `dev` profile [optimized] target(s) in 0.16s
     Running `target/debug/xtask run-checks no_std`
error: invalid value 'no_std' for '<ENV>'
  [possible values: all, std, no-std, typos, examples]

  tip: a similar value exists: 'no-std'

For more information, try '--help'.
```

2.environment values

“If no `environment` value has been passed, run both `std` and `no_std` checks”, this is incorrect because when I use the script without environment args, it causes an error as follow. 

```rust
% ./run-checks.sh       
    Finished `dev` profile [optimized] target(s) in 0.15s
     Running `target/debug/xtask run-checks`
error: the following required arguments were not provided:
  <ENV>

Usage: xtask run-checks <ENV>
```

It is because the implementation and docs are different. As of now, I believe script comments are correct and modify the codes by modifying default value so as to keep `All` as it is and executes checks except examples. But if you prefer to others, I will follow it, so please let me know.

3.torch installation. 
I got in trouble when executing `./run-checks.sh all` because I have never installed torch on my pc. It is because `./run-checks.sh all` executes `crates/burn-tch` and it requires torch installation. Therefore, adding the link of `crates/burn-tch` will definitely help developers like me to solve the issue, so I added the link on the `CONTRIBUTING.md`.

### Testing

I run `./run-check.sh` and checked to `All` is executed.