### PR TITLE
Add new FromData operation description

### DIFF
--- a/crates/burn-fusion/src/stream/context.rs
+++ b/crates/burn-fusion/src/stream/context.rs
@@ -1056,6 +1056,12 @@ impl RelativeOps for BaseOperationDescription {
             BaseOperationDescription::Empty(desc) => {
                 BaseOperationDescription::Empty(desc.to_relative(converter))
             }
+            BaseOperationDescription::FromData(desc) => {
+                BaseOperationDescription::FromData(FromDataOperationDescription {
+                    data: desc.data.clone(),
+                    out: desc.out.to_relative(converter),
+                })
+            }
         }
     }
 }

--- a/crates/burn-router/src/ops/op_float.rs
+++ b/crates/burn-router/src/ops/op_float.rs
@@ -8,13 +8,13 @@ use burn_tensor::ops::{
 use burn_tensor::repr::{
     BaseOperationDescription, BinaryOperationDescription, CatOperationDescription,
     ClampOperationDescription, ExpandOperationDescription, FlipOperationDescription,
-    FloatOperationDescription, GatherOperationDescription, MaskFillOperationDescription,
-    MaskWhereOperationDescription, NumericOperationDescription, OperationDescription,
-    PermuteOperationDescription, RandomOperationDescription, ReduceDimWithIndicesDescription,
-    RepeatDimOperationDescription, ReshapeDescription, ScalarOperationDescription,
-    ScatterOperationDescription, SelectAssignOperationDescription, SelectOperationDescription,
-    SliceAssignOperationDescription, SliceOperationDescription, SwapDimsDescription,
-    UnaryOperationDescription,
+    FloatOperationDescription, FromDataOperationDescription, GatherOperationDescription,
+    MaskFillOperationDescription, MaskWhereOperationDescription, NumericOperationDescription,
+    OperationDescription, PermuteOperationDescription, RandomOperationDescription,
+    ReduceDimWithIndicesDescription, RepeatDimOperationDescription, ReshapeDescription,
+    ScalarOperationDescription, ScatterOperationDescription, SelectAssignOperationDescription,
+    SelectOperationDescription, SliceAssignOperationDescription, SliceOperationDescription,
+    SwapDimsDescription, UnaryOperationDescription,
 };
 use burn_tensor::{
     DType, Device, Distribution, Element, ElementConversion, Shape, TensorData, TensorMetadata,
@@ -25,7 +25,18 @@ use crate::{get_client, BackendRouter, RunnerChannel, RunnerClient};
 impl<R: RunnerChannel> FloatTensorOps<Self> for BackendRouter<R> {
     fn float_from_data(data: TensorData, device: &Device<Self>) -> FloatTensor<Self> {
         let client = get_client::<R>(device);
-        client.register_tensor_data(data.convert::<<Self as Backend>::FloatElem>())
+        let out = client.register_empty_tensor(data.shape.clone(), FloatElem::<Self>::dtype());
+
+        let desc = FromDataOperationDescription {
+            data,
+            out: out.to_description_out(),
+        };
+
+        client.register(OperationDescription::BaseFloat(
+            BaseOperationDescription::FromData(desc),
+        ));
+
+        out
     }
 
     fn float_random(

--- a/crates/burn-router/src/runner.rs
+++ b/crates/burn-router/src/runner.rs
@@ -245,6 +245,10 @@ impl<B: ReprBackend> RunnerClient for Runner<B> {
                     let output = B::float_empty(shape, &self.device);
                     handles.register_float_tensor::<B>(&desc.id, output);
                 }
+                BaseOperationDescription::FromData(desc) => {
+                    let output = B::float_from_data(desc.data.clone(), &self.device);
+                    handles.register_float_tensor::<B>(&desc.out.id, output);
+                }
             },
             OperationDescription::BaseInt(op) => match op {
                 BaseOperationDescription::ToDevice(_) => unreachable!(),
@@ -315,6 +319,10 @@ impl<B: ReprBackend> RunnerClient for Runner<B> {
                     let shape = Shape::from(desc.shape.clone());
                     let output = B::int_empty(shape, &self.device);
                     handles.register_int_tensor::<B>(&desc.id, output);
+                }
+                BaseOperationDescription::FromData(desc) => {
+                    let output = B::int_from_data(desc.data.clone(), &self.device);
+                    handles.register_int_tensor::<B>(&desc.out.id, output);
                 }
             },
             OperationDescription::BaseBool(op) => match op {
@@ -390,6 +398,10 @@ impl<B: ReprBackend> RunnerClient for Runner<B> {
                     let shape = Shape::from(desc.shape.clone());
                     let output = B::bool_empty(shape, &self.device);
                     handles.register_bool_tensor::<B>(&desc.id, output);
+                }
+                BaseOperationDescription::FromData(desc) => {
+                    let output = B::bool_from_data(desc.data.clone(), &self.device);
+                    handles.register_bool_tensor::<B>(&desc.out.id, output);
                 }
             },
             OperationDescription::NumericFloat(_dtype, op) => match op {

--- a/crates/burn-tensor/src/repr/operation.rs
+++ b/crates/burn-tensor/src/repr/operation.rs
@@ -6,6 +6,7 @@ use alloc::borrow::ToOwned;
 use alloc::boxed::Box;
 use alloc::{string::String, vec, vec::Vec};
 
+use crate::TensorData;
 use crate::{
     ops::{
         ConvOptions, ConvTransposeOptions, DeformConvOptions, InterpolateMode, InterpolateOptions,
@@ -199,6 +200,12 @@ pub enum ModuleOperationDescription {
 pub enum BaseOperationDescription {
     /// Operation corresponding to:
     ///
+    /// Float => [from_data](crate::ops::FloatTensorOps::float_from_data).
+    /// Int => [from_data](crate::ops::IntTensorOps::int_from_data).
+    /// Bool => [from_data](crate::ops::BoolTensorOps::bool_from_data).
+    FromData(FromDataOperationDescription),
+    /// Operation corresponding to:
+    ///
     /// Float => [to device](crate::ops::FloatTensorOps::float_to_device).
     /// Int => [to device](crate::ops::IntTensorOps::int_to_device).
     /// Bool => [to device](crate::ops::BoolTensorOps::bool_to_device).
@@ -272,9 +279,9 @@ pub enum BaseOperationDescription {
 
     /// Operation corresponding to:
     ///
-    /// Float => [equal](crate::ops::FloatTensorOps::float_empty).
-    /// Int => [equal](crate::ops::IntTensorOps::int_empty).
-    /// Bool => [equal](crate::ops::BoolTensorOps::bool_empty).
+    /// Float => [empty](crate::ops::FloatTensorOps::float_empty).
+    /// Int => [empty](crate::ops::IntTensorOps::int_empty).
+    /// Bool => [empty](crate::ops::BoolTensorOps::bool_empty).
     Empty(TensorDescription),
 }
 
@@ -584,6 +591,13 @@ pub struct FlipOperationDescription {
 pub struct RandomOperationDescription {
     pub out: TensorDescription,
     pub distribution: Distribution,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub struct FromDataOperationDescription {
+    pub out: TensorDescription,
+    pub data: TensorData,
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Serialize, Deserialize)]
@@ -1364,6 +1378,7 @@ impl BaseOperationDescription {
             BaseOperationDescription::Cat(desc) => desc.tensors.iter().collect(),
             BaseOperationDescription::Cast(desc) => vec![&desc.input, &desc.out],
             BaseOperationDescription::Empty(desc) => vec![desc],
+            BaseOperationDescription::FromData(desc) => vec![&desc.out],
         }
     }
 }
@@ -1674,6 +1689,14 @@ impl ModuleOperationDescription {
                 vec![&desc.x, &desc.out, &desc.grad]
             }
         }
+    }
+}
+
+impl core::hash::Hash for FromDataOperationDescription {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.out.hash(state);
+
+        self.data.bytes.hash(state);
     }
 }
 

--- a/crates/burn-tensor/src/repr/operation.rs
+++ b/crates/burn-tensor/src/repr/operation.rs
@@ -1695,8 +1695,6 @@ impl ModuleOperationDescription {
 impl core::hash::Hash for FromDataOperationDescription {
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         self.out.hash(state);
-
-        self.data.bytes.hash(state);
     }
 }
 

--- a/crates/burn-tensor/src/tensor/data.rs
+++ b/crates/burn-tensor/src/tensor/data.rs
@@ -36,7 +36,7 @@ pub enum DataError {
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct TensorData {
     /// The values of the tensor (as bytes).
-    pub(crate) bytes: Bytes,
+    bytes: Bytes,
 
     /// The shape of the tensor.
     pub shape: Vec<usize>,

--- a/crates/burn-tensor/src/tensor/data.rs
+++ b/crates/burn-tensor/src/tensor/data.rs
@@ -36,7 +36,7 @@ pub enum DataError {
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct TensorData {
     /// The values of the tensor (as bytes).
-    bytes: Bytes,
+    pub(crate) bytes: Bytes,
 
     /// The shape of the tensor.
     pub shape: Vec<usize>,


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.

### Related Issues/PRs

Fixes #2719

### Changes

- Added a new operation description for `FromData`, similar to other tensor creation ops (zeros, random, etc.)
- Refactored fusion to use the `FromData` description (fixes linked issue, since an operation is registered the handles are correctly freed)
- Fixed empty tensor op in fusion in the process (same issue as from data)

