### PR TITLE
Unify AsIndex (+ AsShape) handling.

### DIFF
--- a/crates/burn-std/src/tensor/index_conversion.rs
+++ b/crates/burn-std/src/tensor/index_conversion.rs
@@ -1,0 +1,159 @@
+//! # Common Index Coercions
+//!
+//! This module contains common index coercions that can be used to implement
+//! various indexing operations.
+
+use super::indexing::IndexWrap;
+use core::fmt::Debug;
+
+/// Types which can be converted to a `usize` Size.
+pub trait AsSize: Debug + Copy + Sized {
+    /// Convert to a `usize` Size.
+    fn as_size(self) -> usize;
+}
+
+impl<T> AsSize for &T
+where
+    T: AsSize,
+{
+    fn as_size(self) -> usize {
+        (*self).as_size()
+    }
+}
+
+macro_rules! gen_as_size {
+    ($ty:ty) => {
+        impl AsSize for $ty {
+            fn as_size(self) -> usize {
+                self.try_into()
+                    .unwrap_or_else(|_| panic!(
+                        "Unable to convert value to usize: {}_{}",
+                        self,
+                        stringify!($ty)))
+            }
+        }
+    };
+    ($($ty:ty),*) => {$(gen_as_size!($ty);)*};
+}
+
+gen_as_size!(usize, isize, i64, u64, i32, u32, i16, u16, i8, u8);
+
+/// Helper trait for implementing indexing with support for negative indices.
+///
+/// # Example
+/// ```rust
+/// use burn_std::AsIndex;
+///
+/// fn example<I: AsIndex, const D: usize>(dim: I, size: usize) -> isize {
+///    let dim: usize = dim.expect_dim_index(D);
+///    unimplemented!()
+/// }
+/// ```
+pub trait AsIndex: Debug + Copy + Sized {
+    /// Converts into an `isize` index.
+    fn as_index(self) -> isize;
+
+    /// Short-form [`IndexWrap::expect_index(idx, size)`].
+    fn expect_elem_index(self, size: usize) -> usize {
+        IndexWrap::expect_elem(self, size)
+    }
+
+    /// Short-form [`IndexWrap::expect_dim(idx, size)`].
+    fn expect_dim_index(self, size: usize) -> usize {
+        IndexWrap::expect_dim(self, size)
+    }
+}
+
+impl<T> AsIndex for &T
+where
+    T: AsIndex,
+{
+    fn as_index(self) -> isize {
+        (*self).as_index()
+    }
+}
+
+macro_rules! gen_as_index {
+    ($ty:ty) => {
+        impl AsIndex for $ty {
+            fn as_index(self) -> isize {
+                self as isize
+            }
+        }
+    };
+    ($($ty:ty),*) => {$(gen_as_index!($ty);)*};
+}
+
+gen_as_index!(usize, isize, i64, u64, i32, u32, i16, u16, i8, u8);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_as_size() {
+        assert_eq!(1_usize.as_size(), 1_usize);
+        assert_eq!(1_isize.as_size(), 1_usize);
+        assert_eq!(1_i64.as_size(), 1_usize);
+        assert_eq!(1_u64.as_size(), 1_usize);
+        assert_eq!(1_i32.as_size(), 1_usize);
+        assert_eq!(1_u32.as_size(), 1_usize);
+        assert_eq!(1_i16.as_size(), 1_usize);
+        assert_eq!(1_u16.as_size(), 1_usize);
+        assert_eq!(1_i8.as_size(), 1_usize);
+        assert_eq!(1_u8.as_size(), 1_usize);
+
+        assert_eq!((&1_usize).as_size(), 1_usize);
+    }
+
+    #[test]
+    #[should_panic(expected = "Unable to convert value to usize: -1_isize")]
+    fn test_as_size_isize_panic() {
+        (-1_isize).as_size();
+    }
+    #[test]
+    #[should_panic(expected = "Unable to convert value to usize: -1_i64")]
+    fn test_as_size_i64() {
+        (-1_i64).as_size();
+    }
+
+    #[test]
+    #[should_panic(expected = "Unable to convert value to usize: -1_i32")]
+    fn test_as_size_i32() {
+        (-1_i32).as_size();
+    }
+
+    #[test]
+    #[should_panic(expected = "Unable to convert value to usize: -1_i16")]
+    fn test_as_size_i16() {
+        (-1_i16).as_size();
+    }
+
+    #[test]
+    #[should_panic(expected = "Unable to convert value to usize: -1_i8")]
+    fn test_as_size_i8() {
+        (-1_i8).as_size();
+    }
+
+    #[test]
+    fn test_as_index() {
+        assert_eq!(1_usize.as_index(), 1_isize);
+        assert_eq!(1_isize.as_index(), 1_isize);
+        assert_eq!(1_i64.as_index(), 1_isize);
+        assert_eq!(1_u64.as_index(), 1_isize);
+        assert_eq!(1_i32.as_index(), 1_isize);
+        assert_eq!(1_u32.as_index(), 1_isize);
+        assert_eq!(1_i16.as_index(), 1_isize);
+        assert_eq!(1_u16.as_index(), 1_isize);
+        assert_eq!(1_i8.as_index(), 1_isize);
+        assert_eq!(1_u8.as_index(), 1_isize);
+
+        assert_eq!((&1_usize).as_index(), 1_isize);
+
+        assert_eq!(-1_isize.as_index(), -1_isize);
+        assert_eq!(-1_i64.as_index(), -1_isize);
+        assert_eq!(-1_i32.as_index(), -1_isize);
+        assert_eq!(-1_i16.as_index(), -1_isize);
+        assert_eq!(-1_i8.as_index(), -1_isize);
+    }
+}

