### PR TITLE
[Breaking] Make squeeze/squeeze_dim consistent with other APIs

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -131,55 +131,56 @@ for the sake of simplicity, we ignore type signatures. For more details, refer t
 
 Those operations are available for all tensor kinds: `Int`, `Float`, and `Bool`.
 
-| Burn                                        | PyTorch Equivalent                                                        |
-|---------------------------------------------|---------------------------------------------------------------------------|
-| `Tensor::cat(tensors, dim)`                 | `torch.cat(tensors, dim)`                                                 |
-| `Tensor::empty(shape, device)`              | `torch.empty(shape, device=device)`                                       |
-| `Tensor::from_primitive(primitive)`         | N/A                                                                       |
-| `Tensor::stack(tensors, dim)`               | `torch.stack(tensors, dim)`                                               |
-| `tensor.all()`                              | `tensor.all()`                                                            |
-| `tensor.all_dim(dim)`                       | `tensor.all(dim)`                                                         |
-| `tensor.any()`                              | `tensor.any()`                                                            |
-| `tensor.any_dim(dim)`                       | `tensor.any(dim)`                                                         |
-| `tensor.chunk(num_chunks, dim)`             | `tensor.chunk(num_chunks, dim)`                                           |
-| `tensor.split(split_size, dim)`             | `tensor.split(split_size, dim)`                                           |
-| `tensor.split_with_sizes(split_sizes, dim)` | `tensor.split([split_sizes], dim)`                                        |
-| `tensor.device()`                           | `tensor.device`                                                           |
-| `tensor.dtype()`                            | `tensor.dtype`                                                            |
-| `tensor.dims()`                             | `tensor.size()`                                                           |
-| `tensor.equal(other)`                       | `x == y`                                                                  |
-| `tensor.expand(shape)`                      | `tensor.expand(shape)`                                                    |
-| `tensor.flatten(start_dim, end_dim)`        | `tensor.flatten(start_dim, end_dim)`                                      |
-| `tensor.flip(axes)`                         | `tensor.flip(axes)`                                                       |
-| `tensor.into_data()`                        | N/A                                                                       |
-| `tensor.into_primitive()`                   | N/A                                                                       |
-| `tensor.into_scalar()`                      | `tensor.item()`                                                           |
-| `tensor.narrow(dim, start, length)`         | `tensor.narrow(dim, start, length)`                                       |
-| `tensor.not_equal(other)`                   | `x != y`                                                                  |
-| `tensor.permute(axes)`                      | `tensor.permute(axes)`                                                    |
-| `tensor.movedim(src, dst)`                  | `tensor.movedim(src, dst)`                                                |
-| `tensor.repeat_dim(dim, times)`             | `tensor.repeat(*[times if i == dim else 1 for i in range(tensor.dim())])` |
-| `tensor.repeat(sizes)`                      | `tensor.repeat(sizes)`                                                    |
-| `tensor.reshape(shape)`                     | `tensor.view(shape)`                                                      |
-| `tensor.roll(shfts, dims)`                  | `tensor.roll(shifts, dims)`                                               |
-| `tensor.roll_dim(shift, dim)`               | `tensor.roll([shift], [dim])`                                             |
-| `tensor.select(dim, indices)`               | `tensor.index_select(dim, indices)`                                       |
-| `tensor.select_assign(dim, indices, values)`| N/A                                                                       |
-| `tensor.shape()`                            | `tensor.shape`                                                            |
-| `tensor.slice(slices)`                      | `tensor[(*ranges,)]`                                                       |
-| `tensor.slice_assign(slices, values)`       | `tensor[(*ranges,)] = values`                                             |
-| `tensor.slice_fill(slices, value)`          | `tensor[(*ranges,)] = value`                                              |
-| `tensor.slice_dim(dim, range)`              | N/A                                                                       |
-| `tensor.squeeze(dim)`                       | `tensor.squeeze(dim)`                                                     |
-| `tensor.swap_dims(dim1, dim2)`              | `tensor.transpose(dim1, dim2)`                                            |
-| `tensor.take(dim, indices)`                 | `numpy.take(tensor, indices, dim)`                                        |
-| `tensor.to_data()`                          | N/A                                                                       |
-| `tensor.to_device(device)`                  | `tensor.to(device)`                                                       |
-| `tensor.transpose()`                        | `tensor.T`                                                                |
-| `tensor.t()`                                | `tensor.T`                                                                |
-| `tensor.unsqueeze()`                        | `tensor.unsqueeze(0)`                                                     |
-| `tensor.unsqueeze_dim(dim)`                 | `tensor.unsqueeze(dim)`                                                   |
-| `tensor.unsqueeze_dims(dims)`               | N/A                                                                       |
+| Burn                                         | PyTorch Equivalent                                                        |
+| -------------------------------------------- | ------------------------------------------------------------------------- |
+| `Tensor::cat(tensors, dim)`                  | `torch.cat(tensors, dim)`                                                 |
+| `Tensor::empty(shape, device)`               | `torch.empty(shape, device=device)`                                       |
+| `Tensor::from_primitive(primitive)`          | N/A                                                                       |
+| `Tensor::stack(tensors, dim)`                | `torch.stack(tensors, dim)`                                               |
+| `tensor.all()`                               | `tensor.all()`                                                            |
+| `tensor.all_dim(dim)`                        | `tensor.all(dim)`                                                         |
+| `tensor.any()`                               | `tensor.any()`                                                            |
+| `tensor.any_dim(dim)`                        | `tensor.any(dim)`                                                         |
+| `tensor.chunk(num_chunks, dim)`              | `tensor.chunk(num_chunks, dim)`                                           |
+| `tensor.split(split_size, dim)`              | `tensor.split(split_size, dim)`                                           |
+| `tensor.split_with_sizes(split_sizes, dim)`  | `tensor.split([split_sizes], dim)`                                        |
+| `tensor.device()`                            | `tensor.device`                                                           |
+| `tensor.dtype()`                             | `tensor.dtype`                                                            |
+| `tensor.dims()`                              | `tensor.size()`                                                           |
+| `tensor.equal(other)`                        | `x == y`                                                                  |
+| `tensor.expand(shape)`                       | `tensor.expand(shape)`                                                    |
+| `tensor.flatten(start_dim, end_dim)`         | `tensor.flatten(start_dim, end_dim)`                                      |
+| `tensor.flip(axes)`                          | `tensor.flip(axes)`                                                       |
+| `tensor.into_data()`                         | N/A                                                                       |
+| `tensor.into_primitive()`                    | N/A                                                                       |
+| `tensor.into_scalar()`                       | `tensor.item()`                                                           |
+| `tensor.narrow(dim, start, length)`          | `tensor.narrow(dim, start, length)`                                       |
+| `tensor.not_equal(other)`                    | `x != y`                                                                  |
+| `tensor.permute(axes)`                       | `tensor.permute(axes)`                                                    |
+| `tensor.movedim(src, dst)`                   | `tensor.movedim(src, dst)`                                                |
+| `tensor.repeat_dim(dim, times)`              | `tensor.repeat(*[times if i == dim else 1 for i in range(tensor.dim())])` |
+| `tensor.repeat(sizes)`                       | `tensor.repeat(sizes)`                                                    |
+| `tensor.reshape(shape)`                      | `tensor.view(shape)`                                                      |
+| `tensor.roll(shfts, dims)`                   | `tensor.roll(shifts, dims)`                                               |
+| `tensor.roll_dim(shift, dim)`                | `tensor.roll([shift], [dim])`                                             |
+| `tensor.select(dim, indices)`                | `tensor.index_select(dim, indices)`                                       |
+| `tensor.select_assign(dim, indices, values)` | N/A                                                                       |
+| `tensor.shape()`                             | `tensor.shape`                                                            |
+| `tensor.slice(slices)`                       | `tensor[(*ranges,)]`                                                      |
+| `tensor.slice_assign(slices, values)`        | `tensor[(*ranges,)] = values`                                             |
+| `tensor.slice_fill(slices, value)`           | `tensor[(*ranges,)] = value`                                              |
+| `tensor.slice_dim(dim, range)`               | N/A                                                                       |
+| `tensor.squeeze()`                           | `tensor.squeeze()`                                                        |
+| `tensor.squeeze_dim(dim)`                    | `tensor.squeeze(dim)`                                                     |
+| `tensor.swap_dims(dim1, dim2)`               | `tensor.transpose(dim1, dim2)`                                            |
+| `tensor.take(dim, indices)`                  | `numpy.take(tensor, indices, dim)`                                        |
+| `tensor.to_data()`                           | N/A                                                                       |
+| `tensor.to_device(device)`                   | `tensor.to(device)`                                                       |
+| `tensor.transpose()`                         | `tensor.T`                                                                |
+| `tensor.t()`                                 | `tensor.T`                                                                |
+| `tensor.unsqueeze()`                         | `tensor.unsqueeze(0)`                                                     |
+| `tensor.unsqueeze_dim(dim)`                  | `tensor.unsqueeze(dim)`                                                   |
+| `tensor.unsqueeze_dims(dims)`                | N/A                                                                       |
 
 ### Numeric Operations
 
