### PR TITLE
Add HannWindow operator to burn-tensor

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/float/ops/hann_window.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/hann_window.rs
@@ -1,9 +1,10 @@
 use super::*;
+use burn_tensor::signal::hann_window;
 use burn_tensor::{DType, TensorData, Tolerance};
 
 #[test]
 fn should_support_hann_window_periodic() {
-    let tensor = TestTensor::<1>::hann_window(8, true, &Default::default());
+    let tensor: TestTensor<1> = hann_window(8, true, &Default::default());
     let expected = TensorData::from([0.0, 0.146447, 0.5, 0.853553, 1.0, 0.853553, 0.5, 0.146447]);
 
     // Metal has less precise trigonometric functions.
@@ -16,7 +17,7 @@ fn should_support_hann_window_periodic() {
 
 #[test]
 fn should_support_hann_window_symmetric() {
-    let tensor = TestTensor::<1>::hann_window(8, false, &Default::default());
+    let tensor: TestTensor<1> = hann_window(8, false, &Default::default());
     let expected = TensorData::from([
         0.0, 0.188255, 0.611260, 0.950484, 0.950484, 0.611260, 0.188255, 0.0,
     ]);
@@ -31,19 +32,19 @@ fn should_support_hann_window_symmetric() {
 
 #[test]
 fn should_support_hann_window_options_dtype() {
-    let tensor = TestTensor::<1>::hann_window(4, true, (&Default::default(), DType::F32));
+    let tensor: TestTensor<1> = hann_window(4, true, (&Default::default(), DType::F32));
     assert_eq!(tensor.dtype(), DType::F32);
 }
 
 #[test]
 fn should_support_hann_window_empty() {
-    let tensor = TestTensor::<1>::hann_window(0, true, &Default::default());
+    let tensor: TestTensor<1> = hann_window(0, true, &Default::default());
     assert_eq!(tensor.shape().dims(), [0]);
 }
 
 #[test]
 fn should_handle_hann_window_size_one_symmetric() {
-    let tensor = TestTensor::<1>::hann_window(1, false, &Default::default());
+    let tensor: TestTensor<1> = hann_window(1, false, &Default::default());
     let expected = TensorData::from([1.0]);
 
     tensor
@@ -53,7 +54,7 @@ fn should_handle_hann_window_size_one_symmetric() {
 
 #[test]
 fn should_handle_hann_window_size_one_periodic() {
-    let tensor = TestTensor::<1>::hann_window(1, true, &Default::default());
+    let tensor: TestTensor<1> = hann_window(1, true, &Default::default());
     let expected = TensorData::from([1.0]);
 
     tensor

--- a/crates/burn-tensor/src/tensor/api/float.rs
+++ b/crates/burn-tensor/src/tensor/api/float.rs
@@ -1,7 +1,6 @@
 use crate::AsIndex;
 use crate::FloatDType;
 use crate::Tensor;
-use crate::TensorCreationOptions;
 use crate::cast::ToElement;
 use crate::check;
 use crate::check::TensorCheck;
@@ -22,74 +21,6 @@ pub const DEFAULT_RTOL: f64 = 1e-5;
 
 /// Default ATOL value for `is_close` and `all_close`.
 pub const DEFAULT_ATOL: f64 = 1e-8;
-
-impl<B> Tensor<B, 1>
-where
-    B: Backend,
-{
-    /// Creates a 1D Hann window.
-    ///
-    #[cfg_attr(
-        doc,
-        doc = r#"
-$$w_n = 0.5 - 0.5 \cos\left(\frac{2\pi n}{N}\right)$$
-
-where $N$ = `size` when `periodic` is `true`, or $N$ = `size - 1` when `periodic` is `false`.
-"#
-    )]
-    #[cfg_attr(
-        not(doc),
-        doc = "`w_n = 0.5 - 0.5 * cos(2πn/N)` where N = size (periodic) or N = size-1 (symmetric)"
-    )]
-    ///
-    /// # Notes
-    ///
-    /// - `size == 0` returns an empty tensor.
-    /// - `size == 1` returns `[1.0]` regardless of `periodic` (consistent with PyTorch / NumPy).
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use burn_tensor::backend::Backend;
-    /// use burn_tensor::Tensor;
-    ///
-    /// fn example<B: Backend>() {
-    ///     let device = B::Device::default();
-    ///     let window = Tensor::<B, 1>::hann_window(8, true, &device);
-    ///     println!("{window}");
-    /// }
-    /// ```
-    pub fn hann_window(
-        size: usize,
-        periodic: bool,
-        options: impl Into<TensorCreationOptions<B>>,
-    ) -> Self {
-        let opt = options.into();
-        let dtype = opt.resolve_policy(<B::FloatElem as burn_backend::Element>::dtype());
-        let shape = crate::Shape::new([size]);
-        check!(TensorCheck::creation_ops::<1>("HannWindow", &shape));
-
-        if size == 0 {
-            return Self::empty(shape, opt).cast(dtype);
-        }
-
-        if size == 1 {
-            return Self::ones(shape, opt).cast(dtype);
-        }
-
-        let size_i64 = i64::try_from(size).expect("HannWindow size doesn't fit in i64 range.");
-        let denominator = if periodic { size } else { size - 1 };
-        let angular_increment = (2.0 * core::f64::consts::PI) / denominator as f64;
-
-        Tensor::<B, 1, Int>::arange(0..size_i64, &opt.device)
-            .float()
-            .mul_scalar(angular_increment)
-            .cos()
-            .mul_scalar(-0.5)
-            .add_scalar(0.5)
-            .cast(dtype)
-    }
-}
 
 impl<const D: usize, B> Tensor<B, D>
 where

--- a/crates/burn-tensor/src/tensor/mod.rs
+++ b/crates/burn-tensor/src/tensor/mod.rs
@@ -42,6 +42,9 @@ pub mod loss;
 /// The neural network module.
 pub mod module;
 
+/// The signal processing module.
+pub mod signal;
+
 /// Operations on tensors module.
 pub mod ops {
     pub use burn_backend::backend::ops::*;

--- a/crates/burn-tensor/src/tensor/signal/hann_window.rs
+++ b/crates/burn-tensor/src/tensor/signal/hann_window.rs
@@ -1,0 +1,69 @@
+use burn_backend::{
+    Backend,
+    tensor::{Float, Int},
+};
+
+use crate::{Tensor, TensorCreationOptions, check, check::TensorCheck};
+
+/// Creates a 1D Hann window.
+///
+#[cfg_attr(
+    doc,
+    doc = r#"
+$$w_n = 0.5 - 0.5 \cos\left(\frac{2\pi n}{N}\right)$$
+
+where $N$ = `size` when `periodic` is `true`, or $N$ = `size - 1` when `periodic` is `false`.
+"#
+)]
+#[cfg_attr(
+    not(doc),
+    doc = "`w_n = 0.5 - 0.5 * cos(2πn/N)` where N = size (periodic) or N = size-1 (symmetric)"
+)]
+///
+/// # Notes
+///
+/// - `size == 0` returns an empty tensor.
+/// - `size == 1` returns `[1.0]` regardless of `periodic`.
+///
+/// # Example
+///
+/// ```rust
+/// use burn_tensor::backend::Backend;
+/// use burn_tensor::signal::hann_window;
+///
+/// fn example<B: Backend>() {
+///     let device = B::Device::default();
+///     let window = hann_window::<B>(8, true, &device);
+///     println!("{window}");
+/// }
+/// ```
+pub fn hann_window<B: Backend>(
+    size: usize,
+    periodic: bool,
+    options: impl Into<TensorCreationOptions<B>>,
+) -> Tensor<B, 1> {
+    let opt = options.into();
+    let dtype = opt.resolve_dtype::<Float>();
+    let shape = [size];
+    check!(TensorCheck::creation_ops::<1>("HannWindow", &shape));
+
+    if size == 0 {
+        return Tensor::<B, 1>::empty(shape, opt).cast(dtype);
+    }
+
+    if size == 1 {
+        return Tensor::<B, 1>::ones(shape, opt).cast(dtype);
+    }
+
+    let size_i64 = i64::try_from(size).expect("HannWindow size doesn't fit in i64 range.");
+    let denominator = if periodic { size } else { size - 1 };
+    let angular_increment = (2.0 * core::f64::consts::PI) / denominator as f64;
+
+    Tensor::<B, 1, Int>::arange(0..size_i64, &opt.device)
+        .float()
+        .mul_scalar(angular_increment)
+        .cos()
+        .mul_scalar(-0.5)
+        .add_scalar(0.5)
+        .cast(dtype)
+}

