### PR TITLE
Adding option for ceiling to compute size for pool output

### DIFF
--- a/crates/burn-autodiff/src/ops/module.rs
+++ b/crates/burn-autodiff/src/ops/module.rs
@@ -1196,6 +1196,7 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
         stride: usize,
         padding: usize,
         count_include_pad: bool,
+        ceil: bool,
     ) -> AutodiffTensor<B> {
         #[derive(Debug)]
         struct AvgPool1D;
@@ -1243,6 +1244,7 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                         stride,
                         padding,
                         count_include_pad,
+                        ceil,
                     ),
                 )
             }
@@ -1252,6 +1254,7 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                 stride,
                 padding,
                 count_include_pad,
+                ceil,
             )),
         }
     }
@@ -1262,6 +1265,7 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
         stride: [usize; 2],
         padding: [usize; 2],
         count_include_pad: bool,
+        ceil: bool,
     ) -> AutodiffTensor<B> {
         #[derive(Debug)]
         struct AvgPool2D;
@@ -1309,6 +1313,7 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                         stride,
                         padding,
                         count_include_pad,
+                        ceil,
                     ),
                 )
             }
@@ -1318,6 +1323,7 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                 stride,
                 padding,
                 count_include_pad,
+                ceil,
             )),
         }
     }
@@ -1339,6 +1345,7 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
         stride: usize,
         padding: usize,
         dilation: usize,
