### PR TITLE
[Chore] Migrate to new cubecl tensorhandle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1582,7 +1582,6 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=40aaddc8162f2c2261c4a7b1525a490ee250d37e#40aaddc8162f2c2261c4a7b1525a490ee250d37e"
 dependencies = [
  "cubecl-core",
  "cubecl-cuda",
@@ -1597,7 +1596,6 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=40aaddc8162f2c2261c4a7b1525a490ee250d37e#40aaddc8162f2c2261c4a7b1525a490ee250d37e"
 dependencies = [
  "bytemuck",
  "derive-new 0.6.0",
@@ -1622,7 +1620,6 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=40aaddc8162f2c2261c4a7b1525a490ee250d37e#40aaddc8162f2c2261c4a7b1525a490ee250d37e"
 dependencies = [
  "bitflags 2.9.0",
  "bytemuck",
@@ -1644,7 +1641,6 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=40aaddc8162f2c2261c4a7b1525a490ee250d37e#40aaddc8162f2c2261c4a7b1525a490ee250d37e"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1658,7 +1654,6 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=40aaddc8162f2c2261c4a7b1525a490ee250d37e#40aaddc8162f2c2261c4a7b1525a490ee250d37e"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1675,7 +1670,6 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=40aaddc8162f2c2261c4a7b1525a490ee250d37e#40aaddc8162f2c2261c4a7b1525a490ee250d37e"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1701,7 +1695,6 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=40aaddc8162f2c2261c4a7b1525a490ee250d37e#40aaddc8162f2c2261c4a7b1525a490ee250d37e"
 dependencies = [
  "cubecl-common",
  "cubecl-macros-internal",
@@ -1719,10 +1712,11 @@ dependencies = [
 [[package]]
 name = "cubecl-linalg"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=40aaddc8162f2c2261c4a7b1525a490ee250d37e#40aaddc8162f2c2261c4a7b1525a490ee250d37e"
 dependencies = [
  "bytemuck",
+ "cubecl-common",
  "cubecl-core",
+ "cubecl-reduce",
  "cubecl-runtime",
  "cubecl-std",
  "half",
@@ -1732,7 +1726,6 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=40aaddc8162f2c2261c4a7b1525a490ee250d37e#40aaddc8162f2c2261c4a7b1525a490ee250d37e"
 dependencies = [
  "cubecl-common",
  "darling",
@@ -1747,7 +1740,6 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=40aaddc8162f2c2261c4a7b1525a490ee250d37e#40aaddc8162f2c2261c4a7b1525a490ee250d37e"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1758,7 +1750,6 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=40aaddc8162f2c2261c4a7b1525a490ee250d37e#40aaddc8162f2c2261c4a7b1525a490ee250d37e"
 dependencies = [
  "cubecl-common",
  "cubecl-ir",
@@ -1774,7 +1765,6 @@ dependencies = [
 [[package]]
 name = "cubecl-reduce"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=40aaddc8162f2c2261c4a7b1525a490ee250d37e#40aaddc8162f2c2261c4a7b1525a490ee250d37e"
 dependencies = [
  "cubecl-core",
  "cubecl-runtime",
@@ -1786,12 +1776,12 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=40aaddc8162f2c2261c4a7b1525a490ee250d37e#40aaddc8162f2c2261c4a7b1525a490ee250d37e"
 dependencies = [
  "async-channel",
  "async-lock",
  "cfg_aliases",
  "cubecl-common",
+ "cubecl-ir",
  "derive-new 0.6.0",
  "hashbrown 0.14.5",
  "log",
@@ -1806,7 +1796,6 @@ dependencies = [
 [[package]]
 name = "cubecl-spirv"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=40aaddc8162f2c2261c4a7b1525a490ee250d37e#40aaddc8162f2c2261c4a7b1525a490ee250d37e"
 dependencies = [
  "bitflags 2.9.0",
  "cubecl-common",
@@ -1821,7 +1810,6 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=40aaddc8162f2c2261c4a7b1525a490ee250d37e#40aaddc8162f2c2261c4a7b1525a490ee250d37e"
 dependencies = [
  "cubecl-core",
  "cubecl-runtime",
@@ -1831,7 +1819,6 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.5.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=40aaddc8162f2c2261c4a7b1525a490ee250d37e#40aaddc8162f2c2261c4a7b1525a490ee250d37e"
 dependencies = [
  "ash",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,13 +160,13 @@ portable-atomic = { version = "1.11.0" }
 portable-atomic-util = { version = "0.2.4", features = ["alloc"] }
 
 ### For the main burn branch. ###
-# cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "40aaddc8162f2c2261c4a7b1525a490ee250d37e" }
-# cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "40aaddc8162f2c2261c4a7b1525a490ee250d37e" }
-# cubecl-std = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "40aaddc8162f2c2261c4a7b1525a490ee250d37e" }
+cubecl = { git = "https://github.com/wingertge/cubecl", default-features = false, rev = "39495cb619e0d7abff5e51ad5fde923a4f58e23e" }
+cubecl-common = { git = "https://github.com/wingertge/cubecl", default-features = false, rev = "39495cb619e0d7abff5e51ad5fde923a4f58e23e" }
+cubecl-std = { git = "https://github.com/wingertge/cubecl", default-features = false, rev = "39495cb619e0d7abff5e51ad5fde923a4f58e23e" }
 ### For local development. ###
-cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
-cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }
-cubecl-std = { path = "../cubecl/crates/cubecl-std", default-features = false }
+# cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
+# cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }
+# cubecl-std = { path = "../cubecl/crates/cubecl-std", default-features = false }
 ### For the release. ###
 # cubecl = { version = "0.4.0", default-features = false }
 # cubecl-common = { version = "0.4.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,13 +160,13 @@ portable-atomic = { version = "1.11.0" }
 portable-atomic-util = { version = "0.2.4", features = ["alloc"] }
 
 ### For the main burn branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "40aaddc8162f2c2261c4a7b1525a490ee250d37e" }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "40aaddc8162f2c2261c4a7b1525a490ee250d37e" }
-cubecl-std = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "40aaddc8162f2c2261c4a7b1525a490ee250d37e" }
+# cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "40aaddc8162f2c2261c4a7b1525a490ee250d37e" }
+# cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "40aaddc8162f2c2261c4a7b1525a490ee250d37e" }
+# cubecl-std = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "40aaddc8162f2c2261c4a7b1525a490ee250d37e" }
 ### For local development. ###
-# cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
-# cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }
-# cubecl-std = { path = "../cubecl/crates/cubecl-std", default-features = false }
+cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
+cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }
+cubecl-std = { path = "../cubecl/crates/cubecl-std", default-features = false }
 ### For the release. ###
 # cubecl = { version = "0.4.0", default-features = false }
 # cubecl-common = { version = "0.4.0", default-features = false }

--- a/burn-book/src/advanced/backend-extension/custom-cubecl-kernel.md
+++ b/burn-book/src/advanced/backend-extension/custom-cubecl-kernel.md
@@ -192,10 +192,10 @@ impl<R: CubeRuntime, F: FloatElement, I: IntElement> Backend for CubeBackend<R, 
             &lhs.client,
             cube_count,
             cube_dim,
-            lhs.as_tensor_arg::<F>(1),
-            rhs.as_tensor_arg::<F>(1),
-            bias.as_tensor_arg::<F>(1),
-            output.as_tensor_arg::<F>(1),
+            lhs.as_tensor_arg(1),
+            rhs.as_tensor_arg(1),
+            bias.as_tensor_arg(1),
+            output.as_tensor_arg(1),
         );
 
         // Return the output tensor.

--- a/crates/burn-cubecl-fusion/src/base.rs
+++ b/crates/burn-cubecl-fusion/src/base.rs
@@ -119,7 +119,7 @@ impl<R: Runtime> CubeFusionHandle<R> {
             strides: &self.strides,
             shape,
             runtime: PhantomData,
-            elem_size: self.dtype.size(),
+            elem_size: self.elem_size(),
         }
     }
     /// Return the reference to a tensor argument.
@@ -132,8 +132,17 @@ impl<R: Runtime> CubeFusionHandle<R> {
                 handle.strides,
                 handle.shape,
                 vectorisation,
-                self.dtype.size(),
+                handle.elem_size,
             )
+        }
+    }
+
+    fn elem_size(&self) -> usize {
+        if let DType::QFloat(_) = self.dtype {
+            // Encoded as u32
+            core::mem::size_of::<u32>()
+        } else {
+            self.dtype.size()
         }
     }
 }

--- a/crates/burn-cubecl-fusion/src/shared/io.rs
+++ b/crates/burn-cubecl-fusion/src/shared/io.rs
@@ -179,6 +179,23 @@ pub fn read_input_window<C: CubePrimitive>(
 }
 
 #[cube]
+pub fn to_slice<C: CubePrimitive>(inputs: &GlobalArgs, #[comptime] pos: u32) -> Slice<Line<C>> {
+    let tensor = inputs.tensors.index(pos);
+    let slice = tensor.tensor.to_slice();
+    slice.try_cast_unchecked()
+}
+
+#[cube]
+pub fn to_slice_mut<C: CubePrimitive>(
+    outputs: &mut GlobalArgs,
+    #[comptime] pos: u32,
+) -> SliceMut<Line<C>> {
+    let tensor = outputs.tensors.index_mut(pos);
+    let slice = tensor.tensor.to_slice_mut();
+    slice.try_cast_unchecked()
+}
+
+#[cube]
 pub fn read_input_aligned<C: CubePrimitive>(
     inputs: &GlobalArgs,
     locals: &LocalArgs,

--- a/crates/burn-cubecl/src/kernel/base.rs
+++ b/crates/burn-cubecl/src/kernel/base.rs
@@ -1,0 +1,22 @@
+use cubecl::prelude::*;
+
+/// Index into a pitched output tensor (must be contiguous_pitched)
+#[cube]
+pub(crate) fn index_pitched<E: CubePrimitive>(
+    tensor: &Tensor<Line<E>>,
+    offset: u32,
+    #[comptime] pitched: bool,
+) -> u32 {
+    let rank = tensor.rank();
+    let mut offset = offset;
+
+    if pitched {
+        let offset_abs = offset * tensor.line_size();
+        let x = offset_abs % tensor.shape(rank - 1);
+        let y = offset_abs / tensor.shape(rank - 1);
+        let offset_adj = y * tensor.stride(rank - 2) + x;
+        offset = offset_adj / tensor.line_size();
+    }
+
+    offset
+}

--- a/crates/burn-cubecl/src/kernel/binary.rs
+++ b/crates/burn-cubecl/src/kernel/binary.rs
@@ -1,6 +1,8 @@
 use std::marker::PhantomData;
 
-use crate::{CubeRuntime, element::CubeElement, ops::numeric::empty_device, tensor::CubeTensor};
+use crate::{
+    CubeRuntime, element::CubeElement, ops::numeric::empty_device_contiguous, tensor::CubeTensor,
+};
 use burn_tensor::Shape;
 use cubecl::{
     calculate_cube_count_elemwise, linalg::tensor::index_offset_with_layout, prelude::*,
@@ -188,26 +190,26 @@ pub(crate) fn launch_binop<R: CubeRuntime, E: CubeElement, O: BinaryOpFamily>(
     lhs: CubeTensor<R>,
     rhs: CubeTensor<R>,
 ) -> CubeTensor<R> {
-    let ndims = lhs.shape.num_dims();
+    let ndims = lhs.shape().num_dims();
     let line_size_lhs = tensor_line_size_parallel(
         R::line_size_elem(&E::as_elem_native_unchecked()),
-        &lhs.shape.dims,
-        &lhs.strides,
+        &lhs.shape().dims,
+        lhs.strides(),
         ndims - 1,
     );
     let line_size_rhs = tensor_line_size_parallel(
         R::line_size_elem(&E::as_elem_native_unchecked()),
-        &rhs.shape.dims,
-        &rhs.strides,
+        &rhs.shape().dims,
+        rhs.strides(),
         ndims - 1,
     );
     let line_size = Ord::min(line_size_lhs, line_size_rhs);
 
     let mut shape_out = vec![0; ndims];
-    lhs.shape
+    lhs.shape()
         .dims
         .iter()
-        .zip(rhs.shape.dims.iter())
+        .zip(rhs.shape().dims.iter())
         .enumerate()
         .for_each(|(index, (dim_lhs, dim_rhs))| {
             shape_out[index] = usize::max(*dim_lhs, *dim_rhs);
@@ -226,12 +228,12 @@ pub(crate) fn launch_binop<R: CubeRuntime, E: CubeElement, O: BinaryOpFamily>(
                 &client,
                 cube_count,
                 cube_dim,
-                lhs.as_tensor_arg::<E>(line_size),
-                rhs.as_tensor_arg::<E>(line_size),
+                lhs.as_tensor_arg(line_size),
+                rhs.as_tensor_arg(line_size),
                 TensorArg::alias(0),
                 None,
                 false,
-                rhs.strides != lhs.strides || rhs.shape != lhs.shape,
+                rhs.strides() != lhs.strides() || rhs.shape() != lhs.shape(),
             );
 
             lhs
@@ -240,27 +242,30 @@ pub(crate) fn launch_binop<R: CubeRuntime, E: CubeElement, O: BinaryOpFamily>(
                 &client,
                 cube_count,
                 cube_dim,
-                lhs.as_tensor_arg::<E>(line_size),
-                rhs.as_tensor_arg::<E>(line_size),
+                lhs.as_tensor_arg(line_size),
+                rhs.as_tensor_arg(line_size),
                 TensorArg::alias(1),
                 None,
-                rhs.strides != lhs.strides || rhs.shape != lhs.shape,
+                rhs.strides() != lhs.strides() || rhs.shape() != lhs.shape(),
                 false,
             );
 
             rhs
         } else {
-            let output = empty_device::<R, E>(lhs.client.clone(), lhs.device.clone(), shape_out);
-            let to_contiguous_lhs = lhs.strides != output.strides || lhs.shape != output.shape;
-            let to_contiguous_rhs = rhs.strides != output.strides || rhs.shape != output.shape;
+            let output =
+                empty_device_contiguous::<R, E>(lhs.client.clone(), lhs.device.clone(), shape_out);
+            let to_contiguous_lhs =
+                lhs.strides() != output.strides() || lhs.shape() != output.shape();
+            let to_contiguous_rhs =
+                rhs.strides() != output.strides() || rhs.shape() != output.shape();
 
             kernel_binop::launch_unchecked::<E, O, R>(
                 &client,
                 cube_count,
                 cube_dim,
-                lhs.as_tensor_arg::<E>(line_size),
-                rhs.as_tensor_arg::<E>(line_size),
-                output.as_tensor_arg::<E>(line_size),
+                lhs.as_tensor_arg(line_size),
+                rhs.as_tensor_arg(line_size),
+                output.as_tensor_arg(line_size),
                 None,
                 to_contiguous_lhs,
                 to_contiguous_rhs,
@@ -280,15 +285,15 @@ pub(crate) fn launch_scalar_binop<R: CubeRuntime, E: CubeElement, O: BinaryOpFam
     }
 
     // Vectorization is only enabled when the last dimension is contiguous.
-    let ndims = tensor.shape.num_dims();
+    let ndims = tensor.shape().num_dims();
     let line_size = tensor_line_size_parallel(
         R::line_size_elem(&E::as_elem_native_unchecked()),
-        &tensor.shape.dims,
-        &tensor.strides,
+        &tensor.shape().dims,
+        tensor.strides(),
         ndims - 1,
     );
     let client = tensor.client.clone();
-    let num_elems = tensor.shape.num_elements();
+    let num_elems = tensor.shape().num_elements();
 
     let cube_dim = CubeDim::default();
     let cube_count = calculate_cube_count_elemwise(num_elems / line_size as usize, cube_dim);
@@ -299,26 +304,26 @@ pub(crate) fn launch_scalar_binop<R: CubeRuntime, E: CubeElement, O: BinaryOpFam
                 &client,
                 cube_count,
                 cube_dim,
-                tensor.as_tensor_arg::<E>(line_size),
+                tensor.as_tensor_arg(line_size),
                 ScalarArg::new(scalar),
                 TensorArg::alias(0),
             );
 
             tensor
         } else {
-            let output = empty_device::<R, E>(
+            let output = empty_device_contiguous::<R, E>(
                 tensor.client.clone(),
                 tensor.device.clone(),
-                tensor.shape.clone(),
+                tensor.shape().clone(),
             );
 
             kernel_scalar_binop::launch_unchecked::<E, O, R>(
                 &client,
                 cube_count,
                 CubeDim::default(),
-                tensor.as_tensor_arg::<E>(line_size),
+                tensor.as_tensor_arg(line_size),
                 ScalarArg::new(scalar),
-                output.as_tensor_arg::<E>(line_size),
+                output.as_tensor_arg(line_size),
             );
 
             output

--- a/crates/burn-cubecl/src/kernel/cast/base.rs
+++ b/crates/burn-cubecl/src/kernel/cast/base.rs
@@ -1,5 +1,7 @@
-use crate::{CubeElement, CubeRuntime, tensor::CubeTensor};
-use cubecl::linalg::tensor::index_offset_with_layout;
+use crate::{
+    CubeElement, CubeRuntime, kernel::index_pitched, ops::numeric::empty_device, tensor::CubeTensor,
+};
+use cubecl::linalg::tensor::index_offset_contiguous;
 use cubecl::{calculate_cube_count_elemwise, prelude::*, tensor_vectorization_factor};
 use std::any::TypeId;
 
@@ -8,6 +10,7 @@ pub(crate) fn cast_element<I: CubePrimitive, O: CubePrimitive>(
     input: &Tensor<Line<I>>,
     output: &mut Tensor<Line<O>>,
     #[comptime] rank: Option<u32>,
+    #[comptime] pitched: bool,
 ) {
     let offset_output = ABSOLUTE_POS;
 
@@ -15,14 +18,8 @@ pub(crate) fn cast_element<I: CubePrimitive, O: CubePrimitive>(
         terminate!();
     }
 
-    let offset_input = index_offset_with_layout::<I, O>(
-        input,
-        output,
-        offset_output,
-        0,
-        rank.unwrap_or_else(|| output.rank()),
-        rank.is_some(),
-    );
+    let offset_input = index_offset_contiguous::<I>(input, offset_output, rank);
+    let offset_output = index_pitched(output, offset_output, pitched);
 
     output[offset_output] = Line::cast_from(input[offset_input]);
 }
@@ -34,42 +31,34 @@ pub fn cast<R: CubeRuntime, EI: CubeElement, EO: CubeElement>(
     input: CubeTensor<R>,
 ) -> CubeTensor<R> {
     if TypeId::of::<EI>() == TypeId::of::<EO>() {
-        return CubeTensor::new_contiguous(
-            input.client,
-            input.device,
-            input.shape,
-            input.handle,
-            input.dtype,
-        );
+        return CubeTensor::new(input.client, input.handle, input.device, input.dtype);
     }
 
     // Vectorization is only enabled when the last dimension is contiguous.
-    let rank = input.shape.num_dims();
-    let vectorization_factor =
-        tensor_vectorization_factor(&[4, 2], &input.shape.dims, &input.strides, rank - 1);
+    let rank = input.shape().num_dims();
+    let vectorization_factor = tensor_vectorization_factor(
+        R::supported_line_sizes(),
+        &input.shape().dims,
+        input.strides(),
+        rank - 1,
+    );
 
-    let num_elems: usize = input.shape.num_elements();
+    let num_elems: usize = input.shape().num_elements();
 
     let cube_dim = CubeDim::default();
     let cube_count =
         calculate_cube_count_elemwise(num_elems / vectorization_factor as usize, cube_dim);
     let client = input.client.clone();
-    let handle = client.empty(num_elems * core::mem::size_of::<EO>());
-    let output = CubeTensor::new_contiguous(
-        client.clone(),
-        input.device.clone(),
-        input.shape.clone(),
-        handle,
-        EO::dtype(),
-    );
+    let output = empty_device::<R, EO>(client.clone(), input.device.clone(), input.shape().clone());
 
     cast_element::launch::<EI, EO, R>(
         &client,
         cube_count,
         cube_dim,
-        input.as_tensor_arg::<EI>(vectorization_factor),
-        output.as_tensor_arg::<EO>(vectorization_factor),
+        input.as_tensor_arg(vectorization_factor),
+        output.as_tensor_arg(vectorization_factor),
         Some(rank as u32),
+        output.is_pitched(),
     );
 
     output

--- a/crates/burn-cubecl/src/kernel/contiguous.rs
+++ b/crates/burn-cubecl/src/kernel/contiguous.rs
@@ -12,13 +12,22 @@ pub fn into_contiguous<R: CubeRuntime>(tensor: CubeTensor<R>) -> CubeTensor<R> {
             &tensor.as_handle_ref(),
         );
 
-        CubeTensor::new(
-            tensor.client,
-            output.handle,
-            output.shape.into(),
-            tensor.device,
-            output.strides,
-            tensor.dtype,
-        )
+        CubeTensor::new(tensor.client, output.handle, tensor.device, tensor.dtype)
+    })
+}
+
+/// Make a jit tensor contiguous.
+pub fn into_contiguous_pitched<R: CubeRuntime>(tensor: CubeTensor<R>) -> CubeTensor<R> {
+    if tensor.is_contiguous_pitched() {
+        return tensor;
+    }
+
+    execute_with_dtype!(tensor.dtype, E, {
+        let output = cubecl::linalg::tensor::into_contiguous_pitched::<R, E>(
+            &tensor.client,
+            &tensor.as_handle_ref(),
+        );
+
+        CubeTensor::new(tensor.client, output.handle, tensor.device, tensor.dtype)
     })
 }

--- a/crates/burn-cubecl/src/kernel/conv/conv2d/tune/conv2d.rs
+++ b/crates/burn-cubecl/src/kernel/conv/conv2d/tune/conv2d.rs
@@ -79,8 +79,8 @@ fn create_key<R: CubeRuntime, E: FloatElement>(
     bias: &Option<CubeTensor<R>>,
     options: &ConvOptions<2>,
 ) -> CubeAutotuneKey {
-    let [batch_size, in_channels, height, width] = input.shape.dims();
-    let [out_channels, _, kernel_h, kernel_w] = weights.shape.dims();
+    let [batch_size, in_channels, height, width] = input.shape().dims();
+    let [out_channels, _, kernel_h, kernel_w] = weights.shape().dims();
     let ConvOptions {
         stride,
         padding,

--- a/crates/burn-cubecl/src/kernel/conv/conv2d/tune/conv_transpose2d.rs
+++ b/crates/burn-cubecl/src/kernel/conv/conv2d/tune/conv_transpose2d.rs
@@ -73,8 +73,8 @@ fn create_key<R: CubeRuntime, E: FloatElement>(
     bias: &Option<CubeTensor<R>>,
     options: &ConvTransposeOptions<2>,
 ) -> CubeAutotuneKey {
-    let [batch_size, in_channels, height, width] = input.shape.dims();
-    let [out_channels, _, kernel_h, kernel_w] = weights.shape.dims();
+    let [batch_size, in_channels, height, width] = input.shape().dims();
+    let [out_channels, _, kernel_h, kernel_w] = weights.shape().dims();
     let ConvTransposeOptions {
         stride,
         padding,

--- a/crates/burn-cubecl/src/kernel/conv/conv3d.rs
+++ b/crates/burn-cubecl/src/kernel/conv/conv3d.rs
@@ -9,7 +9,7 @@ use crate::{
     CubeRuntime, FloatElement,
     kernel::into_contiguous,
     ops::{
-        numeric::{empty_device, zeros_device},
+        numeric::{empty_device_contiguous, zeros_device},
         reshape,
     },
     tensor::CubeTensor,
@@ -147,8 +147,8 @@ pub(crate) fn conv3d<R: CubeRuntime, E: FloatElement>(
 ) -> CubeTensor<R> {
     let input = into_contiguous(input);
     let weight = into_contiguous(weight);
-    let [batch_size, _, in_depth, in_height, in_width] = input.shape.dims();
-    let [out_channels, _, kernel_0, kernel_1, kernel_2] = weight.shape.dims();
+    let [batch_size, _, in_depth, in_height, in_width] = input.shape().dims();
+    let [out_channels, _, kernel_0, kernel_1, kernel_2] = weight.shape().dims();
 
     let out_0 = calculate_conv_output_size(
         kernel_0,
@@ -174,7 +174,7 @@ pub(crate) fn conv3d<R: CubeRuntime, E: FloatElement>(
 
     let shape_out = Shape::new([batch_size, out_channels, out_0, out_1, out_2]);
 
-    let output = empty_device::<R, E>(
+    let output = empty_device_contiguous::<R, E>(
         input.client.clone(),
         input.device.clone(),
         shape_out.clone(),
@@ -182,26 +182,26 @@ pub(crate) fn conv3d<R: CubeRuntime, E: FloatElement>(
 
     let bias = match bias {
         Some(bias) => {
-            let shape = Shape::from([bias.shape.dims[0], 1, 1, 1, 1]);
+            let shape = Shape::from([bias.shape().dims[0], 1, 1, 1, 1]);
             reshape(bias, shape)
         }
         None => {
-            let shape = Shape::from([output.shape.dims[0], 1, 1, 1, 1]);
+            let shape = Shape::from([output.shape().dims[0], 1, 1, 1, 1]);
             zeros_device::<R, E>(input.client.clone(), input.device.clone(), shape)
         }
     };
 
     let cube_dim = CubeDim::default();
-    let cube_count = calculate_cube_count_elemwise(output.shape.num_elements(), cube_dim);
+    let cube_count = calculate_cube_count_elemwise(output.shape().num_elements(), cube_dim);
 
     conv3d_kernel::launch::<E, R>(
         &input.client,
         cube_count,
         cube_dim,
-        input.as_tensor_arg::<E>(1),
-        weight.as_tensor_arg::<E>(1),
-        bias.as_tensor_arg::<E>(1),
-        output.as_tensor_arg::<E>(1),
+        input.as_tensor_arg(1),
+        weight.as_tensor_arg(1),
+        bias.as_tensor_arg(1),
+        output.as_tensor_arg(1),
         Conv3dArgsLaunch::new(
             ScalarArg::new(options.stride[0] as u32),
             ScalarArg::new(options.stride[1] as u32),

--- a/crates/burn-cubecl/src/kernel/conv/conv_transpose3d.rs
+++ b/crates/burn-cubecl/src/kernel/conv/conv_transpose3d.rs
@@ -5,7 +5,7 @@ use crate::{
     element::CubeElement,
     kernel::into_contiguous,
     ops::{
-        numeric::{empty_device, zeros_device},
+        numeric::{empty_device_contiguous, zeros_device},
         reshape,
     },
     tensor::CubeTensor,
@@ -153,8 +153,8 @@ pub(crate) fn conv_transpose3d<R: CubeRuntime, E: CubeElement + Element>(
 ) -> CubeTensor<R> {
     let input = into_contiguous(input);
     let weight = into_contiguous(weight);
-    let [batch_size, _, in_depth, in_height, in_width] = input.shape.dims();
-    let [_, out_channels, kernel_0, kernel_1, kernel_2] = weight.shape.dims();
+    let [batch_size, _, in_depth, in_height, in_width] = input.shape().dims();
+    let [_, out_channels, kernel_0, kernel_1, kernel_2] = weight.shape().dims();
 
     let out_0 = (in_depth - 1) * options.stride[0]
         + options.dilation[0] * (kernel_0 - 1)
@@ -180,7 +180,7 @@ pub(crate) fn conv_transpose3d<R: CubeRuntime, E: CubeElement + Element>(
         out_2,
     ]);
 
-    let output = empty_device::<R, E>(
+    let output = empty_device_contiguous::<R, E>(
         input.client.clone(),
         input.device.clone(),
         shape_out.clone(),
@@ -188,26 +188,26 @@ pub(crate) fn conv_transpose3d<R: CubeRuntime, E: CubeElement + Element>(
 
     let bias = match bias {
         Some(bias) => {
-            let shape = Shape::from([bias.shape.dims[0], 1, 1, 1, 1]);
+            let shape = Shape::from([bias.shape().dims[0], 1, 1, 1, 1]);
             reshape(bias, shape)
         }
         None => {
-            let shape = Shape::from([output.shape.dims[0], 1, 1, 1, 1]);
+            let shape = Shape::from([output.shape().dims[0], 1, 1, 1, 1]);
             zeros_device::<R, E>(input.client.clone(), input.device.clone(), shape)
         }
     };
 
     let cube_dim = CubeDim::default();
-    let cube_count = calculate_cube_count_elemwise(output.shape.num_elements(), cube_dim);
+    let cube_count = calculate_cube_count_elemwise(output.shape().num_elements(), cube_dim);
 
     conv_transpose3d_kernel::launch::<E, R>(
         &input.client,
         cube_count,
         cube_dim,
-        input.as_tensor_arg::<E>(1),
-        weight.as_tensor_arg::<E>(1),
-        bias.as_tensor_arg::<E>(1),
-        output.as_tensor_arg::<E>(1),
+        input.as_tensor_arg(1),
+        weight.as_tensor_arg(1),
+        bias.as_tensor_arg(1),
+        output.as_tensor_arg(1),
         ConvArgsLaunch::new(
             ScalarArg::new(options.stride[0] as u32),
             ScalarArg::new(options.stride[1] as u32),

--- a/crates/burn-cubecl/src/kernel/conv/deform_conv2d.rs
+++ b/crates/burn-cubecl/src/kernel/conv/deform_conv2d.rs
@@ -196,7 +196,7 @@ pub(crate) fn deform_im2col<R: CubeRuntime, E: FloatElement>(
     let client = input.client.clone();
     let device = input.device.clone();
 
-    let [batch_size, in_channels, _, _] = input.shape.dims();
+    let [batch_size, in_channels, _, _] = input.shape().dims();
     let (out_height, out_width) = out_dims;
     let (kernel_height, kernel_width) = kernel_dims;
 
@@ -212,10 +212,10 @@ pub(crate) fn deform_im2col<R: CubeRuntime, E: FloatElement>(
             client.clone(),
             device.clone(),
             Shape::new([
-                offset.shape.dims[0],
-                offset.shape.dims[1] / 2,
-                offset.shape.dims[2],
-                offset.shape.dims[3],
+                offset.shape().dims[0],
+                offset.shape().dims[1] / 2,
+                offset.shape().dims[2],
+                offset.shape().dims[3],
             ]),
         )
     });
@@ -244,7 +244,7 @@ pub(crate) fn deform_im2col<R: CubeRuntime, E: FloatElement>(
             ScalarArg::new(kernel_width as u32),
             ScalarArg::new(out_height as u32),
             ScalarArg::new(out_width as u32),
-            ScalarArg::new(output.strides[0] as u32),
+            ScalarArg::new(output.strides()[0] as u32),
         ),
         Some(kernel_height as u32),
         Some(kernel_width as u32),
@@ -268,8 +268,8 @@ pub(crate) fn deform_conv2d<R: CubeRuntime, E: FloatElement>(
     let mask = mask.map(|it| into_contiguous(it));
     let bias = bias.map(|it| into_contiguous(it));
 
-    let [batch_size, _, in_height, in_width] = input.shape.dims();
-    let [out_channels, _, kernel_h, kernel_w] = weight.shape.dims();
+    let [batch_size, _, in_height, in_width] = input.shape().dims();
+    let [out_channels, _, kernel_h, kernel_w] = weight.shape().dims();
     let groups = options.weight_groups;
 
     let out_h = calculate_conv_output_size(
@@ -291,7 +291,7 @@ pub(crate) fn deform_conv2d<R: CubeRuntime, E: FloatElement>(
     let columns =
         deform_im2col::<R, E>(input, offset, mask, options, out_dims, (kernel_h, kernel_w));
 
-    let [col_size_0, col_size_1] = columns.shape.dims();
+    let [col_size_0, col_size_1] = columns.shape().dims();
     let col_size_0 = col_size_0 / groups;
     let out_c_per_group = out_channels / groups;
 

--- a/crates/burn-cubecl/src/kernel/index/gather.rs
+++ b/crates/burn-cubecl/src/kernel/index/gather.rs
@@ -1,4 +1,6 @@
-use crate::{CubeRuntime, element::CubeElement, ops::numeric::empty_device, tensor::CubeTensor};
+use crate::{
+    CubeRuntime, element::CubeElement, ops::numeric::empty_device_contiguous, tensor::CubeTensor,
+};
 use cubecl::CubeDim;
 use cubecl::frontend::{ABSOLUTE_POS, Numeric, Tensor};
 use cubecl::linalg::tensor::index_offset_with_layout;
@@ -37,9 +39,10 @@ pub(crate) fn gather<R: CubeRuntime, E: CubeElement, I: CubeElement>(
     tensor: CubeTensor<R>,
     indices: CubeTensor<R>,
 ) -> CubeTensor<R> {
-    let shape_output = indices.shape.clone();
+    let shape_output = indices.shape().clone();
     let total_elem = shape_output.num_elements();
-    let output = empty_device::<R, E>(tensor.client.clone(), tensor.device.clone(), shape_output);
+    let output =
+        empty_device_contiguous::<R, E>(tensor.client.clone(), tensor.device.clone(), shape_output);
 
     let cube_dim = CubeDim::default();
     let cube_count = calculate_cube_count_elemwise(total_elem, cube_dim);
@@ -48,9 +51,9 @@ pub(crate) fn gather<R: CubeRuntime, E: CubeElement, I: CubeElement>(
             &tensor.client,
             cube_count,
             cube_dim,
-            tensor.as_tensor_arg::<E>(1),
-            indices.as_tensor_arg::<I>(1),
-            output.as_tensor_arg::<E>(1),
+            tensor.as_tensor_arg(1),
+            indices.as_tensor_arg(1),
+            output.as_tensor_arg(1),
             ScalarArg::new(dim as u32),
         )
     }

--- a/crates/burn-cubecl/src/kernel/index/select_assign.rs
+++ b/crates/burn-cubecl/src/kernel/index/select_assign.rs
@@ -50,7 +50,7 @@ pub(crate) fn select_assign<R: CubeRuntime, E: CubeElement, I: CubeElement>(
     indices: CubeTensor<R>,
     value: CubeTensor<R>,
 ) -> CubeTensor<R> {
-    let ndims = tensor.shape.num_dims();
+    let ndims = tensor.shape().num_dims();
     let tensor = match tensor.can_mut() {
         true => tensor,
         false => tensor.copy(),
@@ -61,7 +61,7 @@ pub(crate) fn select_assign<R: CubeRuntime, E: CubeElement, I: CubeElement>(
     let mut num_elems = 1;
 
     tensor
-        .shape
+        .shape()
         .dims
         .iter()
         .enumerate()
@@ -70,7 +70,7 @@ pub(crate) fn select_assign<R: CubeRuntime, E: CubeElement, I: CubeElement>(
         .for_each(|(index, val)| {
             strides[index] = current;
             current *= val;
-            num_elems *= tensor.shape.dims[index];
+            num_elems *= tensor.shape().dims[index];
         });
     let cube_dim = CubeDim::default();
     let cube_count = calculate_cube_count_elemwise(num_elems, cube_dim);
@@ -80,10 +80,10 @@ pub(crate) fn select_assign<R: CubeRuntime, E: CubeElement, I: CubeElement>(
             &tensor.client,
             cube_count,
             cube_dim,
-            tensor.as_tensor_arg::<E>(1),
+            tensor.as_tensor_arg(1),
             // Ignored shape + custom strides.
-            TensorArg::from_raw_parts::<I>(&indices.handle, &strides, &strides, 1),
-            value.as_tensor_arg::<E>(1),
+            TensorArg::from_raw_parts::<I>(&indices.handle.handle, &strides, &strides, 1),
+            value.as_tensor_arg(1),
             ScalarArg::new(dim as u32),
         );
     };

--- a/crates/burn-cubecl/src/kernel/index/slice_assign.rs
+++ b/crates/burn-cubecl/src/kernel/index/slice_assign.rs
@@ -34,7 +34,7 @@ pub(crate) fn slice_assign<R: CubeRuntime, E: CubeElement>(
         true => tensor,
         false => tensor.copy(),
     };
-    let ndims = tensor.shape.num_dims();
+    let ndims = tensor.shape().num_dims();
     let mut indices_sequence = SequenceArg::<R, u32>::new();
 
     for i in 0..ndims {
@@ -43,14 +43,14 @@ pub(crate) fn slice_assign<R: CubeRuntime, E: CubeElement>(
     }
 
     let cube_dim = CubeDim::default();
-    let cube_count = calculate_cube_count_elemwise(tensor.shape.num_elements(), cube_dim);
+    let cube_count = calculate_cube_count_elemwise(tensor.shape().num_elements(), cube_dim);
 
     slice_assign_kernel::launch::<E, R>(
         &tensor.client,
         cube_count,
         cube_dim,
-        tensor.as_tensor_arg::<E>(1),
-        value.as_tensor_arg::<E>(1),
+        tensor.as_tensor_arg(1),
+        value.as_tensor_arg(1),
         indices_sequence,
         ndims as u32,
     );

--- a/crates/burn-cubecl/src/kernel/interpolate/bicubic.rs
+++ b/crates/burn-cubecl/src/kernel/interpolate/bicubic.rs
@@ -126,14 +126,14 @@ pub(crate) fn interpolate_bicubic_launch<R: CubeRuntime, E: FloatElement>(
     output: CubeTensor<R>,
 ) -> CubeTensor<R> {
     let cube_dim = CubeDim::default();
-    let cube_count = calculate_cube_count_elemwise(output.shape.num_elements(), cube_dim);
+    let cube_count = calculate_cube_count_elemwise(output.shape().num_elements(), cube_dim);
 
     interpolate_bicubic_kernel::launch::<E, R>(
         &input.client,
         cube_count,
         cube_dim,
-        input.as_tensor_arg::<E>(1),
-        output.as_tensor_arg::<E>(1),
+        input.as_tensor_arg(1),
+        output.as_tensor_arg(1),
     );
 
     output

--- a/crates/burn-cubecl/src/kernel/interpolate/bilinear.rs
+++ b/crates/burn-cubecl/src/kernel/interpolate/bilinear.rs
@@ -84,14 +84,14 @@ pub(crate) fn interpolate_bilinear_launch<R: CubeRuntime, F: FloatElement>(
     output: CubeTensor<R>,
 ) -> CubeTensor<R> {
     let cube_dim = CubeDim::default();
-    let cube_count = calculate_cube_count_elemwise(output.shape.num_elements(), cube_dim);
+    let cube_count = calculate_cube_count_elemwise(output.shape().num_elements(), cube_dim);
 
     interpolate_bilinear_kernel::launch::<F, R>(
         &input.client,
         cube_count,
         cube_dim,
-        input.as_tensor_arg::<F>(1),
-        output.as_tensor_arg::<F>(1),
+        input.as_tensor_arg(1),
+        output.as_tensor_arg(1),
     );
 
     output

--- a/crates/burn-cubecl/src/kernel/interpolate/nearest.rs
+++ b/crates/burn-cubecl/src/kernel/interpolate/nearest.rs
@@ -36,15 +36,15 @@ pub(crate) fn interpolate_nearest_launch<R: CubeRuntime, E: FloatElement>(
     output: CubeTensor<R>,
 ) -> CubeTensor<R> {
     let cube_dim = CubeDim::default();
-    let cube_count = calculate_cube_count_elemwise(output.shape.num_elements(), cube_dim);
+    let cube_count = calculate_cube_count_elemwise(output.shape().num_elements(), cube_dim);
 
     unsafe {
         interpolate_nearest_kernel::launch_unchecked::<E, R>(
             &input.client,
             cube_count,
             cube_dim,
-            input.as_tensor_arg::<E>(1),
-            output.as_tensor_arg::<E>(1),
+            input.as_tensor_arg(1),
+            output.as_tensor_arg(1),
         )
     };
 

--- a/crates/burn-cubecl/src/kernel/interpolate/nearest_backward.rs
+++ b/crates/burn-cubecl/src/kernel/interpolate/nearest_backward.rs
@@ -60,15 +60,15 @@ pub(crate) fn interpolate_nearest_backward_launch<R: CubeRuntime, E: FloatElemen
     output: CubeTensor<R>,
 ) -> CubeTensor<R> {
     let cube_dim = CubeDim::default();
-    let cube_count = calculate_cube_count_elemwise(output.shape.num_elements(), cube_dim);
+    let cube_count = calculate_cube_count_elemwise(output.shape().num_elements(), cube_dim);
 
     unsafe {
         interpolate_nearest_backward_kernel::launch_unchecked::<E, R>(
             &out_grad.client,
             cube_count,
             cube_dim,
-            out_grad.as_tensor_arg::<E>(1),
-            output.as_tensor_arg::<E>(1),
+            out_grad.as_tensor_arg(1),
+            output.as_tensor_arg(1),
         )
     };
 

--- a/crates/burn-cubecl/src/kernel/mask/mask_where.rs
+++ b/crates/burn-cubecl/src/kernel/mask/mask_where.rs
@@ -3,7 +3,7 @@ use cubecl::{calculate_cube_count_elemwise, linalg::tensor::index_offset_with_la
 use crate::{
     BoolElement, CubeRuntime,
     element::CubeElement,
-    ops::{max_vectorization, numeric::empty_device},
+    ops::{max_line_size, numeric::empty_device_contiguous},
     tensor::CubeTensor,
 };
 
@@ -83,25 +83,25 @@ fn mask_where_readonly<R: CubeRuntime, EI: CubeElement, EM: BoolElement>(
     mask: CubeTensor<R>,
     value: CubeTensor<R>,
 ) -> CubeTensor<R> {
-    let ndims = input.shape.num_dims();
-    let output = empty_device::<R, EI>(
+    let ndims = input.shape().num_dims();
+    let output = empty_device_contiguous::<R, EI>(
         input.client.clone(),
         input.device.clone(),
-        input.shape.clone(),
+        input.shape().clone(),
     );
 
     let cube_dim = CubeDim::default();
-    let cube_count = calculate_cube_count_elemwise(input.shape.num_elements(), cube_dim);
-    let vectorization = max_vectorization(&input);
+    let cube_count = calculate_cube_count_elemwise(input.shape().num_elements(), cube_dim);
+    let vectorization = max_line_size(&input);
 
     mask_where_readonly_kernel::launch::<EI, EM, R>(
         &input.client,
         cube_count,
         cube_dim,
-        input.as_tensor_arg::<EI>(vectorization),
-        mask.as_tensor_arg::<EM>(vectorization),
-        value.as_tensor_arg::<EI>(vectorization),
-        output.as_tensor_arg::<EI>(vectorization),
+        input.as_tensor_arg(vectorization),
+        mask.as_tensor_arg(vectorization),
+        value.as_tensor_arg(vectorization),
+        output.as_tensor_arg(vectorization),
         ndims as u32,
     );
 
@@ -114,18 +114,18 @@ fn mask_where_inplace<R: CubeRuntime, EI: CubeElement, EM: BoolElement>(
     value: CubeTensor<R>,
     reverse: bool,
 ) -> CubeTensor<R> {
-    let ndims = input.shape.num_dims();
+    let ndims = input.shape().num_dims();
     let cube_dim = CubeDim::default();
-    let cube_count = calculate_cube_count_elemwise(input.shape.num_elements(), cube_dim);
-    let vectorization = max_vectorization(&input);
+    let cube_count = calculate_cube_count_elemwise(input.shape().num_elements(), cube_dim);
+    let vectorization = max_line_size(&input);
 
     mask_where_inplace_kernel::launch::<EI, EM, R>(
         &input.client,
         cube_count,
         cube_dim,
-        input.as_tensor_arg::<EI>(vectorization),
-        mask.as_tensor_arg::<EM>(vectorization),
-        value.as_tensor_arg::<EI>(vectorization),
+        input.as_tensor_arg(vectorization),
+        mask.as_tensor_arg(vectorization),
+        value.as_tensor_arg(vectorization),
         ScalarArg::new(EM::new_bool(reverse)),
         ndims as u32,
     );

--- a/crates/burn-cubecl/src/kernel/matmul/tune/base.rs
+++ b/crates/burn-cubecl/src/kernel/matmul/tune/base.rs
@@ -11,7 +11,7 @@ use crate::{
     CubeRuntime, CubeTuneId,
     element::FloatElement,
     kernel::{matmul::utils::init_matmul_output, prng::random_like_uniform},
-    ops::numeric::empty_device,
+    ops::numeric::empty_device_contiguous,
     tensor::CubeTensor,
 };
 
@@ -25,7 +25,11 @@ fn matmul_input_gen<R: CubeRuntime, E: FloatElement>(
     let lhs = random_like_uniform(lhs, random_bounds.0, random_bounds.1);
     let rhs = random_like_uniform(rhs, random_bounds.0, random_bounds.1);
 
-    let out = empty_device::<R, E>(out.client.clone(), out.device.clone(), out.shape.clone());
+    let out = empty_device_contiguous::<R, E>(
+        out.client.clone(),
+        out.device.clone(),
+        out.shape().clone(),
+    );
 
     (lhs, rhs, out)
 }
@@ -63,10 +67,10 @@ fn create_key<R: CubeRuntime, E: FloatElement>(
     _out: &CubeTensor<R>,
 ) -> MatmulAutotuneKey {
     MatmulAutotuneKey::generate(
-        &lhs.shape.dims,
-        &rhs.shape.dims,
-        &lhs.strides,
-        &rhs.strides,
+        &lhs.shape().dims,
+        &rhs.shape().dims,
+        lhs.strides(),
+        rhs.strides(),
         E::dtype().into(),
         E::dtype().into(),
         E::dtype().into(),

--- a/crates/burn-cubecl/src/kernel/matmul/utils.rs
+++ b/crates/burn-cubecl/src/kernel/matmul/utils.rs
@@ -1,4 +1,6 @@
-use crate::{CubeRuntime, element::CubeElement, ops::numeric::empty_device, tensor::CubeTensor};
+use crate::{
+    CubeRuntime, element::CubeElement, ops::numeric::empty_device_contiguous, tensor::CubeTensor,
+};
 use burn_tensor::Shape;
 
 /// Creates an empty output tensor with matmul output shape
@@ -6,21 +8,21 @@ pub fn init_matmul_output<R: CubeRuntime, E: CubeElement>(
     lhs: &CubeTensor<R>,
     rhs: &CubeTensor<R>,
 ) -> CubeTensor<R> {
-    empty_device::<R, E>(lhs.client.clone(), lhs.device.clone(), shape_out(lhs, rhs))
+    empty_device_contiguous::<R, E>(lhs.client.clone(), lhs.device.clone(), shape_out(lhs, rhs))
 }
 
 pub(crate) fn shape_out<R: CubeRuntime>(lhs: &CubeTensor<R>, rhs: &CubeTensor<R>) -> Shape {
-    let ndims = lhs.shape.num_dims();
+    let ndims = lhs.shape().num_dims();
     let mut shape_out = vec![0; ndims];
-    lhs.shape
+    lhs.shape()
         .dims
         .iter()
-        .zip(rhs.shape.dims.iter())
+        .zip(rhs.shape().dims.iter())
         .enumerate()
         .for_each(|(index, (dim_lhs, dim_rhs))| {
             shape_out[index] = usize::max(*dim_lhs, *dim_rhs);
         });
-    shape_out[ndims - 2] = lhs.shape.dims[ndims - 2];
-    shape_out[ndims - 1] = rhs.shape.dims[ndims - 1];
+    shape_out[ndims - 2] = lhs.shape().dims[ndims - 2];
+    shape_out[ndims - 1] = rhs.shape().dims[ndims - 1];
     Shape::from(shape_out)
 }

--- a/crates/burn-cubecl/src/kernel/mod.rs
+++ b/crates/burn-cubecl/src/kernel/mod.rs
@@ -1,3 +1,4 @@
+mod base;
 mod binary;
 mod binary_int;
 mod cast;
@@ -10,6 +11,7 @@ mod unary_float;
 mod unary_int;
 mod unary_numeric;
 
+pub(crate) use base::*;
 pub(crate) use binary::*;
 pub(crate) use binary_int::*;
 pub use cast::*;

--- a/crates/burn-cubecl/src/kernel/pool/avg_pool2d.rs
+++ b/crates/burn-cubecl/src/kernel/pool/avg_pool2d.rs
@@ -5,7 +5,7 @@ use crate::{
     CubeRuntime,
     element::CubeElement,
     kernel::conv::nchw_to_nhwc,
-    ops::{max_vectorization, numeric::empty_device, permute},
+    ops::{max_line_size, numeric::empty_device_contiguous, permute},
     tensor::CubeTensor,
 };
 use burn_tensor::{Shape, ops::conv::calculate_pool_output_size};
@@ -81,7 +81,7 @@ pub(crate) fn avg_pool2d<R: CubeRuntime, E: CubeElement>(
     padding: [usize; 2],
     count_include_pad: bool,
 ) -> CubeTensor<R> {
-    let [batch_size, channels, _, _] = x.shape.dims();
+    let [batch_size, channels, _, _] = x.shape().dims();
     let dilation = 1;
 
     let size_0 = calculate_pool_output_size(
@@ -89,14 +89,14 @@ pub(crate) fn avg_pool2d<R: CubeRuntime, E: CubeElement>(
         stride[0],
         padding[0],
         dilation,
-        x.shape.dims[2],
+        x.shape().dims[2],
     );
     let size_1 = calculate_pool_output_size(
         kernel_size[1],
         stride[1],
         padding[1],
         dilation,
-        x.shape.dims[3],
+        x.shape().dims[3],
     );
 
     let x = if x.is_contiguous() {
@@ -104,21 +104,21 @@ pub(crate) fn avg_pool2d<R: CubeRuntime, E: CubeElement>(
     } else {
         permute(x, &[0, 2, 3, 1])
     };
-    let line_size = max_vectorization(&x);
+    let line_size = max_line_size(&x);
 
     let shape_out = Shape::new([batch_size, size_0, size_1, channels]);
-    let output = empty_device::<R, E>(x.client.clone(), x.device.clone(), shape_out);
+    let output = empty_device_contiguous::<R, E>(x.client.clone(), x.device.clone(), shape_out);
 
     let cube_dim = CubeDim::default();
     let cube_count =
-        calculate_cube_count_elemwise(output.shape.num_elements() / line_size as usize, cube_dim);
+        calculate_cube_count_elemwise(output.shape().num_elements() / line_size as usize, cube_dim);
 
     pool2d_direct::launch::<E, AvgPoolStrategy, R>(
         &x.client,
         cube_count,
         cube_dim,
-        x.as_tensor_arg::<E>(line_size),
-        output.as_tensor_arg::<E>(line_size),
+        x.as_tensor_arg(line_size),
+        output.as_tensor_arg(line_size),
         (),
         Pool2dDirectArgsLaunch::new(
             ScalarArg::new(stride[0] as u32),

--- a/crates/burn-cubecl/src/kernel/pool/max_pool2d_backward.rs
+++ b/crates/burn-cubecl/src/kernel/pool/max_pool2d_backward.rs
@@ -2,7 +2,7 @@ use crate::{
     CubeRuntime, IntElement,
     element::CubeElement,
     kernel::conv::nchw_to_nhwc,
-    ops::{max_vectorization, numeric::empty_device, permute},
+    ops::{max_line_size, numeric::empty_device_contiguous, permute},
     tensor::CubeTensor,
 };
 use burn_tensor::Shape;
@@ -95,7 +95,7 @@ pub(crate) fn max_pool2d_with_indices_backward<R: CubeRuntime, E: CubeElement, I
     padding: [usize; 2],
     dilation: [usize; 2],
 ) -> CubeTensor<R> {
-    let [batches, channels, height, width] = x.shape.dims();
+    let [batches, channels, height, width] = x.shape().dims();
 
     let grad = if grad.is_contiguous() {
         nchw_to_nhwc::<R, E>(grad)
@@ -107,26 +107,26 @@ pub(crate) fn max_pool2d_with_indices_backward<R: CubeRuntime, E: CubeElement, I
     } else {
         permute(indices, &[0, 2, 3, 1])
     };
-    let line_size = if grad.strides[3] == indices.strides[3] {
-        max_vectorization(&grad)
+    let line_size = if grad.strides()[3] == indices.strides()[3] {
+        max_line_size(&grad)
     } else {
         1
     };
 
     let out_shape = Shape::new([batches, height, width, channels]);
-    let output = empty_device::<R, E>(x.client.clone(), x.device.clone(), out_shape);
+    let output = empty_device_contiguous::<R, E>(x.client.clone(), x.device.clone(), out_shape);
     let cube_dim = CubeDim::default();
     let cube_count =
-        calculate_cube_count_elemwise(output.shape.num_elements() / line_size as usize, cube_dim);
+        calculate_cube_count_elemwise(output.shape().num_elements() / line_size as usize, cube_dim);
 
     unsafe {
         max_pool2d_with_indices_backward_kernel::launch_unchecked::<E, I, R>(
             &x.client,
             cube_count,
             cube_dim,
-            grad.as_tensor_arg::<E>(line_size),
-            indices.as_tensor_arg::<I>(line_size),
-            output.as_tensor_arg::<E>(line_size),
+            grad.as_tensor_arg(line_size),
+            indices.as_tensor_arg(line_size),
+            output.as_tensor_arg(line_size),
             PoolBackwardArgsLaunch::new(
                 ScalarArg::new(stride[0] as i32),
                 ScalarArg::new(stride[1] as i32),

--- a/crates/burn-cubecl/src/kernel/prng/base.rs
+++ b/crates/burn-cubecl/src/kernel/prng/base.rs
@@ -1,6 +1,8 @@
 use cubecl::prelude::*;
 
-use crate::{CubeElement, CubeRuntime, SEED, ops::numeric::empty_device, tensor::CubeTensor};
+use crate::{
+    CubeElement, CubeRuntime, SEED, ops::numeric::empty_device_contiguous, tensor::CubeTensor,
+};
 use burn_common::rand::get_seeded_rng;
 use burn_tensor::Shape;
 use rand::Rng;
@@ -14,18 +16,18 @@ pub(crate) fn random<P: PrngRuntime<E>, R: CubeRuntime, E: CubeElement>(
     prng: P,
 ) -> CubeTensor<R> {
     let client = R::client(device);
-    let output = empty_device::<R, E>(client.clone(), device.clone(), shape);
+    let output = empty_device_contiguous::<R, E>(client.clone(), device.clone(), shape);
     let seeds = get_seeds();
     let args = prng.args();
 
     let cube_dim = CubeDim::default();
-    let cube_count = prng_cube_count(output.shape.num_elements(), cube_dim, N_VALUES_PER_THREAD);
+    let cube_count = prng_cube_count(output.shape().num_elements(), cube_dim, N_VALUES_PER_THREAD);
 
     prng_kernel::launch::<P, E, R>(
         &client,
         cube_count,
         cube_dim,
-        output.as_tensor_arg::<E>(1),
+        output.as_tensor_arg(1),
         ScalarArg::new(seeds[0]),
         ScalarArg::new(seeds[1]),
         ScalarArg::new(seeds[2]),

--- a/crates/burn-cubecl/src/kernel/prng/uniform.rs
+++ b/crates/burn-cubecl/src/kernel/prng/uniform.rs
@@ -89,7 +89,7 @@ pub fn random_like_uniform<R: CubeRuntime, E: CubeElement>(
     upper_bound: E,
 ) -> CubeTensor<R> {
     random_uniform(
-        tensor.shape.clone(),
+        tensor.shape().clone(),
         &tensor.device,
         lower_bound,
         upper_bound,

--- a/crates/burn-cubecl/src/kernel/quantization/dequantize.rs
+++ b/crates/burn-cubecl/src/kernel/quantization/dequantize.rs
@@ -174,7 +174,7 @@ where
 {
     // The actual number of elements is 1/4 (four int8 values packed in a single u32)
     // so we choose a line size to match a valid input binding size.
-    let num_out_elems = tensor.shape.num_elements();
+    let num_out_elems = tensor.shape().num_elements();
     let num_elems = usize::div_ceil(num_out_elems, 4);
     let line_size_in = 1;
     let line_size_out = if num_out_elems < 4 { 1 } else { 4 };
@@ -187,7 +187,7 @@ where
     let output = CubeTensor::new_contiguous(
         client.clone(),
         tensor.device.clone(),
-        tensor.shape.clone(),
+        tensor.shape().clone(),
         handle,
         F::dtype(),
     );
@@ -200,8 +200,8 @@ where
                         &client,
                         cube_count,
                         cube_dim,
-                        tensor.as_array_arg::<u32>(line_size_in),
-                        output.as_tensor_arg::<F>(line_size_out),
+                        tensor.as_full_array_arg::<u32>(line_size_in),
+                        output.as_tensor_arg(line_size_out),
                         scheme,
                     )
                 };
@@ -212,8 +212,8 @@ where
                         &client,
                         cube_count,
                         cube_dim,
-                        tensor.as_array_arg::<u32>(line_size_in),
-                        output.as_tensor_arg::<F>(line_size_out),
+                        tensor.as_full_array_arg::<u32>(line_size_in),
+                        output.as_tensor_arg(line_size_out),
                         scheme,
                     )
                 };
@@ -229,8 +229,8 @@ where
                         &client,
                         cube_count,
                         cube_dim,
-                        tensor.as_array_arg::<u32>(line_size_in),
-                        output.as_tensor_arg::<F>(line_size_out),
+                        tensor.as_full_array_arg::<u32>(line_size_in),
+                        output.as_tensor_arg(line_size_out),
                         scheme,
                         num_blocks,
                     )
@@ -247,8 +247,8 @@ where
                         &client,
                         cube_count,
                         cube_dim,
-                        tensor.as_array_arg::<u32>(line_size_in),
-                        output.as_tensor_arg::<F>(line_size_out),
+                        tensor.as_full_array_arg::<u32>(line_size_in),
+                        output.as_tensor_arg(line_size_out),
                         scheme,
                         num_blocks,
                     )

--- a/crates/burn-cubecl/src/kernel/quantization/quantize.rs
+++ b/crates/burn-cubecl/src/kernel/quantization/quantize.rs
@@ -289,7 +289,7 @@ where
 {
     let client = tensor.client.clone();
     // Output tensor contains 4x less elements (four int8 values packed in a single u32)
-    let num_elems = tensor.shape.num_elements();
+    let num_elems = tensor.shape().num_elements();
 
     // Force vectorization to process 4 quantized values packed for 1 output value
     let line_size: u8 = if num_elems < 4 { 1 } else { 4 };
@@ -300,13 +300,13 @@ where
         client.clone(),
         num_elems,
         tensor.device.clone(),
-        tensor.shape.clone(),
+        tensor.shape().clone(),
         *scheme,
     );
 
     match scheme {
         QuantizationScheme::PerTensor(mode, QuantizationType::QInt8) => {
-            let ndims = tensor.shape.num_dims();
+            let ndims = tensor.shape().num_dims();
             let dummy_array = vec![1; ndims];
 
             match mode {
@@ -316,23 +316,23 @@ where
                             &client,
                             cube_count,
                             cube_dim,
-                            tensor.as_tensor_arg::<F>(line_size),
+                            tensor.as_tensor_arg(line_size),
                             // Ignore shape and stride
                             TensorArg::from_raw_parts::<F>(
-                                &scale.handle,
+                                &scale.handle.handle,
                                 &dummy_array,
                                 &dummy_array,
                                 1,
                             ),
                             TensorArg::from_raw_parts::<I>(
-                                &offset.expect("Should have offset").handle,
+                                &offset.expect("Should have offset").handle.handle,
                                 &dummy_array,
                                 &dummy_array,
                                 1,
                             ),
                             ScalarArg::new(i8::MIN as f32),
                             ScalarArg::new(i8::MAX as f32),
-                            output.as_array_arg::<u32>(1),
+                            output.as_full_array_arg::<u32>(1),
                         )
                     };
                 }
@@ -342,17 +342,17 @@ where
                             &client,
                             cube_count,
                             cube_dim,
-                            tensor.as_tensor_arg::<F>(line_size),
+                            tensor.as_tensor_arg(line_size),
                             // Ignore shape and stride
                             TensorArg::from_raw_parts::<F>(
-                                &scale.handle,
+                                &scale.handle.handle,
                                 &dummy_array,
                                 &dummy_array,
                                 1,
                             ),
                             ScalarArg::new(-i8::MAX as f32),
                             ScalarArg::new(i8::MAX as f32),
-                            output.as_array_arg::<u32>(1),
+                            output.as_full_array_arg::<u32>(1),
                         )
                     };
                 }
@@ -381,13 +381,13 @@ where
                             &client,
                             cube_count,
                             cube_dim,
-                            tensor.as_tensor_arg::<F>(line_size),
-                            scale.as_tensor_arg::<F>(1),
-                            offset.expect("Should have offset").as_tensor_arg::<I>(1),
+                            tensor.as_tensor_arg(line_size),
+                            scale.as_tensor_arg(1),
+                            offset.expect("Should have offset").as_tensor_arg(1),
                             ScalarArg::new(i8::MIN as f32),
                             ScalarArg::new(i8::MAX as f32),
                             ScalarArg::new(*block_size),
-                            output.as_array_arg::<u32>(1),
+                            output.as_full_array_arg::<u32>(1),
                             num_blocks,
                         )
                     };
@@ -398,12 +398,12 @@ where
                             &client,
                             cube_count,
                             cube_dim,
-                            tensor.as_tensor_arg::<F>(line_size),
-                            scale.as_tensor_arg::<F>(1),
+                            tensor.as_tensor_arg(line_size),
+                            scale.as_tensor_arg(1),
                             ScalarArg::new(-i8::MAX as f32),
                             ScalarArg::new(i8::MAX as f32),
                             ScalarArg::new(*block_size),
-                            output.as_array_arg::<u32>(1),
+                            output.as_full_array_arg::<u32>(1),
                             num_blocks,
                         )
                     };

--- a/crates/burn-cubecl/src/kernel/unary_float.rs
+++ b/crates/burn-cubecl/src/kernel/unary_float.rs
@@ -1,4 +1,6 @@
-use crate::{CubeRuntime, element::CubeElement, ops::numeric::empty_device, tensor::CubeTensor};
+use crate::{
+    CubeRuntime, element::CubeElement, ops::numeric::empty_device_contiguous, tensor::CubeTensor,
+};
 use cubecl::{
     calculate_cube_count_elemwise, linalg::tensor::index_offset_with_layout, prelude::*,
     tensor_line_size_parallel,
@@ -55,16 +57,16 @@ where
     E: CubeElement + Float,
     O: FloatUnaryOpFamily,
 {
-    let ndims = tensor.shape.num_dims();
+    let ndims = tensor.shape().num_dims();
     let line_size = tensor_line_size_parallel(
         R::line_size_elem(&E::as_elem_native_unchecked()),
-        &tensor.shape.dims,
-        &tensor.strides,
+        &tensor.shape().dims,
+        tensor.strides(),
         ndims - 1,
     );
 
     let client = tensor.client.clone();
-    let num_elems = tensor.shape.num_elements();
+    let num_elems = tensor.shape().num_elements();
 
     let cube_dim = CubeDim::default();
     let cube_count = calculate_cube_count_elemwise(num_elems / line_size as usize, cube_dim);
@@ -76,7 +78,7 @@ where
                 &client,
                 cube_count,
                 cube_dim,
-                tensor.as_tensor_arg::<E>(line_size),
+                tensor.as_tensor_arg(line_size),
                 TensorArg::alias(0),
                 args(&()),
                 None,
@@ -85,18 +87,18 @@ where
 
             tensor
         } else {
-            let output = empty_device::<R, E>(
+            let output = empty_device_contiguous::<R, E>(
                 tensor.client.clone(),
                 tensor.device.clone(),
-                tensor.shape.clone(),
+                tensor.shape().clone(),
             );
 
             unary_float::launch_unchecked::<E, O, R>(
                 &client,
                 cube_count,
                 CubeDim::default(),
-                tensor.as_tensor_arg::<E>(line_size),
-                output.as_tensor_arg::<E>(line_size),
+                tensor.as_tensor_arg(line_size),
+                output.as_tensor_arg(line_size),
                 args(&()),
                 Some(ndims as u32),
                 !is_contiguous,

--- a/crates/burn-cubecl/src/kernel/unary_int.rs
+++ b/crates/burn-cubecl/src/kernel/unary_int.rs
@@ -1,4 +1,4 @@
-use crate::{CubeRuntime, IntElement, ops::numeric::empty_device, tensor::CubeTensor};
+use crate::{CubeRuntime, IntElement, ops::numeric::empty_device_contiguous, tensor::CubeTensor};
 use cubecl::{
     calculate_cube_count_elemwise, linalg::tensor::index_offset_with_layout, prelude::*,
     tensor_line_size_parallel,
@@ -53,15 +53,15 @@ where
     E: IntElement + Int,
     O: IntUnaryOpFamily,
 {
-    let ndims = tensor.shape.num_dims();
+    let ndims = tensor.shape().num_dims();
     let line_size = tensor_line_size_parallel(
         R::line_size_elem(&E::as_elem_native_unchecked()),
-        &tensor.shape.dims,
-        &tensor.strides,
+        &tensor.shape().dims,
+        tensor.strides(),
         ndims - 1,
     );
     let client = tensor.client.clone();
-    let num_elems = tensor.shape.num_elements();
+    let num_elems = tensor.shape().num_elements();
 
     let cube_dim = CubeDim::default();
     let cube_count = calculate_cube_count_elemwise(num_elems / line_size as usize, cube_dim);
@@ -73,7 +73,7 @@ where
                 &client,
                 cube_count,
                 cube_dim,
-                tensor.as_tensor_arg::<E>(line_size),
+                tensor.as_tensor_arg(line_size),
                 TensorArg::alias(0),
                 args(&()),
                 None,
@@ -82,18 +82,18 @@ where
 
             tensor
         } else {
-            let output = empty_device::<R, E>(
+            let output = empty_device_contiguous::<R, E>(
                 tensor.client.clone(),
                 tensor.device.clone(),
-                tensor.shape.clone(),
+                tensor.shape().clone(),
             );
 
             unary_int::launch_unchecked::<E, O, R>(
                 &client,
                 cube_count,
                 CubeDim::default(),
-                tensor.as_tensor_arg::<E>(line_size),
-                output.as_tensor_arg::<E>(line_size),
+                tensor.as_tensor_arg(line_size),
+                output.as_tensor_arg(line_size),
                 args(&()),
                 Some(ndims as u32),
                 !is_contiguous,

--- a/crates/burn-cubecl/src/kernel/unary_numeric.rs
+++ b/crates/burn-cubecl/src/kernel/unary_numeric.rs
@@ -1,4 +1,6 @@
-use crate::{CubeRuntime, element::CubeElement, ops::numeric::empty_device, tensor::CubeTensor};
+use crate::{
+    CubeRuntime, element::CubeElement, ops::numeric::empty_device_contiguous, tensor::CubeTensor,
+};
 use cubecl::{
     calculate_cube_count_elemwise, linalg::tensor::index_offset_with_layout, prelude::*,
     tensor_line_size_parallel,
@@ -58,15 +60,15 @@ where
     E: CubeElement + Numeric,
     O: NumericUnaryOpFamily,
 {
-    let ndims = tensor.shape.num_dims();
+    let ndims = tensor.shape().num_dims();
     let line_size = tensor_line_size_parallel(
         R::line_size_elem(&E::as_elem_native_unchecked()),
-        &tensor.shape.dims,
-        &tensor.strides,
+        &tensor.shape().dims,
+        tensor.strides(),
         ndims - 1,
     );
     let client = tensor.client.clone();
-    let num_elems = tensor.shape.num_elements();
+    let num_elems = tensor.shape().num_elements();
 
     let cube_dim = CubeDim::default();
     let cube_count = calculate_cube_count_elemwise(num_elems / line_size as usize, cube_dim);
@@ -78,7 +80,7 @@ where
                 &client,
                 cube_count,
                 cube_dim,
-                tensor.as_tensor_arg::<E>(line_size),
+                tensor.as_tensor_arg(line_size),
                 TensorArg::alias(0),
                 args(&()),
                 None,
@@ -87,18 +89,18 @@ where
 
             tensor
         } else {
-            let output = empty_device::<R, E>(
+            let output = empty_device_contiguous::<R, E>(
                 tensor.client.clone(),
                 tensor.device.clone(),
-                tensor.shape.clone(),
+                tensor.shape().clone(),
             );
 
             unary_numeric::launch_unchecked::<E, O, R>(
                 &client,
                 cube_count,
                 CubeDim::default(),
-                tensor.as_tensor_arg::<E>(line_size),
-                output.as_tensor_arg::<E>(line_size),
+                tensor.as_tensor_arg(line_size),
+                output.as_tensor_arg(line_size),
                 args(&()),
                 Some(ndims as u32),
                 !is_contiguous,

--- a/crates/burn-cubecl/src/ops/base.rs
+++ b/crates/burn-cubecl/src/ops/base.rs
@@ -13,9 +13,15 @@ pub(crate) fn from_data<R: CubeRuntime>(data: TensorData, device: &R::Device) ->
 pub(crate) async fn into_data<R: CubeRuntime, E: CubeElement>(tensor: CubeTensor<R>) -> TensorData {
     let tensor = kernel::into_contiguous(tensor);
 
-    let bytes = tensor.client.read_one_async(tensor.handle.binding()).await;
-    let actual_len = tensor.shape.num_elements() * size_of::<E>();
-    TensorData::new(E::from_bytes(&bytes[..actual_len]).to_vec(), tensor.shape)
+    let bytes = tensor
+        .client
+        .read_one_async(tensor.handle.handle.clone().binding())
+        .await;
+    let actual_len = tensor.shape().num_elements() * size_of::<E>();
+    TensorData::new(
+        E::from_bytes(&bytes[..actual_len]).to_vec(),
+        tensor.shape().dims.clone(),
+    )
 }
 
 /// Read data from a `CubeTensor` synchronously
@@ -23,9 +29,14 @@ pub(crate) async fn into_data<R: CubeRuntime, E: CubeElement>(tensor: CubeTensor
 pub fn into_data_sync<R: CubeRuntime, E: CubeElement>(tensor: CubeTensor<R>) -> TensorData {
     let tensor = kernel::into_contiguous(tensor);
 
-    let bytes = tensor.client.read_one(tensor.handle.binding());
-    let actual_len = tensor.shape.num_elements() * size_of::<E>();
-    TensorData::new(E::from_bytes(&bytes[..actual_len]).to_vec(), tensor.shape)
+    let bytes = tensor
+        .client
+        .read_one(tensor.handle.handle.clone().binding());
+    let actual_len = tensor.shape().num_elements() * size_of::<E>();
+    TensorData::new(
+        E::from_bytes(&bytes[..actual_len]).to_vec(),
+        tensor.shape().dims.clone(),
+    )
 }
 
 pub(crate) fn to_device<R: CubeRuntime>(
@@ -55,8 +66,8 @@ pub(crate) fn swap_dims<R: CubeRuntime>(
     dim1: usize,
     dim2: usize,
 ) -> CubeTensor<R> {
-    tensor.strides.swap(dim1, dim2);
-    tensor.shape.dims.swap(dim1, dim2);
+    tensor.strides_mut().swap(dim1, dim2);
+    tensor.shape_mut().dims.swap(dim1, dim2);
 
     tensor
 }
@@ -64,15 +75,18 @@ pub(crate) fn swap_dims<R: CubeRuntime>(
 /// Permute a tensor's dimensions
 pub fn permute<R: CubeRuntime>(mut tensor: CubeTensor<R>, axes: &[usize]) -> CubeTensor<R> {
     // remap strides
-    tensor.strides = axes.iter().map(|i| tensor.strides[*i]).collect();
+    *tensor.strides_mut() = axes.iter().map(|i| tensor.strides()[*i]).collect();
 
     // remap shape
-    tensor.shape.dims = axes.iter().map(|i| tensor.shape.dims[*i]).collect();
+    tensor.shape_mut().dims = axes.iter().map(|i| tensor.shape().dims[*i]).collect();
 
     tensor
 }
-pub(crate) fn expand<R: CubeRuntime>(tensor: CubeTensor<R>, target_shape: Shape) -> CubeTensor<R> {
-    let ndims_in = tensor.shape.num_dims();
+pub(crate) fn expand<R: CubeRuntime>(
+    mut tensor: CubeTensor<R>,
+    target_shape: Shape,
+) -> CubeTensor<R> {
+    let ndims_in = tensor.shape().num_dims();
     let ndims_out = target_shape.num_dims();
 
     // Initialize new strides with zeros
@@ -82,14 +96,14 @@ pub(crate) fn expand<R: CubeRuntime>(tensor: CubeTensor<R>, target_shape: Shape)
     let dim_diff = ndims_out.saturating_sub(ndims_in);
 
     // Compare dimensions from the end, setting strides for matching dimensions or broadcasted ones
-    let mut tensor_dim_iter = tensor.shape.dims.iter().rev();
+    let mut tensor_dim_iter = tensor.shape().dims.iter().rev();
     for i in (0..ndims_out).rev() {
         if i >= dim_diff {
             if let Some(&tensor_dim) = tensor_dim_iter.next() {
                 if tensor_dim == target_shape.dims[i] || tensor_dim == 1 {
                     // Copy stride for non-broadcast dimensions or set to 0 for broadcast ones
                     new_strides[i] = if tensor_dim == target_shape.dims[i] {
-                        tensor.strides[i - dim_diff]
+                        tensor.strides()[i - dim_diff]
                     } else {
                         0
                     };
@@ -111,11 +125,12 @@ pub(crate) fn expand<R: CubeRuntime>(tensor: CubeTensor<R>, target_shape: Shape)
         }
     }
 
+    *tensor.shape_mut() = target_shape;
+    *tensor.strides_mut() = new_strides;
+
     CubeTensor {
         client: tensor.client,
         device: tensor.device,
-        shape: target_shape,
-        strides: new_strides,
         handle: tensor.handle,
         dtype: tensor.dtype,
     }
@@ -130,16 +145,16 @@ pub fn reshape<R: CubeRuntime>(tensor: CubeTensor<R>, shape: Shape) -> CubeTenso
         tensor.client,
         tensor.device,
         shape,
-        tensor.handle,
+        tensor.handle.handle,
         tensor.dtype,
     )
 }
 
-pub(crate) fn max_vectorization<R: CubeRuntime>(tensor: &CubeTensor<R>) -> u8 {
+pub(crate) fn max_line_size<R: CubeRuntime>(tensor: &CubeTensor<R>) -> u8 {
     tensor_vectorization_factor(
         R::supported_line_sizes(),
-        &tensor.shape.dims,
-        &tensor.strides,
-        tensor.shape.num_dims() - 1,
+        &tensor.shape().dims,
+        tensor.strides(),
+        tensor.shape().num_dims() - 1,
     )
 }

--- a/crates/burn-cubecl/src/ops/bool_ops.rs
+++ b/crates/burn-cubecl/src/ops/bool_ops.rs
@@ -80,8 +80,8 @@ where
     }
 
     fn bool_swap_dims(mut tensor: BoolTensor<Self>, dim1: usize, dim2: usize) -> BoolTensor<Self> {
-        tensor.strides.swap(dim1, dim2);
-        tensor.shape.dims.swap(dim1, dim2);
+        tensor.strides_mut().swap(dim1, dim2);
+        tensor.shape_mut().dims.swap(dim1, dim2);
 
         tensor
     }

--- a/crates/burn-cubecl/src/ops/int_ops.rs
+++ b/crates/burn-cubecl/src/ops/int_ops.rs
@@ -264,8 +264,8 @@ where
     }
 
     fn int_swap_dims(mut tensor: IntTensor<Self>, dim1: usize, dim2: usize) -> IntTensor<Self> {
-        tensor.strides.swap(dim1, dim2);
-        tensor.shape.dims.swap(dim1, dim2);
+        tensor.strides_mut().swap(dim1, dim2);
+        tensor.shape_mut().dims.swap(dim1, dim2);
 
         tensor
     }

--- a/crates/burn-cubecl/src/ops/qtensor.rs
+++ b/crates/burn-cubecl/src/ops/qtensor.rs
@@ -93,10 +93,13 @@ where
 
     async fn q_into_data(tensor: QuantizedTensor<Self>) -> TensorData {
         let tensor = kernel::into_contiguous(tensor);
-        let bytes = tensor.client.read_one_async(tensor.handle.binding()).await;
+        let bytes = tensor
+            .client
+            .read_one_async(tensor.handle.handle.clone().binding())
+            .await;
 
         // We use the same internal representation
-        TensorData::from_bytes(bytes, tensor.shape, tensor.dtype)
+        TensorData::from_bytes(bytes, tensor.shape().clone(), tensor.dtype)
     }
 
     fn q_swap_dims(

--- a/crates/burn-cubecl/src/ops/transaction.rs
+++ b/crates/burn-cubecl/src/ops/transaction.rs
@@ -34,7 +34,11 @@ where
                 client = Some(t.client.clone());
             }
 
-            kinds.push(Kind::Float(num_bindings, t.shape.into(), F::dtype()));
+            kinds.push(Kind::Float(
+                num_bindings,
+                t.handle.shape.clone(),
+                F::dtype(),
+            ));
             num_bindings += 1;
             bindings.push(t.handle.binding())
         });
@@ -43,7 +47,7 @@ where
                 client = Some(t.client.clone());
             }
 
-            kinds.push(Kind::Int(num_bindings, t.shape.into(), I::dtype()));
+            kinds.push(Kind::Int(num_bindings, t.handle.shape.clone(), I::dtype()));
             num_bindings += 1;
             bindings.push(t.handle.binding())
         });
@@ -52,7 +56,11 @@ where
                 client = Some(t.client.clone());
             }
 
-            kinds.push(Kind::Bool(num_bindings, t.shape.into(), BT::dtype()));
+            kinds.push(Kind::Bool(
+                num_bindings,
+                t.handle.shape.clone(),
+                BT::dtype(),
+            ));
             num_bindings += 1;
             bindings.push(t.handle.binding())
         });

--- a/crates/burn-cubecl/src/template/base.rs
+++ b/crates/burn-cubecl/src/template/base.rs
@@ -77,20 +77,20 @@ macro_rules! kernel_source {
 /// | (2 * D + 1)..(3 * D + 1) | lhs shape   |
 /// | (3 * D + 1)..(4 * D + 1) | rhs shape   |
 pub fn build_info<R: CubeRuntime, E: CubeElement>(tensors: &[&CubeTensor<R>]) -> Vec<u32> {
-    let ndims = tensors[0].shape.num_dims();
+    let ndims = tensors[0].shape().num_dims();
     let mut info: Vec<u32> = vec![0; tensors.len() * 2 * ndims + 1];
     info[0] = ndims as u32;
 
     let mut current = 1;
     for tensor in tensors.iter() {
         for d in 0..ndims {
-            info[current] = tensor.strides[d] as u32;
+            info[current] = tensor.strides()[d] as u32;
             current += 1;
         }
     }
     for tensor in tensors.iter() {
         for d in 0..ndims {
-            info[current] = tensor.shape.dims[d] as u32;
+            info[current] = tensor.shape().dims[d] as u32;
             current += 1;
         }
     }

--- a/crates/burn-tensor/src/tensor/quantization/bytes.rs
+++ b/crates/burn-tensor/src/tensor/quantization/bytes.rs
@@ -18,6 +18,7 @@ use super::{
 /// 2) Quantization parameters are appended to the tensor data.
 ///    As such, the last bytes always correspond to the scale parameter.
 ///    If the quantization scheme includes an offset (zero-point) parameter, it is next to last.
+#[derive(Debug)]
 pub struct QuantizedBytes {
     /// The quantized values and quantization parameters represented as bytes.
     pub bytes: Bytes,
@@ -108,6 +109,9 @@ impl QuantizedBytes {
         let (values, (qparams, num_params)) = self.split_values_off();
 
         let values = unpack_u32s_to_i8s(values, numel);
+        println!("values: {values:?}");
+        println!("qparams: {qparams:?}");
+        println!("num_params: {num_params:?}");
 
         // Quantization parameters are added at the end of the tensor data.
         // As such, the last bytes always correspond to the scale parameter(s).

--- a/crates/burn-tensor/src/tests/ops/all.rs
+++ b/crates/burn-tensor/src/tests/ops/all.rs
@@ -4,8 +4,7 @@ mod tests {
     use burn_tensor::{Tensor, TensorData};
 
     #[test]
-    fn test_all() {
-        // test float tensor
+    fn test_all_float() {
         let tensor = TestTensor::<2>::from([[0.0, 1.0, 0.0], [1.0, -1.0, 1.0]]);
         let data_actual = tensor.all().into_data();
         let data_expected = TensorData::from([false]);
@@ -15,8 +14,10 @@ mod tests {
         let data_actual = tensor.all().into_data();
         let data_expected = TensorData::from([true]);
         data_expected.assert_eq(&data_actual, false);
+    }
 
-        // test int tensor
+    #[test]
+    fn test_all_int() {
         let tensor = TestTensorInt::<2>::from([[0, 1, 0], [1, -1, 1]]);
         let data_actual = tensor.all().into_data();
         let data_expected = TensorData::from([false]);
@@ -26,8 +27,10 @@ mod tests {
         let data_actual = tensor.all().into_data();
         let data_expected = TensorData::from([true]);
         data_expected.assert_eq(&data_actual, false);
+    }
 
-        // test bool tensor
+    #[test]
+    fn test_all_bool() {
         let tensor = TestTensorBool::<2>::from([[false, true, false], [true, true, true]]);
         let data_actual = tensor.all().into_data();
         let data_expected = TensorData::from([false]);

--- a/crates/burn-vision/src/backends/cube/connected_components/hardware_accelerated.rs
+++ b/crates/burn-vision/src/backends/cube/connected_components/hardware_accelerated.rs
@@ -481,9 +481,9 @@ pub fn hardware_accelerated<R: CubeRuntime, F: FloatElement, I: IntElement, BT: 
         return Err("Requires plane size of at least 32".into());
     }
 
-    let [rows, cols] = img.shape.dims();
+    let [rows, cols] = img.shape().dims();
 
-    let labels = zeros_device::<R, I>(client.clone(), device.clone(), img.shape.clone());
+    let labels = zeros_device::<R, I>(client.clone(), device.clone(), img.shape().clone());
 
     // Assume 32 wide warp. Currently, larger warps are handled by just exiting everything past 32.
     // This isn't ideal but we require CUBE_DIM_X == warp_size, and we can't query the actual warp
@@ -498,8 +498,8 @@ pub fn hardware_accelerated<R: CubeRuntime, F: FloatElement, I: IntElement, BT: 
             &client,
             cube_count,
             cube_dim,
-            img.as_tensor_arg::<BT>(1),
-            labels.as_tensor_arg::<I>(1),
+            img.as_tensor_arg(1),
+            labels.as_tensor_arg(1),
             connectivity,
         )
     };
@@ -516,8 +516,8 @@ pub fn hardware_accelerated<R: CubeRuntime, F: FloatElement, I: IntElement, BT: 
             &client,
             cube_count,
             cube_dim_merge,
-            img.as_tensor_arg::<BT>(1),
-            labels.as_tensor_arg::<I>(1),
+            img.as_tensor_arg(1),
+            labels.as_tensor_arg(1),
             connectivity,
         )
     };
@@ -535,8 +535,8 @@ pub fn hardware_accelerated<R: CubeRuntime, F: FloatElement, I: IntElement, BT: 
                 &client,
                 cube_count,
                 cube_dim,
-                img.as_tensor_arg::<BT>(1),
-                labels.as_tensor_arg::<I>(1),
+                img.as_tensor_arg(1),
+                labels.as_tensor_arg(1),
             )
         };
     } else {
@@ -545,14 +545,14 @@ pub fn hardware_accelerated<R: CubeRuntime, F: FloatElement, I: IntElement, BT: 
                 &client,
                 cube_count,
                 cube_dim,
-                img.as_tensor_arg::<BT>(1),
-                labels.as_tensor_arg::<I>(1),
-                stats.area.as_tensor_arg::<I>(1),
-                stats.top.as_tensor_arg::<I>(1),
-                stats.left.as_tensor_arg::<I>(1),
-                stats.right.as_tensor_arg::<I>(1),
-                stats.bottom.as_tensor_arg::<I>(1),
-                stats.max_label.as_tensor_arg::<I>(1),
+                img.as_tensor_arg(1),
+                labels.as_tensor_arg(1),
+                stats.area.as_tensor_arg(1),
+                stats.top.as_tensor_arg(1),
+                stats.left.as_tensor_arg(1),
+                stats.right.as_tensor_arg(1),
+                stats.bottom.as_tensor_arg(1),
+                stats.max_label.as_tensor_arg(1),
                 stats_opt,
             )
         };
@@ -578,9 +578,9 @@ pub fn hardware_accelerated<R: CubeRuntime, F: FloatElement, I: IntElement, BT: 
                     &client,
                     cube_count,
                     cube_dim,
-                    labels.as_tensor_arg::<I>(1),
-                    relabel.as_tensor_arg::<I>(1),
-                    stats.max_label.as_tensor_arg::<I>(1),
+                    labels.as_tensor_arg(1),
+                    relabel.as_tensor_arg(1),
+                    stats.max_label.as_tensor_arg(1),
                 )
             };
 
@@ -591,17 +591,17 @@ pub fn hardware_accelerated<R: CubeRuntime, F: FloatElement, I: IntElement, BT: 
                     &client,
                     cube_count,
                     cube_dim,
-                    stats.area.copy().as_tensor_arg::<I>(1),
-                    stats.area.as_tensor_arg::<I>(1),
-                    stats.top.copy().as_tensor_arg::<I>(1),
-                    stats.top.as_tensor_arg::<I>(1),
-                    stats.left.copy().as_tensor_arg::<I>(1),
-                    stats.left.as_tensor_arg::<I>(1),
-                    stats.right.copy().as_tensor_arg::<I>(1),
-                    stats.right.as_tensor_arg::<I>(1),
-                    stats.bottom.copy().as_tensor_arg::<I>(1),
-                    stats.bottom.as_tensor_arg::<I>(1),
-                    relabel.as_tensor_arg::<I>(1),
+                    stats.area.copy().as_tensor_arg(1),
+                    stats.area.as_tensor_arg(1),
+                    stats.top.copy().as_tensor_arg(1),
+                    stats.top.as_tensor_arg(1),
+                    stats.left.copy().as_tensor_arg(1),
+                    stats.left.as_tensor_arg(1),
+                    stats.right.copy().as_tensor_arg(1),
+                    stats.right.as_tensor_arg(1),
+                    stats.bottom.copy().as_tensor_arg(1),
+                    stats.bottom.as_tensor_arg(1),
+                    relabel.as_tensor_arg(1),
                 )
             };
         }

--- a/crates/burn-vision/src/backends/cube/connected_components/mod.rs
+++ b/crates/burn-vision/src/backends/cube/connected_components/mod.rs
@@ -24,17 +24,16 @@ where
     I: IntElement,
     BT: BoolElement,
 {
-    let [height, width] = l.shape.dims();
+    let [height, width] = l.shape().dims();
     let shape = Shape::new([height * width]);
     let zeros = || zeros_device::<R, I>(l.client.clone(), l.device.clone(), shape.clone());
     let max = I::max_value();
     let max = || full_device::<R, I>(l.client.clone(), shape.clone(), l.device.clone(), max);
     let dummy = || {
-        CubeTensor::new_contiguous(
+        CubeTensor::new(
             l.client.clone(),
-            l.device.clone(),
-            shape.clone(),
             l.handle.clone(),
+            l.device.clone(),
             l.dtype,
         )
     };

--- a/examples/custom-cubecl-kernel/src/forward.rs
+++ b/examples/custom-cubecl-kernel/src/forward.rs
@@ -29,15 +29,15 @@ impl<R: CubeRuntime, F: FloatElement, I: IntElement, BT: BoolElement> Backend
         let bias = into_contiguous(bias);
 
         // Get the matmul relevant shapes.
-        let ndims = lhs.shape.num_dims();
-        let num_rows = lhs.shape.dims[ndims - 2];
-        let num_cols = rhs.shape.dims[ndims - 1];
+        let ndims = lhs.shape().num_dims();
+        let num_rows = lhs.shape().dims[ndims - 2];
+        let num_cols = rhs.shape().dims[ndims - 1];
 
         // Compute shape of output, while tracking number of batches.
         let mut num_batches = 1;
         let mut shape_out = vec![0; ndims];
         for i in shape_out.clone().into_iter().take(ndims - 2) {
-            shape_out[i] = usize::max(lhs.shape.dims[i], rhs.shape.dims[i]);
+            shape_out[i] = usize::max(lhs.shape().dims[i], rhs.shape().dims[i]);
             num_batches *= shape_out[i];
         }
         shape_out[ndims - 2] = num_rows;
@@ -70,10 +70,10 @@ impl<R: CubeRuntime, F: FloatElement, I: IntElement, BT: BoolElement> Backend
             &lhs.client,
             cube_count,
             cube_dim,
-            lhs.as_tensor_arg::<F>(1),
-            rhs.as_tensor_arg::<F>(1),
-            bias.as_tensor_arg::<F>(1),
-            output.as_tensor_arg::<F>(1),
+            lhs.as_tensor_arg(1),
+            rhs.as_tensor_arg(1),
+            bias.as_tensor_arg(1),
+            output.as_tensor_arg(1),
         );
 
         // Return the output tensor.

--- a/examples/custom-wgpu-kernel/src/forward.rs
+++ b/examples/custom-wgpu-kernel/src/forward.rs
@@ -61,15 +61,15 @@ impl<F: FloatElement, I: IntElement, BT: BoolElement> Backend
         let bias = into_contiguous(bias);
 
         // Get the matmul relevant shapes.
-        let ndims = lhs.shape.num_dims();
-        let num_rows = lhs.shape.dims[ndims - 2];
-        let num_cols = rhs.shape.dims[ndims - 1];
+        let ndims = lhs.shape().num_dims();
+        let num_rows = lhs.shape().dims[ndims - 2];
+        let num_cols = rhs.shape().dims[ndims - 1];
 
         // Compute shape of output, while tracking number of batches.
         let mut num_batches = 1;
         let mut shape_out = vec![0; ndims];
         for i in shape_out.clone().into_iter().take(ndims - 2) {
-            shape_out[i] = usize::max(lhs.shape.dims[i], rhs.shape.dims[i]);
+            shape_out[i] = usize::max(lhs.shape().dims[i], rhs.shape().dims[i]);
             num_batches *= shape_out[i];
         }
         shape_out[ndims - 2] = num_rows;
@@ -107,6 +107,7 @@ impl<F: FloatElement, I: IntElement, BT: BoolElement> Backend
         lhs.client.execute(
             Box::new(SourceKernel::new(kernel, cube_dim)),
             cube_count,
+            vec![],
             vec![
                 lhs.handle.binding(),
                 rhs.handle.binding(),


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ ] Confirmed that `run-checks all` script has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Working branch to test this cubecl PR https://github.com/tracel-ai/cubecl/pull/533

### Changes

Migrates `CubeTensor` to make use of the new `TensorHandle` primitive in cubecl, and fixes various bugs caused by kernels presuming contiguous layout without checking. Only cast kernels currently use the new strided allocator, to keep things slightly more confined. I'd like to port the rest of the burn kernels over time.

### Testing

_Describe how these changes have been tested._
