### PR TITLE
Optional Ordering for NdArrayElement

### DIFF
--- a/crates/burn-ndarray/src/element.rs
+++ b/crates/burn-ndarray/src/element.rs
@@ -10,14 +10,14 @@ use num_traits::Pow;
 use libm::{log1p, log1pf};
 
 /// A float element for ndarray backend.
-pub trait FloatNdArrayElement: NdArrayElement + Signed
+pub trait FloatNdArrayElement: NdArrayElement + Signed + core::cmp::PartialOrd<Self>
 where
     Self: Sized,
 {
 }
 
 /// An int element for ndarray backend.
-pub trait IntNdArrayElement: NdArrayElement {}
+pub trait IntNdArrayElement: NdArrayElement + core::cmp::PartialOrd<Self> {}
 
 /// A general element for ndarray backend.
 pub trait NdArrayElement:
@@ -29,7 +29,6 @@ pub trait NdArrayElement:
     + num_traits::FromPrimitive
     + core::ops::AddAssign
     + core::cmp::PartialEq
-    + core::cmp::PartialOrd<Self>
     + core::ops::Rem<Output = Self>
 {
 }

--- a/crates/burn-ndarray/src/ops/macros.rs
+++ b/crates/burn-ndarray/src/ops/macros.rs
@@ -84,7 +84,10 @@ pub(crate) fn cumprod_dim<E: NdArrayElement>(tensor: SharedArray<E>, dim: usize)
     cumulative_with_op(tensor, dim, |c, &p| *c = c.mul(p.elem()))
 }
 
-pub(crate) fn cummin_dim<E: NdArrayElement>(tensor: SharedArray<E>, dim: usize) -> SharedArray<E> {
+pub(crate) fn cummin_dim<E: NdArrayElement + core::cmp::PartialOrd<E>>(
+    tensor: SharedArray<E>,
+    dim: usize,
+) -> SharedArray<E> {
     cumulative_with_op(tensor, dim, |c, &p| {
         if p < *c {
             *c = p;
@@ -92,7 +95,10 @@ pub(crate) fn cummin_dim<E: NdArrayElement>(tensor: SharedArray<E>, dim: usize) 
     })
 }
 
-pub(crate) fn cummax_dim<E: NdArrayElement>(tensor: SharedArray<E>, dim: usize) -> SharedArray<E> {
+pub(crate) fn cummax_dim<E: NdArrayElement + core::cmp::PartialOrd<E>>(
+    tensor: SharedArray<E>,
+    dim: usize,
+) -> SharedArray<E> {
     cumulative_with_op(tensor, dim, |c, &p| {
         if p > *c {
             *c = p;


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

- #4255
- #4419

### Changes

altered NdarrayElement to remove partialOrdering, added it to float and int variants, and added the constraint to the methods that require it. 

NOTE: I'm not sure making sign checking dependent on partial ord is desirable. Could we make another `impl NdArray MathOps` that requires `Signed`?

### Testing

so far just `cargo test -p burn-ndarray`. Should pass run-checks as it's only reorganizing existing methods