### PR TITLE
[CI] Disable GCP runners in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,85 +137,88 @@ jobs:
       - name: Documentation Tests
         run: cargo xtask doc tests
 
-  linux-std-tests-gcp-launcher:
-    needs: [prepare-checks, code-quality]
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        rust: [stable]
-        backend: [cuda]
-        # backend: [cuda, vulkan]
-    outputs:
-      label_stable_cuda: ${{ steps.gen_output.outputs.label_stable_cuda }}
-      # label_stable_vulkan: ${{ steps.gen_output.outputs.label_stable_vulkan }}
-    steps:
-      - name: Create runners
-        id: create-runner
-        uses: related-sciences/gce-github-runner@v0.14
-        with:
-          ephemeral: true
-          image_family: ${{ env.GCP_RUNNERS_IMAGE_FAMILY }}
-          image_project: ${{ secrets.GCP_CI_PROJECT_ID }}
-          machine_type: ${{ env.GCP_RUNNERS_TYPE }}
-          machine_zone: ${{ env.GCP_RUNNERS_ZONE }}
-          maintenance_policy_terminate: true
-          project_id: ${{ secrets.GCP_CI_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          token: ${{ secrets.GCE_GITHUB_RUNNER_GH_TOKEN }}
-          vm_name_prefix: ${{ format('gce-gh-runner-linux-std-{0}-{1}-tests', matrix.rust, matrix.backend) }}
-      # --------------------------------------------------------------------------------
-      - name: Generate output
-        id: gen_output
-        run: |
-          rust=${{ matrix.rust }}
-          backend=${{ matrix.backend }}
-          label=${{ steps.create-runner.outputs.label }}
-          echo "label_${rust}_${backend}=${label}" >> "$GITHUB_OUTPUT"
-      # --------------------------------------------------------------------------------
-      # handle the case where we cancel the workflow while runners are being created
-      - name: Install gcloud
-        uses: google-github-actions/setup-gcloud@v2
-        if: cancelled()
-      # --------------------------------------------------------------------------------
-      - name: Gcloud authentication
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-          create_credentials_file: false
-        if: cancelled()
-      # --------------------------------------------------------------------------------
-      - name: Make sure ephemeral runners are deleted
-        if: cancelled()
-        run: >
-          gcloud compute instances delete
-          --project ${{ secrets.GCP_CI_PROJECT_ID }}
-          --zone ${{ env.GCP_RUNNERS_ZONE }}
-          --quiet
-          ${{ format('gce-gh-runner-linux-std-cuda-tests-{0}', matrix.rust) }}-${{ github.run_id }}-${{ github.run_attempt }}
+  ######################################################################################
+  ## Disable CUDA tests for now, will be back soon
+  ######################################################################################
+  # linux-std-tests-gcp-launcher:
+  #   needs: [prepare-checks, code-quality]
+  #   runs-on: ubuntu-22.04
+  #   strategy:
+  #     matrix:
+  #       rust: [stable]
+  #       backend: [cuda]
+  #       # backend: [cuda, vulkan]
+  #   outputs:
+  #     label_stable_cuda: ${{ steps.gen_output.outputs.label_stable_cuda }}
+  #     # label_stable_vulkan: ${{ steps.gen_output.outputs.label_stable_vulkan }}
+  #   steps:
+  #     - name: Create runners
+  #       id: create-runner
+  #       uses: related-sciences/gce-github-runner@v0.14
+  #       with:
+  #         ephemeral: true
+  #         image_family: ${{ env.GCP_RUNNERS_IMAGE_FAMILY }}
+  #         image_project: ${{ secrets.GCP_CI_PROJECT_ID }}
+  #         machine_type: ${{ env.GCP_RUNNERS_TYPE }}
+  #         machine_zone: ${{ env.GCP_RUNNERS_ZONE }}
+  #         maintenance_policy_terminate: true
+  #         project_id: ${{ secrets.GCP_CI_PROJECT_ID }}
+  #         service_account_key: ${{ secrets.GCP_SA_KEY }}
+  #         token: ${{ secrets.GCE_GITHUB_RUNNER_GH_TOKEN }}
+  #         vm_name_prefix: ${{ format('gce-gh-runner-linux-std-{0}-{1}-tests', matrix.rust, matrix.backend) }}
+  #     # --------------------------------------------------------------------------------
+  #     - name: Generate output
+  #       id: gen_output
+  #       run: |
+  #         rust=${{ matrix.rust }}
+  #         backend=${{ matrix.backend }}
+  #         label=${{ steps.create-runner.outputs.label }}
+  #         echo "label_${rust}_${backend}=${label}" >> "$GITHUB_OUTPUT"
+  #     # --------------------------------------------------------------------------------
+  #     # handle the case where we cancel the workflow while runners are being created
+  #     - name: Install gcloud
+  #       uses: google-github-actions/setup-gcloud@v2
+  #       if: cancelled()
+  #     # --------------------------------------------------------------------------------
+  #     - name: Gcloud authentication
+  #       uses: google-github-actions/auth@v2
+  #       with:
+  #         credentials_json: ${{ secrets.GCP_SA_KEY }}
+  #         create_credentials_file: false
+  #       if: cancelled()
+  #     # --------------------------------------------------------------------------------
+  #     - name: Make sure ephemeral runners are deleted
+  #       if: cancelled()
+  #       run: >
+  #         gcloud compute instances delete
+  #         --project ${{ secrets.GCP_CI_PROJECT_ID }}
+  #         --zone ${{ env.GCP_RUNNERS_ZONE }}
+  #         --quiet
+  #         ${{ format('gce-gh-runner-linux-std-cuda-tests-{0}', matrix.rust) }}-${{ github.run_id }}-${{ github.run_attempt }}
 
-  linux-std-cuda-tests:
-    needs: [prepare-checks, code-quality, linux-std-tests-gcp-launcher]
-    runs-on: ${{ needs.linux-std-tests-gcp-launcher.outputs[format('label_{0}_cuda', matrix.rust)] }}
-    env:
-      LD_LIBRARY_PATH: '/usr/local/cuda/lib64'
-      # disable incremental compilation (reduces artifact size)
-      CARGO_PROFILE_TEST_INCREMENTAL: 'false'
-    # Keep the stragegy to be able to easily add new rust versions if required
-    strategy:
-      matrix:
-        rust: [stable]
-        include:
-          - rust: stable
-            toolchain: stable
-    steps:
-      - name: Setup Rust
-        uses: tracel-ai/github-actions/setup-rust@v2
-        with:
-          rust-toolchain: ${{ matrix.toolchain }}
-          enable-cache: false
-      # --------------------------------------------------------------------------------
-      - name: Tests (burn-cuda)
-        run: cargo xtask test --ci gcp-cuda-runner
+  # linux-std-cuda-tests:
+  #   needs: [prepare-checks, code-quality, linux-std-tests-gcp-launcher]
+  #   runs-on: ${{ needs.linux-std-tests-gcp-launcher.outputs[format('label_{0}_cuda', matrix.rust)] }}
+  #   env:
+  #     LD_LIBRARY_PATH: '/usr/local/cuda/lib64'
+  #     # disable incremental compilation (reduces artifact size)
+  #     CARGO_PROFILE_TEST_INCREMENTAL: 'false'
+  #   # Keep the stragegy to be able to easily add new rust versions if required
+  #   strategy:
+  #     matrix:
+  #       rust: [stable]
+  #       include:
+  #         - rust: stable
+  #           toolchain: stable
+  #   steps:
+  #     - name: Setup Rust
+  #       uses: tracel-ai/github-actions/setup-rust@v2
+  #       with:
+  #         rust-toolchain: ${{ matrix.toolchain }}
+  #         enable-cache: false
+  #     # --------------------------------------------------------------------------------
+  #     - name: Tests (burn-cuda)
+  #       run: cargo xtask test --ci gcp-cuda-runner
 
   ######################################################################################
   ## Disable Vulkan tests as they are very long to run for now in GCP


### PR DESCRIPTION
We need to use a different execution model to create and delete runners for our public repos. In the meantime we disable the GCP runners.