### PR TITLE
Remove affine

### DIFF
--- a/burn-book/src/quantization.md
+++ b/burn-book/src/quantization.md
@@ -119,20 +119,11 @@ Burn currently supports the following `QuantizationScheme` variants.
 | Variant                        | Description                                                                                                                                                              |
 | :----------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `PerTensor(mode, type)`        | Applies a single set of quantization parameters to the entire tensor. The `mode` defines how values are transformed, and `type` represents the target quantization type. |
-| `PerBlock(mode, type, layout)` | Applies quantization parameters to individual blocks within the tensor. The `layout` defines how the tensor is partitioned.                                              |
 
 #### Quantization Mode
 
 | Mode        | Description                                                          |
 | ----------- | -------------------------------------------------------------------- |
-| `Affine`    | Maps values using an affine transformation with a zero point offset. |
 | `Symmetric` | Maps values using a scale factor for a range centered around zero.   |
 
 ---
-
-#### Block Layout
-
-| Layout             | Description                                              |
-| ------------------ | -------------------------------------------------------- |
-| `Flat(block_size)` | Divides the tensor into linear 1D blocks of fixed size.  |
-| `Grid(m, n)`       | Divides the tensor into 2D blocks of `m` x `n` elements. |

--- a/crates/burn-core/src/nn/transformer/decoder.rs
+++ b/crates/burn-core/src/nn/transformer/decoder.rs
@@ -523,7 +523,7 @@ mod tests {
         // Should produce the same tokens.
         output_1
             .into_data()
-            .assert_approx_eq::<FT>(&output_2.into_data(), Tolerance::rel_abs(1e-4, 1e-4));
+            .assert_approx_eq::<FT>(&output_2.into_data(), Tolerance::rel_abs(1e-3, 1e-4));
     }
 
     #[test]

--- a/crates/burn-cubecl/src/kernel/quantization/dequantize.rs
+++ b/crates/burn-cubecl/src/kernel/quantization/dequantize.rs
@@ -1,19 +1,11 @@
 use crate::tensor::CubeTensor;
 use crate::{CubeElement, CubeRuntime};
 use burn_tensor::DType;
-use burn_tensor::quantization::{
-    BlockLayout, QuantizationMode, QuantizationScheme, QuantizationType,
-};
+use burn_tensor::quantization::{QuantizationMode, QuantizationScheme, QuantizationType};
 use cubecl::calculate_cube_count_elemwise;
 use cubecl::prelude::*;
 
 use super::{QParams, QTensor};
