### PR TITLE
Move conv autotune under feature flag (except key)

### DIFF
--- a/crates/burn-jit/src/kernel/conv/conv2d/base.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d/base.rs
@@ -6,10 +6,10 @@ use burn_tensor::{
 use crate::{tensor::JitTensor, FloatElement, IntElement, JitElement, JitRuntime};
 
 #[cfg(feature = "autotune")]
-use super::conv2d_autotune;
+use super::{conv2d_autotune, conv_transpose2d_autotune};
 use super::{
-    conv2d_direct, conv2d_im2col, conv_transpose2d_autotune, conv_transpose2d_col2im,
-    conv_transpose2d_direct, implicit_gemm::conv2d_implicit_gemm,
+    conv2d_direct, conv2d_im2col, conv_transpose2d_col2im, conv_transpose2d_direct,
+    implicit_gemm::conv2d_implicit_gemm,
 };
 
 /// The strategy to be used when launching a convolution kernel.

--- a/crates/burn-jit/src/kernel/conv/conv2d/mod.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d/mod.rs
@@ -5,7 +5,6 @@ mod im2col;
 mod implicit_gemm;
 mod transpose_direct;
 
-#[cfg(feature = "autotune")]
 mod tune;
 
 pub use base::*;
@@ -14,5 +13,4 @@ pub use direct::*;
 pub use im2col::*;
 pub use implicit_gemm::*;
 pub use transpose_direct::*;
-#[cfg(feature = "autotune")]
 pub use tune::*;

--- a/crates/burn-jit/src/kernel/conv/conv2d/tune/conv2d.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d/tune/conv2d.rs
@@ -5,9 +5,7 @@ use burn_tensor::{
 use cubecl::{
     tune,
     tune::{local_tuner, tune_with, LocalTuner},
-    AutotuneKey,
 };
-use serde::{Deserialize, Serialize};
 
 use crate::{
     kernel::{
@@ -17,6 +15,8 @@ use crate::{
     tensor::JitTensor,
     FloatElement, IntElement, JitAutotuneKey, JitRuntime, JitTuneId,
 };
+
+use super::Conv2dAutotuneKey;
 
 /// Executes autotune on conv2d operations
 pub fn conv2d_autotune<R: JitRuntime, E: FloatElement, I: IntElement>(
@@ -36,27 +36,6 @@ pub fn conv2d_autotune<R: JitRuntime, E: FloatElement, I: IntElement>(
             input, weights, bias, options,
         )),
     )
-}
-
-#[derive(Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize, AutotuneKey)]
-/// Autotune key representative of matmul versions
-pub struct Conv2dAutotuneKey {
-    pub kernel_size: [usize; 2],
-    pub stride: [usize; 2],
-    pub padding: [usize; 2],
-    pub dilation: [usize; 2],
-    pub groups: usize,
-    #[autotune(anchor)]
-    pub in_channels: usize,
-    #[autotune(anchor)]
-    pub out_channels: usize,
-    #[autotune(anchor)]
-    pub height: usize,
-    #[autotune(anchor)]
-    pub width: usize,
-    #[autotune(anchor)]
-    pub batch_size: usize,
-    pub has_bias: bool,
 }
 
 #[tune(

--- a/crates/burn-jit/src/kernel/conv/conv2d/tune/conv_transpose2d.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d/tune/conv_transpose2d.rs
@@ -2,9 +2,7 @@ use burn_tensor::{ops::ConvTransposeOptions, ElementConversion, Shape};
 use cubecl::{
     tune,
     tune::{local_tuner, tune_with, LocalTuner},
-    AutotuneKey,
 };
-use serde::{Deserialize, Serialize};
 
 use crate::{
     kernel::{
@@ -15,27 +13,7 @@ use crate::{
     FloatElement, IntElement, JitAutotuneKey, JitRuntime, JitTuneId,
 };
 
-#[derive(Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize, AutotuneKey)]
-/// Autotune key representative of matmul versions
-pub struct ConvTranspose2dAutotuneKey {
-    pub kernel_size: [usize; 2],
-    pub stride: [usize; 2],
-    pub padding: [usize; 2],
-    pub padding_out: [usize; 2],
-    pub dilation: [usize; 2],
-    pub groups: usize,
-    #[autotune(anchor)]
-    pub in_channels: usize,
-    #[autotune(anchor)]
-    pub out_channels: usize,
-    #[autotune(anchor)]
-    pub height: usize,
-    #[autotune(anchor)]
-    pub width: usize,
-    #[autotune(anchor)]
-    pub batch_size: usize,
-    pub has_bias: bool,
-}
+use super::ConvTranspose2dAutotuneKey;
 
 /// Executes autotune on conv2d operations
 pub fn conv_transpose2d_autotune<R: JitRuntime, E: FloatElement, I: IntElement>(

--- a/crates/burn-jit/src/kernel/conv/conv2d/tune/key.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d/tune/key.rs
@@ -1,0 +1,45 @@
+use cubecl::AutotuneKey;
+use serde::{Deserialize, Serialize};
+
+#[derive(Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize, AutotuneKey)]
+/// Autotune key representative of matmul versions
+pub struct Conv2dAutotuneKey {
+    pub kernel_size: [usize; 2],
+    pub stride: [usize; 2],
+    pub padding: [usize; 2],
+    pub dilation: [usize; 2],
+    pub groups: usize,
+    #[autotune(anchor)]
+    pub in_channels: usize,
+    #[autotune(anchor)]
+    pub out_channels: usize,
+    #[autotune(anchor)]
+    pub height: usize,
+    #[autotune(anchor)]
+    pub width: usize,
+    #[autotune(anchor)]
+    pub batch_size: usize,
+    pub has_bias: bool,
+}
+
+#[derive(Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize, AutotuneKey)]
+/// Autotune key representative of matmul versions
+pub struct ConvTranspose2dAutotuneKey {
+    pub kernel_size: [usize; 2],
+    pub stride: [usize; 2],
+    pub padding: [usize; 2],
+    pub padding_out: [usize; 2],
+    pub dilation: [usize; 2],
+    pub groups: usize,
+    #[autotune(anchor)]
+    pub in_channels: usize,
+    #[autotune(anchor)]
+    pub out_channels: usize,
+    #[autotune(anchor)]
+    pub height: usize,
+    #[autotune(anchor)]
+    pub width: usize,
+    #[autotune(anchor)]
+    pub batch_size: usize,
+    pub has_bias: bool,
+}

--- a/crates/burn-jit/src/kernel/conv/conv2d/tune/mod.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d/tune/mod.rs
@@ -1,5 +1,12 @@
+#[cfg(feature = "autotune")]
 mod conv2d;
+#[cfg(feature = "autotune")]
 mod conv_transpose2d;
 
+#[cfg(feature = "autotune")]
 pub use conv2d::*;
+#[cfg(feature = "autotune")]
 pub use conv_transpose2d::*;
+
+mod key;
+pub use key::*;


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.

### Related Issues/PRs

Stumbled upon this while validating the changes in #2311 with the `mnist-inference-web` example (using wgpu)

### Changes

When `autotune` feature flag is not used, the autotune key should still be available otherwise its usage in `JitAutotuneKey` will throw some unresolved import errors.

### Testing

Works with `mnist-inference-web` example on wgpu.