@@ -267,8 +268,8 @@ Those operations are available for numeric tensor kinds: `Float` and `Int`.
 
 Those operations are only available for `Float` tensors.
 
-| Burn API                                     | PyTorch Equivalent                      |
-| -------------------------------------------- | ---------------------------------------    |
+| Burn API                                     | PyTorch Equivalent                         |
+| -------------------------------------------- | ------------------------------------------ |
 | `tensor.cast(dtype)`                         | `tensor.to(dtype)`                         |
 | `tensor.ceil()`                              | `tensor.ceil()`                            |
 | `tensor.cos()`                               | `tensor.cos()`                             |
@@ -333,7 +334,7 @@ Those operations are only available for `Int` tensors.
 Those operations are only available for `Bool` tensors.
 
 | Burn API                             | PyTorch Equivalent              |
-|--------------------------------------|---------------------------------|
+| ------------------------------------ | ------------------------------- |
 | `Tensor::diag_mask(shape, diagonal)` | N/A                             |
 | `Tensor::tril_mask(shape, diagonal)` | N/A                             |
 | `Tensor::triu_mask(shape, diagonal)` | N/A                             |
@@ -379,14 +380,14 @@ strategies.
 ## Grid Functions
 
 | Burn API                                           | PyTorch Equivalent                      |
-|----------------------------------------------------|-----------------------------------------|
+| -------------------------------------------------- | --------------------------------------- |
 | `grid::meshgrid(tensors, GridIndexing::Matrix)`    | `torch.meshgrid(tensors, indexing="ij") |
 | `grid::meshgrid(tensors, GridIndexing::Cartesian)` | `torch.meshgrid(tensors, indexing="xy") |
 
 ## Linalg Functions
 
 | Burn API                               | PyTorch Equivalent                        |
