### PR TITLE
Fix compile for dataset crate with vision feature

### DIFF
--- a/crates/burn-dataset/Cargo.toml
+++ b/crates/burn-dataset/Cargo.toml
@@ -21,7 +21,7 @@ fake = ["dep:fake"]
 sqlite = ["__sqlite-shared", "dep:rusqlite"]
 sqlite-bundled = ["__sqlite-shared", "rusqlite/bundled"]
 
-vision = ["dep:flate2", "dep:globwalk", "dep:burn-common"]
+vision = ["dep:flate2", "dep:globwalk", "dep:burn-common", "dep:image"]
 
 # internal
 __sqlite-shared = [


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [X] Confirmed that `run-checks all` script has been executed.
- [X] Made sure the book is up to date with changes in this PR.


### Changes

This fixes the compile error when burn is compiled with only the `dataset` and `vision` feature enabled

````toml
burn = { default-features = false, features = ["dataset", "vision"] }
````

