### PR TITLE
Add `#[module(constant)]` and `#[module(skip)]` attributes

### DIFF
--- a/crates/burn-candle/src/lib.rs
+++ b/crates/burn-candle/src/lib.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(unused)] // TODO remove when backend filled
 #![deprecated(
-    since = "0.21.0-pre.1",
+    since = "0.21.0",
     note = "burn-candle is deprecated and will be removed in a future release. Use burn-cubecl (CUDA/ROCm/Vulkan/Metal/WebGPU), burn-ndarray, or burn-tch instead."
 )]
 

--- a/crates/burn-core/src/module/param/constant.rs
+++ b/crates/burn-core/src/module/param/constant.rs
@@ -30,7 +30,7 @@ pub type ConstantRecord = EmptyRecord;
 /// or modules without parameters).
 ///
 /// This record contains no fields and serializes to `None`.
-#[derive(Debug, Clone, Copy, new, Default)]
+#[derive(Debug, Clone, Copy, new, Default, PartialEq, Eq)]
 pub struct EmptyRecord;
 
 impl serde::Serialize for EmptyRecord {
@@ -378,6 +378,12 @@ impl<T> core::ops::Deref for Ignored<T> {
 #[derive(Debug, Clone, Copy, new)]
 pub struct ValueRecord<T> {
     value: T,
+}
+
+impl<T: PartialEq> PartialEq for ValueRecord<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.value == other.value
+    }
 }
 
 impl<T> ValueRecord<T> {

--- a/crates/burn-core/src/module/param/constant.rs
+++ b/crates/burn-core/src/module/param/constant.rs
@@ -1,5 +1,6 @@
 use alloc::{format, string::ToString};
 use core::{fmt::Display, marker::PhantomData};
+use serde::{Serialize, de::DeserializeOwned};
 
 use crate as burn;
 use crate::{
@@ -15,11 +16,24 @@ use burn_tensor::{
     ops::Device,
 };
 
-/// Record used for constant type implementing the [module](crate::module::Module) trait.
-#[derive(Debug, Clone, Copy, new, Default)]
-pub struct ConstantRecord;
+#[deprecated(
+    since = "0.21.0",
+    note = "ConstantRecord is misleading as it doesn't persist data. Use EmptyRecord instead."
+)]
+/// A record representing the absence of persistent module state.
+pub type ConstantRecord = EmptyRecord;
 
