### PR TITLE
Improve documentation page for "Tensor"

### DIFF
--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -1583,9 +1583,9 @@ where
     ///
     /// For each dimension:
     /// - If current size is `1` and the requested size is `n` > 1, the tensor will be extended by
-    /// repeating itself in this dimension.
+    ///   repeating itself in this dimension.
     /// - If the current size is `n` > 1, then output size must be `n`. `-1` can be used to inferred this
-    /// automatically.
+    ///   automatically.
     /// - Otherwise tensor cannot be broadcasted.
     ///
     /// # Arguments

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -533,7 +533,7 @@ where
     /// # Panics
     ///
     /// If the size in the squeezed dimension is not 1.
-    ///  
+    ///
     /// # Returns
     ///
     /// A new `Tensor<B, D2, K>` instance with the specified dimension removed.
@@ -670,7 +670,7 @@ where
     /// # Panics
     ///
     /// If `D2` is lower than the actual number of dimensions.
-    ///  
+    ///
     /// # Returns
     ///
     /// A new `Tensor<B, D2, K>` instance with the specified dimensions added.

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -215,7 +215,7 @@ where
         Tensor::new(K::reshape(self.primitive, shape))
     }
 
-    /// Transpose the tensor. Permute the 2 last dimensions of the tensor.
+    /// Transpose the tensor.
     ///
     /// For a 2D tensor, this is the standard matrix transpose. For `D > 2`, the transpose is
     /// applied on the last two dimensions. For example, the transpose of a tensor with shape

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -173,7 +173,9 @@ where
         self.primitive.shape()
     }
 
-    /// Reshape the tensor to have the given shape, keeping the same values in the same order.
+    /// Reshape the tensor to have the given shape.
+    ///
+    /// The tensor has the same data and number of elements as the input.
     ///
     /// A `-1` in the shape is used to infer the remaining dimensions, e.g.: `[2, -1]`
     /// will reshape the tensor with [2, 3, 4] dimensions to [2, 12].
@@ -215,7 +217,9 @@ where
 
     /// Transpose the tensor. Permute the 2 last dimensions of the tensor.
     ///
-    /// For a tensor with a shape `[1, 2, 3, 4]` the result will be a tensor with a shape `[1, 2, 4, 3]`.
+    /// For a 2D tensor, this is the standard matrix transpose. For `D > 2`, the transpose is
+    /// applied on the last two dimensions. For example, the transpose of a tensor with shape
+    /// `[1, 2, 3, 4]` will have shape `[1, 2, 4, 3]`.
     ///
     /// See also [`permute`](Tensor::permute).
     ///
@@ -660,8 +664,7 @@ where
         Tensor::new(K::reshape(self.primitive, new_dims.into()))
     }
 
-    /// Unsqueeze the current tensor. Create new dimensions to fit the given size.
-    /// New dimensions will be added in front of existing dimensions.
+    /// Unsqueeze the current tensor. Create new leading dimensions to fit the given size.
     ///
     /// # Type Parameters
     ///
@@ -669,7 +672,7 @@ where
     ///
     /// # Panics
     ///
-    /// If `D2` is lower than the actual number of dimensions.
+    /// If the output size `D2` is smaller than the current number of dimensions.
     ///
     /// # Returns
     ///
@@ -927,11 +930,7 @@ where
         K::device(&self.primitive)
     }
 
-    /// Returns a new tensor on the given device filled with the values of the current tensor.
-    ///
-    /// # Note
-    ///
-    /// Unlike the name implies, this is a `into_` conversion that takes ownership of current tensor.
+    /// Move the tensor to the given device.
     pub fn to_device(self, device: &B::Device) -> Self {
         Self::new(K::to_device(self.primitive, device))
     }
@@ -1000,6 +999,7 @@ where
 
     /// Repeat the tensor along the given dimension.
     ///
+    /// The output tensor has the same shape, except along the given dimension.
     ///
     /// # Arguments
     /// - `dim`: The dimension to repeat.
@@ -1007,8 +1007,7 @@ where
     ///
     /// # Returns
     ///
-    /// A new tensor with the given dimension repeated `times` times, the new tensor has the same rank but
-    /// a modified shape with a size multiplied by `times` in the given dimension.
+    /// A new tensor with the given dimension repeated `times` times.
     ///
     /// # Example
     ///
@@ -1072,7 +1071,10 @@ where
         tensor
     }
 
