### PR TITLE
Fix candle mask broadcasting

### DIFF
--- a/crates/burn-candle/src/ops/base.rs
+++ b/crates/burn-candle/src/ops/base.rs
@@ -139,9 +139,14 @@ pub fn mask_where_broadcasted(
         .unwrap();
 
     let mut tensor = tensor.tensor;
+    let mut mask = mask.tensor;
+
     if shape != *tensor.shape() {
-        tensor = tensor.broadcast_as(shape).unwrap();
+        tensor = tensor.broadcast_as(shape.clone()).unwrap();
+    }
+    if shape != *mask.shape() {
+        mask = mask.broadcast_as(shape).unwrap();
     }
 
-    CandleTensor::new(mask.tensor.where_cond(&value.tensor, &tensor).unwrap())
+    CandleTensor::new(mask.where_cond(&value.tensor, &tensor).unwrap())
 }

--- a/crates/burn-candle/src/ops/tensor.rs
+++ b/crates/burn-candle/src/ops/tensor.rs
@@ -231,14 +231,8 @@ impl<F: FloatCandleElement, I: IntCandleElement> FloatTensorOps<Self> for Candle
         mask: BoolTensor<Self>,
         value: FloatElem<Self>,
     ) -> FloatTensor<Self> {
-        CandleTensor::new(
-            mask.tensor
-                .where_cond(
-                    &super::candle_utils::fill_like::<F>(value, &tensor.tensor),
-                    &tensor.tensor,
-                )
-                .unwrap(),
-        )
+        let value = super::candle_utils::fill_like::<F>(value, &tensor.tensor);
+        super::base::mask_where_broadcasted(tensor, mask, CandleTensor::new(value))
     }
 
     fn float_equal(lhs: FloatTensor<Self>, rhs: FloatTensor<Self>) -> BoolTensor<Self> {

--- a/crates/burn-tensor/src/tests/ops/mask.rs
+++ b/crates/burn-tensor/src/tests/ops/mask.rs
@@ -147,6 +147,26 @@ mod tests {
     }
 
     #[test]
+    fn should_support_mask_fill_broadcasted() {
+        let device = Default::default();
+        let tensor = TestTensor::zeros([1, 4, 2, 2], &device);
+        let mask = TestTensorBool::<4>::from_bool(
+            TensorData::from([[[[true, false], [false, true]]]]),
+            &device,
+        );
+
+        let output = tensor.mask_fill(mask, 2.0);
+        let expected = TensorData::from([[
+            [[2., 0.], [0., 2.]],
+            [[2., 0.], [0., 2.]],
+            [[2., 0.], [0., 2.]],
+            [[2., 0.], [0., 2.]],
+        ]]);
+
+        output.into_data().assert_eq(&expected, false);
+    }
+
+    #[test]
     fn should_support_int_mask_where_ops() {
         let device = Default::default();
         let tensor = TestTensorInt::<2>::from_data([[1, 7], [2, 3]], &device);


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Fixes #3486

### Changes

Added broadcasting support for mask in `mask_fill` / `mask_where` operations

### Testing

Added unit test
