### PR TITLE
Update SUPPORTED-ONNX-OPS.md with the latest info

### DIFF
--- a/crates/burn-import/SUPPORTED-ONNX-OPS.md
+++ b/crates/burn-import/SUPPORTED-ONNX-OPS.md
@@ -7,7 +7,6 @@ represent Burn's implementation of dimension-specific versions of the
 corresponding ONNX operators to make the mapping clearer between ONNX and Burn
 functionality.
 
-
 | ONNX OP                          | Import Support | Burn Support |
 |----------------------------------|:--------------:|:------------:|
 | [Abs][1]                         | ✅             | ✅           |

--- a/crates/burn-import/SUPPORTED-ONNX-OPS.md
+++ b/crates/burn-import/SUPPORTED-ONNX-OPS.md
@@ -7,6 +7,7 @@ represent Burn's implementation of dimension-specific versions of the
 corresponding ONNX operators to make the mapping clearer between ONNX and Burn
 functionality.
 
+
 | ONNX OP                          | Import Support | Burn Support |
 |----------------------------------|:--------------:|:------------:|
 | [Abs][1]                         | ✅             | ✅           |

--- a/crates/burn-import/SUPPORTED-ONNX-OPS.md
+++ b/crates/burn-import/SUPPORTED-ONNX-OPS.md
@@ -1,6 +1,11 @@
 # Supported ONNX Operators
 
-Note: some ONNX Ops listed below are pseudo Ops, such as `Linear`, `Conv1d`, `Conv2d` (or other with 1d, 2d suffixes used to signify the dimensionality). These are not real ONNX Ops, but are used to represent the corresponding Burn Op.
+This table lists the support status for ONNX operators in Burn. Note that some
+entries marked with dimensional suffixes (such as `Conv1d`, `Conv2d`, etc.) or
+other specialized names like `Linear` are not standard ONNX operators. These
+represent Burn's implementation of dimension-specific versions of the
+corresponding ONNX operators to make the mapping clearer between ONNX and Burn
+functionality.
 
 | ONNX OP                          | Import Support | Burn Support |
 |----------------------------------|:--------------:|:------------:|

--- a/crates/burn-import/SUPPORTED-ONNX-OPS.md
+++ b/crates/burn-import/SUPPORTED-ONNX-OPS.md
@@ -1,8 +1,6 @@
 # Supported ONNX Operators
 
-Note: some ONNX Ops listed below are pseudo Ops, such as `Linear`, `Conv1d`, `Conv2d` (or other with
-1d, 2d suffixes used signify the dimensionality). These are not real ONNX Ops, but are used to
-represent the corresponding Burn Op.
+Note: some ONNX Ops listed below are pseudo Ops, such as `Linear`, `Conv1d`, `Conv2d` (or other with 1d, 2d suffixes used to signify the dimensionality). These are not real ONNX Ops, but are used to represent the corresponding Burn Op.
 
 | ONNX OP                          | Import Support | Burn Support |
 |----------------------------------|:--------------:|:------------:|
@@ -10,26 +8,27 @@ represent the corresponding Burn Op.
 | [Acos][2]                        | ❌             | ❌           |
 | [Acosh][3]                       | ❌             | ❌           |
 | [Add][4]                         | ✅             | ✅           |
-| [And][5]                         | ❌             | ❌           |
+| [And][5]                         | ❌             | ✅           |
 | [ArgMax][6]                      | ✅             | ✅           |
-| [ArgMin][7]                      | ❌             | ❌           |
+| [ArgMin][7]                      | ❌             | ✅           |
 | [Asin][8]                        | ❌             | ❌           |
 | [Asinh][9]                       | ❌             | ❌           |
 | [Atan][10]                       | ❌             | ❌           |
 | [Atanh][11]                      | ❌             | ❌           |
+| [Attention][194]                 | ❌             | ✅           |
 | [AveragePool1d][12]              | ✅             | ✅           |
 | [AveragePool2d][12]              | ✅             | ✅           |
 | [BatchNormalization][14]         | ✅             | ✅           |
 | [Bernoulli][15]                  | ❌             | ❌           |
