### PR TITLE
Tensor::<agg>_dims()

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -188,7 +188,7 @@ Those operations are available for all tensor kinds: `Int`, `Float`, and `Bool`.
 Those operations are available for numeric tensor kinds: `Float` and `Int`.
 
 | Burn                                                            | PyTorch Equivalent                             |
-| --------------------------------------------------------------- | ---------------------------------------------- |
+|-----------------------------------------------------------------|------------------------------------------------|
 | `tensor.abs()`                                                  | `torch.abs(tensor)`                            |
 | `tensor.add(other)` or `tensor + other`                         | `tensor + other`                               |
 | `tensor.add_scalar(scalar)` or `tensor + scalar`                | `tensor + scalar`                              |
@@ -222,12 +222,15 @@ Those operations are available for numeric tensor kinds: `Float` and `Int`.
 | `tensor.max_abs()`                                              | `tensor.abs().max()`                           |
 | `tensor.max_abs_dim(dim)`                                       | `tensor.abs().max(dim, keepdim=True)`          |
 | `tensor.max_dim(dim)`                                           | `tensor.max(dim, keepdim=True)`                |
+| `tensor.max_dims(dims)`                                         | `tensor.max(dims, keepdim=True)`               |
 | `tensor.max_dim_with_indices(dim)`                              | N/A                                            |
 | `tensor.max_pair(other)`                                        | `torch.Tensor.max(a,b)`                        |
 | `tensor.mean()`                                                 | `tensor.mean()`                                |
 | `tensor.mean_dim(dim)`                                          | `tensor.mean(dim, keepdim=True)`               |
+| `tensor.mean_dims(dims)`                                        | `tensor.mean(dims, keepdim=True)`              |
 | `tensor.min()`                                                  | `tensor.min()`                                 |
 | `tensor.min_dim(dim)`                                           | `tensor.min(dim, keepdim=True)`                |
+| `tensor.min_dims(dims)`                                         | `tensor.min(dims, keepdim=True)`               |
 | `tensor.min_dim_with_indices(dim)`                              | N/A                                            |
 | `tensor.min_pair(other)`                                        | `torch.Tensor.min(a,b)`                        |
 | `tensor.mul(other)` or `tensor * other`                         | `tensor * other`                               |
@@ -242,6 +245,7 @@ Those operations are available for numeric tensor kinds: `Float` and `Int`.
 | `tensor.powf_scalar(scalar)` or `tensor.powi_scalar(intscalar)` | `tensor.pow(scalar)`                           |
 | `tensor.prod()`                                                 | `tensor.prod()`                                |
 | `tensor.prod_dim(dim)`                                          | `tensor.prod(dim, keepdim=True)`               |
+| `tensor.prod_dims(dims)`                                        | `tensor.prod(dims, keepdim=True)`              |
 | `tensor.rem(other)` or `tensor % other`                         | `tensor % other`                               |
 | `tensor.scatter(dim, indices, values)`                          | `tensor.scatter_add(dim, indices, values)`     |
 | `tensor.sign()`                                                 | `tensor.sign()`                                |
@@ -253,6 +257,7 @@ Those operations are available for numeric tensor kinds: `Float` and `Int`.
 | `tensor.sub_scalar(scalar)` or `tensor - scalar`                | `tensor - scalar`                              |
 | `tensor.sum()`                                                  | `tensor.sum()`                                 |
 | `tensor.sum_dim(dim)`                                           | `tensor.sum(dim, keepdim=True)`                |
+| `tensor.sum_dims(dims)`                                         | `tensor.sum(dims, keepdim=True)`               |
 | `tensor.topk(k, dim)`                                           | `tensor.topk(k, dim).values`                   |
 | `tensor.topk_with_indices(k, dim)`                              | `tensor.topk(k, dim)`                          |
 | `tensor.tril(diagonal)`                                         | `torch.tril(tensor, diagonal)`                 |

--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -221,6 +221,7 @@ Those operations are available for numeric tensor kinds: `Float` and `Int`.
 | `tensor.max()`                                                  | `tensor.max()`                                 |
 | `tensor.max_abs()`                                              | `tensor.abs().max()`                           |
 | `tensor.max_abs_dim(dim)`                                       | `tensor.abs().max(dim, keepdim=True)`          |
