### PR TITLE
Refactor quantization tensor data representation

### DIFF
--- a/crates/burn-fusion/src/ops/qtensor.rs
+++ b/crates/burn-fusion/src/ops/qtensor.rs
@@ -2,7 +2,7 @@ use std::{marker::PhantomData, ops::Range};
 
 use burn_tensor::{
     ops::{FloatElem, FloatTensor, IntTensor, QTensorOps, QuantizedTensor},
-    quantization::{QuantizationParametersPrimitive, QuantizationScheme, QuantizationStrategy},
+    quantization::{QuantizationParametersPrimitive, QuantizationScheme, QuantizationType},
     repr::{
         DequantizeOperationDescription, FloatOperationDescription, HandleContainer,
         OperationDescription, QuantizationParametersDescription, QuantizeOperationDescription,
@@ -21,14 +21,14 @@ use crate::{
 impl<B: FusionBackend> QTensorOps<Self> for Fusion<B> {
     fn q_from_data(data: TensorData, device: &Device<Self>) -> QuantizedTensor<Self> {
         match data.dtype {
-            DType::QFloat(strategy) => {
+            DType::QFloat(scheme) => {
                 let client = get_client::<B>(device);
                 let tensor = B::q_from_data(data, device);
                 let shape = B::q_shape(&tensor);
 
                 let handles = B::quantized_tensor_handle(tensor);
-                let qparams = match strategy {
-                    QuantizationStrategy::PerTensorAffineInt8(_) => {
+                let qparams = match scheme {
+                    QuantizationScheme::PerTensorAffine(QuantizationType::QInt8) => {
                         let offset = if let Some(offset) = handles.offset {
                             offset
                         } else {
@@ -49,7 +49,7 @@ impl<B: FusionBackend> QTensorOps<Self> for Fusion<B> {
                             )),
                         }
                     }
-                    QuantizationStrategy::PerTensorSymmetricInt8(_) => {
+                    QuantizationScheme::PerTensorSymmetric(QuantizationType::QInt8) => {
                         assert!(
                             handles.offset.is_none(),
                             "Offset should not be provided for symmetric quantization."
@@ -74,7 +74,7 @@ impl<B: FusionBackend> QTensorOps<Self> for Fusion<B> {
                 QFusionTensor {
                     qtensor,
                     qparams,
-                    scheme: strategy.scheme(),
+                    scheme,
                 }
             }
             _ => panic!(
@@ -142,7 +142,7 @@ impl<B: FusionBackend> QTensorOps<Self> for Fusion<B> {
                 scale: qparams.scale.clone().into_description(),
                 offset: qparams.offset.clone().map(|x| x.into_description()),
             },
-            scheme: scheme.clone(),
+            scheme: *scheme,
             out: out.to_description_out(),
         };
 
@@ -157,7 +157,7 @@ impl<B: FusionBackend> QTensorOps<Self> for Fusion<B> {
 
         QFusionTensor {
             qtensor: out,
-            scheme: scheme.clone(),
+            scheme: *scheme,
             qparams: qparams.into(),
         }
     }

--- a/crates/burn-fusion/src/stream/context.rs
+++ b/crates/burn-fusion/src/stream/context.rs
@@ -544,7 +544,7 @@ impl RelativeOpsScalar<f32> for FloatOperationDescription {
                             .as_ref()
                             .map(|x| x.to_relative(converter)),
                     },
-                    scheme: desc.scheme.clone(),
+                    scheme: desc.scheme,
                     out: desc.out.to_relative(converter),
                 })
             }
@@ -561,7 +561,7 @@ impl RelativeOpsScalar<f32> for FloatOperationDescription {
                                 .as_ref()
                                 .map(|x| x.to_relative(converter)),
                         },
-                        scheme: desc.qtensor.scheme.clone(),
+                        scheme: desc.qtensor.scheme,
                     },
                     out: desc.out.to_relative(converter),
                 })

--- a/crates/burn-fusion/src/tensor.rs
+++ b/crates/burn-fusion/src/tensor.rs
@@ -190,7 +190,7 @@ impl<R: FusionRuntime> Clone for QFusionTensor<R> {
     fn clone(&self) -> Self {
         Self {
             qtensor: self.qtensor.clone(),
-            scheme: self.scheme.clone(),
+            scheme: self.scheme,
             qparams: self.qparams.clone(),
         }
     }

--- a/crates/burn-jit/src/kernel/quantization/quantize.rs
+++ b/crates/burn-jit/src/kernel/quantization/quantize.rs
@@ -214,7 +214,7 @@ where
 
     QJitTensor {
         qtensor,
-        scheme: scheme.clone(),
+        scheme: *scheme,
         qparams,
     }
 }

--- a/crates/burn-jit/src/ops/qtensor.rs
+++ b/crates/burn-jit/src/ops/qtensor.rs
@@ -1,6 +1,5 @@
 use std::ops::Range;
 
-use alloc::vec::Vec;
 use burn_tensor::{
     ops::{FloatTensor, IntTensor, QTensorOps, QuantizedTensor},
     quantization::{
@@ -16,28 +15,14 @@ use crate::{
 };
 use cubecl::CubeElement;
 
-fn pack_i8s_to_u32s(data: &TensorData) -> Vec<u32> {
-    // Shift and combine groups of four 8-bit values into a u32.
-    // Same as doing this:
-    //     let result = (a_u8 & 0xFF) << 24 | (b_u8 & 0xFF) << 16 | (c_u8 & 0xFF) << 8 | (d_u8 & 0xFF);
-    data.as_bytes()
-        .chunks(4)
-        .map(|x| {
-            x.iter().enumerate().fold(0u32, |acc, (i, x)| {
-                acc | (*x as i8 as u32 & 0xFF) << ((3 - i) * 8)
-            })
-        })
-        .collect()
-}
-
 /// Create a quantized tensor with packed values (u32).
 fn packed_tensor<R: JitRuntime, S: Into<Shape>>(
-    data: Vec<u32>,
+    data: &[u8],
     shape: S,
     device: &R::Device,
 ) -> JitTensor<R, u32> {
     let client = R::client(device);
-    let buffer = client.create(u32::as_bytes(&data));
+    let buffer = client.create(data);
 
     JitTensor::new_contiguous(client, device.clone(), shape.into(), buffer)
 }
@@ -56,7 +41,7 @@ where
                     // Convert quantized values to packed u32s
                     let qparams = data.get_q_params().unwrap();
                     QJitTensor {
-                        qtensor: packed_tensor(pack_i8s_to_u32s(&data), data.shape, device),
+                        qtensor: packed_tensor(data.values_as_bytes(), data.shape.clone(), device),
                         scheme,
                         qparams: JitQuantizationParameters::new(
                             qparams.scale,
@@ -112,35 +97,18 @@ where
 
     async fn q_into_data(tensor: QuantizedTensor<Self>) -> TensorData {
         let strategy = tensor.strategy();
-        let numel = tensor.qtensor.shape.num_elements();
         let qtensor = kernel::into_contiguous(tensor.qtensor);
 
         let bytes = qtensor.client.read_async(qtensor.handle.binding()).await;
 
-        // Convert packed bytes to quantized dtype (TensorData can be used with other backends,
-        // which don't have the prior knowledge of this packed representation)
+        // TensorData keeps quantized values packed into 32-bit unsigned integers so we can
+        // keep the current representation, just cast the bytes as u32.
         match &tensor.scheme {
             QuantizationScheme::PerTensorAffine(dtype)
             | QuantizationScheme::PerTensorSymmetric(dtype) => match dtype {
-                QuantizationType::QInt8 => TensorData::quantized(
-                    u32::from_bytes(&bytes)
-                        .iter()
-                        .enumerate()
-                        .flat_map(|(i, packed)| {
-                            // A single u32 could contain less than four 8-bit values...
-                            let n = core::cmp::min(4, numel - i * 4);
-                            // Extract each 8-bit segment from u32 and cast back to i8
-                            // Same as doing this (when 4 values are fully packed):
-                            //     let a = ((packed >> 24) & 0xFF) as i8;
-                            //     let b = ((packed >> 16) & 0xFF) as i8;
-                            //     let c = ((packed >> 8) & 0xFF) as i8;
-                            //     let d = (packed & 0xFF) as i8;
-                            (0..n).map(move |i| (packed >> ((3 - i) * 8) & 0xFF) as i8)
-                        })
-                        .collect(),
-                    qtensor.shape,
-                    strategy,
-                ),
+                QuantizationType::QInt8 => {
+                    TensorData::quantized(u32::from_bytes(&bytes).to_vec(), qtensor.shape, strategy)
+                }
             },
         }
     }

--- a/crates/burn-jit/src/tensor/qtensor.rs
+++ b/crates/burn-jit/src/tensor/qtensor.rs
@@ -61,7 +61,7 @@ impl<R: JitRuntime, F: FloatElement, I: IntElement> Clone for QJitTensor<R, F, I
     fn clone(&self) -> Self {
         Self {
             qtensor: self.qtensor.clone(),
-            scheme: self.scheme.clone(),
+            scheme: self.scheme,
             qparams: self.qparams.clone(),
         }
     }

--- a/crates/burn-ndarray/src/ops/qtensor.rs
+++ b/crates/burn-ndarray/src/ops/qtensor.rs
@@ -96,7 +96,6 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> QTensorOps<S
         let shape = tensor.qtensor.shape();
         let strategy = tensor.strategy();
         let values = tensor.qtensor.array.into_iter().collect();
-        println!("Quantized values: {values:?}");
         let data = TensorData::quantized(values, shape, strategy);
         NdArrayTensor::<E>::from_data(data.dequantize().unwrap())
     }

--- a/crates/burn-ndarray/src/ops/qtensor.rs
+++ b/crates/burn-ndarray/src/ops/qtensor.rs
@@ -3,8 +3,9 @@ use core::ops::Range;
 use burn_tensor::{
     ops::{FloatTensor, IntTensor, QTensorOps, QuantizedTensor},
     quantization::{
-        AffineQuantization, Quantization, QuantizationParametersPrimitive, QuantizationScheme,
-        QuantizationStrategy, QuantizationType, SymmetricQuantization,
+        AffineQuantization, QTensorPrimitive, QParams,
+        QuantizationParametersPrimitive, QuantizationScheme, QuantizationStrategy,
+        QuantizationType, SymmetricQuantization,
     },
     DType, Shape, TensorData,
 };
@@ -27,24 +28,15 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> QTensorOps<S
 {
     fn q_from_data(data: TensorData, _device: &NdArrayDevice) -> QuantizedTensor<Self> {
         match data.dtype {
-            DType::QFloat(strategy) => match strategy {
-                QuantizationStrategy::PerTensorAffineInt8(_) => {
-                    let data = data.convert::<i8>();
-                    NdArrayQTensor {
-                        qtensor: NdArrayTensor::<Q>::from_data(data),
-                        scheme: strategy.scheme(),
-                        strategy,
-                    }
+            DType::QFloat(scheme) => {
+                let qparams = data.get_q_params().unwrap();
+                let data = data.convert::<Q>();
+                NdArrayQTensor {
+                    qtensor: NdArrayTensor::<Q>::from_data(data),
+                    scheme,
+                    qparams,
                 }
-                QuantizationStrategy::PerTensorSymmetricInt8(_) => {
-                    let data = data.convert::<i8>();
-                    NdArrayQTensor {
-                        qtensor: NdArrayTensor::<Q>::from_data(data),
-                        scheme: strategy.scheme(),
-                        strategy,
-                    }
-                }
-            },
+            }
             _ => panic!(
                 "Invalid dtype (expected DType::QFloat, got {:?})",
                 data.dtype
@@ -57,39 +49,56 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> QTensorOps<S
         scheme: &QuantizationScheme,
         qparams: QuantizationParametersPrimitive<Self>,
     ) -> QuantizedTensor<Self> {
-        let strategy = match scheme {
+        let (strategy, qparams) = match scheme {
             QuantizationScheme::PerTensorAffine(dtype) => match dtype {
                 QuantizationType::QInt8 => {
-                    QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(
-                        into_data(qparams.scale).iter().next().unwrap(),
-                        into_data(qparams.offset.unwrap()).iter().next().unwrap(),
-                    ))
+                    let scale = into_data(qparams.scale).iter().next().unwrap();
+                    let offset = into_data(qparams.offset.unwrap())
+                        .iter::<Q>()
+                        .next()
+                        .unwrap();
+                    (
+                        QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(
+                            scale,
+                            offset.elem(),
+                        )),
+                        QParams {
+                            scale,
+                            offset: Some(offset),
+                        },
+                    )
                 }
             },
             QuantizationScheme::PerTensorSymmetric(dtype) => match dtype {
-                QuantizationType::QInt8 => QuantizationStrategy::PerTensorSymmetricInt8(
-                    SymmetricQuantization::init(into_data(qparams.scale).iter().next().unwrap()),
-                ),
+                QuantizationType::QInt8 => {
+                    let scale = into_data(qparams.scale).iter().next().unwrap();
+                    (
+                        QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(
+                            scale,
+                        )),
+                        QParams {
+                            scale,
+                            offset: None,
+                        },
+                    )
+                }
             },
         };
 
         let data = into_data(tensor).with_quantization(strategy);
         NdArrayQTensor {
             qtensor: NdArrayTensor::<Q>::from_data(data),
-            strategy,
-            scheme: scheme.clone(),
+            scheme: *scheme,
+            qparams,
         }
     }
 
     fn dequantize(tensor: QuantizedTensor<Self>) -> FloatTensor<Self> {
-        let data = into_data(tensor.qtensor);
-        let values = match tensor.strategy {
-            QuantizationStrategy::PerTensorAffineInt8(s) => s.dequantize(data.as_slice().unwrap()),
-            QuantizationStrategy::PerTensorSymmetricInt8(s) => {
-                s.dequantize(data.as_slice().unwrap())
-            }
-        };
-        NdArrayTensor::<E>::from_data(TensorData::new(values, data.shape))
+        let shape = tensor.qtensor.shape();
+        let strategy = tensor.strategy();
+        let data =
+            TensorData::quantized(tensor.qtensor.array.into_iter().collect(), shape, strategy);
+        NdArrayTensor::<E>::from_data(data.dequantize().unwrap())
     }
 
     fn q_shape(tensor: &QuantizedTensor<Self>) -> Shape {
@@ -111,14 +120,15 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> QTensorOps<S
         NdArrayQTensor {
             qtensor: NdArrayOps::reshape(tensor.qtensor, shape),
             scheme: tensor.scheme,
-            strategy: tensor.strategy,
+            qparams: tensor.qparams,
         }
     }
 
     async fn q_into_data(tensor: QuantizedTensor<Self>) -> TensorData {
+        let strategy = tensor.strategy();
         let shape = tensor.qtensor.shape();
         let values = tensor.qtensor.array.into_iter().collect();
-        TensorData::quantized(values, shape, tensor.strategy)
+        TensorData::quantized(values, shape, strategy)
     }
 
     fn q_swap_dims(
@@ -129,7 +139,7 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> QTensorOps<S
         NdArrayQTensor {
             qtensor: NdArrayOps::swap_dims(tensor.qtensor, dim1, dim2),
             scheme: tensor.scheme,
-            strategy: tensor.strategy,
+            qparams: tensor.qparams,
         }
     }
 
@@ -137,7 +147,7 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> QTensorOps<S
         NdArrayQTensor {
             qtensor: NdArrayOps::permute(tensor.qtensor, axes),
             scheme: tensor.scheme,
-            strategy: tensor.strategy,
+            qparams: tensor.qparams,
         }
     }
 
@@ -145,7 +155,7 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> QTensorOps<S
         NdArrayQTensor {
             qtensor: NdArrayOps::flip(tensor.qtensor, axes),
             scheme: tensor.scheme,
-            strategy: tensor.strategy,
+            qparams: tensor.qparams,
         }
     }
 
@@ -157,7 +167,7 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> QTensorOps<S
         NdArrayQTensor {
             qtensor: NdArrayMathOps::gather(dim, tensor.qtensor, indices),
             scheme: tensor.scheme,
-            strategy: tensor.strategy,
+            qparams: tensor.qparams,
         }
     }
 
@@ -169,7 +179,7 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> QTensorOps<S
         NdArrayQTensor {
             qtensor: NdArrayMathOps::select(tensor.qtensor, dim, indices),
             scheme: tensor.scheme,
-            strategy: tensor.strategy,
+            qparams: tensor.qparams,
         }
     }
 
@@ -177,7 +187,7 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> QTensorOps<S
         NdArrayQTensor {
             qtensor: NdArrayOps::slice(tensor.qtensor, ranges),
             scheme: tensor.scheme,
-            strategy: tensor.strategy,
+            qparams: tensor.qparams,
         }
     }
 
@@ -193,7 +203,7 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> QTensorOps<S
         NdArrayQTensor {
             qtensor: NdArrayOps::expand(tensor.qtensor, shape),
             scheme: tensor.scheme,
-            strategy: tensor.strategy,
+            qparams: tensor.qparams,
         }
     }
 }

--- a/crates/burn-ndarray/src/ops/qtensor.rs
+++ b/crates/burn-ndarray/src/ops/qtensor.rs
@@ -3,9 +3,8 @@ use core::ops::Range;
 use burn_tensor::{
     ops::{FloatTensor, IntTensor, QTensorOps, QuantizedTensor},
     quantization::{
-        AffineQuantization, QTensorPrimitive, QParams,
-        QuantizationParametersPrimitive, QuantizationScheme, QuantizationStrategy,
-        QuantizationType, SymmetricQuantization,
+        AffineQuantization, QParams, QTensorPrimitive, QuantizationParametersPrimitive,
+        QuantizationScheme, QuantizationStrategy, QuantizationType, SymmetricQuantization,
     },
     DType, Shape, TensorData,
 };
@@ -96,8 +95,9 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> QTensorOps<S
     fn dequantize(tensor: QuantizedTensor<Self>) -> FloatTensor<Self> {
         let shape = tensor.qtensor.shape();
         let strategy = tensor.strategy();
-        let data =
-            TensorData::quantized(tensor.qtensor.array.into_iter().collect(), shape, strategy);
+        let values = tensor.qtensor.array.into_iter().collect();
+        println!("Quantized values: {values:?}");
+        let data = TensorData::quantized(values, shape, strategy);
         NdArrayTensor::<E>::from_data(data.dequantize().unwrap())
     }
 

--- a/crates/burn-ndarray/src/tensor.rs
+++ b/crates/burn-ndarray/src/tensor.rs
@@ -1,7 +1,7 @@
 use burn_tensor::{
     quantization::{
-        AffineQuantization, QTensorPrimitive, QParams, QuantizationScheme,
-        QuantizationStrategy, QuantizationType, SymmetricQuantization,
+        AffineQuantization, QParams, QTensorPrimitive, QuantizationScheme, QuantizationStrategy,
+        QuantizationType, SymmetricQuantization,
     },
     Element, Shape, TensorData,
 };

--- a/crates/burn-tch/src/ops/base.rs
+++ b/crates/burn-tch/src/ops/base.rs
@@ -1,4 +1,4 @@
-use burn_tensor::{quantization::QuantizationStrategy, Shape};
+use burn_tensor::Shape;
 use tch::Scalar;
 
 use crate::{LibTorchDevice, TchShape, TchTensor};
@@ -474,31 +474,5 @@ impl<E: tch::kind::Element + Copy + Default> TchOps<E> {
 
     pub fn argsort(tensor: TchTensor<E>, dim: usize, descending: bool) -> TchTensor<i64> {
         TchTensor::new(tensor.tensor.argsort(dim as i64, descending))
-    }
-
-    pub fn quantize<I: tch::kind::Element>(
-        tensor: TchTensor<E>,
-        strategy: &QuantizationStrategy,
-    ) -> TchTensor<I> {
-        let mut tensor = tensor;
-        // Quantize only works on Float Tensor
-        if tensor.tensor.kind() == tch::Kind::Half {
-            tensor.tensor = tensor.tensor.to_kind(tch::Kind::Float);
-        }
-
-        match strategy {
-            QuantizationStrategy::PerTensorAffineInt8(ref q) => {
-                TchTensor::new(tensor.tensor.quantize_per_tensor(
-                    q.scale.into(),
-                    q.offset.into(),
-                    tch::Kind::QInt8,
-                ))
-            }
-            QuantizationStrategy::PerTensorSymmetricInt8(ref q) => TchTensor::new(
-                tensor
-                    .tensor
-                    .quantize_per_tensor(q.scale.into(), 0, tch::Kind::QInt8),
-            ),
-        }
     }
 }

--- a/crates/burn-tensor/src/repr/handle.rs
+++ b/crates/burn-tensor/src/repr/handle.rs
@@ -138,7 +138,7 @@ impl<H: Clone> HandleContainer<H> {
                 .as_ref()
                 .map(|offset| self.get_tensor_handle(offset)),
         };
-        B::quantized_tensor(handles, tensor.scheme.clone())
+        B::quantized_tensor(handles, tensor.scheme)
     }
 
     /// Register a new [float tensor](crate::backend::Backend::FloatTensorPrimitive) with the corresponding [tensor id](TensorId).

--- a/crates/burn-tensor/src/tensor/data.rs
+++ b/crates/burn-tensor/src/tensor/data.rs
@@ -11,7 +11,7 @@ use bytemuck::AnyBitPattern;
 use half::{bf16, f16};
 
 use crate::{
-    quantization::{Quantization, QuantizationStrategy},
+    quantization::{AffineQuantization, Quantization, QuantizationStrategy},
     tensor::Shape,
     DType, Distribution, Element, ElementConversion,
 };
@@ -23,6 +23,8 @@ use num_traits::pow::Pow;
 use num_traits::Float;
 
 use rand::RngCore;
+
+use super::quantization::{QParams, QuantizationScheme, QuantizationType, SymmetricQuantization};
 
 /// The things that can go wrong when manipulating tensor data.
 #[derive(Debug)]
@@ -47,29 +49,31 @@ pub struct TensorData {
     pub dtype: DType,
 }
 
+fn value_into_bytes<E>(mut value: Vec<E>) -> Vec<u8> {
+    // Ensure `E` satisfies the `Pod` trait requirements
+    assert_eq!(core::mem::size_of::<E>() % core::mem::size_of::<u8>(), 0);
+
+    let factor = core::mem::size_of::<E>() / core::mem::size_of::<u8>();
+    let len = value.len() * factor;
+    let capacity = value.capacity() * factor;
+    let ptr = value.as_mut_ptr();
+
+    core::mem::forget(value);
+
+    unsafe { Vec::from_raw_parts(ptr as *mut u8, len, capacity) }
+}
+
 impl TensorData {
     /// Creates a new tensor data structure.
-    pub fn new<E: Element, S: Into<Vec<usize>>>(value: Vec<E>, shape: S) -> Self {
+    pub fn new<E: Element, S: Into<Vec<usize>>>(mut value: Vec<E>, shape: S) -> Self {
+        let shape = shape.into();
+        Self::validate_data_shape(&mut value, &shape);
         Self::init(value, shape, E::dtype())
     }
 
-    /// Creates a new quantized tensor data structure.
-    pub fn quantized<E: Element, S: Into<Vec<usize>>>(
-        value: Vec<E>,
-        shape: S,
-        strategy: QuantizationStrategy,
-    ) -> Self {
-        Self::init(value, shape, DType::QFloat(strategy))
-    }
-
-    /// Initializes a new tensor data structure from the provided values.
-    fn init<E: Element, S: Into<Vec<usize>>>(mut value: Vec<E>, shape: S, dtype: DType) -> Self {
-        // Ensure `E` satisfies the `Pod` trait requirements
-        assert_eq!(core::mem::size_of::<E>() % core::mem::size_of::<u8>(), 0);
-
+    fn validate_data_shape<E>(value: &mut Vec<E>, shape: &[usize]) {
         // Ensure shape is valid
-        let shape = shape.into();
-        let shape_numel = Self::numel(&shape);
+        let shape_numel = Self::numel(shape);
         value.truncate(shape_numel);
         let numel = value.len();
         assert_eq!(
@@ -77,19 +81,43 @@ impl TensorData {
             "Shape {:?} is invalid for input of size {:?}",
             shape, numel,
         );
+    }
 
-        let factor = core::mem::size_of::<E>() / core::mem::size_of::<u8>();
-        let len = numel * factor;
-        let capacity = value.capacity() * factor;
-        let ptr = value.as_mut_ptr();
+    /// Creates a new quantized tensor data structure.
+    pub fn quantized<E: Element, S: Into<Vec<usize>>>(
+        mut value: Vec<E>,
+        shape: S,
+        strategy: QuantizationStrategy,
+    ) -> Self {
+        let shape = shape.into();
+        Self::validate_data_shape(&mut value, &shape);
 
-        core::mem::forget(value);
+        let mut value = value_into_bytes(value);
 
-        let bytes = unsafe { Vec::from_raw_parts(ptr as *mut u8, len, capacity) };
+        // Quantization parameters are packed at the end of the tensor data.
+        // As such, the last bytes always correspond to the scale parameter.
+        // If the quantization scheme includes an offset (zero-point) parameter, it is next to last.
+        match strategy {
+            QuantizationStrategy::PerTensorAffineInt8(q) => {
+                let scale_bytes = bytemuck::bytes_of(&q.scale);
+                let offset_bytes = bytemuck::bytes_of(&q.offset);
+                value.extend_from_slice(offset_bytes);
+                value.extend_from_slice(scale_bytes);
+            }
+            QuantizationStrategy::PerTensorSymmetricInt8(q) => {
+                let scale_bytes = bytemuck::bytes_of(&q.scale);
+                value.extend_from_slice(scale_bytes);
+            }
+        }
 
+        Self::init(value, shape, DType::QFloat(strategy.scheme()))
+    }
+
+    /// Initializes a new tensor data structure from the provided values.
+    fn init<E: Element, S: Into<Vec<usize>>>(value: Vec<E>, shape: S, dtype: DType) -> Self {
         Self {
-            bytes,
-            shape,
+            bytes: value_into_bytes(value),
+            shape: shape.into(),
             dtype,
         }
     }
@@ -221,16 +249,16 @@ impl TensorData {
                 ),
                 // bool is a byte value equal to either 0 or 1
                 DType::Bool => Box::new(self.bytes.iter().map(|e| e.elem::<E>())),
-                DType::QFloat(q) => match q {
-                    // NOTE: we do not dequantize the values to iterate over
-                    QuantizationStrategy::PerTensorAffineInt8(_strategy) => Box::new(
-                        bytemuck::checked::cast_slice(&self.bytes)
+                DType::QFloat(scheme) => match scheme {
+                    // NOTE: the tensor values are not dequantized, simply cast to their quantized type
+                    QuantizationScheme::PerTensorAffine(QuantizationType::QInt8) => Box::new(
+                        bytemuck::checked::cast_slice(self.tensor_bytes())
                             .iter()
                             .map(|e: &i8| e.elem::<E>()),
                     ),
 
-                    QuantizationStrategy::PerTensorSymmetricInt8(_strategy) => Box::new(
-                        bytemuck::checked::cast_slice(&self.bytes)
+                    QuantizationScheme::PerTensorSymmetric(QuantizationType::QInt8) => Box::new(
+                        bytemuck::checked::cast_slice(self.tensor_bytes())
                             .iter()
                             .map(|e: &i8| e.elem::<E>()),
                     ),
@@ -379,6 +407,83 @@ impl TensorData {
         }
     }
 
+    /// Returns the values of the tensor as bytes.
+    ///
+    /// Takes into account the quantization parameters to ignore since they are packed
+    /// into the tensor data bytes.
+    fn tensor_bytes(&self) -> &[u8] {
+        match self.dtype {
+            DType::QFloat(scheme) => {
+                let scale_size = core::mem::size_of::<f32>();
+                let mut tensor_bytes_end = self.bytes.len() - scale_size;
+
+                if let QuantizationScheme::PerTensorAffine(QuantizationType::QInt8) = scheme {
+                    tensor_bytes_end -= core::mem::size_of::<i8>();
+                }
+
+                &self.bytes[..tensor_bytes_end]
+            }
+            _ => self.bytes.as_slice(),
+        }
+    }
+
+    /// Get the quantization parameters for a quantized data type.
+    pub fn get_q_params<E: Element, Q: Element>(&self) -> Option<QParams<E, Q>> {
+        if let DType::QFloat(scheme) = &self.dtype {
+            let total_bytes = self.bytes.len();
+
+            // Quantization parameters are packed at the end of the tensor data.
+            // As such, the last bytes always correspond to the scale parameter.
+            // If the quantization scheme includes an offset (zero-point) parameter, it is next to last.
+            let scale_size = core::mem::size_of::<E>();
+            let scale_bytes = &self.bytes[total_bytes - scale_size..];
+            // The starting memory address isn't guaranteed to be  divisible by the target type's
+            // alignment size, so using `from_bytes` could fail. Instead, we use `read_unaligned`.
+            let scale = bytemuck::checked::pod_read_unaligned(scale_bytes);
+            let mut offset = None;
+
+            if let QuantizationScheme::PerTensorAffine(_) = scheme {
+                let offset_size = core::mem::size_of::<Q>();
+                let offset_bytes =
+                    &self.bytes[total_bytes - scale_size - offset_size..total_bytes - scale_size];
+                offset = Some(bytemuck::checked::pod_read_unaligned(offset_bytes))
+            }
+
+            Some(QParams { scale, offset })
+        } else {
+            None
+        }
+    }
+
+    /// Dequantizes the data according to its quantization scheme.
+    pub fn dequantize(self) -> Result<Self, DataError> {
+        if let DType::QFloat(scheme) = &self.dtype {
+            let qparams = self.get_q_params::<f32, i8>().unwrap();
+            match scheme {
+                QuantizationScheme::PerTensorAffine(QuantizationType::QInt8) => {
+                    let strategy = AffineQuantization::<f32, i8, i32>::init(
+                        qparams.scale,
+                        qparams.offset.unwrap(),
+                    );
+                    let value =
+                        strategy.dequantize(bytemuck::checked::cast_slice(self.tensor_bytes()));
+                    Ok(Self::new(value, self.shape))
+                }
+                QuantizationScheme::PerTensorSymmetric(QuantizationType::QInt8) => {
+                    let strategy = SymmetricQuantization::<f32, i8>::init(qparams.scale);
+                    let value =
+                        strategy.dequantize(bytemuck::checked::cast_slice(self.tensor_bytes()));
+                    Ok(Self::new(value, self.shape))
+                }
+            }
+        } else {
+            Err(DataError::TypeMismatch(format!(
+                "Expected quantized data, got {:?}",
+                self.dtype
+            )))
+        }
+    }
+
     /// Asserts the data is approximately equal to another data.
     ///
     /// # Arguments
@@ -440,14 +545,14 @@ impl TensorData {
                 };
                 match (q, q_other) {
                     (
-                        QuantizationStrategy::PerTensorAffineInt8(_),
-                        QuantizationStrategy::PerTensorAffineInt8(_),
+                        QuantizationScheme::PerTensorAffine(QuantizationType::QInt8),
+                        QuantizationScheme::PerTensorAffine(QuantizationType::QInt8),
+                    )
+                    | (
+                        QuantizationScheme::PerTensorSymmetric(QuantizationType::QInt8),
+                        QuantizationScheme::PerTensorSymmetric(QuantizationType::QInt8),
                     ) => self.assert_eq_elem::<i8>(other),
-                    (
-                        QuantizationStrategy::PerTensorSymmetricInt8(_),
-                        QuantizationStrategy::PerTensorSymmetricInt8(_),
-                    ) => self.assert_eq_elem::<i8>(other),
-                    _ => panic!("Quantization strategies differ ({:?} != {:?})", q, q_other),
+                    _ => panic!("Quantization schemes differ ({:?} != {:?})", q, q_other),
                 }
             }
         }
@@ -728,12 +833,10 @@ impl core::fmt::Display for TensorData {
             DType::U16 => format!("{:?}", self.as_slice::<u16>().unwrap()),
             DType::U8 => format!("{:?}", self.as_slice::<u8>().unwrap()),
             DType::Bool => format!("{:?}", self.as_slice::<bool>().unwrap()),
-            DType::QFloat(q) => match &q {
-                QuantizationStrategy::PerTensorAffineInt8(_) => {
-                    format!("{:?} {q:?}", self.try_as_slice::<i8>().unwrap())
-                }
-                QuantizationStrategy::PerTensorSymmetricInt8(_) => {
-                    format!("{:?} {q:?}", self.try_as_slice::<i8>().unwrap())
+            DType::QFloat(scheme) => match scheme {
+                QuantizationScheme::PerTensorAffine(QuantizationType::QInt8)
+                | QuantizationScheme::PerTensorSymmetric(QuantizationType::QInt8) => {
+                    format!("{:?} {scheme:?}", self.try_as_slice::<i8>().unwrap())
                 }
             },
         };
@@ -1273,5 +1376,63 @@ mod tests {
         test_precision::<f16>();
         test_precision::<i64>();
         test_precision::<i32>();
+    }
+
+    #[test]
+    fn should_pack_unpack_quantization_parameters_symmetric() {
+        let scale = 0.03937008;
+        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
+        let data = TensorData::quantized(
+            vec![0i8, 25, 51, 76, 102, 127],
+            [2, 3],
+            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(scale)),
+        );
+
+        let qparams = data.get_q_params::<f32, i8>().unwrap();
+
+        assert_eq!(qparams.scale, scale);
+        assert_eq!(qparams.offset, None);
+    }
+
+    #[test]
+    fn should_pack_unpack_quantization_parameters_affine() {
+        let scale = 0.019607844;
+        let offset = -128;
+        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
+        let data = TensorData::quantized(
+            vec![-128i8, -77, -26, 25, 76, 127],
+            [2, 3],
+            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(scale, offset)),
+        );
+        let qparams = data.get_q_params::<f32, i8>().unwrap();
+
+        assert_eq!(qparams.scale, scale);
+        assert_eq!(qparams.offset, Some(offset));
+    }
+
+    #[test]
+    fn should_not_return_q_params() {
+        let data = TensorData::from([[3.0, 5.0, 6.0, 7.0]]);
+        assert!(data.get_q_params::<f32, i8>().is_none());
+    }
+    #[test]
+    #[should_panic = "Expected quantized data"]
+    fn should_not_dequantize() {
+        let data = TensorData::from([[3.0, 5.0, 6.0, 7.0]]);
+        data.dequantize().unwrap();
+    }
+
+    #[test]
+    fn should_support_dequantize() {
+        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
+        let data = TensorData::quantized(
+            vec![-128i8, -77, -26, 25, 76, 127],
+            [2, 3],
+            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
+        );
+
+        let output = data.dequantize().unwrap();
+
+        output.assert_approx_eq(&TensorData::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]), 4);
     }
 }

--- a/crates/burn-tensor/src/tensor/data.rs
+++ b/crates/burn-tensor/src/tensor/data.rs
@@ -53,7 +53,7 @@ pub struct TensorData {
     pub dtype: DType,
 }
 
-fn value_into_bytes<E>(mut value: Vec<E>) -> Vec<u8> {
+fn into_bytes<E>(mut value: Vec<E>) -> Vec<u8> {
     // Ensure `E` satisfies the `Pod` trait requirements
     assert_eq!(core::mem::size_of::<E>() % core::mem::size_of::<u8>(), 0);
 
@@ -70,8 +70,8 @@ fn value_into_bytes<E>(mut value: Vec<E>) -> Vec<u8> {
 impl TensorData {
     /// Creates a new tensor data structure.
     pub fn new<E: Element, S: Into<Vec<usize>>>(mut value: Vec<E>, shape: S) -> Self {
-        let shape: Vec<usize> = shape.into();
         // Ensure shape is valid
+        let shape = shape.into();
         let shape_numel = Self::numel(&shape);
         value.truncate(shape_numel);
         let numel = value.len();
@@ -93,7 +93,7 @@ impl TensorData {
         shape: S,
         strategy: QuantizationStrategy,
     ) -> Self {
-        let mut value = value_into_bytes(value);
+        let mut value = into_bytes(value);
 
         // Notes on quantization data representation:
         // 1) The quantized values are packed into 32-bit unsigned integers. For example, int8
@@ -136,7 +136,7 @@ impl TensorData {
     /// Initializes a new tensor data structure from the provided values.
     fn init<E: Element, S: Into<Vec<usize>>>(value: Vec<E>, shape: S, dtype: DType) -> Self {
         Self {
-            bytes: value_into_bytes(value),
+            bytes: into_bytes(value),
             shape: shape.into(),
             dtype,
         }

--- a/crates/burn-tensor/src/tensor/data.rs
+++ b/crates/burn-tensor/src/tensor/data.rs
@@ -467,7 +467,7 @@ impl TensorData {
                         CheckedCastError::PodCastError(_) => {
                             // Fallback to manual copy
                             let mut aligned_bytes = vec![0u8; core::mem::size_of::<T>()];
-                            aligned_bytes.copy_from_slice(&bytes);
+                            aligned_bytes.copy_from_slice(bytes);
                             Ok(*bytemuck::checked::from_bytes(&aligned_bytes))
                         }
                         _ => Err(err),

--- a/crates/burn-tensor/src/tensor/data.rs
+++ b/crates/burn-tensor/src/tensor/data.rs
@@ -6,6 +6,7 @@ use core::{
 use alloc::boxed::Box;
 use alloc::format;
 use alloc::string::String;
+use alloc::vec;
 use alloc::vec::Vec;
 use bytemuck::{checked::CheckedCastError, AnyBitPattern};
 use half::{bf16, f16};
@@ -1308,7 +1309,6 @@ fn compare_floats(value: f64, other: f64, ty: DType, tolerance: f64) -> Option<(
 #[allow(deprecated)]
 mod tests {
     use super::*;
-    use alloc::vec;
     use rand::{rngs::StdRng, SeedableRng};
 
     #[test]

--- a/crates/burn-tensor/src/tensor/element/base.rs
+++ b/crates/burn-tensor/src/tensor/element/base.rs
@@ -1,6 +1,10 @@
 use core::cmp::Ordering;
 
-use crate::{cast::ToElement, quantization::QuantizationStrategy, Distribution};
+use crate::{
+    cast::ToElement,
+    quantization::{QuantizationScheme, QuantizationType},
+    Distribution,
+};
 #[cfg(feature = "cubecl")]
 use cubecl::flex32;
 use half::{bf16, f16};
@@ -279,7 +283,7 @@ pub enum DType {
     U16,
     U8,
     Bool,
-    QFloat(QuantizationStrategy),
+    QFloat(QuantizationScheme),
 }
 
 impl DType {
@@ -299,9 +303,11 @@ impl DType {
             DType::U16 => core::mem::size_of::<u16>(),
             DType::U8 => core::mem::size_of::<u8>(),
             DType::Bool => core::mem::size_of::<bool>(),
-            DType::QFloat(strategy) => match strategy {
-                QuantizationStrategy::PerTensorAffineInt8(_) => core::mem::size_of::<u8>(),
-                QuantizationStrategy::PerTensorSymmetricInt8(_) => core::mem::size_of::<u8>(),
+            DType::QFloat(scheme) => match scheme {
+                QuantizationScheme::PerTensorAffine(qtype)
+                | QuantizationScheme::PerTensorSymmetric(qtype) => match qtype {
+                    QuantizationType::QInt8 => core::mem::size_of::<i8>(),
+                },
             },
         }
     }

--- a/crates/burn-tensor/src/tensor/module.rs
+++ b/crates/burn-tensor/src/tensor/module.rs
@@ -184,6 +184,7 @@ pub fn max_pool2d<B>(
     x: Tensor<B, 4>,
     kernel_size: [usize; 2],
     stride: [usize; 2],
+    // TODO: support asymmetric padding
     padding: [usize; 2],
     dilation: [usize; 2],
 ) -> Tensor<B, 4>

--- a/crates/burn-tensor/src/tensor/module.rs
+++ b/crates/burn-tensor/src/tensor/module.rs
@@ -184,7 +184,6 @@ pub fn max_pool2d<B>(
     x: Tensor<B, 4>,
     kernel_size: [usize; 2],
     stride: [usize; 2],
-    // TODO: support asymmetric padding
     padding: [usize; 2],
     dilation: [usize; 2],
 ) -> Tensor<B, 4>

--- a/crates/burn-tensor/src/tensor/ops/qtensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/qtensor.rs
@@ -198,7 +198,7 @@ pub trait QTensorOps<B: Backend> {
     ///
     /// The result of adding the scalar to the tensor.
     fn q_add_scalar(lhs: QuantizedTensor<B>, rhs: FloatElem<B>) -> QuantizedTensor<B> {
-        let scheme = lhs.scheme().clone();
+        let scheme = *lhs.scheme();
 
         let lhs_f = Self::dequantize(lhs);
         let out_f = B::float_add_scalar(lhs_f, rhs);
@@ -217,7 +217,7 @@ pub trait QTensorOps<B: Backend> {
     ///
     /// The clamped tensor.
     fn q_clamp_min(tensor: QuantizedTensor<B>, min: FloatElem<B>) -> QuantizedTensor<B> {
-        let scheme = tensor.scheme().clone();
+        let scheme = *tensor.scheme();
 
         let tensor_f = Self::dequantize(tensor);
         let out_f = B::float_clamp_min(tensor_f, min);
@@ -236,7 +236,7 @@ pub trait QTensorOps<B: Backend> {
     ///
     /// The clamped tensor.
     fn q_clamp_max(tensor: QuantizedTensor<B>, max: FloatElem<B>) -> QuantizedTensor<B> {
-        let scheme = tensor.scheme().clone();
+        let scheme = *tensor.scheme();
 
         let tensor_f = Self::dequantize(tensor);
         let out_f = B::float_clamp_max(tensor_f, max);
@@ -260,7 +260,7 @@ pub trait QTensorOps<B: Backend> {
         min: FloatElem<B>,
         max: FloatElem<B>,
     ) -> QuantizedTensor<B> {
-        let scheme = tensor.scheme().clone();
+        let scheme = *tensor.scheme();
 
         let tensor_f = Self::dequantize(tensor);
         let out_f = B::float_clamp(tensor_f, min, max);
@@ -298,7 +298,7 @@ pub trait QTensorOps<B: Backend> {
     ///
     /// The result of subtracting the scalar from the tensor.
     fn q_sub_scalar(lhs: QuantizedTensor<B>, rhs: FloatElem<B>) -> QuantizedTensor<B> {
-        let scheme = lhs.scheme().clone();
+        let scheme = *lhs.scheme();
 
         let lhs_f = Self::dequantize(lhs);
         let out_f = B::float_sub_scalar(lhs_f, rhs);
@@ -327,7 +327,7 @@ pub trait QTensorOps<B: Backend> {
     ///
     /// The result of multiplying the tensor by the scalar.
     fn q_mul_scalar(lhs: QuantizedTensor<B>, rhs: FloatElem<B>) -> QuantizedTensor<B> {
-        let scheme = lhs.scheme().clone();
+        let scheme = *lhs.scheme();
 
         let lhs_f = Self::dequantize(lhs);
         let out_f = B::float_mul_scalar(lhs_f, rhs);
@@ -365,7 +365,7 @@ pub trait QTensorOps<B: Backend> {
     ///
     /// The result of dividing the tensor by the scalar.
     fn q_div_scalar(lhs: QuantizedTensor<B>, rhs: FloatElem<B>) -> QuantizedTensor<B> {
-        let scheme = lhs.scheme().clone();
+        let scheme = *lhs.scheme();
 
         let lhs_f = Self::dequantize(lhs);
         let out_f = B::float_div_scalar(lhs_f, rhs);
@@ -402,7 +402,7 @@ pub trait QTensorOps<B: Backend> {
     ///
     /// The result of applying the modulus of the scalar to the tensor.
     fn q_remainder_scalar(lhs: QuantizedTensor<B>, rhs: FloatElem<B>) -> QuantizedTensor<B> {
-        let scheme = lhs.scheme().clone();
+        let scheme = *lhs.scheme();
 
         let lhs_f = Self::dequantize(lhs);
         let out_f = B::float_remainder_scalar(lhs_f, rhs);
@@ -431,7 +431,7 @@ pub trait QTensorOps<B: Backend> {
 
     /// Negates a tensor element-wise.
     fn q_neg(tensor: QuantizedTensor<B>) -> QuantizedTensor<B> {
-        let scheme = tensor.scheme().clone();
+        let scheme = *tensor.scheme();
 
         let tensor_f = Self::dequantize(tensor);
         let out_f = B::float_neg(tensor_f);
@@ -441,7 +441,7 @@ pub trait QTensorOps<B: Backend> {
 
     /// Calculates the reciprocals element-wise
     fn q_recip(tensor: QuantizedTensor<B>) -> QuantizedTensor<B> {
-        let scheme = tensor.scheme().clone();
+        let scheme = *tensor.scheme();
 
         let tensor_f = Self::dequantize(tensor);
         let out_f = B::float_recip(tensor_f);
@@ -1016,7 +1016,7 @@ pub trait QTensorOps<B: Backend> {
     /// A tensor with the concatenated tensors along `dim`.
     fn q_cat(tensors: Vec<QuantizedTensor<B>>, dim: usize) -> QuantizedTensor<B> {
         // Heuristic: prioritize first tensor scheme
-        let scheme = tensors.first().unwrap().scheme().clone();
+        let scheme = *tensors.first().unwrap().scheme();
 
         let tensor_f = tensors
             .into_iter()
@@ -1204,7 +1204,7 @@ pub trait QTensorOps<B: Backend> {
     ///
     /// A vector of tensors
     fn q_chunk(tensor: QuantizedTensor<B>, chunks: usize, dim: usize) -> Vec<QuantizedTensor<B>> {
-        let scheme = tensor.scheme().clone();
+        let scheme = *tensor.scheme();
 
         let tensor_f = Self::dequantize(tensor);
         let out_f = B::float_chunk(tensor_f, chunks, dim);
@@ -1323,7 +1323,7 @@ pub trait QTensorOps<B: Backend> {
         descending: bool,
     ) -> (QuantizedTensor<B>, IntTensor<B>) {
         // Default implementation. Backends can sort on the int values since qparams remain the same.
-        let scheme = tensor.scheme().clone();
+        let scheme = *tensor.scheme();
 
         let tensor_f = Self::dequantize(tensor);
         let (out_f, indices) = B::float_sort_with_indices(tensor_f, dim, descending);

--- a/crates/burn-tensor/src/tensor/quantization/data.rs
+++ b/crates/burn-tensor/src/tensor/quantization/data.rs
@@ -1,0 +1,41 @@
+use alloc::vec::Vec;
+
+/// Pack signed 8-bit integer values into a sequence of unsigned 32-bit integers.
+///
+/// # Note
+/// This assumes that the bytes represent `i8` values.
+pub fn pack_i8s_to_u32s(bytes: &[u8]) -> Vec<u32> {
+    // Shift and combine groups of four 8-bit values into a u32.
+    // Same as doing this:
+    //     let result = (a_u8 & 0xFF) << 24 | (b_u8 & 0xFF) << 16 | (c_u8 & 0xFF) << 8 | (d_u8 & 0xFF);
+    bytes
+        .chunks(4)
+        .map(|x| {
+            x.iter().enumerate().fold(0u32, |acc, (i, x)| {
+                acc | (*x as i8 as u32 & 0xFF) << ((3 - i) * 8)
+            })
+        })
+        .collect()
+}
+
+/// Unpack 32-bit unsiged integer values into a sequence of signed 8-bit integers.
+///
+/// # Note
+/// This assumes that the bytes represent `u32` values.
+pub fn unpack_u32s_to_i8s(bytes: &[u8], numel: usize) -> Vec<i8> {
+    bytemuck::cast_slice::<_, u32>(bytes)
+        .iter()
+        .enumerate()
+        .flat_map(|(i, packed)| {
+            // A single u32 could contain less than four 8-bit values...
+            let n = core::cmp::min(4, numel - i * 4);
+            // Extract each 8-bit segment from u32 and cast back to i8
+            // Same as doing this (when 4 values are fully packed):
+            //     let a = ((packed >> 24) & 0xFF) as i8;
+            //     let b = ((packed >> 16) & 0xFF) as i8;
+            //     let c = ((packed >> 8) & 0xFF) as i8;
+            //     let d = (packed & 0xFF) as i8;
+            (0..n).map(move |i| (packed >> ((3 - i) * 8) & 0xFF) as i8)
+        })
+        .collect()
+}

--- a/crates/burn-tensor/src/tensor/quantization/mod.rs
+++ b/crates/burn-tensor/src/tensor/quantization/mod.rs
@@ -1,10 +1,12 @@
 mod calibration;
+mod data;
 mod parameters;
 mod primitive;
 mod scheme;
 mod strategy;
 
 pub use calibration::*;
+pub use data::*;
 pub use parameters::*;
 pub use primitive::*;
 pub use scheme::*;

--- a/crates/burn-tensor/src/tensor/quantization/parameters.rs
+++ b/crates/burn-tensor/src/tensor/quantization/parameters.rs
@@ -2,13 +2,6 @@ use crate::{backend::Backend, Int, Tensor};
 
 /// The tensor quantization parameters.
 pub type QuantizationParameters<B> = QParams<Tensor<B, 1>, Tensor<B, 1, Int>>;
-// #[derive(Clone, Debug)]
-// pub struct QuantizationParameters<B: Backend> {
-//     /// The scaling factor.
-//     pub scale: Tensor<B, 1>,
-//     /// The zero-point offset.
-//     pub offset: Option<Tensor<B, 1, Int>>,
-// }
 
 /// The quantization tensor data parameters.
 #[derive(Clone, Debug)]

--- a/crates/burn-tensor/src/tensor/quantization/parameters.rs
+++ b/crates/burn-tensor/src/tensor/quantization/parameters.rs
@@ -1,12 +1,22 @@
 use crate::{backend::Backend, Int, Tensor};
 
-/// The quantization parameters.
+/// The tensor quantization parameters.
+pub type QuantizationParameters<B> = QParams<Tensor<B, 1>, Tensor<B, 1, Int>>;
+// #[derive(Clone, Debug)]
+// pub struct QuantizationParameters<B: Backend> {
+//     /// The scaling factor.
+//     pub scale: Tensor<B, 1>,
+//     /// The zero-point offset.
+//     pub offset: Option<Tensor<B, 1, Int>>,
+// }
+
+/// The quantization tensor data parameters.
 #[derive(Clone, Debug)]
-pub struct QuantizationParameters<B: Backend> {
+pub struct QParams<S, O> {
     /// The scaling factor.
-    pub scale: Tensor<B, 1>,
+    pub scale: S,
     /// The zero-point offset.
-    pub offset: Option<Tensor<B, 1, Int>>,
+    pub offset: Option<O>,
 }
 
 /// The quantization parameters primitive.

--- a/crates/burn-tensor/src/tensor/quantization/scheme.rs
+++ b/crates/burn-tensor/src/tensor/quantization/scheme.rs
@@ -5,14 +5,14 @@ use crate::{backend::Backend, Tensor, TensorPrimitive};
 use super::{CalibrationRange, QuantizationParameters, QuantizationParametersPrimitive};
 
 /// Quantization data type.
-#[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub enum QuantizationType {
     /// 8-bit signed integer.
     QInt8,
 }
 
 /// Quantization scheme.
-#[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub enum QuantizationScheme {
     /// Per-tensor affine/asymmetric quantization.
     PerTensorAffine(QuantizationType),

--- a/crates/burn-tensor/src/tensor/quantization/strategy.rs
+++ b/crates/burn-tensor/src/tensor/quantization/strategy.rs
@@ -10,8 +10,6 @@ use serde::{Deserialize, Serialize};
 
 use super::{QuantizationScheme, QuantizationType};
 
-// NOTE: QuantizationStrategy is used for TensorData (sync).
-
 /// Quantization strategy.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub enum QuantizationStrategy {


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.

### Changes

`DType::QFloat` no longer contains the `QuantizationStrategy` with quantization parameters as it is not known at compile-time. Instead, use the existing `QuantizationScheme` enum which only indicates the method and dtype.

Also changed the representation to pack the quantized values (as was previously done in `burn-jit` exclusively) and include the quantization parameters as the bytes.

### Testing

Added unit tests for packed/unpacked quantization parameters.
