### PR TITLE
remove lto linker option to make build successful

### DIFF
--- a/examples/mnist-inference-web/build-for-web.sh
+++ b/examples/mnist-inference-web/build-for-web.sh
@@ -10,7 +10,7 @@ then
 fi
 
 # Set optimization flags
-export RUSTFLAGS="-C lto=fat -C embed-bitcode=yes -C codegen-units=1 -C opt-level=3 --cfg web_sys_unstable_apis"
+export RUSTFLAGS="-C embed-bitcode=yes -C codegen-units=1 -C opt-level=3 --cfg web_sys_unstable_apis"
 
 # Run wasm pack tool to build JS wrapper files and copy wasm to pkg directory.
 mkdir -p pkg


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

https://github.com/tracel-ai/burn/issues/2122

Summary
The -C lto=fat option in the RUSTFLAGS environment variable causes build errors when compiling proc-macro crates. This is due to the incompatibility of Link Time Optimization (LTO) with proc-macro crate types without the experimental -Zdylib-lto flag. The errors are specifically related to crates like serde_derive, zerocopy-derive, and walrus-macro.

Proposal
To resolve this issue, I propose removing the -C lto=fat option from RUSTFLAGS. This change will ensure compatibility with proc-macro crates and prevent the build errors.


### Changes

Removed lto option.
I think it is okay because [image-classification-web](https://github.com/tracel-ai/burn/blob/main/examples/image-classification-web/build-for-web.sh) does not set up the lto option.

### Testing

After removing the option, `./build-for-web.sh wgpu|ndarray` succeeded in the https://github.com/tracel-ai/burn/tree/main/examples/mnist-inference-web.