### PR TITLE
Expose deserialize numericentry

### DIFF
--- a/crates/burn-train/src/metric/base.rs
+++ b/crates/burn-train/src/metric/base.rs
@@ -139,7 +139,8 @@ impl NumericEntry {
 }
 
 impl NumericEntry {
-    pub(crate) fn serialize(&self) -> String {
+    /// Returns a String representing the NumericEntry
+    pub fn serialize(&self) -> String {
         match self {
             Self::Value(v) => v.to_string(),
             Self::Aggregated { sum, count, .. } => format!("{sum},{count}"),


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

This is to avoid code duplication between burn and burn-central. See this PR (coming soon...).

### Changes

Made deserialize function public outside the crate.

### Testing

Tested with burn-central (works fine, numeric entries can be deserialized).
