### PR TITLE
Fix evaluator dataloader device

### DIFF
--- a/crates/burn-train/src/evaluator/base.rs
+++ b/crates/burn-train/src/evaluator/base.rs
@@ -4,7 +4,7 @@ use crate::{
     metric::processor::{EvaluatorEvent, EventProcessorEvaluation, LearnerItem},
     renderer::{EvaluationName, MetricsRenderer},
 };
-use burn_core::data::dataloader::DataLoader;
+use burn_core::{data::dataloader::DataLoader, module::Module};
 use std::sync::Arc;
 
 /// Evaluates a model on a specific dataset.
@@ -28,6 +28,9 @@ impl<EC: EvaluatorComponentTypes> Evaluator<EC> {
         name: S,
         dataloader: TestLoader<EC>,
     ) -> Box<dyn MetricsRenderer> {
+        // Move dataloader to the model device
+        let dataloader = dataloader.to_device(self.model.devices().first().unwrap());
+
         let name = EvaluationName::new(name);
         let mut iterator = dataloader.iter();
         let mut iteration = 0;


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.

### Related Issues/PRs

Stumbled upon this issue while testing #3892 

### Changes

Similar to the learner, the evaluator should use the correct model device when loading data.

### Testing

Tested mnist example with tch (where model is on Cuda device and dataloader was on default device, i.e. CPU). Now it matches the model device.
