### PR TITLE
Add Selu activation function

### DIFF
--- a/burn-book/src/building-blocks/module.md
+++ b/burn-book/src/building-blocks/module.md
@@ -243,6 +243,7 @@ Burn comes with built-in modules that you can use to build your own modules.
 | `Linear`        | `nn.Linear`                                   |
 | `Prelu`         | `nn.PReLu`                                    |
 | `Relu`          | `nn.ReLU`                                     |
+| `Selu`          | `nn.SELU`                                     |
 | `Softsign`      | `nn.Softsign`                                 |
 | `RmsNorm`       | _No direct equivalent_                        |
 | `SwiGlu`        | _No direct equivalent_                        |

--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -393,6 +393,7 @@ strategies.
 | `activation::quiet_softmax(tensor, dim)`         | `nn.functional.quiet_softmax(tensor, dim)`         |
 | `activation::relu(tensor)`                       | `nn.functional.relu(tensor)`                       |
 | `activation::sigmoid(tensor)`                    | `nn.functional.sigmoid(tensor)`                    |
+| `activation::selu(tensor)`                       | `nn.functional.selu(tensor)`                       |
 | `activation::silu(tensor)`                       | `nn.functional.silu(tensor)`                       |
 | `activation::softmax(tensor, dim)`               | `nn.functional.softmax(tensor, dim)`               |
 | `activation::softmin(tensor, dim)`               | `nn.functional.softmin(tensor, dim)`               |

--- a/crates/burn-backend-tests/tests/tensor/float/activation/mod.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/activation/mod.rs
@@ -11,6 +11,7 @@ mod mish;
 mod prelu;
 mod quiet_softmax;
 mod relu;
+mod selu;
 mod sigmoid;
 mod silu;
 mod softmax;

--- a/crates/burn-backend-tests/tests/tensor/float/activation/selu.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/activation/selu.rs
@@ -1,0 +1,37 @@
+use super::*;
+use burn_tensor::Tolerance;
+use burn_tensor::{TensorData, activation};
+
+#[test]
+fn test_selu() {
+    // selu(x) = gamma * x if x > 0, gamma * alpha * (exp(x) - 1) if x <= 0
+    // alpha = 1.6733, gamma = 1.0507
+    let tensor = TestTensor::<2>::from([[0.0, 1.0, -1.0], [2.0, -2.0, 0.5]]);
+
+    let output = activation::selu(tensor);
+
+    // Expected values computed from the formula:
+    // selu(0.0)  = 1.0507 * 1.6733 * (exp(0) - 1) = 0.0
+    // selu(1.0)  = 1.0507 * 1.0 = 1.0507
+    // selu(-1.0) = 1.0507 * 1.6733 * (exp(-1) - 1) = 1.7581 * (0.3679 - 1) = -1.1113
+    // selu(2.0)  = 1.0507 * 2.0 = 2.1014
+    // selu(-2.0) = 1.0507 * 1.6733 * (exp(-2) - 1) = 1.7581 * (0.1353 - 1) = -1.5202
+    // selu(0.5)  = 1.0507 * 0.5 = 0.5254
+    let expected = TensorData::from([[0.0, 1.0507, -1.1113], [2.1014, -1.5202, 0.5254]]);
+
+    output
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
+}
+
+#[test]
+fn test_selu_zero() {
+    let tensor = TestTensor::<1>::from([0.0]);
+
+    let output = activation::selu(tensor);
+    let expected = TensorData::from([0.0]);
+
+    output
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
+}

--- a/crates/burn-nn/src/activation/mod.rs
+++ b/crates/burn-nn/src/activation/mod.rs
@@ -7,6 +7,7 @@
 //! * [`Gelu`]
 //! * [`LeakyRelu`]
 //! * [`SwiGlu`]
+//! * [`Selu`]
 //! * [`Sigmoid`]
 //! * [`HardSigmoid`]
 //! * [`HardSwish`]
@@ -34,6 +35,7 @@ pub(crate) mod hard_swish;
 pub(crate) mod leaky_relu;
 pub(crate) mod prelu;
 pub(crate) mod relu;
+pub(crate) mod selu;
 pub(crate) mod sigmoid;
 pub(crate) mod softplus;
 pub(crate) mod softsign;
@@ -51,6 +53,7 @@ pub use hard_swish::*;
 pub use leaky_relu::*;
 pub use prelu::*;
 pub use relu::*;
+pub use selu::*;
 pub use sigmoid::*;
 pub use softplus::*;
 pub use softsign::*;

--- a/crates/burn-nn/src/activation/selu.rs
+++ b/crates/burn-nn/src/activation/selu.rs
@@ -1,0 +1,38 @@
+use burn_core as burn;
+
+use burn::module::Module;
+use burn::tensor::Tensor;
+use burn::tensor::backend::Backend;
+
+/// Applies the Scaled Exponential Linear Unit function element-wise.
+/// See also [selu](burn::tensor::activation::selu)
+#[derive(Module, Clone, Debug, Default)]
+pub struct Selu;
+
+impl Selu {
+    /// Create the module.
+    pub fn new() -> Self {
+        Self {}
+    }
+    /// Applies the forward pass on the input tensor.
+    ///
+    /// # Shapes
+    ///
+    /// - input: `[..., any]`
+    /// - output: `[..., any]`
+    pub fn forward<B: Backend, const D: usize>(&self, input: Tensor<B, D>) -> Tensor<B, D> {
+        burn::tensor::activation::selu(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display() {
+        let layer = Selu::new();
+
+        assert_eq!(alloc::format!("{layer}"), "Selu");
+    }
+}

--- a/crates/burn-nn/src/lib.rs
+++ b/crates/burn-nn/src/lib.rs
@@ -14,7 +14,7 @@ pub use modules::*;
 
 pub mod activation;
 pub use activation::{
-    celu::*, elu::*, gelu::*, glu::*, hard_sigmoid::*, leaky_relu::*, prelu::*, relu::*,
+    celu::*, elu::*, gelu::*, glu::*, hard_sigmoid::*, leaky_relu::*, prelu::*, relu::*, selu::*,
     sigmoid::*, softplus::*, softsign::*, swiglu::*, tanh::*, thresholded_relu::*,
 };
 


### PR DESCRIPTION
## Summary

- Adds the SELU (Scaled Exponential Linear Unit) activation function (`selu(x) = gamma * alpha * (exp(x) - 1)` for `x <= 0`, `gamma * x` for `x > 0`) to enable ONNX Selu operator import
- Implements tensor-level function, NN module, activation wrapper variant, backend tests, and burn-book documentation

Closes #4429

## Test plan

- [x] `cargo check -p burn-tensor` passes
- [x] `cargo check -p burn-nn` passes
- [x] `cargo test -p burn-backend-tests selu` passes (2 tests)
- [x] `cargo test -p burn-nn selu` passes (2 tests)