### PR TITLE
Switches epoch and iteration to be in the proper order for the custom training loop section of the book

### DIFF
--- a/burn-book/src/custom-training-loop.md
+++ b/burn-book/src/custom-training-loop.md
@@ -78,8 +78,8 @@ pub fn run<B: AutodiffBackend>(device: B::Device) {
 
             println!(
                 "[Train - Epoch {} - Iteration {}] Loss {:.3} | Accuracy {:.3} %",
-                iteration,
                 epoch,
+                iteration,
                 loss.clone().into_scalar(),
                 accuracy,
             );
@@ -104,8 +104,8 @@ pub fn run<B: AutodiffBackend>(device: B::Device) {
 
             println!(
                 "[Valid - Epoch {} - Iteration {}] Loss {} | Accuracy {}",
-                iteration,
                 epoch,
+                iteration,
                 loss.clone().into_scalar(),
                 accuracy,
             );


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

In the custom training loop section of the burn book, iteration and epoch are in the wrong order. This just switches it around.