### PR TITLE
Add checks for even padding when kernel size is even

### DIFF
--- a/crates/burn-core/src/nn/conv/checks.rs
+++ b/crates/burn-core/src/nn/conv/checks.rs
@@ -9,3 +9,14 @@ pub(crate) fn checks_channels_div_groups(channels_in: usize, channels_out: usize
         );
     }
 }
+
+// https://github.com/tracel-ai/burn/issues/2676
+/// Only symmetric padding is currently supported. As such, using `Same` padding with an even kernel
+/// size is not supported as it will not produce the same output size.
+pub(crate) fn check_same_padding_support(kernel_size: &[usize]) {
+    for k in kernel_size.iter() {
+        if k % 2 == 0 {
+            unimplemented!("Same padding with an even kernel size is not supported");
+        }
+    }
+}

--- a/crates/burn-core/src/nn/conv/conv1d.rs
+++ b/crates/burn-core/src/nn/conv/conv1d.rs
@@ -129,6 +129,10 @@ impl<B: Backend> Conv1d<B> {
     ///
     /// - input: `[batch_size, channels_in, length_in]`
     /// - output: `[batch_size, channels_out, length_out]`
+    ///
+    /// ### Panics
+    /// Only symmetric padding is currently supported. As such, using `Same` padding with an even kernel
+    /// size is not supported as it will not produce the same output size.
     pub fn forward(&self, input: Tensor<B, 3>) -> Tensor<B, 3> {
         let [_batch_size, _channels, length] = input.dims();
         let padding = self

--- a/crates/burn-core/src/nn/conv/conv2d.rs
+++ b/crates/burn-core/src/nn/conv/conv2d.rs
@@ -141,6 +141,10 @@ impl<B: Backend> Conv2d<B> {
     ///
     /// - input: `[batch_size, channels_in, height_in, width_in]`
     /// - output: `[batch_size, channels_out, height_out, width_out]`
+    ///
+    /// ### Panics
+    /// Only symmetric padding is currently supported. As such, using `Same` padding with an even kernel
+    /// size is not supported as it will not produce the same output size.
     pub fn forward(&self, input: Tensor<B, 4>) -> Tensor<B, 4> {
         let [_batch_size, _channels_in, height_in, width_in] = input.dims();
         let padding =

--- a/crates/burn-core/src/nn/conv/conv2d.rs
+++ b/crates/burn-core/src/nn/conv/conv2d.rs
@@ -30,6 +30,10 @@ pub struct Conv2dConfig {
     #[config(default = "1")]
     pub groups: usize,
     /// The padding configuration.
+    ///
+    /// ### Warning
+    /// Only symmetric padding is currently supported. As such, using `Same` padding with an even kernel
+    /// size is not supported as it will not produce the same output size.
     #[config(default = "PaddingConfig2d::Valid")]
     pub padding: PaddingConfig2d,
     /// If bias should be added to the output.
@@ -68,6 +72,9 @@ impl Conv2dConfig {
     /// Initialize a new [conv2d](Conv2d) module.
     pub fn init<B: Backend>(&self, device: &B::Device) -> Conv2d<B> {
         checks::checks_channels_div_groups(self.channels[0], self.channels[1], self.groups);
+        if self.padding == PaddingConfig2d::Same {
+            checks::check_same_padding_support(&self.kernel_size);
+        }
 
         let shape = [
             self.channels[1],
@@ -141,10 +148,6 @@ impl<B: Backend> Conv2d<B> {
     ///
     /// - input: `[batch_size, channels_in, height_in, width_in]`
     /// - output: `[batch_size, channels_out, height_out, width_out]`
-    ///
-    /// ### Panics
-    /// Only symmetric padding is currently supported. As such, using `Same` padding with an even kernel
-    /// size is not supported as it will not produce the same output size.
     pub fn forward(&self, input: Tensor<B, 4>) -> Tensor<B, 4> {
         let [_batch_size, _channels_in, height_in, width_in] = input.dims();
         let padding =
@@ -229,6 +232,14 @@ mod tests {
     fn channels_with_groups_is_invalid() {
         let device = Default::default();
         let config = Conv2dConfig::new([1, 4], [1, 1]).with_groups(4);
+        let _ = config.init::<TestBackend>(&device);
+    }
+
+    #[test]
+    #[should_panic = "Same padding with an even kernel size is not supported"]
+    fn same_with_even_kernel_is_invalid() {
+        let device = Default::default();
+        let config = Conv2dConfig::new([4, 4], [2, 2]).with_padding(PaddingConfig2d::Same);
         let _ = config.init::<TestBackend>(&device);
     }
 

--- a/crates/burn-core/src/nn/conv/conv3d.rs
+++ b/crates/burn-core/src/nn/conv/conv3d.rs
@@ -142,6 +142,10 @@ impl<B: Backend> Conv3d<B> {
     ///
     /// - input: `[batch_size, channels_in, depth_in, height_in, width_in]`
     /// - output: `[batch_size, channels_out, depth_out, height_out, width_out]`
+    ///
+    /// ### Panics
+    /// Only symmetric padding is currently supported. As such, using `Same` padding with an even kernel
+    /// size is not supported as it will not produce the same output size.
     pub fn forward(&self, input: Tensor<B, 5>) -> Tensor<B, 5> {
         let [_batch_size, _channels_in, depth_in, height_in, width_in] = input.dims();
         let padding = self.padding.calculate_padding_3d(

--- a/crates/burn-core/src/nn/conv/deform_conv2d.rs
+++ b/crates/burn-core/src/nn/conv/deform_conv2d.rs
@@ -33,6 +33,10 @@ pub struct DeformConv2dConfig {
     #[config(default = "1")]
     pub offset_groups: usize,
     /// The padding configuration.
+    ///
+    /// ### Warning
+    /// Only symmetric padding is currently supported. As such, using `Same` padding with an even kernel
+    /// size is not supported as it will not produce the same output size.
     #[config(default = "PaddingConfig2d::Valid")]
     pub padding: PaddingConfig2d,
     /// If bias should be added to the output.
@@ -73,6 +77,9 @@ impl DeformConv2dConfig {
     /// Initialize a new [DeformConv2d](DeformConv2d) module.
     pub fn init<B: Backend>(&self, device: &B::Device) -> DeformConv2d<B> {
         checks::checks_channels_div_groups(self.channels[0], self.channels[1], self.weight_groups);
+        if self.padding == PaddingConfig2d::Same {
+            checks::check_same_padding_support(&self.kernel_size);
+        }
 
         let shape = [
             self.channels[1],
@@ -150,10 +157,6 @@ impl<B: Backend> DeformConv2d<B> {
     /// - offset: `[batch_size, 2 * offset_groups * kernel_height * kernel_width, height_out, width_out]`
     /// - mask: `[batch_size, offset_groups * kernel_height * kernel_width, height_out, width_out]`
     /// - output: `[batch_size, channels_out, height_out, width_out]`
-    ///
-    /// ### Panics
-    /// Only symmetric padding is currently supported. As such, using `Same` padding with an even kernel
-    /// size is not supported as it will not produce the same output size.
     pub fn forward(
         &self,
         input: Tensor<B, 4>,
@@ -251,6 +254,14 @@ mod tests {
     fn channels_with_groups_is_invalid() {
         let device = Default::default();
         let config = DeformConv2dConfig::new([1, 4], [1, 1]).with_weight_groups(4);
+        let _ = config.init::<TestBackend>(&device);
+    }
+
+    #[test]
+    #[should_panic = "Same padding with an even kernel size is not supported"]
+    fn same_with_even_kernel_is_invalid() {
+        let device = Default::default();
+        let config = DeformConv2dConfig::new([4, 4], [2, 2]).with_padding(PaddingConfig2d::Same);
         let _ = config.init::<TestBackend>(&device);
     }
 

--- a/crates/burn-core/src/nn/conv/deform_conv2d.rs
+++ b/crates/burn-core/src/nn/conv/deform_conv2d.rs
@@ -150,6 +150,10 @@ impl<B: Backend> DeformConv2d<B> {
     /// - offset: `[batch_size, 2 * offset_groups * kernel_height * kernel_width, height_out, width_out]`
     /// - mask: `[batch_size, offset_groups * kernel_height * kernel_width, height_out, width_out]`
     /// - output: `[batch_size, channels_out, height_out, width_out]`
+    ///
+    /// ### Panics
+    /// Only symmetric padding is currently supported. As such, using `Same` padding with an even kernel
+    /// size is not supported as it will not produce the same output size.
     pub fn forward(
         &self,
         input: Tensor<B, 4>,

--- a/crates/burn-core/src/nn/padding.rs
+++ b/crates/burn-core/src/nn/padding.rs
@@ -4,11 +4,24 @@ use crate::tensor::ops::conv::calculate_conv_padding;
 
 use crate::config::Config;
 
+// https://github.com/tracel-ai/burn/issues/2676
+fn check_same_padding_support(kernel_size: &[usize]) {
+    for k in kernel_size.iter() {
+        if k % 2 == 0 {
+            unimplemented!("same padding with an even kernel size is not supported");
+        }
+    }
+}
+
 /// Padding configuration for 1D operators.
 #[derive(Config, Debug, PartialEq)]
 pub enum PaddingConfig1d {
     /// Dynamically calculate the amount of padding necessary to ensure that the output size will be
     /// the same as the input.
+    ///
+    /// **Warning:**
+    /// Only symmetric padding is currently supported. As such, using `Same` padding with an even kernel
+    /// size is not supported as it will not produce the same output size.
     Same,
     /// Same as no padding.
     Valid,
@@ -23,7 +36,10 @@ impl PaddingConfig1d {
         kernel_size: usize,
         stride: usize,
     ) -> usize {
-        let same_padding = || calculate_conv_padding(kernel_size, stride, length, length);
+        let same_padding = || {
+            check_same_padding_support(&[kernel_size]);
+            calculate_conv_padding(kernel_size, stride, length, length)
+        };
         match self {
             Self::Valid => 0,
             Self::Same => same_padding(),
@@ -37,6 +53,10 @@ impl PaddingConfig1d {
 pub enum PaddingConfig2d {
     /// Dynamically calculate the amount of padding necessary to ensure that the output size will be
     /// the same as the input.
+    ///
+    /// **Warning:**
+    /// Only symmetric padding is currently supported. As such, using `Same` padding with an even kernel
+    /// size is not supported as it will not produce the same output size.
     Same,
     /// Same as no padding.
     Valid,
@@ -53,6 +73,7 @@ impl PaddingConfig2d {
         stride: &[usize; 2],
     ) -> [usize; 2] {
         let same_padding = || {
+            check_same_padding_support(kernel_size.as_slice());
             let p1 = calculate_conv_padding(kernel_size[0], stride[0], height, height);
             let p2 = calculate_conv_padding(kernel_size[1], stride[1], width, width);
 
@@ -72,6 +93,10 @@ impl PaddingConfig2d {
 pub enum PaddingConfig3d {
     /// Dynamically calculate the amount of padding necessary to ensure that the output size will be
     /// the same as the input.
+    ///
+    /// **Warning:**
+    /// Only symmetric padding is currently supported. As such, using `Same` padding with an even kernel
+    /// size is not supported as it will not produce the same output size.
     Same,
     /// Same as no padding.
     Valid,
@@ -89,6 +114,7 @@ impl PaddingConfig3d {
         stride: &[usize; 3],
     ) -> [usize; 3] {
         let same_padding = || {
+            check_same_padding_support(kernel_size.as_slice());
             let p1 = calculate_conv_padding(kernel_size[0], stride[0], depth, depth);
             let p2 = calculate_conv_padding(kernel_size[1], stride[1], height, height);
             let p3 = calculate_conv_padding(kernel_size[2], stride[2], width, width);

--- a/crates/burn-core/src/nn/padding.rs
+++ b/crates/burn-core/src/nn/padding.rs
@@ -4,24 +4,11 @@ use crate::tensor::ops::conv::calculate_conv_padding;
 
 use crate::config::Config;
 
-// https://github.com/tracel-ai/burn/issues/2676
-fn check_same_padding_support(kernel_size: &[usize]) {
-    for k in kernel_size.iter() {
-        if k % 2 == 0 {
-            unimplemented!("same padding with an even kernel size is not supported");
-        }
-    }
-}
-
 /// Padding configuration for 1D operators.
 #[derive(Config, Debug, PartialEq)]
 pub enum PaddingConfig1d {
     /// Dynamically calculate the amount of padding necessary to ensure that the output size will be
     /// the same as the input.
-    ///
-    /// **Warning:**
-    /// Only symmetric padding is currently supported. As such, using `Same` padding with an even kernel
-    /// size is not supported as it will not produce the same output size.
     Same,
     /// Same as no padding.
     Valid,
@@ -36,10 +23,7 @@ impl PaddingConfig1d {
         kernel_size: usize,
         stride: usize,
     ) -> usize {
-        let same_padding = || {
-            check_same_padding_support(&[kernel_size]);
-            calculate_conv_padding(kernel_size, stride, length, length)
-        };
+        let same_padding = || calculate_conv_padding(kernel_size, stride, length, length);
         match self {
             Self::Valid => 0,
             Self::Same => same_padding(),
@@ -53,10 +37,6 @@ impl PaddingConfig1d {
 pub enum PaddingConfig2d {
     /// Dynamically calculate the amount of padding necessary to ensure that the output size will be
     /// the same as the input.
-    ///
-    /// **Warning:**
-    /// Only symmetric padding is currently supported. As such, using `Same` padding with an even kernel
-    /// size is not supported as it will not produce the same output size.
     Same,
     /// Same as no padding.
     Valid,
@@ -73,7 +53,6 @@ impl PaddingConfig2d {
         stride: &[usize; 2],
     ) -> [usize; 2] {
         let same_padding = || {
-            check_same_padding_support(kernel_size.as_slice());
             let p1 = calculate_conv_padding(kernel_size[0], stride[0], height, height);
             let p2 = calculate_conv_padding(kernel_size[1], stride[1], width, width);
 
@@ -93,10 +72,6 @@ impl PaddingConfig2d {
 pub enum PaddingConfig3d {
     /// Dynamically calculate the amount of padding necessary to ensure that the output size will be
     /// the same as the input.
-    ///
-    /// **Warning:**
-    /// Only symmetric padding is currently supported. As such, using `Same` padding with an even kernel
-    /// size is not supported as it will not produce the same output size.
     Same,
     /// Same as no padding.
     Valid,
@@ -114,7 +89,6 @@ impl PaddingConfig3d {
         stride: &[usize; 3],
     ) -> [usize; 3] {
         let same_padding = || {
-            check_same_padding_support(kernel_size.as_slice());
             let p1 = calculate_conv_padding(kernel_size[0], stride[0], depth, depth);
             let p2 = calculate_conv_padding(kernel_size[1], stride[1], height, height);
             let p3 = calculate_conv_padding(kernel_size[2], stride[2], width, width);

--- a/crates/burn-core/src/nn/pool/avg_pool1d.rs
+++ b/crates/burn-core/src/nn/pool/avg_pool1d.rs
@@ -36,10 +36,6 @@ pub struct AvgPool1dConfig {
 /// legitimate values, and they contribute to the denominator
 /// when calculating the average. This is equivalent to
 /// `torch.nn.AvgPool2d` with `count_include_pad=True`.
-///
-/// TODO: Add support for `count_include_pad=False`, see
-/// [Issue 636](https://github.com/tracel-ai/burn/issues/636)
-
 #[derive(Module, Clone, Debug)]
 #[module(custom_display)]
 pub struct AvgPool1d {
@@ -91,6 +87,10 @@ impl AvgPool1d {
     ///
     /// - input: `[batch_size, channels, length_in]`
     /// - output: `[batch_size, channels, length_out]`
+    ///
+    /// ### Panics
+    /// Only symmetric padding is currently supported. As such, using `Same` padding with an even kernel
+    /// size is not supported as it will not produce the same output size.
     pub fn forward<B: Backend>(&self, input: Tensor<B, 3>) -> Tensor<B, 3> {
         let [_batch_size, _channels, length] = input.dims();
         let padding = self

--- a/crates/burn-core/src/nn/pool/avg_pool1d.rs
+++ b/crates/burn-core/src/nn/pool/avg_pool1d.rs
@@ -1,4 +1,5 @@
 use crate as burn;
+use crate::nn::conv::checks::check_same_padding_support;
 
 use crate::config::Config;
 use crate::module::{Content, DisplaySettings, ModuleDisplay};
@@ -18,6 +19,10 @@ pub struct AvgPool1dConfig {
     #[config(default = "1")]
     pub stride: usize,
     /// The padding configuration.
+    ///
+    /// ### Warning
+    /// Only symmetric padding is currently supported. As such, using `Same` padding with an even kernel
+    /// size is not supported as it will not produce the same output size.
     #[config(default = "PaddingConfig1d::Valid")]
     pub padding: PaddingConfig1d,
     /// If the padding is counted in the denominator when computing the average.
@@ -69,6 +74,9 @@ impl ModuleDisplay for AvgPool1d {
 impl AvgPool1dConfig {
     /// Initialize a new [avg pool 1d](AvgPool1d) module.
     pub fn init(&self) -> AvgPool1d {
+        if self.padding == PaddingConfig1d::Same {
+            check_same_padding_support(&[self.kernel_size]);
+        }
         AvgPool1d {
             stride: self.stride,
             kernel_size: self.kernel_size,
@@ -87,10 +95,6 @@ impl AvgPool1d {
     ///
     /// - input: `[batch_size, channels, length_in]`
     /// - output: `[batch_size, channels, length_out]`
-    ///
-    /// ### Panics
-    /// Only symmetric padding is currently supported. As such, using `Same` padding with an even kernel
-    /// size is not supported as it will not produce the same output size.
     pub fn forward<B: Backend>(&self, input: Tensor<B, 3>) -> Tensor<B, 3> {
         let [_batch_size, _channels, length] = input.dims();
         let padding = self
@@ -110,6 +114,13 @@ impl AvgPool1d {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    #[should_panic = "Same padding with an even kernel size is not supported"]
+    fn same_with_even_kernel_is_invalid() {
+        let config = AvgPool1dConfig::new(2).with_padding(PaddingConfig1d::Same);
+        let _ = config.init();
+    }
 
     #[test]
     fn display() {

--- a/crates/burn-core/src/nn/pool/avg_pool2d.rs
+++ b/crates/burn-core/src/nn/pool/avg_pool2d.rs
@@ -36,9 +36,6 @@ pub struct AvgPool2dConfig {
 /// legitimate values, and they contribute to the denominator
 /// when calculating the average. This is equivalent to
 /// `torch.nn.AvgPool2d` with `count_include_pad=True`.
-///
-/// TODO: Add support for `count_include_pad=False`, see
-/// [Issue 636](https://github.com/tracel-ai/burn/issues/636)
 #[derive(Module, Clone, Debug)]
 #[module(custom_display)]
 pub struct AvgPool2d {
@@ -90,6 +87,10 @@ impl AvgPool2d {
     ///
     /// - input: `[batch_size, channels, height_in, width_in]`
     /// - output: `[batch_size, channels, height_out, width_out]`
+    ///
+    /// ### Panics
+    /// Only symmetric padding is currently supported. As such, using `Same` padding with an even kernel
+    /// size is not supported as it will not produce the same output size.
     pub fn forward<B: Backend>(&self, input: Tensor<B, 4>) -> Tensor<B, 4> {
         let [_batch_size, _channels_in, height_in, width_in] = input.dims();
         let padding =

--- a/crates/burn-core/src/nn/pool/max_pool1d.rs
+++ b/crates/burn-core/src/nn/pool/max_pool1d.rs
@@ -1,4 +1,5 @@
 use crate as burn;
+use crate::nn::conv::checks::check_same_padding_support;
 
 use crate::config::Config;
 use crate::module::{Content, DisplaySettings, ModuleDisplay};
@@ -18,6 +19,10 @@ pub struct MaxPool1dConfig {
     #[config(default = "1")]
     pub stride: usize,
     /// The padding configuration.
+    ///
+    /// ### Warning
+    /// Only symmetric padding is currently supported. As such, using `Same` padding with an even kernel
+    /// size is not supported as it will not produce the same output size.
     #[config(default = "PaddingConfig1d::Valid")]
     pub padding: PaddingConfig1d,
     /// The dilation.
@@ -61,6 +66,9 @@ impl ModuleDisplay for MaxPool1d {
 impl MaxPool1dConfig {
     /// Initialize a new [max pool 1d](MaxPool1d) module.
     pub fn init(&self) -> MaxPool1d {
+        if self.padding == PaddingConfig1d::Same {
+            check_same_padding_support(&[self.kernel_size]);
+        }
         MaxPool1d {
             stride: self.stride,
             kernel_size: self.kernel_size,
@@ -79,10 +87,6 @@ impl MaxPool1d {
     ///
     /// - input: `[batch_size, channels, length_in]`
     /// - output: `[batch_size, channels, length_out]`
-    ///
-    /// ### Panics
-    /// Only symmetric padding is currently supported. As such, using `Same` padding with an even kernel
-    /// size is not supported as it will not produce the same output size.
     pub fn forward<B: Backend>(&self, input: Tensor<B, 3>) -> Tensor<B, 3> {
         let [_batch_size, _channels, length] = input.dims();
         let padding = self
@@ -96,6 +100,13 @@ impl MaxPool1d {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    #[should_panic = "Same padding with an even kernel size is not supported"]
+    fn same_with_even_kernel_is_invalid() {
+        let config = MaxPool1dConfig::new(2).with_padding(PaddingConfig1d::Same);
+        let _ = config.init();
+    }
 
     #[test]
     fn display() {

--- a/crates/burn-core/src/nn/pool/max_pool1d.rs
+++ b/crates/burn-core/src/nn/pool/max_pool1d.rs
@@ -79,6 +79,10 @@ impl MaxPool1d {
     ///
     /// - input: `[batch_size, channels, length_in]`
     /// - output: `[batch_size, channels, length_out]`
+    ///
+    /// ### Panics
+    /// Only symmetric padding is currently supported. As such, using `Same` padding with an even kernel
+    /// size is not supported as it will not produce the same output size.
     pub fn forward<B: Backend>(&self, input: Tensor<B, 3>) -> Tensor<B, 3> {
         let [_batch_size, _channels, length] = input.dims();
         let padding = self

--- a/crates/burn-core/src/nn/pool/max_pool2d.rs
+++ b/crates/burn-core/src/nn/pool/max_pool2d.rs
@@ -79,6 +79,10 @@ impl MaxPool2d {
     ///
     /// - input: `[batch_size, channels, height_in, width_in]`
     /// - output: `[batch_size, channels, height_out, width_out]`
+    ///
+    /// ### Panics
+    /// Only symmetric padding is currently supported. As such, using `Same` padding with an even kernel
+    /// size is not supported as it will not produce the same output size.
     pub fn forward<B: Backend>(&self, input: Tensor<B, 4>) -> Tensor<B, 4> {
         let [_batch_size, _channels_in, height_in, width_in] = input.dims();
         let padding =

--- a/crates/burn-core/src/nn/pool/max_pool2d.rs
+++ b/crates/burn-core/src/nn/pool/max_pool2d.rs
@@ -1,4 +1,5 @@
 use crate as burn;
+use crate::nn::conv::checks::check_same_padding_support;
 
 use crate::config::Config;
 use crate::module::{Content, DisplaySettings, ModuleDisplay};
@@ -18,6 +19,10 @@ pub struct MaxPool2dConfig {
     #[config(default = "[1, 1]")]
     pub strides: [usize; 2],
     /// The padding configuration.
+    ///
+    /// ### Warning
+    /// Only symmetric padding is currently supported. As such, using `Same` padding with an even kernel
+    /// size is not supported as it will not produce the same output size.
     #[config(default = "PaddingConfig2d::Valid")]
     pub padding: PaddingConfig2d,
     /// The dilation.
@@ -61,6 +66,9 @@ impl ModuleDisplay for MaxPool2d {
 impl MaxPool2dConfig {
     /// Initialize a new [max pool 2d](MaxPool2d) module.
     pub fn init(&self) -> MaxPool2d {
+        if self.padding == PaddingConfig2d::Same {
+            check_same_padding_support(&self.kernel_size);
+        }
         MaxPool2d {
             stride: self.strides,
             kernel_size: self.kernel_size,
@@ -79,10 +87,6 @@ impl MaxPool2d {
     ///
     /// - input: `[batch_size, channels, height_in, width_in]`
     /// - output: `[batch_size, channels, height_out, width_out]`
-    ///
-    /// ### Panics
-    /// Only symmetric padding is currently supported. As such, using `Same` padding with an even kernel
-    /// size is not supported as it will not produce the same output size.
     pub fn forward<B: Backend>(&self, input: Tensor<B, 4>) -> Tensor<B, 4> {
         let [_batch_size, _channels_in, height_in, width_in] = input.dims();
         let padding =
@@ -96,6 +100,13 @@ impl MaxPool2d {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    #[should_panic = "Same padding with an even kernel size is not supported"]
+    fn same_with_even_kernel_is_invalid() {
+        let config = MaxPool2dConfig::new([2, 2]).with_padding(PaddingConfig2d::Same);
+        let _ = config.init();
+    }
 
     #[test]
     fn display() {


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.

### Related Issues/PRs

#2676 

### Changes

We only support symmetric padding right now. Since we don't return a `Result` when initializing a module (e.g., `Conv2d` or `MaxPool2d`), I added a check that panics if the module is initialized with this unsupported combination.

This doesn't cover the case where users manually create the module struct, but the preferred way is to use the config anyway. And the same is already done in conv2d init for channels divisible by the number of groups 👍 
