### PR TITLE
Infer ONNX conv output shapes

### DIFF
--- a/crates/onnx-ir/src/dim_inference.rs
+++ b/crates/onnx-ir/src/dim_inference.rs
@@ -573,10 +573,6 @@ fn flatten_update_outputs(node: &mut Node) {
 }
 
 /// Calculates the output shape of a convolution operator
-///
-/// Inputs:
-/// * `x_shape` - input tensor shape (`X` in onnx parlance)
-/// * `w_shape` - weights tensor shape (`W` in onnx)
 fn calculate_conv_output_shape(
     x_shape: &Shape,
     w_shape: &Shape,
@@ -637,7 +633,7 @@ fn calculate_conv_output_shape(
     Some(out_shape)
 }
 
-/// Infers the shape of a Conv1d node and replaces the shape of the output tensor.
+/// Infers the shape of a Conv1d or Conv2d node and replaces the shape of the output tensor.
 fn conv_update_outputs(node: &mut Node) {
     let input_ty = node.inputs[0].ty.get_tensor_type();
     let weights_ty = node.inputs[1].ty.get_tensor_type();

--- a/crates/onnx-ir/src/ir.rs
+++ b/crates/onnx-ir/src/ir.rs
@@ -135,6 +135,9 @@ impl ArgType {
     pub fn is_tensor(&self) -> bool {
         matches!(self, Self::Tensor(_))
     }
+    pub fn is_shape(&self) -> bool {
+        matches!(self, Self::Shape(_))
+    }
 
     /// returns the rank (dimension) of the Arg
     pub fn rank(&self) -> usize {
@@ -151,6 +154,15 @@ impl ArgType {
             ArgType::Scalar(s) => s,
             ArgType::Shape(_) => panic!("ArgType::Shape has no ElementType"),
             ArgType::Tensor(t) => &t.elem_type,
+        }
+    }
+
+    /// returns the contained [`TensorType`] if this `ArgType` is a `Tensor`, else panics
+    pub fn get_tensor_type(&self) -> &TensorType {
+        if let Self::Tensor(tensor) = &self {
+            tensor
+        } else {
+            panic!("ArgType is no Tensor!");
         }
     }
 }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Should fix #2243

### Changes

Calculate output shape of convolutions in ONNX import dim_inference step.
I've found https://arxiv.org/abs/1603.07285 to follow, since the correct output shape isn't really defined in the ONNX specs, but am not quite sure if this implementation is correct for cases where `group` != 1.

Also, convtranspose also has the same problem (in that it just returns the input shape as its output shape), but here, I've just set the shape to None instead of trying to implement it fully - this should at least prevent dependent nodes from relying on wrong information.
