### PR TITLE
feat(core/diffusion): Flow‑matching schedulers (Euler, Heun, PingPong) + timesteps utility

### DIFF
--- a/burn-book/src/SUMMARY.md
+++ b/burn-book/src/SUMMARY.md
@@ -14,6 +14,7 @@
   - [Tensor](./building-blocks/tensor.md)
   - [Autodiff](./building-blocks/autodiff.md)
   - [Module](./building-blocks/module.md)
+  - [Diffusion Schedulers](./building-blocks/diffusion-schedulers.md)
   - [Learner](./building-blocks/learner.md)
   - [Metric](./building-blocks/metric.md)
   - [Config](./building-blocks/config.md)

--- a/burn-book/src/building-blocks/diffusion-schedulers.md
+++ b/burn-book/src/building-blocks/diffusion-schedulers.md
@@ -1,0 +1,58 @@
+# Diffusion Schedulers
+
+This page introduces a small set of schedulers and utilities for diffusion model inference.
+They provide a convenient, backend‑agnostic way to generate timesteps and to advance latent
+samples using common ODE/SDE steppers.
+
+## Why
+
+- Flow‑matching and diffusion pipelines often share the same stepping logic (Euler / Heun,
+  and simple stochastic variants). Providing a stable API in `burn-core` simplifies building
+  pipelines across domains (audio, image, video) without duplicating boilerplate.
+
+## API Overview
+
+- `DiffusionScheduler<B, D>` trait
+  - `set_timesteps(num_inference_steps)`: configure the schedule
+  - `sigmas(&device) -> Tensor<_, 1>` and `timesteps(&device) -> Tensor<_, 1>`
+  - `step(model_output, timestep, sample, omega) -> sample`: advance one step
+  - `scale_noise(sample, timestep, noise) -> noisy_sample`: forward process helper
+
+- Implementations
+  - `FlowMatchEuler` — first‑order ODE step with optional mean‑shift scaling
+  - `FlowMatchHeun` — second‑order (Heun) stepper for improved local accuracy
+  - `FlowMatchPingPong` — simple stochastic step (denoise + resample noise)
+
+- Utility
+  - `retrieve_timesteps(device, sigmas, steps, num_train_timesteps, sigmas_override)`:
+    resamples timesteps for an arbitrary number of inference steps, compatible with
+    timesteps used by common diffusion libraries.
+
+## Example
+
+```rust
+use burn::prelude::*;
+use burn::diffusion::{FlowMatchEuler, FlowMatchEulerConfig, DiffusionScheduler};
+
+let device = Default::default();
+let mut sched = FlowMatchEuler::<burn_ndarray::NdArray<f32>, 4>::new(
+    FlowMatchEulerConfig { num_train_timesteps: 1000, shift: 1.0, sigma_max: 1.0 }
+);
+sched.set_timesteps(50);
+
+let sigmas = sched.sigmas(&device);
+let t = sched.timesteps(&device);
+
+// one step
+let sample = Tensor::zeros([1, 8, 16, 16], &device);
+let model_out = sample.clone();
+let t0 = t.clone().into_data().convert::<f32>().value[0];
+let next = sched.step(model_out, t0, sample, 1.0);
+```
+
+## References
+
+- [Flow Matching for Generative Modeling (arXiv)](https://arxiv.org/abs/2210.02747)
+- Diffusion scheduling patterns inspired by practical implementations in the community, e.g.
+  [Hugging Face diffusers](https://github.com/huggingface/diffusers).
+

--- a/crates/burn-core/src/diffusion/euler.rs
+++ b/crates/burn-core/src/diffusion/euler.rs
@@ -1,0 +1,128 @@
+use super::scheduler::{tensor_from_vec, DiffusionScheduler};
+use super::utils::logistic_rescale;
+use crate::tensor::{Tensor, backend::Backend};
+
+/// Configuration for the Euler flow-matching scheduler.
+#[derive(Debug, Clone)]
+pub struct FlowMatchEulerConfig {
+    /// Number of training timesteps used to scale `sigma <-> t`.
+    pub num_train_timesteps: usize,
+    /// Shift factor applied to the sigma schedule (default 1.0).
+    pub shift: f32,
+    /// Maximum sigma used to construct the schedule (default 1.0).
+    pub sigma_max: f32,
+}
+
+impl Default for FlowMatchEulerConfig {
+    fn default() -> Self {
+        Self { num_train_timesteps: 1000, shift: 1.0, sigma_max: 1.0 }
+    }
+}
+
+/// Euler flow-matching scheduler.
+pub struct FlowMatchEuler<B: Backend, const D: usize> {
+    cfg: FlowMatchEulerConfig,
+    sigmas: Vec<f32>,
+    timesteps: Vec<f32>,
+    step_index: usize,
+    _phantom: core::marker::PhantomData<B>,
+}
+
+impl<B: Backend, const D: usize> FlowMatchEuler<B, D> {
+    /// Create a new scheduler with the given configuration and default 50 steps.
+    pub fn new(cfg: FlowMatchEulerConfig) -> Self {
+        let mut s = Self { cfg, sigmas: Vec::new(), timesteps: Vec::new(), step_index: 0, _phantom: core::marker::PhantomData };
+        s.set_timesteps(50);
+        s
+    }
+
+    fn build_schedule(&mut self, num_inference_steps: usize) {
+        // Base linear schedule in sigma-space from sigma_max -> sigma_min.
+        let n = self.cfg.num_train_timesteps as f32;
+        let sigma_min = 1.0 / n; // minimal non-zero value
+        let sigma_max = self.cfg.sigma_max;
+
+        let mut sigmas = Vec::with_capacity(num_inference_steps + 1);
+        for i in 0..num_inference_steps {
+            let a = i as f32 / (num_inference_steps.saturating_sub(1).max(1) as f32);
+            let s = sigma_max * (1.0 - a) + sigma_min * a;
+            // Apply shift transform as in common flow-matching schedules.
+            let s = self.cfg.shift * s / (1.0 + (self.cfg.shift - 1.0) * s);
+            sigmas.push(s);
+        }
+        // Append a terminal zero to simplify indexing at the end.
+        sigmas.push(0.0);
+
+        let timesteps = sigmas
+            .iter()
+            .map(|s| s * self.cfg.num_train_timesteps as f32)
+            .collect::<Vec<_>>();
+
+        self.sigmas = sigmas;
+        self.timesteps = timesteps;
+        self.step_index = 0;
+    }
+}
+
+impl<B: Backend, const D: usize> DiffusionScheduler<B, D> for FlowMatchEuler<B, D> {
+    fn sigmas(&self, device: &B::Device) -> Tensor<B, 1> {
+        tensor_from_vec(device, &self.sigmas)
+    }
+
+    fn timesteps(&self, device: &B::Device) -> Tensor<B, 1> {
+        tensor_from_vec(device, &self.timesteps)
+    }
+
+    fn set_timesteps(&mut self, num_inference_steps: usize) {
+        self.build_schedule(num_inference_steps);
+    }
+
+    fn num_train_timesteps(&self) -> usize {
+        self.cfg.num_train_timesteps
+    }
+
+    fn reset(&mut self) {
+        self.step_index = 0;
+    }
+
+    fn step_index(&self) -> usize {
+        self.step_index
+    }
+
+    fn step(
+        &mut self,
+        model_output: Tensor<B, D>,
+        _timestep: f32,
+        sample: Tensor<B, D>,
+        omega: f32,
+    ) -> Tensor<B, D> {
+        let i = self.step_index;
+        let sigma = self.sigmas[i];
+        let sigma_next = self.sigmas[i + 1];
+
+        // Optional logistic rescale of omega for stability (maps near 1.0)
+        let omega = logistic_rescale(omega, 0.9, 1.1, 0.0, 0.1);
+        let dx = model_output.mul_scalar((sigma_next - sigma) * omega);
+        let prev_sample = sample + dx;
+
+        self.step_index += 1;
+        prev_sample
+    }
+
+    fn scale_noise(
+        &mut self,
+        sample: Tensor<B, D>,
+        timestep: f32,
+        noise: Tensor<B, D>,
+    ) -> Tensor<B, D> {
+        // Locate the sigma corresponding to this timestep.
+        // We assume timesteps are exact multiples of 1 and can be matched approximately.
+        let idx = self
+            .timesteps
+            .iter()
+            .position(|t| (*t - timestep).abs() < 1e-3)
+            .unwrap_or(self.step_index);
+        let sigma = self.sigmas[idx];
+        noise.mul_scalar(sigma).add(sample.mul_scalar(1.0 - sigma))
+    }
+}

--- a/crates/burn-core/src/diffusion/heun.rs
+++ b/crates/burn-core/src/diffusion/heun.rs
@@ -1,0 +1,165 @@
+use super::scheduler::{tensor_from_vec, DiffusionScheduler};
+use super::utils::logistic_rescale;
+use crate::tensor::{Tensor, backend::Backend};
+
+/// Configuration for the Heun flow-matching scheduler.
+#[derive(Debug, Clone)]
+pub struct FlowMatchHeunConfig {
+    /// Number of training timesteps used to scale `sigma <-> t`.
+    pub num_train_timesteps: usize,
+    /// Shift factor applied to the sigma schedule (default 1.0).
+    pub shift: f32,
+    /// Maximum sigma used to construct the schedule (default 1.0).
+    pub sigma_max: f32,
+}
+
+impl Default for FlowMatchHeunConfig {
+    fn default() -> Self {
+        Self { num_train_timesteps: 1000, shift: 1.0, sigma_max: 1.0 }
+    }
+}
+
+/// Heun (2nd-order) flow-matching scheduler.
+pub struct FlowMatchHeun<B: Backend, const D: usize> {
+    cfg: FlowMatchHeunConfig,
+    sigmas: Vec<f32>,
+    timesteps: Vec<f32>,
+    step_index: usize,
+    prev_derivative: Option<Tensor<B, D>>,
+    dt: Option<f32>,
+    sample_first: Option<Tensor<B, D>>,
+}
+
+impl<B: Backend, const D: usize> FlowMatchHeun<B, D> {
+    pub fn new(cfg: FlowMatchHeunConfig) -> Self {
+        let mut s = Self {
+            cfg,
+            sigmas: Vec::new(),
+            timesteps: Vec::new(),
+            step_index: 0,
+            prev_derivative: None,
+            dt: None,
+            sample_first: None,
+        };
+        s.set_timesteps(50);
+        s
+    }
+
+    fn build_schedule(&mut self, num_inference_steps: usize) {
+        let n = self.cfg.num_train_timesteps as f32;
+        let sigma_min = 1.0 / n;
+        let sigma_max = self.cfg.sigma_max;
+
+        let mut sigmas = Vec::with_capacity(num_inference_steps + 1);
+        for i in 0..num_inference_steps {
+            let a = i as f32 / (num_inference_steps.saturating_sub(1).max(1) as f32);
+            let s = sigma_max * (1.0 - a) + sigma_min * a;
+            let s = self.cfg.shift * s / (1.0 + (self.cfg.shift - 1.0) * s);
+            sigmas.push(s);
+        }
+        sigmas.push(0.0);
+
+        let timesteps = sigmas
+            .iter()
+            .map(|s| s * self.cfg.num_train_timesteps as f32)
+            .collect::<Vec<_>>();
+
+        self.sigmas = sigmas;
+        self.timesteps = timesteps;
+        self.step_index = 0;
+        self.prev_derivative = None;
+        self.dt = None;
+        self.sample_first = None;
+    }
+}
+
+impl<B: Backend, const D: usize> DiffusionScheduler<B, D> for FlowMatchHeun<B, D> {
+    fn sigmas(&self, device: &B::Device) -> Tensor<B, 1> {
+        tensor_from_vec(device, &self.sigmas)
+    }
+
+    fn timesteps(&self, device: &B::Device) -> Tensor<B, 1> {
+        tensor_from_vec(device, &self.timesteps)
+    }
+
+    fn set_timesteps(&mut self, num_inference_steps: usize) {
+        self.build_schedule(num_inference_steps);
+    }
+
+    fn num_train_timesteps(&self) -> usize {
+        self.cfg.num_train_timesteps
+    }
+
+    fn reset(&mut self) {
+        self.step_index = 0;
+        self.prev_derivative = None;
+        self.dt = None;
+        self.sample_first = None;
+    }
+
+    fn step_index(&self) -> usize {
+        self.step_index
+    }
+
+    fn step(
+        &mut self,
+        model_output: Tensor<B, D>,
+        _timestep: f32,
+        sample: Tensor<B, D>,
+        omega: f32,
+    ) -> Tensor<B, D> {
+        let i = self.step_index;
+        let (sigma, sigma_next) = if self.prev_derivative.is_none() {
+            (self.sigmas[i], self.sigmas[i + 1])
+        } else {
+            // 2nd order path reuses sigma_next for averaging.
+            (self.sigmas[i - 1], self.sigmas[i])
+        };
+
+        let omega = logistic_rescale(omega, 0.9, 1.1, 0.0, 0.1);
+
+        let prev = if self.prev_derivative.is_none() {
+            // First (Euler) stage.
+            // Derivative estimate in ODE form.
+            let denoised = sample.clone() - model_output.clone().mul_scalar(sigma);
+            let derivative = (sample.clone() - denoised).div_scalar(sigma.max(1e-8));
+            let dt = sigma_next - sigma;
+            self.prev_derivative = Some(derivative.clone());
+            self.dt = Some(dt);
+            self.sample_first = Some(sample.clone());
+
+            let dx = derivative.mul_scalar(dt * omega);
+            sample + dx
+        } else {
+            // Second (Heun) stage.
+            let sample_first = self.sample_first.take().unwrap();
+            let dt = self.dt.take().unwrap();
+            let prev_derivative = self.prev_derivative.take().unwrap();
+
+            let denoised = sample.clone() - model_output.clone().mul_scalar(sigma_next);
+            let derivative_next = (sample - denoised).div_scalar(sigma_next.max(1e-8));
+            let derivative = prev_derivative.mul_scalar(0.5) + derivative_next.mul_scalar(0.5);
+
+            let dx = derivative.mul_scalar(dt * omega);
+            sample_first + dx
+        };
+
+        self.step_index += 1;
+        prev
+    }
+
+    fn scale_noise(
+        &mut self,
+        sample: Tensor<B, D>,
+        timestep: f32,
+        noise: Tensor<B, D>,
+    ) -> Tensor<B, D> {
+        let idx = self
+            .timesteps
+            .iter()
+            .position(|t| (*t - timestep).abs() < 1e-3)
+            .unwrap_or(self.step_index);
+        let sigma = self.sigmas[idx];
+        noise.mul_scalar(sigma).add(sample.mul_scalar(1.0 - sigma))
+    }
+}

--- a/crates/burn-core/src/diffusion/mod.rs
+++ b/crates/burn-core/src/diffusion/mod.rs
@@ -1,0 +1,18 @@
+//! Diffusion inference utilities.
+//!
+//! This module provides a small set of scheduler implementations commonly
+//! used for diffusion model inference, along with utilities to manage
+//! timesteps/sigmas in a diffusers-compatible fashion.
+
+mod scheduler;
+mod euler;
+mod heun;
+mod pingpong;
+mod utils;
+
+pub use scheduler::*;
+pub use euler::*;
+pub use heun::*;
+pub use pingpong::*;
+pub use utils::*;
+

--- a/crates/burn-core/src/diffusion/pingpong.rs
+++ b/crates/burn-core/src/diffusion/pingpong.rs
@@ -1,0 +1,120 @@
+use super::scheduler::{tensor_from_vec, DiffusionScheduler};
+use crate::tensor::{Distribution, Tensor, backend::Backend};
+
+/// Configuration for the PingPong stochastic scheduler.
+#[derive(Debug, Clone)]
+pub struct FlowMatchPingPongConfig {
+    /// Number of training timesteps used to scale `sigma <-> t`.
+    pub num_train_timesteps: usize,
+    /// Shift factor applied to the sigma schedule (default 1.0).
+    pub shift: f32,
+    /// Maximum sigma used to construct the schedule (default 1.0).
+    pub sigma_max: f32,
+}
+
+impl Default for FlowMatchPingPongConfig {
+    fn default() -> Self {
+        Self { num_train_timesteps: 1000, shift: 1.0, sigma_max: 1.0 }
+    }
+}
+
+/// PingPong flow-matching scheduler (stochastic variant).
+pub struct FlowMatchPingPong<B: Backend, const D: usize> {
+    cfg: FlowMatchPingPongConfig,
+    sigmas: Vec<f32>,
+    timesteps: Vec<f32>,
+    step_index: usize,
+    _phantom: core::marker::PhantomData<B>,
+}
+
+impl<B: Backend, const D: usize> FlowMatchPingPong<B, D> {
+    pub fn new(cfg: FlowMatchPingPongConfig) -> Self {
+        let mut s = Self { cfg, sigmas: Vec::new(), timesteps: Vec::new(), step_index: 0, _phantom: core::marker::PhantomData };
+        s.set_timesteps(50);
+        s
+    }
+
+    fn build_schedule(&mut self, num_inference_steps: usize) {
+        let n = self.cfg.num_train_timesteps as f32;
+        let sigma_min = 1.0 / n;
+        let sigma_max = self.cfg.sigma_max;
+
+        let mut sigmas = Vec::with_capacity(num_inference_steps + 1);
+        for i in 0..num_inference_steps {
+            let a = i as f32 / (num_inference_steps.saturating_sub(1).max(1) as f32);
+            let s = sigma_max * (1.0 - a) + sigma_min * a;
+            let s = self.cfg.shift * s / (1.0 + (self.cfg.shift - 1.0) * s);
+            sigmas.push(s);
+        }
+        sigmas.push(0.0);
+
+        let timesteps = sigmas
+            .iter()
+            .map(|s| s * self.cfg.num_train_timesteps as f32)
+            .collect::<Vec<_>>();
+
+        self.sigmas = sigmas;
+        self.timesteps = timesteps;
+        self.step_index = 0;
+    }
+}
+
+impl<B: Backend, const D: usize> DiffusionScheduler<B, D> for FlowMatchPingPong<B, D> {
+    fn sigmas(&self, device: &B::Device) -> Tensor<B, 1> {
+        tensor_from_vec(device, &self.sigmas)
+    }
+
+    fn timesteps(&self, device: &B::Device) -> Tensor<B, 1> {
+        tensor_from_vec(device, &self.timesteps)
+    }
+
+    fn set_timesteps(&mut self, num_inference_steps: usize) {
+        self.build_schedule(num_inference_steps);
+    }
+
+    fn num_train_timesteps(&self) -> usize {
+        self.cfg.num_train_timesteps
+    }
+
+    fn reset(&mut self) {
+        self.step_index = 0;
+    }
+
+    fn step_index(&self) -> usize { self.step_index }
+
+    fn step(
+        &mut self,
+        model_output: Tensor<B, D>,
+        _timestep: f32,
+        sample: Tensor<B, D>,
+        _omega: f32,
+    ) -> Tensor<B, D> {
+        let i = self.step_index;
+        let sigma = self.sigmas[i];
+        let sigma_next = self.sigmas[i + 1];
+
+        // Stochastic ping-pong step: denoise then sample with new sigma.
+        let denoised = sample.clone() - model_output.mul_scalar(sigma);
+        let shape: [usize; D] = denoised.shape().dims();
+        let noise = Tensor::<B, D>::random::<[usize; D]>(shape, Distribution::Default, &denoised.device());
+        let prev_sample = denoised.mul_scalar(1.0 - sigma_next) + noise.mul_scalar(sigma_next);
+
+        self.step_index += 1;
+        prev_sample
+    }
+
+    fn scale_noise(
+        &mut self,
+        sample: Tensor<B, D>,
+        timestep: f32,
+        noise: Tensor<B, D>,
+    ) -> Tensor<B, D> {
+        let idx = self
+            .timesteps
+            .iter()
+            .position(|t| (*t - timestep).abs() < 1e-3)
+            .unwrap_or(self.step_index);
+        let sigma = self.sigmas[idx];
+        noise.mul_scalar(sigma).add(sample.mul_scalar(1.0 - sigma))
+    }
+}

--- a/crates/burn-core/src/diffusion/scheduler.rs
+++ b/crates/burn-core/src/diffusion/scheduler.rs
@@ -1,0 +1,53 @@
+use crate::tensor::{Shape, Tensor, backend::Backend};
+
+/// Trait implemented by diffusion schedulers used during inference.
+///
+/// The scheduler is responsible for producing a sequence of timesteps (or
+/// corresponding sigmas) and for stepping the latent sample between them.
+pub trait DiffusionScheduler<B: Backend, const D: usize> {
+    /// Returns the sigmas used for the current inference schedule on device.
+    fn sigmas(&self, device: &B::Device) -> Tensor<B, 1>;
+
+    /// Returns the corresponding discrete timesteps `t = sigma * num_train_timesteps` on device.
+    fn timesteps(&self, device: &B::Device) -> Tensor<B, 1>;
+
+    /// Sets the number of inference steps and recomputes the internal schedule.
+    fn set_timesteps(&mut self, num_inference_steps: usize);
+
+    /// Number of training timesteps used to convert `sigma` to `t` and vice-versa.
+    fn num_train_timesteps(&self) -> usize;
+
+    /// Resets the internal step index to the beginning of the schedule.
+    fn reset(&mut self);
+
+    /// Current step index within the schedule.
+    fn step_index(&self) -> usize;
+
+    /// Advances the sample according to the scheduler dynamics.
+    ///
+    /// - `model_output`: model prediction at current sample and timestep
+    /// - `timestep`: current discrete timestep value (one of `self.timesteps()`)
+    /// - `sample`: current latent/sample to be advanced
+    /// - `omega`: optional strength factor (used by some flow-matching variants); set to `1.0` if unsure.
+    fn step(
+        &mut self,
+        model_output: Tensor<B, D>,
+        timestep: f32,
+        sample: Tensor<B, D>,
+        omega: f32,
+    ) -> Tensor<B, D>;
+
+    /// Scales a clean sample by the forward process at the given timestep with additive noise.
+    fn scale_noise(
+        &mut self,
+        sample: Tensor<B, D>,
+        timestep: f32,
+        noise: Tensor<B, D>,
+    ) -> Tensor<B, D>;
+}
+
+/// Utility: allocate a 1D tensor on a backend from an iterator of f32 values.
+pub(crate) fn tensor_from_vec<B: Backend>(device: &B::Device, values: &[f32]) -> Tensor<B, 1> {
+    Tensor::from_floats(values, device)
+}
+

--- a/crates/burn-core/src/diffusion/utils.rs
+++ b/crates/burn-core/src/diffusion/utils.rs
@@ -1,0 +1,48 @@
+use crate::tensor::{Tensor, backend::Backend};
+
+/// Returns `(timesteps, num_inference_steps)` as a 1D tensor on the given device.
+///
+/// If `sigmas_override` is provided, it is used to build `timesteps = sigmas * num_train_timesteps`.
+pub fn retrieve_timesteps<B: Backend>(
+    device: &B::Device,
+    sigmas: &[f32],
+    num_inference_steps: usize,
+    num_train_timesteps: usize,
+    sigmas_override: Option<&[f32]>,
+) -> (Tensor<B, 1>, usize) {
+    let used_sigmas: Vec<f32> = if let Some(s) = sigmas_override {
+        s.to_vec()
+    } else {
+        // Resample evenly across the provided sigma schedule to match `num_inference_steps`.
+        if num_inference_steps >= sigmas.len() {
+            sigmas.to_vec()
+        } else {
+            // Linearly interpolate indices across the schedule.
+            let last = sigmas.len() - 1;
+            (0..num_inference_steps)
+                .map(|i| {
+                    let idx = (i as f32) * (last as f32) / ((num_inference_steps - 1).max(1) as f32);
+                    let low = idx.floor() as usize;
+                    let high = idx.ceil() as usize;
+                    if low == high {
+                        sigmas[low]
+                    } else {
+                        let w = idx - (low as f32);
+                        sigmas[low] * (1.0 - w) + sigmas[high] * w
+                    }
+                })
+                .collect()
+        }
+    };
+
+    let timesteps_vals: Vec<f32> = used_sigmas
+        .iter()
+        .map(|s| s * num_train_timesteps as f32)
+        .collect();
+    (Tensor::from_floats(timesteps_vals.as_slice(), device), used_sigmas.len())
+}
+
+/// Logistic rescale helper used by some flow-matching variants.
+pub(crate) fn logistic_rescale(x: f32, l: f32, u: f32, x0: f32, k: f32) -> f32 {
+    l + (u - l) / (1.0 + (-k * (x - x0)).exp())
+}

--- a/crates/burn-core/src/lib.rs
+++ b/crates/burn-core/src/lib.rs
@@ -34,6 +34,9 @@ pub mod module;
 /// Neural network module.
 pub mod nn;
 
+/// Diffusion utilities (schedulers, guidance, etc.) for inference.
+pub mod diffusion;
+
 /// Module for the recorder.
 pub mod record;
 

--- a/crates/burn-core/tests/diffusion_schedulers.rs
+++ b/crates/burn-core/tests/diffusion_schedulers.rs
@@ -1,0 +1,59 @@
+use burn_core::diffusion::{
+    FlowMatchEuler, FlowMatchEulerConfig, FlowMatchHeun, FlowMatchHeunConfig, FlowMatchPingPong,
+    FlowMatchPingPongConfig, DiffusionScheduler, retrieve_timesteps,
+};
+use burn_core::prelude::Backend;
+use burn_core::tensor::{Distribution, Tensor};
+
+type TB = burn_ndarray::NdArray<f32>;
+
+#[test]
+fn euler_step_with_zero_model_output_is_identity() {
+    let device = <TB as Backend>::Device::default();
+    let mut sched = FlowMatchEuler::<TB, 3>::new(FlowMatchEulerConfig::default());
+    sched.set_timesteps(8);
+    let sample = Tensor::<TB, 3>::random([1, 2, 3], Distribution::Default, &device);
+    let model_output = Tensor::<TB, 3>::zeros([1, 2, 3], &device);
+    let out = sched.step(model_output, 0.0, sample.clone(), 1.0);
+    // No change when model output is zero.
+    out.into_data()
+        .assert_approx_eq::<f32>(&sample.into_data(), burn_tensor::Tolerance::default());
+}
+
+#[test]
+fn heun_two_stage_produces_finite_output() {
+    let device = <TB as Backend>::Device::default();
+    let mut sched = FlowMatchHeun::<TB, 3>::new(FlowMatchHeunConfig::default());
+    sched.set_timesteps(6);
+    let mut sample = Tensor::<TB, 3>::random([2, 3, 4], Distribution::Default, &device);
+    // Stage 1: use model_output = sample
+    let out1 = sched.step(sample.clone(), 0.0, sample.clone(), 1.0);
+    // Stage 2: again with new sample
+    let out2 = sched.step(out1.clone(), 0.0, out1.clone(), 1.0);
+
+    // Check shapes and finite values
+    assert_eq!(out2.dims(), [2, 3, 4]);
+    // Sanity: value is not NaN by comparing to itself via approximate equality.
+    let data = out2.clone().into_data();
+    data.assert_approx_eq::<f32>(&out2.into_data(), burn_tensor::Tolerance::default());
+}
+
+#[test]
+fn pingpong_stochastic_step_shapes() {
+    let device = <TB as Backend>::Device::default();
+    let mut sched = FlowMatchPingPong::<TB, 2>::new(FlowMatchPingPongConfig::default());
+    sched.set_timesteps(4);
+    let sample = Tensor::<TB, 2>::random([5, 7], Distribution::Default, &device);
+    let model_output = sample.clone();
+    let out = sched.step(model_output, 0.0, sample, 1.0);
+    assert_eq!(out.dims(), [5, 7]);
+}
+
+#[test]
+fn retrieve_timesteps_resamples_correct_len() {
+    let device = <TB as Backend>::Device::default();
+    let sigmas = vec![1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1];
+    let (t, n) = retrieve_timesteps::<TB>(&device, &sigmas, 5, 1000, None);
+    assert_eq!(n, 5);
+    assert_eq!(t.dims(), [5]);
+}


### PR DESCRIPTION
## Summary
Adds a small, backend‑agnostic diffusion scheduler layer with reference steppers (Euler, Heun, and a simple stochastic variant) and a timesteps utility compatible with common diffusion libraries.

## Why
- Many diffusion/flow‑matching pipelines share the same stepping patterns; surfacing them in Burn reduces boilerplate and promotes reuse across audio/image/video.
- Complements conditioning utilities and attention modules for end‑to‑end diffusion in Rust.

## Highlights
- Minimal trait surface (`set_timesteps`, `sigmas/timesteps`, `step`, `scale_noise`).
- Retrieve timesteps utility for diffusers‑style schedules.

## References
- [Flow Matching for Generative Modeling (arXiv)](https://arxiv.org/abs/2210.02747)
- [Rectified Flow (arXiv)](https://arxiv.org/abs/2209.03109)
- [Elucidating the Design Space of Diffusion‑Based Generative Models (arXiv)](https://arxiv.org/abs/2206.00364)
- [DDIM (arXiv)](https://arxiv.org/abs/2010.02502), [PNDM (arXiv)](https://arxiv.org/abs/2202.09778), [UniPC (arXiv)](https://arxiv.org/abs/2302.09765)
- [DPM‑Solver (arXiv)](https://arxiv.org/abs/2206.00927)
- [Hugging Face diffusers (GitHub)](https://github.com/huggingface/diffusers)
- Music diffusion pipeline: [ACE‑Step (GitHub)](https://github.com/ace-step/ACE-Step)

## Notes
- Additive and non‑breaking; backend‑neutral reference with room for fused kernels.
