### PR TITLE
Unify all_reduce `LocalCollectiveClient` operation handling.

### DIFF
--- a/crates/burn-collective/src/local/client.rs
+++ b/crates/burn-collective/src/local/client.rs
@@ -20,9 +20,9 @@ pub(crate) struct PendingCollectiveOperation<T> {
     rx: Receiver<Result<T, CollectiveError>>,
 }
 
-impl<T> Into<Receiver<Result<T, CollectiveError>>> for PendingCollectiveOperation<T> {
-    fn into(self) -> Receiver<Result<T, CollectiveError>> {
-        self.rx
+impl<T> From<PendingCollectiveOperation<T>> for Receiver<Result<T, CollectiveError>> {
+    fn from(value: PendingCollectiveOperation<T>) -> Self {
+        value.rx
     }
 }
 


### PR DESCRIPTION
- Extract common logic for starting and waiting on collective operations into dedicated methods (`start_operation`, `operation_wait`).
- Opens door for more complex unit-testing, and common telemetry.
- Add reusable validation logic with `common_valid_start`.
- Refactor `register`, `reduce`, `all_reduce`, `broadcast`, and `finish` methods to leverage new utilities.

- [x] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.
