### PR TITLE
move sign back to mathOps

### DIFF
--- a/crates/burn-ndarray/src/ops/base.rs
+++ b/crates/burn-ndarray/src/ops/base.rs
@@ -857,6 +857,27 @@ where
 
         lhs.mapv(|a| a == rhs).into_shared()
     }
+
+    pub(crate) fn sign_op(tensor: SharedArray<E>) -> SharedArray<E>
+    where
+        E: Signed,
+    {
+        let zero = 0.elem();
+        let one = 1.elem::<E>();
+
+        tensor
+            .mapv(|x| {
+                if x == zero {
+                    zero
+                } else {
+                    match x.is_positive() {
+                        true => one,
+                        false => -one,
+                    }
+                }
+            })
+            .into_shared()
+    }
 }
 
 impl<E> NdArrayMathOps<E>
@@ -912,26 +933,6 @@ where
         dim: usize,
     ) -> SharedArray<I> {
         arg(tensor, dim, CmpType::Max)
-    }
-
-    pub(crate) fn sign_op(tensor: SharedArray<E>) -> SharedArray<E>
-    where
-        E: Signed,
-    {
-        let zero = 0.elem();
-        let one = 1.elem::<E>();
-
-        tensor
-            .mapv(|x| {
-                if x > zero {
-                    one
-                } else if x < zero {
-                    -one
-                } else {
-                    zero
-                }
-            })
-            .into_shared()
     }
 
     pub fn argmin<I: NdArrayElement + PartialOrd>(


### PR DESCRIPTION
## Pull Request Template

sorry, #4559 was merged before I could make this change there. Since we are still requiring Elements/NdarrayElements to implement equality (though not ord/partial ord) and sign checking may behave unexpectedly specific for zero, I changed the check to first check if the float is zero, then use the normal is_positive to check whether the number's sign. spinning up rust playground [0.0==-0.0](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=0fbd2c805ec3eaecae810a37bb22dbc2)

with this we can avoid adding another trait.

### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

_Provide links to relevant issues and dependent PRs._

### Changes

_Summarize the problem being addressed and your solution._

### Testing

_Describe how these changes have been tested._
