### PR TITLE
Fix from_embedded and bool ops docs

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -319,10 +319,12 @@ Those operations are only available for `Bool` tensors.
 | `Tensor::tril_mask(shape, diagonal)` | N/A                             |
 | `Tensor::triu_mask(shape, diagonal)` | N/A                             |
 | `tensor.argwhere()`                  | `tensor.argwhere()`             |
+| `tensor.bool_and()`                  | `tensor.logical_and()`          |
+| `tensor.bool_not()`                  | `tensor.logical_not()`          |
+| `tensor.bool_or()`                   | `tensor.logical_or()`           |
 | `tensor.float()`                     | `tensor.to(torch.float)`        |
 | `tensor.int()`                       | `tensor.to(torch.long)`         |
 | `tensor.nonzero()`                   | `tensor.nonzero(as_tuple=True)` |
-| `tensor.not()`                       | `tensor.logical_not()`          |
 
 ### Quantization Operations
 

--- a/burn-book/src/import/onnx-model.md
+++ b/burn-book/src/import/onnx-model.md
@@ -164,7 +164,7 @@ let model = Model::<Backend>::new(&device);
 let model = Model::<Backend>::from_file("path/to/weights", &device);
 
 // Load from embedded weights (if embed_states was true)
-let model = Model::<Backend>::from_embedded();
+let model = Model::<Backend>::from_embedded(&device);
 
 // Load from the out director location and load to default device (useful for testing)
 let model = Model::<Backend>::default();


### PR DESCRIPTION
### Checklist

- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Fixes #2847
#2845

### Changes

- Added `bool_or` and `bool_and` to boolean ops
- Fixed `bool_not` (incorrectly documented in the book as `not`)
- Fixed `from_embbeded` usage for ONNX import (missing device)

