### PR TITLE
Perf/ndarray data

### DIFF
--- a/crates/burn-tensor/src/tensor/data.rs
+++ b/crates/burn-tensor/src/tensor/data.rs
@@ -333,9 +333,7 @@ impl TensorData {
             let val = &val.elem::<Target>();
             let slice_new = bytemuck::bytes_of(val);
 
-            for i in 0..step {
-                slice_old[i] = slice_new[i].clone();
-            }
+            slice_old.clone_from_slice(slice_new);
         }
         self.dtype = Target::dtype();
 
@@ -1180,7 +1178,7 @@ mod tests {
     #[test]
     fn should_convert_bytes_correctly_inplace() {
         fn test_precision<E: Element>() {
-            let data = TensorData::new((0..32).into_iter().collect(), [32]);
+            let data = TensorData::new((0..32).collect(), [32]);
             for (i, val) in data
                 .clone()
                 .convert::<E>()

--- a/crates/burn-tensor/src/tensor/data.rs
+++ b/crates/burn-tensor/src/tensor/data.rs
@@ -144,7 +144,6 @@ impl TensorData {
 
         let capacity = capacity_bytes / size_elem;
         let length = length_bytes / size_elem;
-        println!("Capacity {capacity}, length {length}");
 
         unsafe {
             let ptr = self.bytes.as_mut_ptr();

--- a/crates/burn-tensor/src/tensor/element/base.rs
+++ b/crates/burn-tensor/src/tensor/element/base.rs
@@ -260,6 +260,23 @@ pub enum DType {
 }
 
 impl DType {
+    pub fn size(&self) -> usize {
+        match self {
+            DType::F64 => core::mem::size_of::<f64>(),
+            DType::F32 => core::mem::size_of::<f32>(),
+            DType::F16 => core::mem::size_of::<f16>(),
+            DType::BF16 => core::mem::size_of::<bf16>(),
+            DType::I64 => core::mem::size_of::<i64>(),
+            DType::I32 => core::mem::size_of::<i32>(),
+            DType::I16 => core::mem::size_of::<i16>(),
+            DType::I8 => core::mem::size_of::<i8>(),
+            DType::U64 => core::mem::size_of::<u64>(),
+            DType::U32 => core::mem::size_of::<u32>(),
+            DType::U8 => core::mem::size_of::<u8>(),
+            DType::Bool => core::mem::size_of::<bool>(),
+            DType::QFloat(_) => core::mem::size_of::<u8>(), // TODO: Unsure
+        }
+    }
     /// Returns true if the data type is a floating point type.
     pub fn is_float(&self) -> bool {
         matches!(self, DType::F64 | DType::F32 | DType::F16 | DType::BF16)

--- a/crates/burn-tensor/src/tensor/element/base.rs
+++ b/crates/burn-tensor/src/tensor/element/base.rs
@@ -260,7 +260,8 @@ pub enum DType {
 }
 
 impl DType {
-    pub fn size(&self) -> usize {
+    /// Returns the size of a type in bytes.
+    pub const fn size(&self) -> usize {
         match self {
             DType::F64 => core::mem::size_of::<f64>(),
             DType::F32 => core::mem::size_of::<f32>(),
@@ -274,7 +275,10 @@ impl DType {
             DType::U32 => core::mem::size_of::<u32>(),
             DType::U8 => core::mem::size_of::<u8>(),
             DType::Bool => core::mem::size_of::<bool>(),
-            DType::QFloat(_) => core::mem::size_of::<u8>(), // TODO: Unsure
+            DType::QFloat(strategy) => match strategy {
+                QuantizationStrategy::PerTensorAffineInt8(_) => core::mem::size_of::<u8>(),
+                QuantizationStrategy::PerTensorSymmetricInt8(_) => core::mem::size_of::<u8>(),
+            },
         }
     }
     /// Returns true if the data type is a floating point type.


### PR DESCRIPTION
Try to remove allocations when manipulating the TensorData struct and reduce memory copies when serializing and deserializing ndarray tensors.