### PR TITLE
Fix/onnx/auto pad

### DIFF
--- a/crates/onnx-ir/src/node/avg_pool1d.rs
+++ b/crates/onnx-ir/src/node/avg_pool1d.rs
@@ -54,8 +54,6 @@ pub fn avg_pool1d_config(curr: &Node) -> AvgPool1dConfig {
                     panic!("Unsupported 'auto_pad' value: {auto_pad}");
                 }
             }
-            // These are attributes that are allowed but not used in this implementation
-            "storage_order" => {}
             _ => panic!("Unexpected attribute for AvgPool1d: {key}"),
         }
     }

--- a/crates/onnx-ir/src/node/avg_pool1d.rs
+++ b/crates/onnx-ir/src/node/avg_pool1d.rs
@@ -47,8 +47,15 @@ pub fn avg_pool1d_config(curr: &Node) -> AvgPool1dConfig {
             "pads" => pads = value.clone().into_i64s(),
             "count_include_pad" => count_include_pad = value.clone().into_i64(),
             "ceil_mode" => ceil_mode = value.clone().into_i64(),
+            "auto_pad" => {
+                // At least support default (not set -> explicit)
+                let auto_pad = value.clone().into_string();
+                if auto_pad != "NOTSET" {
+                    panic!("Unsupported 'auto_pad' value: {auto_pad}");
+                }
+            }
             // These are attributes that are allowed but not used in this implementation
-            "auto_pad" | "storage_order" => {}
+            "storage_order" => {}
             _ => panic!("Unexpected attribute for AvgPool1d: {key}"),
         }
     }

--- a/crates/onnx-ir/src/node/avg_pool2d.rs
+++ b/crates/onnx-ir/src/node/avg_pool2d.rs
@@ -46,8 +46,15 @@ pub fn avg_pool2d_config(curr: &Node) -> AvgPool2dConfig {
             "pads" => pads = value.clone().into_i64s(),
             "count_include_pad" => count_include_pad = value.clone().into_i64(),
             "ceil_mode" => ceil_mode = value.clone().into_i64(),
+            "auto_pad" => {
+                // At least support default (not set -> explicit)
+                let auto_pad = value.clone().into_string();
+                if auto_pad != "NOTSET" {
+                    panic!("Unsupported 'auto_pad' value: {auto_pad}");
+                }
+            }
             // These are attributes that are allowed but not used in this implementation
-            "auto_pad" | "storage_order" => {}
+            "storage_order" => {}
             _ => panic!("Unexpected attribute for AvgPool2d: {key}"),
         }
     }

--- a/crates/onnx-ir/src/node/avg_pool2d.rs
+++ b/crates/onnx-ir/src/node/avg_pool2d.rs
@@ -53,8 +53,6 @@ pub fn avg_pool2d_config(curr: &Node) -> AvgPool2dConfig {
                     panic!("Unsupported 'auto_pad' value: {auto_pad}");
                 }
             }
-            // These are attributes that are allowed but not used in this implementation
-            "storage_order" => {}
             _ => panic!("Unexpected attribute for AvgPool2d: {key}"),
         }
     }

--- a/crates/onnx-ir/src/node/conv1d.rs
+++ b/crates/onnx-ir/src/node/conv1d.rs
@@ -74,6 +74,13 @@ pub fn conv1d_config(curr: &Node) -> Conv1dConfig {
             "pads" => pads = value.clone().into_i64s(),
             "dilations" => dilations = value.clone().into_i64s(),
             "group" => group = value.clone().into_i64() as usize,
+            "auto_pad" => {
+                // At least support default (not set -> explicit)
+                let auto_pad = value.clone().into_string();
+                if auto_pad != "NOTSET" {
+                    panic!("Unsupported 'auto_pad' value: {auto_pad}");
+                }
+            }
             _ => {}
         }
     }
