### PR TITLE
Add HammingWindow operator to burn-tensor

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/float/ops/hamming_window.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/hamming_window.rs
@@ -1,0 +1,65 @@
+use super::*;
+use burn_tensor::signal::hamming_window;
+use burn_tensor::{DType, TensorData, Tolerance};
+
+#[test]
+fn should_support_hamming_window_periodic() {
+    let tensor: TestTensor<1> = hamming_window(8, true, &Default::default());
+    let expected = TensorData::from([
+        0.086957, 0.220669, 0.543478, 0.866288, 1.0, 0.866288, 0.543478, 0.220669,
+    ]);
+
+    // Metal has less precise trigonometric functions.
+    let tolerance = Tolerance::default().set_half_precision_relative(1e-2);
+
+    tensor
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, tolerance);
+}
+
+#[test]
+fn should_support_hamming_window_symmetric() {
+    let tensor: TestTensor<1> = hamming_window(8, false, &Default::default());
+    let expected = TensorData::from([
+        0.086957, 0.258842, 0.645064, 0.954790, 0.954790, 0.645064, 0.258842, 0.086957,
+    ]);
+
+    // Metal has less precise trigonometric functions.
+    let tolerance = Tolerance::default().set_half_precision_relative(1e-2);
+
+    tensor
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, tolerance);
+}
+
+#[test]
+fn should_support_hamming_window_options_dtype() {
+    let tensor: TestTensor<1> = hamming_window(4, true, (&Default::default(), DType::F32));
+    assert_eq!(tensor.dtype(), DType::F32);
+}
+
+#[test]
+fn should_support_hamming_window_empty() {
+    let tensor: TestTensor<1> = hamming_window(0, true, &Default::default());
+    assert_eq!(tensor.shape().dims(), [0]);
+}
+
+#[test]
+fn should_handle_hamming_window_size_one_symmetric() {
+    let tensor: TestTensor<1> = hamming_window(1, false, &Default::default());
+    let expected = TensorData::from([1.0]);
+
+    tensor
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
+}
+
+#[test]
+fn should_handle_hamming_window_size_one_periodic() {
+    let tensor: TestTensor<1> = hamming_window(1, true, &Default::default());
+    let expected = TensorData::from([1.0]);
+
+    tensor
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
+}

--- a/crates/burn-backend-tests/tests/tensor/float/ops/mod.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/mod.rs
@@ -30,6 +30,7 @@ mod fmod;
 mod full;
 mod gather_scatter;
 mod grid_sample;
+mod hamming_window;
 mod hann_window;
 mod inf;
 mod init;

--- a/crates/burn-tensor/src/tensor/signal/hamming_window.rs
+++ b/crates/burn-tensor/src/tensor/signal/hamming_window.rs
@@ -1,0 +1,72 @@
+use burn_backend::{
+    Backend,
+    tensor::{Float, Int},
+};
+
+use crate::{Tensor, TensorCreationOptions, check, check::TensorCheck};
+
+/// Creates a 1D Hamming window.
+///
+#[cfg_attr(
+    doc,
+    doc = r#"
+$$w_n = \alpha - \beta \cos\left(\frac{2\pi n}{N}\right)$$
+
+where $\alpha = 25/46$, $\beta = 1 - \alpha$, and $N$ = `size` when `periodic` is `true`, or $N$ = `size - 1` when `periodic` is `false`.
+"#
+)]
+#[cfg_attr(
+    not(doc),
+    doc = "`w_n = 25/46 - 21/46 * cos(2πn/N)` where N = size (periodic) or N = size-1 (symmetric)"
+)]
+///
+/// # Notes
+///
+/// - `size == 0` returns an empty tensor.
+/// - `size == 1` returns `[1.0]` regardless of `periodic`.
+///
+/// # Example
+///
+/// ```rust
+/// use burn_tensor::backend::Backend;
+/// use burn_tensor::signal::hamming_window;
+///
+/// fn example<B: Backend>() {
+///     let device = B::Device::default();
+///     let window = hamming_window::<B>(8, true, &device);
+///     println!("{window}");
+/// }
+/// ```
+pub fn hamming_window<B: Backend>(
+    size: usize,
+    periodic: bool,
+    options: impl Into<TensorCreationOptions<B>>,
+) -> Tensor<B, 1> {
+    let opt = options.into();
+    let dtype = opt.resolve_dtype::<Float>();
+    let shape = [size];
+    check!(TensorCheck::creation_ops::<1>("HammingWindow", &shape));
+
+    if size == 0 {
+        return Tensor::<B, 1>::empty(shape, opt).cast(dtype);
+    }
+
+    if size == 1 {
+        return Tensor::<B, 1>::ones(shape, opt).cast(dtype);
+    }
+
+    let size_i64 = i64::try_from(size).expect("HammingWindow size doesn't fit in i64 range.");
+    let denominator = if periodic { size } else { size - 1 };
+    let angular_increment = (2.0 * core::f64::consts::PI) / denominator as f64;
+
+    let alpha = 25.0_f64 / 46.0_f64;
+    let beta = 1.0 - alpha;
+
+    Tensor::<B, 1, Int>::arange(0..size_i64, &opt.device)
+        .float()
+        .mul_scalar(angular_increment)
+        .cos()
+        .mul_scalar(-beta)
+        .add_scalar(alpha)
+        .cast(dtype)
+}

