### PR TITLE
Fix shape type annotation in test

### DIFF
--- a/crates/burn-cubecl/src/tests/scatter.rs
+++ b/crates/burn-cubecl/src/tests/scatter.rs
@@ -45,7 +45,7 @@ mod tests {
         let tensor = Tensor::<TestBackend, D>::random(shape1, Distribution::Default, &test_device);
         let value = Tensor::<TestBackend, D>::random(shape2, Distribution::Default, &test_device);
         let indices = Tensor::<TestBackend, 1, Int>::random(
-            [shape2.iter().product()],
+            [shape2.iter().product::<usize>()],
             Distribution::Uniform(0., shape2[dim] as f64),
             &test_device,
         )


### PR DESCRIPTION
Type annotation needed now that `From<[..; D]>` is implemented for i32 and i64 in addition to usize (#3381)