### PR TITLE
fix: Fix interpolate with NHWC input

### DIFF
--- a/crates/burn-cubecl/src/kernel/interpolate/base.rs
+++ b/crates/burn-cubecl/src/kernel/interpolate/base.rs
@@ -1,5 +1,6 @@
 use crate::{
     CubeRuntime,
+    kernel::into_contiguous_aligned,
     ops::{numeric::empty_device_optimized_dtype, permute_nchw_to_nhwc, permute_nhwc_to_nchw},
     tensor::CubeTensor,
 };
@@ -24,7 +25,7 @@ pub fn interpolate<R: CubeRuntime>(
     let [batch_size, channels, _, _] = input.shape.dims();
     let [out_height, out_width] = output_size;
 
-    let input = permute_nchw_to_nhwc(input);
+    let input = into_contiguous_aligned(permute_nchw_to_nhwc(input));
 
     let shape_out = Shape::new([batch_size, out_height, out_width, channels]);
     let output = empty_device_optimized_dtype(

--- a/crates/burn-cubecl/src/kernel/interpolate/bicubic.rs
+++ b/crates/burn-cubecl/src/kernel/interpolate/bicubic.rs
@@ -70,31 +70,31 @@ fn interpolate_bicubic_kernel<F: Float>(
     let x2_stride = x2 * in_stride_x;
     let x3_stride = x3 * in_stride_x;
 
-    let inp_0 = input[index_base + y0_stride + x0_stride];
-    let inp_1 = input[index_base + y0_stride + x1_stride];
-    let inp_2 = input[index_base + y0_stride + x2_stride];
-    let inp_3 = input[index_base + y0_stride + x3_stride];
+    let inp_0 = input[(index_base + y0_stride + x0_stride) / line_size];
+    let inp_1 = input[(index_base + y0_stride + x1_stride) / line_size];
+    let inp_2 = input[(index_base + y0_stride + x2_stride) / line_size];
+    let inp_3 = input[(index_base + y0_stride + x3_stride) / line_size];
 
     let coefficients0 = cubic_interp_1d::<F>(inp_0, inp_1, inp_2, inp_3, xw);
 
-    let inp_0 = input[index_base + y1_stride + x0_stride];
-    let inp_1 = input[index_base + y1_stride + x1_stride];
-    let inp_2 = input[index_base + y1_stride + x2_stride];
-    let inp_3 = input[index_base + y1_stride + x3_stride];
+    let inp_0 = input[(index_base + y1_stride + x0_stride) / line_size];
+    let inp_1 = input[(index_base + y1_stride + x1_stride) / line_size];
+    let inp_2 = input[(index_base + y1_stride + x2_stride) / line_size];
+    let inp_3 = input[(index_base + y1_stride + x3_stride) / line_size];
 
     let coefficients1 = cubic_interp_1d::<F>(inp_0, inp_1, inp_2, inp_3, xw);
 
-    let inp_0 = input[index_base + y2_stride + x0_stride];
-    let inp_1 = input[index_base + y2_stride + x1_stride];
-    let inp_2 = input[index_base + y2_stride + x2_stride];
-    let inp_3 = input[index_base + y2_stride + x3_stride];
+    let inp_0 = input[(index_base + y2_stride + x0_stride) / line_size];
+    let inp_1 = input[(index_base + y2_stride + x1_stride) / line_size];
+    let inp_2 = input[(index_base + y2_stride + x2_stride) / line_size];
+    let inp_3 = input[(index_base + y2_stride + x3_stride) / line_size];
 
     let coefficients2 = cubic_interp_1d::<F>(inp_0, inp_1, inp_2, inp_3, xw);
 
-    let inp_0 = input[index_base + y3_stride + x0_stride];
-    let inp_1 = input[index_base + y3_stride + x1_stride];
-    let inp_2 = input[index_base + y3_stride + x2_stride];
-    let inp_3 = input[index_base + y3_stride + x3_stride];
+    let inp_0 = input[(index_base + y3_stride + x0_stride) / line_size];
+    let inp_1 = input[(index_base + y3_stride + x1_stride) / line_size];
+    let inp_2 = input[(index_base + y3_stride + x2_stride) / line_size];
+    let inp_3 = input[(index_base + y3_stride + x3_stride) / line_size];
 
     let coefficients3 = cubic_interp_1d::<F>(inp_0, inp_1, inp_2, inp_3, xw);
 

--- a/crates/burn-cubecl/src/kernel/interpolate/bilinear.rs
+++ b/crates/burn-cubecl/src/kernel/interpolate/bilinear.rs
@@ -78,22 +78,22 @@ fn interpolate_bilinear_kernel<F: Float>(
 
     let p_a = select(
         x0_ok && y0_ok,
-        input[index_base + y0_stride + x0_stride] * xw_ * yw_,
+        input[(index_base + y0_stride + x0_stride) / line_size] * xw_ * yw_,
         zero,
     );
     let p_b = select(
         x1_ok && y0_ok,
-        input[index_base + y0_stride + x1_stride] * xw * yw_,
+        input[(index_base + y0_stride + x1_stride) / line_size] * xw * yw_,
         zero,
     );
     let p_c = select(
         x0_ok && y1_ok,
-        input[index_base + y1_stride + x0_stride] * xw_ * yw,
+        input[(index_base + y1_stride + x0_stride) / line_size] * xw_ * yw,
         zero,
     );
     let p_d = select(
         x1_ok && y1_ok,
-        input[index_base + y1_stride + x1_stride] * xw * yw,
+        input[(index_base + y1_stride + x1_stride) / line_size] * xw * yw,
         zero,
     );
 


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

Fixes interpolate kernels when the input has contiguous channels. Also ensures that's always the case since it improves performance.

### Testing

The tests actually use line size now and pass, and the bug reproduction is fixed by this.