### PR TITLE
Fix `mask_where` broadcasted line size

### DIFF
--- a/crates/burn-cubecl/src/kernel/mask/mask_where.rs
+++ b/crates/burn-cubecl/src/kernel/mask/mask_where.rs
@@ -4,7 +4,7 @@ use crate::{
     BoolElement, CubeRuntime,
     element::CubeElement,
     kernel::utils::{broadcast_shape, linear_view, linear_view_alias, linear_view_ref},
-    ops::{max_line_size, numeric::empty_device},
+    ops::{max_line_size, max_line_size_many, numeric::empty_device},
     tensor::CubeTensor,
 };
 
@@ -46,7 +46,7 @@ pub fn mask_where<R: CubeRuntime, E: CubeElement, BT: BoolElement>(
     strategy: MaskWhereStrategy,
 ) -> CubeTensor<R> {
     let cube_dim = CubeDim::default();
-    let line_size = max_line_size(&input);
+    let line_size = max_line_size_many(&[&input, &mask, &value], input.shape.num_dims() - 1);
     let cube_count =
         calculate_cube_count_elemwise(input.shape.num_elements() / line_size as usize, cube_dim);
 

--- a/crates/burn-tensor/src/tests/ops/mask.rs
+++ b/crates/burn-tensor/src/tests/ops/mask.rs
@@ -96,6 +96,19 @@ mod tests {
     }
 
     #[test]
+    fn should_support_mask_where_broadcast_value_small() {
+        let device = Default::default();
+        let tensor = TestTensorInt::<1>::arange(2..4, &device);
+        let mask = TestTensorBool::<1>::from_bool(TensorData::from([true, false]), &device);
+        let value = TestTensor::<1>::ones([1], &device);
+
+        let output = tensor.float().mask_where(mask, value);
+        let expected = TensorData::from([1., 3.]);
+
+        output.into_data().assert_eq(&expected, false);
+    }
+
+    #[test]
     fn should_handle_mask_where_nans() {
         let device = Default::default();
         let tensor = TestTensor::from_data(


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.

### Related Issues/PRs

Fixes #3807 

### Changes

Select line size based on input, mask and value.

### Testing

Added test.