### PR TITLE
Tensor::num_dims()

### DIFF
--- a/crates/burn-autodiff/src/tensor.rs
+++ b/crates/burn-autodiff/src/tensor.rs
@@ -22,6 +22,10 @@ impl<B: Backend> TensorMetadata for AutodiffTensor<B> {
     fn shape(&self) -> burn_tensor::Shape {
         self.primitive.shape()
     }
+
+    fn num_dims(&self) -> usize {
+        self.primitive.num_dims()
+    }
 }
 
 pub type NodeRefCount = Arc<NodeID>;

--- a/crates/burn-candle/src/tensor.rs
+++ b/crates/burn-candle/src/tensor.rs
@@ -27,6 +27,10 @@ impl TensorMetadata for CandleTensor {
     fn shape(&self) -> Shape {
         Shape::from(self.tensor.dims().to_vec())
     }
+
+    fn num_dims(&self) -> usize {
+        self.tensor.dims().len()
+    }
 }
 
 impl QTensorPrimitive for CandleTensor {

--- a/crates/burn-cubecl/src/tensor/base.rs
+++ b/crates/burn-cubecl/src/tensor/base.rs
@@ -152,6 +152,10 @@ impl<R: CubeRuntime> TensorMetadata for CubeTensor<R> {
     fn shape(&self) -> Shape {
         self.shape.clone()
     }
+
+    fn num_dims(&self) -> usize {
+        self.shape.num_dims()
+    }
 }
 
 impl<R: CubeRuntime> QTensorPrimitive for CubeTensor<R> {

--- a/crates/burn-fusion/src/tensor.rs
+++ b/crates/burn-fusion/src/tensor.rs
@@ -65,6 +65,10 @@ impl<R: FusionRuntime> TensorMetadata for FusionTensor<R> {
     fn shape(&self) -> Shape {
         Shape::from(self.shape.clone())
     }
+
+    fn num_dims(&self) -> usize {
+        self.shape.len()
+    }
 }
 
 impl<R: FusionRuntime> FusionTensor<R> {

--- a/crates/burn-ndarray/src/tensor.rs
+++ b/crates/burn-ndarray/src/tensor.rs
@@ -308,6 +308,10 @@ impl TensorMetadata for NdArrayTensor {
             a.shape().to_vec()
         ))
     }
+
+    fn num_dims(&self) -> usize {
+        self.shape().num_dims()
+    }
 }
 
 pub(crate) trait ShapeOps {
@@ -551,6 +555,10 @@ impl TensorMetadata for NdArrayQTensor {
 
     fn shape(&self) -> Shape {
         self.qtensor.shape()
+    }
+
+    fn num_dims(&self) -> usize {
+        self.shape().num_dims()
     }
 }
 

--- a/crates/burn-router/src/tensor.rs
+++ b/crates/burn-router/src/tensor.rs
@@ -24,6 +24,10 @@ impl<C: RunnerClient> TensorMetadata for RouterTensor<C> {
     fn shape(&self) -> Shape {
         Shape::from(self.shape.clone())
     }
+
+    fn num_dims(&self) -> usize {
+        self.shape.len()
+    }
 }
 
 impl<C: RunnerClient> RouterTensor<C> {

--- a/crates/burn-tch/src/tensor.rs
+++ b/crates/burn-tch/src/tensor.rs
@@ -85,6 +85,10 @@ impl TensorMetadata for TchTensor {
     fn shape(&self) -> Shape {
         Shape::from(self.tensor.size())
     }
+
+    fn num_dims(&self) -> usize {
+        self.tensor.dim()
+    }
 }
 
 impl burn_tensor::quantization::QTensorPrimitive for TchTensor {

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -123,6 +123,11 @@ where
         Self::new(tensor)
     }
 
+    /// Returns the number of dimensions of the tensor.
+    pub fn num_dims(&self) -> usize {
+        self.primitive.num_dims()
+    }
+
     /// Returns the tensor primitive data type.
     ///
     /// # Note

--- a/crates/burn-tensor/src/tensor/api/kind.rs
+++ b/crates/burn-tensor/src/tensor/api/kind.rs
@@ -45,6 +45,13 @@ impl<B: Backend> TensorMetadata for TensorPrimitive<B> {
             TensorPrimitive::QFloat(tensor) => tensor.shape(),
         }
     }
+
+    fn num_dims(&self) -> usize {
+        match self {
+            TensorPrimitive::Float(tensor) => tensor.num_dims(),
+            TensorPrimitive::QFloat(tensor) => tensor.num_dims(),
+        }
+    }
 }
 
 /// Tensor metadata trait for tensor primitive.
@@ -53,6 +60,11 @@ pub trait TensorMetadata: Clone + Send + Sync + core::fmt::Debug {
     fn dtype(&self) -> DType;
     /// The shape of the tensor.
     fn shape(&self) -> Shape;
+
+    /// The number of dimensions of the tensor.
+    fn num_dims(&self) -> usize {
+        self.shape().num_dims()
+    }
 }
 
 /// A type-level representation of the kind of a tensor.

--- a/crates/burn-tensor/src/tests/ops/reshape.rs
+++ b/crates/burn-tensor/src/tests/ops/reshape.rs
@@ -4,6 +4,15 @@ mod tests {
     use burn_tensor::{Bool, Int, Tensor, TensorData};
 
     #[test]
+    fn should_support_num_dims() {
+        let data = TensorData::from([0.0, 1.0, 2.0]);
+        assert_eq!(data.num_dims(), 1);
+
+        let data = TensorData::from([[0.0, 1.0, 2.0]]);
+        assert_eq!(data.num_dims(), 2);
+    }
+
+    #[test]
     fn should_support_reshape_1d() {
         let data = TensorData::from([0.0, 1.0, 2.0]);
         let tensor = TestTensor::<1>::from_data(data, &Default::default());


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

Explicit `Tensor::num_dims()` api; which doesn't require resolved D param; to avoid `tensor.shape().num_dims()` heap copy.