### PR TITLE
Use float intrinsics for deform_conv2d backward, fix `into_data` for padded tensors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,7 +1581,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.4.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=8244dbb4660e373ff1ffb780feb73a5b899e5977#8244dbb4660e373ff1ffb780feb73a5b899e5977"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b179e368c5404e871176155262cfd5221ae0ed60#b179e368c5404e871176155262cfd5221ae0ed60"
 dependencies = [
  "cubecl-core",
  "cubecl-cuda",
@@ -1613,7 +1613,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.4.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=8244dbb4660e373ff1ffb780feb73a5b899e5977#8244dbb4660e373ff1ffb780feb73a5b899e5977"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b179e368c5404e871176155262cfd5221ae0ed60#b179e368c5404e871176155262cfd5221ae0ed60"
 dependencies = [
  "derive-new 0.6.0",
  "embassy-futures",
@@ -1630,7 +1630,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.4.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=8244dbb4660e373ff1ffb780feb73a5b899e5977#8244dbb4660e373ff1ffb780feb73a5b899e5977"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b179e368c5404e871176155262cfd5221ae0ed60#b179e368c5404e871176155262cfd5221ae0ed60"
 dependencies = [
  "bytemuck",
  "cubecl-common 0.4.0",
@@ -1649,7 +1649,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.4.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=8244dbb4660e373ff1ffb780feb73a5b899e5977#8244dbb4660e373ff1ffb780feb73a5b899e5977"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b179e368c5404e871176155262cfd5221ae0ed60#b179e368c5404e871176155262cfd5221ae0ed60"
 dependencies = [
  "bytemuck",
  "cubecl-common 0.4.0",
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.4.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=8244dbb4660e373ff1ffb780feb73a5b899e5977#8244dbb4660e373ff1ffb780feb73a5b899e5977"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b179e368c5404e871176155262cfd5221ae0ed60#b179e368c5404e871176155262cfd5221ae0ed60"
 dependencies = [
  "bytemuck",
  "cubecl-common 0.4.0",
@@ -1679,7 +1679,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.4.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=8244dbb4660e373ff1ffb780feb73a5b899e5977#8244dbb4660e373ff1ffb780feb73a5b899e5977"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b179e368c5404e871176155262cfd5221ae0ed60#b179e368c5404e871176155262cfd5221ae0ed60"
 dependencies = [
  "bytemuck",
  "cubecl-common 0.4.0",
@@ -1705,7 +1705,7 @@ dependencies = [
 [[package]]
 name = "cubecl-linalg"
 version = "0.4.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=8244dbb4660e373ff1ffb780feb73a5b899e5977#8244dbb4660e373ff1ffb780feb73a5b899e5977"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b179e368c5404e871176155262cfd5221ae0ed60#b179e368c5404e871176155262cfd5221ae0ed60"
 dependencies = [
  "bytemuck",
  "cubecl-core",
@@ -1717,7 +1717,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.4.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=8244dbb4660e373ff1ffb780feb73a5b899e5977#8244dbb4660e373ff1ffb780feb73a5b899e5977"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b179e368c5404e871176155262cfd5221ae0ed60#b179e368c5404e871176155262cfd5221ae0ed60"
 dependencies = [
  "cubecl-common 0.4.0",
  "darling",
@@ -1732,7 +1732,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.4.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=8244dbb4660e373ff1ffb780feb73a5b899e5977#8244dbb4660e373ff1ffb780feb73a5b899e5977"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b179e368c5404e871176155262cfd5221ae0ed60#b179e368c5404e871176155262cfd5221ae0ed60"
 dependencies = [
  "cubecl-common 0.4.0",
  "cubecl-core",
@@ -1770,7 +1770,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.4.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=8244dbb4660e373ff1ffb780feb73a5b899e5977#8244dbb4660e373ff1ffb780feb73a5b899e5977"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b179e368c5404e871176155262cfd5221ae0ed60#b179e368c5404e871176155262cfd5221ae0ed60"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -1791,7 +1791,7 @@ dependencies = [
 [[package]]
 name = "cubecl-spirv"
 version = "0.4.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=8244dbb4660e373ff1ffb780feb73a5b899e5977#8244dbb4660e373ff1ffb780feb73a5b899e5977"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b179e368c5404e871176155262cfd5221ae0ed60#b179e368c5404e871176155262cfd5221ae0ed60"
 dependencies = [
  "cubecl-common 0.4.0",
  "cubecl-core",
@@ -1805,7 +1805,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.4.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=8244dbb4660e373ff1ffb780feb73a5b899e5977#8244dbb4660e373ff1ffb780feb73a5b899e5977"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b179e368c5404e871176155262cfd5221ae0ed60#b179e368c5404e871176155262cfd5221ae0ed60"
 dependencies = [
  "ash",
  "async-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,7 +1581,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.4.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5a3f9ac9f6178c4f76570535bf5e42ef12a19a3d#5a3f9ac9f6178c4f76570535bf5e42ef12a19a3d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b179e368c5404e871176155262cfd5221ae0ed60#b179e368c5404e871176155262cfd5221ae0ed60"
 dependencies = [
  "cubecl-core",
  "cubecl-cuda",
@@ -1613,7 +1613,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.4.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5a3f9ac9f6178c4f76570535bf5e42ef12a19a3d#5a3f9ac9f6178c4f76570535bf5e42ef12a19a3d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b179e368c5404e871176155262cfd5221ae0ed60#b179e368c5404e871176155262cfd5221ae0ed60"
 dependencies = [
  "derive-new 0.6.0",
  "embassy-futures",
@@ -1630,7 +1630,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.4.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5a3f9ac9f6178c4f76570535bf5e42ef12a19a3d#5a3f9ac9f6178c4f76570535bf5e42ef12a19a3d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b179e368c5404e871176155262cfd5221ae0ed60#b179e368c5404e871176155262cfd5221ae0ed60"
 dependencies = [
  "bytemuck",
  "cubecl-common 0.4.0",
@@ -1649,7 +1649,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.4.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5a3f9ac9f6178c4f76570535bf5e42ef12a19a3d#5a3f9ac9f6178c4f76570535bf5e42ef12a19a3d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b179e368c5404e871176155262cfd5221ae0ed60#b179e368c5404e871176155262cfd5221ae0ed60"
 dependencies = [
  "bytemuck",
  "cubecl-common 0.4.0",
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.4.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5a3f9ac9f6178c4f76570535bf5e42ef12a19a3d#5a3f9ac9f6178c4f76570535bf5e42ef12a19a3d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b179e368c5404e871176155262cfd5221ae0ed60#b179e368c5404e871176155262cfd5221ae0ed60"
 dependencies = [
  "bytemuck",
  "cubecl-common 0.4.0",
@@ -1679,7 +1679,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.4.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5a3f9ac9f6178c4f76570535bf5e42ef12a19a3d#5a3f9ac9f6178c4f76570535bf5e42ef12a19a3d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b179e368c5404e871176155262cfd5221ae0ed60#b179e368c5404e871176155262cfd5221ae0ed60"
 dependencies = [
  "bytemuck",
  "cubecl-common 0.4.0",
@@ -1705,7 +1705,7 @@ dependencies = [
 [[package]]
 name = "cubecl-linalg"
 version = "0.4.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5a3f9ac9f6178c4f76570535bf5e42ef12a19a3d#5a3f9ac9f6178c4f76570535bf5e42ef12a19a3d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b179e368c5404e871176155262cfd5221ae0ed60#b179e368c5404e871176155262cfd5221ae0ed60"
 dependencies = [
  "bytemuck",
  "cubecl-core",
@@ -1717,7 +1717,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.4.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5a3f9ac9f6178c4f76570535bf5e42ef12a19a3d#5a3f9ac9f6178c4f76570535bf5e42ef12a19a3d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b179e368c5404e871176155262cfd5221ae0ed60#b179e368c5404e871176155262cfd5221ae0ed60"
 dependencies = [
  "cubecl-common 0.4.0",
  "darling",
@@ -1732,7 +1732,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.4.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5a3f9ac9f6178c4f76570535bf5e42ef12a19a3d#5a3f9ac9f6178c4f76570535bf5e42ef12a19a3d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b179e368c5404e871176155262cfd5221ae0ed60#b179e368c5404e871176155262cfd5221ae0ed60"
 dependencies = [
  "cubecl-common 0.4.0",
  "cubecl-core",
@@ -1742,6 +1742,7 @@ dependencies = [
  "petgraph",
  "smallvec",
  "stable-vec",
+ "type-map",
 ]
 
 [[package]]
@@ -1769,7 +1770,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.4.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5a3f9ac9f6178c4f76570535bf5e42ef12a19a3d#5a3f9ac9f6178c4f76570535bf5e42ef12a19a3d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b179e368c5404e871176155262cfd5221ae0ed60#b179e368c5404e871176155262cfd5221ae0ed60"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -1790,7 +1791,7 @@ dependencies = [
 [[package]]
 name = "cubecl-spirv"
 version = "0.4.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5a3f9ac9f6178c4f76570535bf5e42ef12a19a3d#5a3f9ac9f6178c4f76570535bf5e42ef12a19a3d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b179e368c5404e871176155262cfd5221ae0ed60#b179e368c5404e871176155262cfd5221ae0ed60"
 dependencies = [
  "cubecl-common 0.4.0",
  "cubecl-core",
@@ -1804,7 +1805,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.4.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=5a3f9ac9f6178c4f76570535bf5e42ef12a19a3d#5a3f9ac9f6178c4f76570535bf5e42ef12a19a3d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b179e368c5404e871176155262cfd5221ae0ed60#b179e368c5404e871176155262cfd5221ae0ed60"
 dependencies = [
  "ash",
  "async-channel",
@@ -7622,6 +7623,15 @@ dependencies = [
  "sha1",
  "thiserror 2.0.9",
  "utf-8",
+]
+
+[[package]]
+name = "type-map"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb68604048ff8fa93347f02441e4487594adc20bb8a084f9e564d2b827a0a9f"
+dependencies = [
+ "rustc-hash 1.1.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,8 +104,8 @@ text_placeholder = "0.5.1"
 wgpu = "23.0.0"
 
 # Benchmarks and Burnbench
-chrono = "0.4.39"
 arboard = "3.4.1"
+chrono = "0.4.39"
 os_info = "3.9.0"
 wsl = "0.1.0"
 
@@ -153,8 +153,8 @@ ahash = { version = "0.8.11", default-features = false }
 portable-atomic-util = { version = "0.2.4", features = ["alloc"] }
 
 ### For the main burn branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "5a3f9ac9f6178c4f76570535bf5e42ef12a19a3d" }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "5a3f9ac9f6178c4f76570535bf5e42ef12a19a3d" }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "b179e368c5404e871176155262cfd5221ae0ed60" }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "b179e368c5404e871176155262cfd5221ae0ed60" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }

--- a/crates/burn-jit/src/kernel/conv/conv2d/gemm/launch.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d/gemm/launch.rs
@@ -80,8 +80,10 @@ fn conv2d_gemm_cmma_strategy<
     } else if TypeId::of::<F>() == TypeId::of::<bf16>() || TypeId::of::<F>() == TypeId::of::<f16>()
     {
         conv2d_gemm_with_algo::<R, (F, F, f32), Alg, S>(input, weight, bias, options)
-    } else {
+    } else if has_tf32(&input) {
         conv2d_gemm_with_algo::<R, (F, tf32, f32), Alg, S>(input, weight, bias, options)
+    } else {
+        conv2d_gemm_with_algo::<R, (F, f16, f32), Alg, S>(input, weight, bias, options)
     }
 }
 


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.


### Changes

Uses float intrinsics instead of CAS where available - `f32` is currently disabled because of a bug in CUDA I need to investigate. `f16` and `bf16` work fine.
Fixes `into_data` for padded tensors by slicing to the expected length before creating the `TensorData`.


### Testing

All tests pass except for `remainder` on wgpu/spirv, which is still broken due to a driver bug.