### PR TITLE
Make ElementType Copy

### DIFF
--- a/crates/burn-import/src/burn/node/constant.rs
+++ b/crates/burn-import/src/burn/node/constant.rs
@@ -285,9 +285,9 @@ impl OnnxIntoNode for ConstantNode {
                         .value
                         .as_ref()
                         .expect("Scalar constant should have value");
-                    scalar_from_data(tensor.elem_type.clone(), v.data.clone())
+                    scalar_from_data(tensor.elem_type, v.data.clone())
                 } else {
-                    let kind: TensorKind = tensor.elem_type.clone().into();
+                    let kind: TensorKind = tensor.elem_type.into();
                     let rank = tensor.rank;
                     let name = node.name.clone();
                     let tensor_data = attr.value.expect("Constant tensor should have value");

--- a/crates/burn-import/src/burn/ty.rs
+++ b/crates/burn-import/src/burn/ty.rs
@@ -311,7 +311,7 @@ impl From<&onnx_ir::ir::Argument> for Type {
                         ScalarKind::from(&tensor.elem_type),
                     ))
                 } else {
-                    let kind: TensorKind = tensor.elem_type.clone().into();
+                    let kind: TensorKind = tensor.elem_type.into();
                     let rank = tensor.rank;
                     let name = arg.name.clone();
                     Type::Tensor(TensorType::new(name, rank, kind))

--- a/crates/onnx-ir/src/ir.rs
+++ b/crates/onnx-ir/src/ir.rs
@@ -199,7 +199,7 @@ pub enum AttributeValue {
 pub type Attributes = HashMap<String, AttributeValue>;
 
 /// The type of an element.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ElementType {
     Float32,
     Float64,

--- a/crates/onnx-ir/src/node/attention.rs
+++ b/crates/onnx-ir/src/node/attention.rs
@@ -121,14 +121,14 @@ pub fn attention_update_output(node: &mut Node) {
     let q = extract_tensor(node.inputs.first(), "Q").unwrap();
 
     node.outputs[0].ty = ArgType::Tensor(TensorType {
-        elem_type: node.inputs[0].ty.elem_type().clone(),
+        elem_type: *node.inputs[0].ty.elem_type(),
         rank: q.rank,
         static_shape: None,
     });
 
     if let Some(present_key) = node.outputs.get_mut(1) {
         present_key.ty = ArgType::Tensor(TensorType {
-            elem_type: node.inputs[4].ty.elem_type().clone(),
+            elem_type: *node.inputs[4].ty.elem_type(),
             rank: 4,
             static_shape: None,
         });
@@ -136,7 +136,7 @@ pub fn attention_update_output(node: &mut Node) {
 
     if let Some(present_value) = node.outputs.get_mut(2) {
         present_value.ty = ArgType::Tensor(TensorType {
-            elem_type: node.inputs[5].ty.elem_type().clone(),
+            elem_type: *node.inputs[5].ty.elem_type(),
             rank: 4,
             static_shape: None,
         });
@@ -144,7 +144,7 @@ pub fn attention_update_output(node: &mut Node) {
 
     if let Some(qk_matmul_output) = node.outputs.get_mut(3) {
         qk_matmul_output.ty = ArgType::Tensor(TensorType {
-            elem_type: node.inputs[0].ty.elem_type().clone(),
+            elem_type: *node.inputs[0].ty.elem_type(),
             rank: 4,
             static_shape: None,
         });

--- a/crates/onnx-ir/src/node/cast.rs
+++ b/crates/onnx-ir/src/node/cast.rs
@@ -63,7 +63,7 @@ pub fn cast_update_outputs(node: &mut Node) {
                 | ElementType::Float16
                 | ElementType::Bool => {
                     output.ty = ArgType::Tensor(TensorType {
-                        elem_type: elem_type.clone(),
+                        elem_type,
                         rank: 1,
                         static_shape: Some(vec![rank]),
                     });

--- a/crates/onnx-ir/src/node/concat.rs
+++ b/crates/onnx-ir/src/node/concat.rs
@@ -64,7 +64,7 @@ pub fn concat_update_outputs(node: &mut Node) {
             );
 
             node.outputs[0].ty = ArgType::Tensor(TensorType {
-                elem_type: tensor.elem_type.clone(),
+                elem_type: tensor.elem_type,
                 rank: tensor.rank,
                 static_shape: None,
             });

--- a/crates/onnx-ir/src/node/depth_to_space.rs
+++ b/crates/onnx-ir/src/node/depth_to_space.rs
@@ -42,7 +42,7 @@ pub fn depth_to_space_update_outputs(node: &mut Node) {
     });
 
     node.outputs[0].ty = ArgType::Tensor(TensorType {
-        elem_type: tensor.elem_type.clone(),
+        elem_type: tensor.elem_type,
         rank: tensor.rank,
         static_shape,
     });

--- a/crates/onnx-ir/src/node/expand.rs
+++ b/crates/onnx-ir/src/node/expand.rs
@@ -35,7 +35,7 @@ pub fn expand_update_outputs(node: &mut Node) {
 
     // Get input element type - Expand should preserve the input's element type
     let input_elem_type = match &node.inputs[0].ty {
-        ArgType::Tensor(tensor) => tensor.elem_type.clone(),
+        ArgType::Tensor(tensor) => tensor.elem_type,
         _ => panic!("Expand operation requires first input to be a tensor"),
     };
 
@@ -46,7 +46,7 @@ pub fn expand_update_outputs(node: &mut Node) {
 
     if let Some(shape) = shape {
         node.outputs[0].ty = ArgType::Tensor(TensorType {
-            elem_type: input_elem_type.clone(),
+            elem_type: input_elem_type,
             rank: shape.len(),
             static_shape: Some(shape.into_iter().map(|dim| dim as usize).collect()),
         });

--- a/crates/onnx-ir/src/node/eye_like.rs
+++ b/crates/onnx-ir/src/node/eye_like.rs
@@ -45,7 +45,7 @@ pub fn eye_like_update_output(node: &mut Node) {
 
             let config = eye_like_config(node);
             // Output type is either specified dtype or input type
-            let output_type = config.dtype.unwrap_or_else(|| tensor.elem_type.clone());
+            let output_type = config.dtype.unwrap_or(tensor.elem_type);
 
             node.outputs[0].ty = ArgType::Tensor(TensorType {
                 elem_type: output_type,

--- a/crates/onnx-ir/src/node/gather.rs
+++ b/crates/onnx-ir/src/node/gather.rs
@@ -50,12 +50,12 @@ pub fn gather_update_outputs(node: &mut Node) {
 
             if output_rank == 0 {
                 // Output is scalar when gathering a single element
-                node.outputs[0].ty = ArgType::Scalar(input_tensor.elem_type.clone());
+                node.outputs[0].ty = ArgType::Scalar(input_tensor.elem_type);
                 log::debug!("Gather result for {} is scalar", node.name);
             } else {
                 // Output is tensor
                 node.outputs[0].ty = ArgType::Tensor(TensorType {
-                    elem_type: input_tensor.elem_type.clone(),
+                    elem_type: input_tensor.elem_type,
                     rank: output_rank,
                     static_shape: None,
                 });

--- a/crates/onnx-ir/src/node/gemm.rs
+++ b/crates/onnx-ir/src/node/gemm.rs
@@ -28,7 +28,7 @@ pub fn gemm_output_shape(node: &mut Node) {
         rank: output_rank,
         static_shape: None,
         elem_type: match &node.inputs[0].ty {
-            ArgType::Tensor(t) => t.elem_type.clone(),
+            ArgType::Tensor(t) => t.elem_type,
             _ => panic!("Unexpected type for input A"),
         },
     });

--- a/crates/onnx-ir/src/node/linear.rs
+++ b/crates/onnx-ir/src/node/linear.rs
@@ -36,7 +36,7 @@ pub fn linear_update_outputs(node: &mut Node) {
         log::debug!("Linear input rank for {}: {}", node.name, tensor.rank);
 
         node.outputs[0].ty = ArgType::Tensor(TensorType {
-            elem_type: tensor.elem_type.clone(),
+            elem_type: tensor.elem_type,
             rank: tensor.rank,
             static_shape: None,
         });

--- a/crates/onnx-ir/src/node/matmul.rs
+++ b/crates/onnx-ir/src/node/matmul.rs
@@ -24,7 +24,7 @@ pub fn matmul_update_outputs(node: &mut Node) {
             }
 
             node.outputs[0].ty = ArgType::Tensor(TensorType {
-                elem_type: a.elem_type.clone(),
+                elem_type: a.elem_type,
                 rank: out_rank,
                 static_shape: None,
             });

--- a/crates/onnx-ir/src/node/one_hot.rs
+++ b/crates/onnx-ir/src/node/one_hot.rs
@@ -38,7 +38,7 @@ pub fn one_hot_output_shape(node: &mut Node) {
     log::debug!("OneHot output rank for {}: {}", node.name, output_rank);
 
     node.outputs[0].ty = ArgType::Tensor(TensorType {
-        elem_type: node.outputs[0].ty.elem_type().clone(),
+        elem_type: *node.outputs[0].ty.elem_type(),
         rank: output_rank,
         static_shape: None,
     });

--- a/crates/onnx-ir/src/node/reduce.rs
+++ b/crates/onnx-ir/src/node/reduce.rs
@@ -95,7 +95,7 @@ pub fn reduce_update_outputs(node: &mut Node) {
     if should_be_scalar {
         // Output is a scalar
         log::debug!("{} output is scalar for node {}", node.node_type, node.name);
-        node.outputs[0].ty = ArgType::Scalar(tensor.elem_type.clone());
+        node.outputs[0].ty = ArgType::Scalar(tensor.elem_type);
     } else {
         // Output is a tensor
         let output_rank = if config.keepdims {
@@ -154,7 +154,7 @@ pub fn reduce_update_outputs(node: &mut Node) {
         );
 
         node.outputs[0].ty = ArgType::Tensor(TensorType {
-            elem_type: tensor.elem_type.clone(),
+            elem_type: tensor.elem_type,
             rank: output_rank,
             static_shape: output_shape,
         });

--- a/crates/onnx-ir/src/node/reshape.rs
+++ b/crates/onnx-ir/src/node/reshape.rs
@@ -43,7 +43,7 @@ struct InputInfo {
 fn extract_input_info(input: &Argument) -> InputInfo {
     match &input.ty {
         ArgType::Tensor(tensor) => InputInfo {
-            elem_type: tensor.elem_type.clone(),
+            elem_type: tensor.elem_type,
             is_shape: false,
             shape_size: None,
         },
@@ -69,7 +69,7 @@ fn determine_output_type(
     // Case 1: Scalar output (rank 0)
     if output_rank == 0 {
         log::debug!("Reshape node {} outputs a scalar", node.name);
-        return ArgType::Scalar(input_info.elem_type.clone());
+        return ArgType::Scalar(input_info.elem_type);
     }
 
     // Case 2: Shape input -> Shape output (optimization)
@@ -91,7 +91,7 @@ fn determine_output_type(
     ArgType::Tensor(TensorType {
         rank: output_rank,
         static_shape,
-        elem_type: input_info.elem_type.clone(),
+        elem_type: input_info.elem_type,
     })
 }
 

--- a/crates/onnx-ir/src/node/space_to_depth.rs
+++ b/crates/onnx-ir/src/node/space_to_depth.rs
@@ -42,7 +42,7 @@ pub fn space_to_depth_update_outputs(node: &mut Node) {
     });
 
     node.outputs[0].ty = ArgType::Tensor(TensorType {
-        elem_type: tensor.elem_type.clone(),
+        elem_type: tensor.elem_type,
         rank: tensor.rank,
         static_shape,
     });

--- a/crates/onnx-ir/src/node/split.rs
+++ b/crates/onnx-ir/src/node/split.rs
@@ -17,7 +17,7 @@ pub fn split_update_outputs(node: &mut Node) {
 
     for (i, output_arg) in node.outputs.iter_mut().enumerate() {
         output_arg.ty = ArgType::Tensor(TensorType {
-            elem_type: tensor.elem_type.clone(),
+            elem_type: tensor.elem_type,
             rank: tensor.rank,
             static_shape: None,
         });

--- a/crates/onnx-ir/src/node/squeeze.rs
+++ b/crates/onnx-ir/src/node/squeeze.rs
@@ -60,7 +60,7 @@ pub fn squeeze_update_output(node: &mut Node) {
             log::debug!("Squeeze output rank for {}: {}", node.name, output_rank);
 
             node.outputs[0].ty = ArgType::Tensor(TensorType {
-                elem_type: tensor.elem_type.clone(),
+                elem_type: tensor.elem_type,
                 rank: output_rank,
                 static_shape: None,
             });
@@ -94,7 +94,7 @@ pub fn squeeze_update_output(node: &mut Node) {
         }
         ArgType::Scalar(scalar_type) => {
             // Scalar squeeze is a no-op
-            node.outputs[0].ty = ArgType::Scalar(scalar_type.clone());
+            node.outputs[0].ty = ArgType::Scalar(*scalar_type);
             log::debug!("Squeeze Scalar unchanged for {}", node.name);
         }
     }

--- a/crates/onnx-ir/src/node/topk.rs
+++ b/crates/onnx-ir/src/node/topk.rs
@@ -11,7 +11,7 @@ pub fn top_k_update_output(node: &mut Node) {
     log::debug!("TopK input rank for {}: {}", node.name, rank);
 
     node.outputs[0].ty = ArgType::Tensor(TensorType {
-        elem_type: node.inputs[0].ty.elem_type().clone(),
+        elem_type: *node.inputs[0].ty.elem_type(),
         rank,
         static_shape: None,
     });

--- a/crates/onnx-ir/src/node/unsqueeze.rs
+++ b/crates/onnx-ir/src/node/unsqueeze.rs
@@ -91,7 +91,7 @@ pub fn unsqueeze_update_output(node: &mut Node) {
                     node.outputs[0].ty = ArgType::Tensor(TensorType {
                         rank: output_rank,
                         static_shape: None,
-                        elem_type: elem_type.clone(),
+                        elem_type: *elem_type,
                     });
                 }
             }
@@ -99,8 +99,8 @@ pub fn unsqueeze_update_output(node: &mut Node) {
         _ => {
             // Regular tensor or scalar to tensor conversion
             let output_elem = match &node.outputs[0].ty {
-                ArgType::Tensor(_) => node.inputs[0].ty.elem_type().clone(),
-                ArgType::Scalar(elem_type) => elem_type.clone(),
+                ArgType::Tensor(_) => *node.inputs[0].ty.elem_type(),
+                ArgType::Scalar(elem_type) => *elem_type,
                 ArgType::Shape(_) => crate::ir::ElementType::Int64, // Shape elements are always i64
             };
 

--- a/crates/onnx-ir/src/node/where_op.rs
+++ b/crates/onnx-ir/src/node/where_op.rs
@@ -6,8 +6,8 @@ use crate::{
 /// Get element type from ArgType, handling Shape types specially
 fn get_elem_type(arg_type: &ArgType) -> ElementType {
     match arg_type {
-        ArgType::Scalar(elem_type) => elem_type.clone(),
-        ArgType::Tensor(tensor) => tensor.elem_type.clone(),
+        ArgType::Scalar(elem_type) => *elem_type,
+        ArgType::Tensor(tensor) => tensor.elem_type,
         ArgType::Shape(_) => ElementType::Int64, // Shape types are always i64
     }
 }

--- a/crates/onnx-ir/src/util.rs
+++ b/crates/onnx-ir/src/util.rs
@@ -220,17 +220,17 @@ pub fn same_as_input_broadcast(node: &mut Node) {
     log::debug!("Max rank for broadcasting node {}: {}", node.name, max_rank);
 
     if max_rank == 0 {
-        node.outputs[0].ty = ArgType::Scalar(node.inputs[0].ty.elem_type().clone());
+        node.outputs[0].ty = ArgType::Scalar(*node.inputs[0].ty.elem_type());
         log::debug!("Scalar result for node {}", node.name);
     } else {
         let elem_type = node
             .inputs
             .iter()
             .find_map(|input| match &input.ty {
-                ArgType::Tensor(tensor) => Some(tensor.elem_type.clone()),
+                ArgType::Tensor(tensor) => Some(tensor.elem_type),
                 _ => None,
             })
-            .unwrap_or_else(|| node.inputs[0].ty.elem_type().clone());
+            .unwrap_or_else(|| *node.inputs[0].ty.elem_type());
 
         // Try to compute static shape from broadcast
         let static_shape = compute_broadcast_static_shape(&node.inputs);


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [X] Confirmed that `cargo run-checks` command has been executed.
- [X] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

N/A
### Changes

tldr; I derived `Copy` on the `ElementType` enum.

While using the `onnx-ir` crate as a dependency I noticed that the `ElementType` enum wasn't `Copy`, causing me to clone it in various places. Not sure why it's not `Copy` the type is certainly small enough to be, so I went ahead and made it `Copy`. This unfortunately unleashed a bit of an attack of the `clones()` which I also fixed, and that's the bulk of the changes.

### Testing

Ran `cargo run-checks`, the only errors I got were FP comparison errors, same as in my last few PRs. They're not related this change.