### PR TITLE
Port {numpy,pytorch}.meshgrid() to burn_tensor::grid

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -361,6 +361,12 @@ strategies.
 | `activation::softplus(tensor, beta)`             | `nn.functional.softplus(tensor, beta)`             |
 | `activation::tanh(tensor)`                       | `nn.functional.tanh(tensor)`                       |
 
+## Grid Functions
+
+| Burn API                        | PyTorch Equivalent                      |
+|---------------------------------|-----------------------------------------|
+| `grid::meshgrid_dense(tensors)` | `torch.meshgrid(tensors, indexing="ij") |
+
 ## Displaying Tensor Details
 
 Burn provides flexible options for displaying tensor information, allowing you to control the level

--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -363,9 +363,10 @@ strategies.
 
 ## Grid Functions
 
-| Burn API                        | PyTorch Equivalent                      |
-|---------------------------------|-----------------------------------------|
-| `grid::meshgrid_dense(tensors)` | `torch.meshgrid(tensors, indexing="ij") |
+| Burn API                                           | PyTorch Equivalent                      |
+|----------------------------------------------------|-----------------------------------------|
+| `grid::meshgrid(tensors, GridIndexing::Matrix)`    | `torch.meshgrid(tensors, indexing="ij") |
+| `grid::meshgrid(tensors, GridIndexing::Cartesian)` | `torch.meshgrid(tensors, indexing="xy") |
 
 ## Displaying Tensor Details
 

