### PR TITLE
Update cubecl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,7 +1475,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=49f38a2b426b9a7fb90969ceb097003cc78556b1#49f38a2b426b9a7fb90969ceb097003cc78556b1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa#29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa"
 dependencies = [
  "cubecl-core",
  "cubecl-cuda",
@@ -1490,7 +1490,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=49f38a2b426b9a7fb90969ceb097003cc78556b1#49f38a2b426b9a7fb90969ceb097003cc78556b1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa#29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa"
 dependencies = [
  "bytemuck",
  "derive-new 0.6.0",
@@ -1511,7 +1511,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=49f38a2b426b9a7fb90969ceb097003cc78556b1#49f38a2b426b9a7fb90969ceb097003cc78556b1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa#29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa"
 dependencies = [
  "bitflags 2.8.0",
  "bytemuck",
@@ -1532,7 +1532,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=49f38a2b426b9a7fb90969ceb097003cc78556b1#49f38a2b426b9a7fb90969ceb097003cc78556b1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa#29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1546,7 +1546,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=49f38a2b426b9a7fb90969ceb097003cc78556b1#49f38a2b426b9a7fb90969ceb097003cc78556b1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa#29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1562,7 +1562,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=49f38a2b426b9a7fb90969ceb097003cc78556b1#49f38a2b426b9a7fb90969ceb097003cc78556b1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa#29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1588,7 +1588,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=49f38a2b426b9a7fb90969ceb097003cc78556b1#49f38a2b426b9a7fb90969ceb097003cc78556b1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa#29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa"
 dependencies = [
  "cubecl-common",
  "cubecl-macros-internal",
@@ -1606,7 +1606,7 @@ dependencies = [
 [[package]]
 name = "cubecl-linalg"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=49f38a2b426b9a7fb90969ceb097003cc78556b1#49f38a2b426b9a7fb90969ceb097003cc78556b1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa#29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa"
 dependencies = [
  "bytemuck",
  "cubecl-core",
@@ -1618,7 +1618,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=49f38a2b426b9a7fb90969ceb097003cc78556b1#49f38a2b426b9a7fb90969ceb097003cc78556b1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa#29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa"
 dependencies = [
  "cubecl-common",
  "darling",
@@ -1633,7 +1633,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=49f38a2b426b9a7fb90969ceb097003cc78556b1#49f38a2b426b9a7fb90969ceb097003cc78556b1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa#29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1644,7 +1644,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=49f38a2b426b9a7fb90969ceb097003cc78556b1#49f38a2b426b9a7fb90969ceb097003cc78556b1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa#29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa"
 dependencies = [
  "cubecl-common",
  "cubecl-ir",
@@ -1660,7 +1660,7 @@ dependencies = [
 [[package]]
 name = "cubecl-reduce"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=49f38a2b426b9a7fb90969ceb097003cc78556b1#49f38a2b426b9a7fb90969ceb097003cc78556b1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa#29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa"
 dependencies = [
  "cubecl-core",
  "cubecl-runtime",
@@ -1670,7 +1670,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=49f38a2b426b9a7fb90969ceb097003cc78556b1#49f38a2b426b9a7fb90969ceb097003cc78556b1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa#29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -1692,7 +1692,7 @@ dependencies = [
 [[package]]
 name = "cubecl-spirv"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=49f38a2b426b9a7fb90969ceb097003cc78556b1#49f38a2b426b9a7fb90969ceb097003cc78556b1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa#29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa"
 dependencies = [
  "bitflags 2.8.0",
  "cubecl-common",
@@ -1707,7 +1707,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=49f38a2b426b9a7fb90969ceb097003cc78556b1#49f38a2b426b9a7fb90969ceb097003cc78556b1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa#29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa"
 dependencies = [
  "ash",
  "async-channel",
@@ -1719,6 +1719,7 @@ dependencies = [
  "cubecl-runtime",
  "cubecl-spirv",
  "derive-new 0.6.0",
+ "derive_more 1.0.0",
  "hashbrown 0.14.5",
  "log",
  "web-time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,8 +153,8 @@ ahash = { version = "0.8.11", default-features = false }
 portable-atomic-util = { version = "0.2.4", features = ["alloc"] }
 
 ### For the main burn branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "49f38a2b426b9a7fb90969ceb097003cc78556b1" }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "49f38a2b426b9a7fb90969ceb097003cc78556b1" }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa" }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "29bcebb04145e79d9c176ed2b93f10a7e5b9c2aa" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }

--- a/crates/burn-jit/src/kernel/conv/conv2d/gemm/algorithm.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d/gemm/algorithm.rs
@@ -59,16 +59,12 @@ impl Algorithm for ImplicitCmmaConv {
     type Input = <Self::GlobalConvolution as ConvolutionConfigFactory>::Input;
 
     fn cube_dim(selection: &ConvSelection) -> CubeDim {
-        CubeDim::new(
-            selection.matmul.plane_dim,
-            selection.matmul.num_stagess.m,
-            1,
-        )
+        CubeDim::new(selection.matmul.plane_dim, selection.matmul.tile_count.m, 1)
     }
 
     fn cube_count(selection: &ConvSelection, problem: &ConvolutionProblem) -> CubeCount {
-        let m_stage = selection.matmul.num_stagess.m * selection.matmul.tile.m;
-        let n_stage = selection.matmul.num_stagess.n * selection.matmul.tile.n;
+        let m_stage = selection.matmul.tile_count.m * selection.matmul.tile_shape.m;
+        let n_stage = selection.matmul.tile_count.n * selection.matmul.tile_shape.n;
         let cubes_needed_m = (problem.m as u32).div_ceil(m_stage);
         let cubes_needed_n = (problem.n as u32).div_ceil(n_stage);
 

--- a/crates/burn-jit/src/kernel/conv/conv2d/gemm/loader/im2col.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d/gemm/loader/im2col.rs
@@ -97,10 +97,10 @@ impl SimpleIm2col {
         #[comptime] ident: Ident,
         #[comptime] config: G,
     ) {
-        let stage_dim = config.stage_dim(ident);
+        let stage_tiling = config.stage_tiling(ident);
         let line_size = config.global_line_size(ident);
 
-        let num_stage_elements = stage_dim.total_elements();
+        let num_stage_elements = stage_tiling.total_size();
         let total_units = comptime!(config.num_planes() * config.plane_dim());
         let jump_length = comptime!(total_units * line_size);
         let num_loads_per_unit = num_stage_elements / jump_length;
@@ -114,20 +114,20 @@ impl SimpleIm2col {
         for i in 0..num_loads_per_unit {
             let unit_position = unit_position_base + i * jump_length;
 
-            let tile_num_elements = stage_dim.tile_num_elements();
+            let tile_num_elements = stage_tiling.tile_size();
             let nth_tile = unit_position / tile_num_elements;
             let pos_within_tile = unit_position % tile_num_elements;
 
             let (tile_x, tile_y) = match config.tiling_order(ident) {
                 TilingOrderConfig::RowMajor => RowMajorTiling::to_x_y(
                     nth_tile,
-                    stage_dim.num_tiles_x_dim(),
-                    stage_dim.num_tiles_y_dim(),
+                    stage_tiling.total_row(),
+                    stage_tiling.total_col(),
                 ),
                 TilingOrderConfig::ColMajor => ColMajorTiling::to_x_y(
                     nth_tile,
-                    stage_dim.num_tiles_x_dim(),
-                    stage_dim.num_tiles_y_dim(),
+                    stage_tiling.total_row(),
+                    stage_tiling.total_col(),
                 ),
             };
 

--- a/crates/burn-jit/src/kernel/conv/conv2d/gemm/reader/im2col.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d/gemm/reader/im2col.rs
@@ -98,8 +98,8 @@ impl<E: Numeric> Im2colReader<E> {
         #[comptime] config: G,
     ) -> Line<E> {
         let line_size = config.global_line_size(ident);
-        let tile_size_x = config.stage_dim(ident).tile_size_x_dim();
-        let tile_size_y = config.stage_dim(ident).tile_size_y_dim();
+        let tile_size_x = config.stage_tiling(ident).total_row();
+        let tile_size_y = config.stage_tiling(ident).total_col();
 
         let view_tile_m = tile_x * tile_size_x + self.m_offset;
         let view_tile_k = tile_y * tile_size_y + self.k_offset;

--- a/crates/burn-jit/src/kernel/conv/conv2d/gemm/selection.rs
+++ b/crates/burn-jit/src/kernel/conv/conv2d/gemm/selection.rs
@@ -3,11 +3,7 @@ use super::{
     precision::ConvPrecision,
 };
 use crate::JitRuntime;
-use cubecl::linalg::matmul::components::{
-    stage::CommonStageInput,
-    tile::{accelerated::Accelerated, TileMatmulFamily},
-    MatmulSelection, MatmulSize,
-};
+use cubecl::linalg::matmul::components::{CompleteStageTiling, MatmulSelection, MatmulSize};
 
 pub struct ConvSelection {
     pub matmul: MatmulSelection,
@@ -32,17 +28,17 @@ impl ConvSelector<ImplicitCmmaConv> for Large {
         <ImplicitCmmaConv as Algorithm>::Input,
     ) {
         let selection = MatmulSelection {
-            tile: MatmulSize {
+            tile_shape: MatmulSize {
                 m: 16,
                 n: 16,
                 k: 16,
             },
-            num_stagess: MatmulSize { m: 8, n: 4, k: 2 },
+            tile_count: MatmulSize { m: 8, n: 4, k: 2 },
             plane_dim,
         };
-        let config_input = CommonStageInput {
-            tile: Accelerated::input(selection.tile),
-            num_stages: selection.num_stagess,
+        let config_input = CompleteStageTiling {
+            tile_shape: selection.tile_shape,
+            tile_count: selection.tile_count,
         };
 
         let selection = ConvSelection { matmul: selection };
@@ -59,17 +55,17 @@ impl ConvSelector<ImplicitCmmaConv> for Balanced {
         <ImplicitCmmaConv as Algorithm>::Input,
     ) {
         let selection = MatmulSelection {
-            tile: MatmulSize {
+            tile_shape: MatmulSize {
                 m: 16,
                 n: 16,
                 k: 16,
             },
-            num_stagess: MatmulSize { m: 4, n: 2, k: 4 },
+            tile_count: MatmulSize { m: 4, n: 2, k: 4 },
             plane_dim,
         };
-        let config_input = CommonStageInput {
-            tile: Accelerated::input(selection.tile),
-            num_stages: selection.num_stagess,
+        let config_input = CompleteStageTiling {
+            tile_shape: selection.tile_shape,
+            tile_count: selection.tile_count,
         };
 
         let selection = ConvSelection { matmul: selection };

--- a/crates/burn-jit/src/template/base.rs
+++ b/crates/burn-jit/src/template/base.rs
@@ -20,7 +20,12 @@ pub struct SourceKernel<K> {
 }
 
 impl<C: Compiler, K: KernelSource> CubeTask<C> for SourceKernel<K> {
-    fn compile(&self, _options: &C::CompilationOptions, _mode: ExecutionMode) -> CompiledKernel<C> {
+    fn compile(
+        &self,
+        _compiler: &mut C,
+        _options: &C::CompilationOptions,
+        _mode: ExecutionMode,
+    ) -> CompiledKernel<C> {
         let source_template = self.kernel_source.source();
         let source = source_template.complete();
 
@@ -29,7 +34,6 @@ impl<C: Compiler, K: KernelSource> CubeTask<C> for SourceKernel<K> {
             debug_name: Some(core::any::type_name::<K>()),
             source,
             cube_dim: self.cube_dim,
-            shared_mem_bytes: 0,
             debug_info: None,
             repr: None,
         }

--- a/crates/burn-wgpu/src/lib.rs
+++ b/crates/burn-wgpu/src/lib.rs
@@ -14,10 +14,6 @@ pub use burn_jit::{BoolElement, FloatElement, IntElement};
 pub use cubecl::flex32;
 pub use cubecl::CubeDim;
 
-// feature wgpu = auto, webgpu = wgsl, vulkan = spirv
-// if no generic:
-// NOTE: WgpuRuntime always uses the AutoGraphicsApi (so backend is entirely dynamic)
-
 pub use cubecl::wgpu::{
     init_device, init_setup, init_setup_async, AutoCompiler, MemoryConfiguration, RuntimeOptions,
     WgpuDevice, WgpuResource, WgpuRuntime, WgpuSetup, WgpuStorage,

--- a/crates/burn-wgpu/src/lib.rs
+++ b/crates/burn-wgpu/src/lib.rs
@@ -14,8 +14,12 @@ pub use burn_jit::{BoolElement, FloatElement, IntElement};
 pub use cubecl::flex32;
 pub use cubecl::CubeDim;
 
+// feature wgpu = auto, webgpu = wgsl, vulkan = spirv
+// if no generic:
+// NOTE: WgpuRuntime always uses the AutoGraphicsApi (so backend is entirely dynamic)
+
 pub use cubecl::wgpu::{
-    init_device, init_setup, init_setup_async, MemoryConfiguration, RuntimeOptions, WgpuCompiler,
+    init_device, init_setup, init_setup_async, AutoCompiler, MemoryConfiguration, RuntimeOptions,
     WgpuDevice, WgpuResource, WgpuRuntime, WgpuSetup, WgpuStorage,
 };
 // Vulkan and WebGpu would have conflicting type names
@@ -24,7 +28,7 @@ pub mod graphics {
 }
 
 #[cfg(feature = "cubecl-spirv")]
-pub use cubecl::wgpu::spirv::SpirvCompiler;
+pub use cubecl::wgpu::vulkan::VkSpirvCompiler;
 #[cfg(feature = "cubecl-wgsl")]
 pub use cubecl::wgpu::WgslCompiler;
 
@@ -60,8 +64,8 @@ pub use cubecl::wgpu::WgslCompiler;
 ///
 /// You can disable the `fusion` feature flag to remove that functionality, which might be
 /// necessary on `wasm` for now.
-pub type Wgpu<F = f32, I = i32, B = u32, C = cubecl::wgpu::WgslCompiler> =
-    burn_fusion::Fusion<JitBackend<cubecl::wgpu::WgpuRuntime<C>, F, I, B>>;
+pub type Wgpu<F = f32, I = i32, B = u32> =
+    burn_fusion::Fusion<JitBackend<cubecl::wgpu::WgpuRuntime, F, I, B>>;
 
 #[cfg(not(feature = "fusion"))]
 /// Tensor backend that uses the wgpu crate for executing GPU compute shaders.
@@ -95,16 +99,15 @@ pub type Wgpu<F = f32, I = i32, B = u32, C = cubecl::wgpu::WgslCompiler> =
 ///
 /// You can enable the `fusion` feature flag to add that functionality, which might improve
 /// performance.
-pub type Wgpu<F = f32, I = i32, B = u32, C = cubecl::wgpu::WgslCompiler> =
-    JitBackend<cubecl::wgpu::WgpuRuntime<C>, F, I, B>;
+pub type Wgpu<F = f32, I = i32, B = u32> = JitBackend<cubecl::wgpu::WgpuRuntime, F, I, B>;
 
 #[cfg(feature = "vulkan")]
 /// Tensor backend that leverages the Vulkan graphics API to execute GPU compute shaders compiled to SPIR-V.
-pub type Vulkan<F = f32, I = i32, B = u8> = Wgpu<F, I, B, cubecl::wgpu::spirv::VkSpirvCompiler>;
+pub type Vulkan<F = f32, I = i32, B = u8> = Wgpu<F, I, B>;
 
 #[cfg(feature = "webgpu")]
 /// Tensor backend that uses the wgpu crate to execute GPU compute shaders written in WGSL.
-pub type WebGpu<F = f32, I = i32, B = u32> = Wgpu<F, I, B, WgslCompiler>;
+pub type WebGpu<F = f32, I = i32, B = u32> = Wgpu<F, I, B>;
 
 #[cfg(test)]
 mod tests {
@@ -112,11 +115,7 @@ mod tests {
     #[cfg(feature = "vulkan")]
     pub use half::f16;
 
-    #[cfg(feature = "cubecl-spirv")]
-    type Compiler = cubecl::wgpu::spirv::VkSpirvCompiler;
-    #[cfg(not(feature = "cubecl-spirv"))]
-    type Compiler = cubecl::wgpu::WgslCompiler;
-    pub type TestRuntime = cubecl::wgpu::WgpuRuntime<Compiler>;
+    pub type TestRuntime = cubecl::wgpu::WgpuRuntime;
 
     // Don't test `flex32` for now, burn sees it as `f32` but is actually `f16` precision, so it
     // breaks a lot of tests from precision issues


### PR DESCRIPTION
With the new auto compiler for wgpu not sure how we want to proceed for the `Vulkan` and `WebGpu` backend type alias.

The auto compiler is hardcoded as the associated type for the runtime (and the variant is selected based on the feature flag). Could be changed in another PR.
