### PR TITLE
Fix typo in comment for logger_task function

### DIFF
--- a/examples/raspberry-pi-pico/src/bin/main.rs
+++ b/examples/raspberry-pi-pico/src/bin/main.rs
@@ -84,7 +84,7 @@ fn run_model(model: &Model<NdArray>, device: &BackendDevice, input: f32) -> Tens
     model.forward(input)
 }
 
-// This runs as a seperate task whenever there is an await
+// This runs as a separate task whenever there is an await
 #[embassy_executor::task]
 async fn logger_task(driver: Driver<'static, USB>) {
     // This just makes a logger that outputs to serial.


### PR DESCRIPTION
1-liner; was showing up in build warnings.

```terminaloutput
[2025-12-11T21:13:45Z INFO  tracel_xtask::utils::process] Command line: typos --diff --color always
--- ./examples/raspberry-pi-pico/src/bin/main.rs        original
+++ ./examples/raspberry-pi-pico/src/bin/main.rs        fixed
@@ -87 +87 @@
-// This runs as a seperate task whenever there is an await
+// This runs as a separate task whenever there is an await
```