### PR TITLE
Simplify Tensor::unsqueeze_dims(); improve handling of negative indicies.

### DIFF
--- a/crates/burn-tensor/src/tests/ops/squeeze.rs
+++ b/crates/burn-tensor/src/tests/ops/squeeze.rs
@@ -151,9 +151,16 @@ mod tests {
     #[test]
     fn should_unsqueeze_dims_multiple_trailing_negatives() {
         let input_tensor = TestTensor::<3>::ones(Shape::new([3, 4, 5]), &Default::default());
-        let output_tensor: Tensor<TestBackend, 6> =
-            input_tensor.unsqueeze_dims(&[-2, 0, -3, -1, -2, -1]);
-        let expected_shape = Shape::new([1, 1, 3, 4, 1, 1, 5, 1, 1]);
+        let output_tensor: Tensor<TestBackend, 6> = input_tensor.unsqueeze_dims(&[0, -1, -2, -1]);
+        let expected_shape = Shape::new([1, 3, 4, 1, 5, 1, 1]);
+        assert_eq!(output_tensor.shape(), expected_shape);
+    }
+
+    #[test]
+    fn should_unsqueeze_dims_negative() {
+        let input_tensor = TestTensor::<3>::ones(Shape::new([3, 4, 5]), &Default::default());
+        let output_tensor: Tensor<TestBackend, 6> = input_tensor.unsqueeze_dims(&[-2]);
+        let expected_shape = Shape::new([3, 4, 1, 5]);
         assert_eq!(output_tensor.shape(), expected_shape);
     }
 

--- a/crates/burn-tensor/src/tests/ops/squeeze.rs
+++ b/crates/burn-tensor/src/tests/ops/squeeze.rs
@@ -151,8 +151,9 @@ mod tests {
     #[test]
     fn should_unsqueeze_dims_multiple_trailing_negatives() {
         let input_tensor = TestTensor::<3>::ones(Shape::new([3, 4, 5]), &Default::default());
-        let output_tensor: Tensor<TestBackend, 6> = input_tensor.unsqueeze_dims(&[0, -1, -1]);
-        let expected_shape = Shape::new([1, 3, 4, 5, 1, 1]);
+        let output_tensor: Tensor<TestBackend, 6> =
+            input_tensor.unsqueeze_dims(&[-2, 0, -3, -1, -2, -1]);
+        let expected_shape = Shape::new([1, 1, 3, 4, 1, 1, 5, 1, 1]);
         assert_eq!(output_tensor.shape(), expected_shape);
     }
 

--- a/crates/burn-tensor/src/tests/ops/squeeze.rs
+++ b/crates/burn-tensor/src/tests/ops/squeeze.rs
@@ -151,16 +151,25 @@ mod tests {
     #[test]
     fn should_unsqueeze_dims_multiple_trailing_negatives() {
         let input_tensor = TestTensor::<3>::ones(Shape::new([3, 4, 5]), &Default::default());
-        let output_tensor: Tensor<TestBackend, 6> = input_tensor.unsqueeze_dims(&[0, -1, -2, -1]);
-        let expected_shape = Shape::new([1, 3, 4, 1, 5, 1, 1]);
+        let output_tensor: Tensor<TestBackend, 6> = input_tensor.unsqueeze_dims(&[0, -1, -1]);
+        let expected_shape = Shape::new([1, 3, 4, 5, 1, 1]);
         assert_eq!(output_tensor.shape(), expected_shape);
     }
 
     #[test]
-    fn should_unsqueeze_dims_negative() {
+    fn should_unsqueeze_dims_negative_two() {
         let input_tensor = TestTensor::<3>::ones(Shape::new([3, 4, 5]), &Default::default());
         let output_tensor: Tensor<TestBackend, 6> = input_tensor.unsqueeze_dims(&[-2]);
         let expected_shape = Shape::new([3, 4, 1, 5]);
+        assert_eq!(output_tensor.shape(), expected_shape);
+    }
+
+    #[test]
+    fn should_unsqueeze_dims_complex_negatives() {
+        let input_tensor = TestTensor::<3>::ones(Shape::new([3, 4, 5]), &Default::default());
+        let output_tensor: Tensor<TestBackend, 6> =
+            input_tensor.unsqueeze_dims(&[0, -1, -3, -2, -1]);
+        let expected_shape = Shape::new([1, 1, 3, 4, 1, 5, 1, 1]);
         assert_eq!(output_tensor.shape(), expected_shape);
     }
 

--- a/crates/burn-tensor/src/tests/ops/squeeze.rs
+++ b/crates/burn-tensor/src/tests/ops/squeeze.rs
@@ -159,17 +159,16 @@ mod tests {
     #[test]
     fn should_unsqueeze_dims_negative_two() {
         let input_tensor = TestTensor::<3>::ones(Shape::new([3, 4, 5]), &Default::default());
-        let output_tensor: Tensor<TestBackend, 6> = input_tensor.unsqueeze_dims(&[-2]);
-        let expected_shape = Shape::new([3, 4, 1, 5]);
+        let output_tensor: Tensor<TestBackend, 5> = input_tensor.unsqueeze_dims(&[-2, -2]);
+        let expected_shape = Shape::new([3, 4, 1, 1, 5]);
         assert_eq!(output_tensor.shape(), expected_shape);
     }
 
     #[test]
-    fn should_unsqueeze_dims_complex_negatives() {
-        let input_tensor = TestTensor::<3>::ones(Shape::new([3, 4, 5]), &Default::default());
-        let output_tensor: Tensor<TestBackend, 6> =
-            input_tensor.unsqueeze_dims(&[0, -1, -3, -2, -1]);
-        let expected_shape = Shape::new([1, 1, 3, 4, 1, 5, 1, 1]);
+    fn should_unsqueeze_dims_negative_fence() {
+        let input_tensor = TestTensor::<2>::ones(Shape::new([3, 4]), &Default::default());
+        let output_tensor: Tensor<TestBackend, 5> = input_tensor.unsqueeze_dims(&[-3, -2, -1]);
+        let expected_shape = Shape::new([1, 3, 1, 4, 1]);
         assert_eq!(output_tensor.shape(), expected_shape);
     }
 


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

https://github.com/tracel-ai/burn/commit/f8c845d42a93b86bf7b5f38949b1335e51a5678b

### Changes

Independently re-discovered the unsqueeze bug fixed on HEAD at: https://github.com/tracel-ai/burn/commit/f8c845d42a93b86bf7b5f38949b1335e51a5678b

This PR makes the tests more aggressive for negative offsets greater than -1; and accumulation of negative offsets.
