### PR TITLE
Refactor: Split conv backward to allow conditional gradient computation

### DIFF
--- a/crates/burn-autodiff/src/ops/module.rs
+++ b/crates/burn-autodiff/src/ops/module.rs
@@ -78,20 +78,28 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                 let grad = grads.consume::<B, 3>(&ops.node);
 
                 let (x_state, weight_state, bias_state, options) = ops.state;
-                let x = checkpointer.retrieve_node_output(x_state);
-                let weight = checkpointer.retrieve_node_output(weight_state);
-                let bias = Some(checkpointer.retrieve_node_output(bias_state));
-
-                let backward = B::conv1d_backward(x, weight, bias, grad, options);
+                let x = checkpointer.retrieve_node_output::<B::FloatTensorPrimitive<3>>(x_state);
+                let weight =
+                    checkpointer.retrieve_node_output::<B::FloatTensorPrimitive<3>>(weight_state);
+                let bias =
+                    checkpointer.retrieve_node_output::<B::FloatTensorPrimitive<1>>(bias_state);
 
                 if let Some(node) = node_x {
-                    grads.register::<B, 3>(node.id, backward.x_grad)
+                    let grad = B::conv1d_x_backward(
+                        x.clone(),
+                        weight.clone(),
+                        grad.clone(),
+                        options.clone(),
+                    );
+                    grads.register::<B, 3>(node.id, grad)
                 }
                 if let Some(node) = node_weight {
-                    grads.register::<B, 3>(node.id, backward.weights_grad)
+                    let grad = B::conv1d_weight_backward(x.clone(), weight, grad.clone(), options);
+                    grads.register::<B, 3>(node.id, grad)
                 }
                 if let Some(node) = node_bias {
-                    grads.register::<B, 1>(node.id, backward.bias_grad.unwrap())
+                    let grad = B::conv1d_bias_backward(x, bias, grad);
+                    grads.register::<B, 1>(node.id, grad)
                 }
             }
         }
@@ -109,16 +117,22 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                 let grad = grads.consume::<B, 3>(&ops.node);
 
                 let (x_state, weight_state, options) = ops.state;
-                let x = checkpointer.retrieve_node_output(x_state);
-                let weight = checkpointer.retrieve_node_output(weight_state);
-
-                let backward = B::conv1d_backward(x, weight, None, grad, options);
+                let x = checkpointer.retrieve_node_output::<B::FloatTensorPrimitive<3>>(x_state);
+                let weight =
+                    checkpointer.retrieve_node_output::<B::FloatTensorPrimitive<3>>(weight_state);
 
                 if let Some(node) = node_x {
-                    grads.register::<B, 3>(node.id, backward.x_grad)
+                    let grad = B::conv1d_x_backward(
+                        x.clone(),
+                        weight.clone(),
+                        grad.clone(),
+                        options.clone(),
+                    );
+                    grads.register::<B, 3>(node.id, grad)
                 }
                 if let Some(node) = node_weight {
-                    grads.register::<B, 3>(node.id, backward.weights_grad)
+                    let grad = B::conv1d_weight_backward(x, weight, grad, options);
+                    grads.register::<B, 3>(node.id, grad)
                 }
             }
         }
@@ -188,20 +202,32 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                 let grad = grads.consume::<B, 3>(&ops.node);
 
                 let (x_state, weight_state, bias_state, options) = ops.state;
