### PR TITLE
fix(constant_of_shape): fix compile error due to .into_scalar() returning u32, not bool (#3370)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7668,9 +7668,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracel-xtask"
-version = "2.1.6"
+version = "2.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422d67baf99078f08d2a67026b43b6f997b41a89ec926bf3ef31c584335cf08c"
+checksum = "8c787864b252f8416c973043877279b5d80ebda013c127a3ccd85789bec42448"
 dependencies = [
  "anyhow",
  "clap",
@@ -7689,9 +7689,9 @@ dependencies = [
 
 [[package]]
 name = "tracel-xtask-macros"
-version = "2.1.6"
+version = "2.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01f8ec2790c3e89e8f303c4fd78051722bcf860f5dc92b3a3c38ca7160cd2cec"
+checksum = "482636f5289136e0139c1b5dcf8a4e03de89b14395f2ec90e95b65a2133b2e8a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/burn-import/onnx-tests/tests/constant_of_shape/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/constant_of_shape/mod.rs
@@ -38,8 +38,8 @@ mod tests {
         let input = Tensor::ones(shape, &device);
         let (f_output, i_output, b_output) = model.forward(input);
 
-        assert!(f_output.equal(f_expected).all().into_scalar());
-        assert!(i_output.equal(i_expected).all().into_scalar());
-        assert!(b_output.equal(b_expected).all().into_scalar());
+        f_output.to_data().assert_eq(&f_expected.to_data(), true);
+        i_output.to_data().assert_eq(&i_expected.to_data(), true);
+        b_output.to_data().assert_eq(&b_expected.to_data(), true);
     }
 }


### PR DESCRIPTION
See: https://github.com/tracel-ai/burn/issues/3370#issuecomment-3079922352

The root cause is that WGPU uses `u32` to represent boolean values. Thus, using `.equal(...).all().into_scalar()` returns a `u32`, which cannot be directly used in `assert!` (expects `bool`).

To fix this, compare the `Tensor::to_data()` results instead, which performs proper value comparison.

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Fixes #3370 

### Testing
- Confirmed compilation with:
```sh
cargo test  --features backend-autodiff-wgpu
```
- All tests pass with:
```
cargo test
```
- Also ran successfully:
```
RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Zmacro-backtrace" cargo run-checks
```
