### PR TITLE
Add chapter to book for nightly use

### DIFF
--- a/burn-book/src/SUMMARY.md
+++ b/burn-book/src/SUMMARY.md
@@ -33,3 +33,4 @@
   - [Custom Optimizer]()
   - [WebAssembly]()
   - [No-Std](./advanced/no-std.md)
+  - [Nightly](./advanced/nightly.md)

--- a/burn-book/src/advanced/nightly.md
+++ b/burn-book/src/advanced/nightly.md
@@ -1,0 +1,17 @@
+# Nightly
+
+Burn has nightly support by default. However, one may meet this error during compilation:
+
+```
+error[E0658]: use of unstable library feature `allocator_api`
+```
+
+To solve it, the `hashbrown` crate with version higher than `0.15` needs to be involved explicitly in `Cargo.toml`:
+
+```toml
+hashbrown = { version = "0.15", features = ["nightly"] }
+```
+
+even it's not required by your code.
+
+See [here](https://github.com/rust-lang/hashbrown/issues/564) for track the issue and [here](https://github.com/zakarumych/allocator-api2/issues/19) for the status.


### PR DESCRIPTION
One may meet this problem when use Burn and another crate with `hashbrown=^0.14` or earlier simultaneously.

![8d8b6f70392272c36efdde952b4af3f](https://github.com/user-attachments/assets/90dfb31b-76e1-4de0-9aa8-3bb916bd01cb)

Similar to https://github.com/rust-lang/hashbrown/issues/564.

In our case, the older version of `hashbrown` is used by `dashmap`.

I've tried to add new feature flags to Burn, but it soon became a tedious business.

Another way is to add alias for older `hashbrown` like what the `polars` has done: https://github.com/pola-rs/polars/pull/19091/files, but I think it's not elegant enough as it can also be complicated.

So maybe the better way is to tell the users the solution in the book.

For more info: https://github.com/rust-lang/hashbrown/issues/564 and https://github.com/zakarumych/allocator-api2/issues/19.