@@ -109,6 +116,7 @@ mod tests {
         dilations: Vec<i64>,
         group: i64,
         has_bias: bool,
+        auto_pad: Option<&str>,
     ) -> Node {
         // Create weight tensor data
         let weight_data = vec![0.1; 16];
@@ -128,6 +136,10 @@ mod tests {
             builder = builder.input_tensor_f32_data("bias", vec![0.1, 0.2], vec![2]);
         }
 
+        if let Some(auto_pad) = auto_pad {
+            builder = builder.attr_string("auto_pad", auto_pad);
+        }
+
         // Add attributes
         builder = builder
             .attr_ints("kernel_shape", kernel_shape)
@@ -141,7 +153,7 @@ mod tests {
 
     #[test]
     fn test_conv1d_config_basic() {
-        let node = create_test_node(vec![4], vec![1], vec![0, 0], vec![1], 1, false);
+        let node = create_test_node(vec![4], vec![1], vec![0, 0], vec![1], 1, false, None);
         let config = conv1d_config(&node);
 
         assert_eq!(config.channels_in, 2);
@@ -156,7 +168,7 @@ mod tests {
 
     #[test]
     fn test_conv1d_config_with_padding() {
-        let node = create_test_node(vec![4], vec![2], vec![2, 2], vec![1], 1, true);
+        let node = create_test_node(vec![4], vec![2], vec![2, 2], vec![1], 1, true, None);
         let config = conv1d_config(&node);
 
         assert_eq!(config.channels_in, 2);
@@ -171,7 +183,7 @@ mod tests {
 
     #[test]
     fn test_conv1d_config_with_dilation() {
-        let node = create_test_node(vec![4], vec![1], vec![0, 0], vec![2], 1, false);
+        let node = create_test_node(vec![4], vec![1], vec![0, 0], vec![2], 1, false, None);
         let config = conv1d_config(&node);
 
         assert_eq!(config.channels_in, 2);
@@ -186,7 +198,7 @@ mod tests {
 
     #[test]
     fn test_conv1d_config_with_groups() {
-        let node = create_test_node(vec![4], vec![1], vec![0, 0], vec![1], 2, false);
+        let node = create_test_node(vec![4], vec![1], vec![0, 0], vec![1], 2, false, None);
         let config = conv1d_config(&node);
 
         assert_eq!(config.channels_in, 4);
@@ -202,14 +214,60 @@ mod tests {
     #[test]
     #[should_panic(expected = "Asymmetric padding is not supported")]
     fn test_conv1d_config_asymmetric_padding() {
-        let node = create_test_node(vec![4], vec![1], vec![1, 2], vec![1], 1, false);
+        let node = create_test_node(vec![4], vec![1], vec![1, 2], vec![1], 1, false, None);
         let _ = conv1d_config(&node);
     }
 
     #[test]
     #[should_panic(expected = "Negative pad values are not supported")]
     fn test_conv1d_config_negative_padding() {
-        let node = create_test_node(vec![4], vec![1], vec![-1, -1], vec![1], 1, false);
+        let node = create_test_node(vec![4], vec![1], vec![-1, -1], vec![1], 1, false, None);
         let _ = conv1d_config(&node);
+    }
+
+    #[test]
+    fn test_conv1d_config_autopad_not_set() {
+        let node = create_test_node(
+            vec![4],
+            vec![1],
+            vec![0, 0],
+            vec![1],
+            1,
+            false,
+            Some("NOTSET"),
+        );
+        let config = conv1d_config(&node);
+
+        assert_eq!(config.channels_in, 2);
+        assert_eq!(config.channels_out, 2);
+        assert_eq!(config.kernel_size, 4);
+        assert_eq!(config.stride, 1);
+        assert_eq!(config.dilation, 1);
+        assert_eq!(config.groups, 1);
+        assert!(!config.bias);
+        assert!(matches!(config.padding, PaddingConfig1d::Valid));
+    }
+    #[test]
+    #[should_panic = "Unsupported 'auto_pad' value"]
+    fn test_conv1d_config_autopad_not_supported() {
+        let node = create_test_node(
+            vec![4],
+            vec![1],
+            vec![0, 0],
+            vec![1],
+            1,
+            false,
+            Some("SAME_UPPER"),
+        );
+        let config = conv1d_config(&node);
+
+        assert_eq!(config.channels_in, 2);
+        assert_eq!(config.channels_out, 2);
+        assert_eq!(config.kernel_size, 4);
+        assert_eq!(config.stride, 1);
+        assert_eq!(config.dilation, 1);
+        assert_eq!(config.groups, 1);
+        assert!(!config.bias);
+        assert!(matches!(config.padding, PaddingConfig1d::Valid));
     }
 }

--- a/crates/onnx-ir/src/node/conv1d.rs
+++ b/crates/onnx-ir/src/node/conv1d.rs
@@ -81,7 +81,7 @@ pub fn conv1d_config(curr: &Node) -> Conv1dConfig {
                     panic!("Unsupported 'auto_pad' value: {auto_pad}");
                 }
             }
-            _ => {}
+            _ => panic!("Unexpected attribute for Conv1d: {key}"),
         }
     }
 

--- a/crates/onnx-ir/src/node/conv2d.rs
+++ b/crates/onnx-ir/src/node/conv2d.rs
@@ -68,6 +68,13 @@ pub fn conv2d_config(curr: &Node) -> Conv2dConfig {
             "pads" => pads = value.clone().into_i64s(),
             "dilations" => dilations = value.clone().into_i64s(),
             "group" => group = value.clone().into_i64() as usize,
+            "auto_pad" => {
+                // At least support default (not set -> explicit)
+                let auto_pad = value.clone().into_string();
+                if auto_pad != "NOTSET" {
+                    panic!("Unsupported 'auto_pad' value: {auto_pad}");
+                }
+            }
             _ => panic!("Unexpected attribute for Conv2d: {key}"),
         }
     }
@@ -102,6 +109,7 @@ mod tests {
         dilations: Vec<i64>,
         group: i64,
         has_bias: bool,
+        auto_pad: Option<&str>,
     ) -> Node {
         // Weight tensor data - not important for the test
         let weight_data = vec![0.0; 16];
@@ -122,6 +130,10 @@ mod tests {
             builder = builder.input_tensor_f32("bias", 1, None);
         }
 
+        if let Some(auto_pad) = auto_pad {
+            builder = builder.attr_string("auto_pad", auto_pad);
+        }
+
         builder.build()
     }
 
@@ -134,6 +146,7 @@ mod tests {
             vec![1, 1],
             1,
             false,
+            None,
         );
         let config = conv2d_config(&node);
 
@@ -155,6 +168,7 @@ mod tests {
             vec![1, 1],
             1,
             false,
+            None,
         );
         let config = conv2d_config(&node);
 
@@ -171,6 +185,7 @@ mod tests {
             vec![1, 1],
             2,
             false,
+            None,
         );
         let config = conv2d_config(&node);
 
@@ -187,9 +202,42 @@ mod tests {
             vec![1, 1],
             1,
             true,
+            None,
         );
         let config = conv2d_config(&node);
 
         assert!(config.bias);
+    }
+
+    #[test]
+    fn test_conv2d_config_autopad_not_set() {
+        let node = create_test_node(
+            vec![3, 3],
+            vec![1, 1],
+            vec![1, 1, 1, 1],
+            vec![1, 1],
+            1,
+            false,
+            Some("NOTSET"),
+        );
+        let config = conv2d_config(&node);
+
+        assert_eq!(config.kernel_size, [3, 3]);
+        assert!(matches!(config.padding, PaddingConfig2d::Explicit(1, 1)));
+    }
+
+    #[test]
+    #[should_panic = "Unsupported 'auto_pad' value"]
+    fn test_conv2d_config_autopad_not_supported() {
+        let node = create_test_node(
+            vec![3, 3],
+            vec![1, 1],
+            vec![1, 1, 1, 1],
+            vec![1, 1],
+            1,
+            false,
+            Some("SAME_UPPER"),
+        );
+        let _config = conv2d_config(&node);
     }
 }

--- a/crates/onnx-ir/src/node/conv3d.rs
+++ b/crates/onnx-ir/src/node/conv3d.rs
@@ -68,6 +68,13 @@ pub fn conv3d_config(curr: &Node) -> Conv3dConfig {
             "pads" => pads = value.clone().into_i64s(),
             "dilations" => dilations = value.clone().into_i64s(),
             "group" => group = value.clone().into_i64() as usize,
+            "auto_pad" => {
+                // At least support default (not set -> explicit)
+                let auto_pad = value.clone().into_string();
+                if auto_pad != "NOTSET" {
+                    panic!("Unsupported 'auto_pad' value: {auto_pad}");
+                }
+            }
             _ => panic!("Unexpected attribute for Conv3d: {key}"),
         }
     }
@@ -114,6 +121,7 @@ mod tests {
         dilations: Vec<i64>,
         group: i64,
         has_bias: bool,
+        auto_pad: Option<&str>,
     ) -> Node {
         // Create weight tensor data (not important for the test)
         let weight_data = vec![0.0; 32];
@@ -138,6 +146,10 @@ mod tests {
             .attr_ints("dilations", dilations)
             .attr_int("group", group);
 
+        if let Some(auto_pad) = auto_pad {
+            builder = builder.attr_string("auto_pad", auto_pad);
+        }
+
         builder.build()
     }
 
@@ -150,6 +162,7 @@ mod tests {
             vec![1, 1, 1],
             1,
             false,
+            None,
         );
         let config = conv3d_config(&node);
 
@@ -171,6 +184,7 @@ mod tests {
             vec![1, 1, 1],
             1,
             false,
+            None,
         );
         let config = conv3d_config(&node);
 
@@ -187,6 +201,7 @@ mod tests {
             vec![1, 1, 1],
             2,
             false,
+            None,
         );
         let config = conv3d_config(&node);
 
@@ -203,9 +218,47 @@ mod tests {
             vec![1, 1, 1],
             1,
             true,
+            None,
         );
         let config = conv3d_config(&node);
 
         assert!(config.bias);
+    }
+
+    #[test]
+    fn test_conv3d_config_autopad_not_set() {
+        let node = create_test_node(
+            vec![2, 2, 2],
+            vec![1, 1, 1],
+            vec![0, 0, 0, 0, 0, 0],
+            vec![1, 1, 1],
+            1,
+            false,
+            Some("NOTSET"),
+        );
+        let config = conv3d_config(&node);
+
+        assert_eq!(config.channels, [2, 4]);
+        assert_eq!(config.kernel_size, [2, 2, 2]);
+        assert_eq!(config.stride, [1, 1, 1]);
+        assert_eq!(config.dilation, [1, 1, 1]);
+        assert_eq!(config.groups, 1);
+        assert!(!config.bias);
+        assert!(matches!(config.padding, PaddingConfig3d::Valid));
+    }
+
+    #[test]
+    #[should_panic = "Unsupported 'auto_pad' value"]
+    fn test_conv3d_config_autopad_not_supported() {
+        let node = create_test_node(
+            vec![2, 2, 2],
+            vec![1, 1, 1],
+            vec![0, 0, 0, 0, 0, 0],
+            vec![1, 1, 1],
+            1,
+            false,
+            Some("SAME_UPPER"),
+        );
+        let _config = conv3d_config(&node);
     }
 }

--- a/crates/onnx-ir/src/node/conv_transpose2d.rs
+++ b/crates/onnx-ir/src/node/conv_transpose2d.rs
@@ -65,6 +65,13 @@ pub fn conv_transpose2d_config(curr: &Node) -> ConvTranspose2dConfig {
             "dilations" => dilations = value.clone().into_i64s(),
             "group" => group = value.clone().into_i64() as usize,
             "output_padding" => output_padding = value.clone().into_i64s(),
+            "auto_pad" => {
+                // At least support default (not set -> explicit)
+                let auto_pad = value.clone().into_string();
+                if auto_pad != "NOTSET" {
+                    panic!("Unsupported 'auto_pad' value: {auto_pad}");
+                }
+            }
             _ => panic!("Unexpected attribute for ConvTranspose2d: {key}"),
         }
     }
