### PR TITLE
Move `burn-nn` module name checks in `burn-store` adapter to the test section

### DIFF
--- a/crates/burn-store/Cargo.toml
+++ b/crates/burn-store/Cargo.toml
@@ -53,7 +53,6 @@ pytorch = ["burn-core/record-item-custom-serde", "zip", "serde", "tar"]
 
 [dependencies]
 burn-core = { path = "../burn-core", version = "=0.21.0-pre.1", default-features = false }
-burn-nn = { path = "../burn-nn", version = "=0.21.0-pre.1", default-features = false }
 burn-tensor = { path = "../burn-tensor", version = "=0.21.0-pre.1", default-features = false }
 
 # External dependencies
@@ -82,6 +81,7 @@ burn-wgpu = { path = "../burn-wgpu", version = "=0.21.0-pre.1", optional = true 
 [dev-dependencies]
 # burn-import = { path = "../burn-import", version = "=0.21.0-pre.1" } # disabled (circular dep in publish, only for bench)
 burn-ndarray = { path = "../burn-ndarray", version = "=0.21.0-pre.1" }
+burn-nn = { path = "../burn-nn", version = "=0.21.0-pre.1", default-features = false }
 divan = "0.1"
 tempfile = { workspace = true }
 

--- a/crates/burn-store/src/adapter.rs
+++ b/crates/burn-store/src/adapter.rs
@@ -18,13 +18,7 @@ use burn_tensor::TensorData;
 // These come from the Module derive macro which uses stringify! on the struct name
 // Format: "Struct:TypeName" for user-defined structs
 mod module_names {
-    // Import the types to ensure they exist at compile time
-    // If these types are renamed or moved, we'll get a compile error
-    #[allow(unused_imports)]
-    use burn_nn::{BatchNorm, GroupNorm, LayerNorm, Linear};
-
     // The actual string constants that match what the Module derive macro produces
-    // The imports above ensure these types exist at compile-time
     pub const LINEAR: &str = "Struct:Linear";
     pub const BATCH_NORM: &str = "Struct:BatchNorm";
     pub const LAYER_NORM: &str = "Struct:LayerNorm";
@@ -358,6 +352,21 @@ mod tests {
     use alloc::sync::Arc;
     use burn_tensor::{DType, TensorData};
     use core::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn test_module_names_match_burn_nn() {
+        // If these types are renamed or moved in `burn-nn`, this test will fail to compile.
+        // This use statement replicates the previous check/alarm system.
+        #[allow(unused_imports)]
+        use burn_nn::{BatchNorm, GroupNorm, LayerNorm, Linear};
+
+        // These assert statements work as extra checks that should remind maintainers more
+        // clearly that the hardcoded strings needs get updated.
+        assert_eq!(module_names::LINEAR, "Struct:Linear");
+        assert_eq!(module_names::BATCH_NORM, "Struct:BatchNorm");
+        assert_eq!(module_names::LAYER_NORM, "Struct:LayerNorm");
+        assert_eq!(module_names::GROUP_NORM, "Struct:GroupNorm");
+    }
 
     fn create_test_snapshot(path: &str, shape: Vec<usize>, container_type: &str) -> TensorSnapshot {
         let path_parts: Vec<String> = path.split('.').map(|s| s.to_string()).collect();


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Closes [Unnecessary burn-nn usage in the burn-store crate #4576](https://github.com/tracel-ai/burn/issues/4576)

### Changes

- Removed the following two lines from `mod module_names`:
```rust
#[allow(unused_imports)]
use burn_nn::{BatchNorm, GroupNorm, LayerNorm, Linear};
```
- Added a new test case where the above code snippet is used. This test case will cause compile error if the imported types are renamed or moved in `burn-nn`. Hence, this new test case replicates the functionality of the previous check system in `mod module_names`.
- Moved `burn-nn` from `[dependencies]` to `[dev-dependencies]` in the `Cargo.toml` file of the `burn-store` crate since all the use cases of `burn-nn` in the `burn-store` crate is now for testing and benchmarking. 

### Testing

Not applicable. The previous in-code check have been moved to the test section.