--- a/crates/burn-tensor/src/tensor/grid/meshgrid.rs
+++ b/crates/burn-tensor/src/tensor/grid/meshgrid.rs
@@ -38,6 +38,7 @@ where
 {
     let options = options.into();
     let swap_dims = options.indexing == GridIndexing::Cartesian && N > 1;
+    let dense = options.sparsity == GridSparsity::Dense;
 
     let grid_shape: [usize; N] = tensors
         .iter()
@@ -46,7 +47,7 @@ where
         .try_into()
         .unwrap();
 
-    let result = tensors
+    tensors
         .iter()
         .enumerate()
         .map(|(i, tensor)| {
@@ -56,18 +57,16 @@ where
             // Reshape the tensor to have singleton dimensions in all but the i-th dimension
             let mut tensor = tensor.clone().reshape(coord_tensor_shape);
 
-            if options.sparsity == GridSparsity::Dense {
+            if dense {
                 tensor = tensor.expand(grid_shape);
             }
-
             if swap_dims {
-                // Swap the first two dimensions for "xy" / CartesianIndexing
                 tensor = tensor.swap_dims(0, 1);
             }
 
             tensor
         })
-        .collect::<Vec<_>>();
-
-    result.try_into().unwrap()
+        .collect::<Vec<_>>()
+        .try_into()
+        .unwrap()
 }

--- a/crates/burn-tensor/src/tensor/grid/meshgrid.rs
+++ b/crates/burn-tensor/src/tensor/grid/meshgrid.rs
@@ -1,44 +1,7 @@
 use crate::backend::Backend;
-use crate::tensor::grid::{GridIndexing, GridSparsity};
+use crate::tensor::grid::{GridIndexing, GridOptions, GridSparsity};
 use crate::tensor::{BasicOps, Tensor};
 use alloc::vec::Vec;
-
-/// Configuration options for `meshgrid`.
-#[derive(new, Debug, Copy, Clone)]
-pub struct MeshGridOptions {
-    /// Sparsity mode.
-    pub sparsity: GridSparsity,
-
-    /// Indexing mode.
-    pub indexing: GridIndexing,
-}
-
-impl Default for MeshGridOptions {
-    fn default() -> Self {
-        Self {
-            sparsity: GridSparsity::Dense,
-            indexing: GridIndexing::Matrix,
-        }
-    }
-}
-
-impl From<GridSparsity> for MeshGridOptions {
-    fn from(value: GridSparsity) -> Self {
-        Self {
-            sparsity: value,
-            ..Default::default()
-        }
-    }
-}
-
-impl From<GridIndexing> for MeshGridOptions {
-    fn from(value: GridIndexing) -> Self {
-        Self {
-            indexing: value,
-            ..Default::default()
-        }
-    }
-}
 
 /// Return a collection of coordinate matrices for coordinate vectors.
 ///
@@ -71,7 +34,7 @@ pub fn meshgrid<B: Backend, const N: usize, K, O>(
 ) -> [Tensor<B, N, K>; N]
 where
     K: BasicOps<B>,
-    O: Into<MeshGridOptions>,
+    O: Into<GridOptions>,
 {
     let options = options.into();
     let swap_dims = options.indexing == GridIndexing::Cartesian && N > 1;

--- a/crates/burn-tensor/src/tensor/grid/meshgrid.rs
+++ b/crates/burn-tensor/src/tensor/grid/meshgrid.rs
@@ -1,0 +1,192 @@
+use crate::backend::Backend;
+use crate::tensor::grid::{GridCompatIndexing, GridSparsity};
+use crate::tensor::{BasicOps, Tensor};
+use alloc::vec::Vec;
+
+/// Return a collection of coordinate matrices for coordinate vectors.
+///
+/// Takes N 1D tensors and returns N tensors where each tensor represents the coordinates
+/// in one dimension across an N-dimensional grid.
+///
+/// The generated coordinate tensors can either be `Sparse` or `Dense`:
+/// * In `Sparse` mode, output tensors will have shape 1 everywhere except their cardinal dimension.
+/// * In `Dense` mode, output tensors will be expanded to the full grid shape.
+///
+/// Equivalent to ``meshgrid_compat(tensors, sparsity, GridCompatIndexing::CartesianIndexing)``.
+///
+/// Users who need compatibility with the legacy `"xy"` indexing mode from
+/// NumPy and PyTorch should use `meshgrid_compat`.
+///
+/// See:
+///  - https://numpy.org/doc/stable/reference/generated/numpy.meshgrid.html
+///  - https://pytorch.org/docs/stable/generated/torch.meshgrid.html
+///
+/// # Arguments
+///
+/// * `tensors` - A slice of 1D tensors
+/// * `sparsity` - the sparse mode.
+/// * `indexing` - Optional IndexingMode, defaults to `MatrixIndexing`.
+///
+/// # Returns
+///
+/// A vector of N N-dimensional tensors representing the grid coordinates.
+pub fn meshgrid<B: Backend, const N: usize, K>(
+    tensors: &[Tensor<B, 1, K>; N],
+    sparsity: GridSparsity,
+) -> [Tensor<B, N, K>; N]
+where
+    K: BasicOps<B>,
+{
+    meshgrid_compat(tensors, sparsity, GridCompatIndexing::MatrixIndexing)
+}
+
+/// Return a dense collection of coordinate matrices for coordinate vectors.
+///
+/// Takes N 1D tensors and returns N dense tensors (populated with the full
+/// cartesian product shape of the inputs) where each tensor represents
+/// the coordinates in one dimension across an N-dimensional grid.
+///
+/// Equivalent to ``meshgrid(tensors, GridSparsity::Dense)``.
+///
+/// Users who need compatibility with the legacy `"xy"` indexing mode from
+/// NumPy and PyTorch should use `meshgrid_compat`.
+///
+/// See:
+///  - https://numpy.org/doc/stable/reference/generated/numpy.meshgrid.html
+///  - https://pytorch.org/docs/stable/generated/torch.meshgrid.html
+///
+/// # Arguments
+///
+/// * `tensors` - A slice of 1D tensors
+/// * `sparsity` - the sparse mode.
+/// * `indexing` - Optional IndexingMode, defaults to `MatrixIndexing`.
+///
+/// # Returns
+///
+/// A vector of N N-dimensional tensors representing the grid coordinates.
+pub fn meshgrid_dense<B: Backend, const N: usize, K>(
+    tensors: &[Tensor<B, 1, K>; N],
+) -> [Tensor<B, N, K>; N]
+where
+    K: BasicOps<B>,
+{
+    meshgrid_compat(
+        tensors,
+        GridSparsity::Dense,
+        GridCompatIndexing::MatrixIndexing,
+    )
+}
+
+/// Return a collection of coordinate matrices for coordinate vectors.
+///
+/// Takes N 1D tensors and returns N sparse tensors (each tensor has shape 1
+/// everywhere except its cardinal dimension) where each tensor represents
+/// the coordinates in one dimension across an N-dimensional grid.
+///
+/// Equivalent to ``meshgrid(tensors, GridSparsity::Sparse)``.
+///
+/// Users who need compatibility with the legacy `"xy"` indexing mode from
+/// NumPy and PyTorch should use `meshgrid_compat`.
+///
+/// See:
+///  - https://numpy.org/doc/stable/reference/generated/numpy.meshgrid.html
+///  - https://pytorch.org/docs/stable/generated/torch.meshgrid.html
+///
+/// # Arguments
+///
+/// * `tensors` - A slice of 1D tensors
+/// * `sparsity` - the sparse mode.
+/// * `indexing` - Optional IndexingMode, defaults to `MatrixIndexing`.
+///
+/// # Returns
+///
+/// A vector of N N-dimensional tensors representing the grid coordinates.
+pub fn meshgrid_sparse<B: Backend, const N: usize, K>(
+    tensors: &[Tensor<B, 1, K>; N],
+) -> [Tensor<B, N, K>; N]
+where
+    K: BasicOps<B>,
+{
+    meshgrid_compat(
+        tensors,
+        GridSparsity::Sparse,
+        GridCompatIndexing::MatrixIndexing,
+    )
+}
+
+/// Return a collection of coordinate matrices for coordinate vectors.
+///
+/// Takes N 1D tensors and returns N tensors where each tensor represents the coordinates
+/// in one dimension across an N-dimensional grid.
+///
+/// The generated coordinate tensors can either be `Sparse` or `Dense`:
+/// * In `Sparse` mode, output tensors will have shape 1 everywhere except their cardinal dimension.
+/// * In `Dense` mode, output tensors will be expanded to the full grid shape.
+///
+/// The optional `indexing` argument allows you to choose between two indexing modes:
+/// * `MatrixIndexing` (default): Dimensions are in the same order as the cardinality of the inputs.
+/// * `CartesianIndexing`: The first two dimensions are swapped, giving a backward compatibility
+///   with the legacy Cartesian indexing ("xy") style used by NumPy and PyTorch.
+///
+/// See:
+///  - https://numpy.org/doc/stable/reference/generated/numpy.meshgrid.html
+///  - https://pytorch.org/docs/stable/generated/torch.meshgrid.html
+///
+/// # Arguments
+///
+/// * `tensors` - A slice of 1D tensors
+/// * `sparsity` - the sparse mode.
+/// * `indexing` - Optional IndexingMode, defaults to `MatrixIndexing`.
+///
+/// # Returns
+///
+/// A vector of N N-dimensional tensors representing the grid coordinates.
+pub fn meshgrid_compat<B: Backend, const N: usize, K>(
+    tensors: &[Tensor<B, 1, K>; N],
+    sparsity: GridSparsity,
+    indexing: impl Into<Option<GridCompatIndexing>>,
+) -> [Tensor<B, N, K>; N]
+where
+    K: BasicOps<B>,
+{
+    let indexing_mode = indexing
+        .into()
+        .unwrap_or(GridCompatIndexing::MatrixIndexing);
+    let swap_dims = indexing_mode == GridCompatIndexing::CartesianIndexing && N > 1;
+
+    let mut grid_shape = [0; N];
+    for (i, tensor) in tensors.iter().enumerate() {
+        assert_eq!(
+            tensor.dims().len(),
+            1,
+            "All tensors must be 1D, found shape: {:?}",
+            tensor.dims()
+        );
+        grid_shape[i] = tensor.dims()[0];
+    }
+
+    let result = tensors
+        .iter()
+        .enumerate()
+        .map(|(i, tensor)| {
+            let mut coord_tensor_shape = [1; N];
+            coord_tensor_shape[i] = grid_shape[i];
+
+            // Reshape the tensor to have singleton dimensions in all but the i-th dimension
+            let mut tensor = tensor.clone().reshape(coord_tensor_shape);
+
+            if sparsity == GridSparsity::Dense {
+                tensor = tensor.expand(grid_shape);
+            }
+
+            if swap_dims {
+                // Swap the first two dimensions for "xy" / CartesianIndexing
+                tensor = tensor.swap_dims(0, 1);
+            }
+
+            tensor
+        })
+        .collect::<Vec<_>>();
+
+    result.try_into().unwrap()
+}

--- a/crates/burn-tensor/src/tensor/grid/meshgrid.rs
+++ b/crates/burn-tensor/src/tensor/grid/meshgrid.rs
@@ -154,16 +154,12 @@ where
         .unwrap_or(GridCompatIndexing::MatrixIndexing);
     let swap_dims = indexing_mode == GridCompatIndexing::CartesianIndexing && N > 1;
 
-    let mut grid_shape = [0; N];
-    for (i, tensor) in tensors.iter().enumerate() {
-        assert_eq!(
-            tensor.dims().len(),
-            1,
-            "All tensors must be 1D, found shape: {:?}",
-            tensor.dims()
-        );
-        grid_shape[i] = tensor.dims()[0];
-    }
+    let grid_shape: [usize; N] = tensors
+        .iter()
+        .map(|t| t.dims()[0])
+        .collect::<Vec<_>>()
+        .try_into()
+        .unwrap();
 
     let result = tensors
         .iter()

--- a/crates/burn-tensor/src/tensor/grid/mod.rs
+++ b/crates/burn-tensor/src/tensor/grid/mod.rs
@@ -2,16 +2,6 @@ mod meshgrid;
 
 pub use meshgrid::*;
 
-/// Enum to specify grid sparsity mode.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum GridSparsity {
-    /// The grid is sparse, expanded only at the cardinal dimensions.
-    Sparse,
-
-    /// The grid is fully expanded to the full cartesian product shape.
-    Dense,
-}
-
 /// Enum to specify index cardinal layout.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GridIndexing {
@@ -20,7 +10,45 @@ pub enum GridIndexing {
     #[default]
     Matrix,
 
-    /// The first two dimensions are swapped.
+    /// The same as Matrix, but the first two dimensions are swapped.
     /// Equivalent to "xy" indexing in NumPy and PyTorch.
     Cartesian,
+}
+
+/// Enum to specify grid sparsity mode.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GridSparsity {
+    /// The grid is fully expanded to the full cartesian product shape.
+    #[default]
+    Dense,
+
+    /// The grid is sparse, expanded only at the cardinal dimensions.
+    Sparse,
+}
+
+/// Grid policy options.
+#[derive(new, Default, Debug, Copy, Clone)]
+pub struct GridOptions {
+    /// Indexing mode.
+    pub indexing: GridIndexing,
+
+    /// Sparsity mode.
+    pub sparsity: GridSparsity,
+}
+
+impl From<GridIndexing> for GridOptions {
+    fn from(value: GridIndexing) -> Self {
+        Self {
+            indexing: value,
+            ..Default::default()
+        }
+    }
+}
+impl From<GridSparsity> for GridOptions {
+    fn from(value: GridSparsity) -> Self {
+        Self {
+            sparsity: value,
+            ..Default::default()
+        }
+    }
 }

