### PR TITLE
Use `cache_dir()` instead of hardcoded `~/.cache` path

### DIFF
--- a/burn-book/src/building-blocks/dataset.md
+++ b/burn-book/src/building-blocks/dataset.md
@@ -407,10 +407,9 @@ impl MnistDataset {
 #    /// Download the MNIST dataset files from the web.
 #    /// Panics if the download cannot be completed or the content of the file cannot be written to disk.
 #    fn download(split: &str) -> PathBuf {
-#        // Dataset files are stored un the burn-dataset cache directory
-#        let cache_dir = dirs::home_dir()
-#            .expect("Could not get home directory")
-#            .join(".cache")
+#        // Dataset files are stored in the burn-dataset cache directory
+#        let cache_dir = dirs::cache_dir()
+#            .expect("Could not get cache directory")
 #            .join("burn-dataset");
 #        let split_dir = cache_dir.join("mnist").join(split);
 #

--- a/crates/burn-dataset/src/dataset/sqlite.rs
+++ b/crates/burn-dataset/src/dataset/sqlite.rs
@@ -360,11 +360,9 @@ impl SqliteDatasetStorage {
     pub fn base_dir(base_dir: Option<PathBuf>) -> PathBuf {
         match base_dir {
             Some(base_dir) => base_dir,
-            None => {
-                let home_dir = dirs::home_dir().expect("Could not get home directory");
-
-                home_dir.join(".cache").join("burn-dataset")
-            }
+            None => dirs::cache_dir()
+                .expect("Could not get cache directory")
+                .join("burn-dataset"),
         }
     }
 

--- a/crates/burn-dataset/src/nlp/ag_news.rs
+++ b/crates/burn-dataset/src/nlp/ag_news.rs
@@ -81,9 +81,8 @@ impl AgNewsDataset {
         let _lock = DOWNLOAD_LOCK.lock().unwrap();
 
         // Dataset files are stored in the burn-dataset cache directory
-        let cache_dir = dirs::home_dir()
-            .expect("Could not get home directory")
-            .join(".cache")
+        let cache_dir = dirs::cache_dir()
+            .expect("Could not get cache directory")
             .join("burn-dataset");
 
         // AG NEWS dataset directory

--- a/crates/burn-dataset/src/source/huggingface/downloader.rs
+++ b/crates/burn-dataset/src/source/huggingface/downloader.rs
@@ -100,7 +100,7 @@ impl HuggingfaceDatasetLoader {
 
     /// Specify a base directory to store the dataset.
     ///
-    /// If not specified, the dataset will be stored in `~/.cache/burn-dataset`.
+    /// If not specified, the dataset will be stored in the system cache directory under `burn-dataset`.
     pub fn with_base_dir(mut self, base_dir: &str) -> Self {
         self.base_dir = Some(base_dir.into());
         self
@@ -116,7 +116,7 @@ impl HuggingfaceDatasetLoader {
 
     /// Specify a huggingface cache directory to store the downloaded datasets.
     ///
-    /// If not specified, the dataset will be stored in `~/.cache/huggingface/datasets`.
+    /// If not specified, the dataset will be stored in the system cache directory under `huggingface/datasets`.
     pub fn with_huggingface_cache_dir(mut self, huggingface_cache_dir: &str) -> Self {
         self.huggingface_cache_dir = Some(huggingface_cache_dir.to_string());
         self

--- a/crates/burn-dataset/src/vision/cifar.rs
+++ b/crates/burn-dataset/src/vision/cifar.rs
@@ -118,9 +118,8 @@ fn download(cifar_type: &CifarType) -> PathBuf {
     let _lock = DOWNLOAD_LOCK.lock().unwrap();
 
     // Dataset files are stored in the burn-dataset cache directory
-    let cache_dir = dirs::home_dir()
-        .expect("Could not get home directory")
-        .join(".cache")
+    let cache_dir = dirs::cache_dir()
+        .expect("Could not get cache directory")
         .join("burn-dataset");
 
     // Cifar store directory

--- a/crates/burn-dataset/src/vision/mnist.rs
+++ b/crates/burn-dataset/src/vision/mnist.rs
@@ -118,10 +118,9 @@ impl MnistDataset {
     /// Download the MNIST dataset files from the web.
     /// Panics if the download cannot be completed or the content of the file cannot be written to disk.
     fn download(split: &str) -> PathBuf {
-        // Dataset files are stored un the burn-dataset cache directory
-        let cache_dir = dirs::home_dir()
-            .expect("Could not get home directory")
-            .join(".cache")
+        // Dataset files are stored in the burn-dataset cache directory
+        let cache_dir = dirs::cache_dir()
+            .expect("Could not get cache directory")
             .join("burn-dataset");
         let split_dir = cache_dir.join("mnist").join(split);
 


### PR DESCRIPTION
Replace `dirs::home_dir().join(".cache")` with `dirs::cache_dir()` for cross-platform compatibility. This respects platform conventions and environment variables like $XDG_CACHE_HOME on Linux.

The codebase was using `dirs::home_dir().join(".cache")` which is Linux-specific. This PR switches to `dirs::cache_dir()` which returns the platform-appropriate cache directory:

| Platform | Path |
|----------|------|
| Linux | `$XDG_CACHE_HOME` or `~/.cache` |
| macOS | `~/Library/Caches` |
| Windows | `{FOLDERPATH_LOCAL_APPDATA}` |

## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

N/A 

### Changes

- Replace `dirs::home_dir().join(".cache")` with `dirs::cache_dir()` for cross-platform compatibility
- Update documentation to reflect the change

### Testing

Tested mnist example to make sure the cache is saved under `~/Library/Caches` on mac

### Breaking 

Can redownload or alert missing files in ~/.cache path
