### PR TITLE
Add int tensor cast - WIP

### DIFF
--- a/crates/burn-autodiff/src/ops/int_tensor.rs
+++ b/crates/burn-autodiff/src/ops/int_tensor.rs
@@ -313,6 +313,10 @@ impl<B: Backend, C: CheckpointStrategy> IntTensorOps<Self> for Autodiff<B, C> {
         B::int_sort_with_indices(tensor, dim, descending)
     }
 
+    fn int_cast(tensor: IntTensor<Self>, dtype: burn_tensor::IntDType) -> IntTensor<Self> {
+        B::int_cast(tensor, dtype)
+    }
+
     fn int_argsort(tensor: IntTensor<Self>, dim: usize, descending: bool) -> IntTensor<Self> {
         B::int_argsort(tensor, dim, descending)
     }

--- a/crates/burn-candle/src/ops/int_tensor.rs
+++ b/crates/burn-candle/src/ops/int_tensor.rs
@@ -1,6 +1,6 @@
 use burn_common::future::DynFut;
 use burn_tensor::{
-    Bool, Device, Distribution, ElementConversion, Shape, TensorData,
+    Bool, Device, Distribution, ElementConversion, IntDType, Shape, TensorData,
     ops::{BoolTensor, FloatTensor, IntElem, IntTensor, IntTensorOps},
 };
 
@@ -369,6 +369,22 @@ impl<F: FloatCandleElement, I: IntCandleElement> IntTensorOps<Self> for Candle<F
     fn int_sign(tensor: IntTensor<Self>) -> IntTensor<Self> {
         sign(tensor)
     }
+
+    fn int_cast(tensor: IntTensor<Self>, dtype: IntDType) -> IntTensor<Self> {
+        let dtype = match dtype {
+            IntDType::I64 => candle_core::DType::I64,
+            IntDType::U8 => candle_core::DType::U8,
+            IntDType::U32 => candle_core::DType::U32,
+            _ => panic!("candle doesn't support this dtype"),
+        };
+
+        if tensor.tensor.dtype() == dtype {
+            tensor
+        } else {
+            CandleTensor::new(tensor.tensor.to_dtype(dtype).unwrap())
+        }
+    }
+
     fn bitwise_and(lhs: IntTensor<Self>, rhs: IntTensor<Self>) -> IntTensor<Self> {
         unimplemented!("bitwise_and is not implemented for Candle IntTensor");
     }

--- a/crates/burn-cubecl/src/ops/int_ops.rs
+++ b/crates/burn-cubecl/src/ops/int_ops.rs
@@ -357,6 +357,75 @@ where
         kernel::flip::<R, I, BT>(tensor, axes)
     }
 
