### PR TITLE
ci: Add burn-bench config to benchmarks.toml

### DIFF
--- a/benchmarks.toml
+++ b/benchmarks.toml
@@ -2,6 +2,7 @@
 gcp_gpu_attached = true
 gcp_image_family = "tracel-ci-ubuntu-2404-amd64-nvidia"
 # https://cloud.google.com/compute/docs/accelerator-optimized-machines
+# put the faster machine on first place for faster 'Benchmarks Started' feedback in PRs
 gcp_machine_types = [
   "a2-highgpu-1g", # 1 A100 40GB
   "g2-standard-4", # 1 L4 24GB
@@ -18,6 +19,10 @@ rust_toolchain = "stable"
 rust_version = "stable"
 
 [burn-bench]
+github_organization = "tracel-ai"
+github_repository = "burn-bench"
+github_branch = "main"
+github_workflow = "benchmarks.yml"
 # vulkan autotune seems to take ages, disabling it for now
 # backends = ["cuda-fusion", "vulkan-fusion", "wgpu-fusion"]
 backends = ["cuda-fusion"]


### PR DESCRIPTION
This allows to eventually test burn-bench modifications outside of its main branch.