### PR TITLE
Enhance PRelu config initialization with alpha and num_parameters

### DIFF
--- a/crates/burn-import/src/burn/node/prelu.rs
+++ b/crates/burn-import/src/burn/node/prelu.rs
@@ -55,8 +55,12 @@ impl<PS: PrecisionSettings> NodeCodegen<PS> for PReluNode {
 
     fn field_init(&self) -> Option<TokenStream> {
         let name = &self.field.name;
+        let alpha = &self.config.alpha;
+        let num_parameters = self.config.num_parameters;
         let tokens = quote! {
             let #name = PReluConfig::new()
+                .with_num_parameters(#num_parameters)
+                .with_alpha(#alpha)
                 .init(device);
         };
 
@@ -129,7 +133,10 @@ mod tests {
         impl<B: Backend> Model<B> {
             #[allow(unused_variables)]
             pub fn new(device: &B::Device) -> Self {
-                let prelu = PReluConfig::new().init(device);
+                let prelu = PReluConfig::new()
+                    .with_num_parameters(1usize)
+                    .with_alpha(0.25f64)
+                    .init(device);
                 Self {
                     prelu,
                     phantom: core::marker::PhantomData,


### PR DESCRIPTION
This PR enhances PRelu node code generation in the ONNX-to-Burn converter by properly initializing PReluConfig with alpha and num_parameters values. The changes improve ONNX conversion logic to correctly handle and flatten PRelu weight shapes, ensuring compatibility with Burn's expectations.

This fix resolves an issue of loading safetensor weights using SafetensorStore which enforces destination shape of tensor weights. Previously Recorder would override model's shape information, which is set to be [1] if Prelu is not configured for ONNX properly.

## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Message from discord: https://discord.com/channels/1038839012602941528/1091796857996451942/1417563911602835678

### Changes

- Enhanced PRelu weight shape handling with better validation and flattening logic
- Updated PReluNode to initialize PReluConfig with proper alpha and num_parameters values
- Improved error messages for invalid PRelu weight shapes

### Testing

Reviewed generated source code and all tests are passing.
