### PR TITLE
Adding inital image augmentation.rs module in burn-datasets

### DIFF
--- a/crates/burn-dataset/Cargo.toml
+++ b/crates/burn-dataset/Cargo.toml
@@ -33,6 +33,7 @@ dataframe = ["dep:polars"]
 burn-common = { path = "../burn-common", version = "0.17.0", optional = true, features = [
     "network",
 ] }
+burn-tensor = { path = "../burn-tensor", version = "0.17.0"}
 csv = { workspace = true }
 derive-new = { workspace = true }
 dirs = { workspace = true }
@@ -60,6 +61,8 @@ thiserror = { workspace = true }
 rayon = { workspace = true }
 rstest = { workspace = true }
 fake = { workspace = true }
+burn-tensor = { path = "../burn-tensor", version = "0.17.0" }
+burn-ndarray = { path = "../burn-ndarray", version = "0.17.0" }
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["strum", "strum_macros"]

--- a/crates/burn-dataset/src/vision/image_augmentation.rs
+++ b/crates/burn-dataset/src/vision/image_augmentation.rs
@@ -1,0 +1,351 @@
+use super::image_ops;
+use burn_tensor::{ElementConversion, Tensor, backend::Backend};
+use rand::{SeedableRng, rngs::StdRng};
+
+/// Image augmentation and preprocessing utilities.
+///
+/// `Augmentations` provides randomized image transformations commonly used to
+/// boost model performance through data augmentation.
+///
+/// # Supported Augmentations
+///
+/// - `random_photometric_distortion` — Adjusts brightness, contrast and hue with a set probability
+/// - `random_zoom_out` — Pads and resizes to simulate zooming out with a set probability.
+/// - `random_vertical_flip` — Flips images vertically with a set probability.
+///
+/// # Notes
+///
+/// - Augmentations are applied probabilistically and may vary on each call.
+/// - Aims to improve model robustness to lighting, scale, and spatial orientation.
+#[derive(Clone, Debug)]
+pub struct Augmentations<R>
+where
+    R: rand::Rng,
+{
+    rng: R,
+}
+
+/// Provides a default implementation for `Augmentations`.
+///
+/// This creates a ready-to-use `Augmentations` instance with standard settings.
+impl Default for Augmentations<StdRng> {
+    /// Creates a default `Augmentations` instance.
+    ///
+    /// This is the recommended method for most users to obtain a ready-to-use
+    /// augmentation with standard behavior.
+    ///
+    /// # Returns
+    ///
+    /// A new `Augmentations` instance with default settings.
+    fn default() -> Self {
+        Self {
+            rng: StdRng::from_os_rng(),
+        }
+    }
+}
+
+impl<R: rand::Rng> Augmentations<R> {
+    /// Creates a new instance of `Augmentations` with the given random number generator.
+    ///
+    /// # Arguments
+    ///
+    /// * `rng` – The random number generator to be used for augmentations.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `Augmentations` with the provided RNG.
+    pub fn new(rng: R) -> Self {
+        Self { rng }
+    }
+
+    /// Returns a boolean result based on a uniform random probability.
+    ///
+    /// This function generates a random boolean value, where the probability of returning
+    /// `true` is determined by `p`.
+    ///
+    /// # Arguments
+    ///
+    /// * `p` – The probability (between 0.0 and 1.0) that the function will return `true`.
+    ///
+    /// # Returns
+    ///
+    /// A boolean value: `true` with probability `p`.
+    ///
+    /// # Remarks
+    ///
+    /// - If `p` is 0.0, the function will always return `false`.
+    /// - If `p` is 1.0, the function will always return `true`.
+    /// - Values outside the range [0.0, 1.0] are clamped to this range.
+    fn should_apply(&mut self, p: f32) -> bool {
+        self.rng.random::<f32>() < p.clamp(0.0, 1.0)
+    }
+
+    /// Applies random photometric distortions to a 3-channel image tensor, inspired by the
+    /// data augmentation strategy used in SSD: Single Shot MultiBox Detector.
+    ///
+    /// Each transformation (brightness, contrast, hue) is applied independently
+    /// with probability `p`, using values randomly sampled from the specified ranges.
+    ///
+    /// # Arguments
+    ///
+    /// * `img_tnsr` – A 3D tensor representing the image, in shape `[3, H, W]` (channel-first format).
+    /// * `brightness` – A `(min, max)` tuple specifying the brightness adjustment range.
+    ///   The brightness factor is sampled uniformly from this range (`-1.0 ≤ min ≤ max ≤ 1.0`).
+    /// * `contrast` – A `(min, max)` tuple specifying the contrast adjustment range (as a percentage).
+    ///   The contrast factor is sampled uniformly from this range (`-1.0 ≤ min ≤ max ≤ 1.0`).
+    /// * `hue` – A `(min, max)` tuple specifying the hue rotation range in degrees
+    ///   (`-180.0 ≤ min ≤ max ≤ 180.0`).
+    /// * `p` – The probability (between 0.0 and 1.0) that each individual transformation is applied.
+    ///
+    /// # Returns
+    ///
+    /// A new image tensor of shape `[3, H, W]` with photometric distortions applied probabilistically.
+    /// If a transformation is not applied (based on probability `p`), the corresponding attribute remains unchanged.
+    pub fn random_photometric_distort<B: Backend>(
+        &mut self,
+        mut img_tnsr: Tensor<B, 3>,
+        brightness: (f32, f32),
+        contrast: (f32, f32),
+        hue: (f32, f32),
+        p: f32,
+    ) -> Tensor<B, 3> {
+        if self.should_apply(p) {
+            let r_bright = (self
+                .rng
+                .random_range(brightness.0.clamp(-1.0, 1.0)..brightness.1.clamp(-1.0, 1.0))
+                * image_ops::MAX_PIXEL_VAL) as i32;
+            img_tnsr = image_ops::brighten(img_tnsr, r_bright);
+        }
+
+        if self.should_apply(p) {
+            let r_contrast = self
+                .rng
+                .random_range(contrast.0.clamp(-1.0, 1.0)..contrast.1.clamp(-1.0, 1.0))
+                * 100.0;
+            img_tnsr = image_ops::contrast(img_tnsr, r_contrast);
+        }
+
+        if self.should_apply(p) {
+            let r_hue_rot = self
+                .rng
+                .random_range(hue.0.clamp(-1.0, 1.0)..hue.1.clamp(-1.0, 1.0) * 180.0);
+
+            img_tnsr = image_ops::hue_rotate(img_tnsr, r_hue_rot);
+        }
+
+        img_tnsr
+    }
+
+    /// Applies a "zoom out" transformation by randomly padding the image and adjusting bounding boxes, as described in
+    /// the SSD: Single Shot MultiBox Detector paper.
+    ///
+    /// This augmentation simulates zooming out by increasing the canvas size and filling
+    /// the surrounding space with a specified value. The new canvas size is randomly selected
+    /// within a given range, and the transformation is applied with a specified probability.
+    ///
+    /// Some parts inspired by:
+    /// https://pytorch.org/vision/stable/generated/torchvision.transforms.v2.RandomZoomOut.html
+    ///
+    /// # Arguments
+    ///
+    /// * `img_data` – A tuple containing:
+    ///     - A 3D tensor representing the image, in shape `[3, H, W]` (channel-first format).
+    ///     - An optional vector of bounding box tensors, each of shape `[4]` in `[x, y, w, h]` format.
+    ///       If provided, the bounding boxes are adjusted to match the new padded image dimensions.
+    /// * `fill` – The pixel value used to fill the padded areas (e.g., `0.0` for black).
+    /// * `side_range` – A `(min, max)` tuple specifying the range of scaling factors for the
+    ///   output canvas size relative to the original image.
+    /// * `p` – The probability (between 0.0 and 1.0) that the zoom-out transformation is applied.
+    ///
+    /// # Returns
+    ///
+    /// Returns a new tuple:
+    /// - The padded (zoomed-out) image tensor.
+    /// - The adjusted bounding box tensors (if provided), updated to match the new image size.
+    ///   If the operation is not applied (based on the probability), the original image and bounding boxes
+    ///   are returned unchanged.
+    pub fn random_zoom_out<B: Backend>(
+        &mut self,
+        img_data: (Tensor<B, 3>, Option<Vec<Tensor<B, 1>>>),
+        fill: u8,
+        side_range: (f32, f32),
+        p: f32,
+    ) -> (Tensor<B, 3>, Option<Vec<Tensor<B, 1>>>) {
+        if !self.should_apply(p) {
+            return img_data;
+        }
+
+        let (cur_img_tnsr, mut maybe_bb_tnsr_list) = img_data;
+        let [_ch, height, width] = cur_img_tnsr.dims();
+
+        if side_range.0 < 1.0 || side_range.0 > side_range.1 {
+            panic!("Invalid side range provided {:#?}.", side_range);
+        }
+
+        let r = side_range.0 + self.rng.random::<f32>() * (side_range.1 - side_range.0);
+
+        let canvas_width = (width as f32 * r) as usize;
+        let canvas_height = (height as f32 * r) as usize;
+
+        let r = (self.rng.random::<f32>(), self.rng.random::<f32>());
+
+        let left = ((canvas_width - width) as f32 * r.0) as usize;
+        let top = ((canvas_height - height) as f32 * r.1) as usize;
+        let right = canvas_width - (left + width);
+        let bottom = canvas_height - (top + height);
+
+        // Pad image
+        let new_img_tnsr = cur_img_tnsr.pad(
+            (left, right, top, bottom),
+            ElementConversion::elem::<f32>(fill as f32),
+        );
+
+        // Translate bounding box
+        if let Some(cur_bb_t_list) = maybe_bb_tnsr_list.as_mut() {
+            let device = new_img_tnsr.device();
+            let mut tmp_bb_tnsr_list = Vec::<Tensor<B, 1>>::new();
+            for bbox in cur_bb_t_list.iter() {
+                let trans = Tensor::<B, 1>::from_data([left as f32, top as f32, 0.0, 0.0], &device);
+                tmp_bb_tnsr_list.push(bbox.clone().add(trans));
+            }
+
+            maybe_bb_tnsr_list = Some(tmp_bb_tnsr_list);
+        }
+
+        (new_img_tnsr, maybe_bb_tnsr_list)
+    }
+
+    /// Flips a 3-channel image tensor of shape `[C, H, W]` and its associated bounding boxes vertically
+    /// with a given probability.
+    ///
+    /// This augmentation randomly flips the input image along the horizontal axis (top ↔ bottom) and
+    /// its associated bounding boxes with a probability `p`.
+    ///
+    /// # Arguments
+    ///
+    /// * `img_data` – A tuple containing:
+    ///     - A 3D tensor representing the image, in shape `[3, H, W]` (channel-first format).
+    ///     - An optional vector of bounding box tensors, each of shape `[4]` in `[x, y, w, h]` format,
+    ///       representing object locations in the image. If provided, the bounding boxes will also be flipped
+    ///       vertically to remain aligned with the transformed image.
+    /// * `p` – The probability (between 0.0 and 1.0) that the vertical flip will be applied.
+    ///
+    /// # Returns
+    ///
+    /// Returns a new tuple:
+    /// - The vertically flipped image tensor.
+    /// - The vertically flipped bounding box tensors (if provided), adjusted for the new vertical orientation,
+    ///   still in `[x, y, w, h]` format.
+    ///   If the operation is not applied (based on the probability), the original image and bounding boxes
+    ///   are returned unchanged.
+    pub fn random_vertical_flip<B: Backend>(
+        &mut self,
+        img_data: (Tensor<B, 3>, Option<Vec<Tensor<B, 1>>>),
+        p: f32,
+    ) -> (Tensor<B, 3>, Option<Vec<Tensor<B, 1>>>) {
+        if !self.should_apply(p) {
+            return img_data;
+        }
+        image_ops::vertical_flip(img_data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vision::BoundingBox;
+    use burn_ndarray::{NdArray, NdArrayDevice};
+    use rand::Rng;
+    use std::hash::{DefaultHasher, Hash, Hasher};
+
+    #[test]
+    fn test_seeded_random_number_generation() {
+        let mut mse = StdRng::seed_from_u64(3);
+        let mut test_vec = Vec::<i32>::new();
+        let expected_vec = vec![-1513825812, 408920382, -83330236, 1513922966, 612228279];
+
+        for _ in 0..5 {
+            test_vec.push(mse.random::<i32>());
+        }
+
+        assert_eq!(expected_vec, test_vec);
+    }
+
+    #[test]
+    fn random_zoom_test() {
+        let img = image_ops::create_test_image(32, 32, [1, 2, 3]);
+
+        let mut bb_list = Vec::<Tensor<NdArray<f32>, 1>>::new();
+        let device = NdArrayDevice::default();
+
+        let bb = BoundingBox {
+            coords: [3.0, 4.0, 2.0, 2.0],
+            label: 0,
+        };
+
+        bb_list.push(image_ops::bbox_as_tensor::<NdArray<f32>>(bb, &device));
+
+        let bb = BoundingBox {
+            coords: [1.0, 2.0, 3.0, 4.0],
+            label: 0,
+        };
+
+        bb_list.push(image_ops::bbox_as_tensor::<NdArray<f32>>(bb, &device));
+
+        let mut aug = Augmentations::new(StdRng::seed_from_u64(3));
+
+        let image_t = image_ops::rgb_img_as_tensor::<NdArray>(img, &device);
+
+        let (img_tensor, bb_tlist) =
+            aug.random_zoom_out::<NdArray>((image_t, Some(bb_list)), 0, (1.0, 4.0), 1.0);
+
+        let (img_tensor, bb_tlist) = aug.random_vertical_flip((img_tensor, bb_tlist), 1.0);
+
+        // Check image test result
+        let test_success_hash: u64 = 1697389267139162335;
+        let mut h = DefaultHasher::new();
+        img_tensor.into_data().as_bytes().hash(&mut h);
+        assert_eq!(test_success_hash, h.finish());
+
+        // Check bounding box translations
+        let bb_vec = bb_tlist.unwrap();
+
+        let eq_test_t = bb_vec[0].to_data();
+        let eq_test_t: Vec<i32> = eq_test_t
+            .as_slice::<f32>()
+            .unwrap()
+            .iter()
+            .map(|&x| x as i32)
+            .collect();
+
+        assert_eq!(eq_test_t.as_slice(), [11, 32, 2, 2]);
+
+        let eq_test_t = bb_vec[1].to_data();
+        let eq_test_t: Vec<i32> = eq_test_t
+            .as_slice::<f32>()
+            .unwrap()
+            .iter()
+            .map(|&x| x as i32)
+            .collect();
+
+        assert_eq!(eq_test_t.as_slice(), [9, 32, 3, 4]);
+    }
+
+    #[test]
+    fn random_photometeric_test() {
+        let img = image_ops::create_test_image(12, 12, [128, 128, 255]);
+        let test_success_hash: u64 = 13135064361691146484;
+        let device = NdArrayDevice::default();
+
+        let image_t = image_ops::rgb_img_as_tensor::<NdArray<f32>>(img, &device);
+        let mut aug = Augmentations::new(StdRng::seed_from_u64(3));
+
+        let image_t =
+            aug.random_photometric_distort(image_t, (0.0, 0.3), (-0.5, 0.5), (0.0, 1.0), 0.5);
+
+        // Test hash of image
+        let mut h = DefaultHasher::new();
+        image_t.to_data().as_bytes().hash(&mut h);
+        assert_eq!(test_success_hash, h.finish());
+    }
+}

--- a/crates/burn-dataset/src/vision/image_ops.rs
+++ b/crates/burn-dataset/src/vision/image_ops.rs
@@ -1,0 +1,311 @@
+use burn_tensor::{Tensor, TensorData, backend::Backend};
+use image::RgbImage;
+
+use super::BoundingBox;
+
+/// Maximum pixel value for a RGB8 pixel
+pub const MAX_PIXEL_VAL: f32 = 255.0;
+
+/// Vertically flips an image and optionally its associated bounding boxes.
+///
+/// # Type Parameters
+/// - `B`: The backend used by the tensor, implementing the `Backend` trait.
+///
+/// # Parameters
+/// - `img_data`: A tuple containing:
+///     - A 3D tensor representing the image, in shape `[3, H, W]` (channel-first format).
+///     - An `Option` containing a list of 1D tensors representing bounding boxes in `[x, y, w, h]` format,
+///       where `(x, y)` is the top-left corner of the box, and `w` and `h` are the width and height.
+///
+/// # Returns
+/// Returns a new tuple:
+/// - The vertically flipped image tensor.
+/// - The vertically flipped bounding box tensors (if provided), adjusted for the new vertical orientation,
+///   still in `[x, y, w, h]` format.
+pub fn vertical_flip<B: Backend>(
+    img_data: (Tensor<B, 3>, Option<Vec<Tensor<B, 1>>>),
+) -> (Tensor<B, 3>, Option<Vec<Tensor<B, 1>>>) {
+    let (mut img_tnsr, mut maybe_bbox_t_list) = img_data;
+    let [_ch, height, _width] = img_tnsr.dims();
+
+    // Flip image vertically
+    img_tnsr = img_tnsr.flip([1]);
+
+    // Flip bounding boxes vertically
+    if let Some(cur_bb_tnsr_lst) = maybe_bbox_t_list.as_mut() {
+        let device = img_tnsr.device();
+        let mut tmp_bb_tnsr_list = Vec::<Tensor<B, 1>>::new();
+        for bbox in cur_bb_tnsr_lst.iter() {
+            let mut trans = bbox.clone().into_data().to_vec::<f32>().unwrap();
+            trans[1] = height as f32 - trans[1] - trans[3];
+            tmp_bb_tnsr_list.push(Tensor::<B, 1>::from_data(
+                TensorData::new(trans, [4]),
+                &device,
+            ));
+        }
+
+        maybe_bbox_t_list = Some(tmp_bb_tnsr_list);
+    }
+
+    (img_tnsr, maybe_bbox_t_list)
+}
+
+/// Adjusts the contrast of an image tensor by a specified percentage.
+///
+/// # Type Parameters
+/// - `B`: The backend used by the tensor, implementing the `Backend` trait.
+///
+/// # Parameters
+/// - `tensor_img`: A 3D tensor representing the image in `[3, H, W]` format (channel-first).
+/// - `contrast`: A `f32` value representing the percentage of contrast adjustment:
+///     - `0.0` leaves the image unchanged.
+///     - Positive values increase contrast (e.g., `20.0` increases by 20%).
+///     - Negative values decrease contrast (e.g., `-20.0` decreases by 20%).
+///
+/// # Returns
+/// A new tensor representing the image with adjusted contrast.
+pub fn contrast<B: Backend>(img_tnsr: Tensor<B, 3>, contrast: f32) -> Tensor<B, 3> {
+    let percent = ((100.0 + contrast) / 100.0).powi(2);
+    img_tnsr
+        .div_scalar(MAX_PIXEL_VAL)
+        .sub_scalar(0.5)
+        .mul_scalar(percent)
+        .add_scalar(0.5)
+        .mul_scalar(MAX_PIXEL_VAL)
+        .clamp(0.0, MAX_PIXEL_VAL)
+}
+
+/// Rotates the hue of an RGB image tensor in RGB color space.
+///
+/// Applies a hue shift using a rotation matrix derived from the input angle.
+/// Operates directly in RGB space (no HSV conversion).
+///
+/// # Parameters
+/// - `tensor_img`: A 3D tensor representing the image in `[3, H, W]` format (channel-first).
+/// - `angle`: Hue rotation angle in degrees. Positive rotates clockwise, negative counter-clockwise.
+///
+/// # Returns
+/// A new tensor representing the image with adjusted hue.
+pub fn hue_rotate<B: Backend>(img_tnsr: Tensor<B, 3>, angle: f32) -> Tensor<B, 3> {
+    let cosv = angle.to_radians().cos();
+    let sinv = angle.to_radians().sin();
+
+    let coeffs: [f32; 9] = [
+        // Reds
+        0.213 + cosv * 0.787 - sinv * 0.213,
+        0.715 - cosv * 0.715 - sinv * 0.715,
+        0.072 - cosv * 0.072 + sinv * 0.928,
+        // Greens
+        0.213 - cosv * 0.213 + sinv * 0.143,
+        0.715 + cosv * 0.285 + sinv * 0.140,
+        0.072 - cosv * 0.072 - sinv * 0.283,
+        // Blues
+        0.213 - cosv * 0.213 - sinv * 0.787,
+        0.715 - cosv * 0.715 + sinv * 0.715,
+        0.072 + cosv * 0.928 + sinv * 0.072,
+    ];
+
+    let chunks = img_tnsr.split(1, 0);
+
+    let red = chunks[0]
+        .clone()
+        .mul_scalar(coeffs[0])
+        .add(chunks[1].clone().mul_scalar(coeffs[1]))
+        .add(chunks[2].clone().mul_scalar(coeffs[2]));
+
+    let green = chunks[0]
+        .clone()
+        .mul_scalar(coeffs[3])
+        .add(chunks[1].clone().mul_scalar(coeffs[4]))
+        .add(chunks[2].clone().mul_scalar(coeffs[5]));
+
+    let blue = chunks[0]
+        .clone()
+        .mul_scalar(coeffs[6])
+        .add(chunks[1].clone().mul_scalar(coeffs[7]))
+        .add(chunks[2].clone().mul_scalar(coeffs[8]));
+
+    Tensor::cat(vec![red, green, blue], 0).clamp(0.0, MAX_PIXEL_VAL)
+}
+
+/// Brightens an RGB image tensor by adding a scalar value to all pixels.
+///
+/// Increases the brightness of the image by adding the specified `value` to each pixel.
+///
+/// # Parameters
+/// - `tensor_img`: A 3D tensor representing the image in `[3, H, W]` format (channel-first).
+/// - `value`: The brightness adjustment value. Positive values brighten, negative values darken.
+///
+/// /// # Returns
+/// A new tensor representing the image with adjusted brigthness.
+pub fn brighten<B: Backend>(img_tnsr: Tensor<B, 3>, value: i32) -> Tensor<B, 3> {
+    img_tnsr.add_scalar(value as f32).clamp(0.0, MAX_PIXEL_VAL)
+}
+
+/// Converts an RGB image to a tensor.
+///
+/// Takes an `RgbImage` and converts it into a `[3, H, W]` tensor, where the channels
+/// correspond to Red, Green, and Blue, respectively.
+///
+/// # Parameters
+/// - `rgb_image`: The input RGB image to be converted.
+///
+/// # Returns
+/// A `[3, H, W]` tensor representing the RGB image.
+pub fn rgb_img_as_tensor<B: Backend>(rgb_img: image::RgbImage, device: &B::Device) -> Tensor<B, 3> {
+    let width = rgb_img.width() as usize;
+    let height = rgb_img.height() as usize;
+    let img_vec = rgb_img.into_raw().iter().map(|&p| p as f32).collect();
+
+    // [H, W, C] -> [C, H, W]
+    Tensor::<B, 3>::from_data(
+        TensorData::new(img_vec, [height, width, 3]).convert::<B::FloatElem>(),
+        device,
+    )
+    .permute([2, 0, 1])
+}
+
+/// Converts a bounding box into a tensor.
+///
+/// Takes a `BoundingBox` and converts it into a 1D tensor.
+///
+/// # Parameters
+/// - `bbox`: The bounding box to be converted.
+///
+/// # Returns
+/// An `Option` containing the `[x, y, w, h]` tensor representing the bounding box,
+/// or `None` if the bounding box is invalid.
+pub fn bbox_as_tensor<B: Backend>(bbox: BoundingBox, device: &B::Device) -> Tensor<B, 1> {
+    Tensor::<B, 1>::from_data(bbox.coords, device)
+}
+
+/// Creates an RGB test image with a specified pattern.
+///
+/// Generates a new image of the given width and height, filling it with the specified
+/// RGB pattern.
+///
+/// # Arguments
+///
+/// * `width` – The width of the image in pixels.
+/// * `height` – The height of the image in pixels.
+/// * `pattern` – A 3-element array representing the RGB pattern to fill the image with.
+///
+/// # Returns
+///
+/// An `RgbImage` with the specified width, height, and pattern applied to all pixels.
+pub fn create_test_image(width: u32, height: u32, pattern: [u8; 3]) -> RgbImage {
+    let mut img = RgbImage::new(width, height);
+    let img_pattern: image::Rgb<u8> = image::Rgb(pattern);
+
+    for px in img.pixels_mut() {
+        *px = img_pattern;
+    }
+
+    img
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vision::BoundingBox;
+    use burn_ndarray::{NdArray, NdArrayDevice};
+    use std::hash::{DefaultHasher, Hash, Hasher};
+
+    #[test]
+    fn vertical_flip_test() {
+        let img = create_test_image(12, 12, [127, 128, 255]);
+        let mut bbox_tnsr_list = Vec::<Tensor<NdArray<f32>, 1>>::new();
+
+        let bb = BoundingBox {
+            coords: [1.0, 1.0, 6.0, 6.0],
+            label: 0,
+        };
+        let device = NdArrayDevice::default();
+        bbox_tnsr_list.push(bbox_as_tensor::<NdArray<f32>>(bb, &device));
+
+        let bb = BoundingBox {
+            coords: [1.0, 2.0, 3.0, 4.0],
+            label: 1,
+        };
+
+        bbox_tnsr_list.push(bbox_as_tensor::<NdArray<f32>>(bb, &device));
+
+        let img_tnsr = rgb_img_as_tensor::<NdArray<f32>>(img, &device);
+
+        let (img_tnsr, bbox_tnsr_list) = vertical_flip((img_tnsr, Some(bbox_tnsr_list)));
+
+        // Test hash of image
+        let test_success_hash: u64 = 10732386221966926898;
+        let mut h = DefaultHasher::new();
+        img_tnsr.to_data().as_bytes().hash(&mut h);
+        assert_eq!(test_success_hash, h.finish());
+
+        // Check bounding box translations
+        let bb_vec = bbox_tnsr_list.unwrap();
+
+        let eq_test_t = bb_vec[0].to_data();
+        let eq_test_t: Vec<i32> = eq_test_t
+            .as_slice::<f32>()
+            .unwrap()
+            .iter()
+            .map(|&x| x as i32)
+            .collect();
+
+        assert_eq!(eq_test_t.as_slice(), [1, 5, 6, 6]);
+
+        let eq_test_t = bb_vec[1].to_data();
+        let eq_test_t: Vec<i32> = eq_test_t
+            .as_slice::<f32>()
+            .unwrap()
+            .iter()
+            .map(|&x| x as i32)
+            .collect();
+
+        assert_eq!(eq_test_t.as_slice(), [1, 6, 3, 4]);
+    }
+
+    #[test]
+    fn brighten_test() {
+        let img = create_test_image(12, 12, [127, 128, 255]);
+        let device = NdArrayDevice::default();
+        let img_tnsr = rgb_img_as_tensor::<NdArray<f32>>(img, &device);
+
+        let img_tnsr = brighten::<NdArray>(img_tnsr, 4);
+
+        // Test hash of image
+        let test_success_hash: u64 = 10243697479348201339;
+        let mut h = DefaultHasher::new();
+        img_tnsr.to_data().as_bytes().hash(&mut h);
+        assert_eq!(test_success_hash, h.finish());
+    }
+
+    #[test]
+    fn contrast_test() {
+        let img = create_test_image(12, 12, [127, 128, 100]);
+        let device = NdArrayDevice::default();
+        let img_tnsr = rgb_img_as_tensor::<NdArray<f32>>(img, &device);
+
+        let img_tnsr = contrast::<NdArray>(img_tnsr, 70.0);
+
+        // Test hash of image
+        let test_success_hash: u64 = 15073504107166547824;
+        let mut h = DefaultHasher::new();
+        img_tnsr.to_data().as_bytes().hash(&mut h);
+        assert_eq!(test_success_hash, h.finish());
+    }
+
+    #[test]
+    fn hue_rotate_test() {
+        let img = create_test_image(12, 12, [127, 128, 255]);
+        let device = NdArrayDevice::default();
+        let img_tnsr = rgb_img_as_tensor::<NdArray<f32>>(img, &device);
+
+        let img_tnsr = hue_rotate::<NdArray>(img_tnsr, 180.0);
+
+        // Test hash of image
+        let test_success_hash: u64 = 13006992659458449744;
+        let mut h = DefaultHasher::new();
+        img_tnsr.to_data().as_bytes().hash(&mut h);
+        assert_eq!(test_success_hash, h.finish());
+    }
+}

--- a/crates/burn-dataset/src/vision/mod.rs
+++ b/crates/burn-dataset/src/vision/mod.rs
@@ -1,5 +1,9 @@
+mod image_augmentation;
 mod image_folder;
+mod image_ops;
 mod mnist;
 
+pub use image_augmentation::*;
 pub use image_folder::*;
+pub use image_ops::*;
 pub use mnist::*;


### PR DESCRIPTION
Image augmentation and preprocessing utilities.

`Augmentations` provides randomized image transformations commonly used to
boost model performance through data augmentation.

# Supported Augmentations

- `random_photometric_distortion` — Adjusts brightness, contrast and hue with a set probability
- `random_zoom_out` — Pads and resizes to simulate zooming out with a set probability.
- `random_vertical_flip` — Flips images vertically with a set probability.

# Notes

- Augmentations are applied probabilistically and may vary on each call.
- Designed to be composable and easily integrated into preprocessing pipelines.
- Aims to improve model robustness to lighting, scale, and spatial orientation.

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [X] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

https://github.com/tracel-ai/burn/issues/207

https://github.com/tracel-ai/burn/issues/2361

https://github.com/tracel-ai/burn/pull/2426

### Changes

This adds an initial module for image augmentation using a the image-rs library and the tensor backend where it was easily implementable. 

### Testing

Tested with actual images, also tested using unit tests.