-| [BitShift][16]                   | ❌             | ❌           |
-| [BitwiseAnd][17]                 | ❌             | ❌           |
-| [BitwiseNot][18]                 | ❌             | ❌           |
-| [BitwiseOr][19]                  | ❌             | ❌           |
-| [BitwiseXor][20]                 | ❌             | ❌           |
+| [BitShift][16]                   | ❌             | ✅           |
+| [BitwiseAnd][17]                 | ❌             | ✅           |
+| [BitwiseNot][18]                 | ❌             | ✅           |
+| [BitwiseOr][19]                  | ❌             | ✅           |
+| [BitwiseXor][20]                 | ❌             | ✅           |
 | [BlackmanWindow][21]             | ❌             | ❌           |
 | [Cast][22]                       | ✅             | ✅           |
 | [CastLike][23]                   | ❌             | ❌           |
-| [Ceil][24]                       | ❌             | ❌           |
+| [Ceil][24]                       | ❌             | ✅           |
 | [Celu][25]                       | ❌             | ❌           |
 | [CenterCropPad][26]              | ❌             | ❌           |
 | [Clip][27]                       | ✅             | ✅           |
@@ -49,6 +48,7 @@ represent the corresponding Burn Op.
 | [Cos][39]                        | ✅             | ✅           |
 | [Cosh][40]                       | ✅             | ✅           |
 | [CumSum][41]                     | ❌             | ❌           |
+| [DeformConv][196]                | ❌             | ❌           |
 | [DepthToSpace][42]               | ❌             | ❌           |
 | [DequantizeLinear][43]           | ❌             | ❌           |
 | [Det][44]                        | ❌             | ❌           |
@@ -62,14 +62,14 @@ represent the corresponding Burn Op.
 | [Erf][52]                        | ✅             | ✅           |
 | [Exp][53]                        | ✅             | ✅           |
 | [Expand][54]                     | ✅             | ✅           |
-| [EyeLike][55]                    | ❌             | ❌           |
+| [EyeLike][55]                    | ❌             | ✅           |
 | [Flatten][56]                    | ✅             | ✅           |
 | [Floor][57]                      | ✅             | ✅           |
 | [Gather][58]                     | ✅             | ✅           |
 | [GatherElements][59]             | ✅             | ✅           |
 | [GatherND][60]                   | ❌             | ❌           |
 | [Gelu][61]                       | ✅             | ✅           |
-| [Gemm][62]                       | ✅             | 🟨           |
+| [Gemm][62]                       | ✅             | ✅           |
 | [GlobalAveragePool][63]          | ✅             | ✅           |
 | [GlobalLpPool][64]               | ❌             | ❌           |
 | [GlobalMaxPool][65]              | ❌             | ❌           |
@@ -119,13 +119,13 @@ represent the corresponding Burn Op.
 | [Neg][109]                       | ✅             | ✅           |
 | [NegativeLogLikelihoodLoss][110] | ❌             | ❌           |
 | [NonMaxSuppression][112]         | ❌             | ❌           |
-| [NonZero][113]                   | ❌             | ❌           |
+| [NonZero][113]                   | ❌             | ✅           |
 | [Not][114]                       | ✅             | ✅           |
 | [OneHot][115]                    | ✅             | ✅           |
 | [Optional][116]                  | ❌             | ❌           |
 | [OptionalGetElement][117]        | ❌             | ❌           |
 | [OptionalHasElement][118]        | ❌             | ❌           |
-| [Or][119]                        | ❌             | ❌           |
+| [Or][119]                        | ❌             | ✅           |
 | [Pad][120]                       | ✅             | ✅           |
 | [Pow][121]                       | ✅             | ✅           |
 | [PRelu][122]                     | ✅             | ✅           |
@@ -153,7 +153,7 @@ represent the corresponding Burn Op.
 | [ReverseSequence][144]           | ❌             | ❌           |
 | [RNN][145]                       | ❌             | ✅           |
 | [RoiAlign][146]                  | ❌             | ❌           |
-| [Round][147]                     | ❌             | ❌           |
+| [Round][147]                     | ❌             | ✅           |
 | [Scan][148]                      | ❌             | ❌           |
 | [Scatter][149]                   | ❌             | ✅           |
 | [ScatterElements][150]           | ❌             | ❌           |
@@ -200,8 +200,6 @@ represent the corresponding Burn Op.
 | [Where][191]                     | ✅             | ✅           |
 | [Xor][192]                       | ❌             | ❌           |
 | [Unsqueeze][193]                 | ✅             | ✅           |
