### PR TITLE
Derive clone for Record Items

### DIFF
--- a/crates/burn-core/src/record/primitive.rs
+++ b/crates/burn-core/src/record/primitive.rs
@@ -258,6 +258,7 @@ primitive!(i8);
 /// deserializing arrays of variable size,
 /// see [serde/issues/1937](https://github.com/serde-rs/serde/issues/1937)
 /// for backward compatibility reasons. Serde APIs were created before const generics.
+#[derive(Clone)]
 pub struct Array<const N: usize, T>([T; N]);
 
 impl<T: Serialize, const N: usize> Serialize for Array<N, T> {

--- a/crates/burn-core/tests/test_derive_module.rs
+++ b/crates/burn-core/tests/test_derive_module.rs
@@ -83,6 +83,37 @@ impl<B: Backend> ModuleComposed<B> {
     }
 }
 
+#[allow(dead_code)]
+mod compiletime_clone_impl_check {
+    use burn_core::{
+        module::{Module, ModuleDisplay},
+        prelude::Backend,
+        record::{PrecisionSettings, Record},
+    };
+
+    use super::*;
+    
+    type RecordItem<M, B, S> = <<M as Module<B>>::Record as Record<B>>::Item<S>;
+
+    fn implements_clone<T: Clone>() {}
+
+    fn basic_implements_clone<B: Backend, S: PrecisionSettings>() {
+        implements_clone::<RecordItem<ModuleBasic<B>, B, S>>();
+        implements_clone::<RecordItem<ModuleComposed<B>, B, S>>();
+    }
+
+    fn generic_implements_clone<B, S, M>()
+    where
+        B: Backend,
+        S: PrecisionSettings,
+        M: Module<B> + ModuleDisplay,
+        RecordItem<M, B, S>: Clone,
+    {
+        implements_clone::<RecordItem<ModuleWithGenericModule<B, M>, B, S>>();
+        implements_clone::<RecordItem<ModuleEnumWithGenericModule<B, M>, B, S>>();
+    }
+}
+
 mod state {
     use super::*;
 

--- a/crates/burn-core/tests/test_derive_module.rs
+++ b/crates/burn-core/tests/test_derive_module.rs
@@ -92,7 +92,7 @@ mod compiletime_clone_impl_check {
     };
 
     use super::*;
-    
+
     type RecordItem<M, B, S> = <<M as Module<B>>::Record as Record<B>>::Item<S>;
 
     fn implements_clone<T: Clone>() {}

--- a/crates/burn-derive/src/record/item/codegen_enum.rs
+++ b/crates/burn-derive/src/record/item/codegen_enum.rs
@@ -26,7 +26,9 @@ impl RecordItemCodegen for EnumRecordItemCodegen {
         has_backend: bool,
     ) -> TokenStream {
         let mut variants = quote! {};
-        let mut bounds = quote! {};
+        let mut serde_bounds = quote! {};
+        let mut clone_bounds = vec![];
+        let mut clone_match_arms = quote! {};
         let vis = &self.vis;
 
         // Capture the Record enum variant types and names to transpose them in RecordItem
@@ -40,34 +42,56 @@ impl RecordItemCodegen for EnumRecordItemCodegen {
             });
 
             // Item types must implement serialization/deserialization
-            bounds.extend(quote! {
-              <#ty as burn::record::Record<B>>::Item<S>: burn::serde::Serialize + burn::serde::de::DeserializeOwned,
-          });
+            serde_bounds.extend(quote! {
+                <#ty as burn::record::Record<B>>::Item<S>: burn::serde::Serialize + burn::serde::de::DeserializeOwned,
+            });
+            clone_bounds.push(parse_quote! {
+                <#ty as burn::record::Record<B>>::Item<S>: Clone
+            });
+
+            clone_match_arms.extend(quote! {
+                Self::#name(inner) => Self::#name(inner.clone()),
+            });
         }
-        let bound = bounds.to_string();
+        let serde_bound = serde_bounds.to_string();
 
         // Capture the type's generics and bounds in where clauses
