### PR TITLE
slice_fill() should pick a compatible dtype

### DIFF
--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -2864,7 +2864,11 @@ pub trait BasicOps<B: Backend>: TensorKind<B> {
         let slice_shape_vec = calculate_slice_output_shape(slices, &tensor_shape.dims);
         let slice_shape = Shape::from(slice_shape_vec);
 
-        let value = Self::from_data(TensorData::from([value]), &Self::device(&tensor));
+        let value = Self::from_data_dtype(
+            TensorData::from([value]),
+            &Self::device(&tensor),
+            Self::dtype(&tensor),
+        );
         let value = Self::expand(value, slice_shape);
         Self::slice_assign(tensor, slices, value)
     }


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Encountered `slice_fill()` failing for a F64 tensor.

### Changes

create the fill value tensor with the correct dtype.

### Testing

I need help with the tests, there's conditional availability I don't understand for backend types.