### PR TITLE
Add a `Tensor::<B, D, K>::unit(fill_value, device)` op for `[1; D]` tensors.

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -3,7 +3,7 @@
 As previously explained in the [model section](../basic-workflow/model.md), the Tensor struct has 3
 generic arguments: the backend B, the dimensionality D, and the data type.
 
-```rust , ignore
+```rust, ignore
 Tensor<B, D>           // Float tensor (default)
 Tensor<B, D, Float>    // Explicit float tensor
 Tensor<B, D, Int>      // Int tensor
@@ -135,6 +135,9 @@ Those operations are available for all tensor kinds: `Int`, `Float`, and `Bool`.
 |---------------------------------------------|---------------------------------------------------------------------------|
 | `Tensor::cat(tensors, dim)`                 | `torch.cat(tensors, dim)`                                                 |
 | `Tensor::empty(shape, device)`              | `torch.empty(shape, device=device)`                                       |
+| `Tensor::full(shape, fill_value, device)`   | `torch.full(shape, fill_value, device=device)`                            |
+| `tensor::full_like(fill_value)`             | `torch.full_like(tensor, fill_value)`                                     |
+| `Tensor::<D>::unit(fill_value, device)`     | `torch.full([1] * D, fill_value, device=device)`                          |
 | `Tensor::from_primitive(primitive)`         | N/A                                                                       |
 | `Tensor::stack(tensors, dim)`               | `torch.stack(tensors, dim)`                                               |
 | `tensor.all()`                              | `tensor.all()`                                                            |
@@ -185,7 +188,6 @@ Those operations are available for numeric tensor kinds: `Float` and `Int`.
 | Burn                                                            | PyTorch Equivalent                             |
 | --------------------------------------------------------------- | ---------------------------------------------- |
 | `Tensor::eye(size, device)`                                     | `torch.eye(size, device=device)`               |
-| `Tensor::full(shape, fill_value, device)`                       | `torch.full(shape, fill_value, device=device)` |
 | `Tensor::ones(shape, device)`                                   | `torch.ones(shape, device=device)`             |
 | `Tensor::zeros(shape, device)`                                  | `torch.zeros(shape, device=device)`            |
 | `tensor.abs()`                                                  | `torch.abs(tensor)`                            |
@@ -205,7 +207,6 @@ Those operations are available for numeric tensor kinds: `Float` and `Int`.
 | `tensor.div_scalar(scalar)` or `tensor / scalar`                | `tensor / scalar`                              |
 | `tensor.dot()`                                                  | `torch.dot()`                                  |
 | `tensor.equal_elem(other)`                                      | `tensor.eq(other)`                             |
-| `tensor.full_like(fill_value)`                                  | `torch.full_like(tensor, fill_value)`          |
 | `tensor.gather(dim, indices)`                                   | `torch.gather(tensor, dim, indices)`           |
 | `tensor.greater(other)`                                         | `tensor.gt(other)`                             |
 | `tensor.greater_elem(scalar)`                                   | `tensor.gt(scalar)`                            |
@@ -392,7 +393,7 @@ of detail and formatting to suit your needs.
 
 To display a detailed view of a tensor, you can simply use Rust's `println!` or `format!` macros:
 
-```rust
+```rust, ignore
 let tensor = Tensor::<Backend, 2>::full([2, 3], 0.123456789, &Default::default());
 println!("{}", tensor);
 ```
@@ -440,7 +441,7 @@ Tensor {
 For more fine-grained control over tensor printing, Burn provides a `PrintOptions` struct and a
 `set_print_options` function:
 
-```rust
+```rust, ignore
 use burn::tensor::{set_print_options, PrintOptions};
 
 let print_options = PrintOptions {
@@ -469,7 +470,7 @@ Options:
 
   Here's an example of how to use `check_closeness`:
 
-  ```rust
+  ```rust, ignore
   use burn::tensor::{check_closeness, Tensor};
   type B = burn::backend::NdArray;
 

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -201,6 +201,24 @@ where
         Self::full(self.shape(), fill_value, &self.device())
     }
 
+    /// Returns a new tensor of shape ``[1; D]`` filled with the provided value.
+    ///
+    /// # Example
+    /// ```rust
+    /// use burn_tensor::backend::Backend;
+    /// use burn_tensor::{Tensor, Shape};
+    ///
+    /// fn example<B: Backend>() {
+    ///    let device = B::Device::default();
+    ///    let tensor = Tensor::<B, 2>::unit(0.5, &device);
+    ///    println!("{tensor}");
+    ///    // [[0.5]]
+    /// }
+    /// ```
+    pub fn unit<E: ElementConversion>(fill_value: E, device: &B::Device) -> Self {
+        Self::full([1; D], fill_value, device)
+    }
+
     /// Returns the dimensions of the current tensor.
     ///
     /// # Example

--- a/crates/burn-tensor/src/tests/mod.rs
+++ b/crates/burn-tensor/src/tests/mod.rs
@@ -239,6 +239,7 @@ macro_rules! testgen_with_float_param {
         burn_tensor::testgen_tanh!();
         burn_tensor::testgen_transpose!();
         burn_tensor::testgen_tri!();
+        burn_tensor::testgen_unit!();
         burn_tensor::testgen_powf!();
         burn_tensor::testgen_any!();
         burn_tensor::testgen_all_op!();

--- a/crates/burn-tensor/src/tests/ops/mod.rs
+++ b/crates/burn-tensor/src/tests/ops/mod.rs
@@ -76,3 +76,4 @@ mod topk;
 mod transpose;
 mod tri;
 mod tri_mask;
+mod unit;

--- a/crates/burn-tensor/src/tests/ops/unit.rs
+++ b/crates/burn-tensor/src/tests/ops/unit.rs
@@ -1,0 +1,27 @@
+#[burn_tensor_testgen::testgen(unit)]
+mod tests {
+    use super::*;
+    use burn_tensor::{Bool, Int, Shape, Tensor, TensorData, backend::Backend};
+
+    #[test]
+    fn test_tensor_unit() {
+        let device = Default::default();
+        // Test full with f32
+        let tensor = TestTensor::<2>::unit(2.1, &device);
+        tensor
+            .into_data()
+            .assert_eq(&TensorData::from([[2.1]]), false);
+
+        // Test full with Int
+        let int_tensor = TestTensorInt::<3>::unit(2, &device);
+        int_tensor
+            .into_data()
+            .assert_eq(&TensorData::from([[[2]]]), false);
+
+        // Test full with bool
+        let bool_tensor = TestTensorBool::<1>::unit(true, &device);
+        bool_tensor
+            .into_data()
+            .assert_eq(&TensorData::from([true]), false);
+    }
+}


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

Unit tensors come up in some algorithms; and they're trivial to construct on top of `.full()`.

Also moved the `full()/full_like()` docs.

### Testing

tests.