### PR TITLE
Add  feature flag to bytemuck due to usage of API extern_crate_alloc

### DIFF
--- a/crates/onnx-ir/Cargo.toml
+++ b/crates/onnx-ir/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 
 
 [dependencies]
-bytemuck = { workspace = true }
+bytemuck = { workspace = true, features = ["extern_crate_alloc"] }
 half = { workspace = true, features = ["bytemuck"] }
 log = { workspace = true }
 protobuf = { workspace = true, features = ["with-bytes"] }


### PR DESCRIPTION
I got some compile issues with some tests in onnx-ir before this PR.

https://docs.rs/bytemuck/latest/bytemuck/allocation/fn.try_cast_vec.html

The flag in this PR is required for `try_cast_vec`.

### Changes

Add the flag.

### Testing

Tests in onnx-ir were able to compile and run with the flag enabled.