-                let x = checkpointer.retrieve_node_output(x_state);
-                let weight = checkpointer.retrieve_node_output(weight_state);
-                let bias = Some(checkpointer.retrieve_node_output(bias_state));
-
-                let backward = B::conv_transpose1d_backward(x, weight, bias, grad, options);
+                let x = checkpointer.retrieve_node_output::<B::FloatTensorPrimitive<3>>(x_state);
+                let weight =
+                    checkpointer.retrieve_node_output::<B::FloatTensorPrimitive<3>>(weight_state);
+                let bias =
+                    checkpointer.retrieve_node_output::<B::FloatTensorPrimitive<1>>(bias_state);
 
                 if let Some(node) = node_x {
-                    grads.register::<B, 3>(node.id, backward.x_grad)
+                    let grad = B::conv_transpose1d_x_backward(
+                        weight.clone(),
+                        grad.clone(),
+                        options.clone(),
+                    );
+                    grads.register::<B, 3>(node.id, grad)
                 }
                 if let Some(node) = node_weight {
-                    grads.register::<B, 3>(node.id, backward.weights_grad)
+                    let grad = B::conv_transpose1d_weight_backward(
+                        x.clone(),
+                        weight,
+                        grad.clone(),
+                        options,
+                    );
+                    grads.register::<B, 3>(node.id, grad)
                 }
                 if let Some(node) = node_bias {
-                    grads.register::<B, 1>(node.id, backward.bias_grad.unwrap())
+                    let grad = B::conv_transpose1d_bias_backward(x, bias, grad);
+                    grads.register::<B, 1>(node.id, grad)
                 }
             }
         }
@@ -219,16 +245,21 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                 let grad = grads.consume::<B, 3>(&ops.node);
 
                 let (x_state, weight_state, options) = ops.state;
-                let x = checkpointer.retrieve_node_output(x_state);
-                let weight = checkpointer.retrieve_node_output(weight_state);
-
-                let backward = B::conv_transpose1d_backward(x, weight, None, grad, options);
+                let x = checkpointer.retrieve_node_output::<B::FloatTensorPrimitive<3>>(x_state);
+                let weight =
+                    checkpointer.retrieve_node_output::<B::FloatTensorPrimitive<3>>(weight_state);
 
                 if let Some(node) = node_x {
-                    grads.register::<B, 3>(node.id, backward.x_grad)
+                    let grad = B::conv_transpose1d_x_backward(
+                        weight.clone(),
+                        grad.clone(),
+                        options.clone(),
+                    );
+                    grads.register::<B, 3>(node.id, grad)
                 }
                 if let Some(node) = node_weight {
-                    grads.register::<B, 3>(node.id, backward.weights_grad)
+                    let grad = B::conv_transpose1d_weight_backward(x, weight, grad, options);
+                    grads.register::<B, 3>(node.id, grad)
                 }
             }
         }
@@ -307,20 +338,29 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                 let grad = grads.consume::<B, 4>(&ops.node);
 
                 let (x_state, weight_state, bias_state, options) = ops.state;
-                let x = checkpointer.retrieve_node_output(x_state);
-                let weight = checkpointer.retrieve_node_output(weight_state);
-                let bias = Some(checkpointer.retrieve_node_output(bias_state));
-
-                let backward = B::conv2d_backward(x, weight, bias, grad, options);
+                let x = checkpointer.retrieve_node_output::<B::FloatTensorPrimitive<4>>(x_state);
+                let weight =
+                    checkpointer.retrieve_node_output::<B::FloatTensorPrimitive<4>>(weight_state);
+                let bias =
+                    checkpointer.retrieve_node_output::<B::FloatTensorPrimitive<1>>(bias_state);
 
                 if let Some(node) = node_x {
-                    grads.register::<B, 4>(node.id, backward.x_grad)
+                    let grad = B::conv2d_x_backward(
+                        x.clone(),
+                        weight.clone(),
+                        grad.clone(),
+                        options.clone(),
+                    );
+                    grads.register::<B, 4>(node.id, grad)
                 }
                 if let Some(node) = node_weight {
-                    grads.register::<B, 4>(node.id, backward.weights_grad)
+                    let grad =
+                        B::conv2d_weight_backward(x.clone(), weight.clone(), grad.clone(), options);
+                    grads.register::<B, 4>(node.id, grad)
                 }
                 if let Some(node) = node_bias {
-                    grads.register::<B, 1>(node.id, backward.bias_grad.unwrap())
+                    let grad = B::conv2d_bias_backward(x, weight, bias, grad);
+                    grads.register::<B, 1>(node.id, grad)
                 }
             }
         }
@@ -338,16 +378,22 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                 let grad = grads.consume::<B, 4>(&ops.node);
 
                 let (x_state, weight_state, options) = ops.state;
