### PR TITLE
add fusion matmul optimization i64 support

### DIFF
--- a/crates/burn-cubecl-fusion/src/matmul/optimization.rs
+++ b/crates/burn-cubecl-fusion/src/matmul/optimization.rs
@@ -361,6 +361,7 @@ impl<R: Runtime> TraceRunner<R> for FusedMatmul {
         configs: &'a [FuseBlockConfig],
     ) -> Result<(), FusedMatmulError> {
         match self.out.precision() {
+            FusePrecision::F64 => self.matmul_fused::<R, f64>(client, inputs, outputs, &configs[0]),
             FusePrecision::F32 => self.matmul_fused::<R, f32>(client, inputs, outputs, &configs[0]),
             FusePrecision::Flex32 => {
                 self.matmul_fused::<R, flex32>(client, inputs, outputs, &configs[0])
@@ -377,7 +378,7 @@ impl<R: Runtime> TraceRunner<R> for FusedMatmul {
             FusePrecision::U16 => self.matmul_fused::<R, u16>(client, inputs, outputs, &configs[0]),
             FusePrecision::U32 => self.matmul_fused::<R, u32>(client, inputs, outputs, &configs[0]),
             FusePrecision::U64 => self.matmul_fused::<R, u64>(client, inputs, outputs, &configs[0]),
-            _ => panic!("Unsupported precision"),
+            FusePrecision::Bool => panic!("Unsupported precision"),
         }
     }
 }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

Adds i64 support to matmul fusion.

I ran into the `Unsupported precision` catch-all case with i64. It seems that simply adding a case to handle this works, at least in my external work. One thing I'm not sure about if the `row_count` for `FusedMatmulSelector::OrderedDoubleBuffering` on line 506 in this file should also be updated to handle this precision?

### Testing

Only tested externally in private code. I'd be happy to add some tests here with some guidance