### PR TITLE
unsqueeze() to unsqueeze_dim(1)

### DIFF
--- a/examples/simple-regression/src/model.rs
+++ b/examples/simple-regression/src/model.rs
@@ -50,7 +50,7 @@ impl<B: Backend> RegressionModel<B> {
     }
 
     pub fn forward_step(&self, item: DiabetesBatch<B>) -> RegressionOutput<B> {
-        let targets: Tensor<B, 2> = item.targets.unsqueeze();
+        let targets: Tensor<B, 2> = item.targets.unsqueeze_dim(1);
         let output: Tensor<B, 2> = self.forward(item.inputs);
 
         let loss = MseLoss::new().forward(output.clone(), targets.clone(), Mean);


### PR DESCRIPTION
In the simple regression example, the dimension size are different betwwen targets and output, and I calculated the MseLoss by hand, the results are also different with the result generated by burn. Changing `unsqueeze()` to `unsqueeze_dim(1)` eliminates the discrepency.