--- a/crates/burn-tensor/src/tensor/signal/mod.rs
+++ b/crates/burn-tensor/src/tensor/signal/mod.rs
@@ -1,3 +1,5 @@
+mod hamming_window;
 mod hann_window;
 
+pub use hamming_window::*;
 pub use hann_window::*;


### PR DESCRIPTION

## Pull Request Template

### Checklist
- [x] Confirmed that `cargo run-checks` command has been executed. (Note: Ran targeted checks instead due to local CUDA SDK limitations, see Testing section below for details).
- [ ] Made sure the book is up to date with changes in this PR. (Note: N/A, this is an API addition and the Rustdoc is fully documented).

### Related Issues/PRs
Addresses part of #4531 (Specifically the HammingWindow signal processing operator).

### Changes
Added the `HammingWindow` operator to the Tensor API to support signal processing models and align with ONNX specifications.

Detailed implementation:

**`crates/burn-tensor/src/tensor/signal/hamming_window.rs` & `mod.rs`:**

- Added `hamming_window(size, periodic, options)` to the signal module.
- Implemented the exact Hamming window formula: $w_n = \alpha - \beta \times \cos(2\pi n / N)$ leveraging existing tensor operations (`arange`, `float`, `cos`, `mul_scalar`, `add_scalar`, `cast`).
- Maintained exact mathematical precision by resolving the ONNX constants (0.543478 and 0.456522) into exact fractions for `f64` stability ($\alpha = 25/46$ and $\beta = 21/46$).
- Supported both periodic ($N = size$) and symmetric ($N = size - 1$) modes.
- Handled edge cases perfectly: `size = 0` returns an empty tensor, and `size = 1` returns `[1.0]` (preventing division-by-zero panics and matching PyTorch/NumPy behavior).
- Used `f64` precision for the angular increment calculation to ensure high accuracy before casting to the target dtype.
- Added dual-state documentation (`cfg_attr`) for clean KaTeX math rendering in Rustdoc and readable plain-text fallbacks in IDE hover hints.

**`crates/burn-backend-tests/tests/tensor/float/ops/hamming_window.rs` & `mod.rs`:**

- Registered the new test module.
- Added 6 comprehensive test cases covering `periodic` mode, `symmetric` mode, dtype options, empty tensors, and the `size=1` boundary for both modes.
- Calculated exact benchmark expected tensors to ensure precision against the updated $\alpha$ and $\beta$ coefficients.
- Used `assert_approx_eq` with `Tolerance` for cross-backend floating-point stability.

### Testing
I do not have CUDA on my device (Mac), so I followed the same methods of testing as #4631 


| Check | Command | Result |
| --- | --- | --- |
| Formatting | `cargo fmt --all -- --check` | Passed ✅ |
| Linting | `cargo clippy -p burn-tensor -p burn-backend-tests -- -D warnings` | Passed ✅ |
| Testing | `cargo test -p burn-backend-tests --test tensor -- hamming_window` | 6/6 Passed ✅ |

I had checked every line of code to make sure the PR is right.
