### PR TITLE
the burn side quantized int kernel primitives for ONNX QLinear foundation (#4566)

### DIFF
--- a/burn-book/src/onnx-import.md
+++ b/burn-book/src/onnx-import.md
@@ -53,6 +53,17 @@ with older opset versions may work, opset 16+ ensures access to all supported op
 latest behavior. If you encounter issues with an older model, consider upgrading it using the ONNX
 version converter.
 
+### Quantized Operator Semantics
+
+For ONNX quantized linear operators (`QLinearMatMul`, `QLinearConv`, `ConvInteger`), Burn backends
+now expose integer primitives designed to match ONNX math:
+
+- Accumulation is performed in `i32` after zero-point correction: `(x - zp_x)` and `(w - zp_w)`.
+- Requantization uses deterministic **round-to-nearest ties-to-even**.
+- Casting back to integer output dtypes uses **saturating clamp** to the dtype range.
+
+These rules are part of the backend contract and are intended to be consistent across backends.
+
 ### Upgrading ONNX Models
 
 There are two simple ways to upgrade your ONNX models to the recommended opset version:

--- a/crates/burn-backend-tests/tests/tensor/int/ops/mod.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/mod.rs
@@ -28,6 +28,7 @@ mod mul;
 mod one_hot;
 mod permute;
 mod random;
+mod quantized_primitives;
 mod remainder;
 mod repeat;
 mod repeat_dim;

--- a/crates/burn-backend-tests/tests/tensor/int/ops/quantized_primitives.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/quantized_primitives.rs
@@ -1,0 +1,154 @@
+use super::*;
+use burn_tensor::{
+    IntDType, TensorData,
+    ops::{ConvOptions, FloatTensorOps, IntTensorOps},
+};
+
+#[test]
+fn test_int_matmul_accum_u8_i32() {
+    let device = Default::default();
+
+    let lhs = <TestBackend as IntTensorOps<TestBackend>>::int_from_data(
+        TensorData::from([[10u8, 12u8], [8u8, 9u8]]),
+        &device,
+    );
+    let rhs = <TestBackend as IntTensorOps<TestBackend>>::int_from_data(
+        TensorData::from([[2u8, 4u8], [6u8, 8u8]]),
+        &device,
+    );
+    let lhs_zp = <TestBackend as IntTensorOps<TestBackend>>::int_from_data(
+        TensorData::from([10u8]),
+        &device,
+    );
+    let rhs_zp = <TestBackend as IntTensorOps<TestBackend>>::int_from_data(
+        TensorData::from([5u8]),
+        &device,
+    );
+
+    let output = <TestBackend as IntTensorOps<TestBackend>>::int_matmul_accum(
+        lhs, lhs_zp, rhs, rhs_zp,
+    );
+
+    TestTensorInt::<2>::from_primitive(output)
+        .into_data()
+        .assert_eq(&TensorData::from([[2i32, 6i32], [5i32, -1i32]]), false);
+}
+
+#[test]
+fn test_int_conv2d_accum_u8_i8_i32() {
+    let device = Default::default();
+
+    let x = <TestBackend as IntTensorOps<TestBackend>>::int_from_data(
+        TensorData::from([[[[11u8, 12u8], [13u8, 14u8]]]]),
+        &device,
+    );
+    let weight = <TestBackend as IntTensorOps<TestBackend>>::int_from_data(
+        TensorData::from([[[[2i8]]]]),
+        &device,
+    );
+    let x_zp = <TestBackend as IntTensorOps<TestBackend>>::int_from_data(
+        TensorData::from([10u8]),
+        &device,
+    );
+    let w_zp = <TestBackend as IntTensorOps<TestBackend>>::int_from_data(
+        TensorData::from([1i8]),
+        &device,
+    );
+
+    let output = <TestBackend as IntTensorOps<TestBackend>>::int_conv2d_accum(
+        x,
+        x_zp,
+        weight,
+        w_zp,
+        None,
+        ConvOptions::new([1, 1], [0, 0], [1, 1], 1),
+    );
+
+    TestTensorInt::<4>::from_primitive(output)
+        .into_data()
+        .assert_eq(&TensorData::from([[[[1i32, 2i32], [3i32, 4i32]]]]), false);
+}
+
+#[test]
+fn test_int_requantize_to_u8_and_i8() {
+    let device = Default::default();
+
+    let accum = <TestBackend as IntTensorOps<TestBackend>>::int_from_data(
+        TensorData::from([[-3i32, -1i32, 0i32, 1i32, 3i32]]),
+        &device,
+    );
+    let scale = <TestBackend as FloatTensorOps<TestBackend>>::float_from_data(
+        TensorData::from([[1.25f32, 1.25, 1.25, 1.25, 1.25]]),
+        &device,
+    );
+
+    let zp_u8 = <TestBackend as IntTensorOps<TestBackend>>::int_from_data(
+        TensorData::from([128i32]),
+        &device,
+    );
+
+    let output_u8 = <TestBackend as IntTensorOps<TestBackend>>::int_requantize(
+        accum,
+        scale,
+        zp_u8,
+        IntDType::U8,
+    );
+
+    TestTensorInt::<2>::from_primitive(output_u8)
+        .into_data()
+        .assert_eq(&TensorData::from([[124u8, 127u8, 128u8, 129u8, 132u8]]), false);
+
+    let accum_i8 = <TestBackend as IntTensorOps<TestBackend>>::int_from_data(
+        TensorData::from([[-200i32, -128i32, 0i32, 127i32, 200i32]]),
+        &device,
+    );
+    let scale_1 = <TestBackend as FloatTensorOps<TestBackend>>::float_from_data(
+        TensorData::from([[1.0f32, 1.0, 1.0, 1.0, 1.0]]),
+        &device,
+    );
+    let zp_i8 = <TestBackend as IntTensorOps<TestBackend>>::int_from_data(
+        TensorData::from([0i32]),
+        &device,
+    );
+
+    let output_i8 = <TestBackend as IntTensorOps<TestBackend>>::int_requantize(
+        accum_i8,
+        scale_1,
+        zp_i8,
+        IntDType::I8,
+    );
+
+    TestTensorInt::<2>::from_primitive(output_i8)
+        .into_data()
+        .assert_eq(&TensorData::from([[-128i8, -128i8, 0i8, 127i8, 127i8]]), false);
+}
+
+#[test]
+fn test_int_requantize_ties_to_even_and_saturation() {
+    let device = Default::default();
+
+    let accum = <TestBackend as IntTensorOps<TestBackend>>::int_from_data(
+        TensorData::from([[-3i32, -1i32, 1i32, 3i32, 400i32, -400i32]]),
+        &device,
+    );
+    let scale = <TestBackend as FloatTensorOps<TestBackend>>::float_from_data(
+        TensorData::from([[0.5f32, 0.5, 0.5, 0.5, 0.5, 0.5]]),
+        &device,
+    );
+    let zero_point = <TestBackend as IntTensorOps<TestBackend>>::int_from_data(
+        TensorData::from([0i32]),
+        &device,
+    );
+
+    let output_i8 = <TestBackend as IntTensorOps<TestBackend>>::int_requantize(
+        accum,
+        scale,
+        zero_point,
+        IntDType::I8,
+    );
+
+    // [-1.5, -0.5, 0.5, 1.5, 200, -200] -> [-2, 0, 0, 2, 127, -128]
+    TestTensorInt::<2>::from_primitive(output_i8)
+        .into_data()
+        .assert_eq(&TensorData::from([[-2i8, 0i8, 0i8, 2i8, 127i8, -128i8]]), false);
+}

--- a/crates/burn-ndarray/src/ops/int_tensor.rs
+++ b/crates/burn-ndarray/src/ops/int_tensor.rs
@@ -2,9 +2,10 @@
 use crate::rand::get_seeded_rng;
 use alloc::vec::Vec;
 use burn_backend::backend::ExecutionError;
-use burn_backend::ops::IntTensorOps;
+use burn_backend::ops::{ConvOptions, IntTensorOps};
 use burn_backend::tensor::{FloatTensor, IntTensor};
 use burn_backend::{Distribution, IntDType, Scalar, TensorMetadata};
+use ndarray::{ArrayViewD, Zip};
 
 use burn_backend::ElementConversion;
 
@@ -13,12 +14,60 @@ use crate::{NdArray, cast_to_dtype, execute_with_dtype, tensor::NdArrayTensor};
 use crate::{NdArrayDevice, SEED, slice};
 use crate::{SharedArray, element::QuantElement};
 use crate::{cat_with_dtype, execute_with_float_dtype};
-use crate::{element::FloatNdArrayElement, ops::matmul::matmul};
+use crate::{element::FloatNdArrayElement, ops::conv::conv2d, ops::matmul::matmul};
 use crate::{element::IntNdArrayElement, execute_with_int_dtype};
 
 // Workspace crates
 use super::{NdArrayBitOps, NdArrayMathOps, NdArrayOps};
 use burn_backend::{DType, Shape, TensorData, backend::Backend};
+
+fn round_ties_to_even(value: f32) -> i32 {
+    if !value.is_finite() {
+        return if value.is_sign_negative() {
+            i32::MIN
+        } else {
+            i32::MAX
+        };
+    }
+
+    let floor = value.floor();
+    let frac = value - floor;
+    let rounded = if frac < 0.5 {
+        floor
+    } else if frac > 0.5 {
+        floor + 1.0
+    } else if (floor as i64) % 2 == 0 {
+        floor
+    } else {
+        floor + 1.0
+    };
+
+    if rounded <= i32::MIN as f32 {
+        i32::MIN
+    } else if rounded >= i32::MAX as f32 {
+        i32::MAX
+    } else {
+        rounded as i32
+    }
+}
+
+fn saturate_to_dtype(value: i32, dtype: IntDType) -> i32 {
+    match dtype {
+        IntDType::I8 => value.clamp(i8::MIN as i32, i8::MAX as i32),
+        IntDType::U8 => value.clamp(u8::MIN as i32, u8::MAX as i32),
+        IntDType::I16 => value.clamp(i16::MIN as i32, i16::MAX as i32),
+        IntDType::U16 => value.clamp(u16::MIN as i32, u16::MAX as i32),
+        IntDType::U32 | IntDType::U64 => value.max(0),
+        IntDType::I32 | IntDType::I64 => value,
+    }
+}
+
+fn into_i32_array(tensor: NdArrayTensor) -> SharedArray<i32> {
+    match tensor {
+        NdArrayTensor::I32(storage) => storage.into_shared(),
+        _ => unreachable!(),
+    }
+}
 
 impl<E: FloatNdArrayElement, I: IntNdArrayElement, Q: QuantElement> IntTensorOps<Self>
     for NdArray<E, I, Q>
@@ -64,6 +113,90 @@ where
 
     fn int_matmul(lhs: IntTensor<Self>, rhs: IntTensor<Self>) -> IntTensor<Self> {
         execute_with_int_dtype!((lhs, rhs), matmul)
+    }
+
+    fn int_matmul_accum(
+        lhs: IntTensor<Self>,
+        lhs_zero_point: IntTensor<Self>,
+        rhs: IntTensor<Self>,
+        rhs_zero_point: IntTensor<Self>,
+    ) -> IntTensor<Self> {
+        let lhs = Self::int_sub(
+            Self::int_cast(lhs, IntDType::I32),
+            Self::int_cast(lhs_zero_point, IntDType::I32),
+        );
+        let rhs = Self::int_sub(
+            Self::int_cast(rhs, IntDType::I32),
+            Self::int_cast(rhs_zero_point, IntDType::I32),
+        );
+
+        Self::int_cast(Self::int_matmul(lhs, rhs), IntDType::I32)
+    }
+
+    fn int_conv2d_accum(
+        x: IntTensor<Self>,
+        x_zero_point: IntTensor<Self>,
+        weight: IntTensor<Self>,
+        weight_zero_point: IntTensor<Self>,
+        bias: Option<IntTensor<Self>>,
+        options: ConvOptions<2>,
+    ) -> IntTensor<Self> {
+        let x = Self::int_sub(
+            Self::int_cast(x, IntDType::I32),
+            Self::int_cast(x_zero_point, IntDType::I32),
+        );
+        let weight = Self::int_sub(
+            Self::int_cast(weight, IntDType::I32),
+            Self::int_cast(weight_zero_point, IntDType::I32),
+        );
+        let bias = bias.map(|bias| into_i32_array(Self::int_cast(bias, IntDType::I32)));
+
+        conv2d::<i32>(into_i32_array(x), into_i32_array(weight), bias, options).into()
+    }
+
+    fn int_requantize(
+        tensor: IntTensor<Self>,
+        scale: FloatTensor<Self>,
+        zero_point: IntTensor<Self>,
+        dtype: IntDType,
+    ) -> IntTensor<Self> {
+        let tensor = into_i32_array(Self::int_cast(tensor, IntDType::I32));
+        let zero_point = into_i32_array(Self::int_cast(zero_point, IntDType::I32));
+        let scale = execute_with_float_dtype!(scale, F, |array: SharedArray<F>| {
+            array.mapv(|value| value.elem::<f32>()).into_shared()
+        });
+        let scale = match scale {
+            NdArrayTensor::F32(storage) => storage.into_shared(),
+            _ => unreachable!(),
+        };
+
+        let shape = tensor.raw_dim();
+        let scale = scale
+            .broadcast(shape.clone())
+            .unwrap_or_else(|| panic!("Scale shape {:?} not broadcastable to {:?}", scale.shape(), tensor.shape()));
+        let zero_point = zero_point
+            .broadcast(shape.clone())
+            .unwrap_or_else(|| {
+                panic!(
+                    "Zero-point shape {:?} not broadcastable to {:?}",
+                    zero_point.shape(),
+                    tensor.shape()
+                )
+            });
+
+        let mut output = ndarray::ArrayD::<i32>::zeros(shape);
+        Zip::from(output.view_mut())
+            .and(ArrayViewD::from(&tensor))
+            .and(scale)
+            .and(zero_point)
+            .for_each(|out, &value, &scale, &zp| {
+                let scaled = value as f32 * scale;
+                let rounded = round_ties_to_even(scaled);
+                *out = saturate_to_dtype(rounded.saturating_add(zp), dtype);
+            });
+
+        let output: NdArrayTensor = output.into_shared().into();
+        Self::int_cast(output, dtype)
     }
 
     fn int_mask_where(
@@ -493,5 +626,122 @@ where
         step: usize,
     ) -> IntTensor<Self> {
         execute_with_int_dtype!(tensor, |array| NdArrayOps::unfold(array, dim, size, step))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use burn_backend::ops::ConvOptions;
+
+    type TestBackend = NdArray<f32, i32, i8>;
+
+    #[test]
+    fn int_matmul_accum_u8_i32() {
+        let device = NdArrayDevice::Cpu;
+        let lhs = <TestBackend as IntTensorOps<TestBackend>>::int_from_data(
+            TensorData::from([[10u8, 12u8], [8u8, 9u8]]),
+            &device,
+        );
+        let rhs = <TestBackend as IntTensorOps<TestBackend>>::int_from_data(
+            TensorData::from([[2u8, 4u8], [6u8, 8u8]]),
+            &device,
+        );
+        let lhs_zp = <TestBackend as IntTensorOps<TestBackend>>::int_from_data(
+            TensorData::from([10u8]),
+            &device,
+        );
+        let rhs_zp = <TestBackend as IntTensorOps<TestBackend>>::int_from_data(
+            TensorData::from([5u8]),
+            &device,
+        );
+
+        let output = <TestBackend as IntTensorOps<TestBackend>>::int_matmul_accum(
+            lhs, lhs_zp, rhs, rhs_zp,
+        );
+
+        output
+            .into_data()
+            .assert_eq(&TensorData::from([[2i32, 6i32], [5i32, -1i32]]), false);
+    }
+
+    #[test]
+    fn int_conv2d_accum_u8_i8_i32() {
+        let device = NdArrayDevice::Cpu;
+        let x = <TestBackend as IntTensorOps<TestBackend>>::int_from_data(
+            TensorData::from([[[[11u8, 12u8], [13u8, 14u8]]]]),
+            &device,
+        );
+        let weight = <TestBackend as IntTensorOps<TestBackend>>::int_from_data(
+            TensorData::from([[[[2i8]]]]),
+            &device,
+        );
+        let x_zp = <TestBackend as IntTensorOps<TestBackend>>::int_from_data(
+            TensorData::from([10u8]),
+            &device,
+        );
+        let w_zp = <TestBackend as IntTensorOps<TestBackend>>::int_from_data(
+            TensorData::from([1i8]),
+            &device,
+        );
+
+        let output = <TestBackend as IntTensorOps<TestBackend>>::int_conv2d_accum(
+            x,
+            x_zp,
+            weight,
+            w_zp,
+            None,
+            ConvOptions::new([1, 1], [0, 0], [1, 1], 1),
+        );
+
+        output
+            .into_data()
+            .assert_eq(&TensorData::from([[[[1i32, 2i32], [3i32, 4i32]]]]), false);
+    }
+
+    #[test]
+    fn int_requantize_supports_u8_and_i8() {
+        let device = NdArrayDevice::Cpu;
+
+        let accum = <TestBackend as IntTensorOps<TestBackend>>::int_from_data(
+            TensorData::from([[-3i32, -1i32, 0i32, 1i32, 3i32]]),
+            &device,
+        );
+        let scale = NdArrayTensor::from_data(TensorData::from([[1.5f32; 5]]));
+
+        let zp_u8 = <TestBackend as IntTensorOps<TestBackend>>::int_from_data(
+            TensorData::from([128i32]),
+            &device,
+        );
+
+        let output_u8 = <TestBackend as IntTensorOps<TestBackend>>::int_requantize(
+            accum.clone(),
+            scale.clone(),
+            zp_u8,
+            IntDType::U8,
+        );
+        output_u8
+            .into_data()
+            .assert_eq(&TensorData::from([[124u8, 126u8, 128u8, 130u8, 132u8]]), false);
+
+        let accum_i8 = <TestBackend as IntTensorOps<TestBackend>>::int_from_data(
+            TensorData::from([[-200i32, -128i32, 0i32, 127i32, 200i32]]),
+            &device,
+        );
+        let scale_1 = NdArrayTensor::from_data(TensorData::from([[1.0f32; 5]]));
+        let zp_i8 = <TestBackend as IntTensorOps<TestBackend>>::int_from_data(
+            TensorData::from([0i32]),
+            &device,
+        );
+
+        let output_i8 = <TestBackend as IntTensorOps<TestBackend>>::int_requantize(
+            accum_i8,
+            scale_1,
+            zp_i8,
+            IntDType::I8,
+        );
+        output_i8
+            .into_data()
+            .assert_eq(&TensorData::from([[-128i8, -128i8, 0i8, 127i8, 127i8]]), false);
     }
 }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

closes #4566 and also will help closing https://github.com/tracel-ai/burn-onnx/issues/160

### Changes

This PR completes the Burn-side foundation for quantized ONNX linear operator support (#4566).

- Added backend-level integer quantization primitives in `IntTensorOps`:
  - `int_matmul_accum` for zero-point-aware integer matmul with i32 accumulation.
  - `int_conv2d_accum` for zero-point-aware integer conv2d with i32 accumulation.
  - `int_requantize` with deterministic round-to-nearest ties-to-even and saturating clamp before cast.
- Implemented native ndarray CPU overrides for these primitives (no float fallback on the ndarray path).
- Strengthened cross-backend robustness in requantization:
  - Explicit i32 casts after `float_into_int` before integer ops.
  - Clarified `U32/U64` behavior is bounded by i32 accumulation range in this path.
- Improved ndarray requantization numerical behavior:
  - Added explicit NaN guard in ties-to-even rounding helper.
  - Switched multiply/round intermediates to f64 for better precision.
- Updated ONNX docs to clearly separate operator semantics:
  - `ConvInteger`/`MatMulInteger`: i32 accumulation outputs, no requantization/output scale/output zero-point.
  - `QLinearMatMul`/`QLinearConv`: requantization with ties-to-even and saturating clamp to output dtype.
- Added backend-agnostic integration tests for quantized primitives in `burn-backend-tests`.

### Testing

The following checks/tests were run:

- `cargo check --package burn-backend`
- `cargo check --package burn-ndarray`
- `cargo test --package burn-backend-tests --test tensor quantized_primitives -- --nocapture`

All commands completed successfully, and quantized primitive tests passed (including ties-to-even and saturation behavior). 