### PR TITLE
Tensor::slice_fill()

### DIFF
--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -943,6 +943,32 @@ where
         Self::new(K::slice_assign(self.primitive, &ranges, values.primitive))
     }
 
+    /// Returns a copy of the current tensor with the selected elements changed to the new ones at
+    /// the selected indices.
+    ///
+    /// # Panics
+    ///
+    /// - If a range exceeds the number of elements on a dimension.
+    /// - If the given values don't match the given ranges.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use burn_tensor::backend::Backend;
+    /// use burn_tensor::Tensor;
+    ///
+    /// fn example<B: Backend>() {
+    ///   let device = B::Device::default();
+    ///   let tensor = Tensor::<B, 3>::ones([2, 3, 3], &device);
+    ///   let tensor_sliced = tensor.slice_fill([0..1, 0..1, 0..1], 2.0);
+    ///   println!("{:?}", tensor_sliced.dims()); // [2, 3, 3]
+    /// }
+    /// ```
+    pub fn slice_fill<const D2: usize>(self, ranges: [Range<usize>; D2], value: K::Elem) -> Self {
+        check!(TensorCheck::slice::<D, D2>(&self.shape(), &ranges));
+        Self::new(K::slice_fill(self.primitive, &ranges, value))
+    }
+
     /// Returns the device of the current tensor.
     pub fn device(&self) -> B::Device {
         K::device(&self.primitive)
@@ -2182,6 +2208,38 @@ pub trait BasicOps<B: Backend>: TensorKind<B> {
         ranges: &[Range<usize>],
         value: Self::Primitive,
     ) -> Self::Primitive;
+
+    /// Fills the tensor elements corresponding for the given ranges with the given value.
+    ///
+    /// # Arguments
+    ///
+    /// * `tensor` - The tensor.
+    /// * `ranges` - The ranges of the elements to fill.
+    /// * `value` - The value to fill.
+    ///
+    /// # Returns
+    ///
+    /// The tensor with the filled values.
+    ///
+    /// # Remarks
+    ///
+    /// This is a low-level function used internally by the library to call different backend functions
+    /// with static dispatch. It is not designed for direct usage by users, and not recommended to import
+    /// or use this function directly.
+    ///
+    /// For filling values in a tensor, users should prefer the [Tensor::slice_fill](Tensor::slice_fill) function,
+    /// which is more high-level and designed for public use.
+    fn slice_fill(
+        tensor: Self::Primitive,
+        ranges: &[Range<usize>],
+        value: Self::Elem,
+    ) -> Self::Primitive {
+        let slice_shape = Self::slice(tensor.clone(), ranges).shape();
+
+        let value = Self::from_data(TensorData::from([value]), &Self::device(&tensor));
+        let value = Self::expand(value, slice_shape);
+        Self::slice_assign(tensor, ranges, value)
+    }
 
     /// Returns the device on which the tensor is allocated.
     ///

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -15,7 +15,8 @@ use serde::{Deserialize, Deserializer};
 use serde::{Serialize, Serializer};
 
 use crate::{
-    Bool, Float, Int, Shape, TensorData, TensorKind, backend::Backend, check, ops::Device,
+    Bool, ElementConversion, Float, Int, Shape, TensorData, TensorKind, backend::Backend, check,
+    ops::Device,
 };
 use crate::{DType, Element, TensorPrimitive};
 use crate::{cast::ToElement, check::TensorCheck};
@@ -964,9 +965,13 @@ where
     ///   println!("{:?}", tensor_sliced.dims()); // [2, 3, 3]
     /// }
     /// ```
-    pub fn slice_fill<const D2: usize>(self, ranges: [Range<usize>; D2], value: K::Elem) -> Self {
+    pub fn slice_fill<const D2: usize, E: ElementConversion>(
+        self,
+        ranges: [Range<usize>; D2],
+        value: E,
+    ) -> Self {
         check!(TensorCheck::slice::<D, D2>(&self.shape(), &ranges));
-        Self::new(K::slice_fill(self.primitive, &ranges, value))
+        Self::new(K::slice_fill(self.primitive, &ranges, value.elem()))
     }
 
     /// Returns the device of the current tensor.

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -935,7 +935,14 @@ where
     ///     println!("{:?}", tensor_sliced.dims()); // [2, 3, 3]
     /// }
     /// ```
-    pub fn slice_assign<const D2: usize>(self, ranges: [Range<usize>; D2], values: Self) -> Self {
+    ///
+    /// # Note
+    ///
+    /// This function uses the `RangesArg` trait for flexible range specification. The trait
+    /// handles the conversion of various range formats and applies clamping and negative
+    /// index handling internally.
+    pub fn slice_assign<const D2: usize, R: RangesArg<D2>>(self, ranges: R, values: Self) -> Self {
+        let ranges = ranges.into_ranges(self.shape());
         check!(TensorCheck::slice_assign::<D, D2>(
             &self.shape(),
             &values.shape(),
@@ -965,12 +972,20 @@ where
     ///   println!("{:?}", tensor_sliced.dims()); // [2, 3, 3]
     /// }
     /// ```
-    pub fn slice_fill<const D2: usize, E: ElementConversion>(
+    ///
+    /// # Note
+    ///
+    /// This function uses the `RangesArg` trait for flexible range specification. The trait
+    /// handles the conversion of various range formats and applies clamping and negative
+    /// index handling internally.
+    pub fn slice_fill<const D2: usize, R: RangesArg<D2>, E: ElementConversion>(
         self,
-        ranges: [Range<usize>; D2],
+        ranges: R,
         value: E,
     ) -> Self {
+        let ranges = ranges.into_ranges(self.shape());
         check!(TensorCheck::slice::<D, D2>(&self.shape(), &ranges));
+
         Self::new(K::slice_fill(self.primitive, &ranges, value.elem()))
     }
 

--- a/crates/burn-tensor/src/tests/ops/slice.rs
+++ b/crates/burn-tensor/src/tests/ops/slice.rs
@@ -121,6 +121,32 @@ mod tests {
     }
 
     #[test]
+    fn should_support_slice_fill_1d() {
+        let data = TensorData::from([0.0, 1.0, 2.0]);
+
+        let device = Default::default();
+        let tensor = TestTensor::<1>::from_data(data, &device);
+
+        let output = tensor.slice_fill([0..2], -1.0);
+        let expected = TensorData::from([-1.0, -1.0, 2.0]);
+
+        output.into_data().assert_eq(&expected, false);
+    }
+
+    #[test]
+    fn should_support_slice_fill_2d() {
+        let data = TensorData::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+
+        let device = Default::default();
+        let tensor = TestTensor::<2>::from_data(data, &device);
+
+        let output = tensor.slice_fill([1..2, 0..2], -1.0);
+        let expected = TensorData::from([[0.0, 1.0, 2.0], [-1.0, -1.0, 5.0]]);
+
+        output.into_data().assert_eq(&expected, false);
+    }
+
+    #[test]
     fn slice_should_not_corrupt_potentially_inplace_operations() {
         let tensor = TestTensorInt::<1>::from_data([1, 2, 3, 4, 5], &Default::default());
         let tensor = tensor.clone().slice([0..3]) + tensor.clone().slice([2..5]);

--- a/crates/burn-tensor/src/tests/ops/slice.rs
+++ b/crates/burn-tensor/src/tests/ops/slice.rs
@@ -134,6 +134,19 @@ mod tests {
     }
 
     #[test]
+    fn should_support_slice_fill_1d_neg() {
+        let data = TensorData::from([0.0, 1.0, 2.0]);
+
+        let device = Default::default();
+        let tensor = TestTensor::<1>::from_data(data, &device);
+
+        let output = tensor.slice_fill([-1..], -1.0);
+        let expected = TensorData::from([0.0, 1.0, -1.0]);
+
+        output.into_data().assert_eq(&expected, false);
+    }
+
+    #[test]
     fn should_support_slice_fill_2d() {
         let data = TensorData::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
 


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

Adds a `<tensor>.slice_fill(ranges, elem)` api.

### Testing

Added tests.