### PR TITLE
Slice: Copy, full(), default()

### DIFF
--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -2882,13 +2882,8 @@ pub trait BasicOps<B: Backend>: TensorKind<B> {
     /// with static dispatch. It is not designed for direct usage by users, and not recommended to import
     /// or use this function directly.
     fn slice_dim(tensor: Self::Primitive, dim: usize, slice: &Slice) -> Self::Primitive {
-        let mut slices: Vec<Slice> = tensor
-            .shape()
-            .dims
-            .iter()
-            .map(|&s| Slice::new(0, Some(s as isize), 1))
-            .collect();
-        slices[dim] = slice.clone();
+        let mut slices = vec![Slice::full(); tensor.shape().num_dims()];
+        slices[dim] = *slice;
 
         Self::slice(tensor, &slices)
     }

--- a/crates/burn-tensor/src/tensor/api/slice.rs
+++ b/crates/burn-tensor/src/tensor/api/slice.rs
@@ -331,7 +331,7 @@ macro_rules! s {
 /// ```
 ///
 /// See also the [`s!`] macro for the preferred way to create slices.
-#[derive(Clone, Debug, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Slice {
     /// Slice start index.
     pub start: isize,
@@ -341,11 +341,22 @@ pub struct Slice {
     pub step: isize,
 }
 
+impl Default for Slice {
+    fn default() -> Self {
+        Self::full()
+    }
+}
+
 impl Slice {
     /// Creates a new slice with start, end, and step
-    pub fn new(start: isize, end: Option<isize>, step: isize) -> Self {
+    pub const fn new(start: isize, end: Option<isize>, step: isize) -> Self {
         assert!(step != 0, "Step cannot be zero");
         Self { start, end, step }
+    }
+
+    /// Creates a slice that represents the full range.
+    pub const fn full() -> Self {
+        Self::new(0, None, 1)
     }
 
     /// Creates a slice that represents a single index

--- a/crates/burn-tensor/src/tests/ops/slice.rs
+++ b/crates/burn-tensor/src/tests/ops/slice.rs
@@ -4,6 +4,29 @@ mod tests {
     use burn_tensor::{Int, Slice, Tensor, TensorData, as_type, s};
 
     #[test]
+    fn should_support_const_and_full() {
+        static SLICES: [Slice; 2] = [Slice::full(), Slice::new(2, None, 1)];
+        assert_eq!(SLICES[0], Slice::new(0, None, 1));
+        assert_eq!(SLICES[1], Slice::new(2, None, 1));
+    }
+
+    #[test]
+    fn should_support_default() {
+        assert_eq!(Slice::default(), Slice::new(0, None, 1));
+    }
+
+    #[test]
+    fn should_support_copy() {
+        let mut slice = Slice::new(1, Some(3), 2);
+        let slice_copy = slice;
+
+        slice.end = Some(4);
+
+        assert_eq!(slice, Slice::new(1, Some(4), 2));
+        assert_eq!(slice_copy, Slice::new(1, Some(3), 2));
+    }
+
+    #[test]
     fn should_support_slice_dim_1d() {
         let data = TensorData::from([0.0, 1.0, 2.0]);
         let tensor = TestTensor::<1>::from_data(data.clone(), &Default::default());


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

Added `Copy`, `full()`, and `Default` to `Slice`.