### PR TITLE
fix the incorrcet link in contributor-books

### DIFF
--- a/contributor-book/src/guides/adding-a-new-operation-to-burn.md
+++ b/contributor-book/src/guides/adding-a-new-operation-to-burn.md
@@ -11,7 +11,7 @@ various backends. The core of this lies in
 which is home to the numeric trait and its implementation for the different tensor types. The
 numeric trait is the home of all tensor operations that are numeric in nature and that are shared by
 `Int` and `Float` Tensor types. More information on the relationship between Tensor modules can be
-found under the section for [Tensor Architecture](../project-architecture/Tensor.md#tensorops).
+found under the section for [Tensor Architecture](../project-architecture/tensor.md#tensor-operations).
 
 Here is where pow was added to `crates/burn-tensor/src/tensor/api/numeric.rs`:
 


### PR DESCRIPTION
## Pull Request

In the page of https://burn.dev/contributor-book/guides/adding-a-new-operation-to-burn.html, 
there is a wrong link which makes you redirect to burn.dev top page.
![image](https://github.com/user-attachments/assets/959dba69-3ee6-4285-b3d7-5df8b43328cb)
When clicking the last link in the attached picture [Tensor Architecture](https://burn.dev/contributor-book/project-architecture/Tensor.html#tensorops), I am redirected.
This PR fixes the link.

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

None

### Changes

Fix the link.

### Testing

Run `cargo xtask books contributor open` and open the link to go to the correct page, locally 
http://localhost:4058/project-architecture/tensor.html#tensor-operations.