### PR TITLE
Propagate audio feature flag

### DIFF
--- a/crates/burn-core/Cargo.toml
+++ b/crates/burn-core/Cargo.toml
@@ -38,6 +38,7 @@ doc = [
     "wgpu",
     "cuda-jit",
     "hip-jit",
+    "audio",
     "vision",
     "autodiff",
     "remote",
@@ -79,6 +80,7 @@ std = [
     "num-traits/std",
 ]
 vision = ["burn-dataset?/vision", "burn-common/network"]
+audio = ["burn-dataset?/audio"]
 
 # Backend
 autodiff = ["burn-autodiff"]

--- a/crates/burn/Cargo.toml
+++ b/crates/burn/Cargo.toml
@@ -32,6 +32,7 @@ dataset = ["burn-core/dataset"]
 sqlite = ["burn-core/sqlite"]
 sqlite-bundled = ["burn-core/sqlite-bundled"]
 
+audio = ["burn-core/audio"]
 vision = ["burn-core/vision"]
 
 # Backends


### PR DESCRIPTION
### Related Issues/PRs

Fixes #2631

### Changes

Added feature flag to the burn crate (currently only enables the burn-dataset `audio` feature)