### PR TITLE
Fix: size_of import in quantization tests

### DIFF
--- a/crates/burn-cubecl/src/kernel/matmul/base.rs
+++ b/crates/burn-cubecl/src/kernel/matmul/base.rs
@@ -8,7 +8,6 @@ use cubecl::{
     linalg::matmul::{components::Quantized, kernels::MatmulLaunchError},
     prelude::TensorHandleRef,
 };
-use cubecl_std::size_of;
 
 #[cfg(feature = "autotune")]
 use super::matmul_autotune;
@@ -89,7 +88,7 @@ pub fn q_matmul<R: CubeRuntime>(
             &lhs_scales,
             &[1],
             &[1],
-            size_of::<f32>().try_into().unwrap(),
+            core::mem::size_of::<f32>().try_into().unwrap(),
         )
     };
     let rhs_scales = unsafe {
@@ -97,7 +96,7 @@ pub fn q_matmul<R: CubeRuntime>(
             &rhs_scales,
             &[1],
             &[1],
-            size_of::<f32>().try_into().unwrap(),
+            core::mem::size_of::<f32>().try_into().unwrap(),
         )
     };
 

--- a/crates/burn-cubecl/src/kernel/matmul/base.rs
+++ b/crates/burn-cubecl/src/kernel/matmul/base.rs
@@ -84,20 +84,10 @@ pub fn q_matmul<R: CubeRuntime>(
     rhs_scales.offset_end = None;
 
     let lhs_scales = unsafe {
-        TensorHandleRef::from_raw_parts(
-            &lhs_scales,
-            &[1],
-            &[1],
-            core::mem::size_of::<f32>().try_into().unwrap(),
-        )
+        TensorHandleRef::from_raw_parts(&lhs_scales, &[1], &[1], core::mem::size_of::<f32>())
     };
     let rhs_scales = unsafe {
-        TensorHandleRef::from_raw_parts(
-            &rhs_scales,
-            &[1],
-            &[1],
-            core::mem::size_of::<f32>().try_into().unwrap(),
-        )
+        TensorHandleRef::from_raw_parts(&rhs_scales, &[1], &[1], core::mem::size_of::<f32>())
     };
 
     match scheme.acc_precision {


### PR DESCRIPTION
There were 8 tests failing with `Unexpanded Cube functions should not be called.` 
Now 2 of them are passing, the other 6 fail for some new reason. 