### PR TITLE
Fix burn-flex bool binary ops to broadcast operands

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/bool/ops/comparison.rs
+++ b/crates/burn-backend-tests/tests/tensor/bool/ops/comparison.rs
@@ -34,6 +34,54 @@ fn should_support_bool_not_equal() {
 }
 
 #[test]
+fn should_support_bool_equal_broadcast() {
+    // [2, 2, 2] equal [1, 2, 2] broadcasts along the leading dim.
+    let device = Default::default();
+    let tensor_1 = TestTensorBool::<3>::from_data(
+        TensorData::from([
+            [[true, false], [false, true]],
+            [[true, true], [false, false]],
+        ]),
+        &device,
+    );
+    let tensor_2 = TestTensorBool::<2>::from_data(
+        TensorData::from([[true, false], [false, true]]),
+        &device,
+    );
+
+    let actual = tensor_1.equal(tensor_2.unsqueeze::<3>()).into_data();
+    let expected = TensorData::from([
+        [[true, true], [true, true]],
+        [[true, false], [true, false]],
+    ]);
+    expected.assert_eq(&actual, false);
+}
+
+#[test]
+fn should_support_bool_not_equal_broadcast() {
+    // [2, 2, 2] not_equal [1, 2, 2] broadcasts along the leading dim.
+    let device = Default::default();
+    let tensor_1 = TestTensorBool::<3>::from_data(
+        TensorData::from([
+            [[true, false], [false, true]],
+            [[true, true], [false, false]],
+        ]),
+        &device,
+    );
+    let tensor_2 = TestTensorBool::<2>::from_data(
+        TensorData::from([[true, false], [false, true]]),
+        &device,
+    );
+
+    let actual = tensor_1.not_equal(tensor_2.unsqueeze::<3>()).into_data();
+    let expected = TensorData::from([
+        [[false, false], [false, false]],
+        [[false, true], [false, true]],
+    ]);
+    expected.assert_eq(&actual, false);
+}
+
+#[test]
 fn should_support_bool_not() {
     let data_1 = TensorData::from([[false, true, true], [true, true, false]]);
     let tensor_1 = TestTensorBool::<2>::from_data(data_1, &Default::default());

--- a/crates/burn-backend-tests/tests/tensor/bool/ops/comparison.rs
+++ b/crates/burn-backend-tests/tests/tensor/bool/ops/comparison.rs
@@ -44,16 +44,11 @@ fn should_support_bool_equal_broadcast() {
         ]),
         &device,
     );
-    let tensor_2 = TestTensorBool::<2>::from_data(
-        TensorData::from([[true, false], [false, true]]),
-        &device,
-    );
+    let tensor_2 =
+        TestTensorBool::<2>::from_data(TensorData::from([[true, false], [false, true]]), &device);
 
     let actual = tensor_1.equal(tensor_2.unsqueeze::<3>()).into_data();
-    let expected = TensorData::from([
-        [[true, true], [true, true]],
-        [[true, false], [true, false]],
-    ]);
+    let expected = TensorData::from([[[true, true], [true, true]], [[true, false], [true, false]]]);
     expected.assert_eq(&actual, false);
 }
 
@@ -68,10 +63,8 @@ fn should_support_bool_not_equal_broadcast() {
         ]),
         &device,
     );
-    let tensor_2 = TestTensorBool::<2>::from_data(
-        TensorData::from([[true, false], [false, true]]),
-        &device,
-    );
+    let tensor_2 =
+        TestTensorBool::<2>::from_data(TensorData::from([[true, false], [false, true]]), &device);
 
     let actual = tensor_1.not_equal(tensor_2.unsqueeze::<3>()).into_data();
     let expected = TensorData::from([

--- a/crates/burn-backend-tests/tests/tensor/bool/ops/logical.rs
+++ b/crates/burn-backend-tests/tests/tensor/bool/ops/logical.rs
@@ -177,10 +177,8 @@ fn test_bool_xor_broadcast_rank_mismatch() {
         ]),
         &device,
     );
