### PR TITLE
Feature: Remove generic dependency on backends from RecordItems

### DIFF
--- a/crates/burn-core/src/record/primitive.rs
+++ b/crates/burn-core/src/record/primitive.rs
@@ -258,6 +258,7 @@ primitive!(i8);
 /// deserializing arrays of variable size,
 /// see [serde/issues/1937](https://github.com/serde-rs/serde/issues/1937)
 /// for backward compatibility reasons. Serde APIs were created before const generics.
+#[derive(Clone)]
 pub struct Array<const N: usize, T>([T; N]);
 
 impl<T: Serialize, const N: usize> Serialize for Array<N, T> {

--- a/crates/burn-core/tests/test_derive_module.rs
+++ b/crates/burn-core/tests/test_derive_module.rs
@@ -83,6 +83,37 @@ impl<B: Backend> ModuleComposed<B> {
     }
 }
 
+#[allow(dead_code)]
+mod compiletime_clone_impl_check {
+    use burn_core::{
+        module::{Module, ModuleDisplay},
+        prelude::Backend,
+        record::{PrecisionSettings, Record},
+    };
+
+    use super::*;
+    
+    type RecordItem<M, B, S> = <<M as Module<B>>::Record as Record<B>>::Item<S>;
+
+    fn implements_clone<T: Clone>() {}
+
+    fn basic_implements_clone<B: Backend, S: PrecisionSettings>() {
+        implements_clone::<RecordItem<ModuleBasic<B>, B, S>>();
+        implements_clone::<RecordItem<ModuleComposed<B>, B, S>>();
+    }
+
+    fn generic_implements_clone<B, S, M>()
+    where
+        B: Backend,
+        S: PrecisionSettings,
+        M: Module<B> + ModuleDisplay,
+        RecordItem<M, B, S>: Clone,
+    {
+        implements_clone::<RecordItem<ModuleWithGenericModule<B, M>, B, S>>();
+        implements_clone::<RecordItem<ModuleEnumWithGenericModule<B, M>, B, S>>();
+    }
+}
+
 mod state {
     use super::*;
 

--- a/crates/burn-core/tests/test_derive_module.rs
+++ b/crates/burn-core/tests/test_derive_module.rs
@@ -92,7 +92,7 @@ mod compiletime_clone_impl_check {
     };
 
     use super::*;
-    
+
     type RecordItem<M, B, S> = <<M as Module<B>>::Record as Record<B>>::Item<S>;
 
     fn implements_clone<T: Clone>() {}

--- a/crates/burn-derive/Cargo.toml
+++ b/crates/burn-derive/Cargo.toml
@@ -19,5 +19,5 @@ proc-macro = true
 [dependencies]
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
-syn = { workspace = true }
+syn = { workspace = true, features = ["visit-mut"] }
 derive-new = { workspace = true }

--- a/crates/burn-derive/src/record/item/codegen.rs
+++ b/crates/burn-derive/src/record/item/codegen.rs
@@ -1,5 +1,8 @@
 use proc_macro2::{Ident, TokenStream};
-use syn::Generics;
+use syn::{
+    GenericArgument, Generics, TypePath,
+    visit_mut::{self, VisitMut},
+};
 
 /// Basic trait to be implemented for record generation.
 pub(crate) trait RecordItemCodegen {
@@ -16,4 +19,30 @@ pub(crate) trait RecordItemCodegen {
     fn gen_into_item(&self, item_name: &Ident) -> TokenStream;
     /// Generate the from item function.
     fn gen_from_item(&self) -> TokenStream;
+}
+
+pub(crate) struct ReplaceBackend<'a> {
+    pub(crate) replacement: &'a TypePath,
+}
+
+impl<'a> VisitMut for ReplaceBackend<'a> {
+    fn visit_type_path_mut(&mut self, tp: &mut syn::TypePath) {
+        if tp.qself.is_none() && tp.path.segments.len() == 1 && tp.path.segments[0].ident == "B" {
+            *tp = self.replacement.clone();
+            return;
+        }
+
+        // Otherwise recurse and also scrub generic args like Foo<B, T>
+        for seg in tp.path.segments.iter_mut() {
+            if let syn::PathArguments::AngleBracketed(ab) = &mut seg.arguments {
+                for arg in ab.args.iter_mut() {
+                    if let GenericArgument::Type(ty) = arg {
+                        self.visit_type_mut(ty);
+                    }
+                }
+            }
+        }
+
+        visit_mut::visit_type_path_mut(self, tp);
+    }
 }

--- a/crates/burn-derive/src/record/item/codegen_enum.rs
+++ b/crates/burn-derive/src/record/item/codegen_enum.rs
@@ -26,7 +26,9 @@ impl RecordItemCodegen for EnumRecordItemCodegen {
         has_backend: bool,
     ) -> TokenStream {
         let mut variants = quote! {};
-        let mut bounds = quote! {};
+        let mut serde_bounds = quote! {};
+        let mut clone_bounds = vec![];
+        let mut clone_match_arms = quote! {};
         let vis = &self.vis;
 
         // Capture the Record enum variant types and names to transpose them in RecordItem
@@ -40,34 +42,56 @@ impl RecordItemCodegen for EnumRecordItemCodegen {
             });
 
             // Item types must implement serialization/deserialization
-            bounds.extend(quote! {
-              <#ty as burn::record::Record<B>>::Item<S>: burn::serde::Serialize + burn::serde::de::DeserializeOwned,
-          });
+            serde_bounds.extend(quote! {
+                <#ty as burn::record::Record<B>>::Item<S>: burn::serde::Serialize + burn::serde::de::DeserializeOwned,
+            });
+            clone_bounds.push(parse_quote! {
+                <#ty as burn::record::Record<B>>::Item<S>: Clone
+            });
+
+            clone_match_arms.extend(quote! {
+                Self::#name(inner) => Self::#name(inner.clone()),
+            });
         }
