### PR TITLE
fix(onnx-test): mismatch between expected and actual output types (#3370)

### DIFF
--- a/crates/burn-import/onnx-tests/Cargo.toml
+++ b/crates/burn-import/onnx-tests/Cargo.toml
@@ -6,6 +6,10 @@ license.workspace = true
 
 [features]
 backend-autodiff-wgpu = ["burn-autodiff", "burn-wgpu"]
+int-i32 = []
+bool-u32 = []
+
+backend-autodiff-wgpu-default = ["backend-autodiff-wgpu", "int-i32", "bool-u32"]
 
 [dev-dependencies]
 burn = { path = "../../burn" }

--- a/crates/burn-import/onnx-tests/README.md
+++ b/crates/burn-import/onnx-tests/README.md
@@ -185,6 +185,20 @@ fn test_my_new_op() {
 
 Your test will be automatically included in the main test suite through `tests/test_mod.rs`.
 
+Note:
+- Be aware that different backends use different data types. For example, the `NdArray` backend uses native `bool`, while the `Wgpu` backend uses `u32` for boolean values. Feature flags are used to select the appropriate types depending on the backend. In test code, you might write:
+
+```rust
+    #[cfg(feature = "bool-u32")]
+    let expected = TensorData::from([[1u32, 0, 1, 1]]);
+
+    #[cfg(not(feature = "bool-u32"))]
+    let expected = TensorData::from([[true, false, true, true]]);
+```
+- Refer to `Cargo.toml` and `backend.rs` for how these features are defined and used.
+
+- The `bool-u32` feature only takes effect when using the `backend-autodiff-wgpu` backend. When using `NdArray`, native `bool` is always used, regardless of feature flags.
+
 ## Best Practices for ONNX Testing
 
 ### Model Generation
@@ -234,7 +248,7 @@ This command runs all tests using the default backend: `burn_ndarray::NdArray<f3
 
 To run tests with an alternative backend (e.g. `burn_autodiff::Autodiff<burn_wgpu::Wgpu>`), use:
 ```
-cargo test --features backend-autodiff-wgpu
+cargo test --features backend-autodiff-wgpu-default
 ```
 Currently supported backends:
 *	`burn_ndarray::NdArray<f32> (default)`
@@ -248,7 +262,7 @@ cargo test --test test_mod my_new_op::test_my_new_op
 
 Run a specific test with a selected backend:
 ```
-cargo test --test test_mod my_new_op::test_my_new_op --features backend-autodiff-wgpu
+cargo test --test test_mod my_new_op::test_my_new_op --features backend-autodiff-wgpu-default
 ```
 
 ## Debugging Failed Tests

--- a/crates/burn-import/onnx-tests/tests/add/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/add/mod.rs
@@ -34,6 +34,11 @@ mod tests {
         let input = Tensor::<Backend, 4, Int>::from_ints([[[[1, 2, 3, 4]]]], &device);
         let scalar = 2;
         let output = model.forward(input, scalar);
+
+        #[cfg(feature = "int-i32")]
+        let expected = TensorData::from([[[[9i32, 11, 13, 15]]]]);
+
+        #[cfg(not(feature = "int-i32"))]
         let expected = TensorData::from([[[[9i64, 11, 13, 15]]]]);
 
         output.to_data().assert_eq(&expected, true);

--- a/crates/burn-import/onnx-tests/tests/argmax/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/argmax/mod.rs
@@ -18,6 +18,11 @@ mod tests {
         // Run the model
         let input = Tensor::<Backend, 2>::from_floats([[1., 2., 3.], [4., 5., 6.]], &device);
         let output = model.forward(input);
+
+        #[cfg(feature = "int-i32")]
+        let expected = TensorData::from([[2i32], [2]]);
+
+        #[cfg(not(feature = "int-i32"))]
         let expected = TensorData::from([[2i64], [2]]);
 
         output.to_data().assert_eq(&expected, true);

--- a/crates/burn-import/onnx-tests/tests/argmin/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/argmin/mod.rs
@@ -21,6 +21,11 @@ mod tests {
             &device,
         );
         let output = model.forward(input);
+
+        #[cfg(feature = "int-i32")]
+        let expected = TensorData::from([[2i32], [0]]);
+
+        #[cfg(not(feature = "int-i32"))]
         let expected = TensorData::from([[2i64], [0]]);
 
         output.to_data().assert_eq(&expected, true);

--- a/crates/burn-import/onnx-tests/tests/backend.rs
+++ b/crates/burn-import/onnx-tests/tests/backend.rs
@@ -1,5 +1,20 @@
-#[cfg(feature = "backend-autodiff-wgpu")]
-pub type Backend = burn_autodiff::Autodiff<burn_wgpu::Wgpu>;
+type FloatType = f32;
 
+#[cfg(feature = "int-i32")]
+type IntType = i32;
+
+#[cfg(not(feature = "int-i32"))]
+type IntType = i64; // default int type
+
+#[cfg(feature = "bool-u32")]
+type BoolType = u32;
+
+#[cfg(feature = "backend-autodiff-wgpu")]
+pub type Backend = burn_autodiff::Autodiff<burn_wgpu::Wgpu<FloatType, IntType, BoolType>>;
+
+#[cfg(all(feature = "bool-u32", not(feature = "backend-autodiff-wgpu")))]
+compile_error!(
+    "`bool-u32` has no effect when using the `NdArray` backend, which always uses native `bool`."
+);
 #[cfg(not(feature = "backend-autodiff-wgpu"))]
-pub type Backend = burn_ndarray::NdArray<f32>;
+pub type Backend = burn_ndarray::NdArray<FloatType, IntType>;

--- a/crates/burn-import/onnx-tests/tests/equal/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/equal/mod.rs
@@ -19,10 +19,16 @@ mod tests {
 
         let scalar = 2f64;
         let (tensor_out, scalar_out) = model.forward(input, scalar);
+
+        #[cfg(feature = "bool-u32")]
+        let expected_tensor = TensorData::from([[[[1u32, 1, 1, 1]]]]);
+
+        #[cfg(not(feature = "bool-u32"))]
         let expected_tensor = TensorData::from([[[[true, true, true, true]]]]);
-        let expected_scalar = false;
 
         tensor_out.to_data().assert_eq(&expected_tensor, true);
+
+        let expected_scalar = false;
         assert_eq!(scalar_out, expected_scalar);
     }
 }

--- a/crates/burn-import/onnx-tests/tests/gather/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/gather/mod.rs
@@ -54,6 +54,11 @@ mod tests {
         // shape(input) = [2, 3]
         let index = Tensor::<Backend, 1, Int>::from_ints([0], &device);
         let output = model.forward(input, index);
+
+        #[cfg(feature = "int-i32")]
+        let expected = TensorData::from([2i32]);
+
+        #[cfg(not(feature = "int-i32"))]
         let expected = TensorData::from([2i64]);
 
         assert_eq!(output.to_data(), expected);

--- a/crates/burn-import/onnx-tests/tests/greater/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/greater/mod.rs
@@ -18,6 +18,11 @@ mod tests {
         let input2 = Tensor::<Backend, 2>::from_floats([[1.0, 5.0, 8.0, -25.0]], &device);
 
         let output = model.forward(input1, input2);
+
+        #[cfg(feature = "bool-u32")]
+        let expected = TensorData::from([[0u32, 0, 1, 1]]);
+
+        #[cfg(not(feature = "bool-u32"))]
         let expected = TensorData::from([[false, false, true, true]]);
 
         output.to_data().assert_eq(&expected, true);
@@ -32,6 +37,11 @@ mod tests {
         let input2 = 1.0;
 
         let output = model.forward(input1, input2);
+
+        #[cfg(feature = "bool-u32")]
+        let expected = TensorData::from([[0u32, 1, 1, 0]]);
+
+        #[cfg(not(feature = "bool-u32"))]
         let expected = TensorData::from([[false, true, true, false]]);
 
         output.to_data().assert_eq(&expected, true);

--- a/crates/burn-import/onnx-tests/tests/greater_or_equal/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/greater_or_equal/mod.rs
@@ -18,6 +18,11 @@ mod tests {
         let input2 = Tensor::<Backend, 2>::from_floats([[1.0, 5.0, 8.0, -25.0]], &device);
 
         let output = model.forward(input1, input2);
+
+        #[cfg(feature = "bool-u32")]
+        let expected = TensorData::from([[1u32, 0, 1, 1]]);
+
+        #[cfg(not(feature = "bool-u32"))]
         let expected = TensorData::from([[true, false, true, true]]);
 
         output.to_data().assert_eq(&expected, true);
@@ -33,6 +38,11 @@ mod tests {
         let input2 = 1.0;
 
         let output = model.forward(input1, input2);
+
+        #[cfg(feature = "bool-u32")]
+        let expected = TensorData::from([[1u32, 1, 1, 0]]);
+
+        #[cfg(not(feature = "bool-u32"))]
         let expected = TensorData::from([[true, true, true, false]]);
 
         output.to_data().assert_eq(&expected, true);

--- a/crates/burn-import/onnx-tests/tests/less/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/less/mod.rs
@@ -18,6 +18,10 @@ mod tests {
         let input2 = Tensor::<Backend, 2>::from_floats([[1.0, 5.0, 8.0, -25.0]], &device);
 
         let output = model.forward(input1, input2);
+        #[cfg(feature = "bool-u32")]
+        let expected = TensorData::from([[0u32, 1, 0, 0]]);
+
+        #[cfg(not(feature = "bool-u32"))]
         let expected = TensorData::from([[false, true, false, false]]);
 
         output.to_data().assert_eq(&expected, true);
@@ -32,6 +36,11 @@ mod tests {
         let input2 = 1.0;
 
         let output = model.forward(input1, input2);
+
+        #[cfg(feature = "bool-u32")]
+        let expected = TensorData::from([[0u32, 0, 0, 1]]);
+
+        #[cfg(not(feature = "bool-u32"))]
         let expected = TensorData::from([[false, false, false, true]]);
 
         output.to_data().assert_eq(&expected, true);

--- a/crates/burn-import/onnx-tests/tests/less_or_equal/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/less_or_equal/mod.rs
@@ -18,6 +18,11 @@ mod tests {
         let input2 = Tensor::<Backend, 2>::from_floats([[1.0, 5.0, 8.0, -25.0]], &device);
 
         let output = model.forward(input1, input2);
+
+        #[cfg(feature = "bool-u32")]
+        let expected = TensorData::from([[1u32, 1, 0, 0]]);
+
+        #[cfg(not(feature = "bool-u32"))]
         let expected = TensorData::from([[true, true, false, false]]);
 
         output.to_data().assert_eq(&expected, true);
@@ -32,6 +37,11 @@ mod tests {
         let input2 = 1.0;
 
         let output = model.forward(input1, input2);
+
+        #[cfg(feature = "bool-u32")]
+        let expected = TensorData::from([[1u32, 0, 0, 1]]);
+
+        #[cfg(not(feature = "bool-u32"))]
         let expected = TensorData::from([[true, false, false, true]]);
 
         output.to_data().assert_eq(&expected, true);


### PR DESCRIPTION
See: https://github.com/tracel-ai/burn/issues/3370#issuecomment-3080046479

The root cause is that the WGPU backend uses `i32` and `u32` to represent integer and boolean values, respectively. However, the expected values in tests were defined using `i64` and `bool`, which align with the default types used by the NdArray backend.

To address this mismatch, new features such as `int-i32` and `bool-u32` are introduced to allow switching the expected types depending on the backend.

### Considered alternatives:
1. **Implementing `From` for `TensorData`**: This would reduce boilerplate but obscure the actual data types, which ONNX test contributors are expected to be aware of.
2. **Using helper functions to convert values**: Given that both backend type and expected values vary across tests, such helpers would have limited use and add unnecessary complexity. Furthermore, they make tests less self-contained and harder to reason about locally.

## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Partially fixes #3370 

### Testing

- **Regression test**:   
  run `cargo test` in`crates/burn-import/onnx-tests`; all tests passed.
- **WGPU feature tests**: 
  run `cargo test --features backend-autodiff-wgpu-default`; all type-mismatch-related tests passed.
- **Full test suite**: 
  run `RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Zmacro-backtrace" cargo run-checks` from the repository root; all test passed.

