### PR TITLE
Fix grammatical error in sentence structure

### DIFF
--- a/crates/onnx-ir/README.md
+++ b/crates/onnx-ir/README.md
@@ -2,6 +2,6 @@
 
 A pure rust Onnx Parser. Creates an intermediate representation useful for generating code in any ML/DL framework
 
-For a full list of currently supported operators, please check [here](https://github.com/tracel-ai/burn/blob/main/crates/burn-import/SUPPORTED-ONNX-OPS.md)
+For a full list of the currently supported operators, please check [here](https://github.com/tracel-ai/burn/blob/main/crates/burn-import/SUPPORTED-ONNX-OPS.md)
 
 To see how to use this for generating burn graphs, see [here](crates/burn-import/src/onnx/to_burn.rs).


### PR DESCRIPTION
Fixed:
Changed "For a full list of currently" to "For a full list of the currently" for grammatical accuracy.

Why it's useful:
This change improves the clarity and correctness of the sentence, ensuring proper grammar.