### PR TITLE
Implement `From<E>` for constant padding

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/float/ops/padding.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/padding.rs
@@ -6,7 +6,7 @@ fn padding_constant_2d_test() {
     let unpadded_floats: [[f32; 3]; 2] = [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]];
     let tensor = TestTensor::<2>::from(unpadded_floats);
 
-    let padded_tensor = tensor.pad((2, 2, 2, 2), PadMode::Constant(1.1));
+    let padded_tensor = tensor.pad((2, 2, 2, 2), 1.1);
 
     let expected = TensorData::from([
         [1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1],
@@ -24,7 +24,7 @@ fn padding_constant_4d_test() {
     let unpadded_floats = [[[[0.0, 1.0], [2.0, 3.0], [4.0, 5.0]]]];
     let tensor = TestTensor::<4>::from(unpadded_floats);
 
-    let padded_tensor = tensor.pad((2, 2, 2, 2), PadMode::Constant(1.1));
+    let padded_tensor = tensor.pad((2, 2, 2, 2), 1.1);
 
     let expected = TensorData::from([[[
         [1.1, 1.1, 1.1, 1.1, 1.1, 1.1],
@@ -43,7 +43,7 @@ fn padding_constant_asymmetric_test() {
     let unpadded_floats = [[[[0.0, 1.0], [2.0, 3.0], [4.0, 5.0]]]];
     let tensor = TestTensor::<4>::from(unpadded_floats);
 
-    let padded_tensor = tensor.pad((2, 1, 4, 3), PadMode::Constant(1.1));
+    let padded_tensor = tensor.pad((2, 1, 4, 3), 1.1);
 
     let expected = TensorData::from([[[
         [1.1, 1.1, 1.1, 1.1, 1.1],
@@ -270,7 +270,7 @@ fn padding_empty_tensor_constant_test() {
     let tensor: TestTensor<2> = TestTensor::empty([0, 3], &Default::default());
 
     // Padding an empty height dimension with constant should create a tensor of just padding
-    let padded = tensor.pad((0, 0, 2, 2), PadMode::Constant(1.0));
+    let padded = tensor.pad((0, 0, 2, 2), 1.0);
 
     // Result should be 4x3 (0 + 2 + 2 = 4 rows)
     assert_eq!(padded.dims(), [4, 3]);

--- a/crates/burn-backend/src/backend/ops/modules/base.rs
+++ b/crates/burn-backend/src/backend/ops/modules/base.rs
@@ -2,7 +2,7 @@ use super::{conv, pool};
 use crate::ops::attention;
 use crate::ops::unfold::unfold4d_using_conv2d;
 use crate::tensor::{BoolTensor, FloatTensor, IntTensor};
-use crate::{Backend, TensorMetadata};
+use crate::{Backend, ElementConversion, TensorMetadata};
 use burn_std::Shape;
 use core::num::NonZeroUsize;
 
@@ -351,6 +351,12 @@ pub enum PadMode {
 impl Default for PadMode {
     fn default() -> Self {
         PadMode::Constant(0.0)
+    }
+}
+
+impl<E: ElementConversion> From<E> for PadMode {
+    fn from(value: E) -> Self {
+        PadMode::Constant(value.elem())
     }
 }
 

--- a/crates/burn-tensor/src/tensor/api/pad.rs
+++ b/crates/burn-tensor/src/tensor/api/pad.rs
@@ -80,8 +80,8 @@ where
     ///    // [[12.0, 12.0, −2.0, 3.0, 3.0], [5.0, 5.0, 3.0, 6.0, 6.0]]
     /// }
     /// ```
-    pub fn pad(self, padding: (usize, usize, usize, usize), mode: PadMode) -> Self {
-        match mode {
+    pub fn pad(self, padding: (usize, usize, usize, usize), mode: impl Into<PadMode>) -> Self {
+        match mode.into() {
             PadMode::Constant(value) => pad_constant(self, padding, value),
             PadMode::Reflect => pad_reflect(self, padding),
             PadMode::Edge => pad_edge(self, padding),


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.

### Related Issues/PRs

https://github.com/tracel-ai/burn/pull/4105/

### Changes

Update `tensor.pad(padding, value)` signature to support constant padding via a single value provided. This removes the breaking change introduced by the linked PR (constant padding as before).