+    fn int_cast(tensor: IntTensor<Self>, dtype: IntDType) -> IntTensor<Self> {
+        match (tensor.dtype, dtype) {
+            (Dtype::I8, IntDType::I8)
+            | (Dtype::I16, IntDType::I16)
+            | (Dtype::I32, IntDType::I32)
+            | (Dtype::I64, IntDType::I64)
+            | (Dtype::U8, IntDType::U8)
+            | (Dtype::U16, IntDType::I16)
+            | (Dtype::U32, IntDType::I32)
+            | (Dtype::U64, IntDType::I64) => tensor,
+            (Dtype::I64, IntDType::I32) => kernel::cast::<R, i64, i32>(tensor),
+            (Dtype::I64, IntDType::I16) => kernel::cast::<R, i64, i16>(tensor),
+            (Dtype::I64, IntDType::I8) => kernel::cast::<R, i64, i8>(tensor),
+            (Dtype::I32, IntDType::I64) => kernel::cast::<R, i32, i64>(tensor),
+            (Dtype::I32, IntDType::I16) => kernel::cast::<R, i32, i16>(tensor),
+            (Dtype::I32, IntDType::I8) => kernel::cast::<R, i32, i8>(tensor),
+            (Dtype::I16, IntDType::I64) => kernel::cast::<R, i16, i64>(tensor),
+            (Dtype::I16, IntDType::I32) => kernel::cast::<R, i16, i32>(tensor),
+            (Dtype::I16, IntDType::I8) => kernel::cast::<R, i16, i8>(tensor),
+            (Dtype::I8, IntDType::I64) => kernel::cast::<R, i8, i64>(tensor),
+            (Dtype::I8, IntDType::I32) => kernel::cast::<R, i8, i32>(tensor),
+            (Dtype::I8, IntDType::I16) => kernel::cast::<R, i8, i16>(tensor),
+            (Dtype::U64, IntDType::U32) => kernel::cast::<R, u64, u32>(tensor),
+            (Dtype::U64, IntDType::U16) => kernel::cast::<R, u64, u16>(tensor),
+            (Dtype::U64, IntDType::U8) => kernel::cast::<R, u64, u8>(tensor),
+            (Dtype::U32, IntDType::U64) => kernel::cast::<R, u32, u64>(tensor),
+            (Dtype::U32, IntDType::U16) => kernel::cast::<R, u32, u16>(tensor),
+            (Dtype::U32, IntDType::U8) => kernel::cast::<R, u32, u8>(tensor),
+            (Dtype::U16, IntDType::U64) => kernel::cast::<R, u16, u64>(tensor),
+            (Dtype::U16, IntDType::U32) => kernel::cast::<R, u16, u32>(tensor),
+            (Dtype::U16, IntDType::U8) => kernel::cast::<R, u16, u8>(tensor),
+            (Dtype::U8, IntDType::U64) => kernel::cast::<R, u8, u64>(tensor),
+            (Dtype::U8, IntDType::U32) => kernel::cast::<R, u8, u32>(tensor),
+            (Dtype::U8, IntDType::U16) => kernel::cast::<R, u8, u16>(tensor),
+            (Dtype::I64, IntDType::U64) => kernel::cast::<R, i64, u64>(tensor),
+            (Dtype::I64, IntDType::U32) => kernel::cast::<R, i64, u32>(tensor),
+            (Dtype::I64, IntDType::U16) => kernel::cast::<R, i64, u16>(tensor),
+            (Dtype::I64, IntDType::U8) => kernel::cast::<R, i64, u8>(tensor),
+            (Dtype::I32, IntDType::U64) => kernel::cast::<R, i32, u64>(tensor),
+            (Dtype::I32, IntDType::U32) => kernel::cast::<R, i32, u32>(tensor),
+            (Dtype::I32, IntDType::U16) => kernel::cast::<R, i32, u16>(tensor),
+            (Dtype::I32, IntDType::U8) => kernel::cast::<R, i32, U8>(tensor),
+            (Dtype::I16, IntDType::U64) => kernel::cast::<R, i16, U64>(tensor),
+            (Dtype::I16, IntDType::U32) => kernel::cast::<R, i16, u32>(tensor),
+            (Dtype::I16, IntDType::U16) => kernel::cast::<R, i16, u16>(tensor),
+            (Dtype::I16, IntDType::U8) => kernel::cast::<R, i16, u8>(tensor),
+            (Dtype::I8, IntDType::U64) => kernel::cast::<R, i8, u64>(tensor),
+            (Dtype::I8, IntDType::U32) => kernel::cast::<R, i8, u32>(tensor),
+            (Dtype::I8, IntDType::U16) => kernel::cast::<R, i8, u16>(tensor),
+            (Dtype::I8, IntDType::U8) => kernel::cast::<R, i8, u8>(tensor),
+            (Dtype::U64, IntDType::I64) => kernel::cast::<R, u64, i64>(tensor),
+            (Dtype::U64, IntDType::I32) => kernel::cast::<R, u64, i32>(tensor),
+            (Dtype::U64, IntDType::I16) => kernel::cast::<R, u64, i16>(tensor),
+            (Dtype::U64, IntDType::I8) => kernel::cast::<R, u64, i8>(tensor),
+            (Dtype::U32, IntDType::I64) => kernel::cast::<R, u32, i64>(tensor),
+            (Dtype::U32, IntDType::I32) => kernel::cast::<R, u32, i32>(tensor),
+            (Dtype::U32, IntDType::I16) => kernel::cast::<R, u32, i16>(tensor),
+            (Dtype::U32, IntDType::I8) => kernel::cast::<R, u32, i8>(tensor),
+            (Dtype::U16, IntDType::I64) => kernel::cast::<R, u16, i64>(tensor),
+            (Dtype::U16, IntDType::I32) => kernel::cast::<R, u16, i32>(tensor),
+            (Dtype::U16, IntDType::I16) => kernel::cast::<R, u16, i16>(tensor),
+            (Dtype::U16, IntDType::I8) => kernel::cast::<R, u16, i8>(tensor),
+            (Dtype::U8, IntDType::I64) => kernel::cast::<R, u8, i64>(tensor),
+            (Dtype::U8, IntDType::I32) => kernel::cast::<R, u8, i32>(tensor),
+            (Dtype::U8, IntDType::I16) => kernel::cast::<R, u8, i16>(tensor),
+            (Dtype::U8, IntDType::I8) => kernel::cast::<R, u8, i8>(tensor),
+        }
+    }
+
     fn bitwise_and(lhs: IntTensor<Self>, rhs: IntTensor<Self>) -> IntTensor<Self> {
         numeric::bitwise_and::<R, I>(lhs, rhs)
     }

--- a/crates/burn-ndarray/src/element.rs
+++ b/crates/burn-ndarray/src/element.rs
@@ -18,7 +18,7 @@ where
 }
 
 /// An int element for ndarray backend.
-pub trait IntNdArrayElement: NdArrayElement + Signed {}
+pub trait IntNdArrayElement: NdArrayElement + Signed{}
 
 /// A general element for ndarray backend.
 pub trait NdArrayElement:
@@ -64,6 +64,12 @@ impl FloatNdArrayElement for f32 {}
 
 impl IntNdArrayElement for i64 {}
 impl IntNdArrayElement for i32 {}
