### PR TITLE
Adding image dimensions to ImageDatasetItem

### DIFF
--- a/crates/burn-dataset/src/vision/image_folder.rs
+++ b/crates/burn-dataset/src/vision/image_folder.rs
@@ -98,6 +98,12 @@ pub struct ImageDatasetItem {
     /// Image as a vector with a valid image type.
     pub image: Vec<PixelDepth>,
 
+    /// Original source image width.
+    pub image_width: usize,
+
+    /// Original source image height.
+    pub image_height: usize,
+
     /// Annotation for the image.
     pub annotation: Annotation,
 
@@ -357,6 +363,10 @@ impl Mapper<ImageDatasetItemRaw, ImageDatasetItem> for PathToImageDatasetItem {
         // Load image from disk
         let image = image::open(&item.image_path).unwrap();
 
+        // Save image dimensions for manipulation
+        let img_width = image.width() as usize;
+        let img_height = image.height() as usize;
+
         // Image as Vec<PixelDepth>
         let img_vec = match image.color() {
             ColorType::L8 => image
@@ -414,6 +424,8 @@ impl Mapper<ImageDatasetItemRaw, ImageDatasetItem> for PathToImageDatasetItem {
 
         ImageDatasetItem {
             image: img_vec,
+            image_width: img_width,
+            image_height: img_height,
             annotation,
             image_path: item.image_path.display().to_string(),
         }
@@ -744,6 +756,46 @@ mod tests {
         // Dataset elements should be: orange (0), red (1)
         assert_eq!(dataset.get(0).unwrap().annotation, Annotation::Label(0));
         assert_eq!(dataset.get(1).unwrap().annotation, Annotation::Label(1));
+    }
+
+    #[test]
+    pub fn image_folder_dataset_with_items_sizes() {
+        let root = Path::new(DATASET_ROOT);
+        let items = vec![
+            (root.join("orange").join("dot.jpg"), "orange".to_string()),
+            (root.join("red").join("dot.jpg"), "red".to_string()),
+            (root.join("red").join("dot.png"), "red".to_string()),
+        ];
+        let dataset =
+            ImageFolderDataset::new_classification_with_items(items, &["orange", "red"]).unwrap();
+
+        // Dataset has 3 elements
+        assert_eq!(dataset.len(), 3);
+        assert_eq!(dataset.get(3), None);
+
+        // Test item sizes
+
+        assert_eq!(
+            (
+                dataset.get(0).unwrap().image_width,
+                dataset.get(0).unwrap().image_height
+            ),
+            (1, 1)
+        );
+        assert_eq!(
+            (
+                dataset.get(1).unwrap().image_width,
+                dataset.get(1).unwrap().image_height
+            ),
+            (1, 1)
+        );
+        assert_eq!(
+            (
+                dataset.get(2).unwrap().image_width,
+                dataset.get(2).unwrap().image_height
+            ),
+            (1, 1)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Discord discussion here:
https://discord.com/channels/1038839012602941528/1357819409267425341/1359178264530256045

### Changes

This adds original image dimensions to the ImageDataset struct items so that image tensors can be shaped correctly when necessary

### Testing

Added unit tests for testing image size
