### PR TITLE
Update deny.toml to follow the spec changes of cargo-deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -6,6 +6,7 @@
 # this list would mean the nix crate, as well as any of its exclusive
 # dependencies not shared by any other crates, would be ignored, as the target
 # list here is effectively saying which targets you are building for.
+[graph]
 targets = [
     { triple = "x86_64-unknown-linux-gnu" },
     { triple = "aarch64-unknown-linux-gnu" },
@@ -16,14 +17,6 @@ targets = [
 ]
 
 [advisories]
-# The lint level for security vulnerabilities
-vulnerability = "deny"
-# The lint level for unmaintained crates
-unmaintained = "deny"
-# The lint level for crates that have been yanked from their source registry
-yanked = "deny"
-# The lint level for crates with security notices.
-notice = "deny"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
@@ -70,10 +63,6 @@ unknown-registry = "deny"
 unknown-git = "deny"
 
 [licenses]
-# The lint level for crates which do not have a detectable license
-unlicensed = "deny"
-# Lint level for licenses considered copyleft
-copyleft = "deny"
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
 # canonical license text of a valid SPDX license file.


### PR DESCRIPTION
## Pull Request Template

I am not sure `deny.toml` with xtask is used now. But I submit a fix PR cause security is important.

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

https://github.com/EmbarkStudios/cargo-deny/pull/611

### Changes

I found errors as follows and the command stops before executing.

```
% cargo xtask dependencies deny                   
    Finished `dev` profile [optimized] target(s) in 0.41s
     Running `target/xtask/debug/xtask dependencies deny`
[2024-09-18T02:51:35Z INFO  tracel_xtask] Execution environment: std
[2024-09-18T02:51:36Z INFO  tracel_xtask::commands::dependencies] Cargo: run deny checks
[2024-09-18T02:51:36Z INFO  tracel_xtask::utils::process] Command line: cargo deny check
error[deprecated]: this key has been removed, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for migration information
   ┌─ /Users/tiruka/Desktop/oss-fork/burn/deny.toml:20:1
   │
20 │ vulnerability = "deny"
   │ ━━━━━━━━━━━━━

error[deprecated]: this key has been removed, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for migration information
   ┌─ /Users/tiruka/Desktop/oss-fork/burn/deny.toml:22:1
   │
22 │ unmaintained = "deny"
   │ ━━━━━━━━━━━━

error[deprecated]: this key has been removed, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for migration information
   ┌─ /Users/tiruka/Desktop/oss-fork/burn/deny.toml:26:1
   │
26 │ notice = "deny"
   │ ━━━━━━

error[deprecated]: this key has been removed, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for migration information
   ┌─ /Users/tiruka/Desktop/oss-fork/burn/deny.toml:74:1
   │
74 │ unlicensed = "deny"
   │ ━━━━━━━━━━

error[deprecated]: this key has been removed, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for migration information
   ┌─ /Users/tiruka/Desktop/oss-fork/burn/deny.toml:76:1
   │
76 │ copyleft = "deny"
   │ ━━━━━━━━

warning[deprecated]: this key has been moved to [graph]
  ┌─ /Users/tiruka/Desktop/oss-fork/burn/deny.toml:9:1
  │
9 │ targets = [
  │ ━━━━━━━

2024-09-18 02:51:36 [ERROR] failed to validate configuration file /Users/tiruka/Desktop/oss-fork/burn/deny.toml
Error: Some dependencies don't meet the requirements!
```
When seeing https://github.com/EmbarkStudios/cargo-deny/pull/611,
the advisories section has updated its defaults: vulnerabilities, unmaintained, unsound, and notices are now all set to deny, changing from a previous warning status and so on.
I modified the 

### Testing

`cargo xtask dependencies deny` command run successfully though there are violations.

