### PR TITLE
Implement CandleElement and IntCandleElement for i32

### DIFF
--- a/crates/burn-candle/src/element.rs
+++ b/crates/burn-candle/src/element.rs
@@ -28,5 +28,11 @@ impl IntCandleElement for u8 {}
 impl CandleElement for u32 {}
 impl IntCandleElement for u32 {}
 
+impl CandleElement for i32 {}
+impl IntCandleElement for i32 {}
+
 impl CandleElement for i64 {}
 impl IntCandleElement for i64 {}
+
+impl CandleElement for u64 {}
+impl IntCandleElement for u64 {}


### PR DESCRIPTION
since wgpu default `I=i32`, it makes sense to support i32 in candle

## Pull Request Template

### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

#4398

### Changes

when switching from wgpu backend to candle backend, `Candle<F = f32, I = i32>` is not supported, 
```
the trait `burn::backend::burn_candle::IntCandleElement` is not implemented for `i32`
```

### Testing

it was not tested, since i made edits on webpage.
