### PR TITLE
Ignore number_prefix advisory from tokenizers

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -10,6 +10,7 @@
 ignore = [
     "RUSTSEC-2024-0437", # Protobuf used in ONNX graph parsing.
     "RUSTSEC-2024-0436", # Paste used to generate macro, should be removed at some point.
+    "RUSTSEC-2025-0119", # `number_prefix` used by `tokenizers`, only in the examples.
 ] # advisory IDs to ignore e.g. ["RUSTSEC-2019-0001", ...]
 informational_warnings = [
     "unmaintained",


### PR DESCRIPTION
https://github.com/tracel-ai/burn/pull/4035

Fixes cargo audit