### PR TITLE
Fix: autotune errors with fusion

### DIFF
--- a/crates/burn-cubecl-fusion/src/matmul/tune.rs
+++ b/crates/burn-cubecl-fusion/src/matmul/tune.rs
@@ -177,7 +177,12 @@ fn tune_fused<R: Runtime, BT: CubeElement, S: MatmulVariantSelection>(
     let context = input.context();
 
     match context {
-        TuneContext::Original(context) => optimization.execute_fused::<BT, S>(context),
+        TuneContext::Original(context) => match optimization.execute_fused::<BT, S>(context) {
+            Ok(out) => Ok(out),
+            Err(_) => {
+                return tune_fallback::<R, BT>(input);
+            }
+        },
         TuneContext::Fork(mut context_owned) => {
             optimization.execute_fused::<BT, S>(&mut context_owned.as_context())
         }


### PR DESCRIPTION
It's hard to generalize error handling with the tuner since we don't want to clone the inputs, but they are given to the tuner function. The autotune error isn't generic over the input type, so we can't pass back the inputs in the error to test a fallback optimization, but at some point, we might with casting.