### PR TITLE
Fixed cubecl-matmul-2d invalid config bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1498,7 +1498,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=150829d0876e5ced8e937f18abbc7e3c757e11c7#150829d0876e5ced8e937f18abbc7e3c757e11c7"
+source = "git+https://github.com/tracel-ai/cubecl?rev=17cb785970a48f1ac4b99c74f58d166bd8c62fbb#17cb785970a48f1ac4b99c74f58d166bd8c62fbb"
 dependencies = [
  "cubecl-core",
  "cubecl-cuda",
@@ -1514,7 +1514,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=150829d0876e5ced8e937f18abbc7e3c757e11c7#150829d0876e5ced8e937f18abbc7e3c757e11c7"
+source = "git+https://github.com/tracel-ai/cubecl?rev=17cb785970a48f1ac4b99c74f58d166bd8c62fbb#17cb785970a48f1ac4b99c74f58d166bd8c62fbb"
 dependencies = [
  "bytemuck",
  "derive-new 0.6.0",
@@ -1537,7 +1537,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=150829d0876e5ced8e937f18abbc7e3c757e11c7#150829d0876e5ced8e937f18abbc7e3c757e11c7"
+source = "git+https://github.com/tracel-ai/cubecl?rev=17cb785970a48f1ac4b99c74f58d166bd8c62fbb#17cb785970a48f1ac4b99c74f58d166bd8c62fbb"
 dependencies = [
  "bitflags 2.9.0",
  "bytemuck",
@@ -1560,7 +1560,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=150829d0876e5ced8e937f18abbc7e3c757e11c7#150829d0876e5ced8e937f18abbc7e3c757e11c7"
+source = "git+https://github.com/tracel-ai/cubecl?rev=17cb785970a48f1ac4b99c74f58d166bd8c62fbb#17cb785970a48f1ac4b99c74f58d166bd8c62fbb"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1574,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=150829d0876e5ced8e937f18abbc7e3c757e11c7#150829d0876e5ced8e937f18abbc7e3c757e11c7"
+source = "git+https://github.com/tracel-ai/cubecl?rev=17cb785970a48f1ac4b99c74f58d166bd8c62fbb#17cb785970a48f1ac4b99c74f58d166bd8c62fbb"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1591,7 +1591,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=150829d0876e5ced8e937f18abbc7e3c757e11c7#150829d0876e5ced8e937f18abbc7e3c757e11c7"
+source = "git+https://github.com/tracel-ai/cubecl?rev=17cb785970a48f1ac4b99c74f58d166bd8c62fbb#17cb785970a48f1ac4b99c74f58d166bd8c62fbb"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1618,7 +1618,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=150829d0876e5ced8e937f18abbc7e3c757e11c7#150829d0876e5ced8e937f18abbc7e3c757e11c7"
+source = "git+https://github.com/tracel-ai/cubecl?rev=17cb785970a48f1ac4b99c74f58d166bd8c62fbb#17cb785970a48f1ac4b99c74f58d166bd8c62fbb"
 dependencies = [
  "cubecl-common",
  "cubecl-macros-internal",
@@ -1636,7 +1636,7 @@ dependencies = [
 [[package]]
 name = "cubecl-linalg"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=150829d0876e5ced8e937f18abbc7e3c757e11c7#150829d0876e5ced8e937f18abbc7e3c757e11c7"
+source = "git+https://github.com/tracel-ai/cubecl?rev=17cb785970a48f1ac4b99c74f58d166bd8c62fbb#17cb785970a48f1ac4b99c74f58d166bd8c62fbb"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1651,7 +1651,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=150829d0876e5ced8e937f18abbc7e3c757e11c7#150829d0876e5ced8e937f18abbc7e3c757e11c7"
+source = "git+https://github.com/tracel-ai/cubecl?rev=17cb785970a48f1ac4b99c74f58d166bd8c62fbb#17cb785970a48f1ac4b99c74f58d166bd8c62fbb"
 dependencies = [
  "cubecl-common",
  "darling",
@@ -1666,7 +1666,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=150829d0876e5ced8e937f18abbc7e3c757e11c7#150829d0876e5ced8e937f18abbc7e3c757e11c7"
+source = "git+https://github.com/tracel-ai/cubecl?rev=17cb785970a48f1ac4b99c74f58d166bd8c62fbb#17cb785970a48f1ac4b99c74f58d166bd8c62fbb"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1677,7 +1677,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=150829d0876e5ced8e937f18abbc7e3c757e11c7#150829d0876e5ced8e937f18abbc7e3c757e11c7"
+source = "git+https://github.com/tracel-ai/cubecl?rev=17cb785970a48f1ac4b99c74f58d166bd8c62fbb#17cb785970a48f1ac4b99c74f58d166bd8c62fbb"
 dependencies = [
  "cubecl-common",
  "cubecl-ir",
@@ -1693,7 +1693,7 @@ dependencies = [
 [[package]]
 name = "cubecl-reduce"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=150829d0876e5ced8e937f18abbc7e3c757e11c7#150829d0876e5ced8e937f18abbc7e3c757e11c7"
+source = "git+https://github.com/tracel-ai/cubecl?rev=17cb785970a48f1ac4b99c74f58d166bd8c62fbb#17cb785970a48f1ac4b99c74f58d166bd8c62fbb"
 dependencies = [
  "cubecl-core",
  "cubecl-runtime",
@@ -1706,7 +1706,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=150829d0876e5ced8e937f18abbc7e3c757e11c7#150829d0876e5ced8e937f18abbc7e3c757e11c7"
+source = "git+https://github.com/tracel-ai/cubecl?rev=17cb785970a48f1ac4b99c74f58d166bd8c62fbb#17cb785970a48f1ac4b99c74f58d166bd8c62fbb"
 dependencies = [
  "async-channel",
  "bytemuck",
@@ -1730,7 +1730,7 @@ dependencies = [
 [[package]]
 name = "cubecl-spirv"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=150829d0876e5ced8e937f18abbc7e3c757e11c7#150829d0876e5ced8e937f18abbc7e3c757e11c7"
+source = "git+https://github.com/tracel-ai/cubecl?rev=17cb785970a48f1ac4b99c74f58d166bd8c62fbb#17cb785970a48f1ac4b99c74f58d166bd8c62fbb"
 dependencies = [
  "bitflags 2.9.0",
  "cubecl-common",
@@ -1745,7 +1745,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=150829d0876e5ced8e937f18abbc7e3c757e11c7#150829d0876e5ced8e937f18abbc7e3c757e11c7"
+source = "git+https://github.com/tracel-ai/cubecl?rev=17cb785970a48f1ac4b99c74f58d166bd8c62fbb#17cb785970a48f1ac4b99c74f58d166bd8c62fbb"
 dependencies = [
  "cubecl-core",
  "cubecl-runtime",
@@ -1756,7 +1756,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.6.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=150829d0876e5ced8e937f18abbc7e3c757e11c7#150829d0876e5ced8e937f18abbc7e3c757e11c7"
+source = "git+https://github.com/tracel-ai/cubecl?rev=17cb785970a48f1ac4b99c74f58d166bd8c62fbb#17cb785970a48f1ac4b99c74f58d166bd8c62fbb"
 dependencies = [
  "ash",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,9 +156,9 @@ portable-atomic = { version = "1.11.0" }
 portable-atomic-util = { version = "0.2.4", features = ["alloc"] }
 
 ### For the main burn branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "150829d0876e5ced8e937f18abbc7e3c757e11c7" }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "150829d0876e5ced8e937f18abbc7e3c757e11c7" }
-cubecl-std = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "150829d0876e5ced8e937f18abbc7e3c757e11c7" }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "17cb785970a48f1ac4b99c74f58d166bd8c62fbb" }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "17cb785970a48f1ac4b99c74f58d166bd8c62fbb" }
+cubecl-std = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "17cb785970a48f1ac4b99c74f58d166bd8c62fbb" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.


> [!TIP]
> Want more detailed macro error diagnostics? This is especially useful for debugging tensor-related tests:
>
> ```bash
> RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Zmacro-backtrace" cargo run-checks
> ```

### Related Issues/PRs

[CubeCL #667](https://github.com/tracel-ai/cubecl/pull/667)

### Changes

2D inputs in matmul were not mapping to the correct configs so I edited the matmul logic in a forked version of CubeCL repo such that it handles 2D inputs robustly. See the PR description from the link above for more details.
