### PR TITLE
Orthogonal initialization

### DIFF
--- a/crates/burn-core/src/nn/initializer.rs
+++ b/crates/burn-core/src/nn/initializer.rs
@@ -544,7 +544,6 @@ mod tests {
             .assert_within_range(-0.00001..0.00001);
     }
 
-
     #[test]
     fn initializer_orthogonal_correct() {
         TB::seed(0);
@@ -557,8 +556,13 @@ mod tests {
             .init([size, size], &Default::default())
             .into_value();
         let eye = Tensor::<TB, 2>::eye(size, &Default::default());
-        let diff: f32 = (eye - q.clone().transpose().matmul(q.clone()).round()).sum().into_scalar();
-        assert!(-0.00001 < diff && diff < 0.00001, "Expected Q.T @ Q to be close to identiy matrix.");
+        let diff: f32 = (eye - q.clone().transpose().matmul(q.clone()).round())
+            .sum()
+            .into_scalar();
+        assert!(
+            -0.00001 < diff && diff < 0.00001,
+            "Expected Q.T @ Q to be close to identiy matrix."
+        );
     }
 
     #[test]

--- a/crates/burn-core/src/nn/initializer.rs
+++ b/crates/burn-core/src/nn/initializer.rs
@@ -555,6 +555,7 @@ mod tests {
             .init([size, size], &Default::default())
             .into_value();
         let eye = Tensor::<TB, 2>::eye(size, &Default::default());
+
         // Q.T @ Q should be close to identity matrix
         q.clone()
             .transpose()

--- a/crates/burn-core/src/nn/initializer.rs
+++ b/crates/burn-core/src/nn/initializer.rs
@@ -561,7 +561,7 @@ mod tests {
             .into_scalar();
         assert!(
             -0.00001 < diff && diff < 0.00001,
-            "Expected Q.T @ Q to be close to identiy matrix."
+            "Expected Q.T @ Q to be close to identity matrix."
         );
     }
 

--- a/crates/burn-core/src/nn/initializer.rs
+++ b/crates/burn-core/src/nn/initializer.rs
@@ -579,7 +579,7 @@ mod tests {
         let dims = t.dims();
         assert_eq!(
             shape, dims,
-            "Expected the shape of the input tensor to match the shape of the ouput. ({:?}, {:?})",
+            "Expected the shape of the input tensor to match the shape of the output. ({:?}, {:?})",
             shape, dims
         );
 
@@ -591,7 +591,7 @@ mod tests {
         let dims = t.dims();
         assert_eq!(
             shape, dims,
-            "Expected the shape of the input tensor to match the shape of the ouput. ({:?}, {:?})",
+            "Expected the shape of the input tensor to match the shape of the output. ({:?}, {:?})",
             shape, dims
         );
     }

--- a/crates/burn-core/src/nn/initializer.rs
+++ b/crates/burn-core/src/nn/initializer.rs
@@ -538,10 +538,9 @@ mod tests {
         let q_matmul_r = qr.0.clone().matmul(qr.1.clone());
 
         // assert that the difference between input (`a`) and Q @ R is (almost) zero
-        (a.round() - q_matmul_r.clone().round())
-            .sum()
+        q_matmul_r
             .into_data()
-            .assert_within_range(-0.00001..0.00001);
+            .assert_approx_eq::<FT>(&a.into_data(), Tolerance::rel_abs(1e-5, 1e-5));
     }
 
     #[test]

--- a/crates/burn-core/src/nn/initializer.rs
+++ b/crates/burn-core/src/nn/initializer.rs
@@ -216,6 +216,7 @@ fn qr_decomposition<B: Backend>(
             r = r
                 .clone()
                 .slice_assign([i..i + 1, j..j + 1], r_ij.clone().unsqueeze());
+
             v = v - q_i.mul(r_ij);
         }
 
@@ -224,14 +225,16 @@ fn qr_decomposition<B: Backend>(
             .powf(Tensor::from_floats([2.0], device))
             .sum()
             .sqrt();
+
         r = r
             .clone()
             .slice_assign([j..j + 1, j..j + 1], r_jj.clone().unsqueeze());
 
         let q_j = v / r_jj;
+
         q = q
             .clone()
-            .slice_assign([0..n, j..j + 1], q_j.unsqueeze_dim(1));
+            .slice_assign([0..m, j..j+1], q_j.unsqueeze_dim(1));
     }
 
     (q, r)

--- a/crates/burn-core/src/nn/initializer.rs
+++ b/crates/burn-core/src/nn/initializer.rs
@@ -284,8 +284,6 @@ fn qr_decomposition<B: Backend>(
 
 #[cfg(test)]
 mod tests {
-    use core::default;
-
     use super::*;
 
     use crate::tensor::{ElementConversion, TensorData};
@@ -544,6 +542,23 @@ mod tests {
             .sum()
             .into_data()
             .assert_within_range(-0.00001..0.00001);
+    }
+
+
+    #[test]
+    fn initializer_orthogonal_correct() {
+        TB::seed(0);
+
+        let gain = 1.;
+
+        // test 2D tensor
+        let size = 10;
+        let q: Tensor<TB, 2> = Initializer::Orthogonal { gain }
+            .init([size, size], &Default::default())
+            .into_value();
+        let eye = Tensor::<TB, 2>::eye(size, &Default::default());
+        let diff: f32 = (eye - q.clone().transpose().matmul(q.clone()).round()).sum().into_scalar();
+        assert!(-0.00001 < diff && diff < 0.00001, "Expected Q.T @ Q to be close to identiy matrix.");
     }
 
     #[test]

--- a/crates/burn-core/src/nn/initializer.rs
+++ b/crates/burn-core/src/nn/initializer.rs
@@ -555,13 +555,12 @@ mod tests {
             .init([size, size], &Default::default())
             .into_value();
         let eye = Tensor::<TB, 2>::eye(size, &Default::default());
-        let diff: f32 = (eye - q.clone().transpose().matmul(q.clone()).round())
-            .sum()
-            .into_scalar();
-        assert!(
-            -0.00001 < diff && diff < 0.00001,
-            "Expected Q.T @ Q to be close to identity matrix."
-        );
+        // Q.T @ Q should be close to identity matrix
+        q.clone()
+            .transpose()
+            .matmul(q)
+            .into_data()
+            .assert_approx_eq::<FT>(&eye.into_data(), Tolerance::rel_abs(1e-5, 1e-5));
     }
 
     #[test]

--- a/crates/burn-core/src/nn/initializer.rs
+++ b/crates/burn-core/src/nn/initializer.rs
@@ -3,7 +3,7 @@ use crate::tensor::Shape;
 use crate::config::Config;
 use crate::module::{Param, ParamId};
 use crate::tensor::backend::Backend;
-use crate::tensor::{Distribution, Tensor};
+use crate::tensor::{Distribution, Tensor, s};
 
 use crate as burn;
 
@@ -248,10 +248,10 @@ fn qr_decomposition<B: Backend>(
     let mut r = Tensor::<B, 2>::zeros([n, n], device);
 
     for j in 0..n {
-        let mut v: Tensor<B, 1> = a.clone().slice(burn::prelude::s![.., j..=j]).squeeze(1);
+        let mut v: Tensor<B, 1> = a.clone().slice(s![.., j..=j]).squeeze(1);
 
         for i in 0..j {
-            let q_i: Tensor<B, 1> = q.clone().slice(burn::prelude::s![.., i..=i]).squeeze(1);
+            let q_i: Tensor<B, 1> = q.clone().slice(s![.., i..=i]).squeeze(1);
             let r_ij = q_i.clone().mul(v.clone()).sum();
 
             r = r

--- a/crates/onnx-ir/src/proto_conversion.rs
+++ b/crates/onnx-ir/src/proto_conversion.rs
@@ -221,7 +221,7 @@ impl TryFrom<ValueInfoProto> for Argument {
                 }
             });
 
-            // TODO DT use infered shape information
+            // TODO DT use inferred shape information
 
             let static_shape = if has_unknown_dim {
                 None


### PR DESCRIPTION
## Orthogonal weight initialization like in Pytorch

### Checklist

- [x] Confirmed that `run-checks all` script has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs
No related Issues/PRs. 

### Changes
Some models need to be initialized with orthogonal weights. Pytorch provides that kind of initialization scheme ([torch.nn.init.orthogonal_](https://pytorch.org/docs/stable/nn.init.html#torch.nn.init.orthogonal_)). This PR implements orthogonal weight initialization for burn.

### Testing
This PR comes with four tests checking the correctness of the calculations and that initialization itself is working. 
