### PR TITLE
Use CliMetricsRenderer when not in a terminal

### DIFF
--- a/crates/burn-train/src/learner/builder.rs
+++ b/crates/burn-train/src/learner/builder.rs
@@ -316,9 +316,9 @@ where
                 log::warn!("Failed to install the experiment logger: {}", e);
             }
         }
-        let renderer = self.renderer.unwrap_or_else(|| {
-            Box::new(default_renderer(self.interrupter.clone(), self.checkpoint))
-        });
+        let renderer = self
+            .renderer
+            .unwrap_or_else(|| default_renderer(self.interrupter.clone(), self.checkpoint));
 
         if self.num_loggers == 0 {
             self.event_store

--- a/crates/burn-train/src/renderer/cli.rs
+++ b/crates/burn-train/src/renderer/cli.rs
@@ -17,10 +17,10 @@ impl MetricsRenderer for CliMetricsRenderer {
     fn update_valid(&mut self, _state: MetricState) {}
 
     fn render_train(&mut self, item: TrainingProgress) {
-        dbg!(item);
+        println!("{:?}", item);
     }
 
     fn render_valid(&mut self, item: TrainingProgress) {
-        dbg!(item);
+        println!("{:?}", item);
     }
 }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Fixes: https://github.com/tracel-ai/burn/issues/2302

### Changes

- When stdout is not a terminal, `TuiMetricsRenderer` can create junk output. This change checks that `stdout` is a terminal before using `TuiMetricsRenderer` and falls-back to `CliMetricsRenderer` when necessary.

- `default_renderer` now returns `Box<dyn Renderer>`, but this (hopefully) shouldn't be a problem because `LearnerBuilder` requires a boxed dyn anyway.

- `CliMetricsRenderer` has been changed from `dbg!`, which writes to `stderr`, to `println!("{:?}", ...)`, which writes to `stdout`. This is probably what users would expect when running a job piped to a file.

### Testing

- Tested with `tui` enabled that: a) normal training uses `TuiMetricsRenderer` and b) piping to a file uses `CliMetricsRenderer`.
- Tested with `tui` disabled that everything still works with `CliMetricsRenderer`.

