### PR TITLE
Add `QTensorOps` docs + refactor tests to simplify inputs

### DIFF
--- a/contributor-book/src/guides/adding-a-new-operation-to-burn.md
+++ b/contributor-book/src/guides/adding-a-new-operation-to-burn.md
@@ -79,11 +79,12 @@ previous section). Tests for `q_*` ops follow a similar procedure: the test is a
 the module name is inserted into `crates/burn-tensor/src/tests/quantization/ops/mod.rs` and finally
 the test is added to the
 [`testgen_quantization` macro](https://github.com/tracel-ai/burn/blob/a6a5c22e0db56d947b9165d4dae42783a5a6b689/crates/burn-tensor/src/tests/mod.rs#L67).
-If you take a look at any of the existing tests for an operation on a quantized tensor (e.g.,
-[`q_add`](https://github.com/tracel-ai/burn/blob/a6a5c22e0db56d947b9165d4dae42783a5a6b689/crates/burn-tensor/src/tests/quantization/ops/add.rs)),
+If you take a look at any of the existing tests for an operation on a quantized tensor,
 you will see that the inputs and expected outputs are always defined with floating point values.
 While it assumes that the quantization and dequantization are correct, it makes the tests much more
-readable and easier to understand w.r.t. what is being tested.
+readable and easier to understand w.r.t. what is being tested. Effectively, the tests are there to
+ensure that a tensor operation is invariant to quantization (up to some quantization error, of
+course).
 
 _Note: the tests try to use tensors with floating point values which can be de/quantized without
 introducing too much quantization error, but the result always depends on the operation (e.g.,

--- a/crates/burn-tensor/src/tensor/quantization/scheme.rs
+++ b/crates/burn-tensor/src/tensor/quantization/scheme.rs
@@ -45,7 +45,10 @@ impl QuantizationScheme {
                     let zero = Tensor::zeros_like(&range.max);
                     let max = range.max.max_pair(zero);
 
+                    // If scale is 0 (most likely due to a tensor full of zeros), we arbitrarily adjust the
+                    // scale to 0.1 to avoid division by zero.
                     let scale = max.sub(min.clone()).div_scalar(b - a);
+                    let scale = scale.clone().mask_fill(scale.equal_elem(0.), 0.1);
                     let offset = Some(-(min.div(scale.clone()).sub_scalar(a)).int());
                     QuantizationParameters { scale, offset }
                 }

--- a/crates/burn-tensor/src/tests/mod.rs
+++ b/crates/burn-tensor/src/tests/mod.rs
@@ -108,7 +108,7 @@ macro_rules! testgen_quantization {
         burn_tensor::testgen_q_sin!();
         burn_tensor::testgen_q_slice!();
         burn_tensor::testgen_q_sort_argsort!();
-        // burn_tensor::testgen_q_split!();
+        burn_tensor::testgen_q_split!();
         burn_tensor::testgen_q_sqrt!();
         burn_tensor::testgen_q_stack!();
         burn_tensor::testgen_q_sub!();

--- a/crates/burn-tensor/src/tests/mod.rs
+++ b/crates/burn-tensor/src/tests/mod.rs
@@ -66,6 +66,42 @@ macro_rules! testgen_all {
 #[macro_export]
 macro_rules! testgen_quantization {
     () => {
+        // Quantized tensor utilities
+        pub mod qtensor {
+            use core::marker::PhantomData;
+
+            use burn_tensor::{
+                backend::Backend,
+                quantization::{QuantizationScheme, QuantizationType},
+                Tensor, TensorData,
+            };
+
+            pub struct QTensor<B: Backend, const D: usize> {
+                b: PhantomData<B>,
+            }
+
+            impl<B: Backend, const D: usize> QTensor<B, D> {
+                /// Creates a quantized int8 tensor from the floating point data using the default quantization scheme
+                /// (i.e., per-tensor symmetric quantization).
+                pub fn int8<F: Into<TensorData>>(floats: F) -> Tensor<B, D> {
+                    Self::int8_symmetric(floats)
+                }
+                /// Creates a quantized int8 tensor from the floating point data using per-tensor symmetric quantization.
+                pub fn int8_symmetric<F: Into<TensorData>>(floats: F) -> Tensor<B, D> {
+                    Tensor::from_floats(floats, &Default::default()).quantize_dynamic(
+                        &QuantizationScheme::PerTensorSymmetric(QuantizationType::QInt8),
+                    )
+                }
+                /// Creates a quantized int8 tensor from the floating point data using per-tensor affine quantization.
+                pub fn int8_affine<F: Into<TensorData>>(floats: F) -> Tensor<B, D> {
+                    Tensor::from_floats(floats, &Default::default()).quantize_dynamic(
+                        &QuantizationScheme::PerTensorAffine(QuantizationType::QInt8),
+                    )
+                }
+            }
+        }
+        pub use qtensor::*;
+
         // test quantization
         burn_tensor::testgen_calibration!();
         burn_tensor::testgen_scheme!();
@@ -104,6 +140,7 @@ macro_rules! testgen_quantization {
         burn_tensor::testgen_q_remainder!();
         burn_tensor::testgen_q_repeat_dim!();
         burn_tensor::testgen_q_reshape!();
+        burn_tensor::testgen_q_round!();
         burn_tensor::testgen_q_select!();
         burn_tensor::testgen_q_sin!();
         burn_tensor::testgen_q_slice!();

--- a/crates/burn-tensor/src/tests/quantization/ops/abs.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/abs.rs
@@ -1,18 +1,11 @@
 #[burn_tensor_testgen::testgen(q_abs)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{QuantizationStrategy, SymmetricQuantization};
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::TensorData;
 
     #[test]
     fn should_support_abs_ops() {
-        // Quantized [[0.0, -1.0, 2.0], [3.0, 4.0, -5.0]]
-        let data = TensorData::quantized(
-            vec![0i8, -25, 51, 76, 102, -127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, -1.0, 2.0], [3.0, 4.0, -5.0]]);
 
         let output = tensor.abs();
 

--- a/crates/burn-tensor/src/tests/quantization/ops/add.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/add.rs
@@ -1,25 +1,12 @@
 #[burn_tensor_testgen::testgen(q_add)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{QuantizationStrategy, SymmetricQuantization};
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::TensorData;
 
     #[test]
     fn test_add_d2() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &Default::default());
-        // Quantized [[6.0, 7.0, 8.0], [9.0, 10.0, 11.0]]
-        let data = TensorData::quantized(
-            vec![69i8, 81, 92, 104, 115, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.08661418)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor_1 = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8([[6.0, 7.0, 8.0], [9.0, 10.0, 11.0]]);
 
         let output = tensor_1 + tensor_2;
 
@@ -32,20 +19,8 @@ mod tests {
 
     #[test]
     fn test_add_broadcast() {
-        // Quantized [[0.0, 1.0, 2.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 64, 127],
-            [1, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.015748031)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &Default::default());
-        // Quantized [[3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]
-        let data = TensorData::quantized(
-            vec![48i8, 64, 79, 95, 111, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.062992126)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor_1 = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8([[3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]);
 
         let output = tensor_1 + tensor_2;
 
@@ -58,22 +33,10 @@ mod tests {
 
     #[test]
     fn test_add_different_strides_rhs() {
-        // Quantized [[0.0, 1.0], [2.0, 3.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 42, 85, 127],
-            [2, 2],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.023622047)),
-        );
         // We need to execute an operation after `from data` to trigger inplace in some backends.
         // Which is the operation that might be problematic in this case.
-        let tensor_1 = TestTensor::<2>::from_data(data, &Default::default()) * 1;
-        // Quantized [[4.0, 5.0], [6.0, 7.0]]
-        let data = TensorData::quantized(
-            vec![73i8, 91, 109, 127],
-            [2, 2],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.05511811)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data, &Default::default()) * 1;
+        let tensor_1 = QTensor::<TestBackend, 2>::int8([[0.0, 1.0], [2.0, 3.0]]) * 1;
+        let tensor_2 = QTensor::<TestBackend, 2>::int8([[4.0, 5.0], [6.0, 7.0]]) * 1;
 
         let output = tensor_1 + tensor_2.transpose();
 
@@ -86,22 +49,10 @@ mod tests {
 
     #[test]
     fn test_add_different_strides_lhs() {
-        // Quantized [[0.0, 1.0], [2.0, 3.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 42, 85, 127],
-            [2, 2],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.023622047)),
-        );
         // We need to execute an operation after `from data` to trigger inplace in some backends.
         // Which is the operation that might be problematic in this case.
-        let tensor_1 = TestTensor::<2>::from_data(data, &Default::default()) * 1;
-        // Quantized [[4.0, 5.0], [6.0, 7.0]]
-        let data = TensorData::quantized(
-            vec![73i8, 91, 109, 127],
-            [2, 2],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.05511811)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data, &Default::default()) * 1;
+        let tensor_1 = QTensor::<TestBackend, 2>::int8([[0.0, 1.0], [2.0, 3.0]]) * 1;
+        let tensor_2 = QTensor::<TestBackend, 2>::int8([[4.0, 5.0], [6.0, 7.0]]) * 1;
 
         let output = tensor_1.transpose() + tensor_2;
 
@@ -114,22 +65,10 @@ mod tests {
 
     #[test]
     fn test_add_different_strides_broadcast() {
-        // Quantized [[0.0, 1.0], [2.0, 3.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 42, 85, 127],
-            [2, 2],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.023622047)),
-        );
         // We need to execute an operation after `from data` to trigger inplace in some backends.
         // Which is the operation that might be problematic in this case.
-        let tensor_1 = TestTensor::<2>::from_data(data, &Default::default()) * 1;
-        // Quantized [[4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![102i8, 127],
-            [1, 2],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data, &Default::default()) * 1;
+        let tensor_1 = QTensor::<TestBackend, 2>::int8([[0.0, 1.0], [2.0, 3.0]]) * 1;
+        let tensor_2 = QTensor::<TestBackend, 2>::int8([[4.0, 5.0]]) * 1;
 
         let output = tensor_1.transpose() + tensor_2;
 
@@ -143,13 +82,7 @@ mod tests {
     #[test]
     fn should_support_add_scalar_ops() {
         let scalar = 2.0;
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor + scalar;
 

--- a/crates/burn-tensor/src/tests/quantization/ops/aggregation.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/aggregation.rs
@@ -130,7 +130,6 @@ mod tests {
             QTensor::<TestBackend, 2>::int8_affine([[2.0, 0.0, 2.0], [3.0, 4.0, 5.0]]);
         let output = tensor_with_zero.prod();
 
-        println!("wut");
         output
             .dequantize()
             .into_data()

--- a/crates/burn-tensor/src/tests/quantization/ops/aggregation.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/aggregation.rs
@@ -1,20 +1,11 @@
 #[burn_tensor_testgen::testgen(q_aggregation)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{
-        AffineQuantization, QuantizationStrategy, SymmetricQuantization,
-    };
-    use burn_tensor::{Shape, Tensor, TensorData};
+    use burn_tensor::TensorData;
 
     #[test]
     fn test_should_mean() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.mean();
 
@@ -27,13 +18,7 @@ mod tests {
 
     #[test]
     fn test_should_sum() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.sum();
 
@@ -46,13 +31,7 @@ mod tests {
 
     #[test]
     fn test_should_mean_last_dim() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.mean_dim(1);
         let expected = TensorData::from([[3.0 / 3.0], [12.0 / 3.0]]);
@@ -66,13 +45,7 @@ mod tests {
 
     #[test]
     fn test_should_sum_last_dim() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.sum_dim(1);
 
@@ -85,13 +58,7 @@ mod tests {
 
     #[test]
     fn test_should_sum_first_dim() {
-        // Quantized [[3.0, 1.0, 2.0], [4.0, 2.0, 3.0]]
-        let data = TensorData::quantized(
-            vec![95i8, 32, 64, 127, 64, 95],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.031496063)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[3.0, 1.0, 2.0], [4.0, 2.0, 3.0]]);
 
         let output = tensor.sum_dim(0);
 
@@ -104,13 +71,7 @@ mod tests {
 
     #[test]
     fn test_should_mean_first_dim() {
-        // Quantized [[3.0, 1.0, 2.0], [4.0, 2.0, 3.0]]
-        let data = TensorData::quantized(
-            vec![95i8, 32, 64, 127, 64, 95],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.031496063)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[3.0, 1.0, 2.0], [4.0, 2.0, 3.0]]);
 
         let output = tensor.mean_dim(0);
 
@@ -123,16 +84,10 @@ mod tests {
 
     #[test]
     fn test_should_sum_mid_dim_3d_non_contiguous_1() {
-        // Quantized [
-        //     [[2.0, 4.0, 1.0], [7.0, -5.0, 3.0]],
-        //     [[3.0, 1.0, 2.0], [4.0, 2.0, 3.0]],
-        // ]
-        let data = TensorData::quantized(
-            vec![36i8, 73, 18, 127, -91, 54, 54, 18, 36, 73, 36, 54],
-            [2, 2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.05511811)),
-        );
-        let tensor = TestTensor::<3>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 3>::int8([
+            [[2.0, 4.0, 1.0], [7.0, -5.0, 3.0]],
+            [[3.0, 1.0, 2.0], [4.0, 2.0, 3.0]],
+        ]);
 
         let output = tensor.swap_dims(0, 2).sum_dim(1);
 
@@ -145,16 +100,10 @@ mod tests {
 
     #[test]
     fn test_should_sum_mid_dim_3d_non_contiguous_2() {
-        // Quantized [
-        //     [[2.0, 4.0, 1.0], [7.0, -5.0, 3.0]],
-        //     [[3.0, 1.0, 2.0], [4.0, 2.0, 3.0]],
-        // ]
-        let data = TensorData::quantized(
-            vec![36i8, 73, 18, 127, -91, 54, 54, 18, 36, 73, 36, 54],
-            [2, 2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.05511811)),
-        );
-        let tensor = TestTensor::<3>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 3>::int8([
+            [[2.0, 4.0, 1.0], [7.0, -5.0, 3.0]],
+            [[3.0, 1.0, 2.0], [4.0, 2.0, 3.0]],
+        ]);
 
         let output = tensor.swap_dims(0, 1).sum_dim(1);
 
@@ -167,14 +116,9 @@ mod tests {
 
     #[test]
     fn test_prod_float() {
-        // Quantized [[2.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
         // NOTE: we use affine quantization to reduce quantization errors since `prod()` amplifies the error
-        let data = TensorData::quantized(
-            vec![-26i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[2.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+
         let output = tensor.prod();
 
         output
@@ -182,15 +126,11 @@ mod tests {
             .into_data()
             .assert_approx_eq(&TensorData::from([240.0]), 3);
 
-        // Quantized [[2.0, 0.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![51i8, 0, 51, 76, 102, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor_with_zero = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor_with_zero =
+            QTensor::<TestBackend, 2>::int8_affine([[2.0, 0.0, 2.0], [3.0, 4.0, 5.0]]);
         let output = tensor_with_zero.prod();
 
+        println!("wut");
         output
             .dequantize()
             .into_data()
@@ -199,14 +139,9 @@ mod tests {
 
     #[test]
     fn test_prod_dim_float() {
-        // Quantized [[2.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
         // NOTE: we use affine quantization to reduce quantization errors since `prod()` amplifies the error
-        let data = TensorData::quantized(
-            vec![-26i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[2.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+
         let output = tensor.prod_dim(1);
 
         // Precision 1 to approximate de/quantization errors
@@ -215,13 +150,8 @@ mod tests {
             .into_data()
             .assert_approx_eq(&TensorData::from([[4.0], [60.0]]), 1);
 
-        // Quantized [[2.0, 0.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-26i8, -128, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor_with_zero = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor_with_zero =
+            QTensor::<TestBackend, 2>::int8_affine([[2.0, 0.0, 2.0], [3.0, 4.0, 5.0]]);
         let output = tensor_with_zero.prod_dim(1);
         let expected = TensorData::from([[0.0], [60.0]]);
 

--- a/crates/burn-tensor/src/tests/quantization/ops/all.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/all.rs
@@ -1,29 +1,16 @@
 #[burn_tensor_testgen::testgen(q_all)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{QuantizationStrategy, SymmetricQuantization};
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::TensorData;
 
     #[test]
     fn test_all() {
-        // Quantized [[0.0, 1.0, 0.0], [1.0, -1.0, 1.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 127, 0, 127, -127, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.007874016)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 0.0], [1.0, -1.0, 1.0]]);
         let data_actual = tensor.all().into_data();
         let data_expected = TensorData::from([false]);
         assert_eq!(data_expected, data_actual);
 
-        // Quantized [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]
-        let data = TensorData::quantized(
-            vec![127i8, 127, 127, 127, 127, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.007874016)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]);
         let data_actual = tensor.all().into_data();
         let data_expected = TensorData::from([true]);
         assert_eq!(data_expected, data_actual);
@@ -31,13 +18,7 @@ mod tests {
 
     #[test]
     fn test_all_dim() {
-        // Quantized [[0.0, 1.0, 0.0], [1.0, -1.0, 1.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 127, 0, 127, -127, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.007874016)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 0.0], [1.0, -1.0, 1.0]]);
         let data_actual = tensor.all_dim(1).into_data();
         let data_expected = TensorData::from([[false], [true]]);
         assert_eq!(data_expected, data_actual);

--- a/crates/burn-tensor/src/tests/quantization/ops/any.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/any.rs
@@ -1,31 +1,16 @@
 #[burn_tensor_testgen::testgen(q_any)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{QuantizationStrategy, SymmetricQuantization};
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::TensorData;
 
     #[test]
     fn test_any() {
-        // Quantized [[0.0, 0.0, 0.0], [1.0, -1.0, 0.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 0, 0, 127, -127, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.007874016)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
-
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 0.0, 0.0], [1.0, -1.0, 0.0]]);
         let data_actual = tensor.any().into_data();
         let data_expected = TensorData::from([true]);
         assert_eq!(data_expected, data_actual);
 
-        // Quantized [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 0, 0, 0, 0, 0],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.007874016)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
-
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]);
         let data_actual = tensor.any().into_data();
         let data_expected = TensorData::from([false]);
         assert_eq!(data_expected, data_actual);
@@ -33,13 +18,7 @@ mod tests {
 
     #[test]
     fn test_any_dim() {
-        // Quantized [[0.0, 0.0, 0.0], [1.0, -1.0, 0.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 0, 0, 127, -127, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.007874016)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 0.0, 0.0], [1.0, -1.0, 0.0]]);
 
         let data_actual = tensor.any_dim(1).into_data();
         let data_expected = TensorData::from([[false], [true]]);

--- a/crates/burn-tensor/src/tests/quantization/ops/arg.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/arg.rs
@@ -1,18 +1,11 @@
 #[burn_tensor_testgen::testgen(q_arg)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{QuantizationStrategy, SymmetricQuantization};
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::TensorData;
 
     #[test]
     fn test_argmax_2d_dim0() {
-        // Quantized [[10.0, 11.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![115i8, 127, 23, 35, 46, 58],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.08661418)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[10.0, 11.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.argmax(0);
 
@@ -23,13 +16,7 @@ mod tests {
 
     #[test]
     fn test_argmin_2d_dim0() {
-        // Quantized [[10.0, 11.0, 2.0], [30.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![42i8, 47, 8, 127, 17, 21],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.23622048)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[10.0, 11.0, 2.0], [30.0, 4.0, 5.0]]);
 
         let output = tensor.argmin(0);
 
@@ -40,13 +27,7 @@ mod tests {
 
     #[test]
     fn test_argmax_2d_dim1() {
-        // Quantized [[10.0, 11.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![115i8, 127, 23, 35, 46, 58],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.08661418)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[10.0, 11.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.argmax(1);
 
@@ -57,13 +38,7 @@ mod tests {
 
     #[test]
     fn test_argmin_2d_dim1() {
-        // Quantized [[10.0, 11.0, 2.0], [30.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![42i8, 47, 8, 127, 17, 21],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.23622048)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[10.0, 11.0, 2.0], [30.0, 4.0, 5.0]]);
 
         let output = tensor.argmin(1);
 

--- a/crates/burn-tensor/src/tests/quantization/ops/cat.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/cat.rs
@@ -1,27 +1,13 @@
 #[burn_tensor_testgen::testgen(q_cat)]
 mod tests {
     use super::*;
-    use alloc::vec::Vec;
-    use burn_tensor::quantization::{QuantizationStrategy, SymmetricQuantization};
-    use burn_tensor::{Bool, Int, Tensor, TensorData};
+    use alloc::vec;
+    use burn_tensor::TensorData;
 
     #[test]
     fn should_support_cat_ops_2d_dim0() {
-        let device = Default::default();
-        // Quantized [[1.0, 2.0, 3.0]]
-        let data = TensorData::quantized(
-            vec![42i8, 85, 127],
-            [1, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.023622047)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &device);
-        // Quantized [[4.0, 5.0, 6.0]]
-        let data = TensorData::quantized(
-            vec![85i8, 106, 127],
-            [1, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.047244094)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data, &device);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8([[1.0, 2.0, 3.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8([[4.0, 5.0, 6.0]]);
 
         let output = TestTensor::cat(vec![tensor_1, tensor_2], 0);
         let expected = TensorData::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
@@ -35,21 +21,8 @@ mod tests {
 
     #[test]
     fn should_support_cat_ops_2d_dim1() {
-        let device = Default::default();
-        // Quantized [[1.0, 2.0, 3.0]]
-        let data = TensorData::quantized(
-            vec![42i8, 85, 127],
-            [1, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.023622047)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &device);
-        // Quantized [[4.0, 5.0, 6.0]]
-        let data = TensorData::quantized(
-            vec![85i8, 106, 127],
-            [1, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.047244094)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data, &device);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8([[1.0, 2.0, 3.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8([[4.0, 5.0, 6.0]]);
 
         let output = TestTensor::cat(vec![tensor_1, tensor_2], 1);
         let expected = TensorData::from([[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]]);
@@ -63,21 +36,8 @@ mod tests {
 
     #[test]
     fn should_support_cat_ops_3d() {
-        let device = Default::default();
-        // Quantized [[[1.0, 2.0, 3.0]], [[1.1, 2.1, 3.1]]]
-        let data = TensorData::quantized(
-            vec![41i8, 82, 123, 45, 86, 127],
-            [2, 1, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.024409449)),
-        );
-        let tensor_1 = TestTensor::<3>::from_data(data, &device);
-        // Quantized [[4.0, 5.0, 6.0]]
-        let data = TensorData::quantized(
-            vec![85i8, 106, 127],
-            [1, 1, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.047244094)),
-        );
-        let tensor_2 = TestTensor::<3>::from_data(data, &device);
+        let tensor_1 = QTensor::<TestBackend, 3>::int8([[[1.0, 2.0, 3.0]], [[1.1, 2.1, 3.1]]]);
+        let tensor_2 = QTensor::<TestBackend, 3>::int8([[[4.0, 5.0, 6.0]]]);
 
         let output = TestTensor::cat(vec![tensor_1, tensor_2], 0);
         let expected = TensorData::from([[[1.0, 2.0, 3.0]], [[1.1, 2.1, 3.1]], [[4.0, 5.0, 6.0]]]);
@@ -92,23 +52,8 @@ mod tests {
     #[test]
     #[should_panic]
     fn should_panic_when_dimensions_are_not_the_same() {
-        let device = Default::default();
-        // Quantized [[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]]
-        let data = TensorData::quantized(
-            vec![42i8, 85, 127, 42, 85, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.023622047)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &device);
-        // Quantized [[4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![102i8, 127],
-            [2, 1],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data, &device);
-        let tensor_1 = TestTensor::<2>::from_data([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]], &device);
-        let tensor_2 = TestTensor::from_data([[4.0, 5.0]], &device);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8([[4.0, 5.0]]);
 
         let output = TestTensor::cat(vec![tensor_1, tensor_2], 0);
     }
@@ -116,21 +61,8 @@ mod tests {
     #[test]
     #[should_panic]
     fn should_panic_when_cat_exceeds_dimension() {
-        let device = Default::default();
-        // Quantized [[1.0, 2.0, 3.0]]
-        let data = TensorData::quantized(
-            vec![42i8, 85, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.023622047)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &device);
-        // Quantized [[4.0, 5.0, 6.0]]
-        let data = TensorData::quantized(
-            vec![85i8, 106, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.047244094)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data, &device);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8([[1.0, 2.0, 3.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8([[4.0, 5.0, 6.0]]);
 
         let output = TestTensor::cat(vec![tensor_1, tensor_2], 3);
     }

--- a/crates/burn-tensor/src/tests/quantization/ops/ceil.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/ceil.rs
@@ -1,21 +1,14 @@
 #[burn_tensor_testgen::testgen(q_ceil)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{AffineQuantization, QuantizationStrategy};
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::TensorData;
 
     #[test]
     fn should_support_ceil_ops() {
-        let data = TensorData::quantized(
-            // [[24.0423, 87.9478, 76.1838], [59.6929, 43.8169, 94.8826]]
-            vec![-63i8, 108, 76, 32, -10, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(
-                0.3725856688608348,
-                -128,
-            )),
-        );
-        let tensor = Tensor::<TestBackend, 2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([
+            [24.0423, 87.9478, 76.1838],
+            [59.6929, 43.8169, 94.8826],
+        ]);
 
         let output = tensor.ceil();
         let expected = TensorData::from([[25., 88., 77.], [60., 44., 96.]]);

--- a/crates/burn-tensor/src/tests/quantization/ops/chunk.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/chunk.rs
@@ -2,19 +2,12 @@
 mod tests {
     use super::*;
     use alloc::vec::Vec;
-    use burn_tensor::quantization::{QuantizationStrategy, SymmetricQuantization};
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::TensorData;
 
     fn test_chunk_evenly_divisible() {
-        // Quantized [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [6],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]);
 
-        let tensors: Vec<Tensor<TestBackend, 1>> = tensor.chunk(3, 0);
+        let tensors: Vec<TestTensor<1>> = tensor.chunk(3, 0);
         assert_eq!(tensors.len(), 3);
 
         let expected = vec![
@@ -34,15 +27,9 @@ mod tests {
 
     #[test]
     fn test_chunk_not_evenly_divisible() {
-        // Quantized [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
-        let data = TensorData::quantized(
-            vec![0i8, 21, 42, 64, 85, 106, 127],
-            [7],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.047244094)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
 
-        let tensors: Vec<Tensor<TestBackend, 1>> = tensor.chunk(4, 0);
+        let tensors: Vec<TestTensor<1>> = tensor.chunk(4, 0);
         assert_eq!(tensors.len(), 4);
 
         let expected = vec![
@@ -63,15 +50,9 @@ mod tests {
 
     #[test]
     fn test_chunk_not_divisible() {
-        // Quantized [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [6],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]);
 
-        let tensors: Vec<Tensor<TestBackend, 1>> = tensor.chunk(7, 0);
+        let tensors: Vec<TestTensor<1>> = tensor.chunk(7, 0);
         assert_eq!(tensors.len(), 6);
 
         let expected = vec![
@@ -94,15 +75,9 @@ mod tests {
 
     #[test]
     fn test_chunk_multi_dimension() {
-        // Quantized [[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [1, 6],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]]);
 
-        let tensors: Vec<Tensor<TestBackend, 2>> = tensor.chunk(2, 1);
+        let tensors: Vec<TestTensor<2>> = tensor.chunk(2, 1);
         assert_eq!(tensors.len(), 2);
 
         let expected = vec![
@@ -122,12 +97,6 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_invalid_dim() {
-        // Quantized [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [6],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensors = TestTensor::<1>::from_data(data, &Default::default()).chunk(6, 1);
+        let tensors = QTensor::<TestBackend, 1>::int8([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]).chunk(6, 1);
     }
 }

--- a/crates/burn-tensor/src/tests/quantization/ops/clamp.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/clamp.rs
@@ -1,18 +1,11 @@
 #[burn_tensor_testgen::testgen(q_clamp)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{QuantizationStrategy, SymmetricQuantization};
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::TensorData;
 
     #[test]
     fn clamp_min() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.clamp_min(2.0);
 
@@ -25,13 +18,7 @@ mod tests {
 
     #[test]
     fn clamp_max() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.clamp_max(2.0);
 
@@ -44,13 +31,7 @@ mod tests {
 
     #[test]
     fn clamp_min_max() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.clamp(1.0, 4.0);
 

--- a/crates/burn-tensor/src/tests/quantization/ops/cos.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/cos.rs
@@ -1,18 +1,11 @@
 #[burn_tensor_testgen::testgen(q_cos)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{QuantizationStrategy, SymmetricQuantization};
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::TensorData;
 
     #[test]
     fn should_support_cos_ops() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.cos();
         let expected = TensorData::from([[1.0, 0.5403, -0.4161], [-0.9899, -0.6536, 0.2836]]);

--- a/crates/burn-tensor/src/tests/quantization/ops/div.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/div.rs
@@ -1,26 +1,12 @@
 #[burn_tensor_testgen::testgen(q_div)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{QuantizationStrategy, SymmetricQuantization};
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::TensorData;
 
     #[test]
     fn should_support_div_ops() {
-        let device = Default::default();
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &device);
-        // Quantized [[1.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![25i8, 25, 51, 76, 102, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data, &device);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8([[1.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor_1 / tensor_2;
         let expected = TensorData::from([[0.0, 1.0, 1.0], [1.0, 1.0, 1.0]]);
@@ -34,21 +20,8 @@ mod tests {
 
     #[test]
     fn test_div_broadcast() {
-        let device = Default::default();
-        // Quantized [[0.0, 1.0, 2.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 64, 127],
-            [1, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.015748031)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &device);
-        // Quantized [[1.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![25i8, 25, 51, 76, 102, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data, &device);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8([[1.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor_1 / tensor_2;
 
@@ -62,14 +35,7 @@ mod tests {
     #[test]
     fn should_support_div_scalar_ops() {
         let scalar = 2.0;
-        let device = Default::default();
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &device);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor / scalar;
 

--- a/crates/burn-tensor/src/tests/quantization/ops/erf.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/erf.rs
@@ -1,18 +1,11 @@
 #[burn_tensor_testgen::testgen(q_erf)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{QuantizationStrategy, SymmetricQuantization};
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::TensorData;
 
     #[test]
     fn should_support_erf_ops() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.erf();
         let expected = TensorData::from([[0.0000, 0.8427, 0.9953], [1.0000, 1.0000, 1.0000]]);
@@ -26,13 +19,7 @@ mod tests {
 
     #[test]
     fn should_support_erf_ops_with_negative_number() {
-        // Quantized [[-0.056, -0.043, -0.089], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-1i8, -1, -2, 76, 102, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[-0.056, -0.043, -0.089], [3.0, 4.0, 5.0]]);
 
         let output = tensor.erf();
         let expected = TensorData::from([

--- a/crates/burn-tensor/src/tests/quantization/ops/exp.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/exp.rs
@@ -1,19 +1,12 @@
 #[burn_tensor_testgen::testgen(q_exp)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{AffineQuantization, QuantizationStrategy};
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::TensorData;
 
     #[test]
     fn should_support_exp_ops() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
         // NOTE: we use affine quantization to reduce quantization errors since `exp()` amplifies the error
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.exp();
         let expected = TensorData::from([[1.0, 2.71830, 7.3891], [20.0855, 54.5981, 148.4132]]);

--- a/crates/burn-tensor/src/tests/quantization/ops/expand.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/expand.rs
@@ -1,18 +1,11 @@
 #[burn_tensor_testgen::testgen(q_expand)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{QuantizationStrategy, SymmetricQuantization};
-    use burn_tensor::{Shape, Tensor, TensorData};
+    use burn_tensor::TensorData;
 
     #[test]
     fn expand_2d() {
-        // Quantized [1.0, 2.0, 3.0]
-        let data = TensorData::quantized(
-            vec![42i8, 85, 127],
-            [3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.023622047)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8([1.0, 2.0, 3.0]);
         let output = tensor.expand([3, 3]);
 
         // Precision 1 to approximate de/quantization errors
@@ -22,12 +15,7 @@ mod tests {
         );
 
         // Quantized [4.0, 7.0, 2.0, 3.0]
-        let data = TensorData::quantized(
-            vec![73i8, 127, 36, 54],
-            [4],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.05511811)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8([4.0, 7.0, 2.0, 3.0]);
         let output = tensor.expand([2, 4]);
 
         // Precision 1 to approximate de/quantization errors
@@ -39,13 +27,8 @@ mod tests {
 
     #[test]
     fn expand_3d() {
-        // Quantized [[1.0, 2.0], [3.0, 4.0]]
-        let data = TensorData::quantized(
-            vec![32i8, 64, 95, 127],
-            [2, 2],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.031496063)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[1.0, 2.0], [3.0, 4.0]]);
+
         let output = tensor.expand([3, 2, 2]);
         let expected = TensorData::from([
             [[1.0, 2.0], [3.0, 4.0]],
@@ -62,13 +45,8 @@ mod tests {
 
     #[test]
     fn expand_higher_dimensions() {
-        // Quantized [[1.0, 2.0, 3.0, 4.0]]
-        let data = TensorData::quantized(
-            vec![32i8, 64, 95, 127],
-            [1, 4],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.031496063)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[1.0, 2.0, 3.0, 4.0]]);
+
         let output = tensor.expand([2, 3, 4]);
         let expected = TensorData::from([
             [
@@ -92,13 +70,8 @@ mod tests {
 
     #[test]
     fn broadcast_single() {
-        // Quantized [1.0]
-        let data = TensorData::quantized(
-            vec![127i8],
-            [1],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.007874016)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8([1.0]);
+
         let output = tensor.expand([2, 3]);
 
         output
@@ -110,25 +83,14 @@ mod tests {
     #[test]
     #[should_panic]
     fn should_fail_expand_incompatible_shapes() {
-        // Quantized [1.0, 2.0, 3.0]
-        let data = TensorData::quantized(
-            vec![42i8, 85, 127],
-            [3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.023622047)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8([1.0, 2.0, 3.0]);
         let _expanded_tensor = tensor.expand([2, 2]);
     }
 
     #[test]
     fn should_all_negative_one() {
-        // Quantized [1.0, 2.0, 3.0]
-        let data = TensorData::quantized(
-            vec![42i8, 85, 127],
-            [3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.023622047)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8([1.0, 2.0, 3.0]);
+
         let output = tensor.expand([2, -1]);
 
         // Precision 1 to approximate de/quantization errors
@@ -141,13 +103,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn should_panic_negative_one_on_non_existing_dim() {
-        // Quantized [1.0, 2.0, 3.0]
-        let data = TensorData::quantized(
-            vec![42i8, 85, 127],
-            [3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.023622047)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8([1.0, 2.0, 3.0]);
         let _expanded_tensor = tensor.expand([-1, 3]);
     }
 }

--- a/crates/burn-tensor/src/tests/quantization/ops/flip.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/flip.rs
@@ -1,18 +1,11 @@
 #[burn_tensor_testgen::testgen(q_flip)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{QuantizationStrategy, SymmetricQuantization};
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::TensorData;
 
     #[test]
     fn flip_float() {
-        // Quantized [[[0.0, 1.0, 2.0]], [[3.0, 4.0, 5.0]]]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [2, 1, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<3>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 3>::int8([[[0.0, 1.0, 2.0]], [[3.0, 4.0, 5.0]]]);
 
         let flipped = tensor.clone().flip([0, 2]);
         let expected = TensorData::from([[[5., 4., 3.]], [[2., 1., 0.]]]);
@@ -31,13 +24,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn flip_duplicated_axes() {
-        // Quantized [[[0.0, 1.0, 2.0]], [[3.0, 4.0, 5.0]]]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [2, 1, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<3>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 3>::int8([[[0.0, 1.0, 2.0]], [[3.0, 4.0, 5.0]]]);
 
         // Test with a duplicated axis
         let _ = tensor.flip([0, 0, 1]);
@@ -46,13 +33,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn flip_out_of_bound_axis() {
-        // Quantized [[[0.0, 1.0, 2.0]], [[3.0, 4.0, 5.0]]]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [2, 1, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<3>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 3>::int8([[[0.0, 1.0, 2.0]], [[3.0, 4.0, 5.0]]]);
 
         // Test with an out of bound axis
         let _ = tensor.clone().flip([3, 0, 1]);

--- a/crates/burn-tensor/src/tests/quantization/ops/floor.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/floor.rs
@@ -1,20 +1,14 @@
 #[burn_tensor_testgen::testgen(q_floor)]
 mod tests {
     use super::*;
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::TensorData;
 
     #[test]
     fn should_support_floor_ops() {
-        let data = TensorData::quantized(
-            // [[24.0423, 87.9478, 76.1838], [59.6929, 43.8169, 94.8826]]
-            vec![-63, 108, 76, 32, -10, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(
-                0.3725856688608348,
-                -128,
-            )),
-        );
-        let tensor = Tensor::<TestBackend, 2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([
+            [24.0423, 87.9478, 76.1838],
+            [59.6929, 43.8169, 94.8826],
+        ]);
 
         let output = tensor.floor();
         let expected = TensorData::from([[24., 87., 76.], [59., 43., 95.]]);

--- a/crates/burn-tensor/src/tests/quantization/ops/gather_scatter.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/gather_scatter.rs
@@ -1,20 +1,12 @@
 #[burn_tensor_testgen::testgen(q_gather_scatter)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{QuantizationStrategy, SymmetricQuantization};
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::TensorData;
 
     #[test]
     fn should_gather_1d_dim0() {
-        let device = Default::default();
-        // Quantized [0.0, 1.0, 2.0]
-        let data = TensorData::quantized(
-            vec![0i8, 64, 127],
-            [3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.015748031)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &device);
-        let indices = TestTensorInt::from_ints([1, 1, 0, 1, 2], &device);
+        let tensor = QTensor::<TestBackend, 1>::int8([0.0, 1.0, 2.0]);
+        let indices = TestTensorInt::from_ints([1, 1, 0, 1, 2], &Default::default());
 
         let output = tensor.gather(0, indices);
 
@@ -27,15 +19,8 @@ mod tests {
 
     #[test]
     fn should_gather_2d_dim0() {
-        let device = Default::default();
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &device);
-        let indices = TestTensorInt::from_ints([[0, 1, 0], [1, 0, 1]], &device);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let indices = TestTensorInt::from_ints([[0, 1, 0], [1, 0, 1]], &Default::default());
 
         let output = tensor.gather(0, indices);
 
@@ -48,15 +33,8 @@ mod tests {
 
     #[test]
     fn should_gather_2d_dim1() {
-        let device = Default::default();
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &device);
-        let indices = TestTensorInt::from_ints([[2, 1, 0, 0], [2, 0, 1, 2]], &device);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let indices = TestTensorInt::from_ints([[2, 1, 0, 0], [2, 0, 1, 2]], &Default::default());
 
         let output = tensor.gather(1, indices);
 
@@ -69,19 +47,14 @@ mod tests {
 
     #[test]
     fn should_gather_3d_dim1() {
-        let device = Default::default();
-        // Quantized  [
-        //     [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]],
-        //     [[6.0, 7.0, 8.0], [9.0, 10.0, 11.0]],
-        // ]
-        let data = TensorData::quantized(
-            vec![0i8, 12, 23, 35, 46, 58, 69, 81, 92, 104, 115, 127],
-            [2, 2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.08661418)),
+        let tensor = QTensor::<TestBackend, 3>::int8([
+            [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]],
+            [[6.0, 7.0, 8.0], [9.0, 10.0, 11.0]],
+        ]);
+        let indices = TestTensorInt::from_ints(
+            [[[1, 0, 0], [0, 1, 0]], [[0, 0, 1], [0, 1, 1]]],
+            &Default::default(),
         );
-        let tensor = TestTensor::<3>::from_data(data, &device);
-        let indices =
-            TestTensorInt::from_ints([[[1, 0, 0], [0, 1, 0]], [[0, 0, 1], [0, 1, 1]]], &device);
 
         let output = tensor.gather(1, indices);
         let expected = TensorData::from([
@@ -98,15 +71,8 @@ mod tests {
 
     #[test]
     fn should_gather_2d_only_1dim() {
-        let device = Default::default();
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &device);
-        let indices = TestTensorInt::<2>::from_ints([[1, 2]], &device).reshape([2, 1]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let indices = TestTensorInt::<2>::from_ints([[1, 2]], &Default::default()).reshape([2, 1]);
 
         let output = tensor.gather(1, indices);
 
@@ -119,22 +85,9 @@ mod tests {
 
     #[test]
     fn should_scatter_1d() {
-        let device = Default::default();
-        // Quantized [0.0, 0.0, 0.0]
-        let data = TensorData::quantized(
-            vec![0i8, 0, 0],
-            [3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.1)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &device);
-        // Quantized [5.0, 4.0, 3.0]
-        let data = TensorData::quantized(
-            vec![127i8, 102, 76],
-            [3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let values = TestTensor::<1>::from_data(data, &device);
-        let indices = TestTensorInt::from_ints([1, 0, 2], &device);
+        let tensor = QTensor::<TestBackend, 1>::int8([0.0, 0.0, 0.0]);
+        let values = QTensor::<TestBackend, 1>::int8([5.0, 4.0, 3.0]);
+        let indices = TestTensorInt::from_ints([1, 0, 2], &Default::default());
 
         let output = tensor.scatter(0, indices, values);
 
@@ -147,22 +100,9 @@ mod tests {
 
     #[test]
     fn should_scatter_2d_dim0() {
-        let device = Default::default();
-        // Quantized [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 0, 0, 0, 0, 0],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.1)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &device);
-        // Quantized [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]
-        let data = TensorData::quantized(
-            vec![21i8, 42, 64, 85, 106, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.047244094)),
-        );
-        let values = TestTensor::<2>::from_data(data, &device);
-        let indices = TestTensorInt::from_ints([[1, 0, 1], [1, 1, 0]], &device);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]);
+        let values = QTensor::<TestBackend, 2>::int8([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+        let indices = TestTensorInt::from_ints([[1, 0, 1], [1, 1, 0]], &Default::default());
 
         let output = tensor.scatter(0, indices, values);
 
@@ -175,22 +115,9 @@ mod tests {
 
     #[test]
     fn should_scatter_2d_dim1() {
-        let device = Default::default();
-        // Quantized [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 0, 0, 0, 0, 0],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.1)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &device);
-        // Quantized [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]
-        let data = TensorData::quantized(
-            vec![21i8, 42, 64, 85, 106, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.047244094)),
-        );
-        let values = TestTensor::<2>::from_data(data, &device);
-        let indices = TestTensorInt::from_ints([[1, 0, 2], [1, 2, 0]], &device);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]);
+        let values = QTensor::<TestBackend, 2>::int8([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+        let indices = TestTensorInt::from_ints([[1, 0, 2], [1, 2, 0]], &Default::default());
 
         let output = tensor.scatter(1, indices, values);
 
@@ -203,29 +130,18 @@ mod tests {
 
     #[test]
     fn should_scatter_3d_dim1() {
-        let device = Default::default();
-        // Quantized  [
-        //     [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]],
-        //     [[6.0, 7.0, 8.0], [9.0, 10.0, 11.0]],
-        // ]
-        let data = TensorData::quantized(
-            vec![0i8, 12, 23, 35, 46, 58, 69, 81, 92, 104, 115, 127],
-            [2, 2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.08661418)),
+        let tensor = QTensor::<TestBackend, 3>::int8([
+            [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]],
+            [[6.0, 7.0, 8.0], [9.0, 10.0, 11.0]],
+        ]);
+        let values = QTensor::<TestBackend, 3>::int8([
+            [[12.0, 13.0, 14.0], [15.0, 16.0, 17.0]],
+            [[18.0, 19.0, 20.0], [21.0, 22.0, 23.0]],
+        ]);
+        let indices = TestTensorInt::from_ints(
+            [[[1, 0, 0], [0, 1, 0]], [[0, 0, 1], [0, 1, 1]]],
+            &Default::default(),
         );
-        let tensor = TestTensor::<3>::from_data(data, &device);
-        // Quantized  [
-        //     [[12.0, 13.0, 14.0], [15.0, 16.0, 17.0]],
-        //     [[18.0, 19.0, 20.0], [21.0, 22.0, 23.0]],
-        // ]
-        let data = TensorData::quantized(
-            vec![66i8, 72, 77, 83, 88, 94, 99, 105, 110, 116, 121, 127],
-            [2, 2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.18110237)),
-        );
-        let values = TestTensor::<3>::from_data(data, &device);
-        let indices =
-            TestTensorInt::from_ints([[[1, 0, 0], [0, 1, 0]], [[0, 0, 1], [0, 1, 1]]], &device);
 
         let output = tensor.scatter(1, indices, values);
         let expected = TensorData::from([
@@ -242,22 +158,9 @@ mod tests {
 
     #[test]
     fn should_scatter_2d_dim1_diff_shape() {
-        let device = Default::default();
-        // Quantized [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 0, 0, 0, 0, 0],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.1)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &device);
-        // Quantized [[1.0], [4.0]]
-        let data = TensorData::quantized(
-            vec![32i8, 127],
-            [2, 1],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.031496063)),
-        );
-        let values = TestTensor::<2>::from_data(data, &device);
-        let indices = TestTensorInt::from_ints([[1], [2]], &device);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]);
+        let values = QTensor::<TestBackend, 2>::int8([[1.0], [4.0]]);
+        let indices = TestTensorInt::from_ints([[1], [2]], &Default::default());
 
         let output = tensor.scatter(1, indices, values);
 
@@ -271,22 +174,9 @@ mod tests {
     #[test]
     #[should_panic]
     fn scatter_should_panic_on_mismatch_of_shapes() {
-        let device = Default::default();
-        // Quantized [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 0, 0, 0, 0, 0],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.1)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &device);
-        // Quantized [1.0, 4.0]
-        let data = TensorData::quantized(
-            vec![32i8, 127],
-            [2],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.031496063)),
-        );
-        let values = TestTensor::<2>::from_data(data, &device);
-        let indices = TestTensorInt::from_ints([1, 0, 2], &device);
+        let tensor = QTensor::<TestBackend, 1>::int8([0.0, 0.0, 0.0]);
+        let values = QTensor::<TestBackend, 1>::int8([1.0, 4.0]);
+        let indices = TestTensorInt::from_ints([1, 0, 2], &Default::default());
 
         tensor.scatter(0, indices, values);
     }

--- a/crates/burn-tensor/src/tests/quantization/ops/log.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/log.rs
@@ -1,18 +1,11 @@
 #[burn_tensor_testgen::testgen(q_log)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{QuantizationStrategy, SymmetricQuantization};
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::TensorData;
 
     #[test]
     fn should_support_log_ops() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.log();
         let expected = TensorData::from([

--- a/crates/burn-tensor/src/tests/quantization/ops/log1p.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/log1p.rs
@@ -1,18 +1,11 @@
 #[burn_tensor_testgen::testgen(q_log1p)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{QuantizationStrategy, SymmetricQuantization};
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::TensorData;
 
     #[test]
     fn should_support_exp_log1p() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.log1p();
         let expected = TensorData::from([

--- a/crates/burn-tensor/src/tests/quantization/ops/map_comparison.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/map_comparison.rs
@@ -1,27 +1,13 @@
 #[burn_tensor_testgen::testgen(q_map_comparison)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{AffineQuantization, QuantizationStrategy};
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::TensorData;
 
     // NOTE: we use affine quantization to reduce quantization errors since equality tests are precise
     #[test]
     fn test_equal() {
-        let device = Default::default();
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &device);
-        // Quantized [[0.0, 1.0, 1.0], [3.0, 5.0, 4.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -77, 25, 127, 76],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data, &device);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 1.0], [3.0, 5.0, 4.0]]);
 
         let data_actual_cloned = tensor_1.clone().equal(tensor_2.clone());
         let data_actual_inplace = tensor_1.equal(tensor_2);
@@ -33,21 +19,8 @@ mod tests {
 
     #[test]
     fn test_not_equal() {
-        let device = Default::default();
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &device);
-        // Quantized [[0.0, 1.0, 1.0], [3.0, 5.0, 4.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -77, 25, 127, 76],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data, &device);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 1.0], [3.0, 5.0, 4.0]]);
 
         let data_actual_cloned = tensor_1.clone().not_equal(tensor_2.clone());
         let data_actual_inplace = tensor_1.not_equal(tensor_2);
@@ -59,16 +32,10 @@ mod tests {
 
     #[test]
     fn test_equal_elem() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 2.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, -26, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 2.0, 5.0]]);
 
-        let data_actual_cloned = tensor_1.clone().equal_elem(2);
-        let data_actual_inplace = tensor_1.equal_elem(2);
+        let data_actual_cloned = tensor.clone().equal_elem(2);
+        let data_actual_inplace = tensor.equal_elem(2);
 
         let data_expected = TensorData::from([[false, false, true], [false, true, false]]);
         assert_eq!(data_expected, data_actual_cloned.into_data());
@@ -77,16 +44,10 @@ mod tests {
 
     #[test]
     fn test_not_equal_elem() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 2.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, -26, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 2.0, 5.0]]);
 
-        let data_actual_cloned = tensor_1.clone().not_equal_elem(2);
-        let data_actual_inplace = tensor_1.not_equal_elem(2);
+        let data_actual_cloned = tensor.clone().not_equal_elem(2);
+        let data_actual_inplace = tensor.not_equal_elem(2);
 
         let data_expected = TensorData::from([[true, true, false], [true, false, true]]);
         assert_eq!(data_expected, data_actual_cloned.into_data());
@@ -95,16 +56,10 @@ mod tests {
 
     #[test]
     fn test_greater_elem() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
-        let data_actual_cloned = tensor_1.clone().greater_elem(4);
-        let data_actual_inplace = tensor_1.greater_elem(4);
+        let data_actual_cloned = tensor.clone().greater_elem(4);
+        let data_actual_inplace = tensor.greater_elem(4);
 
         let data_expected = TensorData::from([[false, false, false], [false, false, true]]);
         assert_eq!(data_expected, data_actual_cloned.into_data());
@@ -113,16 +68,10 @@ mod tests {
 
     #[test]
     fn test_greater_equal_elem() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
-        let data_actual_cloned = tensor_1.clone().greater_equal_elem(4.0);
-        let data_actual_inplace = tensor_1.greater_equal_elem(4.0);
+        let data_actual_cloned = tensor.clone().greater_equal_elem(4.0);
+        let data_actual_inplace = tensor.greater_equal_elem(4.0);
 
         let data_expected = TensorData::from([[false, false, false], [false, true, true]]);
         assert_eq!(data_expected, data_actual_cloned.into_data());
@@ -131,21 +80,8 @@ mod tests {
 
     #[test]
     fn test_greater() {
-        let device = Default::default();
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &device);
-        // Quantized [[0.0, 1.0, 1.0], [3.0, 5.0, 4.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -77, 25, 127, 76],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data, &device);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 1.0], [3.0, 5.0, 4.0]]);
 
         let data_actual_cloned = tensor_1.clone().greater(tensor_2.clone());
         let data_actual_inplace = tensor_1.greater(tensor_2);
@@ -157,21 +93,8 @@ mod tests {
 
     #[test]
     fn test_greater_equal() {
-        let device = Default::default();
-        // Quantized [[0.0, 1.0, 1.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -77, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &device);
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 5.0, 4.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 127, 76],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data, &device);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 1.0], [3.0, 4.0, 5.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 5.0, 4.0]]);
 
         let data_actual_cloned = tensor_1.clone().greater_equal(tensor_2.clone());
         let data_actual_inplace = tensor_1.greater_equal(tensor_2);
@@ -183,16 +106,10 @@ mod tests {
 
     #[test]
     fn test_lower_elem() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
-        let data_actual_cloned = tensor_1.clone().lower_elem(4.0);
-        let data_actual_inplace = tensor_1.lower_elem(4.0);
+        let data_actual_cloned = tensor.clone().lower_elem(4.0);
+        let data_actual_inplace = tensor.lower_elem(4.0);
 
         let data_expected = TensorData::from([[true, true, true], [true, false, false]]);
         assert_eq!(data_expected, data_actual_cloned.into_data());
@@ -201,16 +118,10 @@ mod tests {
 
     #[test]
     fn test_lower_equal_elem() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
-        let data_actual_cloned = tensor_1.clone().lower_equal_elem(4.0);
-        let data_actual_inplace = tensor_1.lower_equal_elem(4.0);
+        let data_actual_cloned = tensor.clone().lower_equal_elem(4.0);
+        let data_actual_inplace = tensor.lower_equal_elem(4.0);
 
         let data_expected = TensorData::from([[true, true, true], [true, true, false]]);
         assert_eq!(data_expected, data_actual_cloned.into_data());
@@ -219,21 +130,8 @@ mod tests {
 
     #[test]
     fn test_lower() {
-        let device = Default::default();
-        // Quantized [[0.0, 1.0, 1.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -77, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &device);
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 5.0, 4.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 127, 76],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data, &device);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 1.0], [3.0, 4.0, 5.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 5.0, 4.0]]);
 
         let data_actual_cloned = tensor_1.clone().lower(tensor_2.clone());
         let data_actual_inplace = tensor_1.lower(tensor_2);
@@ -245,21 +143,8 @@ mod tests {
 
     #[test]
     fn test_lower_equal() {
-        let device = Default::default();
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &device);
-        // Quantized [[0.0, 1.0, 1.0], [3.0, 5.0, 4.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -77, 25, 127, 76],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data, &device);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 1.0], [3.0, 5.0, 4.0]]);
 
         let data_actual_cloned = tensor_1.clone().lower_equal(tensor_2.clone());
         let data_actual_inplace = tensor_1.lower_equal(tensor_2);

--- a/crates/burn-tensor/src/tests/quantization/ops/mask.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/mask.rs
@@ -1,30 +1,16 @@
 #[burn_tensor_testgen::testgen(q_mask)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{QuantizationStrategy, SymmetricQuantization};
-    use burn_tensor::{Bool, Int, Tensor, TensorData};
+    use burn_tensor::TensorData;
 
     #[test]
     fn should_support_mask_where_ops() {
-        let device = Default::default();
-        // Quantized [[1.0, 7.0], [2.0, 3.0]]
-        let data = TensorData::quantized(
-            vec![18i8, 127, 36, 54],
-            [2, 2],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.05511811)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &device);
+        let tensor = QTensor::<TestBackend, 2>::int8([[1.0, 7.0], [2.0, 3.0]]);
         let mask = TestTensorBool::<2>::from_bool(
             TensorData::from([[true, false], [false, true]]),
-            &device,
+            &Default::default(),
         );
-        // Quantized [[1.0, 7.0], [2.0, 3.0]]
-        let data = TensorData::quantized(
-            vec![48i8, 74, 101, 127],
-            [2, 2],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.037795275)),
-        );
-        let value = TestTensor::<2>::from_data(data, &device);
+        let value = QTensor::<TestBackend, 2>::int8([[1.8, 2.8], [3.8, 4.8]]);
 
         let output = tensor.mask_where(mask, value);
         let expected = TensorData::from([[1.8, 7.0], [2.0, 4.8]]);
@@ -38,17 +24,10 @@ mod tests {
 
     #[test]
     fn should_support_mask_fill_ops() {
-        let device = Default::default();
-        // Quantized [[1.0, 7.0], [2.0, 3.0]]
-        let data = TensorData::quantized(
-            vec![18i8, 127, 36, 54],
-            [2, 2],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.05511811)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &device);
+        let tensor = QTensor::<TestBackend, 2>::int8([[1.0, 7.0], [2.0, 3.0]]);
         let mask = TestTensorBool::<2>::from_bool(
             TensorData::from([[true, false], [false, true]]),
-            &device,
+            &Default::default(),
         );
 
         let output = tensor.mask_fill(mask, 2.0);

--- a/crates/burn-tensor/src/tests/quantization/ops/matmul.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/matmul.rs
@@ -1,29 +1,13 @@
 #[burn_tensor_testgen::testgen(q_matmul)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{
-        AffineQuantization, QuantizationStrategy, SymmetricQuantization,
-    };
-    use burn_tensor::{Int, Tensor, TensorData};
+    use burn_tensor::TensorData;
 
     // NOTE: we set higher tolerance (0.3) due to larger de/quantization errors accumulation
     #[test]
     fn test_matmul_d2() {
-        let device = Default::default();
-        // Quantized [[1.0, 7.0], [2.0, 3.0], [1.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![18i8, 127, 36, 54, 18, 91],
-            [3, 2],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.05511811)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &device);
-        // Quantized [[4.0, 7.0, 5.0], [2.0, 3.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![73i8, 127, 91, 36, 54, 91],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.05511811)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data, &device);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8([[1.0, 7.0], [2.0, 3.0], [1.0, 5.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8([[4.0, 7.0, 5.0], [2.0, 3.0, 5.0]]);
 
         let tensor_3 = tensor_1.matmul(tensor_2);
         let expected =
@@ -37,21 +21,8 @@ mod tests {
 
     #[test]
     fn test_matmul_d3() {
-        let device = Default::default();
-        // Quantized [[[1.0, 7.0], [2.0, 3.0]]]
-        let data = TensorData::quantized(
-            vec![18i8, 127, 36, 54],
-            [1, 2, 2],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.05511811)),
-        );
-        let tensor_1 = TestTensor::<3>::from_data(data, &device);
-        // Quantized [[[4.0, 7.0], [2.0, 3.0]]]
-        let data = TensorData::quantized(
-            vec![73i8, 127, 36, 54],
-            [1, 2, 2],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.05511811)),
-        );
-        let tensor_2 = TestTensor::<3>::from_data(data, &device);
+        let tensor_1 = QTensor::<TestBackend, 3>::int8([[[1.0, 7.0], [2.0, 3.0]]]);
+        let tensor_2 = QTensor::<TestBackend, 3>::int8([[[4.0, 7.0], [2.0, 3.0]]]);
 
         let tensor_3 = tensor_1.matmul(tensor_2);
         let expected = TensorData::from([[[18.0, 28.0], [14.0, 23.0]]]);
@@ -64,21 +35,9 @@ mod tests {
 
     #[test]
     fn test_matmul_broadcast_1() {
-        let device = Default::default();
-        // Quantized [[[1.0, 7.0], [2.0, 3.0]]]
-        let data = TensorData::quantized(
-            vec![18i8, 127, 36, 54],
-            [1, 2, 2],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.05511811)),
-        );
-        let tensor_1 = TestTensor::<3>::from_data(data, &device);
-        // Quantized [[[4.0, 7.0], [2.0, 3.0]], [[2.0, 5.0], [6.0, 3.0]]]
-        let data = TensorData::quantized(
-            vec![73i8, 127, 36, 54, 36, 91, 109, 54],
-            [2, 2, 2],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.05511811)),
-        );
-        let tensor_2 = TestTensor::<3>::from_data(data, &device);
+        let tensor_1 = QTensor::<TestBackend, 3>::int8([[[1.0, 7.0], [2.0, 3.0]]]);
+        let tensor_2 =
+            QTensor::<TestBackend, 3>::int8([[[4.0, 7.0], [2.0, 3.0]], [[2.0, 5.0], [6.0, 3.0]]]);
 
         let tensor_3 = tensor_1.matmul(tensor_2);
         let expected =
@@ -92,21 +51,12 @@ mod tests {
 
     #[test]
     fn test_matmul_broadcast_4d() {
-        let device = Default::default();
-        // Quantized [[[[1.0, 7.0], [2.0, 3.0]]], [[[2.0, 5.0], [6.0, 3.0]]]]
-        let data = TensorData::quantized(
-            vec![18i8, 127, 36, 54, 36, 91, 109, 54],
-            [2, 1, 2, 2],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.05511811)),
-        );
-        let tensor_1 = TestTensor::<4>::from_data(data, &device);
-        // Quantized [[[[9.0, 8.0], [1.0, 4.0]], [[2.0, 7.0], [3.0, 5.0]]]]
-        let data = TensorData::quantized(
-            vec![127i8, 113, 14, 56, 28, 99, 42, 71],
-            [1, 2, 2, 2],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.070866145)),
-        );
-        let tensor_2 = TestTensor::<4>::from_data(data, &device);
+        let tensor_1 = QTensor::<TestBackend, 4>::int8([
+            [[[1.0, 7.0], [2.0, 3.0]]],
+            [[[2.0, 5.0], [6.0, 3.0]]],
+        ]);
+        let tensor_2 =
+            QTensor::<TestBackend, 4>::int8([[[[9.0, 8.0], [1.0, 4.0]], [[2.0, 7.0], [3.0, 5.0]]]]);
 
         // [2, 1, 2, 2] @ [1, 2, 2, 2] -> [2, 2, 2, 2]
         let tensor_3 = tensor_1.matmul(tensor_2);
@@ -123,22 +73,9 @@ mod tests {
 
     #[test]
     fn test_matmul_simple_1() {
-        let device = Default::default();
         // NOTE: we use affine quantization to lower de/quantization errors
-        // Quantized [[5.0, 14.0], [14.0, 25.0]]
-        let data = TensorData::quantized(
-            vec![-77i8, 15, 15, 127],
-            [2, 2],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.09803922, -128)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &device);
-        // Quantized [[3.0, 4.0, 5.0], [0.0, 1.0, 2.0]]
-        let data = TensorData::quantized(
-            vec![25i8, 76, 127, -128, -77, -26],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data, &device);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8_affine([[5.0, 14.0], [14.0, 25.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8_affine([[3.0, 4.0, 5.0], [0.0, 1.0, 2.0]]);
 
         let tensor_3 = tensor_1.matmul(tensor_2);
         let expected = TensorData::from([[15.0, 34.0, 53.0], [42.0, 81.0, 120.0]]);
@@ -151,22 +88,18 @@ mod tests {
 
     #[test]
     fn test_matmul_4_3() {
-        let device = Default::default();
         // NOTE: we use affine quantization to lower de/quantization errors
-        // Quantized [[0., 1., 2., 3.], [4., 5., 6., 7.], [8., 9., 10., 11.]]
-        let data = TensorData::quantized(
-            vec![-128i8, -105, -82, -58, -35, -12, 11, 34, 57, 81, 104, 127],
-            [3, 4],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.043137256, -128)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &device);
-        // Quantized [[0., 1., 2.], [4., 5., 6.], [8., 9., 10.], [13., 14., 15.]]
-        let data = TensorData::quantized(
-            vec![-128i8, -111, -94, -60, -43, -26, 8, 25, 42, 93, 110, 127],
-            [4, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.05882353, -128)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data, &device);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8_affine([
+            [0., 1., 2., 3.],
+            [4., 5., 6., 7.],
+            [8., 9., 10., 11.],
+        ]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8_affine([
+            [0., 1., 2.],
+            [4., 5., 6.],
+            [8., 9., 10.],
+            [13., 14., 15.],
+        ]);
 
         let tensor_3 = tensor_1.matmul(tensor_2);
         let expected = TensorData::from([[59., 65., 71.], [159., 181., 203.], [259., 297., 335.]]);
@@ -179,17 +112,13 @@ mod tests {
 
     #[test]
     fn test_matmul_trivial() {
-        let device = Default::default();
         // NOTE: we use affine quantization to lower de/quantization errors
-        // Quantized [[0., 1., 2., 3.], [4., 5., 6., 7.], [8., 9., 10., 11.], [12., 13., 14., 15.]]
-        let data = TensorData::quantized(
-            vec![
-                -128i8, -111, -94, -77, -60, -43, -26, -9, 8, 25, 42, 59, 76, 93, 110, 127,
-            ],
-            [4, 4],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.05882353, -128)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &device);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8_affine([
+            [0., 1., 2., 3.],
+            [4., 5., 6., 7.],
+            [8., 9., 10., 11.],
+            [12., 13., 14., 15.],
+        ]);
 
         let tensor_3 = tensor_1.clone().matmul(tensor_1);
 
@@ -206,17 +135,13 @@ mod tests {
 
     #[test]
     fn test_matmul_trivial_transposed() {
-        let device = Default::default();
         // NOTE: we use affine quantization to lower de/quantization errors
-        // Quantized [[0., 1., 2., 3.], [4., 5., 6., 7.], [8., 9., 10., 11.], [12., 13., 14., 15.]]
-        let data = TensorData::quantized(
-            vec![
-                -128i8, -111, -94, -77, -60, -43, -26, -9, 8, 25, 42, 59, 76, 93, 110, 127,
-            ],
-            [4, 4],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.05882353, -128)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &device);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8_affine([
+            [0., 1., 2., 3.],
+            [4., 5., 6., 7.],
+            [8., 9., 10., 11.],
+            [12., 13., 14., 15.],
+        ]);
 
         let tensor_3 = tensor_1.clone().matmul(tensor_1.transpose());
 
@@ -233,21 +158,8 @@ mod tests {
 
     #[test]
     fn test_matmul_simple_2() {
-        let device = Default::default();
-        // Quantized [[1.0, 2.0, 3.0, 4.0]]
-        let data = TensorData::quantized(
-            vec![32i8, 64, 95, 127],
-            [1, 4],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.031496063)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &device);
-        // Quantized [[1.0, 2.0, 3.0, 4.0]]
-        let data = TensorData::quantized(
-            vec![64i8, 85, 106, 127],
-            [4, 1],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.047244094)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data, &device);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8([[1.0, 2.0, 3.0, 4.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8([[3.0], [4.0], [5.0], [6.0]]);
 
         let tensor_3 = tensor_1.matmul(tensor_2);
         let expected = TensorData::from([[50.0]]);
@@ -260,21 +172,14 @@ mod tests {
 
     #[test]
     fn test_matmul_simple_3() {
-        let device = Default::default();
-        // Quantized [[3., 3., 3.], [4., 4., 4.], [5., 5., 5.], [6., 6., 6.]]
-        let data = TensorData::quantized(
-            vec![64i8, 64, 64, 85, 85, 85, 106, 106, 106, 127, 127, 127],
-            [4, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.047244094)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &device);
-        // Quantized [[1., 2., 3., 4.], [1., 2., 3., 4.], [1., 2., 3., 4.]]
-        let data = TensorData::quantized(
-            vec![32i8, 64, 95, 127, 32, 64, 95, 127, 32, 64, 95, 127],
-            [3, 4],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.031496063)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data, &device);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8([
+            [3., 3., 3.],
+            [4., 4., 4.],
+            [5., 5., 5.],
+            [6., 6., 6.],
+        ]);
+        let tensor_2 =
+            QTensor::<TestBackend, 2>::int8([[1., 2., 3., 4.], [1., 2., 3., 4.], [1., 2., 3., 4.]]);
 
         let tensor_3 = tensor_1.matmul(tensor_2);
         let expected = TensorData::from([
@@ -293,21 +198,9 @@ mod tests {
     #[test]
     #[should_panic]
     fn should_panic_when_inner_dimensions_are_not_equal() {
-        let device = Default::default();
-        // Quantized [[3., 3.], [4., 4.], [5., 5.], [6., 6.]]
-        let data = TensorData::quantized(
-            vec![64i8, 64, 85, 85, 106, 106, 127, 127],
-            [4, 2],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.047244094)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &device);
-        // Quantized [[1., 2., 3., 4.], [1., 2., 3., 4.], [1., 2., 3., 4.]]
-        let data = TensorData::quantized(
-            vec![32i8, 64, 95, 127, 32, 64, 95, 127, 32, 64, 95, 127],
-            [4, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.031496063)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data, &device);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8([[3., 3.], [4., 4.], [5., 5.], [6., 6.]]);
+        let tensor_2 =
+            QTensor::<TestBackend, 2>::int8([[1., 2., 3., 4.], [1., 2., 3., 4.], [1., 2., 3., 4.]]);
 
         let _ = tensor_1.matmul(tensor_2);
     }

--- a/crates/burn-tensor/src/tests/quantization/ops/maxmin.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/maxmin.rs
@@ -1,18 +1,12 @@
 #[burn_tensor_testgen::testgen(q_maxmin)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{AffineQuantization, QuantizationStrategy};
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::TensorData;
 
+    // NOTE: we use affine quantization to reduce quantization errors for range of input values
     #[test]
     fn test_max_dim_2d() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.max_dim(1);
         let expected = TensorData::from([[2.], [5.]]);
@@ -22,13 +16,7 @@ mod tests {
 
     #[test]
     fn test_max_dim_with_indices_2d_with_dim_0th() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let (output, index) = tensor.max_dim_with_indices(0);
 
@@ -44,13 +32,7 @@ mod tests {
 
     #[test]
     fn test_max_dim_with_indices_2d() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let (output, index) = tensor.max_dim_with_indices(1);
 
@@ -66,13 +48,7 @@ mod tests {
 
     #[test]
     fn test_min_dim_2d() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.min_dim(1);
 
@@ -83,13 +59,7 @@ mod tests {
 
     #[test]
     fn test_min_dim_with_indices_2d() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let (output, index) = tensor.min_dim_with_indices(1);
 
@@ -105,13 +75,7 @@ mod tests {
 
     #[test]
     fn test_min_dim_2d_with_0th_dim() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.min_dim(0);
         let expected = TensorData::from([[0., 1., 2.]]);
@@ -121,13 +85,7 @@ mod tests {
 
     #[test]
     fn test_max_dim_2d_with_0th_dim() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.max_dim(0);
         let expected = TensorData::from([[3., 4., 5.]]);
@@ -137,13 +95,7 @@ mod tests {
 
     #[test]
     fn test_min_dim_with_indices_2d_with_0th_dim() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let (output, index) = tensor.min_dim_with_indices(0);
 
@@ -159,23 +111,11 @@ mod tests {
 
     #[test]
     fn test_maximum_pair() {
-        // Quantized [1.0, 2.0, 3.0, 4.0] (with range [0., 5.])
-        let data = TensorData::quantized(
-            vec![-77i8, -26, 25, 76],
-            [4],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let a = TestTensor::<1>::from_data(data, &Default::default());
-        // Quantized [2.0, 1.0, 4.0, 5.0] (with range [0., 5.])
-        let data = TensorData::quantized(
-            vec![-26i8, -77, 76, 127],
-            [4],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let b = TestTensor::<1>::from_data(data, &Default::default());
+        let a = QTensor::<TestBackend, 1>::int8_affine([1.0, 5.0, 3.0, 4.0]);
+        let b = QTensor::<TestBackend, 1>::int8_affine([2.0, 1.0, 4.0, 5.0]);
 
         let output = a.max_pair(b);
-        let expected = TensorData::from([2.0, 2.0, 4.0, 5.0]);
+        let expected = TensorData::from([2.0, 5.0, 4.0, 5.0]);
 
         output
             .dequantize()
@@ -185,20 +125,8 @@ mod tests {
 
     #[test]
     fn test_minimum_pair() {
-        // Quantized [1.0, 2.0, 3.0, 4.0] (with range [0., 5.])
-        let data = TensorData::quantized(
-            vec![-77i8, -26, 25, 76],
-            [4],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let a = TestTensor::<1>::from_data(data, &Default::default());
-        // Quantized [2.0, 1.0, 4.0, 5.0] (with range [0., 5.])
-        let data = TensorData::quantized(
-            vec![-26i8, -77, 76, 127],
-            [4],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let b = TestTensor::<1>::from_data(data, &Default::default());
+        let a = QTensor::<TestBackend, 1>::int8_affine([1.0, 5.0, 3.0, 4.0]);
+        let b = QTensor::<TestBackend, 1>::int8_affine([2.0, 1.0, 4.0, 5.0]);
 
         let output = a.min_pair(b);
         let expected = TensorData::from([1.0, 1.0, 3.0, 4.0]);

--- a/crates/burn-tensor/src/tests/quantization/ops/mod.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/mod.rs
@@ -38,6 +38,7 @@ mod select;
 mod sin;
 mod slice;
 mod sort_argsort;
+mod split;
 mod sqrt;
 mod stack;
 mod sub;

--- a/crates/burn-tensor/src/tests/quantization/ops/mul.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/mul.rs
@@ -1,20 +1,12 @@
 #[burn_tensor_testgen::testgen(q_mul)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{AffineQuantization, QuantizationStrategy};
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::TensorData;
 
     #[test]
     fn should_support_mul_ops() {
-        let device = Default::default();
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data.clone(), &device);
-        let tensor_2 = TestTensor::<2>::from_data(data, &device);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor_2 = tensor_1.clone();
 
         let output = tensor_1 * tensor_2;
         let expected = TensorData::from([[0.0, 1.0, 4.0], [9.0, 16.0, 25.0]]);
@@ -28,21 +20,8 @@ mod tests {
 
     #[test]
     fn test_mul_broadcast() {
-        let device = Default::default();
-        // Quantized [[0.0, 1.0, 2.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -1, 127],
-            [1, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.007843138, -128)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data.clone(), &device);
-        // Quantized [[3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]
-        let data = TensorData::quantized(
-            vec![-32i8, -1, 31, 63, 95, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.03137255, -128)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data.clone(), &device);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8([[3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]);
 
         let output = tensor_1 * tensor_2;
         let expected = TensorData::from([[0.0, 4.0, 10.0], [0.0, 7.0, 16.0]]);
@@ -56,21 +35,8 @@ mod tests {
 
     #[test]
     fn test_mul_broadcast_2_dims() {
-        let device = Default::default();
-        // Quantized [[0.0, 1.0, 2.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -1, 127],
-            [3, 1],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.007843138, -128)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data.clone(), &device);
-        // Quantized [[0.0, 1.0, 2.0]]
-        let data = TensorData::quantized(
-            vec![25i8, 76, 127],
-            [1, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data.clone(), &device);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8([[0.0], [1.0], [2.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8([[3.0, 4.0, 5.0]]);
 
         let output = tensor_1 * tensor_2;
         let expected = TensorData::from([[0.0, 0.0, 0.0], [3.0, 4.0, 5.0], [6.0, 8.0, 10.0]]);
@@ -84,13 +50,7 @@ mod tests {
 
     #[test]
     fn should_support_mul_scalar_ops() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data.clone(), &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
         let scalar = 2.0;
 
         let output = tensor * scalar;

--- a/crates/burn-tensor/src/tests/quantization/ops/narrow.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/narrow.rs
@@ -1,18 +1,13 @@
 #[burn_tensor_testgen::testgen(q_narrow)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{AffineQuantization, QuantizationStrategy};
-    use burn_tensor::{Shape, Tensor, TensorData};
+    use burn_tensor::{Shape, TensorData};
 
+    // NOTE: we use affine quantization to reduce quantization errors for range of input values
     #[test]
     fn test_narrow() {
-        // Quantized [[1., 2., 3.], [7., 8., 9.], [13., 14., 15.]]
-        let data = TensorData::quantized(
-            vec![-111i8, -94, -77, -9, 8, 25, 93, 110, 127],
-            [3, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.05882353, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data.clone(), &Default::default());
+        let tensor =
+            QTensor::<TestBackend, 2>::int8_affine([[1., 2., 3.], [7., 8., 9.], [13., 14., 15.]]);
 
         let output = tensor.clone().narrow(0, 0, 2);
         let expected = TensorData::from([[1., 2., 3.], [7., 8., 9.]]);
@@ -35,13 +30,8 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_narrow_invalid_dim() {
-        // Quantized [[1., 2., 3.], [7., 8., 9.], [13., 14., 15.]]
-        let data = TensorData::quantized(
-            vec![-111i8, -94, -77, -9, 8, 25, 93, 110, 127],
-            [3, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.05882353, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data.clone(), &Default::default());
+        let tensor =
+            QTensor::<TestBackend, 2>::int8_affine([[1., 2., 3.], [7., 8., 9.], [13., 14., 15.]]);
 
         let output = tensor.narrow(2, 0, 2);
     }
@@ -49,13 +39,8 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_narrow_invalid_start() {
-        // Quantized [[1., 2., 3.], [7., 8., 9.], [13., 14., 15.]]
-        let data = TensorData::quantized(
-            vec![-111i8, -94, -77, -9, 8, 25, 93, 110, 127],
-            [3, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.05882353, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data.clone(), &Default::default());
+        let tensor =
+            QTensor::<TestBackend, 2>::int8_affine([[1., 2., 3.], [7., 8., 9.], [13., 14., 15.]]);
 
         let output = tensor.narrow(0, 3, 2);
     }
@@ -63,13 +48,8 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_narrow_invalid_zero_length() {
-        // Quantized [[1., 2., 3.], [7., 8., 9.], [13., 14., 15.]]
-        let data = TensorData::quantized(
-            vec![-111i8, -94, -77, -9, 8, 25, 93, 110, 127],
-            [3, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.05882353, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data.clone(), &Default::default());
+        let tensor =
+            QTensor::<TestBackend, 2>::int8_affine([[1., 2., 3.], [7., 8., 9.], [13., 14., 15.]]);
 
         let output = tensor.narrow(0, 1, 0);
     }
@@ -77,13 +57,8 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_narrow_invalid_length() {
-        // Quantized [[1., 2., 3.], [7., 8., 9.], [13., 14., 15.]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [3, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.05882353, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data.clone(), &Default::default());
+        let tensor =
+            QTensor::<TestBackend, 2>::int8_affine([[1., 2., 3.], [7., 8., 9.], [13., 14., 15.]]);
 
         let output = tensor.narrow(0, 0, 4);
     }

--- a/crates/burn-tensor/src/tests/quantization/ops/neg.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/neg.rs
@@ -1,18 +1,11 @@
 #[burn_tensor_testgen::testgen(q_neg)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{AffineQuantization, QuantizationStrategy};
     use burn_tensor::{Tensor, TensorData};
 
     #[test]
     fn should_support_neg_ops() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data.clone(), &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.neg();
         let expected = TensorData::from([[-0.0, -1.0, -2.0], [-3.0, -4.0, -5.0]]).convert::<f32>();

--- a/crates/burn-tensor/src/tests/quantization/ops/permute.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/permute.rs
@@ -1,22 +1,15 @@
 #[burn_tensor_testgen::testgen(q_permute)]
 mod tests {
     use super::*;
-    use burn_tensor::backend::Backend;
-    use burn_tensor::quantization::{AffineQuantization, QuantizationStrategy};
-    use burn_tensor::{Device, Tensor, TensorData};
+    use burn_tensor::TensorData;
 
+    // NOTE: we use affine quantization to reduce quantization errors for the given values range
     #[test]
     fn permute_float() {
-        let device = Default::default();
-        // Quantized [0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.]
-        let data = TensorData::quantized(
-            vec![
-                -128i8, -111, -94, -77, -60, -43, -26, -9, 8, 25, 42, 59, 76, 93, 110, 127,
-            ],
-            [2, 2, 4],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.05882353, -128)),
-        );
-        let tensor = TestTensor::<3>::from_data(data.clone(), &device);
+        let tensor = QTensor::<TestBackend, 1>::int8_affine([
+            0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
+        ])
+        .reshape([2, 2, 4]);
 
         let permuted = tensor.clone().permute([2, 1, 0]);
 
@@ -47,36 +40,24 @@ mod tests {
     #[test]
     #[should_panic]
     fn edge_repeated_axes() {
-        let device = Default::default();
-        // Quantized [0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.]
-        let data = TensorData::quantized(
-            vec![
-                -128i8, -111, -94, -77, -60, -43, -26, -9, 8, 25, 42, 59, 76, 93, 110, 127,
-            ],
-            [2, 2, 4],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.05882353, -128)),
-        );
-        let tensor = TestTensor::<3>::from_data(data.clone(), &device);
+        let tensor = QTensor::<TestBackend, 1>::int8_affine([
+            0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
+        ])
+        .reshape([2, 2, 4]);
 
         // Test with a repeated axis
-        let _ = tensor.clone().permute([0, 0, 1]);
+        let _ = tensor.permute([0, 0, 1]);
     }
 
     #[test]
     #[should_panic]
     fn edge_out_of_bound_axis() {
-        let device = Default::default();
-        // Quantized [0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.]
-        let data = TensorData::quantized(
-            vec![
-                -128i8, -111, -94, -77, -60, -43, -26, -9, 8, 25, 42, 59, 76, 93, 110, 127,
-            ],
-            [2, 2, 4],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.05882353, -128)),
-        );
-        let tensor = TestTensor::<3>::from_data(data.clone(), &device);
+        let tensor = QTensor::<TestBackend, 1>::int8_affine([
+            0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
+        ])
+        .reshape([2, 2, 4]);
 
         // Test with an invalid axis
-        let _ = tensor.clone().permute([3, 0, 1]);
+        let _ = tensor.permute([3, 0, 1]);
     }
 }

--- a/crates/burn-tensor/src/tests/quantization/ops/powf.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/powf.rs
@@ -1,56 +1,29 @@
 #[burn_tensor_testgen::testgen(q_powf)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{
-        AffineQuantization, QuantizationStrategy, SymmetricQuantization,
-    };
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::TensorData;
 
     #[test]
     fn should_support_powf_ops() {
-        let device = Default::default();
-        // Quantized [[1.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-77i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &device);
-        // Quantized [[1.0, 1.0, 2.0], [3.0, 4.0, 2.0]] (with range [1., 5.] to reduce quantization errors)
-        let data = TensorData::quantized(
-            vec![-77i8, -77, -26, 25, 76, -26],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor_pow = TestTensor::<2>::from_data(data, &device);
+        // NOTE: we use affine quantization to reduce quantization errors
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[1.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor_pow = QTensor::<TestBackend, 2>::int8_affine([[1.0, 1.0, 2.0], [3.0, 4.0, 2.0]]);
 
         let output = tensor.powf(tensor_pow);
         let expected = TensorData::from([[1.0, 1.0, 4.0], [27.0, 256.0, 25.0]]);
 
-        // NOTE: we set higher tolerance (0.2) due to larger de/quantization errors accumulation w/ powers
+        // Precision 1 to approximate de/quantization errors
         output
             .dequantize()
             .into_data()
-            .assert_approx_eq_diff(&expected, 0.2);
+            .assert_approx_eq(&expected, 1);
     }
 
     #[test]
     fn should_support_neg_power() {
-        let device = Default::default();
-        // Quantized [[1.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-77i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &device);
-        // Quantized [[-0.95, -0.67, -0.45], [-0.24, -0.5, -0.6]]
-        let data = TensorData::quantized(
-            vec![-128i8, -53, 6, 63, -7, -34],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.00372549, 127)),
-        );
-        let tensor_pow = TestTensor::<2>::from_data(data, &device);
+        let tensor = QTensor::<TestBackend, 2>::int8([[1.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor_pow =
+            QTensor::<TestBackend, 2>::int8([[-0.95, -0.67, -0.45], [-0.24, -0.5, -0.6]]);
 
         let output = tensor.powf(tensor_pow);
         let expected = TensorData::from([[1., 1., 0.73204285], [0.76822936, 0.5, 0.38073079]]);
@@ -64,24 +37,11 @@ mod tests {
 
     #[test]
     fn should_support_neg_values_with_even_power() {
-        let device = Default::default();
-        // Quantized [[0.0, -1.0, -2.0], [-3.0, -4.0, -5.0]]
-        let data = TensorData::quantized(
-            vec![126i8, 75, 24, -27, -78, -128],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, 126)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &device);
-        // Quantized [[4.0, 2.0, 4.0], [2.0, 4.0, 2.0]] (with range [2., 5.] to reduce quantization errors)
-        let data = TensorData::quantized(
-            vec![76i8, -26, 76, -26, 76, -26],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor_pow = TestTensor::<2>::from_data(data, &device);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, -1.0, -2.0], [-3.0, -4.0, -5.0]]);
+        let tensor_pow = QTensor::<TestBackend, 2>::int8([[2.0, 2.0, 2.0], [2.0, 2.0, 2.0]]);
 
         let output = tensor.powf(tensor_pow);
-        let expected = TensorData::from([[0.0, 1.0, 16.0], [9.0, 256.0, 25.0]]);
+        let expected = TensorData::from([[0.0, 1.0, 4.0], [9.0, 16.0, 25.0]]);
 
         // Precision 1 to approximate de/quantization errors
         output
@@ -92,30 +52,16 @@ mod tests {
 
     #[test]
     fn should_support_neg_values_with_odd_power() {
-        let device = Default::default();
-        // Quantized [[0.0, -1.0, -2.0], [-3.0, -4.0, -4.0]] (with range [-5., 0.] to reduce quantization errors)
-        let data = TensorData::quantized(
-            vec![126i8, 75, 24, -27, -78, -78],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, 126)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
-        // Quantized [[3.0, 3.0, 3.0], [3.0, 3.0, 3.0]]
-        let data = TensorData::quantized(
-            vec![127i8, 127, 127, 127, 127, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.011764706, -128)),
-        );
-        let tensor_pow = TestTensor::<2>::from_data(data, &device);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, -1.0, -2.0], [-3.0, -4.0, -4.0]]);
+        let tensor_pow = QTensor::<TestBackend, 2>::int8([[3.0, 3.0, 3.0], [3.0, 3.0, 3.0]]);
 
         let output = tensor.powf(tensor_pow);
         let expected = TensorData::from([[0.0, -1.0, -8.0], [-27.0, -64.0, -64.0]]);
 
-        // NOTE: we set higher tolerance (0.3) due to larger de/quantization errors accumulation w/ powers
-        // and large output range
+        // Precision 1 to approximate de/quantization errors
         output
             .dequantize()
             .into_data()
-            .assert_approx_eq_diff(&expected, 0.3);
+            .assert_approx_eq(&expected, 1);
     }
 }

--- a/crates/burn-tensor/src/tests/quantization/ops/recip.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/recip.rs
@@ -1,18 +1,11 @@
 #[burn_tensor_testgen::testgen(q_recip)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{AffineQuantization, QuantizationStrategy};
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::TensorData;
 
     #[test]
     fn should_support_recip_ops() {
-        // Quantized [[0.5, 1.0, 2.0], [3.0, -4.0, -5.0]]
-        let data = TensorData::quantized(
-            vec![47i8, 63, 95, 127, -96, -128],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.03137255, 31)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.5, 1.0, 2.0], [3.0, -4.0, -5.0]]);
 
         let output = tensor.recip();
         let expected = TensorData::from([[2.0, 1.0, 0.5], [0.33333, -0.25, -0.2]]);

--- a/crates/burn-tensor/src/tests/quantization/ops/remainder.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/remainder.rs
@@ -1,39 +1,17 @@
 #[burn_tensor_testgen::testgen(q_remainder)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{
-        AffineQuantization, QuantizationStrategy, SymmetricQuantization,
-    };
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::TensorData;
 
     #[test]
     fn should_support_remainder_basic() {
-        let device = Default::default();
-        let lhs = TestTensor::<1>::from_data(
-            // [-3.0, -2.0, -1.0, 1.0, 2.0, 3.0]
-            TensorData::quantized(
-                vec![-127i8, -85, -42, 42, 85, 127],
-                [6],
-                QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(
-                    0.023622047,
-                )),
-            ),
-            &device,
-        );
-        let rhs = TestTensor::<1>::from_data(
-            // [2.0, 3.0, 1.0, 2.0, 1.0, 3.0]
-            TensorData::quantized(
-                vec![85i8, 127, 42, 85, 42, 127],
-                [6],
-                QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(
-                    0.023622047,
-                )),
-            ),
-            &device,
-        );
+        let lhs = QTensor::<TestBackend, 1>::int8([-3.0, -2.0, -1.0, 1.0, 2.0, 2.0]);
+        let rhs = QTensor::<TestBackend, 1>::int8([2.0, 3.0, 1.0, 2.0, 1.0, 2.0]);
 
         let output = lhs.remainder(rhs);
         let expected = TensorData::from([1., 1., 0., 1., 0., 0.]);
+
+        // Precision 1 to approximate de/quantization errors
         output
             .dequantize()
             .into_data()
@@ -42,13 +20,8 @@ mod tests {
 
     #[test]
     fn should_support_remainder_basic_scalar() {
-        // Quantized [-3.0, -2.0, -1.0, 1.0, 2.0, 3.0]
-        let data = TensorData::quantized(
-            vec![-128i8, -85, -43, 43, 85, 127],
-            [6],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.023529412, 0)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        // NOTE: we use affine quantization to reduce quantization errors for range of input values
+        let tensor = QTensor::<TestBackend, 1>::int8_affine([-3.0, -2.0, -1.0, 1.0, 2.0, 3.0]);
 
         let output = tensor.remainder_scalar(2.0);
         let expected = TensorData::from([1.0, 0.0, 1.0, 1.0, 0.0, 1.0]);
@@ -62,28 +35,13 @@ mod tests {
 
     #[test]
     fn should_support_remainder_float() {
-        let device = Default::default();
-        let lhs = TestTensor::<1>::from_data(
-            // [1.0, 2.0, 3.0, 4.0, 5.0]
-            TensorData::quantized(
-                vec![-77i8, -26, 25, 76, 127],
-                [5],
-                QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019623, -128)),
-            ),
-            &device,
-        );
-        let rhs = TestTensor::<1>::from_data(
-            // [1.4233, 2.7313, 0.2641, 1.9651, 0.5897]
-            TensorData::quantized(
-                vec![5i8, 127, -103, 56, -73],
-                [5],
-                QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.010700, -128)),
-            ),
-            &device,
-        );
+        let lhs = QTensor::<TestBackend, 1>::int8([1.0, 2.0, 3.0, 4.0, 5.0]);
+        let rhs = QTensor::<TestBackend, 1>::int8([1.4233, 2.7313, 0.2641, 1.9651, 0.5897]);
 
         let output = lhs.remainder(rhs);
         let expected = TensorData::from([1., 2., 0.0949, 0.0698, 0.2824]);
+
+        // Precision 1 to approximate de/quantization errors
         output
             .dequantize()
             .into_data()
@@ -92,13 +50,7 @@ mod tests {
 
     #[test]
     fn should_support_remainder_float_scalar() {
-        // Quantized [1.0, 2.0, 3.0, 4.0, 5.0]
-        let data = TensorData::quantized(
-            vec![-77i8, -26, 25, 76, 127],
-            [5],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8([1.0, 2.0, 3.0, 4.0, 5.0]);
 
         let output = tensor.remainder_scalar(-1.5);
         let expected = TensorData::from([-0.5, -1.0, 0.0, -0.5, -1.0]);
@@ -112,29 +64,13 @@ mod tests {
 
     #[test]
     fn should_be_zero() {
-        let device = Default::default();
-        let lhs = TestTensor::<1>::from_data(
-            // [0.0, 0.0, 0.0]
-            TensorData::quantized(
-                vec![0i8, 0, 0],
-                [3],
-                QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.1)),
-            ),
-            &device,
-        );
-        let rhs = TestTensor::<1>::from_data(
-            // [3.5, -2.1, 1e-5 rounded]
-            TensorData::quantized(
-                vec![127i8, -128, -33],
-                [3],
-                QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.021961, -32)),
-            ),
-            &device,
-        );
+        let lhs = QTensor::<TestBackend, 1>::int8([0.0, 0.0, 0.0]);
+        let rhs = QTensor::<TestBackend, 1>::int8([3.5, -2.1, 1.5]);
 
         let output = lhs.remainder(rhs);
         let expected = TensorData::from([0.0, 0.0, 0.0]);
 
+        // Precision 1 to approximate de/quantization errors
         output
             .dequantize()
             .into_data()
@@ -143,13 +79,7 @@ mod tests {
 
     #[test]
     fn should_be_zero_scalar() {
-        // Quantized [0.0, 0.0, 0.0]
-        let data = TensorData::quantized(
-            vec![0i8, 0, 0],
-            [3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.1)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8([0.0, 0.0, 0.0]);
 
         let output = tensor.remainder_scalar(3.5);
         let expected = TensorData::from([0.0, 0.0, 0.0]);
@@ -162,33 +92,11 @@ mod tests {
 
     #[test]
     fn should_have_no_remainder() {
-        // quantization errors introduces remainder values
-        let device = Default::default();
-        let lhs = TestTensor::<1>::from_data(
-            // [-1.4843, 1.135, -2.1563, 1.0862, 0.5034, 3.6587]
-            TensorData::quantized(
-                vec![-52i8, 39, -75, 38, 17, 127],
-                [6],
-                QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(
-                    0.02880866,
-                )),
-            ),
-            &device,
-        );
-        let rhs = TestTensor::<1>::from_data(
-            // [1.4843, 1.135, 2.1563, 1.0862, 0.5034, 3.6587]
-            TensorData::quantized(
-                vec![52i8, 39, 75, 38, 17, 127],
-                [6],
-                QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(
-                    0.02880866,
-                )),
-            ),
-            &device,
-        );
+        let lhs = QTensor::<TestBackend, 1>::int8([1.0, 2.0, 3.0, 4.0, 5.0]);
+        let rhs = QTensor::<TestBackend, 1>::int8([1.0, 2.0, 3.0, 4.0, 5.0]);
 
         let output = lhs.remainder(rhs);
-        let expected = TensorData::from([0.0, 0.0, 0.0, 0.0, 0.0, 0.0]);
+        let expected = TensorData::from([0.0, 0.0, 0.0, 0.0, 0.0]);
 
         output
             .dequantize()
@@ -198,16 +106,10 @@ mod tests {
 
     #[test]
     fn should_have_no_remainder_scalar() {
-        // Quantized [-4.0, 4.0]
-        let data = TensorData::quantized(
-            vec![-127i8, 127],
-            [2],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.031496063)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8([4.0, 4.0]);
 
         let output = tensor.remainder_scalar(4.0);
-        let expected = TensorData::from([-0.0, 0.0]);
+        let expected = TensorData::from([0.0, 0.0]);
 
         output
             .dequantize()
@@ -217,26 +119,8 @@ mod tests {
 
     #[test]
     fn should_be_negative() {
-        let device = Default::default();
-
-        let lhs = TestTensor::<1>::from_data(
-            // [-7.0, -3.0, 2.0, 6.0]
-            TensorData::quantized(
-                vec![-128i8, -50, 48, 127],
-                [4],
-                QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.050980, 9)),
-            ),
-            &device,
-        );
-        let rhs = TestTensor::<1>::from_data(
-            // [-2.5, -2.1, -1.5, -3.25]
-            TensorData::quantized(
-                vec![-69i8, -38, 9, -128],
-                [4],
-                QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.012757, 127)),
-            ),
-            &device,
-        );
+        let lhs = QTensor::<TestBackend, 1>::int8([-7.0, -3.0, 2.0, 6.0]);
+        let rhs = QTensor::<TestBackend, 1>::int8([-2.5, -2.1, -1.5, -3.25]);
 
         let output = lhs.remainder(rhs);
         let expected = TensorData::from([-2., -0.9, -1., -0.5]);
@@ -249,13 +133,7 @@ mod tests {
 
     #[test]
     fn should_be_negative_scalar() {
-        // Quantized [-7.0, -3.0, 2.0, 6.0]
-        let data = TensorData::quantized(
-            vec![-128i8, -50, 48, 127],
-            [4],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.050980393, 9)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8([-7.0, -3.0, 2.0, 6.0]);
 
         let output = tensor.remainder_scalar(-2.5);
         let expected = TensorData::from([-2.0, -0.50, -0.50, -1.5]);
@@ -268,13 +146,7 @@ mod tests {
 
     #[test]
     fn should_support_fp_dividends() {
-        // Quantized [-7.5, -2.5, 2.5, 7.5]
-        let data = TensorData::quantized(
-            vec![-127i8, -42, 42, 127],
-            [4],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.05905512)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8([-7.5, -2.5, 2.5, 7.5]);
 
         let output = tensor.remainder_scalar(3.0);
         let expected = TensorData::from([1.5, 0.5, 2.5, 1.5]);
@@ -287,27 +159,9 @@ mod tests {
 
     #[test]
     fn should_support_large_divisor() {
-        let device = Default::default();
-
-        let lhs = TestTensor::<1>::from_data(
-            // [-1.0, 1.0, -1.5, 1.5, -1.0, 1.0, -1.5, 1.5]
-            TensorData::quantized(
-                vec![-85i8, 85, -128, 127, -85, 85, -128, 127],
-                [8],
-                QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.011765, 0)),
-            ),
-            &device,
-        );
-
-        let rhs = TestTensor::<1>::from_data(
-            // [10.0, 10.0, 10.0, 10.0, -10.0, -10.0, -10.0, -10.0]
-            TensorData::quantized(
-                vec![127i8, 127, 127, 127, -127, -127, -127, -127],
-                [8],
-                QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.078431, 0)),
-            ),
-            &device,
-        );
+        let lhs = QTensor::<TestBackend, 1>::int8([-1.0, 1.0, -1.5, 1.5, -1.0, 1.0, -1.5, 1.5]);
+        let rhs =
+            QTensor::<TestBackend, 1>::int8([10.0, 10.0, 10.0, 10.0, -10.0, -10.0, -10.0, -10.0]);
 
         let output = lhs.remainder(rhs);
         let expected = TensorData::from([9., 1., 8.5, 1.5, -1., -9., -1.5, -8.5]);
@@ -320,13 +174,7 @@ mod tests {
 
     #[test]
     fn should_support_large_divisor_scalar() {
-        // Quantized [-1.0, 1.0]
-        let data = TensorData::quantized(
-            vec![-127i8, 127],
-            [2],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.007874016)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8([-1.0, 1.0]);
 
         let output = tensor.remainder_scalar(10.0);
         let expected = TensorData::from([9.0, 1.0]);
@@ -339,31 +187,10 @@ mod tests {
 
     #[test]
     fn should_support_remainder_op() {
-        let device = Default::default();
-        let lhs = TestTensor::<1>::from_data(
-            // [-3.0, -2.0, -1.0, 1.0, 2.0, 3.0]
-            TensorData::quantized(
-                vec![-127i8, -85, -42, 42, 85, 127],
-                [6],
-                QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(
-                    0.023622047,
-                )),
-            ),
-            &device,
-        );
-        let rhs = TestTensor::<1>::from_data(
-            // [2.0, 3.0, 1.0, 2.0, 1.0, 3.0]
-            TensorData::quantized(
-                vec![85i8, 127, 42, 85, 42, 127],
-                [6],
-                QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(
-                    0.023622047,
-                )),
-            ),
-            &device,
-        );
+        let lhs = QTensor::<TestBackend, 1>::int8([-3.0, -2.0, -1.0, 1.0, 2.0, 2.0]);
+        let rhs = QTensor::<TestBackend, 1>::int8([2.0, 3.0, 1.0, 2.0, 1.0, 2.0]);
 
-        let output = lhs.remainder(rhs);
+        let output = lhs % rhs;
         let expected = TensorData::from([1., 1., 0., 1., 0., 0.]);
 
         output
@@ -374,13 +201,8 @@ mod tests {
 
     #[test]
     fn should_support_remainder_scalar_op() {
-        // Quantized [-3.0, -2.0, -1.0, 1.0, 2.0, 3.0]
-        let data = TensorData::quantized(
-            vec![-128i8, -85, -43, 43, 85, 127],
-            [6],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.023529412, 0)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        // NOTE: we use affine quantization to reduce quantization errors for range of input values
+        let tensor = QTensor::<TestBackend, 1>::int8_affine([-3.0, -2.0, -1.0, 1.0, 2.0, 3.0]);
 
         let output = tensor % 2.0;
         let expected = TensorData::from([1.0, 0.0, 1.0, 1.0, 0.0, 1.0]);

--- a/crates/burn-tensor/src/tests/quantization/ops/repeat_dim.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/repeat_dim.rs
@@ -1,18 +1,12 @@
 #[burn_tensor_testgen::testgen(q_repeat_dim)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{AffineQuantization, QuantizationStrategy};
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::TensorData;
 
+    // NOTE: we use affine quantization to reduce quantization errors for range of input values
     #[test]
     fn should_support_repeat_ops() {
-        // Quantized [[0.0, 1.0, 2.0, 3.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -43, 42, 127],
-            [1, 4],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.011764706, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0, 3.0]]);
 
         let output = tensor.repeat_dim(0, 4);
         let expected = TensorData::from([
@@ -27,15 +21,10 @@ mod tests {
 
     #[test]
     fn should_support_repeat_on_dims_larger_than_1() {
-        // Quantized [0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.]
-        let data = TensorData::quantized(
-            vec![
-                -128i8, -111, -94, -77, -60, -43, -26, -9, 8, 25, 42, 59, 76, 93, 110, 127,
-            ],
-            [4, 2, 2],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.05882353, -128)),
-        );
-        let tensor = TestTensor::<3>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8_affine([
+            0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
+        ])
+        .reshape([4, 2, 2]);
 
         let output = tensor.repeat_dim(2, 2);
         let expected = TensorData::from([

--- a/crates/burn-tensor/src/tests/quantization/ops/reshape.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/reshape.rs
@@ -1,20 +1,12 @@
 #[burn_tensor_testgen::testgen(q_reshape)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{
-        AffineQuantization, QuantizationStrategy, SymmetricQuantization,
-    };
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::TensorData;
 
+    // NOTE: we use affine quantization to reduce quantization errors for range of input values
     #[test]
     fn should_support_reshape_1d() {
-        // Quantized [0.0, 1.0, 2.0, 3.0]
-        let data = TensorData::quantized(
-            vec![-128i8, -43, 42, 127],
-            [4],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.011764706, -128)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0, 3.0]]);
 
         let output = tensor.clone().reshape([1, 4]);
         let expected = TensorData::from([[0.0, 1.0, 2.0, 3.0]]);
@@ -24,13 +16,7 @@ mod tests {
 
     #[test]
     fn should_support_reshape_2d() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.clone().reshape([6]);
         let expected = TensorData::from([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]);
@@ -40,13 +26,10 @@ mod tests {
 
     #[test]
     fn should_support_dim_infererence() {
-        // Quantized [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0]
-        let data = TensorData::quantized(
-            vec![-128i8, -105, -82, -58, -35, -12, 11, 34, 57, 81, 104, 127],
-            [4, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.043137256, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8_affine([
+            0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0,
+        ])
+        .reshape([4, 3]);
 
         // Infer the dimension via -1
         let reshaped = tensor.clone().reshape([2, -1]);
@@ -67,13 +50,7 @@ mod tests {
 
     #[test]
     fn should_not_corrupt_after_slice() {
-        // Quantized [0.0, 0.0]
-        let data = TensorData::quantized(
-            vec![0i8, 0],
-            [2],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.1)),
-        );
-        let zeros = TestTensor::<1>::from_data(data, &Default::default());
+        let zeros = QTensor::<TestBackend, 1>::int8([0.0, 0.0]);
         zeros.clone().slice([1..2]).reshape([1]).exp();
 
         // May lead to zeroes being equal to [0.0, 1.0]
@@ -86,26 +63,14 @@ mod tests {
     #[test]
     #[should_panic]
     fn multiple_neg_ones() {
-        // Quantized [0.0, 1.0, 2.0]
-        let data = TensorData::quantized(
-            vec![0i8, 64, 127],
-            [3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.015748031)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8([0.0, 1.0, 2.0]);
         let data_actual = tensor.reshape([-1, -1]).into_data();
     }
 
     #[test]
     #[should_panic]
     fn neg_value() {
-        // Quantized [0.0, 1.0, 2.0]
-        let data = TensorData::quantized(
-            vec![0i8, 64, 127],
-            [3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.015748031)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8([0.0, 1.0, 2.0]);
         let data_actual = tensor.reshape([-2, -1]).into_data();
     }
 }

--- a/crates/burn-tensor/src/tests/quantization/ops/select.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/select.rs
@@ -1,20 +1,13 @@
 #[burn_tensor_testgen::testgen(q_select)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{AffineQuantization, QuantizationStrategy};
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::TensorData;
 
+    // NOTE: we use affine quantization to reduce quantization errors for range of input values
     #[test]
     fn should_select_1d() {
-        let device = Default::default();
-        // Quantized [0.0, 1.0, 2.0, 3.0]
-        let data = TensorData::quantized(
-            vec![-128i8, -43, 42, 127],
-            [4],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.011764706, -128)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &device);
-        let indices = TestTensorInt::from_data([1, 1, 0, 1, 2], &device);
+        let tensor = QTensor::<TestBackend, 1>::int8_affine([0.0, 1.0, 2.0, 3.0]);
+        let indices = TestTensorInt::from_data([1, 1, 0, 1, 2], &Default::default());
 
         let output = tensor.select(0, indices);
         let expected = TensorData::from([1.0, 1.0, 0.0, 1.0, 2.0]);
@@ -24,15 +17,8 @@ mod tests {
 
     #[test]
     fn should_select_2d_dim0_same_num_dim() {
-        let device = Default::default();
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &device);
-        let indices = TestTensorInt::from_data(([1, 0]), &device);
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let indices = TestTensorInt::from_data(([1, 0]), &Default::default());
 
         let output = tensor.select(0, indices);
         let expected = TensorData::from([[3.0, 4.0, 5.0], [0.0, 1.0, 2.0]]);
@@ -42,15 +28,8 @@ mod tests {
 
     #[test]
     fn should_select_2d_dim0_more_num_dim() {
-        let device = Default::default();
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &device);
-        let indices = TestTensorInt::from_data([1, 0, 1, 1], &device);
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let indices = TestTensorInt::from_data([1, 0, 1, 1], &Default::default());
 
         let output = tensor.select(0, indices);
         let expected = TensorData::from([
@@ -65,15 +44,8 @@ mod tests {
 
     #[test]
     fn should_select_2d_dim1() {
-        let device = Default::default();
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &device);
-        let indices = TestTensorInt::from_data([1, 1, 0, 1, 2], &device);
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let indices = TestTensorInt::from_data([1, 1, 0, 1, 2], &Default::default());
 
         let output = tensor.select(1, indices);
         let expected = TensorData::from([[1.0, 1.0, 0.0, 1.0, 2.0], [4.0, 4.0, 3.0, 4.0, 5.0]]);
@@ -83,22 +55,10 @@ mod tests {
 
     #[test]
     fn should_select_assign_1d() {
-        let device = Default::default();
-        // Quantized [0.0, 1.0, 2.0]
-        let data = TensorData::quantized(
-            vec![-128i8, -1, 127],
-            [3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.007843138, -128)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &device);
-        // Quantized [5.0, 4.0, 3.0, 2.0, 1.0]
-        let data = TensorData::quantized(
-            vec![127i8, 76, 25, -26, -77],
-            [5],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let values = TestTensor::<1>::from_data(data, &device);
-        let indices = TestTensorInt::from_data(TensorData::from([1, 1, 0, 1, 2]), &device);
+        let tensor = QTensor::<TestBackend, 1>::int8_affine([0.0, 1.0, 2.0]);
+        let values = QTensor::<TestBackend, 1>::int8_affine([5.0, 4.0, 3.0, 2.0, 1.0]);
+        let indices =
+            TestTensorInt::from_data(TensorData::from([1, 1, 0, 1, 2]), &Default::default());
 
         let output = tensor.select_assign(0, indices, values);
         let expected = TensorData::from([3.0, 12.0, 3.0]);
@@ -112,16 +72,9 @@ mod tests {
 
     #[test]
     fn should_select_assign_2d_dim0() {
-        let device = Default::default();
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &device);
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
         let values = tensor.clone();
-        let indices = TestTensorInt::from_data(TensorData::from([1, 0]), &device);
+        let indices = TestTensorInt::from_data(TensorData::from([1, 0]), &Default::default());
 
         let output = tensor.select_assign(0, indices, values);
         let expected = TensorData::from([[3.0, 5.0, 7.0], [3.0, 5.0, 7.0]]);
@@ -135,16 +88,9 @@ mod tests {
 
     #[test]
     fn should_select_assign_2d_dim1() {
-        let device = Default::default();
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &device);
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
         let values = tensor.clone();
-        let indices = TestTensorInt::from_data(TensorData::from([1, 0, 2]), &device);
+        let indices = TestTensorInt::from_data(TensorData::from([1, 0, 2]), &Default::default());
 
         let output = tensor.select_assign(1, indices, values);
         let expected = TensorData::from([[1.0, 1.0, 4.0], [7.0, 7.0, 10.0]]);
@@ -159,15 +105,8 @@ mod tests {
     #[test]
     #[should_panic]
     fn should_select_panic_invalid_dimension() {
-        let device = Default::default();
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &device);
-        let indices = TestTensorInt::from_data([1, 1, 0, 1, 2], &device);
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let indices = TestTensorInt::from_data([1, 1, 0, 1, 2], &Default::default());
 
         tensor.select(10, indices);
     }

--- a/crates/burn-tensor/src/tests/quantization/ops/sin.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/sin.rs
@@ -1,18 +1,12 @@
 #[burn_tensor_testgen::testgen(q_sin)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{AffineQuantization, QuantizationStrategy};
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::TensorData;
 
     #[test]
     fn should_support_sin_ops() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        // NOTE: we use affine quantization to reduce quantization errors for range of input values
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.sin();
         let expected = TensorData::from([[0.0, 0.8414, 0.9092], [0.1411, -0.7568, -0.9589]]);

--- a/crates/burn-tensor/src/tests/quantization/ops/sort_argsort.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/sort_argsort.rs
@@ -1,18 +1,15 @@
 #[burn_tensor_testgen::testgen(q_sort_argsort)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{AffineQuantization, QuantizationStrategy};
-    use burn_tensor::{Shape, Tensor, TensorData};
+    use burn_tensor::TensorData;
 
+    // NOTE: we use affine quantization to reduce quantization errors for range of input values
     #[test]
     fn test_sort_1d_float() {
         // Quantized [0.5, 1.2, -0.21, 0., 2.1, 0.94, -0.3, 2.3, 5.2, 4., 0.99, 3., -8.1]
-        let data = TensorData::quantized(
-            vec![37i8, 50, 23, 27, 67, 45, 21, 71, 127, 104, 46, 85, -128],
-            [13],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.052156862, 27)),
-        );
-        let tensor = TestTensor::<1>::from_data(data.clone(), &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8_affine([
+            0.5, 1.2, -0.21, 0., 2.1, 0.94, -0.3, 2.3, 5.2, 4., 0.99, 3., -8.1,
+        ]);
 
         // Sort along dim=0
         let values = tensor.sort(0);
@@ -30,13 +27,9 @@ mod tests {
 
     #[test]
     fn test_argsort_1d_float() {
-        // Quantized [0.5, 1.2, -0.21, 0., 2.1, 0.94, -0.3, 2.3, 5.2, 4., 0.99, 3., -8.1]
-        let data = TensorData::quantized(
-            vec![37i8, 50, 23, 27, 67, 45, 21, 71, 127, 104, 46, 85, -128],
-            [13],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.052156862, 27)),
-        );
-        let tensor = TestTensor::<1>::from_data(data.clone(), &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8_affine([
+            0.5, 1.2, -0.21, 0., 2.1, 0.94, -0.3, 2.3, 5.2, 4., 0.99, 3., -8.1,
+        ]);
 
         // Sort along dim=0
         let indices = tensor.argsort(0);
@@ -48,13 +41,9 @@ mod tests {
     #[test]
     fn test_sort_with_indices_descending_float() {
         // 1D
-        // Quantized [0.5, 1.2, -0.21, 0., 2.1, 0.94, -0.3, 2.3, 5.2, 4., 0.99, 3., -8.1]
-        let data = TensorData::quantized(
-            vec![37i8, 50, 23, 27, 67, 45, 21, 71, 127, 104, 46, 85, -128],
-            [13],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.052156862, 27)),
-        );
-        let tensor = TestTensor::<1>::from_data(data.clone(), &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8_affine([
+            0.5, 1.2, -0.21, 0., 2.1, 0.94, -0.3, 2.3, 5.2, 4., 0.99, 3., -8.1,
+        ]);
 
         // Sort along dim=0
         let (values, indices) = tensor.sort_descending_with_indices(0);
@@ -73,12 +62,10 @@ mod tests {
 
         // 3D
         // Quantized [-0.5, 1.2, -0.21, 0., 2.1, 0.94, -0.3, 2.3, 4., 0.99, 3., -8.1]
-        let data = TensorData::quantized(
-            vec![31i8, 67, 38, 42, 86, 62, 36, 90, 126, 63, 105, -128],
-            [2, 2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.047450982, 42)),
-        );
-        let tensor = TestTensor::<3>::from_data(data.clone(), &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8_affine([
+            -0.5, 1.2, -0.21, 0., 2.1, 0.94, -0.3, 2.3, 4., 0.99, 3., -8.1,
+        ])
+        .reshape([2, 2, 3]);
 
         // Sort along dim=1
         let (values, indices) = tensor.sort_descending_with_indices(1);
@@ -99,13 +86,10 @@ mod tests {
 
     #[test]
     fn test_sort_float() {
-        // Quantized [-0.5, 1.2, -0.21, 0., 2.1, 0.94, -0.3, 2.3, 4., 0.99, 3., -8.1]
-        let data = TensorData::quantized(
-            vec![31i8, 67, 38, 42, 86, 62, 36, 90, 126, 63, 105, -128],
-            [2, 2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.047450982, 42)),
-        );
-        let tensor = TestTensor::<3>::from_data(data.clone(), &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8_affine([
+            -0.5, 1.2, -0.21, 0., 2.1, 0.94, -0.3, 2.3, 4., 0.99, 3., -8.1,
+        ])
+        .reshape([2, 2, 3]);
 
         // Sort along dim=0
         let values = tensor.clone().sort(0);
@@ -149,13 +133,10 @@ mod tests {
 
     #[test]
     fn test_sort_with_indices_float() {
-        // Quantized [-0.5, 1.2, -0.21, 0., 2.1, 0.94, -0.3, 2.3, 4., 0.99, 3., -8.1]
-        let data = TensorData::quantized(
-            vec![31i8, 67, 38, 42, 86, 62, 36, 90, 126, 63, 105, -128],
-            [2, 2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.047450982, 42)),
-        );
-        let tensor = TestTensor::<3>::from_data(data.clone(), &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8_affine([
+            -0.5, 1.2, -0.21, 0., 2.1, 0.94, -0.3, 2.3, 4., 0.99, 3., -8.1,
+        ])
+        .reshape([2, 2, 3]);
 
         // Sort along dim=0
         let (values, indices) = tensor.clone().sort_with_indices(0);
@@ -207,13 +188,10 @@ mod tests {
 
     #[test]
     fn test_argsort_float() {
-        // Quantized [-0.5, 1.2, -0.21, 0., 2.1, 0.94, -0.3, 2.3, 4., 0.99, 3., -8.1]
-        let data = TensorData::quantized(
-            vec![31i8, 67, 38, 42, 86, 62, 36, 90, 126, 63, 105, -128],
-            [2, 2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.047450982, 42)),
-        );
-        let tensor = TestTensor::<3>::from_data(data.clone(), &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8_affine([
+            -0.5, 1.2, -0.21, 0., 2.1, 0.94, -0.3, 2.3, 4., 0.99, 3., -8.1,
+        ])
+        .reshape([2, 2, 3]);
 
         // Sort along dim=0
         let indices = tensor.clone().argsort(0);
@@ -235,25 +213,8 @@ mod tests {
     }
 
     #[test]
-    fn test_sort_float_nan() {
-        let tensor = TestTensor::<2>::from([[-0.5, f32::NAN], [0., 0.94], [-0.3, f32::NAN]]);
-
-        // Sort along dim=0
-        let values = tensor.sort(0);
-
-        let values_expected = TensorData::from([[-0.5, 0.94], [-0.3, f32::NAN], [0., f32::NAN]]);
-        values.into_data().assert_approx_eq(&values_expected, 5);
-    }
-
-    #[test]
     fn test_sort_descending_1d() {
-        // Quantized [1.0, 2.0, 3.0, 4.0, 5.0]
-        let data = TensorData::quantized(
-            vec![-77i8, -26, 25, 76, 127],
-            [5],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8_affine([1.0, 2.0, 3.0, 4.0, 5.0]);
 
         // Sort along dim=0
         let values = tensor.sort_descending(0);

--- a/crates/burn-tensor/src/tests/quantization/ops/split.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/split.rs
@@ -1,0 +1,213 @@
+#[burn_tensor_testgen::testgen(q_split)]
+mod tests {
+    use super::*;
+    use alloc::vec::Vec;
+    use burn_tensor::quantization::{QuantizationStrategy, SymmetricQuantization};
+    use burn_tensor::{Tensor, TensorData};
+
+    #[test]
+    fn test_split_evenly_divisible() {
+        // Quantized [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+        let data = TensorData::quantized(
+            vec![0i8, 25, 51, 76, 102, 127],
+            [6],
+            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
+        );
+        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+
+        let tensors = tensor.split(2, 0);
+        assert_eq!(tensors.len(), 3);
+
+        let expected = vec![
+            TensorData::from([0., 1.]),
+            TensorData::from([2., 3.]),
+            TensorData::from([4., 5.]),
+        ];
+
+        // Precision 1 to approximate de/quantization errors
+        for (index, tensor) in tensors.into_iter().enumerate() {
+            tensor
+                .dequantize()
+                .to_data()
+                .assert_approx_eq(&expected[index], 1);
+        }
+    }
+
+    #[test]
+    fn test_split_not_evenly_divisible() {
+        // Quantized [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+        let data = TensorData::quantized(
+            vec![0i8, 21, 42, 64, 85, 106, 127],
+            [7],
+            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.047244094)),
+        );
+        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+
+        let tensors = tensor.split(2, 0);
+        assert_eq!(tensors.len(), 4);
+
+        let expected = vec![
+            TensorData::from([0., 1.]),
+            TensorData::from([2., 3.]),
+            TensorData::from([4., 5.]),
+            TensorData::from([6.]),
+        ];
+
+        // Precision 1 to approximate de/quantization errors
+        for (index, tensor) in tensors.into_iter().enumerate() {
+            tensor
+                .dequantize()
+                .to_data()
+                .assert_approx_eq(&expected[index], 1);
+        }
+    }
+
+    #[test]
+    fn test_split_along_dim1() {
+        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
+        let data = TensorData::quantized(
+            vec![0i8, 25, 51, 76, 102, 127],
+            [2, 3],
+            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
+        );
+        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+
+        let tensors = tensor.split(2, 1);
+        assert_eq!(tensors.len(), 2);
+
+        let expected = vec![
+            TensorData::from([[0., 1.], [3., 4.]]),
+            TensorData::from([[2.], [5.]]),
+        ];
+
+        // Precision 1 to approximate de/quantization errors
+        for (index, tensor) in tensors.into_iter().enumerate() {
+            tensor
+                .dequantize()
+                .to_data()
+                .assert_approx_eq(&expected[index], 1);
+        }
+    }
+
+    #[test]
+    fn test_split_split_size_larger_than_tensor_size() {
+        // Quantized [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+        let data = TensorData::quantized(
+            vec![0i8, 25, 51, 76, 102, 127],
+            [6],
+            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
+        );
+        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+
+        let tensors = tensor.split(10, 0);
+        assert_eq!(tensors.len(), 1);
+
+        let expected = vec![TensorData::from([0.0, 1.0, 2.0, 3.0, 4.0, 5.0])];
+
+        // Precision 1 to approximate de/quantization errors
+        for (index, tensor) in tensors.into_iter().enumerate() {
+            tensor
+                .dequantize()
+                .to_data()
+                .assert_approx_eq(&expected[index], 1);
+        }
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "split_size must be greater than 0 unless the tensor size along the dimension is 0."
+    )]
+    fn test_split_with_zero_split_size_non_zero_tensor() {
+        // Quantized [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+        let data = TensorData::quantized(
+            vec![0i8, 25, 51, 76, 102, 127],
+            [6],
+            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
+        );
+        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+
+        let _ = tensor.split(0, 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "Given dimension is greater than or equal to the tensor rank.")]
+    fn test_split_invalid_dim() {
+        // Quantized [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+        let data = TensorData::quantized(
+            vec![0i8, 25, 51, 76, 102, 127],
+            [6],
+            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
+        );
+        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+
+        let _ = tensor.split(1, 2);
+    }
+
+    #[test]
+    fn test_split_with_sizes() {
+        // Quantized [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+        let data = TensorData::quantized(
+            vec![0i8, 25, 51, 76, 102, 127],
+            [6],
+            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
+        );
+        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+
+        let tensors = tensor.split_with_sizes(vec![2, 3, 1], 0);
+        assert_eq!(tensors.len(), 3);
+
+        let expected = vec![
+            TensorData::from([0., 1.]),
+            TensorData::from([2., 3., 4.]),
+            TensorData::from([5.]),
+        ];
+
+        // Precision 1 to approximate de/quantization errors
+        for (index, tensor) in tensors.into_iter().enumerate() {
+            tensor
+                .dequantize()
+                .to_data()
+                .assert_approx_eq(&expected[index], 1);
+        }
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "The sum of split_sizes must equal the tensor size along the specified dimension."
+    )]
+    fn test_split_with_sizes_invalid_sum() {
+        // Quantized [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+        let data = TensorData::quantized(
+            vec![0i8, 25, 51, 76, 102, 127],
+            [6],
+            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
+        );
+        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+
+        let _ = tensor.split_with_sizes(vec![2, 2, 1], 0);
+    }
+
+    #[test]
+    fn test_split_with_sizes_zero_length() {
+        // Quantized [0.0, 2.0, 5.0]
+        let data = TensorData::quantized(
+            vec![0i8, 51, 127],
+            [3],
+            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
+        );
+        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+
+        let tensors = tensor.split_with_sizes(vec![0, 1, 2], 0);
+        assert_eq!(tensors.len(), 2);
+
+        let expected = vec![TensorData::from([0.]), TensorData::from([2., 5.])];
+
+        // Precision 1 to approximate de/quantization errors
+        for (index, tensor) in tensors.into_iter().enumerate() {
+            tensor
+                .dequantize()
+                .to_data()
+                .assert_approx_eq(&expected[index], 1);
+        }
+    }
+}

--- a/crates/burn-tensor/src/tests/quantization/ops/split.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/split.rs
@@ -1,19 +1,12 @@
 #[burn_tensor_testgen::testgen(q_split)]
 mod tests {
     use super::*;
-    use alloc::vec::Vec;
-    use burn_tensor::quantization::{QuantizationStrategy, SymmetricQuantization};
+    use alloc::vec;
     use burn_tensor::{Tensor, TensorData};
 
     #[test]
     fn test_split_evenly_divisible() {
-        // Quantized [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [6],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]);
 
         let tensors = tensor.split(2, 0);
         assert_eq!(tensors.len(), 3);
@@ -35,13 +28,7 @@ mod tests {
 
     #[test]
     fn test_split_not_evenly_divisible() {
-        // Quantized [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
-        let data = TensorData::quantized(
-            vec![0i8, 21, 42, 64, 85, 106, 127],
-            [7],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.047244094)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
 
         let tensors = tensor.split(2, 0);
         assert_eq!(tensors.len(), 4);
@@ -64,13 +51,7 @@ mod tests {
 
     #[test]
     fn test_split_along_dim1() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let tensors = tensor.split(2, 1);
         assert_eq!(tensors.len(), 2);
@@ -91,13 +72,7 @@ mod tests {
 
     #[test]
     fn test_split_split_size_larger_than_tensor_size() {
-        // Quantized [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [6],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]);
 
         let tensors = tensor.split(10, 0);
         assert_eq!(tensors.len(), 1);
@@ -118,13 +93,7 @@ mod tests {
         expected = "split_size must be greater than 0 unless the tensor size along the dimension is 0."
     )]
     fn test_split_with_zero_split_size_non_zero_tensor() {
-        // Quantized [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [6],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]);
 
         let _ = tensor.split(0, 0);
     }
@@ -132,26 +101,14 @@ mod tests {
     #[test]
     #[should_panic(expected = "Given dimension is greater than or equal to the tensor rank.")]
     fn test_split_invalid_dim() {
-        // Quantized [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [6],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]);
 
         let _ = tensor.split(1, 2);
     }
 
     #[test]
     fn test_split_with_sizes() {
-        // Quantized [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [6],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]);
 
         let tensors = tensor.split_with_sizes(vec![2, 3, 1], 0);
         assert_eq!(tensors.len(), 3);
@@ -176,26 +133,14 @@ mod tests {
         expected = "The sum of split_sizes must equal the tensor size along the specified dimension."
     )]
     fn test_split_with_sizes_invalid_sum() {
-        // Quantized [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
-        let data = TensorData::quantized(
-            vec![0i8, 25, 51, 76, 102, 127],
-            [6],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]);
 
         let _ = tensor.split_with_sizes(vec![2, 2, 1], 0);
     }
 
     #[test]
     fn test_split_with_sizes_zero_length() {
-        // Quantized [0.0, 2.0, 5.0]
-        let data = TensorData::quantized(
-            vec![0i8, 51, 127],
-            [3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.03937008)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8([0.0, 2.0, 5.0]);
 
         let tensors = tensor.split_with_sizes(vec![0, 1, 2], 0);
         assert_eq!(tensors.len(), 2);

--- a/crates/burn-tensor/src/tests/quantization/ops/sqrt.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/sqrt.rs
@@ -1,19 +1,13 @@
 #[burn_tensor_testgen::testgen(q_sqrt)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{AffineQuantization, QuantizationStrategy};
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::TensorData;
     use core::f32::consts::SQRT_2;
 
     #[test]
     fn should_support_sqrt_ops() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        // NOTE: we use affine quantization to reduce quantization errors for range of input values
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.sqrt();
         let expected = TensorData::from([[0.0, 1.0, SQRT_2], [1.73205, 2.0, 2.2360]]);

--- a/crates/burn-tensor/src/tests/quantization/ops/stack.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/stack.rs
@@ -1,27 +1,14 @@
 #[burn_tensor_testgen::testgen(q_stack)]
 mod tests {
     use super::*;
-    use alloc::vec::Vec;
-    use burn_tensor::quantization::{AffineQuantization, QuantizationStrategy};
+    use alloc::vec;
     use burn_tensor::{Tensor, TensorData};
 
+    // NOTE: we use affine quantization to reduce quantization errors for range of input values
     #[test]
     fn should_support_stack_ops_2d_dim0() {
-        let device = Default::default();
-        // Quantized [[1.0, 2.0, 3.0]]
-        let data = TensorData::quantized(
-            vec![-43i8, 42, 127],
-            [1, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.011764706, -128)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &device);
-        // Quantized [[4.0, 5.0, 6.0]]
-        let data = TensorData::quantized(
-            vec![42i8, 85, 127],
-            [1, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.023529412, -128)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data, &device);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8_affine([[1.0, 2.0, 3.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8_affine([[4.0, 5.0, 6.0]]);
 
         let output = Tensor::stack::<3>(vec![tensor_1, tensor_2], 0);
         let expected = TensorData::from([[[1.0, 2.0, 3.0]], [[4.0, 5.0, 6.0]]]);
@@ -35,21 +22,8 @@ mod tests {
 
     #[test]
     fn should_support_stack_ops_2d_dim1() {
-        let device = Default::default();
-        // Quantized [[1.0, 2.0, 3.0]]
-        let data = TensorData::quantized(
-            vec![-43i8, 42, 127],
-            [1, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.011764706, -128)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &device);
-        // Quantized [[4.0, 5.0, 6.0]]
-        let data = TensorData::quantized(
-            vec![42i8, 85, 127],
-            [1, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.023529412, -128)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data, &device);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8_affine([[1.0, 2.0, 3.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8_affine([[4.0, 5.0, 6.0]]);
 
         let output = Tensor::stack::<3>(vec![tensor_1, tensor_2], 1);
         let expected = TensorData::from([[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]]);
@@ -63,21 +37,10 @@ mod tests {
 
     #[test]
     fn should_support_stack_ops_3d() {
-        let device = Default::default();
-        // Quantized [[[1.0, 2.0, 3.0]], [[3.0, 2.0, 1.0]]]
-        let data = TensorData::quantized(
-            vec![-43i8, 42, 127, 127, 42, -43],
-            [2, 1, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.011764706, -128)),
-        );
-        let tensor_1 = TestTensor::<3>::from_data(data, &device);
-        // Quantized [[[4.0, 5.0, 6.0]], [[6.0, 5.0, 4.0]]]
-        let data = TensorData::quantized(
-            vec![42i8, 85, 127, 127, 85, 42],
-            [2, 1, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.023529412, -128)),
-        );
-        let tensor_2 = TestTensor::<3>::from_data(data, &device);
+        let tensor_1 =
+            QTensor::<TestBackend, 3>::int8_affine([[[1.0, 2.0, 3.0]], [[3.0, 2.0, 1.0]]]);
+        let tensor_2 =
+            QTensor::<TestBackend, 3>::int8_affine([[[4.0, 5.0, 6.0]], [[6.0, 5.0, 4.0]]]);
 
         let output = Tensor::stack::<4>(vec![tensor_1, tensor_2], 0);
         let expected = TensorData::from([
@@ -95,44 +58,19 @@ mod tests {
     #[test]
     #[should_panic]
     fn should_panic_when_dimensions_are_not_the_same() {
-        let device = Default::default();
-        // Quantized [[1.0, 2.0, 3.0]], [[3.0, 2.0, 1.0]]
-        let data = TensorData::quantized(
-            vec![-43i8, 42, 127, 127, 42, -43],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.011764706, -128)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &device);
-        // Quantized [[4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![76i8, 127],
-            [1, 2],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data, &device);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8_affine([[1.0, 2.0, 3.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8_affine([[4.0, 5.0]]);
 
-        let output: Tensor<TestBackend, 3> = Tensor::stack(vec![tensor_1, tensor_2], 0);
+        let output: TestTensor<3> = Tensor::stack(vec![tensor_1, tensor_2], 0);
     }
 
     #[test]
     #[should_panic]
     fn should_panic_when_stack_exceeds_dimension() {
-        let device = Default::default();
-        // Quantized [[[1.0, 2.0, 3.0]], [[3.0, 2.0, 1.0]]]
-        let data = TensorData::quantized(
-            vec![-43i8, 42, 127, 127, 42, -43],
-            [1, 2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.011764706, -128)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &device);
-        // Quantized [[4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![42i8, 85, 127],
-            [1, 1, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.023529412, -128)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data, &device);
+        let tensor_1 =
+            QTensor::<TestBackend, 3>::int8_affine([[[1.0, 2.0, 3.0]], [[3.0, 2.0, 1.0]]]);
+        let tensor_2 = QTensor::<TestBackend, 3>::int8_affine([[[4.0, 5.0, 6.0]]]);
 
-        let output: Tensor<TestBackend, 4> = TestTensor::stack(vec![tensor_1, tensor_2], 3);
+        let output: TestTensor<4> = TestTensor::stack(vec![tensor_1, tensor_2], 3);
     }
 }

--- a/crates/burn-tensor/src/tests/quantization/ops/sub.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/sub.rs
@@ -1,26 +1,13 @@
 #[burn_tensor_testgen::testgen(q_sub)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{AffineQuantization, QuantizationStrategy};
-    use burn_tensor::{backend::Backend, Tensor, TensorData};
+    use burn_tensor::TensorData;
 
+    // NOTE: we use affine quantization to reduce quantization errors for range of input values
     #[test]
     fn should_support_sub_ops() {
-        let device = Default::default();
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &device);
-        // Quantized [[6.0, 7.0, 8.0], [9.0, 10.0, 11.0]]
-        let data = TensorData::quantized(
-            vec![11i8, 34, 57, 81, 104, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.043137256, -128)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data, &device);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8_affine([[6.0, 7.0, 8.0], [9.0, 10.0, 11.0]]);
 
         let output = tensor_1 - tensor_2;
         let expected = TensorData::from([[-6.0, -6.0, -6.0], [-6.0, -6.0, -6.0]]);
@@ -34,23 +21,8 @@ mod tests {
 
     #[test]
     fn test_sub_broadcast() {
-        let data_1 = TensorData::from([[0.0, 1.0, 2.0]]);
-        let data_2 = TensorData::from([[3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]);
-        let device = Default::default();
-        // Quantized [[0.0, 1.0, 2.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -1, 127],
-            [1, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.007843138, -128)),
-        );
-        let tensor_1 = TestTensor::<2>::from_data(data, &device);
-        // Quantized [[3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]
-        let data = TensorData::quantized(
-            vec![-32i8, -1, 31, 63, 95, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.03137255, -128)),
-        );
-        let tensor_2 = TestTensor::<2>::from_data(data, &device);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8_affine([[3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]);
 
         let output = tensor_1 - tensor_2;
         let expected = TensorData::from([[-3.0, -3.0, -3.0], [-6.0, -6.0, -6.0]]);
@@ -64,13 +36,7 @@ mod tests {
 
     #[test]
     fn should_support_sub_scalar_ops() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
         let scalar = 2.0;
 
         let output = tensor - scalar;

--- a/crates/burn-tensor/src/tests/quantization/ops/tanh.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/tanh.rs
@@ -1,18 +1,12 @@
 #[burn_tensor_testgen::testgen(q_tanh)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{AffineQuantization, QuantizationStrategy};
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::TensorData;
 
     #[test]
     fn should_support_tanh_ops() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
-            [2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor = TestTensor::<2>::from_data(data, &Default::default());
+        // NOTE: we use affine quantization to reduce quantization errors for range of input values
+        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.tanh();
         let expected = TensorData::from([[0.0, 0.7615, 0.9640], [0.9950, 0.9993, 0.9999]]);

--- a/crates/burn-tensor/src/tests/quantization/ops/topk.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/topk.rs
@@ -1,18 +1,12 @@
 #[burn_tensor_testgen::testgen(q_topk)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{AffineQuantization, QuantizationStrategy};
-    use burn_tensor::{Shape, Tensor, TensorData};
+    use burn_tensor::TensorData;
 
+    // NOTE: we use affine quantization to reduce quantization errors for range of input values
     #[test]
     fn test_topk_1d() {
-        // Quantized [1.0, 2.0, 3.0, 4.0, 5.0]
-        let data = TensorData::quantized(
-            vec![-77i8, -26, 25, 76, 127],
-            [5],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8_affine([1.0, 2.0, 3.0, 4.0, 5.0]);
 
         let values = tensor.topk(3, /*dim*/ 0);
         let expected = TensorData::from([5., 4., 3.]);
@@ -25,13 +19,10 @@ mod tests {
 
     #[test]
     fn test_topk() {
-        // Quantized [[[1., 4., 7.], [2., 5., 6.]], [[3., 0., 9.], [8., 2., 7.]]]
-        let data = TensorData::quantized(
-            vec![-100i8, -15, 70, -71, 14, 42, -43, -128, 127, 99, -71, 70],
-            [2, 2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.03529412, -128)),
-        );
-        let tensor = TestTensor::<3>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 3>::int8_affine([
+            [[1., 4., 7.], [2., 5., 6.]],
+            [[3., 0., 9.], [8., 2., 7.]],
+        ]);
 
         let values = tensor.topk(2, /*dim*/ 2);
         let expected = TensorData::from([[[7., 4.], [6., 5.]], [[9., 3.], [8., 7.]]]);
@@ -46,13 +37,7 @@ mod tests {
     #[test]
     fn test_topk_with_indices() {
         // 1D
-        // Quantized [1.0, 2.0, 3.0, 4.0, 5.0]
-        let data = TensorData::quantized(
-            vec![-77i8, -26, 25, 76, 127],
-            [5],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.019607844, -128)),
-        );
-        let tensor = TestTensor::<1>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8_affine([1.0, 2.0, 3.0, 4.0, 5.0]);
 
         let (values, indices) = tensor.topk_with_indices(3, /*dim*/ 0);
 
@@ -66,13 +51,10 @@ mod tests {
         indices.into_data().assert_eq(&indices_expected, false);
 
         // 3D
-        // Quantized [[[1., 4., 7.], [2., 5., 6.]], [[3., 0., 9.], [8., 2., 7.]]]
-        let data = TensorData::quantized(
-            vec![-100i8, -15, 70, -71, 14, 42, -43, -128, 127, 99, -71, 70],
-            [2, 2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.03529412, -128)),
-        );
-        let tensor = TestTensor::<3>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 3>::int8_affine([
+            [[1., 4., 7.], [2., 5., 6.]],
+            [[3., 0., 9.], [8., 2., 7.]],
+        ]);
 
         let (values, indices) = tensor.topk_with_indices(2, /*dim*/ 2);
 

--- a/crates/burn-tensor/src/tests/quantization/ops/transpose.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/transpose.rs
@@ -1,18 +1,15 @@
 #[burn_tensor_testgen::testgen(q_transpose)]
 mod tests {
     use super::*;
-    use burn_tensor::quantization::{AffineQuantization, QuantizationStrategy};
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::TensorData;
 
+    // NOTE: we use affine quantization to reduce quantization errors for range of input values
     #[test]
     fn should_support_transpose_ops() {
-        // Quantized [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0]
-        let data = TensorData::quantized(
-            vec![-128i8, -105, -82, -58, -35, -12, 11, 34, 57, 81, 104, 127],
-            [2, 2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.043137256, -128)),
-        );
-        let tensor = TestTensor::<3>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8_affine([
+            0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0,
+        ])
+        .reshape([2, 2, 3]);
 
         let output = tensor.transpose();
         let expected = TensorData::from([
@@ -29,13 +26,10 @@ mod tests {
 
     #[test]
     fn should_support_swap_dims() {
-        // Quantized [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0]
-        let data = TensorData::quantized(
-            vec![-128i8, -105, -82, -58, -35, -12, 11, 34, 57, 81, 104, 127],
-            [2, 2, 3],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.043137256, -128)),
-        );
-        let tensor = TestTensor::<3>::from_data(data, &Default::default());
+        let tensor = QTensor::<TestBackend, 1>::int8_affine([
+            0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0,
+        ])
+        .reshape([2, 2, 3]);
 
         let output = tensor.swap_dims(0, 2);
         let expected = TensorData::from([


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `run-checks all` script has been executed.

### Changes

- Refactored qtensor ops tests w/ `QTensor` helper struct
  - Previously defined inputs was clunky, error prone and difficult to understand. Now anyone can more easily add tests for operations using floating point values. `QTensor` methods will automatically quantize the inputs.
- Added missing `q_split` tests
- Added `QTensorOps` docs to burn contrib book
- Fixed zero scale edge cases everywhere

