### PR TITLE
CubeCL: Fix wgpu extensions possibly being emitted multiple times with the same name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,7 @@ dependencies = [
  "bitflags 2.9.3",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "log",
  "prettyplease 0.2.37",
  "proc-macro2",
@@ -1380,7 +1380,7 @@ checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.2.0",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -1714,7 +1714,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.7.0"
-source = "git+https://github.com/amfaber/cubecl?rev=2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3#2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3"
+source = "git+https://github.com/amfaber/cubecl?rev=e790a93af640c107430bf3d184ee3b631d0f57cb#e790a93af640c107430bf3d184ee3b631d0f57cb"
 dependencies = [
  "cubecl-convolution",
  "cubecl-core",
@@ -1733,7 +1733,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.7.0"
-source = "git+https://github.com/amfaber/cubecl?rev=2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3#2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3"
+source = "git+https://github.com/amfaber/cubecl?rev=e790a93af640c107430bf3d184ee3b631d0f57cb#e790a93af640c107430bf3d184ee3b631d0f57cb"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -1762,7 +1762,7 @@ dependencies = [
 [[package]]
 name = "cubecl-convolution"
 version = "0.7.0"
-source = "git+https://github.com/amfaber/cubecl?rev=2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3#2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3"
+source = "git+https://github.com/amfaber/cubecl?rev=e790a93af640c107430bf3d184ee3b631d0f57cb#e790a93af640c107430bf3d184ee3b631d0f57cb"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1780,7 +1780,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.7.0"
-source = "git+https://github.com/amfaber/cubecl?rev=2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3#2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3"
+source = "git+https://github.com/amfaber/cubecl?rev=e790a93af640c107430bf3d184ee3b631d0f57cb#e790a93af640c107430bf3d184ee3b631d0f57cb"
 dependencies = [
  "bitflags 2.9.3",
  "bytemuck",
@@ -1803,7 +1803,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.7.0"
-source = "git+https://github.com/amfaber/cubecl?rev=2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3#2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3"
+source = "git+https://github.com/amfaber/cubecl?rev=e790a93af640c107430bf3d184ee3b631d0f57cb#e790a93af640c107430bf3d184ee3b631d0f57cb"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1817,7 +1817,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.7.0"
-source = "git+https://github.com/amfaber/cubecl?rev=2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3#2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3"
+source = "git+https://github.com/amfaber/cubecl?rev=e790a93af640c107430bf3d184ee3b631d0f57cb#e790a93af640c107430bf3d184ee3b631d0f57cb"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1827,6 +1827,7 @@ dependencies = [
  "cubecl-opt",
  "cubecl-reduce",
  "cubecl-runtime",
+ "cubecl-std",
  "derive-new",
  "half",
  "log",
@@ -1838,7 +1839,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.7.0"
-source = "git+https://github.com/amfaber/cubecl?rev=2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3#2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3"
+source = "git+https://github.com/amfaber/cubecl?rev=e790a93af640c107430bf3d184ee3b631d0f57cb#e790a93af640c107430bf3d184ee3b631d0f57cb"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1855,7 +1856,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.7.0"
-source = "git+https://github.com/amfaber/cubecl?rev=2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3#2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3"
+source = "git+https://github.com/amfaber/cubecl?rev=e790a93af640c107430bf3d184ee3b631d0f57cb#e790a93af640c107430bf3d184ee3b631d0f57cb"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1883,7 +1884,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.7.0"
-source = "git+https://github.com/amfaber/cubecl?rev=2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3#2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3"
+source = "git+https://github.com/amfaber/cubecl?rev=e790a93af640c107430bf3d184ee3b631d0f57cb#e790a93af640c107430bf3d184ee3b631d0f57cb"
 dependencies = [
  "cubecl-common",
  "cubecl-macros-internal",
@@ -1901,7 +1902,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.7.0"
-source = "git+https://github.com/amfaber/cubecl?rev=2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3#2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3"
+source = "git+https://github.com/amfaber/cubecl?rev=e790a93af640c107430bf3d184ee3b631d0f57cb#e790a93af640c107430bf3d184ee3b631d0f57cb"
 dependencies = [
  "cubecl-common",
  "darling 0.21.3",
@@ -1916,7 +1917,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.7.0"
-source = "git+https://github.com/amfaber/cubecl?rev=2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3#2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3"
+source = "git+https://github.com/amfaber/cubecl?rev=e790a93af640c107430bf3d184ee3b631d0f57cb#e790a93af640c107430bf3d184ee3b631d0f57cb"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
@@ -1927,7 +1928,7 @@ dependencies = [
 [[package]]
 name = "cubecl-matmul"
 version = "0.7.0"
-source = "git+https://github.com/amfaber/cubecl?rev=2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3#2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3"
+source = "git+https://github.com/amfaber/cubecl?rev=e790a93af640c107430bf3d184ee3b631d0f57cb#e790a93af640c107430bf3d184ee3b631d0f57cb"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1944,7 +1945,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.7.0"
-source = "git+https://github.com/amfaber/cubecl?rev=2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3#2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3"
+source = "git+https://github.com/amfaber/cubecl?rev=e790a93af640c107430bf3d184ee3b631d0f57cb#e790a93af640c107430bf3d184ee3b631d0f57cb"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1961,7 +1962,7 @@ dependencies = [
 [[package]]
 name = "cubecl-quant"
 version = "0.7.0"
-source = "git+https://github.com/amfaber/cubecl?rev=2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3#2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3"
+source = "git+https://github.com/amfaber/cubecl?rev=e790a93af640c107430bf3d184ee3b631d0f57cb#e790a93af640c107430bf3d184ee3b631d0f57cb"
 dependencies = [
  "cubecl-core",
  "cubecl-runtime",
@@ -1973,7 +1974,7 @@ dependencies = [
 [[package]]
 name = "cubecl-random"
 version = "0.7.0"
-source = "git+https://github.com/amfaber/cubecl?rev=2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3#2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3"
+source = "git+https://github.com/amfaber/cubecl?rev=e790a93af640c107430bf3d184ee3b631d0f57cb#e790a93af640c107430bf3d184ee3b631d0f57cb"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1988,7 +1989,7 @@ dependencies = [
 [[package]]
 name = "cubecl-reduce"
 version = "0.7.0"
-source = "git+https://github.com/amfaber/cubecl?rev=2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3#2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3"
+source = "git+https://github.com/amfaber/cubecl?rev=e790a93af640c107430bf3d184ee3b631d0f57cb#e790a93af640c107430bf3d184ee3b631d0f57cb"
 dependencies = [
  "cubecl-core",
  "cubecl-runtime",
@@ -2003,7 +2004,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.7.0"
-source = "git+https://github.com/amfaber/cubecl?rev=2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3#2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3"
+source = "git+https://github.com/amfaber/cubecl?rev=e790a93af640c107430bf3d184ee3b631d0f57cb#e790a93af640c107430bf3d184ee3b631d0f57cb"
 dependencies = [
  "async-channel",
  "bytemuck",
@@ -2029,7 +2030,7 @@ dependencies = [
 [[package]]
 name = "cubecl-spirv"
 version = "0.7.0"
-source = "git+https://github.com/amfaber/cubecl?rev=2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3#2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3"
+source = "git+https://github.com/amfaber/cubecl?rev=e790a93af640c107430bf3d184ee3b631d0f57cb#e790a93af640c107430bf3d184ee3b631d0f57cb"
 dependencies = [
  "bitflags 2.9.3",
  "cubecl-common",
@@ -2045,7 +2046,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.7.0"
-source = "git+https://github.com/amfaber/cubecl?rev=2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3#2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3"
+source = "git+https://github.com/amfaber/cubecl?rev=e790a93af640c107430bf3d184ee3b631d0f57cb#e790a93af640c107430bf3d184ee3b631d0f57cb"
 dependencies = [
  "cubecl-core",
  "cubecl-runtime",
@@ -2056,7 +2057,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.7.0"
-source = "git+https://github.com/amfaber/cubecl?rev=2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3#2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3"
+source = "git+https://github.com/amfaber/cubecl?rev=e790a93af640c107430bf3d184ee3b631d0f57cb#e790a93af640c107430bf3d184ee3b631d0f57cb"
 dependencies = [
  "ash",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,9 +155,9 @@ portable-atomic = { version = "1.11.1" }
 portable-atomic-util = { version = "0.2.4", features = ["alloc"] }
 
 ### For the main burn branch. ###
-cubecl = { git = "https://github.com/amfaber/cubecl", default-features = false, rev = "2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3" }
-cubecl-common = { git = "https://github.com/amfaber/cubecl", default-features = false, rev = "2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3" }
-cubecl-quant = { git = "https://github.com/amfaber/cubecl", default-features = false, rev = "2e7a437a5773efc6b8a86dcc11976b2ead3ef5c3" }
+cubecl = { git = "https://github.com/amfaber/cubecl", default-features = false, rev = "e790a93af640c107430bf3d184ee3b631d0f57cb" }
+cubecl-common = { git = "https://github.com/amfaber/cubecl", default-features = false, rev = "e790a93af640c107430bf3d184ee3b631d0f57cb" }
+cubecl-quant = { git = "https://github.com/amfaber/cubecl", default-features = false, rev = "e790a93af640c107430bf3d184ee3b631d0f57cb" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }


### PR DESCRIPTION
## Make sure wgpu extensions are emitted with different names

Should solve https://github.com/tracel-ai/burn/issues/3461, though I didn't get the concrete example to run as I didn't want to bother with installing SDL2 on windows to run gym-rs. I experienced the same panic in my model, and my model is fixed by this change.

As per the guidelines for contributing to cubecl, I am also opening a PR here to ensure nothing in burn breaks as a result of the changes.

[The cubecl PR](https://github.com/tracel-ai/cubecl/pull/838) has more details