-    let rhs = TestTensorBool::<2>::from_data(
-        TensorData::from([[true, false], [false, true]]),
-        &device,
-    );
+    let rhs =
+        TestTensorBool::<2>::from_data(TensorData::from([[true, false], [false, true]]), &device);
 
     let actual = lhs.bool_xor(rhs.unsqueeze::<3>()).into_data();
     let expected = TensorData::from([

--- a/crates/burn-backend-tests/tests/tensor/bool/ops/logical.rs
+++ b/crates/burn-backend-tests/tests/tensor/bool/ops/logical.rs
@@ -187,3 +187,73 @@ fn test_bool_xor_broadcast_rank_mismatch() {
     ]);
     expected.assert_eq(&actual, false);
 }
+
+#[test]
+fn test_bool_and_broadcast_row_lhs() {
+    // [1, 3] AND [2, 3] broadcasts lhs along dim 0 only. Distinct from
+    // the scalar_lhs pattern, which broadcasts along both dims.
+    let device = Default::default();
+    let lhs =
+        TestTensorBool::<2>::from_data(TensorData::from([[true, false, true]]), &device);
+    let rhs = TestTensorBool::<2>::from_data(
+        TensorData::from([[true, true, false], [false, true, true]]),
+        &device,
+    );
+
+    let actual = lhs.bool_and(rhs).into_data();
+    let expected = TensorData::from([[true, false, false], [false, false, true]]);
+    expected.assert_eq(&actual, false);
+}
+
+#[test]
+fn test_bool_and_broadcast_mutual() {
+    // [3, 1] AND [1, 3] - both operands need expansion along different
+    // axes, producing [3, 3]. Exercises the "neither operand matches the
+    // output shape" path through broadcast_binary.
+    let device = Default::default();
+    let lhs = TestTensorBool::<2>::from_data(
+        TensorData::from([[true], [false], [true]]),
+        &device,
+    );
+    let rhs =
+        TestTensorBool::<2>::from_data(TensorData::from([[true, false, true]]), &device);
+
+    let actual = lhs.bool_and(rhs).into_data();
+    let expected = TensorData::from([
+        [true, false, true],
+        [false, false, false],
+        [true, false, true],
+    ]);
+    expected.assert_eq(&actual, false);
+}
+
+#[test]
+fn test_bool_and_broadcast_4d() {
+    // 4D broadcast: [2, 1, 2, 1] AND [1, 2, 1, 2] -> [2, 2, 2, 2].
+    // Confirms the fix is rank-agnostic. Pre-fix, both operands had 4
+    // storage elements so the inplace helper ran without panicking, but
+    // the output silently kept lhs's [2, 1, 2, 1] shape - shape assert
+    // catches that.
+    let device = Default::default();
+    let lhs = TestTensorBool::<4>::from_data(
+        TensorData::from([[[[true], [false]]], [[[false], [true]]]]),
+        &device,
+    );
+    let rhs = TestTensorBool::<4>::from_data(
+        TensorData::from([[[[true, false]], [[false, true]]]]),
+        &device,
+    );
+
+    let actual = lhs.bool_and(rhs).into_data();
+    let expected = TensorData::from([
+        [
+            [[true, false], [false, false]],
+            [[false, true], [false, false]],
+        ],
+        [
+            [[false, false], [true, false]],
+            [[false, false], [false, true]],
+        ],
+    ]);
+    expected.assert_eq(&actual, false);
+}

--- a/crates/burn-backend-tests/tests/tensor/bool/ops/logical.rs
+++ b/crates/burn-backend-tests/tests/tensor/bool/ops/logical.rs
@@ -47,3 +47,145 @@ fn test_bool_and_vec() {
     let data_expected = TensorData::from([false; 256]);
     data_expected.assert_eq(&data_actual, false);
 }
