### PR TITLE
Add Elu activation function

### DIFF
--- a/burn-book/src/building-blocks/module.md
+++ b/burn-book/src/building-blocks/module.md
@@ -231,6 +231,7 @@ Burn comes with built-in modules that you can use to build your own modules.
 | --------------- | --------------------------------------------- |
 | `BatchNorm`     | `nn.BatchNorm1d`, `nn.BatchNorm2d` etc.       |
 | `Dropout`       | `nn.Dropout`                                  |
+| `Elu`           | `nn.ELU`                                      |
 | `Embedding`     | `nn.Embedding`                                |
 | `Gelu`          | `nn.Gelu`                                     |
 | `GroupNorm`     | `nn.GroupNorm`                                |

--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -380,6 +380,7 @@ strategies.
 
 | Burn API                                         | PyTorch Equivalent                                 |
 | ------------------------------------------------ | -------------------------------------------------- |
+| `activation::elu(tensor, alpha)`                 | `nn.functional.elu(tensor, alpha)`                 |
 | `activation::gelu(tensor)`                       | `nn.functional.gelu(tensor)`                       |
 | `activation::hard_sigmoid(tensor, alpha, beta)`  | `nn.functional.hardsigmoid(tensor)`                |
 | `activation::hard_swish(tensor)`                 | `nn.functional.hardswish(tensor)`                  |

--- a/crates/burn-backend-tests/tests/tensor/float/activation/elu.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/activation/elu.rs
@@ -1,0 +1,32 @@
+use super::*;
+use burn_tensor::Tolerance;
+use burn_tensor::{TensorData, activation};
+
+#[test]
+fn test_elu() {
+    let tensor = TestTensor::<2>::from([[1.0, 7.0], [13.0, -3.0]]);
+
+    let output = activation::elu(tensor, 1.0);
+    // elu(1, 1) = 1, elu(7, 1) = 7, elu(13, 1) = 13
+    // elu(-3, 1) = 1 * (exp(-3) - 1) = -0.950213
+    let expected = TensorData::from([[1.0, 7.0], [13.0, -0.950213]]);
+
+    output
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
+}
+
+#[test]
+fn test_elu_alpha() {
+    let tensor = TestTensor::<1>::from([0.0, -1.0, -2.0]);
+
+    let output = activation::elu(tensor, 2.0);
+    // elu(0, 2) = 2*(exp(0)-1) = 0
+    // elu(-1, 2) = 2*(exp(-1)-1) = 2*(-0.632121) = -1.264241
+    // elu(-2, 2) = 2*(exp(-2)-1) = 2*(-0.864665) = -1.729329
+    let expected = TensorData::from([0.0, -1.264241, -1.729329]);
+
+    output
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
+}

--- a/crates/burn-backend-tests/tests/tensor/float/activation/mod.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/activation/mod.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+mod elu;
 mod gelu;
 mod glu;
 mod hard_sigmoid;

