### PR TITLE
burn-dataset: Catch import.py unsuccessful exits

### DIFF
--- a/crates/burn-dataset/src/source/huggingface/downloader.rs
+++ b/crates/burn-dataset/src/source/huggingface/downloader.rs
@@ -232,9 +232,14 @@ fn import(
         command.arg("True");
     }
     let mut handle = command.spawn().unwrap();
-    handle
+
+    let exit_status = handle
         .wait()
         .map_err(|err| ImporterError::Unknown(format!("{err:?}")))?;
+
+    if !exit_status.success() {
+        return Err(ImporterError::Unknown(format!("{exit_status}")));
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
  - Note: these failed for me, but after looking at their code, I don't think it's related to the change.
    ```plain
    failures:
        tests::tensor::display::tests::test_display_2d_bool_tensor
        tests::tensor::display::tests::test_display_2d_float_tensor
        tests::tensor::display::tests::test_display_2d_int_tensor
        tests::tensor::display::tests::test_display_3d_tensor
        tests::tensor::display::tests::test_display_4d_tensor
        tests::tensor::display::tests::test_display_precision
        tests::tensor::display::tests::test_display_tensor_summarize_1
        tests::tensor::display::tests::test_display_tensor_summarize_2
        tests::tensor::display::tests::test_display_tensor_summarize_3
        types::tests::should_support_dual_byte_bridge
	```
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs
n/a (searched for "exit", "status", "sqlite")

### Changes
#### Problem
I was chasing an unrelated issue that manifested by `SqliteDataset` being unable to open the database file created by `importer.py`. After running the script manually with the args that `burn` used, it turned out to be a segfault. After looking at `downloader.rs` I noticed that only the `wait()` result is validated, but not the `ExitStatus`. This resulted in `Ok` returned despite `import.py` segfault and later caused issues to `SqliteDataset`.

#### Solution
Check for `!ExitStatus::success()`, use `ImporterError::Unknown` like existing code does.

Note: A cleaner solution might be something like `handle.wait().map(|status| status.exit_ok()).map_err(...)?` but `exit_ok()` is not stable yet.

### Testing
#### Before
```shell
$ cargo run --example text-generation
[...]
Creating SQL from Arrow format:   0%|                                                                                                                                | 0/560 [00:00<?, ?ba/s]
thread 'main' panicked at examples/text-generation/src/data/dataset.rs:40:14:
called `Result::unwrap()` on an `Err` value: SqliteDataset(ConnectionPool(Error(Some("unable to open database file: /home/drozdziak1/.cache/burn-dataset/dbpedia_14.db"))))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
#### After
```shell
$ cargo run --example text-generation
[...]
Creating SQL from Arrow format:   0%|                                                                                                                                | 0/560 [00:00<?, ?ba/s]
thread 'main' panicked at examples/text-generation/src/data/dataset.rs:40:14:
called `Result::unwrap()` on an `Err` value: Unknown("signal: 11 (SIGSEGV) (core dumped)")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