+
+#[test]
+fn test_bool_and_broadcast_scalar_lhs() {
+    // [1, 1] AND [2, 3] broadcasts to [2, 3].
+    let device = Default::default();
+    let tensor1 = TestTensorBool::<2>::from_data(TensorData::from([[true]]), &device);
+    let tensor2 = TestTensorBool::<2>::from_data(
+        TensorData::from([[true, false, true], [false, true, false]]),
+        &device,
+    );
+
+    let actual = tensor1.bool_and(tensor2).into_data();
+    let expected = TensorData::from([[true, false, true], [false, true, false]]);
+    expected.assert_eq(&actual, false);
+}
+
+#[test]
+fn test_bool_or_broadcast_scalar_lhs() {
+    // [1, 1]=false OR [2, 3] broadcasts to [2, 3] and equals rhs.
+    let device = Default::default();
+    let tensor1 = TestTensorBool::<2>::from_data(TensorData::from([[false]]), &device);
+    let tensor2 = TestTensorBool::<2>::from_data(
+        TensorData::from([[true, false, true], [false, true, false]]),
+        &device,
+    );
+
+    let actual = tensor1.bool_or(tensor2).into_data();
+    let expected = TensorData::from([[true, false, true], [false, true, false]]);
+    expected.assert_eq(&actual, false);
+}
+
+#[test]
+fn test_bool_and_broadcast_rank_mismatch() {
+    // [2, 3, 4] AND [1, 3, 4] (unsqueezed from [3, 4]) broadcasts along dim 0.
+    let device = Default::default();
+    let lhs = TestTensorBool::<3>::from_data(
+        TensorData::from([
+            [
+                [true, false, false, false],
+                [true, false, true, false],
+                [false, true, true, true],
+            ],
+            [
+                [true, false, false, true],
+                [false, false, true, true],
+                [true, true, false, true],
+            ],
+        ]),
+        &device,
+    );
+    let rhs = TestTensorBool::<2>::from_data(
+        TensorData::from([
+            [false, false, true, true],
+            [false, true, true, false],
+            [false, false, false, true],
+        ]),
+        &device,
+    );
+
+    let actual = lhs.bool_and(rhs.unsqueeze::<3>()).into_data();
+    let expected = TensorData::from([
+        [
+            [false, false, false, false],
+            [false, false, true, false],
+            [false, false, false, true],
+        ],
+        [
+            [false, false, false, true],
+            [false, false, true, false],
+            [false, false, false, true],
+        ],
+    ]);
+    expected.assert_eq(&actual, false);
+}
+
+#[test]
+fn test_bool_or_broadcast_rank_mismatch() {
+    // [2, 3, 4] OR [1, 3, 4] (unsqueezed from [3, 4]) broadcasts along dim 0.
+    let device = Default::default();
+    let lhs = TestTensorBool::<3>::from_data(
+        TensorData::from([
+            [
+                [true, false, false, false],
+                [true, false, true, false],
+                [false, true, true, true],
+            ],
+            [
+                [true, false, false, true],
+                [false, false, true, true],
+                [true, true, false, true],
+            ],
+        ]),
+        &device,
+    );
+    let rhs = TestTensorBool::<2>::from_data(
+        TensorData::from([
+            [false, false, true, true],
+            [false, true, true, false],
+            [false, false, false, true],
+        ]),
+        &device,
+    );
+
+    let actual = lhs.bool_or(rhs.unsqueeze::<3>()).into_data();
+    let expected = TensorData::from([
+        [
+            [true, false, true, true],
+            [true, true, true, false],
+            [false, true, true, true],
+        ],
+        [
+            [true, false, true, true],
+            [false, true, true, true],
+            [true, true, false, true],
+        ],
+    ]);
+    expected.assert_eq(&actual, false);
+}
+
+#[test]
+fn test_bool_xor_broadcast_rank_mismatch() {
+    // [2, 2, 2] XOR [1, 2, 2] broadcasts along the leading dim.
+    let device = Default::default();
+    let lhs = TestTensorBool::<3>::from_data(
+        TensorData::from([
+            [[true, false], [false, true]],
+            [[true, true], [false, false]],
+        ]),
+        &device,
+    );
+    let rhs = TestTensorBool::<2>::from_data(
+        TensorData::from([[true, false], [false, true]]),
+        &device,
+    );
+
+    let actual = lhs.bool_xor(rhs.unsqueeze::<3>()).into_data();
+    let expected = TensorData::from([
+        [[false, false], [false, false]],
+        [[false, true], [false, true]],
+    ]);
+    expected.assert_eq(&actual, false);
+}

