### PR TITLE
Refactor backend selection for onnx-tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5165,10 +5165,7 @@ name = "onnx-tests"
 version = "0.19.0"
 dependencies = [
  "burn",
- "burn-autodiff",
  "burn-import",
- "burn-ndarray",
- "burn-wgpu",
  "float-cmp",
  "serde",
 ]

--- a/burn-book/src/import/pytorch-model.md
+++ b/burn-book/src/import/pytorch-model.md
@@ -123,7 +123,7 @@ use crate::model;
 use burn::record::{FullPrecisionSettings, Recorder};
 use burn_import::pytorch::PyTorchFileRecorder;
 
-type Backend = burn_ndarray::NdArray<f32>;
+use crate::backend::Backend;
 
 fn main() {
     let device = Default::default();
@@ -150,7 +150,7 @@ use crate::model;
 use burn::record::{FullPrecisionSettings, NamedMpkFileRecorder, Recorder};
 use burn_import::pytorch::PyTorchFileRecorder;
 
-type Backend = burn_ndarray::NdArray<f32>;
+use crate::backend::Backend;
 
 fn convert_model() {
     let device = Default::default();

--- a/burn-book/src/import/pytorch-model.md
+++ b/burn-book/src/import/pytorch-model.md
@@ -123,7 +123,7 @@ use crate::model;
 use burn::record::{FullPrecisionSettings, Recorder};
 use burn_import::pytorch::PyTorchFileRecorder;
 
-use crate::backend::Backend;
+type Backend = burn_ndarray::NdArray<f32>;
 
 fn main() {
     let device = Default::default();
@@ -150,7 +150,7 @@ use crate::model;
 use burn::record::{FullPrecisionSettings, NamedMpkFileRecorder, Recorder};
 use burn_import::pytorch::PyTorchFileRecorder;
 
-use crate::backend::Backend;
+type Backend = burn_ndarray::NdArray<f32>;
 
 fn convert_model() {
     let device = Default::default();

--- a/burn-book/src/import/safetensors-model.md
+++ b/burn-book/src/import/safetensors-model.md
@@ -109,7 +109,7 @@ use crate::model;
 use burn::record::{FullPrecisionSettings, Recorder};
 use burn_import::safetensors::SafetensorsFileRecorder;
 
-use crate::backend::Backend;
+type Backend = burn_ndarray::NdArray<f32>;
 
 fn main() {
     let device = Default::default();
@@ -136,7 +136,7 @@ use crate::model;
 use burn::record::{FullPrecisionSettings, NamedMpkFileRecorder, Recorder};
 use burn_import::safetensors::SafetensorsFileRecorder;
 
-use crate::backend::Backend;
+type Backend = burn_ndarray::NdArray<f32>;
 
 fn convert_model() {
     let device = Default::default();

--- a/burn-book/src/import/safetensors-model.md
+++ b/burn-book/src/import/safetensors-model.md
@@ -109,7 +109,7 @@ use crate::model;
 use burn::record::{FullPrecisionSettings, Recorder};
 use burn_import::safetensors::SafetensorsFileRecorder;
 
-type Backend = burn_ndarray::NdArray<f32>;
+use crate::backend::Backend;
 
 fn main() {
     let device = Default::default();
@@ -136,7 +136,7 @@ use crate::model;
 use burn::record::{FullPrecisionSettings, NamedMpkFileRecorder, Recorder};
 use burn_import::safetensors::SafetensorsFileRecorder;
 
-type Backend = burn_ndarray::NdArray<f32>;
+use crate::backend::Backend;
 
 fn convert_model() {
     let device = Default::default();

--- a/crates/burn-core/src/record/serde/ser.rs
+++ b/crates/burn-core/src/record/serde/ser.rs
@@ -365,7 +365,7 @@ mod tests {
 
     #[test]
     fn test_param_serde() {
-        type Backend = burn_ndarray::NdArray<f32>;
+        use crate::backend::Backend;
 
         let device = Default::default();
         let tensor: Tensor<Backend, 2> = Tensor::ones([2, 2], &device);

--- a/crates/burn-core/src/record/serde/ser.rs
+++ b/crates/burn-core/src/record/serde/ser.rs
@@ -309,6 +309,7 @@ impl SerializeSeq for Serializer {
 #[cfg(test)]
 mod tests {
     use crate::{
+        TestBackend,
         module::{Param, ParamId},
         record::{FullPrecisionSettings, Record},
         tensor::Tensor,
@@ -365,10 +366,8 @@ mod tests {
 
     #[test]
     fn test_param_serde() {
-        use crate::backend::Backend;
-
         let device = Default::default();
-        let tensor: Tensor<Backend, 2> = Tensor::ones([2, 2], &device);
+        let tensor: Tensor<TestBackend, 2> = Tensor::ones([2, 2], &device);
         let param = Param::initialized(ParamId::new(), tensor);
         let param_item = param.into_item::<FullPrecisionSettings>();
 

--- a/crates/burn-import/onnx-tests/Cargo.toml
+++ b/crates/burn-import/onnx-tests/Cargo.toml
@@ -5,10 +5,10 @@ edition.workspace = true
 license.workspace = true
 
 [features]
-default = ["backend-ndarray"]
-backend-wgpu = ["burn/wgpu"]
-backend-ndarray = ["burn/ndarray"]
-backend-tch = ["burn/tch"]
+default = ["test-ndarray"]
+test-wgpu = ["burn/wgpu"]
+test-ndarray = ["burn/ndarray"]
+test-tch = ["burn/tch"]
 
 [dev-dependencies]
 burn = { path = "../../burn" }

--- a/crates/burn-import/onnx-tests/Cargo.toml
+++ b/crates/burn-import/onnx-tests/Cargo.toml
@@ -5,17 +5,15 @@ edition.workspace = true
 license.workspace = true
 
 [features]
-backend-autodiff-wgpu = ["burn-autodiff", "burn-wgpu"]
+default = ["backend-ndarray"]
+backend-wgpu = ["burn/wgpu"]
+backend-ndarray = ["burn/ndarray"]
+backend-tch = ["burn/tch"]
 
 [dev-dependencies]
 burn = { path = "../../burn" }
-burn-ndarray = { path = "../../burn-ndarray" }
 serde = { workspace = true }
 float-cmp = { workspace = true }
 
 [build-dependencies]
 burn-import = { path = "../" }
-
-[dependencies]
-burn-autodiff = { path = "../../burn-autodiff", version = "0.19.0", default-features = false, optional = true }
-burn-wgpu = { path = "../../burn-wgpu", version = "0.19.0", optional = true, default-features = false }

--- a/crates/burn-import/onnx-tests/README.md
+++ b/crates/burn-import/onnx-tests/README.md
@@ -225,31 +225,63 @@ Your test will be automatically included in the main test suite through `tests/t
 
 ## Running Tests
 
+### Default Backend
+
 Run all tests with:
 
 ```sh
 cargo test
 ```
-This command runs all tests using the default backend: `burn_ndarray::NdArray<f32>`.
 
-To run tests with an alternative backend (e.g. `burn_autodiff::Autodiff<burn_wgpu::Wgpu>`), use:
-```
-cargo test --features backend-autodiff-wgpu
-```
-Currently supported backends:
-*	`burn_ndarray::NdArray<f32> (default)`
-*	`burn_autodiff::Autodiff<burn_wgpu::Wgpu>`
+This command runs all tests using the default backend: `burn::backend::NdArray<f32>`.
 
-Run tests for a specific operator with:
+### Testing with Different Backends
+
+You can test with different Burn backends by using feature flags:
+
+#### WGPU Backend
+
+```sh
+cargo test --features backend-wgpu
+```
+
+Uses `burn::backend::Wgpu` for GPU-accelerated computation.
+
+#### LibTorch Backend
+
+```sh
+cargo test --features backend-tch
+```
+
+Uses `burn::backend::LibTorch<f32>` for PyTorch backend integration.
+
+#### NdArray Backend (Explicit)
+
+```sh
+cargo test --features backend-ndarray
+```
+
+Explicitly uses `burn::backend::NdArray<f32>` (same as default).
+
+### Running Specific Tests
+
+Run tests for a specific operator:
 
 ```sh
 cargo test --test test_mod my_new_op::test_my_new_op
 ```
 
 Run a specific test with a selected backend:
+
+```sh
+cargo test --test test_mod my_new_op::test_my_new_op --features backend-wgpu
 ```
-cargo test --test test_mod my_new_op::test_my_new_op --features backend-autodiff-wgpu
-```
+
+### Supported Backends
+
+- `burn::backend::NdArray<f32>` (default) - CPU-based computation using ndarray
+- `burn::backend::Wgpu` - GPU-accelerated computation using WebGPU
+- `burn::backend::LibTorch<f32>` - PyTorch backend integration
 
 ## Debugging Failed Tests
 

--- a/crates/burn-import/onnx-tests/README.md
+++ b/crates/burn-import/onnx-tests/README.md
@@ -281,11 +281,13 @@ cargo test --test test_mod my_new_op::test_my_new_op --features test-wgpu
 
 - `burn::backend::NdArray<f32>` (default) - CPU-based computation using ndarray
 - `burn::backend::Wgpu` - GPU-accelerated computation using WebGPU
-- `burn::backend::LibTorch<f32>` - PyTorch backend integration
+- `burn::backend::LibTorch<f32>` - Torch backend integration
 
-**Note:** Only one backend feature should be enabled at a time. The backend selection uses conditional compilation with the following priority:
+**Note:** Only one backend feature should be enabled at a time. The backend selection uses
+conditional compilation with the following priority:
+
 1. `test-wgpu` (highest priority)
-2. `test-tch` 
+2. `test-tch`
 3. `test-ndarray` (default when no other backend is selected)
 
 ## Debugging Failed Tests

--- a/crates/burn-import/onnx-tests/README.md
+++ b/crates/burn-import/onnx-tests/README.md
@@ -242,7 +242,7 @@ You can test with different Burn backends by using feature flags:
 #### WGPU Backend
 
 ```sh
-cargo test --features backend-wgpu
+cargo test --features test-wgpu
 ```
 
 Uses `burn::backend::Wgpu` for GPU-accelerated computation.
@@ -250,15 +250,15 @@ Uses `burn::backend::Wgpu` for GPU-accelerated computation.
 #### LibTorch Backend
 
 ```sh
-cargo test --features backend-tch
+cargo test --features test-tch
 ```
 
-Uses `burn::backend::LibTorch<f32>` for PyTorch backend integration.
+Uses `burn::backend::LibTorch<f32>` for Torch backend integration.
 
 #### NdArray Backend (Explicit)
 
 ```sh
-cargo test --features backend-ndarray
+cargo test --features test-ndarray
 ```
 
 Explicitly uses `burn::backend::NdArray<f32>` (same as default).
@@ -274,7 +274,7 @@ cargo test --test test_mod my_new_op::test_my_new_op
 Run a specific test with a selected backend:
 
 ```sh
-cargo test --test test_mod my_new_op::test_my_new_op --features backend-wgpu
+cargo test --test test_mod my_new_op::test_my_new_op --features test-wgpu
 ```
 
 ### Supported Backends
@@ -282,6 +282,11 @@ cargo test --test test_mod my_new_op::test_my_new_op --features backend-wgpu
 - `burn::backend::NdArray<f32>` (default) - CPU-based computation using ndarray
 - `burn::backend::Wgpu` - GPU-accelerated computation using WebGPU
 - `burn::backend::LibTorch<f32>` - PyTorch backend integration
+
+**Note:** Only one backend feature should be enabled at a time. The backend selection uses conditional compilation with the following priority:
+1. `test-wgpu` (highest priority)
+2. `test-tch` 
+3. `test-ndarray` (default when no other backend is selected)
 
 ## Debugging Failed Tests
 

--- a/crates/burn-import/onnx-tests/tests/abs/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/abs/mod.rs
@@ -7,15 +7,15 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    use crate::backend::Backend;
-    type FT = FloatElem<Backend>;
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
 
     #[test]
     fn abs() {
         let device = Default::default();
-        let model: abs::Model<Backend> = abs::Model::new(&device);
+        let model: abs::Model<TestBackend> = abs::Model::new(&device);
 
-        let input = Tensor::<Backend, 4>::from_floats([[[[-1.0, -4.0, 9.0, -25.0]]]], &device);
+        let input = Tensor::<TestBackend, 4>::from_floats([[[[-1.0, -4.0, 9.0, -25.0]]]], &device);
 
         let output = model.forward(input);
         let expected = TensorData::from([[[[1.0f32, 4.0, 9.0, 25.0]]]]);

--- a/crates/burn-import/onnx-tests/tests/add/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/add/mod.rs
@@ -7,16 +7,16 @@ mod tests {
     use super::*;
     use burn::tensor::{Int, Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn add_scalar_to_tensor_and_tensor_to_tensor() {
         // Initialize the model with weights (loaded from the exported file)
-        let model: add::Model<Backend> = add::Model::default();
+        let model: add::Model<TestBackend> = add::Model::default();
 
         let device = Default::default();
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats([[[[1., 2., 3., 4.]]]], &device);
+        let input = Tensor::<TestBackend, 4>::from_floats([[[[1., 2., 3., 4.]]]], &device);
         let scalar = 2f64;
         let output = model.forward(input, scalar);
         let expected = TensorData::from([[[[9f32, 10., 11., 12.]]]]);
@@ -27,11 +27,11 @@ mod tests {
     #[test]
     fn add_scalar_to_int_tensor_and_int_tensor_to_int_tensor() {
         // Initialize the model with weights (loaded from the exported file)
-        let model: add_int::Model<Backend> = add_int::Model::default();
+        let model: add_int::Model<TestBackend> = add_int::Model::default();
 
         let device = Default::default();
         // Run the model
-        let input = Tensor::<Backend, 4, Int>::from_ints([[[[1, 2, 3, 4]]]], &device);
+        let input = Tensor::<TestBackend, 4, Int>::from_ints([[[[1, 2, 3, 4]]]], &device);
         let scalar = 2;
         let output = model.forward(input, scalar);
         let expected = TensorData::from([[[[9i64, 11, 13, 15]]]]);
@@ -42,12 +42,12 @@ mod tests {
     #[test]
     fn add_shape_with_scalar_and_shape() {
         // Initialize the model
-        let model: add_shape::Model<Backend> = add_shape::Model::default();
+        let model: add_shape::Model<TestBackend> = add_shape::Model::default();
 
         let device = Default::default();
         // Create input tensors
-        let input1 = Tensor::<Backend, 3>::ones([2, 3, 4], &device);
-        let input2 = Tensor::<Backend, 3>::ones([5, 6, 7], &device);
+        let input1 = Tensor::<TestBackend, 3>::ones([2, 3, 4], &device);
+        let input2 = Tensor::<TestBackend, 3>::ones([5, 6, 7], &device);
         let (shape_plus_scalar, shape_plus_shape) = model.forward(input1, input2);
 
         // Expected outputs

--- a/crates/burn-import/onnx-tests/tests/and/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/and/mod.rs
@@ -7,18 +7,18 @@ mod tests {
     use super::*;
     use burn::tensor::{Bool, Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn and() {
         let device = Default::default();
-        let model: and::Model<Backend> = and::Model::new(&device);
+        let model: and::Model<TestBackend> = and::Model::new(&device);
 
-        let input_x = Tensor::<Backend, 4, Bool>::from_bool(
+        let input_x = Tensor::<TestBackend, 4, Bool>::from_bool(
             TensorData::from([[[[false, false, true, true]]]]),
             &device,
         );
-        let input_y = Tensor::<Backend, 4, Bool>::from_bool(
+        let input_y = Tensor::<TestBackend, 4, Bool>::from_bool(
             TensorData::from([[[[false, true, false, true]]]]),
             &device,
         );

--- a/crates/burn-import/onnx-tests/tests/argmax/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/argmax/mod.rs
@@ -26,14 +26,16 @@ mod tests {
     #[test]
     fn argmax_both_keepdims() {
         // Test both keepdims=True and keepdims=False in the same model
-        let model: argmax_both_keepdims::Model<TestBackend> = argmax_both_keepdims::Model::default();
+        let model: argmax_both_keepdims::Model<TestBackend> =
+            argmax_both_keepdims::Model::default();
 
         let device = Default::default();
         // Input: [[1.0, 3.0, 2.0], [4.0, 2.0, 1.0]]
         // ArgMax along dim=1 should return:
         // - keepdims=True: [[1], [0]] (indices in 2D format)
         // - keepdims=False: [1, 0] (indices in 1D format)
-        let input = Tensor::<TestBackend, 2>::from_floats([[1.0, 3.0, 2.0], [4.0, 2.0, 1.0]], &device);
+        let input =
+            Tensor::<TestBackend, 2>::from_floats([[1.0, 3.0, 2.0], [4.0, 2.0, 1.0]], &device);
         let (output_keepdims_true, output_keepdims_false) = model.forward(input);
 
         // Expected outputs based on PyTorch verification:

--- a/crates/burn-import/onnx-tests/tests/argmax/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/argmax/mod.rs
@@ -7,16 +7,16 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn argmax() {
         // Initialize the model with weights (loaded from the exported file)
-        let model: argmax::Model<Backend> = argmax::Model::default();
+        let model: argmax::Model<TestBackend> = argmax::Model::default();
 
         let device = Default::default();
         // Run the model
-        let input = Tensor::<Backend, 2>::from_floats([[1., 2., 3.], [4., 5., 6.]], &device);
+        let input = Tensor::<TestBackend, 2>::from_floats([[1., 2., 3.], [4., 5., 6.]], &device);
         let output = model.forward(input);
         let expected = TensorData::from([[2i64], [2]]);
 
@@ -26,14 +26,14 @@ mod tests {
     #[test]
     fn argmax_both_keepdims() {
         // Test both keepdims=True and keepdims=False in the same model
-        let model: argmax_both_keepdims::Model<Backend> = argmax_both_keepdims::Model::default();
+        let model: argmax_both_keepdims::Model<TestBackend> = argmax_both_keepdims::Model::default();
 
         let device = Default::default();
         // Input: [[1.0, 3.0, 2.0], [4.0, 2.0, 1.0]]
         // ArgMax along dim=1 should return:
         // - keepdims=True: [[1], [0]] (indices in 2D format)
         // - keepdims=False: [1, 0] (indices in 1D format)
-        let input = Tensor::<Backend, 2>::from_floats([[1.0, 3.0, 2.0], [4.0, 2.0, 1.0]], &device);
+        let input = Tensor::<TestBackend, 2>::from_floats([[1.0, 3.0, 2.0], [4.0, 2.0, 1.0]], &device);
         let (output_keepdims_true, output_keepdims_false) = model.forward(input);
 
         // Expected outputs based on PyTorch verification:
@@ -53,12 +53,12 @@ mod tests {
     #[test]
     fn argmax_1d() {
         // Initialize the model with weights (loaded from the exported file)
-        let model: argmax_1d::Model<Backend> = argmax_1d::Model::default();
+        let model: argmax_1d::Model<TestBackend> = argmax_1d::Model::default();
 
         let device = Default::default();
         // Run the model with test input [1.0, 3.0, 2.0, 5.0, 4.0]
         // Expected output: 3 (index of max value 5.0)
-        let input = Tensor::<Backend, 1>::from_floats([1.0, 3.0, 2.0, 5.0, 4.0], &device);
+        let input = Tensor::<TestBackend, 1>::from_floats([1.0, 3.0, 2.0, 5.0, 4.0], &device);
         let output = model.forward(input);
 
         // Output should be scalar value 3

--- a/crates/burn-import/onnx-tests/tests/argmin/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/argmin/mod.rs
@@ -29,11 +29,13 @@ mod tests {
     #[test]
     fn argmin_both_keepdims() {
         // Initialize the model with weights (loaded from the exported file)
-        let model: argmin_both_keepdims::Model<TestBackend> = argmin_both_keepdims::Model::default();
+        let model: argmin_both_keepdims::Model<TestBackend> =
+            argmin_both_keepdims::Model::default();
 
         let device = Default::default();
         // Run the model with test input: [[3.0, 1.0, 2.0], [2.0, 4.0, 1.0]]
-        let input = Tensor::<TestBackend, 2>::from_floats([[3.0, 1.0, 2.0], [2.0, 4.0, 1.0]], &device);
+        let input =
+            Tensor::<TestBackend, 2>::from_floats([[3.0, 1.0, 2.0], [2.0, 4.0, 1.0]], &device);
         let (output_keepdims_true, output_keepdims_false) = model.forward(input);
 
         // Expected: argmin along dim=1

--- a/crates/burn-import/onnx-tests/tests/argmin/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/argmin/mod.rs
@@ -7,16 +7,16 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn argmin() {
         // Initialize the model with weights (loaded from the exported file)
-        let model: argmin::Model<Backend> = argmin::Model::default();
+        let model: argmin::Model<TestBackend> = argmin::Model::default();
 
         let device = Default::default();
         // Run the model
-        let input = Tensor::<Backend, 2>::from_floats(
+        let input = Tensor::<TestBackend, 2>::from_floats(
             [[1.6124, 1.0463, -1.3808], [-0.3852, 0.1301, 0.9780]],
             &device,
         );
@@ -29,11 +29,11 @@ mod tests {
     #[test]
     fn argmin_both_keepdims() {
         // Initialize the model with weights (loaded from the exported file)
-        let model: argmin_both_keepdims::Model<Backend> = argmin_both_keepdims::Model::default();
+        let model: argmin_both_keepdims::Model<TestBackend> = argmin_both_keepdims::Model::default();
 
         let device = Default::default();
         // Run the model with test input: [[3.0, 1.0, 2.0], [2.0, 4.0, 1.0]]
-        let input = Tensor::<Backend, 2>::from_floats([[3.0, 1.0, 2.0], [2.0, 4.0, 1.0]], &device);
+        let input = Tensor::<TestBackend, 2>::from_floats([[3.0, 1.0, 2.0], [2.0, 4.0, 1.0]], &device);
         let (output_keepdims_true, output_keepdims_false) = model.forward(input);
 
         // Expected: argmin along dim=1
@@ -53,12 +53,12 @@ mod tests {
     #[test]
     fn argmin_1d() {
         // Initialize the model with weights (loaded from the exported file)
-        let model: argmin_1d::Model<Backend> = argmin_1d::Model::default();
+        let model: argmin_1d::Model<TestBackend> = argmin_1d::Model::default();
 
         let device = Default::default();
         // Run the model with test input [5.0, 3.0, 2.0, 1.0, 4.0]
         // Expected output: 3 (index of min value 1.0)
-        let input = Tensor::<Backend, 1>::from_floats([5.0, 3.0, 2.0, 1.0, 4.0], &device);
+        let input = Tensor::<TestBackend, 1>::from_floats([5.0, 3.0, 2.0, 1.0, 4.0], &device);
         let output = model.forward(input);
 
         // Output should be scalar value 3

--- a/crates/burn-import/onnx-tests/tests/attention/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/attention/mod.rs
@@ -201,7 +201,8 @@ mod tests {
     #[test]
     fn is_causal() {
         let device = Default::default();
-        let model: attention_is_causal::Model<TestBackend> = attention_is_causal::Model::new(&device);
+        let model: attention_is_causal::Model<TestBackend> =
+            attention_is_causal::Model::new(&device);
 
         let q = Tensor::<TestBackend, 4>::from_floats([[[[1.0, 0.0], [0.0, 1.0]]]], &device);
         let k = Tensor::<TestBackend, 4>::from_floats([[[[0.0, 1.0], [1.0, 0.0]]]], &device);

--- a/crates/burn-import/onnx-tests/tests/attention/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/attention/mod.rs
@@ -21,7 +21,6 @@ mod tests {
     use super::*;
     use crate::backend::Backend;
     use burn::tensor::{Bool, Int, Tensor, TensorData, Tolerance, ops::FloatElem};
-    use burn_ndarray::{NdArray, NdArrayDevice};
     type FT = FloatElem<Backend>;
 
     #[test]
@@ -136,16 +135,15 @@ mod tests {
     }
 
     #[allow(clippy::type_complexity)]
-    fn cached_attn_inputs(
-        device: &NdArrayDevice,
-    ) -> (
-        Tensor<NdArray, 4>,
-        Tensor<NdArray, 4>,
-        Tensor<NdArray, 4>,
-        Tensor<NdArray, 2, Bool>,
-        Tensor<NdArray, 4>,
-        Tensor<NdArray, 4>,
+    fn cached_attn_inputs() -> (
+        Tensor<Backend, 4>,
+        Tensor<Backend, 4>,
+        Tensor<Backend, 4>,
+        Tensor<Backend, 2, Bool>,
+        Tensor<Backend, 4>,
+        Tensor<Backend, 4>,
     ) {
+        let device = &Default::default();
         let q = Tensor::<Backend, 4>::from_floats([[[[1.0, 0.0], [0.0, 1.0]]]], device);
         let k = Tensor::<Backend, 4>::from_floats([[[[1.0, 0.0]]]], device);
         let v = Tensor::<Backend, 4>::from_floats([[[[0.3, 0.6]]]], device);
@@ -164,7 +162,7 @@ mod tests {
         let device = Default::default();
         let model: attention_cache::Model<Backend> = attention_cache::Model::new(&device);
 
-        let (q, k, v, attn_mask, past_k, past_v) = cached_attn_inputs(&device);
+        let (q, k, v, attn_mask, past_k, past_v) = cached_attn_inputs();
 
         let (output, present_k, present_v) = model.forward(q, k, v, attn_mask, past_k, past_v);
         let expected = TensorData::from([[[[0.283488f32, 0.566976], [0.266511, 0.533023]]]]);
@@ -223,7 +221,7 @@ mod tests {
         let model: attention_qk_output_0::Model<Backend> =
             attention_qk_output_0::Model::new(&device);
 
-        let (q, k, v, attn_mask, past_k, past_v) = cached_attn_inputs(&device);
+        let (q, k, v, attn_mask, past_k, past_v) = cached_attn_inputs();
 
         let (_, _, _, qk_output) = model.forward(q, k, v, attn_mask, past_k, past_v);
         #[allow(clippy::approx_constant)]
@@ -240,7 +238,7 @@ mod tests {
         let model: attention_qk_output_1::Model<Backend> =
             attention_qk_output_1::Model::new(&device);
 
-        let (q, k, v, attn_mask, past_k, past_v) = cached_attn_inputs(&device);
+        let (q, k, v, attn_mask, past_k, past_v) = cached_attn_inputs();
 
         let (_, _, _, qk_output) = model.forward(q, k, v, attn_mask, past_k, past_v);
         #[allow(clippy::approx_constant)]
@@ -257,7 +255,7 @@ mod tests {
         let model: attention_qk_output_2::Model<Backend> =
             attention_qk_output_2::Model::new(&device);
 
-        let (q, k, v, attn_mask, past_k, past_v) = cached_attn_inputs(&device);
+        let (q, k, v, attn_mask, past_k, past_v) = cached_attn_inputs();
 
         let (_, _, _, qk_output) = model.forward(q, k, v, attn_mask, past_k, past_v);
         #[allow(clippy::approx_constant)]
@@ -274,7 +272,7 @@ mod tests {
         let model: attention_qk_output_3::Model<Backend> =
             attention_qk_output_3::Model::new(&device);
 
-        let (q, k, v, attn_mask, past_k, past_v) = cached_attn_inputs(&device);
+        let (q, k, v, attn_mask, past_k, past_v) = cached_attn_inputs();
 
         let (_, _, _, qk_output) = model.forward(q, k, v, attn_mask, past_k, past_v);
         #[allow(clippy::approx_constant)]

--- a/crates/burn-import/onnx-tests/tests/attention/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/attention/mod.rs
@@ -19,18 +19,18 @@ include_models!(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
     use burn::tensor::{Bool, Int, Tensor, TensorData, Tolerance, ops::FloatElem};
-    type FT = FloatElem<Backend>;
+    type FT = FloatElem<TestBackend>;
 
     #[test]
     fn simple_4d() {
         let device = Default::default();
-        let model: attention_4d::Model<Backend> = attention_4d::Model::new(&device);
+        let model: attention_4d::Model<TestBackend> = attention_4d::Model::new(&device);
 
-        let q = Tensor::<Backend, 4>::from_floats([[[[1.0, 0.0], [0.0, 1.0]]]], &device);
-        let k = Tensor::<Backend, 4>::from_floats([[[[0.0, 1.0], [1.0, 0.0]]]], &device);
-        let v = Tensor::<Backend, 4>::from_floats([[[[0.25, 0.5], [0.3, 0.6]]]], &device);
+        let q = Tensor::<TestBackend, 4>::from_floats([[[[1.0, 0.0], [0.0, 1.0]]]], &device);
+        let k = Tensor::<TestBackend, 4>::from_floats([[[[0.0, 1.0], [1.0, 0.0]]]], &device);
+        let v = Tensor::<TestBackend, 4>::from_floats([[[[0.25, 0.5], [0.3, 0.6]]]], &device);
 
         let output = model.forward(q, k, v);
         let expected = TensorData::from([[[[0.283488f32, 0.566976], [0.266511, 0.533023]]]]);
@@ -43,11 +43,11 @@ mod tests {
     #[test]
     fn simple_3d() {
         let device = Default::default();
-        let model: attention_3d::Model<Backend> = attention_3d::Model::new(&device);
+        let model: attention_3d::Model<TestBackend> = attention_3d::Model::new(&device);
 
-        let q = Tensor::<Backend, 3>::from_floats([[[1.0, 0.0], [0.0, 1.0]]], &device);
-        let k = Tensor::<Backend, 3>::from_floats([[[0.0, 1.0], [1.0, 0.0]]], &device);
-        let v = Tensor::<Backend, 3>::from_floats([[[0.25, 0.5], [0.3, 0.6]]], &device);
+        let q = Tensor::<TestBackend, 3>::from_floats([[[1.0, 0.0], [0.0, 1.0]]], &device);
+        let k = Tensor::<TestBackend, 3>::from_floats([[[0.0, 1.0], [1.0, 0.0]]], &device);
+        let v = Tensor::<TestBackend, 3>::from_floats([[[0.25, 0.5], [0.3, 0.6]]], &device);
 
         let output = model.forward(q, k, v);
         let expected = TensorData::from([[[0.283488f32, 0.566976], [0.266511, 0.533023]]]);
@@ -60,13 +60,13 @@ mod tests {
     #[test]
     fn attn_mask_bool() {
         let device = Default::default();
-        let model: attention_attn_mask_bool::Model<Backend> =
+        let model: attention_attn_mask_bool::Model<TestBackend> =
             attention_attn_mask_bool::Model::new(&device);
 
-        let q = Tensor::<Backend, 4>::from_floats([[[[1.0, 0.0], [0.0, 1.0]]]], &device);
-        let k = Tensor::<Backend, 4>::from_floats([[[[0.0, 1.0], [1.0, 0.0]]]], &device);
-        let v = Tensor::<Backend, 4>::from_floats([[[[0.25, 0.5], [0.3, 0.6]]]], &device);
-        let attn_mask = Tensor::<Backend, 2, Bool>::from_bool(
+        let q = Tensor::<TestBackend, 4>::from_floats([[[[1.0, 0.0], [0.0, 1.0]]]], &device);
+        let k = Tensor::<TestBackend, 4>::from_floats([[[[0.0, 1.0], [1.0, 0.0]]]], &device);
+        let v = Tensor::<TestBackend, 4>::from_floats([[[[0.25, 0.5], [0.3, 0.6]]]], &device);
+        let attn_mask = Tensor::<TestBackend, 2, Bool>::from_bool(
             TensorData::from([[true, false], [false, true]]),
             &device,
         );
@@ -82,13 +82,13 @@ mod tests {
     #[test]
     fn attn_mask_int() {
         let device = Default::default();
-        let model: attention_attn_mask_int::Model<Backend> =
+        let model: attention_attn_mask_int::Model<TestBackend> =
             attention_attn_mask_int::Model::new(&device);
 
-        let q = Tensor::<Backend, 4>::from_floats([[[[1.0, 0.0], [0.0, 1.0]]]], &device);
-        let k = Tensor::<Backend, 4>::from_floats([[[[0.0, 1.0], [1.0, 0.0]]]], &device);
-        let v = Tensor::<Backend, 4>::from_floats([[[[0.25, 0.5], [0.3, 0.6]]]], &device);
-        let attn_mask = Tensor::<Backend, 2, Int>::from_ints([[2, 0], [0, 3]], &device);
+        let q = Tensor::<TestBackend, 4>::from_floats([[[[1.0, 0.0], [0.0, 1.0]]]], &device);
+        let k = Tensor::<TestBackend, 4>::from_floats([[[[0.0, 1.0], [1.0, 0.0]]]], &device);
+        let v = Tensor::<TestBackend, 4>::from_floats([[[[0.25, 0.5], [0.3, 0.6]]]], &device);
+        let attn_mask = Tensor::<TestBackend, 2, Int>::from_ints([[2, 0], [0, 3]], &device);
 
         let output = model.forward(q, k, v, attn_mask);
         let expected = TensorData::from([[[[0.260768f32, 0.521536], [0.295414, 0.590828]]]]);
@@ -101,13 +101,13 @@ mod tests {
     #[test]
     fn attn_mask_float() {
         let device = Default::default();
-        let model: attention_attn_mask_float::Model<Backend> =
+        let model: attention_attn_mask_float::Model<TestBackend> =
             attention_attn_mask_float::Model::new(&device);
 
-        let q = Tensor::<Backend, 4>::from_floats([[[[1.0, 0.0], [0.0, 1.0]]]], &device);
-        let k = Tensor::<Backend, 4>::from_floats([[[[0.0, 1.0], [1.0, 0.0]]]], &device);
-        let v = Tensor::<Backend, 4>::from_floats([[[[0.25, 0.5], [0.3, 0.6]]]], &device);
-        let attn_mask = Tensor::<Backend, 2>::from_floats([[2.0, 0.0], [0.0, 3.0]], &device);
+        let q = Tensor::<TestBackend, 4>::from_floats([[[[1.0, 0.0], [0.0, 1.0]]]], &device);
+        let k = Tensor::<TestBackend, 4>::from_floats([[[[0.0, 1.0], [1.0, 0.0]]]], &device);
+        let v = Tensor::<TestBackend, 4>::from_floats([[[[0.25, 0.5], [0.3, 0.6]]]], &device);
+        let attn_mask = Tensor::<TestBackend, 2>::from_floats([[2.0, 0.0], [0.0, 3.0]], &device);
 
         let output = model.forward(q, k, v, attn_mask);
         let expected = TensorData::from([[[[0.260768f32, 0.521536], [0.295414, 0.590828]]]]);
@@ -120,11 +120,11 @@ mod tests {
     #[test]
     fn softcap() {
         let device = Default::default();
-        let model: attention_softcap::Model<Backend> = attention_softcap::Model::new(&device);
+        let model: attention_softcap::Model<TestBackend> = attention_softcap::Model::new(&device);
 
-        let q = Tensor::<Backend, 4>::from_floats([[[[1.0, 0.0], [0.0, 1.0]]]], &device);
-        let k = Tensor::<Backend, 4>::from_floats([[[[0.0, 1.0], [1.0, 0.0]]]], &device);
-        let v = Tensor::<Backend, 4>::from_floats([[[[0.25, 0.5], [0.3, 0.6]]]], &device);
+        let q = Tensor::<TestBackend, 4>::from_floats([[[[1.0, 0.0], [0.0, 1.0]]]], &device);
+        let k = Tensor::<TestBackend, 4>::from_floats([[[[0.0, 1.0], [1.0, 0.0]]]], &device);
+        let v = Tensor::<TestBackend, 4>::from_floats([[[[0.25, 0.5], [0.3, 0.6]]]], &device);
 
         let output = model.forward(q, k, v);
         let expected = TensorData::from([[[[0.283176f32, 0.566352], [0.266823, 0.533647]]]]);
@@ -136,23 +136,23 @@ mod tests {
 
     #[allow(clippy::type_complexity)]
     fn cached_attn_inputs() -> (
-        Tensor<Backend, 4>,
-        Tensor<Backend, 4>,
-        Tensor<Backend, 4>,
-        Tensor<Backend, 2, Bool>,
-        Tensor<Backend, 4>,
-        Tensor<Backend, 4>,
+        Tensor<TestBackend, 4>,
+        Tensor<TestBackend, 4>,
+        Tensor<TestBackend, 4>,
+        Tensor<TestBackend, 2, Bool>,
+        Tensor<TestBackend, 4>,
+        Tensor<TestBackend, 4>,
     ) {
         let device = &Default::default();
-        let q = Tensor::<Backend, 4>::from_floats([[[[1.0, 0.0], [0.0, 1.0]]]], device);
-        let k = Tensor::<Backend, 4>::from_floats([[[[1.0, 0.0]]]], device);
-        let v = Tensor::<Backend, 4>::from_floats([[[[0.3, 0.6]]]], device);
-        let attn_mask = Tensor::<Backend, 2, Bool>::from_bool(
+        let q = Tensor::<TestBackend, 4>::from_floats([[[[1.0, 0.0], [0.0, 1.0]]]], device);
+        let k = Tensor::<TestBackend, 4>::from_floats([[[[1.0, 0.0]]]], device);
+        let v = Tensor::<TestBackend, 4>::from_floats([[[[0.3, 0.6]]]], device);
+        let attn_mask = Tensor::<TestBackend, 2, Bool>::from_bool(
             TensorData::from([[true, true], [true, true]]),
             device,
         );
-        let past_k = Tensor::<Backend, 4>::from_floats([[[[0.0, 1.0]]]], device);
-        let past_v = Tensor::<Backend, 4>::from_floats([[[[0.25, 0.5]]]], device);
+        let past_k = Tensor::<TestBackend, 4>::from_floats([[[[0.0, 1.0]]]], device);
+        let past_v = Tensor::<TestBackend, 4>::from_floats([[[[0.25, 0.5]]]], device);
 
         (q, k, v, attn_mask, past_k, past_v)
     }
@@ -160,7 +160,7 @@ mod tests {
     #[test]
     fn cache() {
         let device = Default::default();
-        let model: attention_cache::Model<Backend> = attention_cache::Model::new(&device);
+        let model: attention_cache::Model<TestBackend> = attention_cache::Model::new(&device);
 
         let (q, k, v, attn_mask, past_k, past_v) = cached_attn_inputs();
 
@@ -183,12 +183,12 @@ mod tests {
     #[test]
     fn custom_scale() {
         let device = Default::default();
-        let model: attention_custom_scale::Model<Backend> =
+        let model: attention_custom_scale::Model<TestBackend> =
             attention_custom_scale::Model::new(&device);
 
-        let q = Tensor::<Backend, 4>::from_floats([[[[1.0, 0.0], [0.0, 1.0]]]], &device);
-        let k = Tensor::<Backend, 4>::from_floats([[[[0.0, 1.0], [1.0, 0.0]]]], &device);
-        let v = Tensor::<Backend, 4>::from_floats([[[[0.25, 0.5], [0.3, 0.6]]]], &device);
+        let q = Tensor::<TestBackend, 4>::from_floats([[[[1.0, 0.0], [0.0, 1.0]]]], &device);
+        let k = Tensor::<TestBackend, 4>::from_floats([[[[0.0, 1.0], [1.0, 0.0]]]], &device);
+        let v = Tensor::<TestBackend, 4>::from_floats([[[[0.25, 0.5], [0.3, 0.6]]]], &device);
 
         let output = model.forward(q, k, v);
         let expected = TensorData::from([[[[0.294039f32, 0.588079], [0.255960, 0.511920]]]]);
@@ -201,11 +201,11 @@ mod tests {
     #[test]
     fn is_causal() {
         let device = Default::default();
-        let model: attention_is_causal::Model<Backend> = attention_is_causal::Model::new(&device);
+        let model: attention_is_causal::Model<TestBackend> = attention_is_causal::Model::new(&device);
 
-        let q = Tensor::<Backend, 4>::from_floats([[[[1.0, 0.0], [0.0, 1.0]]]], &device);
-        let k = Tensor::<Backend, 4>::from_floats([[[[0.0, 1.0], [1.0, 0.0]]]], &device);
-        let v = Tensor::<Backend, 4>::from_floats([[[[0.25, 0.5], [0.3, 0.6]]]], &device);
+        let q = Tensor::<TestBackend, 4>::from_floats([[[[1.0, 0.0], [0.0, 1.0]]]], &device);
+        let k = Tensor::<TestBackend, 4>::from_floats([[[[0.0, 1.0], [1.0, 0.0]]]], &device);
+        let v = Tensor::<TestBackend, 4>::from_floats([[[[0.25, 0.5], [0.3, 0.6]]]], &device);
 
         let output = model.forward(q, k, v);
         let expected = TensorData::from([[[[0.25f32, 0.5], [0.266511, 0.533023]]]]);
@@ -218,7 +218,7 @@ mod tests {
     #[test]
     fn qk_matmul_output_0() {
         let device = Default::default();
-        let model: attention_qk_output_0::Model<Backend> =
+        let model: attention_qk_output_0::Model<TestBackend> =
             attention_qk_output_0::Model::new(&device);
 
         let (q, k, v, attn_mask, past_k, past_v) = cached_attn_inputs();
@@ -235,7 +235,7 @@ mod tests {
     #[test]
     fn qk_matmul_output_1() {
         let device = Default::default();
-        let model: attention_qk_output_1::Model<Backend> =
+        let model: attention_qk_output_1::Model<TestBackend> =
             attention_qk_output_1::Model::new(&device);
 
         let (q, k, v, attn_mask, past_k, past_v) = cached_attn_inputs();
@@ -252,7 +252,7 @@ mod tests {
     #[test]
     fn qk_matmul_output_2() {
         let device = Default::default();
-        let model: attention_qk_output_2::Model<Backend> =
+        let model: attention_qk_output_2::Model<TestBackend> =
             attention_qk_output_2::Model::new(&device);
 
         let (q, k, v, attn_mask, past_k, past_v) = cached_attn_inputs();
@@ -269,7 +269,7 @@ mod tests {
     #[test]
     fn qk_matmul_output_3() {
         let device = Default::default();
-        let model: attention_qk_output_3::Model<Backend> =
+        let model: attention_qk_output_3::Model<TestBackend> =
             attention_qk_output_3::Model::new(&device);
 
         let (q, k, v, attn_mask, past_k, past_v) = cached_attn_inputs();

--- a/crates/burn-import/onnx-tests/tests/avg_pool/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/avg_pool/mod.rs
@@ -7,17 +7,17 @@ mod tests {
     use super::*;
     use burn::tensor::{Shape, Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    use crate::backend::Backend;
-    type FT = FloatElem<Backend>;
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
 
     #[test]
     fn avg_pool1d() {
         // Initialize the model without weights (because the exported file does not contain them)
         let device = Default::default();
-        let model: avg_pool1d::Model<Backend> = avg_pool1d::Model::new(&device);
+        let model: avg_pool1d::Model<TestBackend> = avg_pool1d::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 3>::from_floats(
+        let input = Tensor::<TestBackend, 3>::from_floats(
             [[
                 [-1.526, -0.750, -0.654, -1.609, -0.100],
                 [-0.609, -0.980, -1.609, -0.712, 1.171],
@@ -68,10 +68,10 @@ mod tests {
     fn avg_pool2d() {
         // Initialize the model without weights (because the exported file does not contain them)
         let device = Default::default();
-        let model: avg_pool2d::Model<Backend> = avg_pool2d::Model::new(&device);
+        let model: avg_pool2d::Model<TestBackend> = avg_pool2d::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats(
+        let input = Tensor::<TestBackend, 4>::from_floats(
             [[[
                 [-0.077, 0.360, -0.782, 0.072, 0.665],
                 [-0.287, 1.621, -1.597, -0.052, 0.611],

--- a/crates/burn-import/onnx-tests/tests/backend.rs
+++ b/crates/burn-import/onnx-tests/tests/backend.rs
@@ -1,5 +1,12 @@
-#[cfg(feature = "backend-autodiff-wgpu")]
-pub type Backend = burn_autodiff::Autodiff<burn_wgpu::Wgpu>;
+#[cfg(feature = "backend-wgpu")]
+pub type Backend = burn::backend::Wgpu;
 
-#[cfg(not(feature = "backend-autodiff-wgpu"))]
-pub type Backend = burn_ndarray::NdArray<f32>;
+#[cfg(all(
+    feature = "backend-ndarray",
+    not(feature = "backend-wgpu"),
+    not(feature = "backend-tch")
+))]
+pub type Backend = burn::backend::NdArray<f32>;
+
+#[cfg(feature = "backend-tch")]
+pub type Backend = burn::backend::LibTorch<f32>;

--- a/crates/burn-import/onnx-tests/tests/backend.rs
+++ b/crates/burn-import/onnx-tests/tests/backend.rs
@@ -1,12 +1,12 @@
-#[cfg(feature = "backend-wgpu")]
+#[cfg(feature = "test-wgpu")]
 pub type Backend = burn::backend::Wgpu;
 
 #[cfg(all(
-    feature = "backend-ndarray",
-    not(feature = "backend-wgpu"),
-    not(feature = "backend-tch")
+    feature = "test-ndarray",
+    not(feature = "test-wgpu"),
+    not(feature = "test-tch")
 ))]
 pub type Backend = burn::backend::NdArray<f32>;
 
-#[cfg(feature = "backend-tch")]
+#[cfg(feature = "test-tch")]
 pub type Backend = burn::backend::LibTorch<f32>;

--- a/crates/burn-import/onnx-tests/tests/backend.rs
+++ b/crates/burn-import/onnx-tests/tests/backend.rs
@@ -1,12 +1,12 @@
 #[cfg(feature = "test-wgpu")]
-pub type Backend = burn::backend::Wgpu;
+pub type TestBackend = burn::backend::Wgpu;
 
 #[cfg(all(
     feature = "test-ndarray",
     not(feature = "test-wgpu"),
     not(feature = "test-tch")
 ))]
-pub type Backend = burn::backend::NdArray<f32>;
+pub type TestBackend = burn::backend::NdArray<f32>;
 
 #[cfg(feature = "test-tch")]
-pub type Backend = burn::backend::LibTorch<f32>;
+pub type TestBackend = burn::backend::LibTorch<f32>;

--- a/crates/burn-import/onnx-tests/tests/batch_norm/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/batch_norm/mod.rs
@@ -8,14 +8,14 @@ mod tests {
     use burn::tensor::{Shape, Tensor};
     use float_cmp::ApproxEq;
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn batch_norm() {
-        let model: batch_norm::Model<Backend> = batch_norm::Model::default();
+        let model: batch_norm::Model<TestBackend> = batch_norm::Model::default();
 
         // Run the model with ones as input for easier testing
-        let input = Tensor::<Backend, 3>::ones([1, 20, 1], &Default::default());
+        let input = Tensor::<TestBackend, 3>::ones([1, 20, 1], &Default::default());
         let output = model.forward(input);
 
         let expected_shape = Shape::from([1, 5, 2, 2]);

--- a/crates/burn-import/onnx-tests/tests/bernoulli/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/bernoulli/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use burn::tensor::Shape;
     use burn::tensor::Tensor;
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn bernoulli() {

--- a/crates/burn-import/onnx-tests/tests/bernoulli/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/bernoulli/mod.rs
@@ -7,15 +7,15 @@ mod tests {
     use burn::tensor::Shape;
     use burn::tensor::Tensor;
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn bernoulli() {
         let device = Default::default();
-        let model = bernoulli::Model::<Backend>::new(&device);
+        let model = bernoulli::Model::<TestBackend>::new(&device);
 
         let shape = Shape::from([10]);
-        let input = Tensor::<Backend, 1>::full(Shape::from([10]), 0.5, &device);
+        let input = Tensor::<TestBackend, 1>::full(Shape::from([10]), 0.5, &device);
         let output = model.forward(input);
         assert_eq!(shape, output.shape());
     }

--- a/crates/burn-import/onnx-tests/tests/bitshift/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/bitshift/mod.rs
@@ -36,7 +36,8 @@ mod tests {
     fn bitshift_left_scalar_tensor() {
         // Initialize the model with weights (loaded from the exported file)
         let device = Default::default();
-        let model: bitshift_left_scalar::Model<TestBackend> = bitshift_left_scalar::Model::new(&device);
+        let model: bitshift_left_scalar::Model<TestBackend> =
+            bitshift_left_scalar::Model::new(&device);
         // Run the model
         let input1 = Tensor::<TestBackend, 1, Int>::from_ints([1, 2, 3, 4], &device);
         let scalar = 2;
@@ -78,7 +79,8 @@ mod tests {
     #[test]
     fn scalar_bitshift_left_tensor() {
         let device = Default::default();
-        let model: scalar_bitshift_left::Model<TestBackend> = scalar_bitshift_left::Model::new(&device);
+        let model: scalar_bitshift_left::Model<TestBackend> =
+            scalar_bitshift_left::Model::new(&device);
         // Run the model
         let scalar = 4;
         let shift_amounts = Tensor::<TestBackend, 1, Int>::from_ints([1, 1, 2, 2], &device);

--- a/crates/burn-import/onnx-tests/tests/bitshift/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/bitshift/mod.rs
@@ -16,16 +16,16 @@ mod tests {
     use super::*;
     use burn::tensor::{Int, Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn bitshift_left_tensors() {
         // Initialize the model with weights (loaded from the exported file)
         let device = Default::default();
-        let model: bitshift_left::Model<Backend> = bitshift_left::Model::new(&device);
+        let model: bitshift_left::Model<TestBackend> = bitshift_left::Model::new(&device);
         // Run the model
-        let input1 = Tensor::<Backend, 1, Int>::from_ints([1, 2, 3, 4], &device);
-        let input2 = Tensor::<Backend, 1, Int>::from_ints([1, 1, 2, 2], &device);
+        let input1 = Tensor::<TestBackend, 1, Int>::from_ints([1, 2, 3, 4], &device);
+        let input2 = Tensor::<TestBackend, 1, Int>::from_ints([1, 1, 2, 2], &device);
         let output = model.forward(input1, input2);
         let expected = TensorData::from([2i64, 4, 12, 16]);
 
@@ -36,9 +36,9 @@ mod tests {
     fn bitshift_left_scalar_tensor() {
         // Initialize the model with weights (loaded from the exported file)
         let device = Default::default();
-        let model: bitshift_left_scalar::Model<Backend> = bitshift_left_scalar::Model::new(&device);
+        let model: bitshift_left_scalar::Model<TestBackend> = bitshift_left_scalar::Model::new(&device);
         // Run the model
-        let input1 = Tensor::<Backend, 1, Int>::from_ints([1, 2, 3, 4], &device);
+        let input1 = Tensor::<TestBackend, 1, Int>::from_ints([1, 2, 3, 4], &device);
         let scalar = 2;
         let output = model.forward(input1, scalar);
         let expected = TensorData::from([4i64, 8, 12, 16]);
@@ -49,11 +49,11 @@ mod tests {
     #[test]
     fn bitshift_right_tensors() {
         let device = Default::default();
-        let model: bitshift_right::Model<Backend> = bitshift_right::Model::new(&device);
+        let model: bitshift_right::Model<TestBackend> = bitshift_right::Model::new(&device);
 
         // Run the model
-        let input1 = Tensor::<Backend, 1, Int>::from_ints([1, 2, 3, 4], &device);
-        let input2 = Tensor::<Backend, 1, Int>::from_ints([1, 1, 2, 2], &device);
+        let input1 = Tensor::<TestBackend, 1, Int>::from_ints([1, 2, 3, 4], &device);
+        let input2 = Tensor::<TestBackend, 1, Int>::from_ints([1, 1, 2, 2], &device);
         let output = model.forward(input1, input2);
         let expected = TensorData::from([0i64, 1, 0, 1]);
 
@@ -64,10 +64,10 @@ mod tests {
     fn bitshift_right_scalar_tensor() {
         // Initialize the model with weights (loaded from the exported file)
         let device = Default::default();
-        let model: bitshift_right_scalar::Model<Backend> =
+        let model: bitshift_right_scalar::Model<TestBackend> =
             bitshift_right_scalar::Model::new(&device);
         // Run the model
-        let input1 = Tensor::<Backend, 1, Int>::from_ints([1, 2, 3, 4], &device);
+        let input1 = Tensor::<TestBackend, 1, Int>::from_ints([1, 2, 3, 4], &device);
         let scalar = 2;
         let output = model.forward(input1, scalar);
         let expected = TensorData::from([0i64, 0, 0, 1]);
@@ -78,10 +78,10 @@ mod tests {
     #[test]
     fn scalar_bitshift_left_tensor() {
         let device = Default::default();
-        let model: scalar_bitshift_left::Model<Backend> = scalar_bitshift_left::Model::new(&device);
+        let model: scalar_bitshift_left::Model<TestBackend> = scalar_bitshift_left::Model::new(&device);
         // Run the model
         let scalar = 4;
-        let shift_amounts = Tensor::<Backend, 1, Int>::from_ints([1, 1, 2, 2], &device);
+        let shift_amounts = Tensor::<TestBackend, 1, Int>::from_ints([1, 1, 2, 2], &device);
         let output = model.forward(scalar, shift_amounts);
         // 4 << 1 = 8, 4 << 1 = 8, 4 << 2 = 16, 4 << 2 = 16
         let expected = TensorData::from([8i64, 8, 16, 16]);
@@ -92,11 +92,11 @@ mod tests {
     #[test]
     fn scalar_bitshift_right_tensor() {
         let device = Default::default();
-        let model: scalar_bitshift_right::Model<Backend> =
+        let model: scalar_bitshift_right::Model<TestBackend> =
             scalar_bitshift_right::Model::new(&device);
         // Run the model
         let scalar = 8;
-        let shift_amounts = Tensor::<Backend, 1, Int>::from_ints([1, 2, 3, 4], &device);
+        let shift_amounts = Tensor::<TestBackend, 1, Int>::from_ints([1, 2, 3, 4], &device);
         let output = model.forward(scalar, shift_amounts);
         // 8 >> 1 = 4, 8 >> 2 = 2, 8 >> 3 = 1, 8 >> 4 = 0
         let expected = TensorData::from([4i64, 2, 1, 0]);
@@ -107,7 +107,7 @@ mod tests {
     #[test]
     fn scalar_bitshift_left_scalar() {
         let device = Default::default();
-        let model: scalar_bitshift_left_scalar::Model<Backend> =
+        let model: scalar_bitshift_left_scalar::Model<TestBackend> =
             scalar_bitshift_left_scalar::Model::new(&device);
         // Run the model
         let lhs = 4;
@@ -120,7 +120,7 @@ mod tests {
     #[test]
     fn scalar_bitshift_right_scalar() {
         let device = Default::default();
-        let model: scalar_bitshift_right_scalar::Model<Backend> =
+        let model: scalar_bitshift_right_scalar::Model<TestBackend> =
             scalar_bitshift_right_scalar::Model::new(&device);
         // Run the model
         let lhs = 16;

--- a/crates/burn-import/onnx-tests/tests/bitshift/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/bitshift/mod.rs
@@ -16,7 +16,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Int, Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn bitshift_left_tensors() {

--- a/crates/burn-import/onnx-tests/tests/bitwise_and/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/bitwise_and/mod.rs
@@ -12,15 +12,15 @@ mod tests {
     use super::*;
     use burn::tensor::{Int, Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn bitwise_and_tensors() {
         let device = Default::default();
-        let model: bitwise_and::Model<Backend> = bitwise_and::Model::new(&device);
+        let model: bitwise_and::Model<TestBackend> = bitwise_and::Model::new(&device);
         // Run the model
-        let input1 = Tensor::<Backend, 1, Int>::from_ints([1, 2, 3, 4], &device);
-        let input2 = Tensor::<Backend, 1, Int>::from_ints([1, 1, 2, 2], &device);
+        let input1 = Tensor::<TestBackend, 1, Int>::from_ints([1, 2, 3, 4], &device);
+        let input2 = Tensor::<TestBackend, 1, Int>::from_ints([1, 1, 2, 2], &device);
         let output = model.forward(input1, input2);
         let expected = TensorData::from([1i64, 0, 2, 0]);
         output.to_data().assert_eq(&expected, true);
@@ -29,9 +29,9 @@ mod tests {
     #[test]
     fn bitwise_and_scalar_tensor() {
         let device = Default::default();
-        let model: bitwise_and_scalar::Model<Backend> = bitwise_and_scalar::Model::new(&device);
+        let model: bitwise_and_scalar::Model<TestBackend> = bitwise_and_scalar::Model::new(&device);
         // Run the model
-        let input1 = Tensor::<Backend, 1, Int>::from_ints([1, 2, 3, 4], &device);
+        let input1 = Tensor::<TestBackend, 1, Int>::from_ints([1, 2, 3, 4], &device);
         let scalar = 2;
         let output = model.forward(input1, scalar);
         let expected = TensorData::from([0i64, 2, 2, 0]);
@@ -41,10 +41,10 @@ mod tests {
     #[test]
     fn scalar_bitwise_and_tensor() {
         let device = Default::default();
-        let model: scalar_bitwise_and::Model<Backend> = scalar_bitwise_and::Model::new(&device);
+        let model: scalar_bitwise_and::Model<TestBackend> = scalar_bitwise_and::Model::new(&device);
         // Run the model
         let scalar = 2;
-        let input2 = Tensor::<Backend, 1, Int>::from_ints([1, 2, 3, 4], &device);
+        let input2 = Tensor::<TestBackend, 1, Int>::from_ints([1, 2, 3, 4], &device);
         let output = model.forward(scalar, input2);
         // Bitwise AND is commutative, so result should be same as tensor-scalar
         let expected = TensorData::from([0i64, 2, 2, 0]);
@@ -54,7 +54,7 @@ mod tests {
     #[test]
     fn scalar_bitwise_and_scalar() {
         let device = Default::default();
-        let model: scalar_bitwise_and_scalar::Model<Backend> =
+        let model: scalar_bitwise_and_scalar::Model<TestBackend> =
             scalar_bitwise_and_scalar::Model::new(&device);
         // Run the model
         let lhs = 7; // 0b111

--- a/crates/burn-import/onnx-tests/tests/bitwise_and/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/bitwise_and/mod.rs
@@ -12,7 +12,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Int, Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn bitwise_and_tensors() {

--- a/crates/burn-import/onnx-tests/tests/bitwise_not/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/bitwise_not/mod.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Int, Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn bitwise_not_tensors() {

--- a/crates/burn-import/onnx-tests/tests/bitwise_not/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/bitwise_not/mod.rs
@@ -7,14 +7,14 @@ mod tests {
     use super::*;
     use burn::tensor::{Int, Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn bitwise_not_tensors() {
         let device = Default::default();
-        let model: bitwise_not::Model<Backend> = bitwise_not::Model::new(&device);
+        let model: bitwise_not::Model<TestBackend> = bitwise_not::Model::new(&device);
         // Run the model
-        let input = Tensor::<Backend, 2, Int>::from_ints([[1, 2, 3, 4]], &device);
+        let input = Tensor::<TestBackend, 2, Int>::from_ints([[1, 2, 3, 4]], &device);
         let output = model.forward(input);
         let expected = TensorData::from([[-2i64, -3, -4, -5]]);
         output.to_data().assert_eq(&expected, true);

--- a/crates/burn-import/onnx-tests/tests/bitwise_or/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/bitwise_or/mod.rs
@@ -12,7 +12,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Int, Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn bitwise_or_tensors() {

--- a/crates/burn-import/onnx-tests/tests/bitwise_or/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/bitwise_or/mod.rs
@@ -12,16 +12,16 @@ mod tests {
     use super::*;
     use burn::tensor::{Int, Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn bitwise_or_tensors() {
         // Initialize the model
         let device = Default::default();
-        let model: bitwise_or::Model<Backend> = bitwise_or::Model::new(&device);
+        let model: bitwise_or::Model<TestBackend> = bitwise_or::Model::new(&device);
         // Run the model
-        let input1 = Tensor::<Backend, 2, Int>::from_ints([[1, 2, 3, 4]], &device);
-        let input2 = Tensor::<Backend, 2, Int>::from_ints([[1, 1, 2, 2]], &device);
+        let input1 = Tensor::<TestBackend, 2, Int>::from_ints([[1, 2, 3, 4]], &device);
+        let input2 = Tensor::<TestBackend, 2, Int>::from_ints([[1, 1, 2, 2]], &device);
         let output = model.forward(input1, input2);
         let expected = TensorData::from([[1i64, 3, 3, 6]]);
         output.to_data().assert_eq(&expected, true);
@@ -31,9 +31,9 @@ mod tests {
     fn bitwise_or_scalar_tensor() {
         // Initialize the model
         let device = Default::default();
-        let model: bitwise_or_scalar::Model<Backend> = bitwise_or_scalar::Model::new(&device);
+        let model: bitwise_or_scalar::Model<TestBackend> = bitwise_or_scalar::Model::new(&device);
         // Run the model
-        let input1 = Tensor::<Backend, 2, Int>::from_ints([[1, 2, 3, 4]], &device);
+        let input1 = Tensor::<TestBackend, 2, Int>::from_ints([[1, 2, 3, 4]], &device);
         let scalar = 2;
         let output = model.forward(input1, scalar);
         let expected = TensorData::from([[3i64, 2, 3, 6]]);
@@ -44,10 +44,10 @@ mod tests {
     fn scalar_bitwise_or_tensor() {
         // Initialize the model
         let device = Default::default();
-        let model: scalar_bitwise_or::Model<Backend> = scalar_bitwise_or::Model::new(&device);
+        let model: scalar_bitwise_or::Model<TestBackend> = scalar_bitwise_or::Model::new(&device);
         // Run the model
         let scalar = 2;
-        let input2 = Tensor::<Backend, 2, Int>::from_ints([[1, 2, 3, 4]], &device);
+        let input2 = Tensor::<TestBackend, 2, Int>::from_ints([[1, 2, 3, 4]], &device);
         let output = model.forward(scalar, input2);
         // Bitwise OR is commutative, so result should be same as tensor-scalar
         let expected = TensorData::from([[3i64, 2, 3, 6]]);
@@ -57,7 +57,7 @@ mod tests {
     #[test]
     fn scalar_bitwise_or_scalar() {
         let device = Default::default();
-        let model: scalar_bitwise_or_scalar::Model<Backend> =
+        let model: scalar_bitwise_or_scalar::Model<TestBackend> =
             scalar_bitwise_or_scalar::Model::new(&device);
         // Run the model
         let lhs = 5; // 0b101

--- a/crates/burn-import/onnx-tests/tests/bitwise_xor/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/bitwise_xor/mod.rs
@@ -12,7 +12,7 @@ mod tests {
     use super::*;
     use burn::tensor::{Int, Tensor, TensorData};
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     fn bitwise_xor_tensors() {

--- a/crates/burn-import/onnx-tests/tests/bitwise_xor/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/bitwise_xor/mod.rs
@@ -12,15 +12,15 @@ mod tests {
     use super::*;
     use burn::tensor::{Int, Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn bitwise_xor_tensors() {
         let device = Default::default();
-        let model: bitwise_xor::Model<Backend> = bitwise_xor::Model::new(&device);
+        let model: bitwise_xor::Model<TestBackend> = bitwise_xor::Model::new(&device);
         // Run the model
-        let input1 = Tensor::<Backend, 2, Int>::from_ints([[1, 2, 3, 4]], &device);
-        let input2 = Tensor::<Backend, 2, Int>::from_ints([[1, 1, 2, 2]], &device);
+        let input1 = Tensor::<TestBackend, 2, Int>::from_ints([[1, 2, 3, 4]], &device);
+        let input2 = Tensor::<TestBackend, 2, Int>::from_ints([[1, 1, 2, 2]], &device);
         let output = model.forward(input1, input2);
         let expected = TensorData::from([[0i64, 3, 1, 6]]);
         output.to_data().assert_eq(&expected, true);
@@ -29,9 +29,9 @@ mod tests {
     #[test]
     fn bitwise_xor_scalar_tensor() {
         let device = Default::default();
-        let model: bitwise_xor_scalar::Model<Backend> = bitwise_xor_scalar::Model::new(&device);
+        let model: bitwise_xor_scalar::Model<TestBackend> = bitwise_xor_scalar::Model::new(&device);
         // Run the model
-        let input1 = Tensor::<Backend, 2, Int>::from_ints([[1, 2, 3, 4]], &device);
+        let input1 = Tensor::<TestBackend, 2, Int>::from_ints([[1, 2, 3, 4]], &device);
         let scalar = 2;
         let output = model.forward(input1, scalar);
         let expected = TensorData::from([[3i64, 0, 1, 6]]);
@@ -41,10 +41,10 @@ mod tests {
     #[test]
     fn scalar_bitwise_xor_tensor() {
         let device = Default::default();
-        let model: scalar_bitwise_xor::Model<Backend> = scalar_bitwise_xor::Model::new(&device);
+        let model: scalar_bitwise_xor::Model<TestBackend> = scalar_bitwise_xor::Model::new(&device);
         // Run the model
         let scalar = 2;
-        let input2 = Tensor::<Backend, 2, Int>::from_ints([[1, 2, 3, 4]], &device);
+        let input2 = Tensor::<TestBackend, 2, Int>::from_ints([[1, 2, 3, 4]], &device);
         let output = model.forward(scalar, input2);
         // Bitwise XOR is commutative, so result should be same as tensor-scalar
         let expected = TensorData::from([[3i64, 0, 1, 6]]);
@@ -54,7 +54,7 @@ mod tests {
     #[test]
     fn scalar_bitwise_xor_scalar() {
         let device = Default::default();
-        let model: scalar_bitwise_xor_scalar::Model<Backend> =
+        let model: scalar_bitwise_xor_scalar::Model<TestBackend> =
             scalar_bitwise_xor_scalar::Model::new(&device);
         // Run the model
         let lhs = 5; // 0b101

--- a/crates/burn-import/onnx-tests/tests/cast/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/cast/mod.rs
@@ -7,18 +7,18 @@ mod tests {
     use super::*;
     use burn::tensor::{Bool, Int, Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    use crate::backend::Backend;
-    type FT = FloatElem<Backend>;
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
 
     #[test]
     fn cast() {
         let device = Default::default();
-        let model: cast::Model<Backend> = cast::Model::new(&device);
+        let model: cast::Model<TestBackend> = cast::Model::new(&device);
 
         let input_bool =
-            Tensor::<Backend, 2, Bool>::from_bool(TensorData::from([[true], [true]]), &device);
-        let input_int = Tensor::<Backend, 2, Int>::from_ints([[1], [1]], &device);
-        let input_float = Tensor::<Backend, 2>::from_floats([[1f32], [1.]], &device);
+            Tensor::<TestBackend, 2, Bool>::from_bool(TensorData::from([[true], [true]]), &device);
+        let input_int = Tensor::<TestBackend, 2, Int>::from_ints([[1], [1]], &device);
+        let input_float = Tensor::<TestBackend, 2>::from_floats([[1f32], [1.]], &device);
         let input_scalar = 1f32;
 
         let (
@@ -70,10 +70,10 @@ mod tests {
         // even when cast to other integer types in ONNX
 
         let device = Default::default();
-        let model: cast_shape::Model<Backend> = cast_shape::Model::new(&device);
+        let model: cast_shape::Model<TestBackend> = cast_shape::Model::new(&device);
 
         // Create test input
-        let input = Tensor::<Backend, 3>::ones([2, 3, 4], &device);
+        let input = Tensor::<TestBackend, 3>::ones([2, 3, 4], &device);
 
         // Run the model
         let (shape_original, shape_casted) = model.forward(input);
@@ -90,17 +90,17 @@ mod tests {
         // When casting Shape to float, it should convert to a 1D tensor
 
         let device = Default::default();
-        let model: cast_shape_to_float::Model<Backend> = cast_shape_to_float::Model::new(&device);
+        let model: cast_shape_to_float::Model<TestBackend> = cast_shape_to_float::Model::new(&device);
 
         // Create test input with shape [2, 3, 4]
-        let input = Tensor::<Backend, 3>::ones([2, 3, 4], &device);
-        let multiplier = Tensor::<Backend, 1>::from_floats([2.0], &device);
+        let input = Tensor::<TestBackend, 3>::ones([2, 3, 4], &device);
+        let multiplier = Tensor::<TestBackend, 1>::from_floats([2.0], &device);
 
         // Run the model - it extracts shape, casts to float, and multiplies by 2
         let output = model.forward(input, multiplier);
 
         // The output should be [2.0, 3.0, 4.0] * 2.0 = [4.0, 6.0, 8.0]
-        let expected = Tensor::<Backend, 1>::from_floats([4.0, 6.0, 8.0], &device);
+        let expected = Tensor::<TestBackend, 1>::from_floats([4.0, 6.0, 8.0], &device);
 
         // Check values are close
         output
@@ -114,17 +114,17 @@ mod tests {
         // When casting Shape to bool, non-zero values become true
 
         let device = Default::default();
-        let model: cast_shape_to_bool::Model<Backend> = cast_shape_to_bool::Model::new(&device);
+        let model: cast_shape_to_bool::Model<TestBackend> = cast_shape_to_bool::Model::new(&device);
 
         // Create test input with shape [2, 3, 4] (all non-zero dimensions)
-        let input = Tensor::<Backend, 3>::ones([2, 3, 4], &device);
+        let input = Tensor::<TestBackend, 3>::ones([2, 3, 4], &device);
 
         // Run the model - it extracts shape and casts to bool
         let output = model.forward(input);
 
         // The output should be [true, true, true] since all dimensions are non-zero
         let expected =
-            Tensor::<Backend, 1, Bool>::from_bool(TensorData::from([true, true, true]), &device);
+            Tensor::<TestBackend, 1, Bool>::from_bool(TensorData::from([true, true, true]), &device);
 
         // Check values match
         output.to_data().assert_eq(&expected.to_data(), true);

--- a/crates/burn-import/onnx-tests/tests/cast/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/cast/mod.rs
@@ -90,7 +90,8 @@ mod tests {
         // When casting Shape to float, it should convert to a 1D tensor
 
         let device = Default::default();
-        let model: cast_shape_to_float::Model<TestBackend> = cast_shape_to_float::Model::new(&device);
+        let model: cast_shape_to_float::Model<TestBackend> =
+            cast_shape_to_float::Model::new(&device);
 
         // Create test input with shape [2, 3, 4]
         let input = Tensor::<TestBackend, 3>::ones([2, 3, 4], &device);
@@ -123,8 +124,10 @@ mod tests {
         let output = model.forward(input);
 
         // The output should be [true, true, true] since all dimensions are non-zero
-        let expected =
-            Tensor::<TestBackend, 1, Bool>::from_bool(TensorData::from([true, true, true]), &device);
+        let expected = Tensor::<TestBackend, 1, Bool>::from_bool(
+            TensorData::from([true, true, true]),
+            &device,
+        );
 
         // Check values match
         output.to_data().assert_eq(&expected.to_data(), true);

--- a/crates/burn-import/onnx-tests/tests/ceil/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/ceil/mod.rs
@@ -6,17 +6,17 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, ops::FloatElem};
 
-    use crate::backend::Backend;
-    type FT = FloatElem<Backend>;
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
 
     #[test]
     fn ceil_test() {
         // Test for ceil
         let device = Default::default();
-        let model = ceil::Model::<Backend>::new(&device);
+        let model = ceil::Model::<TestBackend>::new(&device);
 
-        let input = Tensor::<Backend, 1>::from_floats([-0.5, 1.5, 2.1], &device);
-        let expected = Tensor::<Backend, 1>::from_floats([0., 2., 3.], &device);
+        let input = Tensor::<TestBackend, 1>::from_floats([-0.5, 1.5, 2.1], &device);
+        let expected = Tensor::<TestBackend, 1>::from_floats([0., 2., 3.], &device);
 
         let output = model.forward(input);
 

--- a/crates/burn-import/onnx-tests/tests/clip/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/clip/mod.rs
@@ -7,16 +7,16 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn clip() {
         // Initialize the model without weights (because the exported file does not contain them)
         let device = Default::default();
-        let model: clip::Model<Backend> = clip::Model::new(&device);
+        let model: clip::Model<TestBackend> = clip::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 1>::from_floats(
+        let input = Tensor::<TestBackend, 1>::from_floats(
             [
                 0.88226926,
                 0.91500396,

--- a/crates/burn-import/onnx-tests/tests/concat/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/concat/mod.rs
@@ -7,16 +7,16 @@ mod tests {
     use super::*;
     use burn::tensor::{Shape, Tensor};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn concat_tensors() {
         // Initialize the model
         let device = Default::default();
-        let model: concat::Model<Backend> = concat::Model::new(&device);
+        let model: concat::Model<TestBackend> = concat::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::zeros([1, 2, 3, 5], &device);
+        let input = Tensor::<TestBackend, 4>::zeros([1, 2, 3, 5], &device);
 
         let output = model.forward(input);
 
@@ -29,12 +29,12 @@ mod tests {
     fn concat_shapes() {
         // Initialize the model
         let device = Default::default();
-        let model: concat_shape::Model<Backend> = concat_shape::Model::new(&device);
+        let model: concat_shape::Model<TestBackend> = concat_shape::Model::new(&device);
 
         // Create test inputs with the expected shapes
-        let input1 = Tensor::<Backend, 2>::zeros([2, 3], &device);
-        let input2 = Tensor::<Backend, 3>::zeros([4, 5, 6], &device);
-        let input3 = Tensor::<Backend, 1>::zeros([7], &device);
+        let input1 = Tensor::<TestBackend, 2>::zeros([2, 3], &device);
+        let input2 = Tensor::<TestBackend, 3>::zeros([4, 5, 6], &device);
+        let input3 = Tensor::<TestBackend, 1>::zeros([7], &device);
 
         // Run the model - it extracts shapes and concatenates them
         let output = model.forward(input1, input2, input3);
@@ -48,11 +48,11 @@ mod tests {
     fn concat_shape_with_constant() {
         // Initialize the model
         let device = Default::default();
-        let model: concat_shape_with_constant::Model<Backend> =
+        let model: concat_shape_with_constant::Model<TestBackend> =
             concat_shape_with_constant::Model::new(&device);
 
         // Create test input with shape [3, 4, 5]
-        let input1 = Tensor::<Backend, 3>::zeros([3, 4, 5], &device);
+        let input1 = Tensor::<TestBackend, 3>::zeros([3, 4, 5], &device);
 
         // Run the model - it extracts shape and concatenates with constant [10, 20]
         let output = model.forward(input1);

--- a/crates/burn-import/onnx-tests/tests/constant/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/constant/mod.rs
@@ -14,14 +14,14 @@ mod tests {
     use super::*;
     use burn::tensor::{Int, Shape, Tensor};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn add_constant_f32() {
         let device = Default::default();
-        let model = constant_f32::Model::<Backend>::new(&device);
-        let input = Tensor::<Backend, 3>::zeros(Shape::from([2, 3, 4]), &device);
-        let expected = Tensor::<Backend, 3>::full([2, 3, 4], 2, &device).to_data();
+        let model = constant_f32::Model::<TestBackend>::new(&device);
+        let input = Tensor::<TestBackend, 3>::zeros(Shape::from([2, 3, 4]), &device);
+        let expected = Tensor::<TestBackend, 3>::full([2, 3, 4], 2, &device).to_data();
 
         let output = model.forward(input);
 
@@ -31,9 +31,9 @@ mod tests {
     #[test]
     fn add_constant_f64() {
         let device = Default::default();
-        let model = constant_f64::Model::<Backend>::new(&device);
-        let input = Tensor::<Backend, 3>::zeros(Shape::from([2, 3, 4]), &device);
-        let expected = Tensor::<Backend, 3>::full([2, 3, 4], 2, &device).to_data();
+        let model = constant_f64::Model::<TestBackend>::new(&device);
+        let input = Tensor::<TestBackend, 3>::zeros(Shape::from([2, 3, 4]), &device);
+        let expected = Tensor::<TestBackend, 3>::full([2, 3, 4], 2, &device).to_data();
 
         let output = model.forward(input);
 
@@ -43,9 +43,9 @@ mod tests {
     #[test]
     fn add_constant_i32() {
         let device = Default::default();
-        let model = constant_i32::Model::<Backend>::new(&device);
-        let input = Tensor::<Backend, 3, Int>::zeros(Shape::from([2, 3, 4]), &device);
-        let expected = Tensor::<Backend, 3, Int>::full([2, 3, 4], 2, &device).to_data();
+        let model = constant_i32::Model::<TestBackend>::new(&device);
+        let input = Tensor::<TestBackend, 3, Int>::zeros(Shape::from([2, 3, 4]), &device);
+        let expected = Tensor::<TestBackend, 3, Int>::full([2, 3, 4], 2, &device).to_data();
 
         let output = model.forward(input);
 
@@ -55,9 +55,9 @@ mod tests {
     #[test]
     fn add_constant_i64() {
         let device = Default::default();
-        let model = constant_i64::Model::<Backend>::new(&device);
-        let input = Tensor::<Backend, 3, Int>::zeros(Shape::from([2, 3, 4]), &device);
-        let expected = Tensor::<Backend, 3, Int>::full([2, 3, 4], 2, &device).to_data();
+        let model = constant_i64::Model::<TestBackend>::new(&device);
+        let input = Tensor::<TestBackend, 3, Int>::zeros(Shape::from([2, 3, 4]), &device);
+        let expected = Tensor::<TestBackend, 3, Int>::full([2, 3, 4], 2, &device).to_data();
 
         let output = model.forward(input);
 
@@ -67,10 +67,10 @@ mod tests {
     #[test]
     fn constant_shape() {
         let device = Default::default();
-        let model = constant_shape::Model::<Backend>::new(&device);
+        let model = constant_shape::Model::<TestBackend>::new(&device);
 
         // Create input tensor with shape [2, 4, 6]
-        let input = Tensor::<Backend, 3>::zeros(Shape::from([2, 4, 6]), &device);
+        let input = Tensor::<TestBackend, 3>::zeros(Shape::from([2, 4, 6]), &device);
 
         // The model tests Shape operations with constants
         // Input shape: [2, 4, 6]
@@ -113,10 +113,10 @@ mod tests {
         // This should succeed with our fix
         // Without the fix, this would panic during model creation with:
         // "Concat axis 2 is out of bounds for rank 2"
-        let model = rank_inference_propagation::Model::<Backend>::new(&device);
+        let model = rank_inference_propagation::Model::<TestBackend>::new(&device);
 
         // Create a 3D input tensor (batch=2, sequence=4, features=384)
-        let input = Tensor::<Backend, 3>::ones([2, 4, 384], &device);
+        let input = Tensor::<TestBackend, 3>::ones([2, 4, 384], &device);
 
         // Run the model
         let output = model.forward(input);

--- a/crates/burn-import/onnx-tests/tests/constant_lifting_multiple/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/constant_lifting_multiple/mod.rs
@@ -5,18 +5,18 @@ include_models!(constant_lifting_multiple);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
     use burn::tensor::{Tensor, TensorData};
 
     #[test]
     fn test_constant_lifting_multiple() {
-        let model: constant_lifting_multiple::Model<Backend> =
+        let model: constant_lifting_multiple::Model<TestBackend> =
             constant_lifting_multiple::Model::default();
 
         let device = Default::default();
 
         // Create input tensor (2x3 as defined in the Python script)
-        let input = Tensor::<Backend, 2>::from_data(
+        let input = Tensor::<TestBackend, 2>::from_data(
             TensorData::from([[1.0f32, -2.0, 8.0], [-4.0, 5.0, 3.0]]),
             &device,
         );

--- a/crates/burn-import/onnx-tests/tests/constant_of_shape/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/constant_of_shape/mod.rs
@@ -15,16 +15,16 @@ mod tests {
     use super::*;
     use burn::tensor::{Int, Tensor, Tolerance, ops::FloatElem};
 
-    use crate::backend::Backend;
-    type FT = FloatElem<Backend>;
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
 
     #[test]
     fn constant_of_shape() {
         // This tests shape is being passed directly to the model
         let device = Default::default();
-        let model = constant_of_shape::Model::<Backend>::new(&device);
+        let model = constant_of_shape::Model::<TestBackend>::new(&device);
         let input_shape = [2i64, 3i64, 2i64];
-        let expected = Tensor::<Backend, 3>::full([2, 3, 2], 1.125, &device).to_data();
+        let expected = Tensor::<TestBackend, 3>::full([2, 3, 2], 1.125, &device).to_data();
 
         let output = model.forward(input_shape);
 
@@ -37,11 +37,11 @@ mod tests {
     fn constant_of_shape_full_like() {
         // This tests shape is being passed from the input tensor
         let device = Default::default();
-        let model = constant_of_shape_full_like::Model::<Backend>::new(&device);
+        let model = constant_of_shape_full_like::Model::<TestBackend>::new(&device);
         let shape = [2, 3, 2];
-        let f_expected = Tensor::<Backend, 3>::full(shape, 3.0, &device);
-        let i_expected = Tensor::<Backend, 3, Int>::full(shape, 5, &device);
-        let b_expected = Tensor::<Backend, 3, Int>::ones(shape, &device).bool();
+        let f_expected = Tensor::<TestBackend, 3>::full(shape, 3.0, &device);
+        let i_expected = Tensor::<TestBackend, 3, Int>::full(shape, 5, &device);
+        let b_expected = Tensor::<TestBackend, 3, Int>::ones(shape, &device).bool();
 
         let input = Tensor::ones(shape, &device);
         let (f_output, i_output, b_output) = model.forward(input);
@@ -55,7 +55,7 @@ mod tests {
     fn constant_of_shape_scalar_test() {
         // Test scalar output case
         let device = Default::default();
-        let model = constant_of_shape_scalar::Model::<Backend>::new(&device);
+        let model = constant_of_shape_scalar::Model::<TestBackend>::new(&device);
 
         // Input is an empty shape (rank 0)
         let shape_input = [];
@@ -69,7 +69,7 @@ mod tests {
     fn constant_of_shape_scalar_custom_value_test() {
         // Test scalar output with custom value
         let device = Default::default();
-        let model = constant_of_shape_scalar_custom_value::Model::<Backend>::new(&device);
+        let model = constant_of_shape_scalar_custom_value::Model::<TestBackend>::new(&device);
 
         // Input is an empty shape (rank 0)
         let shape_input = [];
@@ -83,7 +83,7 @@ mod tests {
     fn constant_of_shape_tensor_test() {
         // Test tensor output case
         let device = Default::default();
-        let model = constant_of_shape_tensor::Model::<Backend>::new(&device);
+        let model = constant_of_shape_tensor::Model::<TestBackend>::new(&device);
 
         // Input is shape [2, 3]
         let shape_input = [2i64, 3i64];
@@ -91,7 +91,7 @@ mod tests {
 
         // Output should be a 2x3 tensor filled with 0.0 (default)
         assert_eq!(output.dims(), [2, 3]);
-        let expected = Tensor::<Backend, 2>::zeros([2, 3], &device);
+        let expected = Tensor::<TestBackend, 2>::zeros([2, 3], &device);
         output.to_data().assert_eq(&expected.to_data(), true);
     }
 
@@ -99,7 +99,7 @@ mod tests {
     fn constant_of_shape_shape_optimization_test() {
         // Test Shape(1) -> Shape(1) optimization with Int64
         let device = Default::default();
-        let model = constant_of_shape_shape_optimization::Model::<Backend>::new(&device);
+        let model = constant_of_shape_shape_optimization::Model::<TestBackend>::new(&device);
 
         // Input is Shape(1) with some dimension
         let shape_input = [3i64]; // Requesting a shape with 3 elements
@@ -115,14 +115,14 @@ mod tests {
         // This tests the constant lifting mechanism where the shape values
         // are known at compile time and embedded directly in the generated code
         let device = Default::default();
-        let model = constant_of_shape_with_constant_input::Model::<Backend>::new(&device);
+        let model = constant_of_shape_with_constant_input::Model::<TestBackend>::new(&device);
 
         // Model has no inputs - the shape [2, 3, 4] comes from a constant
         let output = model.forward();
 
         // Output should be a 2x3x4 tensor filled with 1 (as specified in the value attribute)
         assert_eq!(output.dims(), [2, 3, 4]);
-        let expected = Tensor::<Backend, 3, Int>::full([2, 3, 4], 1i64, &device);
+        let expected = Tensor::<TestBackend, 3, Int>::full([2, 3, 4], 1i64, &device);
         output.to_data().assert_eq(&expected.to_data(), true);
     }
 }

--- a/crates/burn-import/onnx-tests/tests/conv/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/conv/mod.rs
@@ -9,15 +9,15 @@ mod tests {
     use core::f64::consts;
     use float_cmp::ApproxEq;
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn conv1d() {
         // Initialize the model with weights (loaded from the exported file)
-        let model: conv1d::Model<Backend> = conv1d::Model::default();
+        let model: conv1d::Model<TestBackend> = conv1d::Model::default();
 
         // Run the model with pi as input for easier testing
-        let input = Tensor::<Backend, 3>::full([6, 4, 10], consts::PI, &Default::default());
+        let input = Tensor::<TestBackend, 3>::full([6, 4, 10], consts::PI, &Default::default());
 
         let output = model.forward(input);
 
@@ -35,10 +35,10 @@ mod tests {
     #[test]
     fn conv2d() {
         // Initialize the model with weights (loaded from the exported file)
-        let model: conv2d::Model<Backend> = conv2d::Model::default();
+        let model: conv2d::Model<TestBackend> = conv2d::Model::default();
 
         // Run the model with ones as input for easier testing
-        let input = Tensor::<Backend, 4>::ones([2, 4, 10, 15], &Default::default());
+        let input = Tensor::<TestBackend, 4>::ones([2, 4, 10, 15], &Default::default());
 
         let output = model.forward(input);
 
@@ -57,10 +57,10 @@ mod tests {
     #[test]
     fn conv3d() {
         // Initialize the model with weights (loaded from the exported file)
-        let model: conv3d::Model<Backend> = conv3d::Model::default();
+        let model: conv3d::Model<TestBackend> = conv3d::Model::default();
 
         // Run the model with ones as input for easier testing
-        let input = Tensor::<Backend, 5>::ones([2, 4, 4, 5, 7], &Default::default());
+        let input = Tensor::<TestBackend, 5>::ones([2, 4, 4, 5, 7], &Default::default());
 
         let output = model.forward(input);
 

--- a/crates/burn-import/onnx-tests/tests/conv_transpose/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/conv_transpose/mod.rs
@@ -8,15 +8,15 @@ mod tests {
     use burn::tensor::{Shape, Tensor};
     use float_cmp::ApproxEq;
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn conv_transpose1d() {
         // Initialize the model with weights (loaded from the exported file)
-        let model: conv_transpose1d::Model<Backend> = conv_transpose1d::Model::default();
+        let model: conv_transpose1d::Model<TestBackend> = conv_transpose1d::Model::default();
 
         // Run the model with ones as input for easier testing
-        let input = Tensor::<Backend, 3>::ones([2, 4, 10], &Default::default());
+        let input = Tensor::<TestBackend, 3>::ones([2, 4, 10], &Default::default());
 
         let output = model.forward(input);
 
@@ -35,10 +35,10 @@ mod tests {
     #[test]
     fn conv_transpose2d() {
         // Initialize the model with weights (loaded from the exported file)
-        let model: conv_transpose2d::Model<Backend> = conv_transpose2d::Model::default();
+        let model: conv_transpose2d::Model<TestBackend> = conv_transpose2d::Model::default();
 
         // Run the model with ones as input for easier testing
-        let input = Tensor::<Backend, 4>::ones([2, 4, 10, 15], &Default::default());
+        let input = Tensor::<TestBackend, 4>::ones([2, 4, 10, 15], &Default::default());
 
         let output = model.forward(input);
 
@@ -57,10 +57,10 @@ mod tests {
     #[test]
     fn conv_transpose3d() {
         // Initialize the model with weights (loaded from the exported file)
-        let model: conv_transpose3d::Model<Backend> = conv_transpose3d::Model::default();
+        let model: conv_transpose3d::Model<TestBackend> = conv_transpose3d::Model::default();
 
         // Run the model with ones as input for easier testing
-        let input = Tensor::<Backend, 5>::ones([2, 4, 4, 5, 7], &Default::default());
+        let input = Tensor::<TestBackend, 5>::ones([2, 4, 4, 5, 7], &Default::default());
 
         let output = model.forward(input);
 

--- a/crates/burn-import/onnx-tests/tests/cos/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/cos/mod.rs
@@ -7,15 +7,15 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    use crate::backend::Backend;
-    type FT = FloatElem<Backend>;
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
 
     #[test]
     fn cos() {
         let device = Default::default();
-        let model: cos::Model<Backend> = cos::Model::new(&device);
+        let model: cos::Model<TestBackend> = cos::Model::new(&device);
 
-        let input = Tensor::<Backend, 4>::from_floats([[[[1.0, 4.0, 9.0, 25.0]]]], &device);
+        let input = Tensor::<TestBackend, 4>::from_floats([[[[1.0, 4.0, 9.0, 25.0]]]], &device);
 
         let output = model.forward(input);
         let expected = TensorData::from([[[[0.5403f32, -0.6536, -0.9111, 0.9912]]]]);

--- a/crates/burn-import/onnx-tests/tests/cosh/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/cosh/mod.rs
@@ -7,15 +7,15 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    use crate::backend::Backend;
-    type FT = FloatElem<Backend>;
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
 
     #[test]
     fn cosh() {
         let device = Default::default();
-        let model: cosh::Model<Backend> = cosh::Model::new(&device);
+        let model: cosh::Model<TestBackend> = cosh::Model::new(&device);
 
-        let input = Tensor::<Backend, 4>::from_floats([[[[-4.0, 0.5, 1.0, 9.0]]]], &device);
+        let input = Tensor::<TestBackend, 4>::from_floats([[[[-4.0, 0.5, 1.0, 9.0]]]], &device);
 
         let output = model.forward(input);
         let expected = TensorData::from([[[[27.3082, 1.1276, 1.5431, 4051.5420]]]]);

--- a/crates/burn-import/onnx-tests/tests/depth_to_space/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/depth_to_space/mod.rs
@@ -7,15 +7,15 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    use crate::backend::Backend;
-    type FT = FloatElem<Backend>;
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
 
     #[test]
     fn depth_to_space_dcr() {
         let device = Default::default();
-        let model: depth_to_space_dcr::Model<Backend> = depth_to_space_dcr::Model::new(&device);
+        let model: depth_to_space_dcr::Model<TestBackend> = depth_to_space_dcr::Model::new(&device);
 
-        let input = Tensor::<Backend, 4>::from_floats(
+        let input = Tensor::<TestBackend, 4>::from_floats(
             [
                 [
                     [[0.5, -0.14, 0.65], [1.52, -0.23, -0.23]],
@@ -56,9 +56,9 @@ mod tests {
     #[test]
     fn depth_to_space_crd() {
         let device = Default::default();
-        let model: depth_to_space_crd::Model<Backend> = depth_to_space_crd::Model::new(&device);
+        let model: depth_to_space_crd::Model<TestBackend> = depth_to_space_crd::Model::new(&device);
 
-        let input = Tensor::<Backend, 4>::from_floats(
+        let input = Tensor::<TestBackend, 4>::from_floats(
             [
                 [
                     [[0.34, -1.76, 0.32], [-0.39, -0.68, 0.61]],

--- a/crates/burn-import/onnx-tests/tests/div/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/div/mod.rs
@@ -7,16 +7,16 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn div_tensor_by_scalar_and_tensor_by_tensor() {
         // Initialize the model without weights (because the exported file does not contain them)
         let device = Default::default();
-        let model: div::Model<Backend> = div::Model::new(&device);
+        let model: div::Model<TestBackend> = div::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats([[[[3., 6., 6., 9.]]]], &device);
+        let input = Tensor::<TestBackend, 4>::from_floats([[[[3., 6., 6., 9.]]]], &device);
         let scalar1 = 9.0f64;
         let scalar2 = 3.0f64;
         let output = model.forward(input, scalar1, scalar2);
@@ -29,11 +29,11 @@ mod tests {
     fn div_shape_with_scalar_and_shape() {
         // Initialize the model
         let device = Default::default();
-        let model: div_shape::Model<Backend> = div_shape::Model::new(&device);
+        let model: div_shape::Model<TestBackend> = div_shape::Model::new(&device);
 
         // Create input tensors
-        let input1 = Tensor::<Backend, 3>::ones([8, 12, 16], &device);
-        let input2 = Tensor::<Backend, 3>::ones([2, 3, 4], &device);
+        let input1 = Tensor::<TestBackend, 3>::ones([8, 12, 16], &device);
+        let input2 = Tensor::<TestBackend, 3>::ones([2, 3, 4], &device);
         let (shape_div_scalar, shape_div_shape) = model.forward(input1, input2);
 
         // Expected outputs

--- a/crates/burn-import/onnx-tests/tests/dropout/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/dropout/mod.rs
@@ -8,14 +8,14 @@ mod tests {
     use burn::tensor::{Shape, Tensor};
     use float_cmp::ApproxEq;
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn dropout() {
-        let model: dropout::Model<Backend> = dropout::Model::default();
+        let model: dropout::Model<TestBackend> = dropout::Model::default();
 
         // Run the model with ones as input for easier testing
-        let input = Tensor::<Backend, 4>::ones([2, 4, 10, 15], &Default::default());
+        let input = Tensor::<TestBackend, 4>::ones([2, 4, 10, 15], &Default::default());
 
         let output = model.forward(input);
 

--- a/crates/burn-import/onnx-tests/tests/equal/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/equal/mod.rs
@@ -15,7 +15,8 @@ mod tests {
         let model: equal::Model<TestBackend> = equal::Model::default();
 
         // Run the model
-        let input = Tensor::<TestBackend, 4>::from_floats([[[[1., 1., 1., 1.]]]], &Default::default());
+        let input =
+            Tensor::<TestBackend, 4>::from_floats([[[[1., 1., 1., 1.]]]], &Default::default());
 
         let scalar = 2f64;
         let (tensor_out, scalar_out) = model.forward(input, scalar);

--- a/crates/burn-import/onnx-tests/tests/equal/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/equal/mod.rs
@@ -7,15 +7,15 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn equal_scalar_to_scalar_and_tensor_to_tensor() {
         // Initialize the model with weights (loaded from the exported file)
-        let model: equal::Model<Backend> = equal::Model::default();
+        let model: equal::Model<TestBackend> = equal::Model::default();
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats([[[[1., 1., 1., 1.]]]], &Default::default());
+        let input = Tensor::<TestBackend, 4>::from_floats([[[[1., 1., 1., 1.]]]], &Default::default());
 
         let scalar = 2f64;
         let (tensor_out, scalar_out) = model.forward(input, scalar);
@@ -29,10 +29,10 @@ mod tests {
     #[test]
     fn equal_shape() {
         // Test comparing a Shape output with a constant shape
-        let model: equal_shape::Model<Backend> = equal_shape::Model::default();
+        let model: equal_shape::Model<TestBackend> = equal_shape::Model::default();
 
         // Create input tensor with shape [2, 3, 4]
-        let input = Tensor::<Backend, 3>::zeros([2, 3, 4], &Default::default());
+        let input = Tensor::<TestBackend, 3>::zeros([2, 3, 4], &Default::default());
 
         let output = model.forward(input);
         // Shape [2, 3, 4] should equal [2, 3, 4]
@@ -44,11 +44,11 @@ mod tests {
     #[test]
     fn equal_two_shapes() {
         // Test comparing shapes from two different tensors
-        let model: equal_two_shapes::Model<Backend> = equal_two_shapes::Model::default();
+        let model: equal_two_shapes::Model<TestBackend> = equal_two_shapes::Model::default();
 
         // Create two input tensors with same shape [2, 3, 4]
-        let input1 = Tensor::<Backend, 3>::zeros([2, 3, 4], &Default::default());
-        let input2 = Tensor::<Backend, 3>::ones([2, 3, 4], &Default::default());
+        let input1 = Tensor::<TestBackend, 3>::zeros([2, 3, 4], &Default::default());
+        let input2 = Tensor::<TestBackend, 3>::ones([2, 3, 4], &Default::default());
 
         let output = model.forward(input1, input2);
         // Both have shape [2, 3, 4] so all elements should be equal (1 for true)

--- a/crates/burn-import/onnx-tests/tests/erf/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/erf/mod.rs
@@ -7,18 +7,18 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, Tolerance, ops::FloatElem};
 
-    use crate::backend::Backend;
-    type FT = FloatElem<Backend>;
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
 
     #[test]
     fn erf() {
-        let model: erf::Model<Backend> = erf::Model::default();
+        let model: erf::Model<TestBackend> = erf::Model::default();
 
         let device = Default::default();
-        let input = Tensor::<Backend, 4>::from_data([[[[1.0, 2.0, 3.0, 4.0]]]], &device);
+        let input = Tensor::<TestBackend, 4>::from_data([[[[1.0, 2.0, 3.0, 4.0]]]], &device);
         let output = model.forward(input);
         let expected =
-            Tensor::<Backend, 4>::from_data([[[[0.8427f32, 0.9953, 1.0000, 1.0000]]]], &device);
+            Tensor::<TestBackend, 4>::from_data([[[[0.8427f32, 0.9953, 1.0000, 1.0000]]]], &device);
 
         output
             .to_data()

--- a/crates/burn-import/onnx-tests/tests/exp/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/exp/mod.rs
@@ -7,16 +7,16 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    use crate::backend::Backend;
-    type FT = FloatElem<Backend>;
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
 
     #[test]
     #[allow(clippy::approx_constant)]
     fn exp() {
         let device = Default::default();
-        let model: exp::Model<Backend> = exp::Model::new(&device);
+        let model: exp::Model<TestBackend> = exp::Model::new(&device);
 
-        let input = Tensor::<Backend, 4>::from_floats([[[[0.0000, 0.6931]]]], &device);
+        let input = Tensor::<TestBackend, 4>::from_floats([[[[0.0000, 0.6931]]]], &device);
 
         let output = model.forward(input);
         let expected = TensorData::from([[[[1f32, 2.]]]]);

--- a/crates/burn-import/onnx-tests/tests/expand/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/expand/mod.rs
@@ -7,14 +7,14 @@ mod tests {
     use super::*;
     use burn::tensor::{Int, Shape, Tensor};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn expand() {
         let device = Default::default();
-        let model: expand::Model<Backend> = expand::Model::new(&device);
+        let model: expand::Model<TestBackend> = expand::Model::new(&device);
 
-        let input1 = Tensor::<Backend, 2>::from_floats([[-1.0], [1.0]], &device);
+        let input1 = Tensor::<TestBackend, 2>::from_floats([[-1.0], [1.0]], &device);
 
         let output = model.forward(input1);
         let expected_shape = Shape::from([2, 2]);
@@ -25,10 +25,10 @@ mod tests {
     #[test]
     fn expand_tensor() {
         let device = Default::default();
-        let model: expand_tensor::Model<Backend> = expand_tensor::Model::new(&device);
+        let model: expand_tensor::Model<TestBackend> = expand_tensor::Model::new(&device);
 
-        let input1 = Tensor::<Backend, 2>::from_floats([[-1.0], [1.0]], &device);
-        let input2 = Tensor::<Backend, 1, Int>::from_ints([2, 2], &device);
+        let input1 = Tensor::<TestBackend, 2>::from_floats([[-1.0], [1.0]], &device);
+        let input2 = Tensor::<TestBackend, 1, Int>::from_ints([2, 2], &device);
 
         let output = model.forward(input1, input2);
         let expected_shape = Shape::from([2, 2]);
@@ -39,10 +39,10 @@ mod tests {
     #[test]
     fn expand_shape() {
         let device = Default::default();
-        let model: expand_shape::Model<Backend> = expand_shape::Model::new(&device);
+        let model: expand_shape::Model<TestBackend> = expand_shape::Model::new(&device);
 
-        let input1 = Tensor::<Backend, 2>::from_floats([[-1.0], [1.0], [1.0], [1.0]], &device);
-        let input2 = Tensor::<Backend, 2>::zeros([4, 4], &device);
+        let input1 = Tensor::<TestBackend, 2>::from_floats([[-1.0], [1.0], [1.0], [1.0]], &device);
+        let input2 = Tensor::<TestBackend, 2>::zeros([4, 4], &device);
 
         let output = model.forward(input1, input2);
         let expected_shape = Shape::from([4, 4]);

--- a/crates/burn-import/onnx-tests/tests/flatten/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/flatten/mod.rs
@@ -6,16 +6,16 @@ mod tests {
     use super::*;
     use burn::tensor::{Shape, Tensor};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn flatten() {
         // Initialize the model without weights (because the exported file does not contain them)
         let device = Default::default();
-        let model: flatten::Model<Backend> = flatten::Model::new(&device);
+        let model: flatten::Model<TestBackend> = flatten::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 3>::ones([1, 5, 15], &device);
+        let input = Tensor::<TestBackend, 3>::ones([1, 5, 15], &device);
         let output = model.forward(input);
 
         let expected_shape = Shape::from([1, 75]);
@@ -26,10 +26,10 @@ mod tests {
     fn flatten_2d() {
         // Initialize the model without weights (because the exported file does not contain them)
         let device = Default::default();
-        let model: flatten_2d::Model<Backend> = flatten_2d::Model::new(&device);
+        let model: flatten_2d::Model<TestBackend> = flatten_2d::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::ones([2, 3, 4, 5], &device);
+        let input = Tensor::<TestBackend, 4>::ones([2, 3, 4, 5], &device);
         let output = model.forward(input);
 
         // Flatten leading and trailing dimensions (axis = 2) and returns a 2D tensor

--- a/crates/burn-import/onnx-tests/tests/floor/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/floor/mod.rs
@@ -6,17 +6,17 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, ops::FloatElem};
 
-    use crate::backend::Backend;
-    type FT = FloatElem<Backend>;
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
 
     #[test]
     fn floor_test() {
         // Test for floor
         let device = Default::default();
-        let model = floor::Model::<Backend>::new(&device);
+        let model = floor::Model::<TestBackend>::new(&device);
 
-        let input = Tensor::<Backend, 1>::from_floats([-0.5, 1.5, 2.1], &device);
-        let expected = Tensor::<Backend, 1>::from_floats([-1., 1., 2.], &device);
+        let input = Tensor::<TestBackend, 1>::from_floats([-0.5, 1.5, 2.1], &device);
+        let expected = Tensor::<TestBackend, 1>::from_floats([-1., 1., 2.], &device);
 
         let output = model.forward(input);
 

--- a/crates/burn-import/onnx-tests/tests/gather/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/gather/mod.rs
@@ -15,16 +15,16 @@ mod tests {
     use super::*;
     use burn::tensor::{Int, Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn gather_1d_idx() {
-        let model: gather_1d_idx::Model<Backend> = gather_1d_idx::Model::default();
+        let model: gather_1d_idx::Model<TestBackend> = gather_1d_idx::Model::default();
 
         let device = Default::default();
 
-        let input = Tensor::<Backend, 2>::from_floats([[1., 2., 3.], [4., 5., 6.]], &device);
-        let index = Tensor::<Backend, 1, Int>::from_ints([0, 2], &device);
+        let input = Tensor::<TestBackend, 2>::from_floats([[1., 2., 3.], [4., 5., 6.]], &device);
+        let index = Tensor::<TestBackend, 1, Int>::from_ints([0, 2], &device);
         let expected = TensorData::from([[1f32, 3.], [4., 6.]]);
         let output = model.forward(input, index);
 
@@ -33,12 +33,12 @@ mod tests {
 
     #[test]
     fn gather_2d_idx() {
-        let model: gather_2d_idx::Model<Backend> = gather_2d_idx::Model::default();
+        let model: gather_2d_idx::Model<TestBackend> = gather_2d_idx::Model::default();
 
         let device = Default::default();
 
-        let input = Tensor::<Backend, 2>::from_data([[1.0, 1.2], [2.3, 3.4], [4.5, 5.7]], &device);
-        let index = Tensor::<Backend, 2, Int>::from_data([[0, 1], [1, 2]], &device);
+        let input = Tensor::<TestBackend, 2>::from_data([[1.0, 1.2], [2.3, 3.4], [4.5, 5.7]], &device);
+        let index = Tensor::<TestBackend, 2, Int>::from_data([[0, 1], [1, 2]], &device);
         let expected = TensorData::from([[[1f32, 1.2], [2.3, 3.4]], [[2.3, 3.4], [4.5, 5.7]]]);
         let output = model.forward(input, index);
 
@@ -47,13 +47,13 @@ mod tests {
 
     #[test]
     fn gather_shape() {
-        let model: gather_shape::Model<Backend> = gather_shape::Model::default();
+        let model: gather_shape::Model<TestBackend> = gather_shape::Model::default();
 
         let device = Default::default();
 
-        let input = Tensor::<Backend, 2>::from_floats([[1., 2., 3.], [4., 5., 6.]], &device);
+        let input = Tensor::<TestBackend, 2>::from_floats([[1., 2., 3.], [4., 5., 6.]], &device);
         // shape(input) = [2, 3]
-        let index = Tensor::<Backend, 1, Int>::from_ints([0], &device);
+        let index = Tensor::<TestBackend, 1, Int>::from_ints([0], &device);
         let output = model.forward(input, index);
         let expected = [2i64];
 
@@ -62,11 +62,11 @@ mod tests {
 
     #[test]
     fn gather_scalar() {
-        let model: gather_scalar::Model<Backend> = gather_scalar::Model::default();
+        let model: gather_scalar::Model<TestBackend> = gather_scalar::Model::default();
 
         let device = Default::default();
 
-        let input = Tensor::<Backend, 2>::from_floats([[1., 2., 3.], [4., 5., 6.]], &device);
+        let input = Tensor::<TestBackend, 2>::from_floats([[1., 2., 3.], [4., 5., 6.]], &device);
         let index = 0;
         let output = model.forward(input, index);
         let expected = TensorData::from([1f32, 2., 3.]);
@@ -76,11 +76,11 @@ mod tests {
 
     #[test]
     fn gather_scalar_out() {
-        let model: gather_scalar_out::Model<Backend> = gather_scalar_out::Model::default();
+        let model: gather_scalar_out::Model<TestBackend> = gather_scalar_out::Model::default();
 
         let device = Default::default();
 
-        let input = Tensor::<Backend, 1>::from_floats([1., 2., 3.], &device);
+        let input = Tensor::<TestBackend, 1>::from_floats([1., 2., 3.], &device);
         let index = 1;
         let output = model.forward(input, index);
 
@@ -91,12 +91,12 @@ mod tests {
     #[test]
     fn gather_elements() {
         // Initialize the model with weights (loaded from the exported file)
-        let model: gather_elements::Model<Backend> = gather_elements::Model::default();
+        let model: gather_elements::Model<TestBackend> = gather_elements::Model::default();
 
         let device = Default::default();
         // Run the model
-        let input = Tensor::<Backend, 2>::from_floats([[1., 2.], [3., 4.]], &device);
-        let index = Tensor::<Backend, 2, Int>::from_ints([[0, 0], [1, 0]], &device);
+        let input = Tensor::<TestBackend, 2>::from_floats([[1., 2.], [3., 4.]], &device);
+        let index = Tensor::<TestBackend, 2, Int>::from_ints([[0, 0], [1, 0]], &device);
         let output = model.forward(input, index);
         let expected = TensorData::from([[1f32, 1.], [4., 3.]]);
 
@@ -107,13 +107,13 @@ mod tests {
     fn gather_with_shape_indices() {
         // Test the most comprehensive case of our runtime Shape indices implementation:
         // This is the exact scenario that was causing the original panic and required our full fix.
-        let model: gather_with_shape_indices::Model<Backend> =
+        let model: gather_with_shape_indices::Model<TestBackend> =
             gather_with_shape_indices::Model::default();
 
         let device = Default::default();
 
         // Input tensor with shape [2, 3]
-        let input = Tensor::<Backend, 2>::from_floats([[1., 2., 3.], [4., 5., 6.]], &device);
+        let input = Tensor::<TestBackend, 2>::from_floats([[1., 2., 3.], [4., 5., 6.]], &device);
         let output = model.forward(input);
 
         // Expected: shape [2, 3] used as indices to gather from [100, 200, 300, 400, 500]

--- a/crates/burn-import/onnx-tests/tests/gather/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/gather/mod.rs
@@ -37,7 +37,8 @@ mod tests {
 
         let device = Default::default();
 
-        let input = Tensor::<TestBackend, 2>::from_data([[1.0, 1.2], [2.3, 3.4], [4.5, 5.7]], &device);
+        let input =
+            Tensor::<TestBackend, 2>::from_data([[1.0, 1.2], [2.3, 3.4], [4.5, 5.7]], &device);
         let index = Tensor::<TestBackend, 2, Int>::from_data([[0, 1], [1, 2]], &device);
         let expected = TensorData::from([[[1f32, 1.2], [2.3, 3.4]], [[2.3, 3.4], [4.5, 5.7]]]);
         let output = model.forward(input, index);

--- a/crates/burn-import/onnx-tests/tests/gelu/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/gelu/mod.rs
@@ -7,15 +7,15 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    use crate::backend::Backend;
-    type FT = FloatElem<Backend>;
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
 
     #[test]
     fn gelu() {
         let device = Default::default();
-        let model: gelu::Model<Backend> = gelu::Model::new(&device);
+        let model: gelu::Model<TestBackend> = gelu::Model::new(&device);
 
-        let input = Tensor::<Backend, 4>::from_floats([[[[1.0, 4.0, 9.0, 25.0]]]], &device);
+        let input = Tensor::<TestBackend, 4>::from_floats([[[[1.0, 4.0, 9.0, 25.0]]]], &device);
 
         let output = model.forward(input);
         let expected = TensorData::from([[[[0.8413f32, 3.9999, 9.0000, 25.0000]]]]);

--- a/crates/burn-import/onnx-tests/tests/gemm/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/gemm/mod.rs
@@ -6,25 +6,25 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn gemm_test() {
         // Test for GEMM
         let device = Default::default();
-        let model = gemm::Model::<Backend>::new(&device);
+        let model = gemm::Model::<TestBackend>::new(&device);
 
         // Create input matrices
         let a =
-            Tensor::<Backend, 2>::from_data(TensorData::from([[1.0, 2.0], [3.0, 4.0]]), &device);
+            Tensor::<TestBackend, 2>::from_data(TensorData::from([[1.0, 2.0], [3.0, 4.0]]), &device);
         let b =
-            Tensor::<Backend, 2>::from_data(TensorData::from([[5.0, 6.0], [7.0, 8.0]]), &device);
+            Tensor::<TestBackend, 2>::from_data(TensorData::from([[5.0, 6.0], [7.0, 8.0]]), &device);
         let c = 1.0;
 
         // Expected result of matrix multiplication
         // [1.0, 2.0] × [5.0, 6.0] = [1×5 + 2×7, 1×6 + 2×8] = [19.0 + 1.0, 22.0 + 1.0] = [20.0, 23.0]
         // [3.0, 4.0] × [7.0, 8.0] = [3×5 + 4×7, 3×6 + 4×8] = [43.0 + 1.0, 50.0 + 1.0] = [44.0, 51.0]
-        let expected = Tensor::<Backend, 2>::from_data(
+        let expected = Tensor::<TestBackend, 2>::from_data(
             TensorData::from([[20.0, 23.0], [44.0, 51.0]]),
             &device,
         );
@@ -40,20 +40,20 @@ mod tests {
     fn gemm_test_non_unit_alpha_beta() {
         // Test for GEMM
         let device = Default::default();
-        let model = gemm_non_unit_alpha_beta::Model::<Backend>::new(&device);
+        let model = gemm_non_unit_alpha_beta::Model::<TestBackend>::new(&device);
 
         // Create input matrices
         let a =
-            Tensor::<Backend, 2>::from_data(TensorData::from([[1.0, 2.0], [3.0, 4.0]]), &device);
+            Tensor::<TestBackend, 2>::from_data(TensorData::from([[1.0, 2.0], [3.0, 4.0]]), &device);
         let b =
-            Tensor::<Backend, 2>::from_data(TensorData::from([[5.0, 6.0], [7.0, 8.0]]), &device);
+            Tensor::<TestBackend, 2>::from_data(TensorData::from([[5.0, 6.0], [7.0, 8.0]]), &device);
         let c = 1.0;
 
         // Alpha = Beta = 0.5
         // Expected result of matrix multiplication
         // [1.0, 2.0] × [5.0, 6.0] = [1×5 + 2×7, 1×6 + 2×8] = [19.0 * .5 + 1.0 * .5, 22.0 * .5 + 1.0 * .5] = [10.0, 11.5]
         // [3.0, 4.0] × [7.0, 8.0] = [3×5 + 4×7, 3×6 + 4×8] = [43.0 * .5 + 1.0 * .5, 50.0 * .5 + 1.0 * .5] = [22.0, 25.5]
-        let expected = Tensor::<Backend, 2>::from_data(
+        let expected = Tensor::<TestBackend, 2>::from_data(
             TensorData::from([[10.0, 11.5], [22.0, 25.5]]),
             &device,
         );
@@ -69,19 +69,19 @@ mod tests {
     fn gemm_test_no_c() {
         // Test for GEMM
         let device = Default::default();
-        let model = gemm_no_c::Model::<Backend>::new(&device);
+        let model = gemm_no_c::Model::<TestBackend>::new(&device);
 
         // Create input matrices
         let a =
-            Tensor::<Backend, 2>::from_data(TensorData::from([[1.0, 2.0], [3.0, 4.0]]), &device);
+            Tensor::<TestBackend, 2>::from_data(TensorData::from([[1.0, 2.0], [3.0, 4.0]]), &device);
         let b =
-            Tensor::<Backend, 2>::from_data(TensorData::from([[5.0, 6.0], [7.0, 8.0]]), &device);
+            Tensor::<TestBackend, 2>::from_data(TensorData::from([[5.0, 6.0], [7.0, 8.0]]), &device);
 
         // Alpha = Beta = 0.5
         // Expected result of matrix multiplication
         // [1.0, 2.0] × [5.0, 6.0] = [1×5 + 2×7, 1×6 + 2×8] = [19.0, 22.0]
         // [3.0, 4.0] × [7.0, 8.0] = [3×5 + 4×7, 3×6 + 4×8] = [43.0, 50.0]
-        let expected = Tensor::<Backend, 2>::from_data(
+        let expected = Tensor::<TestBackend, 2>::from_data(
             TensorData::from([[19.0, 22.0], [43.0, 50.0]]),
             &device,
         );

--- a/crates/burn-import/onnx-tests/tests/gemm/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/gemm/mod.rs
@@ -15,10 +15,14 @@ mod tests {
         let model = gemm::Model::<TestBackend>::new(&device);
 
         // Create input matrices
-        let a =
-            Tensor::<TestBackend, 2>::from_data(TensorData::from([[1.0, 2.0], [3.0, 4.0]]), &device);
-        let b =
-            Tensor::<TestBackend, 2>::from_data(TensorData::from([[5.0, 6.0], [7.0, 8.0]]), &device);
+        let a = Tensor::<TestBackend, 2>::from_data(
+            TensorData::from([[1.0, 2.0], [3.0, 4.0]]),
+            &device,
+        );
+        let b = Tensor::<TestBackend, 2>::from_data(
+            TensorData::from([[5.0, 6.0], [7.0, 8.0]]),
+            &device,
+        );
         let c = 1.0;
 
         // Expected result of matrix multiplication
@@ -43,10 +47,14 @@ mod tests {
         let model = gemm_non_unit_alpha_beta::Model::<TestBackend>::new(&device);
 
         // Create input matrices
-        let a =
-            Tensor::<TestBackend, 2>::from_data(TensorData::from([[1.0, 2.0], [3.0, 4.0]]), &device);
-        let b =
-            Tensor::<TestBackend, 2>::from_data(TensorData::from([[5.0, 6.0], [7.0, 8.0]]), &device);
+        let a = Tensor::<TestBackend, 2>::from_data(
+            TensorData::from([[1.0, 2.0], [3.0, 4.0]]),
+            &device,
+        );
+        let b = Tensor::<TestBackend, 2>::from_data(
+            TensorData::from([[5.0, 6.0], [7.0, 8.0]]),
+            &device,
+        );
         let c = 1.0;
 
         // Alpha = Beta = 0.5
@@ -72,10 +80,14 @@ mod tests {
         let model = gemm_no_c::Model::<TestBackend>::new(&device);
 
         // Create input matrices
-        let a =
-            Tensor::<TestBackend, 2>::from_data(TensorData::from([[1.0, 2.0], [3.0, 4.0]]), &device);
-        let b =
-            Tensor::<TestBackend, 2>::from_data(TensorData::from([[5.0, 6.0], [7.0, 8.0]]), &device);
+        let a = Tensor::<TestBackend, 2>::from_data(
+            TensorData::from([[1.0, 2.0], [3.0, 4.0]]),
+            &device,
+        );
+        let b = Tensor::<TestBackend, 2>::from_data(
+            TensorData::from([[5.0, 6.0], [7.0, 8.0]]),
+            &device,
+        );
 
         // Alpha = Beta = 0.5
         // Expected result of matrix multiplication

--- a/crates/burn-import/onnx-tests/tests/global_avr_pool/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/global_avr_pool/mod.rs
@@ -8,17 +8,17 @@ mod tests {
     use burn::tensor::{Shape, Tensor};
     use float_cmp::ApproxEq;
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn globalavrpool_1d_2d() {
         // The model contains 1d and 2d global average pooling nodes
-        let model: global_avr_pool::Model<Backend> = global_avr_pool::Model::default();
+        let model: global_avr_pool::Model<TestBackend> = global_avr_pool::Model::default();
 
         let device = Default::default();
         // Run the model with ones as input for easier testing
-        let input_1d = Tensor::<Backend, 3>::ones([2, 4, 10], &device);
-        let input_2d = Tensor::<Backend, 4>::ones([3, 10, 3, 15], &device);
+        let input_1d = Tensor::<TestBackend, 3>::ones([2, 4, 10], &device);
+        let input_2d = Tensor::<TestBackend, 4>::ones([3, 10, 3, 15], &device);
 
         let (output_1d, output_2d) = model.forward(input_1d, input_2d);
 

--- a/crates/burn-import/onnx-tests/tests/graph_multiple_output_tracking/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/graph_multiple_output_tracking/mod.rs
@@ -5,12 +5,12 @@ include_models!(graph_multiple_output_tracking);
 mod tests {
     use super::*;
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn graph_multiple_output_tracking() {
         // Initialize the model with weights (loaded from the exported file)
-        let _model: graph_multiple_output_tracking::Model<Backend> =
+        let _model: graph_multiple_output_tracking::Model<TestBackend> =
             graph_multiple_output_tracking::Model::default();
 
         // We don't actually care about the output here, the compiler will tell us if we passed

--- a/crates/burn-import/onnx-tests/tests/greater/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/greater/mod.rs
@@ -7,15 +7,15 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn greater() {
         let device = Default::default();
-        let model: greater::Model<Backend> = greater::Model::new(&device);
+        let model: greater::Model<TestBackend> = greater::Model::new(&device);
 
-        let input1 = Tensor::<Backend, 2>::from_floats([[1.0, 4.0, 9.0, 25.0]], &device);
-        let input2 = Tensor::<Backend, 2>::from_floats([[1.0, 5.0, 8.0, -25.0]], &device);
+        let input1 = Tensor::<TestBackend, 2>::from_floats([[1.0, 4.0, 9.0, 25.0]], &device);
+        let input2 = Tensor::<TestBackend, 2>::from_floats([[1.0, 5.0, 8.0, -25.0]], &device);
 
         let output = model.forward(input1, input2);
         let expected = TensorData::from([[false, false, true, true]]);
@@ -26,9 +26,9 @@ mod tests {
     #[test]
     fn greater_scalar() {
         let device = Default::default();
-        let model: greater_scalar::Model<Backend> = greater_scalar::Model::new(&device);
+        let model: greater_scalar::Model<TestBackend> = greater_scalar::Model::new(&device);
 
-        let input1 = Tensor::<Backend, 2>::from_floats([[1.0, 4.0, 9.0, 0.5]], &device);
+        let input1 = Tensor::<TestBackend, 2>::from_floats([[1.0, 4.0, 9.0, 0.5]], &device);
         let input2 = 1.0;
 
         let output = model.forward(input1, input2);

--- a/crates/burn-import/onnx-tests/tests/greater_or_equal/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/greater_or_equal/mod.rs
@@ -7,15 +7,15 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn greater_or_equal() {
         let device = Default::default();
-        let model: greater_or_equal::Model<Backend> = greater_or_equal::Model::new(&device);
+        let model: greater_or_equal::Model<TestBackend> = greater_or_equal::Model::new(&device);
 
-        let input1 = Tensor::<Backend, 2>::from_floats([[1.0, 4.0, 9.0, 25.0]], &device);
-        let input2 = Tensor::<Backend, 2>::from_floats([[1.0, 5.0, 8.0, -25.0]], &device);
+        let input1 = Tensor::<TestBackend, 2>::from_floats([[1.0, 4.0, 9.0, 25.0]], &device);
+        let input2 = Tensor::<TestBackend, 2>::from_floats([[1.0, 5.0, 8.0, -25.0]], &device);
 
         let output = model.forward(input1, input2);
         let expected = TensorData::from([[true, false, true, true]]);
@@ -26,10 +26,10 @@ mod tests {
     #[test]
     fn greater_or_equal_scalar() {
         let device = Default::default();
-        let model: greater_or_equal_scalar::Model<Backend> =
+        let model: greater_or_equal_scalar::Model<TestBackend> =
             greater_or_equal_scalar::Model::new(&device);
 
-        let input1 = Tensor::<Backend, 2>::from_floats([[1.0, 4.0, 9.0, 0.5]], &device);
+        let input1 = Tensor::<TestBackend, 2>::from_floats([[1.0, 4.0, 9.0, 0.5]], &device);
         let input2 = 1.0;
 
         let output = model.forward(input1, input2);

--- a/crates/burn-import/onnx-tests/tests/group_norm/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/group_norm/mod.rs
@@ -7,15 +7,15 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    use crate::backend::Backend;
-    type FT = FloatElem<Backend>;
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
 
     #[test]
     fn group_norm() {
         let device = Default::default();
-        let model: group_norm::Model<Backend> = group_norm::Model::default();
+        let model: group_norm::Model<TestBackend> = group_norm::Model::default();
 
-        let input = Tensor::<Backend, 4>::from_floats(
+        let input = Tensor::<TestBackend, 4>::from_floats(
             [
                 [
                     [[0.5, -0.14, 0.65], [1.52, -0.23, -0.23]],

--- a/crates/burn-import/onnx-tests/tests/hard_sigmoid/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/hard_sigmoid/mod.rs
@@ -6,17 +6,17 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, ops::FloatElem};
 
-    use crate::backend::Backend;
-    type FT = FloatElem<Backend>;
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
 
     #[test]
     fn hard_sigmoid() {
         // Initialize the model without weights (because the exported file does not contain them)
         let device = Default::default();
-        let model: hard_sigmoid::Model<Backend> = hard_sigmoid::Model::new(&device);
+        let model: hard_sigmoid::Model<TestBackend> = hard_sigmoid::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 2>::from_floats(
+        let input = Tensor::<TestBackend, 2>::from_floats(
             [
                 [0.33669037, 0.12880941, 0.23446237],
                 [0.23033303, -1.12285638, -0.18632829],

--- a/crates/burn-import/onnx-tests/tests/identity/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/identity/mod.rs
@@ -32,7 +32,8 @@ mod tests {
 
     #[test]
     fn test_identity_passthrough() {
-        let model: identity_passthrough::Model<TestBackend> = identity_passthrough::Model::default();
+        let model: identity_passthrough::Model<TestBackend> =
+            identity_passthrough::Model::default();
 
         let device = Default::default();
 

--- a/crates/burn-import/onnx-tests/tests/identity/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/identity/mod.rs
@@ -10,12 +10,12 @@ include_models!(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
     use burn::tensor::{Tensor, TensorData};
 
     #[test]
     fn test_identity_constant() {
-        let model: identity_constant::Model<Backend> = identity_constant::Model::default();
+        let model: identity_constant::Model<TestBackend> = identity_constant::Model::default();
 
         let output = model.forward();
 
@@ -32,12 +32,12 @@ mod tests {
 
     #[test]
     fn test_identity_passthrough() {
-        let model: identity_passthrough::Model<Backend> = identity_passthrough::Model::default();
+        let model: identity_passthrough::Model<TestBackend> = identity_passthrough::Model::default();
 
         let device = Default::default();
 
         // Create input tensor (2x3 as defined in the Python script)
-        let input = Tensor::<Backend, 2>::from_data(
+        let input = Tensor::<TestBackend, 2>::from_data(
             TensorData::from([[1.0f32, 2.0, 3.0], [4.0, 5.0, 6.0]]),
             &device,
         );
@@ -58,12 +58,12 @@ mod tests {
 
     #[test]
     fn test_identity_chain() {
-        let model: identity_chain::Model<Backend> = identity_chain::Model::default();
+        let model: identity_chain::Model<TestBackend> = identity_chain::Model::default();
 
         let device = Default::default();
 
         // Create input tensor (2x3 as defined in the Python script)
-        let input = Tensor::<Backend, 2>::from_data(
+        let input = Tensor::<TestBackend, 2>::from_data(
             TensorData::from([[1.0f32, -2.0, 3.0], [-4.0, 5.0, -6.0]]),
             &device,
         );
@@ -84,12 +84,12 @@ mod tests {
 
     #[test]
     fn test_identity_only() {
-        let model: identity_only::Model<Backend> = identity_only::Model::default();
+        let model: identity_only::Model<TestBackend> = identity_only::Model::default();
 
         let device = Default::default();
 
         // Create input tensor (3x4 as defined in the Python script)
-        let input = Tensor::<Backend, 2>::from_data(
+        let input = Tensor::<TestBackend, 2>::from_data(
             TensorData::from([
                 [1.0f32, 2.0, 3.0, 4.0],
                 [5.0, 6.0, 7.0, 8.0],

--- a/crates/burn-import/onnx-tests/tests/initializer_to_const/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/initializer_to_const/mod.rs
@@ -5,17 +5,17 @@ include_models!(initializer_to_const);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
     use burn::tensor::{Tensor, TensorData};
 
     #[test]
     fn test_initializer_to_const() {
-        let model: initializer_to_const::Model<Backend> = initializer_to_const::Model::default();
+        let model: initializer_to_const::Model<TestBackend> = initializer_to_const::Model::default();
 
         let device = Default::default();
 
         // Create input tensor (2x3 as defined in the Python script)
-        let input = Tensor::<Backend, 2>::from_data(
+        let input = Tensor::<TestBackend, 2>::from_data(
             TensorData::from([[1.0f32, 1.0, 1.0], [1.0, 1.0, 1.0]]),
             &device,
         );

--- a/crates/burn-import/onnx-tests/tests/initializer_to_const/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/initializer_to_const/mod.rs
@@ -10,7 +10,8 @@ mod tests {
 
     #[test]
     fn test_initializer_to_const() {
-        let model: initializer_to_const::Model<TestBackend> = initializer_to_const::Model::default();
+        let model: initializer_to_const::Model<TestBackend> =
+            initializer_to_const::Model::default();
 
         let device = Default::default();
 

--- a/crates/burn-import/onnx-tests/tests/instance_norm/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/instance_norm/mod.rs
@@ -7,15 +7,15 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    use crate::backend::Backend;
-    type FT = FloatElem<Backend>;
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
 
     #[test]
     fn instance_norm1d() {
         let device = Default::default();
-        let model: instance_norm1d::Model<Backend> = instance_norm1d::Model::default();
+        let model: instance_norm1d::Model<TestBackend> = instance_norm1d::Model::default();
 
-        let input = Tensor::<Backend, 3>::from_floats(
+        let input = Tensor::<TestBackend, 3>::from_floats(
             [
                 [
                     [0., 1., 2., 3.], //
@@ -51,9 +51,9 @@ mod tests {
     #[test]
     fn instance_norm2d() {
         let device = Default::default();
-        let model: instance_norm2d::Model<Backend> = instance_norm2d::Model::default();
+        let model: instance_norm2d::Model<TestBackend> = instance_norm2d::Model::default();
 
-        let input = Tensor::<Backend, 4>::from_floats(
+        let input = Tensor::<TestBackend, 4>::from_floats(
             [
                 [
                     [
@@ -117,9 +117,9 @@ mod tests {
     #[test]
     fn instance_norm3d() {
         let device = Default::default();
-        let model: instance_norm3d::Model<Backend> = instance_norm3d::Model::default();
+        let model: instance_norm3d::Model<TestBackend> = instance_norm3d::Model::default();
 
-        let input = Tensor::<Backend, 5>::from_floats(
+        let input = Tensor::<TestBackend, 5>::from_floats(
             [
                 [
                     [[[0., 1.], [2., 3.]], [[4., 5.], [6., 7.]]],

--- a/crates/burn-import/onnx-tests/tests/is_inf/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/is_inf/mod.rs
@@ -13,14 +13,14 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn is_inf() {
         let device = Default::default();
-        let model: is_inf::Model<Backend> = is_inf::Model::new(&device);
+        let model: is_inf::Model<TestBackend> = is_inf::Model::new(&device);
 
-        let input1 = Tensor::<Backend, 2>::from_floats(
+        let input1 = Tensor::<TestBackend, 2>::from_floats(
             [[1.0, f32::INFINITY, -9.0, f32::NEG_INFINITY]],
             &device,
         );
@@ -34,7 +34,7 @@ mod tests {
     #[test]
     fn is_inf_scalar() {
         let device = Default::default();
-        let model: is_inf_scalar::Model<Backend> = is_inf_scalar::Model::new(&device);
+        let model: is_inf_scalar::Model<TestBackend> = is_inf_scalar::Model::new(&device);
 
         let input1 = f32::INFINITY;
 
@@ -47,9 +47,9 @@ mod tests {
     #[test]
     fn is_inf_neg_only() {
         let device = Default::default();
-        let model: is_inf_neg_only::Model<Backend> = is_inf_neg_only::Model::new(&device);
+        let model: is_inf_neg_only::Model<TestBackend> = is_inf_neg_only::Model::new(&device);
 
-        let input1 = Tensor::<Backend, 2>::from_floats(
+        let input1 = Tensor::<TestBackend, 2>::from_floats(
             [[1.0, f32::INFINITY, -9.0, f32::NEG_INFINITY]],
             &device,
         );
@@ -63,9 +63,9 @@ mod tests {
     #[test]
     fn is_inf_pos_only() {
         let device = Default::default();
-        let model: is_inf_pos_only::Model<Backend> = is_inf_pos_only::Model::new(&device);
+        let model: is_inf_pos_only::Model<TestBackend> = is_inf_pos_only::Model::new(&device);
 
-        let input1 = Tensor::<Backend, 2>::from_floats(
+        let input1 = Tensor::<TestBackend, 2>::from_floats(
             [[1.0, f32::INFINITY, -9.0, f32::NEG_INFINITY]],
             &device,
         );
@@ -79,9 +79,9 @@ mod tests {
     #[test]
     fn is_inf_none() {
         let device = Default::default();
-        let model: is_inf_none::Model<Backend> = is_inf_none::Model::new(&device);
+        let model: is_inf_none::Model<TestBackend> = is_inf_none::Model::new(&device);
 
-        let input1 = Tensor::<Backend, 2>::from_floats(
+        let input1 = Tensor::<TestBackend, 2>::from_floats(
             [[1.0, f32::INFINITY, -9.0, f32::NEG_INFINITY]],
             &device,
         );

--- a/crates/burn-import/onnx-tests/tests/is_nan/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/is_nan/mod.rs
@@ -7,14 +7,14 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn is_nan() {
         let device = Default::default();
-        let model: is_nan::Model<Backend> = is_nan::Model::new(&device);
+        let model: is_nan::Model<TestBackend> = is_nan::Model::new(&device);
 
-        let input1 = Tensor::<Backend, 2>::from_floats([[1.0, f32::NAN, -9.0, f32::NAN]], &device);
+        let input1 = Tensor::<TestBackend, 2>::from_floats([[1.0, f32::NAN, -9.0, f32::NAN]], &device);
 
         let output = model.forward(input1);
         let expected = TensorData::from([[false, true, false, true]]);
@@ -25,7 +25,7 @@ mod tests {
     #[test]
     fn is_nan_scalar() {
         let device = Default::default();
-        let model: is_nan_scalar::Model<Backend> = is_nan_scalar::Model::new(&device);
+        let model: is_nan_scalar::Model<TestBackend> = is_nan_scalar::Model::new(&device);
 
         let input1 = f32::NAN;
 

--- a/crates/burn-import/onnx-tests/tests/is_nan/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/is_nan/mod.rs
@@ -14,7 +14,8 @@ mod tests {
         let device = Default::default();
         let model: is_nan::Model<TestBackend> = is_nan::Model::new(&device);
 
-        let input1 = Tensor::<TestBackend, 2>::from_floats([[1.0, f32::NAN, -9.0, f32::NAN]], &device);
+        let input1 =
+            Tensor::<TestBackend, 2>::from_floats([[1.0, f32::NAN, -9.0, f32::NAN]], &device);
 
         let output = model.forward(input1);
         let expected = TensorData::from([[false, true, false, true]]);

--- a/crates/burn-import/onnx-tests/tests/layer_norm/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/layer_norm/mod.rs
@@ -7,16 +7,16 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    use crate::backend::Backend;
-    type FT = FloatElem<Backend>;
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
 
     #[test]
     fn layer_norm() {
         let device = Default::default();
-        let model: layer_norm::Model<Backend> = layer_norm::Model::default();
+        let model: layer_norm::Model<TestBackend> = layer_norm::Model::default();
 
         // Run the model with ones as input for easier testing
-        let input = Tensor::<Backend, 3>::from_floats(
+        let input = Tensor::<TestBackend, 3>::from_floats(
             [
                 [[0., 1., 2., 3.], [4., 5., 6., 7.], [8., 9., 10., 11.]],
                 [

--- a/crates/burn-import/onnx-tests/tests/leaky_relu/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/leaky_relu/mod.rs
@@ -6,16 +6,16 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn leaky_relu() {
         // Initialize the model without weights (because the exported file does not contain them)
         let device = Default::default();
-        let model: leaky_relu::Model<Backend> = leaky_relu::Model::new(&device);
+        let model: leaky_relu::Model<TestBackend> = leaky_relu::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 2>::from_floats(
+        let input = Tensor::<TestBackend, 2>::from_floats(
             [
                 [0.33669037, 0.0, 0.23446237],
                 [0.23033303, -1.122_856, -0.18632829],

--- a/crates/burn-import/onnx-tests/tests/less/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/less/mod.rs
@@ -7,15 +7,15 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn less() {
         let device = Default::default();
-        let model: less::Model<Backend> = less::Model::new(&device);
+        let model: less::Model<TestBackend> = less::Model::new(&device);
 
-        let input1 = Tensor::<Backend, 2>::from_floats([[1.0, 4.0, 9.0, 25.0]], &device);
-        let input2 = Tensor::<Backend, 2>::from_floats([[1.0, 5.0, 8.0, -25.0]], &device);
+        let input1 = Tensor::<TestBackend, 2>::from_floats([[1.0, 4.0, 9.0, 25.0]], &device);
+        let input2 = Tensor::<TestBackend, 2>::from_floats([[1.0, 5.0, 8.0, -25.0]], &device);
 
         let output = model.forward(input1, input2);
         let expected = TensorData::from([[false, true, false, false]]);
@@ -26,9 +26,9 @@ mod tests {
     #[test]
     fn less_scalar() {
         let device = Default::default();
-        let model: less_scalar::Model<Backend> = less_scalar::Model::new(&device);
+        let model: less_scalar::Model<TestBackend> = less_scalar::Model::new(&device);
 
-        let input1 = Tensor::<Backend, 2>::from_floats([[1.0, 4.0, 9.0, 0.5]], &device);
+        let input1 = Tensor::<TestBackend, 2>::from_floats([[1.0, 4.0, 9.0, 0.5]], &device);
         let input2 = 1.0;
 
         let output = model.forward(input1, input2);

--- a/crates/burn-import/onnx-tests/tests/less_or_equal/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/less_or_equal/mod.rs
@@ -26,7 +26,8 @@ mod tests {
     #[test]
     fn less_or_equal_scalar() {
         let device = Default::default();
-        let model: less_or_equal_scalar::Model<TestBackend> = less_or_equal_scalar::Model::new(&device);
+        let model: less_or_equal_scalar::Model<TestBackend> =
+            less_or_equal_scalar::Model::new(&device);
 
         let input1 = Tensor::<TestBackend, 2>::from_floats([[1.0, 4.0, 9.0, 0.5]], &device);
         let input2 = 1.0;

--- a/crates/burn-import/onnx-tests/tests/less_or_equal/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/less_or_equal/mod.rs
@@ -7,15 +7,15 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn less_or_equal() {
         let device = Default::default();
-        let model: less_or_equal::Model<Backend> = less_or_equal::Model::new(&device);
+        let model: less_or_equal::Model<TestBackend> = less_or_equal::Model::new(&device);
 
-        let input1 = Tensor::<Backend, 2>::from_floats([[1.0, 4.0, 9.0, 25.0]], &device);
-        let input2 = Tensor::<Backend, 2>::from_floats([[1.0, 5.0, 8.0, -25.0]], &device);
+        let input1 = Tensor::<TestBackend, 2>::from_floats([[1.0, 4.0, 9.0, 25.0]], &device);
+        let input2 = Tensor::<TestBackend, 2>::from_floats([[1.0, 5.0, 8.0, -25.0]], &device);
 
         let output = model.forward(input1, input2);
         let expected = TensorData::from([[true, true, false, false]]);
@@ -26,9 +26,9 @@ mod tests {
     #[test]
     fn less_or_equal_scalar() {
         let device = Default::default();
-        let model: less_or_equal_scalar::Model<Backend> = less_or_equal_scalar::Model::new(&device);
+        let model: less_or_equal_scalar::Model<TestBackend> = less_or_equal_scalar::Model::new(&device);
 
-        let input1 = Tensor::<Backend, 2>::from_floats([[1.0, 4.0, 9.0, 0.5]], &device);
+        let input1 = Tensor::<TestBackend, 2>::from_floats([[1.0, 4.0, 9.0, 0.5]], &device);
         let input2 = 1.0;
 
         let output = model.forward(input1, input2);

--- a/crates/burn-import/onnx-tests/tests/linear/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/linear/mod.rs
@@ -41,8 +41,8 @@ mod tests {
         let expected_sum2 = -8.053_822; // from pytorch
         let expected_sum3 = 27.575_281; // from pytorch
 
-        assert!(expected_sum1.approx_eq(output_sum1, (1.0e-6, 2)));
-        assert!(expected_sum2.approx_eq(output_sum2, (1.0e-6, 2)));
-        assert!(expected_sum3.approx_eq(output_sum3, (1.0e-6, 2)));
+        assert!(expected_sum1.approx_eq(output_sum1, (1.0e-5, 2)));
+        assert!(expected_sum2.approx_eq(output_sum2, (1.0e-5, 2)));
+        assert!(expected_sum3.approx_eq(output_sum3, (1.0e-5, 2)));
     }
 }

--- a/crates/burn-import/onnx-tests/tests/linear/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/linear/mod.rs
@@ -7,19 +7,19 @@ mod tests {
     use burn::tensor::{Shape, Tensor};
     use float_cmp::ApproxEq;
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn linear() {
         let device = Default::default();
         // Initialize the model with weights (loaded from the exported file)
-        let model: linear::Model<Backend> = linear::Model::default();
+        let model: linear::Model<TestBackend> = linear::Model::default();
         #[allow(clippy::approx_constant)]
-        let input1 = Tensor::<Backend, 2>::full([4, 3], 3.14, &device);
+        let input1 = Tensor::<TestBackend, 2>::full([4, 3], 3.14, &device);
         #[allow(clippy::approx_constant)]
-        let input2 = Tensor::<Backend, 2>::full([2, 5], 3.14, &device);
+        let input2 = Tensor::<TestBackend, 2>::full([2, 5], 3.14, &device);
         #[allow(clippy::approx_constant)]
-        let input3 = Tensor::<Backend, 3>::full([3, 2, 7], 3.14, &device);
+        let input3 = Tensor::<TestBackend, 3>::full([3, 2, 7], 3.14, &device);
 
         let (output1, output2, output3) = model.forward(input1, input2, input3);
 

--- a/crates/burn-import/onnx-tests/tests/log/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/log/mod.rs
@@ -6,15 +6,15 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, ops::FloatElem};
 
-    use crate::backend::Backend;
-    type FT = FloatElem<Backend>;
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
 
     #[test]
     fn log() {
         let device = Default::default();
-        let model: log::Model<Backend> = log::Model::new(&device);
+        let model: log::Model<TestBackend> = log::Model::new(&device);
 
-        let input = Tensor::<Backend, 4>::from_floats([[[[1.0, 4.0, 9.0, 25.0]]]], &device);
+        let input = Tensor::<TestBackend, 4>::from_floats([[[[1.0, 4.0, 9.0, 25.0]]]], &device);
 
         let output = model.forward(input);
         let expected = TensorData::from([[[[0.0000f32, 1.3863, 2.1972, 3.2189]]]]);

--- a/crates/burn-import/onnx-tests/tests/log_softmax/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/log_softmax/mod.rs
@@ -7,16 +7,16 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn log_softmax() {
         // Initialize the model without weights (because the exported file does not contain them)
         let device = Default::default();
-        let model: log_softmax::Model<Backend> = log_softmax::Model::new(&device);
+        let model: log_softmax::Model<TestBackend> = log_softmax::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 2>::from_floats(
+        let input = Tensor::<TestBackend, 2>::from_floats(
             [
                 [0.33669037, 0.128_809_4, 0.23446237],
                 [0.23033303, -1.122_856_4, -0.18632829],

--- a/crates/burn-import/onnx-tests/tests/matmul/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/matmul/mod.rs
@@ -7,24 +7,24 @@ mod tests {
     use super::*;
     use burn::tensor::{Int, Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn matmul() {
         // Initialize the model with weights (loaded from the exported file)
-        let model: matmul::Model<Backend> = matmul::Model::default();
+        let model: matmul::Model<TestBackend> = matmul::Model::default();
 
         let device = Default::default();
-        let a = Tensor::<Backend, 1, Int>::arange(0..24, &device)
+        let a = Tensor::<TestBackend, 1, Int>::arange(0..24, &device)
             .reshape([1, 2, 3, 4])
             .float();
-        let b = Tensor::<Backend, 1, Int>::arange(0..16, &device)
+        let b = Tensor::<TestBackend, 1, Int>::arange(0..16, &device)
             .reshape([1, 2, 4, 2])
             .float();
-        let c = Tensor::<Backend, 1, Int>::arange(0..96, &device)
+        let c = Tensor::<TestBackend, 1, Int>::arange(0..96, &device)
             .reshape([2, 3, 4, 4])
             .float();
-        let d = Tensor::<Backend, 1, Int>::arange(0..4, &device).float();
+        let d = Tensor::<TestBackend, 1, Int>::arange(0..4, &device).float();
 
         let (output_mm, output_mv, output_vm) = model.forward(a, b, c, d);
         // matrix-matrix `a @ b`

--- a/crates/burn-import/onnx-tests/tests/max/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/max/mod.rs
@@ -7,15 +7,15 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn max() {
         let device = Default::default();
 
-        let model: max::Model<Backend> = max::Model::new(&device);
-        let input1 = Tensor::<Backend, 2>::from_floats([[1.0, 42.0, 9.0, 42.0]], &device);
-        let input2 = Tensor::<Backend, 2>::from_floats([[42.0, 4.0, 42.0, 25.0]], &device);
+        let model: max::Model<TestBackend> = max::Model::new(&device);
+        let input1 = Tensor::<TestBackend, 2>::from_floats([[1.0, 42.0, 9.0, 42.0]], &device);
+        let input2 = Tensor::<TestBackend, 2>::from_floats([[42.0, 4.0, 42.0, 25.0]], &device);
 
         let output = model.forward(input1, input2);
         let expected = TensorData::from([[42.0f32, 42.0, 42.0, 42.0]]);

--- a/crates/burn-import/onnx-tests/tests/maxpool/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/maxpool/mod.rs
@@ -7,14 +7,14 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn maxpool1d() {
         let device = Default::default();
 
-        let model: maxpool1d::Model<Backend> = maxpool1d::Model::new(&device);
-        let input = Tensor::<Backend, 3>::from_floats(
+        let model: maxpool1d::Model<TestBackend> = maxpool1d::Model::new(&device);
+        let input = Tensor::<TestBackend, 3>::from_floats(
             [[
                 [1.927, 1.487, 0.901, -2.106, 0.678],
                 [-1.235, -0.043, -1.605, -0.752, -0.687],
@@ -39,10 +39,10 @@ mod tests {
     fn maxpool2d() {
         // Initialize the model without weights (because the exported file does not contain them)
         let device = Default::default();
-        let model: maxpool2d::Model<Backend> = maxpool2d::Model::new(&device);
+        let model: maxpool2d::Model<TestBackend> = maxpool2d::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats(
+        let input = Tensor::<TestBackend, 4>::from_floats(
             [[[
                 [1.927, 1.487, 0.901, -2.106, 0.678],
                 [-1.235, -0.043, -1.605, -0.752, -0.687],

--- a/crates/burn-import/onnx-tests/tests/mean/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/mean/mod.rs
@@ -7,16 +7,16 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn mean_tensor_and_tensor() {
         let device = Default::default();
-        let model: mean::Model<Backend> = mean::Model::default();
+        let model: mean::Model<TestBackend> = mean::Model::default();
 
-        let input1 = Tensor::<Backend, 1>::from_floats([1., 2., 3., 4.], &device);
-        let input2 = Tensor::<Backend, 1>::from_floats([2., 2., 4., 0.], &device);
-        let input3 = Tensor::<Backend, 1>::from_floats([3., 2., 5., -4.], &device);
+        let input1 = Tensor::<TestBackend, 1>::from_floats([1., 2., 3., 4.], &device);
+        let input2 = Tensor::<TestBackend, 1>::from_floats([2., 2., 4., 0.], &device);
+        let input3 = Tensor::<TestBackend, 1>::from_floats([3., 2., 5., -4.], &device);
 
         let output = model.forward(input1, input2, input3);
         let expected = TensorData::from([2.0f32, 2., 4., 0.]);

--- a/crates/burn-import/onnx-tests/tests/min/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/min/mod.rs
@@ -7,15 +7,15 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn min() {
         let device = Default::default();
 
-        let model: min::Model<Backend> = min::Model::new(&device);
-        let input1 = Tensor::<Backend, 2>::from_floats([[-1.0, 42.0, 0.0, 42.0]], &device);
-        let input2 = Tensor::<Backend, 2>::from_floats([[2.0, 4.0, 42.0, 25.0]], &device);
+        let model: min::Model<TestBackend> = min::Model::new(&device);
+        let input1 = Tensor::<TestBackend, 2>::from_floats([[-1.0, 42.0, 0.0, 42.0]], &device);
+        let input2 = Tensor::<TestBackend, 2>::from_floats([[2.0, 4.0, 42.0, 25.0]], &device);
 
         let output = model.forward(input1, input2);
         let expected = TensorData::from([[-1.0f32, 4.0, 0.0, 25.0]]);

--- a/crates/burn-import/onnx-tests/tests/mul/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/mul/mod.rs
@@ -7,16 +7,16 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn mul_scalar_with_tensor_and_tensor_with_tensor() {
         // Initialize the model with weights (loaded from the exported file)
-        let model: mul::Model<Backend> = mul::Model::default();
+        let model: mul::Model<TestBackend> = mul::Model::default();
 
         let device = Default::default();
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats([[[[1., 2., 3., 4.]]]], &device);
+        let input = Tensor::<TestBackend, 4>::from_floats([[[[1., 2., 3., 4.]]]], &device);
         let scalar = 6.0f64;
         let output = model.forward(input, scalar);
         let expected = TensorData::from([[[[126f32, 252., 378., 504.]]]]);
@@ -27,12 +27,12 @@ mod tests {
     #[test]
     fn mul_shape_with_scalar_and_shape() {
         // Initialize the model
-        let model: mul_shape::Model<Backend> = mul_shape::Model::default();
+        let model: mul_shape::Model<TestBackend> = mul_shape::Model::default();
 
         let device = Default::default();
         // Create input tensors
-        let input1 = Tensor::<Backend, 3>::ones([2, 3, 4], &device);
-        let input2 = Tensor::<Backend, 3>::ones([1, 2, 3], &device);
+        let input1 = Tensor::<TestBackend, 3>::ones([2, 3, 4], &device);
+        let input2 = Tensor::<TestBackend, 3>::ones([1, 2, 3], &device);
         let (shape_times_scalar, shape_times_shape) = model.forward(input1, input2);
 
         // Expected outputs

--- a/crates/burn-import/onnx-tests/tests/neg/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/neg/mod.rs
@@ -7,15 +7,15 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    use crate::backend::Backend;
-    type FT = FloatElem<Backend>;
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
 
     #[test]
     fn neg() {
         let device = Default::default();
-        let model: neg::Model<Backend> = neg::Model::new(&device);
+        let model: neg::Model<TestBackend> = neg::Model::new(&device);
 
-        let input1 = Tensor::<Backend, 4>::from_floats([[[[1.0, 4.0, 9.0, 25.0]]]], &device);
+        let input1 = Tensor::<TestBackend, 4>::from_floats([[[[1.0, 4.0, 9.0, 25.0]]]], &device);
         let input2 = 99f64;
 
         let (output1, output2) = model.forward(input1, input2);

--- a/crates/burn-import/onnx-tests/tests/not/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/not/mod.rs
@@ -7,14 +7,14 @@ mod tests {
     use super::*;
     use burn::tensor::{Bool, Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn not() {
         let device = Default::default();
-        let model: not::Model<Backend> = not::Model::new(&device);
+        let model: not::Model<TestBackend> = not::Model::new(&device);
 
-        let input = Tensor::<Backend, 4, Bool>::from_bool(
+        let input = Tensor::<TestBackend, 4, Bool>::from_bool(
             TensorData::from([[[[true, false, true, false]]]]),
             &device,
         );

--- a/crates/burn-import/onnx-tests/tests/one_hot/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/one_hot/mod.rs
@@ -6,18 +6,18 @@ mod tests {
     use super::*;
     use burn::tensor::{Int, Tensor, TensorData, ops::FloatElem};
 
-    use crate::backend::Backend;
-    type FT = FloatElem<Backend>;
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
 
     #[test]
     fn one_hot() {
         // Test for OneHot model
         let device = Default::default();
-        let model = one_hot::Model::<Backend>::new(&device);
-        let input: Tensor<Backend, 1, Int> = Tensor::from_ints([1, 0, 2], &device);
-        let expected: Tensor<Backend, 2, burn::prelude::Float> =
+        let model = one_hot::Model::<TestBackend>::new(&device);
+        let input: Tensor<TestBackend, 1, Int> = Tensor::from_ints([1, 0, 2], &device);
+        let expected: Tensor<TestBackend, 2, burn::prelude::Float> =
             Tensor::from_data(TensorData::from([[0, 1, 0], [1, 0, 0], [0, 0, 1]]), &device);
-        let output: Tensor<Backend, 2, Int> = model.forward(input);
+        let output: Tensor<TestBackend, 2, Int> = model.forward(input);
         output
             .to_data()
             .assert_approx_eq::<FT>(&expected.to_data(), burn::tensor::Tolerance::default());

--- a/crates/burn-import/onnx-tests/tests/or/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/or/mod.rs
@@ -7,18 +7,18 @@ mod tests {
     use super::*;
     use burn::tensor::{Bool, Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn or() {
         let device = Default::default();
-        let model: or::Model<Backend> = or::Model::new(&device);
+        let model: or::Model<TestBackend> = or::Model::new(&device);
 
-        let input_x = Tensor::<Backend, 4, Bool>::from_bool(
+        let input_x = Tensor::<TestBackend, 4, Bool>::from_bool(
             TensorData::from([[[[false, false, true, true]]]]),
             &device,
         );
-        let input_y = Tensor::<Backend, 4, Bool>::from_bool(
+        let input_y = Tensor::<TestBackend, 4, Bool>::from_bool(
             TensorData::from([[[[false, true, false, true]]]]),
             &device,
         );

--- a/crates/burn-import/onnx-tests/tests/pad/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/pad/mod.rs
@@ -6,14 +6,14 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn pad() {
         let device = Default::default();
-        let model: pad::Model<Backend> = pad::Model::new(&device);
+        let model: pad::Model<TestBackend> = pad::Model::new(&device);
 
-        let input = Tensor::<Backend, 2>::from_floats([[1., 2.], [3., 4.], [5., 6.]], &device);
+        let input = Tensor::<TestBackend, 2>::from_floats([[1., 2.], [3., 4.], [5., 6.]], &device);
         let output = model.forward(input).to_data();
         let expected = TensorData::from([
             [0.0_f32, 0., 0., 0., 0., 0., 0., 0.],

--- a/crates/burn-import/onnx-tests/tests/pow/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/pow/mod.rs
@@ -6,14 +6,14 @@ mod tests {
     use super::*;
     use burn::tensor::{Int, Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn pow_int_with_tensor_and_scalar() {
         let device = Default::default();
-        let model: pow_int::Model<Backend> = pow_int::Model::new(&device);
+        let model: pow_int::Model<TestBackend> = pow_int::Model::new(&device);
 
-        let input1 = Tensor::<Backend, 4, Int>::from_ints([[[[1, 2, 3, 4]]]], &device);
+        let input1 = Tensor::<TestBackend, 4, Int>::from_ints([[[[1, 2, 3, 4]]]], &device);
         let input2 = 2;
 
         let output = model.forward(input1, input2);
@@ -25,7 +25,7 @@ mod tests {
     #[test]
     fn pow_with_tensor_and_scalar() {
         let device = Default::default();
-        let model: pow::Model<Backend> = pow::Model::new(&device);
+        let model: pow::Model<TestBackend> = pow::Model::new(&device);
 
         let input1 = Tensor::from_floats([[[[1., 2., 3., 4.]]]], &device);
         let input2 = 2f64;

--- a/crates/burn-import/onnx-tests/tests/prelu/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/prelu/mod.rs
@@ -7,16 +7,16 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn prelu() {
         // Initialize the model without weights (because the exported file does not contain them)
         let device = Default::default();
-        let model: prelu::Model<Backend> = prelu::Model::new(&device);
+        let model: prelu::Model<TestBackend> = prelu::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 2>::from_floats(
+        let input = Tensor::<TestBackend, 2>::from_floats(
             [
                 [0.33669037, 0.0, 0.23446237],
                 [0.23033303, -1.122_856, -0.18632829],

--- a/crates/burn-import/onnx-tests/tests/random_normal/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/random_normal/mod.rs
@@ -6,12 +6,12 @@ mod tests {
     use super::*;
     use burn::tensor::Shape;
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn random_normal() {
         let device = Default::default();
-        let model = random_normal::Model::<Backend>::new(&device);
+        let model = random_normal::Model::<TestBackend>::new(&device);
         let expected_shape = Shape::from([2, 3]);
         let output = model.forward();
         assert_eq!(expected_shape, output.shape());

--- a/crates/burn-import/onnx-tests/tests/random_normal_like/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/random_normal_like/mod.rs
@@ -6,12 +6,12 @@ mod tests {
     use super::*;
     use burn::tensor::{Shape, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn random_normal_like() {
         let device = Default::default();
-        let model = random_normal_like::Model::<Backend>::new(&device);
+        let model = random_normal_like::Model::<TestBackend>::new(&device);
         let input = TensorData::zeros::<f64, _>(Shape::from([2, 4, 4]));
         let expected_shape = Shape::from([2, 4, 4]);
 

--- a/crates/burn-import/onnx-tests/tests/random_uniform/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/random_uniform/mod.rs
@@ -6,12 +6,12 @@ mod tests {
     use super::*;
     use burn::tensor::Shape;
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn random_uniform() {
         let device = Default::default();
-        let model = random_uniform::Model::<Backend>::new(&device);
+        let model = random_uniform::Model::<TestBackend>::new(&device);
         let expected_shape = Shape::from([2, 3]);
         let output = model.forward();
         assert_eq!(expected_shape, output.shape());

--- a/crates/burn-import/onnx-tests/tests/random_uniform_like/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/random_uniform_like/mod.rs
@@ -6,12 +6,12 @@ mod tests {
     use super::*;
     use burn::tensor::{Shape, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn random_uniform_like() {
         let device = Default::default();
-        let model = random_uniform_like::Model::<Backend>::new(&device);
+        let model = random_uniform_like::Model::<TestBackend>::new(&device);
         let input = TensorData::zeros::<f64, _>(Shape::from([2, 4, 4]));
         let expected_shape = Shape::from([2, 4, 4]);
 

--- a/crates/burn-import/onnx-tests/tests/range/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/range/mod.rs
@@ -6,12 +6,12 @@ mod tests {
     use super::*;
     use burn::tensor::TensorData;
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn range() {
         let device = Default::default();
-        let model: range::Model<Backend> = range::Model::new(&device);
+        let model: range::Model<TestBackend> = range::Model::new(&device);
 
         // Run the model
         let start = 0i64;

--- a/crates/burn-import/onnx-tests/tests/recip/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/recip/mod.rs
@@ -6,17 +6,17 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, ops::FloatElem};
 
-    use crate::backend::Backend;
-    type FT = FloatElem<Backend>;
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
 
     #[test]
     fn recip() {
         // Initialize the model
         let device = Default::default();
-        let model = recip::Model::<Backend>::new(&device);
+        let model = recip::Model::<TestBackend>::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats([[[[1., 2., 3., 4.]]]], &device);
+        let input = Tensor::<TestBackend, 4>::from_floats([[[[1., 2., 3., 4.]]]], &device);
         let output = model.forward(input);
         // data from pyTorch
         let expected = TensorData::from([[[[1.0000f32, 0.5000, 0.3333, 0.2500]]]]);

--- a/crates/burn-import/onnx-tests/tests/reduce/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/reduce/mod.rs
@@ -17,8 +17,8 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, ops::FloatElem};
 
-    use crate::backend::Backend;
-    type FT = FloatElem<Backend>;
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
 
     // Helper function to assert scalar values with tolerance
     fn assert_scalar_approx_eq(actual: f32, expected: f32, tolerance: f64) {
@@ -35,10 +35,10 @@ mod tests {
     #[test]
     fn reduce_min() {
         let device = Default::default();
-        let model: reduce_min::Model<Backend> = reduce_min::Model::new(&device);
+        let model: reduce_min::Model<TestBackend> = reduce_min::Model::new(&device);
 
         // Run the models
-        let input = Tensor::<Backend, 4>::from_floats(
+        let input = Tensor::<TestBackend, 4>::from_floats(
             [[[
                 [1.0, 4.0, 9.0, 25.0], //
                 [2.0, 5.0, 10.0, 26.0],
@@ -66,10 +66,10 @@ mod tests {
     #[test]
     fn reduce_max() {
         let device = Default::default();
-        let model: reduce_max::Model<Backend> = reduce_max::Model::new(&device);
+        let model: reduce_max::Model<TestBackend> = reduce_max::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats(
+        let input = Tensor::<TestBackend, 4>::from_floats(
             [[[
                 [1.0, 4.0, 9.0, 25.0], //
                 [2.0, 5.0, 10.0, 26.0],
@@ -97,10 +97,10 @@ mod tests {
     #[test]
     fn reduce_sum() {
         let device = Default::default();
-        let model: reduce_sum::Model<Backend> = reduce_sum::Model::new(&device);
+        let model: reduce_sum::Model<TestBackend> = reduce_sum::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats(
+        let input = Tensor::<TestBackend, 4>::from_floats(
             [[[
                 [1.0, 4.0, 9.0, 25.0], //
                 [2.0, 5.0, 10.0, 26.0],
@@ -132,10 +132,10 @@ mod tests {
     #[test]
     fn reduce_prod() {
         let device = Default::default();
-        let model: reduce_prod::Model<Backend> = reduce_prod::Model::new(&device);
+        let model: reduce_prod::Model<TestBackend> = reduce_prod::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats(
+        let input = Tensor::<TestBackend, 4>::from_floats(
             [[[
                 [1.0, 4.0, 9.0, 25.0], //
                 [2.0, 5.0, 10.0, 26.0],
@@ -163,10 +163,10 @@ mod tests {
     #[test]
     fn reduce_mean() {
         let device = Default::default();
-        let model: reduce_mean::Model<Backend> = reduce_mean::Model::new(&device);
+        let model: reduce_mean::Model<TestBackend> = reduce_mean::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats(
+        let input = Tensor::<TestBackend, 4>::from_floats(
             [[[
                 [1.0, 4.0, 9.0, 25.0], //
                 [2.0, 5.0, 10.0, 26.0],
@@ -202,10 +202,10 @@ mod tests {
     #[test]
     fn reduce_sum_square() {
         let device = Default::default();
-        let model: reduce_sum_square::Model<Backend> = reduce_sum_square::Model::new(&device);
+        let model: reduce_sum_square::Model<TestBackend> = reduce_sum_square::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats(
+        let input = Tensor::<TestBackend, 4>::from_floats(
             [[[
                 [1.0, 4.0, 9.0, 25.0], //
                 [2.0, 5.0, 10.0, 26.0],
@@ -246,10 +246,10 @@ mod tests {
     #[test]
     fn reduce_l1() {
         let device = Default::default();
-        let model: reduce_l1::Model<Backend> = reduce_l1::Model::new(&device);
+        let model: reduce_l1::Model<TestBackend> = reduce_l1::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats(
+        let input = Tensor::<TestBackend, 4>::from_floats(
             [[[
                 [1.0, -4.0, 9.0, 25.0], //
                 [2.0, 5.0, -10.0, 26.0],
@@ -291,10 +291,10 @@ mod tests {
     #[test]
     fn reduce_l2() {
         let device = Default::default();
-        let model: reduce_l2::Model<Backend> = reduce_l2::Model::new(&device);
+        let model: reduce_l2::Model<TestBackend> = reduce_l2::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats(
+        let input = Tensor::<TestBackend, 4>::from_floats(
             [[[
                 [1.0, -4.0, 9.0, 25.0], //
                 [2.0, 5.0, -10.0, 26.0],
@@ -335,10 +335,10 @@ mod tests {
     #[test]
     fn reduce_log_sum() {
         let device = Default::default();
-        let model: reduce_log_sum::Model<Backend> = reduce_log_sum::Model::new(&device);
+        let model: reduce_log_sum::Model<TestBackend> = reduce_log_sum::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats(
+        let input = Tensor::<TestBackend, 4>::from_floats(
             [[[
                 [1.0, 4.0, 9.0, 25.0], //
                 [2.0, 5.0, 10.0, 26.0],
@@ -379,10 +379,10 @@ mod tests {
     #[test]
     fn reduce_log_sum_exp() {
         let device = Default::default();
-        let model: reduce_log_sum_exp::Model<Backend> = reduce_log_sum_exp::Model::new(&device);
+        let model: reduce_log_sum_exp::Model<TestBackend> = reduce_log_sum_exp::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats(
+        let input = Tensor::<TestBackend, 4>::from_floats(
             [[[
                 [1.0, 4.0, 9.0, 25.0], //
                 [2.0, 5.0, 10.0, 26.0],

--- a/crates/burn-import/onnx-tests/tests/relu/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/relu/mod.rs
@@ -6,16 +6,16 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn relu() {
         // Initialize the model without weights (because the exported file does not contain them)
         let device = Default::default();
-        let model: relu::Model<Backend> = relu::Model::new(&device);
+        let model: relu::Model<TestBackend> = relu::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 2>::from_floats(
+        let input = Tensor::<TestBackend, 2>::from_floats(
             [
                 [0.33669037, 0.128_809_4, 0.23446237],
                 [0.23033303, -1.122_856_4, -0.18632829],

--- a/crates/burn-import/onnx-tests/tests/reshape/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/reshape/mod.rs
@@ -99,7 +99,8 @@ mod tests {
 
         // Initialize the model
         let device = Default::default();
-        let model: reshape_3d_to_scalar::Model<TestBackend> = reshape_3d_to_scalar::Model::new(&device);
+        let model: reshape_3d_to_scalar::Model<TestBackend> =
+            reshape_3d_to_scalar::Model::new(&device);
 
         // Run the model with a 1x1x1 tensor input
         let input = Tensor::<TestBackend, 3>::from_floats([[[2.5]]], &device);

--- a/crates/burn-import/onnx-tests/tests/reshape/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/reshape/mod.rs
@@ -15,16 +15,16 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn reshape() {
         // Initialize the model without weights (because the exported file does not contain them)
         let device = Default::default();
-        let model: reshape::Model<Backend> = reshape::Model::new(&device);
+        let model: reshape::Model<TestBackend> = reshape::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 1>::from_floats([0., 1., 2., 3.], &device);
+        let input = Tensor::<TestBackend, 1>::from_floats([0., 1., 2., 3.], &device);
         let output = model.forward(input);
         let expected = TensorData::from([[0f32, 1., 2., 3.]]);
 
@@ -38,15 +38,15 @@ mod tests {
 
         // Initialize the model
         let device = Default::default();
-        let model: reshape_with_1d_tensor::Model<Backend> =
+        let model: reshape_with_1d_tensor::Model<TestBackend> =
             reshape_with_1d_tensor::Model::new(&device);
 
         // Run the model with shape as tensor input
-        let input = Tensor::<Backend, 1>::from_floats(
+        let input = Tensor::<TestBackend, 1>::from_floats(
             [0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11.],
             &device,
         );
-        let shape = Tensor::<Backend, 1, burn::tensor::Int>::from_ints([3, 4], &device);
+        let shape = Tensor::<TestBackend, 1, burn::tensor::Int>::from_ints([3, 4], &device);
         let output = model.forward(input, shape);
 
         // Output should be 2D with shape [3, 4] as specified in the ONNX model
@@ -61,15 +61,15 @@ mod tests {
 
         // Initialize the model
         let device = Default::default();
-        let model: reshape_with_shape::Model<Backend> = reshape_with_shape::Model::new(&device);
+        let model: reshape_with_shape::Model<TestBackend> = reshape_with_shape::Model::new(&device);
 
         // Run the model with input and shape_source tensors
-        let input = Tensor::<Backend, 1>::from_floats(
+        let input = Tensor::<TestBackend, 1>::from_floats(
             [0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11.],
             &device,
         );
         // shape_source is used to extract shape via Shape node
-        let shape_source = Tensor::<Backend, 2>::zeros([3, 4], &device);
+        let shape_source = Tensor::<TestBackend, 2>::zeros([3, 4], &device);
         let output = model.forward(input, shape_source);
 
         // Output should be 2D with shape [3, 4] extracted from shape_source
@@ -83,10 +83,10 @@ mod tests {
 
         // Initialize the model
         let device = Default::default();
-        let model: reshape_to_scalar::Model<Backend> = reshape_to_scalar::Model::new(&device);
+        let model: reshape_to_scalar::Model<TestBackend> = reshape_to_scalar::Model::new(&device);
 
         // Run the model with a 1x1 tensor input
-        let input = Tensor::<Backend, 2>::from_floats([[1.5]], &device);
+        let input = Tensor::<TestBackend, 2>::from_floats([[1.5]], &device);
         let output = model.forward(input);
 
         // Output should be a scalar value
@@ -99,10 +99,10 @@ mod tests {
 
         // Initialize the model
         let device = Default::default();
-        let model: reshape_3d_to_scalar::Model<Backend> = reshape_3d_to_scalar::Model::new(&device);
+        let model: reshape_3d_to_scalar::Model<TestBackend> = reshape_3d_to_scalar::Model::new(&device);
 
         // Run the model with a 1x1x1 tensor input
-        let input = Tensor::<Backend, 3>::from_floats([[[2.5]]], &device);
+        let input = Tensor::<TestBackend, 3>::from_floats([[[2.5]]], &device);
         let output = model.forward(input);
 
         // Output should be a scalar value
@@ -116,11 +116,11 @@ mod tests {
 
         // Initialize the model
         let device = Default::default();
-        let model: reshape_shape_to_shape::Model<Backend> =
+        let model: reshape_shape_to_shape::Model<TestBackend> =
             reshape_shape_to_shape::Model::new(&device);
 
         // Run the model with a tensor whose shape will be extracted and reshaped
-        let input = Tensor::<Backend, 3>::zeros([2, 3, 4], &device);
+        let input = Tensor::<TestBackend, 3>::zeros([2, 3, 4], &device);
         let output = model.forward(input);
 
         // Output should be [2, 3, 4] - the shape of the input tensor
@@ -133,11 +133,11 @@ mod tests {
 
         // Initialize the model
         let device = Default::default();
-        let model: reshape_shape_with_neg::Model<Backend> =
+        let model: reshape_shape_with_neg::Model<TestBackend> =
             reshape_shape_with_neg::Model::new(&device);
 
         // Run the model with a tensor whose shape will be extracted and reshaped with -1
-        let input = Tensor::<Backend, 3>::zeros([2, 3, 4], &device);
+        let input = Tensor::<TestBackend, 3>::zeros([2, 3, 4], &device);
         let output = model.forward(input);
 
         // Output should be [2, 3, 4] reshaped to 1D with inferred size 3
@@ -150,11 +150,11 @@ mod tests {
 
         // Initialize the model
         let device = Default::default();
-        let model: reshape_shape_partial::Model<Backend> =
+        let model: reshape_shape_partial::Model<TestBackend> =
             reshape_shape_partial::Model::new(&device);
 
         // Run the model with a tensor whose shape will be sliced and reshaped
-        let input = Tensor::<Backend, 4>::zeros([2, 3, 4, 5], &device);
+        let input = Tensor::<TestBackend, 4>::zeros([2, 3, 4, 5], &device);
         let output = model.forward(input);
 
         // Output should be [2, 3] - first two dimensions after slicing

--- a/crates/burn-import/onnx-tests/tests/resize/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/resize/mod.rs
@@ -129,7 +129,8 @@ mod tests {
         );
 
         // Create sizes tensor [1, 3, 2, 2] - resize to 2x2
-        let sizes = Tensor::<TestBackend, 1, burn::tensor::Int>::from_ints([1i64, 3, 2, 2], &device);
+        let sizes =
+            Tensor::<TestBackend, 1, burn::tensor::Int>::from_ints([1i64, 3, 2, 2], &device);
 
         // The model should resize from [1, 3, 4, 4] to [1, 3, 2, 2] using nearest neighbor
         let output = model.forward(input, sizes);

--- a/crates/burn-import/onnx-tests/tests/resize/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/resize/mod.rs
@@ -17,17 +17,17 @@ mod tests {
     use burn::tensor::{Tensor, TensorData, ops::FloatElem};
     use float_cmp::ApproxEq;
 
-    use crate::backend::Backend;
-    type FT = FloatElem<Backend>;
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
 
     #[test]
     fn resize_with_sizes() {
         // Initialize the model without weights (because the exported file does not contain them)
         let device = Default::default();
-        let model: resize_with_sizes::Model<Backend> = resize_with_sizes::Model::new(&device);
+        let model: resize_with_sizes::Model<TestBackend> = resize_with_sizes::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats(
+        let input = Tensor::<TestBackend, 4>::from_floats(
             [[[
                 [0.0, 1.0, 2.0, 3.0],
                 [4.0, 5.0, 6.0, 7.0],
@@ -48,10 +48,10 @@ mod tests {
     fn resize_with_shape() {
         // Initialize the model without weights
         let device = Default::default();
-        let model: resize_with_shape::Model<Backend> = resize_with_shape::Model::new(&device);
+        let model: resize_with_shape::Model<TestBackend> = resize_with_shape::Model::new(&device);
 
         // Create input tensor [1, 3, 4, 4]
-        let input = Tensor::<Backend, 4>::from_floats(
+        let input = Tensor::<TestBackend, 4>::from_floats(
             [[
                 [
                     [0.0, 1.0, 2.0, 3.0],
@@ -100,11 +100,11 @@ mod tests {
     fn resize_with_sizes_tensor() {
         // Initialize the model without weights
         let device = Default::default();
-        let model: resize_with_sizes_tensor::Model<Backend> =
+        let model: resize_with_sizes_tensor::Model<TestBackend> =
             resize_with_sizes_tensor::Model::new(&device);
 
         // Create input tensor [1, 3, 4, 4]
-        let input = Tensor::<Backend, 4>::from_floats(
+        let input = Tensor::<TestBackend, 4>::from_floats(
             [[
                 [
                     [1.0, 2.0, 3.0, 4.0],
@@ -129,7 +129,7 @@ mod tests {
         );
 
         // Create sizes tensor [1, 3, 2, 2] - resize to 2x2
-        let sizes = Tensor::<Backend, 1, burn::tensor::Int>::from_ints([1i64, 3, 2, 2], &device);
+        let sizes = Tensor::<TestBackend, 1, burn::tensor::Int>::from_ints([1i64, 3, 2, 2], &device);
 
         // The model should resize from [1, 3, 4, 4] to [1, 3, 2, 2] using nearest neighbor
         let output = model.forward(input, sizes);
@@ -156,11 +156,11 @@ mod tests {
     fn resize_with_scales_1d_linear() {
         // Initialize the model without weights (because the exported file does not contain them)
         let device = Default::default();
-        let model: resize_1d_linear_scale::Model<Backend> =
+        let model: resize_1d_linear_scale::Model<TestBackend> =
             resize_1d_linear_scale::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 3>::from_floats(
+        let input = Tensor::<TestBackend, 3>::from_floats(
             [[[1.5410, -0.2934, -2.1788, 0.5684, -1.0845, -1.3986]]],
             &device,
         );
@@ -168,7 +168,7 @@ mod tests {
         // The scales are 1.5
         let output = model.forward(input);
 
-        Tensor::<Backend, 3>::from([[[
+        Tensor::<TestBackend, 3>::from([[[
             1.5410, 0.3945, -0.7648, -1.9431, -0.8052, 0.3618, -0.6713, -1.2023, -1.3986,
         ]]])
         .to_data()
@@ -179,11 +179,11 @@ mod tests {
     fn resize_with_scales_2d_bilinear() {
         // Initialize the model without weights (because the exported file does not contain them)
         let device = Default::default();
-        let model: resize_2d_bilinear_scale::Model<Backend> =
+        let model: resize_2d_bilinear_scale::Model<TestBackend> =
             resize_2d_bilinear_scale::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats(
+        let input = Tensor::<TestBackend, 4>::from_floats(
             [[[
                 [-1.1258, -1.1524, -0.2506, -0.4339, 0.8487, 0.6920],
                 [-0.3160, -2.1152, 0.3223, -1.2633, 0.3500, 0.3081],
@@ -208,11 +208,11 @@ mod tests {
     fn resize_with_scales_2d_nearest() {
         // Initialize the model without weights (because the exported file does not contain them)
         let device = Default::default();
-        let model: resize_2d_nearest_scale::Model<Backend> =
-            resize_2d_nearest_scale::Model::<Backend>::new(&device);
+        let model: resize_2d_nearest_scale::Model<TestBackend> =
+            resize_2d_nearest_scale::Model::<TestBackend>::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats(
+        let input = Tensor::<TestBackend, 4>::from_floats(
             [[[
                 [-1.1258, -1.1524, -0.2506, -0.4339, 0.8487, 0.6920],
                 [-0.3160, -2.1152, 0.3223, -1.2633, 0.3500, 0.3081],
@@ -239,11 +239,11 @@ mod tests {
     fn resize_with_scales_1d_nearest() {
         // Initialize the model without weights (because the exported file does not contain them)
         let device = Default::default();
-        let model: resize_1d_nearest_scale::Model<Backend> =
-            resize_1d_nearest_scale::Model::<Backend>::new(&device);
+        let model: resize_1d_nearest_scale::Model<TestBackend> =
+            resize_1d_nearest_scale::Model::<TestBackend>::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 3>::from_floats(
+        let input = Tensor::<TestBackend, 3>::from_floats(
             [[[1.5410, -0.2934, -2.1788, 0.5684, -1.0845, -1.3986]]],
             &device,
         );
@@ -263,11 +263,11 @@ mod tests {
     fn resize_with_scales_2d_bicubic() {
         // Initialize the model without weights (because the exported file does not contain them)
         let device = Default::default();
-        let model: resize_2d_bicubic_scale::Model<Backend> =
-            resize_2d_bicubic_scale::Model::<Backend>::new(&device);
+        let model: resize_2d_bicubic_scale::Model<TestBackend> =
+            resize_2d_bicubic_scale::Model::<TestBackend>::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats(
+        let input = Tensor::<TestBackend, 4>::from_floats(
             [[[
                 [-1.1258, -1.1524, -0.2506, -0.4339, 0.8487, 0.6920],
                 [-0.3160, -2.1152, 0.3223, -1.2633, 0.3500, 0.3081],

--- a/crates/burn-import/onnx-tests/tests/round/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/round/mod.rs
@@ -6,17 +6,17 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, ops::FloatElem};
 
-    use crate::backend::Backend;
-    type FT = FloatElem<Backend>;
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
 
     #[test]
     fn round_test() {
         // Test for round
         let device = Default::default();
-        let model = round::Model::<Backend>::new(&device);
+        let model = round::Model::<TestBackend>::new(&device);
 
-        let input = Tensor::<Backend, 1>::from_floats([-0.5, 1.5, 2.1], &device);
-        let expected = Tensor::<Backend, 1>::from_floats([0., 2., 2.], &device);
+        let input = Tensor::<TestBackend, 1>::from_floats([-0.5, 1.5, 2.1], &device);
+        let expected = Tensor::<TestBackend, 1>::from_floats([0., 2., 2.], &device);
 
         let output = model.forward(input);
 

--- a/crates/burn-import/onnx-tests/tests/shape/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/shape/mod.rs
@@ -6,15 +6,15 @@ mod tests {
     use super::*;
     use burn::tensor::Tensor;
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn shape() {
         let device = Default::default();
-        let model: shape::Model<Backend> = shape::Model::new(&device);
+        let model: shape::Model<TestBackend> = shape::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 2>::ones([4, 2], &device);
+        let input = Tensor::<TestBackend, 2>::ones([4, 2], &device);
         let output = model.forward(input);
         let expected = [4i64, 2i64];
         assert_eq!(output, expected);

--- a/crates/burn-import/onnx-tests/tests/sigmoid/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/sigmoid/mod.rs
@@ -6,17 +6,17 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, ops::FloatElem};
 
-    use crate::backend::Backend;
-    type FT = FloatElem<Backend>;
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
 
     #[test]
     fn sigmoid() {
         // Initialize the model without weights (because the exported file does not contain them)
         let device = Default::default();
-        let model: sigmoid::Model<Backend> = sigmoid::Model::new(&device);
+        let model: sigmoid::Model<TestBackend> = sigmoid::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 2>::from_floats(
+        let input = Tensor::<TestBackend, 2>::from_floats(
             [
                 [0.33669037, 0.128_809_4, 0.23446237],
                 [0.23033303, -1.122_856_4, -0.18632829],

--- a/crates/burn-import/onnx-tests/tests/sign/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/sign/mod.rs
@@ -7,15 +7,15 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    use crate::backend::Backend;
-    type FT = FloatElem<Backend>;
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
 
     #[test]
     fn sign() {
         let device = Default::default();
-        let model: sign::Model<Backend> = sign::Model::new(&device);
+        let model: sign::Model<TestBackend> = sign::Model::new(&device);
 
-        let input = Tensor::<Backend, 4>::from_floats([[[[-1.0, 2.0, 0.0, -4.0]]]], &device);
+        let input = Tensor::<TestBackend, 4>::from_floats([[[[-1.0, 2.0, 0.0, -4.0]]]], &device);
 
         let output = model.forward(input);
         let expected = TensorData::from([[[[-1.0f32, 1.0, 0.0, -1.0]]]]);

--- a/crates/burn-import/onnx-tests/tests/sin/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/sin/mod.rs
@@ -7,15 +7,15 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    use crate::backend::Backend;
-    type FT = FloatElem<Backend>;
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
 
     #[test]
     fn sin() {
         let device = Default::default();
-        let model: sin::Model<Backend> = sin::Model::new(&device);
+        let model: sin::Model<TestBackend> = sin::Model::new(&device);
 
-        let input = Tensor::<Backend, 4>::from_floats([[[[1.0, 4.0, 9.0, 25.0]]]], &device);
+        let input = Tensor::<TestBackend, 4>::from_floats([[[[1.0, 4.0, 9.0, 25.0]]]], &device);
 
         let output = model.forward(input);
         let expected = TensorData::from([[[[0.8415f32, -0.7568, 0.4121, -0.1324]]]]);

--- a/crates/burn-import/onnx-tests/tests/sinh/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/sinh/mod.rs
@@ -7,15 +7,15 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    use crate::backend::Backend;
-    type FT = FloatElem<Backend>;
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
 
     #[test]
     fn sinh() {
         let device = Default::default();
-        let model: sinh::Model<Backend> = sinh::Model::new(&device);
+        let model: sinh::Model<TestBackend> = sinh::Model::new(&device);
 
-        let input = Tensor::<Backend, 4>::from_floats([[[[-4.0, 0.5, 1.0, 9.0]]]], &device);
+        let input = Tensor::<TestBackend, 4>::from_floats([[[[-4.0, 0.5, 1.0, 9.0]]]], &device);
 
         let output = model.forward(input);
         let expected = TensorData::from([[[[-27.2899, 0.5211, 1.1752, 4051.5419]]]]);

--- a/crates/burn-import/onnx-tests/tests/size/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/size/mod.rs
@@ -7,15 +7,15 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-use crate::backend::Backend;
+use crate::backend::TestBackend;
 
     #[test]
     fn size() {
-        let model: size::Model<Backend> = size::Model::default();
+        let model: size::Model<TestBackend> = size::Model::default();
         let device = Default::default();
 
         let input =
-            Tensor::<Backend, 1>::arange(0..(1 * 2 * 3 * 4 * 5), &device).reshape([1, 2, 3, 4, 5]);
+            Tensor::<TestBackend, 1>::arange(0..(1 * 2 * 3 * 4 * 5), &device).reshape([1, 2, 3, 4, 5]);
         let output = model.forward(input);
         let expected = TensorData::from([120]);
 

--- a/crates/burn-import/onnx-tests/tests/slice/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/slice/mod.rs
@@ -20,14 +20,14 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn slice() {
-        let model: slice::Model<Backend> = slice::Model::default();
+        let model: slice::Model<TestBackend> = slice::Model::default();
         let device = Default::default();
 
-        let input = Tensor::<Backend, 2>::from_floats(
+        let input = Tensor::<TestBackend, 2>::from_floats(
             [
                 [1., 2., 3., 4., 5., 6., 7., 8., 9., 10.],
                 [11., 12., 13., 14., 15., 16., 17., 18., 19., 20.],
@@ -49,10 +49,10 @@ mod tests {
 
     #[test]
     fn slice_shape() {
-        let model: slice_shape::Model<Backend> = slice_shape::Model::default();
+        let model: slice_shape::Model<TestBackend> = slice_shape::Model::default();
         let device = Default::default();
 
-        let input = Tensor::<Backend, 4>::zeros([1, 2, 3, 1], &device);
+        let input = Tensor::<TestBackend, 4>::zeros([1, 2, 3, 1], &device);
 
         // Slice Start == 1, End == 3
         let output = model.forward(input);
@@ -62,10 +62,10 @@ mod tests {
 
     #[test]
     fn slice_scalar() {
-        let model: slice_scalar::Model<Backend> = slice_scalar::Model::default();
+        let model: slice_scalar::Model<TestBackend> = slice_scalar::Model::default();
         let device = Default::default();
 
-        let input = Tensor::<Backend, 2>::ones([5, 3], &device);
+        let input = Tensor::<TestBackend, 2>::ones([5, 3], &device);
         let start = 1;
         let end = 4;
 
@@ -77,11 +77,11 @@ mod tests {
 
     #[test]
     fn slice_mixed() {
-        let model: slice_mixed::Model<Backend> = slice_mixed::Model::default();
+        let model: slice_mixed::Model<TestBackend> = slice_mixed::Model::default();
         let device = Default::default();
 
         // Create test input tensor [5, 3]
-        let input = Tensor::<Backend, 2>::from_floats(
+        let input = Tensor::<TestBackend, 2>::from_floats(
             [
                 [1.0, 2.0, 3.0],
                 [4.0, 5.0, 6.0],
@@ -104,11 +104,11 @@ mod tests {
 
     #[test]
     fn slice_shape_gather() {
-        let model: slice_shape_gather::Model<Backend> = slice_shape_gather::Model::default();
+        let model: slice_shape_gather::Model<TestBackend> = slice_shape_gather::Model::default();
         let device = Default::default();
 
         // Create test input tensor [2, 4, 6, 8]
-        let input = Tensor::<Backend, 4>::ones([2, 4, 6, 8], &device);
+        let input = Tensor::<TestBackend, 4>::ones([2, 4, 6, 8], &device);
 
         let output = model.forward(input.clone());
 
@@ -129,14 +129,14 @@ mod tests {
 
     #[test]
     fn slice_shape_runtime() {
-        let model: slice_shape_runtime::Model<Backend> = slice_shape_runtime::Model::default();
+        let model: slice_shape_runtime::Model<TestBackend> = slice_shape_runtime::Model::default();
         let device = Default::default();
 
         // Create test input tensor [10, 8, 6]
-        let input = Tensor::<Backend, 3>::ones([10, 8, 6], &device);
+        let input = Tensor::<TestBackend, 3>::ones([10, 8, 6], &device);
 
         // Create shape input tensor [3, 4] - its shape will be used as slice ends
-        let shape_input = Tensor::<Backend, 2>::ones([3, 4], &device);
+        let shape_input = Tensor::<TestBackend, 2>::ones([3, 4], &device);
 
         let output = model.forward(input, shape_input);
 
@@ -149,18 +149,18 @@ mod tests {
 
     #[test]
     fn slice_shape_multi() {
-        let model: slice_shape_multi::Model<Backend> = slice_shape_multi::Model::default();
+        let model: slice_shape_multi::Model<TestBackend> = slice_shape_multi::Model::default();
         let device = Default::default();
 
         // Create test input tensor [8, 6, 10, 12]
-        let input = Tensor::<Backend, 4>::ones([8, 6, 10, 12], &device);
+        let input = Tensor::<TestBackend, 4>::ones([8, 6, 10, 12], &device);
 
         // Create shape tensors whose shapes will be used as slice parameters
         // start_shape_input has shape [1, 2, 3] -> used as start indices
-        let start_shape_input = Tensor::<Backend, 3>::zeros([1, 2, 3], &device);
+        let start_shape_input = Tensor::<TestBackend, 3>::zeros([1, 2, 3], &device);
 
         // end_shape_input has shape [5, 4, 7] -> used as end indices
-        let end_shape_input = Tensor::<Backend, 3>::zeros([5, 4, 7], &device);
+        let end_shape_input = Tensor::<TestBackend, 3>::zeros([5, 4, 7], &device);
 
         let output = model.forward(input, start_shape_input, end_shape_input);
 
@@ -173,11 +173,11 @@ mod tests {
 
     #[test]
     fn slice_shape_negative() {
-        let model: slice_shape_negative::Model<Backend> = slice_shape_negative::Model::default();
+        let model: slice_shape_negative::Model<TestBackend> = slice_shape_negative::Model::default();
         let device = Default::default();
 
         // Create test input tensor [2, 3, 4, 5]
-        let input = Tensor::<Backend, 4>::ones([2, 3, 4, 5], &device);
+        let input = Tensor::<TestBackend, 4>::ones([2, 3, 4, 5], &device);
 
         let output = model.forward(input);
 
@@ -189,12 +189,12 @@ mod tests {
 
     #[test]
     fn slice_shape_negative_range() {
-        let model: slice_shape_negative_range::Model<Backend> =
+        let model: slice_shape_negative_range::Model<TestBackend> =
             slice_shape_negative_range::Model::default();
         let device = Default::default();
 
         // Create test input tensor [2, 3, 4, 5]
-        let input = Tensor::<Backend, 4>::ones([2, 3, 4, 5], &device);
+        let input = Tensor::<TestBackend, 4>::ones([2, 3, 4, 5], &device);
 
         let output: [i64; 2] = model.forward(input);
 
@@ -206,17 +206,17 @@ mod tests {
 
     #[test]
     fn slice_1d_tensor() {
-        let model: slice_1d_tensor::Model<Backend> = slice_1d_tensor::Model::default();
+        let model: slice_1d_tensor::Model<TestBackend> = slice_1d_tensor::Model::default();
         let device = Default::default();
 
         // Create test input tensor [4, 5, 6] using range and reshape
-        let input = Tensor::<Backend, 1, burn::tensor::Int>::arange(1..121, &device)
+        let input = Tensor::<TestBackend, 1, burn::tensor::Int>::arange(1..121, &device)
             .float()
             .reshape([4, 5, 6]);
 
         // Create 1D tensors for starts and ends
-        let starts = Tensor::<Backend, 1, burn::tensor::Int>::from_ints([1i64, 2i64], &device);
-        let ends = Tensor::<Backend, 1, burn::tensor::Int>::from_ints([3i64, 5i64], &device);
+        let starts = Tensor::<TestBackend, 1, burn::tensor::Int>::from_ints([1i64, 2i64], &device);
+        let ends = Tensor::<TestBackend, 1, burn::tensor::Int>::from_ints([3i64, 5i64], &device);
 
         let output = model.forward(input, starts, ends);
 
@@ -230,25 +230,25 @@ mod tests {
         let expected_data: alloc::vec::Vec<f32> =
             (43..61).chain(73..91).map(|x| x as f32).collect();
         let expected =
-            Tensor::<Backend, 1>::from_floats(expected_data.as_slice(), &device).reshape([2, 3, 6]);
+            Tensor::<TestBackend, 1>::from_floats(expected_data.as_slice(), &device).reshape([2, 3, 6]);
 
         output.to_data().assert_eq(&expected.to_data(), true);
     }
 
     #[test]
     fn slice_shape_start_tensor_end() {
-        let model: slice_shape_start_tensor_end::Model<Backend> =
+        let model: slice_shape_start_tensor_end::Model<TestBackend> =
             slice_shape_start_tensor_end::Model::default();
         let device = Default::default();
 
         // Create test input tensor [6, 8, 10]
-        let input = Tensor::<Backend, 3>::ones([6, 8, 10], &device);
+        let input = Tensor::<TestBackend, 3>::ones([6, 8, 10], &device);
 
         // Create shape input tensor [2, 3] - its shape will be used as starts
-        let shape_input = Tensor::<Backend, 2>::ones([2, 3], &device);
+        let shape_input = Tensor::<TestBackend, 2>::ones([2, 3], &device);
 
         // Create 1D tensor for ends
-        let ends = Tensor::<Backend, 1, burn::tensor::Int>::from_ints([5i64, 8i64], &device);
+        let ends = Tensor::<TestBackend, 1, burn::tensor::Int>::from_ints([5i64, 8i64], &device);
 
         let output = model.forward(input, shape_input, ends);
 
@@ -261,18 +261,18 @@ mod tests {
 
     #[test]
     fn slice_tensor_start_shape_end() {
-        let model: slice_tensor_start_shape_end::Model<Backend> =
+        let model: slice_tensor_start_shape_end::Model<TestBackend> =
             slice_tensor_start_shape_end::Model::default();
         let device = Default::default();
 
         // Create test input tensor [10, 12, 8]
-        let input = Tensor::<Backend, 3>::ones([10, 12, 8], &device);
+        let input = Tensor::<TestBackend, 3>::ones([10, 12, 8], &device);
 
         // Create 1D tensor for starts
-        let starts = Tensor::<Backend, 1, burn::tensor::Int>::from_ints([2i64, 3i64], &device);
+        let starts = Tensor::<TestBackend, 1, burn::tensor::Int>::from_ints([2i64, 3i64], &device);
 
         // Create shape input tensor [6, 10] - its shape will be used as ends
-        let shape_input = Tensor::<Backend, 2>::ones([6, 10], &device);
+        let shape_input = Tensor::<TestBackend, 2>::ones([6, 10], &device);
 
         let output = model.forward(input, starts, shape_input);
 

--- a/crates/burn-import/onnx-tests/tests/slice/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/slice/mod.rs
@@ -173,7 +173,8 @@ mod tests {
 
     #[test]
     fn slice_shape_negative() {
-        let model: slice_shape_negative::Model<TestBackend> = slice_shape_negative::Model::default();
+        let model: slice_shape_negative::Model<TestBackend> =
+            slice_shape_negative::Model::default();
         let device = Default::default();
 
         // Create test input tensor [2, 3, 4, 5]
@@ -229,8 +230,8 @@ mod tests {
         // Create expected tensor directly using from_floats
         let expected_data: alloc::vec::Vec<f32> =
             (43..61).chain(73..91).map(|x| x as f32).collect();
-        let expected =
-            Tensor::<TestBackend, 1>::from_floats(expected_data.as_slice(), &device).reshape([2, 3, 6]);
+        let expected = Tensor::<TestBackend, 1>::from_floats(expected_data.as_slice(), &device)
+            .reshape([2, 3, 6]);
 
         output.to_data().assert_eq(&expected.to_data(), true);
     }

--- a/crates/burn-import/onnx-tests/tests/softmax/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/softmax/mod.rs
@@ -7,16 +7,16 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn softmax() {
         // Initialize the model without weights (because the exported file does not contain them)
         let device = Default::default();
-        let model: softmax::Model<Backend> = softmax::Model::new(&device);
+        let model: softmax::Model<TestBackend> = softmax::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 2>::from_floats(
+        let input = Tensor::<TestBackend, 2>::from_floats(
             [
                 [0.33669037, 0.128_809_4, 0.23446237],
                 [0.23033303, -1.122_856_4, -0.18632829],

--- a/crates/burn-import/onnx-tests/tests/space_to_depth/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/space_to_depth/mod.rs
@@ -7,15 +7,15 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, Tolerance, ops::FloatElem};
 
-    use crate::backend::Backend;
-    type FT = FloatElem<Backend>;
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
 
     #[test]
     fn space_to_depth() {
         let device = Default::default();
-        let model: space_to_depth::Model<Backend> = space_to_depth::Model::new(&device);
+        let model: space_to_depth::Model<TestBackend> = space_to_depth::Model::new(&device);
 
-        let input = Tensor::<Backend, 4>::from_floats(
+        let input = Tensor::<TestBackend, 4>::from_floats(
             [
                 [[
                     [0.5, -0.14, 0.65, 1.52, -0.23, -0.23],

--- a/crates/burn-import/onnx-tests/tests/split/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/split/mod.rs
@@ -6,12 +6,12 @@ mod tests {
     use super::*;
     use burn::tensor::{Shape, Tensor};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn split() {
         let device = Default::default();
-        let model = split::Model::<Backend>::new(&device);
+        let model = split::Model::<TestBackend>::new(&device);
         let shape = [5, 2];
         let input = Tensor::ones(shape, &device);
 

--- a/crates/burn-import/onnx-tests/tests/sqrt/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/sqrt/mod.rs
@@ -7,14 +7,14 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn sqrt() {
         let device = Default::default();
-        let model: sqrt::Model<Backend> = sqrt::Model::new(&device);
+        let model: sqrt::Model<TestBackend> = sqrt::Model::new(&device);
 
-        let input1 = Tensor::<Backend, 4>::from_floats([[[[1.0, 4.0, 9.0, 25.0]]]], &device);
+        let input1 = Tensor::<TestBackend, 4>::from_floats([[[[1.0, 4.0, 9.0, 25.0]]]], &device);
         let input2 = 36f64;
 
         let (output1, output2) = model.forward(input1, input2);

--- a/crates/burn-import/onnx-tests/tests/squeeze/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/squeeze/mod.rs
@@ -14,12 +14,12 @@ mod tests {
     use super::*;
     use burn::tensor::{Shape, Tensor};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn squeeze() {
         let device = Default::default();
-        let model = squeeze::Model::<Backend>::new(&device);
+        let model = squeeze::Model::<TestBackend>::new(&device);
         let input_shape = Shape::from([3, 4, 1, 5]);
         let expected_shape = Shape::from([3, 4, 5]);
         let input = Tensor::ones(input_shape, &device);
@@ -30,7 +30,7 @@ mod tests {
     #[test]
     fn squeeze_multiple() {
         let device = Default::default();
-        let model = squeeze_multiple::Model::<Backend>::new(&device);
+        let model = squeeze_multiple::Model::<TestBackend>::new(&device);
         let input_shape = Shape::from([3, 4, 1, 5, 1]);
         let expected_shape = Shape::from([3, 4, 5]);
         let input = Tensor::ones(input_shape, &device);
@@ -41,9 +41,9 @@ mod tests {
     #[test]
     fn squeeze_shape() {
         let device = Default::default();
-        let model = squeeze_shape::Model::<Backend>::new(&device);
+        let model = squeeze_shape::Model::<TestBackend>::new(&device);
         // Input tensor is 3x4x5
-        let input = Tensor::<Backend, 3>::ones([3, 4, 5], &device);
+        let input = Tensor::<TestBackend, 3>::ones([3, 4, 5], &device);
         // The model: Shape -> Slice(0:1) -> Squeeze
         // Expected: [3, 4, 5] -> [3] -> 3
         let output = model.forward(input);
@@ -53,9 +53,9 @@ mod tests {
     #[test]
     fn squeeze_shape_noop() {
         let device = Default::default();
-        let model = squeeze_shape_noop::Model::<Backend>::new(&device);
+        let model = squeeze_shape_noop::Model::<TestBackend>::new(&device);
         // Input tensor is 6x7
-        let input = Tensor::<Backend, 2>::ones([6, 7], &device);
+        let input = Tensor::<TestBackend, 2>::ones([6, 7], &device);
         // The model: Shape -> Squeeze(axis=0)
         // Expected: [6, 7] -> [6, 7] (no-op since axis 0 has size 6, not 1)
         let output = model.forward(input);
@@ -65,7 +65,7 @@ mod tests {
     #[test]
     fn squeeze_scalar() {
         let device = Default::default();
-        let model = squeeze_scalar::Model::<Backend>::new(&device);
+        let model = squeeze_scalar::Model::<TestBackend>::new(&device);
         // The model has a constant scalar 1.5 that gets squeezed
         // Expected: 1.5 -> 1.5 (no-op)
         let output = model.forward();
@@ -77,8 +77,8 @@ mod tests {
         // Test verifies that the improved squeeze implementation using .into_scalar()
         // works correctly for float tensors with .elem::<f32>() casting
         let device = Default::default();
-        let model = squeeze_float::Model::<Backend>::new(&device);
-        let input = Tensor::<Backend, 1>::from_data([14159.222f32], &device);
+        let model = squeeze_float::Model::<TestBackend>::new(&device);
+        let input = Tensor::<TestBackend, 1>::from_data([14159.222f32], &device);
         let output = model.forward(input);
         assert!((output - 14159.222f32).abs() < 1e-6);
     }
@@ -87,8 +87,8 @@ mod tests {
     fn squeeze_tensor_to_scalar() {
         // Test squeezing a multi-dimensional tensor [1, 1, 1] with one element to a scalar
         let device = Default::default();
-        let model = squeeze_tensor_to_scalar::Model::<Backend>::new(&device);
-        let input = Tensor::<Backend, 3>::from_data([[[42.5f32]]], &device);
+        let model = squeeze_tensor_to_scalar::Model::<TestBackend>::new(&device);
+        let input = Tensor::<TestBackend, 3>::from_data([[[42.5f32]]], &device);
         let output = model.forward(input);
         assert!((output - 42.5f32).abs() < 1e-6);
     }

--- a/crates/burn-import/onnx-tests/tests/sub/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/sub/mod.rs
@@ -7,16 +7,16 @@ mod tests {
     use super::*;
     use burn::tensor::{Int, Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn sub_scalar_from_tensor_and_tensor_from_tensor() {
         // Initialize the model with weights (loaded from the exported file)
-        let model: sub::Model<Backend> = sub::Model::default();
+        let model: sub::Model<TestBackend> = sub::Model::default();
 
         let device = Default::default();
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats([[[[1., 2., 3., 4.]]]], &device);
+        let input = Tensor::<TestBackend, 4>::from_floats([[[[1., 2., 3., 4.]]]], &device);
         let scalar = 3.0f64;
         let output = model.forward(input, scalar);
         let expected = TensorData::from([[[[-12f32, -13., -14., -15.]]]]);
@@ -27,11 +27,11 @@ mod tests {
     #[test]
     fn sub_scalar_from_int_tensor_and_int_tensor_from_tensor() {
         // Initialize the model with weights (loaded from the exported file)
-        let model: sub_int::Model<Backend> = sub_int::Model::default();
+        let model: sub_int::Model<TestBackend> = sub_int::Model::default();
 
         let device = Default::default();
         // Run the model
-        let input = Tensor::<Backend, 4, Int>::from_ints([[[[1, 2, 3, 4]]]], &device);
+        let input = Tensor::<TestBackend, 4, Int>::from_ints([[[[1, 2, 3, 4]]]], &device);
         let scalar = 3;
         let output = model.forward(input, scalar);
         let expected = TensorData::from([[[[-12i64, -12, -12, -12]]]]);
@@ -42,12 +42,12 @@ mod tests {
     #[test]
     fn sub_shape_with_scalar_and_shape() {
         // Initialize the model
-        let model: sub_shape::Model<Backend> = sub_shape::Model::default();
+        let model: sub_shape::Model<TestBackend> = sub_shape::Model::default();
 
         let device = Default::default();
         // Create input tensors
-        let input1 = Tensor::<Backend, 3>::ones([10, 8, 6], &device);
-        let input2 = Tensor::<Backend, 3>::ones([2, 3, 4], &device);
+        let input1 = Tensor::<TestBackend, 3>::ones([10, 8, 6], &device);
+        let input2 = Tensor::<TestBackend, 3>::ones([2, 3, 4], &device);
         let (shape_minus_scalar, shape_minus_shape) = model.forward(input1, input2);
 
         // Expected outputs

--- a/crates/burn-import/onnx-tests/tests/sum/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/sum/mod.rs
@@ -7,16 +7,16 @@ mod tests {
     use super::*;
     use burn::tensor::{Int, Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn sum_tensor_and_tensor() {
         let device = Default::default();
-        let model: sum::Model<Backend> = sum::Model::default();
+        let model: sum::Model<TestBackend> = sum::Model::default();
 
-        let input1 = Tensor::<Backend, 1>::from_floats([1., 2., 3., 4.], &device);
-        let input2 = Tensor::<Backend, 1>::from_floats([1., 2., 3., 4.], &device);
-        let input3 = Tensor::<Backend, 1>::from_floats([1., 2., 3., 4.], &device);
+        let input1 = Tensor::<TestBackend, 1>::from_floats([1., 2., 3., 4.], &device);
+        let input2 = Tensor::<TestBackend, 1>::from_floats([1., 2., 3., 4.], &device);
+        let input3 = Tensor::<TestBackend, 1>::from_floats([1., 2., 3., 4.], &device);
 
         let output = model.forward(input1, input2, input3);
         let expected = TensorData::from([3f32, 6., 9., 12.]);
@@ -27,11 +27,11 @@ mod tests {
     #[test]
     fn sum_int_tensor_and_int_tensor() {
         let device = Default::default();
-        let model: sum_int::Model<Backend> = sum_int::Model::default();
+        let model: sum_int::Model<TestBackend> = sum_int::Model::default();
 
-        let input1 = Tensor::<Backend, 1, Int>::from_ints([1, 2, 3, 4], &device);
-        let input2 = Tensor::<Backend, 1, Int>::from_ints([1, 2, 3, 4], &device);
-        let input3 = Tensor::<Backend, 1, Int>::from_ints([1, 2, 3, 4], &device);
+        let input1 = Tensor::<TestBackend, 1, Int>::from_ints([1, 2, 3, 4], &device);
+        let input2 = Tensor::<TestBackend, 1, Int>::from_ints([1, 2, 3, 4], &device);
+        let input3 = Tensor::<TestBackend, 1, Int>::from_ints([1, 2, 3, 4], &device);
 
         let output = model.forward(input1, input2, input3);
         let expected = TensorData::from([3i64, 6, 9, 12]);

--- a/crates/burn-import/onnx-tests/tests/tan/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/tan/mod.rs
@@ -6,17 +6,17 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, ops::FloatElem};
 
-    use crate::backend::Backend;
-    type FT = FloatElem<Backend>;
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
 
     #[test]
     fn tan() {
         // Initialize the model
         let device = Default::default();
-        let model = tan::Model::<Backend>::new(&device);
+        let model = tan::Model::<TestBackend>::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats([[[[1., 2., 3., 4.]]]], &device);
+        let input = Tensor::<TestBackend, 4>::from_floats([[[[1., 2., 3., 4.]]]], &device);
         let output = model.forward(input);
         // data from pyTorch
         let expected = TensorData::from([[[[1.5574f32, -2.1850, -0.1425, 1.1578]]]]);

--- a/crates/burn-import/onnx-tests/tests/tanh/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/tanh/mod.rs
@@ -6,17 +6,17 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData, ops::FloatElem};
 
-    use crate::backend::Backend;
-    type FT = FloatElem<Backend>;
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
 
     #[test]
     fn tanh() {
         // Initialize the model
         let device = Default::default();
-        let model = tanh::Model::<Backend>::new(&device);
+        let model = tanh::Model::<TestBackend>::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 4>::from_floats([[[[1., 2., 3., 4.]]]], &device);
+        let input = Tensor::<TestBackend, 4>::from_floats([[[[1., 2., 3., 4.]]]], &device);
         let output = model.forward(input);
         // data from pyTorch
         let expected = TensorData::from([[[[0.7616f32, 0.9640, 0.9951, 0.9993]]]]);

--- a/crates/burn-import/onnx-tests/tests/test_record_type.rs
+++ b/crates/burn-import/onnx-tests/tests/test_record_type.rs
@@ -24,10 +24,10 @@ macro_rules! test_model {
         #[test]
         fn $mod_name() {
             // Initialize the model with weights (loaded from the exported file)
-            let model: $mod_name::Model<Backend> = $mod_name::Model::default();
+            let model: $mod_name::Model<TestBackend> = $mod_name::Model::default();
 
             // Run the model with pi as input for easier testing
-            let input = Tensor::<Backend, 3>::full([6, 4, 10], consts::PI, &Default::default());
+            let input = Tensor::<TestBackend, 3>::full([6, 4, 10], consts::PI, &Default::default());
 
             let output = model.forward(input);
 
@@ -46,7 +46,7 @@ macro_rules! test_model {
 
 #[cfg(test)]
 mod tests {
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
     use burn::tensor::{Shape, Tensor};
     use float_cmp::ApproxEq;
     use std::f64::consts;

--- a/crates/burn-import/onnx-tests/tests/tile/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/tile/mod.rs
@@ -6,14 +6,14 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn tile() {
         let device = Default::default();
-        let model: tile::Model<Backend> = tile::Model::new(&device);
+        let model: tile::Model<TestBackend> = tile::Model::new(&device);
 
-        let input = Tensor::<Backend, 2>::from_floats([[1., 2.], [3., 4.]], &device);
+        let input = Tensor::<TestBackend, 2>::from_floats([[1., 2.], [3., 4.]], &device);
         let output = model.forward(input).to_data();
         let expected = TensorData::from([
             [1.0f32, 2.0f32, 1.0f32, 2.0f32],

--- a/crates/burn-import/onnx-tests/tests/topk/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/topk/mod.rs
@@ -6,16 +6,16 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn topk() {
         // Initialize the model
         let device = Default::default();
-        let model = topk::Model::<Backend>::new(&device);
+        let model = topk::Model::<TestBackend>::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 2>::from_floats(
+        let input = Tensor::<TestBackend, 2>::from_floats(
             [
                 [0.33669037, 0.12880941, 0.23446237, 0.23033303, -1.12285638],
                 [-0.18632829, 2.20820141, -0.63799703, 0.46165723, 0.26735088],

--- a/crates/burn-import/onnx-tests/tests/transpose/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/transpose/mod.rs
@@ -6,16 +6,16 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn transpose() {
         // Initialize the model without weights (because the exported file does not contain them)
         let device = Default::default();
-        let model: transpose::Model<Backend> = transpose::Model::new(&device);
+        let model: transpose::Model<TestBackend> = transpose::Model::new(&device);
 
         // Run the model
-        let input = Tensor::<Backend, 3>::from_floats(
+        let input = Tensor::<TestBackend, 3>::from_floats(
             [
                 [[0., 1., 2., 3.], [4., 5., 6., 7.], [8., 9., 10., 11.]],
                 [

--- a/crates/burn-import/onnx-tests/tests/trilu/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/trilu/mod.rs
@@ -6,13 +6,13 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn trilu_upper() {
         let device = Default::default();
-        let model: trilu_upper::Model<Backend> = trilu_upper::Model::new(&device);
-        let input = Tensor::<Backend, 3>::from_floats(
+        let model: trilu_upper::Model<TestBackend> = trilu_upper::Model::new(&device);
+        let input = Tensor::<TestBackend, 3>::from_floats(
             [[[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]]],
             &device,
         );
@@ -30,8 +30,8 @@ mod tests {
     #[test]
     fn trilu_lower() {
         let device = Default::default();
-        let model: trilu_lower::Model<Backend> = trilu_lower::Model::new(&device);
-        let input = Tensor::<Backend, 3>::from_floats(
+        let model: trilu_lower::Model<TestBackend> = trilu_lower::Model::new(&device);
+        let input = Tensor::<TestBackend, 3>::from_floats(
             [[[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]]],
             &device,
         );

--- a/crates/burn-import/onnx-tests/tests/unsqueeze/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/unsqueeze/mod.rs
@@ -11,12 +11,12 @@ mod tests {
     use super::*;
     use burn::tensor::{Shape, Tensor};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn unsqueeze_runtime_axes() {
         let device = Default::default();
-        let model: unsqueeze_runtime_axes::Model<Backend> =
+        let model: unsqueeze_runtime_axes::Model<TestBackend> =
             unsqueeze_runtime_axes::Model::new(&device);
         let input_shape = Shape::from([3, 4, 5]);
         let expected_shape = Shape::from([1, 3, 1, 4, 5, 1]);
@@ -33,7 +33,7 @@ mod tests {
     #[test]
     fn unsqueeze_like() {
         let device = Default::default();
-        let model = unsqueeze_like::Model::<Backend>::new(&device);
+        let model = unsqueeze_like::Model::<TestBackend>::new(&device);
         let input_shape = Shape::from([3, 4, 5]);
         let expected_shape = Shape::from([3, 4, 5, 1]);
         let input = Tensor::ones(input_shape, &device);
@@ -49,7 +49,7 @@ mod tests {
         // rather than tensors, which is crucial for efficient dynamic shape operations
         // The generated model takes an i64 scalar and returns a Shape array [i64; 1]
         let device = Default::default();
-        let model = unsqueeze_int_to_shape::Model::<Backend>::new(&device);
+        let model = unsqueeze_int_to_shape::Model::<TestBackend>::new(&device);
 
         // Input: scalar int64 value
         let scalar_value = 42i64;
@@ -70,12 +70,12 @@ mod tests {
         // This verifies that the squeeze/unsqueeze operations are symmetric and maintain
         // type consistency for shape manipulation patterns common in ONNX models
         let device = Default::default();
-        let model = squeeze_unsqueeze_roundtrip::Model::<Backend>::new(&device);
+        let model = squeeze_unsqueeze_roundtrip::Model::<TestBackend>::new(&device);
 
         // Input: 1D tensor with a value
         let input_value = 256i64;
         let input_tensor =
-            Tensor::<Backend, 1, burn::tensor::Int>::from_data([input_value], &device);
+            Tensor::<TestBackend, 1, burn::tensor::Int>::from_data([input_value], &device);
 
         // The roundtrip should preserve the value
         let output_tensor = model.forward(input_tensor.clone());

--- a/crates/burn-import/onnx-tests/tests/where_op/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/where_op/mod.rs
@@ -16,12 +16,12 @@ mod tests {
     use super::*;
     use burn::tensor::{Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn where_op() {
         let device = Default::default();
-        let model: where_op::Model<Backend> = where_op::Model::new(&device);
+        let model: where_op::Model<TestBackend> = where_op::Model::new(&device);
 
         let x = Tensor::ones([2, 2], &device);
         let y = Tensor::zeros([2, 2], &device);
@@ -36,7 +36,7 @@ mod tests {
     #[test]
     fn where_op_broadcast() {
         let device = Default::default();
-        let model: where_op_broadcast::Model<Backend> = where_op_broadcast::Model::new(&device);
+        let model: where_op_broadcast::Model<TestBackend> = where_op_broadcast::Model::new(&device);
 
         let x = Tensor::ones([2], &device);
         let y = Tensor::zeros([2], &device);
@@ -51,7 +51,7 @@ mod tests {
     #[test]
     fn where_op_scalar_x() {
         let device = Default::default();
-        let model: where_op_scalar_x::Model<Backend> = where_op_scalar_x::Model::new(&device);
+        let model: where_op_scalar_x::Model<TestBackend> = where_op_scalar_x::Model::new(&device);
 
         let x = 1.0f32;
         let y = Tensor::zeros([2, 2], &device);
@@ -66,7 +66,7 @@ mod tests {
     #[test]
     fn where_op_scalar_y() {
         let device = Default::default();
-        let model: where_op_scalar_y::Model<Backend> = where_op_scalar_y::Model::new(&device);
+        let model: where_op_scalar_y::Model<TestBackend> = where_op_scalar_y::Model::new(&device);
 
         let x = Tensor::ones([2, 2], &device);
         let y = 0.0f32;
@@ -81,7 +81,7 @@ mod tests {
     #[test]
     fn where_op_all_scalar() {
         let device = Default::default();
-        let model: where_op_all_scalar::Model<Backend> = where_op_all_scalar::Model::new(&device);
+        let model: where_op_all_scalar::Model<TestBackend> = where_op_all_scalar::Model::new(&device);
 
         let x = 1.0f32;
         let y = 0.0f32;
@@ -96,14 +96,14 @@ mod tests {
     #[test]
     fn where_shape_all_shapes() {
         let device = Default::default();
-        let model: where_shape_all_shapes::Model<Backend> =
+        let model: where_shape_all_shapes::Model<TestBackend> =
             where_shape_all_shapes::Model::new(&device);
 
         // Create input tensors with specific shapes
-        let input1 = Tensor::<Backend, 3>::ones([2, 3, 4], &device);
-        let input2 = Tensor::<Backend, 3>::ones([5, 6, 7], &device);
-        let input3 = Tensor::<Backend, 3>::ones([10, 20, 30], &device);
-        let input4 = Tensor::<Backend, 3>::ones([100, 200, 300], &device);
+        let input1 = Tensor::<TestBackend, 3>::ones([2, 3, 4], &device);
+        let input2 = Tensor::<TestBackend, 3>::ones([5, 6, 7], &device);
+        let input3 = Tensor::<TestBackend, 3>::ones([10, 20, 30], &device);
+        let input4 = Tensor::<TestBackend, 3>::ones([100, 200, 300], &device);
 
         let output = model.forward(input1, input2, input3, input4);
         // Since shapes are different, Equal will return [0, 0, 0]
@@ -116,12 +116,12 @@ mod tests {
     #[test]
     fn where_shape_scalar_cond() {
         let device = Default::default();
-        let model: where_shape_scalar_cond::Model<Backend> =
+        let model: where_shape_scalar_cond::Model<TestBackend> =
             where_shape_scalar_cond::Model::new(&device);
 
         // Create input tensors
-        let input1 = Tensor::<Backend, 3>::ones([2, 3, 4], &device);
-        let input2 = Tensor::<Backend, 3>::ones([5, 6, 7], &device);
+        let input1 = Tensor::<TestBackend, 3>::ones([2, 3, 4], &device);
+        let input2 = Tensor::<TestBackend, 3>::ones([5, 6, 7], &device);
 
         // Test with true condition
         let condition = true;
@@ -139,14 +139,14 @@ mod tests {
     #[test]
     fn where_shapes_from_inputs() {
         let device = Default::default();
-        let model: where_shapes_from_inputs::Model<Backend> =
+        let model: where_shapes_from_inputs::Model<TestBackend> =
             where_shapes_from_inputs::Model::new(&device);
 
         // Create input tensors with shapes [1,2,3], [4,5,6], [7,8,9], and [1,0,3]
-        let input1 = Tensor::<Backend, 3>::ones([1, 2, 3], &device);
-        let input2 = Tensor::<Backend, 3>::ones([4, 5, 6], &device);
-        let input3 = Tensor::<Backend, 3>::ones([7, 8, 9], &device);
-        let input4 = Tensor::<Backend, 3>::ones([1, 0, 3], &device); // Note: The shape matters, not the content
+        let input1 = Tensor::<TestBackend, 3>::ones([1, 2, 3], &device);
+        let input2 = Tensor::<TestBackend, 3>::ones([4, 5, 6], &device);
+        let input3 = Tensor::<TestBackend, 3>::ones([7, 8, 9], &device);
+        let input4 = Tensor::<TestBackend, 3>::ones([1, 0, 3], &device); // Note: The shape matters, not the content
 
         let output = model.forward(input1, input2, input3, input4);
         // Condition is shape1 == shape4 -> [1, 0, 1] (true=1, false=0)

--- a/crates/burn-import/onnx-tests/tests/where_op/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/where_op/mod.rs
@@ -81,7 +81,8 @@ mod tests {
     #[test]
     fn where_op_all_scalar() {
         let device = Default::default();
-        let model: where_op_all_scalar::Model<TestBackend> = where_op_all_scalar::Model::new(&device);
+        let model: where_op_all_scalar::Model<TestBackend> =
+            where_op_all_scalar::Model::new(&device);
 
         let x = 1.0f32;
         let y = 0.0f32;

--- a/crates/burn-import/onnx-tests/tests/xor/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/xor/mod.rs
@@ -7,18 +7,18 @@ mod tests {
     use super::*;
     use burn::tensor::{Bool, Tensor, TensorData};
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     fn xor() {
         let device = Default::default();
-        let model: xor::Model<Backend> = xor::Model::new(&device);
+        let model: xor::Model<TestBackend> = xor::Model::new(&device);
 
-        let input_x = Tensor::<Backend, 4, Bool>::from_bool(
+        let input_x = Tensor::<TestBackend, 4, Bool>::from_bool(
             TensorData::from([[[[false, false, true, true]]]]),
             &device,
         );
-        let input_y = Tensor::<Backend, 4, Bool>::from_bool(
+        let input_y = Tensor::<TestBackend, 4, Bool>::from_bool(
             TensorData::from([[[[false, true, false, true]]]]),
             &device,
         );

--- a/crates/burn-import/pytorch-tests/tests/backend.rs
+++ b/crates/burn-import/pytorch-tests/tests/backend.rs
@@ -1,0 +1,1 @@
+pub type TestBackend = burn_ndarray::NdArray<f32>;

--- a/crates/burn-import/pytorch-tests/tests/batch_norm/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/batch_norm/mod.rs
@@ -24,7 +24,7 @@ impl<B: Backend> Net<B> {
 
 #[cfg(test)]
 mod tests {
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     use burn::{
         record::{FullPrecisionSettings, Recorder},
@@ -41,13 +41,13 @@ mod tests {
             .load("tests/batch_norm/batch_norm2d.pt".into(), &device)
             .expect("Should decode state successfully");
 
-        let model = Net::<Backend>::new(&device).load_record(record);
+        let model = Net::<TestBackend>::new(&device).load_record(record);
 
-        let input = Tensor::<Backend, 4>::ones([1, 5, 2, 2], &device) - 0.3;
+        let input = Tensor::<TestBackend, 4>::ones([1, 5, 2, 2], &device) - 0.3;
 
         let output = model.forward(input);
 
-        let expected = Tensor::<Backend, 4>::from_data(
+        let expected = Tensor::<TestBackend, 4>::from_data(
             [[
                 [[0.68515635, 0.68515635], [0.68515635, 0.68515635]],
                 [[0.68515635, 0.68515635], [0.68515635, 0.68515635]],

--- a/crates/burn-import/pytorch-tests/tests/batch_norm/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/batch_norm/mod.rs
@@ -24,7 +24,7 @@ impl<B: Backend> Net<B> {
 
 #[cfg(test)]
 mod tests {
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     use burn::{
         record::{FullPrecisionSettings, Recorder},

--- a/crates/burn-import/pytorch-tests/tests/boolean/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/boolean/mod.rs
@@ -33,7 +33,7 @@ mod tests {
 
     use super::*;
 
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     #[test]
     #[ignore = "It appears loading boolean tensors are not supported yet"]

--- a/crates/burn-import/pytorch-tests/tests/boolean/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/boolean/mod.rs
@@ -33,7 +33,7 @@ mod tests {
 
     use super::*;
 
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     #[test]
     #[ignore = "It appears loading boolean tensors are not supported yet"]
@@ -44,14 +44,16 @@ mod tests {
             .load("tests/boolean/boolean.pt".into(), &device)
             .expect("Should decode state successfully");
 
-        let model = Net::<Backend>::new_with(record);
+        let model = Net::<TestBackend>::new_with(record);
 
-        let input = Tensor::<Backend, 2>::ones([3, 3], &device);
+        let input = Tensor::<TestBackend, 2>::ones([3, 3], &device);
 
         let output = model.forward(input);
 
-        let expected =
-            Tensor::<Backend, 1, Bool>::from_bool(TensorData::from([true, false, true]), &device);
+        let expected = Tensor::<TestBackend, 1, Bool>::from_bool(
+            TensorData::from([true, false, true]),
+            &device,
+        );
 
         assert_eq!(output.to_data(), expected.to_data());
     }

--- a/crates/burn-import/pytorch-tests/tests/buffer/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/buffer/mod.rs
@@ -24,7 +24,7 @@ impl<B: Backend> Net<B> {
 
 #[cfg(test)]
 mod tests {
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     use burn::{
         record::{FullPrecisionSettings, Recorder},
@@ -41,13 +41,13 @@ mod tests {
             .load("tests/buffer/buffer.pt".into(), &device)
             .expect("Should decode state successfully");
 
-        let model = Net::<Backend>::new_with(record);
+        let model = Net::<TestBackend>::new_with(record);
 
-        let input = Tensor::<Backend, 2>::ones([3, 3], &device);
+        let input = Tensor::<TestBackend, 2>::ones([3, 3], &device);
 
         let output = model.forward(input);
 
-        let expected = Tensor::<Backend, 2>::ones([3, 3], &device) * 2.0;
+        let expected = Tensor::<TestBackend, 2>::ones([3, 3], &device) * 2.0;
 
         output
             .to_data()

--- a/crates/burn-import/pytorch-tests/tests/buffer/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/buffer/mod.rs
@@ -24,7 +24,7 @@ impl<B: Backend> Net<B> {
 
 #[cfg(test)]
 mod tests {
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     use burn::{
         record::{FullPrecisionSettings, Recorder},

--- a/crates/burn-import/pytorch-tests/tests/conv1d/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/conv1d/mod.rs
@@ -29,22 +29,22 @@ impl<B: Backend> Net<B> {
 
 #[cfg(test)]
 mod tests {
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
     use burn::{
         record::{FullPrecisionSettings, HalfPrecisionSettings, Recorder},
         tensor::{Tolerance, ops::FloatElem},
     };
     use burn_import::pytorch::PyTorchFileRecorder;
-    type FT = FloatElem<Backend>;
+    type FT = FloatElem<TestBackend>;
 
     use super::*;
 
-    fn conv1d(record: NetRecord<Backend>, precision: f32) {
+    fn conv1d(record: NetRecord<TestBackend>, precision: f32) {
         let device = Default::default();
 
-        let model = Net::<Backend>::init(&device).load_record(record);
+        let model = Net::<TestBackend>::init(&device).load_record(record);
 
-        let input = Tensor::<Backend, 3>::from_data(
+        let input = Tensor::<TestBackend, 3>::from_data(
             [[
                 [
                     0.93708336, 0.65559506, 0.31379688, 0.19801933, 0.41619217, 0.28432965,
@@ -63,7 +63,7 @@ mod tests {
 
         let output = model.forward(input);
 
-        let expected = Tensor::<Backend, 3>::from_data(
+        let expected = Tensor::<TestBackend, 3>::from_data(
             [[
                 [0.02987457, 0.03134188, 0.04234261, -0.02437721],
                 [-0.03788019, -0.02972012, -0.00806090, -0.01981254],

--- a/crates/burn-import/pytorch-tests/tests/conv1d/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/conv1d/mod.rs
@@ -29,7 +29,7 @@ impl<B: Backend> Net<B> {
 
 #[cfg(test)]
 mod tests {
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     use burn::{
         record::{FullPrecisionSettings, HalfPrecisionSettings, Recorder},
         tensor::{Tolerance, ops::FloatElem},

--- a/crates/burn-import/pytorch-tests/tests/conv2d/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/conv2d/mod.rs
@@ -31,7 +31,7 @@ impl<B: Backend> Net<B> {
 
 #[cfg(test)]
 mod tests {
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     use burn::{
         record::{FullPrecisionSettings, HalfPrecisionSettings, Recorder},

--- a/crates/burn-import/pytorch-tests/tests/conv2d/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/conv2d/mod.rs
@@ -31,7 +31,7 @@ impl<B: Backend> Net<B> {
 
 #[cfg(test)]
 mod tests {
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     use burn::{
         record::{FullPrecisionSettings, HalfPrecisionSettings, Recorder},
@@ -41,12 +41,12 @@ mod tests {
 
     use super::*;
 
-    fn conv2d(record: NetRecord<Backend>, precision: f32) {
+    fn conv2d(record: NetRecord<TestBackend>, precision: f32) {
         let device = Default::default();
 
-        let model = Net::<Backend>::init(&device).load_record(record);
+        let model = Net::<TestBackend>::init(&device).load_record(record);
 
-        let input = Tensor::<Backend, 4>::from_data(
+        let input = Tensor::<TestBackend, 4>::from_data(
             [[
                 [
                     [
@@ -92,7 +92,7 @@ mod tests {
 
         let output = model.forward(input);
 
-        let expected = Tensor::<Backend, 4>::from_data(
+        let expected = Tensor::<TestBackend, 4>::from_data(
             [[
                 [
                     [-0.02502128, 0.00250649, 0.04841233],

--- a/crates/burn-import/pytorch-tests/tests/conv_transpose1d/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/conv_transpose1d/mod.rs
@@ -29,7 +29,7 @@ impl<B: Backend> Net<B> {
 
 #[cfg(test)]
 mod tests {
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     use burn::{
         record::{FullPrecisionSettings, HalfPrecisionSettings, Recorder},

--- a/crates/burn-import/pytorch-tests/tests/conv_transpose1d/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/conv_transpose1d/mod.rs
@@ -29,7 +29,7 @@ impl<B: Backend> Net<B> {
 
 #[cfg(test)]
 mod tests {
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     use burn::{
         record::{FullPrecisionSettings, HalfPrecisionSettings, Recorder},
@@ -39,19 +39,19 @@ mod tests {
 
     use super::*;
 
-    fn conv_transpose1d(record: NetRecord<Backend>, precision: f32) {
+    fn conv_transpose1d(record: NetRecord<TestBackend>, precision: f32) {
         let device = Default::default();
 
-        let model = Net::<Backend>::init(&device).load_record(record);
+        let model = Net::<TestBackend>::init(&device).load_record(record);
 
-        let input = Tensor::<Backend, 3>::from_data(
+        let input = Tensor::<TestBackend, 3>::from_data(
             [[[0.93708336, 0.65559506], [0.31379688, 0.19801933]]],
             &device,
         );
 
         let output = model.forward(input);
 
-        let expected = Tensor::<Backend, 3>::from_data(
+        let expected = Tensor::<TestBackend, 3>::from_data(
             [[
                 [0.02935525, 0.01119324, -0.01356167, -0.00682688],
                 [0.01644749, -0.01429807, 0.00083987, 0.00279229],

--- a/crates/burn-import/pytorch-tests/tests/conv_transpose2d/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/conv_transpose2d/mod.rs
@@ -29,7 +29,7 @@ impl<B: Backend> Net<B> {
 
 #[cfg(test)]
 mod tests {
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     use burn::{
         record::{FullPrecisionSettings, HalfPrecisionSettings, Recorder},
@@ -39,12 +39,12 @@ mod tests {
 
     use super::*;
 
-    fn conv_transpose2d(record: NetRecord<Backend>, precision: f32) {
+    fn conv_transpose2d(record: NetRecord<TestBackend>, precision: f32) {
         let device = Default::default();
 
-        let model = Net::<Backend>::init(&device).load_record(record);
+        let model = Net::<TestBackend>::init(&device).load_record(record);
 
-        let input = Tensor::<Backend, 4>::from_data(
+        let input = Tensor::<TestBackend, 4>::from_data(
             [[
                 [[0.024_595_8, 0.25883394], [0.93905586, 0.416_715_5]],
                 [[0.713_979_7, 0.267_644_3], [0.990_609, 0.28845078]],
@@ -54,7 +54,7 @@ mod tests {
 
         let output = model.forward(input);
 
-        let expected = Tensor::<Backend, 4>::from_data(
+        let expected = Tensor::<TestBackend, 4>::from_data(
             [[
                 [
                     [0.04547675, 0.01879685, -0.01636661, 0.00310803],

--- a/crates/burn-import/pytorch-tests/tests/conv_transpose2d/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/conv_transpose2d/mod.rs
@@ -29,7 +29,7 @@ impl<B: Backend> Net<B> {
 
 #[cfg(test)]
 mod tests {
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     use burn::{
         record::{FullPrecisionSettings, HalfPrecisionSettings, Recorder},

--- a/crates/burn-import/pytorch-tests/tests/embedding/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/embedding/mod.rs
@@ -24,7 +24,7 @@ impl<B: Backend> Net<B> {
 
 #[cfg(test)]
 mod tests {
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     use burn::{
         record::{FullPrecisionSettings, HalfPrecisionSettings, Recorder},
         tensor::Tolerance,

--- a/crates/burn-import/pytorch-tests/tests/embedding/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/embedding/mod.rs
@@ -24,7 +24,7 @@ impl<B: Backend> Net<B> {
 
 #[cfg(test)]
 mod tests {
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
     use burn::{
         record::{FullPrecisionSettings, HalfPrecisionSettings, Recorder},
         tensor::Tolerance,
@@ -33,16 +33,16 @@ mod tests {
 
     use super::*;
 
-    fn embedding(record: NetRecord<Backend>, precision: f32) {
+    fn embedding(record: NetRecord<TestBackend>, precision: f32) {
         let device = Default::default();
 
-        let model = Net::<Backend>::init(&device).load_record(record);
+        let model = Net::<TestBackend>::init(&device).load_record(record);
 
-        let input = Tensor::<Backend, 2, Int>::from_data([[1, 2, 4, 5], [4, 3, 2, 9]], &device);
+        let input = Tensor::<TestBackend, 2, Int>::from_data([[1, 2, 4, 5], [4, 3, 2, 9]], &device);
 
         let output = model.forward(input);
 
-        let expected = Tensor::<Backend, 3>::from_data(
+        let expected = Tensor::<TestBackend, 3>::from_data(
             [
                 [
                     [-1.609_484_9, -0.10016718, -0.609_188_9],

--- a/crates/burn-import/pytorch-tests/tests/enum_module/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/enum_module/mod.rs
@@ -60,14 +60,14 @@ impl<B: Backend> Net<B> {
 
 #[cfg(test)]
 mod tests {
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     use burn::{
         record::{FullPrecisionSettings, Recorder},
         tensor::{Tolerance, ops::FloatElem},
     };
     use burn_import::pytorch::{LoadArgs, PyTorchFileRecorder};
-    type FT = FloatElem<Backend>;
+    type FT = FloatElem<TestBackend>;
 
     use super::*;
 
@@ -81,8 +81,8 @@ mod tests {
             .load(load_args, &device)
             .expect("Should decode state successfully");
 
-        let model = Net::<Backend>::new_with(record);
-        let input = Tensor::<Backend, 4>::from_data(
+        let model = Net::<TestBackend>::new_with(record);
+        let input = Tensor::<TestBackend, 4>::from_data(
             [[
                 [
                     [0.713_979_7, 0.267_644_3, 0.990_609, 0.28845078, 0.874_962_4],
@@ -116,7 +116,7 @@ mod tests {
 
         let output = model.forward(input);
 
-        let expected = Tensor::<Backend, 4>::from_data(
+        let expected = Tensor::<TestBackend, 4>::from_data(
             [[
                 [
                     [0.35449377, -0.02832414, 0.490_976_1],
@@ -147,9 +147,9 @@ mod tests {
             .load(load_args, &device)
             .expect("Should decode state successfully");
 
-        let model = Net::<Backend>::new_with(record);
+        let model = Net::<TestBackend>::new_with(record);
 
-        let input = Tensor::<Backend, 4>::from_data(
+        let input = Tensor::<TestBackend, 4>::from_data(
             [[
                 [
                     [0.713_979_7, 0.267_644_3, 0.990_609, 0.28845078, 0.874_962_4],
@@ -183,7 +183,7 @@ mod tests {
 
         let output = model.forward(input);
 
-        let expected = Tensor::<Backend, 4>::from_data(
+        let expected = Tensor::<TestBackend, 4>::from_data(
             [[
                 [
                     [0.77874625, 0.859_017_6, 0.834_283_5],

--- a/crates/burn-import/pytorch-tests/tests/enum_module/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/enum_module/mod.rs
@@ -60,7 +60,7 @@ impl<B: Backend> Net<B> {
 
 #[cfg(test)]
 mod tests {
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     use burn::{
         record::{FullPrecisionSettings, Recorder},

--- a/crates/burn-import/pytorch-tests/tests/group_norm/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/group_norm/mod.rs
@@ -24,7 +24,7 @@ impl<B: Backend> Net<B> {
 
 #[cfg(test)]
 mod tests {
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     use burn::record::{FullPrecisionSettings, HalfPrecisionSettings, Recorder};
     use burn::tensor::Tolerance;
     use burn_import::pytorch::PyTorchFileRecorder;

--- a/crates/burn-import/pytorch-tests/tests/group_norm/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/group_norm/mod.rs
@@ -24,19 +24,19 @@ impl<B: Backend> Net<B> {
 
 #[cfg(test)]
 mod tests {
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
     use burn::record::{FullPrecisionSettings, HalfPrecisionSettings, Recorder};
     use burn::tensor::Tolerance;
     use burn_import::pytorch::PyTorchFileRecorder;
 
     use super::*;
 
-    fn group_norm(record: NetRecord<Backend>, precision: f32) {
+    fn group_norm(record: NetRecord<TestBackend>, precision: f32) {
         let device = Default::default();
 
-        let model = Net::<Backend>::init(&device).load_record(record);
+        let model = Net::<TestBackend>::init(&device).load_record(record);
 
-        let input = Tensor::<Backend, 4>::from_data(
+        let input = Tensor::<TestBackend, 4>::from_data(
             [[
                 [[0.757_631_6, 0.27931088], [0.40306926, 0.73468447]],
                 [[0.02928156, 0.799_858_6], [0.39713734, 0.75437194]],
@@ -50,7 +50,7 @@ mod tests {
 
         let output = model.forward(input);
 
-        let expected = Tensor::<Backend, 4>::from_data(
+        let expected = Tensor::<TestBackend, 4>::from_data(
             [[
                 [[1.042_578_5, -1.122_016_7], [-0.56195974, 0.938_733_6]],
                 [[-2.253_500_7, 1.233_672_9], [-0.588_804_1, 1.027_827_3]],

--- a/crates/burn-import/pytorch-tests/tests/integer/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/integer/mod.rs
@@ -24,7 +24,7 @@ impl<B: Backend> Net<B> {
 
 #[cfg(test)]
 mod tests {
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
     use burn::{
         record::{FullPrecisionSettings, HalfPrecisionSettings, Recorder},
         tensor::TensorData,

--- a/crates/burn-import/pytorch-tests/tests/integer/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/integer/mod.rs
@@ -24,7 +24,7 @@ impl<B: Backend> Net<B> {
 
 #[cfg(test)]
 mod tests {
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
     use burn::{
         record::{FullPrecisionSettings, HalfPrecisionSettings, Recorder},
         tensor::TensorData,
@@ -33,16 +33,17 @@ mod tests {
 
     use super::*;
 
-    fn integer(record: NetRecord<Backend>, _precision: usize) {
+    fn integer(record: NetRecord<TestBackend>, _precision: usize) {
         let device = Default::default();
 
-        let model = Net::<Backend>::new_with(record);
+        let model = Net::<TestBackend>::new_with(record);
 
-        let input = Tensor::<Backend, 2>::ones([3, 3], &device);
+        let input = Tensor::<TestBackend, 2>::ones([3, 3], &device);
 
         let output = model.forward(input);
 
-        let expected = Tensor::<Backend, 1, Int>::from_data(TensorData::from([1, 2, 3]), &device);
+        let expected =
+            Tensor::<TestBackend, 1, Int>::from_data(TensorData::from([1, 2, 3]), &device);
 
         assert_eq!(output.to_data(), expected.to_data());
     }

--- a/crates/burn-import/pytorch-tests/tests/key_remap/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/key_remap/mod.rs
@@ -30,12 +30,12 @@ impl<B: Backend> Net<B> {
 
 #[cfg(test)]
 mod tests {
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     use burn::record::{FullPrecisionSettings, Recorder};
     use burn::tensor::{Tolerance, ops::FloatElem};
     use burn_import::pytorch::{LoadArgs, PyTorchFileRecorder};
-    type FT = FloatElem<Backend>;
+    type FT = FloatElem<TestBackend>;
 
     use super::*;
 
@@ -50,9 +50,9 @@ mod tests {
             .load(load_args, &device)
             .expect("Should decode state successfully");
 
-        let model = Net::<Backend>::init(&device).load_record(record);
+        let model = Net::<TestBackend>::init(&device).load_record(record);
 
-        let input = Tensor::<Backend, 4>::from_data(
+        let input = Tensor::<TestBackend, 4>::from_data(
             [[
                 [
                     [
@@ -98,7 +98,7 @@ mod tests {
 
         let output = model.forward(input);
 
-        let expected = Tensor::<Backend, 4>::from_data(
+        let expected = Tensor::<TestBackend, 4>::from_data(
             [[
                 [
                     [-0.02502128, 0.00250649, 0.04841233],

--- a/crates/burn-import/pytorch-tests/tests/key_remap/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/key_remap/mod.rs
@@ -30,7 +30,7 @@ impl<B: Backend> Net<B> {
 
 #[cfg(test)]
 mod tests {
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     use burn::record::{FullPrecisionSettings, Recorder};
     use burn::tensor::{Tolerance, ops::FloatElem};

--- a/crates/burn-import/pytorch-tests/tests/key_remap_chained/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/key_remap_chained/mod.rs
@@ -95,13 +95,13 @@ impl<B: Backend> Model<B, ConvBlock<B>> {
 
 #[cfg(test)]
 mod tests {
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     use burn::record::{FullPrecisionSettings, Recorder};
     use burn_import::pytorch::{LoadArgs, PyTorchFileRecorder};
 
     use burn::tensor::{Tolerance, ops::FloatElem};
-    type FT = FloatElem<Backend>;
+    type FT = FloatElem<TestBackend>;
 
     use super::*;
 
@@ -120,7 +120,7 @@ mod tests {
             .load(load_args, &device)
             .expect("Should decode state successfully");
 
-        let model: Model<Backend, _> = Model::new(&device);
+        let model: Model<TestBackend, _> = Model::new(&device);
 
         model.load_record(record);
     }
@@ -140,11 +140,11 @@ mod tests {
             .load(load_args, &device)
             .expect("Should decode state successfully");
 
-        let model: Model<Backend, _> = Model::new(&device);
+        let model: Model<TestBackend, _> = Model::new(&device);
 
         let model = model.load_record(record);
 
-        let input = Tensor::<Backend, 4>::from_data(
+        let input = Tensor::<TestBackend, 4>::from_data(
             [[
                 [
                     [0.76193494, 0.626_546_1, 0.49510366, 0.11974698],
@@ -167,7 +167,7 @@ mod tests {
             ]],
             &device,
         );
-        let expected = Tensor::<Backend, 4>::from_data(
+        let expected = Tensor::<TestBackend, 4>::from_data(
             [[
                 [[0.198_967_1, 0.17847246], [0.06883702, 0.20012866]],
                 [[0.17582723, 0.11344293], [0.05444185, 0.13307181]],

--- a/crates/burn-import/pytorch-tests/tests/key_remap_chained/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/key_remap_chained/mod.rs
@@ -95,7 +95,7 @@ impl<B: Backend> Model<B, ConvBlock<B>> {
 
 #[cfg(test)]
 mod tests {
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     use burn::record::{FullPrecisionSettings, Recorder};
     use burn_import::pytorch::{LoadArgs, PyTorchFileRecorder};

--- a/crates/burn-import/pytorch-tests/tests/layer_norm/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/layer_norm/mod.rs
@@ -24,21 +24,21 @@ impl<B: Backend> Net<B> {
 
 #[cfg(test)]
 mod tests {
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     use burn::record::{FullPrecisionSettings, HalfPrecisionSettings, Recorder};
     use burn::tensor::{Tolerance, ops::FloatElem};
     use burn_import::pytorch::PyTorchFileRecorder;
-    type FT = FloatElem<Backend>;
+    type FT = FloatElem<TestBackend>;
 
     use super::*;
 
-    fn layer_norm(record: NetRecord<Backend>, precision: f32) {
+    fn layer_norm(record: NetRecord<TestBackend>, precision: f32) {
         let device = Default::default();
 
-        let model = Net::<Backend>::init(&device).load_record(record);
+        let model = Net::<TestBackend>::init(&device).load_record(record);
 
-        let input = Tensor::<Backend, 4>::from_data(
+        let input = Tensor::<TestBackend, 4>::from_data(
             [[
                 [[0.757_631_6, 0.27931088], [0.40306926, 0.73468447]],
                 [[0.02928156, 0.799_858_6], [0.39713734, 0.75437194]],
@@ -48,7 +48,7 @@ mod tests {
 
         let output = model.forward(input);
 
-        let expected = Tensor::<Backend, 4>::from_data(
+        let expected = Tensor::<TestBackend, 4>::from_data(
             [[
                 [[0.99991274, -0.999_912_5], [-0.999_818_3, 0.999_818_3]],
                 [[-0.999_966_2, 0.99996626], [-0.99984336, 0.99984336]],

--- a/crates/burn-import/pytorch-tests/tests/layer_norm/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/layer_norm/mod.rs
@@ -24,7 +24,7 @@ impl<B: Backend> Net<B> {
 
 #[cfg(test)]
 mod tests {
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     use burn::record::{FullPrecisionSettings, HalfPrecisionSettings, Recorder};
     use burn::tensor::{Tolerance, ops::FloatElem};

--- a/crates/burn-import/pytorch-tests/tests/linear/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/linear/mod.rs
@@ -51,7 +51,7 @@ impl<B: Backend> NetWithBias<B> {
 
 #[cfg(test)]
 mod tests {
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     use burn::record::{FullPrecisionSettings, HalfPrecisionSettings, Recorder};
     use burn::tensor::{Tolerance, ops::FloatElem};

--- a/crates/burn-import/pytorch-tests/tests/linear/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/linear/mod.rs
@@ -51,20 +51,20 @@ impl<B: Backend> NetWithBias<B> {
 
 #[cfg(test)]
 mod tests {
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     use burn::record::{FullPrecisionSettings, HalfPrecisionSettings, Recorder};
     use burn::tensor::{Tolerance, ops::FloatElem};
     use burn_import::pytorch::PyTorchFileRecorder;
-    type FT = FloatElem<Backend>;
+    type FT = FloatElem<TestBackend>;
 
     use super::*;
 
-    fn linear_test(record: NetRecord<Backend>, precision: f32) {
+    fn linear_test(record: NetRecord<TestBackend>, precision: f32) {
         let device = Default::default();
-        let model = Net::<Backend>::init(&device).load_record(record);
+        let model = Net::<TestBackend>::init(&device).load_record(record);
 
-        let input = Tensor::<Backend, 4>::from_data(
+        let input = Tensor::<TestBackend, 4>::from_data(
             [[
                 [[0.63968194, 0.97427773], [0.830_029_9, 0.04443115]],
                 [[0.024_595_8, 0.25883394], [0.93905586, 0.416_715_5]],
@@ -73,7 +73,7 @@ mod tests {
         );
 
         let output = model.forward(input);
-        let expected = Tensor::<Backend, 4>::from_data(
+        let expected = Tensor::<TestBackend, 4>::from_data(
             [[
                 [
                     [0.09778349, -0.13756673, 0.04962806, 0.08856435],
@@ -119,9 +119,9 @@ mod tests {
             .load("tests/linear/linear_with_bias.pt".into(), &device)
             .expect("Should decode state successfully");
 
-        let model = NetWithBias::<Backend>::init(&device).load_record(record);
+        let model = NetWithBias::<TestBackend>::init(&device).load_record(record);
 
-        let input = Tensor::<Backend, 4>::from_data(
+        let input = Tensor::<TestBackend, 4>::from_data(
             [[
                 [[0.63968194, 0.97427773], [0.830_029_9, 0.04443115]],
                 [[0.024_595_8, 0.25883394], [0.93905586, 0.416_715_5]],
@@ -131,7 +131,7 @@ mod tests {
 
         let output = model.forward(input);
 
-        let expected = Tensor::<Backend, 4>::from_data(
+        let expected = Tensor::<TestBackend, 4>::from_data(
             [[
                 [
                     [-0.00432095, -1.107_101_2, 0.870_691_4],

--- a/crates/burn-import/pytorch-tests/tests/missing_module_field/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/missing_module_field/mod.rs
@@ -7,7 +7,7 @@ pub struct Net<B: Backend> {
 
 #[cfg(test)]
 mod tests {
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     use burn::record::{FullPrecisionSettings, Recorder};
     use burn_import::pytorch::PyTorchFileRecorder;

--- a/crates/burn-import/pytorch-tests/tests/missing_module_field/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/missing_module_field/mod.rs
@@ -7,7 +7,7 @@ pub struct Net<B: Backend> {
 
 #[cfg(test)]
 mod tests {
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     use burn::record::{FullPrecisionSettings, Recorder};
     use burn_import::pytorch::PyTorchFileRecorder;
@@ -20,11 +20,12 @@ mod tests {
     )]
     fn should_fail_if_struct_field_is_missing() {
         let device = Default::default();
-        let _record: NetRecord<Backend> = PyTorchFileRecorder::<FullPrecisionSettings>::default()
-            .load(
-                "tests/missing_module_field/missing_module_field.pt".into(),
-                &device,
-            )
-            .expect("Should decode state successfully");
+        let _record: NetRecord<TestBackend> =
+            PyTorchFileRecorder::<FullPrecisionSettings>::default()
+                .load(
+                    "tests/missing_module_field/missing_module_field.pt".into(),
+                    &device,
+                )
+                .expect("Should decode state successfully");
     }
 }

--- a/crates/burn-import/pytorch-tests/tests/non_contiguous_indexes/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/non_contiguous_indexes/mod.rs
@@ -32,7 +32,7 @@ impl<B: Backend> Net<B> {
 
 #[cfg(test)]
 mod tests {
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     use burn::record::{FullPrecisionSettings, Recorder};
     use burn::tensor::{Tolerance, ops::FloatElem};

--- a/crates/burn-import/pytorch-tests/tests/non_contiguous_indexes/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/non_contiguous_indexes/mod.rs
@@ -32,12 +32,12 @@ impl<B: Backend> Net<B> {
 
 #[cfg(test)]
 mod tests {
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     use burn::record::{FullPrecisionSettings, Recorder};
     use burn::tensor::{Tolerance, ops::FloatElem};
     use burn_import::pytorch::{LoadArgs, PyTorchFileRecorder};
-    type FT = FloatElem<Backend>;
+    type FT = FloatElem<TestBackend>;
 
     use super::*;
 
@@ -52,9 +52,9 @@ mod tests {
             .load(load_args, &device)
             .expect("Should decode state successfully");
 
-        let model = Net::<Backend>::new_with(record);
+        let model = Net::<TestBackend>::new_with(record);
 
-        let input = Tensor::<Backend, 4>::from_data(
+        let input = Tensor::<TestBackend, 4>::from_data(
             [[
                 [
                     [
@@ -82,7 +82,7 @@ mod tests {
 
         let output = model.forward(input);
 
-        let expected = Tensor::<Backend, 4>::from_data(
+        let expected = Tensor::<TestBackend, 4>::from_data(
             [[
                 [
                     [0.00000000, 0.00000000, 0.00000000, 0.00000000, 0.00000000],

--- a/crates/burn-import/pytorch-tests/tests/test_mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/test_mod.rs
@@ -1,3 +1,5 @@
+mod backend;
+
 mod batch_norm;
 mod boolean;
 mod buffer;

--- a/crates/burn-import/pytorch-tests/tests/top_level_key/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/top_level_key/mod.rs
@@ -7,7 +7,7 @@ pub struct Net<B: Backend> {
 
 #[cfg(test)]
 mod tests {
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     use burn::record::{FullPrecisionSettings, Recorder};
     use burn_import::pytorch::{LoadArgs, PyTorchFileRecorder};
@@ -18,7 +18,7 @@ mod tests {
     #[should_panic]
     fn should_fail_if_not_found() {
         let device = Default::default();
-        let _record: NetRecord<Backend> = PyTorchFileRecorder::<FullPrecisionSettings>::default()
+        let _record: NetRecord<TestBackend> = PyTorchFileRecorder::<FullPrecisionSettings>::default()
             .load("tests/top_level_key/top_level_key.pt".into(), &device)
             .expect("Should decode state successfully");
     }
@@ -29,7 +29,7 @@ mod tests {
         let load_args = LoadArgs::new("tests/top_level_key/top_level_key.pt".into())
             .with_top_level_key("my_state_dict");
 
-        let _record: NetRecord<Backend> = PyTorchFileRecorder::<FullPrecisionSettings>::default()
+        let _record: NetRecord<TestBackend> = PyTorchFileRecorder::<FullPrecisionSettings>::default()
             .load(load_args, &device)
             .expect("Should decode state successfully");
     }

--- a/crates/burn-import/pytorch-tests/tests/top_level_key/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/top_level_key/mod.rs
@@ -18,9 +18,10 @@ mod tests {
     #[should_panic]
     fn should_fail_if_not_found() {
         let device = Default::default();
-        let _record: NetRecord<TestBackend> = PyTorchFileRecorder::<FullPrecisionSettings>::default()
-            .load("tests/top_level_key/top_level_key.pt".into(), &device)
-            .expect("Should decode state successfully");
+        let _record: NetRecord<TestBackend> =
+            PyTorchFileRecorder::<FullPrecisionSettings>::default()
+                .load("tests/top_level_key/top_level_key.pt".into(), &device)
+                .expect("Should decode state successfully");
     }
 
     #[test]
@@ -29,8 +30,9 @@ mod tests {
         let load_args = LoadArgs::new("tests/top_level_key/top_level_key.pt".into())
             .with_top_level_key("my_state_dict");
 
-        let _record: NetRecord<TestBackend> = PyTorchFileRecorder::<FullPrecisionSettings>::default()
-            .load(load_args, &device)
-            .expect("Should decode state successfully");
+        let _record: NetRecord<TestBackend> =
+            PyTorchFileRecorder::<FullPrecisionSettings>::default()
+                .load(load_args, &device)
+                .expect("Should decode state successfully");
     }
 }

--- a/crates/burn-import/pytorch-tests/tests/top_level_key/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/top_level_key/mod.rs
@@ -7,7 +7,7 @@ pub struct Net<B: Backend> {
 
 #[cfg(test)]
 mod tests {
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     use burn::record::{FullPrecisionSettings, Recorder};
     use burn_import::pytorch::{LoadArgs, PyTorchFileRecorder};

--- a/crates/burn-import/safetensors-tests/tests/backend.rs
+++ b/crates/burn-import/safetensors-tests/tests/backend.rs
@@ -1,0 +1,1 @@
+pub type TestBackend = burn_ndarray::NdArray<f32>;

--- a/crates/burn-import/safetensors-tests/tests/multi_layer/mod.rs
+++ b/crates/burn-import/safetensors-tests/tests/multi_layer/mod.rs
@@ -40,7 +40,7 @@ impl<B: Backend> Net<B> {
 
 #[cfg(test)]
 mod tests {
-    use crate::backend::Backend;
+    use crate::backend::TestBackend;
 
     use burn::{
         record::{FullPrecisionSettings, Recorder},
@@ -57,14 +57,14 @@ mod tests {
             .load("tests/multi_layer/multi_layer.safetensors".into(), &device)
             .expect("Should decode state successfully");
 
-        let model = Net::<Backend>::new(&device).load_record(record);
+        let model = Net::<TestBackend>::new(&device).load_record(record);
 
-        let input = Tensor::<Backend, 4>::ones([1, 3, 8, 8], &device);
+        let input = Tensor::<TestBackend, 4>::ones([1, 3, 8, 8], &device);
 
         let output = model.forward(input);
 
         // Note: Expected values should be updated based on the actual output from the PyTorch model
-        let expected = Tensor::<Backend, 2>::from_data(
+        let expected = Tensor::<TestBackend, 2>::from_data(
             [[
                 0.04971555,
                 -0.16849735,

--- a/crates/burn-import/safetensors-tests/tests/multi_layer/mod.rs
+++ b/crates/burn-import/safetensors-tests/tests/multi_layer/mod.rs
@@ -40,7 +40,7 @@ impl<B: Backend> Net<B> {
 
 #[cfg(test)]
 mod tests {
-    type Backend = burn_ndarray::NdArray<f32>;
+    use crate::backend::Backend;
 
     use burn::{
         record::{FullPrecisionSettings, Recorder},

--- a/crates/burn-import/safetensors-tests/tests/test_mod.rs
+++ b/crates/burn-import/safetensors-tests/tests/test_mod.rs
@@ -1,1 +1,3 @@
+mod backend;
+
 mod multi_layer;

--- a/crates/burn-import/src/burn/node/resize.rs
+++ b/crates/burn-import/src/burn/node/resize.rs
@@ -244,11 +244,6 @@ impl<PS: PrecisionSettings> NodeCodegen<PS> for ResizeNode {
             } else {
                 panic!("Unsupported input rank for resize node");
             }
-        } else {
-            // Runtime resize - need tensor interpolate function
-            imports.register("burn::tensor::module::interpolate");
-            imports.register("burn::tensor::ops::InterpolateOptions");
-            imports.register("burn::tensor::ops::InterpolateMode");
         }
     }
 


### PR DESCRIPTION
This PR refactors backend selection for ONNX tests and import examples to improve backend flexibility and consistency. The changes replace hardcoded backend type aliases with a centralized backend configuration system that allows switching between different Burn backends via feature flags.

## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

* https://github.com/tracel-ai/burn/issues/3370
* https://github.com/tracel-ai/burn/issues/3583

### Changes
- Removes hardcoded backend type definitions across test files and documentation
- Introduces centralized backend configuration in `backend.rs` supporting WGPU, NdArray, and LibTorch backends
- Updates tolerance values in ONNX linear tests and removes unused import registration code

### Testing

Tests are passing for ndarray and tch but failing due to this error: https://github.com/tracel-ai/burn/issues/3583
