### PR TITLE
fix: Fix segfaults from fusion panics with simple workaround

### DIFF
--- a/crates/burn-fusion/src/tensor.rs
+++ b/crates/burn-fusion/src/tensor.rs
@@ -187,6 +187,11 @@ impl<R: FusionRuntime> Drop for FusionTensor<R> {
     fn drop(&mut self) {
         let count = self.count.fetch_sub(1, Ordering::Relaxed);
 
+        // Workaround to prevent segfaults when an operation panics
+        if std::thread::panicking() {
+            return;
+        }
+
         match self.status(count) {
             TensorStatus::ReadWrite => {
                 let mut shape = Vec::new();


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

Adds a simple check to `FusionTensor` to avoid segfaulting/aborting the program when fusion encounters a panic.

### Testing

Tests aren't affected, except panics no longer cause segfaults or opaque errors.
