### PR TITLE
Avoid 0 denominator in interpolate frac

### DIFF
--- a/crates/burn-import/onnx-tests/tests/test_onnx.rs
+++ b/crates/burn-import/onnx-tests/tests/test_onnx.rs
@@ -962,7 +962,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "https://github.com/tracel-ai/burn/issues/2080"]
     fn resize_with_scales_1d_linear() {
         // Initialize the model without weights (because the exported file does not contain them)
         let device = Default::default();

--- a/crates/burn-import/onnx-tests/tests/test_onnx.rs
+++ b/crates/burn-import/onnx-tests/tests/test_onnx.rs
@@ -977,10 +977,11 @@ mod tests {
         // The scales are 1.5
         let output = model.forward(input);
 
-        let output_sum = output.sum().into_scalar();
-        let expected_sum = -4.568_224; // from pytorch
-
-        assert!(expected_sum.approx_eq(output_sum, (1.0e-4, 2)));
+        Tensor::<Backend, 3>::from([[[
+            1.5410, 0.3945, -0.7648, -1.9431, -0.8052, 0.3618, -0.6713, -1.2023, -1.3986,
+        ]]])
+        .to_data()
+        .assert_approx_eq(&output.into_data(), 3);
     }
 
     #[test]

--- a/crates/burn-jit/src/kernel/interpolate/bicubic.rs
+++ b/crates/burn-jit/src/kernel/interpolate/bicubic.rs
@@ -100,6 +100,7 @@ impl<E: JitElement> InterpolateBicubicShader<E> {
 
         cpa!(scope, input_height = input_shape_2 - 1u32);
         cpa!(scope, output_height = output_shape_2 - 1u32);
+        cpa!(scope, output_height = max(output_height, 1u32));
         cpa!(scope, numerator = h * input_height);
         cpa!(scope, numerator_float = cast(numerator));
         cpa!(scope, output_height_float = cast(output_height));
@@ -129,6 +130,7 @@ impl<E: JitElement> InterpolateBicubicShader<E> {
 
         cpa!(scope, input_width = input_shape_3 - 1u32);
         cpa!(scope, output_width = output_shape_3 - 1u32);
+        cpa!(scope, output_width = max(output_width, 1u32));
         cpa!(scope, numerator = w * input_width);
         cpa!(scope, numerator_float = cast(numerator));
         cpa!(scope, output_width_float = cast(output_width));

--- a/crates/burn-jit/src/kernel/interpolate/bilinear.rs
+++ b/crates/burn-jit/src/kernel/interpolate/bilinear.rs
@@ -101,6 +101,7 @@ impl InterpolateBilinearShader {
 
         cpa!(scope, numerator_int = input_shape_2 - 1u32);
         cpa!(scope, denominator_int = output_shape_2 - 1u32);
+        cpa!(scope, denominator_int = max(denominator_int, 1u32));
         cpa!(scope, factor_float = cast(h));
         cpa!(scope, numerator_float = cast(numerator_int));
         cpa!(scope, denominator_float = cast(denominator_int));
@@ -115,6 +116,7 @@ impl InterpolateBilinearShader {
 
         cpa!(scope, numerator_int = input_shape_3 - 1u32);
         cpa!(scope, denominator_int = output_shape_3 - 1u32);
+        cpa!(scope, denominator_int = max(denominator_int, 1u32));
         cpa!(scope, factor_float = cast(w));
         cpa!(scope, numerator_float = cast(numerator_int));
         cpa!(scope, denominator_float = cast(denominator_int));

--- a/crates/burn-ndarray/src/ops/interpolate.rs
+++ b/crates/burn-ndarray/src/ops/interpolate.rs
@@ -96,8 +96,8 @@ pub(crate) fn bilinear_interpolate<E: FloatNdArrayElement>(
     let (batch_size, channels, in_height, in_width) = x.dim();
     let [out_height, out_width] = output_size;
 
-    let y_ratio = ((in_height - 1) as f64) / ((out_height - 1) as f64);
-    let x_ratio = ((in_width - 1) as f64) / ((out_width - 1) as f64);
+    let y_ratio = ((in_height - 1) as f64) / (core::cmp::max(out_height - 1, 1) as f64);
+    let x_ratio = ((in_width - 1) as f64) / (core::cmp::max(out_width - 1, 1) as f64);
 
     let out_element_num = batch_size * channels * out_height * out_width;
     let strides = (
@@ -174,8 +174,8 @@ pub(crate) fn bicubic_interpolate<E: FloatNdArrayElement>(
     let (batch_size, channels, in_height, in_width) = x.dim();
     let [out_height, out_width] = output_size;
 
-    let y_ratio = ((in_height - 1) as f64) / ((out_height - 1) as f64);
-    let x_ratio = ((in_width - 1) as f64) / ((out_width - 1) as f64);
+    let y_ratio = ((in_height - 1) as f64) / (core::cmp::max(out_height - 1, 1) as f64);
+    let x_ratio = ((in_width - 1) as f64) / (core::cmp::max(out_width - 1, 1) as f64);
 
     let out_element_num = batch_size * channels * out_height * out_width;
     let strides = (

--- a/crates/burn-tensor/src/tests/module/bicubic_interpolate.rs
+++ b/crates/burn-tensor/src/tests/module/bicubic_interpolate.rs
@@ -86,7 +86,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "https://github.com/tracel-ai/burn/issues/2080"]
     fn test_1d_bicubic() {
         // Initialize the model without weights (because the exported file does not contain them)
         let device = Default::default();

--- a/crates/burn-tensor/src/tests/module/bilinear_interpolate.rs
+++ b/crates/burn-tensor/src/tests/module/bilinear_interpolate.rs
@@ -86,7 +86,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "https://github.com/tracel-ai/burn/issues/2080"]
     fn test_1d_bilinear() {
         // Initialize the model without weights (because the exported file does not contain them)
         let device = Default::default();


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.

### Related Issues/PRs

Fixes #2080 

### Changes

Denominator in fraction would be 0 for output size of 1, leading to `NaN`.

### Testing

Enabled previously ignored tests
