### PR TITLE
Add dtype-aware numerical precision info (finfo equivalent)

### DIFF
--- a/crates/burn-backend/src/backend/ops/modules/attention.rs
+++ b/crates/burn-backend/src/backend/ops/modules/attention.rs
@@ -70,15 +70,15 @@ pub fn attention_fallback<B: Backend>(
     // When all positions in a row are masked (-inf), naive softmax has two NaN paths:
     //   (1) max is -inf, so the shift -inf - (-inf) = NaN;
     //   (2) after fixing (1), all exp values are 0, so sum is 0 and 0/0 = NaN.
-    // Clamping max to finfo.min (most negative finite value) and sum to finfo.tiny (smallest
-    // positive normal) avoids both, yielding 0 for fully-masked rows.
+    // Clamping max to finfo.min (most negative finite value) and sum to finfo.min_positive
+    // (smallest positive normal) avoids both, yielding 0 for fully-masked rows.
     let finfo = attention_scores.dtype().finfo().expect("float tensor");
     let max_per_dim = B::float_max_dim(attention_scores.clone(), 3);
     let max_per_dim = B::float_clamp_min(max_per_dim, finfo.min.into());
     let minus_max = B::float_sub(attention_scores, max_per_dim);
     let numerator = B::float_exp(minus_max);
     let sum_exp = B::float_sum_dim(numerator.clone(), 3);
-    let sum_exp = B::float_clamp_min(sum_exp, finfo.tiny.into());
+    let sum_exp = B::float_clamp_min(sum_exp, finfo.min_positive.into());
     let softmax = B::float_div(numerator, sum_exp);
 
     // Context: S · V

--- a/crates/burn-backend/src/element/base.rs
+++ b/crates/burn-backend/src/element/base.rs
@@ -95,44 +95,6 @@ pub trait ElementLimits {
     const MAX: Self;
 }
 
-/// Precision properties for floating-point element types.
-///
-/// Provides associated constants analogous to NumPy's `finfo` fields,
-/// usable in generic Rust code and CubeCL kernels.
-pub trait FloatElementPrecision: Element {
-    /// Machine epsilon: smallest value such that `1.0 + EPSILON != 1.0`.
-    const EPSILON: Self;
-    /// Smallest positive normal value (equivalent to `tiny` in NumPy/PyTorch).
-    const TINY: Self;
-}
-
-impl FloatElementPrecision for f64 {
-    const EPSILON: Self = f64::EPSILON;
-    const TINY: Self = f64::MIN_POSITIVE;
-}
-
-impl FloatElementPrecision for f32 {
-    const EPSILON: Self = f32::EPSILON;
-    const TINY: Self = f32::MIN_POSITIVE;
-}
-
-impl FloatElementPrecision for f16 {
-    const EPSILON: Self = f16::EPSILON;
-    const TINY: Self = f16::MIN_POSITIVE;
-}
-
-impl FloatElementPrecision for bf16 {
-    const EPSILON: Self = bf16::EPSILON;
-    const TINY: Self = bf16::MIN_POSITIVE;
-}
-
-#[cfg(feature = "cubecl")]
-impl FloatElementPrecision for flex32 {
-    // Flex32 computes at reduced precision; use f16 limits for safety.
-    const EPSILON: Self = flex32::from_f32(f16::EPSILON.to_f32_const());
-    const TINY: Self = flex32::from_f32(f16::MIN_POSITIVE.to_f32_const());
-}
-
 /// Macro to implement the element trait for a type.
 #[macro_export]
 macro_rules! make_element {

--- a/crates/burn-nn/src/loss/kldiv.rs
+++ b/crates/burn-nn/src/loss/kldiv.rs
@@ -94,7 +94,7 @@ impl KLDivLoss {
                     .dtype()
                     .finfo()
                     .unwrap_or(burn::tensor::FloatDType::F32.finfo())
-                    .tiny;
+                    .min_positive;
                 let log_target = targets.clone().clamp(epsilon, 1.0).log();
                 targets.mul(log_target.sub(predictions))
             }

--- a/crates/burn-optim/src/grad_clipping/base.rs
+++ b/crates/burn-optim/src/grad_clipping/base.rs
@@ -75,12 +75,12 @@ impl GradientClipping {
         threshold: f32,
     ) -> Tensor<B, D> {
         let norm = Self::l2_norm(grad.clone());
-        let tiny = grad
+        let min_positive = grad
             .dtype()
             .finfo()
             .unwrap_or(burn::tensor::FloatDType::F32.finfo())
-            .tiny;
-        let clip_coef = threshold / norm.add_scalar(tiny);
+            .min_positive;
+        let clip_coef = threshold / norm.add_scalar(min_positive);
         let clip_coef_clamped = clip_coef.clamp_max(1.0);
         grad.mul(clip_coef_clamped.unsqueeze())
     }

--- a/crates/burn-std/src/tensor/dtype.rs
+++ b/crates/burn-std/src/tensor/dtype.rs
@@ -129,7 +129,7 @@ impl DType {
     /// Returns float precision info if this is a float dtype, `None` otherwise.
     ///
     /// Analogous to `torch.finfo(dtype)` or `numpy.finfo(dtype)`.
-    pub const fn finfo(&self) -> Option<FloatDTypeInfo> {
+    pub const fn finfo(&self) -> Option<FloatInfo> {
         match self {
             DType::F64 => Some(FloatDType::F64.finfo()),
             DType::F32 => Some(FloatDType::F32.finfo()),
@@ -182,54 +182,54 @@ pub enum FloatDType {
 /// widened to `f64` so they can be inspected without knowing the concrete
 /// element type at compile time.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct FloatDTypeInfo {
-    /// Machine epsilon: smallest value such that `1.0 + eps != 1.0`.
-    pub eps: f64,
+pub struct FloatInfo {
+    /// Machine epsilon: smallest value such that `1.0 + epsilon != 1.0`.
+    pub epsilon: f64,
     /// Largest representable finite value.
     pub max: f64,
     /// Most negative representable finite value.
     pub min: f64,
-    /// Smallest positive normal value (called `tiny` in NumPy/PyTorch).
-    pub tiny: f64,
+    /// Smallest positive normal value.
+    pub min_positive: f64,
 }
 
 impl FloatDType {
     /// Returns numerical precision properties for this float dtype.
     ///
     /// Analogous to `torch.finfo(dtype)` or `numpy.finfo(dtype)`.
-    pub const fn finfo(self) -> FloatDTypeInfo {
+    pub const fn finfo(self) -> FloatInfo {
         match self {
-            FloatDType::F64 => FloatDTypeInfo {
-                eps: f64::EPSILON,
+            FloatDType::F64 => FloatInfo {
+                epsilon: f64::EPSILON,
                 max: f64::MAX,
                 min: f64::MIN,
-                tiny: f64::MIN_POSITIVE, // ~2.225e-308
+                min_positive: f64::MIN_POSITIVE, // ~2.225e-308
             },
-            FloatDType::F32 => FloatDTypeInfo {
-                eps: f32::EPSILON as f64,
+            FloatDType::F32 => FloatInfo {
+                epsilon: f32::EPSILON as f64,
                 max: f32::MAX as f64,
                 min: f32::MIN as f64,
-                tiny: f32::MIN_POSITIVE as f64, // ~1.175e-38
+                min_positive: f32::MIN_POSITIVE as f64, // ~1.175e-38
             },
             // Flex32 stores as f32 but computes at reduced (f16-like) precision.
             // Use f16 precision limits so stability code stays safe.
-            FloatDType::Flex32 => FloatDTypeInfo {
-                eps: f16::EPSILON.to_f64_const(),
+            FloatDType::Flex32 => FloatInfo {
+                epsilon: f16::EPSILON.to_f64_const(),
                 max: f16::MAX.to_f64_const(),
                 min: f16::MIN.to_f64_const(),
-                tiny: f16::MIN_POSITIVE.to_f64_const(), // ~6.104e-5
+                min_positive: f16::MIN_POSITIVE.to_f64_const(), // ~6.104e-5
             },
-            FloatDType::F16 => FloatDTypeInfo {
-                eps: f16::EPSILON.to_f64_const(),
+            FloatDType::F16 => FloatInfo {
+                epsilon: f16::EPSILON.to_f64_const(),
                 max: f16::MAX.to_f64_const(),
                 min: f16::MIN.to_f64_const(),
-                tiny: f16::MIN_POSITIVE.to_f64_const(), // ~6.104e-5
+                min_positive: f16::MIN_POSITIVE.to_f64_const(), // ~6.104e-5
             },
-            FloatDType::BF16 => FloatDTypeInfo {
-                eps: bf16::EPSILON.to_f64_const(),
+            FloatDType::BF16 => FloatInfo {
+                epsilon: bf16::EPSILON.to_f64_const(),
                 max: bf16::MAX.to_f64_const(),
                 min: bf16::MIN.to_f64_const(),
-                tiny: bf16::MIN_POSITIVE.to_f64_const(), // ~1.175e-38
+                min_positive: bf16::MIN_POSITIVE.to_f64_const(), // ~1.175e-38
             },
         }
     }
@@ -354,47 +354,47 @@ mod tests {
     #[test]
     fn finfo_f32() {
         let info = FloatDType::F32.finfo();
-        assert_eq!(info.eps, f32::EPSILON as f64);
+        assert_eq!(info.epsilon, f32::EPSILON as f64);
         assert_eq!(info.max, f32::MAX as f64);
         assert_eq!(info.min, f32::MIN as f64);
-        assert_eq!(info.tiny, f32::MIN_POSITIVE as f64);
+        assert_eq!(info.min_positive, f32::MIN_POSITIVE as f64);
     }
 
     #[test]
     fn finfo_f64() {
         let info = FloatDType::F64.finfo();
-        assert_eq!(info.eps, f64::EPSILON);
+        assert_eq!(info.epsilon, f64::EPSILON);
         assert_eq!(info.max, f64::MAX);
         assert_eq!(info.min, f64::MIN);
-        assert_eq!(info.tiny, f64::MIN_POSITIVE);
+        assert_eq!(info.min_positive, f64::MIN_POSITIVE);
     }
 
     #[test]
     fn finfo_f16() {
         let info = FloatDType::F16.finfo();
-        assert_eq!(info.eps, f16::EPSILON.to_f64_const());
-        assert!(info.eps > 0.0);
-        assert!(info.tiny > 0.0);
+        assert_eq!(info.epsilon, f16::EPSILON.to_f64_const());
+        assert!(info.epsilon > 0.0);
+        assert!(info.min_positive > 0.0);
         // f16 epsilon is much larger than f32
-        assert!(info.eps > FloatDType::F32.finfo().eps);
+        assert!(info.epsilon > FloatDType::F32.finfo().epsilon);
     }
 
     #[test]
     fn finfo_bf16() {
         let info = FloatDType::BF16.finfo();
-        assert_eq!(info.eps, bf16::EPSILON.to_f64_const());
-        assert!(info.eps > 0.0);
-        assert!(info.tiny > 0.0);
+        assert_eq!(info.epsilon, bf16::EPSILON.to_f64_const());
+        assert!(info.epsilon > 0.0);
+        assert!(info.min_positive > 0.0);
         // bf16 epsilon is larger than f32 (fewer mantissa bits)
-        assert!(info.eps > FloatDType::F32.finfo().eps);
+        assert!(info.epsilon > FloatDType::F32.finfo().epsilon);
     }
 
     #[test]
     fn finfo_flex32_uses_f16_limits() {
         let flex = FloatDType::Flex32.finfo();
         let f16_info = FloatDType::F16.finfo();
-        assert_eq!(flex.eps, f16_info.eps);
-        assert_eq!(flex.tiny, f16_info.tiny);
+        assert_eq!(flex.epsilon, f16_info.epsilon);
+        assert_eq!(flex.min_positive, f16_info.min_positive);
     }
 
     #[test]
@@ -423,11 +423,17 @@ mod tests {
             FloatDType::Flex32,
         ] {
             let info = dtype.finfo();
-            assert!(info.eps > 0.0, "{dtype:?}: eps must be positive");
-            assert!(info.tiny > 0.0, "{dtype:?}: tiny must be positive");
+            assert!(info.epsilon > 0.0, "{dtype:?}: epsilon must be positive");
+            assert!(
+                info.min_positive > 0.0,
+                "{dtype:?}: min_positive must be positive"
+            );
             assert!(info.max > 0.0, "{dtype:?}: max must be positive");
             assert!(info.min < 0.0, "{dtype:?}: min must be negative");
-            assert!(info.max > info.tiny, "{dtype:?}: max > tiny");
+            assert!(
+                info.max > info.min_positive,
+                "{dtype:?}: max > min_positive"
+            );
         }
     }
 }

--- a/crates/burn-tensor/src/tensor/linalg/cosine_similarity.rs
+++ b/crates/burn-tensor/src/tensor/linalg/cosine_similarity.rs
@@ -28,8 +28,12 @@ pub fn cosine_similarity<B: Backend, const D: usize>(
     eps: Option<B::FloatElem>,
 ) -> Tensor<B, D> {
     let eps = eps.unwrap_or_else(|| {
-        let tiny = x1.dtype().finfo().unwrap_or(FloatDType::F32.finfo()).tiny;
-        B::FloatElem::from_elem(tiny)
+        let min_positive = x1
+            .dtype()
+            .finfo()
+            .unwrap_or(FloatDType::F32.finfo())
+            .min_positive;
+        B::FloatElem::from_elem(min_positive)
     });
 
     // Convert negative dimension to positive


### PR DESCRIPTION
## Summary

Adds dtype-aware numerical precision info, equivalent to NumPy's `finfo` / PyTorch's `torch.finfo`, and replaces hardcoded constants that silently underflow to zero on f16/bf16.

Closes #4700
Closes #4367

## Changes

### New API

**Runtime query** (`burn-std`): `FloatDTypeInfo` struct and `finfo()` on both `FloatDType` and `DType`:

```rust
let info = DType::F16.finfo().unwrap();
// info.eps   - machine epsilon (smallest value where 1.0 + eps != 1.0)
// info.max   - largest representable finite value
// info.min   - most negative representable finite value
// info.tiny  - smallest positive normal value
```

**Compile-time generic** (`burn-backend`): `FloatElementPrecision` trait for generic Rust code and CubeCL kernels:

```rust
fn stabilize<E: FloatElementPrecision>(x: E) {
    // E::EPSILON, E::TINY available as associated constants
}
```

Implemented for: `f32`, `f64`, `f16`, `bf16`, `flex32`.

### Replaced hardcoded constants

These constants underflow to zero on f16 (`MIN_POSITIVE` ~6.1e-5), silently defeating the numerical stability they provide:

| File | Before | After | Purpose |
|------|--------|-------|---------|
| `attention.rs` | `SOFTMAX_MAX_FLOOR = -1e4` | `finfo.min` | Prevent `-inf - (-inf) = NaN` |
| `attention.rs` | `SOFTMAX_SUM_EPS = 1e-6` | `finfo.tiny` | Prevent `0 / 0 = NaN` |
| `kldiv.rs` | `epsilon = 1e-8` | `finfo.tiny` | Prevent `log(0)` |
| `cosine_similarity.rs` | `DEFAULT_EPSILON = 1e-8` | `finfo.tiny` | Prevent division by zero |
| `grad_clipping.rs` | `1e-6` | `finfo.tiny` | Prevent division by zero |

### Not changed (intentionally)

- **Config defaults** (norm modules `1e-5`, optimizer epsilon `1e-5`/`1e-8`): user-overridable, match PyTorch defaults
- **`DEFAULT_RTOL`/`DEFAULT_ATOL`**: match NumPy's `is_close` spec
- **Metric constants** (FID, PSNR, DISTS, Dice): run on CPU f64, not dtype-sensitive

## Test plan

- [x] 8 unit tests covering all float dtypes, `DType` delegation, non-float returns `None`, and cross-dtype invariants
- [x] `cargo check` passes for burn-std, burn-backend, burn-tensor, burn-nn, burn-optim
- [x] `cargo check --features cubecl` passes (flex32 impl)
- [x] All existing tests pass (grad_clipping, cosine_similarity, kldiv, burn-backend-tests)