### PR TITLE
Introduce `NormLayer` abstraction for unified normalization layers.

### DIFF
--- a/crates/burn-core/src/nn/mod.rs
+++ b/crates/burn-core/src/nn/mod.rs
@@ -28,7 +28,6 @@ mod hard_sigmoid;
 mod initializer;
 mod leaky_relu;
 mod linear;
-mod norm;
 mod padding;
 mod pos_encoding;
 mod prelu;
@@ -40,6 +39,14 @@ mod swiglu;
 mod tanh;
 mod unfold;
 
+pub mod norm;
+pub use norm::{
+    BatchNorm, BatchNormConfig, BatchNormRecord, BatchNormRecordItem, GroupNorm, GroupNormConfig,
+    GroupNormRecord, GroupNormRecordItem, InstanceNorm, InstanceNormConfig, InstanceNormRecord,
+    InstanceNormRecordItem, LayerNorm, LayerNormConfig, LayerNormRecord, LayerNormRecordItem,
+    RmsNorm, RmsNormConfig, RmsNormRecord, RmsNormRecordItem,
+};
+
 pub use dropout::*;
 pub use embedding::*;
 pub use gelu::*;
@@ -48,7 +55,6 @@ pub use hard_sigmoid::*;
 pub use initializer::*;
 pub use leaky_relu::*;
 pub use linear::*;
-pub use norm::*;
 pub use padding::*;
 pub use pos_encoding::*;
 pub use prelu::*;

--- a/crates/burn-core/src/nn/mod.rs
+++ b/crates/burn-core/src/nn/mod.rs
@@ -40,12 +40,7 @@ mod tanh;
 mod unfold;
 
 pub mod norm;
-pub use norm::{
-    BatchNorm, BatchNormConfig, BatchNormRecord, BatchNormRecordItem, GroupNorm, GroupNormConfig,
-    GroupNormRecord, GroupNormRecordItem, InstanceNorm, InstanceNormConfig, InstanceNormRecord,
-    InstanceNormRecordItem, LayerNorm, LayerNormConfig, LayerNormRecord, LayerNormRecordItem,
-    RmsNorm, RmsNormConfig, RmsNormRecord, RmsNormRecordItem,
-};
+pub use norm::{batch::*, group::*, instance::*, layer::*, rms::*};
 
 pub use dropout::*;
 pub use embedding::*;

--- a/crates/burn-core/src/nn/norm/mod.rs
+++ b/crates/burn-core/src/nn/norm/mod.rs
@@ -2,10 +2,12 @@ mod batch;
 mod group;
 mod instance;
 mod layer;
+mod norm_layer;
 mod rms;
 
 pub use batch::*;
 pub use group::*;
 pub use instance::*;
 pub use layer::*;
+pub use norm_layer::*;
 pub use rms::*;

--- a/crates/burn-core/src/nn/norm/mod.rs
+++ b/crates/burn-core/src/nn/norm/mod.rs
@@ -7,12 +7,13 @@
 /// * [`Instance`] - [`InstanceNorm`]
 /// * [`Layer`] - [`LayerNorm`]
 /// * [`Rms`] - [`RmsNorm`]
-mod batch;
-mod group;
-mod instance;
-mod layer;
+pub(crate) mod batch;
+pub(crate) mod group;
+pub(crate) mod instance;
+pub(crate) mod layer;
+pub(crate) mod rms;
+
 mod normalization_wrapper;
-mod rms;
 
 pub use batch::*;
 pub use group::*;

--- a/crates/burn-core/src/nn/norm/mod.rs
+++ b/crates/burn-core/src/nn/norm/mod.rs
@@ -1,13 +1,22 @@
+//! # Normalization Layers
+//!
+//! Users who wish to provide an abstraction over swappable normalization
+//! layers can use the [`Normalization`] wrapper, with support for:
+/// * [`Batch`] - [`BatchNorm`]
+/// * [`Group`] - [`GroupNorm`]
+/// * [`Instance`] - [`InstanceNorm`]
+/// * [`Layer`] - [`LayerNorm`]
+/// * [`Rms`] - [`RmsNorm`]
 mod batch;
 mod group;
 mod instance;
 mod layer;
