### PR TITLE
Move LrSchedule generic to make it easier to use

### DIFF
--- a/crates/burn-core/src/lr_scheduler/base.rs
+++ b/crates/burn-core/src/lr_scheduler/base.rs
@@ -3,17 +3,17 @@ use burn_tensor::backend::Backend;
 use crate::{record::Record, LearningRate};
 
 /// Learning rate scheduler defines how the learning rate will evolve during training.
-pub trait LrScheduler<B: Backend>: Send + Sync {
+pub trait LrScheduler: Send + Sync {
     /// Scheduler associative type to be used when saving and loading the state.
-    type Record: Record<B>;
+    type Record<B: Backend>: Record<B>;
 
     /// Perform the scheduler step, potentially updating its state, and returning the effective
     /// learning rate.
     fn step(&mut self) -> LearningRate;
 
     /// Get the current state of the scheduler as a [record](Record).
-    fn to_record(&self) -> Self::Record;
+    fn to_record<B: Backend>(&self) -> Self::Record<B>;
 
     /// Load the state of the scheduler as a [record](Record).
-    fn load_record(self, record: Self::Record) -> Self;
+    fn load_record<B: Backend>(self, record: Self::Record<B>) -> Self;
 }

--- a/crates/burn-core/src/lr_scheduler/constant.rs
+++ b/crates/burn-core/src/lr_scheduler/constant.rs
@@ -19,30 +19,30 @@ impl From<LearningRate> for ConstantLr {
     }
 }
 
