### PR TITLE
[WIP] Lift .full()/.full_like() into base Tensor.

### DIFF
--- a/crates/burn-autodiff/src/ops/bool_tensor.rs
+++ b/crates/burn-autodiff/src/ops/bool_tensor.rs
@@ -40,6 +40,14 @@ impl<B: Backend, C: CheckpointStrategy> BoolTensorOps<Self> for Autodiff<B, C> {
         B::bool_empty(shape, device)
     }
 
+    fn bool_zeros(shape: Shape, device: &Device<B>) -> BoolTensor<B> {
+        B::bool_zeros(shape, device)
+    }
+
+    fn bool_ones(shape: Shape, device: &Device<B>) -> BoolTensor<B> {
+        B::bool_ones(shape, device)
+    }
+
     fn bool_slice_assign(
         tensor: BoolTensor<Self>,
         ranges: &[core::ops::Range<usize>],

--- a/crates/burn-candle/src/ops/base.rs
+++ b/crates/burn-candle/src/ops/base.rs
@@ -43,8 +43,18 @@ pub fn to_device(tensor: CandleTensor, device: &CandleDevice) -> CandleTensor {
 }
 
 pub fn empty(shape: Shape, device: &CandleDevice, dtype: candle_core::DType) -> CandleTensor {
+    zeros(shape, device, dtype)
+}
+
+pub fn zeros(shape: Shape, device: &CandleDevice, dtype: candle_core::DType) -> CandleTensor {
     CandleTensor::new(
         candle_core::Tensor::zeros(shape.dims, dtype, &(device.clone()).into()).unwrap(),
+    )
+}
+
+pub fn ones(shape: Shape, device: &CandleDevice, dtype: candle_core::DType) -> CandleTensor {
+    CandleTensor::new(
+        candle_core::Tensor::ones(shape.dims, dtype, &(device.clone()).into()).unwrap(),
     )
 }
 

--- a/crates/burn-candle/src/ops/bool_tensor.rs
+++ b/crates/burn-candle/src/ops/bool_tensor.rs
@@ -16,6 +16,14 @@ impl<F: FloatCandleElement, I: IntCandleElement> BoolTensorOps<Self> for Candle<
         super::base::empty(shape, device, candle_core::DType::U8)
     }
 
