### PR TITLE
Check channels_in matches in convolution layers

### DIFF
--- a/crates/burn-core/src/nn/conv/conv1d.rs
+++ b/crates/burn-core/src/nn/conv/conv1d.rs
@@ -137,7 +137,13 @@ impl<B: Backend> Conv1d<B> {
     /// - input: `[batch_size, channels_in, length_in]`
     /// - output: `[batch_size, channels_out, length_out]`
     pub fn forward(&self, input: Tensor<B, 3>) -> Tensor<B, 3> {
-        let [_batch_size, _channels, length] = input.dims();
+        let [_batch_size, channels_in, length] = input.dims();
+        let expected = self.weight.dims()[1] * self.groups;
+        assert_eq!(
+            channels_in, expected,
+            "This conv layer requies a channels_in dimension of {expected}, but got {channels_in}"
+        );
+
         let padding = self
             .padding
             .calculate_padding_1d(length, self.kernel_size, self.stride);
@@ -199,5 +205,15 @@ mod tests {
             alloc::format!("{}", conv),
             "Conv1d {stride: 1, kernel_size: 5, dilation: 1, groups: 1, padding: Valid, params: 130}"
         );
+    }
+
+    #[test]
+    #[should_panic = "This conv layer requies a channels_in dimension of 5, but got 3"]
+    fn input_channels_mismatch() {
+        let config = Conv1dConfig::new(5, 5, 5);
+        let conv = config.init::<TestBackend>(&Default::default());
+
+        let input = Tensor::<TestBackend, 3>::zeros([1, 3, 10], &Default::default());
+        let _ = conv.forward(input);
     }
 }

--- a/crates/burn-core/src/nn/conv/conv1d.rs
+++ b/crates/burn-core/src/nn/conv/conv1d.rs
@@ -202,12 +202,12 @@ mod tests {
     }
 
     #[test]
-    #[should_panic = "Number of channels in input tensor and input channels of convolution must be equal. got: 3, expected: 5"]
+    #[should_panic = "Number of channels in input tensor and input channels of convolution must be equal. got: 4, expected: 5"]
     fn input_channels_mismatch() {
-        let config = Conv1dConfig::new(5, 5, 5);
+        let config = Conv1dConfig::new(5, 3, 3);
         let conv = config.init::<TestBackend>(&Default::default());
 
-        let input = Tensor::<TestBackend, 3>::zeros([1, 3, 10], &Default::default());
+        let input = Tensor::<TestBackend, 3>::zeros([1, 4, 10], &Default::default());
         let _ = conv.forward(input);
     }
 }

