### PR TITLE
Base impl of `Tensor::slice_dim(self, dim, range)`; add `RangeArg` trait.

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -165,6 +165,7 @@ Those operations are available for all tensor kinds: `Int`, `Float`, and `Bool`.
 | `tensor.slice(ranges)`                       | `tensor[(*ranges,)]`                                                       |
 | `tensor.slice_assign(ranges, values)`        | `tensor[(*ranges,)] = values`                                              |
 | `tensor.slice_fill(ranges, value)`           | `tensor[(*ranges,)] = value`                                               |
+| `tensor.slice_dim(dim, range)`               | N/A                                                                        |
 | `tensor.squeeze(dim)`                        | `tensor.squeeze(dim)`                                                      |
 | `tensor.swap_dims(dim1, dim2)`               | `tensor.transpose(dim1, dim2)`                                             |
 | `tensor.to_data()`                           | N/A                                                                        |

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -989,6 +989,33 @@ where
         Self::new(K::slice_fill(self.primitive, &ranges, value.elem()))
     }
 
+    /// Returns a new tensor with the specified dimension sliced.
+    ///
+    /// # Arguments
+    ///
+    /// * `dim`: The dimension to slice.
+    /// * `range`: The range to slice the dimension with.
+    ///
+    /// # Returns
+    ///
+    /// A new tensor with the specified dimension sliced.
+    ///
+    /// # Panics
+    ///
+    /// If the range is out of bounds for the specified dimension.
+    ///
+    /// # Note
+    ///
+    /// This function uses the `RangeArg` trait for flexible range specification. The trait
+    /// handles the conversion of various range formats and applies clamping and negative
+    /// index handling internally.
+    pub fn slice_dim<R: RangeArg>(self, dim: usize, range: R) -> Self {
+        let range = range.into_range(self.shape().dims[dim]);
+        check!(TensorCheck::slice_dim::<D>(&self.shape(), dim, &range));
+
+        Self::new(K::slice_dim(self.primitive, dim, &range))
+    }
+
     /// Returns the device of the current tensor.
     pub fn device(&self) -> B::Device {
         K::device(&self.primitive)
@@ -2261,6 +2288,30 @@ pub trait BasicOps<B: Backend>: TensorKind<B> {
         Self::slice_assign(tensor, ranges, value)
     }
 
+    /// Slices the tensor along a given dimension with the specified range.
+    ///
+    /// # Arguments
+    ///
+    /// * `tensor` - The tensor to slice.
+    /// * `dim` - The dimension along which to slice.
+    /// * `range` - The range of indices to slice along the specified dimension.
+    ///
+    /// # Returns
+    ///
+    /// The sliced tensor.
+    ///
+    /// # Remarks
+    ///
+    /// This is a low-level function used internally by the library to call different backend functions
+    /// with static dispatch. It is not designed for direct usage by users, and not recommended to import
+    /// or use this function directly.
+    fn slice_dim(tensor: Self::Primitive, dim: usize, range: &Range<usize>) -> Self::Primitive {
+        let mut ranges: Vec<Range<usize>> = tensor.shape().dims.iter().map(|&s| 0..s).collect();
+        ranges[dim] = range.clone();
+
+        Self::slice(tensor, &ranges)
+    }
+
     /// Returns the device on which the tensor is allocated.
     ///
     /// # Arguments
@@ -2993,6 +3044,18 @@ impl MovedimArgs for i32 {
         set.push(dim);
 
         set
+    }
+}
+
+/// Trait used for slice dim arguments.
+pub trait RangeArg {
+    /// Converts into a range for the `tensor.slice_dim()` function
+    fn into_range(self, shape_dim: usize) -> Range<usize>;
+}
+
+impl<T: Into<Slice>> RangeArg for T {
+    fn into_range(self, shape_dim: usize) -> Range<usize> {
+        self.into().into_range(shape_dim)
     }
 }
 

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -1009,9 +1009,12 @@ where
     /// This function uses the `RangeArg` trait for flexible range specification. The trait
     /// handles the conversion of various range formats and applies clamping and negative
     /// index handling internally.