@@ -116,6 +123,7 @@ mod tests {
         output_padding: Vec<i64>,
         group: i64,
         has_bias: bool,
+        auto_pad: Option<&str>,
     ) -> Node {
         // Create weight tensor data
         let weight_data = vec![0.0; 16]; // Not important for the test
@@ -144,6 +152,10 @@ mod tests {
             .attr_ints("output_padding", output_padding)
             .attr_int("group", group);
 
+        if let Some(auto_pad) = auto_pad {
+            builder = builder.attr_string("auto_pad", auto_pad);
+        }
+
         builder.build()
     }
 
@@ -157,6 +169,7 @@ mod tests {
             vec![0, 0],
             1,
             false,
+            None,
         );
         let config = conv_transpose2d_config(&node);
 
@@ -180,6 +193,7 @@ mod tests {
             vec![0, 0],
             1,
             false,
+            None,
         );
         let config = conv_transpose2d_config(&node);
 
@@ -197,6 +211,7 @@ mod tests {
             vec![1, 1],
             1,
             false,
+            None,
         );
         let config = conv_transpose2d_config(&node);
 
@@ -213,6 +228,7 @@ mod tests {
             vec![0, 0],
             2,
             false,
+            None,
         );
         let config = conv_transpose2d_config(&node);
 
@@ -230,6 +246,7 @@ mod tests {
             vec![0, 0],
             1,
             true,
+            None,
         );
         let config = conv_transpose2d_config(&node);
 
@@ -247,7 +264,48 @@ mod tests {
             vec![0, 0],
             1,
             false,
+            None,
         );
         let _ = conv_transpose2d_config(&node);
+    }
+
+    #[test]
+    fn test_conv_transpose2d_config_autopad_not_set() {
+        let node = create_test_node(
+            vec![2, 2],
+            vec![1, 1],
+            vec![0, 0, 0, 0],
+            vec![1, 1],
+            vec![0, 0],
+            1,
+            false,
+            Some("NOTSET"),
+        );
+        let config = conv_transpose2d_config(&node);
+
+        assert_eq!(config.channels, [4, 2]);
+        assert_eq!(config.kernel_size, [2, 2]);
+        assert_eq!(config.stride, [1, 1]);
+        assert_eq!(config.dilation, [1, 1]);
+        assert_eq!(config.padding, [0, 0]);
+        assert_eq!(config.padding_out, [0, 0]);
+        assert_eq!(config.groups, 1);
+        assert!(!config.bias);
+    }
+
+    #[test]
+    #[should_panic = "Unsupported 'auto_pad' value"]
+    fn test_conv_transpose2d_config_autopad_not_supported() {
+        let node = create_test_node(
+            vec![2, 2],
+            vec![1, 1],
+            vec![0, 0, 0, 0],
+            vec![1, 1],
+            vec![0, 0],
+            1,
+            false,
+            Some("SAME_UPPER"),
+        );
+        let _config = conv_transpose2d_config(&node);
     }
 }

