### PR TITLE
Bump tch to 0.22.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7846,9 +7846,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tch"
-version = "0.19.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa1ed622c8f13b0c42f8b1afa0e5e9ccccd82ecb6c0e904120722ab52fdc5234"
+checksum = "9e09b91610202dc4820c21eb474a42b386ef69f323b1c0902b5472ba7456ebb5"
 dependencies = [
  "half",
  "lazy_static",
@@ -8273,9 +8273,9 @@ checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
 
 [[package]]
 name = "torch-sys"
-version = "0.19.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef14f5d239e3d60f4919f536a5dfe1d4f71b27b7abf6fe6875fd3a4b22c2dcd5"
+checksum = "aef40c585e342df95b66a1fa7c923188623999c2b657227befb481dfb03a6a42"
 dependencies = [
  "anyhow",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,8 +163,8 @@ libc = "0.2.177"
 nvml-wrapper = "0.11.0"
 sysinfo = "0.37.2"
 systemstat = "0.2.5"
-tch = "0.19.0"
-torch-sys = "0.19.0"                                        # matches what tch is using, required for lib detection
+tch = "0.22.0"
+torch-sys = "0.22.0"                                        # matches what tch is using, required for lib detection
 
 ahash = { version = "0.8.12", default-features = false }
 portable-atomic = { version = "1.11.1" }

--- a/crates/burn-tch/README.md
+++ b/crates/burn-tch/README.md
@@ -17,7 +17,7 @@ The backend supports CPU (multithreaded), [CUDA](https://pytorch.org/docs/stable
 [`tch-rs`](https://github.com/LaurentMazare/tch-rs) requires the C++ PyTorch library (LibTorch) to
 be available on your system.
 
-By default, the CPU distribution is installed for LibTorch v2.6.0 as required by `tch-rs`.
+By default, the CPU distribution is installed for LibTorch v2.9.0 as required by `tch-rs`.
 
 <details>
 <summary><strong>CUDA</strong></summary>
@@ -26,13 +26,13 @@ To install the latest compatible CUDA distribution, set the `TORCH_CUDA_VERSION`
 variable before the `tch-rs` dependency is retrieved with `cargo`.
 
 ```shell
-export TORCH_CUDA_VERSION=cu124
+export TORCH_CUDA_VERSION=cu128
 ```
 
 On Windows:
 
 ```powershell
-$Env:TORCH_CUDA_VERSION = "cu124"
+$Env:TORCH_CUDA_VERSION = "cu128"
 ```
 
 > Note: `tch` doesn't expose the downloaded libtorch directory on Windows when using the automatic
@@ -44,7 +44,7 @@ For example, running the validation sample for the first time could be done with
 commands:
 
 ```shell
-export TORCH_CUDA_VERSION=cu124
+export TORCH_CUDA_VERSION=cu128
 cargo run --bin cuda --release
 ```
 
@@ -93,7 +93,7 @@ platform.
 First, download the LibTorch CPU distribution.
 
 ```shell
-wget -O libtorch.zip https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.6.0%2Bcpu.zip
+wget -O libtorch.zip https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-2.9.0%2Bcpu.zip
 unzip libtorch.zip
 ```
 
@@ -113,7 +113,7 @@ export LD_LIBRARY_PATH=/absolute/path/to/libtorch/lib:$LD_LIBRARY_PATH
 First, download the LibTorch CPU distribution.
 
 ```shell
-wget -O libtorch.zip https://download.pytorch.org/libtorch/cpu/libtorch-macos-x86_64-2.6.0.zip
+wget -O libtorch.zip https://download.pytorch.org/libtorch/cpu/libtorch-macos-arm64-2.9.0.zip
 unzip libtorch.zip
 ```
 
@@ -133,7 +133,7 @@ export DYLD_LIBRARY_PATH=/absolute/path/to/libtorch/lib:$DYLD_LIBRARY_PATH
 First, download the LibTorch CPU distribution.
 
 ```powershell
-wget https://download.pytorch.org/libtorch/cpu/libtorch-win-shared-with-deps-2.6.0%2Bcpu.zip -OutFile libtorch.zip
+wget https://download.pytorch.org/libtorch/cpu/libtorch-win-shared-with-deps-2.9.0%2Bcpu.zip -OutFile libtorch.zip
 Expand-Archive libtorch.zip
 ```
 
@@ -149,9 +149,9 @@ $Env:Path += ";/absolute/path/to/libtorch/"
 
 #### CUDA
 
-LibTorch 2.6.0 currently includes binary distributions with CUDA 11.8, 12.4 or 12.6 runtimes. The
+LibTorch 2.9.0 currently includes binary distributions with CUDA 12.6, 12.8 or 13.0 runtimes. The
 manual installation instructions are detailed below for CUDA 12.6, but can be applied to the other
-CUDA versions by replacing `cu126` with the corresponding version string (e.g., `cu118` or `cu124`).
+CUDA versions by replacing `cu126` with the corresponding version string (e.g., `cu130`).
 
 <details open>
 <summary><strong>🐧 Linux</strong></summary>
@@ -159,7 +159,7 @@ CUDA versions by replacing `cu126` with the corresponding version string (e.g., 
 First, download the LibTorch CUDA 12.6 distribution.
 
 ```shell
-wget -O libtorch.zip https://download.pytorch.org/libtorch/cu126/libtorch-cxx11-abi-shared-with-deps-2.6.0%2Bcu126.zip
+wget -O libtorch.zip https://download.pytorch.org/libtorch/cu126/libtorch-shared-with-deps-2.9.0%2Bcu126.zip
 unzip libtorch.zip
 ```
 
@@ -181,7 +181,7 @@ export LD_LIBRARY_PATH=/absolute/path/to/libtorch/lib:$LD_LIBRARY_PATH
 First, download the LibTorch CUDA 12.6 distribution.
 
 ```powershell
-wget https://download.pytorch.org/libtorch/cu126/libtorch-win-shared-with-deps-2.6.0%2Bcu126.zip -OutFile libtorch.zip
+wget https://download.pytorch.org/libtorch/cu126/libtorch-win-shared-with-deps-2.9.0%2Bcu126.zip -OutFile libtorch.zip
 Expand-Archive libtorch.zip
 ```
 
@@ -203,7 +203,7 @@ is to use a PyTorch installation. This requires a Python installation.
 _Note: MPS acceleration is available on MacOS 12.3+._
 
 ```shell
-pip install torch==2.6.0 numpy==1.26.4 setuptools
+pip install torch==2.9.0 numpy==1.26.4 setuptools
 export LIBTORCH_USE_PYTORCH=1
 export DYLD_LIBRARY_PATH=/path/to/pytorch/lib:$DYLD_LIBRARY_PATH
 ```

--- a/examples/custom-image-dataset/README.md
+++ b/examples/custom-image-dataset/README.md
@@ -54,7 +54,7 @@ achieves 70-80% accuracy on the test set after just 30 epochs.
 Run it with the Torch GPU backend:
 
 ```sh
-export TORCH_CUDA_VERSION=cu124
+export TORCH_CUDA_VERSION=cu128
 cargo run --example custom-image-dataset --release --features tch-gpu
 ```
 

--- a/examples/mnist/README.md
+++ b/examples/mnist/README.md
@@ -17,7 +17,7 @@ cargo run --example mnist --release --features ndarray                # CPU NdAr
 cargo run --example mnist --release --features ndarray-blas-openblas  # CPU NdArray Backend - f32 - blas with openblas
 cargo run --example mnist --release --features ndarray-blas-netlib    # CPU NdArray Backend - f32 - blas with netlib
 echo "Using tch backend"
-export TORCH_CUDA_VERSION=cu124                                       # Set the cuda version
+export TORCH_CUDA_VERSION=cu128                                       # Set the cuda version
 cargo run --example mnist --release --features tch-gpu                # GPU Tch Backend - f32
 cargo run --example mnist --release --features tch-cpu                # CPU Tch Backend - f32
 echo "Using wgpu backend"

--- a/examples/modern-lstm/README.md
+++ b/examples/modern-lstm/README.md
@@ -27,7 +27,7 @@ cargo run --example lstm-train --release --features cuda
 cargo run --example lstm-train --release --features wgpu
 
 # Tch GPU backend
-export TORCH_CUDA_VERSION=cu124 # Set the cuda version
+export TORCH_CUDA_VERSION=cu128 # Set the cuda version
 cargo run --example lstm-train --release --features tch-gpu
 
 # Tch CPU backend

--- a/examples/simple-regression/README.md
+++ b/examples/simple-regression/README.md
@@ -26,7 +26,7 @@ cargo run --example regression --release --features ndarray                # CPU
 cargo run --example regression --release --features ndarray-blas-openblas  # CPU NdArray Backend - f32 - blas with openblas
 cargo run --example regression --release --features ndarray-blas-netlib    # CPU NdArray Backend - f32 - blas with netlib
 echo "Using tch backend"
-export TORCH_CUDA_VERSION=cu124                                            # Set the cuda version
+export TORCH_CUDA_VERSION=cu128                                            # Set the cuda version
 cargo run --example regression --release --features tch-gpu                # GPU Tch Backend - f32
 cargo run --example regression --release --features tch-cpu                # CPU Tch Backend - f32
 echo "Using wgpu backend"

--- a/examples/text-classification/README.md
+++ b/examples/text-classification/README.md
@@ -29,7 +29,7 @@ cd burn
 # Use the --release flag to really speed up training.
 # Use the f16 feature if your CUDA device supports FP16 (half precision) operations. May not work well on every device.
 
-export TORCH_CUDA_VERSION=cu124  # Set the cuda version (CUDA users)
+export TORCH_CUDA_VERSION=cu128  # Set the cuda version (CUDA users)
 
 # AG News
 cargo run --example ag-news-train --release --features tch-gpu   # Train on the ag news dataset

--- a/examples/text-generation/README.md
+++ b/examples/text-generation/README.md
@@ -14,7 +14,7 @@ git clone https://github.com/tracel-ai/burn.git
 cd burn
 
 # Use the --release flag to really speed up training.
-export TORCH_CUDA_VERSION=cu124
+export TORCH_CUDA_VERSION=cu128
 cargo run --example text-generation --release
 ```
 

--- a/examples/wgan/README.md
+++ b/examples/wgan/README.md
@@ -17,7 +17,7 @@ cargo run --example wgan-mnist --release --features cuda
 cargo run --example wgan-mnist --release --features wgpu
 
 # Tch GPU backend
-export TORCH_CUDA_VERSION=cu124 # Set the cuda version
+export TORCH_CUDA_VERSION=cu128 # Set the cuda version
 cargo run --example wgan-mnist --release --features tch-gpu
 
 # Tch CPU backend


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.

### Changes

Update tch version and instructions

### Testing

Unit tests + example

/edit: Just booted on my windows partition to validate that CUDA worked. Just have to set the `LIBTORCH` var (as usual). So both linux and windows work with the update.