### PR TITLE
Add with_interrupter for LearnerBuilder

### DIFF
--- a/crates/burn-train/src/learner/builder.rs
+++ b/crates/burn-train/src/learner/builder.rs
@@ -241,6 +241,12 @@ where
     pub fn interrupter(&self) -> TrainingInterrupter {
         self.interrupter.clone()
     }
+    
+    /// Override the handle for stopping training with an externally provided handle
+    pub fn with_interrupter(mut self, interrupter: TrainingInterrupter) -> Self {
+        self.interrupter = interrupter;
+        self
+    }
 
     /// Register an [early stopping strategy](EarlyStoppingStrategy) to stop the training when the
     /// conditions are meet.

--- a/crates/burn-train/src/learner/builder.rs
+++ b/crates/burn-train/src/learner/builder.rs
@@ -241,7 +241,7 @@ where
     pub fn interrupter(&self) -> TrainingInterrupter {
         self.interrupter.clone()
     }
-    
+
     /// Override the handle for stopping training with an externally provided handle
     pub fn with_interrupter(mut self, interrupter: TrainingInterrupter) -> Self {
         self.interrupter = interrupter;


### PR DESCRIPTION
## Add a with_interrupter method for LearnerBuilder

Currently, the LearnerBuilder constructs its own TrainingInterrupter, and the only way to get a handle to it is by getting it from .interrupter() before training is started. I want to wrap a bunch of configuration of my training loop in a more convenient function. This means that the LearnerBuilder is constructed and consumed within my convenience function, and thus there is no way to get a handle to the interrupter. This change makes it possible to my convenience function to take the interrupter as an argument and pass it along to the learner.
