### PR TITLE
Fix typo in code documentation for BurnGraph codegen

### DIFF
--- a/crates/burn-import/src/burn/graph.rs
+++ b/crates/burn-import/src/burn/graph.rs
@@ -199,7 +199,7 @@ impl<PS: PrecisionSettings> BurnGraph<PS> {
         self
     }
 
-    /// Generate tokens reprensenting the graph with Burn modules and tensor operations.
+    /// Generate tokens representing the graph with Burn modules and tensor operations.
     pub fn codegen(mut self) -> TokenStream {
         self.build_scope();
 


### PR DESCRIPTION


Description:  
This pull request corrects a minor typo in the documentation comment for the codegen function in graph.rs. The word "representing" is now spelled correctly. No functional code changes were made; this update improves code readability and documentation accuracy.
