### PR TITLE
(perf) generate_mask functions optimizations

### DIFF
--- a/crates/burn-core/src/nn/attention/mask.rs
+++ b/crates/burn-core/src/nn/attention/mask.rs
@@ -11,17 +11,8 @@ pub fn generate_autoregressive_mask<B: Backend>(
     seq_length: usize,
     device: &B::Device,
 ) -> Tensor<B, 3, Bool> {
-    // TODO replace with more efficient op of `triu_mask` and `expand`
-    let mut mask = Tensor::<B, 3, Int>::zeros([1, seq_length, seq_length], device);
-
-    for i in 0..(seq_length - 1) {
-        let values = Tensor::<B, 3, Int>::ones([1, 1, seq_length - (i + 1)], device);
-        mask = mask.slice_assign([0..1, i..i + 1, i + 1..seq_length], values);
-    }
-
-    mask = mask.repeat_dim(0, batch_size);
-
-    mask.equal_elem(1_i64.elem::<i64>())
+    let mask = Tensor::<B, 2, Bool>::tril_mask([seq_length, seq_length], 0, device);
+    mask.expand([batch_size, seq_length, seq_length])
 }
 
 /// Generate a padding attention mask.

--- a/crates/burn-core/src/nn/attention/mask.rs
+++ b/crates/burn-core/src/nn/attention/mask.rs
@@ -51,22 +51,14 @@ pub fn generate_padding_mask<B: Backend>(
     tensor = tensor.add_scalar(pad_token as i64);
 
     for (index, tokens) in tokens_list.into_iter().enumerate() {
-        let mut seq_length = tokens.len();
-        let mut tokens = tokens;
-
-        if let Some(max_seq_length) = max_seq_length {
-            if seq_length > max_seq_length {
-                seq_length = max_seq_length;
-                let _ = tokens.split_off(seq_length);
-            }
-        }
-
+        let seq_length = tokens.len().min(max_size);
         tensor = tensor.slice_assign(
-            [index..index + 1, 0..tokens.len()],
+            [index..index + 1, 0..seq_length],
             Tensor::from_data(
                 TensorData::new(
                     tokens
                         .into_iter()
+                        .take(max_size)
                         .map(|e| (e as i64).elem::<IntElem<B>>())
                         .collect(),
                     Shape::new([1, seq_length]),


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.

There were 8 failing tests on my system (Asus PN50-E1, Ryzen 4700U) which seem unrelated to these changes

<details>
<summary>run-checks errors</summary>

```
failures:
                                                                                                                                                                                                                    
---- tests::cube::kernel::conv2d::tests::nchw_to_nhwc_should_match_into_contiguous stdout ----
                                                                                                                                                                                                                    
thread 'tests::cube::kernel::conv2d::tests::nchw_to_nhwc_should_match_into_contiguous' panicked at crates/burn-wgpu/src/lib.rs:129:5:
Tensors are not approx eq:
  => Position 0: 0.8401348 != 0.4808194
     diff (rel = +2.72e-1, abs = +3.59e-1), tol (rel = +7.63e-6, abs = +1.88e-37)
  => Position 1: 0.2639603 != 0.8517316
     diff (rel = +5.27e-1, abs = +5.88e-1), tol (rel = +7.63e-6, abs = +1.88e-37)
  => Position 2: 0.09077653 != 0.08293253
     diff (rel = +4.52e-2, abs = +7.84e-3), tol (rel = +7.63e-6, abs = +1.88e-37)
  => Position 3: 0.64059836 != 0.18346767
     diff (rel = +5.55e-1, abs = +4.57e-1), tol (rel = +7.63e-6, abs = +1.88e-37)
  => Position 4: 0.3280799 != 0.057279117
     diff (rel = +7.03e-1, abs = +2.71e-1), tol (rel = +7.63e-6, abs = +1.88e-37)
474865 more errors...
                                                                                                                                                                                                                    
---- tests::cube::kernel::conv2d::tests::nchw_to_nhwc_should_match_into_contiguous_regression stdout ----
                                                                                                                                                                                                                    
thread 'tests::cube::kernel::conv2d::tests::nchw_to_nhwc_should_match_into_contiguous_regression' panicked at crates/burn-wgpu/src/lib.rs:129:5:
Tensors are not approx eq:
  => Position 288: 0.16456887 != 0.020139458
     diff (rel = +7.82e-1, abs = +1.44e-1), tol (rel = +7.63e-6, abs = +1.88e-37)
  => Position 289: 0.15798609 != 0.0511629
     diff (rel = +5.11e-1, abs = +1.07e-1), tol (rel = +7.63e-6, abs = +1.88e-37)
  => Position 290: 0.15135513 != 0.91991514
     diff (rel = +7.17e-1, abs = +7.69e-1), tol (rel = +7.63e-6, abs = +1.88e-37)
  => Position 291: 0 != 0.95116186
     diff (rel = +1.00e0, abs = +9.51e-1), tol (rel = +7.63e-6, abs = +1.88e-37)
  => Position 292: 0.165027 != 0.054931425
     diff (rel = +5.01e-1, abs = +1.10e-1), tol (rel = +7.63e-6, abs = +1.88e-37)
13 more errors...
                                                                                                                                                                                                                    
---- tests::cube::tensor::f32_ty::remainder::tests::should_support_remainder_basic stdout ----
                                                                                                                                                                                                                    
thread 'tests::cube::tensor::f32_ty::remainder::tests::should_support_remainder_basic' panicked at crates/burn-wgpu/src/lib.rs:129:5:
Tensors are not approx eq:
  => Position 5: 3 != 0
     diff (rel = +1.00e0, abs = +3.00e0), tol (rel = +7.63e-6, abs = +1.88e-37)
                                                                                                                                                                                                                    
---- tests::cube::tensor::f32_ty::remainder::tests::should_support_remainder_op stdout ----
                                                                                                                                                                                                                    
thread 'tests::cube::tensor::f32_ty::remainder::tests::should_support_remainder_op' panicked at crates/burn-wgpu/src/lib.rs:129:5:
Tensors are not approx eq:
  => Position 5: 3 != 0
     diff (rel = +1.00e0, abs = +3.00e0), tol (rel = +7.63e-6, abs = +1.88e-37)
                                                                                                                                                                                                                    
---- tests::cube::tensor::f32_ty::vector_norm::tests::test_normalize stdout ----
                                                                                                                                                                                                                    
thread 'tests::cube::tensor::f32_ty::vector_norm::tests::test_normalize' panicked at crates/burn-wgpu/src/lib.rs:129:5:
Tensors are not eq:
  => Position 1: 0.3333333 != 0.33333334
  => Position 3: 0.6666666 != 0.6666667
                                                                                                                                                                                                                    
---- tests::cube_fusion::tensor::f32_ty::remainder::tests::should_support_remainder_op stdout ----
                                                                                                                                                                                                                    
thread 'tests::cube_fusion::tensor::f32_ty::remainder::tests::should_support_remainder_op' panicked at crates/burn-wgpu/src/lib.rs:129:5:
Tensors are not approx eq:
  => Position 5: 3 != 0
     diff (rel = +1.00e0, abs = +3.00e0), tol (rel = +7.63e-6, abs = +1.88e-37)
                                                                                                                                                                                                                    
---- tests::cube_fusion::tensor::f32_ty::remainder::tests::should_support_remainder_basic stdout ----
                                                                                                                                                                                                                    
thread 'tests::cube_fusion::tensor::f32_ty::remainder::tests::should_support_remainder_basic' panicked at crates/burn-wgpu/src/lib.rs:129:5:
Tensors are not approx eq:
  => Position 5: 3 != 0
     diff (rel = +1.00e0, abs = +3.00e0), tol (rel = +7.63e-6, abs = +1.88e-37)
                                                                                                                                                                                                                    
---- tests::cube_fusion::tensor::f32_ty::vector_norm::tests::test_normalize stdout ----
                                                                                                                                                                                                                    
thread 'tests::cube_fusion::tensor::f32_ty::vector_norm::tests::test_normalize' panicked at crates/burn-wgpu/src/lib.rs:129:5:
Tensors are not eq:
  => Position 1: 0.3333333 != 0.33333334
  => Position 3: 0.6666666 != 0.6666667
                                                                                                                                                                                                                    
                                                                                                                                                                                                                    
failures:
    tests::cube::kernel::conv2d::tests::nchw_to_nhwc_should_match_into_contiguous
    tests::cube::kernel::conv2d::tests::nchw_to_nhwc_should_match_into_contiguous_regression
    tests::cube::tensor::f32_ty::remainder::tests::should_support_remainder_basic
    tests::cube::tensor::f32_ty::remainder::tests::should_support_remainder_op
    tests::cube::tensor::f32_ty::vector_norm::tests::test_normalize
    tests::cube_fusion::tensor::f32_ty::remainder::tests::should_support_remainder_basic
    tests::cube_fusion::tensor::f32_ty::remainder::tests::should_support_remainder_op
    tests::cube_fusion::tensor::f32_ty::vector_norm::tests::test_normalize
                                                                                                                                                                                                                    
test result: FAILED. 2967 passed; 8 failed; 16 ignored; 0 measured; 0 filtered out; finished in 60.44s
```        
</details>

- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

No particular issue, this as it is a simple performance related PR

### Changes

There are 2 perf changes:
- `generate_autoregressive_mask`: as per the TODO, use triangular tensors and expand instead of manually populating the mask
- `generate_padding_mask`: avoid `split_off` calls and instead only take up to `max_size` elements when iterating

As explained in the commit messages, I am no expert in terms of code generation (for the autoregressive change). I don't really know if it ends up being better or not.

### Testing

I have mostly generated a simple script to confirm that the tensors stay are the same.

```rs
use burn::backend::Wgpu;
use burn::nn::attention::generate_autoregressive_mask;
use burn::tensor::{Bool, Tensor};

fn main() {
    let ssz = 5;
    let bsz = 4;
    type MyBackend = Wgpu<f32, i32>;
    let device = burn::backend::wgpu::WgpuDevice::default();
    let t: Tensor<MyBackend, 2, _> = Tensor::tril_mask([ssz, ssz], 0, &device);
    let t: Tensor<MyBackend, 3, Bool> = t.expand([bsz, ssz, ssz]);
    let t2: Tensor<MyBackend, 3, Bool> = generate_autoregressive_mask(bsz, ssz, &device);
    println!("tensor: {t}, {t2}");
}
```
