### PR TITLE
Fix floating point norm test tolerance

### DIFF
--- a/crates/burn-nn/src/modules/norm/normalization_wrapper.rs
+++ b/crates/burn-nn/src/modules/norm/normalization_wrapper.rs
@@ -212,6 +212,8 @@ impl<B: Backend> Normalization<B> {
 mod tests {
     use super::*;
     use crate::TestAutodiffBackend;
+    use burn::tensor::{Tolerance, ops::FloatElem};
+    type FT = FloatElem<TestAutodiffBackend>;
 
     #[test]
     fn test_match_feature_size() {
@@ -284,7 +286,9 @@ mod tests {
 
         let output = layer.forward(input);
 
-        output.to_data().assert_eq(&expected.to_data(), true);
+        output
+            .to_data()
+            .assert_approx_eq::<FT>(&expected.to_data(), Tolerance::default());
     }
 
     #[test]
@@ -307,7 +311,9 @@ mod tests {
 
         let output = layer.forward(input);
 
-        output.to_data().assert_eq(&expected.to_data(), true);
+        output
+            .to_data()
+            .assert_approx_eq::<FT>(&expected.to_data(), Tolerance::default());
     }
 
     #[test]
@@ -330,7 +336,9 @@ mod tests {
 
         let output = layer.forward(input);
 
-        output.to_data().assert_eq(&expected.to_data(), true);
+        output
+            .to_data()
+            .assert_approx_eq::<FT>(&expected.to_data(), Tolerance::default());
     }
 
     #[test]
@@ -353,6 +361,8 @@ mod tests {
 
         let output = layer.forward(input);
 
-        output.to_data().assert_eq(&expected.to_data(), true);
+        output
+            .to_data()
+            .assert_approx_eq::<FT>(&expected.to_data(), Tolerance::default());
     }
 }


### PR DESCRIPTION
Fixes tolerance for wgpu/vulkan CI: https://github.com/tracel-ai/burn/actions/runs/19636103921/job/56227098236

```
  failures:
  
  ---- modules::norm::normalization_wrapper::tests::test_instance_norm stdout ----
  
  thread 'modules::norm::normalization_wrapper::tests::test_instance_norm' (18811) panicked at crates/burn-nn/src/modules/norm/normalization_wrapper.rs:310:26:
  Tensors are not eq:
    => Position 0: 0 != -0.000009424321
    => Position 1: 0 != -0.000009424321
    => Position 2: 0 != -0.000009424321
    => Position 3: 0 != -0.000009424321
    => Position 4: 0 != -0.000009424321
  283 more errors...
  
  ---- modules::norm::normalization_wrapper::tests::test_group_norm stdout ----
  
  thread 'modules::norm::normalization_wrapper::tests::test_group_norm' (18810) panicked at crates/burn-nn/src/modules/norm/normalization_wrapper.rs:287:26:
  Tensors are not eq:
    => Position 0: 0 != -0.000009424321
    => Position 1: 0 != -0.000009424321
    => Position 2: 0 != -0.000009424321
    => Position 3: 0 != -0.000009424321
    => Position 4: 0 != -0.000009424321
  283 more errors...
  
  
  failures:
      modules::norm::normalization_wrapper::tests::test_group_norm
      modules::norm::normalization_wrapper::tests::test_instance_norm
  
  test result: FAILED. 215 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 35.84s
  
  error: test failed, to rerun pass `-p burn-nn --lib`
  ```