### PR TITLE
Add uint16 to onnx-ir

### DIFF
--- a/crates/burn-import/src/burn/node/cast.rs
+++ b/crates/burn-import/src/burn/node/cast.rs
@@ -44,6 +44,7 @@ impl<PS: PrecisionSettings> NodeCodegen<PS> for CastNode {
                     ElementType::Int32
                     | ElementType::Int64
                     | ElementType::Int8
+                    | ElementType::Uint16
                     | ElementType::Uint8 => ScalarKind::Int64,
                     ElementType::Bool => ScalarKind::Bool,
                     ElementType::String => panic!("Cast: String type not supported"),
@@ -61,6 +62,7 @@ impl<PS: PrecisionSettings> NodeCodegen<PS> for CastNode {
                         ElementType::Float64 => quote! { f64 },
                         ElementType::Int32 => quote! { i32 },
                         ElementType::Int64 => quote! { i64 },
+                        ElementType::Uint16 => quote! { u16 },
                         ElementType::Int8 => quote! { i8 },
                         ElementType::Uint8 => quote! { u8 },
                         ElementType::Bool => quote! { bool },
@@ -88,6 +90,7 @@ impl<PS: PrecisionSettings> NodeCodegen<PS> for CastNode {
                     ElementType::Int32
                     | ElementType::Int64
                     | ElementType::Int8
+                    | ElementType::Uint16
                     | ElementType::Uint8 => TensorKind::Int,
                     ElementType::Bool => TensorKind::Bool,
                     ElementType::String => panic!("Cast: String type not supported"),
@@ -163,6 +166,7 @@ impl<PS: PrecisionSettings> NodeCodegen<PS> for CastNode {
                     ElementType::Int32
                     | ElementType::Int64
                     | ElementType::Int8
+                    | ElementType::Uint16
                     | ElementType::Uint8 => {
                         panic!(
                             "Cast: Shape to Int tensor should be handled as Shape->Shape in onnx-ir"

--- a/crates/burn-import/src/onnx/to_burn.rs
+++ b/crates/burn-import/src/onnx/to_burn.rs
@@ -2134,6 +2134,7 @@ impl From<&ElementType> for ScalarKind {
             ElementType::Int32 => ScalarKind::Int32,
             ElementType::Int64 => ScalarKind::Int64,
             ElementType::Bool => ScalarKind::Bool,
+            ElementType::Uint16 => ScalarKind::Int32,
             ElementType::Int8 | ElementType::Uint8 => ScalarKind::Int32,
             ElementType::String => panic!("String tensor unsupported"),
             ElementType::Float16 => panic!("Float16 tensor unsupported"),
@@ -2157,9 +2158,11 @@ impl From<ElementType> for TensorKind {
 
 fn tensor_type_from_elem_and_rank(name: String, elem: &ElementType, rank: usize) -> TensorType {
     match elem {
-        ElementType::Uint8 | ElementType::Int8 | ElementType::Int32 | ElementType::Int64 => {
-            TensorType::new(name, rank, TensorKind::Int)
-        }
+        ElementType::Uint8
+        | ElementType::Int8
+        | ElementType::Uint16
+        | ElementType::Int32
+        | ElementType::Int64 => TensorType::new(name, rank, TensorKind::Int),
 
         ElementType::Float16 | ElementType::Float32 | ElementType::Float64 => {
             // If you have TensorType::new_float, use that; otherwise:

--- a/crates/onnx-ir/src/from_onnx.rs
+++ b/crates/onnx-ir/src/from_onnx.rs
@@ -59,6 +59,7 @@ pub fn element_type_from_proto(dt_i32: i32) -> Result<ElementType, String> {
         DT::FLOAT16 => Ok(ElementType::Float16),
         DT::INT64 => Ok(ElementType::Int64),
         DT::INT32 => Ok(ElementType::Int32),
+        DT::UINT16 => Ok(ElementType::Uint16),
         DT::UINT8 => Ok(ElementType::Uint8),
         DT::INT8 => Ok(ElementType::Int8),
         DT::BOOL => Ok(ElementType::Bool),

--- a/crates/onnx-ir/src/ir.rs
+++ b/crates/onnx-ir/src/ir.rs
@@ -120,13 +120,14 @@ impl Argument {
                         1 => ElementType::Float32,  // FLOAT
                         2 => ElementType::Uint8,    // UINT8
                         3 => ElementType::Int8,     // INT8
+                        4 => ElementType::Uint16,   // UINT16
                         6 => ElementType::Int32,    // INT32
                         7 => ElementType::Int64,    // INT64
                         9 => ElementType::Bool,     // BOOL
                         10 => ElementType::Float16, // FLOAT16
                         11 => ElementType::Float64, // DOUBLE
                         8 => ElementType::String,   // STRING (rare as tensor; empty ok)
-                        // If you need more (e.g., UINT16/UINT32/UINT64), add them here.
+                        // If you need more (e.g., UINT32/UINT64), add them here.
                         other => panic!(
                             "unsupported empty-tensor data_type={} for '{}'",
                             other, name
@@ -140,6 +141,7 @@ impl Argument {
                         ElementType::Float16 => Data::Float16s(Vec::new()),
                         ElementType::Int32 => Data::Int32s(Vec::new()),
                         ElementType::Int64 => Data::Int64s(Vec::new()),
+                        ElementType::Uint16 => Data::Uint16s(Vec::new()),
                         ElementType::Uint8 => Data::Uint8s(Vec::new()),
                         ElementType::Int8 => Data::Int8s(Vec::new()),
                         ElementType::Bool => Data::Bools(Vec::new()),
@@ -206,6 +208,7 @@ pub enum ElementType {
     String,
     Float16,
     Bool,
+    Uint16,
     Uint8,
     Int8,
 }
@@ -303,6 +306,7 @@ impl TensorData {
             Data::Float16(_) | Data::Float16s(_) => ElementType::Float16,
             Data::Float32(_) | Data::Float32s(_) => ElementType::Float32,
             Data::Float64(_) | Data::Float64s(_) => ElementType::Float64,
+            Data::Uint16(_) | Data::Uint16s(_) => ElementType::Uint16,
             Data::Uint8(_) | Data::Uint8s(_) => ElementType::Uint8,
             Data::Int8(_) | Data::Int8s(_) => ElementType::Int8,
             Data::Int32(_) | Data::Int32s(_) => ElementType::Int32,
@@ -323,6 +327,8 @@ pub enum Data {
     Float32s(Vec<f32>),
     Float64(f64),
     Float64s(Vec<f64>),
+    Uint16(u16),
+    Uint16s(Vec<u16>),
     Uint8(u8),
     Uint8s(Vec<u8>),
     Int8(i8),
@@ -644,6 +650,8 @@ impl fmt::Debug for Data {
             Data::Float16(v) => write!(f, "Float16({v})"),
             Data::Float32(v) => write!(f, "Float32({v})"),
             Data::Float64(v) => write!(f, "Float64({v})"),
+            Data::Uint16(v) => write!(f, "Uint16({v})"),
+            Data::Uint16s(v) => write!(f, "Uint16s({})", trunc(v)),
             Data::Uint8s(v) => write!(f, "Uint8s({})", trunc(v)),
             Data::Int8s(v) => write!(f, "Int8s({})", trunc(v)),
             Data::Uint8(v) => write!(f, "Uint8({v})"),

--- a/crates/onnx-ir/src/proto_conversion.rs
+++ b/crates/onnx-ir/src/proto_conversion.rs
@@ -40,6 +40,7 @@ impl TryFrom<TensorProto> for TensorData {
                 ElementType::Float16 => Data::Float16s(cast_vec_with_fallback(tensor.raw_data)),
                 ElementType::Int32 => Data::Int32s(cast_vec_with_fallback(tensor.raw_data)),
                 ElementType::Int64 => Data::Int64s(cast_vec_with_fallback(tensor.raw_data)),
+                ElementType::Uint16 => Data::Uint16s(cast_vec_with_fallback(tensor.raw_data)),
                 ElementType::Uint8 => Data::Uint8s(tensor.raw_data), // keep bytes
                 ElementType::Int8 => {
                     Data::Int8s(tensor.raw_data.into_iter().map(|b| b as i8).collect())


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [X] Confirmed that `cargo run-checks` command has been executed.

All tests except these 4 passed. I think this might be floating-point precision issues. I'm running these tests on AppleSilicon. I don't think my changes would have affected this part of the code.

```
failures:
    tests::autodiff::ad_div::tests::test_div_complex_2
    tests::autodiff::ad_log_sigmoid::tests::should_diff_log_sigmoid
    tests::autodiff_checkpointing::ad_div::tests::test_div_complex_2
    tests::autodiff_checkpointing::ad_log_sigmoid::tests::should_diff_log_sigmoid
```

- [X] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

None

### Changes

Added `Uint16` as a element type in `onnx-ir`. I'm using `onnx-ir` as a as an ONNX parser, and ran into an issue where a model takes a type `Uint16` input tensor. This fixes the issue on my end, and I am able to parse the ONNX model to completion.

### Testing

Manually tested on my local machine to ensure that a model using uint16 input parses.