### PR TITLE
Feature/inference timing utils

### DIFF
--- a/examples/inference_timing.rs
+++ b/examples/inference_timing.rs
@@ -1,0 +1,80 @@
+use burn::{
+    backend::{
+        libtorch::{LibTorch, LibTorchDevice},
+        wgpu::{Wgpu, WgpuDevice},
+        ndarray::{NdArray, NdArrayDevice},
+        Backend,
+    },
+    tensor::Tensor,
+};
+use burn_example::{utils::{TimingConfig, measure_inference_time, InferenceMeasurable}};
+
+// Example model that performs matrix multiplication
+struct ExampleModel<B: Backend> {
+    weights: Tensor<B, 2>,
+}
+
+impl<B: Backend> ExampleModel<B> {
+    fn new(device: &B::Device) -> Self {
+        let weights = Tensor::ones([100, 100]).to_device(device);
+        Self { weights }
+    }
+
+    fn forward(&self, input: &Tensor<B, 2>) -> Tensor<B, 2> {
+        input.matmul(&self.weights)
+    }
+}
+
+// Implement the InferenceMeasurable trait for our model
+impl_inference_measurable!(ExampleModel<B>, Tensor<B, 2>, Tensor<B, 2>);
+
+fn run_benchmark<B: Backend>(device: B::Device) {
+    println!("Running benchmark on {}", B::name(&device));
+    
+    // Create model and input
+    let model = ExampleModel::new(&device);
+    let input = Tensor::ones([1, 100]).to_device(&device);
+    
+    // Configure timing parameters
+    let config = TimingConfig {
+        num_warmup: 10,
+        num_iterations: 100,
+    };
+    
+    // Measure inference time
+    let results = measure_inference_time(&model, &input, &device, config);
+    
+    // Print results
+    println!("Results:");
+    println!("  Mean: {:?}", results.mean);
+    println!("  Std Dev: {:?}", results.std_dev);
+    println!("  Min: {:?}", results.min);
+    println!("  Max: {:?}", results.max);
+}
+
+fn main() {
+    // Test on CPU with ndarray backend
+    println!("\nTesting with NdArray backend (CPU):");
+    run_benchmark::<NdArray>(NdArrayDevice::Cpu);
+    
+    // Test on GPU with WGPU backend if available
+    #[cfg(feature = "wgpu")]
+    {
+        println!("\nTesting with WGPU backend:");
+        run_benchmark::<Wgpu>(WgpuDevice::default());
+    }
+    
+    // Test on GPU with LibTorch backend if available
+    #[cfg(feature = "libtorch-cuda")]
+    {
+        println!("\nTesting with LibTorch backend (CUDA):");
+        run_benchmark::<LibTorch>(LibTorchDevice::Cuda(0));
+    }
+    
+    // Test on Metal with LibTorch backend if available
+    #[cfg(all(feature = "libtorch-metal", target_os = "macos"))]
+    {
+        println!("\nTesting with LibTorch backend (Metal):");
+        run_benchmark::<LibTorch>(LibTorchDevice::Mps);
+    }
+} 

