### PR TITLE
Fix burn book links

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ functionalities of a backend implementation to suit your personal modeling requi
 
 This versatility is advantageous in numerous ways, such as supporting custom operations like flash
 attention or manually writing your own kernel for a specific backend to enhance performance. See
-[this section](https://burn.dev/book/advanced/backend-extension/index.html) in the Burn Book 🔥 for
+[this section](https://burn.dev/burn-book/advanced/backend-extension/index.html) in the Burn Book 🔥 for
 more details.
 
 </details>
@@ -244,7 +244,7 @@ you have written in another framework like TensorFlow or PyTorch to Burn to bene
 advantages our framework offers.
 
 Our ONNX support is further described in
-[this section of the Burn Book 🔥](https://burn.dev/book/import/onnx-model.html).
+[this section of the Burn Book 🔥](https://burn.dev/burn-book/import/onnx-model.html).
 
 > **Note**: This crate is in active development and currently supports a
 > [limited set of ONNX operators](./crates/burn-import/SUPPORTED-ONNX-OPS.md).
@@ -259,7 +259,7 @@ Importing PyTorch Models 🚚
 
 Support for loading of PyTorch model weights into Burn’s native model architecture, ensuring
 seamless integration. See
-[Burn Book 🔥 section on importing PyTorch](https://burn.dev/book/import/pytorch-model.html)
+[Burn Book 🔥 section on importing PyTorch](https://burn.dev/burn-book/import/pytorch-model.html)
 
 </details>
 
@@ -480,7 +480,7 @@ The Burn Book 🔥
 
 To begin working effectively with Burn, it is crucial to understand its key components and
 philosophy. This is why we highly recommend new users to read the first sections of
-[The Burn Book 🔥](https://burn.dev/book/). It provides detailed examples and explanations covering
+[The Burn Book 🔥](https://burn.dev/burn-book/). It provides detailed examples and explanations covering
 every facet of the framework, including building blocks like tensors, modules, and optimizers, all
 the way to advanced usage, like coding your own GPU kernels.
 
@@ -526,7 +526,7 @@ impl<B: Backend> PositionWiseFeedForward<B> {
 We have a somewhat large amount of [examples](./examples) in the repository that shows how to use
 the framework in different scenarios.
 
-Following [the book](https://burn.dev/book/):
+Following [the book](https://burn.dev/burn-book/):
 
 - [Basic Workflow](./examples/guide) : Creates a custom CNN `Module` to train on the MNIST dataset
   and use for inference.

--- a/contributor-book/src/guides/onnx-to-burn-conversion-tool.md
+++ b/contributor-book/src/guides/onnx-to-burn-conversion-tool.md
@@ -6,7 +6,7 @@ learning framework written in Rust. It converts both ONNX models to Rust source 
 weights to Burn state files.
 
 For an introduction to ONNX import in Burn, see
-[this section of the Burn book](https://burn.dev/book/import/onnx-model.html).
+[this section of the Burn book](https://burn.dev/burn-book/import/onnx-model.html).
 
 ## Table of Contents
 

--- a/contributor-book/src/overview.md
+++ b/contributor-book/src/overview.md
@@ -7,7 +7,7 @@ provide some detailed guidance on how to contribute to the project.
 
 We have crafted some sections for you:
 
-- [Getting Started](./getting-started): Much like the [Burn Book](https://burn.dev/book/) which
+- [Getting Started](./getting-started): Much like the [Burn Book](https://burn.dev/burn-book/) which
   targets users, we'll start with the fundamentals, guiding you through tasks like setting up the
   development environment, running tests, and what you should check prior to each commit.
 

--- a/examples/guide/README.md
+++ b/examples/guide/README.md
@@ -1,6 +1,6 @@
 # Basic Workflow: From Training to Inference
 
-This example corresponds to the [book's guide](https://burn.dev/book/basic-workflow/).
+This example corresponds to the [book's guide](https://burn.dev/burn-book/basic-workflow/).
 
 ## Example Usage
 


### PR DESCRIPTION
The burn book links were broken now that it points to `burn.dev/burn-book`.

Fixed 'em 🙂 