### PR TITLE
Make metric order consistent in summaries

### DIFF
--- a/crates/burn-train/src/learner/builder.rs
+++ b/crates/burn-train/src/learner/builder.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -57,7 +57,8 @@ where
     num_loggers: usize,
     checkpointer_strategy: Box<dyn CheckpointingStrategy>,
     early_stopping: Option<Box<dyn EarlyStoppingStrategy>>,
-    summary_metrics: HashSet<String>,
+    // Use BTreeSet instead of HashSet for consistent (alphabetical) iteration order
+    summary_metrics: BTreeSet<String>,
     summary: bool,
 }
 
@@ -105,7 +106,7 @@ where
                     .build(),
             ),
             early_stopping: None,
-            summary_metrics: HashSet::new(),
+            summary_metrics: BTreeSet::new(),
             summary: false,
         }
     }


### PR DESCRIPTION
The order in which metrics are displayed in summaries is arbitrary and changes each time. It's not a huge deal, but it's annoying when comparing the results, as you need to scan to find matching lines.

For instance for two identical trainings:

```
| Split | Metric        | Min.     | Epoch    | Max.     | Epoch    |
|-------|---------------|----------|----------|----------|----------|
| Train | Loss          | 0.520    | 3        | 0.552    | 1        |
| Train | Learning Rate | 2.052e-5 | 3        | 2.793e-4 | 1        |
| Train | Accuracy      | 71.711   | 1        | 76.197   | 3        |
| Valid | Loss          | 0.465    | 3        | 0.469    | 1        |
| Valid | Accuracy      | 77.747   | 1        | 78.306   | 3        |
```

Then another identical run:

```
| Split | Metric        | Min.     | Epoch    | Max.     | Epoch    |
|-------|---------------|----------|----------|----------|----------|
| Train | Accuracy      | 68.341   | 1        | 72.558   | 3        |
| Train | Loss          | 0.572    | 3        | 0.602    | 1        |
| Train | Learning Rate | 2.049e-5 | 3        | 2.792e-4 | 1        |
| Valid | Accuracy      | 76.086   | 2        | 76.171   | 3        |
| Valid | Loss          | 0.527    | 3        | 0.532    | 1        |
```

The root cause is that HashSet does not guarantee a consistent iteration order, and it actually varies across runs, even with identical data. I just swapped it for BTreeSet. This guarantees increasing order of iteration every time.

```
| Split | Metric        | Min.     | Epoch    | Max.     | Epoch    |
|-------|---------------|----------|----------|----------|----------|
| Train | Accuracy      | 68.403   | 1        | 72.555   | 3        |
| Train | Learning Rate | 2.049e-5 | 3        | 2.792e-4 | 1        |
| Train | Loss          | 0.572    | 3        | 0.602    | 1        |
| Valid | Accuracy      | 76.080   | 2        | 76.204   | 3        |
| Valid | Loss          | 0.527    | 3        | 0.532    | 1        |
```