### PR TITLE
Fix root-mean-square precision issue

### DIFF
--- a/crates/burn-core/src/nn/norm/rms.rs
+++ b/crates/burn-core/src/nn/norm/rms.rs
@@ -68,8 +68,14 @@ impl<B: Backend> RmsNorm<B> {
     /// - output: `[..., any, d_model]`
     pub fn forward<const D: usize>(&self, x: Tensor<B, D>) -> Tensor<B, D> {
         // Calculate the root-mean-square norm of the input tensor along the last dimension
-        let rms = (x.clone().powf_scalar(2.0).mean_dim(D - 1) + self.epsilon).sqrt();
-        (x / rms) * self.gamma.val().unsqueeze()
+        let rms = (x
+            .clone()
+            .into_full_precision()
+            .powf_scalar(2.0)
+            .mean_dim(D - 1)
+            + self.epsilon)
+            .sqrt();
+        (x / Tensor::from_full_precision(rms)) * self.gamma.val().unsqueeze()
     }
 }
 


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.

### Changes

Changed `RmsNorm` forward to perform the root-mean-square in full precision, which would otherwise lead to precision issues (inf) in lower precision (f16).

### Testing

Tested with [Llama 3.1](https://github.com/tracel-ai/models/pull/38)