### PR TITLE
Make .init() method of LR schedulers return Result

### DIFF
--- a/crates/burn-core/src/lr_scheduler/base.rs
+++ b/crates/burn-core/src/lr_scheduler/base.rs
@@ -1,3 +1,5 @@
+pub(super) use alloc::string::String;
+
 use burn_tensor::backend::Backend;
 
 use crate::{record::Record, LearningRate};

--- a/examples/text-classification/src/training.rs
+++ b/examples/text-classification/src/training.rs
@@ -88,7 +88,8 @@ pub fn train<B: AutodiffBackend, D: TextClassificationDataset + 'static>(
     let lr_scheduler = NoamLrSchedulerConfig::new(1e-2)
         .with_warmup_steps(1000)
         .with_model_size(config.transformer.d_model)
-        .init();
+        .init()
+        .unwrap();
 
     // Initialize learner
     let learner = LearnerBuilder::new(artifact_dir)

--- a/examples/text-generation/src/training.rs
+++ b/examples/text-generation/src/training.rs
@@ -66,7 +66,8 @@ pub fn train<B: AutodiffBackend, D: Dataset<TextGenerationItem> + 'static>(
     let lr_scheduler = NoamLrSchedulerConfig::new(0.01 / accum as f64)
         .with_warmup_steps(6000)
         .with_model_size(config.transformer.d_model)
-        .init();
+        .init()
+        .unwrap();
 
     let learner = LearnerBuilder::new(artifact_dir)
         .metric_train(CudaMetric::new())


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

`run-checks` script was executed with `DISABLE_WGPU=1`, because otherwise I would get an unrelated error  similar to #1477.

### Related Issues/PRs

Fix #2510

### Changes

* Make `.init()` method of LR schedulers return `Result` instead of panicking for invalid configuration.
Add check and test code for Noam LR scheduler accordingly.
`ConstantLr` is not changed because there is nothing to check.

* Update affected examples (text-generation & text-classification).

* Clean up related test code (eliminate unnecessary constants and helper function)


### Testing

* Ensured that `DISABLE_WGPU=1 bash ./run-checks.sh` ran with no error
* Checked documentation by reading it in a browser
* Confirmed by grep-ing "scheduler" in the source code that the Books were not affected