### PR TITLE
Add ModernBERT-base model check crate

### DIFF
--- a/crates/burn-import/model-checks/modernbert-base/Cargo.toml
+++ b/crates/burn-import/model-checks/modernbert-base/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "burn-import-model-checks-modernbert-base"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[workspace]
+
+[features]
+default = ["tch"]
+ndarray = []
+tch = []
+wgpu = []
+metal = []
+
+[dependencies]
+burn = { path = "../../../../crates/burn", features = [
+    "ndarray",
+    "tch",
+    "wgpu",
+    "metal",
+] }
+burn-import = { path = "../../../burn-import", features = ["pytorch"] }
+
+[build-dependencies]
+burn-import = { path = "../../../burn-import" }

--- a/crates/burn-import/model-checks/modernbert-base/README.md
+++ b/crates/burn-import/model-checks/modernbert-base/README.md
@@ -1,0 +1,72 @@
+# ModernBERT-base Model Check
+
+This crate provides testing for the ModernBERT-base model with Burn.
+
+## Model
+
+- `ModernBERT-base` - Modern BERT variant from Answer.AI
+  (https://huggingface.co/answerdotai/ModernBERT-base)
+
+## Usage
+
+### 1. Download and prepare the model
+
+```bash
+# Using Python directly
+python get_model.py
+
+# Or using uv
+uv run get_model.py
+```
+
+**Note:** This will download the model from HuggingFace and export it to ONNX format using PyTorch.
+Make sure you have the `transformers` library installed.
+
+### 2. Build and run the model test
+
+```bash
+# Build the model
+cargo build
+
+# Run the test
+cargo run --release
+```
+
+## Directory Structure
+
+```
+modernbert-base/
+├── artifacts/                         # Downloaded ONNX model and test data
+│   ├── modernbert-base_opset16.onnx
+│   ├── test_data.pt
+│   └── model-python.txt
+├── src/
+│   └── main.rs                        # Test runner
+├── build.rs                           # Build script that generates model code
+├── get_model.py                       # Model download and ONNX export script
+├── Cargo.toml
+└── README.md
+```
+
+## Model Architecture
+
+ModernBERT is a modern variant of BERT designed by Answer.AI with improved efficiency and
+performance. It features several architectural improvements over the original BERT, including better
+positional embeddings and optimized attention mechanisms.
+
+- **Inputs**:
+  - `input_ids`: Token IDs (shape: [batch_size, sequence_length])
+  - `attention_mask`: Attention mask (shape: [batch_size, sequence_length])
+
+- **Outputs**:
+  - `last_hidden_state`: Sequence of hidden states (shape: [batch_size, sequence_length, 768])
+  - `pooled_output`: Mean-pooled sentence embeddings (computed, shape: [batch_size, 768])
+
+## Notes
+
+- The default sequence length is 512 tokens
+- The model has a hidden size of 768
+- The model uses ONNX opset 16
+- Test data is generated with random inputs for reproducibility (seed=42)
+- Vocabulary size: 50,368 tokens
+- The pooled output is computed using mean pooling over the last hidden state

--- a/crates/burn-import/model-checks/modernbert-base/build.rs
+++ b/crates/burn-import/model-checks/modernbert-base/build.rs
@@ -1,0 +1,32 @@
+use burn_import::onnx::ModelGen;
+use std::path::Path;
+
+fn main() {
+    let onnx_path = "artifacts/modernbert-base_opset16.onnx";
+    let test_data_path = "artifacts/test_data.pt";
+
+    // Tell Cargo to only rebuild if these files change
+    println!("cargo:rerun-if-changed={}", onnx_path);
+    println!("cargo:rerun-if-changed={}", test_data_path);
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // Check if the ONNX model file exists
+    if !Path::new(onnx_path).exists() {
+        eprintln!("Error: ONNX model file not found at '{}'", onnx_path);
+        eprintln!();
+        eprintln!("Please run the following command to download and prepare the model:");
+        eprintln!("  python get_model.py");
+        eprintln!();
+        eprintln!("Or if you prefer using uv:");
+        eprintln!("  uv run get_model.py");
+        eprintln!();
+        eprintln!("This will download the ModernBERT-base model and convert it to ONNX format.");
+        std::process::exit(1);
+    }
+
+    // Generate the model code from the ONNX file
+    ModelGen::new()
+        .input(onnx_path)
+        .out_dir("model/")
+        .run_from_script();
+}

--- a/crates/burn-import/model-checks/modernbert-base/get_model.py
+++ b/crates/burn-import/model-checks/modernbert-base/get_model.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env -S uv run --script
+
+# /// script
+# dependencies = [
+#   "onnx==1.19.0",
+#   "onnxruntime>=1.22.0",
+#   "huggingface-hub>=0.20.0",
+#   "numpy",
+#   "torch",
+#   "transformers>=4.46.0",
+# ]
+# ///
+
+import os
+import sys
+import onnx
+from onnx import shape_inference, version_converter
+import numpy as np
+from pathlib import Path
+from huggingface_hub import hf_hub_download
+
+
+def download_modernbert_model(output_path):
+    """Download ModernBERT-base model from Hugging Face and export to ONNX."""
+    print("Downloading ModernBERT-base model from Hugging Face...")
+
+    try:
+        import torch
+        from transformers import AutoModel, AutoTokenizer
+
+        # Download the model
+        model_name = "answerdotai/ModernBERT-base"
+        print(f"  Loading {model_name}...")
+        model = AutoModel.from_pretrained(model_name, cache_dir="./artifacts/cache")
+        tokenizer = AutoTokenizer.from_pretrained(model_name, cache_dir="./artifacts/cache")
+
+        # Set model to evaluation mode
+        model.eval()
+
+        # Create dummy input
+        dummy_text = "This is a test sentence."
+        inputs = tokenizer(
+            dummy_text, return_tensors="pt", padding="max_length", max_length=512
+        )
+
+        # Export to ONNX
+        print(f"  Exporting model to ONNX...")
+        torch.onnx.export(
+            model,
+            (inputs["input_ids"], inputs["attention_mask"]),
+            str(output_path),
+            input_names=["input_ids", "attention_mask"],
+            output_names=["last_hidden_state"],
+            dynamic_axes={
+                "input_ids": {0: "batch", 1: "sequence"},
+                "attention_mask": {0: "batch", 1: "sequence"},
+                "last_hidden_state": {0: "batch", 1: "sequence"},
+            },
+            opset_version=16,
+        )
+
+        print(f"✓ Model exported to ONNX: {output_path}")
+
+    except ImportError as e:
+        print(f"\n✗ Error: Missing required package.")
+        print(f"  {str(e)}")
+        print("\nPlease install transformers:")
+        print("  uv pip install transformers")
+        sys.exit(1)
+
+
+def process_model(input_path, output_path, target_opset=16):
+    """Load, upgrade opset, and apply shape inference to model."""
+    print(f"Loading model from {input_path}...")
+    model = onnx.load(input_path)
+
+    # Check and upgrade opset if needed
+    current_opset = model.opset_import[0].version
+    if current_opset < target_opset:
+        print(f"Upgrading opset from {current_opset} to {target_opset}...")
+        model = version_converter.convert_version(model, target_opset)
+
+    # Apply shape inference
+    print("Applying shape inference...")
+    model = shape_inference.infer_shapes(model)
+
+    # Save processed model
+    onnx.save(model, output_path)
+    print(f"✓ Processed model saved to: {output_path}")
+
+    return model
+
+
+def get_input_info(model):
+    """Extract input information from ONNX model."""
+    inputs = []
+    for input_info in model.graph.input:
+        shape = []
+        for dim in input_info.type.tensor_type.shape.dim:
+            if dim.HasField("dim_value"):
+                shape.append(dim.dim_value)
+            else:
+                # Use proper defaults for ModernBERT
+                if (
+                    "input_ids" in input_info.name
+                    or "attention_mask" in input_info.name
+                ):
+                    # Default sequence length
+                    shape.append(1 if len(shape) == 0 else 512)
+                else:
+                    shape.append(1)  # Default to 1 for other dynamic dimensions
+        inputs.append(
+            {
+                "name": input_info.name,
+                "shape": shape,
+                "dtype": input_info.type.tensor_type.elem_type,
+            }
+        )
+    return inputs
+
+
+def generate_test_data(model_path, output_dir):
+    """Generate test input/output data and save as PyTorch tensors."""
+    import torch
+    import onnxruntime as ort
+
+    print("\nGenerating test data...")
+
+    # Load model to get input shapes
+    model = onnx.load(model_path)
+    input_infos = get_input_info(model)
+
+    print(f"  Model has {len(input_infos)} inputs:")
+    for info in input_infos:
+        print(f"    - {info['name']}: shape={info['shape']}, dtype={info['dtype']}")
+
+    # Create reproducible test inputs
+    np.random.seed(42)
+    test_inputs = {}
+
+    for info in input_infos:
+        if info["dtype"] == onnx.TensorProto.INT64:
+            # Handle different integer inputs appropriately
+            if "attention_mask" in info["name"]:
+                # Attention mask should be 1 for valid tokens, 0 for padding
+                # For testing, use all 1s (all valid tokens)
+                test_input = np.ones(info["shape"], dtype=np.int64)
+            elif "input_ids" in info["name"]:
+                # For input_ids, use random integers in vocabulary range
+                # ModernBERT uses a 50368 vocabulary
+                test_input = np.random.randint(0, 50368, size=info["shape"], dtype=np.int64)
+            else:
+                # For other INT64 inputs, use random integers
+                test_input = np.random.randint(0, 50368, size=info["shape"], dtype=np.int64)
+        else:
+            # For float inputs, use random floats
+            test_input = np.random.rand(*info["shape"]).astype(np.float32)
+        test_inputs[info["name"]] = test_input
+
+    # Run inference to get output
+    session = ort.InferenceSession(model_path)
+    outputs = session.run(None, test_inputs)
+
+    # Save in a format that's easier to load in Rust
+    # For ModernBERT, we expect:
+    # - Inputs: input_ids, attention_mask
+    # - Outputs: last_hidden_state (3D)
+
+    # Compute mean pooled output
+    last_hidden_state = outputs[0]
+    attention_mask_np = test_inputs.get("attention_mask")
+
+    # Mean pooling - take attention mask into account for correct averaging
+    input_mask_expanded = np.expand_dims(attention_mask_np, axis=-1).astype(np.float32)
+    sum_embeddings = np.sum(last_hidden_state * input_mask_expanded, axis=1)
+    sum_mask = np.clip(np.sum(input_mask_expanded, axis=1), a_min=1e-9, a_max=None)
+    pooled_output = sum_embeddings / sum_mask
+
+    # Create a more structured format for Rust
+    test_data = {
+        "input_ids": torch.from_numpy(
+            test_inputs.get(
+                "input_ids", test_inputs.get("inputs.0", list(test_inputs.values())[0])
+            )
+        ),
+        "attention_mask": torch.from_numpy(
+            test_inputs.get(
+                "attention_mask",
+                test_inputs.get("inputs.1", list(test_inputs.values())[1]),
+            )
+        ),
+        "last_hidden_state": torch.from_numpy(outputs[0]),
+        "pooled_output": torch.from_numpy(pooled_output),
+    }
+
+    test_data_path = Path(output_dir) / "test_data.pt"
+    torch.save(test_data, test_data_path)
+
+    print(f"  ✓ Test data saved to: {test_data_path}")
+    print(f"    Input shapes:")
+    print(f"      input_ids: {test_data['input_ids'].shape}")
+    print(f"      attention_mask: {test_data['attention_mask'].shape}")
+    print(f"    Output shapes:")
+    print(f"      last_hidden_state: {test_data['last_hidden_state'].shape}")
+    print(f"      pooled_output: {test_data['pooled_output'].shape}")
+
+
+def save_model_info(model_path, output_dir):
+    """Save model structure information to a text file."""
+    print("\nSaving model information...")
+
+    model = onnx.load(model_path)
+
+    info_path = Path(output_dir) / "model-python.txt"
+    with open(info_path, "w") as f:
+        f.write("ModernBERT-base Model Information\n")
+        f.write("=" * 60 + "\n\n")
+
+        # Input information
+        f.write("Inputs:\n")
+        for input_info in model.graph.input:
+            f.write(f"  - {input_info.name}\n")
+            shape = []
+            for dim in input_info.type.tensor_type.shape.dim:
+                if dim.HasField("dim_value"):
+                    shape.append(dim.dim_value)
+                else:
+                    shape.append("dynamic")
+            f.write(f"    Shape: {shape}\n")
+            f.write(
+                f"    Type: {onnx.TensorProto.DataType.Name(input_info.type.tensor_type.elem_type)}\n"
+            )
+
+        # Output information
+        f.write("\nOutputs:\n")
+        for output_info in model.graph.output:
+            f.write(f"  - {output_info.name}\n")
+            shape = []
+            for dim in output_info.type.tensor_type.shape.dim:
+                if dim.HasField("dim_value"):
+                    shape.append(dim.dim_value)
+                else:
+                    shape.append("dynamic")
+            f.write(f"    Shape: {shape}\n")
+            f.write(
+                f"    Type: {onnx.TensorProto.DataType.Name(output_info.type.tensor_type.elem_type)}\n"
+            )
+
+        # Model statistics
+        f.write(f"\nModel Statistics:\n")
+        f.write(f"  Opset version: {model.opset_import[0].version}\n")
+        f.write(f"  Number of nodes: {len(model.graph.node)}\n")
+        f.write(f"  Number of initializers: {len(model.graph.initializer)}\n")
+
+        # Node types summary
+        node_types = {}
+        for node in model.graph.node:
+            op_type = node.op_type
+            node_types[op_type] = node_types.get(op_type, 0) + 1
+
+        f.write(f"\nNode types:\n")
+        for op_type, count in sorted(node_types.items()):
+            f.write(f"  {op_type}: {count}\n")
+
+    print(f"  ✓ Model info saved to: {info_path}")
+
+
+def main():
+    print("=" * 60)
+    print("ModernBERT-base Model Preparation Tool")
+    print("=" * 60)
+
+    # Setup paths
+    artifacts_dir = Path("artifacts")
+    artifacts_dir.mkdir(exist_ok=True)
+
+    original_path = artifacts_dir / "modernbert-base.onnx"
+    processed_path = artifacts_dir / "modernbert-base_opset16.onnx"
+    test_data_path = artifacts_dir / "test_data.pt"
+    model_info_path = artifacts_dir / "model-python.txt"
+
+    # Check if we already have everything
+    if processed_path.exists() and test_data_path.exists() and model_info_path.exists():
+        print(f"\n✓ All files already exist:")
+        print(f"  Model: {processed_path}")
+        print(f"  Test data: {test_data_path}")
+        print(f"  Model info: {model_info_path}")
+        print("\nNothing to do!")
+        return
+
+    # Download and export model if needed
+    if not original_path.exists() and not processed_path.exists():
+        print("\nStep 1: Downloading and exporting ModernBERT-base model...")
+        download_modernbert_model(original_path)
+
+    # Process model if needed (already at opset 16, but apply shape inference)
+    if not processed_path.exists():
+        if original_path.exists():
+            print("\nStep 2: Processing model...")
+            process_model(original_path, processed_path, target_opset=16)
+
+            # Clean up original if we have the processed version
+            if original_path.exists() and processed_path.exists():
+                original_path.unlink()
+
+    # Generate test data if needed
+    if not test_data_path.exists():
+        print("\nStep 3: Generating test data...")
+        generate_test_data(processed_path, artifacts_dir)
+
+    # Save model info if needed
+    if not model_info_path.exists():
+        print("\nStep 4: Saving model information...")
+        save_model_info(processed_path, artifacts_dir)
+
+    print("\n" + "=" * 60)
+    print("✓ ModernBERT-base model preparation completed!")
+    print(f"  Model: {processed_path}")
+    print(f"  Test data: {test_data_path}")
+    print(f"  Model info: {model_info_path}")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("\n⚠ Operation cancelled by user.")
+        sys.exit(1)
+    except Exception as e:
+        print(f"\n✗ Error: {str(e)}")
+        import traceback
+
+        traceback.print_exc()
+        sys.exit(1)

--- a/crates/burn-import/model-checks/modernbert-base/src/main.rs
+++ b/crates/burn-import/model-checks/modernbert-base/src/main.rs
@@ -1,0 +1,258 @@
+extern crate alloc;
+
+use burn::module::Param;
+use burn::prelude::*;
+use burn::record::*;
+
+use burn_import::pytorch::PyTorchFileRecorder;
+use std::path::Path;
+use std::time::Instant;
+
+#[cfg(feature = "wgpu")]
+pub type MyBackend = burn::backend::Wgpu;
+
+#[cfg(feature = "ndarray")]
+pub type MyBackend = burn::backend::NdArray<f32>;
+
+#[cfg(feature = "tch")]
+pub type MyBackend = burn::backend::LibTorch<f32>;
+
+#[cfg(feature = "metal")]
+pub type MyBackend = burn::backend::Metal;
+
+// Import the generated model code as a module
+pub mod modernbert_base {
+    include!(concat!(
+        env!("OUT_DIR"),
+        "/model/modernbert-base_opset16.rs"
+    ));
+}
+
+#[derive(Debug, Module)]
+struct TestData<B: Backend> {
+    input_ids: Param<Tensor<B, 2, Int>>,
+    attention_mask: Param<Tensor<B, 2, Int>>,
+    last_hidden_state: Param<Tensor<B, 3>>,
+    pooled_output: Param<Tensor<B, 2>>,
+}
+
+/// Apply mean pooling to get sentence embeddings
+fn mean_pool<B: Backend>(
+    last_hidden_state: Tensor<B, 3>,
+    attention_mask: Tensor<B, 2, Int>,
+) -> Tensor<B, 2> {
+    // Convert attention_mask to float and expand dimensions to match hidden_state
+    let attention_mask_float = attention_mask.float().unsqueeze_dim::<3>(2);
+
+    // Multiply hidden states by attention mask
+    let masked_embeddings = last_hidden_state * attention_mask_float.clone();
+
+    // Sum along sequence dimension (dim 1)
+    let sum_embeddings = masked_embeddings.sum_dim(1);
+
+    // Sum attention mask to get count of non-padding tokens
+    let sum_mask = attention_mask_float.sum_dim(1).clamp_min(1e-9);
+
+    // Divide to get mean - result is [batch, 1, hidden]
+    let pooled = sum_embeddings / sum_mask;
+
+    // Get the shape to reshape to [batch, hidden]
+    let shape = pooled.shape();
+    let batch_size = shape.dims[0];
+    let hidden_size = shape.dims[2];
+
+    pooled.reshape([batch_size, hidden_size])
+}
+
+fn main() {
+    println!("========================================");
+    println!("ModernBERT-base Burn Model Test");
+    println!("========================================\n");
+
+    // Check if artifacts exist
+    let artifacts_dir = Path::new("artifacts");
+    if !artifacts_dir.exists() {
+        eprintln!("Error: artifacts directory not found!");
+        eprintln!("Please run get_model.py first to download the model and test data.");
+        std::process::exit(1);
+    }
+
+    // Initialize the model (using default which includes the converted weights)
+    println!("Initializing ModernBERT-base model...");
+    let start = Instant::now();
+    let device = Default::default();
+    let model: modernbert_base::Model<MyBackend> = modernbert_base::Model::default();
+    let init_time = start.elapsed();
+    println!("  Model initialized in {:.2?}", init_time);
+
+    // Save model structure to file
+    println!("\nSaving model structure to artifacts/model.txt...");
+    let model_str = format!("{}", model);
+    std::fs::write("artifacts/model.txt", &model_str)
+        .expect("Failed to write model structure to file");
+    println!("  Model structure saved");
+
+    // Load test data from PyTorch file
+    println!("\nLoading test data from artifacts/test_data.pt...");
+    let start = Instant::now();
+    let test_data: TestDataRecord<MyBackend> = PyTorchFileRecorder::<FullPrecisionSettings>::new()
+        .load("artifacts/test_data.pt".into(), &device)
+        .expect("Failed to load test data");
+    let load_time = start.elapsed();
+    println!("  Data loaded in {:.2?}", load_time);
+
+    // Get the input tensors from test data
+    let input_ids = test_data.input_ids.val();
+    let attention_mask = test_data.attention_mask.val();
+    let input_ids_shape = input_ids.shape();
+    let attention_mask_shape = attention_mask.shape();
+    println!("  Loaded input_ids with shape: {:?}", input_ids_shape.dims);
+    println!(
+        "  Loaded attention_mask with shape: {:?}",
+        attention_mask_shape.dims
+    );
+
+    // Get the reference outputs from test data
+    let reference_last_hidden_state = test_data.last_hidden_state.val();
+    let reference_pooled_output = test_data.pooled_output.val();
+    let ref_last_hidden_shape = reference_last_hidden_state.shape();
+    let ref_pooled_shape = reference_pooled_output.shape();
+    println!(
+        "  Loaded reference last_hidden_state with shape: {:?}",
+        ref_last_hidden_shape.dims
+    );
+    println!(
+        "  Loaded reference pooled_output with shape: {:?}",
+        ref_pooled_shape.dims
+    );
+
+    // Run inference with the loaded input
+    println!("\nRunning model inference with test input...");
+    let start = Instant::now();
+
+    let last_hidden_state = model.forward(input_ids.clone(), attention_mask.clone());
+
+    let inference_time = start.elapsed();
+    println!("  Inference completed in {:.2?}", inference_time);
+
+    // Compute pooled output (mean pooling)
+    println!("\nComputing pooled output (mean pooling)...");
+    let start = Instant::now();
+    let pooled_output = mean_pool(last_hidden_state.clone(), attention_mask.clone());
+    let pooling_time = start.elapsed();
+    println!("  Pooling completed in {:.2?}", pooling_time);
+
+    // Display output shapes
+    let last_hidden_shape = last_hidden_state.shape();
+    let pooled_shape = pooled_output.shape();
+    println!("\n  Model output shapes:");
+    println!("    last_hidden_state: {:?}", last_hidden_shape.dims);
+    println!("    pooled_output: {:?}", pooled_shape.dims);
+
+    // Verify expected output shapes match
+    if last_hidden_shape.dims == ref_last_hidden_shape.dims {
+        println!(
+            "  ✓ last_hidden_state shape matches expected: {:?}",
+            ref_last_hidden_shape.dims
+        );
+    } else {
+        println!(
+            "  ⚠ Warning: Expected last_hidden_state shape {:?}, got {:?}",
+            ref_last_hidden_shape.dims, last_hidden_shape.dims
+        );
+    }
+
+    if pooled_shape.dims == ref_pooled_shape.dims {
+        println!(
+            "  ✓ pooled_output shape matches expected: {:?}",
+            ref_pooled_shape.dims
+        );
+    } else {
+        println!(
+            "  ⚠ Warning: Expected pooled_output shape {:?}, got {:?}",
+            ref_pooled_shape.dims, pooled_shape.dims
+        );
+    }
+
+    // Compare outputs
+    println!("\nComparing model outputs with reference data...");
+
+    // Check if last_hidden_state is close
+    println!("\n  Checking last_hidden_state:");
+    if last_hidden_state.clone().all_close(
+        reference_last_hidden_state.clone(),
+        Some(1e-4),
+        Some(1e-4),
+    ) {
+        println!("    ✓ last_hidden_state matches reference data within tolerance (1e-4)!");
+    } else {
+        println!("    ⚠ last_hidden_state differs from reference data!");
+
+        // Calculate and display the difference statistics
+        let diff = last_hidden_state.clone() - reference_last_hidden_state.clone();
+        let abs_diff = diff.abs();
+        let max_diff = abs_diff.clone().max().into_scalar();
+        let mean_diff = abs_diff.mean().into_scalar();
+
+        println!("    Maximum absolute difference: {:.6}", max_diff);
+        println!("    Mean absolute difference: {:.6}", mean_diff);
+
+        // Show some sample values for debugging
+        println!("\n    Sample values comparison (first 5 elements):");
+        let output_flat = last_hidden_state.clone().flatten::<1>(0, 2);
+        let reference_flat = reference_last_hidden_state.clone().flatten::<1>(0, 2);
+
+        for i in 0..5.min(output_flat.dims()[0]) {
+            let model_val: f32 = output_flat.clone().slice(s![i..i + 1]).into_scalar();
+            let ref_val: f32 = reference_flat.clone().slice(s![i..i + 1]).into_scalar();
+            println!(
+                "      [{}] Model: {:.6}, Reference: {:.6}, Diff: {:.6}",
+                i,
+                model_val,
+                ref_val,
+                (model_val - ref_val).abs()
+            );
+        }
+    }
+
+    // Check if pooled_output is close
+    println!("\n  Checking pooled_output:");
+    if pooled_output
+        .clone()
+        .all_close(reference_pooled_output.clone(), Some(1e-4), Some(1e-4))
+    {
+        println!("    ✓ pooled_output matches reference data within tolerance (1e-4)!");
+    } else {
+        println!("    ⚠ pooled_output differs from reference data!");
+
+        // Calculate and display the difference statistics
+        let diff = pooled_output.clone() - reference_pooled_output.clone();
+        let abs_diff = diff.abs();
+        let max_diff = abs_diff.clone().max().into_scalar();
+        let mean_diff = abs_diff.mean().into_scalar();
+
+        println!("    Maximum absolute difference: {:.6}", max_diff);
+        println!("    Mean absolute difference: {:.6}", mean_diff);
+
+        // Show some sample values for debugging
+        println!("\n    Sample values comparison (first 5 elements):");
+        let output_flat = pooled_output.clone().flatten::<1>(0, 1);
+        let reference_flat = reference_pooled_output.clone().flatten::<1>(0, 1);
+
+        for i in 0..5.min(output_flat.dims()[0]) {
+            let model_val: f32 = output_flat.clone().slice(s![i..i + 1]).into_scalar();
+            let ref_val: f32 = reference_flat.clone().slice(s![i..i + 1]).into_scalar();
+            println!(
+                "      [{}] Model: {:.6}, Reference: {:.6}, Diff: {:.6}",
+                i,
+                model_val,
+                ref_val,
+                (model_val - ref_val).abs()
+            );
+        }
+    }
+
+    println!("\n========================================");
+    println!("Model test completed!");
+    println!("========================================");
+}


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

https://github.com/tracel-ai/burn/issues/3412

### Changes

Introduces a new crate for testing the ModernBERT-base model with Burn. Includes Cargo.toml, a detailed README, a build script for ONNX model code generation, a Python script to download/export the model and generate test data, and a Rust test runner to validate model outputs against reference data.


### Testing

model checks have been tested end-to-end

### Results

tch backend has a slight mismatch:

```
========================================
ModernBERT-base Burn Model Test
========================================

Initializing ModernBERT-base model...
  Model initialized in 167.95ms

Saving model structure to artifacts/model.txt...
  Model structure saved

Loading test data from artifacts/test_data.pt...
  Data loaded in 755.04µs
  Loaded input_ids with shape: [1, 512]
  Loaded attention_mask with shape: [1, 512]
  Loaded reference last_hidden_state with shape: [1, 512, 768]
  Loaded reference pooled_output with shape: [1, 768]

Running model inference with test input...
  Inference completed in 134.29ms

Computing pooled output (mean pooling)...
  Pooling completed in 89.92µs

  Model output shapes:
    last_hidden_state: [1, 512, 768]
    pooled_output: [1, 768]
  ✓ last_hidden_state shape matches expected: [1, 512, 768]
  ✓ pooled_output shape matches expected: [1, 768]

Comparing model outputs with reference data...

  Checking last_hidden_state:
    ⚠ last_hidden_state differs from reference data!
    Maximum absolute difference: 0.007055
    Mean absolute difference: 0.000004

    Sample values comparison (first 5 elements):
      [0] Model: 0.763678, Reference: 0.763678, Diff: 0.000000
      [1] Model: -1.024649, Reference: -1.024651, Diff: 0.000002
      [2] Model: -1.176253, Reference: -1.176251, Diff: 0.000002
      [3] Model: -0.079886, Reference: -0.079884, Diff: 0.000002
      [4] Model: 0.352740, Reference: 0.352740, Diff: 0.000000

  Checking pooled_output:
    ✓ pooled_output matches reference data within tolerance (1e-4)!

========================================
Model test completed!
========================================
```

Ndarray has similar results:

```
========================================
ModernBERT-base Burn Model Test
========================================

Initializing ModernBERT-base model...
  Model initialized in 114.73ms

Saving model structure to artifacts/model.txt...
  Model structure saved

Loading test data from artifacts/test_data.pt...
  Data loaded in 788.25µs
  Loaded input_ids with shape: [1, 512]
  Loaded attention_mask with shape: [1, 512]
  Loaded reference last_hidden_state with shape: [1, 512, 768]
  Loaded reference pooled_output with shape: [1, 768]

Running model inference with test input...
  Inference completed in 1.10s

Computing pooled output (mean pooling)...
  Pooling completed in 256.88µs

  Model output shapes:
    last_hidden_state: [1, 512, 768]
    pooled_output: [1, 768]
  ✓ last_hidden_state shape matches expected: [1, 512, 768]
  ✓ pooled_output shape matches expected: [1, 768]

Comparing model outputs with reference data...

  Checking last_hidden_state:
    ⚠ last_hidden_state differs from reference data!
    Maximum absolute difference: 0.003334
    Mean absolute difference: 0.000002

    Sample values comparison (first 5 elements):
      [0] Model: 0.763675, Reference: 0.763678, Diff: 0.000003
      [1] Model: -1.024649, Reference: -1.024651, Diff: 0.000002
      [2] Model: -1.176249, Reference: -1.176251, Diff: 0.000002
      [3] Model: -0.079885, Reference: -0.079884, Diff: 0.000000
      [4] Model: 0.352740, Reference: 0.352740, Diff: 0.000000

  Checking pooled_output:
    ✓ pooled_output matches reference data within tolerance (1e-4)!

========================================
Model test completed!
========================================

```

Metal backend is failing:

```
========================================
ModernBERT-base Burn Model Test
========================================

Initializing ModernBERT-base model...
  Model initialized in 198.44ms

Saving model structure to artifacts/model.txt...
  Model structure saved

Loading test data from artifacts/test_data.pt...
  Data loaded in 13.19ms
  Loaded input_ids with shape: [1, 512]
  Loaded attention_mask with shape: [1, 512]
  Loaded reference last_hidden_state with shape: [1, 512, 768]
  Loaded reference pooled_output with shape: [1, 768]

Running model inference with test input...

thread 'main' panicked at /Users/dilshod/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wgpu-26.0.1/src/backend/wgpu_core.rs:1055:30:
wgpu error: Validation Error

Caused by:
  In Device::create_shader_module_passthrough, label = 'reduce_kernel_f32_f32_f32'
    Failed to generate the backend-specific code


note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

```