### PR TITLE
Fix rand os_rng

### DIFF
--- a/crates/burn-dataset/Cargo.toml
+++ b/crates/burn-dataset/Cargo.toml
@@ -57,7 +57,7 @@ encoding_rs = { workspace = true, optional = true }
 polars = { workspace = true, optional = true }
 r2d2 = { workspace = true, optional = true }
 r2d2_sqlite = { workspace = true, optional = true }
-rand = { workspace = true, features = ["std"] }
+rand = { workspace = true, features = ["std", "os_rng"] }
 zip = { workspace = true, optional = true }
 rmp-serde = { workspace = true }
 rusqlite = { workspace = true, optional = true }


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Fixes #4292 

### Changes

Added missing `os_rng` feature for `rand` in `burn-dataset`.

### Testing

Reproduced linked issue (only happened with `ndarray` feature, as `wgpu` would activate rand default features with downstream deps chain)
