### PR TITLE
Chain lint inheritance [was: Disable new default clippy tests]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,11 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 version = "0.18.0"
 
+[workspace.lints.clippy]
+large_enum_variant = "allow"
+let_and_return = "allow"
+manual_contains = "allow"
+
 [workspace.dependencies]
 atomic_float = "1"
 bytemuck = "1.21.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,6 @@ readme = "README.md"
 version = "0.18.0"
 
 [workspace.lints.clippy]
-large_enum_variant = "allow"
-let_and_return = "allow"
-manual_contains = "allow"
 
 [workspace.dependencies]
 atomic_float = "1"

--- a/crates/burn-autodiff/Cargo.toml
+++ b/crates/burn-autodiff/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-autodiff"
 documentation = "https://docs.rs/burn-autodiff"
 version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = ["std"]
 export_tests = ["burn-tensor-testgen"]

--- a/crates/burn-candle/Cargo.toml
+++ b/crates/burn-candle/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-candle"
 documentation = "https://docs.rs/burn-candle"
 version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = ["std"]
 std = []

--- a/crates/burn-common/Cargo.toml
+++ b/crates/burn-common/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-common"
 documentation = "https://docs.rs/burn-common"
 version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = ["std", "cubecl-common/default"]
 std = ["cubecl-common/std"]