--- a/crates/burn-std/src/tensor/indexing.rs
+++ b/crates/burn-std/src/tensor/indexing.rs
@@ -8,92 +8,7 @@ use alloc::format;
 use alloc::string::{String, ToString};
 use core::fmt::Debug;
 
-/// Helper trait for implementing indexing with support for negative indices.
-///
-/// # Example
-/// ```rust
-/// use burn_std::AsIndex;
-///
-/// fn example<I: AsIndex, const D: usize>(dim: I, size: usize) -> isize {
-///    let dim: usize = dim.expect_dim_index(D);
-///    unimplemented!()
-/// }
-/// ```
-pub trait AsIndex: Debug + Copy + Sized {
-    /// Converts into a slice index.
-    fn index(self) -> isize;
-
-    /// Short-form [`IndexWrap::expect_index(idx, size)`].
-    fn expect_elem_index(self, size: usize) -> usize {
-        IndexWrap::expect_elem(self, size)
-    }
-
-    /// Short-form [`IndexWrap::expect_dim(idx, size)`].
-    fn expect_dim_index(self, size: usize) -> usize {
-        IndexWrap::expect_dim(self, size)
-    }
-}
-
-impl AsIndex for usize {
-    fn index(self) -> isize {
-        self as isize
-    }
-}
-
-impl AsIndex for isize {
-    fn index(self) -> isize {
-        self
-    }
-}
-
-impl AsIndex for i64 {
-    fn index(self) -> isize {
-        self as isize
-    }
-}
-
-impl AsIndex for u64 {
-    fn index(self) -> isize {
-        self as isize
-    }
-}
-
-// Default integer type
-impl AsIndex for i32 {
-    fn index(self) -> isize {
-        self as isize
-    }
-}
-
-impl AsIndex for u32 {
-    fn index(self) -> isize {
-        self as isize
-    }
-}
-
-impl AsIndex for i16 {
-    fn index(self) -> isize {
-        self as isize
-    }
-}
-
-impl AsIndex for u16 {
-    fn index(self) -> isize {
-        self as isize
-    }
-}
-
-impl AsIndex for i8 {
-    fn index(self) -> isize {
-        self as isize
-    }
-}
-
-impl AsIndex for u8 {
-    fn index(self) -> isize {
-        self as isize
-    }
-}
+pub use crate::tensor::index_conversion::AsIndex;
 
 /// Wraps an index with negative indexing support.
 #[derive(Debug)]
