### PR TITLE
docs: More examples for boolean tensor operations

### DIFF
--- a/crates/burn-tensor/src/tensor/api/bool.rs
+++ b/crates/burn-tensor/src/tensor/api/bool.rs
@@ -20,16 +20,74 @@ where
     B: Backend,
 {
     /// Create a boolean tensor from data on the given device.
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - The tensor data.
+    /// * `device` - The device on which the tensor will be allocated.
+    ///
+    /// # Returns
+    ///
+    /// A boolean tensor.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use burn_tensor::backend::Backend;
+    /// use burn_tensor::{Tensor, Bool};
+    ///
+    /// fn example<B: Backend>() {
+    ///     let device = Default::default();
+    ///     let tensor = Tensor::<B, 2, Bool>::from_bool([[true, false], [false, true]].into(), &device);
+    ///     println!("{tensor}");
+    /// }
+    /// ```
     pub fn from_bool(data: TensorData, device: &B::Device) -> Self {
         Self::new(B::bool_from_data(data.convert::<B::BoolElem>(), device))
     }
 
     /// Convert the bool tensor into an int tensor.
+    ///
+    /// # Returns
+    ///
+    /// An integer tensor where `true` is converted to `1` and `false` to `0`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use burn_tensor::backend::Backend;
+    /// use burn_tensor::{Tensor, Bool};
+    ///
+    /// fn example<B: Backend>() {
+    ///     let device = Default::default();
+    ///     let bool_tensor = Tensor::<B, 1, Bool>::from_bool([true, false, true].into(), &device);
+    ///     let int_tensor = bool_tensor.int();
+    ///     println!("{int_tensor}"); // [1, 0, 1]
+    /// }
+    /// ```
     pub fn int(self) -> Tensor<B, D, Int> {
         Tensor::new(B::bool_into_int(self.primitive))
     }
 
     /// Convert the bool tensor into a float tensor.
+    ///
+    /// # Returns
+    ///
+    /// A float tensor where `true` is converted to `1.0` and `false` to `0.0`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use burn_tensor::backend::Backend;
+    /// use burn_tensor::{Tensor, Bool};
+    ///
+    /// fn example<B: Backend>() {
+    ///     let device = Default::default();
+    ///     let bool_tensor = Tensor::<B, 1, Bool>::from_bool([true, false, true].into(), &device);
+    ///     let float_tensor = bool_tensor.float();
+    ///     println!("{float_tensor}"); // [1.0, 0.0, 1.0]
+    /// }
+    /// ```
     pub fn float(self) -> Tensor<B, D> {
         Tensor::new(TensorPrimitive::Float(B::bool_into_float(self.primitive)))
     }
@@ -144,6 +202,24 @@ where
     ///
     /// A vector of tensors, one for each dimension of the given tensor, containing the indices of
     /// the non-zero elements in that dimension.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use burn_tensor::backend::Backend;
+    /// use burn_tensor::{Tensor, Bool};
+    ///
+    /// fn example<B: Backend>() {
+    ///     let device = Default::default();
+    ///     let tensor = Tensor::<B, 2, Bool>::from_bool(
+    ///         [[true, false, true], [false, true, false], [false, true, false]].into(),
+    ///         &device,
+    ///     );
+    ///     let indices = tensor.nonzero();
+    ///     println!("{}", indices[0]); // [0, 0, 1, 2]
+    ///     println!("{}", indices[1]); // [0, 2, 1, 1]
+    /// }
+    /// ```
     pub fn nonzero(self) -> Vec<Tensor<B, 1, Int>> {
         try_read_sync(self.nonzero_async())
             .expect("Failed to read tensor data synchronously. Try using nonzero_async instead.")
@@ -177,6 +253,23 @@ where
     ///
     /// A tensor containing the indices of all non-zero elements of the given tensor. Each row in the
     /// result contains the indices of a non-zero element.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use burn_tensor::backend::Backend;
+    /// use burn_tensor::{Tensor, Bool};
+    ///
+    /// fn example<B: Backend>() {
+    ///     let device = Default::default();
+    ///     let tensor = Tensor::<B, 2, Bool>::from_bool(
+    ///         [[true, false, true], [false, true, false], [false, true, false]].into(),
+    ///         &device,
+    ///     );
+    ///     let indices = tensor.argwhere();
+    ///     println!("{indices}"); // [[0, 0], [0, 2], [1, 1], [2, 1]]
+    /// }
+    /// ```
     pub fn argwhere(self) -> Tensor<B, 2, Int> {
         try_read_sync(self.argwhere_async())
             .expect("Failed to read tensor data synchronously. Try using argwhere_async instead.")


### PR DESCRIPTION
### Checklist

- [X] Confirmed that `cargo run-checks` command has been executed.
- [X] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Contributes to #2450

### Changes

Added documentation examples for remaining boolean tensor operations in `burn-tensor`:

- `from_bool` - Boolean tensor construction
- `int` - Int tensor conversion
- `float` - Float tensor conversion
- `nonzero` - Indices of nonzero elements for each dimension
- `argwhere` - Indices of nonzero elements as coordinates

Added doc examples with:

- Clear descriptions of what each operation does
- Arguments and Returns sections
- Code examples
- Expected output in comments

### Testing

`cargo test --doc`
