### PR TITLE
chore: fix typos caught by xtask

### DIFF
--- a/burn-book/src/advanced/backend-extension/custom-cubecl-kernel.md
+++ b/burn-book/src/advanced/backend-extension/custom-cubecl-kernel.md
@@ -317,7 +317,7 @@ impl<B: Backend, C: CheckpointStrategy> Backend for Autodiff<B, C> {
                 // The state consists of what will be needed for this operation's backward pass.
                 // Since we need the parents' outputs, we must checkpoint their ids to retrieve
                 // their node output at the beginning of the backward pass. We can also save
-                // utilitary data such as the bias shape. If we also need this operation's output,
+                // utility data such as the bias shape. If we also need this operation's output,
                 // we can either save it in the state or recompute it.
                 // during the backward pass. Here we choose to save it in the state because it's a
                 // compute bound operation.

--- a/burn-book/src/advanced/backend-extension/custom-wgpu-kernel.md
+++ b/burn-book/src/advanced/backend-extension/custom-wgpu-kernel.md
@@ -394,7 +394,7 @@ impl<B: Backend, C: CheckpointStrategy> Backend for Autodiff<B, C> {
 
                 // The state consists of what will be needed for this operation's backward pass.
                 // Since we need the parents' outputs, we must checkpoint their ids to retrieve their node
-                // output at the beginning of the backward. We can also save utilitary data such as the bias shape
+                // output at the beginning of the backward. We can also save utility data such as the bias shape
                 // If we also need this operation's output, we can either save it in the state or recompute it
                 // during the backward pass. Here we choose to save it in the state because it's a compute bound operation.
                 let lhs_state = prep.checkpoint(&lhs);

--- a/crates/burn-autodiff/src/checkpoint/builder.rs
+++ b/crates/burn-autodiff/src/checkpoint/builder.rs
@@ -37,7 +37,7 @@ pub enum CheckpointingAction {
 unsafe impl Send for CheckpointingAction {}
 
 impl CheckpointingAction {
-    /// Utilitary function to access the id of the node of the checkpointing action
+    /// Utility function to access the id of the node of the checkpointing action
     pub fn id(&self) -> NodeId {
         match self {
             CheckpointingAction::Computed {

--- a/crates/burn-autodiff/src/runtime/memory_management.rs
+++ b/crates/burn-autodiff/src/runtime/memory_management.rs
@@ -154,7 +154,7 @@ impl GraphMemoryManagement {
         let mut to_tag_useful = PopNodeSet::default();
         let mut to_explore = PopNodeSet::new(leaves);
 
-        // Utilitary function to iterate over a node's parents
+        // Utility function to iterate over a node's parents
         let parents = |node_id| {
             self.nodes
                 .get(&node_id)

--- a/crates/burn-cubecl/src/kernel/matmul/mod.rs
+++ b/crates/burn-cubecl/src/kernel/matmul/mod.rs
@@ -1,7 +1,7 @@
 mod base;
 mod tune;
 
-/// Contains utilitary for matmul operation
+/// Contains utilities for matmul operation
 pub mod utils;
 
 pub use base::*;

--- a/crates/burn-remote/src/server/stream.rs
+++ b/crates/burn-remote/src/server/stream.rs
@@ -15,7 +15,7 @@ use burn_tensor::TensorData;
 use tokio::sync::mpsc::{Receiver, Sender};
 
 /// A stream makes sure all operations registered are executed in the order they were sent to the
-/// server, protentially waiting to reconstruct consistency.
+/// server, potentially waiting to reconstruct consistency.
 #[derive(Clone)]
 pub struct Stream<B, P>
 where

--- a/examples/custom-cubecl-kernel/src/backward.rs
+++ b/examples/custom-cubecl-kernel/src/backward.rs
@@ -108,7 +108,7 @@ impl<B: Backend, C: CheckpointStrategy> Backend for Autodiff<B, C> {
                 // The state consists of what will be needed for this operation's backward pass.
                 // Since we need the parents' outputs, we must checkpoint their ids to retrieve
                 // their node output at the beginning of the backward pass. We can also save
-                // utilitary data such as the bias shape. If we also need this operation's output,
+                // utility data such as the bias shape. If we also need this operation's output,
                 // we can either save it in the state or recompute it.
                 // during the backward pass. Here we choose to save it in the state because it's a
                 // compute bound operation.

--- a/examples/custom-wgpu-kernel/src/backward.rs
+++ b/examples/custom-wgpu-kernel/src/backward.rs
@@ -113,7 +113,7 @@ impl<B: Backend, C: CheckpointStrategy> Backend for Autodiff<B, C> {
 
                 // The state consists of what will be needed for this operation's backward pass.
                 // Since we need the parents' outputs, we must checkpoint their ids to retrieve their node
-                // output at the beginning of the backward. We can also save utilitary data such as the bias shape
+                // output at the beginning of the backward. We can also save utility data such as the bias shape
                 // If we also need this operation's output, we can either save it in the state or recompute it
                 // during the backward pass. Here we choose to save it in the state because it's a compute bound operation.
                 let lhs_state = prep.checkpoint(&lhs);


### PR DESCRIPTION
  ## Checklist
  - [x] Confirmed that `cargo run-checks` command has been executed.
  - [x] Made sure the book is up to date with changes in this PR.

  ## Related Issues/PRs
  - None.

  ## Changes
  - Fix spelling in docs/comments (and a couple of docstrings) that are flagged by `typos`.
  - No functional changes.

  ## Testing
  - `cargo run-checks`