### PR TITLE
Fix equal/not-equal infinity numbers for burn-ndarray

### DIFF
--- a/crates/burn-ndarray/src/ops/int_tensor.rs
+++ b/crates/burn-ndarray/src/ops/int_tensor.rs
@@ -8,6 +8,7 @@ use burn_tensor::Distribution;
 use burn_tensor::ElementConversion;
 use core::ops::Range;
 use ndarray::IntoDimension;
+use ndarray::Zip;
 
 // Current crate
 use crate::element::ExpElement;
@@ -109,9 +110,11 @@ impl<E: FloatNdArrayElement, Q: QuantElement> IntTensorOps<Self> for NdArray<E, 
         lhs: NdArrayTensor<i64, D>,
         rhs: NdArrayTensor<i64, D>,
     ) -> NdArrayTensor<bool, D> {
-        let tensor = Self::int_sub(lhs, rhs);
-
-        Self::int_equal_elem(tensor, 0)
+        let output = Zip::from(&lhs.array)
+            .and(&rhs.array)
+            .map_collect(|&lhs_val, &rhs_val| (lhs_val == rhs_val))
+            .into_shared();
+        NdArrayTensor::new(output)
     }
 
     fn int_equal_elem<const D: usize>(

--- a/crates/burn-ndarray/src/ops/tensor.rs
+++ b/crates/burn-ndarray/src/ops/tensor.rs
@@ -1,7 +1,7 @@
 // Language
 use alloc::vec::Vec;
 use core::ops::Range;
-use ndarray::IntoDimension;
+use ndarray::{IntoDimension, Zip};
 
 // Current crate
 use super::{matmul::matmul, NdArrayMathOps, NdArrayOps};
@@ -225,10 +225,11 @@ impl<E: FloatNdArrayElement, Q: QuantElement> FloatTensorOps<Self> for NdArray<E
         lhs: NdArrayTensor<E, D>,
         rhs: NdArrayTensor<E, D>,
     ) -> NdArrayTensor<bool, D> {
-        let tensor = NdArray::<E>::float_sub(lhs, rhs);
-        let zero = 0.elem();
-
-        Self::float_equal_elem(tensor, zero)
+        let output = Zip::from(&lhs.array)
+            .and(&rhs.array)
+            .map_collect(|&lhs_val, &rhs_val| (lhs_val == rhs_val))
+            .into_shared();
+        NdArrayTensor::new(output)
     }
 
     fn float_equal_elem<const D: usize>(

--- a/crates/burn-tensor/src/tests/ops/map_comparison.rs
+++ b/crates/burn-tensor/src/tests/ops/map_comparison.rs
@@ -128,6 +128,38 @@ mod tests {
         lower_equal::<Int, IntElem>()
     }
 
+    #[test]
+    fn test_equal_inf() {
+        let data_1 = TensorData::from([[0.0, 1.0, 2.0], [f32::INFINITY, 4.0, f32::NEG_INFINITY]]);
+        let data_2 = TensorData::from([[1.0, 1.0, 1.0], [f32::INFINITY, 3.0, f32::NEG_INFINITY]]);
+        let device = Default::default();
+        let tensor_1 = Tensor::<TestBackend, 2>::from_data(data_1, &device);
+        let tensor_2 = Tensor::<TestBackend, 2>::from_data(data_2, &device);
+
+        let data_actual_cloned = tensor_1.clone().equal(tensor_2.clone());
+        let data_actual_inplace = tensor_1.equal(tensor_2);
+
+        let data_expected = TensorData::from([[false, true, false], [true, false, true]]);
+        assert_eq!(data_expected, data_actual_cloned.into_data());
+        assert_eq!(data_expected, data_actual_inplace.into_data());
+    }
+
+    #[test]
+    fn test_not_equal_inf() {
+        let data_1 = TensorData::from([[0.0, 1.0, 2.0], [3.0, f32::INFINITY, 5.0]]);
+        let data_2 = TensorData::from([[1.0, 1.0, 1.0], [f32::INFINITY, 3.0, f32::NEG_INFINITY]]);
+        let device = Default::default();
+        let tensor_1 = Tensor::<TestBackend, 2>::from_data(data_1, &device);
+        let tensor_2 = Tensor::<TestBackend, 2>::from_data(data_2, &device);
+
+        let data_actual_cloned = tensor_1.clone().not_equal(tensor_2.clone());
+        let data_actual_inplace = tensor_1.not_equal(tensor_2);
+
+        let data_expected = TensorData::from([[true, false, true], [true, true, true]]);
+        assert_eq!(data_expected, data_actual_cloned.into_data());
+        assert_eq!(data_expected, data_actual_inplace.into_data());
+    }
+
     fn equal<K, E>()
     where
         K: Numeric<TestBackend, Elem = E> + BasicOps<TestBackend, Elem = E>,


### PR DESCRIPTION
This PR fixes a bug in burn-ndarray where tensor equal and not equal ops do not operate correctly for negative/positive infinities correctly. This was discovered when using contains_nan operator for a tensor that contained -inf numbers with burn-ndarray backend.

## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

1. Fixed the bug in float_equal
2. Updated logic int_equal to match float_equal
3. Fixed potential tensor mutation bug in bool_equal by making it consistent with float_equal
4. Added regression tests

### Testing

Added regression tests. 