### PR TITLE
Add fusion quantization ops

### DIFF
--- a/crates/burn-fusion/src/client/base.rs
+++ b/crates/burn-fusion/src/client/base.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 
 use crate::{
     stream::{execution::Operation, StreamId},
-    FusionBackend, FusionDevice, FusionHandle, FusionRuntime, FusionTensor,
+    FusionBackend, FusionDevice, FusionHandle, FusionRuntime, FusionTensor, QFusionTensor,
 };
 use burn_tensor::{
     repr::{OperationDescription, QuantizedTensorDescription, TensorDescription, TensorId},
@@ -91,6 +91,15 @@ where
         client: Self,
         stream: StreamId,
     ) -> FusionTensor<R>
+    where
+        B: FusionBackend<FusionRuntime = R>;
+    /// Change the client of the given quantized tensor.
+    fn change_client_quantized<B>(
+        &self,
+        tensor: QuantizedTensorDescription,
+        client: Self,
+        streams: Vec<StreamId>,
+    ) -> QFusionTensor<R>
     where
         B: FusionBackend<FusionRuntime = R>;
     /// Drop the tensor with the given [tensor id](TensorId).

--- a/crates/burn-fusion/src/client/base.rs
+++ b/crates/burn-fusion/src/client/base.rs
@@ -5,7 +5,7 @@ use crate::{
     FusionBackend, FusionDevice, FusionHandle, FusionRuntime, FusionTensor,
 };
 use burn_tensor::{
-    repr::{OperationDescription, TensorDescription, TensorId},
+    repr::{OperationDescription, QuantizedTensorDescription, TensorDescription, TensorId},
     DType, TensorData,
 };
 
@@ -55,6 +55,14 @@ where
         &self,
         tensor: TensorDescription,
         stream: StreamId,
+    ) -> impl Future<Output = TensorData> + Send
+    where
+        B: FusionBackend<FusionRuntime = R>;
+    /// Read the values contained by a quantized tensor.
+    fn read_tensor_quantized<B>(
+        &self,
+        tensor: QuantizedTensorDescription,
+        streams: Vec<StreamId>,
     ) -> impl Future<Output = TensorData> + Send
     where
         B: FusionBackend<FusionRuntime = R>;

--- a/crates/burn-fusion/src/client/mutex.rs
+++ b/crates/burn-fusion/src/client/mutex.rs
@@ -211,7 +211,7 @@ where
         core::mem::drop(server_other);
         core::mem::drop(server_current);
 
