### PR TITLE
Fix flaky initializer_normal_init test

### DIFF
--- a/crates/burn-core/src/module/initializer.rs
+++ b/crates/burn-core/src/module/initializer.rs
@@ -342,7 +342,7 @@ mod tests {
 
         let (mean, std) = (0.0, 1.0);
         let normal: Tensor<TB, 1> = Initializer::Normal { mean, std }
-            .init([1000], &Default::default())
+            .init([10000], &Default::default())
             .into_value();
         let (var_act, mean_act) = normal.var_mean(0);
 


### PR DESCRIPTION
   ### Checklist

   - [x] Confirmed that `cargo run-checks` command has been executed.
   - [x] Made sure the book is up to date with changes in this PR.

   ### Related Issues/PRs

   Closes #4705

   ### Changes

   Bump the sample size in `initializer_normal_init` from 1,000 to 10,000.

   With only 1,000 samples the ±0.1 tolerance is about 2.2σ, so it flakes roughly 1 in 37 runs. Bumping to 10,000 pushes it to ~7σ, which kills the flakiness without weakening the test.

   ### Testing

   Ran the test 30 times.

   ```bash
   for i in $(seq 1 30); do cargo test -p burn-core --lib -- module::initializer::tests::initializer_normal_init; done


