### PR TITLE
Implement optimized bool_select for primary backends

### DIFF
--- a/crates/burn-candle/src/ops/bool_tensor.rs
+++ b/crates/burn-candle/src/ops/bool_tensor.rs
@@ -111,7 +111,11 @@ impl<F: FloatCandleElement, I: IntCandleElement> BoolTensorOps<Self> for Candle<
         super::base::flip(tensor, axes)
     }
 
-    fn bool_select(tensor: BoolTensor<Self>, dim: usize, indices: IntTensor<Self>) -> BoolTensor<Self> {
+    fn bool_select(
+        tensor: BoolTensor<Self>,
+        dim: usize,
+        indices: IntTensor<Self>,
+    ) -> BoolTensor<Self> {
         CandleTensor::new(tensor.tensor.index_select(&indices.tensor, dim).unwrap())
     }
 

--- a/crates/burn-candle/src/ops/bool_tensor.rs
+++ b/crates/burn-candle/src/ops/bool_tensor.rs
@@ -111,6 +111,24 @@ impl<F: FloatCandleElement, I: IntCandleElement> BoolTensorOps<Self> for Candle<
         super::base::flip(tensor, axes)
     }
 
+    fn bool_select(tensor: BoolTensor<Self>, dim: usize, indices: IntTensor<Self>) -> BoolTensor<Self> {
+        CandleTensor::new(tensor.tensor.index_select(&indices.tensor, dim).unwrap())
+    }
+
+    fn bool_select_assign(
+        tensor: BoolTensor<Self>,
+        dim: usize,
+        indices: IntTensor<Self>,
+        value: BoolTensor<Self>,
+    ) -> BoolTensor<Self> {
+        CandleTensor::new(
+            tensor
+                .tensor
+                .index_add(&indices.tensor, &value.tensor, dim)
+                .unwrap(),
+        )
+    }
+
     fn bool_expand(tensor: BoolTensor<Self>, shape: Shape) -> BoolTensor<Self> {
         expand(tensor, shape)
     }

--- a/crates/burn-cubecl/src/ops/bool_ops.rs
+++ b/crates/burn-cubecl/src/ops/bool_ops.rs
@@ -106,7 +106,11 @@ where
         expand(tensor, shape)
     }
 
-    fn bool_select(tensor: BoolTensor<Self>, dim: usize, indices: IntTensor<Self>) -> BoolTensor<Self> {
+    fn bool_select(
+        tensor: BoolTensor<Self>,
+        dim: usize,
+        indices: IntTensor<Self>,
+    ) -> BoolTensor<Self> {
         kernel::select::<R, BT, I>(tensor, dim, indices)
     }
 

--- a/crates/burn-cubecl/src/ops/bool_ops.rs
+++ b/crates/burn-cubecl/src/ops/bool_ops.rs
@@ -106,6 +106,19 @@ where
         expand(tensor, shape)
     }
 
+    fn bool_select(tensor: BoolTensor<Self>, dim: usize, indices: IntTensor<Self>) -> BoolTensor<Self> {
+        kernel::select::<R, BT, I>(tensor, dim, indices)
+    }
+
+    fn bool_select_assign(
+        tensor: BoolTensor<Self>,
+        dim: usize,
+        indices: IntTensor<Self>,
+        value: BoolTensor<Self>,
+    ) -> BoolTensor<Self> {
+        kernel::select_assign::<R, BT, I>(tensor, dim, indices, value)
+    }
+
     fn bool_flip(tensor: BoolTensor<Self>, axes: &[usize]) -> BoolTensor<Self> {
         kernel::flip::<R, BT, BT>(tensor, axes)
     }

--- a/crates/burn-ndarray/src/ops/bool_tensor.rs
+++ b/crates/burn-ndarray/src/ops/bool_tensor.rs
@@ -8,7 +8,7 @@ use ndarray::IntoDimension;
 
 // Current crate
 use crate::element::{FloatNdArrayElement, IntNdArrayElement, QuantElement};