-    /// Applies element-wise equal comparison and returns a boolean tensor with the same shape.
+    /// Applies element-wise equal comparison.
+    ///
+    /// # Returns
+    /// A boolean tensor that is `true` where input is equal to `other` and `false` elsewhere.
     ///
     /// # Panics
     ///
@@ -1099,7 +1101,10 @@ where
         Tensor::new(K::equal(self.primitive, other.primitive))
     }
 
-    /// Applies element-wise non-equality comparison and returns a boolean tensor with the same shape.
+    /// Applies element-wise non-equality comparison.
+    ///
+    /// # Returns
+    /// A boolean tensor that is `true` where input is not equal to `other` and `false` elsewhere.
     ///
     /// # Panics
     ///
@@ -1581,12 +1586,8 @@ where
 
     /// Broadcast the tensor to the given shape.
     ///
-    /// For each dimension:
-    /// - If current size is `1` and the requested size is `n` > 1, the tensor will be extended by
-    ///   repeating itself in this dimension.
-    /// - If the current size is `n` > 1, then output size must be `n`. `-1` can be used to inferred this
-    ///   automatically.
-    /// - Otherwise tensor cannot be broadcasted.
+    /// Only singleton dimensions can be expanded to a larger size. Other dimensions must have the same size
+    /// (which can be inferred with `-1`).
     ///
     /// # Arguments
     ///

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -372,9 +372,9 @@ where
     ///     println!("{moved}");
     /// }
     /// ```
-    /// 
+    ///
     /// # Note
-    /// 
+    ///
     /// This is a syntactic sugar for `permute`. It is used widely enough, so we define a separate Op
     /// for it
     pub fn movedim<S1: MovedimArgs, S2: MovedimArgs>(self, src: S1, dst: S2) -> Tensor<B, D, K> {
@@ -531,7 +531,7 @@ where
     ///  - `D2`: The resulting number of dimensions in the squeezed tensor.
     ///
     /// # Panics
-    /// 
+    ///
     /// If the size in the squeezed dimension is not 1.
     ///  
     /// # Returns
@@ -668,7 +668,7 @@ where
     ///  - `D2`: The resulting number of dimensions in the unsqueezed tensor.
     ///
     /// # Panics
-    /// 
+    ///
     /// If `D2` is lower than the actual number of dimensions.
     ///  
     /// # Returns
@@ -928,7 +928,7 @@ where
     }
 
     /// Returns a new tensor on the given device filled with the values of the current tensor.
-    /// 
+    ///
     /// # Note
     ///
     /// Unlike the name implies, this is a `into_` conversion that takes ownership of current tensor.
@@ -1580,7 +1580,7 @@ where
     }
 
     /// Broadcast the tensor to the given shape.
-    /// 
+    ///
     /// For each dimension:
     /// - If current size is `1` and the requested size is `n` > 1, the tensor will be extended by
     /// repeating itself in this dimension.

--- a/crates/burn-tensor/src/tensor/api/bool.rs
+++ b/crates/burn-tensor/src/tensor/api/bool.rs
@@ -211,6 +211,8 @@ where
     /// # Arguments
     ///
     /// * `shape`: The shape of the matrix.
+    /// * `offset`: The offset from the diagonal, where 0 means the diagonal, and positive values shift
+    ///    towards the upper triangle.
     /// * `device`: The device on which the tensor will be allocated.
     ///
     /// # Returns

--- a/crates/burn-tensor/src/tensor/api/float.rs
+++ b/crates/burn-tensor/src/tensor/api/float.rs
@@ -65,7 +65,10 @@ where
         )))
     }
 
-    /// Applies element wise reciprocal operation.
+    /// Applies [reciprocal operation](https://en.wikipedia.org/wiki/Multiplicative_inverse) 
+    /// (or multiplicative inverse) element wise.
+    /// 
+    /// `y = 1/x`
     pub fn recip(self) -> Self {
         Self::new(TensorPrimitive::Float(B::float_recip(
             self.primitive.tensor(),

--- a/crates/burn-tensor/src/tensor/api/float.rs
+++ b/crates/burn-tensor/src/tensor/api/float.rs
@@ -65,9 +65,9 @@ where
         )))
     }
 
-    /// Applies [reciprocal operation](https://en.wikipedia.org/wiki/Multiplicative_inverse) 
+    /// Applies [reciprocal operation](https://en.wikipedia.org/wiki/Multiplicative_inverse)
     /// (or multiplicative inverse) element wise.
