### PR TITLE
Kill `tensor^T` magic transpose marker in favor of `tensor.T()`.

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -173,7 +173,7 @@ Those operations are available for all tensor kinds: `Int`, `Float`, and `Bool`.
 | `tensor.to_data()`                          | N/A                                                                       |
 | `tensor.to_device(device)`                  | `tensor.to(device)`                                                       |
 | `tensor.transpose()`                        | `tensor.T`                                                                |
-| `tensor.T()`                                | `tensor.T`                                                                |
+| `tensor.t()`                                | `tensor.T`                                                                |
 | `tensor.unsqueeze()`                        | `tensor.unsqueeze(0)`                                                     |
 | `tensor.unsqueeze_dim(dim)`                 | `tensor.unsqueeze(dim)`                                                   |
 | `tensor.unsqueeze_dims(dims)`               | N/A                                                                       |

--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -173,6 +173,7 @@ Those operations are available for all tensor kinds: `Int`, `Float`, and `Bool`.
 | `tensor.to_data()`                          | N/A                                                                       |
 | `tensor.to_device(device)`                  | `tensor.to(device)`                                                       |
 | `tensor.transpose()`                        | `tensor.T`                                                                |
+| `tensor.T()`                                | `tensor.T`                                                                |
 | `tensor.unsqueeze()`                        | `tensor.unsqueeze(0)`                                                     |
 | `tensor.unsqueeze_dim(dim)`                 | `tensor.unsqueeze(dim)`                                                   |
 | `tensor.unsqueeze_dims(dims)`               | N/A                                                                       |

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -272,6 +272,7 @@ where
     }
 
     /// Alias for `transpose`.
+    #[inline(always)]
     #[allow(non_snake_case)]
     pub fn T(self) -> Tensor<B, D, K> {
         self.transpose()

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -273,7 +273,6 @@ where
 
     /// Alias for `transpose`.
     #[inline(always)]
-    #[allow(non_snake_case)]
     pub fn t(self) -> Tensor<B, D, K> {
         self.transpose()
     }

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -274,7 +274,7 @@ where
     /// Alias for `transpose`.
     #[inline(always)]
     #[allow(non_snake_case)]
-    pub fn T(self) -> Tensor<B, D, K> {
+    pub fn t(self) -> Tensor<B, D, K> {
         self.transpose()
     }
 

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -271,6 +271,12 @@ where
         Tensor::new(K::transpose(self.primitive))
     }
 
+    /// Alias for `transpose`.
+    #[allow(non_snake_case)]
+    pub fn T(self) -> Tensor<B, D, K> {
+        self.transpose()
+    }
+
     /// Swaps two dimensions of a tensor.
     ///
     /// # Arguments
@@ -2280,26 +2286,6 @@ where
 
         writeln!(f, "  dtype:  {:?},", dtype.name())?;
         write!(f, "}}")
-    }
-}
-
-/// Transpose marker (zero-size type). Used to sugar the transpose of a tensor, e.g.
-/// ```rust
-/// use burn_tensor::backend::Backend;
-/// use burn_tensor::{Tensor, T};
-///
-/// fn example<B: Backend>() {
-///     let device = Default::default();
-///     let tensor = Tensor::<B, 2>::from_floats([[1.0, 2.0], [3.0, 4.0]], &device);
-///     let transposed = tensor^T;
-/// }
-/// ```
-pub struct T;
-
-impl<B: Backend, const D: usize> core::ops::BitXor<T> for Tensor<B, D> {
-    type Output = Self;
-    fn bitxor(self, _: T) -> Self::Output {
-        self.transpose()
     }
 }
 

--- a/crates/burn-tensor/src/tests/ops/transpose.rs
+++ b/crates/burn-tensor/src/tests/ops/transpose.rs
@@ -15,7 +15,9 @@ mod tests {
             &Default::default(),
         );
 
-        let output = tensor.transpose();
+        // Check the .T() alias.
+        let output = tensor.T();
+
         let expected = TensorData::from([
             [[0.0, 3.0], [1.0, 4.0], [2.0, 5.0]],
             [[6.0, 9.0], [7.0, 10.0], [8.0, 11.0]],

--- a/crates/burn-tensor/src/tests/ops/transpose.rs
+++ b/crates/burn-tensor/src/tests/ops/transpose.rs
@@ -15,8 +15,8 @@ mod tests {
             &Default::default(),
         );
 
-        // Check the .T() alias.
-        let output = tensor.T();
+        // Check the .t() alias.
+        let output = tensor.t();
 
         let expected = TensorData::from([
             [[0.0, 3.0], [1.0, 4.0], [2.0, 5.0]],


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

IDEs were frequently auto-importing `use burn::tensor::T` while editing other
unrelated generic rust expressions (which use `T`) in `burn` projects.

- killed `tensor^T` where `T` was a magic marker struct.
- added `tensor.T()` as an alias for `tensor.transpose()`.

