### PR TITLE
Add .d_input()/.d_output() methods to Linear

### DIFF
--- a/crates/burn-core/src/nn/linear.rs
+++ b/crates/burn-core/src/nn/linear.rs
@@ -84,6 +84,16 @@ impl<B: Backend> Linear<B> {
             None => output,
         }
     }
+
+    /// Returns the input dimension size.
+    pub fn d_input(&self) -> usize {
+        self.weight.dims()[0]
+    }
+
+    /// Returns the output dimension size.
+    pub fn d_output(&self) -> usize {
+        self.weight.dims()[1]
+    }
 }
 
 impl<B: Backend> ModuleDisplay for Linear<B> {
@@ -141,6 +151,21 @@ mod tests {
             .weight
             .to_data()
             .assert_approx_eq(&TensorData::zeros::<f32, _>(linear.weight.shape()), 3);
+    }
+
+    #[test]
+    fn test_features() {
+        TestBackend::seed(0);
+
+        let d_input = 2;
+        let d_output = 3;
+
+        let config = LinearConfig::new(d_input, d_output);
+        let device = Default::default();
+        let linear = config.init::<TestBackend>(&device);
+
+        assert_eq!(linear.d_input(), d_input);
+        assert_eq!(linear.d_output(), d_output);
     }
 
     #[test]

--- a/crates/burn-core/src/nn/linear.rs
+++ b/crates/burn-core/src/nn/linear.rs
@@ -154,7 +154,7 @@ mod tests {
     }
 
     #[test]
-    fn test_features() {
+    fn test_input_output_dims() {
         TestBackend::seed(0);
 
         let d_input = 2;


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

Added in/out introspection methods to Linear;
so assertions can be written relative to Linear's configs,
rather than reaching into the `.weights.dim()[]` manually.

### Testing

Wrote a test.