### PR TITLE
re-export serde macros

### DIFF
--- a/crates/burn-core/src/lib.rs
+++ b/crates/burn-core/src/lib.rs
@@ -8,9 +8,12 @@
 #[macro_use]
 extern crate derive_new;
 
-/// Re-export serde for proc macros.
+/// Re-export serde and macros.
+/// - Supports burn proc macros,
+/// - Permits clients to define serializable structs with the pinned serde.
+#[allow(unused_imports)]
 #[macro_use]
-pub use serde;
+pub extern crate serde;
 
 /// The configuration module.
 pub mod config;


### PR DESCRIPTION
Burn clients which use `#[derive(Serialize, Deserialize)]` on structs are forced to align a serde dep with their `burn` dep, solely because the `serde` macros are not re-exported.

This permits clients to work directly with the pinned serde dep for simple derive blocks.
