### PR TITLE
Dont attempt naive reduction when reduce_dim is too high

### DIFF
--- a/crates/burn-jit/src/kernel/reduce/tune/base.rs
+++ b/crates/burn-jit/src/kernel/reduce/tune/base.rs
@@ -103,6 +103,19 @@ where
             _ => panic!("Fastest index is out of bound"),
         }
     }
+
+    fn should_run(&self, key: &JitAutotuneKey, index: usize) -> bool {
+        let JitAutotuneKey::ReduceDim(key) = key else {
+            unreachable!();
+        };
+
+        // Little hope that naively reducing is faster if the dim length is that high.
+        if index == 0 && key.reduce_dim_length > 8192 {
+            return false;
+        }
+
+        true
+    }
 }
 
 /// Executes autotune on reduce_dim operation

--- a/crates/burn-jit/src/kernel/reduce/tune/base.rs
+++ b/crates/burn-jit/src/kernel/reduce/tune/base.rs
@@ -109,12 +109,13 @@ where
             unreachable!();
         };
 
-        // Little hope that naively reducing is faster if the dim length is that high.
-        if index == 0 && key.reduce_dim_length > 8192 {
-            return false;
+        match index {
+            // Naive
+            0 => key.reduce_dim_length <= 8192,
+            // Shared
+            1 => key.reduce_dim_length >= 16,
+            _ => true,
         }
-
-        true
     }
 }
 

--- a/crates/burn-jit/src/kernel/reduce/tune/key.rs
+++ b/crates/burn-jit/src/kernel/reduce/tune/key.rs
@@ -6,9 +6,9 @@ use burn_tensor::Shape;
 #[derive(Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
 /// Autotune key representative of reduce versions
 pub struct ReduceAutotuneKey {
-    reduce_dim_length: usize,
-    reduce_dim_stride: usize,
-    others_product: usize,
+    pub(crate) reduce_dim_length: usize,
+    pub(crate) reduce_dim_stride: usize,
+    pub(crate) others_product: usize,
 }
 
 impl Display for ReduceAutotuneKey {


### PR DESCRIPTION
## Pull Request Template


### Changes
Currently, when autotuning a reduction burn might attempt a naive reduction even for something like the mean() of an 800x800 image. This is sufficiently slow that it's problematic - taking over ~2-3 seconds of GPU time on an M1. This seems to be especially problematic on wasm where tuning is asynchronous, so as other work is running it can take even longer, meaning the app has bad performance for up to minutes before tuning is complete.

This changes it so naive reduction isn't tried above 8000 elements. That's arbitrary - but I suspect it's well above the threshold where a naive reduction makes sense. Happy to bump it up even further if it's a concern.

### Testing
My app warms up much faster on WASM with this change!
