### PR TITLE
[Fix] Prevent various OOB accesses and discontiguous buffer bugs

### DIFF
--- a/crates/burn-fusion/src/ops/int.rs
+++ b/crates/burn-fusion/src/ops/int.rs
@@ -1694,9 +1694,9 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
 
         impl<B: FusionBackend> Operation<B::FusionRuntime> for ExpandOps<B> {
             fn execute(self: Box<Self>, handles: &mut HandleContainer<B::Handle>) {
-                let input = handles.get_bool_tensor::<B>(&self.desc.input);
-                let output = B::bool_expand(input, self.desc.shape.into());
-                handles.register_bool_tensor::<B>(&self.desc.out.id, output);
+                let input = handles.get_int_tensor::<B>(&self.desc.input);
+                let output = B::int_expand(input, self.desc.shape.into());
+                handles.register_int_tensor::<B>(&self.desc.out.id, output);
             }
         }
 

--- a/crates/burn-jit/src/kernel/comparison.rs
+++ b/crates/burn-jit/src/kernel/comparison.rs
@@ -1,9 +1,11 @@
-use crate::{element::JitElement, tensor::JitTensor, JitRuntime};
+use crate::{element::JitElement, ops::numeric::empty_device, tensor::JitTensor, JitRuntime};
 use burn_tensor::Shape;
 use cubecl::{
     calculate_cube_count_elemwise, linalg::tensor::index_offset_with_layout, prelude::*,
     tensor_vectorization_factor,
 };
+
+use super::into_contiguous;
 
 #[cube]
 pub(crate) trait ComparisonOp<C: Numeric>: 'static + Send + Sync {
