### PR TITLE
clone file in str2reader to avoid passing owned mutables

### DIFF
--- a/crates/burn-core/src/record/file.rs
+++ b/crates/burn-core/src/record/file.rs
@@ -150,7 +150,7 @@ impl<S: PrecisionSettings, B: Backend> Recorder<B> for BinGzFileRecorder<S> {
         Ok(())
     }
 
-    fn load_item<I: DeserializeOwned>(&self, file: Self::LoadArgs) -> Result<I, RecorderError> {
+    fn load_item<I: DeserializeOwned>(&self, file: &Self::LoadArgs) -> Result<I, RecorderError> {
         let reader = str2reader!(file)?;
         let mut reader = GzDecoder::new(reader);
         let state = bincode::serde::decode_from_std_read(&mut reader, bin_config())
@@ -178,7 +178,7 @@ impl<S: PrecisionSettings, B: Backend> Recorder<B> for BinFileRecorder<S> {
         Ok(())
     }
 
-    fn load_item<I: DeserializeOwned>(&self, file: Self::LoadArgs) -> Result<I, RecorderError> {
+    fn load_item<I: DeserializeOwned>(&self, file: &Self::LoadArgs) -> Result<I, RecorderError> {
         let mut reader = str2reader!(file)?;
         let state = bincode::serde::decode_from_std_read(&mut reader, bin_config())
             .map_err(|err| RecorderError::Unknown(err.to_string()))?;
@@ -205,7 +205,7 @@ impl<S: PrecisionSettings, B: Backend> Recorder<B> for JsonGzFileRecorder<S> {
         Ok(())
     }
 
-    fn load_item<I: DeserializeOwned>(&self, file: Self::LoadArgs) -> Result<I, RecorderError> {
+    fn load_item<I: DeserializeOwned>(&self, file: &Self::LoadArgs) -> Result<I, RecorderError> {
         let reader = str2reader!(file)?;
         let reader = GzDecoder::new(reader);
         let state = serde_json::from_reader(reader)
@@ -232,7 +232,7 @@ impl<S: PrecisionSettings, B: Backend> Recorder<B> for PrettyJsonFileRecorder<S>
         Ok(())
     }
 
-    fn load_item<I: DeserializeOwned>(&self, file: Self::LoadArgs) -> Result<I, RecorderError> {
+    fn load_item<I: DeserializeOwned>(&self, file: &Self::LoadArgs) -> Result<I, RecorderError> {
         let reader = str2reader!(file)?;
         let state = serde_json::from_reader(reader)
             .map_err(|err| RecorderError::Unknown(err.to_string()))?;
@@ -260,7 +260,7 @@ impl<S: PrecisionSettings, B: Backend> Recorder<B> for NamedMpkGzFileRecorder<S>
         Ok(())
     }
 
-    fn load_item<I: DeserializeOwned>(&self, file: Self::LoadArgs) -> Result<I, RecorderError> {
+    fn load_item<I: DeserializeOwned>(&self, file: &Self::LoadArgs) -> Result<I, RecorderError> {
         let reader = str2reader!(file)?;
         let reader = GzDecoder::new(reader);
         let state = rmp_serde::decode::from_read(reader)
@@ -289,7 +289,7 @@ impl<S: PrecisionSettings, B: Backend> Recorder<B> for NamedMpkFileRecorder<S> {
         Ok(())
     }
 
-    fn load_item<I: DeserializeOwned>(&self, file: Self::LoadArgs) -> Result<I, RecorderError> {
+    fn load_item<I: DeserializeOwned>(&self, file: &Self::LoadArgs) -> Result<I, RecorderError> {
         let reader = str2reader!(file)?;
         let state = rmp_serde::decode::from_read(reader)
             .map_err(|err| RecorderError::Unknown(err.to_string()))?;

--- a/crates/burn-core/src/record/file.rs
+++ b/crates/burn-core/src/record/file.rs
@@ -90,9 +90,10 @@ macro_rules! str2reader {
     (
         $file:expr
     ) => {{
-        $file.set_extension(<Self as FileRecorder<B>>::file_extension());
-        let path = $file.as_path();
 
+        let mut path = $file.clone();
+        path.set_extension(<Self as FileRecorder<B>>::file_extension());
+        let path = path.as_path();
         File::open(path)
             .map_err(|err| match err.kind() {
                 std::io::ErrorKind::NotFound => RecorderError::FileNotFound(err.to_string()),
@@ -149,7 +150,7 @@ impl<S: PrecisionSettings, B: Backend> Recorder<B> for BinGzFileRecorder<S> {
         Ok(())
     }
 
-    fn load_item<I: DeserializeOwned>(&self, mut file: Self::LoadArgs) -> Result<I, RecorderError> {
+    fn load_item<I: DeserializeOwned>(&self, file: Self::LoadArgs) -> Result<I, RecorderError> {
         let reader = str2reader!(file)?;
         let mut reader = GzDecoder::new(reader);
         let state = bincode::serde::decode_from_std_read(&mut reader, bin_config())
@@ -177,7 +178,7 @@ impl<S: PrecisionSettings, B: Backend> Recorder<B> for BinFileRecorder<S> {
         Ok(())
     }
 
-    fn load_item<I: DeserializeOwned>(&self, mut file: Self::LoadArgs) -> Result<I, RecorderError> {
+    fn load_item<I: DeserializeOwned>(&self, file: Self::LoadArgs) -> Result<I, RecorderError> {
         let mut reader = str2reader!(file)?;
         let state = bincode::serde::decode_from_std_read(&mut reader, bin_config())
             .map_err(|err| RecorderError::Unknown(err.to_string()))?;
@@ -204,7 +205,7 @@ impl<S: PrecisionSettings, B: Backend> Recorder<B> for JsonGzFileRecorder<S> {
         Ok(())
     }
 
-    fn load_item<I: DeserializeOwned>(&self, mut file: Self::LoadArgs) -> Result<I, RecorderError> {
+    fn load_item<I: DeserializeOwned>(&self, file: Self::LoadArgs) -> Result<I, RecorderError> {
         let reader = str2reader!(file)?;
         let reader = GzDecoder::new(reader);
         let state = serde_json::from_reader(reader)
@@ -231,7 +232,7 @@ impl<S: PrecisionSettings, B: Backend> Recorder<B> for PrettyJsonFileRecorder<S>
         Ok(())
     }
 
-    fn load_item<I: DeserializeOwned>(&self, mut file: Self::LoadArgs) -> Result<I, RecorderError> {
+    fn load_item<I: DeserializeOwned>(&self, file: Self::LoadArgs) -> Result<I, RecorderError> {
         let reader = str2reader!(file)?;
         let state = serde_json::from_reader(reader)
             .map_err(|err| RecorderError::Unknown(err.to_string()))?;
@@ -259,7 +260,7 @@ impl<S: PrecisionSettings, B: Backend> Recorder<B> for NamedMpkGzFileRecorder<S>
         Ok(())
     }
 
-    fn load_item<I: DeserializeOwned>(&self, mut file: Self::LoadArgs) -> Result<I, RecorderError> {
+    fn load_item<I: DeserializeOwned>(&self, file: Self::LoadArgs) -> Result<I, RecorderError> {
         let reader = str2reader!(file)?;
         let reader = GzDecoder::new(reader);
         let state = rmp_serde::decode::from_read(reader)
@@ -288,7 +289,7 @@ impl<S: PrecisionSettings, B: Backend> Recorder<B> for NamedMpkFileRecorder<S> {
         Ok(())
     }
 
-    fn load_item<I: DeserializeOwned>(&self, mut file: Self::LoadArgs) -> Result<I, RecorderError> {
+    fn load_item<I: DeserializeOwned>(&self, file: Self::LoadArgs) -> Result<I, RecorderError> {
         let reader = str2reader!(file)?;
         let state = rmp_serde::decode::from_read(reader)
             .map_err(|err| RecorderError::Unknown(err.to_string()))?;

--- a/crates/burn-core/src/record/memory.rs
+++ b/crates/burn-core/src/record/memory.rs
@@ -35,7 +35,7 @@ impl<S: PrecisionSettings, B: Backend> Recorder<B> for BinBytesRecorder<S> {
     ) -> Result<Self::RecordOutput, RecorderError> {
         Ok(bincode::serde::encode_to_vec(item, bin_config()).unwrap())
     }
-    fn load_item<I: DeserializeOwned>(&self, args: Self::LoadArgs) -> Result<I, RecorderError> {
+    fn load_item<I: DeserializeOwned>(&self, args: &Self::LoadArgs) -> Result<I, RecorderError> {
         let state = bincode::serde::decode_borrowed_from_slice(&args, bin_config()).unwrap();
         Ok(state)
     }
@@ -65,7 +65,7 @@ impl<S: PrecisionSettings, B: Backend> Recorder<B> for NamedMpkBytesRecorder<S> 
     ) -> Result<Self::RecordOutput, RecorderError> {
         rmp_serde::encode::to_vec_named(&item).map_err(|e| RecorderError::Unknown(e.to_string()))
     }
-    fn load_item<I: DeserializeOwned>(&self, args: Self::LoadArgs) -> Result<I, RecorderError> {
+    fn load_item<I: DeserializeOwned>(&self, args: &Self::LoadArgs) -> Result<I, RecorderError> {
         rmp_serde::decode::from_slice(&args).map_err(|e| RecorderError::Unknown(e.to_string()))
     }
 }

--- a/crates/burn-core/src/record/recorder.rs
+++ b/crates/burn-core/src/record/recorder.rs
@@ -60,8 +60,8 @@ pub trait Recorder<B: Backend>:
         R: Record<B>,
     {
         let item: BurnRecord<R::Item<Self::Settings>, B> =
-            self.load_item(args.clone()).map_err(|err| {
-                if let Ok(record) = self.load_item::<BurnRecordNoItem>(args.clone()) {
+            self.load_item(&args).map_err(|err| {
+                if let Ok(record) = self.load_item::<BurnRecordNoItem>(&args) {
                     let mut message = "Unable to load record.".to_string();
                     let metadata = recorder_metadata::<Self, B>();
                     if metadata.float != record.metadata.float {
@@ -133,7 +133,7 @@ pub trait Recorder<B: Backend>:
     /// # Returns
     ///
     /// The loaded item.
-    fn load_item<I>(&self, args: Self::LoadArgs) -> Result<I, RecorderError>
+    fn load_item<I>(&self, args: &Self::LoadArgs) -> Result<I, RecorderError>
     where
         I: DeserializeOwned;
 }

--- a/crates/burn-import/src/burn/graph.rs
+++ b/crates/burn-import/src/burn/graph.rs
@@ -376,9 +376,10 @@ impl<PS: PrecisionSettings> BurnGraph<PS> {
             }
             _blank_!();
             impl<B: Backend> Model<B> {
-                pub fn from_embedded(device: &B::Device) -> Self {
+                pub fn
+                from_embedded(device: &B::Device) -> Self {
                     let record = BinBytesRecorder::<#precision_ty>::default()
-                    .load(EMBEDDED_STATES.to_vec(), device)
+                    .load(&EMBEDDED_STATES, device)
                     .expect("Should decode state successfully");
 
                     Self::new(device).load_record(record)

--- a/crates/burn-import/src/pytorch/recorder.rs
+++ b/crates/burn-import/src/pytorch/recorder.rs
@@ -35,7 +35,7 @@ impl<PS: PrecisionSettings, B: Backend> Recorder<B> for PyTorchFileRecorder<PS> 
         unimplemented!("save_item not implemented for PyTorchFileRecorder")
     }
 
-    fn load_item<I: DeserializeOwned>(&self, _file: Self::LoadArgs) -> Result<I, RecorderError> {
+    fn load_item<I: DeserializeOwned>(&self, _file: &Self::LoadArgs) -> Result<I, RecorderError> {
         unimplemented!("load_item not implemented for PyTorchFileRecorder")
     }
 


### PR DESCRIPTION
Only clone loading arguments when necessary. Since the e.g. the bin loader uses a slice of a cloned vector this clone can be omitted. 

Opening as draft hoping that people will stop me when I'm going down the wrong rabbit hole before I spend tons of time digging into it :)

### Checklist

- [ ] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

https://github.com/tracel-ai/burn/issues/2871

### Testing

`cargo test`
TODO when ready: run burn examples. 
