### PR TITLE
enable doc_auto_cfg to show feature-req-hint in docs.rs

### DIFF
--- a/crates/burn-autodiff/Cargo.toml
+++ b/crates/burn-autodiff/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 name = "burn-autodiff"
 readme.workspace = true
 repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-autodiff"
+documentation = "https://docs.rs/burn-autodiff"
 version.workspace = true
 
 [features]
@@ -29,3 +30,7 @@ log = { workspace = true }
 burn-tensor = { path = "../burn-tensor", version = "0.15.0", default-features = false, features = [
   "export_tests",
 ] }
+
+[package.metadata.docs.rs]
+features = ["default"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/burn-autodiff/src/lib.rs
+++ b/crates/burn-autodiff/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 //! # Burn Autodiff
 //!

--- a/crates/burn-candle/Cargo.toml
+++ b/crates/burn-candle/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 name = "burn-candle"
 readme.workspace = true
 repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-candle"
+documentation = "https://docs.rs/burn-candle"
 version.workspace = true
 
 [features]
@@ -17,7 +18,6 @@ doc = ["default"]
 cuda = ["candle-core/cuda"]
 metal = ["candle-core/metal"]
 accelerate = ["candle-core/accelerate"]
-
 
 [dependencies]
 derive-new = { workspace = true }
@@ -37,3 +37,4 @@ burn-tensor = { path = "../burn-tensor", version = "0.15.0", default-features = 
 
 [package.metadata.docs.rs]
 features = ["doc"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/burn-candle/src/lib.rs
+++ b/crates/burn-candle/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![allow(unused)] // TODO remove when backend filled
 
 //! Burn Candle Backend

--- a/crates/burn-common/Cargo.toml
+++ b/crates/burn-common/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 name = "burn-common"
 readme.workspace = true
 repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-common"
+documentation = "https://docs.rs/burn-common"
 version.workspace = true
 
 [features]
@@ -20,7 +21,6 @@ rayon = ["dep:rayon"]
 [target.'cfg(target_family = "wasm")'.dependencies]
 getrandom = { workspace = true, features = ["js"] }
 web-time = { version = "1.1.0" }
-
 
 [dependencies]
 data-encoding = { workspace = true }
@@ -39,3 +39,4 @@ dashmap = { workspace = true }
 
 [package.metadata.docs.rs]
 features = ["doc"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/burn-common/src/lib.rs
+++ b/crates/burn-common/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 //! # Burn Common Library
 //!

--- a/crates/burn-core/Cargo.toml
+++ b/crates/burn-core/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 name = "burn-core"
 readme.workspace = true
 repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-core"
+documentation = "https://docs.rs/burn-core"
 version.workspace = true
 
 [features]
@@ -152,3 +153,4 @@ burn-autodiff = { path = "../burn-autodiff", version = "0.15.0" }
 
 [package.metadata.docs.rs]
 features = ["doc"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/burn-core/Cargo.toml
+++ b/crates/burn-core/Cargo.toml
@@ -51,6 +51,7 @@ doc = [
     "ndarray",
     "tch",
     "wgpu",
+    "cuda-jit",
     "vision",
     "autodiff",
     # Doc features
@@ -137,7 +138,7 @@ serde_json = { workspace = true, features = ["alloc"] } #Default enables std
 thiserror = { workspace = true, optional = true }
 regex = { workspace = true, optional = true }
 num-traits = { workspace = true }
-spin = { workspace = true } # Using in place of use std::sync::Mutex when std is disabled
+spin = { workspace = true }                             # Using in place of use std::sync::Mutex when std is disabled
 
 [target.'cfg(not(target_has_atomic = "ptr"))'.dependencies]
 portable-atomic-util = { workspace = true }

--- a/crates/burn-core/src/lib.rs
+++ b/crates/burn-core/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 //! The core crate of Burn.
 

--- a/crates/burn-cuda/Cargo.toml
+++ b/crates/burn-cuda/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 name = "burn-cuda"
 readme.workspace = true
 repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-cuda"
+documentation = "https://docs.rs/burn-cuda"
 version.workspace = true
 
 [features]
@@ -36,3 +37,4 @@ burn-jit = { path = "../burn-jit", version = "0.15.0", default-features = false,
 
 [package.metadata.docs.rs]
 features = ["doc"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/burn-cuda/src/lib.rs
+++ b/crates/burn-cuda/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 extern crate alloc;
 
 use burn_jit::JitBackend;

--- a/crates/burn-dataset/Cargo.toml
+++ b/crates/burn-dataset/Cargo.toml
@@ -8,21 +8,17 @@ license.workspace = true
 name = "burn-dataset"
 readme.workspace = true
 repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-dataset"
+documentation = "https://docs.rs/burn-dataset"
 version.workspace = true
 
 [features]
 default = ["sqlite-bundled"]
 doc = ["default"]
-
 audio = ["hound"]
-
 fake = ["dep:fake"]
-
 sqlite = ["__sqlite-shared", "dep:rusqlite"]
 sqlite-bundled = ["__sqlite-shared", "rusqlite/bundled"]
-
 vision = ["dep:flate2", "dep:globwalk", "dep:burn-common", "dep:image"]
-
 # internal
 __sqlite-shared = [
     "dep:r2d2",
@@ -31,7 +27,6 @@ __sqlite-shared = [
     "dep:image",
     "dep:gix-tempfile",
 ]
-
 dataframe = ["dep:polars"]
 
 [dependencies]
@@ -72,3 +67,4 @@ normal = ["strum", "strum_macros"]
 
 [package.metadata.docs.rs]
 features = ["doc"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/burn-dataset/src/lib.rs
+++ b/crates/burn-dataset/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 //! # Burn Dataset
 //!

--- a/crates/burn-fusion/Cargo.toml
+++ b/crates/burn-fusion/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 name = "burn-fusion"
 readme.workspace = true
 repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-fusion"
+documentation = "https://docs.rs/burn-fusion"
 version.workspace = true
 
 [features]
@@ -27,3 +28,4 @@ half = { workspace = true }
 
 [package.metadata.docs.rs]
 features = ["doc"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/burn-fusion/src/lib.rs
+++ b/crates/burn-fusion/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 //! # Burn Fusion
 //!

--- a/crates/burn-import/Cargo.toml
+++ b/crates/burn-import/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 name = "burn-import"
 readme.workspace = true
 repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-import"
+documentation = "https://docs.rs/burn-import"
 version.workspace = true
 
 default-run = "onnx2burn"
@@ -40,3 +41,7 @@ zip = { workspace = true, optional = true }
 [dev-dependencies]
 pretty_assertions = { workspace = true }
 rstest = { workspace = true }
+
+[package.metadata.docs.rs]
+features = ["default"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/burn-import/src/lib.rs
+++ b/crates/burn-import/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![allow(clippy::ptr_arg)]
 #![allow(clippy::single_match)]
 #![allow(clippy::upper_case_acronyms)]

--- a/crates/burn-jit/Cargo.toml
+++ b/crates/burn-jit/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 name = "burn-jit"
 readme.workspace = true
 repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-jit"
+documentation = "https://docs.rs/burn-jit"
 version.workspace = true
 
 [features]
@@ -54,3 +55,4 @@ burn-ndarray = { path = "../burn-ndarray", version = "0.15.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["doc"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/burn-jit/src/lib.rs
+++ b/crates/burn-jit/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 //! Burn JIT Backend
 

--- a/crates/burn-ndarray/Cargo.toml
+++ b/crates/burn-ndarray/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 name = "burn-ndarray"
 readme.workspace = true
 repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-ndarray"
+documentation = "https://docs.rs/burn-ndarray"
 version.workspace = true
 
 [features]
@@ -69,3 +70,4 @@ burn-tensor = { path = "../burn-tensor", version = "0.15.0", default-features = 
 
 [package.metadata.docs.rs]
 features = ["doc"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/burn-ndarray/src/lib.rs
+++ b/crates/burn-ndarray/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 //! Burn ndarray backend.
 

--- a/crates/burn-tch/Cargo.toml
+++ b/crates/burn-tch/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 name = "burn-tch"
 readme.workspace = true
 repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-tch"
+documentation = "https://docs.rs/burn-tch"
 version.workspace = true
 
 [features]
@@ -33,3 +34,4 @@ burn-tensor = { path = "../burn-tensor", version = "0.15.0", default-features = 
 
 [package.metadata.docs.rs]
 features = ["doc"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/burn-tch/src/lib.rs
+++ b/crates/burn-tch/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![allow(clippy::single_range_in_vec_init)]
 
 //! Burn Tch Backend

--- a/crates/burn-tensor/Cargo.toml
+++ b/crates/burn-tensor/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 name = "burn-tensor"
 readme.workspace = true
 repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-tensor"
+documentation = "https://docs.rs/burn-tensor"
 version.workspace = true
 
 [features]
@@ -53,3 +54,4 @@ rand = { workspace = true, features = ["std", "std_rng"] } # Default enables std
 
 [package.metadata.docs.rs]
 features = ["doc"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/burn-tensor/src/lib.rs
+++ b/crates/burn-tensor/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Allow deprecated `Data` and `DataSerialize`
 #![allow(deprecated)]
 

--- a/crates/burn-train/Cargo.toml
+++ b/crates/burn-train/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 name = "burn-train"
 readme.workspace = true
 repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-train"
+documentation = "https://docs.rs/burn-train"
 version.workspace = true
 
 [features]
@@ -42,3 +43,4 @@ burn-ndarray = { path = "../burn-ndarray", version = "0.15.0" }
 
 [package.metadata.docs.rs]
 features = ["doc"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/burn-train/Cargo.toml
+++ b/crates/burn-train/Cargo.toml
@@ -46,3 +46,4 @@ burn-ndarray = { path = "../burn-ndarray", version = "0.15.0" }
 
 [package.metadata.docs.rs]
 features = ["doc"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/burn-train/Cargo.toml
+++ b/crates/burn-train/Cargo.toml
@@ -18,7 +18,10 @@ metrics = ["nvml-wrapper", "sysinfo", "systemstat"]
 tui = ["ratatui", "crossterm"]
 
 [dependencies]
-burn-core = { path = "../burn-core", version = "0.15.0", features = ["dataset", "std"], default-features = false }
+burn-core = { path = "../burn-core", version = "0.15.0", features = [
+    "dataset",
+    "std",
+], default-features = false }
 
 log = { workspace = true }
 tracing-subscriber = { workspace = true }
@@ -43,4 +46,3 @@ burn-ndarray = { path = "../burn-ndarray", version = "0.15.0" }
 
 [package.metadata.docs.rs]
 features = ["doc"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/burn-train/src/lib.rs
+++ b/crates/burn-train/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 //! A library for training neural networks using the burn crate.
 

--- a/crates/burn-wgpu/Cargo.toml
+++ b/crates/burn-wgpu/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 name = "burn-wgpu"
 readme.workspace = true
 repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-wgpu"
+documentation = "https://docs.rs/burn-wgpu"
 version.workspace = true
 
 [features]
@@ -30,3 +31,7 @@ burn-fusion = { path = "../burn-fusion", version = "0.15.0", optional = true }
 burn-jit = { path = "../burn-jit", version = "0.15.0", default-features = false, features = [
   "export_tests",
 ] }
+
+[package.metadata.docs.rs]
+features = ["default"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/burn-wgpu/src/lib.rs
+++ b/crates/burn-wgpu/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 extern crate alloc;
 
 #[cfg(feature = "template")]

--- a/crates/burn/Cargo.toml
+++ b/crates/burn/Cargo.toml
@@ -73,4 +73,3 @@ burn-train = { path = "../burn-train", version = "0.15.0", optional = true, defa
 
 [package.metadata.docs.rs]
 features = ["doc"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/burn/Cargo.toml
+++ b/crates/burn/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 name = "burn"
 readme.workspace = true
 repository = "https://github.com/tracel-ai/burn"
+documentation = "https://docs.rs/burn"
 version.workspace = true
 rust-version = "1.80"
 
@@ -72,3 +73,4 @@ burn-train = { path = "../burn-train", version = "0.15.0", optional = true, defa
 
 [package.metadata.docs.rs]
 features = ["doc"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/burn/Cargo.toml
+++ b/crates/burn/Cargo.toml
@@ -15,20 +15,7 @@ rust-version = "1.80"
 [features]
 default = ["burn-core/default", "burn-train?/default", "std"]
 std = ["burn-core/std"]
-doc = [
-    "default",
-    "train",
-    "burn-core/doc",
-    "burn-train/doc",
-    "ndarray",
-    "autodiff",
-    "wgpu",
-    "cuda-jit",
-    "candle",
-    "tch",
-    "metrics",
-    "tui",
-]
+doc = ["default", "train", "burn-core/doc", "burn-train/doc"]
 
 # Training with full features
 train = ["burn-train", "autodiff", "dataset"]
@@ -83,7 +70,3 @@ record-backward-compat = ["burn-core/record-backward-compat"]
 
 burn-core = { path = "../burn-core", version = "0.15.0", default-features = false }
 burn-train = { path = "../burn-train", version = "0.15.0", optional = true, default-features = false }
-
-[package.metadata.docs.rs]
-features = ["doc"]
-rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/burn/Cargo.toml
+++ b/crates/burn/Cargo.toml
@@ -73,3 +73,4 @@ burn-train = { path = "../burn-train", version = "0.15.0", optional = true, defa
 
 [package.metadata.docs.rs]
 features = ["doc"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/burn/Cargo.toml
+++ b/crates/burn/Cargo.toml
@@ -15,7 +15,20 @@ rust-version = "1.80"
 [features]
 default = ["burn-core/default", "burn-train?/default", "std"]
 std = ["burn-core/std"]
-doc = ["default", "burn-core/doc", "burn-train/doc"]
+doc = [
+    "default",
+    "train",
+    "burn-core/doc",
+    "burn-train/doc",
+    "ndarray",
+    "autodiff",
+    "wgpu",
+    "cuda-jit",
+    "candle",
+    "tch",
+    "metrics",
+    "tui",
+]
 
 # Training with full features
 train = ["burn-train", "autodiff", "dataset"]

--- a/crates/burn/src/lib.rs
+++ b/crates/burn/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 //! # Burn
 //!

--- a/crates/burn/src/lib.rs
+++ b/crates/burn/src/lib.rs
@@ -93,6 +93,8 @@
 //!   - `std`: Activates the standard library (deactivate for no_std)
 //!   - `network`: Enables network utilities (currently, only a file downloader with progress bar)
 //!   - `experimental-named-tensor`: Enables named tensors (experimental)
+//!
+//! You can also check the details in sub-crates [`burn-core`](https://docs.rs/burn-core) and [`burn-train`](https://docs.rs/burn-train).
 
 pub use burn_core::*;
 

--- a/crates/burn/src/lib.rs
+++ b/crates/burn/src/lib.rs
@@ -96,8 +96,7 @@
 //!   - `experimental-named-tensor`: Enables named tensors (experimental)
 
 pub use burn_core::{
-    config, constant, grad_clipping, module, nn, prelude, record, serde,
-    tensor, LearningRate,
+    config, constant, grad_clipping, module, nn, prelude, record, serde, tensor, LearningRate,
 };
 
 #[cfg(feature = "std")]

--- a/crates/burn/src/lib.rs
+++ b/crates/burn/src/lib.rs
@@ -96,9 +96,12 @@
 //!   - `experimental-named-tensor`: Enables named tensors (experimental)
 
 pub use burn_core::{
-    config, constant, data, grad_clipping, lr_scheduler, module, nn, optim, prelude, record, serde,
+    config, constant, grad_clipping, module, nn, prelude, record, serde,
     tensor, LearningRate,
 };
+
+#[cfg(feature = "std")]
+pub use burn_core::{data, lr_scheduler, optim};
 
 /// Backend module.
 pub mod backend {

--- a/crates/burn/src/lib.rs
+++ b/crates/burn/src/lib.rs
@@ -95,10 +95,75 @@
 //!   - `network`: Enables network utilities (currently, only a file downloader with progress bar)
 //!   - `experimental-named-tensor`: Enables named tensors (experimental)
 
-pub use burn_core::*;
+pub use burn_core::{
+    config, constant, data, grad_clipping, lr_scheduler, module, nn, optim, prelude, record, serde,
+    tensor, LearningRate,
+};
+
+/// Backend module.
+pub mod backend {
+    #[cfg(feature = "autodiff")]
+    pub use burn_core::backend::autodiff;
+    #[cfg(feature = "autodiff")]
+    pub use burn_core::backend::Autodiff;
+
+    #[cfg(feature = "candle")]
+    pub use burn_core::backend::candle;
+    #[cfg(feature = "candle")]
+    pub use burn_core::backend::Candle;
+
+    #[cfg(feature = "cuda-jit")]
+    pub use burn_core::backend::cuda_jit;
+    #[cfg(feature = "cuda-jit")]
+    pub use burn_core::backend::CudaJit;
+
+    #[cfg(feature = "tch")]
+    pub use burn_core::backend::libtorch;
+    #[cfg(feature = "tch")]
+    pub use burn_core::backend::LibTorch;
+
+    #[cfg(feature = "ndarray")]
+    pub use burn_core::backend::ndarray;
+    #[cfg(feature = "ndarray")]
+    pub use burn_core::backend::NdArray;
+
+    #[cfg(feature = "wgpu")]
+    pub use burn_core::backend::wgpu;
+    #[cfg(feature = "wgpu")]
+    pub use burn_core::backend::Wgpu;
+}
 
 /// Train module
 #[cfg(feature = "train")]
 pub mod train {
-    pub use burn_train::*;
+    pub use burn_train::{
+        checkpoint, logger, train, ApplicationLoggerInstaller, ClassificationOutput,
+        EarlyStoppingStrategy, FileApplicationLoggerInstaller, Learner, LearnerBuilder,
+        LearnerSummary, MetricEarlyStoppingStrategy, MetricEntry, MetricSummary,
+        MultiDevicesTrainStep, MultiLabelClassificationOutput, RegressionOutput, StoppingCondition,
+        SummaryMetrics, TrainEpoch, TrainOutput, TrainStep, TrainingInterrupter, ValidEpoch,
+        ValidStep,
+    };
+
+    /// The metric module.
+    pub mod metrics {
+        pub use burn_train::metric::{
+            format_float, state, store, AccuracyInput, AccuracyMetric, Adaptor, HammingScore,
+            HammingScoreInput, LearningRateMetric, LossInput, LossMetric, Metric, MetricEntry,
+            MetricMetadata, Numeric, NumericEntry,
+        };
+
+        #[cfg(feature = "metrics")]
+        pub use burn_train::metric::{
+            CpuMemory, CpuTemperature, CpuUse, CudaMetric, TopKAccuracyInput, TopKAccuracyMetric,
+        };
+    }
+
+    /// Renderer modules to display metrics and training information.
+    pub mod renderer {
+        pub use burn_train::renderer::{MetricState, MetricsRenderer, TrainingProgress};
+
+        #[cfg(feature = "tui")]
+        pub use burn_train::renderer::SelectedMetricsRenderer;
+    }
 }

--- a/crates/burn/src/lib.rs
+++ b/crates/burn/src/lib.rs
@@ -95,9 +95,7 @@
 //!   - `network`: Enables network utilities (currently, only a file downloader with progress bar)
 //!   - `experimental-named-tensor`: Enables named tensors (experimental)
 
-pub use burn_core::{
-    config, constant, grad_clipping, module, nn, prelude, record, serde, tensor, LearningRate,
-};
+pub use burn_core::*;
 
 #[cfg(feature = "std")]
 pub use burn_core::{data, lr_scheduler, optim};
@@ -105,55 +103,27 @@ pub use burn_core::{data, lr_scheduler, optim};
 /// Backend module.
 pub mod backend {
     #[cfg(feature = "autodiff")]
-    pub use burn_core::backend::autodiff;
-    #[cfg(feature = "autodiff")]
-    pub use burn_core::backend::Autodiff;
-
+    pub use burn_core::backend::{autodiff, Autodiff};
     #[cfg(feature = "candle")]
-    pub use burn_core::backend::candle;
-    #[cfg(feature = "candle")]
-    pub use burn_core::backend::Candle;
-
+    pub use burn_core::backend::{candle, Candle};
     #[cfg(feature = "cuda-jit")]
-    pub use burn_core::backend::cuda_jit;
-    #[cfg(feature = "cuda-jit")]
-    pub use burn_core::backend::CudaJit;
-
+    pub use burn_core::backend::{cuda_jit, CudaJit};
     #[cfg(feature = "tch")]
-    pub use burn_core::backend::libtorch;
-    #[cfg(feature = "tch")]
-    pub use burn_core::backend::LibTorch;
-
+    pub use burn_core::backend::{libtorch, LibTorch};
     #[cfg(feature = "ndarray")]
-    pub use burn_core::backend::ndarray;
-    #[cfg(feature = "ndarray")]
-    pub use burn_core::backend::NdArray;
-
+    pub use burn_core::backend::{ndarray, NdArray};
     #[cfg(feature = "wgpu")]
-    pub use burn_core::backend::wgpu;
-    #[cfg(feature = "wgpu")]
-    pub use burn_core::backend::Wgpu;
+    pub use burn_core::backend::{wgpu, Wgpu};
 }
 
 /// Train module
 #[cfg(feature = "train")]
 pub mod train {
-    pub use burn_train::{
-        checkpoint, logger, train, ApplicationLoggerInstaller, ClassificationOutput,
-        EarlyStoppingStrategy, FileApplicationLoggerInstaller, Learner, LearnerBuilder,
-        LearnerSummary, MetricEarlyStoppingStrategy, MetricEntry, MetricSummary,
-        MultiDevicesTrainStep, MultiLabelClassificationOutput, RegressionOutput, StoppingCondition,
-        SummaryMetrics, TrainEpoch, TrainOutput, TrainStep, TrainingInterrupter, ValidEpoch,
-        ValidStep,
-    };
+    pub use burn_train::*;
 
     /// The metric module.
     pub mod metric {
-        pub use burn_train::metric::{
-            format_float, state, store, AccuracyInput, AccuracyMetric, Adaptor, HammingScore,
-            HammingScoreInput, LearningRateMetric, LossInput, LossMetric, Metric, MetricEntry,
-            MetricMetadata, Numeric, NumericEntry,
-        };
+        pub use burn_train::metric::*;
 
         #[cfg(feature = "metrics")]
         pub use burn_train::metric::{
@@ -163,7 +133,7 @@ pub mod train {
 
     /// Renderer modules to display metrics and training information.
     pub mod renderer {
-        pub use burn_train::renderer::{MetricState, MetricsRenderer, TrainingProgress};
+        pub use burn_train::renderer::*;
 
         #[cfg(feature = "tui")]
         pub use burn_train::renderer::SelectedMetricsRenderer;

--- a/crates/burn/src/lib.rs
+++ b/crates/burn/src/lib.rs
@@ -146,7 +146,7 @@ pub mod train {
     };
 
     /// The metric module.
-    pub mod metrics {
+    pub mod metric {
         pub use burn_train::metric::{
             format_float, state, store, AccuracyInput, AccuracyMetric, Adaptor, HammingScore,
             HammingScoreInput, LearningRateMetric, LossInput, LossMetric, Metric, MetricEntry,

--- a/crates/burn/src/lib.rs
+++ b/crates/burn/src/lib.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 //! # Burn
 //!
@@ -97,45 +96,8 @@
 
 pub use burn_core::*;
 
-#[cfg(feature = "std")]
-pub use burn_core::{data, lr_scheduler, optim};
-
-/// Backend module.
-pub mod backend {
-    #[cfg(feature = "autodiff")]
-    pub use burn_core::backend::{autodiff, Autodiff};
-    #[cfg(feature = "candle")]
-    pub use burn_core::backend::{candle, Candle};
-    #[cfg(feature = "cuda-jit")]
-    pub use burn_core::backend::{cuda_jit, CudaJit};
-    #[cfg(feature = "tch")]
-    pub use burn_core::backend::{libtorch, LibTorch};
-    #[cfg(feature = "ndarray")]
-    pub use burn_core::backend::{ndarray, NdArray};
-    #[cfg(feature = "wgpu")]
-    pub use burn_core::backend::{wgpu, Wgpu};
-}
-
 /// Train module
 #[cfg(feature = "train")]
 pub mod train {
     pub use burn_train::*;
-
-    /// The metric module.
-    pub mod metric {
-        pub use burn_train::metric::*;
-
-        #[cfg(feature = "metrics")]
-        pub use burn_train::metric::{
-            CpuMemory, CpuTemperature, CpuUse, CudaMetric, TopKAccuracyInput, TopKAccuracyMetric,
-        };
-    }
-
-    /// Renderer modules to display metrics and training information.
-    pub mod renderer {
-        pub use burn_train::renderer::*;
-
-        #[cfg(feature = "tui")]
-        pub use burn_train::renderer::SelectedMetricsRenderer;
-    }
 }

--- a/crates/onnx-ir/Cargo.toml
+++ b/crates/onnx-ir/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 name = "onnx-ir"
 readme.workspace = true
 repository = "https://github.com/tracel-ai/burn/tree/main/crates/onnx-ir"
+documentation = "https://docs.rs/onnx-ir"
 version.workspace = true
 
 

--- a/examples/mnist/Cargo.toml
+++ b/examples/mnist/Cargo.toml
@@ -17,8 +17,8 @@ tch-gpu = ["burn/tch"]
 wgpu = ["burn/wgpu"]
 
 [dependencies]
-burn = {path = "../../crates/burn", features=["train"]}
+burn = { path = "../../crates/burn", features = ["train"] }
 
 # Serialization
-log = {workspace = true}
-serde = {workspace = true, features = ["std", "derive"]}
+log = { workspace = true }
+serde = { workspace = true, features = ["std", "derive"] }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ ] Confirmed that `run-checks all` script has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

None

### Changes

According to [this](https://github.com/rust-lang/rust/issues/43781), `cargo doc` has an cool feature `doc_auto_cfg`, which helps show the features-required hints like `tokio`.

```rust
# in lib.rs
#![cfg_attr(docsrs, feature(doc_auto_cfg))]
```

```toml
# in Cargo.toml
[package.metadata.docs.rs]
features = ["doc"]
rustdoc-args = ["--cfg", "docsrs"]
```

Apart from that, I also add `documentation` keys in `[package]`.


### Testing

```sh
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --features doc --no-deps -p burn --open
```

I just checked that it works and show things like:

<img width="1335" alt="Screenshot 2024-09-11 at 17 24 06" src="https://github.com/user-attachments/assets/e06998f9-2940-4ea1-8061-cf0e792655ee">


But I don't know how to automize this with xtask, and it needs nightly Rust as the version used by docs.rs.
