### PR TITLE
Expose client utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1709,7 +1709,6 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=763109fcc38bb5710c34a74b48b7e063e2750330#763109fcc38bb5710c34a74b48b7e063e2750330"
 dependencies = [
  "cubecl-convolution",
  "cubecl-core",
@@ -1728,7 +1727,6 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=763109fcc38bb5710c34a74b48b7e063e2750330#763109fcc38bb5710c34a74b48b7e063e2750330"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -1755,7 +1753,6 @@ dependencies = [
 [[package]]
 name = "cubecl-convolution"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=763109fcc38bb5710c34a74b48b7e063e2750330#763109fcc38bb5710c34a74b48b7e063e2750330"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1773,7 +1770,6 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=763109fcc38bb5710c34a74b48b7e063e2750330#763109fcc38bb5710c34a74b48b7e063e2750330"
 dependencies = [
  "bitflags 2.9.1",
  "bytemuck",
@@ -1796,7 +1792,6 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=763109fcc38bb5710c34a74b48b7e063e2750330#763109fcc38bb5710c34a74b48b7e063e2750330"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1810,7 +1805,6 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=763109fcc38bb5710c34a74b48b7e063e2750330#763109fcc38bb5710c34a74b48b7e063e2750330"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1832,7 +1826,6 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=763109fcc38bb5710c34a74b48b7e063e2750330#763109fcc38bb5710c34a74b48b7e063e2750330"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1849,7 +1842,6 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=763109fcc38bb5710c34a74b48b7e063e2750330#763109fcc38bb5710c34a74b48b7e063e2750330"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1877,7 +1869,6 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=763109fcc38bb5710c34a74b48b7e063e2750330#763109fcc38bb5710c34a74b48b7e063e2750330"
 dependencies = [
  "cubecl-common",
  "cubecl-macros-internal",
@@ -1895,7 +1886,6 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=763109fcc38bb5710c34a74b48b7e063e2750330#763109fcc38bb5710c34a74b48b7e063e2750330"
 dependencies = [
  "cubecl-common",
  "darling 0.21.0",
@@ -1910,7 +1900,6 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=763109fcc38bb5710c34a74b48b7e063e2750330#763109fcc38bb5710c34a74b48b7e063e2750330"
 dependencies = [
  "darling 0.21.0",
  "proc-macro2",
@@ -1921,7 +1910,6 @@ dependencies = [
 [[package]]
 name = "cubecl-matmul"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=763109fcc38bb5710c34a74b48b7e063e2750330#763109fcc38bb5710c34a74b48b7e063e2750330"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1938,7 +1926,6 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=763109fcc38bb5710c34a74b48b7e063e2750330#763109fcc38bb5710c34a74b48b7e063e2750330"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1955,7 +1942,6 @@ dependencies = [
 [[package]]
 name = "cubecl-random"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=763109fcc38bb5710c34a74b48b7e063e2750330#763109fcc38bb5710c34a74b48b7e063e2750330"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1970,7 +1956,6 @@ dependencies = [
 [[package]]
 name = "cubecl-reduce"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=763109fcc38bb5710c34a74b48b7e063e2750330#763109fcc38bb5710c34a74b48b7e063e2750330"
 dependencies = [
  "cubecl-core",
  "cubecl-runtime",
@@ -1985,7 +1970,6 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=763109fcc38bb5710c34a74b48b7e063e2750330#763109fcc38bb5710c34a74b48b7e063e2750330"
 dependencies = [
  "async-channel",
  "bytemuck",
@@ -2011,7 +1995,6 @@ dependencies = [
 [[package]]
 name = "cubecl-spirv"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=763109fcc38bb5710c34a74b48b7e063e2750330#763109fcc38bb5710c34a74b48b7e063e2750330"
 dependencies = [
  "bitflags 2.9.1",
  "cubecl-common",
@@ -2027,7 +2010,6 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=763109fcc38bb5710c34a74b48b7e063e2750330#763109fcc38bb5710c34a74b48b7e063e2750330"
 dependencies = [
  "cubecl-core",
  "cubecl-runtime",
@@ -2038,7 +2020,6 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=763109fcc38bb5710c34a74b48b7e063e2750330#763109fcc38bb5710c34a74b48b7e063e2750330"
 dependencies = [
  "ash",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,11 +155,11 @@ portable-atomic = { version = "1.11.1" }
 portable-atomic-util = { version = "0.2.4", features = ["alloc"] }
 
 ### For the main burn branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "763109fcc38bb5710c34a74b48b7e063e2750330" }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "763109fcc38bb5710c34a74b48b7e063e2750330" }
+# cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "763109fcc38bb5710c34a74b48b7e063e2750330" }
+# cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "763109fcc38bb5710c34a74b48b7e063e2750330" }
 ### For local development. ###
-# cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
-# cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }
+cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
+cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }
 ### For the release. ###
 # cubecl = { version = "0.6.0", default-features = false }
 # cubecl-common = { version = "0.6.0", default-features = false }

--- a/crates/burn-fusion/src/backend.rs
+++ b/crates/burn-fusion/src/backend.rs
@@ -14,7 +14,7 @@ use std::marker::PhantomData;
 
 pub(crate) static CLIENTS: FusionClientLocator = FusionClientLocator::new();
 
-pub(crate) fn get_client<B: FusionBackend>(device: &Device<B>) -> Client<B::FusionRuntime> {
+pub fn get_client<B: FusionBackend>(device: &Device<B>) -> Client<B::FusionRuntime> {
     CLIENTS.client::<B::FusionRuntime>(device)
 }
 

--- a/crates/burn-fusion/src/lib.rs
+++ b/crates/burn-fusion/src/lib.rs
@@ -27,4 +27,5 @@ pub(crate) use server::*;
 
 pub use backend::*;
 pub use fusion::*;
+pub use ops::NoOp;
 pub use tensor::*;

--- a/crates/burn-fusion/src/ops/mod.rs
+++ b/crates/burn-fusion/src/ops/mod.rs
@@ -9,4 +9,5 @@ mod transaction;
 mod unary;
 
 mod base;
+pub use base::NoOp;
 pub(crate) use base::*;


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [X] Confirmed that `cargo run-checks` command has been executed.
- [X] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

n/a

### Changes

This change exposes NoOp and get_client() in burn_fusion.  Both are used in methods implemented on FusionBackend to register operations via the FusionClient.

get_client():
- Other examples of extending FusionBackends, such as [this one](https://github.com/ArthurBrussee/brush/blob/a9cb04da9471753c4457a40c8cbbd6c84711b3b4/crates/brush-render-bwd/src/burn_glue.rs#L267) fetch the fusion client from an input tensor.
- However, if your extension does not have access to an existing tensor from the backend, then you have no way to access the client.

NoOp:
- This is only one fusion Op that we're exposing, but potentially many others could be useful to backend extension development.
### Testing

No testing - as we're only exposing existing types to the public burn_fusion API.
