### PR TITLE
`burn-import`: import `derive_new::new` for `safetensors` feat

### DIFF
--- a/crates/burn-import/src/lib.rs
+++ b/crates/burn-import/src/lib.rs
@@ -10,7 +10,7 @@
 //! aligns the imported model with Burn's model and converts tensor data into a format compatible with
 //! Burn.
 
-#[cfg(any(feature = "pytorch", feature = "onnx"))]
+#[cfg(any(feature = "pytorch", feature = "onnx", feature = "safetensors"))]
 #[macro_use]
 extern crate derive_new;
 


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [n/a] Confirmed that `cargo run-checks` command has been executed.
- [n/a] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

- Fixes #3204

### Changes

Depending on `burn-import` with only the `safetensors` feat causes a build failure.
The fix is a one-line change to import it on the `safetensors` feat.

### Testing

The build succeeds.
