### PR TITLE
Contributor Book: Fix the link of primitive types in the "Serialization" page

### DIFF
--- a/contributor-book/src/project-architecture/serialization.md
+++ b/contributor-book/src/project-architecture/serialization.md
@@ -40,8 +40,8 @@ which field is a parameter or a constant, or we assume that each field implement
 
 The second solution was chosen as it simplifies the code generation and reduces the size of the user
 API. This means that the `Module` trait should be implemented by
-[primitives types](./burn-core/src/module/param/primitive.rs). The following diagrams highlight the
-main types and traits used in the solution.
+[primitive types](https://github.com/tracel-ai/burn/blob/6d96e8d8086d2309c425f2c8a43a8246f8c454d2/crates/burn-core/src/module/param/primitive.rs).
+The following diagrams highlight the main types and traits used in the solution.
 
 <div align="center">
 <h4>Module Serialization Types</h4>

--- a/contributor-book/src/project-architecture/serialization.md
+++ b/contributor-book/src/project-architecture/serialization.md
@@ -40,7 +40,7 @@ which field is a parameter or a constant, or we assume that each field implement
 
 The second solution was chosen as it simplifies the code generation and reduces the size of the user
 API. This means that the `Module` trait should be implemented by
-[primitive types](https://github.com/tracel-ai/burn/blob/6d96e8d8086d2309c425f2c8a43a8246f8c454d2/crates/burn-core/src/module/param/primitive.rs).
+[primitive types](https://github.com/tracel-ai/burn/blob/main/crates/burn-core/src/module/param/primitive.rs).
 The following diagrams highlight the main types and traits used in the solution.
 
 <div align="center">


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
    (Executed with DISABLE_WGPU=1 because currently my development environment is in a container with no access to a physical GPU)
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

None.

### Changes

* Problems:
The link of primitive types in the "Serialization" page is an intra-doc link pointing to a place that doesn't exist. Also its name `primitives types` doesn't sound very natural (English is not my first language, so please  correct me if I'm wrong).

* Changes:
Replace the intra-doc link with an external one pointing to the source code file in "burn-core", and change its name to `primitive types`.

### Testing

* Self-reviewed the change by `git diff`.
* Checked the affected part by reading it in a browser.