### PR TITLE
Add train end event

### DIFF
--- a/burn-book/src/basic-workflow/model.md
+++ b/burn-book/src/basic-workflow/model.md
@@ -221,6 +221,8 @@ impl ModelConfig {
 At a glance, you can view the model configuration by printing the model instance:
 
 ```rust , ignore
+mod model;
+
 use crate::model::ModelConfig;
 use burn::backend::Wgpu;
 

--- a/crates/burn-train/src/learner/train_val.rs
+++ b/crates/burn-train/src/learner/train_val.rs
@@ -1,5 +1,5 @@
 use crate::components::LearnerComponents;
-use crate::metric::processor::EventProcessor;
+use crate::metric::processor::{Event, EventProcessor};
 use crate::{Learner, TrainEpoch, ValidEpoch};
 use burn_core::data::dataloader::DataLoader;
 use burn_core::module::{AutodiffModule, Module};
@@ -199,13 +199,13 @@ impl<LC: LearnerComponents> Learner<LC> {
             }
         }
 
+        // Signal training end. For the TUI renderer, this handles the exit & return to main screen.
+        self.event_processor.process_train(Event::End);
+
         // Display learner summary
         if let Some(summary) = self.summary {
             match summary.init() {
                 Ok(summary) => {
-                    // Drop event processor (includes renderer) so the summary is displayed
-                    // when switching back to "main" screen
-                    core::mem::drop(self.event_processor);
                     println!("{}", summary.with_model(self.model.to_string()))
                 }
                 Err(err) => log::error!("Could not retrieve learner summary:\n{err}"),

--- a/crates/burn-train/src/metric/processor/base.rs
+++ b/crates/burn-train/src/metric/processor/base.rs
@@ -7,6 +7,8 @@ pub enum Event<T> {
     ProcessedItem(LearnerItem<T>),
     /// Signal the end of an epoch.
     EndEpoch(usize),
+    /// Signal the end of the process (e.g., training end).
+    End,
 }
 
 /// Items that are lazy are not ready to be processed by metrics.

--- a/crates/burn-train/src/metric/processor/full.rs
+++ b/crates/burn-train/src/metric/processor/full.rs
@@ -62,6 +62,9 @@ impl<T: ItemLazy, V: ItemLazy> EventProcessor for FullEventProcessor<T, V> {
                 self.store
                     .add_event_train(crate::metric::store::Event::EndEpoch(epoch));
             }
+            Event::End => {
+                self.renderer.on_train_end().ok();
+            }
         }
     }
 
@@ -97,6 +100,7 @@ impl<T: ItemLazy, V: ItemLazy> EventProcessor for FullEventProcessor<T, V> {
                 self.store
                     .add_event_valid(crate::metric::store::Event::EndEpoch(epoch));
             }
+            Event::End => {} // no-op for now
         }
     }
 }

--- a/crates/burn-train/src/metric/processor/minimal.rs
+++ b/crates/burn-train/src/metric/processor/minimal.rs
@@ -30,6 +30,7 @@ impl<T: ItemLazy, V: ItemLazy> EventProcessor for MinimalEventProcessor<T, V> {
                 self.store
                     .add_event_train(crate::metric::store::Event::EndEpoch(epoch));
             }
+            Event::End => {} // no-op for now
         }
     }
 
@@ -49,6 +50,7 @@ impl<T: ItemLazy, V: ItemLazy> EventProcessor for MinimalEventProcessor<T, V> {
                 self.store
                     .add_event_valid(crate::metric::store::Event::EndEpoch(epoch));
             }
+            Event::End => {} // no-op for now
         }
     }
 }

--- a/crates/burn-train/src/renderer/base.rs
+++ b/crates/burn-train/src/renderer/base.rs
@@ -31,6 +31,16 @@ pub trait MetricsRenderer: Send + Sync {
     ///
     /// * `item` - The validation progress.
     fn render_valid(&mut self, item: TrainingProgress);
+
+    /// Callback method invoked when training ends, whether it
+    /// completed successfully or was interrupted.
+    ///
+    /// # Returns
+    ///
+    /// A result indicating whether the end-of-training actions were successful.
+    fn on_train_end(&mut self) -> Result<(), Box<dyn core::error::Error>> {
+        Ok(())
+    }
 }
 
 /// The state of a metric.


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Fixes #2955

### Changes

Previously, we force dropped the event processor in order to reset the TUI renderer screen which didn't always work (see lniked issue).

A better (and cleaner) way to handle this is by adding an additional event type to signal/process the training end, at which point the `TuiMetricsRenderer` can be reset.

Other `Event::End` are currently ignore (no-op) for the renderers, but for custom renderers this can also be useful for different hooks.

### Testing

Repeatedly tested the example in the linked issue for 1 epoch.
