### PR TITLE
Fork dataloader to device in learner

### DIFF
--- a/crates/burn-core/src/data/dataloader/base.rs
+++ b/crates/burn-core/src/data/dataloader/base.rs
@@ -2,6 +2,7 @@ use burn_tensor::backend::Backend;
 
 pub use crate::data::dataset::{Dataset, DatasetIterator};
 use core::iter::Iterator;
+use std::sync::Arc;
 
 /// A progress struct that can be used to track the progress of a data loader.
 #[derive(new, Clone, Debug)]
@@ -28,8 +29,8 @@ pub trait DataLoader<B: Backend, O>: Send {
     /// corresponding to the items_total of the progress returned by the iterator.
     fn num_items(&self) -> usize;
 
-    /// Forks the data loader to the given device, ensuring the batches are assigned to the correct device.
-    fn forked(&self, device: &B::Device) -> Box<dyn DataLoader<B, O>>;
+    /// Move the data loader to the given device, ensuring the batches are assigned to the correct device.
+    fn to_device(&self, device: &B::Device) -> Arc<dyn DataLoader<B, O>>;
 
     /// Returns a new data loader containing a subset of the data.
     ///
@@ -44,5 +45,5 @@ pub trait DataLoader<B: Backend, O>: Send {
     /// # Returns
     ///
     /// A boxed [`DataLoader`] instance containing only the specified range.
-    fn slice(&self, start: usize, end: usize) -> Box<dyn DataLoader<B, O>>;
+    fn slice(&self, start: usize, end: usize) -> Arc<dyn DataLoader<B, O>>;
 }

--- a/crates/burn-core/src/data/dataloader/base.rs
+++ b/crates/burn-core/src/data/dataloader/base.rs
@@ -28,8 +28,8 @@ pub trait DataLoader<B: Backend, O>: Send {
     /// corresponding to the items_total of the progress returned by the iterator.
     fn num_items(&self) -> usize;
 
-    /// Sets the device for the data loader, ensuring the batches are assigned to the correct device.
-    fn set_device(&mut self, device: B::Device);
+    /// Forks the data loader to the given device, ensuring the batches are assigned to the correct device.
+    fn forked(&self, device: &B::Device) -> Box<dyn DataLoader<B, O>>;
 
     /// Returns a new data loader containing a subset of the data.
     ///

--- a/crates/burn-core/src/data/dataloader/batch.rs
+++ b/crates/burn-core/src/data/dataloader/batch.rs
@@ -102,8 +102,18 @@ where
         self.dataset.len()
     }
 
-    fn set_device(&mut self, device: B::Device) {
-        self.device = device;
+    fn forked(&self, device: &B::Device) -> Box<dyn DataLoader<B, O>> {
+        let rng = self.rng.as_ref().map(|rng| {
+            let rng = rng.lock();
+            rng.clone()
+        });
+        Box::new(Self::new(
+            self.strategy.clone_dyn(),
+            self.dataset.clone(),
+            self.batcher.clone_dyn(),
+            device.clone(),
+            rng,
+        ))
     }
 
     fn slice(&self, start: usize, end: usize) -> Box<dyn DataLoader<B, O>> {

--- a/crates/burn-core/src/data/dataloader/batcher.rs
+++ b/crates/burn-core/src/data/dataloader/batcher.rs
@@ -4,7 +4,7 @@ use burn_tensor::backend::Backend;
 use crate::TestBackend;
 
 /// A trait for batching items of type `I` into items of type `O`.
-pub trait Batcher<B: Backend, I, O>: Send {
+pub trait Batcher<B: Backend, I, O>: Send + Sync {
     /// Batches the given items on the specified device.
     ///
     /// # Arguments
@@ -16,24 +16,6 @@ pub trait Batcher<B: Backend, I, O>: Send {
     ///
     /// The batched items.
     fn batch(&self, items: Vec<I>, device: &B::Device) -> O;
-}
-
-/// A super trait for [batcher](Batcher) that allows it to be cloned dynamically.
-///
-/// Any batcher that implements [Clone] should also implement this automatically.
-pub trait DynBatcher<B: Backend, I, O>: Send + Batcher<B, I, O> {
-    /// Clone the batcher and returns a new one.
-    fn clone_dyn(&self) -> Box<dyn DynBatcher<B, I, O>>;
-}
-
-impl<Bt, B, I, O> DynBatcher<B, I, O> for Bt
-where
-    Bt: Batcher<B, I, O> + Clone + 'static,
-    B: Backend,
-{
-    fn clone_dyn(&self) -> Box<dyn DynBatcher<B, I, O>> {
-        Box::new(self.clone())
-    }
 }
 
 /// Test batcher

--- a/crates/burn-core/src/data/dataloader/builder.rs
+++ b/crates/burn-core/src/data/dataloader/builder.rs
@@ -98,7 +98,7 @@ where
     /// # Returns
     ///
     /// The data loader builder.
-    pub fn set_device<D>(mut self, device: B::Device) -> Self {
+    pub fn set_device(mut self, device: B::Device) -> Self {
         self.device = Some(device);
         self
     }
@@ -225,10 +225,8 @@ mod tests {
         let (device1, device2) = (burn_cuda::CudaDevice::new(0), burn_cuda::CudaDevice::new(1));
 
         assert_eq!(dataloader.num_items(), 11);
-        let mut dataloader_1 = dataloader.slice(0, 5);
-        dataloader_1.set_device(device1);
-        let mut dataloader_2 = dataloader.slice(5, 11);
-        dataloader_2.set_device(device2);
+        let dataloader_1 = dataloader.slice(0, 5).forked(&device1);
+        let dataloader_2 = dataloader.slice(5, 11).forked(&device2);
 
         assert_eq!(dataloader_1.num_items(), 5);
         assert_eq!(dataloader_2.num_items(), 6);

--- a/crates/burn-core/src/data/dataloader/multithread.rs
+++ b/crates/burn-core/src/data/dataloader/multithread.rs
@@ -166,8 +166,15 @@ where
         self.dataset.len()
     }
 
-    fn set_device(&mut self, device: B::Device) {
-        self.device = device;
+    fn forked(&self, device: &B::Device) -> Box<dyn DataLoader<B, O>> {
+        Box::new(Self::new(
+            self.strategy.clone_dyn(),
+            self.dataset.clone(),
+            self.batcher.clone_dyn(),
+            self.num_threads,
+            device.clone(),
+            self.rng.clone(),
+        ))
     }
 
     fn slice(&self, start: usize, end: usize) -> Box<dyn DataLoader<B, O>> {

--- a/crates/burn-core/src/data/dataloader/split.rs
+++ b/crates/burn-core/src/data/dataloader/split.rs
@@ -22,7 +22,7 @@ pub fn split_dataloader<B: Backend, O>(
             } else {
                 start + step
             };
-            let dataloader = dataloader.slice(start, end).forked(&device);
+            let dataloader = dataloader.slice(start, end).forked(device);
             dataloaders.push(Arc::from(dataloader));
             start = end;
         }

--- a/crates/burn-core/src/data/dataloader/split.rs
+++ b/crates/burn-core/src/data/dataloader/split.rs
@@ -22,8 +22,8 @@ pub fn split_dataloader<B: Backend, O>(
             } else {
                 start + step
             };
-            let dataloader = dataloader.slice(start, end).forked(device);
-            dataloaders.push(Arc::from(dataloader));
+            let dataloader = dataloader.slice(start, end).to_device(device);
+            dataloaders.push(dataloader);
             start = end;
         }
         dataloaders
@@ -56,7 +56,7 @@ mod tests {
             }
         }
 
-        let batcher = Box::new(TestBatcher::new());
+        let batcher = Arc::new(TestBatcher::new());
         let dataset = Arc::new(FakeDataset::<String>::new(11));
         let dataloader = Arc::new(BatchDataLoader::new(
             Box::new(FixBatchStrategy::new(5)),

--- a/crates/burn-core/src/data/dataloader/split.rs
+++ b/crates/burn-core/src/data/dataloader/split.rs
@@ -22,8 +22,7 @@ pub fn split_dataloader<B: Backend, O>(
             } else {
                 start + step
             };
-            let mut dataloader = dataloader.slice(start, end);
-            dataloader.set_device(device.clone());
+            let dataloader = dataloader.slice(start, end).forked(&device);
             dataloaders.push(Arc::from(dataloader));
             start = end;
         }

--- a/crates/burn-cubecl/src/tensor/base.rs
+++ b/crates/burn-cubecl/src/tensor/base.rs
@@ -44,22 +44,22 @@ impl<R: CubeRuntime> cubecl::tune::AutotuneOutput for CubeTensor<R> {
             DType::F64 => {
                 let expected = into_data_sync::<R, f64>(self.clone());
                 let actual = into_data_sync::<R, f64>(other);
-                expected.assert_approx_eq::<f64>(&actual, Tolerance::relative(0.01));
+                expected.assert_approx_eq::<f64>(&actual, Tolerance::rel_abs(1e-2, 1e-3));
             }
             DType::F32 => {
                 let expected = into_data_sync::<R, f32>(self.clone());
                 let actual = into_data_sync::<R, f32>(other);
-                expected.assert_approx_eq::<f32>(&actual, Tolerance::relative(0.01));
+                expected.assert_approx_eq::<f32>(&actual, Tolerance::rel_abs(1e-2, 1e-3));
             }
             DType::F16 => {
                 let expected = into_data_sync::<R, half::f16>(self.clone());
                 let actual = into_data_sync::<R, half::f16>(other);
-                expected.assert_approx_eq::<half::f16>(&actual, Tolerance::relative(0.01));
+                expected.assert_approx_eq::<half::f16>(&actual, Tolerance::rel_abs(1e-2, 2e-3));
             }
             DType::BF16 => {
                 let expected = into_data_sync::<R, half::bf16>(self.clone());
                 let actual = into_data_sync::<R, half::bf16>(other);
-                expected.assert_approx_eq::<half::bf16>(&actual, Tolerance::relative(0.01));
+                expected.assert_approx_eq::<half::bf16>(&actual, Tolerance::rel_abs(1e-2, 1e-3));
             }
             DType::I64 => {
                 let expected = into_data_sync::<R, i64>(self.clone());

--- a/crates/burn-train/src/learner/train_val.rs
+++ b/crates/burn-train/src/learner/train_val.rs
@@ -127,8 +127,8 @@ impl<LC: LearnerComponents> Learner<LC> {
         // The reference model is always on the first device provided.
         if let Some(device) = self.devices.first() {
             self.model = self.model.fork(device);
-            dataloader_train = Arc::from(dataloader_train.forked(device));
-            dataloader_valid = Arc::from(dataloader_valid.forked(device));
+            dataloader_train = dataloader_train.to_device(device);
+            dataloader_valid = dataloader_valid.to_device(device);
         }
 
         let starting_epoch = match self.checkpoint {

--- a/crates/burn-train/src/learner/train_val.rs
+++ b/crates/burn-train/src/learner/train_val.rs
@@ -111,8 +111,8 @@ impl<LC: LearnerComponents> Learner<LC> {
     /// The fitted model.
     pub fn fit<InputTrain, InputValid, OutputTrain, OutputValid>(
         mut self,
-        dataloader_train: Arc<dyn DataLoader<TrainBackend<LC>, InputTrain>>,
-        dataloader_valid: Arc<dyn DataLoader<ValidBackend<LC>, InputValid>>,
+        mut dataloader_train: Arc<dyn DataLoader<TrainBackend<LC>, InputTrain>>,
+        mut dataloader_valid: Arc<dyn DataLoader<ValidBackend<LC>, InputValid>>,
     ) -> LC::Model
     where
         InputTrain: Send + 'static,
@@ -127,6 +127,8 @@ impl<LC: LearnerComponents> Learner<LC> {
         // The reference model is always on the first device provided.
         if let Some(device) = self.devices.first() {
             self.model = self.model.fork(device);
+            dataloader_train = Arc::from(dataloader_train.forked(device));
+            dataloader_valid = Arc::from(dataloader_valid.forked(device));
         }
 
         let starting_epoch = match self.checkpoint {


### PR DESCRIPTION
- Rename `set_device` -> `to_device` in data loader trait
- Use `Arc` instead of `Box` as much as possible (+ remove `DynBatcher` and need for its `clone_dyn()`)
- Automatically move data loader to learner device in `fit(...)`
