### PR TITLE
Make {Cosine,Exponential,Linear} LR schedulers return the initial LR at the first step

### DIFF
--- a/crates/burn-core/src/lr_scheduler/base.rs
+++ b/crates/burn-core/src/lr_scheduler/base.rs
@@ -17,3 +17,60 @@ pub trait LrScheduler: Send + Sync {
     /// Load the state of the scheduler as a [record](Record).
     fn load_record<B: Backend>(self, record: Self::Record<B>) -> Self;
 }
+
+#[cfg(test)]
+pub(super) mod test_utils {
+    use super::*;
+    use crate::TestBackend;
+
+    pub fn check_lr_sequence<I, S>(mut scheduler: S, expected_lrs: I)
+    where
+        I: IntoIterator<Item = LearningRate>,
+        S: LrScheduler,
+    {
+        // Depending on how learning rates are computed by the scheduler, floating-point arithmetic
+        // error might exceed f64::EPSILON, so we use a larger epsilon here.
+        const LOOSE_EPSILON: f64 = 1e-10;
+
+        expected_lrs
+            .into_iter()
+            .enumerate()
+            .for_each(|(i, expected)| {
+                let lr = scheduler.step();
+                assert!(
+                    (lr - expected).abs() < LOOSE_EPSILON,
+                    "Scheduled learning rate {lr} is not approximately equal to the expected value \
+                     {expected} at step {i}",
+                );
+            });
+    }
+
+    // save_at_step is the number of steps to run the scheduler before saving and loading back its
+    // state.
+    pub fn check_save_load<S>(mut scheduler: S, save_at_step: usize)
+    where
+        S: Clone + LrScheduler,
+    {
+        let mut truth = scheduler.clone();
+        // Consume some steps before saving and loading back
+        (0..save_at_step).for_each(|_| {
+            truth.step();
+            scheduler.step();
+        });
+        let rec = scheduler.to_record::<TestBackend>();
+        scheduler = scheduler.load_record::<TestBackend>(rec);
+
+        // Validate that the scheduler resumes from where it left off.
+        (save_at_step..2 * save_at_step).for_each(|i| {
+            let expected = truth.step();
+            let lr = scheduler.step();
+            // The two schedulers run with the exact same settings and code,
+            // so the difference, if any, should be small enough to fit in f64::EPSILON.
+            assert!(
+                (lr - expected).abs() < f64::EPSILON,
+                "Scheduled learning rate {lr} is not approximately equal to the expected value \
+                 {expected} at step {i}",
+            );
+        });
+    }
+}

--- a/crates/burn-core/src/lr_scheduler/cosine.rs
+++ b/crates/burn-core/src/lr_scheduler/cosine.rs
@@ -3,10 +3,12 @@ use crate as burn;
 use crate::{config::Config, LearningRate};
 use burn_tensor::backend::Backend;
 
-/// The configuration for creating a Cosine Annealing learning rate scheduler with cold restarts.
+/// The configuration for creating a [Cosine Annealing learning rate scheduler with warm
+/// restarts](CosineAnnealingLrScheduler).
 ///
-/// This scheduler starts at a learning rate `initial_lr`, then changes the learning rate by following a cosine function
-/// with a period of `num_iters` iterations. After `num_iters` iterations, the learning rate is reset to `initial_lr`.
+/// This scheduler returns the learning rate `initial_lr` at the first step, then changes it by
+/// following a cosine function. After `num_iters` iterations, the learning rate is reset to
+/// `initial_lr`.
 #[derive(Config)]
 pub struct CosineAnnealingLrSchedulerConfig {
     // The initial learning rate.
@@ -14,7 +16,8 @@ pub struct CosineAnnealingLrSchedulerConfig {
     // The final learning rate.
     #[config(default = 0.0)]
     min_lr: LearningRate,
-    // The number of iterations before the learning rate is reset.
+    // The number of iterations between two restarts. The two restart iterations themselves are not
+    // included.
     num_iters: usize,
 }
 
@@ -38,22 +41,21 @@ impl CosineAnnealingLrSchedulerConfig {
         );
 
         CosineAnnealingLrScheduler {
-            previous_lr: self.initial_lr,
             min_lr: self.min_lr,
             max_lr: self.initial_lr,
             num_iters: self.num_iters,
-            current_iter: 0,
+            current_iter: usize::MAX,
         }
     }
 }
 
 /// A Cosine Annealing learning rate scheduler.
 ///
