### PR TITLE
verifying parent nodes' existence

### DIFF
--- a/crates/burn-autodiff/src/runtime/memory_management.rs
+++ b/crates/burn-autodiff/src/runtime/memory_management.rs
@@ -84,8 +84,8 @@ impl GraphMemoryManagement {
         for (id, parents) in self.nodes.iter() {
             let is_useful = matches!(self.statuses.get(id), Some(NodeMemoryStatus::Useful));
 
-            let parents_absent =
-                parents.is_empty() || parents.iter().all(|p| !self.nodes.contains_key(p));
+            // Check if parents are either empty or absent from self.nodes
+            let parents_absent = parents.iter().all(|p| !self.nodes.contains_key(p));
 
             if !is_useful && Arc::strong_count(id) == 1 && parents_absent {
                 to_delete.push(*id.as_ref())

--- a/crates/burn-autodiff/src/runtime/memory_management.rs
+++ b/crates/burn-autodiff/src/runtime/memory_management.rs
@@ -84,7 +84,10 @@ impl GraphMemoryManagement {
         for (id, parents) in self.nodes.iter() {
             let is_useful = matches!(self.statuses.get(id), Some(NodeMemoryStatus::Useful));
 
-            if !is_useful && Arc::strong_count(id) == 1 && parents.is_empty() {
+            let parents_absent =
+                parents.is_empty() || parents.iter().all(|p| !self.nodes.contains_key(p));
+
+            if !is_useful && Arc::strong_count(id) == 1 && parents_absent {
                 to_delete.push(*id.as_ref())
             }
         }


### PR DESCRIPTION
Fix https://github.com/tracel-ai/burn/issues/2487

Since the loop over self.nodes.iter() in GraphMemoryManagement::clear_unused_roots() does not process nodes in child-to-parent order, if a node's parents are removed first, that node will not be deleted and will remain. To address this, I added a check to verify if all parents are absent from self.nodes. If none of the parents exist in self.nodes, the node is treated as having no parents and is marked for deletion.