-    /// 
+    ///
     /// `y = 1/x`
     pub fn recip(self) -> Self {
         Self::new(TensorPrimitive::Float(B::float_recip(

--- a/crates/burn-tensor/src/tensor/api/int.rs
+++ b/crates/burn-tensor/src/tensor/api/int.rs
@@ -145,12 +145,12 @@ where
         Self::new(B::bitwise_right_shift(self.primitive, other.primitive))
     }
 
-    /// Applies the bitwise left shift operation with the integers in the tensor.
+    /// Applies the bitwise left shift operation with the scalar.
     pub fn bitwise_left_shift_scalar(self, other: B::IntElem) -> Self {
         Self::new(B::bitwise_left_shift_scalar(self.primitive, other))
     }
 
-    /// Applies the bitwise right shift operation with the integers in the tensor.
+    /// Applies the bitwise right shift operation with the scalar.
     pub fn bitwise_right_shift_scalar(self, other: B::IntElem) -> Self {
         Self::new(B::bitwise_right_shift_scalar(self.primitive, other))
     }

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -201,7 +201,7 @@ where
 
     /// Applies element wise the remainder operation with a scalar.
     ///
-    /// `y = x2 % x1`
+    /// `y = x % s`
     ///
     /// # Arguments
     ///
@@ -539,8 +539,8 @@ where
     ///    let tensor = Tensor::<B, 2>::from_data([[1.0, -2.0, 3.0], [5.0, 9.0, 6.0]], &device);
     ///    let tensor = tensor.clone().sum_dim(0);
     ///    println!("{tensor}");
-    ///    let tensor = tensor.clone().sum_dim(1);
     ///    // [[6.0, 7.0, 9.0]]
+    ///    let tensor = tensor.clone().sum_dim(1);
     ///    println!("{tensor}");
     ///    // [[2.0], [20.0]]
     /// }
@@ -550,8 +550,7 @@ where
         Self::new(K::sum_dim(self.primitive, dim))
     }
 
-    /// Aggregate all elements along the given *dimension* or *axis*
-    /// in the tensor with the product operation.
+    /// Aggregate all elements in the tensor with the product operation.
     ///
     /// # Example
     ///
@@ -663,7 +662,7 @@ where
     /// fn example<B: Backend>() {
     ///   let device = B::Device::default();
     ///   let tensor1 = Tensor::<B, 2>::from_data([[1.0, -2.0, 3.0], [5.0, 9.0, 6.0]], &device);
-    ///   let tensor2 = Tensor::<B, 2>::from_data([[2.0, 3.0, 4.0], [1.0, 2.0, 3.0]], &device);
+    ///   let tensor2 = Tensor::<B, 2>::from_data([[1.0, 3.0, 4.0], [1.0, 2.0, 3.0]], &device);
     ///   let tensor = tensor1.greater(tensor2);
     ///   println!("{tensor}");
     ///   // [[false, false, false], [true, true, true]]
@@ -689,10 +688,10 @@ where
     /// fn example<B: Backend>() {
     ///    let device = B::Device::default();
     ///    let tensor1 = Tensor::<B, 2>::from_data([[1.0, -2.0, 3.0], [5.0, 9.0, 6.0]], &device);
-    ///    let tensor2 = Tensor::<B, 2>::from_data([[2.0, 3.0, 4.0], [1.0, 2.0, 3.0]], &device);
+    ///    let tensor2 = Tensor::<B, 2>::from_data([[1.0, 3.0, 4.0], [1.0, 2.0, 3.0]], &device);
     ///    let tensor = tensor1.greater_equal(tensor2);
     ///    println!("{tensor}");
-    ///    // [[false, false, false], [true, true, true]]
+    ///    // [[true, false, false], [true, true, true]]
     /// }
     /// ```
     pub fn greater_equal(self, other: Self) -> Tensor<B, D, Bool> {
@@ -715,10 +714,10 @@ where
     /// fn example<B: Backend>() {
     ///    let device = B::Device::default();
     ///    let tensor1 = Tensor::<B, 2>::from_data([[1.0, -2.0, 3.0], [5.0, 9.0, 6.0]], &device);
-    ///    let tensor2 = Tensor::<B, 2>::from_data([[2.0, 3.0, 4.0], [1.0, 2.0, 3.0]], &device);
+    ///    let tensor2 = Tensor::<B, 2>::from_data([[1.0, 3.0, 4.0], [1.0, 2.0, 3.0]], &device);
     ///    let tensor = tensor1.lower(tensor2);
     ///    println!("{tensor}");
-    ///    // [[true, true, true], [false, false, false]]
+    ///    // [[false, true, true], [false, false, false]]
     /// }
     /// ```
     pub fn lower(self, other: Self) -> Tensor<B, D, Bool> {
@@ -741,7 +740,7 @@ where
     /// fn example<B: Backend>() {
     ///    let device = B::Device::default();
     ///    let tensor1 = Tensor::<B, 2>::from_data([[1.0, -2.0, 3.0], [5.0, 9.0, 6.0]], &device);
-    ///    let tensor2 = Tensor::<B, 2>::from_data([[2.0, 3.0, 4.0], [1.0, 2.0, 3.0]], &device);
+    ///    let tensor2 = Tensor::<B, 2>::from_data([[1.0, 3.0, 4.0], [1.0, 2.0, 3.0]], &device);
     ///    let tensor = tensor1.lower_equal(tensor2);
     ///    println!("{tensor}");
     ///    // [[true, true, true], [false, false, false]]
@@ -752,7 +751,7 @@ where
         Tensor::new(K::lower_equal(self.primitive, other.primitive))
     }
 
-    /// Applies element wise greater comparison and returns a boolean tensor.
+    /// Applies greater than `other` comparison and returns a boolean tensor.
     ///
     /// # Arguments
     ///
@@ -776,7 +775,7 @@ where
         Tensor::new(K::greater_elem(self.primitive, other.elem()))
     }
 
-    /// Applies element wise greater-equal comparison and returns a boolean tensor.
+    /// Applies greater-equal than `other` comparison and returns a boolean tensor.
     ///
     /// # Arguments
     ///
@@ -800,7 +799,7 @@ where
         Tensor::new(K::greater_equal_elem(self.primitive, other.elem()))
     }
 
-    /// Applies element wise lower comparison and returns a boolean tensor.
+    /// Applies lower than `other` comparison and returns a boolean tensor.
     ///
     /// # Arguments
     ///
@@ -824,7 +823,7 @@ where
         Tensor::new(K::lower_elem(self.primitive, other.elem()))
     }
 
