### PR TITLE
burn-dataset: Make virtualenv optional when running importer.py

### DIFF
--- a/crates/burn-dataset/src/source/huggingface/downloader.rs
+++ b/crates/burn-dataset/src/source/huggingface/downloader.rs
@@ -66,6 +66,7 @@ pub struct HuggingfaceDatasetLoader {
     huggingface_cache_dir: Option<String>,
     huggingface_data_dir: Option<String>,
     trust_remote_code: bool,
+    use_python_venv: bool,
 }
 
 impl HuggingfaceDatasetLoader {
@@ -79,6 +80,7 @@ impl HuggingfaceDatasetLoader {
             huggingface_cache_dir: None,
             huggingface_data_dir: None,
             trust_remote_code: false,
+            use_python_venv: true,
         }
     }
 
@@ -134,6 +136,16 @@ impl HuggingfaceDatasetLoader {
         self
     }
 
+    /// Specify whether or not to use the burn-dataset Python
+    /// virtualenv for running the importer script. If false, local
+    /// `python3`'s environment is used.
+    ///
+    /// If not specified, the virtualenv is used.
+    pub fn with_use_python_venv(mut self, use_python_venv: bool) -> Self {
+        self.use_python_venv = use_python_venv;
+        self
+    }
+
     /// Load the dataset.
     pub fn dataset<I: DeserializeOwned + Clone>(
         self,
@@ -178,6 +190,7 @@ impl HuggingfaceDatasetLoader {
                 self.huggingface_cache_dir,
                 self.huggingface_data_dir,
                 self.trust_remote_code,
+                self.use_python_venv,
             )?;
         }
 
@@ -196,10 +209,15 @@ fn import(
     huggingface_cache_dir: Option<String>,
     huggingface_data_dir: Option<String>,
     trust_remote_code: bool,
+    use_python_venv: bool,
 ) -> Result<(), ImporterError> {
-    let venv_python_path = install_python_deps(&base_dir)?;
+    let python_path = if use_python_venv {
+        install_python_deps(&base_dir)?
+    } else {
+        "python3".into()
+    };
 
-    let mut command = Command::new(venv_python_path);
+    let mut command = Command::new(python_path);
 
     command.arg(importer_script_path(&base_dir));
 

--- a/crates/burn-dataset/src/source/huggingface/downloader.rs
+++ b/crates/burn-dataset/src/source/huggingface/downloader.rs
@@ -214,7 +214,7 @@ fn import(
     let python_path = if use_python_venv {
         install_python_deps(&base_dir)?
     } else {
-        "python3".into()
+        get_python_name()?.into()
     };
 
     let mut command = Command::new(python_path);


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
  Note: I got two failures, but they seem unrelated to the change (I'm on 2x 4090, 565.77 open-source driver, NixOS 24.11, CUDA toolkit 12.4, wgpu-utils 22.1):
  ```plain
    failures:                                                                                                                                                                                    

    ---- tests::cube::tensor::f32_ty::remainder::tests::should_have_no_remainder stdout ----                                                                                                     

    thread 'tests::cube::tensor::f32_ty::remainder::tests::should_have_no_remainder' panicked at crates/burn-wgpu/src/lib.rs:129:5:                                                              
    Tensors are not approx eq:                                                                                                                                                                   
    => Position 4: 0.5034 != 0                                                                                                                                                                 
        diff (rel = +1.00e0, abs = +5.03e-1), tol (rel = +5.00e-3, abs = +1.00e-5)                                                                                                              

    ---- tests::cube_fusion::tensor::f32_ty::remainder::tests::should_have_no_remainder stdout ----                                                                                              

    thread 'tests::cube_fusion::tensor::f32_ty::remainder::tests::should_have_no_remainder' panicked at crates/burn-wgpu/src/lib.rs:129:5:
    Tensors are not approx eq:
    => Position 4: 0.5034 != 0
        diff (rel = +1.00e0, abs = +5.03e-1), tol (rel = +5.00e-3, abs = +1.00e-5)


    failures:
        tests::cube::tensor::f32_ty::remainder::tests::should_have_no_remainder
        tests::cube_fusion::tensor::f32_ty::remainder::tests::should_have_no_remainder
  ```
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs
Last week I opened #3236 where I made potential importer.py segfaults more visible. This change works around a segfault that motivated the other PR (not the root cause though).


### Changes

#### Problem
The `importer.py` segfault in my case was likely because of being on
NixOS which occasionally doesn't play nice with projects that bundle
dependencies. The debugging options were very limited, so I decided to
try adding `importer.py` deps to my Nix shell. It ran without problems
when I bypassed the venv and invoked it manually with the deps in
scope. My original segfault might be a red herring at this point and I
found a way to make it work with minimal changes to Burn.

#### Solution
I propose we add a `use_python_venv` option to
`HuggingFaceDatasetLoader` for bypassing the venv, making the Python
environment an opt-in responsibility for the user. Default behavior remains the same.

### Testing
After my initial success with the manual venv bypass, I ran my Burn-dependent code with the change. The importer worked without any problems from there:
```shell
********************************************************************************                                                                                                             
Starting huggingface dataset download and export                                                                                                                                             
Dataset Name: HuggingFaceFW/fineweb                                                                                                                                                          
Subset Name: sample-10BT                                                                                                                                                                     
Sqlite database file: /home/drozdziak1/.cache/burn-dataset/HuggingFaceFWfineweb-sample-10BT.db                                                                                               
Trust remote code: None                                                                                                                                                                      
Custom cache dir: None                                                                                                                                                                       
********************************************************************************                                                                                                             
Resolving data files: 100%|██████████| 25868/25868 [00:04<00:00, 5748.25it/s]
Loading dataset shards: 100%|██████████| 102/102 [00:00<00:00, 1107.59it/s]
Dataset: DatasetDict({                                                                                                                                                                       
    train: Dataset({                                                                                                                                                                         
        features: ['text', 'id', 'dump', 'url', 'date', 'file_path', 'language', 'language_score', 'token_count'],                                                                           
        num_rows: 14868862                                                                                                                                                                   
    })                                                                                                                                                                                       
})                                                                                                                                                                                           
Saving dataset: HuggingFaceFW/fineweb - train                                                                                                                                                
Dataset features: {'text': Value(dtype='string', id=None), 'id': Value(dtype='string', id=None), 'dump': Value(dtype='string', 
id=None), 'url': Value(dtype='string', id=None), 'date': Value (dtype='string', id=None), 'file_path': Value(dtype='string', 
id=None), 'language': Value(dtype='string', id=None), 'language_score': Value(dtype='float64', id=None), 'token_count': Value(d
type='int64', id=None)}                                                                                                                                                                      
Creating SQL from Arrow format: 100%|██████████| 14869/14869 [04:41<00:00, 52.82ba/s]
Printing table schema for sqlite3 db (Engine(sqlite:////home/drozdziak1/.cache/burn-dataset/HuggingFaceFWfineweb-sample-10BT.db))                                                            
Table: train                                                                                                                                                                                 
Column: text - TEXT                                                                                                                                                                          
Column: id - TEXT                                                                                                                                                                            
Column: dump - TEXT                                                                                                                                                                          
Column: url - TEXT                                                                                                                                                                           
Column: date - TEXT                                                                                                                                                                          
Column: file_path - TEXT                                                                                                                                                                     
Column: language - TEXT                                                                                                                                                                      
Column: language_score - FLOAT                                                                                                                                                               
Column: token_count - BIGINT                                                                                                                                                                 
Column: row_id - INTEGER 
```
