### PR TITLE
Fix panic with non-contiguous tensors in matmul

### DIFF
--- a/crates/burn-cubecl/src/ops/float_ops.rs
+++ b/crates/burn-cubecl/src/ops/float_ops.rs
@@ -157,6 +157,9 @@ where
 
     fn float_matmul(lhs: FloatTensor<Self>, rhs: FloatTensor<Self>) -> FloatTensor<Self> {
         let dtype = lhs.dtype;
+        // Ensure tensors are contiguous for matmul kernel compatibility
+        let lhs = into_contiguous(lhs);
+        let rhs = into_contiguous(rhs);
         matmul(lhs, rhs, None, MatmulStrategy::default(), dtype).unwrap()
     }
 

--- a/crates/burn-cubecl/src/ops/int_ops.rs
+++ b/crates/burn-cubecl/src/ops/int_ops.rs
@@ -8,7 +8,7 @@ use crate::kernel::{
 use crate::{
     CubeBackend, CubeRuntime, FloatElement, IntElement,
     kernel::{
-        self,
+        self, into_contiguous,
         matmul::{MatmulStrategy, matmul},
     },
 };
@@ -96,6 +96,9 @@ where
 
     fn int_matmul(lhs: IntTensor<Self>, rhs: IntTensor<Self>) -> IntTensor<Self> {
         let dtype = lhs.dtype;
+        // Ensure tensors are contiguous for matmul kernel compatibility
+        let lhs = into_contiguous(lhs);
+        let rhs = into_contiguous(rhs);
         matmul(lhs, rhs, None, MatmulStrategy::default(), dtype).unwrap()
     }
 

--- a/crates/burn-cubecl/src/ops/qtensor.rs
+++ b/crates/burn-cubecl/src/ops/qtensor.rs
@@ -13,7 +13,7 @@ use cubecl::server::{Allocation, AllocationDescriptor, AllocationKind};
 use crate::{
     CubeBackend, CubeRuntime, FloatElement, IntElement,
     element::BoolElement,
-    kernel::{self, matmul::MatmulStrategy},
+    kernel::{self, into_contiguous, matmul::MatmulStrategy},
     tensor::{CubeTensor, QParams},
 };
 
@@ -293,6 +293,10 @@ where
             TensorPrimitive::Float(rhs) => (rhs.dtype, rhs),
             TensorPrimitive::QFloat(rhs) => (out_dtype, rhs),
         };
+
+        // Ensure tensors are contiguous for matmul kernel compatibility
+        let lhs = into_contiguous(lhs);
+        let rhs = into_contiguous(rhs);
 
         let out =
             kernel::matmul::matmul(lhs, rhs, None, MatmulStrategy::default(), out_dtype).unwrap();


### PR DESCRIPTION
The cubek matmul library requires contiguous or specific stride patterns for input tensors. When a transposed tensor (e.g., from LinearLayout::Col) was passed to matmul, it would panic with "Invalid or non-contiguous matrix layout".

This fix ensures tensors are made contiguous before passing them to the matmul kernel by calling into_contiguous() on both lhs and rhs tensors in float_matmul, int_matmul, and q_matmul implementations.

Fixes tracel-ai/burn#4226

## Pull Request Template

### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

_Provide links to relevant issues and dependent PRs._

### Changes

_Summarize the problem being addressed and your solution._

### Testing

_Describe how these changes have been tested._
