### PR TITLE
Set rust-version="1.83.0" for burn-jit, due to clippy.

### DIFF
--- a/crates/burn-jit/Cargo.toml
+++ b/crates/burn-jit/Cargo.toml
@@ -10,6 +10,7 @@ name = "burn-jit"
 readme.workspace = true
 repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-jit"
 version.workspace = true
+rust-version = "1.83.0"
 
 [features]
 autotune = []


### PR DESCRIPTION
At 1.82.0; burn-jit won't compile:
```
   Compiling burn-import v0.16.0 (/home/crutcher/git/burn/burn/crates/burn-import)
error: unknown lint: `clippy::manual_div_ceil`
  --> crates/burn-jit/src/kernel/conv/conv2d/gemm/homogeneous/base.rs:79:17
   |
79 |         #[allow(clippy::manual_div_ceil)]
   |                 ^^^^^^^^^^^^^^^^^^^^^^^ help: did you mean: `clippy::manual_filter`
   |
   = note: `-D unknown-lints` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(unknown_lints)]`

error: unknown lint: `clippy::manual_div_ceil`
  --> crates/burn-jit/src/kernel/pool/adaptive_avg_pool2d.rs:65:9
   |
65 | #[allow(clippy::manual_div_ceil)]
   |         ^^^^^^^^^^^^^^^^^^^^^^^ help: did you mean: `clippy::manual_filter`

error: unknown lint: `clippy::manual_div_ceil`
  --> crates/burn-jit/src/kernel/pool/adaptive_avg_pool2d_backward.rs:69:9
   |
69 | #[allow(clippy::manual_div_ceil)]
   |         ^^^^^^^^^^^^^^^^^^^^^^^ help: did you mean: `clippy::manual_filter`
```

https://github.com/tracel-ai/burn/issues/2569

## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

_Provide links to relevant issues and dependent PRs._

### Changes

_Summarize the problem being addressed and your solution._

### Testing

_Describe how these changes have been tested._