-                let x = checkpointer.retrieve_node_output(x_state);
-                let weight = checkpointer.retrieve_node_output(weight_state);
-
-                let backward = B::conv2d_backward(x, weight, None, grad, options);
+                let x = checkpointer.retrieve_node_output::<B::FloatTensorPrimitive<4>>(x_state);
+                let weight =
+                    checkpointer.retrieve_node_output::<B::FloatTensorPrimitive<4>>(weight_state);
 
                 if let Some(node) = node_x {
-                    grads.register::<B, 4>(node.id, backward.x_grad)
+                    let grad = B::conv2d_x_backward(
+                        x.clone(),
+                        weight.clone(),
+                        grad.clone(),
+                        options.clone(),
+                    );
+                    grads.register::<B, 4>(node.id, grad)
                 }
                 if let Some(node) = node_weight {
-                    grads.register::<B, 4>(node.id, backward.weights_grad)
+                    let grad = B::conv2d_weight_backward(x, weight, grad, options);
+                    grads.register::<B, 4>(node.id, grad)
                 }
             }
         }
@@ -419,20 +465,32 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                 let grad = grads.consume::<B, 4>(&ops.node);
 
                 let (x_state, weight_state, bias_state, options) = ops.state;
-                let x = checkpointer.retrieve_node_output(x_state);
-                let weight = checkpointer.retrieve_node_output(weight_state);
-                let bias = Some(checkpointer.retrieve_node_output(bias_state));
-
-                let backward = B::conv_transpose2d_backward(x, weight, bias, grad, options);
+                let x = checkpointer.retrieve_node_output::<B::FloatTensorPrimitive<4>>(x_state);
+                let weight =
+                    checkpointer.retrieve_node_output::<B::FloatTensorPrimitive<4>>(weight_state);
+                let bias =
+                    checkpointer.retrieve_node_output::<B::FloatTensorPrimitive<1>>(bias_state);
 
                 if let Some(node) = node_x {
-                    grads.register::<B, 4>(node.id, backward.x_grad)
+                    let grad = B::conv_transpose2d_x_backward(
+                        weight.clone(),
+                        grad.clone(),
+                        options.clone(),
+                    );
+                    grads.register::<B, 4>(node.id, grad)
                 }
                 if let Some(node) = node_weight {
-                    grads.register::<B, 4>(node.id, backward.weights_grad)
+                    let grad = B::conv_transpose2d_weight_backward(
+                        x.clone(),
+                        weight,
+                        grad.clone(),
+                        options,
+                    );
+                    grads.register::<B, 4>(node.id, grad)
                 }
                 if let Some(node) = node_bias {
-                    grads.register::<B, 1>(node.id, backward.bias_grad.unwrap())
+                    let grad = B::conv_transpose2d_bias_backward(x, bias, grad);
+                    grads.register::<B, 1>(node.id, grad)
                 }
             }
         }
@@ -450,16 +508,21 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                 let grad = grads.consume::<B, 4>(&ops.node);
 
                 let (x_state, weight_state, options) = ops.state;
-                let x = checkpointer.retrieve_node_output(x_state);
-                let weight = checkpointer.retrieve_node_output(weight_state);
-
-                let backward = B::conv_transpose2d_backward(x, weight, None, grad, options);
+                let x = checkpointer.retrieve_node_output::<B::FloatTensorPrimitive<4>>(x_state);
+                let weight =
+                    checkpointer.retrieve_node_output::<B::FloatTensorPrimitive<4>>(weight_state);
 
                 if let Some(node) = node_x {
-                    grads.register::<B, 4>(node.id, backward.x_grad)
+                    let grad = B::conv_transpose2d_x_backward(
+                        weight.clone(),
+                        grad.clone(),
+                        options.clone(),
+                    );
+                    grads.register::<B, 4>(node.id, grad)
                 }
                 if let Some(node) = node_weight {
-                    grads.register::<B, 4>(node.id, backward.weights_grad)
+                    let grad = B::conv_transpose2d_weight_backward(x, weight, grad, options);
+                    grads.register::<B, 4>(node.id, grad)
                 }
             }
         }
@@ -540,20 +603,29 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                 let grad = grads.consume::<B, 5>(&ops.node);
 
                 let (x_state, weight_state, bias_state, options) = ops.state;