-impl serde::Serialize for ConstantRecord {
+/// A record representing the absence of persistent module state.
+///
+/// `EmptyRecord` is used for modules that do not store any data to be
+/// serialized or restored (e.g., modules marked with `#[module(skip)]`
+/// or modules without parameters).
+///
+/// This record contains no fields and serializes to `None`.
+#[derive(Debug, Clone, Copy, new, Default)]
+pub struct EmptyRecord;
+
+impl serde::Serialize for EmptyRecord {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -29,18 +43,18 @@ impl serde::Serialize for ConstantRecord {
     }
 }
 
-impl<'de> serde::Deserialize<'de> for ConstantRecord {
+impl<'de> serde::Deserialize<'de> for EmptyRecord {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
         deserializer.deserialize_option(serde::de::IgnoredAny).ok();
-        Ok(ConstantRecord::new())
+        Ok(EmptyRecord::new())
     }
 }
 
-impl<B: Backend> Record<B> for ConstantRecord {
-    type Item<S: PrecisionSettings> = ConstantRecord;
+impl<B: Backend> Record<B> for EmptyRecord {
+    type Item<S: PrecisionSettings> = EmptyRecord;
 
     fn into_item<S: PrecisionSettings>(self) -> Self::Item<S> {
         self
@@ -52,9 +66,9 @@ impl<B: Backend> Record<B> for ConstantRecord {
 }
 /// Constant macro.
 #[macro_export]
-macro_rules! constant {
+macro_rules! empty {
     (module) => {
-        type Record = burn::module::ConstantRecord;
+        type Record = burn::module::EmptyRecord;
 
         fn visit<V: burn::module::ModuleVisitor<B>>(&self, _visitor: &mut V) {
             // Nothing to do
@@ -69,7 +83,7 @@ macro_rules! constant {
         }
 
         fn into_record(self) -> Self::Record {
-            burn::module::ConstantRecord::new()
+            burn::module::EmptyRecord::new()
         }
 
         fn to_device(self, _: &B::Device) -> Self {
@@ -99,11 +113,11 @@ macro_rules! constant {
 
     ($type:ty) => {
         impl<B: burn::tensor::backend::Backend> burn::module::Module<B> for $type {
-            constant!(module);
+            empty!(module);
         }
 
         impl<B: burn::tensor::backend::AutodiffBackend> burn::module::AutodiffModule<B> for $type {
-            constant!(ad_module, $type);
+            empty!(ad_module, $type);
         }
 
         impl burn::module::ModuleDisplayDefault for $type {
@@ -117,29 +131,31 @@ macro_rules! constant {
     };
 }
 
+// TODO: breaking change for these constant types (currently empty record, non-persistent)
+
 // General Types
-constant!(alloc::string::String);
-constant!(bool);
+empty!(alloc::string::String);
+empty!(bool);
 
 // Float Types
-constant!(f64);
-constant!(f32);
-constant!(half::bf16);
-constant!(half::f16);
+empty!(f64);
+empty!(f32);
+empty!(half::bf16);
+empty!(half::f16);
 
 // Unsigned Integer Types
-constant!(usize);
-constant!(u64);
-constant!(u32);
-constant!(u16);
-constant!(u8);
+empty!(usize);
+empty!(u64);
+empty!(u32);
+empty!(u16);
+empty!(u8);
 
 // Signed Integer Types
-constant!(isize);
-constant!(i64);
-constant!(i32);
-constant!(i16);
-constant!(i8);
+empty!(isize);
+empty!(i64);
+empty!(i32);
+empty!(i16);
+empty!(i8);
 
 impl burn::module::ModuleDisplay for str {}
 impl burn::module::ModuleDisplayDefault for str {
@@ -148,8 +164,9 @@ impl burn::module::ModuleDisplayDefault for str {
     }
 }
 
+// TODO: tensor record should persist
 impl<const D: usize, B: Backend, K: BasicOps<B>> Module<B> for Tensor<B, D, K> {
-    type Record = ConstantRecord;
+    type Record = EmptyRecord;
 
     fn visit<V: ModuleVisitor<B>>(&self, _visitor: &mut V) {}
 
@@ -158,7 +175,7 @@ impl<const D: usize, B: Backend, K: BasicOps<B>> Module<B> for Tensor<B, D, K> {
     }
 
     fn into_record(self) -> Self::Record {
-        ConstantRecord
+        EmptyRecord
     }
 
     fn load_record(self, _record: Self::Record) -> Self {
@@ -208,7 +225,7 @@ impl<const D: usize, B: AutodiffBackend, K: BasicAutodiffOps<B>> AutodiffModule<
 }
 
 impl<B: Backend> Module<B> for PhantomData<B> {
-    type Record = ConstantRecord;
+    type Record = EmptyRecord;
 
     fn visit<V: ModuleVisitor<B>>(&self, _visitor: &mut V) {
         // Nothing to do
@@ -223,7 +240,7 @@ impl<B: Backend> Module<B> for PhantomData<B> {
     }
 
     fn into_record(self) -> Self::Record {
-        ConstantRecord::new()
+        EmptyRecord::new()
     }
 
     fn to_device(self, _: &Device<B>) -> Self {
@@ -261,14 +278,19 @@ impl<B: AutodiffBackend> AutodiffModule<B> for PhantomData<B> {
 
 /// Container to satisfy the Module trait for types that are not modules.
 #[derive(Clone, Debug)]
+#[deprecated(
+    since = "0.21.0",
+    note = "Ignored<T> is deprecated. Use #[module(skip)] for non-persistent fields (same behavior) or #[module(constant)] for persistent fields."
+)]
 pub struct Ignored<T>(pub T);
 
+#[allow(deprecated)]
 impl<B, T> Module<B> for Ignored<T>
 where
     B: Backend,
     T: Sync + Send + core::fmt::Debug + Clone,
 {
-    type Record = ConstantRecord;
+    type Record = EmptyRecord;
 
     fn visit<V: ModuleVisitor<B>>(&self, _visitor: &mut V) {
         // Nothing to do
@@ -283,7 +305,7 @@ where
     }
 
     fn into_record(self) -> Self::Record {
-        ConstantRecord::new()
+        EmptyRecord::new()
     }
 
     fn to_device(self, _: &Device<B>) -> Self {
@@ -299,6 +321,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<T> ModuleDisplayDefault for Ignored<T>
 where
     T: Sync + Send + core::fmt::Debug + Clone,
@@ -309,8 +332,10 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<T> ModuleDisplay for Ignored<T> where T: Sync + Send + core::fmt::Debug + Clone {}
 
+#[allow(deprecated)]
 impl<T> Display for Ignored<T>
 where
     T: Sync + Send + core::fmt::Debug + Clone,
@@ -320,6 +345,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<B: AutodiffBackend, T> AutodiffModule<B> for Ignored<T>
 where
     B: AutodiffBackend,
@@ -336,12 +362,46 @@ where
     }
 }
 
+#[allow(deprecated)]
 // Implement deref for Ignored
 impl<T> core::ops::Deref for Ignored<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+/// A record that persists a simple value.
+///
+/// This is used for fields marked with `#[module(constant)]`.
+#[derive(Debug, Clone, Copy, new)]
+pub struct ValueRecord<T> {
+    value: T,
+}
+
+impl<T> ValueRecord<T> {
+    /// Gets the value while consuming the record.
+    pub fn consume(self) -> T {
+        self.value
+    }
+}
+
+unsafe impl<T> Send for ValueRecord<T> {}
+
+impl<B: Backend, T> Record<B> for ValueRecord<T>
+where
+    T: Serialize + DeserializeOwned + Clone, // Record and item
+{
+    // The Item is the type T itself, as it already satisfies the bounds
+    type Item<S: PrecisionSettings> = T;
+
+    fn into_item<S: PrecisionSettings>(self) -> Self::Item<S> {
+        self.value
+    }
+
+    fn from_item<S: PrecisionSettings>(item: Self::Item<S>, _device: &B::Device) -> Self {
+        Self { value: item }
     }
 }
 

--- a/crates/burn-core/src/module/param/constant.rs
+++ b/crates/burn-core/src/module/param/constant.rs
@@ -387,11 +387,9 @@ impl<T> ValueRecord<T> {
     }
 }
 
-unsafe impl<T> Send for ValueRecord<T> {}
-
 impl<B: Backend, T> Record<B> for ValueRecord<T>
 where
-    T: Serialize + DeserializeOwned + Clone, // Record and item
+    T: Send + Serialize + DeserializeOwned + Clone, // Record and item
 {
     // The Item is the type T itself, as it already satisfies the bounds
     type Item<S: PrecisionSettings> = T;

--- a/crates/burn-core/tests/test_derive_module.rs
+++ b/crates/burn-core/tests/test_derive_module.rs
@@ -94,7 +94,7 @@ pub struct ModuleWithAttributes<B: Backend, M: Module<B>> {
     nested: ModuleEnumWithGenericModule<B, M>,
     /// By default, primitives were not persistent (same as `#[module(skip)]`).
     other_prob: f64,
-    /// By default, tensors were not persistent (same as `#[module(skip)]`).
+    /// By default, tensors were not persistent and not visited/mapped (same as `#[module(skip)]`).
     tensor: Tensor<B, 1>,
     /// A persistent config value.
     #[module(constant)]
@@ -105,6 +105,10 @@ pub struct ModuleWithAttributes<B: Backend, M: Module<B>> {
     /// A field that contains some debug state.
     #[module(skip)]
     debug_state: String,
+    // TODO: constant tensor (currently not supported due to default empty record behavior)
+    // /// A constant tensor (persisted, but not visited/mapped since it's not a param).
+    // #[module(constant)]
+    // tensor_const: Tensor<B, 1>,
 }
 
 impl<B: Backend> ModuleWithAttributes<B, ModuleBasic<B>> {
@@ -375,6 +379,13 @@ mod num_params {
 
         let module = ModuleEnum::Composed(ModuleComposed::<TestBackend>::new(&device));
         assert_eq!(4 * 20 * 20, module.num_params());
+    }
+
+    #[test]
+    fn should_calculate_num_params_based_on_attributes() {
+        let device = <TestBackend as Backend>::Device::default();
+        let module = ModuleWithAttributes::<TestBackend, _>::new(&device);
+        assert_eq!(20 * 20 * 2, module.num_params());
     }
 }
 

--- a/crates/burn-core/tests/test_derive_module.rs
+++ b/crates/burn-core/tests/test_derive_module.rs
@@ -89,9 +89,13 @@ impl<B: Backend> ModuleComposed<B> {
 #[derive(Module, Debug)]
 pub struct ModuleWithAttributes<B: Backend, M: Module<B>> {
     /// A normal parameter.
-    weights: Param<Tensor<B, 2>>,
+    weight: Param<Tensor<B, 2>>,
     /// A nested module.
     nested: ModuleEnumWithGenericModule<B, M>,
+    /// By default, primitives were not persistent (same as `#[module(skip)]`).
+    other_prob: f64,
+    /// By default, tensors were not persistent (same as `#[module(skip)]`).
+    tensor: Tensor<B, 1>,
     /// A persistent config value.
     #[module(constant)]
     dropout_prob: f64,
@@ -101,6 +105,23 @@ pub struct ModuleWithAttributes<B: Backend, M: Module<B>> {
     /// A field that contains some debug state.
     #[module(skip)]
     debug_state: String,
+}
+
+impl<B: Backend> ModuleWithAttributes<B, ModuleBasic<B>> {
+    fn new(device: &B::Device) -> Self {
+        let basic = ModuleBasic::new(device);
+        let weight = basic.weight_basic.clone();
+
+        Self {
+            weight: weight,
+            nested: ModuleEnumWithGenericModule::Basic(basic),
+            other_prob: 1.,
+            tensor: Tensor::ones([2], device),
+            dropout_prob: 0.,
+            cached_mask: Some(Tensor::ones([2, 2], device)),
+            debug_state: "Hello World".into(),
+        }
+    }
 }
 
 #[allow(dead_code)]
@@ -135,6 +156,8 @@ mod compiletime_clone_impl_check {
 }
 
 mod state {
+    use burn_core::module::{EmptyRecord, ValueRecord};
+
     use super::*;
 
     #[test]
@@ -204,6 +227,76 @@ mod state {
         assert_eq!(
             module_1_basic.weight_basic.to_data(),
             module_2_basic.weight_basic.to_data()
+        );
+    }
+
+    #[test]
+    fn should_load_from_record_based_on_attributes() {
+        let device = <TestBackend as Backend>::Device::default();
+        let mut module_1 = ModuleWithAttributes::<TestBackend, _>::new(&device);
+        let mut module_2 = ModuleWithAttributes::new(&device);
+
+        assert_ne!(module_1.weight.to_data(), module_2.weight.to_data(),);
+
+        let ModuleEnumWithGenericModule::Basic(ref m1_basic) = module_1.nested else {
+            panic!("Invalid module type")
+        };
+        let ModuleEnumWithGenericModule::Basic(ref m2_basic) = module_2.nested else {
+            panic!("Invalid module type")
+        };
+
+        assert_ne!(
+            m1_basic.weight_basic.to_data(),
+            m2_basic.weight_basic.to_data(),
+        );
+
+        assert_eq!(module_1.tensor.to_data(), module_2.tensor.to_data());
+        assert_eq!(
+            module_1.cached_mask.as_ref().unwrap().to_data(),
+            module_2.cached_mask.as_ref().unwrap().to_data()
+        );
+
+        assert_eq!(module_1.dropout_prob, module_2.dropout_prob);
+        assert_eq!(module_1.other_prob, module_2.other_prob);
+        assert_eq!(module_1.debug_state, module_2.debug_state);
+
+        // Alter state of constant and skipped fields to validate persistence
+        module_1.cached_mask = Some(module_1.cached_mask.unwrap() * 2);
+        module_1.tensor = module_1.tensor * 2;
+        module_1.dropout_prob = 1.0;
+        module_1.other_prob = 0.;
+        module_1.debug_state = "Hello World!".into();
+
+        let state_1 = module_1.clone().into_record();
+
+        assert_eq!(state_1.cached_mask, EmptyRecord);
+        assert_eq!(state_1.dropout_prob, ValueRecord::new(1.0));
+        assert_eq!(state_1.other_prob, EmptyRecord);
+        assert_eq!(state_1.debug_state, EmptyRecord);
+
+        module_2 = module_2.load_record(state_1);
+
+        let ModuleEnumWithGenericModule::Basic(m2_basic) = module_2.nested else {
+            panic!("Invalid module type")
+        };
+
+        // Modules & params
+        assert_eq!(module_1.weight.to_data(), module_2.weight.to_data(),);
+        assert_eq!(
+            m1_basic.weight_basic.to_data(),
+            m2_basic.weight_basic.to_data(),
+        );
+
+        // `#[module(constant)]`
+        assert_eq!(module_1.dropout_prob, module_2.dropout_prob);
+
+        // `#[module(skip)]` field and other skip-by-default
+        assert_ne!(module_1.other_prob, module_2.other_prob);
+        assert_ne!(module_1.debug_state, module_2.debug_state);
+        assert_ne!(module_1.tensor.to_data(), module_2.tensor.to_data());
+        assert_ne!(
+            module_1.cached_mask.as_ref().unwrap().to_data(),
+            module_2.cached_mask.as_ref().unwrap().to_data()
         );
     }
 

--- a/crates/burn-core/tests/test_derive_module.rs
+++ b/crates/burn-core/tests/test_derive_module.rs
@@ -86,6 +86,23 @@ impl<B: Backend> ModuleComposed<B> {
     }
 }
 
+#[derive(Module, Debug)]
+pub struct ModuleWithAttributes<B: Backend, M: Module<B>> {
+    /// A normal parameter.
+    weights: Param<Tensor<B, 2>>,
+    /// A nested module.
+    nested: ModuleEnumWithGenericModule<B, M>,
+    /// A persistent config value.
+    #[module(constant)]
+    dropout_prob: f64,
+    /// A field that is recomputed at runtime.
+    #[module(skip)]
+    cached_mask: Option<Tensor<B, 2>>,
+    /// A field that contains some debug state.
+    #[module(skip)]
+    debug_state: String,
+}
+
 #[allow(dead_code)]
 mod compiletime_clone_impl_check {
     use burn_core::{

--- a/crates/burn-core/tests/test_record_resilience.rs
+++ b/crates/burn-core/tests/test_record_resilience.rs
@@ -43,6 +43,7 @@ mod tests {
         linear1: Linear<B>,
         array_const: [usize; 2],
         linear2: Linear<B>,
+        array_lin: [Linear<B>; 2],
     }
 
     #[derive(Module, Debug)]
@@ -51,6 +52,7 @@ mod tests {
         linear1: Linear<B>,
         array_const: [usize; 2],
         linear2: Linear<B>,
+        array_lin: [Linear<B>; 2],
         new_field: Option<usize>,
     }
 
@@ -60,6 +62,7 @@ mod tests {
         linear1: Linear<B>,
         array_const: [usize; 2],
         linear2: Linear<B>,
+        array_lin: [Linear<B>; 2],
         new_field: usize,
     }
 
@@ -69,6 +72,7 @@ mod tests {
         array_const: [usize; 2],
         linear2: Linear<B>,
         single_const: f32,
+        array_lin: [Linear<B>; 2],
         linear1: Linear<B>,
     }
 
@@ -162,8 +166,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn deserialize_with_new_optional_field_doesnt_works_with_bin_file_recorder() {
+    fn deserialize_with_new_optional_field_works_with_bin_file_recorder() {
         deserialize_with_new_optional_field("bin", BinFileRecorder::<FullPrecisionSettings>::new())
             .unwrap();
     }
@@ -193,7 +196,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn deserialize_with_new_field_order_works_with_bin_file_recorder() {
         deserialize_with_new_field_order("bin", BinFileRecorder::<FullPrecisionSettings>::new())
             .unwrap();
@@ -224,6 +226,10 @@ mod tests {
             linear1: Linear::<TestBackend>::new(20, 20, &device),
             array_const: [2, 2],
             linear2: Linear::<TestBackend>::new(20, 20, &device),
+            array_lin: [
+                Linear::<TestBackend>::new(20, 20, &device),
+                Linear::<TestBackend>::new(20, 20, &device),
+            ],
         };
 
         recorder
@@ -252,6 +258,10 @@ mod tests {
             linear1: Linear::<TestBackend>::new(20, 20, &device),
             array_const: [2, 2],
             linear2: Linear::<TestBackend>::new(20, 20, &device),
+            array_lin: [
+                Linear::<TestBackend>::new(20, 20, &device),
+                Linear::<TestBackend>::new(20, 20, &device),
+            ],
             new_field: None,
         };
 
@@ -276,6 +286,10 @@ mod tests {
             array_const: [2, 2],
             linear1: Linear::<TestBackend>::new(20, 20, &device),
             linear2: Linear::<TestBackend>::new(20, 20, &device),
+            array_lin: [
+                Linear::<TestBackend>::new(20, 20, &device),
+                Linear::<TestBackend>::new(20, 20, &device),
+            ],
         };
 
         recorder
@@ -304,6 +318,10 @@ mod tests {
             array_const: [2, 2],
             linear1: Linear::<TestBackend>::new(20, 20, &device),
             linear2: Linear::<TestBackend>::new(20, 20, &device),
+            array_lin: [
+                Linear::<TestBackend>::new(20, 20, &device),
+                Linear::<TestBackend>::new(20, 20, &device),
+            ],
             new_field: 0,
         };
 
@@ -328,6 +346,10 @@ mod tests {
             single_const: 32.0,
             linear1: Linear::<TestBackend>::new(20, 20, &device),
             linear2: Linear::<TestBackend>::new(20, 20, &device),
+            array_lin: [
+                Linear::<TestBackend>::new(20, 20, &device),
+                Linear::<TestBackend>::new(20, 20, &device),
+            ],
         };
 
         recorder

--- a/crates/burn-derive/src/lib.rs
+++ b/crates/burn-derive/src/lib.rs
@@ -15,7 +15,7 @@ pub(crate) mod shared;
 // TODO: change nn modules `#[module(skip)]` (currently used for backward compat)
 // to `#[module(constant)` for persistent non-parameter fields.
 
-/// Derive macro for the [`Module`](burn::module::Module) trait.
+/// Derive macro for the `Module` trait.
 ///
 /// # Field Attributes
 ///

--- a/crates/burn-derive/src/lib.rs
+++ b/crates/burn-derive/src/lib.rs
@@ -12,7 +12,50 @@ pub(crate) mod module;
 pub(crate) mod record;
 pub(crate) mod shared;
 
-/// Derive macro for the module.
+// TODO: change nn modules `#[module(skip)]` (currently used for backward compat)
+// to `#[module(constant)` for persistent non-parameter fields.
+
+/// Derive macro for the [`Module`](burn::module::Module) trait.
+///
+/// # Field Attributes
+///
+/// By default, every field in a `Module` is treated as a sub-module or a parameter.
+/// You can change this behavior using the `#[module]` attribute.
+///
+/// ## `#[module(constant)]`
+///
+/// Marks the field as a constant value. Constants are not parameters or modules, but are persistent.
+///
+/// Use this for configuration or other persistent metadata that should be saved and loaded with the module.
+///
+/// ## `#[module(skip)]`
+///
+/// Marks the field to be skipped by the module system. Skipped fields are
+/// not parameters, not modules, and are not persistent.
+///
+/// Use this for fields that should not be saved or restored with the module,
+/// such as markers, caches or other auxiliary runtime state.
+///
+/// This is equivalent to the deprecated `Ignored<T>` wrapper.
+///
+/// # Example
+///
+/// ```ignore
+/// #[derive(Module, Debug)]
+/// pub struct MyModule<B: Backend> {
+///     /// A normal parameter.
+///     weights: Param<Tensor<B, 2>>,
+///     /// A persistent config value.
+///     #[module(constant)]
+///     dropout_prob: f64,
+///     /// A field that is recomputed at runtime.
+///     #[module(skip)]
+///     cached_mask: Option<Tensor<B, 2>>,
+///     /// A field that contains some debug state.
+///     #[module(skip)]
+///     debug_state: String,
+/// }
+/// ```
 #[proc_macro_derive(Module, attributes(module))]
 pub fn module_derive(input: TokenStream) -> TokenStream {
     let input = syn::parse(input).unwrap();

--- a/crates/burn-derive/src/lib.rs
+++ b/crates/burn-derive/src/lib.rs
@@ -28,6 +28,10 @@ pub(crate) mod shared;
 ///
 /// Use this for configuration or other persistent metadata that should be saved and loaded with the module.
 ///
+/// ### Requirements
+///
+/// The field must implement: `Debug + Clone + Send + Serialize + DeserializeOwned`.
+///
 /// ## `#[module(skip)]`
 ///
 /// Marks the field to be skipped by the module system. Skipped fields are
@@ -37,6 +41,10 @@ pub(crate) mod shared;
 /// such as markers, caches or other auxiliary runtime state.
 ///
 /// This is equivalent to the deprecated `Ignored<T>` wrapper.
+///
+/// ### Requirements
+///
+/// The field must implement: `Debug + Clone + Send`.
 ///
 /// # Example
 ///

--- a/crates/burn-derive/src/module/base.rs
+++ b/crates/burn-derive/src/module/base.rs
@@ -14,13 +14,16 @@ pub(crate) fn derive_impl(ast: &syn::DeriveInput) -> TokenStream {
         .unwrap_or(false);
 
     match &ast.data {
-        syn::Data::Struct(_) => {
-            if has_backend {
-                generate_module_standard(ast, StructModuleCodegen::from_ast(ast))
-            } else {
-                generate_module_const(ast)
+        syn::Data::Struct(_) => match StructModuleCodegen::from_ast(ast) {
+            Ok(struct_codegen) => {
+                if has_backend {
+                    generate_module_standard(ast, struct_codegen)
+                } else {
+                    generate_module_const(ast)
+                }
             }
-        }
+            Err(err) => err.to_compile_error(),
+        },
         syn::Data::Enum(_data) => match EnumModuleCodegen::from_ast(ast) {
             Ok(enum_codegen) => {
                 if has_backend {

--- a/crates/burn-derive/src/module/codegen.rs
+++ b/crates/burn-derive/src/module/codegen.rs
@@ -237,9 +237,6 @@ impl GenericsParser {
                 requires_module_bound = has_module_bound || maybe_module;
             }
 
-            eprintln!("requires_module_bound: {requires_module_bound}");
-            eprintln!("module generics: {module_generics:?}");
-
             if requires_module_bound {
                 module.add_predicate(
                     parse_quote! {

--- a/crates/burn-derive/src/module/codegen_struct.rs
+++ b/crates/burn-derive/src/module/codegen_struct.rs
@@ -443,7 +443,7 @@ pub(crate) fn parse_module_field_type(
                 }?;
 
                 if is_param && field_type.attr.is_some() {
-                    Err(meta.error("Fields of type 'Param' cannot be marked as 'constant' or 'skip'. Use a 'Tensor' instead."))
+                    Err(meta.error("Fields of type 'Param' should not be marked as 'constant' or 'skip'. Use a 'Tensor' instead."))
                 } else {
                     Ok(())
                 }

--- a/crates/burn-derive/src/module/codegen_struct.rs
+++ b/crates/burn-derive/src/module/codegen_struct.rs
@@ -400,7 +400,7 @@ pub(crate) fn parse_module_field_type(
     // Check for generics
     let mut has_backend = false;
     let mut has_module_bound = false;
-    let field_generics = parse_ty_generics(&field.ty, &generics)
+    let field_generics = parse_ty_generics(&field.ty, generics)
         .into_iter()
         .filter_map(|ident| {
             if ident == "B" {

--- a/crates/burn-derive/src/module/codegen_struct.rs
+++ b/crates/burn-derive/src/module/codegen_struct.rs
@@ -422,12 +422,16 @@ pub(crate) fn parse_module_field_type(
         if attr.path().is_ident("module") {
             attr.parse_nested_meta(|meta| {
                 if meta.path.is_ident("constant") {
-                    // Mark field attribute and generic
-                    field_type.attr = Some(ModuleFieldAttribute::Constant);
-                    for ty in &field_generics {
-                        generics.update(ty, GenericKind::Constant);
+                    if is_tensor {
+                        Err(meta.error("Fields of type 'Tensor' cannot be marked as 'constant' due to the current default behavior."))
+                    } else {
+                        // Mark field attribute and generic
+                        field_type.attr = Some(ModuleFieldAttribute::Constant);
+                        for ty in &field_generics {
+                            generics.update(ty, GenericKind::Constant);
+                        }
+                        Ok(())
                     }
-                    Ok(())
                 } else if meta.path.is_ident("skip") {
                     // Mark field attribute and generic
                     field_type.attr = Some(ModuleFieldAttribute::Skip);

--- a/crates/burn-derive/src/module/codegen_struct.rs
+++ b/crates/burn-derive/src/module/codegen_struct.rs
@@ -1,22 +1,32 @@
+use std::collections::HashSet;
+
+use crate::module::generics::{
+    GenericKind, ModuleGenerics, parse_module_generics, parse_ty_generics,
+};
+
 use super::{codegen::ModuleCodegen, record_struct::StructModuleRecordCodegen};
-use crate::shared::field::{FieldTypeAnalyzer, parse_fields};
 use proc_macro2::{Ident, TokenStream};
-use quote::quote;
-use syn::Visibility;
+use quote::{ToTokens, quote};
+use syn::{Field, Visibility};
 
 pub(crate) struct StructModuleCodegen {
     pub name: Ident,
-    pub fields: Vec<FieldTypeAnalyzer>,
+    pub fields: Vec<ModuleField>,
     pub vis: Visibility,
+    pub generics: ModuleGenerics,
 }
 
 impl ModuleCodegen for StructModuleCodegen {
     type RecordCodegen = StructModuleRecordCodegen;
 
     fn gen_num_params(&self) -> TokenStream {
-        let body = self.gen_fields_fn(|name| {
-            quote! {
-                num_params += burn::module::Module::<B>::num_params(&self.#name);
+        let body = self.gen_fields_fn(|name, field_type| {
+            if field_type.is_parameter_module() || field_type.maybe_generic_module() {
+                quote! {
+                    num_params += burn::module::Module::<B>::num_params(&self.#name);
+                }
+            } else {
+                quote! {} // other fields have 0 params
             }
         });
 
@@ -32,12 +42,16 @@ impl ModuleCodegen for StructModuleCodegen {
     fn gen_visit(&self) -> TokenStream {
         let struct_name = self.name.to_string();
         let container_type = format!("Struct:{}", struct_name);
-        let body = self.gen_fields_fn(|name| {
-            let name_str = name.to_string();
-            quote! {
-                visitor.enter_module(#name_str, #container_type);
-                burn::module::Module::visit(&self.#name, visitor);
-                visitor.exit_module(#name_str, #container_type);
+        let body = self.gen_fields_fn(|name, field_type| {
+            if field_type.is_parameter_module() || field_type.maybe_generic_module() {
+                let name_str = name.to_string();
+                quote! {
+                    visitor.enter_module(#name_str, #container_type);
+                    burn::module::Module::visit(&self.#name, visitor);
+                    visitor.exit_module(#name_str, #container_type);
+                }
+            } else {
+                quote! {}
             }
         });
 
@@ -49,9 +63,13 @@ impl ModuleCodegen for StructModuleCodegen {
     }
 
     fn gen_collect_devices(&self) -> TokenStream {
-        let body = self.gen_fields_fn(|name| {
-            quote! {
-                let devices = burn::module::Module::<B>::collect_devices(&self.#name, devices);
+        let body = self.gen_fields_fn(|name, field_type| {
+            if field_type.is_module || field_type.maybe_generic_module() {
+                quote! {
+                    let devices = burn::module::Module::<B>::collect_devices(&self.#name, devices);
+                }
+            } else {
+                quote! {}
             }
         });
 
@@ -61,44 +79,45 @@ impl ModuleCodegen for StructModuleCodegen {
                 devices: burn::module::Devices<B>
             ) -> burn::module::Devices<B> {
                 #body
-
                 devices
             }
         }
     }
 
     fn gen_to_device(&self) -> TokenStream {
-        let (names, body) = self.gen_fields_fn_names(|name| {
-            quote! {
-                let #name = burn::module::Module::<B>::to_device(self.#name, device);
+        let (names, body) = self.gen_fields_fn_names(|name, field_type| {
+            if field_type.is_module || field_type.maybe_generic_module() {
+                quote! {
+                    let #name = burn::module::Module::<B>::to_device(self.#name, device);
+                }
+            } else {
+                quote! { let #name = self.#name; }
             }
         });
 
         quote! {
             fn to_device(self, device: &B::Device) -> Self {
                 #body
-
-                Self {
-                    #(#names),*
-                }
+                Self { #(#names),* }
             }
         }
     }
 
     fn gen_fork(&self) -> TokenStream {
-        let (names, body) = self.gen_fields_fn_names(|name| {
-            quote! {
-                let #name = burn::module::Module::<B>::fork(self.#name, device);
+        let (names, body) = self.gen_fields_fn_names(|name, field_type| {
+            if field_type.is_module || field_type.maybe_generic_module() {
+                quote! {
+                    let #name = burn::module::Module::<B>::fork(self.#name, device);
+                }
+            } else {
+                quote! { let #name = self.#name; }
             }
         });
 
         quote! {
             fn fork(self, device: &B::Device) -> Self {
                 #body
-
-                Self {
-                    #(#names),*
-                }
+                Self { #(#names),* }
             }
         }
     }
@@ -106,52 +125,57 @@ impl ModuleCodegen for StructModuleCodegen {
     fn gen_map(&self) -> TokenStream {
         let struct_name = self.name.to_string();
         let container_type = format!("Struct:{}", struct_name);
-        let (names, body) = self.gen_fields_fn_names(|name| {
-            let name_str = name.to_string();
-            quote! {
-                mapper.enter_module(#name_str, #container_type);
-                let #name = burn::module::Module::<B>::map(self.#name, mapper);
-                mapper.exit_module(#name_str, #container_type);
+        let (names, body) = self.gen_fields_fn_names(|name, field_type| {
+            if field_type.is_parameter_module() || field_type.maybe_generic_module() {
+                let name_str = name.to_string();
+                quote! {
+                    mapper.enter_module(#name_str, #container_type);
+                    let #name = burn::module::Module::<B>::map(self.#name, mapper);
+                    mapper.exit_module(#name_str, #container_type);
+                }
+            } else {
+                quote! { let #name = self.#name; }
             }
         });
 
         quote! {
             fn map<Mapper: burn::module::ModuleMapper<B>>(self, mapper: &mut Mapper) -> Self {
                 #body
-
-                Self {
-                    #(#names),*
-                }
+                Self { #(#names),* }
             }
         }
     }
 
     fn gen_valid(&self) -> TokenStream {
-        let (names, body) = self.gen_fields_fn_names(|name| {
-            quote! {
-                let #name = burn::module::AutodiffModule::<B>::valid(&self.#name);
+        let (names, body) = self.gen_fields_fn_names(|name, field_type| {
+            if field_type.is_module || field_type.maybe_generic_module() {
+                quote! {
+                    let #name = burn::module::AutodiffModule::<B>::valid(&self.#name);
+                }
+            } else {
+                quote! { let #name = self.#name.clone(); }
             }
         });
 
         quote! {
             fn valid(&self) -> Self::InnerModule {
                 #body
-
-                Self::InnerModule {
-                    #(#names),*
-                }
+                Self::InnerModule { #(#names),* }
             }
         }
     }
 
     fn gen_from_inner(&self) -> TokenStream {
-        let (names, body) = self.gen_fields_fn_names(|name| {
-            quote! {
-                let #name = burn::module::AutodiffModule::<B>::from_inner(#name);
+        let (names, body) = self.gen_fields_fn_names(|name, field_type| {
+            if field_type.is_module || field_type.maybe_generic_module() {
+                quote! {
+                    let #name = burn::module::AutodiffModule::<B>::from_inner(#name);
+                }
+            } else {
+                quote! { let #name = #name; }
             }
         });
 
-        // Destructure inner module to move all fields
         let destructure = quote! {
             let Self::InnerModule { #(#names),* } = module;
         };
@@ -160,48 +184,61 @@ impl ModuleCodegen for StructModuleCodegen {
             fn from_inner(module: Self::InnerModule) -> Self {
                 #destructure
                 #body
-
-                Self {
-                    #(#names),*
-                }
+                Self { #(#names),* }
             }
         }
     }
 
     fn gen_into_record(&self) -> TokenStream {
-        let body = self.gen_fields_fn(|name| {
-            quote! {
-                #name: burn::module::Module::<B>::into_record(self.#name),
+        let body = self.gen_fields_fn(|name, field_type| {
+            if field_type.is_persistent_module() || field_type.maybe_generic_module() {
+                quote! { #name: burn::module::Module::<B>::into_record(self.#name), }
+            } else {
+                match field_type.attr {
+                    Some(ModuleFieldAttribute::Constant) => {
+                        quote! { #name: burn::module::ValueRecord::new(self.#name), }
+                    }
+                    // Default (None) gets skipped
+                    None | Some(ModuleFieldAttribute::Skip) => {
+                        quote! { #name: burn::module::EmptyRecord::new(), }
+                    }
+                }
             }
         });
 
         quote! {
             fn into_record(self) -> Self::Record {
-                Self::Record {
-                    #body
-                }
+                Self::Record { #body }
             }
         }
     }
 
     fn gen_load_record(&self) -> TokenStream {
-        let body = self.gen_fields_fn(|name| {
-            quote! {
-                #name: burn::module::Module::<B>::load_record(self.#name, record.#name),
+        let body = self.gen_fields_fn(|name, field_type| {
+            if field_type.is_persistent_module() || field_type.maybe_generic_module() {
+                quote! { #name: burn::module::Module::<B>::load_record(self.#name, record.#name), }
+            } else {
+                match field_type.attr {
+                    Some(ModuleFieldAttribute::Constant) => {
+                        quote! { #name: record.#name.consume(), }
+                    }
+                    // Default (None) gets skipped
+                    None | Some(ModuleFieldAttribute::Skip) => {
+                        quote! { #name: self.#name, }
+                    }
+                }
             }
         });
 
         quote! {
             fn load_record(self, record: Self::Record) -> Self {
-                Self {
-                    #body
-                }
+                Self { #body }
             }
         }
     }
 
     fn gen_clone(&self) -> TokenStream {
-        let (names, body) = self.gen_fields_fn_names(|name| {
+        let (names, body) = self.gen_fields_fn_names(|name, _field_type| {
             quote! {
                 let #name = self.#name.clone();
             }
@@ -210,10 +247,7 @@ impl ModuleCodegen for StructModuleCodegen {
         quote! {
             fn clone(&self) -> Self {
                 #body
-
-                Self {
-                    #(#names),*
-                }
+                Self { #(#names),* }
             }
         }
     }
@@ -221,23 +255,50 @@ impl ModuleCodegen for StructModuleCodegen {
     fn record_codegen(self) -> Self::RecordCodegen {
         StructModuleRecordCodegen::new(self.fields, self.vis)
     }
+
+    fn module_generics(&self) -> &ModuleGenerics {
+        &self.generics
+    }
+
+    fn gen_display(&self) -> TokenStream {
+        let struct_name = self.name.to_string();
+        let field_prints = self.fields.iter().map(|field| {
+            let field_name = field.ident();
+            if field.field_type.is_module || field.field_type.maybe_generic_module() {
+                // Standard module type, use underlying `ModuleDisplay` impl
+                quote! { .add(stringify!(#field_name), &self.#field_name) }
+            } else {
+                // Not a module, use the debug implementation
+                quote! {
+                    .add_debug_attribute(stringify!(#field_name), &self.#field_name)
+                }
+            }
+        });
+        quote! {
+            fn content(&self, mut content: burn::module::Content) -> Option<burn::module::Content> {
+                content
+                    .set_top_level_type(&stringify!(#struct_name))
+                    #(#field_prints)*
+                    .optional()
+            }
+        }
+    }
 }
 
 impl StructModuleCodegen {
-    pub fn from_ast(ast: &syn::DeriveInput) -> Self {
-        Self {
+    pub fn from_ast(ast: &syn::DeriveInput) -> syn::Result<Self> {
+        let mut generics = parse_module_generics(&ast.generics);
+        Ok(Self {
             name: ast.ident.clone(),
-            fields: parse_fields(ast)
-                .into_iter()
-                .map(FieldTypeAnalyzer::new)
-                .collect(),
+            fields: parse_module_fields(ast, &mut generics)?,
             vis: ast.vis.clone(),
-        }
+            generics,
+        })
     }
 
     fn gen_fields_fn_names<F>(&self, func: F) -> (Vec<Ident>, TokenStream)
     where
-        F: Fn(Ident) -> TokenStream,
+        F: Fn(Ident, &ModuleFieldType) -> TokenStream,
     {
         let mut body = quote! {};
         let mut names = Vec::new();
@@ -246,7 +307,7 @@ impl StructModuleCodegen {
             let name = field.ident();
 
             names.push(name.clone());
-            body.extend(func(field.ident()));
+            body.extend(func(name, &field.field_type));
         }
 
         (names, body)
@@ -254,14 +315,173 @@ impl StructModuleCodegen {
 
     fn gen_fields_fn<F>(&self, func: F) -> TokenStream
     where
-        F: Fn(Ident) -> TokenStream,
+        F: Fn(Ident, &ModuleFieldType) -> TokenStream,
     {
         let mut body = quote! {};
 
         for field in self.fields.iter() {
-            body.extend(func(field.ident()));
+            body.extend(func(field.ident(), &field.field_type));
         }
 
         body
     }
+}
+
+#[derive(new)]
+pub struct ModuleField {
+    pub field: Field,
+    pub field_type: ModuleFieldType,
+}
+
+impl ModuleField {
+    pub fn ident(&self) -> Ident {
+        self.field.ident.clone().unwrap()
+    }
+}
+
+#[derive(Debug)]
+pub enum ModuleFieldAttribute {
+    Constant,
+    Skip,
+}
+
+#[derive(Default, Debug)]
+pub struct ModuleFieldType {
+    pub is_module: bool,
+    pub attr: Option<ModuleFieldAttribute>,
+    pub generic_idents: HashSet<Ident>,
+}
+
+impl ModuleFieldType {
+    /// Returns true if the field is a module with parameters
+    /// (i.e., a real module that is neither skipped nor constant).
+    pub fn is_parameter_module(&self) -> bool {
+        self.is_module && self.attr.is_none()
+    }
+
+    /// Returns true for modules that should be persisted, including constants.
+    pub fn is_persistent_module(&self) -> bool {
+        self.is_module && !matches!(self.attr, Some(ModuleFieldAttribute::Skip))
+    }
+
+    /// Returns true for generic fields that are assumed to be modules.
+    pub fn maybe_generic_module(&self) -> bool {
+        // We assumed it might be a module generic if the field is not marked
+        // by any attributes (skip or constant)
+        !self.generic_idents.is_empty() && self.attr.is_none()
+    }
+}
+
+pub(crate) fn parse_module_fields(
+    ast: &syn::DeriveInput,
+    generics: &mut ModuleGenerics,
+) -> syn::Result<Vec<ModuleField>> {
+    let mut fields = Vec::new();
+
+    match &ast.data {
+        syn::Data::Struct(struct_data) => {
+            for field in struct_data.fields.iter() {
+                let field_type = parse_module_field_type(field, generics)?;
+                fields.push(ModuleField::new(field.clone(), field_type));
+            }
+        }
+        syn::Data::Enum(_) => panic!("Only struct can be derived"),
+        syn::Data::Union(_) => panic!("Only struct can be derived"),
+    };
+    Ok(fields)
+}
+
+pub(crate) fn parse_module_field_type(
+    field: &Field,
+    generics: &mut ModuleGenerics,
+) -> syn::Result<ModuleFieldType> {
+    let mut field_type = ModuleFieldType::default();
+
+    // Check for generics
+    let mut has_backend = false;
+    let mut has_module_bound = false;
+    let field_generics = parse_ty_generics(&field.ty)
+        .into_iter()
+        .filter_map(|ident| {
+            if ident == "B" {
+                has_backend = true;
+                None
+            } else if generics.is_bounded_module(&ident) {
+                has_module_bound = true;
+                None
+            } else {
+                Some(ident)
+            }
+        })
+        .collect::<HashSet<_>>();
+
+    // Infer if a field is a module
+    let is_primitive = is_primitive_type(&field.ty);
+    let is_param = is_param_type(&field.ty);
+    let is_tensor = is_tensor_type(&field.ty);
+
+    for attr in &field.attrs {
+        if attr.path().is_ident("module") {
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("constant") {
+                    // Mark field attribute and generic
+                    field_type.attr = Some(ModuleFieldAttribute::Constant);
+                    for ty in &field_generics {
+                        generics.update(ty, GenericKind::Constant);
+                    }
+                    Ok(())
+                } else if meta.path.is_ident("skip") {
+                    // Mark field attribute and generic
+                    field_type.attr = Some(ModuleFieldAttribute::Skip);
+                    for ty in &field_generics {
+                        generics.update(ty, GenericKind::Skip);
+                    }
+                    Ok(())
+                } else {
+                    let path = meta.path.to_token_stream().to_string();
+                    Err(meta.error(format!("Unsupported module attribute: {}", path)))
+                }?;
+
+                if is_param && field_type.attr.is_some() {
+                    Err(meta.error("Fields of type 'Param' cannot be marked as 'constant' or 'skip'. Use a 'Tensor' instead."))
+                } else {
+                    Ok(())
+                }
+            })?;
+        }
+    }
+
+    field_type.is_module =
+        !is_primitive && (has_module_bound || is_param || is_tensor || has_backend);
+    field_type.generic_idents = field_generics;
+
+    Ok(field_type)
+}
+
+fn type_matches_ident(ty: &syn::Type, idents: &[&str]) -> bool {
+    if let syn::Type::Path(type_path) = ty {
+        // Look at the last segment of the path (e.g., 'Param' in 'burn::module::Param')
+        if let Some(segment) = type_path.path.segments.last() {
+            return idents.contains(&segment.ident.to_string().as_str());
+        }
+    }
+    false
+}
+
+fn is_primitive_type(ty: &syn::Type) -> bool {
+    type_matches_ident(
+        ty,
+        &[
+            "bool", "u8", "u16", "u32", "u64", "usize", "i8", "i16", "i32", "i64", "isize", "f32",
+            "f64", "String",
+        ],
+    )
+}
+
+fn is_tensor_type(ty: &syn::Type) -> bool {
+    type_matches_ident(ty, &["Tensor"])
+}
+
+fn is_param_type(ty: &syn::Type) -> bool {
+    type_matches_ident(ty, &["Param"])
 }

--- a/crates/burn-derive/src/module/codegen_struct.rs
+++ b/crates/burn-derive/src/module/codegen_struct.rs
@@ -400,16 +400,14 @@ pub(crate) fn parse_module_field_type(
     // Check for generics
     let mut has_backend = false;
     let mut has_module_bound = false;
-    let field_generics = parse_ty_generics(&field.ty)
+    let field_generics = parse_ty_generics(&field.ty, &generics)
         .into_iter()
         .filter_map(|ident| {
             if ident == "B" {
                 has_backend = true;
                 None
-            } else if generics.is_bounded_module(&ident) {
-                has_module_bound = true;
-                None
             } else {
+                has_module_bound = generics.is_bounded_module(&ident);
                 Some(ident)
             }
         })

--- a/crates/burn-derive/src/module/generics.rs
+++ b/crates/burn-derive/src/module/generics.rs
@@ -1,0 +1,126 @@
+use std::collections::{HashMap, HashSet};
+
+use proc_macro2::Ident;
+use syn::{GenericParam, Generics, Type, TypeParamBound, WherePredicate, visit::Visit};
+
+#[derive(Debug)]
+pub enum GenericKind {
+    /// A generic with `Module<B>` bound.
+    Module,
+    /// A generic used in a field marked by `#[module(constant)]`.
+    Constant,
+    /// A generic used in a field marked by `#[module(skip)]`.
+    Skip,
+    /// A plain generic that does not fit any of the above conditions.
+    Plain,
+}
+
+#[derive(Debug)]
+pub struct ModuleGenerics {
+    kinds: HashMap<Ident, GenericKind>,
+}
+
+impl ModuleGenerics {
+    pub fn is_empty(&self) -> bool {
+        self.kinds.is_empty()
+    }
+
+    pub fn is_bounded_module(&self, ident: &Ident) -> bool {
+        self.kinds
+            .get(ident)
+            .map(|kind| matches!(kind, GenericKind::Module))
+            .unwrap_or(false)
+    }
+
+    pub fn is_plain_type(&self, ident: &Ident) -> bool {
+        self.kinds
+            .get(ident)
+            .map(|kind| matches!(kind, GenericKind::Plain))
+            .unwrap_or(false)
+    }
+
+    pub fn update(&mut self, ident: &Ident, kind: GenericKind) {
+        self.kinds.insert(ident.clone(), kind);
+    }
+}
+
+pub fn parse_module_generics(generics: &Generics) -> ModuleGenerics {
+    let mut kinds = HashMap::new();
+
+    // Check inline bounds e.g. `M: Module<B>`
+    for param in &generics.params {
+        if let GenericParam::Type(type_param) = param {
+            let ident = &type_param.ident;
+            if ident != "B" {
+                if has_module_bound(&type_param.bounds) {
+                    kinds.insert(ident.clone(), GenericKind::Module);
+                } else {
+                    kinds.insert(ident.clone(), GenericKind::Plain);
+                }
+            }
+        }
+    }
+
+    // Check `where` clauses
+    if let Some(where_clause) = &generics.where_clause {
+        for predicate in &where_clause.predicates {
+            if let WherePredicate::Type(pt) = predicate {
+                // We only care if the bounded type is a simple identifier (like 'M')
+                if let Type::Path(p) = &pt.bounded_ty {
+                    if let Some(ident) = p.path.get_ident()
+                        && ident != "B"
+                    {
+                        if has_module_bound(&pt.bounds) {
+                            kinds.insert(ident.clone(), GenericKind::Module);
+                        } else {
+                            kinds.insert(ident.clone(), GenericKind::Plain);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    ModuleGenerics { kinds }
+}
+
+/// Helper to check if a list of bounds contains "Module".
+fn has_module_bound(
+    bounds: &syn::punctuated::Punctuated<TypeParamBound, syn::token::Plus>,
+) -> bool {
+    bounds.iter().any(|bound| {
+        if let TypeParamBound::Trait(trait_bound) = bound {
+            if let Some(segment) = trait_bound.path.segments.last() {
+                return segment.ident == "Module";
+            }
+        }
+        false
+    })
+}
+
+pub fn parse_ty_generics(ty: &Type) -> HashSet<Ident> {
+    struct Collector {
+        generics: HashSet<Ident>,
+    }
+
+    impl<'ast> Visit<'ast> for Collector {
+        fn visit_type_path(&mut self, type_path: &'ast syn::TypePath) {
+            // Capture generic identifiers like `M`, `B`, etc.
+            if type_path.qself.is_none() {
+                if let Some(ident) = type_path.path.get_ident() {
+                    self.generics.insert(ident.clone());
+                }
+            }
+
+            // Continue recursion
+            syn::visit::visit_type_path(self, type_path);
+        }
+    }
+
+    let mut collector = Collector {
+        generics: HashSet::new(),
+    };
+    collector.visit_type(ty);
+
+    collector.generics
+}

--- a/crates/burn-derive/src/module/generics.rs
+++ b/crates/burn-derive/src/module/generics.rs
@@ -66,15 +66,14 @@ pub fn parse_module_generics(generics: &Generics) -> ModuleGenerics {
         for predicate in &where_clause.predicates {
             if let WherePredicate::Type(pt) = predicate {
                 // We only care if the bounded type is a simple identifier (like 'M')
-                if let Type::Path(p) = &pt.bounded_ty {
-                    if let Some(ident) = p.path.get_ident()
-                        && ident != "B"
-                    {
-                        if has_module_bound(&pt.bounds) {
-                            kinds.insert(ident.clone(), GenericKind::Module);
-                        } else {
-                            kinds.insert(ident.clone(), GenericKind::Plain);
-                        }
+                if let Type::Path(p) = &pt.bounded_ty
+                    && let Some(ident) = p.path.get_ident()
+                    && ident != "B"
+                {
+                    if has_module_bound(&pt.bounds) {
+                        kinds.insert(ident.clone(), GenericKind::Module);
+                    } else {
+                        kinds.insert(ident.clone(), GenericKind::Plain);
                     }
                 }
             }
@@ -89,10 +88,10 @@ fn has_module_bound(
     bounds: &syn::punctuated::Punctuated<TypeParamBound, syn::token::Plus>,
 ) -> bool {
     bounds.iter().any(|bound| {
-        if let TypeParamBound::Trait(trait_bound) = bound {
-            if let Some(segment) = trait_bound.path.segments.last() {
-                return segment.ident == "Module";
-            }
+        if let TypeParamBound::Trait(trait_bound) = bound
+            && let Some(segment) = trait_bound.path.segments.last()
+        {
+            return segment.ident == "Module";
         }
         false
     })
@@ -106,10 +105,10 @@ pub fn parse_ty_generics(ty: &Type) -> HashSet<Ident> {
     impl<'ast> Visit<'ast> for Collector {
         fn visit_type_path(&mut self, type_path: &'ast syn::TypePath) {
             // Capture generic identifiers like `M`, `B`, etc.
-            if type_path.qself.is_none() {
-                if let Some(ident) = type_path.path.get_ident() {
-                    self.generics.insert(ident.clone());
-                }
+            if type_path.qself.is_none()
+                && let Some(ident) = type_path.path.get_ident()
+            {
+                self.generics.insert(ident.clone());
             }
 
             // Continue recursion

--- a/crates/burn-derive/src/module/generics.rs
+++ b/crates/burn-derive/src/module/generics.rs
@@ -25,17 +25,14 @@ impl ModuleGenerics {
         self.kinds.is_empty()
     }
 
+    pub fn get_generic_kind(&self, ident: &Ident) -> Option<&GenericKind> {
+        self.kinds.get(ident)
+    }
+
     pub fn is_bounded_module(&self, ident: &Ident) -> bool {
         self.kinds
             .get(ident)
             .map(|kind| matches!(kind, GenericKind::Module))
-            .unwrap_or(false)
-    }
-
-    pub fn is_plain_type(&self, ident: &Ident) -> bool {
-        self.kinds
-            .get(ident)
-            .map(|kind| matches!(kind, GenericKind::Plain))
             .unwrap_or(false)
     }
 

--- a/crates/burn-derive/src/module/mod.rs
+++ b/crates/burn-derive/src/module/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod codegen;
 pub(crate) mod codegen_enum;
 pub(crate) mod codegen_struct;
 pub(crate) mod display;
+pub(crate) mod generics;
 pub(crate) mod record;
 pub(crate) mod record_enum;
 pub(crate) mod record_struct;

--- a/crates/burn-derive/src/module/record.rs
+++ b/crates/burn-derive/src/module/record.rs
@@ -4,5 +4,5 @@ use syn::Generics;
 /// Basic trait to generate a record type based on the Module struct.
 pub(crate) trait ModuleRecordCodegen {
     /// Generate the record type (i.e a struct)
-    fn gen_record_type(&self, record_name: &Ident, generics: &Generics) -> TokenStream;
+    fn gen_record_type(&self, record_name: &Ident, generics: &Generics) -> (TokenStream, Generics);
 }

--- a/crates/burn-derive/src/module/record_enum.rs
+++ b/crates/burn-derive/src/module/record_enum.rs
@@ -12,7 +12,7 @@ pub(crate) struct EnumModuleRecordCodegen {
 }
 
 impl ModuleRecordCodegen for EnumModuleRecordCodegen {
-    fn gen_record_type(&self, record_name: &Ident, generics: &Generics) -> TokenStream {
+    fn gen_record_type(&self, record_name: &Ident, generics: &Generics) -> (TokenStream, Generics) {
         let mut variants = quote! {};
         let vis = &self.vis;
 
@@ -27,15 +27,18 @@ impl ModuleRecordCodegen for EnumModuleRecordCodegen {
             });
         }
 
-        let (generics, _generics_ty, generics_where) = generics.split_for_impl();
+        let (impl_generics, _generics_ty, generics_where) = generics.split_for_impl();
 
-        quote! {
+        (
+            quote! {
 
-            /// The record type for the module.
-            #[derive(burn::record::Record)]
-            #vis enum #record_name #generics #generics_where {
-                #variants
-            }
-        }
+                /// The record type for the module.
+                #[derive(burn::record::Record)]
+                #vis enum #record_name #impl_generics #generics_where {
+                    #variants
+                }
+            },
+            generics.clone(),
+        )
     }
 }

--- a/crates/burn-derive/src/module/record_struct.rs
+++ b/crates/burn-derive/src/module/record_struct.rs
@@ -56,8 +56,6 @@ impl ModuleRecordCodegen for StructModuleRecordCodegen {
             }
         }
 
-        // eprintln!("All generics: {generics:?}");
-        // eprintln!("Used generics: {used_generics:?}");
         let mut filtered_generics = generics.clone();
         filtered_generics.params = generics
             .params
@@ -69,7 +67,6 @@ impl ModuleRecordCodegen for StructModuleRecordCodegen {
             })
             .cloned()
             .collect();
-        // eprintln!("Filtered generics: {filtered_generics:?}");
 
         let (impl_generics, _generics_ty, generics_where) = filtered_generics.split_for_impl();
 

--- a/crates/burn-derive/src/module/record_struct.rs
+++ b/crates/burn-derive/src/module/record_struct.rs
@@ -15,26 +15,10 @@ pub(crate) struct StructModuleRecordCodegen {
 
 impl ModuleRecordCodegen for StructModuleRecordCodegen {
     fn gen_record_type(&self, record_name: &Ident, generics: &Generics) -> (TokenStream, Generics) {
-        // TODO: generics should be filtered based on skip. When a field `m: M` is marked as skip,
-        // the generics should not carry over to the ModuleRecord because `m` will be an `EmptyRecord`
-        //, so nothing captures the generic
-
         let mut fields = quote! {};
         let vis = &self.vis;
 
         let mut used_generics = HashSet::new();
-
-        // for field in self.fields.iter() {
-        //     match field.field_type.attr {
-        //         Some(ModuleFieldAttribute::Skip) => continue,
-        //         None => continue, // becomes EmptyRecord
-        //         _ => {}
-        //     }
-
-        //     for ident in &field.field_type.generic_idents {
-        //         used_generics.insert(ident.clone());
-        //     }
-        // }
 
         for field in self.fields.iter() {
             let ty = &field.field.ty;

--- a/crates/burn-derive/src/module/record_struct.rs
+++ b/crates/burn-derive/src/module/record_struct.rs
@@ -1,4 +1,6 @@
-use crate::shared::field::FieldTypeAnalyzer;
+use std::collections::HashSet;
+
+use crate::module::codegen_struct::{ModuleField, ModuleFieldAttribute};
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 use syn::{Generics, Visibility};
@@ -7,34 +9,96 @@ use super::record::ModuleRecordCodegen;
 
 #[derive(new)]
 pub(crate) struct StructModuleRecordCodegen {
-    fields: Vec<FieldTypeAnalyzer>,
+    fields: Vec<ModuleField>,
     vis: Visibility,
 }
 
 impl ModuleRecordCodegen for StructModuleRecordCodegen {
-    fn gen_record_type(&self, record_name: &Ident, generics: &Generics) -> TokenStream {
+    fn gen_record_type(&self, record_name: &Ident, generics: &Generics) -> (TokenStream, Generics) {
+        // TODO: generics should be filtered based on skip. When a field `m: M` is marked as skip,
+        // the generics should not carry over to the ModuleRecord because `m` will be an `EmptyRecord`
+        //, so nothing captures the generic
+
         let mut fields = quote! {};
         let vis = &self.vis;
+
+        let mut used_generics = HashSet::new();
+
+        // for field in self.fields.iter() {
+        //     match field.field_type.attr {
+        //         Some(ModuleFieldAttribute::Skip) => continue,
+        //         None => continue, // becomes EmptyRecord
+        //         _ => {}
+        //     }
+
+        //     for ident in &field.field_type.generic_idents {
+        //         used_generics.insert(ident.clone());
+        //     }
+        // }
 
         for field in self.fields.iter() {
             let ty = &field.field.ty;
             let name = &field.field.ident;
 
-            fields.extend(quote! {
-                /// The module record associative type.
-                #vis #name: <#ty as burn::module::Module<B>>::Record,
-            });
-        }
+            if field.field_type.is_persistent_module() || field.field_type.maybe_generic_module() {
+                fields.extend(quote! {
+                    /// The module record associative type.
+                    #vis #name: <#ty as burn::module::Module<B>>::Record,
+                });
 
-        let (generics, _generics_ty, generics_where) = generics.split_for_impl();
+                used_generics.extend(&field.field_type.generic_idents);
+            } else {
+                match field.field_type.attr {
+                    Some(ModuleFieldAttribute::Constant) => {
+                        // If constant, store the type directly in the record.
+                        // This assumes the type implements Clone and Serialize/Deserialize.
+                        fields.extend(quote! {
+                            #[allow(missing_docs)]
+                            #vis #name: burn::module::ValueRecord<#ty>,
+                        });
 
-        quote! {
+                        used_generics.extend(&field.field_type.generic_idents);
+                    }
+                    // Default (None) gets skipped
+                    None | Some(ModuleFieldAttribute::Skip) => {
+                        fields.extend(quote! {
+                            #[allow(missing_docs)]
+                            #vis #name: burn::module::EmptyRecord,
+                        });
 
-            /// The record type for the module.
-            #[derive(burn::record::Record)]
-            #vis struct #record_name #generics #generics_where {
-                #fields
+                        // Do not capture generics from this field since it produces an empty record
+                    }
+                }
             }
         }
+
+        // eprintln!("All generics: {generics:?}");
+        // eprintln!("Used generics: {used_generics:?}");
+        let mut filtered_generics = generics.clone();
+        filtered_generics.params = generics
+            .params
+            .iter()
+            .filter(|param| match param {
+                syn::GenericParam::Type(ty) if ty.ident == "B" => true,
+                syn::GenericParam::Type(ty) => used_generics.contains(&ty.ident),
+                _ => true,
+            })
+            .cloned()
+            .collect();
+        // eprintln!("Filtered generics: {filtered_generics:?}");
+
+        let (impl_generics, _generics_ty, generics_where) = filtered_generics.split_for_impl();
+
+        (
+            quote! {
+
+                /// The record type for the module.
+                #[derive(burn::record::Record)]
+                #vis struct #record_name #impl_generics #generics_where {
+                    #fields
+                }
+            },
+            filtered_generics,
+        )
     }
 }

--- a/crates/burn-derive/src/shared/enum_variant.rs
+++ b/crates/burn-derive/src/shared/enum_variant.rs
@@ -69,6 +69,15 @@ pub(crate) fn parse_variants(ast: &syn::DeriveInput) -> syn::Result<Vec<EnumVari
     let mut variants = Vec::new();
 
     for variant in enum_data.variants.iter() {
+        for attr in &variant.attrs {
+            if attr.path().is_ident("module") {
+                Err(syn::Error::new_spanned(
+                    variant,
+                    "Module attributes are not supported for enum variants.",
+                ))?;
+            }
+        }
+
         match &variant.fields {
             syn::Fields::Unnamed(fields) if fields.unnamed.len() == 1 => {
                 let field = &fields.unnamed[0];

--- a/crates/burn-nn/src/modules/conv/conv1d.rs
+++ b/crates/burn-nn/src/modules/conv/conv1d.rs
@@ -6,7 +6,7 @@ use crate::{PaddingConfig1d, conv::checks};
 use burn::tensor::{Tensor, backend::Backend, module::conv1d, ops::PaddedConvOptions};
 use burn::{
     config::Config,
-    module::{Content, DisplaySettings, Ignored, Initializer, Module, ModuleDisplay, Param},
+    module::{Content, DisplaySettings, Initializer, Module, ModuleDisplay, Param},
 };
 
 /// Configuration to create a [1D convolution](Conv1d) layer using the [init function](Conv1dConfig::init).
@@ -62,7 +62,8 @@ pub struct Conv1d<B: Backend> {
     /// Controls the connections between input and output channels.
     pub groups: usize,
     /// Padding configuration.
-    pub padding: Ignored<PaddingConfig1d>,
+    #[module(skip)]
+    pub padding: PaddingConfig1d,
 }
 
 impl<B: Backend> ModuleDisplay for Conv1d<B> {
@@ -73,9 +74,6 @@ impl<B: Backend> ModuleDisplay for Conv1d<B> {
     }
 
     fn custom_content(&self, content: Content) -> Option<Content> {
-        // Format padding
-        let padding_formatted = format!("{}", &self.padding);
-
         // Format stride/dilation as strings
         let stride = format!("{:?}", self.stride);
         let kernel_size = format!("{:?}", self.kernel_size);
@@ -94,7 +92,7 @@ impl<B: Backend> ModuleDisplay for Conv1d<B> {
             .add("kernel_size", &kernel_size)
             .add("dilation", &dilation)
             .add("groups", &self.groups)
-            .add("padding", &padding_formatted)
+            .add_debug_attribute("padding", &self.padding)
             .optional()
     }
 }
@@ -128,7 +126,7 @@ impl Conv1dConfig {
             bias,
             stride: self.stride,
             kernel_size: self.kernel_size,
-            padding: Ignored(self.padding.clone()),
+            padding: self.padding.clone(),
             dilation: self.dilation,
             groups: self.groups,
         }

--- a/crates/burn-nn/src/modules/conv/conv2d.rs
+++ b/crates/burn-nn/src/modules/conv/conv2d.rs
@@ -5,7 +5,7 @@ use burn_core as burn;
 use crate::PaddingConfig2d;
 use burn::config::Config;
 use burn::module::Initializer;
-use burn::module::{Content, DisplaySettings, Ignored, Module, ModuleDisplay, Param};
+use burn::module::{Content, DisplaySettings, Module, ModuleDisplay, Param};
 use burn::tensor::Tensor;
 use burn::tensor::backend::Backend;
 use burn::tensor::module::conv2d;
@@ -64,7 +64,8 @@ pub struct Conv2d<B: Backend> {
     /// Controls the connections between input and output channels.
     pub groups: usize,
     /// The padding configuration.
-    pub padding: Ignored<PaddingConfig2d>,
+    #[module(skip)]
+    pub padding: PaddingConfig2d,
 }
 
 impl Conv2dConfig {
@@ -103,7 +104,7 @@ impl Conv2dConfig {
             stride: self.stride,
             kernel_size: self.kernel_size,
             dilation: self.dilation,
-            padding: Ignored(self.padding.clone()),
+            padding: self.padding.clone(),
             groups: self.groups,
         }
     }
@@ -117,9 +118,6 @@ impl<B: Backend> ModuleDisplay for Conv2d<B> {
     }
 
     fn custom_content(&self, content: Content) -> Option<Content> {
-        // Since padding does not implement ModuleDisplay, we need to format it manually.
-        let padding_formatted = format!("{}", &self.padding);
-
         // Format the stride, kernel_size and dilation as strings, formatted as arrays instead of indexed.
         let stride = format!("{:?}", self.stride);
         let kernel_size = format!("{:?}", self.kernel_size);
@@ -135,7 +133,7 @@ impl<B: Backend> ModuleDisplay for Conv2d<B> {
             .add("kernel_size", &kernel_size)
             .add("dilation", &dilation)
             .add("groups", &self.groups)
-            .add("padding", &padding_formatted)
+            .add_debug_attribute("padding", &self.padding)
             .optional()
     }
 }

--- a/crates/burn-nn/src/modules/conv/conv3d.rs
+++ b/crates/burn-nn/src/modules/conv/conv3d.rs
@@ -5,7 +5,7 @@ use burn_core as burn;
 use crate::PaddingConfig3d;
 use burn::config::Config;
 use burn::module::Initializer;
-use burn::module::{Content, DisplaySettings, Ignored, Module, ModuleDisplay, Param};
+use burn::module::{Content, DisplaySettings, Module, ModuleDisplay, Param};
 use burn::tensor::Tensor;
 use burn::tensor::backend::Backend;
 use burn::tensor::module::conv3d;
@@ -61,7 +61,8 @@ pub struct Conv3d<B: Backend> {
     /// Controls the connections between input and output channels.
     pub groups: usize,
     /// The padding configuration.
-    pub padding: Ignored<PaddingConfig3d>,
+    #[module(skip)]
+    pub padding: PaddingConfig3d,
 }
 
 impl Conv3dConfig {
@@ -104,7 +105,7 @@ impl Conv3dConfig {
             stride: self.stride,
             kernel_size: self.kernel_size,
             dilation: self.dilation,
-            padding: Ignored(self.padding.clone()),
+            padding: self.padding.clone(),
             groups: self.groups,
         }
     }
@@ -118,9 +119,6 @@ impl<B: Backend> ModuleDisplay for Conv3d<B> {
     }
 
     fn custom_content(&self, content: Content) -> Option<Content> {
-        // Padding doesn't implement ModuleDisplay, so format manually.
-        let padding_formatted = format!("{}", &self.padding);
-
         // Format arrays as strings (consistent with Conv2d/Conv1d).
         let stride = format!("{:?}", self.stride);
         let kernel_size = format!("{:?}", self.kernel_size);
@@ -139,7 +137,7 @@ impl<B: Backend> ModuleDisplay for Conv3d<B> {
             .add("kernel_size", &kernel_size)
             .add("dilation", &dilation)
             .add("groups", &self.groups)
-            .add("padding", &padding_formatted)
+            .add_debug_attribute("padding", &self.padding)
             .optional()
     }
 }

--- a/crates/burn-nn/src/modules/conv/deform_conv2d.rs
+++ b/crates/burn-nn/src/modules/conv/deform_conv2d.rs
@@ -6,7 +6,7 @@ use burn_core as burn;
 use crate::PaddingConfig2d;
 use burn::config::Config;
 use burn::module::Initializer;
-use burn::module::{Content, DisplaySettings, Ignored, Module, ModuleDisplay, Param};
+use burn::module::{Content, DisplaySettings, Module, ModuleDisplay, Param};
 use burn::tensor::Tensor;
 use burn::tensor::backend::Backend;
 use burn::tensor::module::deform_conv2d;
@@ -70,7 +70,8 @@ pub struct DeformConv2d<B: Backend> {
     /// Offset groups.
     pub offset_groups: usize,
     /// The padding configuration.
-    pub padding: Ignored<PaddingConfig2d>,
+    #[module(skip)]
+    pub padding: PaddingConfig2d,
 }
 
 impl DeformConv2dConfig {
@@ -112,7 +113,7 @@ impl DeformConv2dConfig {
             stride: self.stride,
             kernel_size: self.kernel_size,
             dilation: self.dilation,
-            padding: Ignored(self.padding.clone()),
+            padding: self.padding.clone(),
             weight_groups: self.weight_groups,
             offset_groups: self.weight_groups,
         }
@@ -127,9 +128,6 @@ impl<B: Backend> ModuleDisplay for DeformConv2d<B> {
     }
 
     fn custom_content(&self, content: Content) -> Option<Content> {
-        // Since padding does not implement ModuleDisplay, we need to format it manually.
-        let padding_formatted = format!("{}", &self.padding);
-
         // Format the stride, kernel_size and dilation as strings, formatted as arrays instead of indexed.
         let stride = format!("{:?}", self.stride);
         let kernel_size = format!("{:?}", self.kernel_size);
@@ -141,7 +139,7 @@ impl<B: Backend> ModuleDisplay for DeformConv2d<B> {
             .add("dilation", &dilation)
             .add("weight_groups", &self.weight_groups)
             .add("offset_groups", &self.offset_groups)
-            .add("padding", &padding_formatted)
+            .add_debug_attribute("padding", &self.padding)
             .optional()
     }
 }

--- a/crates/burn-nn/src/modules/interpolate/interpolate1d.rs
+++ b/crates/burn-nn/src/modules/interpolate/interpolate1d.rs
@@ -5,7 +5,7 @@ use burn::tensor::module::interpolate;
 use burn_core as burn;
 
 use burn::config::Config;
-use burn::module::{Content, DisplaySettings, Ignored, Module, ModuleDisplay};
+use burn::module::{Content, DisplaySettings, Module, ModuleDisplay};
 use burn::tensor::Tensor;
 use burn::tensor::backend::Backend;
 use burn::tensor::ops::InterpolateOptions;
@@ -61,7 +61,8 @@ pub struct Interpolate1d {
     pub scale_factor: Option<f32>,
 
     /// Interpolation mode used for resizing
-    pub mode: Ignored<InterpolateMode>,
+    #[module(skip)]
+    pub mode: InterpolateMode,
 
     /// Whether to align corner pixels
     pub align_corners: bool,
@@ -73,7 +74,7 @@ impl Interpolate1dConfig {
         Interpolate1d {
             output_size: self.output_size,
             scale_factor: self.scale_factor,
-            mode: Ignored(self.mode),
+            mode: self.mode,
             align_corners: self.align_corners,
         }
     }
@@ -111,7 +112,7 @@ impl Interpolate1d {
         let result = interpolate(
             input,
             [1, output_size],
-            InterpolateOptions::new(self.mode.0.clone().into())
+            InterpolateOptions::new(self.mode.clone().into())
                 .with_align_corners(self.align_corners),
         );
 
@@ -170,7 +171,7 @@ impl ModuleDisplay for Interpolate1d {
 
     fn custom_content(&self, content: Content) -> Option<Content> {
         content
-            .add("mode", &self.mode)
+            .add_debug_attribute("mode", &self.mode)
             .add("output_size", &format!("{:?}", self.output_size))
             .add("scale_factor", &self.scale_factor)
             .optional()

--- a/crates/burn-nn/src/modules/interpolate/interpolate2d.rs
+++ b/crates/burn-nn/src/modules/interpolate/interpolate2d.rs
@@ -5,7 +5,7 @@ use burn::tensor::module::interpolate;
 use burn_core as burn;
 
 use burn::config::Config;
-use burn::module::{Content, DisplaySettings, Ignored, Module, ModuleDisplay};
+use burn::module::{Content, DisplaySettings, Module, ModuleDisplay};
 use burn::tensor::Tensor;
 use burn::tensor::backend::Backend;
 use burn::tensor::ops::InterpolateOptions;
@@ -62,7 +62,8 @@ pub struct Interpolate2d {
     pub scale_factor: Option<[f32; 2]>,
 
     /// Interpolation mode used for resizing
-    pub mode: Ignored<InterpolateMode>,
+    #[module(skip)]
+    pub mode: InterpolateMode,
 
     /// Whether to align corner pixels
     pub align_corners: bool,
@@ -74,7 +75,7 @@ impl Interpolate2dConfig {
         Interpolate2d {
             output_size: self.output_size,
             scale_factor: self.scale_factor,
-            mode: Ignored(self.mode),
+            mode: self.mode,
             align_corners: self.align_corners,
         }
     }
@@ -106,7 +107,7 @@ impl Interpolate2d {
         interpolate(
             input,
             output_size,
-            InterpolateOptions::new(self.mode.0.clone().into())
+            InterpolateOptions::new(self.mode.clone().into())
                 .with_align_corners(self.align_corners),
         )
     }
@@ -169,7 +170,7 @@ impl ModuleDisplay for Interpolate2d {
 
     fn custom_content(&self, content: Content) -> Option<Content> {
         content
-            .add("mode", &self.mode)
+            .add_debug_attribute("mode", &self.mode)
             .add("output_size", &format!("{:?}", self.output_size))
             .add("scale_factor", &self.scale_factor)
             .optional()

--- a/crates/burn-nn/src/modules/pool/avg_pool1d.rs
+++ b/crates/burn-nn/src/modules/pool/avg_pool1d.rs
@@ -70,7 +70,7 @@ impl ModuleDisplay for AvgPool1d {
         content
             .add("kernel_size", &self.kernel_size)
             .add("stride", &self.stride)
-            .add_debug_attribute(&"padding", &self.padding)
+            .add_debug_attribute("padding", &self.padding)
             .add("count_include_pad", &self.count_include_pad)
             .add("ceil_mode", &self.ceil_mode)
             .optional()

--- a/crates/burn-nn/src/modules/pool/avg_pool1d.rs
+++ b/crates/burn-nn/src/modules/pool/avg_pool1d.rs
@@ -2,8 +2,8 @@ use burn_core as burn;
 
 use crate::PaddingConfig1d;
 use burn::config::Config;
+use burn::module::Module;
 use burn::module::{Content, DisplaySettings, ModuleDisplay};
-use burn::module::{Ignored, Module};
 use burn::tensor::Tensor;
 use burn::tensor::backend::Backend;
 use burn::tensor::ops::PadMode;
@@ -51,7 +51,8 @@ pub struct AvgPool1d {
     /// The size of the kernel.
     pub kernel_size: usize,
     /// The padding configuration.
-    pub padding: Ignored<PaddingConfig1d>,
+    #[module(skip)]
+    pub padding: PaddingConfig1d,
     /// If the padding is counted in the denominator when computing the average.
     pub count_include_pad: bool,
     /// If true, use ceiling instead of floor for output size calculation.
@@ -69,7 +70,7 @@ impl ModuleDisplay for AvgPool1d {
         content
             .add("kernel_size", &self.kernel_size)
             .add("stride", &self.stride)
-            .add("padding", &self.padding)
+            .add_debug_attribute(&"padding", &self.padding)
             .add("count_include_pad", &self.count_include_pad)
             .add("ceil_mode", &self.ceil_mode)
             .optional()
@@ -82,7 +83,7 @@ impl AvgPool1dConfig {
         AvgPool1d {
             stride: self.stride,
             kernel_size: self.kernel_size,
-            padding: Ignored(self.padding.clone()),
+            padding: self.padding.clone(),
             count_include_pad: self.count_include_pad,
             ceil_mode: self.ceil_mode,
         }

--- a/crates/burn-nn/src/modules/pool/avg_pool2d.rs
+++ b/crates/burn-nn/src/modules/pool/avg_pool2d.rs
@@ -2,8 +2,8 @@ use burn_core as burn;
 
 use crate::PaddingConfig2d;
 use burn::config::Config;
+use burn::module::Module;
 use burn::module::{Content, DisplaySettings, ModuleDisplay};
-use burn::module::{Ignored, Module};
 use burn::tensor::Tensor;
 use burn::tensor::backend::Backend;
 use burn::tensor::ops::PadMode;
@@ -51,7 +51,8 @@ pub struct AvgPool2d {
     /// Size of the kernel.
     pub kernel_size: [usize; 2],
     /// Padding configuration.
-    pub padding: Ignored<PaddingConfig2d>,
+    #[module(skip)]
+    pub padding: PaddingConfig2d,
     /// If the padding is counted in the denominator when computing the average.
     pub count_include_pad: bool,
     /// If true, use ceiling instead of floor for output size calculation.
@@ -69,7 +70,7 @@ impl ModuleDisplay for AvgPool2d {
         content
             .add("kernel_size", &alloc::format!("{:?}", &self.kernel_size))
             .add("stride", &alloc::format!("{:?}", &self.stride))
-            .add("padding", &self.padding)
+            .add_debug_attribute("padding", &self.padding)
             .add("count_include_pad", &self.count_include_pad)
             .add("ceil_mode", &self.ceil_mode)
             .optional()
@@ -82,7 +83,7 @@ impl AvgPool2dConfig {
         AvgPool2d {
             stride: self.strides,
             kernel_size: self.kernel_size,
-            padding: Ignored(self.padding.clone()),
+            padding: self.padding.clone(),
             count_include_pad: self.count_include_pad,
             ceil_mode: self.ceil_mode,
         }

--- a/crates/burn-nn/src/modules/pool/max_pool1d.rs
+++ b/crates/burn-nn/src/modules/pool/max_pool1d.rs
@@ -2,8 +2,8 @@ use burn_core as burn;
 
 use crate::PaddingConfig1d;
 use burn::config::Config;
+use burn::module::Module;
 use burn::module::{Content, DisplaySettings, ModuleDisplay};
-use burn::module::{Ignored, Module};
 use burn::tensor::Tensor;
 use burn::tensor::backend::Backend;
 use burn::tensor::ops::PadMode;
@@ -43,7 +43,8 @@ pub struct MaxPool1d {
     /// The size of the kernel.
     pub kernel_size: usize,
     /// The padding configuration.
-    pub padding: Ignored<PaddingConfig1d>,
+    #[module(skip)]
+    pub padding: PaddingConfig1d,
     /// The dilation.
     pub dilation: usize,
     /// If true, use ceiling instead of floor for output size calculation.
@@ -61,7 +62,7 @@ impl ModuleDisplay for MaxPool1d {
         content
             .add("kernel_size", &self.kernel_size)
             .add("stride", &self.stride)
-            .add("padding", &self.padding)
+            .add_debug_attribute("padding", &self.padding)
             .add("dilation", &self.dilation)
             .add("ceil_mode", &self.ceil_mode)
             .optional()
@@ -74,7 +75,7 @@ impl MaxPool1dConfig {
         MaxPool1d {
             stride: self.stride,
             kernel_size: self.kernel_size,
-            padding: Ignored(self.padding.clone()),
+            padding: self.padding.clone(),
             dilation: self.dilation,
             ceil_mode: self.ceil_mode,
         }

--- a/crates/burn-nn/src/modules/pool/max_pool2d.rs
+++ b/crates/burn-nn/src/modules/pool/max_pool2d.rs
@@ -2,8 +2,8 @@ use burn_core as burn;
 
 use crate::PaddingConfig2d;
 use burn::config::Config;
+use burn::module::Module;
 use burn::module::{Content, DisplaySettings, ModuleDisplay};
-use burn::module::{Ignored, Module};
 use burn::tensor::Tensor;
 use burn::tensor::backend::Backend;
 use burn::tensor::ops::PadMode;
@@ -43,7 +43,8 @@ pub struct MaxPool2d {
     /// The size of the kernel.
     pub kernel_size: [usize; 2],
     /// The padding configuration.
-    pub padding: Ignored<PaddingConfig2d>,
+    #[module(skip)]
+    pub padding: PaddingConfig2d,
     /// The dilation.
     pub dilation: [usize; 2],
     /// If true, use ceiling instead of floor for output size calculation.
@@ -61,7 +62,7 @@ impl ModuleDisplay for MaxPool2d {
         content
             .add("kernel_size", &alloc::format!("{:?}", &self.kernel_size))
             .add("stride", &alloc::format!("{:?}", &self.stride))
-            .add("padding", &self.padding)
+            .add_debug_attribute("padding", &self.padding)
             .add("dilation", &alloc::format!("{:?}", &self.dilation))
             .add("ceil_mode", &self.ceil_mode)
             .optional()
@@ -74,7 +75,7 @@ impl MaxPool2dConfig {
         MaxPool2d {
             stride: self.strides,
             kernel_size: self.kernel_size,
-            padding: Ignored(self.padding.clone()),
+            padding: self.padding.clone(),
             dilation: self.dilation,
             ceil_mode: self.ceil_mode,
         }


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Changes

Improved the module derive to handle non-module fields and generics

- Add module attributes to handle non-module / parameter types
  -  `#[module(constant)]`: treated as persistent values (useful for configs, persistent tensor values, etc.)
  - `#[module(skip)]`: treated as runtime state (non-persistent)
- Deprecate `Ignored<T>` fields (in favor of `#[module(skip)]`)
- Deprecated `ConstantRecord`, a misnomer that did not persist any value (empty record), in favor of `EmptyRecord`
- Added `ValueRecord` for constant values

Example:
```rust
#[derive(Module, Debug)]
pub struct ModuleWithAttributes<B: Backend, M: Module<B>> {
    /// A normal parameter.
    weight: Param<Tensor<B, 2>>,
    /// A nested enum module with generics.
    nested: ModuleEnumWithGenericModule<B, M>,
    /// By default, primitives were not persistent (same as `#[module(skip)]`).
    other_prob: f64,
    /// By default, tensors were not persistent and not visited/mapped (same as `#[module(skip)]`).
    tensor: Tensor<B, 1>,
    /// A persistent config value.
    #[module(constant)]
    dropout_prob: f64,
    /// A field that is recomputed at runtime.
    #[module(skip)]
    cached_mask: Option<Tensor<B, 2>>,
    /// A field that contains some debug state.
    #[module(skip)]
    debug_state: String,
}
```

Modules now use `#[module(skip)]` instead of `Ignored<T>`:
```rust
#[derive(Module, Debug)]
#[module(custom_display)]
pub struct Conv1d<B: Backend> {
    // ...
    /// Padding configuration.
    #[module(skip)]
    pub padding: PaddingConfig1d,
}
```

This preserves the previous behavior, but users can now mark configs as `#[module(constant)]` to persist the values.

TODO:
- [Breaking] Tensors and primitives should not be empty records by default, but constants (allow de/serialization)

### Testing

Module derive tests