### PR TITLE
Fix module derive with generics

### DIFF
--- a/crates/burn-derive/src/module/codegen.rs
+++ b/crates/burn-derive/src/module/codegen.rs
@@ -224,11 +224,6 @@ impl GenericsParser {
             );
 
             generics_names_except_backend.extend(quote! { <#ident as burn::module::AutodiffModule<B>>::InnerModule, });
-            module_autodiff.add_predicate(
-                parse_quote! {
-                    #ident: burn::module::Module<B::InnerBackend>
-                }
-            );
 
             module_autodiff.add_predicate(
                 parse_quote! {

--- a/crates/burn-derive/src/module/codegen.rs
+++ b/crates/burn-derive/src/module/codegen.rs
@@ -201,16 +201,9 @@ impl GenericsParser {
 
             module.add_predicate(
                 parse_quote! {
-                    #ident: burn::module::ModuleDisplayDefault
-                }
-            );
-
-            module.add_predicate(
-                parse_quote! {
                     #ident: burn::module::ModuleDisplay
                 }
             );
-
 
             module_autodiff.add_predicate(
                 parse_quote! {
@@ -230,23 +223,10 @@ impl GenericsParser {
                 }
             );
 
-            module_autodiff.add_predicate(
-                parse_quote! {
-                    <#ident as burn::module::AutodiffModule<B>>::InnerModule: burn::module::ModuleDisplay
-                }
-            );
-
-
             generics_names_except_backend.extend(quote! { <#ident as burn::module::AutodiffModule<B>>::InnerModule, });
             module_autodiff.add_predicate(
                 parse_quote! {
                     #ident: burn::module::Module<B::InnerBackend>
-                }
-            );
-
-            module_autodiff.add_predicate(
-                parse_quote! {
-                    #ident: burn::module::ModuleDisplayDefault
                 }
             );
 


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.

### Related Issues/PRs

Fixes #2124

### Changes

Previously, we added an erroneous bound on an autodiff module's generics
```rust
module_autodiff.add_predicate(
   parse_quote! {
       #ident: burn::module::Module<B::InnerBackend>
   }
);
```

Considering that the generic is a module with the autodiff backend of the parent module, this would lead to an invalid constraint such as `MyModule<Autodiff<B>>: Module<B>`, which could not be met.

I also removed some redundant `ModuleDisplayDefault` bounds (`ModuleDisplay` already requires it).

### Testing

Ran the checks and a training example for current usage.
