### PR TITLE
Fix burn-tch gpu check

### DIFF
--- a/crates/burn-tch/build.rs
+++ b/crates/burn-tch/build.rs
@@ -227,7 +227,7 @@ fn main() {
     }
     let check_file = PathBuf::from(out_dir).join("tch_gpu_check.rs");
     if gpu_found {
-        fs::write(check_file, "()").unwrap();
+        fs::write(check_file, "#[allow(clippy::no_effect)]\n()").unwrap();
     } else {
         let message = if !found_dir {
             r#"Could not find libtorch dir.


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.

### Related Issues/PRs

[Discord message](https://discord.com/channels/1038839012602941528/1091796857996451942/1355551847401918545)

### Changes

Allow no effect lint
