### PR TITLE
feat(onnx-tests): support flexible backend selection for import tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4731,8 +4731,10 @@ name = "onnx-tests"
 version = "0.18.0"
 dependencies = [
  "burn",
+ "burn-autodiff",
  "burn-import",
  "burn-ndarray",
+ "burn-wgpu",
  "float-cmp",
  "serde",
 ]

--- a/crates/burn-import/onnx-tests/Cargo.toml
+++ b/crates/burn-import/onnx-tests/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+backend-autodiff-wgpu = ["burn-autodiff", "burn-wgpu"]
+
 [dev-dependencies]
 burn = { path = "../../burn" }
 burn-ndarray = { path = "../../burn-ndarray" }
@@ -12,3 +15,7 @@ float-cmp = { workspace = true }
 
 [build-dependencies]
 burn-import = { path = "../" }
+
+[dependencies]
+burn-autodiff = { path = "../../burn-autodiff", version = "0.18.0", default-features = false, optional = true }
+burn-wgpu = { path = "../../burn-wgpu", version = "0.18.0", optional = true, default-features = false }

--- a/crates/burn-import/onnx-tests/README.md
+++ b/crates/burn-import/onnx-tests/README.md
@@ -230,11 +230,25 @@ Run all tests with:
 ```sh
 cargo test
 ```
+This command runs all tests using the default backend: `burn_ndarray::NdArray<f32>`.
+
+To run tests with an alternative backend (e.g. `burn_autodiff::Autodiff<burn_wgpu::Wgpu>`), use:
+```
+cargo test --features backend-autodiff-wgpu
+```
+Currently supported backends:
+*	`burn_ndarray::NdArray<f32> (default)`
+*	`burn_autodiff::Autodiff<burn_wgpu::Wgpu>`
 
 Run tests for a specific operator with:
 
 ```sh
 cargo test --test test_mod my_new_op::test_my_new_op
+```
+
+Run a specific test with a selected backend:
+```
+cargo test --test test_mod my_new_op::test_my_new_op --features backend-autodiff-wgpu
 ```
 
 ## Debugging Failed Tests

