### PR TITLE
Fix test checks for macos

### DIFF
--- a/xtask/src/commands/test.rs
+++ b/xtask/src/commands/test.rs
@@ -100,27 +100,29 @@ pub(crate) fn handle_command(
                     "std wgpu",
                 )?;
 
-                let disable_wgpu_spirv = std::env::var("DISABLE_WGPU_SPIRV")
-                    .map(|val| val == "1" || val == "true")
-                    .unwrap_or(false);
-
                 // Vulkan isn't available on MacOS
                 #[cfg(not(target_os = "macos"))]
-                if !disable_wgpu_spirv {
-                    helpers::custom_crates_tests(
-                        vec!["burn-core"],
-                        vec!["--features", "test-wgpu-spirv"],
-                        None,
-                        None,
-                        "std vulkan",
-                    )?;
-                    helpers::custom_crates_tests(
-                        vec!["burn-vision"],
-                        vec!["--features", "test-vulkan"],
-                        None,
-                        None,
-                        "std vulkan",
-                    )?;
+                {
+                    let disable_wgpu_spirv = std::env::var("DISABLE_WGPU_SPIRV")
+                        .map(|val| val == "1" || val == "true")
+                        .unwrap_or(false);
+
+                    if !disable_wgpu_spirv {
+                        helpers::custom_crates_tests(
+                            vec!["burn-core"],
+                            vec!["--features", "test-wgpu-spirv"],
+                            None,
+                            None,
+                            "std vulkan",
+                        )?;
+                        helpers::custom_crates_tests(
+                            vec!["burn-vision"],
+                            vec!["--features", "test-vulkan"],
+                            None,
+                            None,
+                            "std vulkan",
+                        )?;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

When running `./run-checks all` on macOS, from master, a failure happens because of unused variable:
```
[2025-03-24T10:59:50Z INFO  tracel_xtask::utils::process] Command line: cargo clippy --no-deps --color=always -- --deny warnings
    Blocking waiting for file lock on build directory
   Compiling ring v0.17.14
   Compiling burn-tensor v0.17.0 (/Users/lucas/gitRepo_perso/burn/crates/burn-tensor)
   Compiling onnx-ir v0.17.0 (/Users/lucas/gitRepo_perso/burn/crates/onnx-ir)
    Checking xtask v1.2.0 (/Users/lucas/gitRepo_perso/burn/xtask)
error: unused variable: `disable_wgpu_spirv`
   --> xtask/src/commands/test.rs:103:21
    |
103 |                 let disable_wgpu_spirv = std::env::var("DISABLE_WGPU_SPIRV")
    |                     ^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_disable_wgpu_spirv`
    |
    = note: `-D unused-variables` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(unused_variables)]`

error: could not compile `xtask` (bin "xtask") due to 1 previous error
warning: build failed, waiting for other jobs to finish...
Error: Workspace lint failed

```

Moving the declaration of this variable inside of the conditional block fixes it.

### Testing

`./run-checks all` is now all green on macOS.
