### PR TITLE
Infer convolution kernel shape from weight

### DIFF
--- a/crates/burn-import/src/onnx/op_configuration.rs
+++ b/crates/burn-import/src/onnx/op_configuration.rs
@@ -42,6 +42,10 @@ pub fn conv1d_config(curr: &Node) -> Conv1dConfig {
         }
     }
 
+    if kernel_shape.is_empty() {
+        kernel_shape = onnx_ir::util::infer_conv_kernel_shape(&curr.inputs[1].ty);
+    }
+
     // the channels are inverted in the weight tensor
     let shape = weight.shape.clone().unwrap();
     let channels_in = shape[1] * group;
@@ -83,6 +87,10 @@ pub fn conv2d_config(curr: &Node) -> Conv2dConfig {
             "group" => group = value.clone().into_i64() as usize,
             _ => {}
         }
+    }
+
+    if kernel_shape.is_empty() {
+        kernel_shape = onnx_ir::util::infer_conv_kernel_shape(&curr.inputs[1].ty);
     }
 
     // the channels are inverted in the weight tensor
@@ -128,6 +136,10 @@ pub fn conv3d_config(curr: &Node) -> Conv3dConfig {
             "group" => group = value.clone().into_i64() as usize,
             _ => {}
         }
+    }
+
+    if kernel_shape.is_empty() {
+        kernel_shape = onnx_ir::util::infer_conv_kernel_shape(&curr.inputs[1].ty);
     }
 
     // the channels are inverted in the weight tensor

--- a/crates/onnx-ir/src/lib.rs
+++ b/crates/onnx-ir/src/lib.rs
@@ -5,7 +5,7 @@ pub mod ir;
 mod node_remap;
 mod proto_conversion;
 mod protos;
-mod util;
+pub mod util;
 
 pub use from_onnx::convert_constant_value;
 pub use from_onnx::parse_onnx;

--- a/crates/onnx-ir/src/node_remap.rs
+++ b/crates/onnx-ir/src/node_remap.rs
@@ -1,3 +1,5 @@
+use crate::util::infer_conv_kernel_shape;
+
 use super::ir::{AttributeValue, Node, NodeType};
 
 /// Remap node type using kernel shape
@@ -5,10 +7,16 @@ pub fn remap_node_with_kernel_shape<F>(node: &mut Node, new_node_type: F)
 where
     F: FnOnce(&Vec<i64>) -> NodeType,
 {
-    if let AttributeValue::Int64s(ints) = node.attrs.get("kernel_shape").unwrap() {
-        node.node_type = new_node_type(ints);
+    if let Some(kernel_shape) = node.attrs.get("kernel_shape") {
+        if let AttributeValue::Int64s(ints) = kernel_shape {
+            node.node_type = new_node_type(ints);
+        } else {
+            panic!("kernel_shape is not an int64s");
+        }
     } else {
-        panic!("kernel_shape is not an int64s");
+        // Handle conv where "kernel_shape" is optional and can be inferred from weights
+        let kernel_shape = infer_conv_kernel_shape(&node.inputs[1].ty);
+        node.node_type = new_node_type(&kernel_shape);
     }
 }
 

--- a/crates/onnx-ir/src/util.rs
+++ b/crates/onnx-ir/src/util.rs
@@ -81,3 +81,14 @@ pub fn shape_config(curr: &Node) -> (usize, usize) {
 
     (start_dim as usize, end_dim as usize)
 }
+
+/// Infer convolution kernel shape from weight
+pub fn infer_conv_kernel_shape(w: &ArgType) -> Vec<i64> {
+    if let ArgType::Tensor(tensor) = w {
+        // Weight [out_channels, in_channels, kernel size...]
+        let shape = &tensor.shape.as_ref().unwrap()[2..];
+        shape.iter().map(|x| *x as i64).collect()
+    } else {
+        panic!("Cannot infer kernel shape");
+    }
+}


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `run-checks all` script has been executed.

### Related Issues/PRs

Fixes #2430 

### Changes

Infer convolution kernel shape from weights (in line with ONNX spec)
