### PR TITLE
Don't panic on allowzero since reshape supports it

### DIFF
--- a/crates/onnx-ir/src/node/reshape.rs
+++ b/crates/onnx-ir/src/node/reshape.rs
@@ -282,7 +282,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reshape_config_allowzero_not_supported() {
+    fn test_reshape_config_allowzero_supported() {
         let node = create_test_node(1, vec![2, 3]);
         let _ = reshape_config(&node);
     }


### PR DESCRIPTION
Context:

https://discordapp.com/channels/1038839012602941528/1091796857996451942/1406031450548998225

> PRs are welcome. Burn reshape supports it now. I remember adding it. 

I'm not sure if anything more substantial is required than what I've done in this PR.
If I understood correctly the check was in place before reshape could handle zeros, but since it does the check is unnecessary (?). 


Before the changes my model gets

```
DEBUG burn_import::burn::graph: Registering node => 'split'
ERROR burn_import::logger: PANIC => panicked at crates/onnx-ir/src/node/reshape.rs:210:9:
Zero shape size is not supported

thread 'main' panicked at crates/onnx-ir/src/node/reshape.rs:210:9:
Zero shape size is not supported
```


### Changes

Remove the check disallowing `allowzero`.

### Testing

My model no longer panics when it uses `allowzero`.
