### PR TITLE
Add SPIR-V compiler backend to `burn-wgpu`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1420,10 +1420,11 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.2.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7854b343975c990dd8bb1b4b68b3bc9bda488c1d#7854b343975c990dd8bb1b4b68b3bc9bda488c1d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=547c3fe249deae7d0efe13a47d368c34ce9a736c#547c3fe249deae7d0efe13a47d368c34ce9a736c"
 dependencies = [
  "cubecl-core",
  "cubecl-cuda",
+ "cubecl-hip",
  "cubecl-linalg",
  "cubecl-runtime",
  "cubecl-wgpu",
@@ -1432,7 +1433,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.2.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7854b343975c990dd8bb1b4b68b3bc9bda488c1d#7854b343975c990dd8bb1b4b68b3bc9bda488c1d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=547c3fe249deae7d0efe13a47d368c34ce9a736c#547c3fe249deae7d0efe13a47d368c34ce9a736c"
 dependencies = [
  "derive-new",
  "embassy-futures",
@@ -1448,7 +1449,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.2.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7854b343975c990dd8bb1b4b68b3bc9bda488c1d#7854b343975c990dd8bb1b4b68b3bc9bda488c1d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=547c3fe249deae7d0efe13a47d368c34ce9a736c#547c3fe249deae7d0efe13a47d368c34ce9a736c"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1463,13 +1464,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "cubecl-cuda"
+name = "cubecl-cpp"
 version = "0.2.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7854b343975c990dd8bb1b4b68b3bc9bda488c1d#7854b343975c990dd8bb1b4b68b3bc9bda488c1d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=547c3fe249deae7d0efe13a47d368c34ce9a736c#547c3fe249deae7d0efe13a47d368c34ce9a736c"
 dependencies = [
  "bytemuck",
  "cubecl-common",
  "cubecl-core",
+ "cubecl-runtime",
+ "derive-new",
+ "half",
+ "log",
+]
+
+[[package]]
+name = "cubecl-cuda"
+version = "0.2.0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=547c3fe249deae7d0efe13a47d368c34ce9a736c#547c3fe249deae7d0efe13a47d368c34ce9a736c"
+dependencies = [
+ "bytemuck",
+ "cubecl-common",
+ "cubecl-core",
+ "cubecl-cpp",
  "cubecl-runtime",
  "cudarc 0.12.1",
  "derive-new",
@@ -1478,9 +1494,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "cubecl-hip"
+version = "0.2.0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=547c3fe249deae7d0efe13a47d368c34ce9a736c#547c3fe249deae7d0efe13a47d368c34ce9a736c"
+dependencies = [
+ "bytemuck",
+ "cubecl-common",
+ "cubecl-core",
+ "cubecl-cpp",
+ "cubecl-hip-sys",
+ "cubecl-runtime",
+ "derive-new",
+ "half",
+ "log",
+]
+
+[[package]]
+name = "cubecl-hip-sys"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daa04c96e99d6983de13345fc8175fe1479b1076019686f6344383b3c0db8bb1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cubecl-linalg"
 version = "0.2.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7854b343975c990dd8bb1b4b68b3bc9bda488c1d#7854b343975c990dd8bb1b4b68b3bc9bda488c1d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=547c3fe249deae7d0efe13a47d368c34ce9a736c#547c3fe249deae7d0efe13a47d368c34ce9a736c"
 dependencies = [
  "bytemuck",
  "cubecl-core",
@@ -1491,7 +1532,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.2.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7854b343975c990dd8bb1b4b68b3bc9bda488c1d#7854b343975c990dd8bb1b4b68b3bc9bda488c1d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=547c3fe249deae7d0efe13a47d368c34ce9a736c#547c3fe249deae7d0efe13a47d368c34ce9a736c"
 dependencies = [
  "cubecl-common",
  "darling",
@@ -1504,9 +1545,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cubecl-opt"
+version = "0.2.0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=547c3fe249deae7d0efe13a47d368c34ce9a736c#547c3fe249deae7d0efe13a47d368c34ce9a736c"
+dependencies = [
+ "cubecl-common",
+ "cubecl-core",
+ "float-ord",
+ "log",
+ "num",
+ "petgraph",
+ "smallvec",
+ "stable-vec",
+]
+
+[[package]]
 name = "cubecl-runtime"
 version = "0.2.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7854b343975c990dd8bb1b4b68b3bc9bda488c1d#7854b343975c990dd8bb1b4b68b3bc9bda488c1d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=547c3fe249deae7d0efe13a47d368c34ce9a736c#547c3fe249deae7d0efe13a47d368c34ce9a736c"
 dependencies = [
  "async-channel",
  "cfg_aliases 0.2.1",
@@ -1516,6 +1572,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "log",
  "md5",
+ "sanitize-filename",
  "serde",
  "serde_json",
  "spin",
@@ -1523,16 +1580,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "cubecl-spirv"
+version = "0.2.0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=547c3fe249deae7d0efe13a47d368c34ce9a736c#547c3fe249deae7d0efe13a47d368c34ce9a736c"
+dependencies = [
+ "cubecl-common",
+ "cubecl-core",
+ "cubecl-opt",
+ "cubecl-runtime",
+ "hashbrown 0.14.5",
+ "rspirv",
+]
+
+[[package]]
 name = "cubecl-wgpu"
 version = "0.2.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7854b343975c990dd8bb1b4b68b3bc9bda488c1d#7854b343975c990dd8bb1b4b68b3bc9bda488c1d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=547c3fe249deae7d0efe13a47d368c34ce9a736c#547c3fe249deae7d0efe13a47d368c34ce9a736c"
 dependencies = [
+ "ash",
  "async-channel",
  "bytemuck",
  "cfg_aliases 0.2.1",
  "cubecl-common",
  "cubecl-core",
  "cubecl-runtime",
+ "cubecl-spirv",
  "derive-new",
  "hashbrown 0.14.5",
  "log",
@@ -2066,6 +2138,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "flate2"
 version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2083,6 +2161,12 @@ checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "float-ord"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
 
 [[package]]
 name = "flume"
@@ -3786,6 +3870,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "no-std-compat"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df270209a7f04d62459240d890ecb792714d5db12c92937823574a09930276b4"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3827,6 +3917,20 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
 ]
 
 [[package]]
@@ -3872,6 +3976,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -4369,6 +4484,16 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.6.0",
+]
 
 [[package]]
 name = "phf"
@@ -5517,6 +5642,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rspirv"
+version = "0.12.0+sdk-1.3.268.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cf3a93856b6e5946537278df0d3075596371b1950ccff012f02b0f7eafec8d"
+dependencies = [
+ "rustc-hash",
+ "spirv",
+]
+
+[[package]]
 name = "rstest"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6095,6 +6230,15 @@ checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
 dependencies = [
  "quote",
  "syn 2.0.79",
+]
+
+[[package]]
+name = "stable-vec"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1dff32a2ce087283bec878419027cebd888760d8760b2941ad0843531dc9ec8"
+dependencies = [
+ "no-std-compat",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,8 +152,8 @@ tch = "0.15.0"
 portable-atomic-util = { version = "0.2.2", features = ["alloc"] }
 
 ### For the main burn branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "7854b343975c990dd8bb1b4b68b3bc9bda488c1d" }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "7854b343975c990dd8bb1b4b68b3bc9bda488c1d" }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "547c3fe249deae7d0efe13a47d368c34ce9a736c" }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "547c3fe249deae7d0efe13a47d368c34ce9a736c" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false  }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ lines of WGSL [WebGPU Shading Language]("https://www.w3.org/TR/WGSL/https://www.
 an extremely verbose lower level shader language you probably don't want to program your deep
 learning models in!
 
-> As of now, our fusion strategy is only implemented for our own WGPU backend and supports only a
-> subset of operations. We plan to add more operations very soon and extend this technique to other
-> future in-house backends.
+> As of now, our fusion strategy is only implemented for our own WGPU and CUDA backends and supports
+> only a subset of operations. We plan to add more operations very soon and extend this technique to
+> other future in-house backends.
 
 </details>
 
@@ -160,9 +160,10 @@ since this is how fully-connected neural networks are modeled.
 
 More and more, hardware manufacturers optimize their chips specifically for matrix multiplication
 workloads. For instance, Nvidia has its _Tensor Cores_ and today most cellphones have AI specialized
-chips. As of this moment, we support Tensor Cores with our LibTorch and Candle backends, but not
-other accelerators yet. We hope [this issue](https://github.com/gpuweb/gpuweb/issues/4195) gets
-resolved at some point to bring support to our WGPU backend.
+chips. As of this moment, we support Tensor Cores with our LibTorch, Candle, CUDA and WGPU/SPIR-V
+backends, but not other accelerators yet. We hope
+[this issue](https://github.com/gpuweb/gpuweb/issues/4195) gets resolved at some point to bring
+support to our WGPU backend.
 
 </details>
 
@@ -178,8 +179,8 @@ functionalities of a backend implementation to suit your personal modeling requi
 
 This versatility is advantageous in numerous ways, such as supporting custom operations like flash
 attention or manually writing your own kernel for a specific backend to enhance performance. See
-[this section](https://burn.dev/burn-book/advanced/backend-extension/index.html) in the Burn Book 🔥 for
-more details.
+[this section](https://burn.dev/burn-book/advanced/backend-extension/index.html) in the Burn Book 🔥
+for more details.
 
 </details>
 
@@ -300,7 +301,8 @@ means it can run in bare metal environment such as embedded devices without an o
 <div align="left">
 <img align="right" src="https://raw.githubusercontent.com/tracel-ai/burn/main/assets/backend-chip.png" height="96px"/>
 Burn strives to be as fast as possible on as many hardwares as possible, with robust implementations.
-We believe this flexibility is crucial for modern needs where you may train your models in the cloud, then deploy on customer hardwares, which vary from user to user.
+We believe this flexibility is crucial for modern needs where you may train your models in the cloud,
+then deploy on customer hardwares, which vary from user to user.
 </div>
 
 <br />
@@ -322,8 +324,9 @@ WGPU (WebGPU): Cross-Platform GPU Backend 🌐
 
 Based on the most popular and well-supported Rust graphics library, [WGPU](https://wgpu.rs), this
 backend automatically targets Vulkan, OpenGL, Metal, Direct X11/12, and WebGPU, by using the WebGPU
-shading language [WGSL](https://www.w3.org/TR/WGSL/https://www.w3.org/TR/WGSL/). It can also be
-compiled to Web Assembly to run in the browser while leveraging the GPU, see
+shading language [WGSL](https://www.w3.org/TR/WGSL/https://www.w3.org/TR/WGSL/), or optionally
+[SPIR-V](https://www.khronos.org/spir/) when targeting Vulkan. It can also be compiled to Web Assembly
+to run in the browser while leveraging the GPU, see
 [this demo](https://antimora.github.io/image-classification/). For more information on the benefits
 of this backend, see [this blog](https://burn.dev/blog/cross-platform-gpu-backend).
 
@@ -331,8 +334,11 @@ The WGPU backend is our first "in-house backend", which means we have complete c
 implementation details. It is fully optimized with the
 [performance characteristics mentioned earlier](#performance), as it serves as our research
 playground for a variety of optimizations.
+We've since added CUDA, ROCm and SPIR-V support using the same compiler infrastructure, so a kernel
+written for burn once, can run anywhere.
 
-See the [WGPU Backend README](./crates/burn-wgpu/README.md) for more details.
+See the [WGPU Backend README](./crates/burn-wgpu/README.md) and
+[CUDA Backend README](./crates/burn-cuda/README.md) for more details.
 
 </details>
 
@@ -429,7 +435,7 @@ Fusion: Backend decorator that brings kernel fusion to backends that support it 
 
 This backend decorator enhances a backend with kernel fusion, provided that the inner backend
 supports it. Note that you can compose this backend with other backend decorators such as Autodiff.
-For now, only the WGPU backend has support for fused kernels.
+For now, only the WGPU and CUDA backends have support for fused kernels.
 
 ```rust
 use burn::backend::{Autodiff, Fusion, Wgpu};

--- a/backend-comparison/Cargo.toml
+++ b/backend-comparison/Cargo.toml
@@ -26,6 +26,8 @@ tch-cpu = ["burn/tch"]
 tch-gpu = ["burn/tch"]
 wgpu = ["burn/wgpu", "burn/autotune"]
 wgpu-fusion = ["wgpu", "burn/fusion"]
+wgpu-spirv = ["burn/wgpu-spirv", "burn/autotune"]
+wgpu-spirv-fusion = ["wgpu-spirv", "burn/fusion"]
 
 [dependencies]
 arboard = { workspace = true }
@@ -34,7 +36,7 @@ burn-common = { path = "../crates/burn-common", version = "0.15.0" }
 burn-wgpu = { path = "../crates/burn-wgpu", default-features = false, version = "0.15.0", optional = true }
 clap = { workspace = true }
 colored = { workspace = true }
-cubecl = { workspace = true, features = ["wgpu"] }
+cubecl = { workspace = true, features = ["wgpu"], default-features = true }
 derive-new = { workspace = true }
 dirs = { workspace = true }
 github-device-flow = { workspace = true }

--- a/backend-comparison/README.md
+++ b/backend-comparison/README.md
@@ -37,14 +37,23 @@ Available Backends:
 - tch-gpu
 - wgpu
 - wgpu-fusion
+- wgpu-spirv
+- wgpu-spirv-fusion
 
 Available Benchmarks:
 - binary
 - custom-gelu
 - data
 - matmul
-- resnet50
 - unary
+- max-pool2d
+- resnet50
+- load-record
+- autodiff
+- conv-transpose2d
+- conv-transpose3d
+- conv2d
+- conv3d
 ```
 
 #### Run benchmarks

--- a/backend-comparison/src/burnbenchapp/base.rs
+++ b/backend-comparison/src/burnbenchapp/base.rs
@@ -78,6 +78,10 @@ enum BackendValues {
     Wgpu,
     #[strum(to_string = "wgpu-fusion")]
     WgpuFusion,
+    #[strum(to_string = "wgpu-spirv")]
+    WgpuSpirv,
+    #[strum(to_string = "wgpu-spirv-fusion")]
+    WgpuSpirvFusion,
     #[strum(to_string = "cuda-jit")]
     CudaJit,
     #[strum(to_string = "cuda-jit-fusion")]

--- a/backend-comparison/src/lib.rs
+++ b/backend-comparison/src/lib.rs
@@ -57,16 +57,27 @@ macro_rules! bench_on_backend {
         let feature_name = "wgpu";
         #[cfg(feature = "wgpu-fusion")]
         let feature_name = "wgpu-fusion";
+        #[cfg(feature = "wgpu-spirv")]
+        let feature_name = "wgpu-spirv";
+        #[cfg(feature = "wgpu-spirv-fusion")]
+        let feature_name = "wgpu-spirv-fusion";
         #[cfg(feature = "cuda-jit")]
         let feature_name = "cuda-jit";
         #[cfg(feature = "cuda-jit-fusion")]
         let feature_name = "cuda-jit-fusion";
 
-        #[cfg(feature = "wgpu")]
+        #[cfg(any(feature = "wgpu"))]
         {
             use burn::backend::wgpu::{Wgpu, WgpuDevice};
 
             bench::<Wgpu<f32, i32>>(&WgpuDevice::default(), feature_name, url, token);
+        }
+
+        #[cfg(any(feature = "wgpu-spirv"))]
+        {
+            use burn::backend::wgpu::{Wgpu, WgpuDevice};
+
+            bench::<Wgpu<half::f16, i32>>(&WgpuDevice::default(), feature_name, url, token);
         }
 
         #[cfg(feature = "tch-gpu")]

--- a/crates/burn-core/Cargo.toml
+++ b/crates/burn-core/Cargo.toml
@@ -104,6 +104,7 @@ test-cuda = ["cuda-jit"] # To use cuda during testing, default uses ndarray.
 test-tch = ["tch"] # To use tch during testing, default uses ndarray.
 test-wgpu = ["wgpu"] # To use wgpu during testing, default uses ndarray.
 test-wgpu-spirv = [
+    "test-wgpu",
     "wgpu-spirv",
 ] # To use wgpu-spirv during testing, default uses ndarray.
 

--- a/crates/burn-core/Cargo.toml
+++ b/crates/burn-core/Cargo.toml
@@ -2,16 +2,17 @@
 authors = ["nathanielsimard <nathaniel.simard.42@gmail.com>"]
 categories = ["science", "no-std", "embedded", "wasm"]
 description = "Flexible and Comprehensive Deep Learning Framework in Rust"
+documentation = "https://docs.rs/burn-core"
 edition.workspace = true
 keywords = ["deep-learning", "machine-learning", "tensor", "pytorch", "ndarray"]
 license.workspace = true
 name = "burn-core"
 readme.workspace = true
 repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-core"
-documentation = "https://docs.rs/burn-core"
 version.workspace = true
 
 [features]
+dataset = ["burn-dataset"]
 default = [
     "std",
     "burn-candle?/default",
@@ -23,24 +24,6 @@ default = [
     "burn-wgpu?/default",
     "burn-cuda?/default",
     "burn-autodiff?/default",
-]
-std = [
-    "burn-autodiff?/std",
-    "bincode/std",
-    "burn-candle?/std",
-    "burn-common/std",
-    "burn-ndarray?/std",
-    "burn-tensor/std",
-    "burn-wgpu?/std",
-    "burn-cuda?/std",
-    "flate2",
-    "half/std",
-    "log",
-    "rand/std",
-    "rmp-serde",
-    "serde/std",
-    "serde_json/std",
-    "num-traits/std",
 ]
 doc = [
     "std",
@@ -64,10 +47,27 @@ doc = [
     "burn-wgpu/doc",
     "burn-cuda/doc",
 ]
-dataset = ["burn-dataset"]
 network = ["burn-common/network"]
 sqlite = ["burn-dataset?/sqlite"]
 sqlite-bundled = ["burn-dataset?/sqlite-bundled"]
+std = [
+    "burn-autodiff?/std",
+    "bincode/std",
+    "burn-candle?/std",
+    "burn-common/std",
+    "burn-ndarray?/std",
+    "burn-tensor/std",
+    "burn-wgpu?/std",
+    "burn-cuda?/std",
+    "flate2",
+    "half/std",
+    "log",
+    "rand/std",
+    "rmp-serde",
+    "serde/std",
+    "serde_json/std",
+    "num-traits/std",
+]
 vision = ["burn-dataset?/vision", "burn-common/network"]
 
 # Backend
@@ -75,20 +75,21 @@ autodiff = ["burn-autodiff"]
 fusion = ["burn-wgpu?/fusion", "burn-cuda?/fusion"]
 
 ## Backend features
-metal = ["burn-candle?/metal"]
 accelerate = ["burn-candle?/accelerate", "burn-ndarray?/blas-accelerate"]
+autotune = ["burn-wgpu?/autotune"]
+blas-netlib = ["burn-ndarray?/blas-netlib"]
+metal = ["burn-candle?/metal"]
 openblas = ["burn-ndarray?/blas-openblas"]
 openblas-system = ["burn-ndarray?/blas-openblas-system"]
-blas-netlib = ["burn-ndarray?/blas-netlib"]
-autotune = ["burn-wgpu?/autotune"]
 template = ["burn-wgpu?/template"]
 
-ndarray = ["burn-ndarray"]
-tch = ["burn-tch"]
 candle = ["burn-candle"]
 candle-cuda = ["candle", "burn-candle/cuda"]
-wgpu = ["burn-wgpu"]
 cuda-jit = ["burn-cuda"]
+ndarray = ["burn-ndarray"]
+tch = ["burn-tch"]
+wgpu = ["burn-wgpu"]
+wgpu-spirv = ["wgpu", "burn-wgpu/spirv"]
 
 # Custom deserializer for Record that is helpful for importing data, such as PyTorch pt files.
 record-item-custom-serde = ["thiserror", "regex"]
@@ -99,9 +100,9 @@ experimental-named-tensor = ["burn-tensor/experimental-named-tensor"]
 # Backwards compatibility with previous serialized data format.
 record-backward-compat = []
 
+test-cuda = ["cuda-jit"] # To use cuda during testing, default uses ndarray.
 test-tch = ["tch"]       # To use tch during testing, default uses ndarray.
 test-wgpu = ["wgpu"]     # To use wgpu during testing, default uses ndarray.
-test-cuda = ["cuda-jit"] # To use cuda during testing, default uses ndarray.
 
 [dependencies]
 
@@ -113,12 +114,12 @@ burn-derive = { path = "../burn-derive", version = "0.15.0" }
 burn-tensor = { path = "../burn-tensor", version = "0.15.0", default-features = false }
 
 # Backends
-burn-ndarray = { path = "../burn-ndarray", version = "0.15.0", optional = true, default-features = false }
-burn-wgpu = { path = "../burn-wgpu", version = "0.15.0", optional = true, default-features = false }
-burn-cuda = { path = "../burn-cuda", version = "0.15.0", optional = true, default-features = false }
 burn-autodiff = { path = "../burn-autodiff", version = "0.15.0", optional = true }
-burn-tch = { path = "../burn-tch", version = "0.15.0", optional = true }
 burn-candle = { path = "../burn-candle", version = "0.15.0", optional = true }
+burn-cuda = { path = "../burn-cuda", version = "0.15.0", optional = true, default-features = false }
+burn-ndarray = { path = "../burn-ndarray", version = "0.15.0", optional = true, default-features = false }
+burn-tch = { path = "../burn-tch", version = "0.15.0", optional = true }
+burn-wgpu = { path = "../burn-wgpu", version = "0.15.0", optional = true, default-features = false }
 
 data-encoding = { workspace = true }
 uuid = { workspace = true }
@@ -136,24 +137,24 @@ serde = { workspace = true, features = ["derive"] }
 
 bincode = { workspace = true }
 half = { workspace = true }
+num-traits = { workspace = true }
+regex = { workspace = true, optional = true }
 rmp-serde = { workspace = true, optional = true }
 serde_json = { workspace = true, features = ["alloc"] } #Default enables std
-thiserror = { workspace = true, optional = true }
-regex = { workspace = true, optional = true }
-num-traits = { workspace = true }
 spin = { workspace = true }                             # Using in place of use std::sync::Mutex when std is disabled
+thiserror = { workspace = true, optional = true }
 
 [target.'cfg(not(target_has_atomic = "ptr"))'.dependencies]
 portable-atomic-util = { workspace = true }
 
 [dev-dependencies]
-tempfile = { workspace = true }
 burn-dataset = { path = "../burn-dataset", version = "0.15.0", features = [
     "fake",
 ] }
+tempfile = { workspace = true }
 
-burn-ndarray = { path = "../burn-ndarray", version = "0.15.0", default-features = false }
 burn-autodiff = { path = "../burn-autodiff", version = "0.15.0" }
+burn-ndarray = { path = "../burn-ndarray", version = "0.15.0", default-features = false }
 
 [package.metadata.docs.rs]
 features = ["doc"]

--- a/crates/burn-core/Cargo.toml
+++ b/crates/burn-core/Cargo.toml
@@ -101,8 +101,11 @@ experimental-named-tensor = ["burn-tensor/experimental-named-tensor"]
 record-backward-compat = []
 
 test-cuda = ["cuda-jit"] # To use cuda during testing, default uses ndarray.
-test-tch = ["tch"]       # To use tch during testing, default uses ndarray.
-test-wgpu = ["wgpu"]     # To use wgpu during testing, default uses ndarray.
+test-tch = ["tch"] # To use tch during testing, default uses ndarray.
+test-wgpu = ["wgpu"] # To use wgpu during testing, default uses ndarray.
+test-wgpu-spirv = [
+    "wgpu-spirv",
+] # To use wgpu-spirv during testing, default uses ndarray.
 
 [dependencies]
 

--- a/crates/burn-wgpu/Cargo.toml
+++ b/crates/burn-wgpu/Cargo.toml
@@ -2,21 +2,22 @@
 authors = ["nathanielsimard <nathaniel.simard.42@gmail.com>"]
 categories = ["science"]
 description = "WGPU backend for the Burn framework"
+documentation = "https://docs.rs/burn-wgpu"
 edition.workspace = true
 keywords = ["deep-learning", "machine-learning", "gpu", "wgpu", "webgpu"]
 license.workspace = true
 name = "burn-wgpu"
 readme.workspace = true
 repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-wgpu"
-documentation = "https://docs.rs/burn-wgpu"
 version.workspace = true
 
 [features]
 autotune = ["burn-jit/autotune"]
 default = ["std", "autotune", "fusion", "burn-jit/default", "cubecl/default"]
 doc = ["burn-jit/doc"]
-fusion = ["burn-fusion", "burn-jit/fusion"]
 exclusive-memory-only = ["cubecl/exclusive-memory-only"]
+fusion = ["burn-fusion", "burn-jit/fusion"]
+spirv = ["cubecl/wgpu-spirv"]
 std = ["burn-jit/std", "cubecl/std"]
 template = ["burn-jit/template", "cubecl/template"]
 
@@ -28,6 +29,7 @@ burn-jit = { path = "../burn-jit", version = "0.15.0", default-features = false 
 burn-tensor = { path = "../burn-tensor", version = "0.15.0", features = [
   "cubecl-wgpu",
 ] }
+
 
 [dev-dependencies]
 burn-jit = { path = "../burn-jit", version = "0.15.0", default-features = false, features = [

--- a/crates/burn-wgpu/README.md
+++ b/crates/burn-wgpu/README.md
@@ -28,7 +28,17 @@ mod wgpu {
 
 ## Configuration
 
-You can set `BURN_WGPU_MAX_TASKS` to a positive integer that determines how many computing tasks are submitted in batches to the graphics API.
+You can set `BURN_WGPU_MAX_TASKS` to a positive integer that determines how many computing tasks are
+submitted in batches to the graphics API.
+
+## Alternative SPIR-V backend
+
+When targeting Vulkan, the `spirv` feature flag can be enabled to enable the SPIR-V compiler backend,
+which performs significantly better than WGSL. This is especially true for matrix multiplication,
+where SPIR-V can make use of TensorCores and run at `f16` precision. This isn't currently supported
+by WGSL.
+The compiler can also be selected at runtime by setting the corresponding generic parameter to
+either `SpirV` or `Wgsl`.
 
 ## Platform Support
 

--- a/crates/burn-wgpu/src/lib.rs
+++ b/crates/burn-wgpu/src/lib.rs
@@ -14,6 +14,15 @@ pub use burn_jit::{FloatElement, IntElement};
 pub use cubecl::ir::CubeDim;
 pub use cubecl::wgpu::*;
 
+pub type Wgsl = cubecl::wgpu::WgslCompiler;
+#[cfg(feature = "spirv")]
+pub type SpirV = cubecl::wgpu::spirv::VkSpirvCompiler;
+
+#[cfg(feature = "spirv")]
+type Compiler = SpirV;
+#[cfg(not(feature = "spirv"))]
+type Compiler = Wgsl;
+
 #[cfg(feature = "fusion")]
 /// Tensor backend that uses the wgpu crate for executing GPU compute shaders.
 ///
@@ -46,7 +55,8 @@ pub use cubecl::wgpu::*;
 ///
 /// You can disable the `fusion` feature flag to remove that functionality, which might be
 /// necessary on `wasm` for now.
-pub type Wgpu<F = f32, I = i32> = burn_fusion::Fusion<JitBackend<cubecl::wgpu::WgpuRuntime, F, I>>;
+pub type Wgpu<F = f32, I = i32, C = Compiler> =
+    burn_fusion::Fusion<JitBackend<cubecl::wgpu::WgpuRuntime<C>, F, I>>;
 
 #[cfg(not(feature = "fusion"))]
 /// Tensor backend that uses the wgpu crate for executing GPU compute shaders.
@@ -80,12 +90,12 @@ pub type Wgpu<F = f32, I = i32> = burn_fusion::Fusion<JitBackend<cubecl::wgpu::W
 ///
 /// You can enable the `fusion` feature flag to add that functionality, which might improve
 /// performance.
-pub type Wgpu<F = f32, I = i32> = JitBackend<WgpuRuntime, F, I>;
+pub type Wgpu<F = f32, I = i32, C = Compiler> = JitBackend<cubecl::wgpu::WgpuRuntime<C>, F, I>;
 
 #[cfg(test)]
 mod tests {
     use burn_jit::JitBackend;
-    pub type TestRuntime = cubecl::wgpu::WgpuRuntime;
+    pub type TestRuntime = cubecl::wgpu::WgpuRuntime<super::Compiler>;
 
     burn_jit::testgen_all!();
 }

--- a/crates/burn/Cargo.toml
+++ b/crates/burn/Cargo.toml
@@ -2,20 +2,20 @@
 authors = ["nathanielsimard <nathaniel.simard.42@gmail.com>"]
 categories = ["science", "no-std", "embedded", "wasm"]
 description = "Flexible and Comprehensive Deep Learning Framework in Rust"
+documentation = "https://docs.rs/burn"
 edition.workspace = true
 keywords = ["deep-learning", "machine-learning", "tensor", "pytorch", "ndarray"]
 license.workspace = true
 name = "burn"
 readme.workspace = true
 repository = "https://github.com/tracel-ai/burn"
-documentation = "https://docs.rs/burn"
-version.workspace = true
 rust-version = "1.80"
+version.workspace = true
 
 [features]
 default = ["burn-core/default", "burn-train?/default", "std"]
-std = ["burn-core/std"]
 doc = ["default", "train", "burn-core/doc", "burn-train/doc"]
+std = ["burn-core/std"]
 
 # Training with full features
 train = ["burn-train", "autodiff", "dataset"]
@@ -39,20 +39,21 @@ autodiff = ["burn-core/autodiff"]
 fusion = ["burn-core/fusion"]
 
 ## Backend features
+accelerate = ["burn-core/accelerate"]
+autotune = ["burn-core/autotune"]
+blas-netlib = ["burn-core/blas-netlib"]
 candle-cuda = ["burn-core/candle-cuda"]
 metal = ["burn-core/metal"]
-accelerate = ["burn-core/accelerate"]
 openblas = ["burn-core/openblas"]
 openblas-system = ["burn-core/openblas-system"]
-blas-netlib = ["burn-core/blas-netlib"]
-autotune = ["burn-core/autotune"]
 template = ["burn-core/template"]
 
-ndarray = ["burn-core/ndarray"]
-wgpu = ["burn-core/wgpu"]
-cuda-jit = ["burn-core/cuda-jit"]
-tch = ["burn-core/tch"]
 candle = ["burn-core/candle"]
+cuda-jit = ["burn-core/cuda-jit"]
+ndarray = ["burn-core/ndarray"]
+tch = ["burn-core/tch"]
+wgpu = ["burn-core/wgpu"]
+wgpu-spirv = ["burn-core/wgpu-spirv"]
 
 # Network utils
 network = ["burn-core/network"]
@@ -61,8 +62,8 @@ network = ["burn-core/network"]
 experimental-named-tensor = ["burn-core/experimental-named-tensor"]
 
 # Records
-record-item-custom-serde = ["burn-core/record-item-custom-serde"]
 record-backward-compat = ["burn-core/record-backward-compat"]
+record-item-custom-serde = ["burn-core/record-item-custom-serde"]
 
 [dependencies]
 

--- a/crates/burn/src/lib.rs
+++ b/crates/burn/src/lib.rs
@@ -76,6 +76,7 @@
 //!   - `vision`: Enables vision datasets (MnistDataset)
 //! - Backends
 //!   - `wgpu`: Makes available the WGPU backend
+//!   - `wgpu-spirv`: Makes available the `wgpu` backend with the alternative SPIR-V compiler
 //!   - `candle`: Makes available the Candle backend
 //!   - `tch`: Makes available the LibTorch backend
 //!   - `ndarray`: Makes available the NdArray backend

--- a/xtask/src/commands/test.rs
+++ b/xtask/src/commands/test.rs
@@ -74,6 +74,16 @@ pub(crate) fn handle_command(
                 )?;
             }
 
+            if std::env::var("DISABLE_WGPU_SPIRV").is_err() {
+                helpers::custom_crates_tests(
+                    vec!["burn-core"],
+                    vec!["--features", "test-wgpu-spirv"],
+                    None,
+                    None,
+                    "std wgpu-spirv",
+                )?;
+            }
+
             // MacOS specific tests
             #[cfg(target_os = "macos")]
             {


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

Adds a feature to enable the new alternative SPIR-V compiler for the WGPU backend. When the feature is enabled the compiler defaults to SPIR-V, but can still be overriden with a generic.

### Testing

New testing option has been added to run SPIR-V tests in addition to the `wgsl` ones. All tests pass. `xtask validate` passes.