### PR TITLE
Pin xtask version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,7 @@ cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features 
 # cubecl-common = { version = "0.3.0", default-features = false }
 
 ### For xtask crate ###
-tracel-xtask = { version = "~1.1" }
+tracel-xtask = { version = "=1.1.8" }
 
 [profile.dev]
 debug = 0 # Speed up compilation time and not necessary.


### PR DESCRIPTION
Turns out that maintenance is way better by pining our xtask crate rather than allowing auto-update.