-|----------------------------------------|-------------------------------------------|
+| -------------------------------------- | ----------------------------------------- |
 | `linalg::vector_norm(tensors, p, dim)` | `torch.linalg.vector_norm(tensor, p, dim) |
 | `linalg::diag(tensor)`                 | `torch.diag(tensor)`                      |
 | `linalg::trace(tensor)`                | `torch.trace(tensor)`                     |

--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -172,13 +172,14 @@ Those operations are available for all tensor kinds: `Int`, `Float`, and `Bool`.
 | `tensor.slice_dim(dim, range)`               | N/A                                                                       |
 | `tensor.squeeze()`                           | `tensor.squeeze()`                                                        |
 | `tensor.squeeze_dim(dim)`                    | `tensor.squeeze(dim)`                                                     |
+| `tensor.squeeze_dims(dims)`                  | `tensor.squeeze(dims)` where `dims` is a tuple of ints                    |
 | `tensor.swap_dims(dim1, dim2)`               | `tensor.transpose(dim1, dim2)`                                            |
 | `tensor.take(dim, indices)`                  | `numpy.take(tensor, indices, dim)`                                        |
 | `tensor.to_data()`                           | N/A                                                                       |
 | `tensor.to_device(device)`                   | `tensor.to(device)`                                                       |
 | `tensor.transpose()`                         | `tensor.T`                                                                |
 | `tensor.t()`                                 | `tensor.T`                                                                |
-| `tensor.unsqueeze()`                         | `tensor.unsqueeze(0)`                                                     |
+| `tensor.unsqueeze()`                         | N/A                                                                       |
 | `tensor.unsqueeze_dim(dim)`                  | `tensor.unsqueeze(dim)`                                                   |
 | `tensor.unsqueeze_dims(dims)`                | N/A                                                                       |
 

--- a/crates/burn-core/src/module/initializer.rs
+++ b/crates/burn-core/src/module/initializer.rs
@@ -249,10 +249,10 @@ fn qr_decomposition<B: Backend>(
     let mut r = Tensor::<B, 2>::zeros([n, n], device);
 
     for j in 0..n {
-        let mut v: Tensor<B, 1> = a.clone().slice(s![.., j..=j]).squeeze(1);
+        let mut v: Tensor<B, 1> = a.clone().slice(s![.., j..=j]).squeeze_dim(1);
 
         for i in 0..j {
-            let q_i: Tensor<B, 1> = q.clone().slice(s![.., i..=i]).squeeze(1);
+            let q_i: Tensor<B, 1> = q.clone().slice(s![.., i..=i]).squeeze_dim(1);
             let r_ij = q_i.clone().mul(v.clone()).sum();
 
             r = r

--- a/crates/burn-import/onnx-tests/tests/reduce/mod.rs
+++ b/crates/burn-import/onnx-tests/tests/reduce/mod.rs
@@ -51,7 +51,7 @@ mod tests {
         let expected2_scalar = 1.0f32;
         let expected3 = input.to_data();
         let expected4 = TensorData::from([[[[1.0f32], [2.]]]]);
-        let expected5 = input.clone().squeeze::<3>(0).to_data();
+        let expected5 = input.clone().squeeze_dim::<3>(0).to_data();
         let expected6 = TensorData::from([[1.0f32, 4., 9., 25.]]);
 
         // Assert scalar outputs
@@ -82,7 +82,7 @@ mod tests {
         let expected2_scalar = 26.0f32;
         let expected3 = input.to_data();
         let expected4 = TensorData::from([[[[25.0f32], [26.]]]]);
-        let expected5 = input.clone().squeeze::<3>(0).to_data();
+        let expected5 = input.clone().squeeze_dim::<3>(0).to_data();
         let expected6 = TensorData::from([[2.0f32, 5., 10., 26.]]);
 
         // Assert scalar outputs
@@ -113,7 +113,7 @@ mod tests {
         let expected2_scalar = 82.0f32;
         let expected3 = input.to_data();
         let expected4 = TensorData::from([[[[39.0f32], [43.]]]]);
-        let expected5 = input.clone().squeeze::<3>(0).to_data();
+        let expected5 = input.clone().squeeze_dim::<3>(0).to_data();
         let expected6 = TensorData::from([[3.0f32, 9., 19., 51.]]);
 
         // Assert scalar outputs
@@ -179,7 +179,7 @@ mod tests {
         let expected2_scalar = 10.25f32;
         let expected3 = input.to_data();
         let expected4 = TensorData::from([[[[9.75f32], [10.75]]]]);
-        let expected5 = input.clone().squeeze::<3>(0).to_data();
+        let expected5 = input.clone().squeeze_dim::<3>(0).to_data();
         let expected6 = TensorData::from([[1.5f32, 4.5, 9.5, 25.5]]);
 
         // Assert scalar outputs

--- a/crates/burn-import/src/burn/node/argmax.rs
+++ b/crates/burn-import/src/burn/node/argmax.rs
@@ -55,7 +55,7 @@ impl<PS: PrecisionSettings> NodeCodegen<PS> for ArgMaxNode {
                     let output_rank = tensor.rank;
                     quote! {
                         let argmax_result = #input.argmax(#axis);
-                        let #output = argmax_result.squeeze::<#output_rank>(#axis);
+                        let #output = argmax_result.squeeze_dim::<#output_rank>(#axis);
                     }
                 }
             }
@@ -168,7 +168,7 @@ mod tests {
                     tensor1: Tensor<B, 2>
                 ) -> Tensor<B, 1, Int> {
                     let argmax_result = tensor1.argmax(1);
-                    let tensor2 = argmax_result.squeeze::<1usize>(1);
+                    let tensor2 = argmax_result.squeeze_dim::<1usize>(1);
 
                     tensor2
                 }

--- a/crates/burn-import/src/burn/node/argmin.rs
+++ b/crates/burn-import/src/burn/node/argmin.rs
@@ -56,7 +56,7 @@ impl<PS: PrecisionSettings> NodeCodegen<PS> for ArgMinNode {
                     let output_rank = tensor.rank;
                     quote! {
                         let argmin_result = #input.argmin(#axis);
-                        let #output = argmin_result.squeeze::<#output_rank>(#axis);
+                        let #output = argmin_result.squeeze_dim::<#output_rank>(#axis);
                     }
                 }
             }
@@ -170,7 +170,7 @@ mod tests {
                     tensor1: Tensor<B, 2>
                 ) -> Tensor<B, 1, Int> {
                     let argmin_result = tensor1.argmin(1);
-                    let tensor2 = argmin_result.squeeze::<1usize>(1);
+                    let tensor2 = argmin_result.squeeze_dim::<1usize>(1);
 
                     tensor2
                 }

--- a/crates/burn-import/src/burn/node/gather.rs
+++ b/crates/burn-import/src/burn/node/gather.rs
@@ -284,7 +284,7 @@ impl GatherNode {
 
                         quote! {
                             let sliced = #input.slice(s![#(#slice_args),*]);
-                            let #output = sliced.squeeze::<#output_rank>(#dim);
+                            let #output = sliced.squeeze_dim::<#output_rank>(#dim);
                         }
                     }
                     GatherIndices::Runtime(Type::Tensor(idx_tensor)) => {
@@ -577,7 +577,7 @@ mod tests {
                     scalar1: i64
                 ) -> Tensor<B, 1> {
                     let sliced = tensor1.slice(s![(scalar1 as usize)..((scalar1 as usize) + 1), ..]);
-                    let tensor2 = sliced.squeeze::<1usize>(0);
+                    let tensor2 = sliced.squeeze_dim::<1usize>(0);
                     tensor2
                 }
             }

--- a/crates/burn-import/src/burn/node/matmul.rs
+++ b/crates/burn-import/src/burn/node/matmul.rs
@@ -59,7 +59,7 @@ impl<PS: PrecisionSettings> NodeCodegen<PS> for MatmulNode {
                     }
 
                     quote! {
-                        let #output = #lhs.matmul(#rhs.unsqueeze_dims(&[#(#unsqueeze_dims),*])).squeeze::<#output_rank>(#squeeze_dim);
+                        let #output = #lhs.matmul(#rhs.unsqueeze_dims(&[#(#unsqueeze_dims),*])).squeeze_dim::<#output_rank>(#squeeze_dim);
                     }
                 } else {
                     // General tensor broadcasting: add leading dimensions
@@ -78,7 +78,7 @@ impl<PS: PrecisionSettings> NodeCodegen<PS> for MatmulNode {
                     let target_rank = rhs_dim;
 
                     quote! {
-                        let #output = #lhs.unsqueeze::<#target_rank>().matmul(#rhs).squeeze::<#output_rank>(#squeeze_dim);
+                        let #output = #lhs.unsqueeze::<#target_rank>().matmul(#rhs).squeeze_dim::<#output_rank>(#squeeze_dim);
                     }
                 } else {
                     // General tensor broadcasting: add leading dimensions
@@ -200,7 +200,7 @@ mod tests {
                     tensor1: Tensor<B, 4>,
                     tensor2: Tensor<B, 1>
                 ) -> Tensor<B, 3> {
-                    let tensor3 = tensor1.matmul(tensor2.unsqueeze_dims(&[-1isize, 0isize, 0isize])).squeeze::<3usize>(3usize);
+                    let tensor3 = tensor1.matmul(tensor2.unsqueeze_dims(&[-1isize, 0isize, 0isize])).squeeze_dim::<3usize>(3usize);
 
                     tensor3
                 }
@@ -249,7 +249,7 @@ mod tests {
                     tensor1: Tensor<B, 1>,
                     tensor2: Tensor<B, 4>
                 ) -> Tensor<B, 3> {
-                    let tensor3 = tensor1.unsqueeze::<4usize>().matmul(tensor2).squeeze::<3usize>(2usize);
+                    let tensor3 = tensor1.unsqueeze::<4usize>().matmul(tensor2).squeeze_dim::<3usize>(2usize);
 
                     tensor3
                 }

--- a/crates/burn-import/src/burn/node/matmul_integer.rs
+++ b/crates/burn-import/src/burn/node/matmul_integer.rs
@@ -116,7 +116,7 @@ impl<PS: PrecisionSettings> NodeCodegen<PS> for MatMulIntegerNode {
                     }
 
                     quote! {
-                        let #out = (#lhs_c).matmul((#rhs_c).unsqueeze_dims(&[#(#unsqueeze_dims),*])).squeeze::<#out_rank>(#squeeze_dim);
+                        let #out = (#lhs_c).matmul((#rhs_c).unsqueeze_dims(&[#(#unsqueeze_dims),*])).squeeze_dim::<#out_rank>(#squeeze_dim);
                     }
                 } else {
                     // General tensor broadcasting: add leading dimensions
@@ -134,7 +134,7 @@ impl<PS: PrecisionSettings> NodeCodegen<PS> for MatMulIntegerNode {
                     let out_rank = rhs_dim - 1;
                     let target_rank = rhs_dim;
                     quote! {
-                        let #out = (#lhs_c).unsqueeze::<#target_rank>().matmul(#rhs_c).squeeze::<#out_rank>(#squeeze_dim);
+                        let #out = (#lhs_c).unsqueeze::<#target_rank>().matmul(#rhs_c).squeeze_dim::<#out_rank>(#squeeze_dim);
                     }
                 } else {
                     // General tensor broadcasting: add leading dimensions

--- a/crates/burn-import/src/burn/node/squeeze.rs
+++ b/crates/burn-import/src/burn/node/squeeze.rs
@@ -35,11 +35,10 @@ impl<PS: PrecisionSettings> NodeCodegen<PS> for SqueezeNode {
                         }
                     }
                     None => {
-                        // When axes is None, pass empty array to squeeze_dims
-                        // This will squeeze all dimensions with size 1
+                        // When axes is None, squeeze all dimensions with size 1
                         let output_rank = output.rank;
                         quote! {
-                            let #output_name = #input_tensor.squeeze_dims::<#output_rank>(&[]);
+                            let #output_name = #input_tensor.squeeze::<#output_rank>();
                         }
                     }
                 }

--- a/crates/burn-nn/src/loss/cosine_embedding.rs
+++ b/crates/burn-nn/src/loss/cosine_embedding.rs
@@ -120,7 +120,7 @@ impl CosineEmbeddingLoss {
         // cos_sim shape: [batch_size, 1]
         let cos_sim = cosine_similarity(input1, input2, 1, None);
         // cos_sim shape: [batch_size]
-        let cos_sim: Tensor<B, 1> = cos_sim.squeeze(1);
+        let cos_sim: Tensor<B, 1> = cos_sim.squeeze_dim(1);
 
         let mut loss = cos_sim.zeros_like();
 

--- a/crates/burn-nn/src/modules/rnn/gru.rs
+++ b/crates/burn-nn/src/modules/rnn/gru.rs
@@ -143,7 +143,7 @@ impl<B: Backend> Gru<B> {
         };
 
         for (t, input_t) in batched_input.iter_dim(1).enumerate() {
-            let input_t = input_t.squeeze(1);
+            let input_t = input_t.squeeze_dim(1);
             // u(pdate)g(ate) tensors
             let biased_ug_input_sum =
                 self.gate_product(&input_t, &hidden_t, None, &self.update_gate);
@@ -332,7 +332,7 @@ mod tests {
 
         let output = state
             .select(0, Tensor::arange(0..1, &device))
-            .squeeze::<2>(0);
+            .squeeze_dim::<2>(0);
 
         let tolerance = Tolerance::default();
         output
@@ -345,7 +345,7 @@ mod tests {
 
         let output = state
             .select(0, Tensor::arange(0..1, &device))
-            .squeeze::<2>(0);
+            .squeeze_dim::<2>(0);
 
         output
             .to_data()
@@ -365,7 +365,7 @@ mod tests {
         let result = gru.forward(input.clone(), None);
         let output = result
             .select(0, Tensor::arange(0..1, &device))
-            .squeeze::<2>(0);
+            .squeeze_dim::<2>(0);
 
         let tolerance = Tolerance::default();
         output
@@ -378,7 +378,7 @@ mod tests {
 
         let output = state
             .select(0, Tensor::arange(0..1, &device))
-            .squeeze::<2>(0);
+            .squeeze_dim::<2>(0);
 
         output
             .to_data()

--- a/crates/burn-nn/src/modules/rnn/lstm.rs
+++ b/crates/burn-nn/src/modules/rnn/lstm.rs
@@ -152,7 +152,7 @@ impl<B: Backend> Lstm<B> {
         };
 
         for (input_t, t) in input_timestep_iter {
-            let input_t = input_t.squeeze(1);
+            let input_t = input_t.squeeze_dim(1);
             // f(orget)g(ate) tensors
             let biased_fg_input_sum = self
                 .forget_gate
@@ -294,20 +294,20 @@ impl<B: Backend> BiLstm<B> {
                     .cell
                     .clone()
                     .slice([0..1, 0..batch_size, 0..self.d_hidden])
-                    .squeeze(0);
+                    .squeeze_dim(0);
                 let hidden_state_forward = state
                     .hidden
                     .clone()
                     .slice([0..1, 0..batch_size, 0..self.d_hidden])
-                    .squeeze(0);
+                    .squeeze_dim(0);
                 let cell_state_reverse = state
                     .cell
                     .slice([1..2, 0..batch_size, 0..self.d_hidden])
-                    .squeeze(0);
+                    .squeeze_dim(0);
                 let hidden_state_reverse = state
                     .hidden
                     .slice([1..2, 0..batch_size, 0..self.d_hidden])
-                    .squeeze(0);
+                    .squeeze_dim(0);
 
                 [
                     Some(LstmState::new(cell_state_forward, hidden_state_forward)),
@@ -482,7 +482,7 @@ mod tests {
 
         output
             .select(0, Tensor::arange(0..1, &device))
-            .squeeze::<2>(0)
+            .squeeze_dim::<2>(0)
             .to_data()
             .assert_approx_eq::<FT>(&state.hidden.to_data(), tolerance);
     }

--- a/crates/burn-nn/src/modules/rope_encoding.rs
+++ b/crates/burn-nn/src/modules/rope_encoding.rs
@@ -306,7 +306,7 @@ mod tests {
         );
 
         output
-            .squeeze::<3>(0)
+            .squeeze_dim::<3>(0)
             .to_data()
             .assert_approx_eq::<FT>(&expected_output.to_data(), Tolerance::default());
     }
@@ -335,7 +335,7 @@ mod tests {
         );
 
         output
-            .squeeze::<3>(0)
+            .squeeze_dim::<3>(0)
             .to_data()
             .assert_approx_eq::<FT>(&expected_output.to_data(), Tolerance::default());
     }

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -659,8 +659,7 @@ where
             .shape()
             .dims
             .iter()
-            .enumerate()
-            .filter_map(|(index, &dim)| if dim == 1 { Some(index) } else { None })
+            .filter_map(|&dim| if dim == 1 { None } else { Some(dim) })
             .collect::<Vec<_>>();
         check!(TensorCheck::squeeze_dims_len::<D2>(new_dims.len()));
 

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -622,6 +622,51 @@ where
         Tensor::new(K::reshape(self.primitive, new_dims.into()))
     }
 
+    /// Squeeze the tensor along all dimensions, removing dimensions
+    /// of size one, and effectively reducing the rank of the tensor.
+    ///
+    /// # Type Parameters
+    ///
+    ///  - `D2`: The resulting number of dimensions in the squeezed tensor.
+    ///
+    /// # Returns
+    ///
+    /// A new `Tensor<B, D2, K>` instance with the specified dimension removed.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    ///
+    /// use burn_tensor::backend::Backend;
+    /// use burn_tensor::{Tensor, Shape};
+    ///
+    /// fn example<B: Backend>() {
+    ///     let device = Default::default();
+    ///     // Create a 4D tensor with dimensions [1, 3, 1, 3]
+    ///     let tensor = Tensor::<B, 4>::from_data(
+    ///         [[[[3.0, 4.9, 2.0]], [[2.0, 1.9, 3.0]], [[4.0, 5.9, 8.0]]]],
+    ///         &device,
+    ///     );
+    ///
+    ///     // Squeeze the tensor dimensions.
+    ///     // The resulting tensor will have dimensions [3, 3].
+    ///     let squeezed = tensor.squeeze::<2>();
+    ///     println!("{squeezed}");
+    /// }
+    /// ```
+    pub fn squeeze<const D2: usize>(self) -> Tensor<B, D2, K> {
+        let new_dims = self
+            .shape()
+            .dims
+            .iter()
+            .enumerate()
+            .filter_map(|(index, &dim)| if dim == 1 { Some(index) } else { None })
+            .collect::<Vec<_>>();
+        check!(TensorCheck::squeeze_dims_len::<D2>(new_dims.len()));
+
+        Tensor::new(K::reshape(self.primitive, new_dims.into()))
+    }
+
     /// Squeeze the tensor along the given dimension, removing the specified dimension
     /// of size one, and effectively reducing the rank of the tensor by one.
     ///
