### PR TITLE
Add support for yolo12x model variant check

### DIFF
--- a/crates/burn-import/model-checks/yolo/README.md
+++ b/crates/burn-import/model-checks/yolo/README.md
@@ -7,8 +7,9 @@ This crate provides a unified interface for testing multiple YOLO model variants
 - `yolov5s` - YOLOv5 small variant
 - `yolov8n` - YOLOv8 nano variant
 - `yolov8s` - YOLOv8 small variant
-- `yolo11x` - YOLO11 extra-large variant
 - `yolov10n` - YOLOv10 nano variant (Note: Currently fails due to TopK operator issue)
+- `yolo11x` - YOLO11 extra-large variant
+- `yolo12x` - YOLO12 extra-large variant
 
 ## Usage
 

--- a/crates/burn-import/model-checks/yolo/build.rs
+++ b/crates/burn-import/model-checks/yolo/build.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 fn main() {
     // Supported models
-    let supported_models = vec!["yolov5s", "yolov8n", "yolov8s", "yolov10n", "yolo11x"];
+    let supported_models = vec!["yolov5s", "yolov8n", "yolov8s", "yolov10n", "yolo11x", "yolo12x"];
 
     // Get the model name from environment variable (required)
     let model_name = env::var("YOLO_MODEL").unwrap_or_else(|_| {

--- a/crates/burn-import/model-checks/yolo/get_model.py
+++ b/crates/burn-import/model-checks/yolo/get_model.py
@@ -27,6 +27,7 @@ SUPPORTED_MODELS = {
     'yolov8s': {'download_name': 'yolov8s.pt', 'display_name': 'YOLOv8s'},
     'yolov10n': {'download_name': 'yolov10n.pt', 'display_name': 'YOLOv10n'},
     'yolo11x': {'download_name': 'yolo11x.pt', 'display_name': 'YOLO11x'},
+    'yolo12x': {'download_name': 'yolo12x.pt', 'display_name': 'YOLO12x'},
 }
 
 

--- a/crates/burn-import/model-checks/yolo/src/main.rs
+++ b/crates/burn-import/model-checks/yolo/src/main.rs
@@ -40,6 +40,7 @@ fn get_model_display_name(model_name: &str) -> &str {
         "yolov8s" => "YOLOv8s",
         "yolov10n" => "YOLOv10n",
         "yolo11x" => "YOLO11x",
+        "yolo12x" => "YOLO12x",
         _ => model_name,
     }
 }
@@ -76,6 +77,7 @@ fn main() {
         eprintln!("  - yolov8s");
         eprintln!("  - yolov10n");
         eprintln!("  - yolo11x");
+        eprintln!("  - yolo12x");
         std::process::exit(1);
     }
 


### PR DESCRIPTION
Added yolo12x to the list of supported YOLO model variants in README, build script, Python model downloader, and main Rust source. This enables testing and usage of the yolo12x extra-large variant alongside existing models.

## Pull Request Template

### Related Issues/PRs

https://github.com/tracel-ai/burn-onnx/issues/18

### Changes

Added yolo12x to the list of supported YOLO model variant

### Testing

Run the check but unfortunately our onnx import still doesn't support it

```
 DEBUG onnx_ir::phases::node_conversion: Keeping MatMul node matmul30 (second input is not a constant weight)
  DEBUG onnx_ir::phases::node_conversion: Keeping MatMul node matmul31 (second input is not a constant weight)
  DEBUG onnx_ir::phases::node_conversion: Keeping MatMul node matmul32 (second input is not a constant weight)
   WARN onnx_ir::graph_state: Input  not found, should only happen when peeking
   WARN onnx_ir::graph_state: Input  not found, should only happen when peeking
  DEBUG onnx_ir::pipeline:  PHASE 3: Type Inference
  DEBUG onnx_ir::phases::type_inference: Type inference converged after 5 iterations
  DEBUG onnx_ir::pipeline:  PHASE 4: Post-processing
  DEBUG onnx_ir::phases::post_processing: Starting Identity elimination
  DEBUG onnx_ir::phases::post_processing: Re-running constant lifting after Identity elimination
  DEBUG onnx_ir::pipeline:  PHASE 5: Finalization
  DEBUG onnx_ir::pipeline:  PHASE 6: Node Conversion (NodeBuilder -> Node)
  ERROR burn_import::logger: PANIC => panicked at /Users/dilshod/Projects/burn/crates/onnx-ir/src/node/split.rs:307:14:
  Config extraction failed: Custom("Split: sum of split sizes (96) must equal dimension size (12) along axis 2")

  --- stderr

  thread 'main' panicked at /Users/dilshod/Projects/burn/crates/onnx-ir/src/node/split.rs:307:14:
  Config extraction failed: Custom("Split: sum of split sizes (96) must equal dimension size (12) along axis 2")
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
```