### PR TITLE
Fix/wgpu/matmul web

### DIFF
--- a/crates/burn-jit/src/kernel/matmul/base.rs
+++ b/crates/burn-jit/src/kernel/matmul/base.rs
@@ -23,6 +23,7 @@ pub enum MatmulStrategy {
 }
 
 impl Default for MatmulStrategy {
+    #[allow(unreachable_code)]
     fn default() -> Self {
         // if wasm, force simple kernel for now (regardless of autotune)
         // issue: https://github.com/tracel-ai/burn/issues/2178

--- a/crates/burn-jit/src/kernel/matmul/base.rs
+++ b/crates/burn-jit/src/kernel/matmul/base.rs
@@ -24,6 +24,14 @@ pub enum MatmulStrategy {
 
 impl Default for MatmulStrategy {
     fn default() -> Self {
+        // if wasm, force simple kernel for now (regardless of autotune)
+        // issue: https://github.com/tracel-ai/burn/issues/2178
+        #[cfg(target_arch = "wasm32")]
+        return MatmulStrategy::Simple {
+            grid_x: 16,
+            grid_y: 16,
+        };
+
         // if autotune is enabled, default to autotune
         #[cfg(feature = "autotune")]
         return MatmulStrategy::Autotune;


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `run-checks all` script has been executed.

### Related Issues/PRs

Fixes #2178

### Changes

Work around the cubecl/wgpu issue by forcing the simple matmul strategy until read write strategy is fixed.

### Testing

The [MWE](https://github.com/laggui/burn-2178-mwe) works and the mnist-inference-web results are coherent.