--- a/crates/onnx-ir/src/node/conv_transpose3d.rs
+++ b/crates/onnx-ir/src/node/conv_transpose3d.rs
@@ -65,6 +65,13 @@ pub fn conv_transpose3d_config(curr: &Node) -> ConvTranspose3dConfig {
             "dilations" => dilations = value.clone().into_i64s(),
             "group" => group = value.clone().into_i64() as usize,
             "output_padding" => output_padding = value.clone().into_i64s(),
+            "auto_pad" => {
+                // At least support default (not set -> explicit)
+                let auto_pad = value.clone().into_string();
+                if auto_pad != "NOTSET" {
+                    panic!("Unsupported 'auto_pad' value: {auto_pad}");
+                }
+            }
             _ => panic!("Unexpected attribute for ConvTranspose3d: {key}"),
         }
     }
@@ -130,6 +137,7 @@ mod tests {
         output_padding: Vec<i64>,
         group: i64,
         has_bias: bool,
+        auto_pad: Option<&str>,
     ) -> Node {
         // Create weight tensor data
         let weight_data = vec![0.0; 32]; // Not important for the test
@@ -158,6 +166,10 @@ mod tests {
             .attr_ints("output_padding", output_padding)
             .attr_int("group", group);
 
+        if let Some(auto_pad) = auto_pad {
+            builder = builder.attr_string("auto_pad", auto_pad);
+        }
+
         builder.build()
     }
 
@@ -171,6 +183,7 @@ mod tests {
             vec![0, 0, 0],
             1,
             false,
+            None,
         );
         let config = conv_transpose3d_config(&node);
 
@@ -194,6 +207,7 @@ mod tests {
             vec![0, 0, 0],
             1,
             false,
+            None,
         );
         let config = conv_transpose3d_config(&node);
 
@@ -211,6 +225,7 @@ mod tests {
             vec![1, 1, 1],
             1,
             false,
+            None,
         );
         let config = conv_transpose3d_config(&node);
 
@@ -227,6 +242,7 @@ mod tests {
             vec![0, 0, 0],
             2,
             false,
+            None,
         );
         let config = conv_transpose3d_config(&node);
 
@@ -244,6 +260,7 @@ mod tests {
             vec![0, 0, 0],
             1,
             true,
+            None,
         );
         let config = conv_transpose3d_config(&node);
 
@@ -261,7 +278,48 @@ mod tests {
             vec![0, 0, 0],
             1,
             false,
+            None,
         );
         let _ = conv_transpose3d_config(&node);
+    }
+
+    #[test]
+    fn test_conv_transpose3d_config_autopad_not_set() {
+        let node = create_test_node(
+            vec![2, 2, 2],
+            vec![1, 1, 1],
+            vec![0, 0, 0, 0, 0, 0],
+            vec![1, 1, 1],
+            vec![0, 0, 0],
+            1,
+            false,
+            Some("NOTSET"),
+        );
+        let config = conv_transpose3d_config(&node);
+
+        assert_eq!(config.channels, [4, 2]);
+        assert_eq!(config.kernel_size, [2, 2, 2]);
+        assert_eq!(config.stride, [1, 1, 1]);
+        assert_eq!(config.dilation, [1, 1, 1]);
+        assert_eq!(config.padding, [0, 0, 0]);
+        assert_eq!(config.padding_out, [0, 0, 0]);
+        assert_eq!(config.groups, 1);
+        assert!(!config.bias);
+    }
+
+    #[test]
+    #[should_panic = "Unsupported 'auto_pad' value"]
+    fn test_conv_transpose3d_config_autopad_not_supported() {
+        let node = create_test_node(
+            vec![2, 2, 2],
+            vec![1, 1, 1],
+            vec![0, 0, 0, 0, 0, 0],
+            vec![1, 1, 1],
+            vec![0, 0, 0],
+            1,
+            false,
+            Some("SAME_UPPER"),
+        );
+        let _config = conv_transpose3d_config(&node);
     }
 }

