### PR TITLE
Fix tch int_zeros dtype in sync

### DIFF
--- a/crates/burn-tch/src/backend.rs
+++ b/crates/burn-tch/src/backend.rs
@@ -153,7 +153,7 @@ impl<E: TchElement> Backend for LibTorch<E> {
                 burn_backend::read_sync(Self::int_into_data(Self::int_zeros(
                     [1].into(),
                     device,
-                    E::dtype().into(),
+                    <Self::IntElem as burn_backend::Element>::dtype().into(),
                 )))
                 .unwrap();
             }


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Fixes #4658 

The float elem type was incorrectly used to create an int tensor of zeros.

### Changes

Fixed the int elem type use in the manual sync.

