### PR TITLE
Evenly distribute complete chunks/batches across partial dataset splits

### DIFF
--- a/crates/burn-core/src/data/dataloader/multithread.rs
+++ b/crates/burn-core/src/data/dataloader/multithread.rs
@@ -97,7 +97,12 @@ where
                     ));
                 }
 
-                let datasets = PartialDataset::split(dataset, self.num_threads);
+                let datasets = match self.strategy.batch_size() {
+                    Some(batch_size) => {
+                        PartialDataset::split_chunks(dataset, self.num_threads, batch_size)
+                    }
+                    None => PartialDataset::split(dataset, self.num_threads),
+                };
 
                 // Create more rngs from the first one, one for each new dataloader.
                 let mut rng = self.rng.clone();
@@ -372,5 +377,44 @@ mod tests {
                 assert_eq!(batch_items.len(), num_classes);
             }
         }
+    }
+
+    #[test]
+    fn test_multi_thread_batch_dataloader_incomplete_batches() {
+        let batcher = Arc::new(TestBatcher::new());
+        let dataset = Arc::new(FakeDataset::<String>::new(27));
+        let dataloader_single_thread = BatchDataLoader::new(
+            Box::new(FixBatchStrategy::new(5)),
+            dataset.clone(),
+            batcher.clone(),
+            Default::default(),
+            None,
+        );
+        let dataloader_multi_thread = MultiThreadDataLoader::new(
+            Box::new(FixBatchStrategy::new(5)),
+            dataset,
+            batcher,
+            4,
+            Default::default(),
+            None,
+        );
+
+        let mut items_single_thread = HashSet::new();
+        let mut items_multi_thread = HashSet::new();
+
+        let mut single_thread_cnt = 0;
+        let mut multi_thread_cnt = 0;
+        for items in dataloader_single_thread.iter() {
+            items_single_thread.insert(items);
+            single_thread_cnt += 1;
+        }
+
+        for items in dataloader_multi_thread.iter() {
+            items_multi_thread.insert(items);
+            multi_thread_cnt += 1;
+        }
+
+        assert_eq!(single_thread_cnt, multi_thread_cnt);
+        assert_eq!(items_single_thread, items_multi_thread);
     }
 }

--- a/crates/burn-core/src/data/dataloader/strategy.rs
+++ b/crates/burn-core/src/data/dataloader/strategy.rs
@@ -24,6 +24,13 @@ pub trait BatchStrategy<I>: Send {
     ///
     /// The new strategy.
     fn clone_dyn(&self) -> Box<dyn BatchStrategy<I>>;
+
+    /// Returns the expected batch size for this strategy.
+    ///
+    /// # Returns
+    ///
+    /// The batch size, or None if the strategy doesn't have a fixed batch size.
+    fn batch_size(&self) -> Option<usize>;
 }
 
 /// A strategy to batch items with a fixed batch size.
@@ -72,5 +79,9 @@ impl<I: Send + 'static> BatchStrategy<I> for FixBatchStrategy<I> {
 
     fn clone_dyn(&self) -> Box<dyn BatchStrategy<I>> {
         Box::new(Self::new(self.batch_size))
+    }
+
+    fn batch_size(&self) -> Option<usize> {
+        Some(self.batch_size)
     }
 }

--- a/crates/burn-dataset/src/transform/partial.rs
+++ b/crates/burn-dataset/src/transform/partial.rs
@@ -39,6 +39,47 @@ where
 
         datasets
     }
+
+    /// Splits a dataset by distributing complete chunks/batches across multiple partial datasets.
+    pub fn split_chunks(
+        dataset: D,
+        num: usize,
+        batch_size: usize,
+    ) -> Vec<PartialDataset<Arc<D>, I>> {
+        let dataset = Arc::new(dataset); // cheap cloning.
+        let total_items = dataset.len();
+
+        // Total number of complete batches
+        let total_batches = total_items.div_ceil(batch_size);
+        let batches_per_split = total_batches / num;
+        let extra_batches = total_batches % num;
+
+        let mut datasets = Vec::with_capacity(num);
+        let mut current_batch = 0;
+
+        for i in 0..num {
+            // Extra batches distributed across first splits
+            let split_batches = if i < extra_batches {
+                batches_per_split + 1
+            } else {
+                batches_per_split
+            };
+
+            let start_batch = current_batch;
+            let end_batch = start_batch + split_batches;
+
+            let start_index = start_batch * batch_size;
+            let end_index = core::cmp::min(end_batch * batch_size, total_items);
+
+            if start_index < total_items {
+                datasets.push(PartialDataset::new(dataset.clone(), start_index, end_index));
+            }
+
+            current_batch = end_batch;
+        }
+
+        datasets
+    }
 }
 
 impl<D, I> Dataset<I> for PartialDataset<D, I>
@@ -127,8 +168,34 @@ mod tests {
         }
 
         let dataset_partials = PartialDataset::split(dataset_original, 4);
+        let expected_len = [6, 6, 6, 9];
 
-        for dataset in dataset_partials {
+        for (i, dataset) in dataset_partials.iter().enumerate() {
+            assert_eq!(dataset.len(), expected_len[i]);
+            for item in dataset.iter() {
+                items_partial.push(item);
+            }
+        }
+
+        assert_eq!(items_original, items_partial);
+    }
+
+    #[test]
+    fn test_split_chunks_contains_all_items_without_duplicates() {
+        let dataset_original = FakeDataset::<String>::new(27);
+        let mut items_original = Vec::new();
+        let mut items_partial = Vec::new();
+        for item in dataset_original.iter() {
+            items_original.push(item);
+        }
+
+        let dataset_partials = PartialDataset::split_chunks(dataset_original, 4, 5);
+        // [(2 * 5), (2 * 5), 5, 2] -> 5 complete chunks + 1 incomplete with 2 remaining items
+        // OTOH, `split(dataset, 4)` would yield [6, 6, 6, 9] -> 4 incomplete chunks + 4 incomplete with [1, 1, 1, 4]
+        let expected_len = [10, 10, 5, 2];
+
+        for (i, dataset) in dataset_partials.iter().enumerate() {
+            assert_eq!(dataset.len(), expected_len[i]);
             for item in dataset.iter() {
                 items_partial.push(item);
             }


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

#2373
#3448

The current implementation prioritizes the number of workers, so the dataset is first split into `num_workers` partial subsets. Then each partial dataset is used to retrieve a batch. This can yield additional partial batches and doesn't match most users' expected behavior.

### Changes

- Added `PartialDataset::split_chunks` which evenly distributes complete chunks/batches across multiple partial datasets.
- Changed multi-thread dataloader behavior to use `split_chunks` when `BatchStrategy` defines the expected batch size (default with fixed batch size)

### Testing

Added unit tests
