### PR TITLE
feat(burn-store): add ModuleAdapter chaining

### DIFF
--- a/crates/burn-store/src/lib.rs
+++ b/crates/burn-store/src/lib.rs
@@ -85,7 +85,9 @@ mod filter;
 mod tensor_snapshot;
 mod traits;
 
-pub use adapter::{BurnToPyTorchAdapter, IdentityAdapter, ModuleAdapter, PyTorchToBurnAdapter};
+pub use adapter::{
+    BurnToPyTorchAdapter, ChainAdapter, IdentityAdapter, ModuleAdapter, PyTorchToBurnAdapter,
+};
 pub use applier::Applier;
 pub use apply_result::{ApplyError, ApplyResult};
 pub use collector::Collector;


### PR DESCRIPTION
  ## Checklist
  - [x] Confirmed that `cargo run-checks` command has been executed.
  - [x] Made sure the book is up to date with changes in this PR. (N/A)

  ## Related Issues/PRs
  - Resolves #4401
  - Note: this PR was rebased onto `main` after #4406 was merged (typos gate fix).

  ## Changes
  - Add `ModuleAdapter::chain(...)` as a default method.
  - Add `ChainAdapter` to compose two adapters:
    - `adapt`: `second.adapt(&first.adapt(snapshot))`
    - `get_alternative_param_name`: pipe `first` -> `second`, with fallback to the intermediate name when `second` returns `None`.
  - Re-export `ChainAdapter` from `burn-store`.
  - Add unit tests covering piping + fallback semantics.

  ## Testing
  - `cargo run-checks`
  - `cargo test -p burn-store`