### PR TITLE
Add RoPE `init_with_frequency_scaling`

### DIFF
--- a/crates/burn-core/src/nn/rope_encoding.rs
+++ b/crates/burn-core/src/nn/rope_encoding.rs
@@ -365,9 +365,7 @@ mod tests {
 
         // if wavelen < high_freq_wavelen
         let cond = wavelen.lower_elem(high_freq_wavelen);
-        let new_freqs = new_freqs.mask_where(cond, freqs);
-
-        new_freqs
+        new_freqs.mask_where(cond, freqs)
     }
 
     #[test]


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.

### Related Issues/PRs

Required for [Llama 3.1](https://github.com/tracel-ai/models/pull/38)

### Changes

There exists many extensions to the basic rotary position embedding (RoPE). By adding a new initialization method which accepts a custom function to transform the frequencies, we can apply custom frequency scaling as done in [Llama 3.1 implementation](https://github.com/meta-llama/llama-models/blob/main/models/llama3/reference_impl/model.py#L45).

### Testing

Added unit test.
