### PR TITLE
Cleanup autodiff unused roots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,6 +591,7 @@ dependencies = [
  "hashbrown 0.15.5",
  "log",
  "num-traits",
+ "parking_lot",
  "portable-atomic",
  "spin",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ indicatif = "0.18.0"
 js-sys = "0.3.77"
 libm = "0.2.15"
 log = { default-features = false, version = "0.4.28" }
+parking_lot = { version = "0.12.5", default-features = false }
 paste = "1"
 planus = { version = "=1.1" }
 polars = { version = "0.51.0", features = ["lazy"] }

--- a/crates/burn-autodiff/Cargo.toml
+++ b/crates/burn-autodiff/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 [features]
 default = ["std"]
 export_tests = ["burn-tensor-testgen"]
-std = []
+std = ["dep:parking_lot"]
 
 [dependencies]
 burn-common = { path = "../burn-common", version = "0.20.0-pre.2", default-features = false }
@@ -26,10 +26,12 @@ burn-tensor-testgen = { path = "../burn-tensor-testgen", version = "0.20.0-pre.2
 
 derive-new = { workspace = true }
 spin = { workspace = true }
+parking_lot = { workspace = true, optional = true }
 log = { workspace = true }
 hashbrown = { workspace = true }
 num-traits = { workspace = true }
 portable-atomic = { workspace = true }
+
 
 [dev-dependencies]
 burn-tensor = { path = "../burn-tensor", version = "0.20.0-pre.2", default-features = false, features = [

--- a/crates/burn-autodiff/src/runtime/client.rs
+++ b/crates/burn-autodiff/src/runtime/client.rs
@@ -10,15 +10,6 @@ use burn_tensor::backend::Backend;
 pub trait AutodiffClient: Send + Clone {
     /// Register a new step.
     fn register(&self, node_id: NodeRefCount, step: StepBoxed, actions: CheckpointerBuilder);
-    /// Register a new untracked step.
-    fn register_untracked(
-        &self,
-        node_id: NodeRefCount,
-        step: StepBoxed,
-        actions: CheckpointerBuilder,
-    ) {
-        self.register(node_id, step, actions);
-    }
     /// Call backpropagation from the given tensor.
     fn backward<B: Backend>(&self, tensor: AutodiffTensor<B>) -> Gradients;
 }

--- a/crates/burn-autodiff/src/runtime/memory_management.rs
+++ b/crates/burn-autodiff/src/runtime/memory_management.rs
@@ -260,6 +260,10 @@ impl GraphMemoryManagement {
             None => panic!("Node should be in the nodes map"),
         }
     }
+
+    pub(crate) fn maybe_useful(&self) -> bool {
+        self.nodes.keys().any(|node| Arc::strong_count(node) > 1)
+    }
 }
 
 /// Wrapper over hash set for fast popping of any node

--- a/crates/burn-autodiff/src/runtime/server.rs
+++ b/crates/burn-autodiff/src/runtime/server.rs
@@ -136,4 +136,8 @@ impl AutodiffServer {
 
         grads
     }
+
+    pub(crate) fn maybe_useful(&self) -> bool {
+        self.memory_management.maybe_useful()
+    }
 }

--- a/crates/burn-autodiff/src/tensor.rs
+++ b/crates/burn-autodiff/src/tensor.rs
@@ -156,19 +156,11 @@ impl<B: Backend> AutodiffTensor<B> {
         step_that_created_the_tensor: S,
         actions: CheckpointerBuilder,
     ) -> Self {
-        if self.is_tracked() {
-            self.node.client.register(
-                self.rc.clone(),
-                Box::new(step_that_created_the_tensor),
-                actions,
-            );
-        } else {
-            self.node.client.register_untracked(
-                self.rc.clone(),
-                Box::new(step_that_created_the_tensor),
-                actions,
-            );
-        }
+        self.node.client.register(
+            self.rc.clone(),
+            Box::new(step_that_created_the_tensor),
+            actions,
+        );
         self
     }
 


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.

### Related Issues/PRs

Fixes an issue introduced by the `GraphMutexClient` in https://github.com/tracel-ai/burn/pull/3793

Previously, the single global autodiff server would take care of unused roots (tensors explicitly marked as require grad that are never used within a backward pass).

With the graph separation, these tensors (and possibly children ops, leading to a tiny unused graph) were never cleaned up since they were never part of a backward pass (never included as part of a "hot" or active backward graph).

This could lead to an increasing amount of tiny graphs during training that were never freed. Because some steps might require the tensors as part of the backward state, it also meant that the GPU handles for these tensors were not being freed either.

### Changes

On backward, `cleanup_orphaned_entries` now also deals with unused roots. This also automatically handles untracked nodes, so I removed part of the changes from https://github.com/tracel-ai/burn/pull/3957

### Testing

Tested using [brush](https://github.com/ArthurBrussee/brush).

Before:
<img width="545" height="278" alt="memory-main" src="https://github.com/user-attachments/assets/0e626b55-1863-4beb-ac28-6b6bcfcda46f" />

The number of graphs continually grows throughout training
```
[INFO  brush_process::train_stream] Start training loop.
...
[INFO  brush_cli] Refine iter 61, 37194 splats.
[INFO  burn_autodiff::backend] ====== Autodiff graph report ======
[INFO  burn_autodiff::backend] GraphMemoryReport { steps: 509, nodes: 509, leaves: 223, graphs: 193 }
[INFO  burn_autodiff::backend] ===================================
...
[INFO  burn_autodiff::backend] ====== Autodiff graph report ======
[INFO  burn_autodiff::backend] GraphMemoryReport { steps: 4227, nodes: 4227, leaves: 1932, graphs: 1697 }
[INFO  burn_autodiff::backend] ===================================
[INFO  brush_cli] Done training.
```

After:
<img width="545" height="278" alt="memory-fixed" src="https://github.com/user-attachments/assets/f578efc6-920a-47ed-9bc0-031348ac3b78" />

The unused roots are cleaned up, keeping only relevant graphs
```
[INFO  brush_process::train_stream] Start training loop.
...
[INFO  brush_cli] Refine iter 61, 37091 splats.
[INFO  burn_autodiff::backend] ====== Autodiff graph report ======
[INFO  burn_autodiff::backend] GraphMemoryReport { steps: 43, nodes: 43, leaves: 15, graphs: 11 }
[INFO  burn_autodiff::backend] ===================================
[INFO  burn_autodiff::backend] ====== Autodiff graph report ======
[INFO  burn_autodiff::backend] GraphMemoryReport { steps: 20, nodes: 20, leaves: 8, graphs: 6 }
[INFO  burn_autodiff::backend] ===================================
[INFO  burn_autodiff::backend] ====== Autodiff graph report ======
[INFO  burn_autodiff::backend] GraphMemoryReport { steps: 10, nodes: 10, leaves: 5, graphs: 4 }
[INFO  burn_autodiff::backend] ===================================
[INFO  burn_autodiff::backend] ====== Autodiff graph report ======
[INFO  burn_autodiff::backend] GraphMemoryReport { steps: 4, nodes: 4, leaves: 2, graphs: 2 }
[INFO  burn_autodiff::backend] ===================================
[INFO  burn_autodiff::backend] ====== Autodiff graph report ======
[INFO  burn_autodiff::backend] GraphMemoryReport { steps: 1, nodes: 1, leaves: 1, graphs: 1 }
[INFO  burn_autodiff::backend] ===================================
...
[INFO  burn_autodiff::backend] ====== Autodiff graph report ======
[INFO  burn_autodiff::backend] GraphMemoryReport { steps: 43, nodes: 43, leaves: 15, graphs: 11 }
[INFO  burn_autodiff::backend] ===================================
[INFO  burn_autodiff::backend] ====== Autodiff graph report ======
[INFO  burn_autodiff::backend] GraphMemoryReport { steps: 20, nodes: 20, leaves: 8, graphs: 6 }
[INFO  burn_autodiff::backend] ===================================
[INFO  burn_autodiff::backend] ====== Autodiff graph report ======
[INFO  burn_autodiff::backend] GraphMemoryReport { steps: 10, nodes: 10, leaves: 5, graphs: 4 }
[INFO  burn_autodiff::backend] ===================================
[INFO  burn_autodiff::backend] ====== Autodiff graph report ======
[INFO  burn_autodiff::backend] GraphMemoryReport { steps: 4, nodes: 4, leaves: 2, graphs: 2 }
[INFO  burn_autodiff::backend] ===================================
[INFO  burn_autodiff::backend] ====== Autodiff graph report ======
[INFO  burn_autodiff::backend] GraphMemoryReport { steps: 1, nodes: 1, leaves: 1, graphs: 1 }
[INFO  burn_autodiff::backend] ===================================
[INFO  brush_cli] Done training.
...

