### PR TITLE
fix: replace ValidStep with InferenceStep in training.md

### DIFF
--- a/burn-book/src/basic-workflow/training.md
+++ b/burn-book/src/basic-workflow/training.md
@@ -27,7 +27,7 @@ Since the MNIST task is a classification problem, we will use the `Classificatio
 #     record::CompactRecorder,
 #     tensor::backend::AutodiffBackend,
 #     train::{
-#         ClassificationOutput, Learner, SupervisedTraining, TrainOutput, TrainStep, ValidStep,
+#         ClassificationOutput, Learner, SupervisedTraining, TrainOutput, TrainStep, InferenceStep,
 #         metric::{AccuracyMetric, LossMetric},
 #     },
 # };
@@ -114,7 +114,7 @@ impl<B: Backend> InferenceStep for Model<B> {
 }
 ```
 
-Here we define the input and output types as generic arguments in the `TrainStep` and `ValidStep`.
+Here we define the input and output types as generic arguments in the `TrainStep` and `InferenceStep`.
 We will call them `MnistBatch` and `ClassificationOutput`. In the training step, the computation of
 gradients is straightforward, necessitating a simple invocation of `backward()` on the loss. Note
 that contrary to PyTorch, gradients are not stored alongside each tensor parameter, but are rather
@@ -132,7 +132,7 @@ autodiff. We will see later how to create a backend with autodiff support.
 Although generic data types, trait and trait bounds were already introduced in previous sections of
 this guide, the previous code snippet might be a lot to take in at first.
 
-In the example above, we implement the `TrainStep` and `ValidStep` trait for our `Model` struct,
+In the example above, we implement the `TrainStep` and `InferenceStep` trait for our `Model` struct,
 which is generic over the `Backend` trait as has been covered before. These traits are provided by
 `burn::train` and define a common `step` method that should be implemented for all structs. Since
 the trait is generic over the input and output types, the trait implementation must specify the


### PR DESCRIPTION
`ValidStep` was renamed to `InferenceStep`, update the outdated references in the burn-book training guide.