-                let x = checkpointer.retrieve_node_output(x_state);
-                let weight = checkpointer.retrieve_node_output(weight_state);
-                let bias = Some(checkpointer.retrieve_node_output(bias_state));
-
-                let backward = B::conv3d_backward(x, weight, bias, grad, options);
+                let x = checkpointer.retrieve_node_output::<B::FloatTensorPrimitive<5>>(x_state);
+                let weight =
+                    checkpointer.retrieve_node_output::<B::FloatTensorPrimitive<5>>(weight_state);
+                let bias =
+                    checkpointer.retrieve_node_output::<B::FloatTensorPrimitive<1>>(bias_state);
 
                 if let Some(node) = node_x {
-                    grads.register::<B, 5>(node.id, backward.x_grad)
+                    let grad = B::conv3d_x_backward(
+                        x.clone(),
+                        weight.clone(),
+                        grad.clone(),
+                        options.clone(),
+                    );
+                    grads.register::<B, 5>(node.id, grad)
                 }
                 if let Some(node) = node_weight {
-                    grads.register::<B, 5>(node.id, backward.weights_grad)
+                    let grad =
+                        B::conv3d_weight_backward(x.clone(), weight.clone(), grad.clone(), options);
+                    grads.register::<B, 5>(node.id, grad)
                 }
                 if let Some(node) = node_bias {
-                    grads.register::<B, 1>(node.id, backward.bias_grad.unwrap())
+                    let grad = B::conv3d_bias_backward(x, weight, bias, grad);
+                    grads.register::<B, 1>(node.id, grad)
                 }
             }
         }
@@ -571,16 +643,22 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                 let grad = grads.consume::<B, 5>(&ops.node);
 
                 let (x_state, weight_state, options) = ops.state;
-                let x = checkpointer.retrieve_node_output(x_state);
-                let weight = checkpointer.retrieve_node_output(weight_state);
-
-                let backward = B::conv3d_backward(x, weight, None, grad, options);
+                let x = checkpointer.retrieve_node_output::<B::FloatTensorPrimitive<5>>(x_state);
+                let weight =
+                    checkpointer.retrieve_node_output::<B::FloatTensorPrimitive<5>>(weight_state);
 
                 if let Some(node) = node_x {
-                    grads.register::<B, 5>(node.id, backward.x_grad)
+                    let grad = B::conv3d_x_backward(
+                        x.clone(),
+                        weight.clone(),
+                        grad.clone(),
+                        options.clone(),
+                    );
+                    grads.register::<B, 5>(node.id, grad)
                 }
                 if let Some(node) = node_weight {
-                    grads.register::<B, 5>(node.id, backward.weights_grad)
+                    let grad = B::conv3d_weight_backward(x, weight, grad, options);
+                    grads.register::<B, 5>(node.id, grad)
                 }
             }
         }
@@ -652,20 +730,32 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                 let grad = grads.consume::<B, 5>(&ops.node);
 
                 let (x_state, weight_state, bias_state, options) = ops.state;
-                let x = checkpointer.retrieve_node_output(x_state);
-                let weight = checkpointer.retrieve_node_output(weight_state);
-                let bias = Some(checkpointer.retrieve_node_output(bias_state));
-
-                let backward = B::conv_transpose3d_backward(x, weight, bias, grad, options);
+                let x = checkpointer.retrieve_node_output::<B::FloatTensorPrimitive<5>>(x_state);
+                let weight =
+                    checkpointer.retrieve_node_output::<B::FloatTensorPrimitive<5>>(weight_state);
+                let bias =
+                    checkpointer.retrieve_node_output::<B::FloatTensorPrimitive<1>>(bias_state);
 
                 if let Some(node) = node_x {
-                    grads.register::<B, 5>(node.id, backward.x_grad)
+                    let grad = B::conv_transpose3d_x_backward(
+                        weight.clone(),
+                        grad.clone(),
+                        options.clone(),
+                    );
+                    grads.register::<B, 5>(node.id, grad)
                 }
                 if let Some(node) = node_weight {
-                    grads.register::<B, 5>(node.id, backward.weights_grad)
+                    let grad = B::conv_transpose3d_weight_backward(
+                        x.clone(),
+                        weight,
+                        grad.clone(),
+                        options,
+                    );
+                    grads.register::<B, 5>(node.id, grad)
                 }
                 if let Some(node) = node_bias {
-                    grads.register::<B, 1>(node.id, backward.bias_grad.unwrap())
+                    let grad = B::conv_transpose3d_bias_backward(x, bias, grad);
+                    grads.register::<B, 1>(node.id, grad)
                 }
             }
         }
