### PR TITLE
Limit cubecl cpu target

### DIFF
--- a/crates/burn-cpu/src/lib.rs
+++ b/crates/burn-cpu/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg(target_os = "linux")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 extern crate alloc;

--- a/crates/burn-tensor/src/lib.rs
+++ b/crates/burn-tensor/src/lib.rs
@@ -107,7 +107,7 @@ mod cube_cuda {
     }
 }
 
-#[cfg(feature = "cubecl-cpu")]
+#[cfg(all(feature = "cubecl-cpu", target_os = "linux"))]
 mod cube_cpu {
     use crate::backend::{DeviceId, DeviceOps};
     use cubecl::cpu::CpuDevice;


### PR DESCRIPTION
Fixes #3655

Mirror `cubecl-cpu` restriction for linux