### PR TITLE
Feat/quant/per block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,6 +919,7 @@ version = "0.17.0"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]

--- a/burn-book/src/quantization.md
+++ b/burn-book/src/quantization.md
@@ -43,14 +43,16 @@ Quantizing the weights of your model after training is quite simple. We have acc
 tensors and can collect their statistics, such as the min and max value when using
 `MinMaxCalibration`, to compute the quantization parameters.
 
+TODO: update
+
 ```rust , ignore
 # use burn::module::Quantizer;
-# use burn::tensor::quantization::{MinMaxCalibration, QuantizationScheme, QuantizationType};
+# use burn::tensor::quantization::{Calibration, QuantizationScheme, QuantizationType};
 #
 // Quantization config
 let mut quantizer = Quantizer {
-    calibration: MinMaxCalibration {},
-    scheme: QuantizationScheme::PerTensorSymmetric(QuantizationType::QInt8),
+    calibration: Calibration::MinMax,
+    scheme: QuantizationScheme::PerTensor(QuantizationMode::Symmetric, QuantizationType::QInt8),
 };
 
 // Quantize the weights
@@ -95,9 +97,9 @@ _quantization-time_ (weights are static), but activations require more attention
 
 To compute the quantization parameters, Burn supports the following `Calibration` methods.
 
-| Method              | Description                                                                      |
-| :------------------ | :------------------------------------------------------------------------------- |
-| `MinMaxCalibration` | Computes the quantization range mapping based on the running min and max values. |
+| Method   | Description                                                                      |
+| :------- | :------------------------------------------------------------------------------- |
+| `MinMax` | Computes the quantization range mapping based on the running min and max values. |
 
 ### Quantization Scheme
 
@@ -116,7 +118,23 @@ channel with per-channel quantization (commonly used with CNNs).
 
 Burn currently supports the following `QuantizationScheme` variants.
 
-| Variant              | Description                                                                                                    |
-| :------------------- | :------------------------------------------------------------------------------------------------------------- |
-| `PerTensorAffine`    | Computes the quantization parameters for the whole tensor and applies an affine range mapping with zero point. |
-| `PerTensorSymmetric` | Computes the quantization parameters for the whole tensor and applies a scale range mapping centered around 0. |
+| Variant                        | Description                                                                                                                                                              |
+| :----------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PerTensor(mode, type)`        | Applies a single set of quantization parameters to the entire tensor. The `mode` defines how values are transformed, and `type` represents the target quantization type. |
+| `PerBlock(mode, type, layout)` | Applies quantization parameters to individual blocks within the tensor. The `layout` defines how the tensor is partitioned.                                              |
+
+#### Quantization Mode
+
+| Mode        | Description                                                          |
+| ----------- | -------------------------------------------------------------------- |
+| `Affine`    | Maps values using an affine transformation with a zero point offset. |
+| `Symmetric` | Maps values using a scale factor for a range centered around zero.   |
+
+---
+
+#### Block Layout
+
+| Layout             | Description                                              |
+| ------------------ | -------------------------------------------------------- |
+| `Flat(block_size)` | Divides the tensor into linear 1D blocks of fixed size.  |
+| `Grid(m, n)`       | Divides the tensor into 2D blocks of `m` x `n` elements. |

--- a/crates/burn-candle/src/backend.rs
+++ b/crates/burn-candle/src/backend.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use burn_tensor::{
     backend::{Backend, DeviceId, DeviceOps},
-    quantization::{QTensorPrimitive, QuantizationStrategy},
+    quantization::QTensorPrimitive,
     Device,
 };
 use candle_core::{backend::BackendDevice, DeviceLocation};

--- a/crates/burn-candle/src/ops/qtensor.rs
+++ b/crates/burn-candle/src/ops/qtensor.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 use burn_tensor::{
     backend::Backend,
     ops::{FloatTensor, IntTensor, QTensorOps, QuantizedTensor},
-    quantization::{QuantizationParametersPrimitive, QuantizationScheme, QuantizationStrategy},
+    quantization::{QuantizationParametersPrimitive, QuantizationScheme},
     DType, Device, Shape, TensorData,
 };
 

--- a/crates/burn-candle/src/tensor.rs
+++ b/crates/burn-candle/src/tensor.rs
@@ -1,5 +1,5 @@
 use burn_tensor::{
-    quantization::{QTensorPrimitive, QuantizationScheme, QuantizationStrategy},
+    quantization::{QTensorPrimitive, QuantizationScheme},
     DType, Element, Shape, TensorData, TensorMetadata,
 };
 

--- a/crates/burn-core/src/module/base.rs
+++ b/crates/burn-core/src/module/base.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use alloc::vec::Vec;
 pub use burn_derive::Module;
-use burn_tensor::{ops::Device, quantization::Calibration, Bool, Int, Tensor};
+use burn_tensor::{ops::Device, Bool, Int, Tensor};
 
 /// Type alias to `Vec<B::Device>` which supports `no_std` environments, but automatically using
 /// the `alloc` crate.
@@ -204,7 +204,7 @@ pub trait Module<B: Backend>: Clone + Send + core::fmt::Debug {
     }
 
     /// Quantize the weights of the module.
-    fn quantize_weights<C: Calibration>(self, quantizer: &mut Quantizer<C>) -> Self {
+    fn quantize_weights(self, quantizer: &mut Quantizer) -> Self {
         self.map(quantizer)
     }
 }

