### PR TITLE
feat(core/nn/image): 2D image patch embedding + unpatchify

### DIFF
--- a/burn-book/src/SUMMARY.md
+++ b/burn-book/src/SUMMARY.md
@@ -14,6 +14,7 @@
   - [Tensor](./building-blocks/tensor.md)
   - [Autodiff](./building-blocks/autodiff.md)
   - [Module](./building-blocks/module.md)
+  - [2D Image Patch Embedding](./building-blocks/image-patch-embedding.md)
   - [Learner](./building-blocks/learner.md)
   - [Metric](./building-blocks/metric.md)
   - [Config](./building-blocks/config.md)

--- a/burn-book/src/building-blocks/image-patch-embedding.md
+++ b/burn-book/src/building-blocks/image-patch-embedding.md
@@ -1,0 +1,39 @@
+# 2D Image Patch Embedding
+
+Patchify images into tokens with a Conv2d and reconstruct with ConvTranspose2d. Useful for latent 2D transformers and diffusion models.
+
+## API
+
+- `ImagePatchEmbeddingConfig::new(in_channels, embed_dim, [h, w])`
+  - Optional: `.with_stride(Some([h, w]))` (defaults to patch size), `.with_bias(true/false)`.
+  - `forward(x: [B, C, H, W]) -> [B, N, D]` where `N = H_p×W_p`.
+  - `forward_4d(x) -> [B, D, H_p, W_p]` and `grid_sizes(H, W) -> [H_p, W_p]`.
+
+- `ImageUnpatchifyConfig::new(out_channels, [h, w])`
+  - Optional: `.with_stride(Some([h, w]))`.
+  - `init(embed_dim, &device)` returns `ImageUnpatchify`.
+  - `forward(tokens: [B, N, D], [H_p, W_p]) -> [B, C, H, W]`.
+
+## Example
+
+```rust
+use burn::prelude::*;
+use burn::nn::image::{ImagePatchEmbeddingConfig, ImageUnpatchifyConfig};
+
+let device = Default::default();
+let patch = [4, 4];
+let pe = ImagePatchEmbeddingConfig::new(3, 64, patch).init::<burn_ndarray::NdArray<f32>>(&device);
+
+let x = Tensor::random([1, 3, 128, 128], Distribution::Default, &device);
+let tokens = pe.forward(x.clone());
+let [hp, wp] = pe.grid_sizes(128, 128);
+
+let up = ImageUnpatchifyConfig::new(3, patch).init::<burn_ndarray::NdArray<f32>>(64, &device);
+let y = up.forward(tokens, [hp, wp]);
+```
+
+## Notes
+
+- Defaults assume valid padding. For custom stride/padding, ensure shapes divide as intended.
+- Pairs naturally with positional encodings and attention layers for 2D latents.
+

--- a/crates/burn-core/src/nn/image/mod.rs
+++ b/crates/burn-core/src/nn/image/mod.rs
@@ -1,0 +1,4 @@
+mod patch2d;
+
+pub use patch2d::*;
+

