### PR TITLE
Add q4 q2 quantization

### DIFF
--- a/crates/burn-cubecl/Cargo.toml
+++ b/crates/burn-cubecl/Cargo.toml
@@ -86,7 +86,7 @@ hashbrown = { workspace = true }
 
 # When exporting tests
 burn-autodiff = { path = "../burn-autodiff", version = "0.19.0", default-features = false, optional = true }
-burn-ndarray = { path = "../burn-ndarray", version = "0.19.0", optional = true }
+burn-ndarray = { path = "../burn-ndarray", version = "0.19.0", features = ["export_tests"], optional = true }
 paste = { workspace = true, optional = true }
 serial_test = { workspace = true, optional = true }
 

--- a/crates/burn-cubecl/src/tests/quantization.rs
+++ b/crates/burn-cubecl/src/tests/quantization.rs
@@ -123,8 +123,15 @@ mod tests {
     }
 
     #[test]
-    fn should_quantize_dequantize_symmetric_per_block_q2s_packed() {
+    #[should_panic = "Block size must be divisible by 16"]
+    fn should_panic_when_block_size_cannot_store_num_quants() {
+        // num_quants in u32 = 32 bits / 2 bits = 16
         should_quantize_dequantize_symmetric_per_block(QuantValue::Q2S, 8, QuantStore::U32)
+    }
+
+    #[test]
+    fn should_quantize_dequantize_symmetric_per_block_q2s_packed() {
+        should_quantize_dequantize_symmetric_per_block(QuantValue::Q2S, 16, QuantStore::U32)
     }
 
     #[test]

--- a/crates/burn-cubecl/src/tests/quantization.rs
+++ b/crates/burn-cubecl/src/tests/quantization.rs
@@ -9,10 +9,8 @@ mod tests {
     use burn_tensor::{Tolerance, ops::FloatElem};
     type FT = FloatElem<TestBackend>;
 
-    fn should_quantize_dequantize_symmetric_arange(store: QuantStore) {
-        let scheme = QuantScheme::default()
-            .with_value(QuantValue::Q8S)
-            .with_store(store);
+    fn should_quantize_dequantize_symmetric_arange(value: QuantValue, store: QuantStore) {
+        let scheme = QuantScheme::default().with_value(value).with_store(store);
         let scheme_ref = scheme.clone().with_store(QuantStore::Native);
 
         let input = Tensor::<TestBackend, 1, Int>::arange(0..128, &Default::default()).float();
@@ -32,10 +30,14 @@ mod tests {
             .assert_approx_eq::<FT>(&output_ref.to_data(), Tolerance::default());
     }
 
-    fn should_quantize_dequantize_symmetric_per_block(store: QuantStore) {
+    fn should_quantize_dequantize_symmetric_per_block(
+        value: QuantValue,
+        block_size: usize,
+        store: QuantStore,
+    ) {
         let scheme = QuantScheme::default()
-            .with_value(QuantValue::Q8S)
-            .with_level(QuantLevel::Block(8))
+            .with_value(value)
+            .with_level(QuantLevel::Block(block_size))
             .with_store(store);
         let scheme_ref = scheme.clone().with_store(QuantStore::Native);
 
@@ -81,26 +83,61 @@ mod tests {
     }
 
     #[test]
-    fn should_quantize_dequantize_symmetric_arange_packed() {
-        should_quantize_dequantize_symmetric_arange(QuantStore::U32)
+    fn should_quantize_dequantize_symmetric_arange_q8s_packed() {
+        should_quantize_dequantize_symmetric_arange(QuantValue::Q8S, QuantStore::U32)
     }
 
     #[test]
-    fn should_quantize_dequantize_symmetric_per_block_packed() {
-        should_quantize_dequantize_symmetric_per_block(QuantStore::U32)
+    fn should_quantize_dequantize_symmetric_arange_q8f_packed() {
+        should_quantize_dequantize_symmetric_arange(QuantValue::Q8F, QuantStore::U32)
     }
 
     #[test]
-    fn should_quantize_dequantize_symmetric_arange_native() {
+    fn should_quantize_dequantize_symmetric_arange_q4s_packed() {
+        should_quantize_dequantize_symmetric_arange(QuantValue::Q4S, QuantStore::U32)
+    }
+
+    #[test]
+    fn should_quantize_dequantize_symmetric_arange_q4f_packed() {
+        should_quantize_dequantize_symmetric_arange(QuantValue::Q4F, QuantStore::U32)
+    }
+
+    #[test]
+    fn should_quantize_dequantize_symmetric_arange_q2s_packed() {
+        should_quantize_dequantize_symmetric_arange(QuantValue::Q2S, QuantStore::U32)
+    }
+
+    #[test]
+    fn should_quantize_dequantize_symmetric_arange_q2f_packed() {
+        should_quantize_dequantize_symmetric_arange(QuantValue::Q2F, QuantStore::U32)
+    }
+
+    #[test]
+    fn should_quantize_dequantize_symmetric_per_block_q8s_packed() {
+        should_quantize_dequantize_symmetric_per_block(QuantValue::Q8S, 8, QuantStore::U32)
+    }
+
+    #[test]
+    fn should_quantize_dequantize_symmetric_per_block_q4s_packed() {
+        should_quantize_dequantize_symmetric_per_block(QuantValue::Q4S, 8, QuantStore::U32)
+    }
+
+    #[test]
+    fn should_quantize_dequantize_symmetric_per_block_q2s_packed() {
+        should_quantize_dequantize_symmetric_per_block(QuantValue::Q2S, 8, QuantStore::U32)
+    }
+
+    #[test]
+    fn should_quantize_dequantize_symmetric_arange_q8s_native() {
         if supports_native() {
-            should_quantize_dequantize_symmetric_arange(QuantStore::Native)
+            should_quantize_dequantize_symmetric_arange(QuantValue::Q8S, QuantStore::Native)
         }
     }
 
     #[test]
-    fn should_quantize_dequantize_symmetric_per_block_native() {
+    fn should_quantize_dequantize_symmetric_per_block_q8s_native() {
         if supports_native() {
-            should_quantize_dequantize_symmetric_per_block(QuantStore::Native)
+            should_quantize_dequantize_symmetric_per_block(QuantValue::Q8S, 8, QuantStore::Native)
         }
     }
 

--- a/crates/burn-ndarray/Cargo.toml
+++ b/crates/burn-ndarray/Cargo.toml
@@ -46,6 +46,9 @@ blas-openblas-system = [
 ]
 simd = ["macerator", "bytemuck", "seq-macro", "itertools"]
 
+# Serves as a ref impl for some burn-cubecl kernels
+export_tests = []
+
 [dependencies]
 
 # ** Please make sure all dependencies support no_std when std is disabled **

--- a/crates/burn-ndarray/src/lib.rs
+++ b/crates/burn-ndarray/src/lib.rs
@@ -43,12 +43,6 @@ mod tests {
     burn_autodiff::testgen_all!();
 
     // Quantization
-    impl burn_tensor::quantization::QuantSchemeDefault for crate::NdArray {
-        fn quant_scheme() -> burn_tensor::quantization::QuantScheme {
-            burn_tensor::quantization::QuantScheme::default()
-                .with_store(burn_tensor::quantization::QuantStore::Native)
-        }
-    }
     burn_tensor::testgen_calibration!();
     burn_tensor::testgen_scheme!();
     burn_tensor::testgen_quantize!();

--- a/crates/burn-ndarray/src/lib.rs
+++ b/crates/burn-ndarray/src/lib.rs
@@ -43,6 +43,12 @@ mod tests {
     burn_autodiff::testgen_all!();
 
     // Quantization
+    impl burn_tensor::quantization::QuantSchemeDefault for crate::NdArray {
+        fn quant_scheme() -> burn_tensor::quantization::QuantScheme {
+            burn_tensor::quantization::QuantScheme::default()
+                .with_store(burn_tensor::quantization::QuantStore::Native)
+        }
+    }
     burn_tensor::testgen_calibration!();
     burn_tensor::testgen_scheme!();
     burn_tensor::testgen_quantize!();

--- a/crates/burn-ndarray/src/lib.rs
+++ b/crates/burn-ndarray/src/lib.rs
@@ -41,4 +41,10 @@ mod tests {
 
     #[cfg(feature = "std")]
     burn_autodiff::testgen_all!();
+
+    // Quantization
+    burn_tensor::testgen_calibration!();
+    burn_tensor::testgen_scheme!();
+    burn_tensor::testgen_quantize!();
+    burn_tensor::testgen_q_data!();
 }

--- a/crates/burn-ndarray/src/ops/qtensor.rs
+++ b/crates/burn-ndarray/src/ops/qtensor.rs
@@ -95,7 +95,12 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> QTensorOps<S
             QuantScheme {
                 level: QuantLevel::Tensor,
                 mode: QuantMode::Symmetric,
-                value:
+                #[cfg(not(feature = "export_tests"))]
+                    value: QuantValue::Q8F | QuantValue::Q8S,
+                // For tests, "native" sub-byte quant serves as a reference for value equality.
+                // Values are stored as i8 regardless.
+                #[cfg(feature = "export_tests")]
+                    value:
                     QuantValue::Q8F
                     | QuantValue::Q8S
                     | QuantValue::Q4F
@@ -117,7 +122,10 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> QTensorOps<S
             QuantScheme {
                 level: QuantLevel::Block(block_size),
                 mode: QuantMode::Symmetric,
-                value:
+                #[cfg(not(feature = "export_tests"))]
+                    value: QuantValue::Q8F | QuantValue::Q8S,
+                #[cfg(feature = "export_tests")]
+                    value:
                     QuantValue::Q8F
                     | QuantValue::Q8S
                     | QuantValue::Q4F
@@ -143,6 +151,12 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> QTensorOps<S
             }
             QuantScheme {
                 store: QuantStore::U32,
+                ..
+            } => unimplemented!("Quantization not supported for scheme {scheme:?}"),
+            #[cfg(not(feature = "export_tests"))]
+            QuantScheme {
+                value: QuantValue::Q4F | QuantValue::Q4S | QuantValue::Q2F | QuantValue::Q2S,
+                store: QuantStore::Native,
                 ..
             } => unimplemented!("Quantization not supported for scheme {scheme:?}"),
         };

--- a/crates/burn-ndarray/src/ops/qtensor.rs
+++ b/crates/burn-ndarray/src/ops/qtensor.rs
@@ -51,12 +51,14 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> QTensorOps<S
                         level: QuantLevel::Tensor | QuantLevel::Block(_),
                         mode: QuantMode::Symmetric,
                         value: QuantValue::Q8F | QuantValue::Q8S,
-                        store: QuantStore::Native,
+                        store: QuantStore::Native | QuantStore::U32,
                         ..
                     } => {
-                        // We should probably check that `Q` matches i8.. but it's the only valid type now
+                        // We can load QuantStore::U32 w/ QuantizedBytes impl
                         let (values, qparams) = q_bytes.into_vec_i8();
                         let data = TensorData::new(values, shape);
+                        // Overwrite storage
+                        let scheme = scheme.with_store(QuantStore::Native);
 
                         let qparams = qparams
                             .scales
@@ -72,11 +74,6 @@ impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> QTensorOps<S
                     }
                     QuantScheme {
                         value: QuantValue::Q4F | QuantValue::Q4S | QuantValue::Q2F | QuantValue::Q2S,
-                        store: QuantStore::Native,
-                        ..
-                    }
-                    | QuantScheme {
-                        store: QuantStore::U32,
                         ..
                     } => unimplemented!("from_data not supported for scheme {scheme:?}"),
                 }

--- a/crates/burn-ndarray/src/tensor.rs
+++ b/crates/burn-ndarray/src/tensor.rs
@@ -371,6 +371,11 @@ impl<Q: QuantElement> QTensorPrimitive for NdArrayQTensor<Q> {
     fn scheme(&self) -> &QuantScheme {
         &self.scheme
     }
+
+    #[cfg(test)]
+    fn default_scheme() -> QuantScheme {
+        QuantScheme::default().with_store(burn_tensor::quantization::QuantStore::Native)
+    }
 }
 
 impl<Q: QuantElement> TensorMetadata for NdArrayQTensor<Q> {

--- a/crates/burn-ndarray/src/tensor.rs
+++ b/crates/burn-ndarray/src/tensor.rs
@@ -333,27 +333,36 @@ impl<Q: QuantElement> NdArrayQTensor<Q> {
             QuantScheme {
                 level: QuantLevel::Tensor,
                 mode: QuantMode::Symmetric,
-                value: QuantValue::Q8F | QuantValue::Q8S,
+                value:
+                    QuantValue::Q8F
+                    | QuantValue::Q8S
+                    | QuantValue::Q4F
+                    | QuantValue::Q4S
+                    | QuantValue::Q2F
+                    | QuantValue::Q2S,
                 ..
-            } => QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(
+            } => QuantizationStrategy::PerTensorSymmetric(SymmetricQuantization::init(
                 self.qparams[0].scales,
+                self.scheme.value,
             )),
             QuantScheme {
                 level: QuantLevel::Block(block_size),
                 mode: QuantMode::Symmetric,
-                value: QuantValue::Q8F | QuantValue::Q8S,
+                value:
+                    QuantValue::Q8F
+                    | QuantValue::Q8S
+                    | QuantValue::Q4F
+                    | QuantValue::Q4S
+                    | QuantValue::Q2F
+                    | QuantValue::Q2S,
                 ..
-            } => QuantizationStrategy::PerBlockSymmetricInt8(
+            } => QuantizationStrategy::PerBlockSymmetric(
                 self.qparams
                     .iter()
-                    .map(|q| SymmetricQuantization::init(q.scales))
+                    .map(|q| SymmetricQuantization::init(q.scales, self.scheme.value))
                     .collect(),
                 block_size,
             ),
-            QuantScheme {
-                value: QuantValue::Q4F | QuantValue::Q4S | QuantValue::Q2F | QuantValue::Q2S,
-                ..
-            } => unimplemented!(),
         }
     }
 }
@@ -460,7 +469,10 @@ mod tests {
         assert_eq!(qtensor.scheme(), &scheme);
         assert_eq!(
             qtensor.strategy(),
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(scale))
+            QuantizationStrategy::PerTensorSymmetric(SymmetricQuantization::init(
+                scale,
+                QuantValue::Q8S
+            ))
         );
     }
 }

--- a/crates/burn-tch/src/lib.rs
+++ b/crates/burn-tch/src/lib.rs
@@ -25,11 +25,5 @@ mod tests {
     burn_tensor::testgen_all!();
     burn_autodiff::testgen_all!();
 
-    impl burn_tensor::quantization::QuantSchemeDefault for crate::LibTorch {
-        fn quant_scheme() -> burn_tensor::quantization::QuantScheme {
-            burn_tensor::quantization::QuantScheme::default()
-                .with_store(burn_tensor::quantization::QuantStore::Native)
-        }
-    }
     burn_tensor::testgen_quantization!();
 }

--- a/crates/burn-tch/src/lib.rs
+++ b/crates/burn-tch/src/lib.rs
@@ -24,5 +24,12 @@ mod tests {
 
     burn_tensor::testgen_all!();
     burn_autodiff::testgen_all!();
+
+    impl burn_tensor::quantization::QuantSchemeDefault for crate::LibTorch {
+        fn quant_scheme() -> burn_tensor::quantization::QuantScheme {
+            burn_tensor::quantization::QuantScheme::default()
+                .with_store(burn_tensor::quantization::QuantStore::Native)
+        }
+    }
     burn_tensor::testgen_quantization!();
 }

--- a/crates/burn-tch/src/ops/qtensor.rs
+++ b/crates/burn-tch/src/ops/qtensor.rs
@@ -230,7 +230,7 @@ impl<E: TchElement, Q: QuantElement> QTensorOps<Self> for LibTorch<E, Q> {
         // To get the integer values we have to call `int_repr()`
         let values: Result<Vec<i8>, tch::TchError> = tensor.qtensor.tensor.int_repr().try_into();
 
-        TensorData::quantized(values.unwrap(), shape, strategy)
+        TensorData::quantized(values.unwrap(), shape, strategy, tensor.scheme)
     }
 
     fn q_swap_dims(

--- a/crates/burn-tch/src/tensor.rs
+++ b/crates/burn-tch/src/tensor.rs
@@ -328,7 +328,6 @@ pub struct TchQTensor {
 }
 
 impl TchQTensor {
-    // TODO: remove QuantizationStrategy
     /// Returns the quantization strategy, including quantization parameters, for the given tensor.
     pub fn strategy(&self) -> QuantizationStrategy {
         match &self.scheme {
@@ -340,8 +339,9 @@ impl TchQTensor {
                 ..
             } => {
                 let scale = self.qtensor.tensor.q_scale();
-                QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(
+                QuantizationStrategy::PerTensorSymmetric(SymmetricQuantization::init(
                     scale as f32,
+                    self.scheme.value,
                 ))
             }
             QuantScheme {
@@ -466,8 +466,9 @@ mod tests {
         assert_eq!(qtensor.scheme(), &scheme);
         assert_eq!(
             qtensor.strategy(),
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(
-                0.009_019_608
+            QuantizationStrategy::PerTensorSymmetric(SymmetricQuantization::init(
+                0.009_019_608,
+                QuantValue::Q8S
             ))
         );
     }

--- a/crates/burn-tch/src/tensor.rs
+++ b/crates/burn-tch/src/tensor.rs
@@ -379,6 +379,11 @@ impl QTensorPrimitive for TchQTensor {
     fn scheme(&self) -> &QuantScheme {
         &self.scheme
     }
+
+    #[cfg(test)]
+    fn default_scheme() -> QuantScheme {
+        QuantScheme::default().with_store(burn_tensor::quantization::QuantStore::Native)
+    }
 }
 
 #[cfg(test)]

--- a/crates/burn-tensor/src/tensor/quantization/bytes.rs
+++ b/crates/burn-tensor/src/tensor/quantization/bytes.rs
@@ -1,11 +1,11 @@
 use core::any::TypeId;
 
-use crate::{Bytes, Element};
+use crate::{Bytes, Element, quantization::unpack_q_to_i8s};
 use alloc::vec::Vec;
-use cubecl_quant::scheme::QuantScheme;
 
 use super::{
-    QParams, QuantLevel, QuantMode, QuantValue, QuantizationStrategy, SymmetricQuantization,
+    QParams, QuantLevel, QuantMode, QuantScheme, QuantStore, QuantValue, QuantizationStrategy,
+    SymmetricQuantization,
 };
 
 /// Quantized data bytes representation.
@@ -28,13 +28,16 @@ pub struct QuantizedBytes {
 
 impl QuantizedBytes {
     /// Creates a new quantized bytes representation.
-    pub fn new<E: Element>(value: Vec<E>, strategy: QuantizationStrategy) -> Self {
+    pub fn new<E: Element>(
+        value: Vec<E>,
+        strategy: QuantizationStrategy,
+        scheme: QuantScheme,
+    ) -> Self {
         let mut bytes: Bytes;
         let num_elements = value.len();
-        let scheme = strategy.scheme();
 
         match strategy {
-            QuantizationStrategy::PerTensorSymmetricInt8(quant) => {
+            QuantizationStrategy::PerTensorSymmetric(quant) => {
                 if TypeId::of::<E>() == TypeId::of::<i8>() {
                     // Re-interpret `Vec<E>` as `Vec<i8>` with `Vec::from_raw_parts`
                     let i8s: Vec<i8> = bytemuck::allocation::cast_vec(value);
@@ -45,7 +48,7 @@ impl QuantizedBytes {
                 let scale_bytes = bytemuck::bytes_of(&quant.scale);
                 bytes.extend_from_byte_slice_aligned(scale_bytes, align_of::<f32>());
             }
-            QuantizationStrategy::PerBlockSymmetricInt8(quant, _block_size) => {
+            QuantizationStrategy::PerBlockSymmetric(quant, _block_size) => {
                 if TypeId::of::<E>() == TypeId::of::<i8>() {
                     // Re-interpret `Vec<E>` as `Vec<i8>` with `Vec::from_raw_parts`
                     let i8s: Vec<i8> = bytemuck::allocation::cast_vec(value);
@@ -88,16 +91,8 @@ impl QuantizedBytes {
         (values, QParams { scales })
     }
 
-    /// Splits the quantized values of the tensor from the quantization parameters.
-    ///
-    /// Returns the packed values and a newly allocated vector containing the quantization parameters.
-    fn split_values_off(self) -> (Vec<i8>, (Vec<u32>, usize)) {
+    fn split_i8_values(self, num_params: usize) -> (Vec<i8>, Vec<u32>) {
         let mut values = self.bytes.try_into_vec::<i8>().unwrap();
-
-        let num_params = match self.scheme.level {
-            QuantLevel::Tensor => 1,
-            QuantLevel::Block(block_size) => self.num_elements / block_size,
-        };
 
         let scale_size = num_params * size_of::<f32>();
         let values_end = values.len() - scale_size;
@@ -124,6 +119,34 @@ impl QuantizedBytes {
                 crate::quantization::pack_i8s_to_u32s(bytemuck::cast_vec(qparams))
             }
         };
+        (values, qparams)
+    }
+
+    /// Splits the quantized values of the tensor from the quantization parameters.
+    ///
+    /// Returns the values in i8 and a newly allocated vector containing the quantization parameters.
+    fn split_values_off(self) -> (Vec<i8>, (Vec<u32>, usize)) {
+        let num_params = match self.scheme.level {
+            QuantLevel::Tensor => 1,
+            QuantLevel::Block(block_size) => self.num_elements / block_size,
+        };
+
+        let (values, qparams) = match self.scheme.store {
+            QuantStore::Native => self.split_i8_values(num_params),
+            QuantStore::U32 => match self.scheme.value {
+                QuantValue::Q8F | QuantValue::Q8S => self.split_i8_values(num_params),
+                QuantValue::Q4F | QuantValue::Q4S | QuantValue::Q2F | QuantValue::Q2S => {
+                    let mut values = self.bytes.try_into_vec::<u32>().unwrap();
+                    let scale_size = num_params; // size of f32 same as u32
+                    let values_end = values.len() - scale_size;
+
+                    let qparams = values.split_off(values_end);
+                    // Sub-byte values are unpacked as i8s for value equality tests
+                    let values = unpack_q_to_i8s(&values, self.num_elements, &self.scheme.value);
+                    (values, qparams)
+                }
+            },
+        };
 
         (values, (qparams, num_params))
     }
@@ -134,34 +157,47 @@ impl QuantizedBytes {
             QuantScheme {
                 level: QuantLevel::Tensor,
                 mode: QuantMode::Symmetric,
-                value: QuantValue::Q8S | QuantValue::Q8F,
+                value:
+                    QuantValue::Q8S
+                    | QuantValue::Q8F
+                    | QuantValue::Q4S
+                    | QuantValue::Q4F
+                    | QuantValue::Q2S
+                    | QuantValue::Q2F,
                 ..
             } => {
+                let value = self.scheme.value;
                 let (values, qparams) = self.into_vec_i8();
-                let strategy = QuantizationStrategy::PerTensorSymmetricInt8(
-                    SymmetricQuantization::init(qparams.scales[0]),
+                let strategy = QuantizationStrategy::PerTensorSymmetric(
+                    SymmetricQuantization::init(qparams.scales[0], value),
                 );
                 (strategy.dequantize(&values), qparams)
             }
             QuantScheme {
                 level: QuantLevel::Block(block_size),
                 mode: QuantMode::Symmetric,
-                value: QuantValue::Q8S | QuantValue::Q8F,
+                value:
+                    QuantValue::Q8S
+                    | QuantValue::Q8F
+                    | QuantValue::Q4S
+                    | QuantValue::Q4F
+                    | QuantValue::Q2S
+                    | QuantValue::Q2F,
                 ..
             } => {
+                let value = self.scheme.value;
                 let (values, qparams) = self.into_vec_i8();
                 assert_eq!(values.len() / qparams.scales.len(), block_size);
-                let strategy = QuantizationStrategy::PerBlockSymmetricInt8(
+                let strategy = QuantizationStrategy::PerBlockSymmetric(
                     qparams
                         .scales
                         .iter()
-                        .map(|&s| SymmetricQuantization::init(s))
+                        .map(|&s| SymmetricQuantization::init(s, value))
                         .collect(),
                     block_size,
                 );
                 (strategy.dequantize(&values), qparams)
             }
-            _ => unimplemented!(),
         }
     }
 }
@@ -180,7 +216,11 @@ mod tests {
 
         let q_bytes = QuantizedBytes::new(
             values.clone(),
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(scale)),
+            QuantizationStrategy::PerTensorSymmetric(SymmetricQuantization::init(
+                scale,
+                QuantValue::Q8S,
+            )),
+            QuantScheme::default(),
         );
 
         let (q_values, qparams) = q_bytes.into_vec_i8();

--- a/crates/burn-tensor/src/tensor/quantization/data.rs
+++ b/crates/burn-tensor/src/tensor/quantization/data.rs
@@ -42,7 +42,7 @@ pub fn pack_i8s_to_u32s(values: Vec<i8>) -> Vec<u32> {
 }
 
 /// Unpack integer values into a sequence of signed 8-bit integers.
-pub(crate) fn unpack_q_to_i8s<Q: PrimInt + core::fmt::Display>(
+pub(crate) fn unpack_q_to_i8s<Q: PrimInt>(
     values: &[Q],
     numel: usize,
     value: &QuantValue,
@@ -105,5 +105,29 @@ mod tests {
         let unpacked = unpack_q_to_i8s(&[55u32], 1, &QuantValue::Q8S);
 
         assert_eq!(unpacked, vec![55]);
+    }
+
+    #[test]
+    fn should_unpack_u32s_to_i8s_arange() {
+        let unpacked = unpack_q_to_i8s(
+            &[
+                0u32, 286331136, 286331153, 572657937, 572662306, 857874978, 858993459, 858993459,
+                1145324612, 1145324612, 1431655748, 1431655765, 1717982549, 1717986918, 2003199590,
+                2004318071,
+            ],
+            128,
+            &QuantValue::Q4S,
+        );
+
+        assert_eq!(
+            unpacked,
+            vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+                3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5,
+                5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
+                6, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7
+            ]
+        );
     }
 }

--- a/crates/burn-tensor/src/tensor/quantization/data.rs
+++ b/crates/burn-tensor/src/tensor/quantization/data.rs
@@ -1,4 +1,6 @@
+use crate::quantization::QuantValue;
 use alloc::vec::Vec;
+use num_traits::PrimInt;
 
 /// Pack signed 8-bit integer values into a sequence of unsigned 32-bit integers.
 pub fn pack_i8s_to_u32s(values: Vec<i8>) -> Vec<u32> {
@@ -39,47 +41,35 @@ pub fn pack_i8s_to_u32s(values: Vec<i8>) -> Vec<u32> {
     }
 }
 
-/// Unpack 32-bit unsigned integer values into a sequence of signed 8-bit integers.
-pub fn unpack_u32s_to_i8s(values: Vec<u32>, numel: usize) -> Vec<i8> {
-    #[cfg(target_endian = "big")]
-    {
-        values
-            .into_iter()
-            .enumerate()
-            .flat_map(|(i, packed)| {
-                // A single u32 could contain less than four 8-bit values...
-                let n = core::cmp::min(4, numel - i * 4);
-                // Extract each 8-bit segment from u32 and cast back to i8
-                // Same as doing this (when 4 values are fully packed):
-                //     let a = (packed & 0xFF) as i8;
-                //     let b = ((packed >> 8) & 0xFF) as i8;
-                //     let c = ((packed >> 16) & 0xFF) as i8;
-                //     let d = ((packed >> 24) & 0xFF) as i8;
-                (0..n).map(move |i| (packed >> (i * 8) & 0xFF) as i8)
+/// Unpack integer values into a sequence of signed 8-bit integers.
+pub(crate) fn unpack_q_to_i8s<Q: PrimInt + core::fmt::Display>(
+    values: &[Q],
+    numel: usize,
+    value: &QuantValue,
+) -> Vec<i8> {
+    let size_store = size_of::<Q>() * 8;
+    let size_quant = value.size_bits();
+    let num_quants = size_store / size_quant;
+    let mask = Q::from((1 << size_quant) - 1).unwrap();
+    let sign_shift = 8 - size_quant; // sign extension for sub-byte values
+    values
+        .into_iter()
+        .enumerate()
+        .flat_map(|(i, &packed)| {
+            // A single u32 could contain less than four 8-bit values...
+            let n = core::cmp::min(num_quants, numel - i * num_quants);
+            // Extract each 8-bit segment from u32 and cast back to i8
+            // Same as doing this (when 4 values are fully packed):
+            //     let a = (packed & 0xFF) as i8;
+            //     let b = ((packed >> 8) & 0xFF) as i8;
+            //     let c = ((packed >> 16) & 0xFF) as i8;
+            //     let d = ((packed >> 24) & 0xFF) as i8;
+            (0..n).map(move |i| {
+                let raw = (packed >> (i * size_quant) & mask).to_u8().unwrap();
+                ((raw << sign_shift) as i8) >> sign_shift
             })
-            .collect()
-    }
-
-    // The order of bytes in little endian matches the above description, we just need to
-    // handle padding when the number of elements is not a factor of 4
-    #[cfg(target_endian = "little")]
-    {
-        let len = values.len() * 4;
-        let capacity = values.capacity() * 4;
-
-        // Pre-forget the old vec and re-interpret as u32
-        let mut values = core::mem::ManuallyDrop::new(values);
-        let ptr = values.as_mut_ptr() as *mut i8;
-
-        let mut vec = unsafe { Vec::from_raw_parts(ptr, len, capacity) };
-
-        let padding = len - numel;
-        if padding > 0 {
-            vec.truncate(len - padding);
-        }
-
-        vec
-    }
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -105,14 +95,14 @@ mod tests {
 
     #[test]
     fn should_unpack_u32s_to_i8s() {
-        let unpacked = unpack_u32s_to_i8s(vec![2147287680u32], 4);
+        let unpacked = unpack_q_to_i8s(&[2147287680u32], 4, &QuantValue::Q8S);
 
         assert_eq!(unpacked, vec![-128, 2, -3, 127]);
     }
 
     #[test]
     fn should_unpack_u32s_to_i8s_padded() {
-        let unpacked = unpack_u32s_to_i8s(vec![55u32], 1);
+        let unpacked = unpack_q_to_i8s(&[55u32], 1, &QuantValue::Q8S);
 
         assert_eq!(unpacked, vec![55]);
     }

--- a/crates/burn-tensor/src/tensor/quantization/data.rs
+++ b/crates/burn-tensor/src/tensor/quantization/data.rs
@@ -53,7 +53,7 @@ pub(crate) fn unpack_q_to_i8s<Q: PrimInt + core::fmt::Display>(
     let mask = Q::from((1 << size_quant) - 1).unwrap();
     let sign_shift = 8 - size_quant; // sign extension for sub-byte values
     values
-        .into_iter()
+        .iter()
         .enumerate()
         .flat_map(|(i, &packed)| {
             // A single u32 could contain less than four 8-bit values...

--- a/crates/burn-tensor/src/tensor/quantization/primitive.rs
+++ b/crates/burn-tensor/src/tensor/quantization/primitive.rs
@@ -14,4 +14,10 @@ pub trait QTensorPrimitive {
     fn propagation(&self) -> QuantPropagation {
         QuantPropagation::Inhibit
     }
+
+    #[cfg(feature = "export_tests")]
+    /// Returns the default quantization scheme.
+    fn default_scheme() -> QuantScheme {
+        QuantScheme::default()
+    }
 }

--- a/crates/burn-tensor/src/tensor/quantization/scheme.rs
+++ b/crates/burn-tensor/src/tensor/quantization/scheme.rs
@@ -11,6 +11,15 @@ use super::{
     Calibration, CalibrationRange, QuantizationParameters, QuantizationParametersPrimitive,
 };
 
+#[cfg(feature = "export_tests")]
+/// Define the default quantization scheme, which can be backend specific.
+pub trait QuantSchemeDefault {
+    /// Returns the default quantization scheme.
+    fn quant_scheme() -> QuantScheme {
+        QuantScheme::default()
+    }
+}
+
 #[derive(
     Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Default,
 )]

--- a/crates/burn-tensor/src/tensor/quantization/scheme.rs
+++ b/crates/burn-tensor/src/tensor/quantization/scheme.rs
@@ -11,15 +11,6 @@ use super::{
     Calibration, CalibrationRange, QuantizationParameters, QuantizationParametersPrimitive,
 };
 
-#[cfg(feature = "export_tests")]
-/// Define the default quantization scheme, which can be backend specific.
-pub trait QuantSchemeDefault {
-    /// Returns the default quantization scheme.
-    fn quant_scheme() -> QuantScheme {
-        QuantScheme::default()
-    }
-}
-
 #[derive(
     Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Default,
 )]

--- a/crates/burn-tensor/src/tensor/quantization/strategy.rs
+++ b/crates/burn-tensor/src/tensor/quantization/strategy.rs
@@ -1,25 +1,24 @@
 use alloc::vec::Vec;
-use core::marker::PhantomData;
-use num_traits::{Float, PrimInt, Signed};
+use num_traits::{Float, PrimInt};
 use serde::{Deserialize, Serialize};
 
-use super::{QuantLevel, QuantMode, QuantParam, QuantScheme, QuantStore, QuantValue};
+use super::QuantValue;
 
 /// Quantization strategy.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum QuantizationStrategy {
-    /// Per-tensor `int8` symmetric quantization.
-    PerTensorSymmetricInt8(SymmetricQuantization<f32, i8>),
-    /// Per-block `int8` symmetric quantization.
-    PerBlockSymmetricInt8(Vec<SymmetricQuantization<f32, i8>>, usize),
+    /// Per-tensor symmetric quantization.
+    PerTensorSymmetric(SymmetricQuantization<f32>),
+    /// Per-block symmetric quantization.
+    PerBlockSymmetric(Vec<SymmetricQuantization<f32>>, usize),
 }
 
 impl QuantizationStrategy {
     /// Quantize the values to a lower precision data type.
     pub fn quantize(&self, values: &[f32]) -> Vec<i8> {
         match self {
-            QuantizationStrategy::PerTensorSymmetricInt8(strategy) => strategy.quantize(values),
-            QuantizationStrategy::PerBlockSymmetricInt8(strategy, block_size) => {
+            QuantizationStrategy::PerTensorSymmetric(strategy) => strategy.quantize(values),
+            QuantizationStrategy::PerBlockSymmetric(strategy, block_size) => {
                 let num_blocks = strategy.len();
                 let numel = values.len();
                 assert_eq!(
@@ -39,8 +38,8 @@ impl QuantizationStrategy {
     /// Dequantize the values to a higher precision data type.
     pub fn dequantize(&self, values: &[i8]) -> Vec<f32> {
         match self {
-            QuantizationStrategy::PerTensorSymmetricInt8(strategy) => strategy.dequantize(values),
-            QuantizationStrategy::PerBlockSymmetricInt8(strategy, block_size) => {
+            QuantizationStrategy::PerTensorSymmetric(strategy) => strategy.dequantize(values),
+            QuantizationStrategy::PerBlockSymmetric(strategy, block_size) => {
                 let num_blocks = strategy.len();
                 let numel = values.len();
                 assert_eq!(
@@ -58,43 +57,19 @@ impl QuantizationStrategy {
     }
 }
 
-impl QuantizationStrategy {
-    /// Returns the corresponding quantization scheme.
-    pub fn scheme(&self) -> QuantScheme {
-        match self {
-            QuantizationStrategy::PerTensorSymmetricInt8(_) => QuantScheme {
-                level: QuantLevel::Tensor,
-                mode: QuantMode::Symmetric,
-                value: QuantValue::Q8S,
-                store: QuantStore::U32,
-                param: QuantParam::F32,
-            },
-            QuantizationStrategy::PerBlockSymmetricInt8(_blocks, block_size) => QuantScheme {
-                level: QuantLevel::Block(*block_size),
-                mode: QuantMode::Symmetric,
-                value: QuantValue::Q8S,
-                store: QuantStore::U32,
-                param: QuantParam::F32,
-            },
-        }
-    }
-}
-
 /// Quantization scheme to convert elements of a higher precision data type `E` to a lower precision
 /// data type `Q` and vice-versa.
-pub trait Quantization<E: Float + Send + Sync, Q: PrimInt + Send + Sync> {
+pub trait Quantization<E: Float + Send + Sync> {
     /// Returns the quantization range `[a, b]`.
-    fn range() -> (Q, Q);
-    /// Create a new quantization scheme for an input range `[alpha, beta]`.
-    fn new(alpha: E, beta: E) -> Self;
+    fn range(&self) -> (E, E);
     /// Convert the values to a lower precision data type.
-    fn quantize(&self, values: &[E]) -> Vec<Q>;
+    fn quantize<Q: PrimInt>(&self, values: &[E]) -> Vec<Q>;
     /// Convert a single value to a lower precision data type.
-    fn quantize_one(&self, value: E) -> Q;
+    fn quantize_one<Q: PrimInt>(&self, value: E) -> Q;
     /// Convert the values back to a higher precision data type.
-    fn dequantize(&self, values: &[Q]) -> Vec<E>;
+    fn dequantize<Q: PrimInt>(&self, values: &[Q]) -> Vec<E>;
     /// Convert a single value back to a higher precision data type.
-    fn dequantize_one(&self, value: Q) -> E;
+    fn dequantize_one<Q: PrimInt>(&self, value: Q) -> E;
 }
 
 fn valid_scale<E: Float>(mut scale: E) -> E {
@@ -108,78 +83,72 @@ fn valid_scale<E: Float>(mut scale: E) -> E {
 
 /// Symmetric quantization scheme.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub struct SymmetricQuantization<E: Float + Send + Sync, Q: PrimInt + Signed + Send + Sync> {
+pub struct SymmetricQuantization<E: Float + Send + Sync> {
     /// The scaling factor.
     pub scale: E,
-    /// The quantized type.
-    _q: PhantomData<Q>,
+    // The quantization value data type.
+    value: QuantValue,
 }
 
-impl<E: Float + Send + Sync, Q: PrimInt + Signed + Send + Sync> SymmetricQuantization<E, Q> {
+impl<E: Float + Send + Sync> SymmetricQuantization<E> {
     /// Initialize a symmetric quantization scheme with the given parameters.
-    pub fn init(scale: E) -> Self {
+    pub fn init(scale: E, value: QuantValue) -> Self {
         Self {
             scale: valid_scale(scale),
-            _q: PhantomData,
+            value,
         }
     }
-}
 
-impl<E: Float + Send + Sync, Q: PrimInt + Signed + Send + Sync> Quantization<E, Q>
-    for SymmetricQuantization<E, Q>
-{
-    fn new(alpha: E, beta: E) -> Self {
-        let (a, b) = Self::range();
+    #[allow(dead_code)]
+    /// Create a new quantization scheme for an input range `[alpha, beta]`.
+    fn new(alpha: E, beta: E, value: QuantValue) -> Self {
+        let (a, b) = value.range();
         let a = E::from(a).unwrap();
         let b = E::from(b).unwrap();
 
         // Compute scale to convert a floating point value in range `[-alpha, alpha]` to the quantized range
         let alpha = alpha.abs().max(beta.abs());
         let scale = valid_scale((alpha + alpha) / (b - a));
-        Self {
-            scale,
-            _q: PhantomData,
-        }
+        Self { scale, value }
     }
+}
 
-    fn quantize(&self, values: &[E]) -> Vec<Q> {
+impl<E: Float + Send + Sync> Quantization<E> for SymmetricQuantization<E> {
+    fn quantize<Q: PrimInt>(&self, values: &[E]) -> Vec<Q> {
         values.iter().map(|x| self.quantize_one(*x)).collect()
     }
 
-    fn dequantize(&self, values: &[Q]) -> Vec<E> {
+    fn dequantize<Q: PrimInt>(&self, values: &[Q]) -> Vec<E> {
         values.iter().map(|x_q| self.dequantize_one(*x_q)).collect()
     }
 
-    fn quantize_one(&self, value: E) -> Q {
-        let (a, b) = Self::range();
-        let a = E::from(a).unwrap();
-        let b = E::from(b).unwrap();
+    fn quantize_one<Q: PrimInt>(&self, value: E) -> Q {
+        let (a, b) = self.range();
 
         // x_q = clamp(round(x / scale), a, b)
         Q::from(value.div(self.scale).round().clamp(a, b)).unwrap()
     }
 
-    fn dequantize_one(&self, value: Q) -> E {
+    fn dequantize_one<Q: PrimInt>(&self, value: Q) -> E {
         // x = scale * x_q
         self.scale * E::from(value).unwrap()
     }
 
-    fn range() -> (Q, Q) {
-        // Only implemented for symmetric *signed* at this time
-        let b = Q::max_value();
-        (b.neg(), b)
+    fn range(&self) -> (E, E) {
+        let (a, b) = self.value.range();
+        let a = E::from(a).unwrap();
+        let b = E::from(b).unwrap();
+        (a, b)
     }
 }
 
-impl<E: Float + Send + Sync, Q: PrimInt + Signed + Send + Sync> PartialEq
-    for SymmetricQuantization<E, Q>
-{
+impl<E: Float + Send + Sync> PartialEq for SymmetricQuantization<E> {
     fn eq(&self, other: &Self) -> bool {
         self.scale == other.scale
     }
 }
 
-impl<E: Float + Send + Sync, Q: PrimInt + Signed + Send + Sync> Eq for SymmetricQuantization<E, Q> {}
+impl<E: Float + Send + Sync> Eq for SymmetricQuantization<E> {}
 
 #[cfg(test)]
 mod tests {
@@ -192,7 +161,7 @@ mod tests {
         let expected_q = vec![-127, -71, 0, 35];
         let expected_d = vec![-1.8, -1.0062993, 0.0, 0.496063];
 
-        let symmetric = SymmetricQuantization::<f32, i8>::new(-1.8, 0.5);
+        let symmetric = SymmetricQuantization::<f32>::new(-1.8, 0.5, QuantValue::Q8S);
 
         let q: Vec<i8> = symmetric.quantize(&x);
         assert_eq!(q, expected_q);
@@ -210,8 +179,8 @@ mod tests {
             -1.8, -1.0062993, 0.0, 0.496063, -1.8, -1.0062993, 0.0, 0.496063,
         ];
 
-        let symmetric = SymmetricQuantization::<f32, i8>::new(-1.8, 0.5);
-        let strategy = QuantizationStrategy::PerBlockSymmetricInt8(vec![symmetric, symmetric], 4);
+        let symmetric = SymmetricQuantization::<f32>::new(-1.8, 0.5, QuantValue::Q8S);
+        let strategy = QuantizationStrategy::PerBlockSymmetric(vec![symmetric, symmetric], 4);
 
         let q: Vec<i8> = strategy.quantize(&x);
         assert_eq!(q, expected_q);

--- a/crates/burn-tensor/src/tests/mod.rs
+++ b/crates/burn-tensor/src/tests/mod.rs
@@ -386,14 +386,14 @@ pub mod qtensor {
     use crate::{
         Tensor, TensorData,
         backend::Backend,
-        quantization::{QuantSchemeDefault, QuantValue},
+        quantization::{QTensorPrimitive, QuantValue},
     };
 
     pub struct QTensor<B: Backend, const D: usize> {
         b: PhantomData<B>,
     }
 
-    impl<B: Backend + QuantSchemeDefault, const D: usize> QTensor<B, D> {
+    impl<B: Backend, const D: usize> QTensor<B, D> {
         /// Creates a quantized int8 tensor from the floating point data using the default quantization scheme
         /// (i.e., per-tensor symmetric quantization).
         pub fn int8<F: Into<TensorData>>(floats: F) -> Tensor<B, D> {
@@ -402,8 +402,10 @@ pub mod qtensor {
 
         /// Creates a quantized int8 tensor from the floating point data using per-tensor symmetric quantization.
         pub fn int8_symmetric<F: Into<TensorData>>(floats: F) -> Tensor<B, D> {
-            Tensor::from_floats(floats, &Default::default())
-                .quantize_dynamic(&B::quant_scheme().with_value(QuantValue::Q8S))
+            Tensor::from_floats(floats, &Default::default()).quantize_dynamic(
+                &<B::QuantizedTensorPrimitive as QTensorPrimitive>::default_scheme()
+                    .with_value(QuantValue::Q8S),
+            )
         }
     }
 }

--- a/crates/burn-tensor/src/tests/mod.rs
+++ b/crates/burn-tensor/src/tests/mod.rs
@@ -386,14 +386,14 @@ pub mod qtensor {
     use crate::{
         Tensor, TensorData,
         backend::Backend,
-        quantization::{QuantScheme, QuantValue},
+        quantization::{QuantSchemeDefault, QuantValue},
     };
 
     pub struct QTensor<B: Backend, const D: usize> {
         b: PhantomData<B>,
     }
 
-    impl<B: Backend, const D: usize> QTensor<B, D> {
+    impl<B: Backend + QuantSchemeDefault, const D: usize> QTensor<B, D> {
         /// Creates a quantized int8 tensor from the floating point data using the default quantization scheme
         /// (i.e., per-tensor symmetric quantization).
         pub fn int8<F: Into<TensorData>>(floats: F) -> Tensor<B, D> {
@@ -403,7 +403,7 @@ pub mod qtensor {
         /// Creates a quantized int8 tensor from the floating point data using per-tensor symmetric quantization.
         pub fn int8_symmetric<F: Into<TensorData>>(floats: F) -> Tensor<B, D> {
             Tensor::from_floats(floats, &Default::default())
-                .quantize_dynamic(&QuantScheme::default().with_value(QuantValue::Q8S))
+                .quantize_dynamic(&B::quant_scheme().with_value(QuantValue::Q8S))
         }
     }
 }

--- a/crates/burn-tensor/src/tests/quantization/calibration.rs
+++ b/crates/burn-tensor/src/tests/quantization/calibration.rs
@@ -3,14 +3,15 @@ mod tests {
     use super::*;
     use burn_tensor::{
         Tensor, TensorData,
-        quantization::{Calibration, QuantLevel, QuantSchemeDefault, QuantValue, compute_range},
+        ops::QuantizedTensor,
+        quantization::{Calibration, QTensorPrimitive, QuantLevel, QuantValue, compute_range},
     };
 
     // NOTE: The scheme variant fields are not important for calibration, only the "main" variant (e.g., per-tensor)
     #[test]
     fn min_max_calibration_range_per_tensor() {
         let tensor = TestTensor::<1>::from_floats([-1.8, -1.0, 0.0, 0.5], &Default::default());
-        let scheme = TestBackend::quant_scheme().with_value(QuantValue::Q8S);
+        let scheme = QuantizedTensor::<TestBackend>::default_scheme().with_value(QuantValue::Q8S);
 
         let range = compute_range(&scheme, &tensor, &Calibration::MinMax);
 
@@ -35,7 +36,7 @@ mod tests {
             ],
             &Default::default(),
         );
-        let scheme = TestBackend::quant_scheme()
+        let scheme = QuantizedTensor::<TestBackend>::default_scheme()
             .with_value(QuantValue::Q8S)
             .with_level(QuantLevel::Block(4));
 

--- a/crates/burn-tensor/src/tests/quantization/calibration.rs
+++ b/crates/burn-tensor/src/tests/quantization/calibration.rs
@@ -3,14 +3,14 @@ mod tests {
     use super::*;
     use burn_tensor::{
         Tensor, TensorData,
-        quantization::{Calibration, QuantLevel, QuantScheme, QuantValue, compute_range},
+        quantization::{Calibration, QuantLevel, QuantSchemeDefault, QuantValue, compute_range},
     };
 
     // NOTE: The scheme variant fields are not important for calibration, only the "main" variant (e.g., per-tensor)
     #[test]
     fn min_max_calibration_range_per_tensor() {
         let tensor = TestTensor::<1>::from_floats([-1.8, -1.0, 0.0, 0.5], &Default::default());
-        let scheme = QuantScheme::default().with_value(QuantValue::Q8S);
+        let scheme = TestBackend::quant_scheme().with_value(QuantValue::Q8S);
 
         let range = compute_range(&scheme, &tensor, &Calibration::MinMax);
 
@@ -35,7 +35,7 @@ mod tests {
             ],
             &Default::default(),
         );
-        let scheme = QuantScheme::default()
+        let scheme = TestBackend::quant_scheme()
             .with_value(QuantValue::Q8S)
             .with_level(QuantLevel::Block(4));
 

--- a/crates/burn-tensor/src/tests/quantization/data.rs
+++ b/crates/burn-tensor/src/tests/quantization/data.rs
@@ -2,7 +2,9 @@
 mod tests {
     use super::*;
     use alloc::{vec, vec::Vec};
-    use burn_tensor::quantization::{QuantizationStrategy, SymmetricQuantization};
+    use burn_tensor::quantization::{
+        QuantScheme, QuantValue, QuantizationStrategy, SymmetricQuantization,
+    };
     use burn_tensor::{Tensor, TensorData};
 
     #[test]
@@ -10,9 +12,11 @@ mod tests {
         let data = TensorData::quantized(
             vec![-127i8, -71, 0, 35],
             [4],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(
+            QuantizationStrategy::PerTensorSymmetric(SymmetricQuantization::init(
                 0.014_173_228,
+                QuantValue::Q8S,
             )),
+            QuantScheme::default(),
         );
         let tensor = TestTensor::<1>::from_data(data.clone(), &Default::default());
 
@@ -31,13 +35,14 @@ mod tests {
                 -127i8, -71, 0, 35, -127i8, -71, 0, 35, -32, -63, -95, -127, -32, -63, -95, -127,
             ],
             [16],
-            QuantizationStrategy::PerBlockSymmetricInt8(
+            QuantizationStrategy::PerBlockSymmetric(
                 vec![
-                    SymmetricQuantization::init(0.014_173_228),
-                    SymmetricQuantization::init(0.000_314_96),
+                    SymmetricQuantization::init(0.014_173_228, QuantValue::Q8S),
+                    SymmetricQuantization::init(0.000_314_96, QuantValue::Q8S),
                 ],
                 8,
             ),
+            QuantScheme::default(),
         );
         let tensor = TestTensor::<1>::from_data(data.clone(), &Default::default());
 

--- a/crates/burn-tensor/src/tests/quantization/data.rs
+++ b/crates/burn-tensor/src/tests/quantization/data.rs
@@ -3,9 +3,9 @@ mod tests {
     use super::*;
     use alloc::{vec, vec::Vec};
     use burn_tensor::quantization::{
-        QuantLevel, QuantSchemeDefault, QuantValue, QuantizationStrategy, SymmetricQuantization,
+        QTensorPrimitive, QuantLevel, QuantValue, QuantizationStrategy, SymmetricQuantization,
     };
-    use burn_tensor::{Tensor, TensorData};
+    use burn_tensor::{Tensor, TensorData, ops::QuantizedTensor};
 
     #[test]
     fn should_support_per_tensor_symmetric_int8() {
@@ -16,7 +16,7 @@ mod tests {
                 0.014_173_228,
                 QuantValue::Q8S,
             )),
-            TestBackend::quant_scheme().with_value(QuantValue::Q8S),
+            QuantizedTensor::<TestBackend>::default_scheme().with_value(QuantValue::Q8S),
         );
         let tensor = TestTensor::<1>::from_data(data.clone(), &Default::default());
 
@@ -42,7 +42,7 @@ mod tests {
                 ],
                 8,
             ),
-            TestBackend::quant_scheme()
+            QuantizedTensor::<TestBackend>::default_scheme()
                 .with_value(QuantValue::Q8S)
                 .with_level(QuantLevel::Block(8)),
         );

--- a/crates/burn-tensor/src/tests/quantization/data.rs
+++ b/crates/burn-tensor/src/tests/quantization/data.rs
@@ -3,7 +3,7 @@ mod tests {
     use super::*;
     use alloc::{vec, vec::Vec};
     use burn_tensor::quantization::{
-        QuantScheme, QuantValue, QuantizationStrategy, SymmetricQuantization,
+        QuantLevel, QuantSchemeDefault, QuantValue, QuantizationStrategy, SymmetricQuantization,
     };
     use burn_tensor::{Tensor, TensorData};
 
@@ -16,7 +16,7 @@ mod tests {
                 0.014_173_228,
                 QuantValue::Q8S,
             )),
-            QuantScheme::default(),
+            TestBackend::quant_scheme().with_value(QuantValue::Q8S),
         );
         let tensor = TestTensor::<1>::from_data(data.clone(), &Default::default());
 
@@ -42,7 +42,9 @@ mod tests {
                 ],
                 8,
             ),
-            QuantScheme::default(),
+            TestBackend::quant_scheme()
+                .with_value(QuantValue::Q8S)
+                .with_level(QuantLevel::Block(8)),
         );
         let tensor = TestTensor::<1>::from_data(data.clone(), &Default::default());
 

--- a/crates/burn-tensor/src/tests/quantization/ops/quantize.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/quantize.rs
@@ -40,9 +40,11 @@ mod tests {
         let expected = TensorData::quantized(
             vec![-127i8, -71, 0, 35],
             [4],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(
+            QuantizationStrategy::PerTensorSymmetric(SymmetricQuantization::init(
                 0.014_173_228,
+                QuantValue::Q8S,
             )),
+            QuantScheme::default(),
         );
 
         // Values equality
@@ -77,7 +79,11 @@ mod tests {
         let expected = TensorData::quantized(
             vec![50i8, 0, 40, -127],
             [4],
-            QuantizationStrategy::PerTensorSymmetricInt8(SymmetricQuantization::init(0.1)),
+            QuantizationStrategy::PerTensorSymmetric(SymmetricQuantization::init(
+                0.1,
+                QuantValue::Q8S,
+            )),
+            QuantScheme::default(),
         );
 
         x_q.into_data().assert_eq(&expected, false);

--- a/crates/burn-tensor/src/tests/quantization/ops/quantize.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/quantize.rs
@@ -3,11 +3,14 @@ mod tests {
     use super::*;
     use alloc::{vec, vec::Vec};
     use burn_tensor::quantization::{
-        QParams, QuantSchemeDefault, QuantValue, QuantizationParameters, QuantizationStrategy,
+        QParams, QTensorPrimitive, QuantValue, QuantizationParameters, QuantizationStrategy,
         QuantizedBytes, SymmetricQuantization,
     };
     use burn_tensor::{DType, Tensor, TensorData};
-    use burn_tensor::{Tolerance, ops::FloatElem};
+    use burn_tensor::{
+        Tolerance,
+        ops::{FloatElem, QuantizedTensor},
+    };
     type FT = FloatElem<TestBackend>;
 
     fn get_q_params(data: TensorData) -> QParams<Vec<f32>> {
@@ -29,7 +32,7 @@ mod tests {
     fn should_support_quantize_symmetric_int8() {
         let device = Default::default();
         let tensor = TestTensor::<1>::from_floats([-1.8, -1.0, 0.0, 0.5], &device);
-        let scheme = TestBackend::quant_scheme().with_value(QuantValue::Q8S);
+        let scheme = QuantizedTensor::<TestBackend>::default_scheme().with_value(QuantValue::Q8S);
         let qparams = QuantizationParameters {
             scales: Tensor::from_floats([0.014_173_228], &device),
         };
@@ -72,7 +75,7 @@ mod tests {
         // NOTE: we use fully representable values since different backend implementations could differ slightly
         // due to rounding discrepancies
         let tensor = TestTensor::<1>::from_floats([5., 0., 4., -12.7], &device);
-        let scheme = TestBackend::quant_scheme().with_value(QuantValue::Q8S);
+        let scheme = QuantizedTensor::<TestBackend>::default_scheme().with_value(QuantValue::Q8S);
 
         let x_q = tensor.quantize_dynamic(&scheme);
 
@@ -91,7 +94,7 @@ mod tests {
 
     #[test]
     fn should_quantize_dequantize_symmetric_single_with_transform() {
-        let scheme = TestBackend::quant_scheme().with_value(QuantValue::Q8S);
+        let scheme = QuantizedTensor::<TestBackend>::default_scheme().with_value(QuantValue::Q8S);
         let input = TestTensorInt::<1>::arange(0..32, &Default::default()).float();
 
         let quant = input.quantize_dynamic(&scheme);

--- a/crates/burn-tensor/src/tests/quantization/ops/quantize.rs
+++ b/crates/burn-tensor/src/tests/quantization/ops/quantize.rs
@@ -3,7 +3,7 @@ mod tests {
     use super::*;
     use alloc::{vec, vec::Vec};
     use burn_tensor::quantization::{
-        QParams, QuantScheme, QuantValue, QuantizationParameters, QuantizationStrategy,
+        QParams, QuantSchemeDefault, QuantValue, QuantizationParameters, QuantizationStrategy,
         QuantizedBytes, SymmetricQuantization,
     };
     use burn_tensor::{DType, Tensor, TensorData};
@@ -29,7 +29,7 @@ mod tests {
     fn should_support_quantize_symmetric_int8() {
         let device = Default::default();
         let tensor = TestTensor::<1>::from_floats([-1.8, -1.0, 0.0, 0.5], &device);
-        let scheme = QuantScheme::default().with_value(QuantValue::Q8S);
+        let scheme = TestBackend::quant_scheme().with_value(QuantValue::Q8S);
         let qparams = QuantizationParameters {
             scales: Tensor::from_floats([0.014_173_228], &device),
         };
@@ -44,7 +44,7 @@ mod tests {
                 0.014_173_228,
                 QuantValue::Q8S,
             )),
-            QuantScheme::default(),
+            scheme,
         );
 
         // Values equality
@@ -72,7 +72,7 @@ mod tests {
         // NOTE: we use fully representable values since different backend implementations could differ slightly
         // due to rounding discrepancies
         let tensor = TestTensor::<1>::from_floats([5., 0., 4., -12.7], &device);
-        let scheme = QuantScheme::default().with_value(QuantValue::Q8S);
+        let scheme = TestBackend::quant_scheme().with_value(QuantValue::Q8S);
 
         let x_q = tensor.quantize_dynamic(&scheme);
 
@@ -83,7 +83,7 @@ mod tests {
                 0.1,
                 QuantValue::Q8S,
             )),
-            QuantScheme::default(),
+            scheme,
         );
 
         x_q.into_data().assert_eq(&expected, false);
@@ -91,7 +91,7 @@ mod tests {
 
     #[test]
     fn should_quantize_dequantize_symmetric_single_with_transform() {
-        let scheme = QuantScheme::default().with_value(QuantValue::Q8S);
+        let scheme = TestBackend::quant_scheme().with_value(QuantValue::Q8S);
         let input = TestTensorInt::<1>::arange(0..32, &Default::default()).float();
 
         let quant = input.quantize_dynamic(&scheme);

--- a/crates/burn-tensor/src/tests/quantization/scheme.rs
+++ b/crates/burn-tensor/src/tests/quantization/scheme.rs
@@ -4,8 +4,8 @@ mod tests {
     use burn_tensor::{
         DType, Element, Tensor, TensorData,
         quantization::{
-            CalibrationRange, QuantLevel, QuantMode, QuantParam, QuantPropagation, QuantScheme,
-            QuantStore, QuantValue, compute_q_params,
+            CalibrationRange, QuantLevel, QuantMode, QuantParam, QuantPropagation,
+            QuantSchemeDefault, QuantStore, QuantValue, compute_q_params,
         },
     };
     use burn_tensor::{Tolerance, ops::FloatElem};
@@ -14,7 +14,7 @@ mod tests {
     #[test]
     fn per_tensor_symmetric_int8() {
         let device = Default::default();
-        let scheme = QuantScheme::default().with_value(QuantValue::Q8S);
+        let scheme = TestBackend::quant_scheme().with_value(QuantValue::Q8S);
         let range = CalibrationRange {
             min: TestTensor::<1>::from_floats([0.5], &device),
             max: TestTensor::<1>::from_floats([1.8], &device),
@@ -31,7 +31,7 @@ mod tests {
     #[test]
     fn per_block_symmetric_int8() {
         let device = Default::default();
-        let scheme = QuantScheme::default()
+        let scheme = TestBackend::quant_scheme()
             .with_value(QuantValue::Q8S)
             .with_level(QuantLevel::Block(4));
         let range = CalibrationRange {
@@ -50,7 +50,7 @@ mod tests {
     #[test]
     fn quant_scheme_should_inhibit_by_default() {
         let device = Default::default();
-        let scheme = QuantScheme::default().with_value(QuantValue::Q8S);
+        let scheme = TestBackend::quant_scheme().with_value(QuantValue::Q8S);
 
         let tensor_1 = TestTensor::<2>::from_floats(
             [[1.0, 6.35, 0., 0.], [2.0, 3.0, 0., 0.], [1.0, 3.0, 0., 0.]],

--- a/crates/burn-tensor/src/tests/quantization/scheme.rs
+++ b/crates/burn-tensor/src/tests/quantization/scheme.rs
@@ -3,9 +3,10 @@ mod tests {
     use super::*;
     use burn_tensor::{
         DType, Element, Tensor, TensorData,
+        ops::QuantizedTensor,
         quantization::{
-            CalibrationRange, QuantLevel, QuantMode, QuantParam, QuantPropagation,
-            QuantSchemeDefault, QuantStore, QuantValue, compute_q_params,
+            CalibrationRange, QTensorPrimitive, QuantLevel, QuantMode, QuantParam,
+            QuantPropagation, QuantStore, QuantValue, compute_q_params,
         },
     };
     use burn_tensor::{Tolerance, ops::FloatElem};
@@ -14,7 +15,7 @@ mod tests {
     #[test]
     fn per_tensor_symmetric_int8() {
         let device = Default::default();
-        let scheme = TestBackend::quant_scheme().with_value(QuantValue::Q8S);
+        let scheme = QuantizedTensor::<TestBackend>::default_scheme().with_value(QuantValue::Q8S);
         let range = CalibrationRange {
             min: TestTensor::<1>::from_floats([0.5], &device),
             max: TestTensor::<1>::from_floats([1.8], &device),
@@ -31,7 +32,7 @@ mod tests {
     #[test]
     fn per_block_symmetric_int8() {
         let device = Default::default();
-        let scheme = TestBackend::quant_scheme()
+        let scheme = QuantizedTensor::<TestBackend>::default_scheme()
             .with_value(QuantValue::Q8S)
             .with_level(QuantLevel::Block(4));
         let range = CalibrationRange {
@@ -50,7 +51,7 @@ mod tests {
     #[test]
     fn quant_scheme_should_inhibit_by_default() {
         let device = Default::default();
-        let scheme = TestBackend::quant_scheme().with_value(QuantValue::Q8S);
+        let scheme = QuantizedTensor::<TestBackend>::default_scheme().with_value(QuantValue::Q8S);
 
         let tensor_1 = TestTensor::<2>::from_floats(
             [[1.0, 6.35, 0., 0.], [2.0, 3.0, 0., 0.], [1.0, 3.0, 0., 0.]],


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Follow-up to #3613

Vulkan tests pass with fixes in this cubecl PR:
https://github.com/tracel-ai/cubecl/pull/843
(not included, requires a minor refactor to reflect the layout changes in another PR that was merged)

### Changes

- Correct data conversion for sub-byte types (required for value equality tests)
- Tests for quant formats, including q2 and q4

### Testing

Unit tests
