### PR TITLE
Fix typos in implicit_gemm.rs and backend.rs

### DIFF
--- a/crates/burn-jit/src/kernel/conv/conv2d/implicit_gemm.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d/implicit_gemm.rs
@@ -528,7 +528,7 @@ fn load_input_tile<F: Float, FMat: Float>(
         // Slices are always `kernel_size * channels` elements wide so we can compute where inside a slice
         // we are and also which row the slice is in relative to the start of the CMMA matrix
 
-        // Actual index within a slice (0 to `kernel_size * channels - 1`) that the thread is repsonsible for
+        // Actual index within a slice (0 to `kernel_size * channels - 1`) that the thread is responsible for
         let my_slice_idx = (slice_start_idx + (m % cmma_k)) % dims.slice_size;
 
         let channel = my_slice_idx % channels;

--- a/crates/burn-router/src/backend.rs
+++ b/crates/burn-router/src/backend.rs
@@ -11,7 +11,7 @@ use burn_tensor::{
 
 use super::{get_client, set_seed, RouterTensor, RunnerChannel, RunnerClient};
 
-/// A backend that forwards the tensor operations to the appropiate backend (given multiple backends).
+/// A backend that forwards the tensor operations to the appropriate backend (given multiple backends).
 pub struct BackendRouter<R: RunnerChannel> {
     r: PhantomData<R>,
 }


### PR DESCRIPTION
## Pull Request Template

During development, I found some typos. This pr fix them.
I wonder if it is a good way to replace current warning with error to detect. (Just suggestions and another issue ticket might be filed separatedly.)

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.

### Related Issues/PRs

One is regression of https://github.com/tracel-ai/burn/pull/2363

### Changes

```
% typos --diff --color always
--- ./crates/burn-jit/src/kernel/conv/conv2d/implicit_gemm.rs   original
+++ ./crates/burn-jit/src/kernel/conv/conv2d/implicit_gemm.rs   fixed
@@ -531 +531 @@
-        // Actual index within a slice (0 to `kernel_size * channels - 1`) that the thread is repsonsible for
+        // Actual index within a slice (0 to `kernel_size * channels - 1`) that the thread is responsible for
--- ./crates/burn-router/src/backend.rs original
+++ ./crates/burn-router/src/backend.rs fixed
@@ -14 +14 @@
-/// A backend that forwards the tensor operations to the appropiate backend (given multiple backends).
+/// A backend that forwards the tensor operations to the appropriate backend (given multiple backends).
```

And `typos` command causes errors as below.
```
% typos                      
error: `repsonsible` should be `responsible`
  --> ./crates/burn-jit/src/kernel/conv/conv2d/implicit_gemm.rs:531:95
    |
531 |         // Actual index within a slice (0 to `kernel_size * channels - 1`) that the thread is repsonsible for
    |                                                                                               ^^^^^^^^^^^
    |
error: `appropiate` should be `appropriate`
  --> ./crates/burn-router/src/backend.rs:14:58
   |
14 | /// A backend that forwards the tensor operations to the appropiate backend (given multiple backends).
```

### Testing

After fixing them, `typos` command has no errors.