### PR TITLE
Add native impementations for scatter_nd / gather_nd; provide autodiff for assign & add

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,5 +1,5 @@
 [default]
-extend-ignore-identifiers-re = ["ratatui", "Ratatui", "NdArray*", "ND"]
+extend-ignore-identifiers-re = ["ratatui", "Ratatui", "NdArray*", "ND", ".*_nd.*", ".*Nd.*"]
 
 [default.extend-identifiers]
 UE4M3 = "UE4M3"
@@ -14,6 +14,8 @@ extend-exclude = [
 ]
 
 [default.extend-words]
+# Don't correct "nd" (n-dimensional, as in scatter_nd/gather_nd)
+nd = "nd"
 # Don't correct "arange" which is intentional
 arange = "arange"
 # Don't correct "convnet" (convolutional network)

--- a/_typos.toml
+++ b/_typos.toml
@@ -20,6 +20,5 @@ nd = "nd"
 arange = "arange"
 # Don't correct "convnet" (convolutional network)
 convnet = "convnet"
-# Don't correct "Nd" / "nd" in convNd / conv_nd (N-dimensional)
+# Don't correct "Nd" in convNd / conv_nd (N-dimensional)
 Nd = "Nd"
-nd = "nd"

--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -171,6 +171,12 @@ Those operations are available for all tensor kinds: `Int`, `Float`, and `Bool`.
 | `tensor.roll(shifts, dims)`                          | `tensor.roll(shifts, dims)`                                               |
 | `tensor.roll_dim(shift, dim)`                        | `tensor.roll([shift], [dim])`                                             |
 | `tensor.scatter(dim, indices, values, update)`       | `tensor.scatter_add(dim, indices, values)`                                |
+| `tensor.scatter_nd(indices, values)`                 | `tensor.scatter_(0, indices, values)` (flattened)                         |
+| `tensor.scatter_nd_add(indices, values)`             | `tensor.scatter_add(0, indices, values)` (flattened)                      |
+| `tensor.scatter_nd_mul(indices, values)`             | `tensor.scatter_reduce(0, indices, values, "prod")` (flattened) [^1]      |
+| `tensor.scatter_nd_min(indices, values)`             | `tensor.scatter_reduce(0, indices, values, "amin")` (flattened) [^1]      |
+| `tensor.scatter_nd_max(indices, values)`             | `tensor.scatter_reduce(0, indices, values, "amax")` (flattened) [^1]      |
+| `tensor.gather_nd(indices)`                          | N/A (flatten + `index_select`)                                            |
 | `tensor.select(dim, indices)`                        | `tensor.index_select(dim, indices)`                                       |
 | `tensor.select_assign(dim, indices, values, update)` | `tensor.index_add(dim, indices, values)`                                  |
 | `tensor.shape()`                                     | `tensor.shape`                                                            |
@@ -194,6 +200,9 @@ Those operations are available for all tensor kinds: `Int`, `Float`, and `Bool`.
 | `Tensor::full(shape, fill_value, options)`           | `torch.full(shape, fill_value, device=device, dtype=dtype)`               |
 | `Tensor::ones(shape, options)`                       | `torch.ones(shape, device=device, dtype=dtype)`                           |
 | `Tensor::zeros(shape, options)`                      | `torch.zeros(shape, device=device, dtype=dtype)`                          |
+
+[^1]: Forward pass only. Autodiff is supported for `scatter_nd` (assign) and `scatter_nd_add`;
+mul/min/max reductions do not support backward.
 
 ### Numeric Operations
 

--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -171,12 +171,8 @@ Those operations are available for all tensor kinds: `Int`, `Float`, and `Bool`.
 | `tensor.roll(shifts, dims)`                          | `tensor.roll(shifts, dims)`                                               |
 | `tensor.roll_dim(shift, dim)`                        | `tensor.roll([shift], [dim])`                                             |
 | `tensor.scatter(dim, indices, values, update)`       | `tensor.scatter_add(dim, indices, values)`                                |
-| `tensor.scatter_nd(indices, values)`                 | `tensor.scatter_(0, indices, values)` (flattened)                         |
-| `tensor.scatter_nd_add(indices, values)`             | `tensor.scatter_add(0, indices, values)` (flattened)                      |
-| `tensor.scatter_nd_mul(indices, values)`             | `tensor.scatter_reduce(0, indices, values, "prod")` (flattened) [^1]      |
-| `tensor.scatter_nd_min(indices, values)`             | `tensor.scatter_reduce(0, indices, values, "amin")` (flattened) [^1]      |
-| `tensor.scatter_nd_max(indices, values)`             | `tensor.scatter_reduce(0, indices, values, "amax")` (flattened) [^1]      |
-| `tensor.gather_nd(indices)`                          | N/A (flatten + `index_select`)                                            |
+| `tensor.scatter_nd(indices, values, update)`[^1]     | N/A                                                                       |
+| `tensor.gather_nd(indices)`                          | N/A                                                                       |
 | `tensor.select(dim, indices)`                        | `tensor.index_select(dim, indices)`                                       |
 | `tensor.select_assign(dim, indices, values, update)` | `tensor.index_add(dim, indices, values)`                                  |
 | `tensor.shape()`                                     | `tensor.shape`                                                            |
@@ -201,7 +197,7 @@ Those operations are available for all tensor kinds: `Int`, `Float`, and `Bool`.
 | `Tensor::ones(shape, options)`                       | `torch.ones(shape, device=device, dtype=dtype)`                           |
 | `Tensor::zeros(shape, options)`                      | `torch.zeros(shape, device=device, dtype=dtype)`                          |
 
-[^1]: Forward pass only. Autodiff is supported for `scatter_nd` (assign) and `scatter_nd_add`;
+[^1]: Forward pass only. Autodiff is supported for `scatter_nd` assign and add;
 mul/min/max reductions do not support backward.
 
 ### Numeric Operations

--- a/crates/burn-autodiff/src/ops/tensor.rs
+++ b/crates/burn-autodiff/src/ops/tensor.rs
@@ -1125,8 +1125,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                         _checkpointer: &mut Checkpointer,
                     ) {
                         let (indices, values_shape, device) = ops.state;
-                        let [indices_4lhs, indices_4rhs] =
-                            duplicate(&ops.parents, Some(indices));
+                        let [indices_4lhs, indices_4rhs] = duplicate(&ops.parents, Some(indices));
 
                         binary::<B, _, _>(
                             ops.parents,
@@ -1134,11 +1133,8 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                             grads,
                             |grad| {
                                 // Zero out the scattered positions in grad
-                                let zeros = B::float_zeros(
-                                    values_shape,
-                                    &device,
-                                    grad.dtype().into(),
-                                );
+                                let zeros =
+                                    B::float_zeros(values_shape, &device, grad.dtype().into());
                                 B::float_scatter_nd(
                                     grad,
                                     indices_4lhs.unwrap(),
@@ -1186,10 +1182,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
         }
     }
 
-    fn float_gather_nd(
-        data: FloatTensor<Self>,
-        indices: IntTensor<B>,
-    ) -> FloatTensor<Self> {
+    fn float_gather_nd(data: FloatTensor<Self>, indices: IntTensor<B>) -> FloatTensor<Self> {
         #[derive(Debug)]
         struct GatherNd;
 
@@ -1229,9 +1222,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                 ),
                 B::float_gather_nd(data.primitive, indices),
             ),
-            OpsKind::UnTracked(prep) => {
-                prep.finish(B::float_gather_nd(data.primitive, indices))
-            }
+            OpsKind::UnTracked(prep) => prep.finish(B::float_gather_nd(data.primitive, indices)),
         }
     }
 

--- a/crates/burn-autodiff/src/ops/tensor.rs
+++ b/crates/burn-autodiff/src/ops/tensor.rs
@@ -1054,6 +1054,187 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
         }
     }
 
+    fn float_scatter_nd(
+        data: FloatTensor<Self>,
+        indices: IntTensor<B>,
+        values: FloatTensor<Self>,
+        reduction: burn_backend::tensor::ScatterNdReduction,
+    ) -> FloatTensor<Self> {
+        use burn_backend::tensor::ScatterNdReduction;
+
+        match reduction {
+            ScatterNdReduction::Add => {
+                #[derive(Debug)]
+                struct ScatterNdAdd;
+
+                impl<B: Backend> Backward<B, 2> for ScatterNdAdd {
+                    type State = IntTensor<B>;
+
+                    fn backward(
+                        self,
+                        ops: Ops<Self::State, 2>,
+                        grads: &mut Gradients,
+                        _checkpointer: &mut Checkpointer,
+                    ) {
+                        let indices = ops.state;
+                        let [_, indices_4rhs] = duplicate(&ops.parents, Some(indices));
+
+                        binary::<B, _, _>(
+                            ops.parents,
+                            ops.node,
+                            grads,
+                            |grad| grad,
+                            |grad| B::float_gather_nd(grad, indices_4rhs.unwrap()),
+                        );
+                    }
+                }
+
+                match ScatterNdAdd
+                    .prepare::<C>([data.node, values.node])
+                    .compute_bound()
+                    .stateful()
+                {
+                    OpsKind::Tracked(prep) => prep.finish(
+                        indices.clone(),
+                        B::float_scatter_nd(
+                            data.primitive,
+                            indices,
+                            values.primitive,
+                            ScatterNdReduction::Add,
+                        ),
+                    ),
+                    OpsKind::UnTracked(prep) => prep.finish(B::float_scatter_nd(
+                        data.primitive,
+                        indices,
+                        values.primitive,
+                        ScatterNdReduction::Add,
+                    )),
+                }
+            }
+            ScatterNdReduction::Assign => {
+                #[derive(Debug)]
+                struct ScatterNdAssign;
+
+                impl<B: Backend> Backward<B, 2> for ScatterNdAssign {
+                    type State = (IntTensor<B>, Shape, B::Device);
+
+                    fn backward(
+                        self,
+                        ops: Ops<Self::State, 2>,
+                        grads: &mut Gradients,
+                        _checkpointer: &mut Checkpointer,
+                    ) {
+                        let (indices, values_shape, device) = ops.state;
+                        let [indices_4lhs, indices_4rhs] =
+                            duplicate(&ops.parents, Some(indices));
+
+                        binary::<B, _, _>(
+                            ops.parents,
+                            ops.node,
+                            grads,
+                            |grad| {
+                                // Zero out the scattered positions in grad
+                                let zeros = B::float_zeros(
+                                    values_shape,
+                                    &device,
+                                    grad.dtype().into(),
+                                );
+                                B::float_scatter_nd(
+                                    grad,
+                                    indices_4lhs.unwrap(),
+                                    zeros,
+                                    ScatterNdReduction::Assign,
+                                )
+                            },
+                            |grad| B::float_gather_nd(grad, indices_4rhs.unwrap()),
+                        );
+                    }
+                }
+
+                match ScatterNdAssign
+                    .prepare::<C>([data.node, values.node])
+                    .compute_bound()
+                    .stateful()
+                {
+                    OpsKind::Tracked(prep) => prep.finish(
+                        (
+                            indices.clone(),
+                            values.primitive.shape(),
+                            B::float_device(&data.primitive),
+                        ),
+                        B::float_scatter_nd(
+                            data.primitive,
+                            indices,
+                            values.primitive,
+                            ScatterNdReduction::Assign,
+                        ),
+                    ),
+                    OpsKind::UnTracked(prep) => prep.finish(B::float_scatter_nd(
+                        data.primitive,
+                        indices,
+                        values.primitive,
+                        ScatterNdReduction::Assign,
+                    )),
+                }
+            }
+            _ => panic!(
+                "scatter_nd backward is not supported for {:?} reduction. \
+                 Only Assign and Add support autograd. Use these reductions in \
+                 inference-only contexts or detach the tensor first.",
+                reduction,
+            ),
+        }
+    }
+
+    fn float_gather_nd(
+        data: FloatTensor<Self>,
+        indices: IntTensor<B>,
+    ) -> FloatTensor<Self> {
+        #[derive(Debug)]
+        struct GatherNd;
+
+        impl<B: Backend> Backward<B, 1> for GatherNd {
+            type State = (IntTensor<B>, Shape, B::Device);
+
+            fn backward(
+                self,
+                ops: Ops<Self::State, 1>,
+                grads: &mut Gradients,
+                _checkpointer: &mut Checkpointer,
+            ) {
+                let (indices, data_shape, device) = ops.state;
+
+                unary::<B, _>(ops.parents, ops.node, grads, |grad| {
+                    let zeros = B::float_zeros(data_shape, &device, grad.dtype().into());
+                    B::float_scatter_nd(
+                        zeros,
+                        indices,
+                        grad,
+                        burn_backend::tensor::ScatterNdReduction::Add,
+                    )
+                });
+            }
+        }
+
+        match GatherNd
+            .prepare::<C>([data.node])
+            .compute_bound()
+            .stateful()
+        {
+            OpsKind::Tracked(prep) => prep.finish(
+                (
+                    indices.clone(),
+                    data.primitive.shape(),
+                    B::float_device(&data.primitive),
+                ),
+                B::float_gather_nd(data.primitive, indices),
+            ),
+            OpsKind::UnTracked(prep) => {
+                prep.finish(B::float_gather_nd(data.primitive, indices))
+            }
+        }
+    }
+
     fn float_select(
         tensor: FloatTensor<Self>,
         dim: usize,

--- a/crates/burn-autodiff/src/ops/tensor.rs
+++ b/crates/burn-autodiff/src/ops/tensor.rs
@@ -1058,13 +1058,13 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
         data: FloatTensor<Self>,
         indices: IntTensor<B>,
         values: FloatTensor<Self>,
-        reduction: burn_backend::tensor::ScatterNdReduction,
+        reduction: burn_backend::tensor::IndexingUpdateOp,
     ) -> FloatTensor<Self> {
-        use burn_backend::tensor::ScatterNdReduction;
+        use burn_backend::tensor::IndexingUpdateOp;
 
         if matches!(
             reduction,
-            ScatterNdReduction::Mul | ScatterNdReduction::Min | ScatterNdReduction::Max
+            IndexingUpdateOp::Mul | IndexingUpdateOp::Min | IndexingUpdateOp::Max
         ) && (!data.node.requirement.is_none() || !values.node.requirement.is_none())
         {
             panic!(
@@ -1075,7 +1075,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
         }
 
         match reduction {
-            ScatterNdReduction::Add => {
+            IndexingUpdateOp::Add => {
                 #[derive(Debug)]
                 struct ScatterNdAdd;
 
@@ -1112,18 +1112,18 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                             data.primitive,
                             indices,
                             values.primitive,
-                            ScatterNdReduction::Add,
+                            IndexingUpdateOp::Add,
                         ),
                     ),
                     OpsKind::UnTracked(prep) => prep.finish(B::float_scatter_nd(
                         data.primitive,
                         indices,
                         values.primitive,
-                        ScatterNdReduction::Add,
+                        IndexingUpdateOp::Add,
                     )),
                 }
             }
-            ScatterNdReduction::Assign => {
+            IndexingUpdateOp::Assign => {
                 #[derive(Debug)]
                 struct ScatterNdAssign;
 
@@ -1151,7 +1151,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                                     grad,
                                     indices_4lhs.unwrap(),
                                     zeros,
-                                    ScatterNdReduction::Assign,
+                                    IndexingUpdateOp::Assign,
                                 )
                             },
                             |grad| B::float_gather_nd(grad, indices_4rhs.unwrap()),
@@ -1174,14 +1174,14 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                             data.primitive,
                             indices,
                             values.primitive,
-                            ScatterNdReduction::Assign,
+                            IndexingUpdateOp::Assign,
                         ),
                     ),
                     OpsKind::UnTracked(prep) => prep.finish(B::float_scatter_nd(
                         data.primitive,
                         indices,
                         values.primitive,
-                        ScatterNdReduction::Assign,
+                        IndexingUpdateOp::Assign,
                     )),
                 }
             }
@@ -1215,7 +1215,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                         zeros,
                         indices,
                         grad,
-                        burn_backend::tensor::ScatterNdReduction::Add,
+                        burn_backend::tensor::IndexingUpdateOp::Add,
                     )
                 });
             }

--- a/crates/burn-autodiff/src/ops/tensor.rs
+++ b/crates/burn-autodiff/src/ops/tensor.rs
@@ -1185,12 +1185,45 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                     )),
                 }
             }
-            _ => panic!(
-                "scatter_nd backward is not supported for {:?} reduction. \
-                 Only Assign and Add support autograd. Use these reductions in \
-                 inference-only contexts or detach the tensor first.",
-                reduction,
-            ),
+            // The early check above ensures no input requires grad for Mul/Min/Max,
+            // so we can safely forward to the inner backend without registering a
+            // backward op.
+            IndexingUpdateOp::Mul | IndexingUpdateOp::Min | IndexingUpdateOp::Max => {
+                #[derive(Debug)]
+                struct ScatterNdNoBackward;
+
+                impl<B: Backend> Backward<B, 2> for ScatterNdNoBackward {
+                    type State = ();
+
+                    fn backward(
+                        self,
+                        _ops: Ops<Self::State, 2>,
+                        _grads: &mut Gradients,
+                        _checkpointer: &mut Checkpointer,
+                    ) {
+                        unreachable!(
+                            "scatter_nd Mul/Min/Max backward must not run; \
+                             the forward path rejects grad-tracked inputs."
+                        )
+                    }
+                }
+
+                match ScatterNdNoBackward
+                    .prepare::<C>([data.node, values.node])
+                    .compute_bound()
+                    .stateful()
+                {
+                    OpsKind::Tracked(_) => unreachable!(
+                        "scatter_nd Mul/Min/Max forward path rejects grad-tracked inputs."
+                    ),
+                    OpsKind::UnTracked(prep) => prep.finish(B::float_scatter_nd(
+                        data.primitive,
+                        indices,
+                        values.primitive,
+                        reduction,
+                    )),
+                }
+            }
         }
     }
 

--- a/crates/burn-autodiff/src/ops/tensor.rs
+++ b/crates/burn-autodiff/src/ops/tensor.rs
@@ -1062,6 +1062,18 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
     ) -> FloatTensor<Self> {
         use burn_backend::tensor::ScatterNdReduction;
 
+        if matches!(
+            reduction,
+            ScatterNdReduction::Mul | ScatterNdReduction::Min | ScatterNdReduction::Max
+        ) && (!data.node.requirement.is_none() || !values.node.requirement.is_none())
+        {
+            panic!(
+                "scatter_nd with {:?} reduction does not support autograd. \
+                 Detach the input tensors or use Assign/Add reduction instead.",
+                reduction,
+            );
+        }
+
         match reduction {
             ScatterNdReduction::Add => {
                 #[derive(Debug)]

--- a/crates/burn-backend-tests/tests/autodiff/gather_scatter_nd.rs
+++ b/crates/burn-backend-tests/tests/autodiff/gather_scatter_nd.rs
@@ -1,0 +1,85 @@
+use super::*;
+use burn_tensor::TensorData;
+
+#[test]
+fn test_scatter_nd_add_grad() {
+    let device = AutodiffDevice::new();
+    let data: TestTensor<2> = TestTensor::from_data(
+        TensorData::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]),
+        &device,
+    )
+    .require_grad();
+    let values: TestTensor<2> =
+        TestTensor::from_data(TensorData::from([[10.0, 20.0, 30.0]]), &device).require_grad();
+    let indices = TestTensorInt::<2>::from_data(TensorData::from([[1]]), &device);
+
+    // scatter_nd_add: data[1, :] += values[0, :]
+    let result: TestTensor<2> = data.clone().scatter_nd_add(indices, values.clone());
+    let grads = result.sum().backward();
+
+    let grad_data = data.grad(&grads).unwrap();
+    let grad_values = values.grad(&grads).unwrap();
+
+    // grad_data = all ones (identity for add)
+    grad_data.to_data().assert_eq(
+        &TensorData::from([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]),
+        false,
+    );
+    // grad_values = gather_nd(ones, indices) = ones at row 1
+    grad_values
+        .to_data()
+        .assert_eq(&TensorData::from([[1.0, 1.0, 1.0]]), false);
+}
+
+#[test]
+fn test_scatter_nd_assign_grad() {
+    let device = AutodiffDevice::new();
+    let data: TestTensor<2> = TestTensor::from_data(
+        TensorData::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]),
+        &device,
+    )
+    .require_grad();
+    let values: TestTensor<2> =
+        TestTensor::from_data(TensorData::from([[10.0, 20.0, 30.0]]), &device).require_grad();
+    let indices = TestTensorInt::<2>::from_data(TensorData::from([[1]]), &device);
+
+    // scatter_nd (assign): data[1, :] = values[0, :]
+    let result: TestTensor<2> = data.clone().scatter_nd(indices, values.clone());
+    let grads = result.sum().backward();
+
+    let grad_data = data.grad(&grads).unwrap();
+    let grad_values = values.grad(&grads).unwrap();
+
+    // grad_data: all ones except row 1 is zeroed out (overwritten positions get no gradient)
+    grad_data.to_data().assert_eq(
+        &TensorData::from([[1.0, 1.0, 1.0], [0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]),
+        false,
+    );
+    // grad_values = gather_nd(ones, indices) = ones at row 1
+    grad_values
+        .to_data()
+        .assert_eq(&TensorData::from([[1.0, 1.0, 1.0]]), false);
+}
+
+#[test]
+fn test_gather_nd_grad() {
+    let device = AutodiffDevice::new();
+    let data: TestTensor<2> = TestTensor::from_data(
+        TensorData::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]),
+        &device,
+    )
+    .require_grad();
+    let indices = TestTensorInt::<2>::from_data(TensorData::from([[0], [2]]), &device);
+
+    // gather_nd: extract rows 0 and 2
+    let result: TestTensor<2> = data.clone().gather_nd(indices);
+    let grads = result.sum().backward();
+
+    let grad_data = data.grad(&grads).unwrap();
+
+    // grad_data: scatter_nd(zeros, indices, ones, Add) -> row 0 and 2 get 1s, row 1 stays 0
+    grad_data.to_data().assert_eq(
+        &TensorData::from([[1.0, 1.0, 1.0], [0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]),
+        false,
+    );
+}

--- a/crates/burn-backend-tests/tests/autodiff/gather_scatter_nd.rs
+++ b/crates/burn-backend-tests/tests/autodiff/gather_scatter_nd.rs
@@ -83,3 +83,80 @@ fn test_gather_nd_grad() {
         false,
     );
 }
+
+#[test]
+fn test_scatter_nd_add_grad_k_equals_d() {
+    // K=D: scalar-level indexing (each index tuple selects a single element)
+    let device = AutodiffDevice::new();
+    let data: TestTensor<2> =
+        TestTensor::from_data(TensorData::from([[1.0, 2.0], [3.0, 4.0]]), &device).require_grad();
+    let values: TestTensor<1> =
+        TestTensor::from_data(TensorData::from([10.0, 20.0]), &device).require_grad();
+    // indices shape: [2, 2] => K=2=D, M=2, DV = 1+2-2 = 1
+    let indices = TestTensorInt::<2>::from_data(TensorData::from([[0, 1], [1, 0]]), &device);
+
+    let result: TestTensor<2> = data.clone().scatter_nd_add(indices, values.clone());
+    let grads = result.sum().backward();
+
+    let grad_data = data.grad(&grads).unwrap();
+    let grad_values = values.grad(&grads).unwrap();
+
+    // grad_data = all ones (identity for add)
+    grad_data
+        .to_data()
+        .assert_eq(&TensorData::from([[1.0, 1.0], [1.0, 1.0]]), false);
+    // grad_values = gather_nd(ones, indices) = [1.0, 1.0]
+    grad_values
+        .to_data()
+        .assert_eq(&TensorData::from([1.0, 1.0]), false);
+}
+
+#[test]
+fn test_gather_nd_grad_k_equals_d() {
+    // K=D: scalar-level gather
+    let device = AutodiffDevice::new();
+    let data: TestTensor<2> =
+        TestTensor::from_data(TensorData::from([[1.0, 2.0], [3.0, 4.0]]), &device).require_grad();
+    // indices shape: [2, 2] => K=2=D
+    let indices = TestTensorInt::<2>::from_data(TensorData::from([[0, 1], [1, 0]]), &device);
+
+    let result: TestTensor<1> = data.clone().gather_nd(indices);
+    let grads = result.sum().backward();
+
+    let grad_data = data.grad(&grads).unwrap();
+
+    // grad = scatter_nd(zeros, indices, ones, Add)
+    // [0,1] => data[0][1] gets 1, [1,0] => data[1][0] gets 1
+    grad_data
+        .to_data()
+        .assert_eq(&TensorData::from([[0.0, 1.0], [1.0, 0.0]]), false);
+}
+
+#[test]
+fn test_scatter_nd_assign_grad_k_equals_d() {
+    // K=D: scalar-level assign, each index overwrites a single element
+    let device = AutodiffDevice::new();
+    let data: TestTensor<2> =
+        TestTensor::from_data(TensorData::from([[1.0, 2.0], [3.0, 4.0]]), &device).require_grad();
+    let values: TestTensor<1> =
+        TestTensor::from_data(TensorData::from([10.0, 20.0]), &device).require_grad();
+    // indices shape: [2, 2] => K=2=D
+    // Overwrite data[0,1] and data[1,0]
+    let indices = TestTensorInt::<2>::from_data(TensorData::from([[0, 1], [1, 0]]), &device);
+
+    let result: TestTensor<2> = data.clone().scatter_nd(indices, values.clone());
+    let grads = result.sum().backward();
+
+    let grad_data = data.grad(&grads).unwrap();
+    let grad_values = values.grad(&grads).unwrap();
+
+    // grad_data: ones everywhere except the overwritten positions are zeroed
+    // [0,1] and [1,0] were overwritten, so those get 0
+    grad_data
+        .to_data()
+        .assert_eq(&TensorData::from([[1.0, 0.0], [0.0, 1.0]]), false);
+    // grad_values = gather_nd(ones, indices) = [1.0, 1.0]
+    grad_values
+        .to_data()
+        .assert_eq(&TensorData::from([1.0, 1.0]), false);
+}

--- a/crates/burn-backend-tests/tests/autodiff/gather_scatter_nd.rs
+++ b/crates/burn-backend-tests/tests/autodiff/gather_scatter_nd.rs
@@ -1,5 +1,5 @@
 use super::*;
-use burn_tensor::TensorData;
+use burn_tensor::{IndexingUpdateOp, TensorData};
 
 #[test]
 fn test_scatter_nd_add_grad() {
@@ -14,7 +14,9 @@ fn test_scatter_nd_add_grad() {
     let indices = TestTensorInt::<2>::from_data(TensorData::from([[1]]), &device);
 
     // scatter_nd_add: data[1, :] += values[0, :]
-    let result: TestTensor<2> = data.clone().scatter_nd_add(indices, values.clone());
+    let result: TestTensor<2> =
+        data.clone()
+            .scatter_nd(indices, values.clone(), IndexingUpdateOp::Add);
     let grads = result.sum().backward();
 
     let grad_data = data.grad(&grads).unwrap();
@@ -44,7 +46,9 @@ fn test_scatter_nd_assign_grad() {
     let indices = TestTensorInt::<2>::from_data(TensorData::from([[1]]), &device);
 
     // scatter_nd (assign): data[1, :] = values[0, :]
-    let result: TestTensor<2> = data.clone().scatter_nd(indices, values.clone());
+    let result: TestTensor<2> =
+        data.clone()
+            .scatter_nd(indices, values.clone(), IndexingUpdateOp::Assign);
     let grads = result.sum().backward();
 
     let grad_data = data.grad(&grads).unwrap();
@@ -95,7 +99,9 @@ fn test_scatter_nd_add_grad_k_equals_d() {
     // indices shape: [2, 2] => K=2=D, M=2, DV = 1+2-2 = 1
     let indices = TestTensorInt::<2>::from_data(TensorData::from([[0, 1], [1, 0]]), &device);
 
-    let result: TestTensor<2> = data.clone().scatter_nd_add(indices, values.clone());
+    let result: TestTensor<2> =
+        data.clone()
+            .scatter_nd(indices, values.clone(), IndexingUpdateOp::Add);
     let grads = result.sum().backward();
 
     let grad_data = data.grad(&grads).unwrap();
@@ -144,7 +150,9 @@ fn test_scatter_nd_assign_grad_k_equals_d() {
     // Overwrite data[0,1] and data[1,0]
     let indices = TestTensorInt::<2>::from_data(TensorData::from([[0, 1], [1, 0]]), &device);
 
-    let result: TestTensor<2> = data.clone().scatter_nd(indices, values.clone());
+    let result: TestTensor<2> =
+        data.clone()
+            .scatter_nd(indices, values.clone(), IndexingUpdateOp::Assign);
     let grads = result.sum().backward();
 
     let grad_data = data.grad(&grads).unwrap();

--- a/crates/burn-backend-tests/tests/autodiff/mod.rs
+++ b/crates/burn-backend-tests/tests/autodiff/mod.rs
@@ -38,6 +38,7 @@ mod expand;
 mod flip;
 mod floor;
 mod gather_scatter;
+mod gather_scatter_nd;
 mod gelu;
 mod gradients;
 mod log;

--- a/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter_nd.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter_nd.rs
@@ -1,0 +1,254 @@
+use super::*;
+use burn_tensor::TensorData;
+
+#[test]
+fn test_gather_nd_2d_k_equals_d() {
+    // Gather single elements from a 2D tensor (K=D=2)
+    let device = Default::default();
+    // data shape: [3, 3]
+    let data = TestTensor::<2>::from_floats(
+        [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]],
+        &device,
+    );
+    // indices shape: [3, 2] => K=2, M=2, DV = M-1+D-K = 1+2-2 = 1
+    // Each row is [row, col]
+    let indices = TestTensorInt::<2>::from_ints([[0, 1], [1, 2], [2, 0]], &device);
+
+    let output: TestTensor<1> = data.gather_nd(indices);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([1.0, 5.0, 6.0]), false);
+}
+
+#[test]
+fn test_gather_nd_3d_k1_slices() {
+    // Gather 2D slices from a 3D tensor (K=1)
+    let device = Default::default();
+    // data shape: [2, 3, 4]
+    let data = TestTensor::<3>::from_floats(
+        [
+            [
+                [0.0, 1.0, 2.0, 3.0],
+                [4.0, 5.0, 6.0, 7.0],
+                [8.0, 9.0, 10.0, 11.0],
+            ],
+            [
+                [12.0, 13.0, 14.0, 15.0],
+                [16.0, 17.0, 18.0, 19.0],
+                [20.0, 21.0, 22.0, 23.0],
+            ],
+        ],
+        &device,
+    );
+    // indices shape: [2, 1] => K=1, M=2, DV = 1 + 3 - 1 = 3
+    // Each index selects a whole 2D slice along dim 0
+    let indices = TestTensorInt::<2>::from_ints([[1], [0]], &device);
+
+    let output: TestTensor<3> = data.gather_nd(indices);
+
+    output.into_data().assert_eq(
+        &TensorData::from([
+            [
+                [12.0, 13.0, 14.0, 15.0],
+                [16.0, 17.0, 18.0, 19.0],
+                [20.0, 21.0, 22.0, 23.0],
+            ],
+            [
+                [0.0, 1.0, 2.0, 3.0],
+                [4.0, 5.0, 6.0, 7.0],
+                [8.0, 9.0, 10.0, 11.0],
+            ],
+        ]),
+        false,
+    );
+}
+
+#[test]
+fn test_gather_nd_3d_k_equals_d() {
+    // Gather scalar elements from a 3D tensor (K=D=3)
+    let device = Default::default();
+    let data = TestTensor::<3>::from_floats(
+        [
+            [[0.0, 1.0], [2.0, 3.0]],
+            [[4.0, 5.0], [6.0, 7.0]],
+        ],
+        &device,
+    );
+    // indices shape: [2, 3] => K=3, M=2, DV = 1+3-3 = 1
+    let indices = TestTensorInt::<2>::from_ints([[0, 0, 1], [1, 1, 0]], &device);
+
+    let output: TestTensor<1> = data.gather_nd(indices);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([1.0, 6.0]), false);
+}
+
+#[test]
+fn test_gather_nd_batch() {
+    // Batch dimension in indices
+    let device = Default::default();
+    // data shape: [2, 3]
+    let data = TestTensor::<2>::from_floats([[10.0, 20.0, 30.0], [40.0, 50.0, 60.0]], &device);
+    // indices shape: [3, 2] => K=2, M=2, DV = 1+2-2 = 1
+    let indices = TestTensorInt::<2>::from_ints([[0, 0], [0, 2], [1, 1]], &device);
+
+    let output: TestTensor<1> = data.gather_nd(indices);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([10.0, 30.0, 50.0]), false);
+}
+
+#[test]
+fn test_scatter_nd_assign_2d() {
+    let device = Default::default();
+    // data shape: [3, 3], initialized to zeros
+    let data = TestTensor::<2>::zeros([3, 3], &device);
+    // indices shape: [2, 2] => K=2, M=2, DV = 1+2-2 = 1
+    let indices = TestTensorInt::<2>::from_ints([[0, 1], [2, 0]], &device);
+    // values shape: [2] (scalar per index tuple)
+    let values = TestTensor::<1>::from_floats([10.0, 20.0], &device);
+
+    let output = data.scatter_nd(indices, values);
+
+    output.into_data().assert_eq(
+        &TensorData::from([[0.0, 10.0, 0.0], [0.0, 0.0, 0.0], [20.0, 0.0, 0.0]]),
+        false,
+    );
+}
+
+#[test]
+fn test_scatter_nd_add_2d() {
+    let device = Default::default();
+    let data = TestTensor::<2>::from_floats(
+        [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0]],
+        &device,
+    );
+    let indices = TestTensorInt::<2>::from_ints([[0, 1], [2, 0]], &device);
+    let values = TestTensor::<1>::from_floats([10.0, 20.0], &device);
+
+    let output = data.scatter_nd_add(indices, values);
+
+    output.into_data().assert_eq(
+        &TensorData::from([[1.0, 11.0, 1.0], [1.0, 1.0, 1.0], [21.0, 1.0, 1.0]]),
+        false,
+    );
+}
+
+#[test]
+fn test_scatter_nd_add_duplicate_indices() {
+    let device = Default::default();
+    let data = TestTensor::<2>::zeros([2, 3], &device);
+    // Both index tuples point to the same location
+    let indices = TestTensorInt::<2>::from_ints([[0, 1], [0, 1]], &device);
+    let values = TestTensor::<1>::from_floats([5.0, 3.0], &device);
+
+    let output = data.scatter_nd_add(indices, values);
+
+    // Values should accumulate: 5.0 + 3.0 = 8.0
+    output.into_data().assert_eq(
+        &TensorData::from([[0.0, 8.0, 0.0], [0.0, 0.0, 0.0]]),
+        false,
+    );
+}
+
+#[test]
+fn test_scatter_nd_3d_slices() {
+    // Scatter 1D slices into a 3D tensor (K=1)
+    let device = Default::default();
+    // data shape: [2, 3]
+    let data = TestTensor::<2>::zeros([2, 3], &device);
+    // indices shape: [2, 1] => K=1, M=2, DV = 1+2-1 = 2
+    // Each index selects a row
+    let indices = TestTensorInt::<2>::from_ints([[0], [1]], &device);
+    // values shape: [2, 3]
+    let values =
+        TestTensor::<2>::from_floats([[10.0, 20.0, 30.0], [40.0, 50.0, 60.0]], &device);
+
+    let output = data.scatter_nd(indices, values);
+
+    output.into_data().assert_eq(
+        &TensorData::from([[10.0, 20.0, 30.0], [40.0, 50.0, 60.0]]),
+        false,
+    );
+}
+
+#[test]
+fn test_scatter_nd_mul() {
+    let device = Default::default();
+    let data = TestTensor::<2>::from_floats(
+        [[2.0, 3.0, 4.0], [5.0, 6.0, 7.0]],
+        &device,
+    );
+    let indices = TestTensorInt::<2>::from_ints([[0, 1], [1, 2]], &device);
+    let values = TestTensor::<1>::from_floats([10.0, 2.0], &device);
+
+    let output = data.scatter_nd_mul(indices, values);
+
+    output.into_data().assert_eq(
+        &TensorData::from([[2.0, 30.0, 4.0], [5.0, 6.0, 14.0]]),
+        false,
+    );
+}
+
+#[test]
+fn test_scatter_nd_min() {
+    let device = Default::default();
+    let data = TestTensor::<2>::from_floats(
+        [[5.0, 10.0], [15.0, 20.0]],
+        &device,
+    );
+    let indices = TestTensorInt::<2>::from_ints([[0, 0], [1, 1]], &device);
+    let values = TestTensor::<1>::from_floats([3.0, 25.0], &device);
+
+    let output = data.scatter_nd_min(indices, values);
+
+    // min(5.0, 3.0) = 3.0; min(20.0, 25.0) = 20.0
+    output.into_data().assert_eq(
+        &TensorData::from([[3.0, 10.0], [15.0, 20.0]]),
+        false,
+    );
+}
+
+#[test]
+fn test_scatter_nd_max() {
+    let device = Default::default();
+    let data = TestTensor::<2>::from_floats(
+        [[5.0, 10.0], [15.0, 20.0]],
+        &device,
+    );
+    let indices = TestTensorInt::<2>::from_ints([[0, 0], [1, 1]], &device);
+    let values = TestTensor::<1>::from_floats([3.0, 25.0], &device);
+
+    let output = data.scatter_nd_max(indices, values);
+
+    // max(5.0, 3.0) = 5.0; max(20.0, 25.0) = 25.0
+    output.into_data().assert_eq(
+        &TensorData::from([[5.0, 10.0], [15.0, 25.0]]),
+        false,
+    );
+}
+
+#[test]
+fn test_scatter_nd_batch() {
+    // Scatter with batch dimensions
+    let device = Default::default();
+    // data shape: [3, 3]
+    let data = TestTensor::<2>::zeros([3, 3], &device);
+    // indices shape: [3, 1] => K=1, M=2, DV = 1+2-1 = 2
+    let indices = TestTensorInt::<2>::from_ints([[0], [2], [1]], &device);
+    // values shape: [3, 3]
+    let values = TestTensor::<2>::from_floats(
+        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
+        &device,
+    );
+
+    let output = data.scatter_nd(indices, values);
+
+    output.into_data().assert_eq(
+        &TensorData::from([[1.0, 2.0, 3.0], [7.0, 8.0, 9.0], [4.0, 5.0, 6.0]]),
+        false,
+    );
+}