@@ -683,16 +773,21 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                 let grad = grads.consume::<B, 5>(&ops.node);
 
                 let (x_state, weight_state, options) = ops.state;
-                let x = checkpointer.retrieve_node_output(x_state);
-                let weight = checkpointer.retrieve_node_output(weight_state);
-
-                let backward = B::conv_transpose3d_backward(x, weight, None, grad, options);
+                let x = checkpointer.retrieve_node_output::<B::FloatTensorPrimitive<5>>(x_state);
+                let weight =
+                    checkpointer.retrieve_node_output::<B::FloatTensorPrimitive<5>>(weight_state);
 
                 if let Some(node) = node_x {
-                    grads.register::<B, 5>(node.id, backward.x_grad)
+                    let grad = B::conv_transpose3d_x_backward(
+                        weight.clone(),
+                        grad.clone(),
+                        options.clone(),
+                    );
+                    grads.register::<B, 5>(node.id, grad)
                 }
                 if let Some(node) = node_weight {
-                    grads.register::<B, 5>(node.id, backward.weights_grad)
+                    let grad = B::conv_transpose3d_weight_backward(x, weight, grad, options);
+                    grads.register::<B, 5>(node.id, grad)
                 }
             }
         }

--- a/crates/burn-tensor/src/tensor/ops/modules/base.rs
+++ b/crates/burn-tensor/src/tensor/ops/modules/base.rs
@@ -5,32 +5,6 @@ use crate::{
     Shape,
 };
 
