### PR TITLE
Fix adaptive avg pool2d backward line size

### DIFF
--- a/crates/burn-autodiff/src/tests/adaptive_avgpool2d.rs
+++ b/crates/burn-autodiff/src/tests/adaptive_avgpool2d.rs
@@ -36,6 +36,36 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn test_avg_pool2d_output_1() {
+        let test = AdaptiveAvgPool2dTestCase {
+            batch_size: 1,
+            channels: 1,
+            height: 4,
+            width: 8,
+            output_size_1: 1,
+            output_size_2: 1,
+        };
+
+        test.assert_output(TestTensor::from_floats(
+            [[[
+                [
+                    0.03125, 0.03125, 0.03125, 0.03125, 0.03125, 0.03125, 0.03125, 0.03125,
+                ],
+                [
+                    0.03125, 0.03125, 0.03125, 0.03125, 0.03125, 0.03125, 0.03125, 0.03125,
+                ],
+                [
+                    0.03125, 0.03125, 0.03125, 0.03125, 0.03125, 0.03125, 0.03125, 0.03125,
+                ],
+                [
+                    0.03125, 0.03125, 0.03125, 0.03125, 0.03125, 0.03125, 0.03125, 0.03125,
+                ],
+            ]]],
+            &Default::default(),
+        ));
+    }
+
     struct AdaptiveAvgPool2dTestCase {
         batch_size: usize,
         channels: usize,

--- a/crates/burn-cubecl/src/kernel/pool/adaptive_avg_pool2d_backward.rs
+++ b/crates/burn-cubecl/src/kernel/pool/adaptive_avg_pool2d_backward.rs
@@ -91,7 +91,7 @@ pub(crate) fn adaptive_avg_pool2d_backward<R: CubeRuntime, E: CubeElement>(
     let [batches, channels, height, width] = x.shape.dims();
 
     let out_grad = into_contiguous(permute_nchw_to_nhwc(out_grad));
-    let line_size = max_line_size(&x);
+    let line_size = max_line_size(&out_grad);
 
     let out_shape = Shape::new([batches, height, width, channels]);
     let output = empty_device::<R, E>(x.client.clone(), x.device.clone(), out_shape);


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.

### Related Issues/PRs

Fixes #3830

### Changes

Line size was incorrectly being selected based on input instead of grad.

### Testing

Added unit test.