+    fn bool_zeros(shape: Shape, device: &Device<Self>) -> BoolTensor<Self> {
+        super::base::zeros(shape, device, candle_core::DType::U8)
+    }
+
+    fn bool_ones(shape: Shape, device: &Device<Self>) -> BoolTensor<Self> {
+        super::base::ones(shape, device, candle_core::DType::U8)
+    }
+
     async fn bool_into_data(tensor: BoolTensor<Self>) -> TensorData {
         let x: Vec<u8> = tensor.tensor.flatten_all().unwrap().to_vec1().unwrap();
         let y = x.iter().map(|b| !matches!(b, 0)).collect();

--- a/crates/burn-cubecl/src/ops/bool_ops.rs
+++ b/crates/burn-cubecl/src/ops/bool_ops.rs
@@ -7,7 +7,7 @@ use burn_tensor::ops::{BoolTensor, BoolTensorOps, Device, FloatTensor, IntTensor
 use burn_tensor::{Shape, TensorData};
 use std::ops::Range;
 
-use super::{expand, permute};
+use super::{expand, numeric, permute};
 
 impl<R, F, I, BT> BoolTensorOps<Self> for CubeBackend<R, F, I, BT>
 where
@@ -18,6 +18,14 @@ where
 {
     fn bool_empty(shape: Shape, device: &Device<Self>) -> BoolTensor<Self> {
         super::empty::<R, BT>(shape, device)
+    }
+
+    fn bool_zeros(shape: Shape, device: &Device<Self>) -> BoolTensor<Self> {
+        numeric::zeros::<R, I>(shape, device)
+    }
+
+    fn bool_ones(shape: Shape, device: &Device<Self>) -> BoolTensor<Self> {
+        numeric::ones::<R, I>(shape, device)
     }
 
     async fn bool_into_data(tensor: BoolTensor<Self>) -> TensorData {

--- a/crates/burn-fusion/src/ops/boolean.rs
+++ b/crates/burn-fusion/src/ops/boolean.rs
@@ -47,6 +47,62 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
         out
     }
 
+    fn bool_zeros(shape: Shape, device: &Device<Self>) -> BoolTensor<Self> {
+        #[derive(new, Debug)]
+        struct ZerosOps<B: FusionBackend> {
+            desc: TensorIr,
+            device: Device<B>,
+        }
+
+        impl<B: FusionBackend> Operation<B::FusionRuntime> for ZerosOps<B> {
+            fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
+                let output = B::bool_zeros(Shape::from(&self.desc.shape), &self.device);
+                handles.register_bool_tensor::<B>(&self.desc.id, output);
+            }
+        }
+
+        let client = get_client::<B>(&device.clone());
+        let out = client.tensor_uninitialized(shape.dims.clone(), B::BoolElem::dtype());
+
+        let desc = out.to_ir_out();
+
+        client.register(
+            OperationStreams::default(),
+            OperationIr::BaseBool(BaseOperationIr::Empty(desc.clone())),
+            ZerosOps::<B>::new(desc, device.clone()),
+        );
+
+        out
+    }
+
+    fn bool_ones(shape: Shape, device: &Device<Self>) -> BoolTensor<Self> {
+        #[derive(new, Debug)]
+        struct OnesOps<B: FusionBackend> {
+            desc: TensorIr,
+            device: Device<B>,
+        }
+
+        impl<B: FusionBackend> Operation<B::FusionRuntime> for OnesOps<B> {
+            fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
+                let output = B::bool_ones(Shape::from(&self.desc.shape), &self.device);
+                handles.register_bool_tensor::<B>(&self.desc.id, output);
+            }
+        }
+
+        let client = get_client::<B>(&device.clone());
+        let out = client.tensor_uninitialized(shape.dims.clone(), B::BoolElem::dtype());
+
+        let desc = out.to_ir_out();
+
+        client.register(
+            OperationStreams::default(),
+            OperationIr::BaseBool(BaseOperationIr::Empty(desc.clone())),
+            OnesOps::<B>::new(desc, device.clone()),
+        );
+
+        out
+    }
+
     async fn bool_into_data(tensor: BoolTensor<Self>) -> TensorData {
         tensor.bool_into_data::<B>().await
     }

--- a/crates/burn-ndarray/src/ops/bool_tensor.rs
+++ b/crates/burn-ndarray/src/ops/bool_tensor.rs
@@ -56,7 +56,16 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> BoolTensorOp
     }
 
     fn bool_empty(shape: Shape, _device: &<NdArray<E> as Backend>::Device) -> NdArrayTensor<bool> {
+        Self::bool_zeros(shape, _device)
+    }
+
+    fn bool_zeros(shape: Shape, _device: &<NdArray<E> as Backend>::Device) -> NdArrayTensor<bool> {
         let values = vec![false; shape.num_elements()];
+        NdArrayTensor::from_data(TensorData::new(values, shape))
+    }
+
+    fn bool_ones(shape: Shape, _device: &<NdArray<E> as Backend>::Device) -> NdArrayTensor<bool> {
+        let values = vec![true; shape.num_elements()];
         NdArrayTensor::from_data(TensorData::new(values, shape))
     }
 

--- a/crates/burn-tch/src/ops/bool_tensor.rs
+++ b/crates/burn-tch/src/ops/bool_tensor.rs
@@ -43,6 +43,24 @@ impl<E: TchElement, Q: QuantElement> BoolTensorOps<Self> for LibTorch<E, Q> {
         TchTensor::new(tensor)
     }
 