@@ -192,7 +107,7 @@ pub fn try_wrap<I>(
 where
     I: AsIndex,
 {
-    let source_idx = idx.index();
+    let source_idx = idx.as_index();
     let source_size = size;
 
     let size = if source_size > 0 {
@@ -242,7 +157,7 @@ where
     if size == 0 {
         return 0; // Avoid modulo by zero
     }
-    let wrapped = idx.index().rem_euclid(size as isize);
+    let wrapped = idx.as_index().rem_euclid(size as isize);
     if wrapped < 0 {
         (wrapped + size as isize) as usize
     } else {

--- a/crates/burn-std/src/tensor/mod.rs
+++ b/crates/burn-std/src/tensor/mod.rs
@@ -1,10 +1,12 @@
 pub mod dtype;
+pub mod index_conversion;
 pub mod indexing;
 pub mod quantization;
 pub mod shape;
 pub mod slice;
 
 pub use dtype::*;
+pub use index_conversion::*;
 pub use indexing::*;
 pub use quantization::*;
 pub use shape::*;

--- a/crates/burn-std/src/tensor/shape.rs
+++ b/crates/burn-std/src/tensor/shape.rs
@@ -14,6 +14,8 @@ use core::{
 };
 use serde::{Deserialize, Serialize};
 
+pub use crate::tensor::index_conversion::AsSize;
+
 /// Shape of a tensor.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Shape {
@@ -616,70 +618,32 @@ impl DerefMut for Shape {
     }
 }
 
-// Conversion sugar
-impl<const D: usize> From<[usize; D]> for Shape {
-    fn from(dims: [usize; D]) -> Self {
-        Shape::new(dims)
-    }
-}
-
-impl<const D: usize> From<[i64; D]> for Shape {
-    fn from(dims: [i64; D]) -> Self {
-        Shape {
-            dims: dims.into_iter().map(|d| d as usize).collect(),
-        }
-    }
-}
-
-impl<const D: usize> From<[i32; D]> for Shape {
-    fn from(dims: [i32; D]) -> Self {
-        Shape {
-            dims: dims.into_iter().map(|d| d as usize).collect(),
-        }
-    }
-}
-
-impl From<&[usize]> for Shape {
-    fn from(dims: &[usize]) -> Self {
-        Shape { dims: dims.into() }
-    }
-}
-
-impl From<Vec<i64>> for Shape {
-    fn from(shape: Vec<i64>) -> Self {
-        Self {
-            dims: shape.into_iter().map(|d| d as usize).collect(),
-        }
-    }
-}
-
-impl From<Vec<u64>> for Shape {
-    fn from(shape: Vec<u64>) -> Self {
-        Self {
-            dims: shape.into_iter().map(|d| d as usize).collect(),
-        }
-    }
-}
-
-impl From<Vec<usize>> for Shape {
-    fn from(shape: Vec<usize>) -> Self {
-        Self { dims: shape }
-    }
-}
-
-impl From<&Vec<usize>> for Shape {
-    fn from(shape: &Vec<usize>) -> Self {
-        Self {
-            dims: shape.clone(),
-        }
-    }
-}
-
 impl From<Shape> for Vec<usize> {
     fn from(shape: Shape) -> Self {
         shape.dims
     }
 }
+
+/// Marker trait for types that can be converted into a shape.
+pub trait ShapeSource {}
+
+impl<T> From<T> for Shape
+where
+    T: ShapeSource + IntoIterator,
+    T::Item: AsSize,
+{
+    fn from(dims: T) -> Self {
+        Shape {
+            dims: dims.into_iter().map(|d| d.as_size()).collect(),
+        }
+    }
+}
+
+impl<I> ShapeSource for &[I] {}
+impl<I> ShapeSource for &Vec<I> {}
+impl<I> ShapeSource for Vec<I> {}
+impl<I, const D: usize> ShapeSource for [I; D] {}
+impl<I, const D: usize> ShapeSource for &[I; D] {}
 
 #[cfg(test)]
 #[allow(clippy::identity_op, reason = "useful for clarity")]

--- a/crates/burn-std/src/tensor/slice.rs
+++ b/crates/burn-std/src/tensor/slice.rs
@@ -547,8 +547,8 @@ fn handle_signed_inclusive_end(end: isize) -> Option<isize> {
 impl<I: AsIndex> From<Range<I>> for Slice {
     fn from(r: Range<I>) -> Self {
         Self {
-            start: r.start.index(),
-            end: Some(r.end.index()),
+            start: r.start.as_index(),
+            end: Some(r.end.as_index()),
             step: 1,
         }
     }
@@ -557,8 +557,8 @@ impl<I: AsIndex> From<Range<I>> for Slice {
 impl<I: AsIndex + Copy> From<RangeInclusive<I>> for Slice {
     fn from(r: RangeInclusive<I>) -> Self {
         Self {
-            start: (*r.start()).index(),
-            end: handle_signed_inclusive_end((*r.end()).index()),
+            start: r.start().as_index(),
+            end: handle_signed_inclusive_end(r.end().as_index()),
             step: 1,
         }
     }
@@ -567,7 +567,7 @@ impl<I: AsIndex + Copy> From<RangeInclusive<I>> for Slice {
 impl<I: AsIndex> From<RangeFrom<I>> for Slice {
     fn from(r: RangeFrom<I>) -> Self {
         Self {
-            start: r.start.index(),
+            start: r.start.as_index(),
             end: None,
             step: 1,
         }
@@ -578,7 +578,7 @@ impl<I: AsIndex> From<RangeTo<I>> for Slice {
     fn from(r: RangeTo<I>) -> Self {
         Self {
             start: 0,
-            end: Some(r.end.index()),
+            end: Some(r.end.as_index()),
             step: 1,
         }
     }
@@ -588,7 +588,7 @@ impl<I: AsIndex> From<RangeToInclusive<I>> for Slice {
     fn from(r: RangeToInclusive<I>) -> Self {
         Self {
             start: 0,
-            end: handle_signed_inclusive_end(r.end.index()),
+            end: handle_signed_inclusive_end(r.end.as_index()),
             step: 1,
         }
     }

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -1156,7 +1156,7 @@ where
         let mut accumulated_shifts: Vec<isize> = vec![0; shape.len()];
         for i in 0..item_count {
             let dim = dims[i].expect_dim_index(D);
-            accumulated_shifts[dim] += shifts[i].index();
+            accumulated_shifts[dim] += shifts[i].as_index();
         }
 
         // Do this after we've checked the validity of `dims` and `shifts`.
@@ -3184,7 +3184,7 @@ impl<const D1: usize, const D2: usize, E: AsIndex> BroadcastArgs<D1, D2> for [E;
             .iter()
             .rev()
             .map(|x| {
-                let primitive = x.index();
+                let primitive = x.as_index();
                 if primitive < -1 || primitive == 0 {
                     panic!("Broadcast arguments must be positive or -1");
                 }


### PR DESCRIPTION
- Simplify / Unify / Broaden AsIndex; introduce AsShape.
- Expand `From<T> for Shape`

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.