### PR TITLE
Fix burn-communication WebSocket server config

### DIFF
--- a/crates/burn-communication/src/websocket/server.rs
+++ b/crates/burn-communication/src/websocket/server.rs
@@ -72,9 +72,15 @@ impl ProtocolServer for WsServer {
         };
 
         let method = get(|ws: WebSocketUpgrade, _: State<()>| async {
-            ws.on_upgrade(async move |socket| {
-                callback(WsServerChannel { inner: socket }).await;
-            })
+            const MB: usize = 1024 * 1024;
+            ws.write_buffer_size(0)
+                .max_message_size(usize::MAX)
+                .max_frame_size(MB * 512)
+                .accept_unmasked_frames(true)
+                .read_buffer_size(64 * 1024)
+                .on_upgrade(async move |socket| {
+                    callback(WsServerChannel { inner: socket }).await;
+                })
         });
 
         self.router = self.router.route(&path, method);


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs
#3516 

### Changes
The problem lies in the `WebSocketUpgrade` struct of the axum library. When the http connection is upgraded, there will be a `WebSocketConfig` inside the struct. If the parameters are not manually set, it will fall back to the default parameters.

[axum doc reference](https://docs.rs/axum/0.8.3/axum/extract/struct.WebSocketUpgrade.html)