### PR TITLE
Expose `BurnpackError`

### DIFF
--- a/crates/burn-store/src/lib.rs
+++ b/crates/burn-store/src/lib.rs
@@ -113,6 +113,6 @@ pub use safetensors::{SafetensorsStore, SafetensorsStoreError};
 #[cfg(feature = "burnpack")]
 mod burnpack;
 #[cfg(feature = "burnpack")]
-pub use burnpack::store::BurnpackStore;
-#[cfg(feature = "burnpack")]
 pub use burnpack::writer::BurnpackWriter;
+#[cfg(feature = "burnpack")]
+pub use burnpack::{base::BurnpackError, store::BurnpackStore};


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [X] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs



### Changes

This PR exposes the `BurnpackError` from the burn-store crate, similar to what is already exposed for PytorchStore and SafetensorsStore. This is needed to correctly propagate and handle the error without using `Box<dyn Error>` in user's code


### Testing


