### PR TITLE
Improve ONNX Tensor-shape tracking

### DIFF
--- a/crates/burn-import/src/burn/ty.rs
+++ b/crates/burn-import/src/burn/ty.rs
@@ -143,6 +143,10 @@ impl TensorType {
             );
         }
         let formatted_name = Self::format_name(name.as_ref());
+        assert_ne!(
+            dim, 0,
+            "Trying to create TensorType with dim = 0 - should be a Scalar instead!"
+        );
         Self {
             name: Ident::new(&formatted_name, Span::call_site()),
             dim,
@@ -151,15 +155,39 @@ impl TensorType {
         }
     }
     pub fn new_float<S: AsRef<str>>(name: S, dim: usize) -> Self {
-        Self::new(name, dim, TensorKind::Float, None)
+        Self::new_float_with_shape(name, dim, None)
+    }
+
+    pub fn new_float_with_shape<S: AsRef<str>>(
+        name: S,
+        dim: usize,
+        shape: Option<Vec<usize>>,
+    ) -> Self {
+        Self::new(name, dim, TensorKind::Float, shape)
     }
 
     pub fn new_int<S: AsRef<str>>(name: S, dim: usize) -> Self {
-        Self::new(name, dim, TensorKind::Int, None)
+        Self::new_int_with_shape(name, dim, None)
+    }
+
+    pub fn new_int_with_shape<S: AsRef<str>>(
+        name: S,
+        dim: usize,
+        shape: Option<Vec<usize>>,
+    ) -> Self {
+        Self::new(name, dim, TensorKind::Int, shape)
     }
 
     pub fn new_bool<S: AsRef<str>>(name: S, dim: usize) -> Self {
-        Self::new(name, dim, TensorKind::Bool, None)
+        Self::new_bool_with_shape(name, dim, None)
+    }
+
+    pub fn new_bool_with_shape<S: AsRef<str>>(
+        name: S,
+        dim: usize,
+        shape: Option<Vec<usize>>,
+    ) -> Self {
+        Self::new(name, dim, TensorKind::Bool, shape)
     }
 
     pub fn ty(&self) -> TokenStream {

--- a/crates/burn-import/src/onnx/to_burn.rs
+++ b/crates/burn-import/src/onnx/to_burn.rs
@@ -424,12 +424,7 @@ impl ParsedOnnxGraph {
 
     fn random_uniform_conversion(node: Node) -> RandomUniformNode {
         let output = node.outputs.first().unwrap();
-        // cannot use output.to_tensor_type() here, since it drops the shape info...
-        let output_type = if let Type::Tensor(t) = Type::from(output) {
-            t
-        } else {
-            panic!("RandomUniform output type is no Tensor.");
-        };
+        let output_type = TensorType::from(output);
 
         let high = node
             .attrs
@@ -451,12 +446,7 @@ impl ParsedOnnxGraph {
 
     fn random_normal_conversion(node: Node) -> RandomNormalNode {
         let output = node.outputs.first().unwrap();
-        // cannot use output.to_tensor_type() here, since it drops the shape info...
-        let output_type = if let Type::Tensor(t) = Type::from(output) {
-            t
-        } else {
-            panic!("RandomNormal output type is no Tensor.");
-        };
+        let output_type = TensorType::from(output);
 
         let mean = node
             .attrs
@@ -480,11 +470,12 @@ impl ParsedOnnxGraph {
         // Additional types needed for ConstantOfShape:
         use crate::burn::node::constant_of_shape::ConstantValue;
 
-        let input = node
-            .inputs
-            .first()
-            .expect("ConstantOfShape requires an input tensor");
-        let output = node.outputs.first().unwrap();
+        let input = Type::from(
+            node.inputs
+                .first()
+                .expect("ConstantOfShape requires an input tensor"),
+        );
+        let output = Type::from(node.outputs.first().unwrap());
 
         // The value of the output elements.Should be a one-element tensor.
         // If not specified, it defaults to a tensor of value 0 and datatype float32
@@ -504,7 +495,7 @@ impl ParsedOnnxGraph {
             })
             .unwrap_or(ConstantValue::Float32(0.0f32));
 
-        ConstantOfShapeNode::new(Type::from(input), Type::from(output), value)
+        ConstantOfShapeNode::new(input, output, value)
     }
 
     fn add_conversion(node: Node) -> BinaryNode {
@@ -1082,18 +1073,27 @@ impl ParsedOnnxGraph {
         UnaryNode::exp(input, output)
     }
 
-    fn expand_conversion(node: Node) -> ExpandNode {
+    fn expand_conversion(mut node: Node) -> ExpandNode {
         let input = TensorType::from(node.inputs.first().unwrap());
-        let mut output = TensorType::from(node.outputs.first().unwrap());
         let shape = expand_config(&node);
-        output.dim = match &shape {
-            ExpandShape::Static(s) => s.len(),
-            ExpandShape::Runtime(Type::Shape(s)) => s.dim,
-            ExpandShape::Runtime(Type::Tensor(t)) => t.shape.as_ref().unwrap()[0],
-            _ => panic!("Invalid ExpandShape {shape:?}!"),
-        };
 
-        ExpandNode::new(input, output, shape)
+        // dim_inference left the dim at zero, so it needs to be filled before converting to TensorType:
+        assert_eq!(
+            node.outputs.len(),
+            1,
+            "ExpandNode must have exactly 1 output!"
+        );
+        let mut output_arg = node.outputs.pop().unwrap();
+        if let ArgType::Tensor(output_arg_tensor) = &mut output_arg.ty {
+            output_arg_tensor.dim = match &shape {
+                ExpandShape::Static(s) => s.len(),
+                ExpandShape::Runtime(Type::Shape(s)) => s.dim,
+                ExpandShape::Runtime(Type::Tensor(t)) => t.shape.as_ref().unwrap()[0],
+                _ => panic!("Invalid ExpandShape {shape:?}!"),
+            };
+        }
+
+        ExpandNode::new(input, TensorType::from(&output_arg), shape)
     }
 
     fn neg_conversion(node: Node) -> UnaryNode {
@@ -1236,18 +1236,21 @@ impl From<&OnnxArgument> for TensorType {
             ArgType::Tensor(OnnxTensorType {
                 elem_type: ElementType::Float16 | ElementType::Float32 | ElementType::Float64,
                 dim,
+                shape,
                 ..
-            }) => TensorType::new_float(arg.name.clone(), *dim),
+            }) => TensorType::new_float_with_shape(arg.name.clone(), *dim, shape.clone()),
             ArgType::Tensor(OnnxTensorType {
                 elem_type: ElementType::Int32 | ElementType::Int64,
                 dim,
+                shape,
                 ..
-            }) => TensorType::new_int(arg.name.clone(), *dim),
+            }) => TensorType::new_int_with_shape(arg.name.clone(), *dim, shape.clone()),
             ArgType::Tensor(OnnxTensorType {
                 elem_type: ElementType::Bool,
                 dim,
+                shape,
                 ..
-            }) => TensorType::new_bool(arg.name.clone(), *dim),
+            }) => TensorType::new_bool_with_shape(arg.name.clone(), *dim, shape.clone()),
             _ => panic!("Can't transform {:?} to tensor.", arg.ty),
         }
     }

