### PR TITLE
Fix memory growth: use GraphLocator::remove_entry for orphan cleanup

### DIFF
--- a/crates/burn-autodiff/src/runtime/graph.rs
+++ b/crates/burn-autodiff/src/runtime/graph.rs
@@ -153,7 +153,7 @@ impl<'a> GraphCleaner<'a> {
             let mut state = STATE.lock();
             if let Some(state) = state.as_mut() {
                 for node in should_remove {
-                    state.graphs.remove(&node);
+                    state.remove_entry(&node);
                 }
             }
         }


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.

### Changes

`GraphCleaner::cleanup_orphaned_entries` removes orphaned nodes from `GraphLocator::graphs`, but does not update `GraphLocator::keys`.
This leaves `GraphLocator` in an inconsistent state and can cause `keys` to grow over time, which looks like a memory leak in long-running workloads.