--- a/crates/burn-backend-tests/tests/tensor/bool/ops/logical.rs
+++ b/crates/burn-backend-tests/tests/tensor/bool/ops/logical.rs
@@ -193,8 +193,7 @@ fn test_bool_and_broadcast_row_lhs() {
     // [1, 3] AND [2, 3] broadcasts lhs along dim 0 only. Distinct from
     // the scalar_lhs pattern, which broadcasts along both dims.
     let device = Default::default();
-    let lhs =
-        TestTensorBool::<2>::from_data(TensorData::from([[true, false, true]]), &device);
+    let lhs = TestTensorBool::<2>::from_data(TensorData::from([[true, false, true]]), &device);
     let rhs = TestTensorBool::<2>::from_data(
         TensorData::from([[true, true, false], [false, true, true]]),
         &device,
@@ -211,12 +210,8 @@ fn test_bool_and_broadcast_mutual() {
     // axes, producing [3, 3]. Exercises the "neither operand matches the
     // output shape" path through broadcast_binary.
     let device = Default::default();
-    let lhs = TestTensorBool::<2>::from_data(
-        TensorData::from([[true], [false], [true]]),
-        &device,
-    );
-    let rhs =
-        TestTensorBool::<2>::from_data(TensorData::from([[true, false, true]]), &device);
+    let lhs = TestTensorBool::<2>::from_data(TensorData::from([[true], [false], [true]]), &device);
+    let rhs = TestTensorBool::<2>::from_data(TensorData::from([[true, false, true]]), &device);
 
     let actual = lhs.bool_and(rhs).into_data();
     let expected = TensorData::from([

--- a/crates/burn-flex/src/ops/bool.rs
+++ b/crates/burn-flex/src/ops/bool.rs
@@ -142,11 +142,12 @@ impl BoolTensorOps<Flex> for Flex {
     fn bool_equal(lhs: BoolTensor<Flex>, rhs: BoolTensor<Flex>) -> BoolTensor<Flex> {
         use crate::strided_index::StridedIter;
 
-        debug_assert_eq!(
-            lhs.layout().shape(),
-            rhs.layout().shape(),
-            "bool_equal: shape mismatch"
-        );
+        // Broadcast to a common shape before comparing. The contiguous fast
+        // path below uses `zip`, which silently truncates to the shorter
+        // operand; and the output shape is taken from lhs, so mismatched
+        // operands would otherwise produce a result vec shorter than the
+        // output layout claims.
+        let (lhs, rhs) = crate::ops::expand::broadcast_binary(lhs, rhs);
 
         let out_dtype = burn_std::BoolDType::from(lhs.dtype());
         let shape = lhs.layout().shape().clone();
@@ -435,15 +436,15 @@ enum BoolBinaryOp {
     Xor,
 }
 
-fn bool_binary_op_simd(mut lhs: FlexTensor, mut rhs: FlexTensor, op: BoolBinaryOp) -> FlexTensor {
+fn bool_binary_op_simd(lhs: FlexTensor, rhs: FlexTensor, op: BoolBinaryOp) -> FlexTensor {
     use crate::strided_index::StridedIter;
 
-    debug_assert_eq!(
-        lhs.layout().shape(),
-        rhs.layout().shape(),
-        "bool_binary_op: shape mismatch"
-    );
     debug_assert_eq!(lhs.dtype(), rhs.dtype(), "bool_binary_op: dtype mismatch");
+
+    // Broadcast to a common shape before dispatching. The scalar/SIMD helpers
+    // below assume equal-length operands; without this, mismatched shapes
+    // either silently keep the lhs shape or OOB-panic inside the helpers.
+    let (mut lhs, mut rhs) = crate::ops::expand::broadcast_binary(lhs, rhs);
 
     // Preserve the input bool dtype (taken from lhs; rhs is assumed to match
     // since bool binary ops require shape and dtype consistency).

--- a/crates/burn-flex/src/ops/bool.rs
+++ b/crates/burn-flex/src/ops/bool.rs
@@ -447,7 +447,7 @@ fn bool_binary_op_simd(lhs: FlexTensor, rhs: FlexTensor, op: BoolBinaryOp) -> Fl
     let (mut lhs, mut rhs) = crate::ops::expand::broadcast_binary(lhs, rhs);
 
     // Preserve the input bool dtype (taken from lhs; rhs is assumed to match
-    // since bool binary ops require shape and dtype consistency).
+    // in dtype, checked above).
     let out_dtype = burn_std::BoolDType::from(lhs.dtype());
     let shape = lhs.layout().shape().clone();
     let l_offsets = lhs.layout().contiguous_offsets();


### PR DESCRIPTION
Fixes tracel-ai/burn#4771.

## Summary

`burn-flex`'s bool binary ops (`bool_and`/`bool_or`/`bool_xor`) and `bool_equal` used `debug_assert_eq!` on the two operands' shapes and then dispatched to scalar/SIMD helpers that assume equal-length inputs. In release builds the assertion is stripped, so mismatched-but-broadcastable shapes would either:

- OOB-panic inside `bool_and_inplace_u8`/`bool_or_inplace_u8` (when lhs.len > rhs.len), or
- Silently keep the lhs shape as the output shape (when lhs is the shorter one), or
- In `bool_equal`'s case, silently truncate via `iter().zip(...)` and produce a data vec shorter than the output layout claimed.

Both code paths now call `crate::ops::expand::broadcast_binary` upfront, mirroring the existing pattern in `ops::binary::binary_op` (`crates/burn-flex/src/ops/binary.rs:44`) and `ops::comparison::bool_not_equal` (`crates/burn-flex/src/ops/comparison.rs:718`). The broadcast case goes through stride-0 views, which cleanly fall through to the `StridedIter` fallback while same-shape inputs still hit the in-place SIMD fast path.

Surfaced while migrating burn-onnx from `burn-ndarray` to `burn-flex` - three `onnx-tests` integration tests were failing against burn-flex with the symptoms described in #4771.

## Audit

I also audited the rest of `crates/burn-flex/src/ops/` for the same bug class (strict shape assumption on binary ops that should broadcast). One additional instance found: `bool_equal` at `crates/burn-flex/src/ops/bool.rs:142` had the same pattern as `bool_and/or/xor`, with a subtler failure mode (silent truncation via `zip` rather than OOB panic). Fixed in the same commit. All other binary ops in `ops/binary.rs`, `ops/comparison.rs`, `ops/int.rs`, `ops/float.rs`, and `ops/mask.rs` already route through `broadcast_binary` correctly.

A separate, mechanically distinct broadcast bug surfaced by the same burn-onnx migration is tracked in #4772 (`attention_naive` rejects ONNX-compliant broadcast mask/bias). That one is not covered here - it lives in `attention.rs`, uses its own offset arithmetic on raw storage, and needs a different fix (expand + materialize). Will be addressed in a separate PR.

## Test plan

New regression tests in `burn-backend-tests`, covering both the dispatch path and the fix:

- `bool::ops::logical::test_bool_and_broadcast_scalar_lhs` / `test_bool_or_broadcast_scalar_lhs` - `[1, 1]` vs `[2, 3]` scalar-lhs broadcast (repro case 1 from #4771)
- `bool::ops::logical::test_bool_and_broadcast_rank_mismatch` / `test_bool_or_broadcast_rank_mismatch` - `[2, 3, 4]` vs `[3, 4]` (repro cases 2 and 3 from #4771)
- `bool::ops::logical::test_bool_xor_broadcast_rank_mismatch` - xor takes the same dispatch path, covered for parity
- `bool::ops::comparison::should_support_bool_equal_broadcast` - regression for the `bool_equal` sibling bug found in the audit
- `bool::ops::comparison::should_support_bool_not_equal_broadcast` - parallel coverage; was already working pre-fix, now permanent

These are backend-agnostic tests in `burn-backend-tests`, so they'll run against every backend that wires into the shared suite via feature flags. I verified all 7 new tests pass against:

- [x] `cargo test -p burn-backend-tests --no-default-features --features "flex,std" --test tensor -- bool::ops`
- [x] `cargo test -p burn-backend-tests --no-default-features --features "ndarray,std" --test tensor -- bool::ops` (confirms expected outputs match numpy reference semantics)

Full flex suite:

- [x] `cargo test -p burn-flex` - 571 lib + 9 comparison + 6 stride + 1 doctest, all pass

## Notes for reviewer

- The `_flipped` tests in `crates/burn-flex/src/ops/bool.rs` were left in place - those specifically exercise negative-stride layouts from `flip()` and are genuinely flex-specific. I initially added the broadcast tests in that file too but removed them after noticing they were duplicates of the backend-tests versions with no flex-specific layout wrinkle. Tracked the broader "move generic tests out of burn-flex" cleanup as tracel-ai/burn#4774.
- The fix is three lines in the hot path (the `broadcast_binary` call replaces the old `debug_assert_eq!`). Most of the +23 in `bool.rs` is the fix comment explaining the failure modes and a similar comment on `bool_equal`.
