### PR TITLE
Issue pip missing

### DIFF
--- a/burn-book/src/building-blocks/dataset.md
+++ b/burn-book/src/building-blocks/dataset.md
@@ -136,6 +136,23 @@ For now, there are only a couple of dataset sources available with Burn, but mor
 
 ### Hugging Face
 
+⚠️ **Prerequisite**
+
+Hugging Face datasets in Burn require a Python installation with `pip`.  
+If you see errors like:
+
+```
+/venv/bin/python3: No module named pip
+```
+
+install pip in the environment and retry:
+
+```bash
+python3 -m ensurepip --upgrade
+rm -rf ~/.cache/burn-dataset/venv
+```
+This will recreate the Burn dataset cache with pip enabled.
+
 You can easily import any Hugging Face dataset with Burn. We use SQLite as the storage to avoid
 downloading the model each time or starting a Python process. You need to know the format of each
 item in the dataset beforehand. Here's an example with the

--- a/crates/burn-dataset/src/source/huggingface/downloader.rs
+++ b/crates/burn-dataset/src/source/huggingface/downloader.rs
@@ -342,9 +342,9 @@ fn install_python_deps(base_dir: &Path) -> Result<PathBuf, ImporterError> {
         "datasets",
     ]);
 
-    let output = command
-        .output()
-        .map_err(|err| ImporterError::FailToDownloadPythonDependencies(format!("Failed to run pip: {err}")))?;
+    let output = command.output().map_err(|err| {
+        ImporterError::FailToDownloadPythonDependencies(format!("Failed to run pip: {err}"))
+    })?;
 
     // Check if pip actually ran successfully
     if !output.status.success() {
@@ -354,7 +354,8 @@ fn install_python_deps(base_dir: &Path) -> Result<PathBuf, ImporterError> {
             return Err(ImporterError::FailToDownloadPythonDependencies(
                 "Python environment is missing pip. \
                 Please install pip with:\n\n\
-                python3 -m ensurepip --upgrade && rm -rf ~/.cache/burn-dataset/venv\n".to_string(),
+                python3 -m ensurepip --upgrade && rm -rf ~/.cache/burn-dataset/venv\n"
+                    .to_string(),
             ));
         }
 


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ yes] Confirmed that `cargo run-checks` command has been executed.
- [ yes] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

_Provide links to relevant issues and dependent PRs._
https://github.com/tracel-ai/burn/issues/3473

### Changes

_Summarize the problem being addressed and your solution._

1) Updated the Burn Book (dataset.md) to add a note that Hugging Face datasets require Python with pip.
2) Improved error handling in downloader.rs to show a clear message when pip is missing, with steps to fix.
### Testing

_Describe how these changes have been tested._

The changes were tested as follows:

1) With pip missing:

  >rm -rf ~/.cache/burn-dataset/venv
  >python3 -m venv --without-pip ~/.cache/burn-dataset/venv
  >cargo run -r --example hf_dataset --features ndarray
→ Confirmed the new friendly error message is shown.

2) With pip present:
   >python3 -m venv ~/.cache/burn-dataset/venv
  >~/.cache/burn-dataset/venv/bin/python3 -m ensurepip --upgrade
  >cargo run -r --example hf_dataset --features ndarray
  
  3) Ran formatting and checks:
      cargo fmt
      cargo fmt -- --check
      cargo run -p xtask check
      cargo run-checks
