### PR TITLE
Use AsRef<Path> instead of &str for file operations

### DIFF
--- a/crates/burn-core/tests/test_derive_config.rs
+++ b/crates/burn-core/tests/test_derive_config.rs
@@ -1,5 +1,6 @@
 use burn::config::{config_to_json, Config};
 use burn_core as burn;
+use std::path::Path;
 
 #[derive(Config, Debug, PartialEq, Eq)]
 pub struct TestEmptyStructConfig {}
@@ -26,7 +27,7 @@ pub enum TestEnumConfig {
 
 #[cfg(feature = "std")]
 #[inline(always)]
-fn file_path(file_name: &str) -> std::path::PathBuf {
+fn file_path<P: AsRef<Path>>(file_name: P) -> std::path::PathBuf {
     std::env::temp_dir().join(file_name)
 }
 

--- a/crates/burn-import/src/onnx/to_burn.rs
+++ b/crates/burn-import/src/onnx/to_burn.rs
@@ -102,14 +102,14 @@ impl ModelGen {
     }
 
     /// Set output directory.
-    pub fn out_dir(&mut self, out_dir: &str) -> &mut Self {
-        self.out_dir = Some(Path::new(out_dir).into());
+    pub fn out_dir<P: AsRef<Path>>(&mut self, out_dir: P) -> &mut Self {
+        self.out_dir = Some(out_dir.as_ref().into());
         self
     }
 
     /// Add input file.
-    pub fn input(&mut self, input: &str) -> &mut Self {
-        self.inputs.push(input.into());
+    pub fn input<P: AsRef<Path>>(&mut self, input: P) -> &mut Self {
+        self.inputs.push(input.as_ref().into());
         self
     }
 

--- a/examples/custom-image-dataset/src/training.rs
+++ b/examples/custom-image-dataset/src/training.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use std::{path::Path, time::Instant};
 
 use crate::{
     data::{ClassificationBatch, ClassificationBatcher},
@@ -65,9 +65,9 @@ pub struct TrainingConfig {
     pub learning_rate: f64,
 }
 
-fn create_artifact_dir(artifact_dir: &str) {
+fn create_artifact_dir<P: AsRef<Path>>(artifact_dir: P) {
     // Remove existing artifacts before to get an accurate learner summary
-    std::fs::remove_dir_all(artifact_dir).ok();
+    std::fs::remove_dir_all(artifact_dir.as_ref()).ok();
     std::fs::create_dir_all(artifact_dir).ok();
 }
 

--- a/examples/guide/src/bin/infer.rs
+++ b/examples/guide/src/bin/infer.rs
@@ -10,7 +10,7 @@ fn main() {
     let artifact_dir = "/tmp/guide";
 
     // Infer the model
-    inference::infer::<MyBackend>(
+    inference::infer::<MyBackend, &str>(
         artifact_dir,
         device,
         burn::data::dataset::vision::MnistDataset::test()

--- a/examples/guide/src/bin/train.rs
+++ b/examples/guide/src/bin/train.rs
@@ -20,14 +20,14 @@ fn main() {
     let artifact_dir = "/tmp/guide";
 
     // Train the model
-    training::train::<MyAutodiffBackend>(
+    training::train::<MyAutodiffBackend, &str>(
         artifact_dir,
         TrainingConfig::new(ModelConfig::new(10, 512), AdamConfig::new()),
         device.clone(),
     );
 
     // Infer the model
-    inference::infer::<MyBackend>(
+    inference::infer::<MyBackend, &str>(
         artifact_dir,
         device,
         burn::data::dataset::vision::MnistDataset::test()

--- a/examples/guide/src/inference.rs
+++ b/examples/guide/src/inference.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use crate::{data::MnistBatcher, model::Model, training::TrainingConfig};
 use burn::{
     data::{dataloader::batcher::Batcher, dataset::vision::MnistItem},
@@ -5,11 +7,11 @@ use burn::{
     record::{CompactRecorder, Recorder},
 };
 
-pub fn infer<B: Backend>(artifact_dir: &str, device: B::Device, item: MnistItem) {
-    let config = TrainingConfig::load(format!("{artifact_dir}/config.json"))
+pub fn infer<B: Backend, P: AsRef<Path>>(artifact_dir: P, device: B::Device, item: MnistItem) {
+    let config = TrainingConfig::load(artifact_dir.as_ref().join("config.json"))
         .expect("Config should exist for the model; run train first");
     let record = CompactRecorder::new()
-        .load(format!("{artifact_dir}/model").into(), &device)
+        .load(artifact_dir.as_ref().join("model"), &device)
         .expect("Trained model should exist; run train first");
 
     let model: Model<B> = config.model.init(&device).load_record(record);

--- a/examples/mnist/src/training.rs
+++ b/examples/mnist/src/training.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use crate::{data::MnistBatcher, model::Model};
 
 use burn::{
@@ -34,9 +36,9 @@ pub struct MnistTrainingConfig {
     pub optimizer: AdamConfig,
 }
 
-fn create_artifact_dir(artifact_dir: &str) {
+fn create_artifact_dir<P: AsRef<Path>>(artifact_dir: P) {
     // Remove existing artifacts before to get an accurate learner summary
-    std::fs::remove_dir_all(artifact_dir).ok();
+    std::fs::remove_dir_all(artifact_dir.as_ref()).ok();
     std::fs::create_dir_all(artifact_dir).ok();
 }
 

--- a/examples/text-classification/examples/ag-news-infer.rs
+++ b/examples/text-classification/examples/ag-news-infer.rs
@@ -8,7 +8,7 @@ type ElemType = f32;
 type ElemType = burn::tensor::f16;
 
 pub fn launch<B: Backend>(device: B::Device) {
-    text_classification::inference::infer::<B, AgNewsDataset>(
+    text_classification::inference::infer::<B, AgNewsDataset, &str>(
         device,
         "/tmp/text-classification-ag-news",
         // Samples from the test dataset, but you are free to test with your own text.

--- a/examples/text-classification/examples/ag-news-train.rs
+++ b/examples/text-classification/examples/ag-news-train.rs
@@ -20,7 +20,7 @@ pub fn launch<B: AutodiffBackend>(devices: Vec<B::Device>) {
         AdamConfig::new().with_weight_decay(Some(WeightDecayConfig::new(5e-5))),
     );
 
-    text_classification::training::train::<B, AgNewsDataset>(
+    text_classification::training::train::<B, AgNewsDataset, &str>(
         devices,
         AgNewsDataset::train(),
         AgNewsDataset::test(),

--- a/examples/text-classification/examples/db-pedia-infer.rs
+++ b/examples/text-classification/examples/db-pedia-infer.rs
@@ -9,7 +9,7 @@ type ElemType = f32;
 type ElemType = burn::tensor::f16;
 
 pub fn launch<B: AutodiffBackend>(device: B::Device) {
-    text_classification::inference::infer::<B, DbPediaDataset>(
+    text_classification::inference::infer::<B, DbPediaDataset, &str>(
         device,
         "/tmp/text-classification-db-pedia",
         // Samples from the test dataset, but you are free to test with your own text.

--- a/examples/text-classification/examples/db-pedia-train.rs
+++ b/examples/text-classification/examples/db-pedia-train.rs
@@ -18,7 +18,7 @@ pub fn launch<B: AutodiffBackend>(devices: Vec<B::Device>) {
         AdamConfig::new().with_weight_decay(Some(WeightDecayConfig::new(5e-5))),
     );
 
-    text_classification::training::train::<B, DbPediaDataset>(
+    text_classification::training::train::<B, DbPediaDataset, &str>(
         devices,
         DbPediaDataset::train(),
         DbPediaDataset::test(),

--- a/examples/text-classification/src/inference.rs
+++ b/examples/text-classification/src/inference.rs
@@ -14,16 +14,16 @@ use burn::{
     prelude::*,
     record::{CompactRecorder, Recorder},
 };
-use std::sync::Arc;
+use std::{path::Path, sync::Arc};
 
 // Define inference function
-pub fn infer<B: Backend, D: TextClassificationDataset + 'static>(
+pub fn infer<B: Backend, D: TextClassificationDataset + 'static, P: AsRef<Path>>(
     device: B::Device, // Device on which to perform computation (e.g., CPU or CUDA device)
-    artifact_dir: &str, // Directory containing model and config files
+    artifact_dir: P,   // Directory containing model and config files
     samples: Vec<String>, // Text samples for inference
 ) {
     // Load experiment configuration
-    let config = ExperimentConfig::load(format!("{artifact_dir}/config.json").as_str())
+    let config = ExperimentConfig::load(artifact_dir.as_ref().join("config.json"))
         .expect("Config file present");
 
     // Initialize tokenizer
@@ -42,7 +42,7 @@ pub fn infer<B: Backend, D: TextClassificationDataset + 'static>(
     // Load pre-trained model weights
     println!("Loading weights ...");
     let record = CompactRecorder::new()
-        .load(format!("{artifact_dir}/model").into(), &device)
+        .load(artifact_dir.as_ref().join("model"), &device)
         .expect("Trained model weights");
 
     // Create model using loaded weights

--- a/examples/text-generation/examples/text-generation.rs
+++ b/examples/text-generation/examples/text-generation.rs
@@ -15,7 +15,7 @@ fn main() {
         burn::optim::AdamConfig::new().with_weight_decay(Some(WeightDecayConfig::new(1.0e-6))),
     );
 
-    text_generation::training::train::<Backend, DbPediaDataset>(
+    text_generation::training::train::<Backend, DbPediaDataset, &str>(
         if cfg!(target_os = "macos") {
             burn::tensor::Device::<Backend>::Mps
         } else {


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

https://github.com/tracel-ai/burn/issues/698

### Changes

Replaced all file related `&str` with `AsRef<Path>`

Exception: https://github.com/tracel-ai/burn/blob/main/crates/burn-import/src/burn/graph.rs#L347
This generates code, where `std::path::Path` can be added, but std is not available.
Also not sure whether e.g. [here](https://github.com/ivnsch/burn/blob/replace_str_with_as_ref/examples/guide/src/inference.rs#L10) the order of the type variables is correct, should it match the order of the parameters, or just be appended (current)?

Some calls got slightly noisier, but not necessarily an issue https://github.com/ivnsch/burn/blob/replace_str_with_as_ref/examples/guide/src/bin/infer.rs#L13

Anyway, just opening the PR and waiting for feedback.

### Testing

I ran `./run-checks.sh all` and `cargo test`. `cargo test` is currently not helping much, because of all the cuda errors (don't have nvidia and not sure how to exclude them).

These changes seem unlikely to affect the book, but can review it once this has received some feedback.