### PR TITLE
Deterministic rng in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,6 +666,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_json",
+ "serial_test",
  "spin",
  "thiserror 2.0.11",
  "uuid",

--- a/crates/burn-core/Cargo.toml
+++ b/crates/burn-core/Cargo.toml
@@ -121,6 +121,7 @@ burn-autodiff = { path = "../burn-autodiff", version = "0.17.0" }
 burn-dataset = { path = "../burn-dataset", version = "0.17.0", features = [
     "fake",
 ] }
+serial_test.workspace = true
 
 [package.metadata.docs.rs]
 features = ["doc"]

--- a/crates/burn-core/src/nn/conv/conv1d.rs
+++ b/crates/burn-core/src/nn/conv/conv1d.rs
@@ -159,8 +159,6 @@ mod tests {
 
     #[test]
     fn initializer_default() {
-        TestBackend::seed(0);
-
         let config = Conv1dConfig::new(5, 5, 5);
         let k = (config.channels_in * config.kernel_size) as f64;
         let k = (config.groups as f64 / k).sqrt() as f32;
@@ -171,8 +169,6 @@ mod tests {
 
     #[test]
     fn initializer_zeros() {
-        TestBackend::seed(0);
-
         let config = Conv1dConfig::new(5, 5, 5).with_initializer(Initializer::Zeros);
         let conv = config.init::<TestBackend>(&Default::default());
 

--- a/crates/burn-core/src/nn/conv/conv2d.rs
+++ b/crates/burn-core/src/nn/conv/conv2d.rs
@@ -170,8 +170,6 @@ mod tests {
 
     #[test]
     fn initializer_default() {
-        TestBackend::seed(0);
-
         let config = Conv2dConfig::new([5, 1], [5, 5]);
         let k = (config.channels[0] * config.kernel_size[0] * config.kernel_size[1]) as f64;
         let k = (config.groups as f64 / k).sqrt() as f32;
@@ -183,8 +181,6 @@ mod tests {
 
     #[test]
     fn initializer_zeros() {
-        TestBackend::seed(0);
-
         let config = Conv2dConfig::new([5, 2], [5, 5]).with_initializer(Initializer::Zeros);
         let device = Default::default();
         let conv = config.init::<TestBackend>(&device);
@@ -197,8 +193,6 @@ mod tests {
 
     #[test]
     fn initializer_fan_out() {
-        TestBackend::seed(0);
-
         let init = Initializer::KaimingUniform {
             gain: 1.0 / 3.0f64.sqrt(),
             fan_out_only: true, // test that fan_out is passed to `init_with()`
@@ -212,8 +206,6 @@ mod tests {
 
     #[test]
     fn initializer_fan_with_groups_is_valid() {
-        TestBackend::seed(0);
-
         let init = Initializer::KaimingUniform {
             gain: 1.0 / 3.0f64.sqrt(),
             fan_out_only: true,

--- a/crates/burn-core/src/nn/conv/conv3d.rs
+++ b/crates/burn-core/src/nn/conv/conv3d.rs
@@ -171,8 +171,6 @@ mod tests {
 
     #[test]
     fn initializer_default() {
-        TestBackend::seed(0);
-
         let config = Conv3dConfig::new([5, 1], [5, 5, 5]);
         let k = (config.channels[0]
             * config.kernel_size[0]
@@ -187,8 +185,6 @@ mod tests {
 
     #[test]
     fn initializer_zeros() {
-        TestBackend::seed(0);
-
         let config = Conv3dConfig::new([5, 2], [5, 5, 5]).with_initializer(Initializer::Zeros);
         let device = Default::default();
         let conv = config.init::<TestBackend>(&device);
@@ -201,8 +197,6 @@ mod tests {
 
     #[test]
     fn initializer_fan_out() {
-        TestBackend::seed(0);
-
         let init = Initializer::KaimingUniform {
             gain: 1.0 / 3.0f64.sqrt(),
             fan_out_only: true, // test that fan_out is passed to `init_with()`
@@ -216,8 +210,6 @@ mod tests {
 
     #[test]
     fn initializer_fan_with_groups_is_valid() {
-        TestBackend::seed(0);
-
         let init = Initializer::KaimingUniform {
             gain: 1.0 / 3.0f64.sqrt(),
             fan_out_only: true,

--- a/crates/burn-core/src/nn/conv/conv_transpose1d.rs
+++ b/crates/burn-core/src/nn/conv/conv_transpose1d.rs
@@ -163,8 +163,6 @@ mod tests {
 
     #[test]
     fn initializer_default() {
-        TestBackend::seed(0);
-
         let config = ConvTranspose1dConfig::new([5, 1], 5);
         let k = (config.channels[1] * config.kernel_size) as f64;
         let k = (config.groups as f64 / k).sqrt() as f32;
@@ -175,8 +173,6 @@ mod tests {
 
     #[test]
     fn initializer_zeros() {
-        TestBackend::seed(0);
-
         let config = ConvTranspose1dConfig::new([5, 2], 5).with_initializer(Initializer::Zeros);
         let conv = config.init::<TestBackend>(&Default::default());
 

--- a/crates/burn-core/src/nn/conv/conv_transpose2d.rs
+++ b/crates/burn-core/src/nn/conv/conv_transpose2d.rs
@@ -164,8 +164,6 @@ mod tests {
 
     #[test]
     fn initializer_default() {
-        TestBackend::seed(0);
-
         let config = ConvTranspose2dConfig::new([5, 1], [5, 5]);
         let k = (config.channels[1] * config.kernel_size[0] * config.kernel_size[1]) as f64;
         let k = (config.groups as f64 / k).sqrt() as f32;
@@ -176,8 +174,6 @@ mod tests {
 
     #[test]
     fn initializer_zeros() {
-        TestBackend::seed(0);
-
         let config =
             ConvTranspose2dConfig::new([5, 2], [5, 5]).with_initializer(Initializer::Zeros);
         let conv = config.init::<TestBackend>(&Default::default());

--- a/crates/burn-core/src/nn/conv/conv_transpose3d.rs
+++ b/crates/burn-core/src/nn/conv/conv_transpose3d.rs
@@ -165,8 +165,6 @@ mod tests {
 
     #[test]
     fn initializer_default() {
-        TestBackend::seed(0);
-
         let config = ConvTranspose3dConfig::new([5, 1], [5, 5, 5]);
         let k = (config.channels[1]
             * config.kernel_size[0]
@@ -180,8 +178,6 @@ mod tests {
 
     #[test]
     fn initializer_zeros() {
-        TestBackend::seed(0);
-
         let config =
             ConvTranspose3dConfig::new([5, 2], [5, 5, 5]).with_initializer(Initializer::Zeros);
         let conv = config.init::<TestBackend>(&Default::default());

--- a/crates/burn-core/src/nn/conv/deform_conv2d.rs
+++ b/crates/burn-core/src/nn/conv/deform_conv2d.rs
@@ -192,8 +192,6 @@ mod tests {
 
     #[test]
     fn initializer_default() {
-        TestBackend::seed(0);
-
         let config = DeformConv2dConfig::new([5, 1], [5, 5]);
         let k = (config.channels[0] * config.kernel_size[0] * config.kernel_size[1]) as f64;
         let k = (config.offset_groups as f64 / k).sqrt() as f32;
@@ -205,8 +203,6 @@ mod tests {
 
     #[test]
     fn initializer_zeros() {
-        TestBackend::seed(0);
-
         let config = DeformConv2dConfig::new([5, 2], [5, 5]).with_initializer(Initializer::Zeros);
         let device = Default::default();
         let conv = config.init::<TestBackend>(&device);
@@ -219,8 +215,6 @@ mod tests {
 
     #[test]
     fn initializer_fan_out() {
-        TestBackend::seed(0);
-
         let init = Initializer::KaimingUniform {
             gain: 1.0 / 3.0f64.sqrt(),
             fan_out_only: true, // test that fan_out is passed to `init_with()`
@@ -234,8 +228,6 @@ mod tests {
 
     #[test]
     fn initializer_fan_with_groups_is_valid() {
-        TestBackend::seed(0);
-
         let init = Initializer::KaimingUniform {
             gain: 1.0 / 3.0f64.sqrt(),
             fan_out_only: true,

--- a/crates/burn-core/src/nn/embedding.rs
+++ b/crates/burn-core/src/nn/embedding.rs
@@ -100,10 +100,10 @@ mod tests {
         );
         var_act
             .to_data()
-            .assert_approx_eq(&TensorData::from([1.0f32]), 0);
+            .assert_approx_eq(&TensorData::from([1.0f32]), 1);
         mean_act
             .to_data()
-            .assert_approx_eq(&TensorData::from([0.0f32]), 0);
+            .assert_approx_eq(&TensorData::from([0.0f32]), 1);
     }
 
     #[test]

--- a/crates/burn-core/src/nn/embedding.rs
+++ b/crates/burn-core/src/nn/embedding.rs
@@ -80,11 +80,12 @@ mod tests {
     use super::*;
     use crate::tensor::TensorData;
     use crate::TestBackend;
+    use serial_test::serial;
 
     #[test]
+    #[serial]
     fn initializer_default() {
         TestBackend::seed(0);
-
         let config = EmbeddingConfig::new(100, 10);
         let embed = config.init::<TestBackend>(&Default::default());
         let weights = embed.weight.val().reshape([1000]);

--- a/crates/burn-core/src/nn/initializer.rs
+++ b/crates/burn-core/src/nn/initializer.rs
@@ -234,8 +234,6 @@ mod tests {
 
     #[test]
     fn initializer_uniform_init() {
-        TB::seed(0);
-
         let (min, max) = (0.0, 1.0);
         let uniform = Initializer::Uniform { min, max };
         let tensor: Tensor<TB, 4> = uniform.init([2, 2, 2, 2], &Default::default()).into_value();
@@ -302,8 +300,6 @@ mod tests {
 
     #[test]
     fn initializer_kaiming_uniform_init() {
-        TB::seed(0);
-
         let gain = 2_f64;
         let (fan_in, fan_out) = (5, 6);
         let k = gain * (3.0 / fan_in as f64).sqrt();
@@ -338,8 +334,6 @@ mod tests {
 
     #[test]
     fn initializer_kaiming_uniform_init_bias() {
-        TB::seed(0);
-
         let gain = 2_f64;
         let shape = [3];
         let fan_in = 5;
@@ -356,8 +350,6 @@ mod tests {
 
     #[test]
     fn initializer_kaiming_uniform_init_fan_out() {
-        TB::seed(0);
-
         let gain = 2_f64;
         let (fan_in, fan_out) = (5, 6);
         let k = gain * (3.0 / fan_out as f64).sqrt();
@@ -374,8 +366,6 @@ mod tests {
     #[test]
     #[should_panic]
     fn initializer_kaiming_uniform_no_fan() {
-        TB::seed(0);
-
         let gain = 2_f64;
         let (fan_in, fan_out) = (5, 6);
 
@@ -389,8 +379,6 @@ mod tests {
 
     #[test]
     fn initializer_xavier_uniform_init() {
-        TB::seed(0);
-
         let gain = 2.;
         let (fan_in, fan_out) = (5, 6);
         let bound = gain * (6. / (fan_in + fan_out) as f64).sqrt();
@@ -430,8 +418,6 @@ mod tests {
     #[test]
     #[should_panic]
     fn initializer_xavier_uniform_no_fan() {
-        TB::seed(0);
-
         let gain = 2.;
         let (fan_in, fan_out) = (5, 6);
         let _: Tensor<TB, 2> = Initializer::XavierUniform { gain }

--- a/crates/burn-core/src/nn/initializer.rs
+++ b/crates/burn-core/src/nn/initializer.rs
@@ -202,6 +202,7 @@ mod tests {
 
     use crate::tensor::{ElementConversion, TensorData};
     use num_traits::Pow;
+    use serial_test::serial;
 
     pub type TB = burn_ndarray::NdArray<f32>;
 
@@ -243,6 +244,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn initializer_normal_init() {
         // seed random generator
         TB::seed(0);
@@ -316,6 +318,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn initializer_kaiming_normal_init() {
         TB::seed(0);
 
@@ -404,6 +407,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn initializer_xavier_normal_init() {
         TB::seed(0);
 

--- a/crates/burn-core/src/nn/linear.rs
+++ b/crates/burn-core/src/nn/linear.rs
@@ -111,8 +111,6 @@ mod tests {
 
     #[test]
     fn initializer_default() {
-        TestBackend::seed(0);
-
         let config = LinearConfig::new(5, 5);
         let k = (1.0 / config.d_input as f64).sqrt() as f32;
         let device = Default::default();
@@ -130,8 +128,6 @@ mod tests {
 
     #[test]
     fn initializer_zeros() {
-        TestBackend::seed(0);
-
         let config = LinearConfig::new(5, 5).with_initializer(Initializer::Zeros);
         let device = Default::default();
         let linear = config.init::<TestBackend>(&device);
@@ -145,8 +141,6 @@ mod tests {
 
     #[test]
     fn test_linear_forward_no_bias() {
-        TestBackend::seed(0);
-
         let value = 2.;
         let config = LinearConfig::new(2, 3)
             .with_initializer(Initializer::Constant { value })
@@ -163,8 +157,6 @@ mod tests {
 
     #[test]
     fn test_linear_forward_with_bias() {
-        TestBackend::seed(0);
-
         let device = Default::default();
 
         let value = 2.;
@@ -180,8 +172,6 @@ mod tests {
 
     #[test]
     fn test_linear_1d() {
-        TestBackend::seed(0);
-
         let device = Default::default();
 
         let value = 2.;

--- a/crates/burn-core/src/nn/rnn/gru.rs
+++ b/crates/burn-core/src/nn/rnn/gru.rs
@@ -246,6 +246,7 @@ mod tests {
     use super::*;
     use crate::tensor::{Distribution, TensorData};
     use crate::{module::Param, nn::LinearRecord, TestBackend};
+    use serial_test::serial;
 
     fn init_gru<B: Backend>(reset_after: bool, device: &B::Device) -> Gru<B> {
         fn create_gate_controller<B: Backend>(
@@ -316,6 +317,7 @@ mod tests {
     ///
     /// h_t = z_t * h' + (1 - z_t) * g_t = 0.0341
     #[test]
+    #[serial]
     fn tests_forward_single_input_single_feature() {
         TestBackend::seed(0);
         let device = Default::default();
@@ -345,6 +347,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn tests_forward_seq_len_3() {
         TestBackend::seed(0);
         let device = Default::default();

--- a/crates/burn-core/src/nn/rnn/lstm.rs
+++ b/crates/burn-core/src/nn/rnn/lstm.rs
@@ -357,6 +357,7 @@ mod tests {
     use super::*;
     use crate::tensor::{Device, Distribution, TensorData};
     use crate::{module::Param, nn::LinearRecord, TestBackend};
+    use serial_test::serial;
 
     #[cfg(feature = "std")]
     use crate::TestAutodiffBackend;
@@ -387,6 +388,7 @@ mod tests {
     /// C_t = f_t * 0 + i_t * c_t = 0 + 0.5123725 * 0.0892937 = 0.04575243
     /// h_t = o_t * tanh(C_t) = 0.5274723 * tanh(0.04575243) = 0.5274723 * 0.04568173 = 0.024083648
     #[test]
+    #[serial]
     fn test_forward_single_input_single_feature() {
         TestBackend::seed(0);
         let config = LstmConfig::new(1, 1, false);
@@ -537,6 +539,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_bidirectional() {
         TestBackend::seed(0);
         let config = BiLstmConfig::new(2, 3, true);

--- a/crates/burn-core/src/nn/rnn/lstm.rs
+++ b/crates/burn-core/src/nn/rnn/lstm.rs
@@ -364,8 +364,6 @@ mod tests {
 
     #[test]
     fn test_with_uniform_initializer() {
-        TestBackend::seed(0);
-
         let config = LstmConfig::new(5, 5, false)
             .with_initializer(Initializer::Uniform { min: 0.0, max: 1.0 });
         let lstm = config.init::<TestBackend>(&Default::default());

--- a/crates/burn-core/src/nn/swiglu.rs
+++ b/crates/burn-core/src/nn/swiglu.rs
@@ -95,7 +95,6 @@ mod tests {
 
     #[test]
     fn test_swiglu_forward_no_bias() {
-        TestBackend::seed(0);
         let device = Default::default();
         let config = SwiGluConfig::new(3, 3).with_initializer(Initializer::Constant { value: 0.5 });
         let swiglu = config.init(&device);
@@ -113,7 +112,6 @@ mod tests {
 
     #[test]
     fn test_swiglu_forward_with_bias() {
-        TestBackend::seed(0);
         let device = Default::default();
         let config = SwiGluConfig::new(3, 3)
             .with_bias(true)

--- a/crates/burn-core/src/nn/transformer/decoder.rs
+++ b/crates/burn-core/src/nn/transformer/decoder.rs
@@ -463,7 +463,6 @@ mod tests {
     #[test]
     fn test_autoregressive_norm_last() {
         let [d_model, d_ff, n_heads, num_layers] = [12, 24, 2, 3];
-        TestBackend::seed(0);
 
         test_autoregressive(
             TransformerDecoderConfig::new(d_model, d_ff, n_heads, num_layers)
@@ -474,7 +473,6 @@ mod tests {
     #[test]
     fn test_autoregressive_norm_first() {
         let [d_model, d_ff, n_heads, num_layers] = [12, 24, 2, 3];
-        TestBackend::seed(0);
 
         test_autoregressive(
             TransformerDecoderConfig::new(d_model, d_ff, n_heads, num_layers).with_norm_first(true),

--- a/crates/burn-cubecl/Cargo.toml
+++ b/crates/burn-cubecl/Cargo.toml
@@ -65,6 +65,9 @@ burn-ndarray = { path = "../burn-ndarray", version = "0.17.0", optional = true }
 paste = { workspace = true, optional = true }
 serial_test = { workspace = true, optional = true }
 
+[dev-dependencies]
+serial_test.workspace = true
+
 [package.metadata.docs.rs]
 features = ["doc"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/burn-cubecl/src/tests/avg_pool2d.rs
+++ b/crates/burn-cubecl/src/tests/avg_pool2d.rs
@@ -4,6 +4,7 @@ mod tests {
     use burn_tensor::{
         backend::Backend, module, ops::ModuleOps, Distribution, Tensor, TensorPrimitive,
     };
+    use serial_test::serial;
 
     #[test]
     fn avg_pool2d_should_match_reference_backend() {
@@ -29,6 +30,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn avg_pool2d_backward_should_match_reference_backend() {
         TestBackend::seed(0);
         ReferenceBackend::seed(0);

--- a/crates/burn-cubecl/src/tests/cat.rs
+++ b/crates/burn-cubecl/src/tests/cat.rs
@@ -19,7 +19,6 @@ mod tests {
     }
 
     fn test_same_as_reference(shape: [usize; 2], num_tensors: usize, dim: usize) {
-        TestBackend::seed(0);
         let tensors = (0..num_tensors)
             .map(|_| {
                 Tensor::<TestBackend, 2>::random(shape, Distribution::Default, &Default::default())

--- a/crates/burn-cubecl/src/tests/conv_transpose2d.rs
+++ b/crates/burn-cubecl/src/tests/conv_transpose2d.rs
@@ -5,8 +5,6 @@ mod tests {
 
     #[test]
     fn conv_transpose2d_should_match_reference_backend() {
-        TestBackend::seed(0);
-
         let height = 8;
         let width = 8;
         let in_channels = 8;

--- a/crates/burn-cubecl/src/tests/conv_transpose3d.rs
+++ b/crates/burn-cubecl/src/tests/conv_transpose3d.rs
@@ -5,8 +5,6 @@ mod tests {
 
     #[test]
     fn conv_transpose3d_should_match_reference_backend() {
-        TestBackend::seed(0);
-
         let depth = 8;
         let height = 8;
         let width = 8;

--- a/crates/burn-cubecl/src/tests/gather.rs
+++ b/crates/burn-cubecl/src/tests/gather.rs
@@ -14,7 +14,6 @@ mod tests {
     }
 
     fn test_same_as_ref<const D: usize>(shape: [usize; D], dim: usize) {
-        TestBackend::seed(0);
         let max = shape[dim];
         let shape = Shape::new(shape);
         let tensor = Tensor::<TestBackend, D>::random(

--- a/crates/burn-cubecl/src/tests/mask_where.rs
+++ b/crates/burn-cubecl/src/tests/mask_where.rs
@@ -68,7 +68,6 @@ mod tests {
         Tensor<ReferenceBackend, 3>,
         Tensor<ReferenceBackend, 3, Bool>,
     ) {
-        TestBackend::seed(0);
         let device = Default::default();
         let tensor = Tensor::<TestBackend, 3>::random([2, 6, 256], Distribution::Default, &device);
         let value = Tensor::<TestBackend, 3>::random([2, 6, 256], Distribution::Default, &device);

--- a/crates/burn-cubecl/src/tests/scatter.rs
+++ b/crates/burn-cubecl/src/tests/scatter.rs
@@ -38,7 +38,6 @@ mod tests {
         shape1: [usize; D],
         shape2: [usize; D],
     ) {
-        TestBackend::seed(0);
         let test_device = Default::default();
         let tensor = Tensor::<TestBackend, D>::random(shape1, Distribution::Default, &test_device);
         let value = Tensor::<TestBackend, D>::random(shape2, Distribution::Default, &test_device);

--- a/crates/burn-cubecl/src/tests/select_assign.rs
+++ b/crates/burn-cubecl/src/tests/select_assign.rs
@@ -29,7 +29,6 @@ mod tests {
     }
 
     fn select_assign_same_as_ref<const D: usize>(dim: usize, shape: [usize; D]) {
-        TestBackend::seed(0);
         let tensor =
             Tensor::<TestBackend, D>::random(shape, Distribution::Default, &Default::default());
         let value =


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Problem

1. Normal distributions are unbounded, so there is a small chance the variables or their properties will be outside the test range.
2. The RNG is a global static, this introduces a race condition when tests are run in parallel that allows seeded tests to be non-deterministic

Example: `thread 'nn::initializer::tests::initializer_normal_init' panicked at crates/burn-core/src/nn/initializer.rs:258:9:
Expected variance to be between 1.0 += 0.1, but got 1.1060424`

### Solution

If tests rely on specific rng, they should be tagged `#[serial]`.
If tests do not rely on specific rng (uniform or constant distribution), they should not be seeded.

### Testing

Ran the affected tests