### PR TITLE
Bump rustls-webpki to 0.103.10 and tar to 0.4.45

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8543,9 +8543,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ spin = { version = "0.10.0", features = [
 ] }
 strum = { version = "0.28.0", features = ["derive"] }
 syn = { version = "2.0.111", features = ["full", "extra-traits"] }
-tar = "0.4.44"
+tar = "0.4.45"
 tempfile = "3.24.0"
 textdistance = { version = "1.1.1", default-features = false }
 thiserror = { version = "2", default-features = false }

--- a/examples/custom-image-dataset/Cargo.toml
+++ b/examples/custom-image-dataset/Cargo.toml
@@ -27,4 +27,4 @@ burn = { path = "../../crates/burn", features = [
 
 # File download
 flate2 = { workspace = true }
-tar = "0.4.44"
+tar = { workspace = true }


### PR DESCRIPTION
Fixes cargo audit

https://rustsec.org/advisories/RUSTSEC-2026-0049
https://rustsec.org/advisories/RUSTSEC-2026-0067