### PR TITLE
Fix/fusion/write out aligned

### DIFF
--- a/crates/burn-cubecl-fusion/src/engine/codegen/io.rs
+++ b/crates/burn-cubecl-fusion/src/engine/codegen/io.rs
@@ -498,7 +498,12 @@ fn write_output_aligned<C: Scalar, N: Size>(
             #[unroll]
             for i in 0..config.width {
                 let idx = offset + i * stride;
-                output.tensor[idx] = Vector::cast_from(value[i % value.vector_size()]);
+                let val = if comptime![value.vector_size() == config.width] {
+                    Vector::cast_from(value[i])
+                } else {
+                    Vector::cast_from(value[i % value.vector_size()])
+                };
+                output.tensor[idx] = val;
             }
         }
         LayoutInfo::Unknown => {
@@ -521,7 +526,13 @@ fn write_output_aligned<C: Scalar, N: Size>(
                     None,
                 );
                 let output = outputs.tensors.index_mut(pos);
-                output.tensor[offset] = Vector::cast_from(value[i % value.vector_size()]);
+
+                let val = if comptime![value.vector_size() == config.width] {
+                    Vector::cast_from(value[i])
+                } else {
+                    Vector::cast_from(value[i % value.vector_size()])
+                };
+                output.tensor[offset] = val;
             }
         }
     }


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

#4675

### Changes

Fix fusion `write_output_aligned` when writing a scalar value to an output so it is correctly broadcasted.

Otherwise SPIR-V optimization would panic during post SSA passes:

```
thread 'Device-4-0' (160907) panicked at /home/laggui/.cargo/git/checkouts/cubecl-058c47895211d464/2c59137/crates/cubecl-opt/src/passes/composite.rs:131:25:
assertion `left == right` failed: Can't index into scalar
  left: 1
 right: 0
```

### Testing

Test passes with `cargo test-vulkan`