### PR TITLE
Remove D param from `BatchNorm<B, D>`.

### DIFF
--- a/crates/burn-import/pytorch-tests/tests/batch_norm/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/batch_norm/mod.rs
@@ -6,7 +6,7 @@ use burn::{
 
 #[derive(Module, Debug)]
 pub struct Net<B: Backend> {
-    norm1: BatchNorm<B, 2>,
+    norm1: BatchNorm<B>,
 }
 
 impl<B: Backend> Net<B> {

--- a/crates/burn-import/pytorch-tests/tests/complex_nested/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/complex_nested/mod.rs
@@ -20,13 +20,13 @@ use burn_import::pytorch::{LoadArgs, PyTorchFileRecorder};
 #[derive(Module, Debug)]
 pub struct ConvBlock<B: Backend> {
     conv: Conv2d<B>,
-    norm: BatchNorm<B, 2>,
+    norm: BatchNorm<B>,
 }
 
 #[derive(Module, Debug)]
 pub struct Net<B: Backend> {
     conv_blocks: Vec<ConvBlock<B>>,
-    norm1: BatchNorm<B, 2>,
+    norm1: BatchNorm<B>,
     fc1: Linear<B>,
     fc2: Linear<B>,
 }

--- a/crates/burn-import/pytorch-tests/tests/key_remap_chained/mod.rs
+++ b/crates/burn-import/pytorch-tests/tests/key_remap_chained/mod.rs
@@ -18,7 +18,7 @@ pub trait ForwardModule<B: Backend> {
 #[derive(Module, Debug)]
 pub struct ConvBlock<B: Backend> {
     conv: Conv2d<B>,
-    bn: BatchNorm<B, 2>,
+    bn: BatchNorm<B>,
 }
 
 impl<B: Backend> ForwardModule<B> for ConvBlock<B> {
@@ -70,7 +70,7 @@ impl<B: Backend> ModuleBlock<B, ConvBlock<B>> {
 #[derive(Module, Debug)]
 pub struct Model<B: Backend, M> {
     conv: Conv2d<B>,
-    bn: BatchNorm<B, 2>,
+    bn: BatchNorm<B>,
     layer: ModuleBlock<B, M>,
 }
 

--- a/crates/burn-import/safetensors-tests/tests/multi_layer/mod.rs
+++ b/crates/burn-import/safetensors-tests/tests/multi_layer/mod.rs
@@ -10,7 +10,7 @@ use burn::{
 #[derive(Module, Debug)]
 pub struct Net<B: Backend> {
     conv1: Conv2d<B>,
-    norm1: BatchNorm<B, 2>,
+    norm1: BatchNorm<B>,
     fc1: Linear<B>,
     relu: Relu,
 }

--- a/crates/burn-import/src/burn/node/batch_norm.rs
+++ b/crates/burn-import/src/burn/node/batch_norm.rs
@@ -37,14 +37,12 @@ impl BatchNormNode {
         running_var: TensorData,
         config: BatchNormConfig,
     ) -> Self {
-        let dim_tokens = dim.to_tokens();
-
         Self {
             dim,
             field: OtherType::new(
                 name,
                 quote! {
-                    BatchNorm<B, #dim_tokens>
+                    BatchNorm<B>
                 },
             ),
             input,
@@ -60,18 +58,7 @@ impl BatchNormNode {
 
 macro_rules! batch_norm_serialize {
     ($self:expr, $serializer:expr) => {{
-        match $self.dim {
-            0 => batch_norm_serialize!($self, $serializer, 0),
-            1 => batch_norm_serialize!($self, $serializer, 1),
-            2 => batch_norm_serialize!($self, $serializer, 2),
-            3 => batch_norm_serialize!($self, $serializer, 3),
-            4 => batch_norm_serialize!($self, $serializer, 4),
-            _ => panic!("Unsupported dim {}", $self.dim),
-        }
-    }};
-
-    ($self:expr, $serializer:expr, $dim:expr) => {{
-        let record: BatchNormRecord<SerializationBackend, $dim> =
+        let record: BatchNormRecord<SerializationBackend> =
             batch_norm_serialize!(record $self);
         let item = Record::into_item::<PS>(record);
 
@@ -184,7 +171,7 @@ mod tests {
 
             #[derive(Module, Debug)]
             pub struct Model <B: Backend> {
-                norm: BatchNorm<B, 2>,
+                norm: BatchNorm<B>,
                 phantom: core::marker::PhantomData<B>,
                 device: burn::module::Ignored<B::Device>,
             }

--- a/examples/import-model-weights/src/model.rs
+++ b/examples/import-model-weights/src/model.rs
@@ -12,10 +12,10 @@ pub struct Model<B: Backend> {
     conv1: Conv2d<B>,
     conv2: Conv2d<B>,
     conv3: Conv2d<B>,
-    norm1: BatchNorm<B, 2>,
+    norm1: BatchNorm<B>,
     fc1: Linear<B>,
     fc2: Linear<B>,
-    norm2: BatchNorm<B, 0>,
+    norm2: BatchNorm<B>,
 }
 
 impl<B: Backend> Model<B> {

--- a/examples/mnist-inference-web/src/model.rs
+++ b/examples/mnist-inference-web/src/model.rs
@@ -65,7 +65,7 @@ impl<B: Backend> Model<B> {
 #[derive(Module, Debug)]
 pub struct ConvBlock<B: Backend> {
     conv: nn::conv::Conv2d<B>,
-    norm: BatchNorm<B, 2>,
+    norm: BatchNorm<B>,
     pool: Option<MaxPool2d>,
     activation: nn::Relu,
 }

--- a/examples/mnist/src/model.rs
+++ b/examples/mnist/src/model.rs
@@ -91,7 +91,7 @@ impl<B: Backend> Model<B> {
 #[derive(Module, Debug)]
 pub struct ConvBlock<B: Backend> {
     conv: nn::conv::Conv2d<B>,
-    norm: BatchNorm<B, 2>,
+    norm: BatchNorm<B>,
     pool: Option<MaxPool2d>,
     activation: nn::Relu,
 }

--- a/examples/wgan/src/model.rs
+++ b/examples/wgan/src/model.rs
@@ -1,6 +1,5 @@
 use burn::{
     module::{Module, ModuleMapper, ParamId},
-    nn::BatchNorm,
     prelude::*,
     tensor::backend::AutodiffBackend,
 };
@@ -9,7 +8,7 @@ use burn::{
 #[derive(Module, Debug)]
 pub struct LayerBlock<B: Backend> {
     fc: nn::Linear<B>,
-    bn: nn::BatchNorm<B, 0>,
+    bn: nn::BatchNorm<B>,
     leakyrelu: nn::LeakyRelu,
 }
 
@@ -18,7 +17,7 @@ impl<B: Backend> LayerBlock<B> {
         let fc = nn::LinearConfig::new(input, output)
             .with_bias(true)
             .init(device);
-        let bn: BatchNorm<B, 0> = nn::BatchNormConfig::new(output)
+        let bn: nn::BatchNorm<B> = nn::BatchNormConfig::new(output)
             .with_epsilon(0.8)
             .init(device);
         let leakyrelu = nn::LeakyReluConfig::new().with_negative_slope(0.2).init();


### PR DESCRIPTION
Based upon discussion with @laggui

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

`BatchNorm<B, D>` has a type/call interface distinct from the other norm layers in the tree; making norm-abstraction wrapper layers messy. Additionally, the param is used only in a run-time check in `.forward()`.
