### PR TITLE
Add #[allow(clippy::too_many_arguments)] to config constructor

### DIFF
--- a/crates/burn-derive/src/config/analyzer_struct.rs
+++ b/crates/burn-derive/src/config/analyzer_struct.rs
@@ -193,6 +193,7 @@ impl ConfigAnalyzer for ConfigStructAnalyzer {
 
         let body = quote! {
             /// Create a new instance of the config.
+            #[allow(clippy::too_many_arguments)]
             pub fn new(
                 #(#names),*
             ) -> Self {


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

Shuts up some clippy errors when a config has lots of required fields.