### PR TITLE
Update rusqlite and associated libraries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3299,9 +3299,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.28.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
  "pkg-config",
@@ -5068,9 +5068,9 @@ dependencies = [
 
 [[package]]
 name = "r2d2_sqlite"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a982edf65c129796dba72f8775b292ef482b40d035e827a9825b3bc07ccc5f2"
+checksum = "eb14dba8247a6a15b7fdbc7d389e2e6f03ee9f184f87117706d509c092dfe846"
 dependencies = [
  "r2d2",
  "rusqlite",
@@ -5526,9 +5526,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
  "bitflags 2.6.0",
  "fallible-iterator",
@@ -5825,9 +5825,9 @@ dependencies = [
 
 [[package]]
 name = "serde_rusqlite"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d903d9524cecbcd7b75745b6ee0e3f3774b878ea489dfaf2ea749463283d6"
+checksum = "b741cc5ef185cd96157e762c3bba743c4e94c8dc6af0edb053c48d2b3c27e691"
 dependencies = [
  "rusqlite",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,19 +61,19 @@ protobuf = "3.4.0"
 protobuf-codegen = "3.4.0"
 quote = "1.0.37"
 r2d2 = "0.8.10"
-r2d2_sqlite = { version = "0.24.0" }
+r2d2_sqlite = { version = "0.25.0" }
 rayon = "1.10.0"
 regex = "1.11.0"
 reqwest = "0.12.5"
 rmp-serde = "1.3.0"
 rstest = "0.19.0"
-rusqlite = { version = "0.31.0" }
+rusqlite = { version = "0.32.1" }
 rust-format = { version = "0.3.4" }
 sanitize-filename = "0.5.0"
 serde_bytes = { version = "0.11.15", default-features = false, features = [
     "alloc",
 ] } # alloc for no_std
-serde_rusqlite = "0.35.0"
+serde_rusqlite = "0.36.0"
 serial_test = "3.1.1"
 spin = { version = "0.9.8", features = [
     "mutex",


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ X ] Confirmed that `run-checks all` script has been executed.
- [ X ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

_Provide links to relevant issues and dependent PRs._

### Changes

_Summarize the problem being addressed and your solution._

sqlite dependencies in burn were old, making a single distribution with other more up-to-date libraries (shuttle.rs) difficult without forking burn

### Testing

_Describe how these changes have been tested._

Ran the scripts and tests. These changes fixed a shuttle project which previously filed with cargo not able to map rusqlite and similar libraries to compatible versions.