+    fn bool_zeros(shape: Shape, device: &<LibTorch<E> as Backend>::Device) -> TchTensor {
+        let tensor = tch::Tensor::zeros(
+            TchShape::from(shape).dims,
+            (tch::Kind::Bool, (*device).into()),
+        );
+
+        TchTensor::new(tensor)
+    }
+
+    fn bool_ones(shape: Shape, device: &<LibTorch<E> as Backend>::Device) -> TchTensor {
+        let tensor = tch::Tensor::zeros(
+            TchShape::from(shape).dims,
+            (tch::Kind::Bool, (*device).into()),
+        );
+
+        TchTensor::new(tensor)
+    }
+
     fn bool_slice(tensor: TchTensor, ranges: &[Range<usize>]) -> TchTensor {
         TchOps::slice(tensor, ranges)
     }

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -93,6 +93,7 @@ impl<B, const D: usize, K> Tensor<B, D, K>
 where
     B: Backend,
     K: BasicOps<B>,
+    K::Elem: Element,
 {
     /// Executes an operation on the tensor and modifies its value.
     ///
@@ -153,6 +154,51 @@ where
         let shape = shape.into();
         check!(TensorCheck::creation_ops::<D>("Empty", &shape.dims));
         Self::new(K::empty(shape, device))
+    }
+
+    /// Create a tensor of the given shape where each element is equal to the provided value.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use burn_tensor::backend::Backend;
+    /// use burn_tensor::{Tensor, Shape};
+    ///
+    /// fn example<B: Backend>() {
+    ///   let device = B::Device::default();
+    ///   let tensor = Tensor::<B, 2>::full(Shape::new([2, 3]), 5.0, &device);
+    ///   println!("{tensor}");
+    ///   // [[5.0, 5.0, 5.0], [5.0, 5.0, 5.0]]
+    /// }
+    /// ```
+    pub fn full<S: Into<Shape>, E: ElementConversion>(
+        shape: S,
+        fill_value: E,
+        device: &B::Device,
+    ) -> Self {
+        let shape = shape.into();
+        check!(TensorCheck::creation_ops::<D>("Full", &shape.dims));
+        Self::new(K::full(shape, fill_value, device))
+    }
+
+    ///Returns a new tensor with the same shape and device as the current tensor filled with the provided value.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use burn_tensor::backend::Backend;
+    /// use burn_tensor::{Tensor, Shape};
+    ///
+    /// fn example<B: Backend>() {
+    ///    let device = B::Device::default();
+    ///    let tensor = Tensor::<B, 2>::from_data([[1.0, -2.0, 3.0], [5.0, 9.0, 6.0]], &device);
+    ///    let tensor = tensor.full_like(5.0);
+    ///    println!("{tensor}");
+    ///    // [[5.0, 5.0, 5.0], [5.0, 5.0, 5.0]]
+    /// }
+    /// ```
+    pub fn full_like<E: ElementConversion>(&self, fill_value: E) -> Self {
+        Self::full(self.shape(), fill_value, &self.device())
     }
 
     /// Returns the dimensions of the current tensor.