-
-#[cube]
-fn dequantize_affine_int8<F: Float>(value: Line<i32>, scale: f32, offset: i32) -> Line<F> {
-    // x = scale * (x_q - offset)
-    Line::cast_from(scale) * Line::cast_from(value - Line::cast_from(offset))
-}
 
 #[cube]
 fn dequantize_symmetric_int8<F: Float>(value: Line<i32>, scale: f32) -> Line<F> {
@@ -44,37 +36,6 @@ fn unpack_i8s(value: u32) -> Line<i32> {
 }
 
 #[cube(launch_unchecked)]
-fn dequantize_per_tensor_affine_int8_kernel(
-    input: &QTensor,
-    output: &mut Tensor<Line<f32>>,
-    #[comptime] scheme: QuantizationScheme,
-) {
-    // Last two positions contain the qparams
-    if ABSOLUTE_POS >= input.len() - 2 {
-        terminate!();
-    }
-
-    let qparams = QParams::new(scheme, 0u32);
-    let (scale, offset) = qparams.values(input, ABSOLUTE_POS);
-
-    let value = input[ABSOLUTE_POS];
-
-    // Input line size is fixed to 1
-    if comptime!(output.line_size() == 4) {
-        output[ABSOLUTE_POS] = dequantize_affine_int8(unpack_i8s(value[0]), scale, offset);
-    } else {
-        // For very small inputs where number of elements < 4, the output line size is 1
-        let out = dequantize_affine_int8::<f32>(unpack_i8s(value[0]), scale, offset);
-
-        #[unroll]
-        for j in 0..out.size() {
-            output[ABSOLUTE_POS * out.size() + j] = Line::cast_from(out[j]);
-        }
-    }
-}
-
-// Would have wrapped symmetric with the same affine kernel but cube doesn't support Option<Tensor> for offset.
-#[cube(launch_unchecked)]
 fn dequantize_per_tensor_symmetric_int8_kernel(
     input: &QTensor,
     output: &mut Tensor<Line<f32>>,
@@ -85,8 +46,8 @@ fn dequantize_per_tensor_symmetric_int8_kernel(
         terminate!();
     }
 
-    let qparams = QParams::new(scheme, 0u32);
-    let (scale, _) = qparams.values(input, ABSOLUTE_POS);
+    let qparams = QParams::new(scheme);
+    let (scale, _) = qparams.values(input);
 
     let value = input[ABSOLUTE_POS];
 
@@ -96,68 +57,6 @@ fn dequantize_per_tensor_symmetric_int8_kernel(
     } else {
         // For very small inputs where number of elements < 4, the output line size is 1
         let out = dequantize_symmetric_int8::<f32>(unpack_i8s(value[0]), scale);
-
-        #[unroll]
-        for j in 0..out.size() {
-            output[ABSOLUTE_POS * out.size() + j] = Line::cast_from(out[j]);
-        }
-    }
-}
-
-#[cube(launch_unchecked)]
-fn dequantize_per_block_symmetric_int8_kernel(
-    input: &QTensor,
-    output: &mut Tensor<Line<f32>>,
-    #[comptime] scheme: QuantizationScheme,
-    #[comptime] num_blocks: u32,
-) {
-    // Last num_blocks positions contains the qparams
-    if ABSOLUTE_POS >= input.len() - num_blocks {
-        terminate!();
-    }
-
-    let qparams = QParams::new(scheme, num_blocks);
-    let (scale, _) = qparams.values(input, ABSOLUTE_POS);
-
-    let value = input[ABSOLUTE_POS];
-
-    // Input line size is fixed to 1
-    if comptime!(output.line_size() == 4) {
-        output[ABSOLUTE_POS] = dequantize_symmetric_int8(unpack_i8s(value[0]), scale);
-    } else {
-        // For very small inputs where number of elements < 4, the output line size is 1
-        let out = dequantize_symmetric_int8::<f32>(unpack_i8s(value[0]), scale);
-
-        #[unroll]
-        for j in 0..out.size() {
-            output[ABSOLUTE_POS * out.size() + j] = Line::cast_from(out[j]);
-        }
-    }
-}
-
-#[cube(launch_unchecked)]
-fn dequantize_per_block_affine_int8_kernel(
-    input: &QTensor,
-    output: &mut Tensor<Line<f32>>,
-    #[comptime] scheme: QuantizationScheme,
-    #[comptime] num_blocks: u32,
-) {
-    // Last 2 * num_blocks positions contain the qparams
-    if ABSOLUTE_POS >= input.len() - 2 * num_blocks {
-        terminate!();
-    }
-
-    let qparams = QParams::new(scheme, num_blocks);
-    let (scale, offset) = qparams.values(input, ABSOLUTE_POS);
-
-    let value = input[ABSOLUTE_POS];
-
-    // Input line size is fixed to 1
-    if comptime!(output.line_size() == 4) {
-        output[ABSOLUTE_POS] = dequantize_affine_int8(unpack_i8s(value[0]), scale, offset);
-    } else {
-        // For very small inputs where number of elements < 4, the output line size is 1
-        let out = dequantize_affine_int8::<f32>(unpack_i8s(value[0]), scale, offset);
 
         #[unroll]
         for j in 0..out.size() {
@@ -194,18 +93,6 @@ where
 
     if let DType::QFloat(scheme) = tensor.dtype {
         match scheme {
-            QuantizationScheme::PerTensor(QuantizationMode::Affine, QuantizationType::QInt8) => {
-                unsafe {
-                    dequantize_per_tensor_affine_int8_kernel::launch_unchecked::<R>(
-                        &client,
-                        cube_count,
-                        cube_dim,
-                        tensor.as_array_arg::<u32>(line_size_in),
-                        output.as_tensor_arg::<F>(line_size_out),
-                        scheme,
-                    )
-                };
-            }
             QuantizationScheme::PerTensor(QuantizationMode::Symmetric, QuantizationType::QInt8) => {
                 unsafe {
                     dequantize_per_tensor_symmetric_int8_kernel::launch_unchecked::<R>(
@@ -218,43 +105,6 @@ where
                     )
                 };
             }
-            QuantizationScheme::PerBlock(
-                QuantizationMode::Affine,
-                QuantizationType::QInt8,
-                BlockLayout::Flat(block_size),
-            ) => {
-                let num_blocks = num_out_elems as u32 / block_size;
-                unsafe {
-                    dequantize_per_block_affine_int8_kernel::launch_unchecked::<R>(
-                        &client,
-                        cube_count,
-                        cube_dim,
-                        tensor.as_array_arg::<u32>(line_size_in),
-                        output.as_tensor_arg::<F>(line_size_out),
-                        scheme,
-                        num_blocks,
-                    )
-                };
-            }
-            QuantizationScheme::PerBlock(
-                QuantizationMode::Symmetric,
-                QuantizationType::QInt8,
-                BlockLayout::Flat(block_size),
-            ) => {
-                let num_blocks = num_out_elems as u32 / block_size;
-                unsafe {
-                    dequantize_per_block_symmetric_int8_kernel::launch_unchecked::<R>(
-                        &client,
-                        cube_count,
-                        cube_dim,
-                        tensor.as_array_arg::<u32>(line_size_in),
-                        output.as_tensor_arg::<F>(line_size_out),
-                        scheme,
-                        num_blocks,
-                    )
-                };
-            }
-            _ => panic!("Unsupported scheme for dequantize {scheme:?}"),
         }
     }
 

--- a/crates/burn-cubecl/src/kernel/quantization/qtensor.rs
+++ b/crates/burn-cubecl/src/kernel/quantization/qtensor.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs)] // cube derive macros
 
-use burn_tensor::quantization::{BlockLayout, QuantizationMode, QuantizationScheme};
+use burn_tensor::quantization::{QuantizationMode, QuantizationScheme};
 use cubecl::prelude::*;
 
 /// Quantization parameters.
@@ -8,8 +8,6 @@ use cubecl::prelude::*;
 pub struct QParams {
     #[cube(comptime)]
     scheme: QuantizationScheme,
-    #[cube(comptime)]
-    num_blocks: u32,
 }
 
 /// Quantized tensor representation.
@@ -18,71 +16,18 @@ pub type QTensor = Array<Line<u32>>;
 #[cube]
 impl QParams {
     /// Create a new quantization parameters instance.
-    pub fn new(scheme: QuantizationScheme, #[comptime] num_blocks: u32) -> Self {
-        QParams { scheme, num_blocks }
+    pub fn new(scheme: QuantizationScheme) -> Self {
+        QParams { scheme }
     }
 
     /// Get the quantization parameters values.
-    pub fn values(&self, tensor: &QTensor, value_pos: u32) -> (f32, i32) {
+    pub fn values(&self, tensor: &QTensor) -> (f32, i32) {
         let len = tensor.len();
         match comptime!(self.scheme) {
-            QuantizationScheme::PerTensor(QuantizationMode::Affine, _) => {
-                match comptime!(tensor.line_size()) {
-                    // For line size of 1, scale is the last value in the buffer
-                    1 => (
-                        f32::reinterpret(tensor[len - 1][0]),
-                        i32::cast_from(tensor[len - 2][0]),
-                    ),
-                    // For any other line size > 1, scale and zero-point offset are the last two elements
-                    _ => {
-                        let values = tensor[len - 1];
-                        (
-                            f32::reinterpret(values[tensor.line_size() - 1]),
-                            i32::cast_from(values[tensor.line_size() - 2]),
-                        )
-                    }
-                }
-            }
             // Symmetric quantization only contains the scaling factor as the last element
             QuantizationScheme::PerTensor(QuantizationMode::Symmetric, _) => {
                 (f32::reinterpret(tensor[len - 1][tensor.line_size() - 1]), 0)
             }
-            // For affine quantization, there are 2 parameters per block
-            // The (scale, offset) parameters are stored contiguously by parameter type
-            // [offset, offset, offset, ..., scale, scale, scale, ...]
-            // (but we might want to store them with each block in the future?)
-            QuantizationScheme::PerBlock(
-                QuantizationMode::Affine,
-                _dtype,
-                BlockLayout::Flat(block_size),
-            ) => {
-                // For each position in the quantized tensor, there are 4 packed values.
-                // The block size must be a factor of 4, so at least [4, 8, ...] values are contained in a single block
-                let line_size = tensor.line_size();
-                let block_idx = value_pos * 4 / block_size;
-
-                let scale =
-                    tensor[len - (self.num_blocks - block_idx) / line_size][block_idx % line_size];
-                let offset = tensor[len - (2 * self.num_blocks - block_idx / line_size)]
-                    [block_idx % line_size];
-
-                (f32::reinterpret(scale), i32::cast_from(offset))
-            }
-            QuantizationScheme::PerBlock(
-                QuantizationMode::Symmetric,
-                _dtype,
-                BlockLayout::Flat(block_size),
-            ) => {
-                // For each position in the quantized tensor, there are 4 packed values.
-                // The block size must be a factor of 4, so at least [4, 8, ...] values are contained in a single block
-                let line_size = tensor.line_size();
-                let block_idx = value_pos * 4 / block_size;
-
-                let scale =
-                    tensor[len - (self.num_blocks - block_idx) / line_size][block_idx % line_size];
-                (f32::reinterpret(scale), 0)
-            }
-            _ => comptime!(unimplemented!()),
         }
     }
 }

--- a/crates/burn-cubecl/src/kernel/quantization/quantize.rs
+++ b/crates/burn-cubecl/src/kernel/quantization/quantize.rs
@@ -85,7 +85,6 @@ fn quantize_per_tensor_symmetric_int8_kernel(
     }
 }
 
-
 fn create_quantized_output<R: CubeRuntime>(
     client: ComputeClient<R::Server, R::Channel>,
     num_input_elems: usize,

--- a/crates/burn-cubecl/src/kernel/quantization/quantize.rs
+++ b/crates/burn-cubecl/src/kernel/quantization/quantize.rs
@@ -1,9 +1,7 @@
 use crate::tensor::CubeTensor;
 use crate::{CubeElement, CubeRuntime, IntElement};
 use burn_tensor::Shape;
-use burn_tensor::quantization::{
-    BlockLayout, QuantizationMode, QuantizationScheme, QuantizationType,
-};
+use burn_tensor::quantization::{QuantizationMode, QuantizationScheme, QuantizationType};
 use cubecl::calculate_cube_count_elemwise;
 use cubecl::prelude::*;
 
@@ -19,25 +17,6 @@ fn pack_i8s_to_u32s(value: Line<u32>) -> u32 {
         v_packed |= (value[i] & 0xFF) << (8 * i);
     }
     v_packed
-}
-
-#[cube]
-fn quantize_affine_int8<F: Float>(
-    value: Line<F>,
-    scale: f32,
-    offset: i32,
-    range_min: f32,
-    range_max: f32,
-) -> Line<u32> {
-    // x_q = clamp(round(x / scale + offset), a, b)
-    // NOTE: we add 256 before casting to unsigned to correctly represent negative values
-    Line::cast_from(
-        Line::clamp(
-            Line::round((value / Line::cast_from(scale)) + Line::cast_from(offset)),
-            Line::cast_from(range_min),
-            Line::cast_from(range_max),
-        ) + Line::cast_from(comptime!(256f32)),
-    )
 }
 
 #[cube]
@@ -59,20 +38,6 @@ fn quantize_symmetric_int8<F: Float>(
 }
 
 #[cube]
-fn quantize_affine_int8_packed(
-    input: Line<f32>,
-    scale: f32,
-    offset: i32,
-    range_min: f32,
-    range_max: f32,
-) -> u32 {
-    // Assuming a line size of 4 (equal to the number of values packed)
-    let value = quantize_affine_int8::<f32>(input, scale, offset, range_min, range_max);
-    // Shift and combine into u32
-    pack_i8s_to_u32s(value)
-}
-
-#[cube]
 fn quantize_symmetric_int8_packed(
     input: Line<f32>,
     scale: f32,
@@ -85,51 +50,6 @@ fn quantize_symmetric_int8_packed(
     pack_i8s_to_u32s(value)
 }
 
-#[cube(launch_unchecked)]
-fn quantize_per_tensor_affine_int8_kernel(
-    input: &Tensor<Line<f32>>,
-    scale: &Tensor<f32>,
-    offset: &Tensor<i32>,
-    range_min: f32,
-    range_max: f32,
-    output: &mut Array<u32>,
-) {
-    if ABSOLUTE_POS >= output.len() {
-        terminate!();
-    }
-
-    let scale = scale[0];
-    let offset = offset[0];
-
-    // Cast the scale to u32 and write the value in the output
-    if ABSOLUTE_POS == output.len() - 1 {
-        output[ABSOLUTE_POS] = u32::reinterpret(scale);
-        terminate!();
-    }
-
-    // Cast the offset to u32 and write the value in the output
-    if ABSOLUTE_POS == output.len() - 2 {
-        output[ABSOLUTE_POS] = u32::reinterpret(offset);
-        terminate!();
-    }
-
-    if comptime!(input.line_size() == 4) {
-        output[ABSOLUTE_POS] =
-            quantize_affine_int8_packed(input[ABSOLUTE_POS], scale, offset, range_min, range_max);
-    } else {
-        // line size 1
-        let num_packed = comptime!(4);
-        let mut values = Line::<f32>::empty(num_packed);
-        #[unroll]
-        for i in 0..num_packed {
-            values[i] = input[ABSOLUTE_POS * num_packed + i][0];
-        }
-        output[ABSOLUTE_POS] =
-            quantize_affine_int8_packed(values, scale, offset, range_min, range_max);
-    }
-}
-
-// Would have wrapped symmetric with the same affine kernel but cube doesn't support Option<Tensor> for offset.
 #[cube(launch_unchecked)]
 fn quantize_per_tensor_symmetric_int8_kernel(
     input: &Tensor<Line<f32>>,
@@ -165,92 +85,6 @@ fn quantize_per_tensor_symmetric_int8_kernel(
     }
 }
 
-#[cube(launch_unchecked)]
-fn quantize_per_block_flat_symmetric_int8_kernel(
-    input: &Tensor<Line<f32>>,
-    scale: &Tensor<f32>,
-    range_min: f32,
-    range_max: f32,
-    block_size: u32,
-    output: &mut Array<u32>,
-    #[comptime] num_blocks: u32,
-) {
-    if ABSOLUTE_POS >= output.len() {
-        terminate!();
-    }
-
-    // Cast the scale to u32 and write the value in the output
-    if ABSOLUTE_POS >= output.len() - num_blocks {
-        let scale_idx = num_blocks - (output.len() - ABSOLUTE_POS);
-        output[ABSOLUTE_POS] = u32::reinterpret(scale[scale_idx]);
-        terminate!();
-    }
-
-    let line_size = comptime!(input.line_size());
-    let block_idx = (ABSOLUTE_POS * line_size) / block_size;
-    let scale = scale[block_idx];
-    if comptime!(line_size == 4) {
-        output[ABSOLUTE_POS] =
-            quantize_symmetric_int8_packed(input[ABSOLUTE_POS], scale, range_min, range_max);
-    } else {
-        // line size 1
-        let num_packed = comptime!(4);
-        let mut values = Line::<f32>::empty(num_packed);
-        #[unroll]
-        for i in 0..num_packed {
-            values[i] = input[ABSOLUTE_POS * num_packed + i][0];
-        }
-        output[ABSOLUTE_POS] = quantize_symmetric_int8_packed(values, scale, range_min, range_max);
-    }
-}
-
-#[cube(launch_unchecked)]
-fn quantize_per_block_flat_affine_int8_kernel(
-    input: &Tensor<Line<f32>>,
-    scale: &Tensor<f32>,
-    offset: &Tensor<i32>,
-    range_min: f32,
-    range_max: f32,
-    block_size: u32,
-    output: &mut Array<u32>,
-    #[comptime] num_blocks: u32,
-) {
-    if ABSOLUTE_POS >= output.len() {
-        terminate!();
-    }
-
-    // Cast the scale to u32 and write the value in the output
-    if ABSOLUTE_POS >= output.len() - num_blocks {
-        let scale_idx = num_blocks - (output.len() - ABSOLUTE_POS);
-        output[ABSOLUTE_POS] = u32::reinterpret(scale[scale_idx]);
-        terminate!();
-    }
-
-    // Cast the offset to u32 and write the value in the output
-    if ABSOLUTE_POS >= output.len() - 2 * num_blocks {
-        let offset_idx = 2 * num_blocks - (output.len() - ABSOLUTE_POS);
-        output[ABSOLUTE_POS] = u32::reinterpret(offset[offset_idx]);
-        terminate!();
-    }
-
-    let line_size = comptime!(input.line_size());
-    let block_idx = (ABSOLUTE_POS * line_size) / block_size;
-    let scale = scale[block_idx];
-    let offset = offset[block_idx];
-    if comptime!(line_size == 4) {
-        output[ABSOLUTE_POS] =
-            quantize_affine_int8_packed(input[ABSOLUTE_POS], scale, offset, range_min, range_max);
-    } else {
-        // line size 1
-        let num_packed = comptime!(4);
-        let mut values = Line::<f32>::empty(num_packed);
-        #[unroll]
-        for i in 0..num_packed {
-            values[i] = input[ABSOLUTE_POS * num_packed + i][0];
-        }
-        output[ABSOLUTE_POS] = quantize_symmetric_int8_packed(values, scale, range_min, range_max);
-    }
-}
 
 fn create_quantized_output<R: CubeRuntime>(
     client: ComputeClient<R::Server, R::Channel>,
@@ -265,22 +99,8 @@ fn create_quantized_output<R: CubeRuntime>(
     // Scale and offset (optional) qparams are also packed in the tensor data
     let qparams_size = match &scheme {
         QuantizationScheme::PerTensor(mode, ..) => match mode {
-            QuantizationMode::Affine => core::mem::size_of::<f32>() + core::mem::size_of::<i32>(),
             QuantizationMode::Symmetric => core::mem::size_of::<f32>(),
         },
-        QuantizationScheme::PerBlock(mode, _, layout) => {
-            let num_blocks = match layout {
-                BlockLayout::Flat(block_size) => num_input_elems / *block_size as usize,
-                BlockLayout::Grid(m, n) => num_input_elems / (m * n) as usize,
-            };
-
-            match mode {
-                QuantizationMode::Affine => {
-                    (core::mem::size_of::<f32>() + core::mem::size_of::<i32>()) * num_blocks
-                }
-                QuantizationMode::Symmetric => core::mem::size_of::<f32>() * num_blocks,
-            }
-        }
     };
 
     let handle = client.empty(output_elems_size + qparams_size);
@@ -298,7 +118,6 @@ pub fn quantize<R, F, I>(
     tensor: CubeTensor<R>,
     scheme: &QuantizationScheme,
     scale: CubeTensor<R>,
-    offset: Option<CubeTensor<R>>,
 ) -> CubeTensor<R>
 where
     R: CubeRuntime,
@@ -329,32 +148,6 @@ where
             let dummy_array = vec![1; ndims];
 
             match mode {
-                QuantizationMode::Affine => {
-                    unsafe {
-                        quantize_per_tensor_affine_int8_kernel::launch_unchecked::<R>(
-                            &client,
-                            cube_count,
-                            cube_dim,
-                            tensor.as_tensor_arg::<F>(line_size),
-                            // Ignore shape and stride
-                            TensorArg::from_raw_parts::<F>(
-                                &scale.handle,
-                                &dummy_array,
-                                &dummy_array,
-                                1,
-                            ),
-                            TensorArg::from_raw_parts::<I>(
-                                &offset.expect("Should have offset").handle,
-                                &dummy_array,
-                                &dummy_array,
-                                1,
-                            ),
-                            ScalarArg::new(i8::MIN as f32),
-                            ScalarArg::new(i8::MAX as f32),
-                            output.as_array_arg::<u32>(1),
-                        )
-                    };
-                }
                 QuantizationMode::Symmetric => {
                     unsafe {
                         quantize_per_tensor_symmetric_int8_kernel::launch_unchecked::<R>(
@@ -376,61 +169,6 @@ where
                     };
                 }
             }
-        }
-        QuantizationScheme::PerBlock(
-            mode,
-            QuantizationType::QInt8,
-            BlockLayout::Flat(block_size),
-        ) => {
-            // if line_size != 4 {
-            //     panic!(
-            //         "Per-block quantization is only supported for a line size of 4, got {line_size} ({num_elems} elements)"
-            //     )
-            // }
-
-            if block_size % line_size as u32 != 0 {
-                panic!("Block size must be a factor of {line_size}, got {block_size}")
-            }
-
-            let num_blocks = num_elems as u32 / block_size;
-            match mode {
-                QuantizationMode::Affine => {
-                    unsafe {
-                        quantize_per_block_flat_affine_int8_kernel::launch_unchecked::<R>(
-                            &client,
-                            cube_count,
-                            cube_dim,
-                            tensor.as_tensor_arg::<F>(line_size),
-                            scale.as_tensor_arg::<F>(1),
-                            offset.expect("Should have offset").as_tensor_arg::<I>(1),
-                            ScalarArg::new(i8::MIN as f32),
-                            ScalarArg::new(i8::MAX as f32),
-                            ScalarArg::new(*block_size),
-                            output.as_array_arg::<u32>(1),
-                            num_blocks,
-                        )
-                    };
-                }
-                QuantizationMode::Symmetric => {
-                    unsafe {
-                        quantize_per_block_flat_symmetric_int8_kernel::launch_unchecked::<R>(
-                            &client,
-                            cube_count,
-                            cube_dim,
-                            tensor.as_tensor_arg::<F>(line_size),
-                            scale.as_tensor_arg::<F>(1),
-                            ScalarArg::new(-i8::MAX as f32),
-                            ScalarArg::new(i8::MAX as f32),
-                            ScalarArg::new(*block_size),
-                            output.as_array_arg::<u32>(1),
-                            num_blocks,
-                        )
-                    };
-                }
-            }
-        }
-        QuantizationScheme::PerBlock(.., BlockLayout::Grid(..)) => {
-            panic!("Per-block quantization is not supported for grid layout")
         }
     }
 

--- a/crates/burn-cubecl/src/tests/quantization.rs
+++ b/crates/burn-cubecl/src/tests/quantization.rs
@@ -3,7 +3,7 @@ mod tests {
     use super::*;
     use burn_tensor::{
         Tensor,
-        quantization::{BlockLayout, QuantizationMode, QuantizationScheme, QuantizationType},
+        quantization::{QuantizationMode, QuantizationScheme, QuantizationType},
     };
     use burn_tensor::{Tolerance, ops::FloatElem};
     type FT = FloatElem<TestBackend>;
@@ -30,27 +30,6 @@ mod tests {
     }
 
     #[test]
-    fn should_quantize_dequantize_affine_single() {
-        let scheme =
-            QuantizationScheme::PerTensor(QuantizationMode::Affine, QuantizationType::QInt8);
-        let input = Tensor::<TestBackend, 1>::from_floats([-1.8], &Default::default());
-        let input_ref =
-            Tensor::<ReferenceBackend, 1>::from_data(input.to_data(), &Default::default());
-
-        let output = input.quantize_dynamic(&scheme);
-        let output_ref = input_ref.quantize_dynamic(&scheme);
-
-        output.to_data().assert_eq(&output_ref.to_data(), false);
-
-        let output = output.dequantize();
-        let output_ref = output_ref.dequantize();
-
-        output
-            .to_data()
-            .assert_approx_eq::<FT>(&output_ref.to_data(), Tolerance::rel_abs(1e-2, 1e-2));
-    }
-
-    #[test]
     fn should_quantize_dequantize_symmetric_multiple() {
         let scheme =
             QuantizationScheme::PerTensor(QuantizationMode::Symmetric, QuantizationType::QInt8);
@@ -58,91 +37,6 @@ mod tests {
             Tensor::<TestBackend, 1>::from_floats([-1.8, -1.0, 0.0, 0.5, 0.0], &Default::default());
         let input_ref =
             Tensor::<ReferenceBackend, 1>::from_data(input.to_data(), &Default::default());
-
-        let output = input.quantize_dynamic(&scheme);
-        let output_ref = input_ref.quantize_dynamic(&scheme);
-
-        output.to_data().assert_eq(&output_ref.to_data(), false);
-
-        let output = output.dequantize();
-        let output_ref = output_ref.dequantize();
-
-        output
-            .to_data()
-            .assert_approx_eq::<FT>(&output_ref.to_data(), Tolerance::rel_abs(1e-2, 1e-2));
-    }
-
-    #[test]
-    fn should_quantize_dequantize_affine_multiple() {
-        let scheme =
-            QuantizationScheme::PerTensor(QuantizationMode::Affine, QuantizationType::QInt8);
-        let input =
-            Tensor::<TestBackend, 1>::from_floats([-1.8, -1.0, 0.0, 0.5, 0.0], &Default::default());
-        let input_ref =
-            Tensor::<ReferenceBackend, 1>::from_data(input.to_data(), &Default::default());
-
-        let output = input.quantize_dynamic(&scheme);
-        let output_ref = input_ref.quantize_dynamic(&scheme);
-
-        output.to_data().assert_eq(&output_ref.to_data(), false);
-
-        let output = output.dequantize();
-        let output_ref = output_ref.dequantize();
-
-        output
-            .to_data()
-            .assert_approx_eq::<FT>(&output_ref.to_data(), Tolerance::rel_abs(1e-2, 1e-2));
-    }
-
-    #[test]
-    #[ignore]
-    fn should_quantize_dequantize_per_block_symmetric() {
-        // block_size > line_size
-        let scheme = QuantizationScheme::PerBlock(
-            QuantizationMode::Symmetric,
-            QuantizationType::QInt8,
-            BlockLayout::Flat(8),
-        );
-        let input = Tensor::<TestBackend, 2>::from_floats(
-            [
-                [-1.8, -1.0, 0.0, 0.5, -0.8, 1.2, 0.25, 0.5],
-                [-0.08, 0.12, 0.025, 0.05, 0.2, 0.3, 0.4, 0.5],
-            ],
-            &Default::default(),
-        );
-        let input_ref =
-            Tensor::<ReferenceBackend, 2>::from_data(input.to_data(), &Default::default());
-
-        let output = input.quantize_dynamic(&scheme);
-        let output_ref = input_ref.quantize_dynamic(&scheme);
-
-        output.to_data().assert_eq(&output_ref.to_data(), false);
-
-        let output = output.dequantize();
-        let output_ref = output_ref.dequantize();
-
-        output
-            .to_data()
-            .assert_approx_eq::<FT>(&output_ref.to_data(), Tolerance::rel_abs(1e-2, 1e-2));
-    }
-
-    #[test]
-    #[ignore]
-    fn should_quantize_dequantize_per_block_affine() {
-        let scheme = QuantizationScheme::PerBlock(
-            QuantizationMode::Affine,
-            QuantizationType::QInt8,
-            BlockLayout::Flat(4),
-        );
-        let input = Tensor::<TestBackend, 2>::from_floats(
-            [
-                [-1.8, -1.0, 0.0, 0.5, -0.8, 1.2, 0.25, 0.5],
-                [0.5, 0.25, 1.2, -0.8, 0.2, 0.3, 0.4, 0.5],
-            ],
-            &Default::default(),
-        );
-        let input_ref =
-            Tensor::<ReferenceBackend, 2>::from_data(input.to_data(), &Default::default());
 
         let output = input.quantize_dynamic(&scheme);
         let output_ref = input_ref.quantize_dynamic(&scheme);

--- a/crates/burn-tch/src/tensor.rs
+++ b/crates/burn-tch/src/tensor.rs
@@ -2,7 +2,7 @@ use crate::{LibTorchDevice, TchElement};
 use burn_tensor::{
     DType, Shape, TensorData, TensorMetadata,
     quantization::{
-        AffineQuantization, QTensorPrimitive, QuantizationMode, QuantizationScheme,
+        QTensorPrimitive, QuantizationMode, QuantizationScheme,
         QuantizationStrategy, QuantizationType, SymmetricQuantization,
     },
 };
@@ -331,22 +331,12 @@ impl TchQTensor {
     /// Returns the quantization strategy, including quantization parameters, for the given tensor.
     pub fn strategy(&self) -> QuantizationStrategy {
         match &self.scheme {
-            QuantizationScheme::PerTensor(QuantizationMode::Affine, QuantizationType::QInt8) => {
-                let scale = self.qtensor.tensor.q_scale();
-                let offset = self.qtensor.tensor.q_zero_point();
-                QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(
-                    scale as f32,
-                    offset as i8,
-                ))
-            }
             QuantizationScheme::PerTensor(QuantizationMode::Symmetric, QuantizationType::QInt8) => {
                 let scale = self.qtensor.tensor.q_scale();
                 QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(
                     scale as f32,
                 ))
             }
-            // Only per-tensor and per-channel are supported
-            QuantizationScheme::PerBlock(..) => unreachable!(),
         }
     }
 }
@@ -439,7 +429,7 @@ mod tests {
         let tensor =
             TchTensor::from_data::<f32>(TensorData::from([-1.8, -1.0, 0.0, 0.5]), tch::Device::Cpu);
         let scheme =
-            QuantizationScheme::PerTensor(QuantizationMode::Affine, QuantizationType::QInt8);
+            QuantizationScheme::PerTensor(QuantizationMode::Symmetric, QuantizationType::QInt8);
         let qparams = QuantizationParametersPrimitive::<LibTorch<f32, i8>> {
             scale: TchTensor::from_data::<f32>(TensorData::from([0.009_019_608]), tch::Device::Cpu),
             offset: Some(TchTensor::from_data::<i8>(
@@ -452,7 +442,9 @@ mod tests {
         assert_eq!(qtensor.scheme(), &scheme);
         assert_eq!(
             qtensor.strategy(),
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.009_019_608, 72))
+            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(
+                0.009_019_608
+            ))
         );
     }
 }

--- a/crates/burn-tch/src/tensor.rs
+++ b/crates/burn-tch/src/tensor.rs
@@ -2,8 +2,8 @@ use crate::{LibTorchDevice, TchElement};
 use burn_tensor::{
     DType, Shape, TensorData, TensorMetadata,
     quantization::{
-        QTensorPrimitive, QuantizationMode, QuantizationScheme,
-        QuantizationStrategy, QuantizationType, SymmetricQuantization,
+        QTensorPrimitive, QuantizationMode, QuantizationScheme, QuantizationStrategy,
+        QuantizationType, SymmetricQuantization,
     },
 };
 use libc::c_void;

--- a/crates/burn-tensor/src/tensor/data.rs
+++ b/crates/burn-tensor/src/tensor/data.rs
@@ -1126,22 +1126,21 @@ mod tests {
 
     #[test]
     fn should_support_dequantize() {
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
         let data = TensorData::quantized(
-            vec![-128i8, -77, -26, 25, 76, 127],
+            vec![-127i8, -77, -26, 25, 76, 127],
             [2, 3],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.019607844)),
+            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.1)),
         );
 
         let output = data.dequantize().unwrap();
 
         output.assert_approx_eq::<f32>(
-            &TensorData::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]),
+            &TensorData::from([[-12.7, -7.7, -2.6], [2.5, 7.6, 12.7]]),
             Tolerance::default(),
         );
 
         output.assert_approx_eq::<f16>(
-            &TensorData::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]),
+            &TensorData::from([[-12.7, -7.7, -2.6], [2.5, 7.6, 12.7]]),
             Tolerance::default(),
         );
     }