--- a/crates/burn-tensor/src/tensor/grid/mod.rs
+++ b/crates/burn-tensor/src/tensor/grid/mod.rs
@@ -12,19 +12,14 @@ pub enum GridSparsity {
     Dense,
 }
 
-/// Legacy compatibility enum for grid indexing modes.
-///
-/// NumPy (and by copying, PyTorch) used an indexing mode which swapped the first two dimensions,
-/// added to simplify some graphics and plotting tasks. As it broke the natural order of the
-/// dimensions, the behavior was flagged, and migration plans are in-flight in both libraries
-/// to make the natural ordering the default.
+/// Enum to specify index cardinal layout.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum GridCompatIndexing {
+pub enum GridIndexing {
     /// Dimensions are in the same order as the cardinality of the inputs.
     /// Equivalent to "ij" indexing in NumPy and PyTorch.
-    MatrixIndexing,
+    Matrix,
 
     /// The first two dimensions are swapped.
     /// Equivalent to "xy" indexing in NumPy and PyTorch.
-    CartesianIndexing,
+    Cartesian,
 }

--- a/crates/burn-tensor/src/tensor/grid/mod.rs
+++ b/crates/burn-tensor/src/tensor/grid/mod.rs
@@ -1,0 +1,30 @@
+mod meshgrid;
+
+pub use meshgrid::*;
+
+/// Enum to specify grid sparsity mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GridSparsity {
+    /// The grid is sparse, expanded only at the cardinal dimensions.
+    Sparse,
+
+    /// The grid is fully expanded to the full cartesian product shape.
+    Dense,
+}
+
+/// Legacy compatibility enum for grid indexing modes.
+///
+/// NumPy (and by copying, PyTorch) used an indexing mode which swapped the first two dimensions,
+/// added to simplify some graphics and plotting tasks. As it broke the natural order of the
+/// dimensions, the behavior was flagged, and migration plans are in-flight in both libraries
+/// to make the natural ordering the default.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GridCompatIndexing {
+    /// Dimensions are in the same order as the cardinality of the inputs.
+    /// Equivalent to "ij" indexing in NumPy and PyTorch.
+    MatrixIndexing,
+
+    /// The first two dimensions are swapped.
+    /// Equivalent to "xy" indexing in NumPy and PyTorch.
+    CartesianIndexing,
+}

