### PR TITLE
Add cubecl re-export, root Tensor, doc updates and Noam scheduler fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,6 +582,7 @@ dependencies = [
  "burn-tch",
  "burn-train",
  "burn-wgpu",
+ "cubecl",
 ]
 
 [[package]]
@@ -7862,7 +7863,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "windows-sys 0.60.2",
 ]
 

--- a/crates/burn-core/src/lib.rs
+++ b/crates/burn-core/src/lib.rs
@@ -39,6 +39,8 @@ pub mod record;
 
 /// Module for the tensor.
 pub mod tensor;
+// Tensor at root: `burn::Tensor`
+pub use tensor::Tensor;
 
 /// Module for visual operations
 #[cfg(feature = "vision")]

--- a/crates/burn-tensor/src/tensor/element/base.rs
+++ b/crates/burn-tensor/src/tensor/element/base.rs
@@ -14,7 +14,6 @@ pub trait Element:
     ToElement
     + ElementRandom
     + ElementConversion
-    + ElementPrecision
     + ElementComparison
     + ElementLimits
     + bytemuck::CheckedBitPattern
@@ -78,42 +77,20 @@ pub trait ElementLimits {
     const MAX: Self;
 }
 
-/// Element precision trait for tensor.
-#[derive(Clone, PartialEq, Eq, Copy, Debug)]
-pub enum Precision {
-    /// Double precision, e.g. f64.
-    Double,
-
-    /// Full precision, e.g. f32.
-    Full,
-
-    /// Half precision, e.g. f16.
-    Half,
-
-    /// Other precision.
-    Other,
-}
-
-/// Element precision trait for tensor.
-pub trait ElementPrecision {
-    /// Returns the precision of the element.
-    fn precision() -> Precision;
-}
-
 /// Macro to implement the element trait for a type.
 #[macro_export]
 macro_rules! make_element {
     (
-        ty $type:ident $precision:expr,
+        ty $type:ident,
         convert $convert:expr,
         random $random:expr,
         cmp $cmp:expr,
         dtype $dtype:expr
     ) => {
-        make_element!(ty $type $precision, convert $convert, random $random, cmp $cmp, dtype $dtype, min $type::MIN, max $type::MAX);
+        make_element!(ty $type, convert $convert, random $random, cmp $cmp, dtype $dtype, min $type::MIN, max $type::MAX);
     };
     (
-        ty $type:ident $precision:expr,
+        ty $type:ident,
         convert $convert:expr,
         random $random:expr,
         cmp $cmp:expr,
@@ -137,12 +114,6 @@ macro_rules! make_element {
             #[inline(always)]
             fn elem<E: Element>(self) -> E {
                 E::from_elem(self)
-            }
-        }
-
-        impl ElementPrecision for $type {
-            fn precision() -> Precision {
-                $precision
             }
         }
 
@@ -170,7 +141,7 @@ macro_rules! make_element {
 }
 
 make_element!(
-    ty f64 Precision::Double,
+    ty f64,
     convert ToElement::to_f64,
     random |distribution: Distribution, rng: &mut R| distribution.sampler(rng).sample(),
     cmp |a: &f64, b: &f64| a.total_cmp(b),
@@ -178,7 +149,7 @@ make_element!(
 );
 
 make_element!(
-    ty f32 Precision::Full,
+    ty f32,
     convert ToElement::to_f32,
     random |distribution: Distribution, rng: &mut R| distribution.sampler(rng).sample(),
     cmp |a: &f32, b: &f32| a.total_cmp(b),
@@ -186,7 +157,7 @@ make_element!(
 );
 
 make_element!(
-    ty i64 Precision::Double,
+    ty i64,
     convert ToElement::to_i64,
     random |distribution: Distribution, rng: &mut R| distribution.sampler(rng).sample(),
     cmp |a: &i64, b: &i64| Ord::cmp(a, b),
@@ -194,7 +165,7 @@ make_element!(
 );
 
 make_element!(
-    ty u64 Precision::Double,
+    ty u64,
     convert ToElement::to_u64,
     random |distribution: Distribution, rng: &mut R| distribution.sampler(rng).sample(),
     cmp |a: &u64, b: &u64| Ord::cmp(a, b),
@@ -202,7 +173,7 @@ make_element!(
 );
 
 make_element!(
-    ty i32 Precision::Full,
+    ty i32,
     convert ToElement::to_i32,
     random |distribution: Distribution, rng: &mut R| distribution.sampler(rng).sample(),
     cmp |a: &i32, b: &i32| Ord::cmp(a, b),
@@ -210,7 +181,7 @@ make_element!(
 );
 
 make_element!(
-    ty u32 Precision::Full,
+    ty u32,
     convert ToElement::to_u32,
     random |distribution: Distribution, rng: &mut R| distribution.sampler(rng).sample(),
     cmp |a: &u32, b: &u32| Ord::cmp(a, b),
@@ -218,7 +189,7 @@ make_element!(
 );
 
 make_element!(
-    ty i16 Precision::Half,
+    ty i16,
     convert ToElement::to_i16,
     random |distribution: Distribution, rng: &mut R| distribution.sampler(rng).sample(),
     cmp |a: &i16, b: &i16| Ord::cmp(a, b),
@@ -226,7 +197,7 @@ make_element!(
 );
 
 make_element!(
-    ty u16 Precision::Half,
+    ty u16,
     convert ToElement::to_u16,
     random |distribution: Distribution, rng: &mut R| distribution.sampler(rng).sample(),
     cmp |a: &u16, b: &u16| Ord::cmp(a, b),
@@ -234,7 +205,7 @@ make_element!(
 );
 
 make_element!(
-    ty i8 Precision::Other,
+    ty i8,
     convert ToElement::to_i8,
     random |distribution: Distribution, rng: &mut R| distribution.sampler(rng).sample(),
     cmp |a: &i8, b: &i8| Ord::cmp(a, b),
@@ -242,7 +213,7 @@ make_element!(
 );
 
 make_element!(
-    ty u8 Precision::Other,
+    ty u8,
     convert ToElement::to_u8,
     random |distribution: Distribution, rng: &mut R| distribution.sampler(rng).sample(),
     cmp |a: &u8, b: &u8| Ord::cmp(a, b),
@@ -250,7 +221,7 @@ make_element!(
 );
 
 make_element!(
-    ty f16 Precision::Half,
+    ty f16,
     convert ToElement::to_f16,
     random |distribution: Distribution, rng: &mut R| {
         let sample: f32 = distribution.sampler(rng).sample();
@@ -260,7 +231,7 @@ make_element!(
     dtype DType::F16
 );
 make_element!(
-    ty bf16 Precision::Half,
+    ty bf16,
     convert ToElement::to_bf16,
     random |distribution: Distribution, rng: &mut R| {
         let sample: f32 = distribution.sampler(rng).sample();
@@ -272,7 +243,7 @@ make_element!(
 
 #[cfg(feature = "cubecl")]
 make_element!(
-    ty flex32 Precision::Half,
+    ty flex32,
     convert |elem: &dyn ToElement| flex32::from_f32(elem.to_f32()),
     random |distribution: Distribution, rng: &mut R| {
         let sample: f32 = distribution.sampler(rng).sample();
@@ -285,7 +256,7 @@ make_element!(
 );
 
 make_element!(
-    ty bool Precision::Other,
+    ty bool,
     convert ToElement::to_bool,
     random |distribution: Distribution, rng: &mut R| {
         let sample: u8 = distribution.sampler(rng).sample();

--- a/crates/burn/Cargo.toml
+++ b/crates/burn/Cargo.toml
@@ -90,6 +90,8 @@ experimental-named-tensor = ["burn-core/experimental-named-tensor"]
 # Model storage and serialization (SafeTensors, PyTorch interop)
 store = ["burn-store"]
 
+# CubeCL re-export
+cubecl = ["dep:cubecl"]
 
 audio = ["burn-core/audio"]
 vision = ["burn-core/vision"]
@@ -156,3 +158,5 @@ burn-router = { path = "../burn-router", version = "0.19.0", default-features = 
 burn-tch = { path = "../burn-tch", version = "0.19.0", default-features = false, optional = true }
 burn-wgpu = { path = "../burn-wgpu", version = "0.19.0", optional = true, default-features = false }
 burn-ir = { path = "../burn-ir", version = "0.19.0", optional = true, default-features = false }
+
+cubecl = { workspace = true, default-features = false, optional = true }

--- a/crates/burn/src/lib.rs
+++ b/crates/burn/src/lib.rs
@@ -57,7 +57,7 @@
 //! representations that are more robust to the reduction in precision.
 //!
 //! Quantization support in Burn is currently in active development. It supports the following modes on some backends:
-//! - Static per-tensor quantization to signed 8-bit integer (`i8`)
+//! - Per-tensor and per-block (linear) quantization to 8-bit, 4-bit and 2-bit representations
 //!
 //! ## Feature Flags
 //!

--- a/crates/burn/src/lib.rs
+++ b/crates/burn/src/lib.rs
@@ -125,3 +125,9 @@ pub mod collective;
 pub mod store {
     pub use burn_store::*;
 }
+
+/// CubeCL module re-export.
+#[cfg(feature = "cubecl")]
+pub mod cubecl {
+    pub use cubecl::*;
+}


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.

### Changes

A couple of minor changes/improvements

- Add `burn::cubecl` re-export under `cubecl` feature flag for easy integration
  - Users can enable the desired backend (e.g., `WebGpu`) and this feature flag to use the matching cubecl version for development
- Re-export `Tensor` at root `burn::Tensor` (`burn::tensor::Tensor` still available)
- Update the quantization docs
- Fix Noam LR scheduler `init_lr` misnomer
- Remove `ElementPrecision` / `Precision` (no longer needed or used)
