### PR TITLE
fix: Fix bug with scalar tail in morphology op

### DIFF
--- a/crates/burn-vision/src/backends/cpu/morphology/filter.rs
+++ b/crates/burn-vision/src/backends/cpu/morphology/filter.rs
@@ -449,12 +449,14 @@ impl<T: Scalar, Op: MorphOperator<T>, VecOp: VecColumn<T>> MorphColumnFilter<T, 
         let width = width as isize;
 
         let mut d = 0;
-        let mut x = x0;
+        let mut x;
         let mut y = 0;
 
         let slice = |row: *const T| unsafe { slice::from_raw_parts(row, width as usize) };
 
         while ksize > 1 && count > 1 {
+            x = x0;
+
             while x as isize <= width - 4 {
                 let row = slice(src[y + 1]);
                 let mut s0 = row[x];


### PR DESCRIPTION
Fixes a bug in `burn-vision`s morphology ops caused by not resetting the x position on each y loop in the scalar tail. This was causing artifacting when image width does not divide cleanly by `lanes / 2`.

## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.
