### PR TITLE
Move impl<T> Adaptor<()> for T to metrics/base.rs

### DIFF
--- a/crates/burn-train/src/metric/base.rs
+++ b/crates/burn-train/src/metric/base.rs
@@ -69,6 +69,10 @@ pub trait Adaptor<T> {
     fn adapt(&self) -> T;
 }
 
+impl<T> Adaptor<()> for T {
+    fn adapt(&self) {}
+}
+
 /// Declare a metric to be numeric.
 ///
 /// This is useful to plot the values of a metric during training.

--- a/crates/burn-train/src/metric/cuda.rs
+++ b/crates/burn-train/src/metric/cuda.rs
@@ -1,4 +1,4 @@
-use super::{Adaptor, MetricMetadata};
+use super::MetricMetadata;
 use crate::metric::{Metric, MetricEntry};
 use nvml_wrapper::Nvml;
 
@@ -23,10 +23,6 @@ impl Default for CudaMetric {
     fn default() -> Self {
         Self::new()
     }
-}
-
-impl<T> Adaptor<()> for T {
-    fn adapt(&self) {}
 }
 
 impl Metric for CudaMetric {


### PR DESCRIPTION
metric::cuda is only included if the "sys-metrics" is enabled. However, this impl does not rely on cuda, as is useful more generally. In particular, this allows registering LearningRateMetric even when burn's "metric" feature is not enabled.

## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Testing

Besides `cargo run-checks`, I checked that after this change, I can use `LearnerBuilder::metric_train_numeric(LearningRateMetric::new())` without requiring the "metrics" feature.
