### PR TITLE
Support int min/max types in clip_config

### DIFF
--- a/crates/onnx-ir/src/node/clip.rs
+++ b/crates/onnx-ir/src/node/clip.rs
@@ -33,7 +33,9 @@ pub fn clip_config(node: &Node) -> (Option<f64>, Option<f64>) {
                 Data::Float16(min) => Some(f32::from(min) as f64),
                 Data::Float32(min) => Some(min as f64),
                 Data::Float64(min) => Some(min),
-                _ => panic!("Clip: only float min is supported"),
+                Data::Int32(min) => Some(min as f64),
+                Data::Int64(min) => Some(min as f64),
+                _ => panic!("Clip: unsupported min data type {:?}", min),
             };
         }
 
@@ -45,7 +47,9 @@ pub fn clip_config(node: &Node) -> (Option<f64>, Option<f64>) {
                 Data::Float16(max) => Some(f32::from(max) as f64),
                 Data::Float32(max) => Some(max as f64),
                 Data::Float64(max) => Some(max),
-                _ => panic!("Clip: only float max is supported"),
+                Data::Int32(max) => Some(max as f64),
+                Data::Int64(max) => Some(max as f64),
+                _ => panic!("Clip: unsupported max data type {:?}", max),
             };
         }
     }


### PR DESCRIPTION
Added handling for Int32 and Int64 types for min and max values in the clip_config function. 

Came across a case when building deberta model. This should fix it.

## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

https://github.com/tracel-ai/burn/pull/3381

### Changes

Add more datatypes. 

### Testing

Built deberta model.
