### PR TITLE
Bump MSRV from 1.85 to latest stable 1.87

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ env:
   # Note: It is not possible to define top level env vars and pass them to composite actions.
   # To work around this issue we use inputs and define all the env vars here.
 
-  RUST_PREVIOUS_VERSION: 1.88.0
+  RUST_PREVIOUS_VERSION: 1.87.0
 
   # Cargo
   CARGO_TERM_COLOR: "always"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ env:
   # Note: It is not possible to define top level env vars and pass them to composite actions.
   # To work around this issue we use inputs and define all the env vars here.
 
-  RUST_PREVIOUS_VERSION: 1.87.0
+  RUST_PREVIOUS_VERSION: 1.88.0
 
   # Cargo
   CARGO_TERM_COLOR: "always"

--- a/crates/burn/Cargo.toml
+++ b/crates/burn/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 name = "burn"
 readme.workspace = true
 repository = "https://github.com/tracel-ai/burn"
-rust-version = "1.85"
+rust-version = "1.88"
 version.workspace = true
 
 [lints]

--- a/crates/burn/Cargo.toml
+++ b/crates/burn/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 name = "burn"
 readme.workspace = true
 repository = "https://github.com/tracel-ai/burn"
-rust-version = "1.88"
+rust-version = "1.87"
 version.workspace = true
 
 [lints]


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Discussed briefly in the comments on #3423.

### Changes

Updates the MSRV from the 1.85 to the latest stable version 1.88.

### Testing

`cargo run-checks` works fine and since Rust is backwards compatible within the same edition, there should be no other major problems.