--- a/crates/burn-nn/src/activation/elu.rs
+++ b/crates/burn-nn/src/activation/elu.rs
@@ -1,0 +1,85 @@
+use burn::config::Config;
+use burn::module::Module;
+use burn::module::{Content, DisplaySettings, ModuleDisplay};
+use burn::tensor::Tensor;
+use burn::tensor::backend::Backend;
+use burn_core as burn;
+
+use burn::tensor::activation::elu;
+
+/// ELU (Exponential Linear Unit) layer.
+///
+/// Should be created with [EluConfig](EluConfig).
+#[derive(Module, Clone, Debug)]
+#[module(custom_display)]
+pub struct Elu {
+    /// The alpha value.
+    pub alpha: f64,
+}
+/// Configuration to create an [Elu](Elu) layer using the [init function](EluConfig::init).
+#[derive(Config, Debug)]
+pub struct EluConfig {
+    /// The alpha value. Default is 1.0
+    #[config(default = "1.0")]
+    pub alpha: f64,
+}
+impl EluConfig {
+    /// Initialize a new [Elu](Elu) Layer
+    pub fn init(&self) -> Elu {
+        Elu { alpha: self.alpha }
+    }
+}
+
+impl ModuleDisplay for Elu {
+    fn custom_settings(&self) -> Option<DisplaySettings> {
+        DisplaySettings::new()
+            .with_new_line_after_attribute(false)
+            .optional()
+    }
+
+    fn custom_content(&self, content: Content) -> Option<Content> {
+        content.add("alpha", &self.alpha).optional()
+    }
+}
+
+impl Elu {
+    /// Forward pass for the ELU layer.
+    ///
+    /// See [elu](burn::tensor::activation::elu) for more information.
+    ///
+    /// # Shapes
+    /// - input: `[..., any]`
+    /// - output: `[..., any]`
+    pub fn forward<B: Backend, const D: usize>(&self, input: Tensor<B, D>) -> Tensor<B, D> {
+        elu(input, self.alpha)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::TestBackend;
+    use burn::tensor::TensorData;
+    use burn::tensor::{Tolerance, ops::FloatElem};
+    type FT = FloatElem<TestBackend>;
+
+    #[test]
+    fn test_elu_forward() {
+        let device = <TestBackend as Backend>::Device::default();
+        let model: Elu = EluConfig::new().init();
+        let input =
+            Tensor::<TestBackend, 2>::from_data(TensorData::from([[0.4410, -0.2507]]), &device);
+        let out = model.forward(input);
+        // elu(0.4410, 1.0) = 0.4410
+        // elu(-0.2507, 1.0) = 1.0 * (exp(-0.2507) - 1) = -0.22186
+        let expected = TensorData::from([[0.4410, -0.22186]]);
+        out.to_data()
+            .assert_approx_eq::<FT>(&expected, Tolerance::default());
+    }
+
+    #[test]
+    fn display() {
+        let config = EluConfig::new().init();
+        assert_eq!(alloc::format!("{config}"), "Elu {alpha: 1}");
+    }
+}

--- a/crates/burn-nn/src/activation/mod.rs
+++ b/crates/burn-nn/src/activation/mod.rs
@@ -13,6 +13,7 @@
 //! * [`Softplus`]
 //! * [`Softsign`]
 //! * [`Tanh`]
+//! * [`Elu`]
 //! * [`ThresholdedRelu`]
 //!
 //! The activation layer [`GLU`] has shape-changing behaviors
@@ -23,6 +24,7 @@ mod activation_wrapper;
 
 // These are pub(crate) for dual-export in `nn` without re-exporting
 // all of `nn.activation`, or manually listing each symbol.
+pub(crate) mod elu;
 pub(crate) mod gelu;
 pub(crate) mod glu;
 pub(crate) mod hard_sigmoid;
@@ -38,6 +40,7 @@ pub(crate) mod tanh;
 pub(crate) mod thresholded_relu;
 
 pub use activation_wrapper::*;
+pub use elu::*;
 pub use gelu::*;
 pub use glu::*;
 pub use hard_sigmoid::*;

--- a/crates/burn-nn/src/lib.rs
+++ b/crates/burn-nn/src/lib.rs
@@ -14,8 +14,8 @@ pub use modules::*;
 
 pub mod activation;
 pub use activation::{
-    gelu::*, glu::*, hard_sigmoid::*, leaky_relu::*, prelu::*, relu::*, sigmoid::*, softplus::*,
-    softsign::*, swiglu::*, tanh::*, thresholded_relu::*,
+    elu::*, gelu::*, glu::*, hard_sigmoid::*, leaky_relu::*, prelu::*, relu::*, sigmoid::*,
+    softplus::*, softsign::*, swiglu::*, tanh::*, thresholded_relu::*,
 };
 
 mod padding;

--- a/crates/burn-tensor/src/tensor/activation/base.rs
+++ b/crates/burn-tensor/src/tensor/activation/base.rs
@@ -402,6 +402,30 @@ pub fn tanh<const D: usize, B: Backend>(tensor: Tensor<B, D>) -> Tensor<B, D> {
     tensor.tanh()
 }
 
+/// Applies the Exponential Linear Unit function element-wise.
+///
+#[cfg_attr(
+    doc,
+    doc = r#"
+$$
+\text{ELU}\(x\) =
+ \begin{cases}
+     x & \text{if } x > 0 \newline
+     \alpha \cdot (\exp(x) - 1) & \text{if } x \leq 0
+ \end{cases}
+$$
+"#
+)]
+#[cfg_attr(
+    not(doc),
+    doc = "`f(x) =`\n- `x for x > 0`\n- `alpha * (exp(x) - 1) for x <= 0`"
+)]
+pub fn elu<const D: usize, B: Backend>(tensor: Tensor<B, D>, alpha: f64) -> Tensor<B, D> {
+    let mask = tensor.clone().lower_equal_elem(0);
+    let scaled = tensor.clone().exp().sub_scalar(1).mul_scalar(alpha);
+    tensor.mask_where(mask, scaled)
+}
+
 /// Applies the thresholded rectified linear unit function element-wise.
 ///
 #[cfg_attr(


### PR DESCRIPTION
## Summary

- Adds the ELU (Exponential Linear Unit) activation function to enable ONNX Elu operator import
- Formula: `elu(x, alpha) = x if x > 0, alpha * (exp(x) - 1) if x <= 0`
- Configurable `alpha` parameter (default 1.0)

Closes #4428

## Changes

- **Tensor activation** (`burn-tensor`): `activation::elu(tensor, alpha)`
- **Backend tests** (`burn-backend-tests`): 2 tests covering default and custom alpha
- **NN module** (`burn-nn`): `Elu` struct with `EluConfig`
- **Activation wrapper**: `ActivationConfig::Elu` variant with `From<EluConfig>` impl
- **Documentation**: burn-book tensor and module tables updated

## Test plan

- [x] `cargo check -p burn-tensor` passes
- [x] `cargo check -p burn-nn` passes
- [x] `cargo test -p burn-backend-tests elu` passes (2 tests)
- [x] `cargo test -p burn-nn elu` passes (3 tests)