### PR TITLE
Fix burn-cubecl with autotune disabled

### DIFF
--- a/crates/burn-cubecl/src/kernel/conv/conv_transpose2d/base.rs
+++ b/crates/burn-cubecl/src/kernel/conv/conv_transpose2d/base.rs
@@ -3,7 +3,9 @@ use cubecl::linalg::convolution::ConvLaunchError;
 
 use crate::{CubeRuntime, FloatElement, IntElement, tensor::CubeTensor};
 
-use super::{conv_transpose2d_autotune, conv_transpose2d_col2im, conv_transpose2d_direct};
+#[cfg(feature = "autotune")]
+use super::conv_transpose2d_autotune;
+use super::{conv_transpose2d_col2im, conv_transpose2d_direct};
 
 /// The strategy to be used when launching a conv_transpose kernel.
 pub enum ConvTranspose2dStrategy {

--- a/crates/burn-cubecl/src/kernel/conv/conv_transpose2d/tune.rs
+++ b/crates/burn-cubecl/src/kernel/conv/conv_transpose2d/tune.rs
@@ -1,14 +1,10 @@
-use burn_tensor::{DType, ElementConversion, Shape, ops::ConvTransposeOptions};
-use cubecl::{
-    AutotuneKey,
-    tune::{LocalTuner, TunableSet, local_tuner},
-};
-use serde::{Deserialize, Serialize};
+use burn_tensor::{ElementConversion, Shape, ops::ConvTransposeOptions};
+use cubecl::tune::{LocalTuner, TunableSet, local_tuner};
 
 use crate::{
     CubeAutotuneKey, CubeRuntime, CubeTuneId, FloatElement,
     kernel::{
-        conv::{conv_transpose2d_col2im, conv_transpose2d_direct},
+        conv::{ConvTranspose2dAutotuneKey, conv_transpose2d_col2im, conv_transpose2d_direct},
         prng::random_uniform,
     },
     tensor::CubeTensor,
@@ -35,29 +31,6 @@ pub fn conv_transpose2d_autotune<R: CubeRuntime, E: FloatElement>(
         &tune_set,
         (input, weights, bias, options),
     )
-}
-
-#[derive(Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize, AutotuneKey)]
-/// Autotune key representative of matmul versions
-pub struct ConvTranspose2dAutotuneKey {
-    pub kernel_size: [usize; 2],
-    pub stride: [usize; 2],
-    pub padding: [usize; 2],
-    pub padding_out: [usize; 2],
-    pub dilation: [usize; 2],
-    pub groups: usize,
-    #[autotune(anchor)]
-    pub in_channels: usize,
-    #[autotune(anchor)]
-    pub out_channels: usize,
-    #[autotune(anchor)]
-    pub height: usize,
-    #[autotune(anchor)]
-    pub width: usize,
-    #[autotune(anchor)]
-    pub batch_size: usize,
-    pub has_bias: bool,
-    pub dtype: DType,
 }
 
 pub fn create_transpose2d_input<R: CubeRuntime, E: FloatElement>(

--- a/crates/burn-cubecl/src/kernel/conv/implicit_gemm/launch.rs
+++ b/crates/burn-cubecl/src/kernel/conv/implicit_gemm/launch.rs
@@ -43,6 +43,7 @@ pub fn conv_gemm_cyclic<R: CubeRuntime, F: FloatElement, const N: usize>(
 /// * `weight` - The weights (filter) applied to each kernel
 /// * `bias` - The bias added to each channel
 /// * `options` - The options to use for the convolution
+#[allow(unused)]
 pub fn conv_gemm_tma<R: CubeRuntime, F: FloatElement, const N: usize>(
     input: CubeTensor<R>,
     weight: CubeTensor<R>,
@@ -61,6 +62,7 @@ pub fn conv_gemm_tma<R: CubeRuntime, F: FloatElement, const N: usize>(
 /// * `weight` - The weights (filter) applied to each kernel
 /// * `bias` - The bias added to each channel
 /// * `options` - The options to use for the convolution
+#[allow(unused)]
 pub fn conv_gemm_tma_multi_stage<R: CubeRuntime, F: FloatElement, const N: usize>(
     input: CubeTensor<R>,
     weight: CubeTensor<R>,

--- a/crates/burn-cubecl/src/kernel/conv/mod.rs
+++ b/crates/burn-cubecl/src/kernel/conv/mod.rs
@@ -9,6 +9,7 @@ mod implicit_gemm;
 
 #[cfg(feature = "autotune")]
 mod tune;
+mod tune_key;
 
 pub(crate) use conv_transpose2d::*;
 pub(crate) use conv_transpose3d::*;
@@ -23,3 +24,4 @@ pub use conv_transpose2d::{ConvTranspose2dStrategy, conv_transpose2d, layout_swa
 
 #[cfg(feature = "autotune")]
 pub(crate) use tune::*;
+pub(crate) use tune_key::*;

--- a/crates/burn-cubecl/src/kernel/conv/tune.rs
+++ b/crates/burn-cubecl/src/kernel/conv/tune.rs
@@ -1,9 +1,5 @@
-use burn_tensor::{DType, ElementConversion, Shape, ops::ConvOptions};
-use cubecl::{
-    AutotuneKey,
-    tune::{LocalTuner, TunableSet, anchor, local_tuner},
-};
-use serde::{Deserialize, Serialize};
+use burn_tensor::{ElementConversion, Shape, ops::ConvOptions};
+use cubecl::tune::{LocalTuner, TunableSet, anchor, local_tuner};
 
 use crate::{
     CubeAutotuneKey, CubeRuntime, CubeTuneId, FloatElement,
@@ -17,24 +13,7 @@ use crate::{
     tensor::CubeTensor,
 };
 
-#[derive(Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize, AutotuneKey)]
-/// Autotune key representative of matmul versions
-pub struct ConvAutotuneKey {
-    pub kernel_size: Vec<usize>,
-    pub stride: Vec<usize>,
-    pub padding: Vec<usize>,
-    pub dilation: Vec<usize>,
-    pub groups: usize,
-    #[autotune(anchor)]
-    pub in_channels: usize,
-    #[autotune(anchor)]
-    pub out_channels: usize,
-    pub shape: Vec<usize>,
-    #[autotune(anchor)]
-    pub batch_size: usize,
-    pub has_bias: bool,
-    pub dtype: DType,
-}
+use super::ConvAutotuneKey;
 
 /// Executes autotune on conv2d operations
 pub fn conv_autotune<R: CubeRuntime, E: FloatElement, const N: usize>(

--- a/crates/burn-cubecl/src/kernel/conv/tune_key.rs
+++ b/crates/burn-cubecl/src/kernel/conv/tune_key.rs
@@ -1,0 +1,45 @@
+use burn_tensor::DType;
+use cubecl::AutotuneKey;
+use serde::{Deserialize, Serialize};
+
+#[derive(Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize, AutotuneKey)]
+/// Autotune key representative of matmul versions
+pub struct ConvAutotuneKey {
+    pub kernel_size: Vec<usize>,
+    pub stride: Vec<usize>,
+    pub padding: Vec<usize>,
+    pub dilation: Vec<usize>,
+    pub groups: usize,
+    #[autotune(anchor)]
+    pub in_channels: usize,
+    #[autotune(anchor)]
+    pub out_channels: usize,
+    pub shape: Vec<usize>,
+    #[autotune(anchor)]
+    pub batch_size: usize,
+    pub has_bias: bool,
+    pub dtype: DType,
+}
+
+#[derive(Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize, AutotuneKey)]
+/// Autotune key representative of matmul versions
+pub struct ConvTranspose2dAutotuneKey {
+    pub kernel_size: [usize; 2],
+    pub stride: [usize; 2],
+    pub padding: [usize; 2],
+    pub padding_out: [usize; 2],
+    pub dilation: [usize; 2],
+    pub groups: usize,
+    #[autotune(anchor)]
+    pub in_channels: usize,
+    #[autotune(anchor)]
+    pub out_channels: usize,
+    #[autotune(anchor)]
+    pub height: usize,
+    #[autotune(anchor)]
+    pub width: usize,
+    #[autotune(anchor)]
+    pub batch_size: usize,
+    pub has_bias: bool,
+    pub dtype: DType,
+}

--- a/crates/burn-cubecl/src/kernel/matmul/mod.rs
+++ b/crates/burn-cubecl/src/kernel/matmul/mod.rs
@@ -5,5 +5,6 @@ mod tune;
 pub mod utils;
 
 pub use base::*;
+#[cfg(feature = "autotune")]
 pub use tune::*;
 pub use utils::*;

--- a/crates/burn-cubecl/src/kernel/reduce/base.rs
+++ b/crates/burn-cubecl/src/kernel/reduce/base.rs
@@ -3,10 +3,24 @@ use super::{autotune_reduce, autotune_sum};
 use crate::{CubeRuntime, element::CubeElement, ops::numeric::empty_device, tensor::CubeTensor};
 use burn_tensor::{DType, Shape};
 pub use cubecl::reduce::instructions::{ArgMax, ArgMin, Mean, Prod, Sum};
-use cubecl::reduce::{
-    instructions::{ReduceFn, ReduceFnConfig},
-    shared_sum,
+use cubecl::{
+    AutotuneKey,
+    reduce::{
+        instructions::{ReduceFn, ReduceFnConfig},
+        shared_sum,
+    },
 };
+use serde::{Deserialize, Serialize};
+
+#[derive(Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize, AutotuneKey)]
+/// Autotune key representative of sum versions
+pub struct SumAutotuneKey {
+    /// The type of the tensor
+    pub dtype: burn_tensor::DType,
+    /// The anchored length of the tensor
+    #[autotune(anchor)]
+    pub length: usize,
+}
 
 /// Specialize reduce function to compute the sum of all elements of the `input` tensor and return
 /// the value into a single-element tensor of shape `1 x 1 x 1 x ...` with the same rank as `input`.

--- a/crates/burn-cubecl/src/kernel/reduce/mod.rs
+++ b/crates/burn-cubecl/src/kernel/reduce/mod.rs
@@ -1,5 +1,7 @@
 mod base;
+#[cfg(feature = "autotune")]
 mod tune;
 
 pub use base::*;
+#[cfg(feature = "autotune")]
 pub use tune::*;

--- a/crates/burn-cubecl/src/kernel/reduce/tune.rs
+++ b/crates/burn-cubecl/src/kernel/reduce/tune.rs
@@ -2,17 +2,17 @@
 
 use burn_tensor::ElementConversion;
 use cubecl::{
-    AutotuneKey,
     client::ComputeClient,
     reduce::{ReduceFamily, tune_key::ReduceAutotuneKey},
     tune::{LocalTuner, TunableSet, local_tuner},
 };
-use serde::{Deserialize, Serialize};
 
 use crate::{
     CubeAutotuneKey, CubeElement, CubeRuntime, CubeTuneId, kernel::prng::random_like_uniform,
     ops::numeric::empty_device, tensor::CubeTensor,
 };
+
+use super::SumAutotuneKey;
 
 /// Executes autotune on reduce operations.
 pub fn autotune_reduce<
@@ -237,15 +237,8 @@ pub(crate) fn create_key_sum<Run: CubeRuntime>(input: &CubeTensor<Run>) -> CubeA
     CubeAutotuneKey::Sum(SumAutotuneKey::generate(input))
 }
 
-#[derive(Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize, AutotuneKey)]
-/// Autotune key representative of sum versions
-pub struct SumAutotuneKey {
-    dtype: burn_tensor::DType,
-    #[autotune(anchor)]
-    length: usize,
-}
-
 impl SumAutotuneKey {
+    #[allow(unused)]
     pub(crate) fn generate<Run: CubeRuntime>(input: &CubeTensor<Run>) -> Self {
         let dtype = input.dtype;
         let length = input.shape.num_elements();


### PR DESCRIPTION
Small fix to feature gates that were causing compile errors with autotune disabled. This was caused by the module refactor in convolution.
