### PR TITLE
Fix function arg name inconsistencies

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -432,7 +432,7 @@ strategies.
 | `linalg::matvec(matrix, vector)`                   | `torch.matmul(matrix, vector)` / `@` operator       |
 | `linalg::max_abs_norm(tensor, dim)`                | _No direct equivalent_                              |
 | `linalg::min_abs_norm(tensor, dim)`                | _No direct equivalent_                              |
-| `linalg::outer(x, y)`                              | `torch.outer(x, y)` / `einsum("bi,bj->bij", …)`     |
+| `linalg::outer(lhs, rhs)`                          | `torch.outer(lhs, rhs)` / `einsum("bi,bj->bij", …)` |
 | `linalg::outer_dim(lhs, rhs, dim)`                 | _No direct equivalent_                              |
 | `linalg::trace(tensor)`                            | `torch.trace(tensor)`                               |
 | `linalg::vector_norm(tensor, p, dim)`              | `torch.linalg.vector_norm(tensor, p, dim)`          |

--- a/crates/burn-backend/src/backend/ops/bool_tensor.rs
+++ b/crates/burn-backend/src/backend/ops/bool_tensor.rs
@@ -376,7 +376,7 @@ pub trait BoolTensorOps<B: Backend> {
     /// # Returns
     ///
     /// The tensor with the result of the logical and.
-    fn bool_and(tensor: BoolTensor<B>, rhs: BoolTensor<B>) -> BoolTensor<B>;
+    fn bool_and(lhs: BoolTensor<B>, rhs: BoolTensor<B>) -> BoolTensor<B>;
 
     /// Executes the logical or (`||`) operation on two boolean tensors.
     ///
@@ -388,7 +388,7 @@ pub trait BoolTensorOps<B: Backend> {
     /// # Returns
     ///
     /// The tensor with the result of the logical or.
-    fn bool_or(tensor: BoolTensor<B>, rhs: BoolTensor<B>) -> BoolTensor<B>;
+    fn bool_or(lhs: BoolTensor<B>, rhs: BoolTensor<B>) -> BoolTensor<B>;
 
     /// Element-wise exclusive or.
     ///

--- a/crates/burn-tensor/src/tensor/linalg/outer.rs
+++ b/crates/burn-tensor/src/tensor/linalg/outer.rs
@@ -9,7 +9,6 @@ use crate::{AsIndex, Numeric};
 /// # Arguments
 /// - `lhs`: the "row" tensor, with shape ``[..., i]``.
 /// - `rhs`: the "col" tensor, with shape ``[..., j]``.
-/// - `dim`: the dimension to product.
 ///
 /// # Returns
 ///
@@ -19,13 +18,13 @@ use crate::{AsIndex, Numeric};
 /// result[..., i, j] = lhs[..., i] * rhs[..., j]
 /// ``
 pub fn outer<B: Backend, const D: usize, const R: usize, K>(
-    x: Tensor<B, D, K>,
-    y: Tensor<B, D, K>,
+    lhs: Tensor<B, D, K>,
+    rhs: Tensor<B, D, K>,
 ) -> Tensor<B, R, K>
 where
     K: BasicOps<B> + Numeric<B>,
 {
-    outer_dim(x, y, -1)
+    outer_dim(lhs, rhs, -1)
 }
 
 /// Computes the outer product along a specific dimension, broadcasting over others.


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

None

### Changes

While updating the burn book, I noticed the parameters and their names in the `linalg::outer()` function do not match the function's doc so I fixed this. Also searched for similar cases and fixed the inconsistencies in the parameter names of `bool_and()` and `bool_or()` functions in the `crates/burn-backend/src/backend/ops/bool_tensor.rs` file. 

### Testing

Not applicable. All existing tests passes.
