### PR TITLE
Specialize powi instruction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1498,7 +1498,6 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d983df489d527cee287e8de195af48c639c6975e#d983df489d527cee287e8de195af48c639c6975e"
 dependencies = [
  "cubecl-core",
  "cubecl-cuda",
@@ -1514,7 +1513,6 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d983df489d527cee287e8de195af48c639c6975e#d983df489d527cee287e8de195af48c639c6975e"
 dependencies = [
  "bytemuck",
  "derive-new 0.6.0",
@@ -1537,7 +1535,6 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d983df489d527cee287e8de195af48c639c6975e#d983df489d527cee287e8de195af48c639c6975e"
 dependencies = [
  "bitflags 2.9.0",
  "bytemuck",
@@ -1560,7 +1557,6 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d983df489d527cee287e8de195af48c639c6975e#d983df489d527cee287e8de195af48c639c6975e"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1574,7 +1570,6 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d983df489d527cee287e8de195af48c639c6975e#d983df489d527cee287e8de195af48c639c6975e"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1591,7 +1586,6 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d983df489d527cee287e8de195af48c639c6975e#d983df489d527cee287e8de195af48c639c6975e"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1618,7 +1612,6 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d983df489d527cee287e8de195af48c639c6975e#d983df489d527cee287e8de195af48c639c6975e"
 dependencies = [
  "cubecl-common",
  "cubecl-macros-internal",
@@ -1636,7 +1629,6 @@ dependencies = [
 [[package]]
 name = "cubecl-linalg"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d983df489d527cee287e8de195af48c639c6975e#d983df489d527cee287e8de195af48c639c6975e"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1651,7 +1643,6 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d983df489d527cee287e8de195af48c639c6975e#d983df489d527cee287e8de195af48c639c6975e"
 dependencies = [
  "cubecl-common",
  "darling",
@@ -1666,7 +1657,6 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d983df489d527cee287e8de195af48c639c6975e#d983df489d527cee287e8de195af48c639c6975e"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1677,7 +1667,6 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d983df489d527cee287e8de195af48c639c6975e#d983df489d527cee287e8de195af48c639c6975e"
 dependencies = [
  "cubecl-common",
  "cubecl-ir",
@@ -1693,7 +1682,6 @@ dependencies = [
 [[package]]
 name = "cubecl-reduce"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d983df489d527cee287e8de195af48c639c6975e#d983df489d527cee287e8de195af48c639c6975e"
 dependencies = [
  "cubecl-core",
  "cubecl-runtime",
@@ -1706,7 +1694,6 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d983df489d527cee287e8de195af48c639c6975e#d983df489d527cee287e8de195af48c639c6975e"
 dependencies = [
  "async-channel",
  "bytemuck",
@@ -1728,7 +1715,6 @@ dependencies = [
 [[package]]
 name = "cubecl-spirv"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d983df489d527cee287e8de195af48c639c6975e#d983df489d527cee287e8de195af48c639c6975e"
 dependencies = [
  "bitflags 2.9.0",
  "cubecl-common",
@@ -1743,7 +1729,6 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d983df489d527cee287e8de195af48c639c6975e#d983df489d527cee287e8de195af48c639c6975e"
 dependencies = [
  "cubecl-core",
  "cubecl-runtime",
@@ -1754,7 +1739,6 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d983df489d527cee287e8de195af48c639c6975e#d983df489d527cee287e8de195af48c639c6975e"
 dependencies = [
  "ash",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,13 +156,13 @@ portable-atomic = { version = "1.11.0" }
 portable-atomic-util = { version = "0.2.4", features = ["alloc"] }
 
 ### For the main burn branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "d983df489d527cee287e8de195af48c639c6975e" }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "d983df489d527cee287e8de195af48c639c6975e" }
-cubecl-std = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "d983df489d527cee287e8de195af48c639c6975e" }
+# cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "d983df489d527cee287e8de195af48c639c6975e" }
+# cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "d983df489d527cee287e8de195af48c639c6975e" }
+# cubecl-std = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "d983df489d527cee287e8de195af48c639c6975e" }
 ### For local development. ###
-# cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
-# cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }
-# cubecl-std = { path = "../cubecl/crates/cubecl-std", default-features = false }
+cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
+cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }
+cubecl-std = { path = "../cubecl/crates/cubecl-std", default-features = false }
 ### For the release. ###
 # cubecl = { version = "0.5.0", default-features = false }
 # cubecl-common = { version = "0.5.0", default-features = false }

--- a/crates/burn-autodiff/src/ops/tensor.rs
+++ b/crates/burn-autodiff/src/ops/tensor.rs
@@ -375,7 +375,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                     grads,
                     |grad| {
                         let rhs = rhs_4lhs.unwrap();
-                        let value = B::float_powf_scalar(rhs, -1.0);
+                        let value = B::float_recip(rhs);
                         let grad = B::float_mul(grad, value);
 
                         broadcast.backward_lhs::<B>(grad)
@@ -383,7 +383,8 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                     |grad| {
                         let rhs = rhs_4rhs.unwrap();
                         let lhs = lhs.unwrap();
-                        let value = B::float_div(B::float_neg(lhs), B::float_powf_scalar(rhs, 2.0));
+                        let value =
+                            B::float_div(B::float_neg(lhs), B::float_powi_scalar(rhs, 2.elem()));
                         let grad = B::float_mul(grad, value);
 
                         broadcast.backward_rhs::<B>(grad)
@@ -1631,7 +1632,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
             ) {
                 let input = checkpointer.retrieve_node_output(ops.state);
                 unary::<B, _>(ops.parents, ops.node, grads, |grad| {
-                    let value = B::float_powf_scalar(input, -1.0);
+                    let value = B::float_recip(input);
                     B::float_mul(grad, value)
                 });
             }
@@ -1670,7 +1671,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                 let input = checkpointer.retrieve_node_output(ops.state);
                 unary::<B, _>(ops.parents, ops.node, grads, |grad| {
                     let value = B::float_add_scalar(input, 1.elem());
-                    let value = B::float_powf_scalar(value, -1.0);
+                    let value = B::float_recip(value);
 
                     B::float_mul(grad, value)
                 });
@@ -1920,7 +1921,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                 let state = B::float_tanh(input);
                 unary::<B, _>(ops.parents, ops.node, grads, |grad| {
                     let value = B::float_add_scalar(
-                        B::float_neg(B::float_powf_scalar(state, 2.0)),
+                        B::float_neg(B::float_powi_scalar(state, 2.elem())),
                         1.elem(),
                     );
                     B::float_mul(grad, value)
@@ -2068,7 +2069,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
             ) {
                 unary::<B, _>(ops.parents, ops.node, grads, |grad| {
                     let ops = checkpointer.retrieve_node_output(ops.state);
-                    let exponent = B::float_neg(B::float_powf_scalar(ops, 2.0));
+                    let exponent = B::float_neg(B::float_powi_scalar(ops, 2.elem()));
                     let numerator = B::float_mul_scalar(B::float_exp(exponent), 2.0.elem());
                     let denominator = core::f64::consts::PI.sqrt().elem();
                     let value = B::float_div_scalar(numerator, denominator);

--- a/crates/burn-candle/src/ops/tensor.rs
+++ b/crates/burn-candle/src/ops/tensor.rs
@@ -2,7 +2,7 @@ use std::borrow::Borrow;
 
 use burn_tensor::{
     Device, Distribution, ElementConversion, FloatDType, Shape, TensorData,
-    ops::{BoolTensor, FloatElem, FloatTensor, FloatTensorOps, IntTensor},
+    ops::{BoolTensor, FloatElem, FloatTensor, FloatTensorOps, IntElem, IntTensor},
 };
 use candle_core::{Tensor, backend::BackendStorage, shape};
 use half::{bf16, f16};
@@ -331,6 +331,10 @@ impl<F: FloatCandleElement, I: IntCandleElement> FloatTensorOps<Self> for Candle
         CandleTensor::new(tensor.tensor.powf(value.elem::<f64>()).unwrap())
     }
 
+    fn float_powi_scalar(tensor: FloatTensor<Self>, value: i32) -> FloatTensor<Self> {
+        CandleTensor::new(tensor.tensor.powf(value.elem::<f64>()).unwrap())
+    }
+
     fn float_sqrt(tensor: FloatTensor<Self>) -> FloatTensor<Self> {
         CandleTensor::new(tensor.tensor.sqrt().unwrap())
     }
@@ -432,17 +436,11 @@ impl<F: FloatCandleElement, I: IntCandleElement> FloatTensorOps<Self> for Candle
     }
 
     fn float_powf(lhs: FloatTensor<Self>, rhs: FloatTensor<Self>) -> FloatTensor<Self> {
-        //broadcast_pow is in main but not yet published
-        //note: probably replace once pow once 0.3.3 is out
-        //see: https://github.com/huggingface/candle/pull/1583/files#diff-6319fa1e16dadc4c7b4e25698139703d93b70f30a1f8e2ac0999978e39efaa81R2594
+        CandleTensor::new(lhs.tensor.broadcast_pow(&rhs.tensor).unwrap())
+    }
 
-        CandleTensor::new(
-            rhs.tensor
-                .broadcast_mul(&lhs.tensor.log().unwrap())
-                .unwrap()
-                .exp()
-                .unwrap(),
-        )
+    fn float_powi(lhs: FloatTensor<Self>, rhs: IntTensor<Self>) -> FloatTensor<Self> {
+        CandleTensor::new(lhs.tensor.broadcast_pow(&rhs.tensor).unwrap())
     }
 
     fn float_permute(tensor: FloatTensor<Self>, axes: &[usize]) -> FloatTensor<Self> {

--- a/crates/burn-core/src/grad_clipping/base.rs
+++ b/crates/burn-core/src/grad_clipping/base.rs
@@ -88,7 +88,7 @@ impl GradientClipping {
     }
 
     fn l2_norm<B: Backend, const D: usize>(tensor: Tensor<B, D>) -> Tensor<B, 1> {
-        let squared = tensor.powf_scalar(2.0);
+        let squared = tensor.powi_scalar(2);
         let sum = squared.sum();
         sum.sqrt()
     }

--- a/crates/burn-core/src/nn/loss/huber.rs
+++ b/crates/burn-core/src/nn/loss/huber.rs
@@ -132,7 +132,7 @@ impl HuberLoss {
         // Moreover |r| = sign(r) * r
         let outside = softsign.mul(residuals.clone()).sub_scalar(self.lin_bias);
 
-        let inside = residuals.powf_scalar(2.).mul_scalar(0.5);
+        let inside = residuals.powi_scalar(2).mul_scalar(0.5);
         inside.mask_where(is_large, outside)
     }
 }

--- a/crates/burn-core/src/nn/loss/mse.rs
+++ b/crates/burn-core/src/nn/loss/mse.rs
@@ -46,7 +46,7 @@ impl MseLoss {
         logits: Tensor<B, D>,
         targets: Tensor<B, D>,
     ) -> Tensor<B, D> {
-        logits.sub(targets).powf_scalar(2.0)
+        logits.sub(targets).powi_scalar(2)
     }
 }
 

--- a/crates/burn-core/src/nn/norm/batch.rs
+++ b/crates/burn-core/src/nn/norm/batch.rs
@@ -138,7 +138,7 @@ impl<const D: usize, B: Backend> BatchNorm<B, D> {
         let var = input
             .clone()
             .sub(mean.clone())
-            .powf_scalar(2.0)
+            .powi_scalar(2)
             .swap_dims(0, 1)
             .reshape([channels, flatten_size])
             .mean_dim(1)

--- a/crates/burn-core/src/nn/norm/group.rs
+++ b/crates/burn-core/src/nn/norm/group.rs
@@ -170,7 +170,7 @@ pub(crate) fn group_norm<B: Backend, const D: usize>(
     let mean = input.clone().sum_dim(2) / hidden_size as f64;
     let input = input.sub(mean);
 
-    let var = input.clone().powf_scalar(2.).sum_dim(2) / hidden_size as f64;
+    let var = input.clone().powi_scalar(2).sum_dim(2) / hidden_size as f64;
     let input_normalized = input.div(var.add_scalar(epsilon).sqrt());
 
     if affine {

--- a/crates/burn-core/src/nn/norm/rms.rs
+++ b/crates/burn-core/src/nn/norm/rms.rs
@@ -71,8 +71,7 @@ impl<B: Backend> RmsNorm<B> {
     pub fn forward<const D: usize>(&self, x: Tensor<B, D>) -> Tensor<B, D> {
         // Calculate the root-mean-square norm of the input tensor along the last dimension
         let dtype = x.dtype();
-        let rms =
-            (x.clone().cast(DType::F32).powf_scalar(2.0).mean_dim(D - 1) + self.epsilon).sqrt();
+        let rms = (x.clone().cast(DType::F32).powi_scalar(2).mean_dim(D - 1) + self.epsilon).sqrt();
         (x / rms.cast(dtype)) * self.gamma.val().unsqueeze()
     }
 }

--- a/crates/burn-core/src/nn/rope_encoding.rs
+++ b/crates/burn-core/src/nn/rope_encoding.rs
@@ -79,7 +79,7 @@ impl RotaryEncodingConfig {
         // Calculate (10000 ^ (2i / d_model)) by using the log base property `exp(log(10000) * (2i / d_model))`
         // This is done since burn doesn't support exponentiation of scalar to tensor
         let theta_i = exponent.mul_scalar(self.theta.ln()).exp();
-        let theta_i = theta_i.powf_scalar(-1.0);
+        let theta_i = theta_i.recip();
 
         let theta_i = scaling(theta_i);
 

--- a/crates/burn-core/src/optim/adagrad.rs
+++ b/crates/burn-core/src/optim/adagrad.rs
@@ -117,11 +117,11 @@ impl LrDecay {
         lr_decay_state: Option<LrDecayState<B, D>>,
     ) -> (Tensor<B, D>, LrDecayState<B, D>) {
         let state = if let Some(mut state) = lr_decay_state {
-            state.sum = state.sum.add(grad.clone().powf_scalar(2.));
+            state.sum = state.sum.add(grad.clone().powi_scalar(2));
             state.time += 1;
             state
         } else {
-            LrDecayState::new(1, grad.clone().powf_scalar(2.))
+            LrDecayState::new(1, grad.clone().powi_scalar(2))
         };
 
         let new_lr = lr / (1. + (state.time as f64 - 1.) * self.lr_decay);

--- a/crates/burn-core/src/optim/adam.rs
+++ b/crates/burn-core/src/optim/adam.rs
@@ -140,7 +140,7 @@ impl AdaptiveMomentum {
             state.moment_2 = state
                 .moment_2
                 .mul_scalar(self.beta_2)
-                .add(grad.powf_scalar(2.0).mul_scalar(factor));
+                .add(grad.powi_scalar(2).mul_scalar(factor));
 
             state.time += 1;
 
@@ -150,7 +150,7 @@ impl AdaptiveMomentum {
             let moment_1 = grad.clone().mul_scalar(factor);
 
             let factor = 1.0 - self.beta_2;
-            let moment_2 = grad.powf_scalar(2.0).mul_scalar(factor);
+            let moment_2 = grad.powi_scalar(2).mul_scalar(factor);
 
             AdaptiveMomentumState::new(1, moment_1, moment_2)
         };

--- a/crates/burn-core/src/optim/adam.rs
+++ b/crates/burn-core/src/optim/adam.rs
@@ -10,7 +10,7 @@ use super::{
 use crate::config::Config;
 use crate::optim::adaptor::OptimizerAdaptor;
 use crate::tensor::{Tensor, backend::AutodiffBackend};
-use burn_tensor::{ElementConversion, backend::Backend, ops::Device};
+use burn_tensor::{backend::Backend, ops::Device};
 
 #[cfg(not(feature = "std"))]
 use num_traits::Float;
@@ -155,7 +155,7 @@ impl AdaptiveMomentum {
             AdaptiveMomentumState::new(1, moment_1, moment_2)
         };
 
-        let time = (state.time as i32).elem();
+        let time = state.time as i32;
         let moment_1_corrected = state
             .moment_1
             .clone()

--- a/crates/burn-core/src/optim/adamw.rs
+++ b/crates/burn-core/src/optim/adamw.rs
@@ -126,7 +126,7 @@ impl AdaptiveMomentumW {
             state.moment_2 = state
                 .moment_2
                 .mul_scalar(self.beta_2)
-                .add(grad.powf_scalar(2.0).mul_scalar(factor));
+                .add(grad.powi_scalar(2).mul_scalar(factor));
 
             // Update time.
             state.time += 1;
@@ -139,7 +139,7 @@ impl AdaptiveMomentumW {
 
             // Initialize second moment estimate.
             let factor = 1.0 - self.beta_2;
-            let moment_2 = grad.powf_scalar(2.0).mul_scalar(factor);
+            let moment_2 = grad.powi_scalar(2).mul_scalar(factor);
 
             AdaptiveMomentumState::new(1, moment_1, moment_2)
         };

--- a/crates/burn-core/src/optim/rmsprop.rs
+++ b/crates/burn-core/src/optim/rmsprop.rs
@@ -159,11 +159,11 @@ impl<B: Backend, const D: usize> SquareAvgState<B, D> {
                 let square_avg = state
                     .square_avg
                     .mul_scalar(alpha)
-                    .add(grad.clone().powf_scalar(2.).mul_scalar(1. - alpha));
+                    .add(grad.clone().powi_scalar(2).mul_scalar(1. - alpha));
                 (grad, Self { square_avg })
             }
             _ => {
-                let square_avg = grad.clone().powf_scalar(2.).mul_scalar(1. - alpha);
+                let square_avg = grad.clone().powi_scalar(2).mul_scalar(1. - alpha);
                 (grad, Self { square_avg })
             }
         }
@@ -215,7 +215,7 @@ impl<B: Backend, const D: usize> CenteredState<B, D> {
             let avg = square_avg_state
                 .square_avg
                 .clone()
-                .sub(grad_avg.clone().powf_scalar(2.));
+                .sub(grad_avg.clone().powi_scalar(2));
 
             (
                 grad,

--- a/crates/burn-cubecl/src/kernel/binary.rs
+++ b/crates/burn-cubecl/src/kernel/binary.rs
@@ -33,7 +33,7 @@ pub(crate) struct OrOp;
 ///
 /// Because of this we won't benefit from the cubecl rust compilation speed improvement from using
 /// the family pattern for [PowOp], but at least we don't duplicate code.
-pub(crate) struct PowOp<F: Float> {
+pub(crate) struct PowfOp<F: Float> {
     _f: PhantomData<F>,
 }
 
@@ -57,7 +57,7 @@ impl BinaryOpFamily for RemainderOp {
     type BinaryOp<C: Numeric> = Self;
 }
 
-impl<F: Float> BinaryOpFamily for PowOp<F> {
+impl<F: Float> BinaryOpFamily for PowfOp<F> {
     type BinaryOp<C: Numeric> = Self;
 }
 
@@ -105,7 +105,7 @@ impl<N: Numeric> BinaryOp<N> for RemainderOp {
 }
 
 #[cube]
-impl<N: Numeric, F: Float> BinaryOp<N> for PowOp<F> {
+impl<N: Numeric, F: Float> BinaryOp<N> for PowfOp<F> {
     fn execute(lhs: Line<N>, rhs: Line<N>) -> Line<N> {
         let lhs = Line::<F>::cast_from(lhs);
         let rhs = Line::<F>::cast_from(rhs);

--- a/crates/burn-cubecl/src/ops/float_ops.rs
+++ b/crates/burn-cubecl/src/ops/float_ops.rs
@@ -514,6 +514,30 @@ where
         )
     }
 
+    fn float_powi_scalar(lhs: FloatTensor<Self>, rhs: i32) -> FloatTensor<Self> {
+        struct Powi;
+
+        #[cube]
+        impl<F: Float> FloatUnaryOp<F> for Powi {
+            type Options = F;
+
+            fn execute(input: Line<F>, options: &Self::Options) -> Line<F> {
+                Line::powf(input, Line::new(*options))
+            }
+        }
+
+        impl FloatUnaryOpFamily for Powi {
+            type Options<F: Float> = F;
+            type Unary<F: Float> = Self;
+        }
+
+        execute_with_dtype!(
+            float(lhs.dtype),
+            F,
+            launch_unary_float::<R, F, Powi, _>(lhs, |_| ScalarArg::new(rhs.elem::<F>()))
+        )
+    }
+
     fn float_sqrt(tensor: FloatTensor<Self>) -> FloatTensor<Self> {
         unary_basic::launch::<R, _>(tensor, |_| &BasicFloatUnaryKind::Sqrt)
     }
@@ -607,6 +631,10 @@ where
     }
 
     fn float_powf(lhs: FloatTensor<Self>, rhs: FloatTensor<Self>) -> FloatTensor<Self> {
+        execute_with_dtype!(float(lhs.dtype), E, numeric::pow::<R, E>(lhs, rhs))
+    }
+
+    fn float_powi(lhs: FloatTensor<Self>, rhs: IntTensor<Self>) -> FloatTensor<Self> {
         execute_with_dtype!(float(lhs.dtype), E, numeric::pow::<R, E>(lhs, rhs))
     }
 

--- a/crates/burn-cubecl/src/ops/numeric.rs
+++ b/crates/burn-cubecl/src/ops/numeric.rs
@@ -1,5 +1,5 @@
 use crate::kernel::{
-    AddOp, BitwiseAndOp, BitwiseOrOp, BitwiseXorOp, DivOp, MulOp, PowOp, RemainderOp, SubOp,
+    AddOp, BitwiseAndOp, BitwiseOrOp, BitwiseXorOp, DivOp, MulOp, PowfOp, RemainderOp, SubOp,
     launch_binop, launch_binop_int, launch_scalar_binop, launch_scalar_binop_int,
 };
 use crate::{CubeRuntime, FloatElement, IntElement};
@@ -185,7 +185,7 @@ pub fn pow<R: CubeRuntime, E: FloatElement>(
     lhs: CubeTensor<R>,
     rhs: CubeTensor<R>,
 ) -> CubeTensor<R> {
-    launch_binop::<R, E, PowOp<E>>(lhs, rhs)
+    launch_binop::<R, E, PowfOp<E>>(lhs, rhs)
 }
 
 /// Bitwise and two tensors

--- a/crates/burn-fusion/src/ops/binary.rs
+++ b/crates/burn-fusion/src/ops/binary.rs
@@ -62,6 +62,39 @@ macro_rules! binary_float_ops {
 
 #[allow(missing_docs)]
 #[macro_export(local_inner_macros)]
+macro_rules! binary_float_int_ops {
+    (
+        $name:ident,
+        $ops:expr
+    ) => {
+        struct $name<B: FusionBackend> {
+            desc: BinaryOpIr,
+            _b: PhantomData<B>,
+        }
+
+        impl<B: FusionBackend> $name<B> {
+            fn new(desc: BinaryOpIr) -> Self {
+                Self {
+                    desc: $crate::ops::binary::check_binary_op(desc).unwrap(),
+                    _b: PhantomData,
+                }
+            }
+        }
+
+        impl<B: FusionBackend> Operation<B::FusionRuntime> for $name<B> {
+            fn execute(self: Box<Self>, handles: &mut HandleContainer<B::Handle>) {
+                let lhs = handles.get_float_tensor::<B>(&self.desc.lhs);
+                let rhs = handles.get_int_tensor::<B>(&self.desc.rhs);
+                let output = $ops(lhs, rhs);
+
+                handles.register_float_tensor::<B>(&self.desc.out.id, output);
+            }
+        }
+    };
+}
+
+#[allow(missing_docs)]
+#[macro_export(local_inner_macros)]
 macro_rules! binary_float_cmp_ops {
     (
         $name:ident,

--- a/crates/burn-fusion/src/stream/context.rs
+++ b/crates/burn-fusion/src/stream/context.rs
@@ -524,7 +524,7 @@ impl RelativeOps for ModuleOperationIr {
 }
 
 impl RelativeOpsScalar<f32> for FloatOperationIr {
-    fn to_relative<F>(&self, converter: &mut OperationConverter, local_elem: F) -> Self
+    fn to_relative<F>(&self, converter: &mut OperationConverter, _local_elem: F) -> Self
     where
         F: Fn(&mut OperationConverter, &f32) -> f32,
     {
@@ -547,7 +547,12 @@ impl RelativeOpsScalar<f32> for FloatOperationIr {
             }),
             FloatOperationIr::PowfScalar(desc) => FloatOperationIr::PowfScalar(ScalarOpIr {
                 lhs: desc.lhs.to_relative(converter),
-                rhs: local_elem(converter, &desc.rhs.elem()),
+                rhs: desc.rhs,
+                out: desc.out.to_relative(converter),
+            }),
+            FloatOperationIr::PowiScalar(desc) => FloatOperationIr::PowiScalar(ScalarOpIr {
+                lhs: desc.lhs.to_relative(converter),
+                rhs: desc.rhs,
                 out: desc.out.to_relative(converter),
             }),
             FloatOperationIr::Sqrt(desc) => FloatOperationIr::Sqrt(UnaryOpIr {
@@ -993,7 +998,7 @@ impl<E: Element> RelativeOpsScalar<E> for NumericOperationIr<E> {
                 out: desc.out.to_relative(converter),
                 distribution: desc.distribution,
             }),
-            NumericOperationIr::Powf(desc) => NumericOperationIr::Powf(BinaryOpIr {
+            NumericOperationIr::Pow(desc) => NumericOperationIr::Pow(BinaryOpIr {
                 lhs: desc.lhs.to_relative(converter),
                 rhs: desc.rhs.to_relative(converter),
                 out: desc.out.to_relative(converter),

--- a/crates/burn-ir/src/operation.rs
+++ b/crates/burn-ir/src/operation.rs
@@ -96,6 +96,8 @@ pub enum FloatOperationIr {
     Erf(UnaryOpIr),
     /// Operation corresponding to [powf_scalar](burn_tensor::ops::FloatTensorOps::float_powf_scalar).
     PowfScalar(ScalarOpIr<f32>),
+    /// Operation corresponding to [powi_scalar](burn_tensor::ops::FloatTensorOps::float_powi_scalar).
+    PowiScalar(ScalarOpIr<i32>),
     /// Operation corresponding to [sqrt](burn_tensor::ops::FloatTensorOps::float_sqrt).
     Sqrt(UnaryOpIr),
     /// Operation corresponding to [cos](burn_tensor::ops::FloatTensorOps::float_cos).
@@ -521,7 +523,7 @@ pub enum NumericOperationIr<E> {
     ///
     /// Float => [powf](burn_tensor::ops::FloatTensorOps::float_powf).
     /// Int => [powf](burn_tensor::ops::IntTensorOps::int_powf).
-    Powf(BinaryOpIr),
+    Pow(BinaryOpIr),
 }
 
 /// Operation intermediate representation specific to an int tensor.
@@ -1567,7 +1569,7 @@ impl<E: Element> NumericOperationIr<E> {
             NumericOperationIr::IntRandom(repr) => {
                 vec![&repr.out]
             }
-            NumericOperationIr::Powf(repr) => {
+            NumericOperationIr::Pow(repr) => {
                 vec![&repr.lhs, &repr.rhs, &repr.out]
             }
         }
@@ -1587,6 +1589,7 @@ impl FloatOperationIr {
             FloatOperationIr::Erf(repr) => vec![&repr.input, &repr.out],
             FloatOperationIr::Recip(repr) => vec![&repr.input, &repr.out],
             FloatOperationIr::PowfScalar(repr) => vec![&repr.lhs, &repr.out],
+            FloatOperationIr::PowiScalar(repr) => vec![&repr.lhs, &repr.out],
             FloatOperationIr::Sqrt(repr) => vec![&repr.input, &repr.out],
             FloatOperationIr::Cos(repr) => vec![&repr.input, &repr.out],
             FloatOperationIr::Sin(repr) => vec![&repr.input, &repr.out],
@@ -1874,7 +1877,7 @@ impl<E> core::hash::Hash for NumericOperationIr<E> {
             NumericOperationIr::MaxAbsDim(repr) => repr.hash(state),
             NumericOperationIr::Clamp(repr) => repr.hash(state),
             NumericOperationIr::IntRandom(repr) => repr.hash(state),
-            NumericOperationIr::Powf(repr) => repr.hash(state),
+            NumericOperationIr::Pow(repr) => repr.hash(state),
         }
     }
 }

--- a/crates/burn-router/src/runner.rs
+++ b/crates/burn-router/src/runner.rs
@@ -570,7 +570,7 @@ impl<B: BackendIr> RunnerClient for Runner<B> {
                     handles.register_float_tensor::<B>(&desc.out.id, output);
                 }
                 NumericOperationIr::IntRandom(_) => unreachable!(),
-                NumericOperationIr::Powf(desc) => {
+                NumericOperationIr::Pow(desc) => {
                     binary_float_ops!(handles, desc, B::float_powf)
                 }
             },
@@ -853,6 +853,9 @@ impl<B: BackendIr> RunnerClient for Runner<B> {
                 }
                 FloatOperationIr::PowfScalar(desc) => {
                     scalar_float_ops!(handles, desc, B::float_powf_scalar)
+                }
+                FloatOperationIr::PowiScalar(desc) => {
+                    scalar_float_ops!(handles, desc, B::float_powi_scalar)
                 }
                 FloatOperationIr::Sqrt(desc) => {
                     unary_float_ops!(handles, desc, B::float_sqrt)

--- a/crates/burn-tch/src/ops/tensor.rs
+++ b/crates/burn-tch/src/ops/tensor.rs
@@ -350,6 +350,13 @@ impl<E: TchElement, Q: QuantElement> FloatTensorOps<Self> for LibTorch<E, Q> {
         )
     }
 
+    fn float_powi_scalar(tensor: TchTensor, value: i32) -> TchTensor {
+        tensor.unary_ops(
+            |mut tensor| tensor.f_pow_(value as i64).unwrap(),
+            |tensor| tensor.pow_tensor_scalar(value as i64),
+        )
+    }
+
     fn float_sqrt(tensor: TchTensor) -> TchTensor {
         tensor.unary_ops(|mut tensor| tensor.sqrt_(), |tensor| tensor.sqrt())
     }
@@ -412,6 +419,10 @@ impl<E: TchElement, Q: QuantElement> FloatTensorOps<Self> for LibTorch<E, Q> {
     }
 
     fn float_powf(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
+        TchOps::powf(lhs, rhs)
+    }
+
+    fn float_powi(lhs: TchTensor, rhs: TchTensor) -> TchTensor {
         TchOps::powf(lhs, rhs)
     }
 

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -1555,7 +1555,7 @@ where
     /// fn example<B: Backend>() {
     ///    let device = B::Device::default();
     ///    let tensor = Tensor::<B, 2>::from_data([[1.0, -2.0, 3.0], [5.0, 9.0, 6.0]], &device);
-    ///    let tensor = tensor.powf_scalar(2.0);
+    ///    let tensor = tensor.powi_scalar(2);
     ///    println!("{tensor}");
     ///    // [[1.0, 4.0, 9.0], [25.0, 81.0, 36.0]]
     /// }
@@ -3801,7 +3801,7 @@ impl<B: Backend> Numeric<B> for Int {
     }
 
     fn powi_scalar<E: ElementConversion>(lhs: Self::Primitive, rhs: E) -> Self::Primitive {
-        B::int_powf_scalar(lhs, rhs.elem())
+        B::int_powi_scalar(lhs, rhs.elem())
     }
 
     fn random(shape: Shape, distribution: Distribution, device: &Device<B>) -> Self::Primitive {
@@ -4291,10 +4291,10 @@ impl<B: Backend> Numeric<B> for Float {
     fn powi_scalar<E: ElementConversion>(lhs: Self::Primitive, rhs: E) -> Self::Primitive {
         match lhs {
             TensorPrimitive::Float(lhs) => {
-                TensorPrimitive::Float(B::float_powf_scalar(lhs, rhs.elem()))
+                TensorPrimitive::Float(B::float_powi_scalar(lhs, rhs.elem()))
             }
             TensorPrimitive::QFloat(lhs) => {
-                TensorPrimitive::QFloat(B::q_powf_scalar(lhs, rhs.elem()))
+                TensorPrimitive::QFloat(B::q_powi_scalar(lhs, rhs.elem()))
             }
         }
     }

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -1560,8 +1560,8 @@ where
     ///    // [[1.0, 4.0, 9.0], [25.0, 81.0, 36.0]]
     /// }
     /// ```
-    pub fn powf_scalar<E: ElementConversion>(self, other: E) -> Self {
-        Self::new(K::powf_scalar::<E>(self.primitive, other))
+    pub fn powf_scalar(self, other: f32) -> Self {
+        Self::new(K::powf_scalar(self.primitive, other))
     }
 
     /// Applies element wise power operation with a integer Tensor
@@ -1614,8 +1614,8 @@ where
     ///    // [[2.25, 4., 9.], [25., 81., 36.]]
     /// }
     /// ```
-    pub fn powi_scalar<E: ElementConversion>(self, other: E) -> Self {
-        Self::new(K::powi_scalar::<E>(self.primitive, other))
+    pub fn powi_scalar(self, other: i32) -> Self {
+        Self::new(K::powi_scalar(self.primitive, other))
     }
 
     /// Checks element wise if the tensor is close to another tensor.
@@ -3458,14 +3458,14 @@ where
     /// # Arguments
     /// * `tensor` - The tensor to apply power to.
     /// * `power` - The power to apply to the tensor.
-    fn powf_scalar<E: ElementConversion>(lhs: Self::Primitive, rhs: E) -> Self::Primitive;
+    fn powf_scalar(lhs: Self::Primitive, rhs: f32) -> Self::Primitive;
 
     /// Element-wise power of a tensor to a scalar int
     ///
     /// # Arguments
     /// * `tensor` - The tensor to apply power to.
     /// * `power` - The power to apply to the tensor.
-    fn powi_scalar<E: ElementConversion>(lhs: Self::Primitive, rhs: E) -> Self::Primitive;
+    fn powi_scalar(lhs: Self::Primitive, rhs: i32) -> Self::Primitive;
 
     /// Create a random tensor.
     ///
@@ -3789,19 +3789,16 @@ impl<B: Backend> Numeric<B> for Int {
         B::int_powf(lhs, B::int_into_float(rhs))
     }
 
-    fn powf_scalar<E: ElementConversion>(
-        lhs: Self::Primitive,
-        rhs: E,
-    ) -> <Int as TensorKind<B>>::Primitive {
-        B::int_powf_scalar(lhs, rhs.elem())
+    fn powf_scalar(lhs: Self::Primitive, rhs: f32) -> <Int as TensorKind<B>>::Primitive {
+        B::int_powf_scalar(lhs, rhs)
     }
 
     fn powi(lhs: Self::Primitive, rhs: Self::Primitive) -> Self::Primitive {
         B::int_powi(lhs, rhs)
     }
 
-    fn powi_scalar<E: ElementConversion>(lhs: Self::Primitive, rhs: E) -> Self::Primitive {
-        B::int_powi_scalar(lhs, rhs.elem())
+    fn powi_scalar(lhs: Self::Primitive, rhs: i32) -> Self::Primitive {
+        B::int_powi_scalar(lhs, rhs)
     }
 
     fn random(shape: Shape, distribution: Distribution, device: &Device<B>) -> Self::Primitive {
@@ -4265,7 +4262,7 @@ impl<B: Backend> Numeric<B> for Float {
         }
     }
 
-    fn powf_scalar<E: ElementConversion>(lhs: Self::Primitive, rhs: E) -> Self::Primitive {
+    fn powf_scalar(lhs: Self::Primitive, rhs: f32) -> Self::Primitive {
         match lhs {
             TensorPrimitive::Float(lhs) => {
                 TensorPrimitive::Float(B::float_powf_scalar(lhs, rhs.elem()))
@@ -4288,7 +4285,7 @@ impl<B: Backend> Numeric<B> for Float {
         }
     }
 
-    fn powi_scalar<E: ElementConversion>(lhs: Self::Primitive, rhs: E) -> Self::Primitive {
+    fn powi_scalar(lhs: Self::Primitive, rhs: i32) -> Self::Primitive {
         match lhs {
             TensorPrimitive::Float(lhs) => {
                 TensorPrimitive::Float(B::float_powi_scalar(lhs, rhs.elem()))

--- a/crates/burn-tensor/src/tensor/ops/activation.rs
+++ b/crates/burn-tensor/src/tensor/ops/activation.rs
@@ -101,7 +101,7 @@ pub trait ActivationOps<B: Backend> {
         let constant_3 = 0.0535161;
         let constant_4 = 0.398942;
 
-        let x3 = B::float_powf_scalar(x.clone(), 3.0);
+        let x3 = B::float_powi_scalar(x.clone(), 3.elem());
 
         let c1 = B::float_mul_scalar(x3.clone(), constant_1.elem());
         let c2 = B::float_mul_scalar(x.clone(), constant_2.elem());
@@ -113,7 +113,7 @@ pub trait ActivationOps<B: Backend> {
 
         let tanh = B::float_tanh(inner1);
 
-        let sech = B::float_powf_scalar(tanh.clone(), 2.0);
+        let sech = B::float_powi_scalar(tanh.clone(), 2.elem());
         let sech = B::float_neg(sech);
         let sech = B::float_add_scalar(sech, 1.elem());
 

--- a/crates/burn-tensor/src/tensor/ops/int_tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/int_tensor.rs
@@ -1,7 +1,6 @@
 use super::cat::cat_with_slice_assign;
 use super::repeat_dim::repeat_with_slice_assign;
 use super::{BoolTensor, Device, FloatTensor, IntElem, IntTensor};
-use crate::cast::ToElement;
 use crate::{Distribution, ElementConversion, Int, TensorData, backend::Backend, tensor::Shape};
 use alloc::vec::Vec;
 use core::ops::Range;
@@ -419,10 +418,7 @@ pub trait IntTensorOps<B: Backend> {
     ///
     /// The elements of `lhs` raised to the power of the elements of `rhs`.
     fn int_powi(lhs: IntTensor<B>, rhs: IntTensor<B>) -> IntTensor<B> {
-        B::float_into_int(B::float_powf(
-            B::int_into_float(lhs),
-            B::int_into_float(rhs),
-        ))
+        B::float_into_int(B::float_powi(B::int_into_float(lhs), rhs))
     }
 
     /// Element-wise power with a floatTensor.
@@ -450,7 +446,7 @@ pub trait IntTensorOps<B: Backend> {
     ///
     /// The elements of `lhs` raised to the value of `rhs`.
     fn int_powi_scalar(lhs: IntTensor<B>, rhs: IntElem<B>) -> IntTensor<B> {
-        B::float_into_int(B::float_powf_scalar(B::int_into_float(lhs), rhs.to_f32()))
+        B::float_into_int(B::float_powi_scalar(B::int_into_float(lhs), rhs))
     }
 
     /// Element-wise power with a floatTensor.

--- a/crates/burn-tensor/src/tensor/ops/int_tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/int_tensor.rs
@@ -445,7 +445,7 @@ pub trait IntTensorOps<B: Backend> {
     /// # Returns
     ///
     /// The elements of `lhs` raised to the value of `rhs`.
-    fn int_powi_scalar(lhs: IntTensor<B>, rhs: IntElem<B>) -> IntTensor<B> {
+    fn int_powi_scalar(lhs: IntTensor<B>, rhs: i32) -> IntTensor<B> {
         B::float_into_int(B::float_powi_scalar(B::int_into_float(lhs), rhs))
     }
 

--- a/crates/burn-tensor/src/tensor/ops/qtensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/qtensor.rs
@@ -9,7 +9,7 @@ use crate::{
     },
 };
 
-use super::{BoolTensor, FloatElem, FloatTensor, IntElem, IntTensor, QuantizedTensor};
+use super::{BoolTensor, FloatElem, FloatTensor, IntTensor, QuantizedTensor};
 
 /// Automatically applies dequantization -> float operation -> quantization.
 #[macro_export]
@@ -866,7 +866,7 @@ pub trait QTensorOps<B: Backend> {
     /// # Returns
     ///
     /// The elements of `lhs` raised to the value of `rhs`.
-    fn q_powi_scalar(lhs: QuantizedTensor<B>, rhs: IntElem<B>) -> QuantizedTensor<B> {
+    fn q_powi_scalar(lhs: QuantizedTensor<B>, rhs: i32) -> QuantizedTensor<B> {
         dequant_op_quant!(
             ty Self,
             float_op |tensor| B::float_powi_scalar(tensor, rhs),

--- a/crates/burn-tensor/src/tensor/ops/tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/tensor.rs
@@ -1,7 +1,6 @@
 use super::cat::cat_with_slice_assign;
 use super::repeat_dim::repeat_with_slice_assign;
 use super::{BoolTensor, Device, FloatElem, FloatTensor, IntElem, IntTensor};
-use crate::tensor::cast::ToElement;
 use crate::{Distribution, ElementConversion, Float, TensorData, backend::Backend, tensor::Shape};
 use crate::{FloatDType, TensorMetadata, TensorPrimitive};
 use alloc::vec::Vec;
@@ -845,7 +844,14 @@ pub trait FloatTensorOps<B: Backend> {
     ///
     /// The elements of `lhs` raised to the value of `rhs`.
     fn float_powi_scalar(lhs: FloatTensor<B>, rhs: IntElem<B>) -> FloatTensor<B> {
-        Self::float_powf_scalar(lhs, rhs.to_f32())
+        let rhs: i32 = rhs.elem();
+
+        match rhs {
+            -1 => B::float_recip(lhs),
+            1 => lhs,
+            2 => B::float_mul(lhs.clone(), lhs),
+            val => Self::float_powf_scalar(lhs, val as f32),
+        }
     }
 
     /// Returns a new tensor with values raised to the power of float `value`.

--- a/crates/burn-tensor/src/tensor/ops/tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/tensor.rs
@@ -1,6 +1,6 @@
 use super::cat::cat_with_slice_assign;
 use super::repeat_dim::repeat_with_slice_assign;
-use super::{BoolTensor, Device, FloatElem, FloatTensor, IntElem, IntTensor};
+use super::{BoolTensor, Device, FloatElem, FloatTensor, IntTensor};
 use crate::{Distribution, ElementConversion, Float, TensorData, backend::Backend, tensor::Shape};
 use crate::{FloatDType, TensorMetadata, TensorPrimitive};
 use alloc::vec::Vec;
@@ -829,30 +829,7 @@ pub trait FloatTensorOps<B: Backend> {
     /// # Returns
     ///
     /// The elements of `lhs` raised to the value of `rhs`. Result is an IntTensor.
-    fn float_powi(lhs: FloatTensor<B>, rhs: IntTensor<B>) -> FloatTensor<B> {
-        Self::float_powf(lhs, B::int_into_float(rhs))
-    }
-
-    /// raises a tensor to the power of an int scalar.
-    ///
-    /// # Arguments
-    ///
-    /// * `lhs` - The left hand side tensor.
-    /// * `rhs` - The right hand side scalar.
-    ///
-    /// # Returns
-    ///
-    /// The elements of `lhs` raised to the value of `rhs`.
-    fn float_powi_scalar(lhs: FloatTensor<B>, rhs: IntElem<B>) -> FloatTensor<B> {
-        let rhs: i32 = rhs.elem();
-
-        match rhs {
-            -1 => B::float_recip(lhs),
-            1 => lhs,
-            2 => B::float_mul(lhs.clone(), lhs),
-            val => Self::float_powf_scalar(lhs, val as f32),
-        }
-    }
+    fn float_powi(lhs: FloatTensor<B>, rhs: IntTensor<B>) -> FloatTensor<B>;
 
     /// Returns a new tensor with values raised to the power of float `value`.
     ///
@@ -865,6 +842,18 @@ pub trait FloatTensorOps<B: Backend> {
     ///
     /// A tensor with the same shape as `tensor` with values raised to the power of `value`.
     fn float_powf_scalar(tensor: FloatTensor<B>, value: f32) -> FloatTensor<B>;
+
+    /// raises a tensor to the power of an int scalar.
+    ///
+    /// # Arguments
+    ///
+    /// * `lhs` - The left hand side tensor.
+    /// * `rhs` - The right hand side scalar.
+    ///
+    /// # Returns
+    ///
+    /// The elements of `lhs` raised to the value of `rhs`.
+    fn float_powi_scalar(lhs: FloatTensor<B>, rhs: i32) -> FloatTensor<B>;
 
     /// Returns a new tensor with square root values.
     ///

--- a/crates/burn-tensor/src/tensor/stats/mod.rs
+++ b/crates/burn-tensor/src/tensor/stats/mod.rs
@@ -36,7 +36,7 @@ pub fn var_with_mean_n<B: Backend, const D: usize>(
 ) -> Tensor<B, D> {
     tensor
         .sub(mean)
-        .powf_scalar(2.0)
+        .powi_scalar(2)
         .sum_dim(dim)
         .div_scalar(n as f32)
 }

--- a/crates/burn-tensor/src/tests/clone_invariance.rs
+++ b/crates/burn-tensor/src/tests/clone_invariance.rs
@@ -231,7 +231,7 @@ mod tests {
         );
         clone_invariance_test!(
             unary: PowScalar,
-                                        ops_float: |tensor: TestTensor<2>| tensor.powf_scalar(2.0)
+            ops_float: |tensor: TestTensor<2>| tensor.powf_scalar(2.0)
         );
         clone_invariance_test!(
             unary: Sqrt,


### PR DESCRIPTION
## Pull Request Template

Specialize powi for -1 (recip), 1 (id), 2 (sqr). Otherwise use floating point fallback. Update more places to use powi_scalar when possible.

TODO: Not 100% sure yet if this is actually faster due to inplace operations.
TODO: specialize 3/4/8 as well? -2/-4/-8?