+impl IntNdArrayElement for i16 {}
+impl IntNdArrayElement for i8 {}
+impl IntNdArrayElement for u64 {}
+impl IntNdArrayElement for u32 {}
+impl IntNdArrayElement for u16 {}
+impl IntNdArrayElement for u8 {}
 
 macro_rules! make_elem {
     (

--- a/crates/burn-ndarray/src/tensor.rs
+++ b/crates/burn-ndarray/src/tensor.rs
@@ -189,6 +189,343 @@ macro_rules! execute_with_float_dtype {
     }};
 }
 
+/// Int tensor primitive.
+#[derive(Debug, Clone)]
+pub enum NdArrayTensorInt {
+    I64(NdArrayTensor<i64>),
+    I32(NdArrayTensor<i32>),
+    I16(NdArrayTensor<i16>),
+    I8(NdArrayTensor<i8>),
+    U64(NdArrayTensor<u64>),
+    U32(NdArrayTensor<u32>),
+    U16(NdArrayTensor<u16>),
+    U8(NdArrayTensor<u8>),
+}
+
+impl From<NdArrayTensor<i64>> for NdArrayTensorInt {
+    fn from(value: NdArrayTensor<i64>) -> Self {
+        NdArrayTensorInt::I64(value)
+    }
+}
+impl From<NdArrayTensor<i32>> for NdArrayTensorInt {
+    fn from(value: NdArrayTensor<i32>) -> Self {
+        NdArrayTensorInt::I32(value)
+    }
+}
+
+impl From<NdArrayTensor<i16>> for NdArrayTensorInt {
+    fn from(value: NdArrayTensor<i16>) -> Self {
+        NdArrayTensorInt::I16(value)
+    }
+}
+
+impl From<NdArrayTensor<i8>> for NdArrayTensorInt {
+    fn from(value: NdArrayTensor<i8>) -> Self {
+        NdArrayTensorInt::I8(value)
+    }
+}
+impl From<NdArrayTensor<u64>> for NdArrayTensorInt {
+    fn from(value: NdArrayTensor<u64>) -> Self {
+        NdArrayTensorInt::U64(value)
+    }
+}
+
+impl From<NdArrayTensor<u32>> for NdArrayTensorInt {
+    fn from(value: NdArrayTensor<u32>) -> Self {
+        NdArrayTensorInt::U32(value)
+    }
+}
+
+impl From<NdArrayTensor<u16>> for NdArrayTensorInt {
+    fn from(value: NdArrayTensor<u16>) -> Self {
+        NdArrayTensorInt::U16(value)
+    }
+}
+
+impl From<NdArrayTensor<u8>> for NdArrayTensorInt {
+    fn from(value: NdArrayTensor<u8>) -> Self {
+        NdArrayTensorInt::U8(value)
+    }
+}
+
+impl TensorMetadata for NdArrayTensorInt {
+    fn dtype(&self) -> DType {
+        match self {
+            NdArrayTensorInt::I64(tensor) => tensor.dtype(),
+            NdArrayTensorInt::I32(tensor) => tensor.dtype(),
+            NdArrayTensorInt::I16(tensor) => tensor.dtype(),
+            NdArrayTensorInt::I8(tensor) => tensor.dtype(),
+            NdArrayTensorInt::U64(tensor) => tensor.dtype(),
+            NdArrayTensorInt::U32(tensor) => tensor.dtype(),
+            NdArrayTensorInt::U16(tensor) => tensor.dtype(),
+            NdArrayTensorInt::U8(tensor) => tensor.dtype(),
+        }
+
+    }
+
+    fn shape(&self) -> Shape {
+        match self {
+            NdArrayTensorInt::I64(tensor) => tensor.shape(),
+            NdArrayTensorInt::I32(tensor) => tensor.shape(),
+            NdArrayTensorInt::I16(tensor) => tensor.shape(),
+            NdArrayTensorInt::I8(tensor) => tensor.shape(),
+            NdArrayTensorInt::U64(tensor) => tensor.shape(),
+            NdArrayTensorInt::U32(tensor) => tensor.shape(),
+            NdArrayTensorInt::U16(tensor) => tensor.shape(),
+            NdArrayTensorInt::U8(tensor) => tensor.shape(),
+        }
+    }
+}
+
+/// Macro to create a new [int tensor](NdArrayIntTensor) based on the element type.
+#[macro_export]
+macro_rules! new_tensor_int {
+    // Op executed with default dtype
+    ($tensor:expr) => {{
+        match E::dtype() {
+            burn_tensor::DType::I64 => $crate::NdArrayTensorFloat::I64($tensor),
+            burn_tensor::DType::I32 => $crate::NdArrayTensorFloat::I32($tensor),
+            burn_tensor::DType::I16 => $crate::NdArrayTensorFloat::I16($tensor),
+            burn_tensor::DType::I8 => $crate::NdArrayTensorFloat::I8($tensor),
+            burn_tensor::DType::U64 => $crate::NdArrayTensorFloat::U64($tensor),
+            burn_tensor::DType::U32 => $crate::NdArrayTensorFloat::U32($tensor),
+            burn_tensor::DType::U16 => $crate::NdArrayTensorFloat::U16($tensor),
+            burn_tensor::DType::U8 => $crate::NdArrayTensorFloat::U8($tensor),
+            _ => unimplemented!("Unsupported dtype"),
+        }
+    }};
+}
+
+
+/// Macro to execute an operation a given element type.
+///
+/// # Panics
+/// Since there is no automatic type cast at this time, binary operations for different
+/// floating point precision data types will panic with a data type mismatch.
+#[macro_export]
+macro_rules! execute_with_int_dtype {
+    // Binary op: type automatically inferred by the compiler
+    (($lhs:expr, $rhs:expr), $op:expr) => {{
+        let lhs_dtype = burn_tensor::TensorMetadata::dtype(&$lhs);
+        let rhs_dtype = burn_tensor::TensorMetadata::dtype(&$rhs);
+        match ($lhs, $rhs) {
+            ($crate::NdArrayTensorInt::I64(lhs), $crate::NdArrayTensorInt::I64(rhs)) => {
+                $crate::NdArrayTensorInt::I64($op(lhs, rhs))
+            }
+            ($crate::NdArrayTensorInt::I32(lhs), $crate::NdArrayTensorInt::I32(rhs)) => {
+                $crate::NdArrayTensorInt::I32($op(lhs, rhs))
+            }
+            ($crate::NdArrayTensorInt::I16(lhs), $crate::NdArrayTensorInt::I16(rhs)) => {
+                $crate::NdArrayTensorInt::I16($op(lhs, rhs))
+            }
+            ($crate::NdArrayTensorInt::I8(lhs), $crate::NdArrayTensorInt::I8(rhs)) => {
+                $crate::NdArrayTensorInt::I8($op(lhs, rhs))
+            }
+            ($crate::NdArrayTensorInt::U64(lhs), $crate::NdArrayTensorInt::U64(rhs)) => {
+                $crate::NdArrayTensorInt::U64($op(lhs, rhs))
+            }
+            ($crate::NdArrayTensorInt::U32(lhs), $crate::NdArrayTensorInt::U32(rhs)) => {
+                $crate::NdArrayTensorInt::U32($op(lhs, rhs))
+            }
+            ($crate::NdArrayTensorInt::U16(lhs), $crate::NdArrayTensorInt::U16(rhs)) => {
+                $crate::NdArrayTensorInt::U16($op(lhs, rhs))
+            }
+            ($crate::NdArrayTensorInt::U8(lhs), $crate::NdArrayTensorInt::U8(rhs)) => {
+                $crate::NdArrayTensorInt::U8($op(lhs, rhs))
+            }
+            _ => panic!(
+                "Data type mismatch (lhs: {:?}, rhs: {:?})",
+                lhs_dtype, rhs_dtype
+            ),
+        }
+    }};
+
+    // Binary op: generic type cannot be inferred for an operation
+    (($lhs:expr, $rhs:expr), $element:ident, $op:expr) => {{
+        let lhs_dtype = burn_tensor::TensorMetadata::dtype(&$lhs);
+        let rhs_dtype = burn_tensor::TensorMetadata::dtype(&$rhs);
+        match ($lhs, $rhs) {
+            ($crate::NdArrayTensorInt::I64(lhs), $crate::NdArrayTensorInt::I64(rhs)) => {
+                type $element = i64;
+                $crate::NdArrayTensorInt::I64($op(lhs, rhs))
+            }
+            ($crate::NdArrayTensorInt::I32(lhs), $crate::NdArrayTensorInt::I32(rhs)) => {
+                type $element = i32;
+                $crate::NdArrayTensorInt::I32($op(lhs, rhs))
+            }
+            ($crate::NdArrayTensorInt::I16(lhs), $crate::NdArrayTensorInt::I16(rhs)) => {
+                type $element = i16;
+                $crate::NdArrayTensorInt::I16($op(lhs, rhs))
+            }
+            ($crate::NdArrayTensorInt::I8(lhs), $crate::NdArrayTensorInt::I8(rhs)) => {
+                type $element = i8;
+                $crate::NdArrayTensorInt::I8($op(lhs, rhs))
+            }
+            ($crate::NdArrayTensorInt::U64(lhs), $crate::NdArrayTensorInt::U64(rhs)) => {
+                type $element = u64;
+                $crate::NdArrayTensorInt::U64($op(lhs, rhs))
+            }
+            ($crate::NdArrayTensorInt::U32(lhs), $crate::NdArrayTensorInt::U32(rhs)) => {
+                type $element = u32;
+                  $crate::NdArrayTensorInt::U32($op(lhs, rhs))
+            }
+            ($crate::NdArrayTensorInt::U16(lhs), $crate::NdArrayTensorInt::U16(rhs)) => {
+                type $element = u16;
+                $crate::NdArrayTensorInt::U16($op(lhs, rhs))
+            }
+            ($crate::NdArrayTensorInt::U8(lhs), $crate::NdArrayTensorInt::U8(rhs)) => {
+                type $element = u8;
+                $crate::NdArrayTensorInt::U8($op(lhs, rhs))
+            }
+            _ => panic!(
+                "Data type mismatch (lhs: {:?}, rhs: {:?})",
+                lhs_dtype, rhs_dtype
+            ),
+        }
+    }};
+
+    // Binary op: type automatically inferred by the compiler but return type is not a float tensor
+    (($lhs:expr, $rhs:expr) => $op:expr) => {{
+        let lhs_dtype = burn_tensor::TensorMetadata::dtype(&$lhs);
+        let rhs_dtype = burn_tensor::TensorMetadata::dtype(&$rhs);
+        match ($lhs, $rhs) {
+            ($crate::NdArrayTensorInt::I64(lhs), $crate::NdArrayTensorInt::I64(rhs)) => {
+                $op(lhs, rhs)
+            }
+            ($crate::NdArrayTensorInt::I32(lhs), $crate::NdArrayTensorInt::I32(rhs)) => {
+                $op(lhs, rhs)
+            }
+            ($crate::NdArrayTensorInt::I16(lhs), $crate::NdArrayTensorInt::I16(rhs)) => {
+                $op(lhs, rhs)
+            }
+            ($crate::NdArrayTensorInt::I8(lhs), $crate::NdArrayTensorInt::I8(rhs)) => {
+                $op(lhs, rhs)
+            }
+            ($crate::NdArrayTensorInt::U64(lhs), $crate::NdArrayTensorInt::U64(rhs)) => {
+                $op(lhs, rhs)
+            }
+            ($crate::NdArrayTensorInt::U32(lhs), $crate::NdArrayTensorInt::U32(rhs)) => {
+                $op(lhs, rhs)
+            }
+            ($crate::NdArrayTensorInt::U16(lhs), $crate::NdArrayTensorInt::U16(rhs)) => {
+                $op(lhs, rhs)
+            }
+            ($crate::NdArrayTensorInt::U8(lhs), $crate::NdArrayTensorInt::U8(rhs)) {
+                $op(lhs, rhs)
+            }
+            _ => panic!(
+                "Data type mismatch (lhs: {:?}, rhs: {:?})",
+                lhs_dtype, rhs_dtype
+            ),
+        }
+    }};
+
+    // Unary op: type automatically inferred by the compiler
+    ($tensor:expr, $op:expr) => {{
+        match $tensor {
+            $crate::NdArrayIntTensor::I64(tensor) => $crate::NdArrayIntTensor::I64($op(tensor)),
+            $crate::NdArrayIntTensor::I32(tensor) => $crate::NdArrayIntTensor::I32($op(tensor)),
+            $crate::NdArrayIntTensor::I16(tensor) => $crate::NdArrayIntTensor::I16($op(tensor)),
+            $crate::NdArrayIntTensor::I8(tensor) => $crate::NdArrayIntTensor::I8($op(tensor)),
+            $crate::NdArrayIntTensor::U64(tensor) => $crate::NdArrayIntTensor::U64($op(tensor)),
+            $crate::NdArrayIntTensor::U32(tensor) => $crate::NdArrayIntTensor::U32($op(tensor)),
+            $crate::NdArrayIntTensor::U16(tensor) => $crate::NdArrayIntTensor::U16($op(tensor)),
+            $crate::NdArrayIntTensor::U8(tensor) => $crate::NdArrayIntTensor::U8($op(tensor)),
+        }
+    }};
+
+    // Unary op: generic type cannot be inferred for an operation
+    ($tensor:expr, $element:ident, $op:expr) => {{
+        match $tensor {
+            $crate::NdArrayTensorFloat::I64(tensor) => {
+                type $element = i64;
+                $crate::NdArrayTensorFloat::I64($op(tensor))
+            }
+            $crate::NdArrayTensorFloat::I32(tensor) => {
+                type $element = i32;
+                $crate::NdArrayTensorFloat::I32($op(tensor))
+            }
+            $crate::NdArrayTensorFloat::I16(tensor) => {
+                type $element = i16;
+                $crate::NdArrayTensorFloat::I16($op(tensor))
+            }
+            $crate::NdArrayTensorFloat::I8(tensor) => {
+                type $element = i8;
+                $crate::NdArrayTensorFloat::I8($op(tensor))
+            }
+            $crate::NdArrayTensorFloat::U64(tensor) => {
+                type $element = u64;
+                $crate::NdArrayTensorFloat::U64($op(tensor))
+            }
+            $crate::NdArrayTensorFloat::U32(tensor) => {
+                type $element = u32;
+                $crate::NdArrayTensorFloat::U32($op(tensor))
+            }
+            $crate::NdArrayTensorFloat::U16(tensor) => {
+                type $element = u16;
+                $crate::NdArrayTensorFloat::U16($op(tensor))
+            }
+            $crate::NdArrayTensorFloat::U8(tensor) => {
+                type $element = u8;
+                $crate::NdArrayTensorFloat::U8($op(tensor))
+            }
+        }
+    }};
+
+    // Unary op: type automatically inferred by the compiler but return type is not a float tensor
+    ($tensor:expr => $op:expr) => {{
+        match $tensor {
+            $crate::NdArrayTensorInt::I64(tensor) => $op(tensor),
+            $crate::NdArrayTensorInt::I32(tensor) => $op(tensor),
+            $crate::NdArrayTensorInt::I16(tensor) => $op(tensor),
+            $crate::NdArrayTensorInt::I8(tensor) => $op(tensor),
+            $crate::NdArrayTensorInt::U64(tensor) => $op(tensor),
+            $crate::NdArrayTensorInt::U32(tensor) => $op(tensor),
+            $crate::NdArrayTensorInt::U16(tensor) => $op(tensor),
+            $crate::NdArrayTensorInt::U8(tensor) => $op(tensor),
+        }
+    }};
+
+    // Unary op: generic type cannot be inferred for an operation and return type is not a float tensor
+    ($tensor:expr, $element:ident => $op:expr) => {{
+        match $tensor {
+            $crate::NdArrayTensorInt::I64(tensor) => {
+                type $element = i64;
+                $op(tensor)
+            }
+            $crate::NdArrayTensorInt::I32(tensor) => {
+                type $element = i32;
+                $op(tensor)
+            }
+            $crate::NdArrayTensorInt::I16(tensor) => {
+                type $element = i16;
+                $op(tensor)
+            }
+            $crate::NdArrayTensorInt::I8(tensor) => {
+                type $element = i8;
+                $op(tensor)
+            }
+            $crate::NdArrayTensorInt::U64(tensor) => {
+                type $element = u64;
+                $op(tensor)
+            }
+            $crate::NdArrayTensorInt::U32(tensor) => {
+                type $element = u32;
+                $op(tensor)
+            }
+            $crate::NdArrayTensorInt::U16(tensor) => {
+                type $element = u16;
+                $op(tensor)
+            }
+            $crate::NdArrayTensorInt::U8(tensor) => {
+                type $element = u8;
+                $op(tensor)
+            }    
+        }
+
+    }};
+}
+
 mod utils {
     use burn_common::tensor::is_contiguous;
 

--- a/crates/burn-remote/src/client/runner.rs
+++ b/crates/burn-remote/src/client/runner.rs
@@ -63,6 +63,14 @@ impl RunnerClient for WsClient {
         self.register_empty_tensor(shape, DType::F32)
     }
 
+    fn register_int_tensor(
+        &self,
+        shape: Vec<usize>,
+        _dtype: burn_tensor::IntDType,
+    ) -> RouterTensor<Self> {
+        self.register_empty_tensor(shape, DType::I32)
+    }
+
     fn device(&self) -> Self::Device {
         self.device.clone()
     }

--- a/crates/burn-router/src/client/base.rs
+++ b/crates/burn-router/src/client/base.rs
@@ -10,7 +10,7 @@ use spin::Mutex;
 
 use burn_ir::{OperationIr, TensorId, TensorIr};
 use burn_tensor::{
-    DType, FloatDType, TensorData,
+    DType, FloatDType, IntDType, TensorData,
     backend::{DeviceId, DeviceOps},
 };
 
@@ -40,6 +40,8 @@ pub trait RunnerClient: Clone + Send + Sync + Sized {
     fn register_empty_tensor(&self, shape: Vec<usize>, dtype: DType) -> RouterTensor<Self>;
     /// Create a new float [RouterTensor] with no resources associated.
     fn register_float_tensor(&self, shape: Vec<usize>, dtype: FloatDType) -> RouterTensor<Self>;
+    /// Create a new interger [RouterTensor] with no resources associated.
+    fn register_int_tensor(&self, shape: Vec<usize>, dtype: IntDType) -> RouterTensor<Self>;
     /// Get the current device used by all operations handled by this client.
     fn device(&self) -> Self::Device;
     /// Drop the tensor with the given [tensor id](TensorId).

--- a/crates/burn-router/src/ops/op_float.rs
+++ b/crates/burn-router/src/ops/op_float.rs
@@ -1433,7 +1433,6 @@ impl<R: RunnerChannel> FloatTensorOps<Self> for BackendRouter<R> {
         };
 
         client.register(OperationIr::BaseFloat(BaseOperationIr::Cast(desc)));
-
         out
     }
 }

