### PR TITLE
Make is_contiguous check common

### DIFF
--- a/crates/burn-common/src/lib.rs
+++ b/crates/burn-common/src/lib.rs
@@ -28,9 +28,9 @@ pub mod tensor {
     /// Check if the current tensor is contiguous.
     ///
     /// A tensor is considered contiguous if its elements are stored in memory
-    /// such that the strides are in strictly decreasing order, and the stride at
-    /// position `k` is equal to the product of the shapes of all dimensions greater
-    /// than `k`. Axes with a shape of 1 are ignored.
+    /// such that the strides are in non-increasing order, and the stride at position
+    /// `k` is equal to the product of the shapes of all dimensions greater than `k`.
+    /// Axes with a shape of 1 are ignored.
     pub fn is_contiguous(shape: &[usize], strides: &[usize]) -> bool {
         if shape.is_empty() {
             return true;

--- a/crates/burn-common/src/lib.rs
+++ b/crates/burn-common/src/lib.rs
@@ -25,6 +25,8 @@ pub mod parallel;
 
 /// Tensor utilities.
 pub mod tensor {
+    use alloc::vec::Vec;
+
     /// Check if the current tensor is contiguous.
     ///
     /// A tensor is considered contiguous if its elements are stored in memory

--- a/crates/burn-common/src/lib.rs
+++ b/crates/burn-common/src/lib.rs
@@ -28,38 +28,38 @@ pub mod tensor {
     /// Check if the current tensor is contiguous.
     ///
     /// A tensor is considered contiguous if its elements are stored in memory
-    /// such that the strides are in non-increasing order, and the stride at position
-    /// `k` is equal to the product of the shapes of all dimensions greater than `k`.
-    /// Axes with a shape of 1 are ignored.
+    /// such that the stride at position `k` is equal to the product of the shapes
+    /// of all dimensions greater than `k`.
+    ///
+    /// This means that strides increase as you move from the rightmost to the leftmost dimension.
     pub fn is_contiguous(shape: &[usize], strides: &[usize]) -> bool {
         if shape.is_empty() {
             return true;
         }
 
-        let mut prev_stride = 1;
-        let mut current_num_elems_shape = 1;
-
-        for (i, (&stride, &shape)) in strides.iter().zip(shape).rev().enumerate() {
-            if shape == 1 {
-                continue;
-            }
-
-            if i > 0 {
-                if current_num_elems_shape != stride {
-                    return false;
-                }
-
-                if prev_stride > stride {
-                    return false;
-                }
-            } else if stride != 1 {
+        for (expected, &stride) in contiguous_strides(shape).into_iter().zip(strides) {
+            if expected != stride {
                 return false;
             }
-
-            current_num_elems_shape *= shape;
-            prev_stride = stride;
         }
 
         true
+    }
+
+    /// Computes the strides for a contiguous tensor with the given shape.
+    ///
+    /// In a contiguous row-major tensor, the stride for each dimension
+    /// equals the product of all dimension sizes to its right.
+    pub fn contiguous_strides(shape: &[usize]) -> Vec<usize> {
+        let mut strides = Vec::with_capacity(shape.len());
+        let mut current = 1;
+
+        for &dim in shape.iter().rev() {
+            strides.push(current);
+            current *= dim;
+        }
+
+        strides.reverse();
+        strides
     }
 }

--- a/crates/burn-common/src/lib.rs
+++ b/crates/burn-common/src/lib.rs
@@ -22,3 +22,44 @@ pub mod network;
 
 /// Parallel utilities.
 pub mod parallel;
+
+/// Tensor utilities.
+pub mod tensor {
+    /// Check if the current tensor is contiguous.
+    ///
+    /// A tensor is considered contiguous if its elements are stored in memory
+    /// such that the strides are in strictly decreasing order, and the stride at
+    /// position `k` is equal to the product of the shapes of all dimensions greater
+    /// than `k`. Axes with a shape of 1 are ignored.
+    pub fn is_contiguous(shape: &[usize], strides: &[usize]) -> bool {
+        if shape.is_empty() {
+            return true;
+        }
+
+        let mut prev_stride = 1;
+        let mut current_num_elems_shape = 1;
+
+        for (i, (&stride, &shape)) in strides.iter().zip(shape).rev().enumerate() {
+            if shape == 1 {
+                continue;
+            }
+
+            if i > 0 {
+                if current_num_elems_shape != stride {
+                    return false;
+                }
+
+                if prev_stride > stride {
+                    return false;
+                }
+            } else if stride != 1 {
+                return false;
+            }
+
+            current_num_elems_shape *= shape;
+            prev_stride = stride;
+        }
+
+        true
+    }
+}

--- a/crates/burn-cubecl-fusion/src/base.rs
+++ b/crates/burn-cubecl-fusion/src/base.rs
@@ -137,33 +137,3 @@ impl<R: Runtime> CubeFusionHandle<R> {
         }
     }
 }
-
-pub(crate) fn is_contiguous(shape: &[usize], strides: &[usize]) -> bool {
-    if shape.is_empty() {
-        return true;
-    }
-
-    if shape.len() == 1 {
-        return strides[0] == 1;
-    }
-
-    let mut prev_stride = 1;
-    let mut current_num_elems_shape = 1;
-
-    for (i, (stride, shape)) in strides.iter().zip(shape).rev().enumerate() {
-        if i > 0 {
-            if current_num_elems_shape != *stride {
-                return false;
-            }
-
-            if prev_stride >= *stride {
-                return false;
-            }
-        }
-
-        current_num_elems_shape *= shape;
-        prev_stride = *stride;
-    }
-
-    true
-}

--- a/crates/burn-cubecl-fusion/src/shared/trace/output.rs
+++ b/crates/burn-cubecl-fusion/src/shared/trace/output.rs
@@ -1,10 +1,11 @@
+use burn_common::tensor::is_contiguous;
 use burn_fusion::stream::Context;
 use burn_ir::{TensorId, TensorIr};
 use burn_tensor::DType;
 use cubecl::{CubeElement, Runtime, client::ComputeClient, ir::Elem};
 
 use crate::{
-    CubeFusionHandle, elem_dtype, is_contiguous,
+    CubeFusionHandle, elem_dtype,
     shared::ir::{Arg, FuseOp, LayoutInfo},
     strides_dyn_rank,
 };

--- a/crates/burn-cubecl/src/tensor/base.rs
+++ b/crates/burn-cubecl/src/tensor/base.rs
@@ -456,7 +456,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn is_contiguous_degenerate() {
+    fn is_contiguous_non_increasing() {
         assert!(is_contiguous(&[3, 1], &[1, 1]));
     }
 

--- a/crates/burn-cubecl/src/tensor/base.rs
+++ b/crates/burn-cubecl/src/tensor/base.rs
@@ -437,7 +437,7 @@ where
     /// Check if the current tensor is contiguous.
     ///
     /// A tensor is contiguous if the elements are stored in memory
-    /// if the strides in strict decreasing order and the
+    /// if the strides in non-increasing order and the
     /// strides at position k is equal to the product of the shapes
     /// at all positions greater than k. However, all axes with a shape of 1 are ignored.
     pub fn is_contiguous(&self) -> bool {


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.

### Related Issues/PRs

Following [this comment](https://github.com/tracel-ai/burn/pull/3077#discussion_r2060270547) in #3077

### Changes

Migrated `is_contiguous` to common (including minor fix).

### Testing

Also added a unit test for shape `[3, 1]` and strides `[1, 1]` which would previously be marked as not contiguous.
