### PR TITLE
Don't panic when Ratatui progress gauge is > 1.0

### DIFF
--- a/crates/burn-train/src/renderer/tui/progress.rs
+++ b/crates/burn-train/src/renderer/tui/progress.rs
@@ -86,7 +86,7 @@ impl ProgressBarView {
 
         let iteration = Gauge::default()
             .gauge_style(Style::default().fg(Color::Yellow))
-            .ratio(self.progress);
+            .ratio(self.progress.min(1.0));
         let eta = Paragraph::new(Line::from(vec![
             Span::from(" ("),
             Span::from(self.eta).italic(),


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [X] Confirmed that `run-checks all` script has been executed.
- [X] Made sure the book is up to date with changes in this PR.

### Changes

Ratatui asserts that gauges don't have a progress greater than 1.0 This can happen if a `Dataset` reports a lower `len()` than it actually provides.

This change prevents a panic when the `Progress::items_processed` is greater than the `Progress::items_total`
