### PR TITLE
Fix quantization docs (make it clear that only PTQ is supported)

### DIFF
--- a/burn-book/src/performance/quantization.md
+++ b/burn-book/src/performance/quantization.md
@@ -30,7 +30,7 @@ Quantization support in Burn is currently in active development.
 
 It supports the following PTQ modes on some backends:
 
-- Per-tensor and per-block (linear) quantization to 8-bit, 4-bit and 2-bit representations
+- Per-tensor and per-block quantization to 8-bit, 4-bit and 2-bit representations
 
 No integer operations are currently supported, which means tensors are dequantized to perform the
 operations in floating point precision.


### PR DESCRIPTION
### Checklist

- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

As originally reported [on discord](https://discord.com/channels/1038839012602941528/1091796857996451942/1459972510484402378):

> It should probably be clarified, this paragraph
"
Quantization errors are thus modeled in the forward and backward passes using fake quantization modules, which helps the model learn representations that are more robust to the reduction in precision.
" particularly makes it sound like [QAT is] implemented with it giving technical details

### Changes

Updated description to clarify that only PTQ is currently implemented, no QAT support yet.