### PR TITLE
add some missing `default-features = false`

### DIFF
--- a/crates/burn-tch/Cargo.toml
+++ b/crates/burn-tch/Cargo.toml
@@ -20,7 +20,7 @@ std = []
 doc = ["tch/doc-only"]
 
 [dependencies]
-burn-tensor = { path = "../burn-tensor", version = "0.19.0" }
+burn-tensor = { path = "../burn-tensor", version = "0.19.0", default-features = false }
 
 half = { workspace = true, features = ["std"] }
 libc = { workspace = true }

--- a/crates/burn/Cargo.toml
+++ b/crates/burn/Cargo.toml
@@ -147,6 +147,6 @@ burn-rocm = { path = "../burn-rocm", version = "0.19.0", optional = true, defaul
 burn-ndarray = { path = "../burn-ndarray", version = "0.19.0", optional = true, default-features = false }
 burn-remote = { path = "../burn-remote", version = "0.19.0", default-features = false, optional = true }
 burn-router = { path = "../burn-router", version = "0.19.0", default-features = false, optional = true }
-burn-tch = { path = "../burn-tch", version = "0.19.0", optional = true }
+burn-tch = { path = "../burn-tch", version = "0.19.0", default-features = false, optional = true }
 burn-wgpu = { path = "../burn-wgpu", version = "0.19.0", optional = true, default-features = false }
 burn-ir = { path = "../burn-ir", version = "0.19.0", optional = true, default-features = false }


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Changes do not affect the book.

### Changes

`cargo build`ing a crate that uses `burn` was failing when configured this way:

```
[dependencies.burn]
version = "0.19"
default-features = false
features = ["ndarray", "tch"]
```

The solution is for `burn-tch` not to pull in `burn-tensor` with default features (which are `["std", "burn-common/rayon"]`). This somehow caused `ndarray` and `burn-ndarray` to have problems compiling against `rayon`.

### Testing

Minimal `Cargo.toml` above now builds. `cargo run-checks` passes.
