### PR TITLE
Fix image-classification-web links

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,14 +286,14 @@ Inference in the Browser 🌐
 </summary>
 <br />
 
-Several of our backends can run in WebAssembly environments: NdArray for CPU execution,
-and WGPU for GPU acceleration via WebGPU. This means that you can run inference directly within a
-browser. We provide several examples of this:
+Several of our backends can run in WebAssembly environments: NdArray for CPU execution, and WGPU for
+GPU acceleration via WebGPU. This means that you can run inference directly within a browser. We
+provide several examples of this:
 
 - [MNIST](./examples/mnist-inference-web) where you can draw digits and a small convnet tries to
   find which one it is! 2️⃣ 7️⃣ 😰
-- [Image Classification](./examples/image-classification-web) where you can upload images and
-  classify them! 🌄
+- [Image Classification](https://github.com/tracel-ai/burn-onnx/tree/main/examples/image-classification-web)
+  where you can upload images and classify them! 🌄
 
 </details>
 

--- a/_typos.toml
+++ b/_typos.toml
@@ -11,7 +11,6 @@ extend-exclude = [
     "*.onnx",
     "*.proto",
     "assets/ModuleSerialization.xml",
-    "examples/image-classification-web/src/model/label.txt",
 ]
 
 [default.extend-words]

--- a/burn-book/src/advanced/web-assembly.md
+++ b/burn-book/src/advanced/web-assembly.md
@@ -5,7 +5,7 @@ models to run directly in the browser.
 
 Check out the following examples:
 
-- [Image Classification Web](https://github.com/tracel-ai/burn/tree/main/examples/image-classification-web)
+- [Image Classification Web](https://github.com/tracel-ai/burn-onnx/tree/main/examples/image-classification-web)
 - [MNIST Inference on Web](https://github.com/tracel-ai/burn/tree/main/examples/mnist-inference-web)
 
 When targeting WebAssembly, certain dependencies require additional configuration. In particular,


### PR DESCRIPTION
Missing changes from the example move to burn-onnx repo