-        let bound = bounds.to_string();
+        let serde_bound = serde_bounds.to_string();
 
         // Capture the type's generics and bounds in where clauses
-        let (generics, generics_where) = if !has_backend {
-            let mut generics = generics.clone();
+        let mut generics = generics.clone();
+        if !has_backend {
             let param: syn::TypeParam = parse_quote! { B: burn::tensor::backend::Backend };
             generics.params.push(syn::GenericParam::Type(param));
-            let (generics, _, generics_where) = generics.split_for_impl();
-            (quote! { #generics }, quote! { #generics_where })
-        } else {
-            let (generics, _, generics_where) = generics.split_for_impl();
-            (quote! { #generics }, quote! { #generics_where })
+        }
+        let (generics, type_generics, generics_where) = generics.split_for_impl();
+
+        let clone_bounds = generics_where.cloned().map(|mut where_clause| {
+            for predicate in clone_bounds {
+                where_clause.predicates.push(predicate);
+            }
+            where_clause
+        });
+
+        let clone_impl = quote! {
+            impl #generics Clone for #item_name #type_generics #clone_bounds{
+                fn clone(&self) -> Self{
+                    match self{
+                        #clone_match_arms
+                    }
+                }
+            }
         };
 
         // Return the generated stream of token trees (i.e., code to be generated)
         quote! {
 
             /// The record item type for the module.
-            #[derive(burn::serde::Serialize, burn::serde::Deserialize, Clone)]
+            #[derive(burn::serde::Serialize, burn::serde::Deserialize)]
             #[serde(crate = "burn::serde")]
-            #[serde(bound = #bound)]
+            #[serde(bound = #serde_bound)]
             #vis enum #item_name #generics #generics_where {
                 #variants
             }
+
+            #clone_impl
         }
     }
 

--- a/crates/burn-derive/src/record/item/codegen_enum.rs
+++ b/crates/burn-derive/src/record/item/codegen_enum.rs
@@ -71,9 +71,9 @@ impl RecordItemCodegen for EnumRecordItemCodegen {
         });
 
         let clone_impl = quote! {
-            impl #generics Clone for #item_name #type_generics #clone_bounds{
-                fn clone(&self) -> Self{
-                    match self{
+            impl #generics Clone for #item_name #type_generics #clone_bounds {
+                fn clone(&self) -> Self {
+                    match self {
                         #clone_match_arms
                     }
                 }

--- a/crates/burn-derive/src/record/item/codegen_enum.rs
+++ b/crates/burn-derive/src/record/item/codegen_enum.rs
@@ -62,7 +62,7 @@ impl RecordItemCodegen for EnumRecordItemCodegen {
         quote! {
 
             /// The record item type for the module.
-            #[derive(burn::serde::Serialize, burn::serde::Deserialize)]
+            #[derive(burn::serde::Serialize, burn::serde::Deserialize, Clone)]
             #[serde(crate = "burn::serde")]
             #[serde(bound = #bound)]
             #vis enum #item_name #generics #generics_where {

--- a/crates/burn-derive/src/record/item/codegen_struct.rs
+++ b/crates/burn-derive/src/record/item/codegen_struct.rs
@@ -1,7 +1,10 @@
-use crate::shared::field::{FieldTypeAnalyzer, parse_fields};
+use crate::{
+    record::{codegen::strip_backend_from_generics, item::codegen::ReplaceBackend},
+    shared::field::{FieldTypeAnalyzer, parse_fields},
+};
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
-use syn::{Generics, Visibility, parse_quote};
+use syn::{Generics, Visibility, parse_quote, visit_mut::VisitMut};
 
 use super::codegen::RecordItemCodegen;
 
@@ -33,21 +36,33 @@ impl RecordItemCodegen for StructRecordItemCodegen {
         let mut clone_delegate = quote! {};
         let vis = &self.vis;
 
+        let backend = parse_quote!(burn::tensor::backend::DummyBackend);
+
+        let mut replacer = ReplaceBackend {
+            replacement: &backend,
+        };
+
         for field in self.fields.iter() {
-            let ty = &field.field.ty;
+            let mut ty = field.field.ty.clone();
+
+            if has_backend {
+                replacer.visit_type_mut(&mut ty);
+            }
             let name = &field.field.ident;
+
+            let item_type = quote!(<#ty as burn::record::Record<#backend>>::Item<S>);
 
             fields.extend(quote! {
                 /// Field to be serialized.
-                pub #name: <#ty as burn::record::Record<B>>::Item<S>,
+                pub #name: #item_type,
             });
 
             serde_bounds.extend(quote! {
-                <#ty as burn::record::Record<B>>::Item<S>: burn::serde::Serialize + burn::serde::de::DeserializeOwned,
+                #item_type: burn::serde::Serialize + burn::serde::de::DeserializeOwned,
             });
 
             clone_bounds.push(parse_quote! {
-                <#ty as burn::record::Record<B>>::Item<S>: Clone
+                #item_type: Clone
             });
 
             clone_delegate.extend(quote! {
@@ -56,11 +71,18 @@ impl RecordItemCodegen for StructRecordItemCodegen {
         }
         let serde_bound = serde_bounds.to_string();
 
-        let mut generics = generics.clone();
-        if !has_backend {
-            let param: syn::TypeParam = parse_quote! { B: burn::tensor::backend::Backend };
-            generics.params.push(syn::GenericParam::Type(param));
-        }
+        let generics = if has_backend {
+            strip_backend_from_generics(generics)
+        } else {
+            generics.clone()
+        };
+
+        // let mut generics = generics.clone();
+        // if !has_backend {
+        //     let param: syn::TypeParam = parse_quote! { B: burn::tensor::backend::Backend };
+        //     generics.params.push(syn::GenericParam::Type(param));
+        // }
+
         let (generics, type_generics, generics_where) = generics.split_for_impl();
 
         let clone_bounds = generics_where.cloned().map(|mut where_clause| {

--- a/crates/burn-derive/src/record/item/codegen_struct.rs
+++ b/crates/burn-derive/src/record/item/codegen_struct.rs
@@ -71,9 +71,9 @@ impl RecordItemCodegen for StructRecordItemCodegen {
         });
 
         let clone_impl = quote! {
-            impl #generics Clone for #item_name #type_generics #clone_bounds{
-                fn clone(&self) -> Self{
-                    Self{
+            impl #generics Clone for #item_name #type_generics #clone_bounds {
+                fn clone(&self) -> Self {
+                    Self {
                         #clone_delegate
                     }
                 }

--- a/crates/burn-derive/src/record/item/codegen_struct.rs
+++ b/crates/burn-derive/src/record/item/codegen_struct.rs
@@ -28,7 +28,9 @@ impl RecordItemCodegen for StructRecordItemCodegen {
         has_backend: bool,
     ) -> TokenStream {
         let mut fields = quote! {};
-        let mut bounds = quote! {};
+        let mut serde_bounds = quote! {};
+        let mut clone_bounds = vec![];
+        let mut clone_delegate = quote! {};
         let vis = &self.vis;
 
         for field in self.fields.iter() {
@@ -40,32 +42,55 @@ impl RecordItemCodegen for StructRecordItemCodegen {
                 pub #name: <#ty as burn::record::Record<B>>::Item<S>,
             });
 
-            bounds.extend(quote! {
-          <#ty as burn::record::Record<B>>::Item<S>: burn::serde::Serialize + burn::serde::de::DeserializeOwned,
-      });
-        }
-        let bound = bounds.to_string();
+            serde_bounds.extend(quote! {
+                <#ty as burn::record::Record<B>>::Item<S>: burn::serde::Serialize + burn::serde::de::DeserializeOwned,
+            });
 
-        let (generics, generics_where) = if !has_backend {
-            let mut generics = generics.clone();
+            clone_bounds.push(parse_quote! {
+                <#ty as burn::record::Record<B>>::Item<S>: Clone
+            });
+
+            clone_delegate.extend(quote! {
+                #name: self.#name.clone(),
+            });
+        }
+        let serde_bound = serde_bounds.to_string();
+
+        let mut generics = generics.clone();
+        if !has_backend {
             let param: syn::TypeParam = parse_quote! { B: burn::tensor::backend::Backend };
             generics.params.push(syn::GenericParam::Type(param));
-            let (generics, _, generics_where) = generics.split_for_impl();
-            (quote! { #generics }, quote! { #generics_where })
-        } else {
-            let (generics, _, generics_where) = generics.split_for_impl();
-            (quote! { #generics }, quote! { #generics_where })
+        }
+        let (generics, type_generics, generics_where) = generics.split_for_impl();
+
+        let clone_bounds = generics_where.cloned().map(|mut where_clause| {
+            for predicate in clone_bounds {
+                where_clause.predicates.push(predicate);
+            }
+            where_clause
+        });
+
+        let clone_impl = quote! {
+            impl #generics Clone for #item_name #type_generics #clone_bounds{
+                fn clone(&self) -> Self{
+                    Self{
+                        #clone_delegate
+                    }
+                }
+            }
         };
 
         quote! {
 
             /// The record item type for the module.
-            #[derive(burn::serde::Serialize, burn::serde::Deserialize, Clone)]
+            #[derive(burn::serde::Serialize, burn::serde::Deserialize)]
             #[serde(crate = "burn::serde")]
-            #[serde(bound = #bound)]
+            #[serde(bound = #serde_bound)]
             #vis struct #item_name #generics #generics_where {
                 #fields
             }
+
+            #clone_impl
         }
     }
 

--- a/crates/burn-derive/src/record/item/codegen_struct.rs
+++ b/crates/burn-derive/src/record/item/codegen_struct.rs
@@ -60,7 +60,7 @@ impl RecordItemCodegen for StructRecordItemCodegen {
         quote! {
 
             /// The record item type for the module.
-            #[derive(burn::serde::Serialize, burn::serde::Deserialize)]
+            #[derive(burn::serde::Serialize, burn::serde::Deserialize, Clone)]
             #[serde(crate = "burn::serde")]
             #[serde(bound = #bound)]
             #vis struct #item_name #generics #generics_where {

--- a/crates/burn-tensor/src/tensor/backend/dummy.rs
+++ b/crates/burn-tensor/src/tensor/backend/dummy.rs
@@ -1,0 +1,1301 @@
+use crate::{
+    TensorMetadata,
+    backend::{Backend, DeviceOps},
+    ops::{
+        ActivationOps, BoolTensorOps, FloatTensorOps, IntTensorOps, ModuleOps, QTensorOps,
+        TransactionOps,
+    },
+    quantization::QTensorPrimitive,
+};
+
+#[derive(Clone, Debug, Default)]
+pub struct DummyBackend;
+
+#[derive(Clone, Default, PartialEq, Debug)]
+pub struct DummyDevice;
+
+impl DeviceOps for DummyDevice {
+    fn id(&self) -> super::DeviceId {
+        todo!()
+    }
+}
+
+impl TensorMetadata for DummyTensor {
+    fn dtype(&self) -> crate::DType {
+        todo!()
+    }
+
+    fn shape(&self) -> crate::Shape {
+        todo!()
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct DummyTensor;
+
+impl QTensorPrimitive for DummyTensor {
+    fn scheme(&self) -> &cubecl_quant::scheme::QuantScheme {
+        todo!()
+    }
+}
+
+impl Backend for DummyBackend {
+    type Device = DummyDevice;
+
+    type FloatTensorPrimitive = DummyTensor;
+
+    type FloatElem = f32;
+
+    type IntTensorPrimitive = DummyTensor;
+
+    type IntElem = i32;
+
+    type BoolTensorPrimitive = DummyTensor;
+
+    type BoolElem = bool;
+
+    type QuantizedTensorPrimitive = DummyTensor;
+
+    type QuantizedEncoding = i8;
+
+    fn name(_device: &Self::Device) -> String {
+        unimplemented!()
+    }
+
+    fn seed(_seed: u64) {
+        unimplemented!()
+    }
+}
+
+impl FloatTensorOps<DummyBackend> for DummyBackend {
+    fn float_from_data(
+        data: crate::TensorData,
+        device: &crate::Device<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_random(
+        shape: crate::Shape,
+        distribution: crate::Distribution,
+        device: &crate::Device<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_into_data(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+    ) -> impl Future<Output = crate::TensorData> + Send {
+        async { todo!() }
+    }
+
+    fn float_device(tensor: &crate::ops::FloatTensor<DummyBackend>) -> crate::Device<DummyBackend> {
+        todo!()
+    }
+
+    fn float_to_device(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+        device: &crate::Device<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_into_int(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_empty(
+        shape: crate::Shape,
+        device: &crate::Device<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_add(
+        lhs: crate::ops::FloatTensor<DummyBackend>,
+        rhs: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_add_scalar(
+        lhs: crate::ops::FloatTensor<DummyBackend>,
+        rhs: crate::ops::FloatElem<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_sub(
+        lhs: crate::ops::FloatTensor<DummyBackend>,
+        rhs: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_sub_scalar(
+        lhs: crate::ops::FloatTensor<DummyBackend>,
+        rhs: crate::ops::FloatElem<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_mul(
+        lhs: crate::ops::FloatTensor<DummyBackend>,
+        rhs: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_mul_scalar(
+        lhs: crate::ops::FloatTensor<DummyBackend>,
+        rhs: crate::ops::FloatElem<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_div(
+        lhs: crate::ops::FloatTensor<DummyBackend>,
+        rhs: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_div_scalar(
+        lhs: crate::ops::FloatTensor<DummyBackend>,
+        rhs: crate::ops::FloatElem<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_remainder(
+        lhs: crate::ops::FloatTensor<DummyBackend>,
+        rhs: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_remainder_scalar(
+        lhs: crate::ops::FloatTensor<DummyBackend>,
+        rhs: crate::ops::FloatElem<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_matmul(
+        lhs: crate::ops::FloatTensor<DummyBackend>,
+        rhs: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_recip(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_swap_dims(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+        dim1: usize,
+        dim2: usize,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_permute(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+        axes: &[usize],
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_flip(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+        axes: &[usize],
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_reshape(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+        shape: crate::Shape,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_gather(
+        dim: usize,
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+        indices: crate::ops::IntTensor<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_scatter(
+        dim: usize,
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+        indices: crate::ops::IntTensor<DummyBackend>,
+        value: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_select(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+        dim: usize,
+        indices: crate::ops::IntTensor<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_select_assign(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+        dim: usize,
+        indices: crate::ops::IntTensor<DummyBackend>,
+        value: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_slice(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+        ranges: &[core::ops::Range<usize>],
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_slice_assign(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+        ranges: &[core::ops::Range<usize>],
+        value: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_mask_where(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+        mask: crate::ops::BoolTensor<DummyBackend>,
+        value: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_mask_fill(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+        mask: crate::ops::BoolTensor<DummyBackend>,
+        value: crate::ops::FloatElem<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_equal(
+        lhs: crate::ops::FloatTensor<DummyBackend>,
+        rhs: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_equal_elem(
+        lhs: crate::ops::FloatTensor<DummyBackend>,
+        rhs: crate::ops::FloatElem<DummyBackend>,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_greater(
+        lhs: crate::ops::FloatTensor<DummyBackend>,
+        rhs: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_greater_elem(
+        lhs: crate::ops::FloatTensor<DummyBackend>,
+        rhs: crate::ops::FloatElem<DummyBackend>,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_greater_equal(
+        lhs: crate::ops::FloatTensor<DummyBackend>,
+        rhs: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_greater_equal_elem(
+        lhs: crate::ops::FloatTensor<DummyBackend>,
+        rhs: crate::ops::FloatElem<DummyBackend>,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_lower(
+        lhs: crate::ops::FloatTensor<DummyBackend>,
+        rhs: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_lower_elem(
+        lhs: crate::ops::FloatTensor<DummyBackend>,
+        rhs: crate::ops::FloatElem<DummyBackend>,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_lower_equal(
+        lhs: crate::ops::FloatTensor<DummyBackend>,
+        rhs: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_lower_equal_elem(
+        lhs: crate::ops::FloatTensor<DummyBackend>,
+        rhs: crate::ops::FloatElem<DummyBackend>,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_sum(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_sum_dim(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+        dim: usize,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_mean_dim(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+        dim: usize,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_cast(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+        dtype: crate::FloatDType,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_exp(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_log(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_log1p(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_powf(
+        lhs: crate::ops::FloatTensor<DummyBackend>,
+        rhs: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_powf_scalar(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+        value: f32,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_sqrt(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_abs(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_cos(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_sin(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_round(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_floor(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_ceil(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_erf(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_argmax(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+        dim: usize,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_argmin(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+        dim: usize,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn float_expand(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+        shape: crate::Shape,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+}
+
+impl TransactionOps<DummyBackend> for DummyBackend {}
+
+impl QTensorOps<DummyBackend> for DummyBackend {
+    fn q_from_data(
+        data: crate::TensorData,
+        device: &crate::Device<DummyBackend>,
+    ) -> crate::ops::QuantizedTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn quantize(
+        tensor: crate::ops::FloatTensor<DummyBackend>,
+        scheme: &cubecl_quant::scheme::QuantScheme,
+        qparams: crate::quantization::QuantizationParametersPrimitive<DummyBackend>,
+    ) -> crate::ops::QuantizedTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn dequantize(
+        tensor: crate::ops::QuantizedTensor<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn q_device(tensor: &crate::ops::QuantizedTensor<DummyBackend>) -> crate::Device<DummyBackend> {
+        todo!()
+    }
+
+    fn q_to_device(
+        tensor: crate::ops::QuantizedTensor<DummyBackend>,
+        device: &crate::Device<DummyBackend>,
+    ) -> crate::ops::QuantizedTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn q_reshape(
+        tensor: crate::ops::QuantizedTensor<DummyBackend>,
+        shape: crate::Shape,
+    ) -> crate::ops::QuantizedTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn q_into_data(
+        tensor: crate::ops::QuantizedTensor<DummyBackend>,
+    ) -> impl Future<Output = crate::TensorData> + Send {
+        async { todo!() }
+    }
+
+    fn q_expand(
+        tensor: crate::ops::QuantizedTensor<DummyBackend>,
+        shape: crate::Shape,
+    ) -> crate::ops::QuantizedTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn q_swap_dims(
+        tensor: crate::ops::QuantizedTensor<DummyBackend>,
+        dim1: usize,
+        dim2: usize,
+    ) -> crate::ops::QuantizedTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn q_permute(
+        tensor: crate::ops::QuantizedTensor<DummyBackend>,
+        axes: &[usize],
+    ) -> crate::ops::QuantizedTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn q_flip(
+        tensor: crate::ops::QuantizedTensor<DummyBackend>,
+        axes: &[usize],
+    ) -> crate::ops::QuantizedTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn q_select(
+        tensor: crate::ops::QuantizedTensor<DummyBackend>,
+        dim: usize,
+        indices: crate::ops::IntTensor<DummyBackend>,
+    ) -> crate::ops::QuantizedTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn q_slice(
+        tensor: crate::ops::QuantizedTensor<DummyBackend>,
+        ranges: &[core::ops::Range<usize>],
+    ) -> crate::ops::QuantizedTensor<DummyBackend> {
+        todo!()
+    }
+}
+
+impl ActivationOps<DummyBackend> for DummyBackend {}
+
+impl BoolTensorOps<DummyBackend> for DummyBackend {
+    fn bool_empty(
+        shape: crate::Shape,
+        device: &crate::Device<DummyBackend>,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn bool_zeros(
+        shape: crate::Shape,
+        device: &crate::Device<DummyBackend>,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn bool_ones(
+        shape: crate::Shape,
+        device: &crate::Device<DummyBackend>,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn bool_into_data(
+        tensor: crate::ops::BoolTensor<DummyBackend>,
+    ) -> impl Future<Output = crate::TensorData> + Send {
+        async { todo!() }
+    }
+
+    fn bool_from_data(
+        data: crate::TensorData,
+        device: &crate::Device<DummyBackend>,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn bool_into_int(
+        tensor: crate::ops::BoolTensor<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn bool_into_float(
+        tensor: crate::ops::BoolTensor<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn bool_device(tensor: &crate::ops::BoolTensor<DummyBackend>) -> crate::Device<DummyBackend> {
+        todo!()
+    }
+
+    fn bool_to_device(
+        tensor: crate::ops::BoolTensor<DummyBackend>,
+        device: &crate::Device<DummyBackend>,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn bool_reshape(
+        tensor: crate::ops::BoolTensor<DummyBackend>,
+        shape: crate::Shape,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn bool_slice(
+        tensor: crate::ops::BoolTensor<DummyBackend>,
+        ranges: &[core::ops::Range<usize>],
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn bool_slice_assign(
+        tensor: crate::ops::BoolTensor<DummyBackend>,
+        ranges: &[core::ops::Range<usize>],
+        value: crate::ops::BoolTensor<DummyBackend>,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn bool_equal(
+        lhs: crate::ops::BoolTensor<DummyBackend>,
+        rhs: crate::ops::BoolTensor<DummyBackend>,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn bool_not(
+        tensor: crate::ops::BoolTensor<DummyBackend>,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn bool_and(
+        tensor: crate::ops::BoolTensor<DummyBackend>,
+        rhs: crate::ops::BoolTensor<DummyBackend>,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn bool_or(
+        tensor: crate::ops::BoolTensor<DummyBackend>,
+        rhs: crate::ops::BoolTensor<DummyBackend>,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn bool_swap_dims(
+        tensor: crate::ops::BoolTensor<DummyBackend>,
+        dim1: usize,
+        dim2: usize,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn bool_permute(
+        tensor: crate::ops::BoolTensor<DummyBackend>,
+        axes: &[usize],
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn bool_flip(
+        tensor: crate::ops::BoolTensor<DummyBackend>,
+        axes: &[usize],
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn bool_expand(
+        tensor: crate::ops::BoolTensor<DummyBackend>,
+        shape: crate::Shape,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+}
+
+impl ModuleOps<DummyBackend> for DummyBackend {
+    fn conv2d(
+        x: crate::ops::FloatTensor<DummyBackend>,
+        weight: crate::ops::FloatTensor<DummyBackend>,
+        bias: Option<crate::ops::FloatTensor<DummyBackend>>,
+        options: crate::ops::ConvOptions<2>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn deform_conv2d(
+        x: crate::ops::FloatTensor<DummyBackend>,
+        offset: crate::ops::FloatTensor<DummyBackend>,
+        weight: crate::ops::FloatTensor<DummyBackend>,
+        mask: Option<crate::ops::FloatTensor<DummyBackend>>,
+        bias: Option<crate::ops::FloatTensor<DummyBackend>>,
+        options: crate::ops::DeformConvOptions<2>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn deform_conv2d_backward(
+        x: crate::ops::FloatTensor<DummyBackend>,
+        offset: crate::ops::FloatTensor<DummyBackend>,
+        weight: crate::ops::FloatTensor<DummyBackend>,
+        mask: Option<crate::ops::FloatTensor<DummyBackend>>,
+        bias: Option<crate::ops::FloatTensor<DummyBackend>>,
+        output_grad: crate::ops::FloatTensor<DummyBackend>,
+        options: crate::ops::DeformConvOptions<2>,
+    ) -> crate::ops::DeformConv2dBackward<DummyBackend> {
+        todo!()
+    }
+
+    fn conv3d(
+        x: crate::ops::FloatTensor<DummyBackend>,
+        weight: crate::ops::FloatTensor<DummyBackend>,
+        bias: Option<crate::ops::FloatTensor<DummyBackend>>,
+        options: crate::ops::ConvOptions<3>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn conv_transpose2d(
+        x: crate::ops::FloatTensor<DummyBackend>,
+        weight: crate::ops::FloatTensor<DummyBackend>,
+        bias: Option<crate::ops::FloatTensor<DummyBackend>>,
+        options: crate::ops::ConvTransposeOptions<2>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn conv_transpose3d(
+        x: crate::ops::FloatTensor<DummyBackend>,
+        weight: crate::ops::FloatTensor<DummyBackend>,
+        bias: Option<crate::ops::FloatTensor<DummyBackend>>,
+        options: crate::ops::ConvTransposeOptions<3>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn avg_pool2d(
+        x: crate::ops::FloatTensor<DummyBackend>,
+        kernel_size: [usize; 2],
+        stride: [usize; 2],
+        padding: [usize; 2],
+        count_include_pad: bool,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn avg_pool2d_backward(
+        x: crate::ops::FloatTensor<DummyBackend>,
+        grad: crate::ops::FloatTensor<DummyBackend>,
+        kernel_size: [usize; 2],
+        stride: [usize; 2],
+        padding: [usize; 2],
+        count_include_pad: bool,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn adaptive_avg_pool2d(
+        x: crate::ops::FloatTensor<DummyBackend>,
+        output_size: [usize; 2],
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn adaptive_avg_pool2d_backward(
+        x: crate::ops::FloatTensor<DummyBackend>,
+        grad: crate::ops::FloatTensor<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn max_pool2d(
+        x: crate::ops::FloatTensor<DummyBackend>,
+        kernel_size: [usize; 2],
+        stride: [usize; 2],
+        padding: [usize; 2],
+        dilation: [usize; 2],
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn max_pool2d_with_indices(
+        x: crate::ops::FloatTensor<DummyBackend>,
+        kernel_size: [usize; 2],
+        stride: [usize; 2],
+        padding: [usize; 2],
+        dilation: [usize; 2],
+    ) -> crate::ops::MaxPool2dWithIndices<DummyBackend> {
+        todo!()
+    }
+
+    fn max_pool2d_with_indices_backward(
+        x: crate::ops::FloatTensor<DummyBackend>,
+        kernel_size: [usize; 2],
+        stride: [usize; 2],
+        padding: [usize; 2],
+        dilation: [usize; 2],
+        output_grad: crate::ops::FloatTensor<DummyBackend>,
+        indices: crate::ops::IntTensor<DummyBackend>,
+    ) -> crate::ops::MaxPool2dBackward<DummyBackend> {
+        todo!()
+    }
+
+    fn interpolate(
+        x: crate::ops::FloatTensor<DummyBackend>,
+        output_size: [usize; 2],
+        options: crate::ops::InterpolateOptions,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn interpolate_backward(
+        x: crate::ops::FloatTensor<DummyBackend>,
+        grad: crate::ops::FloatTensor<DummyBackend>,
+        output_size: [usize; 2],
+        options: crate::ops::InterpolateOptions,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+}
+
+impl IntTensorOps<DummyBackend> for DummyBackend {
+    fn int_empty(
+        shape: crate::Shape,
+        device: &crate::Device<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_into_data(
+        tensor: crate::ops::IntTensor<DummyBackend>,
+    ) -> impl Future<Output = crate::TensorData> + Send {
+        async { todo!() }
+    }
+
+    fn int_from_data(
+        data: crate::TensorData,
+        device: &crate::Device<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_device(tensor: &crate::ops::IntTensor<DummyBackend>) -> crate::Device<DummyBackend> {
+        todo!()
+    }
+
+    fn int_to_device(
+        tensor: crate::ops::IntTensor<DummyBackend>,
+        device: &crate::Device<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_reshape(
+        tensor: crate::ops::IntTensor<DummyBackend>,
+        shape: crate::Shape,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_slice(
+        tensor: crate::ops::IntTensor<DummyBackend>,
+        indices: &[core::ops::Range<usize>],
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_slice_assign(
+        tensor: crate::ops::IntTensor<DummyBackend>,
+        indices: &[core::ops::Range<usize>],
+        value: crate::ops::IntTensor<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_into_float(
+        tensor: crate::ops::IntTensor<DummyBackend>,
+    ) -> crate::ops::FloatTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_mask_where(
+        tensor: crate::ops::IntTensor<DummyBackend>,
+        mask: crate::ops::BoolTensor<DummyBackend>,
+        source: crate::ops::IntTensor<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_mask_fill(
+        tensor: crate::ops::IntTensor<DummyBackend>,
+        mask: crate::ops::BoolTensor<DummyBackend>,
+        value: crate::ops::IntElem<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_gather(
+        dim: usize,
+        tensor: crate::ops::IntTensor<DummyBackend>,
+        indices: crate::ops::IntTensor<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_scatter(
+        dim: usize,
+        tensor: crate::ops::IntTensor<DummyBackend>,
+        indices: crate::ops::IntTensor<DummyBackend>,
+        value: crate::ops::IntTensor<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_select(
+        tensor: crate::ops::IntTensor<DummyBackend>,
+        dim: usize,
+        indices: crate::ops::IntTensor<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_select_assign(
+        tensor: crate::ops::IntTensor<DummyBackend>,
+        dim: usize,
+        indices: crate::ops::IntTensor<DummyBackend>,
+        value: crate::ops::IntTensor<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_equal(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntTensor<DummyBackend>,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_equal_elem(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntElem<DummyBackend>,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_greater(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntTensor<DummyBackend>,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_greater_elem(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntElem<DummyBackend>,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_greater_equal(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntTensor<DummyBackend>,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_greater_equal_elem(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntElem<DummyBackend>,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_lower(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntTensor<DummyBackend>,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_lower_elem(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntElem<DummyBackend>,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_lower_equal(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntTensor<DummyBackend>,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_lower_equal_elem(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntElem<DummyBackend>,
+    ) -> crate::ops::BoolTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_add(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntTensor<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_add_scalar(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntElem<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_sub(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntTensor<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_sub_scalar(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntElem<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_mul(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntTensor<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_mul_scalar(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntElem<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_div(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntTensor<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_div_scalar(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntElem<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_remainder(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntTensor<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_remainder_scalar(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntElem<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_matmul(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntTensor<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_zeros(
+        shape: crate::Shape,
+        device: &crate::Device<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_ones(
+        shape: crate::Shape,
+        device: &crate::Device<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_sum(tensor: crate::ops::IntTensor<DummyBackend>) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_sum_dim(
+        tensor: crate::ops::IntTensor<DummyBackend>,
+        dim: usize,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_prod(
+        tensor: crate::ops::IntTensor<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_prod_dim(
+        tensor: crate::ops::IntTensor<DummyBackend>,
+        dim: usize,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_mean_dim(
+        tensor: crate::ops::IntTensor<DummyBackend>,
+        dim: usize,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_argmax(
+        tensor: crate::ops::IntTensor<DummyBackend>,
+        dim: usize,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_argmin(
+        tensor: crate::ops::IntTensor<DummyBackend>,
+        dim: usize,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_abs(tensor: crate::ops::IntTensor<DummyBackend>) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_swap_dims(
+        tensor: crate::ops::IntTensor<DummyBackend>,
+        dim1: usize,
+        dim2: usize,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_permute(
+        tensor: crate::ops::IntTensor<DummyBackend>,
+        axes: &[usize],
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_flip(
+        tensor: crate::ops::IntTensor<DummyBackend>,
+        axes: &[usize],
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_random(
+        shape: crate::Shape,
+        distribution: crate::Distribution,
+        device: &crate::Device<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn int_expand(
+        tensor: crate::ops::IntTensor<DummyBackend>,
+        shape: crate::Shape,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn bitwise_and(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntTensor<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn bitwise_and_scalar(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntElem<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn bitwise_or(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntTensor<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn bitwise_or_scalar(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntElem<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn bitwise_xor(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntTensor<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn bitwise_xor_scalar(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntElem<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn bitwise_not(
+        tensor: crate::ops::IntTensor<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn bitwise_left_shift(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntTensor<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn bitwise_left_shift_scalar(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntElem<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn bitwise_right_shift(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntTensor<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+
+    fn bitwise_right_shift_scalar(
+        lhs: crate::ops::IntTensor<DummyBackend>,
+        rhs: crate::ops::IntElem<DummyBackend>,
+    ) -> crate::ops::IntTensor<DummyBackend> {
+        todo!()
+    }
+}

--- a/crates/burn-tensor/src/tensor/backend/mod.rs
+++ b/crates/burn-tensor/src/tensor/backend/mod.rs
@@ -1,8 +1,10 @@
 mod base;
 mod device;
+mod dummy;
 
 pub use base::*;
 pub use device::*;
+pub use dummy::{DummyBackend};
 
 // Not needed for now, useful for different tensor memory layout
 // pub mod conversion;


### PR DESCRIPTION
## Remove generic dependency on backends from RecordItems
Motivated by the same usecase as I described in https://github.com/tracel-ai/burn/pull/3601, and also includes the changes from there. 

This PR is still a draft and somewhat messy - my intention is to gauge your interest in whether you would even like this change and only continue with it if you do.

As I want to store these RecordItems on my app struct, I became annoyed with their generic dependency on a <B: Backend>. This dependency seems to be entirely artificial and solely a byproduct of needing a way to name the appropriate associated types in the derive macros that produce the RecordItems.

In theory, different implementations with different backends could define different RecordItems, meaning that there would be an actual need to know what backend we're talking about when describing a RecordItem. However in practice, this would mean that the serialization / deserialization from these two different implementations would also be incompatible, which I would think would be an antipattern in burn - it would mean that a model serialized from one backend wouldn't be able to be loaded on another backend.

In practice, the RecordItems seem to always be the same regardless of backend, making models deserializable to any backend.

This means that the only motivation for the <B: Backend> generic is to name the nested RecordItems when deriving Module or Record. I propose that this can instead be done by referencing them through a single "implementor" of Backend.
DummyBackend is a typesystem trick to always provide a single backend implementor that we can always use to refer to the required associated items in the derive macro.

Let me know what you think about the core idea. I am quite happy that I can represent a cpu-side version of my model without completely type-erasing it and without infecting my structs with needless <B: Backend> generics.

I think it also enforces something that wasn't explicitly enforced before - the RecordItem /shouldn't/ need to know which backend it belongs to, as that means that it potentially can't be loaded onto other backends.

I also understand if this is too niche and you don't think it fits the project - in that case I'll probably move the DummyBackend to my "userspace" and simply transmute the RecordItem I get from burn on some backend to a RecordItem<DummyBackend> instead and just store that. I'd rather avoid that piece of unsafety if I can though


### Testing

Cargo check fails on some generated files from burn-onnx - I'll look into these and run the full test suite once I know the burn project is interested in these changes