--- a/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter_nd.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter_nd.rs
@@ -130,6 +130,24 @@ fn test_scatter_nd_add_2d() {
     );
 }
 
+// Duplicate indices are non-deterministic on GPU; only test on CPU backends.
+#[cfg(feature = "ndarray")]
+#[test]
+fn test_scatter_nd_add_duplicate_indices() {
+    let device = Default::default();
+    let data = TestTensor::<2>::zeros([2, 3], &device);
+    // Both index tuples point to the same location
+    let indices = TestTensorInt::<2>::from_ints([[0, 1], [0, 1]], &device);
+    let values = TestTensor::<1>::from_floats([5.0, 3.0], &device);
+
+    let output = data.scatter_nd_add(indices, values);
+
+    // Values should accumulate: 5.0 + 3.0 = 8.0
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([[0.0, 8.0, 0.0], [0.0, 0.0, 0.0]]), false);
+}
+
 #[test]
 fn test_scatter_nd_3d_slices() {
     // Scatter 1D slices into a 3D tensor (K=1)
@@ -274,6 +292,65 @@ fn test_gather_scatter_nd_roundtrip() {
 
     reconstructed.into_data().assert_eq(
         &TensorData::from([[1.0, 2.0, 3.0], [0.0, 0.0, 0.0], [7.0, 8.0, 9.0]]),
+        false,
+    );
+}
+
+#[test]
+fn test_scatter_nd_3d_k2_partial_slices() {
+    // K=2 on 3D data: each index tuple selects a 1D row within a 2D slice
+    let device = Default::default();
+    // data shape: [2, 3, 4]
+    let data = TestTensor::<3>::zeros([2, 3, 4], &device);
+    // indices shape: [2, 2] => K=2, M=2, DV = 1+3-2 = 2
+    // [0, 1] => data[0, 1, :], [1, 2] => data[1, 2, :]
+    let indices = TestTensorInt::<2>::from_ints([[0, 1], [1, 2]], &device);
+    // values shape: [2, 4]
+    let values = TestTensor::<2>::from_floats(
+        [[10.0, 20.0, 30.0, 40.0], [50.0, 60.0, 70.0, 80.0]],
+        &device,
+    );
+
+    let output = data.scatter_nd(indices, values);
+
+    // Only data[0,1,:] and data[1,2,:] should be set
+    let output_data = output.into_data();
+    output_data.assert_eq(
+        &TensorData::from([
+            [
+                [0.0, 0.0, 0.0, 0.0],
+                [10.0, 20.0, 30.0, 40.0],
+                [0.0, 0.0, 0.0, 0.0],
+            ],
+            [
+                [0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0],
+                [50.0, 60.0, 70.0, 80.0],
+            ],
+        ]),
+        false,
+    );
+}
+
+#[test]
+fn test_gather_nd_3d_k2_partial_slices() {
+    // K=2 on 3D data: each index tuple gathers a 1D row
+    let device = Default::default();
+    let data = TestTensor::<3>::from_floats(
+        [
+            [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]],
+            [[7.0, 8.0], [9.0, 10.0], [11.0, 12.0]],
+        ],
+        &device,
+    );
+    // indices shape: [3, 2] => K=2, M=2, DV = 1+3-2 = 2
+    let indices = TestTensorInt::<2>::from_ints([[0, 2], [1, 0], [0, 1]], &device);
+
+    let output: TestTensor<2> = data.gather_nd(indices);
+
+    // [0,2] => [5,6], [1,0] => [7,8], [0,1] => [3,4]
+    output.into_data().assert_eq(
+        &TensorData::from([[5.0, 6.0], [7.0, 8.0], [3.0, 4.0]]),
         false,
     );
 }

--- a/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter_nd.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter_nd.rs
@@ -6,10 +6,8 @@ fn test_gather_nd_2d_k_equals_d() {
     // Gather single elements from a 2D tensor (K=D=2)
     let device = Default::default();
     // data shape: [3, 3]
-    let data = TestTensor::<2>::from_floats(
-        [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]],
-        &device,
-    );
+    let data =
+        TestTensor::<2>::from_floats([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]], &device);
     // indices shape: [3, 2] => K=2, M=2, DV = M-1+D-K = 1+2-2 = 1
     // Each row is [row, col]
     let indices = TestTensorInt::<2>::from_ints([[0, 1], [1, 2], [2, 0]], &device);
@@ -69,10 +67,7 @@ fn test_gather_nd_3d_k_equals_d() {
     // Gather scalar elements from a 3D tensor (K=D=3)
     let device = Default::default();
     let data = TestTensor::<3>::from_floats(
-        [
-            [[0.0, 1.0], [2.0, 3.0]],
-            [[4.0, 5.0], [6.0, 7.0]],
-        ],
+        [[[0.0, 1.0], [2.0, 3.0]], [[4.0, 5.0], [6.0, 7.0]]],
         &device,
     );
     // indices shape: [2, 3] => K=3, M=2, DV = 1+3-3 = 1
@@ -122,10 +117,8 @@ fn test_scatter_nd_assign_2d() {
 #[test]
 fn test_scatter_nd_add_2d() {
     let device = Default::default();
-    let data = TestTensor::<2>::from_floats(
-        [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0]],
-        &device,
-    );
+    let data =
+        TestTensor::<2>::from_floats([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0]], &device);
     let indices = TestTensorInt::<2>::from_ints([[0, 1], [2, 0]], &device);
     let values = TestTensor::<1>::from_floats([10.0, 20.0], &device);
 
@@ -148,10 +141,9 @@ fn test_scatter_nd_add_duplicate_indices() {
     let output = data.scatter_nd_add(indices, values);
 
     // Values should accumulate: 5.0 + 3.0 = 8.0
-    output.into_data().assert_eq(
-        &TensorData::from([[0.0, 8.0, 0.0], [0.0, 0.0, 0.0]]),
-        false,
-    );
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([[0.0, 8.0, 0.0], [0.0, 0.0, 0.0]]), false);
 }
 
 #[test]
@@ -164,8 +156,7 @@ fn test_scatter_nd_3d_slices() {
     // Each index selects a row
     let indices = TestTensorInt::<2>::from_ints([[0], [1]], &device);
     // values shape: [2, 3]
-    let values =
-        TestTensor::<2>::from_floats([[10.0, 20.0, 30.0], [40.0, 50.0, 60.0]], &device);
+    let values = TestTensor::<2>::from_floats([[10.0, 20.0, 30.0], [40.0, 50.0, 60.0]], &device);
 
     let output = data.scatter_nd(indices, values);
 
@@ -178,10 +169,7 @@ fn test_scatter_nd_3d_slices() {
 #[test]
 fn test_scatter_nd_mul() {
     let device = Default::default();
-    let data = TestTensor::<2>::from_floats(
-        [[2.0, 3.0, 4.0], [5.0, 6.0, 7.0]],
-        &device,
-    );
+    let data = TestTensor::<2>::from_floats([[2.0, 3.0, 4.0], [5.0, 6.0, 7.0]], &device);
     let indices = TestTensorInt::<2>::from_ints([[0, 1], [1, 2]], &device);
     let values = TestTensor::<1>::from_floats([10.0, 2.0], &device);
 
@@ -196,39 +184,31 @@ fn test_scatter_nd_mul() {
 #[test]
 fn test_scatter_nd_min() {
     let device = Default::default();
-    let data = TestTensor::<2>::from_floats(
-        [[5.0, 10.0], [15.0, 20.0]],
-        &device,
-    );
+    let data = TestTensor::<2>::from_floats([[5.0, 10.0], [15.0, 20.0]], &device);
     let indices = TestTensorInt::<2>::from_ints([[0, 0], [1, 1]], &device);
     let values = TestTensor::<1>::from_floats([3.0, 25.0], &device);
 
     let output = data.scatter_nd_min(indices, values);
 
     // min(5.0, 3.0) = 3.0; min(20.0, 25.0) = 20.0
-    output.into_data().assert_eq(
-        &TensorData::from([[3.0, 10.0], [15.0, 20.0]]),
-        false,
-    );
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([[3.0, 10.0], [15.0, 20.0]]), false);
 }
 
 #[test]
 fn test_scatter_nd_max() {
     let device = Default::default();
-    let data = TestTensor::<2>::from_floats(
-        [[5.0, 10.0], [15.0, 20.0]],
-        &device,
-    );
+    let data = TestTensor::<2>::from_floats([[5.0, 10.0], [15.0, 20.0]], &device);
     let indices = TestTensorInt::<2>::from_ints([[0, 0], [1, 1]], &device);
     let values = TestTensor::<1>::from_floats([3.0, 25.0], &device);
 
     let output = data.scatter_nd_max(indices, values);
 
     // max(5.0, 3.0) = 5.0; max(20.0, 25.0) = 25.0
-    output.into_data().assert_eq(
-        &TensorData::from([[5.0, 10.0], [15.0, 25.0]]),
-        false,
-    );
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([[5.0, 10.0], [15.0, 25.0]]), false);
 }
 
 #[test]
@@ -240,10 +220,8 @@ fn test_scatter_nd_batch() {
     // indices shape: [3, 1] => K=1, M=2, DV = 1+2-1 = 2
     let indices = TestTensorInt::<2>::from_ints([[0], [2], [1]], &device);
     // values shape: [3, 3]
-    let values = TestTensor::<2>::from_floats(
-        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
-        &device,
-    );
+    let values =
+        TestTensor::<2>::from_floats([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]], &device);
 
     let output = data.scatter_nd(indices, values);
 

--- a/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter_nd.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter_nd.rs
@@ -230,3 +230,83 @@ fn test_scatter_nd_batch() {
         false,
     );
 }
+
+#[test]
+fn test_scatter_nd_single_element() {
+    // Single update to a single element in a 1D tensor
+    let device = Default::default();
+    let data = TestTensor::<1>::from_floats([1.0, 2.0, 3.0], &device);
+    let indices = TestTensorInt::<2>::from_ints([[2]], &device);
+    let values = TestTensor::<1>::from_floats([99.0], &device);
+
+    let output = data.scatter_nd(indices, values);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([1.0, 2.0, 99.0]), false);
+}
+
+#[test]
+fn test_scatter_nd_k1_high_rank() {
+    // K=1 on a 3D tensor: each index selects a full 2D slice
+    let device = Default::default();
+    let data = TestTensor::<3>::zeros([2, 2, 2], &device);
+    let indices = TestTensorInt::<2>::from_ints([[1]], &device);
+    let values = TestTensor::<3>::from_floats([[[10.0, 20.0], [30.0, 40.0]]], &device);
+
+    let output = data.scatter_nd(indices, values);
+
+    output.into_data().assert_eq(
+        &TensorData::from([[[0.0, 0.0], [0.0, 0.0]], [[10.0, 20.0], [30.0, 40.0]]]),
+        false,
+    );
+}
+
+#[test]
+fn test_gather_nd_single_element() {
+    // Gather a single scalar from a 1D tensor
+    let device = Default::default();
+    let data = TestTensor::<1>::from_floats([10.0, 20.0, 30.0], &device);
+    let indices = TestTensorInt::<2>::from_ints([[1]], &device);
+
+    let output: TestTensor<1> = data.gather_nd(indices);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([20.0]), false);
+}
+
+#[test]
+fn test_scatter_nd_empty_indices() {
+    // Zero updates should return data unchanged
+    let device = Default::default();
+    let data = TestTensor::<2>::from_floats([[1.0, 2.0], [3.0, 4.0]], &device);
+    let indices = TestTensorInt::<2>::zeros([0, 2], &device);
+    let values = TestTensor::<1>::zeros([0], &device);
+
+    let output = data.scatter_nd(indices, values);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([[1.0, 2.0], [3.0, 4.0]]), false);
+}
+
+#[test]
+fn test_gather_scatter_nd_roundtrip() {
+    // gather_nd then scatter_nd_add back should reconstruct selected rows
+    let device = Default::default();
+    let data = TestTensor::<2>::from_floats(
+        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
+        &device,
+    );
+    let indices = TestTensorInt::<2>::from_ints([[0], [2]], &device);
+
+    let gathered: TestTensor<2> = data.clone().gather_nd(indices.clone());
+    let zeros = TestTensor::<2>::zeros([3, 3], &device);
+    let reconstructed: TestTensor<2> = zeros.scatter_nd_add(indices, gathered);
+
+    reconstructed.into_data().assert_eq(
+        &TensorData::from([[1.0, 2.0, 3.0], [0.0, 0.0, 0.0], [7.0, 8.0, 9.0]]),
+        false,
+    );
+}

--- a/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter_nd.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter_nd.rs
@@ -131,22 +131,6 @@ fn test_scatter_nd_add_2d() {
 }
 
 #[test]