--- a/crates/burn-core/src/nn/image/patch2d.rs
+++ b/crates/burn-core/src/nn/image/patch2d.rs
@@ -1,0 +1,163 @@
+use crate as burn;
+
+use crate::module::Module;
+use crate::config::Config;
+use crate::nn::conv::{Conv2d, Conv2dConfig, ConvTranspose2d, ConvTranspose2dConfig};
+use crate::tensor::{Tensor, backend::Backend};
+//
+
+/// Configuration for 2D image patch embedding.
+#[derive(Config, Debug)]
+pub struct ImagePatchEmbeddingConfig {
+    /// Input channels (e.g., RGB = 3).
+    pub in_channels: usize,
+    /// Output embedding dimension per patch.
+    pub embed_dim: usize,
+    /// Patch size [h, w].
+    pub patch_size: [usize; 2],
+    /// Stride [h, w]; defaults to `patch_size`.
+    #[config(default = "None")]
+    pub stride: Option<[usize; 2]>,
+    /// Include bias in the convolution.
+    #[config(default = true)]
+    pub bias: bool,
+}
+
+/// 2D patch embedding using Conv2d with kernel=stride=patch.
+#[derive(Module, Debug)]
+pub struct ImagePatchEmbedding<B: Backend> {
+    conv: Conv2d<B>,
+    patch: [usize; 2],
+    stride: [usize; 2],
+}
+
+impl ImagePatchEmbeddingConfig {
+    /// Initialize the module.
+    pub fn init<B: Backend>(&self, device: &B::Device) -> ImagePatchEmbedding<B> {
+        let stride = self.stride.unwrap_or(self.patch_size);
+        let conv = Conv2dConfig::new([self.in_channels, self.embed_dim], self.patch_size)
+            .with_stride(stride)
+            .with_bias(self.bias)
+            .init::<B>(device);
+        ImagePatchEmbedding { conv, patch: self.patch_size, stride }
+    }
+}
+
+impl<B: Backend> ImagePatchEmbedding<B> {
+    /// Compute grid sizes (H_p, W_p) for the given input shape.
+    pub fn grid_sizes(&self, height: usize, width: usize) -> [usize; 2] {
+        let [sh, sw] = self.stride;
+        let [kh, kw] = self.patch;
+        let hp = height.saturating_sub(kh) / sh + 1;
+        let wp = width.saturating_sub(kw) / sw + 1;
+        [hp, wp]
+    }
+
+    /// Forward to tokens `[B, N, D]` (N = H_p×W_p, D = embed_dim).
+    pub fn forward(&self, x: Tensor<B, 4>) -> Tensor<B, 3> {
+        let [b, _c, _h, _w] = x.dims();
+        let y = self.conv.forward(x); // [B, D, Hp, Wp]
+        let [_, d, hp, wp] = y.dims();
+        y.reshape([b, d, hp * wp]).swap_dims(1, 2)
+    }
+
+    /// Forward to `[B, D, H_p, W_p]`.
+    pub fn forward_4d(&self, x: Tensor<B, 4>) -> Tensor<B, 4> {
+        self.conv.forward(x)
+    }
+}
+
+/// Configuration for reconstructing images from patch tokens using ConvTranspose2d.
+#[derive(Config, Debug)]
+pub struct ImageUnpatchifyConfig {
+    /// Output channels (e.g., RGB = 3).
+    pub out_channels: usize,
+    /// Patch size [h, w] used during embedding.
+    pub patch_size: [usize; 2],
+    /// Stride [h, w]; defaults to `patch_size`.
+    #[config(default = "None")]
+    pub stride: Option<[usize; 2]>,
+    /// Include bias in the transposed convolution.
+    #[config(default = true)]
+    pub bias: bool,
+}
+
+/// 2D unpatchify using ConvTranspose2d. Expects tokens reshaped to `[B, D, H_p, W_p]`.
+#[derive(Module, Debug)]
+pub struct ImageUnpatchify<B: Backend> {
+    deconv: ConvTranspose2d<B>,
+    stride: [usize; 2],
+}
+
+impl ImageUnpatchifyConfig {
+    /// Initialize the module.
+    pub fn init<B: Backend>(&self, embed_dim: usize, device: &B::Device) -> ImageUnpatchify<B> {
+        let stride = self.stride.unwrap_or(self.patch_size);
+        let deconv =
+            ConvTranspose2dConfig::new([embed_dim, self.out_channels], self.patch_size)
+                .with_stride(stride)
+                .with_bias(self.bias)
+                .init::<B>(device);
+        ImageUnpatchify { deconv, stride }
+    }
+}
+
+impl<B: Backend> ImageUnpatchify<B> {
+    /// Unpatchify from tokens `[B, N, D]` given grid sizes `[H_p, W_p]`.
+    pub fn forward(&self, tokens: Tensor<B, 3>, grid_sizes: [usize; 2]) -> Tensor<B, 4> {
+        let [b, n, d] = tokens.dims();
+        let [hp, wp] = grid_sizes;
+        assert_eq!(n, hp * wp, "tokens length must match grid sizes");
+        let x = tokens.swap_dims(1, 2).reshape([b, d, hp, wp]);
+        self.deconv.forward(x)
+    }
+
+    /// Unpatchify from `[B, D, H_p, W_p]`.
+    pub fn forward_4d(&self, x: Tensor<B, 4>) -> Tensor<B, 4> {
+        self.deconv.forward(x)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::TestBackend;
+    use crate::tensor::{Distribution, Tensor};
+
+    #[test]
+    fn shapes_roundtrip() {
+        let device = Default::default();
+        let in_ch = 3;
+        let out_ch = 3;
+        let embed = 8;
+        let patch = [4, 4];
+        let x = Tensor::<TestBackend, 4>::random([1, in_ch, 16, 16], Distribution::Default, &device);
+
+        let pe = ImagePatchEmbeddingConfig {
+            in_channels: in_ch,
+            embed_dim: embed,
+            patch_size: patch,
+            stride: None,
+            bias: true,
+        }
+        .init::<TestBackend>(&device);
+        let tokens = pe.forward(x);
+        let [b, n, d] = tokens.dims();
+        assert_eq!(b, 1);
+        assert_eq!(d, embed);
+
+        let gs = pe.grid_sizes(16, 16);
+        assert_eq!(n, gs[0] * gs[1]);
+
+        let up = ImageUnpatchifyConfig {
+            out_channels: out_ch,
+            patch_size: patch,
+            stride: None,
+            bias: true,
+        }
+            .init::<TestBackend>(embed, &device);
+        let y = up.forward(tokens, gs);
+        let [bb, cc, hh, ww] = y.dims();
+        assert_eq!([bb, cc, hh, ww], [1, out_ch, 16, 16]);
+    }
+}

--- a/crates/burn-core/src/nn/mod.rs
+++ b/crates/burn-core/src/nn/mod.rs
@@ -34,6 +34,7 @@ mod pos_encoding;
 mod rnn;
 mod rope_encoding;
 mod unfold;
+mod image;
 
 pub mod norm;
 pub use norm::{batch::*, group::*, instance::*, layer::*, rms::*};
@@ -47,3 +48,4 @@ pub use pos_encoding::*;
 pub use rnn::*;
 pub use rope_encoding::*;
 pub use unfold::*;
+pub use image::*;


### PR DESCRIPTION
## Summary
Adds reusable 2D patchify/unpatchify modules using Conv2d / ConvTranspose2d for image tokens and reconstruction.

## Why
- Patches (kernel=stride=patch) are a standard interface for vision transformers and diffusion pipelines; standardizing this in Burn reduces boilerplate and aligns shapes.

## Highlights
- Produce tokens `[B, N, D]` or `[B, D, H_p, W_p]` and reconstruct back to `[B, C, H, W]`, with helpers for grid sizes.

## References
- [An Image is Worth 16×16 Words: Transformers for Image Recognition at Scale (ViT, arXiv)](https://arxiv.org/abs/2010.11929)
- Masked/efficient pretraining with patches: [MAE (arXiv)](https://arxiv.org/abs/2111.06377), [DeiT (arXiv)](https://arxiv.org/abs/2012.12877)
- Hierarchical vision backbones: [Swin Transformer (arXiv)](https://arxiv.org/abs/2103.14030)

## Notes
- Additive and non‑breaking; complements 3D video patch modules and attention/positioning layers.
