### PR TITLE
Implement the PSNR vision metric

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1213,7 +1213,6 @@ dependencies = [
  "burn-collective",
  "burn-core",
  "burn-ndarray",
- "burn-nn",
  "burn-optim",
  "derive-new",
  "log",

--- a/crates/burn-train/Cargo.toml
+++ b/crates/burn-train/Cargo.toml
@@ -38,7 +38,6 @@ burn-optim = { path = "../burn-optim", version = "=0.21.0", features = [
     "std",
 ], default-features = false }
 burn-collective = { path = "../burn-collective", version = "=0.21.0", optional = true }
-burn-nn = { path = "../burn-nn", version = "=0.21.0" }
 
 log = { workspace = true }
 tracing-subscriber = { workspace = true }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

[Image quality metrics #4312](https://github.com/tracel-ai/burn/issues/4312)

### Changes

Implemented the PSNR vision metric in the `crates/burn-train/src/metric/vision/psnr.rs` file. It computes the per-image PSNR values and then average them across all the images in the batch. Since the PSNR (in dB) is defined as following:

$$
PSNR = 10 \cdot \log_{10}\left(\frac{MAX_{I}^2}{MSE}\right)
$$

the MSE value is clamped a minimum value of `epsilon` to avoid division by 0. The `epsilon` field of the `PsnrMetricConfig` struct is set to `1e-10` by default. Users can set a custom/different epsilon value as well. 


### Testing

Added 18 test cases to the `psnr.rs` file. Tests cover different input shapes, different PSNR values, different image representation (where maximum possible pixel values are different), multichannel tensors, running average, setting custom name and/or epsilon, panics, etc. The test cases verify actual expected values rather than just ranges (which is approach taken by the other open PR).

### Note

- Right after creating this PR, I noticed that there is another open PR also implementing PSNR (https://github.com/tracel-ai/burn/pull/4377). 
- Below are the main differences (that I noticed) between my PR and the other PR:
    - My test cases verify very specific expected values while the other PR verifies if the psnr is within some range. 
    - The other PR implements a default method for the metric which I don't. This is because the PSNR metric always needs have the `max_pixel_val` set but this value depends on the specific image format used. Depending on whether the images are normalized to [0, 1] range, or they are 8, 16, 32, etc bits, this value changes. Hence, in my code, the user who is aware of their specific image formats must always set this value. 
    - My code only accepts 4d tensors with the shape [N, C, H, W] while the other PR accepts tensors with more than 1 dimension (dim >= 2)
        - I designed the code this way since I did not want the users to misuse the metric due to ambiguity. 
        - I might be wrong but I believe the implementation in the other PR is flawed. While the code in the other PR accepts tensors with more than 1 dimension, their `update()` method always treats the first dimension (dim 0) as the batches. This does not work in many different cases such as when the input tensors have shapes such as [H, W], [C, H, W], etc which are still valid shapes in their code. 
    - While the approach taken for computing MSE and also dealing with division by zero are different between the two PRs, they should not affect the actual functionality of the code. 