### PR TITLE
use alias for more consistent typing

### DIFF
--- a/crates/burn-autodiff/src/grads.rs
+++ b/crates/burn-autodiff/src/grads.rs
@@ -1,4 +1,4 @@
-use burn_tensor::{backend::Backend, container::TensorContainer};
+use burn_tensor::{backend::Backend, container::TensorContainer, ops::FloatTensor};
 
 use crate::{
     graph::{NodeRef, Requirement},
@@ -14,11 +14,9 @@ pub struct Gradients {
     container: TensorContainer<GradID>,
 }
 
-type TensorPrimitive<B> = <B as Backend>::FloatTensorPrimitive;
-
 impl Gradients {
     /// Creates a new gradients container.
-    pub fn new<B: Backend>(root_node: NodeRef, root_tensor: TensorPrimitive<B>) -> Self {
+    pub fn new<B: Backend>(root_node: NodeRef, root_tensor: FloatTensor<B>) -> Self {
         let mut gradients = Self {
             container: TensorContainer::new(),
         };
@@ -33,7 +31,7 @@ impl Gradients {
     ///
     /// Each tensor should be consumed exactly 1 time if its gradients are only required during the
     /// backward pass, otherwise, it may be consume multiple times.
-    pub fn consume<B: Backend>(&mut self, node: &NodeRef) -> TensorPrimitive<B> {
+    pub fn consume<B: Backend>(&mut self, node: &NodeRef) -> FloatTensor<B> {
         match node.requirement {
             Requirement::Grad => self
                 .container
@@ -50,14 +48,14 @@ impl Gradients {
     }
 
     /// Removes a grad tensor from the container.
-    pub fn remove<B: Backend>(&mut self, tensor: &AutodiffTensor<B>) -> Option<TensorPrimitive<B>> {
+    pub fn remove<B: Backend>(&mut self, tensor: &AutodiffTensor<B>) -> Option<FloatTensor<B>> {
         self.container
             .remove::<B>(&tensor.node.id.value)
             .map(|tensor| tensor.tensor())
     }
 
     /// Gets a grad tensor from the container.
-    pub fn get<B: Backend>(&self, tensor: &AutodiffTensor<B>) -> Option<TensorPrimitive<B>> {
+    pub fn get<B: Backend>(&self, tensor: &AutodiffTensor<B>) -> Option<FloatTensor<B>> {
         self.container
             .get::<B>(&tensor.node.id.value)
             .map(|tensor| tensor.tensor())
@@ -66,7 +64,7 @@ impl Gradients {
     /// Register a grad tensor in the container.
     ///
     /// If the tensor already exists, add both tensors together before saving the result.
-    pub fn register<B: Backend>(&mut self, node_id: NodeID, value: TensorPrimitive<B>) {
+    pub fn register<B: Backend>(&mut self, node_id: NodeID, value: FloatTensor<B>) {
         if let Some(tensor_old) = self.container.remove::<B>(&node_id.value) {
             self.container.register::<B>(
                 node_id.value,

--- a/crates/burn-core/src/module/base.rs
+++ b/crates/burn-core/src/module/base.rs
@@ -5,11 +5,11 @@ use crate::{
 };
 use alloc::vec::Vec;
 pub use burn_derive::Module;
-use burn_tensor::{quantization::Calibration, Bool, Int, Tensor};
+use burn_tensor::{ops::Device, quantization::Calibration, Bool, Int, Tensor};
 
 /// Type alias to `Vec<B::Device>` which supports `no_std` environments, but automatically using
 /// the `alloc` crate.
-pub type Devices<B> = Vec<<B as Backend>::Device>;
+pub type Devices<B> = Vec<Device<B>>;
 
 // At the moment, our plan is to continue experimenting with the macro internally and monitor its development.
 // We may consider making it public in the future.

--- a/crates/burn-core/src/module/param/constant.rs
+++ b/crates/burn-core/src/module/param/constant.rs
@@ -12,6 +12,7 @@ use crate::{
 use burn::record::PrecisionSettings;
 use burn_tensor::{
     backend::{AutodiffBackend, Backend},
+    ops::Device,
     BasicAutodiffOps, BasicOps, Tensor,
 };
 
@@ -217,11 +218,11 @@ impl<B: Backend> Module<B> for PhantomData<B> {
         ConstantRecord::new()
     }
 
-    fn to_device(self, _: &<B as Backend>::Device) -> Self {
+    fn to_device(self, _: &Device<B>) -> Self {
         self
     }
 
-    fn fork(self, _: &<B as Backend>::Device) -> Self {
+    fn fork(self, _: &Device<B>) -> Self {
         self
     }
 
@@ -273,11 +274,11 @@ where
         ConstantRecord::new()
     }
 
-    fn to_device(self, _: &<B as Backend>::Device) -> Self {
+    fn to_device(self, _: &Device<B>) -> Self {
         self
     }
 
-    fn fork(self, _: &<B as Backend>::Device) -> Self {
+    fn fork(self, _: &Device<B>) -> Self {
         self
     }
 

--- a/crates/burn-core/src/module/param/primitive.rs
+++ b/crates/burn-core/src/module/param/primitive.rs
@@ -5,7 +5,10 @@ use crate::module::{
 
 use alloc::{format, vec::Vec};
 
-use burn_tensor::backend::{AutodiffBackend, Backend};
+use burn_tensor::{
+    backend::{AutodiffBackend, Backend},
+    ops::Device,
+};
 use core::fmt::Debug;
 
 impl<T, B> Module<B> for Option<T>
@@ -40,11 +43,11 @@ where
         self.map(Module::into_record)
     }
 
-    fn to_device(self, device: &<B as Backend>::Device) -> Self {
+    fn to_device(self, device: &Device<B>) -> Self {
         self.map(|module| module.to_device(device))
     }
 
-    fn fork(self, device: &<B as Backend>::Device) -> Self {
+    fn fork(self, device: &Device<B>) -> Self {
         self.map(|module| module.fork(device))
     }
 
@@ -125,13 +128,13 @@ where
             .collect()
     }
 
-    fn to_device(self, device: &<B as Backend>::Device) -> Self {
+    fn to_device(self, device: &Device<B>) -> Self {
         self.into_iter()
             .map(|module| module.to_device(device))
             .collect()
     }
 
-    fn fork(self, device: &<B as Backend>::Device) -> Self {
+    fn fork(self, device: &Device<B>) -> Self {
         self.into_iter().map(|module| module.fork(device)).collect()
     }
 
@@ -218,11 +221,11 @@ where
         self.map(Module::into_record)
     }
 
-    fn to_device(self, device: &<B as Backend>::Device) -> Self {
+    fn to_device(self, device: &Device<B>) -> Self {
         self.map(|module| module.to_device(device))
     }
 
-    fn fork(self, device: &<B as Backend>::Device) -> Self {
+    fn fork(self, device: &Device<B>) -> Self {
         self.map(|module| module.fork(device))
     }
 }
@@ -276,11 +279,11 @@ macro_rules! impl_module_tuple {
                 devices
             }
 
-            fn fork(self, device: &<B as Backend>::Device) -> Self {
+            fn fork(self, device: &Device<B>) -> Self {
                 ($(self.$i.fork(device),)*)
             }
 
-            fn to_device(self, device: &<B as Backend>::Device) -> Self {
+            fn to_device(self, device: &Device<B>) -> Self {
                 ($(self.$i.to_device(device),)*)
             }
 

--- a/crates/burn-core/src/module/param/running.rs
+++ b/crates/burn-core/src/module/param/running.rs
@@ -16,6 +16,7 @@ use portable_atomic_util::Arc;
 use burn_common::stub::Mutex;
 use burn_tensor::{
     backend::{AutodiffBackend, Backend},
+    ops::Device,
     Tensor,
 };
 
@@ -109,7 +110,7 @@ impl<const D: usize, B: Backend> Module<B> for RunningState<Tensor<B, D>> {
         self
     }
 
-    fn to_device(self, device: &<B as Backend>::Device) -> Self {
+    fn to_device(self, device: &Device<B>) -> Self {
         let mut tensor = self.value.lock().unwrap();
         let tensor_out = tensor.clone().to_device(device);
 
@@ -119,14 +120,11 @@ impl<const D: usize, B: Backend> Module<B> for RunningState<Tensor<B, D>> {
         self
     }
 
-    fn fork(self, device: &<B as Backend>::Device) -> Self {
+    fn fork(self, device: &Device<B>) -> Self {
         self.to_device(device) // Same thing here since no grad.
     }
 
-    fn collect_devices(
-        &self,
-        mut devices: Vec<<B as Backend>::Device>,
-    ) -> Vec<<B as Backend>::Device> {
+    fn collect_devices(&self, mut devices: Vec<Device<B>>) -> Vec<Device<B>> {
         let device = self.value.lock().unwrap().device();
 
         if !devices.contains(&device) {

--- a/crates/burn-core/src/module/param/tensor.rs
+++ b/crates/burn-core/src/module/param/tensor.rs
@@ -8,7 +8,7 @@ use crate::tensor::{
     Tensor,
 };
 use alloc::{format, string::ToString, vec::Vec};
-use burn_tensor::{Bool, Float, Int, TensorData};
+use burn_tensor::{ops::Device, Bool, Float, Int, TensorData};
 
 impl<B: Backend, const D: usize> Parameter for Tensor<B, D, Float> {
     type Device = B::Device;
@@ -118,11 +118,11 @@ impl<const D: usize, B: Backend> Module<B> for Param<Tensor<B, D>> {
         Self::initialized(new_id, new_value)
     }
 
-    fn to_device(self, device: &<B as Backend>::Device) -> Self {
+    fn to_device(self, device: &Device<B>) -> Self {
         self.map(|tensor| tensor.to_device(device))
     }
 
-    fn fork(self, device: &<B as Backend>::Device) -> Self {
+    fn fork(self, device: &Device<B>) -> Self {
         self.map(|tensor| {
             let is_require_grad = tensor.is_require_grad();
             let mut tensor = tensor.to_device(device).detach();
@@ -135,10 +135,7 @@ impl<const D: usize, B: Backend> Module<B> for Param<Tensor<B, D>> {
         })
     }
 
-    fn collect_devices(
-        &self,
-        mut devices: Vec<<B as Backend>::Device>,
-    ) -> Vec<<B as Backend>::Device> {
+    fn collect_devices(&self, mut devices: Vec<Device<B>>) -> Vec<Device<B>> {
         let device = self.val().device();
 
         if !devices.contains(&device) {
@@ -194,18 +191,15 @@ impl<const D: usize, B: Backend> Module<B> for Param<Tensor<B, D, Int>> {
         Self::initialized(new_id, new_value)
     }
 
-    fn to_device(self, device: &<B as Backend>::Device) -> Self {
+    fn to_device(self, device: &Device<B>) -> Self {
         self.map(|tensor| tensor.to_device(device))
     }
 
-    fn fork(self, device: &<B as Backend>::Device) -> Self {
+    fn fork(self, device: &Device<B>) -> Self {
         self.to_device(device) // Don't support autodiff.
     }
 
-    fn collect_devices(
-        &self,
-        mut devices: Vec<<B as Backend>::Device>,
-    ) -> Vec<<B as Backend>::Device> {
+    fn collect_devices(&self, mut devices: Vec<Device<B>>) -> Vec<Device<B>> {
         let device = self.val().device();
 
         if !devices.contains(&device) {
@@ -261,18 +255,15 @@ impl<const D: usize, B: Backend> Module<B> for Param<Tensor<B, D, Bool>> {
         Self::initialized(new_id, new_value)
     }
 
-    fn to_device(self, device: &<B as Backend>::Device) -> Self {
+    fn to_device(self, device: &Device<B>) -> Self {
         self.map(|tensor| tensor.to_device(device))
     }
 
-    fn fork(self, device: &<B as Backend>::Device) -> Self {
+    fn fork(self, device: &Device<B>) -> Self {
         self.to_device(device) // Don't support autodiff.
     }
 
-    fn collect_devices(
-        &self,
-        mut devices: Vec<<B as Backend>::Device>,
-    ) -> Vec<<B as Backend>::Device> {
+    fn collect_devices(&self, mut devices: Vec<Device<B>>) -> Vec<Device<B>> {
         let device = self.val().device();
 
         if !devices.contains(&device) {

--- a/crates/burn-core/src/optim/adagrad.rs
+++ b/crates/burn-core/src/optim/adagrad.rs
@@ -10,7 +10,7 @@ use super::{
 use crate::config::Config;
 use crate::optim::adaptor::OptimizerAdaptor;
 use crate::tensor::{backend::AutodiffBackend, Tensor};
-use burn_tensor::backend::Backend;
+use burn_tensor::{backend::Backend, ops::Device};
 
 /// AdaGrad configuration.
 #[derive(Config)]
@@ -65,10 +65,7 @@ impl<B: Backend> SimpleOptimizer<B> for AdaGrad<B> {
         (tensor - grad, Some(state))
     }
 
-    fn to_device<const D: usize>(
-        mut state: Self::State<D>,
-        device: &<B as Backend>::Device,
-    ) -> Self::State<D> {
+    fn to_device<const D: usize>(mut state: Self::State<D>, device: &Device<B>) -> Self::State<D> {
         state.lr_decay = state.lr_decay.to_device(device);
         state
     }

--- a/crates/burn-core/src/optim/adam.rs
+++ b/crates/burn-core/src/optim/adam.rs
@@ -10,7 +10,7 @@ use super::{
 use crate::config::Config;
 use crate::optim::adaptor::OptimizerAdaptor;
 use crate::tensor::{backend::AutodiffBackend, Tensor};
-use burn_tensor::{backend::Backend, ElementConversion};
+use burn_tensor::{backend::Backend, ops::Device, ElementConversion};
 
 /// Adam configuration.
 #[derive(Config)]
@@ -71,10 +71,7 @@ impl<B: Backend> SimpleOptimizer<B> for Adam<B> {
         (tensor - delta, Some(state))
     }
 
-    fn to_device<const D: usize>(
-        mut state: Self::State<D>,
-        device: &<B as Backend>::Device,
-    ) -> Self::State<D> {
+    fn to_device<const D: usize>(mut state: Self::State<D>, device: &Device<B>) -> Self::State<D> {
         state.momentum = state.momentum.to_device(device);
         state
     }

--- a/crates/burn-core/src/optim/adamw.rs
+++ b/crates/burn-core/src/optim/adamw.rs
@@ -8,7 +8,7 @@ use super::SimpleOptimizer;
 use crate::config::Config;
 use crate::optim::adaptor::OptimizerAdaptor;
 use crate::tensor::{backend::AutodiffBackend, Tensor};
-use burn_tensor::{backend::Backend, ElementConversion};
+use burn_tensor::{backend::Backend, ops::Device, ElementConversion};
 
 /// AdamW configuration.
 #[derive(Config)]
@@ -69,10 +69,7 @@ impl<B: Backend> SimpleOptimizer<B> for AdamW<B> {
         (tensor_updated - raw_delta.mul_scalar(lr), Some(state))
     }
 
-    fn to_device<const D: usize>(
-        mut state: Self::State<D>,
-        device: &<B as Backend>::Device,
-    ) -> Self::State<D> {
+    fn to_device<const D: usize>(mut state: Self::State<D>, device: &Device<B>) -> Self::State<D> {
         state.momentum = state.momentum.to_device(device);
         state
     }

--- a/crates/burn-core/src/optim/rmsprop.rs
+++ b/crates/burn-core/src/optim/rmsprop.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use crate::config::Config;
 use crate::optim::adaptor::OptimizerAdaptor;
-use crate::tensor::{backend::AutodiffBackend, Tensor};
+use crate::tensor::{backend::AutodiffBackend, ops::Device, Tensor};
 use burn_tensor::backend::Backend;
 
 /// Configuration to create the [RmsProp](RmsProp) optimizer.
@@ -125,10 +125,7 @@ impl<B: Backend> SimpleOptimizer<B> for RmsProp<B> {
         (tensor - delta, Some(state))
     }
 
-    fn to_device<const D: usize>(
-        mut state: Self::State<D>,
-        device: &<B as Backend>::Device,
-    ) -> Self::State<D> {
+    fn to_device<const D: usize>(mut state: Self::State<D>, device: &Device<B>) -> Self::State<D> {
         state.square_avg = state.square_avg.to_device(device);
         state.centered = state.centered.to_device(device);
         state.momentum = state.momentum.map(|momentum| momentum.to_device(device));

--- a/crates/burn-remote/src/server/base.rs
+++ b/crates/burn-remote/src/server/base.rs
@@ -10,11 +10,7 @@ use axum::{
     Router,
 };
 
-use burn_tensor::{
-    backend::{Backend, BackendBridge},
-    repr::ReprBackend,
-    Device,
-};
+use burn_tensor::{ops::FullPrecisionBackend, repr::ReprBackend, Device};
 use tracing_core::{Level, LevelFilter};
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{filter::filter_fn, registry};
@@ -31,8 +27,7 @@ pub struct WsServer<B: ReprBackend> {
 impl<B: ReprBackend> WsServer<B>
 where
     // Restrict full precision backend handle to be the same
-    <<B as Backend>::FullPrecisionBridge as BackendBridge<B>>::Target:
-        ReprBackend<Handle = B::Handle>,
+    FullPrecisionBackend<B>: ReprBackend<Handle = B::Handle>,
 {
     /// Start the server on the given address.
     pub async fn start(device: Device<B>, port: u16) {
@@ -189,8 +184,7 @@ where
 pub async fn start<B: ReprBackend>(device: Device<B>, port: u16)
 where
     // Restrict full precision backend handle to be the same
-    <<B as Backend>::FullPrecisionBridge as BackendBridge<B>>::Target:
-        ReprBackend<Handle = B::Handle>,
+    FullPrecisionBackend<B>: ReprBackend<Handle = B::Handle>,
 {
     WsServer::<B>::start(device, port).await;
 }

--- a/crates/burn-remote/src/server/processor.rs
+++ b/crates/burn-remote/src/server/processor.rs
@@ -1,6 +1,6 @@
 use burn_router::{Runner, RunnerClient};
 use burn_tensor::{
-    backend::{Backend, BackendBridge},
+    ops::FullPrecisionBackend,
     repr::{OperationDescription, ReprBackend, TensorDescription, TensorId},
     TensorData,
 };
@@ -29,8 +29,7 @@ pub enum ProcessorTask {
 impl<B: ReprBackend> Processor<B>
 where
     // Restrict full precision backend handle to be the same
-    <<B as Backend>::FullPrecisionBridge as BackendBridge<B>>::Target:
-        ReprBackend<Handle = B::Handle>,
+    FullPrecisionBackend<B>: ReprBackend<Handle = B::Handle>,
 {
     pub fn start(runner: Runner<B>) -> Sender<ProcessorTask> {
         let (sender, rec) = std::sync::mpsc::channel();

--- a/crates/burn-remote/src/server/session.rs
+++ b/crates/burn-remote/src/server/session.rs
@@ -1,7 +1,7 @@
 use burn_common::id::StreamId;
 use burn_router::Runner;
 use burn_tensor::{
-    backend::{Backend, BackendBridge},
+    ops::FullPrecisionBackend,
     repr::{ReprBackend, TensorDescription, TensorId, TensorStatus},
     Device,
 };
@@ -35,8 +35,7 @@ struct Session<B: ReprBackend> {
 impl<B: ReprBackend> SessionManager<B>
 where
     // Restrict full precision backend handle to be the same
-    <<B as Backend>::FullPrecisionBridge as BackendBridge<B>>::Target:
-        ReprBackend<Handle = B::Handle>,
+    FullPrecisionBackend<B>: ReprBackend<Handle = B::Handle>,
 {
     pub fn new(device: Device<B>) -> Self {
         Self {
@@ -117,8 +116,7 @@ where
 impl<B: ReprBackend> Session<B>
 where
     // Restrict full precision backend handle to be the same
-    <<B as Backend>::FullPrecisionBridge as BackendBridge<B>>::Target:
-        ReprBackend<Handle = B::Handle>,
+    FullPrecisionBackend<B>: ReprBackend<Handle = B::Handle>,
 {
     fn new(runner: Runner<B>) -> Self {
         let (sender, reveiver) = std::sync::mpsc::channel();

--- a/crates/burn-remote/src/server/session.rs
+++ b/crates/burn-remote/src/server/session.rs
@@ -1,11 +1,7 @@
 use burn_common::id::StreamId;
 use burn_common::stub::Mutex;
 use burn_router::Runner;
-use burn_tensor::{
-    ops::FullPrecisionBackend,
-    repr::ReprBackend,
-    Device,
-};
+use burn_tensor::{ops::FullPrecisionBackend, repr::ReprBackend, Device};
 use std::{
     collections::HashMap,
     sync::mpsc::{Receiver, SyncSender},

--- a/crates/burn-remote/src/server/session.rs
+++ b/crates/burn-remote/src/server/session.rs
@@ -2,9 +2,8 @@ use burn_common::id::StreamId;
 use burn_common::stub::Mutex;
 use burn_router::Runner;
 use burn_tensor::{
-    backend::{Backend, BackendBridge},
     ops::FullPrecisionBackend,
-    repr::{ReprBackend, TensorDescription, TensorId, TensorStatus},
+    repr::ReprBackend,
     Device,
 };
 use std::{

--- a/crates/burn-remote/src/server/session.rs
+++ b/crates/burn-remote/src/server/session.rs
@@ -2,9 +2,9 @@ use burn_common::id::StreamId;
 use burn_common::stub::Mutex;
 use burn_router::Runner;
 use burn_tensor::{
+    backend::{Backend, BackendBridge},
     ops::FullPrecisionBackend,
     repr::{ReprBackend, TensorDescription, TensorId, TensorStatus},
-    backend::{Backend, BackendBridge},
     Device,
 };
 use std::{

--- a/crates/burn-remote/src/server/stream.rs
+++ b/crates/burn-remote/src/server/stream.rs
@@ -6,7 +6,7 @@ use crate::shared::{ConnectionId, TaskResponse};
 use super::processor::{Processor, ProcessorTask};
 use burn_router::Runner;
 use burn_tensor::{
-    backend::{Backend, BackendBridge},
+    ops::FullPrecisionBackend,
     repr::{OperationDescription, ReprBackend, TensorDescription, TensorId},
     TensorData,
 };
@@ -23,8 +23,7 @@ pub struct Stream<B: ReprBackend> {
 impl<B: ReprBackend> Stream<B>
 where
     // Restrict full precision backend handle to be the same
-    <<B as Backend>::FullPrecisionBridge as BackendBridge<B>>::Target:
-        ReprBackend<Handle = B::Handle>,
+    FullPrecisionBackend<B>: ReprBackend<Handle = B::Handle>,
 {
     pub fn new(runner: Runner<B>, writer_sender: Sender<Receiver<TaskResponse>>) -> Self {
         let sender = Processor::start(runner);

--- a/crates/burn-router/src/runner.rs
+++ b/crates/burn-router/src/runner.rs
@@ -2,7 +2,7 @@ use alloc::{sync::Arc, vec::Vec};
 use spin::Mutex;
 
 use burn_tensor::{
-    backend::{Backend, BackendBridge},
+    backend::Backend,
     ops::FullPrecisionBackend,
     repr::{
         BaseOperationDescription, BoolOperationDescription, FloatOperationDescription,
@@ -55,8 +55,7 @@ pub struct Runner<B: ReprBackend> {
 impl<B: ReprBackend> Runner<B>
 where
     // Restrict full precision backend handle to be the same
-    <<B as Backend>::FullPrecisionBridge as BackendBridge<B>>::Target:
-        ReprBackend<Handle = B::Handle>,
+    FullPrecisionBackend<B>: ReprBackend<Handle = B::Handle>,
 {
     /// Create a new runner.
     pub fn new(device: B::Device) -> Self {
@@ -173,8 +172,7 @@ where
 impl<B: ReprBackend> RunnerClient for Runner<B>
 where
     // Restrict full precision backend handle to be the same
-    <<B as Backend>::FullPrecisionBridge as BackendBridge<B>>::Target:
-        ReprBackend<Handle = B::Handle>,
+    FullPrecisionBackend<B>: ReprBackend<Handle = B::Handle>,
 {
     type Device = B::Device;
 

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -16,7 +16,9 @@ use serde::{Serialize, Serializer};
 
 use crate::check::TensorCheck;
 use crate::tensor::api::narrow::narrow;
-use crate::{backend::Backend, check, Bool, Float, Int, Shape, TensorData, TensorKind};
+use crate::{
+    backend::Backend, check, ops::Device, Bool, Float, Int, Shape, TensorData, TensorKind,
+};
 use crate::{DType, Element, TensorPrimitive};
 
 /// A tensor with a given backend, shape and data type.
@@ -2308,14 +2310,14 @@ impl<B: Backend> BasicOps<B> for Float {
         }
     }
 
-    fn device(tensor: &Self::Primitive) -> <B as Backend>::Device {
+    fn device(tensor: &Self::Primitive) -> Device<B> {
         match tensor {
             TensorPrimitive::Float(tensor) => B::float_device(tensor),
             TensorPrimitive::QFloat(tensor) => B::q_device(tensor),
         }
     }
 
-    fn to_device(tensor: Self::Primitive, device: &<B as Backend>::Device) -> Self::Primitive {
+    fn to_device(tensor: Self::Primitive, device: &Device<B>) -> Self::Primitive {
         match tensor {
             TensorPrimitive::Float(tensor) => {
                 TensorPrimitive::Float(B::float_to_device(tensor, device))
@@ -2465,11 +2467,11 @@ impl<B: Backend> BasicOps<B> for Int {
         B::int_slice_assign(tensor, ranges, value)
     }
 
-    fn device(tensor: &Self::Primitive) -> <B as Backend>::Device {
+    fn device(tensor: &Self::Primitive) -> Device<B> {
         B::int_device(tensor)
     }
 
-    fn to_device(tensor: Self::Primitive, device: &<B as Backend>::Device) -> Self::Primitive {
+    fn to_device(tensor: Self::Primitive, device: &Device<B>) -> Self::Primitive {
         B::int_to_device(tensor, device)
     }
 
@@ -2564,11 +2566,11 @@ impl<B: Backend> BasicOps<B> for Bool {
         B::bool_slice_assign(tensor, ranges, value)
     }
 
-    fn device(tensor: &Self::Primitive) -> <B as Backend>::Device {
+    fn device(tensor: &Self::Primitive) -> Device<B> {
         B::bool_device(tensor)
     }
 
-    fn to_device(tensor: Self::Primitive, device: &<B as Backend>::Device) -> Self::Primitive {
+    fn to_device(tensor: Self::Primitive, device: &Device<B>) -> Self::Primitive {
         B::bool_to_device(tensor, device)
     }
 

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -4,8 +4,12 @@ use crate::alloc::borrow::ToOwned;
 
 use crate::TensorPrimitive;
 use crate::{
-    backend::Backend, check, check::TensorCheck, BasicOps, Bool, Distribution, Element,
-    ElementConversion, Float, Int, Shape, Tensor, TensorKind,
+    backend::Backend,
+    check,
+    check::TensorCheck,
+    ops::{Device, IntTensor},
+    BasicOps, Bool, Distribution, Element, ElementConversion, Float, Int, Shape, Tensor,
+    TensorKind,
 };
 
 impl<B, const D: usize, K> Tensor<B, D, K>
@@ -2273,11 +2277,11 @@ impl<B: Backend> Numeric<B> for Int {
         B::int_scatter(dim, tensor, indices, values)
     }
 
-    fn argmax(tensor: Self::Primitive, dim: usize) -> <B as Backend>::IntTensorPrimitive {
+    fn argmax(tensor: Self::Primitive, dim: usize) -> IntTensor<B> {
         B::int_argmax(tensor, dim)
     }
 
-    fn argmin(tensor: Self::Primitive, dim: usize) -> <B as Backend>::IntTensorPrimitive {
+    fn argmin(tensor: Self::Primitive, dim: usize) -> IntTensor<B> {
         B::int_argmin(tensor, dim)
     }
 
@@ -2292,7 +2296,7 @@ impl<B: Backend> Numeric<B> for Int {
     fn max_dim_with_indices(
         tensor: Self::Primitive,
         dim: usize,
-    ) -> (Self::Primitive, <B as Backend>::IntTensorPrimitive) {
+    ) -> (Self::Primitive, IntTensor<B>) {
         B::int_max_dim_with_indices(tensor, dim)
     }
 
@@ -2307,7 +2311,7 @@ impl<B: Backend> Numeric<B> for Int {
     fn min_dim_with_indices(
         tensor: Self::Primitive,
         dim: usize,
-    ) -> (Self::Primitive, <B as Backend>::IntTensorPrimitive) {
+    ) -> (Self::Primitive, IntTensor<B>) {
         B::int_min_dim_with_indices(tensor, dim)
     }
 
@@ -2346,11 +2350,7 @@ impl<B: Backend> Numeric<B> for Int {
         B::int_powf_scalar(lhs, rhs.elem())
     }
 
-    fn random(
-        shape: Shape,
-        distribution: Distribution,
-        device: &<B as Backend>::Device,
-    ) -> Self::Primitive {
+    fn random(shape: Shape, distribution: Distribution, device: &Device<B>) -> Self::Primitive {
         B::int_random(shape, distribution, device)
     }
 
@@ -2689,14 +2689,14 @@ impl<B: Backend> Numeric<B> for Float {
         }
     }
 
-    fn argmax(tensor: Self::Primitive, dim: usize) -> <B as Backend>::IntTensorPrimitive {
+    fn argmax(tensor: Self::Primitive, dim: usize) -> IntTensor<B> {
         match tensor {
             TensorPrimitive::Float(tensor) => B::float_argmax(tensor, dim),
             TensorPrimitive::QFloat(tensor) => B::q_argmax(tensor, dim),
         }
     }
 
-    fn argmin(tensor: Self::Primitive, dim: usize) -> <B as Backend>::IntTensorPrimitive {
+    fn argmin(tensor: Self::Primitive, dim: usize) -> IntTensor<B> {
         match tensor {
             TensorPrimitive::Float(tensor) => B::float_argmin(tensor, dim),
             TensorPrimitive::QFloat(tensor) => B::q_argmin(tensor, dim),
@@ -2720,7 +2720,7 @@ impl<B: Backend> Numeric<B> for Float {
     fn max_dim_with_indices(
         tensor: Self::Primitive,
         dim: usize,
-    ) -> (Self::Primitive, <B as Backend>::IntTensorPrimitive) {
+    ) -> (Self::Primitive, IntTensor<B>) {
         match tensor {
             TensorPrimitive::Float(tensor) => {
                 let (values, indices) = B::float_max_dim_with_indices(tensor, dim);
@@ -2750,7 +2750,7 @@ impl<B: Backend> Numeric<B> for Float {
     fn min_dim_with_indices(
         tensor: Self::Primitive,
         dim: usize,
-    ) -> (Self::Primitive, <B as Backend>::IntTensorPrimitive) {
+    ) -> (Self::Primitive, IntTensor<B>) {
         match tensor {
             TensorPrimitive::Float(tensor) => {
                 let (values, indices) = B::float_min_dim_with_indices(tensor, dim);
@@ -2845,11 +2845,7 @@ impl<B: Backend> Numeric<B> for Float {
         }
     }
 
-    fn random(
-        shape: Shape,
-        distribution: Distribution,
-        device: &<B as Backend>::Device,
-    ) -> Self::Primitive {
+    fn random(shape: Shape, distribution: Distribution, device: &Device<B>) -> Self::Primitive {
         TensorPrimitive::Float(B::float_random(shape, distribution, device))
     }
 


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ ] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

I'm getting some linker errors but I don't think they're due to the change:
```
~/FunCode/burn_fork/burn/target/debug/deps/train-7e34297544b4ef5b" "-Wl,-dead_strip" "-nodefaultlibs"
  = note: ld: warning: ignoring duplicate libraries: '-lSystem', '-lc'
          ld: multiple errors: unknown file type in '~/FunCode/burn_fork/libtorch/lib/libtorch_cpu.so'; unknown file type in '/~/FunCode/burn_fork/libtorch/lib/libc10.so'; unknown file type in '~/FunCode/burn_fork/libtorch/lib/libtorch.so'
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

### Related Issues/PRs

No issues, just something I noticed could maybe be improved since we're not super consistent about which type naming to use

### Changes

No issues, just something I noticed could maybe be improved since we're not super consistent about which type naming to use

### Testing

Just type renaming and linter seemed to think it made sense.