--- a/crates/burn-tensor/src/tensor/grid/mod.rs
+++ b/crates/burn-tensor/src/tensor/grid/mod.rs
@@ -13,10 +13,11 @@ pub enum GridSparsity {
 }
 
 /// Enum to specify index cardinal layout.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GridIndexing {
     /// Dimensions are in the same order as the cardinality of the inputs.
     /// Equivalent to "ij" indexing in NumPy and PyTorch.
+    #[default]
     Matrix,
 
     /// The first two dimensions are swapped.

--- a/crates/burn-tensor/src/tensor/mod.rs
+++ b/crates/burn-tensor/src/tensor/mod.rs
@@ -23,6 +23,9 @@ pub mod backend;
 /// The container module.
 pub mod container;
 
+/// The grid module.
+pub mod grid;
+
 /// The loss module.
 pub mod loss;
 
@@ -43,6 +46,7 @@ mod report;
 
 #[cfg(feature = "experimental-named-tensor")]
 mod named;
+
 #[cfg(feature = "experimental-named-tensor")]
 pub use named::*;
 

--- a/crates/burn-tensor/src/tensor/mod.rs
+++ b/crates/burn-tensor/src/tensor/mod.rs
@@ -46,7 +46,6 @@ mod report;
 
 #[cfg(feature = "experimental-named-tensor")]
 mod named;