--- a/crates/burn-core/src/nn/conv/conv1d.rs
+++ b/crates/burn-core/src/nn/conv/conv1d.rs
@@ -137,13 +137,7 @@ impl<B: Backend> Conv1d<B> {
     /// - input: `[batch_size, channels_in, length_in]`
     /// - output: `[batch_size, channels_out, length_out]`
     pub fn forward(&self, input: Tensor<B, 3>) -> Tensor<B, 3> {
-        let [_batch_size, channels_in, length] = input.dims();
-        let expected = self.weight.dims()[1] * self.groups;
-        assert_eq!(
-            channels_in, expected,
-            "This conv layer requies a channels_in dimension of {expected}, but got {channels_in}"
-        );
-
+        let length = input.dims()[2];
         let padding = self
             .padding
             .calculate_padding_1d(length, self.kernel_size, self.stride);
@@ -208,7 +202,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic = "This conv layer requies a channels_in dimension of 5, but got 3"]
+    #[should_panic = "Number of channels in input tensor and input channels of convolution must be equal. got: 3, expected: 5"]
     fn input_channels_mismatch() {
         let config = Conv1dConfig::new(5, 5, 5);
         let conv = config.init::<TestBackend>(&Default::default());

--- a/crates/burn-core/src/nn/conv/conv2d.rs
+++ b/crates/burn-core/src/nn/conv/conv2d.rs
@@ -255,12 +255,12 @@ mod tests {
     }
 
     #[test]
-    #[should_panic = "Number of channels in input tensor and input channels of convolution must be equal. got: 3, expected: 5"]
+    #[should_panic = "Number of channels in input tensor and input channels of convolution must be equal. got: 4, expected: 5"]
     fn input_channels_mismatch() {
-        let config = Conv2dConfig::new([5, 5], [5, 5]);
+        let config = Conv2dConfig::new([5, 3], [3, 3]);
         let conv = config.init::<TestBackend>(&Default::default());
 
-        let input = Tensor::<TestBackend, 4>::zeros([1, 3, 10, 10], &Default::default());
+        let input = Tensor::<TestBackend, 4>::zeros([1, 4, 10, 10], &Default::default());
         let _ = conv.forward(input);
     }
 }

--- a/crates/burn-core/src/nn/conv/conv2d.rs
+++ b/crates/burn-core/src/nn/conv/conv2d.rs
@@ -149,7 +149,13 @@ impl<B: Backend> Conv2d<B> {
     /// - input: `[batch_size, channels_in, height_in, width_in]`
     /// - output: `[batch_size, channels_out, height_out, width_out]`
     pub fn forward(&self, input: Tensor<B, 4>) -> Tensor<B, 4> {
-        let [_batch_size, _channels_in, height_in, width_in] = input.dims();
+        let [_batch_size, channels_in, height_in, width_in] = input.dims();
+        let expected = self.weight.dims()[1] * self.groups;
+        assert_eq!(
+            channels_in, expected,
+            "This conv layer requies a channels_in dimension of {expected}, but got {channels_in}"
+        );
+
         let padding =
             self.padding
                 .calculate_padding_2d(height_in, width_in, &self.kernel_size, &self.stride);
@@ -252,5 +258,15 @@ mod tests {
             alloc::format!("{}", conv),
             "Conv2d {stride: [1, 1], kernel_size: [5, 5], dilation: [1, 1], groups: 1, padding: Valid, params: 126}"
         );
+    }
+
+    #[test]
+    #[should_panic = "This conv layer requies a channels_in dimension of 5, but got 3"]
+    fn input_channels_mismatch() {
+        let config = Conv2dConfig::new([5, 5], [5, 5]);
+        let conv = config.init::<TestBackend>(&Default::default());
+
+        let input = Tensor::<TestBackend, 4>::zeros([1, 3, 10, 10], &Default::default());
+        let _ = conv.forward(input);
     }
 }

--- a/crates/burn-core/src/nn/conv/conv2d.rs
+++ b/crates/burn-core/src/nn/conv/conv2d.rs
@@ -149,13 +149,7 @@ impl<B: Backend> Conv2d<B> {
     /// - input: `[batch_size, channels_in, height_in, width_in]`
     /// - output: `[batch_size, channels_out, height_out, width_out]`
     pub fn forward(&self, input: Tensor<B, 4>) -> Tensor<B, 4> {
-        let [_batch_size, channels_in, height_in, width_in] = input.dims();
-        let expected = self.weight.dims()[1] * self.groups;
-        assert_eq!(
-            channels_in, expected,
-            "This conv layer requies a channels_in dimension of {expected}, but got {channels_in}"
-        );
-
+        let [_batch_size, _channels_in, height_in, width_in] = input.dims();
         let padding =
             self.padding
                 .calculate_padding_2d(height_in, width_in, &self.kernel_size, &self.stride);
@@ -261,7 +255,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic = "This conv layer requies a channels_in dimension of 5, but got 3"]
+    #[should_panic = "Number of channels in input tensor and input channels of convolution must be equal. got: 3, expected: 5"]
     fn input_channels_mismatch() {
         let config = Conv2dConfig::new([5, 5], [5, 5]);
         let conv = config.init::<TestBackend>(&Default::default());

--- a/crates/burn-core/src/nn/conv/conv3d.rs
+++ b/crates/burn-core/src/nn/conv/conv3d.rs
@@ -146,13 +146,7 @@ impl<B: Backend> Conv3d<B> {
     /// - input: `[batch_size, channels_in, depth_in, height_in, width_in]`
     /// - output: `[batch_size, channels_out, depth_out, height_out, width_out]`
     pub fn forward(&self, input: Tensor<B, 5>) -> Tensor<B, 5> {
-        let [_batch_size, channels_in, depth_in, height_in, width_in] = input.dims();
-        let expected = self.weight.dims()[1] * self.groups;
-        assert_eq!(
-            channels_in, expected,
-            "This conv layer requies a channels_in dimension of {expected}, but got {channels_in}"
-        );
-
+        let [_batch_size, _channels_in, depth_in, height_in, width_in] = input.dims();
         let padding = self.padding.calculate_padding_3d(
             depth_in,
             height_in,
@@ -257,7 +251,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic = "This conv layer requies a channels_in dimension of 5, but got 3"]
+    #[should_panic = "Number of channels in input tensor and input channels of convolution must be equal. got: 3, expected: 5"]
     fn input_channels_mismatch() {
         let config = Conv3dConfig::new([5, 5], [5, 5, 5]);
         let conv = config.init::<TestBackend>(&Default::default());

--- a/crates/burn-core/src/nn/conv/conv3d.rs
+++ b/crates/burn-core/src/nn/conv/conv3d.rs
@@ -251,12 +251,12 @@ mod tests {
     }
 
     #[test]
-    #[should_panic = "Number of channels in input tensor and input channels of convolution must be equal. got: 3, expected: 5"]
+    #[should_panic = "Number of channels in input tensor and input channels of convolution must be equal. got: 4, expected: 5"]
     fn input_channels_mismatch() {
-        let config = Conv3dConfig::new([5, 5], [5, 5, 5]);
+        let config = Conv3dConfig::new([5, 3], [3, 3, 3]);
         let conv = config.init::<TestBackend>(&Default::default());
 
-        let input = Tensor::<TestBackend, 5>::zeros([1, 3, 10, 10, 10], &Default::default());
+        let input = Tensor::<TestBackend, 5>::zeros([1, 4, 10, 10, 10], &Default::default());
         let _ = conv.forward(input);
     }
 }

--- a/crates/burn-core/src/nn/conv/conv_transpose1d.rs
+++ b/crates/burn-core/src/nn/conv/conv_transpose1d.rs
@@ -140,12 +140,6 @@ impl<B: Backend> ConvTranspose1d<B> {
     /// - input: `[batch_size, channels_in, length_in]`
     /// - output: `[batch_size, channels_out, length_out]`
     pub fn forward(&self, input: Tensor<B, 3>) -> Tensor<B, 3> {
-        let channels_in = input.dims()[1];
-        let expected = self.weight.dims()[0];
-        assert_eq!(
-            channels_in, expected,
-            "This conv layer requies a channels_in dimension of {expected}, but got {channels_in}"
-        );
         conv_transpose1d(
             input,
             self.weight.val(),
@@ -204,7 +198,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic = "This conv layer requies a channels_in dimension of 5, but got 3"]
+    #[should_panic = "Number of channels in input tensor and input channels of convolution must be equal. got: 3, expected: 5"]
     fn input_channels_mismatch() {
         let config = ConvTranspose1dConfig::new([5, 5], 5);
         let conv = config.init::<TestBackend>(&Default::default());

--- a/crates/burn-core/src/nn/conv/conv_transpose1d.rs
+++ b/crates/burn-core/src/nn/conv/conv_transpose1d.rs
@@ -141,7 +141,7 @@ impl<B: Backend> ConvTranspose1d<B> {
     /// - output: `[batch_size, channels_out, length_out]`
     pub fn forward(&self, input: Tensor<B, 3>) -> Tensor<B, 3> {
         let channels_in = input.dims()[1];
-        let expected = self.weight.dims()[1] * self.groups;
+        let expected = self.weight.dims()[0];
         assert_eq!(
             channels_in, expected,
             "This conv layer requies a channels_in dimension of {expected}, but got {channels_in}"

--- a/crates/burn-core/src/nn/conv/conv_transpose1d.rs
+++ b/crates/burn-core/src/nn/conv/conv_transpose1d.rs
@@ -198,12 +198,12 @@ mod tests {
     }
 
     #[test]
-    #[should_panic = "Number of channels in input tensor and input channels of convolution must be equal. got: 3, expected: 5"]
+    #[should_panic = "Number of channels in input tensor and input channels of convolution must be equal. got: 4, expected: 5"]
     fn input_channels_mismatch() {
-        let config = ConvTranspose1dConfig::new([5, 5], 5);
+        let config = ConvTranspose1dConfig::new([5, 3], 3);
         let conv = config.init::<TestBackend>(&Default::default());
 
-        let input = Tensor::<TestBackend, 3>::zeros([1, 3, 10], &Default::default());
+        let input = Tensor::<TestBackend, 3>::zeros([1, 4, 10], &Default::default());
         let _ = conv.forward(input);
     }
 }

--- a/crates/burn-core/src/nn/conv/conv_transpose1d.rs
+++ b/crates/burn-core/src/nn/conv/conv_transpose1d.rs
@@ -140,6 +140,12 @@ impl<B: Backend> ConvTranspose1d<B> {
     /// - input: `[batch_size, channels_in, length_in]`
     /// - output: `[batch_size, channels_out, length_out]`
     pub fn forward(&self, input: Tensor<B, 3>) -> Tensor<B, 3> {
+        let channels_in = input.dims()[1];
+        let expected = self.weight.dims()[1] * self.groups;
+        assert_eq!(
+            channels_in, expected,
+            "This conv layer requies a channels_in dimension of {expected}, but got {channels_in}"
+        );
         conv_transpose1d(
             input,
             self.weight.val(),
@@ -195,5 +201,15 @@ mod tests {
             format!("{}", conv),
             "ConvTranspose1d {channels: [5, 2], stride: 1, kernel_size: 5, dilation: 1, groups: 1, padding: 0, padding_out: 0, params: 52}"
         );
+    }
+
+    #[test]
+    #[should_panic = "This conv layer requies a channels_in dimension of 5, but got 3"]
+    fn input_channels_mismatch() {
+        let config = ConvTranspose1dConfig::new([5, 5], 5);
+        let conv = config.init::<TestBackend>(&Default::default());
+
+        let input = Tensor::<TestBackend, 3>::zeros([1, 3, 10], &Default::default());
+        let _ = conv.forward(input);
     }
 }

--- a/crates/burn-core/src/nn/conv/conv_transpose2d.rs
+++ b/crates/burn-core/src/nn/conv/conv_transpose2d.rs
@@ -141,6 +141,12 @@ impl<B: Backend> ConvTranspose2d<B> {
     /// - input: `[batch_size, channels_in, height_in, width_in]`
     /// - output: `[batch_size, channels_out, height_out, width_out]`
     pub fn forward(&self, input: Tensor<B, 4>) -> Tensor<B, 4> {
+        let channels_in = input.dims()[1];
+        let expected = self.weight.dims()[1] * self.groups;
+        assert_eq!(
+            channels_in, expected,
+            "This conv layer requies a channels_in dimension of {expected}, but got {channels_in}"
+        );
         conv_transpose2d(
             input,
             self.weight.val(),
@@ -197,5 +203,15 @@ mod tests {
             format!("{}", conv),
             "ConvTranspose2d {channels: [5, 2], stride: [1, 1], kernel_size: [5, 5], dilation: [1, 1], groups: 1, padding: [0, 0], padding_out: [0, 0], params: 252}"
         );
+    }
+
+    #[test]
+    #[should_panic = "This conv layer requies a channels_in dimension of 5, but got 3"]
+    fn input_channels_mismatch() {
+        let config = ConvTranspose2dConfig::new([5, 5], [5, 5]);
+        let conv = config.init::<TestBackend>(&Default::default());
+
+        let input = Tensor::<TestBackend, 4>::zeros([1, 3, 10, 10], &Default::default());
+        let _ = conv.forward(input);
     }
 }

--- a/crates/burn-core/src/nn/conv/conv_transpose2d.rs
+++ b/crates/burn-core/src/nn/conv/conv_transpose2d.rs
@@ -200,12 +200,12 @@ mod tests {
     }
 
     #[test]
-    #[should_panic = "Number of channels in input tensor and input channels of convolution must be equal. got: 3, expected: 5"]
+    #[should_panic = "Number of channels in input tensor and input channels of convolution must be equal. got: 4, expected: 5"]
     fn input_channels_mismatch() {
-        let config = ConvTranspose2dConfig::new([5, 5], [5, 5]);
+        let config = ConvTranspose2dConfig::new([5, 3], [3, 3]);
         let conv = config.init::<TestBackend>(&Default::default());
 
-        let input = Tensor::<TestBackend, 4>::zeros([1, 3, 10, 10], &Default::default());
+        let input = Tensor::<TestBackend, 4>::zeros([1, 4, 10, 10], &Default::default());
         let _ = conv.forward(input);
     }
 }

--- a/crates/burn-core/src/nn/conv/conv_transpose2d.rs
+++ b/crates/burn-core/src/nn/conv/conv_transpose2d.rs
@@ -142,7 +142,7 @@ impl<B: Backend> ConvTranspose2d<B> {
     /// - output: `[batch_size, channels_out, height_out, width_out]`
     pub fn forward(&self, input: Tensor<B, 4>) -> Tensor<B, 4> {
         let channels_in = input.dims()[1];
-        let expected = self.weight.dims()[1] * self.groups;
+        let expected = self.weight.dims()[0];
         assert_eq!(
             channels_in, expected,
             "This conv layer requies a channels_in dimension of {expected}, but got {channels_in}"

--- a/crates/burn-core/src/nn/conv/conv_transpose2d.rs
+++ b/crates/burn-core/src/nn/conv/conv_transpose2d.rs
@@ -141,12 +141,6 @@ impl<B: Backend> ConvTranspose2d<B> {
     /// - input: `[batch_size, channels_in, height_in, width_in]`
     /// - output: `[batch_size, channels_out, height_out, width_out]`
     pub fn forward(&self, input: Tensor<B, 4>) -> Tensor<B, 4> {
-        let channels_in = input.dims()[1];
-        let expected = self.weight.dims()[0];
-        assert_eq!(
-            channels_in, expected,
-            "This conv layer requies a channels_in dimension of {expected}, but got {channels_in}"
-        );
         conv_transpose2d(
             input,
             self.weight.val(),
@@ -206,7 +200,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic = "This conv layer requies a channels_in dimension of 5, but got 3"]
+    #[should_panic = "Number of channels in input tensor and input channels of convolution must be equal. got: 3, expected: 5"]
     fn input_channels_mismatch() {
         let config = ConvTranspose2dConfig::new([5, 5], [5, 5]);
         let conv = config.init::<TestBackend>(&Default::default());

--- a/crates/burn-core/src/nn/conv/conv_transpose3d.rs
+++ b/crates/burn-core/src/nn/conv/conv_transpose3d.rs
@@ -204,12 +204,12 @@ mod tests {
     }
 
     #[test]
-    #[should_panic = "Number of channels in input tensor and input channels of convolution must be equal. got: 3, expected: 5"]
+    #[should_panic = "Number of channels in input tensor and input channels of convolution must be equal. got: 4, expected: 5"]
     fn input_channels_mismatch() {
-        let config = ConvTranspose3dConfig::new([5, 5], [5, 5, 5]);
+        let config = ConvTranspose3dConfig::new([5, 3], [3, 3, 3]);
         let conv = config.init::<TestBackend>(&Default::default());
 
-        let input = Tensor::<TestBackend, 5>::zeros([1, 3, 10, 10, 10], &Default::default());
+        let input = Tensor::<TestBackend, 5>::zeros([1, 4, 10, 10, 10], &Default::default());
         let _ = conv.forward(input);
     }
 }

--- a/crates/burn-core/src/nn/conv/conv_transpose3d.rs
+++ b/crates/burn-core/src/nn/conv/conv_transpose3d.rs
@@ -142,12 +142,6 @@ impl<B: Backend> ConvTranspose3d<B> {
     /// - input: `[batch_size, channels_in, depth_in, height_in, width_in]`
     /// - output: `[batch_size, channels_out, depth_out, height_out, width_out]`
     pub fn forward(&self, input: Tensor<B, 5>) -> Tensor<B, 5> {
-        let channels_in = input.dims()[1];
-        let expected = self.weight.dims()[0];
-        assert_eq!(
-            channels_in, expected,
-            "This conv layer requies a channels_in dimension of {expected}, but got {channels_in}"
-        );
         conv_transpose3d(
             input,
             self.weight.val(),
@@ -210,7 +204,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic = "This conv layer requies a channels_in dimension of 5, but got 3"]
+    #[should_panic = "Number of channels in input tensor and input channels of convolution must be equal. got: 3, expected: 5"]
     fn input_channels_mismatch() {
         let config = ConvTranspose3dConfig::new([5, 5], [5, 5, 5]);
         let conv = config.init::<TestBackend>(&Default::default());

--- a/crates/burn-core/src/nn/conv/conv_transpose3d.rs
+++ b/crates/burn-core/src/nn/conv/conv_transpose3d.rs
@@ -143,7 +143,7 @@ impl<B: Backend> ConvTranspose3d<B> {
     /// - output: `[batch_size, channels_out, depth_out, height_out, width_out]`
     pub fn forward(&self, input: Tensor<B, 5>) -> Tensor<B, 5> {
         let channels_in = input.dims()[1];
-        let expected = self.weight.dims()[1] * self.groups;
+        let expected = self.weight.dims()[0];
         assert_eq!(
             channels_in, expected,
             "This conv layer requies a channels_in dimension of {expected}, but got {channels_in}"

--- a/crates/burn-core/src/nn/conv/deform_conv2d.rs
+++ b/crates/burn-core/src/nn/conv/deform_conv2d.rs
@@ -277,13 +277,13 @@ mod tests {
     }
 
     #[test]
-    #[should_panic = "Number of channels in input tensor and input channels of convolution must be equal. got: 3, expected: 5"]
+    #[should_panic = "Number of channels in input tensor and input channels of convolution must be equal. got: 4, expected: 5"]
     fn input_channels_mismatch() {
-        let config = DeformConv2dConfig::new([5, 5], [5, 5]);
+        let config = DeformConv2dConfig::new([5, 3], [3, 3]);
         let conv = config.init::<TestBackend>(&Default::default());
 
-        let input = Tensor::<TestBackend, 4>::zeros([1, 3, 10, 10], &Default::default());
-        let offset = Tensor::<TestBackend, 4>::zeros([1, 2 * 5 * 5, 10, 10], &Default::default());
+        let input = Tensor::<TestBackend, 4>::zeros([1, 4, 10, 10], &Default::default());
+        let offset = Tensor::<TestBackend, 4>::zeros([1, 2 * 3 * 3, 10, 10], &Default::default());
         let _ = conv.forward(input, offset, None);
     }
 }

--- a/crates/burn-core/src/nn/conv/deform_conv2d.rs
+++ b/crates/burn-core/src/nn/conv/deform_conv2d.rs
@@ -163,13 +163,7 @@ impl<B: Backend> DeformConv2d<B> {
         offset: Tensor<B, 4>,
         mask: Option<Tensor<B, 4>>,
     ) -> Tensor<B, 4> {
-        let [_batch_size, channels_in, height_in, width_in] = input.dims();
-        let expected = self.weight.dims()[1] * self.weight_groups;
-        assert_eq!(
-            channels_in, expected,
-            "This conv layer requies a channels_in dimension of {expected}, but got {channels_in}"
-        );
-
+        let [_batch_size, _channels_in, height_in, width_in] = input.dims();
         let padding =
             self.padding
                 .calculate_padding_2d(height_in, width_in, &self.kernel_size, &self.stride);
@@ -283,7 +277,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic = "This conv layer requies a channels_in dimension of 5, but got 3"]
+    #[should_panic = "Number of channels in input tensor and input channels of convolution must be equal. got: 3, expected: 5"]
     fn input_channels_mismatch() {
         let config = DeformConv2dConfig::new([5, 5], [5, 5]);
         let conv = config.init::<TestBackend>(&Default::default());

--- a/crates/burn-core/src/nn/conv/deform_conv2d.rs
+++ b/crates/burn-core/src/nn/conv/deform_conv2d.rs
@@ -163,7 +163,13 @@ impl<B: Backend> DeformConv2d<B> {
         offset: Tensor<B, 4>,
         mask: Option<Tensor<B, 4>>,
     ) -> Tensor<B, 4> {
-        let [_batch_size, _channels_in, height_in, width_in] = input.dims();
+        let [_batch_size, channels_in, height_in, width_in] = input.dims();
+        let expected = self.weight.dims()[1] * self.weight_groups;
+        assert_eq!(
+            channels_in, expected,
+            "This conv layer requies a channels_in dimension of {expected}, but got {channels_in}"
+        );
+
         let padding =
             self.padding
                 .calculate_padding_2d(height_in, width_in, &self.kernel_size, &self.stride);
@@ -274,5 +280,16 @@ mod tests {
             alloc::format!("{}", conv),
             "DeformConv2d {stride: [1, 1], kernel_size: [5, 5], dilation: [1, 1], weight_groups: 1, offset_groups: 1, padding: Valid, params: 126}"
         );
+    }
+
+    #[test]
+    #[should_panic = "This conv layer requies a channels_in dimension of 5, but got 3"]
+    fn input_channels_mismatch() {
+        let config = DeformConv2dConfig::new([5, 5], [5, 5]);
+        let conv = config.init::<TestBackend>(&Default::default());
+
+        let input = Tensor::<TestBackend, 4>::zeros([1, 3, 10, 10], &Default::default());
+        let offset = Tensor::<TestBackend, 4>::zeros([1, 2 * 5 * 5, 10, 10], &Default::default());
+        let _ = conv.forward(input, offset, None);
     }
 }

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -1,4 +1,3 @@
-use crate::ops::{ConvOptions, DeformConvOptions};
 use crate::{BasicOps, Numeric, Shape, Tensor, backend::Backend, cast::ToElement};
 use alloc::format;
 use alloc::string::{String, ToString};
@@ -1196,52 +1195,20 @@ impl TensorCheck {
         check
     }
 
-    pub fn conv<const D1: usize, const D2: usize, const N: usize>(
+    pub fn conv<const D1: usize, const D2: usize>(
         ops: &str,
         x: [usize; D1],
         weight: [usize; D2],
-        options: &ConvOptions<N>,
+        groups: usize,
+        transpose: bool,
     ) -> Self {
         let mut check = TensorCheck::Ok;
         let channels = x[1];
-        let expected = weight[1] * options.groups;
-        if channels != expected {
-            check = check.register(
-                ops,
-                TensorError::new("Number of channels in input tensor and input channels of convolution must be equal.")
-                .details(format!("got: {channels}, expected: {expected}")),
-            );
-        }
-        check
-    }
-
-    pub fn deform_conv<const D1: usize, const D2: usize, const N: usize>(
-        ops: &str,
-        x: [usize; D1],
-        weight: [usize; D2],
-        options: &DeformConvOptions<N>,
-    ) -> Self {
-        let mut check = TensorCheck::Ok;
-        let channels = x[1];
-        let expected = weight[1] * options.weight_groups;
-        if channels != expected {
-            check = check.register(
-                ops,
-                TensorError::new("Number of channels in input tensor and input channels of convolution must be equal.")
-                .details(format!("got: {channels}, expected: {expected}")),
-            );
-        }
-        check
-    }
-
-    pub fn transpose_conv<const D1: usize, const D2: usize>(
-        ops: &str,
-        x: [usize; D1],
-        weight: [usize; D2],
-    ) -> Self {
-        let mut check = TensorCheck::Ok;
-        let channels = x[1];
-        let expected = weight[0];
+        let expected = if transpose {
+            weight[0]
+        } else {
+            weight[1] * groups
+        };
         if channels != expected {
             check = check.register(
                 ops,

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -1,3 +1,4 @@
+use crate::ops::{ConvOptions, DeformConvOptions};
 use crate::{BasicOps, Numeric, Shape, Tensor, backend::Backend, cast::ToElement};
 use alloc::format;
 use alloc::string::{String, ToString};
@@ -1192,6 +1193,62 @@ impl TensorCheck {
             }
         }
 
+        check
+    }
+
+    pub fn conv<const D1: usize, const D2: usize, const N: usize>(
+        ops: &str,
+        x: [usize; D1],
+        weight: [usize; D2],
+        options: &ConvOptions<N>,
+    ) -> Self {
+        let mut check = TensorCheck::Ok;
+        let channels = x[1];
+        let expected = weight[1] * options.groups;
+        if channels != expected {
+            check = check.register(
+                ops,
+                TensorError::new("Number of channels in input tensor and input channels of convolution must be equal.")
+                .details(format!("got: {channels}, expected: {expected}")),
+            );
+        }
+        check
+    }
+
+    pub fn deform_conv<const D1: usize, const D2: usize, const N: usize>(
+        ops: &str,
+        x: [usize; D1],
+        weight: [usize; D2],
+        options: &DeformConvOptions<N>,
+    ) -> Self {
+        let mut check = TensorCheck::Ok;
+        let channels = x[1];
+        let expected = weight[1] * options.weight_groups;
+        if channels != expected {
+            check = check.register(
+                ops,
+                TensorError::new("Number of channels in input tensor and input channels of convolution must be equal.")
+                .details(format!("got: {channels}, expected: {expected}")),
+            );
+        }
+        check
+    }
+
+    pub fn transpose_conv<const D1: usize, const D2: usize>(
+        ops: &str,
+        x: [usize; D1],
+        weight: [usize; D2],
+    ) -> Self {
+        let mut check = TensorCheck::Ok;
+        let channels = x[1];
+        let expected = weight[0];
+        if channels != expected {
+            check = check.register(
+                ops,
+                TensorError::new("Number of channels in input tensor and input channels of convolution must be equal.")
+                .details(format!("got: {channels}, expected: {expected}")),
+            );
+        }
         check
     }
 }

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -1195,6 +1195,8 @@ impl TensorCheck {
         check
     }
 
+    /// Conv layers must have at least two dimensions for `batch` and `channels_in`
+    /// Will fail to compile if dimensions of x or weight is less than 2
     pub fn conv<const D1: usize, const D2: usize>(
         ops: &str,
         x: [usize; D1],
@@ -1203,14 +1205,13 @@ impl TensorCheck {
         transpose: bool,
     ) -> Self {
         // blocked on const generics:
-        // let _ASSERT: [(); (D1 >= 2 && D2 >= 2) as usize] = [()];
+        // const _ASSERT: [(); (D1 >= 2 && D2 >= 2) as usize] = [()];
         // Instead we have to:
         struct Assert<const D: usize>;
         impl<const D: usize> Assert<D> {
             const TRUE: usize = D - 2;
         }
-        let _ = Assert::<D1>::TRUE;
-        let _ = Assert::<D2>::TRUE;
+        let _ = Assert::<D1>::TRUE + Assert::<D2>::TRUE;
         let mut check = TensorCheck::Ok;
         let channels = x[1];
         let expected = if transpose {

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -1202,6 +1202,15 @@ impl TensorCheck {
         groups: usize,
         transpose: bool,
     ) -> Self {
+        // blocked on const generics:
+        // let _ASSERT: [(); (D1 >= 2 && D2 >= 2) as usize] = [()];
+        // Instead we have to:
+        struct Assert<const D: usize>;
+        impl<const D: usize> Assert<D> {
+            const TRUE: usize = D - 2;
+        }
+        let _ = Assert::<D1>::TRUE;
+        let _ = Assert::<D2>::TRUE;
         let mut check = TensorCheck::Ok;
         let channels = x[1];
         let expected = if transpose {

--- a/crates/burn-tensor/src/tensor/module.rs
+++ b/crates/burn-tensor/src/tensor/module.rs
@@ -34,7 +34,6 @@ where
         x.dims(),
         weight.dims(),
         options.groups,
-        false,
     ));
     Tensor::new(TensorPrimitive::Float(B::conv1d(
         x.primitive.tensor(),
@@ -59,7 +58,6 @@ where
         x.dims(),
         weight.dims(),
         options.groups,
-        false,
     ));
     Tensor::new(TensorPrimitive::Float(B::conv2d(
         x.primitive.tensor(),
@@ -84,7 +82,6 @@ where
         x.dims(),
         weight.dims(),
         options.groups,
-        false,
     ));
     Tensor::new(TensorPrimitive::Float(B::conv3d(
         x.primitive.tensor(),
@@ -111,7 +108,6 @@ where
         x.dims(),
         weight.dims(),
         options.weight_groups,
-        false,
     ));
     Tensor::new(TensorPrimitive::Float(B::deform_conv2d(
         x.primitive.tensor(),
@@ -133,12 +129,10 @@ pub fn conv_transpose1d<B>(
 where
     B: Backend,
 {
-    check!(TensorCheck::conv(
+    check!(TensorCheck::conv_transpose(
         "conv_transpose1d",
         x.dims(),
         weight.dims(),
-        options.groups,
-        true,
     ));
     Tensor::new(TensorPrimitive::Float(B::conv_transpose1d(
         x.primitive.tensor(),
@@ -158,12 +152,10 @@ pub fn conv_transpose2d<B>(
 where
     B: Backend,
 {
-    check!(TensorCheck::conv(
+    check!(TensorCheck::conv_transpose(
         "conv_transpose2d",
         x.dims(),
         weight.dims(),
-        options.groups,
-        true,
     ));
     Tensor::new(TensorPrimitive::Float(B::conv_transpose2d(
         x.primitive.tensor(),
@@ -183,12 +175,10 @@ pub fn conv_transpose3d<B>(
 where
     B: Backend,
 {
-    check!(TensorCheck::conv(
+    check!(TensorCheck::conv_transpose(
         "conv_transpose3d",
         x.dims(),
         weight.dims(),
-        options.groups,
-        true,
     ));
     Tensor::new(TensorPrimitive::Float(B::conv_transpose3d(
         x.primitive.tensor(),

--- a/crates/burn-tensor/src/tensor/module.rs
+++ b/crates/burn-tensor/src/tensor/module.rs
@@ -33,7 +33,8 @@ where
         "conv1d",
         x.dims(),
         weight.dims(),
-        &options,
+        options.groups,
+        false,
     ));
     Tensor::new(TensorPrimitive::Float(B::conv1d(
         x.primitive.tensor(),
@@ -57,7 +58,8 @@ where
         "conv2d",
         x.dims(),
         weight.dims(),
-        &options,
+        options.groups,
+        false,
     ));
     Tensor::new(TensorPrimitive::Float(B::conv2d(
         x.primitive.tensor(),
@@ -81,7 +83,8 @@ where
         "conv3d",
         x.dims(),
         weight.dims(),
-        &options,
+        options.groups,
+        false,
     ));
     Tensor::new(TensorPrimitive::Float(B::conv3d(
         x.primitive.tensor(),
@@ -103,11 +106,12 @@ pub fn deform_conv2d<B>(
 where
     B: Backend,
 {
-    check!(TensorCheck::deform_conv(
+    check!(TensorCheck::conv(
         "deform_conv2d",
         x.dims(),
         weight.dims(),
-        &options,
+        options.weight_groups,
+        false,
     ));
     Tensor::new(TensorPrimitive::Float(B::deform_conv2d(
         x.primitive.tensor(),
@@ -129,10 +133,12 @@ pub fn conv_transpose1d<B>(
 where
     B: Backend,
 {
-    check!(TensorCheck::transpose_conv(
+    check!(TensorCheck::conv(
         "conv_transpose1d",
         x.dims(),
-        weight.dims()
+        weight.dims(),
+        options.groups,
+        true,
     ));
     Tensor::new(TensorPrimitive::Float(B::conv_transpose1d(
         x.primitive.tensor(),
@@ -152,10 +158,12 @@ pub fn conv_transpose2d<B>(
 where
     B: Backend,
 {
-    check!(TensorCheck::transpose_conv(
+    check!(TensorCheck::conv(
         "conv_transpose2d",
         x.dims(),
-        weight.dims()
+        weight.dims(),
+        options.groups,
+        true,
     ));
     Tensor::new(TensorPrimitive::Float(B::conv_transpose2d(
         x.primitive.tensor(),
@@ -175,10 +183,12 @@ pub fn conv_transpose3d<B>(
 where
     B: Backend,
 {
-    check!(TensorCheck::transpose_conv(
+    check!(TensorCheck::conv(
         "conv_transpose3d",
         x.dims(),
-        weight.dims()
+        weight.dims(),
+        options.groups,
+        true,
     ));
     Tensor::new(TensorPrimitive::Float(B::conv_transpose3d(
         x.primitive.tensor(),

--- a/crates/burn-tensor/src/tensor/module.rs
+++ b/crates/burn-tensor/src/tensor/module.rs
@@ -1,6 +1,8 @@
 use crate::{
     Int, Tensor, TensorPrimitive,
     backend::Backend,
+    check,
+    check::TensorCheck,
     ops::{ConvOptions, ConvTransposeOptions, InterpolateOptions, UnfoldOptions},
 };
 
@@ -27,6 +29,12 @@ pub fn conv1d<B>(
 where
     B: Backend,
 {
+    check!(TensorCheck::conv(
+        "conv1d",
+        x.dims(),
+        weight.dims(),
+        &options,
+    ));
     Tensor::new(TensorPrimitive::Float(B::conv1d(
         x.primitive.tensor(),
         weight.primitive.tensor(),
@@ -45,6 +53,12 @@ pub fn conv2d<B>(
 where
     B: Backend,
 {
+    check!(TensorCheck::conv(
+        "conv2d",
+        x.dims(),
+        weight.dims(),
+        &options,
+    ));
     Tensor::new(TensorPrimitive::Float(B::conv2d(
         x.primitive.tensor(),
         weight.primitive.tensor(),
@@ -63,6 +77,12 @@ pub fn conv3d<B>(
 where
     B: Backend,
 {
+    check!(TensorCheck::conv(
+        "conv3d",
+        x.dims(),
+        weight.dims(),
+        &options,
+    ));
     Tensor::new(TensorPrimitive::Float(B::conv3d(
         x.primitive.tensor(),
         weight.primitive.tensor(),
@@ -83,6 +103,12 @@ pub fn deform_conv2d<B>(
 where
     B: Backend,
 {
+    check!(TensorCheck::deform_conv(
+        "deform_conv2d",
+        x.dims(),
+        weight.dims(),
+        &options,
+    ));
     Tensor::new(TensorPrimitive::Float(B::deform_conv2d(
         x.primitive.tensor(),
         offset.primitive.tensor(),
@@ -103,6 +129,11 @@ pub fn conv_transpose1d<B>(
 where
     B: Backend,
 {
+    check!(TensorCheck::transpose_conv(
+        "conv_transpose1d",
+        x.dims(),
+        weight.dims()
+    ));
     Tensor::new(TensorPrimitive::Float(B::conv_transpose1d(
         x.primitive.tensor(),
         weight.primitive.tensor(),
@@ -121,6 +152,11 @@ pub fn conv_transpose2d<B>(
 where
     B: Backend,
 {
+    check!(TensorCheck::transpose_conv(
+        "conv_transpose2d",
+        x.dims(),
+        weight.dims()
+    ));
     Tensor::new(TensorPrimitive::Float(B::conv_transpose2d(
         x.primitive.tensor(),
         weight.primitive.tensor(),
@@ -139,6 +175,11 @@ pub fn conv_transpose3d<B>(
 where
     B: Backend,
 {
+    check!(TensorCheck::transpose_conv(
+        "conv_transpose3d",
+        x.dims(),
+        weight.dims()
+    ));
     Tensor::new(TensorPrimitive::Float(B::conv_transpose3d(
         x.primitive.tensor(),
         weight.primitive.tensor(),


### PR DESCRIPTION
- [x] Confirmed that `run-checks all` script has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

When channels_in to a convolution call mismatches the weights, backends break in various confusing ways.
This check avoids that with an early panic and informative error message.
I also added unit tests to ensure this check does panic.