### PR TITLE
modified mnist image link in the Hugging face

### DIFF
--- a/examples/onnx-inference/README.md
+++ b/examples/onnx-inference/README.md
@@ -21,7 +21,7 @@ Success!
 Predicted: 5
 Actual: 5
 See the image online, click the link below:
-https://datasets-server.huggingface.co/assets/mnist/--/mnist/test/15/image/image.jpg
+https://huggingface.co/datasets/ylecun/mnist/viewer/mnist/test?row=15
 ```
 
 ## Feature Flags

--- a/examples/onnx-inference/src/bin/mnist_inference.rs
+++ b/examples/onnx-inference/src/bin/mnist_inference.rs
@@ -57,10 +57,6 @@ fn main() {
     println!("Success!");
     println!("Predicted: {}", arg_max);
     println!("Actual: {}", item.label);
-
-    // Print the image URL if the image index is less than 100 (the online dataset only has 100 images)
-    if image_index < 100 {
-        println!("See the image online, click the link below:");
-        println!("https://datasets-server.huggingface.co/assets/mnist/--/mnist/test/{image_index}/image/image.jpg");
-    }
+    println!("See the image online, click the link below:");
+    println!("https://huggingface.co/datasets/ylecun/mnist/viewer/mnist/test?row={image_index}");
 }

--- a/examples/pytorch-import/README.md
+++ b/examples/pytorch-import/README.md
@@ -25,5 +25,5 @@ Success!
 Predicted: 5
 Actual: 5
 See the image online, click the link below:
-https://datasets-server.huggingface.co/assets/mnist/--/mnist/test/15/image/image.jpg
+https://huggingface.co/datasets/ylecun/mnist/viewer/mnist/test?row=15
 ```

--- a/examples/pytorch-import/src/main.rs
+++ b/examples/pytorch-import/src/main.rs
@@ -66,10 +66,6 @@ fn main() {
     println!("Success!");
     println!("Predicted: {}", arg_max);
     println!("Actual: {}", item.label);
-
-    // Print the image URL if the image index is less than 100 (the online dataset only has 100 images)
-    if image_index < 100 {
-        println!("See the image online, click the link below:");
-        println!("https://datasets-server.huggingface.co/assets/mnist/--/mnist/test/{image_index}/image/image.jpg");
-    }
+    println!("See the image online, click the link below:");
+    println!("https://huggingface.co/datasets/ylecun/mnist/viewer/mnist/test?row={image_index}");
 }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

https://github.com/tracel-ai/burn/issues/2133

### Changes

- I made search for the similar link which shows the corresponding image.  Instead of `https://datasets-server.huggingface.co/assets/mnist`, `https://huggingface.co/datasets/ylecun/mnist/viewer/mnist/test` will be matched for the purpose to show the image.
- `https://huggingface.co/datasets/ylecun/mnist/viewer/mnist/test` can be used with `row` parameter so I replaced it with the old one.
- `https://huggingface.co/datasets/ylecun/mnist/viewer/mnist/test`  can show you 0-9999 indexed image, so I remove the limit of under-100 indexed image condition.
- The same bug are found in `pytorch-import/README.md`, so I did the same thing for them.

### Testing

I executed the codes and check out the link as screenshots.

## index 15
```
% cargo run -- 15  
    Finished `dev` profile [optimized] target(s) in 0.36s
     Running `/Users/toru/Desktop/oss-fork/burn/target/debug/mnist_inference 15`
Image index: 15
Success!
Predicted: 5
Actual: 5
See the image online, click the link below:
https://huggingface.co/datasets/ylecun/mnist/viewer/mnist/test?row=15
```
<img width="1230" alt="image" src="https://github.com/user-attachments/assets/8ebdace2-282b-44fa-a83b-4c268fb604a7">


## index 9999
(`assert!(image_index < 10000, "Image index must be less than 10000");`  condition is already included in the code, so 9999 is enough.)
```
% cargo run -- 9999                                   
   Compiling onnx-inference v0.14.0 (/Users/toru/Desktop/oss-fork/burn/examples/onnx-inference)
    Finished `dev` profile [optimized] target(s) in 2.36s
     Running `/Users/toru/Desktop/oss-fork/burn/target/debug/mnist_inference 9999`
Image index: 9999
Success!
Predicted: 6
Actual: 6
See the image online, click the link below:
https://huggingface.co/datasets/ylecun/mnist/viewer/mnist/test?row=9999
```
<img width="1420" alt="image" src="https://github.com/user-attachments/assets/5232cd5f-0b52-4b31-b01a-aa5a1d8c1899">


