### PR TITLE
Fix: `SupervisedTraining` should use the model device by default

### DIFF
--- a/crates/burn-train/src/learner/base.rs
+++ b/crates/burn-train/src/learner/base.rs
@@ -31,7 +31,7 @@ pub type LearnerSchedulerRecord<LC> =
 
 /// Learner struct encapsulating all components necessary to train a Neural Network model.
 pub struct Learner<LC: LearningComponentsTypes> {
-    model: LC::TrainingModel,
+    pub(crate) model: LC::TrainingModel,
     optim: LC::Optimizer,
     lr_scheduler: LC::LrScheduler,
     lr: f64,


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Reported [on discord](https://discord.com/channels/1038839012602941528/1059209073784008835/1468378738096865473)

The learner currently defaulted to a single device strategy that ignored the model device.

For backend with multiple devices like tch, this meant the training was actually happening on the CPU (default) instead of the specified GPU.

### Changes

Changed the `SupervisedTraining` to default to the model device when no strategy is explicitly set.


### Testing

Tested mnist example with `--features tch-gpu`
