### PR TITLE
Support training in no-std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,8 +575,11 @@ dependencies = [
  "burn-common",
  "burn-tensor",
  "burn-tensor-testgen",
+ "cfg_block",
  "derive-new 0.7.0",
+ "hashbrown 0.15.2",
  "log",
+ "num-traits",
  "spin",
 ]
 
@@ -1146,6 +1149,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "cfg_block"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f16895abeb4fd800dcd4e7916b690d79b33a964ae3272d51510623b76aa7108"
+
+[[package]]
 name = "chrono"
 version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,7 +1286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3706,7 +3715,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7966,7 +7975,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,5 +167,7 @@ cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features 
 ### For xtask crate ###
 tracel-xtask = { version = "=1.1.8" }
 
+cfg_block = "0.2.0"
+
 [profile.dev]
 debug = 0 # Speed up compilation time and not necessary.

--- a/crates/burn-autodiff/Cargo.toml
+++ b/crates/burn-autodiff/Cargo.toml
@@ -25,6 +25,9 @@ burn-tensor-testgen = { path = "../burn-tensor-testgen", version = "0.17.0", opt
 derive-new = { workspace = true }
 spin = { workspace = true }
 log = { workspace = true }
+cfg_block = { workspace = true }
+hashbrown = { workspace = true }
+num-traits = { workspace = true }
 
 [dev-dependencies]
 burn-tensor = { path = "../burn-tensor", version = "0.17.0", default-features = false, features = [

--- a/crates/burn-autodiff/src/backend.rs
+++ b/crates/burn-autodiff/src/backend.rs
@@ -1,6 +1,7 @@
 use crate::{
     checkpoint::strategy::{CheckpointStrategy, NoCheckpointing},
     grads::Gradients,
+    libs::{format, String},
     runtime::AutodiffClient,
     tensor::AutodiffTensor,
 };

--- a/crates/burn-autodiff/src/checkpoint/base.rs
+++ b/crates/burn-autodiff/src/checkpoint/base.rs
@@ -3,7 +3,7 @@ use super::{
     state::{BackwardStates, State},
 };
 use crate::graph::NodeID;
-use std::collections::HashMap;
+use crate::libs::{vec, HashMap, Vec};
 
 #[derive(new, Debug)]
 /// Links a [NodeID] to its autodiff graph [NodeRef]

--- a/crates/burn-autodiff/src/checkpoint/builder.rs
+++ b/crates/burn-autodiff/src/checkpoint/builder.rs
@@ -1,9 +1,10 @@
 use crate::{
     graph::{ComputingProperty, NodeID, NodeSteps},
+    libs::{Arc, Box, HashMap, Vec},
     tensor::AutodiffTensor,
 };
 use burn_tensor::backend::Backend;
-use std::{any::Any, collections::HashMap, sync::Arc};
+use core::any::Any;
 
 use super::{
     base::{Checkpointer, NodeTree},

--- a/crates/burn-autodiff/src/checkpoint/retro_forward.rs
+++ b/crates/burn-autodiff/src/checkpoint/retro_forward.rs
@@ -1,6 +1,7 @@
 use crate::graph::NodeID;
+use crate::libs::{Arc, HashMap};
 
-use std::{collections::HashMap, fmt::Debug, sync::Arc};
+use core::fmt::Debug;
 
 use super::state::{BackwardStates, State};
 

--- a/crates/burn-autodiff/src/checkpoint/state.rs
+++ b/crates/burn-autodiff/src/checkpoint/state.rs
@@ -1,6 +1,7 @@
-use std::{any::Any, collections::HashMap};
+use core::any::Any;
 
 use crate::graph::NodeID;
+use crate::libs::{Box, HashMap};
 
 /// In order to accept arbitrary node output in the same hashmap, we need to upcast them to any.
 pub(crate) type StateContent = Box<dyn Any + Send>;

--- a/crates/burn-autodiff/src/checkpoint/strategy.rs
+++ b/crates/burn-autodiff/src/checkpoint/strategy.rs
@@ -1,9 +1,8 @@
 use core::fmt::Debug;
-use std::sync::Arc;
 
 use burn_tensor::backend::Backend;
 
-use crate::{graph::ComputingProperty, tensor::AutodiffTensor};
+use crate::{graph::ComputingProperty, libs::Arc, tensor::AutodiffTensor};
 
 use super::{
     builder::{ActionType, CheckpointerBuilder},

--- a/crates/burn-autodiff/src/graph/base.rs
+++ b/crates/burn-autodiff/src/graph/base.rs
@@ -1,9 +1,12 @@
 use super::NodeID;
-use crate::{checkpoint::base::Checkpointer, grads::Gradients};
-use std::collections::HashMap;
+use crate::{
+    checkpoint::base::Checkpointer,
+    grads::Gradients,
+    libs::{Box, HashMap, Vec},
+};
 
 /// Backward step for reverse mode autodiff.
-pub trait Step: Send + std::fmt::Debug {
+pub trait Step: Send + core::fmt::Debug {
     /// Executes the step and consumes it.
     fn step(self: Box<Self>, grads: &mut Gradients, checkpointer: &mut Checkpointer);
     /// Depth of the operation relative to the first node added to a graph.

--- a/crates/burn-autodiff/src/graph/node.rs
+++ b/crates/burn-autodiff/src/graph/node.rs
@@ -1,7 +1,7 @@
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use core::sync::atomic::{AtomicU64, Ordering};
 
 use crate::checkpoint::retro_forward::RetroForward;
+use crate::libs::{Arc, Vec};
 use crate::runtime::AutodiffClientImpl;
 
 use super::Requirement;

--- a/crates/burn-autodiff/src/graph/traversal.rs
+++ b/crates/burn-autodiff/src/graph/traversal.rs
@@ -1,6 +1,6 @@
 use super::{Step, StepBoxed};
+use crate::libs::{HashMap, HashSet, Vec};
 use crate::NodeID;
-use std::collections::{HashMap, HashSet};
 
 /// Breadth for search algorithm.
 pub struct BreadthFirstSearch;

--- a/crates/burn-autodiff/src/lib.rs
+++ b/crates/burn-autodiff/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
@@ -34,3 +35,28 @@ pub use backend::*;
 
 #[cfg(feature = "export_tests")]
 mod tests;
+
+/// A facade around all the types we need from the `std`, `core`, and `alloc`
+/// crates. This avoids elaborate import wrangling having to happen in every
+/// module.
+mod libs {
+    cfg_block::cfg_block! {
+        if #[cfg(feature = "std")] {
+            pub use std::collections::{HashMap, HashSet};
+            pub use std::sync::Arc;
+            pub use std::{vec, vec::Vec};
+            pub use std::string::String;
+            pub use std::boxed::Box;
+            pub use std::format;
+            pub use std::borrow::ToOwned;
+        } else {
+            pub use hashbrown::{HashMap, HashSet};
+            pub use alloc::sync::Arc;
+            pub use alloc::{vec, vec::Vec};
+            pub use alloc::string::String;
+            pub use alloc::boxed::Box;
+            pub use alloc::format;
+            pub use alloc::borrow::ToOwned;
+        }
+    }
+}

--- a/crates/burn-autodiff/src/ops/activation.rs
+++ b/crates/burn-autodiff/src/ops/activation.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use crate::{
     checkpoint::{

--- a/crates/burn-autodiff/src/ops/backward.rs
+++ b/crates/burn-autodiff/src/ops/backward.rs
@@ -14,13 +14,13 @@ use burn_tensor::backend::Backend;
 /// Concrete types implementing this trait should not have any state.
 /// If a state is necessary during the backward pass,
 /// they should be declared with the associated type 'State'.
-pub trait Backward<B, const N: usize>: Send + std::fmt::Debug
+pub trait Backward<B, const N: usize>: Send + core::fmt::Debug
 where
     Self: Sized + 'static,
     B: Backend,
 {
     /// Associated type to compute the backward pass.
-    type State: Clone + Send + std::fmt::Debug + 'static;
+    type State: Clone + Send + core::fmt::Debug + 'static;
 
     /// The backward pass.
     fn backward(

--- a/crates/burn-autodiff/src/ops/base.rs
+++ b/crates/burn-autodiff/src/ops/base.rs
@@ -8,10 +8,11 @@ use crate::{
     },
     grads::Gradients,
     graph::{ComputingProperty, NodeID, NodeRef, Requirement, Step},
+    libs::{Box, Vec},
     tensor::AutodiffTensor,
 };
 use burn_tensor::{backend::Backend, ops::FloatTensor, Shape, TensorMetadata};
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Operation in preparation.
 ///
@@ -134,7 +135,7 @@ where
 impl<BO, B, S, C, const N: usize> OpsPrep<BO, B, S, C, N, ComputePropertyDone>
 where
     B: Backend,
-    S: Clone + Send + std::fmt::Debug + 'static,
+    S: Clone + Send + core::fmt::Debug + 'static,
     BO: Backward<B, N, State = S>,
 {
     /// Prepare an operation that requires a state during the backward pass.
@@ -161,7 +162,7 @@ where
 impl<BO, B, S, C, const N: usize> OpsPrep<BO, B, S, C, N, UnTracked>
 where
     B: Backend,
-    S: Clone + Send + std::fmt::Debug + 'static,
+    S: Clone + Send + core::fmt::Debug + 'static,
     BO: Backward<B, N, State = S>,
 {
     /// Finish the preparation of an untracked operation and returns the output tensor.
@@ -184,7 +185,7 @@ where
 impl<BO, B, S, C, const N: usize> OpsPrep<BO, B, S, C, N, Tracked>
 where
     B: Backend,
-    S: Clone + Send + std::fmt::Debug + 'static,
+    S: Clone + Send + core::fmt::Debug + 'static,
     BO: Backward<B, N, State = S>,
 {
     /// Finish the preparation of a tracked operation and returns the output tensor.
@@ -235,7 +236,7 @@ struct OpsStep<B, T, SB, const N: usize>
 where
     B: Backend,
     T: Backward<B, N, State = SB>,
-    SB: Clone + Send + std::fmt::Debug + 'static,
+    SB: Clone + Send + core::fmt::Debug + 'static,
 {
     ops: Ops<SB, N>,
     backward: T,
@@ -246,7 +247,7 @@ impl<B, T, SB, const N: usize> Step for OpsStep<B, T, SB, N>
 where
     B: Backend,
     T: Backward<B, N, State = SB>,
-    SB: Clone + Send + std::fmt::Debug + 'static,
+    SB: Clone + Send + core::fmt::Debug + 'static,
 {
     fn step(self: Box<Self>, grads: &mut Gradients, checkpointer: &mut Checkpointer) {
         self.backward.backward(self.ops, grads, checkpointer);

--- a/crates/burn-autodiff/src/ops/bool_tensor.rs
+++ b/crates/burn-autodiff/src/ops/bool_tensor.rs
@@ -1,4 +1,6 @@
-use crate::{checkpoint::strategy::CheckpointStrategy, tensor::AutodiffTensor, Autodiff};
+use crate::{
+    checkpoint::strategy::CheckpointStrategy, libs::Vec, tensor::AutodiffTensor, Autodiff,
+};
 
 use burn_tensor::{
     backend::Backend,
@@ -31,7 +33,7 @@ impl<B: Backend, C: CheckpointStrategy> BoolTensorOps<Self> for Autodiff<B, C> {
         B::bool_reshape(tensor, shape)
     }
 
-    fn bool_slice(tensor: BoolTensor<B>, ranges: &[std::ops::Range<usize>]) -> BoolTensor<B> {
+    fn bool_slice(tensor: BoolTensor<B>, ranges: &[core::ops::Range<usize>]) -> BoolTensor<B> {
         B::bool_slice(tensor, ranges)
     }
 
@@ -41,7 +43,7 @@ impl<B: Backend, C: CheckpointStrategy> BoolTensorOps<Self> for Autodiff<B, C> {
 
     fn bool_slice_assign(
         tensor: BoolTensor<Self>,
-        ranges: &[std::ops::Range<usize>],
+        ranges: &[core::ops::Range<usize>],
         value: BoolTensor<Self>,
     ) -> BoolTensor<Self> {
         B::bool_slice_assign(tensor, ranges, value)

--- a/crates/burn-autodiff/src/ops/int_tensor.rs
+++ b/crates/burn-autodiff/src/ops/int_tensor.rs
@@ -1,4 +1,6 @@
-use crate::{checkpoint::strategy::CheckpointStrategy, tensor::AutodiffTensor, Autodiff};
+use crate::{
+    checkpoint::strategy::CheckpointStrategy, libs::Vec, tensor::AutodiffTensor, Autodiff,
+};
 
 use burn_tensor::{
     backend::Backend,
@@ -27,7 +29,7 @@ impl<B: Backend, C: CheckpointStrategy> IntTensorOps<Self> for Autodiff<B, C> {
         B::int_reshape(tensor, shape)
     }
 
-    fn int_slice(tensor: IntTensor<B>, ranges: &[std::ops::Range<usize>]) -> IntTensor<B> {
+    fn int_slice(tensor: IntTensor<B>, ranges: &[core::ops::Range<usize>]) -> IntTensor<B> {
         B::int_slice(tensor, ranges)
     }
 
@@ -37,7 +39,7 @@ impl<B: Backend, C: CheckpointStrategy> IntTensorOps<Self> for Autodiff<B, C> {
 
     fn int_slice_assign(
         tensor: IntTensor<B>,
-        ranges: &[std::ops::Range<usize>],
+        ranges: &[core::ops::Range<usize>],
         value: IntTensor<B>,
     ) -> IntTensor<B> {
         B::int_slice_assign(tensor, ranges, value)
@@ -305,7 +307,7 @@ impl<B: Backend, C: CheckpointStrategy> IntTensorOps<Self> for Autodiff<B, C> {
         B::int_random(shape, distribution, device)
     }
 
-    fn int_arange(range: std::ops::Range<i64>, device: &Device<Self>) -> IntTensor<Self> {
+    fn int_arange(range: core::ops::Range<i64>, device: &Device<Self>) -> IntTensor<Self> {
         B::int_arange(range, device)
     }
 

--- a/crates/burn-autodiff/src/ops/qtensor.rs
+++ b/crates/burn-autodiff/src/ops/qtensor.rs
@@ -1,4 +1,4 @@
-use std::ops::Range;
+use core::ops::Range;
 
 use burn_tensor::{
     backend::Backend,

--- a/crates/burn-autodiff/src/ops/tensor.rs
+++ b/crates/burn-autodiff/src/ops/tensor.rs
@@ -1,5 +1,8 @@
-use alloc::{vec, vec::Vec};
-use std::marker::PhantomData;
+use core::marker::PhantomData;
+
+#[cfg(not(feature = "std"))]
+#[allow(unused_imports, reason = "required on aarch64, unused on x86_64")]
+use num_traits::float::Float;
 
 use crate::{
     checkpoint::{
@@ -8,6 +11,7 @@ use crate::{
     },
     grads::Gradients,
     graph::{ComputingProperty, NodeID, NodeRef, Requirement, Step},
+    libs::{vec, Box, Vec},
     ops::{binary, broadcast_shape, unary, Backward, Ops, OpsKind},
     retro_binary, retro_unary, retro_unary_scalar,
     tensor::AutodiffTensor,
@@ -1127,7 +1131,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
 
     fn float_slice(
         tensor: FloatTensor<Self>,
-        ranges: &[std::ops::Range<usize>],
+        ranges: &[core::ops::Range<usize>],
     ) -> FloatTensor<Self> {
         #[derive(Debug)]
         struct Index;
@@ -1135,7 +1139,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
         #[derive(new, Debug)]
         struct RetroSlice<B: Backend> {
             tensor_id: NodeID,
-            ranges: Vec<std::ops::Range<usize>>,
+            ranges: Vec<core::ops::Range<usize>>,
             _backend: PhantomData<B>,
         }
 
@@ -1148,7 +1152,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
         }
 
         impl<B: Backend> Backward<B, 1> for Index {
-            type State = (Vec<std::ops::Range<usize>>, Shape, B::Device);
+            type State = (Vec<core::ops::Range<usize>>, Shape, B::Device);
 
             fn backward(
                 self,
@@ -1186,7 +1190,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
 
     fn float_slice_assign(
         tensor: FloatTensor<Self>,
-        ranges: &[std::ops::Range<usize>],
+        ranges: &[core::ops::Range<usize>],
         value: FloatTensor<Self>,
     ) -> FloatTensor<Self> {
         #[derive(Debug)]
@@ -1195,7 +1199,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
         #[derive(new, Debug)]
         struct RetroSliceAssign<B: Backend> {
             tensor_id: NodeID,
-            ranges: Vec<std::ops::Range<usize>>,
+            ranges: Vec<core::ops::Range<usize>>,
             value_id: NodeID,
             _backend: PhantomData<B>,
         }
@@ -1210,7 +1214,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
         }
 
         impl<B: Backend> Backward<B, 2> for SliceAssign {
-            type State = (Vec<std::ops::Range<usize>>, Shape, B::Device);
+            type State = (Vec<core::ops::Range<usize>>, Shape, B::Device);
 
             fn backward(
                 self,
@@ -2066,7 +2070,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                     let ops = checkpointer.retrieve_node_output(ops.state);
                     let exponent = B::float_neg(B::float_powf_scalar(ops, 2.0));
                     let numerator = B::float_mul_scalar(B::float_exp(exponent), 2.0.elem());
-                    let denominator = std::f64::consts::PI.sqrt().elem();
+                    let denominator = core::f64::consts::PI.sqrt().elem();
                     let value = B::float_div_scalar(numerator, denominator);
 
                     B::float_mul(grad, value)

--- a/crates/burn-autodiff/src/ops/transaction.rs
+++ b/crates/burn-autodiff/src/ops/transaction.rs
@@ -8,7 +8,7 @@ use crate::{checkpoint::strategy::CheckpointStrategy, Autodiff};
 impl<B: Backend, C: CheckpointStrategy> TransactionOps<Self> for Autodiff<B, C> {
     fn tr_execute(
         transaction: TransactionPrimitive<Self>,
-    ) -> impl std::future::Future<Output = burn_tensor::ops::TransactionPrimitiveResult> + 'static + Send
+    ) -> impl core::future::Future<Output = burn_tensor::ops::TransactionPrimitiveResult> + 'static + Send
     {
         B::tr_execute(TransactionPrimitive {
             read_floats: transaction

--- a/crates/burn-autodiff/src/runtime/memory_management.rs
+++ b/crates/burn-autodiff/src/runtime/memory_management.rs
@@ -1,9 +1,9 @@
-use crate::{tensor::NodeRefCount, NodeID};
-use std::{
-    collections::{HashMap, HashSet},
-    mem,
-    sync::Arc,
+use crate::{
+    libs::{vec, Arc, HashMap, HashSet, ToOwned, Vec},
+    tensor::NodeRefCount,
+    NodeID,
 };
+use core::mem;
 
 #[derive(Default, Debug)]
 pub struct GraphMemoryManagement {
@@ -82,7 +82,10 @@ impl GraphMemoryManagement {
 
     fn clear_unused_roots(&mut self, to_delete: &mut Vec<NodeID>) {
         for (id, parents) in self.nodes.iter() {
-            let is_useful = matches!(self.statuses.get(id), Some(NodeMemoryStatus::Useful));
+            let is_useful = matches!(
+                self.statuses.get(id.as_ref()),
+                Some(NodeMemoryStatus::Useful)
+            );
 
             // Check if parents are either empty or absent from self.nodes
             let parents_absent = parents.iter().all(|p| !self.nodes.contains_key(p));

--- a/crates/burn-autodiff/src/runtime/mutex.rs
+++ b/crates/burn-autodiff/src/runtime/mutex.rs
@@ -11,7 +11,7 @@ use burn_tensor::backend::Backend;
 pub struct MutexClient;
 
 impl core::fmt::Debug for MutexClient {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_str("MutexClient")
     }
 }

--- a/crates/burn-autodiff/src/runtime/server.rs
+++ b/crates/burn-autodiff/src/runtime/server.rs
@@ -3,10 +3,10 @@ use crate::{
     checkpoint::{base::Checkpointer, builder::CheckpointerBuilder},
     grads::Gradients,
     graph::{traversal::BreadthFirstSearch, StepBoxed},
+    libs::{HashMap, Vec},
     tensor::NodeRefCount,
     NodeID,
 };
-use std::collections::HashMap;
 
 #[derive(Default)]
 pub struct AutodiffServer {

--- a/crates/burn-autodiff/src/tensor.rs
+++ b/crates/burn-autodiff/src/tensor.rs
@@ -1,9 +1,8 @@
-use std::sync::Arc;
-
 use crate::{
     checkpoint::{base::Checkpointer, builder::CheckpointerBuilder},
     grads::Gradients,
     graph::{ComputingProperty, Node, NodeID, NodeRef, Requirement, Step},
+    libs::{vec, Arc, Box, Vec},
     runtime::{AutodiffClient, AutodiffClientImpl},
 };
 use burn_tensor::{backend::Backend, TensorMetadata};

--- a/crates/burn-autodiff/src/utils.rs
+++ b/crates/burn-autodiff/src/utils.rs
@@ -1,4 +1,4 @@
-use crate::graph::NodeRef;
+use crate::{graph::NodeRef, libs::Vec};
 
 /// Duplicate the given object for each node that requires gradients.
 ///
@@ -8,7 +8,7 @@ use crate::graph::NodeRef;
 /// will be updated.
 ///
 /// If the object is a tensor and if one reference exists, it can be updated inplace.
-pub fn duplicate<T: Clone + std::fmt::Debug, const N: usize>(
+pub fn duplicate<T: Clone + core::fmt::Debug, const N: usize>(
     nodes: &[Option<NodeRef>; N],
     obj: Option<T>,
 ) -> [Option<T>; N] {

--- a/crates/burn-core/src/lib.rs
+++ b/crates/burn-core/src/lib.rs
@@ -19,7 +19,6 @@ pub mod config;
 pub mod data;
 
 /// Optimizer module.
-#[cfg(feature = "std")]
 pub mod optim;
 
 /// Learning rate scheduler module.

--- a/crates/burn-core/src/optim/adagrad.rs
+++ b/crates/burn-core/src/optim/adagrad.rs
@@ -150,7 +150,7 @@ impl<B: Backend, const D: usize> LrDecayState<B, D> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
     use crate::module::{Module, Param};

--- a/crates/burn-core/src/optim/adam.rs
+++ b/crates/burn-core/src/optim/adam.rs
@@ -188,7 +188,7 @@ impl<B: Backend, const D: usize> AdaptiveMomentumState<B, D> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
     use crate::module::{Module, Param};

--- a/crates/burn-core/src/optim/adam.rs
+++ b/crates/burn-core/src/optim/adam.rs
@@ -12,6 +12,9 @@ use crate::optim::adaptor::OptimizerAdaptor;
 use crate::tensor::{backend::AutodiffBackend, Tensor};
 use burn_tensor::{backend::Backend, ops::Device, ElementConversion};
 
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
+
 /// Adam configuration.
 #[derive(Config)]
 pub struct AdamConfig {

--- a/crates/burn-core/src/optim/adamw.rs
+++ b/crates/burn-core/src/optim/adamw.rs
@@ -8,6 +8,9 @@ use crate::{
 };
 use burn_tensor::{backend::Backend, ops::Device};
 
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
+
 /// AdamW configuration.
 #[derive(Config)]
 pub struct AdamWConfig {

--- a/crates/burn-core/src/optim/adamw.rs
+++ b/crates/burn-core/src/optim/adamw.rs
@@ -168,7 +168,7 @@ impl AdaptiveMomentumW {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
     use crate::module::{Module, Param};

--- a/crates/burn-core/src/optim/grad_accum.rs
+++ b/crates/burn-core/src/optim/grad_accum.rs
@@ -71,7 +71,7 @@ impl<B: AutodiffBackend, M: AutodiffModule<B>> ModuleVisitor<B> for ModuleGradsA
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
     use crate::{

--- a/crates/burn-core/src/optim/grads.rs
+++ b/crates/burn-core/src/optim/grads.rs
@@ -111,7 +111,7 @@ impl GradientsParams {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
     use crate::{

--- a/crates/burn-core/src/optim/rmsprop.rs
+++ b/crates/burn-core/src/optim/rmsprop.rs
@@ -313,7 +313,7 @@ impl<B: Backend, const D: usize> RmsPropMomentumState<B, D> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use burn_tensor::Shape;
 

--- a/crates/burn-core/src/optim/sgd.rs
+++ b/crates/burn-core/src/optim/sgd.rs
@@ -95,7 +95,7 @@ impl<B: Backend> SimpleOptimizer<B> for Sgd<B> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
     use crate::{

--- a/crates/burn-core/src/optim/simple/record/v1.rs
+++ b/crates/burn-core/src/optim/simple/record/v1.rs
@@ -6,6 +6,9 @@ use burn_tensor::backend::Backend;
 use core::any::Any;
 use serde::{Deserialize, Serialize};
 
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+
 /// [Optimizer adaptor](crate::optim::simple::adaptor::OptimizerAdaptor) record item.
 pub enum AdaptorRecordV1<O: SimpleOptimizer<B>, B: Backend> {
     /// Rank 0.

--- a/crates/burn-core/src/optim/visitor.rs
+++ b/crates/burn-core/src/optim/visitor.rs
@@ -3,6 +3,9 @@ use crate::module::{AutodiffModule, ModuleVisitor, ParamId};
 use burn_tensor::{backend::AutodiffBackend, Tensor};
 use core::marker::PhantomData;
 
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 #[derive(new)]
 pub struct GradientsParamsConverter<'a, M: AutodiffModule<B>, B: AutodiffBackend> {
     grads: &'a mut B::Gradients,

--- a/crates/burn/Cargo.toml
+++ b/crates/burn/Cargo.toml
@@ -115,7 +115,7 @@ burn-core = { path = "../burn-core", version = "0.17.0", default-features = fals
 burn-train = { path = "../burn-train", version = "0.17.0", optional = true, default-features = false }
 
 # Backends
-burn-autodiff = { path = "../burn-autodiff", version = "0.17.0", optional = true }
+burn-autodiff = { path = "../burn-autodiff", version = "0.17.0", optional = true, default-features = false }
 burn-candle = { path = "../burn-candle", version = "0.17.0", optional = true }
 burn-cuda = { path = "../burn-cuda", version = "0.17.0", optional = true, default-features = false }
 burn-hip = { path = "../burn-hip", version = "0.17.0", optional = true, default-features = false }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -12,6 +12,12 @@ const ARM_TARGET: &str = "thumbv7m-none-eabi";
 const ARM_NO_ATOMIC_PTR_TARGET: &str = "thumbv6m-none-eabi";
 const NO_STD_CRATES: &[&str] = &[
     "burn",
+    // cannot run no-std tests on burn-autodiff as no-std tests run with target
+    // `thumbv7m-none-eabi`(a 32-bit environment), and burn-autodiff need
+    // `core::sync::atomic::AtomicU64`, which doesn't live in a 32-bit
+    // environment.
+    // Mark it here for notification.
+    // "burn-autodiff",
     "burn-core",
     "burn-common",
     "burn-tensor",


### PR DESCRIPTION
## Support training in no-std

### Checklist

- [*] Confirmed that `run-checks all` script has been executed.
- [*] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

#2829


### Changes

#### 1. burn-core
Make `optim` module support no-std:
1. Manually import `alloc::vec::Vec` and `alloc::boxed::Box` when `no-std`
2. Use `num_traits::float::Float` to support `sqrt` function in `no-std`
3. Mark all of the tests in `optim` `std only` as they require TestAutodiffBackend.

#### 2. burn-autodiff
Fix `no-std` feature and provide a facade `crate::libs` for clean codes:
1. Changing some imports from `std` to `core` or `alloc`.
2. Replacing `std::collections::{HashMap, HashSet}` with `hashbrown::{HashMap, HashSet}` when `no-std`
4. Use `num_traits::float::Float` to support some math functions in `no-std`
5. Mark `burn-autodiff` NO_STD in `xtask`

#### 3. burn
Fix dependency of `burn-autodiff`: add `default-features = false` on dependency of `burn-autodiff`

### Testing

Successfully compile a TA(trusted application) and run with it.

![image](https://github.com/user-attachments/assets/b78733d0-8028-407b-8961-17d7a5b68220)

PS: I tried `run-checks.sh all` but it always failed by network reason(cannot reach huggingface.co).