### PR TITLE
feat(core/nn/attention): 1D sequence attention masks (lengths, causal, chunked)

### DIFF
--- a/burn-book/src/SUMMARY.md
+++ b/burn-book/src/SUMMARY.md
@@ -14,6 +14,7 @@
   - [Tensor](./building-blocks/tensor.md)
   - [Autodiff](./building-blocks/autodiff.md)
   - [Module](./building-blocks/module.md)
+  - [Attention Masks (1D Helpers)](./building-blocks/attention-masks-1d.md)
   - [Learner](./building-blocks/learner.md)
   - [Metric](./building-blocks/metric.md)
   - [Config](./building-blocks/config.md)

--- a/burn-book/src/building-blocks/attention-masks-1d.md
+++ b/burn-book/src/building-blocks/attention-masks-1d.md
@@ -1,0 +1,25 @@
+# Attention Masks (1D Helpers)
+
+This page provides small utilities for common 1D sequence masking patterns.
+
+## Why
+
+- Many text/audio models need simple helpers to create padding masks from sequence lengths or to generate causal/chunked masks for streaming encoders.
+- Keeping these utilities in `burn-core` avoids ad‑hoc masking logic scattered across projects.
+
+## API
+
+- `lengths_to_mask(lengths: &[usize], max_len: usize, &device) -> BoolTensor [B, L]`
+  - True marks padding positions (masked), false marks valid tokens.
+
+- `generate_causal_mask_1d(seq_len, &device) -> BoolTensor [L, L]`
+  - Lower‑triangular mask (true = masked) suitable for causal attention without batching.
+
+- `generate_chunked_causal_mask_1d(seq_len, chunk_size, num_left_chunks, &device) -> BoolTensor [L, L]`
+  - Conformer‑style streaming mask: each row `i` can attend within a local window of chunks to the left and its own chunk; future positions remain masked.
+
+## Notes
+
+- Mask semantics: consistent with other Burn masks — `true` means masked.
+- For batched causal masks, prefer `generate_autoregressive_mask(batch, length, &device)`.
+

--- a/crates/burn-core/tests/attention_masks_1d.rs
+++ b/crates/burn-core/tests/attention_masks_1d.rs
@@ -1,0 +1,57 @@
+use burn_core::nn::attention::{
+    generate_causal_mask_1d, generate_chunked_causal_mask_1d, lengths_to_mask,
+};
+use burn_core::prelude::Backend;
+use burn_core::tensor::TensorData;
+
+type TB = burn_ndarray::NdArray<f32>;
+
+#[test]
+fn lengths_to_mask_basic() {
+    let device = <TB as Backend>::Device::default();
+    let mask = lengths_to_mask::<TB>(&[3, 1], 5, &device).into_data();
+    mask.assert_eq(
+        &TensorData::from([
+            [false, false, false, true, true],
+            [false, true, true, true, true],
+        ]),
+        false,
+    );
+}
+
+#[test]
+fn causal_mask_1d_has_future_masked() {
+    let device = <TB as Backend>::Device::default();
+    let mask = generate_causal_mask_1d::<TB>(4, &device).into_data();
+    mask.assert_eq(
+        &TensorData::from([
+            [false, true, true, true],
+            [false, false, true, true],
+            [false, false, false, true],
+            [false, false, false, false],
+        ]),
+        false,
+    );
+}
+
+#[test]
+fn chunked_causal_mask_respects_window() {
+    let device = <TB as Backend>::Device::default();
+    let mask = generate_chunked_causal_mask_1d::<TB>(8, 2, 1, &device).into_data();
+    // Spot-check a few rows: allowed region should be unmasked (false), others masked (true)
+    // Row 3: chunk_idx=1, start=(1-1)*2=0, end=min(4, i+1=4)=4 -> [0..4) allowed
+    // Compare full matrix expectation on row 3 via slicing when available is cumbersome here,
+    // so we assert a few positions directly.
+    let md = mask.convert::<bool>();
+    // Convert to flat bytes and index manually: row-major [i*L + j]
+    let bytes = md.bytes;
+    let l = 8usize;
+    for j in 0..4 {
+        let idx = 3 * l + j;
+        assert_eq!(bytes[idx], 0u8); // false
+    }
+    for j in 4..8 {
+        let idx = 3 * l + j;
+        assert_eq!(bytes[idx], 1u8); // true
+    }
+}


### PR DESCRIPTION
## Summary
Adds small, reusable 1D attention mask helpers for padding, causal, and chunked/streaming scenarios.

## Why
- Text/audio pipelines frequently need consistent mask utilities; standardizing them avoids ad‑hoc re‑implementations and keeps semantics clear (true = masked).
- Chunked masks are especially useful for streaming encoders.

## Highlights
- `lengths_to_mask` (padding), `generate_causal_mask_1d` (lower‑triangular), and `generate_chunked_causal_mask_1d` (Conformer‑style windowed causal).

## References
- [Conformer: Convolution‑augmented Transformer for Speech Recognition (arXiv)](https://arxiv.org/abs/2005.08100)
- Chunkwise attention for streaming: [MoChA (arXiv)](https://arxiv.org/abs/1712.05382)
- Streaming encoders in practice: [Emformer (arXiv)](https://arxiv.org/abs/2010.10759)

## Notes
- Additive and non‑breaking; complements existing `generate_autoregressive_mask`.