-    /// Applies element wise lower-equal comparison and returns a boolean tensor.
+    /// Applies lower-equal than `other` comparison and returns a boolean tensor.
     ///
     /// # Arguments
     ///
@@ -1115,7 +1114,7 @@ where
         (tensor, index)
     }
 
-    /// Finds the maximum pair wise values with another Tensor
+    /// Finds the maximum pair wise values with another tensor.
     ///
     /// # Arguments
     ///
@@ -1222,7 +1221,7 @@ where
     ///    let tensor = Tensor::<B, 2>::from_data([[7.0, -2.0, 3.0], [5.0, 9.0, 6.0]], &device);
     ///    let (tensor, index) = tensor.min_dim_with_indices(0);
     ///    println!("{tensor}");
-    ///    // [[1.0, -2.0, 3.0]]
+    ///    // [[5.0, -2.0, 3.0]]
     ///    println!("{}", index);
     ///    // [[1, 0, 0]]
     /// }
@@ -1238,7 +1237,7 @@ where
         (tensor, index)
     }
 
-    /// Finds the minimum pair wise values with another Tensor
+    /// Finds the minimum pair wise values with another tensor.
     ///
     /// # Arguments
     ///
@@ -1268,7 +1267,7 @@ where
         self.mask_where(mask, other)
     }
 
-    /// Clamp the tensor between the given min and max values.
+    /// Clamp element wise between the given min and max values.
     ///
     /// # Arguments
     ///
@@ -1303,7 +1302,7 @@ where
         Self::new(K::clamp(self.primitive, min.elem(), max.elem()))
     }
 
-    /// Clamps a tensor under a minimum value.
+    /// Clamp element wise under a minimum value.
     ///
     /// # Arguments
     ///
@@ -1334,7 +1333,7 @@ where
         Self::new(K::clamp_min(self.primitive, min.elem()))
     }
 
-    /// Clamps a tensor over a maximum value.
+    /// Clamp element wise over a maximum value.
     ///
     /// # Arguments
     ///
@@ -1365,7 +1364,7 @@ where
         Self::new(K::clamp_max(self.primitive, max.elem()))
     }
 
-    /// Apply element wise absolute value operation
+    /// Apply element wise absolute value operation.
     ///
     /// # Example
     ///
