### PR TITLE
[burn-import] Fix 🐛: Inherit input's elem types for `unsqueeze` and `reshape` nodes

### DIFF
--- a/crates/onnx-ir/src/dim_inference.rs
+++ b/crates/onnx-ir/src/dim_inference.rs
@@ -345,16 +345,11 @@ fn reshape_update_outputs(node: &mut Node) {
         node.attrs.get("shape").cloned().map(|v| v.into_i64s())
     };
 
-    let output = match &node.outputs[0].ty {
-        ArgType::Tensor(tensor) => tensor.clone(),
-        _ => panic!("Reshape: invalid output types"),
-    };
-
     if let Some(shape) = shape {
         node.outputs[0].ty = ArgType::Tensor(TensorType {
+            elem_type: node.inputs[0].ty.elem_type().clone(),
             dim: shape.len(),
             shape: None, // shape is calculated at runtime
-            ..output
         });
     }
 }
@@ -495,7 +490,7 @@ fn unsqueeze_update_output(node: &mut Node) {
     };
 
     let output_elem = match &node.outputs[0].ty {
-        ArgType::Tensor(tensor) => tensor.elem_type.clone(),
+        ArgType::Tensor(_) => node.inputs[0].ty.elem_type().clone(),
         ArgType::Scalar(elem_type) => elem_type.clone(),
         _ => panic!("Unsqueeze: invalid output type"),
     };


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

_Provide links to relevant issues and dependent PRs._
- #2592
- #2806

### Changes

_Summarize the problem being addressed and your solution._

`onnx-ir` nodes are instantiated with a default `Float32` `elem_type`, and it seems that many ONNX operations assume that the output type is unchanged (i.e. hardcoded to `Float32`). However, in practice a node's output `elem_type` should be consistent with its input's `elem_type` (which may not always be `Float32`). 

This PR is an unexhaustive PR, that fixes the aforementioned issue for the `Unsqueeze` and `Reshape` operations. 

### Testing

_Describe how these changes have been tested._
Ran `run-checks all` with all tests passing. 