### PR TITLE
DefaultDevice should be an alias of BestAvailable

### DIFF
--- a/burn-book/src/getting-started.md
+++ b/burn-book/src/getting-started.md
@@ -157,7 +157,7 @@ Tensor {
 [[3.0, 4.0],
  [5.0, 6.0]],
   shape:  [2, 2],
-  device:  BestAvailable,
+  device:  DefaultDevice,
   backend:  "wgpu",
   kind:  "Float",
   dtype:  "f32",

--- a/crates/burn-tensor/src/lib.rs
+++ b/crates/burn-tensor/src/lib.rs
@@ -65,7 +65,7 @@ mod cube_wgpu {
                 WgpuDevice::IntegratedGpu(index) => DeviceId::new(1, *index as u32),
                 WgpuDevice::VirtualGpu(index) => DeviceId::new(2, *index as u32),
                 WgpuDevice::Cpu => DeviceId::new(3, 0),
-                WgpuDevice::BestAvailable => DeviceId::new(4, 0),
+                WgpuDevice::BestAvailable | WgpuDevice::DefaultDevice => DeviceId::new(4, 0),
                 // For an existing device, use the 64 bit wgpu device ID as the burn DeviceID.
                 // We're only storing 32 bits, so wrap the the 64 bit value to 32 bits. This
                 // might collide - but a 1 in 4 billion chance seems ok given there's only a few
@@ -73,7 +73,6 @@ mod cube_wgpu {
                 WgpuDevice::Existing(id) => {
                     DeviceId::new(5, (id.inner() % (u32::MAX as u64)) as u32)
                 }
-                WgpuDevice::DefaultDevice => DeviceId::new(6, 0),
             }
         }
     }


### PR DESCRIPTION
DefaultDevice was added as a new name of BestAvailable which is marked deprecated. They should be aliases of each other, not distrinct devices.