@@ -169,9 +171,7 @@ pub(crate) fn launch_cmp<R: JitRuntime, E: JitElement, O: ComparisonOp<E>>(
 
         JitTensor::new(rhs.client, rhs.handle, rhs.shape, rhs.device, rhs.strides)
     } else {
-        let buffer = lhs.client.empty(num_elems * core::mem::size_of::<u32>());
-        let output =
-            JitTensor::new_contiguous(lhs.client.clone(), lhs.device.clone(), shape_out, buffer);
+        let output = empty_device(lhs.client.clone(), lhs.device.clone(), shape_out);
         let to_contiguous_lhs = lhs.strides != output.strides || lhs.shape != output.shape;
         let to_contiguous_rhs = rhs.strides != output.strides || rhs.shape != output.shape;
 
@@ -192,9 +192,13 @@ pub(crate) fn launch_cmp<R: JitRuntime, E: JitElement, O: ComparisonOp<E>>(
 }
 
 pub(crate) fn launch_scalar_cmp<R: JitRuntime, E: JitElement, O: ComparisonOp<E>>(
-    tensor: JitTensor<R, E>,
+    mut tensor: JitTensor<R, E>,
     scalar: E,
 ) -> JitTensor<R, u32> {
+    if !tensor.is_contiguous_buffer() {
+        tensor = into_contiguous(tensor);
+    }
+
     let ndims = tensor.shape.num_dims();
     // Vectorization is only enabled when the last dimension is contiguous.
     let vectorization_factor =
@@ -225,13 +229,10 @@ pub(crate) fn launch_scalar_cmp<R: JitRuntime, E: JitElement, O: ComparisonOp<E>
             tensor.strides,
         )
     } else {
-        let buffer = tensor.client.empty(num_elems * core::mem::size_of::<u32>());
-        let output = JitTensor::new(
+        let output = empty_device(
             tensor.client.clone(),
-            buffer,
-            tensor.shape.clone(),
             tensor.device.clone(),
-            tensor.strides.clone(),
+            tensor.shape.clone(),
         );
 
         kernel_scalar_cmp::launch::<E, O, R>(

--- a/crates/burn-jit/src/kernel/conv/conv2d/col2im.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d/col2im.rs
@@ -217,11 +217,9 @@ fn col2im_kernel<F: Float>(
     args: &Col2ImArgs,
     #[comptime] has_bias: bool,
 ) {
-    if ABSOLUTE_POS > image.len() {
+    if ABSOLUTE_POS >= image.len() {
         return;
     }
-
-    let _ = bias[0]; // Keep in bind group
 
     let im_x = ABSOLUTE_POS % image.shape(3) + args.pad_w;
     let im_y = ABSOLUTE_POS / image.stride(2) % image.shape(2) + args.pad_h;

--- a/crates/burn-jit/src/kernel/conv/conv2d/implicit_gemm.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d/implicit_gemm.rs
@@ -91,7 +91,6 @@ pub fn conv2d_implicit_gemm<R: JitRuntime, F: FloatElement, I: IntElement>(
 
     let input_tile_size = cmma_m * cmma_k;
     let weight_tile_size = cmma_k * cmma_n;
-    let acc_tile_size = cmma_m * cmma_n;
 
     let warp_size = 32;
     let warps_per_cube = (cube_dim_y * cube_dim_x) / warp_size;
@@ -104,8 +103,6 @@ pub fn conv2d_implicit_gemm<R: JitRuntime, F: FloatElement, I: IntElement>(
     let weight_elems_per_thread = weight_tile_size / warp_size;
     let weight_vectorization =
         find_common_vec(in_channels, weight_elems_per_thread, supported_vecs);
-    let bias_elems_per_thread = acc_tile_size / warp_size;
-    let bias_vectorization = find_common_vec(out_channels, bias_elems_per_thread, supported_vecs);
 
     let has_bias = bias.is_some();
     let bias = bias.unwrap_or_else(|| {
@@ -147,7 +144,7 @@ pub fn conv2d_implicit_gemm<R: JitRuntime, F: FloatElement, I: IntElement>(
         cube_dim,
         input.as_tensor_arg(input_vectorization),
         weight.as_tensor_arg(weight_vectorization),
-        bias.as_tensor_arg(bias_vectorization),
+        bias.as_tensor_arg(1),
         out.as_tensor_arg(1),
         DimensionsLaunch::new(
             ScalarArg::new(gemm_m),
@@ -266,7 +263,7 @@ struct Matrices<F: Float, FAcc: Float> {
 fn implicit_gemm_kernel<F: Float, FMat: Float>(
     input: &Tensor<Line<F>>,
     weight: &Tensor<Line<F>>,
-    bias: &Tensor<Line<F>>,
+    bias: &Tensor<F>,
     out: &mut Tensor<F>,
     dims: &Dimensions,
     args: &ConvArgs,
@@ -410,7 +407,7 @@ fn make_matrices<F: Float, FAcc: Float>(
 fn execute_gemm<F: Float, FMat: Float>(
     input: &Tensor<Line<F>>,
     weight: &Tensor<Line<F>>,
-    bias: &Tensor<Line<F>>,
+    bias: &Tensor<F>,
     out: &mut SliceMut<F>,
     input_tile: &mut SliceMut<FMat>,
     weight_tile: &mut SliceMut<FMat>,
@@ -420,28 +417,14 @@ fn execute_gemm<F: Float, FMat: Float>(
     #[comptime] g_settings: GemmSettings,
     #[comptime] k_settings: ConvSettings,
 ) {
-    let GemmSettings {
-        cmma_m,
-        cmma_n,
-        cmma_k,
-        warps_per_cube,
-        ..
-    } = g_settings;
+    let GemmSettings { cmma_n, cmma_k, .. } = g_settings;
     let has_bias = k_settings.has_bias;
 
     let matrices = make_matrices::<FMat, F>(g_settings, has_bias);
     if has_bias {
-        let acc_tile_size = cmma_m * cmma_n;
-        let mut smem_bias = SharedMemory::new(acc_tile_size * warps_per_cube);
-        let bias_tile_start = pos.cube_linear_warp_idx * acc_tile_size;
-        let bias_tile = smem_bias.slice_mut(bias_tile_start, bias_tile_start + acc_tile_size);
-        load_bias_tile(bias, bias_tile, pos, g_settings);
-        cmma::load_with_layout(
-            &matrices.acc,
-            bias_tile.as_slice(),
-            cmma_n,
-            MatrixLayout::RowMajor,
-        );
+        let n = UNIT_POS_Y * cmma_n + pos.global_n;
+        let bias_tile = bias.slice(n, n + cmma_n);
+        cmma::load_with_layout(&matrices.acc, bias_tile, 0, MatrixLayout::RowMajor);
     }
 
     // Loop over the K-dimension
@@ -615,39 +598,6 @@ fn load_weight_tile<F: Float, FMat: Float>(
         };
         let value = FMat::cast_from(weight[idx / vec]);
         let value = select(k_in_bounds && n_in_bounds, value, FMat::new(0.0));
-
-        #[unroll]
-        for i in 0..vec {
-            tile[n + i] = value[i];
-        }
-    }
-}
-
-#[cube]
-fn load_bias_tile<F: Float>(
-    bias: &Tensor<Line<F>>,
-    tile: &mut SliceMut<F>,
-    pos: &Positions,
-    #[comptime] gemm_settings: GemmSettings,
-) {
-    let GemmSettings {
-        cmma_n,
-        cmma_m,
-        warp_size,
-        ..
-    } = gemm_settings;
-
-    let vec = vectorization_of(bias);
-    let cmma_acc_tile_size = cmma_m * cmma_n;
-    let elems_per_thread = cmma_acc_tile_size / warp_size;
-    let start = pos.intra_warp_unit_idx * elems_per_thread;
-
-    #[unroll]
-    for n in range_stepped(0, elems_per_thread, vec) {
-        let n = n + start;
-
-        let row = n % cmma_n + pos.global_n;
-        let value = bias[row / vec];
 
         #[unroll]
         for i in 0..vec {

--- a/crates/burn-jit/src/kernel/conv/conv2d/implicit_gemm.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d/implicit_gemm.rs
@@ -262,7 +262,7 @@ struct Matrices<F: Float, FAcc: Float> {
 }
 
 #[allow(clippy::collapsible_else_if)]
-#[cube(launch_unchecked, launch)]
+#[cube(launch)]
 fn implicit_gemm_kernel<F: Float, FMat: Float>(
     input: &Tensor<Line<F>>,
     weight: &Tensor<Line<F>>,

--- a/crates/burn-jit/src/kernel/conv/conv2d/tune/conv2d.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d/tune/conv2d.rs
@@ -9,10 +9,7 @@ use cubecl::{
 
 use crate::{
     kernel::{
-        conv::{
-            batches_per_run, can_do_implicit_gemm, conv2d_direct, conv2d_im2col,
-            conv2d_implicit_gemm,
-        },
+        conv::{batches_per_run, can_do_implicit_gemm, conv2d_direct, conv2d_im2col},
         prng::random_uniform,
     },
     tensor::JitTensor,
@@ -42,7 +39,7 @@ pub fn conv2d_autotune<R: JitRuntime, E: FloatElement, I: IntElement>(
 }
 
 #[tune(
-    operations(conv2d_direct, conv2d_im2col, conv2d_implicit_gemm),
+    operations(conv2d_direct, conv2d_im2col),
     create_key = create_key,
     should_run = should_run
 )]

--- a/crates/burn-jit/src/kernel/conv/conv2d/tune/conv2d.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d/tune/conv2d.rs
@@ -9,7 +9,10 @@ use cubecl::{
 
 use crate::{
     kernel::{
-        conv::{batches_per_run, can_do_implicit_gemm, conv2d_direct, conv2d_im2col},
+        conv::{
+            batches_per_run, can_do_implicit_gemm, conv2d_direct, conv2d_im2col,
+            conv2d_implicit_gemm,
+        },
         prng::random_uniform,
     },
     tensor::JitTensor,
@@ -39,7 +42,7 @@ pub fn conv2d_autotune<R: JitRuntime, E: FloatElement, I: IntElement>(
 }
 
 #[tune(
-    operations(conv2d_direct, conv2d_im2col),
+    operations(conv2d_direct, conv2d_im2col, conv2d_implicit_gemm),
     create_key = create_key,
     should_run = should_run
 )]

--- a/crates/burn-jit/src/tensor/base.rs
+++ b/crates/burn-jit/src/tensor/base.rs
@@ -202,7 +202,8 @@ where
         is_contiguous(&self.shape.dims, &self.strides)
     }
 
-    /// Check if the current tensor is contiguous.
+    /// Check if the current tensor has a contiguous backing buffer (no overlap and no empty memory
+    /// regions within the shape).
     pub fn is_contiguous_buffer(&self) -> bool {
         self.shape.num_elements() * E::as_elem().size() == self.handle.size() as usize
     }

--- a/crates/burn-jit/src/tensor/base.rs
+++ b/crates/burn-jit/src/tensor/base.rs
@@ -153,7 +153,7 @@ where
     }
 
     pub(crate) fn can_mut_broadcast(&self, rhs: &Self) -> bool {
-        if !self.handle.can_mut() {
+        if !self.handle.can_mut() || !self.is_contiguous_buffer() {
             return false;
         }
         let ndims = self.shape.num_dims();
@@ -200,6 +200,11 @@ where
     /// Check if the current tensor is contiguous.
     pub fn is_contiguous(&self) -> bool {
         is_contiguous(&self.shape.dims, &self.strides)
+    }
+
+    /// Check if the current tensor is contiguous.
+    pub fn is_contiguous_buffer(&self) -> bool {
+        self.shape.num_elements() * E::as_elem().size() == self.handle.size() as usize
     }
 }
 

--- a/crates/burn-tensor/src/tests/ops/random.rs
+++ b/crates/burn-tensor/src/tests/ops/random.rs
@@ -8,7 +8,12 @@ mod tests {
         let tensor = TestTensor::<1>::random([20], Distribution::Default, &Default::default());
 
         // check that the tensor is within the range of [0..1) (1 is exclusive)
-        tensor.into_data().assert_within_range(0.0..1.0);
+        // the conversion can ceil the value if `FloatType` is less precise than f32
+        if FloatType::EPSILON.to_f32() > f32::EPSILON {
+            tensor.into_data().assert_within_range_inclusive(0.0..=1.0);
+        } else {
+            tensor.into_data().assert_within_range(0.0..1.0);
+        }
     }
 
     #[test]
@@ -16,7 +21,6 @@ mod tests {
         let tensor =
             TestTensor::<1>::random([20], Distribution::Uniform(4., 5.), &Default::default());
 
-        // the conversion can ceil the value if `FloatType` is less precise than f32
         if FloatType::EPSILON.to_f32() > f32::EPSILON {
             tensor.into_data().assert_within_range_inclusive(4.0..=5.0);
         } else {


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

Fixes OOB bugs in the reduce kernels and `col2im`.
Fixes bugs when running scalar ops with discontiguous buffers (buffers with empty memory regions created by things like `slice`) by making them contiguous first (this is almost always faster than strided access).

### Testing

All tests now pass with no weird values or segfaults
