### PR TITLE
Fix/conv2d docs display

### DIFF
--- a/burn-book/src/basic-workflow/model.md
+++ b/burn-book/src/basic-workflow/model.md
@@ -243,8 +243,8 @@ Output:
 
 ```rust , ignore
 Model {
-  conv1: Conv2d {stride: [1, 1], kernel_size: [3, 3], dilation: [1, 1], groups: 1, padding: Valid, params: 80}
-  conv2: Conv2d {stride: [1, 1], kernel_size: [3, 3], dilation: [1, 1], groups: 1, padding: Valid, params: 1168}
+  conv1: Conv2d {ch_in: 1, ch_out: 8, stride: [1, 1], kernel_size: [3, 3], dilation: [1, 1], groups: 1, padding: Valid, params: 80}
+  conv2: Conv2d {ch_in: 8, ch_out: 16, stride: [1, 1], kernel_size: [3, 3], dilation: [1, 1], groups: 1, padding: Valid, params: 1168}
   pool: AdaptiveAvgPool2d {output_size: [8, 8]}
   dropout: Dropout {prob: 0.5}
   linear1: Linear {d_input: 1024, d_output: 512, bias: true, params: 524800}

--- a/crates/burn-core/src/nn/conv/conv1d.rs
+++ b/crates/burn-core/src/nn/conv/conv1d.rs
@@ -74,19 +74,31 @@ impl<B: Backend> ModuleDisplay for Conv1d<B> {
     }
 
     fn custom_content(&self, content: Content) -> Option<Content> {
-        // Since padding does not implement ModuleDisplay, we need to format it manually.
-        let padding_formatted = format!("{}", &self.padding);
+    // Format padding
+    let padding_formatted = format!("{}", &self.padding);
 
-        content
-            .add("stride", &self.stride)
-            .add("kernel_size", &self.kernel_size)
-            .add("dilation", &self.dilation)
-            .add("groups", &self.groups)
-            .add("padding", &padding_formatted)
-            .optional()
-    }
+    // Format stride/dilation as strings
+    let stride = format!("{:?}", self.stride);
+    let kernel_size = format!("{:?}", self.kernel_size);
+    let dilation = format!("{:?}", self.dilation);
+
+    // Extract channels in/out from weight dims
+    let [channels_out, group_channels_in, _] = self.weight.dims();
+    let channels_in = group_channels_in * self.groups;
+    let ch_out = format!("{:?}", channels_out);
+    let ch_in = format!("{:?}", channels_in);
+
+    content
+        .add("ch_in", &ch_in)
+        .add("ch_out", &ch_out)
+        .add("stride", &stride)
+        .add("kernel_size", &kernel_size)
+        .add("dilation", &dilation)
+        .add("groups", &self.groups)
+        .add("padding", &padding_formatted)
+        .optional()
+   }
 }
-
 impl Conv1dConfig {
     /// Initialize a new [conv1d](Conv1d) module.
     pub fn init<B: Backend>(&self, device: &B::Device) -> Conv1d<B> {
@@ -195,14 +207,14 @@ mod tests {
 
     #[test]
     fn display() {
-        let config = Conv1dConfig::new(5, 5, 5);
-        let conv = config.init::<TestBackend>(&Default::default());
+    let config = Conv1dConfig::new(5, 5, 5);
+    let conv = config.init::<TestBackend>(&Default::default());
 
-        assert_eq!(
-            alloc::format!("{conv}"),
-            "Conv1d {stride: 1, kernel_size: 5, dilation: 1, groups: 1, padding: Valid, params: 130}"
-        );
-    }
+    assert_eq!(
+        alloc::format!("{conv}"),
+        "Conv1d {ch_in: 5, ch_out: 5, stride: 1, kernel_size: 5, dilation: 1, groups: 1, padding: Valid, params: 130}"
+    );
+}
 
     #[test]
     #[should_panic = "Number of channels in input tensor and input channels of convolution must be equal. got: 4, expected: 5"]

--- a/crates/burn-core/src/nn/conv/conv1d.rs
+++ b/crates/burn-core/src/nn/conv/conv1d.rs
@@ -74,30 +74,30 @@ impl<B: Backend> ModuleDisplay for Conv1d<B> {
     }
 
     fn custom_content(&self, content: Content) -> Option<Content> {
-    // Format padding
-    let padding_formatted = format!("{}", &self.padding);
+        // Format padding
+        let padding_formatted = format!("{}", &self.padding);
 
-    // Format stride/dilation as strings
-    let stride = format!("{:?}", self.stride);
-    let kernel_size = format!("{:?}", self.kernel_size);
-    let dilation = format!("{:?}", self.dilation);
+        // Format stride/dilation as strings
+        let stride = format!("{:?}", self.stride);
+        let kernel_size = format!("{:?}", self.kernel_size);
+        let dilation = format!("{:?}", self.dilation);
 
-    // Extract channels in/out from weight dims
-    let [channels_out, group_channels_in, _] = self.weight.dims();
-    let channels_in = group_channels_in * self.groups;
-    let ch_out = format!("{:?}", channels_out);
-    let ch_in = format!("{:?}", channels_in);
+        // Extract channels in/out from weight dims
+        let [channels_out, group_channels_in, _] = self.weight.dims();
+        let channels_in = group_channels_in * self.groups;
+        let ch_out = format!("{:?}", channels_out);
+        let ch_in = format!("{:?}", channels_in);
 
-    content
-        .add("ch_in", &ch_in)
-        .add("ch_out", &ch_out)
-        .add("stride", &stride)
-        .add("kernel_size", &kernel_size)
-        .add("dilation", &dilation)
-        .add("groups", &self.groups)
-        .add("padding", &padding_formatted)
-        .optional()
-   }
+        content
+            .add("ch_in", &ch_in)
+            .add("ch_out", &ch_out)
+            .add("stride", &stride)
+            .add("kernel_size", &kernel_size)
+            .add("dilation", &dilation)
+            .add("groups", &self.groups)
+            .add("padding", &padding_formatted)
+            .optional()
+    }
 }
 impl Conv1dConfig {
     /// Initialize a new [conv1d](Conv1d) module.
@@ -207,14 +207,14 @@ mod tests {
 
     #[test]
     fn display() {
-    let config = Conv1dConfig::new(5, 5, 5);
-    let conv = config.init::<TestBackend>(&Default::default());
+        let config = Conv1dConfig::new(5, 5, 5);
+        let conv = config.init::<TestBackend>(&Default::default());
 
-    assert_eq!(
-        alloc::format!("{conv}"),
-        "Conv1d {ch_in: 5, ch_out: 5, stride: 1, kernel_size: 5, dilation: 1, groups: 1, padding: Valid, params: 130}"
-    );
-}
+        assert_eq!(
+            alloc::format!("{conv}"),
+            "Conv1d {ch_in: 5, ch_out: 5, stride: 1, kernel_size: 5, dilation: 1, groups: 1, padding: Valid, params: 130}"
+        );
+    }
 
     #[test]
     #[should_panic = "Number of channels in input tensor and input channels of convolution must be equal. got: 4, expected: 5"]

--- a/crates/burn-core/src/nn/conv/conv2d.rs
+++ b/crates/burn-core/src/nn/conv/conv2d.rs
@@ -163,7 +163,7 @@ impl<B: Backend> ModuleDisplay for Conv2d<B> {
 impl<B: Backend> Conv2d<B> {
     /// Applies the forward pass on the input tensor.
     ///
-    /// See [`conv2d`] for more information.
+    /// See [conv2d](crate::tensor::module::conv2d) for more information.
     ///
     /// # Shapes
     /// - `input`: `[batch_size, channels_in, height_in, width_in]`

--- a/crates/burn-core/src/nn/conv/conv2d.rs
+++ b/crates/burn-core/src/nn/conv/conv2d.rs
@@ -114,22 +114,6 @@ impl Conv2dConfig {
 }
 
 impl<B: Backend> ModuleDisplay for Conv2d<B> {
-    /// # Example
-    /// ```rust
-    /// # #[cfg(feature = "ndarray")]
-    /// # {
-    /// use burn::backend::ndarray::NdArray;
-    /// use burn::nn::conv::Conv2dConfig;
-    ///
-    /// let device = Default::default();
-    /// let conv = Conv2dConfig::new([3, 8], [3, 3]).init::<NdArray>(&device);
-    ///
-    /// // Print Conv2d layer information using Display
-    /// println!("{}", conv);
-    /// # }
-    /// # #[cfg(not(feature = "ndarray"))]
-    /// # fn main() {}
-    /// ```
     fn custom_settings(&self) -> Option<DisplaySettings> {
         DisplaySettings::new()
             .with_new_line_after_attribute(false)
@@ -144,8 +128,8 @@ impl<B: Backend> ModuleDisplay for Conv2d<B> {
         let stride = format!("{:?}", self.stride);
         let kernel_size = format!("{:?}", self.kernel_size);
         let dilation = format!("{:?}", self.dilation);
-        let [channels_out, group_channels_in, _kernel_size, __kernel_size] = self.weight.dims();
-        let channels_in = group_channels_in * &self.groups;
+        let [channels_out, group_channels_in, _, _] = self.weight.dims();
+        let channels_in = group_channels_in * self.groups;
         let ch_out = format!("{:?}", channels_out);
         let ch_in = format!("{:?}", channels_in);
         content
@@ -170,9 +154,7 @@ impl<B: Backend> Conv2d<B> {
     /// - `output`: `[batch_size, channels_out, height_out, width_out]`
     ///
     /// # Example
-    /// ```rust
-    /// # #[cfg(feature = "ndarray")]
-    /// # {
+    /// ```rust,ignore
     /// use burn::backend::ndarray::NdArray;
     /// use burn::nn::conv::Conv2dConfig;
     /// use burn::tensor::Tensor;
@@ -180,17 +162,10 @@ impl<B: Backend> Conv2d<B> {
     /// let device = Default::default();
     /// let conv = Conv2dConfig::new([3, 8], [3, 3]).init::<NdArray>(&device);
     ///
-    /// // Fake input: [batch=1, channels=3, height=28, width=28]
     /// let x = Tensor::<NdArray, 4>::zeros([1, 3, 28, 28], &device);
-    ///
-    /// // Apply convolution
     /// let y = conv.forward(x);
     ///
-    /// // Output shape: [1, 8, 26, 26]
-    /// println!("{:?}", y.dims());
-    /// # }
-    /// # #[cfg(not(feature = "ndarray"))]
-    /// # fn main() {}
+    /// println!("{:?}", y.dims()); // [1, 8, 26, 26]
     /// ```
     pub fn forward(&self, input: Tensor<B, 4>) -> Tensor<B, 4> {
         let [_batch_size, _channels_in, height_in, width_in] = input.dims();

--- a/crates/burn-core/src/nn/conv/conv2d.rs
+++ b/crates/burn-core/src/nn/conv/conv2d.rs
@@ -155,14 +155,16 @@ impl<B: Backend> Conv2d<B> {
     ///
     /// # Example
     /// ```rust,ignore
-    /// use burn::backend::ndarray::NdArray;
     /// use burn::nn::conv::Conv2dConfig;
     /// use burn::tensor::Tensor;
     ///
-    /// let device = Default::default();
-    /// let conv = Conv2dConfig::new([3, 8], [3, 3]).init::<NdArray>(&device);
+    /// // Choose your backend for B (e.g., burn::backend::ndarray::NdArray)
+    /// type B = burn::backend::ndarray::NdArray;
     ///
-    /// let x = Tensor::<NdArray, 4>::zeros([1, 3, 28, 28], &device);
+    /// let device = Default::default();
+    /// let conv = Conv2dConfig::new([3, 8], [3, 3]).init::<B>(&device);
+    ///
+    /// let x = Tensor::<B, 4>::zeros([1, 3, 28, 28], &device);
     /// let y = conv.forward(x);
     ///
     /// println!("{:?}", y.dims()); // [1, 8, 26, 26]

--- a/crates/burn-core/src/nn/conv/conv2d.rs
+++ b/crates/burn-core/src/nn/conv/conv2d.rs
@@ -66,7 +66,6 @@ pub struct Conv2d<B: Backend> {
     pub groups: usize,
     /// The padding configuration.
     pub padding: Ignored<PaddingConfig2d>,
-    
 }
 
 impl Conv2dConfig {
@@ -116,21 +115,21 @@ impl Conv2dConfig {
 
 impl<B: Backend> ModuleDisplay for Conv2d<B> {
     /// # Example
-/// ```rust
-/// # #[cfg(feature = "ndarray")]
-/// # {
-/// use burn::backend::ndarray::NdArray;
-/// use burn::nn::conv::Conv2dConfig;
-///
-/// let device = Default::default();
-/// let conv = Conv2dConfig::new([3, 8], [3, 3]).init::<NdArray>(&device);
-///
-/// // Print Conv2d layer information using Display
-/// println!("{}", conv);
-/// # }
-/// # #[cfg(not(feature = "ndarray"))]
-/// # fn main() {}
-/// ```
+    /// ```rust
+    /// # #[cfg(feature = "ndarray")]
+    /// # {
+    /// use burn::backend::ndarray::NdArray;
+    /// use burn::nn::conv::Conv2dConfig;
+    ///
+    /// let device = Default::default();
+    /// let conv = Conv2dConfig::new([3, 8], [3, 3]).init::<NdArray>(&device);
+    ///
+    /// // Print Conv2d layer information using Display
+    /// println!("{}", conv);
+    /// # }
+    /// # #[cfg(not(feature = "ndarray"))]
+    /// # fn main() {}
+    /// ```
     fn custom_settings(&self) -> Option<DisplaySettings> {
         DisplaySettings::new()
             .with_new_line_after_attribute(false)
@@ -162,37 +161,37 @@ impl<B: Backend> ModuleDisplay for Conv2d<B> {
 }
 
 impl<B: Backend> Conv2d<B> {
-/// Applies the forward pass on the input tensor.
-/// 
-/// See [`conv2d`] for more information.
-/// 
-/// # Shapes
-/// - `input`: `[batch_size, channels_in, height_in, width_in]`
-/// - `output`: `[batch_size, channels_out, height_out, width_out]`
-/// 
-/// # Example
-/// ```rust
-/// # #[cfg(feature = "ndarray")]
-/// # {
-/// use burn::backend::ndarray::NdArray;
-/// use burn::nn::conv::Conv2dConfig;
-/// use burn::tensor::Tensor;
-///
-/// let device = Default::default();
-/// let conv = Conv2dConfig::new([3, 8], [3, 3]).init::<NdArray>(&device);
-///
-/// // Fake input: [batch=1, channels=3, height=28, width=28]
-/// let x = Tensor::<NdArray, 4>::zeros([1, 3, 28, 28], &device);
-///
-/// // Apply convolution
-/// let y = conv.forward(x);
-///
-/// // Output shape: [1, 8, 26, 26]
-/// println!("{:?}", y.dims());
-/// # }
-/// # #[cfg(not(feature = "ndarray"))]
-/// # fn main() {}
-/// ```
+    /// Applies the forward pass on the input tensor.
+    ///
+    /// See [`conv2d`] for more information.
+    ///
+    /// # Shapes
+    /// - `input`: `[batch_size, channels_in, height_in, width_in]`
+    /// - `output`: `[batch_size, channels_out, height_out, width_out]`
+    ///
+    /// # Example
+    /// ```rust
+    /// # #[cfg(feature = "ndarray")]
+    /// # {
+    /// use burn::backend::ndarray::NdArray;
+    /// use burn::nn::conv::Conv2dConfig;
+    /// use burn::tensor::Tensor;
+    ///
+    /// let device = Default::default();
+    /// let conv = Conv2dConfig::new([3, 8], [3, 3]).init::<NdArray>(&device);
+    ///
+    /// // Fake input: [batch=1, channels=3, height=28, width=28]
+    /// let x = Tensor::<NdArray, 4>::zeros([1, 3, 28, 28], &device);
+    ///
+    /// // Apply convolution
+    /// let y = conv.forward(x);
+    ///
+    /// // Output shape: [1, 8, 26, 26]
+    /// println!("{:?}", y.dims());
+    /// # }
+    /// # #[cfg(not(feature = "ndarray"))]
+    /// # fn main() {}
+    /// ```
     pub fn forward(&self, input: Tensor<B, 4>) -> Tensor<B, 4> {
         let [_batch_size, _channels_in, height_in, width_in] = input.dims();
         let padding =
@@ -299,9 +298,9 @@ mod tests {
         let conv = config.init::<TestBackend>(&Default::default());
 
         assert_eq!(
-        alloc::format!("{conv}"),
-        "Conv2d {ch_in: 5, ch_out: 1, stride: [1, 1], kernel_size: [5, 5], dilation: [1, 1], groups: 1, padding: Valid, params: 126}"
-);
+            alloc::format!("{conv}"),
+            "Conv2d {ch_in: 5, ch_out: 1, stride: [1, 1], kernel_size: [5, 5], dilation: [1, 1], groups: 1, padding: Valid, params: 126}"
+        );
     }
 
     #[test]

--- a/crates/burn-core/src/nn/conv/conv2d.rs
+++ b/crates/burn-core/src/nn/conv/conv2d.rs
@@ -158,9 +158,7 @@ impl<B: Backend> Conv2d<B> {
     /// use burn::nn::conv::Conv2dConfig;
     /// use burn::tensor::Tensor;
     ///
-    /// // Choose your backend for B (e.g., burn::backend::ndarray::NdArray)
-    /// type B = burn::backend::ndarray::NdArray;
-    ///
+    /// // Assuming backend type alias `B`
     /// let device = Default::default();
     /// let conv = Conv2dConfig::new([3, 8], [3, 3]).init::<B>(&device);
     ///

--- a/crates/burn-core/src/nn/conv/conv3d.rs
+++ b/crates/burn-core/src/nn/conv/conv3d.rs
@@ -118,15 +118,23 @@ impl<B: Backend> ModuleDisplay for Conv3d<B> {
     }
 
     fn custom_content(&self, content: Content) -> Option<Content> {
-        // Since padding does not implement ModuleDisplay, we need to format it manually.
+        // Padding doesn't implement ModuleDisplay, so format manually.
         let padding_formatted = format!("{}", &self.padding);
 
-        // Format the stride, kernel_size and dilation as strings, formatted as arrays instead of indexed.
+        // Format arrays as strings (consistent with Conv2d/Conv1d).
         let stride = format!("{:?}", self.stride);
         let kernel_size = format!("{:?}", self.kernel_size);
         let dilation = format!("{:?}", self.dilation);
 
+        // Weight dims: [channels_out, channels_in/groups, k1, k2, k3]
+        let [channels_out, group_channels_in, _, _, _] = self.weight.dims();
+        let channels_in = group_channels_in * self.groups;
+        let ch_out = format!("{:?}", channels_out);
+        let ch_in = format!("{:?}", channels_in);
+
         content
+            .add("ch_in", &ch_in)
+            .add("ch_out", &ch_out)
             .add("stride", &stride)
             .add("kernel_size", &kernel_size)
             .add("dilation", &dilation)
@@ -245,14 +253,14 @@ mod tests {
 
     #[test]
     fn display() {
-        let config = Conv3dConfig::new([5, 1], [5, 5, 5]);
-        let conv = config.init::<TestBackend>(&Default::default());
+    let config = Conv3dConfig::new([5, 1], [5, 5, 5]);
+    let conv = config.init::<TestBackend>(&Default::default());
 
-        assert_eq!(
-            alloc::format!("{conv}"),
-            "Conv3d {stride: [1, 1, 1], kernel_size: [5, 5, 5], dilation: [1, 1, 1], groups: 1, padding: Valid, params: 626}"
-        );
-    }
+    assert_eq!(
+        alloc::format!("{conv}"),
+        "Conv3d {ch_in: 5, ch_out: 1, stride: [1, 1, 1], kernel_size: [5, 5, 5], dilation: [1, 1, 1], groups: 1, padding: Valid, params: 626}"
+    );
+}
 
     #[test]
     #[should_panic = "Number of channels in input tensor and input channels of convolution must be equal. got: 4, expected: 5"]

--- a/crates/burn-core/src/nn/conv/conv3d.rs
+++ b/crates/burn-core/src/nn/conv/conv3d.rs
@@ -253,14 +253,14 @@ mod tests {
 
     #[test]
     fn display() {
-    let config = Conv3dConfig::new([5, 1], [5, 5, 5]);
-    let conv = config.init::<TestBackend>(&Default::default());
+        let config = Conv3dConfig::new([5, 1], [5, 5, 5]);
+        let conv = config.init::<TestBackend>(&Default::default());
 
-    assert_eq!(
-        alloc::format!("{conv}"),
-        "Conv3d {ch_in: 5, ch_out: 1, stride: [1, 1, 1], kernel_size: [5, 5, 5], dilation: [1, 1, 1], groups: 1, padding: Valid, params: 626}"
-    );
-}
+        assert_eq!(
+            alloc::format!("{conv}"),
+            "Conv3d {ch_in: 5, ch_out: 1, stride: [1, 1, 1], kernel_size: [5, 5, 5], dilation: [1, 1, 1], groups: 1, padding: Valid, params: 626}"
+        );
+    }
 
     #[test]
     #[should_panic = "Number of channels in input tensor and input channels of convolution must be equal. got: 4, expected: 5"]


### PR DESCRIPTION
## Pull Request

### Checklist
- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book (`model.md`) is up to date with changes in this PR.

### Related Issues/PRs
Fixes #3509

### Changes
- `Conv2d` Display now includes `ch_in` and `ch_out` (consistent with `Linear` showing `d_input`/`d_output`).
- Added doctest examples for `Conv2d::forward` and `Display` (feature-gated for `ndarray`).
- **Book**: updated `Model { ... }` example in `model.md` to reflect the new `Conv2d` Display output.  
  >code adapted from the issue reporter in #3509.

### Testing
Backend-agnostic check (Display derives from `weight.dims` + groups, so it should behave the same on any backend):
Ndarray example:
use burn::backend::ndarray::NdArray;
use burn::nn::conv::Conv2dConfig;

type B = NdArray;

fn main() {
    let device = Default::default();
    let conv = Conv2dConfig::new([3, 8], [3, 3]).init::<B>(&device);
    println!("{}", conv);
}
Output: Conv2d {ch_in: 3, ch_out: 8, stride: [1, 1], kernel_size: [3, 3], dilation: [1, 1], groups: 1, padding: Valid, params: 224}
WGPU example:

use burn::backend::wgpu::Wgpu;
use burn::nn::conv::Conv2dConfig;
use burn::tensor::{backend::Backend, Tensor};

type B = Wgpu<f32, i64>;

fn main() {
    let device = <B as Backend>::Device::default();
    let conv = Conv2dConfig::new([3, 8], [3, 3]).init::<B>(&device);
    println!("{}", conv);

    let x = Tensor::<B, 4>::zeros([1, 3, 32, 32], &device);
    let y = conv.forward(x);
    println!("Output dims: {:?}", y.dims());
}
Output:
Conv2d { ch_in: 3, ch_out: 8, stride: [1, 1], kernel_size: [3, 3], dilation: [1, 1], groups: 1, padding: Valid, params: 224 }
Output dims: [1, 8, 30, 30]
