### PR TITLE
Added graph node pruning

### DIFF
--- a/crates/onnx-ir/src/from_onnx.rs
+++ b/crates/onnx-ir/src/from_onnx.rs
@@ -343,14 +343,13 @@ impl OnnxGraphBuilder {
 ///
 /// * If the file cannot be opened
 /// * If the file cannot be parsed
-/// * If the graph is missing from the parsed ModelProto
 /// * If the nodes are not topologically sorted
 pub fn parse_onnx(onnx_path: &Path) -> OnnxGraph {
     log::info!("Parsing ONNX file: {}", onnx_path.display());
 
     // Open the file
     let mut file = File::open(onnx_path).expect("Unable to open file");
-    let mut onnx_model: ModelProto =
+    let onnx_model: ModelProto =
         Message::parse_from_reader(&mut file).expect("Unable to parse ONNX file");
 
     // ONNX nodes must be topologically sorted per spec:


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ ] Confirmed that `run-checks all` script has been executed. (Fails in Burn-Tensor)
- [ ] Made sure the book is up to date with changes in this PR. (N/A)

### Related Issues/PRs

N/A

### Changes

Currently certain ONNX files have extraneous empty output strings when parsed using burn-import. This causes issues with is_top_sorted because the empty strings match on the inputs and outputs even though they aren't actually connected in the graph.

This also causes warnings when attempting to guess the inputs for various node types since the input doesn't have a type associated with it in the graph.

An example ONNX file that triggers this issue : https://huggingface.co/HuggingFaceTB/SmolLM2-360M-Instruct/blob/main/onnx/model.onnx

The fix here is to go through the entire graph once it is loaded from the `onnx` file and prune every node's inputs and outputs `Vec<String>` to remove empty strings. Added bonus here is that it should improve the performance of topology checks, as well as any other iterating over all inputs or outputs since we can remove useless entries from the tree.

Example of empty output:
![image](https://github.com/user-attachments/assets/53f09aec-ec2f-486d-9cbb-e6524a5a0359)

Example of empty input:
![image1](https://github.com/user-attachments/assets/4198e4dd-029f-46d3-ad73-206f72a960d2)

Both of these types are in Microsoft's domain, so perhaps this isn't a true ONNX issue, but this pruning shouldn't affect any other implementations that are fully populated.

### Testing

Tested by reloading the problematic ONNX file which now fails on an unimplemented ONNX Op, progress.
