### PR TITLE
Absolute tolerance is too tight for strict/balanced/permissive

### DIFF
--- a/crates/burn-tensor/src/tensor/data.rs
+++ b/crates/burn-tensor/src/tensor/data.rs
@@ -863,14 +863,14 @@ impl<F: Float> Tolerance<F> {
     pub fn strict() -> Self {
         Self {
             relative: F::from(0.00).unwrap(),
-            absolute: F::from(16).unwrap() * F::min_positive_value(),
+            absolute: F::from(64).unwrap() * F::min_positive_value(),
         }
     }
     /// Create a tolerance with balanced precision setting.
     pub fn balanced() -> Self {
         Self {
             relative: F::from(0.005).unwrap(), // 0.5%
-            absolute: F::from(32).unwrap() * F::min_positive_value(),
+            absolute: F::from(1e-5).unwrap(),
         }
     }
 
@@ -878,7 +878,7 @@ impl<F: Float> Tolerance<F> {
     pub fn permissive() -> Self {
         Self {
             relative: F::from(0.01).unwrap(), // 1.0%
-            absolute: F::from(64).unwrap() * F::min_positive_value(),
+            absolute: F::from(1e-3).unwrap(),
         }
     }
     /// When comparing two numbers, this uses both the relative and absolute differences.


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.

### Related Issues/PRs

Follow-up to changes in #3197

See also [CI failures that just happened on main](https://github.com/tracel-ai/burn/actions/runs/15348981924/job/43192381924) (unrelated to last merged changes)

```
  thread 'tests::cube::kernel::conv_transpose2d::tests::conv_transpose2d_should_match_reference_backend' panicked at /Users/admin/actions-runner/_work/burn/burn/crates/burn-cubecl/src/tensor/base.rs:53:26:
  Tensors are not approx eq:
    => Position 3057: -0.0000141859055 != -0.000014565485
       diff (rel = +2.61e-2, abs = +3.80e-7), tol (rel = +1.00e-2, abs = +7.52e-37)
```

### Changes

Relative tolerances were adjusted for different modes in a previous PR, but the absolute tolerance was too strict. For values near zero, approximate floating-point comparison should have less strict absolute tolerance.