--- a/crates/burn-import/onnx-tests/tests/add/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/add/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Int, Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn add_scalar_to_tensor_and_tensor_to_tensor() {

--- a/crates/burn-import/onnx-tests/tests/and/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/and/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Bool, Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn and() {

--- a/crates/burn-import/onnx-tests/tests/argmax/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/argmax/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn argmax() {

--- a/crates/burn-import/onnx-tests/tests/argmin/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/argmin/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn argmin() {

--- a/crates/burn-import/onnx-tests/tests/avg_pool/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/avg_pool/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Shape, Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     type FT = FloatElem<Backend>;
 
     #[test]

--- a/crates/burn-import/onnx-tests/tests/backend.rs
+++ b/crates/burn-import/onnx-tests/tests/backend.rs
@@ -1,0 +1,5 @@
+#[cfg(feature = "backend-autodiff-wgpu")]
+pub type Backend = burn_autodiff::Autodiff<burn_wgpu::Wgpu>;
+
+#[cfg(not(feature = "backend-autodiff-wgpu"))]
+pub type Backend = burn_ndarray::NdArray<f32>;

--- a/crates/burn-import/onnx-tests/tests/batch_norm/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/batch_norm/mod.rs
@@ -8,7 +8,7 @@ mod tests {
     use burn::tensor::{Shape, Tensor};
     use float_cmp::ApproxEq;
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn batch_norm() {

--- a/crates/burn-import/onnx-tests/tests/cast/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/cast/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Bool, Int, Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     type FT = FloatElem<Backend>;
 
     #[test]

--- a/crates/burn-import/onnx-tests/tests/ceil/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/ceil/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, ops::FloatElem};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     type FT = FloatElem<Backend>;
 
     #[test]

--- a/crates/burn-import/onnx-tests/tests/clip/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/clip/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn clip() {

--- a/crates/burn-import/onnx-tests/tests/concat/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/concat/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Shape, Tensor};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn concat_tensors() {

--- a/crates/burn-import/onnx-tests/tests/constant/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/constant/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Int, Shape, Tensor};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn add_constant_f32() {

--- a/crates/burn-import/onnx-tests/tests/constant_of_shape/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/constant_of_shape/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Int, Tensor, Tolerance, ops::FloatElem};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     type FT = FloatElem<Backend>;
 
     #[test]

--- a/crates/burn-import/onnx-tests/tests/conv/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/conv/mod.rs
@@ -9,7 +9,7 @@ mod tests {
     use core::f64::consts;
     use float_cmp::ApproxEq;
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn conv1d() {

--- a/crates/burn-import/onnx-tests/tests/conv_transpose/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/conv_transpose/mod.rs
@@ -8,7 +8,7 @@ mod tests {
     use burn::tensor::{Shape, Tensor};
     use float_cmp::ApproxEq;
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn conv_transpose1d() {

--- a/crates/burn-import/onnx-tests/tests/cos/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/cos/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     type FT = FloatElem<Backend>;
 
     #[test]

--- a/crates/burn-import/onnx-tests/tests/cosh/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/cosh/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     type FT = FloatElem<Backend>;
 
     #[test]

--- a/crates/burn-import/onnx-tests/tests/depth_to_space/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/depth_to_space/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     type FT = FloatElem<Backend>;
 
     #[test]

--- a/crates/burn-import/onnx-tests/tests/div/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/div/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn div_tensor_by_scalar_and_tensor_by_tensor() {

--- a/crates/burn-import/onnx-tests/tests/dropout/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/dropout/mod.rs
@@ -8,7 +8,7 @@ mod tests {
     use burn::tensor::{Shape, Tensor};
     use float_cmp::ApproxEq;
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn dropout() {

--- a/crates/burn-import/onnx-tests/tests/equal/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/equal/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn equal_scalar_to_scalar_and_tensor_to_tensor() {

--- a/crates/burn-import/onnx-tests/tests/erf/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/erf/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, Tolerance, ops::FloatElem};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     type FT = FloatElem<Backend>;
 
     #[test]

--- a/crates/burn-import/onnx-tests/tests/exp/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/exp/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     type FT = FloatElem<Backend>;
 
     #[test]

--- a/crates/burn-import/onnx-tests/tests/expand/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/expand/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Int, Shape, Tensor};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn expand() {

--- a/crates/burn-import/onnx-tests/tests/flatten/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/flatten/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Shape, Tensor};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn flatten() {

--- a/crates/burn-import/onnx-tests/tests/floor/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/floor/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, ops::FloatElem};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     type FT = FloatElem<Backend>;
 
     #[test]

--- a/crates/burn-import/onnx-tests/tests/gather/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/gather/mod.rs
@@ -14,7 +14,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Int, Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn gather_1d_idx() {

--- a/crates/burn-import/onnx-tests/tests/gelu/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/gelu/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     type FT = FloatElem<Backend>;
 
     #[test]

--- a/crates/burn-import/onnx-tests/tests/gemm/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/gemm/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn gemm_test() {

--- a/crates/burn-import/onnx-tests/tests/global_avr_pool/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/global_avr_pool/mod.rs
@@ -8,7 +8,7 @@ mod tests {
     use burn::tensor::{Shape, Tensor};
     use float_cmp::ApproxEq;
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn globalavrpool_1d_2d() {

--- a/crates/burn-import/onnx-tests/tests/graph_multiple_output_tracking/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/graph_multiple_output_tracking/mod.rs
@@ -5,7 +5,7 @@ include_models!(graph_multiple_output_tracking);
 mod tests {
     use super::*;
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn graph_multiple_output_tracking() {

--- a/crates/burn-import/onnx-tests/tests/greater/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/greater/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn greater() {

--- a/crates/burn-import/onnx-tests/tests/greater_or_equal/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/greater_or_equal/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn greater_or_equal() {

--- a/crates/burn-import/onnx-tests/tests/group_norm/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/group_norm/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     type FT = FloatElem<Backend>;
 
     #[test]

--- a/crates/burn-import/onnx-tests/tests/hard_sigmoid/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/hard_sigmoid/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, ops::FloatElem};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     type FT = FloatElem<Backend>;
 
     #[test]

--- a/crates/burn-import/onnx-tests/tests/instance_norm/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/instance_norm/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     type FT = FloatElem<Backend>;
 
     #[test]

--- a/crates/burn-import/onnx-tests/tests/layer_norm/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/layer_norm/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     type FT = FloatElem<Backend>;
 
     #[test]

--- a/crates/burn-import/onnx-tests/tests/leaky_relu/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/leaky_relu/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn leaky_relu() {

--- a/crates/burn-import/onnx-tests/tests/less/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/less/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn less() {

--- a/crates/burn-import/onnx-tests/tests/less_or_equal/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/less_or_equal/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn less_or_equal() {

--- a/crates/burn-import/onnx-tests/tests/linear/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/linear/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use burn::tensor::{Shape, Tensor};
     use float_cmp::ApproxEq;
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn linear() {

--- a/crates/burn-import/onnx-tests/tests/log/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/log/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, ops::FloatElem};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     type FT = FloatElem<Backend>;
 
     #[test]

--- a/crates/burn-import/onnx-tests/tests/log_softmax/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/log_softmax/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn log_softmax() {

--- a/crates/burn-import/onnx-tests/tests/mask_where/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/mask_where/mod.rs
@@ -13,7 +13,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn mask_where() {

--- a/crates/burn-import/onnx-tests/tests/matmul/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/matmul/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Int, Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn matmul() {

--- a/crates/burn-import/onnx-tests/tests/max/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/max/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn max() {

--- a/crates/burn-import/onnx-tests/tests/maxpool/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/maxpool/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn maxpool1d() {

--- a/crates/burn-import/onnx-tests/tests/mean/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/mean/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn mean_tensor_and_tensor() {

--- a/crates/burn-import/onnx-tests/tests/min/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/min/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn min() {

--- a/crates/burn-import/onnx-tests/tests/mul/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/mul/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn mul_scalar_with_tensor_and_tensor_with_tensor() {

--- a/crates/burn-import/onnx-tests/tests/neg/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/neg/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     type FT = FloatElem<Backend>;
 
     #[test]

--- a/crates/burn-import/onnx-tests/tests/not/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/not/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Bool, Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn not() {

--- a/crates/burn-import/onnx-tests/tests/one_hot/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/one_hot/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Int, Tensor, TensorData, ops::FloatElem};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     type FT = FloatElem<Backend>;
 
     #[test]

--- a/crates/burn-import/onnx-tests/tests/or/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/or/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Bool, Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn or() {

--- a/crates/burn-import/onnx-tests/tests/pad/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/pad/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn pad() {

--- a/crates/burn-import/onnx-tests/tests/pow/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/pow/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Int, Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn pow_int_with_tensor_and_scalar() {

--- a/crates/burn-import/onnx-tests/tests/prelu/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/prelu/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn prelu() {

--- a/crates/burn-import/onnx-tests/tests/random_normal/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/random_normal/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::Shape;
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn random_normal() {

--- a/crates/burn-import/onnx-tests/tests/random_normal_like/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/random_normal_like/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Shape, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn random_normal_like() {

--- a/crates/burn-import/onnx-tests/tests/random_uniform/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/random_uniform/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::Shape;
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn random_uniform() {

--- a/crates/burn-import/onnx-tests/tests/random_uniform_like/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/random_uniform_like/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Shape, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn random_uniform_like() {

--- a/crates/burn-import/onnx-tests/tests/range/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/range/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::TensorData;
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn range() {

--- a/crates/burn-import/onnx-tests/tests/recip/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/recip/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, ops::FloatElem};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     type FT = FloatElem<Backend>;
 
     #[test]

--- a/crates/burn-import/onnx-tests/tests/reduce/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/reduce/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, ops::FloatElem};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+use crate::backend::Backend;
     type FT = FloatElem<Backend>;
 
     #[test]

--- a/crates/burn-import/onnx-tests/tests/reduce_max/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/reduce_max/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn reduce_max() {

--- a/crates/burn-import/onnx-tests/tests/reduce_mean/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/reduce_mean/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn reduce_mean() {

--- a/crates/burn-import/onnx-tests/tests/reduce_min/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/reduce_min/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn reduce_min() {

--- a/crates/burn-import/onnx-tests/tests/reduce_prod/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/reduce_prod/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     type FT = FloatElem<Backend>;
 
     #[test]

--- a/crates/burn-import/onnx-tests/tests/reduce_sum/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/reduce_sum/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn reduce_sum() {

--- a/crates/burn-import/onnx-tests/tests/relu/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/relu/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn relu() {

--- a/crates/burn-import/onnx-tests/tests/reshape/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/reshape/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn reshape() {

--- a/crates/burn-import/onnx-tests/tests/resize/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/resize/mod.rs
@@ -14,7 +14,7 @@ mod tests {
     use burn::tensor::{Tensor, TensorData, ops::FloatElem};
     use float_cmp::ApproxEq;
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     type FT = FloatElem<Backend>;
 
     #[test]

--- a/crates/burn-import/onnx-tests/tests/round/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/round/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, ops::FloatElem};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     type FT = FloatElem<Backend>;
 
     #[test]

--- a/crates/burn-import/onnx-tests/tests/shape/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/shape/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::Tensor;
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn shape() {

--- a/crates/burn-import/onnx-tests/tests/sigmoid/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/sigmoid/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, ops::FloatElem};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     type FT = FloatElem<Backend>;
 
     #[test]

--- a/crates/burn-import/onnx-tests/tests/sign/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/sign/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     type FT = FloatElem<Backend>;
 
     #[test]

--- a/crates/burn-import/onnx-tests/tests/sin/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/sin/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     type FT = FloatElem<Backend>;
 
     #[test]

--- a/crates/burn-import/onnx-tests/tests/sinh/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/sinh/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     type FT = FloatElem<Backend>;
 
     #[test]

--- a/crates/burn-import/onnx-tests/tests/size/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/size/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+use crate::backend::Backend;
 
     #[test]
     fn size() {

--- a/crates/burn-import/onnx-tests/tests/slice/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/slice/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn slice() {

--- a/crates/burn-import/onnx-tests/tests/softmax/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/softmax/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn softmax() {

--- a/crates/burn-import/onnx-tests/tests/space_to_depth/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/space_to_depth/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     type FT = FloatElem<Backend>;
 
     #[test]

--- a/crates/burn-import/onnx-tests/tests/split/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/split/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Shape, Tensor};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn split() {

--- a/crates/burn-import/onnx-tests/tests/sqrt/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/sqrt/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn sqrt() {

--- a/crates/burn-import/onnx-tests/tests/squeeze/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/squeeze/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Shape, Tensor};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn squeeze() {

--- a/crates/burn-import/onnx-tests/tests/sub/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/sub/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Int, Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn sub_scalar_from_tensor_and_tensor_from_tensor() {

--- a/crates/burn-import/onnx-tests/tests/sum/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/sum/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Int, Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn sum_tensor_and_tensor() {

--- a/crates/burn-import/onnx-tests/tests/tan/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/tan/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, ops::FloatElem};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     type FT = FloatElem<Backend>;
 
     #[test]

--- a/crates/burn-import/onnx-tests/tests/tanh/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/tanh/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, ops::FloatElem};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     type FT = FloatElem<Backend>;
 
     #[test]

--- a/crates/burn-import/onnx-tests/tests/test_mod.rs
+++ b/crates/burn-import/onnx-tests/tests/test_mod.rs
@@ -2,6 +2,8 @@
 
 extern crate alloc;
 
+mod backend;
+
 // Import individual node modules
 pub mod add;
 pub mod and;

--- a/crates/burn-import/onnx-tests/tests/test_record_type.rs
+++ b/crates/burn-import/onnx-tests/tests/test_record_type.rs
@@ -5,6 +5,8 @@
 // For half precision, we use a different tolerance because the output is
 // different.
 
+mod backend;
+
 macro_rules! test_model {
     ($mod_name:ident) => {
         test_model!($mod_name, 1.0e-4); // Default tolerance
@@ -44,11 +46,10 @@ macro_rules! test_model {
 
 #[cfg(test)]
 mod tests {
+    use crate::backend::Backend;
     use burn::tensor::{Shape, Tensor};
     use float_cmp::ApproxEq;
     use std::f64::consts;
-
-    type Backend = burn_ndarray::NdArray<f32>;
 
     test_model!(named_mpk);
     test_model!(named_mpk_half, 1.0e-2); // Reduce tolerance for half precision

--- a/crates/burn-import/onnx-tests/tests/tile/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/tile/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn tile() {

--- a/crates/burn-import/onnx-tests/tests/topk/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/topk/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn topk() {

--- a/crates/burn-import/onnx-tests/tests/transpose/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/transpose/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn transpose() {

--- a/crates/burn-import/onnx-tests/tests/trilu/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/trilu/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn trilu_upper() {

--- a/crates/burn-import/onnx-tests/tests/unsqueeze/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/unsqueeze/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Shape, Tensor};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn unsqueeze_runtime_axes() {

--- a/crates/burn-import/onnx-tests/tests/xor/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/xor/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Bool, Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn xor() {


### PR DESCRIPTION
Refactored ONNX import tests to support backend selection via feature flags.

By default, tests use the `burn_ndarray::NdArray<f32>` backend. When the `backend-autodiff-wgpu` feature is enabled, the tests instead run using `burn_autodiff::Autodiff<burn_wgpu::Wgpu>`. This setup lays the groundwork for easily adding support for other backends in the future.

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Addresses part of:  #3370  — ONNX import tests fail or do not compile when switching backend from NdArray to Autodiff<Wgpu>

### Changes

The original ONNX import tests only supported the NdArray<f32> backend, with the backend type hardcoded. This PR refactors the tests to support backend selection via feature flags, enabling the use of alternative backends such as Autodiff<Wgpu>.

The backend type is now defined centrally in backend.rs, making it easier to maintain and extend to new backends in the future.

### Testing

run:
```sh
cargo test
```
All tests pass using the default backend NdArray<f32>.

run:
```sh
cargo test --features backend-autodiff-wgpu
```
Tests run using Autodiff<Wgpu>, reproducing the failures described in #3370