### PR TITLE
Bump cubecl to use wgpu 26

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,9 +158,9 @@ portable-atomic = { version = "1.11.1" }
 portable-atomic-util = { version = "0.2.4", features = ["alloc"] }
 
 ### For the main burn branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "7daf6b6c65fb44e27df0e42e7c4ab141d93518dc" }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "7daf6b6c65fb44e27df0e42e7c4ab141d93518dc" }
-cubecl-quant = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "7daf6b6c65fb44e27df0e42e7c4ab141d93518dc" }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "e770e3ee6bcf9d55ffe0753ca926193e0e0fdcc8" }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "e770e3ee6bcf9d55ffe0753ca926193e0e0fdcc8" }
+cubecl-quant = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "e770e3ee6bcf9d55ffe0753ca926193e0e0fdcc8" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [X] Confirmed that `cargo run-checks` command has been executed.
- [X] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

https://github.com/tracel-ai/cubecl/pull/850

### Changes

Use wgpu 26 :)

### Testing

CI and `cargo run-checks`