-
-🟨 Supported via other operations.
 
 [1]: https://onnx.ai/onnx/operators/onnx__Abs.html "ONNX Abs"
 [2]: https://onnx.ai/onnx/operators/onnx__Acos.html "ONNX Acos"
@@ -295,8 +293,8 @@ represent the corresponding Burn Op.
 [94]: https://onnx.ai/onnx/operators/onnx__MatMul.html "ONNX MatMul"
 [95]: https://onnx.ai/onnx/operators/onnx__MatMulInteger.html "ONNX MatMulInteger"
 [96]: https://onnx.ai/onnx/operators/onnx__Max.html "ONNX Max"
-[97]: https://onnx.ai/onnx/operators/onnx__MaxPool1d.html "ONNX MaxPool1d"
-[98]: https://onnx.ai/onnx/operators/onnx__MaxPool2d.html "ONNX MaxPool2d"
+[97]: https://onnx.ai/onnx/operators/onnx__MaxPool.html "ONNX MaxPool1d"
+[98]: https://onnx.ai/onnx/operators/onnx__MaxPool.html "ONNX MaxPool2d"
 [99]: https://onnx.ai/onnx/operators/onnx__MaxRoiPool.html "ONNX MaxRoiPool"
 [100]: https://onnx.ai/onnx/operators/onnx__MaxUnpool.html "ONNX MaxUnpool"
 [101]: https://onnx.ai/onnx/operators/onnx__Mean.html "ONNX Mean"
@@ -320,8 +318,6 @@ represent the corresponding Burn Op.
 [120]: https://onnx.ai/onnx/operators/onnx__Pad.html "ONNX Pad"
 [121]: https://onnx.ai/onnx/operators/onnx__Pow.html "ONNX Pow"
 [122]: https://onnx.ai/onnx/operators/onnx__PRelu.html "ONNX PRelu"
-[123]: https://onnx.ai/onnx/operators/onnx__QLinearConv.html "ONNX QLinearConv"
-[124]: https://onnx.ai/onnx/operators/onnx__QLinearMatMul.html "ONNX QLinearMatMul"
 [125]: https://onnx.ai/onnx/operators/onnx__QuantizeLinear.html "ONNX QuantizeLinear"
 [126]: https://onnx.ai/onnx/operators/onnx__RandomNormal.html "ONNX RandomNormal"
 [127]: https://onnx.ai/onnx/operators/onnx__RandomNormalLike.html "ONNX RandomNormalLike"
@@ -329,7 +325,7 @@ represent the corresponding Burn Op.
 [129]: https://onnx.ai/onnx/operators/onnx__RandomUniformLike.html "ONNX RandomUniformLike"
 [130]: https://onnx.ai/onnx/operators/onnx__Range.html "ONNX Range"
 [131]: https://onnx.ai/onnx/operators/onnx__Reciprocal.html "ONNX Reciprocal"
-[132]: https://onnx.ai/onnx/operators/onnx__ReduceL.html "ONNX ReduceL"
+[132]: https://onnx.ai/onnx/operators/onnx__ReduceL1.html "ONNX ReduceL"
 [133]: https://onnx.ai/onnx/operators/onnx__ReduceLogSum.html "ONNX ReduceLogSum"
 [134]: https://onnx.ai/onnx/operators/onnx__ReduceLogSumExp.html "ONNX ReduceLogSumExp"
 [135]: https://onnx.ai/onnx/operators/onnx__ReduceMax.html "ONNX ReduceMax"
@@ -391,3 +387,5 @@ represent the corresponding Burn Op.
 [191]: https://onnx.ai/onnx/operators/onnx__Where.html "ONNX Where"
 [192]: https://onnx.ai/onnx/operators/onnx__Xor.html "ONNX Xor"
 [193]: https://onnx.ai/onnx/operators/onnx__Unsqueeze.html "ONNX Unsqueeze"
+[194]: https://onnx.ai/onnx/operators/onnx__Attention.html "ONNX Attention"
+[196]: https://onnx.ai/onnx/operators/onnx__DeformConv.html "ONNX DeformConv"


### PR DESCRIPTION
I updated the currently supported ONNX ops with the latest Burn API changes and added a couple of new ONNX ops (Attention and DeformConv)


### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

#1714

### Changes

Identified new Burn APIs from the book (main branch) and checked the latest ONNX op list.

Also updated #1714 with missing implementations. 

### Testing

Rendered.