+| `tensor.max_abs_dims(dims)`                                     | `tensor.abs().max(dims, keepdim=True)`         |
 | `tensor.max_dim(dim)`                                           | `tensor.max(dim, keepdim=True)`                |
 | `tensor.max_dims(dims)`                                         | `tensor.max(dims, keepdim=True)`               |
 | `tensor.max_dim_with_indices(dim)`                              | N/A                                            |

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -1095,7 +1095,7 @@ where
     ///   // [[5.0, 9.0, 6.0]]
     /// }
     /// ```
-    pub fn max_dim<I: AsIndex>(self, dim: I) -> Tensor<B, D, K> {
+    pub fn max_dim<I: AsIndex>(self, dim: I) -> Self {
         let dim = canonicalize_dim(dim, D, false);
         check!(TensorCheck::aggregate_dim::<D>("Max", dim));
         Tensor::new(K::max_dim(self.primitive, dim))
@@ -1127,7 +1127,7 @@ where
     ///   // [[9.0]]
     /// }
     /// ```
-    pub fn max_dims<I: AsIndex>(self, dims: &[I]) -> Tensor<B, D, K> {
+    pub fn max_dims<I: AsIndex>(self, dims: &[I]) -> Self {
         dims.iter().fold(self, |tensor, &dim| tensor.max_dim(dim))
     }
 
@@ -1151,7 +1151,7 @@ where
     ///    println!("{index}");
     /// }
     /// ```
-    pub fn max_dim_with_indices<I: AsIndex>(self, dim: I) -> (Tensor<B, D, K>, Tensor<B, D, Int>) {
+    pub fn max_dim_with_indices<I: AsIndex>(self, dim: I) -> (Self, Tensor<B, D, Int>) {
         let dim = canonicalize_dim(dim, D, false);
         check!(TensorCheck::aggregate_dim::<D>("Max", dim));
 
@@ -1240,7 +1240,7 @@ where
     ///   // [[5.0, 9.0, 6.0]]
     /// }
     /// ```
-    pub fn max_abs_dim<I: AsIndex>(self, dim: I) -> Tensor<B, D, K> {
+    pub fn max_abs_dim<I: AsIndex>(self, dim: I) -> Self {
         let dim = canonicalize_dim(dim, D, false);
         check!(TensorCheck::aggregate_dim::<D>("MaxAbs", dim));
 
@@ -1273,7 +1273,7 @@ where
     ///   // [[9.0]]
     /// }
     /// ```
-    pub fn max_abs_dims<I: AsIndex>(self, dims: &[I]) -> Tensor<B, D, K> {
+    pub fn max_abs_dims<I: AsIndex>(self, dims: &[I]) -> Self {
         dims.iter()
             .fold(self, |tensor, &dim| tensor.max_abs_dim(dim))
     }
@@ -1344,7 +1344,7 @@ where
     ///    // [[1.0, -2.0, 3.0]]
     /// }
     /// ```
-    pub fn min_dim<I: AsIndex>(self, dim: I) -> Tensor<B, D, K> {
+    pub fn min_dim<I: AsIndex>(self, dim: I) -> Self {
         let dim = canonicalize_dim(dim, D, false);
         check!(TensorCheck::aggregate_dim::<D>("Min", dim));
         Tensor::new(K::min_dim(self.primitive, dim))
@@ -1376,7 +1376,7 @@ where
     ///   // [[-2.0]]
     /// }
     /// ```
-    pub fn min_dims<I: AsIndex>(self, dims: &[I]) -> Tensor<B, D, K> {
+    pub fn min_dims<I: AsIndex>(self, dims: &[I]) -> Self {
         dims.iter().fold(self, |tensor, &dim| tensor.min_dim(dim))
     }
 
@@ -1400,7 +1400,7 @@ where
     ///    // [[1, 0, 0]]
     /// }
     /// ```
-    pub fn min_dim_with_indices<I: AsIndex>(self, dim: I) -> (Tensor<B, D, K>, Tensor<B, D, Int>) {
+    pub fn min_dim_with_indices<I: AsIndex>(self, dim: I) -> (Self, Tensor<B, D, Int>) {
         let dim = canonicalize_dim(dim, D, false);
         check!(TensorCheck::aggregate_dim::<D>("Min", dim));
 
@@ -1846,7 +1846,7 @@ where
     ///   // [[-2.0, 3.0, 12.0], [3.0, 5.0, 6.0]]
     /// }
     /// ```
-    pub fn sort(self, dim: usize) -> Tensor<B, D, K> {
+    pub fn sort(self, dim: usize) -> Self {
         check!(TensorCheck::sort_dim::<D>("Sort", dim));
         Tensor::new(K::sort(self.primitive, dim, /*descending*/ false))
     }
@@ -1880,7 +1880,7 @@ where
     ///    // [[12.0, 3.0, -2.0], [6.0, 5.0, 3.0]]
     /// }
     /// ```
-    pub fn sort_descending(self, dim: usize) -> Tensor<B, D, K> {
+    pub fn sort_descending(self, dim: usize) -> Self {
         check!(TensorCheck::sort_dim::<D>("Sort", dim));
         Tensor::new(K::sort(self.primitive, dim, /*descending*/ true))
     }
@@ -1914,7 +1914,7 @@ where
     ///   // [[1, 0, 0], [0, 1, 1]]
     /// }
     /// ```
-    pub fn sort_with_indices(self, dim: usize) -> (Tensor<B, D, K>, Tensor<B, D, Int>) {
+    pub fn sort_with_indices(self, dim: usize) -> (Self, Tensor<B, D, Int>) {
         check!(TensorCheck::sort_dim::<D>("Sort_with_indices", dim));
         let (values, indices) =
             K::sort_with_indices(self.primitive, dim, /*descending*/ false);
@@ -1946,7 +1946,7 @@ where
     ///    // [[0, 1, 1], [1, 0, 0]]
     /// }
     /// ```
-    pub fn sort_descending_with_indices(self, dim: usize) -> (Tensor<B, D, K>, Tensor<B, D, Int>) {
+    pub fn sort_descending_with_indices(self, dim: usize) -> (Self, Tensor<B, D, Int>) {
         check!(TensorCheck::sort_dim::<D>("Sort_with_indices", dim));
         let (values, indices) = K::sort_with_indices(self.primitive, dim, /*descending*/ true);
         (Tensor::new(values), Tensor::new(indices))
@@ -2036,7 +2036,7 @@ where
     ///   // [[12.0], [6.0]]
     /// }
     /// ```
-    pub fn topk(self, k: usize, dim: usize) -> Tensor<B, D, K> {
+    pub fn topk(self, k: usize, dim: usize) -> Self {
         let k_indices = Tensor::arange(0..k as i64, &self.device());
         self.sort_descending(dim).select(dim, k_indices)
     }
@@ -2070,7 +2070,7 @@ where
     ///    // [[0], [2]]
     /// }
     /// ```
-    pub fn topk_with_indices(self, k: usize, dim: usize) -> (Tensor<B, D, K>, Tensor<B, D, Int>) {
+    pub fn topk_with_indices(self, k: usize, dim: usize) -> (Self, Tensor<B, D, Int>) {
         let k_indices = Tensor::arange(0..k as i64, &self.device());
         let (values, indices) = self.sort_descending_with_indices(dim);
         (
@@ -2113,7 +2113,7 @@ where
         self,
         padding: (usize, usize, usize, usize),
         value: E,
-    ) -> Tensor<B, D, K> {
+    ) -> Self {
         let (left, right, top, bottom) = padding;
 
         let mut padded_dims: [usize; D] = self.dims();
@@ -2248,7 +2248,7 @@ where
     /// ```math
     /// C = AB
     /// ```
-    pub fn matmul(self, other: Tensor<B, D, K>) -> Tensor<B, D, K> {
+    pub fn matmul(self, other: Self) -> Self {
         check!(TensorCheck::matmul(&self, &other));
         Tensor::new(K::matmul(self.primitive, other.primitive))
     }
@@ -4204,7 +4204,7 @@ where
 {
     type Output = Self;
 
-    fn add(self, rhs: Tensor<B, D, K>) -> Self::Output {
+    fn add(self, rhs: Self) -> Self::Output {
         Self::add(self, rhs)
     }
 }
@@ -4248,7 +4248,7 @@ where
 {
     type Output = Self;
 
-    fn sub(self, rhs: Tensor<B, D, K>) -> Self::Output {
+    fn sub(self, rhs: Self) -> Self::Output {
         Tensor::sub(self, rhs)
     }
 }

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -490,6 +490,36 @@ where
         Self::new(K::mean_dim(self.primitive, dim))
     }
 
+    /// Aggregate all elements along the given *axes*
+    /// in the tensor with the mean operation.
+    ///
+    /// # Arguments
+    ///
+    /// * `dims` - the dimensions to aggregate; supports negative indexing.
+    ///
+    /// # Returns
+    ///
+    /// The returned tensor will have the same rank,
+    /// but the aggregated dimensions will have size 1.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use burn_tensor::backend::Backend;
+    /// use burn_tensor::{Tensor, Shape};
+    ///
+    /// fn example<B: Backend>() {
+    ///    let device = B::Device::default();
+    ///    let tensor = Tensor::<B, 2>::from_data([[2.0, 4.0], [6.0, -4.0]], &device);
+    ///    let tensor = tensor.clone().mean_dims(&[0, 1]);
+    ///    println!("{tensor}");
+    ///    // [[2.5]]
+    /// }
+    /// ```
+    pub fn mean_dims<I: AsIndex>(self, dims: &[I]) -> Self {
+        dims.iter().fold(self, |tensor, &dim| tensor.mean_dim(dim))
+    }
+
     /// Aggregate all elements along the given *dimension* or *axis*
     /// in the tensor with the sum operation.
     ///
@@ -521,6 +551,36 @@ where
         Self::new(K::sum_dim(self.primitive, dim))
     }
 
+    /// Aggregate all elements along the given *axes*
+    /// in the tensor with the sum operation.
+    ///
+    /// # Arguments
+    ///
+    /// * `dims` - the dimensions to aggregate; supports negative indexing.
+    ///
+    /// # Returns
+    ///
+    /// The returned tensor will have the same rank,
+    /// but the aggregated dimensions will have size 1.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use burn_tensor::backend::Backend;
+    /// use burn_tensor::{Tensor, Shape};
+    ///
+    /// fn example<B: Backend>() {
+    ///    let device = B::Device::default();
+    ///    let tensor = Tensor::<B, 2>::from_data([[1.0, -2.0, 3.0], [5.0, 9.0, 6.0]], &device);
+    ///    let tensor = tensor.clone().sum_dims(&[0, 1]);
+    ///    println!("{tensor}");
+    ///    // [[27]]
+    /// }
+    /// ```
+    pub fn sum_dims<I: AsIndex>(self, dims: &[I]) -> Self {
+        dims.iter().fold(self, |tensor, &dim| tensor.sum_dim(dim))
+    }
+
     /// Aggregate all elements in the tensor with the product operation.
     ///
     /// # Example
@@ -549,6 +609,11 @@ where
     /// * `dim` - The dimension or axis along which to aggregate the elements,
     ///   supports negative indexing.
     ///
+    /// # Returns
+    ///
+    /// The returned tensor will have the same rank,
+    /// but the aggregated dimension will have size 1.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -570,6 +635,36 @@ where
         let dim = canonicalize_dim(dim, D, false);
         check!(TensorCheck::aggregate_dim::<D>("Prod", dim));
         Self::new(K::prod_dim(self.primitive, dim))
+    }
+
+    /// Aggregate all elements along the given *axes*
+    /// in the tensor with the prod operation.
+    ///
+    /// # Arguments
+    ///
+    /// * `dims` - the dimensions to aggregate, supports negative indexing.
+    ///
+    /// # Returns
+    ///
+    /// The returned tensor will have the same rank,
+    /// but the aggregated dimensions will have size 1.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use burn_tensor::backend::Backend;
+    /// use burn_tensor::{Tensor, Shape};
+    ///
+    /// fn example<B: Backend>() {
+    ///    let device = B::Device::default();
+    ///    let tensor = Tensor::<B, 2>::from_data([[1.0, -2.0, 3.0], [5.0, 9.0, 6.0]], &device);
+    ///    let tensor = tensor.clone().sum_dims(&[0, 1]);
+    ///    println!("{tensor}");
+    ///    // [[-1620.0]]
+    /// }
+    /// ```
+    pub fn prod_dims<I: AsIndex>(self, dims: &[I]) -> Self {
+        dims.iter().fold(self, |tensor, &dim| tensor.prod_dim(dim))
     }
 
     /// Applies element wise equal comparison and returns a boolean tensor.
@@ -976,6 +1071,16 @@ where
 
     /// Find the maximum value along the given dimension.
     ///
+    /// # Arguments
+    ///
+    /// * `dim` - The dimension or axis along which to aggregate the elements;
+    ///   supports negative indexing.
+    ///
+    /// # Returns
+    ///
+    /// The returned tensor will have the same rank,
+    /// but the aggregated dimension will have size 1.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -994,6 +1099,36 @@ where
         let dim = canonicalize_dim(dim, D, false);
         check!(TensorCheck::aggregate_dim::<D>("Max", dim));
         Tensor::new(K::max_dim(self.primitive, dim))
+    }
+
+    /// Find the maximum value along the given dimensions.
+    ///
+    /// # Arguments
+    ///
+    /// * `dims` - The dimensions or axis along which to aggregate the elements;
+    ///   supports negative indexing.
+    ///
+    /// # Returns
+    ///
+    /// The returned tensor will have the same rank,
+    /// but the aggregated dimensions will have size 1.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use burn_tensor::backend::Backend;
+    /// use burn_tensor::{Tensor, Shape};
+    ///
+    /// fn example<B: Backend>() {
+    ///   let device = B::Device::default();
+    ///   let tensor = Tensor::<B, 2>::from_data([[1.0, -2.0, 3.0], [5.0, 9.0, 6.0]], &device);
+    ///   let tensor = tensor.max_dims(&[0, 1]);
+    ///   println!("{tensor}");
+    ///   // [[9.0]]
+    /// }
+    /// ```
+    pub fn max_dims<I: AsIndex>(self, dims: &[I]) -> Tensor<B, D, K> {
+        dims.iter().fold(self, |tensor, &dim| tensor.max_dim(dim))
     }
 
     /// Find the maximum value along the given dimension.
@@ -1081,6 +1216,16 @@ where
 
     /// Find the maximum absolute value along the given dimension.
     ///
+    /// # Arguments
+    ///
+    /// * `dim` - The dimension or axis along which to aggregate the elements,
+    ///   supports negative indexing.
+    ///
+    /// # Returns
+    ///
+    /// The returned tensor will have the same rank,
+    /// but the aggregated dimension will have size 1.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -1100,6 +1245,37 @@ where
         check!(TensorCheck::aggregate_dim::<D>("MaxAbs", dim));
 
         Tensor::new(K::max_abs_dim(self.primitive, dim))
+    }
+
+    /// Find the maximum absolute value along the given dimensions.
+    ///
+    /// # Arguments
+    ///
+    /// * `dims` - The dimensions or axes along which to aggregate the elements,
+    ///   supports negative indexing.
+    ///
+    /// # Returns
+    ///
+    /// The returned tensor will have the same rank,
+    /// but the aggregated dimensions will have size 1.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use burn_tensor::backend::Backend;
+    /// use burn_tensor::{Tensor, Shape};
+    ///
+    /// fn example<B: Backend>() {
+    ///   let device = B::Device::default();
+    ///   let tensor = Tensor::<B, 2>::from_data([[1.0, -2.0, 3.0], [5.0, 9.0, 6.0]], &device);
+    ///   let tensor = tensor.max_abs_dims(&[0, 1]);
+    ///   println!("{tensor}");
+    ///   // [[9.0]]
+    /// }
+    /// ```
+    pub fn max_abs_dims<I: AsIndex>(self, dims: &[I]) -> Tensor<B, D, K> {
+        dims.iter()
+            .fold(self, |tensor, &dim| tensor.max_abs_dim(dim))
     }
 
     /// Applies the argmin function along the given dimension and returns an integer tensor.
@@ -1144,6 +1320,16 @@ where
 
     /// Find the minimum value along the given dimension.
     ///
+    /// # Arguments
+    ///
+    /// * `dim` - The dimension or axis along which to aggregate the elements;
+    ///   supports negative indexing.
+    ///
+    /// # Returns
+    ///
+    /// The returned tensor will have the same rank,
+    /// but the aggregated dimension will have size 1.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -1162,6 +1348,36 @@ where
         let dim = canonicalize_dim(dim, D, false);
         check!(TensorCheck::aggregate_dim::<D>("Min", dim));
         Tensor::new(K::min_dim(self.primitive, dim))
+    }
+
+    /// Find the minimum value along the given dimensions.
+    ///
+    /// # Arguments
+    ///
+    /// * `dims` - The dimensions or axes along which to aggregate the elements;
+    ///   supports negative indexing.
+    ///
+    /// # Returns
+    ///
+    /// The returned tensor will have the same rank,
+    /// but the aggregated dimensions will have size 1.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use burn_tensor::backend::Backend;
+    /// use burn_tensor::{Tensor, Shape};
+    ///
+    /// fn example<B: Backend>() {
+    ///   let device = B::Device::default();
+    ///   let tensor = Tensor::<B, 2>::from_data([[1.0, -2.0, 3.0], [5.0, 9.0, 6.0]], &device);
+    ///   let tensor = tensor.min_dims(&[0, 1]);
+    ///   println!("{tensor}");
+    ///   // [[-2.0]]
+    /// }
+    /// ```
+    pub fn min_dims<I: AsIndex>(self, dims: &[I]) -> Tensor<B, D, K> {
+        dims.iter().fold(self, |tensor, &dim| tensor.min_dim(dim))
     }
 
     /// Find the minimum value along the given dimension.

--- a/crates/burn-tensor/src/tests/ops/aggregation.rs
+++ b/crates/burn-tensor/src/tests/ops/aggregation.rs
@@ -265,6 +265,30 @@ mod tests {
     }
 
     #[test]
+    fn test_sum_dims_2d() {
+        let tensor =
+            TestTensor::<2>::from_floats([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]], &Default::default());
+
+        tensor
+            .clone()
+            .sum_dims(&[1])
+            .to_data()
+            .assert_eq(&TensorData::from([[3.], [12.]]), false);
+
+        tensor
+            .clone()
+            .sum_dims(&[-1])
+            .to_data()
+            .assert_eq(&TensorData::from([[3.], [12.]]), false);
+
+        tensor
+            .clone()
+            .sum_dims(&[0, 1])
+            .to_data()
+            .assert_eq(&TensorData::from([[15.]]), false);
+    }
+
+    #[test]
     fn test_sum_dim_1_reshape_maybe_fused() {
         let tensor = TestTensorInt::arange(0..9, &Default::default()).float();
         TestBackend::sync(&tensor.device());
@@ -438,5 +462,29 @@ mod tests {
         output
             .into_data()
             .assert_approx_eq::<FT>(&expected, Tolerance::default());
+    }
+
+    #[test]
+    fn test_mean_dims_2d() {
+        let tensor =
+            TestTensor::<2>::from_floats([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]], &Default::default());
+
+        tensor
+            .clone()
+            .mean_dims(&[1])
+            .to_data()
+            .assert_eq(&TensorData::from([[1.], [4.]]), false);
+
+        tensor
+            .clone()
+            .mean_dims(&[-1])
+            .to_data()
+            .assert_eq(&TensorData::from([[1.], [4.]]), false);
+
+        tensor
+            .clone()
+            .mean_dims(&[0, 1])
+            .to_data()
+            .assert_eq(&TensorData::from([[2.5]]), false);
     }
 }

--- a/crates/burn-tensor/src/tests/ops/maxmin.rs
+++ b/crates/burn-tensor/src/tests/ops/maxmin.rs
@@ -246,6 +246,30 @@ mod tests {
     }
 
     #[test]
+    fn test_max_abs_dims_2d() {
+        let tensor =
+            TestTensor::<2>::from_floats([[0., 1., -2.], [-5., 6., 1.]], &Default::default());
+
+        tensor
+            .clone()
+            .max_abs_dims(&[0])
+            .into_data()
+            .assert_eq(&TensorData::from([[5., 6., 2.]]), false);
+
+        tensor
+            .clone()
+            .max_abs_dims(&[-2])
+            .into_data()
+            .assert_eq(&TensorData::from([[5., 6., 2.]]), false);
+
+        tensor
+            .clone()
+            .max_abs_dims(&[0, 1])
+            .into_data()
+            .assert_eq(&TensorData::from([[6.]]), false);
+    }
+
+    #[test]
     fn test_max_abs_dim_2d_dim_1() {
         let tensor =
             TestTensor::<2>::from_floats([[0., 1., -2.], [-5., 6., 1.]], &Default::default());

--- a/crates/burn-tensor/src/tests/ops/maxmin.rs
+++ b/crates/burn-tensor/src/tests/ops/maxmin.rs
@@ -39,6 +39,27 @@ mod tests {
     }
 
     #[test]
+    fn test_max_dims_2d() {
+        let f =
+            TestTensor::<2>::from_floats([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]], &Default::default());
+
+        f.clone()
+            .max_dims(&[0])
+            .into_data()
+            .assert_eq(&TensorData::from([[3., 4., 5.]]), false);
+
+        f.clone()
+            .max_dims(&[-2])
+            .into_data()
+            .assert_eq(&TensorData::from([[3., 4., 5.]]), false);
+
+        f.clone()
+            .max_dims(&[0, 1])
+            .into_data()
+            .assert_eq(&TensorData::from([[5.]]), false);
+    }
+
+    #[test]
     fn test_max_dim_with_indices_2d_with_dim_0th() {
         let tensor =
             TestTensor::<2>::from_floats([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]], &Default::default());
@@ -122,6 +143,27 @@ mod tests {
             .min_dim(1)
             .into_data()
             .assert_eq(&TensorData::from([[0], [3]]).into(), false);
+    }
+
+    #[test]
+    fn test_min_dims_2d() {
+        let f =
+            TestTensor::<2>::from_floats([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]], &Default::default());
+
+        f.clone()
+            .min_dims(&[0])
+            .into_data()
+            .assert_eq(&TensorData::from([[0., 1., 2.]]), false);
+
+        f.clone()
+            .min_dims(&[-2])
+            .into_data()
+            .assert_eq(&TensorData::from([[0., 1., 2.]]), false);
+
+        f.clone()
+            .min_dims(&[0, 1])
+            .into_data()
+            .assert_eq(&TensorData::from([[0.]]), false);
     }
 
     #[test]

--- a/crates/burn-tensor/src/tests/ops/prod.rs
+++ b/crates/burn-tensor/src/tests/ops/prod.rs
@@ -13,4 +13,39 @@ mod tests {
             .into_data()
             .assert_eq(&TensorData::from([-600.0]), false);
     }
+
+    #[test]
+    fn test_prod_dim_2d() {
+        let f = TestTensor::<2>::from([[-5.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+
+        f.clone()
+            .prod_dim(1)
+            .into_data()
+            .assert_eq(&TensorData::from([[-10.0], [60.0]]), false);
+
+        f.clone()
+            .prod_dim(-1)
+            .into_data()
+            .assert_eq(&TensorData::from([[-10.0], [60.0]]), false);
+    }
+
+    #[test]
+    fn test_prod_dims_2d() {
+        let f = TestTensor::<2>::from([[-5.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+
+        f.clone()
+            .prod_dims(&[1])
+            .into_data()
+            .assert_eq(&TensorData::from([[-10.0], [60.0]]), false);
+
+        f.clone()
+            .prod_dims(&[-1])
+            .into_data()
+            .assert_eq(&TensorData::from([[-10.0], [60.0]]), false);
+
+        f.clone()
+            .prod_dims(&[0, 1])
+            .into_data()
+            .assert_eq(&TensorData::from([[-600.0]]), false);
+    }
 }


### PR DESCRIPTION
- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

- `Tensor::sum_dims`
- `Tensor::mean_dims`
- `Tensor::max_dims`
- `Tensor::min_dims`
- `Tensor::prod_dims`
- `Tensor::max_abs_dims`

Improved docs for `Tensor::<agg>_dim` methods.
Unified to use `Self` in numeric ops where appropriate.