### PR TITLE
Add outer and outer_batch ops in linalg

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -384,11 +384,13 @@ strategies.
 
 ## Linalg Functions
 
-| Burn API                               | PyTorch Equivalent                        |
-|----------------------------------------|-------------------------------------------|
-| `linalg::vector_norm(tensors, p, dim)` | `torch.linalg.vector_norm(tensor, p, dim) |
-| `linalg::diag(tensor)`                 | `torch.diag(tensor)`                      |
-| `linalg::trace(tensor)`                | `torch.trace(tensor)`                     |
+| Burn API                                   | PyTorch Equivalent                               |
+|--------------------------------------------|--------------------------------------------------|
+| `linalg::vector_norm(tensors, p, dim)`     | `torch.linalg.vector_norm(tensor, p, dim)`       |
+| `linalg::diag(tensor)`                     | `torch.diag(tensor)`                             |
+| `linalg::trace(tensor)`                    | `torch.trace(tensor)`                            |
+| `linalg::outer(x, y)`                      | `torch.outer(x, y)`                              |
+| `linalg::outer_batch(x, y)`                | `torch.einsum("bi,bj->bij", x, y)` (no direct op)|
 
 ## Displaying Tensor Details
 

--- a/crates/burn-tensor/src/tensor/linalg/mod.rs
+++ b/crates/burn-tensor/src/tensor/linalg/mod.rs
@@ -1,9 +1,13 @@
 mod cosine_similarity;
 mod diag;
+mod outer;
+mod outer_batch;
 mod trace;
 mod vector_norm;
 
 pub use cosine_similarity::*;
 pub use diag::*;
+pub use outer::*;
+pub use outer_batch::*;
 pub use trace::*;
 pub use vector_norm::*;

--- a/crates/burn-tensor/src/tensor/linalg/outer.rs
+++ b/crates/burn-tensor/src/tensor/linalg/outer.rs
@@ -1,0 +1,43 @@
+use crate::backend::Backend;
+use crate::tensor::{BasicOps, Tensor};
+use crate::{Numeric, Shape};
+/// Computes the outer product of two 1D tensors (vectors).
+///
+/// Given `x` of shape `(m,)` and `y` of shape `(n,)`, returns a tensor
+/// of shape `(m, n)` where `out[i, j] = x[i] * y[j]`.
+///
+/// See:
+/// - [torch.outer](https://pytorch.org/docs/stable/generated/torch.outer.html)
+/// - [numpy.outer](https://numpy.org/doc/stable/reference/generated/numpy.outer.html)
+///
+/// # Arguments
+///
+/// * `x` - A 1D input tensor.
+/// * `y` - A 1D input tensor.
+///
+/// # Returns
+///
+/// A 2D tensor containing the outer product of `x` and `y`.
+pub fn outer<B: Backend, K>(
+    x: Tensor<B, 1, K>, // x is a 1-D vector (rank 1)
+    y: Tensor<B, 1, K>, // y is a 1-D vector (rank 1)
+) -> Tensor<B, 2, K>
+// we return a 2-D matrix (rank 2)
+where
+    K: BasicOps<B> + Numeric<B>, // works for floats AND ints
+{
+    // x.shape().dims() returns an array of dimension sizes.
+    // because x is rank-1, it's exactly [m].
+    let [m] = x.shape().dims();
+    let [n] = y.shape().dims();
+
+    // reshape x to (m, 1) => column
+    let x_col = x.reshape(Shape::new([m, 1]));
+
+    // reshape y to (1, n) => row
+    let y_row = y.reshape(Shape::new([1, n]));
+
+    // broadcasted multiply:
+    // (m,1) * (1,n) -> (m,n), with M[i,j] = x[i] * y[j]
+    x_col * y_row
+}

--- a/crates/burn-tensor/src/tensor/linalg/outer_batch.rs
+++ b/crates/burn-tensor/src/tensor/linalg/outer_batch.rs
@@ -1,0 +1,29 @@
+use crate::backend::Backend;
+use crate::tensor::{BasicOps, Tensor};
+use crate::{Numeric, Shape};
+
+/// Computes the batch outer product of two 2D tensors (batched vectors).
+///
+/// Given `x` of shape `(batch, m)` and `y` of shape `(batch, n)`,
+/// returns a tensor of shape `(batch, m, n)` where
+/// `out[b, i, j] = x[b, i] * y[b, j]`.
+///
+/// # Arguments
+/// * `x` - Batched vectors of shape `(batch, m)`.
+/// * `y` - Batched vectors of shape `(batch, n)`.
+///
+/// # Returns
+/// * A 3D tensor of shape `(batch, m, n)`.
+pub fn outer_batch<B: Backend, K>(x: Tensor<B, 2, K>, y: Tensor<B, 2, K>) -> Tensor<B, 3, K>
+where
+    K: BasicOps<B> + Numeric<B>,
+{
+    let [batch_x, m] = x.shape().dims();
+    let [batch_y, n] = y.shape().dims();
+    assert_eq!(batch_x, batch_y, "batch dimensions must match");
+
+    let x_col = x.reshape(Shape::new([batch_x, m, 1])); // (batch, m, 1)
+    let y_row = y.reshape(Shape::new([batch_y, 1, n])); // (batch, 1, n)
+
+    x_col * y_row // (batch, m, n)
+}

--- a/crates/burn-tensor/src/tests/linalg/mod.rs
+++ b/crates/burn-tensor/src/tests/linalg/mod.rs
@@ -1,4 +1,6 @@
 pub(crate) mod cosine_similarity;
 pub(crate) mod diag;
+pub(crate) mod outer;
+pub(crate) mod outer_batch;
 pub(crate) mod trace;
 pub(crate) mod vector_norm;

--- a/crates/burn-tensor/src/tests/linalg/outer.rs
+++ b/crates/burn-tensor/src/tests/linalg/outer.rs
@@ -1,0 +1,153 @@
+#[burn_tensor_testgen::testgen(outer)]
+mod tests {
+    use super::*;
+    use burn_tensor::linalg;
+    use burn_tensor::{Tolerance, ops::FloatElem};
+
+    type FT = FloatElem<TestBackend>;
+
+    #[test]
+    fn test_outer_basic() {
+        let u = TestTensor::<1>::from([1.0, 2.0, 3.0]);
+        let v = TestTensor::<1>::from([4.0, 5.0]);
+
+        let out = linalg::outer(u, v).into_data();
+        let expected = TestTensor::<2>::from([[4.0, 5.0], [8.0, 10.0], [12.0, 15.0]]).into_data();
+
+        out.assert_approx_eq::<FT>(&expected, Tolerance::default());
+    }
+    #[test]
+    fn test_outer_shapes_only() {
+        let device = Default::default();
+        let u = TestTensor::<1>::zeros([3], &device);
+        let v = TestTensor::<1>::zeros([5], &device);
+        let out = linalg::outer(u, v);
+        assert_eq!(out.shape().dims(), [3, 5]);
+    }
+    #[test]
+    fn test_outer_asymmetry_and_shapes() {
+        let u = TestTensor::<1>::from([1.0, 2.0]);
+        let v = TestTensor::<1>::from([3.0, 4.0, 5.0]);
+
+        let uv = linalg::outer(u.clone(), v.clone());
+        let vu = linalg::outer(v, u);
+
+        assert_eq!(uv.shape().dims(), [2, 3]);
+        assert_eq!(vu.shape().dims(), [3, 2]);
+    }
+
+    #[test]
+    fn test_outer_zero_left() {
+        let device = Default::default();
+        let u = TestTensor::<1>::zeros([3], &device);
+        let v = TestTensor::<1>::from([7.0, 8.0]);
+
+        let out = linalg::outer(u, v).into_data();
+        let expected = TestTensor::<2>::zeros([3, 2], &device).into_data();
+
+        out.assert_eq(&expected, true);
+    }
+
+    #[test]
+    fn test_outer_zero_right() {
+        let device = Default::default();
+        let u = TestTensor::<1>::from([1.0, -2.0, 3.0]);
+        let v = TestTensor::<1>::zeros([4], &device);
+
+        let out = linalg::outer(u, v).into_data();
+        let expected = TestTensor::<2>::zeros([3, 4], &device).into_data();
+
+        out.assert_eq(&expected, true);
+    }
+
+    #[test]
+    fn test_outer_signs() {
+        let u = TestTensor::<1>::from([-1.0, 2.0]);
+        let v = TestTensor::<1>::from([3.0, -4.0]);
+
+        let out = linalg::outer(u, v).into_data();
+        let expected = TestTensor::<2>::from([[-3.0, 4.0], [6.0, -8.0]]).into_data();
+
+        out.assert_approx_eq::<FT>(&expected, Tolerance::default());
+    }
+
+    #[test]
+    fn test_outer_integer_inputs() {
+        let u = TestTensorInt::<1>::from([1, 2, 3]);
+        let v = TestTensorInt::<1>::from([4, 5]);
+
+        let out = linalg::outer(u, v).into_data();
+        let expected = TestTensorInt::<2>::from([[4, 5], [8, 10], [12, 15]]).into_data();
+
+        out.assert_eq(&expected, true);
+    }
+
+    #[test]
+    fn test_outer_equivalence_to_matmul() {
+        let u = TestTensor::<1>::from([1.0, 2.0, 3.0]);
+        let v = TestTensor::<1>::from([4.0, 5.0]);
+
+        let out = linalg::outer(u.clone(), v.clone()).into_data();
+
+        let u2 = u.reshape([3, 1]);
+        let v2 = v.reshape([1, 2]);
+        let out_matmul = u2.matmul(v2).into_data();
+
+        out.assert_approx_eq::<FT>(&out_matmul, Tolerance::default());
+    }
+
+    #[test]
+    fn test_outer_vector_identity_right_mult() {
+        let u = TestTensor::<1>::from([2.0, -1.0]);
+        let v = TestTensor::<1>::from([3.0, 4.0]);
+        let w = TestTensor::<1>::from([5.0, 6.0]);
+
+        let uv = linalg::outer(u.clone(), v.clone());
+        let left = uv.matmul(w.clone().reshape([2, 1])).reshape([2]);
+
+        let v_dot_w = v.dot(w);
+        let right = u * v_dot_w;
+
+        left.into_data()
+            .assert_approx_eq::<FT>(&right.into_data(), Tolerance::default());
+    }
+
+    #[test]
+    fn test_outer_length_one_vectors() {
+        let u = TestTensor::<1>::from([3.0]);
+        let v = TestTensor::<1>::from([4.0, 5.0, 6.0]);
+
+        let out = linalg::outer(u, v).into_data();
+        let expected = TestTensor::<2>::from([[12.0, 15.0, 18.0]]).into_data();
+
+        out.assert_approx_eq::<FT>(&expected, Tolerance::default());
+    }
+
+    #[test]
+    fn test_outer_large_values() {
+        let big = 1.0e10;
+        let u = TestTensor::<1>::from([big, -big]);
+        let v = TestTensor::<1>::from([big, big]);
+
+        let out = linalg::outer(u, v).into_data();
+        let expected =
+            TestTensor::<2>::from([[big * big, big * big], [-big * big, -big * big]]).into_data();
+
+        let tol = Tolerance::relative(1e-6).set_half_precision_relative(1e-3);
+        out.assert_approx_eq::<FT>(&expected, tol);
+    }
+
+    #[test]
+    fn test_outer_nan_propagation() {
+        let u = TestTensor::<1>::from([f32::NAN, 2.0]);
+        let v = TestTensor::<1>::from([3.0, 4.0]);
+
+        let out = linalg::outer(u, v).into_data();
+
+        let values = out.value;
+        assert!(values[0].is_nan()); // first row, col0
+        assert!(values[1].is_nan()); // first row, col1
+        assert_eq!(values[2], 6.0); // second row, col0
+        assert_eq!(values[3], 8.0); // second row, col1
+    }
+}

--- a/crates/burn-tensor/src/tests/linalg/outer_batch.rs
+++ b/crates/burn-tensor/src/tests/linalg/outer_batch.rs
@@ -1,0 +1,139 @@
+// tests/linalg/outer_batch.rs
+
+#[burn_tensor_testgen::testgen(outer_batch)]
+mod tests {
+    use super::*;
+    use burn_tensor::linalg;
+    use burn_tensor::{Tolerance, ops::FloatElem};
+
+    type FT = FloatElem<TestBackend>;
+
+    // (1) Basic correctness: two batches
+    #[test]
+    fn test_outer_batch_basic() {
+        // x: (2, 2), y: (2, 3)
+        let x = TestTensor::<2>::from([[1.0, 2.0], [3.0, 4.0]]);
+        let y = TestTensor::<2>::from([[5.0, 6.0, 7.0], [8.0, 9.0, 10.0]]);
+        let out = linalg::outer_batch(x, y).into_data();
+
+        // Manually computed:
+        // batch 0: [[1*5, 1*6, 1*7],
+        //           [2*5, 2*6, 2*7]]
+        //        = [[5,6,7],[10,12,14]]
+        // batch 1: [[3*8, 3*9, 3*10],
+        //           [4*8, 4*9, 4*10]]
+        //        = [[24,27,30],[32,36,40]]
+        let expected = TestTensor::<3>::from([
+            [[5.0, 6.0, 7.0], [10.0, 12.0, 14.0]],
+            [[24.0, 27.0, 30.0], [32.0, 36.0, 40.0]],
+        ])
+        .into_data();
+
+        out.assert_approx_eq::<FT>(&expected, Tolerance::default());
+    }
+
+    // (2) Shape check only
+    #[test]
+    fn test_outer_batch_shapes() {
+        let device = Default::default();
+        let x = TestTensor::<2>::zeros([3, 4], &device); // (batch=3, m=4)
+        let y = TestTensor::<2>::zeros([3, 5], &device); // (batch=3, n=5)
+
+        let out = linalg::outer_batch(x, y);
+        assert_eq!(out.shape().dims(), [3, 4, 5]);
+    }
+
+    // (3) Zero cases (left & right)
+    #[test]
+    fn test_outer_batch_zero_left() {
+        let device = Default::default();
+        let x = TestTensor::<2>::zeros([2, 3], &device); // (2,3)
+        let y = TestTensor::<2>::from([[7.0, 8.0], [9.0, 10.0]]); // (2,2)
+
+        let out = linalg::outer_batch(x, y).into_data();
+        let expected = TestTensor::<3>::zeros([2, 3, 2], &device).into_data();
+
+        out.assert_eq(&expected, true);
+    }
+
+    #[test]
+    fn test_outer_batch_zero_right() {
+        let device = Default::default();
+        let x = TestTensor::<2>::from([[1.0, -2.0, 3.0], [4.0, 5.0, -6.0]]); // (2,3)
+        let y = TestTensor::<2>::zeros([2, 4], &device); // (2,4)
+
+        let out = linalg::outer_batch(x, y).into_data();
+        let expected = TestTensor::<3>::zeros([2, 3, 4], &device).into_data();
+
+        out.assert_eq(&expected, true);
+    }
+
+    // (4) Signs
+    #[test]
+    fn test_outer_batch_signs() {
+        let x = TestTensor::<2>::from([[-1.0, 2.0], [3.0, -4.0]]);
+        let y = TestTensor::<2>::from([[3.0, -4.0], [-5.0, 6.0]]);
+        let out = linalg::outer_batch(x, y).into_data();
+
+        let expected = TestTensor::<3>::from([
+            [
+                [-3.0, 4.0], // -1*3, -1*-4
+                [6.0, -8.0],
+            ], //  2*3,  2*-4
+            [
+                [-15.0, 18.0], //  3*-5, 3*6
+                [20.0, -24.0],
+            ], // -4*-5,-4*6
+        ])
+        .into_data();
+
+        out.assert_approx_eq::<FT>(&expected, Tolerance::default());
+    }
+
+    // (5) Equivalence with per-sample outer
+    #[test]
+    fn test_outer_batch_equivalence_to_per_sample_outer() {
+        // batch=2, m=2, n=3
+        let x = TestTensor::<2>::from([[1.0, 2.0], [3.0, 4.0]]);
+        let y = TestTensor::<2>::from([[5.0, 6.0, 7.0], [8.0, 9.0, 10.0]]);
+
+        let out_batched = linalg::outer_batch(x.clone(), y.clone());
+
+        // Compare each batch slice with linalg::outer(x[b], y[b])
+        for b in 0..2 {
+            let xb = x.clone().select(0, b); // (m,)
+            let yb = y.clone().select(0, b); // (n,)
+            let per = linalg::outer(xb, yb).into_data();
+            let bat = out_batched.clone().select(0, b).into_data();
+            bat.assert_approx_eq::<FT>(&per, Tolerance::default());
+        }
+    }
+
+    // (6) NaN propagation within batches
+    #[test]
+    fn test_outer_batch_nan_propagation() {
+        let x = TestTensor::<2>::from([
+            [f32::NAN, 2.0], // batch 0
+            [3.0, 4.0],
+        ]); // batch 1
+        let y = TestTensor::<2>::from([
+            [5.0, 6.0], // batch 0
+            [7.0, 8.0],
+        ]); // batch 1
+        let out = linalg::outer_batch(x, y).into_data();
+
+        // out shape (2,2,2), flatten to check values quickly
+        let v = out.value;
+
+        // batch 0 rows: [NaN, NaN], [10, 12]
+        assert!(v[0].is_nan() && v[1].is_nan()); // b0,i0,*
+        assert_eq!(v[2], 10.0);
+        assert_eq!(v[3], 12.0);
+
+        // batch 1 rows: [21, 24], [28, 32]
+        assert_eq!(v[4], 21.0);
+        assert_eq!(v[5], 24.0);
+        assert_eq!(v[6], 28.0);
+        assert_eq!(v[7], 32.0);
+    }
+}

--- a/crates/burn-tensor/src/tests/mod.rs
+++ b/crates/burn-tensor/src/tests/mod.rs
@@ -167,6 +167,8 @@ macro_rules! testgen_with_float_param {
         burn_tensor::testgen_diag!();
         burn_tensor::testgen_cosine_similarity!();
         burn_tensor::testgen_trace!();
+        burn_tensor::testgen_outer!();
+        burn_tensor::testgen_outer_batch!();
 
         // test module
         burn_tensor::testgen_module_conv1d!();


### PR DESCRIPTION
Pull Request
Checklist

 [v] Confirmed that cargo run-checks command has been executed.

[v] Made sure the book is up to date with changes in this PR.

Related Issues/PRs

Contributes to [#1538](https://github.com/tracel-ai/burn/issues/1538)
 — Linear algebra operations.

Changes

Added linalg::outer(x, y) to compute the outer product of two 1-D vectors.

Shapes: (m,) ⊗ (n,) → (m, n).

Equivalent to torch.outer / numpy.outer.

Added linalg::outer_batch(x, y) for batched outer products of 2-D inputs.

Shapes: (batch, m) ⊗ (batch, n) → (batch, m, n).

Each pair (x[b], y[b]) produces one (m, n) matrix.

Updated Linalg Functions table in the Book with both new ops.

Integrated new ops into burn-tensor module exports and test harness.

Testing

Added outer tests covering:

Correctness vs expected matrices

Shape asymmetry ((m,n) vs (n,m))

Zero vectors (left/right)

Negative values and integer inputs

Equivalence with reshape + matmul

Vector identity (u ⊗ v)w == u(v⋅w)

Length-one vectors

Large magnitude stability (no overflow)

NaN propagation

Added outer_batch tests covering:

Basic correctness with small batches

Shape checks (batch, m, n)

Zero batch inputs

Positive/negative value propagation

Integer batch inputs

Consistency with looping over outer

NaN propagation within batches