### PR TITLE
Add scalar tensor operations

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -248,6 +248,7 @@ Those operations are available for numeric tensor kinds: `Float` and `Int`.
 | `tensor.sort_with_indices(dim)`                                 | `tensor.sort(dim)`                             |
 | `tensor.sub(other)` or `tensor - other`                         | `tensor - other`                               |
 | `tensor.sub_scalar(scalar)` or `tensor - scalar`                | `tensor - scalar`                              |
+| `scalar - tensor`                                               | `scalar - tensor`                              |
 | `tensor.sum()`                                                  | `tensor.sum()`                                 |
 | `tensor.sum_dim(dim)`                                           | `tensor.sum(dim, keepdim=True)`                |
 | `tensor.topk(k, dim)`                                           | `tensor.topk(k, dim).values`                   |
@@ -260,35 +261,35 @@ Those operations are available for numeric tensor kinds: `Float` and `Int`.
 
 Those operations are only available for `Float` tensors.
 
-| Burn API                                     | PyTorch Equivalent                 |
-| -------------------------------------------- | ---------------------------------- |
-| `tensor.cast(dtype)`                         | `tensor.to(dtype)`                 |
-| `tensor.ceil()`                              | `tensor.ceil()`                    |
-| `tensor.cos()`                               | `tensor.cos()`                     |
-| `tensor.cosh()`                              | `tensor.cosh()`                    |
-| `tensor.erf()`                               | `tensor.erf()`                     |
-| `tensor.exp()`                               | `tensor.exp()`                     |
-| `tensor.floor()`                             | `tensor.floor()`                   |
-| `tensor.from_floats(floats, device)`         | N/A                                |
-| `tensor.from_full_precision(tensor)`         | N/A                                |
-| `tensor.int()`                               | Similar to `tensor.to(torch.long)` |
-| `tensor.log()`                               | `tensor.log()`                     |
-| `tensor.log1p()`                             | `tensor.log1p()`                   |
-| `tensor.matmul(other)`                       | `tensor.matmul(other)`             |
-| `tensor.random(shape, distribution, device)` | N/A                                |
-| `tensor.random_like(distribution)`           | `torch.rand_like()` only uniform   |
-| `tensor.recip()`                             | `tensor.reciprocal()`              |
-| `tensor.round()`                             | `tensor.round()`                   |
-| `tensor.sin()`                               | `tensor.sin()`                     |
-| `tensor.sinh()`                              | `tensor.sinh()`                    |
-| `tensor.sqrt()`                              | `tensor.sqrt()`                    |
-| `tensor.tan()`                               | `tensor.tan()`                     |
-| `tensor.tanh()`                              | `tensor.tanh()`                    |
-| `tensor.to_full_precision()`                 | `tensor.to(torch.float)`           |
-| `tensor.var(dim)`                            | `tensor.var(dim)`                  |
-| `tensor.var_bias(dim)`                       | N/A                                |
-| `tensor.var_mean(dim)`                       | N/A                                |
-| `tensor.var_mean_bias(dim)`                  | N/A                                |
+| Burn API                                     | PyTorch Equivalent                      |
+| -------------------------------------------- | --------------------------------------- |
+| `tensor.cast(dtype)`                         | `tensor.to(dtype)`                      |
+| `tensor.ceil()`                              | `tensor.ceil()`                         |
+| `tensor.cos()`                               | `tensor.cos()`                          |
+| `tensor.cosh()`                              | `tensor.cosh()`                         |
+| `tensor.erf()`                               | `tensor.erf()`                          |
+| `tensor.exp()`                               | `tensor.exp()`                          |
+| `tensor.floor()`                             | `tensor.floor()`                        |
+| `tensor.from_floats(floats, device)`         | N/A                                     |
+| `tensor.from_full_precision(tensor)`         | N/A                                     |
+| `tensor.int()`                               | Similar to `tensor.to(torch.long)`      |
+| `tensor.log()`                               | `tensor.log()`                          |
+| `tensor.log1p()`                             | `tensor.log1p()`                        |
+| `tensor.matmul(other)`                       | `tensor.matmul(other)`                  |
+| `tensor.random(shape, distribution, device)` | N/A                                     |
+| `tensor.random_like(distribution)`           | `torch.rand_like()` only uniform        |
+| `tensor.recip()` or `1.0 / tensor`           | `tensor.reciprocal()` or `1.0 / tensor` |
+| `tensor.round()`                             | `tensor.round()`                        |
+| `tensor.sin()`                               | `tensor.sin()`                          |
+| `tensor.sinh()`                              | `tensor.sinh()`                         |
+| `tensor.sqrt()`                              | `tensor.sqrt()`                         |
+| `tensor.tan()`                               | `tensor.tan()`                          |
+| `tensor.tanh()`                              | `tensor.tanh()`                         |
+| `tensor.to_full_precision()`                 | `tensor.to(torch.float)`                |
+| `tensor.var(dim)`                            | `tensor.var(dim)`                       |
+| `tensor.var_bias(dim)`                       | N/A                                     |
+| `tensor.var_mean(dim)`                       | N/A                                     |
+| `tensor.var_mean_bias(dim)`                  | N/A                                     |
 
 ### Int Operations
 

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -4372,7 +4372,7 @@ where
 {
     type Output = Self;
 
-    fn add(self, rhs: Tensor<B, D, K>) -> Self {
+    fn add(self, rhs: Tensor<B, D, K>) -> Self::Output {
         Self::add(self, rhs)
     }
 }
@@ -4385,7 +4385,7 @@ where
 {
     type Output = Self;
 
-    fn add(self, other: E) -> Self {
+    fn add(self, other: E) -> Self::Output {
         Tensor::add_scalar(self, other)
     }
 }
@@ -4416,20 +4416,20 @@ where
 {
     type Output = Self;
 
-    fn sub(self, rhs: Tensor<B, D, K>) -> Self {
+    fn sub(self, rhs: Tensor<B, D, K>) -> Self::Output {
         Tensor::sub(self, rhs)
     }
 }
 
 // Tensor - scalar
-impl<E, const D: usize, B: Backend, K: Numeric<B>> core::ops::Sub<E> for Tensor<B, D, K>
+impl<E: ElementConversion, const D: usize, B: Backend, K: Numeric<B>> core::ops::Sub<E>
+    for Tensor<B, D, K>
 where
-    E: ElementConversion,
     K::Elem: Element,
 {
     type Output = Self;
 
-    fn sub(self, other: E) -> Self {
+    fn sub(self, other: E) -> Self::Output {
         Tensor::sub_scalar(self, other)
     }
 }
@@ -4454,26 +4454,26 @@ macro_rules! impl_tensor_scalar_sub {
 impl_tensor_scalar_sub!(f32, f64, i32, i64, u32, u64);
 
 // Tensor / tensor
-impl<B: Backend, const D: usize, K: Numeric<B>> core::ops::Div<Tensor<B, D, K>> for Tensor<B, D, K>
+impl<B: Backend, const D: usize, K: Numeric<B>> core::ops::Div<Self> for Tensor<B, D, K>
 where
     K::Elem: Element,
 {
     type Output = Self;
 
-    fn div(self, rhs: Tensor<B, D, K>) -> Self {
+    fn div(self, rhs: Self) -> Self::Output {
         Tensor::div(self, rhs)
     }
 }
 
 // Tensor / scalar
-impl<E, const D: usize, B: Backend, K: Numeric<B>> core::ops::Div<E> for Tensor<B, D, K>
+impl<E: ElementConversion, const D: usize, B: Backend, K: Numeric<B>> core::ops::Div<E>
+    for Tensor<B, D, K>
 where
-    E: ElementConversion,
     K::Elem: Element,
 {
     type Output = Self;
 
-    fn div(self, other: E) -> Self {
+    fn div(self, other: E) -> Self::Output {
         Tensor::div_scalar(self, other)
     }
 }
@@ -4489,7 +4489,7 @@ macro_rules! impl_tensor_scalar_div {
                 type Output = Tensor<B, D, K>;
 
                 fn div(self, tensor: Tensor<B, D, K>) -> Self::Output {
-                    let data = TensorData::new(vec![self], [1]);
+                    let data = TensorData::new(alloc::vec![self], [1]);
                     let numerator = Tensor::<B, D, K>::from_data(data, &tensor.device()).unsqueeze();
                     Tensor::div(numerator, tensor)
                 }
@@ -4501,12 +4501,13 @@ macro_rules! impl_tensor_scalar_div {
 impl_tensor_scalar_div!(f32, f64, i32, i64, u32, u64);
 
 // Tensor % tensor.
-impl<const D: usize, B: Backend, K: Numeric<B>> core::ops::Rem<Tensor<B, D, K>> for Tensor<B, D, K>
+impl<const D: usize, B: Backend, K: Numeric<B>> core::ops::Rem<Self> for Tensor<B, D, K>
 where
     K::Elem: Element,
 {
     type Output = Self;
-    fn rem(self, rhs: Tensor<B, D, K>) -> Self::Output {
+
+    fn rem(self, rhs: Self) -> Self::Output {
         Tensor::remainder(self, rhs)
     }
 }
@@ -4519,19 +4520,19 @@ where
 {
     type Output = Self;
 
-    fn rem(self, other: E) -> Self {
+    fn rem(self, other: E) -> Self::Output {
         Tensor::remainder_scalar(self, other)
     }
 }
 
 // Tensor * tensor.
-impl<B: Backend, const D: usize, K: Numeric<B>> core::ops::Mul<Tensor<B, D, K>> for Tensor<B, D, K>
+impl<B: Backend, const D: usize, K: Numeric<B>> core::ops::Mul<Self> for Tensor<B, D, K>
 where
     K::Elem: Element,
 {
     type Output = Self;
 
-    fn mul(self, rhs: Tensor<B, D, K>) -> Self {
+    fn mul(self, rhs: Self) -> Self::Output {
         Tensor::mul(self, rhs)
     }
 }
@@ -4544,7 +4545,7 @@ where
 {
     type Output = Self;
 
-    fn mul(self, other: E) -> Self {
+    fn mul(self, other: E) -> Self::Output {
         Tensor::mul_scalar(self, other)
     }
 }
@@ -4576,7 +4577,7 @@ where
 {
     type Output = Self;
 
-    fn neg(self) -> Self {
+    fn neg(self) -> Self::Output {
         Tensor::neg(self)
     }
 }


### PR DESCRIPTION
While tensor <op> scalar generally already existed, scalar <op> tensor didn't.

This is especially annoying for operations like 1.0 / tensor or a common case like (1.0 - tensor).

Due to Rust's orphan rules these sadly can't be implemented for every E: ElementConversion, but manually implementing them for primitives seems to work fine!