### PR TITLE
fixed the debugger settings doc

### DIFF
--- a/contributor-book/src/getting-started/configuring-your-editor.md
+++ b/contributor-book/src/getting-started/configuring-your-editor.md
@@ -23,17 +23,8 @@ To use the debugger, follow these steps:
 1. Open `Command Palette` with `Ctrl+Shift+P` or `F1` and type
    `LLDB: Generate Launch Configurations from Cargo.toml` then select it, this will generate a file
    that should be saved as `.vscode/launch.json`.
-2. Select the configuration from the "run and debug" side panel, then select the target from the
-   list.
-   You may also want to enable debugging by creating a `.vscode/settings.json` file:
-    ```
-    {
-      "rust-analyzer.runnables.extraEnv": {
-        "CARGO_PROFILE_DEV_DEBUG": true
-      }
-    }
-    ```
-    since this repo has `debug = 0` in the root `Cargo.toml` to speed up compilation.
+2. Select the configuration from the "run and debug" side panel, then select the target from the list.
+   Since this repo has `debug = 0` in the root `Cargo.toml` to speed up compilation, you need replace it with `debug = true` in the root `Cargo.toml` when using a debugger and breakpoints with `launch.json` settings.
 3. Now you can enable breakpoints on code through IDE then start debugging the library/binary you
    want, like in the following example:
 


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

Modified doc PR.

### Related Issues/PRs

https://github.com/tracel-ai/burn/pull/1719
https://github.com/tiruka/base_rust/tree/reproduction-vscode-debugger (reproduction purpose)

### Changes

Modified doc for debugger settings.
The below setting is not valid when using vscode debugger with launch.json. I modified the doc and make suggestions that developers should modify the Cargo.toml straight.
```
{
  "rust-analyzer.runnables.extraEnv": {
    "CARGO_PROFILE_DEV_DEBUG": true
  }
}
```

### Testing

I made repo for reproduction. If you need it, please see it.

https://github.com/tiruka/base_rust/tree/reproduction-vscode-debugger