--- a/crates/burn-core/src/module/quantize.rs
+++ b/crates/burn-core/src/module/quantize.rs
@@ -7,16 +7,16 @@ use burn_tensor::{
 use crate::module::{ModuleMapper, ParamId};
 
 /// Describes how to quantize a module.
-pub struct Quantizer<C: Calibration> {
+pub struct Quantizer {
     /// The calibration method used in quantization.
-    pub calibration: C,
+    pub calibration: Calibration,
     /// The quantization scheme.
     pub scheme: QuantizationScheme,
 }
 
-impl<B: Backend, C: Calibration> ModuleMapper<B> for Quantizer<C> {
+impl<B: Backend> ModuleMapper<B> for Quantizer {
     fn map_float<const D: usize>(&mut self, _id: ParamId, tensor: Tensor<B, D>) -> Tensor<B, D> {
-        let range = self.calibration.compute_range(&tensor);
+        let range = self.scheme.compute_range(&tensor, &self.calibration);
         let qparams = self.scheme.compute_q_params(range);
         tensor.quantize(&self.scheme, qparams)
     }

--- a/crates/burn-cubecl/src/kernel/quantization/dequantize.rs
+++ b/crates/burn-cubecl/src/kernel/quantization/dequantize.rs
@@ -1,7 +1,7 @@
 use crate::tensor::CubeTensor;
 use crate::FloatElement;
 use crate::{CubeElement, CubeRuntime};
-use burn_tensor::quantization::{QuantizationScheme, QuantizationType};
+use burn_tensor::quantization::{QuantizationMode, QuantizationScheme, QuantizationType};
 use burn_tensor::DType;
 use cubecl::calculate_cube_count_elemwise;
 use cubecl::prelude::*;
@@ -134,7 +134,7 @@ where
 
     if let DType::QFloat(scheme) = tensor.dtype {
         match scheme {
-            QuantizationScheme::PerTensorAffine(QuantizationType::QInt8) => {
+            QuantizationScheme::PerTensor(QuantizationMode::Affine, QuantizationType::QInt8) => {
                 unsafe {
                     dequantize_per_tensor_affine_int8_kernel::launch_unchecked::<R>(
                         &client,
@@ -146,7 +146,7 @@ where
                     )
                 };
             }
-            QuantizationScheme::PerTensorSymmetric(QuantizationType::QInt8) => {
+            QuantizationScheme::PerTensor(QuantizationMode::Symmetric, QuantizationType::QInt8) => {
                 unsafe {
                     dequantize_per_tensor_symmetric_int8_kernel::launch_unchecked::<R>(
                         &client,
@@ -158,6 +158,7 @@ where
                     )
                 };
             }
+            QuantizationScheme::PerBlock(_mode, QuantizationType::QInt8, _block_layout) => todo!(),
         }
     }
 

--- a/crates/burn-cubecl/src/kernel/quantization/qtensor.rs
+++ b/crates/burn-cubecl/src/kernel/quantization/qtensor.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs)] // cube derive macros
 
-use burn_tensor::quantization::QuantizationScheme;
+use burn_tensor::quantization::{QuantizationMode, QuantizationScheme};
 use cubecl::prelude::*;
 
 /// Quantization parameters.
@@ -24,26 +24,29 @@ impl QParams {
     pub fn values(&self, tensor: &QTensor) -> (f32, i32) {
         let len = tensor.len();
         match comptime!(self.scheme) {
-            QuantizationScheme::PerTensorAffine(_) => match comptime!(tensor.line_size()) {
-                // For line size of 1, scale is the last value in the buffer
-                1 => (
-                    f32::bitcast_from(tensor[len - 1][tensor.line_size() - 1]),
-                    i32::cast_from(tensor[len - 2][tensor.line_size() - 1]),
-                ),
-                // For any other line size > 1, scale and zero-point offset are the last two elements
-                _ => {
-                    let values = tensor[len - 1];
-                    (
-                        f32::bitcast_from(values[tensor.line_size() - 1]),
-                        i32::cast_from(values[tensor.line_size() - 2]),
-                    )
+            QuantizationScheme::PerTensor(QuantizationMode::Affine, _) => {
+                match comptime!(tensor.line_size()) {
+                    // For line size of 1, scale is the last value in the buffer
+                    1 => (
+                        f32::bitcast_from(tensor[len - 1][tensor.line_size() - 1]),
+                        i32::cast_from(tensor[len - 2][tensor.line_size() - 1]),
+                    ),
+                    // For any other line size > 1, scale and zero-point offset are the last two elements
+                    _ => {
+                        let values = tensor[len - 1];
+                        (
+                            f32::bitcast_from(values[tensor.line_size() - 1]),
+                            i32::cast_from(values[tensor.line_size() - 2]),
+                        )
+                    }
                 }
-            },
+            }
             // Symmetric quantization only contains the scaling factor as the last element
-            QuantizationScheme::PerTensorSymmetric(_) => (
+            QuantizationScheme::PerTensor(QuantizationMode::Symmetric, _) => (
                 f32::bitcast_from(tensor[len - 1][tensor.line_size() - 1]),
                 0,
             ),
+            QuantizationScheme::PerBlock(_mode, _dtype, _block_layout) => todo!(),
         }
     }
 }

--- a/crates/burn-cubecl/src/kernel/quantization/qtensor.rs
+++ b/crates/burn-cubecl/src/kernel/quantization/qtensor.rs
@@ -21,6 +21,7 @@ impl QParams {
     }
 
     /// Get the quantization parameters values.
+    // TODO: this needs to take the position of the value we want to dequantize so we can access the associated parameters
     pub fn values(&self, tensor: &QTensor) -> (f32, i32) {
         let len = tensor.len();
         match comptime!(self.scheme) {
@@ -46,7 +47,15 @@ impl QParams {
                 f32::bitcast_from(tensor[len - 1][tensor.line_size() - 1]),
                 0,
             ),
-            QuantizationScheme::PerBlock(_mode, _dtype, _block_layout) => todo!(),
+            QuantizationScheme::PerBlock(_mode, _dtype, _block_layout) => {
+                // TODO
+                // For affine quantization, there are 2 parameters per block
+                // let values = tensor[len - 2 * num_blocks / tensor.line_size()];
+                // The (scale, offset) parameters are stored contiguously by parameter type
+                // [scale, scale, scale, ..., offset, offset, offset, ...]
+                // (but we might want to store them with each block in the future?)
+                (0f32, 0)
+            }
         }
     }
 }

--- a/crates/burn-cubecl/src/kernel/quantization/qtensor.rs
+++ b/crates/burn-cubecl/src/kernel/quantization/qtensor.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs)] // cube derive macros
 
-use burn_tensor::quantization::{QuantizationMode, QuantizationScheme};
+use burn_tensor::quantization::{BlockLayout, QuantizationMode, QuantizationScheme};
 use cubecl::prelude::*;
 
 /// Quantization parameters.
@@ -8,6 +8,8 @@ use cubecl::prelude::*;
 pub struct QParams {
     #[cube(comptime)]
     scheme: QuantizationScheme,
+    #[cube(comptime)]
+    num_blocks: u32,
 }
 
 /// Quantized tensor representation.
@@ -16,21 +18,20 @@ pub type QTensor = Array<Line<u32>>;
 #[cube]
 impl QParams {
     /// Create a new quantization parameters instance.
-    pub fn new(scheme: QuantizationScheme) -> Self {
-        QParams { scheme }
+    pub fn new(scheme: QuantizationScheme, #[comptime] num_blocks: u32) -> Self {
+        QParams { scheme, num_blocks }
     }
 
     /// Get the quantization parameters values.
-    // TODO: this needs to take the position of the value we want to dequantize so we can access the associated parameters
-    pub fn values(&self, tensor: &QTensor) -> (f32, i32) {
+    pub fn values(&self, tensor: &QTensor, value_pos: u32) -> (f32, i32) {
         let len = tensor.len();
         match comptime!(self.scheme) {
             QuantizationScheme::PerTensor(QuantizationMode::Affine, _) => {
                 match comptime!(tensor.line_size()) {
                     // For line size of 1, scale is the last value in the buffer
                     1 => (
-                        f32::bitcast_from(tensor[len - 1][tensor.line_size() - 1]),
-                        i32::cast_from(tensor[len - 2][tensor.line_size() - 1]),
+                        f32::bitcast_from(tensor[len - 1][0]),
+                        i32::cast_from(tensor[len - 2][0]),
                     ),
                     // For any other line size > 1, scale and zero-point offset are the last two elements
                     _ => {
@@ -47,15 +48,42 @@ impl QParams {
                 f32::bitcast_from(tensor[len - 1][tensor.line_size() - 1]),
                 0,
             ),
-            QuantizationScheme::PerBlock(_mode, _dtype, _block_layout) => {
-                // TODO
-                // For affine quantization, there are 2 parameters per block
-                // let values = tensor[len - 2 * num_blocks / tensor.line_size()];
-                // The (scale, offset) parameters are stored contiguously by parameter type
-                // [scale, scale, scale, ..., offset, offset, offset, ...]
-                // (but we might want to store them with each block in the future?)
-                (0f32, 0)
+            // For affine quantization, there are 2 parameters per block
+            // The (scale, offset) parameters are stored contiguously by parameter type
+            // [offset, offset, offset, ..., scale, scale, scale, ...]
+            // (but we might want to store them with each block in the future?)
+            QuantizationScheme::PerBlock(
+                QuantizationMode::Affine,
+                _dtype,
+                BlockLayout::Flat(block_size),
+            ) => {
+                // For each position in the quantized tensor, there are 4 packed values.
+                // The block size must be a factor of 4, so at least [4, 8, ...] values are contained in a single block
+                let line_size = tensor.line_size();
+                let block_idx = value_pos * 4 / block_size;
+
+                let scale =
+                    tensor[len - (self.num_blocks - block_idx) / line_size][block_idx % line_size];
+                let offset = tensor[len - (2 * self.num_blocks - block_idx / line_size)]
+                    [block_idx % line_size];
+
+                (f32::bitcast_from(scale), i32::cast_from(offset))
             }
+            QuantizationScheme::PerBlock(
+                QuantizationMode::Symmetric,
+                _dtype,
+                BlockLayout::Flat(block_size),
+            ) => {
+                // For each position in the quantized tensor, there are 4 packed values.
+                // The block size must be a factor of 4, so at least [4, 8, ...] values are contained in a single block
+                let line_size = tensor.line_size();
+                let block_idx = value_pos * 4 / block_size;
+
+                let scale =
+                    tensor[len - (self.num_blocks - block_idx) / line_size][block_idx % line_size];
+                (f32::bitcast_from(scale), 0)
+            }
+            _ => comptime!(unimplemented!()),
         }
     }
 }

--- a/crates/burn-cubecl/src/kernel/quantization/quantize.rs
+++ b/crates/burn-cubecl/src/kernel/quantization/quantize.rs
@@ -248,11 +248,9 @@ where
     I: IntElement,
 {
     match scheme {
-        QuantizationScheme::PerTensorAffine(dtype)
-        | QuantizationScheme::PerTensorSymmetric(dtype) => match dtype {
-            QuantizationType::QInt8 => {
-                quantize_per_tensor::<R, F, I>(tensor, scale, offset, *scheme)
-            }
-        },
+        QuantizationScheme::PerTensor(_mode, QuantizationType::QInt8) => {
+            quantize_per_tensor::<R, F, I>(tensor, scale, offset, *scheme)
+        }
+        QuantizationScheme::PerBlock(_mode, QuantizationType::QInt8, _block_layout) => todo!(),
     }
 }

--- a/crates/burn-cubecl/src/kernel/quantization/quantize.rs
+++ b/crates/burn-cubecl/src/kernel/quantization/quantize.rs
@@ -189,6 +189,7 @@ pub(crate) fn quantize_per_block_flat_symmetric_int8_kernel(
     }
 }
 
+// TODO: refactor affin/symmetric kernels. The applied function is the same, only the qparams used change.
 #[cube(launch_unchecked)]
 pub(crate) fn quantize_per_block_flat_affine_int8_kernel(
     input: &Tensor<Line<f32>>,

--- a/crates/burn-cubecl/src/kernel/quantization/quantize.rs
+++ b/crates/burn-cubecl/src/kernel/quantization/quantize.rs
@@ -1,12 +1,14 @@
 use crate::tensor::CubeTensor;
-use crate::FloatElement;
 use crate::{CubeElement, CubeRuntime, IntElement};
-use burn_tensor::quantization::{BlockLayout, QuantizationScheme, QuantizationType};
+use burn_tensor::quantization::{
+    BlockLayout, QuantizationMode, QuantizationScheme, QuantizationType,
+};
+use burn_tensor::Shape;
 use cubecl::calculate_cube_count_elemwise;
 use cubecl::prelude::*;
 
 #[cube]
-pub(crate) fn pack_i8s_to_u32s(value: Line<u32>) -> u32 {
+fn pack_i8s_to_u32s(value: Line<u32>) -> u32 {
     // NOTE: assuming line size of 4
     let line_size = value.size();
     let mut v_packed = 0;
@@ -20,7 +22,7 @@ pub(crate) fn pack_i8s_to_u32s(value: Line<u32>) -> u32 {
 }
 
 #[cube]
-pub(crate) fn quantize_affine_int8<F: Float>(
+fn quantize_affine_int8<F: Float>(
     value: Line<F>,
     scale: f32,
     offset: i32,
@@ -39,7 +41,7 @@ pub(crate) fn quantize_affine_int8<F: Float>(
 }
 
 #[cube]
-pub(crate) fn quantize_symmetric_int8<F: Float>(
+fn quantize_symmetric_int8<F: Float>(
     value: Line<F>,
     scale: f32,
     range_min: F,
@@ -56,8 +58,35 @@ pub(crate) fn quantize_symmetric_int8<F: Float>(
     )
 }
 
+#[cube]
+fn quantize_affine_int8_packed(
+    input: Line<f32>,
+    scale: f32,
+    offset: i32,
+    range_min: f32,
+    range_max: f32,
+) -> u32 {
+    // Assuming a line size of 4 (equal to the number of values packed)
+    let value = quantize_affine_int8::<f32>(input, scale, offset, range_min, range_max);
+    // Shift and combine into u32
+    pack_i8s_to_u32s(value)
+}
+
+#[cube]
+fn quantize_symmetric_int8_packed(
+    input: Line<f32>,
+    scale: f32,
+    range_min: f32,
+    range_max: f32,
+) -> u32 {
+    // Assuming a line size of 4 (equal to the number of values packed)
+    let value = quantize_symmetric_int8::<f32>(input, scale, range_min, range_max);
+    // Shift and combine into u32
+    pack_i8s_to_u32s(value)
+}
+
 #[cube(launch_unchecked)]
-pub(crate) fn quantize_per_tensor_affine_int8_kernel(
+fn quantize_per_tensor_affine_int8_kernel(
     input: &Tensor<Line<f32>>,
     scale: &Tensor<f32>,
     offset: &Tensor<i32>,
@@ -84,35 +113,25 @@ pub(crate) fn quantize_per_tensor_affine_int8_kernel(
         terminate!();
     }
 
-    let line_size = comptime!(input.line_size());
-    if comptime!(line_size == 4) {
-        // Assuming a line size of 4 (equal to the number of values packed)
-        let value =
-            quantize_affine_int8::<f32>(input[ABSOLUTE_POS], scale, offset, range_min, range_max);
-        // Shift and combine into u32
-        output[ABSOLUTE_POS] = pack_i8s_to_u32s(value);
+    if comptime!(input.line_size() == 4) {
+        output[ABSOLUTE_POS] =
+            quantize_affine_int8_packed(input[ABSOLUTE_POS], scale, offset, range_min, range_max);
     } else {
-        let mut v_packed = 0;
+        // line size 1
         let num_packed = comptime!(4);
+        let mut values = Line::<f32>::empty(num_packed);
         #[unroll]
         for i in 0..num_packed {
-            let v = quantize_affine_int8::<f32>(
-                input[ABSOLUTE_POS + i],
-                scale,
-                offset,
-                range_min,
-                range_max,
-            );
-            // Shift and combine into u32
-            v_packed |= (v[0] & 0xFF) << (8 * i);
+            values[i] = input[ABSOLUTE_POS + i][0];
         }
-        output[ABSOLUTE_POS] = v_packed;
+        output[ABSOLUTE_POS] =
+            quantize_affine_int8_packed(values, scale, offset, range_min, range_max);
     }
 }
 
 // Would have wrapped symmetric with the same affine kernel but cube doesn't support Option<Tensor> for offset.
 #[cube(launch_unchecked)]
-pub(crate) fn quantize_per_tensor_symmetric_int8_kernel(
+fn quantize_per_tensor_symmetric_int8_kernel(
     input: &Tensor<Line<f32>>,
     scale: &Tensor<f32>,
     range_min: f32,
@@ -131,33 +150,23 @@ pub(crate) fn quantize_per_tensor_symmetric_int8_kernel(
         terminate!();
     }
 
-    let line_size = comptime!(input.line_size());
-    if comptime!(line_size == 4) {
-        // Assuming a vectorization factor of 4 (equal to the number of values packed)
-        let value =
-            quantize_symmetric_int8::<f32>(input[ABSOLUTE_POS], scale, range_min, range_max);
-        // Shift and combine into u32
-        output[ABSOLUTE_POS] = pack_i8s_to_u32s(value);
+    if comptime!(input.line_size() == 4) {
+        output[ABSOLUTE_POS] =
+            quantize_symmetric_int8_packed(input[ABSOLUTE_POS], scale, range_min, range_max);
     } else {
+        // line size 1
         let num_packed = comptime!(4);
-        let mut v_packed = 0;
+        let mut values = Line::<f32>::empty(num_packed);
         #[unroll]
         for i in 0..num_packed {
-            let v = quantize_symmetric_int8::<f32>(
-                input[ABSOLUTE_POS + i],
-                scale,
-                range_min,
-                range_max,
-            );
-            // Shift and combine into u32
-            v_packed |= (v[0] & 0xFF) << (8 * i);
+            values[i] = input[ABSOLUTE_POS + i][0];
         }
-        output[ABSOLUTE_POS] = v_packed;
+        output[ABSOLUTE_POS] = quantize_symmetric_int8_packed(values, scale, range_min, range_max);
     }
 }
 
 #[cube(launch_unchecked)]
-pub(crate) fn quantize_per_block_flat_symmetric_int8_kernel(
+fn quantize_per_block_flat_symmetric_int8_kernel(
     input: &Tensor<Line<f32>>,
     scale: &Tensor<f32>,
     range_min: f32,
@@ -181,17 +190,14 @@ pub(crate) fn quantize_per_block_flat_symmetric_int8_kernel(
     let block_idx = (ABSOLUTE_POS * line_size) / block_size;
     let scale = scale[block_idx];
     if comptime!(line_size == 4) {
-        // Assuming a vectorization factor of 4 (equal to the number of values packed)
-        let value =
-            quantize_symmetric_int8::<f32>(input[ABSOLUTE_POS], scale, range_min, range_max);
-        // Shift and combine into u32
-        output[ABSOLUTE_POS] = pack_i8s_to_u32s(value);
+        output[ABSOLUTE_POS] =
+            quantize_symmetric_int8_packed(input[ABSOLUTE_POS], scale, range_min, range_max);
     }
 }
 
 // TODO: refactor affin/symmetric kernels. The applied function is the same, only the qparams used change.
 #[cube(launch_unchecked)]
-pub(crate) fn quantize_per_block_flat_affine_int8_kernel(
+fn quantize_per_block_flat_affine_int8_kernel(
     input: &Tensor<Line<f32>>,
     scale: &Tensor<f32>,
     offset: &Tensor<i32>,
@@ -224,177 +230,50 @@ pub(crate) fn quantize_per_block_flat_affine_int8_kernel(
     let scale = scale[block_idx];
     let offset = offset[block_idx];
     if comptime!(line_size == 4) {
-        // Assuming a vectorization factor of 4 (equal to the number of values packed)
-        let value =
-            quantize_affine_int8::<f32>(input[ABSOLUTE_POS], scale, offset, range_min, range_max);
-        // Shift and combine into u32
-        output[ABSOLUTE_POS] = pack_i8s_to_u32s(value);
+        output[ABSOLUTE_POS] =
+            quantize_affine_int8_packed(input[ABSOLUTE_POS], scale, offset, range_min, range_max);
     }
 }
 
-pub(crate) fn quantize_per_tensor<R, F, I>(
-    tensor: CubeTensor<R>,
-    scale: CubeTensor<R>,
-    offset: Option<CubeTensor<R>>,
+fn create_quantized_output<R: CubeRuntime>(
+    client: ComputeClient<R::Server, R::Channel>,
+    num_input_elems: usize,
+    device: R::Device,
+    shape: Shape,
     scheme: QuantizationScheme,
-) -> CubeTensor<R>
-where
-    R: CubeRuntime,
-    F: CubeElement,
-    I: IntElement,
-{
-    let ndims = tensor.shape.num_dims();
-    let num_elems = tensor.shape.num_elements();
-    let client = tensor.client.clone();
+) -> CubeTensor<R> {
     // Output tensor contains 4x less elements (four int8 values packed in a single u32)
-    let output_num_elems = usize::div_ceil(num_elems, 4) * core::mem::size_of::<u32>();
+    let output_elems_size = usize::div_ceil(num_input_elems, 4) * core::mem::size_of::<u32>();
 
-    // Force vectorization to process 4 quantized values packed for 1 output value
-    let line_size: u8 = if num_elems < 4 { 1 } else { 4 };
-    let cube_dim = CubeDim::default();
-    let cube_count = calculate_cube_count_elemwise(num_elems / line_size as usize, cube_dim);
+    // Scale and offset (optional) qparams are also packed in the tensor data
+    let qparams_size = match &scheme {
+        QuantizationScheme::PerTensor(mode, ..) => match mode {
+            QuantizationMode::Affine => core::mem::size_of::<f32>() + core::mem::size_of::<i32>(),
+            QuantizationMode::Symmetric => core::mem::size_of::<f32>(),
+        },
+        QuantizationScheme::PerBlock(mode, _, layout) => {
+            let num_blocks = match layout {
+                BlockLayout::Flat(block_size) => num_input_elems / *block_size as usize,
+                BlockLayout::Grid(m, n) => num_input_elems / (m * n) as usize,
+            };
 
-    let dummy_array = vec![1; ndims];
-    if let Some(offset) = offset {
-        // Scale and offset qparams are also packed in the tensor data
-        let handle = client
-            .empty(output_num_elems + core::mem::size_of::<f32>() + core::mem::size_of::<i32>());
-        let output = CubeTensor::new_contiguous(
-            client.clone(),
-            tensor.device.clone(),
-            tensor.shape.clone(),
-            handle,
-            burn_tensor::DType::QFloat(scheme),
-        );
+            match mode {
+                QuantizationMode::Affine => {
+                    (core::mem::size_of::<f32>() + core::mem::size_of::<i32>()) * num_blocks
+                }
+                QuantizationMode::Symmetric => core::mem::size_of::<f32>() * num_blocks,
+            }
+        }
+    };
 
-        unsafe {
-            quantize_per_tensor_affine_int8_kernel::launch_unchecked::<R>(
-                &client,
-                cube_count,
-                cube_dim,
-                tensor.as_tensor_arg::<F>(line_size),
-                // Ignore shape and stride
-                TensorArg::from_raw_parts::<F>(&scale.handle, &dummy_array, &dummy_array, 1),
-                TensorArg::from_raw_parts::<I>(&offset.handle, &dummy_array, &dummy_array, 1),
-                ScalarArg::new(i8::MIN as f32),
-                ScalarArg::new(i8::MAX as f32),
-                output.as_array_arg::<u32>(1),
-            )
-        };
-        output
-    } else {
-        // Scale qparam is also packed in the tensor data
-        let handle = client.empty(output_num_elems + core::mem::size_of::<f32>());
-        let output = CubeTensor::new_contiguous(
-            client.clone(),
-            tensor.device.clone(),
-            tensor.shape.clone(),
-            handle,
-            burn_tensor::DType::QFloat(scheme),
-        );
-
-        unsafe {
-            quantize_per_tensor_symmetric_int8_kernel::launch_unchecked::<R>(
-                &client,
-                cube_count,
-                cube_dim,
-                tensor.as_tensor_arg::<F>(line_size),
-                // Ignore shape and stride
-                TensorArg::from_raw_parts::<F>(&scale.handle, &dummy_array, &dummy_array, 1),
-                ScalarArg::new(-i8::MAX as f32),
-                ScalarArg::new(i8::MAX as f32),
-                output.as_array_arg::<u32>(1),
-            )
-        };
-
-        output
-    }
-}
-
-pub(crate) fn quantize_per_block<R, F, I>(
-    tensor: CubeTensor<R>,
-    scale: CubeTensor<R>,
-    offset: Option<CubeTensor<R>>,
-    block_size: u32,
-    scheme: QuantizationScheme,
-) -> CubeTensor<R>
-where
-    R: CubeRuntime,
-    F: CubeElement,
-    I: IntElement,
-{
-    let line_size: u8 = 4;
-    if block_size % line_size as u32 != 0 {
-        panic!("Block size must be a factor of {line_size}, got {block_size}")
-    }
-
-    let client = tensor.client.clone();
-    // Output tensor contains 4x less elements (four int8 values packed in a single u32)
-    let num_elems = tensor.shape.num_elements();
-    let output_num_elems = usize::div_ceil(num_elems, 4) * core::mem::size_of::<u32>();
-
-    // Force vectorization to process 4 quantized values packed for 1 output value
-    let cube_dim = CubeDim::default();
-    let cube_count = calculate_cube_count_elemwise(num_elems / line_size as usize, cube_dim);
-
-    let num_blocks = num_elems as u32 / block_size;
-    if let Some(offset) = offset {
-        // Scale and offset qparams are also packed in the tensor data
-        let qparams_size =
-            (core::mem::size_of::<f32>() + core::mem::size_of::<i32>()) * num_blocks as usize;
-        let handle = client.empty(output_num_elems + qparams_size);
-        let output = CubeTensor::new_contiguous(
-            client.clone(),
-            tensor.device.clone(),
-            tensor.shape.clone(),
-            handle,
-            burn_tensor::DType::QFloat(scheme),
-        );
-
-        unsafe {
-            quantize_per_block_flat_affine_int8_kernel::launch_unchecked::<R>(
-                &client,
-                cube_count,
-                cube_dim,
-                tensor.as_tensor_arg::<F>(line_size),
-                scale.as_tensor_arg::<F>(1),
-                offset.as_tensor_arg::<I>(1),
-                ScalarArg::new(i8::MIN as f32),
-                ScalarArg::new(i8::MAX as f32),
-                ScalarArg::new(block_size),
-                output.as_array_arg::<u32>(1),
-                num_blocks,
-            )
-        };
-        output
-    } else {
-        // Scale qparam is also packed in the tensor data
-        let qparams_size = core::mem::size_of::<f32>() * num_blocks as usize;
-        let handle = client.empty(output_num_elems + qparams_size);
-        let output = CubeTensor::new_contiguous(
-            client.clone(),
-            tensor.device.clone(),
-            tensor.shape.clone(),
-            handle,
-            burn_tensor::DType::QFloat(scheme),
-        );
-
-        unsafe {
-            quantize_per_block_flat_symmetric_int8_kernel::launch_unchecked::<R>(
-                &client,
-                cube_count,
-                cube_dim,
-                tensor.as_tensor_arg::<F>(line_size),
-                scale.as_tensor_arg::<F>(1),
-                ScalarArg::new(-i8::MAX as f32),
-                ScalarArg::new(i8::MAX as f32),
-                ScalarArg::new(block_size),
-                output.as_array_arg::<u32>(1),
-                num_blocks,
-            )
-        };
-        output
-    }
+    let handle = client.empty(output_elems_size + qparams_size);
+    CubeTensor::new_contiguous(
+        client,
+        device,
+        shape,
+        handle,
+        burn_tensor::DType::QFloat(scheme),
+    )
 }
 
 /// Convert the tensor to a lower precision data type based on the quantization scheme and parameters.
@@ -406,21 +285,132 @@ pub fn quantize<R, F, I>(
 ) -> CubeTensor<R>
 where
     R: CubeRuntime,
-    F: FloatElement,
+    F: CubeElement,
     I: IntElement,
 {
+    let client = tensor.client.clone();
+    // Output tensor contains 4x less elements (four int8 values packed in a single u32)
+    let num_elems = tensor.shape.num_elements();
+
+    // Force vectorization to process 4 quantized values packed for 1 output value
+    let line_size: u8 = if num_elems < 4 { 1 } else { 4 };
+    let cube_dim = CubeDim::default();
+    let cube_count = calculate_cube_count_elemwise(num_elems / line_size as usize, cube_dim);
+
+    let output = create_quantized_output(
+        client.clone(),
+        num_elems,
+        tensor.device.clone(),
+        tensor.shape.clone(),
+        *scheme,
+    );
+
     match scheme {
-        QuantizationScheme::PerTensor(_mode, QuantizationType::QInt8) => {
-            quantize_per_tensor::<R, F, I>(tensor, scale, offset, *scheme)
+        QuantizationScheme::PerTensor(mode, QuantizationType::QInt8) => {
+            let ndims = tensor.shape.num_dims();
+            let dummy_array = vec![1; ndims];
+
+            match mode {
+                QuantizationMode::Affine => {
+                    unsafe {
+                        quantize_per_tensor_affine_int8_kernel::launch_unchecked::<R>(
+                            &client,
+                            cube_count,
+                            cube_dim,
+                            tensor.as_tensor_arg::<F>(line_size),
+                            // Ignore shape and stride
+                            TensorArg::from_raw_parts::<F>(
+                                &scale.handle,
+                                &dummy_array,
+                                &dummy_array,
+                                1,
+                            ),
+                            TensorArg::from_raw_parts::<I>(
+                                &offset.expect("Should have offset").handle,
+                                &dummy_array,
+                                &dummy_array,
+                                1,
+                            ),
+                            ScalarArg::new(i8::MIN as f32),
+                            ScalarArg::new(i8::MAX as f32),
+                            output.as_array_arg::<u32>(1),
+                        )
+                    };
+                }
+                QuantizationMode::Symmetric => {
+                    unsafe {
+                        quantize_per_tensor_symmetric_int8_kernel::launch_unchecked::<R>(
+                            &client,
+                            cube_count,
+                            cube_dim,
+                            tensor.as_tensor_arg::<F>(line_size),
+                            // Ignore shape and stride
+                            TensorArg::from_raw_parts::<F>(
+                                &scale.handle,
+                                &dummy_array,
+                                &dummy_array,
+                                1,
+                            ),
+                            ScalarArg::new(-i8::MAX as f32),
+                            ScalarArg::new(i8::MAX as f32),
+                            output.as_array_arg::<u32>(1),
+                        )
+                    };
+                }
+            }
         }
-        // TODO
-        QuantizationScheme::PerBlock(_mode, QuantizationType::QInt8, layout) => match layout {
-            BlockLayout::Flat(block_size) => {
-                quantize_per_block::<R, F, I>(tensor, scale, offset, *block_size, *scheme)
+        QuantizationScheme::PerBlock(
+            mode,
+            QuantizationType::QInt8,
+            BlockLayout::Flat(block_size),
+        ) => {
+            if line_size != 4 {
+                panic!("Per-block quantization is only supported for a line size of 4, got {line_size} ({num_elems} elements)")
             }
-            BlockLayout::Grid(..) => {
-                unimplemented!("Per-block quantization is not supported for a grid")
+
+            if block_size % line_size as u32 != 0 {
+                panic!("Block size must be a factor of {line_size}, got {block_size}")
             }
-        },
+
+            let num_blocks = num_elems as u32 / block_size;
+            match mode {
+                QuantizationMode::Affine => {
+                    unsafe {
+                        quantize_per_block_flat_affine_int8_kernel::launch_unchecked::<R>(
+                            &client,
+                            cube_count,
+                            cube_dim,
+                            tensor.as_tensor_arg::<F>(line_size),
+                            scale.as_tensor_arg::<F>(1),
+                            offset.expect("Should have offset").as_tensor_arg::<I>(1),
+                            ScalarArg::new(i8::MIN as f32),
+                            ScalarArg::new(i8::MAX as f32),
+                            ScalarArg::new(*block_size),
+                            output.as_array_arg::<u32>(1),
+                            num_blocks,
+                        )
+                    };
+                }
+                QuantizationMode::Symmetric => {
+                    unsafe {
+                        quantize_per_block_flat_symmetric_int8_kernel::launch_unchecked::<R>(
+                            &client,
+                            cube_count,
+                            cube_dim,
+                            tensor.as_tensor_arg::<F>(line_size),
+                            scale.as_tensor_arg::<F>(1),
+                            ScalarArg::new(-i8::MAX as f32),
+                            ScalarArg::new(i8::MAX as f32),
+                            ScalarArg::new(*block_size),
+                            output.as_array_arg::<u32>(1),
+                            num_blocks,
+                        )
+                    };
+                }
+            }
+        }
+        _ => unimplemented!("Unsupported quantization scheme {scheme:?}"),
     }
+
+    output
 }

--- a/crates/burn-cubecl/src/ops/qtensor.rs
+++ b/crates/burn-cubecl/src/ops/qtensor.rs
@@ -40,12 +40,12 @@ where
     fn q_from_data(data: TensorData, device: &Device<Self>) -> QuantizedTensor<Self> {
         match data.dtype {
             DType::QFloat(scheme) => match scheme {
-                QuantizationScheme::PerTensorAffine(QuantizationType::QInt8)
-                | QuantizationScheme::PerTensorSymmetric(QuantizationType::QInt8) => {
+                QuantizationScheme::PerTensor(_mode, QuantizationType::QInt8) => {
                     // TensorData quantized representation is the same, with multiple quantized values
                     // packed into u32 and quantization parameters appended to the bytes
                     new_qtensor(data.as_bytes(), data.shape.clone(), scheme, device)
                 }
+                QuantizationScheme::PerBlock(_mode, _dtype, _block_layout) => todo!(),
             },
             _ => panic!(
                 "Invalid dtype (expected DType::QFloat, got {:?})",

--- a/crates/burn-cubecl/src/ops/qtensor.rs
+++ b/crates/burn-cubecl/src/ops/qtensor.rs
@@ -54,6 +54,8 @@ where
         }
     }
 
+    // TODO: quantize_dynamic (we can compute min-max on the fly and scale, especially when not per-tensor)
+
     fn quantize(
         tensor: FloatTensor<Self>,
         scheme: &QuantizationScheme,

--- a/crates/burn-cubecl/src/ops/qtensor.rs
+++ b/crates/burn-cubecl/src/ops/qtensor.rs
@@ -84,6 +84,7 @@ where
         let tensor = kernel::into_contiguous(tensor);
         let bytes = tensor.client.read_one_async(tensor.handle.binding()).await;
 
+        // We use the same internal representation
         TensorData::from_bytes(bytes, tensor.shape, tensor.dtype)
     }
 

--- a/crates/burn-cubecl/src/tests/quantization.rs
+++ b/crates/burn-cubecl/src/tests/quantization.rs
@@ -2,13 +2,14 @@
 mod tests {
     use super::*;
     use burn_tensor::{
-        quantization::{QuantizationScheme, QuantizationType},
+        quantization::{QuantizationMode, QuantizationScheme, QuantizationType},
         Tensor,
     };
 
     #[test]
     fn should_quantize_dequantize_symmetric_single() {
-        let scheme = QuantizationScheme::PerTensorSymmetric(QuantizationType::QInt8);
+        let scheme =
+            QuantizationScheme::PerTensor(QuantizationMode::Symmetric, QuantizationType::QInt8);
         let input = Tensor::<TestBackend, 1>::from_floats([-1.8], &Default::default());
         let input_ref =
             Tensor::<ReferenceBackend, 1>::from_data(input.to_data(), &Default::default());
@@ -26,7 +27,8 @@ mod tests {
 
     #[test]
     fn should_quantize_dequantize_affine_single() {
-        let scheme = QuantizationScheme::PerTensorAffine(QuantizationType::QInt8);
+        let scheme =
+            QuantizationScheme::PerTensor(QuantizationMode::Affine, QuantizationType::QInt8);
         let input = Tensor::<TestBackend, 1>::from_floats([-1.8], &Default::default());
         let input_ref =
             Tensor::<ReferenceBackend, 1>::from_data(input.to_data(), &Default::default());
@@ -44,7 +46,8 @@ mod tests {
 
     #[test]
     fn should_quantize_dequantize_symmetric_multiple() {
-        let scheme = QuantizationScheme::PerTensorSymmetric(QuantizationType::QInt8);
+        let scheme =
+            QuantizationScheme::PerTensor(QuantizationMode::Symmetric, QuantizationType::QInt8);
         let input =
             Tensor::<TestBackend, 1>::from_floats([-1.8, -1.0, 0.0, 0.5, 0.0], &Default::default());
         let input_ref =
@@ -63,7 +66,8 @@ mod tests {
 
     #[test]
     fn should_quantize_dequantize_affine_multiple() {
-        let scheme = QuantizationScheme::PerTensorAffine(QuantizationType::QInt8);
+        let scheme =
+            QuantizationScheme::PerTensor(QuantizationMode::Affine, QuantizationType::QInt8);
         let input =
             Tensor::<TestBackend, 1>::from_floats([-1.8, -1.0, 0.0, 0.5, 0.0], &Default::default());
         let input_ref =

--- a/crates/burn-import/onnx-tests/tests/split/split.py
+++ b/crates/burn-import/onnx-tests/tests/split/split.py
@@ -16,7 +16,7 @@ class Model(nn.Module):
 
 
 def main():
-    # Set seed for reproducability
+    # Set seed for reproducibility
     torch.manual_seed(42)
 
     torch.set_printoptions(precision=8)

--- a/crates/burn-ndarray/src/ops/qtensor.rs
+++ b/crates/burn-ndarray/src/ops/qtensor.rs
@@ -110,7 +110,7 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> QTensorOps<S
                         offset.elem(),
                     )),
                     vec![QParams {
-                        scale: scale,
+                        scale,
                         offset: Some(offset),
                     }],
                 )
@@ -122,7 +122,7 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> QTensorOps<S
                         scale,
                     )),
                     vec![QParams {
-                        scale: scale,
+                        scale,
                         offset: None,
                     }],
                 )

--- a/crates/burn-ndarray/src/ops/qtensor.rs
+++ b/crates/burn-ndarray/src/ops/qtensor.rs
@@ -134,7 +134,7 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> QTensorOps<S
             ) => {
                 let scale = into_data_f(qparams.scale);
                 let offset = into_data(qparams.offset.unwrap());
-                let (strategy, qparams): (Vec<_>, Vec<_>) = scale
+                let (strategy, qparams) = scale
                     .iter()
                     .zip(offset.iter::<Q>())
                     .map(|(s, o)| {
@@ -159,7 +159,7 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> QTensorOps<S
                 layout,
             ) => {
                 let scale = into_data_f(qparams.scale);
-                let (strategy, qparams): (Vec<_>, Vec<_>) = scale
+                let (strategy, qparams) = scale
                     .iter()
                     .map(|s| {
                         (

--- a/crates/burn-tch/src/ops/qtensor.rs
+++ b/crates/burn-tch/src/ops/qtensor.rs
@@ -48,23 +48,33 @@ impl<E: TchElement, Q: QuantElement> QTensorOps<Self> for LibTorch<E, Q> {
         // So for now we have to load the dequantized values to quantize them back since the dequantization
         // methods take the values provided when quantizing.
         match data.dtype {
-            DType::QFloat(scheme) => {
-                let num_elements = data.num_elements();
-                let q_bytes = QuantizedBytes {
-                    bytes: data.into_bytes(),
-                    scheme,
-                    num_elements,
-                };
+            DType::QFloat(scheme) => match scheme {
+                QuantizationScheme::PerTensor(_, _) => {
+                    let shape = data.shape.clone();
+                    let num_elements = data.num_elements();
+                    let q_bytes = QuantizedBytes {
+                        bytes: data.into_bytes(),
+                        scheme,
+                        num_elements,
+                    };
 
-                let (values, qparams) = q_bytes.dequantize();
-                let tensor = tch::Tensor::from_slice(&values).to(device);
-                let tensor = quantize(tensor.reshape(shape_tch.dims), &scheme, &qparams);
+                    let (values, qparams) = q_bytes.dequantize(&shape);
+                    let qparams = QParams {
+                        scale: qparams.scale[0],
+                        offset: qparams.offset.map(|x| x[0]),
+                    };
+                    let tensor = tch::Tensor::from_slice(&values).to(device);
+                    let tensor = quantize(tensor.reshape(shape_tch.dims), &scheme, &qparams);
 
-                TchQTensor {
-                    qtensor: TchTensor::new(tensor),
-                    scheme,
+                    TchQTensor {
+                        qtensor: TchTensor::new(tensor),
+                        scheme,
+                    }
                 }
-            }
+                QuantizationScheme::PerBlock(..) => {
+                    panic!("Tch does not support per-block quantization")
+                }
+            },
             _ => panic!(
                 "Invalid dtype (expected DType::QFloat, got {:?})",
                 data.dtype
@@ -84,21 +94,23 @@ impl<E: TchElement, Q: QuantElement> QTensorOps<Self> for LibTorch<E, Q> {
         }
 
         let qtensor = match scheme {
-            QuantizationScheme::PerTensor(QuantizationMode::Affine, dtype) => match dtype {
-                QuantizationType::QInt8 => tensor.tensor.quantize_per_tensor_tensor_qparams(
+            QuantizationScheme::PerTensor(QuantizationMode::Affine, QuantizationType::QInt8) => {
+                tensor.tensor.quantize_per_tensor_tensor_qparams(
                     &qparams.scale.tensor,
                     &qparams.offset.unwrap().tensor,
                     tch::Kind::QInt8,
-                ),
-            },
-            QuantizationScheme::PerTensor(QuantizationMode::Symmetric, _) => {
+                )
+            }
+            QuantizationScheme::PerTensor(QuantizationMode::Symmetric, QuantizationType::QInt8) => {
                 tensor.tensor.quantize_per_tensor_tensor_qparams(
                     &qparams.scale.tensor,
                     &tch::Tensor::zeros_like(&qparams.scale.tensor),
                     tch::Kind::QInt8,
                 )
             }
-            QuantizationScheme::PerBlock(_mode, _dtype, _block_layout) => unimplemented!(),
+            QuantizationScheme::PerBlock(..) => {
+                panic!("Tch does not support per-block quantization")
+            }
         };
 
         TchQTensor {
@@ -112,23 +124,23 @@ impl<E: TchElement, Q: QuantElement> QTensorOps<Self> for LibTorch<E, Q> {
         scheme: &QuantizationScheme,
     ) -> QuantizedTensor<Self> {
         let qtensor = match &scheme {
-            QuantizationScheme::PerTensor(QuantizationMode::Affine, dtype) => match dtype {
+            QuantizationScheme::PerTensor(QuantizationMode::Affine, QuantizationType::QInt8) => {
                 // Notes on `reduce_range`:
                 // https://github.com/pytorch/pytorch/issues/93140
                 // https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html#data-type-selection
-                QuantizationType::QInt8 => tensor
+                tensor
                     .tensor
-                    .quantize_per_tensor_dynamic(tch::Kind::QInt8, /*reduce_range*/ false),
-            },
-            QuantizationScheme::PerTensor(QuantizationMode::Symmetric, dtype) => {
-                log::warn!("LibTorch backend does not support symmetric per-tensor scheme for dynamic quantization, reverting to the default per-tensor affine quantization");
-                match dtype {
-                    QuantizationType::QInt8 => tensor
-                        .tensor
-                        .quantize_per_tensor_dynamic(tch::Kind::QInt8, /*reduce_range*/ false),
-                }
+                    .quantize_per_tensor_dynamic(tch::Kind::QInt8, /*reduce_range*/ false)
             }
-            QuantizationScheme::PerBlock(_mode, _dtype, _block_layout) => unimplemented!(),
+            QuantizationScheme::PerTensor(QuantizationMode::Symmetric, QuantizationType::QInt8) => {
+                log::warn!("LibTorch backend does not support symmetric per-tensor scheme for dynamic quantization, reverting to the default per-tensor affine quantization");
+                tensor
+                    .tensor
+                    .quantize_per_tensor_dynamic(tch::Kind::QInt8, /*reduce_range*/ false)
+            }
+            QuantizationScheme::PerBlock(..) => {
+                panic!("Tch does not support per-block quantization")
+            }
         };
 
         TchQTensor {

--- a/crates/burn-tch/src/tensor.rs
+++ b/crates/burn-tch/src/tensor.rs
@@ -345,7 +345,8 @@ impl TchQTensor {
                     scale as f32,
                 ))
             }
-            QuantizationScheme::PerBlock(_mode, _dtype, _block_layout) => unimplemented!(),
+            // Only per-tensor and per-channel are supported
+            QuantizationScheme::PerBlock(..) => unreachable!(),
         }
     }
 }

--- a/crates/burn-tensor-testgen/Cargo.toml
+++ b/crates/burn-tensor-testgen/Cargo.toml
@@ -14,3 +14,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
+syn = { workspace = true }

--- a/crates/burn-tensor-testgen/src/lib.rs
+++ b/crates/burn-tensor-testgen/src/lib.rs
@@ -1,6 +1,130 @@
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::token::Comma;
+use syn::{parse_macro_input, Attribute, Expr, ItemFn, Lit, Meta, MetaNameValue};
+
+// Define a structure to parse the attribute arguments
+struct AttributeArgs {
+    args: Punctuated<Meta, Comma>,
+}
+
+impl Parse for AttributeArgs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        Ok(AttributeArgs {
+            args: Punctuated::parse_terminated(input)?,
+        })
+    }
+}
+
+#[allow(clippy::test_attr_in_doctest)]
+/// A proc macro attribute that adds panic handling to test functions.
+///
+/// # Usage
+/// ```rust, ignore
+/// #[might_panic(reason = "expected panic message prefix")]
+/// #[test]
+/// fn test_that_might_panic() {
+///     // test code that might panic (with acceptable reason)
+/// }
+/// ```
+///
+/// # Behavior
+/// - If the test does not panic, it passes.
+/// - If the test panics with a message starting with the expected prefix, the failure is ignored.
+/// - If the test panics with a different message, the test fails.
+#[proc_macro_attribute]
+pub fn might_panic(args: TokenStream, input: TokenStream) -> TokenStream {
+    // Parse the attribute arguments
+    let args = parse_macro_input!(args as AttributeArgs);
+    let input_fn = parse_macro_input!(input as ItemFn);
+
+    // Extract the expected panic reason
+    let mut expected_reason = None;
+    for arg in args.args.iter() {
+        if let Meta::NameValue(MetaNameValue { path, value, .. }) = arg {
+            if path.is_ident("reason") {
+                if let Expr::Lit(lit) = value {
+                    if let Lit::Str(ref lit_str) = lit.lit {
+                        expected_reason = Some(lit_str.value());
+                    }
+                }
+            }
+        }
+    }
+
+    let expected_reason = match expected_reason {
+        Some(reason) => reason,
+        None => {
+            return syn::Error::new(
+                proc_macro2::Span::call_site(),
+                "The #[might_panic] attribute requires a 'reason' parameter",
+            )
+            .to_compile_error()
+            .into();
+        }
+    };
+
+    let fn_name = &input_fn.sig.ident;
+    let fn_vis = &input_fn.vis;
+    let fn_generics = &input_fn.sig.generics;
+    let fn_block = &input_fn.block;
+    let fn_attrs = input_fn
+        .attrs
+        .iter()
+        .filter(|attr| !attr.path().is_ident("test"))
+        .collect::<Vec<&Attribute>>();
+
+    // Create a wrapped test function
+    let wrapper_name = format_ident!("{}_might_panic", fn_name);
+
+    let expanded = quote! {
+        #(#fn_attrs)*
+        #fn_vis fn #fn_name #fn_generics() {
+            #fn_block
+        }
+
+        #[test]
+        #fn_vis fn #wrapper_name #fn_generics() {
+            use std::panic::{self, AssertUnwindSafe};
+
+            let expected_reason = #expected_reason;
+            let result = panic::catch_unwind(AssertUnwindSafe(|| {
+                #fn_name();
+            }));
+
+            match result {
+                Ok(_) => {
+                    // Test passed without panic - this is OK
+                }
+                Err(e) => {
+                    // Convert the panic payload to a string
+                    let panic_msg = if let Some(s) = e.downcast_ref::<String>() {
+                        s.to_string()
+                    } else if let Some(s) = e.downcast_ref::<&str>() {
+                        s.to_string()
+                    } else {
+                        "Unknown panic".to_string()
+                    };
+
+                    // Check if the panic message starts with the expected reason
+                    if !panic_msg.starts_with(expected_reason) {
+                        panic!(
+                            "Test '{}' marked as 'might_panic' failed. Expected reason: '{}'",
+                            stringify!(#fn_name),
+                            expected_reason
+                        );
+                    }
+                }
+            }
+        }
+    };
+
+    expanded.into()
+}
+
 #[allow(missing_docs)]
 #[proc_macro_attribute]
 pub fn testgen(attr: TokenStream, item: TokenStream) -> TokenStream {

--- a/crates/burn-tensor/src/lib.rs
+++ b/crates/burn-tensor/src/lib.rs
@@ -17,6 +17,10 @@ mod tensor;
 #[allow(missing_docs)]
 pub mod tests;
 
+#[cfg(feature = "export_tests")]
+// Re-export the might_panic proc macro for easy access
+pub use burn_tensor_testgen::might_panic;
+
 pub use half::{bf16, f16};
 pub(crate) use tensor::check::macros::check;
 pub use tensor::*;

--- a/crates/burn-tensor/src/tensor/api/float.rs
+++ b/crates/burn-tensor/src/tensor/api/float.rs
@@ -316,6 +316,9 @@ where
     /// # Returns
     ///
     /// The quantized tensor.
+    ///
+    /// # Notes
+    /// This uses [min-max calibration](crate::quantization::Calibration::MinMax).
     pub fn quantize_dynamic(self, scheme: &QuantizationScheme) -> Tensor<B, D> {
         Tensor::new(TensorPrimitive::QFloat(B::quantize_dynamic(
             self.primitive.tensor(),

--- a/crates/burn-tensor/src/tensor/element/base.rs
+++ b/crates/burn-tensor/src/tensor/element/base.rs
@@ -332,10 +332,10 @@ impl DType {
             DType::U8 => core::mem::size_of::<u8>(),
             DType::Bool => core::mem::size_of::<bool>(),
             DType::QFloat(scheme) => match scheme {
-                QuantizationScheme::PerTensorAffine(qtype)
-                | QuantizationScheme::PerTensorSymmetric(qtype) => match qtype {
-                    QuantizationType::QInt8 => core::mem::size_of::<i8>(),
-                },
+                QuantizationScheme::PerTensor(_mode, QuantizationType::QInt8) => {
+                    core::mem::size_of::<i8>()
+                }
+                QuantizationScheme::PerBlock(_mode, _dtype, _block_layout) => todo!(),
             },
         }
     }

--- a/crates/burn-tensor/src/tensor/element/base.rs
+++ b/crates/burn-tensor/src/tensor/element/base.rs
@@ -332,10 +332,10 @@ impl DType {
             DType::U8 => core::mem::size_of::<u8>(),
             DType::Bool => core::mem::size_of::<bool>(),
             DType::QFloat(scheme) => match scheme {
-                QuantizationScheme::PerTensor(_mode, QuantizationType::QInt8) => {
+                QuantizationScheme::PerTensor(_mode, QuantizationType::QInt8)
+                | QuantizationScheme::PerBlock(_mode, QuantizationType::QInt8, ..) => {
                     core::mem::size_of::<i8>()
                 }
-                QuantizationScheme::PerBlock(_mode, _dtype, _block_layout) => todo!(),
             },
         }
     }

--- a/crates/burn-tensor/src/tensor/ops/qtensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/qtensor.rs
@@ -3,7 +3,9 @@ use core::{future::Future, ops::Range};
 
 use crate::{
     backend::Backend,
-    quantization::{QTensorPrimitive, QuantizationParametersPrimitive, QuantizationScheme},
+    quantization::{
+        Calibration, QTensorPrimitive, QuantizationParametersPrimitive, QuantizationScheme,
+    },
     Device, Shape, TensorData, TensorMetadata,
 };
 
@@ -65,8 +67,7 @@ pub trait QTensorOps<B: Backend> {
     /// Dynamically convert the tensor to a lower precision data type based on the quantization scheme.
     fn quantize_dynamic(tensor: FloatTensor<B>, scheme: &QuantizationScheme) -> QuantizedTensor<B> {
         // Dynamically compute min/max tensor range and qparams before quantizing
-        let min = B::float_min(tensor.clone());
-        let max = B::float_max(tensor.clone());
+        let (min, max) = scheme.compute_range_primitive::<B>(tensor.clone(), &Calibration::MinMax);
         let qparams = scheme.compute_q_params_primitive(min, max);
         Self::quantize(tensor, scheme, qparams)
     }

--- a/crates/burn-tensor/src/tensor/quantization/bytes.rs
+++ b/crates/burn-tensor/src/tensor/quantization/bytes.rs
@@ -4,7 +4,7 @@ use crate::{Bytes, Element};
 use alloc::vec::Vec;
 
 use super::{
-    pack_i8s_to_u32s, unpack_u32s_to_i8s, AffineQuantization, QParams, Quantization,
+    pack_i8s_to_u32s, unpack_u32s_to_i8s, AffineQuantization, BlockLayout, QParams,
     QuantizationMode, QuantizationScheme, QuantizationStrategy, QuantizationType,
     SymmetricQuantization,
 };
@@ -32,9 +32,10 @@ impl QuantizedBytes {
     pub fn new<E: Element>(value: Vec<E>, strategy: QuantizationStrategy) -> Self {
         let mut bytes: Bytes;
         let num_elements = value.len();
+        let scheme = strategy.scheme();
 
         match strategy {
-            QuantizationStrategy::PerTensorAffineInt8(q) => {
+            QuantizationStrategy::PerTensorAffineInt8(quant) => {
                 if TypeId::of::<E>() == TypeId::of::<i8>() {
                     // Re-interpret `Vec<E>` as `Vec<i8>` with `Vec::from_raw_parts`
                     let u32s = pack_i8s_to_u32s(bytemuck::allocation::cast_vec(value));
@@ -43,13 +44,13 @@ impl QuantizedBytes {
                     panic!("Invalid quantized type");
                 }
                 // Scale is always stored as f32 and zero-point offset as i32
-                let offset = q.offset as i32;
-                let scale_bytes = bytemuck::bytes_of(&q.scale);
+                let offset = quant.offset as i32;
+                let scale_bytes = bytemuck::bytes_of(&quant.scale);
                 let offset_bytes = bytemuck::bytes_of(&offset);
                 bytes.extend_from_byte_slice_aligned(offset_bytes, align_of::<i32>());
                 bytes.extend_from_byte_slice_aligned(scale_bytes, align_of::<f32>());
             }
-            QuantizationStrategy::PerTensorSymmetricInt8(q) => {
+            QuantizationStrategy::PerTensorSymmetricInt8(quant) => {
                 if TypeId::of::<E>() == TypeId::of::<i8>() {
                     // Re-interpret `Vec<E>` as `Vec<i8>` with `Vec::from_raw_parts`
                     let u32s = pack_i8s_to_u32s(bytemuck::allocation::cast_vec(value));
@@ -57,45 +58,82 @@ impl QuantizedBytes {
                 } else {
                     panic!("Invalid quantized type");
                 }
-                let scale_bytes = bytemuck::bytes_of(&q.scale);
+                let scale_bytes = bytemuck::bytes_of(&quant.scale);
                 bytes.extend_from_byte_slice_aligned(scale_bytes, align_of::<f32>());
+            }
+            QuantizationStrategy::PerBlockAffineInt8(quant, _layout) => {
+                if TypeId::of::<E>() == TypeId::of::<i8>() {
+                    // Re-interpret `Vec<E>` as `Vec<i8>` with `Vec::from_raw_parts`
+                    let u32s = pack_i8s_to_u32s(bytemuck::allocation::cast_vec(value));
+                    bytes = Bytes::from_elems(u32s);
+                } else {
+                    panic!("Invalid quantized type");
+                }
+                let mut scale_bytes = Vec::with_capacity(quant.len() * size_of::<f32>());
+                let mut offset_bytes = Vec::with_capacity(quant.len() * size_of::<f32>());
+                for q in quant {
+                    scale_bytes.extend_from_slice(bytemuck::bytes_of(&q.scale));
+                    offset_bytes.extend_from_slice(bytemuck::bytes_of(&(q.offset as i32)));
+                }
+                bytes.extend_from_byte_slice_aligned(offset_bytes.as_slice(), align_of::<i32>());
+                bytes.extend_from_byte_slice_aligned(scale_bytes.as_slice(), align_of::<f32>());
+            }
+            QuantizationStrategy::PerBlockSymmetricInt8(quant, _layout) => {
+                if TypeId::of::<E>() == TypeId::of::<i8>() {
+                    // Re-interpret `Vec<E>` as `Vec<i8>` with `Vec::from_raw_parts`
+                    let u32s = pack_i8s_to_u32s(bytemuck::allocation::cast_vec(value));
+                    bytes = Bytes::from_elems(u32s);
+                } else {
+                    panic!("Invalid quantized type");
+                }
+                let mut scale_bytes = Vec::with_capacity(quant.len() * size_of::<f32>());
+                for q in quant {
+                    scale_bytes.extend_from_slice(bytemuck::bytes_of(&q.scale));
+                }
+                bytes.extend_from_byte_slice_aligned(scale_bytes.as_slice(), align_of::<f32>());
             }
         }
 
         Self {
             bytes,
-            scheme: strategy.scheme(),
+            scheme,
             num_elements,
         }
     }
 
     /// Returns the int8 quantized values with the quantization parameters.
-    pub fn into_vec_i8(self) -> (Vec<i8>, QParams<f32, i8>) {
+    pub fn into_vec_i8(self) -> (Vec<i8>, QParams<Vec<f32>, Vec<i8>>) {
         let numel = self.num_elements;
         let scheme = self.scheme;
-        let (values, qparams) = self.split_values_off();
+        let (values, (qparams, num_params)) = self.split_values_off();
 
         let values = unpack_u32s_to_i8s(values, numel);
 
         // Quantization parameters are added at the end of the tensor data.
-        // As such, the last bytes always correspond to the scale parameter.
-        // If the quantization scheme includes an offset (zero-point) parameter, it is next to last.
+        // As such, the last bytes always correspond to the scale parameter(s).
+        // If the quantization scheme includes an offset (zero-point) parameter, the value(s)
+        // precede(s) the scale parameter(s) bytes.
+        // For example, per-block quantization can have multiple parameters for a single tensor:
+        // [offset, offset, offset, ..., scale, scale, scale, ...]
         let scale_size = core::mem::size_of::<f32>(); // scale is stored as f32
-        let qparams_bytes = bytemuck::cast_slice(&qparams);
+        let qparams_bytes: &[u8] = bytemuck::cast_slice(&qparams);
         let total_bytes = qparams_bytes.len();
-        let scale = *bytemuck::checked::from_bytes(&qparams_bytes[total_bytes - scale_size..]);
 
-        let offset = match scheme {
-            QuantizationScheme::PerTensor(QuantizationMode::Affine, _) => {
-                let offset_size = core::mem::size_of::<i32>(); // zero-point offset is stored as i32
-                Some(*bytemuck::checked::from_bytes::<i32>(
-                    &qparams_bytes
-                        [total_bytes - scale_size - offset_size..total_bytes - scale_size],
-                ) as i8)
-            }
-            QuantizationScheme::PerTensor(QuantizationMode::Symmetric, _) => None,
-            QuantizationScheme::PerBlock(_mode, _dtype, _block_layout) => todo!(),
-        };
+        let scales_size = scale_size * num_params;
+
+        let scale = bytemuck::cast_slice(&qparams_bytes[total_bytes - scales_size..]).to_vec();
+        let mut offset = None;
+
+        if scheme.mode() == QuantizationMode::Affine {
+            // Bytes end with [offset, offset, offset, ...]
+            let offset_size = core::mem::size_of::<i32>(); // zero-point offset is stored as i32
+            let offsets_size = offset_size * num_params;
+            let offsets: &[i32] = bytemuck::cast_slice(
+                &qparams_bytes[total_bytes - scales_size - offsets_size..total_bytes - scales_size],
+            );
+
+            offset = Some(offsets.iter().map(|&x| x as i8).collect());
+        }
 
         (values, QParams { scale, offset })
     }
@@ -103,7 +141,7 @@ impl QuantizedBytes {
     /// Splits the quantized values of the tensor from the quantization parameters.
     ///
     /// Returns the packed values and a newly allocated vector containing the quantization parameters.
-    fn split_values_off(self) -> (Vec<u32>, Vec<u32>) {
+    fn split_values_off(self) -> (Vec<u32>, (Vec<u32>, usize)) {
         // The bytes can be created either from packed u32 or existing bytes with the same representation.
         let mut values = match self.bytes.align() {
             1 => {
@@ -122,35 +160,80 @@ impl QuantizedBytes {
             _ => unreachable!(),
         };
 
-        let scale_size = 1; // f32 scale is the same number of bytes as u32
+        let (num_params, mode) = match self.scheme {
+            QuantizationScheme::PerTensor(mode, ..) => (1, mode),
+            QuantizationScheme::PerBlock(mode, _, layout) => {
+                let num_blocks = match layout {
+                    BlockLayout::Flat(block_size) => self.num_elements / block_size as usize,
+                    BlockLayout::Grid(m, n) => self.num_elements / (m * n) as usize,
+                };
+                (num_blocks, mode)
+            }
+        };
+
+        let scale_size = num_params; // f32 scale is the same number of bytes as u32
         let mut values_end = values.len() - scale_size;
 
-        if let QuantizationScheme::PerTensor(QuantizationMode::Affine, _) = self.scheme {
-            values_end -= 1; // zero-point offset is stored as i32 (same number of bytes as u32)
+        if mode == QuantizationMode::Affine {
+            values_end -= num_params; // zero-point offset is stored as i32 (same number of bytes as u32)
         }
 
         let qparams = values.split_off(values_end);
 
-        (values, qparams)
+        (values, (qparams, num_params))
     }
 
     /// Dequantizes the data according to its quantization scheme.
-    pub fn dequantize(self) -> (Vec<f32>, QParams<f32, i8>) {
+    pub fn dequantize(self, shape: &[usize]) -> (Vec<f32>, QParams<Vec<f32>, Vec<i8>>) {
         match self.scheme {
             QuantizationScheme::PerTensor(QuantizationMode::Affine, QuantizationType::QInt8) => {
                 let (values, qparams) = self.into_vec_i8();
-                let strategy = AffineQuantization::<f32, i8, i32>::init(
-                    qparams.scale,
-                    qparams.offset.unwrap(),
-                );
-                (strategy.dequantize(&values), qparams)
+                let strategy = QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(
+                    qparams.scale[0],
+                    qparams.offset.as_ref().unwrap()[0],
+                ));
+                (strategy.dequantize(&values, shape), qparams)
             }
             QuantizationScheme::PerTensor(QuantizationMode::Symmetric, QuantizationType::QInt8) => {
                 let (values, qparams) = self.into_vec_i8();
-                let strategy = SymmetricQuantization::<f32, i8>::init(qparams.scale);
-                (strategy.dequantize(&values), qparams)
+                let strategy = QuantizationStrategy::PerTensorSymmetricInt8(
+                    SymmetricQuantization::init(qparams.scale[0]),
+                );
+                (strategy.dequantize(&values, shape), qparams)
             }
-            QuantizationScheme::PerBlock(_mode, _dtype, _block_layout) => todo!(),
+            QuantizationScheme::PerBlock(
+                QuantizationMode::Affine,
+                QuantizationType::QInt8,
+                layout,
+            ) => {
+                let (values, qparams) = self.into_vec_i8();
+                let strategy = QuantizationStrategy::PerBlockAffineInt8(
+                    qparams
+                        .scale
+                        .iter()
+                        .zip(qparams.offset.as_ref().unwrap().iter())
+                        .map(|(&s, &o)| AffineQuantization::init(s, o))
+                        .collect(),
+                    layout,
+                );
+                (strategy.dequantize(&values, shape), qparams)
+            }
+            QuantizationScheme::PerBlock(
+                QuantizationMode::Symmetric,
+                QuantizationType::QInt8,
+                layout,
+            ) => {
+                let (values, qparams) = self.into_vec_i8();
+                let strategy = QuantizationStrategy::PerBlockSymmetricInt8(
+                    qparams
+                        .scale
+                        .iter()
+                        .map(|&s| SymmetricQuantization::init(s))
+                        .collect(),
+                    layout,
+                );
+                (strategy.dequantize(&values, shape), qparams)
+            }
         }
     }
 }
@@ -187,11 +270,12 @@ unsafe fn reinterpret_vec<T, U>(mut input: Vec<T>) -> Vec<U> {
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
     use alloc::vec;
 
     #[test]
-    fn should_pack_unpack_quantization_parameters_symmetric() {
+    fn should_pack_unpack_quantization_parameters_per_tensor_symmetric() {
         // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
         let scale = 0.03937008;
         let values = vec![0i8, 25, 51, 76, 102, 127];
@@ -203,14 +287,14 @@ mod tests {
 
         let (q_values, qparams) = q_bytes.into_vec_i8();
 
-        assert_eq!(qparams.scale, scale);
+        assert_eq!(qparams.scale, vec![scale]);
         assert_eq!(qparams.offset, None);
 
         assert_eq!(q_values, values);
     }
 
     #[test]
-    fn should_pack_unpack_quantization_parameters_affine() {
+    fn should_pack_unpack_quantization_parameters_per_tensor_affine() {
         let scale = 0.019607844;
         let offset = -128;
         // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
@@ -222,8 +306,33 @@ mod tests {
 
         let (q_values, qparams) = q_bytes.into_vec_i8();
 
+        assert_eq!(qparams.scale, vec![scale]);
+        assert_eq!(qparams.offset, Some(vec![offset]));
+
+        assert_eq!(q_values, values);
+    }
+
+    #[test]
+    fn should_pack_unpack_quantization_parameters_per_block_symmetric() {
+        // Quantized 2x2 blocks: [[-1.8, -1.0, 0.0, 0.5], [-0.8, 1.2, 0.25, 0.5]]
+        let scale = vec![0.014_173_228, 0.009_448_819];
+        let values = vec![-127i8, -71, -85, 127, 0, 35, 26, 53];
+
+        let q_bytes = QuantizedBytes::new(
+            values.clone(),
+            QuantizationStrategy::PerBlockSymmetricInt8(
+                vec![
+                    SymmetricQuantization::init(scale[0]),
+                    SymmetricQuantization::init(scale[1]),
+                ],
+                BlockLayout::Grid(2, 2),
+            ),
+        );
+
+        let (q_values, qparams) = q_bytes.into_vec_i8();
+
         assert_eq!(qparams.scale, scale);
-        assert_eq!(qparams.offset, Some(offset));
+        assert_eq!(qparams.offset, None);
 
         assert_eq!(q_values, values);
     }

--- a/crates/burn-tensor/src/tensor/quantization/calibration.rs
+++ b/crates/burn-tensor/src/tensor/quantization/calibration.rs
@@ -3,9 +3,9 @@ use crate::{backend::Backend, Tensor};
 /// The observed input calibration range.
 #[derive(Clone, Debug)]
 pub struct CalibrationRange<B: Backend> {
-    /// Minimum observed value.
+    /// Minimum observed value(s).
     pub min: Tensor<B, 1>,
-    /// Maximum observed value.
+    /// Maximum observed value(s).
     pub max: Tensor<B, 1>,
 }
 
@@ -19,7 +19,10 @@ pub trait Calibration {
 }
 
 /// Computes the per-tensor quantization range mapping based on the min and max values.
-pub struct MinMaxCalibration {}
+pub struct MinMaxCalibration {
+    // /// Quantization granularity.
+    // pub granularity:
+}
 
 impl Calibration for MinMaxCalibration {
     fn compute_range<B: Backend, const D: usize>(

--- a/crates/burn-tensor/src/tensor/quantization/calibration.rs
+++ b/crates/burn-tensor/src/tensor/quantization/calibration.rs
@@ -10,28 +10,7 @@ pub struct CalibrationRange<B: Backend> {
 }
 
 /// Calibration method used to compute the quantization range mapping.
-pub trait Calibration {
-    /// Compute the input tensor range.
-    fn compute_range<B: Backend, const D: usize>(
-        &self,
-        tensor: &Tensor<B, D>,
-    ) -> CalibrationRange<B>;
-}
-
-/// Computes the per-tensor quantization range mapping based on the min and max values.
-pub struct MinMaxCalibration {
-    // /// Quantization granularity.
-    // pub granularity:
-}
-
-impl Calibration for MinMaxCalibration {
-    fn compute_range<B: Backend, const D: usize>(
-        &self,
-        tensor: &Tensor<B, D>,
-    ) -> CalibrationRange<B> {
-        let min = tensor.clone().min();
-        let max = tensor.clone().max();
-
-        CalibrationRange { min, max }
-    }
+pub enum Calibration {
+    /// Computes quantization range mapping based on the min and max values.
+    MinMax,
 }

--- a/crates/burn-tensor/src/tensor/quantization/scheme.rs
+++ b/crates/burn-tensor/src/tensor/quantization/scheme.rs
@@ -17,18 +17,34 @@ pub enum QuantizationType {
     QInt8,
 }
 
+// CubeType not implemented for usize
+/// Block quantization layout.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "cubecl", derive(CubeType, PartialOrd, Ord))]
+pub enum BlockLayout {
+    /// The tensor is split into linear segments of N elements.
+    Flat(u32),
+    /// The tensor is split into segments of M x N elements.
+    Grid(u32, u32),
+}
+/// Quantization mode.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "cubecl", derive(PartialOrd, Ord))]
+pub enum QuantizationMode {
+    /// Affine or asymmetric quantization.
+    Affine,
+    /// Symmetric or scale quantization.
+    Symmetric,
+}
+
 /// Quantization scheme.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "cubecl", derive(PartialOrd, Ord))]
 pub enum QuantizationScheme {
-    /// Per-tensor affine/asymmetric quantization.
-    PerTensorAffine(QuantizationType),
-    /// Per-tensor symmetric quantization.
-    PerTensorSymmetric(QuantizationType),
-    // /// Per-channel affine/asymmetric quantization.
-    // PerChannelAffine,
-    // /// Per-channel symmetric quantization.
-    // PerChannelSymmetric,
+    /// Per-tensor quantization.
+    PerTensor(QuantizationMode, QuantizationType),
+    /// Per-block quantization.
+    PerBlock(QuantizationMode, QuantizationType, BlockLayout),
 }
 
 #[cfg(feature = "cubecl")]
@@ -53,43 +69,40 @@ impl QuantizationScheme {
         range: CalibrationRange<B>,
     ) -> QuantizationParameters<B> {
         match self {
-            QuantizationScheme::PerTensorAffine(dtype) => match dtype {
-                QuantizationType::QInt8 => {
-                    // Quantized range `[a, b]`
-                    let a = i8::MIN as i32;
-                    let b = i8::MAX as i32;
+            QuantizationScheme::PerTensor(QuantizationMode::Affine, QuantizationType::QInt8) => {
+                // Quantized range `[a, b]`
+                let a = i8::MIN as i32;
+                let b = i8::MAX as i32;
 
-                    // We extend the `[min, max]` interval to ensure that it contains 0.
-                    // Otherwise, we would not meet the requirement that 0 be an exactly
-                    // representable value (zero-point).
-                    let zero = Tensor::zeros_like(&range.min);
-                    let min = range.min.min_pair(zero);
-                    let zero = Tensor::zeros_like(&range.max);
-                    let max = range.max.max_pair(zero);
+                // We extend the `[min, max]` interval to ensure that it contains 0.
+                // Otherwise, we would not meet the requirement that 0 be an exactly
+                // representable value (zero-point).
+                let zero = Tensor::zeros_like(&range.min);
+                let min = range.min.min_pair(zero);
+                let zero = Tensor::zeros_like(&range.max);
+                let max = range.max.max_pair(zero);
 
-                    // If scale is 0 (most likely due to a tensor full of zeros), we arbitrarily adjust the
-                    // scale to 0.1 to avoid division by zero.
-                    let scale = max.sub(min.clone()).div_scalar(b - a);
-                    let scale = scale.clone().mask_fill(scale.equal_elem(0.), 0.1);
-                    let offset = Some(-(min.div(scale.clone()).sub_scalar(a)).int());
-                    QuantizationParameters { scale, offset }
+                // If scale is 0 (most likely due to a tensor full of zeros), we arbitrarily adjust the
+                // scale to 0.1 to avoid division by zero.
+                let scale = max.sub(min.clone()).div_scalar(b - a);
+                let scale = scale.clone().mask_fill(scale.equal_elem(0.), 0.1);
+                let offset = Some(-(min.div(scale.clone()).sub_scalar(a)).int());
+                QuantizationParameters { scale, offset }
+            }
+            QuantizationScheme::PerTensor(QuantizationMode::Symmetric, QuantizationType::QInt8) => {
+                // Quantized range `[a, b]`
+                let b = i8::MAX as i32;
+                let a = -b;
+
+                // Compute scale to convert an input value in range `[-alpha, alpha]`
+                let values_range = range.min.abs().max_pair(range.max.abs()).mul_scalar(2);
+
+                QuantizationParameters {
+                    scale: values_range.div_scalar(b - a),
+                    offset: None,
                 }
-            },
-            QuantizationScheme::PerTensorSymmetric(dtype) => match dtype {
-                QuantizationType::QInt8 => {
-                    // Quantized range `[a, b]`
-                    let b = i8::MAX as i32;
-                    let a = -b;
-
-                    // Compute scale to convert an input value in range `[-alpha, alpha]`
-                    let values_range = range.min.abs().max_pair(range.max.abs()).mul_scalar(2);
-
-                    QuantizationParameters {
-                        scale: values_range.div_scalar(b - a),
-                        offset: None,
-                    }
-                }
-            },
+            }
+            QuantizationScheme::PerBlock(_mode, _dtype, _block_layout) => todo!(),
         }
     }
 

--- a/crates/burn-tensor/src/tensor/quantization/scheme.rs
+++ b/crates/burn-tensor/src/tensor/quantization/scheme.rs
@@ -171,8 +171,13 @@ impl QuantizationScheme {
         &self,
         range: CalibrationRange<B>,
     ) -> QuantizationParameters<B> {
+        // Quantization parameters are computed element-wise based on the calibration range,
+        // so it's the same operations for per-tensor and per-block (just that the latter has
+        // more parameters)
         match self {
-            QuantizationScheme::PerTensor(QuantizationMode::Affine, QuantizationType::QInt8) => {
+            QuantizationScheme::PerTensor(QuantizationMode::Affine, QuantizationType::QInt8)
+            | QuantizationScheme::PerBlock(QuantizationMode::Affine, QuantizationType::QInt8, ..) =>
+            {
                 // Quantized range `[a, b]`
                 let a = i8::MIN as i32;
                 let b = i8::MAX as i32;
@@ -192,7 +197,12 @@ impl QuantizationScheme {
                 let offset = Some(-(min.div(scale.clone()).sub_scalar(a)).int());
                 QuantizationParameters { scale, offset }
             }
-            QuantizationScheme::PerTensor(QuantizationMode::Symmetric, QuantizationType::QInt8) => {
+            QuantizationScheme::PerTensor(QuantizationMode::Symmetric, QuantizationType::QInt8)
+            | QuantizationScheme::PerBlock(
+                QuantizationMode::Symmetric,
+                QuantizationType::QInt8,
+                ..,
+            ) => {
                 // Quantized range `[a, b]`
                 let b = i8::MAX as i32;
                 let a = -b;
@@ -205,7 +215,6 @@ impl QuantizationScheme {
                     offset: None,
                 }
             }
-            QuantizationScheme::PerBlock(_mode, _dtype, _block_layout) => todo!(),
         }
     }
 

--- a/crates/burn-tensor/src/tensor/quantization/scheme.rs
+++ b/crates/burn-tensor/src/tensor/quantization/scheme.rs
@@ -65,6 +65,15 @@ impl cubecl::frontend::Init for QuantizationScheme {
 }
 
 impl QuantizationScheme {
+    /// Get the [quantization mode](QuantizationMode)
+    pub fn mode(&self) -> QuantizationMode {
+        match self {
+            QuantizationScheme::PerTensor(mode, ..) | QuantizationScheme::PerBlock(mode, ..) => {
+                *mode
+            }
+        }
+    }
+
     /// Compute the quantization range mapping.
     pub fn compute_range<B: Backend, const D: usize>(
         &self,

--- a/crates/burn-tensor/src/tensor/quantization/strategy.rs
+++ b/crates/burn-tensor/src/tensor/quantization/strategy.rs
@@ -8,7 +8,7 @@ use burn_common::{iter_slice_par, run_par};
 use num_traits::{Float, PrimInt};
 use serde::{Deserialize, Serialize};
 
-use super::{QuantizationScheme, QuantizationType};
+use super::{QuantizationMode, QuantizationScheme, QuantizationType};
 
 /// Quantization strategy.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize)]
@@ -24,10 +24,10 @@ impl QuantizationStrategy {
     pub fn scheme(&self) -> QuantizationScheme {
         match self {
             QuantizationStrategy::PerTensorAffineInt8(_) => {
-                QuantizationScheme::PerTensorAffine(QuantizationType::QInt8)
+                QuantizationScheme::PerTensor(QuantizationMode::Affine, QuantizationType::QInt8)
             }
             QuantizationStrategy::PerTensorSymmetricInt8(_) => {
-                QuantizationScheme::PerTensorSymmetric(QuantizationType::QInt8)
+                QuantizationScheme::PerTensor(QuantizationMode::Symmetric, QuantizationType::QInt8)
             }
         }
     }

--- a/crates/burn-tensor/src/tensor/quantization/strategy.rs
+++ b/crates/burn-tensor/src/tensor/quantization/strategy.rs
@@ -478,14 +478,14 @@ mod tests {
         .concat();
 
         // Affine quantization for each block with range min/max
-        let per_block_strat = vec![
+        let per_block_strategy = vec![
             AffineQuantization::<f32, i8, i32>::new(-1.8, 0.5),
             AffineQuantization::<f32, i8, i32>::new(-0.8, 1.2),
             AffineQuantization::<f32, i8, i32>::new(-0.08, 0.12),
             AffineQuantization::<f32, i8, i32>::new(0.2, 0.5),
         ];
         let strategy =
-            QuantizationStrategy::PerBlockAffineInt8(per_block_strat, BlockLayout::Flat(4));
+            QuantizationStrategy::PerBlockAffineInt8(per_block_strategy, BlockLayout::Flat(4));
 
         let q: Vec<i8> = strategy.quantize(&x, shape);
         assert_eq!(q, expected_q);
@@ -560,7 +560,7 @@ mod tests {
         .concat();
 
         // Symmetric quantization for each block with range min/max
-        let per_block_strat = vec![
+        let per_block_strategy = vec![
             SymmetricQuantization::<f32, i8>::new(-1.8, 0.5),
             SymmetricQuantization::<f32, i8>::new(-0.8, 1.2),
             SymmetricQuantization::<f32, i8>::new(-0.08, 0.12),
@@ -570,8 +570,10 @@ mod tests {
             SymmetricQuantization::<f32, i8>::new(0.1, 0.4),
             SymmetricQuantization::<f32, i8>::new(-1.8, 0.5),
         ];
-        let strategy =
-            QuantizationStrategy::PerBlockSymmetricInt8(per_block_strat, BlockLayout::Grid(2, 2));
+        let strategy = QuantizationStrategy::PerBlockSymmetricInt8(
+            per_block_strategy,
+            BlockLayout::Grid(2, 2),
+        );
 
         let q: Vec<i8> = strategy.quantize(&x, shape);
         assert_eq!(q, expected_q);

--- a/crates/burn-tensor/src/tensor/quantization/strategy.rs
+++ b/crates/burn-tensor/src/tensor/quantization/strategy.rs
@@ -116,7 +116,6 @@ fn apply_per_block_grid<I: Element, O: Element, F: Fn(usize, I) -> O>(
                 // block width
                 for bw in 0..n {
                     let elem_idx = start_idx + bw;
-                    // let x_q = strategy[block_id].quantize_one(values[elem_idx]);
                     let x_q = transform(block_id, values[elem_idx]);
                     output[elem_idx] = x_q;
                 }

--- a/crates/burn-tensor/src/tensor/quantization/strategy.rs
+++ b/crates/burn-tensor/src/tensor/quantization/strategy.rs
@@ -1,7 +1,6 @@
-use core::marker::PhantomData;
-
-use alloc::vec::Vec;
+use alloc::{vec, vec::Vec};
 use burn_common::{iter_slice_par, run_par};
+use core::marker::PhantomData;
 use num_traits::{Float, PrimInt, Signed};
 use serde::{Deserialize, Serialize};
 
@@ -376,7 +375,6 @@ impl<E: Float + Send + Sync, Q: PrimInt + Signed + Send + Sync> Eq for Symmetric
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloc::vec;
 
     #[test]
     fn test_int8_affine_quantization() {

--- a/crates/burn-tensor/src/tests/mod.rs
+++ b/crates/burn-tensor/src/tests/mod.rs
@@ -84,7 +84,7 @@ macro_rules! testgen_quantization {
 
             use burn_tensor::{
                 backend::Backend,
-                quantization::{QuantizationScheme, QuantizationType},
+                quantization::{QuantizationMode, QuantizationScheme, QuantizationType},
                 Tensor, TensorData,
             };
 
@@ -101,13 +101,19 @@ macro_rules! testgen_quantization {
                 /// Creates a quantized int8 tensor from the floating point data using per-tensor symmetric quantization.
                 pub fn int8_symmetric<F: Into<TensorData>>(floats: F) -> Tensor<B, D> {
                     Tensor::from_floats(floats, &Default::default()).quantize_dynamic(
-                        &QuantizationScheme::PerTensorSymmetric(QuantizationType::QInt8),
+                        &QuantizationScheme::PerTensor(
+                            QuantizationMode::Symmetric,
+                            QuantizationType::QInt8,
+                        ),
                     )
                 }
                 /// Creates a quantized int8 tensor from the floating point data using per-tensor affine quantization.
                 pub fn int8_affine<F: Into<TensorData>>(floats: F) -> Tensor<B, D> {
                     Tensor::from_floats(floats, &Default::default()).quantize_dynamic(
-                        &QuantizationScheme::PerTensorAffine(QuantizationType::QInt8),
+                        &QuantizationScheme::PerTensor(
+                            QuantizationMode::Affine,
+                            QuantizationType::QInt8,
+                        ),
                     )
                 }
             }

--- a/crates/burn-tensor/src/tests/mod.rs
+++ b/crates/burn-tensor/src/tests/mod.rs
@@ -8,7 +8,6 @@ mod stats;
 
 pub use cubecl::prelude::{Float, Int, Numeric};
 
-// TODO: testgen with markers for expected failures (i.e., known ops that are unsupported)?
 #[allow(missing_docs)]
 #[macro_export]
 macro_rules! testgen_all {

--- a/crates/burn-tensor/src/tests/mod.rs
+++ b/crates/burn-tensor/src/tests/mod.rs
@@ -8,6 +8,7 @@ mod stats;
 
 pub use cubecl::prelude::{Float, Int, Numeric};
 
+// TODO: testgen with markers for expected failures (i.e., known ops that are unsupported)?
 #[allow(missing_docs)]
 #[macro_export]
 macro_rules! testgen_all {

--- a/crates/burn-tensor/src/tests/quantization/calibration.rs
+++ b/crates/burn-tensor/src/tests/quantization/calibration.rs
@@ -2,16 +2,20 @@
 mod tests {
     use super::*;
     use burn_tensor::{
-        quantization::{Calibration, MinMaxCalibration, QuantizationType},
+        quantization::{
+            BlockLayout, Calibration, QuantizationMode, QuantizationScheme, QuantizationType,
+        },
         Tensor, TensorData,
     };
 
+    // NOTE: The scheme variant fields are not important for calibration, only the "main" variant (e.g., per-tensor)
     #[test]
-    fn min_max_calibration_range() {
+    fn min_max_calibration_range_per_tensor() {
         let tensor = TestTensor::<1>::from_floats([-1.8, -1.0, 0.0, 0.5], &Default::default());
-        let calibration = MinMaxCalibration {};
+        let scheme =
+            QuantizationScheme::PerTensor(QuantizationMode::Affine, QuantizationType::QInt8);
 
-        let range = calibration.compute_range(&tensor);
+        let range = scheme.compute_range(&tensor, &Calibration::MinMax);
 
         range
             .min
@@ -21,5 +25,107 @@ mod tests {
             .max
             .into_data()
             .assert_eq(&TensorData::from([0.5]), false);
+    }
+
+    #[test]
+    fn min_max_calibration_range_per_block_flat_all() {
+        let tensor = TestTensor::<2>::from_floats(
+            [[-1.8, -1.0, 0.0, 0.5], [1., 2., 3., 4.]],
+            &Default::default(),
+        );
+        let scheme = QuantizationScheme::PerBlock(
+            QuantizationMode::Affine,
+            QuantizationType::QInt8,
+            BlockLayout::Flat(8),
+        );
+
+        let range = scheme.compute_range(&tensor, &Calibration::MinMax);
+
+        range
+            .min
+            .into_data()
+            .assert_eq(&TensorData::from([-1.8]), false);
+        range
+            .max
+            .into_data()
+            .assert_eq(&TensorData::from([4.]), false);
+    }
+
+    #[test]
+    fn min_max_calibration_range_per_block_flat_row() {
+        let tensor = TestTensor::<2>::from_floats(
+            [[-1.8, -1.0, 0.0, 0.5], [1., 2., 3., 4.]],
+            &Default::default(),
+        );
+        let scheme = QuantizationScheme::PerBlock(
+            QuantizationMode::Affine,
+            QuantizationType::QInt8,
+            BlockLayout::Flat(4),
+        );
+
+        let range = scheme.compute_range(&tensor, &Calibration::MinMax);
+        range
+            .min
+            .into_data()
+            .assert_eq(&TensorData::from([-1.8, 1.]), false);
+        range
+            .max
+            .into_data()
+            .assert_eq(&TensorData::from([0.5, 4.]), false);
+    }
+
+    #[test]
+    #[should_panic(expected = "Cannot compute per-block quantization range")]
+    fn min_max_calibration_range_per_block_flat_invalid() {
+        let tensor = TestTensor::<2>::from_floats(
+            [[-1.8, -1.0, 0.0, 0.5], [1., 2., 3., 4.]],
+            &Default::default(),
+        );
+        let scheme = QuantizationScheme::PerBlock(
+            QuantizationMode::Affine,
+            QuantizationType::QInt8,
+            BlockLayout::Flat(3),
+        );
+        let _ = scheme.compute_range(&tensor, &Calibration::MinMax);
+    }
+
+    #[test]
+    fn min_max_calibration_range_per_block_grid() {
+        let tensor = TestTensor::<2>::from_floats(
+            [[-1.8, -1.0, 0.0, 0.5], [1., 2., 3., 4.]],
+            &Default::default(),
+        );
+        let scheme = QuantizationScheme::PerBlock(
+            QuantizationMode::Affine,
+            QuantizationType::QInt8,
+            BlockLayout::Grid(2, 2),
+        );
+
+        let range = scheme.compute_range(&tensor, &Calibration::MinMax);
+
+        range
+            .min
+            .into_data()
+            .assert_eq(&TensorData::from([-1.8, 0.]), false);
+        range
+            .max
+            .into_data()
+            .assert_eq(&TensorData::from([2., 4.]), false);
+    }
+
+    #[test]
+    #[should_panic(expected = "Cannot compute per-block quantization range")]
+    fn min_max_calibration_range_per_block_grid_invalid() {
+        let tensor = TestTensor::<2>::from_floats(
+            [[-1.8, -1.0, 0.0, 0.5], [1., 2., 3., 4.]],
+            &Default::default(),
+        );
+        let scheme = QuantizationScheme::PerBlock(
+            QuantizationMode::Affine,
+            QuantizationType::QInt8,
+            BlockLayout::Grid(3, 3),
+        );
+
+        let _ = scheme.compute_range(&tensor, &Calibration::MinMax);
     }
 }

--- a/crates/burn-tensor/src/tests/quantization/ops/quantize.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/quantize.rs
@@ -3,7 +3,7 @@ mod tests {
     use super::*;
     use burn_tensor::ops::QTensorOps;
     use burn_tensor::quantization::{
-        AffineQuantization, QParams, QuantizationParameters, QuantizationScheme,
+        AffineQuantization, QParams, QuantizationMode, QuantizationParameters, QuantizationScheme,
         QuantizationStrategy, QuantizationType, QuantizedBytes, SymmetricQuantization,
     };
     use burn_tensor::{DType, Tensor, TensorData};
@@ -27,7 +27,8 @@ mod tests {
     fn should_support_quantize_affine_int8() {
         let device = Default::default();
         let tensor = TestTensor::<1>::from_floats([-1.8, -1.0, 0.0, 0.5], &device);
-        let scheme = QuantizationScheme::PerTensorAffine(QuantizationType::QInt8);
+        let scheme =
+            QuantizationScheme::PerTensor(QuantizationMode::Affine, QuantizationType::QInt8);
         let qparams = QuantizationParameters {
             scale: Tensor::from_floats([0.009_019_608], &device),
             offset: Some(Tensor::from_ints([72], &device)),
@@ -55,7 +56,8 @@ mod tests {
     fn should_support_quantize_symmetric_int8() {
         let device = Default::default();
         let tensor = TestTensor::<1>::from_floats([-1.8, -1.0, 0.0, 0.5], &device);
-        let scheme = QuantizationScheme::PerTensorSymmetric(QuantizationType::QInt8);
+        let scheme =
+            QuantizationScheme::PerTensor(QuantizationMode::Symmetric, QuantizationType::QInt8);
         let qparams = QuantizationParameters {
             scale: Tensor::from_floats([0.014_173_228], &device),
             offset: None,
@@ -107,7 +109,8 @@ mod tests {
         // NOTE: we use fully representable values since different backend implementations could differ slightly
         // due to rounding discrepancies
         let tensor = TestTensor::<1>::from_floats([5., 0., 4., -10.], &device);
-        let scheme = QuantizationScheme::PerTensorAffine(QuantizationType::QInt8);
+        let scheme =
+            QuantizationScheme::PerTensor(QuantizationMode::Affine, QuantizationType::QInt8);
 
         let x_q = tensor.quantize_dynamic(&scheme);
 

--- a/crates/burn-tensor/src/tests/quantization/ops/quantize.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/quantize.rs
@@ -203,6 +203,7 @@ mod tests {
         x.into_data().assert_approx_eq(&tensor.into_data(), 2);
     }
 
+    // TODO: block_size 8 (block_size > line_size)
     #[test]
     fn should_support_quantize_per_block_affine_int8() {
         let device = Default::default();

--- a/crates/burn-tensor/src/tests/quantization/ops/quantize.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/quantize.rs
@@ -35,8 +35,9 @@ mod tests {
             offset: Some(Tensor::from_ints([72], &device)),
         };
 
-        let x_q = tensor.quantize(&scheme, qparams).into_data();
+        let x_q = tensor.clone().quantize(&scheme, qparams);
 
+        let x_q_data = x_q.to_data();
         let expected = TensorData::quantized(
             vec![-128i8, -39, 72, 127],
             [4],
@@ -44,15 +45,21 @@ mod tests {
         );
 
         // Values equality
-        x_q.assert_eq(&expected, true);
+        x_q_data.assert_eq(&expected, true);
 
         // Quantization parameters check
-        let qparams = get_q_params(x_q);
+        let qparams = get_q_params(x_q_data);
         let expected = get_q_params(expected);
         assert_eq!(qparams.scale.len(), 1);
         assert_eq!(qparams.scale, expected.scale);
         assert_eq!(qparams.offset.as_ref().map(|x| x.len()), Some(1));
         assert_eq!(qparams.offset, expected.offset);
+
+        // Dequantize
+        let x = x_q.dequantize();
+
+        // Precision 2 for dequantization errors
+        x.into_data().assert_approx_eq(&tensor.into_data(), 2);
     }
 
     #[test]
@@ -66,8 +73,9 @@ mod tests {
             offset: None,
         };
 
-        let x_q = tensor.quantize(&scheme, qparams).into_data();
+        let x_q = tensor.clone().quantize(&scheme, qparams);
 
+        let x_q_data = x_q.to_data();
         let expected = TensorData::quantized(
             vec![-127i8, -71, 0, 35],
             [4],
@@ -77,35 +85,21 @@ mod tests {
         );
 
         // Values equality
-        x_q.assert_eq(&expected, true);
+        x_q_data.assert_eq(&expected, true);
 
         // Quantization parameters check
-        let qparams = get_q_params(x_q);
+        let qparams = get_q_params(x_q_data);
         let expected = get_q_params(expected);
         assert_eq!(qparams.scale.len(), 1);
         assert_eq!(qparams.scale, expected.scale);
         assert_eq!(qparams.offset, None);
         assert_eq!(qparams.offset, expected.offset);
-    }
 
-    #[test]
-    fn should_support_dequantize() {
-        let device = Default::default();
-        // Quantized [-1.8, -1.0, 0.0, 0.5]
-        let data = TensorData::quantized(
-            vec![-127i8, -71, 0, 35],
-            [4],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(
-                0.014_173_228,
-            )),
-        );
-        let x_q = TestTensor::<1>::from_data(data, &device);
-
+        // Dequantize
         let x = x_q.dequantize();
 
         // Precision 2 for dequantization errors
-        x.into_data()
-            .assert_approx_eq(&TensorData::from([-1.8, -1.0, 0.0, 0.5]), 2);
+        x.into_data().assert_approx_eq(&tensor.into_data(), 2);
     }
 
     #[test]
@@ -166,8 +160,9 @@ mod tests {
             offset: None,
         };
 
-        let x_q = tensor.quantize(&scheme, qparams).into_data();
+        let x_q = tensor.clone().quantize(&scheme, qparams);
 
+        let x_q_data = x_q.to_data();
         let expected = TensorData::quantized(
             vec![
                 [-127i8, -71, 0, 35],
@@ -191,15 +186,21 @@ mod tests {
         );
 
         // Values equality
-        x_q.assert_eq(&expected, true);
+        x_q_data.assert_eq(&expected, true);
 
         // Quantization parameters check
-        let qparams = get_q_params(x_q);
+        let qparams = get_q_params(x_q_data);
         let expected = get_q_params(expected);
         assert_eq!(qparams.scale.len(), 8);
         assert_eq!(qparams.scale, expected.scale);
         assert_eq!(qparams.offset, None);
         assert_eq!(qparams.offset, expected.offset);
+
+        // Dequantize
+        let x = x_q.dequantize();
+
+        // Precision 2 for dequantization errors
+        x.into_data().assert_approx_eq(&tensor.into_data(), 2);
     }
 
     #[test]
@@ -226,8 +227,9 @@ mod tests {
             offset: Some(Tensor::from_ints(offsets, &device)),
         };
 
-        let x_q = tensor.quantize(&scheme, qparams).into_data();
+        let x_q = tensor.clone().quantize(&scheme, qparams);
 
+        let x_q_data = x_q.to_data();
         let expected = TensorData::quantized(
             vec![
                 [-128i8, -40, 71, 126],
@@ -248,15 +250,21 @@ mod tests {
         );
 
         // Values equality
-        x_q.assert_eq(&expected, true);
+        x_q_data.assert_eq(&expected, true);
 
         // Quantization parameters check
-        let qparams = get_q_params(x_q);
+        let qparams = get_q_params(x_q_data);
         let expected = get_q_params(expected);
         assert_eq!(qparams.scale.len(), 4);
         assert_eq!(qparams.scale, expected.scale);
         assert_eq!(qparams.offset.as_ref().unwrap().len(), 4);
         assert_eq!(qparams.offset, expected.offset);
+
+        // Dequantize
+        let x = x_q.dequantize();
+
+        // Precision 2 for dequantization errors
+        x.into_data().assert_approx_eq(&tensor.into_data(), 2);
     }
 
     #[test]
@@ -301,8 +309,9 @@ mod tests {
             offset: None,
         };
 
-        let x_q = tensor.quantize(&scheme, qparams).into_data();
+        let x_q = tensor.clone().quantize(&scheme, qparams);
 
+        let x_q_data = x_q.to_data();
         let expected = TensorData::quantized(
             vec![
                 [-127i8, -71, -85, 127],
@@ -326,14 +335,20 @@ mod tests {
         );
 
         // Values equality
-        x_q.assert_eq(&expected, true);
+        x_q_data.assert_eq(&expected, true);
 
         // Quantization parameters check
-        let qparams = get_q_params(x_q);
+        let qparams = get_q_params(x_q_data);
         let expected = get_q_params(expected);
         assert_eq!(qparams.scale.len(), 8);
         assert_eq!(qparams.scale, expected.scale);
         assert_eq!(qparams.offset, None);
         assert_eq!(qparams.offset, expected.offset);
+
+        // Dequantize
+        let x = x_q.dequantize();
+
+        // Precision 2 for dequantization errors
+        x.into_data().assert_approx_eq(&tensor.into_data(), 2);
     }
 }

--- a/crates/burn-tensor/src/tests/quantization/ops/quantize.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/quantize.rs
@@ -203,7 +203,67 @@ mod tests {
         x.into_data().assert_approx_eq(&tensor.into_data(), 2);
     }
 
-    // TODO: block_size 8 (block_size > line_size)
+    #[test]
+    fn should_support_quantize_per_block_flat() {
+        let device = Default::default();
+        let tensor = TestTensor::<2>::from_floats(
+            [
+                [-1.8, -1.0, 0.0, 0.5, -0.8, 1.2, 0.25, 0.5],
+                [-0.08, 0.12, 0.025, 0.05, 0.2, 0.3, 0.4, 0.5],
+            ],
+            &device,
+        );
+        // block_size > line_size
+        let scheme = QuantizationScheme::PerBlock(
+            QuantizationMode::Symmetric,
+            QuantizationType::QInt8,
+            BlockLayout::Flat(8),
+        );
+
+        // Per-block qparams
+        let scales: [f32; 2] = [0.014173228, 0.003937008];
+        let qparams = QuantizationParameters {
+            scale: Tensor::from_floats(scales, &device),
+            offset: None,
+        };
+
+        let x_q = tensor.clone().quantize(&scheme, qparams);
+
+        let x_q_data = x_q.to_data();
+        let expected = TensorData::quantized(
+            vec![
+                [-127i8, -71, 0, 35, -56, 85, 18, 35],
+                [-20, 30, 6, 13, 51, 76, 102, 127],
+            ]
+            .concat(),
+            [2, 8],
+            QuantizationStrategy::PerBlockSymmetricInt8(
+                scales
+                    .iter()
+                    .map(|&s| SymmetricQuantization::init(s))
+                    .collect(),
+                BlockLayout::Flat(8),
+            ),
+        );
+
+        // Values equality
+        x_q_data.assert_eq(&expected, true);
+
+        // Quantization parameters check
+        let qparams = get_q_params(x_q_data);
+        let expected = get_q_params(expected);
+        assert_eq!(qparams.scale.len(), 2);
+        assert_eq!(qparams.scale, expected.scale);
+        assert_eq!(qparams.offset, None);
+        assert_eq!(qparams.offset, expected.offset);
+
+        // Dequantize
+        let x = x_q.dequantize();
+
+        // Precision 2 for dequantization errors
+        x.into_data().assert_approx_eq(&tensor.into_data(), 2);
+    }
+
     #[test]
     fn should_support_quantize_per_block_affine_int8() {
         let device = Default::default();

--- a/crates/burn-tensor/src/tests/quantization/ops/quantize.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/quantize.rs
@@ -11,6 +11,11 @@ mod tests {
     };
     use burn_tensor::{DType, Tensor, TensorData};
 
+    // NOTE: we mark the per-block tests as `might_panic` since backends are not strictly
+    // required to support this quantization scheme
+    use alloc::string::String; // might_panic message
+    use burn_tensor::might_panic;
+
     fn get_q_params(data: TensorData) -> QParams<Vec<f32>, Vec<i8>> {
         let num_elements = data.num_elements();
         let scheme = if let DType::QFloat(scheme) = data.dtype {
@@ -124,6 +129,7 @@ mod tests {
         x_q.into_data().assert_eq(&expected, false);
     }
 
+    #[might_panic(reason = "not implemented")]
     #[test]
     fn should_support_quantize_per_block_symmetric_int8() {
         let device = Default::default();
@@ -205,6 +211,7 @@ mod tests {
         x.into_data().assert_approx_eq(&tensor.into_data(), 2);
     }
 
+    #[might_panic(reason = "not implemented")]
     #[test]
     fn should_support_quantize_per_block_flat() {
         let device = Default::default();
@@ -266,6 +273,7 @@ mod tests {
         x.into_data().assert_approx_eq(&tensor.into_data(), 2);
     }
 
+    #[might_panic(reason = "not implemented")]
     #[test]
     fn should_support_quantize_per_block_affine_int8() {
         let device = Default::default();
@@ -330,6 +338,7 @@ mod tests {
         x.into_data().assert_approx_eq(&tensor.into_data(), 2);
     }
 
+    #[might_panic(reason = "not implemented")]
     #[test]
     fn should_support_quantize_per_block_grid_symmetric_int8() {
         let device = Default::default();

--- a/crates/burn-tensor/src/tests/quantization/ops/quantize.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/quantize.rs
@@ -1,6 +1,8 @@
 #[burn_tensor_testgen::testgen(quantize)]
+
 mod tests {
     use super::*;
+    use alloc::{vec, vec::Vec};
     use burn_tensor::ops::QTensorOps;
     use burn_tensor::quantization::{
         AffineQuantization, BlockLayout, QParams, QuantizationMode, QuantizationParameters,

--- a/crates/burn-tensor/src/tests/quantization/scheme.rs
+++ b/crates/burn-tensor/src/tests/quantization/scheme.rs
@@ -2,7 +2,9 @@
 mod tests {
     use super::*;
     use burn_tensor::{
-        quantization::{CalibrationRange, QuantizationMode, QuantizationScheme, QuantizationType},
+        quantization::{
+            BlockLayout, CalibrationRange, QuantizationMode, QuantizationScheme, QuantizationType,
+        },
         Tensor, TensorData,
     };
 
@@ -35,8 +37,8 @@ mod tests {
         let scheme =
             QuantizationScheme::PerTensor(QuantizationMode::Symmetric, QuantizationType::QInt8);
         let range = CalibrationRange {
-            min: TestTensor::<1>::from_floats([-1.8], &device),
-            max: TestTensor::<1>::from_floats([0.5], &device),
+            min: TestTensor::<1>::from_floats([0.5], &device),
+            max: TestTensor::<1>::from_floats([1.8], &device),
         };
 
         let qparams = scheme.compute_q_params(range);
@@ -45,6 +47,54 @@ mod tests {
             .scale
             .into_data()
             .assert_approx_eq(&TensorData::from([0.014_173_228]), 8);
+        assert!(qparams.offset.is_none());
+    }
+
+    #[test]
+    fn per_block_affine_int8() {
+        let device = Default::default();
+        let scheme = QuantizationScheme::PerBlock(
+            QuantizationMode::Affine,
+            QuantizationType::QInt8,
+            BlockLayout::Flat(3), // layout doesn't matter when computing qparams
+        );
+        let range = CalibrationRange {
+            min: TestTensor::<1>::from_floats([-1.8, -2.0, 0.5], &device),
+            max: TestTensor::<1>::from_floats([0.5, 1.5, 1.8], &device),
+        };
+
+        let qparams = scheme.compute_q_params(range);
+
+        qparams.scale.into_data().assert_approx_eq(
+            &TensorData::from([0.009_019_608, 0.013_725_490, 0.007_0588_234]),
+            8,
+        );
+        qparams
+            .offset
+            .unwrap()
+            .into_data()
+            .assert_eq(&TensorData::from([71, 17, -128]), false);
+    }
+
+    #[test]
+    fn per_block_symmetric_int8() {
+        let device = Default::default();
+        let scheme = QuantizationScheme::PerBlock(
+            QuantizationMode::Symmetric,
+            QuantizationType::QInt8,
+            BlockLayout::Flat(3), // layout doesn't matter when computing qparams
+        );
+        let range = CalibrationRange {
+            min: TestTensor::<1>::from_floats([-1.8, -2.0, 0.5], &device),
+            max: TestTensor::<1>::from_floats([0.5, 1.5, 1.8], &device),
+        };
+
+        let qparams = scheme.compute_q_params(range);
+
+        qparams.scale.into_data().assert_approx_eq(
+            &TensorData::from([0.014_173_228, 0.015_748_031, 0.014_173_228]),
+            8,
+        );
         assert!(qparams.offset.is_none());
     }
 }

--- a/crates/burn-tensor/src/tests/quantization/scheme.rs
+++ b/crates/burn-tensor/src/tests/quantization/scheme.rs
@@ -2,14 +2,15 @@
 mod tests {
     use super::*;
     use burn_tensor::{
-        quantization::{CalibrationRange, QuantizationScheme, QuantizationType},
+        quantization::{CalibrationRange, QuantizationMode, QuantizationScheme, QuantizationType},
         Tensor, TensorData,
     };
 
     #[test]
     fn per_tensor_affine_int8() {
         let device = Default::default();
-        let scheme = QuantizationScheme::PerTensorAffine(QuantizationType::QInt8);
+        let scheme =
+            QuantizationScheme::PerTensor(QuantizationMode::Affine, QuantizationType::QInt8);
         let range = CalibrationRange {
             min: TestTensor::<1>::from_floats([-1.8], &device),
             max: TestTensor::<1>::from_floats([0.5], &device),
@@ -31,7 +32,8 @@ mod tests {
     #[test]
     fn per_tensor_symmetric_int8() {
         let device = Default::default();
-        let scheme = QuantizationScheme::PerTensorSymmetric(QuantizationType::QInt8);
+        let scheme =
+            QuantizationScheme::PerTensor(QuantizationMode::Symmetric, QuantizationType::QInt8);
         let range = CalibrationRange {
             min: TestTensor::<1>::from_floats([-1.8], &device),
             max: TestTensor::<1>::from_floats([0.5], &device),


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ ] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.


### Changes

More quantization granularity!

- Refactored `QuantizationScheme` enum
- Changed `Calibration` to an enum
- Added per-block quantization
  - Flat: linear segments (implemented for ndarray and cubecl backends)
  - Grid: m x n blocks (ndarray only via `QuantizationStrategy`)
  - Quantization parameters are stored as `[offset_1, offset_2, ..., offset_num_blocks, scale_1, scale_2, ..., scale_num_blocks]` (with offsets being optional)
- Added `#[might_panic]` test attribute (for ops configuration that are not strictly required, e.g. different quantization schemes)

### Testing

Unit tests for new schemes
