### PR TITLE
Add empty output string check for is_top_sorted

### DIFF
--- a/crates/onnx-ir/src/from_onnx.rs
+++ b/crates/onnx-ir/src/from_onnx.rs
@@ -426,6 +426,11 @@ impl TopologicalSortable for Vec<NodeProto> {
         for node in self {
             // Iterate over each output of the node
             for output in &node.output {
+                // In certain cases, the outputs and inputs of a node can contain empty strings
+                // this causes false positives that the graph isn't sorted.
+                if output.is_empty() {
+                    continue;
+                }
                 // Iterate over each other node in the vector
                 for other_node in self {
                     // If the other node has an input that matches the current output


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [] Confirmed that `run-checks all` script has been executed. (Failing on unrelated code)
- [ ] Made sure the book is up to date with changes in this PR. (Not applicable)

### Related Issues/PRs

N/A

### Changes

Currently certain ONNX files have extraneous empty output strings when parsed using burn-import. This causes issues with `is_top_sorted` because the empty strings match on the inputs and outputs even though they aren't actually connected in the graph. 

An example ONNX file that triggers this issue : https://huggingface.co/HuggingFaceTB/SmolLM2-360M-Instruct/blob/main/onnx/model.onnx

The fix here is pretty simple, just check if we are comparing against an empty output string and move on in the vector. There are many other ways to solve this, this seems the most straightforward.

### Testing

Tested by reloading the problematic ONNX file which now fails on an unimplemented ONNX Op, progress.
