### PR TITLE
Make xtask validate run no-std checks first.

### DIFF
--- a/xtask/src/commands/validate.rs
+++ b/xtask/src/commands/validate.rs
@@ -14,6 +14,50 @@ pub fn handle_command(
     let exclude = vec![];
     let only = vec![];
 
+    if context == Context::NoStd || context == Context::All {
+        // =================
+        // no-std validation
+        // =================
+        info!("Run validation for no-std execution environment...");
+
+        #[cfg(target_os = "linux")]
+        {
+            // build
+            super::build::handle_command(
+                BurnBuildCmdArgs {
+                    target: target.clone(),
+                    exclude: exclude.clone(),
+                    only: only.clone(),
+                    ci: true,
+                    release: args.release,
+                },
+                env.clone(),
+                Context::NoStd,
+            )?;
+
+            // tests
+            super::test::handle_command(
+                BurnTestCmdArgs {
+                    target: target.clone(),
+                    exclude: exclude.clone(),
+                    only: only.clone(),
+                    threads: None,
+                    jobs: None,
+                    command: Some(TestSubCommand::All),
+                    ci: CiTestType::GithubRunner,
+                    features: None,
+                    no_default_features: false,
+                    force: false,
+                    no_capture: false,
+                    release: args.release,
+                    test: None,
+                },
+                env.clone(),
+                Context::NoStd,
+            )?;
+        }
+    }
+
     if context == Context::Std || context == Context::All {
         // ==============
         // std validation
@@ -91,50 +135,6 @@ pub fn handle_command(
                     context.clone(),
                 )
             })?;
-    }
-
-    if context == Context::NoStd || context == Context::All {
-        // =================
-        // no-std validation
-        // =================
-        info!("Run validation for no-std execution environment...");
-
-        #[cfg(target_os = "linux")]
-        {
-            // build
-            super::build::handle_command(
-                BurnBuildCmdArgs {
-                    target: target.clone(),
-                    exclude: exclude.clone(),
-                    only: only.clone(),
-                    ci: true,
-                    release: args.release,
-                },
-                env.clone(),
-                Context::NoStd,
-            )?;
-
-            // tests
-            super::test::handle_command(
-                BurnTestCmdArgs {
-                    target: target.clone(),
-                    exclude: exclude.clone(),
-                    only: only.clone(),
-                    threads: None,
-                    jobs: None,
-                    command: Some(TestSubCommand::All),
-                    ci: CiTestType::GithubRunner,
-                    features: None,
-                    no_default_features: false,
-                    force: false,
-                    no_capture: false,
-                    release: args.release,
-                    test: None,
-                },
-                env.clone(),
-                Context::NoStd,
-            )?;
-        }
     }
 
     Ok(())


### PR DESCRIPTION
- [x] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.
