### PR TITLE
Correctly set `cubecl::random::seed(seed)`

### DIFF
--- a/crates/burn-cubecl/src/backend.rs
+++ b/crates/burn-cubecl/src/backend.rs
@@ -1,15 +1,12 @@
 use crate::{CubeRuntime, FloatElement, IntElement, element::BoolElement, tensor::CubeTensor};
 use burn_tensor::backend::{Backend, DeviceOps};
 use cubecl::server::ComputeServer;
-use rand::{SeedableRng, rngs::StdRng};
-use std::{marker::PhantomData, sync::Mutex};
+use std::marker::PhantomData;
 
 #[cfg(not(feature = "fusion"))]
 use burn_ir::{BackendIr, TensorHandle};
 #[cfg(not(feature = "fusion"))]
 use burn_tensor::ops::{BoolTensor, FloatTensor, IntTensor, QuantizedTensor};
-
-pub(crate) static SEED: Mutex<Option<StdRng>> = Mutex::new(None);
 
 /// Generic tensor backend that can be compiled just-in-time to any shader runtime
 #[derive(new)]
@@ -46,9 +43,7 @@ where
     }
 
     fn seed(_device: &Self::Device, seed: u64) {
-        let rng = StdRng::seed_from_u64(seed);
-        let mut seed = SEED.lock().unwrap();
-        *seed = Some(rng);
+        cubecl::random::seed(seed);
     }
 
     fn ad_enabled() -> bool {

--- a/crates/burn-cubecl/src/tests/uniform.rs
+++ b/crates/burn-cubecl/src/tests/uniform.rs
@@ -106,4 +106,17 @@ mod tests {
         // Autotune of all (reduce) on lower_equal_elem's output calls uniform distribution
         tensor_1.lower_equal_elem(1.0).all();
     }
+
+    #[test]
+    #[serial]
+    fn test_seed_reproducibility() {
+        let device = Default::default();
+        TestBackend::seed(&device, 42);
+        let t1 = TestTensor::<1>::random([5], Distribution::Default, &device);
+        TestBackend::seed(&device, 42);
+        let t2 = TestTensor::<1>::random([5], Distribution::Default, &device);
+
+        t1.into_data()
+            .assert_approx_eq::<FT>(&t2.into_data(), Tolerance::default());
+    }
 }

--- a/crates/burn-tensor/src/tests/ops/random.rs
+++ b/crates/burn-tensor/src/tests/ops/random.rs
@@ -2,7 +2,7 @@
 mod tests {
     use super::*;
     use burn_tensor::{
-        Distribution, ElementComparison, ElementConversion, Tensor, backend::Backend,
+        Distribution, ElementComparison, ElementConversion, Tensor, Tolerance, backend::Backend,
         cast::ToElement, tests::Float,
     };
 


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Fixes #3871
#3165 

### Changes

Removed static SEED which was no longer used with the refactored `cubecl::random`. Now properly seeds via `cubecl::random::seed(seed)`.

### Testing

Added unit test.
