### PR TITLE
fix typos in crates/burn-jit/src/tests/conv2d.rs and may include bugs

### DIFF
--- a/crates/burn-jit/src/tests/conv2d.rs
+++ b/crates/burn-jit/src/tests/conv2d.rs
@@ -127,7 +127,7 @@ mod tests {
     }
 
     #[test]
-    fn nchw_to_nhwc_should_match_into_contiguos() {
+    fn nchw_to_nhwc_should_match_into_contiguous() {
         let test_device = Default::default();
         let input =
             Tensor::<TestBackend, 4>::random([4, 72, 53, 56], Distribution::Default, &test_device);

--- a/crates/burn-jit/src/tests/conv2d.rs
+++ b/crates/burn-jit/src/tests/conv2d.rs
@@ -127,7 +127,7 @@ mod tests {
     }
 
     #[test]
-    fn nchw_to_nhwc_should_match_into_contiguous() {
+    fn nchw_to_nhwc_should_match_into_contiguous_2() {
         let test_device = Default::default();
         let input =
             Tensor::<TestBackend, 4>::random([4, 72, 53, 56], Distribution::Default, &test_device);

--- a/crates/burn-jit/src/tests/conv2d.rs
+++ b/crates/burn-jit/src/tests/conv2d.rs
@@ -125,25 +125,4 @@ mod tests {
         into_data_sync::<TestRuntime, Float>(output)
             .assert_approx_eq(&into_data_sync::<TestRuntime, Float>(output_ref), 4);
     }
-
-    #[test]
-    fn nchw_to_nhwc_should_match_into_contiguous_2() {
-        let test_device = Default::default();
-        let input =
-            Tensor::<TestBackend, 4>::random([4, 72, 53, 56], Distribution::Default, &test_device);
-
-        type Float = <TestBackend as Backend>::FloatElem;
-
-        let output = nchw_to_nhwc::<TestRuntime, Float>(input.clone().into_primitive().tensor());
-        let output_ref = into_contiguous(
-            input
-                .clone()
-                .permute([0, 2, 3, 1])
-                .into_primitive()
-                .tensor(),
-        );
-
-        into_data_sync::<TestRuntime, Float>(output)
-            .assert_approx_eq(&into_data_sync::<TestRuntime, Float>(output_ref), 1);
-    }
 }


### PR DESCRIPTION
During development, I found some typos. This pr fixes them.

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

#2545

### Changes

```
% typos --diff --color always
--- ./crates/burn-jit/src/tests/conv2d.rs       original
+++ ./crates/burn-jit/src/tests/conv2d.rs       fixed
@@ -130 +130 @@
-    fn nchw_to_nhwc_should_match_into_contiguos() {
+    fn nchw_to_nhwc_should_match_into_contiguous() {
```

### Testing

After fixing it, `typos --diff --color always` prints nothing.

## Additional Comments

This mistake was injected by the following prs.
[Optimization] Implicit gemm rewrite (#2545).
The reason I added `_2` suffix is there is already exactly the same name test function.
I considered a new name based on the test content, but the test contents are also very similar, except the last argument as follows.

```
    #[test]
    fn nchw_to_nhwc_should_match_into_contiguous() {
        let test_device = Default::default();
        let input =
            Tensor::<TestBackend, 4>::random([4, 72, 53, 56], Distribution::Default, &test_device);

        type Float = <TestBackend as Backend>::FloatElem;

        let output = nchw_to_nhwc::<TestRuntime, Float>(input.clone().into_primitive().tensor());
        let output_ref = into_contiguous(
            input
                .clone()
                .permute([0, 2, 3, 1])
                .into_primitive()
                .tensor(),
        );

        into_data_sync::<TestRuntime, Float>(output)
            .assert_approx_eq(&into_data_sync::<TestRuntime, Float>(output_ref), 4);
    }
```

```
    #[test]
    fn nchw_to_nhwc_should_match_into_contiguous_2() {
        let test_device = Default::default();
        let input =
            Tensor::<TestBackend, 4>::random([4, 72, 53, 56], Distribution::Default, &test_device);

        type Float = <TestBackend as Backend>::FloatElem;

        let output = nchw_to_nhwc::<TestRuntime, Float>(input.clone().into_primitive().tensor());
        let output_ref = into_contiguous(
            input
                .clone()
                .permute([0, 2, 3, 1])
                .into_primitive()
                .tensor(),
        );

        into_data_sync::<TestRuntime, Float>(output)
            .assert_approx_eq(&into_data_sync::<TestRuntime, Float>(output_ref), 1); # This 1 is different.
    }
```

I have no idea about the test and targeted function, but it is strange even though the context and inputs are the same but the result output is different, and the tests are passed. I am worried if there are bugs.
Just deleting one test is not enough solution, so I submit a PR to rename it.

