### PR TITLE
Make image-classification-web work with the wgpu backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,8 +143,8 @@ sysinfo = "0.30.13"
 systemstat = "0.2.3"
 
 ### For the main burn branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "30d090c8b725e83a829a6459d9c09578d9a4ba68" }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "30d090c8b725e83a829a6459d9c09578d9a4ba68" }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "32feabc5140170d45d4365a56106db930ed79a33" }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "32feabc5140170d45d4365a56106db930ed79a33" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl" }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common" }

--- a/examples/image-classification-web/Cargo.toml
+++ b/examples/image-classification-web/Cargo.toml
@@ -18,9 +18,7 @@ burn = { path = "../../crates/burn", version = "0.14.0", default-features = fals
     "ndarray",
 ] }
 cubecl = { workspace = true, features = ["wgpu"] }
-burn-wgpu = { path = "../../crates/burn-wgpu", version = "0.14.0", default-features = false, features = [
-    "autotune",
-] }
+burn-wgpu = { path = "../../crates/burn-wgpu", version = "0.14.0", default-features = false }
 burn-candle = { path = "../../crates/burn-candle", version = "0.14.0", default-features = false }
 
 log = { workspace = true }


### PR DESCRIPTION
## Pull Request Template

### Related Issues/PRs

#2118 

### Changes

Update `cubecl` revision to include Rust precision fix.
Remove `autotune` feature for `burn-wgpu` from example's `Cargo.toml`.
