### PR TITLE
Implement Slice iterator and utility methods.

### DIFF
--- a/crates/burn-std/src/tensor/slice.rs
+++ b/crates/burn-std/src/tensor/slice.rs
@@ -351,6 +351,7 @@ impl Iterator for SliceIter {
     }
 }
 
+/// Note: Unbounded [`Slice`]s produce infinite iterators.
 impl IntoIterator for Slice {
     type Item = isize;
     type IntoIter = SliceIter;


### PR DESCRIPTION
- Add `SliceIter` struct and implement `Iterator` for `Slice`.
- Enable `Slice` to be converted into an iterator using `IntoIterator`.
- Add utility methods: `into_vec` and `clip_size` for enhanced slice manipulation.
- Include comprehensive unit tests for new functionality.
