### PR TITLE
Lift constants for ReduceMax and ReduceMean nodes

### DIFF
--- a/crates/onnx-ir/src/from_onnx.rs
+++ b/crates/onnx-ir/src/from_onnx.rs
@@ -19,7 +19,7 @@ use super::rank_inference::rank_inference;
 
 use protobuf::Message;
 
-const LIFT_CONSTANTS_FOR_NODE_TYPES: [NodeType; 28] = [
+const LIFT_CONSTANTS_FOR_NODE_TYPES: [NodeType; 30] = [
     NodeType::BatchNormalization,
     NodeType::Clip,
     NodeType::Conv1d,
@@ -38,6 +38,8 @@ const LIFT_CONSTANTS_FOR_NODE_TYPES: [NodeType; 28] = [
     NodeType::PRelu,
     NodeType::Pad,
     NodeType::Range,
+    NodeType::ReduceMax,
+    NodeType::ReduceMean,
     NodeType::ReduceSum,
     NodeType::Reshape,
     NodeType::Resize,


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [X] Confirmed that `cargo run-checks` command has been executed.
- [X] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

N/A

### Changes

tldr; I added `ReduceMax` and `ReduceMean` nodes to the list of nodes that should check for Constant lifting. 

This was kind of tough to track down. I have a model that has both `ReduceMax` and `ReduceMean`, and for some reason the parsing through `onnx-ir` didn't seem to be working correctly, because both operations were expecting a Tensor, and not a Scalar. Turns out that was a red-herring. The shape inference wasn't working correctly because both these `Reduce*` operations were expecting an input of `Axes` to reduce on. Older versions of the ONNX spec passed `axes` as an Attribute, but newer versions expect axes to be an optional input passed at `inputs[1]`. If we pass axes at `inputs[1]` then `onnx-ir` looks for the actual values of the input at `inputs[1]`, but my model only exports a reference to a `Constant` node.

I think the solution here is to lift that `Constant` node for `ReduceMax` and `ReduceMean` nodes. I made the change and it fixes the parsing issues for my model.

A quick look at the ONNX spec suggests that we this will be an issue for all `Reduce*` operations, but without a model to check I didn't want to add the other `Reduce*` nodes to the list of nodes that require constant lifting.

### Testing

Tested manually on a model that contains both `ReduceMean` and `ReduceMax` nodes to ensure that the `Constant` node that feeds into the `Reduce*` node at position inputs[1] gets lifted into the `Reduce*` node as part of parsing. This resulted in the shape inference giving the expected shape after the `Reduce*` operations.

Ran `cargo run-checks` and got the following errors which look like floating point accuracy errors on my M2 mac:

```
failures:

---- tests::autodiff::ad_div::tests::test_div_complex_2 stdout ----

thread 'tests::autodiff::ad_div::tests::test_div_complex_2' panicked at crates/burn-ndarray/src/lib.rs:42:5:
Tensors are not approx eq:
  => Position 0: 0.08251953 != 0.08333334
     diff (rel = +9.77e-3, abs = +8.14e-4), tol (rel = +5.00e-3, abs = +1.00e-5)
  => Position 2: -0.056803405 != -0.05555558
     diff (rel = +2.20e-2, abs = +1.25e-3), tol (rel = +5.00e-3, abs = +1.00e-5)
  => Position 3: -0.06800783 != -0.06714284
     diff (rel = +1.27e-2, abs = +8.65e-4), tol (rel = +5.00e-3, abs = +1.00e-5)

---- tests::autodiff::ad_log_sigmoid::tests::should_diff_log_sigmoid stdout ----

thread 'tests::autodiff::ad_log_sigmoid::tests::should_diff_log_sigmoid' panicked at crates/burn-ndarray/src/lib.rs:42:5:
Tensors are not approx eq:
  => Position 3: 0.001953125 != 0
     diff (rel = +1.00e0, abs = +1.95e-3), tol (rel = +5.00e-3, abs = +1.00e-5)

---- tests::autodiff_checkpointing::ad_div::tests::test_div_complex_2 stdout ----

thread 'tests::autodiff_checkpointing::ad_div::tests::test_div_complex_2' panicked at crates/burn-ndarray/src/lib.rs:42:5:
Tensors are not approx eq:
  => Position 0: 0.08251953 != 0.08333334
     diff (rel = +9.77e-3, abs = +8.14e-4), tol (rel = +5.00e-3, abs = +1.00e-5)
  => Position 2: -0.056803405 != -0.05555558
     diff (rel = +2.20e-2, abs = +1.25e-3), tol (rel = +5.00e-3, abs = +1.00e-5)
  => Position 3: -0.06800783 != -0.06714284
     diff (rel = +1.27e-2, abs = +8.65e-4), tol (rel = +5.00e-3, abs = +1.00e-5)

---- tests::autodiff_checkpointing::ad_log_sigmoid::tests::should_diff_log_sigmoid stdout ----

thread 'tests::autodiff_checkpointing::ad_log_sigmoid::tests::should_diff_log_sigmoid' panicked at crates/burn-ndarray/src/lib.rs:42:5:
Tensors are not approx eq:
  => Position 3: 0.001953125 != 0
     diff (rel = +1.00e0, abs = +1.95e-3), tol (rel = +5.00e-3, abs = +1.00e-5)


failures:
    tests::autodiff::ad_div::tests::test_div_complex_2
    tests::autodiff::ad_log_sigmoid::tests::should_diff_log_sigmoid
    tests::autodiff_checkpointing::ad_div::tests::test_div_complex_2
    tests::autodiff_checkpointing::ad_log_sigmoid::tests::should_diff_log_sigmoid
```