-impl<B: Backend> LrScheduler<B> for ConstantLr {
-    type Record = ();
+impl LrScheduler for ConstantLr {
+    type Record<B: Backend> = ();
 
     fn step(&mut self) -> LearningRate {
         self.lr
     }
 
-    fn to_record(&self) -> Self::Record {}
+    fn to_record<B: Backend>(&self) -> Self::Record<B> {}
 
-    fn load_record(self, _record: Self::Record) -> Self {
+    fn load_record<B: Backend>(self, _record: Self::Record<B>) -> Self {
         self
     }
 }
 
-impl<B: Backend> LrScheduler<B> for LearningRate {
-    type Record = ();
+impl LrScheduler for LearningRate {
+    type Record<B: Backend> = ();
 
     fn step(&mut self) -> LearningRate {
         *self
     }
 
-    fn to_record(&self) -> Self::Record {}
+    fn to_record<B: Backend>(&self) -> Self::Record<B> {}
 
-    fn load_record(self, _record: Self::Record) -> Self {
+    fn load_record<B: Backend>(self, _record: Self::Record<B>) -> Self {
         self
     }
 }

--- a/crates/burn-core/src/lr_scheduler/cosine.rs
+++ b/crates/burn-core/src/lr_scheduler/cosine.rs
@@ -60,8 +60,8 @@ pub struct CosineAnnealingLrScheduler {
     current_iter: usize,
 }
 
-impl<B: Backend> LrScheduler<B> for CosineAnnealingLrScheduler {
-    type Record = (LearningRate, LearningRate, LearningRate, usize, usize);
+impl LrScheduler for CosineAnnealingLrScheduler {
+    type Record<B: Backend> = (LearningRate, LearningRate, LearningRate, usize, usize);
 
     fn step(&mut self) -> LearningRate {
         if self.current_iter < self.num_iters {
@@ -78,7 +78,7 @@ impl<B: Backend> LrScheduler<B> for CosineAnnealingLrScheduler {
         self.previous_lr
     }
 
-    fn to_record(&self) -> Self::Record {
+    fn to_record<B: Backend>(&self) -> Self::Record<B> {
         (
             self.previous_lr,
             self.min_lr,
@@ -88,7 +88,7 @@ impl<B: Backend> LrScheduler<B> for CosineAnnealingLrScheduler {
         )
     }
 
-    fn load_record(mut self, record: Self::Record) -> Self {
+    fn load_record<B: Backend>(mut self, record: Self::Record<B>) -> Self {
         (
             self.previous_lr,
             self.min_lr,

--- a/crates/burn-core/src/lr_scheduler/cosine.rs
+++ b/crates/burn-core/src/lr_scheduler/cosine.rs
@@ -103,7 +103,6 @@ impl LrScheduler for CosineAnnealingLrScheduler {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::TestBackend;
 
     #[test]
     #[should_panic = "Initial learning rate must be greater than 0 and at most 1"]
@@ -152,7 +151,7 @@ mod test {
         let mut previous_lr = INITIAL_LR;
 
         for _ in 0..NUM_ITERS {
-            let lr = LrScheduler::<TestBackend>::step(&mut scheduler);
+            let lr = scheduler.step();
             assert!(
                 lr < previous_lr,
                 "Learning rate should decrease with each iteration before reaching the specified number of iterations"
@@ -166,7 +165,7 @@ mod test {
         );
 
         assert_eq!(
-            LrScheduler::<TestBackend>::step(&mut scheduler),
+            scheduler.step(),
             INITIAL_LR,
             "Learning rate should be reset after the specified number of iterations"
         );

--- a/crates/burn-core/src/lr_scheduler/exponential.rs
+++ b/crates/burn-core/src/lr_scheduler/exponential.rs
@@ -48,19 +48,19 @@ pub struct ExponentialLrScheduler {
     gamma: f64,
 }
 
-impl<B: Backend> LrScheduler<B> for ExponentialLrScheduler {
-    type Record = (LearningRate, f64);
+impl LrScheduler for ExponentialLrScheduler {
+    type Record<B: Backend> = (LearningRate, f64);
 
     fn step(&mut self) -> LearningRate {
         self.previous_lr *= self.gamma;
         self.previous_lr
     }
 
-    fn to_record(&self) -> Self::Record {
+    fn to_record<B: Backend>(&self) -> Self::Record<B> {
         (self.previous_lr, self.gamma)
     }
 
-    fn load_record(mut self, record: Self::Record) -> Self {
+    fn load_record<B: Backend>(mut self, record: Self::Record<B>) -> Self {
         (self.previous_lr, self.gamma) = record;
         self
     }

--- a/crates/burn-core/src/lr_scheduler/exponential.rs
+++ b/crates/burn-core/src/lr_scheduler/exponential.rs
@@ -69,7 +69,6 @@ impl LrScheduler for ExponentialLrScheduler {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::TestBackend;
 
     #[test]
     #[should_panic = "Initial learning rate must be greater than 0 and at most 1"]
@@ -107,7 +106,7 @@ mod test {
         let mut previous_lr = INITIAL_LR;
 
         for _ in 0..NUM_ITERS {
-            let lr = LrScheduler::<TestBackend>::step(&mut scheduler);
+            let lr = scheduler.step();
             assert!(
                 lr < previous_lr,
                 "Learning rate should decrease with each iteration before reaching the final learning rate"

--- a/crates/burn-core/src/lr_scheduler/linear.rs
+++ b/crates/burn-core/src/lr_scheduler/linear.rs
@@ -54,8 +54,8 @@ pub struct LinearLrScheduler {
     remaining_iters: usize,
 }
 
-impl<B: Backend> LrScheduler<B> for LinearLrScheduler {
-    type Record = (LearningRate, f64, usize);
+impl LrScheduler for LinearLrScheduler {
+    type Record<B: Backend> = (LearningRate, f64, usize);
 
     fn step(&mut self) -> LearningRate {
         if self.remaining_iters > 0 {
@@ -65,11 +65,11 @@ impl<B: Backend> LrScheduler<B> for LinearLrScheduler {
         self.previous_lr
     }
 
-    fn to_record(&self) -> Self::Record {
+    fn to_record<B: Backend>(&self) -> Self::Record<B> {
         (self.previous_lr, self.step_size, self.remaining_iters)
     }
 
-    fn load_record(mut self, record: Self::Record) -> Self {
+    fn load_record<B: Backend>(mut self, record: Self::Record<B>) -> Self {
         (self.previous_lr, self.step_size, self.remaining_iters) = record;
         self
     }

--- a/crates/burn-core/src/lr_scheduler/linear.rs
+++ b/crates/burn-core/src/lr_scheduler/linear.rs
@@ -78,7 +78,6 @@ impl LrScheduler for LinearLrScheduler {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::TestBackend;
 
     #[test]
     #[should_panic = "Initial learning rate must be greater than 0 and at most 1"]
@@ -114,7 +113,7 @@ mod test {
         let mut previous_lr = INITIAL_LR;
 
         for _ in 0..NUM_ITERS {
-            let lr = LrScheduler::<TestBackend>::step(&mut scheduler);
+            let lr = scheduler.step();
             assert!(
                 lr < previous_lr,
                 "Learning rate should decrease with each iteration before reaching the final learning rate"
@@ -123,7 +122,7 @@ mod test {
         }
 
         for _ in 0..NUM_ITERS {
-            let lr = LrScheduler::<TestBackend>::step(&mut scheduler);
+            let lr = scheduler.step();
             assert_eq!(
                 previous_lr, lr,
                 "Learning rate should remain constant after reaching the final learning rate"

--- a/crates/burn-core/src/lr_scheduler/noam.rs
+++ b/crates/burn-core/src/lr_scheduler/noam.rs
@@ -63,8 +63,6 @@ impl LrScheduler for NoamLrScheduler {
 
 #[cfg(test)]
 mod tests {
-    use crate::TestBackend;
-
     use super::*;
 
     #[test]
@@ -76,7 +74,7 @@ mod tests {
         let mut lr_current = 0.0;
 
         for _ in 0..warmup_steps {
-            let lr = LrScheduler::<TestBackend>::step(&mut scheduler);
+            let lr = scheduler.step();
             assert!(
                 lr > lr_current,
                 "Learning rate should increase before the warmup_steps is reached."
@@ -85,7 +83,7 @@ mod tests {
         }
 
         for _ in 0..warmup_steps {
-            let lr = LrScheduler::<TestBackend>::step(&mut scheduler);
+            let lr = scheduler.step();
             assert!(
                 lr < lr_current,
                 "Learning rate should decrease after the warmup_steps is reached."

--- a/crates/burn-core/src/lr_scheduler/noam.rs
+++ b/crates/burn-core/src/lr_scheduler/noam.rs
@@ -39,8 +39,8 @@ impl NoamLrSchedulerConfig {
     }
 }
 
-impl<B: Backend> LrScheduler<B> for NoamLrScheduler {
-    type Record = usize;
+impl LrScheduler for NoamLrScheduler {
+    type Record<B: Backend> = usize;
 
     fn step(&mut self) -> LearningRate {
         self.step += 1.0;
@@ -51,11 +51,11 @@ impl<B: Backend> LrScheduler<B> for NoamLrScheduler {
         self.init_lr * self.embedding_size.powf(-0.5) * f64::min(arg1, arg2)
     }
 
-    fn to_record(&self) -> Self::Record {
+    fn to_record<B: Backend>(&self) -> Self::Record<B> {
         self.step as usize
     }
 
-    fn load_record(mut self, record: Self::Record) -> Self {
+    fn load_record<B: Backend>(mut self, record: Self::Record<B>) -> Self {
         self.step = record as f64;
         self
     }

--- a/crates/burn-train/src/components.rs
+++ b/crates/burn-train/src/components.rs
@@ -15,7 +15,7 @@ pub trait LearnerComponents {
     /// The backend in used for the training.
     type Backend: AutodiffBackend;
     /// The learning rate scheduler used for the training.
-    type LrScheduler: LrScheduler<Self::Backend>;
+    type LrScheduler: LrScheduler;
     /// The model to train.
     type Model: AutodiffModule<Self::Backend> + core::fmt::Display + 'static;
     /// The optimizer used for the training.
@@ -32,7 +32,7 @@ pub trait LearnerComponents {
     >;
     /// The checkpointer used for the scheduler.
     type CheckpointerLrScheduler: Checkpointer<
-        <Self::LrScheduler as LrScheduler<Self::Backend>>::Record,
+        <Self::LrScheduler as LrScheduler>::Record<Self::Backend>,
         Self::Backend,
     >;
     type EventProcessor: EventProcessor + 'static;
@@ -57,12 +57,12 @@ impl<B, LR, M, O, CM, CO, CS, EP, S> LearnerComponents
     for LearnerComponentsMarker<B, LR, M, O, CM, CO, CS, EP, S>
 where
     B: AutodiffBackend,
-    LR: LrScheduler<B>,
+    LR: LrScheduler,
     M: AutodiffModule<B> + core::fmt::Display + 'static,
     O: Optimizer<M, B>,
     CM: Checkpointer<M::Record, B>,
     CO: Checkpointer<O::Record, B>,
-    CS: Checkpointer<LR::Record, B>,
+    CS: Checkpointer<LR::Record<B>, B>,
     EP: EventProcessor + 'static,
     S: CheckpointingStrategy,
 {

--- a/crates/burn-train/src/learner/builder.rs
+++ b/crates/burn-train/src/learner/builder.rs
@@ -33,7 +33,7 @@ where
     B: AutodiffBackend,
     M: AutodiffModule<B>,
     O: Optimizer<M, B>,
-    S: LrScheduler<B>,
+    S: LrScheduler,
 {
     // Not that complex and very convenient when the traits are
     // already constrained correctly. Extracting in another type
@@ -42,7 +42,7 @@ where
     checkpointers: Option<(
         AsyncCheckpointer<M::Record, B>,
         AsyncCheckpointer<O::Record, B>,
-        AsyncCheckpointer<S::Record, B>,
+        AsyncCheckpointer<S::Record<B>, B>,
     )>,
     num_epochs: usize,
     checkpoint: Option<usize>,
@@ -68,7 +68,7 @@ where
     V: Send + 'static,
     M: AutodiffModule<B> + core::fmt::Display + 'static,
     O: Optimizer<M, B>,
-    S: LrScheduler<B>,
+    S: LrScheduler,
 {
     /// Creates a new learner builder.
     ///
@@ -257,7 +257,7 @@ where
         FR: FileRecorder<B::InnerBackend> + 'static,
         O::Record: 'static,
         M::Record: 'static,
-        S::Record: 'static,
+        S::Record<B>: 'static,
     {
         let checkpoint_dir = self.directory.join("checkpoint");
         let checkpointer_model = FileCheckpointer::new(recorder.clone(), &checkpoint_dir, "model");
@@ -301,7 +301,7 @@ where
             O,
             AsyncCheckpointer<M::Record, B>,
             AsyncCheckpointer<O::Record, B>,
-            AsyncCheckpointer<S::Record, B>,
+            AsyncCheckpointer<S::Record<B>, B>,
             FullEventProcessor<T, V>,
             Box<dyn CheckpointingStrategy>,
         >,
@@ -309,7 +309,7 @@ where
     where
         M::Record: 'static,
         O::Record: 'static,
-        S::Record: 'static,
+        S::Record<B>: 'static,
     {
         if self.tracing_logger.is_some() {
             if let Err(e) = self.tracing_logger.as_ref().unwrap().install() {


### PR DESCRIPTION
## Pull Request Template
### Changes

Fixing a random papercut I ran into. When you manually create a scheduler object like `LinearLrSchedule`, you have to call the step function like

```rust
LrScheduler::<B>::step(&mut scheduler);
```

This is because the Scheduler impl requires a backend which is otherwise unconstrained. This backend is only needed for saving/loading, so just move the generic there.