### PR TITLE
Fix backward scatter dim for `{min, max, sort}_dim`

### DIFF
--- a/crates/burn-autodiff/src/ops/maxmin.rs
+++ b/crates/burn-autodiff/src/ops/maxmin.rs
@@ -6,7 +6,7 @@ use burn_tensor::{Shape, backend::Backend};
 pub(crate) struct MaxMinDim;
 
 impl<B: Backend> Backward<B, 1> for MaxMinDim {
-    type State = (B::IntTensorPrimitive, Shape);
+    type State = (B::IntTensorPrimitive, Shape, usize);
 
     fn backward(
         self,
@@ -15,12 +15,11 @@ impl<B: Backend> Backward<B, 1> for MaxMinDim {
         _checkpointer: &mut Checkpointer,
     ) {
         unary::<B, _>(ops.parents, ops.node, grads, |grad| {
-            let (indices, shape) = ops.state;
-            let ndims = shape.num_dims();
+            let (indices, shape, dim) = ops.state;
             let device = B::float_device(&grad);
             let zeros = B::float_zeros(shape, &device);
 
-            B::float_scatter(ndims - 1, zeros, indices, grad)
+            B::float_scatter(dim, zeros, indices, grad)
         });
     }
 }

--- a/crates/burn-autodiff/src/ops/sort.rs
+++ b/crates/burn-autodiff/src/ops/sort.rs
@@ -6,7 +6,7 @@ use burn_tensor::{Shape, backend::Backend};
 pub(crate) struct SortDim;
 
 impl<B: Backend> Backward<B, 1> for SortDim {
-    type State = (B::IntTensorPrimitive, Shape);
+    type State = (B::IntTensorPrimitive, Shape, usize);
 
     fn backward(
         self,
@@ -15,12 +15,11 @@ impl<B: Backend> Backward<B, 1> for SortDim {
         _checkpointer: &mut Checkpointer,
     ) {
         unary::<B, _>(ops.parents, ops.node, grads, |grad| {
-            let (indices, shape) = ops.state;
-            let ndims = shape.num_dims();
+            let (indices, shape, dim) = ops.state;
             let device = B::float_device(&grad);
             let zeros = B::float_zeros(shape, &device);
 
-            B::float_scatter(ndims - 1, zeros, indices, grad)
+            B::float_scatter(dim, zeros, indices, grad)
         });
     }
 }

--- a/crates/burn-autodiff/src/ops/tensor.rs
+++ b/crates/burn-autodiff/src/ops/tensor.rs
@@ -2187,7 +2187,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
             OpsKind::Tracked(prep) => {
                 let shape = tensor.primitive.shape();
                 let (tensor, index) = B::float_max_dim_with_indices(tensor.primitive, dim);
-                prep.finish((index, shape), tensor)
+                prep.finish((index, shape, dim), tensor)
             }
             OpsKind::UnTracked(prep) => prep.finish(B::float_max_dim(tensor.primitive, dim)),
         }
@@ -2204,7 +2204,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
             OpsKind::Tracked(prep) => {
                 let shape = tensor.primitive.shape();
                 let (tensor, index) = B::float_max_dim_with_indices(tensor.primitive, dim);
-                let tensor = prep.finish((index.clone(), shape), tensor);
+                let tensor = prep.finish((index.clone(), shape, dim), tensor);
 
                 (tensor, index)
             }
@@ -2216,6 +2216,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
             }
         }
     }
+
     fn float_min_dim(tensor: FloatTensor<Self>, dim: usize) -> FloatTensor<Self> {
         match MaxMinDim
             .prepare::<C>([tensor.node])
@@ -2225,7 +2226,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
             OpsKind::Tracked(prep) => {
                 let shape = tensor.primitive.shape();
                 let (tensor, index) = B::float_min_dim_with_indices(tensor.primitive, dim);
-                prep.finish((index, shape), tensor)
+                prep.finish((index, shape, dim), tensor)
             }
             OpsKind::UnTracked(prep) => prep.finish(B::float_min_dim(tensor.primitive, dim)),
         }
