### PR TITLE
Fix autodiff cleanup 

### DIFF
--- a/crates/burn-autodiff/src/runtime/server.rs
+++ b/crates/burn-autodiff/src/runtime/server.rs
@@ -31,10 +31,11 @@ impl AutodiffServer {
     }
 
     pub fn backward(&mut self, grads: Gradients, node_id: NodeID) -> Gradients {
-        let step = self.steps.remove(&node_id).expect(
-            "Node should have a step registered, did you forget to call \
+        let step = self.steps.remove(&node_id).expect(&format!(
+            "Node {} should have a step registered, did you forget to call \
              `Tensor::register_grad` on the tensor where you need gradients?",
-        );
+            node_id.value
+        ));
         let builder = self.actions_builder.remove(&node_id).unwrap();
 
         let (tape, checkpointer) = self.build_tape(node_id, step, builder);


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.

### Related Issues/PRs

Fixes #3513

Nodes were marked as unavailable (parent nodes unavailable) and getting cleaned up but were still referenced in another thread for (incomplete) backward pass.

### Changes

Check if node is still referenced by another thread (global autodiff, multi-device setup) when marking for deletion

### Testing

Tested code in linked issue, validated that such nodes are eventually cleaned up as unused roots (only server reference remains, no more parents).
