### PR TITLE
Fix clamp min/max line size > 1

### DIFF
--- a/crates/burn-cubecl/src/kernel/clamp.rs
+++ b/crates/burn-cubecl/src/kernel/clamp.rs
@@ -25,10 +25,11 @@ pub(crate) fn clamp<R: CubeRuntime, E: CubeElement>(
         type Options = Options<N>;
 
         fn execute(input: Line<N>, options: &Self::Options) -> Line<N> {
+            let line_size = input.size();
             Line::clamp(
                 input,
-                Line::new(options.min_value),
-                Line::new(options.max_value),
+                Line::empty(line_size).fill(options.min_value),
+                Line::empty(line_size).fill(options.max_value),
             )
         }
     }

--- a/crates/burn-tensor/src/tests/ops/clamp.rs
+++ b/crates/burn-tensor/src/tests/ops/clamp.rs
@@ -70,4 +70,15 @@ mod tests {
             .into_data()
             .assert_eq(&TensorData::from([[1, 1, 2], [3, 4, 4]]), false);
     }
+
+    #[test]
+    fn clamp_min_max_vec_should_compile() {
+        let input = TestTensor::<2>::ones([2, 4], &Default::default());
+        let output = input.clamp(0., 0.5);
+
+        output.into_data().assert_eq(
+            &TensorData::from([[0.5, 0.5, 0.5, 0.5], [0.5, 0.5, 0.5, 0.5]]),
+            false,
+        );
+    }
 }


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `run-checks all` script has been executed.

### Related Issues/PRs

[Originally from discord](https://discord.com/channels/1038839012602941528/1059209073784008835/1364976790250061944)

`tensor.clamp(min, max)` would not compile for an f16 input with Cuda for line size > 1

```
thread 'main' panicked at cubecl-cuda-0.5.0\src\compute\server.rs:682:17:
[Compilation Error]
    default_program(53): error: no suitable user-defined conversion from "const __half" to "__half2" exists
      __hmax2(scalars___half.x[0], __hmin2(scalars___half.x[1], (reinterpret_cast<__half2_4 const&>(l_2)).i_0)),
                                           ^
    default_program(53): error: no suitable user-defined conversion from "const __half" to "__half2" exists
      __hmax2(scalars___half.x[0], __hmin2(scalars___half.x[1], (reinterpret_cast<__half2_4 const&>(l_2)).i_0)),
              ^
    default_program(54): error: no suitable user-defined conversion from "const __half" to "__half2" exists
      __hmax2(scalars___half.x[0], __hmin2(scalars___half.x[1], (reinterpret_cast<__half2_4 const&>(l_2)).i_1)),
                                           ^
    default_program(54): error: no suitable user-defined conversion from "const __half" to "__half2" exists
      __hmax2(scalars___half.x[0], __hmin2(scalars___half.x[1], (reinterpret_cast<__half2_4 const&>(l_2)).i_1)),
              ^
    default_program(55): error: no suitable user-defined conversion from "const __half" to "__half2" exists
      __hmax2(scalars___half.x[0], __hmin2(scalars___half.x[1], (reinterpret_cast<__half2_4 const&>(l_2)).i_2)),
                                           ^
    default_program(55): error: no suitable user-defined conversion from "const __half" to "__half2" exists
      __hmax2(scalars___half.x[0], __hmin2(scalars___half.x[1], (reinterpret_cast<__half2_4 const&>(l_2)).i_2)),
              ^
    default_program(56): error: no suitable user-defined conversion from "const __half" to "__half2" exists
      __hmax2(scalars___half.x[0], __hmin2(scalars___half.x[1], (reinterpret_cast<__half2_4 const&>(l_2)).i_3)),
                                           ^
    default_program(56): error: no suitable user-defined conversion from "const __half" to "__half2" exists
      __hmax2(scalars___half.x[0], __hmin2(scalars___half.x[1], (reinterpret_cast<__half2_4 const&>(l_2)).i_3)),
              ^
    8 errors detected in the compilation of "default_program".
```

### Changes

Replace `Line::new(val)` with `Line::empty(line_size).fill(val)` to create a line of the correct size with the scalar replicated for the whole line.

### Testing

Added unit test
