### PR TITLE
Comparable Int/FloatDTypes, no-op casts, *_like() dtype preservation.

### DIFF
--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -186,7 +186,8 @@ where
         Self::new(K::full(shape, fill_value, device, K::Elem::dtype()))
     }
 
-    ///Returns a new tensor with the same shape and device as the current tensor filled with the provided value.
+    /// Returns a new tensor with the same shape, dtype, and device as the current tensor,
+    /// filled with the provided value.
     ///
     /// # Example
     ///
@@ -203,7 +204,12 @@ where
     /// }
     /// ```
     pub fn full_like<E: ElementConversion>(&self, fill_value: E) -> Self {
-        Self::full(self.shape(), fill_value, &self.device())
+        Self::new(K::full(
+            self.shape(),
+            fill_value,
+            &self.device(),
+            self.dtype(),
+        ))
     }
 
     /// Returns the dimensions of the current tensor.

--- a/crates/burn-tensor/src/tensor/api/float.rs
+++ b/crates/burn-tensor/src/tensor/api/float.rs
@@ -265,14 +265,15 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
         Tensor::new(B::float_into_int(self.primitive.tensor()))
     }
 
-    /// Returns a new tensor with the same shape and device as the current tensor filled random
+    /// Returns a new tensor with the same shape, dtype, and device as the current tensor filled random
     /// values sampled from the given distribution.
     pub fn random_like(&self, distribution: Distribution) -> Self {
-        Tensor::new(TensorPrimitive::Float(B::float_random(
+        Self::new(TensorPrimitive::Float(B::float_random(
             self.shape(),
             distribution,
             &self.device(),
         )))
+        .cast(self.dtype())
     }
 
     /// Calculate the variance along the given dimension.
@@ -301,13 +302,22 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
 
     /// Converts a tensor to the specified floating point data type.
     ///
+    /// This is always a no-op when casting to the current dtype.
+    ///
     /// # Warning
     /// Most backends don't have automatic type promotion at this time, so make sure that all tensors
     /// have the same floating point precision data type for operations multiple input tensors (e.g., binary ops).
     pub fn cast<F: Into<FloatDType>>(self, dtype: F) -> Tensor<B, D> {
+        let dtype = dtype.into();
+        let self_type: FloatDType = self.dtype().into();
+        if dtype == self_type {
+            // no-op.
+            return self;
+        }
+
         Tensor::new(TensorPrimitive::Float(B::float_cast(
             self.primitive.tensor(),
-            dtype.into(),
+            dtype,
         )))
     }
 

--- a/crates/burn-tensor/src/tensor/api/int.rs
+++ b/crates/burn-tensor/src/tensor/api/int.rs
@@ -158,10 +158,18 @@ where
 
     /// Converts a tensor to the specified integer data type.
     ///
+    /// This is always a no-op when casting to the current dtype.
+    ///
     /// # Warning
     /// Most backends don't have automatic type promotion at this time, so make sure that all tensors
     /// have the same integer data type for operations multiple input tensors (e.g., binary ops).
     pub fn cast<F: Into<IntDType>>(self, dtype: F) -> Tensor<B, D, Int> {
-        Tensor::new(B::int_cast(self.primitive, dtype.into()))
+        let dtype = dtype.into();
+        let self_dtype: IntDType = self.dtype().into();
+        if dtype == self_dtype {
+            // no-op.
+            return self;
+        }
+        Tensor::new(B::int_cast(self.primitive, dtype))
     }
 }

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -358,7 +358,7 @@ where
         Self::new(K::zeros(shape, device, K::Elem::dtype()))
     }
 
-    /// Returns a new tensor with the same shape and device as the current tensor filled with zeros.
+    /// Returns a new tensor with the same shape, dtype, and device as the current tensor filled with zeros.
     ///
     /// # Example
     ///
@@ -375,7 +375,7 @@ where
     /// }
     /// ```
     pub fn zeros_like(&self) -> Self {
-        Self::zeros(self.shape(), &self.device())
+        Self::new(K::zeros(self.shape(), &self.device(), self.dtype()))
     }
 
     /// Create a tensor of the given shape where each element is one.
@@ -399,7 +399,7 @@ where
         Self::new(K::ones(shape, device, K::Elem::dtype()))
     }
 
-    /// Returns a new tensor with the same shape and device as the current tensor filled with ones.
+    /// Returns a new tensor with the same shape, dtype, and device as the current tensor filled with ones.
     ///
     /// # Example
     ///
@@ -416,7 +416,7 @@ where
     /// }
     /// ```
     pub fn ones_like(&self) -> Self {
-        Self::ones(self.shape(), &self.device())
+        Self::new(K::ones(self.shape(), &self.device(), self.dtype()))
     }
 
     /// Aggregate all elements in the tensor with the mean operation.

--- a/crates/burn-tensor/src/tensor/element/base.rs
+++ b/crates/burn-tensor/src/tensor/element/base.rs
@@ -404,7 +404,7 @@ impl DType {
 }
 
 #[allow(missing_docs)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum FloatDType {
     F64,
     F32,
@@ -439,7 +439,7 @@ impl From<FloatDType> for DType {
 }
 
 #[allow(missing_docs)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum IntDType {
     I64,
     I32,


### PR DESCRIPTION
- Update `cast` methods to include no-op checks when dtypes are the same.
- Extend `IntDType` and `FloatDType` with comparison traits (`PartialEq`, `Eq`, `PartialOrd`, `Ord`, etc.).
- Refactor `*_like` tensor methods (`zeros_like`, `ones_like`, `full_like`, `random_like`) to retain `dtype`.
- Improve API documentation to reflect dtype preservation changes.
