### PR TITLE
Remove vulkan/mesa no-std CI setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -201,9 +201,6 @@ jobs:
           rust-toolchain: ${{ matrix.toolchain }}
           cache-key: ${{ matrix.rust }}-linux-no-std
       # --------------------------------------------------------------------------------
-      - name: Setup Linux runner
-        uses: tracel-ai/github-actions/setup-linux@v4
-      # --------------------------------------------------------------------------------
       - name: Crates Build
         run: cargo xtask --context no-std build --ci
       # --------------------------------------------------------------------------------


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.

### Changes

`linux-no-std` runners just broke, don't seem to be compatible with the vulkan sdk version fetched. But we don't need them on no-std tests anyway.
