### PR TITLE
Fix BinBytesRecorder bincode decoding

### DIFF
--- a/crates/burn-core/src/record/memory.rs
+++ b/crates/burn-core/src/record/memory.rs
@@ -1,5 +1,5 @@
 use super::{PrecisionSettings, Recorder, RecorderError, bin_config};
-use alloc::vec::Vec;
+use alloc::{string::ToString, vec::Vec};
 use burn_tensor::backend::Backend;
 use serde::{Serialize, de::DeserializeOwned};
 


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [x] Ran `cargo run -p xtask -- --help` successfully (workspace sanity check without Torch).
- [x] Made sure the book is up to date with changes in this PR. (No book changes needed.)

### Related Issues/PRs

- n/a

### Changes

- Fix `BinBytesRecorder::load_item` to use `bincode::serde::decode_from_slice` (the API available in crates.io bincode).
- Map decode errors to `RecorderError::DeserializeError`.
- Resolves build failure when enabling `burn_runtime`/BinBytesRecorder because `decode_borrowed_from_slice` is unavailable.

### Testing

- cargo fmt
- cargo run -p xtask -- --help
- cargo test (fails on torch-sys libtorch download; unrelated to this change)