--- a/crates/burn-tensor/src/tensor/element/base.rs
+++ b/crates/burn-tensor/src/tensor/element/base.rs
@@ -336,8 +336,7 @@ impl DType {
             DType::U8 => core::mem::size_of::<u8>(),
             DType::Bool => core::mem::size_of::<bool>(),
             DType::QFloat(scheme) => match scheme {
-                QuantizationScheme::PerTensor(_mode, QuantizationType::QInt8)
-                | QuantizationScheme::PerBlock(_mode, QuantizationType::QInt8, ..) => {
+                QuantizationScheme::PerTensor(_mode, QuantizationType::QInt8) => {
                     core::mem::size_of::<i8>()
                 }
             },

--- a/crates/burn-tensor/src/tensor/ops/modules/conv.rs
+++ b/crates/burn-tensor/src/tensor/ops/modules/conv.rs
@@ -2,9 +2,6 @@
 use super::{ConvOptions, ConvTransposeOptions};
 use crate::{Shape, TensorMetadata, backend::Backend, ops::FloatTensor};
 
-#[cfg(not(feature = "std"))]
-use num_traits::Float;
-
 /// Calculate the expected padding size required when applying a convolution.
 pub fn calculate_conv_padding(
     kernel_size: usize,

--- a/crates/burn-tensor/src/tensor/ops/modules/conv.rs
+++ b/crates/burn-tensor/src/tensor/ops/modules/conv.rs
@@ -2,7 +2,7 @@
 use super::{ConvOptions, ConvTransposeOptions};
 use crate::{Shape, TensorMetadata, backend::Backend, ops::FloatTensor};
 
-#[cfg(feature="no_std")]
+#[cfg(not(feature = "std"))]
 use num_traits::Float;
 
 /// Calculate the expected padding size required when applying a convolution.

--- a/crates/burn-tensor/src/tensor/ops/modules/conv.rs
+++ b/crates/burn-tensor/src/tensor/ops/modules/conv.rs
@@ -2,6 +2,9 @@
 use super::{ConvOptions, ConvTransposeOptions};
 use crate::{Shape, TensorMetadata, backend::Backend, ops::FloatTensor};
 
+#[cfg(feature="no_std")]
+use num_traits::Float;
+
 /// Calculate the expected padding size required when applying a convolution.
 pub fn calculate_conv_padding(
     kernel_size: usize,

--- a/crates/burn-tensor/src/tensor/quantization/bytes.rs
+++ b/crates/burn-tensor/src/tensor/quantization/bytes.rs
@@ -4,9 +4,8 @@ use crate::{Bytes, Element};
 use alloc::vec::Vec;
 
 use super::{
-    AffineQuantization, BlockLayout, QParams, QuantizationMode, QuantizationScheme,
-    QuantizationStrategy, QuantizationType, SymmetricQuantization, pack_i8s_to_u32s,
-    unpack_u32s_to_i8s,
+    QParams, QuantizationMode, QuantizationScheme, QuantizationStrategy, QuantizationType,
+    SymmetricQuantization, pack_i8s_to_u32s, unpack_u32s_to_i8s,
 };
 
 /// Quantized data bytes representation.
@@ -35,21 +34,6 @@ impl QuantizedBytes {
         let scheme = strategy.scheme();
 
         match strategy {
-            QuantizationStrategy::PerTensorAffineInt8(quant) => {
-                if TypeId::of::<E>() == TypeId::of::<i8>() {
-                    // Re-interpret `Vec<E>` as `Vec<i8>` with `Vec::from_raw_parts`
-                    let u32s = pack_i8s_to_u32s(bytemuck::allocation::cast_vec(value));
-                    bytes = Bytes::from_elems(u32s);
-                } else {
-                    panic!("Invalid quantized type");
-                }
-                // Scale is always stored as f32 and zero-point offset as i32
-                let offset = quant.offset as i32;
-                let scale_bytes = bytemuck::bytes_of(&quant.scale);
-                let offset_bytes = bytemuck::bytes_of(&offset);
-                bytes.extend_from_byte_slice_aligned(offset_bytes, align_of::<i32>());
-                bytes.extend_from_byte_slice_aligned(scale_bytes, align_of::<f32>());
-            }
             QuantizationStrategy::PerTensorSymmetricInt8(quant) => {
                 if TypeId::of::<E>() == TypeId::of::<i8>() {
                     // Re-interpret `Vec<E>` as `Vec<i8>` with `Vec::from_raw_parts`
@@ -60,37 +44,6 @@ impl QuantizedBytes {
                 }
                 let scale_bytes = bytemuck::bytes_of(&quant.scale);
                 bytes.extend_from_byte_slice_aligned(scale_bytes, align_of::<f32>());
-            }
-            QuantizationStrategy::PerBlockAffineInt8(quant, _layout) => {
-                if TypeId::of::<E>() == TypeId::of::<i8>() {
-                    // Re-interpret `Vec<E>` as `Vec<i8>` with `Vec::from_raw_parts`
-                    let u32s = pack_i8s_to_u32s(bytemuck::allocation::cast_vec(value));
-                    bytes = Bytes::from_elems(u32s);
-                } else {
-                    panic!("Invalid quantized type");
-                }
-                let mut scale_bytes = Vec::with_capacity(quant.len() * size_of::<f32>());
-                let mut offset_bytes = Vec::with_capacity(quant.len() * size_of::<f32>());
-                for q in quant {
-                    scale_bytes.extend_from_slice(bytemuck::bytes_of(&q.scale));
-                    offset_bytes.extend_from_slice(bytemuck::bytes_of(&(q.offset as i32)));
-                }
-                bytes.extend_from_byte_slice_aligned(offset_bytes.as_slice(), align_of::<i32>());
-                bytes.extend_from_byte_slice_aligned(scale_bytes.as_slice(), align_of::<f32>());
-            }
-            QuantizationStrategy::PerBlockSymmetricInt8(quant, _layout) => {
-                if TypeId::of::<E>() == TypeId::of::<i8>() {
-                    // Re-interpret `Vec<E>` as `Vec<i8>` with `Vec::from_raw_parts`
-                    let u32s = pack_i8s_to_u32s(bytemuck::allocation::cast_vec(value));
-                    bytes = Bytes::from_elems(u32s);
-                } else {
-                    panic!("Invalid quantized type");
-                }
-                let mut scale_bytes = Vec::with_capacity(quant.len() * size_of::<f32>());
-                for q in quant {
-                    scale_bytes.extend_from_slice(bytemuck::bytes_of(&q.scale));
-                }
-                bytes.extend_from_byte_slice_aligned(scale_bytes.as_slice(), align_of::<f32>());
             }
         }
 
@@ -104,7 +57,6 @@ impl QuantizedBytes {
     /// Returns the int8 quantized values with the quantization parameters.
     pub fn into_vec_i8(self) -> (Vec<i8>, QParams<Vec<f32>, Vec<i8>>) {
         let numel = self.num_elements;
-        let scheme = self.scheme;
         let (values, (qparams, num_params)) = self.split_values_off();
 
         let values = unpack_u32s_to_i8s(values, numel);
@@ -122,18 +74,7 @@ impl QuantizedBytes {
         let scales_size = scale_size * num_params;
 
         let scale = bytemuck::cast_slice(&qparams_bytes[total_bytes - scales_size..]).to_vec();
-        let mut offset = None;
-
-        if scheme.mode() == QuantizationMode::Affine {
-            // Bytes end with [offset, offset, offset, ...]
-            let offset_size = core::mem::size_of::<i32>(); // zero-point offset is stored as i32
-            let offsets_size = offset_size * num_params;
-            let offsets: &[i32] = bytemuck::cast_slice(
-                &qparams_bytes[total_bytes - scales_size - offsets_size..total_bytes - scales_size],
-            );
-
-            offset = Some(offsets.iter().map(|&x| x as i8).collect());
-        }
+        let offset = None;
 
         (values, QParams { scale, offset })
     }
@@ -160,23 +101,12 @@ impl QuantizedBytes {
             _ => unreachable!(),
         };
 
-        let (num_params, mode) = match self.scheme {
-            QuantizationScheme::PerTensor(mode, ..) => (1, mode),
-            QuantizationScheme::PerBlock(mode, _, layout) => {
-                let num_blocks = match layout {
-                    BlockLayout::Flat(block_size) => self.num_elements / block_size as usize,
-                    BlockLayout::Grid(m, n) => self.num_elements / (m * n) as usize,
-                };
-                (num_blocks, mode)
-            }
+        let num_params = match self.scheme {
+            QuantizationScheme::PerTensor(..) => 1,
         };
 
         let scale_size = num_params; // f32 scale is the same number of bytes as u32
-        let mut values_end = values.len() - scale_size;
-
-        if mode == QuantizationMode::Affine {
-            values_end -= num_params; // zero-point offset is stored as i32 (same number of bytes as u32)
-        }
+        let values_end = values.len() - scale_size;
 
         let qparams = values.split_off(values_end);
 
@@ -184,55 +114,14 @@ impl QuantizedBytes {
     }
 
     /// Dequantizes the data according to its quantization scheme.
-    pub fn dequantize(self, shape: &[usize]) -> (Vec<f32>, QParams<Vec<f32>, Vec<i8>>) {
+    pub fn dequantize(self) -> (Vec<f32>, QParams<Vec<f32>, Vec<i8>>) {
         match self.scheme {
-            QuantizationScheme::PerTensor(QuantizationMode::Affine, QuantizationType::QInt8) => {
-                let (values, qparams) = self.into_vec_i8();
-                let strategy = QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(
-                    qparams.scale[0],
-                    qparams.offset.as_ref().unwrap()[0],
-                ));
-                (strategy.dequantize(&values, shape), qparams)
-            }
             QuantizationScheme::PerTensor(QuantizationMode::Symmetric, QuantizationType::QInt8) => {
                 let (values, qparams) = self.into_vec_i8();
                 let strategy = QuantizationStrategy::PerTensorSymmetricInt8(
                     SymmetricQuantization::init(qparams.scale[0]),
                 );
-                (strategy.dequantize(&values, shape), qparams)
-            }
-            QuantizationScheme::PerBlock(
-                QuantizationMode::Affine,
-                QuantizationType::QInt8,
-                layout,
-            ) => {
-                let (values, qparams) = self.into_vec_i8();
-                let strategy = QuantizationStrategy::PerBlockAffineInt8(
-                    qparams
-                        .scale
-                        .iter()
-                        .zip(qparams.offset.as_ref().unwrap().iter())
-                        .map(|(&s, &o)| AffineQuantization::init(s, o))
-                        .collect(),
-                    layout,
-                );
-                (strategy.dequantize(&values, shape), qparams)
-            }
-            QuantizationScheme::PerBlock(
-                QuantizationMode::Symmetric,
-                QuantizationType::QInt8,
-                layout,
-            ) => {
-                let (values, qparams) = self.into_vec_i8();
-                let strategy = QuantizationStrategy::PerBlockSymmetricInt8(
-                    qparams
-                        .scale
-                        .iter()
-                        .map(|&s| SymmetricQuantization::init(s))
-                        .collect(),
-                    layout,
-                );
-                (strategy.dequantize(&values, shape), qparams)
+                (strategy.dequantize(&values), qparams)
             }
         }
     }
@@ -293,47 +182,4 @@ mod tests {
         assert_eq!(q_values, values);
     }
 
-    #[test]
-    fn should_pack_unpack_quantization_parameters_per_tensor_affine() {
-        let scale = 0.019607844;
-        let offset = -128;
-        // Quantized [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-        let values = vec![-128i8, -77, -26, 25, 76, 127];
-        let q_bytes = QuantizedBytes::new(
-            values.clone(),
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(scale, offset)),
-        );
-
-        let (q_values, qparams) = q_bytes.into_vec_i8();
-
-        assert_eq!(qparams.scale, vec![scale]);
-        assert_eq!(qparams.offset, Some(vec![offset]));
-
-        assert_eq!(q_values, values);
-    }
-
-    #[test]
-    fn should_pack_unpack_quantization_parameters_per_block_symmetric() {
-        // Quantized 2x2 blocks: [[-1.8, -1.0, 0.0, 0.5], [-0.8, 1.2, 0.25, 0.5]]
-        let scale = vec![0.014_173_228, 0.009_448_819];
-        let values = vec![-127i8, -71, -85, 127, 0, 35, 26, 53];
-
-        let q_bytes = QuantizedBytes::new(
-            values.clone(),
-            QuantizationStrategy::PerBlockSymmetricInt8(
-                vec![
-                    SymmetricQuantization::init(scale[0]),
-                    SymmetricQuantization::init(scale[1]),
-                ],
-                BlockLayout::Grid(2, 2),
-            ),
-        );
-
-        let (q_values, qparams) = q_bytes.into_vec_i8();
-
-        assert_eq!(qparams.scale, scale);
-        assert_eq!(qparams.offset, None);
-
-        assert_eq!(q_values, values);
-    }
 }

--- a/crates/burn-tensor/src/tensor/quantization/bytes.rs
+++ b/crates/burn-tensor/src/tensor/quantization/bytes.rs
@@ -181,5 +181,4 @@ mod tests {
 
         assert_eq!(q_values, values);
     }
-
 }

--- a/crates/burn-tensor/src/tensor/quantization/scheme.rs
+++ b/crates/burn-tensor/src/tensor/quantization/scheme.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{Shape, Tensor, TensorMetadata, TensorPrimitive, backend::Backend};
+use crate::{Tensor, TensorPrimitive, backend::Backend};
 
 use super::{
     Calibration, CalibrationRange, QuantizationParameters, QuantizationParametersPrimitive,
@@ -19,22 +19,10 @@ pub enum QuantizationType {
     QInt8,
 }
 
-// CubeType not implemented for usize
-/// Block quantization layout.
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "cubecl", derive(CubeType, PartialOrd, Ord))]
-pub enum BlockLayout {
-    /// The tensor is split into linear segments of N elements.
-    Flat(u32),
-    /// The tensor is split into segments of M x N elements.
-    Grid(u32, u32),
-}
 /// Quantization mode.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "cubecl", derive(PartialOrd, Ord))]
 pub enum QuantizationMode {
-    /// Affine or asymmetric quantization.
-    Affine,
     /// Symmetric or scale quantization.
     Symmetric,
 }
@@ -45,8 +33,6 @@ pub enum QuantizationMode {
 pub enum QuantizationScheme {
     /// Per-tensor quantization.
     PerTensor(QuantizationMode, QuantizationType),
-    /// Per-block quantization.
-    PerBlock(QuantizationMode, QuantizationType, BlockLayout),
 }
 
 #[cfg(feature = "cubecl")]
@@ -68,9 +54,7 @@ impl QuantizationScheme {
     /// Get the [quantization mode](QuantizationMode)
     pub fn mode(&self) -> QuantizationMode {
         match self {
-            QuantizationScheme::PerTensor(mode, ..) | QuantizationScheme::PerBlock(mode, ..) => {
-                *mode
-            }
+            QuantizationScheme::PerTensor(mode, ..) => *mode,
         }
     }
 
@@ -103,75 +87,6 @@ impl QuantizationScheme {
                 QuantizationScheme::PerTensor(_, _) => {
                     (B::float_min(tensor.clone()), B::float_max(tensor))
                 }
-                QuantizationScheme::PerBlock(.., layout) => match layout {
-                    // For per-block quantization, we can compute the (min, max) range with pooling
-                    BlockLayout::Flat(block_size) => {
-                        let block_size = *block_size as usize;
-                        // Tensor shape must be divisible by block size
-                        let shape = tensor.shape();
-                        let numel = shape.num_elements();
-                        assert_eq!(
-                            numel % block_size,
-                            0,
-                            "Cannot compute per-block quantization range with block size {block_size} and tensor of shape {shape:?}"
-                        );
-                        let num_blocks = numel / block_size;
-
-                        let tensor = B::float_reshape(tensor, Shape::new([num_blocks, block_size]));
-                        let min = B::float_reshape(
-                            B::float_min_dim(tensor.clone(), 1),
-                            Shape::new([num_blocks]),
-                        );
-                        let max =
-                            B::float_reshape(B::float_max_dim(tensor, 1), Shape::new([num_blocks]));
-                        // Tensors with shape [b * num_blocks]
-                        (min, max)
-                    }
-                    BlockLayout::Grid(m, n) => {
-                        let (m, n) = (*m as usize, *n as usize);
-                        let shape = tensor.shape();
-                        let (b, h, w) = match shape.num_dims() {
-                            2 => {
-                                let [h, w] = shape.dims();
-                                (1, h, w)
-                            }
-                            3 => {
-                                let [b, h, w] = shape.dims(); // leading batch dim
-                                (b, h, w)
-                            }
-                            _ => unimplemented!(
-                                "Per-block grid quantization is only supported for 2D or 3D tensors"
-                            ),
-                        };
-                        // For optimized dynamic quantization, we probably want a custom kernel that computes the
-                        // (min, max) range to quantize each block on-the-fly.
-                        // For static quantization, it doesn't really matter.
-                        assert!(
-                            h % m == 0 && w % n == 0,
-                            "Cannot compute per-block quantization range with block grid [{m}, {n}] and tensor of shape {shape:?}"
-                        );
-                        let num_blocks_h = h / m;
-                        let num_blocks_w = w / n;
-
-                        // Max and min pooling
-                        let reshaped = B::float_reshape(tensor, Shape::new([b, 1, h, w]));
-                        let max = B::max_pool2d(reshaped.clone(), [m, n], [m, n], [0, 0], [1, 1]);
-                        let min = B::float_neg(B::max_pool2d(
-                            B::float_neg(reshaped),
-                            [m, n],
-                            [m, n],
-                            [0, 0],
-                            [0, 0],
-                        ));
-
-                        // Tensors with shape [b * num_blocks_h * num_blocks_w]
-                        let out_shape = Shape::new([b * num_blocks_h * num_blocks_w]);
-                        (
-                            B::float_reshape(min, out_shape.clone()),
-                            B::float_reshape(max, out_shape),
-                        )
-                    }
-                },
             },
         }
     }
@@ -181,38 +96,8 @@ impl QuantizationScheme {
         &self,
         range: CalibrationRange<B>,
     ) -> QuantizationParameters<B> {
-        // Quantization parameters are computed element-wise based on the calibration range,
-        // so it's the same operations for per-tensor and per-block (just that the latter has
-        // more parameters)
         match self {
-            QuantizationScheme::PerTensor(QuantizationMode::Affine, QuantizationType::QInt8)
-            | QuantizationScheme::PerBlock(QuantizationMode::Affine, QuantizationType::QInt8, ..) =>
-            {
-                // Quantized range `[a, b]`
-                let a = i8::MIN as i32;
-                let b = i8::MAX as i32;
-
-                // We extend the `[min, max]` interval to ensure that it contains 0.
-                // Otherwise, we would not meet the requirement that 0 be an exactly
-                // representable value (zero-point).
-                let zero = Tensor::zeros_like(&range.min);
-                let min = range.min.min_pair(zero);
-                let zero = Tensor::zeros_like(&range.max);
-                let max = range.max.max_pair(zero);
-
-                // If scale is 0 (most likely due to a tensor full of zeros), we arbitrarily adjust the
-                // scale to 0.1 to avoid division by zero.
-                let scale = max.sub(min.clone()).div_scalar(b - a);
-                let scale = scale.clone().mask_fill(scale.equal_elem(0.), 0.1);
-                let offset = Some(-(min.div(scale.clone()).sub_scalar(a)).int());
-                QuantizationParameters { scale, offset }
-            }
-            QuantizationScheme::PerTensor(QuantizationMode::Symmetric, QuantizationType::QInt8)
-            | QuantizationScheme::PerBlock(
-                QuantizationMode::Symmetric,
-                QuantizationType::QInt8,
-                ..,
-            ) => {
+            QuantizationScheme::PerTensor(QuantizationMode::Symmetric, QuantizationType::QInt8) => {
                 // Quantized range `[a, b]`
                 let b = i8::MAX as i32;
                 let a = -b;
@@ -244,7 +129,6 @@ impl QuantizationScheme {
     pub fn q_type(&self) -> QuantizationType {
         match self {
             QuantizationScheme::PerTensor(_, quantization_type) => *quantization_type,
-            QuantizationScheme::PerBlock(_, quantization_type, _) => *quantization_type,
         }
     }
 }

--- a/crates/burn-tensor/src/tensor/quantization/strategy.rs
+++ b/crates/burn-tensor/src/tensor/quantization/strategy.rs
@@ -143,6 +143,7 @@ impl<E: Float + Send + Sync, Q: PrimInt + Signed + Send + Sync> Eq for Symmetric
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
     #[test]
     fn test_int8_symmetric_quantization() {

--- a/crates/burn-tensor/src/tensor/quantization/strategy.rs
+++ b/crates/burn-tensor/src/tensor/quantization/strategy.rs
@@ -1,169 +1,40 @@
-use alloc::{vec, vec::Vec};
-use burn_common::{iter_slice_par, run_par};
+use alloc::vec::Vec;
 use core::marker::PhantomData;
 use num_traits::{Float, PrimInt, Signed};
 use serde::{Deserialize, Serialize};
 
-use crate::{Element, ElementConversion};
-
-use super::{BlockLayout, QuantizationMode, QuantizationScheme, QuantizationType};
+use super::{QuantizationMode, QuantizationScheme, QuantizationType};
 
 /// Quantization strategy.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum QuantizationStrategy {
-    /// Per-tensor `int8` affine/asymmetric quantization.
-    PerTensorAffineInt8(AffineQuantization<f32, i8, i32>),
     /// Per-tensor `int8` symmetric quantization.
     PerTensorSymmetricInt8(SymmetricQuantization<f32, i8>),
-    /// Per-block `int8` affine/asymmetric quantization.
-    PerBlockAffineInt8(Vec<AffineQuantization<f32, i8, i32>>, BlockLayout),
-    /// Per-block `int8` symmetric quantization.
-    PerBlockSymmetricInt8(Vec<SymmetricQuantization<f32, i8>>, BlockLayout),
 }
 
 impl QuantizationStrategy {
     /// Quantize the values to a lower precision data type.
-    pub fn quantize(&self, values: &[f32], shape: &[usize]) -> Vec<i8> {
+    pub fn quantize(&self, values: &[f32]) -> Vec<i8> {
         match self {
-            QuantizationStrategy::PerTensorAffineInt8(strategy) => strategy.quantize(values),
             QuantizationStrategy::PerTensorSymmetricInt8(strategy) => strategy.quantize(values),
-            QuantizationStrategy::PerBlockAffineInt8(strategy, layout) => match layout {
-                BlockLayout::Flat(block_size) => {
-                    apply_per_block(values, *block_size as usize, |block_id, v| {
-                        strategy[block_id].quantize(v)
-                    })
-                }
-                BlockLayout::Grid(m, n) => {
-                    apply_per_block_grid(values, shape, *m as usize, *n as usize, |block_id, v| {
-                        strategy[block_id].quantize_one(v)
-                    })
-                }
-            },
-            QuantizationStrategy::PerBlockSymmetricInt8(strategy, layout) => match layout {
-                BlockLayout::Flat(block_size) => {
-                    apply_per_block(values, *block_size as usize, |block_id, v| {
-                        strategy[block_id].quantize(v)
-                    })
-                }
-                BlockLayout::Grid(m, n) => {
-                    apply_per_block_grid(values, shape, *m as usize, *n as usize, |block_id, v| {
-                        strategy[block_id].quantize_one(v)
-                    })
-                }
-            },
         }
     }
 
     /// Dequantize the values to a higher precision data type.
-    pub fn dequantize(&self, values: &[i8], shape: &[usize]) -> Vec<f32> {
+    pub fn dequantize(&self, values: &[i8]) -> Vec<f32> {
         match self {
-            QuantizationStrategy::PerTensorAffineInt8(strategy) => strategy.dequantize(values),
             QuantizationStrategy::PerTensorSymmetricInt8(strategy) => strategy.dequantize(values),
-            QuantizationStrategy::PerBlockAffineInt8(strategy, layout) => match layout {
-                BlockLayout::Flat(block_size) => {
-                    apply_per_block(values, *block_size as usize, |block_id, v| {
-                        strategy[block_id].dequantize(v)
-                    })
-                }
-                BlockLayout::Grid(m, n) => {
-                    apply_per_block_grid(values, shape, *m as usize, *n as usize, |block_id, v| {
-                        strategy[block_id].dequantize_one(v)
-                    })
-                }
-            },
-            QuantizationStrategy::PerBlockSymmetricInt8(strategy, layout) => match layout {
-                BlockLayout::Flat(block_size) => {
-                    apply_per_block(values, *block_size as usize, |block_id, v| {
-                        strategy[block_id].dequantize(v)
-                    })
-                }
-                BlockLayout::Grid(m, n) => {
-                    apply_per_block_grid(values, shape, *m as usize, *n as usize, |block_id, v| {
-                        strategy[block_id].dequantize_one(v)
-                    })
-                }
-            },
         }
     }
-}
-
-fn apply_per_block_grid<I: Element, O: Element, F: Fn(usize, I) -> O>(
-    values: &[I],
-    shape: &[usize],
-    m: usize,
-    n: usize,
-    transform: F,
-) -> Vec<O> {
-    let (b, height, width) = match shape.len() {
-        2 => (1, shape[0], shape[1]),
-        3 => (shape[0], shape[1], shape[2]),
-        _ => unimplemented!("Per-block grid quantization is only supported for 2D or 3D tensors"),
-    };
-    assert!(
-        height % m == 0 && width % n == 0,
-        "Invalid per-block quantization with block grid [{m}, {n}] and tensor of shape {shape:?}"
-    );
-    let mut output = vec![0.elem::<O>(); values.len()];
-
-    let mut block_id = 0;
-    // TODO: parallel
-    for ih in (0..b * height).step_by(m) {
-        for iw in (0..width).step_by(n) {
-            // block height
-            for bh in 0..m {
-                let start_idx = (ih + bh) * width + iw;
-                // block width
-                for bw in 0..n {
-                    let elem_idx = start_idx + bw;
-                    let x_q = transform(block_id, values[elem_idx]);
-                    output[elem_idx] = x_q;
-                }
-            }
-            block_id += 1;
-        }
-    }
-    output
-}
-
-fn apply_per_block<I: Element, O: Element, F: Fn(usize, &[I]) -> Vec<O>>(
-    values: &[I],
-    block_size: usize,
-    transform: F,
-) -> Vec<O> {
-    let numel = values.len();
-    assert_eq!(
-        numel % block_size,
-        0,
-        "Invalid per-block quantization with block size {block_size} and {numel} values"
-    );
-    // TODO: parallel chunks
-    values
-        .chunks(block_size)
-        .enumerate()
-        .flat_map(|(block_id, block)| transform(block_id, block))
-        .collect()
 }
 
 impl QuantizationStrategy {
     /// Returns the corresponding quantization scheme.
     pub fn scheme(&self) -> QuantizationScheme {
         match self {
-            QuantizationStrategy::PerTensorAffineInt8(_) => {
-                QuantizationScheme::PerTensor(QuantizationMode::Affine, QuantizationType::QInt8)
-            }
             QuantizationStrategy::PerTensorSymmetricInt8(_) => {
                 QuantizationScheme::PerTensor(QuantizationMode::Symmetric, QuantizationType::QInt8)
             }
-            QuantizationStrategy::PerBlockSymmetricInt8(_, layout) => QuantizationScheme::PerBlock(
-                QuantizationMode::Symmetric,
-                QuantizationType::QInt8,
-                *layout,
-            ),
-            QuantizationStrategy::PerBlockAffineInt8(_, layout) => QuantizationScheme::PerBlock(
-                QuantizationMode::Affine,
-                QuantizationType::QInt8,
-                *layout,
-            ),
         }
     }
 }
@@ -185,19 +56,6 @@ pub trait Quantization<E: Float + Send + Sync, Q: PrimInt + Send + Sync> {
     fn dequantize_one(&self, value: Q) -> E;
 }
 
-/// Affine quantization scheme.
-///
-/// Note that the accumulation type `A` should have a bigger range than quantized type `Q`.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub struct AffineQuantization<E: Float + Send + Sync, Q: PrimInt + Send + Sync, A: PrimInt> {
-    /// The scaling factor.
-    pub scale: E,
-    /// The zero-point offset.
-    pub offset: Q,
-    /// Accumulation type.
-    _a: PhantomData<A>,
-}
-
 fn valid_scale<E: Float>(mut scale: E) -> E {
     // If scale is 0 (most likely due to a tensor full of zeros), we arbitrarily adjust the
     // scale to 0.1 to avoid division by zero.
@@ -205,83 +63,6 @@ fn valid_scale<E: Float>(mut scale: E) -> E {
         scale = E::from(0.1).unwrap();
     }
     scale
-}
-
-impl<E: Float + Send + Sync, Q: PrimInt + Send + Sync, A: PrimInt> AffineQuantization<E, Q, A> {
-    /// Initialize an affine quantization scheme with the given parameters.
-    pub fn init(scale: E, offset: Q) -> Self {
-        Self {
-            scale: valid_scale(scale),
-            offset,
-            _a: PhantomData,
-        }
-    }
-}
-
-impl<E: Float + Send + Sync, Q: PrimInt + Send + Sync, A: PrimInt + Send + Sync> Quantization<E, Q>
-    for AffineQuantization<E, Q, A>
-{
-    fn new(alpha: E, beta: E) -> Self {
-        let (a, b) = Self::range();
-        let a = E::from(a).unwrap();
-        let b = E::from(b).unwrap();
-
-        // We extend the `[alpha, beta]` interval to ensure that it contains 0.
-        // Otherwise, we would not meet the requirement that 0 be an exactly
-        // representable value (zero-point).
-        let alpha = E::min(alpha, E::zero());
-        let beta = E::max(beta, E::zero());
-
-        // Compute scale and offset to convert a floating point value in range `[alpha, beta]` to the quantized range
-        let scale = valid_scale((beta - alpha) / (b - a));
-        let z = -(alpha / scale - a);
-        Self {
-            scale,
-            offset: Q::from(z).unwrap(),
-            _a: PhantomData,
-        }
-    }
-
-    fn quantize(&self, values: &[E]) -> Vec<Q> {
-        run_par!(|| {
-            iter_slice_par!(values)
-                .map(|x| self.quantize_one(*x))
-                .collect()
-        })
-    }
-
-    fn dequantize(&self, values: &[Q]) -> Vec<E> {
-        run_par!(|| {
-            iter_slice_par!(values)
-                .map(|x_q| self.dequantize_one(*x_q))
-                .collect()
-        })
-    }
-
-    fn quantize_one(&self, value: E) -> Q {
-        let (a, b) = Self::range();
-        let a = E::from(a).unwrap();
-        let b = E::from(b).unwrap();
-
-        // x_q = clamp(round(x / scale + offset), a, b)
-        let z = E::from(self.offset).unwrap();
-        Q::from(value.div(self.scale).add(z).round().clamp(a, b)).unwrap()
-    }
-
-    fn dequantize_one(&self, value: Q) -> E {
-        // x = scale * (x_q - offset)
-        self.scale
-            * (E::from(
-                A::from(value)
-                    .unwrap()
-                    .saturating_sub(A::from(self.offset).unwrap()),
-            )
-            .unwrap())
-    }
-
-    fn range() -> (Q, Q) {
-        (Q::min_value(), Q::max_value())
-    }
 }
 
 /// Symmetric quantization scheme.
@@ -349,19 +130,6 @@ impl<E: Float + Send + Sync, Q: PrimInt + Signed + Send + Sync> Quantization<E, 
     }
 }
 
-impl<E: Float + Send + Sync, Q: PrimInt + Send + Sync, A: PrimInt> PartialEq
-    for AffineQuantization<E, Q, A>
-{
-    fn eq(&self, other: &Self) -> bool {
-        self.scale == other.scale && self.offset == other.offset
-    }
-}
-
-impl<E: Float + Send + Sync, Q: PrimInt + Send + Sync, A: PrimInt> Eq
-    for AffineQuantization<E, Q, A>
-{
-}
-
 impl<E: Float + Send + Sync, Q: PrimInt + Signed + Send + Sync> PartialEq
     for SymmetricQuantization<E, Q>
 {
@@ -377,41 +145,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_int8_affine_quantization() {
-        let x: [f32; 4] = [-1.8, -1.0, 0.0, 0.5];
-        let expected_q = vec![-128, -40, 71, 126];
-        let expected_d = vec![-1.794902, -1.0011765, 0.0, 0.49607843];
-
-        let affine = AffineQuantization::<f32, i8, i32>::new(-1.8, 0.5);
-
-        let q = affine.quantize(&x);
-        assert_eq!(q, expected_q);
-
-        let d = affine.dequantize(&expected_q);
-
-        assert_eq!(d, expected_d);
-    }
-
-    #[test]
-    fn test_affine_should_ensure_zero_point() {
-        let x: [f32; 6] = [2.0, 1.0, 2.0, 3.0, 4.0, 5.0];
-        let expected_q = vec![-26, -77, -26, 25, 76, 127];
-        let expected_d = x.to_vec();
-
-        let affine = AffineQuantization::<f32, i8, i32>::new(1.0, 5.0);
-
-        assert_eq!(affine.offset, -128);
-        assert_eq!(affine.scale, 0.019607844);
-
-        let q = affine.quantize(&x);
-        assert_eq!(q, expected_q);
-
-        let d = affine.dequantize(&expected_q);
-
-        assert_eq!(d, expected_d);
-    }
-
-    #[test]
     fn test_int8_symmetric_quantization() {
         let x: [f32; 4] = [-1.8, -1.0, 0.0, 0.5];
         let expected_q = vec![-127, -71, 0, 35];
@@ -423,160 +156,6 @@ mod tests {
         assert_eq!(q, expected_q);
 
         let d = symmetric.dequantize(&expected_q);
-
-        assert_eq!(d, expected_d);
-    }
-
-    #[test]
-    fn test_int8_symmetric_quantization_per_block_flat() {
-        let x: [f32; 8] = [-1.8, -1.0, 0.0, 0.5, -1.8, -1.0, 0.0, 0.5];
-        let shape = &[2, 4];
-        let expected_q = vec![-127, -71, 0, 35, -127, -71, 0, 35];
-        let expected_d = vec![
-            -1.8, -1.0062993, 0.0, 0.496063, -1.8, -1.0062993, 0.0, 0.496063,
-        ];
-
-        let symmetric = SymmetricQuantization::<f32, i8>::new(-1.8, 0.5);
-        let strategy = QuantizationStrategy::PerBlockSymmetricInt8(
-            vec![symmetric, symmetric],
-            BlockLayout::Flat(4),
-        );
-
-        let q: Vec<i8> = strategy.quantize(&x, shape);
-        assert_eq!(q, expected_q);
-
-        let d = symmetric.dequantize(&expected_q);
-
-        assert_eq!(d, expected_d);
-    }
-
-    #[test]
-    fn test_int8_affine_quantization_per_block_flat() {
-        let x = [
-            [-1.8, -1.0, 0.0, 0.5],
-            [-0.8, 1.2, 0.25, 0.5],
-            [-8., 12., 2.5, 5.],
-            [0.2, 0.3, 0.4, 0.5],
-        ]
-        .concat();
-        let shape = &[2, 8];
-        let expected_q = [
-            [-128i8, -40, 71, 126],
-            [-128, 127, 6, 38],
-            [-128, 127, 6, 38],
-            [-26, 25, 76, 127],
-        ]
-        .concat();
-        let expected_d = [
-            [-1.794902, -1.0011765, 0.0, 0.49607843],
-            [-0.8000001, 1.2, 0.2509804, 0.5019608],
-            [-8.0, 12.0, 2.509804, 5.019608],
-            [0.20000002, 0.3, 0.40000004, 0.5],
-        ]
-        .concat();
-
-        // Affine quantization for each block with range min/max
-        let per_block_strategy = vec![
-            AffineQuantization::<f32, i8, i32>::new(-1.8, 0.5),
-            AffineQuantization::<f32, i8, i32>::new(-0.8, 1.2),
-            AffineQuantization::<f32, i8, i32>::new(-8., 12.),
-            AffineQuantization::<f32, i8, i32>::new(0.2, 0.5),
-        ];
-        let strategy =
-            QuantizationStrategy::PerBlockAffineInt8(per_block_strategy, BlockLayout::Flat(4));
-
-        let q: Vec<i8> = strategy.quantize(&x, shape);
-        assert_eq!(q, expected_q);
-
-        let d = strategy.dequantize(&expected_q, shape);
-
-        assert_eq!(d, expected_d);
-    }
-
-    #[test]
-    fn test_int8_symmetric_quantization_per_block_grid() {
-        let x: [f32; 8] = [-1.8, -1.0, 0.0, 0.5, 0.5, 0.0, -1.0, -1.8];
-        let shape = &[2, 4];
-        let expected_q = vec![-127, -71, 0, 35, 35, 0, -71, -127];
-        let expected_d = vec![
-            -1.8, -1.0062993, 0.0, 0.496063, 0.496063, 0.0, -1.0062993, -1.8,
-        ];
-
-        let symmetric = SymmetricQuantization::<f32, i8>::new(-1.8, 0.5);
-        let strategy = QuantizationStrategy::PerBlockSymmetricInt8(
-            vec![symmetric, symmetric],
-            BlockLayout::Grid(2, 2),
-        );
-
-        let q: Vec<i8> = strategy.quantize(&x, shape);
-        assert_eq!(q, expected_q);
-
-        let d = strategy.dequantize(&expected_q, shape);
-
-        assert_eq!(d, expected_d);
-    }
-
-    #[test]
-    fn test_int8_symmetric_quantization_per_block_grid_3d() {
-        let shape = &[2, 4, 4];
-        let x = [
-            // 2x2 blocks: [[-1.8, -1.0, 0.0, 0.5], [-0.8, 1.2, 0.25, 0.5]]
-            [-1.8, -1.0, -0.8, 1.2],
-            [0.0, 0.5, 0.25, 0.5],
-            // 2x2 blocks: [[-0.08, 0.12, 0.025, 0.05], [0.2, 0.3, 0.4, 0.5]]
-            [-0.08, 0.12, 0.2, 0.3],
-            [0.025, 0.05, 0.4, 0.5],
-            // 2x2 blocks: [[0.01, 0.03, 0.02, 0.06], [4.0, 3.0, 2.0, 1.0]]
-            [0.01, 0.03, 4.0, 3.0],
-            [0.02, 0.06, 2.0, 1.0],
-            // 2x2 blocks: [[0.4, 0.3, 0.2, 0.1], [0.5, 0.0, -1.0, -1.8]]
-            [0.4, 0.3, 0.5, 0.0],
-            [0.2, 0.1, -1.0, -1.8],
-        ]
-        .concat(); // easier to visualize with a vec of rows
-        let expected_q = [
-            [-127, -71, -85, 127],
-            [0, 35, 26, 53],
-            [-85, 127, 51, 76],
-            [26, 53, 102, 127],
-            [21, 64, 127, 95],
-            [42, 127, 64, 32],
-            [127, 95, 35, 0],
-            [64, 32, -71, -127],
-        ]
-        .concat();
-        let expected_d = [
-            [-1.8, -1.0062993, -0.8031496, 1.2],
-            [0.0, 0.496063, 0.24566929, 0.5007874],
-            [-0.08031496, 0.12, 0.2007874, 0.2992126],
-            [0.024566928, 0.05007874, 0.4015748, 0.5],
-            [0.009921259, 0.03023622, 4.0, 2.992126],
-            [0.019842518, 0.06, 2.015748, 1.007874],
-            [0.4, 0.2992126, 0.496063, 0.0],
-            [0.2015748, 0.1007874, -1.0062993, -1.8],
-        ]
-        .concat();
-
-        // Symmetric quantization for each block with range min/max
-        let per_block_strategy = vec![
-            SymmetricQuantization::<f32, i8>::new(-1.8, 0.5),
-            SymmetricQuantization::<f32, i8>::new(-0.8, 1.2),
-            SymmetricQuantization::<f32, i8>::new(-0.08, 0.12),
-            SymmetricQuantization::<f32, i8>::new(0.2, 0.5),
-            SymmetricQuantization::<f32, i8>::new(0.01, 0.06),
-            SymmetricQuantization::<f32, i8>::new(1.0, 4.0),
-            SymmetricQuantization::<f32, i8>::new(0.1, 0.4),
-            SymmetricQuantization::<f32, i8>::new(-1.8, 0.5),
-        ];
-        let strategy = QuantizationStrategy::PerBlockSymmetricInt8(
-            per_block_strategy,
-            BlockLayout::Grid(2, 2),
-        );
-
-        let q: Vec<i8> = strategy.quantize(&x, shape);
-        assert_eq!(q, expected_q);
-
-        let d = strategy.dequantize(&expected_q, shape);
 
         assert_eq!(d, expected_d);
     }

--- a/crates/burn-tensor/src/tests/mod.rs
+++ b/crates/burn-tensor/src/tests/mod.rs
@@ -377,6 +377,7 @@ pub mod qtensor {
         pub fn int8<F: Into<TensorData>>(floats: F) -> Tensor<B, D> {
             Self::int8_symmetric(floats)
         }
+
         /// Creates a quantized int8 tensor from the floating point data using per-tensor symmetric quantization.
         pub fn int8_symmetric<F: Into<TensorData>>(floats: F) -> Tensor<B, D> {
             Tensor::from_floats(floats, &Default::default()).quantize_dynamic(
@@ -384,12 +385,6 @@ pub mod qtensor {
                     QuantizationMode::Symmetric,
                     QuantizationType::QInt8,
                 ),
-            )
-        }
-        /// Creates a quantized int8 tensor from the floating point data using per-tensor affine quantization.
-        pub fn int8_affine<F: Into<TensorData>>(floats: F) -> Tensor<B, D> {
-            Tensor::from_floats(floats, &Default::default()).quantize_dynamic(
-                &QuantizationScheme::PerTensor(QuantizationMode::Affine, QuantizationType::QInt8),
             )
         }
     }

--- a/crates/burn-tensor/src/tests/quantization/calibration.rs
+++ b/crates/burn-tensor/src/tests/quantization/calibration.rs
@@ -3,9 +3,7 @@ mod tests {
     use super::*;
     use burn_tensor::{
         Tensor, TensorData,
-        quantization::{
-            BlockLayout, Calibration, QuantizationMode, QuantizationScheme, QuantizationType,
-        },
+        quantization::{Calibration, QuantizationMode, QuantizationScheme, QuantizationType},
     };
 
     // NOTE: The scheme variant fields are not important for calibration, only the "main" variant (e.g., per-tensor)
@@ -13,7 +11,7 @@ mod tests {
     fn min_max_calibration_range_per_tensor() {
         let tensor = TestTensor::<1>::from_floats([-1.8, -1.0, 0.0, 0.5], &Default::default());
         let scheme =
-            QuantizationScheme::PerTensor(QuantizationMode::Affine, QuantizationType::QInt8);
+            QuantizationScheme::PerTensor(QuantizationMode::Symmetric, QuantizationType::QInt8);
 
         let range = scheme.compute_range(&tensor, &Calibration::MinMax);
 
@@ -25,107 +23,5 @@ mod tests {
             .max
             .into_data()
             .assert_eq(&TensorData::from([0.5]), false);
-    }
-
-    #[test]
-    fn min_max_calibration_range_per_block_flat_all() {
-        let tensor = TestTensor::<2>::from_floats(
-            [[-1.8, -1.0, 0.0, 0.5], [1., 2., 3., 4.]],
-            &Default::default(),
-        );
-        let scheme = QuantizationScheme::PerBlock(
-            QuantizationMode::Affine,
-            QuantizationType::QInt8,
-            BlockLayout::Flat(8),
-        );
-
-        let range = scheme.compute_range(&tensor, &Calibration::MinMax);
-
-        range
-            .min
-            .into_data()
-            .assert_eq(&TensorData::from([-1.8]), false);
-        range
-            .max
-            .into_data()
-            .assert_eq(&TensorData::from([4.]), false);
-    }
-
-    #[test]
-    fn min_max_calibration_range_per_block_flat_row() {
-        let tensor = TestTensor::<2>::from_floats(
-            [[-1.8, -1.0, 0.0, 0.5], [1., 2., 3., 4.]],
-            &Default::default(),
-        );
-        let scheme = QuantizationScheme::PerBlock(
-            QuantizationMode::Affine,
-            QuantizationType::QInt8,
-            BlockLayout::Flat(4),
-        );
-
-        let range = scheme.compute_range(&tensor, &Calibration::MinMax);
-        range
-            .min
-            .into_data()
-            .assert_eq(&TensorData::from([-1.8, 1.]), false);
-        range
-            .max
-            .into_data()
-            .assert_eq(&TensorData::from([0.5, 4.]), false);
-    }
-
-    #[test]
-    #[should_panic(expected = "Cannot compute per-block quantization range")]
-    fn min_max_calibration_range_per_block_flat_invalid() {
-        let tensor = TestTensor::<2>::from_floats(
-            [[-1.8, -1.0, 0.0, 0.5], [1., 2., 3., 4.]],
-            &Default::default(),
-        );
-        let scheme = QuantizationScheme::PerBlock(
-            QuantizationMode::Affine,
-            QuantizationType::QInt8,
-            BlockLayout::Flat(3),
-        );
-        let _ = scheme.compute_range(&tensor, &Calibration::MinMax);
-    }
-
-    #[test]
-    fn min_max_calibration_range_per_block_grid() {
-        let tensor = TestTensor::<2>::from_floats(
-            [[-1.8, -1.0, 0.0, 0.5], [1., 2., 3., 4.]],
-            &Default::default(),
-        );
-        let scheme = QuantizationScheme::PerBlock(
-            QuantizationMode::Affine,
-            QuantizationType::QInt8,
-            BlockLayout::Grid(2, 2),
-        );
-
-        let range = scheme.compute_range(&tensor, &Calibration::MinMax);
-
-        range
-            .min
-            .into_data()
-            .assert_eq(&TensorData::from([-1.8, 0.]), false);
-        range
-            .max
-            .into_data()
-            .assert_eq(&TensorData::from([2., 4.]), false);
-    }
-
-    #[test]
-    #[should_panic(expected = "Cannot compute per-block quantization range")]
-    fn min_max_calibration_range_per_block_grid_invalid() {
-        let tensor = TestTensor::<2>::from_floats(
-            [[-1.8, -1.0, 0.0, 0.5], [1., 2., 3., 4.]],
-            &Default::default(),
-        );
-        let scheme = QuantizationScheme::PerBlock(
-            QuantizationMode::Affine,
-            QuantizationType::QInt8,
-            BlockLayout::Grid(3, 3),
-        );
-
-        let _ = scheme.compute_range(&tensor, &Calibration::MinMax);
     }
 }

--- a/crates/burn-tensor/src/tests/quantization/data.rs
+++ b/crates/burn-tensor/src/tests/quantization/data.rs
@@ -3,7 +3,7 @@ mod tests {
     use super::*;
     use alloc::{vec, vec::Vec};
     use burn_tensor::quantization::{
-        AffineQuantization, BlockLayout, QuantizationStrategy, SymmetricQuantization,
+        QuantizationStrategy, SymmetricQuantization,
     };
     use burn_tensor::{Tensor, TensorData};
 
@@ -12,18 +12,6 @@ mod tests {
     // Also std feature gated (until `catch_unwind` is stable in core).
     #[cfg(feature = "std")]
     use burn_tensor::might_panic;
-
-    #[test]
-    fn should_support_per_tensor_affine_int8() {
-        let data = TensorData::quantized(
-            vec![-128i8, -39, 72, 127],
-            [4],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.009_019_608, 72)),
-        );
-        let tensor = TestTensor::<1>::from_data(data.clone(), &Default::default());
-
-        tensor.into_data().assert_eq(&data, true);
-    }
 
     #[test]
     fn should_support_per_tensor_symmetric_int8() {
@@ -35,74 +23,6 @@ mod tests {
             )),
         );
         let tensor = TestTensor::<1>::from_data(data.clone(), &Default::default());
-
-        tensor.into_data().assert_eq(&data, true);
-    }
-
-    #[cfg(feature = "std")]
-    #[might_panic(reason = "Per-block quantization is not supported")]
-    #[test]
-    fn should_support_per_block_flat() {
-        // Per-block qparams
-        let data = TensorData::quantized(
-            vec![
-                [-127i8, -71, 0, 35, -56, 85, 18, 35],
-                [-20, 30, 6, 13, 51, 76, 102, 127],
-            ]
-            .concat(),
-            [2, 8],
-            QuantizationStrategy::PerBlockAffineInt8(
-                vec![
-                    AffineQuantization::init(0.009019608, 71),
-                    AffineQuantization::init(0.007843138, -26),
-                    AffineQuantization::init(0.00078431366, -25),
-                    AffineQuantization::init(0.0019607844, -128),
-                ],
-                BlockLayout::Flat(4),
-            ),
-        );
-        let tensor = TestTensor::<2>::from_data(data.clone(), &Default::default());
-
-        tensor.into_data().assert_eq(&data, true);
-    }
-
-    #[cfg(feature = "std")]
-    #[might_panic(reason = "Per-block quantization is not supported")]
-    #[test]
-    fn should_support_per_block_grid() {
-        // Per-block qparams
-        let scales: [f32; 8] = [
-            0.014173228,
-            0.009448819,
-            0.0009448819,
-            0.003937008,
-            0.00047244094,
-            0.031496063,
-            0.0031496063,
-            0.014173228,
-        ];
-        let data = TensorData::quantized(
-            vec![
-                [-127i8, -71, -85, 127],
-                [0, 35, 26, 53],
-                [-85, 127, 51, 76],
-                [26, 53, 102, 127],
-                [21, 64, 127, 95],
-                [42, 127, 64, 32],
-                [127, 95, 35, 0],
-                [64, 32, -71, -127],
-            ]
-            .concat(),
-            [8, 4],
-            QuantizationStrategy::PerBlockSymmetricInt8(
-                scales
-                    .iter()
-                    .map(|&s| SymmetricQuantization::init(s))
-                    .collect(),
-                BlockLayout::Grid(2, 2),
-            ),
-        );
-        let tensor = TestTensor::<2>::from_data(data.clone(), &Default::default());
 
         tensor.into_data().assert_eq(&data, true);
     }

--- a/crates/burn-tensor/src/tests/quantization/data.rs
+++ b/crates/burn-tensor/src/tests/quantization/data.rs
@@ -2,9 +2,7 @@
 mod tests {
     use super::*;
     use alloc::{vec, vec::Vec};
-    use burn_tensor::quantization::{
-        QuantizationStrategy, SymmetricQuantization,
-    };
+    use burn_tensor::quantization::{QuantizationStrategy, SymmetricQuantization};
     use burn_tensor::{Tensor, TensorData};
 
     // NOTE: we mark the per-block tests as `might_panic` since backends are not strictly

--- a/crates/burn-tensor/src/tests/quantization/ops/aggregation.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/aggregation.rs
@@ -127,8 +127,7 @@ mod tests {
             .into_data()
             .assert_approx_eq::<FT>(&TensorData::from([240.0]), Tolerance::absolute(1e-1));
 
-        let tensor_with_zero =
-            QTensor::<TestBackend, 2>::int8([[2.0, 0.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor_with_zero = QTensor::<TestBackend, 2>::int8([[2.0, 0.0, 2.0], [3.0, 4.0, 5.0]]);
         let output = tensor_with_zero.prod();
 
         output
@@ -149,8 +148,7 @@ mod tests {
             Tolerance::absolute(1e-1),
         );
 
-        let tensor_with_zero =
-            QTensor::<TestBackend, 2>::int8([[2.0, 0.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor_with_zero = QTensor::<TestBackend, 2>::int8([[2.0, 0.0, 2.0], [3.0, 4.0, 5.0]]);
         let output = tensor_with_zero.prod_dim(1);
         let expected = TensorData::from([[0.0], [60.0]]);
 

--- a/crates/burn-tensor/src/tests/quantization/ops/aggregation.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/aggregation.rs
@@ -118,8 +118,7 @@ mod tests {
 
     #[test]
     fn test_prod_float() {
-        // NOTE: we use affine quantization to reduce quantization errors since `prod()` amplifies the error
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[2.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[2.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.prod();
 
@@ -129,7 +128,7 @@ mod tests {
             .assert_approx_eq::<FT>(&TensorData::from([240.0]), Tolerance::absolute(1e-1));
 
         let tensor_with_zero =
-            QTensor::<TestBackend, 2>::int8_affine([[2.0, 0.0, 2.0], [3.0, 4.0, 5.0]]);
+            QTensor::<TestBackend, 2>::int8([[2.0, 0.0, 2.0], [3.0, 4.0, 5.0]]);
         let output = tensor_with_zero.prod();
 
         output
@@ -140,8 +139,7 @@ mod tests {
 
     #[test]
     fn test_prod_dim_float() {
-        // NOTE: we use affine quantization to reduce quantization errors since `prod()` amplifies the error
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[2.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[2.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.prod_dim(1);
 
@@ -152,7 +150,7 @@ mod tests {
         );
 
         let tensor_with_zero =
-            QTensor::<TestBackend, 2>::int8_affine([[2.0, 0.0, 2.0], [3.0, 4.0, 5.0]]);
+            QTensor::<TestBackend, 2>::int8([[2.0, 0.0, 2.0], [3.0, 4.0, 5.0]]);
         let output = tensor_with_zero.prod_dim(1);
         let expected = TensorData::from([[0.0], [60.0]]);
 

--- a/crates/burn-tensor/src/tests/quantization/ops/cosh.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/cosh.rs
@@ -7,8 +7,7 @@ mod tests {
 
     #[test]
     fn should_support_cosh_ops() {
-        // NOTE: we use affine quantization to reduce quantization errors for range of input values
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.cosh();
         let expected = TensorData::from([[1.0000, 1.5431, 3.7622], [10.0677, 27.3082, 74.2100]]);

--- a/crates/burn-tensor/src/tests/quantization/ops/exp.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/exp.rs
@@ -7,8 +7,7 @@ mod tests {
 
     #[test]
     fn should_support_exp_ops() {
-        // NOTE: we use affine quantization to reduce quantization errors since `exp()` amplifies the error
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.exp();
         let expected = TensorData::from([[1.0, 2.71830, 7.3891], [20.0855, 54.5981, 148.4132]]);

--- a/crates/burn-tensor/src/tests/quantization/ops/map_comparison.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/map_comparison.rs
@@ -3,11 +3,10 @@ mod tests {
     use super::*;
     use burn_tensor::TensorData;
 
-    // NOTE: we use affine quantization to reduce quantization errors since equality tests are precise
     #[test]
     fn test_equal() {
-        let tensor_1 = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let tensor_2 = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 1.0], [3.0, 5.0, 4.0]]);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 1.0], [3.0, 5.0, 4.0]]);
 
         let data_actual_cloned = tensor_1.clone().equal(tensor_2.clone());
         let data_actual_inplace = tensor_1.equal(tensor_2);
@@ -19,8 +18,8 @@ mod tests {
 
     #[test]
     fn test_not_equal() {
-        let tensor_1 = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let tensor_2 = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 1.0], [3.0, 5.0, 4.0]]);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 1.0], [3.0, 5.0, 4.0]]);
 
         let data_actual_cloned = tensor_1.clone().not_equal(tensor_2.clone());
         let data_actual_inplace = tensor_1.not_equal(tensor_2);
@@ -32,7 +31,7 @@ mod tests {
 
     #[test]
     fn test_equal_elem() {
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 2.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 2.0, 5.0]]);
 
         let data_actual_cloned = tensor.clone().equal_elem(2);
         let data_actual_inplace = tensor.equal_elem(2);
@@ -44,7 +43,7 @@ mod tests {
 
     #[test]
     fn test_not_equal_elem() {
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 2.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 2.0, 5.0]]);
 
         let data_actual_cloned = tensor.clone().not_equal_elem(2);
         let data_actual_inplace = tensor.not_equal_elem(2);
@@ -56,7 +55,7 @@ mod tests {
 
     #[test]
     fn test_greater_elem() {
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let data_actual_cloned = tensor.clone().greater_elem(4);
         let data_actual_inplace = tensor.greater_elem(4);
@@ -68,7 +67,7 @@ mod tests {
 
     #[test]
     fn test_greater_equal_elem() {
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let data_actual_cloned = tensor.clone().greater_equal_elem(4.0);
         let data_actual_inplace = tensor.greater_equal_elem(4.0);
@@ -80,8 +79,8 @@ mod tests {
 
     #[test]
     fn test_greater() {
-        let tensor_1 = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let tensor_2 = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 1.0], [3.0, 5.0, 4.0]]);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 1.0], [3.0, 5.0, 4.0]]);
 
         let data_actual_cloned = tensor_1.clone().greater(tensor_2.clone());
         let data_actual_inplace = tensor_1.greater(tensor_2);
@@ -93,8 +92,8 @@ mod tests {
 
     #[test]
     fn test_greater_equal() {
-        let tensor_1 = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 1.0], [3.0, 4.0, 5.0]]);
-        let tensor_2 = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 5.0, 4.0]]);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 1.0], [3.0, 4.0, 5.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 5.0, 4.0]]);
 
         let data_actual_cloned = tensor_1.clone().greater_equal(tensor_2.clone());
         let data_actual_inplace = tensor_1.greater_equal(tensor_2);
@@ -106,7 +105,7 @@ mod tests {
 
     #[test]
     fn test_lower_elem() {
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let data_actual_cloned = tensor.clone().lower_elem(4.0);
         let data_actual_inplace = tensor.lower_elem(4.0);
@@ -118,7 +117,7 @@ mod tests {
 
     #[test]
     fn test_lower_equal_elem() {
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let data_actual_cloned = tensor.clone().lower_equal_elem(4.0);
         let data_actual_inplace = tensor.lower_equal_elem(4.0);
@@ -130,8 +129,8 @@ mod tests {
 
     #[test]
     fn test_lower() {
-        let tensor_1 = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 1.0], [3.0, 4.0, 5.0]]);
-        let tensor_2 = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 5.0, 4.0]]);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 1.0], [3.0, 4.0, 5.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 5.0, 4.0]]);
 
         let data_actual_cloned = tensor_1.clone().lower(tensor_2.clone());
         let data_actual_inplace = tensor_1.lower(tensor_2);
@@ -143,8 +142,8 @@ mod tests {
 
     #[test]
     fn test_lower_equal() {
-        let tensor_1 = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let tensor_2 = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 1.0], [3.0, 5.0, 4.0]]);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 1.0], [3.0, 5.0, 4.0]]);
 
         let data_actual_cloned = tensor_1.clone().lower_equal(tensor_2.clone());
         let data_actual_inplace = tensor_1.lower_equal(tensor_2);

--- a/crates/burn-tensor/src/tests/quantization/ops/maxmin.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/maxmin.rs
@@ -5,10 +5,9 @@ mod tests {
     use burn_tensor::{Tolerance, ops::FloatElem};
     type FT = FloatElem<TestBackend>;
 
-    // NOTE: we use affine quantization to reduce quantization errors for range of input values
     #[test]
     fn test_max_dim_2d() {
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.max_dim(1);
         let expected = TensorData::from([[2.], [5.]]);
@@ -18,7 +17,7 @@ mod tests {
 
     #[test]
     fn test_max_dim_with_indices_2d_with_dim_0th() {
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let (output, index) = tensor.max_dim_with_indices(0);
 
@@ -34,7 +33,7 @@ mod tests {
 
     #[test]
     fn test_max_dim_with_indices_2d() {
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let (output, index) = tensor.max_dim_with_indices(1);
 
@@ -50,7 +49,7 @@ mod tests {
 
     #[test]
     fn test_min_dim_2d() {
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.min_dim(1);
 
@@ -61,7 +60,7 @@ mod tests {
 
     #[test]
     fn test_min_dim_with_indices_2d() {
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let (output, index) = tensor.min_dim_with_indices(1);
 
@@ -77,7 +76,7 @@ mod tests {
 
     #[test]
     fn test_min_dim_2d_with_0th_dim() {
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.min_dim(0);
         let expected = TensorData::from([[0., 1., 2.]]);
@@ -87,7 +86,7 @@ mod tests {
 
     #[test]
     fn test_max_dim_2d_with_0th_dim() {
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.max_dim(0);
         let expected = TensorData::from([[3., 4., 5.]]);
@@ -97,7 +96,7 @@ mod tests {
 
     #[test]
     fn test_min_dim_with_indices_2d_with_0th_dim() {
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let (output, index) = tensor.min_dim_with_indices(0);
 
@@ -113,8 +112,8 @@ mod tests {
 
     #[test]
     fn test_maximum_pair() {
-        let a = QTensor::<TestBackend, 1>::int8_affine([1.0, 5.0, 3.0, 4.0]);
-        let b = QTensor::<TestBackend, 1>::int8_affine([2.0, 1.0, 4.0, 5.0]);
+        let a = QTensor::<TestBackend, 1>::int8([1.0, 5.0, 3.0, 4.0]);
+        let b = QTensor::<TestBackend, 1>::int8([2.0, 1.0, 4.0, 5.0]);
 
         let output = a.max_pair(b);
         let expected = TensorData::from([2.0, 5.0, 4.0, 5.0]);
@@ -127,8 +126,8 @@ mod tests {
 
     #[test]
     fn test_minimum_pair() {
-        let a = QTensor::<TestBackend, 1>::int8_affine([1.0, 5.0, 3.0, 4.0]);
-        let b = QTensor::<TestBackend, 1>::int8_affine([2.0, 1.0, 4.0, 5.0]);
+        let a = QTensor::<TestBackend, 1>::int8([1.0, 5.0, 3.0, 4.0]);
+        let b = QTensor::<TestBackend, 1>::int8([2.0, 1.0, 4.0, 5.0]);
 
         let output = a.min_pair(b);
         let expected = TensorData::from([1.0, 1.0, 3.0, 4.0]);

--- a/crates/burn-tensor/src/tests/quantization/ops/narrow.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/narrow.rs
@@ -5,11 +5,10 @@ mod tests {
     use burn_tensor::{Tolerance, ops::FloatElem};
     type FT = FloatElem<TestBackend>;
 
-    // NOTE: we use affine quantization to reduce quantization errors for range of input values
     #[test]
     fn test_narrow() {
         let tensor =
-            QTensor::<TestBackend, 2>::int8_affine([[1., 2., 3.], [7., 8., 9.], [13., 14., 15.]]);
+            QTensor::<TestBackend, 2>::int8([[1., 2., 3.], [7., 8., 9.], [13., 14., 15.]]);
 
         let output = tensor.clone().narrow(0, 0, 2);
         let expected = TensorData::from([[1., 2., 3.], [7., 8., 9.]]);
@@ -33,7 +32,7 @@ mod tests {
     #[should_panic]
     fn test_narrow_invalid_dim() {
         let tensor =
-            QTensor::<TestBackend, 2>::int8_affine([[1., 2., 3.], [7., 8., 9.], [13., 14., 15.]]);
+            QTensor::<TestBackend, 2>::int8([[1., 2., 3.], [7., 8., 9.], [13., 14., 15.]]);
 
         let output = tensor.narrow(2, 0, 2);
     }
@@ -42,7 +41,7 @@ mod tests {
     #[should_panic]
     fn test_narrow_invalid_start() {
         let tensor =
-            QTensor::<TestBackend, 2>::int8_affine([[1., 2., 3.], [7., 8., 9.], [13., 14., 15.]]);
+            QTensor::<TestBackend, 2>::int8([[1., 2., 3.], [7., 8., 9.], [13., 14., 15.]]);
 
         let output = tensor.narrow(0, 3, 2);
     }
@@ -51,7 +50,7 @@ mod tests {
     #[should_panic]
     fn test_narrow_invalid_zero_length() {
         let tensor =
-            QTensor::<TestBackend, 2>::int8_affine([[1., 2., 3.], [7., 8., 9.], [13., 14., 15.]]);
+            QTensor::<TestBackend, 2>::int8([[1., 2., 3.], [7., 8., 9.], [13., 14., 15.]]);
 
         let output = tensor.narrow(0, 1, 0);
     }
@@ -60,7 +59,7 @@ mod tests {
     #[should_panic]
     fn test_narrow_invalid_length() {
         let tensor =
-            QTensor::<TestBackend, 2>::int8_affine([[1., 2., 3.], [7., 8., 9.], [13., 14., 15.]]);
+            QTensor::<TestBackend, 2>::int8([[1., 2., 3.], [7., 8., 9.], [13., 14., 15.]]);
 
         let output = tensor.narrow(0, 0, 4);
     }

--- a/crates/burn-tensor/src/tests/quantization/ops/narrow.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/narrow.rs
@@ -7,8 +7,7 @@ mod tests {
 
     #[test]
     fn test_narrow() {
-        let tensor =
-            QTensor::<TestBackend, 2>::int8([[1., 2., 3.], [7., 8., 9.], [13., 14., 15.]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[1., 2., 3.], [7., 8., 9.], [13., 14., 15.]]);
 
         let output = tensor.clone().narrow(0, 0, 2);
         let expected = TensorData::from([[1., 2., 3.], [7., 8., 9.]]);
@@ -31,8 +30,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_narrow_invalid_dim() {
-        let tensor =
-            QTensor::<TestBackend, 2>::int8([[1., 2., 3.], [7., 8., 9.], [13., 14., 15.]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[1., 2., 3.], [7., 8., 9.], [13., 14., 15.]]);
 
         let output = tensor.narrow(2, 0, 2);
     }
@@ -40,8 +38,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_narrow_invalid_start() {
-        let tensor =
-            QTensor::<TestBackend, 2>::int8([[1., 2., 3.], [7., 8., 9.], [13., 14., 15.]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[1., 2., 3.], [7., 8., 9.], [13., 14., 15.]]);
 
         let output = tensor.narrow(0, 3, 2);
     }
@@ -49,8 +46,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_narrow_invalid_zero_length() {
-        let tensor =
-            QTensor::<TestBackend, 2>::int8([[1., 2., 3.], [7., 8., 9.], [13., 14., 15.]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[1., 2., 3.], [7., 8., 9.], [13., 14., 15.]]);
 
         let output = tensor.narrow(0, 1, 0);
     }
@@ -58,8 +54,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_narrow_invalid_length() {
-        let tensor =
-            QTensor::<TestBackend, 2>::int8([[1., 2., 3.], [7., 8., 9.], [13., 14., 15.]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[1., 2., 3.], [7., 8., 9.], [13., 14., 15.]]);
 
         let output = tensor.narrow(0, 0, 4);
     }

--- a/crates/burn-tensor/src/tests/quantization/ops/permute.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/permute.rs
@@ -3,10 +3,9 @@ mod tests {
     use super::*;
     use burn_tensor::TensorData;
 
-    // NOTE: we use affine quantization to reduce quantization errors for the given values range
     #[test]
     fn permute_float() {
-        let tensor = QTensor::<TestBackend, 1>::int8_affine([
+        let tensor = QTensor::<TestBackend, 1>::int8([
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         ])
         .reshape([2, 2, 4]);
@@ -40,7 +39,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn edge_repeated_axes() {
-        let tensor = QTensor::<TestBackend, 1>::int8_affine([
+        let tensor = QTensor::<TestBackend, 1>::int8([
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         ])
         .reshape([2, 2, 4]);
@@ -52,7 +51,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn edge_out_of_bound_axis() {
-        let tensor = QTensor::<TestBackend, 1>::int8_affine([
+        let tensor = QTensor::<TestBackend, 1>::int8([
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         ])
         .reshape([2, 2, 4]);

--- a/crates/burn-tensor/src/tests/quantization/ops/powf.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/powf.rs
@@ -7,9 +7,8 @@ mod tests {
 
     #[test]
     fn should_support_powf_ops() {
-        // NOTE: we use affine quantization to reduce quantization errors
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[1.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let tensor_pow = QTensor::<TestBackend, 2>::int8_affine([[1.0, 1.0, 2.0], [3.0, 4.0, 2.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[1.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor_pow = QTensor::<TestBackend, 2>::int8([[1.0, 1.0, 2.0], [3.0, 4.0, 2.0]]);
 
         let output = tensor.powf(tensor_pow);
         let expected = TensorData::from([[1.0, 1.0, 4.0], [27.0, 256.0, 25.0]]);

--- a/crates/burn-tensor/src/tests/quantization/ops/quantize.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/quantize.rs
@@ -4,9 +4,8 @@ mod tests {
     use super::*;
     use alloc::{vec, vec::Vec};
     use burn_tensor::quantization::{
-        AffineQuantization, BlockLayout, QParams, QuantizationMode, QuantizationParameters,
-        QuantizationScheme, QuantizationStrategy, QuantizationType, QuantizedBytes,
-        SymmetricQuantization,
+        QParams, QuantizationMode, QuantizationParameters, QuantizationScheme,
+        QuantizationStrategy, QuantizationType, QuantizedBytes, SymmetricQuantization,
     };
     use burn_tensor::{DType, Tensor, TensorData};
     use burn_tensor::{Tolerance, ops::FloatElem};
@@ -25,47 +24,6 @@ mod tests {
             num_elements,
         };
         q_bytes.into_vec_i8().1
-    }
-
-    #[test]
-    fn should_support_quantize_affine_int8() {
-        let device = Default::default();
-        let tensor = TestTensor::<1>::from_floats([-1.8, -1.0, 0.0, 0.5], &device);
-        let scheme =
-            QuantizationScheme::PerTensor(QuantizationMode::Affine, QuantizationType::QInt8);
-        let qparams = QuantizationParameters {
-            scale: Tensor::from_floats([0.009_019_608], &device),
-            offset: Some(Tensor::from_ints([72], &device)),
-        };
-
-        let x_q = tensor.clone().quantize(&scheme, qparams);
-
-        let x_q_data = x_q.to_data();
-        let expected = TensorData::quantized(
-            vec![-128i8, -39, 72, 127],
-            [4],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.009_019_608, 72)),
-        );
-
-        // Values equality
-        x_q_data.assert_eq(&expected, true);
-
-        // Quantization parameters check
-        let qparams = get_q_params(x_q_data);
-        let expected = get_q_params(expected);
-        assert_eq!(qparams.scale.len(), 1);
-        assert_eq!(qparams.scale, expected.scale);
-        assert_eq!(qparams.offset.as_ref().map(|x| x.len()), Some(1));
-        assert_eq!(qparams.offset, expected.offset);
-
-        // Dequantize
-        let x = x_q.dequantize();
-
-        // Precision 2 for dequantization errors
-        x.into_data().assert_approx_eq::<FT>(
-            &tensor.into_data(),
-            Tolerance::absolute(1e-1).set_relative(1e-2),
-        );
     }
 
     #[test]
@@ -118,262 +76,16 @@ mod tests {
         // due to rounding discrepancies
         let tensor = TestTensor::<1>::from_floats([5., 0., 4., -10.], &device);
         let scheme =
-            QuantizationScheme::PerTensor(QuantizationMode::Affine, QuantizationType::QInt8);
+            QuantizationScheme::PerTensor(QuantizationMode::Symmetric, QuantizationType::QInt8);
 
         let x_q = tensor.quantize_dynamic(&scheme);
 
         let expected = TensorData::quantized(
             vec![127i8, 42, 110, -128],
             [4],
-            QuantizationStrategy::PerTensorAffineInt8(AffineQuantization::init(0.05882353, 42)),
+            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.05882353)),
         );
 
         x_q.into_data().assert_eq(&expected, false);
-    }
-
-    #[cfg(feature = "std")]
-    #[test]
-    #[ignore] // WIP
-    fn should_support_quantize_per_block_symmetric_int8() {
-        let device = Default::default();
-        let tensor = TestTensor::<2>::from_floats(
-            [
-                [-1.8, -1.0, 0.0, 0.5],
-                [-0.8, 1.2, 0.25, 0.5],
-                [-0.08, 0.12, 0.025, 0.05],
-                [0.2, 0.3, 0.4, 0.5],
-                [0.1, 0.3, 0.2, 0.6],
-                [4.0, 3.0, 2.0, 1.0],
-                [0.4, 0.3, 0.2, 0.1],
-                [0.5, 0.0, -1.0, -1.8],
-            ],
-            &device,
-        );
-        let scheme = QuantizationScheme::PerBlock(
-            QuantizationMode::Symmetric,
-            QuantizationType::QInt8,
-            BlockLayout::Flat(4),
-        );
-
-        // Per-block qparams
-        let scales: [f32; 8] = [
-            0.014173228,
-            0.009448819,
-            0.0009448819,
-            0.003937008,
-            0.0047244094,
-            0.031496063,
-            0.0031496063,
-            0.014173228,
-        ];
-        let qparams = QuantizationParameters {
-            scale: Tensor::from_floats(scales, &device),
-            offset: None,
-        };
-
-        let x_q = tensor.clone().quantize(&scheme, qparams);
-
-        let x_q_data = x_q.to_data();
-        let expected = TensorData::quantized(
-            vec![
-                [-127i8, -71, 0, 35],
-                [-85, 127, 26, 53],
-                [-85, 127, 26, 53],
-                [51, 76, 102, 127],
-                [21, 64, 42, 127],
-                [127, 95, 64, 32],
-                [127, 95, 64, 32],
-                [35, 0, -71, -127],
-            ]
-            .concat(),
-            [8, 4],
-            QuantizationStrategy::PerBlockSymmetricInt8(
-                scales
-                    .iter()
-                    .map(|&s| SymmetricQuantization::init(s))
-                    .collect(),
-                BlockLayout::Flat(4),
-            ),
-        );
-
-        // Values equality
-        x_q_data.assert_eq(&expected, true);
-
-        // Quantization parameters check
-        let qparams = get_q_params(x_q_data);
-        let expected = get_q_params(expected);
-        assert_eq!(qparams.scale.len(), 8);
-        assert_eq!(qparams.scale, expected.scale);
-        assert_eq!(qparams.offset, None);
-        assert_eq!(qparams.offset, expected.offset);
-
-        // Dequantize
-        let x = x_q.dequantize();
-
-        // Precision 2 for dequantization errors
-        x.into_data().assert_approx_eq::<FT>(
-            &tensor.into_data(),
-            Tolerance::absolute(1e-1).set_relative(1e-2),
-        );
-    }
-
-    #[allow(clippy::excessive_precision)]
-    #[cfg(feature = "std")]
-    #[test]
-    #[ignore] // WIP
-    fn should_support_quantize_per_block_affine_int8() {
-        let device = Default::default();
-        let tensor = TestTensor::<2>::from_floats(
-            [
-                [-1.8, -1.0, 0.0, 0.5, -0.8, 1.2, 0.25, 0.5],
-                [-8., 12., 2.5, 5., 0.2, 0.3, 0.4, 0.5],
-            ],
-            &device,
-        );
-        let scheme = QuantizationScheme::PerBlock(
-            QuantizationMode::Affine,
-            QuantizationType::QInt8,
-            BlockLayout::Flat(4),
-        );
-
-        // Per-block qparams
-        let scales: [f32; 4] = [0.009019608, 0.007843138, 0.078431366, 0.0019607844];
-        let offsets: [i8; 4] = [71, -26, -26, -128];
-        let qparams = QuantizationParameters {
-            scale: Tensor::from_floats(scales, &device),
-            offset: Some(Tensor::from_ints(offsets, &device)),
-        };
-
-        let x_q = tensor.clone().quantize(&scheme, qparams);
-
-        let x_q_data = x_q.to_data();
-        let expected = TensorData::quantized(
-            vec![
-                [-128i8, -40, 71, 126],
-                [-128, 127, 6, 38],
-                [-128, 127, 6, 38],
-                [-26, 25, 76, 127],
-            ]
-            .concat(),
-            [2, 8],
-            QuantizationStrategy::PerBlockAffineInt8(
-                scales
-                    .iter()
-                    .zip(offsets.iter())
-                    .map(|(&s, &o)| AffineQuantization::init(s, o))
-                    .collect(),
-                BlockLayout::Flat(4),
-            ),
-        );
-
-        // Values equality
-        x_q_data.assert_eq(&expected, true);
-
-        // Quantization parameters check
-        let qparams = get_q_params(x_q_data);
-        let expected = get_q_params(expected);
-        assert_eq!(qparams.scale.len(), 4);
-        assert_eq!(qparams.scale, expected.scale);
-        assert_eq!(qparams.offset.as_ref().unwrap().len(), 4);
-        assert_eq!(qparams.offset, expected.offset);
-
-        // Dequantize
-        let x = x_q.dequantize();
-
-        // Precision 2 for dequantization errors
-        x.into_data().assert_approx_eq::<FT>(
-            &tensor.into_data(),
-            Tolerance::absolute(1e-1).set_relative(1e-2),
-        );
-    }
-
-    #[cfg(feature = "std")]
-    #[test]
-    #[ignore] // WIP
-    fn should_support_quantize_per_block_grid_symmetric_int8() {
-        let device = Default::default();
-        let tensor = TestTensor::<2>::from_floats(
-            [
-                // 2x2 blocks: [[-1.8, -1.0, 0.0, 0.5], [-0.8, 1.2, 0.25, 0.5]]
-                [-1.8, -1.0, -0.8, 1.2],
-                [0.0, 0.5, 0.25, 0.5],
-                // 2x2 blocks: [[-0.8, 1.2, 0.25, 0.5], [0.2, 0.3, 0.4, 0.5]]
-                [-0.8, 1.2, 0.2, 0.3],
-                [0.25, 0.5, 0.4, 0.5],
-                // 2x2 blocks: [[0.1, 0.3, 0.2, 0.6], [4.0, 3.0, 2.0, 1.0]]
-                [0.1, 0.3, 4.0, 3.0],
-                [0.2, 0.6, 2.0, 1.0],
-                // 2x2 blocks: [[0.4, 0.3, 0.2, 0.1], [0.5, 0.0, -1.0, -1.8]]
-                [0.4, 0.3, 0.5, 0.0],
-                [0.2, 0.1, -1.0, -1.8],
-            ],
-            &device,
-        );
-        let scheme = QuantizationScheme::PerBlock(
-            QuantizationMode::Symmetric,
-            QuantizationType::QInt8,
-            BlockLayout::Grid(2, 2),
-        );
-
-        // Per-block qparams
-        let scales: [f32; 8] = [
-            0.014173228,
-            0.009448819,
-            0.009448819,
-            0.003937008,
-            0.0047244094,
-            0.031496063,
-            0.0031496063,
-            0.014173228,
-        ];
-        let qparams = QuantizationParameters {
-            scale: Tensor::from_floats(scales, &device),
-            offset: None,
-        };
-
-        let x_q = tensor.clone().quantize(&scheme, qparams);
-
-        let x_q_data = x_q.to_data();
-        let expected = TensorData::quantized(
-            vec![
-                [-127i8, -71, -85, 127],
-                [0, 35, 26, 53],
-                [-85, 127, 51, 76],
-                [26, 53, 102, 127],
-                [21, 64, 127, 95],
-                [42, 127, 64, 32],
-                [127, 95, 35, 0],
-                [64, 32, -71, -127],
-            ]
-            .concat(),
-            [8, 4],
-            QuantizationStrategy::PerBlockSymmetricInt8(
-                scales
-                    .iter()
-                    .map(|&s| SymmetricQuantization::init(s))
-                    .collect(),
-                BlockLayout::Grid(2, 2),
-            ),
-        );
-
-        // Values equality
-        x_q_data.assert_eq(&expected, true);
-
-        // Quantization parameters check
-        let qparams = get_q_params(x_q_data);
-        let expected = get_q_params(expected);
-        assert_eq!(qparams.scale.len(), 8);
-        assert_eq!(qparams.scale, expected.scale);
-        assert_eq!(qparams.offset, None);
-        assert_eq!(qparams.offset, expected.offset);
-
-        // Dequantize
-        let x = x_q.dequantize();
-
-        // Precision 2 for dequantization errors
-        x.into_data().assert_approx_eq::<FT>(
-            &tensor.into_data(),
-            Tolerance::absolute(1e-1).set_relative(1e-2),
-        );
     }
 }

--- a/crates/burn-tensor/src/tests/quantization/ops/quantize.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/quantize.rs
@@ -74,16 +74,16 @@ mod tests {
         let device = Default::default();
         // NOTE: we use fully representable values since different backend implementations could differ slightly
         // due to rounding discrepancies
-        let tensor = TestTensor::<1>::from_floats([5., 0., 4., -10.], &device);
+        let tensor = TestTensor::<1>::from_floats([5., 0., 4., -12.7], &device);
         let scheme =
             QuantizationScheme::PerTensor(QuantizationMode::Symmetric, QuantizationType::QInt8);
 
         let x_q = tensor.quantize_dynamic(&scheme);
 
         let expected = TensorData::quantized(
-            vec![127i8, 42, 110, -128],
+            vec![50i8, 0, 40, -127],
             [4],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.05882353)),
+            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.1)),
         );
 
         x_q.into_data().assert_eq(&expected, false);

--- a/crates/burn-tensor/src/tests/quantization/ops/remainder.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/remainder.rs
@@ -22,8 +22,7 @@ mod tests {
 
     #[test]
     fn should_support_remainder_basic_scalar() {
-        // NOTE: we use affine quantization to reduce quantization errors for range of input values
-        let tensor = QTensor::<TestBackend, 1>::int8_affine([-3.0, -2.0, -1.0, 1.0, 2.0, 3.0]);
+        let tensor = QTensor::<TestBackend, 1>::int8([-3.0, -2.0, -1.0, 1.0, 2.0, 3.0]);
 
         let output = tensor.remainder_scalar(2.0);
         let expected = TensorData::from([1.0, 0.0, 1.0, 1.0, 0.0, 1.0]);
@@ -203,8 +202,7 @@ mod tests {
 
     #[test]
     fn should_support_remainder_scalar_op() {
-        // NOTE: we use affine quantization to reduce quantization errors for range of input values
-        let tensor = QTensor::<TestBackend, 1>::int8_affine([-3.0, -2.0, -1.0, 1.0, 2.0, 3.0]);
+        let tensor = QTensor::<TestBackend, 1>::int8([-3.0, -2.0, -1.0, 1.0, 2.0, 3.0]);
 
         let output = tensor % 2.0;
         let expected = TensorData::from([1.0, 0.0, 1.0, 1.0, 0.0, 1.0]);

--- a/crates/burn-tensor/src/tests/quantization/ops/repeat_dim.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/repeat_dim.rs
@@ -3,10 +3,9 @@ mod tests {
     use super::*;
     use burn_tensor::TensorData;
 
-    // NOTE: we use affine quantization to reduce quantization errors for range of input values
     #[test]
     fn should_support_repeat_ops() {
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0, 3.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0, 3.0]]);
 
         let output = tensor.repeat_dim(0, 4);
         let expected = TensorData::from([
@@ -21,7 +20,7 @@ mod tests {
 
     #[test]
     fn should_support_repeat_on_dims_larger_than_1() {
-        let tensor = QTensor::<TestBackend, 1>::int8_affine([
+        let tensor = QTensor::<TestBackend, 1>::int8([
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         ])
         .reshape([4, 2, 2]);

--- a/crates/burn-tensor/src/tests/quantization/ops/reshape.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/reshape.rs
@@ -3,10 +3,9 @@ mod tests {
     use super::*;
     use burn_tensor::TensorData;
 
-    // NOTE: we use affine quantization to reduce quantization errors for range of input values
     #[test]
     fn should_support_reshape_1d() {
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0, 3.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0, 3.0]]);
 
         let output = tensor.clone().reshape([1, 4]);
         let expected = TensorData::from([[0.0, 1.0, 2.0, 3.0]]);
@@ -16,7 +15,7 @@ mod tests {
 
     #[test]
     fn should_support_reshape_2d() {
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.clone().reshape([6]);
         let expected = TensorData::from([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]);
@@ -26,7 +25,7 @@ mod tests {
 
     #[test]
     fn should_support_dim_infererence() {
-        let tensor = QTensor::<TestBackend, 1>::int8_affine([
+        let tensor = QTensor::<TestBackend, 1>::int8([
             0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0,
         ])
         .reshape([4, 3]);

--- a/crates/burn-tensor/src/tests/quantization/ops/select.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/select.rs
@@ -5,10 +5,9 @@ mod tests {
     use burn_tensor::{Tolerance, ops::FloatElem};
     type FT = FloatElem<TestBackend>;
 
-    // NOTE: we use affine quantization to reduce quantization errors for range of input values
     #[test]
     fn should_select_1d() {
-        let tensor = QTensor::<TestBackend, 1>::int8_affine([0.0, 1.0, 2.0, 3.0]);
+        let tensor = QTensor::<TestBackend, 1>::int8([0.0, 1.0, 2.0, 3.0]);
         let indices = TestTensorInt::from_data([1, 1, 0, 1, 2], &Default::default());
 
         let output = tensor.select(0, indices);
@@ -19,7 +18,7 @@ mod tests {
 
     #[test]
     fn should_select_2d_dim0_same_num_dim() {
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
         let indices = TestTensorInt::from_data(([1, 0]), &Default::default());
 
         let output = tensor.select(0, indices);
@@ -30,7 +29,7 @@ mod tests {
 
     #[test]
     fn should_select_2d_dim0_more_num_dim() {
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
         let indices = TestTensorInt::from_data([1, 0, 1, 1], &Default::default());
 
         let output = tensor.select(0, indices);
@@ -46,7 +45,7 @@ mod tests {
 
     #[test]
     fn should_select_2d_dim1() {
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
         let indices = TestTensorInt::from_data([1, 1, 0, 1, 2], &Default::default());
 
         let output = tensor.select(1, indices);
@@ -57,8 +56,8 @@ mod tests {
 
     #[test]
     fn should_select_assign_1d() {
-        let tensor = QTensor::<TestBackend, 1>::int8_affine([0.0, 1.0, 2.0]);
-        let values = QTensor::<TestBackend, 1>::int8_affine([5.0, 4.0, 3.0, 2.0, 1.0]);
+        let tensor = QTensor::<TestBackend, 1>::int8([0.0, 1.0, 2.0]);
+        let values = QTensor::<TestBackend, 1>::int8([5.0, 4.0, 3.0, 2.0, 1.0]);
         let indices =
             TestTensorInt::from_data(TensorData::from([1, 1, 0, 1, 2]), &Default::default());
 
@@ -74,7 +73,7 @@ mod tests {
 
     #[test]
     fn should_select_assign_2d_dim0() {
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
         let values = tensor.clone();
         let indices = TestTensorInt::from_data(TensorData::from([1, 0]), &Default::default());
 
@@ -90,7 +89,7 @@ mod tests {
 
     #[test]
     fn should_select_assign_2d_dim1() {
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
         let values = tensor.clone();
         let indices = TestTensorInt::from_data(TensorData::from([1, 0, 2]), &Default::default());
 
@@ -107,7 +106,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn should_select_panic_invalid_dimension() {
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
         let indices = TestTensorInt::from_data([1, 1, 0, 1, 2], &Default::default());
 
         tensor.select(10, indices);

--- a/crates/burn-tensor/src/tests/quantization/ops/sin.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/sin.rs
@@ -7,8 +7,7 @@ mod tests {
 
     #[test]
     fn should_support_sin_ops() {
-        // NOTE: we use affine quantization to reduce quantization errors for range of input values
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.sin();
         let expected = TensorData::from([[0.0, 0.8414, 0.9092], [0.1411, -0.7568, -0.9589]]);

--- a/crates/burn-tensor/src/tests/quantization/ops/sinh.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/sinh.rs
@@ -7,8 +7,7 @@ mod tests {
 
     #[test]
     fn should_support_sinh_ops() {
-        // NOTE: we use affine quantization to reduce quantization errors for range of input values
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.sinh();
         let expected = TensorData::from([[0.0000, 1.1752, 3.6269], [10.0179, 27.2899, 74.2032]]);

--- a/crates/burn-tensor/src/tests/quantization/ops/slice.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/slice.rs
@@ -5,10 +5,9 @@ mod tests {
     use burn_tensor::{Tolerance, ops::FloatElem};
     type FT = FloatElem<TestBackend>;
 
-    // NOTE: we use affine quantization to reduce quantization errors for range of input values
     #[test]
     fn should_support_full_sliceing_1d() {
-        let tensor = QTensor::<TestBackend, 1>::int8_affine([0.0, 1.0, 2.0, 3.0]);
+        let tensor = QTensor::<TestBackend, 1>::int8([0.0, 1.0, 2.0, 3.0]);
         let data = tensor.to_data();
 
         let output = tensor.slice([0..4]);
@@ -18,7 +17,7 @@ mod tests {
 
     #[test]
     fn should_support_partial_sliceing_1d() {
-        let tensor = QTensor::<TestBackend, 1>::int8_affine([0.0, 1.0, 2.0, 3.0]);
+        let tensor = QTensor::<TestBackend, 1>::int8([0.0, 1.0, 2.0, 3.0]);
 
         let output = tensor.slice([1..3]);
         let expected = TensorData::from([1.0, 2.0]);
@@ -28,7 +27,7 @@ mod tests {
 
     #[test]
     fn should_support_full_sliceing_2d() {
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
         let data = tensor.to_data();
 
         let output = tensor.clone().slice([0..2]);
@@ -40,7 +39,7 @@ mod tests {
 
     #[test]
     fn should_support_partial_sliceing_2d() {
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.slice([0..2, 0..2]);
         let expected = TensorData::from([[0.0, 1.0], [3.0, 4.0]]);
@@ -50,7 +49,7 @@ mod tests {
 
     #[test]
     fn should_support_partial_sliceing_3d() {
-        let tensor = QTensor::<TestBackend, 3>::int8_affine([
+        let tensor = QTensor::<TestBackend, 3>::int8([
             [[0., 1., 2., 3.], [4., 5., 6., 7.]],
             [[8., 9., 10., 11.], [12., 13., 14., 15.]],
         ]);
@@ -63,7 +62,7 @@ mod tests {
 
     #[test]
     fn should_support_partial_sliceing_3d_non_contiguous() {
-        let tensor = QTensor::<TestBackend, 3>::int8_affine([
+        let tensor = QTensor::<TestBackend, 3>::int8([
             [[0., 1., 2., 3.], [4., 5., 6., 7.]],
             [[8., 9., 10., 11.], [12., 13., 14., 15.]],
         ]);
@@ -76,8 +75,8 @@ mod tests {
 
     #[test]
     fn should_support_slice_assign_1d() {
-        let tensor = QTensor::<TestBackend, 1>::int8_affine([0.0, 1.0, 2.0]);
-        let tensor_assigned = QTensor::<TestBackend, 1>::int8_affine([10.0, 5.0]);
+        let tensor = QTensor::<TestBackend, 1>::int8([0.0, 1.0, 2.0]);
+        let tensor_assigned = QTensor::<TestBackend, 1>::int8([10.0, 5.0]);
 
         let output = tensor.slice_assign([0..2], tensor_assigned);
         let expected = TensorData::from([10.0, 5.0, 2.0]);
@@ -91,8 +90,8 @@ mod tests {
 
     #[test]
     fn should_support_slice_assign_2d() {
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let tensor_assigned = QTensor::<TestBackend, 2>::int8_affine([[10.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor_assigned = QTensor::<TestBackend, 2>::int8([[10.0, 5.0]]);
 
         let output = tensor.slice_assign([1..2, 0..2], tensor_assigned);
         let expected = TensorData::from([[0.0, 1.0, 2.0], [10.0, 5.0, 5.0]]);
@@ -106,7 +105,7 @@ mod tests {
 
     #[test]
     fn slice_should_not_corrupt_potentially_inplace_operations() {
-        let tensor = QTensor::<TestBackend, 1>::int8_affine([1.0, 2.0, 3.0, 4.0, 5.0]);
+        let tensor = QTensor::<TestBackend, 1>::int8([1.0, 2.0, 3.0, 4.0, 5.0]);
         let tensor = tensor.clone().slice([0..3]) + tensor.clone().slice([2..5]);
 
         let expected = TensorData::from([4., 6., 8.]);
@@ -120,8 +119,8 @@ mod tests {
 
     #[test]
     fn slice_assign_should_not_corrupt_potentially_inplace_operations() {
-        let tensor = QTensor::<TestBackend, 1>::int8_affine([1.0, 2.0, 3.0, 4.0, 5.0]);
-        let values = QTensor::<TestBackend, 1>::int8_affine([10., 20., 30.]);
+        let tensor = QTensor::<TestBackend, 1>::int8([1.0, 2.0, 3.0, 4.0, 5.0]);
+        let values = QTensor::<TestBackend, 1>::int8([10., 20., 30.]);
 
         let tensor_1 = tensor.clone().slice_assign([0..3], values);
         let tensor_2 = tensor + 2;
@@ -145,7 +144,7 @@ mod tests {
 
     #[test]
     fn clamp_when_slice_exceeds_dimension() {
-        let tensor = QTensor::<TestBackend, 1>::int8_affine([0.0, 1.0, 2.0]);
+        let tensor = QTensor::<TestBackend, 1>::int8([0.0, 1.0, 2.0]);
         let data = tensor.to_data();
 
         let output = tensor.slice([0..4]);
@@ -154,7 +153,7 @@ mod tests {
 
     #[test]
     fn negative_dimensions() {
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
         let data = tensor.to_data();
 
         // Clamping to the tensor dimensions
@@ -172,7 +171,7 @@ mod tests {
 
     #[test]
     fn missing_dimensions() {
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
         let data = tensor.to_data();
 
         // Clamping to the tensor dimensions
@@ -201,7 +200,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn should_panic_when_slice_with_too_many_dimensions() {
-        let tensor = QTensor::<TestBackend, 1>::int8_affine([0.0, 1.0, 2.0]);
+        let tensor = QTensor::<TestBackend, 1>::int8([0.0, 1.0, 2.0]);
 
         let output = tensor.slice([0..1, 0..1]);
     }
@@ -209,7 +208,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn should_panic_when_slice_is_desc() {
-        let tensor = QTensor::<TestBackend, 1>::int8_affine([0.0, 1.0, 2.0]);
+        let tensor = QTensor::<TestBackend, 1>::int8([0.0, 1.0, 2.0]);
 
         #[allow(clippy::reversed_empty_ranges)]
         let output = tensor.slice([2..1]);
@@ -218,7 +217,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn should_panic_when_slice_is_equal() {
-        let tensor = QTensor::<TestBackend, 1>::int8_affine([0.0, 1.0, 2.0]);
+        let tensor = QTensor::<TestBackend, 1>::int8([0.0, 1.0, 2.0]);
 
         let output = tensor.slice([1..1]);
     }

--- a/crates/burn-tensor/src/tests/quantization/ops/sort_argsort.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/sort_argsort.rs
@@ -5,11 +5,10 @@ mod tests {
     use burn_tensor::{Tolerance, ops::FloatElem};
     type FT = FloatElem<TestBackend>;
 
-    // NOTE: we use affine quantization to reduce quantization errors for range of input values
     #[test]
     fn test_sort_1d_float() {
         // Quantized [0.5, 1.2, -0.21, 0., 2.1, 0.94, -0.3, 2.3, 5.2, 4., 0.99, 3., -8.1]
-        let tensor = QTensor::<TestBackend, 1>::int8_affine([
+        let tensor = QTensor::<TestBackend, 1>::int8([
             0.5, 1.2, -0.21, 0., 2.1, 0.94, -0.3, 2.3, 5.2, 4., 0.99, 3., -8.1,
         ]);
 
@@ -29,7 +28,7 @@ mod tests {
 
     #[test]
     fn test_argsort_1d_float() {
-        let tensor = QTensor::<TestBackend, 1>::int8_affine([
+        let tensor = QTensor::<TestBackend, 1>::int8([
             0.5, 1.2, -0.21, 0., 2.1, 0.94, -0.3, 2.3, 5.2, 4., 0.99, 3., -8.1,
         ]);
 
@@ -43,7 +42,7 @@ mod tests {
     #[test]
     fn test_sort_with_indices_descending_float() {
         // 1D
-        let tensor = QTensor::<TestBackend, 1>::int8_affine([
+        let tensor = QTensor::<TestBackend, 1>::int8([
             0.5, 1.2, -0.21, 0., 2.1, 0.94, -0.3, 2.3, 5.2, 4., 0.99, 3., -8.1,
         ]);
 
@@ -64,7 +63,7 @@ mod tests {
 
         // 3D
         // Quantized [-0.5, 1.2, -0.21, 0., 2.1, 0.94, -0.3, 2.3, 4., 0.99, 3., -8.1]
-        let tensor = QTensor::<TestBackend, 1>::int8_affine([
+        let tensor = QTensor::<TestBackend, 1>::int8([
             -0.5, 1.2, -0.21, 0., 2.1, 0.94, -0.3, 2.3, 4., 0.99, 3., -8.1,
         ])
         .reshape([2, 2, 3]);
@@ -88,7 +87,7 @@ mod tests {
 
     #[test]
     fn test_sort_float() {
-        let tensor = QTensor::<TestBackend, 1>::int8_affine([
+        let tensor = QTensor::<TestBackend, 1>::int8([
             -0.5, 1.2, -0.21, 0., 2.1, 0.94, -0.3, 2.3, 4., 0.99, 3., -8.1,
         ])
         .reshape([2, 2, 3]);
@@ -135,7 +134,7 @@ mod tests {
 
     #[test]
     fn test_sort_with_indices_float() {
-        let tensor = QTensor::<TestBackend, 1>::int8_affine([
+        let tensor = QTensor::<TestBackend, 1>::int8([
             -0.5, 1.2, -0.21, 0., 2.1, 0.94, -0.3, 2.3, 4., 0.99, 3., -8.1,
         ])
         .reshape([2, 2, 3]);
@@ -190,7 +189,7 @@ mod tests {
 
     #[test]
     fn test_argsort_float() {
-        let tensor = QTensor::<TestBackend, 1>::int8_affine([
+        let tensor = QTensor::<TestBackend, 1>::int8([
             -0.5, 1.2, -0.21, 0., 2.1, 0.94, -0.3, 2.3, 4., 0.99, 3., -8.1,
         ])
         .reshape([2, 2, 3]);
@@ -216,7 +215,7 @@ mod tests {
 
     #[test]
     fn test_sort_descending_1d() {
-        let tensor = QTensor::<TestBackend, 1>::int8_affine([1.0, 2.0, 3.0, 4.0, 5.0]);
+        let tensor = QTensor::<TestBackend, 1>::int8([1.0, 2.0, 3.0, 4.0, 5.0]);
 
         // Sort along dim=0
         let values = tensor.sort_descending(0);

--- a/crates/burn-tensor/src/tests/quantization/ops/sqrt.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/sqrt.rs
@@ -8,8 +8,7 @@ mod tests {
 
     #[test]
     fn should_support_sqrt_ops() {
-        // NOTE: we use affine quantization to reduce quantization errors for range of input values
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.sqrt();
         let expected = TensorData::from([[0.0, 1.0, SQRT_2], [1.73205, 2.0, 2.2360]]);

--- a/crates/burn-tensor/src/tests/quantization/ops/stack.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/stack.rs
@@ -6,11 +6,10 @@ mod tests {
     use burn_tensor::{Tolerance, ops::FloatElem};
     type FT = FloatElem<TestBackend>;
 
-    // NOTE: we use affine quantization to reduce quantization errors for range of input values
     #[test]
     fn should_support_stack_ops_2d_dim0() {
-        let tensor_1 = QTensor::<TestBackend, 2>::int8_affine([[1.0, 2.0, 3.0]]);
-        let tensor_2 = QTensor::<TestBackend, 2>::int8_affine([[4.0, 5.0, 6.0]]);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8([[1.0, 2.0, 3.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8([[4.0, 5.0, 6.0]]);
 
         let output = Tensor::stack::<3>(vec![tensor_1, tensor_2], 0);
         let expected = TensorData::from([[[1.0, 2.0, 3.0]], [[4.0, 5.0, 6.0]]]);
@@ -24,8 +23,8 @@ mod tests {
 
     #[test]
     fn should_support_stack_ops_2d_dim1() {
-        let tensor_1 = QTensor::<TestBackend, 2>::int8_affine([[1.0, 2.0, 3.0]]);
-        let tensor_2 = QTensor::<TestBackend, 2>::int8_affine([[4.0, 5.0, 6.0]]);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8([[1.0, 2.0, 3.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8([[4.0, 5.0, 6.0]]);
 
         let output = Tensor::stack::<3>(vec![tensor_1, tensor_2], 1);
         let expected = TensorData::from([[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]]);
@@ -40,9 +39,9 @@ mod tests {
     #[test]
     fn should_support_stack_ops_3d() {
         let tensor_1 =
-            QTensor::<TestBackend, 3>::int8_affine([[[1.0, 2.0, 3.0]], [[3.0, 2.0, 1.0]]]);
+            QTensor::<TestBackend, 3>::int8([[[1.0, 2.0, 3.0]], [[3.0, 2.0, 1.0]]]);
         let tensor_2 =
-            QTensor::<TestBackend, 3>::int8_affine([[[4.0, 5.0, 6.0]], [[6.0, 5.0, 4.0]]]);
+            QTensor::<TestBackend, 3>::int8([[[4.0, 5.0, 6.0]], [[6.0, 5.0, 4.0]]]);
 
         let output = Tensor::stack::<4>(vec![tensor_1, tensor_2], 0);
         let expected = TensorData::from([
@@ -60,8 +59,8 @@ mod tests {
     #[test]
     #[should_panic]
     fn should_panic_when_dimensions_are_not_the_same() {
-        let tensor_1 = QTensor::<TestBackend, 2>::int8_affine([[1.0, 2.0, 3.0]]);
-        let tensor_2 = QTensor::<TestBackend, 2>::int8_affine([[4.0, 5.0]]);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8([[1.0, 2.0, 3.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8([[4.0, 5.0]]);
 
         let output: TestTensor<3> = Tensor::stack(vec![tensor_1, tensor_2], 0);
     }
@@ -70,8 +69,8 @@ mod tests {
     #[should_panic]
     fn should_panic_when_stack_exceeds_dimension() {
         let tensor_1 =
-            QTensor::<TestBackend, 3>::int8_affine([[[1.0, 2.0, 3.0]], [[3.0, 2.0, 1.0]]]);
-        let tensor_2 = QTensor::<TestBackend, 3>::int8_affine([[[4.0, 5.0, 6.0]]]);
+            QTensor::<TestBackend, 3>::int8([[[1.0, 2.0, 3.0]], [[3.0, 2.0, 1.0]]]);
+        let tensor_2 = QTensor::<TestBackend, 3>::int8([[[4.0, 5.0, 6.0]]]);
 
         let output: TestTensor<4> = TestTensor::stack(vec![tensor_1, tensor_2], 3);
     }

--- a/crates/burn-tensor/src/tests/quantization/ops/stack.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/stack.rs
@@ -38,10 +38,8 @@ mod tests {
 
     #[test]
     fn should_support_stack_ops_3d() {
-        let tensor_1 =
-            QTensor::<TestBackend, 3>::int8([[[1.0, 2.0, 3.0]], [[3.0, 2.0, 1.0]]]);
-        let tensor_2 =
-            QTensor::<TestBackend, 3>::int8([[[4.0, 5.0, 6.0]], [[6.0, 5.0, 4.0]]]);
+        let tensor_1 = QTensor::<TestBackend, 3>::int8([[[1.0, 2.0, 3.0]], [[3.0, 2.0, 1.0]]]);
+        let tensor_2 = QTensor::<TestBackend, 3>::int8([[[4.0, 5.0, 6.0]], [[6.0, 5.0, 4.0]]]);
 
         let output = Tensor::stack::<4>(vec![tensor_1, tensor_2], 0);
         let expected = TensorData::from([
@@ -68,8 +66,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn should_panic_when_stack_exceeds_dimension() {
-        let tensor_1 =
-            QTensor::<TestBackend, 3>::int8([[[1.0, 2.0, 3.0]], [[3.0, 2.0, 1.0]]]);
+        let tensor_1 = QTensor::<TestBackend, 3>::int8([[[1.0, 2.0, 3.0]], [[3.0, 2.0, 1.0]]]);
         let tensor_2 = QTensor::<TestBackend, 3>::int8([[[4.0, 5.0, 6.0]]]);
 
         let output: TestTensor<4> = TestTensor::stack(vec![tensor_1, tensor_2], 3);

--- a/crates/burn-tensor/src/tests/quantization/ops/sub.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/sub.rs
@@ -5,11 +5,10 @@ mod tests {
     use burn_tensor::{Tolerance, ops::FloatElem};
     type FT = FloatElem<TestBackend>;
 
-    // NOTE: we use affine quantization to reduce quantization errors for range of input values
     #[test]
     fn should_support_sub_ops() {
-        let tensor_1 = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-        let tensor_2 = QTensor::<TestBackend, 2>::int8_affine([[6.0, 7.0, 8.0], [9.0, 10.0, 11.0]]);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8([[6.0, 7.0, 8.0], [9.0, 10.0, 11.0]]);
 
         let output = tensor_1 - tensor_2;
         let expected = TensorData::from([[-6.0, -6.0, -6.0], [-6.0, -6.0, -6.0]]);
@@ -23,8 +22,8 @@ mod tests {
 
     #[test]
     fn test_sub_broadcast() {
-        let tensor_1 = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0]]);
-        let tensor_2 = QTensor::<TestBackend, 2>::int8_affine([[3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]);
+        let tensor_1 = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0]]);
+        let tensor_2 = QTensor::<TestBackend, 2>::int8([[3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]);
 
         let output = tensor_1 - tensor_2;
         let expected = TensorData::from([[-3.0, -3.0, -3.0], [-6.0, -6.0, -6.0]]);
@@ -38,7 +37,7 @@ mod tests {
 
     #[test]
     fn should_support_sub_scalar_ops() {
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
         let scalar = 2.0;
 
         let output = tensor - scalar;

--- a/crates/burn-tensor/src/tests/quantization/ops/tan.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/tan.rs
@@ -7,8 +7,7 @@ mod tests {
 
     #[test]
     fn should_support_tan_ops() {
-        // NOTE: we use affine quantization to reduce quantization errors for range of input values
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.tan();
         let expected = TensorData::from([[0.0, 1.5574, -2.1850], [-0.1425, 1.1578, -3.3805]]);

--- a/crates/burn-tensor/src/tests/quantization/ops/tanh.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/tanh.rs
@@ -7,8 +7,7 @@ mod tests {
 
     #[test]
     fn should_support_tanh_ops() {
-        // NOTE: we use affine quantization to reduce quantization errors for range of input values
-        let tensor = QTensor::<TestBackend, 2>::int8_affine([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = QTensor::<TestBackend, 2>::int8([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 
         let output = tensor.tanh();
         let expected = TensorData::from([[0.0, 0.7615, 0.9640], [0.9950, 0.9993, 0.9999]]);

--- a/crates/burn-tensor/src/tests/quantization/ops/topk.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/topk.rs
@@ -5,10 +5,9 @@ mod tests {
     use burn_tensor::{Tolerance, ops::FloatElem};
     type FT = FloatElem<TestBackend>;
 
-    // NOTE: we use affine quantization to reduce quantization errors for range of input values
     #[test]
     fn test_topk_1d() {
-        let tensor = QTensor::<TestBackend, 1>::int8_affine([1.0, 2.0, 3.0, 4.0, 5.0]);
+        let tensor = QTensor::<TestBackend, 1>::int8([1.0, 2.0, 3.0, 4.0, 5.0]);
 
         let values = tensor.topk(3, /*dim*/ 0);
         let expected = TensorData::from([5., 4., 3.]);
@@ -21,7 +20,7 @@ mod tests {
 
     #[test]
     fn test_topk() {
-        let tensor = QTensor::<TestBackend, 3>::int8_affine([
+        let tensor = QTensor::<TestBackend, 3>::int8([
             [[1., 4., 7.], [2., 5., 6.]],
             [[3., 0., 9.], [8., 2., 7.]],
         ]);
@@ -39,7 +38,7 @@ mod tests {
     #[test]
     fn test_topk_with_indices() {
         // 1D
-        let tensor = QTensor::<TestBackend, 1>::int8_affine([1.0, 2.0, 3.0, 4.0, 5.0]);
+        let tensor = QTensor::<TestBackend, 1>::int8([1.0, 2.0, 3.0, 4.0, 5.0]);
 
         let (values, indices) = tensor.topk_with_indices(3, /*dim*/ 0);
 
@@ -56,7 +55,7 @@ mod tests {
     #[test]
     fn test_topk_with_indices_3d() {
         // 3D
-        let tensor = QTensor::<TestBackend, 3>::int8_affine([
+        let tensor = QTensor::<TestBackend, 3>::int8([
             [[1., 4., 7.], [2., 5., 6.]],
             [[3., 0., 9.], [8., 2., 7.]],
         ]);

--- a/crates/burn-tensor/src/tests/quantization/ops/transpose.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/transpose.rs
@@ -5,10 +5,9 @@ mod tests {
     use burn_tensor::{Tolerance, ops::FloatElem};
     type FT = FloatElem<TestBackend>;
 
-    // NOTE: we use affine quantization to reduce quantization errors for range of input values
     #[test]
     fn should_support_transpose_ops() {
-        let tensor = QTensor::<TestBackend, 1>::int8_affine([
+        let tensor = QTensor::<TestBackend, 1>::int8([
             0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0,
         ])
         .reshape([2, 2, 3]);
@@ -28,7 +27,7 @@ mod tests {
 
     #[test]
     fn should_support_swap_dims() {
-        let tensor = QTensor::<TestBackend, 1>::int8_affine([
+        let tensor = QTensor::<TestBackend, 1>::int8([
             0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0,
         ])
         .reshape([2, 2, 3]);

--- a/crates/burn-tensor/src/tests/quantization/scheme.rs
+++ b/crates/burn-tensor/src/tests/quantization/scheme.rs
@@ -3,9 +3,7 @@ mod tests {
     use super::*;
     use burn_tensor::{
         Tensor, TensorData,
-        quantization::{
-            CalibrationRange, QuantizationMode, QuantizationScheme, QuantizationType,
-        },
+        quantization::{CalibrationRange, QuantizationMode, QuantizationScheme, QuantizationType},
     };
     use burn_tensor::{Tolerance, ops::FloatElem};
     type FT = FloatElem<TestBackend>;

--- a/crates/burn-tensor/src/tests/quantization/scheme.rs
+++ b/crates/burn-tensor/src/tests/quantization/scheme.rs
@@ -4,34 +4,11 @@ mod tests {
     use burn_tensor::{
         Tensor, TensorData,
         quantization::{
-            BlockLayout, CalibrationRange, QuantizationMode, QuantizationScheme, QuantizationType,
+            CalibrationRange, QuantizationMode, QuantizationScheme, QuantizationType,
         },
     };
     use burn_tensor::{Tolerance, ops::FloatElem};
     type FT = FloatElem<TestBackend>;
-
-    #[test]
-    fn per_tensor_affine_int8() {
-        let device = Default::default();
-        let scheme =
-            QuantizationScheme::PerTensor(QuantizationMode::Affine, QuantizationType::QInt8);
-        let range = CalibrationRange {
-            min: TestTensor::<1>::from_floats([-1.8], &device),
-            max: TestTensor::<1>::from_floats([0.5], &device),
-        };
-
-        let qparams = scheme.compute_q_params(range);
-
-        qparams
-            .scale
-            .into_data()
-            .assert_approx_eq::<FT>(&TensorData::from([0.009_019_608]), Tolerance::default());
-        qparams
-            .offset
-            .unwrap()
-            .into_data()
-            .assert_eq(&TensorData::from([71]), false);
-    }
 
     #[test]
     fn per_tensor_symmetric_int8() {
@@ -49,54 +26,6 @@ mod tests {
             .scale
             .into_data()
             .assert_approx_eq::<FT>(&TensorData::from([0.014_173_228]), Tolerance::default());
-        assert!(qparams.offset.is_none());
-    }
-
-    #[test]
-    fn per_block_affine_int8() {
-        let device = Default::default();
-        let scheme = QuantizationScheme::PerBlock(
-            QuantizationMode::Affine,
-            QuantizationType::QInt8,
-            BlockLayout::Flat(3), // layout doesn't matter when computing qparams
-        );
-        let range = CalibrationRange {
-            min: TestTensor::<1>::from_floats([-1.8, -2.0, 0.5], &device),
-            max: TestTensor::<1>::from_floats([0.5, 1.5, 1.8], &device),
-        };
-
-        let qparams = scheme.compute_q_params(range);
-
-        qparams.scale.into_data().assert_approx_eq::<FT>(
-            &TensorData::from([0.009_019_608, 0.013_725_490, 0.007_0588_234]),
-            Tolerance::default(),
-        );
-        qparams
-            .offset
-            .unwrap()
-            .into_data()
-            .assert_eq(&TensorData::from([71, 17, -128]), false);
-    }
-
-    #[test]
-    fn per_block_symmetric_int8() {
-        let device = Default::default();
-        let scheme = QuantizationScheme::PerBlock(
-            QuantizationMode::Symmetric,
-            QuantizationType::QInt8,
-            BlockLayout::Flat(3), // layout doesn't matter when computing qparams
-        );
-        let range = CalibrationRange {
-            min: TestTensor::<1>::from_floats([-1.8, -2.0, 0.5], &device),
-            max: TestTensor::<1>::from_floats([0.5, 1.5, 1.8], &device),
-        };
-
-        let qparams = scheme.compute_q_params(range);
-
-        qparams.scale.into_data().assert_approx_eq::<FT>(
-            &TensorData::from([0.014_173_228, 0.015_748_031, 0.014_173_228]),
-            Tolerance::default(),
-        );
         assert!(qparams.offset.is_none());
     }
 }

--- a/crates/burn-vision/src/backends/cpu/morphology/mod.rs
+++ b/crates/burn-vision/src/backends/cpu/morphology/mod.rs
@@ -109,8 +109,7 @@ pub fn morph<B: Backend, K: BasicOps<B>>(
         DType::U8 => morph_typed::<B, K, u8>(data, shape, kernel, op, iter, btype, bvalue, &device),
         DType::Bool => morph_bool::<B, K>(data, shape, kernel, op, iter, btype, bvalue, &device),
         DType::QFloat(scheme) => match scheme {
-            QuantizationScheme::PerTensor(_mode, QuantizationType::QInt8)
-            | QuantizationScheme::PerBlock(_mode, QuantizationType::QInt8, ..) => {
+            QuantizationScheme::PerTensor(_mode, QuantizationType::QInt8) => {
                 morph_typed::<B, K, i8>(data, shape, kernel, op, iter, btype, bvalue, &device)
             }
         },


### PR DESCRIPTION
Remove affine and per block quantization. This is the first toward the new quantization scheme. It is likely that per block quantization will be reintroduced later when the new scheme is implemented.