### PR TITLE
Implement `From<InterpolateMode>` for grid sample

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/float/ops/grid_sample.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/grid_sample.rs
@@ -23,7 +23,7 @@ fn should_grid_sample_2d_default() {
         &device,
     );
 
-    let output = tensor.grid_sample_2d(grid, GridSampleOptions::default());
+    let output = tensor.grid_sample_2d(grid, InterpolateMode::Bilinear);
 
     // Expected values computed with PyTorch grid_sample(align_corners=False, padding_mode='zeros')
     let expected = TensorData::from([[[[4.0, 2.0625], [2.0, 1.04]]]]);

--- a/crates/burn-backend/src/backend/ops/modules/base.rs
+++ b/crates/burn-backend/src/backend/ops/modules/base.rs
@@ -286,6 +286,12 @@ impl Default for GridSampleOptions {
     }
 }
 
+impl From<InterpolateMode> for GridSampleOptions {
+    fn from(value: InterpolateMode) -> Self {
+        GridSampleOptions::new(value)
+    }
+}
+
 impl GridSampleOptions {
     /// Create new grid sample options with the given interpolation mode.
     ///

--- a/crates/burn-tensor/src/tensor/api/float.rs
+++ b/crates/burn-tensor/src/tensor/api/float.rs
@@ -849,11 +849,15 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     ///     .with_align_corners(true);
     /// let output = tensor.grid_sample_2d(grid, options);
     /// ```
-    pub fn grid_sample_2d(self, grid: Tensor<B, D>, options: GridSampleOptions) -> Tensor<B, D> {
+    pub fn grid_sample_2d(
+        self,
+        grid: Tensor<B, D>,
+        options: impl Into<GridSampleOptions>,
+    ) -> Tensor<B, D> {
         Tensor::new(TensorPrimitive::Float(B::float_grid_sample_2d(
             self.primitive.tensor(),
             grid.primitive.tensor(),
-            options,
+            options.into(),
         )))
     }
 


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.

### Related Issues/PRs

https://github.com/tracel-ai/burn/pull/4084

### Changes

Update `tensor.grid_sample_2d(grid, options)` signature to support default w/ only interpolate mode provided. This doesn't entirely remove the breaking change introduced by the PR, since `GridSampleOptions` now use `align_corners = false` by default (the previous implementation only supported `align_corners = true`).