### PR TITLE
fix: use all dilation entries in `max_pool2d_with_indices_backward`

### DIFF
--- a/crates/burn-cubecl/src/kernel/pool/max_pool2d_backward.rs
+++ b/crates/burn-cubecl/src/kernel/pool/max_pool2d_backward.rs
@@ -140,7 +140,7 @@ pub(crate) fn max_pool2d_with_indices_backward<R: CubeRuntime>(
                 ScalarArg::new(stride[0] as i32),
                 ScalarArg::new(stride[1] as i32),
                 ScalarArg::new(dilation[0] as i32),
-                ScalarArg::new(dilation[0] as i32),
+                ScalarArg::new(dilation[1] as i32),
                 ScalarArg::new(padding[0] as i32),
                 ScalarArg::new(padding[1] as i32),
             ),


### PR DESCRIPTION

### Changes

This PR fixes a likely typo in the crates/burn-cubecl/src/kernel/pool/max_pool2d_backward.rs file to use all dilation entries to build `PoolBackwardArgsLaunch` instead of using `dilation[0]` twice. I don't know anything about this code but the current version seems wrong. I noticed all tests use the same value for both dilation[0] and dilation[1], which is why this was probably never found


