### PR TITLE
Fix typo

### DIFF
--- a/crates/burn-jit/src/kernel/conv/conv2d/implicit_gemm.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d/implicit_gemm.rs
@@ -472,7 +472,7 @@ fn load_input_tile<F: Float, FMat: Float>(
         // Slices are always `kernel_size * channels` elements wide so we can compute where inside a slice
         // we are and also which row the slice is in relative to the start of the CMMA matrix
 
-        // Actual index within a slice (0 to `kernel_size * channels - 1`) that the thread is repsonsible for
+        // Actual index within a slice (0 to `kernel_size * channels - 1`) that the thread is responsible for
         let my_slice_idx = (slice_start_idx + (m % cmma_k)) % dims.slice_size;
 
         let channel = my_slice_idx % channels;


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

None

### Changes
I noticed a typo when running `./run-check all` for other PR.
This PR fixes the typo as follows in crates/burn-jit/src/kernel/conv/conv2d/implicit_gemm.rs.
repsonsible -> responsible
```
-        // Actual index within a slice (0 to `kernel_size * channels - 1`) that the thread is repsonsible for
+        // Actual index within a slice (0 to `kernel_size * channels - 1`) that the thread is responsible for
```

### Testing

`run-checks all` has passed.
