### PR TITLE
Remove hip os cfg flags

### DIFF
--- a/crates/burn-tensor/src/lib.rs
+++ b/crates/burn-tensor/src/lib.rs
@@ -90,7 +90,6 @@ mod cube_cuda {
     }
 }
 
-#[cfg(target_os = "linux")]
 #[cfg(feature = "cubecl-hip")]
 mod cube_hip {
     use crate::backend::{DeviceId, DeviceOps};


### PR DESCRIPTION
Following the changes in `cubecl-hip` https://github.com/tracel-ai/cubecl-hip/commit/125d16db1ab76421f4ad9ee13d6c27bfca1cc4f6

As pointed out by a user [on discord](https://discord.com/channels/1038839012602941528/1091796857996451942/1389487311468756992).