@@ -2242,7 +2243,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
             OpsKind::Tracked(prep) => {
                 let shape = tensor.primitive.shape();
                 let (tensor, index) = B::float_min_dim_with_indices(tensor.primitive, dim);
-                let tensor = prep.finish((index.clone(), shape), tensor);
+                let tensor = prep.finish((index.clone(), shape, dim), tensor);
 
                 (tensor, index)
             }
@@ -2449,7 +2450,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                 let shape = tensor.primitive.shape();
                 let (tensor, indices) =
                     B::float_sort_with_indices(tensor.primitive, dim, descending);
-                prep.finish((indices, shape), tensor)
+                prep.finish((indices, shape, dim), tensor)
             }
             OpsKind::UnTracked(prep) => {
                 prep.finish(B::float_sort(tensor.primitive, dim, descending))
@@ -2471,7 +2472,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                 let shape = tensor.primitive.shape();
                 let (tensor, indices) =
                     B::float_sort_with_indices(tensor.primitive, dim, descending);
-                let tensor = prep.finish((indices.clone(), shape), tensor);
+                let tensor = prep.finish((indices.clone(), shape, dim), tensor);
 
                 (tensor, indices)
             }

--- a/crates/burn-autodiff/src/tests/maxmin.rs
+++ b/crates/burn-autodiff/src/tests/maxmin.rs
@@ -56,4 +56,31 @@ mod tests {
             .to_data()
             .assert_approx_eq::<FT>(&expected, Tolerance::default());
     }
+
+    #[test]
+    fn should_diff_min_dim_3d_dim1() {
+        let device = Default::default();
+        let tensor_1 = TestAutodiffTensor::<3>::from_floats([[[1.0, 7.0], [-2.0, -3.0]]], &device)
+            .require_grad();
+        let tensor_2 =
+            TestAutodiffTensor::<3>::from_floats([[[4., -7.], [2., 3.]]], &device).require_grad();
+
+        let tensor_3 = tensor_1.clone().mul(tensor_2.clone());
+        let tensor_4 = tensor_3.min_dim(1);
+
+        let grads = tensor_4.backward();
+
+        let grad_1 = tensor_1.grad(&grads).unwrap();
+        let grad_2 = tensor_2.grad(&grads).unwrap();
+
+        let expected = TensorData::from([[[0., -7.], [2., 0.]]]);
+        grad_1
+            .to_data()
+            .assert_approx_eq::<FT>(&expected, Tolerance::default());
+
+        let expected = TensorData::from([[[0., 7.], [-2., -0.]]]);
+        grad_2
+            .to_data()
+            .assert_approx_eq::<FT>(&expected, Tolerance::default());
+    }
 }

--- a/crates/burn-autodiff/src/tests/sort.rs
+++ b/crates/burn-autodiff/src/tests/sort.rs
@@ -57,4 +57,30 @@ mod tests {
             .to_data()
             .assert_approx_eq::<FT>(&expected, Tolerance::default());
     }
+
+    #[test]
+    fn should_diff_sort_3d_dim1() {
+        let device = Default::default();
+        let tensor_1 = TestAutodiffTensor::<3>::from_floats([[[1.0, 7.0], [-2.0, -3.0]]], &device)
+            .require_grad();
+        let tensor_2 =
+            TestAutodiffTensor::from_floats([[[4.0, -7.0], [2.0, 3.0]]], &device).require_grad();
+
+        let tensor_3 = tensor_1.clone().matmul(tensor_2.clone());
+        let tensor_4 = tensor_1.clone().mul(tensor_3.sort(1));
+        let grads = tensor_4.backward();
+
+        let grad_1 = tensor_1.grad(&grads).unwrap();
+        let grad_2 = tensor_2.grad(&grads).unwrap();
+
+        let expected = TensorData::from([[[-1., -8.], [-27., 37.]]]);
+        grad_1
+            .to_data()
+            .assert_approx_eq::<FT>(&expected, Tolerance::default());
+
+        let expected = TensorData::from([[[-4., -17.], [-17., -42.]]]);
+        grad_2
+            .to_data()
+            .assert_approx_eq::<FT>(&expected, Tolerance::default());
+    }
 }


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.

### Related Issues/PRs

Fixes #3427

### Changes

Backward implementation was always using the last dim, fixed to use the provided `dim`

### Testing

Added unit tests + ran the example code in the linked issue