### PR TITLE
Add float cast tensor op

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -254,6 +254,7 @@ Those operations are only available for `Float` tensors.
 | Burn API                                      | PyTorch Equivalent                 |
 |-----------------------------------------------| ---------------------------------- |
 | `Tensor::one_hot(index, num_classes, device)` | N/A                                |
+| `tensor.cast(dtype)`                          | `tensor.to(dtype)`                 |
 | `tensor.ceil()`                               | `tensor.ceil()`                    |
 | `tensor.cos()`                                | `tensor.cos()`                     |
 | `tensor.erf()`                                | `tensor.erf()`                     |

--- a/crates/burn-autodiff/src/ops/tensor.rs
+++ b/crates/burn-autodiff/src/ops/tensor.rs
@@ -2558,6 +2558,10 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
         }
     }
 
+    fn float_cast(tensor: FloatTensor<Self>, dtype: burn_tensor::FloatDType) -> FloatTensor<Self> {
+        AutodiffTensor::new(B::float_cast(tensor.primitive, dtype))
+    }
+
     // TODO: Implement float_prod and float_sum
     // https://github.com/tracel-ai/burn/issues/1458
 }

--- a/crates/burn-candle/src/backend.rs
+++ b/crates/burn-candle/src/backend.rs
@@ -163,13 +163,13 @@ impl<F: FloatCandleElement, I: IntCandleElement> Backend for Candle<F, I> {
 
     type FullPrecisionBridge = PrecisionBridge<f32>;
 
-    type FloatTensorPrimitive = CandleTensor<Self::FloatElem>;
+    type FloatTensorPrimitive = CandleTensor;
     type FloatElem = F;
 
-    type IntTensorPrimitive = CandleTensor<Self::IntElem>;
+    type IntTensorPrimitive = CandleTensor;
     type IntElem = I;
 
-    type BoolTensorPrimitive = CandleTensor<u8>;
+    type BoolTensorPrimitive = CandleTensor;
 
     type QuantizedTensorPrimitive = CandleQTensor;
     type QuantizedEncoding = u8;

--- a/crates/burn-candle/src/ops/base.rs
+++ b/crates/burn-candle/src/ops/base.rs
@@ -162,10 +162,7 @@ pub fn narrow(tensor: CandleTensor, dim: usize, start: usize, length: usize) -> 
 pub fn chunk(tensor: CandleTensor, chunks: usize, dim: usize) -> Vec<CandleTensor> {
     let tensors = tensor.tensor.chunk(chunks, dim);
     match tensors {
-        Ok(tensors) => tensors
-            .into_iter()
-            .map(|tensor| CandleTensor::new(tensor))
-            .collect(),
+        Ok(tensors) => tensors.into_iter().map(CandleTensor::new).collect(),
         Err(e) => panic!("error chunk from Candle"),
     }
 }

--- a/crates/burn-candle/src/ops/base.rs
+++ b/crates/burn-candle/src/ops/base.rs
@@ -56,7 +56,33 @@ pub fn into_data(tensor: CandleTensor) -> TensorData {
                 .unwrap(),
             tensor.shape(),
         ),
-        _ => panic!("Not a valid float kind"),
+        candle_core::DType::U8 => TensorData::new(
+            tensor
+                .tensor
+                .flatten_all()
+                .unwrap()
+                .to_vec1::<u8>()
+                .unwrap(),
+            tensor.shape(),
+        ),
+        candle_core::DType::U32 => TensorData::new(
+            tensor
+                .tensor
+                .flatten_all()
+                .unwrap()
+                .to_vec1::<u32>()
+                .unwrap(),
+            tensor.shape(),
+        ),
+        candle_core::DType::I64 => TensorData::new(
+            tensor
+                .tensor
+                .flatten_all()
+                .unwrap()
+                .to_vec1::<i64>()
+                .unwrap(),
+            tensor.shape(),
+        ),
     }
 }
 

--- a/crates/burn-candle/src/ops/base.rs
+++ b/crates/burn-candle/src/ops/base.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
 
-use burn_tensor::{backend::Backend, Shape, TensorData};
+use burn_tensor::{backend::Backend, Element, Shape, TensorData};
+use candle_core::WithDType;
 use half::{bf16, f16};
 
 use crate::{
@@ -19,70 +20,21 @@ pub fn from_data<E: CandleElement>(data: TensorData, device: &CandleDevice) -> C
     CandleTensor::from_data::<E>(data, device.clone())
 }
 pub fn into_data(tensor: CandleTensor) -> TensorData {
+    fn tensor_data_from_dtype<T: WithDType + Element>(tensor: &CandleTensor) -> TensorData {
+        TensorData::new(
+            tensor.tensor.flatten_all().unwrap().to_vec1::<T>().unwrap(),
+            tensor.shape(),
+        )
+    }
+
     match tensor.tensor.dtype() {
-        candle_core::DType::BF16 => TensorData::new(
-            tensor
-                .tensor
-                .flatten_all()
-                .unwrap()
-                .to_vec1::<bf16>()
-                .unwrap(),
-            tensor.shape(),
-        ),
-        candle_core::DType::F16 => TensorData::new(
-            tensor
-                .tensor
-                .flatten_all()
-                .unwrap()
-                .to_vec1::<f16>()
-                .unwrap(),
-            tensor.shape(),
-        ),
-        candle_core::DType::F32 => TensorData::new(
-            tensor
-                .tensor
-                .flatten_all()
-                .unwrap()
-                .to_vec1::<f32>()
-                .unwrap(),
-            tensor.shape(),
-        ),
-        candle_core::DType::F64 => TensorData::new(
-            tensor
-                .tensor
-                .flatten_all()
-                .unwrap()
-                .to_vec1::<f64>()
-                .unwrap(),
-            tensor.shape(),
-        ),
-        candle_core::DType::U8 => TensorData::new(
-            tensor
-                .tensor
-                .flatten_all()
-                .unwrap()
-                .to_vec1::<u8>()
-                .unwrap(),
-            tensor.shape(),
-        ),
-        candle_core::DType::U32 => TensorData::new(
-            tensor
-                .tensor
-                .flatten_all()
-                .unwrap()
-                .to_vec1::<u32>()
-                .unwrap(),
-            tensor.shape(),
-        ),
-        candle_core::DType::I64 => TensorData::new(
-            tensor
-                .tensor
-                .flatten_all()
-                .unwrap()
-                .to_vec1::<i64>()
-                .unwrap(),
-            tensor.shape(),
-        ),
+        candle_core::DType::BF16 => tensor_data_from_dtype::<bf16>(&tensor),
+        candle_core::DType::F16 => tensor_data_from_dtype::<f16>(&tensor),
+        candle_core::DType::F32 => tensor_data_from_dtype::<f32>(&tensor),
+        candle_core::DType::F64 => tensor_data_from_dtype::<f64>(&tensor),
+        candle_core::DType::U8 => tensor_data_from_dtype::<u8>(&tensor),
+        candle_core::DType::U32 => tensor_data_from_dtype::<u32>(&tensor),
+        candle_core::DType::I64 => tensor_data_from_dtype::<i64>(&tensor),
     }
 }
 

