### PR TITLE
[Perf] Interpolate optimizations

### DIFF
--- a/crates/burn-cubecl/src/kernel/conv/conv2d/implicit_gemm/launch.rs
+++ b/crates/burn-cubecl/src/kernel/conv/conv2d/implicit_gemm/launch.rs
@@ -18,7 +18,7 @@ use cubecl::linalg::{
 
 use crate::{
     CubeElement, CubeRuntime, FloatElement,
-    ops::{numeric::empty_device_strided, permute, permute_nchw_to_nhwc, permute_nhwc_to_nchw},
+    ops::{numeric::empty_device_strided, permute_nchw_to_nhwc, permute_nhwc_to_nchw},
     tensor::CubeTensor,
 };
 
@@ -96,7 +96,7 @@ where
     );
 
     let input = permute_nchw_to_nhwc(input);
-    let weight = permute(weight, &[0, 2, 3, 1]);
+    let weight = permute_nchw_to_nhwc(weight);
 
     let out_shape = Shape::new([batch_size, out_h, out_w, out_channels]);
     let out =

--- a/crates/burn-cubecl/src/kernel/conv/conv2d/implicit_gemm/launch.rs
+++ b/crates/burn-cubecl/src/kernel/conv/conv2d/implicit_gemm/launch.rs
@@ -18,7 +18,7 @@ use cubecl::linalg::{
 
 use crate::{
     CubeElement, CubeRuntime, FloatElement,
-    ops::{numeric::empty_device_strided, permute},
+    ops::{numeric::empty_device_strided, permute, permute_nchw_to_nhwc, permute_nhwc_to_nchw},
     tensor::CubeTensor,
 };
 
@@ -95,7 +95,7 @@ where
         width,
     );
 
-    let input = permute(input, &[0, 2, 3, 1]);
+    let input = permute_nchw_to_nhwc(input);
     let weight = permute(weight, &[0, 2, 3, 1]);
 
     let out_shape = Shape::new([batch_size, out_h, out_w, out_channels]);
@@ -117,5 +117,5 @@ where
         },
     )?;
 
-    Ok(permute(out, &[0, 3, 1, 2]))
+    Ok(permute_nhwc_to_nchw(out))
 }

--- a/crates/burn-cubecl/src/kernel/conv/conv2d/layout_swap.rs
+++ b/crates/burn-cubecl/src/kernel/conv/conv2d/layout_swap.rs
@@ -3,8 +3,7 @@ use cubecl::{CubeCount, CubeDim, prelude::*};
 
 use crate::{
     CubeElement, CubeRuntime,
-    kernel::into_contiguous,
-    ops::{max_vectorization, numeric::empty_device_strided},
+    ops::{max_line_size, numeric::empty_device_strided},
     tensor::CubeTensor,
 };
 
@@ -55,7 +54,7 @@ pub fn nchw_to_nhwc<R: CubeRuntime, E: CubeElement>(input: CubeTensor<R>) -> Cub
     };
     let cube_count = CubeCount::Static(cube_count_x, cube_count_y, cube_count_z);
 
-    let in_vec = max_vectorization(&input);
+    let in_vec = max_line_size(&input);
     let out_vec = R::supported_line_sizes()
         .iter()
         .copied()
@@ -200,27 +199,4 @@ pub fn swizzle(offset: u32, #[comptime] bank_count: i32) -> u32 {
     let mask_shift = num_bits;
 
     offset ^ ((offset & yyy_mask) >> mask_shift)
-}
-
-/// Transpose an NCHW tensor to NHWC.
-pub fn permute_nchw_to_nhwc<R: CubeRuntime, E: CubeElement>(input: CubeTensor<R>) -> CubeTensor<R> {
-    // Disabled for now, need to fix hard to track down bug
-
-    // let use_plane = if cfg!(target_family = "wasm") {
-    //     // Any plane op enables subgroups on wasm so we need to make sure it is entirely supported.
-    //     // Otherwise, `nchw_to_nhwc` will cause compilation issues on wasm.
-    //     input
-    //         .client
-    //         .properties()
-    //         .feature_enabled(cubecl::Feature::Plane)
-    // } else {
-    //     true // plane broadcast was/is always used on other platforms
-    // };
-
-    // if input.is_contiguous() && use_plane {
-    //     nchw_to_nhwc::<R, E>(input)
-    // } else {
-    //     crate::ops::permute(input, &[0, 2, 3, 1])
-    // }
-    into_contiguous(crate::ops::permute(input, &[0, 2, 3, 1]))
 }

