### PR TITLE
Add warmup epochs to `MetricEarlyStoppingStrategy`. (#3970)

### DIFF
--- a/crates/burn-train/src/learner/early_stopping.rs
+++ b/crates/burn-train/src/learner/early_stopping.rs
@@ -153,9 +153,14 @@ impl MetricEarlyStoppingStrategy {
     }
 
     /// Set the warmup epochs.
-    pub fn with_warmup_epochs(self, warmup: impl Into<Option<usize>>) -> Self {
+    ///
+    /// Early stopping will not trigger during the warmup epochs.
+    ///
+    /// # Arguments
+    /// - `warmup`: the number of warmup epochs, or None.
+    pub fn with_warmup_epochs(self, warmup: Option<usize>) -> Self {
         Self {
-            warmup_epochs: warmup.into(),
+            warmup_epochs: warmup,
             ..self
         }
     }


### PR DESCRIPTION
- Introduce `warmup_epochs` to prevent early stopping during initial training epochs.
- Provide methods to configure and retrieve the warmup period.
- Update test cases to validate warmup functionality.
- tested behavior.