### PR TITLE
Remove `Clone` bound from `WindowsDataset` item

### DIFF
--- a/crates/burn-dataset/src/transform/window.rs
+++ b/crates/burn-dataset/src/transform/window.rs
@@ -133,7 +133,7 @@ where
 impl<D, I> Dataset<Vec<I>> for WindowsDataset<D, I>
 where
     D: Dataset<I>,
-    I: Clone + Send + Sync,
+    I: Send + Sync,
 {
     /// Retrieves a window of items from the dataset.
     ///


### PR DESCRIPTION
### Related Issues/PRs

Fixes #4583

### Changes

Removed `Clone` trait bound