-
 #[cfg(feature = "experimental-named-tensor")]
 pub use named::*;
 

--- a/crates/burn-tensor/src/tests/grid/meshgrid.rs
+++ b/crates/burn-tensor/src/tests/grid/meshgrid.rs
@@ -3,7 +3,7 @@ mod tests {
     use super::*;
     use burn_tensor::BasicOps;
     use burn_tensor::backend::Backend;
-    use burn_tensor::grid::{GridIndexing, GridSparsity, MeshGridOptions, meshgrid};
+    use burn_tensor::grid::{GridIndexing, GridOptions, GridSparsity, meshgrid};
     use burn_tensor::{Int, Shape, Tensor, TensorData};
 
     fn assert_tensors_equal<const N: usize, B: Backend, K>(
@@ -29,10 +29,7 @@ mod tests {
 
         // 3D, Dense, Matrix
         assert_tensors_equal(
-            &meshgrid(
-                &[x.clone(), y.clone(), z.clone()],
-                MeshGridOptions::default(),
-            ),
+            &meshgrid(&[x.clone(), y.clone(), z.clone()], GridOptions::default()),
             &[
                 x.clone().reshape([4, 1, 1]).expand(grid_shape),
                 y.clone().reshape([1, 2, 1]).expand(grid_shape),
@@ -60,9 +57,9 @@ mod tests {
         assert_tensors_equal(
             &meshgrid(
                 &[x.clone(), y.clone(), z.clone()],
-                MeshGridOptions {
-                    sparsity: GridSparsity::Sparse,
+                GridOptions {
                     indexing: GridIndexing::Matrix,
+                    sparsity: GridSparsity::Sparse,
                 },
             ),
             &[
@@ -103,7 +100,7 @@ mod tests {
         assert_tensors_equal(
             &meshgrid(
                 &[x.clone(), y.clone(), z.clone()],
-                MeshGridOptions::new(GridSparsity::Sparse, GridIndexing::Cartesian),
+                GridOptions::new(GridIndexing::Cartesian, GridSparsity::Sparse),
             ),
             &[
                 x.clone().reshape([4, 1, 1]).swap_dims(0, 1),
@@ -114,9 +111,9 @@ mod tests {
         assert_tensors_equal(
             &meshgrid(
                 &[x.clone(), y.clone(), z.clone()],
-                MeshGridOptions {
-                    sparsity: GridSparsity::Sparse,
+                GridOptions {
                     indexing: GridIndexing::Cartesian,
+                    sparsity: GridSparsity::Sparse,
                 },
             ),
             &[

--- a/crates/burn-tensor/src/tests/grid/meshgrid.rs
+++ b/crates/burn-tensor/src/tests/grid/meshgrid.rs
@@ -1,0 +1,132 @@
+#[burn_tensor_testgen::testgen(meshgrid)]
+mod tests {
+    use super::*;
+    use burn_tensor::BasicOps;
+    use burn_tensor::backend::Backend;
+    use burn_tensor::grid::{
+        GridCompatIndexing, GridSparsity, meshgrid, meshgrid_compat, meshgrid_dense,
+        meshgrid_sparse,
+    };
+    use burn_tensor::{Int, Shape, Tensor, TensorData};
+
+    fn assert_tensors_equal<const N: usize, B: Backend, K>(
+        actual: &[Tensor<B, N, K>; N],
+        expected: &[Tensor<B, N, K>; N],
+    ) where
+        K: BasicOps<B>,
+    {
+        for (a, e) in actual.iter().zip(expected.iter()) {
+            a.clone()
+                .into_data()
+                .assert_eq(&e.clone().into_data(), true);
+        }
+    }
+
+    #[test]
+    fn test_meshgrid() {
+        let x = TestTensor::<1>::from([1, 2, 3, 4]);
+        let y = TestTensor::<1>::from([5, 6]);
+        let z = TestTensor::<1>::from([7, 8]);
+
+        let grid_shape = [x.dims()[0], y.dims()[0], z.dims()[0]];
+
+        // 3D, Dense, Matrix
+        assert_tensors_equal(
+            &meshgrid_compat(
+                &[x.clone(), y.clone(), z.clone()],
+                GridSparsity::Dense,
+                None,
+            ),
+            &[
+                x.clone().reshape([4, 1, 1]).expand(grid_shape),
+                y.clone().reshape([1, 2, 1]).expand(grid_shape),
+                z.clone().reshape([1, 1, 2]).expand(grid_shape),
+            ],
+        );
+        assert_tensors_equal(
+            &meshgrid(&[x.clone(), y.clone(), z.clone()], GridSparsity::Dense),
+            &[
+                x.clone().reshape([4, 1, 1]).expand(grid_shape),
+                y.clone().reshape([1, 2, 1]).expand(grid_shape),
+                z.clone().reshape([1, 1, 2]).expand(grid_shape),
+            ],
+        );
+        assert_tensors_equal(
+            &meshgrid_dense(&[x.clone(), y.clone(), z.clone()]),
+            &[
+                x.clone().reshape([4, 1, 1]).expand(grid_shape),
+                y.clone().reshape([1, 2, 1]).expand(grid_shape),
+                z.clone().reshape([1, 1, 2]).expand(grid_shape),
+            ],
+        );
+
+        // 3D, Sparse, Matrix
+        assert_tensors_equal(
+            &meshgrid_compat(
+                &[x.clone(), y.clone(), z.clone()],
+                GridSparsity::Sparse,
+                // Via the Into promotion:
+                GridCompatIndexing::MatrixIndexing,
+            ),
+            &[
+                x.clone().reshape([4, 1, 1]),
+                y.clone().reshape([1, 2, 1]),
+                z.clone().reshape([1, 1, 2]),
+            ],
+        );
+        assert_tensors_equal(
+            &meshgrid(&[x.clone(), y.clone(), z.clone()], GridSparsity::Sparse),
+            &[
+                x.clone().reshape([4, 1, 1]),
+                y.clone().reshape([1, 2, 1]),
+                z.clone().reshape([1, 1, 2]),
+            ],
+        );
+        assert_tensors_equal(
+            &meshgrid_sparse(&[x.clone(), y.clone(), z.clone()]),
+            &[
+                x.clone().reshape([4, 1, 1]),
+                y.clone().reshape([1, 2, 1]),
+                z.clone().reshape([1, 1, 2]),
+            ],
+        );
+
+        // 3D, sparse=false, Cartesian
+        assert_tensors_equal(
+            &meshgrid_compat(
+                &[x.clone(), y.clone(), z.clone()],
+                GridSparsity::Dense,
+                // Via the Option type:
+                Some(GridCompatIndexing::CartesianIndexing),
+            ),
+            &[
+                x.clone()
+                    .reshape([4, 1, 1])
+                    .expand(grid_shape)
+                    .swap_dims(0, 1),
+                y.clone()
+                    .reshape([1, 2, 1])
+                    .expand(grid_shape)
+                    .swap_dims(0, 1),
+                z.clone()
+                    .reshape([1, 1, 2])
+                    .expand(grid_shape)
+                    .swap_dims(0, 1),
+            ],
+        );
+
+        // 3D, sparse=true, Cartesian
+        assert_tensors_equal(
+            &meshgrid_compat(
+                &[x.clone(), y.clone(), z.clone()],
+                GridSparsity::Sparse,
+                Some(GridCompatIndexing::CartesianIndexing),
+            ),
+            &[
+                x.clone().reshape([4, 1, 1]).swap_dims(0, 1),
+                y.clone().reshape([1, 2, 1]).swap_dims(0, 1),
+                z.clone().reshape([1, 1, 2]).swap_dims(0, 1),
+            ],
+        );
+    }
+}

--- a/crates/burn-tensor/src/tests/grid/mod.rs
+++ b/crates/burn-tensor/src/tests/grid/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod meshgrid;

--- a/crates/burn-tensor/src/tests/mod.rs
+++ b/crates/burn-tensor/src/tests/mod.rs
@@ -1,5 +1,6 @@
 mod activation;
 mod clone_invariance;
+mod grid;
 mod module;
 mod ops;
 mod primitive;
@@ -153,6 +154,9 @@ macro_rules! testgen_with_float_param {
         burn_tensor::testgen_log_sigmoid!();
         burn_tensor::testgen_silu!();
         burn_tensor::testgen_tanh_activation!();
+
+        // test grid
+        burn_tensor::testgen_meshgrid!();
 
         // test module
         burn_tensor::testgen_module_conv1d!();


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

- create `burn::grid` module.
- add `meshgrid` family of functions:
  - `meshgrid_compat`
  - `meshgrid`
  - `meshgrid_dense`
  - `meshgrid_sparse`

### Testing

Unit tests added