### PR TITLE
Apply clippy fixes to burn-ndarray

### DIFF
--- a/crates/burn-ndarray/src/ops/base.rs
+++ b/crates/burn-ndarray/src/ops/base.rs
@@ -838,7 +838,7 @@ where
 
         let output = Zip::from(&lhs.array)
             .and(&rhs.array)
-            .map_collect(|&lhs_val, &rhs_val| (lhs_val == rhs_val))
+            .map_collect(|&lhs_val, &rhs_val| lhs_val == rhs_val)
             .into_shared();
         NdArrayTensor::new(output)
     }
@@ -1161,7 +1161,7 @@ impl NdArrayBoolOps {
 
         let output = Zip::from(&lhs.array)
             .and(&rhs.array)
-            .map_collect(|&lhs_val, &rhs_val| (lhs_val == rhs_val))
+            .map_collect(|&lhs_val, &rhs_val| lhs_val == rhs_val)
             .into_shared();
         NdArrayTensor::new(output)
     }
@@ -1175,7 +1175,7 @@ impl NdArrayBoolOps {
 
         let output = Zip::from(&lhs.array)
             .and(&rhs.array)
-            .map_collect(|&lhs_val, &rhs_val| (lhs_val && rhs_val))
+            .map_collect(|&lhs_val, &rhs_val| lhs_val && rhs_val)
             .into_shared();
         NdArrayTensor::new(output)
     }
@@ -1189,7 +1189,7 @@ impl NdArrayBoolOps {
 
         let output = Zip::from(&lhs.array)
             .and(&rhs.array)
-            .map_collect(|&lhs_val, &rhs_val| (lhs_val || rhs_val))
+            .map_collect(|&lhs_val, &rhs_val| lhs_val || rhs_val)
             .into_shared();
         NdArrayTensor::new(output)
     }


### PR DESCRIPTION
### Changes

Every time I e.g. `cargo run --release` in `burn-import` I get clippy related warnings:

<img width="714" height="997" alt="image" src="https://github.com/user-attachments/assets/9bcb5151-1db3-42ab-a9e1-83261b21fd2f" />

might as well fix them.

### Testing

Running `cargo run --release` in `burn-import` doesn't complain anymore
