### PR TITLE
fix: explicitly enable rand/std_rng feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,8 +708,8 @@ dependencies = [
  "hashbrown 0.16.1",
  "num-traits",
  "paste",
- "rand 0.9.2",
- "rand_distr",
+ "rand 0.10.0",
+ "rand_distr 0.6.0",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -838,7 +838,7 @@ dependencies = [
  "num-traits",
  "portable-atomic",
  "portable-atomic-util",
- "rand 0.9.2",
+ "rand 0.10.0",
  "regex",
  "rmp-serde",
  "rstest",
@@ -922,7 +922,7 @@ dependencies = [
  "polars",
  "r2d2",
  "r2d2_sqlite",
- "rand 0.9.2",
+ "rand 0.10.0",
  "rayon",
  "rmp-serde",
  "rstest",
@@ -994,7 +994,7 @@ dependencies = [
  "paste",
  "portable-atomic",
  "portable-atomic-util",
- "rand 0.9.2",
+ "rand 0.10.0",
  "rayon",
  "seq-macro",
 ]
@@ -1086,7 +1086,7 @@ dependencies = [
  "burn-optim",
  "derive-new",
  "log",
- "rand 0.9.2",
+ "rand 0.10.0",
 ]
 
 [[package]]
@@ -1210,7 +1210,7 @@ dependencies = [
  "derive-new",
  "log",
  "nvml-wrapper",
- "rand 0.9.2",
+ "rand 0.10.0",
  "ratatui",
  "rstest",
  "serde",
@@ -1385,7 +1385,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-metal",
  "rand 0.9.2",
- "rand_distr",
+ "rand_distr 0.5.1",
  "rayon",
  "safetensors 0.7.0",
  "thiserror 2.0.18",
@@ -2959,7 +2959,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry-stdout",
  "opentelemetry_sdk",
- "rand 0.9.2",
+ "rand 0.10.0",
  "tokio",
  "tracing",
  "tracing-opentelemetry",
@@ -2979,7 +2979,7 @@ dependencies = [
  "burn",
  "derive-new",
  "gym-rs",
- "rand 0.9.2",
+ "rand 0.10.0",
 ]
 
 [[package]]
@@ -3441,7 +3441,7 @@ dependencies = [
  "half",
  "num-traits",
  "rand 0.9.2",
- "rand_distr",
+ "rand_distr 0.5.1",
 ]
 
 [[package]]
@@ -4185,7 +4185,7 @@ dependencies = [
  "crunchy",
  "num-traits",
  "rand 0.9.2",
- "rand_distr",
+ "rand_distr 0.5.1",
  "serde",
  "zerocopy",
 ]
@@ -5296,7 +5296,7 @@ version = "0.21.0-pre.1"
 dependencies = [
  "burn",
  "log",
- "rand 0.9.2",
+ "rand 0.10.0",
  "serde",
 ]
 
@@ -5326,8 +5326,8 @@ dependencies = [
  "burn",
  "planus",
  "polars",
- "rand 0.9.2",
- "rand_distr",
+ "rand 0.10.0",
+ "rand_distr 0.6.0",
  "serde",
 ]
 
@@ -6487,7 +6487,7 @@ dependencies = [
  "polars-schema",
  "polars-utils",
  "rand 0.9.2",
- "rand_distr",
+ "rand_distr 0.5.1",
  "rayon",
  "regex",
  "serde",
@@ -7273,6 +7273,16 @@ checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
  "rand 0.9.2",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
+dependencies = [
+ "num-traits",
+ "rand 0.10.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
     "xtask",
 ]
 
-exclude = ["examples/notebook", "examples/raspberry-pi-pico"]
+exclude = ["examples/notebook", "examples/raspberry-pi-pico", "crates/burn-import", "crates/burn-onnx", "crates/onnx-ir", "crates/onnx-ir-derive"]
 
 [workspace.package]
 edition = "2024"
@@ -152,8 +152,8 @@ num-traits = { version = "0.2.19", default-features = false, features = [
     "libm",
 ] } # libm is for no_std
 openblas-src = "0.10.14"
-rand = { version = "0.9.2", default-features = false, features = ["std_rng"] }
-rand_distr = { version = "0.5.1", default-features = false }
+rand = { version = "0.10.0", default-features = false, features = ["std_rng"] }
+rand_distr = { version = "0.6.0", default-features = false }
 serde = { version = "1.0.228", default-features = false, features = [
     "derive",
     "alloc",

--- a/crates/burn-backend/src/data/tensor.rs
+++ b/crates/burn-backend/src/data/tensor.rs
@@ -5,7 +5,7 @@ use alloc::format;
 use alloc::string::String;
 use alloc::vec::Vec;
 use bytemuck::{AnyBitPattern, CheckedBitPattern, Zeroable, cast_mut, checked::CheckedCastError};
-use rand::RngCore;
+use rand::Rng;
 use thiserror::Error;
 
 use crate::Scalar;
@@ -307,7 +307,7 @@ impl TensorData {
     }
 
     /// Populates the data with random values.
-    pub fn random<E: Element, R: RngCore, S: Into<Vec<usize>>>(
+    pub fn random<E: Element, R: Rng, S: Into<Vec<usize>>>(
         shape: S,
         distribution: Distribution,
         rng: &mut R,
@@ -685,7 +685,7 @@ mod tests {
         let data = TensorData::random::<f32, _, _>(
             shape,
             Distribution::Default,
-            &mut StdRng::from_os_rng(),
+            &mut rand::make_rng::<StdRng>(),
         );
 
         assert_eq!(data.rank(), 3);
@@ -697,7 +697,7 @@ mod tests {
         let data = TensorData::random::<f32, _, _>(
             shape,
             Distribution::Default,
-            &mut StdRng::from_os_rng(),
+            &mut rand::make_rng::<StdRng>(),
         );
 
         let expected = data.iter::<f32>().collect::<Vec<f32>>();
@@ -713,7 +713,7 @@ mod tests {
         let data = TensorData::random::<f32, _, _>(
             shape,
             Distribution::Default,
-            &mut StdRng::from_os_rng(),
+            &mut rand::make_rng::<StdRng>(),
         );
 
         data.into_vec::<i32>().unwrap();
@@ -726,7 +726,7 @@ mod tests {
         let data = TensorData::random::<f32, _, _>(
             shape,
             Distribution::Default,
-            &mut StdRng::from_os_rng(),
+            &mut rand::make_rng::<StdRng>(),
         );
 
         assert_eq!(num_elements, data.bytes.len() / 4); // f32 stored as u8s

--- a/crates/burn-backend/src/distribution.rs
+++ b/crates/burn-backend/src/distribution.rs
@@ -1,6 +1,6 @@
 //! Random value distributions used to initialize and populate tensor data.
 
-use rand::{Rng, RngCore, distr::StandardUniform};
+use rand::{Rng, RngExt, distr::StandardUniform};
 
 use super::element::{Element, ElementConversion};
 
@@ -27,7 +27,7 @@ pub struct DistributionSampler<'a, E, R>
 where
     StandardUniform: rand::distr::Distribution<E>,
     E: rand::distr::uniform::SampleUniform,
-    R: RngCore,
+    R: Rng,
 {
     kind: DistributionSamplerKind<E>,
     rng: &'a mut R,
@@ -57,7 +57,7 @@ where
     StandardUniform: rand::distr::Distribution<E>,
     E: rand::distr::uniform::SampleUniform,
     E: Element,
-    R: RngCore,
+    R: Rng,
 {
     /// Sames a random value from the distribution.
     pub fn sample(&mut self) -> E {
@@ -88,7 +88,7 @@ impl Distribution {
     /// The distribution sampler.
     pub fn sampler<R, E>(self, rng: &'_ mut R) -> DistributionSampler<'_, E, R>
     where
-        R: RngCore,
+        R: Rng,
         E: Element + rand::distr::uniform::SampleUniform,
         StandardUniform: rand::distr::Distribution<E>,
     {

--- a/crates/burn-backend/src/element/base.rs
+++ b/crates/burn-backend/src/element/base.rs
@@ -1,5 +1,5 @@
 use core::cmp::Ordering;
-use rand::RngCore;
+use rand::Rng;
 
 use crate::distribution::Distribution;
 use burn_std::{DType, bf16, f16};
@@ -72,7 +72,7 @@ pub trait ElementRandom {
     /// # Returns
     ///
     /// The random value.
-    fn random<R: RngCore>(distribution: Distribution, rng: &mut R) -> Self;
+    fn random<R: Rng>(distribution: Distribution, rng: &mut R) -> Self;
 }
 
 /// Element trait for equality of a tensor.
@@ -141,7 +141,7 @@ macro_rules! make_element {
         }
 
         impl ElementRandom for $type {
-            fn random<R: RngCore>(distribution: Distribution, rng: &mut R) -> Self {
+            fn random<R: Rng>(distribution: Distribution, rng: &mut R) -> Self {
                 #[allow(clippy::redundant_closure_call)]
                 $random(distribution, rng)
             }

--- a/crates/burn-candle/src/backend.rs
+++ b/crates/burn-candle/src/backend.rs
@@ -34,10 +34,7 @@ pub(crate) static SEED: Mutex<Option<StdRng>> = Mutex::new(None);
 
 pub(crate) fn get_seeded_rng() -> StdRng {
     let mut seed = SEED.lock().unwrap();
-    match seed.as_ref() {
-        Some(rng_seeded) => rng_seeded.clone(),
-        None => burn_std::rand::get_seeded_rng(),
-    }
+    seed.take().unwrap_or_else(burn_std::rand::get_seeded_rng)
 }
 
 pub(crate) fn set_seeded_rng(rng_seeded: StdRng) {

--- a/crates/burn-core/src/data/dataloader/batch.rs
+++ b/crates/burn-core/src/data/dataloader/batch.rs
@@ -100,8 +100,8 @@ where
 
     fn to_device(&self, device: &B::Device) -> Arc<dyn DataLoader<B, O>> {
         let rng = self.rng.as_ref().map(|rng| {
-            let rng = rng.lock();
-            rng.clone()
+            use rand::SeedableRng;
+            rng.lock().fork()
         });
         Arc::new(Self::new(
             self.strategy.clone_dyn(),
@@ -114,8 +114,8 @@ where
 
     fn slice(&self, start: usize, end: usize) -> Arc<dyn DataLoader<B, O>> {
         let rng = self.rng.as_ref().map(|rng| {
-            let rng = rng.lock();
-            rng.clone()
+            use rand::SeedableRng;
+            rng.lock().fork()
         });
         let dataloader = Self::new(
             self.strategy.clone_dyn(),

--- a/crates/burn-core/src/module/reinit.rs
+++ b/crates/burn-core/src/module/reinit.rs
@@ -4,7 +4,7 @@ use burn_tensor::{
     backend::Backend,
     ops::{FloatElem, IntElem},
 };
-use rand::{Rng, SeedableRng};
+use rand::{RngExt, SeedableRng};
 
 #[derive(Debug)]
 /// Overrides float and int tensors of [burn modules](super::Module).

--- a/crates/burn-dataset/Cargo.toml
+++ b/crates/burn-dataset/Cargo.toml
@@ -57,7 +57,7 @@ encoding_rs = { workspace = true, optional = true }
 polars = { workspace = true, optional = true }
 r2d2 = { workspace = true, optional = true }
 r2d2_sqlite = { workspace = true, optional = true }
-rand = { workspace = true, features = ["std", "os_rng"] }
+rand = { workspace = true, features = ["std", "sys_rng"] }
 zip = { workspace = true, optional = true }
 rmp-serde = { workspace = true }
 rusqlite = { workspace = true, optional = true }

--- a/crates/burn-dataset/src/transform/sampler.rs
+++ b/crates/burn-dataset/src/transform/sampler.rs
@@ -1,7 +1,7 @@
 use crate::Dataset;
 use crate::transform::{RngSource, SizeConfig};
 use rand::prelude::SliceRandom;
-use rand::{Rng, distr::Uniform, rngs::StdRng, seq::IteratorRandom};
+use rand::{RngExt, distr::Uniform, rngs::StdRng, seq::IteratorRandom};
 use std::{marker::PhantomData, ops::DerefMut, sync::Mutex};
 
 /// Options to configure a [SamplerDataset].
@@ -274,7 +274,7 @@ where
                     // > Although the elements are selected randomly, the order of elements in
                     // > the buffer is neither stable nor fully random. If random ordering is
                     // > desired, shuffle the result.
-                    indices.extend(idx_range.choose_multiple(rng, self.size - indices.len()));
+                    indices.extend(idx_range.sample(rng, self.size - indices.len()));
 
                     // The real shuffling is done here.
                     indices.shuffle(rng);
@@ -343,9 +343,9 @@ mod tests {
         assert_eq!(options.rng_source, RngSource::Default);
         let options = options.with_seed(42);
         assert_eq!(options.rng_source, RngSource::Seed(42));
-        let rng = StdRng::seed_from_u64(9);
-        let options = options.with_rng(rng.clone());
-        assert_eq!(options.rng_source, RngSource::Rng(rng.clone()));
+        let mut rng = StdRng::seed_from_u64(9);
+        let options = options.with_rng(&mut rng);
+        matches!(options.rng_source, RngSource::Rng(_));
     }
 
     #[test]

--- a/crates/burn-dataset/src/transform/selection.rs
+++ b/crates/burn-dataset/src/transform/selection.rs
@@ -254,7 +254,7 @@ mod tests {
         let size = 10;
 
         let mut rng1 = StdRng::seed_from_u64(10);
-        let mut rng2 = rng1.clone();
+        let mut rng2 = StdRng::seed_from_u64(10);
 
         let mut expected = iota(size);
         expected.shuffle(&mut rng1);

--- a/crates/burn-ndarray/Cargo.toml
+++ b/crates/burn-ndarray/Cargo.toml
@@ -74,7 +74,7 @@ ndarray = { workspace = true }
 num-traits = { workspace = true }
 openblas-src = { workspace = true, optional = true }
 paste = { workspace = true }
-rand = { workspace = true, default-features = false, features = ["small_rng"] }
+rand = { workspace = true, default-features = false }
 
 # SIMD
 bytemuck = { workspace = true, optional = true }

--- a/crates/burn-ndarray/src/ops/int_tensor.rs
+++ b/crates/burn-ndarray/src/ops/int_tensor.rs
@@ -354,11 +354,7 @@ where
         device: &NdArrayDevice,
     ) -> NdArrayTensor {
         let mut seed = SEED.lock().unwrap();
-        let mut rng = if let Some(rng_seeded) = seed.as_ref() {
-            rng_seeded.clone()
-        } else {
-            get_seeded_rng()
-        };
+        let mut rng = seed.take().unwrap_or_else(get_seeded_rng);
 
         let effective_distribution = if distribution == Distribution::Default {
             Distribution::Uniform(0.0, 255.0) // Assuming UniformInt is the integer variant

--- a/crates/burn-ndarray/src/ops/tensor.rs
+++ b/crates/burn-ndarray/src/ops/tensor.rs
@@ -63,11 +63,7 @@ where
         device: &NdArrayDevice,
     ) -> FloatTensor<Self> {
         let mut seed = SEED.lock().unwrap();
-        let mut rng = if let Some(rng_seeded) = seed.as_ref() {
-            rng_seeded.clone()
-        } else {
-            get_seeded_rng()
-        };
+        let mut rng = seed.take().unwrap_or_else(get_seeded_rng);
         let tensor = Self::float_from_data(
             TensorData::random::<E, _, _>(shape, distribution, &mut rng),
             device,

--- a/examples/mnist/src/data.rs
+++ b/examples/mnist/src/data.rs
@@ -9,7 +9,7 @@ use burn::{
     prelude::*,
     vision::Transform2D,
 };
-use rand::Rng;
+use rand::RngExt;
 
 #[derive(Clone, Debug, Default)]
 pub struct MnistBatcher {}

--- a/examples/modern-lstm/src/dataset.rs
+++ b/examples/modern-lstm/src/dataset.rs
@@ -5,7 +5,7 @@ use burn::{
     },
     prelude::*,
 };
-use rand::Rng;
+use rand::RngExt;
 use rand_distr::{Distribution, Normal};
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
## Summary

Upgrade workspace rand from 0.9 to 0.10 and update cubecl/cubek deps. This is needed because cubecl uses rand 0.10 (via rand_core 0.10 / chacha20 0.10), and having burn on rand 0.9 causes type mismatches between `burn_std::rand::StdRng` and `rand::rngs::StdRng`.

### Changes

**Workspace (`Cargo.toml`)**
- `rand`: 0.9.2 -> 0.10.0
- `rand_distr`: 0.5.1 -> 0.6.0
- cubecl rev updated to `6e988fd3` (merged fix from tracel-ai/cubecl#1184)

**burn-backend** (`data/tensor.rs`, `distribution.rs`, `element/base.rs`)
- `use rand::RngCore` -> `use rand::Rng` (trait renamed in rand 0.10)
- `use rand::Rng` (convenience) -> `use rand::RngExt`
- `StdRng::from_os_rng()` -> `rand::make_rng::<StdRng>()`

**burn-core** (`dataloader/batch.rs`, `dataloader/multithread.rs`, `module/reinit.rs`)
- `rng.lock().clone()` -> `rng.lock().fork()` (StdRng lost Clone in rand 0.10)
- `Option<StdRng>` -> `Option<spin::Mutex<StdRng>>` in multithread dataloader for interior mutability
- `use rand::Rng` -> `use rand::RngExt` where `.sample()` is called

**burn-dataset** (`Cargo.toml`, `transform/options.rs`, `transform/sampler.rs`, `transform/selection.rs`)
- Feature rename: `os_rng` -> `sys_rng`
- `RngSource::Rng(StdRng)` -> `RngSource::Rng([u8; 32])` (store seed bytes since StdRng lost Clone)
- Removed `From<&StdRng>` impl (impossible without Clone)
- `choose_multiple` -> `sample` (renamed in rand 0.10 IteratorRandom)

**burn-ndarray** (`Cargo.toml`, `ops/tensor.rs`, `ops/int_tensor.rs`)
- Removed `small_rng` feature (always available in rand 0.10)
- `seed.as_ref().clone()` -> `seed.take().unwrap_or_else(get_seeded_rng)`

**Examples** (`mnist/src/data.rs`, `modern-lstm/src/dataset.rs`)
- `use rand::Rng` -> `use rand::RngExt`

## Context

Part of the fix for tracel-ai/burn-onnx#135 (wasm build failure due to `getrandom`). The full fix spans:
- tracel-ai/cubecl#1184 (merged) - stop unconditional std propagation
- tracel-ai/cubek#86 (merged) - decouple cubek from cubecl/std
- This PR - upgrade rand 0.9 to 0.10 and explicitly declare `std_rng` feature
- tracel-ai/burn-onnx#144 - remove getrandom workaround from wasm example

## Test plan

- [x] `cargo test -p burn-backend --lib` (58 tests pass)
- [x] `cargo test -p burn-dataset --lib` (47 tests pass)
- [x] `cargo test -p burn-ndarray --lib` (29 tests pass)
- [x] `cargo test -p burn-core --lib` (38 tests pass)
- [x] `cargo check` passes for burn, burn-autodiff, burn-nn, burn-tensor, burn-train, burn-optim, burn-ir, burn-fusion, burn-vision, burn-rl, burn-store
- [x] `wasm-pack build` succeeds for image-classification-web (both SIMD and non-SIMD)
- [ ] CI passes