### PR TITLE
ensure that tensor is owned on iter_dim call

### DIFF
--- a/crates/burn-ndarray/src/ops/base.rs
+++ b/crates/burn-ndarray/src/ops/base.rs
@@ -58,9 +58,9 @@ impl<E> NdArrayOps<E>
 where
     E: Copy + Debug + Element + crate::AddAssignElement,
 {
-    pub fn slice(tensor: SharedArray<E>, slices: &[Slice]) -> SharedArray<E> {
+    pub fn slice(tensor: ArrayView<E, IxDyn>, slices: &[Slice]) -> SharedArray<E> {
         let slices = Self::to_slice_args_with_steps(slices, tensor.shape().num_dims());
-        tensor.slice_move(slices.as_slice()).into_shared()
+        tensor.slice_move(slices.as_slice()).to_shared()
     }
 
     pub fn slice_assign(

--- a/crates/burn-ndarray/src/ops/bool_tensor.rs
+++ b/crates/burn-ndarray/src/ops/bool_tensor.rs
@@ -13,7 +13,7 @@ use ndarray::IntoDimension;
 // Current crate
 use crate::element::{FloatNdArrayElement, IntNdArrayElement, QuantElement};
 use crate::{NdArray, execute_with_int_dtype, tensor::NdArrayTensor};
-use crate::{NdArrayDevice, SharedArray};
+use crate::{NdArrayDevice, SharedArray, slice};
 
 // Workspace crates
 use burn_backend::{Shape, TensorData, backend::Backend};
@@ -46,7 +46,7 @@ where
     }
 
     fn bool_slice(tensor: NdArrayTensor, slices: &[burn_backend::Slice]) -> NdArrayTensor {
-        NdArrayOps::slice(tensor.bool(), slices).into()
+        slice!(tensor, slices)
     }
 
     fn bool_into_int(tensor: NdArrayTensor) -> NdArrayTensor {

--- a/crates/burn-ndarray/src/ops/int_tensor.rs
+++ b/crates/burn-ndarray/src/ops/int_tensor.rs
@@ -10,7 +10,7 @@ use burn_backend::ElementConversion;
 
 // Current crate
 use crate::{NdArray, cast_to_dtype, execute_with_dtype, tensor::NdArrayTensor};
-use crate::{NdArrayDevice, SEED};
+use crate::{NdArrayDevice, SEED, slice};
 use crate::{SharedArray, element::QuantElement};
 use crate::{cat_with_dtype, execute_with_float_dtype};
 use crate::{element::FloatNdArrayElement, ops::matmul::matmul};
@@ -47,7 +47,7 @@ where
     }
 
     fn int_slice(tensor: NdArrayTensor, slices: &[burn_backend::Slice]) -> NdArrayTensor {
-        execute_with_int_dtype!(tensor, |array| NdArrayOps::slice(array, slices))
+        slice!(tensor, slices)
     }
 
     fn int_device(_tensor: &NdArrayTensor) -> <NdArray<E> as Backend>::Device {

--- a/crates/burn-ndarray/src/ops/qtensor.rs
+++ b/crates/burn-ndarray/src/ops/qtensor.rs
@@ -13,7 +13,7 @@ use burn_backend::{
 use crate::{
     FloatNdArrayElement, NdArray, NdArrayDevice, NdArrayQTensor, NdArrayTensor, SharedArray,
     element::{IntNdArrayElement, QuantElement},
-    execute_with_dtype, execute_with_int_dtype, execute_with_numeric_dtype,
+    execute_with_dtype, execute_with_int_dtype, execute_with_numeric_dtype, slice,
 };
 
 use super::quantization::{QuantizationStrategy, SymmetricQuantization};
@@ -300,9 +300,7 @@ where
         slices: &[burn_backend::Slice],
     ) -> QuantizedTensor<Self> {
         NdArrayQTensor {
-            qtensor: execute_with_dtype!(tensor.qtensor, E, |array: SharedArray<E>| {
-                NdArrayOps::slice(array, slices)
-            }),
+            qtensor: slice!(tensor.qtensor, slices),
             scheme: tensor.scheme,
             qparams: tensor.qparams,
         }

--- a/crates/burn-ndarray/src/ops/tensor.rs
+++ b/crates/burn-ndarray/src/ops/tensor.rs
@@ -13,7 +13,7 @@ use super::{
 use crate::{
     NdArray, cast_to_dtype, cat_with_dtype, execute_with_int_dtype, tensor::NdArrayTensor,
 };
-use crate::{NdArrayDevice, SEED};
+use crate::{NdArrayDevice, SEED, slice};
 use crate::{
     SharedArray,
     element::{ExpElement, FloatNdArrayElement, IntNdArrayElement, QuantElement},
@@ -247,9 +247,7 @@ where
     }
 
     fn float_slice(tensor: FloatTensor<Self>, slices: &[burn_backend::Slice]) -> FloatTensor<Self> {
-        execute_with_float_dtype!(tensor, FloatElem, |array: SharedArray<FloatElem>| {
-            NdArrayOps::slice(array, slices)
-        })
+        slice!(tensor, slices)
     }
 
     fn float_slice_assign(

--- a/crates/burn-ndarray/src/tensor.rs
+++ b/crates/burn-ndarray/src/tensor.rs
@@ -511,6 +511,19 @@ macro_rules! reshape {
     }};
 }
 
+/// Slice a tensor
+#[macro_export]
+macro_rules! slice {
+    ($tensor:expr, $slices:expr) => {
+        slice!($tensor, $slices, F64, F32, I64, I32, I16, I8, U64, U32, U16, U8, Bool)
+    };
+    ($tensor:expr, $slices:expr, $($variant:ident),*) => {
+        match $tensor {
+            $(NdArrayTensor::$variant(s) => { NdArrayOps::slice(s.view(), $slices).into() })*
+        }
+    };
+}
+
 impl NdArrayTensor {
     /// Create a new [ndarray tensor](NdArrayTensor) from [data](TensorData).
     ///


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

Changes introduced in https://github.com/tracel-ai/burn/pull/4178 affected `iter_dim` in a way that may blow up memory usage on ndarray, e.g.:

- `iter_dim` get called with a borrowed tensor
- each iteration calls `tensor.clone().slice(...)` (via `impl Iterator for DimIter`)
- call to slice invokes `NdArrayStorage::into_shared`/`into_owned` (via macro in burn-ndarray/src/tensor.rs)
- for a borrowed tensor this ends up calling `view.to_owned()` which clones the whole tensor

I've added a call to `DimIter` constructor to `ensure_owned` on the tensor, so that `NdArrayStorage::into_owned` on each iter is a no-op.

The call goes via a few layers on indirection due to tensor primitive typing and there may be a better way to achieve this that I missed.

### Testing

Tested externally by running a test with `iter_dim` before and after and using heaptrack to profile memory usage.
