### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/crates/burn-tensor/src/tensor/report.rs
+++ b/crates/burn-tensor/src/tensor/report.rs
@@ -76,7 +76,7 @@ pub fn check_closeness<B: Backend, const D: usize>(output: &Tensor<B, D>, expect
     println!("===============================");
 
     for epsilon in [1e-1, 1e-2, 1e-3, 1e-4, 1e-5, 1e-6, 1e-7, 1e-8].iter() {
-        println!("{} {:.e}", "Epsilon:".bold(), epsilon);
+        println!("{} {:e}", "Epsilon:".bold(), epsilon);
 
         let close = output
             .clone()


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.
