### PR TITLE
Fix cast float test precision

### DIFF
--- a/crates/burn-tensor/src/tests/ops/cast.rs
+++ b/crates/burn-tensor/src/tests/ops/cast.rs
@@ -46,6 +46,7 @@ mod tests {
         let output = tensor.cast(DType::F32);
 
         assert_eq!(output.dtype(), DType::F32);
-        output.into_data().assert_approx_eq(&data, 5);
+        // Use precision 2 for parametrized tests in f16 and bf16
+        output.into_data().assert_approx_eq(&data, 2);
     }
 }


### PR DESCRIPTION
### Related Issues/PRs

As correctly pointed out [on discord](https://discord.com/channels/1038839012602941528/1263876972837339196/1313475721225703535), this test will always fail if we cast from f16 or bf16 which have a lower precision.

### Changes

Changed the precision tolerance.

### Testing

Tested on cuda backend with f16 and bf16 (with bf16 having the lowest precision).
