### PR TITLE
Fix Shape, Reshape, and invalid rust variable names.

### DIFF
--- a/crates/burn-import/src/burn/ty.rs
+++ b/crates/burn-import/src/burn/ty.rs
@@ -69,7 +69,9 @@ impl Type {
         if name_is_number {
             format!("_{}", name)
         } else {
-            name.to_string()
+            // Format the name by replacing invalid rust variable names, there is probably more to do here
+            // but these are the ones I ran into.
+            name.replace(".", "_").replace(":", "_")
         }
     }
     pub fn name(&self) -> &Ident {

--- a/crates/burn-import/src/onnx/op_configuration.rs
+++ b/crates/burn-import/src/onnx/op_configuration.rs
@@ -1251,26 +1251,26 @@ pub fn reshape_config(node: &Node) -> Vec<i64> {
     // Burn does not support zero size shape (0 means false in ONNX)
     // (see https://onnx.ai/onnx/operators/onnx__Reshape.html#attributes)
     if allowzero != 0 {
-        panic!("Zero shape size is not supported");
+        panic!("Reshape: Zero shape size is not supported");
     }
 
-    // TODO: check "shape" attribute
-    if node.inputs.len() != 2 || node.inputs[1].value.is_none() {
-        panic!("Reshape: shape tensor must be present for {:?}", node);
-    }
-
-    let input_value = &node.inputs[1].value;
     match &node.inputs[1].ty {
         ArgType::Tensor(tensor) => {
             assert_eq!(tensor.rank, 1, "Reshape: shape tensor must be 1D");
 
-            if let Some(Data::Int64s(shape)) = input_value.as_ref() {
-                shape.clone()
+            if tensor.elem_type != ElementType::Int64 {
+                panic!("Reshape: shape tensor must have element type int64");
             } else {
-                panic!("Tensor data type must be int64")
+                tensor
+                    .shape
+                    .clone()
+                    .unwrap()
+                    .iter()
+                    .map(|x| *x as i64)
+                    .collect()
             }
         }
-        _ => panic!("Only tensor input is valid for shape"),
+        _ => panic!("Reshape: Only tensor input is valid for shape"),
     }
 }
 

--- a/crates/burn-import/src/onnx/op_configuration.rs
+++ b/crates/burn-import/src/onnx/op_configuration.rs
@@ -1257,9 +1257,14 @@ pub fn reshape_config(node: &Node) -> Vec<i64> {
     match &node.inputs[1].ty {
         ArgType::Tensor(tensor) => {
             assert_eq!(tensor.rank, 1, "Reshape: shape tensor must be 1D");
+            assert_eq!(
+                tensor.elem_type,
+                ElementType::Int64,
+                "Reshape: shape tensor must have element type int64"
+            );
 
-            if tensor.elem_type != ElementType::Int64 {
-                panic!("Reshape: shape tensor must have element type int64");
+            if let Some(Data::Int64s(shape)) = &node.inputs[1].value {
+                shape.clone()
             } else {
                 tensor
                     .shape

--- a/crates/onnx-ir/src/rank_inference.rs
+++ b/crates/onnx-ir/src/rank_inference.rs
@@ -337,7 +337,12 @@ fn concat_update_outputs(node: &mut Node) {
 
 fn reshape_update_outputs(node: &mut Node) {
     let shape = if node.inputs.len() == 2 {
-        if let ArgType::Tensor(tensor) = &node.inputs[1].ty {
+        if let Some(value) = &node.inputs[1].value {
+            match value {
+                Data::Int64s(shape) => shape.clone(),
+                _ => panic!("Reshape: invalid input types"),
+            }
+        } else if let ArgType::Tensor(tensor) = &node.inputs[1].ty {
             tensor
                 .shape
                 .clone()
@@ -360,7 +365,7 @@ fn reshape_update_outputs(node: &mut Node) {
     node.outputs[0].ty = ArgType::Tensor(TensorType {
         rank: shape.len(),
         shape: None, // shape is calculated at runtime
-        elem_type: ElementType::Int64,
+        elem_type: node.inputs[0].ty.elem_type().clone(),
     });
 }
 


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ ] Confirmed that `run-checks all` script has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

#2930

### Changes

#### Shape 

- **shape_update_outputs** : Changed the output type to a Tensor as per the Onnx specification. It always outputs a `Tensor`, not a `Shape`.

#### Reshape

- Added improved error reporting. Its really hard to tell where errors are coming from when doing the build, so I made sure everything had `Reshape:` for some extra information
- **reshape_config** : Removed check on input length and input value. The input.value is None, because the input is a Tensor, you can't use value you have to check the Tensor.shape()
- **shape_update_outputs** : Fixed output Tensor elem_type and ensured that `shape` was a valid Vec, this is again done by not trying to get the `value`, but instead looking at the `shape` on the Tensor.

#### format_name
- Simple change, just replace characters that are invalid Rust variable names with underscores. This could possibly be done with a regex, but I don't know that it is entirely necessary right now. I just replaced the characters I ran into issues with while testing.

### Testing

Run `cargo test` on `burn-import` crate with all passing. Also using file referenced in #2930 as a test file.