--- a/crates/burn-tensor/src/tensor/signal/mod.rs
+++ b/crates/burn-tensor/src/tensor/signal/mod.rs
@@ -1,0 +1,3 @@
+mod hann_window;
+
+pub use hann_window::*;


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed. *(Note: Ran targeted checks instead due to local CUDA SDK limitations, see Testing section below for details).*
- [x] Made sure the book is up to date with changes in this PR. *(Note: N/A, this is an API addition and the Rustdoc is fully documented).*

### Related Issues/PRs

Addresses part of #4531 (Specifically the `HannWindow` signal processing operator).

### Changes

Added the `HannWindow` operator to the Tensor API to support signal processing models and align with ONNX specifications. 

**Detailed implementation:**
1. **`crates/burn-tensor/src/tensor/api/float.rs`**:
   - Added `Tensor<B, 1>::hann_window(size, periodic, options)` as an associated function under a new `impl<B> Tensor<B, 1>` block.
   - Implemented the Hann window formula: $w_n = 0.5 - 0.5 \times \cos(2\pi n / N)$ using existing tensor operations (`arange`, `float`, `cos`, `mul_scalar`, `add_scalar`, `cast`).
   - Supported both `periodic` ($N = size$) and `symmetric` ($N = size - 1$) modes.
   - Handled edge cases perfectly: `size = 0` returns an empty tensor, and `size = 1` returns `[1.0]` (preventing division-by-zero panics and matching PyTorch/NumPy behavior).
   - Used `f64` precision for the angular increment calculation to ensure high accuracy before casting to the target dtype.
   - Added dual-state documentation (`cfg_attr`) for clean KaTeX math rendering in Rustdoc and readable plain-text fallbacks in IDE hover hints.

2. **`crates/burn-backend-tests/tests/tensor/float/ops/hann_window.rs` & `mod.rs`**:
   - Registered the new test module.
   - Added 6 comprehensive test cases covering `periodic` mode, `symmetric` mode, dtype options, empty tensors, and the `size=1` boundary for both modes.
   - Used `assert_approx_eq` with `Tolerance` for cross-backend floating-point stability.

### Testing

Due to my local CUDA SDK being an older version, the `cudarc` binding in `cubecl-cuda` failed to find `CUtensorMapL2promotion` and `CUtensorMapFloatOOBfill`. Therefore, I had to skip the global `cargo run-checks` command. 

Instead, I manually and successfully verified the code using targeted commands for the active backends:

| Check | Command | Result |
| :--- | :--- | :--- |
| **Formatting** | `cargo fmt --all -- --check` | Passed ✅ |
| **Linting** | `cargo clippy -p burn-tensor -p burn-backend-tests -- -D warnings` | Passed ✅ |
| **Testing** | `cargo test -p burn-backend-tests --test tensor -- hann_window` | 6/6 Passed ✅ |

I had check every line code to make sure the PR is right