-        let (generics, generics_where) = if !has_backend {
-            let mut generics = generics.clone();
+        let mut generics = generics.clone();
+        if !has_backend {
             let param: syn::TypeParam = parse_quote! { B: burn::tensor::backend::Backend };
             generics.params.push(syn::GenericParam::Type(param));
-            let (generics, _, generics_where) = generics.split_for_impl();
-            (quote! { #generics }, quote! { #generics_where })
-        } else {
-            let (generics, _, generics_where) = generics.split_for_impl();
-            (quote! { #generics }, quote! { #generics_where })
+        }
+        let (generics, type_generics, generics_where) = generics.split_for_impl();
+
+        let clone_bounds = generics_where.cloned().map(|mut where_clause| {
+            for predicate in clone_bounds {
+                where_clause.predicates.push(predicate);
+            }
+            where_clause
+        });
+
+        let clone_impl = quote! {
+            impl #generics Clone for #item_name #type_generics #clone_bounds{
+                fn clone(&self) -> Self{
+                    match self{
+                        #clone_match_arms
+                    }
+                }
+            }
         };
 
         // Return the generated stream of token trees (i.e., code to be generated)
         quote! {
 
             /// The record item type for the module.
-            #[derive(burn::serde::Serialize, burn::serde::Deserialize, Clone)]
+            #[derive(burn::serde::Serialize, burn::serde::Deserialize)]
             #[serde(crate = "burn::serde")]
-            #[serde(bound = #bound)]
+            #[serde(bound = #serde_bound)]
             #vis enum #item_name #generics #generics_where {
                 #variants
             }
+
+            #clone_impl
         }
     }
 

--- a/crates/burn-derive/src/record/item/codegen_enum.rs
+++ b/crates/burn-derive/src/record/item/codegen_enum.rs
@@ -71,9 +71,9 @@ impl RecordItemCodegen for EnumRecordItemCodegen {
         });
 
         let clone_impl = quote! {
-            impl #generics Clone for #item_name #type_generics #clone_bounds{
-                fn clone(&self) -> Self{
-                    match self{
+            impl #generics Clone for #item_name #type_generics #clone_bounds {
+                fn clone(&self) -> Self {
+                    match self {
                         #clone_match_arms
                     }
                 }

--- a/crates/burn-derive/src/record/item/codegen_enum.rs
+++ b/crates/burn-derive/src/record/item/codegen_enum.rs
@@ -62,7 +62,7 @@ impl RecordItemCodegen for EnumRecordItemCodegen {
         quote! {
 
             /// The record item type for the module.
-            #[derive(burn::serde::Serialize, burn::serde::Deserialize)]
+            #[derive(burn::serde::Serialize, burn::serde::Deserialize, Clone)]
             #[serde(crate = "burn::serde")]
             #[serde(bound = #bound)]
             #vis enum #item_name #generics #generics_where {

--- a/crates/burn-derive/src/record/item/codegen_struct.rs
+++ b/crates/burn-derive/src/record/item/codegen_struct.rs
@@ -71,9 +71,9 @@ impl RecordItemCodegen for StructRecordItemCodegen {
         });
 
         let clone_impl = quote! {
-            impl #generics Clone for #item_name #type_generics #clone_bounds{
-                fn clone(&self) -> Self{
-                    Self{
+            impl #generics Clone for #item_name #type_generics #clone_bounds {
+                fn clone(&self) -> Self {
+                    Self {
                         #clone_delegate
                     }
                 }

--- a/crates/burn-derive/src/record/item/codegen_struct.rs
+++ b/crates/burn-derive/src/record/item/codegen_struct.rs
@@ -28,7 +28,9 @@ impl RecordItemCodegen for StructRecordItemCodegen {
         has_backend: bool,
     ) -> TokenStream {
         let mut fields = quote! {};
-        let mut bounds = quote! {};
+        let mut serde_bounds = quote! {};
+        let mut clone_bounds = vec![];
+        let mut clone_delegate = quote! {};
         let vis = &self.vis;
 
         for field in self.fields.iter() {
@@ -40,32 +42,55 @@ impl RecordItemCodegen for StructRecordItemCodegen {
                 pub #name: <#ty as burn::record::Record<B>>::Item<S>,
             });
 
-            bounds.extend(quote! {
-          <#ty as burn::record::Record<B>>::Item<S>: burn::serde::Serialize + burn::serde::de::DeserializeOwned,
-      });
-        }
-        let bound = bounds.to_string();
+            serde_bounds.extend(quote! {
+                <#ty as burn::record::Record<B>>::Item<S>: burn::serde::Serialize + burn::serde::de::DeserializeOwned,
+            });
 
-        let (generics, generics_where) = if !has_backend {
-            let mut generics = generics.clone();
+            clone_bounds.push(parse_quote! {
+                <#ty as burn::record::Record<B>>::Item<S>: Clone
+            });
+
+            clone_delegate.extend(quote! {
+                #name: self.#name.clone(),
+            });
+        }
+        let serde_bound = serde_bounds.to_string();
+
+        let mut generics = generics.clone();
+        if !has_backend {
             let param: syn::TypeParam = parse_quote! { B: burn::tensor::backend::Backend };
             generics.params.push(syn::GenericParam::Type(param));
-            let (generics, _, generics_where) = generics.split_for_impl();
-            (quote! { #generics }, quote! { #generics_where })
-        } else {
-            let (generics, _, generics_where) = generics.split_for_impl();
-            (quote! { #generics }, quote! { #generics_where })
+        }
+        let (generics, type_generics, generics_where) = generics.split_for_impl();
+
+        let clone_bounds = generics_where.cloned().map(|mut where_clause| {
+            for predicate in clone_bounds {
+                where_clause.predicates.push(predicate);
+            }
+            where_clause
+        });
+
+        let clone_impl = quote! {
+            impl #generics Clone for #item_name #type_generics #clone_bounds{
+                fn clone(&self) -> Self{
+                    Self{
+                        #clone_delegate
+                    }
+                }
+            }
         };
 
         quote! {
 
             /// The record item type for the module.
-            #[derive(burn::serde::Serialize, burn::serde::Deserialize, Clone)]
+            #[derive(burn::serde::Serialize, burn::serde::Deserialize)]
             #[serde(crate = "burn::serde")]
-            #[serde(bound = #bound)]
+            #[serde(bound = #serde_bound)]
             #vis struct #item_name #generics #generics_where {
                 #fields
             }
+
+            #clone_impl
         }
     }
 

--- a/crates/burn-derive/src/record/item/codegen_struct.rs
+++ b/crates/burn-derive/src/record/item/codegen_struct.rs
@@ -60,7 +60,7 @@ impl RecordItemCodegen for StructRecordItemCodegen {
         quote! {
 
             /// The record item type for the module.
-            #[derive(burn::serde::Serialize, burn::serde::Deserialize)]
+            #[derive(burn::serde::Serialize, burn::serde::Deserialize, Clone)]
             #[serde(crate = "burn::serde")]
             #[serde(bound = #bound)]
             #vis struct #item_name #generics #generics_where {


### PR DESCRIPTION
# Add `#[derive(Clone)]` for Record Items when deriving Record
Hi! This small change allows all automatically derived RecordItems to implement clone

## Motivation
The clone implementation is crucial if you'd like to hold on to an in-memory, off-device representation of the model that can be put on device at any time.
The requirement of clone comes from the interface of a module being created from a Record, as well as a Record being created from a Record Item, taking their arguments by value. It is thus not possible to put the model on device and hold on to its state on CPU at the same time.
With this change, the RecordItem can be held onto and simply cloned when model instantiation is required.

Now, you might be thinking, why would anyone want this? Why hold onto the CPU-side data if the model as already been put on device? Well, we are building a GUI where users will be able to, among other things, train smaller neural networks through a UI. To this end and to conform with the rest of the GUI architecture, it would be very convenient for us to store the result of training a model in memory until the user is satisfied with its performance, at which point they can save it to disk. It should also be possible to have multiple of such models loaded at the same time, and these representations should derive Serde, such that we can save the models to disk when the user requests it.

The autogenerated RecordItem types seem perfect for this, as they just hold onto the data on CPU side at some precision, and their raison d'etre is to implement Serialize and Deserialize. However, it seems I cannot recover my module from one of these without consuming it, as described above. A clone implementation would allow me to simply clone it before putting it on device. A bit of a waste of resources, but nothing too bad and nothing in comparison to training / inference.

## Other things I considered
- I could serialize to a slice of bytes using the provided Recorder or my own serde implementation. This seems even more wasteful and less elegant than the clone impl
- I could serialize a temporary file. Upside is that it would free up ram, downside is that I need to go to disk to recover the model again (probably fine in this case), but now I also need to worry about whether these temporary files get cleaned up properly, and whether someone else cleans them up while I somehow have a reference to them. Not great.
- I considered making Clone be a required trait for the associated RecordItem type. However as its not actually necessary for normal operation, that doesn't make a whole lot of sense. This way, all the automatically derived versions are clone if you ever end up needing it, while if you implement Record manually you can do that without requiring the RecordItem to be Clone. Again, if you actually need it then you can also manually implement clone for your custom RecordItem type.

Thanks for all the great work!
