### PR TITLE
feat: Add LoRA (Low-Rank Adaptation) for parameter-efficient fine-tuning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4870,6 +4870,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "lora-finetuning"
+version = "0.20.0-pre.6"
+dependencies = [
+ "burn",
+ "log",
+ "rand 0.9.2",
+ "serde",
+]
+
+[[package]]
 name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/burn-book/src/SUMMARY.md
+++ b/burn-book/src/SUMMARY.md
@@ -39,3 +39,4 @@
   - [Custom Optimizer]()
   - [WebAssembly](./advanced/web-assembly.md)
   - [No-Std](./advanced/no-std.md)
+  - [LoRA Fine-tuning](./advanced/lora.md)

--- a/burn-book/src/advanced/lora.md
+++ b/burn-book/src/advanced/lora.md
@@ -1,0 +1,238 @@
+# LoRA (Low-Rank Adaptation)
+
+LoRA enables parameter-efficient fine-tuning by freezing pre-trained weights and adding small
+trainable low-rank matrices. This technique is particularly useful when:
+
+- You have a large pre-trained model and limited GPU memory
+- You want to create multiple specialized adapters from one base model
+- You need fast training with reduced parameter count
+
+All the code can be found under the
+[examples directory](https://github.com/tracel-ai/burn/tree/main/examples/lora-finetuning).
+
+## Key Concepts
+
+| Concept | Description |
+|---------|-------------|
+| **Rank** | Size of low-rank matrices (smaller = fewer parameters, typical: 4-64) |
+| **Alpha** | Scaling factor for LoRA contribution (typical: 2x rank) |
+| **Scaling** | Computed as `alpha / rank`, controls how much LoRA affects output |
+| **Adapter** | The trainable LoRA weights that can be saved/loaded independently |
+
+## Basic Usage
+
+### Configuration
+
+Configure LoRA with rank, alpha, and optional dropout:
+
+```rust,ignore
+use burn::nn::lora::{LoraConfig, LoraBias};
+
+// Configure LoRA
+let lora_config = LoraConfig::new(4)   // rank = 4
+    .with_alpha(8.0)                    // scaling = alpha/rank = 2.0
+    .with_dropout(0.0)
+    .with_bias(LoraBias::None);
+```
+
+### Applying LoRA to Layers
+
+Apply LoRA to any `Linear` layer using the `LoraAdaptable` trait:
+
+```rust,ignore
+use burn::nn::lora::LoraAdaptable;
+
+// Apply LoRA to a linear layer
+let lora_linear = linear.with_lora(&lora_config, &device);
+
+// The base weights are frozen, only LoRA matrices are trainable
+let output = lora_linear.forward(input);
+```
+
+### Merging for Inference
+
+After training, merge LoRA weights back into the base layer for zero-overhead inference:
+
+```rust,ignore
+// Merge LoRA into base weights (zero inference overhead)
+let merged_linear = lora_linear.merge();
+
+// Now it's a regular Linear layer with updated weights
+let output = merged_linear.forward(input);
+```
+
+## Configuration Options
+
+| Option | Type | Description | Default |
+|--------|------|-------------|---------|
+| `rank` | `usize` | Low-rank dimension | Required |
+| `alpha` | `f64` | Scaling factor | `1.0` |
+| `dropout` | `f64` | Dropout probability on LoRA branch | `0.0` |
+| `bias` | `LoraBias` | Bias training mode | `None` |
+
+### Bias Modes
+
+The `LoraBias` enum controls how biases are handled in LoRA-wrapped layers:
+
+- `LoraBias::None` - Keep bias frozen (default, most common)
+- `LoraBias::All` - Unfreeze bias in LoRA-wrapped layers (for non-LoRA layers, manually unfreeze)
+
+## Adapter Persistence
+
+One of LoRA's key benefits is the ability to save and load adapters independently of the base
+model. This enables:
+
+- Sharing small adapter files instead of full model weights
+- Swapping adapters at runtime for different tasks
+- Efficient storage of multiple fine-tuned variants
+
+### Saving Adapters
+
+```rust,ignore
+use burn::record::{FullPrecisionSettings, NamedMpkFileRecorder};
+
+let recorder = NamedMpkFileRecorder::<FullPrecisionSettings>::new();
+
+// Save individual adapter (~KB instead of MB/GB for full model)
+lora_linear.save_adapter("./my-adapter/layer1", &recorder)?;
+```
+
+### Loading Adapters
+
+```rust,ignore
+// Create fresh model with LoRA applied
+let fresh_lora = linear.with_lora(&lora_config, &device);
+
+// Load trained adapter weights
+let loaded = fresh_lora.load_adapter_file(
+    "./my-adapter/layer1",
+    &recorder,
+    &device
+)?;
+```
+
+## Full Example: LoRA Fine-tuning
+
+Here's the complete workflow demonstrated in the example:
+
+### 1. Define a Model with LoRA
+
+```rust,ignore
+use burn::nn::lora::{LoraConfig, LoraLinear, LoraAdaptable};
+use burn::nn::{Linear, LinearConfig, Relu};
+use burn::prelude::*;
+
+// Base model
+#[derive(Module, Debug)]
+pub struct SimpleMlp<B: Backend> {
+    fc1: Linear<B>,
+    fc2: Linear<B>,
+    fc3: Linear<B>,
+    relu: Relu,
+}
+
+// Model with LoRA applied to fc1 and fc2
+#[derive(Module, Debug)]
+pub struct SimpleMlpWithLora<B: Backend> {
+    fc1: LoraLinear<B>,
+    fc2: LoraLinear<B>,
+    fc3: Linear<B>,  // Keep output layer frozen without LoRA
+    relu: Relu,
+}
+
+// Apply LoRA to a base model
+pub fn apply_lora<B: Backend>(
+    model: SimpleMlp<B>,
+    config: &LoraConfig,
+    device: &B::Device,
+) -> SimpleMlpWithLora<B> {
+    SimpleMlpWithLora {
+        fc1: model.fc1.with_lora(config, device),
+        fc2: model.fc2.with_lora(config, device),
+        fc3: model.fc3.no_grad(), // Freeze without LoRA
+        relu: model.relu,
+    }
+}
+```
+
+### 2. Train with SupervisedTraining
+
+```rust,ignore
+use burn::train::{SupervisedTraining, Learner};
+use burn::optim::AdamConfig;
+
+// Apply LoRA to pre-trained model
+let lora_model = apply_lora(base_model, &lora_config, &device);
+
+// Setup training
+let training = SupervisedTraining::new(artifact_dir, train_loader, valid_loader)
+    .metric_train_numeric(LossMetric::new())
+    .metric_valid_numeric(LossMetric::new())
+    .num_epochs(100)
+    .summary();
+
+// Train (only LoRA parameters are updated)
+let result = training.run(Learner::new(
+    lora_model,
+    AdamConfig::new().init(),
+    1e-3,
+));
+```
+
+### 3. Save and Load Adapters
+
+```rust,ignore
+// Save adapters after training
+lora_model.save_adapters("./adapters")?;
+
+// Later: Load base model and apply trained adapters
+let fresh_base = SimpleMlpConfig::new(32, 64, 1).init::<B>(&device);
+let fresh_lora = apply_lora(fresh_base, &lora_config, &device);
+let loaded_model = fresh_lora.load_adapters("./adapters", &device)?;
+```
+
+### 4. Merge for Deployment
+
+```rust,ignore
+// Merge LoRA weights into base model
+let merged_model: SimpleMlp<B> = lora_model.merge();
+
+// Deploy with no LoRA overhead
+let output = merged_model.forward(input);
+```
+
+## Running the Example
+
+```bash
+# Run with ndarray backend (CPU)
+cargo run -p lora-finetuning --features ndarray --example lora
+
+# Run with wgpu backend (GPU)
+cargo run -p lora-finetuning --features wgpu --example lora
+```
+
+The example demonstrates:
+- Creating a base MLP model
+- Applying LoRA to hidden layers
+- Training with a TUI dashboard
+- Saving/loading adapters from disk
+- Merging weights for inference
+
+## When to Use LoRA
+
+| Use Case | LoRA Benefits |
+|----------|--------------|
+| Large language model fine-tuning | Reduces memory from GBs to MBs |
+| Multiple task-specific models | Share base weights, swap small adapters |
+| Edge deployment | Train on cloud, deploy merged weights |
+| Experimentation | Quick iteration with small parameter sets |
+
+## Comparison: Full Fine-tuning vs LoRA
+
+| Aspect | Full Fine-tuning | LoRA |
+|--------|-----------------|------|
+| Trainable params | All | ~0.1-1% |
+| Memory usage | High | Low |
+| Training speed | Slower | Faster |
+| Checkpoint size | Full model | Adapter only |
+| Inference overhead | None | None (after merge) |

--- a/crates/burn-core/src/record/mod.rs
+++ b/crates/burn-core/src/record/mod.rs
@@ -17,6 +17,7 @@ mod file;
 pub use file::*;
 
 pub use primitive::ParamSerde;
+pub use tensor::FloatTensorSerde;
 
 #[cfg(feature = "record-item-custom-serde")]
 pub mod serde;

--- a/crates/burn-nn/src/lib.rs
+++ b/crates/burn-nn/src/lib.rs
@@ -21,6 +21,9 @@ pub use activation::{
 mod padding;
 pub use padding::*;
 
+/// LoRA (Low-Rank Adaptation) module for parameter-efficient fine-tuning.
+pub mod lora;
+
 // For backward compat, `burn::nn::Initializer`
 pub use burn_core::module::Initializer;
 

--- a/crates/burn-nn/src/lora/adapter.rs
+++ b/crates/burn-nn/src/lora/adapter.rs
@@ -1,0 +1,130 @@
+//! LoRA adapter persistence for saving and loading adapter weights.
+//!
+//! This module provides `LoraLinearAdapter` for saving and loading LoRA adapter weights
+//! independently of the base model. This enables:
+//!
+//! - **Efficient storage**: Save only the small LoRA matrices (A & B), not the entire model
+//! - **Adapter swapping**: Load different adapters onto the same base model at runtime
+//! - **Portability**: Share adapter weights separately from base model weights
+//!
+//! # File Format
+//!
+//! Adapters are saved as MessagePack (`.mpk`) files containing:
+//! - `config`: LoRA configuration (rank, alpha, dropout, etc.)
+//! - `lora_a`: Down-projection matrix `[d_input, rank]`
+//! - `lora_b`: Up-projection matrix `[rank, d_output]`
+//!
+//! # Example
+//!
+//! ```ignore
+//! use burn::record::NamedMpkFileRecorder;
+//! use burn::record::FullPrecisionSettings;
+//!
+//! let recorder = NamedMpkFileRecorder::<FullPrecisionSettings>::new();
+//!
+//! // Save adapter after training
+//! lora_linear.save_adapter("./my-adapter", &recorder)?;
+//!
+//! // Load adapter onto fresh LoRA layer
+//! let loaded = fresh_lora_linear.load_adapter_file("./my-adapter", &recorder, &device)?;
+//! ```
+
+use burn_core as burn;
+
+use burn::module::Param;
+use burn::record::{FloatTensorSerde, ParamSerde, PrecisionSettings, Record};
+use burn::serde::{Deserialize, Serialize};
+use burn::tensor::{Tensor, backend::Backend};
+
+use super::config::LoraConfig;
+
+/// Standalone LoRA adapter record containing only trainable weights.
+///
+/// This struct captures the essential LoRA weights (A and B matrices) along with
+/// the configuration needed to reconstruct the adapter. It does NOT include base
+/// model weights - those are loaded separately.
+///
+/// Use this for:
+/// - Saving trained LoRA weights independently of the base model
+/// - Loading adapters onto different base models
+/// - Swapping adapters at runtime without reloading the base model
+///
+/// # Fields
+///
+/// - `lora_a`: Down-projection matrix with shape `[d_input, rank]`
+/// - `lora_b`: Up-projection matrix with shape `[rank, d_output]`
+/// - `config`: LoRA configuration (rank, alpha, dropout, bias, etc.)
+#[derive(Debug, Clone)]
+pub struct LoraLinearAdapter<B: Backend> {
+    /// LoRA A matrix (down-projection): `[d_input, rank]`.
+    pub lora_a: Param<Tensor<B, 2>>,
+    /// LoRA B matrix (up-projection): `[rank, d_output]`.
+    pub lora_b: Param<Tensor<B, 2>>,
+    /// LoRA configuration used to create this adapter.
+    pub config: LoraConfig,
+}
+
+/// Serializable form of `LoraLinearAdapter` for persistence.
+///
+/// This is the `Item` type used by the `Record` trait implementation.
+/// It uses `ParamSerde` for tensor serialization with precision settings.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(crate = "burn::serde", bound = "")]
+pub struct LoraLinearAdapterItem<S: PrecisionSettings> {
+    /// Serialized LoRA A matrix.
+    pub lora_a: ParamSerde<FloatTensorSerde<S>>,
+    /// Serialized LoRA B matrix.
+    pub lora_b: ParamSerde<FloatTensorSerde<S>>,
+    /// LoRA configuration.
+    pub config: LoraConfig,
+}
+
+impl<B: Backend> Record<B> for LoraLinearAdapter<B> {
+    type Item<S: PrecisionSettings> = LoraLinearAdapterItem<S>;
+
+    fn into_item<S: PrecisionSettings>(self) -> Self::Item<S> {
+        LoraLinearAdapterItem {
+            lora_a: self.lora_a.into_item(),
+            lora_b: self.lora_b.into_item(),
+            config: self.config,
+        }
+    }
+
+    fn from_item<S: PrecisionSettings>(item: Self::Item<S>, device: &B::Device) -> Self {
+        LoraLinearAdapter {
+            lora_a: Param::from_item(item.lora_a, device),
+            lora_b: Param::from_item(item.lora_b, device),
+            config: item.config,
+        }
+    }
+}
+
+impl<B: Backend> LoraLinearAdapter<B> {
+    /// Creates a new adapter from LoRA matrices and configuration.
+    pub fn new(
+        lora_a: Param<Tensor<B, 2>>,
+        lora_b: Param<Tensor<B, 2>>,
+        config: LoraConfig,
+    ) -> Self {
+        Self {
+            lora_a,
+            lora_b,
+            config,
+        }
+    }
+
+    /// Returns the LoRA rank.
+    pub fn rank(&self) -> usize {
+        self.lora_a.shape().dims::<2>()[1]
+    }
+
+    /// Returns the input dimension.
+    pub fn d_input(&self) -> usize {
+        self.lora_a.shape().dims::<2>()[0]
+    }
+
+    /// Returns the output dimension.
+    pub fn d_output(&self) -> usize {
+        self.lora_b.shape().dims::<2>()[1]
+    }
+}

--- a/crates/burn-nn/src/lora/config.rs
+++ b/crates/burn-nn/src/lora/config.rs
@@ -1,0 +1,259 @@
+use burn_core as burn;
+
+use burn::config::Config;
+use burn::module::{Initializer, Param};
+use burn::tensor::{Tensor, backend::Backend};
+
+/// Bias training mode for LoRA adaptation.
+///
+/// Controls whether biases are trainable in LoRA-wrapped layers.
+#[derive(Config, Debug, Copy, PartialEq, Eq)]
+pub enum LoraBias {
+    /// Keep bias frozen in LoRA-wrapped layers (default).
+    None,
+    /// Unfreeze bias in LoRA-wrapped layers.
+    ///
+    /// For non-LoRA layers in the model, manually call `.set_require_grad(true)`
+    /// on their biases if you want them to be trainable as well.
+    All,
+}
+
+/// Weight initialization strategy for LoRA matrices.
+///
+/// Standard LoRA uses Kaiming initialization for A and zeros for B,
+/// ensuring the initial LoRA output is zero (identity behavior).
+#[derive(Config, Debug, Copy, PartialEq, Eq)]
+pub enum LoraInit {
+    /// A = KaimingUniform, B = Zeros (standard LoRA, identity start).
+    Kaiming,
+    /// Both A and B ~ N(0, 1/sqrt(rank)).
+    Gaussian,
+    /// Both A and B = Zeros (for testing).
+    Zeros,
+}
+
+/// Configuration for LoRA (Low-Rank Adaptation) layers.
+///
+/// LoRA adds trainable low-rank matrices A and B to frozen base weights,
+/// computing: `output = base(x) + (x @ A @ B) * scaling`
+///
+/// The scaling factor is computed as `alpha / rank` (or `alpha / sqrt(rank)` for RSLoRA).
+///
+/// # Example
+///
+/// ```ignore
+/// use burn_nn::lora::{LoraConfig, LoraAdaptable};
+///
+/// // Basic usage with rank 16
+/// let config = LoraConfig::new(16);
+/// let lora_linear = linear_layer.with_lora(&config, &device);
+///
+/// // Customized configuration
+/// let config = LoraConfig::new(32)
+///     .with_alpha(64.0)       // scaling = 64/32 = 2.0
+///     .with_dropout(0.1)
+///     .with_bias(LoraBias::All)
+///     .with_use_rslora(true); // scaling = 64/sqrt(32)
+/// ```
+#[derive(Config, Debug)]
+pub struct LoraConfig {
+    /// Low-rank dimension (typically 4-64).
+    ///
+    /// Lower ranks reduce trainable parameters but may limit expressiveness.
+    /// Common values: 4, 8, 16, 32, 64.
+    pub rank: usize,
+
+    /// Scaling numerator. The scaling factor is `alpha / rank`.
+    ///
+    /// When `alpha == rank`, the scaling factor is 1.0.
+    /// Default is 1.0, giving a scaling factor of `1/rank`.
+    #[config(default = 1.0)]
+    pub alpha: f64,
+
+    /// Dropout probability applied to LoRA branch input (0.0 = disabled).
+    ///
+    /// Only active during training (when autodiff is enabled).
+    #[config(default = 0.0)]
+    pub dropout: f64,
+
+    /// Bias training mode.
+    ///
+    /// Controls whether biases in LoRA-wrapped layers are trainable.
+    #[config(default = "LoraBias::None")]
+    pub bias: LoraBias,
+
+    /// Use rank-stabilized LoRA scaling: `alpha / sqrt(rank)` instead of `alpha / rank`.
+    ///
+    /// RSLoRA maintains more stable gradients across different rank values.
+    #[config(default = false)]
+    pub use_rslora: bool,
+
+    /// Weight initialization strategy for LoRA matrices A and B.
+    #[config(default = "LoraInit::Kaiming")]
+    pub init: LoraInit,
+}
+
+impl LoraConfig {
+    /// Validate the configuration.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if `rank` is 0. LoRA requires at least rank 1 to create
+    ///   valid low-rank matrices.
+    /// - Panics if `dropout` is negative or greater than 1.0.
+    pub fn validate(&self) {
+        assert!(self.rank > 0, "LoRA rank must be at least 1");
+        assert!(
+            self.dropout >= 0.0 && self.dropout <= 1.0,
+            "LoRA dropout must be between 0.0 and 1.0, got {}",
+            self.dropout
+        );
+    }
+
+    /// Compute the LoRA scaling factor.
+    ///
+    /// Returns `alpha / rank` normally, or `alpha / sqrt(rank)` if RSLoRA is enabled.
+    pub fn scaling(&self) -> f64 {
+        if self.use_rslora {
+            self.alpha / (self.rank as f64).sqrt()
+        } else {
+            self.alpha / self.rank as f64
+        }
+    }
+
+    /// Initialize the LoRA A matrix with shape `[in_features, rank]`.
+    ///
+    /// This is the "down projection" matrix that reduces dimensionality.
+    pub fn init_a<B: Backend>(
+        &self,
+        in_features: usize,
+        device: &B::Device,
+    ) -> Param<Tensor<B, 2>> {
+        let shape = [in_features, self.rank];
+        match self.init {
+            LoraInit::Kaiming => Initializer::KaimingUniform {
+                gain: 1.0,
+                fan_out_only: false,
+            }
+            .init_with(shape, Some(in_features), Some(self.rank), device),
+            LoraInit::Gaussian => Initializer::Normal {
+                mean: 0.0,
+                std: 1.0 / (self.rank as f64).sqrt(),
+            }
+            .init(shape, device),
+            LoraInit::Zeros => Initializer::Zeros.init(shape, device),
+        }
+    }
+
+    /// Initialize the LoRA B matrix with shape `[rank, out_features]`.
+    ///
+    /// This is the "up projection" matrix that restores dimensionality.
+    /// For Kaiming init, this is zeros so initial LoRA output is zero.
+    pub fn init_b<B: Backend>(
+        &self,
+        out_features: usize,
+        device: &B::Device,
+    ) -> Param<Tensor<B, 2>> {
+        let shape = [self.rank, out_features];
+        match self.init {
+            // B is zeros for identity start (standard LoRA behavior)
+            LoraInit::Kaiming | LoraInit::Zeros => Initializer::Zeros.init(shape, device),
+            LoraInit::Gaussian => Initializer::Normal {
+                mean: 0.0,
+                std: 1.0 / (self.rank as f64).sqrt(),
+            }
+            .init(shape, device),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_scaling_standard() {
+        let config = LoraConfig::new(8).with_alpha(16.0);
+        assert!((config.scaling() - 2.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_scaling_rslora() {
+        let config = LoraConfig::new(16).with_alpha(16.0).with_use_rslora(true);
+        // scaling = 16 / sqrt(16) = 16 / 4 = 4.0
+        assert!((config.scaling() - 4.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_default_scaling() {
+        let config = LoraConfig::new(8);
+        // Default alpha=1.0, scaling = 1/8 = 0.125
+        assert!((config.scaling() - 0.125).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_config_defaults() {
+        let config = LoraConfig::new(16);
+        assert_eq!(config.rank, 16);
+        assert!((config.alpha - 1.0).abs() < 1e-10);
+        assert!((config.dropout - 0.0).abs() < 1e-10);
+        assert_eq!(config.bias, LoraBias::None);
+        assert!(!config.use_rslora);
+        assert_eq!(config.init, LoraInit::Kaiming);
+    }
+
+    #[test]
+    #[should_panic(expected = "LoRA rank must be at least 1")]
+    fn test_rank_zero_panics() {
+        // Manually construct config with rank=0 to bypass the normal new() method
+        let config = LoraConfig {
+            rank: 0,
+            alpha: 1.0,
+            dropout: 0.0,
+            bias: LoraBias::None,
+            use_rslora: false,
+            init: LoraInit::Kaiming,
+        };
+        // Validation should panic
+        config.validate();
+    }
+
+    #[test]
+    #[should_panic(expected = "LoRA dropout must be between 0.0 and 1.0")]
+    fn test_dropout_negative_panics() {
+        let config = LoraConfig {
+            rank: 8,
+            alpha: 1.0,
+            dropout: -0.1,
+            bias: LoraBias::None,
+            use_rslora: false,
+            init: LoraInit::Kaiming,
+        };
+        config.validate();
+    }
+
+    #[test]
+    #[should_panic(expected = "LoRA dropout must be between 0.0 and 1.0")]
+    fn test_dropout_greater_than_one_panics() {
+        let config = LoraConfig {
+            rank: 8,
+            alpha: 1.0,
+            dropout: 1.5,
+            bias: LoraBias::None,
+            use_rslora: false,
+            init: LoraInit::Kaiming,
+        };
+        config.validate();
+    }
+
+    #[test]
+    fn test_dropout_boundary_values_valid() {
+        // dropout = 0.0 should be valid
+        let config_zero = LoraConfig::new(8).with_dropout(0.0);
+        config_zero.validate(); // Should not panic
+
+        // dropout = 1.0 should be valid
+        let config_one = LoraConfig::new(8).with_dropout(1.0);
+        config_one.validate(); // Should not panic
+    }
+}

--- a/crates/burn-nn/src/lora/linear.rs
+++ b/crates/burn-nn/src/lora/linear.rs
@@ -1,0 +1,1064 @@
+use alloc::format;
+
+use burn_core as burn;
+
+use burn::module::{Content, DisplaySettings, Ignored, Module, ModuleDisplay, Param};
+use burn::tensor::{Tensor, backend::Backend};
+
+use crate::modules::{Dropout, DropoutConfig, Linear};
+
+use super::LoraAdaptable;
+use super::adapter::LoraLinearAdapter;
+use super::config::{LoraBias, LoraConfig};
+
+#[cfg(feature = "std")]
+use burn::record::{FileRecorder, RecorderError};
+#[cfg(feature = "std")]
+use std::path::PathBuf;
+
+/// Error type for LoRA adapter operations.
+#[derive(Debug, Clone)]
+pub enum LoraError {
+    /// Adapter dimensions don't match layer dimensions.
+    DimensionMismatch {
+        /// Expected input dimension from the layer.
+        expected_d_input: usize,
+        /// Expected output dimension from the layer.
+        expected_d_output: usize,
+        /// Actual input dimension from the adapter.
+        actual_d_input: usize,
+        /// Actual output dimension from the adapter.
+        actual_d_output: usize,
+    },
+}
+
+impl core::fmt::Display for LoraError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            LoraError::DimensionMismatch {
+                expected_d_input,
+                expected_d_output,
+                actual_d_input,
+                actual_d_output,
+            } => {
+                write!(
+                    f,
+                    "Adapter dimensions [{}, {}] don't match layer dimensions [{}, {}]",
+                    actual_d_input, actual_d_output, expected_d_input, expected_d_output
+                )
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for LoraError {}
+
+/// Linear layer with LoRA (Low-Rank Adaptation) applied.
+///
+/// This wrapper adds trainable low-rank matrices A and B to a frozen base
+/// linear layer. The forward pass computes:
+///
+/// ```text
+/// output = base(x) + dropout(x) @ A @ B * scaling
+/// ```
+///
+/// # Fields
+///
+/// - `base`: The frozen base linear layer
+/// - `lora_a`: Down-projection matrix `[d_input, rank]`
+/// - `lora_b`: Up-projection matrix `[rank, d_output]`
+/// - `scaling`: Precomputed scaling factor (`alpha / rank`)
+/// - `dropout`: Dropout applied to LoRA branch input
+///
+/// # Example
+///
+/// ```ignore
+/// use burn_nn::{Linear, LinearConfig};
+/// use burn_nn::lora::{LoraConfig, LoraAdaptable};
+///
+/// let linear = LinearConfig::new(768, 768).init(&device);
+/// let lora_linear = linear.with_lora(&LoraConfig::new(16), &device);
+///
+/// // Forward pass
+/// let output = lora_linear.forward(input);
+///
+/// // Merge for inference
+/// let merged = lora_linear.merge();
+/// ```
+#[derive(Module, Debug)]
+#[module(custom_display)]
+pub struct LoraLinear<B: Backend> {
+    /// Base linear layer (frozen).
+    pub base: Linear<B>,
+    /// LoRA A matrix (down-projection): `[d_input, rank]`.
+    pub lora_a: Param<Tensor<B, 2>>,
+    /// LoRA B matrix (up-projection): `[rank, d_output]`.
+    pub lora_b: Param<Tensor<B, 2>>,
+    /// Precomputed scaling factor: `alpha / rank` (or `alpha / sqrt(rank)` for RSLoRA).
+    pub scaling: f64,
+    /// Dropout applied to LoRA branch input (only active during training).
+    pub dropout: Dropout,
+    /// Original LoRA configuration (preserved for adapter extraction).
+    /// Wrapped in `Ignored` so it doesn't require Module implementation.
+    /// Config is fully preserved when using `into_adapter()` / adapter persistence.
+    pub config: Ignored<LoraConfig>,
+}
+
+impl<B: Backend> LoraAdaptable<B> for Linear<B> {
+    type Wrapped = LoraLinear<B>;
+
+    fn lora_dims(&self) -> (usize, usize) {
+        let [d_in, d_out] = self.weight.shape().dims::<2>();
+        (d_in, d_out)
+    }
+
+    fn with_lora(self, config: &LoraConfig, device: &B::Device) -> LoraLinear<B> {
+        config.validate();
+        let (d_in, d_out) = self.lora_dims();
+
+        // Freeze base weights, optionally unfreeze bias
+        let base = match config.bias {
+            LoraBias::None => self.no_grad(),
+            LoraBias::All => {
+                let mut frozen = self.no_grad();
+                frozen.bias = frozen.bias.map(|b| b.set_require_grad(true));
+                frozen
+            }
+        };
+
+        LoraLinear {
+            base,
+            lora_a: config.init_a(d_in, device),
+            lora_b: config.init_b(d_out, device),
+            scaling: config.scaling(),
+            dropout: DropoutConfig::new(config.dropout).init(),
+            config: Ignored(config.clone()),
+        }
+    }
+}
+
+impl<B: Backend> LoraLinear<B> {
+    /// Applies the forward pass on the input tensor.
+    ///
+    /// Computes: `base(x) + dropout(x) @ A @ B * scaling`
+    ///
+    /// # Arguments
+    ///
+    /// - `input` - The input tensor of shape `[..., d_input]`
+    ///
+    /// # Shapes
+    ///
+    /// - input: `[..., d_input]`
+    /// - output: `[..., d_output]`
+    ///
+    /// # Returns
+    ///
+    /// The transformed tensor of shape `[..., d_output]`.
+    pub fn forward<const D: usize>(&self, input: Tensor<B, D>) -> Tensor<B, D> {
+        // Handle 1D input by temporarily upgrading to 2D
+        // (unsqueeze::<D>() on 2D LoRA weights fails when D=1)
+        if D == 1 {
+            let input_2d: Tensor<B, 2> = input.unsqueeze_dim(0);
+            let output_2d = self.forward_nd(input_2d);
+            return output_2d.squeeze_dim(0);
+        }
+        self.forward_nd(input)
+    }
+
+    /// Internal forward pass for tensors with D >= 2.
+    fn forward_nd<const D: usize>(&self, input: Tensor<B, D>) -> Tensor<B, D> {
+        // LoRA branch: dropout(x) @ A @ B * scaling
+        // Clone is required since both base and LoRA paths need the input.
+        // We compute LoRA first so dropout consumes the clone.
+        let lora_in = self.dropout.forward(input.clone());
+        let lora_a = self.lora_a.val().unsqueeze::<D>();
+        let lora_b = self.lora_b.val().unsqueeze::<D>();
+        let lora_out = lora_in
+            .matmul(lora_a)
+            .matmul(lora_b)
+            .mul_scalar(self.scaling);
+
+        // Base path consumes original input
+        self.base.forward(input) + lora_out
+    }
+
+    /// Merge LoRA weights into the base layer.
+    ///
+    /// Computes: `W_merged = W_base + A @ B * scaling`
+    ///
+    /// This eliminates all LoRA overhead at inference time. The returned
+    /// `Linear` layer produces identical outputs to the `LoraLinear` layer
+    /// (ignoring dropout which is disabled during inference).
+    ///
+    /// The merge preserves the `ParamId` and `ParamMapper` from the base
+    /// layer, ensuring checkpoint compatibility.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Train with LoRA
+    /// let lora_linear = linear.with_lora(&config, &device);
+    /// // ... training ...
+    ///
+    /// // Merge for inference
+    /// let inference_linear = lora_linear.merge();
+    /// ```
+    pub fn merge(self) -> Linear<B> {
+        // Preserve Param infrastructure (ID, mapper for LinearLayout::Col)
+        let (id, weight, mapper) = self.base.weight.consume();
+
+        // Compute merged weight: W + A @ B * scaling
+        let delta = self
+            .lora_a
+            .val()
+            .matmul(self.lora_b.val())
+            .mul_scalar(self.scaling);
+        let merged = (weight + delta).set_require_grad(false);
+
+        Linear {
+            weight: Param::from_mapped_value(id, merged, mapper),
+            bias: self.base.bias,
+        }
+    }
+
+    /// Returns the LoRA rank.
+    pub fn rank(&self) -> usize {
+        self.lora_a.shape().dims::<2>()[1]
+    }
+
+    /// Returns the input dimension of the base layer.
+    pub fn d_input(&self) -> usize {
+        self.base.weight.shape().dims::<2>()[0]
+    }
+
+    /// Returns the output dimension of the base layer.
+    pub fn d_output(&self) -> usize {
+        self.base.weight.shape().dims::<2>()[1]
+    }
+
+    /// Extract adapter weights from this LoRA layer.
+    ///
+    /// Returns a `LoraLinearAdapter` containing only the LoRA matrices (A and B)
+    /// and full configuration. This does NOT include base model weights.
+    ///
+    /// Use this to save trained LoRA adapters independently of the base model,
+    /// enabling adapter swapping and efficient storage.
+    ///
+    /// The full `LoraConfig` is preserved, including `rank`, `alpha`, `dropout`,
+    /// `bias`, `use_rslora`, and `init` settings. This allows training to be
+    /// resumed with the exact same configuration.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let adapter = lora_linear.clone().into_adapter();
+    /// // adapter contains lora_a, lora_b, and full config
+    /// ```
+    pub fn into_adapter(self) -> LoraLinearAdapter<B> {
+        LoraLinearAdapter::new(self.lora_a, self.lora_b, self.config.0)
+    }
+
+    /// Load adapter weights into this LoRA layer.
+    ///
+    /// Replaces the current LoRA matrices (A and B) with those from the adapter.
+    /// The base layer weights remain unchanged. The full config is also restored,
+    /// enabling training continuation with the same settings.
+    ///
+    /// # Arguments
+    ///
+    /// * `adapter` - The adapter containing new LoRA weights and config
+    ///
+    /// # Returns
+    ///
+    /// `Ok(Self)` with updated LoRA weights, scaling, and config, or
+    /// `Err(LoraError::DimensionMismatch)` if adapter dimensions don't match.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Swap to a different adapter at runtime
+    /// lora_linear = lora_linear.load_adapter(new_adapter)?;
+    /// ```
+    pub fn load_adapter(mut self, adapter: LoraLinearAdapter<B>) -> Result<Self, LoraError> {
+        let expected_d_input = self.d_input();
+        let expected_d_output = self.d_output();
+        let actual_d_input = adapter.d_input();
+        let actual_d_output = adapter.d_output();
+
+        if expected_d_input != actual_d_input || expected_d_output != actual_d_output {
+            return Err(LoraError::DimensionMismatch {
+                expected_d_input,
+                expected_d_output,
+                actual_d_input,
+                actual_d_output,
+            });
+        }
+
+        self.lora_a = adapter.lora_a;
+        self.lora_b = adapter.lora_b;
+        self.scaling = adapter.config.scaling();
+        self.config = Ignored(adapter.config);
+        Ok(self)
+    }
+
+    /// Save adapter weights to a file.
+    ///
+    /// Saves only the LoRA matrices (A and B) and configuration to a MessagePack file.
+    /// The base model weights are NOT saved - only the small adapter weights.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path to save the adapter (file extension added automatically)
+    /// * `recorder` - The recorder to use (e.g., `NamedMpkFileRecorder`)
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` on success, or `RecorderError` on failure.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use burn::record::{NamedMpkFileRecorder, FullPrecisionSettings};
+    ///
+    /// let recorder = NamedMpkFileRecorder::<FullPrecisionSettings>::new();
+    /// lora_linear.save_adapter("./my-adapter", &recorder)?;
+    /// // Creates ./my-adapter.mpk
+    /// ```
+    #[cfg(feature = "std")]
+    pub fn save_adapter<R>(
+        &self,
+        path: impl Into<PathBuf>,
+        recorder: &R,
+    ) -> Result<(), RecorderError>
+    where
+        R: FileRecorder<B>,
+    {
+        let adapter = self.clone().into_adapter();
+        recorder.record(adapter, path.into())
+    }
+
+    /// Load adapter weights from a file.
+    ///
+    /// Loads LoRA matrices and configuration from a MessagePack file and applies
+    /// them to this layer. The base model weights remain unchanged.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path to the adapter file (file extension added automatically)
+    /// * `recorder` - The recorder to use (must match the one used for saving)
+    /// * `device` - Device to load the tensors onto
+    ///
+    /// # Returns
+    ///
+    /// Self with loaded adapter weights, or `RecorderError` on failure
+    /// (including dimension mismatch errors).
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use burn::record::{NamedMpkFileRecorder, FullPrecisionSettings};
+    ///
+    /// let recorder = NamedMpkFileRecorder::<FullPrecisionSettings>::new();
+    /// lora_linear = lora_linear.load_adapter_file("./my-adapter", &recorder, &device)?;
+    /// ```
+    #[cfg(feature = "std")]
+    pub fn load_adapter_file<R>(
+        self,
+        path: impl Into<PathBuf>,
+        recorder: &R,
+        device: &B::Device,
+    ) -> Result<Self, RecorderError>
+    where
+        R: FileRecorder<B>,
+    {
+        let adapter: LoraLinearAdapter<B> = recorder.load(path.into(), device)?;
+        self.load_adapter(adapter)
+            .map_err(|e| RecorderError::Unknown(format!("{e}")))
+    }
+}
+
+impl<B: Backend> ModuleDisplay for LoraLinear<B> {
+    fn custom_settings(&self) -> Option<DisplaySettings> {
+        DisplaySettings::new()
+            .with_new_line_after_attribute(false)
+            .optional()
+    }
+
+    fn custom_content(&self, content: Content) -> Option<Content> {
+        let [d_input, d_output] = self.base.weight.shape().dims::<2>();
+        let rank = self.rank();
+        content
+            .add("d_input", &d_input)
+            .add("d_output", &d_output)
+            .add("rank", &rank)
+            .add("bias", &self.base.bias.is_some())
+            .optional()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::TestBackend;
+    use crate::lora::config::LoraInit;
+    use crate::modules::LinearConfig;
+    use burn::tensor::ops::FloatElem;
+    use burn::tensor::{Distribution, Shape, Tolerance};
+
+    type FT = FloatElem<TestBackend>;
+
+    #[test]
+    fn test_lora_linear_identity_start() {
+        // With B=zeros (default Kaiming init), output should match base
+        let device = Default::default();
+        TestBackend::seed(&device, 0);
+
+        let linear = LinearConfig::new(64, 32).init::<TestBackend>(&device);
+        let base_weight = linear.weight.val().clone();
+
+        let lora = linear.with_lora(&LoraConfig::new(8), &device);
+
+        let input = Tensor::<TestBackend, 2>::random([2, 64], Distribution::Default, &device);
+        let base_out = burn::tensor::module::linear(
+            input.clone(),
+            base_weight,
+            lora.base.bias.as_ref().map(|b| b.val()),
+        );
+        let lora_out = lora.forward(input);
+
+        base_out
+            .into_data()
+            .assert_approx_eq::<FT>(&lora_out.into_data(), Tolerance::default());
+    }
+
+    #[test]
+    fn test_lora_linear_merge_equivalence() {
+        // After merge, output should match LoRA output (with non-zero LoRA weights)
+        let device = Default::default();
+        TestBackend::seed(&device, 0);
+
+        let linear = LinearConfig::new(64, 32).init::<TestBackend>(&device);
+        let lora = linear.with_lora(&LoraConfig::new(8).with_init(LoraInit::Gaussian), &device);
+
+        let input = Tensor::<TestBackend, 2>::random([2, 64], Distribution::Default, &device);
+        let lora_out = lora.forward(input.clone());
+
+        let merged = lora.merge();
+        let merged_out = merged.forward(input);
+
+        lora_out
+            .into_data()
+            .assert_approx_eq::<FT>(&merged_out.into_data(), Tolerance::default());
+    }
+
+    #[test]
+    fn test_lora_linear_dimensions() {
+        let device = Default::default();
+
+        let linear = LinearConfig::new(64, 32).init::<TestBackend>(&device);
+        let lora = linear.with_lora(&LoraConfig::new(8), &device);
+
+        assert_eq!(lora.d_input(), 64);
+        assert_eq!(lora.d_output(), 32);
+        assert_eq!(lora.rank(), 8);
+        assert_eq!(lora.lora_a.shape().dims::<2>(), [64, 8]);
+        assert_eq!(lora.lora_b.shape().dims::<2>(), [8, 32]);
+    }
+
+    #[test]
+    fn test_lora_linear_bias_none() {
+        let device = Default::default();
+
+        let linear = LinearConfig::new(64, 32)
+            .with_bias(true)
+            .init::<TestBackend>(&device);
+        let lora = linear.with_lora(&LoraConfig::new(8).with_bias(LoraBias::None), &device);
+
+        // Base weight should be frozen
+        assert!(!lora.base.weight.is_require_grad());
+        // Bias should also be frozen with LoraBias::None
+        assert!(lora.base.bias.is_some());
+        assert!(!lora.base.bias.as_ref().unwrap().is_require_grad());
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_lora_linear_bias_all() {
+        use crate::TestAutodiffBackend;
+
+        let device = Default::default();
+
+        let linear = LinearConfig::new(64, 32)
+            .with_bias(true)
+            .init::<TestAutodiffBackend>(&device);
+        let lora = linear.with_lora(&LoraConfig::new(8).with_bias(LoraBias::All), &device);
+
+        // Base weight should be frozen
+        assert!(!lora.base.weight.is_require_grad());
+        // Bias should be trainable with LoraBias::All
+        assert!(lora.base.bias.is_some());
+        assert!(lora.base.bias.as_ref().unwrap().is_require_grad());
+    }
+
+    #[test]
+    fn test_lora_linear_scaling() {
+        let device = Default::default();
+
+        // Test standard scaling: alpha / rank
+        let config = LoraConfig::new(8).with_alpha(16.0);
+        let linear = LinearConfig::new(64, 32).init::<TestBackend>(&device);
+        let lora = linear.with_lora(&config, &device);
+        assert!((lora.scaling - 2.0).abs() < 1e-10);
+
+        // Test RSLoRA scaling: alpha / sqrt(rank)
+        let config = LoraConfig::new(16).with_alpha(16.0).with_use_rslora(true);
+        let linear = LinearConfig::new(64, 32).init::<TestBackend>(&device);
+        let lora = linear.with_lora(&config, &device);
+        assert!((lora.scaling - 4.0).abs() < 1e-10); // 16 / sqrt(16) = 4
+    }
+
+    #[test]
+    fn test_lora_linear_forward_shapes() {
+        let device = Default::default();
+
+        let linear = LinearConfig::new(64, 32).init::<TestBackend>(&device);
+        let lora = linear.with_lora(&LoraConfig::new(8), &device);
+
+        // Test 2D input
+        let input_2d = Tensor::<TestBackend, 2>::random([4, 64], Distribution::Default, &device);
+        let output_2d = lora.forward(input_2d);
+        assert_eq!(output_2d.shape(), Shape::new([4, 32]));
+
+        // Test 3D input
+        let input_3d = Tensor::<TestBackend, 3>::random([2, 4, 64], Distribution::Default, &device);
+        let output_3d = lora.forward(input_3d);
+        assert_eq!(output_3d.shape(), Shape::new([2, 4, 32]));
+    }
+
+    #[test]
+    fn test_lora_linear_display() {
+        let device = Default::default();
+
+        let linear = LinearConfig::new(64, 32)
+            .with_bias(true)
+            .init::<TestBackend>(&device);
+        let lora = linear.with_lora(&LoraConfig::new(8), &device);
+
+        let display = alloc::format!("{lora}");
+        assert!(display.contains("d_input: 64"));
+        assert!(display.contains("d_output: 32"));
+        assert!(display.contains("rank: 8"));
+        assert!(display.contains("bias: true"));
+    }
+
+    #[test]
+    fn test_lora_linear_no_bias() {
+        let device = Default::default();
+
+        let linear = LinearConfig::new(64, 32)
+            .with_bias(false)
+            .init::<TestBackend>(&device);
+        let lora = linear.with_lora(&LoraConfig::new(8), &device);
+
+        assert!(lora.base.bias.is_none());
+
+        // Should still work
+        let input = Tensor::<TestBackend, 2>::random([2, 64], Distribution::Default, &device);
+        let _output = lora.forward(input);
+    }
+
+    #[test]
+    fn test_into_adapter_preserves_weights_and_full_config() {
+        let device = Default::default();
+        TestBackend::seed(&device, 42);
+
+        // Create LoRA with non-default config values
+        let config = LoraConfig::new(8)
+            .with_alpha(16.0)
+            .with_dropout(0.1)
+            .with_bias(LoraBias::All)
+            .with_use_rslora(true)
+            .with_init(LoraInit::Gaussian);
+
+        let linear = LinearConfig::new(64, 32)
+            .with_bias(true)
+            .init::<TestBackend>(&device);
+        let lora = linear.with_lora(&config, &device);
+
+        // Get original weights
+        let original_a = lora.lora_a.val().clone();
+        let original_b = lora.lora_b.val().clone();
+
+        // Extract adapter
+        let adapter = lora.into_adapter();
+
+        // Verify adapter has same weights
+        original_a
+            .into_data()
+            .assert_approx_eq::<FT>(&adapter.lora_a.val().into_data(), Tolerance::default());
+        original_b
+            .into_data()
+            .assert_approx_eq::<FT>(&adapter.lora_b.val().into_data(), Tolerance::default());
+
+        // Verify FULL config is preserved (not just rank and alpha)
+        assert_eq!(adapter.config.rank, 8);
+        assert!((adapter.config.alpha - 16.0).abs() < 1e-10);
+        assert!((adapter.config.dropout - 0.1).abs() < 1e-10);
+        assert_eq!(adapter.config.bias, LoraBias::All);
+        assert!(adapter.config.use_rslora);
+        assert_eq!(adapter.config.init, LoraInit::Gaussian);
+    }
+
+    #[test]
+    fn test_load_adapter_updates_weights() {
+        let device = Default::default();
+        TestBackend::seed(&device, 0);
+
+        // Create two LoRA layers with different weights
+        let linear1 = LinearConfig::new(64, 32).init::<TestBackend>(&device);
+        let lora1 = linear1.with_lora(&LoraConfig::new(8).with_init(LoraInit::Gaussian), &device);
+
+        TestBackend::seed(&device, 123); // Different seed
+        let linear2 = LinearConfig::new(64, 32).init::<TestBackend>(&device);
+        let lora2 = linear2.with_lora(&LoraConfig::new(8).with_init(LoraInit::Gaussian), &device);
+
+        // Extract adapter from lora2
+        let adapter2 = lora2.clone().into_adapter();
+        let adapter2_a = adapter2.lora_a.val().clone();
+        let adapter2_b = adapter2.lora_b.val().clone();
+
+        // Load adapter2 into lora1
+        let lora1_updated = lora1.load_adapter(adapter2).unwrap();
+
+        // Verify lora1 now has lora2's weights
+        lora1_updated
+            .lora_a
+            .val()
+            .into_data()
+            .assert_approx_eq::<FT>(&adapter2_a.into_data(), Tolerance::default());
+        lora1_updated
+            .lora_b
+            .val()
+            .into_data()
+            .assert_approx_eq::<FT>(&adapter2_b.into_data(), Tolerance::default());
+    }
+
+    #[test]
+    fn test_adapter_output_equivalence() {
+        let device = Default::default();
+        TestBackend::seed(&device, 0);
+
+        // Create LoRA layer
+        let linear = LinearConfig::new(64, 32).init::<TestBackend>(&device);
+        let lora = linear.with_lora(&LoraConfig::new(8).with_init(LoraInit::Gaussian), &device);
+
+        // Get output before extraction
+        let input = Tensor::<TestBackend, 2>::random([2, 64], Distribution::Default, &device);
+        let output_before = lora.forward(input.clone());
+
+        // Extract adapter and load onto fresh layer with same base
+        let adapter = lora.clone().into_adapter();
+
+        // Reload the adapter onto a clone (base weights preserved)
+        let lora_reloaded = lora.clone().load_adapter(adapter).unwrap();
+
+        // Get output after reload
+        let output_after = lora_reloaded.forward(input);
+
+        // Should produce identical output
+        output_before
+            .into_data()
+            .assert_approx_eq::<FT>(&output_after.into_data(), Tolerance::default());
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_adapter_save_load_roundtrip() {
+        use burn::record::{FullPrecisionSettings, NamedMpkFileRecorder};
+        use std::fs;
+
+        let device = Default::default();
+        TestBackend::seed(&device, 42);
+
+        // Create and configure LoRA layer with Gaussian init (non-zero)
+        let linear = LinearConfig::new(64, 32).init::<TestBackend>(&device);
+        let lora = linear.with_lora(
+            &LoraConfig::new(8)
+                .with_alpha(16.0)
+                .with_init(LoraInit::Gaussian),
+            &device,
+        );
+
+        // Get original LoRA weights for comparison
+        let original_a = lora.lora_a.val().clone();
+        let original_b = lora.lora_b.val().clone();
+
+        // Save adapter to temp file
+        let temp_dir = std::env::temp_dir();
+        let adapter_path = temp_dir.join("test_lora_adapter_roundtrip");
+        let recorder = NamedMpkFileRecorder::<FullPrecisionSettings>::new();
+
+        lora.save_adapter(&adapter_path, &recorder)
+            .expect("Failed to save adapter");
+
+        // Create fresh LoRA layer with same base (clone the original)
+        // and zero-initialized LoRA weights
+        let fresh_lora = lora.clone();
+
+        // Load adapter - this should restore the original LoRA weights
+        let loaded_lora = fresh_lora
+            .load_adapter_file(&adapter_path, &recorder, &device)
+            .expect("Failed to load adapter");
+
+        // Verify LoRA weights are identical after roundtrip
+        loaded_lora
+            .lora_a
+            .val()
+            .into_data()
+            .assert_approx_eq::<FT>(&original_a.into_data(), Tolerance::default());
+        loaded_lora
+            .lora_b
+            .val()
+            .into_data()
+            .assert_approx_eq::<FT>(&original_b.into_data(), Tolerance::default());
+
+        // Verify outputs are identical
+        let input = Tensor::<TestBackend, 2>::random([2, 64], Distribution::Default, &device);
+        let output_original = lora.forward(input.clone());
+        let output_loaded = loaded_lora.forward(input);
+
+        output_original
+            .into_data()
+            .assert_approx_eq::<FT>(&output_loaded.into_data(), Tolerance::default());
+
+        // Cleanup
+        let _ = fs::remove_file(adapter_path.with_extension("mpk"));
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_adapter_swap_at_runtime() {
+        use burn::record::{FullPrecisionSettings, NamedMpkFileRecorder};
+        use std::fs;
+
+        let device = Default::default();
+        let recorder = NamedMpkFileRecorder::<FullPrecisionSettings>::new();
+        let temp_dir = std::env::temp_dir();
+
+        // Create two different adapters
+        TestBackend::seed(&device, 1);
+        let linear1 = LinearConfig::new(64, 32).init::<TestBackend>(&device);
+        let lora1 = linear1.with_lora(&LoraConfig::new(8).with_init(LoraInit::Gaussian), &device);
+        let adapter1_path = temp_dir.join("test_adapter1");
+        lora1.save_adapter(&adapter1_path, &recorder).unwrap();
+
+        TestBackend::seed(&device, 2);
+        let linear2 = LinearConfig::new(64, 32).init::<TestBackend>(&device);
+        let lora2 = linear2.with_lora(&LoraConfig::new(8).with_init(LoraInit::Gaussian), &device);
+        let adapter2_path = temp_dir.join("test_adapter2");
+        lora2.save_adapter(&adapter2_path, &recorder).unwrap();
+
+        // Create base LoRA layer
+        TestBackend::seed(&device, 0);
+        let base_linear = LinearConfig::new(64, 32).init::<TestBackend>(&device);
+        let mut lora = base_linear.with_lora(&LoraConfig::new(8), &device);
+
+        let input = Tensor::<TestBackend, 2>::random([2, 64], Distribution::Default, &device);
+
+        // Load adapter1 and get output
+        lora = lora
+            .load_adapter_file(&adapter1_path, &recorder, &device)
+            .unwrap();
+        let output1 = lora.forward(input.clone());
+
+        // Swap to adapter2 and get output
+        lora = lora
+            .load_adapter_file(&adapter2_path, &recorder, &device)
+            .unwrap();
+        let output2 = lora.forward(input.clone());
+
+        // Outputs should be different (different adapters)
+        use burn::tensor::ElementConversion;
+        let diff = (output1.clone() - output2.clone()).abs().sum();
+        assert!(
+            diff.into_scalar().elem::<f32>() > 0.01,
+            "Outputs should differ with different adapters"
+        );
+
+        // Swap back to adapter1 and verify we get the original output
+        lora = lora
+            .load_adapter_file(&adapter1_path, &recorder, &device)
+            .unwrap();
+        let output1_again = lora.forward(input);
+
+        output1
+            .into_data()
+            .assert_approx_eq::<FT>(&output1_again.into_data(), Tolerance::default());
+
+        // Cleanup
+        let _ = fs::remove_file(adapter1_path.with_extension("mpk"));
+        let _ = fs::remove_file(adapter2_path.with_extension("mpk"));
+    }
+
+    #[test]
+    fn test_load_adapter_dimension_mismatch() {
+        let device = Default::default();
+
+        // Create LoRA layers with different dimensions
+        let linear_64_32 = LinearConfig::new(64, 32).init::<TestBackend>(&device);
+        let lora_64_32 = linear_64_32.with_lora(&LoraConfig::new(8), &device);
+
+        let linear_128_64 = LinearConfig::new(128, 64).init::<TestBackend>(&device);
+        let lora_128_64 = linear_128_64.with_lora(&LoraConfig::new(8), &device);
+
+        // Extract adapter from mismatched layer
+        let adapter_128_64 = lora_128_64.into_adapter();
+
+        // Should fail with dimension mismatch
+        let result = lora_64_32.load_adapter(adapter_128_64);
+        assert!(result.is_err());
+
+        // Verify error message contains expected dimensions
+        let err = result.unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("128"));
+        assert!(msg.contains("64"));
+    }
+
+    /// Test that gradients only flow to LoRA parameters, not to frozen base weights.
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_gradient_flow_only_lora_params() {
+        use crate::TestAutodiffBackend;
+
+        let device = Default::default();
+        let linear = LinearConfig::new(64, 32).init::<TestAutodiffBackend>(&device);
+        let lora = linear.with_lora(&LoraConfig::new(8).with_init(LoraInit::Gaussian), &device);
+
+        let input =
+            Tensor::<TestAutodiffBackend, 2>::random([2, 64], Distribution::Default, &device);
+        let output = lora.forward(input);
+        let loss = output.sum();
+        let grads = loss.backward();
+
+        // LoRA params should have gradients
+        assert!(
+            lora.lora_a.grad(&grads).is_some(),
+            "LoRA A should have gradients"
+        );
+        assert!(
+            lora.lora_b.grad(&grads).is_some(),
+            "LoRA B should have gradients"
+        );
+
+        // Base weight should NOT have gradients (frozen via no_grad)
+        assert!(
+            lora.base.weight.grad(&grads).is_none(),
+            "Base weight should not have gradients (frozen)"
+        );
+    }
+
+    /// Test that alpha=0 results in no LoRA contribution.
+    #[test]
+    fn test_lora_alpha_zero_scaling() {
+        let device = Default::default();
+        let config = LoraConfig::new(8).with_alpha(0.0);
+
+        // Scaling should be zero
+        assert!(
+            (config.scaling() - 0.0).abs() < 1e-10,
+            "Scaling should be zero when alpha is zero"
+        );
+
+        // With Gaussian init (non-zero LoRA weights), output should still equal base
+        // because the scaling factor is 0
+        TestBackend::seed(&device, 42);
+        let linear = LinearConfig::new(64, 32).init::<TestBackend>(&device);
+        let base_weight = linear.weight.val().clone();
+        let base_bias = linear.bias.as_ref().map(|b| b.val().clone());
+
+        let lora = linear.with_lora(&config.with_init(LoraInit::Gaussian), &device);
+
+        let input = Tensor::<TestBackend, 2>::random([2, 64], Distribution::Default, &device);
+        let base_out = burn::tensor::module::linear(input.clone(), base_weight, base_bias);
+        let lora_out = lora.forward(input);
+
+        // Should match because scaling is 0 (LoRA contribution is zero)
+        base_out
+            .into_data()
+            .assert_approx_eq::<FT>(&lora_out.into_data(), Tolerance::default());
+    }
+
+    /// Test the minimum valid rank of 1.
+    #[test]
+    fn test_lora_rank_one_minimum() {
+        let device = Default::default();
+        let linear = LinearConfig::new(64, 32).init::<TestBackend>(&device);
+        let lora = linear.with_lora(&LoraConfig::new(1), &device);
+
+        assert_eq!(lora.rank(), 1);
+        assert_eq!(lora.lora_a.shape().dims::<2>(), [64, 1]);
+        assert_eq!(lora.lora_b.shape().dims::<2>(), [1, 32]);
+
+        // Should still work with rank 1
+        let input = Tensor::<TestBackend, 2>::random([2, 64], Distribution::Default, &device);
+        let output = lora.forward(input);
+        assert_eq!(output.shape(), Shape::new([2, 32]));
+    }
+
+    /// Test adapter persistence with half precision settings.
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_adapter_half_precision_roundtrip() {
+        use burn::record::{HalfPrecisionSettings, NamedMpkFileRecorder};
+        use std::fs;
+
+        let device = Default::default();
+        TestBackend::seed(&device, 42);
+
+        let linear = LinearConfig::new(64, 32).init::<TestBackend>(&device);
+        let lora = linear.with_lora(&LoraConfig::new(8).with_init(LoraInit::Gaussian), &device);
+
+        let temp_dir = std::env::temp_dir();
+        let adapter_path = temp_dir.join("test_lora_half_precision");
+        let recorder = NamedMpkFileRecorder::<HalfPrecisionSettings>::new();
+
+        lora.save_adapter(&adapter_path, &recorder)
+            .expect("Save failed");
+
+        let fresh_lora = LinearConfig::new(64, 32)
+            .init::<TestBackend>(&device)
+            .with_lora(&LoraConfig::new(8), &device);
+        let loaded = fresh_lora
+            .load_adapter_file(&adapter_path, &recorder, &device)
+            .expect("Load failed");
+
+        // Verify dimensions preserved
+        assert_eq!(loaded.rank(), 8);
+        assert_eq!(loaded.d_input(), 64);
+        assert_eq!(loaded.d_output(), 32);
+
+        // Cleanup
+        let _ = fs::remove_file(adapter_path.with_extension("mpk"));
+    }
+
+    /// Test forward pass with 4D input tensors.
+    #[test]
+    fn test_forward_4d_input() {
+        let device = Default::default();
+        let linear = LinearConfig::new(64, 32).init::<TestBackend>(&device);
+        let lora = linear.with_lora(&LoraConfig::new(8), &device);
+
+        // 4D input: [batch, seq, heads, d_input]
+        let input = Tensor::<TestBackend, 4>::random([2, 4, 8, 64], Distribution::Default, &device);
+        let output = lora.forward(input);
+        assert_eq!(output.shape(), Shape::new([2, 4, 8, 32]));
+    }
+
+    /// Test forward pass with 1D input tensor (edge case).
+    ///
+    /// 1D input requires special handling since unsqueeze::<D>() on 2D LoRA weights
+    /// fails when D=1. The forward method should upgrade to 2D, process, and squeeze back.
+    #[test]
+    fn test_lora_linear_1d_input() {
+        let device = Default::default();
+        TestBackend::seed(&device, 0);
+
+        let value = 2.;
+        let config =
+            LinearConfig::new(2, 3).with_initializer(crate::Initializer::Constant { value });
+        let linear = config.init::<TestBackend>(&device);
+        let lora = linear.with_lora(&LoraConfig::new(1), &device);
+
+        // Create 1D and 2D inputs with the same data
+        let input_1d = Tensor::<TestBackend, 1>::ones(Shape::new([2]), &device);
+        let input_2d = Tensor::<TestBackend, 2>::ones(Shape::new([1, 2]), &device);
+
+        // Both should produce equivalent results
+        let result_1d = lora.forward(input_1d).unsqueeze::<2>();
+        let result_2d = lora.forward(input_2d);
+
+        result_1d
+            .into_data()
+            .assert_approx_eq::<FT>(&result_2d.into_data(), Tolerance::default());
+    }
+
+    /// Test LoRA formula with known values to verify mathematical correctness.
+    ///
+    /// LoRA computes: output = base(x) + (x @ A @ B) * scaling
+    ///
+    /// This test uses manually set weights to verify the exact formula:
+    /// - base weight W = [[1, 2], [3, 4], [5, 6]] (3x2 -> d_input=3, d_output=2)
+    /// - base bias = [0.1, 0.2]
+    /// - LoRA A = [[0.1], [0.2], [0.3]] (3x1, rank=1)
+    /// - LoRA B = [[0.5, 0.6]] (1x2)
+    /// - alpha = 2.0, rank = 1, scaling = 2.0
+    /// - input x = [[1, 1, 1]] (1x3)
+    ///
+    /// Expected:
+    /// - base(x) = x @ W + bias = [1,1,1] @ [[1,2],[3,4],[5,6]] + [0.1,0.2]
+    ///           = [1+3+5, 2+4+6] + [0.1, 0.2] = [9.1, 12.2]
+    /// - lora(x) = (x @ A @ B) * scaling
+    ///           = ([1,1,1] @ [[0.1],[0.2],[0.3]]) @ [[0.5, 0.6]] * 2.0
+    ///           = [0.6] @ [[0.5, 0.6]] * 2.0 = [0.3, 0.36] * 2.0 = [0.6, 0.72]
+    /// - output = base(x) + lora(x) = [9.1, 12.2] + [0.6, 0.72] = [9.7, 12.92]
+    #[test]
+    fn test_lora_formula_with_known_values() {
+        use burn::tensor::TensorData;
+
+        let device = Default::default();
+
+        // Create linear layer with known weights
+        // W: [d_input=3, d_output=2]
+        let weight_data = TensorData::from([[1.0_f32, 2.0], [3.0, 4.0], [5.0, 6.0]]);
+        let weight = Tensor::<TestBackend, 2>::from_data(weight_data, &device);
+
+        // bias: [d_output=2]
+        let bias_data = TensorData::from([0.1_f32, 0.2]);
+        let bias = Tensor::<TestBackend, 1>::from_data(bias_data, &device);
+
+        // Build Linear manually
+        let linear = Linear {
+            weight: Param::from_tensor(weight),
+            bias: Some(Param::from_tensor(bias)),
+        };
+
+        // Create LoRA config with known scaling
+        let config = LoraConfig::new(1)
+            .with_alpha(2.0)
+            .with_init(LoraInit::Zeros);
+        let mut lora = linear.with_lora(&config, &device);
+
+        // Manually set LoRA A and B matrices
+        // A: [d_input=3, rank=1]
+        let lora_a_data = TensorData::from([[0.1_f32], [0.2], [0.3]]);
+        let lora_a = Tensor::<TestBackend, 2>::from_data(lora_a_data, &device);
+        lora.lora_a = Param::from_tensor(lora_a);
+
+        // B: [rank=1, d_output=2]
+        let lora_b_data = TensorData::from([[0.5_f32, 0.6]]);
+        let lora_b = Tensor::<TestBackend, 2>::from_data(lora_b_data, &device);
+        lora.lora_b = Param::from_tensor(lora_b);
+
+        // Verify scaling is correct: alpha / rank = 2.0 / 1 = 2.0
+        assert!((lora.scaling - 2.0).abs() < 1e-10);
+
+        // Input: [batch=1, d_input=3]
+        let input_data = TensorData::from([[1.0_f32, 1.0, 1.0]]);
+        let input = Tensor::<TestBackend, 2>::from_data(input_data, &device);
+
+        // Forward pass
+        let output = lora.forward(input);
+
+        // Expected output (calculated above):
+        // base(x) = [9.1, 12.2]
+        // lora(x) = [0.6, 0.72]
+        // total = [9.7, 12.92]
+        let expected_data = TensorData::from([[9.7_f32, 12.92]]);
+
+        output
+            .into_data()
+            .assert_approx_eq::<FT>(&expected_data, Tolerance::default());
+    }
+}

--- a/crates/burn-nn/src/lora/mod.rs
+++ b/crates/burn-nn/src/lora/mod.rs
@@ -1,0 +1,113 @@
+//! LoRA (Low-Rank Adaptation) module for parameter-efficient fine-tuning.
+//!
+//! LoRA enables efficient fine-tuning of large pre-trained models by freezing
+//! the original weights and adding trainable low-rank decomposition matrices.
+//! This dramatically reduces the number of trainable parameters while maintaining
+//! model quality.
+//!
+//! # Overview
+//!
+//! Instead of fine-tuning all parameters, LoRA adds pairs of low-rank matrices
+//! (A and B) to existing layers. During forward pass:
+//!
+//! ```text
+//! output = base(x) + (x @ A @ B) * scaling
+//! ```
+//!
+//! Where:
+//! - `base(x)` is the frozen original layer
+//! - `A` has shape `[in_features, rank]` (down projection)
+//! - `B` has shape `[rank, out_features]` (up projection)
+//! - `scaling = alpha / rank` (configurable)
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use burn_nn::{Linear, LinearConfig};
+//! use burn_nn::lora::{LoraConfig, LoraAdaptable, LoraBias};
+//!
+//! // Create a pre-trained linear layer
+//! let linear = LinearConfig::new(768, 768).init(&device);
+//!
+//! // Wrap with LoRA
+//! let config = LoraConfig::new(16)
+//!     .with_alpha(32.0)
+//!     .with_dropout(0.1);
+//! let lora_linear = linear.with_lora(&config, &device);
+//!
+//! // Use normally - only LoRA params are trainable
+//! let output = lora_linear.forward(input);
+//!
+//! // Merge for inference (no overhead)
+//! let merged = lora_linear.merge();
+//! ```
+//!
+//! # Supported Layers
+//!
+//! Currently supported:
+//! - [`Linear`](crate::Linear) via [`LoraLinear`]
+//!
+//! Future support planned for Conv1d, Conv2d, Conv3d, Embedding, etc.
+
+mod adapter;
+mod config;
+mod linear;
+
+pub use adapter::LoraLinearAdapter;
+pub use config::{LoraBias, LoraConfig, LoraInit};
+pub use linear::{LoraError, LoraLinear};
+
+use burn_core as burn;
+
+use burn::module::Module;
+use burn::tensor::backend::Backend;
+
+use crate::lora::config::LoraConfig as Config;
+
+/// Trait for layers that can be wrapped with LoRA adaptation.
+///
+/// Implementors define how to extract dimensions for LoRA matrices and
+/// construct the wrapped version. The wrapper type handles the forward
+/// pass and merge logic.
+///
+/// # Implementing for New Layers
+///
+/// To add LoRA support for a new layer type:
+///
+/// 1. Create a wrapper struct (e.g., `LoraConv2d`)
+/// 2. Implement `LoraAdaptable` for the base layer
+/// 3. Implement `forward()` and `merge()` on the wrapper
+///
+/// ```ignore
+/// impl<B: Backend> LoraAdaptable<B> for Conv2d<B> {
+///     type Wrapped = LoraConv2d<B>;
+///
+///     fn lora_dims(&self) -> (usize, usize) {
+///         let [out_ch, in_ch, kh, kw] = self.weight.shape().dims();
+///         (in_ch * kh * kw, out_ch)
+///     }
+///
+///     fn with_lora(self, config: &LoraConfig, device: &B::Device) -> Self::Wrapped {
+///         // ... implementation
+///     }
+/// }
+/// ```
+pub trait LoraAdaptable<B: Backend>: Module<B> + Sized {
+    /// The LoRA-wrapped version of this layer.
+    ///
+    /// This associated type ensures type safety - each base layer
+    /// maps to exactly one wrapper type.
+    type Wrapped: Module<B>;
+
+    /// Returns dimensions for LoRA matrices: `(in_features, out_features)`.
+    fn lora_dims(&self) -> (usize, usize);
+
+    /// Wrap this layer with LoRA adaptation.
+    ///
+    /// This method:
+    /// - Consumes `self` (the original layer)
+    /// - Freezes the base weights
+    /// - Initializes LoRA matrices A and B
+    /// - Optionally unfreezes bias based on config
+    fn with_lora(self, config: &Config, device: &B::Device) -> Self::Wrapped;
+}

--- a/examples/lora-finetuning/Cargo.toml
+++ b/examples/lora-finetuning/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+authors = ["burn contributors"]
+edition.workspace = true
+license.workspace = true
+name = "lora-finetuning"
+publish = false
+version.workspace = true
+
+[lints]
+workspace = true
+
+[features]
+default = ["burn/tui"]
+ndarray = ["burn/ndarray"]
+ndarray-blas-accelerate = ["burn/ndarray", "burn/accelerate"]
+ndarray-blas-netlib = ["burn/ndarray", "burn/blas-netlib"]
+ndarray-blas-openblas = ["burn/ndarray", "burn/openblas"]
+tch-cpu = ["burn/tch"]
+tch-gpu = ["burn/tch"]
+wgpu = ["burn/wgpu"]
+cuda = ["burn/cuda", "burn/default"]
+metal = ["burn/metal", "burn/default"]
+vulkan = ["burn/vulkan", "burn/default"]
+rocm = ["burn/rocm", "burn/default"]
+remote = ["burn/remote"]
+
+[dependencies]
+burn = { path = "../../crates/burn", features = ["train", "tui"] }
+log = { workspace = true }
+rand = { workspace = true }
+serde = { workspace = true, features = ["std", "derive"] }

--- a/examples/lora-finetuning/README.md
+++ b/examples/lora-finetuning/README.md
@@ -1,0 +1,107 @@
+# LoRA Fine-tuning Example
+
+This example demonstrates how to use LoRA (Low-Rank Adaptation) for parameter-efficient fine-tuning in Burn.
+
+## What is LoRA?
+
+LoRA is a technique for efficiently fine-tuning large pre-trained models by:
+
+1. **Freezing** the original model weights
+2. **Adding** small trainable low-rank matrices (A and B) to specific layers
+3. **Computing**: `output = base(x) + (x @ A @ B) * scaling`
+
+This dramatically reduces the number of trainable parameters while maintaining model quality.
+
+## Key Benefits
+
+- **Parameter Efficiency**: Train only ~1-5% of original parameters
+- **Memory Efficient**: Smaller optimizer states and gradients
+- **Mergeable**: LoRA weights can be merged into base model for zero inference overhead
+- **Composable**: Multiple LoRA adaptations can be swapped without reloading base model
+
+## Running the Example
+
+```bash
+# Using ndarray backend (CPU)
+cargo run --example lora --release --features ndarray
+
+# Using wgpu backend (GPU)
+cargo run --example lora --release --features wgpu
+
+# Using LibTorch CPU
+cargo run --example lora --release --features tch-cpu
+
+# Using LibTorch GPU
+cargo run --example lora --release --features tch-gpu
+```
+
+## Example Output
+
+```
+=== LoRA Fine-tuning Example ===
+
+Base model parameters: 99850
+
+LoRA Configuration:
+  Rank: 8
+  Alpha: 16
+  Scaling: 2.0000
+  Bias mode: None
+
+LoRA trainable parameters: 6144
+Parameter reduction: 93.85%
+
+LoRA model output shape: [4, 10]
+Merged model output shape: [4, 10]
+
+Max difference between LoRA and merged outputs: 0.00e+00
+SUCCESS: LoRA and merged outputs match!
+
+Sample output (first row):
+...
+
+=== Example Complete ===
+```
+
+## Code Highlights
+
+### Applying LoRA to a Model
+
+```rust
+use burn::nn::lora::{LoraConfig, LoraAdaptable, LoraBias};
+
+// Configure LoRA
+let config = LoraConfig::new(8)      // rank = 8
+    .with_alpha(16.0)                 // scaling = 16/8 = 2.0
+    .with_dropout(0.1)                // optional dropout
+    .with_bias(LoraBias::All);        // train biases in LoRA layers
+
+// Apply to a linear layer
+let lora_linear = linear_layer.with_lora(&config, &device);
+```
+
+### Merging for Inference
+
+```rust
+// After training, merge LoRA weights into base layer
+let merged_linear = lora_linear.merge();
+
+// merged_linear is a regular Linear with no LoRA overhead
+// Output is identical to lora_linear (ignoring dropout)
+```
+
+## Configuration Options
+
+| Option       | Description                       | Default   |
+| ------------ | --------------------------------- | --------- |
+| `rank`       | Low-rank dimension (4-64 typical) | Required  |
+| `alpha`      | Scaling numerator                 | 1.0       |
+| `dropout`    | Dropout on LoRA branch            | 0.0       |
+| `bias`       | Bias training mode                | `None`    |
+| `use_rslora` | Rank-stabilized scaling           | false     |
+| `init`       | Weight initialization             | `Kaiming` |
+
+## Bias Modes
+
+- `LoraBias::None` - All biases frozen (default)
+- `LoraBias::All` - Biases trainable in LoRA-wrapped layers

--- a/examples/lora-finetuning/examples/lora.rs
+++ b/examples/lora-finetuning/examples/lora.rs
@@ -1,0 +1,109 @@
+#[cfg(any(
+    feature = "ndarray",
+    feature = "ndarray-blas-netlib",
+    feature = "ndarray-blas-openblas",
+    feature = "ndarray-blas-accelerate",
+))]
+mod ndarray {
+    use burn::backend::Autodiff;
+    use burn::backend::ndarray::{NdArray, NdArrayDevice};
+
+    pub fn run() {
+        let device = NdArrayDevice::Cpu;
+        lora_finetuning::run::<Autodiff<NdArray<f32>>>(device);
+    }
+}
+
+#[cfg(feature = "tch-gpu")]
+mod tch_gpu {
+    use burn::backend::Autodiff;
+    use burn::backend::libtorch::{LibTorch, LibTorchDevice};
+
+    pub fn run() {
+        #[cfg(not(target_os = "macos"))]
+        let device = LibTorchDevice::Cuda(0);
+        #[cfg(target_os = "macos")]
+        let device = LibTorchDevice::Mps;
+
+        lora_finetuning::run::<Autodiff<LibTorch>>(device);
+    }
+}
+
+#[cfg(feature = "tch-cpu")]
+mod tch_cpu {
+    use burn::backend::Autodiff;
+    use burn::backend::libtorch::{LibTorch, LibTorchDevice};
+
+    pub fn run() {
+        let device = LibTorchDevice::Cpu;
+        lora_finetuning::run::<Autodiff<LibTorch>>(device);
+    }
+}
+
+#[cfg(any(feature = "wgpu", feature = "metal", feature = "vulkan"))]
+mod wgpu {
+    use burn::backend::Autodiff;
+    use burn::backend::wgpu::{Wgpu, WgpuDevice};
+
+    pub fn run() {
+        let device = WgpuDevice::default();
+        lora_finetuning::run::<Autodiff<Wgpu>>(device);
+    }
+}
+
+#[cfg(feature = "cuda")]
+mod cuda {
+    use burn::backend::{Autodiff, Cuda};
+
+    pub fn run() {
+        let device = Default::default();
+        lora_finetuning::run::<Autodiff<Cuda>>(device);
+    }
+}
+
+#[cfg(feature = "rocm")]
+mod rocm {
+    use burn::backend::{Autodiff, Rocm};
+
+    pub fn run() {
+        let device = Default::default();
+        lora_finetuning::run::<Autodiff<Rocm>>(device);
+    }
+}
+
+#[cfg(feature = "remote")]
+mod remote {
+    use burn::backend::{Autodiff, RemoteBackend};
+
+    pub fn run() {
+        lora_finetuning::run::<Autodiff<RemoteBackend>>(Default::default());
+    }
+}
+
+fn main() {
+    #[cfg(any(
+        feature = "ndarray",
+        feature = "ndarray-blas-netlib",
+        feature = "ndarray-blas-openblas",
+        feature = "ndarray-blas-accelerate",
+    ))]
+    ndarray::run();
+
+    #[cfg(feature = "tch-gpu")]
+    tch_gpu::run();
+
+    #[cfg(feature = "tch-cpu")]
+    tch_cpu::run();
+
+    #[cfg(any(feature = "wgpu", feature = "metal", feature = "vulkan"))]
+    wgpu::run();
+
+    #[cfg(feature = "cuda")]
+    cuda::run();
+
+    #[cfg(feature = "rocm")]
+    rocm::run();
+
+    #[cfg(feature = "remote")]
+    remote::run();
+}

--- a/examples/lora-finetuning/src/data.rs
+++ b/examples/lora-finetuning/src/data.rs
@@ -1,0 +1,90 @@
+//! Synthetic dataset for LoRA fine-tuning example.
+//!
+//! This module provides a simple synthetic dataset for demonstrating LoRA training.
+//! The task is to predict sin(mean(x) * pi) for input vector x.
+
+use burn::data::dataloader::batcher::Batcher;
+use burn::data::dataset::Dataset;
+use burn::prelude::*;
+use rand::Rng;
+
+/// A single synthetic training item.
+#[derive(Clone, Debug)]
+pub struct SyntheticItem {
+    /// Input features.
+    pub input: Vec<f32>,
+    /// Target value: sin(mean(input) * pi).
+    pub target: f32,
+}
+
+/// Batched data for training.
+#[derive(Clone, Debug)]
+pub struct SyntheticBatch<B: Backend> {
+    /// Input tensor with shape [batch_size, d_input].
+    pub inputs: Tensor<B, 2>,
+    /// Target tensor with shape [batch_size, 1].
+    pub targets: Tensor<B, 2>,
+}
+
+/// Batcher for synthetic data.
+#[derive(Clone, Default)]
+pub struct SyntheticBatcher;
+
+impl<B: Backend> Batcher<B, SyntheticItem, SyntheticBatch<B>> for SyntheticBatcher {
+    fn batch(&self, items: Vec<SyntheticItem>, device: &B::Device) -> SyntheticBatch<B> {
+        let inputs: Vec<Tensor<B, 2>> = items
+            .iter()
+            .map(|item| Tensor::<B, 1>::from_floats(item.input.as_slice(), device).unsqueeze())
+            .collect();
+
+        let targets: Vec<Tensor<B, 2>> = items
+            .iter()
+            .map(|item| Tensor::<B, 1>::from_floats([item.target], device).unsqueeze())
+            .collect();
+
+        SyntheticBatch {
+            inputs: Tensor::cat(inputs, 0),
+            targets: Tensor::cat(targets, 0),
+        }
+    }
+}
+
+/// In-memory synthetic dataset.
+pub struct SyntheticDataset {
+    items: Vec<SyntheticItem>,
+}
+
+impl Dataset<SyntheticItem> for SyntheticDataset {
+    fn get(&self, index: usize) -> Option<SyntheticItem> {
+        self.items.get(index).cloned()
+    }
+
+    fn len(&self) -> usize {
+        self.items.len()
+    }
+}
+
+impl SyntheticDataset {
+    /// Generate synthetic dataset.
+    ///
+    /// Task: predict sin(mean(x) * pi) for input vector x.
+    ///
+    /// # Arguments
+    ///
+    /// * `size` - Number of samples to generate.
+    /// * `d_input` - Dimension of input features.
+    pub fn new(size: usize, d_input: usize) -> Self {
+        let mut rng = rand::rng();
+
+        let items = (0..size)
+            .map(|_| {
+                let input: Vec<f32> = (0..d_input).map(|_| rng.random_range(-1.0..1.0)).collect();
+                let mean: f32 = input.iter().sum::<f32>() / d_input as f32;
+                let target = (mean * std::f32::consts::PI).sin();
+                SyntheticItem { input, target }
+            })
+            .collect();
+
+        Self { items }
+    }
+}

--- a/examples/lora-finetuning/src/lib.rs
+++ b/examples/lora-finetuning/src/lib.rs
@@ -1,0 +1,27 @@
+//! LoRA (Low-Rank Adaptation) Fine-tuning Example
+//!
+//! This example demonstrates how to use LoRA for parameter-efficient fine-tuning.
+//! LoRA freezes the pre-trained model weights and adds small trainable low-rank
+//! matrices, reducing the number of trainable parameters significantly.
+//!
+//! Key features demonstrated:
+//! - Applying LoRA to an existing model
+//! - Training only LoRA parameters while keeping base weights frozen
+//! - Saving and loading LoRA adapters independently of the base model
+//! - Merging LoRA weights back into the base model for inference
+//!
+//! ## Module Structure
+//!
+//! - [`model`]: Model definitions (SimpleMlp, SimpleMlpWithLora, apply_lora)
+//! - [`training`]: Training configuration and execution
+//! - [`data`]: Synthetic dataset for demonstration
+
+pub mod data;
+pub mod model;
+pub mod training;
+
+pub use model::{
+    SimpleMlp, SimpleMlpConfig, SimpleMlpWithLora, apply_lora, count_lora_trainable_params,
+    count_params,
+};
+pub use training::{LoraTrainingConfig, run, run_with_config};

--- a/examples/lora-finetuning/src/model.rs
+++ b/examples/lora-finetuning/src/model.rs
@@ -1,0 +1,199 @@
+//! LoRA-adapted MLP model for fine-tuning demonstration.
+//!
+//! This module contains the model definitions:
+//! - `SimpleMlp`: Base MLP model that can be adapted with LoRA
+//! - `SimpleMlpWithLora`: MLP with LoRA applied to fc1 and fc2 layers
+//! - `apply_lora`: Function to apply LoRA to a SimpleMlp model
+
+use burn::nn::lora::{LoraConfig, LoraLinear};
+use burn::nn::{Linear, LinearConfig, Relu};
+use burn::prelude::*;
+use burn::record::{FullPrecisionSettings, NamedMpkFileRecorder, RecorderError};
+
+use std::path::PathBuf;
+
+/// A simple MLP model that can be adapted with LoRA.
+#[derive(Module, Debug)]
+pub struct SimpleMlp<B: Backend> {
+    pub fc1: Linear<B>,
+    pub fc2: Linear<B>,
+    pub fc3: Linear<B>,
+    pub relu: Relu,
+}
+
+/// Configuration for the SimpleMlp model.
+#[derive(Config, Debug)]
+pub struct SimpleMlpConfig {
+    pub d_input: usize,
+    pub d_hidden: usize,
+    pub d_output: usize,
+}
+
+impl SimpleMlpConfig {
+    /// Initialize a new SimpleMlp model.
+    pub fn init<B: Backend>(&self, device: &B::Device) -> SimpleMlp<B> {
+        SimpleMlp {
+            fc1: LinearConfig::new(self.d_input, self.d_hidden).init(device),
+            fc2: LinearConfig::new(self.d_hidden, self.d_hidden).init(device),
+            fc3: LinearConfig::new(self.d_hidden, self.d_output).init(device),
+            relu: Relu::new(),
+        }
+    }
+}
+
+impl<B: Backend> SimpleMlp<B> {
+    /// Forward pass through the MLP.
+    pub fn forward(&self, x: Tensor<B, 2>) -> Tensor<B, 2> {
+        let x = self.fc1.forward(x);
+        let x = self.relu.forward(x);
+        let x = self.fc2.forward(x);
+        let x = self.relu.forward(x);
+        self.fc3.forward(x)
+    }
+}
+
+/// The same MLP but with LoRA applied to fc1 and fc2.
+/// fc3 remains unchanged (common pattern: adapt attention/hidden, keep output fixed).
+#[derive(Module, Debug)]
+pub struct SimpleMlpWithLora<B: Backend> {
+    pub fc1: LoraLinear<B>,
+    pub fc2: LoraLinear<B>,
+    pub fc3: Linear<B>,
+    pub relu: Relu,
+}
+
+impl<B: Backend> SimpleMlpWithLora<B> {
+    /// Forward pass through the LoRA-adapted MLP.
+    pub fn forward(&self, x: Tensor<B, 2>) -> Tensor<B, 2> {
+        let x = self.fc1.forward(x);
+        let x = self.relu.forward(x);
+        let x = self.fc2.forward(x);
+        let x = self.relu.forward(x);
+        self.fc3.forward(x)
+    }
+
+    /// Merge LoRA weights into base layers for inference.
+    /// Returns a regular SimpleMlp with no LoRA overhead.
+    pub fn merge(self) -> SimpleMlp<B> {
+        SimpleMlp {
+            fc1: self.fc1.merge(),
+            fc2: self.fc2.merge(),
+            fc3: self.fc3,
+            relu: self.relu,
+        }
+    }
+
+    /// Save adapter weights to disk.
+    ///
+    /// Saves only the LoRA matrices (not the base model) to `.mpk` files.
+    /// This enables efficient storage and adapter swapping.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Directory path to save adapters (e.g., "./my-adapter")
+    ///
+    /// # File Structure
+    ///
+    /// ```text
+    /// my-adapter/
+    /// ├── fc1.mpk   # LoRA config + A & B matrices for fc1
+    /// └── fc2.mpk   # LoRA config + A & B matrices for fc2
+    /// ```
+    pub fn save_adapters(&self, path: impl Into<PathBuf>) -> Result<(), RecorderError> {
+        let path = path.into();
+        std::fs::create_dir_all(&path).map_err(|e| RecorderError::Unknown(e.to_string()))?;
+
+        let recorder = NamedMpkFileRecorder::<FullPrecisionSettings>::new();
+
+        self.fc1.save_adapter(path.join("fc1"), &recorder)?;
+        self.fc2.save_adapter(path.join("fc2"), &recorder)?;
+
+        Ok(())
+    }
+
+    /// Load adapter weights from disk.
+    ///
+    /// Loads LoRA matrices from `.mpk` files and applies them to this model.
+    /// The base model weights remain unchanged.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Directory path containing adapter files
+    /// * `device` - Device to load tensors onto
+    pub fn load_adapters(
+        self,
+        path: impl Into<PathBuf>,
+        device: &B::Device,
+    ) -> Result<Self, RecorderError> {
+        let path = path.into();
+        let recorder = NamedMpkFileRecorder::<FullPrecisionSettings>::new();
+
+        let fc1 = self
+            .fc1
+            .load_adapter_file(path.join("fc1"), &recorder, device)?;
+        let fc2 = self
+            .fc2
+            .load_adapter_file(path.join("fc2"), &recorder, device)?;
+
+        Ok(Self {
+            fc1,
+            fc2,
+            fc3: self.fc3,
+            relu: self.relu,
+        })
+    }
+}
+
+/// Apply LoRA to a SimpleMlp model.
+///
+/// This function demonstrates the common pattern of:
+/// 1. Taking a pre-trained model
+/// 2. Wrapping specific layers with LoRA
+/// 3. Returning a new model with frozen base weights and trainable LoRA params
+pub fn apply_lora<B: Backend>(
+    model: SimpleMlp<B>,
+    config: &LoraConfig,
+    device: &B::Device,
+) -> SimpleMlpWithLora<B> {
+    use burn::nn::lora::LoraAdaptable;
+
+    SimpleMlpWithLora {
+        fc1: model.fc1.with_lora(config, device),
+        fc2: model.fc2.with_lora(config, device),
+        fc3: model.fc3.no_grad(), // Keep fc3 frozen without LoRA
+        relu: model.relu,
+    }
+}
+
+/// Count total parameters in a model.
+pub fn count_params<B: Backend>(model: &SimpleMlp<B>) -> usize {
+    let fc1_params = model.fc1.weight.shape().num_elements()
+        + model
+            .fc1
+            .bias
+            .as_ref()
+            .map_or(0, |b| b.shape().num_elements());
+    let fc2_params = model.fc2.weight.shape().num_elements()
+        + model
+            .fc2
+            .bias
+            .as_ref()
+            .map_or(0, |b| b.shape().num_elements());
+    let fc3_params = model.fc3.weight.shape().num_elements()
+        + model
+            .fc3
+            .bias
+            .as_ref()
+            .map_or(0, |b| b.shape().num_elements());
+    fc1_params + fc2_params + fc3_params
+}
+
+/// Count trainable LoRA parameters.
+pub fn count_lora_trainable_params<B: Backend>(model: &SimpleMlpWithLora<B>) -> usize {
+    // LoRA A and B matrices for fc1 and fc2
+    let fc1_lora =
+        model.fc1.lora_a.shape().num_elements() + model.fc1.lora_b.shape().num_elements();
+    let fc2_lora =
+        model.fc2.lora_a.shape().num_elements() + model.fc2.lora_b.shape().num_elements();
+    fc1_lora + fc2_lora
+}

--- a/examples/lora-finetuning/src/training.rs
+++ b/examples/lora-finetuning/src/training.rs
@@ -1,0 +1,346 @@
+//! Training configuration and execution for LoRA fine-tuning.
+//!
+//! This module contains:
+//! - `LoraTrainingConfig`: Configurable training parameters
+//! - `run()`: Main entry point for training
+//! - TrainStep/InferenceStep implementations for the model
+
+use crate::data::{SyntheticBatch, SyntheticBatcher, SyntheticDataset};
+use crate::model::{
+    SimpleMlp, SimpleMlpConfig, SimpleMlpWithLora, apply_lora, count_lora_trainable_params,
+    count_params,
+};
+
+use burn::data::dataloader::DataLoaderBuilder;
+use burn::data::dataset::Dataset;
+use burn::nn::lora::{LoraBias, LoraConfig};
+use burn::nn::loss::MseLoss;
+use burn::optim::AdamConfig;
+use burn::prelude::*;
+use burn::record::{CompactRecorder, Recorder};
+use burn::tensor::backend::AutodiffBackend;
+use burn::train::metric::LossMetric;
+use burn::train::{
+    InferenceStep, Learner, RegressionOutput, SupervisedTraining, TrainOutput, TrainStep,
+};
+
+/// Artifact directory for saving training outputs.
+static ARTIFACT_DIR: &str = "/tmp/burn-lora-example";
+
+/// Configuration for LoRA fine-tuning training.
+#[derive(Config, Debug)]
+pub struct LoraTrainingConfig {
+    // Model dimensions
+    /// Input dimension for the MLP.
+    #[config(default = 32)]
+    pub d_input: usize,
+    /// Hidden dimension for the MLP.
+    #[config(default = 64)]
+    pub d_hidden: usize,
+    /// Output dimension for the MLP.
+    #[config(default = 1)]
+    pub d_output: usize,
+
+    // LoRA parameters
+    /// LoRA rank (low-rank dimension).
+    #[config(default = 4)]
+    pub lora_rank: usize,
+    /// LoRA alpha (scaling factor).
+    #[config(default = 8.0)]
+    pub lora_alpha: f64,
+
+    // Training parameters
+    /// Number of training epochs.
+    #[config(default = 100)]
+    pub num_epochs: usize,
+    /// Batch size for training.
+    #[config(default = 32)]
+    pub batch_size: usize,
+    /// Learning rate.
+    #[config(default = 1e-3)]
+    pub learning_rate: f64,
+
+    // Dataset parameters
+    /// Number of training samples.
+    #[config(default = 1000)]
+    pub train_size: usize,
+    /// Number of validation samples.
+    #[config(default = 200)]
+    pub valid_size: usize,
+    /// Random seed for reproducibility.
+    #[config(default = 42)]
+    pub seed: u64,
+}
+
+impl<B: AutodiffBackend> TrainStep for SimpleMlpWithLora<B> {
+    type Input = SyntheticBatch<B>;
+    type Output = RegressionOutput<B>;
+
+    fn step(&self, batch: SyntheticBatch<B>) -> TrainOutput<RegressionOutput<B>> {
+        let output = self.forward(batch.inputs);
+        let loss = MseLoss::new().forward(
+            output.clone(),
+            batch.targets.clone(),
+            burn::nn::loss::Reduction::Mean,
+        );
+
+        TrainOutput::new(
+            self,
+            loss.backward(),
+            RegressionOutput::new(loss, output, batch.targets),
+        )
+    }
+}
+
+impl<B: Backend> InferenceStep for SimpleMlpWithLora<B> {
+    type Input = SyntheticBatch<B>;
+    type Output = RegressionOutput<B>;
+
+    fn step(&self, batch: SyntheticBatch<B>) -> RegressionOutput<B> {
+        let output = self.forward(batch.inputs);
+        let loss = MseLoss::new().forward(
+            output.clone(),
+            batch.targets.clone(),
+            burn::nn::loss::Reduction::Mean,
+        );
+        RegressionOutput::new(loss, output, batch.targets)
+    }
+}
+
+fn create_artifact_dir(artifact_dir: &str) {
+    // Remove existing artifacts before to get an accurate learner summary
+    std::fs::remove_dir_all(artifact_dir).ok();
+    std::fs::create_dir_all(artifact_dir).ok();
+}
+
+/// Run LoRA fine-tuning with default configuration.
+pub fn run<B: AutodiffBackend>(device: B::Device) {
+    let config = LoraTrainingConfig::new();
+    run_with_config::<B>(ARTIFACT_DIR, config, device);
+}
+
+/// Run LoRA fine-tuning with custom configuration.
+pub fn run_with_config<B: AutodiffBackend>(
+    artifact_dir: &str,
+    config: LoraTrainingConfig,
+    device: B::Device,
+) {
+    create_artifact_dir(artifact_dir);
+
+    // Save config
+    config
+        .save(format!("{artifact_dir}/config.json"))
+        .expect("Config should be saved successfully");
+
+    B::seed(&device, config.seed);
+
+    println!("=== LoRA Fine-tuning Example ===\n");
+
+    // Create the base model (simulating a pre-trained model)
+    let base_model =
+        SimpleMlpConfig::new(config.d_input, config.d_hidden, config.d_output).init::<B>(&device);
+
+    // Count parameters in base model
+    let base_params = count_params(&base_model);
+    println!("Base model parameters: {}", base_params);
+
+    // Evaluate base model before fine-tuning using validation dataset
+    let eval_dataset = SyntheticDataset::new(100, config.d_input);
+    let (test_inputs, test_targets): (Vec<_>, Vec<_>) = (0..eval_dataset.len())
+        .filter_map(|i| eval_dataset.get(i))
+        .map(|item| {
+            let input = Tensor::<B, 1>::from_floats(item.input.as_slice(), &device);
+            let target = Tensor::<B, 1>::from_floats([item.target], &device);
+            (input, target)
+        })
+        .unzip();
+
+    let test_input = Tensor::stack(test_inputs, 0);
+    let test_target = Tensor::stack(test_targets, 0);
+
+    let base_output = base_model.forward(test_input.clone());
+    let base_loss: f32 = MseLoss::new()
+        .forward(
+            base_output,
+            test_target.clone(),
+            burn::nn::loss::Reduction::Mean,
+        )
+        .into_scalar()
+        .elem();
+    println!("Base model loss (before fine-tuning): {:.6}", base_loss);
+
+    // Save base model weights to disk (represents a pre-trained model checkpoint)
+    let base_model_path = format!("{artifact_dir}/base_model");
+    println!("\nSaving base model to: {}", base_model_path);
+    base_model
+        .clone()
+        .save_file(&base_model_path, &CompactRecorder::new())
+        .expect("Failed to save base model");
+
+    // Configure LoRA
+    let lora_config = LoraConfig::new(config.lora_rank)
+        .with_alpha(config.lora_alpha)
+        .with_dropout(0.0)
+        .with_bias(LoraBias::None);
+
+    println!("\nLoRA Configuration:");
+    println!("  Rank: {}", lora_config.rank);
+    println!("  Alpha: {}", lora_config.alpha);
+    println!("  Scaling: {:.4}", lora_config.scaling());
+
+    // Apply LoRA to the model
+    let lora_model = apply_lora(base_model, &lora_config, &device);
+
+    // Count LoRA parameters (only trainable ones)
+    let lora_trainable = count_lora_trainable_params(&lora_model);
+    println!("\nLoRA trainable parameters: {}", lora_trainable);
+    println!(
+        "Parameter reduction: {:.2}%",
+        (1.0 - lora_trainable as f64 / base_params as f64) * 100.0
+    );
+
+    // Create datasets for training with TUI dashboard
+    let train_dataset = SyntheticDataset::new(config.train_size, config.d_input);
+    let valid_dataset = SyntheticDataset::new(config.valid_size, config.d_input);
+
+    println!("Train Dataset Size: {}", train_dataset.len());
+    println!("Valid Dataset Size: {}", valid_dataset.len());
+
+    // Create data loaders with appropriate batchers
+    let batcher_train = SyntheticBatcher;
+    let batcher_valid = SyntheticBatcher;
+
+    let dataloader_train = DataLoaderBuilder::new(batcher_train)
+        .batch_size(config.batch_size)
+        .shuffle(config.seed)
+        .build(train_dataset);
+
+    let dataloader_valid = DataLoaderBuilder::new(batcher_valid)
+        .batch_size(config.batch_size)
+        .build(valid_dataset);
+
+    // Setup training with TUI dashboard
+    let training = SupervisedTraining::new(artifact_dir, dataloader_train, dataloader_valid)
+        .metric_train_numeric(LossMetric::new())
+        .metric_valid_numeric(LossMetric::new())
+        .num_epochs(config.num_epochs)
+        .summary();
+
+    println!("\n--- Training with LoRA (TUI Dashboard) ---\n");
+
+    // Run training
+    let result = training.launch(Learner::new(
+        lora_model,
+        AdamConfig::new().init(),
+        config.learning_rate,
+    ));
+    let lora_model = result.model;
+
+    println!("\n--- Training Complete ---\n");
+
+    // Convert test tensors to inner backend (training result is already on InnerBackend)
+    let test_input_inner = test_input.inner();
+    let test_target_inner = test_target.inner();
+
+    // Evaluate after fine-tuning
+    let lora_output = lora_model.forward(test_input_inner.clone());
+    let lora_loss: f32 = MseLoss::new()
+        .forward(
+            lora_output,
+            test_target_inner.clone(),
+            burn::nn::loss::Reduction::Mean,
+        )
+        .into_scalar()
+        .elem();
+    println!("LoRA model loss (after fine-tuning): {:.6}", lora_loss);
+
+    // Merge LoRA weights for inference (model is already on InnerBackend)
+    let merged_model = lora_model.clone().merge();
+    let merged_output = merged_model.forward(test_input_inner.clone());
+    let merged_loss: f32 = MseLoss::new()
+        .forward(
+            merged_output,
+            test_target_inner.clone(),
+            burn::nn::loss::Reduction::Mean,
+        )
+        .into_scalar()
+        .elem();
+    println!("Merged model loss: {:.6}", merged_loss);
+
+    // Summary
+    println!("\n=== Results Summary ===");
+    println!("Before fine-tuning: {:.6}", base_loss);
+    println!("After fine-tuning:  {:.6}", lora_loss);
+    println!("Improvement: {:.2}x", base_loss / lora_loss);
+    println!(
+        "\nTrained only {} params ({:.2}% of model)",
+        lora_trainable,
+        lora_trainable as f64 / base_params as f64 * 100.0
+    );
+
+    // ====================================
+    // Adapter Persistence Demo
+    // ====================================
+    println!("\n=== Adapter Persistence Demo ===\n");
+
+    // Save adapters to disk (only LoRA weights, not the full model)
+    let adapter_path = format!("{artifact_dir}/adapters");
+    println!("Saving adapters to: {}", adapter_path);
+
+    // Model is already on InnerBackend after training
+    lora_model
+        .save_adapters(&adapter_path)
+        .expect("Failed to save adapters");
+
+    // Show file sizes to demonstrate efficiency
+    let fc1_size = std::fs::metadata(format!("{adapter_path}/fc1.mpk"))
+        .map(|m| m.len())
+        .unwrap_or(0);
+    let fc2_size = std::fs::metadata(format!("{adapter_path}/fc2.mpk"))
+        .map(|m| m.len())
+        .unwrap_or(0);
+    println!("  fc1.mpk: {} bytes", fc1_size);
+    println!("  fc2.mpk: {} bytes", fc2_size);
+    println!("  Total adapter size: {} bytes", fc1_size + fc2_size);
+
+    // Demonstrate REAL end-to-end loading from disk
+    // This is exactly what you would do in production:
+    // 1. Load base model from disk
+    // 2. Apply LoRA with zero-initialized weights
+    // 3. Load trained adapter weights
+    println!("\nLoading from disk (full reload)...");
+
+    // Step 1: Create fresh base model structure and load weights from disk
+    let fresh_base: SimpleMlp<B::InnerBackend> =
+        SimpleMlpConfig::new(config.d_input, config.d_hidden, config.d_output).init(&device);
+    let base_record = CompactRecorder::new()
+        .load(base_model_path.into(), &device)
+        .expect("Failed to load base model");
+    let fresh_base = fresh_base.load_record(base_record);
+
+    // Step 2: Apply LoRA (creates zero-initialized A and B matrices)
+    let fresh_lora = apply_lora(fresh_base, &lora_config, &device);
+
+    // Step 3: Load trained adapter weights from disk
+    let loaded_lora = fresh_lora
+        .load_adapters(&adapter_path, &device)
+        .expect("Failed to load adapters");
+
+    // Verify loaded model produces same output as the trained model
+    let loaded_output = loaded_lora.forward(test_input_inner.clone());
+    let loaded_loss: f32 = MseLoss::new()
+        .forward(
+            loaded_output,
+            test_target_inner.clone(),
+            burn::nn::loss::Reduction::Mean,
+        )
+        .into_scalar()
+        .elem();
+    println!("Loaded model loss: {:.6}", loaded_loss);
+    println!(
+        "Loss difference vs trained (should be ~0): {:.10}",
+        (merged_loss - loaded_loss).abs()
+    );
+
+    println!("\n=== Example Complete ===");
+}


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

https://github.com/tracel-ai/burn/issues/2943

### Changes

Added a new `lora` module in the `burn-nn` crate which implements a considerable set of features inspired by the PEFT library.

#### Features

- Training LoRA adapters on linear layers with frozen base weights
- Configurable rank, alpha scaling, and dropout
- RSLoRA scaling option (`alpha / sqrt(rank)` instead of `alpha / rank`)
- Multiple initialization methods: Kaiming, Gaussian, Zeros
- Bias training modes: `None` (fully frozen) or `LoraOnly` (train bias only)
- Merging LoRA weights into base layer for zero-overhead inference
- Saving adapters (LoRA matrices + config) independently of base model
- Loading adapters onto fresh base models
- Runtime adapter swapping without reloading base weights

### Not implemented for the sake of concision

I figure these can be implemented in separate PRs and this particular change is to layout the foundations.

- **Layers**: Only `Linear` supported (Conv, Embedding)
- **Variants**: No QLoRA, DoRA, LoRA+, or AdaLoRA
- **Multi-adapter**: No fusion or simultaneous adapters
- **Convenience**: No auto-wrap by pattern or architecture presets

### Testing

An example crate `examples/lora-finetuning/` is implemented to test the features and are visualized using the existing `SupervisedTraining` implementation.

Non-exhaustive list of features tested:

i. Saving adapters which saves lora matrices and the configuration
ii. Loading adapters which load the lora matrices and the configurations and apply them to the base model to train 
iii. Roundtrip verification ensuring that a model loaded from disk (base model + adapters) produces identical inference results to the original trained mode
