### PR TITLE
Add `bool_xor` operation for boolean tensors

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -333,7 +333,7 @@ Those operations are only available for `Int` tensors.
 Those operations are only available for `Bool` tensors.
 
 | Burn API                             | PyTorch Equivalent              |
-| ------------------------------------ | ------------------------------- |
+|--------------------------------------|---------------------------------|
 | `Tensor::diag_mask(shape, diagonal)` | N/A                             |
 | `Tensor::tril_mask(shape, diagonal)` | N/A                             |
 | `Tensor::triu_mask(shape, diagonal)` | N/A                             |
@@ -341,6 +341,7 @@ Those operations are only available for `Bool` tensors.
 | `tensor.bool_and()`                  | `tensor.logical_and()`          |
 | `tensor.bool_not()`                  | `tensor.logical_not()`          |
 | `tensor.bool_or()`                   | `tensor.logical_or()`           |
+| `tensor.bool_xor()`                  | `tensor.logical_xor()`          |
 | `tensor.float()`                     | `tensor.to(torch.float)`        |
 | `tensor.int()`                       | `tensor.to(torch.long)`         |
 | `tensor.nonzero()`                   | `tensor.nonzero(as_tuple=True)` |

--- a/crates/burn-autodiff/src/ops/bool_tensor.rs
+++ b/crates/burn-autodiff/src/ops/bool_tensor.rs
@@ -76,6 +76,10 @@ impl<B: Backend, C: CheckpointStrategy> BoolTensorOps<Self> for Autodiff<B, C> {
         B::bool_or(lhs, rhs)
     }
 
+    fn bool_xor(lhs: BoolTensor<B>, rhs: BoolTensor<B>) -> BoolTensor<B> {
+        B::bool_xor(lhs, rhs)
+    }
+
     fn bool_into_float(tensor: BoolTensor<B>) -> <Autodiff<B> as Backend>::FloatTensorPrimitive {
         AutodiffTensor::new(B::bool_into_float(tensor))
     }

--- a/crates/burn-tensor/src/tensor/api/bool.rs
+++ b/crates/burn-tensor/src/tensor/api/bool.rs
@@ -49,6 +49,11 @@ where
         Tensor::new(B::bool_or(self.primitive, rhs.primitive))
     }
 
+    /// Performs logical xor (`^`) on two boolean tensors
+    pub fn bool_xor(self, rhs: Tensor<B, D, Bool>) -> Tensor<B, D, Bool> {
+        Tensor::new(B::bool_xor(self.primitive, rhs.primitive))
+    }
+
     /// Compute the indices of `true` elements in the tensor (i.e., non-zero for boolean tensors).
     ///
     /// # Returns

--- a/crates/burn-tensor/src/tensor/ops/bool_tensor.rs
+++ b/crates/burn-tensor/src/tensor/ops/bool_tensor.rs
@@ -284,6 +284,20 @@ pub trait BoolTensorOps<B: Backend> {
     /// The tensor with the result of the logical or.
     fn bool_or(tensor: BoolTensor<B>, rhs: BoolTensor<B>) -> BoolTensor<B>;
 
+    /// Element-wise exclusive or.
+    ///
+    /// # Arguments
+    ///
+    /// * `lhs` - The left hand side tensor.
+    /// * `rhs` - The right hand side tensor.
+    ///
+    /// # Returns
+    ///
+    /// The tensor with the result of the comparison.
+    fn bool_xor(lhs: BoolTensor<B>, rhs: BoolTensor<B>) -> BoolTensor<B> {
+        Self::bool_not_equal(lhs, rhs)
+    }
+
     /// Transposes a bool tensor.
     ///
     /// # Arguments

--- a/crates/burn-tensor/src/tests/ops/bool.rs
+++ b/crates/burn-tensor/src/tests/ops/bool.rs
@@ -38,6 +38,15 @@ mod tests {
     }
 
     #[test]
+    fn test_bool_xor() {
+        let tensor1 = TestTensorBool::<2>::from([[false, true, false], [true, false, true]]);
+        let tensor2 = TestTensorBool::<2>::from([[true, true, false], [false, false, true]]);
+        let data_actual = tensor1.bool_xor(tensor2).into_data();
+        let data_expected = TensorData::from([[true, false, false], [true, false, false]]);
+        data_expected.assert_eq(&data_actual, false);
+    }
+
+    #[test]
     fn test_bool_or_vec() {
         let device = Default::default();
         let tensor1 = TestTensorBool::<1>::full([256], 0, &device);


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

- Implemented `bool_xor` in tensor traits and backend.
- Added unit tests for the new operation.
- Updated documentation and API reference in the Burn book.