--- a/src/utils/inference_timer.rs
+++ b/src/utils/inference_timer.rs
@@ -1,0 +1,143 @@
+use std::time::{Duration, Instant};
+use burn::tensor::backend::Backend;
+
+/// Configuration for inference timing
+pub struct TimingConfig {
+    /// Number of warm-up iterations before timing
+    pub num_warmup: usize,
+    /// Number of iterations to measure
+    pub num_iterations: usize,
+}
+
+impl Default for TimingConfig {
+    fn default() -> Self {
+        Self {
+            num_warmup: 10,
+            num_iterations: 100,
+        }
+    }
+}
+
+/// Results from timing measurements
+#[derive(Debug)]
+pub struct TimingResults {
+    /// Individual timing measurements
+    pub measurements: Vec<Duration>,
+    /// Mean duration
+    pub mean: Duration,
+    /// Standard deviation
+    pub std_dev: Duration,
+    /// Minimum duration
+    pub min: Duration,
+    /// Maximum duration
+    pub max: Duration,
+}
+
+impl TimingResults {
+    fn new(measurements: Vec<Duration>) -> Self {
+        let len = measurements.len() as f64;
+        let sum: Duration = measurements.iter().sum();
+        let mean = sum / measurements.len() as u32;
+
+        let variance_sum: f64 = measurements
+            .iter()
+            .map(|&d| {
+                let diff = d.as_secs_f64() - mean.as_secs_f64();
+                diff * diff
+            })
+            .sum();
+        let std_dev = Duration::from_secs_f64((variance_sum / len).sqrt());
+
+        let min = *measurements.iter().min().unwrap();
+        let max = *measurements.iter().max().unwrap();
+
+        Self {
+            measurements,
+            mean,
+            std_dev,
+            min,
+            max,
+        }
+    }
+}
+
+/// Measures inference time for any model that can process an input
+pub trait InferenceMeasurable<B: Backend, Input, Output> {
+    /// Run a single inference pass
+    fn infer(&self, input: &Input) -> Output;
+}
+
+/// Measure inference time with proper GPU synchronization
+pub fn measure_inference_time<B, M, I, O>(
+    model: &M,
+    input: &I,
+    device: &B::Device,
+    config: TimingConfig,
+) -> TimingResults 
+where
+    B: Backend,
+    M: InferenceMeasurable<B, I, O>,
+{
+    // Warm-up phase
+    for _ in 0..config.num_warmup {
+        let _ = model.infer(input);
+        B::sync(device);
+    }
+    
+    // Measurement phase
+    let mut timings = Vec::with_capacity(config.num_iterations);
+    
+    for _ in 0..config.num_iterations {
+        let start = Instant::now();
+        let _ = model.infer(input);
+        B::sync(device);
+        timings.push(start.elapsed());
+    }
+    
+    TimingResults::new(timings)
+}
+
+/// Helper macro to implement InferenceMeasurable for a type with a forward method
+#[macro_export]
+macro_rules! impl_inference_measurable {
+    ($type:ty, $input:ty, $output:ty) => {
+        impl<B: Backend> InferenceMeasurable<B, $input, $output> for $type {
+            fn infer(&self, input: &$input) -> $output {
+                self.forward(input)
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use burn::backend::ndarray::{NdArray, NdArrayDevice};
+    use burn::tensor::Tensor;
+
+    struct DummyModel;
+    
+    impl<B: Backend> InferenceMeasurable<B, Tensor<B, 2>, Tensor<B, 2>> for DummyModel {
+        fn infer(&self, input: &Tensor<B, 2>) -> Tensor<B, 2> {
+            input.clone()
+        }
+    }
+
+    #[test]
+    fn test_timing_measurement() {
+        let device = NdArrayDevice::Cpu;
+        let model = DummyModel;
+        let input: Tensor<NdArray, 2> = Tensor::zeros([1, 10]).to_device(&device);
+        
+        let config = TimingConfig {
+            num_warmup: 2,
+            num_iterations: 5,
+        };
+        
+        let results = measure_inference_time::<NdArray, _, _, _>(&model, &input, &device, config);
+        
+        assert_eq!(results.measurements.len(), 5);
+        assert!(results.mean > Duration::from_nanos(0));
+        assert!(results.std_dev >= Duration::from_nanos(0));
+    }
+} 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,3 @@
+mod inference_timer;
+
+pub use inference_timer::*; 


### PR DESCRIPTION
# Add inference timing utilities with GPU synchronization

This PR adds utilities for measuring inference time in Burn with proper GPU synchronization, addressing issue #3226.

## Features
- `TimingConfig` struct for configuring warmup and measurement iterations
- `TimingResults` struct for comprehensive timing statistics (mean, std dev, min, max)
- `InferenceMeasurable` trait for models that can be measured
- `measure_inference_time` function that handles proper GPU synchronization
- Example showing usage with different backends (CPU, WGPU, CUDA, Metal)

## Usage Example
```rust
let device = WgpuDevice::default();
let model = YourModel::new(&device);
let input = your_input.to_device(&device);

let config = TimingConfig {
    num_warmup: 10,      // Number of warm-up iterations
    num_iterations: 100,  // Number of measured iterations
};

let results = measure_inference_time(&model, &input, &device, config);
println!("Mean inference time: {:?}", results.mean);
```

Fixes #3226