### PR TITLE
Fix error messages from tensor checks for flatten

### DIFF
--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -304,7 +304,9 @@ impl TensorCheck {
         if D2 > D1 {
             check = check.register(
                 "Flatten",
-                TensorError::new(format!("Result dim ({D2}) must be smaller than or equal to ({D1})")),
+                TensorError::new(format!(
+                    "Result dim ({D2}) must be smaller than or equal to ({D1})"
+                )),
             );
         }
 

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -296,7 +296,7 @@ impl TensorCheck {
             check = check.register(
                 "Flatten",
                 TensorError::new(format!(
-                    "The start dim ({start_dim}) must be smaller than the end dim ({end_dim})"
+                    "The start dim ({start_dim}) must be smaller than or equal to the end dim ({end_dim})"
                 )),
             );
         }
@@ -304,7 +304,7 @@ impl TensorCheck {
         if D2 > D1 {
             check = check.register(
                 "Flatten",
-                TensorError::new(format!("Result dim ({D2}) must be smaller than ({D1})")),
+                TensorError::new(format!("Result dim ({D2}) must be smaller than or equal to ({D1})")),
             );
         }
 
@@ -312,7 +312,7 @@ impl TensorCheck {
             check = check.register(
                 "Flatten",
                 TensorError::new(format!(
-                    "The end dim ({end_dim}) must be greater than the tensor dim ({D2})"
+                    "The end dim ({end_dim}) must be smaller than the tensor dim ({D1})"
                 )),
             );
         }


### PR DESCRIPTION
Description:
This pull request fixes error messages for `flatten` operation when its tensor checks failed so that the provided messages are compatible with the desired conditions and thus avoid creating confusion. No functional changes were made by this PR.