### PR TITLE
Feature: Add data_dir optional argument to Huggingface DataLoader

### DIFF
--- a/crates/burn-dataset/src/source/huggingface/downloader.rs
+++ b/crates/burn-dataset/src/source/huggingface/downloader.rs
@@ -63,6 +63,7 @@ pub struct HuggingfaceDatasetLoader {
     base_dir: Option<PathBuf>,
     huggingface_token: Option<String>,
     huggingface_cache_dir: Option<String>,
+    huggingface_data_dir: Option<String>,
     trust_remote_code: bool,
 }
 
@@ -75,6 +76,7 @@ impl HuggingfaceDatasetLoader {
             base_dir: None,
             huggingface_token: None,
             huggingface_cache_dir: None,
+            huggingface_data_dir: None,
             trust_remote_code: false,
         }
     }
@@ -110,6 +112,16 @@ impl HuggingfaceDatasetLoader {
     /// If not specified, the dataset will be stored in `~/.cache/huggingface/datasets`.
     pub fn with_huggingface_cache_dir(mut self, huggingface_cache_dir: &str) -> Self {
         self.huggingface_cache_dir = Some(huggingface_cache_dir.to_string());
+        self
+    }
+
+    /// Specify a relative path to a subset of a dataset. This is used in some datasets for the
+    /// manual steps of dataset download process.
+    ///
+    /// Unless you've encountered a ManualDownloadError
+    /// when loading your dataset you probably don't have to worry about this setting.
+    pub fn with_huggingface_data_dir(mut self, huggingface_data_dir: &str) -> Self {
+        self.huggingface_data_dir = Some(huggingface_data_dir.to_string());
         self
     }
 
@@ -163,6 +175,7 @@ impl HuggingfaceDatasetLoader {
                 base_dir,
                 self.huggingface_token,
                 self.huggingface_cache_dir,
+                self.huggingface_data_dir,
                 self.trust_remote_code,
             )?;
         }
@@ -172,6 +185,7 @@ impl HuggingfaceDatasetLoader {
 }
 
 /// Import a dataset from huggingface. The transformed dataset is stored as sqlite database.
+#[allow(clippy::too_many_arguments)]
 fn import(
     name: String,
     subset: Option<String>,
@@ -179,6 +193,7 @@ fn import(
     base_dir: PathBuf,
     huggingface_token: Option<String>,
     huggingface_cache_dir: Option<String>,
+    huggingface_data_dir: Option<String>,
     trust_remote_code: bool,
 ) -> Result<(), ImporterError> {
     let venv_python_path = install_python_deps(&base_dir)?;
@@ -206,6 +221,10 @@ fn import(
     if let Some(huggingface_cache_dir) = huggingface_cache_dir {
         command.arg("--cache_dir");
         command.arg(huggingface_cache_dir);
+    }
+    if let Some(huggingface_data_dir) = huggingface_data_dir {
+        command.arg("--data_dir");
+        command.arg(huggingface_data_dir);
     }
     if trust_remote_code {
         command.arg("--trust_remote_code");

--- a/crates/burn-dataset/src/source/huggingface/importer.py
+++ b/crates/burn-dataset/src/source/huggingface/importer.py
@@ -12,6 +12,7 @@ def download_and_export(
     db_file: str,
     token: str,
     cache_dir: str,
+    data_dir: str | None,
     trust_remote_code: bool,
 ):
     """
@@ -37,6 +38,7 @@ def download_and_export(
         name,
         subset,
         cache_dir=cache_dir,
+        data_dir=data_dir,
         use_auth_token=token,
         trust_remote_code=trust_remote_code,
     )
@@ -174,6 +176,9 @@ def parse_args():
         "--cache_dir", type=str, help="Cache directory", required=False, default=None
     )
     parser.add_argument(
+            "--data_dir", type=str, help="Relative path to a specific subset of your dataset", required=False, default=None
+    )
+    parser.add_argument(
         "--trust_remote_code",
         type=bool,
         help="Trust remote code",
@@ -192,6 +197,7 @@ def run():
         args.subset,
         args.file,
         args.token,
+        args.data_dir,
         args.cache_dir,
         args.trust_remote_code,
     )


### PR DESCRIPTION
Add data_dir optional argument to Huggingface DataLoader to enable some manual download use cases

## Pull Request Template

### Checklist

- [ x] Confirmed that `run-checks all` script has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

#2811 

### Changes

Some datasets (e.x. `facebook/covost2`) require this argument to include the subset of the dataset downloaded manually. 

### Testing

`./run_checks.sh all`