-        // Expected order [qtensor, scale, <offset>]
+        // NOTE: the expected order is known [qtensor, scale, <offset>]
         let offset = tensor.qparams.offset.map(|desc| {
             FusionTensor::new(
                 ids.pop().unwrap(),

--- a/crates/burn-fusion/src/client/mutex.rs
+++ b/crates/burn-fusion/src/client/mutex.rs
@@ -1,10 +1,11 @@
 use super::FusionClient;
 use crate::{
     stream::{execution::Operation, StreamId},
-    FusionBackend, FusionDevice, FusionHandle, FusionRuntime, FusionServer, FusionTensor,
+    FusionBackend, FusionDevice, FusionHandle, FusionQuantizationParameters, FusionRuntime,
+    FusionServer, FusionTensor, QFusionTensor,
 };
 use burn_tensor::{
-    repr::{OperationDescription, TensorDescription, TensorId},
+    repr::{OperationDescription, QuantizedTensorDescription, TensorDescription, TensorId},
     DType,
 };
 use spin::Mutex;
@@ -187,6 +188,59 @@ where
         core::mem::drop(server_current);
 
         FusionTensor::new(id, tensor.shape, tensor.dtype, client, StreamId::current())
+    }
+
+    fn change_client_quantized<B>(
+        &self,
+        tensor: QuantizedTensorDescription,
+        client: Self,
+        streams: Vec<StreamId>,
+    ) -> QFusionTensor<R>
+    where
+        B: FusionBackend<FusionRuntime = R>,
+    {
+        let mut server_other = client.server.lock();
+        let mut server_current = self.server.lock();
+        for stream in streams {
+            server_current.drain_stream(stream);
+        }
+
+        let mut ids =
+            server_current.change_server_quantized::<B>(&tensor, &client.device, &mut server_other);
+
+        core::mem::drop(server_other);
+        core::mem::drop(server_current);
+
+        // Expected order [qtensor, scale, <offset>]
+        let offset = tensor.qparams.offset.map(|desc| {
+            FusionTensor::new(
+                ids.pop().unwrap(),
+                desc.shape,
+                desc.dtype,
+                client.clone(),
+                StreamId::current(),
+            )
+        });
+        let scale = FusionTensor::new(
+            ids.pop().unwrap(),
+            tensor.qparams.scale.shape,
+            tensor.qparams.scale.dtype,
+            client.clone(),
+            StreamId::current(),
+        );
+        let qtensor = FusionTensor::new(
+            ids.pop().unwrap(),
+            tensor.tensor.shape,
+            tensor.tensor.dtype,
+            client,
+            StreamId::current(),
+        );
+
+        QFusionTensor {
+            qtensor,
+            scheme: tensor.scheme,
+            qparams: FusionQuantizationParameters { scale, offset },
+        }
     }
 
     fn register_orphan(&self, id: &TensorId) {

--- a/crates/burn-fusion/src/client/mutex.rs
+++ b/crates/burn-fusion/src/client/mutex.rs
@@ -111,6 +111,20 @@ where
         self.server.lock().read_bool::<B>(tensor, stream).await
     }
 
+    async fn read_tensor_quantized<B>(
+        &self,
+        tensor: QuantizedTensorDescription,
+        streams: Vec<StreamId>,
+    ) -> burn_tensor::TensorData
+    where
+        B: FusionBackend<FusionRuntime = R>,
+    {
+        self.server
+            .lock()
+            .read_quantized::<B>(tensor, streams)
+            .await
+    }
+
     fn change_client_float<B>(
         &self,
         tensor: TensorDescription,

--- a/crates/burn-fusion/src/ops/qtensor.rs
+++ b/crates/burn-fusion/src/ops/qtensor.rs
@@ -1,35 +1,212 @@
-use std::ops::Range;
+use std::{marker::PhantomData, ops::Range};
 
 use burn_tensor::{
-    ops::{FloatTensor, IntTensor, QTensorOps, QuantizedTensor},
-    quantization::{QuantizationParametersPrimitive, QuantizationScheme},
-    Device, Shape, TensorData,
+    ops::{FloatElem, FloatTensor, IntTensor, QTensorOps, QuantizedTensor},
+    quantization::{QuantizationParametersPrimitive, QuantizationScheme, QuantizationStrategy},
+    repr::{
+        DequantizeOperationDescription, FloatOperationDescription, HandleContainer,
+        OperationDescription, QuantizationParametersDescription, QuantizeOperationDescription,
+    },
+    DType, Device, Element, Shape, TensorData,
 };
 
-use crate::{client::FusionClient, Fusion, FusionBackend};
+use crate::{
+    client::FusionClient,
+    get_client,
+    stream::{execution::Operation, StreamId},
+    Fusion, FusionBackend, FusionQuantizationParameters, QFusionTensor,
+};
 
 impl<B: FusionBackend> QTensorOps<Self> for Fusion<B> {
-    fn q_from_data(_data: TensorData, _device: &Device<Self>) -> QuantizedTensor<Self> {
-        unimplemented!()
+    fn q_from_data(data: TensorData, device: &Device<Self>) -> QuantizedTensor<Self> {
+        match data.dtype.clone() {
+            DType::QFloat(strategy) => {
+                let client = get_client::<B>(device);
+                let tensor = B::q_from_data(data, device);
+                let shape = B::q_shape(&tensor);
+
+                let mut handles = B::quantized_tensor_handle(tensor);
+                let qparams = match strategy {
+                    QuantizationStrategy::PerTensorAffineInt8(_) => {
+                        let num_handles = handles.len();
+                        assert_eq!(
+                            num_handles, 3,
+                            "Expected 3 handles for quantized tensor, got {num_handles}"
+                        );
+                        let offset = handles.pop().unwrap();
+                        let scale = handles.pop().unwrap();
+                        FusionQuantizationParameters {
+                            scale: client.register_tensor(
+                                scale,
+                                vec![1],
+                                StreamId::current(),
+                                B::FloatElem::dtype(),
+                            ),
+                            offset: Some(client.register_tensor(
+                                offset,
+                                vec![1],
+                                StreamId::current(),
+                                B::IntElem::dtype(),
+                            )),
+                        }
+                    }
+                    QuantizationStrategy::PerTensorSymmetricInt8(_) => {
+                        let num_handles = handles.len();
+                        assert_eq!(
+                            num_handles, 2,
+                            "Expected 2 handles for quantized tensor, got {num_handles}"
+                        );
+                        let scale = handles.pop().unwrap();
+                        FusionQuantizationParameters {
+                            scale: client.register_tensor(
+                                scale,
+                                vec![1],
+                                StreamId::current(),
+                                B::FloatElem::dtype(),
+                            ),
+                            offset: None,
+                        }
+                    }
+                };
+                // TODO: B::QuantizedElem::dtype()?
+                let qtensor = client.register_tensor(
+                    handles.pop().unwrap(),
+                    shape.dims,
+                    StreamId::current(),
+                    u32::dtype(),
+                );
+                QFusionTensor {
+                    qtensor,
+                    qparams,
+                    scheme: strategy.scheme(),
+                }
+            }
+            _ => panic!(
+                "Invalid dtype (expected DType::QFloat, got {:?})",
+                data.dtype
+            ),
+        }
     }
 
     fn quantize(
-        _tensor: FloatTensor<Self>,
-        _scheme: &QuantizationScheme,
-        _qparams: QuantizationParametersPrimitive<Self>,
+        tensor: FloatTensor<Self>,
+        scheme: &QuantizationScheme,
+        qparams: QuantizationParametersPrimitive<Self>,
     ) -> QuantizedTensor<Self> {
-        unimplemented!()
+        #[derive(new)]
+        struct QuantizeOp<B: FusionBackend> {
+            desc: QuantizeOperationDescription,
+            _b: PhantomData<B>,
+        }
+
+        impl<B: FusionBackend> Operation<B::FusionRuntime> for QuantizeOp<B> {
+            fn execute(self: Box<Self>, handles: &mut HandleContainer<B::Handle>) {
+                let tensor = handles.get_float_tensor::<B>(&self.desc.tensor);
+                let scale = handles.get_float_tensor::<B>(&self.desc.qparams.scale);
+                let offset = match &self.desc.qparams.offset {
+                    Some(offset) => Some(handles.get_int_tensor::<B>(offset)),
+                    None => None,
+                };
+
+                let qparams = QuantizationParametersPrimitive { scale, offset };
+                let output = B::quantize(tensor, &self.desc.scheme, qparams);
+                if let Some(offset) = &self.desc.qparams.offset {
+                    handles.register_quantized_tensor::<B>(
+                        &[&self.desc.out.id, &self.desc.qparams.scale.id, &offset.id],
+                        output,
+                    );
+                } else {
+                    handles.register_quantized_tensor::<B>(
+                        &[&self.desc.out.id, &self.desc.qparams.scale.id],
+                        output,
+                    );
+                }
+            }
+        }
+
+        let shape: Vec<usize> = tensor.shape.clone();
+        // TODO: B::QuantizedElem::dtype()?
+        let out = tensor.client.tensor_uninitialized(shape, u32::dtype());
+
+        let streams = if let Some(offset) = &qparams.offset {
+            vec![tensor.stream, qparams.scale.stream, offset.stream]
+        } else {
+            vec![tensor.stream, qparams.scale.stream]
+        };
+
+        let desc = QuantizeOperationDescription {
+            tensor: tensor.into_description(),
+            qparams: QuantizationParametersDescription {
+                scale: qparams.scale.clone().into_description(),
+                offset: qparams.offset.clone().map(|x| x.into_description()),
+            },
+            scheme: scheme.clone(),
+            out: out.to_description_out(),
+        };
+
+        out.client.register(
+            streams,
+            OperationDescription::Float(
+                FloatElem::<Self>::dtype(),
+                FloatOperationDescription::Quantize(desc.clone()),
+            ),
+            QuantizeOp::<B>::new(desc),
+        );
+
+        QFusionTensor {
+            qtensor: out,
+            scheme: scheme.clone(),
+            qparams: qparams.into(),
+        }
     }
 
-    fn quantize_dynamic(
-        _tensor: FloatTensor<Self>,
-        _scheme: &QuantizationScheme,
-    ) -> QuantizedTensor<Self> {
-        unimplemented!()
-    }
+    fn dequantize(tensor: QuantizedTensor<Self>) -> FloatTensor<Self> {
+        #[derive(new)]
+        struct DequantizeOp<B: FusionBackend> {
+            desc: DequantizeOperationDescription,
+            _b: PhantomData<B>,
+        }
 
-    fn dequantize(_tensor: QuantizedTensor<Self>) -> FloatTensor<Self> {
-        unimplemented!()
+        impl<B: FusionBackend> Operation<B::FusionRuntime> for DequantizeOp<B> {
+            fn execute(self: Box<Self>, handles: &mut HandleContainer<B::Handle>) {
+                let tensor = handles.get_quantized_tensor::<B>(&self.desc.qtensor);
+
+                let output = B::dequantize(tensor);
+                handles.register_float_tensor::<B>(&self.desc.out.id, output);
+            }
+        }
+
+        let shape: Vec<usize> = tensor.qtensor.shape.clone();
+        let out = tensor
+            .qtensor
+            .client
+            .tensor_uninitialized(shape, B::FloatElem::dtype());
+
+        let streams = if let Some(offset) = &tensor.qparams.offset {
+            vec![
+                tensor.qtensor.stream,
+                tensor.qparams.scale.stream,
+                offset.stream,
+            ]
+        } else {
+            vec![tensor.qtensor.stream, tensor.qparams.scale.stream]
+        };
+
+        let desc = DequantizeOperationDescription {
+            qtensor: tensor.into_description(),
+            out: out.to_description_out(),
+        };
+
+        out.client.register(
+            streams,
+            OperationDescription::Float(
+                FloatElem::<Self>::dtype(),
+                FloatOperationDescription::Dequantize(desc.clone()),
+            ),
+            DequantizeOp::<B>::new(desc),
+        );
+
+        out
     }
 
     fn q_shape(tensor: &QuantizedTensor<Self>) -> Shape {
@@ -51,8 +228,8 @@ impl<B: FusionBackend> QTensorOps<Self> for Fusion<B> {
         unimplemented!()
     }
 
-    async fn q_into_data(_tensor: QuantizedTensor<Self>) -> TensorData {
-        unimplemented!()
+    async fn q_into_data(tensor: QuantizedTensor<Self>) -> TensorData {
+        tensor.into_data::<B>().await
     }
 
     fn q_swap_dims(

--- a/crates/burn-fusion/src/ops/qtensor.rs
+++ b/crates/burn-fusion/src/ops/qtensor.rs
@@ -69,6 +69,8 @@ impl<B: FusionBackend> QTensorOps<Self> for Fusion<B> {
                     }
                 };
                 // TODO: B::QuantizedElem::dtype()?
+                // Right now we know that the dtype is u32 for jit backends, but we could possibly
+                // make this more flexible in the future
                 let qtensor = client.register_tensor(
                     handles.pop().unwrap(),
                     shape.dims,
@@ -126,6 +128,8 @@ impl<B: FusionBackend> QTensorOps<Self> for Fusion<B> {
 
         let shape: Vec<usize> = tensor.shape.clone();
         // TODO: B::QuantizedElem::dtype()?
+        // Right now we know that the dtype is u32 for jit backends, but we could possibly
+        // make this more flexible in the future
         let out = tensor.client.tensor_uninitialized(shape, u32::dtype());
 
         let streams = if let Some(offset) = &qparams.offset {

--- a/crates/burn-fusion/src/stream/context.rs
+++ b/crates/burn-fusion/src/stream/context.rs
@@ -487,6 +487,39 @@ impl RelativeOpsScalar<f32> for FloatOperationDescription {
                     out: desc.out.to_relative(converter),
                 })
             }
+            FloatOperationDescription::Quantize(desc) => {
+                FloatOperationDescription::Quantize(QuantizeOperationDescription {
+                    tensor: desc.tensor.to_relative(converter),
+                    qparams: QuantizationParametersDescription {
+                        scale: desc.qparams.scale.to_relative(converter),
+                        offset: desc
+                            .qparams
+                            .offset
+                            .as_ref()
+                            .map(|x| x.to_relative(converter)),
+                    },
+                    scheme: desc.scheme.clone(),
+                    out: desc.out.to_relative(converter),
+                })
+            }
+            FloatOperationDescription::Dequantize(desc) => {
+                FloatOperationDescription::Dequantize(DequantizeOperationDescription {
+                    qtensor: QuantizedTensorDescription {
+                        tensor: desc.qtensor.tensor.to_relative(converter),
+                        qparams: QuantizationParametersDescription {
+                            scale: desc.qtensor.qparams.scale.to_relative(converter),
+                            offset: desc
+                                .qtensor
+                                .qparams
+                                .offset
+                                .as_ref()
+                                .map(|x| x.to_relative(converter)),
+                        },
+                        scheme: desc.qtensor.scheme.clone(),
+                    },
+                    out: desc.out.to_relative(converter),
+                })
+            }
         }
     }
 }

--- a/crates/burn-jit/src/fusion/base.rs
+++ b/crates/burn-jit/src/fusion/base.rs
@@ -82,6 +82,7 @@ impl<R: JitRuntime, F: FloatElement, I: IntElement> ReprBackend for JitBackend<R
         scheme: QuantizationScheme,
     ) -> burn_tensor::ops::QuantizedTensor<Self> {
         match handles.len() {
+            // NOTE: the order of the handles is known [qtensor, scale, <offset>]
             3 => {
                 let mut handles = handles;
                 let offset = handles.pop().unwrap();

--- a/crates/burn-jit/src/ops/qtensor.rs
+++ b/crates/burn-jit/src/ops/qtensor.rs
@@ -103,6 +103,9 @@ where
     fn q_to_device(tensor: QuantizedTensor<Self>, device: &Device<Self>) -> QuantizedTensor<Self> {
         let mut tensor = tensor;
         tensor.qtensor = super::to_device(tensor.qtensor, device);
+        tensor.qparams.scale = super::to_device(tensor.qparams.scale, device);
+        tensor.qparams.offset = tensor.qparams.offset.map(|x| super::to_device(x, device));
+
         tensor
     }
 

--- a/crates/burn-jit/src/tests/mod.rs
+++ b/crates/burn-jit/src/tests/mod.rs
@@ -133,5 +133,13 @@ macro_rules! testgen_jit_fusion {
 
         burn_tensor::testgen_all!();
         burn_autodiff::testgen_all!();
+
+        // Not all ops are implemented for quantization yet, notably missing:
+        // `q_swap_dims`, `q_permute`, `q_flip`, `q_gather`, `q_select`, `q_slice`, `q_expand`
+        // burn_tensor::testgen_quantization!();
+        // test quantization
+        burn_tensor::testgen_calibration!();
+        burn_tensor::testgen_scheme!();
+        burn_tensor::testgen_quantize!();
     };
 }

--- a/crates/burn-tensor/src/repr/backend.rs
+++ b/crates/burn-tensor/src/repr/backend.rs
@@ -1,8 +1,18 @@
 use crate::{
     backend::Backend,
-    ops::{BoolTensor, FloatTensor, IntTensor},
+    ops::{BoolTensor, FloatTensor, IntTensor, QuantizedTensor},
+    quantization::QuantizationScheme,
     Shape,
 };
+use alloc::vec::Vec;
+
+/// A tensor representation containing a reference to a tensor resource with a given shape.
+pub struct TensorHandle<H> {
+    /// The type that can be used to point to a tensor of any kind.
+    pub handle: H,
+    /// The shape associated to the tensor.
+    pub shape: Shape,
+}
 
 /// Backend extension trait that allows an existing [backend](Backend) to use the Burn tensor representation
 /// for compilation purpose or other...
@@ -11,11 +21,16 @@ pub trait ReprBackend: Backend {
     type Handle: Sync + Send + Clone;
 
     /// Convert a [handle](ReprBackend::Handle) to a [float tensor](Backend::FloatTensorPrimitive).
-    fn float_tensor(handle: Self::Handle, shape: Shape) -> FloatTensor<Self>;
+    fn float_tensor(handle: TensorHandle<Self::Handle>) -> FloatTensor<Self>;
     /// Convert a [handle](ReprBackend::Handle) to an [int tensor](Backend::IntTensorPrimitive).
-    fn int_tensor(handle: Self::Handle, shape: Shape) -> IntTensor<Self>;
+    fn int_tensor(handle: TensorHandle<Self::Handle>) -> IntTensor<Self>;
     /// Convert a [handle](ReprBackend::Handle) to a [bool tensor](Backend::BoolTensorPrimitive).
-    fn bool_tensor(handle: Self::Handle, shape: Shape) -> BoolTensor<Self>;
+    fn bool_tensor(handle: TensorHandle<Self::Handle>) -> BoolTensor<Self>;
+    /// Convert a [handle](ReprBackend::Handle) to a [quantized tensor](Backend::QuantizedTensorPrimitive).
+    fn quantized_tensor(
+        handles: Vec<TensorHandle<Self::Handle>>,
+        scheme: QuantizationScheme,
+    ) -> QuantizedTensor<Self>;
 
     /// Convert a [float tensor](Backend::FloatTensorPrimitive) to a [handle](ReprBackend::Handle).
     fn float_tensor_handle(tensor: FloatTensor<Self>) -> Self::Handle;
@@ -23,4 +38,7 @@ pub trait ReprBackend: Backend {
     fn int_tensor_handle(tensor: IntTensor<Self>) -> Self::Handle;
     /// Convert a [bool tensor](Backend::BoolTensorPrimitive) to a [handle](ReprBackend::Handle).
     fn bool_tensor_handle(tensor: BoolTensor<Self>) -> Self::Handle;
+    /// Convert a [quantized tensor](Backend::QuantizedTensorPrimitive) to a [handle](ReprBackend::Handle).
+    /// A quantized tensor has multiple handles for the tensor itself and the quantization parameters.
+    fn quantized_tensor_handle(tensor: QuantizedTensor<Self>) -> Vec<Self::Handle>;
 }

--- a/crates/burn-tensor/src/repr/mod.rs
+++ b/crates/burn-tensor/src/repr/mod.rs
@@ -1,9 +1,11 @@
 mod backend;
 mod handle;
 mod operation;
+mod quantization;
 mod tensor;
 
 pub use backend::*;
 pub use handle::*;
 pub use operation::*;
+pub use quantization::*;
 pub use tensor::*;

--- a/crates/burn-tensor/src/repr/operation.rs
+++ b/crates/burn-tensor/src/repr/operation.rs
@@ -850,7 +850,6 @@ pub struct QuantizeOperationDescription {
 #[allow(missing_docs)]
 pub struct DequantizeOperationDescription {
     pub qtensor: QuantizedTensorDescription,
-    // pub scheme: QuantizationScheme,
     pub out: TensorDescription,
 }
 

--- a/crates/burn-tensor/src/repr/operation.rs
+++ b/crates/burn-tensor/src/repr/operation.rs
@@ -5,9 +5,12 @@ use crate::{
     ops::{
         ConvOptions, ConvTransposeOptions, DeformConvOptions, InterpolateMode, InterpolateOptions,
     },
+    quantization::QuantizationScheme,
     repr::tensor::TensorDescription,
     DType, Distribution, Element,
 };
+
+use super::{QuantizationParametersDescription, QuantizedTensorDescription};
 
 /// Describe all tensor operations possible.
 #[derive(Clone, Debug, Hash, PartialEq, Serialize, Deserialize)]
@@ -61,6 +64,10 @@ pub enum FloatOperationDescription {
     Random(RandomOperationDescription),
     /// Operation corresponding to [recip](crate::ops::FloatTensorOps::float_recip).
     Recip(UnaryOperationDescription),
+    /// Operation corresponding to [quantize](crate::ops::QTensorOps::quantize).
+    Quantize(QuantizeOperationDescription),
+    /// Operation corresponding to [dequantize](crate::ops::QTensorOps::dequantize).
+    Dequantize(DequantizeOperationDescription),
 }
 
 /// Operation description specific to module.
@@ -830,6 +837,23 @@ pub struct ConvTranspose3dOptionsDescription {
     pub groups: usize,
 }
 
+#[derive(Clone, Debug, Hash, PartialEq, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub struct QuantizeOperationDescription {
+    pub tensor: TensorDescription,
+    pub qparams: QuantizationParametersDescription,
+    pub scheme: QuantizationScheme,
+    pub out: TensorDescription,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub struct DequantizeOperationDescription {
+    pub qtensor: QuantizedTensorDescription,
+    // pub scheme: QuantizationScheme,
+    pub out: TensorDescription,
+}
+
 impl From<ConvOptions<1>> for Conv1dOptionsDescription {
     fn from(value: ConvOptions<1>) -> Self {
         Self {
@@ -1421,6 +1445,25 @@ impl FloatOperationDescription {
             FloatOperationDescription::Sin(desc) => vec![&desc.input, &desc.out],
             FloatOperationDescription::Tanh(desc) => vec![&desc.input, &desc.out],
             FloatOperationDescription::IntoInt(desc) => vec![&desc.input, &desc.out],
+            FloatOperationDescription::Quantize(desc) => {
+                if let Some(offset) = &desc.qparams.offset {
+                    vec![&desc.tensor, &desc.qparams.scale, &offset, &desc.out]
+                } else {
+                    vec![&desc.tensor, &desc.qparams.scale, &desc.out]
+                }
+            }
+            FloatOperationDescription::Dequantize(desc) => {
+                if let Some(offset) = &desc.qtensor.qparams.offset {
+                    vec![
+                        &desc.qtensor.tensor,
+                        &desc.qtensor.qparams.scale,
+                        &offset,
+                        &desc.out,
+                    ]
+                } else {
+                    vec![&desc.qtensor.tensor, &desc.qtensor.qparams.scale, &desc.out]
+                }
+            }
         }
     }
 }

--- a/crates/burn-tensor/src/repr/quantization.rs
+++ b/crates/burn-tensor/src/repr/quantization.rs
@@ -1,0 +1,25 @@
+use serde::{Deserialize, Serialize};
+
+use crate::quantization::QuantizationScheme;
+
+use super::TensorDescription;
+
+/// A quantized tensor description represents a snapshot of a quantized tensor when it was used.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QuantizedTensorDescription {
+    /// The quantized tensor.
+    pub tensor: TensorDescription,
+    /// The quantization parameters.
+    pub qparams: QuantizationParametersDescription,
+    /// The quantization scheme
+    pub scheme: QuantizationScheme,
+}
+
+/// Quantization parameters description.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QuantizationParametersDescription {
+    /// The scaling factor.
+    pub scale: TensorDescription,
+    /// The zero-point offset.
+    pub offset: Option<TensorDescription>,
+}

--- a/crates/burn-tensor/src/tensor/quantization/scheme.rs
+++ b/crates/burn-tensor/src/tensor/quantization/scheme.rs
@@ -1,16 +1,18 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{backend::Backend, Tensor, TensorPrimitive};
 
 use super::{CalibrationRange, QuantizationParameters, QuantizationParametersPrimitive};
 
 /// Quantization data type.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub enum QuantizationType {
     /// 8-bit signed integer.
     QInt8,
 }
 
 /// Quantization scheme.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub enum QuantizationScheme {
     /// Per-tensor affine/asymmetric quantization.
     PerTensorAffine(QuantizationType),


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `run-checks all` script has been executed.

### Related Issues/PRs

Following #2275

### Changes

Added `quantize`, `dequantize`, `q_from_data`, `q_into_data` and `q_to_device` implementations for fusion backend.

### Testing

Unit tests
