### PR TITLE
fix: Use correct datatype when filling boolean tensors

### DIFF
--- a/crates/burn-cubecl/src/ops/bool_ops.rs
+++ b/crates/burn-cubecl/src/ops/bool_ops.rs
@@ -21,11 +21,11 @@ where
     }
 
     fn bool_zeros(shape: Shape, device: &Device<Self>) -> BoolTensor<Self> {
-        numeric::zeros::<R, I>(shape, device)
+        numeric::zeros::<R, BT>(shape, device)
     }
 
     fn bool_ones(shape: Shape, device: &Device<Self>) -> BoolTensor<Self> {
-        numeric::ones::<R, I>(shape, device)
+        numeric::ones::<R, BT>(shape, device)
     }
 
     async fn bool_into_data(tensor: BoolTensor<Self>) -> TensorData {


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

`bool_zeros` and `bool_ones` incorrectly used the int element instead of the bool element.