-fn test_scatter_nd_add_duplicate_indices() {
-    let device = Default::default();
-    let data = TestTensor::<2>::zeros([2, 3], &device);
-    // Both index tuples point to the same location
-    let indices = TestTensorInt::<2>::from_ints([[0, 1], [0, 1]], &device);
-    let values = TestTensor::<1>::from_floats([5.0, 3.0], &device);
-
-    let output = data.scatter_nd_add(indices, values);
-
-    // Values should accumulate: 5.0 + 3.0 = 8.0
-    output
-        .into_data()
-        .assert_eq(&TensorData::from([[0.0, 8.0, 0.0], [0.0, 0.0, 0.0]]), false);
-}
-
-#[test]
 fn test_scatter_nd_3d_slices() {
     // Scatter 1D slices into a 3D tensor (K=1)
     let device = Default::default();
@@ -274,21 +258,6 @@ fn test_gather_nd_single_element() {
     output
         .into_data()
         .assert_eq(&TensorData::from([20.0]), false);
-}
-
-#[test]
-fn test_scatter_nd_empty_indices() {
-    // Zero updates should return data unchanged
-    let device = Default::default();
-    let data = TestTensor::<2>::from_floats([[1.0, 2.0], [3.0, 4.0]], &device);
-    let indices = TestTensorInt::<2>::zeros([0, 2], &device);
-    let values = TestTensor::<1>::zeros([0], &device);
-
-    let output = data.scatter_nd(indices, values);
-
-    output
-        .into_data()
-        .assert_eq(&TensorData::from([[1.0, 2.0], [3.0, 4.0]]), false);
 }
 
 #[test]

--- a/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter_nd.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter_nd.rs
@@ -295,10 +295,8 @@ fn test_scatter_nd_empty_indices() {
 fn test_gather_scatter_nd_roundtrip() {
     // gather_nd then scatter_nd_add back should reconstruct selected rows
     let device = Default::default();
-    let data = TestTensor::<2>::from_floats(
-        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
-        &device,
-    );
+    let data =
+        TestTensor::<2>::from_floats([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]], &device);
     let indices = TestTensorInt::<2>::from_ints([[0], [2]], &device);
 
     let gathered: TestTensor<2> = data.clone().gather_nd(indices.clone());

--- a/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter_nd.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter_nd.rs
@@ -252,14 +252,14 @@ fn test_scatter_nd_single_element() {
 fn test_scatter_nd_k1_high_rank() {
     // K=1 on a 3D tensor: each index selects a full 2D slice
     let device = Default::default();
-    let data = TestTensor::<3>::zeros([2, 2, 2], &device);
+    let data = TestTensor::<3>::ones([2, 2, 2], &device);
     let indices = TestTensorInt::<2>::from_ints([[1]], &device);
     let values = TestTensor::<3>::from_floats([[[10.0, 20.0], [30.0, 40.0]]], &device);
 
     let output = data.scatter_nd(indices, values);
 
     output.into_data().assert_eq(
-        &TensorData::from([[[0.0, 0.0], [0.0, 0.0]], [[10.0, 20.0], [30.0, 40.0]]]),
+        &TensorData::from([[[1.0, 1.0], [1.0, 1.0]], [[10.0, 20.0], [30.0, 40.0]]]),
         false,
     );
 }

--- a/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter_nd.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter_nd.rs
@@ -1,5 +1,5 @@
 use super::*;
-use burn_tensor::TensorData;
+use burn_tensor::{IndexingUpdateOp, TensorData};
 
 #[test]
 fn test_gather_nd_2d_k_equals_d() {
@@ -106,7 +106,7 @@ fn test_scatter_nd_assign_2d() {
     // values shape: [2] (scalar per index tuple)
     let values = TestTensor::<1>::from_floats([10.0, 20.0], &device);
 
-    let output = data.scatter_nd(indices, values);
+    let output = data.scatter_nd(indices, values, IndexingUpdateOp::Assign);
 
     output.into_data().assert_eq(
         &TensorData::from([[0.0, 10.0, 0.0], [0.0, 0.0, 0.0], [20.0, 0.0, 0.0]]),
@@ -122,7 +122,7 @@ fn test_scatter_nd_add_2d() {
     let indices = TestTensorInt::<2>::from_ints([[0, 1], [2, 0]], &device);
     let values = TestTensor::<1>::from_floats([10.0, 20.0], &device);
 
-    let output = data.scatter_nd_add(indices, values);
+    let output = data.scatter_nd(indices, values, IndexingUpdateOp::Add);
 
     output.into_data().assert_eq(
         &TensorData::from([[1.0, 11.0, 1.0], [1.0, 1.0, 1.0], [21.0, 1.0, 1.0]]),
@@ -140,7 +140,7 @@ fn test_scatter_nd_add_duplicate_indices() {
     let indices = TestTensorInt::<2>::from_ints([[0, 1], [0, 1]], &device);
     let values = TestTensor::<1>::from_floats([5.0, 3.0], &device);
 
-    let output = data.scatter_nd_add(indices, values);
+    let output = data.scatter_nd(indices, values, IndexingUpdateOp::Add);
 
     // Values should accumulate: 5.0 + 3.0 = 8.0
     output
@@ -160,7 +160,7 @@ fn test_scatter_nd_3d_slices() {
     // values shape: [2, 3]
     let values = TestTensor::<2>::from_floats([[10.0, 20.0, 30.0], [40.0, 50.0, 60.0]], &device);
 
-    let output = data.scatter_nd(indices, values);
+    let output = data.scatter_nd(indices, values, IndexingUpdateOp::Assign);
 
     output.into_data().assert_eq(
         &TensorData::from([[10.0, 20.0, 30.0], [40.0, 50.0, 60.0]]),
@@ -175,7 +175,7 @@ fn test_scatter_nd_mul() {
     let indices = TestTensorInt::<2>::from_ints([[0, 1], [1, 2]], &device);
     let values = TestTensor::<1>::from_floats([10.0, 2.0], &device);
 
-    let output = data.scatter_nd_mul(indices, values);
+    let output = data.scatter_nd(indices, values, IndexingUpdateOp::Mul);
 
     output.into_data().assert_eq(
         &TensorData::from([[2.0, 30.0, 4.0], [5.0, 6.0, 14.0]]),
@@ -190,7 +190,7 @@ fn test_scatter_nd_min() {
     let indices = TestTensorInt::<2>::from_ints([[0, 0], [1, 1]], &device);
     let values = TestTensor::<1>::from_floats([3.0, 25.0], &device);
 
-    let output = data.scatter_nd_min(indices, values);
+    let output = data.scatter_nd(indices, values, IndexingUpdateOp::Min);
 
     // min(5.0, 3.0) = 3.0; min(20.0, 25.0) = 20.0
     output
@@ -205,7 +205,7 @@ fn test_scatter_nd_max() {
     let indices = TestTensorInt::<2>::from_ints([[0, 0], [1, 1]], &device);
     let values = TestTensor::<1>::from_floats([3.0, 25.0], &device);
 
-    let output = data.scatter_nd_max(indices, values);
+    let output = data.scatter_nd(indices, values, IndexingUpdateOp::Max);
 
     // max(5.0, 3.0) = 5.0; max(20.0, 25.0) = 25.0
     output
@@ -225,7 +225,7 @@ fn test_scatter_nd_batch() {
     let values =
         TestTensor::<2>::from_floats([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]], &device);
 
-    let output = data.scatter_nd(indices, values);
+    let output = data.scatter_nd(indices, values, IndexingUpdateOp::Assign);
 
     output.into_data().assert_eq(
         &TensorData::from([[1.0, 2.0, 3.0], [7.0, 8.0, 9.0], [4.0, 5.0, 6.0]]),
@@ -241,7 +241,7 @@ fn test_scatter_nd_single_element() {
     let indices = TestTensorInt::<2>::from_ints([[2]], &device);
     let values = TestTensor::<1>::from_floats([99.0], &device);
 
-    let output = data.scatter_nd(indices, values);
+    let output = data.scatter_nd(indices, values, IndexingUpdateOp::Assign);
 
     output
         .into_data()
@@ -256,7 +256,7 @@ fn test_scatter_nd_k1_high_rank() {
     let indices = TestTensorInt::<2>::from_ints([[1]], &device);
     let values = TestTensor::<3>::from_floats([[[10.0, 20.0], [30.0, 40.0]]], &device);
 
-    let output = data.scatter_nd(indices, values);
+    let output = data.scatter_nd(indices, values, IndexingUpdateOp::Assign);
 
     output.into_data().assert_eq(
         &TensorData::from([[[1.0, 1.0], [1.0, 1.0]], [[10.0, 20.0], [30.0, 40.0]]]),
@@ -288,7 +288,7 @@ fn test_gather_scatter_nd_roundtrip() {
 
     let gathered: TestTensor<2> = data.clone().gather_nd(indices.clone());
     let zeros = TestTensor::<2>::zeros([3, 3], &device);
-    let reconstructed: TestTensor<2> = zeros.scatter_nd_add(indices, gathered);
+    let reconstructed: TestTensor<2> = zeros.scatter_nd(indices, gathered, IndexingUpdateOp::Add);
 
     reconstructed.into_data().assert_eq(
         &TensorData::from([[1.0, 2.0, 3.0], [0.0, 0.0, 0.0], [7.0, 8.0, 9.0]]),
@@ -311,7 +311,7 @@ fn test_scatter_nd_3d_k2_partial_slices() {
         &device,
     );
 
-    let output = data.scatter_nd(indices, values);
+    let output = data.scatter_nd(indices, values, IndexingUpdateOp::Add);
 
     // Only data[0,1,:] and data[1,2,:] should be set
     let output_data = output.into_data();

--- a/crates/burn-backend-tests/tests/tensor/float/ops/mod.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/mod.rs
@@ -30,6 +30,7 @@ mod floor;
 mod fmod;
 mod full;
 mod gather_scatter;
+mod gather_scatter_nd;
 mod grid_sample;
 mod hamming_window;
 mod hann_window;

--- a/crates/burn-backend-tests/tests/tensor/int/ops/gather_scatter_nd.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/gather_scatter_nd.rs
@@ -1,0 +1,46 @@
+use super::*;
+use burn_tensor::TensorData;
+
+#[test]
+fn test_int_gather_nd_2d() {
+    let device = Default::default();
+    let data = TestTensorInt::<2>::from_ints([[10, 20, 30], [40, 50, 60]], &device);
+    // indices shape: [2, 2] => K=2, M=2, DV=1
+    let indices = TestTensorInt::<2>::from_ints([[0, 1], [1, 2]], &device);
+
+    let output: TestTensorInt<1> = data.gather_nd(indices);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([20, 60]), false);
+}
+
+#[test]
+fn test_int_scatter_nd_add() {
+    let device = Default::default();
+    let data = TestTensorInt::<2>::from_ints([[1, 2, 3], [4, 5, 6]], &device);
+    let indices = TestTensorInt::<2>::from_ints([[0, 0], [1, 2]], &device);
+    let values = TestTensorInt::<1>::from_ints([10, 20], &device);
+
+    let output = data.scatter_nd_add(indices, values);
+
+    output.into_data().assert_eq(
+        &TensorData::from([[11, 2, 3], [4, 5, 26]]),
+        false,
+    );
+}
+
+#[test]
+fn test_int_scatter_nd_mul() {
+    let device = Default::default();
+    let data = TestTensorInt::<2>::from_ints([[2, 3], [4, 5]], &device);
+    let indices = TestTensorInt::<2>::from_ints([[0, 1], [1, 0]], &device);
+    let values = TestTensorInt::<1>::from_ints([10, 3], &device);
+
+    let output = data.scatter_nd_mul(indices, values);
+
+    output.into_data().assert_eq(
+        &TensorData::from([[2, 30], [12, 5]]),
+        false,
+    );
+}

--- a/crates/burn-backend-tests/tests/tensor/int/ops/gather_scatter_nd.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/gather_scatter_nd.rs
@@ -24,10 +24,9 @@ fn test_int_scatter_nd_add() {
 
     let output = data.scatter_nd_add(indices, values);
 
-    output.into_data().assert_eq(
-        &TensorData::from([[11, 2, 3], [4, 5, 26]]),
-        false,
-    );
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([[11, 2, 3], [4, 5, 26]]), false);
 }
 
 #[test]
@@ -39,8 +38,7 @@ fn test_int_scatter_nd_mul() {
 
     let output = data.scatter_nd_mul(indices, values);
 
-    output.into_data().assert_eq(
-        &TensorData::from([[2, 30], [12, 5]]),
-        false,
-    );
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([[2, 30], [12, 5]]), false);
 }

--- a/crates/burn-backend-tests/tests/tensor/int/ops/gather_scatter_nd.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/gather_scatter_nd.rs
@@ -42,3 +42,90 @@ fn test_int_scatter_nd_mul() {
         .into_data()
         .assert_eq(&TensorData::from([[2, 30], [12, 5]]), false);
 }
+
+#[test]
+fn test_int_scatter_nd_assign() {
+    let device = Default::default();
+    let data = TestTensorInt::<2>::from_ints([[1, 2, 3], [4, 5, 6]], &device);
+    let indices = TestTensorInt::<2>::from_ints([[0, 1], [1, 2]], &device);
+    let values = TestTensorInt::<1>::from_ints([99, 88], &device);
+
+    let output = data.scatter_nd(indices, values);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([[1, 99, 3], [4, 5, 88]]), false);
+}
+
+#[test]
+fn test_int_scatter_nd_min() {
+    let device = Default::default();
+    let data = TestTensorInt::<2>::from_ints([[5, 10], [15, 20]], &device);
+    let indices = TestTensorInt::<2>::from_ints([[0, 0], [1, 1]], &device);
+    let values = TestTensorInt::<1>::from_ints([3, 25], &device);
+
+    let output = data.scatter_nd_min(indices, values);
+
+    // min(5, 3) = 3; min(20, 25) = 20
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([[3, 10], [15, 20]]), false);
+}
+
+#[test]
+fn test_int_scatter_nd_max() {
+    let device = Default::default();
+    let data = TestTensorInt::<2>::from_ints([[5, 10], [15, 20]], &device);
+    let indices = TestTensorInt::<2>::from_ints([[0, 0], [1, 1]], &device);
+    let values = TestTensorInt::<1>::from_ints([3, 25], &device);
+
+    let output = data.scatter_nd_max(indices, values);
+
+    // max(5, 3) = 5; max(20, 25) = 25
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([[5, 10], [15, 25]]), false);
+}
+
+#[test]
+fn test_int_scatter_nd_slices() {
+    // K=1: each index selects a full row
+    let device = Default::default();
+    let data = TestTensorInt::<2>::zeros([2, 3], &device);
+    let indices = TestTensorInt::<2>::from_ints([[0], [1]], &device);
+    let values = TestTensorInt::<2>::from_ints([[10, 20, 30], [40, 50, 60]], &device);
+
+    let output = data.scatter_nd(indices, values);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([[10, 20, 30], [40, 50, 60]]), false);
+}
+
+#[test]
+fn test_int_gather_nd_slices() {
+    // K=1: each index gathers a full row
+    let device = Default::default();
+    let data = TestTensorInt::<2>::from_ints([[10, 20, 30], [40, 50, 60]], &device);
+    let indices = TestTensorInt::<2>::from_ints([[1], [0]], &device);
+
+    let output: TestTensorInt<2> = data.gather_nd(indices);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([[40, 50, 60], [10, 20, 30]]), false);
+}
+
+#[test]
+fn test_int_scatter_nd_single_element() {
+    let device = Default::default();
+    let data = TestTensorInt::<1>::from_ints([1, 2, 3], &device);
+    let indices = TestTensorInt::<2>::from_ints([[0]], &device);
+    let values = TestTensorInt::<1>::from_ints([99], &device);
+
+    let output = data.scatter_nd(indices, values);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([99, 2, 3]), false);
+}

--- a/crates/burn-backend-tests/tests/tensor/int/ops/gather_scatter_nd.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/gather_scatter_nd.rs
@@ -1,5 +1,5 @@
 use super::*;
-use burn_tensor::TensorData;
+use burn_tensor::{IndexingUpdateOp, TensorData};
 
 #[test]
 fn test_int_gather_nd_2d() {
@@ -22,7 +22,7 @@ fn test_int_scatter_nd_add() {
     let indices = TestTensorInt::<2>::from_ints([[0, 0], [1, 2]], &device);
     let values = TestTensorInt::<1>::from_ints([10, 20], &device);
 
-    let output = data.scatter_nd_add(indices, values);
+    let output = data.scatter_nd(indices, values, IndexingUpdateOp::Add);
 
     output
         .into_data()
@@ -36,7 +36,7 @@ fn test_int_scatter_nd_mul() {
     let indices = TestTensorInt::<2>::from_ints([[0, 1], [1, 0]], &device);
     let values = TestTensorInt::<1>::from_ints([10, 3], &device);
 
-    let output = data.scatter_nd_mul(indices, values);
+    let output = data.scatter_nd(indices, values, IndexingUpdateOp::Mul);
 
     output
         .into_data()
@@ -50,7 +50,7 @@ fn test_int_scatter_nd_assign() {
     let indices = TestTensorInt::<2>::from_ints([[0, 1], [1, 2]], &device);
     let values = TestTensorInt::<1>::from_ints([99, 88], &device);
 
-    let output = data.scatter_nd(indices, values);
+    let output = data.scatter_nd(indices, values, IndexingUpdateOp::Assign);
 
     output
         .into_data()
@@ -64,7 +64,7 @@ fn test_int_scatter_nd_min() {
     let indices = TestTensorInt::<2>::from_ints([[0, 0], [1, 1]], &device);
     let values = TestTensorInt::<1>::from_ints([3, 25], &device);
 
-    let output = data.scatter_nd_min(indices, values);
+    let output = data.scatter_nd(indices, values, IndexingUpdateOp::Min);
 
     // min(5, 3) = 3; min(20, 25) = 20
     output
@@ -79,7 +79,7 @@ fn test_int_scatter_nd_max() {
     let indices = TestTensorInt::<2>::from_ints([[0, 0], [1, 1]], &device);
     let values = TestTensorInt::<1>::from_ints([3, 25], &device);
 
-    let output = data.scatter_nd_max(indices, values);
+    let output = data.scatter_nd(indices, values, IndexingUpdateOp::Max);
 
     // max(5, 3) = 5; max(20, 25) = 25
     output
@@ -95,7 +95,7 @@ fn test_int_scatter_nd_slices() {
     let indices = TestTensorInt::<2>::from_ints([[0], [1]], &device);
     let values = TestTensorInt::<2>::from_ints([[10, 20, 30], [40, 50, 60]], &device);
 
-    let output = data.scatter_nd(indices, values);
+    let output = data.scatter_nd(indices, values, IndexingUpdateOp::Assign);
 
     output
         .into_data()
@@ -123,7 +123,7 @@ fn test_int_scatter_nd_single_element() {
     let indices = TestTensorInt::<2>::from_ints([[0]], &device);
     let values = TestTensorInt::<1>::from_ints([99], &device);
 
-    let output = data.scatter_nd(indices, values);
+    let output = data.scatter_nd(indices, values, IndexingUpdateOp::Assign);
 
     output
         .into_data()

--- a/crates/burn-backend-tests/tests/tensor/int/ops/mod.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/mod.rs
@@ -20,6 +20,7 @@ mod expand;
 mod flip;
 mod full;
 mod gather_scatter;
+mod gather_scatter_nd;
 mod init;
 mod mask;
 mod matmul;

--- a/crates/burn-backend/src/backend/ops/int_tensor.rs
+++ b/crates/burn-backend/src/backend/ops/int_tensor.rs
@@ -187,6 +187,24 @@ pub trait IntTensorOps<B: Backend> {
         value: IntTensor<B>,
     ) -> IntTensor<B>;
 
+    /// Multi-dimensional scatter for int tensors.
+    fn int_scatter_nd(
+        _data: IntTensor<B>,
+        _indices: IntTensor<B>,
+        _values: IntTensor<B>,
+        _reduction: crate::tensor::ScatterNdReduction,
+    ) -> IntTensor<B> {
+        panic!("int_scatter_nd is not implemented for this backend")
+    }
+
+    /// Multi-dimensional gather for int tensors.
+    fn int_gather_nd(
+        _data: IntTensor<B>,
+        _indices: IntTensor<B>,
+    ) -> IntTensor<B> {
+        panic!("int_gather_nd is not implemented for this backend")
+    }
+
     /// Select tensor elements along the given dimension corresponding to the given indices.
     ///
     /// # Arguments

--- a/crates/burn-backend/src/backend/ops/int_tensor.rs
+++ b/crates/burn-backend/src/backend/ops/int_tensor.rs
@@ -198,10 +198,7 @@ pub trait IntTensorOps<B: Backend> {
     }
 
     /// Multi-dimensional gather for int tensors.
-    fn int_gather_nd(
-        _data: IntTensor<B>,
-        _indices: IntTensor<B>,
-    ) -> IntTensor<B> {
+    fn int_gather_nd(_data: IntTensor<B>, _indices: IntTensor<B>) -> IntTensor<B> {
         panic!("int_gather_nd is not implemented for this backend")
     }
 

--- a/crates/burn-backend/src/backend/ops/int_tensor.rs
+++ b/crates/burn-backend/src/backend/ops/int_tensor.rs
@@ -194,12 +194,12 @@ pub trait IntTensorOps<B: Backend> {
         _values: IntTensor<B>,
         _reduction: crate::tensor::IndexingUpdateOp,
     ) -> IntTensor<B> {
-        panic!("int_scatter_nd is not implemented for this backend")
+        unimplemented!("int_scatter_nd is not implemented for this backend")
     }
 
     /// Multi-dimensional gather for int tensors.
     fn int_gather_nd(_data: IntTensor<B>, _indices: IntTensor<B>) -> IntTensor<B> {
-        panic!("int_gather_nd is not implemented for this backend")
+        unimplemented!("int_gather_nd is not implemented for this backend")
     }
 
     /// Select tensor elements along the given dimension corresponding to the given indices.

--- a/crates/burn-backend/src/backend/ops/int_tensor.rs
+++ b/crates/burn-backend/src/backend/ops/int_tensor.rs
@@ -192,7 +192,7 @@ pub trait IntTensorOps<B: Backend> {
         _data: IntTensor<B>,
         _indices: IntTensor<B>,
         _values: IntTensor<B>,
-        _reduction: crate::tensor::ScatterNdReduction,
+        _reduction: crate::tensor::IndexingUpdateOp,
     ) -> IntTensor<B> {
         panic!("int_scatter_nd is not implemented for this backend")
     }

--- a/crates/burn-backend/src/backend/ops/tensor.rs
+++ b/crates/burn-backend/src/backend/ops/tensor.rs
@@ -471,7 +471,7 @@ pub trait FloatTensorOps<B: Backend> {
         _data: FloatTensor<B>,
         _indices: IntTensor<B>,
         _values: FloatTensor<B>,
-        _reduction: crate::tensor::ScatterNdReduction,
+        _reduction: crate::tensor::IndexingUpdateOp,
     ) -> FloatTensor<B> {
         panic!("float_scatter_nd is not implemented for this backend")
     }

--- a/crates/burn-backend/src/backend/ops/tensor.rs
+++ b/crates/burn-backend/src/backend/ops/tensor.rs
@@ -486,10 +486,7 @@ pub trait FloatTensorOps<B: Backend> {
     /// # Returns
     ///
     /// The gathered tensor.
-    fn float_gather_nd(
-        _data: FloatTensor<B>,
-        _indices: IntTensor<B>,
-    ) -> FloatTensor<B> {
+    fn float_gather_nd(_data: FloatTensor<B>, _indices: IntTensor<B>) -> FloatTensor<B> {
         panic!("float_gather_nd is not implemented for this backend")
     }
 

--- a/crates/burn-backend/src/backend/ops/tensor.rs
+++ b/crates/burn-backend/src/backend/ops/tensor.rs
@@ -473,7 +473,7 @@ pub trait FloatTensorOps<B: Backend> {
         _values: FloatTensor<B>,
         _reduction: crate::tensor::IndexingUpdateOp,
     ) -> FloatTensor<B> {
-        panic!("float_scatter_nd is not implemented for this backend")
+        unimplemented!("float_scatter_nd is not implemented for this backend")
     }
 
     /// Multi-dimensional gather: collect slices from `data` at locations specified by `indices`.
@@ -487,7 +487,7 @@ pub trait FloatTensorOps<B: Backend> {
     ///
     /// The gathered tensor.
     fn float_gather_nd(_data: FloatTensor<B>, _indices: IntTensor<B>) -> FloatTensor<B> {
-        panic!("float_gather_nd is not implemented for this backend")
+        unimplemented!("float_gather_nd is not implemented for this backend")
     }
 
     /// Select tensor elements along the given dimension corresponding for the given indices.

--- a/crates/burn-backend/src/backend/ops/tensor.rs
+++ b/crates/burn-backend/src/backend/ops/tensor.rs
@@ -455,6 +455,44 @@ pub trait FloatTensorOps<B: Backend> {
         value: FloatTensor<B>,
     ) -> FloatTensor<B>;
 
+    /// Multi-dimensional scatter: update `data` at locations specified by `indices` with `values`.
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - The tensor to scatter into.
+    /// * `indices` - An M-dimensional integer tensor whose last dimension indexes into `data`.
+    /// * `values` - The values to scatter.
+    /// * `reduction` - How to combine with existing values.
+    ///
+    /// # Returns
+    ///
+    /// The tensor with scattered values.
+    fn float_scatter_nd(
+        _data: FloatTensor<B>,
+        _indices: IntTensor<B>,
+        _values: FloatTensor<B>,
+        _reduction: crate::tensor::ScatterNdReduction,
+    ) -> FloatTensor<B> {
+        panic!("float_scatter_nd is not implemented for this backend")
+    }
+
+    /// Multi-dimensional gather: collect slices from `data` at locations specified by `indices`.
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - The tensor to gather from.
+    /// * `indices` - An M-dimensional integer tensor whose last dimension indexes into `data`.
+    ///
+    /// # Returns
+    ///
+    /// The gathered tensor.
+    fn float_gather_nd(
+        _data: FloatTensor<B>,
+        _indices: IntTensor<B>,
+    ) -> FloatTensor<B> {
+        panic!("float_gather_nd is not implemented for this backend")
+    }
+
     /// Select tensor elements along the given dimension corresponding for the given indices.
     ///
     /// # Arguments

--- a/crates/burn-backend/src/tensor/ops/base.rs
+++ b/crates/burn-backend/src/tensor/ops/base.rs
@@ -5,7 +5,7 @@ use crate::{
     Backend, BackendTypes, ExecutionError, Scalar, TensorData, TensorMetadata,
     element::Element,
     ops::TransactionPrimitive,
-    tensor::{IndexingUpdateOp, IntTensor, ScatterNdReduction, TensorKind},
+    tensor::{IndexingUpdateOp, IntTensor, TensorKind},
 };
 
 /// Trait for the one basic op that still requires Backend
@@ -442,7 +442,7 @@ pub trait BasicOps<B: BackendTypes>: TensorKind<B> {
         data: Self::Primitive,
         indices: IntTensor<B>,
         values: Self::Primitive,
-        reduction: ScatterNdReduction,
+        reduction: IndexingUpdateOp,
     ) -> Self::Primitive;
 
     /// Multi-dimensional gather: collect slices from `data` at multi-index locations.

--- a/crates/burn-backend/src/tensor/ops/base.rs
+++ b/crates/burn-backend/src/tensor/ops/base.rs
@@ -5,7 +5,7 @@ use crate::{
     Backend, BackendTypes, ExecutionError, Scalar, TensorData, TensorMetadata,
     element::Element,
     ops::TransactionPrimitive,
-    tensor::{IndexingUpdateOp, IntTensor, TensorKind},
+    tensor::{IndexingUpdateOp, IntTensor, ScatterNdReduction, TensorKind},
 };
 
 /// Trait for the one basic op that still requires Backend
@@ -435,6 +435,20 @@ pub trait BasicOps<B: BackendTypes>: TensorKind<B> {
         indices: IntTensor<B>,
         values: Self::Primitive,
         update: IndexingUpdateOp,
+    ) -> Self::Primitive;
+
+    /// Multi-dimensional scatter: update `data` at multi-index locations specified by `indices`.
+    fn scatter_nd(
+        data: Self::Primitive,
+        indices: IntTensor<B>,
+        values: Self::Primitive,
+        reduction: ScatterNdReduction,
+    ) -> Self::Primitive;
+
+    /// Multi-dimensional gather: collect slices from `data` at multi-index locations.
+    fn gather_nd(
+        data: Self::Primitive,
+        indices: IntTensor<B>,
     ) -> Self::Primitive;
 
     /// Returns the device on which the tensor is allocated.

--- a/crates/burn-backend/src/tensor/ops/base.rs
+++ b/crates/burn-backend/src/tensor/ops/base.rs
@@ -446,10 +446,7 @@ pub trait BasicOps<B: BackendTypes>: TensorKind<B> {
     ) -> Self::Primitive;
 
     /// Multi-dimensional gather: collect slices from `data` at multi-index locations.
-    fn gather_nd(
-        data: Self::Primitive,
-        indices: IntTensor<B>,
-    ) -> Self::Primitive;
+    fn gather_nd(data: Self::Primitive, indices: IntTensor<B>) -> Self::Primitive;
 
     /// Returns the device on which the tensor is allocated.
     ///

--- a/crates/burn-backend/src/tensor/ops/bool.rs
+++ b/crates/burn-backend/src/tensor/ops/bool.rs
@@ -5,8 +5,8 @@ use crate::{
     AutodiffBackend, Backend, ExecutionError, Scalar, TensorData,
     ops::TransactionPrimitive,
     tensor::{
-        BasicAutodiffOps, BasicOps, Bool, Device, IndexingUpdateOp, IntTensor, TensorKind,
-        TransactionOp,
+        BasicAutodiffOps, BasicOps, Bool, Device, IndexingUpdateOp, IntTensor,
+        ScatterNdReduction, TensorKind, TransactionOp,
     },
 };
 
@@ -124,6 +124,22 @@ impl<B: Backend> BasicOps<B> for Bool {
         match update {
             IndexingUpdateOp::Add => B::bool_scatter_or(dim, tensor, indices, values),
         }
+    }
+
+    fn scatter_nd(
+        _data: Self::Primitive,
+        _indices: IntTensor<B>,
+        _values: Self::Primitive,
+        _reduction: ScatterNdReduction,
+    ) -> Self::Primitive {
+        panic!("scatter_nd is not supported for bool tensors")
+    }
+
+    fn gather_nd(
+        _data: Self::Primitive,
+        _indices: IntTensor<B>,
+    ) -> Self::Primitive {
+        panic!("gather_nd is not supported for bool tensors")
     }
 
     fn device(tensor: &Self::Primitive) -> Device<B> {

--- a/crates/burn-backend/src/tensor/ops/bool.rs
+++ b/crates/burn-backend/src/tensor/ops/bool.rs
@@ -5,8 +5,8 @@ use crate::{
     AutodiffBackend, Backend, ExecutionError, Scalar, TensorData,
     ops::TransactionPrimitive,
     tensor::{
-        BasicAutodiffOps, BasicOps, Bool, Device, IndexingUpdateOp, IntTensor, ScatterNdReduction,
-        TensorKind, TransactionOp,
+        BasicAutodiffOps, BasicOps, Bool, Device, IndexingUpdateOp, IntTensor, TensorKind,
+        TransactionOp,
     },
 };
 
@@ -87,6 +87,7 @@ impl<B: Backend> BasicOps<B> for Bool {
     ) -> Self::Primitive {
         match update {
             IndexingUpdateOp::Add => B::bool_select_or(tensor, dim, indices, values),
+            _ => unimplemented!(),
         }
     }
 
@@ -123,6 +124,7 @@ impl<B: Backend> BasicOps<B> for Bool {
     ) -> Self::Primitive {
         match update {
             IndexingUpdateOp::Add => B::bool_scatter_or(dim, tensor, indices, values),
+            _ => unimplemented!(),
         }
     }
 
@@ -130,7 +132,7 @@ impl<B: Backend> BasicOps<B> for Bool {
         _data: Self::Primitive,
         _indices: IntTensor<B>,
         _values: Self::Primitive,
-        _reduction: ScatterNdReduction,
+        _reduction: IndexingUpdateOp,
     ) -> Self::Primitive {
         panic!("scatter_nd is not supported for bool tensors")
     }

--- a/crates/burn-backend/src/tensor/ops/bool.rs
+++ b/crates/burn-backend/src/tensor/ops/bool.rs
@@ -5,8 +5,8 @@ use crate::{
     AutodiffBackend, Backend, ExecutionError, Scalar, TensorData,
     ops::TransactionPrimitive,
     tensor::{
-        BasicAutodiffOps, BasicOps, Bool, Device, IndexingUpdateOp, IntTensor,
-        ScatterNdReduction, TensorKind, TransactionOp,
+        BasicAutodiffOps, BasicOps, Bool, Device, IndexingUpdateOp, IntTensor, ScatterNdReduction,
+        TensorKind, TransactionOp,
     },
 };
 
@@ -135,10 +135,7 @@ impl<B: Backend> BasicOps<B> for Bool {
         panic!("scatter_nd is not supported for bool tensors")
     }
 
-    fn gather_nd(
-        _data: Self::Primitive,
-        _indices: IntTensor<B>,
-    ) -> Self::Primitive {
+    fn gather_nd(_data: Self::Primitive, _indices: IntTensor<B>) -> Self::Primitive {
         panic!("gather_nd is not supported for bool tensors")
     }
 

--- a/crates/burn-backend/src/tensor/ops/float.rs
+++ b/crates/burn-backend/src/tensor/ops/float.rs
@@ -187,10 +187,7 @@ impl<B: Backend> BasicOps<B> for Float {
         ))
     }
 
-    fn gather_nd(
-        data: Self::Primitive,
-        indices: IntTensor<B>,
-    ) -> Self::Primitive {
+    fn gather_nd(data: Self::Primitive, indices: IntTensor<B>) -> Self::Primitive {
         TensorPrimitive::Float(B::float_gather_nd(data.tensor(), indices))
     }
 

--- a/crates/burn-backend/src/tensor/ops/float.rs
+++ b/crates/burn-backend/src/tensor/ops/float.rs
@@ -7,7 +7,7 @@ use crate::{
     ops::TransactionPrimitive,
     tensor::{
         BasicAutodiffOps, BasicOps, Device, Float, IndexingUpdateOp, IntTensor, Numeric, Ordered,
-        TensorKind, TransactionOp,
+        ScatterNdReduction, TensorKind, TransactionOp,
     },
 };
 
@@ -171,6 +171,27 @@ impl<B: Backend> BasicOps<B> for Float {
                 values.tensor(),
             )),
         }
+    }
+
+    fn scatter_nd(
+        data: Self::Primitive,
+        indices: IntTensor<B>,
+        values: Self::Primitive,
+        reduction: ScatterNdReduction,
+    ) -> Self::Primitive {
+        TensorPrimitive::Float(B::float_scatter_nd(
+            data.tensor(),
+            indices,
+            values.tensor(),
+            reduction,
+        ))
+    }
+
+    fn gather_nd(
+        data: Self::Primitive,
+        indices: IntTensor<B>,
+    ) -> Self::Primitive {
+        TensorPrimitive::Float(B::float_gather_nd(data.tensor(), indices))
     }
 
     fn device(tensor: &Self::Primitive) -> Device<B> {

--- a/crates/burn-backend/src/tensor/ops/float.rs
+++ b/crates/burn-backend/src/tensor/ops/float.rs
@@ -7,7 +7,7 @@ use crate::{
     ops::TransactionPrimitive,
     tensor::{
         BasicAutodiffOps, BasicOps, Device, Float, IndexingUpdateOp, IntTensor, Numeric, Ordered,
-        ScatterNdReduction, TensorKind, TransactionOp,
+        TensorKind, TransactionOp,
     },
 };
 
@@ -126,6 +126,7 @@ impl<B: Backend> BasicOps<B> for Float {
                 indices,
                 values.tensor(),
             )),
+            _ => unimplemented!(),
         }
     }
 
@@ -170,6 +171,7 @@ impl<B: Backend> BasicOps<B> for Float {
                 indices,
                 values.tensor(),
             )),
+            _ => unimplemented!(),
         }
     }
 
@@ -177,7 +179,7 @@ impl<B: Backend> BasicOps<B> for Float {
         data: Self::Primitive,
         indices: IntTensor<B>,
         values: Self::Primitive,
-        reduction: ScatterNdReduction,
+        reduction: IndexingUpdateOp,
     ) -> Self::Primitive {
         TensorPrimitive::Float(B::float_scatter_nd(
             data.tensor(),

--- a/crates/burn-backend/src/tensor/ops/int.rs
+++ b/crates/burn-backend/src/tensor/ops/int.rs
@@ -119,10 +119,7 @@ impl<B: Backend> BasicOps<B> for Int {
         B::int_scatter_nd(data, indices, values, reduction)
     }
 
-    fn gather_nd(
-        data: Self::Primitive,
-        indices: IntTensor<B>,
-    ) -> Self::Primitive {
+    fn gather_nd(data: Self::Primitive, indices: IntTensor<B>) -> Self::Primitive {
         B::int_gather_nd(data, indices)
     }
 

--- a/crates/burn-backend/src/tensor/ops/int.rs
+++ b/crates/burn-backend/src/tensor/ops/int.rs
@@ -7,7 +7,7 @@ use crate::{
     ops::TransactionPrimitive,
     tensor::{
         BasicAutodiffOps, BasicOps, BoolTensor, Device, IndexingUpdateOp, Int, IntTensor, Numeric,
-        Ordered, TensorKind, TransactionOp,
+        Ordered, ScatterNdReduction, TensorKind, TransactionOp,
     },
 };
 
@@ -108,6 +108,22 @@ impl<B: Backend> BasicOps<B> for Int {
         match update {
             IndexingUpdateOp::Add => B::int_scatter_add(dim, tensor, indices, values),
         }
+    }
+
+    fn scatter_nd(
+        data: Self::Primitive,
+        indices: IntTensor<B>,
+        values: Self::Primitive,
+        reduction: ScatterNdReduction,
+    ) -> Self::Primitive {
+        B::int_scatter_nd(data, indices, values, reduction)
+    }
+
+    fn gather_nd(
+        data: Self::Primitive,
+        indices: IntTensor<B>,
+    ) -> Self::Primitive {
+        B::int_gather_nd(data, indices)
     }
 
     fn device(tensor: &Self::Primitive) -> Device<B> {

--- a/crates/burn-backend/src/tensor/ops/int.rs
+++ b/crates/burn-backend/src/tensor/ops/int.rs
@@ -7,7 +7,7 @@ use crate::{
     ops::TransactionPrimitive,
     tensor::{
         BasicAutodiffOps, BasicOps, BoolTensor, Device, IndexingUpdateOp, Int, IntTensor, Numeric,
-        Ordered, ScatterNdReduction, TensorKind, TransactionOp,
+        Ordered, TensorKind, TransactionOp,
     },
 };
 
@@ -71,6 +71,7 @@ impl<B: Backend> BasicOps<B> for Int {
     ) -> Self::Primitive {
         match update {
             IndexingUpdateOp::Add => B::int_select_add(tensor, dim, indices, values),
+            _ => unimplemented!(),
         }
     }
 
@@ -107,6 +108,7 @@ impl<B: Backend> BasicOps<B> for Int {
     ) -> Self::Primitive {
         match update {
             IndexingUpdateOp::Add => B::int_scatter_add(dim, tensor, indices, values),
+            _ => unimplemented!(),
         }
     }
 
@@ -114,7 +116,7 @@ impl<B: Backend> BasicOps<B> for Int {
         data: Self::Primitive,
         indices: IntTensor<B>,
         values: Self::Primitive,
-        reduction: ScatterNdReduction,
+        reduction: IndexingUpdateOp,
     ) -> Self::Primitive {
         B::int_scatter_nd(data, indices, values, reduction)
     }

--- a/crates/burn-backend/src/tensor/ops/mod.rs
+++ b/crates/burn-backend/src/tensor/ops/mod.rs
@@ -19,3 +19,18 @@ pub enum IndexingUpdateOp {
     Add,
     // Mul
 }
+
+/// Reduction mode for multi-dimensional scatter (scatter_nd).
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum ScatterNdReduction {
+    /// Overwrite existing values.
+    Assign,
+    /// Add values to existing.
+    Add,
+    /// Multiply existing values.
+    Mul,
+    /// Take element-wise minimum.
+    Min,
+    /// Take element-wise maximum.
+    Max,
+}

--- a/crates/burn-backend/src/tensor/ops/mod.rs
+++ b/crates/burn-backend/src/tensor/ops/mod.rs
@@ -14,18 +14,9 @@ pub use ordered::*;
 /// Computation to be used to update the existing values in indexed assignment operations (scatter/select).
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum IndexingUpdateOp {
-    // Assign,
-    /// Performs an addition.
-    Add,
-    // Mul
-}
-
-/// Reduction mode for multi-dimensional scatter (scatter_nd).
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub enum ScatterNdReduction {
     /// Overwrite existing values.
     Assign,
-    /// Add values to existing.
+    /// Performs an addition.
     Add,
     /// Multiply existing values.
     Mul,

--- a/crates/burn-candle/src/ops/base.rs
+++ b/crates/burn-candle/src/ops/base.rs
@@ -82,6 +82,117 @@ pub fn empty(shape: Shape, device: &CandleDevice, dtype: candle_core::DType) -> 
     zeros(shape, device, dtype)
 }
 
+/// Flatten K-dimensional index tuples into 1D linear offsets.
+///
+/// `indices` has shape `[num_updates, k]` (i64).
+/// Returns a 1D tensor of shape `[num_updates * slice_size]` (u32, for candle index ops).
+fn flatten_nd_indices(
+    indices: &candle_core::Tensor,
+    data_shape: &[usize],
+    k: usize,
+    slice_size: usize,
+) -> candle_core::Tensor {
+    let device = indices.device();
+    let num_updates = indices.dim(0).unwrap();
+
+    // Compute per-dimension strides for the first K dims
+    let mut strides = vec![0i64; k];
+    if k > 0 {
+        strides[k - 1] = slice_size as i64;
+        for i in (0..k - 1).rev() {
+            strides[i] = strides[i + 1] * data_shape[i + 1] as i64;
+        }
+    }
+
+    let strides_tensor =
+        candle_core::Tensor::from_slice(&strides, (k,), device).unwrap();
+    // base_offsets: [num_updates] = indices @ strides
+    let base_offsets = indices
+        .to_dtype(candle_core::DType::I64)
+        .unwrap()
+        .matmul(&strides_tensor.unsqueeze(1).unwrap())
+        .unwrap()
+        .squeeze(1)
+        .unwrap();
+
+    // Expand to [num_updates, slice_size] + intra-slice offsets
+    let slice_offsets = candle_core::Tensor::arange(0i64, slice_size as i64, device).unwrap();
+    let flat = base_offsets
+        .unsqueeze(1)
+        .unwrap()
+        .broadcast_add(&slice_offsets.unsqueeze(0).unwrap())
+        .unwrap()
+        .reshape((num_updates * slice_size,))
+        .unwrap()
+        .to_dtype(candle_core::DType::U32)
+        .unwrap();
+
+    flat
+}
+
+pub fn scatter_nd(
+    data: CandleTensor,
+    indices: CandleTensor,
+    values: CandleTensor,
+    reduction: burn_backend::tensor::ScatterNdReduction,
+) -> CandleTensor {
+    use burn_backend::tensor::ScatterNdReduction;
+
+    let data_shape: Vec<usize> = data.tensor.dims().to_vec();
+    let idx_shape: Vec<usize> = indices.tensor.dims().to_vec();
+    let m = idx_shape.len();
+    let k = idx_shape[m - 1];
+    let num_updates: usize = idx_shape[..m - 1].iter().product();
+    let total_elems: usize = data_shape.iter().product();
+    let slice_size: usize = data_shape[k..].iter().product();
+
+    let flat_indices = indices.tensor.reshape((num_updates, k)).unwrap();
+    let linear_idx = flatten_nd_indices(&flat_indices, &data_shape, k, slice_size);
+
+    let flat_data = data.tensor.contiguous().unwrap().reshape(total_elems).unwrap();
+    let flat_values = values.tensor.contiguous().unwrap().reshape(num_updates * slice_size).unwrap();
+
+    let result = match reduction {
+        ScatterNdReduction::Assign => {
+            flat_data.scatter(&linear_idx, &flat_values, 0).unwrap()
+        }
+        ScatterNdReduction::Add => {
+            flat_data.scatter_add(&linear_idx, &flat_values, 0).unwrap()
+        }
+        _ => panic!(
+            "scatter_nd with {:?} reduction is not supported by the candle backend",
+            reduction
+        ),
+    };
+
+    CandleTensor::new(result.reshape(data_shape).unwrap())
+}
+
+pub fn gather_nd(
+    data: CandleTensor,
+    indices: CandleTensor,
+) -> CandleTensor {
+    let data_shape: Vec<usize> = data.tensor.dims().to_vec();
+    let idx_shape: Vec<usize> = indices.tensor.dims().to_vec();
+    let m = idx_shape.len();
+    let k = idx_shape[m - 1];
+    let num_indices: usize = idx_shape[..m - 1].iter().product();
+    let total_elems: usize = data_shape.iter().product();
+    let slice_size: usize = data_shape[k..].iter().product();
+
+    let flat_indices = indices.tensor.reshape((num_indices, k)).unwrap();
+    let linear_idx = flatten_nd_indices(&flat_indices, &data_shape, k, slice_size);
+
+    let flat_data = data.tensor.contiguous().unwrap().reshape(total_elems).unwrap();
+    let gathered = flat_data.index_select(&linear_idx, 0).unwrap();
+
+    // Output shape: idx_shape[..m-1] ++ data_shape[k..]
+    let mut out_shape: Vec<usize> = idx_shape[..m - 1].to_vec();
+    out_shape.extend_from_slice(&data_shape[k..]);
+
+    CandleTensor::new(gathered.reshape(out_shape).unwrap())
+}
+
 pub fn zeros(shape: Shape, device: &CandleDevice, dtype: candle_core::DType) -> CandleTensor {
     CandleTensor::new(
         candle_core::Tensor::zeros(shape.to_vec(), dtype, &(device.clone()).into()).unwrap(),

--- a/crates/burn-candle/src/ops/base.rs
+++ b/crates/burn-candle/src/ops/base.rs
@@ -104,8 +104,7 @@ fn flatten_nd_indices(
         }
     }
 
-    let strides_tensor =
-        candle_core::Tensor::from_slice(&strides, (k,), device).unwrap();
+    let strides_tensor = candle_core::Tensor::from_slice(&strides, (k,), device).unwrap();
     // base_offsets: [num_updates] = indices @ strides
     let base_offsets = indices
         .to_dtype(candle_core::DType::I64)
@@ -117,7 +116,7 @@ fn flatten_nd_indices(
 
     // Expand to [num_updates, slice_size] + intra-slice offsets
     let slice_offsets = candle_core::Tensor::arange(0i64, slice_size as i64, device).unwrap();
-    let flat = base_offsets
+    base_offsets
         .unsqueeze(1)
         .unwrap()
         .broadcast_add(&slice_offsets.unsqueeze(0).unwrap())
@@ -125,9 +124,7 @@ fn flatten_nd_indices(
         .reshape((num_updates * slice_size,))
         .unwrap()
         .to_dtype(candle_core::DType::U32)
-        .unwrap();
-
-    flat
+        .unwrap()
 }
 
 pub fn scatter_nd(
@@ -149,16 +146,22 @@ pub fn scatter_nd(
     let flat_indices = indices.tensor.reshape((num_updates, k)).unwrap();
     let linear_idx = flatten_nd_indices(&flat_indices, &data_shape, k, slice_size);
 
-    let flat_data = data.tensor.contiguous().unwrap().reshape(total_elems).unwrap();
-    let flat_values = values.tensor.contiguous().unwrap().reshape(num_updates * slice_size).unwrap();
+    let flat_data = data
+        .tensor
+        .contiguous()
+        .unwrap()
+        .reshape(total_elems)
+        .unwrap();
+    let flat_values = values
+        .tensor
+        .contiguous()
+        .unwrap()
+        .reshape(num_updates * slice_size)
+        .unwrap();
 
     let result = match reduction {
-        ScatterNdReduction::Assign => {
-            flat_data.scatter(&linear_idx, &flat_values, 0).unwrap()
-        }
-        ScatterNdReduction::Add => {
-            flat_data.scatter_add(&linear_idx, &flat_values, 0).unwrap()
-        }
+        ScatterNdReduction::Assign => flat_data.scatter(&linear_idx, &flat_values, 0).unwrap(),
+        ScatterNdReduction::Add => flat_data.scatter_add(&linear_idx, &flat_values, 0).unwrap(),
         _ => panic!(
             "scatter_nd with {:?} reduction is not supported by the candle backend",
             reduction
@@ -168,10 +171,7 @@ pub fn scatter_nd(
     CandleTensor::new(result.reshape(data_shape).unwrap())
 }
 
-pub fn gather_nd(
-    data: CandleTensor,
-    indices: CandleTensor,
-) -> CandleTensor {
+pub fn gather_nd(data: CandleTensor, indices: CandleTensor) -> CandleTensor {
     let data_shape: Vec<usize> = data.tensor.dims().to_vec();
     let idx_shape: Vec<usize> = indices.tensor.dims().to_vec();
     let m = idx_shape.len();
@@ -183,7 +183,12 @@ pub fn gather_nd(
     let flat_indices = indices.tensor.reshape((num_indices, k)).unwrap();
     let linear_idx = flatten_nd_indices(&flat_indices, &data_shape, k, slice_size);
 
-    let flat_data = data.tensor.contiguous().unwrap().reshape(total_elems).unwrap();
+    let flat_data = data
+        .tensor
+        .contiguous()
+        .unwrap()
+        .reshape(total_elems)
+        .unwrap();
     let gathered = flat_data.index_select(&linear_idx, 0).unwrap();
 
     // Output shape: idx_shape[..m-1] ++ data_shape[k..]

--- a/crates/burn-candle/src/ops/base.rs
+++ b/crates/burn-candle/src/ops/base.rs
@@ -131,9 +131,9 @@ pub fn scatter_nd(
     data: CandleTensor,
     indices: CandleTensor,
     values: CandleTensor,
-    reduction: burn_backend::tensor::ScatterNdReduction,
+    reduction: burn_backend::tensor::IndexingUpdateOp,
 ) -> CandleTensor {
-    use burn_backend::tensor::ScatterNdReduction;
+    use burn_backend::tensor::IndexingUpdateOp;
 
     let data_shape: Vec<usize> = data.tensor.dims().to_vec();
     let idx_shape: Vec<usize> = indices.tensor.dims().to_vec();
@@ -160,8 +160,8 @@ pub fn scatter_nd(
         .unwrap();
 
     let result = match reduction {
-        ScatterNdReduction::Assign => flat_data.scatter(&linear_idx, &flat_values, 0).unwrap(),
-        ScatterNdReduction::Add => flat_data.scatter_add(&linear_idx, &flat_values, 0).unwrap(),
+        IndexingUpdateOp::Assign => flat_data.scatter(&linear_idx, &flat_values, 0).unwrap(),
+        IndexingUpdateOp::Add => flat_data.scatter_add(&linear_idx, &flat_values, 0).unwrap(),
         _ => panic!(
             "scatter_nd with {:?} reduction is not supported by the candle backend",
             reduction

--- a/crates/burn-candle/src/ops/base.rs
+++ b/crates/burn-candle/src/ops/base.rs
@@ -91,9 +91,9 @@ fn flatten_nd_indices(
     data_shape: &[usize],
     k: usize,
     slice_size: usize,
-) -> candle_core::Tensor {
+) -> candle_core::Result<candle_core::Tensor> {
     let device = indices.device();
-    let num_updates = indices.dim(0).unwrap();
+    let num_updates = indices.dim(0)?;
 
     // Compute per-dimension strides for the first K dims
     let mut strides = vec![0i64; k];
@@ -104,27 +104,20 @@ fn flatten_nd_indices(
         }
     }
 
-    let strides_tensor = candle_core::Tensor::from_slice(&strides, (k,), device).unwrap();
+    let strides_tensor = candle_core::Tensor::from_slice(&strides, (k,), device)?;
     // base_offsets: [num_updates] = indices @ strides
     let base_offsets = indices
-        .to_dtype(candle_core::DType::I64)
-        .unwrap()
-        .matmul(&strides_tensor.unsqueeze(1).unwrap())
-        .unwrap()
-        .squeeze(1)
-        .unwrap();
+        .to_dtype(candle_core::DType::I64)?
+        .matmul(&strides_tensor.unsqueeze(1)?)?
+        .squeeze(1)?;
 
     // Expand to [num_updates, slice_size] + intra-slice offsets
-    let slice_offsets = candle_core::Tensor::arange(0i64, slice_size as i64, device).unwrap();
+    let slice_offsets = candle_core::Tensor::arange(0i64, slice_size as i64, device)?;
     base_offsets
-        .unsqueeze(1)
-        .unwrap()
-        .broadcast_add(&slice_offsets.unsqueeze(0).unwrap())
-        .unwrap()
-        .reshape((num_updates * slice_size,))
-        .unwrap()
+        .unsqueeze(1)?
+        .broadcast_add(&slice_offsets.unsqueeze(0)?)?
+        .reshape((num_updates * slice_size,))?
         .to_dtype(candle_core::DType::U32)
-        .unwrap()
 }
 
 pub fn scatter_nd(
@@ -133,6 +126,16 @@ pub fn scatter_nd(
     values: CandleTensor,
     reduction: burn_backend::tensor::IndexingUpdateOp,
 ) -> CandleTensor {
+    try_scatter_nd(data, indices, values, reduction)
+        .unwrap_or_else(|e| panic!("candle scatter_nd: {e}"))
+}
+
+fn try_scatter_nd(
+    data: CandleTensor,
+    indices: CandleTensor,
+    values: CandleTensor,
+    reduction: burn_backend::tensor::IndexingUpdateOp,
+) -> candle_core::Result<CandleTensor> {
     use burn_backend::tensor::IndexingUpdateOp;
 
     let data_shape: Vec<usize> = data.tensor.dims().to_vec();
@@ -143,35 +146,32 @@ pub fn scatter_nd(
     let total_elems: usize = data_shape.iter().product();
     let slice_size: usize = data_shape[k..].iter().product();
 
-    let flat_indices = indices.tensor.reshape((num_updates, k)).unwrap();
-    let linear_idx = flatten_nd_indices(&flat_indices, &data_shape, k, slice_size);
+    let flat_indices = indices.tensor.reshape((num_updates, k))?;
+    let linear_idx = flatten_nd_indices(&flat_indices, &data_shape, k, slice_size)?;
 
-    let flat_data = data
-        .tensor
-        .contiguous()
-        .unwrap()
-        .reshape(total_elems)
-        .unwrap();
+    let flat_data = data.tensor.contiguous()?.reshape(total_elems)?;
     let flat_values = values
         .tensor
-        .contiguous()
-        .unwrap()
-        .reshape(num_updates * slice_size)
-        .unwrap();
+        .contiguous()?
+        .reshape(num_updates * slice_size)?;
 
     let result = match reduction {
-        IndexingUpdateOp::Assign => flat_data.scatter(&linear_idx, &flat_values, 0).unwrap(),
-        IndexingUpdateOp::Add => flat_data.scatter_add(&linear_idx, &flat_values, 0).unwrap(),
+        IndexingUpdateOp::Assign => flat_data.scatter(&linear_idx, &flat_values, 0)?,
+        IndexingUpdateOp::Add => flat_data.scatter_add(&linear_idx, &flat_values, 0)?,
         _ => panic!(
             "scatter_nd with {:?} reduction is not supported by the candle backend",
             reduction
         ),
     };
 
-    CandleTensor::new(result.reshape(data_shape).unwrap())
+    Ok(CandleTensor::new(result.reshape(data_shape)?))
 }
 
 pub fn gather_nd(data: CandleTensor, indices: CandleTensor) -> CandleTensor {
+    try_gather_nd(data, indices).unwrap_or_else(|e| panic!("candle gather_nd: {e}"))
+}
+
+fn try_gather_nd(data: CandleTensor, indices: CandleTensor) -> candle_core::Result<CandleTensor> {
     let data_shape: Vec<usize> = data.tensor.dims().to_vec();
     let idx_shape: Vec<usize> = indices.tensor.dims().to_vec();
     let m = idx_shape.len();
@@ -180,22 +180,17 @@ pub fn gather_nd(data: CandleTensor, indices: CandleTensor) -> CandleTensor {
     let total_elems: usize = data_shape.iter().product();
     let slice_size: usize = data_shape[k..].iter().product();
 
-    let flat_indices = indices.tensor.reshape((num_indices, k)).unwrap();
-    let linear_idx = flatten_nd_indices(&flat_indices, &data_shape, k, slice_size);
+    let flat_indices = indices.tensor.reshape((num_indices, k))?;
+    let linear_idx = flatten_nd_indices(&flat_indices, &data_shape, k, slice_size)?;
 
-    let flat_data = data
-        .tensor
-        .contiguous()
-        .unwrap()
-        .reshape(total_elems)
-        .unwrap();
-    let gathered = flat_data.index_select(&linear_idx, 0).unwrap();
+    let flat_data = data.tensor.contiguous()?.reshape(total_elems)?;
+    let gathered = flat_data.index_select(&linear_idx, 0)?;
 
     // Output shape: idx_shape[..m-1] ++ data_shape[k..]
     let mut out_shape: Vec<usize> = idx_shape[..m - 1].to_vec();
     out_shape.extend_from_slice(&data_shape[k..]);
 
-    CandleTensor::new(gathered.reshape(out_shape).unwrap())
+    Ok(CandleTensor::new(gathered.reshape(out_shape)?))
 }
 
 pub fn zeros(shape: Shape, device: &CandleDevice, dtype: candle_core::DType) -> CandleTensor {

--- a/crates/burn-candle/src/ops/int_tensor.rs
+++ b/crates/burn-candle/src/ops/int_tensor.rs
@@ -106,6 +106,22 @@ impl<F: FloatCandleElement, I: IntCandleElement> IntTensorOps<Self> for Candle<F
         )
     }
 
+    fn int_scatter_nd(
+        data: IntTensor<Self>,
+        indices: IntTensor<Self>,
+        values: IntTensor<Self>,
+        reduction: burn_backend::tensor::ScatterNdReduction,
+    ) -> IntTensor<Self> {
+        super::base::scatter_nd(data, indices, values, reduction)
+    }
+
+    fn int_gather_nd(
+        data: IntTensor<Self>,
+        indices: IntTensor<Self>,
+    ) -> IntTensor<Self> {
+        super::base::gather_nd(data, indices)
+    }
+
     fn int_select(
         tensor: IntTensor<Self>,
         dim: usize,

--- a/crates/burn-candle/src/ops/int_tensor.rs
+++ b/crates/burn-candle/src/ops/int_tensor.rs
@@ -110,7 +110,7 @@ impl<F: FloatCandleElement, I: IntCandleElement> IntTensorOps<Self> for Candle<F
         data: IntTensor<Self>,
         indices: IntTensor<Self>,
         values: IntTensor<Self>,
-        reduction: burn_backend::tensor::ScatterNdReduction,
+        reduction: burn_backend::tensor::IndexingUpdateOp,
     ) -> IntTensor<Self> {
         super::base::scatter_nd(data, indices, values, reduction)
     }

--- a/crates/burn-candle/src/ops/int_tensor.rs
+++ b/crates/burn-candle/src/ops/int_tensor.rs
@@ -115,10 +115,7 @@ impl<F: FloatCandleElement, I: IntCandleElement> IntTensorOps<Self> for Candle<F
         super::base::scatter_nd(data, indices, values, reduction)
     }
 
-    fn int_gather_nd(
-        data: IntTensor<Self>,
-        indices: IntTensor<Self>,
-    ) -> IntTensor<Self> {
+    fn int_gather_nd(data: IntTensor<Self>, indices: IntTensor<Self>) -> IntTensor<Self> {
         super::base::gather_nd(data, indices)
     }
 

--- a/crates/burn-candle/src/ops/tensor.rs
+++ b/crates/burn-candle/src/ops/tensor.rs
@@ -197,6 +197,22 @@ impl<F: FloatCandleElement, I: IntCandleElement> FloatTensorOps<Self> for Candle
         )
     }
 
+    fn float_scatter_nd(
+        data: FloatTensor<Self>,
+        indices: IntTensor<Self>,
+        values: FloatTensor<Self>,
+        reduction: burn_backend::tensor::ScatterNdReduction,
+    ) -> FloatTensor<Self> {
+        super::base::scatter_nd(data, indices, values, reduction)
+    }
+
+    fn float_gather_nd(
+        data: FloatTensor<Self>,
+        indices: IntTensor<Self>,
+    ) -> FloatTensor<Self> {
+        super::base::gather_nd(data, indices)
+    }
+
     fn float_select(
         tensor: FloatTensor<Self>,
         dim: usize,

--- a/crates/burn-candle/src/ops/tensor.rs
+++ b/crates/burn-candle/src/ops/tensor.rs
@@ -201,7 +201,7 @@ impl<F: FloatCandleElement, I: IntCandleElement> FloatTensorOps<Self> for Candle
         data: FloatTensor<Self>,
         indices: IntTensor<Self>,
         values: FloatTensor<Self>,
-        reduction: burn_backend::tensor::ScatterNdReduction,
+        reduction: burn_backend::tensor::IndexingUpdateOp,
     ) -> FloatTensor<Self> {
         super::base::scatter_nd(data, indices, values, reduction)
     }

--- a/crates/burn-candle/src/ops/tensor.rs
+++ b/crates/burn-candle/src/ops/tensor.rs
@@ -206,10 +206,7 @@ impl<F: FloatCandleElement, I: IntCandleElement> FloatTensorOps<Self> for Candle
         super::base::scatter_nd(data, indices, values, reduction)
     }
 
-    fn float_gather_nd(
-        data: FloatTensor<Self>,
-        indices: IntTensor<Self>,
-    ) -> FloatTensor<Self> {
+    fn float_gather_nd(data: FloatTensor<Self>, indices: IntTensor<Self>) -> FloatTensor<Self> {
         super::base::gather_nd(data, indices)
     }
 

--- a/crates/burn-cubecl/src/kernel/binary.rs
+++ b/crates/burn-cubecl/src/kernel/binary.rs
@@ -27,6 +27,9 @@ pub(crate) struct RemainderOp;
 pub(crate) struct AndOp;
 pub(crate) struct OrOp;
 pub(crate) struct PowOp;
+pub(crate) struct AssignOp;
+pub(crate) struct BinaryMinOp;
+pub(crate) struct BinaryMaxOp;
 
 impl BinaryOpFamily for AddOp {
     type BinaryOp<C: Numeric, N: Size> = Self;
@@ -57,6 +60,18 @@ impl BinaryOpFamily for AndOp {
 }
 
 impl BinaryOpFamily for OrOp {
+    type BinaryOp<C: Numeric, N: Size> = Self;
+}
+
+impl BinaryOpFamily for AssignOp {
+    type BinaryOp<C: Numeric, N: Size> = Self;
+}
+
+impl BinaryOpFamily for BinaryMinOp {
+    type BinaryOp<C: Numeric, N: Size> = Self;
+}
+
+impl BinaryOpFamily for BinaryMaxOp {
     type BinaryOp<C: Numeric, N: Size> = Self;
 }
 
@@ -145,6 +160,27 @@ impl<T: Numeric, N: Size> BinaryOp<T, N> for AndOp {
 impl<T: Numeric, N: Size> BinaryOp<T, N> for OrOp {
     fn execute(lhs: Vector<T, N>, rhs: Vector<T, N>) -> Vector<T, N> {
         Vector::cast_from(Vector::<bool, N>::cast_from(lhs).or(Vector::<bool, N>::cast_from(rhs)))
+    }
+}
+
+#[cube]
+impl<T: Numeric, N: Size> BinaryOp<T, N> for AssignOp {
+    fn execute(_lhs: Vector<T, N>, rhs: Vector<T, N>) -> Vector<T, N> {
+        rhs
+    }
+}
+
+#[cube]
+impl<T: Numeric, N: Size> BinaryOp<T, N> for BinaryMinOp {
+    fn execute(lhs: Vector<T, N>, rhs: Vector<T, N>) -> Vector<T, N> {
+        clamp_max(lhs, rhs)
+    }
+}
+
+#[cube]
+impl<T: Numeric, N: Size> BinaryOp<T, N> for BinaryMaxOp {
+    fn execute(lhs: Vector<T, N>, rhs: Vector<T, N>) -> Vector<T, N> {
+        clamp_min(lhs, rhs)
     }
 }
 

--- a/crates/burn-cubecl/src/kernel/index/gather_nd.rs
+++ b/crates/burn-cubecl/src/kernel/index/gather_nd.rs
@@ -1,12 +1,9 @@
 use crate::{
-    CubeRuntime,
-    kernel::utils::address_type,
-    ops::numeric::empty_device_dtype,
-    tensor::CubeTensor,
+    CubeRuntime, kernel::utils::address_type, ops::numeric::empty_device_dtype, tensor::CubeTensor,
 };
 use burn_backend::TensorMetadata;
-use cubecl::{CubeDim, calculate_cube_count_elemwise};
 use cubecl::prelude::*;
+use cubecl::{CubeDim, calculate_cube_count_elemwise};
 
 use super::scatter_nd::nd_index_strides;
 

--- a/crates/burn-cubecl/src/kernel/index/gather_nd.rs
+++ b/crates/burn-cubecl/src/kernel/index/gather_nd.rs
@@ -1,0 +1,101 @@
+use crate::{
+    CubeRuntime,
+    kernel::utils::address_type,
+    ops::numeric::empty_device_dtype,
+    tensor::CubeTensor,
+};
+use burn_backend::TensorMetadata;
+use cubecl::{CubeDim, calculate_cube_count_elemwise};
+use cubecl::prelude::*;
+
+use super::scatter_nd::nd_index_strides;
+
+/// gather_nd GPU kernel.
+///
+/// Each thread handles one element of the output.
+/// Work items = num_indices * slice_size.
+///
+/// `data_strides` holds the strides for the first K dimensions of data,
+/// used to convert K-dimensional index tuples into flat offsets.
+#[cube(launch_unchecked, address_type = "dynamic")]
+fn gather_nd_kernel<T: Numeric, I: Int>(
+    data: &Tensor<T>,
+    indices: &Tensor<I>,
+    output: &mut Tensor<T>,
+    data_strides: Sequence<usize>,
+    slice_size: usize,
+    k: usize,
+    #[define(T, I)] _dtypes: [StorageType; 2],
+) {
+    let total = output.len();
+    if ABSOLUTE_POS >= total {
+        terminate!();
+    }
+
+    // Decompose ABSOLUTE_POS into (index_tuple_idx, slice_offset)
+    let slice_offset = ABSOLUTE_POS % slice_size;
+    let index_idx = ABSOLUTE_POS / slice_size;
+
+    // Compute flat offset into data from the K-dimensional index tuple
+    let idx_base = index_idx * k;
+    let mut base_offset = 0usize;
+    for j in 0..k {
+        let idx_val = usize::cast_from(indices[idx_base + j]);
+        base_offset += idx_val * data_strides[j];
+    }
+
+    output[ABSOLUTE_POS] = data[base_offset + slice_offset];
+}
+
+pub(crate) fn gather_nd<R: CubeRuntime>(
+    tensor: CubeTensor<R>,
+    indices: CubeTensor<R>,
+) -> CubeTensor<R> {
+    let data_shape = tensor.shape();
+    let idx_shape = indices.shape();
+    let m = idx_shape.num_dims();
+    let k = idx_shape[m - 1];
+
+    // num_indices = product of first M-1 dims of indices
+    let num_indices: usize = idx_shape.as_slice()[..m - 1].iter().product();
+    // slice_size = product of data.shape[K..]
+    let slice_size: usize = data_shape.as_slice()[k..].iter().product();
+    let total_elem = num_indices * slice_size;
+
+    // Output shape: idx_shape[..m-1] ++ data_shape[k..]
+    let mut out_dims: Vec<usize> = idx_shape.as_slice()[..m - 1].to_vec();
+    out_dims.extend_from_slice(&data_shape.as_slice()[k..]);
+    let out_shape = burn_backend::Shape::from(out_dims);
+
+    let output = empty_device_dtype(
+        tensor.client.clone(),
+        tensor.device.clone(),
+        out_shape,
+        tensor.dtype,
+    );
+
+    let data_strides_arg = nd_index_strides(&data_shape, k, slice_size);
+
+    let cube_dim = CubeDim::new(&tensor.client, total_elem);
+    let cube_count = calculate_cube_count_elemwise(&tensor.client, total_elem, cube_dim);
+
+    let (dtype, indices_dtype) = (tensor.dtype, indices.dtype);
+
+    unsafe {
+        gather_nd_kernel::launch_unchecked(
+            &output.client,
+            cube_count,
+            cube_dim,
+            address_type!(tensor, indices, output),
+            tensor.into_tensor_arg(),
+            indices.into_tensor_arg(),
+            output.clone().into_tensor_arg(),
+            data_strides_arg,
+            slice_size,
+            k,
+            [dtype.into(), indices_dtype.into()],
+        )
+    }
+
+    output
+}

--- a/crates/burn-cubecl/src/kernel/index/gather_nd.rs
+++ b/crates/burn-cubecl/src/kernel/index/gather_nd.rs
@@ -3,29 +3,23 @@ use crate::{
 };
 use burn_backend::TensorMetadata;
 use cubecl::prelude::*;
+use cubecl::std::tensor::layout::linear::LinearView;
 use cubecl::{CubeDim, calculate_cube_count_elemwise};
-
-use super::scatter_nd::nd_index_strides_tensor;
 
 /// gather_nd GPU kernel.
 ///
 /// Each thread handles one element of the output.
 /// Work items = num_indices * slice_size.
-///
-/// `data_strides` is a 1D tensor of length K holding the strides for converting
-/// K-dimensional index tuples into flat offsets.
 #[cube(launch_unchecked, address_type = "dynamic")]
 fn gather_nd_kernel<T: Numeric, I: Int>(
     data: &Tensor<T>,
-    indices: &Tensor<I>,
-    output: &mut Tensor<T>,
-    data_strides: &Tensor<u32>,
+    indices: &LinearView<I>,
+    output: &mut LinearView<T, ReadWrite>,
     slice_size: usize,
     k: usize,
     #[define(T, I)] _dtypes: [StorageType; 2],
 ) {
-    let total = output.len();
-    if ABSOLUTE_POS >= total {
+    if !output.is_in_bounds(ABSOLUTE_POS) {
         terminate!();
     }
 
@@ -38,7 +32,7 @@ fn gather_nd_kernel<T: Numeric, I: Int>(
     let mut base_offset = 0usize;
     for j in 0..k {
         let idx_val = usize::cast_from(indices[idx_base + j]);
-        base_offset += idx_val * data_strides[j] as usize;
+        base_offset += idx_val * data.stride(j);
     }
 
     output[ABSOLUTE_POS] = data[base_offset + slice_offset];
@@ -71,8 +65,6 @@ pub(crate) fn gather_nd<R: CubeRuntime>(
         tensor.dtype,
     );
 
-    let strides_tensor = nd_index_strides_tensor(&tensor, &data_shape, k, slice_size);
-
     let cube_dim = CubeDim::new(&tensor.client, total_elem);
     let cube_count = calculate_cube_count_elemwise(&tensor.client, total_elem, cube_dim);
 
@@ -85,9 +77,8 @@ pub(crate) fn gather_nd<R: CubeRuntime>(
             cube_dim,
             address_type!(tensor, indices, output),
             tensor.into_tensor_arg(),
-            indices.into_tensor_arg(),
-            output.clone().into_tensor_arg(),
-            strides_tensor.into_tensor_arg(),
+            indices.into_linear_view(),
+            output.clone().into_linear_view(),
             slice_size,
             k,
             [dtype.into(), indices_dtype.into()],

--- a/crates/burn-cubecl/src/kernel/index/gather_nd.rs
+++ b/crates/burn-cubecl/src/kernel/index/gather_nd.rs
@@ -5,21 +5,21 @@ use burn_backend::TensorMetadata;
 use cubecl::prelude::*;
 use cubecl::{CubeDim, calculate_cube_count_elemwise};
 
-use super::scatter_nd::nd_index_strides;
+use super::scatter_nd::nd_index_strides_tensor;
 
 /// gather_nd GPU kernel.
 ///
 /// Each thread handles one element of the output.
 /// Work items = num_indices * slice_size.
 ///
-/// `data_strides` holds the strides for the first K dimensions of data,
-/// used to convert K-dimensional index tuples into flat offsets.
+/// `data_strides` is a 1D tensor of length K holding the strides for converting
+/// K-dimensional index tuples into flat offsets.
 #[cube(launch_unchecked, address_type = "dynamic")]
 fn gather_nd_kernel<T: Numeric, I: Int>(
     data: &Tensor<T>,
     indices: &Tensor<I>,
     output: &mut Tensor<T>,
-    data_strides: Sequence<usize>,
+    data_strides: &Tensor<u32>,
     slice_size: usize,
     k: usize,
     #[define(T, I)] _dtypes: [StorageType; 2],
@@ -38,7 +38,7 @@ fn gather_nd_kernel<T: Numeric, I: Int>(
     let mut base_offset = 0usize;
     for j in 0..k {
         let idx_val = usize::cast_from(indices[idx_base + j]);
-        base_offset += idx_val * data_strides[j];
+        base_offset += idx_val * data_strides[j] as usize;
     }
 
     output[ABSOLUTE_POS] = data[base_offset + slice_offset];
@@ -71,7 +71,7 @@ pub(crate) fn gather_nd<R: CubeRuntime>(
         tensor.dtype,
     );
 
-    let data_strides_arg = nd_index_strides(&data_shape, k, slice_size);
+    let strides_tensor = nd_index_strides_tensor(&tensor, &data_shape, k, slice_size);
 
     let cube_dim = CubeDim::new(&tensor.client, total_elem);
     let cube_count = calculate_cube_count_elemwise(&tensor.client, total_elem, cube_dim);
@@ -87,7 +87,7 @@ pub(crate) fn gather_nd<R: CubeRuntime>(
             tensor.into_tensor_arg(),
             indices.into_tensor_arg(),
             output.clone().into_tensor_arg(),
-            data_strides_arg,
+            strides_tensor.into_tensor_arg(),
             slice_size,
             k,
             [dtype.into(), indices_dtype.into()],

--- a/crates/burn-cubecl/src/kernel/index/gather_nd.rs
+++ b/crates/burn-cubecl/src/kernel/index/gather_nd.rs
@@ -1,8 +1,9 @@
+use crate::kernel::utils::{shape_divmod, shape_divmod_range};
 use crate::{
     CubeRuntime, kernel::utils::address_type, ops::numeric::empty_device_dtype, tensor::CubeTensor,
 };
-use burn_backend::TensorMetadata;
 use cubecl::prelude::*;
+use cubecl::std::FastDivmod;
 use cubecl::std::tensor::layout::linear::LinearView;
 use cubecl::{CubeDim, calculate_cube_count_elemwise};
 
@@ -14,16 +15,18 @@ use cubecl::{CubeDim, calculate_cube_count_elemwise};
 fn gather_nd_kernel<T: Numeric, I: Int>(
     data: &Tensor<T>,
     indices: &LinearView<I>,
-    output: &mut LinearView<T, ReadWrite>,
+    output: &mut Tensor<T>,
+    output_shape: Sequence<FastDivmod<usize>>,
+    data_slice_shape: Sequence<FastDivmod<usize>>,
     slice_size: usize,
     k: usize,
+    working_units: usize,
     #[define(T, I)] _dtypes: [StorageType; 2],
 ) {
-    if !output.is_in_bounds(ABSOLUTE_POS) {
+    if ABSOLUTE_POS >= working_units {
         terminate!();
     }
 
-    // Decompose ABSOLUTE_POS into (index_tuple_idx, slice_offset)
     let slice_offset = ABSOLUTE_POS % slice_size;
     let index_idx = ABSOLUTE_POS / slice_size;
 
@@ -35,15 +38,37 @@ fn gather_nd_kernel<T: Numeric, I: Int>(
         base_offset += idx_val * data.stride(j);
     }
 
-    output[ABSOLUTE_POS] = data[base_offset + slice_offset];
+    let slice_rank = data_slice_shape.len().comptime();
+    let mut data_slice_offset = 0usize;
+    let mut remainder = slice_offset;
+    #[unroll]
+    for i in 0..slice_rank {
+        let dim = slice_rank - i - 1;
+        let (rem, coord) = data_slice_shape[dim].div_mod(remainder);
+        remainder = rem;
+        data_slice_offset += coord * data.stride(k + dim);
+    }
+
+    let out_rank = output_shape.len().comptime();
+    let mut out_offset = 0usize;
+    let mut remainder_o = ABSOLUTE_POS;
+    #[unroll]
+    for i in 0..out_rank {
+        let dim = out_rank - i - 1;
+        let (rem, coord) = output_shape[dim].div_mod(remainder_o);
+        remainder_o = rem;
+        out_offset += coord * output.stride(dim);
+    }
+
+    output[out_offset] = data[base_offset + data_slice_offset];
 }
 
 pub(crate) fn gather_nd<R: CubeRuntime>(
     tensor: CubeTensor<R>,
     indices: CubeTensor<R>,
 ) -> CubeTensor<R> {
-    let data_shape = tensor.shape();
-    let idx_shape = indices.shape();
+    let data_shape = &tensor.meta.shape;
+    let idx_shape = &indices.meta.shape;
     let m = idx_shape.num_dims();
     let k = idx_shape[m - 1];
 
@@ -70,6 +95,9 @@ pub(crate) fn gather_nd<R: CubeRuntime>(
 
     let (dtype, indices_dtype) = (tensor.dtype, indices.dtype);
 
+    let data_slice_shape = shape_divmod_range(&tensor, k..data_shape.num_dims());
+    let output_shape_divmod = shape_divmod(&output);
+
     unsafe {
         gather_nd_kernel::launch_unchecked(
             &output.client,
@@ -78,9 +106,12 @@ pub(crate) fn gather_nd<R: CubeRuntime>(
             address_type!(tensor, indices, output),
             tensor.into_tensor_arg(),
             indices.into_linear_view(),
-            output.clone().into_linear_view(),
+            output.clone().into_tensor_arg(),
+            output_shape_divmod,
+            data_slice_shape,
             slice_size,
             k,
+            total_elem,
             [dtype.into(), indices_dtype.into()],
         )
     }

--- a/crates/burn-cubecl/src/kernel/index/mod.rs
+++ b/crates/burn-cubecl/src/kernel/index/mod.rs
@@ -1,14 +1,18 @@
 mod flip;
 mod gather;
+mod gather_nd;
 mod repeat_dim;
 mod scatter;
+mod scatter_nd;
 mod select;
 mod select_assign;
 mod slice;
 mod slice_assign;
 
 pub(crate) use flip::*;
+pub(crate) use gather_nd::*;
 pub(crate) use repeat_dim::*;
+pub(crate) use scatter_nd::*;
 pub(crate) use select::*;
 pub(crate) use select_assign::*;
 pub use slice::*;

--- a/crates/burn-cubecl/src/kernel/index/scatter_nd.rs
+++ b/crates/burn-cubecl/src/kernel/index/scatter_nd.rs
@@ -6,8 +6,8 @@ use crate::{
     },
     tensor::CubeTensor,
 };
-use burn_backend::tensor::IndexingUpdateOp;
 use burn_backend::TensorMetadata;
+use burn_backend::tensor::IndexingUpdateOp;
 use cubecl::prelude::*;
 use cubecl::std::tensor::layout::linear::LinearView;
 use cubecl::{CubeDim, calculate_cube_count_elemwise};

--- a/crates/burn-cubecl/src/kernel/index/scatter_nd.rs
+++ b/crates/burn-cubecl/src/kernel/index/scatter_nd.rs
@@ -6,34 +6,42 @@ use crate::{
     },
     tensor::CubeTensor,
 };
-use burn_backend::TensorMetadata;
+use burn_backend::{DType, TensorMetadata};
 use burn_backend::tensor::ScatterNdReduction;
+use burn_std::Metadata;
 use cubecl::prelude::*;
 use cubecl::{CubeDim, calculate_cube_count_elemwise};
 
 /// Compute the strides used to convert K-dimensional index tuples into flat
-/// offsets into a contiguous data tensor.
+/// offsets into a contiguous data tensor, returned as a 1D CubeTensor of u32.
 ///
-/// Returns a `SequenceArg` where entry `j` = product of `data_shape[j+1..]`
-/// truncated to the first `k` dimensions, with the innermost stride equal to
-/// `slice_size` (the product of the trailing `data_shape[k..]` dimensions).
-pub(super) fn nd_index_strides<R: CubeRuntime>(
+/// Entry `j` = product of `data_shape[j+1..]` truncated to the first `k`
+/// dimensions, with the innermost stride equal to `slice_size`.
+pub(super) fn nd_index_strides_tensor<R: CubeRuntime>(
+    tensor: &CubeTensor<R>,
     data_shape: &burn_backend::Shape,
     k: usize,
     slice_size: usize,
-) -> SequenceArg<R, usize> {
-    let mut strides = vec![0usize; k];
+) -> CubeTensor<R> {
+    let mut strides = vec![0u32; k];
     if k > 0 {
-        strides[k - 1] = slice_size;
+        strides[k - 1] = slice_size as u32;
         for i in (0..k - 1).rev() {
-            strides[i] = strides[i + 1] * data_shape[i + 1];
+            strides[i] = strides[i + 1] * data_shape[i + 1] as u32;
         }
     }
-    let mut arg = SequenceArg::new();
-    for val in strides {
-        arg.push(val);
-    }
-    arg
+    let data = burn_backend::TensorData::new(strides, burn_backend::Shape::from([k]));
+    let shape = burn_backend::Shape::from([k]);
+    let alloc = tensor
+        .client
+        .create_tensor(data.bytes, shape.clone(), data.dtype.size());
+    CubeTensor::new(
+        tensor.client.clone(),
+        alloc.memory,
+        Metadata::new(shape, alloc.strides),
+        tensor.device.clone(),
+        DType::U32,
+    )
 }
 
 /// scatter_nd GPU kernel.
@@ -41,14 +49,14 @@ pub(super) fn nd_index_strides<R: CubeRuntime>(
 /// Each thread handles one element across all update slices.
 /// Work items = num_updates * slice_size.
 ///
-/// `data_strides` holds the "index strides" for the first K dimensions of data,
-/// used to convert K-dimensional index tuples into flat offsets.
+/// `data_strides` is a 1D tensor of length K holding the strides for converting
+/// K-dimensional index tuples into flat offsets.
 #[cube(launch_unchecked, address_type = "dynamic")]
 fn scatter_nd_kernel<T: Numeric, I: Int, Op: BinaryOpFamily>(
     data: &mut Tensor<T>,
     indices: &Tensor<I>,
     values: &Tensor<T>,
-    data_strides: Sequence<usize>,
+    data_strides: &Tensor<u32>,
     slice_size: usize,
     k: usize,
     #[define(T, I)] _dtypes: [StorageType; 2],
@@ -67,7 +75,7 @@ fn scatter_nd_kernel<T: Numeric, I: Int, Op: BinaryOpFamily>(
     let mut base_offset = 0usize;
     for j in 0..k {
         let idx_val = usize::cast_from(indices[idx_base + j]);
-        base_offset += idx_val * data_strides[j];
+        base_offset += idx_val * data_strides[j] as usize;
     }
 
     let data_idx = base_offset + slice_offset;
@@ -103,7 +111,7 @@ pub(crate) fn scatter_nd<R: CubeRuntime>(
     let slice_size: usize = data_shape.as_slice()[k..].iter().product();
     let working_units = num_updates * slice_size;
 
-    let data_strides_arg = nd_index_strides(&data_shape, k, slice_size);
+    let strides_tensor = nd_index_strides_tensor(&tensor, &data_shape, k, slice_size);
 
     let cube_dim = CubeDim::new(&indices.client, working_units);
     let cube_count = calculate_cube_count_elemwise(&indices.client, working_units, cube_dim);
@@ -123,11 +131,11 @@ pub(crate) fn scatter_nd<R: CubeRuntime>(
             &tensor.client.clone(),
             cube_count,
             cube_dim,
-            address_type!(tensor, indices, values),
+            address_type!(tensor, indices, values, strides_tensor),
             tensor.clone().into_tensor_arg(),
             indices.into_tensor_arg(),
             values.into_tensor_arg(),
-            data_strides_arg,
+            strides_tensor.into_tensor_arg(),
             slice_size,
             k,
             [tensor_dtype.into(), indices_dtype.into()],

--- a/crates/burn-cubecl/src/kernel/index/scatter_nd.rs
+++ b/crates/burn-cubecl/src/kernel/index/scatter_nd.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     tensor::CubeTensor,
 };
-use burn_backend::tensor::ScatterNdReduction;
+use burn_backend::tensor::IndexingUpdateOp;
 use burn_backend::{DType, TensorMetadata};
 use burn_std::Metadata;
 use cubecl::prelude::*;
@@ -92,7 +92,7 @@ pub(crate) fn scatter_nd<R: CubeRuntime>(
     tensor: CubeTensor<R>,
     indices: CubeTensor<R>,
     values: CubeTensor<R>,
-    reduction: ScatterNdReduction,
+    reduction: IndexingUpdateOp,
 ) -> CubeTensor<R> {
     // Ensure we can write in-place
     let tensor = match tensor.can_mut() && tensor.is_nonoverlapping() {
@@ -119,11 +119,11 @@ pub(crate) fn scatter_nd<R: CubeRuntime>(
     let (tensor_dtype, indices_dtype) = (tensor.dtype, indices.dtype);
 
     let launch = match reduction {
-        ScatterNdReduction::Assign => scatter_nd_kernel::launch_unchecked::<AssignOp, R>,
-        ScatterNdReduction::Add => scatter_nd_kernel::launch_unchecked::<AddOp, R>,
-        ScatterNdReduction::Mul => scatter_nd_kernel::launch_unchecked::<MulOp, R>,
-        ScatterNdReduction::Min => scatter_nd_kernel::launch_unchecked::<BinaryMinOp, R>,
-        ScatterNdReduction::Max => scatter_nd_kernel::launch_unchecked::<BinaryMaxOp, R>,
+        IndexingUpdateOp::Assign => scatter_nd_kernel::launch_unchecked::<AssignOp, R>,
+        IndexingUpdateOp::Add => scatter_nd_kernel::launch_unchecked::<AddOp, R>,
+        IndexingUpdateOp::Mul => scatter_nd_kernel::launch_unchecked::<MulOp, R>,
+        IndexingUpdateOp::Min => scatter_nd_kernel::launch_unchecked::<BinaryMinOp, R>,
+        IndexingUpdateOp::Max => scatter_nd_kernel::launch_unchecked::<BinaryMaxOp, R>,
     };
 
     unsafe {

--- a/crates/burn-cubecl/src/kernel/index/scatter_nd.rs
+++ b/crates/burn-cubecl/src/kernel/index/scatter_nd.rs
@@ -6,8 +6,8 @@ use crate::{
     },
     tensor::CubeTensor,
 };
-use burn_backend::{DType, TensorMetadata};
 use burn_backend::tensor::ScatterNdReduction;
+use burn_backend::{DType, TensorMetadata};
 use burn_std::Metadata;
 use cubecl::prelude::*;
 use cubecl::{CubeDim, calculate_cube_count_elemwise};

--- a/crates/burn-cubecl/src/kernel/index/scatter_nd.rs
+++ b/crates/burn-cubecl/src/kernel/index/scatter_nd.rs
@@ -1,0 +1,138 @@
+use crate::{
+    CubeRuntime,
+    kernel::{
+        AddOp, AssignOp, BinaryOp, BinaryOpFamily, BinaryMaxOp, BinaryMinOp, MulOp,
+        utils::address_type,
+    },
+    tensor::CubeTensor,
+};
+use burn_backend::TensorMetadata;
+use burn_backend::tensor::ScatterNdReduction;
+use cubecl::{CubeDim, calculate_cube_count_elemwise};
+use cubecl::prelude::*;
+
+/// Compute the strides used to convert K-dimensional index tuples into flat
+/// offsets into a contiguous data tensor.
+///
+/// Returns a `SequenceArg` where entry `j` = product of `data_shape[j+1..]`
+/// truncated to the first `k` dimensions, with the innermost stride equal to
+/// `slice_size` (the product of the trailing `data_shape[k..]` dimensions).
+pub(super) fn nd_index_strides<R: CubeRuntime>(
+    data_shape: &burn_backend::Shape,
+    k: usize,
+    slice_size: usize,
+) -> SequenceArg<R, usize> {
+    let mut strides = vec![0usize; k];
+    if k > 0 {
+        strides[k - 1] = slice_size;
+        for i in (0..k - 1).rev() {
+            strides[i] = strides[i + 1] * data_shape[i + 1];
+        }
+    }
+    let mut arg = SequenceArg::new();
+    for val in strides {
+        arg.push(val);
+    }
+    arg
+}
+
+/// scatter_nd GPU kernel.
+///
+/// Each thread handles one element across all update slices.
+/// Work items = num_updates * slice_size.
+///
+/// `data_strides` holds the "index strides" for the first K dimensions of data,
+/// used to convert K-dimensional index tuples into flat offsets.
+#[cube(launch_unchecked, address_type = "dynamic")]
+fn scatter_nd_kernel<T: Numeric, I: Int, Op: BinaryOpFamily>(
+    data: &mut Tensor<T>,
+    indices: &Tensor<I>,
+    values: &Tensor<T>,
+    data_strides: Sequence<usize>,
+    slice_size: usize,
+    k: usize,
+    #[define(T, I)] _dtypes: [StorageType; 2],
+) {
+    let num_updates_times_slice = values.len();
+    if ABSOLUTE_POS >= num_updates_times_slice {
+        terminate!();
+    }
+
+    // Decompose ABSOLUTE_POS into (update_index, slice_offset)
+    let slice_offset = ABSOLUTE_POS % slice_size;
+    let update_idx = ABSOLUTE_POS / slice_size;
+
+    // Compute flat base offset into data from the K-dimensional index tuple
+    let idx_base = update_idx * k;
+    let mut base_offset = 0usize;
+    for j in 0..k {
+        let idx_val = usize::cast_from(indices[idx_base + j]);
+        base_offset += idx_val * data_strides[j];
+    }
+
+    let data_idx = base_offset + slice_offset;
+    let val_idx = ABSOLUTE_POS;
+
+    let result = Op::BinaryOp::<T, Const<1>>::execute(
+        Vector::cast_from(data[data_idx]),
+        Vector::cast_from(values[val_idx]),
+    );
+    data[data_idx] = result[0];
+}
+
+pub(crate) fn scatter_nd<R: CubeRuntime>(
+    tensor: CubeTensor<R>,
+    indices: CubeTensor<R>,
+    values: CubeTensor<R>,
+    reduction: ScatterNdReduction,
+) -> CubeTensor<R> {
+    // Ensure we can write in-place
+    let tensor = match tensor.can_mut() && tensor.is_nonoverlapping() {
+        true => tensor,
+        false => tensor.copy(),
+    };
+
+    let data_shape = tensor.shape();
+    let idx_shape = indices.shape();
+    let m = idx_shape.num_dims();
+    let k = idx_shape[m - 1];
+
+    // num_updates = product of first M-1 dims of indices
+    let num_updates: usize = idx_shape.as_slice()[..m - 1].iter().product();
+    // slice_size = product of data.shape[K..]
+    let slice_size: usize = data_shape.as_slice()[k..].iter().product();
+    let working_units = num_updates * slice_size;
+
+    let data_strides_arg = nd_index_strides(&data_shape, k, slice_size);
+
+    let cube_dim = CubeDim::new(&indices.client, working_units);
+    let cube_count = calculate_cube_count_elemwise(&indices.client, working_units, cube_dim);
+
+    let (tensor_dtype, indices_dtype) = (tensor.dtype, indices.dtype);
+
+    let launch = match reduction {
+        ScatterNdReduction::Assign => scatter_nd_kernel::launch_unchecked::<AssignOp, R>,
+        ScatterNdReduction::Add => scatter_nd_kernel::launch_unchecked::<AddOp, R>,
+        ScatterNdReduction::Mul => scatter_nd_kernel::launch_unchecked::<MulOp, R>,
+        ScatterNdReduction::Min => scatter_nd_kernel::launch_unchecked::<BinaryMinOp, R>,
+        ScatterNdReduction::Max => scatter_nd_kernel::launch_unchecked::<BinaryMaxOp, R>,
+    };
+
+    unsafe {
+        launch(
+            &tensor.client.clone(),
+            cube_count,
+            cube_dim,
+            address_type!(tensor, indices, values),
+            tensor.clone().into_tensor_arg(),
+            indices.into_tensor_arg(),
+            values.into_tensor_arg(),
+            data_strides_arg,
+            slice_size,
+            k,
+            [tensor_dtype.into(), indices_dtype.into()],
+        )
+    }
+
+    tensor
+}

--- a/crates/burn-cubecl/src/kernel/index/scatter_nd.rs
+++ b/crates/burn-cubecl/src/kernel/index/scatter_nd.rs
@@ -7,62 +7,25 @@ use crate::{
     tensor::CubeTensor,
 };
 use burn_backend::tensor::IndexingUpdateOp;
-use burn_backend::{DType, TensorMetadata};
-use burn_std::Metadata;
+use burn_backend::TensorMetadata;
 use cubecl::prelude::*;
+use cubecl::std::tensor::layout::linear::LinearView;
 use cubecl::{CubeDim, calculate_cube_count_elemwise};
-
-/// Compute the strides used to convert K-dimensional index tuples into flat
-/// offsets into a contiguous data tensor, returned as a 1D CubeTensor of u32.
-///
-/// Entry `j` = product of `data_shape[j+1..]` truncated to the first `k`
-/// dimensions, with the innermost stride equal to `slice_size`.
-pub(super) fn nd_index_strides_tensor<R: CubeRuntime>(
-    tensor: &CubeTensor<R>,
-    data_shape: &burn_backend::Shape,
-    k: usize,
-    slice_size: usize,
-) -> CubeTensor<R> {
-    let mut strides = vec![0u32; k];
-    if k > 0 {
-        strides[k - 1] = slice_size as u32;
-        for i in (0..k - 1).rev() {
-            strides[i] = strides[i + 1] * data_shape[i + 1] as u32;
-        }
-    }
-    let data = burn_backend::TensorData::new(strides, burn_backend::Shape::from([k]));
-    let shape = burn_backend::Shape::from([k]);
-    let alloc = tensor
-        .client
-        .create_tensor(data.bytes, shape.clone(), data.dtype.size());
-    CubeTensor::new(
-        tensor.client.clone(),
-        alloc.memory,
-        Metadata::new(shape, alloc.strides),
-        tensor.device.clone(),
-        DType::U32,
-    )
-}
 
 /// scatter_nd GPU kernel.
 ///
 /// Each thread handles one element across all update slices.
 /// Work items = num_updates * slice_size.
-///
-/// `data_strides` is a 1D tensor of length K holding the strides for converting
-/// K-dimensional index tuples into flat offsets.
 #[cube(launch_unchecked, address_type = "dynamic")]
 fn scatter_nd_kernel<T: Numeric, I: Int, Op: BinaryOpFamily>(
     data: &mut Tensor<T>,
-    indices: &Tensor<I>,
-    values: &Tensor<T>,
-    data_strides: &Tensor<u32>,
+    indices: &LinearView<I>,
+    values: &LinearView<T>,
     slice_size: usize,
     k: usize,
     #[define(T, I)] _dtypes: [StorageType; 2],
 ) {
-    let num_updates_times_slice = values.len();
-    if ABSOLUTE_POS >= num_updates_times_slice {
+    if !values.is_in_bounds(ABSOLUTE_POS) {
         terminate!();
     }
 
@@ -75,7 +38,7 @@ fn scatter_nd_kernel<T: Numeric, I: Int, Op: BinaryOpFamily>(
     let mut base_offset = 0usize;
     for j in 0..k {
         let idx_val = usize::cast_from(indices[idx_base + j]);
-        base_offset += idx_val * data_strides[j] as usize;
+        base_offset += idx_val * data.stride(j);
     }
 
     let data_idx = base_offset + slice_offset;
@@ -111,8 +74,6 @@ pub(crate) fn scatter_nd<R: CubeRuntime>(
     let slice_size: usize = data_shape.as_slice()[k..].iter().product();
     let working_units = num_updates * slice_size;
 
-    let strides_tensor = nd_index_strides_tensor(&tensor, &data_shape, k, slice_size);
-
     let cube_dim = CubeDim::new(&indices.client, working_units);
     let cube_count = calculate_cube_count_elemwise(&indices.client, working_units, cube_dim);
 
@@ -131,11 +92,10 @@ pub(crate) fn scatter_nd<R: CubeRuntime>(
             &tensor.client.clone(),
             cube_count,
             cube_dim,
-            address_type!(tensor, indices, values, strides_tensor),
+            address_type!(tensor, indices, values),
             tensor.clone().into_tensor_arg(),
-            indices.into_tensor_arg(),
-            values.into_tensor_arg(),
-            strides_tensor.into_tensor_arg(),
+            indices.into_linear_view(),
+            values.into_linear_view(),
             slice_size,
             k,
             [tensor_dtype.into(), indices_dtype.into()],

--- a/crates/burn-cubecl/src/kernel/index/scatter_nd.rs
+++ b/crates/burn-cubecl/src/kernel/index/scatter_nd.rs
@@ -1,15 +1,15 @@
 use crate::{
     CubeRuntime,
     kernel::{
-        AddOp, AssignOp, BinaryOp, BinaryOpFamily, BinaryMaxOp, BinaryMinOp, MulOp,
+        AddOp, AssignOp, BinaryMaxOp, BinaryMinOp, BinaryOp, BinaryOpFamily, MulOp,
         utils::address_type,
     },
     tensor::CubeTensor,
 };
 use burn_backend::TensorMetadata;
 use burn_backend::tensor::ScatterNdReduction;
-use cubecl::{CubeDim, calculate_cube_count_elemwise};
 use cubecl::prelude::*;
+use cubecl::{CubeDim, calculate_cube_count_elemwise};
 
 /// Compute the strides used to convert K-dimensional index tuples into flat
 /// offsets into a contiguous data tensor.

--- a/crates/burn-cubecl/src/kernel/index/scatter_nd.rs
+++ b/crates/burn-cubecl/src/kernel/index/scatter_nd.rs
@@ -2,15 +2,14 @@ use crate::{
     CubeRuntime,
     kernel::{
         AddOp, AssignOp, BinaryMaxOp, BinaryMinOp, BinaryOp, BinaryOpFamily, MulOp,
-        utils::address_type,
+        utils::{address_type, shape_divmod_range},
     },
     tensor::CubeTensor,
 };
-use burn_backend::TensorMetadata;
 use burn_backend::tensor::IndexingUpdateOp;
-use cubecl::prelude::*;
 use cubecl::std::tensor::layout::linear::LinearView;
 use cubecl::{CubeDim, calculate_cube_count_elemwise};
+use cubecl::{prelude::*, std::FastDivmod};
 
 /// scatter_nd GPU kernel.
 ///
@@ -20,20 +19,21 @@ use cubecl::{CubeDim, calculate_cube_count_elemwise};
 fn scatter_nd_kernel<T: Numeric, I: Int, Op: BinaryOpFamily>(
     data: &mut Tensor<T>,
     indices: &LinearView<I>,
-    values: &LinearView<T>,
+    values: &Tensor<T>,
+    data_slice_shape: Sequence<FastDivmod<usize>>,
+    values_shape: Sequence<FastDivmod<usize>>,
     slice_size: usize,
     k: usize,
+    working_units: usize,
     #[define(T, I)] _dtypes: [StorageType; 2],
 ) {
-    if !values.is_in_bounds(ABSOLUTE_POS) {
+    if ABSOLUTE_POS >= working_units {
         terminate!();
     }
 
-    // Decompose ABSOLUTE_POS into (update_index, slice_offset)
     let slice_offset = ABSOLUTE_POS % slice_size;
     let update_idx = ABSOLUTE_POS / slice_size;
 
-    // Compute flat base offset into data from the K-dimensional index tuple
     let idx_base = update_idx * k;
     let mut base_offset = 0usize;
     for j in 0..k {
@@ -41,12 +41,34 @@ fn scatter_nd_kernel<T: Numeric, I: Int, Op: BinaryOpFamily>(
         base_offset += idx_val * data.stride(j);
     }
 
-    let data_idx = base_offset + slice_offset;
-    let val_idx = ABSOLUTE_POS;
+    // Decompose slice_offset over data's trailing dims (k..n)
+    let slice_rank = data_slice_shape.len().comptime();
+    let mut data_slice_offset = 0usize;
+    let mut remainder = slice_offset;
+    #[unroll]
+    for i in 0..slice_rank {
+        let dim = slice_rank - i - 1;
+        let (rem, coord) = data_slice_shape[dim].div_mod(remainder);
+        remainder = rem;
+        data_slice_offset += coord * data.stride(k + dim);
+    }
 
+    // Decompose slice_offset over values' dims (1..n_v), with update_idx for dim 0
+    let val_rank = values_shape.len().comptime();
+    let mut val_offset = update_idx * values.stride(0);
+    let mut remainder_v = slice_offset;
+    #[unroll]
+    for i in 0..val_rank {
+        let dim = val_rank - i - 1;
+        let (rem, coord) = values_shape[dim].div_mod(remainder_v);
+        remainder_v = rem;
+        val_offset += coord * values.stride(1 + dim);
+    }
+
+    let data_idx = base_offset + data_slice_offset;
     let result = Op::BinaryOp::<T, Const<1>>::execute(
         Vector::cast_from(data[data_idx]),
-        Vector::cast_from(values[val_idx]),
+        Vector::cast_from(values[val_offset]),
     );
     data[data_idx] = result[0];
 }
@@ -63,8 +85,8 @@ pub(crate) fn scatter_nd<R: CubeRuntime>(
         false => tensor.copy(),
     };
 
-    let data_shape = tensor.shape();
-    let idx_shape = indices.shape();
+    let data_shape = &tensor.meta.shape;
+    let idx_shape = &indices.meta.shape;
     let m = idx_shape.num_dims();
     let k = idx_shape[m - 1];
 
@@ -87,6 +109,10 @@ pub(crate) fn scatter_nd<R: CubeRuntime>(
         IndexingUpdateOp::Max => scatter_nd_kernel::launch_unchecked::<BinaryMaxOp, R>,
     };
 
+    let data_slice_shape = shape_divmod_range(&tensor, k..data_shape.num_dims());
+    // values dims 1.. (skip the num_updates leading dim)
+    let values_slice_shape = shape_divmod_range(&values, 1..values.meta.shape.num_dims());
+
     unsafe {
         launch(
             &tensor.client.clone(),
@@ -95,9 +121,12 @@ pub(crate) fn scatter_nd<R: CubeRuntime>(
             address_type!(tensor, indices, values),
             tensor.clone().into_tensor_arg(),
             indices.into_linear_view(),
-            values.into_linear_view(),
+            values.into_tensor_arg(),
+            data_slice_shape,
+            values_slice_shape,
             slice_size,
             k,
+            working_units,
             [tensor_dtype.into(), indices_dtype.into()],
         )
     }

--- a/crates/burn-cubecl/src/kernel/utils.rs
+++ b/crates/burn-cubecl/src/kernel/utils.rs
@@ -19,6 +19,18 @@ pub fn shape_divmod<R: CubeRuntime>(tensor: &CubeTensor<R>) -> SequenceArg<R, Fa
     arg
 }
 
+pub fn shape_divmod_range<R: CubeRuntime>(
+    tensor: &CubeTensor<R>,
+    range: core::ops::Range<usize>,
+) -> SequenceArg<R, FastDivmod<usize>> {
+    let mut arg = SequenceArg::new();
+    let shape = &tensor.meta.shape;
+    for i in range {
+        arg.push(shape[i]);
+    }
+    arg
+}
+
 pub fn linear_layout<R: CubeRuntime>(
     tensor: &CubeTensor<R>,
     vector_size: VectorSize,

--- a/crates/burn-cubecl/src/ops/int_tensor.rs
+++ b/crates/burn-cubecl/src/ops/int_tensor.rs
@@ -140,7 +140,7 @@ where
         data: IntTensor<Self>,
         indices: IntTensor<Self>,
         values: IntTensor<Self>,
-        reduction: burn_backend::tensor::ScatterNdReduction,
+        reduction: burn_backend::tensor::IndexingUpdateOp,
     ) -> IntTensor<Self> {
         kernel::scatter_nd(data, indices, values, reduction)
     }

--- a/crates/burn-cubecl/src/ops/int_tensor.rs
+++ b/crates/burn-cubecl/src/ops/int_tensor.rs
@@ -145,10 +145,7 @@ where
         kernel::scatter_nd(data, indices, values, reduction)
     }
 
-    fn int_gather_nd(
-        data: IntTensor<Self>,
-        indices: IntTensor<Self>,
-    ) -> IntTensor<Self> {
+    fn int_gather_nd(data: IntTensor<Self>, indices: IntTensor<Self>) -> IntTensor<Self> {
         kernel::gather_nd(data, indices)
     }
 

--- a/crates/burn-cubecl/src/ops/int_tensor.rs
+++ b/crates/burn-cubecl/src/ops/int_tensor.rs
@@ -136,6 +136,22 @@ where
         kernel::scatter(dim, tensor, indices, value, false)
     }
 
+    fn int_scatter_nd(
+        data: IntTensor<Self>,
+        indices: IntTensor<Self>,
+        values: IntTensor<Self>,
+        reduction: burn_backend::tensor::ScatterNdReduction,
+    ) -> IntTensor<Self> {
+        kernel::scatter_nd(data, indices, values, reduction)
+    }
+
+    fn int_gather_nd(
+        data: IntTensor<Self>,
+        indices: IntTensor<Self>,
+    ) -> IntTensor<Self> {
+        kernel::gather_nd(data, indices)
+    }
+
     fn int_select(
         tensor: IntTensor<Self>,
         dim: usize,

--- a/crates/burn-cubecl/src/ops/tensor.rs
+++ b/crates/burn-cubecl/src/ops/tensor.rs
@@ -199,7 +199,7 @@ where
         data: FloatTensor<Self>,
         indices: IntTensor<Self>,
         values: FloatTensor<Self>,
-        reduction: burn_backend::tensor::ScatterNdReduction,
+        reduction: burn_backend::tensor::IndexingUpdateOp,
     ) -> FloatTensor<Self> {
         kernel::scatter_nd(data, indices, values, reduction)
     }

--- a/crates/burn-cubecl/src/ops/tensor.rs
+++ b/crates/burn-cubecl/src/ops/tensor.rs
@@ -195,6 +195,22 @@ where
         kernel::scatter(dim, tensor, indices, value, false)
     }
 
+    fn float_scatter_nd(
+        data: FloatTensor<Self>,
+        indices: IntTensor<Self>,
+        values: FloatTensor<Self>,
+        reduction: burn_backend::tensor::ScatterNdReduction,
+    ) -> FloatTensor<Self> {
+        kernel::scatter_nd(data, indices, values, reduction)
+    }
+
+    fn float_gather_nd(
+        data: FloatTensor<Self>,
+        indices: IntTensor<Self>,
+    ) -> FloatTensor<Self> {
+        kernel::gather_nd(data, indices)
+    }
+
     fn float_select(
         tensor: FloatTensor<Self>,
         dim: usize,

--- a/crates/burn-cubecl/src/ops/tensor.rs
+++ b/crates/burn-cubecl/src/ops/tensor.rs
@@ -204,10 +204,7 @@ where
         kernel::scatter_nd(data, indices, values, reduction)
     }
 
-    fn float_gather_nd(
-        data: FloatTensor<Self>,
-        indices: IntTensor<Self>,
-    ) -> FloatTensor<Self> {
+    fn float_gather_nd(data: FloatTensor<Self>, indices: IntTensor<Self>) -> FloatTensor<Self> {
         kernel::gather_nd(data, indices)
     }
 

--- a/crates/burn-dispatch/src/ops/int_tensor.rs
+++ b/crates/burn-dispatch/src/ops/int_tensor.rs
@@ -91,6 +91,25 @@ impl IntTensorOps<Self> for Dispatch {
         )
     }
 
+    fn int_scatter_nd(
+        data: IntTensor<Self>,
+        indices: IntTensor<Self>,
+        values: IntTensor<Self>,
+        reduction: burn_backend::tensor::ScatterNdReduction,
+    ) -> IntTensor<Self> {
+        multi_op!(
+            inputs[(data, int), (indices, int), (values, int)], => Int,
+            B::int_scatter_nd(data, indices, values, reduction)
+        )
+    }
+
+    fn int_gather_nd(
+        data: IntTensor<Self>,
+        indices: IntTensor<Self>,
+    ) -> IntTensor<Self> {
+        binary_op!((data, int), (indices, int), |data, indices| B::int_gather_nd(data, indices) => Int)
+    }
+
     fn int_select(
         tensor: IntTensor<Self>,
         dim: usize,

--- a/crates/burn-dispatch/src/ops/int_tensor.rs
+++ b/crates/burn-dispatch/src/ops/int_tensor.rs
@@ -95,7 +95,7 @@ impl IntTensorOps<Self> for Dispatch {
         data: IntTensor<Self>,
         indices: IntTensor<Self>,
         values: IntTensor<Self>,
-        reduction: burn_backend::tensor::ScatterNdReduction,
+        reduction: burn_backend::tensor::IndexingUpdateOp,
     ) -> IntTensor<Self> {
         multi_op!(
             inputs[(data, int), (indices, int), (values, int)], => Int,

--- a/crates/burn-dispatch/src/ops/int_tensor.rs
+++ b/crates/burn-dispatch/src/ops/int_tensor.rs
@@ -103,10 +103,7 @@ impl IntTensorOps<Self> for Dispatch {
         )
     }
 
-    fn int_gather_nd(
-        data: IntTensor<Self>,
-        indices: IntTensor<Self>,
-    ) -> IntTensor<Self> {
+    fn int_gather_nd(data: IntTensor<Self>, indices: IntTensor<Self>) -> IntTensor<Self> {
         binary_op!((data, int), (indices, int), |data, indices| B::int_gather_nd(data, indices) => Int)
     }
 

--- a/crates/burn-dispatch/src/ops/tensor.rs
+++ b/crates/burn-dispatch/src/ops/tensor.rs
@@ -150,6 +150,25 @@ impl FloatTensorOps<Self> for Dispatch {
         )
     }
 
+    fn float_scatter_nd(
+        data: FloatTensor<Self>,
+        indices: IntTensor<Self>,
+        values: FloatTensor<Self>,
+        reduction: burn_backend::tensor::ScatterNdReduction,
+    ) -> FloatTensor<Self> {
+        multi_op!(
+            inputs[(data, float), (indices, int), (values, float)], => Float,
+            B::float_scatter_nd(data, indices, values, reduction)
+        )
+    }
+
+    fn float_gather_nd(
+        data: FloatTensor<Self>,
+        indices: IntTensor<Self>,
+    ) -> FloatTensor<Self> {
+        binary_float!((data, float), (indices, int), |data, indices| B::float_gather_nd(data, indices) => Float)
+    }
+
     fn float_select(
         tensor: FloatTensor<Self>,
         dim: usize,

--- a/crates/burn-dispatch/src/ops/tensor.rs
+++ b/crates/burn-dispatch/src/ops/tensor.rs
@@ -162,10 +162,7 @@ impl FloatTensorOps<Self> for Dispatch {
         )
     }
 
-    fn float_gather_nd(
-        data: FloatTensor<Self>,
-        indices: IntTensor<Self>,
-    ) -> FloatTensor<Self> {
+    fn float_gather_nd(data: FloatTensor<Self>, indices: IntTensor<Self>) -> FloatTensor<Self> {
         binary_float!((data, float), (indices, int), |data, indices| B::float_gather_nd(data, indices) => Float)
     }
 

--- a/crates/burn-dispatch/src/ops/tensor.rs
+++ b/crates/burn-dispatch/src/ops/tensor.rs
@@ -154,7 +154,7 @@ impl FloatTensorOps<Self> for Dispatch {
         data: FloatTensor<Self>,
         indices: IntTensor<Self>,
         values: FloatTensor<Self>,
-        reduction: burn_backend::tensor::ScatterNdReduction,
+        reduction: burn_backend::tensor::IndexingUpdateOp,
     ) -> FloatTensor<Self> {
         multi_op!(
             inputs[(data, float), (indices, int), (values, float)], => Float,

--- a/crates/burn-flex/src/ops/float.rs
+++ b/crates/burn-flex/src/ops/float.rs
@@ -310,6 +310,39 @@ impl FloatTensorOps<Flex> for Flex {
         }
     }
 
+    fn float_scatter_nd(
+        data: FloatTensor<Flex>,
+        indices: IntTensor<Flex>,
+        values: FloatTensor<Flex>,
+        reduction: burn_backend::tensor::IndexingUpdateOp,
+    ) -> FloatTensor<Flex> {
+        match data.dtype() {
+            DType::F32 => {
+                crate::ops::gather_scatter::scatter_nd::<f32>(data, indices, values, reduction)
+            }
+            DType::F64 => {
+                crate::ops::gather_scatter::scatter_nd::<f64>(data, indices, values, reduction)
+            }
+            DType::F16 => {
+                crate::ops::gather_scatter::scatter_nd::<f16>(data, indices, values, reduction)
+            }
+            DType::BF16 => {
+                crate::ops::gather_scatter::scatter_nd::<bf16>(data, indices, values, reduction)
+            }
+            _ => panic!("float_scatter_nd: unsupported dtype {:?}", data.dtype()),
+        }
+    }
+
+    fn float_gather_nd(data: FloatTensor<Flex>, indices: IntTensor<Flex>) -> FloatTensor<Flex> {
+        match data.dtype() {
+            DType::F32 => crate::ops::gather_scatter::gather_nd::<f32>(data, indices),
+            DType::F64 => crate::ops::gather_scatter::gather_nd::<f64>(data, indices),
+            DType::F16 => crate::ops::gather_scatter::gather_nd::<f16>(data, indices),
+            DType::BF16 => crate::ops::gather_scatter::gather_nd::<bf16>(data, indices),
+            _ => panic!("float_gather_nd: unsupported dtype {:?}", data.dtype()),
+        }
+    }
+
     fn float_select(
         tensor: FloatTensor<Flex>,
         dim: usize,

--- a/crates/burn-flex/src/ops/gather_scatter.rs
+++ b/crates/burn-flex/src/ops/gather_scatter.rs
@@ -879,6 +879,128 @@ fn compute_strides(dims: &[usize]) -> Vec<usize> {
     strides
 }
 
+/// Multi-dimensional scatter: update `data` at locations specified by N-dimensional index tuples.
+pub fn scatter_nd<
+    E: Element + Pod + Default + Copy + core::ops::AddAssign + core::ops::Mul<Output = E> + PartialOrd,
+>(
+    data: FlexTensor,
+    indices: FlexTensor,
+    values: FlexTensor,
+    reduction: burn_backend::tensor::IndexingUpdateOp,
+) -> FlexTensor {
+    use burn_backend::tensor::IndexingUpdateOp;
+
+    let data = data.to_contiguous();
+    let indices = indices.to_contiguous();
+    let values = values.to_contiguous();
+
+    let data_shape: Vec<usize> = data.layout().shape().to_vec();
+    let idx_shape: Vec<usize> = indices.layout().shape().to_vec();
+    let m = idx_shape.len();
+    let k = idx_shape[m - 1];
+
+    let num_indices: usize = idx_shape[..m - 1].iter().product();
+    let slice_size: usize = data_shape[k..].iter().product();
+
+    let data_data: &[E] = data.storage();
+    let idx_data = read_indices(&indices);
+    let val_data: &[E] = values.storage();
+
+    let mut result: Vec<E> = data_data.to_vec();
+
+    let strides = compute_strides(&data_shape);
+
+    for n in 0..num_indices {
+        let mut base_offset = 0usize;
+        for j in 0..k {
+            let idx_val = idx_data[n * k + j] as usize;
+            base_offset += idx_val * strides[j];
+        }
+
+        let val_offset = n * slice_size;
+        match reduction {
+            IndexingUpdateOp::Assign => {
+                result[base_offset..(base_offset + slice_size)]
+                    .copy_from_slice(&val_data[val_offset..(val_offset + slice_size)]);
+            }
+            IndexingUpdateOp::Add => {
+                for s in 0..slice_size {
+                    result[base_offset + s] += val_data[val_offset + s];
+                }
+            }
+            IndexingUpdateOp::Mul => {
+                for s in 0..slice_size {
+                    result[base_offset + s] = result[base_offset + s] * val_data[val_offset + s];
+                }
+            }
+            IndexingUpdateOp::Min => {
+                for s in 0..slice_size {
+                    let b = val_data[val_offset + s];
+                    if b < result[base_offset + s] {
+                        result[base_offset + s] = b;
+                    }
+                }
+            }
+            IndexingUpdateOp::Max => {
+                for s in 0..slice_size {
+                    let b = val_data[val_offset + s];
+                    if b > result[base_offset + s] {
+                        result[base_offset + s] = b;
+                    }
+                }
+            }
+        }
+    }
+
+    let shape = Shape::from(data_shape);
+    let bytes = Bytes::from_elems(result);
+    FlexTensor::new(bytes, Layout::contiguous(shape), E::dtype())
+}
+
+/// Multi-dimensional gather: collect slices from `data` at locations specified by N-dimensional
+/// index tuples.
+pub fn gather_nd<E: Element + Pod + Default + Copy>(
+    data: FlexTensor,
+    indices: FlexTensor,
+) -> FlexTensor {
+    let data = data.to_contiguous();
+    let indices = indices.to_contiguous();
+
+    let data_shape: Vec<usize> = data.layout().shape().to_vec();
+    let idx_shape: Vec<usize> = indices.layout().shape().to_vec();
+    let m = idx_shape.len();
+    let k = idx_shape[m - 1];
+
+    let num_indices: usize = idx_shape[..m - 1].iter().product();
+    let slice_size: usize = data_shape[k..].iter().product();
+
+    let data_data: &[E] = data.storage();
+    let idx_data = read_indices(&indices);
+
+    let mut out_shape_vec: Vec<usize> = idx_shape[..m - 1].to_vec();
+    out_shape_vec.extend_from_slice(&data_shape[k..]);
+
+    let strides = compute_strides(&data_shape);
+
+    let total = num_indices * slice_size;
+    let mut result = vec![E::default(); total];
+
+    for n in 0..num_indices {
+        let mut base_offset = 0usize;
+        for j in 0..k {
+            let idx_val = idx_data[n * k + j] as usize;
+            base_offset += idx_val * strides[j];
+        }
+        let out_offset = n * slice_size;
+        result[out_offset..(out_offset + slice_size)]
+            .copy_from_slice(&data_data[base_offset..(base_offset + slice_size)]);
+    }
+
+    let shape = Shape::from(out_shape_vec);
+    let bytes = Bytes::from_elems(result);
+    FlexTensor::new(bytes, Layout::contiguous(shape), E::dtype())
+}
+
 // Type-specific wrappers
 
 pub fn gather_f32(tensor: FlexTensor, dim: usize, indices: FlexTensor) -> FlexTensor {

--- a/crates/burn-flex/src/ops/int.rs
+++ b/crates/burn-flex/src/ops/int.rs
@@ -171,6 +171,55 @@ impl IntTensorOps<Flex> for Flex {
         }
     }
 
+    fn int_scatter_nd(
+        data: IntTensor<Flex>,
+        indices: IntTensor<Flex>,
+        values: IntTensor<Flex>,
+        reduction: burn_backend::tensor::IndexingUpdateOp,
+    ) -> IntTensor<Flex> {
+        match data.dtype() {
+            DType::I64 => {
+                crate::ops::gather_scatter::scatter_nd::<i64>(data, indices, values, reduction)
+            }
+            DType::I32 => {
+                crate::ops::gather_scatter::scatter_nd::<i32>(data, indices, values, reduction)
+            }
+            DType::I16 => {
+                crate::ops::gather_scatter::scatter_nd::<i16>(data, indices, values, reduction)
+            }
+            DType::I8 => {
+                crate::ops::gather_scatter::scatter_nd::<i8>(data, indices, values, reduction)
+            }
+            DType::U64 => {
+                crate::ops::gather_scatter::scatter_nd::<u64>(data, indices, values, reduction)
+            }
+            DType::U32 => {
+                crate::ops::gather_scatter::scatter_nd::<u32>(data, indices, values, reduction)
+            }
+            DType::U16 => {
+                crate::ops::gather_scatter::scatter_nd::<u16>(data, indices, values, reduction)
+            }
+            DType::U8 => {
+                crate::ops::gather_scatter::scatter_nd::<u8>(data, indices, values, reduction)
+            }
+            dt => panic!("int_scatter_nd: unsupported dtype {:?}", dt),
+        }
+    }
+
+    fn int_gather_nd(data: IntTensor<Flex>, indices: IntTensor<Flex>) -> IntTensor<Flex> {
+        match data.dtype() {
+            DType::I64 => crate::ops::gather_scatter::gather_nd::<i64>(data, indices),
+            DType::I32 => crate::ops::gather_scatter::gather_nd::<i32>(data, indices),
+            DType::I16 => crate::ops::gather_scatter::gather_nd::<i16>(data, indices),
+            DType::I8 => crate::ops::gather_scatter::gather_nd::<i8>(data, indices),
+            DType::U64 => crate::ops::gather_scatter::gather_nd::<u64>(data, indices),
+            DType::U32 => crate::ops::gather_scatter::gather_nd::<u32>(data, indices),
+            DType::U16 => crate::ops::gather_scatter::gather_nd::<u16>(data, indices),
+            DType::U8 => crate::ops::gather_scatter::gather_nd::<u8>(data, indices),
+            dt => panic!("int_gather_nd: unsupported dtype {:?}", dt),
+        }
+    }
+
     /// Select ints along `dim` by a 1D index tensor.
     ///
     /// The `indices` tensor may be any supported int width. See

--- a/crates/burn-fusion/src/ops/int_tensor.rs
+++ b/crates/burn-fusion/src/ops/int_tensor.rs
@@ -10,7 +10,7 @@ use burn_backend::{
     BoolDType, Distribution, ExecutionError, FloatDType, IntDType, Scalar, Shape, Slice,
     TensorData,
     ops::IntTensorOps,
-    tensor::{BoolTensor, Device, FloatTensor, IndexingUpdateOp, IntTensor, ScatterNdReduction},
+    tensor::{BoolTensor, Device, FloatTensor, IndexingUpdateOp, IntTensor},
 };
 use burn_ir::*;
 use std::marker::PhantomData;
@@ -374,7 +374,7 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
         data: IntTensor<Self>,
         indices: IntTensor<Self>,
         values: IntTensor<Self>,
-        reduction: ScatterNdReduction,
+        reduction: IndexingUpdateOp,
     ) -> IntTensor<Self> {
         #[derive(new, Debug)]
         struct ScatterNdOps<B: FusionBackend> {

--- a/crates/burn-fusion/src/ops/int_tensor.rs
+++ b/crates/burn-fusion/src/ops/int_tensor.rs
@@ -10,10 +10,7 @@ use burn_backend::{
     BoolDType, Distribution, ExecutionError, FloatDType, IntDType, Scalar, Shape, Slice,
     TensorData,
     ops::IntTensorOps,
-    tensor::{
-        BoolTensor, Device, FloatTensor, IndexingUpdateOp, IntTensor,
-        ScatterNdReduction,
-    },
+    tensor::{BoolTensor, Device, FloatTensor, IndexingUpdateOp, IntTensor, ScatterNdReduction},
 };
 use burn_ir::*;
 use std::marker::PhantomData;
@@ -391,8 +388,7 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
                 let indices = handles.get_int_tensor::<B>(&self.desc.indices);
                 let values = handles.get_int_tensor::<B>(&self.desc.values);
 
-                let output =
-                    B::int_scatter_nd(data, indices, values, self.desc.reduction);
+                let output = B::int_scatter_nd(data, indices, values, self.desc.reduction);
 
                 handles.register_int_tensor::<B>(&self.desc.out.id, output);
             }
@@ -418,10 +414,7 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
             .output()
     }
 
-    fn int_gather_nd(
-        data: IntTensor<Self>,
-        indices: IntTensor<Self>,
-    ) -> IntTensor<Self> {
+    fn int_gather_nd(data: IntTensor<Self>, indices: IntTensor<Self>) -> IntTensor<Self> {
         #[derive(new, Debug)]
         struct GatherNdOps<B: FusionBackend> {
             desc: GatherNdOpIr,

--- a/crates/burn-fusion/src/ops/int_tensor.rs
+++ b/crates/burn-fusion/src/ops/int_tensor.rs
@@ -11,7 +11,7 @@ use burn_backend::{
     TensorData,
     ops::IntTensorOps,
     tensor::{
-        BoolTensor, Device, FloatTensor, IndexingUpdateOp, IntElem, IntTensor,
+        BoolTensor, Device, FloatTensor, IndexingUpdateOp, IntTensor,
         ScatterNdReduction,
     },
 };

--- a/crates/burn-fusion/src/ops/int_tensor.rs
+++ b/crates/burn-fusion/src/ops/int_tensor.rs
@@ -10,7 +10,10 @@ use burn_backend::{
     BoolDType, Distribution, ExecutionError, FloatDType, IntDType, Scalar, Shape, Slice,
     TensorData,
     ops::IntTensorOps,
-    tensor::{BoolTensor, Device, FloatTensor, IndexingUpdateOp, IntTensor},
+    tensor::{
+        BoolTensor, Device, FloatTensor, IndexingUpdateOp, IntElem, IntTensor,
+        ScatterNdReduction,
+    },
 };
 use burn_ir::*;
 use std::marker::PhantomData;
@@ -366,6 +369,87 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
                 streams,
                 OperationIr::BaseInt(BaseOperationIr::Scatter(desc.clone())),
                 ScatterOps::<B>::new(desc),
+            )
+            .output()
+    }
+
+    fn int_scatter_nd(
+        data: IntTensor<Self>,
+        indices: IntTensor<Self>,
+        values: IntTensor<Self>,
+        reduction: ScatterNdReduction,
+    ) -> IntTensor<Self> {
+        #[derive(new, Debug)]
+        struct ScatterNdOps<B: FusionBackend> {
+            desc: ScatterNdOpIr,
+            _b: PhantomData<B>,
+        }
+
+        impl<B: FusionBackend> Operation<B::FusionRuntime> for ScatterNdOps<B> {
+            fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
+                let data = handles.get_int_tensor::<B>(&self.desc.data);
+                let indices = handles.get_int_tensor::<B>(&self.desc.indices);
+                let values = handles.get_int_tensor::<B>(&self.desc.values);
+
+                let output =
+                    B::int_scatter_nd(data, indices, values, self.desc.reduction);
+
+                handles.register_int_tensor::<B>(&self.desc.out.id, output);
+            }
+        }
+
+        let streams = OperationStreams::with_inputs([&data, &indices, &values]);
+
+        let client = data.client.clone();
+        let desc = ScatterNdOpIr::create(
+            data.into_ir(),
+            indices.into_ir(),
+            values.into_ir(),
+            reduction,
+            || client.create_empty_handle(),
+        );
+
+        client
+            .register(
+                streams,
+                OperationIr::BaseInt(BaseOperationIr::ScatterNd(desc.clone())),
+                ScatterNdOps::<B>::new(desc),
+            )
+            .output()
+    }
+
+    fn int_gather_nd(
+        data: IntTensor<Self>,
+        indices: IntTensor<Self>,
+    ) -> IntTensor<Self> {
+        #[derive(new, Debug)]
+        struct GatherNdOps<B: FusionBackend> {
+            desc: GatherNdOpIr,
+            _b: PhantomData<B>,
+        }
+
+        impl<B: FusionBackend> Operation<B::FusionRuntime> for GatherNdOps<B> {
+            fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
+                let data = handles.get_int_tensor::<B>(&self.desc.data);
+                let indices = handles.get_int_tensor::<B>(&self.desc.indices);
+
+                let output = B::int_gather_nd(data, indices);
+                handles.register_int_tensor::<B>(&self.desc.out.id, output);
+            }
+        }
+
+        let streams = OperationStreams::with_inputs([&data, &indices]);
+
+        let client = data.client.clone();
+        let desc = GatherNdOpIr::create(data.into_ir(), indices.into_ir(), || {
+            client.create_empty_handle()
+        });
+
+        client
+            .register(
+                streams,
+                OperationIr::BaseInt(BaseOperationIr::GatherNd(desc.clone())),
+                GatherNdOps::<B>::new(desc),
             )
             .output()
     }

--- a/crates/burn-fusion/src/ops/tensor.rs
+++ b/crates/burn-fusion/src/ops/tensor.rs
@@ -10,10 +10,7 @@ use burn_backend::{
     BoolDType, Distribution, ExecutionError, FloatDType, IntDType, Scalar, Shape, Slice,
     TensorData,
     ops::{FloatTensorOps, GridSampleOptions},
-    tensor::{
-        BoolTensor, Device, FloatTensor, IndexingUpdateOp, IntTensor,
-        ScatterNdReduction,
-    },
+    tensor::{BoolTensor, Device, FloatTensor, IndexingUpdateOp, IntTensor, ScatterNdReduction},
 };
 use burn_ir::*;
 use std::marker::PhantomData;
@@ -726,8 +723,7 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
                 let indices = handles.get_int_tensor::<B>(&self.desc.indices);
                 let values = handles.get_float_tensor::<B>(&self.desc.values);
 
-                let output =
-                    B::float_scatter_nd(data, indices, values, self.desc.reduction);
+                let output = B::float_scatter_nd(data, indices, values, self.desc.reduction);
 
                 handles.register_float_tensor::<B>(&self.desc.out.id, output);
             }
@@ -753,10 +749,7 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
             .output()
     }
 
-    fn float_gather_nd(
-        data: FloatTensor<Self>,
-        indices: IntTensor<Self>,
-    ) -> FloatTensor<Self> {
+    fn float_gather_nd(data: FloatTensor<Self>, indices: IntTensor<Self>) -> FloatTensor<Self> {
         #[derive(new, Debug)]
         struct GatherNdOps<B: FusionBackend> {
             desc: GatherNdOpIr,

--- a/crates/burn-fusion/src/ops/tensor.rs
+++ b/crates/burn-fusion/src/ops/tensor.rs
@@ -10,7 +10,7 @@ use burn_backend::{
     BoolDType, Distribution, ExecutionError, FloatDType, IntDType, Scalar, Shape, Slice,
     TensorData,
     ops::{FloatTensorOps, GridSampleOptions},
-    tensor::{BoolTensor, Device, FloatTensor, IndexingUpdateOp, IntTensor, ScatterNdReduction},
+    tensor::{BoolTensor, Device, FloatTensor, IndexingUpdateOp, IntTensor},
 };
 use burn_ir::*;
 use std::marker::PhantomData;
@@ -709,7 +709,7 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
         data: FloatTensor<Self>,
         indices: IntTensor<Self>,
         values: FloatTensor<Self>,
-        reduction: ScatterNdReduction,
+        reduction: IndexingUpdateOp,
     ) -> FloatTensor<Self> {
         #[derive(new, Debug)]
         struct ScatterNdOps<B: FusionBackend> {

--- a/crates/burn-fusion/src/ops/tensor.rs
+++ b/crates/burn-fusion/src/ops/tensor.rs
@@ -11,7 +11,7 @@ use burn_backend::{
     TensorData,
     ops::{FloatTensorOps, GridSampleOptions},
     tensor::{
-        BoolTensor, Device, FloatElem, FloatTensor, IndexingUpdateOp, IntTensor,
+        BoolTensor, Device, FloatTensor, IndexingUpdateOp, IntTensor,
         ScatterNdReduction,
     },
 };

--- a/crates/burn-fusion/src/ops/tensor.rs
+++ b/crates/burn-fusion/src/ops/tensor.rs
@@ -10,7 +10,10 @@ use burn_backend::{
     BoolDType, Distribution, ExecutionError, FloatDType, IntDType, Scalar, Shape, Slice,
     TensorData,
     ops::{FloatTensorOps, GridSampleOptions},
-    tensor::{BoolTensor, Device, FloatTensor, IndexingUpdateOp, IntTensor},
+    tensor::{
+        BoolTensor, Device, FloatElem, FloatTensor, IndexingUpdateOp, IntTensor,
+        ScatterNdReduction,
+    },
 };
 use burn_ir::*;
 use std::marker::PhantomData;
@@ -701,6 +704,87 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
                 streams,
                 OperationIr::BaseFloat(BaseOperationIr::Scatter(desc.clone())),
                 ScatterOps::<B>::new(desc),
+            )
+            .output()
+    }
+
+    fn float_scatter_nd(
+        data: FloatTensor<Self>,
+        indices: IntTensor<Self>,
+        values: FloatTensor<Self>,
+        reduction: ScatterNdReduction,
+    ) -> FloatTensor<Self> {
+        #[derive(new, Debug)]
+        struct ScatterNdOps<B: FusionBackend> {
+            desc: ScatterNdOpIr,
+            _b: PhantomData<B>,
+        }
+
+        impl<B: FusionBackend> Operation<B::FusionRuntime> for ScatterNdOps<B> {
+            fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
+                let data = handles.get_float_tensor::<B>(&self.desc.data);
+                let indices = handles.get_int_tensor::<B>(&self.desc.indices);
+                let values = handles.get_float_tensor::<B>(&self.desc.values);
+
+                let output =
+                    B::float_scatter_nd(data, indices, values, self.desc.reduction);
+
+                handles.register_float_tensor::<B>(&self.desc.out.id, output);
+            }
+        }
+
+        let streams = OperationStreams::with_inputs([&data, &indices, &values]);
+
+        let client = data.client.clone();
+        let desc = ScatterNdOpIr::create(
+            data.into_ir(),
+            indices.into_ir(),
+            values.into_ir(),
+            reduction,
+            || client.create_empty_handle(),
+        );
+
+        client
+            .register(
+                streams,
+                OperationIr::BaseFloat(BaseOperationIr::ScatterNd(desc.clone())),
+                ScatterNdOps::<B>::new(desc),
+            )
+            .output()
+    }
+
+    fn float_gather_nd(
+        data: FloatTensor<Self>,
+        indices: IntTensor<Self>,
+    ) -> FloatTensor<Self> {
+        #[derive(new, Debug)]
+        struct GatherNdOps<B: FusionBackend> {
+            desc: GatherNdOpIr,
+            _b: PhantomData<B>,
+        }
+
+        impl<B: FusionBackend> Operation<B::FusionRuntime> for GatherNdOps<B> {
+            fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
+                let data = handles.get_float_tensor::<B>(&self.desc.data);
+                let indices = handles.get_int_tensor::<B>(&self.desc.indices);
+
+                let output = B::float_gather_nd(data, indices);
+                handles.register_float_tensor::<B>(&self.desc.out.id, output);
+            }
+        }
+
+        let streams = OperationStreams::with_inputs([&data, &indices]);
+
+        let client = data.client.clone();
+        let desc = GatherNdOpIr::create(data.into_ir(), indices.into_ir(), || {
+            client.create_empty_handle()
+        });
+
+        client
+            .register(
+                streams,
+                OperationIr::BaseFloat(BaseOperationIr::GatherNd(desc.clone())),
+                GatherNdOps::<B>::new(desc),
             )
             .output()
     }

--- a/crates/burn-fusion/src/stream/context.rs
+++ b/crates/burn-fusion/src/stream/context.rs
@@ -1136,22 +1136,18 @@ impl RelativeOps for BaseOperationIr {
                 update: desc.update,
                 out: desc.out.to_relative(converter),
             }),
-            BaseOperationIr::ScatterNd(desc) => {
-                BaseOperationIr::ScatterNd(ScatterNdOpIr {
-                    data: desc.data.to_relative(converter),
-                    indices: desc.indices.to_relative(converter),
-                    values: desc.values.to_relative(converter),
-                    reduction: desc.reduction,
-                    out: desc.out.to_relative(converter),
-                })
-            }
-            BaseOperationIr::GatherNd(desc) => {
-                BaseOperationIr::GatherNd(GatherNdOpIr {
-                    data: desc.data.to_relative(converter),
-                    indices: desc.indices.to_relative(converter),
-                    out: desc.out.to_relative(converter),
-                })
-            }
+            BaseOperationIr::ScatterNd(desc) => BaseOperationIr::ScatterNd(ScatterNdOpIr {
+                data: desc.data.to_relative(converter),
+                indices: desc.indices.to_relative(converter),
+                values: desc.values.to_relative(converter),
+                reduction: desc.reduction,
+                out: desc.out.to_relative(converter),
+            }),
+            BaseOperationIr::GatherNd(desc) => BaseOperationIr::GatherNd(GatherNdOpIr {
+                data: desc.data.to_relative(converter),
+                indices: desc.indices.to_relative(converter),
+                out: desc.out.to_relative(converter),
+            }),
             BaseOperationIr::Select(desc) => BaseOperationIr::Select(SelectOpIr {
                 tensor: desc.tensor.to_relative(converter),
                 dim: desc.dim,

--- a/crates/burn-fusion/src/stream/context.rs
+++ b/crates/burn-fusion/src/stream/context.rs
@@ -1136,6 +1136,22 @@ impl RelativeOps for BaseOperationIr {
                 update: desc.update,
                 out: desc.out.to_relative(converter),
             }),
+            BaseOperationIr::ScatterNd(desc) => {
+                BaseOperationIr::ScatterNd(ScatterNdOpIr {
+                    data: desc.data.to_relative(converter),
+                    indices: desc.indices.to_relative(converter),
+                    values: desc.values.to_relative(converter),
+                    reduction: desc.reduction,
+                    out: desc.out.to_relative(converter),
+                })
+            }
+            BaseOperationIr::GatherNd(desc) => {
+                BaseOperationIr::GatherNd(GatherNdOpIr {
+                    data: desc.data.to_relative(converter),
+                    indices: desc.indices.to_relative(converter),
+                    out: desc.out.to_relative(converter),
+                })
+            }
             BaseOperationIr::Select(desc) => BaseOperationIr::Select(SelectOpIr {
                 tensor: desc.tensor.to_relative(converter),
                 dim: desc.dim,

--- a/crates/burn-ir/src/builder.rs
+++ b/crates/burn-ir/src/builder.rs
@@ -11,7 +11,7 @@ use burn_backend::{
         unfold::calculate_unfold_shape,
     },
     quantization::QuantScheme,
-    tensor::IndexingUpdateOp,
+    tensor::{IndexingUpdateOp, ScatterNdReduction},
 };
 
 use crate::{ScalarIr, TensorId, TensorIr};
@@ -302,6 +302,35 @@ impl_ir_create!(
     shape = tensor.shape.clone(), // TODO: check dims compat between tensor and indices
     dtype = output_dtype([&tensor.dtype, &value.dtype]).unwrap()
 );
+
+impl_ir_create!(
+    ScatterNdOpIr {
+        data: TensorIr,
+        indices: TensorIr,
+        values: TensorIr,
+        reduction: ScatterNdReduction
+    },
+    shape = data.shape.clone(),
+    dtype = output_dtype([&data.dtype, &values.dtype]).unwrap()
+);
+
+impl GatherNdOpIr {
+    /// Create a new GatherNd IR operation.
+    pub fn create(
+        data: TensorIr,
+        indices: TensorIr,
+        new_id: impl FnOnce() -> crate::TensorId,
+    ) -> Self {
+        let m = indices.shape.num_dims();
+        let k = indices.shape.dims[m - 1];
+        let mut dims = indices.shape.dims[..m - 1].to_vec();
+        dims.extend_from_slice(&data.shape.dims[k..]);
+        let shape = Shape { dims };
+        let dtype = data.dtype;
+        let out = TensorIr::uninit(new_id(), shape, dtype);
+        GatherNdOpIr { data, indices, out }
+    }
+}
 
 impl_ir_create!(
     ReduceOpIr { input: TensorIr },

--- a/crates/burn-ir/src/builder.rs
+++ b/crates/burn-ir/src/builder.rs
@@ -11,7 +11,7 @@ use burn_backend::{
         unfold::calculate_unfold_shape,
     },
     quantization::QuantScheme,
-    tensor::{IndexingUpdateOp, ScatterNdReduction},
+    tensor::IndexingUpdateOp,
 };
 
 use crate::{ScalarIr, TensorId, TensorIr};
@@ -308,7 +308,7 @@ impl_ir_create!(
         data: TensorIr,
         indices: TensorIr,
         values: TensorIr,
-        reduction: ScatterNdReduction
+        reduction: IndexingUpdateOp
     },
     shape = data.shape.clone(),
     dtype = output_dtype([&data.dtype, &values.dtype]).unwrap()

--- a/crates/burn-ir/src/builder.rs
+++ b/crates/burn-ir/src/builder.rs
@@ -322,10 +322,10 @@ impl GatherNdOpIr {
         new_id: impl FnOnce() -> crate::TensorId,
     ) -> Self {
         let m = indices.shape.num_dims();
-        let k = indices.shape.dims[m - 1];
-        let mut dims = indices.shape.dims[..m - 1].to_vec();
-        dims.extend_from_slice(&data.shape.dims[k..]);
-        let shape = Shape { dims };
+        let k = indices.shape[m - 1];
+        let mut dims = indices.shape.as_slice()[..m - 1].to_vec();
+        dims.extend_from_slice(&data.shape.as_slice()[k..]);
+        let shape = Shape::from(dims);
         let dtype = data.dtype;
         let out = TensorIr::uninit(new_id(), shape, dtype);
         GatherNdOpIr { data, indices, out }

--- a/crates/burn-ir/src/operation.rs
+++ b/crates/burn-ir/src/operation.rs
@@ -1,5 +1,6 @@
 use burn_backend::ops::AttentionModuleOptions;
 use burn_backend::tensor::IndexingUpdateOp;
+use burn_backend::tensor::ScatterNdReduction;
 use core::hash::Hash;
 use serde::{Deserialize, Serialize};
 
@@ -358,6 +359,10 @@ pub enum BaseOperationIr {
     /// Int => [scatter](burn_backend::ops::IntTensorOps::int_scatter_add).
     /// Bool => [scatter](burn_backend::ops::BoolTensorOps::bool_scatter_or).
     Scatter(ScatterOpIr),
+    /// Multi-dimensional scatter operation.
+    ScatterNd(ScatterNdOpIr),
+    /// Multi-dimensional gather operation.
+    GatherNd(GatherNdOpIr),
     /// Operation corresponding to:
     ///
     /// Float => [equal](burn_backend::ops::FloatTensorOps::float_equal).
@@ -889,6 +894,24 @@ pub struct ScatterOpIr {
     pub indices: TensorIr,
     pub value: TensorIr,
     pub update: IndexingUpdateOp,
+    pub out: TensorIr,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub struct ScatterNdOpIr {
+    pub data: TensorIr,
+    pub indices: TensorIr,
+    pub values: TensorIr,
+    pub reduction: ScatterNdReduction,
+    pub out: TensorIr,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub struct GatherNdOpIr {
+    pub data: TensorIr,
+    pub indices: TensorIr,
     pub out: TensorIr,
 }
 
@@ -1977,6 +2000,12 @@ impl BaseOperationIr {
             BaseOperationIr::Scatter(repr) => {
                 Box::new([&repr.tensor, &repr.indices, &repr.value].into_iter())
             }
+            BaseOperationIr::ScatterNd(repr) => {
+                Box::new([&repr.data, &repr.indices, &repr.values].into_iter())
+            }
+            BaseOperationIr::GatherNd(repr) => {
+                Box::new([&repr.data, &repr.indices].into_iter())
+            }
             BaseOperationIr::Select(repr) => Box::new([&repr.tensor, &repr.indices].into_iter()),
             BaseOperationIr::SelectAssign(repr) => {
                 Box::new([&repr.tensor, &repr.indices, &repr.value].into_iter())
@@ -2008,6 +2037,8 @@ impl BaseOperationIr {
             BaseOperationIr::SliceAssign(repr) => Box::new([&repr.out].into_iter()),
             BaseOperationIr::Gather(repr) => Box::new([&repr.out].into_iter()),
             BaseOperationIr::Scatter(repr) => Box::new([&repr.out].into_iter()),
+            BaseOperationIr::ScatterNd(repr) => Box::new([&repr.out].into_iter()),
+            BaseOperationIr::GatherNd(repr) => Box::new([&repr.out].into_iter()),
             BaseOperationIr::Select(repr) => Box::new([&repr.out].into_iter()),
             BaseOperationIr::SelectAssign(repr) => Box::new([&repr.out].into_iter()),
             BaseOperationIr::MaskWhere(repr) => Box::new([&repr.out].into_iter()),
@@ -2060,6 +2091,15 @@ impl BaseOperationIr {
                 repr.tensor.mark_read_only(nodes, &mut output);
                 repr.indices.mark_read_only(nodes, &mut output);
                 repr.value.mark_read_only(nodes, &mut output);
+            }
+            BaseOperationIr::ScatterNd(repr) => {
+                repr.data.mark_read_only(nodes, &mut output);
+                repr.indices.mark_read_only(nodes, &mut output);
+                repr.values.mark_read_only(nodes, &mut output);
+            }
+            BaseOperationIr::GatherNd(repr) => {
+                repr.data.mark_read_only(nodes, &mut output);
+                repr.indices.mark_read_only(nodes, &mut output);
             }
             BaseOperationIr::Select(repr) => {
                 repr.tensor.mark_read_only(nodes, &mut output);

--- a/crates/burn-ir/src/operation.rs
+++ b/crates/burn-ir/src/operation.rs
@@ -2003,9 +2003,7 @@ impl BaseOperationIr {
             BaseOperationIr::ScatterNd(repr) => {
                 Box::new([&repr.data, &repr.indices, &repr.values].into_iter())
             }
-            BaseOperationIr::GatherNd(repr) => {
-                Box::new([&repr.data, &repr.indices].into_iter())
-            }
+            BaseOperationIr::GatherNd(repr) => Box::new([&repr.data, &repr.indices].into_iter()),
             BaseOperationIr::Select(repr) => Box::new([&repr.tensor, &repr.indices].into_iter()),
             BaseOperationIr::SelectAssign(repr) => {
                 Box::new([&repr.tensor, &repr.indices, &repr.value].into_iter())

--- a/crates/burn-ir/src/operation.rs
+++ b/crates/burn-ir/src/operation.rs
@@ -1,6 +1,5 @@
 use burn_backend::ops::AttentionModuleOptions;
 use burn_backend::tensor::IndexingUpdateOp;
-use burn_backend::tensor::ScatterNdReduction;
 use core::hash::Hash;
 use serde::{Deserialize, Serialize};
 
@@ -903,7 +902,7 @@ pub struct ScatterNdOpIr {
     pub data: TensorIr,
     pub indices: TensorIr,
     pub values: TensorIr,
-    pub reduction: ScatterNdReduction,
+    pub reduction: IndexingUpdateOp,
     pub out: TensorIr,
 }
 

--- a/crates/burn-ndarray/src/ops/base.rs
+++ b/crates/burn-ndarray/src/ops/base.rs
@@ -191,7 +191,10 @@ where
         indices: SharedArray<I>,
         values: SharedArray<E>,
         reduction: burn_backend::tensor::ScatterNdReduction,
-    ) -> SharedArray<E> {
+    ) -> SharedArray<E>
+    where
+        E: core::ops::Mul<Output = E> + PartialOrd,
+    {
         use burn_backend::tensor::ScatterNdReduction;
 
         let data_shape: Vec<usize> = data.shape().to_vec();
@@ -252,25 +255,22 @@ where
                 }
                 ScatterNdReduction::Mul => {
                     for s in 0..slice_size {
-                        let a: f64 = output_flat[base_offset + s].elem();
-                        let b: f64 = val_flat[val_offset + s].elem();
-                        output_flat[base_offset + s] = (a * b).elem();
+                        output_flat[base_offset + s] =
+                            output_flat[base_offset + s] * val_flat[val_offset + s];
                     }
                 }
                 ScatterNdReduction::Min => {
                     for s in 0..slice_size {
-                        let a = output_flat[base_offset + s];
                         let b = val_flat[val_offset + s];
-                        if b.elem::<f64>() < a.elem::<f64>() {
+                        if b < output_flat[base_offset + s] {
                             output_flat[base_offset + s] = b;
                         }
                     }
                 }
                 ScatterNdReduction::Max => {
                     for s in 0..slice_size {
-                        let a = output_flat[base_offset + s];
                         let b = val_flat[val_offset + s];
-                        if b.elem::<f64>() > a.elem::<f64>() {
+                        if b > output_flat[base_offset + s] {
                             output_flat[base_offset + s] = b;
                         }
                     }

--- a/crates/burn-ndarray/src/ops/base.rs
+++ b/crates/burn-ndarray/src/ops/base.rs
@@ -242,9 +242,8 @@ where
             let val_offset = n * slice_size;
             match reduction {
                 ScatterNdReduction::Assign => {
-                    for s in 0..slice_size {
-                        output_flat[base_offset + s] = val_flat[val_offset + s];
-                    }
+                    output_flat[base_offset..(base_offset + slice_size)]
+                        .copy_from_slice(&val_flat[val_offset..(val_offset + slice_size)]);
                 }
                 ScatterNdReduction::Add => {
                     for s in 0..slice_size {
@@ -330,17 +329,13 @@ where
             }
 
             let out_offset = n * slice_size;
-            for s in 0..slice_size {
-                output_vec[out_offset + s] = data_flat[base_offset + s];
-            }
+            output_vec[out_offset..(out_offset + slice_size)]
+                .copy_from_slice(&data_flat[base_offset..(base_offset + slice_size)]);
         }
 
         let out_shape = Shape::from(out_shape_vec);
-        let output = ArrayD::from_shape_vec(
-            out_shape.as_slice(),
-            output_vec,
-        )
-        .expect("gather_nd: shape mismatch");
+        let output = ArrayD::from_shape_vec(out_shape.as_slice(), output_vec)
+            .expect("gather_nd: shape mismatch");
 
         output.into_shared()
     }

--- a/crates/burn-ndarray/src/ops/base.rs
+++ b/crates/burn-ndarray/src/ops/base.rs
@@ -335,9 +335,9 @@ where
             }
         }
 
-        let out_shape = Shape { dims: out_shape_vec };
+        let out_shape = Shape::from(out_shape_vec);
         let output = ArrayD::from_shape_vec(
-            out_shape.dims.as_slice(),
+            out_shape.as_slice(),
             output_vec,
         )
         .expect("gather_nd: shape mismatch");

--- a/crates/burn-ndarray/src/ops/base.rs
+++ b/crates/burn-ndarray/src/ops/base.rs
@@ -190,12 +190,12 @@ where
         data: SharedArray<E>,
         indices: SharedArray<I>,
         values: SharedArray<E>,
-        reduction: burn_backend::tensor::ScatterNdReduction,
+        reduction: burn_backend::tensor::IndexingUpdateOp,
     ) -> SharedArray<E>
     where
         E: core::ops::Mul<Output = E> + PartialOrd,
     {
-        use burn_backend::tensor::ScatterNdReduction;
+        use burn_backend::tensor::IndexingUpdateOp;
 
         let data_shape: Vec<usize> = data.shape().to_vec();
         let idx_shape: Vec<usize> = indices.shape().to_vec();
@@ -244,22 +244,22 @@ where
             // Apply reduction over the slice
             let val_offset = n * slice_size;
             match reduction {
-                ScatterNdReduction::Assign => {
+                IndexingUpdateOp::Assign => {
                     output_flat[base_offset..(base_offset + slice_size)]
                         .copy_from_slice(&val_flat[val_offset..(val_offset + slice_size)]);
                 }
-                ScatterNdReduction::Add => {
+                IndexingUpdateOp::Add => {
                     for s in 0..slice_size {
                         output_flat[base_offset + s].add_assign(val_flat[val_offset + s]);
                     }
                 }
-                ScatterNdReduction::Mul => {
+                IndexingUpdateOp::Mul => {
                     for s in 0..slice_size {
                         output_flat[base_offset + s] =
                             output_flat[base_offset + s] * val_flat[val_offset + s];
                     }
                 }
-                ScatterNdReduction::Min => {
+                IndexingUpdateOp::Min => {
                     for s in 0..slice_size {
                         let b = val_flat[val_offset + s];
                         if b < output_flat[base_offset + s] {
@@ -267,7 +267,7 @@ where
                         }
                     }
                 }
-                ScatterNdReduction::Max => {
+                IndexingUpdateOp::Max => {
                     for s in 0..slice_size {
                         let b = val_flat[val_offset + s];
                         if b > output_flat[base_offset + s] {

--- a/crates/burn-ndarray/src/ops/int_tensor.rs
+++ b/crates/burn-ndarray/src/ops/int_tensor.rs
@@ -288,6 +288,30 @@ where
         })
     }
 
+    fn int_scatter_nd(
+        data: NdArrayTensor,
+        indices: NdArrayTensor,
+        values: NdArrayTensor,
+        reduction: burn_backend::tensor::ScatterNdReduction,
+    ) -> NdArrayTensor {
+        execute_with_int_dtype!((data, values), I, |data, values| -> NdArrayTensor {
+            execute_with_int_dtype!(indices, |idx_array| NdArrayOps::<I>::scatter_nd(
+                data, idx_array, values, reduction
+            ))
+        })
+    }
+
+    fn int_gather_nd(
+        data: NdArrayTensor,
+        indices: NdArrayTensor,
+    ) -> NdArrayTensor {
+        execute_with_int_dtype!(data, E, |array| -> NdArrayTensor {
+            execute_with_int_dtype!(indices, |idx_array| NdArrayOps::gather_nd(
+                array, idx_array
+            ))
+        })
+    }
+
     fn int_select(tensor: NdArrayTensor, dim: usize, indices: NdArrayTensor) -> NdArrayTensor {
         execute_with_int_dtype!(tensor, E, |array| -> NdArrayTensor {
             execute_with_int_dtype!(indices, |idx_array| NdArrayMathOps::select(

--- a/crates/burn-ndarray/src/ops/int_tensor.rs
+++ b/crates/burn-ndarray/src/ops/int_tensor.rs
@@ -292,7 +292,7 @@ where
         data: NdArrayTensor,
         indices: NdArrayTensor,
         values: NdArrayTensor,
-        reduction: burn_backend::tensor::ScatterNdReduction,
+        reduction: burn_backend::tensor::IndexingUpdateOp,
     ) -> NdArrayTensor {
         execute_with_int_dtype!((data, values), I, |data, values| -> NdArrayTensor {
             execute_with_int_dtype!(indices, |idx_array| NdArrayOps::<I>::scatter_nd(

--- a/crates/burn-ndarray/src/ops/int_tensor.rs
+++ b/crates/burn-ndarray/src/ops/int_tensor.rs
@@ -301,14 +301,9 @@ where
         })
     }
 
-    fn int_gather_nd(
-        data: NdArrayTensor,
-        indices: NdArrayTensor,
-    ) -> NdArrayTensor {
+    fn int_gather_nd(data: NdArrayTensor, indices: NdArrayTensor) -> NdArrayTensor {
         execute_with_int_dtype!(data, E, |array| -> NdArrayTensor {
-            execute_with_int_dtype!(indices, |idx_array| NdArrayOps::gather_nd(
-                array, idx_array
-            ))
+            execute_with_int_dtype!(indices, |idx_array| NdArrayOps::gather_nd(array, idx_array))
         })
     }
 

--- a/crates/burn-ndarray/src/ops/tensor.rs
+++ b/crates/burn-ndarray/src/ops/tensor.rs
@@ -212,7 +212,7 @@ where
         data: FloatTensor<Self>,
         indices: NdArrayTensor,
         values: FloatTensor<Self>,
-        reduction: burn_backend::tensor::ScatterNdReduction,
+        reduction: burn_backend::tensor::IndexingUpdateOp,
     ) -> FloatTensor<Self> {
         execute_with_int_dtype!(
             indices,

--- a/crates/burn-ndarray/src/ops/tensor.rs
+++ b/crates/burn-ndarray/src/ops/tensor.rs
@@ -208,6 +208,38 @@ where
         )
     }
 
+    fn float_scatter_nd(
+        data: FloatTensor<Self>,
+        indices: NdArrayTensor,
+        values: FloatTensor<Self>,
+        reduction: burn_backend::tensor::ScatterNdReduction,
+    ) -> FloatTensor<Self> {
+        execute_with_int_dtype!(
+            indices,
+            IntElem,
+            |idx_array: SharedArray<IntElem>| -> NdArrayTensor {
+                execute_with_float_dtype!((data, values), |data, values| NdArrayOps::scatter_nd(
+                    data, idx_array, values, reduction
+                ))
+            }
+        )
+    }
+
+    fn float_gather_nd(
+        data: FloatTensor<Self>,
+        indices: NdArrayTensor,
+    ) -> FloatTensor<Self> {
+        execute_with_int_dtype!(
+            indices,
+            IntElem,
+            |idx_array: SharedArray<IntElem>| -> NdArrayTensor {
+                execute_with_float_dtype!(data, FloatElem, |array: SharedArray<FloatElem>| {
+                    NdArrayOps::gather_nd(array, idx_array)
+                })
+            }
+        )
+    }
+
     fn float_select(
         tensor: FloatTensor<Self>,
         dim: usize,

--- a/crates/burn-ndarray/src/ops/tensor.rs
+++ b/crates/burn-ndarray/src/ops/tensor.rs
@@ -225,10 +225,7 @@ where
         )
     }
 
-    fn float_gather_nd(
-        data: FloatTensor<Self>,
-        indices: NdArrayTensor,
-    ) -> FloatTensor<Self> {
+    fn float_gather_nd(data: FloatTensor<Self>, indices: NdArrayTensor) -> FloatTensor<Self> {
         execute_with_int_dtype!(
             indices,
             IntElem,

--- a/crates/burn-router/src/ops/int_tensor.rs
+++ b/crates/burn-router/src/ops/int_tensor.rs
@@ -4,19 +4,18 @@ use burn_std::{BoolDType, FloatDType};
 
 use crate::{BackendRouter, RunnerChannel, RunnerClient, get_client};
 use burn_backend::tensor::{
-    BoolTensor, Device, FloatElem, FloatTensor, IndexingUpdateOp, IntElem, IntTensor,
-    ScatterNdReduction,
+    BoolTensor, Device, FloatTensor, IndexingUpdateOp, IntElem, IntTensor, ScatterNdReduction,
 };
 use burn_backend::{
     Distribution, Element, IntDType, Scalar, Shape, Slice, TensorData, ops::IntTensorOps,
 };
 use burn_ir::{
     BaseOperationIr, BinaryOpIr, CastOpIr, CatOpIr, ClampOpIr, CreationOpIr, DimOpIr, FlipOpIr,
-    GatherOpIr, InitOperationIr, IntOperationIr, MaskFillOpIr, MaskWhereOpIr, MatmulOpIr,
-    NumericOperationIr, OperationIr, OperationOutput, PermuteOpIr, RandomOpIr, ReduceDimOpIr,
-    ReduceDimWithIndicesOpIr, ReduceOpIr, RepeatDimOpIr, ScalarOpIr, ScatterOpIr, SelectAssignOpIr,
-    ScatterNdOpIr, GatherNdOpIr,
-    SelectOpIr, ShapeOpIr, SliceAssignOpIr, SliceOpIr, SwapDimsOpIr, UnaryOpIr, UnfoldOpIr,
+    GatherNdOpIr, GatherOpIr, InitOperationIr, IntOperationIr, MaskFillOpIr, MaskWhereOpIr,
+    MatmulOpIr, NumericOperationIr, OperationIr, OperationOutput, PermuteOpIr, RandomOpIr,
+    ReduceDimOpIr, ReduceDimWithIndicesOpIr, ReduceOpIr, RepeatDimOpIr, ScalarOpIr, ScatterNdOpIr,
+    ScatterOpIr, SelectAssignOpIr, SelectOpIr, ShapeOpIr, SliceAssignOpIr, SliceOpIr, SwapDimsOpIr,
+    UnaryOpIr, UnfoldOpIr,
 };
 
 impl<R: RunnerChannel> IntTensorOps<Self> for BackendRouter<R> {
@@ -195,10 +194,7 @@ impl<R: RunnerChannel> IntTensorOps<Self> for BackendRouter<R> {
             .output()
     }
 
-    fn int_gather_nd(
-        data: IntTensor<Self>,
-        indices: IntTensor<Self>,
-    ) -> IntTensor<Self> {
+    fn int_gather_nd(data: IntTensor<Self>, indices: IntTensor<Self>) -> IntTensor<Self> {
         let client = data.client.clone();
         let desc = GatherNdOpIr::create(data.into_ir(), indices.into_ir(), || {
             client.create_empty_handle()

--- a/crates/burn-router/src/ops/int_tensor.rs
+++ b/crates/burn-router/src/ops/int_tensor.rs
@@ -4,7 +4,7 @@ use burn_std::{BoolDType, FloatDType};
 
 use crate::{BackendRouter, RunnerChannel, RunnerClient, get_client};
 use burn_backend::tensor::{
-    BoolTensor, Device, FloatTensor, IndexingUpdateOp, IntElem, IntTensor, ScatterNdReduction,
+    BoolTensor, Device, FloatTensor, IndexingUpdateOp, IntElem, IntTensor,
 };
 use burn_backend::{
     Distribution, Element, IntDType, Scalar, Shape, Slice, TensorData, ops::IntTensorOps,
@@ -178,7 +178,7 @@ impl<R: RunnerChannel> IntTensorOps<Self> for BackendRouter<R> {
         data: IntTensor<Self>,
         indices: IntTensor<Self>,
         values: IntTensor<Self>,
-        reduction: ScatterNdReduction,
+        reduction: IndexingUpdateOp,
     ) -> IntTensor<Self> {
         let client = data.client.clone();
         let desc = ScatterNdOpIr::create(

--- a/crates/burn-router/src/ops/int_tensor.rs
+++ b/crates/burn-router/src/ops/int_tensor.rs
@@ -3,7 +3,10 @@ use burn_backend::backend::ExecutionError;
 use burn_std::{BoolDType, FloatDType};
 
 use crate::{BackendRouter, RunnerChannel, RunnerClient, get_client};
-use burn_backend::tensor::{BoolTensor, Device, FloatTensor, IndexingUpdateOp, IntElem, IntTensor};
+use burn_backend::tensor::{
+    BoolTensor, Device, FloatElem, FloatTensor, IndexingUpdateOp, IntElem, IntTensor,
+    ScatterNdReduction,
+};
 use burn_backend::{
     Distribution, Element, IntDType, Scalar, Shape, Slice, TensorData, ops::IntTensorOps,
 };
@@ -12,6 +15,7 @@ use burn_ir::{
     GatherOpIr, InitOperationIr, IntOperationIr, MaskFillOpIr, MaskWhereOpIr, MatmulOpIr,
     NumericOperationIr, OperationIr, OperationOutput, PermuteOpIr, RandomOpIr, ReduceDimOpIr,
     ReduceDimWithIndicesOpIr, ReduceOpIr, RepeatDimOpIr, ScalarOpIr, ScatterOpIr, SelectAssignOpIr,
+    ScatterNdOpIr, GatherNdOpIr,
     SelectOpIr, ShapeOpIr, SliceAssignOpIr, SliceOpIr, SwapDimsOpIr, UnaryOpIr, UnfoldOpIr,
 };
 
@@ -168,6 +172,40 @@ impl<R: RunnerChannel> IntTensorOps<Self> for BackendRouter<R> {
 
         client
             .register(OperationIr::BaseInt(BaseOperationIr::Scatter(desc)))
+            .output()
+    }
+
+    fn int_scatter_nd(
+        data: IntTensor<Self>,
+        indices: IntTensor<Self>,
+        values: IntTensor<Self>,
+        reduction: ScatterNdReduction,
+    ) -> IntTensor<Self> {
+        let client = data.client.clone();
+        let desc = ScatterNdOpIr::create(
+            data.into_ir(),
+            indices.into_ir(),
+            values.into_ir(),
+            reduction,
+            || client.create_empty_handle(),
+        );
+
+        client
+            .register(OperationIr::BaseInt(BaseOperationIr::ScatterNd(desc)))
+            .output()
+    }
+
+    fn int_gather_nd(
+        data: IntTensor<Self>,
+        indices: IntTensor<Self>,
+    ) -> IntTensor<Self> {
+        let client = data.client.clone();
+        let desc = GatherNdOpIr::create(data.into_ir(), indices.into_ir(), || {
+            client.create_empty_handle()
+        });
+
+        client
+            .register(OperationIr::BaseInt(BaseOperationIr::GatherNd(desc)))
             .output()
     }
 

--- a/crates/burn-router/src/ops/int_tensor.rs
+++ b/crates/burn-router/src/ops/int_tensor.rs
@@ -3,9 +3,7 @@ use burn_backend::backend::ExecutionError;
 use burn_std::{BoolDType, FloatDType};
 
 use crate::{BackendRouter, RunnerChannel, RunnerClient, get_client};
-use burn_backend::tensor::{
-    BoolTensor, Device, FloatTensor, IndexingUpdateOp, IntElem, IntTensor,
-};
+use burn_backend::tensor::{BoolTensor, Device, FloatTensor, IndexingUpdateOp, IntElem, IntTensor};
 use burn_backend::{
     Distribution, Element, IntDType, Scalar, Shape, Slice, TensorData, ops::IntTensorOps,
 };

--- a/crates/burn-router/src/ops/tensor.rs
+++ b/crates/burn-router/src/ops/tensor.rs
@@ -5,20 +5,16 @@ use burn_std::{BoolDType, IntDType};
 
 use crate::{BackendRouter, RunnerChannel, RunnerClient, get_client};
 use burn_backend::tensor::{
-    BoolTensor, Device, FloatElem, FloatTensor, IndexingUpdateOp, IntElem, IntTensor,
-    ScatterNdReduction,
+    BoolTensor, Device, FloatTensor, IndexingUpdateOp, IntTensor, ScatterNdReduction,
 };
-use burn_backend::{
-    Distribution, Element, FloatDType, Shape, Slice, TensorData, ops::FloatTensorOps,
-};
+use burn_backend::{Distribution, FloatDType, Shape, Slice, TensorData, ops::FloatTensorOps};
 use burn_ir::{
     BaseOperationIr, BinaryOpIr, CastOpIr, CatOpIr, ClampOpIr, CreationOpIr, CrossOpIr, DimOpIr,
-    FlipOpIr, FloatOperationIr, FullOpIr, GatherOpIr, InitOperationIr, MaskFillOpIr, MaskWhereOpIr,
-    MatmulOpIr, NumericOperationIr, OperationIr, OperationOutput, PermuteOpIr, RandomOpIr,
-    ReduceDimOpIr, ReduceDimWithIndicesOpIr, ReduceOpIr, RepeatDimOpIr, ScalarOpIr, ScatterOpIr,
-    ScatterNdOpIr, GatherNdOpIr,
-    SelectAssignOpIr, SelectOpIr, ShapeOpIr, SliceAssignOpIr, SliceOpIr, SwapDimsOpIr, UnaryOpIr,
-    UnfoldOpIr,
+    FlipOpIr, FloatOperationIr, FullOpIr, GatherNdOpIr, GatherOpIr, InitOperationIr, MaskFillOpIr,
+    MaskWhereOpIr, MatmulOpIr, NumericOperationIr, OperationIr, OperationOutput, PermuteOpIr,
+    RandomOpIr, ReduceDimOpIr, ReduceDimWithIndicesOpIr, ReduceOpIr, RepeatDimOpIr, ScalarOpIr,
+    ScatterNdOpIr, ScatterOpIr, SelectAssignOpIr, SelectOpIr, ShapeOpIr, SliceAssignOpIr,
+    SliceOpIr, SwapDimsOpIr, UnaryOpIr, UnfoldOpIr,
 };
 
 impl<R: RunnerChannel> FloatTensorOps<Self> for BackendRouter<R> {
@@ -386,10 +382,7 @@ impl<R: RunnerChannel> FloatTensorOps<Self> for BackendRouter<R> {
             .output()
     }
 
-    fn float_gather_nd(
-        data: FloatTensor<Self>,
-        indices: IntTensor<Self>,
-    ) -> FloatTensor<Self> {
+    fn float_gather_nd(data: FloatTensor<Self>, indices: IntTensor<Self>) -> FloatTensor<Self> {
         let client = data.client.clone();
         let desc = GatherNdOpIr::create(data.into_ir(), indices.into_ir(), || {
             client.create_empty_handle()

--- a/crates/burn-router/src/ops/tensor.rs
+++ b/crates/burn-router/src/ops/tensor.rs
@@ -5,7 +5,7 @@ use burn_std::{BoolDType, IntDType};
 
 use crate::{BackendRouter, RunnerChannel, RunnerClient, get_client};
 use burn_backend::tensor::{
-    BoolTensor, Device, FloatTensor, IndexingUpdateOp, IntTensor, ScatterNdReduction,
+    BoolTensor, Device, FloatTensor, IndexingUpdateOp, IntTensor,
 };
 use burn_backend::{Distribution, FloatDType, Shape, Slice, TensorData, ops::FloatTensorOps};
 use burn_ir::{
@@ -366,7 +366,7 @@ impl<R: RunnerChannel> FloatTensorOps<Self> for BackendRouter<R> {
         data: FloatTensor<Self>,
         indices: IntTensor<Self>,
         values: FloatTensor<Self>,
-        reduction: ScatterNdReduction,
+        reduction: IndexingUpdateOp,
     ) -> FloatTensor<Self> {
         let client = data.client.clone();
         let desc = ScatterNdOpIr::create(

--- a/crates/burn-router/src/ops/tensor.rs
+++ b/crates/burn-router/src/ops/tensor.rs
@@ -4,9 +4,7 @@ use burn_backend::{Scalar, tensor::FloatElem};
 use burn_std::{BoolDType, IntDType};
 
 use crate::{BackendRouter, RunnerChannel, RunnerClient, get_client};
-use burn_backend::tensor::{
-    BoolTensor, Device, FloatTensor, IndexingUpdateOp, IntTensor,
-};
+use burn_backend::tensor::{BoolTensor, Device, FloatTensor, IndexingUpdateOp, IntTensor};
 use burn_backend::{Distribution, FloatDType, Shape, Slice, TensorData, ops::FloatTensorOps};
 use burn_ir::{
     BaseOperationIr, BinaryOpIr, CastOpIr, CatOpIr, ClampOpIr, CreationOpIr, CrossOpIr, DimOpIr,

--- a/crates/burn-router/src/ops/tensor.rs
+++ b/crates/burn-router/src/ops/tensor.rs
@@ -4,13 +4,19 @@ use burn_backend::{Scalar, tensor::FloatElem};
 use burn_std::{BoolDType, IntDType};
 
 use crate::{BackendRouter, RunnerChannel, RunnerClient, get_client};
-use burn_backend::tensor::{BoolTensor, Device, FloatTensor, IndexingUpdateOp, IntTensor};
-use burn_backend::{Distribution, FloatDType, Shape, Slice, TensorData, ops::FloatTensorOps};
+use burn_backend::tensor::{
+    BoolTensor, Device, FloatElem, FloatTensor, IndexingUpdateOp, IntElem, IntTensor,
+    ScatterNdReduction,
+};
+use burn_backend::{
+    Distribution, Element, FloatDType, Shape, Slice, TensorData, ops::FloatTensorOps,
+};
 use burn_ir::{
     BaseOperationIr, BinaryOpIr, CastOpIr, CatOpIr, ClampOpIr, CreationOpIr, CrossOpIr, DimOpIr,
     FlipOpIr, FloatOperationIr, FullOpIr, GatherOpIr, InitOperationIr, MaskFillOpIr, MaskWhereOpIr,
     MatmulOpIr, NumericOperationIr, OperationIr, OperationOutput, PermuteOpIr, RandomOpIr,
     ReduceDimOpIr, ReduceDimWithIndicesOpIr, ReduceOpIr, RepeatDimOpIr, ScalarOpIr, ScatterOpIr,
+    ScatterNdOpIr, GatherNdOpIr,
     SelectAssignOpIr, SelectOpIr, ShapeOpIr, SliceAssignOpIr, SliceOpIr, SwapDimsOpIr, UnaryOpIr,
     UnfoldOpIr,
 };
@@ -357,6 +363,40 @@ impl<R: RunnerChannel> FloatTensorOps<Self> for BackendRouter<R> {
 
         client
             .register(OperationIr::BaseFloat(BaseOperationIr::Scatter(desc)))
+            .output()
+    }
+
+    fn float_scatter_nd(
+        data: FloatTensor<Self>,
+        indices: IntTensor<Self>,
+        values: FloatTensor<Self>,
+        reduction: ScatterNdReduction,
+    ) -> FloatTensor<Self> {
+        let client = data.client.clone();
+        let desc = ScatterNdOpIr::create(
+            data.into_ir(),
+            indices.into_ir(),
+            values.into_ir(),
+            reduction,
+            || client.create_empty_handle(),
+        );
+
+        client
+            .register(OperationIr::BaseFloat(BaseOperationIr::ScatterNd(desc)))
+            .output()
+    }
+
+    fn float_gather_nd(
+        data: FloatTensor<Self>,
+        indices: IntTensor<Self>,
+    ) -> FloatTensor<Self> {
+        let client = data.client.clone();
+        let desc = GatherNdOpIr::create(data.into_ir(), indices.into_ir(), || {
+            client.create_empty_handle()
+        });
+
+        client
+            .register(OperationIr::BaseFloat(BaseOperationIr::GatherNd(desc)))
             .output()
     }
 

--- a/crates/burn-router/src/runner.rs
+++ b/crates/burn-router/src/runner.rs
@@ -212,6 +212,7 @@ impl<B: BackendIr> RunnerClient for Runner<B> {
                         IndexingUpdateOp::Add => {
                             B::float_scatter_add(desc.dim, tensor, indices, value)
                         }
+                        _ => unimplemented!(),
                     };
                     handles.register_float_tensor::<B>(&desc.out.id, output);
                 }
@@ -246,6 +247,7 @@ impl<B: BackendIr> RunnerClient for Runner<B> {
                         IndexingUpdateOp::Add => {
                             B::float_select_add(tensor, desc.dim, indices, value)
                         }
+                        _ => unimplemented!(),
                     };
                     handles.register_float_tensor::<B>(&desc.out.id, output);
                 }
@@ -373,6 +375,7 @@ impl<B: BackendIr> RunnerClient for Runner<B> {
                         IndexingUpdateOp::Add => {
                             B::int_scatter_add(desc.dim, tensor, indices, value)
                         }
+                        _ => unimplemented!(),
                     };
                     handles.register_int_tensor::<B>(&desc.out.id, output);
                 }
@@ -407,6 +410,7 @@ impl<B: BackendIr> RunnerClient for Runner<B> {
                         IndexingUpdateOp::Add => {
                             B::int_select_add(tensor, desc.dim, indices, value)
                         }
+                        _ => unimplemented!(),
                     };
                     handles.register_int_tensor::<B>(&desc.out.id, output);
                 }
@@ -530,6 +534,7 @@ impl<B: BackendIr> RunnerClient for Runner<B> {
                         IndexingUpdateOp::Add => {
                             B::bool_scatter_or(desc.dim, tensor, indices, value)
                         }
+                        _ => unimplemented!(),
                     };
                     handles.register_bool_tensor::<B>(&desc.out.id, output);
                 }
@@ -555,6 +560,7 @@ impl<B: BackendIr> RunnerClient for Runner<B> {
                         IndexingUpdateOp::Add => {
                             B::bool_select_or(tensor, desc.dim, indices, value)
                         }
+                        _ => unimplemented!(),
                     };
                     handles.register_bool_tensor::<B>(&desc.out.id, output);
                 }

--- a/crates/burn-router/src/runner.rs
+++ b/crates/burn-router/src/runner.rs
@@ -215,6 +215,22 @@ impl<B: BackendIr> RunnerClient for Runner<B> {
                     };
                     handles.register_float_tensor::<B>(&desc.out.id, output);
                 }
+                BaseOperationIr::ScatterNd(desc) => {
+                    let data = handles.get_float_tensor::<B>(&desc.data);
+                    let indices = handles.get_int_tensor::<B>(&desc.indices);
+                    let values = handles.get_float_tensor::<B>(&desc.values);
+
+                    let output =
+                        B::float_scatter_nd(data, indices, values, desc.reduction);
+                    handles.register_float_tensor::<B>(&desc.out.id, output);
+                }
+                BaseOperationIr::GatherNd(desc) => {
+                    let data = handles.get_float_tensor::<B>(&desc.data);
+                    let indices = handles.get_int_tensor::<B>(&desc.indices);
+
+                    let output = B::float_gather_nd(data, indices);
+                    handles.register_float_tensor::<B>(&desc.out.id, output);
+                }
                 BaseOperationIr::Select(desc) => {
                     let tensor = handles.get_float_tensor::<B>(&desc.tensor);
                     let indices = handles.get_int_tensor::<B>(&desc.indices);
@@ -361,6 +377,22 @@ impl<B: BackendIr> RunnerClient for Runner<B> {
                     };
                     handles.register_int_tensor::<B>(&desc.out.id, output);
                 }
+                BaseOperationIr::ScatterNd(desc) => {
+                    let data = handles.get_int_tensor::<B>(&desc.data);
+                    let indices = handles.get_int_tensor::<B>(&desc.indices);
+                    let values = handles.get_int_tensor::<B>(&desc.values);
+
+                    let output =
+                        B::int_scatter_nd(data, indices, values, desc.reduction);
+                    handles.register_int_tensor::<B>(&desc.out.id, output);
+                }
+                BaseOperationIr::GatherNd(desc) => {
+                    let data = handles.get_int_tensor::<B>(&desc.data);
+                    let indices = handles.get_int_tensor::<B>(&desc.indices);
+
+                    let output = B::int_gather_nd(data, indices);
+                    handles.register_int_tensor::<B>(&desc.out.id, output);
+                }
                 BaseOperationIr::Select(desc) => {
                     let tensor = handles.get_int_tensor::<B>(&desc.tensor);
                     let indices = handles.get_int_tensor::<B>(&desc.indices);
@@ -502,6 +534,12 @@ impl<B: BackendIr> RunnerClient for Runner<B> {
                         }
                     };
                     handles.register_bool_tensor::<B>(&desc.out.id, output);
+                }
+                BaseOperationIr::ScatterNd(_) => {
+                    unreachable!("scatter_nd not supported for bool tensors")
+                }
+                BaseOperationIr::GatherNd(_) => {
+                    unreachable!("gather_nd not supported for bool tensors")
                 }
                 BaseOperationIr::Select(desc) => {
                     let tensor = handles.get_bool_tensor::<B>(&desc.tensor);

--- a/crates/burn-router/src/runner.rs
+++ b/crates/burn-router/src/runner.rs
@@ -220,8 +220,7 @@ impl<B: BackendIr> RunnerClient for Runner<B> {
                     let indices = handles.get_int_tensor::<B>(&desc.indices);
                     let values = handles.get_float_tensor::<B>(&desc.values);
 
-                    let output =
-                        B::float_scatter_nd(data, indices, values, desc.reduction);
+                    let output = B::float_scatter_nd(data, indices, values, desc.reduction);
                     handles.register_float_tensor::<B>(&desc.out.id, output);
                 }
                 BaseOperationIr::GatherNd(desc) => {
@@ -382,8 +381,7 @@ impl<B: BackendIr> RunnerClient for Runner<B> {
                     let indices = handles.get_int_tensor::<B>(&desc.indices);
                     let values = handles.get_int_tensor::<B>(&desc.values);
 
-                    let output =
-                        B::int_scatter_nd(data, indices, values, desc.reduction);
+                    let output = B::int_scatter_nd(data, indices, values, desc.reduction);
                     handles.register_int_tensor::<B>(&desc.out.id, output);
                 }
                 BaseOperationIr::GatherNd(desc) => {

--- a/crates/burn-tch/src/ops/base.rs
+++ b/crates/burn-tch/src/ops/base.rs
@@ -1,5 +1,5 @@
-use burn_backend::{Shape, TensorMetadata};
 use burn_backend::tensor::ScatterNdReduction;
+use burn_backend::{Shape, TensorMetadata};
 use tch::Scalar;
 
 use crate::{LibTorchDevice, TchShape, TchTensor};
@@ -254,13 +254,13 @@ impl TchOps {
         }
 
         // base_offsets: [num_updates] = sum(indices[:, j] * strides[j])
-        let strides_tensor =
-            tch::Tensor::from_slice(&strides).to_device(indices.device());
-        let base_offsets = indices.matmul(&strides_tensor.unsqueeze(-1)).squeeze_dim(-1);
+        let strides_tensor = tch::Tensor::from_slice(&strides).to_device(indices.device());
+        let base_offsets = indices
+            .matmul(&strides_tensor.unsqueeze(-1))
+            .squeeze_dim(-1);
 
         // Expand base_offsets to [num_updates, slice_size] and add intra-slice offsets
-        let slice_offsets =
-            tch::Tensor::arange(slice_size, (tch::Kind::Int64, indices.device()));
+        let slice_offsets = tch::Tensor::arange(slice_size, (tch::Kind::Int64, indices.device()));
         let flat = base_offsets.unsqueeze(-1) + slice_offsets.unsqueeze(0);
         flat.reshape([flat.size().iter().product::<i64>()])
     }
@@ -288,12 +288,8 @@ impl TchOps {
         let flat_values = values.tensor.reshape([num_updates * slice_size]);
 
         let result = match reduction {
-            ScatterNdReduction::Assign => {
-                flat_data.scatter_(0, &linear_idx, &flat_values)
-            }
-            ScatterNdReduction::Add => {
-                flat_data.scatter_add(0, &linear_idx, &flat_values)
-            }
+            ScatterNdReduction::Assign => flat_data.scatter_(0, &linear_idx, &flat_values),
+            ScatterNdReduction::Add => flat_data.scatter_add(0, &linear_idx, &flat_values),
             ScatterNdReduction::Mul => {
                 flat_data.scatter_reduce(0, &linear_idx, &flat_values, "prod")
             }

--- a/crates/burn-tch/src/ops/base.rs
+++ b/crates/burn-tch/src/ops/base.rs
@@ -1,4 +1,5 @@
 use burn_backend::{Shape, TensorMetadata};
+use burn_backend::tensor::ScatterNdReduction;
 use tch::Scalar;
 
 use crate::{LibTorchDevice, TchShape, TchTensor};
@@ -230,6 +231,105 @@ impl TchOps {
             .scatter_add(dim as i64, &indices.tensor, &value.tensor);
 
         TchTensor::from_existing(tensor, storage)
+    }
+
+    /// Flatten K-dimensional index tuples into 1D linear offsets, suitable for
+    /// use with PyTorch's scatter/gather along dim 0 of a flattened tensor.
+    ///
+    /// `indices` has shape `[num_updates, k]`.
+    /// Returns a 1D tensor of shape `[num_updates * slice_size]`.
+    fn flatten_nd_indices(
+        indices: &tch::Tensor,
+        data_shape: &[i64],
+        k: usize,
+        slice_size: i64,
+    ) -> tch::Tensor {
+        // Compute per-dimension strides for the first K dims
+        let mut strides = vec![0i64; k];
+        if k > 0 {
+            strides[k - 1] = slice_size;
+            for i in (0..k - 1).rev() {
+                strides[i] = strides[i + 1] * data_shape[i + 1];
+            }
+        }
+
+        // base_offsets: [num_updates] = sum(indices[:, j] * strides[j])
+        let strides_tensor =
+            tch::Tensor::from_slice(&strides).to_device(indices.device());
+        let base_offsets = indices.matmul(&strides_tensor.unsqueeze(-1)).squeeze_dim(-1);
+
+        // Expand base_offsets to [num_updates, slice_size] and add intra-slice offsets
+        let slice_offsets =
+            tch::Tensor::arange(slice_size, (tch::Kind::Int64, indices.device()));
+        let flat = base_offsets.unsqueeze(-1) + slice_offsets.unsqueeze(0);
+        flat.reshape([flat.size().iter().product::<i64>()])
+    }
+
+    pub fn scatter_nd(
+        tensor: TchTensor,
+        indices: TchTensor,
+        values: TchTensor,
+        reduction: ScatterNdReduction,
+    ) -> TchTensor {
+        let data_shape: Vec<i64> = tensor.tensor.size();
+        let idx_shape: Vec<i64> = indices.tensor.size();
+        let m = idx_shape.len();
+        let k = *idx_shape.last().unwrap() as usize;
+        let num_updates: i64 = idx_shape[..m - 1].iter().product();
+        let total_elems: i64 = data_shape.iter().product();
+        let slice_size: i64 = data_shape[k..].iter().product();
+
+        // Flatten indices [I0,..,I_{M-2}, K] -> [num_updates, K]
+        let flat_indices = indices.tensor.reshape([num_updates, k as i64]);
+        let linear_idx = Self::flatten_nd_indices(&flat_indices, &data_shape, k, slice_size);
+
+        // Flatten data and values to 1D
+        let mut flat_data = tensor.tensor.reshape([total_elems]);
+        let flat_values = values.tensor.reshape([num_updates * slice_size]);
+
+        let result = match reduction {
+            ScatterNdReduction::Assign => {
+                flat_data.scatter_(0, &linear_idx, &flat_values)
+            }
+            ScatterNdReduction::Add => {
+                flat_data.scatter_add(0, &linear_idx, &flat_values)
+            }
+            ScatterNdReduction::Mul => {
+                flat_data.scatter_reduce(0, &linear_idx, &flat_values, "prod")
+            }
+            ScatterNdReduction::Min => {
+                flat_data.scatter_reduce(0, &linear_idx, &flat_values, "amin")
+            }
+            ScatterNdReduction::Max => {
+                flat_data.scatter_reduce(0, &linear_idx, &flat_values, "amax")
+            }
+        };
+
+        let storage = tensor.storage.clone();
+        TchTensor::from_existing(result.reshape(data_shape), storage)
+    }
+
+    pub fn gather_nd(tensor: TchTensor, indices: TchTensor) -> TchTensor {
+        let data_shape: Vec<i64> = tensor.tensor.size();
+        let idx_shape: Vec<i64> = indices.tensor.size();
+        let m = idx_shape.len();
+        let k = *idx_shape.last().unwrap() as usize;
+        let num_indices: i64 = idx_shape[..m - 1].iter().product();
+        let total_elems: i64 = data_shape.iter().product();
+        let slice_size: i64 = data_shape[k..].iter().product();
+
+        let flat_indices = indices.tensor.reshape([num_indices, k as i64]);
+        let linear_idx = Self::flatten_nd_indices(&flat_indices, &data_shape, k, slice_size);
+
+        let flat_data = tensor.tensor.reshape([total_elems]);
+        let gathered = flat_data.index_select(0, &linear_idx);
+
+        // Output shape: idx_shape[..m-1] ++ data_shape[k..]
+        let mut out_shape: Vec<i64> = idx_shape[..m - 1].to_vec();
+        out_shape.extend_from_slice(&data_shape[k..]);
+
+        let storage = tensor.storage.clone();
+        TchTensor::from_existing(gathered.reshape(out_shape), storage)
     }
 
     pub fn index_select_dim(tensor: TchTensor, dim: usize, indices: TchTensor) -> TchTensor {

--- a/crates/burn-tch/src/ops/base.rs
+++ b/crates/burn-tch/src/ops/base.rs
@@ -290,15 +290,9 @@ impl TchOps {
         let result = match reduction {
             IndexingUpdateOp::Assign => flat_data.scatter_(0, &linear_idx, &flat_values),
             IndexingUpdateOp::Add => flat_data.scatter_add(0, &linear_idx, &flat_values),
-            IndexingUpdateOp::Mul => {
-                flat_data.scatter_reduce(0, &linear_idx, &flat_values, "prod")
-            }
-            IndexingUpdateOp::Min => {
-                flat_data.scatter_reduce(0, &linear_idx, &flat_values, "amin")
-            }
-            IndexingUpdateOp::Max => {
-                flat_data.scatter_reduce(0, &linear_idx, &flat_values, "amax")
-            }
+            IndexingUpdateOp::Mul => flat_data.scatter_reduce(0, &linear_idx, &flat_values, "prod"),
+            IndexingUpdateOp::Min => flat_data.scatter_reduce(0, &linear_idx, &flat_values, "amin"),
+            IndexingUpdateOp::Max => flat_data.scatter_reduce(0, &linear_idx, &flat_values, "amax"),
         };
 
         let storage = tensor.storage.clone();

--- a/crates/burn-tch/src/ops/base.rs
+++ b/crates/burn-tch/src/ops/base.rs
@@ -1,4 +1,4 @@
-use burn_backend::tensor::ScatterNdReduction;
+use burn_backend::tensor::IndexingUpdateOp;
 use burn_backend::{Shape, TensorMetadata};
 use tch::Scalar;
 
@@ -269,7 +269,7 @@ impl TchOps {
         tensor: TchTensor,
         indices: TchTensor,
         values: TchTensor,
-        reduction: ScatterNdReduction,
+        reduction: IndexingUpdateOp,
     ) -> TchTensor {
         let data_shape: Vec<i64> = tensor.tensor.size();
         let idx_shape: Vec<i64> = indices.tensor.size();
@@ -288,15 +288,15 @@ impl TchOps {
         let flat_values = values.tensor.reshape([num_updates * slice_size]);
 
         let result = match reduction {
-            ScatterNdReduction::Assign => flat_data.scatter_(0, &linear_idx, &flat_values),
-            ScatterNdReduction::Add => flat_data.scatter_add(0, &linear_idx, &flat_values),
-            ScatterNdReduction::Mul => {
+            IndexingUpdateOp::Assign => flat_data.scatter_(0, &linear_idx, &flat_values),
+            IndexingUpdateOp::Add => flat_data.scatter_add(0, &linear_idx, &flat_values),
+            IndexingUpdateOp::Mul => {
                 flat_data.scatter_reduce(0, &linear_idx, &flat_values, "prod")
             }
-            ScatterNdReduction::Min => {
+            IndexingUpdateOp::Min => {
                 flat_data.scatter_reduce(0, &linear_idx, &flat_values, "amin")
             }
-            ScatterNdReduction::Max => {
+            IndexingUpdateOp::Max => {
                 flat_data.scatter_reduce(0, &linear_idx, &flat_values, "amax")
             }
         };

--- a/crates/burn-tch/src/ops/int_tensor.rs
+++ b/crates/burn-tch/src/ops/int_tensor.rs
@@ -296,7 +296,7 @@ impl<E: TchElement> IntTensorOps<Self> for LibTorch<E> {
         data: TchTensor,
         indices: TchTensor,
         values: TchTensor,
-        reduction: burn_backend::tensor::ScatterNdReduction,
+        reduction: burn_backend::tensor::IndexingUpdateOp,
     ) -> TchTensor {
         TchOps::scatter_nd(data, indices, values, reduction)
     }

--- a/crates/burn-tch/src/ops/int_tensor.rs
+++ b/crates/burn-tch/src/ops/int_tensor.rs
@@ -292,6 +292,19 @@ impl<E: TchElement> IntTensorOps<Self> for LibTorch<E> {
         TchOps::scatter(dim, tensor, indices, value)
     }
 
+    fn int_scatter_nd(
+        data: TchTensor,
+        indices: TchTensor,
+        values: TchTensor,
+        reduction: burn_backend::tensor::ScatterNdReduction,
+    ) -> TchTensor {
+        TchOps::scatter_nd(data, indices, values, reduction)
+    }
+
+    fn int_gather_nd(data: TchTensor, indices: TchTensor) -> TchTensor {
+        TchOps::gather_nd(data, indices)
+    }
+
     fn int_select(tensor: TchTensor, dim: usize, indices: TchTensor) -> TchTensor {
         TchOps::index_select_dim(tensor, dim, indices)
     }

--- a/crates/burn-tch/src/ops/tensor.rs
+++ b/crates/burn-tch/src/ops/tensor.rs
@@ -207,6 +207,19 @@ impl<E: TchElement> FloatTensorOps<Self> for LibTorch<E> {
         TchOps::scatter(dim, tensor, indices, value)
     }
 
+    fn float_scatter_nd(
+        data: TchTensor,
+        indices: TchTensor,
+        values: TchTensor,
+        reduction: burn_backend::tensor::ScatterNdReduction,
+    ) -> TchTensor {
+        TchOps::scatter_nd(data, indices, values, reduction)
+    }
+
+    fn float_gather_nd(data: TchTensor, indices: TchTensor) -> TchTensor {
+        TchOps::gather_nd(data, indices)
+    }
+
     fn float_select(tensor: TchTensor, dim: usize, indices: TchTensor) -> TchTensor {
         TchOps::index_select_dim(tensor, dim, indices)
     }

--- a/crates/burn-tch/src/ops/tensor.rs
+++ b/crates/burn-tch/src/ops/tensor.rs
@@ -211,7 +211,7 @@ impl<E: TchElement> FloatTensorOps<Self> for LibTorch<E> {
         data: TchTensor,
         indices: TchTensor,
         values: TchTensor,
-        reduction: burn_backend::tensor::ScatterNdReduction,
+        reduction: burn_backend::tensor::IndexingUpdateOp,
     ) -> TchTensor {
         TchOps::scatter_nd(data, indices, values, reduction)
     }

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -1832,6 +1832,11 @@ where
     /// When `indices` contains duplicate entries, the result is non-deterministic on GPU
     /// backends (matching ONNX ScatterND semantics). For deterministic accumulation with
     /// duplicates, use [`scatter_nd_add`](Self::scatter_nd_add) on CPU backends.
+    ///
+    /// # Warning
+    ///
+    /// Not all backends have runtime bound checks for the indices, so make sure they are valid.
+    /// Otherwise, out of bounds indices could lead to unexpected results instead of panicking.
     pub fn scatter_nd<const M: usize, const DV: usize>(
         self,
         indices: Tensor<B, M, Int>,
@@ -1853,6 +1858,11 @@ where
     /// Multi-dimensional scatter with additive reduction.
     ///
     /// With duplicate indices, results are non-deterministic on GPU backends.
+    ///
+    /// # Warning
+    ///
+    /// Not all backends have runtime bound checks for the indices, so make sure they are valid.
+    /// Otherwise, out of bounds indices could lead to unexpected results instead of panicking.
     pub fn scatter_nd_add<const M: usize, const DV: usize>(
         self,
         indices: Tensor<B, M, Int>,
@@ -1872,6 +1882,13 @@ where
     }
 
     /// Multi-dimensional scatter with multiplicative reduction.
+    ///
+    /// With duplicate indices, results are non-deterministic on GPU backends.
+    ///
+    /// # Warning
+    ///
+    /// Not all backends have runtime bound checks for the indices, so make sure they are valid.
+    /// Otherwise, out of bounds indices could lead to unexpected results instead of panicking.
     pub fn scatter_nd_mul<const M: usize, const DV: usize>(
         self,
         indices: Tensor<B, M, Int>,
@@ -1891,6 +1908,13 @@ where
     }
 
     /// Multi-dimensional scatter with minimum reduction.
+    ///
+    /// With duplicate indices, results are non-deterministic on GPU backends.
+    ///
+    /// # Warning
+    ///
+    /// Not all backends have runtime bound checks for the indices, so make sure they are valid.
+    /// Otherwise, out of bounds indices could lead to unexpected results instead of panicking.
     pub fn scatter_nd_min<const M: usize, const DV: usize>(
         self,
         indices: Tensor<B, M, Int>,
@@ -1910,6 +1934,13 @@ where
     }
 
     /// Multi-dimensional scatter with maximum reduction.
+    ///
+    /// With duplicate indices, results are non-deterministic on GPU backends.
+    ///
+    /// # Warning
+    ///
+    /// Not all backends have runtime bound checks for the indices, so make sure they are valid.
+    /// Otherwise, out of bounds indices could lead to unexpected results instead of panicking.
     pub fn scatter_nd_max<const M: usize, const DV: usize>(
         self,
         indices: Tensor<B, M, Int>,
@@ -1934,6 +1965,11 @@ where
     /// `indices` is an M-dimensional integer tensor whose last dimension (K) indexes into the
     /// first K dimensions of `self`. The output has shape
     /// `[indices.shape[0..M-1]..., self.shape[K..D]...]`.
+    ///
+    /// # Warning
+    ///
+    /// Not all backends have runtime bound checks for the indices, so make sure they are valid.
+    /// Otherwise, out of bounds indices could lead to unexpected results instead of panicking.
     pub fn gather_nd<const M: usize, const DV: usize>(
         self,
         indices: Tensor<B, M, Int>,

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -1974,10 +1974,7 @@ where
         self,
         indices: Tensor<B, M, Int>,
     ) -> Tensor<B, DV, K> {
-        check!(TensorCheck::gather_nd::<D, M, DV>(
-            &self.shape(),
-            &indices.shape()
-        ));
+        check!(TensorCheck::gather_nd::<D, M, DV>(&indices.shape()));
         Tensor::new(K::gather_nd(self.primitive, indices.primitive))
     }
 

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -22,7 +22,7 @@ use crate::{
     backend::Backend, check,
 };
 use crate::{DType, Element};
-use crate::{IndexingUpdateOp, ScatterNdReduction, TensorCreationOptions};
+use crate::{IndexingUpdateOp, TensorCreationOptions};
 use crate::{cast::ToElement, check::TensorCheck};
 use serde::{Serialize, Serializer};
 
@@ -1851,7 +1851,7 @@ where
             self.primitive,
             indices.primitive,
             values.primitive,
-            ScatterNdReduction::Assign,
+            IndexingUpdateOp::Assign,
         ))
     }
 
@@ -1877,7 +1877,7 @@ where
             self.primitive,
             indices.primitive,
             values.primitive,
-            ScatterNdReduction::Add,
+            IndexingUpdateOp::Add,
         ))
     }
 
@@ -1903,7 +1903,7 @@ where
             self.primitive,
             indices.primitive,
             values.primitive,
-            ScatterNdReduction::Mul,
+            IndexingUpdateOp::Mul,
         ))
     }
 
@@ -1929,7 +1929,7 @@ where
             self.primitive,
             indices.primitive,
             values.primitive,
-            ScatterNdReduction::Min,
+            IndexingUpdateOp::Min,
         ))
     }
 
@@ -1955,7 +1955,7 @@ where
             self.primitive,
             indices.primitive,
             values.primitive,
-            ScatterNdReduction::Max,
+            IndexingUpdateOp::Max,
         ))
     }
 

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -22,7 +22,7 @@ use crate::{
     backend::Backend, check,
 };
 use crate::{DType, Element};
-use crate::{IndexingUpdateOp, TensorCreationOptions};
+use crate::{IndexingUpdateOp, ScatterNdReduction, TensorCreationOptions};
 use crate::{cast::ToElement, check::TensorCheck};
 use serde::{Serialize, Serializer};
 
@@ -1819,6 +1819,122 @@ where
             values.primitive,
             update,
         ))
+    }
+
+    /// Multi-dimensional scatter: update `self` at locations given by `indices` using assignment.
+    ///
+    /// `indices` is an M-dimensional integer tensor whose last dimension (K) indexes into the
+    /// first K dimensions of `self`. The `values` tensor has shape
+    /// `[indices.shape[0..M-1]..., self.shape[K..D]...]`.
+    pub fn scatter_nd<const M: usize, const DV: usize>(
+        self,
+        indices: Tensor<B, M, Int>,
+        values: Tensor<B, DV, K>,
+    ) -> Self {
+        check!(TensorCheck::scatter_nd::<D, M, DV>(
+            &self.shape(),
+            &indices.shape(),
+            &values.shape()
+        ));
+        Self::new(K::scatter_nd(
+            self.primitive,
+            indices.primitive,
+            values.primitive,
+            ScatterNdReduction::Assign,
+        ))
+    }
+
+    /// Multi-dimensional scatter with additive reduction.
+    pub fn scatter_nd_add<const M: usize, const DV: usize>(
+        self,
+        indices: Tensor<B, M, Int>,
+        values: Tensor<B, DV, K>,
+    ) -> Self {
+        check!(TensorCheck::scatter_nd::<D, M, DV>(
+            &self.shape(),
+            &indices.shape(),
+            &values.shape()
+        ));
+        Self::new(K::scatter_nd(
+            self.primitive,
+            indices.primitive,
+            values.primitive,
+            ScatterNdReduction::Add,
+        ))
+    }
+
+    /// Multi-dimensional scatter with multiplicative reduction.
+    pub fn scatter_nd_mul<const M: usize, const DV: usize>(
+        self,
+        indices: Tensor<B, M, Int>,
+        values: Tensor<B, DV, K>,
+    ) -> Self {
+        check!(TensorCheck::scatter_nd::<D, M, DV>(
+            &self.shape(),
+            &indices.shape(),
+            &values.shape()
+        ));
+        Self::new(K::scatter_nd(
+            self.primitive,
+            indices.primitive,
+            values.primitive,
+            ScatterNdReduction::Mul,
+        ))
+    }
+
+    /// Multi-dimensional scatter with minimum reduction.
+    pub fn scatter_nd_min<const M: usize, const DV: usize>(
+        self,
+        indices: Tensor<B, M, Int>,
+        values: Tensor<B, DV, K>,
+    ) -> Self {
+        check!(TensorCheck::scatter_nd::<D, M, DV>(
+            &self.shape(),
+            &indices.shape(),
+            &values.shape()
+        ));
+        Self::new(K::scatter_nd(
+            self.primitive,
+            indices.primitive,
+            values.primitive,
+            ScatterNdReduction::Min,
+        ))
+    }
+
+    /// Multi-dimensional scatter with maximum reduction.
+    pub fn scatter_nd_max<const M: usize, const DV: usize>(
+        self,
+        indices: Tensor<B, M, Int>,
+        values: Tensor<B, DV, K>,
+    ) -> Self {
+        check!(TensorCheck::scatter_nd::<D, M, DV>(
+            &self.shape(),
+            &indices.shape(),
+            &values.shape()
+        ));
+        Self::new(K::scatter_nd(
+            self.primitive,
+            indices.primitive,
+            values.primitive,
+            ScatterNdReduction::Max,
+        ))
+    }
+
+    /// Multi-dimensional gather: collect slices from `self` at multi-index locations
+    /// specified by `indices`.
+    ///
+    /// `indices` is an M-dimensional integer tensor whose last dimension (K) indexes into the
+    /// first K dimensions of `self`. The output has shape
+    /// `[indices.shape[0..M-1]..., self.shape[K..D]...]`.
+    pub fn gather_nd<const M: usize, const DV: usize>(
+        self,
+        indices: Tensor<B, M, Int>,
+    ) -> Tensor<B, DV, K> {
+        check!(TensorCheck::gather_nd::<D, M, DV>(
+            &self.shape(),
+            &indices.shape()
+        ));
+        Tensor::new(K::gather_nd(self.primitive, indices.primitive))
     }
 
     /// Converts the data of the current tensor.

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -1798,6 +1798,9 @@ where
     /// # Warning
     /// Not all backends have runtime bound checks for the indices, so make sure the they are valid.
     /// Otherwise, out of bounds indices could lead to unexpected results instead of panicking.
+    ///
+    /// # Panics
+    /// If the `update` is not `IndexingUpdateOp::Add`. Other operations are currently not implemented.
     pub fn scatter(
         self,
         dim: usize,
@@ -1821,11 +1824,16 @@ where
         ))
     }
 
-    /// Multi-dimensional scatter: update `self` at locations given by `indices` using assignment.
+    /// Multi-dimensional scatter: update `self` at locations given by `indices` using the specified `update` operation.
     ///
     /// The size of `indices`'s last axis (call it `K`) indexes the leading `K` dims of `self`;
     /// the batch shape `indices.shape[0..M-1]` is preserved. `values` has shape
     /// `indices.shape[0..M-1] ++ self.shape[K..D]`. Constraints: `K <= D` and `M >= 1`.
+    ///
+    /// # Arguments
+    /// * `indices` - The indices of the elements to scatter.
+    /// * `values` - The values to scatter into the tensor.
+    /// * `update` - The operation used to update the existing values at the indexed positions (e.g., add).
     ///
     /// # Note
     ///
@@ -1841,6 +1849,7 @@ where
         self,
         indices: Tensor<B, M, Int>,
         values: Tensor<B, DV, K>,
+        update: IndexingUpdateOp,
     ) -> Self {
         check!(TensorCheck::scatter_nd::<D, M, DV>(
             &self.shape(),
@@ -1851,111 +1860,7 @@ where
             self.primitive,
             indices.primitive,
             values.primitive,
-            IndexingUpdateOp::Assign,
-        ))
-    }
-
-    /// Multi-dimensional scatter with additive reduction.
-    ///
-    /// With duplicate indices, results are non-deterministic on GPU backends.
-    ///
-    /// # Warning
-    ///
-    /// Not all backends have runtime bound checks for the indices, so make sure they are valid.
-    /// Otherwise, out of bounds indices could lead to unexpected results instead of panicking.
-    pub fn scatter_nd_add<const M: usize, const DV: usize>(
-        self,
-        indices: Tensor<B, M, Int>,
-        values: Tensor<B, DV, K>,
-    ) -> Self {
-        check!(TensorCheck::scatter_nd::<D, M, DV>(
-            &self.shape(),
-            &indices.shape(),
-            &values.shape()
-        ));
-        Self::new(K::scatter_nd(
-            self.primitive,
-            indices.primitive,
-            values.primitive,
-            IndexingUpdateOp::Add,
-        ))
-    }
-
-    /// Multi-dimensional scatter with multiplicative reduction.
-    ///
-    /// With duplicate indices, results are non-deterministic on GPU backends.
-    ///
-    /// # Warning
-    ///
-    /// Not all backends have runtime bound checks for the indices, so make sure they are valid.
-    /// Otherwise, out of bounds indices could lead to unexpected results instead of panicking.
-    pub fn scatter_nd_mul<const M: usize, const DV: usize>(
-        self,
-        indices: Tensor<B, M, Int>,
-        values: Tensor<B, DV, K>,
-    ) -> Self {
-        check!(TensorCheck::scatter_nd::<D, M, DV>(
-            &self.shape(),
-            &indices.shape(),
-            &values.shape()
-        ));
-        Self::new(K::scatter_nd(
-            self.primitive,
-            indices.primitive,
-            values.primitive,
-            IndexingUpdateOp::Mul,
-        ))
-    }
-
-    /// Multi-dimensional scatter with minimum reduction.
-    ///
-    /// With duplicate indices, results are non-deterministic on GPU backends.
-    ///
-    /// # Warning
-    ///
-    /// Not all backends have runtime bound checks for the indices, so make sure they are valid.
-    /// Otherwise, out of bounds indices could lead to unexpected results instead of panicking.
-    pub fn scatter_nd_min<const M: usize, const DV: usize>(
-        self,
-        indices: Tensor<B, M, Int>,
-        values: Tensor<B, DV, K>,
-    ) -> Self {
-        check!(TensorCheck::scatter_nd::<D, M, DV>(
-            &self.shape(),
-            &indices.shape(),
-            &values.shape()
-        ));
-        Self::new(K::scatter_nd(
-            self.primitive,
-            indices.primitive,
-            values.primitive,
-            IndexingUpdateOp::Min,
-        ))
-    }
-
-    /// Multi-dimensional scatter with maximum reduction.
-    ///
-    /// With duplicate indices, results are non-deterministic on GPU backends.
-    ///
-    /// # Warning
-    ///
-    /// Not all backends have runtime bound checks for the indices, so make sure they are valid.
-    /// Otherwise, out of bounds indices could lead to unexpected results instead of panicking.
-    pub fn scatter_nd_max<const M: usize, const DV: usize>(
-        self,
-        indices: Tensor<B, M, Int>,
-        values: Tensor<B, DV, K>,
-    ) -> Self {
-        check!(TensorCheck::scatter_nd::<D, M, DV>(
-            &self.shape(),
-            &indices.shape(),
-            &values.shape()
-        ));
-        Self::new(K::scatter_nd(
-            self.primitive,
-            indices.primitive,
-            values.primitive,
-            IndexingUpdateOp::Max,
+            update,
         ))
     }
 

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -1826,6 +1826,12 @@ where
     /// `indices` is an M-dimensional integer tensor whose last dimension (K) indexes into the
     /// first K dimensions of `self`. The `values` tensor has shape
     /// `[indices.shape[0..M-1]..., self.shape[K..D]...]`.
+    ///
+    /// # Note
+    ///
+    /// When `indices` contains duplicate entries, the result is non-deterministic on GPU
+    /// backends (matching ONNX ScatterND semantics). For deterministic accumulation with
+    /// duplicates, use [`scatter_nd_add`](Self::scatter_nd_add) on CPU backends.
     pub fn scatter_nd<const M: usize, const DV: usize>(
         self,
         indices: Tensor<B, M, Int>,
@@ -1845,6 +1851,8 @@ where
     }
 
     /// Multi-dimensional scatter with additive reduction.
+    ///
+    /// With duplicate indices, results are non-deterministic on GPU backends.
     pub fn scatter_nd_add<const M: usize, const DV: usize>(
         self,
         indices: Tensor<B, M, Int>,

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -1823,15 +1823,15 @@ where
 
     /// Multi-dimensional scatter: update `self` at locations given by `indices` using assignment.
     ///
-    /// `indices` is an M-dimensional integer tensor whose last dimension (K) indexes into the
-    /// first K dimensions of `self`. The `values` tensor has shape
-    /// `[indices.shape[0..M-1]..., self.shape[K..D]...]`.
+    /// The size of `indices`'s last axis (call it `K`) indexes the leading `K` dims of `self`;
+    /// the batch shape `indices.shape[0..M-1]` is preserved. `values` has shape
+    /// `indices.shape[0..M-1] ++ self.shape[K..D]`. Constraints: `K <= D` and `M >= 1`.
     ///
     /// # Note
     ///
     /// When `indices` contains duplicate entries, the result is non-deterministic on GPU
-    /// backends (matching ONNX ScatterND semantics). For deterministic accumulation with
-    /// duplicates, use [`scatter_nd_add`](Self::scatter_nd_add) on CPU backends.
+    /// backends (matching ONNX ScatterND semantics). CPU backends are deterministic regardless
+    /// of reduction. For deterministic accumulation with duplicates, run on a CPU backend.
     ///
     /// # Warning
     ///
@@ -1962,9 +1962,9 @@ where
     /// Multi-dimensional gather: collect slices from `self` at multi-index locations
     /// specified by `indices`.
     ///
-    /// `indices` is an M-dimensional integer tensor whose last dimension (K) indexes into the
-    /// first K dimensions of `self`. The output has shape
-    /// `[indices.shape[0..M-1]..., self.shape[K..D]...]`.
+    /// The size of `indices`'s last axis (call it `K`) indexes the leading `K` dims of `self`;
+    /// the batch shape `indices.shape[0..M-1]` is preserved. The output has shape
+    /// `indices.shape[0..M-1] ++ self.shape[K..D]`. Constraints: `K <= D` and `M >= 1`.
     ///
     /// # Warning
     ///

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -993,7 +993,6 @@ impl TensorCheck {
     }
 
     pub(crate) fn gather_nd<const D: usize, const M: usize, const DV: usize>(
-        data_shape: &Shape,
         indices_shape: &Shape,
     ) -> Self {
         let ops = "GatherNd";
@@ -1026,9 +1025,6 @@ impl TensorCheck {
                 )),
             );
         }
-
-        // Suppress unused warning
-        let _ = data_shape;
 
         check
     }

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -925,6 +925,102 @@ impl TensorCheck {
         check
     }
 
+    pub(crate) fn scatter_nd<const D: usize, const M: usize, const DV: usize>(
+        data_shape: &Shape,
+        indices_shape: &Shape,
+        values_shape: &Shape,
+    ) -> Self {
+        let ops = "ScatterNd";
+        let mut check = Self::Ok;
+
+        let k = indices_shape.dims[M - 1];
+
+        if k > D {
+            check = check.register(
+                ops,
+                TensorError::new(format!(
+                    "Last dimension of indices (K={k}) must be <= data rank (D={D})"
+                )),
+            );
+        }
+
+        let expected_dv = M - 1 + D - k;
+        if DV != expected_dv {
+            check = check.register(
+                ops,
+                TensorError::new(format!(
+                    "Values rank DV={DV} does not match expected M-1+D-K = {expected_dv}"
+                )),
+            );
+        }
+
+        // Batch dims: first M-1 dims of values must equal first M-1 dims of indices
+        for i in 0..(M - 1) {
+            if values_shape.dims[i] != indices_shape.dims[i] {
+                check = check.register(
+                    ops,
+                    TensorError::new(format!(
+                        "Batch dimension {i} mismatch: values={} vs indices={}",
+                        values_shape.dims[i], indices_shape.dims[i]
+                    )),
+                );
+            }
+        }
+
+        // Slice dims: last D-K dims of values must equal last D-K dims of data
+        for i in 0..(D - k) {
+            let val_idx = M - 1 + i;
+            let data_idx = k + i;
+            if val_idx < DV && data_idx < D {
+                if values_shape.dims[val_idx] != data_shape.dims[data_idx] {
+                    check = check.register(
+                        ops,
+                        TensorError::new(format!(
+                            "Slice dimension mismatch at values[{val_idx}]={} vs data[{data_idx}]={}",
+                            values_shape.dims[val_idx], data_shape.dims[data_idx]
+                        )),
+                    );
+                }
+            }
+        }
+
+        check
+    }
+
+    pub(crate) fn gather_nd<const D: usize, const M: usize, const DV: usize>(
+        data_shape: &Shape,
+        indices_shape: &Shape,
+    ) -> Self {
+        let ops = "GatherNd";
+        let mut check = Self::Ok;
+
+        let k = indices_shape.dims[M - 1];
+
+        if k > D {
+            check = check.register(
+                ops,
+                TensorError::new(format!(
+                    "Last dimension of indices (K={k}) must be <= data rank (D={D})"
+                )),
+            );
+        }
+
+        let expected_dv = M - 1 + D - k;
+        if DV != expected_dv {
+            check = check.register(
+                ops,
+                TensorError::new(format!(
+                    "Output rank DV={DV} does not match expected M-1+D-K = {expected_dv}"
+                )),
+            );
+        }
+
+        // Suppress unused warning
+        let _ = data_shape;
+
+        check
+    }
+
     pub(crate) fn select<const D: usize>(dim: usize) -> Self {
         Self::check_select_basic::<D>(Self::Ok, "select", dim)
     }

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -971,16 +971,14 @@ impl TensorCheck {
         for i in 0..(D - k) {
             let val_idx = M - 1 + i;
             let data_idx = k + i;
-            if val_idx < DV && data_idx < D {
-                if values_shape[val_idx] != data_shape[data_idx] {
-                    check = check.register(
-                        ops,
-                        TensorError::new(format!(
-                            "Slice dimension mismatch at values[{val_idx}]={} vs data[{data_idx}]={}",
-                            values_shape[val_idx], data_shape[data_idx]
-                        )),
-                    );
-                }
+            if val_idx < DV && data_idx < D && values_shape[val_idx] != data_shape[data_idx] {
+                check = check.register(
+                    ops,
+                    TensorError::new(format!(
+                        "Slice dimension mismatch at values[{val_idx}]={} vs data[{data_idx}]={}",
+                        values_shape[val_idx], data_shape[data_idx]
+                    )),
+                );
             }
         }
 

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -933,6 +933,13 @@ impl TensorCheck {
         let ops = "ScatterNd";
         let mut check = Self::Ok;
 
+        if indices_shape.num_elements() == 0 {
+            return check.register(
+                ops,
+                TensorError::new("Indices tensor must not be empty".to_string()),
+            );
+        }
+
         let k = indices_shape[M - 1];
 
         if k > D {
@@ -991,6 +998,13 @@ impl TensorCheck {
     ) -> Self {
         let ops = "GatherNd";
         let mut check = Self::Ok;
+
+        if indices_shape.num_elements() == 0 {
+            return check.register(
+                ops,
+                TensorError::new("Indices tensor must not be empty".to_string()),
+            );
+        }
 
         let k = indices_shape[M - 1];
 

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -933,6 +933,13 @@ impl TensorCheck {
         let ops = "ScatterNd";
         let mut check = Self::Ok;
 
+        if M == 0 {
+            return check.register(
+                ops,
+                TensorError::new("Indices tensor must have rank >= 1".to_string()),
+            );
+        }
+
         if indices_shape.num_elements() == 0 {
             return check.register(
                 ops,
@@ -997,6 +1004,13 @@ impl TensorCheck {
     ) -> Self {
         let ops = "GatherNd";
         let mut check = Self::Ok;
+
+        if M == 0 {
+            return check.register(
+                ops,
+                TensorError::new("Indices tensor must have rank >= 1".to_string()),
+            );
+        }
 
         if indices_shape.num_elements() == 0 {
             return check.register(

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -933,7 +933,7 @@ impl TensorCheck {
         let ops = "ScatterNd";
         let mut check = Self::Ok;
 
-        let k = indices_shape.dims[M - 1];
+        let k = indices_shape[M - 1];
 
         if k > D {
             check = check.register(
@@ -956,12 +956,12 @@ impl TensorCheck {
 
         // Batch dims: first M-1 dims of values must equal first M-1 dims of indices
         for i in 0..(M - 1) {
-            if values_shape.dims[i] != indices_shape.dims[i] {
+            if values_shape[i] != indices_shape[i] {
                 check = check.register(
                     ops,
                     TensorError::new(format!(
                         "Batch dimension {i} mismatch: values={} vs indices={}",
-                        values_shape.dims[i], indices_shape.dims[i]
+                        values_shape[i], indices_shape[i]
                     )),
                 );
             }
@@ -972,12 +972,12 @@ impl TensorCheck {
             let val_idx = M - 1 + i;
             let data_idx = k + i;
             if val_idx < DV && data_idx < D {
-                if values_shape.dims[val_idx] != data_shape.dims[data_idx] {
+                if values_shape[val_idx] != data_shape[data_idx] {
                     check = check.register(
                         ops,
                         TensorError::new(format!(
                             "Slice dimension mismatch at values[{val_idx}]={} vs data[{data_idx}]={}",
-                            values_shape.dims[val_idx], data_shape.dims[data_idx]
+                            values_shape[val_idx], data_shape[data_idx]
                         )),
                     );
                 }
@@ -994,7 +994,7 @@ impl TensorCheck {
         let ops = "GatherNd";
         let mut check = Self::Ok;
 
-        let k = indices_shape.dims[M - 1];
+        let k = indices_shape[M - 1];
 
         if k > D {
             check = check.register(

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -936,7 +936,7 @@ impl TensorCheck {
         let k = indices_shape[M - 1];
 
         if k > D {
-            check = check.register(
+            return check.register(
                 ops,
                 TensorError::new(format!(
                     "Last dimension of indices (K={k}) must be <= data rank (D={D})"
@@ -995,7 +995,7 @@ impl TensorCheck {
         let k = indices_shape[M - 1];
 
         if k > D {
-            check = check.register(
+            return check.register(
                 ops,
                 TensorError::new(format!(
                     "Last dimension of indices (K={k}) must be <= data rank (D={D})"

--- a/crates/burn-tensor/src/tensor/api/mod.rs
+++ b/crates/burn-tensor/src/tensor/api/mod.rs
@@ -27,4 +27,3 @@ pub use options::*;
 pub use transaction::*;
 
 pub use burn_backend::tensor::IndexingUpdateOp;
-pub use burn_backend::tensor::ScatterNdReduction;

--- a/crates/burn-tensor/src/tensor/api/mod.rs
+++ b/crates/burn-tensor/src/tensor/api/mod.rs
@@ -27,3 +27,4 @@ pub use options::*;
 pub use transaction::*;
 
 pub use burn_backend::tensor::IndexingUpdateOp;
+pub use burn_backend::tensor::ScatterNdReduction;


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Resolves #4469  and partially resolves #4433 

Combined for convenience since one is needed for the gradient of the other, and vice versa

### Changes

- Add implementations for `scatter_nd` (Assign, Add, Mul, Min, Max) and `gather_nd` forward pass
  - Note that candle backend doesn't have native implementation for `scatter_nd` Mul, Min, Max. This implementation will raise an error if any of these are used
- Autodiff for `gather_nd` and `scatter_nd` (Assign, Add). Deferring Mul, Min, Max autodiff to another PR as that would be very meaty, and this PR is big as is.

### Testing

Unit tests for core functionality
