### PR TITLE
Fix two autotune issues on wasm

### DIFF
--- a/crates/burn-cubecl/src/kernel/conv/conv2d/col2im.rs
+++ b/crates/burn-cubecl/src/kernel/conv/conv2d/col2im.rs
@@ -61,8 +61,7 @@ pub fn conv_transpose2d_col2im<R: CubeRuntime, E: FloatElement>(
     );
     let im_channels = im_ch_per_group * groups;
 
-    let batches_per_run = batches_per_run(batch_size, input_h, input_w)
-        .expect("Image too large to run even one batch at once");
+    let batches_per_run = batches_per_run(batch_size, input_h, input_w)?;
     let col_shape_0 = im_ch_per_group * kernel_h * kernel_w;
 
     let weight = reshape(

--- a/crates/burn-cubecl/src/kernel/reduce/tune.rs
+++ b/crates/burn-cubecl/src/kernel/reduce/tune.rs
@@ -218,14 +218,14 @@ pub fn autotune_sum<Run: CubeRuntime, E: CubeElement>(
     static TUNER: LocalTuner<CubeAutotuneKey, CubeTuneId> = local_tuner!();
 
     let tunables = TunableSet::new(create_key_sum::<Run>, sum_input_gen::<Run, E>)
+        .with_tunable(sum_chained::<Run, E>)
         .with_tunable(sum_one_shot::<Run, E, 1>)
         .with_tunable(sum_one_shot::<Run, E, 2>)
         .with_tunable(sum_one_shot::<Run, E, 4>)
         .with_tunable(sum_one_shot::<Run, E, 8>)
         .with_tunable(sum_one_shot::<Run, E, 16>)
         .with_tunable(sum_one_shot::<Run, E, 32>)
-        .with_tunable(sum_one_shot::<Run, E, 64>)
-        .with_tunable(sum_chained::<Run, E>);
+        .with_tunable(sum_one_shot::<Run, E, 64>);
 
     TUNER.execute(
         &CubeTuneId::new::<Run>(&input.device),


### PR DESCRIPTION
## Pull Request Template

### Changes

On WASM autotuning is async, and until the results are in, it needs to use a default setting. ATM it just picks the first one, which atm uses atomic floats, and thus results in an error.

For convolution, it needed to simply bubble up the cube count too large error rather than panic'ing.

