### PR TITLE
Fix typo in dataset.md in Burn Book

### DIFF
--- a/burn-book/src/building-blocks/dataset.md
+++ b/burn-book/src/building-blocks/dataset.md
@@ -280,7 +280,7 @@ storage. At this point, the dataset could be naively iterated over to provide th
 sample to process at a time, but this is not very efficient.
 
 Instead, we collect multiple samples that the model can process as a _batch_ to fully leverage
-modern hardware (e.g., GPUs - which have impressing parallel processing capabilities). Since each
+modern hardware (e.g., GPUs - which have impressive parallel processing capabilities). Since each
 data sample in the dataset can be collected independently, the data loading is typically done in
 parallel to further speed things up. In this case, we parallelize the data loading using a
 multi-threaded `BatchDataLoader` to obtain a sequence of items from the `Dataset` implementation.


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

[Minor Typo in Burn Book #4378](https://github.com/tracel-ai/burn/issues/4378)

### Changes

Fixed the typo in the `building-blocks/dataset.md` file of the Burn Book. 

### Testing

Not applicable