-/// See [CosineAnnealingLrSchedulerConfig] for more information.
+/// This scheduler is described in [SGDR: Stochastic Gradient Descent with Warm
+/// Restarts](https://arxiv.org/abs/1608.03983). See [CosineAnnealingLrSchedulerConfig] for more
+/// information.
 #[derive(Clone, Copy, Debug)]
 pub struct CosineAnnealingLrScheduler {
-    // The previous iteration's learning rate.
-    previous_lr: LearningRate,
     min_lr: LearningRate,
     max_lr: LearningRate,
     num_iters: usize,
@@ -61,47 +63,34 @@ pub struct CosineAnnealingLrScheduler {
 }
 
 impl LrScheduler for CosineAnnealingLrScheduler {
-    type Record<B: Backend> = (LearningRate, LearningRate, LearningRate, usize, usize);
+    type Record<B: Backend> = usize;
 
     fn step(&mut self) -> LearningRate {
-        if self.current_iter < self.num_iters {
-            self.current_iter += 1;
-        } else {
-            self.current_iter = 0;
-        }
-        self.previous_lr = self.min_lr
+        // Make current_iter overflow from usize::MAX to 0 to get the initial learning rate on the
+        // first call. We could've used i64 with an initial value -1, but keeping it in usize saves
+        // us from some type casting here.
+        self.current_iter = self.current_iter.wrapping_add(1) % (self.num_iters + 1);
+        self.min_lr
             + 0.5
                 * (self.max_lr - self.min_lr)
                 * (1.0
                     + (self.current_iter as f64 / self.num_iters as f64 * std::f64::consts::PI)
-                        .cos());
-        self.previous_lr
+                        .cos())
     }
 
     fn to_record<B: Backend>(&self) -> Self::Record<B> {
-        (
-            self.previous_lr,
-            self.min_lr,
-            self.max_lr,
-            self.num_iters,
-            self.current_iter,
-        )
+        self.current_iter
     }
 
     fn load_record<B: Backend>(mut self, record: Self::Record<B>) -> Self {
-        (
-            self.previous_lr,
-            self.min_lr,
-            self.max_lr,
-            self.num_iters,
-            self.current_iter,
-        ) = record;
+        self.current_iter = record;
         self
     }
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
+    use super::super::test_utils;
     use super::*;
 
     #[test]
@@ -142,32 +131,25 @@ mod test {
     fn test_lr_change() {
         const INITIAL_LR: LearningRate = 0.5;
         const MIN_LR: LearningRate = 0.1;
-        const NUM_ITERS: usize = 10;
+        const NUM_ITERS: usize = 2;
 
-        let mut scheduler = CosineAnnealingLrSchedulerConfig::new(INITIAL_LR, NUM_ITERS)
+        let scheduler = CosineAnnealingLrSchedulerConfig::new(INITIAL_LR, NUM_ITERS)
             .with_min_lr(MIN_LR)
             .init();
+        let expected_lrs = [
+            INITIAL_LR,                  // cos(0)
+            (INITIAL_LR + MIN_LR) * 0.5, // cos(PI/2)
+            MIN_LR,                      // cos(PI)
+            INITIAL_LR,                  // restart
+        ];
+        test_utils::check_lr_sequence(scheduler, expected_lrs);
+    }
 
-        let mut previous_lr = INITIAL_LR;
-
-        for _ in 0..NUM_ITERS {
-            let lr = scheduler.step();
-            assert!(
-                lr < previous_lr,
-                "Learning rate should decrease with each iteration before reaching the specified number of iterations"
-            );
-            previous_lr = lr;
-        }
-
-        assert_eq!(
-            previous_lr, MIN_LR,
-            "Learning rate should reach the final learning rate"
-        );
-
-        assert_eq!(
-            scheduler.step(),
-            INITIAL_LR,
-            "Learning rate should be reset after the specified number of iterations"
-        );
+    #[test]
+    fn test_save_and_load() {
+        const INITIAL_LR: LearningRate = 1.0;
+        const NUM_ITERS: usize = 9;
+        let scheduler = CosineAnnealingLrSchedulerConfig::new(INITIAL_LR, NUM_ITERS).init();
+        test_utils::check_save_load(scheduler, NUM_ITERS / 3 * 2);
     }
 }

--- a/crates/burn-core/src/lr_scheduler/exponential.rs
+++ b/crates/burn-core/src/lr_scheduler/exponential.rs
@@ -3,10 +3,11 @@ use crate as burn;
 use crate::{config::Config, LearningRate};
 use burn_tensor::backend::Backend;
 
-/// The configuration for creating an exponential learning rate scheduler.
+/// The configuration for creating an [exponential learning rate scheduler](ExponentialLrScheduler).
 ///
-/// This scheduler starts at a learning rate `initial_lr`, then changes the learning rate by multiplying it by a constant
-/// `gamma` at every iteration. At any iteration `i`, the learning rate is given by `initial_lr * gamma^i`.
+/// This scheduler returns the learning rate `initial_lr` at the first step, then multiplies it by
+/// a constant `gamma` at every iteration. At any iteration `i` (which starts from 0), the learning
+/// rate is given by `initial_lr * gamma^i`.
 #[derive(Config)]
 pub struct ExponentialLrSchedulerConfig {
     // The initial learning rate.
@@ -31,7 +32,9 @@ impl ExponentialLrSchedulerConfig {
         );
 
         ExponentialLrScheduler {
-            previous_lr: self.initial_lr,
+            // Such an initial value eliminates the need for special-case handling of the first
+            // learning rate.
+            previous_lr: self.initial_lr / self.gamma,
             gamma: self.gamma,
         }
     }
@@ -49,7 +52,7 @@ pub struct ExponentialLrScheduler {
 }
 
 impl LrScheduler for ExponentialLrScheduler {
-    type Record<B: Backend> = (LearningRate, f64);
+    type Record<B: Backend> = LearningRate;
 
     fn step(&mut self) -> LearningRate {
         self.previous_lr *= self.gamma;
@@ -57,17 +60,18 @@ impl LrScheduler for ExponentialLrScheduler {
     }
 
     fn to_record<B: Backend>(&self) -> Self::Record<B> {
-        (self.previous_lr, self.gamma)
+        self.previous_lr
     }
 
     fn load_record<B: Backend>(mut self, record: Self::Record<B>) -> Self {
-        (self.previous_lr, self.gamma) = record;
+        self.previous_lr = record;
         self
     }
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
+    use super::super::test_utils;
     use super::*;
 
     #[test]
@@ -96,28 +100,19 @@ mod test {
 
     #[test]
     fn test_lr_change() {
-        const INITIAL_LR: LearningRate = 0.75;
-        const GAMMA: f64 = 0.9;
-        const NUM_ITERS: usize = 10;
-        const EPSILON: f64 = 1e-10;
+        const INITIAL_LR: LearningRate = 0.8;
+        const GAMMA: f64 = 0.1;
 
-        let mut scheduler = ExponentialLrSchedulerConfig::new(INITIAL_LR, GAMMA).init();
+        let scheduler = ExponentialLrSchedulerConfig::new(INITIAL_LR, GAMMA).init();
+        let expected_lrs = [0.8, 0.08, 0.008, 0.0008, 0.00008];
+        test_utils::check_lr_sequence(scheduler, expected_lrs);
+    }
 
-        let mut previous_lr = INITIAL_LR;
-
-        for _ in 0..NUM_ITERS {
-            let lr = scheduler.step();
-            assert!(
-                lr < previous_lr,
-                "Learning rate should decrease with each iteration before reaching the final learning rate"
-            );
-            previous_lr = lr;
-        }
-
-        let expected = INITIAL_LR * GAMMA.powi(NUM_ITERS as i32);
-        assert!(
-            (previous_lr - expected).abs() < EPSILON,
-            "Learning rate should be close to the expected value after reaching the final learning rate"
-        );
+    #[test]
+    fn test_save_and_load() {
+        const INITIAL_LR: LearningRate = 0.083;
+        const GAMMA: f64 = 0.3;
+        let scheduler = ExponentialLrSchedulerConfig::new(INITIAL_LR, GAMMA).init();
+        test_utils::check_save_load(scheduler, 7);
     }
 }

--- a/crates/burn-core/src/lr_scheduler/linear.rs
+++ b/crates/burn-core/src/lr_scheduler/linear.rs
@@ -3,11 +3,12 @@ use crate as burn;
 use crate::{config::Config, LearningRate};
 use burn_tensor::backend::Backend;
 
-/// The configuration for creating a linear learning rate scheduler.
+/// The configuration for creating a [linear learning rate scheduler](LinearLrScheduler).
 ///
-/// This scheduler starts at a learning rate `initial_lr`, then changes the learning rate by a constant amount on each
-/// iteration until reaching a final learning rate `final_lr`. The `num_iters` parameter controls how many iterations
-/// are needed to go from `initial_lr` to `final_lr`.
+/// This scheduler returns the learning rate `initial_lr` at the first step, then changes it by a
+/// constant amount on each iteration until reaching a final learning rate `final_lr`. The
+/// `num_iters` parameter controls how many iterations are needed to go from `initial_lr` to
+/// `final_lr`.
 #[derive(Config)]
 pub struct LinearLrSchedulerConfig {
     // The initial learning rate.
@@ -32,11 +33,15 @@ impl LinearLrSchedulerConfig {
             self.final_lr >= 0. && self.final_lr <= 1.,
             "Final learning rate must be at least 0 and at most 1"
         );
+        assert!(
+            self.num_iters > 0,
+            "Number of iterations must be at least 1"
+        );
 
         LinearLrScheduler {
-            previous_lr: self.initial_lr,
+            final_lr: self.final_lr,
             step_size: (self.final_lr - self.initial_lr) / self.num_iters as f64,
-            remaining_iters: self.num_iters,
+            remaining_iters: self.num_iters + 1,
         }
     }
 }
@@ -46,8 +51,8 @@ impl LinearLrSchedulerConfig {
 /// See [LinearLrSchedulerConfig] for more information.
 #[derive(Clone, Copy, Debug)]
 pub struct LinearLrScheduler {
-    // The previous iteration's learning rate.
-    previous_lr: LearningRate,
+    // The final learning rate after the linear changing process stops.
+    final_lr: LearningRate,
     // The amount that the learning rate changes by on each iteration.
     step_size: f64,
     // The number of iterations left before reaching the final learning rate.
@@ -55,28 +60,26 @@ pub struct LinearLrScheduler {
 }
 
 impl LrScheduler for LinearLrScheduler {
-    type Record<B: Backend> = (LearningRate, f64, usize);
+    type Record<B: Backend> = usize;
 
     fn step(&mut self) -> LearningRate {
-        if self.remaining_iters > 0 {
-            self.remaining_iters -= 1;
-            self.previous_lr += self.step_size;
-        }
-        self.previous_lr
+        self.remaining_iters -= (self.remaining_iters != 0) as usize;
+        self.final_lr - self.step_size * self.remaining_iters as f64
     }
 
     fn to_record<B: Backend>(&self) -> Self::Record<B> {
-        (self.previous_lr, self.step_size, self.remaining_iters)
+        self.remaining_iters
     }
 
     fn load_record<B: Backend>(mut self, record: Self::Record<B>) -> Self {
-        (self.previous_lr, self.step_size, self.remaining_iters) = record;
+        self.remaining_iters = record;
         self
     }
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
+    use super::super::test_utils;
     use super::*;
 
     #[test]
@@ -104,29 +107,47 @@ mod test {
     }
 
     #[test]
-    fn test_lr_change() {
-        const INITIAL_LR: LearningRate = 0.75;
-        const NUM_ITERS: usize = 10;
+    #[should_panic = "Number of iterations must be at least 1"]
+    fn config_num_iters_too_low() {
+        LinearLrSchedulerConfig::new(0.9, 0.1, 0).init();
+    }
 
-        let mut scheduler = LinearLrSchedulerConfig::new(INITIAL_LR, 0.25, NUM_ITERS).init();
+    #[test]
+    fn test_lr_decreasing() {
+        const INITIAL_LR: LearningRate = 0.9;
+        const FINAL_LR: LearningRate = 0.5;
+        const NUM_ITERS: usize = 4;
+        let scheduler = LinearLrSchedulerConfig::new(INITIAL_LR, FINAL_LR, NUM_ITERS).init();
+        let expected_lrs = [0.9, 0.8, 0.7, 0.6, 0.5, 0.5];
+        test_utils::check_lr_sequence(scheduler, expected_lrs);
+    }
 
-        let mut previous_lr = INITIAL_LR;
+    #[test]
+    fn test_lr_increasing() {
+        const INITIAL_LR: LearningRate = 0.01;
+        const FINAL_LR: LearningRate = 0.04;
+        const NUM_ITERS: usize = 3;
+        let scheduler = LinearLrSchedulerConfig::new(INITIAL_LR, FINAL_LR, NUM_ITERS).init();
+        let expected_lrs = [0.01, 0.02, 0.03, 0.04, 0.04];
+        test_utils::check_lr_sequence(scheduler, expected_lrs);
+    }
 
-        for _ in 0..NUM_ITERS {
-            let lr = scheduler.step();
-            assert!(
-                lr < previous_lr,
-                "Learning rate should decrease with each iteration before reaching the final learning rate"
-            );
-            previous_lr = lr;
-        }
+    #[test]
+    fn test_lr_unchanging() {
+        const INITIAL_LR: LearningRate = 0.3;
+        const FINAL_LR: LearningRate = 0.3;
+        const NUM_ITERS: usize = 2;
+        let scheduler = LinearLrSchedulerConfig::new(INITIAL_LR, FINAL_LR, NUM_ITERS).init();
+        let expected_lrs = [0.3, 0.3, 0.3, 0.3];
+        test_utils::check_lr_sequence(scheduler, expected_lrs);
+    }
 
-        for _ in 0..NUM_ITERS {
-            let lr = scheduler.step();
-            assert_eq!(
-                previous_lr, lr,
-                "Learning rate should remain constant after reaching the final learning rate"
-            )
-        }
+    #[test]
+    fn test_save_and_load() {
+        const INITIAL_LR: LearningRate = 1.0;
+        const FINAL_LR: LearningRate = 0.01;
+        const NUM_ITERS: usize = 6;
+        let scheduler = LinearLrSchedulerConfig::new(INITIAL_LR, FINAL_LR, NUM_ITERS).init();
+        test_utils::check_save_load(scheduler, NUM_ITERS / 3 * 2);
     }
 }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
  (It was executed with `DISABLE_WGPU=1` because currently I have the development environment in a container with no access to the physical GPU)
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

#1198

### Changes

The PR includes the following changes for Cosine, Exponential, and Linear LR schedulers:

* Make the first call to `.step()` return the initial LR instead of the second one.
  Reason:
  　The current behavior skips the initial LR, which is unintuitive and inconsistent with other schedulers.
  　This is a breaking change. To retain the previous behavior, users can run `.step()` once to discard the first value before using it to build a `Learner`.

* Include only fields that change across steps when creating a `Record`.
  Reason: Fields that remain unchanged during training should be kept as part of training configurations. Also, the current behavior is inconsistent with other schedulers.

* Improve tests:
  　* Add a test case for saving and loading records
  　* Test concrete LR values instead of changing trends
  　* Rename the test module to the conventional name `tests`
  　* Add a test case for the `num_iters` field (Linear LR scheduler only)
  Reason: Increase test coverage and align with the convention of module naming.

* Improve documentation comments:
  　* Clarify that the first call to `.step()` returns the initial LR
  　* Add some links
  　* Fix the name of restart of Cosine LR scheduler (Should be "warm restart")
   Reason: Describe the behavior of the first call to `.step()` clearly, and make navigation easier.

### Testing

* Added test cases that targeted the code changes.
* Executed `DISABLE_WGPU=1 bash ./run-checks.sh` and ensured that it exited with code 0.
* Checked changes of documentation comments in a browser manually.
* Confirmed that the changes didn't affect the Book by searching LR in it and reading the contents.

==========
Update: Add description of tests for the Book.