--- a/crates/burn-candle/src/ops/bool_tensor.rs
+++ b/crates/burn-candle/src/ops/bool_tensor.rs
@@ -12,7 +12,7 @@ use super::base::{expand, permute};
 
 impl<F: FloatCandleElement, I: IntCandleElement> BoolTensorOps<Self> for Candle<F, I> {
     fn bool_empty(shape: Shape, device: &Device<Self>) -> BoolTensor<Self> {
-        super::base::empty(shape, device)
+        super::base::empty(shape, device, candle_core::DType::U8)
     }
 
     fn bool_shape(tensor: &BoolTensor<Self>) -> Shape {
@@ -27,7 +27,7 @@ impl<F: FloatCandleElement, I: IntCandleElement> BoolTensorOps<Self> for Candle<
 
     fn bool_from_data(data: TensorData, device: &Device<Self>) -> BoolTensor<Self> {
         let data: TensorData = TensorData::new(data.iter::<bool>().collect(), data.shape);
-        super::base::from_data(data, device)
+        super::base::from_data::<u8>(data, device)
     }
 
     fn bool_into_int(tensor: BoolTensor<Self>) -> IntTensor<Self> {

--- a/crates/burn-candle/src/ops/int_tensor.rs
+++ b/crates/burn-candle/src/ops/int_tensor.rs
@@ -12,7 +12,7 @@ use super::base::{expand, permute, sign};
 
 impl<F: FloatCandleElement, I: IntCandleElement> IntTensorOps<Self> for Candle<F, I> {
     fn int_empty(shape: Shape, device: &Device<Self>) -> IntTensor<Self> {
-        super::base::empty(shape, device)
+        super::base::empty(shape, device, I::DTYPE)
     }
 
     fn int_shape(tensor: &IntTensor<Self>) -> Shape {
@@ -24,7 +24,7 @@ impl<F: FloatCandleElement, I: IntCandleElement> IntTensorOps<Self> for Candle<F
     }
 
     fn int_from_data(data: TensorData, device: &Device<Self>) -> IntTensor<Self> {
-        super::base::from_data(data, device)
+        super::base::from_data::<I>(data, device)
     }
 
     fn int_device(tensor: &IntTensor<Self>) -> Device<Self> {
@@ -251,7 +251,7 @@ impl<F: FloatCandleElement, I: IntCandleElement> IntTensorOps<Self> for Candle<F
 
     fn int_sum(tensor: IntTensor<Self>) -> IntTensor<Self> {
         let sum = tensor.tensor.sum_all().unwrap().to_scalar::<I>().unwrap();
-        CandleTensor::from_data(
+        CandleTensor::from_data::<I>(
             TensorData::new([sum].into(), [1]),
             Self::int_device(&tensor),
         )

--- a/crates/burn-candle/src/ops/tensor.rs
+++ b/crates/burn-candle/src/ops/tensor.rs
@@ -14,8 +14,8 @@ use crate::{
 use super::base::{expand, permute, sign};
 
 impl<F: FloatCandleElement, I: IntCandleElement> FloatTensorOps<Self> for Candle<F, I> {
-    fn float_from_data(data: TensorData, device: &Device<Self>) -> CandleTensor<F> {
-        CandleTensor::from_data(data, device.clone())
+    fn float_from_data(data: TensorData, device: &Device<Self>) -> CandleTensor {
+        CandleTensor::from_data::<F>(data, device.clone())
     }
 
     fn float_random(
@@ -52,28 +52,28 @@ impl<F: FloatCandleElement, I: IntCandleElement> FloatTensorOps<Self> for Candle
         }
     }
 
-    fn float_shape(tensor: &CandleTensor<F>) -> Shape {
+    fn float_shape(tensor: &CandleTensor) -> Shape {
         super::base::shape(tensor)
     }
 
-    async fn float_into_data(tensor: CandleTensor<F>) -> TensorData {
+    async fn float_into_data(tensor: CandleTensor) -> TensorData {
         super::base::into_data(tensor)
     }
 
-    fn float_device(tensor: &CandleTensor<F>) -> Device<Self> {
+    fn float_device(tensor: &CandleTensor) -> Device<Self> {
         super::base::device(tensor)
     }
 
-    fn float_to_device(tensor: CandleTensor<F>, device: &Device<Self>) -> CandleTensor<F> {
+    fn float_to_device(tensor: CandleTensor, device: &Device<Self>) -> CandleTensor {
         super::base::to_device(tensor, device)
     }
 
-    fn float_into_int(tensor: CandleTensor<F>) -> IntTensor<Self> {
+    fn float_into_int(tensor: CandleTensor) -> IntTensor<Self> {
         CandleTensor::new(tensor.tensor.to_dtype(I::DTYPE).unwrap())
     }
 
     fn float_empty(shape: Shape, device: &Device<Self>) -> FloatTensor<Self> {
-        super::base::empty(shape, device)
+        super::base::empty(shape, device, F::DTYPE)
     }
 
     fn float_add(lhs: FloatTensor<Self>, rhs: FloatTensor<Self>) -> FloatTensor<Self> {
@@ -298,7 +298,7 @@ impl<F: FloatCandleElement, I: IntCandleElement> FloatTensorOps<Self> for Candle
 
     fn float_sum(tensor: FloatTensor<Self>) -> FloatTensor<Self> {
         let sum = tensor.tensor.sum_all().unwrap().to_scalar::<F>().unwrap();
-        CandleTensor::from_data(
+        CandleTensor::from_data::<F>(
             TensorData::new([sum].into(), [1]),
             Self::float_device(&tensor),
         )

--- a/crates/burn-candle/src/ops/tensor.rs
+++ b/crates/burn-candle/src/ops/tensor.rs
@@ -470,4 +470,11 @@ impl<F: FloatCandleElement, I: IntCandleElement> FloatTensorOps<Self> for Candle
     fn float_sign(tensor: FloatTensor<Self>) -> FloatTensor<Self> {
         sign(tensor)
     }
+
+    fn float_cast(
+        _tensor: FloatTensor<Self>,
+        _dtype: burn_tensor::FloatDType,
+    ) -> FloatTensor<Self> {
+        todo!()
+    }
 }

--- a/crates/burn-candle/src/ops/tensor.rs
+++ b/crates/burn-candle/src/ops/tensor.rs
@@ -2,7 +2,7 @@ use std::borrow::Borrow;
 
 use burn_tensor::{
     ops::{BoolTensor, FloatElem, FloatTensor, FloatTensorOps, FullPrecisionBackend, IntTensor},
-    Device, Distribution, ElementConversion, Shape, TensorData,
+    Device, Distribution, ElementConversion, FloatDType, Shape, TensorData,
 };
 use candle_core::{backend::BackendStorage, shape, Tensor};
 
@@ -471,10 +471,18 @@ impl<F: FloatCandleElement, I: IntCandleElement> FloatTensorOps<Self> for Candle
         sign(tensor)
     }
 
-    fn float_cast(
-        _tensor: FloatTensor<Self>,
-        _dtype: burn_tensor::FloatDType,
-    ) -> FloatTensor<Self> {
-        todo!()
+    fn float_cast(tensor: FloatTensor<Self>, dtype: FloatDType) -> FloatTensor<Self> {
+        let dtype = match dtype {
+            FloatDType::F64 => candle_core::DType::F64,
+            FloatDType::F32 => candle_core::DType::F32,
+            FloatDType::F16 => candle_core::DType::F16,
+            FloatDType::BF16 => candle_core::DType::BF16,
+        };
+
+        if tensor.tensor.dtype() == dtype {
+            tensor
+        } else {
+            CandleTensor::new(tensor.tensor.to_dtype(dtype).unwrap())
+        }
     }
 }

--- a/crates/burn-candle/src/tensor.rs
+++ b/crates/burn-candle/src/tensor.rs
@@ -1,5 +1,3 @@
-use std::marker::PhantomData;
-
 use burn_tensor::{
     quantization::{QTensorPrimitive, QuantizationScheme, QuantizationStrategy},
     Element, Shape, TensorData,
@@ -9,18 +7,14 @@ use crate::{element::CandleElement, CandleDevice};
 
 /// A tensor that uses the candle backend.
 #[derive(Debug, Clone)]
-pub struct CandleTensor<E: CandleElement> {
+pub struct CandleTensor {
     pub(crate) tensor: candle_core::Tensor,
-    phantom: PhantomData<E>,
 }
 
-impl<E: CandleElement> CandleTensor<E> {
+impl CandleTensor {
     /// Create a new tensor.
     pub fn new(tensor: candle_core::Tensor) -> Self {
-        Self {
-            tensor,
-            phantom: PhantomData,
-        }
+        Self { tensor }
     }
 
     /// Creates a new tensor from data and a device.
@@ -33,7 +27,7 @@ impl<E: CandleElement> CandleTensor<E> {
     /// # Returns
     ///
     /// A new tensor.
-    pub fn from_data(data: TensorData, device: CandleDevice) -> Self {
+    pub fn from_data<E: CandleElement>(data: TensorData, device: CandleDevice) -> Self {
         let candle_shape: candle_core::Shape = data.shape.clone().into();
         let tensor = candle_core::Tensor::from_slice(
             data.convert::<E>().as_slice::<E>().unwrap(),
@@ -53,7 +47,7 @@ impl<E: CandleElement> CandleTensor<E> {
 pub struct CandleQTensor {
     /// The quantized tensor.
     // NOTE: candle  does not implement `WithDType` for i8
-    pub qtensor: CandleTensor<u8>,
+    pub qtensor: CandleTensor,
     /// The quantization scheme.
     pub scheme: QuantizationScheme,
 }

--- a/crates/burn-fusion/src/ops/float.rs
+++ b/crates/burn-fusion/src/ops/float.rs
@@ -2196,4 +2196,11 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
 
         out
     }
+
+    fn float_cast(
+        _tensor: FloatTensor<Self>,
+        _dtype: burn_tensor::FloatDType,
+    ) -> FloatTensor<Self> {
+        todo!()
+    }
 }

--- a/crates/burn-jit/src/ops/float_ops.rs
+++ b/crates/burn-jit/src/ops/float_ops.rs
@@ -426,4 +426,11 @@ where
     fn float_flip(tensor: FloatTensor<Self>, axes: &[usize]) -> FloatTensor<Self> {
         kernel::flip(tensor, axes)
     }
+
+    fn float_cast(
+        _tensor: FloatTensor<Self>,
+        _dtype: burn_tensor::FloatDType,
+    ) -> FloatTensor<Self> {
+        todo!()
+    }
 }

--- a/crates/burn-ndarray/src/ops/tensor.rs
+++ b/crates/burn-ndarray/src/ops/tensor.rs
@@ -447,4 +447,11 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> FloatTensorO
     fn float_expand(tensor: NdArrayTensor<E>, shape: Shape) -> NdArrayTensor<E> {
         NdArrayOps::expand(tensor, shape)
     }
+
+    fn float_cast(
+        _tensor: burn_tensor::ops::FloatTensor<Self>,
+        _dtype: burn_tensor::FloatDType,
+    ) -> burn_tensor::ops::FloatTensor<Self> {
+        todo!()
+    }
 }

--- a/crates/burn-router/src/ops/op_float.rs
+++ b/crates/burn-router/src/ops/op_float.rs
@@ -1477,4 +1477,8 @@ impl<R: RunnerChannel> FloatTensorOps<Self> for BackendRouter<R> {
 
         out
     }
+
+    fn float_cast(_tensor: FloatTensor<Self>, _dtype: burn_tensor::FloatDType) -> FloatTensor<Self> {
+        todo!()
+    }
 }

--- a/crates/burn-router/src/ops/op_float.rs
+++ b/crates/burn-router/src/ops/op_float.rs
@@ -1478,7 +1478,10 @@ impl<R: RunnerChannel> FloatTensorOps<Self> for BackendRouter<R> {
         out
     }
 
-    fn float_cast(_tensor: FloatTensor<Self>, _dtype: burn_tensor::FloatDType) -> FloatTensor<Self> {
+    fn float_cast(
+        _tensor: FloatTensor<Self>,
+        _dtype: burn_tensor::FloatDType,
+    ) -> FloatTensor<Self> {
         todo!()
     }
 }

--- a/crates/burn-tch/src/backend.rs
+++ b/crates/burn-tch/src/backend.rs
@@ -95,15 +95,15 @@ impl<E: TchElement, Q: QuantElement> Backend for LibTorch<E, Q> {
     type Device = LibTorchDevice;
     type FullPrecisionBridge = PrecisionBridge<f32>;
 
-    type FloatTensorPrimitive = TchTensor<E>;
+    type FloatTensorPrimitive = TchTensor;
     type FloatElem = E;
 
-    type IntTensorPrimitive = TchTensor<i64>;
+    type IntTensorPrimitive = TchTensor;
     type IntElem = i64;
 
-    type BoolTensorPrimitive = TchTensor<bool>;
+    type BoolTensorPrimitive = TchTensor;
 
-    type QuantizedTensorPrimitive = TchQTensor<Q>;
+    type QuantizedTensorPrimitive = TchQTensor;
     type QuantizedEncoding = Q;
 
     fn seed(seed: u64) {

--- a/crates/burn-tch/src/bridge.rs
+++ b/crates/burn-tch/src/bridge.rs
@@ -2,7 +2,7 @@ use crate::{ops::TchOps, LibTorch, QuantElement, TchElement, TchTensor};
 use burn_tensor::{backend::BackendBridge, ops::FloatTensor, Device};
 use std::marker::PhantomData;
 
-/// Handle precision conversion for the candle backend.
+/// Handle precision conversion for the tch backend.
 #[derive(Debug)]
 pub struct PrecisionBridge<E: TchElement> {
     _e: PhantomData<E>,

--- a/crates/burn-tch/src/element.rs
+++ b/crates/burn-tch/src/element.rs
@@ -16,6 +16,8 @@ impl TchElement for i8 {}
 
 impl TchElement for u8 {}
 
+impl TchElement for bool {}
+
 /// A quantized element for the tch backend.
 pub trait QuantElement: TchElement {}
 

--- a/crates/burn-tch/src/ops/activation.rs
+++ b/crates/burn-tch/src/ops/activation.rs
@@ -2,29 +2,29 @@ use crate::{element::TchElement, LibTorch, QuantElement, TchTensor};
 use burn_tensor::ops::ActivationOps;
 
 impl<E: TchElement, Q: QuantElement> ActivationOps<Self> for LibTorch<E, Q> {
-    fn relu(tensor: TchTensor<E>) -> TchTensor<E> {
+    fn relu(tensor: TchTensor) -> TchTensor {
         tensor.unary_ops(|mut tensor| tensor.relu_(), |tensor| tensor.relu())
     }
 
-    fn gelu(tensor: TchTensor<E>) -> TchTensor<E> {
+    fn gelu(tensor: TchTensor) -> TchTensor {
         tensor.unary_ops(
             |mut tensor| tensor.gelu_("none"),
             |tensor| tensor.gelu("none"),
         )
     }
 
-    fn gelu_backward(tensor: TchTensor<E>, grad: TchTensor<E>) -> TchTensor<E> {
+    fn gelu_backward(tensor: TchTensor, grad: TchTensor) -> TchTensor {
         let storage = tensor.storage.clone();
         let tensor = tensor.tensor.gelu_backward(&grad.tensor, "none");
 
         TchTensor::from_existing(tensor, storage)
     }
 
-    fn sigmoid(tensor: TchTensor<E>) -> TchTensor<E> {
+    fn sigmoid(tensor: TchTensor) -> TchTensor {
         tensor.unary_ops(|mut tensor| tensor.sigmoid_(), |tensor| tensor.sigmoid())
     }
 
-    fn log_sigmoid(tensor: TchTensor<E>) -> TchTensor<E> {
+    fn log_sigmoid(tensor: TchTensor) -> TchTensor {
         // NOTE: we don't override log_sigmoid_backward because Torch has a special backward
         // formula that uses a buffer with computed values from the forward pass
 

--- a/crates/burn-tch/src/ops/base.rs
+++ b/crates/burn-tch/src/ops/base.rs
@@ -2,14 +2,14 @@ use burn_tensor::Shape;
 use tch::Scalar;
 
 use crate::{LibTorchDevice, TchShape, TchTensor};
-use std::{marker::PhantomData, ops::Range};
+use std::ops::Range;
 
-pub struct TchOps<E: tch::kind::Element + Copy + Default> {
-    e: PhantomData<E>,
+pub struct TchOps {
+    // e: PhantomData<E>,
 }
 
-impl<E: tch::kind::Element + Copy + Default> TchOps<E> {
-    pub fn to_device(tensor: TchTensor<E>, device: &LibTorchDevice) -> TchTensor<E> {
+impl TchOps {
+    pub fn to_device(tensor: TchTensor, device: &LibTorchDevice) -> TchTensor {
         let device = (*device).into();
 
         // We have to manually check if the device is the same, since when it's the case, we need to keep
@@ -21,20 +21,20 @@ impl<E: tch::kind::Element + Copy + Default> TchOps<E> {
         TchTensor::new(tensor.tensor.to(device))
     }
 
-    pub fn reshape(tensor: TchTensor<E>, shape: Shape) -> TchTensor<E> {
+    pub fn reshape(tensor: TchTensor, shape: Shape) -> TchTensor {
         let shape_tch: TchShape = shape.into();
 
         TchTensor::from_existing(tensor.tensor.reshape(shape_tch.dims), tensor.storage)
     }
 
-    pub fn repeat_dim(tensor: TchTensor<E>, dim: usize, times: usize) -> TchTensor<E> {
+    pub fn repeat_dim(tensor: TchTensor, dim: usize, times: usize) -> TchTensor {
         let mut dims = vec![1; tensor.shape().num_dims()];
         dims[dim] = times as i64;
         let tensor = tch::Tensor::repeat(&tensor.tensor, dims);
         TchTensor::new(tensor)
     }
 
-    pub fn slice(tensor: TchTensor<E>, ranges: &[Range<usize>]) -> TchTensor<E> {
+    pub fn slice(tensor: TchTensor, ranges: &[Range<usize>]) -> TchTensor {
         let storage = tensor.storage.clone();
         let mut tensor = tensor.tensor.shallow_clone();
 
@@ -47,16 +47,11 @@ impl<E: tch::kind::Element + Copy + Default> TchOps<E> {
         TchTensor::partial(tensor, storage)
     }
 
-    pub fn slice_assign(
-        tensor: TchTensor<E>,
-        ranges: &[Range<usize>],
-        value: TchTensor<E>,
-    ) -> TchTensor<E> {
+    pub fn slice_assign(tensor: TchTensor, ranges: &[Range<usize>], value: TchTensor) -> TchTensor {
         let tch_shape = TchShape::from(tensor.shape());
 
         // Copy the input tensor if we can't mutate it.
-        let tensor_original: TchTensor<E> =
-            tensor.unary_ops(|tensor| tensor, |tensor| tensor.copy());
+        let tensor_original: TchTensor = tensor.unary_ops(|tensor| tensor, |tensor| tensor.copy());
         let tensor_original = tensor_original.tensor;
 
         let mut tensor = tensor_original.view_(tch_shape.dims);
@@ -73,7 +68,7 @@ impl<E: tch::kind::Element + Copy + Default> TchOps<E> {
         TchTensor::new(tensor_original)
     }
 
-    pub fn gather(dim: usize, tensor: TchTensor<E>, indices: TchTensor<i64>) -> TchTensor<E> {
+    pub fn gather(dim: usize, tensor: TchTensor, indices: TchTensor) -> TchTensor {
         let storage = tensor.storage.clone();
         let tensor = tensor.tensor.gather(dim as i64, &indices.tensor, false);
 
@@ -82,10 +77,10 @@ impl<E: tch::kind::Element + Copy + Default> TchOps<E> {
 
     pub fn scatter(
         dim: usize,
-        tensor: TchTensor<E>,
-        indices: TchTensor<i64>,
-        value: TchTensor<E>,
-    ) -> TchTensor<E> {
+        tensor: TchTensor,
+        indices: TchTensor,
+        value: TchTensor,
+    ) -> TchTensor {
         let storage = tensor.storage.clone();
         let tensor = tensor
             .tensor
@@ -94,11 +89,7 @@ impl<E: tch::kind::Element + Copy + Default> TchOps<E> {
         TchTensor::from_existing(tensor, storage)
     }
 
-    pub fn index_select_dim(
-        tensor: TchTensor<E>,
-        dim: usize,
-        indices: TchTensor<i64>,
-    ) -> TchTensor<E> {
+    pub fn index_select_dim(tensor: TchTensor, dim: usize, indices: TchTensor) -> TchTensor {
         let storage = tensor.storage.clone();
         let tensor = tensor.tensor.index_select(dim as i64, &indices.tensor);
 
@@ -106,18 +97,18 @@ impl<E: tch::kind::Element + Copy + Default> TchOps<E> {
     }
 
     pub fn select_assign(
-        tensor: TchTensor<E>,
+        tensor: TchTensor,
         dim: usize,
-        indices: TchTensor<i64>,
-        value: TchTensor<E>,
-    ) -> TchTensor<E> {
+        indices: TchTensor,
+        value: TchTensor,
+    ) -> TchTensor {
         tensor.clone().unary_ops(
             |mut tensor| tensor.index_add_(dim as i64, &indices.tensor, &value.tensor),
             |tensor| tensor.index_add(dim as i64, &indices.tensor, &value.tensor),
         )
     }
 
-    pub fn cat(tensors: Vec<TchTensor<E>>, dim: usize) -> TchTensor<E> {
+    pub fn cat(tensors: Vec<TchTensor>, dim: usize) -> TchTensor {
         let tensors: Vec<tch::Tensor> = tensors
             .into_iter()
             .map(|t| t.tensor.shallow_clone())
@@ -127,7 +118,7 @@ impl<E: tch::kind::Element + Copy + Default> TchOps<E> {
         TchTensor::new(tensor)
     }
 
-    pub fn equal(lhs: TchTensor<E>, rhs: TchTensor<E>) -> TchTensor<bool> {
+    pub fn equal(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchTensor::binary_ops_tensor(
             lhs,
             rhs,
@@ -137,14 +128,14 @@ impl<E: tch::kind::Element + Copy + Default> TchOps<E> {
         )
     }
 
-    pub fn equal_elem<S: Into<tch::Scalar> + Clone>(lhs: TchTensor<E>, rhs: S) -> TchTensor<bool> {
+    pub fn equal_elem<S: Into<tch::Scalar> + Clone>(lhs: TchTensor, rhs: S) -> TchTensor {
         lhs.unary_ops(
             |mut tensor| tensor.eq_(rhs.clone().into()).to_kind(tch::Kind::Bool),
             |tensor| tensor.eq(rhs.clone().into()),
         )
     }
 
-    pub fn greater(lhs: TchTensor<E>, rhs: TchTensor<E>) -> TchTensor<bool> {
+    pub fn greater(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchTensor::binary_ops_tensor(
             lhs,
             rhs,
@@ -154,17 +145,14 @@ impl<E: tch::kind::Element + Copy + Default> TchOps<E> {
         )
     }
 
-    pub fn greater_elem<S: Into<tch::Scalar> + Clone>(
-        lhs: TchTensor<E>,
-        rhs: S,
-    ) -> TchTensor<bool> {
+    pub fn greater_elem<S: Into<tch::Scalar> + Clone>(lhs: TchTensor, rhs: S) -> TchTensor {
         lhs.unary_ops(
             |mut tensor| tensor.greater_(rhs.clone().into()).to_kind(tch::Kind::Bool),
             |tensor| tensor.greater(rhs.clone().into()),
         )
     }
 
-    pub fn greater_equal(lhs: TchTensor<E>, rhs: TchTensor<E>) -> TchTensor<bool> {
+    pub fn greater_equal(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchTensor::binary_ops_tensor(
             lhs,
             rhs,
@@ -174,10 +162,7 @@ impl<E: tch::kind::Element + Copy + Default> TchOps<E> {
         )
     }
 
-    pub fn greater_equal_elem<S: Into<Scalar> + Clone>(
-        lhs: TchTensor<E>,
-        rhs: S,
-    ) -> TchTensor<bool> {
+    pub fn greater_equal_elem<S: Into<Scalar> + Clone>(lhs: TchTensor, rhs: S) -> TchTensor {
         lhs.unary_ops(
             |mut tensor| {
                 tensor
@@ -188,7 +173,7 @@ impl<E: tch::kind::Element + Copy + Default> TchOps<E> {
         )
     }
 
-    pub fn lower(lhs: TchTensor<E>, rhs: TchTensor<E>) -> TchTensor<bool> {
+    pub fn lower(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchTensor::binary_ops_tensor(
             lhs,
             rhs,
@@ -198,14 +183,14 @@ impl<E: tch::kind::Element + Copy + Default> TchOps<E> {
         )
     }
 
-    pub fn lower_elem<S: Into<Scalar> + Clone>(lhs: TchTensor<E>, rhs: S) -> TchTensor<bool> {
+    pub fn lower_elem<S: Into<Scalar> + Clone>(lhs: TchTensor, rhs: S) -> TchTensor {
         lhs.unary_ops(
             |mut tensor| tensor.less_(rhs.clone().into()).to_kind(tch::Kind::Bool),
             |tensor| tensor.less(rhs.clone().into()),
         )
     }
 
-    pub fn lower_equal(lhs: TchTensor<E>, rhs: TchTensor<E>) -> TchTensor<bool> {
+    pub fn lower_equal(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchTensor::binary_ops_tensor(
             lhs,
             rhs,
@@ -215,7 +200,7 @@ impl<E: tch::kind::Element + Copy + Default> TchOps<E> {
         )
     }
 
-    pub fn lower_equal_elem<S: Into<Scalar> + Clone>(lhs: TchTensor<E>, rhs: S) -> TchTensor<bool> {
+    pub fn lower_equal_elem<S: Into<Scalar> + Clone>(lhs: TchTensor, rhs: S) -> TchTensor {
         lhs.unary_ops(
             |mut tensor| {
                 tensor
@@ -226,7 +211,7 @@ impl<E: tch::kind::Element + Copy + Default> TchOps<E> {
         )
     }
 
-    pub fn add(lhs: TchTensor<E>, rhs: TchTensor<E>) -> TchTensor<E> {
+    pub fn add(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchTensor::binary_ops_tensor(
             lhs,
             rhs,
@@ -236,7 +221,7 @@ impl<E: tch::kind::Element + Copy + Default> TchOps<E> {
         )
     }
 
-    pub fn sub(lhs: TchTensor<E>, rhs: TchTensor<E>) -> TchTensor<E> {
+    pub fn sub(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchTensor::binary_ops_tensor(
             lhs,
             rhs,
@@ -246,7 +231,7 @@ impl<E: tch::kind::Element + Copy + Default> TchOps<E> {
         )
     }
 
-    pub fn mul(lhs: TchTensor<E>, rhs: TchTensor<E>) -> TchTensor<E> {
+    pub fn mul(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchTensor::binary_ops_tensor(
             lhs,
             rhs,
@@ -256,7 +241,7 @@ impl<E: tch::kind::Element + Copy + Default> TchOps<E> {
         )
     }
 
-    pub fn div(lhs: TchTensor<E>, rhs: TchTensor<E>) -> TchTensor<E> {
+    pub fn div(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchTensor::binary_ops_tensor(
             lhs,
             rhs,
@@ -266,7 +251,7 @@ impl<E: tch::kind::Element + Copy + Default> TchOps<E> {
         )
     }
 
-    pub fn remainder(lhs: TchTensor<E>, rhs: TchTensor<E>) -> TchTensor<E> {
+    pub fn remainder(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchTensor::binary_ops_tensor(
             lhs,
             rhs,
@@ -276,74 +261,75 @@ impl<E: tch::kind::Element + Copy + Default> TchOps<E> {
         )
     }
 
-    pub fn mean(tensor: TchTensor<E>) -> TchTensor<E> {
+    pub fn mean(tensor: TchTensor) -> TchTensor {
         // view as 1d tensor
-        let tensor = tensor.tensor.mean(E::KIND).view(1);
+        let tensor = tensor.tensor.mean(tensor.tensor.kind()).view(1);
         TchTensor::new(tensor)
     }
 
-    pub fn mean_dim(tensor: TchTensor<E>, dim: usize) -> TchTensor<E> {
+    pub fn mean_dim(tensor: TchTensor, dim: usize) -> TchTensor {
         TchTensor::from_existing(
             tensor
                 .tensor
-                .mean_dim(Some([dim as i64].as_slice()), true, E::KIND),
+                .mean_dim(Some([dim as i64].as_slice()), true, tensor.tensor.kind()),
             tensor.storage,
         )
     }
 
-    pub fn sum(tensor: TchTensor<E>) -> TchTensor<E> {
+    pub fn sum(tensor: TchTensor) -> TchTensor {
         // view as 1d tensor
-        let tensor = tensor.tensor.sum(E::KIND).view(1);
+        let tensor = tensor.tensor.sum(tensor.tensor.kind()).view(1);
         TchTensor::new(tensor)
     }
 
-    pub fn sum_dim(tensor: TchTensor<E>, dim: usize) -> TchTensor<E> {
+    pub fn sum_dim(tensor: TchTensor, dim: usize) -> TchTensor {
+        TchTensor::from_existing(
+            tensor.tensor.sum_dim_intlist(
+                Some([dim as i64].as_slice()),
+                true,
+                tensor.tensor.kind(),
+            ),
+            tensor.storage,
+        )
+    }
+
+    pub fn prod(tensor: TchTensor) -> TchTensor {
+        // view as 1d tensor
+        let tensor = tensor.tensor.prod(tensor.tensor.kind()).view(1);
+        TchTensor::new(tensor)
+    }
+
+    pub fn prod_dim(tensor: TchTensor, dim: usize) -> TchTensor {
         TchTensor::from_existing(
             tensor
                 .tensor
-                .sum_dim_intlist(Some([dim as i64].as_slice()), true, E::KIND),
+                .prod_dim_int(dim as i64, true, tensor.tensor.kind()),
             tensor.storage,
         )
     }
 
-    pub fn prod(tensor: TchTensor<E>) -> TchTensor<E> {
-        // view as 1d tensor
-        let tensor = tensor.tensor.prod(E::KIND).view(1);
-        TchTensor::new(tensor)
-    }
-
-    pub fn prod_dim(tensor: TchTensor<E>, dim: usize) -> TchTensor<E> {
-        TchTensor::from_existing(
-            tensor.tensor.prod_dim_int(dim as i64, true, E::KIND),
-            tensor.storage,
-        )
-    }
-
-    pub fn argmax(tensor: TchTensor<E>, dim: usize) -> TchTensor<i64> {
+    pub fn argmax(tensor: TchTensor, dim: usize) -> TchTensor {
         let storage = tensor.storage.clone();
         let tensor = tensor.tensor.argmax(dim as i64, true);
 
         TchTensor::from_existing(tensor, storage)
     }
 
-    pub fn argmin(tensor: TchTensor<E>, dim: usize) -> TchTensor<i64> {
+    pub fn argmin(tensor: TchTensor, dim: usize) -> TchTensor {
         let storage = tensor.storage.clone();
         let tensor = tensor.tensor.argmin(dim as i64, true);
 
         TchTensor::from_existing(tensor, storage)
     }
 
-    pub fn max_dim(tensor: TchTensor<E>, dim: usize) -> TchTensor<E> {
+    pub fn max_dim(tensor: TchTensor, dim: usize) -> TchTensor {
         let storage = tensor.storage.clone();
         let (tensor, _indices) = tensor.tensor.max_dim(dim as i64, true);
 
         TchTensor::from_existing(tensor, storage)
     }
 
-    pub fn max_dim_with_indices(
-        tensor: TchTensor<E>,
-        dim: usize,
-    ) -> (TchTensor<E>, TchTensor<i64>) {
+    pub fn max_dim_with_indices(tensor: TchTensor, dim: usize) -> (TchTensor, TchTensor) {
         let storage = tensor.storage.clone();
         let (tensor, indices) = tensor.tensor.max_dim(dim as i64, true);
 
@@ -353,17 +339,14 @@ impl<E: tch::kind::Element + Copy + Default> TchOps<E> {
         (tensor, indices)
     }
 
-    pub fn min_dim(tensor: TchTensor<E>, dim: usize) -> TchTensor<E> {
+    pub fn min_dim(tensor: TchTensor, dim: usize) -> TchTensor {
         let storage = tensor.storage.clone();
         let (tensor, _indices) = tensor.tensor.min_dim(dim as i64, true);
 
         TchTensor::from_existing(tensor, storage)
     }
 
-    pub fn min_dim_with_indices(
-        tensor: TchTensor<E>,
-        dim: usize,
-    ) -> (TchTensor<E>, TchTensor<i64>) {
+    pub fn min_dim_with_indices(tensor: TchTensor, dim: usize) -> (TchTensor, TchTensor) {
         let storage = tensor.storage.clone();
         let (tensor, indices) = tensor.tensor.min_dim(dim as i64, true);
 
@@ -373,20 +356,14 @@ impl<E: tch::kind::Element + Copy + Default> TchOps<E> {
         (tensor, indices)
     }
 
-    pub fn clamp_min<S: Into<tch::Scalar> + Clone + Copy>(
-        tensor: TchTensor<E>,
-        min: S,
-    ) -> TchTensor<E> {
+    pub fn clamp_min<S: Into<tch::Scalar> + Clone + Copy>(tensor: TchTensor, min: S) -> TchTensor {
         tensor.unary_ops(
             |mut tensor| tensor.clamp_min_(min),
             |tensor| tensor.clamp_min(min),
         )
     }
 
-    pub fn clamp_max<S: Into<tch::Scalar> + Clone + Copy>(
-        tensor: TchTensor<E>,
-        max: S,
-    ) -> TchTensor<E> {
+    pub fn clamp_max<S: Into<tch::Scalar> + Clone + Copy>(tensor: TchTensor, max: S) -> TchTensor {
         tensor.unary_ops(
             |mut tensor| tensor.clamp_max_(max),
             |tensor| tensor.clamp_max(max),
@@ -394,35 +371,35 @@ impl<E: tch::kind::Element + Copy + Default> TchOps<E> {
     }
 
     pub fn clamp<S: Into<tch::Scalar> + Clone + Copy>(
-        tensor: TchTensor<E>,
+        tensor: TchTensor,
         min: S,
         max: S,
-    ) -> TchTensor<E> {
+    ) -> TchTensor {
         tensor.unary_ops(
             |mut tensor| tensor.clamp_(min, max),
             |tensor| tensor.clamp(min, max),
         )
     }
 
-    pub fn swap_dims(tensor: TchTensor<E>, dim1: usize, dim2: usize) -> TchTensor<E> {
+    pub fn swap_dims(tensor: TchTensor, dim1: usize, dim2: usize) -> TchTensor {
         let tensor = tensor.tensor.transpose(dim1 as i64, dim2 as i64);
         TchTensor::new(tensor)
     }
 
-    pub fn permute(tensor: TchTensor<E>, axes: &[usize]) -> TchTensor<E> {
+    pub fn permute(tensor: TchTensor, axes: &[usize]) -> TchTensor {
         let tensor = tensor
             .tensor
             .permute(axes.iter().map(|x| *x as i64).collect::<Vec<_>>());
         TchTensor::new(tensor)
     }
 
-    pub fn flip(tensor: TchTensor<E>, axes: &[usize]) -> TchTensor<E> {
+    pub fn flip(tensor: TchTensor, axes: &[usize]) -> TchTensor {
         let dims = axes.iter().map(|x| *x as i64).collect::<Vec<_>>();
         let tensor = tensor.tensor.flip(dims);
         TchTensor::new(tensor)
     }
 
-    pub fn narrow(tensor: TchTensor<E>, dim: usize, start: usize, length: usize) -> TchTensor<E> {
+    pub fn narrow(tensor: TchTensor, dim: usize, start: usize, length: usize) -> TchTensor {
         TchTensor::new(
             tensor
                 .tensor
@@ -430,16 +407,16 @@ impl<E: tch::kind::Element + Copy + Default> TchOps<E> {
         )
     }
 
-    pub fn chunk(tensor: TchTensor<E>, chunks: usize, dim: usize) -> Vec<TchTensor<E>> {
+    pub fn chunk(tensor: TchTensor, chunks: usize, dim: usize) -> Vec<TchTensor> {
         tensor
             .tensor
             .chunk(chunks as i64, dim as i64)
             .into_iter()
-            .map(|tensor| TchTensor::new(tensor))
+            .map(TchTensor::new)
             .collect()
     }
 
-    pub fn powf(tensor: TchTensor<E>, exponent: TchTensor<E>) -> TchTensor<E> {
+    pub fn powf(tensor: TchTensor, exponent: TchTensor) -> TchTensor {
         TchTensor::binary_ops_tensor(
             tensor,
             exponent,
@@ -449,30 +426,30 @@ impl<E: tch::kind::Element + Copy + Default> TchOps<E> {
         )
     }
 
-    pub fn sign(tensor: TchTensor<E>) -> TchTensor<E> {
+    pub fn sign(tensor: TchTensor) -> TchTensor {
         tensor.unary_ops(|mut tensor| tensor.sign_(), |tensor| tensor.sign())
     }
 
-    pub fn expand(tensor: TchTensor<E>, shape: Shape) -> TchTensor<E> {
+    pub fn expand(tensor: TchTensor, shape: Shape) -> TchTensor {
         let storage = tensor.storage.clone();
         let broadcasted_tensor = tensor.tensor.broadcast_to(TchShape::from(shape).dims);
         TchTensor::from_existing(broadcasted_tensor, storage)
     }
 
-    pub fn sort(tensor: TchTensor<E>, dim: usize, descending: bool) -> TchTensor<E> {
+    pub fn sort(tensor: TchTensor, dim: usize, descending: bool) -> TchTensor {
         TchTensor::new(tensor.tensor.sort(dim as i64, descending).0)
     }
 
     pub fn sort_with_indices(
-        tensor: TchTensor<E>,
+        tensor: TchTensor,
         dim: usize,
         descending: bool,
-    ) -> (TchTensor<E>, TchTensor<i64>) {
+    ) -> (TchTensor, TchTensor) {
         let sorted = tensor.tensor.sort(dim as i64, descending);
         (TchTensor::new(sorted.0), TchTensor::new(sorted.1))
     }
 
-    pub fn argsort(tensor: TchTensor<E>, dim: usize, descending: bool) -> TchTensor<i64> {
+    pub fn argsort(tensor: TchTensor, dim: usize, descending: bool) -> TchTensor {
         TchTensor::new(tensor.tensor.argsort(dim as i64, descending))
     }
 }

--- a/crates/burn-tch/src/ops/bool_tensor.rs
+++ b/crates/burn-tch/src/ops/bool_tensor.rs
@@ -4,38 +4,38 @@ use burn_tensor::{backend::Backend, ops::BoolTensorOps, Shape, TensorData};
 use std::ops::Range;
 
 impl<E: TchElement, Q: QuantElement> BoolTensorOps<Self> for LibTorch<E, Q> {
-    fn bool_from_data(data: TensorData, device: &LibTorchDevice) -> TchTensor<bool> {
-        TchTensor::from_data(data, (*device).into())
+    fn bool_from_data(data: TensorData, device: &LibTorchDevice) -> TchTensor {
+        TchTensor::from_data::<bool>(data, (*device).into())
     }
 
-    fn bool_shape(tensor: &TchTensor<bool>) -> Shape {
+    fn bool_shape(tensor: &TchTensor) -> Shape {
         tensor.shape()
     }
 
-    fn bool_repeat_dim(tensor: TchTensor<bool>, dim: usize, times: usize) -> TchTensor<bool> {
+    fn bool_repeat_dim(tensor: TchTensor, dim: usize, times: usize) -> TchTensor {
         TchOps::repeat_dim(tensor, dim, times)
     }
 
-    async fn bool_into_data(tensor: TchTensor<bool>) -> TensorData {
+    async fn bool_into_data(tensor: TchTensor) -> TensorData {
         let shape = Self::bool_shape(&tensor);
         let tensor = Self::bool_reshape(tensor.clone(), Shape::new([shape.num_elements()]));
         let values: Result<Vec<bool>, tch::TchError> = tensor.tensor.shallow_clone().try_into();
         TensorData::new(values.unwrap(), shape)
     }
 
-    fn bool_to_device(tensor: TchTensor<bool>, device: &LibTorchDevice) -> TchTensor<bool> {
+    fn bool_to_device(tensor: TchTensor, device: &LibTorchDevice) -> TchTensor {
         TchOps::to_device(tensor, device)
     }
 
-    fn bool_reshape(tensor: TchTensor<bool>, shape: Shape) -> TchTensor<bool> {
+    fn bool_reshape(tensor: TchTensor, shape: Shape) -> TchTensor {
         TchOps::reshape(tensor, shape)
     }
 
-    fn bool_device(tensor: &TchTensor<bool>) -> LibTorchDevice {
+    fn bool_device(tensor: &TchTensor) -> LibTorchDevice {
         tensor.tensor.device().into()
     }
 
-    fn bool_empty(shape: Shape, device: &<LibTorch<E> as Backend>::Device) -> TchTensor<bool> {
+    fn bool_empty(shape: Shape, device: &<LibTorch<E> as Backend>::Device) -> TchTensor {
         let tensor = tch::Tensor::empty(
             TchShape::from(shape).dims,
             (tch::Kind::Bool, (*device).into()),
@@ -44,73 +44,68 @@ impl<E: TchElement, Q: QuantElement> BoolTensorOps<Self> for LibTorch<E, Q> {
         TchTensor::new(tensor)
     }
 
-    fn bool_slice(tensor: TchTensor<bool>, ranges: &[Range<usize>]) -> TchTensor<bool> {
+    fn bool_slice(tensor: TchTensor, ranges: &[Range<usize>]) -> TchTensor {
         TchOps::slice(tensor, ranges)
     }
 
     fn bool_slice_assign(
-        tensor: TchTensor<bool>,
+        tensor: TchTensor,
         ranges: &[Range<usize>],
-        value: TchTensor<bool>,
-    ) -> TchTensor<bool> {
+        value: TchTensor,
+    ) -> TchTensor {
         TchOps::slice_assign(tensor, ranges, value)
     }
 
-    fn bool_cat(tensors: Vec<TchTensor<bool>>, dim: usize) -> TchTensor<bool> {
+    fn bool_cat(tensors: Vec<TchTensor>, dim: usize) -> TchTensor {
         TchOps::cat(tensors, dim)
     }
 
-    fn bool_equal(lhs: TchTensor<bool>, rhs: TchTensor<bool>) -> TchTensor<bool> {
+    fn bool_equal(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchOps::equal(lhs, rhs)
     }
 
-    fn bool_not(tensor: TchTensor<bool>) -> TchTensor<bool> {
+    fn bool_not(tensor: TchTensor) -> TchTensor {
         tensor.unary_ops(
             |mut tensor| tensor.eq_(0).to_kind(tch::Kind::Bool),
             |tensor| tensor.eq(0),
         )
     }
 
-    fn bool_into_int(tensor: TchTensor<bool>) -> TchTensor<i64> {
+    fn bool_into_int(tensor: TchTensor) -> TchTensor {
         let tensor = tensor.tensor.to_kind(tch::Kind::Int64);
         TchTensor::new(tensor)
     }
 
-    fn bool_into_float(tensor: TchTensor<bool>) -> TchTensor<E> {
+    fn bool_into_float(tensor: TchTensor) -> TchTensor {
         let tensor = tensor.tensor.to_kind(E::KIND);
         TchTensor::new(tensor)
     }
 
-    fn bool_swap_dims(tensor: TchTensor<bool>, dim1: usize, dim2: usize) -> TchTensor<bool> {
+    fn bool_swap_dims(tensor: TchTensor, dim1: usize, dim2: usize) -> TchTensor {
         TchOps::swap_dims(tensor, dim1, dim2)
     }
 
-    fn bool_narrow(
-        tensor: TchTensor<bool>,
-        dim: usize,
-        start: usize,
-        length: usize,
-    ) -> TchTensor<bool> {
+    fn bool_narrow(tensor: TchTensor, dim: usize, start: usize, length: usize) -> TchTensor {
         TchOps::narrow(tensor, dim, start, length)
     }
 
-    fn bool_chunk(tensor: TchTensor<bool>, chunks: usize, dim: usize) -> Vec<TchTensor<bool>> {
+    fn bool_chunk(tensor: TchTensor, chunks: usize, dim: usize) -> Vec<TchTensor> {
         TchOps::chunk(tensor, chunks, dim)
     }
 
-    fn bool_permute(tensor: TchTensor<bool>, axes: &[usize]) -> TchTensor<bool> {
+    fn bool_permute(tensor: TchTensor, axes: &[usize]) -> TchTensor {
         TchOps::permute(tensor, axes)
     }
 
-    fn bool_flip(tensor: TchTensor<bool>, axes: &[usize]) -> TchTensor<bool> {
+    fn bool_flip(tensor: TchTensor, axes: &[usize]) -> TchTensor {
         TchOps::flip(tensor, axes)
     }
 
-    async fn bool_argwhere(tensor: TchTensor<bool>) -> TchTensor<i64> {
+    async fn bool_argwhere(tensor: TchTensor) -> TchTensor {
         TchTensor::new(tensor.tensor.argwhere())
     }
 
-    async fn bool_nonzero(tensor: TchTensor<bool>) -> Vec<TchTensor<i64>> {
+    async fn bool_nonzero(tensor: TchTensor) -> Vec<TchTensor> {
         tensor
             .tensor
             .nonzero_numpy()
@@ -121,7 +116,7 @@ impl<E: TchElement, Q: QuantElement> BoolTensorOps<Self> for LibTorch<E, Q> {
             .collect()
     }
 
-    fn bool_expand(tensor: TchTensor<bool>, shape: Shape) -> TchTensor<bool> {
+    fn bool_expand(tensor: TchTensor, shape: Shape) -> TchTensor {
         TchOps::expand(tensor, shape)
     }
 }

--- a/crates/burn-tch/src/ops/int_tensor.rs
+++ b/crates/burn-tch/src/ops/int_tensor.rs
@@ -11,38 +11,38 @@ use crate::{element::TchElement, LibTorch, LibTorchDevice, QuantElement, TchShap
 use super::TchOps;
 
 impl<E: TchElement, Q: QuantElement> IntTensorOps<Self> for LibTorch<E, Q> {
-    fn int_from_data(data: TensorData, device: &LibTorchDevice) -> TchTensor<i64> {
-        TchTensor::from_data(data, (*device).into())
+    fn int_from_data(data: TensorData, device: &LibTorchDevice) -> TchTensor {
+        TchTensor::from_data::<i64>(data, (*device).into())
     }
 
-    fn int_shape(tensor: &TchTensor<i64>) -> Shape {
+    fn int_shape(tensor: &TchTensor) -> Shape {
         tensor.shape()
     }
 
-    fn int_repeat_dim(tensor: TchTensor<i64>, dim: usize, times: usize) -> TchTensor<i64> {
+    fn int_repeat_dim(tensor: TchTensor, dim: usize, times: usize) -> TchTensor {
         TchOps::repeat_dim(tensor, dim, times)
     }
 
-    async fn int_into_data(tensor: TchTensor<i64>) -> TensorData {
+    async fn int_into_data(tensor: TchTensor) -> TensorData {
         let shape = Self::int_shape(&tensor);
         let tensor = Self::int_reshape(tensor.clone(), Shape::new([shape.num_elements()]));
         let values: Result<Vec<i64>, tch::TchError> = tensor.tensor.shallow_clone().try_into();
         TensorData::new(values.unwrap(), shape)
     }
 
-    fn int_to_device(tensor: TchTensor<i64>, device: &LibTorchDevice) -> TchTensor<i64> {
+    fn int_to_device(tensor: TchTensor, device: &LibTorchDevice) -> TchTensor {
         TchOps::to_device(tensor, device)
     }
 
-    fn int_reshape(tensor: TchTensor<i64>, shape: Shape) -> TchTensor<i64> {
+    fn int_reshape(tensor: TchTensor, shape: Shape) -> TchTensor {
         TchOps::reshape(tensor, shape)
     }
 
-    fn int_device(tensor: &TchTensor<i64>) -> LibTorchDevice {
+    fn int_device(tensor: &TchTensor) -> LibTorchDevice {
         tensor.tensor.device().into()
     }
 
-    fn int_empty(shape: Shape, device: &<LibTorch<E> as Backend>::Device) -> TchTensor<i64> {
+    fn int_empty(shape: Shape, device: &<LibTorch<E> as Backend>::Device) -> TchTensor {
         let tensor = tch::Tensor::empty(
             TchShape::from(shape).dims,
             (tch::Kind::Int64, (*device).into()),
@@ -51,101 +51,97 @@ impl<E: TchElement, Q: QuantElement> IntTensorOps<Self> for LibTorch<E, Q> {
         TchTensor::new(tensor)
     }
 
-    fn int_slice(tensor: TchTensor<i64>, ranges: &[Range<usize>]) -> TchTensor<i64> {
+    fn int_slice(tensor: TchTensor, ranges: &[Range<usize>]) -> TchTensor {
         TchOps::slice(tensor, ranges)
     }
 
-    fn int_slice_assign(
-        tensor: TchTensor<i64>,
-        ranges: &[Range<usize>],
-        value: TchTensor<i64>,
-    ) -> TchTensor<i64> {
+    fn int_slice_assign(tensor: TchTensor, ranges: &[Range<usize>], value: TchTensor) -> TchTensor {
         TchOps::slice_assign(tensor, ranges, value)
     }
 
-    fn int_cat(tensors: Vec<TchTensor<i64>>, dim: usize) -> TchTensor<i64> {
+    fn int_cat(tensors: Vec<TchTensor>, dim: usize) -> TchTensor {
         TchOps::cat(tensors, dim)
     }
 
-    fn int_equal(lhs: TchTensor<i64>, rhs: TchTensor<i64>) -> TchTensor<bool> {
+    fn int_equal(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchOps::equal(lhs, rhs)
     }
 
-    fn int_equal_elem(lhs: TchTensor<i64>, rhs: i64) -> TchTensor<bool> {
+    fn int_equal_elem(lhs: TchTensor, rhs: i64) -> TchTensor {
         TchOps::equal_elem(lhs, rhs)
     }
 
-    fn int_greater(lhs: TchTensor<i64>, rhs: TchTensor<i64>) -> TchTensor<bool> {
+    fn int_greater(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchOps::greater(lhs, rhs)
     }
 
-    fn int_greater_elem(lhs: TchTensor<i64>, rhs: i64) -> TchTensor<bool> {
+    fn int_greater_elem(lhs: TchTensor, rhs: i64) -> TchTensor {
         TchOps::greater_elem(lhs, rhs)
     }
 
-    fn int_greater_equal(lhs: TchTensor<i64>, rhs: TchTensor<i64>) -> TchTensor<bool> {
+    fn int_greater_equal(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchOps::greater_equal(lhs, rhs)
     }
 
-    fn int_greater_equal_elem(lhs: TchTensor<i64>, rhs: i64) -> TchTensor<bool> {
+    fn int_greater_equal_elem(lhs: TchTensor, rhs: i64) -> TchTensor {
         TchOps::greater_equal_elem(lhs, rhs)
     }
 
-    fn int_lower(lhs: TchTensor<i64>, rhs: TchTensor<i64>) -> TchTensor<bool> {
+    fn int_lower(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchOps::lower(lhs, rhs)
     }
 
-    fn int_lower_elem(lhs: TchTensor<i64>, rhs: i64) -> TchTensor<bool> {
+    fn int_lower_elem(lhs: TchTensor, rhs: i64) -> TchTensor {
         TchOps::lower_elem(lhs, rhs)
     }
 
-    fn int_lower_equal(lhs: TchTensor<i64>, rhs: TchTensor<i64>) -> TchTensor<bool> {
+    fn int_lower_equal(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchOps::lower_equal(lhs, rhs)
     }
 
-    fn int_lower_equal_elem(lhs: TchTensor<i64>, rhs: i64) -> TchTensor<bool> {
+    fn int_lower_equal_elem(lhs: TchTensor, rhs: i64) -> TchTensor {
         TchOps::lower_equal_elem(lhs, rhs)
     }
 
-    fn int_add(lhs: TchTensor<i64>, rhs: TchTensor<i64>) -> TchTensor<i64> {
+    fn int_add(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchOps::add(lhs, rhs)
     }
 
-    fn int_add_scalar(lhs: TchTensor<i64>, rhs: i64) -> TchTensor<i64> {
+    fn int_add_scalar(lhs: TchTensor, rhs: i64) -> TchTensor {
         lhs.unary_ops(
             |mut tensor| tensor.f_add_scalar_(rhs).unwrap(),
             |tensor| tensor.f_add_scalar(rhs).unwrap(),
         )
     }
 
-    fn int_sub(lhs: TchTensor<i64>, rhs: TchTensor<i64>) -> TchTensor<i64> {
+    fn int_sub(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchOps::sub(lhs, rhs)
     }
 
-    fn int_sub_scalar(lhs: TchTensor<i64>, rhs: i64) -> TchTensor<i64> {
+    fn int_sub_scalar(lhs: TchTensor, rhs: i64) -> TchTensor {
         lhs.unary_ops(
             |mut tensor| tensor.f_sub_scalar_(rhs).unwrap(),
             |tensor| tensor.f_sub_scalar(rhs).unwrap(),
         )
     }
 
-    fn int_mul(lhs: TchTensor<i64>, rhs: TchTensor<i64>) -> TchTensor<i64> {
+    fn int_mul(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchOps::mul(lhs, rhs)
     }
 
-    fn int_mul_scalar(lhs: TchTensor<i64>, rhs: i64) -> TchTensor<i64> {
+    fn int_mul_scalar(lhs: TchTensor, rhs: i64) -> TchTensor {
         lhs.unary_ops(
             |mut tensor| tensor.f_mul_scalar_(rhs).unwrap(),
             |tensor| tensor.f_mul_scalar(rhs).unwrap(),
         )
     }
 
-    fn int_div(lhs: TchTensor<i64>, rhs: TchTensor<i64>) -> TchTensor<i64> {
+    fn int_div(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         let copy = false;
         let non_blocking = true;
-        let lhs: TchTensor<f64> =
+        let lhs: TchTensor =
             TchTensor::new(lhs.tensor.to_dtype(tch::Kind::Float, non_blocking, copy));
-        let rhs: TchTensor<f64> =
+        let rhs: TchTensor =
             TchTensor::new(rhs.tensor.to_dtype(tch::Kind::Float, non_blocking, copy));
 
         let out = TchOps::div(lhs, rhs);
@@ -153,13 +149,13 @@ impl<E: TchElement, Q: QuantElement> IntTensorOps<Self> for LibTorch<E, Q> {
         TchTensor::new(out.tensor.to_dtype(tch::Kind::Int64, non_blocking, copy))
     }
 
-    fn int_div_scalar(lhs: TchTensor<i64>, rhs: i64) -> TchTensor<i64> {
+    fn int_div_scalar(lhs: TchTensor, rhs: i64) -> TchTensor {
         let copy = false;
         let non_blocking = true;
-        let lhs: TchTensor<f64> =
+        let lhs: TchTensor =
             TchTensor::new(lhs.tensor.to_dtype(tch::Kind::Float, non_blocking, copy));
 
-        let out: TchTensor<f64> = lhs.unary_ops(
+        let out: TchTensor = lhs.unary_ops(
             |mut tensor| tensor.f_div_scalar_(rhs).unwrap(),
             |tensor| tensor.f_div_scalar(rhs).unwrap(),
         );
@@ -167,12 +163,12 @@ impl<E: TchElement, Q: QuantElement> IntTensorOps<Self> for LibTorch<E, Q> {
         TchTensor::new(out.tensor.to_dtype(tch::Kind::Int64, non_blocking, copy))
     }
 
-    fn int_remainder(lhs: TchTensor<i64>, rhs: TchTensor<i64>) -> TchTensor<i64> {
+    fn int_remainder(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         let copy = false;
         let non_blocking = true;
-        let lhs: TchTensor<f64> =
+        let lhs: TchTensor =
             TchTensor::new(lhs.tensor.to_dtype(tch::Kind::Float, non_blocking, copy));
-        let rhs: TchTensor<f64> =
+        let rhs: TchTensor =
             TchTensor::new(rhs.tensor.to_dtype(tch::Kind::Float, non_blocking, copy));
 
         let out = TchOps::remainder(lhs, rhs);
@@ -180,25 +176,25 @@ impl<E: TchElement, Q: QuantElement> IntTensorOps<Self> for LibTorch<E, Q> {
         TchTensor::new(out.tensor.to_dtype(tch::Kind::Int64, non_blocking, copy))
     }
 
-    fn int_remainder_scalar(lhs: TchTensor<i64>, rhs: i64) -> TchTensor<i64> {
+    fn int_remainder_scalar(lhs: TchTensor, rhs: i64) -> TchTensor {
         lhs.unary_ops(
             |tensor| tensor.f_remainder(rhs).unwrap(),
             |tensor| tensor.f_remainder(rhs).unwrap(),
         )
     }
 
-    fn int_neg(tensor: TchTensor<i64>) -> TchTensor<i64> {
+    fn int_neg(tensor: TchTensor) -> TchTensor {
         Self::int_mul_scalar(tensor, -1)
     }
 
-    fn int_zeros(shape: Shape, device: &<LibTorch<E> as Backend>::Device) -> TchTensor<i64> {
+    fn int_zeros(shape: Shape, device: &<LibTorch<E> as Backend>::Device) -> TchTensor {
         let shape = TchShape::from(shape);
         let device: tch::Device = (*device).into();
 
         TchTensor::new(tch::Tensor::zeros(shape.dims, (tch::Kind::Int64, device)))
     }
 
-    fn int_ones(shape: Shape, device: &<LibTorch<E> as Backend>::Device) -> TchTensor<i64> {
+    fn int_ones(shape: Shape, device: &<LibTorch<E> as Backend>::Device) -> TchTensor {
         let shape = TchShape::from(shape);
         let device: tch::Device = (*device).into();
 
@@ -209,7 +205,7 @@ impl<E: TchElement, Q: QuantElement> IntTensorOps<Self> for LibTorch<E, Q> {
         shape: Shape,
         fill_value: i64,
         device: &<LibTorch<E> as Backend>::Device,
-    ) -> TchTensor<i64> {
+    ) -> TchTensor {
         let shape = TchShape::from(shape);
         let device: tch::Device = (*device).into();
 
@@ -220,70 +216,66 @@ impl<E: TchElement, Q: QuantElement> IntTensorOps<Self> for LibTorch<E, Q> {
         ))
     }
 
-    fn int_sum(tensor: TchTensor<i64>) -> TchTensor<i64> {
+    fn int_sum(tensor: TchTensor) -> TchTensor {
         TchOps::sum(tensor)
     }
 
-    fn int_sum_dim(tensor: TchTensor<i64>, dim: usize) -> TchTensor<i64> {
+    fn int_sum_dim(tensor: TchTensor, dim: usize) -> TchTensor {
         TchOps::sum_dim(tensor, dim)
     }
 
-    fn int_prod(tensor: TchTensor<i64>) -> TchTensor<i64> {
+    fn int_prod(tensor: TchTensor) -> TchTensor {
         TchOps::prod(tensor)
     }
 
-    fn int_prod_dim(tensor: TchTensor<i64>, dim: usize) -> TchTensor<i64> {
+    fn int_prod_dim(tensor: TchTensor, dim: usize) -> TchTensor {
         TchOps::prod_dim(tensor, dim)
     }
 
-    fn int_mean(tensor: TchTensor<i64>) -> TchTensor<i64> {
-        let tensor: TchTensor<f64> =
+    fn int_mean(tensor: TchTensor) -> TchTensor {
+        let tensor: TchTensor =
             TchTensor::new(tensor.tensor.to_dtype(tch::Kind::Float, true, false));
-        let output: TchTensor<i64> = TchTensor::new(TchOps::mean(tensor).tensor);
+        let output: TchTensor = TchTensor::new(TchOps::mean(tensor).tensor);
 
         TchTensor::new(output.tensor.to_dtype(tch::Kind::Int64, true, false))
     }
 
-    fn int_mean_dim(tensor: TchTensor<i64>, dim: usize) -> TchTensor<i64> {
-        let tensor: TchTensor<f64> =
+    fn int_mean_dim(tensor: TchTensor, dim: usize) -> TchTensor {
+        let tensor: TchTensor =
             TchTensor::new(tensor.tensor.to_dtype(tch::Kind::Float, true, false));
 
-        let output: TchTensor<i64> = TchTensor::new(TchOps::mean_dim(tensor, dim).tensor);
+        let output: TchTensor = TchTensor::new(TchOps::mean_dim(tensor, dim).tensor);
 
         TchTensor::new(output.tensor.to_dtype(tch::Kind::Int64, true, false))
     }
 
-    fn int_gather(dim: usize, tensor: TchTensor<i64>, indices: TchTensor<i64>) -> TchTensor<i64> {
+    fn int_gather(dim: usize, tensor: TchTensor, indices: TchTensor) -> TchTensor {
         TchOps::gather(dim, tensor, indices)
     }
 
     fn int_scatter(
         dim: usize,
-        tensor: TchTensor<i64>,
-        indices: TchTensor<i64>,
-        value: TchTensor<i64>,
-    ) -> TchTensor<i64> {
+        tensor: TchTensor,
+        indices: TchTensor,
+        value: TchTensor,
+    ) -> TchTensor {
         TchOps::scatter(dim, tensor, indices, value)
     }
 
-    fn int_select(tensor: TchTensor<i64>, dim: usize, indices: TchTensor<i64>) -> TchTensor<i64> {
+    fn int_select(tensor: TchTensor, dim: usize, indices: TchTensor) -> TchTensor {
         TchOps::index_select_dim(tensor, dim, indices)
     }
 
     fn int_select_assign(
-        tensor: TchTensor<i64>,
+        tensor: TchTensor,
         dim: usize,
-        indices: TchTensor<i64>,
-        value: TchTensor<i64>,
-    ) -> TchTensor<i64> {
+        indices: TchTensor,
+        value: TchTensor,
+    ) -> TchTensor {
         TchOps::select_assign(tensor, dim, indices, value)
     }
 
-    fn int_mask_where(
-        tensor: TchTensor<i64>,
-        mask: TchTensor<bool>,
-        source: TchTensor<i64>,
-    ) -> TchTensor<i64> {
+    fn int_mask_where(tensor: TchTensor, mask: TchTensor, source: TchTensor) -> TchTensor {
         TchTensor::binary_ops_tensor(
             tensor,
             source,
@@ -293,60 +285,54 @@ impl<E: TchElement, Q: QuantElement> IntTensorOps<Self> for LibTorch<E, Q> {
         )
     }
 
-    fn int_mask_fill(tensor: TchTensor<i64>, mask: TchTensor<bool>, value: i64) -> TchTensor<i64> {
+    fn int_mask_fill(tensor: TchTensor, mask: TchTensor, value: i64) -> TchTensor {
         tensor.unary_ops(
             |mut tensor| tensor.f_masked_fill_(&mask.tensor, value).unwrap(),
             |tensor| tensor.f_masked_fill(&mask.tensor, value).unwrap(),
         )
     }
 
-    fn int_argmax(tensor: TchTensor<i64>, dim: usize) -> TchTensor<i64> {
+    fn int_argmax(tensor: TchTensor, dim: usize) -> TchTensor {
         TchOps::argmax(tensor, dim)
     }
 
-    fn int_argmin(tensor: TchTensor<i64>, dim: usize) -> TchTensor<i64> {
+    fn int_argmin(tensor: TchTensor, dim: usize) -> TchTensor {
         TchOps::argmin(tensor, dim)
     }
 
-    fn int_max_dim(tensor: TchTensor<i64>, dim: usize) -> TchTensor<i64> {
+    fn int_max_dim(tensor: TchTensor, dim: usize) -> TchTensor {
         TchOps::max_dim(tensor, dim)
     }
 
-    fn int_max_dim_with_indices(
-        tensor: TchTensor<i64>,
-        dim: usize,
-    ) -> (TchTensor<i64>, TchTensor<i64>) {
+    fn int_max_dim_with_indices(tensor: TchTensor, dim: usize) -> (TchTensor, TchTensor) {
         TchOps::max_dim_with_indices(tensor, dim)
     }
 
-    fn int_min_dim(tensor: TchTensor<i64>, dim: usize) -> TchTensor<i64> {
+    fn int_min_dim(tensor: TchTensor, dim: usize) -> TchTensor {
         TchOps::min_dim(tensor, dim)
     }
 
-    fn int_min_dim_with_indices(
-        tensor: TchTensor<i64>,
-        dim: usize,
-    ) -> (TchTensor<i64>, TchTensor<i64>) {
+    fn int_min_dim_with_indices(tensor: TchTensor, dim: usize) -> (TchTensor, TchTensor) {
         TchOps::min_dim_with_indices(tensor, dim)
     }
 
-    fn int_clamp_min(tensor: TchTensor<i64>, min: i64) -> TchTensor<i64> {
+    fn int_clamp_min(tensor: TchTensor, min: i64) -> TchTensor {
         TchOps::clamp_min(tensor, min)
     }
 
-    fn int_clamp_max(tensor: TchTensor<i64>, max: i64) -> TchTensor<i64> {
+    fn int_clamp_max(tensor: TchTensor, max: i64) -> TchTensor {
         TchOps::clamp_max(tensor, max)
     }
 
-    fn int_clamp(tensor: TchTensor<i64>, min: i64, max: i64) -> TchTensor<i64> {
+    fn int_clamp(tensor: TchTensor, min: i64, max: i64) -> TchTensor {
         TchOps::clamp(tensor, min, max)
     }
 
-    fn int_abs(tensor: TchTensor<i64>) -> TchTensor<i64> {
+    fn int_abs(tensor: TchTensor) -> TchTensor {
         tensor.unary_ops(|mut tensor| tensor.abs_(), |tensor| tensor.abs())
     }
 
-    fn int_into_float(tensor: TchTensor<i64>) -> TchTensor<E> {
+    fn int_into_float(tensor: TchTensor) -> TchTensor {
         let tensor = tensor.tensor.to_kind(E::KIND);
         TchTensor::new(tensor)
     }
@@ -355,49 +341,40 @@ impl<E: TchElement, Q: QuantElement> IntTensorOps<Self> for LibTorch<E, Q> {
         TchOps::swap_dims(tensor, dim1, dim2)
     }
 
-    fn int_narrow(
-        tensor: TchTensor<i64>,
-        dim: usize,
-        start: usize,
-        length: usize,
-    ) -> TchTensor<i64> {
+    fn int_narrow(tensor: TchTensor, dim: usize, start: usize, length: usize) -> TchTensor {
         TchOps::narrow(tensor, dim, start, length)
     }
 
-    fn int_chunk(tensor: TchTensor<i64>, chunks: usize, dim: usize) -> Vec<TchTensor<i64>> {
+    fn int_chunk(tensor: TchTensor, chunks: usize, dim: usize) -> Vec<TchTensor> {
         TchOps::chunk(tensor, chunks, dim)
     }
 
-    fn int_random(
-        shape: Shape,
-        distribution: Distribution,
-        device: &LibTorchDevice,
-    ) -> TchTensor<i64> {
+    fn int_random(shape: Shape, distribution: Distribution, device: &LibTorchDevice) -> TchTensor {
         match distribution {
             Distribution::Default => {
-                let mut tensor = TchTensor::<i64>::empty(shape, *device);
+                let mut tensor = TchTensor::empty::<i64>(shape, *device);
                 tensor
                     .mut_ops(|tensor| tensor.uniform_(0.0, 255.0))
                     .unwrap()
             }
             Distribution::Bernoulli(prob) => {
-                let mut tensor = TchTensor::<i64>::empty(shape, *device);
+                let mut tensor = TchTensor::empty::<i64>(shape, *device);
                 tensor
                     .mut_ops(|tensor| tensor.f_bernoulli_float_(prob).unwrap())
                     .unwrap()
             }
             Distribution::Uniform(from, to) => {
-                let mut tensor = TchTensor::<i64>::empty(shape, *device);
+                let mut tensor = TchTensor::empty::<i64>(shape, *device);
                 tensor.mut_ops(|tensor| tensor.uniform_(from, to)).unwrap()
             }
             Distribution::Normal(mean, std) => {
-                let mut tensor = TchTensor::<i64>::empty(shape, *device);
+                let mut tensor = TchTensor::empty::<i64>(shape, *device);
                 tensor.mut_ops(|tensor| tensor.normal_(mean, std)).unwrap()
             }
         }
     }
 
-    fn int_arange(range: Range<i64>, device: &LibTorchDevice) -> TchTensor<i64> {
+    fn int_arange(range: Range<i64>, device: &LibTorchDevice) -> TchTensor {
         let device: tch::Device = (*device).into();
         let mut tensor = tch::Tensor::arange(range.end - range.start, (tch::Kind::Int64, device));
 

--- a/crates/burn-tch/src/ops/module.rs
+++ b/crates/burn-tch/src/ops/module.rs
@@ -5,17 +5,13 @@ use burn_tensor::ops::{
 };
 
 impl<E: TchElement, Q: QuantElement> ModuleOps<Self> for LibTorch<E, Q> {
-    fn embedding(weights: TchTensor<E>, indices: TchTensor<i64>) -> TchTensor<E> {
+    fn embedding(weights: TchTensor, indices: TchTensor) -> TchTensor {
         let tensor = tch::Tensor::embedding(&weights.tensor, &indices.tensor, -1, false, false);
 
         TchTensor::new(tensor)
     }
 
-    fn embedding_backward(
-        weights: TchTensor<E>,
-        output: TchTensor<E>,
-        indices: TchTensor<i64>,
-    ) -> TchTensor<E> {
+    fn embedding_backward(weights: TchTensor, output: TchTensor, indices: TchTensor) -> TchTensor {
         let [n_embedding, _d_model] = weights.shape().dims();
         let tensor = tch::Tensor::embedding_backward(
             &output.tensor,
@@ -30,11 +26,11 @@ impl<E: TchElement, Q: QuantElement> ModuleOps<Self> for LibTorch<E, Q> {
     }
 
     fn conv1d(
-        x: TchTensor<E>,
-        weight: TchTensor<E>,
-        bias: Option<TchTensor<E>>,
+        x: TchTensor,
+        weight: TchTensor,
+        bias: Option<TchTensor>,
         options: ConvOptions<1>,
-    ) -> TchTensor<E> {
+    ) -> TchTensor {
         let tensor = tch::Tensor::conv1d(
             &x.tensor,
             &weight.tensor,
@@ -49,11 +45,11 @@ impl<E: TchElement, Q: QuantElement> ModuleOps<Self> for LibTorch<E, Q> {
     }
 
     fn conv2d(
-        x: TchTensor<E>,
-        weight: TchTensor<E>,
-        bias: Option<TchTensor<E>>,
+        x: TchTensor,
+        weight: TchTensor,
+        bias: Option<TchTensor>,
         options: ConvOptions<2>,
-    ) -> TchTensor<E> {
+    ) -> TchTensor {
         let tensor = tch::Tensor::conv2d(
             &x.tensor,
             &weight.tensor,
@@ -68,11 +64,11 @@ impl<E: TchElement, Q: QuantElement> ModuleOps<Self> for LibTorch<E, Q> {
     }
 
     fn conv3d(
-        x: TchTensor<E>,
-        weight: TchTensor<E>,
-        bias: Option<TchTensor<E>>,
+        x: TchTensor,
+        weight: TchTensor,
+        bias: Option<TchTensor>,
         options: ConvOptions<3>,
-    ) -> TchTensor<E> {
+    ) -> TchTensor {
         let tensor = tch::Tensor::conv3d(
             &x.tensor,
             &weight.tensor,
@@ -87,34 +83,34 @@ impl<E: TchElement, Q: QuantElement> ModuleOps<Self> for LibTorch<E, Q> {
     }
 
     fn deform_conv2d(
-        _x: TchTensor<E>,
-        _offset: TchTensor<E>,
-        _weight: TchTensor<E>,
-        _mask: Option<TchTensor<E>>,
-        _bias: Option<TchTensor<E>>,
+        _x: TchTensor,
+        _offset: TchTensor,
+        _weight: TchTensor,
+        _mask: Option<TchTensor>,
+        _bias: Option<TchTensor>,
         _options: DeformConvOptions<2>,
-    ) -> TchTensor<E> {
+    ) -> TchTensor {
         unimplemented!("Torch bindings don't support deform_conv2d");
     }
 
     fn deform_conv2d_backward(
-        _x: TchTensor<E>,
-        _offset: TchTensor<E>,
-        _weight: TchTensor<E>,
-        _mask: Option<TchTensor<E>>,
-        _bias: Option<TchTensor<E>>,
-        _out_grad: TchTensor<E>,
+        _x: TchTensor,
+        _offset: TchTensor,
+        _weight: TchTensor,
+        _mask: Option<TchTensor>,
+        _bias: Option<TchTensor>,
+        _out_grad: TchTensor,
         _options: DeformConvOptions<2>,
     ) -> DeformConv2dBackward<Self> {
         unimplemented!("Torch bindings don't support deform_conv2d");
     }
 
     fn conv_transpose1d(
-        x: TchTensor<E>,
-        weight: TchTensor<E>,
-        bias: Option<TchTensor<E>>,
+        x: TchTensor,
+        weight: TchTensor,
+        bias: Option<TchTensor>,
         options: ConvTransposeOptions<1>,
-    ) -> TchTensor<E> {
+    ) -> TchTensor {
         let tensor = tch::Tensor::conv_transpose1d(
             &x.tensor,
             &weight.tensor,
@@ -130,11 +126,11 @@ impl<E: TchElement, Q: QuantElement> ModuleOps<Self> for LibTorch<E, Q> {
     }
 
     fn conv_transpose2d(
-        x: TchTensor<E>,
-        weight: TchTensor<E>,
-        bias: Option<TchTensor<E>>,
+        x: TchTensor,
+        weight: TchTensor,
+        bias: Option<TchTensor>,
         options: ConvTransposeOptions<2>,
-    ) -> TchTensor<E> {
+    ) -> TchTensor {
         let tensor = tch::Tensor::conv_transpose2d(
             &x.tensor,
             &weight.tensor,
@@ -150,11 +146,11 @@ impl<E: TchElement, Q: QuantElement> ModuleOps<Self> for LibTorch<E, Q> {
     }
 
     fn conv_transpose3d(
-        x: TchTensor<E>,
-        weight: TchTensor<E>,
-        bias: Option<TchTensor<E>>,
+        x: TchTensor,
+        weight: TchTensor,
+        bias: Option<TchTensor>,
         options: ConvTransposeOptions<3>,
-    ) -> TchTensor<E> {
+    ) -> TchTensor {
         let tensor = tch::Tensor::conv_transpose3d(
             &x.tensor,
             &weight.tensor,
@@ -170,12 +166,12 @@ impl<E: TchElement, Q: QuantElement> ModuleOps<Self> for LibTorch<E, Q> {
     }
 
     fn avg_pool1d(
-        x: TchTensor<E>,
+        x: TchTensor,
         kernel_size: usize,
         stride: usize,
         padding: usize,
         count_include_pad: bool,
-    ) -> TchTensor<E> {
+    ) -> TchTensor {
         let tensor = tch::Tensor::avg_pool1d(
             &x.tensor,
             [kernel_size as i64],
@@ -188,12 +184,12 @@ impl<E: TchElement, Q: QuantElement> ModuleOps<Self> for LibTorch<E, Q> {
         TchTensor::new(tensor)
     }
     fn avg_pool2d(
-        x: TchTensor<E>,
+        x: TchTensor,
         kernel_size: [usize; 2],
         stride: [usize; 2],
         padding: [usize; 2],
         count_include_pad: bool,
-    ) -> TchTensor<E> {
+    ) -> TchTensor {
         let tensor = tch::Tensor::avg_pool2d(
             &x.tensor,
             [kernel_size[0] as i64, kernel_size[1] as i64],
@@ -208,13 +204,13 @@ impl<E: TchElement, Q: QuantElement> ModuleOps<Self> for LibTorch<E, Q> {
     }
 
     fn avg_pool2d_backward(
-        x: TchTensor<E>,
-        grad: TchTensor<E>,
+        x: TchTensor,
+        grad: TchTensor,
         kernel_size: [usize; 2],
         stride: [usize; 2],
         padding: [usize; 2],
         count_include_pad: bool,
-    ) -> TchTensor<E> {
+    ) -> TchTensor {
         let tensor = tch::Tensor::avg_pool2d_backward(
             &x.tensor,
             &grad.tensor,
@@ -230,12 +226,12 @@ impl<E: TchElement, Q: QuantElement> ModuleOps<Self> for LibTorch<E, Q> {
     }
 
     fn max_pool1d(
-        x: TchTensor<E>,
+        x: TchTensor,
         kernel_size: usize,
         stride: usize,
         padding: usize,
         dilation: usize,
-    ) -> TchTensor<E> {
+    ) -> TchTensor {
         let tensor = tch::Tensor::max_pool1d(
             &x.tensor,
             kernel_size as i64,
@@ -249,7 +245,7 @@ impl<E: TchElement, Q: QuantElement> ModuleOps<Self> for LibTorch<E, Q> {
     }
 
     fn max_pool1d_with_indices(
-        x: TchTensor<E>,
+        x: TchTensor,
         kernel_size: usize,
         stride: usize,
         padding: usize,
@@ -268,12 +264,12 @@ impl<E: TchElement, Q: QuantElement> ModuleOps<Self> for LibTorch<E, Q> {
     }
 
     fn max_pool2d(
-        x: TchTensor<E>,
+        x: TchTensor,
         kernel_size: [usize; 2],
         stride: [usize; 2],
         padding: [usize; 2],
         dilation: [usize; 2],
-    ) -> TchTensor<E> {
+    ) -> TchTensor {
         let tensor = tch::Tensor::max_pool2d(
             &x.tensor,
             [kernel_size[0] as i64, kernel_size[1] as i64],
@@ -287,7 +283,7 @@ impl<E: TchElement, Q: QuantElement> ModuleOps<Self> for LibTorch<E, Q> {
     }
 
     fn max_pool2d_with_indices(
-        x: TchTensor<E>,
+        x: TchTensor,
         kernel_size: [usize; 2],
         stride: [usize; 2],
         padding: [usize; 2],
@@ -306,13 +302,13 @@ impl<E: TchElement, Q: QuantElement> ModuleOps<Self> for LibTorch<E, Q> {
     }
 
     fn max_pool2d_with_indices_backward(
-        x: TchTensor<E>,
+        x: TchTensor,
         kernel_size: [usize; 2],
         stride: [usize; 2],
         padding: [usize; 2],
         dilation: [usize; 2],
-        output_grad: TchTensor<E>,
-        indices: TchTensor<i64>,
+        output_grad: TchTensor,
+        indices: TchTensor,
     ) -> MaxPool2dBackward<LibTorch<E, Q>> {
         let grad = tch::Tensor::max_pool2d_with_indices_backward(
             &x.tensor,
@@ -328,29 +324,29 @@ impl<E: TchElement, Q: QuantElement> ModuleOps<Self> for LibTorch<E, Q> {
         MaxPool2dBackward::new(TchTensor::new(grad))
     }
 
-    fn adaptive_avg_pool2d(x: TchTensor<E>, output_size: [usize; 2]) -> TchTensor<E> {
+    fn adaptive_avg_pool2d(x: TchTensor, output_size: [usize; 2]) -> TchTensor {
         let tensor = tch::Tensor::adaptive_avg_pool2d(&x.tensor, output_size.map(|e| e as i64));
 
         TchTensor::new(tensor)
     }
 
-    fn adaptive_avg_pool2d_backward(x: TchTensor<E>, grad: TchTensor<E>) -> TchTensor<E> {
+    fn adaptive_avg_pool2d_backward(x: TchTensor, grad: TchTensor) -> TchTensor {
         let tensor = tch::Tensor::internal_adaptive_avg_pool2d_backward(&x.tensor, &grad.tensor);
 
         TchTensor::new(tensor)
     }
 
-    fn adaptive_avg_pool1d(x: TchTensor<E>, output_size: usize) -> TchTensor<E> {
+    fn adaptive_avg_pool1d(x: TchTensor, output_size: usize) -> TchTensor {
         let tensor = tch::Tensor::adaptive_avg_pool1d(&x.tensor, output_size as i64);
 
         TchTensor::new(tensor)
     }
 
     fn interpolate(
-        x: TchTensor<E>,
+        x: TchTensor,
         output_size: [usize; 2],
         options: InterpolateOptions,
-    ) -> TchTensor<E> {
+    ) -> TchTensor {
         let output_size = output_size.map(|e| e as i64);
 
         let tensor = match options.mode {
@@ -369,11 +365,11 @@ impl<E: TchElement, Q: QuantElement> ModuleOps<Self> for LibTorch<E, Q> {
     }
 
     fn interpolate_backward(
-        x: TchTensor<E>,
-        grad: TchTensor<E>,
+        x: TchTensor,
+        grad: TchTensor,
         output_size: [usize; 2],
         options: InterpolateOptions,
-    ) -> TchTensor<E> {
+    ) -> TchTensor {
         let output_size = output_size.map(|e| e as i64);
         let [n, c, h_in, w_in] = x.shape().dims();
         let input_size = [n as i64, c as i64, h_in as i64, w_in as i64];

--- a/crates/burn-tch/src/ops/qtensor.rs
+++ b/crates/burn-tch/src/ops/qtensor.rs
@@ -208,11 +208,11 @@ impl<E: TchElement, Q: QuantElement> QTensorOps<Self> for LibTorch<E, Q> {
     }
 
     fn q_argmax(tensor: QuantizedTensor<Self>, dim: usize) -> IntTensor<Self> {
-        TchOps::argmax(TchTensor::<Q>::new(tensor.qtensor.tensor.int_repr()), dim)
+        TchOps::argmax(TchTensor::new(tensor.qtensor.tensor.int_repr()), dim)
     }
 
     fn q_argmin(tensor: QuantizedTensor<Self>, dim: usize) -> IntTensor<Self> {
-        TchOps::argmin(TchTensor::<Q>::new(tensor.qtensor.tensor.int_repr()), dim)
+        TchOps::argmin(TchTensor::new(tensor.qtensor.tensor.int_repr()), dim)
     }
 
     fn q_max_dim_with_indices(

--- a/crates/burn-tch/src/ops/tensor.rs
+++ b/crates/burn-tch/src/ops/tensor.rs
@@ -5,91 +5,108 @@ use burn_tensor::{
     ops::{FloatTensorOps, IntTensor},
     Distribution, ElementConversion, Shape, TensorData,
 };
+use half::{bf16, f16};
 use std::ops::Range;
 
 impl<E: TchElement, Q: QuantElement> FloatTensorOps<Self> for LibTorch<E, Q> {
-    fn float_from_data(data: TensorData, device: &LibTorchDevice) -> TchTensor<E> {
-        TchTensor::from_data(data, (*device).into())
+    fn float_from_data(data: TensorData, device: &LibTorchDevice) -> TchTensor {
+        TchTensor::from_data::<E>(data, (*device).into())
     }
 
     fn float_random(
         shape: Shape,
         distribution: Distribution,
         device: &LibTorchDevice,
-    ) -> TchTensor<E> {
+    ) -> TchTensor {
         match distribution {
             Distribution::Default => {
-                let mut tensor = TchTensor::<E>::empty(shape, *device);
+                let mut tensor = TchTensor::empty::<E>(shape, *device);
                 tensor
                     .mut_ops(|tensor| tensor.rand_like_out(tensor))
                     .unwrap()
             }
             Distribution::Bernoulli(prob) => {
-                let mut tensor = TchTensor::<E>::empty(shape, *device);
+                let mut tensor = TchTensor::empty::<E>(shape, *device);
                 tensor
                     .mut_ops(|tensor| tensor.f_bernoulli_float_(prob).unwrap())
                     .unwrap()
             }
             Distribution::Uniform(from, to) => {
-                let mut tensor = TchTensor::<E>::empty(shape, *device);
+                let mut tensor = TchTensor::empty::<E>(shape, *device);
                 tensor.mut_ops(|tensor| tensor.uniform_(from, to)).unwrap()
             }
             Distribution::Normal(mean, std) => {
-                let mut tensor = TchTensor::<E>::empty(shape, *device);
+                let mut tensor = TchTensor::empty::<E>(shape, *device);
                 tensor.mut_ops(|tensor| tensor.normal_(mean, std)).unwrap()
             }
         }
     }
 
-    fn float_repeat_dim(tensor: TchTensor<E>, dim: usize, times: usize) -> TchTensor<E> {
+    fn float_repeat_dim(tensor: TchTensor, dim: usize, times: usize) -> TchTensor {
         TchOps::repeat_dim(tensor, dim, times)
     }
 
-    fn float_zeros(shape: Shape, device: &LibTorchDevice) -> TchTensor<E> {
+    fn float_zeros(shape: Shape, device: &LibTorchDevice) -> TchTensor {
         let shape = TchShape::from(shape);
         let device: tch::Device = (*device).into();
 
         TchTensor::new(tch::Tensor::zeros(shape.dims, (E::KIND, device)))
     }
 
-    fn float_ones(shape: Shape, device: &LibTorchDevice) -> TchTensor<E> {
+    fn float_ones(shape: Shape, device: &LibTorchDevice) -> TchTensor {
         let shape = TchShape::from(shape);
         let device: tch::Device = (*device).into();
 
         TchTensor::new(tch::Tensor::ones(shape.dims, (E::KIND, device)))
     }
 
-    fn float_shape(tensor: &TchTensor<E>) -> Shape {
+    fn float_shape(tensor: &TchTensor) -> Shape {
         tensor.shape()
     }
 
-    async fn float_into_data(tensor: TchTensor<E>) -> TensorData {
+    async fn float_into_data(tensor: TchTensor) -> TensorData {
         let shape = Self::float_shape(&tensor);
         let tensor = Self::float_reshape(tensor.clone(), Shape::new([shape.num_elements()]));
-        let values: Result<Vec<E>, tch::TchError> = tensor.tensor.try_into();
-
-        TensorData::new(values.unwrap(), shape)
+        match tensor.tensor.kind() {
+            tch::Kind::Half => {
+                let values: Vec<f16> = tensor.tensor.try_into().unwrap();
+                TensorData::new(values, shape)
+            }
+            tch::Kind::Float => {
+                let values: Vec<f32> = tensor.tensor.try_into().unwrap();
+                TensorData::new(values, shape)
+            }
+            tch::Kind::Double => {
+                let values: Vec<f64> = tensor.tensor.try_into().unwrap();
+                TensorData::new(values, shape)
+            }
+            tch::Kind::BFloat16 => {
+                let values: Vec<bf16> = tensor.tensor.try_into().unwrap();
+                TensorData::new(values, shape)
+            }
+            _ => panic!("Not a valid float kind"),
+        }
     }
 
-    fn float_device(tensor: &TchTensor<E>) -> LibTorchDevice {
+    fn float_device(tensor: &TchTensor) -> LibTorchDevice {
         tensor.tensor.device().into()
     }
 
-    fn float_to_device(tensor: TchTensor<E>, device: &LibTorchDevice) -> TchTensor<E> {
+    fn float_to_device(tensor: TchTensor, device: &LibTorchDevice) -> TchTensor {
         TchOps::to_device(tensor, device)
     }
 
-    fn float_empty(shape: Shape, device: &<LibTorch<E> as Backend>::Device) -> TchTensor<E> {
+    fn float_empty(shape: Shape, device: &<LibTorch<E> as Backend>::Device) -> TchTensor {
         let tensor = tch::Tensor::empty(TchShape::from(shape).dims, (E::KIND, (*device).into()));
 
         TchTensor::new(tensor)
     }
 
-    fn float_add(lhs: TchTensor<E>, rhs: TchTensor<E>) -> TchTensor<E> {
+    fn float_add(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchOps::add(lhs, rhs)
     }
 
-    fn float_add_scalar(lhs: TchTensor<E>, rhs: E) -> TchTensor<E> {
+    fn float_add_scalar(lhs: TchTensor, rhs: E) -> TchTensor {
         let rhs: f64 = rhs.elem();
 
         lhs.unary_ops(
@@ -98,11 +115,11 @@ impl<E: TchElement, Q: QuantElement> FloatTensorOps<Self> for LibTorch<E, Q> {
         )
     }
 
-    fn float_sub(lhs: TchTensor<E>, rhs: TchTensor<E>) -> TchTensor<E> {
+    fn float_sub(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchOps::sub(lhs, rhs)
     }
 
-    fn float_sub_scalar(lhs: TchTensor<E>, rhs: E) -> TchTensor<E> {
+    fn float_sub_scalar(lhs: TchTensor, rhs: E) -> TchTensor {
         let rhs: f64 = rhs.elem();
 
         lhs.unary_ops(
@@ -111,11 +128,11 @@ impl<E: TchElement, Q: QuantElement> FloatTensorOps<Self> for LibTorch<E, Q> {
         )
     }
 
-    fn float_mul(lhs: TchTensor<E>, rhs: TchTensor<E>) -> TchTensor<E> {
+    fn float_mul(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchOps::mul(lhs, rhs)
     }
 
-    fn float_mul_scalar(lhs: TchTensor<E>, rhs: E) -> TchTensor<E> {
+    fn float_mul_scalar(lhs: TchTensor, rhs: E) -> TchTensor {
         let rhs: f64 = rhs.elem();
 
         lhs.unary_ops(
@@ -124,11 +141,11 @@ impl<E: TchElement, Q: QuantElement> FloatTensorOps<Self> for LibTorch<E, Q> {
         )
     }
 
-    fn float_div(lhs: TchTensor<E>, rhs: TchTensor<E>) -> TchTensor<E> {
+    fn float_div(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchOps::div(lhs, rhs)
     }
 
-    fn float_div_scalar(lhs: TchTensor<E>, rhs: E) -> TchTensor<E> {
+    fn float_div_scalar(lhs: TchTensor, rhs: E) -> TchTensor {
         let rhs: f64 = rhs.elem();
 
         lhs.unary_ops(
@@ -137,11 +154,11 @@ impl<E: TchElement, Q: QuantElement> FloatTensorOps<Self> for LibTorch<E, Q> {
         )
     }
 
-    fn float_remainder(lhs: TchTensor<E>, rhs: TchTensor<E>) -> TchTensor<E> {
+    fn float_remainder(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchOps::remainder(lhs, rhs)
     }
 
-    fn float_remainder_scalar(lhs: TchTensor<E>, rhs: E) -> TchTensor<E> {
+    fn float_remainder_scalar(lhs: TchTensor, rhs: E) -> TchTensor {
         let rhs: f64 = rhs.elem();
 
         lhs.unary_ops(
@@ -150,76 +167,72 @@ impl<E: TchElement, Q: QuantElement> FloatTensorOps<Self> for LibTorch<E, Q> {
         )
     }
 
-    fn float_matmul(lhs: TchTensor<E>, rhs: TchTensor<E>) -> TchTensor<E> {
+    fn float_matmul(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         let tensor = lhs.tensor.matmul(&rhs.tensor);
         TchTensor::new(tensor)
     }
 
-    fn float_neg(tensor: TchTensor<E>) -> TchTensor<E> {
+    fn float_neg(tensor: TchTensor) -> TchTensor {
         Self::float_mul_scalar(tensor, (-1f32).elem::<E>())
     }
 
-    fn float_recip(tensor: TchTensor<E>) -> TchTensor<E> {
+    fn float_recip(tensor: TchTensor) -> TchTensor {
         TchTensor::new(tensor.tensor.reciprocal())
     }
 
-    fn float_swap_dims(tensor: TchTensor<E>, dim1: usize, dim2: usize) -> TchTensor<E> {
+    fn float_swap_dims(tensor: TchTensor, dim1: usize, dim2: usize) -> TchTensor {
         TchOps::swap_dims(tensor, dim1, dim2)
     }
 
-    fn float_reshape(tensor: TchTensor<E>, shape: Shape) -> TchTensor<E> {
+    fn float_reshape(tensor: TchTensor, shape: Shape) -> TchTensor {
         TchOps::reshape(tensor, shape)
     }
 
-    fn float_gather(dim: usize, tensor: TchTensor<E>, indices: TchTensor<i64>) -> TchTensor<E> {
+    fn float_gather(dim: usize, tensor: TchTensor, indices: TchTensor) -> TchTensor {
         TchOps::gather(dim, tensor, indices)
     }
 
     fn float_scatter(
         dim: usize,
-        tensor: TchTensor<E>,
-        indices: TchTensor<i64>,
-        value: TchTensor<E>,
-    ) -> TchTensor<E> {
+        tensor: TchTensor,
+        indices: TchTensor,
+        value: TchTensor,
+    ) -> TchTensor {
         TchOps::scatter(dim, tensor, indices, value)
     }
 
-    fn float_select(tensor: TchTensor<E>, dim: usize, indices: TchTensor<i64>) -> TchTensor<E> {
+    fn float_select(tensor: TchTensor, dim: usize, indices: TchTensor) -> TchTensor {
         TchOps::index_select_dim(tensor, dim, indices)
     }
 
     fn float_select_assign(
-        tensor: TchTensor<E>,
+        tensor: TchTensor,
         dim: usize,
-        indices: TchTensor<i64>,
-        value: TchTensor<E>,
-    ) -> TchTensor<E> {
+        indices: TchTensor,
+        value: TchTensor,
+    ) -> TchTensor {
         TchOps::select_assign(tensor, dim, indices, value)
     }
 
-    fn float_slice(tensor: TchTensor<E>, ranges: &[Range<usize>]) -> TchTensor<E> {
+    fn float_slice(tensor: TchTensor, ranges: &[Range<usize>]) -> TchTensor {
         TchOps::slice(tensor, ranges)
     }
 
     fn float_slice_assign(
-        tensor: TchTensor<E>,
+        tensor: TchTensor,
         ranges: &[Range<usize>],
-        value: TchTensor<E>,
-    ) -> TchTensor<E> {
+        value: TchTensor,
+    ) -> TchTensor {
         TchOps::slice_assign(tensor, ranges, value)
     }
 
-    fn float_mask_where(
-        tensor: TchTensor<E>,
-        mask: TchTensor<bool>,
-        value: TchTensor<E>,
-    ) -> TchTensor<E> {
+    fn float_mask_where(tensor: TchTensor, mask: TchTensor, value: TchTensor) -> TchTensor {
         let output = value.tensor.where_self(&mask.tensor, &tensor.tensor);
 
         TchTensor::new(output)
     }
 
-    fn float_mask_fill(tensor: TchTensor<E>, mask: TchTensor<bool>, value: E) -> TchTensor<E> {
+    fn float_mask_fill(tensor: TchTensor, mask: TchTensor, value: E) -> TchTensor {
         let value: f64 = value.elem();
 
         tensor.unary_ops(
@@ -228,224 +241,215 @@ impl<E: TchElement, Q: QuantElement> FloatTensorOps<Self> for LibTorch<E, Q> {
         )
     }
 
-    fn float_equal(lhs: TchTensor<E>, rhs: TchTensor<E>) -> TchTensor<bool> {
+    fn float_equal(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchOps::equal(lhs, rhs)
     }
 
-    fn float_equal_elem(lhs: TchTensor<E>, rhs: E) -> TchTensor<bool> {
+    fn float_equal_elem(lhs: TchTensor, rhs: E) -> TchTensor {
         TchOps::equal_elem(lhs, rhs.elem::<f64>())
     }
 
-    fn float_greater(lhs: TchTensor<E>, rhs: TchTensor<E>) -> TchTensor<bool> {
+    fn float_greater(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchOps::greater(lhs, rhs)
     }
 
-    fn float_greater_elem(lhs: TchTensor<E>, rhs: E) -> TchTensor<bool> {
+    fn float_greater_elem(lhs: TchTensor, rhs: E) -> TchTensor {
         TchOps::greater_elem(lhs, rhs.elem::<f64>())
     }
 
-    fn float_greater_equal(lhs: TchTensor<E>, rhs: TchTensor<E>) -> TchTensor<bool> {
+    fn float_greater_equal(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchOps::greater_equal(lhs, rhs)
     }
 
-    fn float_greater_equal_elem(lhs: TchTensor<E>, rhs: E) -> TchTensor<bool> {
+    fn float_greater_equal_elem(lhs: TchTensor, rhs: E) -> TchTensor {
         TchOps::greater_equal_elem(lhs, rhs.elem::<f64>())
     }
 
-    fn float_lower(lhs: TchTensor<E>, rhs: TchTensor<E>) -> TchTensor<bool> {
+    fn float_lower(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchOps::lower(lhs, rhs)
     }
 
-    fn float_lower_elem(lhs: TchTensor<E>, rhs: E) -> TchTensor<bool> {
+    fn float_lower_elem(lhs: TchTensor, rhs: E) -> TchTensor {
         TchOps::lower_elem(lhs, rhs.elem::<f64>())
     }
 
-    fn float_lower_equal(lhs: TchTensor<E>, rhs: TchTensor<E>) -> TchTensor<bool> {
+    fn float_lower_equal(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchOps::lower_equal(lhs, rhs)
     }
 
-    fn float_lower_equal_elem(lhs: TchTensor<E>, rhs: E) -> TchTensor<bool> {
+    fn float_lower_equal_elem(lhs: TchTensor, rhs: E) -> TchTensor {
         TchOps::lower_equal_elem(lhs, rhs.elem::<f64>())
     }
 
-    fn float_mean(tensor: TchTensor<E>) -> TchTensor<E> {
+    fn float_mean(tensor: TchTensor) -> TchTensor {
         TchOps::mean(tensor)
     }
 
-    fn float_sum(tensor: TchTensor<E>) -> TchTensor<E> {
+    fn float_sum(tensor: TchTensor) -> TchTensor {
         TchOps::sum(tensor)
     }
 
-    fn float_sum_dim(tensor: TchTensor<E>, dim: usize) -> TchTensor<E> {
+    fn float_sum_dim(tensor: TchTensor, dim: usize) -> TchTensor {
         TchOps::sum_dim(tensor, dim)
     }
 
-    fn float_mean_dim(tensor: TchTensor<E>, dim: usize) -> TchTensor<E> {
+    fn float_mean_dim(tensor: TchTensor, dim: usize) -> TchTensor {
         TchOps::mean_dim(tensor, dim)
     }
 
-    fn float_prod(tensor: TchTensor<E>) -> TchTensor<E> {
+    fn float_prod(tensor: TchTensor) -> TchTensor {
         TchOps::prod(tensor)
     }
 
-    fn float_prod_dim(tensor: TchTensor<E>, dim: usize) -> TchTensor<E> {
+    fn float_prod_dim(tensor: TchTensor, dim: usize) -> TchTensor {
         TchOps::prod_dim(tensor, dim)
     }
 
-    fn float_argmax(tensor: TchTensor<E>, dim: usize) -> TchTensor<i64> {
+    fn float_argmax(tensor: TchTensor, dim: usize) -> TchTensor {
         TchOps::argmax(tensor, dim)
     }
 
-    fn float_argmin(tensor: TchTensor<E>, dim: usize) -> TchTensor<i64> {
+    fn float_argmin(tensor: TchTensor, dim: usize) -> TchTensor {
         TchOps::argmin(tensor, dim)
     }
 
-    fn float_max_dim(tensor: TchTensor<E>, dim: usize) -> TchTensor<E> {
+    fn float_max_dim(tensor: TchTensor, dim: usize) -> TchTensor {
         TchOps::max_dim(tensor, dim)
     }
 
-    fn float_max_dim_with_indices(
-        tensor: TchTensor<E>,
-        dim: usize,
-    ) -> (TchTensor<E>, TchTensor<i64>) {
+    fn float_max_dim_with_indices(tensor: TchTensor, dim: usize) -> (TchTensor, TchTensor) {
         TchOps::max_dim_with_indices(tensor, dim)
     }
 
-    fn float_min_dim(tensor: TchTensor<E>, dim: usize) -> TchTensor<E> {
+    fn float_min_dim(tensor: TchTensor, dim: usize) -> TchTensor {
         TchOps::min_dim(tensor, dim)
     }
 
-    fn float_min_dim_with_indices(
-        tensor: TchTensor<E>,
-        dim: usize,
-    ) -> (TchTensor<E>, TchTensor<i64>) {
+    fn float_min_dim_with_indices(tensor: TchTensor, dim: usize) -> (TchTensor, TchTensor) {
         TchOps::min_dim_with_indices(tensor, dim)
     }
 
-    fn float_exp(tensor: TchTensor<E>) -> TchTensor<E> {
+    fn float_exp(tensor: TchTensor) -> TchTensor {
         tensor.unary_ops(|mut tensor| tensor.exp_(), |tensor| tensor.exp())
     }
 
-    fn float_log(tensor: TchTensor<E>) -> TchTensor<E> {
+    fn float_log(tensor: TchTensor) -> TchTensor {
         tensor.unary_ops(|mut tensor| tensor.log_(), |tensor| tensor.log())
     }
 
-    fn float_log1p(tensor: TchTensor<E>) -> TchTensor<E> {
+    fn float_log1p(tensor: TchTensor) -> TchTensor {
         tensor.unary_ops(|mut tensor| tensor.log1p_(), |tensor| tensor.log1p())
     }
 
-    fn float_powf_scalar(tensor: TchTensor<E>, value: f32) -> TchTensor<E> {
+    fn float_powf_scalar(tensor: TchTensor, value: f32) -> TchTensor {
         tensor.unary_ops(
             |mut tensor| tensor.f_pow_(value as f64).unwrap(),
             |tensor| tensor.pow_tensor_scalar(value as f64),
         )
     }
 
-    fn float_sqrt(tensor: TchTensor<E>) -> TchTensor<E> {
+    fn float_sqrt(tensor: TchTensor) -> TchTensor {
         tensor.unary_ops(|mut tensor| tensor.sqrt_(), |tensor| tensor.sqrt())
     }
 
-    fn float_abs(tensor: TchTensor<E>) -> TchTensor<E> {
+    fn float_abs(tensor: TchTensor) -> TchTensor {
         tensor.unary_ops(|mut tensor| tensor.abs_(), |tensor| tensor.abs())
     }
 
-    fn float_cos(tensor: TchTensor<E>) -> TchTensor<E> {
+    fn float_cos(tensor: TchTensor) -> TchTensor {
         tensor.unary_ops(|mut tensor| tensor.cos_(), |tensor| tensor.cos())
     }
 
-    fn float_sin(tensor: TchTensor<E>) -> TchTensor<E> {
+    fn float_sin(tensor: TchTensor) -> TchTensor {
         tensor.unary_ops(|mut tensor| tensor.sin_(), |tensor| tensor.sin())
     }
 
-    fn float_tanh(tensor: TchTensor<E>) -> TchTensor<E> {
+    fn float_tanh(tensor: TchTensor) -> TchTensor {
         tensor.unary_ops(|mut tensor| tensor.tanh_(), |tensor| tensor.tanh())
     }
 
-    fn float_round(tensor: TchTensor<E>) -> TchTensor<E> {
+    fn float_round(tensor: TchTensor) -> TchTensor {
         tensor.unary_ops(|mut tensor| tensor.round_(), |tensor| tensor.round())
     }
 
-    fn float_floor(tensor: TchTensor<E>) -> TchTensor<E> {
+    fn float_floor(tensor: TchTensor) -> TchTensor {
         tensor.unary_ops(|mut tensor| tensor.floor_(), |tensor| tensor.floor())
     }
 
-    fn float_ceil(tensor: TchTensor<E>) -> TchTensor<E> {
+    fn float_ceil(tensor: TchTensor) -> TchTensor {
         tensor.unary_ops(|mut tensor| tensor.ceil_(), |tensor| tensor.ceil())
     }
 
-    fn float_erf(tensor: TchTensor<E>) -> TchTensor<E> {
+    fn float_erf(tensor: TchTensor) -> TchTensor {
         tensor.unary_ops(|mut tensor| tensor.erf_(), |tensor| tensor.erf())
     }
 
-    fn float_cat(tensors: Vec<TchTensor<E>>, dim: usize) -> TchTensor<E> {
+    fn float_cat(tensors: Vec<TchTensor>, dim: usize) -> TchTensor {
         TchOps::cat(tensors, dim)
     }
 
-    fn float_clamp_min(tensor: TchTensor<E>, min: E) -> TchTensor<E> {
+    fn float_clamp_min(tensor: TchTensor, min: E) -> TchTensor {
         TchOps::clamp_min(tensor, min.elem::<f64>())
     }
 
-    fn float_clamp_max(
-        tensor: TchTensor<E>,
-        max: <LibTorch<E> as Backend>::FloatElem,
-    ) -> TchTensor<E> {
+    fn float_clamp_max(tensor: TchTensor, max: <LibTorch<E> as Backend>::FloatElem) -> TchTensor {
         TchOps::clamp_max(tensor, max.elem::<f64>())
     }
 
     fn float_clamp(
-        tensor: TchTensor<E>,
+        tensor: TchTensor,
         min: <LibTorch<E> as Backend>::FloatElem,
         max: <LibTorch<E> as Backend>::FloatElem,
-    ) -> TchTensor<E> {
+    ) -> TchTensor {
         TchOps::clamp(tensor, min.elem::<f64>(), max.elem::<f64>())
     }
 
-    fn float_into_int(tensor: TchTensor<E>) -> TchTensor<i64> {
+    fn float_into_int(tensor: TchTensor) -> TchTensor {
         let tensor = tensor.tensor.to_kind(tch::Kind::Int64);
         TchTensor::new(tensor)
     }
 
-    fn float_narrow(tensor: TchTensor<E>, dim: usize, start: usize, length: usize) -> TchTensor<E> {
+    fn float_narrow(tensor: TchTensor, dim: usize, start: usize, length: usize) -> TchTensor {
         TchOps::narrow(tensor, dim, start, length)
     }
 
-    fn float_chunk(tensor: TchTensor<E>, chunks: usize, dim: usize) -> Vec<TchTensor<E>> {
+    fn float_chunk(tensor: TchTensor, chunks: usize, dim: usize) -> Vec<TchTensor> {
         TchOps::chunk(tensor, chunks, dim)
     }
 
-    fn float_powf(lhs: TchTensor<E>, rhs: TchTensor<E>) -> TchTensor<E> {
+    fn float_powf(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchOps::powf(lhs, rhs)
     }
 
-    fn float_permute(tensor: TchTensor<E>, axes: &[usize]) -> TchTensor<E> {
+    fn float_permute(tensor: TchTensor, axes: &[usize]) -> TchTensor {
         TchOps::permute(tensor, axes)
     }
 
-    fn float_flip(tensor: TchTensor<E>, axes: &[usize]) -> TchTensor<E> {
+    fn float_flip(tensor: TchTensor, axes: &[usize]) -> TchTensor {
         TchOps::flip(tensor, axes)
     }
 
-    fn float_sign(tensor: TchTensor<E>) -> TchTensor<E> {
+    fn float_sign(tensor: TchTensor) -> TchTensor {
         TchOps::sign(tensor)
     }
 
-    fn float_expand(tensor: TchTensor<E>, shape: Shape) -> TchTensor<E> {
+    fn float_expand(tensor: TchTensor, shape: Shape) -> TchTensor {
         TchOps::expand(tensor, shape)
     }
 
-    fn float_sort(tensor: TchTensor<E>, dim: usize, descending: bool) -> TchTensor<E> {
+    fn float_sort(tensor: TchTensor, dim: usize, descending: bool) -> TchTensor {
         TchOps::sort(tensor, dim, descending)
     }
 
     fn float_sort_with_indices(
-        tensor: TchTensor<E>,
+        tensor: TchTensor,
         dim: usize,
         descending: bool,
-    ) -> (TchTensor<E>, TchTensor<i64>) {
+    ) -> (TchTensor, TchTensor) {
         TchOps::sort_with_indices(tensor, dim, descending)
     }
 
-    fn float_argsort(tensor: TchTensor<E>, dim: usize, descending: bool) -> IntTensor<Self> {
+    fn float_argsort(tensor: TchTensor, dim: usize, descending: bool) -> IntTensor<Self> {
         TchOps::argsort(tensor, dim, descending)
     }
 }

--- a/crates/burn-tch/src/ops/tensor.rs
+++ b/crates/burn-tch/src/ops/tensor.rs
@@ -455,7 +455,9 @@ impl<E: TchElement, Q: QuantElement> FloatTensorOps<Self> for LibTorch<E, Q> {
 
     fn float_cast(tensor: TchTensor, dtype: FloatDType) -> TchTensor {
         // NOTE: when dtypes of inputs to an arithmetic operation differ, tch handles type
-        // promotion based on a set of rules: https://pytorch.org/docs/stable/tensor_attributes.html
+        // promotion based on a set of rules: https://pytorch.org/docs/stable/tensor_attributes.html#type-promotion-doc
+
+        // Type promotion is not automatic on all backends so this behavior might differ
         let kind = match dtype {
             FloatDType::F64 => tch::Kind::Double,
             FloatDType::F32 => tch::Kind::Float,

--- a/crates/burn-tch/src/tensor.rs
+++ b/crates/burn-tch/src/tensor.rs
@@ -1,13 +1,13 @@
-use crate::{LibTorchDevice, QuantElement};
+use crate::{LibTorchDevice, TchElement};
 use burn_tensor::{
     quantization::{
         AffineQuantization, QTensorPrimitive, QuantizationScheme, QuantizationStrategy,
         QuantizationType, SymmetricQuantization,
     },
-    Element, Shape, TensorData,
+    Shape, TensorData,
 };
 use libc::c_void;
-use std::{marker::PhantomData, sync::Arc};
+use std::sync::Arc;
 
 /// A reference to a tensor storage.
 ///
@@ -62,18 +62,15 @@ impl Storage {
 
 /// A tensor using the tch backend.
 #[derive(Debug, PartialEq)]
-pub struct TchTensor<E: tch::kind::Element> {
+pub struct TchTensor {
     /// Handle to the tensor. Call methods on this field.
     pub tensor: tch::Tensor,
 
     /// The tensor's storage
     pub storage: Storage,
-
-    /// The element type of the tensor.
-    phantom: PhantomData<E>,
 }
 
-impl<E: tch::kind::Element> TchTensor<E> {
+impl TchTensor {
     /// Create a new tensor.
     ///
     /// Note that if the tensor was created from an operation that may reuse the same tensor
@@ -85,11 +82,7 @@ impl<E: tch::kind::Element> TchTensor<E> {
             buffer_ref: Arc::new(tensor.data_ptr()),
         };
 
-        Self {
-            tensor,
-            storage,
-            phantom: PhantomData,
-        }
+        Self { tensor, storage }
     }
 
     /// Create a tensor that was created from an operation executed on a parent tensor.
@@ -126,11 +119,7 @@ impl<E: tch::kind::Element> TchTensor<E> {
             false => storage_parent.clone(),
         };
 
-        Self {
-            tensor,
-            storage,
-            phantom: PhantomData,
-        }
+        Self { tensor, storage }
     }
 
     /// Create a tensor that uses a part of its parent tensor such as slice and narrow.
@@ -140,15 +129,11 @@ impl<E: tch::kind::Element> TchTensor<E> {
             #[allow(clippy::arc_with_non_send_sync)]
             view_ref: Arc::new(tensor.data_ptr()),
         };
-        Self {
-            tensor,
-            storage,
-            phantom: PhantomData,
-        }
+        Self { tensor, storage }
     }
 }
 
-impl<E: tch::kind::Element> TchTensor<E> {
+impl TchTensor {
     pub(crate) fn shape(&self) -> Shape {
         Shape::from(self.tensor.size())
     }
@@ -157,10 +142,10 @@ impl<E: tch::kind::Element> TchTensor<E> {
 // This is safe since we don't use autodiff from LibTorch.
 // Also, atomic reference counting is used to know if the tensor's data can be reused.
 // If there are multiple reference on the same tensor, it becomes read only.
-unsafe impl<E: tch::kind::Element> Send for TchTensor<E> {}
-unsafe impl<E: tch::kind::Element> Sync for TchTensor<E> {}
+unsafe impl Send for TchTensor {}
+unsafe impl Sync for TchTensor {}
 
-impl<P: tch::kind::Element> TchTensor<P> {
+impl TchTensor {
     /// Checks if the tensor can be mutated in-place.
     ///
     /// Returns `true` if the tensor's stride does not contain zero (no broadcasting)
@@ -172,10 +157,10 @@ impl<P: tch::kind::Element> TchTensor<P> {
     }
 
     /// Executes an operation on a tensor if the data can be reused.
-    pub fn mut_ops<F: Fn(&mut tch::Tensor) -> tch::Tensor, EOut: tch::kind::Element>(
+    pub fn mut_ops<F: Fn(&mut tch::Tensor) -> tch::Tensor>(
         &mut self,
         func: F,
-    ) -> Option<TchTensor<EOut>> {
+    ) -> Option<TchTensor> {
         if !self.can_mut() {
             return None;
         }
@@ -185,11 +170,7 @@ impl<P: tch::kind::Element> TchTensor<P> {
     }
 
     /// Executes a unary operation, reusing the tensor data if possible.
-    pub fn unary_ops<FOwn, FRef, EOut: tch::kind::Element>(
-        self,
-        fown: FOwn,
-        fref: FRef,
-    ) -> TchTensor<EOut>
+    pub fn unary_ops<FOwn, FRef>(self, fown: FOwn, fref: FRef) -> TchTensor
     where
         FOwn: Fn(tch::Tensor) -> tch::Tensor,
         FRef: Fn(&tch::Tensor) -> tch::Tensor,
@@ -202,13 +183,13 @@ impl<P: tch::kind::Element> TchTensor<P> {
     }
 
     /// Executes a binary operation, reusing the tensor data if possible.
-    pub fn binary_ops_tensor<FLMut, FRMut, FRef, EOut: tch::kind::Element>(
+    pub fn binary_ops_tensor<FLMut, FRMut, FRef>(
         mut lhs: Self,
         mut rhs: Self,
         flmut: FLMut,
         frmut: FRMut,
         fref: FRef,
-    ) -> TchTensor<EOut>
+    ) -> TchTensor
     where
         FLMut: Fn(&mut tch::Tensor, &tch::Tensor) -> tch::Tensor,
         FRMut: Fn(&tch::Tensor, &mut tch::Tensor) -> tch::Tensor,
@@ -248,11 +229,10 @@ impl<P: tch::kind::Element> TchTensor<P> {
     }
 }
 
-impl<P: tch::kind::Element> Clone for TchTensor<P> {
+impl Clone for TchTensor {
     fn clone(&self) -> Self {
         Self {
             tensor: self.tensor.shallow_clone(),
-            phantom: PhantomData,
             storage: self.storage.clone(),
         }
     }
@@ -281,7 +261,7 @@ impl From<&[usize]> for TchShape {
     }
 }
 
-impl<E: tch::kind::Element + Default + Element> TchTensor<E> {
+impl TchTensor {
     /// Creates a new tensor from a shape and a device.
     ///
     /// # Arguments
@@ -292,7 +272,7 @@ impl<E: tch::kind::Element + Default + Element> TchTensor<E> {
     /// # Returns
     ///
     /// A new tensor.
-    pub fn from_data(data: TensorData, device: tch::Device) -> Self {
+    pub fn from_data<E: TchElement>(data: TensorData, device: tch::Device) -> Self {
         let shape_tch = TchShape::from(data.shape.as_slice());
         let tensor =
             tch::Tensor::from_slice(data.convert::<E>().as_slice::<E>().unwrap()).to(device);
@@ -302,7 +282,7 @@ impl<E: tch::kind::Element + Default + Element> TchTensor<E> {
     }
 }
 
-impl<E: tch::kind::Element + Default + Copy + std::fmt::Debug> TchTensor<E> {
+impl TchTensor {
     /// Creates an empty tensor from a shape and a device.
     ///
     /// # Arguments
@@ -313,7 +293,7 @@ impl<E: tch::kind::Element + Default + Copy + std::fmt::Debug> TchTensor<E> {
     /// # Returns
     ///
     /// A new empty tensor.
-    pub fn empty(shape: Shape, device: LibTorchDevice) -> Self {
+    pub fn empty<E: tch::kind::Element>(shape: Shape, device: LibTorchDevice) -> Self {
         let shape_tch = TchShape::from(shape);
         let tensor = tch::Tensor::empty(shape_tch.dims, (E::KIND, device.into()));
 
@@ -323,14 +303,14 @@ impl<E: tch::kind::Element + Default + Copy + std::fmt::Debug> TchTensor<E> {
 
 /// A quantized tensor for the tch backend.
 #[derive(Clone, Debug)]
-pub struct TchQTensor<Q: QuantElement> {
+pub struct TchQTensor {
     /// The quantized tensor.
-    pub qtensor: TchTensor<Q>,
+    pub qtensor: TchTensor,
     /// The quantization scheme.
     pub scheme: QuantizationScheme,
 }
 
-impl<Q: QuantElement> QTensorPrimitive for TchQTensor<Q> {
+impl QTensorPrimitive for TchQTensor {
     fn scheme(&self) -> &QuantizationScheme {
         &self.scheme
     }
@@ -377,7 +357,7 @@ mod tests {
             Distribution::Default,
             &mut StdRng::from_entropy(),
         );
-        let tensor = TchTensor::<f32>::from_data(data_expected.clone(), tch::Device::Cpu);
+        let tensor = TchTensor::from_data::<f32>(data_expected.clone(), tch::Device::Cpu);
 
         let data_actual =
             Tensor::<LibTorch<f32>, 1>::from_primitive(TensorPrimitive::Float(tensor)).into_data();
@@ -392,7 +372,7 @@ mod tests {
             Distribution::Default,
             &mut StdRng::from_entropy(),
         );
-        let tensor = TchTensor::<f32>::from_data(data_expected.clone(), tch::Device::Cpu);
+        let tensor = TchTensor::from_data::<f32>(data_expected.clone(), tch::Device::Cpu);
 
         let data_actual =
             Tensor::<LibTorch<f32>, 2>::from_primitive(TensorPrimitive::Float(tensor)).into_data();
@@ -429,16 +409,16 @@ mod tests {
     #[test]
     fn should_support_qtensor_strategy() {
         let tensor =
-            TchTensor::<f32>::from_data(TensorData::from([-1.8, -1.0, 0.0, 0.5]), tch::Device::Cpu);
+            TchTensor::from_data::<f32>(TensorData::from([-1.8, -1.0, 0.0, 0.5]), tch::Device::Cpu);
         let scheme = QuantizationScheme::PerTensorAffine(QuantizationType::QInt8);
-        let qparams = QuantizationParametersPrimitive {
-            scale: TchTensor::from_data(TensorData::from([0.009_019_608]), tch::Device::Cpu),
-            offset: Some(TchTensor::from_data(
+        let qparams = QuantizationParametersPrimitive::<LibTorch<f32, i8>> {
+            scale: TchTensor::from_data::<f32>(TensorData::from([0.009_019_608]), tch::Device::Cpu),
+            offset: Some(TchTensor::from_data::<i8>(
                 TensorData::from([72]),
                 tch::Device::Cpu,
             )),
         };
-        let qtensor: TchQTensor<i8> = LibTorch::quantize(tensor, &scheme, qparams);
+        let qtensor: TchQTensor = LibTorch::quantize(tensor, &scheme, qparams);
 
         assert_eq!(qtensor.scheme(), &scheme);
         assert_eq!(

--- a/crates/burn-tensor/src/tensor/api/float.rs
+++ b/crates/burn-tensor/src/tensor/api/float.rs
@@ -1,7 +1,6 @@
 use alloc::vec::Vec;
 use core::convert::TryInto;
 
-use crate::check;
 use crate::check::TensorCheck;
 use crate::ops::FullPrecisionBackend;
 use crate::quantization::{QuantizationParameters, QuantizationScheme};
@@ -9,6 +8,7 @@ use crate::tensor::backend::Backend;
 use crate::tensor::stats;
 use crate::tensor::{Distribution, Shape, TensorData};
 use crate::Tensor;
+use crate::{check, FloatDType};
 use crate::{Int, TensorPrimitive};
 
 impl<const D: usize, B> Tensor<B, D>
@@ -241,6 +241,14 @@ where
         let mean = self.clone().mean_dim(dim);
         let var = stats::var_with_mean_bias(self, mean.clone(), dim);
         (var, mean)
+    }
+
+    /// Converts a tensor to the specified floating point data type.
+    pub fn cast<F: Into<FloatDType>>(self, dtype: F) -> Tensor<B, D> {
+        Tensor::new(TensorPrimitive::Float(B::float_cast(
+            self.primitive.tensor(),
+            dtype.into(),
+        )))
     }
 
     /// Returns a tensor with full precision based on the selected backend.

--- a/crates/burn-tensor/src/tensor/element/base.rs
+++ b/crates/burn-tensor/src/tensor/element/base.rs
@@ -325,3 +325,24 @@ impl DType {
         matches!(self, DType::Bool)
     }
 }
+
+#[allow(missing_docs)]
+#[derive(Debug, Clone)]
+pub enum FloatDType {
+    F64,
+    F32,
+    F16,
+    BF16,
+}
+
+impl From<DType> for FloatDType {
+    fn from(value: DType) -> Self {
+        match value {
+            DType::F64 => FloatDType::F64,
+            DType::F32 => FloatDType::F32,
+            DType::F16 => FloatDType::F16,
+            DType::BF16 => FloatDType::BF16,
+            _ => panic!("Expected float data type, got {value:?}"),
+        }
+    }
+}

--- a/crates/burn-tensor/src/tensor/ops/tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/tensor.rs
@@ -3,9 +3,9 @@ use super::repeat_dim::repeat_with_slice_assign;
 use super::{BoolTensor, Device, FloatElem, FloatTensor, FullPrecisionBackend, IntElem, IntTensor};
 use crate::backend::BackendBridge;
 use crate::tensor::cast::ToElement;
-use crate::TensorPrimitive;
 use crate::{backend::Backend, tensor::Shape, Distribution, ElementConversion, Float, TensorData};
 use crate::{tensor::api::chunk, tensor::api::narrow};
+use crate::{FloatDType, TensorPrimitive};
 use alloc::vec::Vec;
 use core::future::Future;
 use core::ops::Range;
@@ -789,6 +789,18 @@ pub trait FloatTensorOps<B: Backend> {
     fn float_into_full_precision(tensor: FloatTensor<B>) -> FloatTensor<FullPrecisionBackend<B>> {
         <B::FullPrecisionBridge as BackendBridge<B>>::into_target(tensor, None)
     }
+
+    /// Converts a tensor to another floating point data type.
+    ///
+    /// # Arguments
+    ///
+    /// * `tensor` - The tensor to convert.
+    /// * `dtype` - The target data type.
+    ///
+    /// # Returns
+    ///
+    /// A tensor with the same values as `tensor` but in the target floating point data type.
+    fn float_cast(tensor: FloatTensor<B>, dtype: FloatDType) -> FloatTensor<B>;
 
     /// Converts a tensor from full precision.
     ///

--- a/crates/burn-tensor/src/tests/ops/cast.rs
+++ b/crates/burn-tensor/src/tests/ops/cast.rs
@@ -1,7 +1,7 @@
 #[burn_tensor_testgen::testgen(cast)]
 mod tests {
     use super::*;
-    use burn_tensor::{Bool, FloatDType, Tensor, TensorData};
+    use burn_tensor::{Bool, DType, Tensor, TensorData};
 
     #[test]
     fn cast_float_to_int() {
@@ -42,8 +42,11 @@ mod tests {
     #[test]
     fn cast_float_precision() {
         let data = TensorData::from([[1.0, 2.0, 3.0], [4.4, 5.5, 6.6]]);
-        let tensor = TestTensor::<2>::from(data.clone()).cast(FloatDType::F16);
+        let tensor = TestTensor::<2>::from(data.clone());
 
-        tensor.into_data().assert_eq(&data, false);
+        let output = tensor.cast(DType::F16).into_data();
+
+        assert_eq!(output.dtype, DType::F16);
+        output.assert_eq(&data, false);
     }
 }

--- a/crates/burn-tensor/src/tests/ops/cast.rs
+++ b/crates/burn-tensor/src/tests/ops/cast.rs
@@ -1,7 +1,7 @@
 #[burn_tensor_testgen::testgen(cast)]
 mod tests {
     use super::*;
-    use burn_tensor::{Bool, Tensor, TensorData};
+    use burn_tensor::{Bool, FloatDType, Tensor, TensorData};
 
     #[test]
     fn cast_float_to_int() {
@@ -36,5 +36,14 @@ mod tests {
         let expected = TensorData::from([[1., 0., 1.], [0., 0., 1.]]);
 
         tensor.into_data().assert_eq(&expected, false);
+    }
+
+    #[ignore = "Not implemented for all backends yet"]
+    #[test]
+    fn cast_float_precision() {
+        let data = TensorData::from([[1.0, 2.0, 3.0], [4.4, 5.5, 6.6]]);
+        let tensor = TestTensor::<2>::from(data.clone()).cast(FloatDType::F16);
+
+        tensor.into_data().assert_eq(&data, false);
     }
 }


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

Add `tensor.cast(dtype)` op for floating point casting to different precision types.

Currently implemented for `candle` and `tch`. Had to remove the element type generic on both tensor primitives for this change.

Will be implemented in a follow-up PR for: `burn-ndarray`, `burn-jit`, `burn-fusion` and `burn-router`.

**Important:** handling different floating point precision types in operations between multiple tensors might require automatic type promotion based on a selected strategy (e.g., cast to the higher precision type like [torch](https://pytorch.org/docs/stable/tensor_attributes.html#type-promotion-doc)). This is not in the current scope, instead backends can panic with a dtype mismatch.

### Testing

Added a unit test.
