### PR TITLE
Fix onnx topological sort check

### DIFF
--- a/crates/onnx-ir/src/from_onnx.rs
+++ b/crates/onnx-ir/src/from_onnx.rs
@@ -453,15 +453,8 @@ trait TopologicalSortable {
 
 impl TopologicalSortable for Vec<NodeProto> {
     fn is_top_sorted(&self) -> bool {
-        // Create a hashmap to store the position of each node in the vector
-        let position: HashMap<String, usize> = self
-            .iter()
-            .enumerate()
-            .map(|(idx, node)| (node.name.clone(), idx))
-            .collect();
-
         // Iterate over each node in the vector
-        for node in self {
+        for (node_position, node) in self.iter().enumerate() {
             // Iterate over each output of the node
             for output in &node.output {
                 // If the output is empty, we don't want to check the rest of the graph, inputs and outputs that are optional
@@ -470,11 +463,11 @@ impl TopologicalSortable for Vec<NodeProto> {
                     continue;
                 }
                 // Iterate over each other node in the vector
-                for other_node in self {
+                for (other_node_position, other_node) in self.iter().enumerate() {
                     // If the other node has an input that matches the current output
                     if other_node.input.contains(output) {
                         // If the position of the current node is greater than the position of the other node
-                        if position[&node.name] > position[&other_node.name] {
+                        if node_position > other_node_position {
                             // The vector is not topologically sorted
                             return false;
                         }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

#1714

### Changes

Checked why onnx models are loaded with error "Nodes are not topologically sorted" after using `onnx_opset_upgrade.py` script. The issue is that `position` holds position of last encounter of node by name, and there are empty nodes having `node.name == ""`. I changed it to explicit indices from iterators over nodes.

### Testing

I used scripts provided in linked issue https://github.com/tracel-ai/burn/issues/1714#issuecomment-2952373124
