### PR TITLE
Add removed docs for tensor equal_elem

### DIFF
--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -717,6 +717,7 @@ where
         Self::new(K::cummax(self.primitive, dim))
     }
 
+    /// Applies element wise equal comparison and returns a boolean tensor.
     ///
     /// # Arguments
     ///


### PR DESCRIPTION
Accidentally removed in https://github.com/tracel-ai/burn/pull/3806