### PR TITLE
Fix class_index

### DIFF
--- a/examples/text-classification/src/inference.rs
+++ b/examples/text-classification/src/inference.rs
@@ -66,8 +66,8 @@ pub fn infer<B: Backend, D: TextClassificationDataset + 'static>(
         #[allow(clippy::single_range_in_vec_init)]
         let prediction = predictions.clone().slice([i..i + 1]); // Get prediction for current sample
         let logits = prediction.to_data(); // Convert prediction tensor to data
-        let class_index = prediction.argmax(1).into_data().as_slice::<i32>().unwrap()[0]; // Get class index with the highest value
-        let class = D::class_name(class_index as usize); // Get class name
+        let class_index = prediction.argmax(1).squeeze::<1>(1).into_scalar(); // Get class index with the highest value
+        let class = D::class_name(class_index.elem::<i32>() as usize); // Get class name
 
         // Print sample text, predicted logits and predicted class
         println!(


### PR DESCRIPTION
While going through the examples tests I found this issue with the text classification inference.

The code would panic with tch-gpu because the type is i64 but we try to cast directly to i32 with `as_slice()`. Instead, we can use `into_scalar()` and `.elem()`.