### PR TITLE
Add should_run for convs instead of panicking

### DIFF
--- a/crates/burn-jit/src/kernel/conv/conv2d/col2im.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d/col2im.rs
@@ -56,7 +56,8 @@ pub fn conv_transpose2d_col2im<R: JitRuntime, E: FloatElement, I: IntElement>(
     );
     let im_channels = im_ch_per_group * groups;
 
-    let batches_per_run = batches_per_run(batch_size, input_h, input_w);
+    let batches_per_run = batches_per_run(batch_size, input_h, input_w)
+        .expect("Image too large to run even one batch at once");
     let col_shape_0 = im_ch_per_group * kernel_h * kernel_w;
 
     let weight = reshape(

--- a/crates/burn-jit/src/kernel/conv/conv2d/im2col.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d/im2col.rs
@@ -209,18 +209,6 @@ pub fn conv2d_im2col<R: JitRuntime, E: FloatElement, I: IntElement>(
         return execute_1x1_kernel::<R, E, I>(input, weight, bias, options);
     }
 
-    log::error!("Doing batches_per_run now");
-    log::error!("Batch size: {}", batch_size);
-    log::error!("Input channels: {}", in_channels);
-    log::error!("Input height: {}", in_height);
-    log::error!("Input width: {}", in_width);
-    log::error!("Output channels: {}", out_channels);
-    log::error!("Kernel height: {}", kernel_h);
-    log::error!("Kernel width: {}", kernel_w);
-    log::error!("Output height: {}", out_h);
-    log::error!("Output width: {}", out_w);
-    log::error!("Groups: {}", groups);
-
     let batches_per_run = batches_per_run(batch_size, out_h, out_w)
         .expect("Image too large to run even one batch at once");
     let matmul_shape = Shape::new([groups, out_c_per_group, batches_per_run * out_h * out_w]);

--- a/crates/burn-jit/src/kernel/conv/conv2d/im2col.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d/im2col.rs
@@ -93,23 +93,25 @@ fn im2col_kernel<F: Float>(
 }
 
 #[cfg(not(test))]
-pub(crate) fn batches_per_run(batch_size: usize, out_h: usize, out_w: usize) -> usize {
+pub(crate) fn batches_per_run(batch_size: usize, out_h: usize, out_w: usize) -> Option<usize> {
     let cube_count_per_batch = (out_h * out_w).div_ceil(cubecl::SUBCUBE_DIM_APPROX);
     let max_cube_count = u16::MAX as usize;
     let max_simultaneous = (max_cube_count / cube_count_per_batch).min(batch_size);
     if max_simultaneous == 0 {
-        panic!("Image too large to run even one batch at once");
+        return None;
     }
-    (0..=max_simultaneous)
-        .rev()
-        .find(|per_run| batch_size % per_run == 0)
-        .unwrap()
+    Some(
+        (0..=max_simultaneous)
+            .rev()
+            .find(|per_run| batch_size % per_run == 0)
+            .expect("Logically not possible"),
+    )
 }
 
 #[cfg(test)]
 #[allow(unused)]
-pub(crate) fn batches_per_run(batch_size: usize, out_h: usize, out_w: usize) -> usize {
-    1
+pub(crate) fn batches_per_run(batch_size: usize, out_h: usize, out_w: usize) -> Option<usize> {
+    Some(1)
 }
 
 fn im2col<R: JitRuntime, E: FloatElement>(
@@ -207,7 +209,8 @@ pub fn conv2d_im2col<R: JitRuntime, E: FloatElement, I: IntElement>(
         return execute_1x1_kernel::<R, E, I>(input, weight, bias, options);
     }
 
-    let batches_per_run = batches_per_run(batch_size, out_h, out_w);
+    let batches_per_run = batches_per_run(batch_size, out_h, out_w)
+    	.expect("Image too large to run even one batch at once");
     let matmul_shape = Shape::new([groups, out_c_per_group, batches_per_run * out_h * out_w]);
 
     let mut out = if batches_per_run != batch_size {

--- a/crates/burn-jit/src/kernel/conv/conv2d/im2col.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d/im2col.rs
@@ -209,6 +209,18 @@ pub fn conv2d_im2col<R: JitRuntime, E: FloatElement, I: IntElement>(
         return execute_1x1_kernel::<R, E, I>(input, weight, bias, options);
     }
 
+    log::error!("Doing batches_per_run now");
+    log::error!("Batch size: {}", batch_size);
+    log::error!("Input channels: {}", in_channels);
+    log::error!("Input height: {}", in_height);
+    log::error!("Input width: {}", in_width);
+    log::error!("Output channels: {}", out_channels);
+    log::error!("Kernel height: {}", kernel_h);
+    log::error!("Kernel width: {}", kernel_w);
+    log::error!("Output height: {}", out_h);
+    log::error!("Output width: {}", out_w);
+    log::error!("Groups: {}", groups);
+
     let batches_per_run = batches_per_run(batch_size, out_h, out_w)
         .expect("Image too large to run even one batch at once");
     let matmul_shape = Shape::new([groups, out_c_per_group, batches_per_run * out_h * out_w]);

--- a/crates/burn-jit/src/kernel/conv/conv2d/im2col.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d/im2col.rs
@@ -210,7 +210,7 @@ pub fn conv2d_im2col<R: JitRuntime, E: FloatElement, I: IntElement>(
     }
 
     let batches_per_run = batches_per_run(batch_size, out_h, out_w)
-    	.expect("Image too large to run even one batch at once");
+        .expect("Image too large to run even one batch at once");
     let matmul_shape = Shape::new([groups, out_c_per_group, batches_per_run * out_h * out_w]);
 
     let mut out = if batches_per_run != batch_size {

--- a/crates/burn-jit/src/kernel/conv/conv2d/implicit_gemm.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d/implicit_gemm.rs
@@ -52,7 +52,7 @@ pub fn conv2d_implicit_gemm<R: JitRuntime, F: FloatElement, I: IntElement>(
 
     let padded_batch_size = padded_batch_size(batch_size, out_h, out_w);
 
-    if !can_do_implicit_gemm(&input, &weight, &options, out_h, out_w) {
+    if !can_do_implicit_gemm(&input, &weight, options.groups, out_h, out_w) {
         panic!(
             "Requirements for implicit GEMM not met:
 - CMMA must be available
@@ -648,7 +648,7 @@ fn load_bias_tile<F: Float>(
 pub(crate) fn can_do_implicit_gemm<R: JitRuntime, E: FloatElement>(
     input: &JitTensor<R, E>,
     weight: &JitTensor<R, E>,
-    options: &ConvOptions<2>,
+    groups: usize,
     out_h: usize,
     out_w: usize,
 ) -> bool {
@@ -670,7 +670,7 @@ pub(crate) fn can_do_implicit_gemm<R: JitRuntime, E: FloatElement>(
 
         let smem_size = ((cmma_m + cmma_n) * cmma_k * warps_per_cube) as usize * size_of::<f16>();
 
-        <R::Compiler as Compiler>::max_shared_memory_size() >= smem_size && options.groups == 1
+        <R::Compiler as Compiler>::max_shared_memory_size() >= smem_size && groups == 1
     } else {
         false
     }

--- a/crates/burn-jit/src/kernel/conv/conv2d/implicit_gemm.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d/implicit_gemm.rs
@@ -52,7 +52,16 @@ pub fn conv2d_implicit_gemm<R: JitRuntime, F: FloatElement, I: IntElement>(
 
     let padded_batch_size = padded_batch_size(batch_size, out_h, out_w);
 
-    if !can_do_implicit_gemm(&input, &weight, options.groups, out_h, out_w) {
+    if !can_do_implicit_gemm::<R, F>(
+        batch_size,
+        in_channels,
+        out_channels,
+        [kernel_h, kernel_w],
+        options.groups,
+        out_h,
+        out_w,
+        &input.device,
+    ) {
         panic!(
             "Requirements for implicit GEMM not met:
 - CMMA must be available
@@ -645,16 +654,18 @@ fn load_bias_tile<F: Float>(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn can_do_implicit_gemm<R: JitRuntime, E: FloatElement>(
-    input: &JitTensor<R, E>,
-    weight: &JitTensor<R, E>,
+    batch_size: usize,
+    in_channels: usize,
+    out_channels: usize,
+    kernel_size: [usize; 2],
     groups: usize,
     out_h: usize,
     out_w: usize,
+    device: &R::Device,
 ) -> bool {
-    let [batch_size, in_channels, _, _] = input.shape.dims();
-    let [out_channels, _, kernel_h, kernel_w] = weight.shape.dims();
-    let (in_channels, kernel_h, kernel_w) = padded_k(in_channels, kernel_h, kernel_w);
+    let (in_channels, kernel_h, kernel_w) = padded_k(in_channels, kernel_size[0], kernel_size[1]);
     let batch_size = padded_batch_size(batch_size, out_h, out_w);
     let out_channels = out_channels.div_ceil(16) * 16;
 
@@ -662,8 +673,7 @@ pub(crate) fn can_do_implicit_gemm<R: JitRuntime, E: FloatElement>(
     let gemm_n = out_channels;
     let gemm_k = in_channels * kernel_h * kernel_w;
 
-    let size =
-        find_cmma_size::<R, f16, E>(&input.device, gemm_m as u32, gemm_k as u32, gemm_n as u32);
+    let size = find_cmma_size::<R, f16, E>(device, gemm_m as u32, gemm_k as u32, gemm_n as u32);
 
     if let Some((cmma_m, cmma_k, cmma_n)) = size {
         let warps_per_cube = 8;

--- a/crates/burn-jit/src/kernel/conv/conv2d/tune/conv2d.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d/tune/conv2d.rs
@@ -84,16 +84,27 @@ fn should_run<R: JitRuntime, F: FloatElement, I: IntElement>(
 
     let o = &op.options;
 
-    let out_h =
-        calculate_conv_output_size(kernel_h, o.stride[0], o.padding[0], o.dilation[0], input_h);
-    let out_w =
-        calculate_conv_output_size(kernel_w, o.stride[1], o.padding[1], o.dilation[1], input_w);
-
     match index {
         // im2col
-        1 => batches_per_run(batch_size, out_h, out_w).is_some(),
+        1 => batches_per_run(batch_size, input_h, input_w).is_some(),
         // Implicit gemm.
-        2 => can_do_implicit_gemm(&op.input, &op.weights, op.options.groups, out_h, out_w),
+        2 => {
+            let out_h = calculate_conv_output_size(
+                kernel_h,
+                o.stride[0],
+                o.padding[0],
+                o.dilation[0],
+                input_h,
+            );
+            let out_w = calculate_conv_output_size(
+                kernel_w,
+                o.stride[1],
+                o.padding[1],
+                o.dilation[1],
+                input_w,
+            );
+            can_do_implicit_gemm(&op.input, &op.weights, op.options.groups, out_h, out_w)
+        }
         _ => true,
     }
 }

--- a/crates/burn-jit/src/kernel/conv/conv2d/tune/conv_transpose2d.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d/tune/conv_transpose2d.rs
@@ -113,28 +113,9 @@ fn should_run<R: JitRuntime, F: FloatElement, I: IntElement>(
         stride: [stride_h, stride_w],
         ..
     } = op.options.clone();
-
-    let out_h = calculate_conv_transpose_output_size(
-        kernel_h,
-        stride_h,
-        padding_h,
-        padding_out_h,
-        dilation_h,
-        input_h,
-    );
-    let out_w = calculate_conv_transpose_output_size(
-        kernel_w,
-        stride_w,
-        padding_w,
-        padding_out_w,
-        dilation_w,
-        input_w,
-    );
     match index {
         // im2col
         1 => batches_per_run(batch_size, input_h, input_w).is_some(),
-        // Implicit gemm.
-        2 => can_do_implicit_gemm(&op.input, &op.weights, op.options.groups, out_h, out_w),
         _ => true,
     }
 }

--- a/crates/burn-jit/src/kernel/conv/conv2d/tune/conv_transpose2d.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d/tune/conv_transpose2d.rs
@@ -1,7 +1,4 @@
-use burn_tensor::{
-    ops::{conv::calculate_conv_output_size, ConvTransposeOptions},
-    ElementConversion, Shape,
-};
+use burn_tensor::{ops::ConvTransposeOptions, ElementConversion, Shape};
 use cubecl::{
     tune,
     tune::{local_tuner, tune_with, LocalTuner},
@@ -107,23 +104,9 @@ fn should_run<R: JitRuntime, F: FloatElement, I: IntElement>(
         _ => unreachable!(),
     };
 
-    let out_h = calculate_conv_output_size(
-        key.kernel_size[0],
-        key.stride[0],
-        key.padding[0],
-        key.dilation[0],
-        key.height,
-    );
-    let out_w = calculate_conv_output_size(
-        key.kernel_size[1],
-        key.stride[1],
-        key.padding[1],
-        key.dilation[1],
-        key.width,
-    );
     match index {
         // im2col
-        1 => batches_per_run(key.batch_size, out_h, out_w).is_some(),
+        1 => batches_per_run(key.batch_size, key.height, key.width).is_some(),
         _ => true,
     }
 }

--- a/crates/burn-jit/src/kernel/conv/conv2d/tune/conv_transpose2d.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d/tune/conv_transpose2d.rs
@@ -1,7 +1,4 @@
-use burn_tensor::{
-    ops::{conv::calculate_conv_transpose_output_size, ConvTransposeOptions},
-    ElementConversion, Shape,
-};
+use burn_tensor::{ops::ConvTransposeOptions, ElementConversion, Shape};
 use cubecl::{
     tune,
     tune::{local_tuner, tune_with, LocalTuner},
@@ -9,9 +6,7 @@ use cubecl::{
 
 use crate::{
     kernel::{
-        conv::{
-            batches_per_run, can_do_implicit_gemm, conv_transpose2d_col2im, conv_transpose2d_direct,
-        },
+        conv::{batches_per_run, conv_transpose2d_col2im, conv_transpose2d_direct},
         prng::random_uniform,
     },
     tensor::JitTensor,
@@ -104,15 +99,7 @@ fn should_run<R: JitRuntime, F: FloatElement, I: IntElement>(
     _key: &JitAutotuneKey,
     index: usize,
 ) -> bool {
-    let [_, _, kernel_h, kernel_w] = op.weights.shape.dims();
     let [batch_size, _, input_h, input_w] = op.input.shape.dims();
-    let ConvTransposeOptions {
-        padding: [padding_h, padding_w],
-        padding_out: [padding_out_h, padding_out_w],
-        dilation: [dilation_h, dilation_w],
-        stride: [stride_h, stride_w],
-        ..
-    } = op.options.clone();
     match index {
         // im2col
         1 => batches_per_run(batch_size, input_h, input_w).is_some(),


### PR DESCRIPTION

### Changes
Conv2D currently panic in im2col / col2im for images that are too large when autotuning. This works ok on std as tuning uses catch_unwind, but this crashes on wasm.

### Testing
Running some convs on wasm, doesn't crash anymore!