-    pub fn slice_dim<R: RangeArg>(self, dim: usize, range: R) -> Self {
+    pub fn slice_dim<R>(self, dim: usize, range: R) -> Self
+    where
+        R: RangeArg,
+    {
+        check!(TensorCheck::check_dim::<D>(dim));
         let range = range.into_range(self.shape().dims[dim]);
-        check!(TensorCheck::slice_dim::<D>(&self.shape(), dim, &range));
 
         Self::new(K::slice_dim(self.primitive, dim, &range))
     }

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -858,6 +858,37 @@ impl TensorCheck {
         check
     }
 
+    pub(crate) fn slice_dim<const D1: usize>(
+        shape: &Shape,
+        dim: usize,
+        range: &Range<usize>,
+    ) -> Self {
+        let mut check = Self::Ok;
+
+        if dim >= D1 {
+            check = check.register(
+                "Slice Dim",
+                TensorError::new("The provided dimension exceeds the tensor dimensions.").details(
+                    format!("Tensor has {D1} dimensions, but the provided dimension is {dim}."),
+                ),
+            );
+        }
+
+        let d_size = shape.dims[dim];
+        if range.end > d_size {
+            check = check.register(
+                "Slice Dim",
+                TensorError::new("The provided range exceeds the tensor size.").details(format!(
+                    "The range ({}..{}) exceeds the size of the tensor ({}) at dimension {}. \
+                         Tensor shape {:?}, provided range {:?}.",
+                    range.start, range.end, d_size, dim, shape.dims, range,
+                )),
+            );
+        }
+
+        check
+    }
+
     pub(crate) fn gather<const D: usize>(dim: usize, shape: &Shape, shape_indices: &Shape) -> Self {
         Self::check_gather_scatter_indices::<D>(Self::Ok, "Gather", dim, shape, shape_indices)
     }

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -858,31 +858,15 @@ impl TensorCheck {
         check
     }
 
-    pub(crate) fn slice_dim<const D1: usize>(
-        shape: &Shape,
-        dim: usize,
-        range: &Range<usize>,
-    ) -> Self {
+    pub(crate) fn check_dim<const D: usize>(dim: usize) -> Self {
         let mut check = Self::Ok;
 
-        if dim >= D1 {
+        if dim >= D {
             check = check.register(
-                "Slice Dim",
+                "Check Dim",
                 TensorError::new("The provided dimension exceeds the tensor dimensions.").details(
-                    format!("Tensor has {D1} dimensions, but the provided dimension is {dim}."),
+                    format!("Tensor has {D} dimensions, but the provided dimension is {dim}."),
                 ),
-            );
-        }
-
-        let d_size = shape.dims[dim];
-        if range.end > d_size {
-            check = check.register(
-                "Slice Dim",
-                TensorError::new("The provided range exceeds the tensor size.").details(format!(
-                    "The range ({}..{}) exceeds the size of the tensor ({}) at dimension {}. \
-                         Tensor shape {:?}, provided range {:?}.",
-                    range.start, range.end, d_size, dim, shape.dims, range,
-                )),
             );
         }
 

--- a/crates/burn-tensor/src/tests/ops/slice.rs
+++ b/crates/burn-tensor/src/tests/ops/slice.rs
@@ -1,7 +1,7 @@
 #[burn_tensor_testgen::testgen(slice)]
 mod tests {
     use super::*;
-    use burn_tensor::{Int, Tensor, TensorData, as_type, s};
+    use burn_tensor::{Int, Slice, Tensor, TensorData, as_type, s};
 
     #[test]
     fn should_support_slice_dim_1d() {
@@ -12,6 +12,15 @@ mod tests {
         output
             .into_data()
             .assert_eq(&TensorData::from([1.0, 2.0]), false);
+    }
+
+    #[test]
+    #[should_panic(expected = "The provided dimension exceeds the tensor dimensions")]
+    fn should_panic_when_slice_dim_1d_bad_dim() {
+        let data = TensorData::from([0.0, 1.0, 2.0]);
+        let tensor = TestTensor::<1>::from_data(data.clone(), &Default::default());
+
+        let _output = tensor.slice_dim(1, 1..);
     }
 
     #[test]

--- a/crates/burn-tensor/src/tests/ops/slice.rs
+++ b/crates/burn-tensor/src/tests/ops/slice.rs
@@ -4,6 +4,28 @@ mod tests {
     use burn_tensor::{Int, Tensor, TensorData, as_type, s};
 
     #[test]
+    fn should_support_slice_dim_1d() {
+        let data = TensorData::from([0.0, 1.0, 2.0]);
+        let tensor = TestTensor::<1>::from_data(data.clone(), &Default::default());
+
+        let output = tensor.slice_dim(0, -2..);
+        output
+            .into_data()
+            .assert_eq(&TensorData::from([1.0, 2.0]), false);
+    }
+
+    #[test]
+    fn should_support_slice_dim_2d() {
+        let data = TensorData::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+        let tensor = TestTensor::<2>::from_data(data.clone(), &Default::default());
+
+        let output = tensor.slice_dim(1, 1..);
+        output
+            .into_data()
+            .assert_eq(&TensorData::from([[1.0, 2.0], [4.0, 5.0]]), false);
+    }
+
+    #[test]
     fn should_support_full_sliceing_1d() {
         let data = TensorData::from([0.0, 1.0, 2.0]);
         let tensor = TestTensor::<1>::from_data(data.clone(), &Default::default());


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

- Add `RangeArg` trait for single-dim range params.
- Add `slice_dim` api.
- Add `slice_dim` check.
- Add `slice_dim` default backend impl.

### Testing

Tests for `slice_dim`