### PR TITLE
Add functionality to ensure ONNX node graph is sorted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2045,6 +2045,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "flate2"
 version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4087,6 +4093,7 @@ dependencies = [
  "bytemuck",
  "half",
  "log",
+ "petgraph",
  "pretty_assertions",
  "protobuf",
  "protobuf-codegen",
@@ -4320,6 +4327,16 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.4.0",
+]
 
 [[package]]
 name = "phf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,7 @@ num-traits = { version = "0.2.19", default-features = false, features = [
     "libm",
 ] } # libm is for no_std
 openblas-src = "0.10.9"
+petgraph = "0.6.5"
 rand = { version = "0.8.5", default-features = false, features = [
     "std_rng",
 ] } # std_rng is for no_std

--- a/crates/onnx-ir/Cargo.toml
+++ b/crates/onnx-ir/Cargo.toml
@@ -16,6 +16,7 @@ version.workspace = true
 bytemuck = { workspace = true }
 half = { workspace = true }
 log = { workspace = true }
+petgraph = { workspace = true }
 protobuf = { workspace = true, features = ["with-bytes"] }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/onnx-ir/src/from_onnx.rs
+++ b/crates/onnx-ir/src/from_onnx.rs
@@ -412,7 +412,7 @@ pub(crate) fn remap_unsqueeze_to_reshape(node: &mut Node, out_arg: &Argument) {
     }
 }
 
-/// Topographically sort an ONNX node graph.
+/// Topologically sort an ONNX node graph.
 fn topo_sort(mut input_graph: GraphProto) -> GraphProto {
     let nodes = input_graph.node;
     let mut graph = Graph::new();


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `run-checks all` script has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Changes

Microsoft's [Phi-3 ONNX model](https://huggingface.co/microsoft/Phi-3-mini-128k-instruct-onnx) is not topographically sorted.
It's fairly easy to implement a topographical sort though both to ensure that `burn` can still tolerate non-compliant models, and to ensure that the model's graph is valid.

**Special note:** This also fixes a bug where `is_top_sorted` did not account for unnamed input/output edges.