### PR TITLE
Fix tui label placement

### DIFF
--- a/crates/burn-train/src/renderer/tui/metric_numeric.rs
+++ b/crates/burn-train/src/renderer/tui/metric_numeric.rs
@@ -6,7 +6,7 @@ use ratatui::{
     prelude::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style, Stylize},
     text::Line,
-    widgets::{Axis, Block, Borders, Chart, Paragraph, Tabs},
+    widgets::{Axis, Block, Borders, Chart, LegendPosition, Paragraph, Tabs},
 };
 use std::collections::HashMap;
 
@@ -173,6 +173,7 @@ impl NumericMetricsState {
                     .labels(axes.labels_y.clone().into_iter().map(|s| s.bold()))
                     .bounds(axes.bounds_y),
             )
+            .legend_position(Some(LegendPosition::Right))
     }
 }
 


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed. (loads of formatting issues, not sure why?)
- [x] Made sure the book is up to date with changes in this PR.

### Changes

Fixes a minor pet peeve of mine where the plot is being updated behind the legend
Another pet peeve of mine is the validation plot being only one line going across
I'll try to fix that next unless there are objections

### Testing

before
![1750948751_grim](https://github.com/user-attachments/assets/38cdc0ed-7566-4ca5-bc92-84393c719207)
after
![1751035167_grim](https://github.com/user-attachments/assets/e84f64c1-56f2-4e53-8d1d-d86d81f0e01e)

