### PR TITLE
chore: deprecate burn-candle backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,7 +708,6 @@ name = "burn-backend-tests"
 version = "0.21.0"
 dependencies = [
  "burn-autodiff",
- "burn-candle",
  "burn-cpu",
  "burn-cubecl",
  "burn-cuda",
@@ -1112,7 +1111,6 @@ dependencies = [
 name = "burn-store"
 version = "0.21.0"
 dependencies = [
- "burn-candle",
  "burn-core",
  "burn-cuda",
  "burn-ndarray",
@@ -1203,7 +1201,6 @@ version = "0.21.0"
 dependencies = [
  "aligned-vec",
  "bon",
- "burn-candle",
  "burn-cubecl",
  "burn-cuda",
  "burn-fusion",

--- a/README.md
+++ b/README.md
@@ -42,23 +42,23 @@ Most backends support all operating systems, so we don't mention them in the tab
 
 **GPU Backends:**
 
-|         | CUDA | ROCm | Metal | Vulkan | WebGPU | Candle | LibTorch |
-| ------- | ---- | ---- | ----- | ------ | ------ | ------ | -------- |
-| Nvidia  | ☑️   | -    | -     | ☑️     | ☑️     | ☑️     | ☑️       |
-| AMD     | -    | ☑️   | -     | ☑️     | ☑️     | -      | ☑️       |
-| Apple   | -    | -    | ☑️    | -      | ☑️     | -      | ☑️       |
-| Intel   | -    | -    | -     | ☑️     | ☑️     | -      | -        |
-| Qualcom | -    | -    | -     | ☑️     | ☑️     | -      | -        |
-| Wasm    | -    | -    | -     | -      | ☑️     | -      | -        |
+|         | CUDA | ROCm | Metal | Vulkan | WebGPU | LibTorch |
+| ------- | ---- | ---- | ----- | ------ | ------ | -------- |
+| Nvidia  | ☑️   | -    | -     | ☑️     | ☑️     | ☑️       |
+| AMD     | -    | ☑️   | -     | ☑️     | ☑️     | ☑️       |
+| Apple   | -    | -    | ☑️    | -      | ☑️     | ☑️       |
+| Intel   | -    | -    | -     | ☑️     | ☑️     | -        |
+| Qualcom | -    | -    | -     | ☑️     | ☑️     | -        |
+| Wasm    | -    | -    | -     | -      | ☑️     | -        |
 
 **CPU Backends:**
 
-|        | Cpu (CubeCL) | NdArray | Candle | LibTorch |
-| ------ | ------------ | ------- | ------ | -------- |
-| X86    | ☑️           | ☑️      | ☑️     | ☑️       |
-| Arm    | ☑️           | ☑️      | ☑️     | ☑️       |
-| Wasm   | -            | ☑️      | ☑️     | -        |
-| no-std | -            | ☑️      | -      | -        |
+|        | Cpu (CubeCL) | NdArray | LibTorch |
+| ------ | ------------ | ------- | -------- |
+| X86    | ☑️           | ☑️      | ☑️       |
+| Arm    | ☑️           | ☑️      | ☑️       |
+| Wasm   | -            | ☑️      | -        |
+| no-std | -            | ☑️      | -        |
 
 <br />
 
@@ -286,7 +286,7 @@ Inference in the Browser 🌐
 </summary>
 <br />
 
-Several of our backends can run in WebAssembly environments: Candle and NdArray for CPU execution,
+Several of our backends can run in WebAssembly environments: NdArray for CPU execution,
 and WGPU for GPU acceleration via WebGPU. This means that you can run inference directly within a
 browser. We provide several examples of this:
 

--- a/contributor-book/src/guides/adding-a-new-operation-to-burn.md
+++ b/contributor-book/src/guides/adding-a-new-operation-to-burn.md
@@ -153,7 +153,7 @@ For testing the `autodiff` operations, please refer to
 ## Adding the Op to other backends
 
 Most of these are fairly straightforward implementations. For reference here's pow's float
-implementation for torch, ndarray and candle backends:
+implementation for torch and ndarray backends:
 
 1. Torch implementation in
    [crates/burn-tch/src/ops/tensor.rs](https://github.com/tracel-ai/burn/blob/0ee2021567b3725907df5fd1a905ce60b1aca096/crates/burn-tch/src/ops/tensor.rs#L467)
@@ -161,8 +161,6 @@ implementation for torch, ndarray and candle backends:
    [crates/burn-tch/src/ops/base.rs](https://github.com/tracel-ai/burn/blob/0ee2021567b3725907df5fd1a905ce60b1aca096/crates/burn-tch/src/ops/base.rs#L481)
 2. NdArray in
    [crates/burn-ndarray/src/ops/tensor.rs](https://github.com/tracel-ai/burn/blob/0ee2021567b3725907df5fd1a905ce60b1aca096/crates/burn-ndarray/src/ops/tensor.rs#L472)
-3. Candle in
-   [crates/burn-candle/src/ops/tensor.rs](https://github.com/tracel-ai/burn/blob/0ee2021567b3725907df5fd1a905ce60b1aca096/crates/burn-candle/src/ops/tensor.rs#L504)
 
 This is where any calculation happens currently. Playing a guessing game with method names and
 seeing what completions are suggested will take you far. If you are having trouble figuring out how

--- a/crates/burn-backend-tests/.cargo/config.toml
+++ b/crates/burn-backend-tests/.cargo/config.toml
@@ -1,5 +1,4 @@
 [alias]
-test-candle = "test --release --no-default-features --features candle,std"
 test-cpu = "test --release --no-default-features --features cpu,std"
 test-cuda = "test --release --no-default-features --features cuda,std"
 test-ndarray = "test --release --no-default-features --features ndarray,std"

--- a/crates/burn-backend-tests/Cargo.toml
+++ b/crates/burn-backend-tests/Cargo.toml
@@ -19,7 +19,6 @@ default = [
     "burn-tensor/default",
     "burn-autodiff/default",
     # Backends (default not enabled for CubeCL backends as it activates fusion)
-    "burn-candle?/default",
     "burn-cpu?/default",
     "burn-ndarray?/default",
     "burn-tch?/default",
@@ -31,7 +30,6 @@ std = [
     "burn-tensor/std",
     "burn-autodiff/std",
     # Backends
-    "burn-candle?/std",
     "burn-cpu?/std",
     "burn-ndarray?/std",
     "burn-wgpu?/std",
@@ -45,7 +43,6 @@ tracing = [
     "burn-tensor/tracing",
     "burn-autodiff/tracing",
     # Backends
-    "burn-candle?/tracing",
     "burn-cpu?/tracing",
     "burn-ndarray?/tracing",
     "burn-wgpu?/tracing",
@@ -55,9 +52,6 @@ tracing = [
 ]
 
 # Backends
-candle = ["burn-candle"]
-candle-cuda = ["candle", "burn-candle/cuda"]
-candle-metal = ["burn-candle?/metal"]
 cuda = ["burn-cuda", "quantization", "cube"]
 rocm = ["burn-rocm", "quantization", "cube"]
 ndarray = ["burn-ndarray", "quantization"]
@@ -103,7 +97,6 @@ burn-tensor-testgen = { path = "../burn-tensor-testgen", version = "=0.21.0" }
 burn-autodiff = { path = "../burn-autodiff", version = "=0.21.0", default-features = false, features = [
     "export_tests",
 ] }
-burn-candle = { path = "../burn-candle", version = "=0.21.0", optional = true }
 burn-cuda = { path = "../burn-cuda", version = "=0.21.0", optional = true, default-features = false }
 burn-cpu = { path = "../burn-cpu", version = "=0.21.0", optional = true, default-features = false }
 burn-rocm = { path = "../burn-rocm", version = "=0.21.0", optional = true, default-features = false }

--- a/crates/burn-backend-tests/README.md
+++ b/crates/burn-backend-tests/README.md
@@ -27,8 +27,6 @@ cargo test-metal
 # Router
 cargo test-router
 
-# Candle
-cargo test-candle
 # NdArray
 cargo test-ndarray
 # LibTorch

--- a/crates/burn-backend-tests/tests/common/backend.rs
+++ b/crates/burn-backend-tests/tests/common/backend.rs
@@ -5,9 +5,6 @@ use super::FloatElemType;
 #[cfg(feature = "ndarray")]
 pub type TestBackend = burn_ndarray::NdArray<FloatElemType>;
 
-#[cfg(feature = "candle")]
-pub type TestBackend = burn_candle::Candle<FloatElemType>;
-
 #[cfg(feature = "tch")]
 pub type TestBackend = burn_tch::LibTorch<FloatElemType>;
 

--- a/crates/burn-candle/Cargo.toml
+++ b/crates/burn-candle/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["louisfd <louisfd94@gmail.com>"]
 categories = ["science"]
-description = "Candle backend for the Burn framework"
+description = "[Deprecated] Candle backend for the Burn framework - use burn-cubecl, burn-ndarray, or burn-tch instead"
 edition.workspace = true
 keywords = ["deep-learning", "machine-learning", "data"]
 license.workspace = true

--- a/crates/burn-candle/README.md
+++ b/crates/burn-candle/README.md
@@ -1,14 +1,14 @@
 # Burn Candle Backend
 
+> **Deprecated:** This crate is deprecated as of `0.21.0` and will be removed in a future release.
+> Please migrate to one of the actively maintained backends:
+> - **CubeCL backends** (CUDA, ROCm, Vulkan, Metal, WebGPU) for GPU acceleration
+> - **NdArray** for portable CPU execution
+> - **LibTorch** (`burn-tch`) for a mature CPU/GPU backend
+
 This crate provides a backend for [Burn](https://github.com/tracel-ai/burn) based on the [Candle](https://github.com/huggingface/candle) framework.
 
-It is still in alpha stage, not all operations are supported. It is usable for some use cases, like for inference.
-
-It can be used with CPU or CUDA. On macOS computations can be accelerated by using the Accelerate framework.
-
 ## Feature Flags
-
-The following features are supported:
 
 - `cuda` - Cuda GPU device (NVIDIA only)
 - `accelerate` - Accelerate framework (macOS only)

--- a/crates/burn-candle/src/lib.rs
+++ b/crates/burn-candle/src/lib.rs
@@ -1,8 +1,18 @@
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(unused)] // TODO remove when backend filled
+#![deprecated(
+    since = "0.21.0",
+    note = "burn-candle is deprecated and will be removed in a future release. Use burn-cubecl (CUDA/ROCm/Vulkan/Metal/WebGPU), burn-ndarray, or burn-tch instead."
+)]
 
 //! Burn Candle Backend
+//!
+//! **Deprecated:** This backend is deprecated and will be removed in a future release.
+//! Please migrate to one of the actively maintained backends:
+//! - CubeCL backends (CUDA, ROCm, Vulkan, Metal, WebGPU) for GPU acceleration
+//! - NdArray for portable CPU execution
+//! - LibTorch (`burn-tch`) for a mature CPU/GPU backend
 
 #[macro_use]
 extern crate derive_new;

--- a/crates/burn-store/Cargo.toml
+++ b/crates/burn-store/Cargo.toml
@@ -32,7 +32,6 @@ std = [
     "byteorder/std",
 ]
 tracing = [
-    "burn-candle?/tracing",
     "burn-core/tracing",
     "burn-cuda?/tracing",
     "burn-nn/tracing",
@@ -43,7 +42,6 @@ tracing = [
 
 
 burnpack = ["serde", "ciborium"]
-candle = ["burn-candle"]
 cuda = ["burn-cuda"]
 metal = ["wgpu", "burn-wgpu/metal"]
 tch = ["burn-tch"]
@@ -76,7 +74,6 @@ lzma-rust2 = { workspace = true, optional = true }
 safetensors = { workspace = true, optional = true }
 
 # Optional backend dependencies for benchmarks
-burn-candle = { path = "../burn-candle", version = "=0.21.0", optional = true }
 burn-cuda = { path = "../burn-cuda", version = "=0.21.0", optional = true }
 burn-tch = { path = "../burn-tch", version = "=0.21.0", optional = true }
 burn-wgpu = { path = "../burn-wgpu", version = "=0.21.0", optional = true }

--- a/crates/burn-store/benches/unified_loading.rs
+++ b/crates/burn-store/benches/unified_loading.rs
@@ -46,9 +46,6 @@ type WgpuBackend = burn_wgpu::Wgpu;
 #[cfg(feature = "cuda")]
 type CudaBackend = burn_cuda::Cuda<f32, i32>;
 
-#[cfg(feature = "candle")]
-type CandleBackend = burn_candle::Candle<f32, i64>;
-
 #[cfg(feature = "tch")]
 type TchBackend = burn_tch::LibTorch<f32>;
 
@@ -192,8 +189,6 @@ fn main() {
             println!("  - WGPU (GPU)");
             #[cfg(feature = "cuda")]
             println!("  - CUDA (NVIDIA GPU)");
-            #[cfg(feature = "candle")]
-            println!("  - Candle");
             #[cfg(feature = "tch")]
             println!("  - LibTorch");
             #[cfg(feature = "metal")]
@@ -329,9 +324,6 @@ bench_backend!(WgpuBackend, wgpu_backend, "WGPU Backend (GPU)");
 
 #[cfg(feature = "cuda")]
 bench_backend!(CudaBackend, cuda_backend, "CUDA Backend (NVIDIA GPU)");
-
-#[cfg(feature = "candle")]
-bench_backend!(CandleBackend, candle_backend, "Candle Backend");
 
 #[cfg(feature = "tch")]
 bench_backend!(TchBackend, tch_backend, "LibTorch Backend");

--- a/crates/burn-store/benches/unified_saving.rs
+++ b/crates/burn-store/benches/unified_saving.rs
@@ -37,9 +37,6 @@ type WgpuBackend = burn_wgpu::Wgpu;
 #[cfg(feature = "cuda")]
 type CudaBackend = burn_cuda::Cuda<f32, i32>;
 
-#[cfg(feature = "candle")]
-type CandleBackend = burn_candle::Candle<f32, i64>;
-
 #[cfg(feature = "tch")]
 type TchBackend = burn_tch::LibTorch<f32>;
 
@@ -97,8 +94,6 @@ fn main() {
             println!("  - WGPU (GPU)");
             #[cfg(feature = "cuda")]
             println!("  - CUDA (NVIDIA GPU)");
-            #[cfg(feature = "candle")]
-            println!("  - Candle");
             #[cfg(feature = "tch")]
             println!("  - LibTorch");
             #[cfg(feature = "metal")]
@@ -180,9 +175,6 @@ bench_backend!(WgpuBackend, wgpu_backend, "WGPU Backend (GPU)");
 
 #[cfg(feature = "cuda")]
 bench_backend!(CudaBackend, cuda_backend, "CUDA Backend (NVIDIA GPU)");
-
-#[cfg(feature = "candle")]
-bench_backend!(CandleBackend, candle_backend, "Candle Backend");
 
 #[cfg(feature = "tch")]
 bench_backend!(TchBackend, tch_backend, "LibTorch Backend");

--- a/crates/burn-store/benches/zero_copy_loading.rs
+++ b/crates/burn-store/benches/zero_copy_loading.rs
@@ -63,9 +63,6 @@ type WgpuBackend = burn_wgpu::Wgpu;
 #[cfg(feature = "cuda")]
 type CudaBackend = burn_cuda::Cuda<f32, i32>;
 
-#[cfg(feature = "candle")]
-type CandleBackend = burn_candle::Candle<f32, i64>;
-
 #[cfg(feature = "tch")]
 type TchBackend = burn_tch::LibTorch<f32>;
 
@@ -179,8 +176,6 @@ fn main() {
     println!("  - WGPU (GPU)");
     #[cfg(feature = "cuda")]
     println!("  - CUDA (NVIDIA GPU)");
-    #[cfg(feature = "candle")]
-    println!("  - Candle");
     #[cfg(feature = "tch")]
     println!("  - LibTorch");
     #[cfg(feature = "metal")]
@@ -593,9 +588,6 @@ bench_backend!(WgpuBackend, wgpu_backend, "WGPU Backend (GPU)");
 
 #[cfg(feature = "cuda")]
 bench_backend!(CudaBackend, cuda_backend, "CUDA Backend (NVIDIA GPU)");
-
-#[cfg(feature = "candle")]
-bench_backend!(CandleBackend, candle_backend, "Candle Backend");
 
 #[cfg(feature = "tch")]
 bench_backend!(TchBackend, tch_backend, "LibTorch Backend");

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -2687,7 +2687,7 @@ where
     ///
     /// # Warning
     ///
-    /// For the `ndarray` and `candle` backends; this is not a view but a copy
+    /// For the `ndarray` backend; this is not a view but a copy
     /// with duplicated data.
     ///
     /// # Arguments

--- a/crates/burn-vision/Cargo.toml
+++ b/crates/burn-vision/Cargo.toml
@@ -22,7 +22,6 @@ workspace = true
 default = ["ndarray", "cubecl-backend", "fusion", "std"]
 std = ["aligned-vec/std"]
 tracing = [
-    "burn-candle?/tracing",
     "burn-cubecl?/tracing",
     "burn-fusion?/tracing",
     "burn-ir/tracing",
@@ -32,7 +31,6 @@ tracing = [
     "cubecl/tracing",
 ]
 
-candle = ["burn-candle"]
 cubecl-backend = ["cubecl", "burn-cubecl"]
 fusion = ["burn-fusion", "burn-cuda/fusion", "burn-wgpu/fusion"]
 ndarray = ["burn-ndarray"]
@@ -48,7 +46,6 @@ test-metal = ["burn-wgpu/metal", "test-wgpu"]
 [dependencies]
 aligned-vec = { version = "0.6", default-features = false }
 bon = { workspace = true }
-burn-candle = { path = "../burn-candle", version = "=0.21.0", optional = true }
 burn-cubecl = { path = "../burn-cubecl", version = "=0.21.0", optional = true }
 burn-fusion = { path = "../burn-fusion", version = "=0.21.0", optional = true }
 burn-ir = { path = "../burn-ir", version = "=0.21.0" }

--- a/crates/burn-vision/src/backends/cpu/ops.rs
+++ b/crates/burn-vision/src/backends/cpu/ops.rs
@@ -41,18 +41,6 @@ mod ndarray {
     }
 }
 
-#[cfg(feature = "candle")]
-mod candle {
-    use crate::{BoolVisionOps, FloatVisionOps, IntVisionOps, QVisionOps, VisionBackend};
-    use burn_candle::{Candle, FloatCandleElement, IntCandleElement};
-
-    impl<F: FloatCandleElement, I: IntCandleElement> BoolVisionOps for Candle<F, I> {}
-    impl<F: FloatCandleElement, I: IntCandleElement> IntVisionOps for Candle<F, I> {}
-    impl<F: FloatCandleElement, I: IntCandleElement> FloatVisionOps for Candle<F, I> {}
-    impl<F: FloatCandleElement, I: IntCandleElement> QVisionOps for Candle<F, I> {}
-    impl<F: FloatCandleElement, I: IntCandleElement> VisionBackend for Candle<F, I> {}
-}
-
 #[cfg(feature = "tch")]
 mod tch {
     use crate::{BoolVisionOps, FloatVisionOps, IntVisionOps, QVisionOps, VisionBackend};

--- a/xtask/src/commands/test.rs
+++ b/xtask/src/commands/test.rs
@@ -226,14 +226,6 @@ pub(crate) fn handle_command(
                 CiTestType::GcpCudaRunner => (),
                 CiTestType::GcpVulkanRunner | CiTestType::GcpWgpuRunner => (), // handled in tests above
                 CiTestType::GithubMacRunner => {
-                    // burn-candle
-                    helpers::custom_crates_tests(
-                        vec!["burn-candle"],
-                        handle_test_args(&["--features", "accelerate"], args.release),
-                        None,
-                        None,
-                        "std accelerate",
-                    )?;
                     // burn-ndarray
                     helpers::custom_crates_tests(
                         vec!["burn-ndarray"],


### PR DESCRIPTION
## Summary

- Add deprecation notices to `burn-candle` crate (`#![deprecated]`, updated Cargo.toml description, README)
- Remove all internal usages of `burn-candle` from `burn`, `burn-backend-tests`, `burn-vision`, `burn-store`, `xtask`, and CI
- Remove Candle from README backend tables and docs
- Keep `burn-candle` in the publish workflow so existing users see deprecation warnings on upgrade; full removal planned for a future release

Users should migrate to `burn-cubecl` (CUDA/ROCm/Vulkan/Metal/WebGPU), `burn-ndarray`, or `burn-tch`.

## Test plan

- [ ] `cargo check` passes on workspace
- [ ] `cargo check -p burn-candle` shows deprecation warning
- [ ] Verify no remaining internal feature flag references to candle (outside `burn-candle` crate itself)