### PR TITLE
fix: default to single device strat when only 1 device

### DIFF
--- a/crates/burn-train/src/learner/supervised/strategies/single/strategy.rs
+++ b/crates/burn-train/src/learner/supervised/strategies/single/strategy.rs
@@ -7,10 +7,10 @@ use burn_core::{data::dataloader::Progress, tensor::Device};
 
 /// Simplest learning strategy possible, with only a single devices doing both the training and
 /// validation.
-pub struct SingleDevicetrainingStrategy<LC: LearningComponentsTypes> {
+pub struct SingleDeviceTrainingStrategy<LC: LearningComponentsTypes> {
     device: Device<TrainingBackend<LC>>,
 }
-impl<LC: LearningComponentsTypes> SingleDevicetrainingStrategy<LC> {
+impl<LC: LearningComponentsTypes> SingleDeviceTrainingStrategy<LC> {
     pub fn new(device: Device<TrainingBackend<LC>>) -> Self {
         Self { device }
     }
@@ -42,7 +42,7 @@ impl Iterator for TrainingLoop {
 }
 
 impl<LC: LearningComponentsTypes> SupervisedLearningStrategy<LC>
-    for SingleDevicetrainingStrategy<LC>
+    for SingleDeviceTrainingStrategy<LC>
 {
     fn fit(
         &self,


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs



### Changes

Training strategy should default to single device when only one device is provided.

### Testing

mnist example.
