### PR TITLE
Fix: Insecure WebSocket Connection Allows Data Interception in crates/burn-remote/src/client/runner.rs

### DIFF
--- a/crates/burn-remote/src/client/runner.rs
+++ b/crates/burn-remote/src/client/runner.rs
@@ -101,8 +101,8 @@ impl WsDevice {
     pub fn new(url: &str) -> Self {
         let mut address = String::new();
 
-        if !url.starts_with("ws://") {
-            address += "ws://";
+        if !url.starts_with("wss://") {
+            address += "wss://";
             address += url;
         } else {
             address += url;
@@ -123,7 +123,7 @@ impl Default for WsDevice {
     fn default() -> Self {
         let address = match std::env::var("BURN_REMOTE_ADDRESS") {
             Ok(address) => address,
-            Err(_) => String::from("ws://127.0.0.1:3000"),
+            Err(_) => String::from("wss://127.0.0.1:3000"),
         };
 
         Self::new(&address)


### PR DESCRIPTION
**Context and Purpose:**

This PR automatically remediates a security vulnerability:
- **Description:** Insecure WebSocket Detected. WebSocket Secure (wss) should be used for all WebSocket connections.
- **Rule ID:** javascript.lang.security.detect-insecure-websocket.detect-insecure-websocket
- **Severity:** MEDIUM
- **File:** crates/burn-remote/src/client/runner.rs
- **Lines Affected:** 104 - 104

This change is necessary to protect the application from potential security risks associated with this vulnerability.

**Solution Implemented:**

The automated remediation process has applied the necessary changes to the affected code in `crates/burn-remote/src/client/runner.rs` to resolve the identified issue.

Please review the changes to ensure they are correct and integrate as expected.