+        ceil: bool,
     ) -> AutodiffTensor<B> {
         match MaxPool1D
             .prepare::<C>([x.node.clone()])
@@ -1347,8 +1354,14 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
         {
             OpsKind::Tracked(mut prep) => {
                 let x_state = prep.checkpoint(&x);
-                let output =
-                    B::max_pool1d_with_indices(x.primitive, kernel_size, stride, padding, dilation);
+                let output = B::max_pool1d_with_indices(
+                    x.primitive,
+                    kernel_size,
+                    stride,
+                    padding,
+                    dilation,
+                    ceil,
+                );
                 prep.finish(
                     (
                         x_state,
@@ -1367,6 +1380,7 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                 stride,
                 padding,
                 dilation,
+                ceil,
             )),
         }
     }
@@ -1377,6 +1391,7 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
         stride: usize,
         padding: usize,
         dilation: usize,
+        ceil: bool,
     ) -> MaxPool1dWithIndices<Self> {
         match MaxPool1D
             .prepare::<C>([x.node.clone()])
@@ -1385,8 +1400,14 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
         {
             OpsKind::Tracked(mut prep) => {
                 let x_state = prep.checkpoint(&x);
-                let output =
-                    B::max_pool1d_with_indices(x.primitive, kernel_size, stride, padding, dilation);
+                let output = B::max_pool1d_with_indices(
+                    x.primitive,
+                    kernel_size,
+                    stride,
+                    padding,
+                    dilation,
+                    ceil,
+                );
 
                 let output_tensor = prep.finish(
                     (
@@ -1403,8 +1424,14 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                 MaxPool1dWithIndices::new(output_tensor, output.indices)
             }
             OpsKind::UnTracked(prep) => {
-                let output =
-                    B::max_pool1d_with_indices(x.primitive, kernel_size, stride, padding, dilation);
+                let output = B::max_pool1d_with_indices(
+                    x.primitive,
+                    kernel_size,
+                    stride,
+                    padding,
+                    dilation,
+                    ceil,
+                );
                 let output_tensor = prep.finish(output.output);
 
                 MaxPool1dWithIndices::new(output_tensor, output.indices)
@@ -1439,6 +1466,7 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
         stride: [usize; 2],
         padding: [usize; 2],
         dilation: [usize; 2],
+        ceil: bool,
     ) -> AutodiffTensor<B> {
         match MaxPool2D
             .prepare::<C>([x.node.clone()])
@@ -1447,8 +1475,14 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
         {
             OpsKind::Tracked(mut prep) => {
                 let x_state = prep.checkpoint(&x);
-                let output =
-                    B::max_pool2d_with_indices(x.primitive, kernel_size, stride, padding, dilation);
+                let output = B::max_pool2d_with_indices(
+                    x.primitive,
+                    kernel_size,
+                    stride,
+                    padding,
+                    dilation,
+                    ceil,
+                );
                 prep.finish(
                     (
                         x_state,
@@ -1467,6 +1501,7 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                 stride,
                 padding,
                 dilation,
+                ceil,
             )),
         }
     }
@@ -1477,6 +1512,7 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
         stride: [usize; 2],
         padding: [usize; 2],
         dilation: [usize; 2],
+        ceil: bool,
     ) -> MaxPool2dWithIndices<Self> {
         match MaxPool2D
             .prepare::<C>([x.node.clone()])
@@ -1486,8 +1522,14 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
             OpsKind::Tracked(mut prep) => {
                 let x_state = prep.checkpoint(&x);
 
-                let output =
-                    B::max_pool2d_with_indices(x.primitive, kernel_size, stride, padding, dilation);
+                let output = B::max_pool2d_with_indices(
+                    x.primitive,
+                    kernel_size,
+                    stride,
+                    padding,
+                    dilation,
+                    ceil,
+                );
 
                 let output_tensor = prep.finish(
                     (
@@ -1504,8 +1546,14 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                 MaxPool2dWithIndices::new(output_tensor, output.indices)
             }
             OpsKind::UnTracked(prep) => {
-                let output =
-                    B::max_pool2d_with_indices(x.primitive, kernel_size, stride, padding, dilation);
+                let output = B::max_pool2d_with_indices(
+                    x.primitive,
+                    kernel_size,
+                    stride,
+                    padding,
+                    dilation,
+                    ceil,
+                );
                 let output_tensor = prep.finish(output.output);
 
                 MaxPool2dWithIndices::new(output_tensor, output.indices)

--- a/crates/burn-autodiff/src/tests/avgpool1d.rs
+++ b/crates/burn-autodiff/src/tests/avgpool1d.rs
@@ -14,6 +14,7 @@ mod tests {
             stride: 1,
             length: 6,
             count_include_pad: true,
+            ceil: false,
         };
 
         test.assert_output(TestTensor::from_floats(
@@ -32,6 +33,7 @@ mod tests {
             stride: 2,
             length: 6,
             count_include_pad: true,
+            ceil: false,
         };
 
         test.assert_output(TestTensor::from_floats(
@@ -53,6 +55,7 @@ mod tests {
             stride: 2,
             length: 6,
             count_include_pad: false,
+            ceil: false,
         };
 
         test.assert_output(TestTensor::from_floats(
@@ -72,6 +75,7 @@ mod tests {
         stride: usize,
         length: usize,
         count_include_pad: bool,
+        ceil: bool,
     }
 
     impl AvgPool1dTestCase {
@@ -91,6 +95,7 @@ mod tests {
                 self.stride,
                 self.padding,
                 self.count_include_pad,
+                self.ceil,
             );
             let grads = output.backward();
             let x_grad_actual = x.grad(&grads).unwrap();

--- a/crates/burn-autodiff/src/tests/avgpool2d.rs
+++ b/crates/burn-autodiff/src/tests/avgpool2d.rs
@@ -18,6 +18,7 @@ mod tests {
             height: 6,
             width: 6,
             count_include_pad: true,
+            ceil: false,
         };
 
         test.assert_output(TestTensor::from_floats(
@@ -47,6 +48,7 @@ mod tests {
             height: 4,
             width: 6,
             count_include_pad: true,
+            ceil: false,
         };
 
         test.assert_output(TestTensor::from_floats(
@@ -74,6 +76,7 @@ mod tests {
             height: 4,
             width: 6,
             count_include_pad: false,
+            ceil: false,
         };
 
         test.assert_output(TestTensor::from_floats(
@@ -99,6 +102,7 @@ mod tests {
         height: usize,
         width: usize,
         count_include_pad: bool,
+        ceil: bool,
     }
 
     impl AvgPool2dTestCase {
@@ -118,6 +122,7 @@ mod tests {
                 [self.stride_1, self.stride_2],
                 [self.padding_1, self.padding_2],
                 self.count_include_pad,
+                self.ceil,
             );
             let grads = output.backward();
             let x_grad_actual = x.grad(&grads).unwrap();

--- a/crates/burn-autodiff/src/tests/maxpool1d.rs
+++ b/crates/burn-autodiff/src/tests/maxpool1d.rs
@@ -11,6 +11,7 @@ mod tests {
         let padding = 0;
         let stride = 1;
         let dilation = 1;
+        let ceil = false;
 
         let device = Default::default();
         let x = TestAutodiffTensor::from_floats(
@@ -21,7 +22,7 @@ mod tests {
         let x_grad_expected =
             TestAutodiffTensor::<3>::from_floats([[[1., 1., 0., 0., 0., 1.]]], &device);
 
-        let output = max_pool1d(x.clone(), kernel_size, stride, padding, dilation);
+        let output = max_pool1d(x.clone(), kernel_size, stride, padding, dilation, ceil);
         let grads = output.backward();
 
         // Asserts
@@ -37,6 +38,7 @@ mod tests {
         let padding = 0;
         let stride = 1;
         let dilation = 2;
+        let ceil = false;
 
         let device = Default::default();
         let x = TestAutodiffTensor::from_floats(
@@ -56,7 +58,7 @@ mod tests {
             &device,
         );
 
-        let output = max_pool1d(x.clone(), kernel_size, stride, padding, dilation);
+        let output = max_pool1d(x.clone(), kernel_size, stride, padding, dilation, ceil);
         let grads = output.backward();
 
         // Asserts
@@ -72,6 +74,7 @@ mod tests {
         let padding = 0;
         let stride = 1;
         let dilation = 1;
+        let ceil = false;
 
         let device = Default::default();
         let x = TestAutodiffTensor::from_floats(
@@ -91,7 +94,7 @@ mod tests {
             &device,
         );
 
-        let output = max_pool1d(x.clone(), kernel_size, stride, padding, dilation);
+        let output = max_pool1d(x.clone(), kernel_size, stride, padding, dilation, ceil);
         let grads = output.backward();
 
         // Asserts
@@ -107,6 +110,7 @@ mod tests {
         let padding = 2;
         let stride = 1;
         let dilation = 1;
+        let ceil = false;
 
         let device = Default::default();
         let x = TestAutodiffTensor::from_floats(
@@ -126,7 +130,7 @@ mod tests {
             &device,
         );
 
-        let output = max_pool1d(x.clone(), kernel_size, stride, padding, dilation);
+        let output = max_pool1d(x.clone(), kernel_size, stride, padding, dilation, ceil);
         let grads = output.backward();
 
         // Asserts

--- a/crates/burn-autodiff/src/tests/maxpool2d.rs
+++ b/crates/burn-autodiff/src/tests/maxpool2d.rs
@@ -15,6 +15,7 @@ mod tests {
         let stride_2 = 1;
         let dilation_1 = 1;
         let dilation_2 = 1;
+        let ceil = false;
 
         let device = Default::default();
         let x = TestAutodiffTensor::from_floats(
@@ -43,6 +44,7 @@ mod tests {
             [stride_1, stride_2],
             [padding_1, padding_2],
             [dilation_1, dilation_2],
+            ceil,
         );
         let grads = output.backward();
 
@@ -63,6 +65,7 @@ mod tests {
         let stride_2 = 1;
         let dilation_1 = 1;
         let dilation_2 = 1;
+        let ceil = false;
 
         let device = Default::default();
         let x = TestAutodiffTensor::from_floats(
@@ -91,6 +94,7 @@ mod tests {
             [stride_1, stride_2],
             [padding_1, padding_2],
             [dilation_1, dilation_2],
+            ceil,
         );
         let grads = output.backward();
 
@@ -111,6 +115,7 @@ mod tests {
         let stride_2 = 1;
         let dilation_1 = 2;
         let dilation_2 = 2;
+        let ceil = false;
 
         let device = Default::default();
         let x = TestAutodiffTensor::from_floats(
@@ -139,6 +144,7 @@ mod tests {
             [stride_1, stride_2],
             [padding_1, padding_2],
             [dilation_1, dilation_2],
+            ceil,
         );
         let grads = output.backward();
 
@@ -159,6 +165,7 @@ mod tests {
         let stride_2 = 2;
         let dilation_1 = 1;
         let dilation_2 = 1;
+        let ceil = false;
 
         let device = Default::default();
         let x = TestAutodiffTensor::from_floats(
@@ -189,6 +196,7 @@ mod tests {
             [stride_1, stride_2],
             [padding_1, padding_2],
             [dilation_1, dilation_2],
+            ceil,
         );
         let grads = output.backward();
 

--- a/crates/burn-candle/src/ops/module.rs
+++ b/crates/burn-candle/src/ops/module.rs
@@ -194,6 +194,7 @@ impl<F: FloatCandleElement, I: IntCandleElement> ModuleOps<Self> for Candle<F, I
         stride: [usize; 2],
         padding: [usize; 2],
         count_include_pad: bool,
+        ceil: bool,
     ) -> FloatTensor<Self> {
         assert!(
             padding[0] == 0 && padding[1] == 0,
@@ -227,6 +228,7 @@ impl<F: FloatCandleElement, I: IntCandleElement> ModuleOps<Self> for Candle<F, I
         stride: [usize; 2],
         padding: [usize; 2],
         dilation: [usize; 2],
+        ceil: bool,
     ) -> FloatTensor<Self> {
         assert!(
             padding[0] == 0 && padding[1] == 0,
@@ -249,6 +251,7 @@ impl<F: FloatCandleElement, I: IntCandleElement> ModuleOps<Self> for Candle<F, I
         stride: [usize; 2],
         padding: [usize; 2],
         dilation: [usize; 2],
+        ceil: bool,
     ) -> MaxPool2dWithIndices<Candle<F, I>> {
         panic!("max_pool2d_with_indices is not supported by Candle")
     }

--- a/crates/burn-core/src/nn/pool/avg_pool1d.rs
+++ b/crates/burn-core/src/nn/pool/avg_pool1d.rs
@@ -28,6 +28,9 @@ pub struct AvgPool1dConfig {
     /// If the padding is counted in the denominator when computing the average.
     #[config(default = "true")]
     pub count_include_pad: bool,
+    /// Use ceil when calculating the output size.
+    #[config(default = "false")]
+    pub ceil: bool,
 }
 
 /// Applies a 1D avg pooling over input tensors.
@@ -52,6 +55,8 @@ pub struct AvgPool1d {
     pub padding: Ignored<PaddingConfig1d>,
     /// If the padding is counted in the denominator when computing the average.
     pub count_include_pad: bool,
+    /// Use ceil when calculating the pool size.
+    pub ceil: bool,
 }
 
 impl ModuleDisplay for AvgPool1d {
@@ -67,6 +72,7 @@ impl ModuleDisplay for AvgPool1d {
             .add("stride", &self.stride)
             .add("padding", &self.padding)
             .add("count_include_pad", &self.count_include_pad)
+            .add("ceil", &self.ceil)
             .optional()
     }
 }
@@ -82,6 +88,7 @@ impl AvgPool1dConfig {
             kernel_size: self.kernel_size,
             padding: Ignored(self.padding.clone()),
             count_include_pad: self.count_include_pad,
+            ceil: self.ceil,
         }
     }
 }
@@ -107,6 +114,7 @@ impl AvgPool1d {
             self.stride,
             padding,
             self.count_include_pad,
+            self.ceil,
         )
     }
 }
@@ -129,7 +137,7 @@ mod tests {
 
         assert_eq!(
             alloc::format!("{}", layer),
-            "AvgPool1d {kernel_size: 3, stride: 1, padding: Valid, count_include_pad: true}"
+            "AvgPool1d {kernel_size: 3, stride: 1, padding: Valid, count_include_pad: true, ceil: false}"
         );
     }
 }

--- a/crates/burn-core/src/nn/pool/avg_pool2d.rs
+++ b/crates/burn-core/src/nn/pool/avg_pool2d.rs
@@ -28,6 +28,9 @@ pub struct AvgPool2dConfig {
     /// If the padding is counted in the denominator when computing the average.
     #[config(default = "true")]
     pub count_include_pad: bool,
+    /// Use ceil when calculating the pool size.
+    #[config(default = "false")]
+    pub ceil: bool,
 }
 
 /// Applies a 2D avg pooling over input tensors.
@@ -52,6 +55,8 @@ pub struct AvgPool2d {
     pub padding: Ignored<PaddingConfig2d>,
     /// If the padding is counted in the denominator when computing the average.
     pub count_include_pad: bool,
+    /// Use ceil when calculating the pool size.
+    pub ceil: bool,
 }
 
 impl ModuleDisplay for AvgPool2d {
@@ -67,6 +72,7 @@ impl ModuleDisplay for AvgPool2d {
             .add("stride", &alloc::format!("{:?}", &self.stride))
             .add("padding", &self.padding)
             .add("count_include_pad", &self.count_include_pad)
+            .add("ceil", &self.ceil)
             .optional()
     }
 }
@@ -82,6 +88,7 @@ impl AvgPool2dConfig {
             kernel_size: self.kernel_size,
             padding: Ignored(self.padding.clone()),
             count_include_pad: self.count_include_pad,
+            ceil: self.ceil,
         }
     }
 }
@@ -107,6 +114,7 @@ impl AvgPool2d {
             self.stride,
             padding,
             self.count_include_pad,
+            self.ceil,
         )
     }
 }
@@ -130,7 +138,7 @@ mod tests {
 
         assert_eq!(
             alloc::format!("{}", layer),
-            "AvgPool2d {kernel_size: [3, 3], stride: [1, 1], padding: Valid, count_include_pad: true}"
+            "AvgPool2d {kernel_size: [3, 3], stride: [1, 1], padding: Valid, count_include_pad: true, ceil: false}"
         );
     }
 }

--- a/crates/burn-core/src/nn/pool/max_pool1d.rs
+++ b/crates/burn-core/src/nn/pool/max_pool1d.rs
@@ -28,6 +28,9 @@ pub struct MaxPool1dConfig {
     /// The dilation.
     #[config(default = "1")]
     pub dilation: usize,
+    /// Use ceil when calculating the max pool size.
+    #[config(default = "false")]
+    pub ceil: bool,
 }
 
 /// Applies a 1D max pooling over input tensors.
@@ -44,6 +47,8 @@ pub struct MaxPool1d {
     pub padding: Ignored<PaddingConfig1d>,
     /// The dilation.
     pub dilation: usize,
+    /// Use ceil when calculating the max pool size.
+    pub ceil: bool,
 }
 
 impl ModuleDisplay for MaxPool1d {
@@ -59,6 +64,7 @@ impl ModuleDisplay for MaxPool1d {
             .add("stride", &self.stride)
             .add("padding", &self.padding)
             .add("dilation", &self.dilation)
+            .add("ceil", &self.ceil)
             .optional()
     }
 }
@@ -74,6 +80,7 @@ impl MaxPool1dConfig {
             kernel_size: self.kernel_size,
             padding: Ignored(self.padding.clone()),
             dilation: self.dilation,
+            ceil: self.ceil,
         }
     }
 }
@@ -93,7 +100,14 @@ impl MaxPool1d {
             .padding
             .calculate_padding_1d(length, self.kernel_size, self.stride);
 
-        max_pool1d(input, self.kernel_size, self.stride, padding, self.dilation)
+        max_pool1d(
+            input,
+            self.kernel_size,
+            self.stride,
+            padding,
+            self.dilation,
+            self.ceil,
+        )
     }
 }
 
@@ -116,7 +130,7 @@ mod tests {
 
         assert_eq!(
             alloc::format!("{}", layer),
-            "MaxPool1d {kernel_size: 3, stride: 1, padding: Valid, dilation: 1}"
+            "MaxPool1d {kernel_size: 3, stride: 1, padding: Valid, dilation: 1, ceil: false}"
         );
     }
 }

--- a/crates/burn-core/src/nn/pool/max_pool2d.rs
+++ b/crates/burn-core/src/nn/pool/max_pool2d.rs
@@ -28,6 +28,9 @@ pub struct MaxPool2dConfig {
     /// The dilation.
     #[config(default = "[1, 1]")]
     pub dilation: [usize; 2],
+    /// Use ceil when calculating the max pool size.
+    #[config(default = "false")]
+    pub ceil: bool,
 }
 
 /// Applies a 2D max pooling over input tensors.
@@ -44,6 +47,8 @@ pub struct MaxPool2d {
     pub padding: Ignored<PaddingConfig2d>,
     /// The dilation.
     pub dilation: [usize; 2],
+    /// Use ceil when calculating the max pool size.
+    pub ceil: bool,
 }
 
 impl ModuleDisplay for MaxPool2d {
@@ -59,6 +64,7 @@ impl ModuleDisplay for MaxPool2d {
             .add("stride", &alloc::format!("{:?}", &self.stride))
             .add("padding", &self.padding)
             .add("dilation", &alloc::format!("{:?}", &self.dilation))
+            .add("ceil", &alloc::format!("{:?}", &self.ceil))
             .optional()
     }
 }
@@ -74,6 +80,7 @@ impl MaxPool2dConfig {
             kernel_size: self.kernel_size,
             padding: Ignored(self.padding.clone()),
             dilation: self.dilation,
+            ceil: self.ceil,
         }
     }
 }
@@ -93,7 +100,14 @@ impl MaxPool2d {
             self.padding
                 .calculate_padding_2d(height_in, width_in, &self.kernel_size, &self.stride);
 
-        max_pool2d(input, self.kernel_size, self.stride, padding, self.dilation)
+        max_pool2d(
+            input,
+            self.kernel_size,
+            self.stride,
+            padding,
+            self.dilation,
+            self.ceil,
+        )
     }
 }
 
@@ -116,7 +130,7 @@ mod tests {
 
         assert_eq!(
             alloc::format!("{}", layer),
-            "MaxPool2d {kernel_size: [3, 3], stride: [1, 1], padding: Valid, dilation: [1, 1]}"
+            "MaxPool2d {kernel_size: [3, 3], stride: [1, 1], padding: Valid, dilation: [1, 1], ceil: false}"
         );
     }
 }

--- a/crates/burn-cubecl/src/kernel/pool/avg_pool2d.rs
+++ b/crates/burn-cubecl/src/kernel/pool/avg_pool2d.rs
@@ -80,6 +80,7 @@ pub(crate) fn avg_pool2d<R: CubeRuntime, E: CubeElement>(
     stride: [usize; 2],
     padding: [usize; 2],
     count_include_pad: bool,
+    ceil: bool,
 ) -> CubeTensor<R> {
     let [batch_size, channels, _, _] = x.shape.dims();
     let dilation = 1;
@@ -90,6 +91,7 @@ pub(crate) fn avg_pool2d<R: CubeRuntime, E: CubeElement>(
         padding[0],
         dilation,
         x.shape.dims[2],
+        ceil,
     );
     let size_1 = calculate_pool_output_size(
         kernel_size[1],
@@ -97,6 +99,7 @@ pub(crate) fn avg_pool2d<R: CubeRuntime, E: CubeElement>(
         padding[1],
         dilation,
         x.shape.dims[3],
+        ceil,
     );
 
     let x = into_contiguous(permute_nchw_to_nhwc(x));

--- a/crates/burn-cubecl/src/kernel/pool/max_pool2d.rs
+++ b/crates/burn-cubecl/src/kernel/pool/max_pool2d.rs
@@ -103,6 +103,7 @@ pub(crate) fn max_pool2d<R: CubeRuntime, E: CubeElement>(
     stride: [usize; 2],
     padding: [usize; 2],
     dilation: [usize; 2],
+    ceil: bool,
 ) -> CubeTensor<R> {
     let [batch_size, channels, _, _] = x.shape.dims();
 
@@ -112,6 +113,7 @@ pub(crate) fn max_pool2d<R: CubeRuntime, E: CubeElement>(
         padding[0],
         dilation[0],
         x.shape.dims[2],
+        ceil,
     );
     let size_1 = calculate_pool_output_size(
         kernel_size[1],
@@ -119,6 +121,7 @@ pub(crate) fn max_pool2d<R: CubeRuntime, E: CubeElement>(
         padding[1],
         dilation[1],
         x.shape.dims[3],
+        ceil,
     );
 
     let x = into_contiguous(permute_nchw_to_nhwc(x));
@@ -160,6 +163,7 @@ pub(crate) fn max_pool2d_with_indices<R: CubeRuntime, E: CubeElement, I: CubeEle
     stride: [usize; 2],
     padding: [usize; 2],
     dilation: [usize; 2],
+    ceil: bool,
 ) -> (CubeTensor<R>, CubeTensor<R>) {
     let [batch_size, channels, _, _] = x.shape.dims();
 
@@ -169,6 +173,7 @@ pub(crate) fn max_pool2d_with_indices<R: CubeRuntime, E: CubeElement, I: CubeEle
         padding[0],
         dilation[0],
         x.shape.dims[2],
+        ceil,
     );
     let size_1 = calculate_pool_output_size(
         kernel_size[1],
@@ -176,6 +181,7 @@ pub(crate) fn max_pool2d_with_indices<R: CubeRuntime, E: CubeElement, I: CubeEle
         padding[1],
         dilation[1],
         x.shape.dims[3],
+        ceil,
     );
 
     let x = into_contiguous(permute_nchw_to_nhwc(x));

--- a/crates/burn-cubecl/src/ops/module_ops.rs
+++ b/crates/burn-cubecl/src/ops/module_ops.rs
@@ -109,8 +109,9 @@ where
         stride: [usize; 2],
         padding: [usize; 2],
         count_include_pad: bool,
+        ceil: bool,
     ) -> FloatTensor<Self> {
-        kernel::pool::avg_pool2d::<R, F>(x, kernel_size, stride, padding, count_include_pad)
+        kernel::pool::avg_pool2d::<R, F>(x, kernel_size, stride, padding, count_include_pad, ceil)
     }
 
     fn avg_pool2d_backward(
@@ -137,8 +138,9 @@ where
         stride: [usize; 2],
         padding: [usize; 2],
         dilation: [usize; 2],
+        ceil: bool,
     ) -> FloatTensor<Self> {
-        kernel::pool::max_pool2d::<R, F>(x, kernel_size, stride, padding, dilation)
+        kernel::pool::max_pool2d::<R, F>(x, kernel_size, stride, padding, dilation, ceil)
     }
 
     fn max_pool2d_with_indices(
@@ -147,6 +149,7 @@ where
         stride: [usize; 2],
         padding: [usize; 2],
         dilation: [usize; 2],
+        ceil: bool,
     ) -> MaxPool2dWithIndices<Self> {
         let (output, indices) = kernel::pool::max_pool2d_with_indices::<R, F, I>(
             x,
@@ -154,6 +157,7 @@ where
             stride,
             padding,
             dilation,
+            ceil,
         );
 
         MaxPool2dWithIndices::new(output, indices)

--- a/crates/burn-cubecl/src/tests/avg_pool2d.rs
+++ b/crates/burn-cubecl/src/tests/avg_pool2d.rs
@@ -20,10 +20,24 @@ mod tests {
         let stride = [1, 2];
         let padding = [1, 2];
         let count_include_pad = true;
+        let ceil = false;
 
-        let pooled = module::avg_pool2d(tensor, kernel_size, stride, padding, count_include_pad);
-        let pooled_ref =
-            module::avg_pool2d(tensor_ref, kernel_size, stride, padding, count_include_pad);
+        let pooled = module::avg_pool2d(
+            tensor,
+            kernel_size,
+            stride,
+            padding,
+            count_include_pad,
+            ceil,
+        );
+        let pooled_ref = module::avg_pool2d(
+            tensor_ref,
+            kernel_size,
+            stride,
+            padding,
+            count_include_pad,
+            ceil,
+        );
 
         pooled
             .into_data()
@@ -45,6 +59,7 @@ mod tests {
         let stride = [1, 1];
         let padding = [1, 1];
         let count_include_pad = true;
+        let ceil = false;
 
         let shape_out = module::avg_pool2d(
             tensor.clone(),
@@ -52,6 +67,7 @@ mod tests {
             stride,
             padding,
             count_include_pad,
+            ceil,
         )
         .shape();
         let grad_output =

--- a/crates/burn-cubecl/src/tests/max_pool2d.rs
+++ b/crates/burn-cubecl/src/tests/max_pool2d.rs
@@ -18,9 +18,11 @@ mod tests {
         let stride = [2, 2];
         let padding = [1, 1];
         let dilation = [1, 1];
+        let ceil = false;
 
-        let pooled = module::max_pool2d(tensor, kernel_size, stride, padding, dilation);
-        let pooled_ref = module::max_pool2d(tensor_ref, kernel_size, stride, padding, dilation);
+        let pooled = module::max_pool2d(tensor, kernel_size, stride, padding, dilation, ceil);
+        let pooled_ref =
+            module::max_pool2d(tensor_ref, kernel_size, stride, padding, dilation, ceil);
 
         pooled
             .into_data()
@@ -40,11 +42,18 @@ mod tests {
         let stride = [2, 2];
         let padding = [1, 1];
         let dilation = [1, 1];
+        let ceil = false;
 
         let (pooled, indices) =
-            module::max_pool2d_with_indices(tensor, kernel_size, stride, padding, dilation);
-        let (pooled_ref, indices_ref) =
-            module::max_pool2d_with_indices(tensor_ref, kernel_size, stride, padding, dilation);
+            module::max_pool2d_with_indices(tensor, kernel_size, stride, padding, dilation, ceil);
+        let (pooled_ref, indices_ref) = module::max_pool2d_with_indices(
+            tensor_ref,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+            ceil,
+        );
 
         pooled
             .into_data()

--- a/crates/burn-cubecl/src/tests/max_pool2d_backward.rs
+++ b/crates/burn-cubecl/src/tests/max_pool2d_backward.rs
@@ -20,15 +20,23 @@ mod tests {
         let stride = [2, 2];
         let padding = [1, 1];
         let dilation = [1, 1];
+        let ceil = false;
 
-        let (_, indices) =
-            module::max_pool2d_with_indices(tensor.clone(), kernel_size, stride, padding, dilation);
+        let (_, indices) = module::max_pool2d_with_indices(
+            tensor.clone(),
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+            ceil,
+        );
         let (_, indices_ref) = module::max_pool2d_with_indices(
             tensor_ref.clone(),
             kernel_size,
             stride,
             padding,
             dilation,
+            ceil,
         );
         let grad = TestBackend::max_pool2d_with_indices_backward(
             tensor.into_primitive().tensor(),

--- a/crates/burn-fusion/src/ops/module.rs
+++ b/crates/burn-fusion/src/ops/module.rs
@@ -634,6 +634,7 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
         stride: usize,
         padding: usize,
         count_include_pad: bool,
+        ceil: bool,
     ) -> FloatTensor<Self> {
         make_ops!(
             AvgPool1dOps,
@@ -646,6 +647,7 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
                     args.stride,
                     args.padding,
                     args.count_include_pad,
+                    args.ceil,
                 );
 
                 handles.register_float_tensor::<B>(&args.out.id, output);
@@ -653,7 +655,7 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
         );
 
         let stream = x.stream;
-        let size = calculate_pool_output_size(kernel_size, stride, padding, 1, x.shape[2]);
+        let size = calculate_pool_output_size(kernel_size, stride, padding, 1, x.shape[2], ceil);
         let shape = vec![x.shape[0], x.shape[1], size];
         let out = x.client.tensor_uninitialized(shape, B::FloatElem::dtype());
 
@@ -663,6 +665,7 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
             stride,
             padding,
             count_include_pad,
+            ceil,
             out: out.to_ir_out(),
         };
         out.client.register(
@@ -680,6 +683,7 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
         stride: [usize; 2],
         padding: [usize; 2],
         count_include_pad: bool,
+        ceil: bool,
     ) -> FloatTensor<Self> {
         make_ops!(
             AvgPool2dOps,
@@ -692,6 +696,7 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
                     args.stride,
                     args.padding,
                     args.count_include_pad,
+                    args.ceil,
                 );
 
                 handles.register_float_tensor::<B>(&args.out.id, output);
@@ -699,9 +704,9 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
         );
 
         let size_0 =
-            calculate_pool_output_size(kernel_size[0], stride[0], padding[0], 1, x.shape[2]);
+            calculate_pool_output_size(kernel_size[0], stride[0], padding[0], 1, x.shape[2], ceil);
         let size_1 =
-            calculate_pool_output_size(kernel_size[1], stride[1], padding[1], 1, x.shape[3]);
+            calculate_pool_output_size(kernel_size[1], stride[1], padding[1], 1, x.shape[3], ceil);
 
         let stream = x.stream;
         let shape = vec![x.shape[0], x.shape[1], size_0, size_1];
@@ -713,6 +718,7 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
             stride,
             padding,
             count_include_pad,
+            ceil,
             out: out.to_ir_out(),
         };
         out.client.register(
@@ -832,6 +838,7 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
         stride: usize,
         padding: usize,
         dilation: usize,
+        ceil: bool,
     ) -> FloatTensor<Self> {
         make_ops!(
             MaxPool1dOps,
@@ -844,13 +851,15 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
                     args.stride,
                     args.padding,
                     args.dilation,
+                    args.ceil,
                 );
 
                 handles.register_float_tensor::<B>(&args.out.id, output);
             }
         );
 
-        let size = calculate_pool_output_size(kernel_size, stride, padding, dilation, x.shape[2]);
+        let size =
+            calculate_pool_output_size(kernel_size, stride, padding, dilation, x.shape[2], ceil);
 
         let stream = x.stream;
         let shape = vec![x.shape[0], x.shape[1], size];
@@ -862,6 +871,7 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
             stride,
             padding,
             dilation,
+            ceil,
             out: out.to_ir_out(),
         };
         out.client.register(
@@ -879,6 +889,7 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
         stride: [usize; 2],
         padding: [usize; 2],
         dilation: [usize; 2],
+        ceil: bool,
     ) -> FloatTensor<Self> {
         make_ops!(
             MaxPool2dOps,
@@ -891,6 +902,7 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
                     args.stride,
                     args.padding,
                     args.dilation,
+                    args.ceil,
                 );
 
                 handles.register_float_tensor::<B>(&args.out.id, output);
@@ -903,6 +915,7 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
             padding[0],
             dilation[0],
             x.shape[2],
+            ceil,
         );
         let size_1 = calculate_pool_output_size(
             kernel_size[1],
@@ -910,6 +923,7 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
             padding[1],
             dilation[1],
             x.shape[3],
+            ceil,
         );
 
         let stream = x.stream;
@@ -922,6 +936,7 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
             stride,
             padding,
             dilation,
+            ceil,
             out: out.to_ir_out(),
         };
         out.client.register(
@@ -939,6 +954,7 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
         stride: usize,
         padding: usize,
         dilation: usize,
+        ceil: bool,
     ) -> MaxPool1dWithIndices<Self> {
         make_ops!(
             MaxPool1dWithIndicesOps,
@@ -951,6 +967,7 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
                     args.stride,
                     args.padding,
                     args.dilation,
+                    args.ceil,
                 );
 
                 handles.register_float_tensor::<B>(&args.out.id, output.output);
@@ -959,7 +976,8 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
         );
 
         let stream = x.stream;
-        let size = calculate_pool_output_size(kernel_size, stride, padding, dilation, x.shape[2]);
+        let size =
+            calculate_pool_output_size(kernel_size, stride, padding, dilation, x.shape[2], ceil);
         let shape = vec![x.shape[0], x.shape[1], size];
         let out = x
             .client
@@ -972,6 +990,7 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
             stride,
             padding,
             dilation,
+            ceil,
             out: out.to_ir_out(),
             out_indices: out_indices.to_ir_out(),
         };
@@ -990,6 +1009,7 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
         stride: [usize; 2],
         padding: [usize; 2],
         dilation: [usize; 2],
+        ceil: bool,
     ) -> MaxPool2dWithIndices<Self> {
         make_ops!(
             MaxPool2dWithIndicesOps,
@@ -1002,6 +1022,7 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
                     args.stride,
                     args.padding,
                     args.dilation,
+                    args.ceil,
                 );
 
                 handles.register_float_tensor::<B>(&args.out.id, output.output);
@@ -1015,6 +1036,7 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
             padding[0],
             dilation[0],
             x.shape[2],
+            ceil,
         );
         let size_1 = calculate_pool_output_size(
             kernel_size[1],
@@ -1022,6 +1044,7 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
             padding[1],
             dilation[1],
             x.shape[3],
+            ceil,
         );
 
         let stream = x.stream;
@@ -1037,6 +1060,7 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
             stride,
             padding,
             dilation,
+            ceil,
             out: out.to_ir_out(),
             out_indices: out_indices.to_ir_out(),
         };

--- a/crates/burn-fusion/src/stream/context.rs
+++ b/crates/burn-fusion/src/stream/context.rs
@@ -309,6 +309,7 @@ impl RelativeOps for ModuleOperationIr {
                 stride: desc.stride,
                 padding: desc.padding,
                 count_include_pad: desc.count_include_pad,
+                ceil: desc.ceil,
                 out: desc.out.to_relative(converter),
             }),
             ModuleOperationIr::AvgPool2d(desc) => ModuleOperationIr::AvgPool2d(AvgPool2dOpIr {
@@ -317,6 +318,7 @@ impl RelativeOps for ModuleOperationIr {
                 stride: desc.stride,
                 padding: desc.padding,
                 count_include_pad: desc.count_include_pad,
+                ceil: desc.ceil,
                 out: desc.out.to_relative(converter),
             }),
             ModuleOperationIr::AvgPool1dBackward(desc) => {
@@ -375,6 +377,7 @@ impl RelativeOps for ModuleOperationIr {
                 stride: desc.stride,
                 padding: desc.padding,
                 dilation: desc.dilation,
+                ceil: desc.ceil,
                 out: desc.out.to_relative(converter),
             }),
             ModuleOperationIr::MaxPool1dWithIndices(desc) => {
@@ -384,6 +387,7 @@ impl RelativeOps for ModuleOperationIr {
                     stride: desc.stride,
                     padding: desc.padding,
                     dilation: desc.dilation,
+                    ceil: desc.ceil,
                     out: desc.out.to_relative(converter),
                     out_indices: desc.out_indices.to_relative(converter),
                 })
@@ -406,6 +410,7 @@ impl RelativeOps for ModuleOperationIr {
                 stride: desc.stride,
                 padding: desc.padding,
                 dilation: desc.dilation,
+                ceil: desc.ceil,
                 out: desc.out.to_relative(converter),
             }),
             ModuleOperationIr::MaxPool2dWithIndices(desc) => {
@@ -415,6 +420,7 @@ impl RelativeOps for ModuleOperationIr {
                     stride: desc.stride,
                     padding: desc.padding,
                     dilation: desc.dilation,
+                    ceil: desc.ceil,
                     out: desc.out.to_relative(converter),
                     out_indices: desc.out_indices.to_relative(converter),
                 })

--- a/crates/burn-ir/src/operation.rs
+++ b/crates/burn-ir/src/operation.rs
@@ -1161,6 +1161,7 @@ pub struct AvgPool1dOpIr {
     pub stride: usize,
     pub padding: usize,
     pub count_include_pad: bool,
+    pub ceil: bool,
     pub out: TensorIr,
 }
 
@@ -1172,6 +1173,7 @@ pub struct AvgPool2dOpIr {
     pub stride: [usize; 2],
     pub padding: [usize; 2],
     pub count_include_pad: bool,
+    pub ceil: bool,
     pub out: TensorIr,
 }
 
@@ -1239,6 +1241,7 @@ pub struct MaxPool1dOpIr {
     pub stride: usize,
     pub padding: usize,
     pub dilation: usize,
+    pub ceil: bool,
     pub out: TensorIr,
 }
 
@@ -1250,6 +1253,7 @@ pub struct MaxPool1dWithIndicesOpIr {
     pub stride: usize,
     pub padding: usize,
     pub dilation: usize,
+    pub ceil: bool,
     pub out: TensorIr,
     pub out_indices: TensorIr,
 }
@@ -1275,6 +1279,7 @@ pub struct MaxPool2dOpIr {
     pub stride: [usize; 2],
     pub padding: [usize; 2],
     pub dilation: [usize; 2],
+    pub ceil: bool,
     pub out: TensorIr,
 }
 
@@ -1286,6 +1291,7 @@ pub struct MaxPool2dWithIndicesOpIr {
     pub stride: [usize; 2],
     pub padding: [usize; 2],
     pub dilation: [usize; 2],
+    pub ceil: bool,
     pub out: TensorIr,
     pub out_indices: TensorIr,
 }

--- a/crates/burn-ndarray/src/ops/maxpool.rs
+++ b/crates/burn-ndarray/src/ops/maxpool.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 use burn_common::{iter_range_par, run_par};
-use burn_tensor::{ElementConversion, TensorMetadata};
+use burn_tensor::{ElementConversion, TensorMetadata, ops::conv::calculate_pool_output_size};
 use ndarray::Array4;
 
 pub(crate) fn max_pool2d<E: FloatNdArrayElement>(
@@ -15,6 +15,7 @@ pub(crate) fn max_pool2d<E: FloatNdArrayElement>(
     stride: [usize; 2],
     padding: [usize; 2],
     dilation: [usize; 2],
+    ceil: bool,
 ) -> NdArrayTensor<E> {
     let [kernel_height, kernel_width] = kernel_size;
     let [padding_height, padding_width] = padding;
@@ -23,12 +24,23 @@ pub(crate) fn max_pool2d<E: FloatNdArrayElement>(
     let [batch_size, channels, x_height, x_width] = x.shape().dims();
     let inf = (-f32::INFINITY).elem::<E>();
 
-    let out_height = ((x_height + 2 * padding_height - dilation_height * (kernel_height - 1) - 1)
-        / stride_height)
-        + 1;
-    let out_width = ((x_width + 2 * padding_width - dilation_width * (kernel_width - 1) - 1)
-        / stride_width)
-        + 1;
+    let out_height = calculate_pool_output_size(
+        kernel_height,
+        stride_height,
+        padding_height,
+        dilation_height,
+        x_height,
+        ceil,
+    );
+
+    let out_width = calculate_pool_output_size(
+        kernel_width,
+        stride_width,
+        padding_width,
+        dilation_width,
+        x_width,
+        ceil,
+    );
 
     let x = apply_padding_4d::<E>(x, padding, inf).array;
 
@@ -75,6 +87,7 @@ pub(crate) fn max_pool2d_with_indices<E: FloatNdArrayElement, I: IntNdArrayEleme
     stride: [usize; 2],
     padding: [usize; 2],
     dilation: [usize; 2],
+    ceil: bool,
 ) -> (NdArrayTensor<E>, NdArrayTensor<I>) {
     let [kernel_height, kernel_width] = kernel_size;
     let [padding_height, padding_width] = padding;
@@ -83,12 +96,23 @@ pub(crate) fn max_pool2d_with_indices<E: FloatNdArrayElement, I: IntNdArrayEleme
     let [batch_size, channels, x_height, x_width] = x.shape().dims();
     let inf = (-f32::INFINITY).elem::<E>();
 
-    let out_height = ((x_height + 2 * padding_height - dilation_height * (kernel_height - 1) - 1)
-        / stride_height)
-        + 1;
-    let out_width = ((x_width + 2 * padding_width - dilation_width * (kernel_width - 1) - 1)
-        / stride_width)
-        + 1;
+    let out_height = calculate_pool_output_size(
+        kernel_height,
+        stride_height,
+        padding_height,
+        dilation_height,
+        x_height,
+        ceil,
+    );
+
+    let out_width = calculate_pool_output_size(
+        kernel_width,
+        stride_width,
+        padding_width,
+        dilation_width,
+        x_width,
+        ceil,
+    );
 
     let x = apply_padding_4d::<E>(x, padding, inf).array;
 

--- a/crates/burn-ndarray/src/ops/module.rs
+++ b/crates/burn-ndarray/src/ops/module.rs
@@ -130,6 +130,7 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> ModuleOps<Se
         stride: [usize; 2],
         padding: [usize; 2],
         count_include_pad: bool,
+        _ceil: bool,
     ) -> FloatTensor<Self> {
         module_op!(inp(x), opt(), E, |x| {
             #[cfg(feature = "simd")]
@@ -166,6 +167,7 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> ModuleOps<Se
         stride: [usize; 2],
         padding: [usize; 2],
         dilation: [usize; 2],
+        ceil: bool,
     ) -> FloatTensor<Self> {
         module_op!(inp(x), opt(), E, |x| {
             #[cfg(feature = "simd")]
@@ -173,7 +175,7 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> ModuleOps<Se
                 Ok(out) => return out.into(),
                 Err(x) => x,
             };
-            max_pool2d::<E>(x, kernel_size, stride, padding, dilation).into()
+            max_pool2d::<E>(x, kernel_size, stride, padding, dilation, ceil).into()
         })
     }
 
@@ -183,10 +185,11 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> ModuleOps<Se
         stride: [usize; 2],
         padding: [usize; 2],
         dilation: [usize; 2],
+        ceil: bool,
     ) -> MaxPool2dWithIndices<NdArray<E, I, Q>> {
         module_op!(inp(x), opt(), E, |x| {
             let (output, indices) =
-                max_pool2d_with_indices::<E, I>(x, kernel_size, stride, padding, dilation);
+                max_pool2d_with_indices::<E, I>(x, kernel_size, stride, padding, dilation, ceil);
             MaxPool2dWithIndices::new(output.into(), indices)
         })
     }

--- a/crates/burn-router/src/ops/op_module.rs
+++ b/crates/burn-router/src/ops/op_module.rs
@@ -277,8 +277,9 @@ impl<R: RunnerChannel> ModuleOps<Self> for BackendRouter<R> {
         stride: usize,
         padding: usize,
         count_include_pad: bool,
+        ceil: bool,
     ) -> FloatTensor<Self> {
-        let size = calculate_pool_output_size(kernel_size, stride, padding, 1, x.shape[2]);
+        let size = calculate_pool_output_size(kernel_size, stride, padding, 1, x.shape[2], ceil);
 
         let shape = vec![x.shape[0], x.shape[1], size];
         let client = x.client.clone();
@@ -290,6 +291,7 @@ impl<R: RunnerChannel> ModuleOps<Self> for BackendRouter<R> {
             stride,
             padding,
             count_include_pad,
+            ceil,
             out: out.to_ir_out(),
         };
 
@@ -304,11 +306,12 @@ impl<R: RunnerChannel> ModuleOps<Self> for BackendRouter<R> {
         stride: [usize; 2],
         padding: [usize; 2],
         count_include_pad: bool,
+        ceil: bool,
     ) -> FloatTensor<Self> {
         let size_0 =
-            calculate_pool_output_size(kernel_size[0], stride[0], padding[0], 1, x.shape[2]);
+            calculate_pool_output_size(kernel_size[0], stride[0], padding[0], 1, x.shape[2], ceil);
         let size_1 =
-            calculate_pool_output_size(kernel_size[1], stride[1], padding[1], 1, x.shape[3]);
+            calculate_pool_output_size(kernel_size[1], stride[1], padding[1], 1, x.shape[3], ceil);
 
         let shape = vec![x.shape[0], x.shape[1], size_0, size_1];
         let client = x.client.clone();
@@ -319,6 +322,7 @@ impl<R: RunnerChannel> ModuleOps<Self> for BackendRouter<R> {
             kernel_size,
             stride,
             padding,
+            ceil,
             count_include_pad,
             out: out.to_ir_out(),
         };
@@ -390,8 +394,10 @@ impl<R: RunnerChannel> ModuleOps<Self> for BackendRouter<R> {
         stride: usize,
         padding: usize,
         dilation: usize,
+        ceil: bool,
     ) -> FloatTensor<Self> {
-        let size = calculate_pool_output_size(kernel_size, stride, padding, dilation, x.shape[2]);
+        let size =
+            calculate_pool_output_size(kernel_size, stride, padding, dilation, x.shape[2], ceil);
 
         let shape = vec![x.shape[0], x.shape[1], size];
         let client = x.client.clone();
@@ -403,6 +409,7 @@ impl<R: RunnerChannel> ModuleOps<Self> for BackendRouter<R> {
             stride,
             padding,
             dilation,
+            ceil,
             out: out.to_ir_out(),
         };
 
@@ -417,6 +424,7 @@ impl<R: RunnerChannel> ModuleOps<Self> for BackendRouter<R> {
         stride: [usize; 2],
         padding: [usize; 2],
         dilation: [usize; 2],
+        ceil: bool,
     ) -> FloatTensor<Self> {
         let size_0 = calculate_pool_output_size(
             kernel_size[0],
@@ -424,6 +432,7 @@ impl<R: RunnerChannel> ModuleOps<Self> for BackendRouter<R> {
             padding[0],
             dilation[0],
             x.shape[2],
+            ceil,
         );
         let size_1 = calculate_pool_output_size(
             kernel_size[1],
@@ -431,6 +440,7 @@ impl<R: RunnerChannel> ModuleOps<Self> for BackendRouter<R> {
             padding[1],
             dilation[1],
             x.shape[3],
+            ceil,
         );
 
         let shape = vec![x.shape[0], x.shape[1], size_0, size_1];
@@ -443,6 +453,7 @@ impl<R: RunnerChannel> ModuleOps<Self> for BackendRouter<R> {
             stride,
             padding,
             dilation,
+            ceil,
             out: out.to_ir_out(),
         };
 
@@ -457,8 +468,10 @@ impl<R: RunnerChannel> ModuleOps<Self> for BackendRouter<R> {
         stride: usize,
         padding: usize,
         dilation: usize,
+        ceil: bool,
     ) -> MaxPool1dWithIndices<Self> {
-        let size = calculate_pool_output_size(kernel_size, stride, padding, dilation, x.shape[2]);
+        let size =
+            calculate_pool_output_size(kernel_size, stride, padding, dilation, x.shape[2], ceil);
 
         let shape = vec![x.shape[0], x.shape[1], size];
         let client = x.client.clone();
@@ -471,6 +484,7 @@ impl<R: RunnerChannel> ModuleOps<Self> for BackendRouter<R> {
             stride,
             padding,
             dilation,
+            ceil,
             out: out.to_ir_out(),
             out_indices: out_indices.to_ir_out(),
         };
@@ -488,6 +502,7 @@ impl<R: RunnerChannel> ModuleOps<Self> for BackendRouter<R> {
         stride: [usize; 2],
         padding: [usize; 2],
         dilation: [usize; 2],
+        ceil: bool,
     ) -> MaxPool2dWithIndices<Self> {
         let size_0 = calculate_pool_output_size(
             kernel_size[0],
@@ -495,6 +510,7 @@ impl<R: RunnerChannel> ModuleOps<Self> for BackendRouter<R> {
             padding[0],
             dilation[0],
             x.shape[2],
+            ceil,
         );
         let size_1 = calculate_pool_output_size(
             kernel_size[1],
@@ -502,6 +518,7 @@ impl<R: RunnerChannel> ModuleOps<Self> for BackendRouter<R> {
             padding[1],
             dilation[1],
             x.shape[3],
+            ceil,
         );
 
         let shape = vec![x.shape[0], x.shape[1], size_0, size_1];
@@ -515,6 +532,7 @@ impl<R: RunnerChannel> ModuleOps<Self> for BackendRouter<R> {
             stride,
             padding,
             dilation,
+            ceil,
             out: out.to_ir_out(),
             out_indices: out_indices.to_ir_out(),
         };

--- a/crates/burn-router/src/runner.rs
+++ b/crates/burn-router/src/runner.rs
@@ -1046,6 +1046,7 @@ impl<B: BackendIr> RunnerClient for Runner<B> {
                         desc.stride,
                         desc.padding,
                         desc.count_include_pad,
+                        desc.ceil,
                     );
                     handles.register_float_tensor::<B>(&desc.out.id, output);
                 }
@@ -1058,6 +1059,7 @@ impl<B: BackendIr> RunnerClient for Runner<B> {
                         desc.stride,
                         desc.padding,
                         desc.count_include_pad,
+                        desc.ceil,
                     );
                     handles.register_float_tensor::<B>(&desc.out.id, output);
                 }
@@ -1124,6 +1126,7 @@ impl<B: BackendIr> RunnerClient for Runner<B> {
                         desc.stride,
                         desc.padding,
                         desc.dilation,
+                        desc.ceil,
                     );
                     handles.register_float_tensor::<B>(&desc.out.id, output);
                 }
@@ -1136,6 +1139,7 @@ impl<B: BackendIr> RunnerClient for Runner<B> {
                         desc.stride,
                         desc.padding,
                         desc.dilation,
+                        desc.ceil,
                     );
                     handles.register_float_tensor::<B>(&desc.out.id, output.output);
                     handles.register_int_tensor::<B>(&desc.out_indices.id, output.indices);
@@ -1165,6 +1169,7 @@ impl<B: BackendIr> RunnerClient for Runner<B> {
                         desc.stride,
                         desc.padding,
                         desc.dilation,
+                        desc.ceil,
                     );
                     handles.register_float_tensor::<B>(&desc.out.id, output);
                 }
@@ -1177,6 +1182,7 @@ impl<B: BackendIr> RunnerClient for Runner<B> {
                         desc.stride,
                         desc.padding,
                         desc.dilation,
+                        desc.ceil,
                     );
                     handles.register_float_tensor::<B>(&desc.out.id, output.output);
                     handles.register_int_tensor::<B>(&desc.out_indices.id, output.indices);

--- a/crates/burn-tch/src/ops/module.rs
+++ b/crates/burn-tch/src/ops/module.rs
@@ -175,13 +175,14 @@ impl<E: TchElement, Q: QuantElement> ModuleOps<Self> for LibTorch<E, Q> {
         stride: usize,
         padding: usize,
         count_include_pad: bool,
+        ceil: bool,
     ) -> TchTensor {
         let tensor = tch::Tensor::avg_pool1d(
             &x.tensor,
             [kernel_size as i64],
             [stride as i64],
             [padding as i64],
-            false,
+            ceil,
             count_include_pad,
         );
 
@@ -193,13 +194,14 @@ impl<E: TchElement, Q: QuantElement> ModuleOps<Self> for LibTorch<E, Q> {
         stride: [usize; 2],
         padding: [usize; 2],
         count_include_pad: bool,
+        ceil: bool,
     ) -> TchTensor {
         let tensor = tch::Tensor::avg_pool2d(
             &x.tensor,
             [kernel_size[0] as i64, kernel_size[1] as i64],
             [stride[0] as i64, stride[1] as i64],
             [padding[0] as i64, padding[1] as i64],
-            false,
+            ceil,
             count_include_pad,
             None,
         );
@@ -235,6 +237,7 @@ impl<E: TchElement, Q: QuantElement> ModuleOps<Self> for LibTorch<E, Q> {
         stride: usize,
         padding: usize,
         dilation: usize,
+        ceil: bool,
     ) -> TchTensor {
         let tensor = tch::Tensor::max_pool1d(
             &x.tensor,
@@ -242,7 +245,7 @@ impl<E: TchElement, Q: QuantElement> ModuleOps<Self> for LibTorch<E, Q> {
             stride as i64,
             padding as i64,
             dilation as i64,
-            false,
+            ceil,
         );
 
         TchTensor::new(tensor)
@@ -254,6 +257,7 @@ impl<E: TchElement, Q: QuantElement> ModuleOps<Self> for LibTorch<E, Q> {
         stride: usize,
         padding: usize,
         dilation: usize,
+        ceil: bool,
     ) -> MaxPool1dWithIndices<LibTorch<E, Q>> {
         let (tensor, indices) = tch::Tensor::max_pool1d_with_indices(
             &x.tensor,
@@ -261,7 +265,7 @@ impl<E: TchElement, Q: QuantElement> ModuleOps<Self> for LibTorch<E, Q> {
             stride as i64,
             padding as i64,
             dilation as i64,
-            false,
+            ceil,
         );
 
         MaxPool1dWithIndices::new(TchTensor::new(tensor), TchTensor::new(indices))
@@ -273,6 +277,7 @@ impl<E: TchElement, Q: QuantElement> ModuleOps<Self> for LibTorch<E, Q> {
         stride: [usize; 2],
         padding: [usize; 2],
         dilation: [usize; 2],
+        ceil: bool,
     ) -> TchTensor {
         let tensor = tch::Tensor::max_pool2d(
             &x.tensor,
@@ -280,7 +285,7 @@ impl<E: TchElement, Q: QuantElement> ModuleOps<Self> for LibTorch<E, Q> {
             [stride[0] as i64, stride[1] as i64],
             [padding[0] as i64, padding[1] as i64],
             [dilation[0] as i64, dilation[1] as i64],
-            false,
+            ceil,
         );
 
         TchTensor::new(tensor)
@@ -292,6 +297,7 @@ impl<E: TchElement, Q: QuantElement> ModuleOps<Self> for LibTorch<E, Q> {
         stride: [usize; 2],
         padding: [usize; 2],
         dilation: [usize; 2],
+        ceil: bool,
     ) -> MaxPool2dWithIndices<LibTorch<E, Q>> {
         let (tensor, indices) = tch::Tensor::max_pool2d_with_indices(
             &x.tensor,
@@ -299,7 +305,7 @@ impl<E: TchElement, Q: QuantElement> ModuleOps<Self> for LibTorch<E, Q> {
             [stride[0] as i64, stride[1] as i64],
             [padding[0] as i64, padding[1] as i64],
             [dilation[0] as i64, dilation[1] as i64],
-            false,
+            ceil,
         );
 
         MaxPool2dWithIndices::new(TchTensor::new(tensor), TchTensor::new(indices))

--- a/crates/burn-tensor/src/tensor/module.rs
+++ b/crates/burn-tensor/src/tensor/module.rs
@@ -207,6 +207,7 @@ pub fn max_pool1d<B>(
     stride: usize,
     padding: usize,
     dilation: usize,
+    ceil: bool,
 ) -> Tensor<B, 3>
 where
     B: Backend,
@@ -217,6 +218,7 @@ where
         stride,
         padding,
         dilation,
+        ceil,
     )))
 }
 
@@ -227,6 +229,7 @@ pub fn max_pool2d<B>(
     stride: [usize; 2],
     padding: [usize; 2],
     dilation: [usize; 2],
+    ceil: bool,
 ) -> Tensor<B, 4>
 where
     B: Backend,
@@ -237,6 +240,7 @@ where
         stride,
         padding,
         dilation,
+        ceil,
     )))
 }
 
@@ -247,6 +251,7 @@ pub fn avg_pool2d<B>(
     stride: [usize; 2],
     padding: [usize; 2],
     count_include_pad: bool,
+    ceil: bool,
 ) -> Tensor<B, 4>
 where
     B: Backend,
@@ -257,6 +262,7 @@ where
         stride,
         padding,
         count_include_pad,
+        ceil,
     )))
 }
 
@@ -267,6 +273,7 @@ pub fn avg_pool1d<B>(
     stride: usize,
     padding: usize,
     count_include_pad: bool,
+    ceil: bool,
 ) -> Tensor<B, 3>
 where
     B: Backend,
@@ -277,6 +284,7 @@ where
         stride,
         padding,
         count_include_pad,
+        ceil,
     )))
 }
 
@@ -287,12 +295,19 @@ pub fn max_pool1d_with_indices<B>(
     stride: usize,
     padding: usize,
     dilation: usize,
+    ceil: bool,
 ) -> (Tensor<B, 3>, Tensor<B, 3, Int>)
 where
     B: Backend,
 {
-    let output =
-        B::max_pool1d_with_indices(x.primitive.tensor(), kernel_size, stride, padding, dilation);
+    let output = B::max_pool1d_with_indices(
+        x.primitive.tensor(),
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        ceil,
+    );
 
     (
         Tensor::new(TensorPrimitive::Float(output.output)),
@@ -307,12 +322,19 @@ pub fn max_pool2d_with_indices<B>(
     stride: [usize; 2],
     padding: [usize; 2],
     dilation: [usize; 2],
+    ceil: bool,
 ) -> (Tensor<B, 4>, Tensor<B, 4, Int>)
 where
     B: Backend,
 {
-    let output =
-        B::max_pool2d_with_indices(x.primitive.tensor(), kernel_size, stride, padding, dilation);
+    let output = B::max_pool2d_with_indices(
+        x.primitive.tensor(),
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        ceil,
+    );
 
     (
         Tensor::new(TensorPrimitive::Float(output.output)),

--- a/crates/burn-tensor/src/tensor/ops/modules/base.rs
+++ b/crates/burn-tensor/src/tensor/ops/modules/base.rs
@@ -599,8 +599,9 @@ pub trait ModuleOps<B: Backend> {
         stride: usize,
         padding: usize,
         count_include_pad: bool,
+        ceil: bool,
     ) -> FloatTensor<B> {
-        pool::avg_pool1d_from_2d::<B>(x, kernel_size, stride, padding, count_include_pad)
+        pool::avg_pool1d_from_2d::<B>(x, kernel_size, stride, padding, count_include_pad, ceil)
     }
     /// Backward pass for the [avg pooling 1d](ModuleOps::avg_pool1d) operation.
     fn avg_pool1d_backward(
@@ -631,6 +632,7 @@ pub trait ModuleOps<B: Backend> {
         stride: [usize; 2],
         padding: [usize; 2],
         count_include_pad: bool,
+        ceil: bool,
     ) -> FloatTensor<B>;
     /// Backward pass for the [avg pooling 2d](ModuleOps::avg_pool2d) operation.
     fn avg_pool2d_backward(
@@ -672,8 +674,9 @@ pub trait ModuleOps<B: Backend> {
         stride: usize,
         padding: usize,
         dilation: usize,
+        ceil: bool,
     ) -> FloatTensor<B> {
-        pool::max_pool1d_from_2d::<B>(x, kernel_size, stride, padding, dilation)
+        pool::max_pool1d_from_2d::<B>(x, kernel_size, stride, padding, dilation, ceil)
     }
 
     /// One dimensional max pooling with indices.
@@ -687,8 +690,9 @@ pub trait ModuleOps<B: Backend> {
         stride: usize,
         padding: usize,
         dilation: usize,
+        ceil: bool,
     ) -> MaxPool1dWithIndices<B> {
-        pool::max_pool1d_with_indices_from_2d::<B>(x, kernel_size, stride, padding, dilation)
+        pool::max_pool1d_with_indices_from_2d::<B>(x, kernel_size, stride, padding, dilation, ceil)
     }
     /// Backward pass for the [max pooling 1d](ModuleOps::max_pool1d_with_indices) operation.
     fn max_pool1d_with_indices_backward(
@@ -722,6 +726,7 @@ pub trait ModuleOps<B: Backend> {
         stride: [usize; 2],
         padding: [usize; 2],
         dilation: [usize; 2],
+        ceil: bool,
     ) -> FloatTensor<B>;
 
     /// Two dimensional max pooling with indices.
@@ -735,6 +740,7 @@ pub trait ModuleOps<B: Backend> {
         stride: [usize; 2],
         padding: [usize; 2],
         dilation: [usize; 2],
+        ceil: bool,
     ) -> MaxPool2dWithIndices<B>;
     /// Backward pass for the [max pooling 2d](ModuleOps::max_pool2d_with_indices) operation.
     fn max_pool2d_with_indices_backward(

--- a/crates/burn-tensor/src/tensor/ops/modules/conv.rs
+++ b/crates/burn-tensor/src/tensor/ops/modules/conv.rs
@@ -71,8 +71,17 @@ pub fn calculate_pool_output_size(
     padding: usize,
     dilation: usize,
     size_in: usize,
+    ceil: bool,
 ) -> usize {
-    ((size_in + 2 * padding - dilation * (kernel_size - 1) - 1) / stride) + 1
+    let pool_size = size_in + 2 * padding - dilation * (kernel_size - 1) - 1;
+
+    let pool_size = if ceil {
+        pool_size.div_ceil(stride)
+    } else {
+        pool_size / stride
+    };
+
+    pool_size + 1
 }
 
 /// Calculate the [1D convolution](crate::ops::ModuleOps::conv1d) backward pass, returning the gradient for `x`.
@@ -1210,5 +1219,37 @@ mod tests {
             calculate_conv_output_size(kernel_size, stride, padding, dilation, size_in);
 
         assert_eq!(size_out, size_out_expected, "Expected size");
+    }
+
+    #[test]
+    fn test_calculate_pool_output_size_1() {
+        let kernel_size = 2;
+        let stride = 2;
+        let padding = 1;
+        let size_in = 75;
+        let size_out = 39;
+        let dilation = 1;
+        let ceil = true;
+
+        assert_eq!(
+            calculate_pool_output_size(kernel_size, stride, padding, dilation, size_in, ceil),
+            size_out
+        );
+    }
+
+    #[test]
+    fn test_calculate_pool_output_size_2() {
+        let kernel_size = 2;
+        let stride = 2;
+        let padding = 1;
+        let size_in = 75;
+        let size_out = 38;
+        let dilation = 1;
+        let ceil = false;
+
+        assert_eq!(
+            calculate_pool_output_size(kernel_size, stride, padding, dilation, size_in, ceil),
+            size_out
+        );
     }
 }

--- a/crates/burn-tensor/src/tensor/ops/modules/pool.rs
+++ b/crates/burn-tensor/src/tensor/ops/modules/pool.rs
@@ -12,6 +12,7 @@ pub(crate) fn avg_pool1d_from_2d<B: Backend>(
     stride: usize,
     padding: usize,
     count_include_pad: bool,
+    ceil: bool,
 ) -> FloatTensor<B> {
     let [batch_size, channels, length] = x.shape().dims();
 
@@ -22,6 +23,7 @@ pub(crate) fn avg_pool1d_from_2d<B: Backend>(
         [stride, 1],
         [padding, 0],
         count_include_pad,
+        ceil,
     );
 
     let [batch_size, channels, length, _] = x.shape().dims();
@@ -90,6 +92,7 @@ pub(crate) fn max_pool1d_from_2d<B: Backend>(
     stride: usize,
     padding: usize,
     dilation: usize,
+    ceil: bool,
 ) -> FloatTensor<B> {
     let [batch_size, channels, length] = x.shape().dims();
 
@@ -100,6 +103,7 @@ pub(crate) fn max_pool1d_from_2d<B: Backend>(
         [stride, 1],
         [padding, 0],
         [dilation, 1],
+        ceil,
     );
 
     let [batch_size, channels, length, _] = x.shape().dims();
@@ -113,6 +117,7 @@ pub(crate) fn max_pool1d_with_indices_from_2d<B: Backend>(
     stride: usize,
     padding: usize,
     dilation: usize,
+    ceil: bool,
 ) -> MaxPool1dWithIndices<B> {
     let [batch_size, channels, length] = x.shape().dims();
 
@@ -123,6 +128,7 @@ pub(crate) fn max_pool1d_with_indices_from_2d<B: Backend>(
         [1, stride],
         [0, padding],
         [1, dilation],
+        ceil,
     );
     let [batch_size, channels, _, length] = x.output.shape().dims();
     let output = B::float_reshape(x.output, Shape::from([batch_size, channels, length]));

--- a/crates/burn-tensor/src/tests/module/avgpool1d.rs
+++ b/crates/burn-tensor/src/tests/module/avgpool1d.rs
@@ -16,6 +16,7 @@ mod tests {
             stride: 1,
             length: 6,
             count_include_pad: true,
+            ceil: false,
         };
 
         test.assert_output(TestTensor::from([[[1., 2., 3., 4.]]]));
@@ -31,6 +32,7 @@ mod tests {
             stride: 2,
             length: 6,
             count_include_pad: true,
+            ceil: false,
         };
 
         test.assert_output(TestTensor::from([[
@@ -49,6 +51,7 @@ mod tests {
             stride: 2,
             length: 6,
             count_include_pad: false,
+            ceil: false,
         };
 
         test.assert_output(TestTensor::from([[
@@ -65,6 +68,7 @@ mod tests {
         stride: usize,
         length: usize,
         count_include_pad: bool,
+        ceil: bool,
     }
 
     impl AvgPool1dTestCase {
@@ -81,6 +85,7 @@ mod tests {
                 self.stride,
                 self.padding,
                 self.count_include_pad,
+                self.ceil,
             );
 
             y.to_data().assert_approx_eq::<FT>(

--- a/crates/burn-tensor/src/tests/module/avgpool2d.rs
+++ b/crates/burn-tensor/src/tests/module/avgpool2d.rs
@@ -20,6 +20,7 @@ mod tests {
             height: 6,
             width: 6,
             count_include_pad: true,
+            ceil: false,
         };
 
         test.assert_output(TestTensor::from([[[
@@ -44,6 +45,7 @@ mod tests {
             height: 4,
             width: 6,
             count_include_pad: true,
+            ceil: false,
         };
 
         test.assert_output(TestTensor::from([[[
@@ -68,6 +70,7 @@ mod tests {
             height: 4,
             width: 6,
             count_include_pad: false,
+            ceil: false,
         };
 
         test.assert_output(TestTensor::from([[[
@@ -90,6 +93,7 @@ mod tests {
         height: usize,
         width: usize,
         count_include_pad: bool,
+        ceil: bool,
     }
 
     impl AvgPool2dTestCase {
@@ -106,6 +110,7 @@ mod tests {
                 [self.stride_1, self.stride_2],
                 [self.padding_1, self.padding_2],
                 self.count_include_pad,
+                self.ceil,
             );
 
             y.to_data().assert_approx_eq::<FT>(

--- a/crates/burn-tensor/src/tests/module/maxpool1d.rs
+++ b/crates/burn-tensor/src/tests/module/maxpool1d.rs
@@ -12,6 +12,7 @@ mod tests {
         let padding = 0;
         let stride = 1;
         let dilation = 1;
+        let ceil = false;
 
         let x = TestTensor::from([[
             [0.9861, 0.5474, 0.4477, 0.0732, 0.3548, 0.8221],
@@ -22,7 +23,7 @@ mod tests {
             [0.949, 0.949, 0.949, 0.789],
         ]]);
 
-        let output = max_pool1d(x, kernel_size, stride, padding, dilation);
+        let output = max_pool1d(x, kernel_size, stride, padding, dilation, ceil);
 
         y.to_data()
             .assert_approx_eq::<FT>(&output.into_data(), Tolerance::default());
@@ -34,11 +35,12 @@ mod tests {
         let padding = 1;
         let stride = 2;
         let dilation = 1;
+        let ceil = false;
 
         let x = TestTensor::from([[[0.6309, 0.6112, 0.6998, 0.4708]]]);
         let y = TestTensor::<3>::from([[[0.6309, 0.6998]]]);
 
-        let output = max_pool1d(x, kernel_size, stride, padding, dilation);
+        let output = max_pool1d(x, kernel_size, stride, padding, dilation, ceil);
 
         y.to_data()
             .assert_approx_eq::<FT>(&output.into_data(), Tolerance::default());
@@ -50,11 +52,12 @@ mod tests {
         let padding = 1;
         let stride = 1;
         let dilation = 1;
+        let ceil = false;
 
         let x = TestTensor::from([[[-0.6309, -0.6112, -0.6998, -0.4708]]]);
         let y = TestTensor::<3>::from([[[-0.6112, -0.6112, -0.4708, -0.4708]]]);
 
-        let output = max_pool1d(x, kernel_size, stride, padding, dilation);
+        let output = max_pool1d(x, kernel_size, stride, padding, dilation, ceil);
 
         y.to_data()
             .assert_approx_eq::<FT>(&output.into_data(), Tolerance::default());
@@ -66,6 +69,7 @@ mod tests {
         let padding = 1;
         let stride = 1;
         let dilation = 2;
+        let ceil = false;
 
         let x = TestTensor::from([[
             [0.9861, 0.5474, 0.4477, 0.0732, 0.3548, 0.8221],
@@ -76,7 +80,7 @@ mod tests {
             [0.5474, 0.9490, 0.7890, 0.9490, 0.7890, 0.5537],
         ]]);
 
-        let output = max_pool1d(x, kernel_size, stride, padding, dilation);
+        let output = max_pool1d(x, kernel_size, stride, padding, dilation, ceil);
 
         y.to_data()
             .assert_approx_eq::<FT>(&output.into_data(), Tolerance::default());
@@ -88,13 +92,14 @@ mod tests {
         let padding = 0;
         let stride = 1;
         let dilation = 1;
+        let ceil = false;
 
         let x = TestTensor::from([[[0.2479, 0.6386, 0.3166, 0.5742]]]);
         let indices = TensorData::from([[[1, 1, 3]]]);
         let y = TestTensor::<3>::from([[[0.6386, 0.6386, 0.5742]]]);
 
         let (output, output_indices) =
-            max_pool1d_with_indices(x, kernel_size, stride, padding, dilation);
+            max_pool1d_with_indices(x, kernel_size, stride, padding, dilation, ceil);
 
         y.to_data()
             .assert_approx_eq::<FT>(&output.into_data(), Tolerance::default());
@@ -107,13 +112,14 @@ mod tests {
         let padding = 2;
         let stride = 1;
         let dilation = 1;
+        let ceil = false;
 
         let x = TestTensor::from([[[0.5388, 0.0676, 0.7122, 0.8316, 0.0653]]]);
         let indices = TensorData::from([[[0, 2, 3, 3, 3, 3]]]);
         let y = TestTensor::<3>::from([[[0.5388, 0.7122, 0.8316, 0.8316, 0.8316, 0.8316]]]);
 
         let (output, output_indices) =
-            max_pool1d_with_indices(x, kernel_size, stride, padding, dilation);
+            max_pool1d_with_indices(x, kernel_size, stride, padding, dilation, ceil);
 
         y.to_data()
             .assert_approx_eq::<FT>(&output.into_data(), Tolerance::default());

--- a/crates/burn-tensor/src/tests/module/maxpool2d.rs
+++ b/crates/burn-tensor/src/tests/module/maxpool2d.rs
@@ -18,6 +18,7 @@ mod tests {
         let stride_2 = 1;
         let dilation_1 = 1;
         let dilation_2 = 1;
+        let ceil = false;
 
         let x = TestTensor::from([
             [
@@ -102,6 +103,7 @@ mod tests {
             [stride_1, stride_2],
             [padding_1, padding_2],
             [dilation_1, dilation_2],
+            ceil,
         );
 
         y.to_data()
@@ -120,6 +122,7 @@ mod tests {
         let stride_2 = 2;
         let dilation_1 = 1;
         let dilation_2 = 1;
+        let ceil = false;
 
         let x = TestTensor::from([[[
             [0.6309, 0.6112, 0.6998],
@@ -144,6 +147,7 @@ mod tests {
             [stride_1, stride_2],
             [padding_1, padding_2],
             [dilation_1, dilation_2],
+            ceil,
         );
 
         y.to_data()
@@ -162,6 +166,7 @@ mod tests {
         let stride_2 = 1;
         let dilation_1 = 1;
         let dilation_2 = 1;
+        let ceil = false;
 
         let x = TestTensor::from([[[
             [0.6309, 0.6112, 0.6998],
@@ -187,6 +192,7 @@ mod tests {
             [stride_1, stride_2],
             [padding_1, padding_2],
             [dilation_1, dilation_2],
+            ceil,
         );
 
         y.to_data()
@@ -205,6 +211,7 @@ mod tests {
         let stride_2 = 1;
         let dilation_1 = 2;
         let dilation_2 = 2;
+        let ceil = false;
 
         let x = TestTensor::from([[[
             [0.9861, 0.9861, 0.9490, 0.9490, 0.8221, 0.8221],
@@ -227,6 +234,7 @@ mod tests {
             [stride_1, stride_2],
             [padding_1, padding_2],
             [dilation_1, dilation_2],
+            ceil,
         );
 
         y.to_data()
@@ -244,6 +252,7 @@ mod tests {
         let stride_2 = 1;
         let dilation_1 = 1;
         let dilation_2 = 1;
+        let ceil = false;
 
         let x = TestTensor::from([[[
             [0.2479, 0.6386, 0.3166, 0.5742],
@@ -272,6 +281,7 @@ mod tests {
             [stride_1, stride_2],
             [padding_1, padding_2],
             [dilation_1, dilation_2],
+            ceil,
         );
 
         y.to_data()
@@ -291,6 +301,7 @@ mod tests {
         let stride_2 = 2;
         let dilation_1 = 1;
         let dilation_2 = 1;
+        let ceil = false;
 
         let x = TestTensor::from([[[
             [0.5388, 0.0676, 0.7122, 0.8316, 0.0653],
@@ -321,6 +332,7 @@ mod tests {
             [stride_1, stride_2],
             [padding_1, padding_2],
             [dilation_1, dilation_2],
+            ceil,
         );
 
         y.to_data()


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

https://github.com/tracel-ai/burn/issues/2132

### Changes

Adding a ceil option to max pool operations.

Example:

```
let maxpool2d3 = MaxPool2dConfig::new([2, 2])
    .with_strides([2, 2])
    .with_ceil(true)
    .init();
```
### Testing

Added Unit tests, 

Also tested on SSD: Single Shot MultiBox Detector model I am building, which is required to go from 

300x300->150x150->75x75->**38x38**

38x38 is where the maxpool size wasn't compatible in burn and it would resize to 37x37 instead. This update now allows it to resize properly to 38x38.