@@ -658,11 +703,11 @@ where
     ///
     ///     // Squeeze the dimension 1.
     ///     // The resulting tensor will have dimensions [3, 3].
-    ///     let squeezed = tensor.squeeze::<2>(1);
+    ///     let squeezed = tensor.squeeze_dim::<2>(1);
     ///     println!("{squeezed}");
     /// }
     /// ```
-    pub fn squeeze<const D2: usize>(self, dim: usize) -> Tensor<B, D2, K> {
+    pub fn squeeze_dim<const D2: usize>(self, dim: usize) -> Tensor<B, D2, K> {
         check!(TensorCheck::squeeze::<D2>(dim, &self.shape().dims));
 
         let current_dims = self.shape().dims;

--- a/crates/burn-tensor/src/tensor/linalg/diag.rs
+++ b/crates/burn-tensor/src/tensor/linalg/diag.rs
@@ -40,5 +40,5 @@ where
     let range = Tensor::<B, 1, Int>::arange(0..diag_len as i64, &device);
     let step_tensor = Tensor::<B, 1, Int>::from_data([cols as i64 + 1], &device);
     let indices = range * step_tensor;
-    flat.take::<1, D>(D - 2, indices).squeeze(D - 1)
+    flat.take::<1, D>(D - 2, indices).squeeze_dim(D - 1)
 }

--- a/crates/burn-tensor/src/tests/ops/squeeze.rs
+++ b/crates/burn-tensor/src/tests/ops/squeeze.rs
@@ -5,17 +5,26 @@ mod tests {
 
     /// Test if the function can successfully squeeze the size 1 dimension of a 3D tensor.
     #[test]
-    fn should_squeeze() {
+    fn should_squeeze_dim() {
         let tensor = TestTensor::<3>::ones(Shape::new([2, 1, 4]), &Default::default());
-        let squeezed_tensor: Tensor<TestBackend, 2> = tensor.squeeze(1);
+        let squeezed_tensor: Tensor<TestBackend, 2> = tensor.squeeze_dim(1);
         let expected_shape = Shape::new([2, 4]);
         assert_eq!(squeezed_tensor.shape(), expected_shape);
     }
+
+    #[test]
+    fn should_squeeze() {
+        let tensor = TestTensor::<3>::ones(Shape::new([2, 1, 4]), &Default::default());
+        let squeezed_tensor: Tensor<TestBackend, 2> = tensor.squeeze();
+        let expected_shape = Shape::new([2, 4]);
+        assert_eq!(squeezed_tensor.shape(), expected_shape);
+    }
+
     /// Test if the function can successfully squeeze the first size 1 dimension of a 4D tensor.
     #[test]
     fn should_squeeze_first() {
         let tensor = TestTensor::<4>::ones(Shape::new([1, 3, 4, 5]), &Default::default());
-        let squeezed_tensor: Tensor<TestBackend, 3> = tensor.squeeze(0);
+        let squeezed_tensor: Tensor<TestBackend, 3> = tensor.squeeze_dim(0);
         let expected_shape = Shape::new([3, 4, 5]);
         assert_eq!(squeezed_tensor.shape(), expected_shape);
     }
@@ -23,7 +32,7 @@ mod tests {
     #[test]
     fn should_squeeze_last() {
         let tensor = TestTensor::<4>::ones(Shape::new([2, 3, 4, 1]), &Default::default());
-        let squeezed_tensor: Tensor<TestBackend, 3> = tensor.squeeze(3);
+        let squeezed_tensor: Tensor<TestBackend, 3> = tensor.squeeze_dim(3);
         let expected_shape = Shape::new([2, 3, 4]);
         assert_eq!(squeezed_tensor.shape(), expected_shape);
     }
@@ -32,7 +41,7 @@ mod tests {
     #[should_panic]
     fn should_squeeze_panic() {
         let tensor = TestTensor::<4>::ones(Shape::new([2, 3, 4, 5]), &Default::default());
-        let squeezed_tensor: Tensor<TestBackend, 3> = tensor.squeeze(2);
+        let squeezed_tensor: Tensor<TestBackend, 3> = tensor.squeeze_dim(2);
     }
 
     /// Test if the function works with an empty slice
@@ -40,6 +49,14 @@ mod tests {
     fn should_squeeze_dims_with_empty_slice() {
         let tensor = TestTensor::<3>::ones(Shape::new([1, 1, 3]), &Default::default());
         let squeezed_tensor: Tensor<TestBackend, 1> = tensor.squeeze_dims(&[]);
+        let expected_shape = Shape::new([3]);
+        assert_eq!(squeezed_tensor.shape(), expected_shape);
+    }
+
+    #[test]
+    fn should_squeeze_all_dims() {
+        let tensor = TestTensor::<3>::ones(Shape::new([1, 3, 1]), &Default::default());
+        let squeezed_tensor: Tensor<TestBackend, 1> = tensor.squeeze();
         let expected_shape = Shape::new([3]);
         assert_eq!(squeezed_tensor.shape(), expected_shape);
     }
@@ -70,6 +87,13 @@ mod tests {
         let squeezed_tensor: Tensor<TestBackend, 3> = tensor.squeeze_dims(&[1]);
         let expected_shape = Shape::new([2, 3, 4]);
         assert_eq!(squeezed_tensor.shape(), expected_shape);
+    }
+
+    #[test]
+    #[should_panic]
+    fn should_panic_squeeze_consumes_all_singleton() {
+        let tensor = TestTensor::<3>::ones(Shape::new([1, 3, 1]), &Default::default());
+        let squeezed_tensor: Tensor<TestBackend, 2> = tensor.squeeze(); // output rank should be 1
     }
 
     /// Test to make sure the function panics if too many dimensions are requested to be squeezed

--- a/crates/burn-train/src/metric/auroc.rs
+++ b/crates/burn-train/src/metric/auroc.rs
@@ -93,7 +93,7 @@ impl<B: Backend> Metric for AurocMetric<B> {
             let sum = exponents.clone().sum_dim(1);
             (exponents / sum)
                 .select(1, Tensor::arange(1..2, &input.outputs.device()))
-                .squeeze(1)
+                .squeeze_dim(1)
         };
 
         let area_under_curve = self.binary_auroc(&probabilities, &input.targets);

--- a/crates/burn-train/src/metric/confusion_stats.rs
+++ b/crates/burn-train/src/metric/confusion_stats.rs
@@ -80,7 +80,7 @@ impl<B: Backend> ConfusionStats<B> {
         use ClassReduction::{Macro, Micro};
         match class_reduction {
             Micro => sample_class_mask.float().sum(),
-            Macro => sample_class_mask.float().sum_dim(0).squeeze(0),
+            Macro => sample_class_mask.float().sum_dim(0).squeeze_dim(0),
         }
     }
 

--- a/crates/burn-train/src/metric/fbetascore.rs
+++ b/crates/burn-train/src/metric/fbetascore.rs
@@ -119,7 +119,7 @@ impl<B: Backend> FBetaScoreMetric<B> {
                     let nan_mask = aggregated_metric.clone().is_nan();
                     aggregated_metric = aggregated_metric
                         .clone()
-                        .select(0, nan_mask.bool_not().argwhere().squeeze(1))
+                        .select(0, nan_mask.bool_not().argwhere().squeeze_dim(1))
                 }
                 aggregated_metric.mean()
             }

--- a/crates/burn-train/src/metric/perplexity.rs
+++ b/crates/burn-train/src/metric/perplexity.rs
@@ -187,7 +187,7 @@ impl<B: Backend> Metric for PerplexityMetric<B> {
         // Gather the log probabilities for the target tokens
         let target_log_probs = log_probs
             .gather(1, targets.clone().unsqueeze_dim(1))
-            .squeeze(1);
+            .squeeze_dim(1);
 
         let (sum_log_prob, effective_tokens) = match self.pad_token {
             Some(pad_token) => {

--- a/crates/burn-train/src/metric/precision.rs
+++ b/crates/burn-train/src/metric/precision.rs
@@ -105,7 +105,7 @@ impl<B: Backend> PrecisionMetric<B> {
                     let nan_mask = aggregated_metric.clone().is_nan();
                     aggregated_metric = aggregated_metric
                         .clone()
-                        .select(0, nan_mask.bool_not().argwhere().squeeze(1))
+                        .select(0, nan_mask.bool_not().argwhere().squeeze_dim(1))
                 }
                 aggregated_metric.mean()
             }

--- a/crates/burn-train/src/metric/recall.rs
+++ b/crates/burn-train/src/metric/recall.rs
@@ -102,7 +102,7 @@ impl<B: Backend> RecallMetric<B> {
                     let nan_mask = aggregated_metric.clone().is_nan();
                     aggregated_metric = aggregated_metric
                         .clone()
-                        .select(0, nan_mask.bool_not().argwhere().squeeze(1))
+                        .select(0, nan_mask.bool_not().argwhere().squeeze_dim(1))
                 }
                 aggregated_metric.mean()
             }

--- a/examples/custom-training-loop/src/lib.rs
+++ b/examples/custom-training-loop/src/lib.rs
@@ -105,7 +105,7 @@ pub fn run<B: AutodiffBackend>(device: B::Device) {
 
 /// Create out own accuracy metric calculation.
 fn accuracy<B: Backend>(output: Tensor<B, 2>, targets: Tensor<B, 1, Int>) -> f32 {
-    let predictions = output.argmax(1).squeeze(1);
+    let predictions = output.argmax(1).squeeze_dim(1);
     let num_predictions: usize = targets.dims().iter().product();
     let num_corrects = predictions.equal(targets).int().sum().into_scalar();
 

--- a/examples/modern-lstm/src/inference.rs
+++ b/examples/modern-lstm/src/inference.rs
@@ -32,8 +32,8 @@ pub fn infer<B: Backend>(artifact_dir: &str, device: B::Device) {
     let predicted = model.forward(batch.sequences, None);
     let targets = batch.targets;
 
-    let predicted = predicted.squeeze::<1>(1).into_data();
-    let expected = targets.squeeze::<1>(1).into_data();
+    let predicted = predicted.squeeze_dim::<1>(1).into_data();
+    let expected = targets.squeeze_dim::<1>(1).into_data();
 
     // Display the predicted vs expected values
     let results = df![

--- a/examples/modern-lstm/src/model.rs
+++ b/examples/modern-lstm/src/model.rs
@@ -227,7 +227,7 @@ impl<B: Backend> StackedLstm<B> {
 
         let mut layer_outputs = vec![];
         for t in 0..seq_length {
-            let mut input_t = x.clone().slice(s![.., t..t + 1, ..]).squeeze::<2>(1);
+            let mut input_t = x.clone().slice(s![.., t..t + 1, ..]).squeeze_dim::<2>(1);
             for (i, lstm_cell) in self.layers.iter().enumerate() {
                 let mut state: LstmState<B, 2> =
                     LstmState::new(states[i].cell.clone(), states[i].hidden.clone());
@@ -353,7 +353,7 @@ impl<B: Backend> LstmNetwork<B> {
         self.fc.forward(
             output
                 .slice(s![.., seq_length - 1..seq_length, ..])
-                .squeeze::<2>(1),
+                .squeeze_dim::<2>(1),
         )
     }
 }

--- a/examples/simple-regression/src/inference.rs
+++ b/examples/simple-regression/src/inference.rs
@@ -31,7 +31,7 @@ pub fn infer<B: Backend>(artifact_dir: &str, device: B::Device) {
     let targets = batch.targets;
 
     // Display the predicted vs expected values
-    let predicted = predicted.squeeze::<1>(1).into_data();
+    let predicted = predicted.squeeze_dim::<1>(1).into_data();
     let expected = targets.into_data();
 
     let points = predicted

--- a/examples/text-classification/src/inference.rs
+++ b/examples/text-classification/src/inference.rs
@@ -65,7 +65,7 @@ pub fn infer<B: Backend, D: TextClassificationDataset + 'static>(
         #[allow(clippy::single_range_in_vec_init)]
         let prediction = predictions.clone().slice([i..i + 1]); // Get prediction for current sample
         let logits = prediction.to_data(); // Convert prediction tensor to data
-        let class_index = prediction.argmax(1).squeeze::<1>(1).into_scalar(); // Get class index with the highest value
+        let class_index = prediction.argmax(1).squeeze_dim::<1>(1).into_scalar(); // Get class index with the highest value
         let class = D::class_name(class_index.elem::<i32>() as usize); // Get class name
 
         // Print sample text, predicted logits and predicted class

--- a/examples/wgan/src/training.rs
+++ b/examples/wgan/src/training.rs
@@ -70,7 +70,7 @@ pub fn save_image<B: Backend, Q: AsRef<Path>>(
             let image: Tensor<B, 3> = images
                 .clone()
                 .slice((row * nrow + col) as usize..(row * nrow + col + 1) as usize)
-                .squeeze(0);
+                .squeeze_dim(0);
             // The Rgb32 should be in range 0.0-1.0
             let image = image.into_data().iter::<f32>().collect::<Vec<f32>>();
             // Supports both 1 and 3 channels image


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

Going through some API discrepancies. Almost all operations that act on a given dim have the `_dim(dim)` suffix.

To be consistent with this, and `unsqueeze()` / `unsqueeze_dim(dim)`, I propose we:
- move `squeeze(dim)` -> `squeeze_dim(dim)`
- add `squeeze()` which squeezes all singleton dimensions
  - this is the same behavior as `squeeze_dims(&[])`, which isn't really consistent / clear itself
  
This is a breaking change at the user-level, so not great. There exists a transition path:
- Add `squeeze_dim(dim)
- Temporarily mark `squeeze(dim)` as deprecated for the next release, pointing users to `squeeze_dim(dim)`
- Following the next release remove `squeeze(dim)` and add `squeeze()`

We've already introduced a couple of minor breaking changes since 0.18, so maybe another one isn't so bad 😅 