### PR TITLE
fix: grid sample using excessive memory

### DIFF
--- a/crates/burn-backend/src/backend/ops/modules/grid_sample.rs
+++ b/crates/burn-backend/src/backend/ops/modules/grid_sample.rs
@@ -11,7 +11,7 @@ use burn_std::{Shape, Slice};
 ///
 /// # Arguments
 ///
-/// * `tensor` - The tensor being sampled from, shape (N, C, H_in, W_in)
+/// * `tensor` - The tensor being sampled from, must be contiguous with shape (N, C, H_in, W_in)
 /// * `grid` - A tensor of locations, with shape (N, H_out, W_out, 2). Values are [-1, 1].
 ///   A [x = -1, y = -1] means top-left, and [x = 1, y = 1] means bottom-right
 /// * `options` - Grid sampling options

--- a/crates/burn-backend/src/backend/ops/tensor.rs
+++ b/crates/burn-backend/src/backend/ops/tensor.rs
@@ -1537,7 +1537,7 @@ pub trait FloatTensorOps<B: Backend> {
     ///
     /// # Arguments
     ///
-    /// * `tensor` - The tensor being sampled from, shape (N, C, H_in, W_in)
+    /// * `tensor` - The tensor being sampled from, must be contiguous with shape (N, C, H_in, W_in)
     /// * `grid` - A tensor of locations, with shape (N, H_out, W_out, 2). Values are [-1, 1].
     ///   A [x = -1, y = -1] means top-left, and [x = 1, y = 1] means bottom-right
     /// * `options` - Grid sampling options (mode, padding_mode, align_corners)

--- a/crates/burn-ndarray/src/ops/grid_sample.rs
+++ b/crates/burn-ndarray/src/ops/grid_sample.rs
@@ -13,7 +13,7 @@ use crate::{FloatNdArrayElement, UnsafeSharedRef, iter_range_par, run_par};
 ///
 /// # Arguments
 ///
-/// * `tensor` - The tensor being sampled from, shape (N, C, H_in, W_in)
+/// * `tensor` - The tensor being sampled from, must be contiguous with shape (N, C, H_in, W_in)
 /// * `grid` - A tensor of locations, with shape (N, H_out, W_out, 2). Values are [-1, 1].
 ///   A [x = -1, y = -1] means top-left, and [x = 1, y = 1] means bottom-right
 /// * `options` - Grid sampling options (mode, padding_mode, align_corners)


### PR DESCRIPTION
## Pull Request Template

The int_expands and float_expands caused memory usage to explode: it failed trying to allocate 10.5GB (1 * 3 * 640 * 480 * 2859 elements).

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

Changes the logic to use flattened indexing instead of a huge expand.

### Testing

I no longer get an OOM crash with this change, and the results are equivalent given the tests pass.