### PR TITLE
feat: Enable tuning specialized matmul

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1911,7 +1911,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.9.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7a4d97e836ffa931079eba16348d91431fb69d67#7a4d97e836ffa931079eba16348d91431fb69d67"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3c941743d0f1f84e5b22b94402de806812b5c0fc#3c941743d0f1f84e5b22b94402de806812b5c0fc"
 dependencies = [
  "cubecl-attention",
  "cubecl-convolution",
@@ -1931,7 +1931,7 @@ dependencies = [
 [[package]]
 name = "cubecl-attention"
 version = "0.9.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7a4d97e836ffa931079eba16348d91431fb69d67#7a4d97e836ffa931079eba16348d91431fb69d67"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3c941743d0f1f84e5b22b94402de806812b5c0fc#3c941743d0f1f84e5b22b94402de806812b5c0fc"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1947,7 +1947,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.9.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7a4d97e836ffa931079eba16348d91431fb69d67#7a4d97e836ffa931079eba16348d91431fb69d67"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3c941743d0f1f84e5b22b94402de806812b5c0fc#3c941743d0f1f84e5b22b94402de806812b5c0fc"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -1980,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "cubecl-convolution"
 version = "0.9.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7a4d97e836ffa931079eba16348d91431fb69d67#7a4d97e836ffa931079eba16348d91431fb69d67"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3c941743d0f1f84e5b22b94402de806812b5c0fc#3c941743d0f1f84e5b22b94402de806812b5c0fc"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1998,7 +1998,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.9.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7a4d97e836ffa931079eba16348d91431fb69d67#7a4d97e836ffa931079eba16348d91431fb69d67"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3c941743d0f1f84e5b22b94402de806812b5c0fc#3c941743d0f1f84e5b22b94402de806812b5c0fc"
 dependencies = [
  "bitflags 2.10.0",
  "bytemuck",
@@ -2022,7 +2022,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.9.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7a4d97e836ffa931079eba16348d91431fb69d67#7a4d97e836ffa931079eba16348d91431fb69d67"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3c941743d0f1f84e5b22b94402de806812b5c0fc#3c941743d0f1f84e5b22b94402de806812b5c0fc"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2038,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.9.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7a4d97e836ffa931079eba16348d91431fb69d67#7a4d97e836ffa931079eba16348d91431fb69d67"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3c941743d0f1f84e5b22b94402de806812b5c0fc#3c941743d0f1f84e5b22b94402de806812b5c0fc"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2061,7 +2061,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.9.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7a4d97e836ffa931079eba16348d91431fb69d67#7a4d97e836ffa931079eba16348d91431fb69d67"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3c941743d0f1f84e5b22b94402de806812b5c0fc#3c941743d0f1f84e5b22b94402de806812b5c0fc"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2078,7 +2078,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.9.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7a4d97e836ffa931079eba16348d91431fb69d67#7a4d97e836ffa931079eba16348d91431fb69d67"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3c941743d0f1f84e5b22b94402de806812b5c0fc#3c941743d0f1f84e5b22b94402de806812b5c0fc"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2107,7 +2107,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.9.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7a4d97e836ffa931079eba16348d91431fb69d67#7a4d97e836ffa931079eba16348d91431fb69d67"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3c941743d0f1f84e5b22b94402de806812b5c0fc#3c941743d0f1f84e5b22b94402de806812b5c0fc"
 dependencies = [
  "cubecl-common",
  "cubecl-macros-internal",
@@ -2127,7 +2127,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.9.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7a4d97e836ffa931079eba16348d91431fb69d67#7a4d97e836ffa931079eba16348d91431fb69d67"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3c941743d0f1f84e5b22b94402de806812b5c0fc#3c941743d0f1f84e5b22b94402de806812b5c0fc"
 dependencies = [
  "cubecl-common",
  "darling 0.21.3",
@@ -2142,7 +2142,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.9.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7a4d97e836ffa931079eba16348d91431fb69d67#7a4d97e836ffa931079eba16348d91431fb69d67"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3c941743d0f1f84e5b22b94402de806812b5c0fc#3c941743d0f1f84e5b22b94402de806812b5c0fc"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
@@ -2153,7 +2153,7 @@ dependencies = [
 [[package]]
 name = "cubecl-matmul"
 version = "0.9.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7a4d97e836ffa931079eba16348d91431fb69d67#7a4d97e836ffa931079eba16348d91431fb69d67"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3c941743d0f1f84e5b22b94402de806812b5c0fc#3c941743d0f1f84e5b22b94402de806812b5c0fc"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2170,7 +2170,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.9.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7a4d97e836ffa931079eba16348d91431fb69d67#7a4d97e836ffa931079eba16348d91431fb69d67"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3c941743d0f1f84e5b22b94402de806812b5c0fc#3c941743d0f1f84e5b22b94402de806812b5c0fc"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2187,7 +2187,7 @@ dependencies = [
 [[package]]
 name = "cubecl-quant"
 version = "0.9.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7a4d97e836ffa931079eba16348d91431fb69d67#7a4d97e836ffa931079eba16348d91431fb69d67"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3c941743d0f1f84e5b22b94402de806812b5c0fc#3c941743d0f1f84e5b22b94402de806812b5c0fc"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2200,7 +2200,7 @@ dependencies = [
 [[package]]
 name = "cubecl-random"
 version = "0.9.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7a4d97e836ffa931079eba16348d91431fb69d67#7a4d97e836ffa931079eba16348d91431fb69d67"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3c941743d0f1f84e5b22b94402de806812b5c0fc#3c941743d0f1f84e5b22b94402de806812b5c0fc"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2215,7 +2215,7 @@ dependencies = [
 [[package]]
 name = "cubecl-reduce"
 version = "0.9.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7a4d97e836ffa931079eba16348d91431fb69d67#7a4d97e836ffa931079eba16348d91431fb69d67"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3c941743d0f1f84e5b22b94402de806812b5c0fc#3c941743d0f1f84e5b22b94402de806812b5c0fc"
 dependencies = [
  "cubecl-core",
  "cubecl-runtime",
@@ -2230,7 +2230,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.9.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7a4d97e836ffa931079eba16348d91431fb69d67#7a4d97e836ffa931079eba16348d91431fb69d67"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3c941743d0f1f84e5b22b94402de806812b5c0fc#3c941743d0f1f84e5b22b94402de806812b5c0fc"
 dependencies = [
  "async-channel",
  "bytemuck",
@@ -2257,7 +2257,7 @@ dependencies = [
 [[package]]
 name = "cubecl-spirv"
 version = "0.9.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7a4d97e836ffa931079eba16348d91431fb69d67#7a4d97e836ffa931079eba16348d91431fb69d67"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3c941743d0f1f84e5b22b94402de806812b5c0fc#3c941743d0f1f84e5b22b94402de806812b5c0fc"
 dependencies = [
  "bitflags 2.10.0",
  "cubecl-common",
@@ -2272,7 +2272,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.9.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7a4d97e836ffa931079eba16348d91431fb69d67#7a4d97e836ffa931079eba16348d91431fb69d67"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3c941743d0f1f84e5b22b94402de806812b5c0fc#3c941743d0f1f84e5b22b94402de806812b5c0fc"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2288,7 +2288,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.9.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7a4d97e836ffa931079eba16348d91431fb69d67#7a4d97e836ffa931079eba16348d91431fb69d67"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3c941743d0f1f84e5b22b94402de806812b5c0fc#3c941743d0f1f84e5b22b94402de806812b5c0fc"
 dependencies = [
  "ash",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,9 +171,9 @@ portable-atomic = { version = "1.11.1" }
 portable-atomic-util = { version = "0.2.4", features = ["alloc"] }
 
 ### For the main burn branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "7a4d97e836ffa931079eba16348d91431fb69d67" }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "7a4d97e836ffa931079eba16348d91431fb69d67" }
-cubecl-quant = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "7a4d97e836ffa931079eba16348d91431fb69d67" }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "3c941743d0f1f84e5b22b94402de806812b5c0fc" }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "3c941743d0f1f84e5b22b94402de806812b5c0fc" }
+cubecl-quant = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "3c941743d0f1f84e5b22b94402de806812b5c0fc" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }

--- a/crates/burn-cubecl-fusion/src/matmul/optimization.rs
+++ b/crates/burn-cubecl-fusion/src/matmul/optimization.rs
@@ -17,7 +17,7 @@ use burn_fusion::stream::Context;
 use burn_ir::BinaryOpIr;
 use cubecl::matmul::AcceleratedTileKind;
 use cubecl::matmul::components::MatmulElems;
-use cubecl::matmul::components::tile::io::{Filled, Strided};
+use cubecl::matmul::components::tile::io::Filled;
 use cubecl::matmul::components::tile::{cmma::CmmaMatmul, mma::MmaMatmul};
 use cubecl::matmul::components::{self, MatmulProblem, MatmulSetupError};
 use cubecl::matmul::kernels::layered::Selection;
@@ -422,7 +422,7 @@ macro_rules! with_tile_kind {
                 ($launch)()
             }
             AcceleratedTileKind::Mma => {
-                type $T = MmaMatmul<Strided>;
+                type $T = MmaMatmul;
                 ($launch)()
             }
         }

--- a/crates/onnx-ir/src/node/clip.rs
+++ b/crates/onnx-ir/src/node/clip.rs
@@ -196,13 +196,11 @@ mod tests {
         // Input 1: min (optional)
         // Input 2: max (optional)
         // We need to maintain the correct positions even if values are None
-        let builder = NodeBuilder::new(NodeType::Clip, "test_clip")
+        NodeBuilder::new(NodeType::Clip, "test_clip")
             .input_tensor_f32("X", 4, None)
             .input_scalar_tensor_f32("min", min)
             .input_scalar_tensor_f32("max", max)
-            .output_tensor_f32("Y", 4, None);
-
-        builder
+            .output_tensor_f32("Y", 4, None)
     }
 
     #[test]

--- a/crates/onnx-ir/src/node/trilu.rs
+++ b/crates/onnx-ir/src/node/trilu.rs
@@ -152,7 +152,8 @@ mod tests {
     use crate::node::test_utils::NodeBuilder;
 
     #[test]
-    #[ignore] // Manual test
+    #[ignore] // Manual
+    #[allow(clippy::bool_assert_comparison)]
     fn test_parse_actual_trilu_onnx() {
         use crate::pipeline::parse_onnx;
         use std::path::Path;

--- a/crates/onnx-ir/tests/infrastructure.rs
+++ b/crates/onnx-ir/tests/infrastructure.rs
@@ -213,6 +213,7 @@ fn test_scalar_representations() {
 }
 
 #[test]
+#[allow(clippy::approx_constant, clippy::bool_assert_comparison)]
 fn test_all_data_types_conversion() {
     // INFRASTRUCTURE TEST: Validates ALL data type conversions
     // Tests F32, F64, I32, I64, Bool, U8, I8, F16, U16 with non-empty and empty tensors


### PR DESCRIPTION
Enables the TMA-specific specialized kernel to be tuned by autotune if available. Also refactors the tuner to avoid all the nameless closures in the tuning log.

## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

