### PR TITLE
Update default strides in `AvgPool1dConfig`, `AvgPool2dConfig`, `MaxPool1dConfig`, and `MaxPool2dConfig` to match kernel sizes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,6 +597,7 @@ dependencies = [
  "rand 0.9.1",
  "regex",
  "rmp-serde",
+ "rstest",
  "serde",
  "serde_json",
  "spin 0.10.0",

--- a/crates/burn-core/Cargo.toml
+++ b/crates/burn-core/Cargo.toml
@@ -130,7 +130,7 @@ burn-autodiff = { path = "../burn-autodiff", version = "0.18.0" }
 burn-dataset = { path = "../burn-dataset", version = "0.18.0", features = [
     "fake",
 ] }
-rstest = "0.25.0"
+rstest = { workspace = true }
 
 [package.metadata.docs.rs]
 features = ["doc"]

--- a/crates/burn-core/Cargo.toml
+++ b/crates/burn-core/Cargo.toml
@@ -130,6 +130,7 @@ burn-autodiff = { path = "../burn-autodiff", version = "0.18.0" }
 burn-dataset = { path = "../burn-dataset", version = "0.18.0", features = [
     "fake",
 ] }
+rstest = "0.25.0"
 
 [package.metadata.docs.rs]
 features = ["doc"]

--- a/crates/burn-core/src/nn/pool/avg_pool1d.rs
+++ b/crates/burn-core/src/nn/pool/avg_pool1d.rs
@@ -16,7 +16,7 @@ pub struct AvgPool1dConfig {
     /// The size of the kernel.
     pub kernel_size: usize,
     /// The stride.
-    #[config(default = "1")]
+    #[config(default = "kernel_size")]
     pub stride: usize,
     /// The padding configuration.
     ///
@@ -114,6 +114,7 @@ impl AvgPool1d {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
     #[test]
     #[should_panic = "Same padding with an even kernel size is not supported"]
@@ -128,8 +129,21 @@ mod tests {
         let layer = config.init();
 
         assert_eq!(
-            alloc::format!("{}", layer),
-            "AvgPool1d {kernel_size: 3, stride: 1, padding: Valid, count_include_pad: true}"
+            alloc::format!("{layer}"),
+            "AvgPool1d {kernel_size: 3, stride: 3, padding: Valid, count_include_pad: true}"
+        );
+    }
+
+    #[rstest]
+    #[case(1)]
+    #[case(2)]
+    fn default_strides_match_kernel_size(#[case] kernel_size: usize) {
+        let config = AvgPool1dConfig::new(kernel_size);
+
+        assert_eq!(
+            config.stride, kernel_size,
+            "Expected stride ({:?}) to match kernel size ({:?}) in default AvgPool1dConfig::new constructor",
+            config.stride, config.kernel_size
         );
     }
 }

--- a/crates/burn-core/src/nn/pool/avg_pool2d.rs
+++ b/crates/burn-core/src/nn/pool/avg_pool2d.rs
@@ -16,7 +16,7 @@ pub struct AvgPool2dConfig {
     /// The size of the kernel.
     pub kernel_size: [usize; 2],
     /// The strides.
-    #[config(default = "[1, 1]")]
+    #[config(default = "kernel_size")]
     pub strides: [usize; 2],
     /// The padding configuration.
     ///
@@ -114,6 +114,7 @@ impl AvgPool2d {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
     #[test]
     #[should_panic = "Same padding with an even kernel size is not supported"]
@@ -129,8 +130,21 @@ mod tests {
         let layer = config.init();
 
         assert_eq!(
-            alloc::format!("{}", layer),
-            "AvgPool2d {kernel_size: [3, 3], stride: [1, 1], padding: Valid, count_include_pad: true}"
+            alloc::format!("{layer}"),
+            "AvgPool2d {kernel_size: [3, 3], stride: [3, 3], padding: Valid, count_include_pad: true}"
+        );
+    }
+
+    #[rstest]
+    #[case([2, 2])]
+    #[case([1, 2])]
+    fn default_strides_match_kernel_size(#[case] kernel_size: [usize; 2]) {
+        let config = AvgPool2dConfig::new(kernel_size);
+
+        assert_eq!(
+            config.strides, kernel_size,
+            "Expected strides ({:?}) to match kernel size ({:?}) in default AvgPool2dConfig::new constructor",
+            config.strides, config.kernel_size
         );
     }
 }

--- a/crates/burn-core/src/nn/pool/max_pool1d.rs
+++ b/crates/burn-core/src/nn/pool/max_pool1d.rs
@@ -16,7 +16,7 @@ pub struct MaxPool1dConfig {
     /// The size of the kernel.
     pub kernel_size: usize,
     /// The stride.
-    #[config(default = "1")]
+    #[config(default = "kernel_size")]
     pub stride: usize,
     /// The padding configuration.
     ///
@@ -100,6 +100,7 @@ impl MaxPool1d {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
     #[test]
     #[should_panic = "Same padding with an even kernel size is not supported"]
@@ -115,8 +116,21 @@ mod tests {
         let layer = config.init();
 
         assert_eq!(
-            alloc::format!("{}", layer),
-            "MaxPool1d {kernel_size: 3, stride: 1, padding: Valid, dilation: 1}"
+            alloc::format!("{layer}"),
+            "MaxPool1d {kernel_size: 3, stride: 3, padding: Valid, dilation: 1}"
+        );
+    }
+
+    #[rstest]
+    #[case(1)]
+    #[case(2)]
+    fn default_strides_match_kernel_size(#[case] kernel_size: usize) {
+        let config = MaxPool1dConfig::new(kernel_size);
+
+        assert_eq!(
+            config.stride, kernel_size,
+            "Expected stride ({:?}) to match kernel size ({:?}) in default MaxPool1dConfig::new constructor",
+            config.stride, config.kernel_size
         );
     }
 }

--- a/crates/burn-core/src/nn/pool/max_pool2d.rs
+++ b/crates/burn-core/src/nn/pool/max_pool2d.rs
@@ -16,7 +16,7 @@ pub struct MaxPool2dConfig {
     /// The size of the kernel.
     pub kernel_size: [usize; 2],
     /// The strides.
-    #[config(default = "[1, 1]")]
+    #[config(default = "kernel_size")]
     pub strides: [usize; 2],
     /// The padding configuration.
     ///
@@ -100,6 +100,7 @@ impl MaxPool2d {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
     #[test]
     #[should_panic = "Same padding with an even kernel size is not supported"]
@@ -116,7 +117,20 @@ mod tests {
 
         assert_eq!(
             alloc::format!("{}", layer),
-            "MaxPool2d {kernel_size: [3, 3], stride: [1, 1], padding: Valid, dilation: [1, 1]}"
+            "MaxPool2d {kernel_size: [3, 3], stride: [3, 3], padding: Valid, dilation: [1, 1]}"
+        );
+    }
+
+    #[rstest]
+    #[case([2, 2])]
+    #[case([1, 2])]
+    fn default_strides_match_kernel_size(#[case] kernel_size: [usize; 2]) {
+        let config = MaxPool2dConfig::new(kernel_size);
+
+        assert_eq!(
+            config.strides, kernel_size,
+            "Expected strides ({:?}) to match kernel size ({:?}) in default MaxPool2dConfig::new constructor",
+            config.strides, config.kernel_size
         );
     }
 }

--- a/crates/burn-no-std-tests/src/conv.rs
+++ b/crates/burn-no-std-tests/src/conv.rs
@@ -27,6 +27,7 @@ impl<B: Backend> ConvBlock<B> {
             .with_padding(nn::PaddingConfig2d::Same)
             .init(device);
         let pool = nn::pool::MaxPool2dConfig::new(config.kernel_size)
+            .with_strides([1, 1])
             .with_padding(nn::PaddingConfig2d::Same)
             .init();
         let activation = nn::Gelu::new();


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.


### Related Issues/PRs

Fixes #663

### Changes

- Updated the constructor of `MaxPool2dConfig` to set the default strides equal to the kernel size.
- This ensures that Burn’s behavior mirrors PyTorch’s default stride behavior, which prevents unexpected output shape mismatches.
- Previously, Burn used `[1, 1]` as default strides, resulting in inconsistent behavior with common frameworks.
- This is a breaking change that should be included before the next release to avoid propagating invalid assumptions.

 ### Testing

- Added unit test `default_strides_match_kernel_size` using `rstest`, verifying that default strides match kernel size.
- Tested with multiple kernel shapes including `[2, 2]` and `[1, 2]`.
- Ran `RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Zmacro-backtrace" cargo run-checks` , Encountered a panic in `tests::memory_checks::test_memory_leaks` originating from `burn-fusion`, which persisted after reverting this PR—confirming it is a preexisting upstream issue:

==== Fusion Memory Report ====
 - Handles: 0
 - Streams: 1
 - StreamId(6279463968646665849) => operations: 0 cursor: 2220
 
==============================

