### PR TITLE
Add `shape.into_iter() explicit method

### DIFF
--- a/crates/burn-std/src/tensor/shape.rs
+++ b/crates/burn-std/src/tensor/shape.rs
@@ -244,6 +244,11 @@ impl Shape {
         self.dims.iter()
     }
 
+    /// Consume the shape and return an iterator over its dimensions.
+    pub fn into_iter(self) -> alloc::vec::IntoIter<usize> {
+        self.dims.into_iter()
+    }
+
     /// Mutable iterator over the dimensions.
     pub fn iter_mut(&mut self) -> IterMut<'_, usize> {
         self.dims.iter_mut()

--- a/crates/burn-tch/src/ops/int_tensor.rs
+++ b/crates/burn-tch/src/ops/int_tensor.rs
@@ -390,7 +390,7 @@ impl<E: TchElement> IntTensorOps<Self> for LibTorch<E> {
             Distribution::Default => TchTensor::new(tch::Tensor::randint_low(
                 0,
                 255,
-                shape.dims.into_iter().map(|i| i as i64).collect::<Vec<_>>(),
+                shape.into_iter().map(|i| i as i64).collect::<Vec<_>>(),
                 (tch::Kind::Int64, (*device).into()),
             )),
             Distribution::Bernoulli(prob) => {
@@ -402,7 +402,7 @@ impl<E: TchElement> IntTensorOps<Self> for LibTorch<E> {
             Distribution::Uniform(from, to) => TchTensor::new(tch::Tensor::randint_low(
                 from as i64,
                 to as i64,
-                shape.dims.into_iter().map(|i| i as i64).collect::<Vec<_>>(),
+                shape.into_iter().map(|i| i as i64).collect::<Vec<_>>(),
                 (tch::Kind::Int64, (*device).into()),
             )),
             Distribution::Normal(mean, std) => {

--- a/crates/burn-tch/src/tensor.rs
+++ b/crates/burn-tch/src/tensor.rs
@@ -318,7 +318,7 @@ pub struct TchShape {
 impl From<Shape> for TchShape {
     fn from(shape: Shape) -> Self {
         TchShape {
-            dims: shape.dims.into_iter().map(|d| d as i64).collect(),
+            dims: shape.into_iter().map(|d| d as i64).collect(),
         }
     }
 }


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.

### Related Issues/PRs

Follow-up to https://github.com/tracel-ai/burn/pull/4221

### Changes

`IntoIterator` trait was removed but we can still provide `shape.into_iter()` explicitly, following `shape.iter()`.
