### PR TITLE
Use `CUBECL_DEBUG_OPTION=profile` macos ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -255,6 +255,8 @@ jobs:
   macos-std-tests:
     runs-on: blaze/macos-14
     needs: prepare-checks
+    env:
+      DISABLE_WGPU: '1'
     # Keep the stragegy to be able to easily add new rust versions if required
     strategy:
       matrix:
@@ -270,4 +272,4 @@ jobs:
           cache-key: ${{ matrix.rust }}-macos
       # --------------------------------------------------------------------------------
       - name: Tests
-        run: CUBECL_DEBUG_LOG=stdout cargo xtask test --ci
+        run: cargo xtask test --ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -255,8 +255,6 @@ jobs:
   macos-std-tests:
     runs-on: blaze/macos-14
     needs: prepare-checks
-    env:
-      DISABLE_WGPU: '1'
     # Keep the stragegy to be able to easily add new rust versions if required
     strategy:
       matrix:
@@ -272,4 +270,4 @@ jobs:
           cache-key: ${{ matrix.rust }}-macos
       # --------------------------------------------------------------------------------
       - name: Tests
-        run: cargo xtask test --ci
+        run: CUBECL_DEBUG_OPTION=profile cargo xtask test --ci

--- a/crates/burn-fusion/src/ops/unary.rs
+++ b/crates/burn-fusion/src/ops/unary.rs
@@ -65,7 +65,6 @@ macro_rules! reduce_float_ops {
 
         impl<B: FusionBackend> Operation<B::FusionRuntime> for $name<B> {
             fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
-                std::println!("Executed fused reduce {:?}", self.desc);
                 let input = handles.get_float_tensor::<B>(&self.desc.input);
                 let output = $ops(input, self.desc.axis);
 


### PR DESCRIPTION
MacOS runners have been having issues with wgpu recently. Running the same tests in isolation succeeds, but some tests hang otherwise.

See CI logs in #3160 for different test cases.

Not autotune or fusion related, because even without some tests hang.

Not reproducible on two local machines either.

Disabling wgpu tests (like windows CI) for now.