### PR TITLE
Fix Typos in Documentation Comments

### DIFF
--- a/crates/burn-core/src/optim/simple/base.rs
+++ b/crates/burn-core/src/optim/simple/base.rs
@@ -27,7 +27,7 @@ where
 
     /// Change the device of the state.
     ///
-    /// This function will be called accordindly to have the state on the same device as the
+    /// This function will be called accordingly to have the state on the same device as the
     /// gradient and the tensor when the [step](SimpleOptimizer::step) function is called.
     fn to_device<const D: usize>(state: Self::State<D>, device: &B::Device) -> Self::State<D>;
 }

--- a/crates/burn-fusion/src/stream/execution/base.rs
+++ b/crates/burn-fusion/src/stream/execution/base.rs
@@ -72,7 +72,7 @@ impl<R: FusionRuntime> OperationQueue<R> {
     }
 }
 
-/// A queue execution has the responsability to run the provided
+/// A queue execution has the responsibility to run the provided
 /// [optimization](FusionRuntime::Optimization) without holes.
 enum QueueExecution<'a, R: FusionRuntime> {
     Single {


### PR DESCRIPTION


Description:  
This pull request corrects minor spelling mistakes in documentation comments within the codebase. Specifically, "accordingly" and "responsibility" have been fixed in their respective files to improve clarity and maintain code quality. No functional changes were made.