### PR TITLE
fix: Bool from_data_dtype panics on GPU backends

### DIFF
--- a/crates/burn-backend/src/tensor/ops/bool.rs
+++ b/crates/burn-backend/src/tensor/ops/bool.rs
@@ -140,12 +140,10 @@ impl<B: Backend> BasicOps<B> for Bool {
         B::bool_from_data(data.convert::<B::BoolElem>(), device)
     }
 
-    fn from_data_dtype(data: TensorData, device: &Device<B>, dtype: DType) -> Self::Primitive {
-        // Backends only use one bool representation dtype
-        if dtype != B::BoolElem::dtype() {
-            panic!("Expected bool dtype, got {dtype:?}")
-        }
-        B::bool_from_data(data.convert_dtype(dtype), device)
+    fn from_data_dtype(data: TensorData, device: &Device<B>, _dtype: DType) -> Self::Primitive {
+        // Bool tensors have exactly one representation per backend, so the
+        // requested dtype is irrelevant. Convert to `B::BoolElem` directly.
+        B::bool_from_data(data.convert::<B::BoolElem>(), device)
     }
 
     fn repeat_dim(tensor: Self::Primitive, dim: usize, times: usize) -> Self::Primitive {


### PR DESCRIPTION
## Summary

- `BasicOps<B>::from_data_dtype` for `Bool` tensors panics on Metal/Wgpu backends because it checks `dtype != B::BoolElem::dtype()`. The stored data has `DType::Bool` but these backends represent bools as `u8` (`DType::U8`), so the check always fails.
- Removed the dtype check and switched from `convert_dtype(dtype)` to `convert::<B::BoolElem>()`, matching what `from_data` already does. Bool tensors have exactly one representation per backend, so the dtype parameter is irrelevant.

## Reproducer

Any model with a `Param<Tensor<B, N, Bool>>` loaded via burnpack on Metal/Wgpu. For example, SmolLM has a boolean attention mask constant that triggers this during `Model::default()`.

## Test plan

- [x] Verified `cargo check -p burn-backend` passes
- [x] Verified SmolLM model check passes on Metal backend (max diff 0.000257, within tolerance)
- [x] Verified SmolLM model check still passes on ndarray backend