-mod norm_layer;
+mod normalization_wrapper;
 mod rms;
 
 pub use batch::*;
 pub use group::*;
 pub use instance::*;
 pub use layer::*;
-pub use norm_layer::*;
+pub use normalization_wrapper::*;
 pub use rms::*;

--- a/crates/burn-core/src/nn/norm/norm_layer.rs
+++ b/crates/burn-core/src/nn/norm/norm_layer.rs
@@ -109,6 +109,7 @@ impl<B: Backend> NormLayer<B> {
     }
 }
 
+#[cfg(feature = "std")]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/burn-core/src/nn/norm/norm_layer.rs
+++ b/crates/burn-core/src/nn/norm/norm_layer.rs
@@ -1,0 +1,196 @@
+use crate as burn;
+use crate::nn::{
+    BatchNorm, BatchNormConfig, GroupNorm, GroupNormConfig, InstanceNorm, InstanceNormConfig,
+    LayerNorm, LayerNormConfig, RmsNorm, RmsNormConfig,
+};
+use burn_derive::{Config, Module};
+use burn_tensor::Tensor;
+use burn_tensor::backend::Backend;
+
+/// ['Norm'] Configuration.
+#[derive(Config, Debug)]
+#[non_exhaustive]
+pub enum NormLayerConfig {
+    /// ['BatchNorm'] Configuration.
+    Batch(BatchNormConfig),
+
+    /// ['GroupNorm'] Configuration.
+    Group(GroupNormConfig),
+
+    /// ['InstanceNorm'] Configuration.
+    Instance(InstanceNormConfig),
+
+    /// ['LayerNorm'] Configuration.
+    Layer(LayerNormConfig),
+
+    /// ['RmsNorm'] Configuration.
+    Rms(RmsNormConfig),
+}
+
+impl NormLayerConfig {
+    /// Initialize a ['Norm'] layer.
+    pub fn init<B: Backend>(&self, device: &B::Device) -> NormLayer<B> {
+        match self {
+            NormLayerConfig::Batch(config) => NormLayer::Batch(config.init(device)),
+            NormLayerConfig::Group(config) => NormLayer::Group(config.init(device)),
+            NormLayerConfig::Instance(config) => NormLayer::Instance(config.init(device)),
+            NormLayerConfig::Layer(config) => NormLayer::Layer(config.init(device)),
+            NormLayerConfig::Rms(config) => NormLayer::Rms(config.init(device)),
+        }
+    }
+}
+
+/// Norm Layer Wrapper
+///
+/// Provides support for many built-in ``burn::nn::norm`` norm layers.
+#[derive(Module, Debug)]
+#[non_exhaustive]
+pub enum NormLayer<B: Backend> {
+    /// [`BatchNorm`] layer.
+    Batch(BatchNorm<B>),
+
+    /// [`GroupNorm`] layer.
+    Group(GroupNorm<B>),
+
+    /// ['InstanceNorm'] layer.
+    Instance(InstanceNorm<B>),
+
+    /// [`LayerNorm`] layer.
+    Layer(LayerNorm<B>),
+
+    /// ['RmsNorm'] layer.
+    Rms(RmsNorm<B>),
+}
+
+impl<B: Backend> NormLayer<B> {
+    /// Applies normalization to a tensor.
+    ///
+    /// The normalization contract depends upon the wrapped norm layer;
+    /// but all norm layers assume an input of at least rank 2;
+    /// and produce an output of the same rank and shape.
+    pub fn forward<const D: usize>(&self, input: Tensor<B, D>) -> Tensor<B, D> {
+        match self {
+            NormLayer::Batch(batch_norm) => batch_norm.forward(input),
+            NormLayer::Group(group_norm) => group_norm.forward(input),
+            NormLayer::Instance(instance_norm) => instance_norm.forward(input),
+            NormLayer::Layer(layer_norm) => layer_norm.forward(input),
+            NormLayer::Rms(rms_norm) => rms_norm.forward(input),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::TestAutodiffBackend;
+
+    #[test]
+    fn test_batch_norm() {
+        type B = TestAutodiffBackend;
+        let device = Default::default();
+
+        let num_features = 12;
+        let input: Tensor<B, 4> = Tensor::ones([2, num_features, 3, 4], &device);
+
+        let config = NormLayerConfig::Batch(BatchNormConfig::new(12));
+
+        let layer: NormLayer<B> = config.init(&device);
+
+        let expected = match &layer {
+            NormLayer::Batch(inner) => inner.forward(input.clone()),
+            _ => panic!("Unexpected layer type"),
+        };
+
+        let output = layer.forward(input);
+
+        output.to_data().assert_eq(&expected.to_data(), true);
+    }
+
+    #[test]
+    fn test_group_norm() {
+        type B = TestAutodiffBackend;
+        let device = Default::default();
+
+        let num_features = 12;
+        let input: Tensor<B, 4> = Tensor::ones([2, num_features, 3, 4], &device);
+
+        let config = NormLayerConfig::Group(GroupNormConfig::new(3, num_features));
+
+        let layer: NormLayer<B> = config.init(&device);
+
+        let expected = match &layer {
+            NormLayer::Group(inner) => inner.forward(input.clone()),
+            _ => panic!("Unexpected layer type"),
+        };
+
+        let output = layer.forward(input);
+
+        output.to_data().assert_eq(&expected.to_data(), true);
+    }
+
+    #[test]
+    fn test_instance_norm() {
+        type B = TestAutodiffBackend;
+        let device = Default::default();
+
+        let num_features = 12;
+        let input: Tensor<B, 4> = Tensor::ones([2, num_features, 3, 4], &device);
+
+        let config = NormLayerConfig::Instance(InstanceNormConfig::new(num_features));
+
+        let layer: NormLayer<B> = config.init(&device);
+
+        let expected = match &layer {
+            NormLayer::Instance(inner) => inner.forward(input.clone()),
+            _ => panic!("Unexpected layer type"),
+        };
+
+        let output = layer.forward(input);
+
+        output.to_data().assert_eq(&expected.to_data(), true);
+    }
+
+    #[test]
+    fn test_layer_norm() {
+        type B = TestAutodiffBackend;
+        let device = Default::default();
+
+        let num_features = 12;
+        let input: Tensor<B, 4> = Tensor::ones([2, 3, 4, num_features], &device);
+
+        let config = NormLayerConfig::Layer(LayerNormConfig::new(num_features));
+
+        let layer: NormLayer<B> = config.init(&device);
+
+        let expected = match &layer {
+            NormLayer::Layer(inner) => inner.forward(input.clone()),
+            _ => panic!("Unexpected layer type"),
+        };
+
+        let output = layer.forward(input);
+
+        output.to_data().assert_eq(&expected.to_data(), true);
+    }
+
+    #[test]
+    fn test_rms_norm() {
+        type B = TestAutodiffBackend;
+        let device = Default::default();
+
+        let num_features = 12;
+        let input: Tensor<B, 4> = Tensor::ones([2, 3, 4, num_features], &device);
+
+        let config = NormLayerConfig::Rms(RmsNormConfig::new(num_features));
+
+        let layer: NormLayer<B> = config.init(&device);
+
+        let expected = match &layer {
+            NormLayer::Rms(inner) => inner.forward(input.clone()),
+            _ => panic!("Unexpected layer type"),
+        };
+
+        let output = layer.forward(input);
+
+        output.to_data().assert_eq(&expected.to_data(), true);
+    }
+}

--- a/crates/burn-core/src/nn/norm/norm_layer.rs
+++ b/crates/burn-core/src/nn/norm/norm_layer.rs
@@ -27,6 +27,36 @@ pub enum NormLayerConfig {
     Rms(RmsNormConfig),
 }
 
+impl From<BatchNormConfig> for NormLayerConfig {
+    fn from(config: BatchNormConfig) -> Self {
+        Self::Batch(config)
+    }
+}
+
+impl From<GroupNormConfig> for NormLayerConfig {
+    fn from(config: GroupNormConfig) -> Self {
+        Self::Group(config)
+    }
+}
+
+impl From<InstanceNormConfig> for NormLayerConfig {
+    fn from(config: InstanceNormConfig) -> Self {
+        Self::Instance(config)
+    }
+}
+
+impl From<LayerNormConfig> for NormLayerConfig {
+    fn from(config: LayerNormConfig) -> Self {
+        Self::Layer(config)
+    }
+}
+
+impl From<RmsNormConfig> for NormLayerConfig {
+    fn from(config: RmsNormConfig) -> Self {
+        Self::Rms(config)
+    }
+}
+
 impl NormLayerConfig {
     /// Initialize a ['Norm'] layer.
     pub fn init<B: Backend>(&self, device: &B::Device) -> NormLayer<B> {
@@ -92,7 +122,7 @@ mod tests {
         let num_features = 12;
         let input: Tensor<B, 4> = Tensor::ones([2, num_features, 3, 4], &device);
 
-        let config = NormLayerConfig::Batch(BatchNormConfig::new(12));
+        let config: NormLayerConfig = BatchNormConfig::new(12).into();
 
         let layer: NormLayer<B> = config.init(&device);
 
@@ -114,7 +144,7 @@ mod tests {
         let num_features = 12;
         let input: Tensor<B, 4> = Tensor::ones([2, num_features, 3, 4], &device);
 
-        let config = NormLayerConfig::Group(GroupNormConfig::new(3, num_features));
+        let config: NormLayerConfig = GroupNormConfig::new(3, num_features).into();
 
         let layer: NormLayer<B> = config.init(&device);
 
@@ -136,7 +166,7 @@ mod tests {
         let num_features = 12;
         let input: Tensor<B, 4> = Tensor::ones([2, num_features, 3, 4], &device);
 
-        let config = NormLayerConfig::Instance(InstanceNormConfig::new(num_features));
+        let config: NormLayerConfig = InstanceNormConfig::new(num_features).into();
 
         let layer: NormLayer<B> = config.init(&device);
 
@@ -158,7 +188,7 @@ mod tests {
         let num_features = 12;
         let input: Tensor<B, 4> = Tensor::ones([2, 3, 4, num_features], &device);
 
-        let config = NormLayerConfig::Layer(LayerNormConfig::new(num_features));
+        let config: NormLayerConfig = LayerNormConfig::new(num_features).into();
 
         let layer: NormLayer<B> = config.init(&device);
 
@@ -180,7 +210,7 @@ mod tests {
         let num_features = 12;
         let input: Tensor<B, 4> = Tensor::ones([2, 3, 4, num_features], &device);
 
-        let config = NormLayerConfig::Rms(RmsNormConfig::new(num_features));
+        let config: NormLayerConfig = RmsNormConfig::new(num_features).into();
 
         let layer: NormLayer<B> = config.init(&device);
 

--- a/crates/burn-core/src/nn/norm/rms.rs
+++ b/crates/burn-core/src/nn/norm/rms.rs
@@ -11,7 +11,7 @@ use crate::tensor::Tensor;
 use crate::tensor::backend::Backend;
 
 /// Configuration to create a [RMS Norm](RmsNorm) layer using the [init function](RmsNormConfig::init).
-#[derive(Config)]
+#[derive(Config, Debug)]
 pub struct RmsNormConfig {
     /// The size of the input features.
     pub d_model: usize,


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

- Added `NormLayerConfig` and `NormLayer` enums.
- Supports `BatchNorm`, `GroupNorm`, `InstanceNorm`, `LayerNorm`, and `RmsNorm`.
- Included comprehensive unit tests for all supported layers.
- Added `Debug` to `RmsNormConfig`.