--- a/crates/onnx-ir/src/node/max_pool1d.rs
+++ b/crates/onnx-ir/src/node/max_pool1d.rs
@@ -58,8 +58,15 @@ pub fn max_pool1d_config(curr: &Node) -> MaxPool1dConfig {
             "strides" => stride = value.clone().into_i64s(),
             "pads" => pads = value.clone().into_i64s(),
             "dilations" => dilation = value.clone().into_i64s(),
+            "auto_pad" => {
+                // At least support default (not set -> explicit)
+                let auto_pad = value.clone().into_string();
+                if auto_pad != "NOTSET" {
+                    panic!("Unsupported 'auto_pad' value: {auto_pad}");
+                }
+            }
             // These are attributes that are allowed but not used in this implementation
-            "auto_pad" | "ceil_mode" | "storage_order" => {}
+            "ceil_mode" | "storage_order" => {}
             _ => panic!("Unexpected attribute for MaxPool1d: {key}"),
         }
     }
@@ -92,20 +99,24 @@ mod tests {
         stride: Vec<i64>,
         pads: Vec<i64>,
         dilation: Vec<i64>,
+        auto_pad: Option<&str>,
     ) -> Node {
-        NodeBuilder::new(NodeType::MaxPool1d, "test_maxpool1d")
+        let mut builder = NodeBuilder::new(NodeType::MaxPool1d, "test_maxpool1d")
             .input_tensor_f32("data", 3, None)
             .output_tensor_f32("output", 3, None)
             .attr_ints("kernel_shape", kernel_shape)
             .attr_ints("strides", stride)
             .attr_ints("pads", pads)
-            .attr_ints("dilations", dilation)
-            .build()
+            .attr_ints("dilations", dilation);
+        if let Some(auto_pad) = auto_pad {
+            builder = builder.attr_string("auto_pad", auto_pad);
+        }
+        builder.build()
     }
 
     #[test]
     fn test_max_pool1d_config_basic() {
-        let node = create_test_node(vec![4], vec![1], vec![0, 0], vec![1]);
+        let node = create_test_node(vec![4], vec![1], vec![0, 0], vec![1], None);
         let config = max_pool1d_config(&node);
 
         assert_eq!(config.kernel_size, 4);
@@ -116,7 +127,7 @@ mod tests {
 
     #[test]
     fn test_max_pool1d_config_with_padding() {
-        let node = create_test_node(vec![4], vec![2], vec![2, 2], vec![1]);
+        let node = create_test_node(vec![4], vec![2], vec![2, 2], vec![1], None);
         let config = max_pool1d_config(&node);
 
         assert_eq!(config.kernel_size, 4);
@@ -127,7 +138,7 @@ mod tests {
 
     #[test]
     fn test_max_pool1d_config_with_dilation() {
-        let node = create_test_node(vec![4], vec![1], vec![0, 0], vec![2]);
+        let node = create_test_node(vec![4], vec![1], vec![0, 0], vec![2], None);
         let config = max_pool1d_config(&node);
 
         assert_eq!(config.kernel_size, 4);
@@ -139,7 +150,25 @@ mod tests {
     #[test]
     #[should_panic(expected = "Asymmetric padding is not supported")]
     fn test_max_pool1d_config_asymmetric_padding() {
-        let node = create_test_node(vec![4], vec![1], vec![1, 2], vec![1]);
+        let node = create_test_node(vec![4], vec![1], vec![1, 2], vec![1], None);
         let _ = max_pool1d_config(&node);
+    }
+
+    #[test]
+    fn test_max_pool1d_config_auto_pad_not_set() {
+        let node = create_test_node(vec![4], vec![1], vec![0, 0], vec![1], Some("NOTSET"));
+        let config = max_pool1d_config(&node);
+
+        assert_eq!(config.kernel_size, 4);
+        assert_eq!(config.stride, 1);
+        assert_eq!(config.dilation, 1);
+        assert!(matches!(config.padding, PaddingConfig1d::Valid));
+    }
+
+    #[test]
+    #[should_panic = "Unsupported 'auto_pad' value"]
+    fn test_max_pool2d_config_auto_pad_not_supported() {
+        let node = create_test_node(vec![4], vec![1], vec![0, 0], vec![1], Some("SAME_UPPER"));
+        let _config = max_pool1d_config(&node);
     }
 }

--- a/crates/onnx-ir/src/node/max_pool1d.rs
+++ b/crates/onnx-ir/src/node/max_pool1d.rs
@@ -65,8 +65,13 @@ pub fn max_pool1d_config(curr: &Node) -> MaxPool1dConfig {
                     panic!("Unsupported 'auto_pad' value: {auto_pad}");
                 }
             }
+            "ceil_mode" => {
+                if value.clone().into_i64() == 1 {
+                    panic!("ceil_mode is not supported");
+                }
+            }
             // These are attributes that are allowed but not used in this implementation
-            "ceil_mode" | "storage_order" => {}
+            "storage_order" => {}
             _ => panic!("Unexpected attribute for MaxPool1d: {key}"),
         }
     }

--- a/crates/onnx-ir/src/node/max_pool1d.rs
+++ b/crates/onnx-ir/src/node/max_pool1d.rs
@@ -104,6 +104,7 @@ mod tests {
         stride: Vec<i64>,
         pads: Vec<i64>,
         dilation: Vec<i64>,
+        ceil_mode: i64,
         auto_pad: Option<&str>,
     ) -> Node {
         let mut builder = NodeBuilder::new(NodeType::MaxPool1d, "test_maxpool1d")
@@ -112,6 +113,7 @@ mod tests {
             .attr_ints("kernel_shape", kernel_shape)
             .attr_ints("strides", stride)
             .attr_ints("pads", pads)
+            .attr_int("ceil_mode", ceil_mode)
             .attr_ints("dilations", dilation);
         if let Some(auto_pad) = auto_pad {
             builder = builder.attr_string("auto_pad", auto_pad);
@@ -121,7 +123,7 @@ mod tests {
 
     #[test]
     fn test_max_pool1d_config_basic() {
-        let node = create_test_node(vec![4], vec![1], vec![0, 0], vec![1], None);
+        let node = create_test_node(vec![4], vec![1], vec![0, 0], vec![1], 0, None);
         let config = max_pool1d_config(&node);
 
         assert_eq!(config.kernel_size, 4);
@@ -132,7 +134,7 @@ mod tests {
 
     #[test]
     fn test_max_pool1d_config_with_padding() {
-        let node = create_test_node(vec![4], vec![2], vec![2, 2], vec![1], None);
+        let node = create_test_node(vec![4], vec![2], vec![2, 2], vec![1], 0, None);
         let config = max_pool1d_config(&node);
 
         assert_eq!(config.kernel_size, 4);
@@ -143,7 +145,7 @@ mod tests {
 
     #[test]
     fn test_max_pool1d_config_with_dilation() {
-        let node = create_test_node(vec![4], vec![1], vec![0, 0], vec![2], None);
+        let node = create_test_node(vec![4], vec![1], vec![0, 0], vec![2], 0, None);
         let config = max_pool1d_config(&node);
 
         assert_eq!(config.kernel_size, 4);
@@ -155,13 +157,13 @@ mod tests {
     #[test]
     #[should_panic(expected = "Asymmetric padding is not supported")]
     fn test_max_pool1d_config_asymmetric_padding() {
-        let node = create_test_node(vec![4], vec![1], vec![1, 2], vec![1], None);
+        let node = create_test_node(vec![4], vec![1], vec![1, 2], vec![1], 0, None);
         let _ = max_pool1d_config(&node);
     }
 
     #[test]
     fn test_max_pool1d_config_auto_pad_not_set() {
-        let node = create_test_node(vec![4], vec![1], vec![0, 0], vec![1], Some("NOTSET"));
+        let node = create_test_node(vec![4], vec![1], vec![0, 0], vec![1], 0, Some("NOTSET"));
         let config = max_pool1d_config(&node);
 
         assert_eq!(config.kernel_size, 4);
@@ -172,8 +174,15 @@ mod tests {
 
     #[test]
     #[should_panic = "Unsupported 'auto_pad' value"]
-    fn test_max_pool2d_config_auto_pad_not_supported() {
-        let node = create_test_node(vec![4], vec![1], vec![0, 0], vec![1], Some("SAME_UPPER"));
+    fn test_max_pool1d_config_auto_pad_not_supported() {
+        let node = create_test_node(vec![4], vec![1], vec![0, 0], vec![1], 0, Some("SAME_UPPER"));
+        let _config = max_pool1d_config(&node);
+    }
+
+    #[test]
+    #[should_panic(expected = "ceil_mode is not supported")]
+    fn test_max_pool1d_config_with_ceil_mode() {
+        let node = create_test_node(vec![4], vec![1], vec![0, 0], vec![1], 1, None);
         let _config = max_pool1d_config(&node);
     }
 }

--- a/crates/onnx-ir/src/node/max_pool2d.rs
+++ b/crates/onnx-ir/src/node/max_pool2d.rs
@@ -94,6 +94,7 @@ mod tests {
         strides: Vec<i64>,
         pads: Vec<i64>,
         dilations: Vec<i64>,
+        ceil_mode: i64,
         auto_pad: Option<&str>,
     ) -> Node {
         let mut builder = NodeBuilder::new(NodeType::MaxPool2d, "test_maxpool2d")
@@ -102,6 +103,7 @@ mod tests {
             .attr_ints("kernel_shape", kernel_shape)
             .attr_ints("strides", strides)
             .attr_ints("pads", pads)
+            .attr_int("ceil_mode", ceil_mode)
             .attr_ints("dilations", dilations);
         if let Some(auto_pad) = auto_pad {
             builder = builder.attr_string("auto_pad", auto_pad);
@@ -111,7 +113,14 @@ mod tests {
 
     #[test]
     fn test_max_pool2d_config_basic() {
-        let node = create_test_node(vec![3, 3], vec![1, 1], vec![0, 0, 0, 0], vec![1, 1], None);
+        let node = create_test_node(
+            vec![3, 3],
+            vec![1, 1],
+            vec![0, 0, 0, 0],
+            vec![1, 1],
+            0,
+            None,
+        );
         let config = max_pool2d_config(&node);
 
         assert_eq!(config.kernel_size, [3, 3]);
@@ -122,7 +131,14 @@ mod tests {
 
     #[test]
     fn test_max_pool2d_config_with_padding() {
-        let node = create_test_node(vec![2, 2], vec![2, 2], vec![1, 1, 1, 1], vec![1, 1], None);
+        let node = create_test_node(
+            vec![2, 2],
+            vec![2, 2],
+            vec![1, 1, 1, 1],
+            vec![1, 1],
+            0,
+            None,
+        );
         let config = max_pool2d_config(&node);
 
         assert_eq!(config.kernel_size, [2, 2]);
@@ -133,7 +149,14 @@ mod tests {
 
     #[test]
     fn test_max_pool2d_config_with_dilation() {
-        let node = create_test_node(vec![3, 3], vec![1, 1], vec![0, 0, 0, 0], vec![2, 2], None);
+        let node = create_test_node(
+            vec![3, 3],
+            vec![1, 1],
+            vec![0, 0, 0, 0],
+            vec![2, 2],
+            0,
+            None,
+        );
         let config = max_pool2d_config(&node);
 
         assert_eq!(config.kernel_size, [3, 3]);
@@ -149,6 +172,7 @@ mod tests {
             vec![1, 1],
             vec![0, 0, 0, 0],
             vec![1, 1],
+            0,
             Some("NOTSET"),
         );
         let config = max_pool2d_config(&node);
@@ -167,7 +191,22 @@ mod tests {
             vec![1, 1],
             vec![0, 0, 0, 0],
             vec![1, 1],
+            0,
             Some("SAME_UPPER"),
+        );
+        let _config = max_pool2d_config(&node);
+    }
+
+    #[test]
+    #[should_panic(expected = "ceil_mode is not supported")]
+    fn test_max_pool2d_config_with_ceil_mode() {
+        let node = create_test_node(
+            vec![3, 3],
+            vec![1, 1],
+            vec![0, 0, 0, 0],
+            vec![1, 1],
+            1,
+            None,
         );
         let _config = max_pool2d_config(&node);
     }

--- a/crates/onnx-ir/src/node/max_pool2d.rs
+++ b/crates/onnx-ir/src/node/max_pool2d.rs
@@ -64,8 +64,13 @@ pub fn max_pool2d_config(curr: &Node) -> MaxPool2dConfig {
                     panic!("Unsupported 'auto_pad' value: {auto_pad}");
                 }
             }
+            "ceil_mode" => {
+                if value.clone().into_i64() == 1 {
+                    panic!("ceil_mode is not supported");
+                }
+            }
             // These are attributes that are allowed but not used in this implementation
-            "ceil_mode" | "storage_order" => {}
+            "storage_order" => {}
             _ => panic!("Unexpected attribute for MaxPool2d: {key}"),
         }
     }

--- a/crates/onnx-ir/src/node/max_pool2d.rs
+++ b/crates/onnx-ir/src/node/max_pool2d.rs
@@ -57,8 +57,15 @@ pub fn max_pool2d_config(curr: &Node) -> MaxPool2dConfig {
             "strides" => strides = value.clone().into_i64s(),
             "pads" => pads = value.clone().into_i64s(),
             "dilations" => dilations = value.clone().into_i64s(),
+            "auto_pad" => {
+                // At least support default (not set -> explicit)
+                let auto_pad = value.clone().into_string();
+                if auto_pad != "NOTSET" {
+                    panic!("Unsupported 'auto_pad' value: {auto_pad}");
+                }
+            }
             // These are attributes that are allowed but not used in this implementation
-            "auto_pad" | "ceil_mode" | "storage_order" => {}
+            "ceil_mode" | "storage_order" => {}
             _ => panic!("Unexpected attribute for MaxPool2d: {key}"),
         }
     }
@@ -82,20 +89,24 @@ mod tests {
         strides: Vec<i64>,
         pads: Vec<i64>,
         dilations: Vec<i64>,
+        auto_pad: Option<&str>,
     ) -> Node {
-        NodeBuilder::new(NodeType::MaxPool2d, "test_maxpool2d")
+        let mut builder = NodeBuilder::new(NodeType::MaxPool2d, "test_maxpool2d")
             .input_tensor_f32("data", 4, None)
             .output_tensor_f32("output", 4, None)
             .attr_ints("kernel_shape", kernel_shape)
             .attr_ints("strides", strides)
             .attr_ints("pads", pads)
-            .attr_ints("dilations", dilations)
-            .build()
+            .attr_ints("dilations", dilations);
+        if let Some(auto_pad) = auto_pad {
+            builder = builder.attr_string("auto_pad", auto_pad);
+        }
+        builder.build()
     }
 
     #[test]
     fn test_max_pool2d_config_basic() {
-        let node = create_test_node(vec![3, 3], vec![1, 1], vec![0, 0, 0, 0], vec![1, 1]);
+        let node = create_test_node(vec![3, 3], vec![1, 1], vec![0, 0, 0, 0], vec![1, 1], None);
         let config = max_pool2d_config(&node);
 
         assert_eq!(config.kernel_size, [3, 3]);
@@ -106,7 +117,7 @@ mod tests {
 
     #[test]
     fn test_max_pool2d_config_with_padding() {
-        let node = create_test_node(vec![2, 2], vec![2, 2], vec![1, 1, 1, 1], vec![1, 1]);
+        let node = create_test_node(vec![2, 2], vec![2, 2], vec![1, 1, 1, 1], vec![1, 1], None);
         let config = max_pool2d_config(&node);
 
         assert_eq!(config.kernel_size, [2, 2]);
@@ -117,12 +128,42 @@ mod tests {
 
     #[test]
     fn test_max_pool2d_config_with_dilation() {
-        let node = create_test_node(vec![3, 3], vec![1, 1], vec![0, 0, 0, 0], vec![2, 2]);
+        let node = create_test_node(vec![3, 3], vec![1, 1], vec![0, 0, 0, 0], vec![2, 2], None);
         let config = max_pool2d_config(&node);
 
         assert_eq!(config.kernel_size, [3, 3]);
         assert_eq!(config.strides, [1, 1]);
         assert_eq!(config.dilation, [2, 2]);
         assert!(matches!(config.padding, PaddingConfig2d::Valid));
+    }
+
+    #[test]
+    fn test_max_pool2d_config_auto_pad_not_set() {
+        let node = create_test_node(
+            vec![3, 3],
+            vec![1, 1],
+            vec![0, 0, 0, 0],
+            vec![1, 1],
+            Some("NOTSET"),
+        );
+        let config = max_pool2d_config(&node);
+
+        assert_eq!(config.kernel_size, [3, 3]);
+        assert_eq!(config.strides, [1, 1]);
+        assert_eq!(config.dilation, [1, 1]);
+        assert!(matches!(config.padding, PaddingConfig2d::Valid));
+    }
+
+    #[test]
+    #[should_panic = "Unsupported 'auto_pad' value"]
+    fn test_max_pool2d_config_auto_pad_not_supported() {
+        let node = create_test_node(
+            vec![3, 3],
+            vec![1, 1],
+            vec![0, 0, 0, 0],
+            vec![1, 1],
+            Some("SAME_UPPER"),
+        );
+        let _config = max_pool2d_config(&node);
     }
 }


### PR DESCRIPTION
### Related Issues/PRs

Fixes #3540 

### Changes

- Added `auto_pad` attribute handling for conv and conv transpose
- Added `ceil_mode` attribute handling for pooling (should not be ignored, but checked)

### Testing

Added tests
