### PR TITLE
Fix repeat_dim backward w/ dim size > 1

### DIFF
--- a/crates/burn-autodiff/src/tests/repeat_dim.rs
+++ b/crates/burn-autodiff/src/tests/repeat_dim.rs
@@ -23,4 +23,25 @@ mod tests {
             .to_data()
             .assert_eq(&TensorData::from([[-3.0], [12.0]]), false);
     }
+
+    #[test]
+    fn should_diff_repeat_multi_dim() {
+        let data_1 = TensorData::from([[1.0, 7.0], [-2.0, -3.0]]);
+        let data_2 = TensorData::from([[4.0, 2.0], [2.0, 4.0]]);
+
+        let device = Default::default();
+        let tensor_1 = TestAutodiffTensor::<2>::from_data(data_1, &device).require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data(data_2, &device).require_grad();
+
+        let tensor_3 = tensor_2.clone().repeat_dim(1, 3);
+
+        let tensor_3 = tensor_1.matmul(tensor_3);
+        let grads = tensor_3.backward();
+
+        let grad_2 = tensor_2.grad(&grads).unwrap();
+
+        grad_2
+            .to_data()
+            .assert_eq(&TensorData::from([[-3.0, -3.0], [12.0, 12.0]]), false);
+    }
 }


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.

### Related Issues/PRs

Fixes #2776 

### Changes

We previously expanded the support for repeat dim with a size > 1 but the backward was not implemented for that case.
This PR adds a test and fix for repeat when the original dim size > 1

### Testing

Unit test + linked issue example
