### PR TITLE
fix:Fix ndarray compilation when cubecl-common enables `rayon` but ndarray doesn't

### DIFF
--- a/crates/burn-common/src/lib.rs
+++ b/crates/burn-common/src/lib.rs
@@ -20,9 +20,6 @@ extern crate alloc;
 #[cfg(feature = "network")]
 pub mod network;
 
-/// Parallel utilities.
-pub mod parallel;
-
 /// Tensor utilities.
 pub mod tensor {
     use alloc::vec;

--- a/crates/burn-ndarray/Cargo.toml
+++ b/crates/burn-ndarray/Cargo.toml
@@ -61,6 +61,7 @@ burn-tensor = { path = "../burn-tensor", version = "0.19.0", default-features = 
 
 atomic_float = { workspace = true }
 blas-src = { workspace = true, default-features = false, optional = true }      # no-std compatible
+const-random = { workspace = true }
 derive-new = { workspace = true }
 libm = { workspace = true }
 matrixmultiply = { workspace = true, default-features = false }
@@ -69,7 +70,6 @@ num-traits = { workspace = true }
 openblas-src = { workspace = true, optional = true }
 paste = { workspace = true }
 rand = { workspace = true, default-features = false, features = ["small_rng"] }
-const-random = { workspace = true }
 spin = { workspace = true }
 
 # SIMD

--- a/crates/burn-ndarray/src/lib.rs
+++ b/crates/burn-ndarray/src/lib.rs
@@ -14,6 +14,7 @@ extern crate blas_src;
 mod backend;
 mod element;
 mod ops;
+mod parallel;
 mod rand;
 mod sharing;
 mod tensor;

--- a/crates/burn-ndarray/src/ops/adaptive_avgpool.rs
+++ b/crates/burn-ndarray/src/ops/adaptive_avgpool.rs
@@ -1,5 +1,6 @@
-use crate::{SharedArray, element::FloatNdArrayElement, sharing::UnsafeSharedRef};
-use burn_common::{iter_range_par, run_par};
+use crate::{
+    SharedArray, element::FloatNdArrayElement, iter_range_par, run_par, sharing::UnsafeSharedRef,
+};
 use burn_tensor::ElementConversion;
 use ndarray::Array4;
 

--- a/crates/burn-ndarray/src/ops/avgpool.rs
+++ b/crates/burn-ndarray/src/ops/avgpool.rs
@@ -1,5 +1,6 @@
-use crate::{SharedArray, element::FloatNdArrayElement, sharing::UnsafeSharedRef};
-use burn_common::{iter_range_par, run_par};
+use crate::{
+    SharedArray, element::FloatNdArrayElement, iter_range_par, run_par, sharing::UnsafeSharedRef,
+};
 
 use burn_tensor::ElementConversion;
 use ndarray::Array4;

--- a/crates/burn-ndarray/src/ops/conv.rs
+++ b/crates/burn-ndarray/src/ops/conv.rs
@@ -1,4 +1,3 @@
-use burn_common::{iter_par, iter_range_par, run_par};
 use burn_tensor::{
     ElementConversion,
     ops::{
@@ -11,8 +10,9 @@ use ndarray::{
 };
 
 use crate::{
-    NdArrayElement, SharedArray,
+    NdArrayElement, SharedArray, iter_par, iter_range_par,
     ops::padding::{apply_padding_4d, apply_padding_5d},
+    run_par,
     sharing::UnsafeSharedRef,
     tensor::NdArrayTensor,
 };

--- a/crates/burn-ndarray/src/ops/deform_conv.rs
+++ b/crates/burn-ndarray/src/ops/deform_conv.rs
@@ -1,4 +1,3 @@
-use burn_common::{iter_par, run_par};
 use burn_tensor::ops::{DeformConvOptions, conv::calculate_conv_output_size};
 use core::ops::AddAssign;
 use ndarray::{
@@ -10,7 +9,7 @@ use ndarray::{
 #[allow(unused_imports)]
 use num_traits::Float;
 
-use crate::{FloatNdArrayElement, NdArrayTensor, ShapeOps, SharedArray};
+use crate::{FloatNdArrayElement, NdArrayTensor, ShapeOps, SharedArray, iter_par, run_par};
 
 use super::matmul::matmul;
 

--- a/crates/burn-ndarray/src/ops/grid_sample.rs
+++ b/crates/burn-ndarray/src/ops/grid_sample.rs
@@ -1,10 +1,9 @@
-use burn_common::{iter_range_par, run_par};
 use burn_tensor::ElementConversion;
 use burn_tensor::ops::InterpolateMode;
 
 use ndarray::Array4;
 
-use crate::{FloatNdArrayElement, UnsafeSharedRef};
+use crate::{FloatNdArrayElement, UnsafeSharedRef, iter_range_par, run_par};
 use crate::{SharedArray, ops::interpolate::bilinear_interpolate_single};
 
 /// Sample a tensor

--- a/crates/burn-ndarray/src/ops/interpolate.rs
+++ b/crates/burn-ndarray/src/ops/interpolate.rs
@@ -1,11 +1,10 @@
-use burn_common::{iter_range_par, run_par};
 use burn_tensor::ElementConversion;
 use ndarray::{Array4, ArrayBase, DataOwned};
 #[cfg(not(feature = "std"))]
 #[allow(unused_imports)]
 use num_traits::Float;
 
-use crate::{FloatNdArrayElement, ShapeOps, SharedArray, UnsafeSharedRef};
+use crate::{FloatNdArrayElement, ShapeOps, SharedArray, UnsafeSharedRef, iter_range_par, run_par};
 
 pub(crate) fn nearest_interpolate<E: FloatNdArrayElement>(
     x: SharedArray<E>,

--- a/crates/burn-ndarray/src/ops/matmul.rs
+++ b/crates/burn-ndarray/src/ops/matmul.rs
@@ -1,8 +1,7 @@
 use crate::UnsafeSharedRef;
-use crate::{NdArrayElement, ShapeOps, SharedArray, ops::NdArrayOps};
+use crate::{NdArrayElement, ShapeOps, SharedArray, iter_range_par, ops::NdArrayOps, run_par};
 
 use alloc::{vec, vec::Vec};
-use burn_common::{iter_range_par, run_par};
 use burn_tensor::ElementConversion;
 use burn_tensor::Shape;
 use ndarray::{IxDyn, s};

--- a/crates/burn-ndarray/src/ops/maxpool.rs
+++ b/crates/burn-ndarray/src/ops/maxpool.rs
@@ -1,11 +1,12 @@
 use crate::{
     ShapeOps, SharedArray,
     element::{FloatNdArrayElement, IntNdArrayElement},
+    iter_range_par,
     ops::padding::apply_padding_4d,
+    run_par,
     sharing::UnsafeSharedRef,
 };
 
-use burn_common::{iter_range_par, run_par};
 use burn_tensor::ElementConversion;
 use ndarray::Array4;
 

--- a/crates/burn-ndarray/src/ops/simd/avgpool.rs
+++ b/crates/burn-ndarray/src/ops/simd/avgpool.rs
@@ -1,8 +1,7 @@
 use core::{marker::PhantomData, mem::transmute};
 
-use crate::{SharedArray, sharing::UnsafeSharedRef};
+use crate::{SharedArray, iter_range_par, run_par, sharing::UnsafeSharedRef};
 
-use burn_common::{iter_range_par, run_par};
 use burn_tensor::{DType, Element, ElementConversion};
 use bytemuck::Zeroable;
 use macerator::{Simd, VAdd, VDiv};

--- a/crates/burn-ndarray/src/ops/simd/conv.rs
+++ b/crates/burn-ndarray/src/ops/simd/conv.rs
@@ -1,6 +1,5 @@
 use core::{marker::PhantomData, mem::transmute};
 
-use burn_common::{iter_range_par, run_par};
 use burn_tensor::{
     DType, Element,
     ops::{ConvOptions, conv::calculate_conv_output_size},
@@ -12,7 +11,7 @@ use ndarray::{
 };
 use seq_macro::seq;
 
-use crate::{FloatNdArrayElement, SharedArray, UnsafeSharedRef};
+use crate::{FloatNdArrayElement, SharedArray, UnsafeSharedRef, iter_range_par, run_par};
 
 type Args<E> = (SharedArray<E>, SharedArray<E>, Option<SharedArray<E>>);
 

--- a/crates/burn-ndarray/src/ops/simd/maxpool.rs
+++ b/crates/burn-ndarray/src/ops/simd/maxpool.rs
@@ -1,8 +1,7 @@
 use core::{marker::PhantomData, mem::transmute};
 
-use crate::{SharedArray, sharing::UnsafeSharedRef};
+use crate::{SharedArray, iter_range_par, run_par, sharing::UnsafeSharedRef};
 
-use burn_common::{iter_range_par, run_par};
 use burn_tensor::{DType, Element, quantization::QuantValue};
 use macerator::{Simd, VOrd};
 use ndarray::{Array4, s};

--- a/crates/burn-ndarray/src/parallel.rs
+++ b/crates/burn-ndarray/src/parallel.rs
@@ -1,19 +1,19 @@
 /// Macro for running a function in parallel.
-#[cfg(feature = "rayon")]
+#[cfg(feature = "multi-threads")]
 #[macro_export(local_inner_macros)]
 macro_rules! run_par {
     (
         $func:expr
     ) => {{
-        use $crate::rayon::prelude::*;
+        use burn_common::rayon::prelude::*;
 
         #[allow(clippy::redundant_closure_call)]
-        $crate::rayon::scope(|_| $func())
+        burn_common::rayon::scope(|_| $func())
     }};
 }
 
 /// Macro for running a function in parallel.
-#[cfg(not(feature = "rayon"))]
+#[cfg(not(feature = "multi-threads"))]
 #[macro_export(local_inner_macros)]
 macro_rules! run_par {
     (
@@ -22,7 +22,7 @@ macro_rules! run_par {
 }
 
 /// Macro for iterating in parallel.
-#[cfg(not(feature = "rayon"))]
+#[cfg(not(feature = "multi-threads"))]
 #[macro_export(local_inner_macros)]
 macro_rules! iter_par {
     (
@@ -31,7 +31,7 @@ macro_rules! iter_par {
 }
 
 /// Macro for iterating in parallel.
-#[cfg(feature = "rayon")]
+#[cfg(feature = "multi-threads")]
 #[macro_export(local_inner_macros)]
 macro_rules! iter_par {
     (
@@ -40,7 +40,7 @@ macro_rules! iter_par {
 }
 
 /// Macro for iterating in parallel.
-#[cfg(feature = "rayon")]
+#[cfg(feature = "multi-threads")]
 #[macro_export(local_inner_macros)]
 macro_rules! iter_slice_par {
     (
@@ -49,7 +49,7 @@ macro_rules! iter_slice_par {
 }
 
 /// Macro for iterating in parallel.
-#[cfg(not(feature = "rayon"))]
+#[cfg(not(feature = "multi-threads"))]
 #[macro_export(local_inner_macros)]
 macro_rules! iter_slice_par {
     (
@@ -58,7 +58,7 @@ macro_rules! iter_slice_par {
 }
 
 /// Macro for iterating over a range in parallel.
-#[cfg(feature = "rayon")]
+#[cfg(feature = "multi-threads")]
 #[macro_export(local_inner_macros)]
 macro_rules! iter_range_par {
     (
@@ -67,7 +67,7 @@ macro_rules! iter_range_par {
 }
 
 /// Macro for iterating over a range in parallel.
-#[cfg(not(feature = "rayon"))]
+#[cfg(not(feature = "multi-threads"))]
 #[macro_export(local_inner_macros)]
 macro_rules! iter_range_par {
     (


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

Fixes compilation for `burn-ndarray` by moving the `ndarray` specific macros into the crate and gating them behind the proper feature.