### PR TITLE
Update fusion.rs

### DIFF
--- a/crates/burn-fusion/src/fusion.rs
+++ b/crates/burn-fusion/src/fusion.rs
@@ -3,69 +3,51 @@ use burn_tensor::backend::{DeviceId, DeviceOps};
 
 use crate::{Client, FusionDevice, FusionRuntime, client::FusionClient};
 
-use std::{any::Any, collections::HashMap, ops::DerefMut};
+use std::{
+    any::{Any, TypeId},
+    collections::HashMap,
+    ops::DerefMut,
+};
+use spin::Mutex;
 
 /// Type alias for [representation backend handle](burn_ir::BackendIr::Handle).
 pub type Handle<B> = <B as BackendIr>::Handle;
-type Key = (core::any::TypeId, DeviceId);
+
+/// Key = (runtime tipi, device id)
+type Key = (TypeId, DeviceId);
 
 pub(crate) struct FusionClientLocator {
-    clients: spin::Mutex<Option<HashMap<Key, Box<dyn core::any::Any + Send>>>>,
+    clients: Mutex<HashMap<Key, Box<dyn Any + Send>>>,
 }
 
 impl FusionClientLocator {
     /// Create a new client locator.
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {
-            clients: spin::Mutex::new(None),
+            clients: Mutex::new(HashMap::new()),
         }
     }
 
     /// Get the fusion client for the given device.
     ///
-    /// Provide the init function to create a new client if it isn't already initialized.
+    /// If it doesn't exist, lazily initializes it.
     pub fn client<R: FusionRuntime + 'static>(&self, device: &FusionDevice<R>) -> Client<R> {
         let device_id = device.id();
-        let client_id = (core::any::TypeId::of::<R>(), device_id);
+        let client_id = (TypeId::of::<R>(), device_id);
+
         let mut clients = self.clients.lock();
 
-        if clients.is_none() {
+        // Already exists?
+        if let Some(existing) = clients.get(&client_id) {
+            existing
+                .downcast_ref::<Client<R>>()
+                .expect("Client type mismatch.")
+                .clone()
+        } else {
+            // Otherwise, create and insert
             let client = Client::<R>::new(device.clone());
-            Self::register_inner::<R>(client_id, client, &mut clients);
-        }
-
-        match clients.deref_mut() {
-            Some(clients) => match clients.get(&client_id) {
-                Some(client) => {
-                    let client: &Client<R> = client.downcast_ref().unwrap();
-                    client.clone()
-                }
-                None => {
-                    let client = Client::<R>::new(device.clone());
-                    let any = Box::new(client.clone());
-                    clients.insert(client_id, any);
-                    client
-                }
-            },
-            _ => unreachable!(),
-        }
-    }
-
-    fn register_inner<R: FusionRuntime + 'static>(
-        key: Key,
-        client: Client<R>,
-        clients: &mut Option<HashMap<Key, Box<dyn Any + Send>>>,
-    ) {
-        if clients.is_none() {
-            *clients = Some(HashMap::new());
-        }
-
-        if let Some(clients) = clients {
-            if clients.contains_key(&key) {
-                panic!("Client already created for device {:?}", key);
-            }
-
-            clients.insert(key, Box::new(client));
+            clients.insert(client_id, Box::new(client.clone()));
+            client
         }
     }
 }


### PR DESCRIPTION
refactoring fusion codebase

Instead of option <HashMap<...> was used directly checks like is_none are no longer necessary.
Removed register_inner function, integrated its content directly into client function.
Added expect() error message instead of unwrap() because Rust gives more meaningful panic message if downcast fails.
Mutex is still spin::Mutex but i guess i can switch to parking_lot::Mutex if you wish.