--- a/crates/onnx-ir/src/ir.rs
+++ b/crates/onnx-ir/src/ir.rs
@@ -128,6 +128,15 @@ impl Default for ArgType {
     }
 }
 
+impl ArgType {
+    pub fn is_scalar(&self) -> bool {
+        matches!(self, Self::Scalar(_))
+    }
+    pub fn is_tensor(&self) -> bool {
+        matches!(self, Self::Tensor(_))
+    }
+}
+
 impl Argument {
     pub fn new(name: String) -> Self {
         Self {

--- a/crates/onnx-ir/src/proto_conversion.rs
+++ b/crates/onnx-ir/src/proto_conversion.rs
@@ -242,20 +242,26 @@ impl TryFrom<ValueInfoProto> for Argument {
             }
         };
 
-        let tensor_type = TensorType {
-            dim: tensor_proto.shape.dim.len(),
-            elem_type,
-            shape: Some(
-                tensor_proto
-                    .shape
-                    .dim
-                    .iter()
-                    .map(|x| x.dim_value() as Dim)
-                    .collect(),
-            ),
-        };
+        let ty = if tensor_proto.shape.dim.is_empty() {
+            // tensor_proto describes a scalar
+            ArgType::Scalar(elem_type)
+        } else {
+            // tensor_proto describes a tensor
+            let tensor_type = TensorType {
+                dim: tensor_proto.shape.dim.len(),
+                elem_type,
+                shape: Some(
+                    tensor_proto
+                        .shape
+                        .dim
+                        .iter()
+                        .map(|x| x.dim_value() as Dim)
+                        .collect(),
+                ),
+            };
 
-        let ty = ArgType::Tensor(tensor_type);
+            ArgType::Tensor(tensor_type)
+        };
 
         Ok(Argument {
             ty,


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

(Includes / based on #2189 - dividing them out just to rebase back onto it seems unnecessary busywork)

### Changes

- Calculate result of broadcasting in dim_inference
- keep Shape info when converting from Argument to TensorType
- Remove a few sources of Dim = 0 Tensors, create Scalars instead
- Clean up dim_inference a bit

### Testing

Added a few asserts that are checked by existing test cases.
