### PR TITLE
Remove from_data conversions in backends

### DIFF
--- a/crates/burn-candle/src/backend.rs
+++ b/crates/burn-candle/src/backend.rs
@@ -168,7 +168,7 @@ impl<F: FloatCandleElement, I: IntCandleElement> Backend for Candle<F, I> {
     type IntElem = I;
 
     type BoolTensorPrimitive = CandleTensor;
-    type BoolElem = u32;
+    type BoolElem = u8;
 
     type QuantizedTensorPrimitive = CandleQTensor;
     type QuantizedEncoding = u8;

--- a/crates/burn-candle/src/ops/bool_tensor.rs
+++ b/crates/burn-candle/src/ops/bool_tensor.rs
@@ -1,4 +1,5 @@
 use burn_tensor::{
+    backend::Backend,
     ops::{BoolTensor, BoolTensorOps, FloatTensor, IntTensor},
     Device, Shape, TensorData, TensorMetadata,
 };
@@ -22,8 +23,7 @@ impl<F: FloatCandleElement, I: IntCandleElement> BoolTensorOps<Self> for Candle<
     }
 
     fn bool_from_data(data: TensorData, device: &Device<Self>) -> BoolTensor<Self> {
-        let data: TensorData = TensorData::new(data.iter::<bool>().collect(), data.shape);
-        super::base::from_data::<u8>(data, device)
+        super::base::from_data::<<Self as Backend>::BoolElem>(data, device)
     }
 
     fn bool_into_int(tensor: BoolTensor<Self>) -> IntTensor<Self> {

--- a/crates/burn-candle/src/ops/bool_tensor.rs
+++ b/crates/burn-candle/src/ops/bool_tensor.rs
@@ -1,5 +1,4 @@
 use burn_tensor::{
-    backend::Backend,
     ops::{BoolTensor, BoolTensorOps, FloatTensor, IntTensor},
     Device, Shape, TensorData, TensorMetadata,
 };
@@ -23,7 +22,10 @@ impl<F: FloatCandleElement, I: IntCandleElement> BoolTensorOps<Self> for Candle<
     }
 
     fn bool_from_data(data: TensorData, device: &Device<Self>) -> BoolTensor<Self> {
-        super::base::from_data::<<Self as Backend>::BoolElem>(data, device)
+        match data.dtype {
+            burn_tensor::DType::U8 => super::base::from_data::<u8>(data, device),
+            _ => unimplemented!("Unsupported dtype for `bool_from_data`"),
+        }
     }
 
     fn bool_into_int(tensor: BoolTensor<Self>) -> IntTensor<Self> {

--- a/crates/burn-candle/src/ops/int_tensor.rs
+++ b/crates/burn-candle/src/ops/int_tensor.rs
@@ -20,7 +20,12 @@ impl<F: FloatCandleElement, I: IntCandleElement> IntTensorOps<Self> for Candle<F
     }
 
     fn int_from_data(data: TensorData, device: &Device<Self>) -> IntTensor<Self> {
-        super::base::from_data::<I>(data, device)
+        match data.dtype {
+            burn_tensor::DType::I64 => super::base::from_data::<i64>(data, device),
+            burn_tensor::DType::U32 => super::base::from_data::<u32>(data, device),
+            burn_tensor::DType::U8 => super::base::from_data::<u8>(data, device),
+            _ => unimplemented!("Unsupported dtype for `int_from_data`"),
+        }
     }
 
     fn int_device(tensor: &IntTensor<Self>) -> Device<Self> {

--- a/crates/burn-candle/src/ops/tensor.rs
+++ b/crates/burn-candle/src/ops/tensor.rs
@@ -5,6 +5,7 @@ use burn_tensor::{
     Device, Distribution, ElementConversion, FloatDType, Shape, TensorData,
 };
 use candle_core::{backend::BackendStorage, shape, Tensor};
+use half::{bf16, f16};
 
 use crate::{
     element::{CandleElement, FloatCandleElement, IntCandleElement},
@@ -15,7 +16,13 @@ use super::base::{expand, permute, sign};
 
 impl<F: FloatCandleElement, I: IntCandleElement> FloatTensorOps<Self> for Candle<F, I> {
     fn float_from_data(data: TensorData, device: &Device<Self>) -> CandleTensor {
-        CandleTensor::from_data::<F>(data, device.clone())
+        match data.dtype {
+            burn_tensor::DType::F64 => super::base::from_data::<f64>(data, device),
+            burn_tensor::DType::F32 => super::base::from_data::<f32>(data, device),
+            burn_tensor::DType::F16 => super::base::from_data::<f16>(data, device),
+            burn_tensor::DType::BF16 => super::base::from_data::<bf16>(data, device),
+            _ => unimplemented!("Unsupported dtype for `float_from_data`"),
+        }
     }
 
     fn float_random(

--- a/crates/burn-candle/src/tensor.rs
+++ b/crates/burn-candle/src/tensor.rs
@@ -48,7 +48,7 @@ impl CandleTensor {
     pub fn from_data<E: CandleElement>(data: TensorData, device: CandleDevice) -> Self {
         let candle_shape: candle_core::Shape = data.shape.clone().into();
         let tensor = candle_core::Tensor::from_slice(
-            data.convert::<E>().as_slice::<E>().unwrap(),
+            data.as_slice::<E>().unwrap(),
             candle_shape,
             &device.into(),
         );

--- a/crates/burn-jit/src/ops/base.rs
+++ b/crates/burn-jit/src/ops/base.rs
@@ -8,7 +8,7 @@ pub(crate) fn from_data<R: JitRuntime, E: JitElement>(
 ) -> JitTensor<R> {
     let shape: Shape = (&data.shape).into();
     let client = R::client(device);
-    let buffer = client.create(data.convert::<E>().as_bytes());
+    let buffer = client.create(data.as_bytes());
 
     JitTensor::new_contiguous(client, device.clone(), shape, buffer, E::dtype())
 }

--- a/crates/burn-jit/src/ops/base.rs
+++ b/crates/burn-jit/src/ops/base.rs
@@ -2,15 +2,12 @@ use crate::{element::JitElement, kernel, tensor::JitTensor, BoolElement, JitRunt
 use burn_tensor::{Shape, TensorData};
 use cubecl::tensor_vectorization_factor;
 
-pub(crate) fn from_data<R: JitRuntime, E: JitElement>(
-    data: TensorData,
-    device: &R::Device,
-) -> JitTensor<R> {
+pub(crate) fn from_data<R: JitRuntime>(data: TensorData, device: &R::Device) -> JitTensor<R> {
     let shape: Shape = (&data.shape).into();
     let client = R::client(device);
     let buffer = client.create(data.as_bytes());
 
-    JitTensor::new_contiguous(client, device.clone(), shape, buffer, E::dtype())
+    JitTensor::new_contiguous(client, device.clone(), shape, buffer, data.dtype)
 }
 
 pub(crate) async fn into_data<R: JitRuntime, E: JitElement>(tensor: JitTensor<R>) -> TensorData {

--- a/crates/burn-jit/src/ops/bool_ops.rs
+++ b/crates/burn-jit/src/ops/bool_ops.rs
@@ -21,7 +21,6 @@ where
     }
 
     fn bool_from_data(data: TensorData, device: &Device<Self>) -> BoolTensor<Self> {
-        let data: TensorData = TensorData::new(data.iter::<BT>().collect(), data.shape);
         super::from_data::<R, BT>(data, device)
     }
 

--- a/crates/burn-jit/src/ops/bool_ops.rs
+++ b/crates/burn-jit/src/ops/bool_ops.rs
@@ -21,7 +21,10 @@ where
     }
 
     fn bool_from_data(data: TensorData, device: &Device<Self>) -> BoolTensor<Self> {
-        super::from_data::<R, BT>(data, device)
+        if data.dtype != BT::dtype() {
+            unimplemented!("Unsupported dtype for `bool_from_data`")
+        }
+        super::from_data::<R>(data, device)
     }
 
     fn bool_into_int(tensor: BoolTensor<Self>) -> IntTensor<Self> {

--- a/crates/burn-jit/src/ops/float_ops.rs
+++ b/crates/burn-jit/src/ops/float_ops.rs
@@ -25,7 +25,12 @@ where
     BT: BoolElement,
 {
     fn float_from_data(data: TensorData, device: &Device<Self>) -> FloatTensor<Self> {
-        super::from_data::<R, F>(data, device)
+        match data.dtype {
+            DType::F64 | DType::F32 | DType::F16 | DType::BF16 => {
+                super::from_data::<R>(data, device)
+            }
+            _ => unimplemented!("Unsupported dtype for `float_from_data`"),
+        }
     }
 
     fn float_random(

--- a/crates/burn-jit/src/ops/int_ops.rs
+++ b/crates/burn-jit/src/ops/int_ops.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 use crate::{kernel, FloatElement, IntElement, JitBackend, JitRuntime};
 use burn_tensor::ops::{BoolTensor, Device, FloatTensor, IntElem, IntTensor};
+use burn_tensor::DType;
 use burn_tensor::{ops::IntTensorOps, Distribution, ElementConversion, Shape, TensorData};
 use cubecl::frontend::Numeric;
 use cubecl::prelude::*;
@@ -32,7 +33,12 @@ where
     }
 
     fn int_from_data(data: TensorData, device: &Device<Self>) -> IntTensor<Self> {
-        super::from_data::<R, I>(data, device)
+        match data.dtype {
+            DType::I64 | DType::I32 | DType::I16 | DType::I8 | DType::U32 => {
+                super::from_data::<R>(data, device)
+            }
+            _ => unimplemented!("Unsupported dtype for `int_from_data`"),
+        }
     }
 
     fn int_device(tensor: &IntTensor<Self>) -> Device<Self> {

--- a/crates/burn-ndarray/src/ops/bool_tensor.rs
+++ b/crates/burn-ndarray/src/ops/bool_tensor.rs
@@ -20,6 +20,9 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> BoolTensorOp
     for NdArray<E, I, Q>
 {
     fn bool_from_data(data: TensorData, _device: &NdArrayDevice) -> NdArrayTensor<bool> {
+        if !data.dtype.is_bool() {
+            unimplemented!("Unsupported dtype for `bool_from_data`")
+        }
         NdArrayTensor::from_data(data)
     }
 

--- a/crates/burn-ndarray/src/ops/int_tensor.rs
+++ b/crates/burn-ndarray/src/ops/int_tensor.rs
@@ -20,7 +20,7 @@ use crate::{tensor::NdArrayTensor, NdArray};
 use crate::{NdArrayDevice, SEED};
 
 // Workspace crates
-use burn_tensor::{backend::Backend, Shape, TensorData};
+use burn_tensor::{backend::Backend, DType, Shape, TensorData};
 
 use super::{NdArrayMathOps, NdArrayOps};
 
@@ -28,7 +28,10 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> IntTensorOps
     for NdArray<E, I, Q>
 {
     fn int_from_data(data: TensorData, _device: &NdArrayDevice) -> NdArrayTensor<I> {
-        NdArrayTensor::from_data(data)
+        match data.dtype {
+            DType::I64 | DType::I32 => NdArrayTensor::from_data(data),
+            _ => unimplemented!("Unsupported dtype for `int_from_data`"),
+        }
     }
 
     async fn int_into_data(tensor: NdArrayTensor<I>) -> TensorData {

--- a/crates/burn-ndarray/src/ops/int_tensor.rs
+++ b/crates/burn-ndarray/src/ops/int_tensor.rs
@@ -1,5 +1,4 @@
 // Language
-use alloc::vec;
 use alloc::vec::Vec;
 use burn_common::rand::get_seeded_rng;
 use burn_tensor::ops::FloatTensor;
@@ -52,9 +51,8 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> IntTensorOps
         NdArrayDevice::Cpu
     }
 
-    fn int_empty(shape: Shape, _device: &<NdArray<E> as Backend>::Device) -> NdArrayTensor<I> {
-        let values = vec![0; shape.num_elements()];
-        NdArrayTensor::from_data(TensorData::new(values, shape))
+    fn int_empty(shape: Shape, device: &<NdArray<E> as Backend>::Device) -> NdArrayTensor<I> {
+        Self::int_zeros(shape, device)
     }
 
     fn int_mask_where(
@@ -183,11 +181,11 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> IntTensorOps
     }
 
     fn int_zeros(shape: Shape, device: &<NdArray<E> as Backend>::Device) -> NdArrayTensor<I> {
-        Self::int_from_data(TensorData::zeros::<i64, _>(shape), device)
+        Self::int_from_data(TensorData::zeros::<I, _>(shape), device)
     }
 
     fn int_ones(shape: Shape, device: &<NdArray<E> as Backend>::Device) -> NdArrayTensor<I> {
-        Self::int_from_data(TensorData::ones::<i64, _>(shape), device)
+        Self::int_from_data(TensorData::ones::<I, _>(shape), device)
     }
 
     fn int_full(
@@ -310,7 +308,7 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> IntTensorOps
         };
 
         let tensor = Self::int_from_data(
-            TensorData::random::<i64, _, _>(shape, effective_distribution, &mut rng),
+            TensorData::random::<I, _, _>(shape, effective_distribution, &mut rng),
             device,
         );
         *seed = Some(rng);

--- a/crates/burn-ndarray/src/ops/tensor.rs
+++ b/crates/burn-ndarray/src/ops/tensor.rs
@@ -8,13 +8,13 @@ use ndarray::Zip;
 // Current crate
 use super::{matmul::matmul, NdArrayMathOps, NdArrayOps};
 use crate::element::{ExpElement, FloatNdArrayElement, IntNdArrayElement, QuantElement};
-use crate::{execute_with_float_dtype, new_tensor_float, NdArrayDevice, NdArrayTensorFloat, SEED};
+use crate::{execute_with_float_dtype, NdArrayDevice, NdArrayTensorFloat, SEED};
 use crate::{tensor::NdArrayTensor, NdArray};
 
 // Workspace crates
 use burn_common::rand::get_seeded_rng;
 use burn_tensor::{backend::Backend, ops::FloatTensorOps, ElementConversion, Shape, TensorData};
-use burn_tensor::{Distribution, FloatDType};
+use burn_tensor::{DType, Distribution, FloatDType};
 
 #[cfg(not(feature = "std"))]
 #[allow(unused_imports)]
@@ -42,7 +42,11 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> FloatTensorO
     for NdArray<E, I, Q>
 {
     fn float_from_data(data: TensorData, _device: &NdArrayDevice) -> FloatTensor<Self> {
-        new_tensor_float!(NdArrayTensor::from_data(data))
+        match data.dtype {
+            DType::F64 => NdArrayTensorFloat::F64(NdArrayTensor::from_data(data)),
+            DType::F32 => NdArrayTensorFloat::F32(NdArrayTensor::from_data(data)),
+            _ => unimplemented!("Unsupported dtype for `float_from_data`"),
+        }
     }
 
     fn float_random(

--- a/crates/burn-tch/src/ops/bool_tensor.rs
+++ b/crates/burn-tch/src/ops/bool_tensor.rs
@@ -5,7 +5,10 @@ use std::ops::Range;
 
 impl<E: TchElement, Q: QuantElement> BoolTensorOps<Self> for LibTorch<E, Q> {
     fn bool_from_data(data: TensorData, device: &LibTorchDevice) -> TchTensor {
-        TchTensor::from_data::<bool>(data, (*device).into())
+        match data.dtype {
+            burn_tensor::DType::Bool => TchTensor::from_data::<bool>(data, (*device).into()),
+            _ => unimplemented!("Unsupported dtype for `bool_from_data`"),
+        }
     }
 
     fn bool_repeat_dim(tensor: TchTensor, dim: usize, times: usize) -> TchTensor {

--- a/crates/burn-tch/src/ops/int_tensor.rs
+++ b/crates/burn-tch/src/ops/int_tensor.rs
@@ -12,7 +12,10 @@ use super::TchOps;
 
 impl<E: TchElement, Q: QuantElement> IntTensorOps<Self> for LibTorch<E, Q> {
     fn int_from_data(data: TensorData, device: &LibTorchDevice) -> TchTensor {
-        TchTensor::from_data::<i64>(data, (*device).into())
+        match data.dtype {
+            burn_tensor::DType::I64 => TchTensor::from_data::<i64>(data, (*device).into()),
+            _ => unimplemented!("Unsupported dtype for `int_from_data`"),
+        }
     }
 
     fn int_repeat_dim(tensor: TchTensor, dim: usize, times: usize) -> TchTensor {

--- a/crates/burn-tch/src/ops/tensor.rs
+++ b/crates/burn-tch/src/ops/tensor.rs
@@ -3,14 +3,20 @@ use crate::{element::TchElement, LibTorch, LibTorchDevice, QuantElement, TchShap
 use burn_tensor::{
     backend::Backend,
     ops::{FloatTensorOps, IntTensor},
-    Distribution, ElementConversion, FloatDType, Shape, TensorData, TensorMetadata,
+    DType, Distribution, ElementConversion, FloatDType, Shape, TensorData, TensorMetadata,
 };
 use half::{bf16, f16};
 use std::ops::Range;
 
 impl<E: TchElement, Q: QuantElement> FloatTensorOps<Self> for LibTorch<E, Q> {
     fn float_from_data(data: TensorData, device: &LibTorchDevice) -> TchTensor {
-        TchTensor::from_data::<E>(data, (*device).into())
+        match data.dtype {
+            DType::F64 => TchTensor::from_data::<f64>(data, (*device).into()),
+            DType::F32 => TchTensor::from_data::<f32>(data, (*device).into()),
+            DType::F16 => TchTensor::from_data::<f16>(data, (*device).into()),
+            DType::BF16 => TchTensor::from_data::<bf16>(data, (*device).into()),
+            _ => unimplemented!("Unsupported dtype for `float_from_data`"),
+        }
     }
 
     fn float_random(

--- a/crates/burn-tch/src/tensor.rs
+++ b/crates/burn-tch/src/tensor.rs
@@ -292,8 +292,7 @@ impl TchTensor {
     /// A new tensor.
     pub fn from_data<E: TchElement>(data: TensorData, device: tch::Device) -> Self {
         let shape_tch = TchShape::from(data.shape.as_slice());
-        let tensor =
-            tch::Tensor::from_slice(data.convert::<E>().as_slice::<E>().unwrap()).to(device);
+        let tensor = tch::Tensor::from_slice(data.as_slice::<E>().unwrap()).to(device);
         let tensor = tensor.reshape(shape_tch.dims).to_kind(E::KIND);
 
         Self::new(tensor)

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -2534,7 +2534,10 @@ impl<B: Backend> BasicOps<B> for Float {
             DType::QFloat(_strategy) => {
                 TensorPrimitive::QFloat(B::q_from_data(data.convert_dtype(dtype), device))
             }
-            _ => TensorPrimitive::Float(B::float_from_data(data.convert_dtype(dtype), device)),
+            _ if dtype.is_float() => {
+                TensorPrimitive::Float(B::float_from_data(data.convert_dtype(dtype), device))
+            }
+            _ => panic!("Expected float dtype, got {dtype:?}"),
         }
     }
 
@@ -2711,6 +2714,10 @@ impl<B: Backend> BasicOps<B> for Int {
     }
 
     fn from_data_dtype(data: TensorData, device: &B::Device, dtype: DType) -> Self::Primitive {
+        if !dtype.is_int() {
+            panic!("Expected int dtype, got {dtype:?}")
+        }
+
         B::int_from_data(data.convert_dtype(dtype), device)
     }
 
@@ -2827,6 +2834,10 @@ impl<B: Backend> BasicOps<B> for Bool {
     }
 
     fn from_data_dtype(data: TensorData, device: &B::Device, dtype: DType) -> Self::Primitive {
+        // Backends only use one bool representation dtype
+        if dtype != B::BoolElem::dtype() {
+            panic!("Expected bool dtype, got {dtype:?}")
+        }
         B::bool_from_data(data.convert_dtype(dtype), device)
     }
 

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -2823,7 +2823,7 @@ impl<B: Backend> BasicOps<B> for Bool {
     }
 
     fn from_data(data: TensorData, device: &B::Device) -> Self::Primitive {
-        B::bool_from_data(data.convert::<bool>(), device)
+        B::bool_from_data(data.convert::<B::BoolElem>(), device)
     }
 
     fn from_data_dtype(data: TensorData, device: &B::Device, dtype: DType) -> Self::Primitive {

--- a/crates/burn-tensor/src/tensor/api/bool.rs
+++ b/crates/burn-tensor/src/tensor/api/bool.rs
@@ -21,7 +21,7 @@ where
 {
     /// Create a boolean tensor from data on the given device.
     pub fn from_bool(data: TensorData, device: &B::Device) -> Self {
-        Self::new(B::bool_from_data(data, device))
+        Self::new(B::bool_from_data(data.convert::<B::BoolElem>(), device))
     }
 
     /// Convert the bool tensor into an int tensor.


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.

### Related Issues/PRs

Follow-up to #2778 

### Changes

With the last PR, the data conversion happens at the tensor API level. Backends should not have behave differently to handle conversions themselves.
