### PR TITLE
Ignore bincode RUSTSEC for now (unmaintained)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -11,6 +11,7 @@ ignore = [
     "RUSTSEC-2024-0437", # Protobuf used in ONNX graph parsing.
     "RUSTSEC-2024-0436", # Paste used to generate macro, should be removed at some point.
     "RUSTSEC-2025-0119", # `number_prefix` used by `tokenizers`, only in the examples.
+    "RUSTSEC-2025-0141", # `bincode` is no longer maintained.
 ] # advisory IDs to ignore e.g. ["RUSTSEC-2019-0001", ...]
 informational_warnings = [
     "unmaintained",


### PR DESCRIPTION
`bincode` used in recorder is no longer maintained.

Ignore RUSTSEC until we potentially remove it.

Made into a separate PR just to merge quickly and avoid blocking pending PRs.