### PR TITLE
Vectorize pooling for optimization

### DIFF
--- a/backend-comparison/benches/max_pool2d.rs
+++ b/backend-comparison/benches/max_pool2d.rs
@@ -49,7 +49,7 @@ fn bench<B: Backend>(
     token: Option<&str>,
 ) {
     let benchmark = MaxPool2dBenchmark::<B> {
-        shape: [32, 32, 512, 512].into(),
+        shape: [32, 128, 512, 512].into(),
         kernel_size: [5, 5],
         stride: [2, 2],
         padding: [2, 2],

--- a/crates/burn-cubecl/src/kernel/pool/adaptive_avg_pool2d.rs
+++ b/crates/burn-cubecl/src/kernel/pool/adaptive_avg_pool2d.rs
@@ -1,60 +1,58 @@
-use crate::{element::CubeElement, ops::numeric::empty_device, tensor::CubeTensor, CubeRuntime};
+use crate::{
+    element::CubeElement,
+    kernel::conv::nchw_to_nhwc,
+    ops::{max_vectorization, numeric::empty_device, permute},
+    tensor::CubeTensor,
+    CubeRuntime,
+};
 use burn_tensor::Shape;
 use cubecl::{calculate_cube_count_elemwise, prelude::*};
 
 #[cube(launch)]
-fn adaptive_avg_pool2d_direct<E: Numeric>(input: &Tensor<E>, output: &mut Tensor<E>) {
-    let (output_stride_0, output_stride_1, output_stride_2, output_stride_3) = (
-        output.stride(0),
-        output.stride(1),
-        output.stride(2),
-        output.stride(3),
-    );
-    let (output_shape_0, output_shape_1, output_shape_2, output_shape_3) = (
-        output.shape(0),
-        output.shape(1),
-        output.shape(2),
-        output.shape(3),
-    );
-    let (input_stride_0, input_stride_1, input_stride_2, input_stride_3) = (
+fn adaptive_avg_pool2d_direct<E: Numeric>(input: &Tensor<Line<E>>, output: &mut Tensor<Line<E>>) {
+    let (out_h, out_w, channels) = (output.shape(1), output.shape(2), output.shape(3));
+    let channel_lines = channels / output.line_size();
+    let (in_stride_b, in_stride_h, in_stride_w, in_stride_c) = (
         input.stride(0),
         input.stride(1),
         input.stride(2),
         input.stride(3),
     );
-    let (input_shape_2, input_shape_3) = (input.shape(2), input.shape(3));
+    let (in_h, in_w) = (input.shape(1), input.shape(2));
 
-    let b = (ABSOLUTE_POS / output_stride_0) % output_shape_0;
-    let c = (ABSOLUTE_POS / output_stride_1) % output_shape_1;
-    let oh = (ABSOLUTE_POS / output_stride_2) % output_shape_2;
-    let ow = (ABSOLUTE_POS / output_stride_3) % output_shape_3;
+    let c = (ABSOLUTE_POS % channel_lines) * input.line_size();
+    let pos = ABSOLUTE_POS / channel_lines;
+    let ow = pos % out_w;
+    let pos = pos / out_w;
+    let oh = pos % out_h;
+    let b = pos / out_h;
 
-    let ih_start = start_index(oh, output_shape_2, input_shape_2);
-    let ih_end = end_index(oh, output_shape_2, input_shape_2);
+    let ih_start = start_index(oh, out_h, in_h);
+    let ih_end = end_index(oh, out_h, in_h);
 
-    let iw_start = start_index(ow, output_shape_3, input_shape_3);
-    let iw_end = end_index(ow, output_shape_3, input_shape_3);
+    let iw_start = start_index(ow, out_w, in_w);
+    let iw_end = end_index(ow, out_w, in_w);
 
-    let mut sum = E::from_int(0);
+    let mut sum = Line::empty(input.line_size()).fill(E::from_int(0));
 
-    let index_input_0 = b * input_stride_0;
-    let index_input_1 = c * input_stride_1;
+    let index_input_0 = b * in_stride_b;
+    let index_input_1 = c * in_stride_c;
 
     for ih in ih_start..ih_end {
-        let index_input_2 = ih * input_stride_2;
+        let index_input_2 = ih * in_stride_h;
 
         for iw in iw_start..iw_end {
-            let index_input_3 = iw * input_stride_3;
+            let index_input_3 = iw * in_stride_w;
 
             let index_input = index_input_0 + index_input_1 + index_input_2 + index_input_3;
-            sum += input[index_input];
+            sum += input[index_input / input.line_size()];
         }
     }
 
     let num_ih = ih_end - ih_start;
     let num_iw = iw_end - iw_start;
 
-    output[ABSOLUTE_POS] = sum / E::cast_from(num_ih * num_iw);
+    output[ABSOLUTE_POS] = sum / Line::cast_from(num_ih * num_iw);
 }
 
 #[cube]
@@ -82,20 +80,27 @@ pub(crate) fn adaptive_avg_pool2d<R: CubeRuntime, E: CubeElement>(
 ) -> CubeTensor<R> {
     let [batch_size, channels, _, _] = input.shape.dims();
 
-    let output_shape = Shape::new([batch_size, channels, output_size[0], output_size[1]]);
+    let input = if input.is_contiguous() {
+        nchw_to_nhwc::<R, E>(input)
+    } else {
+        permute(input, &[0, 2, 3, 1])
+    };
+    let line_size = max_vectorization(&input);
+
+    let output_shape = Shape::new([batch_size, output_size[0], output_size[1], channels]);
     let num_elems: usize = output_shape.num_elements();
     let output = empty_device::<R, E>(input.client.clone(), input.device.clone(), output_shape);
 
     let cube_dim = CubeDim::default();
-    let cube_count = calculate_cube_count_elemwise(num_elems, cube_dim);
+    let cube_count = calculate_cube_count_elemwise(num_elems / line_size as usize, cube_dim);
 
     adaptive_avg_pool2d_direct::launch::<E, R>(
         &input.client,
         cube_count,
         cube_dim,
-        input.as_tensor_arg::<E>(1),
-        output.as_tensor_arg::<E>(1),
+        input.as_tensor_arg::<E>(line_size),
+        output.as_tensor_arg::<E>(line_size),
     );
 
-    output
+    permute(output, &[0, 3, 1, 2])
 }

--- a/crates/burn-cubecl/src/kernel/pool/adaptive_avg_pool2d.rs
+++ b/crates/burn-cubecl/src/kernel/pool/adaptive_avg_pool2d.rs
@@ -10,6 +10,10 @@ use cubecl::{calculate_cube_count_elemwise, prelude::*};
 
 #[cube(launch)]
 fn adaptive_avg_pool2d_direct<E: Numeric>(input: &Tensor<Line<E>>, output: &mut Tensor<Line<E>>) {
+    if ABSOLUTE_POS >= output.len() {
+        terminate!();
+    }
+
     let (out_h, out_w, channels) = (output.shape(1), output.shape(2), output.shape(3));
     let channel_lines = channels / output.line_size();
     let (in_stride_b, in_stride_h, in_stride_w, in_stride_c) = (

--- a/crates/burn-cubecl/src/kernel/pool/adaptive_avg_pool2d_backward.rs
+++ b/crates/burn-cubecl/src/kernel/pool/adaptive_avg_pool2d_backward.rs
@@ -13,6 +13,10 @@ fn adaptive_avg_pool2d_backward_direct<E: Numeric>(
     grad: &Tensor<Line<E>>,
     output: &mut Tensor<Line<E>>,
 ) {
+    if ABSOLUTE_POS >= output.len() {
+        terminate!();
+    }
+
     let (out_h, out_w, channels) = (output.shape(1), output.shape(2), output.shape(3));
     let channel_lines = channels / grad.line_size();
     let (grad_stride_b, grad_stride_h, grad_stride_w, grad_stride_c) = (

--- a/crates/burn-cubecl/src/kernel/pool/adaptive_avg_pool2d_backward.rs
+++ b/crates/burn-cubecl/src/kernel/pool/adaptive_avg_pool2d_backward.rs
@@ -1,58 +1,60 @@
-use crate::{element::CubeElement, tensor::CubeTensor, CubeRuntime};
+use crate::{
+    element::CubeElement,
+    kernel::conv::nchw_to_nhwc,
+    ops::{max_vectorization, numeric::empty_device, permute},
+    tensor::CubeTensor,
+    CubeRuntime,
+};
+use burn_tensor::Shape;
 use cubecl::{calculate_cube_count_elemwise, prelude::*};
 
 #[cube(launch)]
-fn adaptive_avg_pool2d_backward_direct<E: Numeric>(grad: &Tensor<E>, output: &mut Tensor<E>) {
-    let (output_stride_0, output_stride_1, output_stride_2, output_stride_3) = (
-        output.stride(0),
-        output.stride(1),
-        output.stride(2),
-        output.stride(3),
-    );
-    let (output_shape_0, output_shape_1, output_shape_2, output_shape_3) = (
-        output.shape(0),
-        output.shape(1),
-        output.shape(2),
-        output.shape(3),
-    );
-    let (grad_stride_0, grad_stride_1, grad_stride_2, grad_stride_3) = (
+fn adaptive_avg_pool2d_backward_direct<E: Numeric>(
+    grad: &Tensor<Line<E>>,
+    output: &mut Tensor<Line<E>>,
+) {
+    let (out_h, out_w, channels) = (output.shape(1), output.shape(2), output.shape(3));
+    let channel_lines = channels / grad.line_size();
+    let (grad_stride_b, grad_stride_h, grad_stride_w, grad_stride_c) = (
         grad.stride(0),
         grad.stride(1),
         grad.stride(2),
         grad.stride(3),
     );
-    let (grad_shape_2, grad_shape_3) = (grad.shape(2), grad.shape(3));
+    let (grad_h, grad_w) = (grad.shape(1), grad.shape(2));
 
-    let b = (ABSOLUTE_POS / output_stride_0) % output_shape_0;
-    let c = (ABSOLUTE_POS / output_stride_1) % output_shape_1;
-    let ih = (ABSOLUTE_POS / output_stride_2) % output_shape_2;
-    let iw = (ABSOLUTE_POS / output_stride_3) % output_shape_3;
+    let c = (ABSOLUTE_POS % channel_lines) * grad.line_size();
+    let pos = ABSOLUTE_POS / channel_lines;
+    let iw = pos % out_w;
+    let pos = pos / out_w;
+    let ih = pos % out_h;
+    let b = pos / out_h;
 
-    let oh_start = start_index(ih, output_shape_2, grad_shape_2);
-    let oh_end = end_index(ih, output_shape_2, grad_shape_2);
+    let oh_start = start_index(ih, out_h, grad_h);
+    let oh_end = end_index(ih, out_h, grad_h);
 
-    let ow_start = start_index(iw, output_shape_3, grad_shape_3);
-    let ow_end = end_index(iw, output_shape_3, grad_shape_3);
+    let ow_start = start_index(iw, out_w, grad_w);
+    let ow_end = end_index(iw, out_w, grad_w);
 
-    let mut grad_acc = E::from_int(0);
+    let mut grad_acc = Line::empty(grad.line_size()).fill(E::from_int(0));
 
-    let index_base = b * grad_stride_0 + (c * grad_stride_1);
+    let index_base = b * grad_stride_b + (c * grad_stride_c);
 
     for oh in oh_start..oh_end {
-        let ih_start = start_index(oh, grad_shape_2, output_shape_2);
-        let ih_end = end_index(oh, grad_shape_2, output_shape_2);
+        let ih_start = start_index(oh, grad_h, out_h);
+        let ih_end = end_index(oh, grad_h, out_h);
 
         if ih >= ih_start && ih < ih_end {
             for ow in ow_start..ow_end {
-                let iw_start = start_index(ow, grad_shape_3, output_shape_3);
-                let iw_end = end_index(ow, grad_shape_3, output_shape_3);
+                let iw_start = start_index(ow, grad_w, out_w);
+                let iw_end = end_index(ow, grad_w, out_w);
 
                 if iw >= iw_start && iw < iw_end {
                     let num_ih = ih_end - ih_start;
                     let num_iw = iw_end - iw_start;
 
-                    let index = index_base + (oh * grad_stride_2) + (ow * grad_stride_3);
-                    grad_acc += grad[index] / E::cast_from(num_iw * num_ih);
+                    let index = index_base + (oh * grad_stride_h) + (ow * grad_stride_w);
+                    grad_acc += grad[index / grad.line_size()] / Line::cast_from(num_iw * num_ih);
                 }
             }
         }
@@ -84,27 +86,30 @@ pub(crate) fn adaptive_avg_pool2d_backward<R: CubeRuntime, E: CubeElement>(
     x: CubeTensor<R>,
     out_grad: CubeTensor<R>,
 ) -> CubeTensor<R> {
-    let output_shape = x.shape.clone();
-    let num_elems = output_shape.num_elements();
-    let output_buffer = x.client.empty(num_elems * core::mem::size_of::<E>());
-    let output = CubeTensor::new_contiguous(
-        x.client.clone(),
-        x.device.clone(),
-        output_shape,
-        output_buffer,
-        x.dtype,
-    );
+    let [batches, channels, height, width] = x.shape.dims();
+
+    let out_grad = if out_grad.is_contiguous() {
+        nchw_to_nhwc::<R, E>(out_grad)
+    } else {
+        permute(out_grad, &[0, 2, 3, 1])
+    };
+    let line_size = max_vectorization(&x);
+
+    let out_shape = Shape::new([batches, height, width, channels]);
+    let output = empty_device::<R, E>(x.client.clone(), x.device.clone(), out_shape);
+
+    let num_elems = output.shape.num_elements();
 
     let cube_dim = CubeDim::default();
-    let cube_count = calculate_cube_count_elemwise(num_elems, cube_dim);
+    let cube_count = calculate_cube_count_elemwise(num_elems / line_size as usize, cube_dim);
 
     adaptive_avg_pool2d_backward_direct::launch::<E, R>(
         &x.client,
         cube_count,
         cube_dim,
-        out_grad.as_tensor_arg::<E>(1),
-        output.as_tensor_arg::<E>(1),
+        out_grad.as_tensor_arg::<E>(line_size),
+        output.as_tensor_arg::<E>(line_size),
     );
 
-    output
+    permute(output, &[0, 3, 1, 2])
 }

--- a/crates/burn-cubecl/src/kernel/pool/avg_pool2d.rs
+++ b/crates/burn-cubecl/src/kernel/pool/avg_pool2d.rs
@@ -1,7 +1,13 @@
 use super::pool2d::{
     pool2d_direct, Pool2dDirectArgsLaunch, Pool2dDirectStrategy, Pool2dDirectStrategyFamily,
 };
-use crate::{element::CubeElement, ops::numeric::empty_device, tensor::CubeTensor, CubeRuntime};
+use crate::{
+    element::CubeElement,
+    kernel::conv::nchw_to_nhwc,
+    ops::{max_vectorization, numeric::empty_device, permute},
+    tensor::CubeTensor,
+    CubeRuntime,
+};
 use burn_tensor::{ops::conv::calculate_pool_output_size, Shape};
 use cubecl::prelude::*;
 use cubecl::{calculate_cube_count_elemwise, prelude::ScalarArg, CubeDim};
@@ -23,12 +29,15 @@ pub struct AvgPoolStrategyConfig {
 
 #[cube]
 impl<N: Numeric> Pool2dDirectStrategy<N> for AvgPoolStrategy {
-    type Accumulator = (N, u32);
+    type Accumulator = (Line<N>, u32);
     type Config = AvgPoolStrategyConfig;
     type Indices = ();
 
-    fn initialize(#[comptime] config: &Self::Config) -> Self::Accumulator {
-        let sum = N::from_int(0);
+    fn initialize(
+        #[comptime] config: &Self::Config,
+        #[comptime] line_size: u32,
+    ) -> Self::Accumulator {
+        let sum = Line::empty(line_size).fill(N::from_int(0));
         let count = comptime! {if config.count_include_pad {
             config.kernel_size_h * config.kernel_size_w
         } else {
@@ -42,7 +51,7 @@ impl<N: Numeric> Pool2dDirectStrategy<N> for AvgPoolStrategy {
         #[comptime] config: &Self::Config,
         accumulator: &mut Self::Accumulator,
         _index: u32,
-        result: N,
+        result: Line<N>,
     ) {
         let (sum, count) = accumulator;
 
@@ -56,12 +65,12 @@ impl<N: Numeric> Pool2dDirectStrategy<N> for AvgPoolStrategy {
     fn store(
         #[comptime] _config: &Self::Config,
         position: u32,
-        output: &mut Tensor<N>,
+        output: &mut Tensor<Line<N>>,
         _output_indices: &mut (),
         accumulator: Self::Accumulator,
     ) {
         let (sum, count) = accumulator;
-        output[position] = sum / N::cast_from(count);
+        output[position] = sum / Line::cast_from(count);
     }
 }
 
@@ -90,18 +99,26 @@ pub(crate) fn avg_pool2d<R: CubeRuntime, E: CubeElement>(
         x.shape.dims[3],
     );
 
-    let shape_out = Shape::new([batch_size, channels, size_0, size_1]);
+    let x = if x.is_contiguous() {
+        nchw_to_nhwc::<R, E>(x)
+    } else {
+        permute(x, &[0, 2, 3, 1])
+    };
+    let line_size = max_vectorization(&x);
+
+    let shape_out = Shape::new([batch_size, size_0, size_1, channels]);
     let output = empty_device::<R, E>(x.client.clone(), x.device.clone(), shape_out);
 
     let cube_dim = CubeDim::default();
-    let cube_count = calculate_cube_count_elemwise(output.shape.num_elements(), cube_dim);
+    let cube_count =
+        calculate_cube_count_elemwise(output.shape.num_elements() / line_size as usize, cube_dim);
 
     pool2d_direct::launch::<E, AvgPoolStrategy, R>(
         &x.client,
         cube_count,
         cube_dim,
-        x.as_tensor_arg::<E>(1),
-        output.as_tensor_arg::<E>(1),
+        x.as_tensor_arg::<E>(line_size),
+        output.as_tensor_arg::<E>(line_size),
         (),
         Pool2dDirectArgsLaunch::new(
             ScalarArg::new(stride[0] as u32),
@@ -119,5 +136,5 @@ pub(crate) fn avg_pool2d<R: CubeRuntime, E: CubeElement>(
         },
     );
 
-    output
+    permute(output, &[0, 3, 1, 2])
 }

--- a/crates/burn-cubecl/src/kernel/pool/avg_pool2d_backward.rs
+++ b/crates/burn-cubecl/src/kernel/pool/avg_pool2d_backward.rs
@@ -1,7 +1,11 @@
 use crate::{
-    element::CubeElement, kernel::into_contiguous, ops::numeric::empty_device, tensor::CubeTensor,
+    element::CubeElement,
+    kernel::conv::nchw_to_nhwc,
+    ops::{max_vectorization, numeric::empty_device, permute},
+    tensor::CubeTensor,
     CubeRuntime,
 };
+use burn_tensor::Shape;
 use cubecl::{calculate_cube_count_elemwise, prelude::*};
 
 #[derive(CubeLaunch)]
@@ -16,8 +20,8 @@ pub(crate) struct PoolBackwardArgs {
 
 #[cube(launch_unchecked)]
 fn avg_pool2d_backward_kernel<E: Numeric>(
-    grad: &Tensor<E>,
-    output: &mut Tensor<E>,
+    grad: &Tensor<Line<E>>,
+    output: &mut Tensor<Line<E>>,
     args: &PoolBackwardArgs,
     #[comptime] kernel_size_0: i32,
     #[comptime] kernel_size_1: i32,
@@ -27,18 +31,23 @@ fn avg_pool2d_backward_kernel<E: Numeric>(
         terminate!();
     }
 
-    let batch = ABSOLUTE_POS / output.stride(0) % output.shape(0);
-    let channel = ABSOLUTE_POS / output.stride(1) % output.shape(1);
-    let ih = ABSOLUTE_POS / output.stride(2) % output.shape(2);
-    let iw = ABSOLUTE_POS / output.stride(3) % output.shape(3);
+    let line_size = grad.line_size();
 
-    let mut grad_acc = E::from_int(0);
+    let channel_lines = output.shape(3) / line_size;
+    let channel = (ABSOLUTE_POS % channel_lines) * output.line_size();
+    let pos = ABSOLUTE_POS / channel_lines;
+    let iw = pos % output.shape(2);
+    let pos = pos / output.shape(2);
+    let ih = pos % output.shape(1);
+    let batch = pos / output.shape(1);
+
+    let mut grad_acc = Line::empty(grad.line_size()).fill(E::from_int(0));
 
     let (oh_start, oh_end, ow_start, ow_end) = loop_ranges(
         ih as i32,
         iw as i32,
+        grad.shape(1),
         grad.shape(2),
-        grad.shape(3),
         args,
         kernel_size_0,
         kernel_size_1,
@@ -51,9 +60,9 @@ fn avg_pool2d_backward_kernel<E: Numeric>(
     let kernel_size_0 = comptime![kernel_size_0 as u32];
     let kernel_size_1 = comptime![kernel_size_1 as u32];
 
-    let index_base = batch * grad.stride(0) + channel * grad.stride(1);
-    let border_bottom = output.shape(2) + padding_0;
-    let border_right = output.shape(3) + padding_1;
+    let index_base = batch * grad.stride(0) + channel * grad.stride(3);
+    let border_bottom = output.shape(1) + padding_0;
+    let border_right = output.shape(2) + padding_1;
     let begin_h = ih + padding_0;
     let begin_w = iw + padding_1;
 
@@ -64,7 +73,7 @@ fn avg_pool2d_backward_kernel<E: Numeric>(
 
         if begin_h >= ih_start && ih < ih_end {
             for ow in ow_start..ow_end {
-                let index = index_base + oh * grad.stride(2) + ow * grad.stride(3);
+                let index = index_base + oh * grad.stride(1) + ow * grad.stride(2);
 
                 let iw_start = ow * stride_1;
                 let iw_end = Min::min(iw_start + kernel_size_1, border_right);
@@ -72,12 +81,13 @@ fn avg_pool2d_backward_kernel<E: Numeric>(
 
                 if begin_w >= iw_start && iw < iw_end {
                     if count_include_pad {
-                        grad_acc += grad[index] / E::cast_from(kernel_size_0 * kernel_size_1);
+                        grad_acc += grad[index / line_size]
+                            / Line::cast_from(kernel_size_0 * kernel_size_1);
                     } else {
                         let ih_diff = ih_end - ih_start;
                         let iw_diff = iw_end - iw_start;
-                        let count = E::cast_from(ih_diff * iw_diff);
-                        grad_acc += grad[index] / count;
+                        let count = Line::cast_from(ih_diff * iw_diff);
+                        grad_acc += grad[index / line_size] / count;
                     }
                 }
             }
@@ -116,20 +126,35 @@ pub(crate) fn avg_pool2d_backward<R: CubeRuntime, E: CubeElement>(
     padding: [usize; 2],
     count_include_pad: bool,
 ) -> CubeTensor<R> {
-    let grad = into_contiguous(grad);
+    let [batches, channels, height, width] = x.shape.dims();
+
+    let grad = if grad.is_contiguous() {
+        nchw_to_nhwc::<R, E>(grad)
+    } else {
+        permute(grad, &[0, 2, 3, 1])
+    };
+
+    let line_size = if x.strides[3] == grad.strides[3] {
+        max_vectorization(&x)
+    } else {
+        1
+    };
+
     let dilation = 1;
 
-    let output = empty_device::<R, E>(x.client.clone(), x.device.clone(), x.shape.clone());
+    let out_shape = Shape::new([batches, height, width, channels]);
+    let output = empty_device::<R, E>(x.client.clone(), x.device.clone(), out_shape);
     let cube_dim = CubeDim::default();
-    let cube_count = calculate_cube_count_elemwise(output.shape.num_elements(), cube_dim);
+    let cube_count =
+        calculate_cube_count_elemwise(output.shape.num_elements() / line_size as usize, cube_dim);
 
     unsafe {
         avg_pool2d_backward_kernel::launch_unchecked::<E, R>(
             &grad.client,
             cube_count,
             cube_dim,
-            grad.as_tensor_arg::<E>(1),
-            output.as_tensor_arg::<E>(1),
+            grad.as_tensor_arg::<E>(line_size),
+            output.as_tensor_arg::<E>(line_size),
             PoolBackwardArgsLaunch::new(
                 ScalarArg::new(stride[0] as i32),
                 ScalarArg::new(stride[1] as i32),
@@ -144,5 +169,5 @@ pub(crate) fn avg_pool2d_backward<R: CubeRuntime, E: CubeElement>(
         )
     };
 
-    output
+    permute(output, &[0, 3, 1, 2])
 }

--- a/crates/burn-cubecl/src/kernel/pool/max_pool2d.rs
+++ b/crates/burn-cubecl/src/kernel/pool/max_pool2d.rs
@@ -1,7 +1,13 @@
 use super::pool2d::{
     pool2d_direct, Pool2dDirectArgsLaunch, Pool2dDirectStrategy, Pool2dDirectStrategyFamily,
 };
-use crate::{element::CubeElement, ops::numeric::empty_device, tensor::CubeTensor, CubeRuntime};
+use crate::{
+    element::CubeElement,
+    kernel::conv::nchw_to_nhwc,
+    ops::{max_vectorization, numeric::empty_device, permute},
+    tensor::CubeTensor,
+    CubeRuntime,
+};
 use burn_tensor::{ops::conv::calculate_pool_output_size, Shape};
 use cubecl::{calculate_cube_count_elemwise, prelude::*, CubeDim};
 
@@ -15,36 +21,37 @@ impl Pool2dDirectStrategyFamily for MaxPoolStrategy {
 }
 
 impl Pool2dDirectStrategyFamily for MaxPoolWithIndicesStrategy {
-    type Indices = Tensor<i32>;
+    type Indices = Tensor<Line<i32>>;
     type Config = ();
     type Pool2d<N: Numeric> = Self;
 }
 
 #[cube]
 impl<N: Numeric> Pool2dDirectStrategy<N> for MaxPoolStrategy {
-    type Accumulator = N;
+    type Accumulator = Line<N>;
     type Config = ();
     type Indices = ();
 
-    fn initialize(#[comptime] _config: &Self::Config) -> Self::Accumulator {
-        N::min_value()
+    fn initialize(
+        #[comptime] _config: &Self::Config,
+        #[comptime] line_size: u32,
+    ) -> Self::Accumulator {
+        Line::empty(line_size).fill(N::min_value())
     }
 
     fn accumulate(
         #[comptime] _config: &Self::Config,
         accumulator: &mut Self::Accumulator,
         _index: u32,
-        result: N,
+        result: Line<N>,
     ) {
-        if result > *accumulator {
-            *accumulator = result;
-        }
+        *accumulator = Max::max(*accumulator, result);
     }
 
     fn store(
         #[comptime] _config: &Self::Config,
         position: u32,
-        output: &mut Tensor<N>,
+        output: &mut Tensor<Line<N>>,
         _output_indices: &mut (),
         accumulator: Self::Accumulator,
     ) {
@@ -54,31 +61,35 @@ impl<N: Numeric> Pool2dDirectStrategy<N> for MaxPoolStrategy {
 
 #[cube]
 impl<N: Numeric> Pool2dDirectStrategy<N> for MaxPoolWithIndicesStrategy {
-    type Accumulator = (N, i32);
+    type Accumulator = (Line<N>, Line<i32>);
     type Config = ();
-    type Indices = Tensor<i32>;
+    type Indices = Tensor<Line<i32>>;
 
-    fn initialize(#[comptime] _config: &Self::Config) -> Self::Accumulator {
-        (N::min_value(), 0i32)
+    fn initialize(
+        #[comptime] _config: &Self::Config,
+        #[comptime] line_size: u32,
+    ) -> Self::Accumulator {
+        let val = Line::empty(line_size).fill(N::min_value());
+        let idx = Line::empty(line_size).fill(0i32);
+        (val, idx)
     }
 
     fn accumulate(
         #[comptime] _config: &Self::Config,
         accumulator: &mut Self::Accumulator,
         index: u32,
-        result: N,
+        result: Line<N>,
     ) {
-        if result > accumulator.0 {
-            accumulator.0 = result;
-            accumulator.1 = i32::cast_from(index);
-        }
+        let indices = Line::cast_from(index);
+        accumulator.1 = select_many(result.greater_than(accumulator.0), indices, accumulator.1);
+        accumulator.0 = Max::max(result, accumulator.0);
     }
 
     fn store(
         #[comptime] _config: &Self::Config,
         position: u32,
-        output: &mut Tensor<N>,
-        output_indices: &mut Tensor<i32>,
+        output: &mut Tensor<Line<N>>,
+        output_indices: &mut Tensor<Line<i32>>,
         accumulator: Self::Accumulator,
     ) {
         output[position] = accumulator.0;
@@ -110,18 +121,27 @@ pub(crate) fn max_pool2d<R: CubeRuntime, E: CubeElement>(
         x.shape.dims[3],
     );
 
-    let shape_out = Shape::new([batch_size, channels, size_0, size_1]);
+    let x = if x.is_contiguous() {
+        nchw_to_nhwc::<R, E>(x)
+    } else {
+        permute(x, &[0, 2, 3, 1])
+    };
+
+    let line_size = max_vectorization(&x);
+
+    let shape_out = Shape::new([batch_size, size_0, size_1, channels]);
     let output = empty_device::<R, E>(x.client.clone(), x.device.clone(), shape_out);
 
     let cube_dim = CubeDim::default();
-    let cube_count = calculate_cube_count_elemwise(output.shape.num_elements(), cube_dim);
+    let cube_count =
+        calculate_cube_count_elemwise(output.shape.num_elements() / line_size as usize, cube_dim);
 
     pool2d_direct::launch::<E, MaxPoolStrategy, R>(
         &x.client,
         cube_count,
         cube_dim,
-        x.as_tensor_arg::<E>(1),
-        output.as_tensor_arg::<E>(1),
+        x.as_tensor_arg::<E>(line_size),
+        output.as_tensor_arg::<E>(line_size),
         (),
         Pool2dDirectArgsLaunch::new(
             ScalarArg::new(stride[0] as u32),
@@ -135,7 +155,7 @@ pub(crate) fn max_pool2d<R: CubeRuntime, E: CubeElement>(
         (),
     );
 
-    output
+    permute(output, &[0, 3, 1, 2])
 }
 
 pub(crate) fn max_pool2d_with_indices<R: CubeRuntime, E: CubeElement, I: CubeElement>(
@@ -162,20 +182,28 @@ pub(crate) fn max_pool2d_with_indices<R: CubeRuntime, E: CubeElement, I: CubeEle
         x.shape.dims[3],
     );
 
-    let shape_out = Shape::new([batch_size, channels, size_0, size_1]);
+    let x = if x.is_contiguous() {
+        nchw_to_nhwc::<R, E>(x)
+    } else {
+        permute(x, &[0, 2, 3, 1])
+    };
+    let line_size = max_vectorization(&x);
+
+    let shape_out = Shape::new([batch_size, size_0, size_1, channels]);
     let output = empty_device::<R, E>(x.client.clone(), x.device.clone(), shape_out.clone());
     let indices = empty_device::<R, I>(x.client.clone(), x.device.clone(), shape_out);
 
     let cube_dim = CubeDim::default();
-    let cube_count = calculate_cube_count_elemwise(output.shape.num_elements(), cube_dim);
+    let cube_count =
+        calculate_cube_count_elemwise(output.shape.num_elements() / line_size as usize, cube_dim);
 
     pool2d_direct::launch::<E, MaxPoolWithIndicesStrategy, R>(
         &x.client,
         cube_count,
         cube_dim,
-        x.as_tensor_arg::<E>(1),
-        output.as_tensor_arg::<E>(1),
-        indices.as_tensor_arg::<I>(1),
+        x.as_tensor_arg::<E>(line_size),
+        output.as_tensor_arg::<E>(line_size),
+        indices.as_tensor_arg::<I>(line_size),
         Pool2dDirectArgsLaunch::new(
             ScalarArg::new(stride[0] as u32),
             ScalarArg::new(stride[1] as u32),
@@ -187,5 +215,8 @@ pub(crate) fn max_pool2d_with_indices<R: CubeRuntime, E: CubeElement, I: CubeEle
         (kernel_size[0] as u32, kernel_size[1] as u32),
         (),
     );
+
+    let output = permute(output, &[0, 3, 1, 2]);
+    let indices = permute(indices, &[0, 3, 1, 2]);
     (output, indices)
 }

--- a/crates/burn-cubecl/src/kernel/pool/pool2d.rs
+++ b/crates/burn-cubecl/src/kernel/pool/pool2d.rs
@@ -14,19 +14,22 @@ pub(crate) trait Pool2dDirectStrategy<N: Numeric>: Send + Sync + 'static {
 
     type Indices: LaunchArg;
 
-    fn initialize(#[comptime] config: &Self::Config) -> Self::Accumulator;
+    fn initialize(
+        #[comptime] config: &Self::Config,
+        #[comptime] line_size: u32,
+    ) -> Self::Accumulator;
 
     fn accumulate(
         #[comptime] config: &Self::Config,
         accumulator: &mut Self::Accumulator,
         index: u32,
-        result: N,
+        result: Line<N>,
     );
 
     fn store(
         #[comptime] config: &Self::Config,
         position: u32,
-        output: &mut Tensor<N>,
+        output: &mut Tensor<Line<N>>,
         output_indices: &mut Self::Indices,
         accumulator: Self::Accumulator,
     );
@@ -44,45 +47,41 @@ pub struct Pool2dDirectArgs {
 
 #[cube(launch)]
 pub fn pool2d_direct<E: Numeric, S: Pool2dDirectStrategyFamily>(
-    input: &Tensor<E>,
-    output: &mut Tensor<E>,
+    input: &Tensor<Line<E>>,
+    output: &mut Tensor<Line<E>>,
     indices: &mut S::Indices,
     args: &Pool2dDirectArgs,
     #[comptime] kernel_size: (u32, u32),
     #[comptime] config: &S::Config,
 ) {
-    let (output_stride_0, output_stride_1, output_stride_2, output_stride_3) = (
-        output.stride(0),
-        output.stride(1),
-        output.stride(2),
-        output.stride(3),
-    );
-    let (output_shape_0, output_shape_1, output_shape_2, output_shape_3) = (
-        output.shape(0),
-        output.shape(1),
-        output.shape(2),
-        output.shape(3),
-    );
-    let (input_stride_0, input_stride_1, input_stride_2, input_stride_3) = (
+    if ABSOLUTE_POS >= output.len() {
+        terminate!();
+    }
+
+    let (out_h, out_w, channels) = (output.shape(1), output.shape(2), output.shape(3));
+    let channel_lines = channels / input.line_size();
+    let (in_stride_b, in_stride_h, in_stride_w, in_stride_c) = (
         input.stride(0),
         input.stride(1),
         input.stride(2),
         input.stride(3),
     );
-    let (input_shape_2, input_shape_3) = (input.shape(2), input.shape(3));
+    let (in_h, in_w) = (input.shape(1), input.shape(2));
 
-    let b = (ABSOLUTE_POS / output_stride_0) % output_shape_0;
-    let c = (ABSOLUTE_POS / output_stride_1) % output_shape_1;
-    let oh = (ABSOLUTE_POS / output_stride_2) % output_shape_2;
-    let ow = (ABSOLUTE_POS / output_stride_3) % output_shape_3;
+    let c = (ABSOLUTE_POS % channel_lines) * input.line_size();
+    let pos = ABSOLUTE_POS / channel_lines;
+    let ow = pos % out_w;
+    let pos = pos / out_w;
+    let oh = pos % out_h;
+    let b = pos / out_h;
 
-    let mut accumulator = S::Pool2d::<E>::initialize(config);
+    let mut accumulator = S::Pool2d::<E>::initialize(config, input.line_size());
 
-    let index_input_0 = b * input_stride_0;
-    let index_input_1 = c * input_stride_1;
+    let in_b_off = b * in_stride_b;
+    let in_c_off = c * in_stride_c;
 
-    let border_bottom = input_shape_2 + args.padding_0;
-    let border_right = input_shape_3 + args.padding_1;
+    let border_bottom = in_h + args.padding_0;
+    let border_right = in_w + args.padding_1;
 
     for kh in 0..kernel_size.0 {
         let ih = oh * args.strides_0 + kh * args.dilation_0;
@@ -96,16 +95,16 @@ pub fn pool2d_direct<E: Numeric, S: Pool2dDirectStrategyFamily>(
                 let ih_pad = ih - args.padding_0;
                 let iw_pad = iw - args.padding_1;
 
-                let index_input_2 = ih_pad * input_stride_2;
-                let index_input_3 = iw_pad * input_stride_3;
+                let in_h_off = ih_pad * in_stride_h;
+                let in_w_off = iw_pad * in_stride_w;
 
-                let index_input = index_input_0 + index_input_1 + index_input_2 + index_input_3;
+                let index_input = in_b_off + in_c_off + in_h_off + in_w_off;
 
                 S::Pool2d::<E>::accumulate(
                     config,
                     &mut accumulator,
-                    index_input_2 + iw_pad,
-                    input[index_input],
+                    ih_pad * in_w + iw_pad,
+                    input[index_input / input.line_size()],
                 );
             }
         }

--- a/crates/burn-tensor/src/tests/quantization/ops/quantize.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/quantize.rs
@@ -212,6 +212,7 @@ mod tests {
         x.into_data().assert_approx_eq(&tensor.into_data(), 2);
     }
 
+    #[allow(clippy::excessive_precision)]
     #[cfg(feature = "std")]
     #[might_panic(reason = "Per-block quantization is not supported")]
     #[test]


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

Uses the custom transpose kernel from implicit GEMM convolution to switch all pooling operations to NHWC, and vectorizes along the channel dimension. This improves performance by approx. 20-25% when processing contiguous NCHW tensors, more when processing contiguous NHWC (i.e. output from implicit GEMM convolution). While migrating the kernels, I also renamed all variables that were just numbered to something more semantically meaningful.

### Testing

All tests pass, and changes to the kernels are kept as minimal as possible.