@@ -2319,6 +2365,32 @@ pub trait BasicOps<B: Backend>: TensorKind<B> {
     /// which is more high-level and designed for public use.
     fn empty(shape: Shape, device: &B::Device) -> Self::Primitive;
 
+    /// Creates a tensor of the given shape where each element is equal to the provided value.
+    ///
+    /// # Arguments
+    ///
+    /// * `shape` - The shape of the tensor.
+    /// * `fill_value` - The value with which to fill the tensor.
+    /// * `device` - The device on which the tensor will be allocated.
+    ///
+    /// # Returns
+    ///
+    /// The empty tensor.
+    ///
+    /// # Remarks
+    ///
+    /// This is a low-level function used internally by the library to call different backend functions
+    /// with static dispatch. It is not designed for direct usage by users, and not recommended to import
+    /// or use this function directly.
+    ///
+    /// For creating full tensors, users should prefer the [Tensor::full](Tensor::full) function,
+    /// which is more high-level and designed for public use.
+    fn full<E: ElementConversion>(
+        shape: Shape,
+        fill_value: E,
+        device: &B::Device,
+    ) -> Self::Primitive;
+
     /// Reshapes the tensor.
     ///
     /// # Arguments
@@ -2783,6 +2855,14 @@ impl<B: Backend> BasicOps<B> for Float {
         TensorPrimitive::Float(B::float_empty(shape, device))
     }
 
+    fn full<E: ElementConversion>(
+        shape: Shape,
+        fill_value: E,
+        device: &B::Device,
+    ) -> Self::Primitive {
+        TensorPrimitive::Float(B::float_full(shape, fill_value.elem(), device))
+    }
+
     fn register_transaction(tr: &mut Transaction<B>, tensor: Self::Primitive) {
         tr.register_float(tensor);
     }
@@ -2964,6 +3044,14 @@ impl<B: Backend> BasicOps<B> for Int {
         B::int_empty(shape, device)
     }
 
+    fn full<E: ElementConversion>(
+        shape: Shape,
+        fill_value: E,
+        device: &B::Device,
+    ) -> Self::Primitive {
+        B::int_full(shape, fill_value.elem(), device)
+    }
+
     fn register_transaction(tr: &mut Transaction<B>, tensor: Self::Primitive) {
         tr.register_int(tensor);
     }
@@ -3066,6 +3154,18 @@ impl<B: Backend> BasicOps<B> for Bool {
 
     fn empty(shape: Shape, device: &B::Device) -> Self::Primitive {
         B::bool_empty(shape, device)
+    }
+
+    fn full<E: ElementConversion>(
+        shape: Shape,
+        fill_value: E,
+        device: &B::Device,
+    ) -> Self::Primitive {
+        if fill_value.elem() {
+            B::bool_ones(shape, device)
+        } else {
+            B::bool_zeros(shape, device)
+        }
     }
 
     fn register_transaction(tr: &mut Transaction<B>, tensor: Self::Primitive) {

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -402,51 +402,6 @@ where
         Self::ones(self.shape(), &self.device())
     }
 
-    /// Create a tensor of the given shape where each element is equal to the provided value.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use burn_tensor::backend::Backend;
-    /// use burn_tensor::{Tensor, Shape};
-    ///
-    /// fn example<B: Backend>() {
-    ///   let device = B::Device::default();
-    ///   let tensor = Tensor::<B, 2>::full(Shape::new([2, 3]), 5.0, &device);
-    ///   println!("{tensor}");
-    ///   // [[5.0, 5.0, 5.0], [5.0, 5.0, 5.0]]
-    /// }
-    /// ```
-    pub fn full<S: Into<Shape>, E: ElementConversion>(
-        shape: S,
-        fill_value: E,
-        device: &B::Device,
-    ) -> Self {
-        let shape = shape.into();
-        check!(TensorCheck::creation_ops::<D>("Full", &shape.dims));
-        Self::new(K::full(shape, fill_value, device))
-    }
-
-    ///Returns a new tensor with the same shape and device as the current tensor filled with the provided value.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use burn_tensor::backend::Backend;
-    /// use burn_tensor::{Tensor, Shape};
-    ///
-    /// fn example<B: Backend>() {
-    ///    let device = B::Device::default();
-    ///    let tensor = Tensor::<B, 2>::from_data([[1.0, -2.0, 3.0], [5.0, 9.0, 6.0]], &device);
-    ///    let tensor = tensor.full_like(5.0);
-    ///    println!("{tensor}");
-    ///    // [[5.0, 5.0, 5.0], [5.0, 5.0, 5.0]]
-    /// }
-    /// ```
-    pub fn full_like<E: ElementConversion>(&self, fill_value: E) -> Self {
-        Self::full(self.shape(), fill_value, &self.device())
-    }
-
     /// Aggregate all elements in the tensor with the mean operation.
     ///
     /// # Example
@@ -2481,32 +2436,6 @@ where
     /// which is more high-level and designed for public use.
     fn ones(shape: Shape, device: &B::Device) -> Self::Primitive;
 
-    /// Creates a tensor filled with elements equal to the given value.
-    ///
-    /// # Arguments
-    ///
-    /// * `shape` - The shape of the tensor.
-    /// * `fill_value` - The value with which to fill the tensor
-    /// * `device` - The device on which the tensor will be allocated.
-    ///
-    /// # Returns
-    ///
-    /// The tensor filled with elements equal to the given value
-    ///
-    /// # Remarks
-    ///
-    /// This is a low-level function used internally by the library to call different backend functions
-    /// with static dispatch. It is not designed for direct usage by users, and not recommended to import
-    /// or use this function directly.
-    ///
-    /// For creating a tensor filled with a specific value, users should prefer the [Tensor::full](Tensor::full) function,
-    /// which is more high-level and designed for public use.
-    fn full<E: ElementConversion>(
-        shape: Shape,
-        fill_value: E,
-        device: &B::Device,
-    ) -> Self::Primitive;
-
     /// Sums all the elements of the tensor.
     ///
     /// # Arguments
@@ -3510,13 +3439,6 @@ impl<B: Backend> Numeric<B> for Int {
     fn ones(shape: Shape, device: &B::Device) -> Self::Primitive {
         B::int_ones(shape, device)
     }
-    fn full<E: ElementConversion>(
-        shape: Shape,
-        fill_value: E,
-        device: &B::Device,
-    ) -> Self::Primitive {
-        B::int_full(shape, fill_value.elem(), device)
-    }
 
     fn sum(tensor: Self::Primitive) -> Self::Primitive {
         B::int_sum(tensor)
@@ -3854,14 +3776,6 @@ impl<B: Backend> Numeric<B> for Float {
     }
     fn ones(shape: Shape, device: &B::Device) -> Self::Primitive {
         TensorPrimitive::Float(B::float_ones(shape, device))
-    }
-
-    fn full<E: ElementConversion>(
-        shape: Shape,
-        fill_value: E,
-        device: &B::Device,
-    ) -> Self::Primitive {
-        TensorPrimitive::Float(B::float_full(shape, fill_value.elem(), device))
     }
 
     fn sum(tensor: Self::Primitive) -> Self::Primitive {

--- a/crates/burn-tensor/src/tensor/ops/bool_tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/bool_tensor.rs
@@ -24,6 +24,30 @@ pub trait BoolTensorOps<B: Backend> {
     /// The boolean tensor with the given shape.
     fn bool_empty(shape: Shape, device: &Device<B>) -> BoolTensor<B>;
 
+    /// Creates a new bool tensor filled false.
+    ///
+    /// # Arguments
+    ///
+    /// * `shape` - The shape of the tensor.
+    /// * `device` - The device to create the tensor on.
+    ///
+    /// # Returns
+    ///
+    /// The boolean tensor filled with false.
+    fn bool_zeros(shape: Shape, device: &Device<B>) -> BoolTensor<B>;
+
+    /// Creates a new bool tensor filled true.
+    ///
+    /// # Arguments
+    ///
+    /// * `shape` - The shape of the tensor.
+    /// * `device` - The device to create the tensor on.
+    ///
+    /// # Returns
+    ///
+    /// The boolean tensor filled with true.
+    fn bool_ones(shape: Shape, device: &Device<B>) -> BoolTensor<B>;
+
     /// Converts the tensor to a data structure.
     ///
     /// # Arguments


### PR DESCRIPTION
This is most of the work to lift `.full()` and `.full_like()` into the base Tensor ops.

I need some help or more time with burn-router; the associated internal enum for operation descriptions has to change.

Future Work:
1. I would like to also lift `.zeros()` into the base; it's the logical pair to `.empty()`, and "all tensors have a default value" is easy to defend.

2. I'd also like some form of `FromBoolOps` for things that can be constructed from bools, and lift `ones()` into that; but that is later.

## Pull Request Template

### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

_Provide links to relevant issues and dependent PRs._

### Changes

_Summarize the problem being addressed and your solution._

### Testing

_Describe how these changes have been tested._