--- a/crates/burn-cubecl/src/kernel/conv/mod.rs
+++ b/crates/burn-cubecl/src/kernel/conv/mod.rs
@@ -10,7 +10,4 @@ pub(crate) use conv3d::*;
 pub(crate) use deform_conv_transpose2d::*;
 pub(crate) use deform_conv2d::*;
 
-pub use conv2d::{
-    Conv2dStrategy, ConvTranspose2dStrategy, conv_transpose2d, conv2d, nchw_to_nhwc,
-    permute_nchw_to_nhwc,
-};
+pub use conv2d::{Conv2dStrategy, ConvTranspose2dStrategy, conv_transpose2d, conv2d, nchw_to_nhwc};

--- a/crates/burn-cubecl/src/kernel/interpolate/bilinear.rs
+++ b/crates/burn-cubecl/src/kernel/interpolate/bilinear.rs
@@ -1,97 +1,121 @@
-use cubecl::{calculate_cube_count_elemwise, prelude::*};
+use cubecl::{calculate_cube_count_elemwise, linalg::tensor::StridedLayout, prelude::*};
+use cubecl_std::FastDivmod;
 
-use crate::{CubeRuntime, FloatElement, tensor::CubeTensor};
+use crate::{
+    CubeRuntime, FloatElement,
+    kernel::utils::{shape_divmod, strided_layout},
+    ops::max_line_size,
+    tensor::CubeTensor,
+};
 
 #[cube(launch)]
