### PR TITLE
Modified unintentional default value in xtask command

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -25,6 +25,7 @@ enum Command {
     /// Run the specified dependencies check locally
     Dependencies {
         /// The dependency check to run
+        #[clap(value_enum, default_value_t = dependencies::DependencyCheck::default())]
         dependency_check: dependencies::DependencyCheck,
     },
     /// Publish a crate to crates.io
@@ -42,6 +43,7 @@ enum Command {
     Vulnerabilities {
         /// The vulnerability check to run.
         /// For the reference visit the page `<https://doc.rust-lang.org/beta/unstable-book/compiler-flags/sanitizer.html>`
+        #[clap(value_enum, default_value_t = vulnerabilities::VulnerabilityCheck::default())]
         vulnerability_check: vulnerabilities::VulnerabilityCheck,
     },
 }


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

https://github.com/tracel-ai/burn/issues/2162

Ref: The similar change is adopted here
- https://github.com/tracel-ai/burn/pull/2107
- https://github.com/tracel-ai/burn/blob/ff8d0308fbfb213c356b7ff94e1fcfa1ec892646/xtask/src/main.rs#L38

### Changes

Added some clap modifications to use default enum value. 

### Testing

`cargo xtask dependencies` executes all.

`cargo xtask vulnerabilities` executes all.
