### PR TITLE
[burnbench] Import code from github-device-flow crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,17 +311,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "628d228f918ac3b82fe590352cc719d30664a0c13ca3a60266fe02c7132d480a"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,10 +350,10 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit",
@@ -378,7 +367,7 @@ dependencies = [
  "serde_path_to_error",
  "serde_urlencoded",
  "sha1",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-tungstenite 0.24.0",
  "tower",
@@ -396,13 +385,13 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -415,19 +404,19 @@ dependencies = [
  "arboard",
  "burn",
  "burn-common",
- "clap 4.5.23",
+ "chrono",
+ "clap",
  "colored",
  "cubecl",
  "derive-new 0.7.0",
  "dirs",
- "github-device-flow",
  "half",
  "indicatif",
  "log",
  "os_info",
  "percent-encoding",
  "rand",
- "reqwest 0.12.12",
+ "reqwest",
  "rstest",
  "serde",
  "serde_json",
@@ -460,12 +449,6 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -673,7 +656,7 @@ dependencies = [
  "getrandom",
  "indicatif",
  "rayon",
- "reqwest 0.12.12",
+ "reqwest",
  "serde",
  "tokio",
  "web-time",
@@ -1248,75 +1231,36 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
-dependencies = [
- "atty",
- "bitflags 1.3.2",
- "clap_derive 3.2.25",
- "clap_lex 0.2.4",
- "indexmap 1.9.3",
- "once_cell",
- "strsim 0.10.0",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap"
-version = "4.5.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+checksum = "9560b07a799281c7e0958b9296854d6fafd4c5f31444a7e5bb1ad6dde5ccf1bd"
 dependencies = [
  "clap_builder",
- "clap_derive 4.5.18",
+ "clap_derive",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.23"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+checksum = "874e0dd3eb68bf99058751ac9712f622e61e6f393a94f7128fa26e3f02f5c7cd"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.7.4",
- "strsim 0.11.1",
+ "clap_lex",
+ "strsim",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.25"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
-dependencies = [
- "heck 0.4.1",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.95",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
 ]
 
 [[package]]
@@ -1894,7 +1838,7 @@ version = "0.16.0"
 dependencies = [
  "burn",
  "csv",
- "reqwest 0.12.12",
+ "reqwest",
  "serde",
 ]
 
@@ -1976,7 +1920,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.95",
 ]
 
@@ -2809,20 +2753,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
-name = "github-device-flow"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98852ab71f5613dac02a0d1b41f3ffaf993b69449904dd13a10575612a56074d"
-dependencies = [
- "chrono",
- "clap 3.2.25",
- "reqwest 0.11.27",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
 name = "gix-features"
 version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3011,25 +2941,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.7.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
@@ -3039,8 +2950,8 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.2.0",
- "indexmap 2.7.0",
+ "http",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -3071,12 +2982,6 @@ dependencies = [
  "hashbrown 0.14.5",
  "serde",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -3132,15 +3037,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -3203,17 +3099,6 @@ checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
@@ -3225,23 +3110,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.2.0",
+ "http",
 ]
 
 [[package]]
@@ -3252,8 +3126,8 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -3277,30 +3151,6 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
@@ -3308,9 +3158,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.7",
- "http 1.2.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -3327,8 +3177,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
- "http 1.2.0",
- "hyper 1.5.2",
+ "http",
+ "hyper",
  "hyper-util",
  "rustls",
  "rustls-native-certs 0.8.1",
@@ -3340,26 +3190,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper 0.14.32",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
-name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -3376,9 +3213,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
- "hyper 1.5.2",
+ "http",
+ "http-body",
+ "hyper",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -3631,16 +3468,6 @@ checksum = "d0263a3d970d5c054ed9312c0057b4f3bde9c0b33836d3637361d4a9e6e7a408"
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
@@ -3846,7 +3673,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4226,7 +4053,7 @@ dependencies = [
  "cfg_aliases 0.1.1",
  "codespan-reporting",
  "hexf-parse",
- "indexmap 2.7.0",
+ "indexmap",
  "log",
  "rustc-hash 1.1.0",
  "spirv",
@@ -4463,7 +4290,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 
@@ -4665,14 +4492,14 @@ dependencies = [
  "chrono",
  "futures",
  "humantime",
- "hyper 1.5.2",
+ "hyper",
  "itertools 0.13.0",
  "md-5",
  "parking_lot 0.12.3",
  "percent-encoding",
  "quick-xml",
  "rand",
- "reqwest 0.12.12",
+ "reqwest",
  "ring",
  "serde",
  "serde_json",
@@ -4837,12 +4664,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4963,7 +4784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.7.0",
+ "indexmap",
 ]
 
 [[package]]
@@ -5143,7 +4964,7 @@ dependencies = [
  "either",
  "hashbrown 0.14.5",
  "hashbrown 0.15.2",
- "indexmap 2.7.0",
+ "indexmap",
  "num-traits",
  "once_cell",
  "polars-arrow",
@@ -5237,7 +5058,7 @@ dependencies = [
  "pyo3",
  "rayon",
  "regex",
- "reqwest 0.12.12",
+ "reqwest",
  "ryu",
  "serde",
  "serde_json",
@@ -5258,7 +5079,7 @@ dependencies = [
  "chrono",
  "fallible-streaming-iterator",
  "hashbrown 0.15.2",
- "indexmap 2.7.0",
+ "indexmap",
  "itoa",
  "num-traits",
  "polars-arrow",
@@ -5332,7 +5153,7 @@ dependencies = [
  "either",
  "hashbrown 0.15.2",
  "hex",
- "indexmap 2.7.0",
+ "indexmap",
  "memchr",
  "num-traits",
  "polars-arrow",
@@ -5469,7 +5290,7 @@ version = "0.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d88667f770291cefa2e8cd366a54f29dc6fe362e9a263914c903db411a58ac1d"
 dependencies = [
- "indexmap 2.7.0",
+ "indexmap",
  "polars-error",
  "polars-utils",
  "serde",
@@ -5560,7 +5381,7 @@ dependencies = [
  "bytes",
  "compact_str",
  "hashbrown 0.15.2",
- "indexmap 2.7.0",
+ "indexmap",
  "libc",
  "memmap2 0.7.1",
  "num-traits",
@@ -5641,30 +5462,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5726,7 +5523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "322330e133eab455718444b4e033ebfac7c6528972c784fcde28d2cc783c6257"
 dependencies = [
  "anyhow",
- "indexmap 2.7.0",
+ "indexmap",
  "log",
  "protobuf",
  "protobuf-support",
@@ -6269,46 +6066,6 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-tls 0.5.0",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pemfile 1.0.4",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
- "tokio",
- "tokio-native-tls",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
@@ -6319,13 +6076,13 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.7",
- "http 1.2.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper",
  "hyper-rustls",
- "hyper-tls 0.6.0",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -6338,13 +6095,13 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-native-certs 0.8.1",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
- "system-configuration 0.6.1",
+ "sync_wrapper",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
@@ -6531,7 +6288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
  "security-framework 2.11.1",
@@ -6547,15 +6304,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework 3.1.0",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -7141,12 +6889,6 @@ checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -7200,12 +6942,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"
@@ -7271,34 +7007,13 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.6.0",
  "core-foundation 0.9.4",
- "system-configuration-sys 0.6.0",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -7441,12 +7156,6 @@ dependencies = [
  "drawille",
  "rgb",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
@@ -7719,7 +7428,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.7.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -7750,7 +7459,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -7776,7 +7485,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fccce80a2ef6bc32a512514a53cf853d438a44abaea286a4acb0c9f8566860"
 dependencies = [
  "anyhow",
- "clap 4.5.23",
+ "clap",
  "derive_more 0.99.18",
  "env_logger",
  "log",
@@ -7888,7 +7597,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.2.0",
+ "http",
  "httparse",
  "log",
  "rand",
@@ -7906,7 +7615,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.2.0",
+ "http",
  "httparse",
  "log",
  "rand",
@@ -8363,7 +8072,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cfg_aliases 0.1.1",
  "document-features",
- "indexmap 2.7.0",
+ "indexmap",
  "log",
  "naga",
  "once_cell",
@@ -8771,16 +8480,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "wrapcenum-derive"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9004,7 +8703,7 @@ dependencies = [
  "crc32fast",
  "crossbeam-utils",
  "displaydoc",
- "indexmap 2.7.0",
+ "indexmap",
  "num_enum",
  "thiserror 1.0.69",
 ]
@@ -9025,7 +8724,7 @@ dependencies = [
  "displaydoc",
  "flate2",
  "hmac",
- "indexmap 2.7.0",
+ "indexmap",
  "lzma-rs",
  "memchr",
  "pbkdf2 0.12.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ version = "0.16.0"
 atomic_float = "1"
 bytemuck = "1.21.0"
 candle-core = { version = "0.8" }
-clap = { version = "4.5.23", features = ["derive"] }
+clap = { version = "4.5.24", features = ["derive"] }
 colored = "2.1.0"
 console_error_panic_hook = "0.1.7"
 csv = "1.3.1"
@@ -104,8 +104,8 @@ text_placeholder = "0.5.1"
 wgpu = "23.0.0"
 
 # Benchmarks and Burnbench
+chrono = "0.4.39"
 arboard = "3.4.1"
-github-device-flow = "0.2.0"
 os_info = "3.9.0"
 wsl = "0.1.0"
 

--- a/NOTICES.md
+++ b/NOTICES.md
@@ -9,7 +9,7 @@ repository copied or derived from.
 
 License: BSD 3-Clause License
 
-Copyright (c) 2017, 
+Copyright (c) 2017,
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -573,3 +573,31 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
+## github-device-flow
+
+**Source**:
+- Part of: https://github.com/jakewilkins/gh-device-flow/blob/main/src/lib.rs
+- https://github.com/jakewilkins/gh-device-flow/blob/main/src/util.rs
+
+MIT License
+
+Copyright (c) 2022 Jake Wilkins
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/backend-comparison/Cargo.toml
+++ b/backend-comparison/Cargo.toml
@@ -37,10 +37,10 @@ burn-common = { path = "../crates/burn-common", version = "0.16.0" }
 
 clap = { workspace = true }
 colored = { workspace = true }
+chrono = { workspace = true }
 cubecl = { workspace = true, features = ["wgpu"], default-features = true }
 derive-new = { workspace = true }
 dirs = { workspace = true }
-github-device-flow = { workspace = true }
 half = { workspace = true }
 indicatif = { workspace = true }
 os_info = { workspace = true }

--- a/backend-comparison/src/burnbenchapp/auth/base.rs
+++ b/backend-comparison/src/burnbenchapp/auth/base.rs
@@ -1,6 +1,5 @@
 use arboard::Clipboard;
 use burn::serde::{Deserialize, Serialize};
-use github_device_flow::{self, DeviceFlow};
 use reqwest;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
@@ -64,7 +63,7 @@ pub(crate) fn get_tokens() -> Option<Tokens> {
 pub(crate) fn get_username(access_token: &str) -> Option<UserInfo> {
     let client = reqwest::blocking::Client::new();
     let response = client
-        .get(format!("{}users/me", super::USER_BENCHMARK_SERVER_URL))
+        .get(format!("{}users/me", USER_BENCHMARK_SERVER_URL))
         .header(reqwest::header::USER_AGENT, "burnbench")
         .header(reqwest::header::CONTENT_TYPE, "application/json")
         .header(
@@ -77,7 +76,7 @@ pub(crate) fn get_username(access_token: &str) -> Option<UserInfo> {
 }
 
 fn auth() -> Option<Tokens> {
-    let mut flow = match DeviceFlow::start(CLIENT_ID, None) {
+    let mut flow = match DeviceFlow::start(CLIENT_ID, None, None) {
         Ok(flow) => flow,
         Err(e) => {
             eprintln!("Error authenticating: {}", e);
@@ -144,7 +143,7 @@ fn refresh_tokens(tokens: &Tokens) -> Option<Tokens> {
     let response = client
         .post(format!(
             "{}auth/refresh-token",
-            super::USER_BENCHMARK_SERVER_URL
+            USER_BENCHMARK_SERVER_URL
         ))
         .header(reqwest::header::USER_AGENT, "burnbench")
         .header(reqwest::header::CONTENT_TYPE, "application/json")
@@ -188,6 +187,8 @@ fn save_tokens(tokens: &Tokens) {
 
 #[cfg(test)]
 use serial_test::serial;
+
+use crate::burnbenchapp::{auth::github_device_flow::DeviceFlow, USER_BENCHMARK_SERVER_URL};
 
 #[cfg(test)]
 mod tests {

--- a/backend-comparison/src/burnbenchapp/auth/base.rs
+++ b/backend-comparison/src/burnbenchapp/auth/base.rs
@@ -141,10 +141,7 @@ fn refresh_tokens(tokens: &Tokens) -> Option<Tokens> {
     println!("Refreshing token...");
     let client = reqwest::blocking::Client::new();
     let response = client
-        .post(format!(
-            "{}auth/refresh-token",
-            USER_BENCHMARK_SERVER_URL
-        ))
+        .post(format!("{}auth/refresh-token", USER_BENCHMARK_SERVER_URL))
         .header(reqwest::header::USER_AGENT, "burnbench")
         .header(reqwest::header::CONTENT_TYPE, "application/json")
         .header(

--- a/backend-comparison/src/burnbenchapp/auth/github_device_flow.rs
+++ b/backend-comparison/src/burnbenchapp/auth/github_device_flow.rs
@@ -1,0 +1,230 @@
+// Initially from: https://github.com/jakewilkins/gh-device-flow
+use std::collections::HashMap;
+use std::{fmt, result::Result, thread, time};
+
+use chrono::offset::Utc;
+use chrono::{DateTime, Duration};
+use serde::{Deserialize, Serialize};
+
+pub fn credential_error(msg: String) -> DeviceFlowError {
+    DeviceFlowError::GitHubError(msg.into())
+}
+
+pub fn send_request(device_flow: &mut DeviceFlow, url: String, body: String) -> Option<HashMap<String, serde_json::Value>> {
+        let client = reqwest::blocking::Client::new();
+        let response_struct = client.post(&url)
+            .header("Accept", "application/json")
+            .body(body)
+            .send();
+
+        match response_struct {
+            Ok(resp) => {
+                match resp.json::<HashMap<String, serde_json::Value>>() {
+                    Ok(hm) => Some(hm),
+                    Err(err) => {
+                        device_flow.state = DeviceFlowState::Failure(err.into());
+                        None
+                    }
+                }
+            },
+            Err(err) => {
+                device_flow.state = DeviceFlowState::Failure(err.into());
+                None
+            }
+        }
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct Credential {
+    pub token: String,
+    pub expiry: String,
+    pub refresh_token: String,
+}
+
+impl Credential {
+    fn empty() -> Credential {
+        Credential {
+            token: String::new(),
+            expiry: String::new(),
+            refresh_token: String::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum DeviceFlowError {
+    HttpError(String),
+    GitHubError(String),
+}
+
+impl fmt::Display for DeviceFlowError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            DeviceFlowError::HttpError(string) => write!(f, "DeviceFlowError: {}", string),
+            DeviceFlowError::GitHubError(string) => write!(f, "DeviceFlowError: {}", string),
+        }
+    }
+}
+
+impl std::error::Error for DeviceFlowError {}
+
+impl From<reqwest::Error> for DeviceFlowError {
+    fn from(e: reqwest::Error) -> Self {
+        DeviceFlowError::HttpError(format!("{:?}", e))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum DeviceFlowState {
+    Pending,
+    Processing(time::Duration),
+    Success(Credential),
+    Failure(DeviceFlowError),
+}
+
+#[derive(Clone)]
+pub struct DeviceFlow {
+    pub host: String,
+    pub client_id: String,
+    pub scope: String,
+    pub user_code: Option<String>,
+    pub device_code: Option<String>,
+    pub verification_uri: Option<String>,
+    pub state: DeviceFlowState,
+}
+
+const FIVE_SECONDS: time::Duration = time::Duration::new(5, 0);
+
+impl DeviceFlow {
+    pub fn new(client_id: &str, maybe_host: Option<&str>, scope: Option<&str>) -> Self {
+        Self {
+            client_id: String::from(client_id),
+            scope: match scope {
+                Some(string) => String::from(string),
+                None => String::new(),
+            },
+            host: match maybe_host {
+                Some(string) => String::from(string),
+                None => String::from("github.com"),
+            },
+            user_code: None,
+            device_code: None,
+            verification_uri: None,
+            state: DeviceFlowState::Pending,
+        }
+    }
+
+    pub fn start(
+        client_id: &str,
+        maybe_host: Option<&str>,
+        scope: Option<&str>,
+    ) -> Result<DeviceFlow, DeviceFlowError> {
+        let mut flow = DeviceFlow::new(client_id, maybe_host, scope);
+
+        flow.setup();
+
+        match flow.state {
+            DeviceFlowState::Processing(_) => Ok(flow.to_owned()),
+            DeviceFlowState::Failure(err) => Err(err),
+            _ => Err(credential_error(
+                "Something truly unexpected happened".into(),
+            )),
+        }
+    }
+
+    pub fn setup(&mut self) {
+        let body = format!("client_id={}&scope={}", &self.client_id, &self.scope);
+        let entry_url = format!("https://{}/login/device/code", &self.host);
+
+        if let Some(res) = send_request(self, entry_url, body) {
+            if res.contains_key("error") && res.contains_key("error_description") {
+                self.state = DeviceFlowState::Failure(credential_error(
+                    res["error_description"].as_str().unwrap().into(),
+                ))
+            } else if res.contains_key("error") {
+                self.state = DeviceFlowState::Failure(credential_error(format!(
+                    "Error response: {:?}",
+                    res["error"].as_str().unwrap()
+                )))
+            } else {
+                self.user_code = Some(String::from(res["user_code"].as_str().unwrap()));
+                self.device_code = Some(String::from(res["device_code"].as_str().unwrap()));
+                self.verification_uri =
+                    Some(String::from(res["verification_uri"].as_str().unwrap()));
+                self.state = DeviceFlowState::Processing(FIVE_SECONDS);
+            }
+        };
+    }
+
+    pub fn poll(&mut self, iterations: u32) -> Result<Credential, DeviceFlowError> {
+        for count in 0..iterations {
+            self.update();
+
+            if let DeviceFlowState::Processing(interval) = self.state {
+                if count == iterations {
+                    return Err(credential_error("Max poll iterations reached".into()));
+                }
+
+                thread::sleep(interval);
+            } else {
+                break;
+            }
+        }
+
+        match &self.state {
+            DeviceFlowState::Success(cred) => Ok(cred.to_owned()),
+            DeviceFlowState::Failure(err) => Err(err.to_owned()),
+            _ => Err(credential_error(
+                "Unable to fetch credential, sorry :/".into(),
+            )),
+        }
+    }
+
+    pub fn update(&mut self) {
+        let poll_url = format!("https://{}/login/oauth/access_token", self.host);
+        let poll_payload = format!(
+            "client_id={}&device_code={}&grant_type=urn:ietf:params:oauth:grant-type:device_code",
+            self.client_id,
+            &self.device_code.clone().unwrap()
+        );
+
+        if let Some(res) = send_request(self, poll_url, poll_payload) {
+            if res.contains_key("error") {
+                match res["error"].as_str().unwrap() {
+                    "authorization_pending" => {}
+                    "slow_down" => {
+                        if let DeviceFlowState::Processing(current_interval) = self.state {
+                            self.state =
+                                DeviceFlowState::Processing(current_interval + FIVE_SECONDS);
+                        };
+                    }
+                    other_reason => {
+                        self.state = DeviceFlowState::Failure(credential_error(format!(
+                            "Error checking for token: {}",
+                            other_reason
+                        )));
+                    }
+                }
+            } else {
+                let mut this_credential = Credential::empty();
+                this_credential.token = res["access_token"].as_str().unwrap().to_string();
+
+                if let Some(expires_in) = res.get("expires_in") {
+                    this_credential.expiry = calculate_expiry(expires_in.as_i64().unwrap());
+                    this_credential.refresh_token =
+                        res["refresh_token"].as_str().unwrap().to_string();
+                }
+
+                self.state = DeviceFlowState::Success(this_credential);
+            }
+        }
+    }
+}
+
+fn calculate_expiry(expires_in: i64) -> String {
+    let expires_in = Duration::seconds(expires_in);
+    let mut expiry: DateTime<Utc> = Utc::now();
+    expiry = expiry + expires_in;
+    expiry.to_rfc3339()
+}
+

--- a/backend-comparison/src/burnbenchapp/auth/github_device_flow.rs
+++ b/backend-comparison/src/burnbenchapp/auth/github_device_flow.rs
@@ -10,28 +10,31 @@ pub fn credential_error(msg: String) -> DeviceFlowError {
     DeviceFlowError::GitHubError(msg.into())
 }
 
-pub fn send_request(device_flow: &mut DeviceFlow, url: String, body: String) -> Option<HashMap<String, serde_json::Value>> {
-        let client = reqwest::blocking::Client::new();
-        let response_struct = client.post(&url)
-            .header("Accept", "application/json")
-            .body(body)
-            .send();
+pub fn send_request(
+    device_flow: &mut DeviceFlow,
+    url: String,
+    body: String,
+) -> Option<HashMap<String, serde_json::Value>> {
+    let client = reqwest::blocking::Client::new();
+    let response_struct = client
+        .post(&url)
+        .header("Accept", "application/json")
+        .body(body)
+        .send();
 
-        match response_struct {
-            Ok(resp) => {
-                match resp.json::<HashMap<String, serde_json::Value>>() {
-                    Ok(hm) => Some(hm),
-                    Err(err) => {
-                        device_flow.state = DeviceFlowState::Failure(err.into());
-                        None
-                    }
-                }
-            },
+    match response_struct {
+        Ok(resp) => match resp.json::<HashMap<String, serde_json::Value>>() {
+            Ok(hm) => Some(hm),
             Err(err) => {
                 device_flow.state = DeviceFlowState::Failure(err.into());
                 None
             }
+        },
+        Err(err) => {
+            device_flow.state = DeviceFlowState::Failure(err.into());
+            None
         }
+    }
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
@@ -227,4 +230,3 @@ fn calculate_expiry(expires_in: i64) -> String {
     expiry = expiry + expires_in;
     expiry.to_rfc3339()
 }
-

--- a/backend-comparison/src/burnbenchapp/auth/github_device_flow.rs
+++ b/backend-comparison/src/burnbenchapp/auth/github_device_flow.rs
@@ -7,7 +7,7 @@ use chrono::{DateTime, Duration};
 use serde::{Deserialize, Serialize};
 
 pub fn credential_error(msg: String) -> DeviceFlowError {
-    DeviceFlowError::GitHubError(msg.into())
+    DeviceFlowError::GitHubError(msg)
 }
 
 pub fn send_request(
@@ -227,6 +227,6 @@ impl DeviceFlow {
 fn calculate_expiry(expires_in: i64) -> String {
     let expires_in = Duration::seconds(expires_in);
     let mut expiry: DateTime<Utc> = Utc::now();
-    expiry = expiry + expires_in;
+    expiry += expires_in;
     expiry.to_rfc3339()
 }

--- a/backend-comparison/src/burnbenchapp/auth/mod.rs
+++ b/backend-comparison/src/burnbenchapp/auth/mod.rs
@@ -1,0 +1,5 @@
+mod base;
+pub(crate) mod github_device_flow;
+
+pub(crate) use base::*;
+

--- a/backend-comparison/src/burnbenchapp/auth/mod.rs
+++ b/backend-comparison/src/burnbenchapp/auth/mod.rs
@@ -2,4 +2,3 @@ mod base;
 pub(crate) mod github_device_flow;
 
 pub(crate) use base::*;
-


### PR DESCRIPTION
We only use some of the code of the crate and some of its code is redundant with our own implementation.

Moreover we don't need some of its dependencies like clap which is on a previous major version. So this allows to remove a whole dependency tree from the lock file.

Fixes #2548

### Testing

Re-authenticate with GitHub.