### PR TITLE
Add closeness tensor report

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,6 +706,7 @@ dependencies = [
  "burn-common",
  "burn-tensor-testgen",
  "bytemuck",
+ "colored",
  "cubecl",
  "derive-new",
  "half",

--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -407,3 +407,50 @@ Options:
 - `threshold`: Maximum number of elements to display before summarizing (default: 1000)
 - `edge_items`: Number of items to show at the beginning and end of each dimension when summarizing
   (default: 3)
+
+  ### Checking Tensor Closeness
+
+  Burn provides a utility function `check_closeness` to compare two tensors and assess their
+  similarity. This function is particularly useful for debugging and validating tensor operations,
+  especially when working with floating-point arithmetic where small numerical differences can
+  accumulate. It's also valuable when comparing model outputs during the process of importing models
+  from other frameworks, helping to ensure that the imported model produces results consistent with
+  the original.
+
+  Here's an example of how to use `check_closeness`:
+
+  ```rust
+  use burn::tensor::{check_closeness, Tensor};
+  type B = burn::backend::NdArray;
+
+  let device = Default::default();
+  let tensor1 = Tensor::<B, 1>::from_floats(
+      [1.0, 2.0, 3.0, 4.0, 5.0, 6.001, 7.002, 8.003, 9.004, 10.1],
+      &device,
+  );
+  let tensor2 = Tensor::<B, 1>::from_floats(
+      [1.0, 2.0, 3.0, 4.000, 5.0, 6.0, 7.001, 8.002, 9.003, 10.004],
+      &device,
+  );
+
+  check_closeness(&tensor1, &tensor2);
+  ```
+
+  The `check_closeness` function compares the two input tensors element-wise, checking their
+  absolute differences against a range of epsilon values. It then prints a detailed report showing
+  the percentage of elements that are within each tolerance level.
+
+  The output provides a breakdown for different epsilon values, allowing you to assess the closeness
+  of the tensors at various precision levels. This is particularly helpful when dealing with
+  operations that may introduce small numerical discrepancies.
+
+  The function uses color-coded output to highlight the results:
+
+  - Green [PASS]: All elements are within the specified tolerance.
+  - Yellow [WARN]: Most elements (90% or more) are within tolerance.
+  - Red [FAIL]: Significant differences are detected.
+
+  This utility can be invaluable when implementing or debugging tensor operations, especially those
+  involving complex mathematical computations or when porting algorithms from other frameworks. It's
+  also an essential tool when verifying the accuracy of imported models, ensuring that the Burn
+  implementation produces results that closely match those of the original model.

--- a/crates/burn-tensor/Cargo.toml
+++ b/crates/burn-tensor/Cargo.toml
@@ -21,6 +21,7 @@ std = [
     "num-traits/std",
     "burn-common/std",
     "burn-common/rayon",
+    "colored",
 ]
 repr = []
 cubecl = ["dep:cubecl"]
@@ -38,7 +39,7 @@ num-traits = { workspace = true }
 rand = { workspace = true }
 rand_distr = { workspace = true }                    # use instead of statrs because it supports no_std
 bytemuck = { workspace = true }
-colored = { workspace = true }
+colored = { workspace = true, optional = true }
 
 # The same implementation of HashMap in std but with no_std support (only needs alloc crate)
 hashbrown = { workspace = true } # no_std compatible

--- a/crates/burn-tensor/Cargo.toml
+++ b/crates/burn-tensor/Cargo.toml
@@ -15,14 +15,20 @@ default = ["std", "repr"]
 doc = ["default"]
 experimental-named-tensor = []
 export_tests = ["burn-tensor-testgen"]
-std = ["rand/std", "half/std", "num-traits/std", "burn-common/std", "burn-common/rayon"]
+std = [
+    "rand/std",
+    "half/std",
+    "num-traits/std",
+    "burn-common/std",
+    "burn-common/rayon",
+]
 repr = []
 cubecl = ["dep:cubecl"]
 cubecl-wgpu = ["cubecl", "cubecl/wgpu"]
 cubecl-cuda = ["cubecl", "cubecl/cuda"]
 
 [dependencies]
-burn-common = { path = "../burn-common", version = "0.14.0", default-features = false}
+burn-common = { path = "../burn-common", version = "0.14.0", default-features = false }
 burn-tensor-testgen = { path = "../burn-tensor-testgen", version = "0.14.0", optional = true }
 cubecl = { workspace = true, optional = true }
 
@@ -32,6 +38,7 @@ num-traits = { workspace = true }
 rand = { workspace = true }
 rand_distr = { workspace = true }                    # use instead of statrs because it supports no_std
 bytemuck = { workspace = true }
+colored = { workspace = true }
 
 # The same implementation of HashMap in std but with no_std support (only needs alloc crate)
 hashbrown = { workspace = true } # no_std compatible

--- a/crates/burn-tensor/src/tensor/mod.rs
+++ b/crates/burn-tensor/src/tensor/mod.rs
@@ -4,14 +4,12 @@ mod api;
 mod data;
 mod distribution;
 mod element;
-mod report;
 mod shape;
 
 pub use api::*;
 pub use data::*;
 pub use distribution::*;
 pub use element::*;
-pub use report::*;
 pub use shape::*;
 
 /// The activation module.
@@ -34,6 +32,12 @@ pub mod ops;
 
 /// Tensor quantization module.
 pub mod quantization;
+
+#[cfg(feature = "std")]
+pub use report::*;
+
+#[cfg(feature = "std")]
+mod report;
 
 #[cfg(feature = "experimental-named-tensor")]
 mod named;

--- a/crates/burn-tensor/src/tensor/mod.rs
+++ b/crates/burn-tensor/src/tensor/mod.rs
@@ -4,12 +4,14 @@ mod api;
 mod data;
 mod distribution;
 mod element;
+mod report;
 mod shape;
 
 pub use api::*;
 pub use data::*;
 pub use distribution::*;
 pub use element::*;
+pub use report::*;
 pub use shape::*;
 
 /// The activation module.

--- a/crates/burn-tensor/src/tensor/report.rs
+++ b/crates/burn-tensor/src/tensor/report.rs
@@ -34,35 +34,35 @@ use super::{backend::Backend, Tensor};
 /// ```text
 /// Tensor Closeness Check Results:
 /// ===============================
-/// Epsilon: 1.00e-1
+/// Epsilon: 1e-1
 ///   Close elements: 10/10 (100.00%)
 ///   [PASS] All elements are within tolerance
 ///
-/// Epsilon: 1.00e-2
+/// Epsilon: 1e-2
 ///   Close elements: 10/10 (100.00%)
 ///   [PASS] All elements are within tolerance
 ///
-/// Epsilon: 1.00e-3
+/// Epsilon: 1e-3
 ///   Close elements: 9/10 (90.00%)
 ///   [WARN] Most elements are within tolerance
 ///
-/// Epsilon: 1.00e-4
+/// Epsilon: 1e-4
 ///   Close elements: 6/10 (60.00%)
 ///   [FAIL] Significant differences detected
 ///
-/// Epsilon: 1.00e-5
+/// Epsilon: 1e-5
 ///   Close elements: 5/10 (50.00%)
 ///   [FAIL] Significant differences detected
 ///
-/// Epsilon: 1.00e-6
+/// Epsilon: 1e-6
 ///   Close elements: 5/10 (50.00%)
 ///   [FAIL] Significant differences detected
 ///
-/// Epsilon: 1.00e-7
+/// Epsilon: 1e-7
 ///   Close elements: 5/10 (50.00%)
 ///   [FAIL] Significant differences detected
 ///
-/// Epsilon: 1.00e-8
+/// Epsilon: 1e-8
 ///   Close elements: 5/10 (50.00%)
 ///   [FAIL] Significant differences detected
 ///
@@ -74,7 +74,7 @@ pub fn check_closeness<B: Backend, const D: usize>(output: &Tensor<B, D>, expect
     println!("===============================");
 
     for epsilon in [1e-1, 1e-2, 1e-3, 1e-4, 1e-5, 1e-6, 1e-7, 1e-8].iter() {
-        println!("\x1b[1mEpsilon: \x1b[36m{:.2e}\x1b[0m", epsilon);
+        println!("\x1b[1mEpsilon: \x1b[36m{:.e}\x1b[0m", epsilon);
 
         let close = output
             .clone()

--- a/crates/burn-tensor/src/tensor/report.rs
+++ b/crates/burn-tensor/src/tensor/report.rs
@@ -84,12 +84,9 @@ pub fn check_closeness<B: Backend, const D: usize>(output: &Tensor<B, D>, expect
             .is_close(expected.clone(), Some(*epsilon), Some(*epsilon));
         let data = close.clone().into_data();
         let num_elements = data.num_elements();
-        let count = data
-            .to_vec::<bool>()
-            .unwrap()
-            .iter()
-            .filter(|&&x| x)
-            .count();
+
+        // Count the number of elements that are close (true)
+        let count = data.iter::<bool>().filter(|x| *x).count();
 
         let percentage = (count as f64 / num_elements as f64) * 100.0;
 

--- a/crates/burn-tensor/src/tensor/report.rs
+++ b/crates/burn-tensor/src/tensor/report.rs
@@ -13,20 +13,21 @@ use super::{backend::Backend, Tensor};
 /// # Example
 ///
 /// ```no_run
+/// use burn_tensor::backend::Backend;
 /// use burn_tensor::{check_closeness, Tensor};
-/// type B = burn_tensor::backend::NdArray;
 ///
-/// let device = Default::default();
-/// let tensor1 = Tensor::<B, 1>::from_floats(
-///     [1.0, 2.0, 3.0, 4.0, 5.0, 6.001, 7.002, 8.003, 9.004, 10.1],
-///     &device,
-/// );
-/// let tensor2 = Tensor::<B, 1>::from_floats(
-///     [1.0, 2.0, 3.0, 4.000, 5.0, 6.0, 7.001, 8.002, 9.003, 10.004],
-///     &device,
-/// );
-///
-/// check_closeness(&tensor1, &tensor2);
+/// fn example<B: Backend>() {
+///     let device = Default::default();
+///     let tensor1 = Tensor::<B, 1>::from_floats(
+///         [1.0, 2.0, 3.0, 4.0, 5.0, 6.001, 7.002, 8.003, 9.004, 10.1],
+///         &device,
+///     );
+///     let tensor2 = Tensor::<B, 1>::from_floats(
+///         [1.0, 2.0, 3.0, 4.000, 5.0, 6.0, 7.001, 8.002, 9.003, 10.004],
+///         &device,
+///     );
+///    check_closeness(&tensor1, &tensor2);
+///}
 /// ```
 ///
 /// # Output

--- a/crates/burn-tensor/src/tensor/report.rs
+++ b/crates/burn-tensor/src/tensor/report.rs
@@ -13,8 +13,8 @@ use super::{backend::Backend, Tensor};
 /// # Example
 ///
 /// ```no_run
-/// use burn::tensor::{check_closeness, Tensor};
-/// type B = burn::backend::NdArray;
+/// use burn_tensor::{check_closeness, Tensor};
+/// type B = burn_tensor::backend::NdArray;
 ///
 /// let device = Default::default();
 /// let tensor1 = Tensor::<B, 1>::from_floats(

--- a/crates/burn-tensor/src/tensor/report.rs
+++ b/crates/burn-tensor/src/tensor/report.rs
@@ -12,7 +12,7 @@ use super::{backend::Backend, Tensor};
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// use burn::tensor::{check_closeness, Tensor};
 /// type B = burn::backend::NdArray;
 ///

--- a/crates/burn-tensor/src/tensor/report.rs
+++ b/crates/burn-tensor/src/tensor/report.rs
@@ -1,0 +1,110 @@
+use super::{backend::Backend, Tensor};
+
+/// Checks the closeness of two tensors and prints the results.
+///
+/// Compares tensors by checking the absolute difference between each element.
+/// Prints the percentage of elements within specified tolerances.
+///
+/// # Arguments
+///
+/// * `output` - The output tensor.
+/// * `expected` - The expected tensor.
+///
+/// # Example
+///
+/// ```
+/// use burn::tensor::{check_closeness, Tensor};
+/// type B = burn::backend::NdArray;
+///
+/// let device = Default::default();
+/// let tensor1 = Tensor::<B, 1>::from_floats(
+///     [1.0, 2.0, 3.0, 4.0, 5.0, 6.001, 7.002, 8.003, 9.004, 10.1],
+///     &device,
+/// );
+/// let tensor2 = Tensor::<B, 1>::from_floats(
+///     [1.0, 2.0, 3.0, 4.000, 5.0, 6.0, 7.001, 8.002, 9.003, 10.004],
+///     &device,
+/// );
+///
+/// check_closeness(&tensor1, &tensor2);
+/// ```
+///
+/// # Output
+///
+/// ```text
+/// Tensor Closeness Check Results:
+/// ===============================
+/// Epsilon: 1.00e-1
+///   Close elements: 10/10 (100.00%)
+///   [PASS] All elements are within tolerance
+///
+/// Epsilon: 1.00e-2
+///   Close elements: 10/10 (100.00%)
+///   [PASS] All elements are within tolerance
+///
+/// Epsilon: 1.00e-3
+///   Close elements: 9/10 (90.00%)
+///   [WARN] Most elements are within tolerance
+///
+/// Epsilon: 1.00e-4
+///   Close elements: 6/10 (60.00%)
+///   [FAIL] Significant differences detected
+///
+/// Epsilon: 1.00e-5
+///   Close elements: 5/10 (50.00%)
+///   [FAIL] Significant differences detected
+///
+/// Epsilon: 1.00e-6
+///   Close elements: 5/10 (50.00%)
+///   [FAIL] Significant differences detected
+///
+/// Epsilon: 1.00e-7
+///   Close elements: 5/10 (50.00%)
+///   [FAIL] Significant differences detected
+///
+/// Epsilon: 1.00e-8
+///   Close elements: 5/10 (50.00%)
+///   [FAIL] Significant differences detected
+///
+/// Closeness check complete.
+/// ```
+
+pub fn check_closeness<B: Backend, const D: usize>(output: &Tensor<B, D>, expected: &Tensor<B, D>) {
+    println!("\x1b[1mTensor Closeness Check Results:\x1b[0m");
+    println!("===============================");
+
+    for epsilon in [1e-1, 1e-2, 1e-3, 1e-4, 1e-5, 1e-6, 1e-7, 1e-8].iter() {
+        println!("\x1b[1mEpsilon: \x1b[36m{:.2e}\x1b[0m", epsilon);
+
+        let close = output
+            .clone()
+            .is_close(expected.clone(), Some(*epsilon), Some(*epsilon));
+        let data = close.clone().into_data();
+        let num_elements = data.num_elements();
+        let count = data
+            .to_vec::<bool>()
+            .unwrap()
+            .iter()
+            .filter(|&&x| x)
+            .count();
+
+        let percentage = (count as f64 / num_elements as f64) * 100.0;
+
+        println!(
+            "  Close elements: {}/{} ({:.2}%)",
+            count, num_elements, percentage
+        );
+
+        if percentage == 100.0 {
+            println!("  \x1b[32m[PASS]\x1b[0m All elements are within tolerance");
+        } else if percentage >= 90.0 {
+            println!("  \x1b[33m[WARN]\x1b[0m Most elements are within tolerance");
+        } else {
+            println!("  \x1b[31m[FAIL]\x1b[0m Significant differences detected");
+        }
+
+        println!();
+    }
+
+    println!("\x1b[1mCloseness check complete.\x1b[0m");
+}

--- a/crates/burn-tensor/src/tensor/report.rs
+++ b/crates/burn-tensor/src/tensor/report.rs
@@ -77,7 +77,7 @@ pub fn check_closeness<B: Backend, const D: usize>(output: &Tensor<B, D>, expect
     println!("===============================");
 
     for epsilon in [1e-1, 1e-2, 1e-3, 1e-4, 1e-5, 1e-6, 1e-7, 1e-8].iter() {
-        println!("{}", "Tensor Closeness Check Results:".bold());
+        println!("{} {:.e}", "Epsilon:".bold(), epsilon);
 
         let close = output
             .clone()

--- a/crates/burn-tensor/src/tensor/report.rs
+++ b/crates/burn-tensor/src/tensor/report.rs
@@ -1,5 +1,7 @@
 use super::{backend::Backend, Tensor};
 
+use colored::*;
+
 /// Checks the closeness of two tensors and prints the results.
 ///
 /// Compares tensors by checking the absolute difference between each element.
@@ -75,7 +77,7 @@ pub fn check_closeness<B: Backend, const D: usize>(output: &Tensor<B, D>, expect
     println!("===============================");
 
     for epsilon in [1e-1, 1e-2, 1e-3, 1e-4, 1e-5, 1e-6, 1e-7, 1e-8].iter() {
-        println!("\x1b[1mEpsilon: \x1b[36m{:.e}\x1b[0m", epsilon);
+        println!("{}", "Tensor Closeness Check Results:".bold());
 
         let close = output
             .clone()
@@ -97,15 +99,15 @@ pub fn check_closeness<B: Backend, const D: usize>(output: &Tensor<B, D>, expect
         );
 
         if percentage == 100.0 {
-            println!("  \x1b[32m[PASS]\x1b[0m All elements are within tolerance");
+            println!("  {} All elements are within tolerance", "[PASS]".green());
         } else if percentage >= 90.0 {
-            println!("  \x1b[33m[WARN]\x1b[0m Most elements are within tolerance");
+            println!("  {} Most elements are within tolerance", "[WARN]".yellow());
         } else {
-            println!("  \x1b[31m[FAIL]\x1b[0m Significant differences detected");
+            println!("  {} Significant differences detected", "[FAIL]".red());
         }
 
         println!();
     }
 
-    println!("\x1b[1mCloseness check complete.\x1b[0m");
+    println!("{}", "Closeness check complete.".bold());
 }

--- a/crates/burn-tensor/src/tensor/report.rs
+++ b/crates/burn-tensor/src/tensor/report.rs
@@ -73,7 +73,7 @@ use colored::*;
 /// ```
 
 pub fn check_closeness<B: Backend, const D: usize>(output: &Tensor<B, D>, expected: &Tensor<B, D>) {
-    println!("\x1b[1mTensor Closeness Check Results:\x1b[0m");
+    println!("{}", "Tensor Closeness Check Results:".bold());
     println!("===============================");
 
     for epsilon in [1e-1, 1e-2, 1e-3, 1e-4, 1e-5, 1e-6, 1e-7, 1e-8].iter() {


### PR DESCRIPTION
This is a tensor utility to check closeness of two float tensors quick for various tolerance levels. This helps figure at what level two tensors are the same or similar.

## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

1. New function
2. New book section

### Testing

Ran an example in the document and verified visually.

Here is its output:

<img width="424" alt="image" src="https://github.com/user-attachments/assets/ae2dba98-52e7-4b89-bc85-ee0b335da035">

