### PR TITLE
Fix burn-store collector tuple modules

### DIFF
--- a/crates/burn-core/src/module/base.rs
+++ b/crates/burn-core/src/module/base.rs
@@ -241,6 +241,7 @@ pub trait ModuleVisitor<B: Backend> {
     ///   - For user-defined structs: "Struct:TypeName" (e.g., "Struct:Linear")
     ///   - For user-defined enums: "Enum:TypeName" (e.g., "Enum:MyEnum")
     ///   - For Vec containers: "Vec" (name is the index)
+    ///   - For Tuple containers: "Tuple" (name is the index)
     ///   - For Array containers: "Array" (name is the index)
     ///
     /// Note: Option containers do not call enter_module/exit_module to preserve
@@ -256,6 +257,7 @@ pub trait ModuleVisitor<B: Backend> {
     ///   - For user-defined structs: "Struct:TypeName" (e.g., "Struct:Linear")
     ///   - For user-defined enums: "Enum:TypeName" (e.g., "Enum:MyEnum")
     ///   - For Vec containers: "Vec" (name is the index)
+    ///   - For Tuple containers: "Tuple" (name is the index)
     ///   - For Array containers: "Array" (name is the index)
     ///
     /// Note: Option containers do not call enter_module/exit_module to preserve
@@ -325,6 +327,7 @@ pub trait ModuleMapper<B: Backend> {
     ///   - For user-defined structs: "Struct:TypeName" (e.g., "Struct:Linear")
     ///   - For user-defined enums: "Enum:TypeName" (e.g., "Enum:MyEnum")
     ///   - For Vec containers: "Vec" (name is the index)
+    ///   - For Tuple containers: "Tuple" (name is the index)
     ///   - For Array containers: "Array" (name is the index)
     ///
     /// Note: Option containers do not call enter_module/exit_module to preserve
@@ -340,6 +343,7 @@ pub trait ModuleMapper<B: Backend> {
     ///   - For user-defined structs: "Struct:TypeName" (e.g., "Struct:Linear")
     ///   - For user-defined enums: "Enum:TypeName" (e.g., "Enum:MyEnum")
     ///   - For Vec containers: "Vec" (name is the index)
+    ///   - For Tuple containers: "Tuple" (name is the index)
     ///   - For Array containers: "Array" (name is the index)
     ///
     /// Note: Option containers do not call enter_module/exit_module to preserve

--- a/crates/burn-store/src/safetensors/store.rs
+++ b/crates/burn-store/src/safetensors/store.rs
@@ -579,6 +579,7 @@ impl MemoryStore {
 }
 
 // Adapter to use TensorSnapshot directly with safetensors
+#[derive(Debug)]
 struct TensorSnapshotAdapter(TensorSnapshot);
 
 impl safetensors::View for TensorSnapshotAdapter {

--- a/crates/burn-store/src/safetensors/tests/mod.rs
+++ b/crates/burn-store/src/safetensors/tests/mod.rs
@@ -1,6 +1,7 @@
 mod adapter;
 mod direct_access;
 mod error_handling;
+#[cfg(feature = "std")]
 mod file_io;
 mod filtering;
 mod integration;


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Fixes #4267 

### Changes

Correctly handle tuple modules "flat path" with field name / index.

Previously the fields were not part of the path, leading to duplicate paths (e.g. multiple `"layers.weight"` paths instead of different `"layers.{i}.weight"`). These duplicate names were filtered, which incorrectly removed snapshots from a module when trying to save it (and thus the linked issue error).

### Testing

Added tests.