--- a/crates/burn-router/src/ops/op_int.rs
+++ b/crates/burn-router/src/ops/op_int.rs
@@ -1203,6 +1203,19 @@ impl<R: RunnerChannel> IntTensorOps<Self> for BackendRouter<R> {
         out
     }
 
+    fn int_cast(tensor: IntTensor<Self>, dtype: burn_tensor::IntDType) -> IntTensor<Self> {
+        let client = tensor.client.clone();
+        let out = client.register_int_tensor(tensor.shape.clone(), dtype);
+
+        let desc = UnaryOpIr {
+            input: tensor.into_ir(),
+            out: out.to_ir_out(),
+        };
+
+        client.register(OperationIr::BaseInt(BaseOperationIr::Cast(desc)));
+        out
+    }
+
     fn bitwise_and(lhs: IntTensor<Self>, rhs: IntTensor<Self>) -> IntTensor<Self> {
         let client = lhs.client.clone();
         let dtype = lhs.dtype;

--- a/crates/burn-router/src/runner.rs
+++ b/crates/burn-router/src/runner.rs
@@ -4,7 +4,7 @@ use burn_ir::{
     BackendIr, BaseOperationIr, BoolOperationIr, FloatOperationIr, HandleContainer, IntOperationIr,
     ModuleOperationIr, NumericOperationIr, OperationIr, TensorId, TensorIr, TensorStatus,
 };
-use burn_tensor::{DType, ElementConversion, FloatDType, Shape, TensorData, backend::Backend};
+use burn_tensor::{DType, ElementConversion, FloatDType, IntDType, Shape, TensorData, backend::Backend};
 
 use super::{RouterTensor, RunnerClient};
 use crate::{
@@ -148,6 +148,15 @@ impl<B: BackendIr> Runner<B> {
         &self,
         shape: Vec<usize>,
         dtype: FloatDType,
+    ) -> TensorIr {
+        self.register_empty_tensor_desc(shape, dtype.into())
+    }
+
+
+    pub(crate) fn register_int_tensor_desc(
+        &self,
+        shape: Vec<usize>,
+        dtype: IntDType,
     ) -> TensorIr {
         self.register_empty_tensor_desc(shape, dtype.into())
     }
@@ -1268,6 +1277,11 @@ impl<B: BackendIr> RunnerClient for Runner<B> {
 
     fn register_float_tensor(&self, shape: Vec<usize>, dtype: FloatDType) -> RouterTensor<Self> {
         let desc = self.register_float_tensor_desc(shape, dtype);
+        RouterTensor::new(Arc::new(desc.id), desc.shape, desc.dtype, self.clone())
+    }
+
+    fn register_int_tensor(&self, shape: Vec<usize>, dtype: burn_tensor::IntDType) -> RouterTensor<Self> {
+        let desc = self.register_int_tensor_desc(shape, dtype);
         RouterTensor::new(Arc::new(desc.id), desc.shape, desc.dtype, self.clone())
     }
 

--- a/crates/burn-router/src/types.rs
+++ b/crates/burn-router/src/types.rs
@@ -157,6 +157,21 @@ macro_rules! impl_multi_backend_types {
                     }
                 }
 
+                fn register_int_tensor(&self, shape: Vec<usize>, dtype: burn_tensor::IntDType) -> RouterTensor<Self> {
+                    match self {
+                        Self::$DefaultBackend(runner) => {
+                            let desc = runner.register_int_tensor_desc(shape, dtype);
+                            RouterTensor::new(Arc::new(desc.id), desc.shape, desc.dtype, self.clone())
+                        }
+                        $(
+                            Self::$OtherBackend(runner) => {
+                            let desc = runner.register_int_tensor_desc(shape, dtype);
+                                RouterTensor::new(Arc::new(desc.id), desc.shape, desc.dtype, self.clone())
+                            }
+                        )+
+                    }
+                }
+
                 fn device(&self) -> Self::Device {
                     match self {
                         Self::$DefaultBackend(runner) => MultiDevice::$DefaultBackend(runner.device()),

--- a/crates/burn-tch/src/ops/int_tensor.rs
+++ b/crates/burn-tch/src/ops/int_tensor.rs
@@ -1,9 +1,7 @@
 use std::ops::Range;
 
 use burn_tensor::{
-    Distribution, Shape, TensorData, TensorMetadata,
-    backend::Backend,
-    ops::{IntTensor, IntTensorOps},
+    backend::Backend, ops::{IntTensor, IntTensorOps}, DType, Distribution, IntDType, Shape, TensorData, TensorMetadata
 };
 
 use crate::{LibTorch, LibTorchDevice, QuantElement, TchShape, TchTensor, element::TchElement};
@@ -398,6 +396,23 @@ impl<E: TchElement, Q: QuantElement> IntTensorOps<Self> for LibTorch<E, Q> {
 
     fn int_argsort(tensor: IntTensor<Self>, dim: usize, descending: bool) -> IntTensor<Self> {
         TchOps::argsort(tensor, dim, descending)
+    }
+
+    fn int_cast(tensor: TchTensor, dtype: IntDType) -> TchTensor {
+        let kind = match dtype {
+            IntDType::I64 => tch::Kind::Int64,
+            IntDType::I32 => tch::Kind::Int,
+            IntDType::I16 => tch::Kind::Int16,
+            IntDType::I8 => tch::Kind::Int8,
+            IntDType::U8 => tch::Kind::Uint8,
+            _ => unimplemented!("torch doesn't support this dtype: {:?}", dtype),
+        };
+
+        if tensor.tensor.kind() == kind {
+            tensor
+        } else {
+            TchTensor::new(tensor.tensor.to_kind(kind))
+        }
     }
 
     fn bitwise_and(lhs: IntTensor<Self>, rhs: IntTensor<Self>) -> IntTensor<Self> {

--- a/crates/burn-tensor/src/tensor/element/base.rs
+++ b/crates/burn-tensor/src/tensor/element/base.rs
@@ -438,3 +438,47 @@ impl From<FloatDType> for DType {
         }
     }
 }
+
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy)]
+pub enum IntDType {
+    I64,
+    I32,
+    I16,
+    I8,
+    U64,
+    U32,
+    U16,
+    U8,
+}
+
+impl From<DType> for IntDType {
+    fn from(value: DType) -> Self {
+        match value {
+            DType::I8 => IntDType::I8,
+            DType::I16 => IntDType::I16,
+            DType::I32 => IntDType::I32,
+            DType::I64 => IntDType::I64,
+            DType::U8 => IntDType::U8,
+            DType::U16 => IntDType::U16,
+            DType::U32 => IntDType::U32,
+            DType::U64 => IntDType::U64,
+            _ => panic!("Expected int data type, got {value:?}"),
+        }
+    }
+}
+
+impl From<IntDType> for DType {
+    fn from(value: IntDType) -> Self {
+        match value {
+            IntDType::I8 => DType::I8,
+            IntDType::I16 => DType::I16,
+            IntDType::I32 => DType::I32,
+            IntDType::I64 => DType::I64,
+            IntDType::U8 => DType::U8,
+            IntDType::U16 => DType::U16,
+            IntDType::U32 => DType::U32,
+            IntDType::U64 => DType::U64,
+        }
+    }
+}

--- a/crates/burn-tensor/src/tensor/ops/int_tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/int_tensor.rs
@@ -2,7 +2,7 @@ use super::cat::cat_with_slice_assign;
 use super::repeat_dim::repeat_with_slice_assign;
 use super::{BoolTensor, Device, FloatTensor, IntElem, IntTensor};
 use crate::{Distribution, ElementConversion, Int, TensorData, backend::Backend, tensor::Shape};
-use crate::{TensorMetadata, argsort, sort, sort_with_indices};
+use crate::{IntDType, TensorMetadata, argsort, sort, sort_with_indices};
 use alloc::vec::Vec;
 use core::ops::Range;
 
@@ -379,6 +379,18 @@ pub trait IntTensorOps<B: Backend> {
     ///
     /// The boolean tensor with the result of the comparison.
     fn int_lower_equal_elem(lhs: IntTensor<B>, rhs: IntElem<B>) -> BoolTensor<B>;
+
+    /// Converts a tensor to another integer point data type.
+    ///
+    /// # Arguments
+    ///
+    /// * `tensor` - The tensor to convert.
+    /// * `dtype` - The target data type.
+    ///
+    /// # Returns
+    ///
+    /// A tensor with the same values as `tensor` but in the target integer data type.
+    fn int_cast(tensor: IntTensor<B>, dtype: IntDType) -> IntTensor<B>;
 
     // ====  NUMERIC ==== //
 


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Changes

As my project is blocked by both #3262 and a TensorFlow-generated ONNX issue, I decided to try implementing this feature.

My implementation is based on the existing float_cast function, so things might be different for integer ones. It is pretty much a work in progress, so there might be errors, and I look forward to receiving any feedback.

Regarding the current state of the implementation, I have added 'int_cast' to all backends, but I am struggling to implement it for the ndarray backend.
I have added the implementation of IntNdArrayElement (crates/burn-ndarray/src/element.rs), but since all uxx are unsigned, it errors with:
```
the trait bound `u64: Signed` is not satisfied
the following other types implement trait `Signed`:
  f32
  f64
  i128
  i16
  i32
  i64
  i8
  isize
```
And the Sized trait cannot be removed since it produce other errors for `IntTensorOps`.

I also get this error for all usage of `execute_with_int_dtype` and I don't understand it because the conversion between `NdArrayTensor<I>` to `NdArrayTensorInt` is implemented.
```
error[E0308]: mismatched types
   --> crates\burn-ndarray\src\tensor.rs:312:14
    |
311 |           match ($lhs, $rhs) {
    |                 ------------ this expression has type `(tensor::NdArrayTensor<I>, tensor::NdArrayTensor<I>)`
312 |               ($crate::NdArrayTensorInt::I64(lhs), $crate::NdArrayTensorInt::I64(rhs)) => {
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `NdArrayTensor<I>`, found `NdArrayTensorInt`
    |
   ::: crates\burn-ndarray\src\ops\int_tensor.rs:74:9
    |
74  | /         execute_with_int_dtype!((tensor, source), |tensor, source| {
75  | |             NdArrayMathOps::mask_where(tensor, mask, source)
76  | |         })
    | |__________- in this macro invocation
    |
    = note: expected struct `tensor::NdArrayTensor<I>`
                 found enum `tensor::NdArrayTensorInt`
    = note: this error originates in the macro `execute_with_int_dtype` (in Nightly builds, run with -Z macro-backtrace for more info)
```


I also noticed some inconsistencies in the file naming conventions between the backends. For example, in the ndarray backend it is named `int_tensor.rs`, whereas in cubecl it's `int_ops.rs`.
What about unifying the naming?


### Testing

Do I need to run tests for each backend, and where?