### PR TITLE
Changes how vectorization is applied during fusion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1531,7 +1531,6 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=8b025f26e5badbf1b8f3e6787fc097427cd961ec#8b025f26e5badbf1b8f3e6787fc097427cd961ec"
 dependencies = [
  "cubecl-core",
  "cubecl-cuda",
@@ -1546,7 +1545,6 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=8b025f26e5badbf1b8f3e6787fc097427cd961ec#8b025f26e5badbf1b8f3e6787fc097427cd961ec"
 dependencies = [
  "bytemuck",
  "derive-new 0.6.0",
@@ -1567,7 +1565,6 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=8b025f26e5badbf1b8f3e6787fc097427cd961ec#8b025f26e5badbf1b8f3e6787fc097427cd961ec"
 dependencies = [
  "bitflags 2.8.0",
  "bytemuck",
@@ -1588,7 +1585,6 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=8b025f26e5badbf1b8f3e6787fc097427cd961ec#8b025f26e5badbf1b8f3e6787fc097427cd961ec"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1602,7 +1598,6 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=8b025f26e5badbf1b8f3e6787fc097427cd961ec#8b025f26e5badbf1b8f3e6787fc097427cd961ec"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1618,7 +1613,6 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=8b025f26e5badbf1b8f3e6787fc097427cd961ec#8b025f26e5badbf1b8f3e6787fc097427cd961ec"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1644,7 +1638,6 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=8b025f26e5badbf1b8f3e6787fc097427cd961ec#8b025f26e5badbf1b8f3e6787fc097427cd961ec"
 dependencies = [
  "cubecl-common",
  "cubecl-macros-internal",
@@ -1662,7 +1655,6 @@ dependencies = [
 [[package]]
 name = "cubecl-linalg"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=8b025f26e5badbf1b8f3e6787fc097427cd961ec#8b025f26e5badbf1b8f3e6787fc097427cd961ec"
 dependencies = [
  "bytemuck",
  "cubecl-core",
@@ -1675,7 +1667,6 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=8b025f26e5badbf1b8f3e6787fc097427cd961ec#8b025f26e5badbf1b8f3e6787fc097427cd961ec"
 dependencies = [
  "cubecl-common",
  "darling",
@@ -1690,7 +1681,6 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=8b025f26e5badbf1b8f3e6787fc097427cd961ec#8b025f26e5badbf1b8f3e6787fc097427cd961ec"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1701,7 +1691,6 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=8b025f26e5badbf1b8f3e6787fc097427cd961ec#8b025f26e5badbf1b8f3e6787fc097427cd961ec"
 dependencies = [
  "cubecl-common",
  "cubecl-ir",
@@ -1717,7 +1706,6 @@ dependencies = [
 [[package]]
 name = "cubecl-reduce"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=8b025f26e5badbf1b8f3e6787fc097427cd961ec#8b025f26e5badbf1b8f3e6787fc097427cd961ec"
 dependencies = [
  "cubecl-core",
  "cubecl-runtime",
@@ -1727,7 +1715,6 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=8b025f26e5badbf1b8f3e6787fc097427cd961ec#8b025f26e5badbf1b8f3e6787fc097427cd961ec"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -1749,7 +1736,6 @@ dependencies = [
 [[package]]
 name = "cubecl-spirv"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=8b025f26e5badbf1b8f3e6787fc097427cd961ec#8b025f26e5badbf1b8f3e6787fc097427cd961ec"
 dependencies = [
  "bitflags 2.8.0",
  "cubecl-common",
@@ -1764,7 +1750,6 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=8b025f26e5badbf1b8f3e6787fc097427cd961ec#8b025f26e5badbf1b8f3e6787fc097427cd961ec"
 dependencies = [
  "cubecl-core",
  "cubecl-runtime",
@@ -1773,7 +1758,6 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=8b025f26e5badbf1b8f3e6787fc097427cd961ec#8b025f26e5badbf1b8f3e6787fc097427cd961ec"
 dependencies = [
  "ash",
  "async-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1531,6 +1531,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.5.0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b41cbd82d53f091e76f56cad58c277fe2481c48e#b41cbd82d53f091e76f56cad58c277fe2481c48e"
 dependencies = [
  "cubecl-core",
  "cubecl-cuda",
@@ -1545,6 +1546,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.5.0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b41cbd82d53f091e76f56cad58c277fe2481c48e#b41cbd82d53f091e76f56cad58c277fe2481c48e"
 dependencies = [
  "bytemuck",
  "derive-new 0.6.0",
@@ -1565,6 +1567,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.5.0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b41cbd82d53f091e76f56cad58c277fe2481c48e#b41cbd82d53f091e76f56cad58c277fe2481c48e"
 dependencies = [
  "bitflags 2.8.0",
  "bytemuck",
@@ -1580,11 +1583,13 @@ dependencies = [
  "paste",
  "serde",
  "serde_json",
+ "variadics_please",
 ]
 
 [[package]]
 name = "cubecl-cpp"
 version = "0.5.0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b41cbd82d53f091e76f56cad58c277fe2481c48e#b41cbd82d53f091e76f56cad58c277fe2481c48e"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1598,6 +1603,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.5.0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b41cbd82d53f091e76f56cad58c277fe2481c48e#b41cbd82d53f091e76f56cad58c277fe2481c48e"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1613,6 +1619,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.5.0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b41cbd82d53f091e76f56cad58c277fe2481c48e#b41cbd82d53f091e76f56cad58c277fe2481c48e"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1638,6 +1645,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.5.0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b41cbd82d53f091e76f56cad58c277fe2481c48e#b41cbd82d53f091e76f56cad58c277fe2481c48e"
 dependencies = [
  "cubecl-common",
  "cubecl-macros-internal",
@@ -1655,6 +1663,7 @@ dependencies = [
 [[package]]
 name = "cubecl-linalg"
 version = "0.5.0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b41cbd82d53f091e76f56cad58c277fe2481c48e#b41cbd82d53f091e76f56cad58c277fe2481c48e"
 dependencies = [
  "bytemuck",
  "cubecl-core",
@@ -1667,6 +1676,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.5.0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b41cbd82d53f091e76f56cad58c277fe2481c48e#b41cbd82d53f091e76f56cad58c277fe2481c48e"
 dependencies = [
  "cubecl-common",
  "darling",
@@ -1681,6 +1691,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.5.0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b41cbd82d53f091e76f56cad58c277fe2481c48e#b41cbd82d53f091e76f56cad58c277fe2481c48e"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1691,6 +1702,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.5.0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b41cbd82d53f091e76f56cad58c277fe2481c48e#b41cbd82d53f091e76f56cad58c277fe2481c48e"
 dependencies = [
  "cubecl-common",
  "cubecl-ir",
@@ -1706,6 +1718,7 @@ dependencies = [
 [[package]]
 name = "cubecl-reduce"
 version = "0.5.0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b41cbd82d53f091e76f56cad58c277fe2481c48e#b41cbd82d53f091e76f56cad58c277fe2481c48e"
 dependencies = [
  "cubecl-core",
  "cubecl-runtime",
@@ -1715,6 +1728,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.5.0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b41cbd82d53f091e76f56cad58c277fe2481c48e#b41cbd82d53f091e76f56cad58c277fe2481c48e"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -1736,6 +1750,7 @@ dependencies = [
 [[package]]
 name = "cubecl-spirv"
 version = "0.5.0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b41cbd82d53f091e76f56cad58c277fe2481c48e#b41cbd82d53f091e76f56cad58c277fe2481c48e"
 dependencies = [
  "bitflags 2.8.0",
  "cubecl-common",
@@ -1750,6 +1765,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.5.0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b41cbd82d53f091e76f56cad58c277fe2481c48e#b41cbd82d53f091e76f56cad58c277fe2481c48e"
 dependencies = [
  "cubecl-core",
  "cubecl-runtime",
@@ -1758,6 +1774,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.5.0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=b41cbd82d53f091e76f56cad58c277fe2481c48e#b41cbd82d53f091e76f56cad58c277fe2481c48e"
 dependencies = [
  "ash",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,11 +155,11 @@ ahash = { version = "0.8.11", default-features = false }
 portable-atomic-util = { version = "0.2.4", features = ["alloc"] }
 
 ### For the main burn branch. ###
-# cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "8b025f26e5badbf1b8f3e6787fc097427cd961ec" }
-# cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "8b025f26e5badbf1b8f3e6787fc097427cd961ec" }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "b41cbd82d53f091e76f56cad58c277fe2481c48e" }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "b41cbd82d53f091e76f56cad58c277fe2481c48e" }
 ### For local development. ###
-cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
-cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }
+# cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
+# cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }
 ### For the release. ###
 # cubecl = { version = "0.4.0", default-features = false }
 # cubecl-common = { version = "0.4.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,11 +155,11 @@ ahash = { version = "0.8.11", default-features = false }
 portable-atomic-util = { version = "0.2.4", features = ["alloc"] }
 
 ### For the main burn branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "8b025f26e5badbf1b8f3e6787fc097427cd961ec" }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "8b025f26e5badbf1b8f3e6787fc097427cd961ec" }
+# cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "8b025f26e5badbf1b8f3e6787fc097427cd961ec" }
+# cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "8b025f26e5badbf1b8f3e6787fc097427cd961ec" }
 ### For local development. ###
-# cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
-# cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }
+cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
+cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }
 ### For the release. ###
 # cubecl = { version = "0.4.0", default-features = false }
 # cubecl-common = { version = "0.4.0", default-features = false }

--- a/crates/burn-autodiff/src/tests/nonzero.rs
+++ b/crates/burn-autodiff/src/tests/nonzero.rs
@@ -29,6 +29,7 @@ mod tests {
             .clone()
             .unsqueeze_dim::<2>(0)
             .matmul(tensor_3.unsqueeze_dim(1));
+        println!("{tensor_4}");
         let grads = tensor_4.backward();
 
         let grad_1 = tensor_1.grad(&grads).unwrap();

--- a/crates/burn-autodiff/src/tests/nonzero.rs
+++ b/crates/burn-autodiff/src/tests/nonzero.rs
@@ -29,7 +29,7 @@ mod tests {
             .clone()
             .unsqueeze_dim::<2>(0)
             .matmul(tensor_3.unsqueeze_dim(1));
-        println!("{tensor_4}");
+
         let grads = tensor_4.backward();
 
         let grad_1 = tensor_1.grad(&grads).unwrap();

--- a/crates/burn-cubecl-fusion/src/elemwise/builder.rs
+++ b/crates/burn-cubecl-fusion/src/elemwise/builder.rs
@@ -38,10 +38,12 @@ impl<R: Runtime> ElementWiseBuilder<R> {
 
 impl<R: Runtime> OptimizationBuilder<CubeOptimization<R>> for ElementWiseBuilder<R> {
     fn register(&mut self, operation: &burn_ir::OperationIr) {
+        println!("{operation:?}");
         self.builder.register(operation);
     }
 
     fn build(&self) -> CubeOptimization<R> {
+        println!("BUILDING OPE {}", self.len());
         let client = R::client(&self.device);
         let trace = self.builder.build();
         let elementwise =

--- a/crates/burn-cubecl-fusion/src/elemwise/builder.rs
+++ b/crates/burn-cubecl-fusion/src/elemwise/builder.rs
@@ -27,8 +27,7 @@ impl<R: Runtime> ElementWiseBuilder<R> {
                 FuseSettings {
                     broadcast: true,
                     output_shape_updates: true,
-                    mix_vectorization: true,
-                    inplace: false,
+                    inplace: true,
                 },
             ),
             device,
@@ -38,12 +37,10 @@ impl<R: Runtime> ElementWiseBuilder<R> {
 
 impl<R: Runtime> OptimizationBuilder<CubeOptimization<R>> for ElementWiseBuilder<R> {
     fn register(&mut self, operation: &burn_ir::OperationIr) {
-        println!("{operation:?}");
         self.builder.register(operation);
     }
 
     fn build(&self) -> CubeOptimization<R> {
-        println!("BUILDING OPE {}", self.len());
         let client = R::client(&self.device);
         let trace = self.builder.build();
         let elementwise =

--- a/crates/burn-cubecl-fusion/src/elemwise/builder.rs
+++ b/crates/burn-cubecl-fusion/src/elemwise/builder.rs
@@ -28,7 +28,7 @@ impl<R: Runtime> ElementWiseBuilder<R> {
                     broadcast: true,
                     output_shape_updates: true,
                     mix_vectorization: true,
-                    inplace: true,
+                    inplace: false,
                 },
             ),
             device,

--- a/crates/burn-cubecl-fusion/src/elemwise/optimization.rs
+++ b/crates/burn-cubecl-fusion/src/elemwise/optimization.rs
@@ -75,17 +75,14 @@ impl<R: Runtime> TraceRunner<R> for ElemwiseRunner {
             Arg::Output(index, _, _) => outputs.tensors.values.get(index as usize),
             _ => panic!("Invalid value"),
         };
-        let (shape, vectorization) = match arg {
+        let shape = match arg {
             Some(val) => match &val.tensor {
-                TensorArg::Handle {
-                    handle,
-                    vectorization_factor,
-                } => (handle.shape, vectorization_factor),
+                TensorArg::Handle { handle, .. } => handle.shape,
                 TensorArg::Alias { .. } => panic!("Can't be an alias, got {val:?}"),
             },
             None => panic!("Invalid argument"),
         };
-        let total_elem = shape.iter().product::<usize>() / *vectorization as usize;
+        let total_elem = shape.iter().product::<usize>() / config.width as usize;
         let cube_dim = CubeDim::default();
         let cube_count = calculate_cube_count_elemwise(total_elem, cube_dim);
 

--- a/crates/burn-cubecl-fusion/src/matmul/args.rs
+++ b/crates/burn-cubecl-fusion/src/matmul/args.rs
@@ -278,3 +278,5 @@ impl Init for FusedMatmulStateExpand {
         self
     }
 }
+
+impl CubeDebug for FusedMatmulStateExpand {}

--- a/crates/burn-cubecl-fusion/src/matmul/builder.rs
+++ b/crates/burn-cubecl-fusion/src/matmul/builder.rs
@@ -33,7 +33,6 @@ impl<R: Runtime> MatmulBuilder<R> {
         let settings = FuseSettings {
             broadcast: true,
             output_shape_updates: false,
-            mix_vectorization: true,
             inplace: true,
         };
 

--- a/crates/burn-cubecl-fusion/src/matmul/optimization.rs
+++ b/crates/burn-cubecl-fusion/src/matmul/optimization.rs
@@ -9,10 +9,15 @@ use burn_fusion::stream::Context;
 use burn_ir::{BinaryOpIr, TensorStatus};
 use cubecl::linalg::matmul::components;
 use cubecl::linalg::matmul::components::tile::accelerated::Accelerated;
+use cubecl::linalg::matmul::components::tile::TileMatmulFamily;
 use cubecl::linalg::matmul::components::MatmulProblem;
-use cubecl::linalg::matmul::kernels::matmul::{
-    DoubleBufferingSelector, MatmulSelector, SimpleSelector, SpecializedSelector,
-};
+use cubecl::linalg::matmul::kernels::matmul::double_buffering::DoubleBufferingAlgorithm;
+use cubecl::linalg::matmul::kernels::matmul::simple::SimpleAlgorithm;
+use cubecl::linalg::matmul::kernels::matmul::specialized::SpecializedAlgorithm;
+use cubecl::linalg::matmul::kernels::matmul::{select_kernel, Algorithm};
+// use cubecl::linalg::matmul::kernels::matmul::{
+//     DoubleBufferingSelector, MatmulSelector, SimpleSelector, SpecializedSelector,
+// };
 use cubecl::linalg::matmul::kernels::{MatmulAvailabilityError, MatmulLaunchError};
 use cubecl::linalg::tensor::{matrix_layout, MatrixLayout};
 use cubecl::{client::ComputeClient, prelude::*};
@@ -351,7 +356,7 @@ impl FusedMatmul {
 
         match self.selector {
             FusedMatmulSelector::Simple => {
-                match matmul_launch_kernel::<R, EG, SimpleSelector<Accelerated>>(
+                match matmul_launch_kernel::<R, EG, SimpleAlgorithm<Accelerated>>(
                     client,
                     FusedMatmulInputLaunch::new(inputs, config, &self.lhs, &self.rhs, &self.out),
                     outputs,
@@ -363,7 +368,7 @@ impl FusedMatmul {
                 }
             }
             FusedMatmulSelector::DoubleBuffering => {
-                match matmul_launch_kernel::<R, EG, DoubleBufferingSelector<Accelerated>>(
+                match matmul_launch_kernel::<R, EG, DoubleBufferingAlgorithm<Accelerated>>(
                     client,
                     FusedMatmulInputLaunch::new(inputs, config, &self.lhs, &self.rhs, &self.out),
                     outputs,
@@ -375,7 +380,7 @@ impl FusedMatmul {
                 }
             }
             FusedMatmulSelector::Specialized => {
-                match matmul_launch_kernel::<R, EG, SpecializedSelector<Accelerated>>(
+                match matmul_launch_kernel::<R, EG, SpecializedAlgorithm<Accelerated>>(
                     client,
                     FusedMatmulInputLaunch::new(inputs, config, &self.lhs, &self.rhs, &self.out),
                     outputs,
@@ -390,7 +395,7 @@ impl FusedMatmul {
     }
 }
 
-fn matmul_launch_kernel<'a, R: Runtime, EG: Numeric, S: MatmulSelector>(
+fn matmul_launch_kernel<'a, R: Runtime, EG: Numeric, A: Algorithm>(
     client: &ComputeClient<R::Server, R::Channel>,
     input: FusedMatmulInputLaunch<'a, R>,
     output: GlobalArgsLaunch<'a, R>,
@@ -400,19 +405,19 @@ fn matmul_launch_kernel<'a, R: Runtime, EG: Numeric, S: MatmulSelector>(
     if TypeId::of::<EG>() == TypeId::of::<half::f16>()
         || TypeId::of::<EG>() == TypeId::of::<flex32>()
     {
-        S::select_kernel::<FusedMatmulSpec<EG, half::f16, f32>, R>(
+        select_kernel::<FusedMatmulSpec<EG, half::f16, f32>, R, A>(
             client, input, output, problem, plane_size, false,
         )
     } else if TypeId::of::<EG>() == TypeId::of::<half::bf16>() {
-        S::select_kernel::<FusedMatmulSpec<EG, half::bf16, f32>, R>(
+        select_kernel::<FusedMatmulSpec<EG, half::bf16, f32>, R, A>(
             client, input, output, problem, plane_size, false,
         )
-    } else if S::stage_tf32_supported() {
-        S::select_kernel::<FusedMatmulSpec<EG, tf32, f32>, R>(
+    } else if <A::TileMatmul as TileMatmulFamily>::requires_tensor_cores() {
+        select_kernel::<FusedMatmulSpec<EG, tf32, f32>, R, A>(
             client, input, output, problem, plane_size, false,
         )
     } else {
-        S::select_kernel::<FusedMatmulSpec<EG, EG, f32>, R>(
+        select_kernel::<FusedMatmulSpec<EG, EG, f32>, R, A>(
             client, input, output, problem, plane_size, false,
         )
     }

--- a/crates/burn-cubecl-fusion/src/matmul/optimization.rs
+++ b/crates/burn-cubecl-fusion/src/matmul/optimization.rs
@@ -15,9 +15,6 @@ use cubecl::linalg::matmul::kernels::matmul::double_buffering::DoubleBufferingAl
 use cubecl::linalg::matmul::kernels::matmul::simple::SimpleAlgorithm;
 use cubecl::linalg::matmul::kernels::matmul::specialized::SpecializedAlgorithm;
 use cubecl::linalg::matmul::kernels::matmul::{select_kernel, Algorithm};
-// use cubecl::linalg::matmul::kernels::matmul::{
-//     DoubleBufferingSelector, MatmulSelector, SimpleSelector, SpecializedSelector,
-// };
 use cubecl::linalg::matmul::kernels::{MatmulAvailabilityError, MatmulLaunchError};
 use cubecl::linalg::tensor::{matrix_layout, MatrixLayout};
 use cubecl::{client::ComputeClient, prelude::*};

--- a/crates/burn-cubecl-fusion/src/on_write/builder.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/builder.rs
@@ -220,7 +220,6 @@ impl FuseOnWriteBuilder {
                 }
             }
             BaseOperationIr::Reshape(desc) => {
-                return false;
                 if desc.input.shape == desc.out.shape {
                     return self.register_unary_ops(desc, |input, out| {
                         ElemwiseOp::Assign(UnaryElemwiseArgs { input, out })

--- a/crates/burn-cubecl-fusion/src/on_write/builder.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/builder.rs
@@ -200,6 +200,7 @@ impl FuseOnWriteBuilder {
                 ElemwiseOp::Assign(UnaryElemwiseArgs { input, out })
             }),
             BaseOperationIr::SwapDims(desc) => {
+                return false;
                 if !self.output_is_compatible(&desc.out) {
                     return false;
                 }
@@ -220,6 +221,7 @@ impl FuseOnWriteBuilder {
                 }
             }
             BaseOperationIr::Reshape(desc) => {
+                return false;
                 if desc.input.shape == desc.out.shape {
                     return self.register_unary_ops(desc, |input, out| {
                         ElemwiseOp::Assign(UnaryElemwiseArgs { input, out })

--- a/crates/burn-cubecl-fusion/src/on_write/builder.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/builder.rs
@@ -200,7 +200,6 @@ impl FuseOnWriteBuilder {
                 ElemwiseOp::Assign(UnaryElemwiseArgs { input, out })
             }),
             BaseOperationIr::SwapDims(desc) => {
-                return false;
                 if !self.output_is_compatible(&desc.out) {
                     return false;
                 }

--- a/crates/burn-cubecl-fusion/src/on_write/io.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/io.rs
@@ -207,7 +207,7 @@ pub fn read_input_aligned<C: CubePrimitive>(
             for i in 0u32..comptime!(config.width as u32) {
                 let index = reshaped_index(
                     inputs,
-                    &tensor_layout,
+                    tensor_layout,
                     ref_pos + i,
                     config.rank,
                     comptime![shape.clone()],

--- a/crates/burn-cubecl-fusion/src/on_write/io.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/io.rs
@@ -399,6 +399,7 @@ fn reshaped_index(
     #[comptime] rank: u32,
     #[comptime] shape: Sequence<Arg>,
 ) -> u32 {
+    let index = index * layout.line_size();
     let mut offset = 0u32;
     let mut stride_curr = 1u32;
 

--- a/crates/burn-cubecl-fusion/src/on_write/io.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/io.rs
@@ -200,16 +200,15 @@ pub fn read_input_aligned<C: CubePrimitive>(
                 _ => comptime![panic!("Invalid ref layout.")],
             };
 
-            let pos_ref_aa = ref_pos * comptime![config.width as u32];
-
             // Very brut force, not really efficient, but not easy to optimize and not a very
             // frequent workflow.
+            let ref_pos = ref_pos * comptime![config.width as u32];
             #[unroll]
             for i in 0u32..comptime!(config.width as u32) {
                 let index = reshaped_index(
                     inputs,
                     &tensor_layout,
-                    pos_ref_aa + i,
+                    ref_pos + i,
                     config.rank,
                     comptime![shape.clone()],
                 );

--- a/crates/burn-cubecl-fusion/src/on_write/io.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/io.rs
@@ -200,7 +200,7 @@ pub fn read_input_aligned<C: CubePrimitive>(
                 _ => comptime![panic!("Invalid ref layout.")],
             };
 
-            // Very brut force, not really efficient, but not easy to optimize and not a very
+            // Very brute force, not really efficient, but not easy to optimize and not a very
             // frequent workflow.
             let ref_pos = ref_pos * comptime![config.width as u32];
             #[unroll]

--- a/crates/burn-cubecl-fusion/src/on_write/ir.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/ir.rs
@@ -22,10 +22,12 @@ pub enum Arg {
     InputReshaped {
         original: Box<Arg>,
         shape: Sequence<Arg>,
+        broadcasted: bool,
     },
     InputSwapDims {
         original: Box<Arg>,
         dims: (u32, u32),
+        broadcasted: bool,
     },
 }
 

--- a/crates/burn-cubecl-fusion/src/on_write/ir.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/ir.rs
@@ -73,6 +73,8 @@ impl IntoRuntime for Arg {
     }
 }
 
+impl CubeDebug for Arg {}
+
 #[derive(CubeType, Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 /// Operations that can be executed and fused.
 pub enum ElemwiseOp {

--- a/crates/burn-cubecl-fusion/src/on_write/ir.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/ir.rs
@@ -375,6 +375,7 @@ pub struct ElemwiseConfig {
     pub rank: u32,
     pub ref_layout: Arg,
     pub ops: Sequence<ElemwiseOp>,
+    pub width: u8,
 }
 
 impl Arg {

--- a/crates/burn-cubecl-fusion/src/on_write/settings.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/settings.rs
@@ -10,11 +10,6 @@ pub struct FuseSettings {
     /// When broadcast is enabled, the output shape can become bigger after a fusion,
     /// therefore an update is needed.
     pub output_shape_updates: bool,
-    /// Enables mix vectorization factor.
-    ///
-    /// Useful when the last dimension is broadcasted for one of the tensors, which would limit the
-    /// vectorization factor to be 1 without this setting enabled.
-    pub mix_vectorization: bool,
     /// Enables the reuse of input buffers.
     pub inplace: bool,
 }

--- a/crates/burn-cubecl-fusion/src/on_write/tensor.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/tensor.rs
@@ -14,18 +14,22 @@ pub struct GlobalTensor {
     pub tensor: Tensor<Line<NumericExpand<DYN_ELEM_ID>>>,
     #[cube(comptime)]
     pub elem: Elem,
+    #[cube(comptime)]
+    pub broadcasted: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Hash, Debug)]
 pub struct GlobalTensorCompilationArg {
     tensor: TensorCompilationArg,
     elem: Elem,
+    broadcasted: bool,
 }
 
 #[derive(new, Debug)]
 pub struct GlobalTensorArg<'a, R: Runtime> {
     pub tensor: <Tensor<Line<NumericExpand<DYN_ELEM_ID>>> as LaunchArg>::RuntimeArg<'a, R>,
     pub elem: Elem,
+    pub broadcasted: bool,
 }
 
 #[derive(CubeType)]
@@ -249,6 +253,7 @@ impl LaunchArg for GlobalTensor {
         GlobalTensorCompilationArg {
             tensor,
             elem: runtime_arg.elem,
+            broadcasted: runtime_arg.broadcasted,
         }
     }
 }
@@ -270,6 +275,7 @@ impl LaunchArgExpand for GlobalTensor {
         GlobalTensorExpand {
             tensor: tensor.into(),
             elem: arg.elem,
+            broadcasted: arg.broadcasted,
         }
     }
     fn expand_output(
@@ -283,6 +289,7 @@ impl LaunchArgExpand for GlobalTensor {
         GlobalTensorExpand {
             tensor: tensor.into(),
             elem: arg.elem,
+            broadcasted: arg.broadcasted,
         }
     }
 }

--- a/crates/burn-cubecl-fusion/src/on_write/trace/base.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/trace/base.rs
@@ -107,68 +107,45 @@ impl FuseOnWriteTrace {
 
 #[derive(Default, Clone, Serialize, Deserialize, Debug)]
 pub struct RegisteredTensors {
-    tensors: BTreeMap<ElemwisePrecision, Vec<(u32, TensorIr)>>,
-    count: u32,
+    tensors: Vec<(TensorIr, ElemwisePrecision)>,
 }
 
 impl RegisteredTensors {
-    pub fn iter(&self) -> impl Iterator<Item = (ElemwisePrecision, &(u32, TensorIr))> {
-        self.tensors.iter().flat_map(|(precision, descriptions)| {
-            descriptions.iter().map(|desc| (*precision, desc))
-        })
+    pub fn iter(&self) -> impl Iterator<Item = &(TensorIr, ElemwisePrecision)> {
+        self.tensors.iter()
     }
 
     pub fn len(&self) -> usize {
-        self.tensors.values().map(|v| v.len()).sum()
+        self.tensors.len()
     }
 
-    pub fn get_index(&self, precision: ElemwisePrecision, tensor_id: TensorId) -> Option<u32> {
-        self.tensors.get(&precision).and_then(|items| {
-            items
-                .iter()
-                .find(|(_id, tensor)| tensor.id == tensor_id)
-                .map(|(id, _)| *id)
-        })
-    }
-
-    pub fn get_all(&self, precision: ElemwisePrecision) -> &[(u32, TensorIr)] {
+    pub fn get_index(&self, tensor_id: TensorId) -> Option<u32> {
         self.tensors
-            .get(&precision)
-            .map(|v| v.as_slice())
-            .unwrap_or(&[])
+            .iter()
+            .enumerate()
+            .find(|(_pos, (tensor, _))| tensor.id == tensor_id)
+            .map(|(pos, (_, _))| pos as u32)
     }
 
-    pub fn get(
-        &self,
-        precision: ElemwisePrecision,
-        tensor_id: TensorId,
-    ) -> Option<&(u32, TensorIr)> {
-        self.get_all(precision)
+    pub fn get(&self, tensor_id: TensorId) -> Option<&(TensorIr, ElemwisePrecision)> {
+        self.tensors
             .iter()
-            .find(|(_, desc)| desc.id == tensor_id)
+            .find(|(tensor, _)| tensor.id == tensor_id)
     }
 
     pub fn insert(&mut self, precision: ElemwisePrecision, tensor: TensorIr) -> u32 {
-        let pos = self.count;
-        self.count += 1;
-
-        if let Some(tensors) = self.tensors.get_mut(&precision) {
-            tensors.push((pos, tensor));
-        } else {
-            self.tensors.insert(precision, vec![(pos, tensor)]);
-        };
-
-        pos
+        let pos = self.len();
+        self.tensors.push((tensor, precision));
+        pos as u32
     }
 
-    pub fn update(&mut self, precision: ElemwisePrecision, tensor: &TensorIr) {
-        if let Some(tensors) = self.tensors.get_mut(&precision) {
-            if let Some((_, tensor_old)) = tensors
-                .iter_mut()
-                .find(|(_, tensor_old)| tensor_old.id == tensor.id)
-            {
-                tensor_old.status = tensor.status.clone();
-            }
+    pub fn update(&mut self, tensor: &TensorIr) {
+        if let Some((tensor_old, _)) = self
+            .tensors
+            .iter_mut()
+            .find(|(tensor_old, _)| tensor_old.id == tensor.id)
+        {
+            tensor_old.status = tensor.status.clone();
         }
     }
 }

--- a/crates/burn-cubecl-fusion/src/on_write/trace/base.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/trace/base.rs
@@ -69,7 +69,7 @@ impl FuseOnWriteTrace {
         OutputPlanner::<R>::new(&self.inputs, &self.outputs, &self.views)
             .run::<BT>(client, device, context, &mut plan);
 
-        VectorizationPlanner::<R>::new(&self.views, &self.reads, &self.settings, &self.indexed)
+        VectorizationPlanner::<R>::new(&self.views, &self.reads, &self.indexed)
             .run::<Runner>(context, &mut plan);
 
         match LaunchPlanExecutor::<R>::new(&self.scalars, &self.views, &self.ops)

--- a/crates/burn-cubecl-fusion/src/on_write/trace/base.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/trace/base.rs
@@ -134,8 +134,18 @@ impl RegisteredTensors {
     }
 
     pub fn insert(&mut self, precision: ElemwisePrecision, tensor: TensorIr) -> u32 {
+        let value = (tensor, precision);
+        if let Some(old) = self
+            .tensors
+            .iter()
+            .enumerate()
+            .find(|(_, val)| *val == &value)
+        {
+            return old.0 as u32;
+        }
+
         let pos = self.len();
-        self.tensors.push((tensor, precision));
+        self.tensors.push(value);
         pos as u32
     }
 

--- a/crates/burn-cubecl-fusion/src/on_write/trace/builder.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/trace/builder.rs
@@ -230,6 +230,7 @@ impl FuseOnWriteTraceBuilder {
         let input = Arg::InputSwapDims {
             original: Box::new(original),
             dims,
+            broadcasted: output.shape[output.shape.len() - 1] == 0,
         };
 
         let reads = if let Entry::Vacant(e) = self.reads.entry(tensor.id) {
@@ -297,6 +298,7 @@ impl FuseOnWriteTraceBuilder {
         let input = Arg::InputReshaped {
             original: Box::new(original),
             shape,
+            broadcasted: output.shape[rank - 1] == 0,
         };
 
         let reads = if let Entry::Vacant(e) = self.reads.entry(tensor.id) {
@@ -331,7 +333,6 @@ impl FuseOnWriteTraceBuilder {
 
     /// Build into a trace.
     pub fn build(&self, shape_ref: Vec<usize>) -> FuseOnWriteTrace {
-        println!("Build with {:?}", self.ops);
         let inputs = self.inputs.clone();
         let outputs = self.output_tensors();
         let ops = self.ops.clone();

--- a/crates/burn-cubecl-fusion/src/on_write/trace/builder.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/trace/builder.rs
@@ -86,7 +86,7 @@ impl FuseOnWriteTraceBuilder {
             _ => precision,
         };
         let new_input = self.inputs.insert(precision_input, tensor.clone());
-        let arg = Arg::Input(new_input as u32, precision_input, LayoutInfo::Unknown);
+        let arg = Arg::Input(new_input, precision_input, LayoutInfo::Unknown);
 
         self.inputs_unhandled.push(tensor.id);
         arg

--- a/crates/burn-cubecl-fusion/src/on_write/trace/builder.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/trace/builder.rs
@@ -86,7 +86,7 @@ impl FuseOnWriteTraceBuilder {
             _ => precision,
         };
         let new_input = self.inputs.insert(precision_input, tensor.clone());
-        let arg = Arg::Input(new_input, precision_input, LayoutInfo::Unknown);
+        let arg = Arg::Input(new_input as u32, precision_input, LayoutInfo::Unknown);
 
         self.inputs_unhandled.push(tensor.id);
         arg
@@ -108,10 +108,10 @@ impl FuseOnWriteTraceBuilder {
 
         let arg = match self.locals.get(precision, tensor.id) {
             Some(local) => {
-                self.inputs.update(precision_input, tensor);
+                self.inputs.update(tensor);
                 // An input can be an output of a previously fused operation.
                 // We need to flag the new status for the tensor.
-                self.outputs.update(precision_input, tensor);
+                self.outputs.update(tensor);
 
                 local
             }
@@ -173,9 +173,7 @@ impl FuseOnWriteTraceBuilder {
             return Some(val.clone());
         };
 
-        let precision = tensor.dtype.into();
-
-        if self.inputs.get(precision, tensor.id).is_some() {
+        if self.inputs.get(tensor.id).is_some() {
             return None;
         }
 
@@ -203,13 +201,13 @@ impl FuseOnWriteTraceBuilder {
         let input_index = match self.locals.get(precision, tensor.id) {
             Some(_) => {
                 // Can't fused an already fused input.
-                if self.outputs.get(precision_input, tensor.id).is_some() {
+                if self.outputs.get(tensor.id).is_some() {
                     return None;
                 }
 
-                match self.inputs.get_index(precision_input, tensor.id) {
+                match self.inputs.get_index(tensor.id) {
                     Some(index) => {
-                        self.inputs.update(precision_input, tensor);
+                        self.inputs.update(tensor);
                         index
                     }
                     None => {
@@ -262,13 +260,13 @@ impl FuseOnWriteTraceBuilder {
         let input_index = match self.locals.get(precision, tensor.id) {
             Some(_) => {
                 // Can't fused an already fused input.
-                if self.outputs.get(precision_input, tensor.id).is_some() {
+                if self.outputs.get(tensor.id).is_some() {
                     return None;
                 }
 
-                match self.inputs.get_index(precision_input, tensor.id) {
+                match self.inputs.get_index(tensor.id) {
                     Some(index) => {
-                        self.inputs.update(precision_input, tensor);
+                        self.inputs.update(tensor);
                         index
                     }
                     None => {
@@ -341,15 +339,15 @@ impl FuseOnWriteTraceBuilder {
 
         let mut writes = BTreeMap::new();
 
-        for (precision, (_, tensor)) in outputs.iter() {
+        for (tensor, precision) in outputs.iter() {
             let local = self.locals.get_any_precision(tensor.id).unwrap();
-            let out_index = outputs.get_index(precision, tensor.id).unwrap();
+            let out_index = outputs.get_index(tensor.id).unwrap();
 
             writes.insert(
                 tensor.id,
                 ElemwiseOp::Assign(UnaryElemwiseArgs {
                     input: local,
-                    out: Arg::Output(out_index, precision, LayoutInfo::Unknown),
+                    out: Arg::Output(out_index, *precision, LayoutInfo::Unknown),
                 }),
             );
         }
@@ -572,16 +570,16 @@ impl FuseOnWriteTraceBuilder {
 
             if !is_read {
                 let (tensor_id, precision) = entry;
-                let (_, tensor) = self.outputs.get(precision, tensor_id).unwrap();
+                let (tensor, _) = self.outputs.get(tensor_id).unwrap();
                 result.insert(precision, tensor.clone());
             }
         }
 
         // All tensors where their latest representation is read only should be written to since they
         // are going to be used after the fused kernel by other operations.
-        for (precision, (_, tensor)) in self.outputs.iter() {
+        for (tensor, precision) in self.outputs.iter() {
             if let TensorStatus::ReadOnly = tensor.status {
-                result.insert(precision, tensor.clone());
+                result.insert(*precision, tensor.clone());
             }
         }
 

--- a/crates/burn-cubecl-fusion/src/on_write/trace/builder.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/trace/builder.rs
@@ -331,6 +331,7 @@ impl FuseOnWriteTraceBuilder {
 
     /// Build into a trace.
     pub fn build(&self, shape_ref: Vec<usize>) -> FuseOnWriteTrace {
+        println!("Build with {:?}", self.ops);
         let inputs = self.inputs.clone();
         let outputs = self.output_tensors();
         let ops = self.ops.clone();

--- a/crates/burn-cubecl-fusion/src/on_write/trace/executor.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/trace/executor.rs
@@ -54,8 +54,6 @@ impl<'a, R: Runtime> LaunchPlanExecutor<'a, R> {
         context: &mut Context<'_, CubeFusionHandle<R>>,
         plan: LaunchPlan<'a, R>,
     ) -> Result<(), ExecutionError<R, Runner>> {
-        println!("{plan:?}");
-
         let reference = match plan.reference {
             Some(reference) => reference,
             None => {
@@ -107,9 +105,11 @@ impl<'a, R: Runtime> LaunchPlanExecutor<'a, R> {
 
         for hi in handle_inputs.iter() {
             let arg = hi.handle.as_tensor_arg(&hi.global_shape, hi.vectorization);
-            inputs
-                .tensors
-                .push(GlobalTensorArg::new(arg, hi.precision.into_elem(), false));
+            inputs.tensors.push(GlobalTensorArg::new(
+                arg,
+                hi.precision.into_elem(),
+                hi.broadcated,
+            ));
         }
 
         let mut index_f32 = 0;

--- a/crates/burn-cubecl-fusion/src/on_write/trace/executor.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/trace/executor.rs
@@ -54,6 +54,8 @@ impl<'a, R: Runtime> LaunchPlanExecutor<'a, R> {
         context: &mut Context<'_, CubeFusionHandle<R>>,
         plan: LaunchPlan<'a, R>,
     ) -> Result<(), ExecutionError<R, Runner>> {
+        println!("{plan:?}");
+
         let reference = match plan.reference {
             Some(reference) => reference,
             None => {
@@ -89,6 +91,7 @@ impl<'a, R: Runtime> LaunchPlanExecutor<'a, R> {
             rank: plan.rank as u32,
             ref_layout: reference.layout,
             ops,
+            width: plan.width,
         };
 
         Runner::run(runner, client, inputs, outputs, &config)
@@ -106,7 +109,7 @@ impl<'a, R: Runtime> LaunchPlanExecutor<'a, R> {
             let arg = hi.handle.as_tensor_arg(&hi.global_shape, hi.vectorization);
             inputs
                 .tensors
-                .push(GlobalTensorArg::new(arg, hi.precision.into_elem()));
+                .push(GlobalTensorArg::new(arg, hi.precision.into_elem(), false));
         }
 
         let mut index_f32 = 0;
@@ -222,6 +225,7 @@ impl<'a, R: Runtime> LaunchPlanExecutor<'a, R> {
                     outputs.tensors.push(GlobalTensorArg::new(
                         TensorArg::alias(*input_pos),
                         precision.into_elem(),
+                        false,
                     ));
                 }
                 HandleOutput::Owned {
@@ -241,7 +245,7 @@ impl<'a, R: Runtime> LaunchPlanExecutor<'a, R> {
                         },
                         _ => precision.into_elem(),
                     };
-                    outputs.tensors.push(GlobalTensorArg::new(arg, elem));
+                    outputs.tensors.push(GlobalTensorArg::new(arg, elem, false));
                 }
             }
         }

--- a/crates/burn-cubecl-fusion/src/on_write/trace/executor.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/trace/executor.rs
@@ -54,6 +54,7 @@ impl<'a, R: Runtime> LaunchPlanExecutor<'a, R> {
         context: &mut Context<'_, CubeFusionHandle<R>>,
         plan: LaunchPlan<'a, R>,
     ) -> Result<(), ExecutionError<R, Runner>> {
+        println!("EXECUTE");
         let reference = match plan.reference {
             Some(reference) => reference,
             None => {

--- a/crates/burn-cubecl-fusion/src/on_write/trace/executor.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/trace/executor.rs
@@ -54,7 +54,6 @@ impl<'a, R: Runtime> LaunchPlanExecutor<'a, R> {
         context: &mut Context<'_, CubeFusionHandle<R>>,
         plan: LaunchPlan<'a, R>,
     ) -> Result<(), ExecutionError<R, Runner>> {
-        println!("EXECUTE");
         let reference = match plan.reference {
             Some(reference) => reference,
             None => {

--- a/crates/burn-cubecl-fusion/src/on_write/trace/input.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/trace/input.rs
@@ -81,6 +81,7 @@ impl<'a, R: Runtime> InputPlanner<'a, R> {
                 global_id: tensor_global.id,
                 global_shape: tensor_global.shape.clone(),
                 vectorization: 1,
+                broadcated: false,
             });
             plan.global_inputs.push(tensor_global);
         }

--- a/crates/burn-cubecl-fusion/src/on_write/trace/output.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/trace/output.rs
@@ -48,9 +48,10 @@ impl<'a, R: Runtime> OutputPlanner<'a, R> {
     ) -> Self {
         let mut outputs_sorted: Vec<_> = outputs
             .iter()
-            .map(|(precision, (pos, tensor))| OutputSorted {
-                pos_original: *pos as usize,
-                precision,
+            .enumerate()
+            .map(|(pos, (tensor, precision))| OutputSorted {
+                pos_original: pos,
+                precision: *precision,
                 tensor_relative: tensor,
             })
             .collect();
@@ -204,7 +205,7 @@ impl<'a, R: Runtime> OutputPlanner<'a, R> {
         if plan.reference.is_none() {
             let index_input = self
                 .inputs
-                .get_index(output.precision, potential_inplace.tensor_relative.id)
+                .get_index(potential_inplace.tensor_relative.id)
                 .unwrap();
 
             plan.reference = Some(Reference {

--- a/crates/burn-cubecl-fusion/src/on_write/trace/output.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/trace/output.rs
@@ -92,7 +92,6 @@ impl<'a, R: Runtime> OutputPlanner<'a, R> {
         core::mem::swap(&mut outputs, &mut self.outputs_sorted);
 
         for output in outputs.into_iter() {
-            println!("OUPTUTPUTPUT {:?}", output.tensor_relative);
             let tensor_global = context
                 .tensors
                 .get(&output.tensor_relative.id)

--- a/crates/burn-cubecl-fusion/src/on_write/trace/output.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/trace/output.rs
@@ -92,6 +92,7 @@ impl<'a, R: Runtime> OutputPlanner<'a, R> {
         core::mem::swap(&mut outputs, &mut self.outputs_sorted);
 
         for output in outputs.into_iter() {
+            println!("OUPTUTPUTPUT {:?}", output.tensor_relative);
             let tensor_global = context
                 .tensors
                 .get(&output.tensor_relative.id)
@@ -390,6 +391,7 @@ impl<'a, R: Runtime> OutputPlanner<'a, R> {
             _ => tensor_global.dtype,
         };
 
+        // TODO: Check if we can also remove the read, if we have a dead partial graph.
         plan.writes.remove(&output.tensor_relative.id);
 
         let strides = original_handle.handle.strides.clone();

--- a/crates/burn-cubecl-fusion/src/on_write/trace/plan.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/trace/plan.rs
@@ -41,6 +41,13 @@ impl Vect {
     pub fn is_broadcast(&self) -> bool {
         matches!(self, Vect::Broadcated)
     }
+
+    pub fn limit_to_one(&self) -> Self {
+        match self {
+            Vect::Broadcated => Vect::Broadcated,
+            Vect::Aligned(_) => Vect::Aligned(1),
+        }
+    }
 }
 
 impl<R: Runtime> LaunchPlan<'_, R> {
@@ -49,7 +56,6 @@ impl<R: Runtime> LaunchPlan<'_, R> {
         writes: &BTreeMap<TensorId, ElemwiseOp>,
         rank: usize,
     ) -> Self {
-        println!("Writes {writes:?}");
         LaunchPlan {
             potential_inplaces: Vec::new(),
             global_inputs: Vec::new(),

--- a/crates/burn-cubecl-fusion/src/on_write/trace/plan.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/trace/plan.rs
@@ -49,6 +49,7 @@ impl<R: Runtime> LaunchPlan<'_, R> {
         writes: &BTreeMap<TensorId, ElemwiseOp>,
         rank: usize,
     ) -> Self {
+        println!("Writes {writes:?}");
         LaunchPlan {
             potential_inplaces: Vec::new(),
             global_inputs: Vec::new(),

--- a/crates/burn-cubecl-fusion/src/on_write/trace/plan.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/trace/plan.rs
@@ -39,6 +39,7 @@ impl Vect {
     }
 
     pub fn is_broadcast(&self) -> bool {
+        matches!(self, Vect::Broadcated)
     }
 }
 
@@ -87,6 +88,7 @@ pub struct HandleInput<R: Runtime> {
     pub handle: CubeFusionHandle<R>,
     pub global_shape: Vec<usize>,
     pub vectorization: u8,
+    pub broadcated: bool,
 }
 
 #[derive(Debug)]

--- a/crates/burn-cubecl-fusion/src/on_write/trace/plan.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/trace/plan.rs
@@ -19,8 +19,27 @@ pub(crate) struct LaunchPlan<'a, R: Runtime> {
     pub reference: Option<Reference>,
     pub reads: BTreeMap<TensorId, Vec<ElemwiseOp>>,
     pub writes: BTreeMap<TensorId, ElemwiseOp>,
-    pub vectorization: BTreeMap<TensorId, u8>,
+    pub vectorization: BTreeMap<TensorId, Vect>,
+    pub width: u8,
     pub rank: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Vect {
+    Broadcated,
+    Aligned(u8),
+}
+
+impl Vect {
+    pub fn line_size(&self) -> u8 {
+        match self {
+            Vect::Broadcated => 1,
+            Vect::Aligned(val) => *val,
+        }
+    }
+
+    pub fn is_broadcast(&self) -> bool {
+    }
 }
 
 impl<R: Runtime> LaunchPlan<'_, R> {
@@ -39,6 +58,7 @@ impl<R: Runtime> LaunchPlan<'_, R> {
             vectorization: BTreeMap::default(),
             reads: reads.clone(),
             writes: writes.clone(),
+            width: 1,
             rank,
         }
     }

--- a/crates/burn-cubecl-fusion/src/on_write/trace/runner.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/trace/runner.rs
@@ -1,4 +1,7 @@
-use super::super::ir::{ElemwiseConfig, GlobalArgsLaunch};
+use super::{
+    super::ir::{ElemwiseConfig, GlobalArgsLaunch},
+    Vect,
+};
 use crate::CubeFusionHandle;
 use burn_ir::{TensorId, TensorIr};
 use cubecl::prelude::*;
@@ -22,13 +25,13 @@ pub trait TraceRunner<R: Runtime> {
 
     /// The vectorization factor for all inputs and outputs.
     fn vectorization<'a>(
-        vectorizations: &mut BTreeMap<TensorId, u8>,
+        vectorizations: &mut BTreeMap<TensorId, Vect>,
         handles_inputs: impl Iterator<Item = &'a CubeFusionHandle<R>>,
         inputs: impl Iterator<Item = &'a TensorIr>,
         outputs: impl Iterator<Item = &'a TensorIr>,
         reshaped: impl Iterator<Item = (&'a TensorIr, &'a TensorIr, bool)>,
         swapped: impl Iterator<Item = (&'a TensorIr, &'a TensorIr, bool, &'a (u32, u32))>,
-    ) {
+    ) -> u8 {
         vectorization_default(
             vectorizations,
             handles_inputs,
@@ -41,18 +44,13 @@ pub trait TraceRunner<R: Runtime> {
 }
 
 fn vectorization_default<'a, R: Runtime>(
-    vectorizations: &mut BTreeMap<TensorId, u8>,
+    vectorizations: &mut BTreeMap<TensorId, Vect>,
     handles_inputs: impl Iterator<Item = &'a CubeFusionHandle<R>>,
     inputs: impl Iterator<Item = &'a TensorIr>,
     outputs: impl Iterator<Item = &'a TensorIr>,
     reshaped: impl Iterator<Item = (&'a TensorIr, &'a TensorIr, bool)>,
     swapped: impl Iterator<Item = (&'a TensorIr, &'a TensorIr, bool, &'a (u32, u32))>,
-) {
-    enum Vect {
-        Broadcated,
-        Max(u8),
-    }
-
+) -> u8 {
     let swapped: Vec<_> = swapped.collect();
 
     // The default version uses the last dimension as vectorization axis and assumes a
@@ -62,7 +60,7 @@ fn vectorization_default<'a, R: Runtime>(
 
         // Last dimension strides should be 1, otherwise vecX won't be contiguous.
         if handle.strides[rank - 1] != 1 {
-            return Vect::Max(1);
+            return Vect::Aligned(1);
         }
         let shape_axis = desc.shape[rank - 1];
 
@@ -73,11 +71,11 @@ fn vectorization_default<'a, R: Runtime>(
         for s in R::line_size_elem(&desc.dtype.into()) {
             // The last dimension should be a multiple of the vector size or broadcated.
             if shape_axis % s as usize == 0 {
-                return Vect::Max(s);
+                return Vect::Aligned(s);
             }
         }
 
-        Vect::Max(1)
+        Vect::Aligned(1)
     };
 
     let vectorization_output = |desc: &TensorIr| {
@@ -86,11 +84,11 @@ fn vectorization_default<'a, R: Runtime>(
         for s in R::line_size_elem(&desc.dtype.into()) {
             // The last dimension should be a multiple of the vector size.
             if desc.shape[rank - 1] % s as usize == 0 {
-                return Vect::Max(s);
+                return Vect::Aligned(s);
             }
         }
 
-        Vect::Max(1)
+        Vect::Aligned(1)
     };
 
     let vectorization_reshape = |reshaped: &TensorIr, original: &TensorIr, multi_reads: bool| {
@@ -105,19 +103,19 @@ fn vectorization_default<'a, R: Runtime>(
             if !multi_reads {
                 // The last dimension should be a multiple of the vector size or broadcated.
                 if reshape_axis % s as usize == 0 {
-                    return Vect::Max(s);
+                    return Vect::Aligned(s);
                 }
             } else {
                 // Since the original tensor must share the same vectorization factor as the
                 // reshaped tensor, they must have compatible shapes when both are access
                 // independently.
                 if reshape_axis % s as usize == 0 && shape_axis % s as usize == 0 {
-                    return Vect::Max(s);
+                    return Vect::Aligned(s);
                 }
             }
         }
 
-        Vect::Max(1)
+        Vect::Aligned(1)
     };
 
     let vectorization_swapped = |handle: &CubeFusionHandle<R>,
@@ -140,13 +138,13 @@ fn vectorization_default<'a, R: Runtime>(
         // Last dimension strides should be 1, otherwise vecX won't be contiguous.
         if multi_reads {
             if handle.strides[last_dim_index] != 1 {
-                return Vect::Max(1);
+                return Vect::Aligned(1);
             }
             if handle.strides[dim_index] != 1 {
-                return Vect::Max(1);
+                return Vect::Aligned(1);
             }
         } else if handle.strides[dim_index] != 1 {
-            return Vect::Max(1);
+            return Vect::Aligned(1);
         }
 
         if !multi_reads && swapped_axis == 1 {
@@ -157,70 +155,55 @@ fn vectorization_default<'a, R: Runtime>(
             // The last dimension should be a multiple of the vector size or broadcated.
             if multi_reads {
                 if swapped_axis % s as usize == 0 {
-                    return Vect::Max(s);
+                    return Vect::Aligned(s);
                 }
             } else if swapped_axis % s as usize == 0 && shape_axis % s as usize == 0 {
-                return Vect::Max(s);
+                return Vect::Aligned(s);
             }
         }
 
-        Vect::Max(1)
+        Vect::Aligned(1)
     };
 
-    let mut max_current = u8::MAX;
+    let mut width = 0;
 
     for (handle, tensor) in handles_inputs.zip(inputs) {
         if let Some((s, o, mr, dims)) = swapped.iter().find(|(_s, o, _mr, _dims)| o.id == tensor.id)
         {
-            match vectorization_swapped(handle, s, o, *mr, dims) {
-                Vect::Broadcated => {
-                    vectorizations.insert(o.id, 1);
-                    vectorizations.insert(s.id, 1);
-                }
-                Vect::Max(val) => {
-                    vectorizations.insert(o.id, 0);
-                    vectorizations.insert(s.id, 0);
-                    max_current = Ord::min(val, max_current);
-                }
+            let val = vectorization_swapped(handle, s, o, *mr, dims);
+            vectorizations.insert(o.id, val);
+            vectorizations.insert(s.id, val);
+
+            if let Vect::Aligned(val) = val {
+                width = Ord::max(val, width);
             }
         } else {
-            match vectorization_input(handle, tensor) {
-                Vect::Broadcated => vectorizations.insert(tensor.id, 1),
-                Vect::Max(val) => {
-                    max_current = Ord::min(val, max_current);
-                    vectorizations.insert(tensor.id, 0)
-                }
-            };
+            let val = vectorization_input(handle, tensor);
+            vectorizations.insert(tensor.id, val);
+            if let Vect::Aligned(val) = val {
+                width = Ord::max(val, width);
+            }
         }
     }
 
     for tensor in outputs {
-        match vectorization_output(tensor) {
-            Vect::Broadcated => vectorizations.insert(tensor.id, 1),
-            Vect::Max(val) => {
-                max_current = Ord::min(val, max_current);
-                vectorizations.insert(tensor.id, 0)
-            }
-        };
+        let val = vectorization_output(tensor);
+        vectorizations.insert(tensor.id, val);
+
+        if let Vect::Aligned(val) = val {
+            width = Ord::max(val, width);
+        }
     }
 
     for (reshaped, original, multi_reads) in reshaped {
-        match vectorization_reshape(reshaped, original, multi_reads) {
-            Vect::Broadcated => {
-                vectorizations.insert(original.id, 1);
-                vectorizations.insert(reshaped.id, 1);
-            }
-            Vect::Max(val) => {
-                vectorizations.insert(original.id, 0);
-                vectorizations.insert(reshaped.id, 0);
-                max_current = Ord::min(val, max_current);
-            }
+        let val = vectorization_reshape(reshaped, original, multi_reads);
+        vectorizations.insert(original.id, val);
+        vectorizations.insert(reshaped.id, val);
+
+        if let Vect::Aligned(val) = val {
+            width = Ord::max(val, width);
         }
     }
 
-    for (_id, val) in vectorizations.iter_mut() {
-        if *val == 0 {
-            *val = max_current;
-        }
-    }
+    width
 }

--- a/crates/burn-cubecl-fusion/src/on_write/trace/vectorization.rs
+++ b/crates/burn-cubecl-fusion/src/on_write/trace/vectorization.rs
@@ -111,10 +111,12 @@ impl<'a, R: Runtime> VectorizationPlanner<'a, R> {
         }
 
         for handle in plan.handle_inputs.iter_mut() {
-            handle.vectorization = match plan.vectorization.get(&handle.global_id) {
-                Some(v) => v.line_size(),
+            let (vect, br) = match plan.vectorization.get(&handle.global_id) {
+                Some(v) => (v.line_size(), v.is_broadcast()),
                 None => panic!("No vectorization factor found for {:?}", handle.global_id),
             };
+            handle.vectorization = vect;
+            handle.broadcated = br;
         }
         for handle in plan.handle_outputs.iter_mut() {
             if let HandleOutput::Owned {

--- a/crates/burn-cubecl/src/fusion.rs
+++ b/crates/burn-cubecl/src/fusion.rs
@@ -163,11 +163,11 @@ impl<R: CubeRuntime, BT: BoolElement> FusionRuntime for FusionCubeRuntime<R, BT>
                 device.clone(),
                 BT::as_elem_native_unchecked().into(),
             )),
-            // Box::new(MatmulBuilder::<R>::new(
-            //     device.clone(),
-            //     BT::as_elem_native_unchecked().into(),
-            //     Arc::new(FallbackMatmul),
-            // )),
+            Box::new(MatmulBuilder::<R>::new(
+                device.clone(),
+                BT::as_elem_native_unchecked().into(),
+                Arc::new(FallbackMatmul),
+            )),
         ]
     }
 }

--- a/crates/burn-cubecl/src/fusion.rs
+++ b/crates/burn-cubecl/src/fusion.rs
@@ -163,11 +163,11 @@ impl<R: CubeRuntime, BT: BoolElement> FusionRuntime for FusionCubeRuntime<R, BT>
                 device.clone(),
                 BT::as_elem_native_unchecked().into(),
             )),
-            Box::new(MatmulBuilder::<R>::new(
-                device.clone(),
-                BT::as_elem_native_unchecked().into(),
-                Arc::new(FallbackMatmul),
-            )),
+            // Box::new(MatmulBuilder::<R>::new(
+            //     device.clone(),
+            //     BT::as_elem_native_unchecked().into(),
+            //     Arc::new(FallbackMatmul),
+            // )),
         ]
     }
 }

--- a/crates/burn-cubecl/src/kernel/matmul/base.rs
+++ b/crates/burn-cubecl/src/kernel/matmul/base.rs
@@ -1,8 +1,6 @@
-use burn_tensor::{Tensor, TensorPrimitive};
-use cubecl::linalg::matmul::kernels::MatmulLaunchError;
-
 use super::init_matmul_output;
-use crate::{tensor::CubeTensor, CubeBackend, CubeRuntime, FloatElement};
+use crate::{tensor::CubeTensor, CubeRuntime, FloatElement};
+use cubecl::linalg::matmul::kernels::MatmulLaunchError;
 
 #[cfg(feature = "autotune")]
 use super::matmul_autotune;

--- a/crates/burn-cubecl/src/kernel/matmul/base.rs
+++ b/crates/burn-cubecl/src/kernel/matmul/base.rs
@@ -34,20 +34,6 @@ pub fn matmul<R: CubeRuntime, E: FloatElement>(
     out: Option<CubeTensor<R>>,
     strategy: MatmulStrategy,
 ) -> Result<CubeTensor<R>, MatmulLaunchError> {
-    println!("== MATMUL ==");
-    println!(
-        "lhs {}",
-        Tensor::<CubeBackend<R, E, i32, u32>, 2>::from_primitive(TensorPrimitive::Float(
-            lhs.clone()
-        ))
-    );
-    println!(
-        "rhs {}",
-        Tensor::<CubeBackend<R, E, i32, u32>, 2>::from_primitive(TensorPrimitive::Float(
-            rhs.clone()
-        ))
-    );
-    println!("============");
     match strategy {
         MatmulStrategy::Cube => {
             let out = out.unwrap_or_else(|| init_matmul_output::<R, E>(&lhs, &rhs));

--- a/crates/burn-cubecl/src/kernel/matmul/base.rs
+++ b/crates/burn-cubecl/src/kernel/matmul/base.rs
@@ -1,7 +1,8 @@
+use burn_tensor::{Tensor, TensorPrimitive};
 use cubecl::linalg::matmul::kernels::MatmulLaunchError;
 
 use super::init_matmul_output;
-use crate::{tensor::CubeTensor, CubeRuntime, FloatElement};
+use crate::{tensor::CubeTensor, CubeBackend, CubeRuntime, FloatElement};
 
 #[cfg(feature = "autotune")]
 use super::matmul_autotune;
@@ -33,6 +34,20 @@ pub fn matmul<R: CubeRuntime, E: FloatElement>(
     out: Option<CubeTensor<R>>,
     strategy: MatmulStrategy,
 ) -> Result<CubeTensor<R>, MatmulLaunchError> {
+    println!("== MATMUL ==");
+    println!(
+        "lhs {}",
+        Tensor::<CubeBackend<R, E, i32, u32>, 2>::from_primitive(TensorPrimitive::Float(
+            lhs.clone()
+        ))
+    );
+    println!(
+        "rhs {}",
+        Tensor::<CubeBackend<R, E, i32, u32>, 2>::from_primitive(TensorPrimitive::Float(
+            rhs.clone()
+        ))
+    );
+    println!("============");
     match strategy {
         MatmulStrategy::Cube => {
             let out = out.unwrap_or_else(|| init_matmul_output::<R, E>(&lhs, &rhs));

--- a/crates/burn-tensor/src/tensor/quantization/scheme.rs
+++ b/crates/burn-tensor/src/tensor/quantization/scheme.rs
@@ -35,6 +35,10 @@ pub enum QuantizationScheme {
 impl CubeType for QuantizationScheme {
     type ExpandType = Self;
 }
+
+#[cfg(feature = "cubecl")]
+impl CubeDebug for QuantizationScheme {}
+
 #[cfg(feature = "cubecl")]
 impl cubecl::frontend::Init for QuantizationScheme {
     fn init(self, _scope: &mut cubecl::ir::Scope) -> Self {

--- a/crates/burn-tensor/src/tests/ops/mul.rs
+++ b/crates/burn-tensor/src/tests/ops/mul.rs
@@ -94,41 +94,4 @@ mod tests {
 
         output.into_data().assert_eq(&expected, false);
     }
-
-    #[test]
-    fn should_support_mul_fused() {
-        let device = Default::default();
-
-        // Sync prevent fusion.
-        let tensor1 = TestTensorInt::arange(0..32, &device);
-        let tensor1 = tensor1.reshape([2, 4, 4]);
-
-        let tensor2 = TestTensorInt::arange(0..16, &device);
-        let tensor2 = tensor2.reshape([1, 4, 4]);
-
-        let tensor3 = TestTensorInt::arange(0..8, &device);
-        let tensor3 = tensor3.reshape([4, 1, 2]);
-        TestBackend::sync(&device);
-        let tensor3 = tensor3.swap_dims(0, 2);
-
-        let out = tensor1 + tensor2 + tensor3;
-        TestBackend::sync(&device);
-
-        let expected = TensorData::from([
-            [
-                [0, 4, 8, 12],
-                [8, 12, 16, 20],
-                [16, 20, 24, 28],
-                [24, 28, 32, 36],
-            ],
-            [
-                [17, 21, 25, 29],
-                [25, 29, 33, 37],
-                [33, 37, 41, 45],
-                [41, 45, 49, 53],
-            ],
-        ]);
-        println!("{out}");
-        out.to_data().assert_eq(&expected, false);
-    }
 }

--- a/crates/burn-tensor/src/tests/ops/mul.rs
+++ b/crates/burn-tensor/src/tests/ops/mul.rs
@@ -1,7 +1,7 @@
 #[burn_tensor_testgen::testgen(mul)]
 mod tests {
     use super::*;
-    use burn_tensor::{Int, Tensor, TensorData};
+    use burn_tensor::{backend::Backend, Int, Tensor, TensorData};
 
     #[test]
     fn should_support_mul_ops() {
@@ -93,5 +93,42 @@ mod tests {
         let expected = TensorData::from([[0, 2, 4], [6, 8, 10]]);
 
         output.into_data().assert_eq(&expected, false);
+    }
+
+    #[test]
+    fn should_support_mul_fused() {
+        let device = Default::default();
+        let tensor1 = TestTensorInt::arange(0..32, &device);
+        let tensor2 = TestTensorInt::arange(0..16, &device);
+        let tensor3 = TestTensorInt::arange(0..8, &device);
+
+        // Sync prevent fusion.
+        let tensor1 = tensor1.reshape([2, 4, 4]);
+        TestBackend::sync(&device);
+        let tensor2 = tensor2.reshape([1, 4, 4]);
+        TestBackend::sync(&device);
+        let tensor3 = tensor3.reshape([4, 1, 2]);
+        TestBackend::sync(&device);
+        let tensor3 = tensor3.swap_dims(0, 2);
+        TestBackend::sync(&device);
+
+        let out = tensor1 + tensor2 + tensor3;
+
+        let expected = TensorData::from([
+            [
+                [0, 4, 8, 12],
+                [8, 12, 16, 20],
+                [16, 20, 24, 28],
+                [24, 28, 32, 36],
+            ],
+            [
+                [17, 21, 25, 29],
+                [25, 29, 33, 37],
+                [33, 37, 41, 45],
+                [41, 45, 49, 53],
+            ],
+        ]);
+        out.to_data().assert_eq(&expected, false);
+        panic!("{out}");
     }
 }

--- a/crates/burn-tensor/src/tests/ops/mul.rs
+++ b/crates/burn-tensor/src/tests/ops/mul.rs
@@ -111,6 +111,9 @@ mod tests {
         TestBackend::sync(&device);
         let tensor3 = tensor3.swap_dims(0, 2);
         TestBackend::sync(&device);
+        // println!("tensor1 {tensor1}");
+        // println!("tensor2 {tensor2}");
+        // println!("tensor3 {tensor3}");
 
         let out = tensor1 + tensor2 + tensor3;
 
@@ -128,7 +131,7 @@ mod tests {
                 [41, 45, 49, 53],
             ],
         ]);
+        println!("{out}");
         out.to_data().assert_eq(&expected, false);
-        panic!("{out}");
     }
 }

--- a/crates/burn-tensor/src/tests/ops/mul.rs
+++ b/crates/burn-tensor/src/tests/ops/mul.rs
@@ -98,24 +98,21 @@ mod tests {
     #[test]
     fn should_support_mul_fused() {
         let device = Default::default();
-        let tensor1 = TestTensorInt::arange(0..32, &device);
-        let tensor2 = TestTensorInt::arange(0..16, &device);
-        let tensor3 = TestTensorInt::arange(0..8, &device);
 
         // Sync prevent fusion.
+        let tensor1 = TestTensorInt::arange(0..32, &device);
         let tensor1 = tensor1.reshape([2, 4, 4]);
-        TestBackend::sync(&device);
+
+        let tensor2 = TestTensorInt::arange(0..16, &device);
         let tensor2 = tensor2.reshape([1, 4, 4]);
-        TestBackend::sync(&device);
+
+        let tensor3 = TestTensorInt::arange(0..8, &device);
         let tensor3 = tensor3.reshape([4, 1, 2]);
         TestBackend::sync(&device);
         let tensor3 = tensor3.swap_dims(0, 2);
-        TestBackend::sync(&device);
-        // println!("tensor1 {tensor1}");
-        // println!("tensor2 {tensor2}");
-        // println!("tensor3 {tensor3}");
 
         let out = tensor1 + tensor2 + tensor3;
+        TestBackend::sync(&device);
 
         let expected = TensorData::from([
             [

--- a/crates/burn-tensor/src/tests/ops/reshape.rs
+++ b/crates/burn-tensor/src/tests/ops/reshape.rs
@@ -110,6 +110,20 @@ mod tests {
     }
 
     #[test]
+    fn should_support_reshape_maybe_fused_5() {
+        let tensor = TestTensorInt::<3>::from_data([[[0], [1], [2], [3]]], &Default::default());
+        let tensor1 = tensor.clone().reshape([2, 1, 2]);
+        let tensor2 = TestTensorInt::<3>::full([2, 4, 2], 0, &Default::default());
+        let output = tensor2.clone() + tensor1 + tensor.clone();
+
+        let expected_tensor1 = TensorData::from([
+            [[0, 1], [1, 2], [2, 3], [3, 4]],
+            [[2, 3], [3, 4], [4, 5], [5, 6]],
+        ]);
+        output.into_data().assert_eq(&expected_tensor1, false);
+    }
+
+    #[test]
     fn should_support_reshape_int() {
         let data = TensorData::from([0, 1, 2]);
         let tensor = TestTensorInt::<1>::from_data(data, &Default::default());

--- a/crates/burn-tensor/src/tests/ops/reshape.rs
+++ b/crates/burn-tensor/src/tests/ops/reshape.rs
@@ -124,6 +124,39 @@ mod tests {
     }
 
     #[test]
+    fn should_support_reshape_maybe_fused_6() {
+        let device = Default::default();
+
+        let tensor1 = TestTensorInt::arange(0..32, &device);
+        let tensor1 = tensor1.reshape([2, 4, 4]);
+
+        let tensor2 = TestTensorInt::arange(0..16, &device);
+        let tensor2 = tensor2.reshape([1, 4, 4]);
+
+        let tensor3 = TestTensorInt::arange(0..8, &device);
+        let tensor3 = tensor3.reshape([4, 1, 2]);
+        let tensor3 = tensor3.swap_dims(0, 2);
+
+        let out = tensor1 + tensor2 + tensor3;
+
+        let expected = TensorData::from([
+            [
+                [0, 4, 8, 12],
+                [8, 12, 16, 20],
+                [16, 20, 24, 28],
+                [24, 28, 32, 36],
+            ],
+            [
+                [17, 21, 25, 29],
+                [25, 29, 33, 37],
+                [33, 37, 41, 45],
+                [41, 45, 49, 53],
+            ],
+        ]);
+        out.to_data().assert_eq(&expected, false);
+    }
+
+    #[test]
     fn should_support_reshape_int() {
         let data = TensorData::from([0, 1, 2]);
         let tensor = TestTensorInt::<1>::from_data(data, &Default::default());

--- a/crates/burn-tensor/src/tests/ops/transpose.rs
+++ b/crates/burn-tensor/src/tests/ops/transpose.rs
@@ -23,6 +23,28 @@ mod tests {
     }
 
     #[test]
+    fn should_support_transpose_maybe_fused_with_one() {
+        let tensor = TestTensor::<3>::from_floats(
+            [
+                [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]],
+                [[6.0, 7.0, 8.0], [9.0, 10.0, 11.0]],
+            ],
+            &Default::default(),
+        );
+        let ones = TestTensor::<3>::ones([1, 1, 1], &Default::default());
+
+        let output = tensor.transpose();
+        let expected = TensorData::from([
+            [[0.0, 3.0], [1.0, 4.0], [2.0, 5.0]],
+            [[6.0, 9.0], [7.0, 10.0], [8.0, 11.0]],
+        ]);
+        let expected_ones = TensorData::from([[[1.0]]]);
+
+        output.into_data().assert_approx_eq(&expected, 3);
+        ones.into_data().assert_approx_eq(&expected_ones, 3);
+    }
+
+    #[test]
     fn should_support_swap_dims() {
         let tensor = TestTensor::<3>::from_floats(
             [


### PR DESCRIPTION
Instead of limiting vectorization based on the most constraining factor, we read inputs multiple times when they can't match the highest vectorization factor. This way, we use the best vectorization factor for each tensor, no matter if others aren't able to.