### PR TITLE
Implement TODO tests and validation for Sum operation in onnx-ir

### DIFF
--- a/crates/onnx-ir/src/node/sum.rs
+++ b/crates/onnx-ir/src/node/sum.rs
@@ -351,7 +351,10 @@ mod tests {
                 assert_eq!(expected, "Numeric (Float, Int, or UInt)");
                 assert_eq!(actual, "Bool");
             }
-            err => panic!("Expected TypeMismatch error for non-numeric type, got {:?}", err),
+            err => panic!(
+                "Expected TypeMismatch error for non-numeric type, got {:?}",
+                err
+            ),
         }
     }
 


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

None

### Changes
Added `ArgType` and `DType` to the line `use crate::ir::{Argument, Node, RawNode};` at the top of crates/onnx-ir/src/node/sum.rs to use them in `infer_type()`. 

Implemented the following TODO comments:
```
// TODO: Missing validation that all inputs have compatible dtypes.
// ONNX spec requires all inputs to have the same data type, but this isn't validated.

// TODO: Missing test for single input - Sum with one input should return that input unchanged.
// This is a valid edge case per ONNX spec.

// TODO: Missing test for broadcasting with different ranks.
// E.g., Sum of [3, 4, 5] + [1, 5] + [5] should broadcast correctly.

// TODO: Missing test for type constraint validation.
// Sum should only support numeric types, need test to verify string/bool inputs are rejected.

// TODO: Missing test for zero-size tensor inputs.
// What happens with Sum of tensors with shape [0, 3, 4]?

// TODO: Missing test for very many inputs (e.g., 100+ inputs).
// Verify implementation can handle many inputs without stack overflow or performance issues.
```

### Testing

While one implemented TODO comment is validation, the remaining five are tests for the existing code. One of the new tests corresponds to the newly implemented validation code in `infer_types()`.