-fn interpolate_bilinear_kernel<F: Float>(input: &Tensor<F>, output: &mut Tensor<F>) {
+fn interpolate_bilinear_kernel<F: Float>(
+    input: &Tensor<Line<F>>,
+    output: &mut Tensor<Line<F>>,
+    shape_out: Sequence<FastDivmod>,
+    out_layout: StridedLayout,
+) {
     if ABSOLUTE_POS >= output.len() {
         terminate!();
     }
 
-    let batch = ABSOLUTE_POS / output.stride(0) % output.shape(0);
-    let channel = ABSOLUTE_POS / output.stride(1) % output.shape(1);
-    let y = ABSOLUTE_POS / output.stride(2) % output.shape(2);
-    let x = ABSOLUTE_POS / output.stride(3) % output.shape(3);
+    let line_size = input.line_size();
+    let out_idx = out_layout.index(output, ABSOLUTE_POS);
 
-    let numerator = F::cast_from(input.shape(2) - 1);
-    let denominator = F::cast_from(Max::max(output.shape(2) - 1, 1));
-    let factor = F::cast_from(y);
+    let (rem, c) = shape_out.index(3).div_mod(ABSOLUTE_POS * line_size);
+    let (rem, x) = shape_out.index(2).div_mod(rem);
+    let (b, y) = shape_out.index(1).div_mod(rem);
+
+    let numerator = (input.shape(1) - 1) as f32;
+    let denominator = Max::max(output.shape(1) - 1, 1) as f32;
+    let factor = f32::cast_from(y);
 
     let frac = factor * (numerator / denominator);
 
     let v0 = Floor::floor(frac);
-    let v1: F = Ceil::ceil(frac);
-    let yw = frac - v0;
-    let yw_ = F::new(1.0) - yw;
-    let y0_ok = v0 >= F::new(0.0);
-    let y0 = u32::cast_from(v0);
-    let y1 = u32::cast_from(v1);
+    let v1: f32 = Ceil::ceil(frac);
+    let yw = F::cast_from(frac - v0);
+    let yw_ = Line::empty(line_size).fill(F::new(1.0) - yw);
+    let yw = Line::empty(line_size).fill(yw);
+    let y0_ok = v0 >= 0.0;
+    let y0 = v0 as u32;
+    let y1 = v1 as u32;
 
-    let numerator = F::cast_from(input.shape(3) - 1);
-    let denominator = F::cast_from(Max::max(output.shape(3) - 1, 1));
-    let factor = F::cast_from(x);
+    let numerator = f32::cast_from(input.shape(2) - 1);
+    let denominator = f32::cast_from(Max::max(output.shape(2) - 1, 1));
+    let factor = f32::cast_from(x);
     let frac = factor * (numerator / denominator);
     let v0 = Floor::floor(frac);
-    let v1: F = Ceil::ceil(frac);
-    let xw = frac - v0;
-    let xw_ = F::new(1.0) - xw;
-    let x0_ok = v0 >= F::new(0.0);
-    let x0 = u32::cast_from(v0);
-    let x1 = u32::cast_from(v1);
+    let v1: f32 = Ceil::ceil(frac);
+    let xw = F::cast_from(frac - v0);
+    let xw_ = Line::empty(line_size).fill(F::new(1.0) - xw);
+    let xw = Line::empty(line_size).fill(xw);
+    let x0_ok = v0 >= 0.0;
+    let x0 = v0 as u32;
+    let x1 = v1 as u32;
 
-    let index_base = batch * input.stride(0) + channel * input.stride(1);
+    let index_base = b * input.stride(0) + c * input.stride(3);
 
-    let in_stride_y = input.stride(2);
-    let in_stride_x = input.stride(3);
+    let in_stride_y = input.stride(1);
+    let in_stride_x = input.stride(2);
 
     let y0_stride = y0 * in_stride_y;
     let y1_stride = y1 * in_stride_y;
     let x0_stride = x0 * in_stride_x;
     let x1_stride = x1 * in_stride_x;
 
-    let height = input.shape(2);
-    let width = input.shape(3);
+    let height = input.shape(1);
+    let width = input.shape(2);
 
     let y1_ok = y1 < height;
     let x1_ok = x1 < width;
 
+    let zero = Line::empty(line_size).fill(F::new(0.0));
+
     let p_a = select(
         x0_ok && y0_ok,
         input[index_base + y0_stride + x0_stride] * xw_ * yw_,
-        F::new(0.0),
+        zero,
     );
     let p_b = select(
         x1_ok && y0_ok,
         input[index_base + y0_stride + x1_stride] * xw * yw_,
-        F::new(0.0),
+        zero,
     );
     let p_c = select(
         x0_ok && y1_ok,
         input[index_base + y1_stride + x0_stride] * xw_ * yw,
-        F::new(0.0),
+        zero,
     );
     let p_d = select(
         x1_ok && y1_ok,
         input[index_base + y1_stride + x1_stride] * xw * yw,
-        F::new(0.0),
+        zero,
     );
 
-    output[ABSOLUTE_POS] = p_a + p_b + p_c + p_d;
+    output[out_idx] = p_a + p_b + p_c + p_d;
 }
 
 pub(crate) fn interpolate_bilinear_launch<R: CubeRuntime, F: FloatElement>(
     input: CubeTensor<R>,
     output: CubeTensor<R>,
 ) -> CubeTensor<R> {
+    let line_size = max_line_size(&input);
+    let out_shape = shape_divmod(&output);
+    let out_layout = strided_layout(&output);
+
     let cube_dim = CubeDim::default();
-    let cube_count = calculate_cube_count_elemwise(output.shape.num_elements(), cube_dim);
+    let cube_count =
+        calculate_cube_count_elemwise(output.shape.num_elements() / line_size as usize, cube_dim);
 
     interpolate_bilinear_kernel::launch::<F, R>(
         &input.client,
         cube_count,
         cube_dim,
-        input.as_tensor_arg::<F>(1),
-        output.as_tensor_arg::<F>(1),
+        input.as_tensor_arg::<F>(line_size),
+        output.as_tensor_arg::<F>(line_size),
+        out_shape,
+        out_layout,
     );
 
     output

--- a/crates/burn-cubecl/src/kernel/interpolate/nearest.rs
+++ b/crates/burn-cubecl/src/kernel/interpolate/nearest.rs
@@ -1,50 +1,71 @@
-use cubecl::{calculate_cube_count_elemwise, prelude::*};
+use cubecl::{calculate_cube_count_elemwise, linalg::tensor::StridedLayout, prelude::*};
+use cubecl_std::FastDivmod;
 
-use crate::{CubeRuntime, FloatElement, tensor::CubeTensor};
+use crate::{
+    CubeRuntime, FloatElement,
+    kernel::utils::{shape_divmod, strided_layout},
+    ops::max_line_size,
+    tensor::CubeTensor,
+};
 
 #[cube(launch_unchecked)]
-fn interpolate_nearest_kernel<F: Float>(input: &Tensor<F>, output: &mut Tensor<F>) {
+fn interpolate_nearest_kernel<F: Float>(
+    input: &Tensor<Line<F>>,
+    output: &mut Tensor<Line<F>>,
+    shape_out: Sequence<FastDivmod>,
+    out_layout: StridedLayout,
+) {
     if ABSOLUTE_POS >= output.len() {
         terminate!();
     }
 
-    let batch = ABSOLUTE_POS / output.stride(0) % output.shape(0);
-    let channel = ABSOLUTE_POS / output.stride(1) % output.shape(1);
-    let y = ABSOLUTE_POS / output.stride(2) % output.shape(2);
-    let x = ABSOLUTE_POS / output.stride(3) % output.shape(3);
+    let line_size = input.line_size();
+    let out_idx = out_layout.index(output, ABSOLUTE_POS);
 
-    let factor = F::cast_from(y);
-    let numerator = F::cast_from(input.shape(2));
-    let denominator = F::cast_from(output.shape(2));
-    let y: F = Floor::floor(factor * numerator / denominator);
+    let out_pos = ABSOLUTE_POS * line_size;
 
-    let factor = F::cast_from(x);
-    let numerator = F::cast_from(input.shape(3));
-    let denominator = F::cast_from(output.shape(3));
-    let x: F = Floor::floor(factor * numerator / denominator);
+    let (h_in, w_in) = (input.shape(1) as f32, input.shape(2) as f32);
+    let (h_out, w_out) = (output.shape(1) as f32, output.shape(2) as f32);
 
-    let index = batch * input.stride(0)
-        + channel * input.stride(1)
-        + u32::cast_from(y) * input.stride(2)
-        + u32::cast_from(x) * input.stride(3);
+    let (rem, c) = shape_out.index(3).div_mod(out_pos);
+    let (rem, x) = shape_out.index(2).div_mod(rem);
+    let (b, y) = shape_out.index(1).div_mod(rem);
 
-    output[ABSOLUTE_POS] = input[index];
+    let y = y as f32 * (h_in / h_out);
+    let x = x as f32 * (w_in / w_out);
+
+    let in_idx = b * input.stride(0)
+        + y as u32 * input.stride(1)
+        + x as u32 * input.stride(2)
+        + c * input.stride(3);
+
+    output[out_idx] = input[in_idx / line_size];
 }
 
 pub(crate) fn interpolate_nearest_launch<R: CubeRuntime, E: FloatElement>(
     input: CubeTensor<R>,
     output: CubeTensor<R>,
 ) -> CubeTensor<R> {
+    let client = input.client.clone();
+
+    let line_size = max_line_size(&input);
+
     let cube_dim = CubeDim::default();
-    let cube_count = calculate_cube_count_elemwise(output.shape.num_elements(), cube_dim);
+    let cube_count =
+        calculate_cube_count_elemwise(output.shape.num_elements() / line_size as usize, cube_dim);
+
+    let shape_out = shape_divmod(&output);
+    let out_layout = strided_layout(&output);
 
     unsafe {
         interpolate_nearest_kernel::launch_unchecked::<E, R>(
-            &input.client,
+            &client,
             cube_count,
             cube_dim,
-            input.as_tensor_arg::<E>(1),
-            output.as_tensor_arg::<E>(1),
+            input.as_tensor_arg::<E>(line_size),
+            output.as_tensor_arg::<E>(line_size),
+            shape_out,
+            out_layout,
         )
     };
 

--- a/crates/burn-cubecl/src/kernel/mask/mask_fill.rs
+++ b/crates/burn-cubecl/src/kernel/mask/mask_fill.rs
@@ -3,7 +3,7 @@ use cubecl::{calculate_cube_count_elemwise, linalg::tensor::index_offset_with_la
 use crate::{
     BoolElement, CubeRuntime,
     element::CubeElement,
-    ops::{max_vectorization, numeric::empty_device},
+    ops::{max_line_size, numeric::empty_device},
     tensor::CubeTensor,
 };
 
@@ -84,7 +84,7 @@ fn mask_fill_readonly<R: CubeRuntime, EI: CubeElement, EM: BoolElement>(
 
     let cube_dim = CubeDim::default();
     let cube_count = calculate_cube_count_elemwise(input.shape.num_elements(), cube_dim);
-    let vectorization = max_vectorization(&input);
+    let vectorization = max_line_size(&input);
 
     mask_fill_readonly_kernel::launch::<EI, EM, R>(
         &input.client,
@@ -108,7 +108,7 @@ fn mask_fill_inplace<R: CubeRuntime, EI: CubeElement, EM: BoolElement>(
     let ndims = input.shape.num_dims();
     let cube_dim = CubeDim::default();
     let cube_count = calculate_cube_count_elemwise(input.shape.num_elements(), cube_dim);
-    let vectorization = max_vectorization(&input);
+    let vectorization = max_line_size(&input);
 
     mask_fill_inplace_kernel::launch::<EI, EM, R>(
         &input.client,

--- a/crates/burn-cubecl/src/kernel/mask/mask_where.rs
+++ b/crates/burn-cubecl/src/kernel/mask/mask_where.rs
@@ -3,7 +3,7 @@ use cubecl::{calculate_cube_count_elemwise, linalg::tensor::index_offset_with_la
 use crate::{
     BoolElement, CubeRuntime,
     element::CubeElement,
-    ops::{max_vectorization, numeric::empty_device},
+    ops::{max_line_size, numeric::empty_device},
     tensor::CubeTensor,
 };
 
@@ -92,7 +92,7 @@ fn mask_where_readonly<R: CubeRuntime, EI: CubeElement, EM: BoolElement>(
 
     let cube_dim = CubeDim::default();
     let cube_count = calculate_cube_count_elemwise(input.shape.num_elements(), cube_dim);
-    let vectorization = max_vectorization(&input);
+    let vectorization = max_line_size(&input);
 
     mask_where_readonly_kernel::launch::<EI, EM, R>(
         &input.client,
@@ -117,7 +117,7 @@ fn mask_where_inplace<R: CubeRuntime, EI: CubeElement, EM: BoolElement>(
     let ndims = input.shape.num_dims();
     let cube_dim = CubeDim::default();
     let cube_count = calculate_cube_count_elemwise(input.shape.num_elements(), cube_dim);
-    let vectorization = max_vectorization(&input);
+    let vectorization = max_line_size(&input);
 
     mask_where_inplace_kernel::launch::<EI, EM, R>(
         &input.client,

--- a/crates/burn-cubecl/src/kernel/mod.rs
+++ b/crates/burn-cubecl/src/kernel/mod.rs
@@ -40,3 +40,5 @@ pub mod reduce;
 pub(crate) use clamp::*;
 pub(crate) use comparison::*;
 pub use index::*;
+
+pub(crate) mod utils;

--- a/crates/burn-cubecl/src/kernel/pool/avg_pool2d_backward.rs
+++ b/crates/burn-cubecl/src/kernel/pool/avg_pool2d_backward.rs
@@ -1,7 +1,7 @@
 use crate::{
     CubeRuntime,
     element::CubeElement,
-    ops::{max_vectorization, numeric::empty_device, permute},
+    ops::{max_line_size, numeric::empty_device, permute_nchw_to_nhwc, permute_nhwc_to_nchw},
     tensor::CubeTensor,
 };
 use burn_tensor::Shape;
@@ -127,10 +127,10 @@ pub(crate) fn avg_pool2d_backward<R: CubeRuntime, E: CubeElement>(
 ) -> CubeTensor<R> {
     let [batches, channels, height, width] = x.shape.dims();
 
-    let grad = permute(grad, &[0, 2, 3, 1]);
+    let grad = permute_nchw_to_nhwc(grad);
 
     let line_size = if x.strides[3] == grad.strides[3] {
-        max_vectorization(&x)
+        max_line_size(&x)
     } else {
         1
     };
@@ -164,5 +164,5 @@ pub(crate) fn avg_pool2d_backward<R: CubeRuntime, E: CubeElement>(
         )
     };
 
-    permute(output, &[0, 3, 1, 2])
+    permute_nhwc_to_nchw(output)
 }

--- a/crates/burn-cubecl/src/kernel/pool/max_pool2d.rs
+++ b/crates/burn-cubecl/src/kernel/pool/max_pool2d.rs
@@ -4,8 +4,8 @@ use super::pool2d::{
 use crate::{
     CubeRuntime,
     element::CubeElement,
-    kernel::conv::permute_nchw_to_nhwc,
-    ops::{max_vectorization, numeric::empty_device, permute},
+    kernel::into_contiguous,
+    ops::{max_line_size, numeric::empty_device, permute_nchw_to_nhwc, permute_nhwc_to_nchw},
     tensor::CubeTensor,
 };
 use burn_tensor::{Shape, ops::conv::calculate_pool_output_size};
@@ -121,9 +121,9 @@ pub(crate) fn max_pool2d<R: CubeRuntime, E: CubeElement>(
         x.shape.dims[3],
     );
 
-    let x = permute_nchw_to_nhwc::<R, E>(x);
+    let x = into_contiguous(permute_nchw_to_nhwc(x));
 
-    let line_size = max_vectorization(&x);
+    let line_size = max_line_size(&x);
 
     let shape_out = Shape::new([batch_size, size_0, size_1, channels]);
     let output = empty_device::<R, E>(x.client.clone(), x.device.clone(), shape_out);
@@ -151,7 +151,7 @@ pub(crate) fn max_pool2d<R: CubeRuntime, E: CubeElement>(
         (),
     );
 
-    permute(output, &[0, 3, 1, 2])
+    permute_nhwc_to_nchw(output)
 }
 
 pub(crate) fn max_pool2d_with_indices<R: CubeRuntime, E: CubeElement, I: CubeElement>(
@@ -178,8 +178,8 @@ pub(crate) fn max_pool2d_with_indices<R: CubeRuntime, E: CubeElement, I: CubeEle
         x.shape.dims[3],
     );
 
-    let x = permute_nchw_to_nhwc::<R, E>(x);
-    let line_size = max_vectorization(&x);
+    let x = into_contiguous(permute_nchw_to_nhwc(x));
+    let line_size = max_line_size(&x);
 
     let shape_out = Shape::new([batch_size, size_0, size_1, channels]);
     let output = empty_device::<R, E>(x.client.clone(), x.device.clone(), shape_out.clone());
@@ -208,7 +208,7 @@ pub(crate) fn max_pool2d_with_indices<R: CubeRuntime, E: CubeElement, I: CubeEle
         (),
     );
 
-    let output = permute(output, &[0, 3, 1, 2]);
-    let indices = permute(indices, &[0, 3, 1, 2]);
+    let output = permute_nhwc_to_nchw(output);
+    let indices = permute_nhwc_to_nchw(indices);
     (output, indices)
 }

--- a/crates/burn-cubecl/src/kernel/utils.rs
+++ b/crates/burn-cubecl/src/kernel/utils.rs
@@ -1,0 +1,21 @@
+use cubecl::{linalg::tensor::StridedLayoutArgs, prelude::SequenceArg};
+use cubecl_std::{FastDivmod, FastDivmodArgs};
+
+use crate::{CubeRuntime, tensor::CubeTensor};
+
+pub fn shape_divmod<'a, R: CubeRuntime>(tensor: &CubeTensor<R>) -> SequenceArg<'a, R, FastDivmod> {
+    let mut arg = SequenceArg::new();
+    for dim in tensor.shape.dims.iter() {
+        arg.push(FastDivmodArgs::new(&tensor.client, *dim as u32));
+    }
+    arg
+}
+
+pub fn strided_layout<'a, R: CubeRuntime>(tensor: &CubeTensor<R>) -> StridedLayoutArgs<'a, R> {
+    let rank = tensor.shape.num_dims();
+    if rank <= 1 || tensor.shape.dims[rank - 1] == tensor.strides[rank - 2] {
+        StridedLayoutArgs::none()
+    } else {
+        StridedLayoutArgs::strided(&tensor.client, tensor.shape.dims[rank - 1] as u32)
+    }
+}

--- a/crates/burn-cubecl/src/ops/base.rs
+++ b/crates/burn-cubecl/src/ops/base.rs
@@ -72,6 +72,16 @@ pub fn permute<R: CubeRuntime>(mut tensor: CubeTensor<R>, axes: &[usize]) -> Cub
     tensor
 }
 
+/// Permute a tensor's dimensions from NCHW to NHWC
+pub fn permute_nchw_to_nhwc<R: CubeRuntime>(tensor: CubeTensor<R>) -> CubeTensor<R> {
+    permute(tensor, &[0, 2, 3, 1])
+}
+
+/// Permute a tensor's dimensions from NHWC to NCHW
+pub fn permute_nhwc_to_nchw<R: CubeRuntime>(tensor: CubeTensor<R>) -> CubeTensor<R> {
+    permute(tensor, &[0, 3, 1, 2])
+}
+
 pub(crate) fn expand<R: CubeRuntime>(tensor: CubeTensor<R>, target_shape: Shape) -> CubeTensor<R> {
     let ndims_in = tensor.shape.num_dims();
     let ndims_out = target_shape.num_dims();
@@ -136,7 +146,7 @@ pub fn reshape<R: CubeRuntime>(tensor: CubeTensor<R>, shape: Shape) -> CubeTenso
     )
 }
 
-pub(crate) fn max_vectorization<R: CubeRuntime>(tensor: &CubeTensor<R>) -> u8 {
+pub(crate) fn max_line_size<R: CubeRuntime>(tensor: &CubeTensor<R>) -> u8 {
     tensor_vectorization_factor(
         R::supported_line_sizes(),
         &tensor.shape.dims,

--- a/crates/burn-cubecl/src/tensor/base.rs
+++ b/crates/burn-cubecl/src/tensor/base.rs
@@ -510,4 +510,10 @@ mod tests {
     fn is_contiguous_4d_negative() {
         assert!(!is_contiguous(&[256, 8, 32, 32], &[1024, 262144, 32, 1]));
     }
+
+    /// Based on a bug encountered in interpolate_1d
+    #[test]
+    fn is_contiguous_4d_unit_shape() {
+        assert!(!is_contiguous(&[1, 1, 1, 9], &[72, 1, 72, 8]));
+    }
 }

--- a/crates/burn-cubecl/src/tensor/base.rs
+++ b/crates/burn-cubecl/src/tensor/base.rs
@@ -353,16 +353,11 @@ where
     }
 
     /// Return the reference to a tensor argument.
-    pub fn as_tensor_arg<'a, E: CubeElement>(&'a self, vectorisation: u8) -> TensorArg<'a, R> {
+    pub fn as_tensor_arg<'a, E: CubeElement>(&'a self, line_size: u8) -> TensorArg<'a, R> {
         let handle: TensorHandleRef<'a, R> = self.as_handle_ref();
 
         unsafe {
-            TensorArg::from_raw_parts::<E>(
-                handle.handle,
-                handle.strides,
-                handle.shape,
-                vectorisation,
-            )
+            TensorArg::from_raw_parts::<E>(handle.handle, handle.strides, handle.shape, line_size)
         }
     }
 
@@ -476,6 +471,8 @@ pub(crate) fn is_contiguous(shape: &[usize], strides: &[usize]) -> bool {
             if prev_stride >= *stride {
                 return false;
             }
+        } else if *stride != 1 {
+            return false;
         }
 
         current_num_elems_shape *= shape;

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -3197,6 +3197,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::reversed_empty_ranges)]
+
     use crate::Shape;
     use crate::s;
 

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -3197,8 +3197,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::reversed_empty_ranges)]
-
     use crate::Shape;
     use crate::s;
 

--- a/crates/burn-tensor/src/tensor/api/slice.rs
+++ b/crates/burn-tensor/src/tensor/api/slice.rs
@@ -21,11 +21,21 @@ use core::ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInc
 #[macro_export]
 macro_rules! s {
     [$range:expr] => {
-        $crate::Slice::from($range)
+        {
+            #[allow(clippy::reversed_empty_ranges)]
+            {
+                $crate::Slice::from($range)
+            }
+        }
     };
 
     [$($range:expr),+] => {
-        [$($crate::Slice::from($range)),+]
+        {
+            #[allow(clippy::reversed_empty_ranges)]
+            {
+                [$($crate::Slice::from($range)),+]
+            }
+        }
     };
 }
 

--- a/crates/burn-tensor/src/tests/ops/slice.rs
+++ b/crates/burn-tensor/src/tests/ops/slice.rs
@@ -1,5 +1,7 @@
 #[burn_tensor_testgen::testgen(slice)]
 mod tests {
+    #![allow(clippy::reversed_empty_ranges)]
+
     use super::*;
     use burn_tensor::{Int, Tensor, TensorData, as_type, s};
 

--- a/crates/burn-tensor/src/tests/ops/slice.rs
+++ b/crates/burn-tensor/src/tests/ops/slice.rs
@@ -1,7 +1,5 @@
 #[burn_tensor_testgen::testgen(slice)]
 mod tests {
-    #![allow(clippy::reversed_empty_ranges)]
-
     use super::*;
     use burn_tensor::{Int, Tensor, TensorData, as_type, s};
 
@@ -172,7 +170,7 @@ mod tests {
         let data = TensorData::from(as_type!(FloatType: [[0.0f32]]));
         output.into_data().assert_eq(&data, true);
 
-        let output = tensor.slice([0..-1, 0..-2]);
+        let output = tensor.slice(s![0..-1, 0..-2]);
         output.into_data().assert_eq(&data, true);
     }
 
@@ -187,7 +185,7 @@ mod tests {
 
         // Negative dimensions
         let data = TensorData::from(as_type!(FloatType: [[0.0f32]]));
-        let output = tensor.clone().slice([0..-1, 0..-2]);
+        let output = tensor.clone().slice(s![0..-1, 0..-2]);
         output.into_data().assert_eq(&data, true);
 
         // Missing dimensions
@@ -230,8 +228,7 @@ mod tests {
         let data = TensorData::from([0.0, 1.0, 2.0]);
         let tensor = TestTensor::<1>::from_data(data.clone(), &Default::default());
 
-        #[allow(clippy::reversed_empty_ranges)]
-        let output = tensor.slice([2..1]);
+        let output = tensor.slice(s![2..1]);
 
         output.into_data().assert_eq(&data, false);
     }

--- a/crates/burn-tensor/src/tests/quantization/ops/slice.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/slice.rs
@@ -1,5 +1,7 @@
 #[burn_tensor_testgen::testgen(q_slice)]
 mod tests {
+    #![allow(clippy::reversed_empty_ranges)]
+
     use super::*;
     use burn_tensor::TensorData;
     use burn_tensor::{Tolerance, ops::FloatElem, s};

--- a/crates/burn-tensor/src/tests/quantization/ops/slice.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/slice.rs
@@ -1,7 +1,5 @@
 #[burn_tensor_testgen::testgen(q_slice)]
 mod tests {
-    #![allow(clippy::reversed_empty_ranges)]
-
     use super::*;
     use burn_tensor::TensorData;
     use burn_tensor::{Tolerance, ops::FloatElem, s};
@@ -167,7 +165,7 @@ mod tests {
         let data = TensorData::from([[0.0f32]]);
         output.dequantize().into_data().assert_eq(&data, false);
 
-        let output = tensor.slice([0..-1, 0..-2]);
+        let output = tensor.slice(s![0..-1, 0..-2]);
         output.dequantize().into_data().assert_eq(&data, false);
     }
 
@@ -182,7 +180,7 @@ mod tests {
 
         // Negative dimensions
         let data = TensorData::from([[0.0f32]]);
-        let output = tensor.clone().slice([0..-1, 0..-2]);
+        let output = tensor.clone().slice(s![0..-1, 0..-2]);
         output.dequantize().into_data().assert_eq(&data, false);
 
         // Missing dimensions
@@ -212,8 +210,7 @@ mod tests {
     fn should_panic_when_slice_is_desc() {
         let tensor = QTensor::<TestBackend, 1>::int8([0.0, 1.0, 2.0]);
 
-        #[allow(clippy::reversed_empty_ranges)]
-        let output = tensor.slice([2..1]);
+        let output = tensor.slice(s![2..1]);
     }
 
     #[test]


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Also fixes https://github.com/tracel-ai/burn/pull/3076

### Changes

Refactors interpolation to use NHWC layout to allow for potential vectorization when used with NHWC layout tensors (i.e. from convolution), as well as other perf optimizations. Also fixes a bug in `is_contiguous` and a clippy warning for slices.

### Testing

All tests pass
