### PR TITLE
Fix scatter values backward

### DIFF
--- a/crates/burn-autodiff/src/ops/tensor.rs
+++ b/crates/burn-autodiff/src/ops/tensor.rs
@@ -986,7 +986,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
         struct Scatter;
 
         impl<B: Backend> Backward<B, 2> for Scatter {
-            type State = (usize, IntTensor<B>, Shape, Shape, B::Device);
+            type State = (usize, IntTensor<B>);
 
             fn backward(
                 self,
@@ -994,21 +994,15 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                 grads: &mut Gradients,
                 _checkpointer: &mut Checkpointer,
             ) {
-                let (dim, indices, shape_lhs, shape_rhs, device) = ops.state;
-                let [indices_4lhs, indices_4rhs] = duplicate(&ops.parents, Some(indices));
+                let (dim, indices) = ops.state;
+                let [_, indices_4rhs] = duplicate(&ops.parents, Some(indices));
 
                 binary::<B, _, _>(
                     ops.parents,
                     ops.node,
                     grads,
-                    |grad| {
-                        let zeros = B::float_zeros(shape_lhs, &device, grad.dtype().into());
-                        B::float_scatter(dim, grad, indices_4lhs.unwrap(), zeros)
-                    },
-                    |grad| {
-                        let zeros = B::float_zeros(shape_rhs, &device, grad.dtype().into());
-                        B::float_scatter(dim, zeros, indices_4rhs.unwrap(), grad)
-                    },
+                    |grad| grad,
+                    |grad| B::float_gather(dim, grad, indices_4rhs.unwrap()),
                 );
             }
         }
@@ -1019,13 +1013,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
             .stateful()
         {
             OpsKind::Tracked(prep) => prep.finish(
-                (
-                    dim,
-                    indices.clone(),
-                    tensor.primitive.shape(),
-                    value.primitive.shape(),
-                    B::float_device(&value.primitive),
-                ),
+                (dim, indices.clone()),
                 B::float_scatter(dim, tensor.primitive, indices, value.primitive),
             ),
             OpsKind::UnTracked(prep) => prep.finish(B::float_scatter(

--- a/crates/burn-autodiff/src/tests/gather_scatter.rs
+++ b/crates/burn-autodiff/src/tests/gather_scatter.rs
@@ -65,4 +65,40 @@ mod tests {
             .to_data()
             .assert_eq(&TensorData::from([[19., 19., 19.], [64., 64., 64.]]), false);
     }
+
+    #[test]
+    fn test_scatter_grad_partial_indices() {
+        let device = Default::default();
+        let tensor_1 = TestAutodiffTensor::from_data(
+            TensorData::from([[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]]),
+            &device,
+        )
+        .require_grad();
+        let tensor_2 = TestAutodiffTensor::from_data(
+            TensorData::from([[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]]),
+            &device,
+        )
+        .require_grad();
+        let values = TestAutodiffTensor::from_data(TensorData::from([[4.0, 5.0, 6.0]]), &device)
+            .require_grad();
+        let indices = Tensor::<TestAutodiffBackend, 2, Int>::from_data(
+            TensorData::from([[2, 1, 0]]),
+            &device,
+        );
+
+        let tensor_3 = tensor_1.clone().mul(tensor_2);
+        let tensor_4 = tensor_3.clone().scatter(1, indices, values.clone());
+
+        let grads = tensor_4.backward();
+
+        let grad_1 = tensor_1.grad(&grads).unwrap();
+        let grad_2 = values.grad(&grads).unwrap();
+
+        grad_1
+            .to_data()
+            .assert_eq(&TensorData::from([[1., 2., 3., 4., 5., 6.]]), false);
+        grad_2
+            .to_data()
+            .assert_eq(&TensorData::from([[1., 1., 1.]]), false);
+    }
 }


### PR DESCRIPTION
Fix the bug described in https://github.com/tracel-ai/burn/issues/4063; `ops::tensor`'s `Scatter.backward()` has a broken autodiff implementation which crashes on backprop when all three arguments are not all the same size, and even if it didn't (by padding with zeros or otherwise), it's mathematically completely wrong (likely the author confused burn's "add" vs "write" `scatter()` semantics?).

Running `cargo run-checks` passes on my laptop up until building the documentation, whence it exhausts all 32GB of RAM on my laptop.

Anyone have any idea how this got through the various test suites it seems like you run (PyTorch, ONNX, etc.)?

Fixes #4063