### PR TITLE
Write to output slice in place in `conv2d/im2col`

### DIFF
--- a/crates/burn-dataset/src/dataset/sqlite.rs
+++ b/crates/burn-dataset/src/dataset/sqlite.rs
@@ -684,9 +684,8 @@ mod tests {
 
         let mut match_count = 0;
         for (_index, result) in indices.iter().zip(results.iter()) {
-            match result {
-                Some(_val) => match_count += 1,
-                None => (),
+            if let Some(_val) = result {
+                match_count += 1
             }
         }
 

--- a/crates/burn-jit/src/kernel/conv/conv2d/col2im.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d/col2im.rs
@@ -5,7 +5,7 @@ use burn_tensor::{
 use cubecl::{calculate_cube_count_elemwise, prelude::*};
 
 use crate::{
-    kernel::{into_contiguous, slice},
+    kernel::into_contiguous,
     ops::{numeric::empty_device, reshape, swap_dims},
     tensor::JitTensor,
     FloatElement, IntElement, JitBackend, JitRuntime,


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

Since offset slices didn't exist when this code was written, I used `slice_assign` to combine outputs between runs. Now that offset handles are implemented we can write to the slice in place and avoid repeated copies of the output tensor. The speed gain is proportional to the number of sub-batches, for the `conv2d` bench on `wgpu` it's twice as fast, with `SPIR-V` (CMMA enabled) it's 3x as fast, but still slower than implicit GEMM.

### Testing

All existing tests pass with the conv2d strategy manually set to `Conv2dStrategy::Gemm`.