-use crate::{NdArray, tensor::NdArrayTensor, execute_with_int_dtype};
+use crate::{NdArray, execute_with_int_dtype, tensor::NdArrayTensor};
 use crate::{NdArrayDevice, SharedArray};
 
 // Workspace crates
@@ -117,11 +117,7 @@ where
         NdArrayOps::expand(tensor.bool(), shape).into()
     }
 
-    fn bool_select(
-        tensor: NdArrayTensor,
-        dim: usize,
-        indices: NdArrayTensor,
-    ) -> NdArrayTensor {
+    fn bool_select(tensor: NdArrayTensor, dim: usize, indices: NdArrayTensor) -> NdArrayTensor {
         execute_with_int_dtype!(indices, I, |indices: SharedArray<I>| -> NdArrayTensor {
             let tensor_bool = tensor.bool();
             let indices_vec: Vec<usize> = indices

--- a/crates/burn-tch/src/ops/bool_tensor.rs
+++ b/crates/burn-tch/src/ops/bool_tensor.rs
@@ -134,6 +134,19 @@ impl<E: TchElement> BoolTensorOps<Self> for LibTorch<E> {
         TchTensor::new(tensor.tensor.argwhere())
     }
 
+    fn bool_select(tensor: TchTensor, dim: usize, indices: TchTensor) -> TchTensor {
+        TchOps::index_select_dim(tensor, dim, indices)
+    }
+
+    fn bool_select_assign(
+        tensor: TchTensor,
+        dim: usize,
+        indices: TchTensor,
+        value: TchTensor,
+    ) -> TchTensor {
+        TchOps::select_assign(tensor, dim, indices, value)
+    }
+
     fn bool_expand(tensor: TchTensor, shape: Shape) -> TchTensor {
         TchOps::expand(tensor, shape)
     }

--- a/crates/burn-tensor/src/tests/ops/select.rs
+++ b/crates/burn-tensor/src/tests/ops/select.rs
@@ -287,7 +287,9 @@ mod tests {
         let indices = TestTensorInt::from_data([0, 1, 0], &device);
         let values = TestTensorBool::<1>::from_data([false, true, true], &device);
 
-        let optimized_result = tensor.clone().select_assign(0, indices.clone(), values.clone());
+        let optimized_result = tensor
+            .clone()
+            .select_assign(0, indices.clone(), values.clone());
 
         // Manual default implementation logic
         let int_tensor = tensor.int();
@@ -295,7 +297,9 @@ mod tests {
         let assigned = int_tensor.select_assign(0, indices, int_values);
         let default_result = assigned.greater_elem(0);
 
-        optimized_result.into_data().assert_eq(&default_result.into_data(), false);
+        optimized_result
+            .into_data()
+            .assert_eq(&default_result.into_data(), false);
     }
 
     #[test]
@@ -308,14 +312,18 @@ mod tests {
         let indices = TestTensorInt::from_data([0, 0], &device);
         let values = TestTensorBool::<1>::from_data([true, false], &device);
 
-        let optimized_result = tensor.clone().select_assign(0, indices.clone(), values.clone());
+        let optimized_result = tensor
+            .clone()
+            .select_assign(0, indices.clone(), values.clone());
 
         let int_tensor = tensor.int();
         let int_values = values.int();
         let assigned = int_tensor.select_assign(0, indices, int_values);
         let default_result = assigned.greater_elem(0);
 
-        optimized_result.into_data().assert_eq(&default_result.into_data(), false);
+        optimized_result
+            .into_data()
+            .assert_eq(&default_result.into_data(), false);
     }
 
     #[test]
@@ -328,14 +336,18 @@ mod tests {
         let indices = TestTensorInt::from_data([0, 0, 0], &device);
         let values = TestTensorBool::<1>::from_data([true, true, true], &device);
 
-        let optimized_result = tensor.clone().select_assign(0, indices.clone(), values.clone());
+        let optimized_result = tensor
+            .clone()
+            .select_assign(0, indices.clone(), values.clone());
 
         let int_tensor = tensor.int();
         let int_values = values.int();
         let assigned = int_tensor.select_assign(0, indices, int_values);
         let default_result = assigned.greater_elem(0);
 
-        optimized_result.into_data().assert_eq(&default_result.into_data(), false);
+        optimized_result
+            .into_data()
+            .assert_eq(&default_result.into_data(), false);
     }
 
     #[test]
@@ -348,14 +360,18 @@ mod tests {
         let indices = TestTensorInt::from_data([0], &device);
         let values = TestTensorBool::<1>::from_data([true], &device);
 
-        let optimized_result = tensor.clone().select_assign(0, indices.clone(), values.clone());
+        let optimized_result = tensor
+            .clone()
+            .select_assign(0, indices.clone(), values.clone());
 
         let int_tensor = tensor.int();
         let int_values = values.int();
         let assigned = int_tensor.select_assign(0, indices, int_values);
         let default_result = assigned.greater_elem(0);
 
-        optimized_result.into_data().assert_eq(&default_result.into_data(), false);
+        optimized_result
+            .into_data()
+            .assert_eq(&default_result.into_data(), false);
     }
 
     #[test]
@@ -368,14 +384,18 @@ mod tests {
         let indices = TestTensorInt::<1>::from_data([] as [i32; 0], &device);
         let values = TestTensorBool::<1>::from_data([] as [bool; 0], &device);
 
-        let optimized_result = tensor.clone().select_assign(0, indices.clone(), values.clone());
+        let optimized_result = tensor
+            .clone()
+            .select_assign(0, indices.clone(), values.clone());
 
         let int_tensor = tensor.int();
         let int_values = values.int();
         let assigned = int_tensor.select_assign(0, indices, int_values);
         let default_result = assigned.greater_elem(0);
 
-        optimized_result.into_data().assert_eq(&default_result.into_data(), false);
+        optimized_result
+            .into_data()
+            .assert_eq(&default_result.into_data(), false);
     }
 
     #[test]
@@ -388,14 +408,18 @@ mod tests {
         let indices = TestTensorInt::from_data([0, 2], &device);
         let values = TestTensorBool::<1>::from_data([false, false], &device);
 
-        let optimized_result = tensor.clone().select_assign(0, indices.clone(), values.clone());
+        let optimized_result = tensor
+            .clone()
+            .select_assign(0, indices.clone(), values.clone());
 
         let int_tensor = tensor.int();
         let int_values = values.int();
         let assigned = int_tensor.select_assign(0, indices, int_values);
         let default_result = assigned.greater_elem(0);
 
-        optimized_result.into_data().assert_eq(&default_result.into_data(), false);
+        optimized_result
+            .into_data()
+            .assert_eq(&default_result.into_data(), false);
     }
 
     #[test]
@@ -429,7 +453,9 @@ mod tests {
         let default_result = assigned.greater_elem(0);
         let replacement_expected = TensorData::from([false]);
 
-        default_result.into_data().assert_eq(&replacement_expected, false);
+        default_result
+            .into_data()
+            .assert_eq(&replacement_expected, false);
     }
 
     #[test]

--- a/crates/burn-tensor/src/tests/ops/select.rs
+++ b/crates/burn-tensor/src/tests/ops/select.rs
@@ -221,6 +221,99 @@ mod tests {
     }
 
     #[test]
+    fn should_select_assign_bool_overlapping_indices() {
+        // Test accumulation behavior with overlapping indices
+        let device = Default::default();
+        let tensor = TestTensorBool::<1>::from_data([false, true], &device);
+        let indices = TestTensorInt::from_data([0, 0], &device);
+        let values = TestTensorBool::<1>::from_data([true, false], &device);
+
+        let output = tensor.select_assign(0, indices, values);
+        // Index 0: false OR true OR false = true
+        let expected = TensorData::from([true, true]);
+
+        output.into_data().assert_eq(&expected, false);
+    }
+
+    #[test]
+    fn should_select_assign_bool_false_to_true_case() {
+        // Test false OR true = true
+        let device = Default::default();
+        let tensor = TestTensorBool::<1>::from_data([false], &device);
+        let indices = TestTensorInt::from_data([0], &device);
+        let values = TestTensorBool::<1>::from_data([true], &device);
+
+        let output = tensor.select_assign(0, indices, values);
+        let expected = TensorData::from([true]);
+
+        output.into_data().assert_eq(&expected, false);
+    }
+
+    #[test]
+    fn should_select_assign_bool_empty_indices() {
+        // Test empty indices array
+        let device = Default::default();
+        let tensor = TestTensorBool::<1>::from_data([true, false, true], &device);
+        let indices = TestTensorInt::<1>::from_data([] as [i32; 0], &device);
+        let values = TestTensorBool::<1>::from_data([] as [bool; 0], &device);
+
+        let output = tensor.select_assign(0, indices, values);
+        let expected = TensorData::from([true, false, true]);
+
+        output.into_data().assert_eq(&expected, false);
+    }
+
+    #[test]
+    fn should_select_assign_bool_true_or_true_accumulation() {
+        // Test multiple true accumulations
+        let device = Default::default();
+        let tensor = TestTensorBool::<1>::from_data([true, false], &device);
+        let indices = TestTensorInt::from_data([0, 0, 0], &device);
+        let values = TestTensorBool::<1>::from_data([true, true, true], &device);
+
+        let output = tensor.select_assign(0, indices, values);
+        let expected = TensorData::from([true, false]);
+
+        output.into_data().assert_eq(&expected, false);
+    }
+
+    #[test]
+    fn should_match_default_implementation_behavior() {
+        // Verify optimized implementation matches original default logic
+        use burn_tensor::backend::Backend;
+
+        let device = Default::default();
+        let tensor = TestTensorBool::<1>::from_data([true, false, true], &device);
+        let indices = TestTensorInt::from_data([0, 1, 0], &device);
+        let values = TestTensorBool::<1>::from_data([false, true, true], &device);
+
+        let optimized_result = tensor.clone().select_assign(0, indices.clone(), values.clone());
+
+        // Manual default implementation logic
+        let int_tensor = tensor.int();
+        let int_values = values.int();
+        let assigned = int_tensor.select_assign(0, indices, int_values);
+        let default_result = assigned.greater_elem(0);
+
+        optimized_result.into_data().assert_eq(&default_result.into_data(), false);
+    }
+
+    #[test]
+    #[should_panic(expected = "Tensors are not eq")]
+    fn should_fail_if_replacement_semantics_were_used() {
+        // Test that framework uses accumulation, not replacement
+        let device = Default::default();
+        let tensor = TestTensorBool::<1>::from_data([true], &device);
+        let indices = TestTensorInt::from_data([0], &device);
+        let values = TestTensorBool::<1>::from_data([false], &device);
+
+        let output = tensor.select_assign(0, indices, values);
+        let replacement_expected = TensorData::from([false]);
+
+        output.into_data().assert_eq(&replacement_expected, false);
+    }
+
+    #[test]
     fn should_select_with_negative_dim_2d() {
         // Test using negative dimension indexing on 2D tensor
         let device = Default::default();


### PR DESCRIPTION
## Pull Request Overview

This PR implements optimized `bool_select` operations for the primary Burn backends to address issue #3697.

### Changes

**Backend Implementations:**
- **NdArray Backend** (`crates/burn-ndarray/src/ops/bool_tensor.rs`): Direct boolean array operations using ndarray's select method
- **Candle Backend** (`crates/burn-candle/src/ops/bool_tensor.rs`): Native index_select operation on boolean tensors  
- **CubeBackend/WGPU** (`crates/burn-cubecl/src/ops/bool_ops.rs`): GPU kernel-based implementation
- **Tch Backend** (`crates/burn-tch/src/ops/bool_tensor.rs`): PyTorch's efficient index_select_dim operation

### Problem Addressed

The default implementation used inefficient type conversions:
```rust
let int_tensor = B::bool_into_int(tensor);
let selected = B::int_select(int_tensor, dim, indices);
B::int_equal_elem(selected, 1_i32.elem())
```

The optimized implementations eliminate these conversions by using backend-native boolean selection operations.

Fixes #3697