### PR TITLE
Fix attention shapes and out rank

### DIFF
--- a/crates/burn-tensor/src/tensor/module.rs
+++ b/crates/burn-tensor/src/tensor/module.rs
@@ -434,14 +434,14 @@ pub fn linear<B: Backend, const D: usize>(
 /// optionally applying a 4D mask to the attention scores.
 ///
 /// # Arguments
-/// - `query`: Query tensor of shape `[batch_size, seq_len_q, num_heads, head_dim]`
-/// - `key`: Key tensor of shape `[batch_size, seq_len_k, num_heads, head_dim]`
-/// - `value`: Value tensor of shape `[batch_size, seq_len_k, num_heads, head_dim]`
-/// - `mask`: Optional boolean mask of shape `[batch_size, seq_len_q, num_heads, seq_len_k]`,
+/// - `query`: Query tensor of shape `[batch_size, num_heads, seq_len_q, head_dim]`
+/// - `key`: Key tensor of shape `[batch_size, num_heads, seq_len_k, head_dim]`
+/// - `value`: Value tensor of shape `[batch_size, num_heads, seq_len_k, head_dim]`
+/// - `mask`: Optional boolean mask of shape `[batch_size, num_heads, seq_len_q, seq_len_k]`,
 ///   where `true` indicates positions to mask (i.e. set to -∞ before softmax).
 ///
 /// # Returns
-/// A tensor of shape `[batch_size, seq_len_q, num_heads, head_dim]`
+/// A tensor of shape `[batch_size, num_heads, seq_len_q, head_dim]`
 /// representing the attended context per head.
 ///
 /// # Note
@@ -452,7 +452,7 @@ pub fn attention<B: Backend>(
     key: Tensor<B, 4>,
     value: Tensor<B, 4>,
     mask: Option<Tensor<B, 4, Bool>>,
-) -> Tensor<B, 3> {
+) -> Tensor<B, 4> {
     Tensor::new(TensorPrimitive::Float(B::attention(
         query.primitive.tensor(),
         key.primitive.tensor(),
@@ -467,7 +467,7 @@ pub fn naive_attention<B: Backend>(
     key: Tensor<B, 4>,
     value: Tensor<B, 4>,
     mask: Option<Tensor<B, 4, Bool>>,
-) -> Tensor<B, 3> {
+) -> Tensor<B, 4> {
     Tensor::new(TensorPrimitive::Float(
         crate::ops::attention::naive_attention::<B>(
             query.primitive.tensor(),


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.

### Related Issues/PRs

Fixes #4191 

### Changes

- Fixed inputs shape docs (had seq and head dims permuted based on cubek implementation)
- Fixed output tensor rank
