### PR TITLE
Bump ratatui from 0.26.3 to 0.29.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,7 +766,6 @@ version = "0.15.0"
 dependencies = [
  "burn-core",
  "burn-ndarray",
- "crossterm",
  "derive-new",
  "log",
  "nvml-wrapper",
@@ -1115,7 +1114,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -1177,21 +1176,22 @@ version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b34115915337defe99b2aff5c2ce6771e5fbc4079f4b506301f5cf394c8452f7"
 dependencies = [
- "crossterm",
+ "crossterm 0.27.0",
  "strum",
  "strum_macros",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
 name = "compact_str"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+checksum = "6050c3a16ddab2e412160b31f2c871015704239bca62f72f6e5f0be631d3f644"
 dependencies = [
  "castaway",
  "cfg-if",
  "itoa",
+ "rustversion",
  "ryu",
  "static_assertions",
 ]
@@ -1214,7 +1214,7 @@ dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
- "unicode-width",
+ "unicode-width 0.1.14",
  "windows-sys 0.52.0",
 ]
 
@@ -1365,8 +1365,21 @@ dependencies = [
  "bitflags 2.6.0",
  "crossterm_winapi",
  "libc",
- "mio 0.8.11",
  "parking_lot 0.12.3",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.6.0",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot 0.12.3",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -3248,8 +3261,14 @@ dependencies = [
  "instant",
  "number_prefix",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
+
+[[package]]
+name = "indoc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "inout"
@@ -3258,6 +3277,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b23a0c8dfe501baac4adf6ebbfa6eddf8f0c07f56b058cc1288017e32397846c"
+dependencies = [
+ "quote",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -3676,24 +3705,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "mio"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.52.0",
 ]
@@ -5276,23 +5294,24 @@ checksum = "9c8a99fddc9f0ba0a85884b8d14e3592853e787d581ca1816c91349b10e4eeab"
 
 [[package]]
 name = "ratatui"
-version = "0.26.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f44c9e68fd46eda15c646fbb85e1040b657a58cdc8c98db1d97a55930d991eef"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
  "bitflags 2.6.0",
  "cassowary",
  "compact_str",
- "crossterm",
- "itertools 0.12.1",
+ "crossterm 0.28.1",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
  "lru",
  "paste",
- "stability",
  "strum",
  "time",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -6090,7 +6109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
- "mio 0.8.11",
+ "mio",
  "signal-hook",
 ]
 
@@ -6222,16 +6241,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "295e9930cd7a97e58ca2a070541a3ca502b17f5d1fa7157376d0fabd85324f25"
 dependencies = [
  "log",
-]
-
-[[package]]
-name = "stability"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
-dependencies = [
- "quote",
- "syn 2.0.82",
 ]
 
 [[package]]
@@ -6715,7 +6724,7 @@ dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio 1.0.2",
+ "mio",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
@@ -6990,7 +6999,7 @@ checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
  "itertools 0.13.0",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -6998,6 +7007,12 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,8 +97,7 @@ async-channel = "2.3"
 futures-lite = { version = "2.3.0", default-features = false }
 
 # Terminal UI
-crossterm = "0.27.0"
-ratatui = "0.26.3"
+ratatui = "0.29.0"
 
 # WGPU stuff
 text_placeholder = "0.5.1"

--- a/crates/burn-train/Cargo.toml
+++ b/crates/burn-train/Cargo.toml
@@ -15,7 +15,7 @@ version.workspace = true
 default = ["metrics", "tui"]
 doc = ["default"]
 metrics = ["nvml-wrapper", "sysinfo", "systemstat"]
-tui = ["ratatui", "crossterm"]
+tui = ["ratatui"]
 
 [dependencies]
 burn-core = { path = "../burn-core", version = "0.15.0", features = [
@@ -34,8 +34,7 @@ sysinfo = { workspace = true, optional = true }
 systemstat = { workspace = true, optional = true }
 
 # Text UI
-ratatui = { workspace = true, optional = true, features = ["all-widgets"] }
-crossterm = { workspace = true, optional = true }
+ratatui = { workspace = true, optional = true, features = ["all-widgets", "crossterm"] }
 
 # Utilities
 derive-new = { workspace = true }

--- a/crates/burn-train/src/renderer/tui/metric_numeric.rs
+++ b/crates/burn-train/src/renderer/tui/metric_numeric.rs
@@ -1,8 +1,8 @@
 use crate::renderer::TrainingProgress;
 
 use super::{FullHistoryPlot, RecentHistoryPlot, TerminalFrame};
-use crossterm::event::{Event, KeyCode, KeyEventKind};
 use ratatui::{
+    crossterm::event::{Event, KeyCode, KeyEventKind},
     prelude::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style, Stylize},
     text::Line,
@@ -164,25 +164,13 @@ impl NumericMetricsState {
                 Axis::default()
                     .style(Style::default().fg(Color::DarkGray))
                     .title("Iteration")
-                    .labels(
-                        axes.labels_x
-                            .clone()
-                            .into_iter()
-                            .map(|s| s.bold())
-                            .collect(),
-                    )
+                    .labels(axes.labels_x.clone().into_iter().map(|s| s.bold()))
                     .bounds(axes.bounds_x),
             )
             .y_axis(
                 Axis::default()
                     .style(Style::default().fg(Color::DarkGray))
-                    .labels(
-                        axes.labels_y
-                            .clone()
-                            .into_iter()
-                            .map(|s| s.bold())
-                            .collect(),
-                    )
+                    .labels(axes.labels_y.clone().into_iter().map(|s| s.bold()))
                     .bounds(axes.bounds_y),
             )
     }

--- a/crates/burn-train/src/renderer/tui/popup.rs
+++ b/crates/burn-train/src/renderer/tui/popup.rs
@@ -1,5 +1,5 @@
-use crossterm::event::{Event, KeyCode};
 use ratatui::{
+    crossterm::event::{Event, KeyCode},
     prelude::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style, Stylize},
     text::{Line, Span},

--- a/crates/burn-train/src/renderer/tui/renderer.rs
+++ b/crates/burn-train/src/renderer/tui/renderer.rs
@@ -1,12 +1,15 @@
 use crate::renderer::{tui::NumericMetricsState, MetricsRenderer};
 use crate::renderer::{MetricState, TrainingProgress};
 use crate::TrainingInterrupter;
-use crossterm::{
-    event::{self, Event, KeyCode},
-    execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+use ratatui::{
+    crossterm::{
+        event::{self, Event, KeyCode},
+        execute,
+        terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    },
+    prelude::*,
+    Terminal,
 };
-use ratatui::{prelude::*, Terminal};
 use std::panic::{set_hook, take_hook};
 use std::sync::Arc;
 use std::{
@@ -132,7 +135,7 @@ impl TuiMetricsRenderer {
 
     fn draw(&mut self) -> Result<(), Box<dyn Error>> {
         self.terminal.draw(|frame| {
-            let size = frame.size();
+            let size = frame.area();
 
             match self.popup.view() {
                 Some(view) => view.render(frame, size),


### PR DESCRIPTION
### Related Issues/PRs

Fixes #2420 

### Changes

- Removed `crossterm` dependency (now accessible via `ratatui` re-export)
- Changed `frame.size()` (deprecated and renamed to `frame.area()`
- Removed `.collect()` for `Axis::labels()` which now accepts an iterator
