### PR TITLE
Fix cargo run checks usage

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,3 @@
 [alias]
 xtask = "run --target-dir target/xtask --color always --package xtask --bin xtask --"
-run-checks = "xtask -c all validate"
+run-checks = "xtask -c all validate --release"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,3 @@
 [alias]
 xtask = "run --target-dir target/xtask --color always --package xtask --bin xtask --"
-run-checks = "xtask -E all validate"
+run-checks = "xtask -c all validate"


### PR DESCRIPTION
Update the `cargo run-checks` alias usage for new xtask version (changed in #3307)