### PR TITLE
Debug log new name during ONNX renames

### DIFF
--- a/crates/onnx-ir/src/from_onnx.rs
+++ b/crates/onnx-ir/src/from_onnx.rs
@@ -262,7 +262,7 @@ impl OnnxGraphBuilder {
         )
         .to_lowercase();
 
-        log::debug!("renaming node {:?} to {new_name:?}", &node.name);
+        log::debug!("Renaming node {:?} to {new_name:?}", &node.name);
 
         node.name.clone_from(&new_name);
     }


### PR DESCRIPTION
If some node "foo" crashes late during ONNX import it can be useful to inspect which node this relates to in e.g. netron.app.

However if the node has been renamed it's not as easy to find the original node.

Therefore also print the new name during renames such that we can find the original name easier in logs, which allows searching for the original node more easily.

The below example would have a log statement about "node_conv_9" being renamed "foo".

<img width="488" height="708" alt="image" src="https://github.com/user-attachments/assets/c8c3c2c5-1109-4dbe-b920-d06afa1fdb34" />

