### PR TITLE
fix: Ensure output layout is the same for SIMD ops in ndarray

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,7 +409,7 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -463,9 +463,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.2"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
+checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
 dependencies = [
  "serde",
 ]
@@ -531,7 +531,7 @@ version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca5abbf2d4a4c6896197c9de13d6d7cb7eff438c63dacde1dde980569cb00248"
 dependencies = [
- "darling 0.21.2",
+ "darling 0.21.3",
  "ident_case",
  "prettyplease 0.2.37",
  "proc-macro2",
@@ -724,7 +724,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spin",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "uuid",
 ]
 
@@ -815,7 +815,7 @@ dependencies = [
  "serde_rusqlite",
  "strum 0.27.2",
  "tempfile",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -863,10 +863,10 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 2.0.106",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tracing-core",
  "tracing-subscriber",
- "zip 4.3.0",
+ "zip 4.5.0",
 ]
 
 [[package]]
@@ -1238,9 +1238,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.33"
+version = "1.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee0f8803222ba5a7e2777dd72ca451868909b1ac410621b676adf07280e9b5f"
+checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
 dependencies = [
  "jobserver",
  "libc",
@@ -1644,7 +1644,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -1713,7 +1713,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d1273b10a233e3c1bd40243bed66d206302d7989#d1273b10a233e3c1bd40243bed66d206302d7989"
+source = "git+https://github.com/tracel-ai/cubecl?rev=22c9226d87550b32412d21579b041d806762f2df#22c9226d87550b32412d21579b041d806762f2df"
 dependencies = [
  "cubecl-convolution",
  "cubecl-core",
@@ -1732,7 +1732,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d1273b10a233e3c1bd40243bed66d206302d7989#d1273b10a233e3c1bd40243bed66d206302d7989"
+source = "git+https://github.com/tracel-ai/cubecl?rev=22c9226d87550b32412d21579b041d806762f2df#22c9226d87550b32412d21579b041d806762f2df"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -1761,7 +1761,7 @@ dependencies = [
 [[package]]
 name = "cubecl-convolution"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d1273b10a233e3c1bd40243bed66d206302d7989#d1273b10a233e3c1bd40243bed66d206302d7989"
+source = "git+https://github.com/tracel-ai/cubecl?rev=22c9226d87550b32412d21579b041d806762f2df#22c9226d87550b32412d21579b041d806762f2df"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1779,9 +1779,9 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d1273b10a233e3c1bd40243bed66d206302d7989#d1273b10a233e3c1bd40243bed66d206302d7989"
+source = "git+https://github.com/tracel-ai/cubecl?rev=22c9226d87550b32412d21579b041d806762f2df#22c9226d87550b32412d21579b041d806762f2df"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "bytemuck",
  "cubecl-common",
  "cubecl-ir",
@@ -1802,7 +1802,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d1273b10a233e3c1bd40243bed66d206302d7989#d1273b10a233e3c1bd40243bed66d206302d7989"
+source = "git+https://github.com/tracel-ai/cubecl?rev=22c9226d87550b32412d21579b041d806762f2df#22c9226d87550b32412d21579b041d806762f2df"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1816,7 +1816,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d1273b10a233e3c1bd40243bed66d206302d7989#d1273b10a233e3c1bd40243bed66d206302d7989"
+source = "git+https://github.com/tracel-ai/cubecl?rev=22c9226d87550b32412d21579b041d806762f2df#22c9226d87550b32412d21579b041d806762f2df"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1826,6 +1826,7 @@ dependencies = [
  "cubecl-opt",
  "cubecl-reduce",
  "cubecl-runtime",
+ "cubecl-std",
  "derive-new",
  "half",
  "log",
@@ -1837,7 +1838,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d1273b10a233e3c1bd40243bed66d206302d7989#d1273b10a233e3c1bd40243bed66d206302d7989"
+source = "git+https://github.com/tracel-ai/cubecl?rev=22c9226d87550b32412d21579b041d806762f2df#22c9226d87550b32412d21579b041d806762f2df"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1854,7 +1855,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d1273b10a233e3c1bd40243bed66d206302d7989#d1273b10a233e3c1bd40243bed66d206302d7989"
+source = "git+https://github.com/tracel-ai/cubecl?rev=22c9226d87550b32412d21579b041d806762f2df#22c9226d87550b32412d21579b041d806762f2df"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1882,7 +1883,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d1273b10a233e3c1bd40243bed66d206302d7989#d1273b10a233e3c1bd40243bed66d206302d7989"
+source = "git+https://github.com/tracel-ai/cubecl?rev=22c9226d87550b32412d21579b041d806762f2df#22c9226d87550b32412d21579b041d806762f2df"
 dependencies = [
  "cubecl-common",
  "cubecl-macros-internal",
@@ -1900,10 +1901,10 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d1273b10a233e3c1bd40243bed66d206302d7989#d1273b10a233e3c1bd40243bed66d206302d7989"
+source = "git+https://github.com/tracel-ai/cubecl?rev=22c9226d87550b32412d21579b041d806762f2df#22c9226d87550b32412d21579b041d806762f2df"
 dependencies = [
  "cubecl-common",
- "darling 0.21.2",
+ "darling 0.21.3",
  "derive-new",
  "ident_case",
  "prettyplease 0.2.37",
@@ -1915,9 +1916,9 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d1273b10a233e3c1bd40243bed66d206302d7989#d1273b10a233e3c1bd40243bed66d206302d7989"
+source = "git+https://github.com/tracel-ai/cubecl?rev=22c9226d87550b32412d21579b041d806762f2df#22c9226d87550b32412d21579b041d806762f2df"
 dependencies = [
- "darling 0.21.2",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -1926,7 +1927,7 @@ dependencies = [
 [[package]]
 name = "cubecl-matmul"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d1273b10a233e3c1bd40243bed66d206302d7989#d1273b10a233e3c1bd40243bed66d206302d7989"
+source = "git+https://github.com/tracel-ai/cubecl?rev=22c9226d87550b32412d21579b041d806762f2df#22c9226d87550b32412d21579b041d806762f2df"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1943,7 +1944,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d1273b10a233e3c1bd40243bed66d206302d7989#d1273b10a233e3c1bd40243bed66d206302d7989"
+source = "git+https://github.com/tracel-ai/cubecl?rev=22c9226d87550b32412d21579b041d806762f2df#22c9226d87550b32412d21579b041d806762f2df"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1960,7 +1961,7 @@ dependencies = [
 [[package]]
 name = "cubecl-quant"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d1273b10a233e3c1bd40243bed66d206302d7989#d1273b10a233e3c1bd40243bed66d206302d7989"
+source = "git+https://github.com/tracel-ai/cubecl?rev=22c9226d87550b32412d21579b041d806762f2df#22c9226d87550b32412d21579b041d806762f2df"
 dependencies = [
  "cubecl-core",
  "cubecl-runtime",
@@ -1972,7 +1973,7 @@ dependencies = [
 [[package]]
 name = "cubecl-random"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d1273b10a233e3c1bd40243bed66d206302d7989#d1273b10a233e3c1bd40243bed66d206302d7989"
+source = "git+https://github.com/tracel-ai/cubecl?rev=22c9226d87550b32412d21579b041d806762f2df#22c9226d87550b32412d21579b041d806762f2df"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1987,7 +1988,7 @@ dependencies = [
 [[package]]
 name = "cubecl-reduce"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d1273b10a233e3c1bd40243bed66d206302d7989#d1273b10a233e3c1bd40243bed66d206302d7989"
+source = "git+https://github.com/tracel-ai/cubecl?rev=22c9226d87550b32412d21579b041d806762f2df#22c9226d87550b32412d21579b041d806762f2df"
 dependencies = [
  "cubecl-core",
  "cubecl-runtime",
@@ -2002,7 +2003,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d1273b10a233e3c1bd40243bed66d206302d7989#d1273b10a233e3c1bd40243bed66d206302d7989"
+source = "git+https://github.com/tracel-ai/cubecl?rev=22c9226d87550b32412d21579b041d806762f2df#22c9226d87550b32412d21579b041d806762f2df"
 dependencies = [
  "async-channel",
  "bytemuck",
@@ -2019,7 +2020,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spin",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "toml 0.9.5",
  "variadics_please",
  "wasm-bindgen-futures",
@@ -2028,9 +2029,9 @@ dependencies = [
 [[package]]
 name = "cubecl-spirv"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d1273b10a233e3c1bd40243bed66d206302d7989#d1273b10a233e3c1bd40243bed66d206302d7989"
+source = "git+https://github.com/tracel-ai/cubecl?rev=22c9226d87550b32412d21579b041d806762f2df#22c9226d87550b32412d21579b041d806762f2df"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "cubecl-common",
  "cubecl-core",
  "cubecl-opt",
@@ -2044,7 +2045,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d1273b10a233e3c1bd40243bed66d206302d7989#d1273b10a233e3c1bd40243bed66d206302d7989"
+source = "git+https://github.com/tracel-ai/cubecl?rev=22c9226d87550b32412d21579b041d806762f2df#22c9226d87550b32412d21579b041d806762f2df"
 dependencies = [
  "cubecl-core",
  "cubecl-runtime",
@@ -2055,7 +2056,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=d1273b10a233e3c1bd40243bed66d206302d7989#d1273b10a233e3c1bd40243bed66d206302d7989"
+source = "git+https://github.com/tracel-ai/cubecl?rev=22c9226d87550b32412d21579b041d806762f2df#22c9226d87550b32412d21579b041d806762f2df"
 dependencies = [
  "ash",
  "async-channel",
@@ -2174,12 +2175,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.2"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08440b3dd222c3d0433e63e097463969485f112baff337dfdaca043a0d760570"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core 0.21.2",
- "darling_macro 0.21.2",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
 ]
 
 [[package]]
@@ -2198,9 +2199,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.2"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25b7912bc28a04ab1b7715a68ea03aaa15662b43a1a4b2c480531fd19f8bf7e"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
 dependencies = [
  "fnv",
  "ident_case",
@@ -2223,11 +2224,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.2"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce154b9bea7fb0c8e8326e62d00354000c36e79770ff21b8c84e3aa267d9d531"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core 0.21.2",
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.106",
 ]
@@ -2748,14 +2749,14 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.25"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
 dependencies = [
  "cfg-if",
  "libc",
  "libredox",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2861,9 +2862,9 @@ checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -3298,7 +3299,7 @@ dependencies = [
  "gix-features",
  "gix-path",
  "gix-utils",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -3312,7 +3313,7 @@ dependencies = [
  "gix-validate",
  "home",
  "once_cell",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -3354,7 +3355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77b9e00cacde5b51388d28ed746c493b18a6add1f19b5e01d686b3b9ece66d4d"
 dependencies = [
  "bstr",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -3393,7 +3394,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "ignore",
  "walkdir",
 ]
@@ -3425,7 +3426,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "gpu-alloc-types",
 ]
 
@@ -3435,7 +3436,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
 ]
 
 [[package]]
@@ -3456,7 +3457,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "gpu-descriptor-types",
  "hashbrown 0.15.5",
 ]
@@ -3467,7 +3468,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
 ]
 
 [[package]]
@@ -3594,7 +3595,7 @@ dependencies = [
  "rand 0.9.2",
  "serde",
  "serde_json",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "ureq 2.12.1",
  "windows-sys 0.60.2",
 ]
@@ -3874,9 +3875,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -3978,9 +3979,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
@@ -4067,11 +4068,11 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "cfg-if",
  "libc",
 ]
@@ -4281,7 +4282,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "libc",
  "redox_syscall",
 ]
@@ -4532,9 +4533,9 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memmap2"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "483758ad303d734cec05e5c12b41d7e93e6a6390c5e9dae6bdeb7c1259012d28"
+checksum = "843a98750cd611cc2965a8213b53b43e715f13c37a9e096c6408e69990961db7"
 dependencies = [
  "libc",
  "stable_deref_trait",
@@ -4546,7 +4547,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "block",
  "core-graphics-types",
  "foreign-types 0.5.0",
@@ -4561,7 +4562,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "block",
  "core-graphics-types",
  "foreign-types 0.5.0",
@@ -4576,7 +4577,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f569fb946490b5743ad69813cb19629130ce9374034abe31614a36402d18f99e"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "block",
  "core-graphics-types",
  "foreign-types 0.5.0",
@@ -4697,7 +4698,7 @@ checksum = "2b977c445f26e49757f9aca3631c3b8b836942cb278d69a92e7b80d3b24da632"
 dependencies = [
  "arrayvec",
  "bit-set",
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "cfg_aliases",
  "codespan-reporting",
  "half",
@@ -4710,7 +4711,7 @@ dependencies = [
  "rustc-hash 1.1.0",
  "spirv",
  "strum 0.26.3",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "unicode-ident",
 ]
 
@@ -4802,7 +4803,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -5003,7 +5004,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d5c6c0ef9702176a570f06ad94f3198bc29c524c8b498f1b9346e1b1bdcbb3a"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "libloading",
  "nvml-wrapper-sys",
  "static_assertions",
@@ -5036,7 +5037,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
 ]
 
 [[package]]
@@ -5093,7 +5094,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tokio",
  "tracing",
  "url",
@@ -5120,7 +5121,7 @@ version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "libc",
  "once_cell",
  "onig_sys",
@@ -5182,7 +5183,7 @@ dependencies = [
  "cc",
  "flate2",
  "tar",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "ureq 3.1.0",
 ]
 
@@ -5204,7 +5205,7 @@ version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
@@ -5342,9 +5343,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
@@ -5462,7 +5463,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "809c5340e9e6c16eee5a07585161bae99f903f53af7402075efec23ee75fce5b"
 dependencies = [
  "atoi_simd",
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "bytemuck",
  "chrono",
  "chrono-tz",
@@ -5528,7 +5529,7 @@ version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fc3c99d7000be1be11665e1e260b93dc3b927342b9da3b53d9a1ac264e4343d"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "boxcar",
  "bytemuck",
  "chrono",
@@ -5578,7 +5579,7 @@ version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d3aa6722c9a3e0b721ec2bcdc4affd9e50e4cb606cd81bb94535a9a5a6ade9"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "hashbrown 0.15.5",
  "num-traits",
  "polars-arrow",
@@ -5643,7 +5644,7 @@ version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4ed0c87bdc8820447a38ae8efdb5a51a5a93e8bd528cffb05d05cf1145e4161"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "chrono",
  "either",
  "memchr",
@@ -5754,7 +5755,7 @@ version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fb4412c42bf637c2c02a617381c682ed425d9c8e4bd1fcb85cf352ed2a67c6"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "bytemuck",
  "bytes",
  "chrono",
@@ -5784,7 +5785,7 @@ version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08fb77ac1d37340d9cfe57cf58000cf3d9cce429e10d25066952c6145c684cc0"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "bytemuck",
  "polars-arrow",
  "polars-compute",
@@ -5811,7 +5812,7 @@ version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a8e512b1f05ffda9963fe8f6a7c62dcba86be85218bc033ecdad2802cc1b1a0"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "hex",
  "polars-core",
  "polars-error",
@@ -5835,7 +5836,7 @@ dependencies = [
  "async-channel",
  "async-trait",
  "atomic-waker",
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-queue",
@@ -6175,7 +6176,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "rustls",
  "socket2 0.5.10",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tokio",
  "tracing",
  "web-time",
@@ -6196,7 +6197,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "tinyvec",
  "tracing",
  "web-time",
@@ -6344,7 +6345,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "cassowary",
  "compact_str 0.8.1",
  "crossterm",
@@ -6425,7 +6426,7 @@ version = "11.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
 ]
 
 [[package]]
@@ -6509,7 +6510,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
 ]
 
 [[package]]
@@ -6520,7 +6521,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -6687,7 +6688,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15d73eae440a8caea284707cb840f1881af029100a814ed6d0f81615979be6c0"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "rspirv",
 ]
 
@@ -6727,7 +6728,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -6779,7 +6780,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -6792,7 +6793,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -6963,7 +6964,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -6976,7 +6977,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -7333,7 +7334,7 @@ version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
 ]
 
 [[package]]
@@ -7514,7 +7515,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7dddc5f0fee506baf8b9fdb989e242f17e4b11c61dfbb0635b705217199eea"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "byteorder",
  "enum-as-inner",
  "libc",
@@ -7528,7 +7529,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "byteorder",
  "enum-as-inner",
  "libc",
@@ -7603,7 +7604,7 @@ dependencies = [
  "cc",
  "llvm-bundler-rs",
  "paste",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -7625,15 +7626,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7698,11 +7699,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.15"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d76d3f064b981389ecb4b6b7f45a0bf9fdac1d5b9204c7bd6714fecc302850"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl 2.0.15",
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -7718,9 +7719,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.15"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d29feb33e986b6ea906bd9c3559a856983f92371b3eaa5e83782a351623de0"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7842,7 +7843,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spm_precompiled",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "unicode-normalization-alignments",
  "unicode-segmentation",
  "unicode_categories",
@@ -8048,7 +8049,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "bytes",
  "futures-util",
  "http",
@@ -8205,7 +8206,7 @@ dependencies = [
  "log",
  "rand 0.9.2",
  "sha1",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "utf-8",
 ]
 
@@ -8427,9 +8428,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "137a3c834eaf7139b73688502f3f1141a0337c5d8e4d9b536f9b8c796e26a7c4"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -8715,7 +8716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8fb398f119472be4d80bc3647339f56eb63b2a331f6a3d16e25d8144197dd9"
 dependencies = [
  "arrayvec",
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "cfg_aliases",
  "document-features",
  "hashbrown 0.15.5",
@@ -8745,7 +8746,7 @@ dependencies = [
  "arrayvec",
  "bit-set",
  "bit-vec",
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "cfg_aliases",
  "document-features",
  "hashbrown 0.15.5",
@@ -8759,7 +8760,7 @@ dependencies = [
  "raw-window-handle",
  "rustc-hash 1.1.0",
  "smallvec",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "wgpu-core-deps-apple",
  "wgpu-core-deps-emscripten",
  "wgpu-core-deps-windows-linux-android",
@@ -8804,7 +8805,7 @@ dependencies = [
  "arrayvec",
  "ash",
  "bit-set",
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "block",
  "bytemuck",
  "cfg-if",
@@ -8833,7 +8834,7 @@ dependencies = [
  "raw-window-handle",
  "renderdoc-sys",
  "smallvec",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
@@ -8847,11 +8848,11 @@ version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2aa49460c2a8ee8edba3fca54325540d904dd85b2e086ada762767e17d06e8bc"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "bytemuck",
  "js-sys",
  "log",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "web-sys",
 ]
 
@@ -8891,11 +8892,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9237,9 +9238,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
@@ -9250,7 +9251,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
 ]
 
 [[package]]
@@ -9488,9 +9489,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "4.3.0"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aed4ac33e8eb078c89e6cbb1d5c4c7703ec6d299fc3e7c3695af8f8b423468b"
+checksum = "8835eb39822904d39cb19465de1159e05d371973f0c6df3a365ad50565ddc8b9"
 dependencies = [
  "aes",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,9 +155,9 @@ portable-atomic = { version = "1.11.1" }
 portable-atomic-util = { version = "0.2.4", features = ["alloc"] }
 
 ### For the main burn branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "d1273b10a233e3c1bd40243bed66d206302d7989" }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "d1273b10a233e3c1bd40243bed66d206302d7989" }
-cubecl-quant = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "d1273b10a233e3c1bd40243bed66d206302d7989" }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "22c9226d87550b32412d21579b041d806762f2df" }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "22c9226d87550b32412d21579b041d806762f2df" }
+cubecl-quant = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "22c9226d87550b32412d21579b041d806762f2df" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }

--- a/crates/burn-import/onnx-tests/tests/test_mod.rs
+++ b/crates/burn-import/onnx-tests/tests/test_mod.rs
@@ -1,4 +1,9 @@
 #![no_std]
+#![allow(
+    clippy::approx_constant,
+    clippy::excessive_precision,
+    clippy::identity_op
+)]
 
 extern crate alloc;
 

--- a/crates/burn-import/pytorch-tests/tests/enum_module/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/enum_module/mod.rs
@@ -5,6 +5,7 @@ use burn::{
 };
 
 #[derive(Module, Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum Conv<B: Backend> {
     DwsConv(DwsConv<B>),
     Conv(Conv2d<B>),

--- a/crates/burn-ndarray/src/ops/simd/base.rs
+++ b/crates/burn-ndarray/src/ops/simd/base.rs
@@ -1,17 +1,41 @@
-use core::marker::PhantomData;
+use core::{marker::PhantomData, mem::MaybeUninit};
 
 use macerator::{Arch, Scalar, Simd};
+use ndarray::{ArcArray, ArrayD, IxDyn, ShapeBuilder};
 
 /// Whether SIMD instructions are worth using
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(all(
+    any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "wasm32",
+        target_arch = "loongarch64"
+    ),
+    not(test)
+))]
 pub fn should_use_simd(len: usize) -> bool {
     len >= 32
 }
 
 /// Whether SIMD instructions are worth using
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")))]
+#[cfg(all(
+    not(any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "wasm32",
+        target_arch = "loongarch64"
+    )),
+    not(test)
+))]
 pub fn should_use_simd(_len: usize) -> bool {
     false
+}
+
+#[cfg(test)]
+pub fn should_use_simd(_len: usize) -> bool {
+    true
 }
 
 pub(crate) fn lanes<E: Scalar>() -> usize {
@@ -34,6 +58,17 @@ pub(crate) fn lanes<E: Scalar>() -> usize {
 
 fn lanes_simd<S: Simd, E: Scalar>(_ty: PhantomData<E>) -> usize {
     E::lanes::<S>()
+}
+
+pub(crate) fn uninit_array_like<In, Out>(reference: &ArcArray<In, IxDyn>) -> ArrayD<Out> {
+    let shape = reference.raw_dim();
+    let strides = reference.strides();
+    let strides = strides.iter().map(|it| *it as usize).collect::<Vec<_>>();
+    let shape_strides = shape.strides(IxDyn(&strides));
+    let size = reference.len();
+    let mut out_data: Vec<MaybeUninit<Out>> = Vec::with_capacity(size);
+    unsafe { out_data.set_len(size) };
+    unsafe { ArrayD::from_shape_vec_unchecked(shape_strides, out_data).assume_init() }
 }
 
 pub trait MinMax {

--- a/crates/burn-ndarray/src/ops/simd/binary.rs
+++ b/crates/burn-ndarray/src/ops/simd/binary.rs
@@ -8,7 +8,7 @@ use macerator::{
 use ndarray::ArrayD;
 use seq_macro::seq;
 
-use crate::{NdArrayElement, NdArrayTensor};
+use crate::{NdArrayElement, NdArrayTensor, ops::simd::uninit_array_like};
 
 use super::{
     MinMax,
@@ -213,7 +213,7 @@ fn binary_simd_same<
         binary(lhs, rhs, out, PhantomData::<Op>);
         unsafe { core::mem::transmute::<ArrayD<T>, ArrayD<Out>>(buf) }
     } else {
-        let mut out = unsafe { ArrayD::uninit(lhs.array.shape()).assume_init() };
+        let mut out = uninit_array_like(&lhs.array);
         let lhs = lhs.array.as_slice().unwrap();
         let rhs = rhs.array.as_slice().unwrap();
         let out_slice = out.as_slice_mut().unwrap();

--- a/crates/burn-ndarray/src/ops/simd/binary_elemwise.rs
+++ b/crates/burn-ndarray/src/ops/simd/binary_elemwise.rs
@@ -8,7 +8,7 @@ use macerator::{
 use ndarray::ArrayD;
 use seq_macro::seq;
 
-use crate::{NdArrayElement, NdArrayTensor};
+use crate::{NdArrayElement, NdArrayTensor, ops::simd::uninit_array_like};
 
 use super::{MinMax, should_use_simd};
 
@@ -308,7 +308,7 @@ fn binary_scalar_simd_owned<
     input: NdArrayTensor<T>,
     elem: Op::Rhs,
 ) -> NdArrayTensor<Out> {
-    let mut out = unsafe { ArrayD::uninit(input.array.shape()).assume_init() };
+    let mut out = uninit_array_like(&input.array);
     let input = input.array.as_slice_memory_order().unwrap();
     let out_slice = out.as_slice_memory_order_mut().unwrap();
     binary_scalar_slice::<T, Out, Op>(input, out_slice, elem, PhantomData);

--- a/crates/burn-ndarray/src/ops/simd/cmp.rs
+++ b/crates/burn-ndarray/src/ops/simd/cmp.rs
@@ -5,7 +5,7 @@ use macerator::{Scalar, Simd, VEq, VOrd, Vector, vload_unaligned};
 use ndarray::ArrayD;
 use seq_macro::seq;
 
-use crate::{NdArrayElement, NdArrayTensor};
+use crate::{NdArrayElement, NdArrayTensor, ops::simd::uninit_array_like};
 
 use super::should_use_simd;
 
@@ -144,7 +144,7 @@ fn cmp_simd_same<T: NdArrayElement + Scalar, Op: SimdCmpOp<T>>(
         cmp(lhs, rhs, out, PhantomData::<Op>);
         unsafe { core::mem::transmute::<ArrayD<T>, ArrayD<bool>>(buf) }
     } else {
-        let mut out = unsafe { ArrayD::uninit(lhs.array.shape()).assume_init() };
+        let mut out = uninit_array_like(&lhs.array);
         let lhs = lhs.array.as_slice().unwrap();
         let rhs = rhs.array.as_slice().unwrap();
         let out_slice = out.as_slice_mut().unwrap();
@@ -274,7 +274,7 @@ mod elemwise {
         input: NdArrayTensor<T>,
         elem: T,
     ) -> NdArrayTensor<bool> {
-        let mut out = unsafe { ArrayD::uninit(input.array.shape()).assume_init() };
+        let mut out = uninit_array_like(&input.array);
         let input = input.array.as_slice_memory_order().unwrap();
         let out_slice = out.as_slice_memory_order_mut().unwrap();
         cmp_scalar_slice::<T, Op>(input, out_slice, elem, PhantomData);


### PR DESCRIPTION
Ndarray was not taking the input strides into account in element-wise ops when creating a new output for tensors that can't be mutated. It now ensures the output is created with the same layout as the input, to ensure element positions match.

## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.
