### PR TITLE
Fix incorrect example in burn-store KeyRemapper docs

### DIFF
--- a/crates/burn-store/src/keyremapper.rs
+++ b/crates/burn-store/src/keyremapper.rs
@@ -17,8 +17,8 @@ use crate::TensorSnapshot;
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// // Create a key remapper
 /// let remapper = KeyRemapper::new()
-///     .add_pattern(r"^pytorch\.(.*)", "burn.$1")?  // pytorch.layer -> burn.layer
-///     .add_pattern(r"\.gamma$", ".weight")?;       // layer.gamma -> layer.weight
+///     .add_pattern(r"^pytorch\.", "burn.")?  // pytorch.layer -> burn.layer
+///     .add_pattern(r"\.gamma$", ".weight")?; // layer.gamma -> layer.weight
 ///
 /// // Use remapper with stores
 /// // store.remap(remapper)


### PR DESCRIPTION
I lost over 3 hours due to this and ~~another bug that I'm going to report soon~~ 🫩
Just a docs fix so I didn't fill in the checklist.

Edit: That other bug is the fact that `PytorchReader` does not store paths into `TensorSnapshots`, but looks like it is intended/not a bug so nevermind