--- a/crates/burn-core/Cargo.toml
+++ b/crates/burn-core/Cargo.toml
@@ -11,6 +11,9 @@ readme.workspace = true
 repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-core"
 version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 dataset = ["burn-dataset"]
 default = [

--- a/crates/burn-cubecl-fusion/Cargo.toml
+++ b/crates/burn-cubecl-fusion/Cargo.toml
@@ -11,6 +11,9 @@ readme.workspace = true
 repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-cubecl-fusion"
 version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = ["autotune", "std", "cubecl/default"]
 autotune = []

--- a/crates/burn-cubecl/Cargo.toml
+++ b/crates/burn-cubecl/Cargo.toml
@@ -11,6 +11,9 @@ readme.workspace = true
 repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-cubecl"
 version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 autotune = ["burn-cubecl-fusion?/autotune"]
 autotune-checks = ["burn-cubecl-fusion?/autotune-checks"]

--- a/crates/burn-cuda/Cargo.toml
+++ b/crates/burn-cuda/Cargo.toml
@@ -11,6 +11,9 @@ readme.workspace = true
 repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-cuda"
 version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 autotune = ["burn-cubecl/autotune"]
 autotune-checks = ["burn-cubecl/autotune-checks"]

--- a/crates/burn-dataset/Cargo.toml
+++ b/crates/burn-dataset/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-dataset"
 documentation = "https://docs.rs/burn-dataset"
 version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = ["sqlite-bundled"]
 doc = ["default"]

--- a/crates/burn-derive/Cargo.toml
+++ b/crates/burn-derive/Cargo.toml
@@ -10,6 +10,9 @@ readme.workspace = true
 repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-derive"
 version.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 proc-macro = true
 

--- a/crates/burn-fusion/Cargo.toml
+++ b/crates/burn-fusion/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-fusion"
 documentation = "https://docs.rs/burn-fusion"
 version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = ["std"]
 std = ["serde/std"]

--- a/crates/burn-import/Cargo.toml
+++ b/crates/burn-import/Cargo.toml
@@ -14,6 +14,9 @@ version.workspace = true
 
 default-run = "onnx2burn"
 
+[lints]
+workspace = true
+
 [features]
 default = ["onnx", "pytorch", "safetensors"]
 onnx = ["burn-ndarray"]

--- a/crates/burn-ir/Cargo.toml
+++ b/crates/burn-ir/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-ir"
 documentation = "https://docs.rs/burn-ir"
 version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = ["std"]
 std = ["burn-tensor/std"]

--- a/crates/burn-ndarray/Cargo.toml
+++ b/crates/burn-ndarray/Cargo.toml
@@ -11,6 +11,9 @@ readme.workspace = true
 repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-ndarray"
 version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = ["std", "simd"]
 doc = ["default"]

--- a/crates/burn-no-std-tests/Cargo.toml
+++ b/crates/burn-no-std-tests/Cargo.toml
@@ -10,6 +10,9 @@ readme.workspace = true
 repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-no-std-tests"
 version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 
 # ** Please make sure all dependencies support no_std **

--- a/crates/burn-remote/Cargo.toml
+++ b/crates/burn-remote/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-router-rem
 documentation = "https://docs.rs/burn-router-remote"
 version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = []
 doc = []

--- a/crates/burn-rocm/Cargo.toml
+++ b/crates/burn-rocm/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-rocm"
 documentation = "https://docs.rs/burn-rocm"
 version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = ["fusion", "burn-cubecl/default", "cubecl/default"]
 fusion = ["burn-fusion", "burn-cubecl/fusion"]

--- a/crates/burn-router/Cargo.toml
+++ b/crates/burn-router/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-router"
 documentation = "https://docs.rs/burn-router"
 version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = ["std"]
 std = ["burn-tensor/std", "burn-common/std", "burn-ir/std"]

--- a/crates/burn-tch/Cargo.toml
+++ b/crates/burn-tch/Cargo.toml
@@ -11,6 +11,9 @@ readme.workspace = true
 repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-tch"
 version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = ["std"]
 std = []

--- a/crates/burn-tensor-testgen/Cargo.toml
+++ b/crates/burn-tensor-testgen/Cargo.toml
@@ -8,6 +8,9 @@ readme.workspace = true
 repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-tensor-testgen"
 version.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 proc-macro = true
 

--- a/crates/burn-tensor/Cargo.toml
+++ b/crates/burn-tensor/Cargo.toml
@@ -11,6 +11,9 @@ readme.workspace = true
 repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-tensor"
 version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 cubecl = ["dep:cubecl"]
 cubecl-cuda = ["cubecl", "cubecl/cuda"]

--- a/crates/burn-train/Cargo.toml
+++ b/crates/burn-train/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-train"
 documentation = "https://docs.rs/burn-train"
 version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = ["sys-metrics", "tui"]
 doc = ["default"]

--- a/crates/burn-vision/Cargo.toml
+++ b/crates/burn-vision/Cargo.toml
@@ -14,6 +14,9 @@ readme.workspace = true
 repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-vision"
 version.workspace = true
 
+[lints]
+workspace = true
+
 
 [features]
 candle = ["burn-candle"]

--- a/crates/burn-wgpu/Cargo.toml
+++ b/crates/burn-wgpu/Cargo.toml
@@ -11,6 +11,9 @@ readme.workspace = true
 repository = "https://github.com/tracel-ai/burn/tree/main/crates/burn-wgpu"
 version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 autotune = ["burn-cubecl/autotune"]
 autotune-checks = ["burn-cubecl/autotune-checks"]

--- a/crates/burn/Cargo.toml
+++ b/crates/burn/Cargo.toml
@@ -12,6 +12,9 @@ repository = "https://github.com/tracel-ai/burn"
 rust-version = "1.85"
 version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = [
     "burn-core/default",

--- a/crates/onnx-ir/Cargo.toml
+++ b/crates/onnx-ir/Cargo.toml
@@ -12,6 +12,9 @@ repository = "https://github.com/tracel-ai/burn/tree/main/crates/onnx-ir"
 documentation = "https://docs.rs/onnx-ir"
 version.workspace = true
 
+[lints]
+workspace = true
+
 
 [dependencies]
 bytemuck = { workspace = true }

--- a/examples/custom-csv-dataset/Cargo.toml
+++ b/examples/custom-csv-dataset/Cargo.toml
@@ -7,6 +7,9 @@ description = "Example implementation for loading a custom CSV dataset from disk
 publish = false
 version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = ["burn/dataset"]
 

--- a/examples/custom-cubecl-kernel/Cargo.toml
+++ b/examples/custom-cubecl-kernel/Cargo.toml
@@ -6,6 +6,9 @@ name = "custom-cubecl-kernel"
 publish = false
 version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 burn = { path = "../../crates/burn", default-features = false, features = [
     "autodiff",

--- a/examples/custom-image-dataset/Cargo.toml
+++ b/examples/custom-image-dataset/Cargo.toml
@@ -7,6 +7,9 @@ description = "Example implementation for loading a custom image dataset from di
 publish = false
 version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = ["burn/default"]
 tch-gpu = ["burn/tch"]

--- a/examples/custom-renderer/Cargo.toml
+++ b/examples/custom-renderer/Cargo.toml
@@ -7,6 +7,9 @@ description = "Example of how to render training progress outside of the tui"
 publish = false
 version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 burn = {path = "../../crates/burn", features=["autodiff", "wgpu", "train", "dataset", "vision"], default-features=false}
 guide = {path = "../guide", default-features=false}

--- a/examples/custom-training-loop/Cargo.toml
+++ b/examples/custom-training-loop/Cargo.toml
@@ -6,6 +6,9 @@ name = "custom-training-loop"
 publish = false
 version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 burn = {path = "../../crates/burn", features=["autodiff", "webgpu", "vision"]}
 guide = {path = "../guide"}

--- a/examples/custom-wgpu-kernel/Cargo.toml
+++ b/examples/custom-wgpu-kernel/Cargo.toml
@@ -6,6 +6,9 @@ name = "custom-wgpu-kernel"
 publish = false
 version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 burn = { path = "../../crates/burn", default-features = false, features = [
     "autodiff",

--- a/examples/guide/Cargo.toml
+++ b/examples/guide/Cargo.toml
@@ -6,6 +6,9 @@ name = "guide"
 publish = false
 version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = ["burn/default"]
 

--- a/examples/image-classification-web/Cargo.toml
+++ b/examples/image-classification-web/Cargo.toml
@@ -6,6 +6,9 @@ name = "image-classification-web"
 publish = false
 version.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 crate-type = ["cdylib"]
 

--- a/examples/import-model-weights/Cargo.toml
+++ b/examples/import-model-weights/Cargo.toml
@@ -6,6 +6,9 @@ name = "import-model-weights"
 publish = false
 version = "0.18.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 
 burn = { path = "../../crates/burn", features = [

--- a/examples/mnist-inference-web/Cargo.toml
+++ b/examples/mnist-inference-web/Cargo.toml
@@ -6,6 +6,9 @@ name = "mnist-inference-web"
 publish = false
 version.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 crate-type = ["cdylib"]
 

--- a/examples/mnist/Cargo.toml
+++ b/examples/mnist/Cargo.toml
@@ -6,6 +6,9 @@ name = "mnist"
 publish = false
 version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = ["burn/dataset", "burn/vision"]
 ndarray = ["burn/ndarray"]

--- a/examples/modern-lstm/Cargo.toml
+++ b/examples/modern-lstm/Cargo.toml
@@ -3,6 +3,9 @@ name = "modern-lstm"
 version = "0.2.0"
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 ndarray = ["burn/ndarray"]
 ndarray-blas-accelerate = ["burn/ndarray", "burn/accelerate"]

--- a/examples/named-tensor/Cargo.toml
+++ b/examples/named-tensor/Cargo.toml
@@ -6,6 +6,9 @@ name = "named-tensor"
 publish = false
 version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 burn = {path = "../../crates/burn", features = ["experimental-named-tensor", "ndarray"]}
 

--- a/examples/onnx-inference/Cargo.toml
+++ b/examples/onnx-inference/Cargo.toml
@@ -6,6 +6,9 @@ name = "onnx-inference"
 publish = false
 version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = ["embedded-model"]
 

--- a/examples/raspberry-pi-pico/Cargo.toml
+++ b/examples/raspberry-pi-pico/Cargo.toml
@@ -5,6 +5,9 @@ name = "raspberry-pi-pico"
 license = "MIT OR Apache-2.0"
 version = "0.1.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 embassy-embedded-hal = { version = "0.3.0", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }

--- a/examples/server/Cargo.toml
+++ b/examples/server/Cargo.toml
@@ -6,6 +6,9 @@ name = "server"
 publish = false
 version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = ["webgpu"]
 cuda = ["burn/cuda", "cubecl/compilation-cache"]

--- a/examples/simple-regression/Cargo.toml
+++ b/examples/simple-regression/Cargo.toml
@@ -6,6 +6,9 @@ name = "simple-regression"
 publish = false
 version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = ["burn/dataset", "burn/sqlite-bundled"]
 ndarray = ["burn/ndarray"]

--- a/examples/text-classification/Cargo.toml
+++ b/examples/text-classification/Cargo.toml
@@ -6,6 +6,9 @@ name = "text-classification"
 publish = false
 version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = []
 f16 = []

--- a/examples/text-generation/Cargo.toml
+++ b/examples/text-generation/Cargo.toml
@@ -6,6 +6,9 @@ name = "text-generation"
 publish = false
 version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = ["burn/dataset", "burn/sqlite-bundled"]
 f16 = []

--- a/examples/wgan/Cargo.toml
+++ b/examples/wgan/Cargo.toml
@@ -3,6 +3,9 @@ name = "wgan"
 version = "0.2.0"
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 ndarray = ["burn/ndarray"]
 ndarray-blas-accelerate = ["burn/ndarray", "burn/accelerate"]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,6 +6,9 @@ license = "MIT OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lints]
+workspace = true
+
 [dependencies]
 log = { workspace = true }
 strum = { workspace = true }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

- Wired up clippy defaults to override several new default warnings that are broken in the codebase.
- Chained crates to depend upon the workspace lint configs.

