### PR TITLE
Add utility methods to split gradients to GradientParams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,6 @@ version = "0.15.0"
 dependencies = [
  "cubecl-common",
  "dashmap",
- "data-encoding",
  "getrandom",
  "indicatif",
  "rayon",
@@ -539,6 +538,7 @@ dependencies = [
  "burn-tch",
  "burn-tensor",
  "burn-wgpu",
+ "data-encoding",
  "derive-new",
  "flate2",
  "half",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,6 +515,7 @@ version = "0.15.0"
 dependencies = [
  "cubecl-common",
  "dashmap",
+ "data-encoding",
  "getrandom",
  "indicatif",
  "rayon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,6 @@ version = "0.15.0"
 dependencies = [
  "cubecl-common",
  "dashmap",
- "data-encoding",
  "getrandom",
  "indicatif",
  "rayon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,6 +554,7 @@ dependencies = [
  "spin",
  "tempfile",
  "thiserror",
+ "uuid",
 ]
 
 [[package]]

--- a/burn-book/src/building-blocks/module.md
+++ b/burn-book/src/building-blocks/module.md
@@ -90,13 +90,13 @@ You can implement your own mapper or visitor by implementing these simple traits
 /// Module visitor trait.
 pub trait ModuleVisitor<B: Backend> {
     /// Visit a tensor in the module.
-    fn visit<const D: usize>(&mut self, id: &ParamId, tensor: &Tensor<B, D>);
+    fn visit<const D: usize>(&mut self, id: ParamId, tensor: &Tensor<B, D>);
 }
 
 /// Module mapper trait.
 pub trait ModuleMapper<B: Backend> {
     /// Map a tensor in the module.
-    fn map<const D: usize>(&mut self, id: &ParamId, tensor: Tensor<B, D>) ->
+    fn map<const D: usize>(&mut self, id: ParamId, tensor: Tensor<B, D>) ->
       Tensor<B, D>;
 }
 ```

--- a/burn-book/src/quantization.md
+++ b/burn-book/src/quantization.md
@@ -73,7 +73,7 @@ let model = model.quantize_weights(&mut quantizer);
 > impl<B: Backend> ModuleMapper<B> for Dequantize {
 >     fn map_float<const D: usize>(
 >         &mut self,
->         _id: &ParamId,
+>         _id: ParamId,
 >         tensor: Tensor<B, D>,
 >     ) -> Tensor<B, D> {
 >         tensor.dequantize()

--- a/crates/burn-common/Cargo.toml
+++ b/crates/burn-common/Cargo.toml
@@ -23,6 +23,8 @@ web-time = { version = "1.1.0" }
 
 
 [dependencies]
+data-encoding = { workspace = true }
+
 # Network downloader
 indicatif = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }

--- a/crates/burn-common/Cargo.toml
+++ b/crates/burn-common/Cargo.toml
@@ -23,8 +23,6 @@ web-time = { version = "1.1.0" }
 
 
 [dependencies]
-data-encoding = { workspace = true }
-
 # Network downloader
 indicatif = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }

--- a/crates/burn-common/src/id.rs
+++ b/crates/burn-common/src/id.rs
@@ -1,21 +1,14 @@
-use alloc::string::String;
-
 use crate::rand::gen_random;
-
-use data_encoding::BASE32_DNSSEC;
 
 /// Simple ID generator.
 pub struct IdGenerator {}
 
 impl IdGenerator {
     /// Generates a new ID.
-    pub fn generate() -> String {
-        // Generate 6 random bytes (281,474,976,710,656 combinations)
-        let random_bytes: [u8; 6] = gen_random();
-
-        // Encode the random bytes in base32 DNSSEC
-        // 6 bytes encodes to 10 lower case characters, e.g. "3uu5e6vv7c"
-        BASE32_DNSSEC.encode(&random_bytes)
+    pub fn generate() -> u64 {
+        // Generate a random u64 (18,446,744,073,709,551,615 combinations)
+        let random_bytes: [u8; 8] = gen_random();
+        u64::from_le_bytes(random_bytes)
     }
 }
 
@@ -23,7 +16,7 @@ impl IdGenerator {
 mod tests {
     use super::*;
 
-    use alloc::{collections::BTreeSet, string::String};
+    use alloc::collections::BTreeSet;
 
     #[cfg(feature = "std")]
     use dashmap::DashSet; //Concurrent HashMap
@@ -31,15 +24,10 @@ mod tests {
     use std::{sync::Arc, thread};
 
     #[test]
-    fn not_empty_test() {
-        assert!(!IdGenerator::generate().is_empty());
-    }
-
-    #[test]
     fn uniqueness_test() {
         const IDS_CNT: usize = 10_000;
 
-        let mut set: BTreeSet<String> = BTreeSet::new();
+        let mut set: BTreeSet<u64> = BTreeSet::new();
 
         for _i in 0..IDS_CNT {
             assert!(set.insert(IdGenerator::generate()));
@@ -55,7 +43,7 @@ mod tests {
         const NUM_REPEATS: usize = 1_000;
         const EXPECTED_TOTAL_IDS: usize = NUM_THREADS * NUM_REPEATS;
 
-        let set: Arc<DashSet<String>> = Arc::new(DashSet::new());
+        let set: Arc<DashSet<u64>> = Arc::new(DashSet::new());
 
         let mut handles = vec![];
 

--- a/crates/burn-core/Cargo.toml
+++ b/crates/burn-core/Cargo.toml
@@ -119,6 +119,7 @@ burn-tch = { path = "../burn-tch", version = "0.15.0", optional = true }
 burn-candle = { path = "../burn-candle", version = "0.15.0", optional = true }
 
 data-encoding = { workspace = true }
+uuid = { workspace = true }
 
 derive-new = { workspace = true }
 log = { workspace = true, optional = true }

--- a/crates/burn-core/Cargo.toml
+++ b/crates/burn-core/Cargo.toml
@@ -118,6 +118,8 @@ burn-autodiff = { path = "../burn-autodiff", version = "0.15.0", optional = true
 burn-tch = { path = "../burn-tch", version = "0.15.0", optional = true }
 burn-candle = { path = "../burn-candle", version = "0.15.0", optional = true }
 
+data-encoding = { workspace = true }
+
 derive-new = { workspace = true }
 log = { workspace = true, optional = true }
 rand = { workspace = true, features = ["std_rng"] } # Default enables std
@@ -136,7 +138,7 @@ serde_json = { workspace = true, features = ["alloc"] } #Default enables std
 thiserror = { workspace = true, optional = true }
 regex = { workspace = true, optional = true }
 num-traits = { workspace = true }
-spin = { workspace = true } # Using in place of use std::sync::Mutex when std is disabled
+spin = { workspace = true }                             # Using in place of use std::sync::Mutex when std is disabled
 
 [target.'cfg(not(target_has_atomic = "ptr"))'.dependencies]
 portable-atomic-util = { workspace = true }

--- a/crates/burn-core/src/module/base.rs
+++ b/crates/burn-core/src/module/base.rs
@@ -19,7 +19,7 @@ macro_rules! module {
         impl<B: Backend> ModuleMapper<B> for Mapper {
             fn map_float<const D: usize>(
                 &mut self,
-                _id: &ParamId,
+                _id: ParamId,
                 tensor: Tensor<B, D>,
             ) -> Tensor<B, D> {
                 let func = $item;
@@ -35,7 +35,7 @@ macro_rules! module {
             backend: core::marker::PhantomData<B>,
         }
         impl<'a, B: Backend> ModuleVisitor<B> for Visitor<'a, B> {
-            fn visit_float<const D: usize>(&mut self, _id: &ParamId, tensor: &Tensor<B, D>) {
+            fn visit_float<const D: usize>(&mut self, _id: ParamId, tensor: &Tensor<B, D>) {
                 let func = $item;
                 func(tensor, &mut self.state)
             }
@@ -212,23 +212,23 @@ pub trait Module<B: Backend>: Clone + Send + core::fmt::Debug {
 /// Module visitor trait.
 pub trait ModuleVisitor<B: Backend> {
     /// Visit a float tensor in the module.
-    fn visit_float<const D: usize>(&mut self, _id: &ParamId, _tensor: &Tensor<B, D>) {}
+    fn visit_float<const D: usize>(&mut self, _id: ParamId, _tensor: &Tensor<B, D>) {}
     /// Visit an int tensor in the module.
-    fn visit_int<const D: usize>(&mut self, _id: &ParamId, _tensor: &Tensor<B, D, Int>) {}
+    fn visit_int<const D: usize>(&mut self, _id: ParamId, _tensor: &Tensor<B, D, Int>) {}
     /// Visit a bool tensor in the module.
-    fn visit_bool<const D: usize>(&mut self, _id: &ParamId, _tensor: &Tensor<B, D, Bool>) {}
+    fn visit_bool<const D: usize>(&mut self, _id: ParamId, _tensor: &Tensor<B, D, Bool>) {}
 }
 
 /// Module mapper trait.
 pub trait ModuleMapper<B: Backend> {
     /// Map a float tensor in the module.
-    fn map_float<const D: usize>(&mut self, _id: &ParamId, tensor: Tensor<B, D>) -> Tensor<B, D> {
+    fn map_float<const D: usize>(&mut self, _id: ParamId, tensor: Tensor<B, D>) -> Tensor<B, D> {
         tensor
     }
     /// Map an int tensor in the module.
     fn map_int<const D: usize>(
         &mut self,
-        _id: &ParamId,
+        _id: ParamId,
         tensor: Tensor<B, D, Int>,
     ) -> Tensor<B, D, Int> {
         tensor
@@ -236,7 +236,7 @@ pub trait ModuleMapper<B: Backend> {
     /// Map a bool tensor in the module.
     fn map_bool<const D: usize>(
         &mut self,
-        _id: &ParamId,
+        _id: ParamId,
         tensor: Tensor<B, D, Bool>,
     ) -> Tensor<B, D, Bool> {
         tensor

--- a/crates/burn-core/src/module/param/base.rs
+++ b/crates/burn-core/src/module/param/base.rs
@@ -235,7 +235,7 @@ impl<T: Parameter> Param<T> {
 
 impl<T: Parameter> Clone for Param<T> {
     fn clone(&self) -> Self {
-        Param::initialized(self.id.clone(), self.val())
+        Param::initialized(self.id, self.val())
     }
 }
 

--- a/crates/burn-core/src/module/param/id.rs
+++ b/crates/burn-core/src/module/param/id.rs
@@ -1,22 +1,14 @@
-use alloc::string::{String, ToString};
+use alloc::string::ToString;
 use burn_common::id::IdGenerator;
 
 /// Parameter ID.
-#[derive(Debug, Hash, PartialEq, Eq, Clone)]
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub struct ParamId {
-    value: String,
+    value: u64,
 }
 
-impl From<&str> for ParamId {
-    fn from(val: &str) -> Self {
-        Self {
-            value: val.to_string(),
-        }
-    }
-}
-
-impl From<String> for ParamId {
-    fn from(value: String) -> Self {
+impl From<u64> for ParamId {
+    fn from(value: u64) -> Self {
         Self { value }
     }
 }
@@ -35,14 +27,14 @@ impl ParamId {
         }
     }
 
-    /// Convert the parameter ID into a string.
-    pub fn into_string(self) -> String {
+    /// Gets the internal value of the id.
+    pub fn val(&self) -> u64 {
         self.value
     }
 }
 
 impl core::fmt::Display for ParamId {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.write_str(self.value.as_str())
+        f.write_str(&self.value.to_string())
     }
 }

--- a/crates/burn-core/src/module/param/id.rs
+++ b/crates/burn-core/src/module/param/id.rs
@@ -1,5 +1,5 @@
-use alloc::string::ToString;
 use burn_common::id::IdGenerator;
+use data_encoding::BASE32_DNSSEC;
 
 /// Parameter ID.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
@@ -31,10 +31,15 @@ impl ParamId {
     pub fn val(&self) -> u64 {
         self.value
     }
+
+    /// Convert the parameter ID into a string.
+    pub fn encode(self) -> String {
+        BASE32_DNSSEC.encode(&self.value.to_le_bytes())
+    }
 }
 
 impl core::fmt::Display for ParamId {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.write_str(&self.value.to_string())
+        f.write_str(&self.encode())
     }
 }

--- a/crates/burn-core/src/module/param/id.rs
+++ b/crates/burn-core/src/module/param/id.rs
@@ -34,13 +34,45 @@ impl ParamId {
     }
 
     /// Convert the parameter ID into a string.
-    pub fn encode(self) -> String {
+    pub fn serialize(self) -> String {
         BASE32_DNSSEC.encode(&self.value.to_le_bytes())
+    }
+
+    /// Deserialize a param id.
+    ///
+    /// Nb: The format used to be 6 bytes, so this
+    /// code supports both.
+    pub fn deserialize(encoded: &str) -> ParamId {
+        let bytes = BASE32_DNSSEC
+            .decode(encoded.as_bytes())
+            .expect("Invalid id");
+        let mut buffer = [0u8; 8];
+        buffer[..bytes.len()].copy_from_slice(&bytes);
+        ParamId::from(u64::from_le_bytes(buffer))
     }
 }
 
 impl core::fmt::Display for ParamId {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.write_str(&self.encode())
+        f.write_str(&self.serialize())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn param_serde_deserialize() {
+        let val = ParamId::from(123456u64);
+        let deserialized = deserialize_param_id(val.serialize());
+        assert_eq!(val, deserialized);
+    }
+
+    #[test]
+    fn param_serde_deserialize_legacy() {
+        let legacy_val = BASE32_DNSSEC.encode(&[45u8; 6]);
+        let param_id = ParamId::deserialize(&legacy_val);
+        assert_eq!(param_id.serialize(), legacy_val);
     }
 }

--- a/crates/burn-core/src/module/param/id.rs
+++ b/crates/burn-core/src/module/param/id.rs
@@ -1,3 +1,4 @@
+use alloc::string::String;
 use burn_common::id::IdGenerator;
 use data_encoding::BASE32_DNSSEC;
 

--- a/crates/burn-core/src/module/param/id.rs
+++ b/crates/burn-core/src/module/param/id.rs
@@ -65,14 +65,15 @@ mod tests {
     #[test]
     fn param_serde_deserialize() {
         let val = ParamId::from(123456u64);
-        let deserialized = deserialize_param_id(val.serialize());
+        let deserialized = ParamId::deserialize(&val.serialize());
         assert_eq!(val, deserialized);
     }
 
     #[test]
     fn param_serde_deserialize_legacy() {
-        let legacy_val = BASE32_DNSSEC.encode(&[45u8; 6]);
-        let param_id = ParamId::deserialize(&legacy_val);
-        assert_eq!(param_id.serialize(), legacy_val);
+        let legacy_val = [45u8; 6];
+        let param_id = ParamId::deserialize(&BASE32_DNSSEC.encode(&legacy_val));
+        assert_eq!(param_id.val().to_le_bytes()[0..6], legacy_val);
+        assert_eq!(param_id.val().to_le_bytes()[6..], [0, 0]);
     }
 }

--- a/crates/burn-core/src/module/param/running.rs
+++ b/crates/burn-core/src/module/param/running.rs
@@ -79,13 +79,12 @@ impl<const D: usize, B: Backend> Module<B> for RunningState<Tensor<B, D>> {
 
     fn visit<V: ModuleVisitor<B>>(&self, visitor: &mut V) {
         let tensor = self.value.lock().unwrap();
-
-        visitor.visit_float(&self.id, &tensor)
+        visitor.visit_float(self.id, &tensor)
     }
 
     fn map<M: ModuleMapper<B>>(self, mapper: &mut M) -> Self {
         let mut tensor = self.value.lock().unwrap();
-        let tensor_out = mapper.map_float(&self.id, tensor.clone());
+        let tensor_out = mapper.map_float(self.id, tensor.clone());
 
         *tensor = tensor_out;
         core::mem::drop(tensor);
@@ -246,6 +245,6 @@ impl<const D: usize, B: AutodiffBackend> AutodiffModule<B> for RunningState<Tens
         self.sync();
         let value = self.value();
 
-        RunningState::with_id(self.id.clone(), value.inner())
+        RunningState::with_id(self.id, value.inner())
     }
 }

--- a/crates/burn-core/src/module/param/tensor.rs
+++ b/crates/burn-core/src/module/param/tensor.rs
@@ -88,13 +88,12 @@ impl<const D: usize, B: Backend> Module<B> for Param<Tensor<B, D>> {
     type Record = Param<Tensor<B, D>>;
 
     fn visit<V: ModuleVisitor<B>>(&self, visitor: &mut V) {
-        visitor.visit_float(&self.id, &self.val())
+        visitor.visit_float(self.id, &self.val())
     }
 
     fn map<M: ModuleMapper<B>>(self, mapper: &mut M) -> Self {
         let (id, tensor) = self.consume();
-        let value = mapper.map_float(&id, tensor);
-
+        let value = mapper.map_float(id, tensor);
         Self::initialized(id, value)
     }
 
@@ -170,11 +169,11 @@ impl<const D: usize, B: Backend> Module<B> for Param<Tensor<B, D, Int>> {
     type Record = Param<Tensor<B, D, Int>>;
 
     fn visit<V: ModuleVisitor<B>>(&self, visitor: &mut V) {
-        visitor.visit_int(&self.id, &self.val())
+        visitor.visit_int(self.id, &self.val())
     }
 
     fn map<M: ModuleMapper<B>>(self, mapper: &mut M) -> Self {
-        let value = mapper.map_int(&self.id, self.val());
+        let value = mapper.map_int(self.id, self.val());
         Self::initialized(self.id, value)
     }
 
@@ -237,11 +236,11 @@ impl<const D: usize, B: Backend> Module<B> for Param<Tensor<B, D, Bool>> {
     type Record = Param<Tensor<B, D, Bool>>;
 
     fn visit<V: ModuleVisitor<B>>(&self, visitor: &mut V) {
-        visitor.visit_bool(&self.id, &self.val())
+        visitor.visit_bool(self.id, &self.val())
     }
 
     fn map<M: ModuleMapper<B>>(self, mapper: &mut M) -> Self {
-        let value = mapper.map_bool(&self.id, self.val());
+        let value = mapper.map_bool(self.id, self.val());
         Self::initialized(self.id, value)
     }
 
@@ -306,7 +305,7 @@ impl<const D: usize, B: AutodiffBackend> AutodiffModule<B> for Param<Tensor<B, D
     type InnerModule = Param<Tensor<B::InnerBackend, D>>;
 
     fn valid(&self) -> Self::InnerModule {
-        Param::initialized(self.id.clone(), self.val().inner().set_require_grad(false))
+        Param::initialized(self.id, self.val().inner().set_require_grad(false))
     }
 }
 
@@ -314,7 +313,7 @@ impl<const D: usize, B: AutodiffBackend> AutodiffModule<B> for Param<Tensor<B, D
     type InnerModule = Param<Tensor<B::InnerBackend, D, Int>>;
 
     fn valid(&self) -> Self::InnerModule {
-        Param::initialized(self.id.clone(), self.val().inner())
+        Param::initialized(self.id, self.val().inner())
     }
 }
 
@@ -322,7 +321,7 @@ impl<const D: usize, B: AutodiffBackend> AutodiffModule<B> for Param<Tensor<B, D
     type InnerModule = Param<Tensor<B::InnerBackend, D, Bool>>;
 
     fn valid(&self) -> Self::InnerModule {
-        Param::initialized(self.id.clone(), self.val().inner())
+        Param::initialized(self.id, self.val().inner())
     }
 }
 

--- a/crates/burn-core/src/module/param/visitor.rs
+++ b/crates/burn-core/src/module/param/visitor.rs
@@ -14,14 +14,14 @@ where
     B: Backend,
     M: Module<B>,
 {
-    fn visit_float<const D: usize>(&mut self, id: &ParamId, _tensor: &Tensor<B, D>) {
-        self.param_ids.push(id.clone());
+    fn visit_float<const D: usize>(&mut self, id: ParamId, _tensor: &Tensor<B, D>) {
+        self.param_ids.push(id);
     }
-    fn visit_int<const D: usize>(&mut self, id: &ParamId, _tensor: &Tensor<B, D, Int>) {
-        self.param_ids.push(id.clone());
+    fn visit_int<const D: usize>(&mut self, id: ParamId, _tensor: &Tensor<B, D, Int>) {
+        self.param_ids.push(id);
     }
-    fn visit_bool<const D: usize>(&mut self, id: &ParamId, _tensor: &Tensor<B, D, Bool>) {
-        self.param_ids.push(id.clone());
+    fn visit_bool<const D: usize>(&mut self, id: ParamId, _tensor: &Tensor<B, D, Bool>) {
+        self.param_ids.push(id);
     }
 }
 

--- a/crates/burn-core/src/module/quantize.rs
+++ b/crates/burn-core/src/module/quantize.rs
@@ -15,7 +15,7 @@ pub struct Quantizer<C: Calibration> {
 }
 
 impl<B: Backend, C: Calibration> ModuleMapper<B> for Quantizer<C> {
-    fn map_float<const D: usize>(&mut self, _id: &ParamId, tensor: Tensor<B, D>) -> Tensor<B, D> {
+    fn map_float<const D: usize>(&mut self, _id: ParamId, tensor: Tensor<B, D>) -> Tensor<B, D> {
         let range = self.calibration.compute_range(&tensor);
         let qparams = self.scheme.compute_q_params(range);
         tensor.quantize(&self.scheme, qparams)

--- a/crates/burn-core/src/optim/grad_accum.rs
+++ b/crates/burn-core/src/optim/grad_accum.rs
@@ -57,7 +57,7 @@ struct ModuleGradsAccumulator<'a, M> {
 impl<'a, B: AutodiffBackend, M: AutodiffModule<B>> ModuleVisitor<B>
     for ModuleGradsAccumulator<'a, M>
 {
-    fn visit_float<const D: usize>(&mut self, id: &ParamId, _tensor: &Tensor<B, D>) {
+    fn visit_float<const D: usize>(&mut self, id: ParamId, _tensor: &Tensor<B, D>) {
         let grad_updated = match self.grads_new.remove::<B::InnerBackend, D>(id) {
             Some(new) => match self.grads.remove::<B::InnerBackend, D>(id) {
                 Some(grad) => grad.add(new),
@@ -69,8 +69,7 @@ impl<'a, B: AutodiffBackend, M: AutodiffModule<B>> ModuleVisitor<B>
             },
         };
 
-        self.grads
-            .register::<B::InnerBackend, D>(id.clone(), grad_updated);
+        self.grads.register::<B::InnerBackend, D>(id, grad_updated);
     }
 }
 

--- a/crates/burn-core/src/optim/grads.rs
+++ b/crates/burn-core/src/optim/grads.rs
@@ -59,18 +59,6 @@ impl GradientsParams {
         grads_params
     }
 
-    /// Segment a module into multiple different GradientParams.
-    pub fn from_segments<B: AutodiffBackend, M: AutodiffModule<B>>(
-        grads: &mut B::Gradients,
-        module: &M,
-        segments: &[&[&ParamId]],
-    ) -> Vec<Self> {
-        segments
-            .iter()
-            .map(|p| Self::from_params(grads, module, p))
-            .collect()
-    }
-
     /// Get the gradients for the given [parameter id](ParamId).
     ///
     /// # Notes

--- a/crates/burn-core/src/optim/grads.rs
+++ b/crates/burn-core/src/optim/grads.rs
@@ -47,14 +47,11 @@ impl GradientsParams {
     pub fn from_params<B: AutodiffBackend, M: AutodiffModule<B>>(
         grads: &mut B::Gradients,
         module: &M,
-        params: &[&ParamId],
+        params: &[ParamId],
     ) -> Self {
         let mut grads_params = GradientsParams::new();
-        let mut visitor = GradientsParamsConverter::<M, B>::new(
-            grads,
-            &mut grads_params,
-            Some(params.iter().copied().cloned().collect()),
-        );
+        let mut visitor =
+            GradientsParamsConverter::<M, B>::new(grads, &mut grads_params, Some(params.to_vec()));
         module.visit(&mut visitor);
         grads_params
     }
@@ -65,19 +62,19 @@ impl GradientsParams {
     ///
     /// You should use [remove](GradientsParams::remove) if you want to get the gradients
     /// only one time.
-    pub fn get<B, const D: usize>(&self, id: &ParamId) -> Option<Tensor<B, D>>
+    pub fn get<B, const D: usize>(&self, id: ParamId) -> Option<Tensor<B, D>>
     where
         B: Backend,
     {
-        self.container.get(id).map(Tensor::from_primitive)
+        self.container.get(&id).map(Tensor::from_primitive)
     }
 
     /// Remove the gradients for the given [parameter id](ParamId).
-    pub fn remove<B, const D: usize>(&mut self, id: &ParamId) -> Option<Tensor<B, D>>
+    pub fn remove<B, const D: usize>(&mut self, id: ParamId) -> Option<Tensor<B, D>>
     where
         B: Backend,
     {
-        self.container.remove(id).map(Tensor::from_primitive)
+        self.container.remove(&id).map(Tensor::from_primitive)
     }
 
     /// Register a gradients tensor for the given [parameter id](ParamId).

--- a/crates/burn-core/src/optim/visitor.rs
+++ b/crates/burn-core/src/optim/visitor.rs
@@ -23,9 +23,9 @@ where
     B: AutodiffBackend,
     M: AutodiffModule<B>,
 {
-    fn visit_float<const D: usize>(&mut self, id: &ParamId, tensor: &Tensor<B, D>) {
+    fn visit_float<const D: usize>(&mut self, id: ParamId, tensor: &Tensor<B, D>) {
         if let Some(filter) = self.filter.as_ref() {
-            if !filter.contains(id) {
+            if !filter.contains(&id) {
                 return;
             }
         }
@@ -33,8 +33,7 @@ where
             return;
         };
 
-        self.grads_params
-            .register::<B::InnerBackend, D>(id.clone(), grad);
+        self.grads_params.register::<B::InnerBackend, D>(id, grad);
     }
 }
 
@@ -43,12 +42,12 @@ where
     B: AutodiffBackend,
     M: AutodiffModule<B>,
 {
-    fn visit_float<const D: usize>(&mut self, id: &ParamId, _tensor: &Tensor<B, D>) {
+    fn visit_float<const D: usize>(&mut self, id: ParamId, _tensor: &Tensor<B, D>) {
         let Some(grad) = self.grads.remove::<B::InnerBackend, D>(id) else {
             return;
         };
 
         self.grads
-            .register::<B::InnerBackend, D>(id.clone(), grad.to_device(self.device));
+            .register::<B::InnerBackend, D>(id, grad.to_device(self.device));
     }
 }

--- a/crates/burn-core/src/optim/visitor.rs
+++ b/crates/burn-core/src/optim/visitor.rs
@@ -4,9 +4,9 @@ use burn_tensor::{backend::AutodiffBackend, Tensor};
 use core::marker::PhantomData;
 
 #[derive(new)]
-pub struct GradientsParamsConverter<'a, 'b, M: AutodiffModule<B>, B: AutodiffBackend> {
+pub struct GradientsParamsConverter<'a, M: AutodiffModule<B>, B: AutodiffBackend> {
     grads: &'a mut B::Gradients,
-    grads_params: &'b mut GradientsParams,
+    grads_params: &'a mut GradientsParams,
     phatom: PhantomData<M>,
     filter: Option<Vec<ParamId>>,
 }
@@ -18,7 +18,7 @@ pub struct GradientsParamsChangeDevice<'a, M: AutodiffModule<B>, B: AutodiffBack
     phatom: PhantomData<M>,
 }
 
-impl<'a, 'b, B, M> ModuleVisitor<B> for GradientsParamsConverter<'a, 'b, M, B>
+impl<'a, B, M> ModuleVisitor<B> for GradientsParamsConverter<'a, M, B>
 where
     B: AutodiffBackend,
     M: AutodiffModule<B>,

--- a/crates/burn-core/src/record/primitive.rs
+++ b/crates/burn-core/src/record/primitive.rs
@@ -163,8 +163,45 @@ where
 /// (De)serialize parameters into a clean format.
 #[derive(new, Debug, Clone, Serialize, Deserialize)]
 pub struct ParamSerde<T> {
+    #[serde(deserialize_with = "compat_param_id")]
     id: u64,
     param: T,
+}
+
+use data_encoding::BASE32_DNSSEC;
+
+// Deserialize a param id from either a u64 or from a BASE32_DNSSEC encoded string (old format).
+fn compat_param_id<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct ParamIdVisitor;
+
+    impl<'de> Visitor<'de> for ParamIdVisitor {
+        type Value = u64;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a u64 or a base32 string")
+        }
+
+        fn visit_u64<E: serde::de::Error>(self, value: u64) -> Result<Self::Value, E> {
+            Ok(value)
+        }
+
+        fn visit_str<E: serde::de::Error>(self, value: &str) -> Result<Self::Value, E> {
+            // Old format encoded only 6 bytes.
+            BASE32_DNSSEC
+                .decode(value.as_bytes())
+                .map_err(serde::de::Error::custom)
+                .map(|bytes| {
+                    u64::from_le_bytes([
+                        bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], 0, 0,
+                    ])
+                })
+        }
+    }
+
+    deserializer.deserialize_any(ParamIdVisitor)
 }
 
 impl<B, const D: usize> Record<B> for Param<Tensor<B, D>>

--- a/crates/burn-core/src/record/primitive.rs
+++ b/crates/burn-core/src/record/primitive.rs
@@ -1,8 +1,4 @@
-use alloc::{
-    string::{String, ToString},
-    vec,
-    vec::Vec,
-};
+use alloc::vec::Vec;
 use core::{fmt, marker::PhantomData};
 
 use super::tensor::{BoolTensorSerde, FloatTensorSerde, IntTensorSerde};
@@ -128,12 +124,12 @@ where
     T: Record<B>,
     B: Backend,
 {
-    type Item<S: PrecisionSettings> = HashMap<String, T::Item<S>>;
+    type Item<S: PrecisionSettings> = HashMap<u64, T::Item<S>>;
 
     fn into_item<S: PrecisionSettings>(self) -> Self::Item<S> {
         let mut items = HashMap::with_capacity(self.len());
         self.into_iter().for_each(|(id, record)| {
-            items.insert(id.to_string(), record.into_item());
+            items.insert(id.val(), record.into_item());
         });
         items
     }
@@ -167,7 +163,7 @@ where
 /// (De)serialize parameters into a clean format.
 #[derive(new, Debug, Clone, Serialize, Deserialize)]
 pub struct ParamSerde<T> {
-    id: String,
+    id: u64,
     param: T,
 }
 
@@ -179,7 +175,7 @@ where
 
     fn into_item<S: PrecisionSettings>(self) -> Self::Item<S> {
         let (id, tensor) = self.consume();
-        ParamSerde::new(id.into_string(), tensor.into_item())
+        ParamSerde::new(id.val(), tensor.into_item())
     }
 
     fn from_item<S: PrecisionSettings>(item: Self::Item<S>, device: &B::Device) -> Self {
@@ -199,7 +195,7 @@ where
 
     fn into_item<S: PrecisionSettings>(self) -> Self::Item<S> {
         let (id, tensor) = self.consume();
-        ParamSerde::new(id.into_string(), tensor.into_item())
+        ParamSerde::new(id.val(), tensor.into_item())
     }
 
     fn from_item<S: PrecisionSettings>(item: Self::Item<S>, device: &B::Device) -> Self {
@@ -218,7 +214,7 @@ where
 
     fn into_item<S: PrecisionSettings>(self) -> Self::Item<S> {
         let (id, tensor) = self.consume();
-        ParamSerde::new(id.into_string(), tensor.into_item::<S>())
+        ParamSerde::new(id.val(), tensor.into_item::<S>())
     }
 
     fn from_item<S: PrecisionSettings>(item: Self::Item<S>, device: &B::Device) -> Self {

--- a/crates/burn-core/src/record/primitive.rs
+++ b/crates/burn-core/src/record/primitive.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::{vec, vec::Vec};
 use core::{fmt, marker::PhantomData};
 
 use super::tensor::{BoolTensorSerde, FloatTensorSerde, IntTensorSerde};

--- a/crates/burn-core/src/record/serde/ser.rs
+++ b/crates/burn-core/src/record/serde/ser.rs
@@ -362,27 +362,27 @@ mod tests {
         // the order of the fields is not guaranteed for HashMaps.
         assert_eq!(serialized_str.len(), 135);
     }
+
     #[test]
     fn test_param_serde() {
         type Backend = burn_ndarray::NdArray<f32>;
 
         let device = Default::default();
-
         let tensor: Tensor<Backend, 2> = Tensor::ones([2, 2], &device);
-
         let param = Param::initialized(ParamId::new(), tensor);
-
         let param_item = param.into_item::<FullPrecisionSettings>();
 
         let serialized = param_item
             .serialize(Serializer::new())
             .expect("Should serialize item successfully");
 
-        let serialized_str = format!("{:?}", serialized);
-
-        // Compare the lengths of expected and actual serialized strings because
-        // the order of the fields is not guaranteed for HashMaps.
-        // 1.0f32 is represented with 4 bytes [0, 0, 128, 63]
-        assert_eq!(serialized_str.len(), 140);
+        let bytes = serialized.as_map().expect("is a map")["param"]
+            .clone()
+            .as_map()
+            .expect("param is a map")["bytes"]
+            .clone()
+            .as_bytes()
+            .expect("has bytes vec");
+        assert_eq!(bytes, [1.0f32; 4].map(|f| f.to_le_bytes()).as_flattened());
     }
 }

--- a/crates/burn-import/src/burn/node/constant.rs
+++ b/crates/burn-import/src/burn/node/constant.rs
@@ -157,7 +157,7 @@ impl<PS: PrecisionSettings> NodeCodegen<PS> for ConstantNode {
     fn field_serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         if let ConstantValue::Tensor(_, data) = &self.value {
             let data = data.clone().convert::<PS::FloatElem>();
-            let data = ParamSerde::new(ParamId::new().into_string(), data);
+            let data = ParamSerde::new(ParamId::new().val(), data);
             return data.serialize(serializer);
         }
 

--- a/crates/burn-import/src/burn/node/constant.rs
+++ b/crates/burn-import/src/burn/node/constant.rs
@@ -157,7 +157,7 @@ impl<PS: PrecisionSettings> NodeCodegen<PS> for ConstantNode {
     fn field_serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         if let ConstantValue::Tensor(_, data) = &self.value {
             let data = data.clone().convert::<PS::FloatElem>();
-            let data = ParamSerde::new(ParamId::new().val(), data);
+            let data = ParamSerde::new(ParamId::new().to_string(), data);
             return data.serialize(serializer);
         }
 

--- a/crates/burn-import/src/pytorch/reader.rs
+++ b/crates/burn-import/src/pytorch/reader.rs
@@ -95,7 +95,7 @@ impl Serializable for CandleTensor {
     {
         let shape = self.shape().clone().into_dims();
         let flatten = CandleTensor(self.flatten_all().expect("Failed to flatten the tensor"));
-        let param_id = ParamId::new().into_string();
+        let param_id = ParamId::new().val();
 
         match self.dtype() {
             candle_core::DType::U8 => {
@@ -127,7 +127,7 @@ impl Serializable for CandleTensor {
 fn serialize_data<T, E>(
     tensor: CandleTensor,
     shape: Vec<usize>,
-    param_id: String,
+    param_id: u64,
     serializer: Serializer,
 ) -> Result<NestedValue, error::Error>
 where
@@ -157,7 +157,7 @@ where
     tensor_data.insert("dtype".into(), dtype.serialize(serializer)?);
 
     let mut param: HashMap<String, NestedValue> = HashMap::new();
-    param.insert("id".into(), NestedValue::String(param_id));
+    param.insert("id".into(), NestedValue::U64(param_id));
     param.insert("param".into(), NestedValue::Map(tensor_data));
 
     Ok(NestedValue::Map(param))

--- a/crates/burn-import/src/pytorch/reader.rs
+++ b/crates/burn-import/src/pytorch/reader.rs
@@ -157,7 +157,7 @@ where
     tensor_data.insert("dtype".into(), dtype.serialize(serializer)?);
 
     let mut param: HashMap<String, NestedValue> = HashMap::new();
-    param.insert("id".into(), NestedValue::String(param_id.encode()));
+    param.insert("id".into(), NestedValue::String(param_id.serialize()));
     param.insert("param".into(), NestedValue::Map(tensor_data));
 
     Ok(NestedValue::Map(param))

--- a/crates/burn-import/src/pytorch/reader.rs
+++ b/crates/burn-import/src/pytorch/reader.rs
@@ -95,7 +95,7 @@ impl Serializable for CandleTensor {
     {
         let shape = self.shape().clone().into_dims();
         let flatten = CandleTensor(self.flatten_all().expect("Failed to flatten the tensor"));
-        let param_id = ParamId::new().val();
+        let param_id = ParamId::new();
 
         match self.dtype() {
             candle_core::DType::U8 => {
@@ -127,7 +127,7 @@ impl Serializable for CandleTensor {
 fn serialize_data<T, E>(
     tensor: CandleTensor,
     shape: Vec<usize>,
-    param_id: u64,
+    param_id: ParamId,
     serializer: Serializer,
 ) -> Result<NestedValue, error::Error>
 where
@@ -157,7 +157,7 @@ where
     tensor_data.insert("dtype".into(), dtype.serialize(serializer)?);
 
     let mut param: HashMap<String, NestedValue> = HashMap::new();
-    param.insert("id".into(), NestedValue::U64(param_id));
+    param.insert("id".into(), NestedValue::String(param_id.encode()));
     param.insert("param".into(), NestedValue::Map(tensor_data));
 
     Ok(NestedValue::Map(param))

--- a/crates/burn-jit/src/fusion/elemwise/kernel.rs
+++ b/crates/burn-jit/src/fusion/elemwise/kernel.rs
@@ -16,7 +16,7 @@ use std::{marker::PhantomData, num::NonZero, sync::Arc};
 
 #[derive(new)]
 pub struct ElementWiseKernelFactory<R: JitRuntime> {
-    id: String,
+    id: u64,
     info: Arc<KernelExpansion>,
     cube_dim: CubeDim,
     _runtime: PhantomData<R>,
@@ -85,7 +85,7 @@ impl<R: JitRuntime> FusionKernelFactory<R> for ElementWiseKernelFactory<R> {
                         });
 
                 FusionKernel::new(
-                    self.id.clone(),
+                    self.id,
                     self.info.clone(),
                     settings,
                     output_infos.collect(),
@@ -103,7 +103,7 @@ impl<R: JitRuntime> FusionKernelFactory<R> for ElementWiseKernelFactory<R> {
                 });
 
                 FusionKernel::new(
-                    self.id.clone(),
+                    self.id,
                     self.info.clone(),
                     settings,
                     output_infos.collect(),

--- a/crates/burn-jit/src/fusion/kernel.rs
+++ b/crates/burn-jit/src/fusion/kernel.rs
@@ -18,7 +18,7 @@ use super::tracing::ExecutionInfo;
 
 #[derive(new)]
 pub struct FusionKernel<R: JitRuntime> {
-    id: String, // Same ID for all different settings.
+    id: u64, // Same ID for all different settings.
     info: Arc<KernelExpansion>,
     settings: KernelSettings,
     runtime_info: Vec<OutputRuntimeInfo>,
@@ -270,7 +270,7 @@ impl<R: JitRuntime> Kernel for FusionKernel<R> {
     }
 
     fn id(&self) -> cubecl::KernelId {
-        cubecl::KernelId::new::<Self>().info((self.settings.clone(), self.id.clone()))
+        cubecl::KernelId::new::<Self>().info((self.settings.clone(), self.id))
     }
 }
 


### PR DESCRIPTION
## Changes

Currently, working with multiple different learning rates in Burn can be a bit of a hassle. The easiest way is to create a different GradientParams for each set of variables, and then step the optimizer for each of these. Eg. in my codebase I had something like:


```rust
let mut grad_means = GradientsParams::new();
grad_means.register(
    splats.means.id.clone(),
    splats.means.grad_remove(&mut grads).unwrap(),
);
let mut grad_opac = GradientsParams::new();
grad_opac.register(
    splats.raw_opacity.id.clone(),
    splats.raw_opacity.grad_remove(&mut grads).unwrap(),
);
let mut grad_rest = GradientsParams::new();
grad_rest.register(
    splats.sh_coeffs.id.clone(),
    splats.sh_coeffs.grad_remove(&mut grads).unwrap(),
);
grad_rest.register(
    splats.rotation.id.clone(),
    splats.rotation.grad_remove(&mut grads).unwrap(),
);
grad_rest.register(
    splats.log_scales.id.clone(),
    splats.log_scales.grad_remove(&mut grads).unwrap(),
);
```

This PR just adds some utility methods to turn this into

```rust
let grad_mean = GradientsParams::from_params(&mut grads, &splats, &[splats.means.id]);
let grad_opac = GradientsParams::from_params(&mut grads, &splats, &[splats.raw_opacity.id]);
// Since the first call modifies the grads this will just be the remaining grads.
let grad_rest = GradientsParams::from_module(&mut grads, &splats);
```

Not entirely sure about the names/shape of the API! It feels like this could be a method on Gradients instead but that's currently not really public. 


To make the API slightly simpler I've made ParamId: Copy by making the ID a 64 bit random hash or something instead of a 6(?) byte random string encoded ID.

I've left from_grads in place as is to not break compatibility but also added a from_module, which allows people to extract a GradientParams for a specific module without consuming the gradients, so you could do something like

```rust
let linear_grads = GradientParams::from_module(&mut all_grads, &self.model.linear.a);
let rest_grads = GradientParams::from_grads(all_grads, &self.model); 
```

from_grads could also just be the same thing as from_module if it's ok to break compat.

Something that's a bit gnarly that if you were to extract a GradientsParam for each param individually, each optimizer step would map over all parameters and things become O(n^2). I doubt that matters much in practice.
