### PR TITLE
Make TransformerEncoderLayer fields public

### DIFF
--- a/crates/burn-nn/src/modules/transformer/encoder.rs
+++ b/crates/burn-nn/src/modules/transformer/encoder.rs
@@ -202,11 +202,18 @@ impl<B: Backend> TransformerEncoder<B> {
 /// Transformer encoder layer module.
 #[derive(Module, Debug)]
 pub struct TransformerEncoderLayer<B: Backend> {
+    /// Multi-head self-attention sub-layer.
     pub mha: MultiHeadAttention<B>,
+    /// Position-wise feed-forward sub-layer.
     pub pwff: PositionWiseFeedForward<B>,
+    /// Layer normalization applied around the feed-forward sub-layer.
     pub norm_1: LayerNorm<B>,
+    /// Layer normalization applied around the attention sub-layer.
     pub norm_2: LayerNorm<B>,
+    /// Dropout module applied to residual connections.
     pub dropout: Dropout,
+    /// If `true`, apply layer normalization before sub-layers (pre-norm),
+    /// otherwise apply it after (post-norm).
     pub norm_first: bool,
 }
 


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

https://github.com/tracel-ai/burn/issues/4043

### Changes

Make TransformerEncoderLayer fields public. It will help to import transformer weighs from pytorch to burn model

