### PR TITLE
Pinned bincode workspace dependency to the exact version =2.0.0-rc.3 …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ github-device-flow = "0.2.0"
 os_info = "3.8.2"
 wsl = "0.1.0"
 
-bincode = { version = "2.0.0-rc.3", features = [
+bincode = { version = "=2.0.0-rc.3", features = [
     "alloc",
     "serde",
 ], default-features = false }


### PR DESCRIPTION
…in Cargo.toml

## Pull Request Template

### Checklist
- [x] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs
- Repro: `git checkout v0.14.0 && rm Cargo.lock && cargo publish --dry-run -p burn-core` fails with E0425 (bincode API change).

### Changes
- Pin `bincode` in burn-core to `=2.0.0-rc.3` to prevent Cargo from resolving 2.0.1+, which removes `decode_borrowed_from_slice` and breaks publish/build when no lockfile is present.
- Scope: 0.14.x line only; minimal change to restore publishability.

### Testing
- `cargo run-checks`
- `cargo publish --dry-run -p burn-core` (succeeds with the exact pin)




Additional info just for clarity:
- Cargo.lock isn’t used by library consumers; when downstream builds burn-core, Cargo re-resolves deps. Any lock in the repo is ignored.
- cargo publish also re-resolves unless you force --locked. With the lock present it holds bincode at 2.0.0-rc.3, so the break is masked; without it, Cargo picks bincode 2.0.1 and build/publish fails.
- The repro removes Cargo.lock to mirror the published experience: fresh resolution pulls bincode 2.0.1, which lacks decode_borrowed_from_slice, causing E0425.
