### PR TITLE
Format all type names (fixes #2324)

### DIFF
--- a/crates/burn-import/src/burn/graph.rs
+++ b/crates/burn-import/src/burn/graph.rs
@@ -553,7 +553,7 @@ impl<PS: PrecisionSettings> BurnGraph<PS> {
         input_names.iter().for_each(|input| {
             self.graph_input_types.push(
                 inputs
-                    .get(&TensorType::format_name(input))
+                    .get(&Type::format_name(input))
                     .unwrap_or_else(|| panic!("Input type not found for {input}"))
                     .clone(),
             );
@@ -562,7 +562,7 @@ impl<PS: PrecisionSettings> BurnGraph<PS> {
         output_names.iter().for_each(|output| {
             self.graph_output_types.push(
                 outputs
-                    .get(&TensorType::format_name(output))
+                    .get(&Type::format_name(output))
                     .unwrap_or_else(|| panic!("Output type not found for {output}"))
                     .clone(),
             );

--- a/crates/burn-import/src/burn/ty.rs
+++ b/crates/burn-import/src/burn/ty.rs
@@ -63,6 +63,16 @@ pub enum Type {
 }
 
 impl Type {
+    // This is used, because types might have number literal name, which cannot be
+    // used as a variable name.
+    pub fn format_name(name: &str) -> String {
+        let name_is_number = name.bytes().all(|digit| digit.is_ascii_digit());
+        if name_is_number {
+            format!("_{}", name)
+        } else {
+            name.to_string()
+        }
+    }
     pub fn name(&self) -> &Ident {
         match self {
             Type::Tensor(tensor) => &tensor.name,
@@ -107,8 +117,10 @@ impl ScalarType {
         if name.as_ref().is_empty() {
             panic!("Scalar of Type {:?} was passed with empty name", kind);
         }
+
+        let formatted_name = Type::format_name(name.as_ref());
         Self {
-            name: Ident::new(name.as_ref(), Span::call_site()),
+            name: Ident::new(formatted_name.as_ref(), Span::call_site()),
             kind,
         }
     }
@@ -150,8 +162,9 @@ impl ShapeType {
         if name.as_ref().is_empty() {
             panic!("Shape was passed with empty name");
         }
+        let formatted_name = Type::format_name(name.as_ref());
         Self {
-            name: Ident::new(name.as_ref(), Span::call_site()),
+            name: Ident::new(formatted_name.as_ref(), Span::call_site()),
             dim,
         }
     }
@@ -173,16 +186,6 @@ impl ShapeType {
 }
 
 impl TensorType {
-    // This is used, because Tensors might have number literal name, which cannot be
-    // used as a variable name.
-    pub fn format_name(name: &str) -> String {
-        let name_is_number = name.bytes().all(|digit| digit.is_ascii_digit());
-        if name_is_number {
-            format!("_{}", name)
-        } else {
-            name.to_string()
-        }
-    }
 
     pub fn new<S: AsRef<str>>(
         name: S,
@@ -196,7 +199,7 @@ impl TensorType {
                 kind, shape
             );
         }
-        let formatted_name = Self::format_name(name.as_ref());
+        let formatted_name = Type::format_name(name.as_ref());
         assert_ne!(
             dim, 0,
             "Trying to create TensorType with dim = 0 - should be a Scalar instead!"
@@ -277,8 +280,9 @@ impl OtherType {
                 tokens
             );
         }
+        let formatted_name = Type::format_name(name.as_ref());
         Self {
-            name: Ident::new(name.as_ref(), Span::call_site()),
+            name: Ident::new(formatted_name.as_ref(), Span::call_site()),
             ty: tokens,
         }
     }

--- a/crates/burn-import/src/burn/ty.rs
+++ b/crates/burn-import/src/burn/ty.rs
@@ -120,7 +120,7 @@ impl ScalarType {
 
         let formatted_name = Type::format_name(name.as_ref());
         Self {
-            name: Ident::new(formatted_name.as_ref(), Span::call_site()),
+            name: Ident::new(&formatted_name, Span::call_site()),
             kind,
         }
     }
@@ -164,7 +164,7 @@ impl ShapeType {
         }
         let formatted_name = Type::format_name(name.as_ref());
         Self {
-            name: Ident::new(formatted_name.as_ref(), Span::call_site()),
+            name: Ident::new(&formatted_name, Span::call_site()),
             dim,
         }
     }
@@ -186,7 +186,6 @@ impl ShapeType {
 }
 
 impl TensorType {
-
     pub fn new<S: AsRef<str>>(
         name: S,
         dim: usize,
@@ -282,7 +281,7 @@ impl OtherType {
         }
         let formatted_name = Type::format_name(name.as_ref());
         Self {
-            name: Ident::new(formatted_name.as_ref(), Span::call_site()),
+            name: Ident::new(&formatted_name, Span::call_site()),
             ty: tokens,
         }
     }


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Issue  #2324

### Changes

Change the wrapping of tensor types to all types.

### Testing

I couldn't reproduce the issue anymore with the changes made.