@@ -1387,6 +1386,13 @@ where
 
     /// Returns the upper triangular part of a matrix (2-D tensor) or batch of matrices input,
     /// the other elements of the result tensor out are set to 0.
+    ///
+    /// See also [`triu_mask`](Tensor::triu_mask).
+    ///
+    /// # Arguments
+    ///
+    /// * `diagonal` - The offset from the diagonal, where 0 means the diagonal, and positive values shift
+    ///    towards the upper triangle.
     ///
     /// # Example
     /// ```rust
@@ -1425,6 +1431,13 @@ where
     /// Returns the lower triangular part of a matrix (2-D tensor) or batch of matrices input,
     /// the other elements of the result tensor out are set to 0.
     ///
+    /// See also [`tril_mask`](Tensor::tril_mask).
+    ///
+    /// # Arguments
+    ///
+    /// * `diagonal` - The offset from the diagonal, where 0 means the diagonal, and positive values shift
+    ///    towards the upper triangle.
+    /// 
     /// # Example
     /// ```rust
     /// use burn_tensor::backend::Backend;
@@ -1551,7 +1564,12 @@ where
     ///    let tensor = Tensor::<B, 2, Int>::from_ints([[1, -2, 3], [5, 9, 6]], &device);
     ///    let tensor = tensor.powi_scalar(2);
     ///    println!("{tensor}");
+    /// 
     ///    // [[1, 4, 9], [25, 81, 36]]
+    ///    let tensor = Tensor::<B, 2>::from_data([[1.5, -2., 3.], [5., 9., 6.]], &device);
+    ///    let tensor = tensor.powi_scalar(2);
+    ///    println!("{tensor}");
+    ///    // [[2.25, 4., 9.], [25., 81., 36.]]
     /// }
     /// ```
     pub fn powi_scalar<E: ElementConversion>(self, other: E) -> Self {
@@ -1679,6 +1697,8 @@ where
 
     /// Create a random tensor of the given shape on the given device where each element is
     /// sampled from the given distribution.
+    ///
+    /// See also [`random_like`](Tensor::random_like).
     ///
     /// # Arguments
     ///

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -1437,7 +1437,7 @@ where
     ///
     /// * `diagonal` - The offset from the diagonal, where 0 means the diagonal, and positive values shift
     ///    towards the upper triangle.
-    /// 
+    ///
     /// # Example
     /// ```rust
     /// use burn_tensor::backend::Backend;
@@ -1564,7 +1564,7 @@ where
     ///    let tensor = Tensor::<B, 2, Int>::from_ints([[1, -2, 3], [5, 9, 6]], &device);
     ///    let tensor = tensor.powi_scalar(2);
     ///    println!("{tensor}");
-    /// 
+    ///
     ///    // [[1, 4, 9], [25, 81, 36]]
     ///    let tensor = Tensor::<B, 2>::from_data([[1.5, -2., 3.], [5., 9., 6.]], &device);
     ///    let tensor = tensor.powi_scalar(2);


### PR DESCRIPTION
## Improve "Tensor" page documentation

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

* fixed some mistakes in the documentation (such as sometimes stating "element wise" when it should have been "with a scalar"). Or example code with wrong values shown (for tensor.min_dim_with_indices)
* changed some examples to make them more explicit about the function behavior.
* Developed a bit some function description when text was quite vague.

### Things to discuss

This is my first PR, I am new to Burn crate and struggled to understand some functions for which I needed to check directly the code. The goal of this PR is to avoid this for next newcomers!  
Also if this PR shall be split in several smaller PRs, please tell me. I didn't feel like I should have made one PR per function documented...

More general remarks about the documentation:

* There is no indications for contributing to documentation in the contribution guide, this is a bit missing, specially for the 2 following points
* The verbs are not consistent, sometimes functions are described with "*Does* this and that" and sometimes it's "Do this and that", is there any recommendation here? If so making it explicit in the guidelines would be great!
* The usage of the vocabulary `rank`, `dimension`, `dimensions`, `size` and `shape` is not always consistent, quite often I found "_tensor of dimensions [x, y, z]_", the idea is totally understandable here, but in this case the right word is "_tensor of shape [x, y, z]_", no? I am asking just to know if I should try to be accurate in the vocab for next PR (maybe even replace existing misuses) or if it's not important and should not be changed?

### Testing

Visual testing of the generated doc.
