### PR TITLE
Proto conversion: Allow f16 tensors

### DIFF
--- a/crates/onnx-ir/Cargo.toml
+++ b/crates/onnx-ir/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 
 [dependencies]
 bytemuck = { workspace = true }
-half = { workspace = true }
+half = { workspace = true, features = ["bytemuck"] }
 log = { workspace = true }
 protobuf = { workspace = true, features = ["with-bytes"] }
 regex = { workspace = true }

--- a/crates/onnx-ir/src/proto_conversion.rs
+++ b/crates/onnx-ir/src/proto_conversion.rs
@@ -34,6 +34,15 @@ impl TryFrom<TensorProto> for TensorData {
                     Data::Float32s(tensor.float_data)
                 },
             ),
+            DataType::FLOAT16 => (
+                ElementType::Float16,
+                // Convert the raw data to a vector of float16s
+                if !tensor.raw_data.is_empty() {
+                    Data::Float16s(cast_slice(&tensor.raw_data[..]).to_vec())
+                } else {
+                    unimplemented!()
+                },
+            ),
             DataType::INT16 => {
                 // TODO : Add support for int16 by converting to int32
                 todo!("Add support for int16");


### PR DESCRIPTION
From the proto comments: 

<img width="1171" height="340" alt="image" src="https://github.com/user-attachments/assets/958c0932-c1cb-417b-b695-2a319d77977c" />

I had a model with a f16 tensor as input which failed due to the `TryFrom<TensorProto> for TensorData` missing the handling of f16.

With the knowledge that f16 can be stored in the raw data field, handle this case.

Add the bytemuck flag to the half crate such that this cast is possible.


My model no longer fails this step on these changes.