### PR TITLE
Fix gather unchecked kernel

### DIFF
--- a/crates/burn-jit/src/kernel/index/gather.rs
+++ b/crates/burn-jit/src/kernel/index/gather.rs
@@ -13,6 +13,10 @@ fn gather_kernel<T: Numeric, I: Numeric>(
     output: &mut Tensor<T>,
     dim: &UInt,
 ) {
+    if ABSOLUTE_POS >= indices.len() {
+        return;
+    }
+
     let index = indices[ABSOLUTE_POS];
 
     let stride = input.stride(*dim);

--- a/crates/burn-jit/src/kernel/index/scatter.rs
+++ b/crates/burn-jit/src/kernel/index/scatter.rs
@@ -16,7 +16,6 @@ fn scatter_kernel<T: Numeric>(
 ) {
     let stride_input = input.stride(*dim);
     let shape_value = value.shape(*dim);
-    let id = ABSOLUTE_POS;
 
     let mut offset_input = UInt::new(0);
     let mut offset_value = UInt::new(0);
@@ -32,7 +31,7 @@ fn scatter_kernel<T: Numeric>(
             let stride_input_loop = input.stride(i);
             let stride_tmp = indices.stride(i);
 
-            let mut num_blocks = id / stride_tmp;
+            let mut num_blocks = ABSOLUTE_POS / stride_tmp;
             num_blocks = num_blocks % shape_input_loop;
 
             let mut offset_tmp = num_blocks * stride_input_loop;
@@ -45,7 +44,7 @@ fn scatter_kernel<T: Numeric>(
         }
     }
 
-    let should_stop = id >= num_elems;
+    let should_stop = ABSOLUTE_POS >= num_elems;
     if should_stop {
         return;
     }


### PR DESCRIPTION
Fix 

```
called `Result::unwrap()` on an `Err` value: DriverError(CUDA_ERROR_ILLEGAL_ADDRESS, "an illegal memory access was encountered") 
```