### PR TITLE
Fix unsqueeze dims with multiple trailing negative indices

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -166,6 +166,7 @@ Those operations are available for all tensor kinds: `Int`, `Float`, and `Bool`.
 | `tensor.to_device(device)`            | `tensor.to(device)`                                                       |
 | `tensor.unsqueeze()`                  | `tensor.unsqueeze(0)`                                                     |
 | `tensor.unsqueeze_dim(dim)`           | `tensor.unsqueeze(dim)`                                                   |
+| `tensor.unsqueeze_dims(dims)`         | N/A                                                  |
 
 ### Numeric Operations
 

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -732,12 +732,18 @@ where
         //for checking if the dimension is in the acceptable range
 
         //part 1: convert the negative indices to positive
+        let mut neg_offset = D2;
         let mut dim_indices = axes
             .iter()
             .map(|d| {
                 // check if the dimension is in the acceptable range
                 check!(TensorCheck::unsqueeze_dims::<{ D2 }>(*d));
-                (if *d < 0 { d + D2 as isize } else { *d }) as usize
+                (if *d < 0 {
+                    neg_offset -= 1; // handle multiple negative indices (decrease dim value in reverse)
+                    d + neg_offset as isize + 1
+                } else {
+                    *d
+                }) as usize
             })
             .collect::<Vec<usize>>();
 

--- a/crates/burn-tensor/src/tests/ops/squeeze.rs
+++ b/crates/burn-tensor/src/tests/ops/squeeze.rs
@@ -149,6 +149,14 @@ mod tests {
     }
 
     #[test]
+    fn should_unsqueeze_dims_multiple_trailing_negatives() {
+        let input_tensor = TestTensor::<3>::ones(Shape::new([3, 4, 5]), &Default::default());
+        let output_tensor: Tensor<TestBackend, 6> = input_tensor.unsqueeze_dims(&[0, -1, -1]);
+        let expected_shape = Shape::new([1, 3, 4, 5, 1, 1]);
+        assert_eq!(output_tensor.shape(), expected_shape);
+    }
+
+    #[test]
     #[should_panic]
     fn should_unsqueeze_dims_panic() {
         let input_tensor = TestTensor::<3>::ones(Shape::new([3, 4, 5]), &Default::default());


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Fixes #2493

### Changes

The example usage used multiple trailing dimensions with a negative index for `tensor.unsqueeze_dims(&[0, -1, -1])` but the conversion to a positive dim index was incorrect (always `negative_idx + D2` which meant that they all mapped to the same dim, but also that the first slice was always too big when copying the chunks of the dims).

### Testing

Added unit test.
