### PR TITLE
Contributor Book: Update the "ONNX to Burn" Page

### DIFF
--- a/contributor-book/src/guides/onnx-to-burn-conversion-tool.md
+++ b/contributor-book/src/guides/onnx-to-burn-conversion-tool.md
@@ -419,7 +419,7 @@ When implementing a new operator, there are several levels of testing to conside
 
 ### Integration Testing
 
-- **Test Path**: Write integration and end-to-end tests in `crates/burn-import/onnx-tests/tests/<op_name>/mod.rs` where `<op_name>` is the name of the new operator. 
+- **Test Path**: Write integration tests in `crates/burn-import/onnx-tests/tests/<op_name>/mod.rs` where `<op_name>` is the name of the new operator. 
 
 - **What to Test**: 
     - Create ONNX models that use your operator and test the end-to-end conversion process


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

None that I am aware of.

### Changes

Changes were made only to the "ONNX to Burn" page of the Contributor Book. The 7th instruction in the "Add New Operators" section was outdated and it included a link to [crates/burn-import/onnx-tests/tests/test_onnx.rs](https://github.com/tracel-ai/burn/blob/main/crates/burn-import/onnx-tests/tests/test_onnx.rs) which no longer exists. Thus, this part was updated to reflect the current repository structure. 

Additionally, the "Integration Testing" and "End-to-End Testing" parts of the Testing section had very similar descriptions and also a link to the text_onnx.rs file which no longer exists. The current repository have integration/end-to-end tests in the `crates/burn-import/onnx-tests/tests/<op_name>/mod.rs files. Thus, the "Integration Testing" and "End-to-End Testing" parts of the Testing section have been combined and the broken link to the test_onnx.rs file have been replaced with the path of mod.rs files. 

### Testing

Not applicable since only a markdown file was modified. 