-/// Gradient computed during the backward pass for each tensor used by [conv2d](ModuleOps::conv2d).
-#[derive(new)]
-pub struct Conv2dBackward<B: Backend> {
-    /// Gradient.
-    pub x_grad: FloatTensor<B, 4>,
-
-    /// Weights gradient.
-    pub weights_grad: FloatTensor<B, 4>,
-
-    /// Bias gradient.
-    pub bias_grad: Option<FloatTensor<B, 1>>,
-}
-
-/// Gradient computed during the backward pass for each tensor used by [conv3d](ModuleOps::conv3d).
-#[derive(new)]
-pub struct Conv3dBackward<B: Backend> {
-    /// Gradient.
-    pub x_grad: FloatTensor<B, 5>,
-
-    /// Weights gradient.
-    pub weights_grad: FloatTensor<B, 5>,
-
-    /// Bias gradient.
-    pub bias_grad: Option<FloatTensor<B, 1>>,
-}
-
 /// Gradient computed during the backward pass for each tensor used by [max_pool1d](ModuleOps::max_pool1d).
 #[derive(new)]
 pub struct MaxPool1dBackward<B: Backend> {
@@ -63,19 +37,6 @@ pub struct MaxPool2dWithIndices<B: Backend> {
 
     /// The indices tensor.
     pub indices: IntTensor<B, 4>,
-}
-
-/// Gradient computed during the backward pass for each tensor used by [conv1d](ModuleOps::conv1d).
-#[derive(new)]
-pub struct Conv1dBackward<B: Backend> {
-    /// Gradient.
-    pub x_grad: FloatTensor<B, 3>,
-
-    /// Weights gradient.
-    pub weights_grad: FloatTensor<B, 3>,
-
-    /// Bias gradient.
-    pub bias_grad: Option<FloatTensor<B, 1>>,
 }
 
 /// Convolution options.
@@ -221,15 +182,31 @@ pub trait ModuleOps<B: Backend> {
     ) -> FloatTensor<B, 3> {
         conv::conv1d_from_conv2d::<B>(x, weight, bias, options)
     }
-    /// Backward pass for the [conv1d](ModuleOps::conv1d) operation.
-    fn conv1d_backward(
+    /// Backward pass for the [conv1d](ModuleOps::conv1d) operation, returning the gradient for `x`.
+    fn conv1d_x_backward(
         x: FloatTensor<B, 3>,
         weight: FloatTensor<B, 3>,
-        bias: Option<FloatTensor<B, 1>>,
         output_grad: FloatTensor<B, 3>,
         options: ConvOptions<1>,
-    ) -> Conv1dBackward<B> {
-        conv::conv1d_backward(x, weight, bias, output_grad, options)
+    ) -> FloatTensor<B, 3> {
+        conv::conv1d_x_backward::<B>(x, weight, output_grad, options)
+    }
+    /// Backward pass for the [conv1d](ModuleOps::conv1d) operation, returning the gradient for `weight`.
+    fn conv1d_weight_backward(
+        x: FloatTensor<B, 3>,
+        weight: FloatTensor<B, 3>,
+        output_grad: FloatTensor<B, 3>,
+        options: ConvOptions<1>,
+    ) -> FloatTensor<B, 3> {
+        conv::conv1d_weight_backward::<B>(x, weight, output_grad, options)
+    }
+    /// Backward pass for the [conv1d](ModuleOps::conv1d) operation, returning the gradient for `bias`.
+    fn conv1d_bias_backward(
+        x: FloatTensor<B, 3>,
+        bias: FloatTensor<B, 1>,
+        output_grad: FloatTensor<B, 3>,
+    ) -> FloatTensor<B, 1> {
+        conv::conv1d_bias_backward::<B>(x, bias, output_grad)
     }
     /// Two dimensional convolution.
     ///
@@ -244,15 +221,32 @@ pub trait ModuleOps<B: Backend> {
         bias: Option<FloatTensor<B, 1>>,
         options: ConvOptions<2>,
     ) -> FloatTensor<B, 4>;
-    /// Backward pass for the [conv2d](ModuleOps::conv2d) operation.
-    fn conv2d_backward(
+    /// Backward pass for the [conv2d](ModuleOps::conv2d) operation, returning the gradient for `x`.
+    fn conv2d_x_backward(
         x: FloatTensor<B, 4>,
         weight: FloatTensor<B, 4>,
-        bias: Option<FloatTensor<B, 1>>,
         output_grad: FloatTensor<B, 4>,
         options: ConvOptions<2>,
-    ) -> Conv2dBackward<B> {
-        conv::conv2d_backward(x, weight, bias, output_grad, options)
+    ) -> FloatTensor<B, 4> {
+        conv::conv2d_x_backward::<B>(x, weight, output_grad, options)
+    }
+    /// Backward pass for the [conv2d](ModuleOps::conv2d) operation, returning the gradient for `weight`.
+    fn conv2d_weight_backward(
+        x: FloatTensor<B, 4>,
+        weight: FloatTensor<B, 4>,
+        output_grad: FloatTensor<B, 4>,
+        options: ConvOptions<2>,
+    ) -> FloatTensor<B, 4> {
+        conv::conv2d_weight_backward::<B>(x, weight, output_grad, options)
+    }
+    /// Backward pass for the [conv2d](ModuleOps::conv2d) operation, returning the gradient for `bias`.
+    fn conv2d_bias_backward(
+        x: FloatTensor<B, 4>,
+        weight: FloatTensor<B, 4>,
+        bias: FloatTensor<B, 1>,
+        output_grad: FloatTensor<B, 4>,
+    ) -> FloatTensor<B, 1> {
+        conv::conv2d_bias_backward::<B>(x, weight, bias, output_grad)
     }
     /// Three dimensional convolution.
     ///
@@ -267,15 +261,32 @@ pub trait ModuleOps<B: Backend> {
         bias: Option<FloatTensor<B, 1>>,
         options: ConvOptions<3>,
     ) -> FloatTensor<B, 5>;
-    /// Backward pass for the [conv3d](ModuleOps::conv3d) operation.
-    fn conv3d_backward(
+    /// Backward pass for the [conv3d](ModuleOps::conv3d) operation, returning the gradient for `x`.
+    fn conv3d_x_backward(
         x: FloatTensor<B, 5>,
         weight: FloatTensor<B, 5>,
-        bias: Option<FloatTensor<B, 1>>,
         output_grad: FloatTensor<B, 5>,
         options: ConvOptions<3>,
-    ) -> Conv3dBackward<B> {
-        conv::conv3d_backward(x, weight, bias, output_grad, options)
+    ) -> FloatTensor<B, 5> {
+        conv::conv3d_x_backward::<B>(x, weight, output_grad, options)
+    }
+    /// Backward pass for the [conv3d](ModuleOps::conv3d) operation, returning the gradient for `weight`.
+    fn conv3d_weight_backward(
+        x: FloatTensor<B, 5>,
+        weight: FloatTensor<B, 5>,
+        output_grad: FloatTensor<B, 5>,
+        options: ConvOptions<3>,
+    ) -> FloatTensor<B, 5> {
+        conv::conv3d_weight_backward::<B>(x, weight, output_grad, options)
+    }
+    /// Backward pass for the [conv3d](ModuleOps::conv3d) operation, returning the gradient for `bias`.
+    fn conv3d_bias_backward(
+        x: FloatTensor<B, 5>,
+        weight: FloatTensor<B, 5>,
+        bias: FloatTensor<B, 1>,
+        output_grad: FloatTensor<B, 5>,
+    ) -> FloatTensor<B, 1> {
+        conv::conv3d_bias_backward::<B>(x, weight, bias, output_grad)
     }
     /// One dimensional transposed convolution.
     ///
@@ -292,15 +303,30 @@ pub trait ModuleOps<B: Backend> {
     ) -> FloatTensor<B, 3> {
         conv::conv_transpose1d_from_conv_transpose2d::<B>(x, weight, bias, options)
     }
-    /// Backward pass for the [conv transpose 1d](ModuleOps::conv_transpose1d) operation.
-    fn conv_transpose1d_backward(
-        x: FloatTensor<B, 3>,
+    /// Backward pass for the [conv transpose 1d](ModuleOps::conv_transpose1d) operation, returning the gradient for `x`.
+    fn conv_transpose1d_x_backward(
         weight: FloatTensor<B, 3>,
-        bias: Option<FloatTensor<B, 1>>,
         output_grad: FloatTensor<B, 3>,
         options: ConvTransposeOptions<1>,
-    ) -> Conv1dBackward<B> {
-        conv::conv_transpose1d_backward(x, weight, bias, output_grad, options)
+    ) -> FloatTensor<B, 3> {
+        conv::conv_transpose1d_x_backward::<B>(weight, output_grad, options)
+    }
+    /// Backward pass for the [conv transpose 1d](ModuleOps::conv_transpose1d) operation, returning the gradient for `weight`.
+    fn conv_transpose1d_weight_backward(
+        x: FloatTensor<B, 3>,
+        weight: FloatTensor<B, 3>,
+        output_grad: FloatTensor<B, 3>,
+        options: ConvTransposeOptions<1>,
+    ) -> FloatTensor<B, 3> {
+        conv::conv_transpose1d_weight_backward::<B>(x, weight, output_grad, options)
+    }
+    /// Backward pass for the [conv transpose 1d](ModuleOps::conv_transpose1d) operation, returning the gradient for `bias`.
+    fn conv_transpose1d_bias_backward(
+        x: FloatTensor<B, 3>,
+        bias: FloatTensor<B, 1>,
+        output_grad: FloatTensor<B, 3>,
+    ) -> FloatTensor<B, 1> {
+        conv::conv_transpose1d_bias_backward::<B>(x, bias, output_grad)
     }
 
     /// Two dimensional transposed convolution.
@@ -316,15 +342,30 @@ pub trait ModuleOps<B: Backend> {
         bias: Option<FloatTensor<B, 1>>,
         options: ConvTransposeOptions<2>,
     ) -> FloatTensor<B, 4>;
-    /// Backward pass for the [conv transpose 2d](ModuleOps::conv_transpose2d) operation.
-    fn conv_transpose2d_backward(
-        x: FloatTensor<B, 4>,
+    /// Backward pass for the [conv transpose 2d](ModuleOps::conv_transpose2d) operation, returning the gradient for `x`.
+    fn conv_transpose2d_x_backward(
         weight: FloatTensor<B, 4>,
-        bias: Option<FloatTensor<B, 1>>,
         output_grad: FloatTensor<B, 4>,
         options: ConvTransposeOptions<2>,
-    ) -> Conv2dBackward<B> {
-        conv::conv_transpose2d_backward(x, weight, bias, output_grad, options)
+    ) -> FloatTensor<B, 4> {
+        conv::conv_transpose2d_x_backward::<B>(weight, output_grad, options)
+    }
+    /// Backward pass for the [conv transpose 2d](ModuleOps::conv_transpose2d) operation, returning the gradient for `weight`.
+    fn conv_transpose2d_weight_backward(
+        x: FloatTensor<B, 4>,
+        weight: FloatTensor<B, 4>,
+        output_grad: FloatTensor<B, 4>,
+        options: ConvTransposeOptions<2>,
+    ) -> FloatTensor<B, 4> {
+        conv::conv_transpose2d_weight_backward::<B>(x, weight, output_grad, options)
+    }
+    /// Backward pass for the [conv transpose 2d](ModuleOps::conv_transpose2d) operation, returning the gradient for `bias`.
+    fn conv_transpose2d_bias_backward(
+        x: FloatTensor<B, 4>,
+        bias: FloatTensor<B, 1>,
+        output_grad: FloatTensor<B, 4>,
+    ) -> FloatTensor<B, 1> {
+        conv::conv_transpose2d_bias_backward::<B>(x, bias, output_grad)
     }
 
     /// Three dimensional transposed convolution.
@@ -340,15 +381,30 @@ pub trait ModuleOps<B: Backend> {
         bias: Option<FloatTensor<B, 1>>,
         options: ConvTransposeOptions<3>,
     ) -> FloatTensor<B, 5>;
-    /// Backward pass for the [conv transpose 3d](ModuleOps::conv_transpose3d) operation.
-    fn conv_transpose3d_backward(
-        x: FloatTensor<B, 5>,
+    /// Backward pass for the [conv transpose 3d](ModuleOps::conv_transpose3d) operation, returning the gradient for `x`.
+    fn conv_transpose3d_x_backward(
         weight: FloatTensor<B, 5>,
-        bias: Option<FloatTensor<B, 1>>,
         output_grad: FloatTensor<B, 5>,
         options: ConvTransposeOptions<3>,
-    ) -> Conv3dBackward<B> {
-        conv::conv_transpose3d_backward(x, weight, bias, output_grad, options)
+    ) -> FloatTensor<B, 5> {
+        conv::conv_transpose3d_x_backward::<B>(weight, output_grad, options)
+    }
+    /// Backward pass for the [conv transpose 3d](ModuleOps::conv_transpose3d) operation, returning the gradient for `weight`.
+    fn conv_transpose3d_weight_backward(
+        x: FloatTensor<B, 5>,
+        weight: FloatTensor<B, 5>,
+        output_grad: FloatTensor<B, 5>,
+        options: ConvTransposeOptions<3>,
+    ) -> FloatTensor<B, 5> {
+        conv::conv_transpose3d_weight_backward::<B>(x, weight, output_grad, options)
+    }
+    /// Backward pass for the [conv transpose 3d](ModuleOps::conv_transpose3d) operation, returning the gradient for `bias`.
+    fn conv_transpose3d_bias_backward(
+        x: FloatTensor<B, 5>,
+        bias: FloatTensor<B, 1>,
+        output_grad: FloatTensor<B, 5>,
+    ) -> FloatTensor<B, 1> {
+        conv::conv_transpose3d_bias_backward::<B>(x, bias, output_grad)
     }
 
     /// Four-dimensional unfolding.


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Not found.

### Changes

In crate `burn-tensor`, I split each of `conv[1-3]d_backward` and their **transposed** variants into three functions suffixed with `*_x_backward`, `*_weight_backward`, and `*_bias_backward`.

In crate `burn-autodiff`, I changed the backward implementations of conv ops to allow gradients being computed **if required**.

The public APIs appear to remain unchanged, since `Autodiff` backend (decorator) hides the changes.

### Testing

All tests are passed on Apple M2 Pro. I did not add any new test because the original tests should be adequate.