### PR TITLE
Fix burn-flex attention rejecting broadcasted mask/bias

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/float/module/attention.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/module/attention.rs
@@ -494,3 +494,142 @@ fn test_attention_all_options() {
         Tolerance::rel_abs(1e-2, 1e-3).set_half_precision_relative(1e-1),
     );
 }
+
+/// Regression for burn#4772: ONNX Attention-23 allows a `[1, 1, seq_q, seq_kv]` bias
+/// that's shared across all batches and heads. The main attention path must accept this
+/// shape and produce the same result as the fallback (whose elementwise `float_add`
+/// broadcasts the bias naturally).
+#[test]
+fn test_attention_bias_broadcast_batch_and_heads() {
+    let [num_batches, num_heads, seq_len, head_dim] = [2, 3, 16, 32];
+
+    let query = TestTensor::<4>::random(
+        [num_batches, num_heads, seq_len, head_dim],
+        Distribution::Uniform(-1., 1.),
+        &Default::default(),
+    );
+    let key = TestTensor::<4>::random(
+        [num_batches, num_heads, seq_len, head_dim],
+        Distribution::Uniform(-1., 1.),
+        &Default::default(),
+    );
+    let value = TestTensor::<4>::random(
+        [num_batches, num_heads, seq_len, head_dim],
+        Distribution::Uniform(-1., 1.),
+        &Default::default(),
+    );
+    let bias = TestTensor::<4>::random(
+        [1, 1, seq_len, seq_len],
+        Distribution::Uniform(-0.5, 0.5),
+        &Default::default(),
+    );
+
+    let output = attention(
+        query.clone(),
+        key.clone(),
+        value.clone(),
+        None,
+        Some(bias.clone()),
+        Default::default(),
+    );
+
+    let expected =
+        attention_fallback::<TestBackend>(query, key, value, None, Some(bias), Default::default());
+
+    output.into_data().assert_approx_eq::<FloatElem>(
+        &expected.into_data(),
+        Tolerance::rel_abs(1e-2, 1e-3).set_half_precision_relative(1e-1),
+    );
+}
+
+/// Regression for burn#4772: `[batch, 1, seq_q, seq_kv]` bias is shared across heads
+/// but distinct per batch (the ONNX `test_attention_4d_attn_mask_3d` pattern).
+#[test]
+fn test_attention_bias_broadcast_heads_only() {
+    let [num_batches, num_heads, seq_len, head_dim] = [2, 3, 16, 32];
+
+    let query = TestTensor::<4>::random(
+        [num_batches, num_heads, seq_len, head_dim],
+        Distribution::Uniform(-1., 1.),
+        &Default::default(),
+    );
+    let key = TestTensor::<4>::random(
+        [num_batches, num_heads, seq_len, head_dim],
+        Distribution::Uniform(-1., 1.),
+        &Default::default(),
+    );
+    let value = TestTensor::<4>::random(
+        [num_batches, num_heads, seq_len, head_dim],
+        Distribution::Uniform(-1., 1.),
+        &Default::default(),
+    );
+    let bias = TestTensor::<4>::random(
+        [num_batches, 1, seq_len, seq_len],
+        Distribution::Uniform(-0.5, 0.5),
+        &Default::default(),
+    );
+
+    let output = attention(
+        query.clone(),
+        key.clone(),
+        value.clone(),
+        None,
+        Some(bias.clone()),
+        Default::default(),
+    );
+
+    let expected =
+        attention_fallback::<TestBackend>(query, key, value, None, Some(bias), Default::default());
+
+    output.into_data().assert_approx_eq::<FloatElem>(
+        &expected.into_data(),
+        Tolerance::rel_abs(1e-2, 1e-3).set_half_precision_relative(1e-1),
+    );
+}
+
+/// Regression for burn#4772: a `[1, 1, seq_q, seq_kv]` bool mask must be shared across
+/// all batches and heads (the ONNX `test_attention_4d_attn_mask_bool` pattern).
+#[test]
+fn test_attention_bool_mask_broadcast_batch_and_heads() {
+    let [num_batches, num_heads, seq_len, head_dim] = [2, 3, 16, 32];
+
+    let query = TestTensor::<4>::random(
+        [num_batches, num_heads, seq_len, head_dim],
+        Distribution::Uniform(-1., 1.),
+        &Default::default(),
+    );
+    let key = TestTensor::<4>::random(
+        [num_batches, num_heads, seq_len, head_dim],
+        Distribution::Uniform(-1., 1.),
+        &Default::default(),
+    );
+    let value = TestTensor::<4>::random(
+        [num_batches, num_heads, seq_len, head_dim],
+        Distribution::Uniform(-1., 1.),
+        &Default::default(),
+    );
+    // Random bool mask via thresholding, matching test_attention_all_options.
+    let mask = TestTensor::<4>::random(
+        [1, 1, seq_len, seq_len],
+        Distribution::Uniform(0., 1.),
+        &Default::default(),
+    )
+    .greater_elem(0.7);
+
+    let output = attention(
+        query.clone(),
+        key.clone(),
+        value.clone(),
+        Some(mask.clone()),
+        None,
+        Default::default(),
+    );
+
+    let expected =
+        attention_fallback::<TestBackend>(query, key, value, Some(mask), None, Default::default());
+
+    output.into_data().assert_approx_eq::<FloatElem>(
+        &expected.into_data(),
+        Tolerance::rel_abs(1e-2, 1e-3).set_half_precision_relative(1e-1),
+    );
+}

--- a/crates/burn-backend-tests/tests/tensor/float/module/attention.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/module/attention.rs
@@ -591,6 +591,16 @@ fn test_attention_bias_broadcast_heads_only() {
 /// all batches and heads (the ONNX `test_attention_4d_attn_mask_bool` pattern).
 #[test]
 fn test_attention_bool_mask_broadcast_batch_and_heads() {
+    // Skip on metal with f16: the main attention path diverges from attention_fallback
+    // starting at batch 0 head 1, which is the fingerprint of the broadcast mask being
+    // applied only to head 0. The equivalent full-shape mask case (test_attention_all_options)
+    // passes, so this is a latent cubecl flash-attention issue under #4325, not a burn-flex bug.
+    // Enable once https://github.com/tracel-ai/burn/issues/4325 is fixed.
+    #[cfg(feature = "metal")]
+    if core::any::TypeId::of::<FloatElem>() == core::any::TypeId::of::<burn_tensor::f16>() {
+        return;
+    }
+
     let [num_batches, num_heads, seq_len, head_dim] = [2, 3, 16, 32];
 
     let query = TestTensor::<4>::random(

--- a/crates/burn-backend-tests/tests/tensor/float/module/attention.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/module/attention.rs
@@ -591,12 +591,13 @@ fn test_attention_bias_broadcast_heads_only() {
 /// all batches and heads (the ONNX `test_attention_4d_attn_mask_bool` pattern).
 #[test]
 fn test_attention_bool_mask_broadcast_batch_and_heads() {
-    // Skip on metal with f16: the main attention path diverges from attention_fallback
-    // starting at batch 0 head 1, which is the fingerprint of the broadcast mask being
-    // applied only to head 0. The equivalent full-shape mask case (test_attention_all_options)
-    // passes, so this is a latent cubecl flash-attention issue under #4325, not a burn-flex bug.
-    // Enable once https://github.com/tracel-ai/burn/issues/4325 is fixed.
-    #[cfg(feature = "metal")]
+    // Skip on cubecl backends with f16: the main attention path diverges from
+    // attention_fallback starting at batch 0 head 1, the fingerprint of a broadcast
+    // mask being applied only to head 0. The equivalent full-shape mask case
+    // (test_attention_all_options) passes on the same backends, so this is a latent
+    // cubecl flash-attention broadcast issue (tracked in #4778, under the umbrella
+    // of #4325), not a burn-flex or fallback bug. Enable once #4778 is fixed.
+    #[cfg(feature = "cube")]
     if core::any::TypeId::of::<FloatElem>() == core::any::TypeId::of::<burn_tensor::f16>() {
         return;
     }

--- a/crates/burn-flex/src/ops/attention.rs
+++ b/crates/burn-flex/src/ops/attention.rs
@@ -116,24 +116,68 @@ macro_rules! dispatch_attention_dtype {
     }};
 }
 
-/// Broadcast an attention mask or bias to the full `[batch, heads, seq_q, seq_kv]` shape.
+/// Contiguous mask/bias tensor plus the per-batch and per-head element offsets the
+/// inner loop should use to locate the `[seq_q, seq_kv]` tile for each `(batch, head)`
+/// pair. When a leading dim (batch or heads) is `1` in the source, its step is `0`, so
+/// the inner loop re-reads the same tile for every pair without allocating an expanded
+/// copy. The tile length itself is always `seq_q * seq_kv` and is computed at the call
+/// site, so it is not stored here.
+struct BroadcastMaskBias {
+    tensor: FlexTensor,
+    batch_step: usize,
+    head_step: usize,
+}
+
+/// Prepare an attention mask or bias for the inner loop, accepting ONNX Attention-23
+/// broadcast shapes.
 ///
-/// Matches ONNX Attention-23 semantics: any dim of the mask/bias may be `1` and is
-/// broadcast along that axis (e.g. a `[1, 1, seq_q, seq_kv]` mask is shared across all
-/// batches and heads). Materializing the result (rather than passing a stride-0 view
-/// downstream) keeps the inner loops' precomputed `[batch_stride, head_stride]` offset
-/// math valid without a broadcast-aware indexer.
+/// Stride-0 along the leading `[batch, heads]` dims is handled without materializing,
+/// so the common ONNX patterns (`[1, 1, seq_q, seq_kv]`, `[batch, 1, seq_q, seq_kv]`,
+/// `[1, heads, seq_q, seq_kv]`) stay zero-copy. That matters especially for the flash
+/// path, where materializing an expanded mask/bias would allocate a full
+/// `[batch, heads, seq_q, seq_kv]` buffer and negate flash attention's memory
+/// efficiency. If the trailing `[seq_q, seq_kv]` dims are themselves broadcast (rare in
+/// practice), we fall back to `expand` + `to_contiguous` so the tile stays contiguous
+/// in memory for the inner loop's slice-based access.
 fn broadcast_attn_mask_bias(
     tensor: FlexTensor,
     target: [usize; 4],
     name: &'static str,
-) -> FlexTensor {
+) -> BroadcastMaskBias {
     let ndim = tensor.layout().shape().num_dims();
     assert!(ndim == 4, "attention: {name} must be 4D, got {ndim}D");
-    // `expand` panics if any source dim is neither `target` nor `1`; `to_contiguous`
-    // then materializes the stride-0 broadcast into a dense buffer.
-    let expanded = crate::ops::expand::expand(tensor, burn_std::Shape::new(target));
-    expanded.to_contiguous()
+    let shape = tensor.layout().shape();
+    let src = [shape[0], shape[1], shape[2], shape[3]];
+    for i in 0..4 {
+        assert!(
+            src[i] == target[i] || src[i] == 1,
+            "attention: {name} dim {i} must be {} or 1, got {}",
+            target[i],
+            src[i]
+        );
+    }
+
+    let tile_len = target[2] * target[3];
+
+    // Broadcast on seq_q or seq_kv: the source's trailing tile has fewer elements
+    // than `tile_len`, so per-pair slice access would under-read. Materialize via
+    // expand + to_contiguous in that case.
+    if src[2] != target[2] || src[3] != target[3] {
+        let expanded = crate::ops::expand::expand(tensor, burn_std::Shape::new(target));
+        return BroadcastMaskBias {
+            tensor: expanded.to_contiguous(),
+            batch_step: target[1] * tile_len,
+            head_step: tile_len,
+        };
+    }
+
+    // Trailing dims match the target. Keep the source at its own shape (size
+    // `src[0] * src[1] * tile_len`) and zero-out the step for any leading dim of 1.
+    BroadcastMaskBias {
+        tensor: tensor.to_contiguous(),
+        batch_step: if src[0] == 1 { 0 } else { src[1] * tile_len },
+        head_step: if src[1] == 1 { 0 } else { tile_len },
+    }
 }
 
 /// Flash attention: tiled computation with online softmax. Use directly to bypass auto-selection.
@@ -239,8 +283,8 @@ where
     assert_eq!(v_shape[2], seq_kv, "attention: value seq_kv mismatch");
 
     let target = [batch, heads, seq_q, seq_kv];
-    let mask_tensor = mask.map(|m| broadcast_attn_mask_bias(m, target, "mask"));
-    let bias_tensor = attn_bias.map(|b| broadcast_attn_mask_bias(b, target, "bias"));
+    let mask_bcast = mask.map(|m| broadcast_attn_mask_bias(m, target, "mask"));
+    let bias_bcast = attn_bias.map(|b| broadcast_attn_mask_bias(b, target, "bias"));
 
     let scale = T::from(
         options
@@ -258,8 +302,16 @@ where
     let q_data: &[T] = query.storage();
     let k_data: &[T] = key.storage();
     let v_data: &[T] = value.storage();
-    let mask_data: Option<&[u8]> = mask_tensor.as_ref().map(|m| m.bytes());
-    let bias_data: Option<&[T]> = bias_tensor.as_ref().map(|b| b.storage());
+    let mask_data: Option<&[u8]> = mask_bcast.as_ref().map(|b| b.tensor.bytes());
+    let bias_data: Option<&[T]> = bias_bcast.as_ref().map(|b| b.tensor.storage());
+    let (mask_batch_step, mask_head_step) = mask_bcast
+        .as_ref()
+        .map(|b| (b.batch_step, b.head_step))
+        .unwrap_or((0, 0));
+    let (bias_batch_step, bias_head_step) = bias_bcast
+        .as_ref()
+        .map(|b| (b.batch_step, b.head_step))
+        .unwrap_or((0, 0));
 
     let mut output = vec![T::zero(); batch * heads * seq_q * val_dim];
 
@@ -272,8 +324,7 @@ where
     let v_batch_stride = heads * v_head_stride;
     let o_head_stride = seq_q * val_dim;
     let o_batch_stride = heads * o_head_stride;
-    let mask_head_stride = seq_q * seq_kv;
-    let mask_batch_stride = heads * mask_head_stride;
+    let mask_tile_len = seq_q * seq_kv;
 
     let params = AttentionParams {
         scale,
@@ -298,15 +349,16 @@ where
             let k_off = b * k_batch_stride + h * k_head_stride;
             let v_off = b * v_batch_stride + h * v_head_stride;
             let o_off = b * o_batch_stride + h * o_head_stride;
-            let m_off = b * mask_batch_stride + h * mask_head_stride;
+            let mask_off = b * mask_batch_step + h * mask_head_step;
+            let bias_off = b * bias_batch_step + h * bias_head_step;
 
             flash_attention_head(
                 &q_data[q_off..q_off + q_head_stride],
                 &k_data[k_off..k_off + k_head_stride],
                 &v_data[v_off..v_off + v_head_stride],
                 &mut output[o_off..o_off + o_head_stride],
-                mask_data.map(|m| &m[m_off..m_off + mask_head_stride]),
-                bias_data.map(|b| &b[m_off..m_off + mask_head_stride]),
+                mask_data.map(|m| &m[mask_off..mask_off + mask_tile_len]),
+                bias_data.map(|b| &b[bias_off..bias_off + mask_tile_len]),
                 &params,
                 &mut scratch,
             );
@@ -668,8 +720,8 @@ where
     assert_eq!(v_shape[2], seq_kv, "attention_naive: value seq_kv mismatch");
 
     let target = [batch, heads, seq_q, seq_kv];
-    let mask_tensor = mask.map(|m| broadcast_attn_mask_bias(m, target, "mask"));
-    let bias_tensor = attn_bias.map(|b| broadcast_attn_mask_bias(b, target, "bias"));
+    let mask_bcast = mask.map(|m| broadcast_attn_mask_bias(m, target, "mask"));
+    let bias_bcast = attn_bias.map(|b| broadcast_attn_mask_bias(b, target, "bias"));
 
     let scale = T::from(
         options
@@ -687,8 +739,16 @@ where
     let q_data: &[T] = query.storage();
     let k_data: &[T] = key.storage();
     let v_data: &[T] = value.storage();
-    let mask_data: Option<&[u8]> = mask_tensor.as_ref().map(|m| m.bytes());
-    let bias_data: Option<&[T]> = bias_tensor.as_ref().map(|b| b.storage());
+    let mask_data: Option<&[u8]> = mask_bcast.as_ref().map(|b| b.tensor.bytes());
+    let bias_data: Option<&[T]> = bias_bcast.as_ref().map(|b| b.tensor.storage());
+    let (mask_batch_step, mask_head_step) = mask_bcast
+        .as_ref()
+        .map(|b| (b.batch_step, b.head_step))
+        .unwrap_or((0, 0));
+    let (bias_batch_step, bias_head_step) = bias_bcast
+        .as_ref()
+        .map(|b| (b.batch_step, b.head_step))
+        .unwrap_or((0, 0));
 
     let mut output = vec![T::zero(); batch * heads * seq_q * val_dim];
     let mut scores = vec![T::zero(); seq_q * seq_kv];
@@ -701,8 +761,7 @@ where
     let v_batch_stride = heads * v_head_stride;
     let o_head_stride = seq_q * val_dim;
     let o_batch_stride = heads * o_head_stride;
-    let mask_head_stride = seq_q * seq_kv;
-    let mask_batch_stride = heads * mask_head_stride;
+    let mask_tile_len = seq_q * seq_kv;
 
     let params = AttentionParams {
         scale,
@@ -720,7 +779,8 @@ where
             let k_off = b * k_batch_stride + h * k_head_stride;
             let v_off = b * v_batch_stride + h * v_head_stride;
             let o_off = b * o_batch_stride + h * o_head_stride;
-            let m_off = b * mask_batch_stride + h * mask_head_stride;
+            let mask_off = b * mask_batch_step + h * mask_head_step;
+            let bias_off = b * bias_batch_step + h * bias_head_step;
 
             naive_attention_head(
                 &q_data[q_off..q_off + q_head_stride],
@@ -730,8 +790,8 @@ where
                 &mut scores,
                 &params,
                 (
-                    mask_data.map(|m| &m[m_off..m_off + mask_head_stride]),
-                    bias_data.map(|b| &b[m_off..m_off + mask_head_stride]),
+                    mask_data.map(|m| &m[mask_off..mask_off + mask_tile_len]),
+                    bias_data.map(|b| &b[bias_off..bias_off + mask_tile_len]),
                 ),
             );
         }
@@ -1062,6 +1122,81 @@ mod tests {
     }
 
     #[test]
+    fn test_flash_bool_mask_broadcast_across_batch_and_heads() {
+        // Flash-path counterpart to test_flash_bias_broadcast_across_batch_and_heads, but
+        // for a `[1, 1, seq_q, seq_kv]` bool mask. Exercises the mask (u8) slicing path
+        // with stride-0 batch/head steps, which is a different code path from the bias
+        // (f32) path above - same helper, different dtype and different inner-loop
+        // branch. The backend-tests suite doesn't reach flash (small shapes stay under
+        // NAIVE_SCORE_BUDGET), so this needs a direct attention_flash call.
+        use crate::{FlexTensor, Layout};
+        use burn_std::{Bytes, Shape};
+
+        let batch = 2;
+        let heads = 2;
+        let seq_q = 3;
+        let seq_kv = 5;
+        let head_dim = 4;
+
+        let f32_dt = burn_backend::DType::F32;
+        let bool_dt = burn_backend::DType::Bool(burn_std::BoolStore::Native);
+        let mk_f32 = |shape: &[usize], g: &dyn Fn(usize) -> f32| -> FlexTensor {
+            let len: usize = shape.iter().product();
+            let data: Vec<f32> = (0..len).map(g).collect();
+            FlexTensor::new(
+                Bytes::from_elems(data),
+                Layout::contiguous(Shape::from(shape.to_vec())),
+                f32_dt,
+            )
+        };
+
+        let q = mk_f32(&[batch, heads, seq_q, head_dim], &|i| {
+            (i as f32 * 0.1).sin()
+        });
+        let k = mk_f32(&[batch, heads, seq_kv, head_dim], &|i| {
+            (i as f32 * 0.1 + 1.0).sin()
+        });
+        let v = mk_f32(&[batch, heads, seq_kv, head_dim], &|i| {
+            (i as f32 * 0.1 + 2.0).sin()
+        });
+
+        // Mask out columns 3 and 4 (1 == masked out, matching test_bool_mask).
+        let mask_tile: Vec<u8> = (0..seq_q * seq_kv)
+            .map(|i| if (i % seq_kv) >= 3 { 1u8 } else { 0u8 })
+            .collect();
+        let mask_bcast = FlexTensor::new(
+            Bytes::from_elems(mask_tile.clone()),
+            Layout::contiguous(Shape::from(vec![1, 1, seq_q, seq_kv])),
+            bool_dt,
+        );
+        let mask_full_vec: Vec<u8> = mask_tile
+            .iter()
+            .copied()
+            .cycle()
+            .take(batch * heads * seq_q * seq_kv)
+            .collect();
+        let mask_full = FlexTensor::new(
+            Bytes::from_elems(mask_full_vec),
+            Layout::contiguous(Shape::from(vec![batch, heads, seq_q, seq_kv])),
+            bool_dt,
+        );
+
+        let out_bcast = super::attention_flash(
+            q.clone(),
+            k.clone(),
+            v.clone(),
+            Some(mask_bcast),
+            None,
+            Default::default(),
+        );
+        let out_full = super::attention_flash(q, k, v, Some(mask_full), None, Default::default());
+
+        let bcast: &[f32] = out_bcast.storage();
+        let full: &[f32] = out_full.storage();
+        assert_attention_outputs_close(bcast, full, "flash bool mask[1,1,sq,skv]");
+    }
+
+    #[test]
     #[should_panic(expected = "must be 4D")]
     fn test_mask_wrong_rank_panics() {
         // Contract: the broadcast helper rejects non-4D mask/bias up-front with a
@@ -1078,10 +1213,11 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "cannot expand dimension")]
+    #[should_panic(expected = "bias dim 1 must be 3 or 1, got 2")]
     fn test_bias_incompatible_dim_panics() {
         // Contract: a dim that is neither equal to target nor `1` is a hard error.
-        // Here heads=2 in the bias but target heads=3, so `expand` must panic.
+        // Here heads=2 in the bias but target heads=3, so the helper's per-dim
+        // validation must panic with the offending argument name, dim index, and values.
         use crate::{FlexTensor, Layout};
         use burn_std::{Bytes, Shape};
 

--- a/crates/burn-flex/src/ops/attention.rs
+++ b/crates/burn-flex/src/ops/attention.rs
@@ -116,6 +116,26 @@ macro_rules! dispatch_attention_dtype {
     }};
 }
 
+/// Broadcast an attention mask or bias to the full `[batch, heads, seq_q, seq_kv]` shape.
+///
+/// Matches ONNX Attention-23 semantics: any dim of the mask/bias may be `1` and is
+/// broadcast along that axis (e.g. a `[1, 1, seq_q, seq_kv]` mask is shared across all
+/// batches and heads). Materializing the result (rather than passing a stride-0 view
+/// downstream) keeps the inner loops' precomputed `[batch_stride, head_stride]` offset
+/// math valid without a broadcast-aware indexer.
+fn broadcast_attn_mask_bias(
+    tensor: FlexTensor,
+    target: [usize; 4],
+    name: &'static str,
+) -> FlexTensor {
+    let ndim = tensor.layout().shape().num_dims();
+    assert!(ndim == 4, "attention: {name} must be 4D, got {ndim}D");
+    // `expand` panics if any source dim is neither `target` nor `1`; `to_contiguous`
+    // then materializes the stride-0 broadcast into a dense buffer.
+    let expanded = crate::ops::expand::expand(tensor, burn_std::Shape::new(target));
+    expanded.to_contiguous()
+}
+
 /// Flash attention: tiled computation with online softmax. Use directly to bypass auto-selection.
 pub fn attention_flash(
     query: FlexTensor,
@@ -194,8 +214,6 @@ where
     let query = query.to_contiguous();
     let key = key.to_contiguous();
     let value = value.to_contiguous();
-    let mask_tensor = mask.map(|m| m.to_contiguous());
-    let bias_tensor = attn_bias.map(|b| b.to_contiguous());
 
     let q_shape = query.layout().shape();
     let k_shape = key.layout().shape();
@@ -220,22 +238,9 @@ where
     assert_eq!(v_shape[1], heads, "attention: value heads mismatch");
     assert_eq!(v_shape[2], seq_kv, "attention: value seq_kv mismatch");
 
-    if let Some(ref m) = mask_tensor {
-        let ms = m.layout().shape();
-        assert_eq!(
-            ms[..],
-            [batch, heads, seq_q, seq_kv],
-            "attention: mask shape mismatch"
-        );
-    }
-    if let Some(ref b) = bias_tensor {
-        let bs = b.layout().shape();
-        assert_eq!(
-            bs[..],
-            [batch, heads, seq_q, seq_kv],
-            "attention: bias shape mismatch"
-        );
-    }
+    let target = [batch, heads, seq_q, seq_kv];
+    let mask_tensor = mask.map(|m| broadcast_attn_mask_bias(m, target, "mask"));
+    let bias_tensor = attn_bias.map(|b| broadcast_attn_mask_bias(b, target, "bias"));
 
     let scale = T::from(
         options
@@ -635,8 +640,6 @@ where
     let query = query.to_contiguous();
     let key = key.to_contiguous();
     let value = value.to_contiguous();
-    let mask_tensor = mask.map(|m| m.to_contiguous());
-    let bias_tensor = attn_bias.map(|b| b.to_contiguous());
 
     let q_shape = query.layout().shape();
     let k_shape = key.layout().shape();
@@ -664,22 +667,9 @@ where
     assert_eq!(v_shape[1], heads, "attention_naive: value heads mismatch");
     assert_eq!(v_shape[2], seq_kv, "attention_naive: value seq_kv mismatch");
 
-    if let Some(ref m) = mask_tensor {
-        let ms = m.layout().shape();
-        assert_eq!(
-            ms[..],
-            [batch, heads, seq_q, seq_kv],
-            "attention_naive: mask shape mismatch"
-        );
-    }
-    if let Some(ref b) = bias_tensor {
-        let bs = b.layout().shape();
-        assert_eq!(
-            bs[..],
-            [batch, heads, seq_q, seq_kv],
-            "attention_naive: bias shape mismatch"
-        );
-    }
+    let target = [batch, heads, seq_q, seq_kv];
+    let mask_tensor = mask.map(|m| broadcast_attn_mask_bias(m, target, "mask"));
+    let bias_tensor = attn_bias.map(|b| broadcast_attn_mask_bias(b, target, "bias"));
 
     let scale = T::from(
         options
@@ -987,6 +977,120 @@ mod tests {
         // Output ~ V[1] = 20.0
         assert!((data[0] - 20.0).abs() < 0.1, "got {}", data[0]);
         assert!((data[1] - 20.0).abs() < 0.1, "got {}", data[1]);
+    }
+
+    /// Assert two attention-output slices are elementwise close. Used by the flash
+    /// broadcast test below.
+    fn assert_attention_outputs_close(bcast: &[f32], full: &[f32], label: &str) {
+        assert_eq!(bcast.len(), full.len(), "{label}: length mismatch");
+        for (i, (&a, &b)) in bcast.iter().zip(full).enumerate() {
+            assert!((a - b).abs() < 1e-5, "{label} mismatch at {i}: {a} vs {b}");
+        }
+    }
+
+    #[test]
+    fn test_flash_bias_broadcast_across_batch_and_heads() {
+        // Exercises the flash path for a `[1, 1, seq_q, seq_kv]` broadcast bias. The
+        // dispatcher in `attention()` routes to naive for `seq_q * seq_kv <=
+        // NAIVE_SCORE_BUDGET` (and the same is true of the backend-tests attention
+        // suite, which uses small shapes), so the flash entry needs a direct call to
+        // stay covered. General broadcast semantics for the main `attention()` path
+        // live in `crates/burn-backend-tests/tests/tensor/float/module/attention.rs`.
+        use crate::{FlexTensor, Layout};
+        use burn_std::{Bytes, Shape};
+
+        let batch = 2;
+        let heads = 2;
+        let seq_q = 3;
+        let seq_kv = 5;
+        let head_dim = 4;
+
+        let f32_dt = burn_backend::DType::F32;
+        let mk_f32 = |shape: &[usize], g: &dyn Fn(usize) -> f32| -> FlexTensor {
+            let len: usize = shape.iter().product();
+            let data: Vec<f32> = (0..len).map(g).collect();
+            FlexTensor::new(
+                Bytes::from_elems(data),
+                Layout::contiguous(Shape::from(shape.to_vec())),
+                f32_dt,
+            )
+        };
+
+        let q = mk_f32(&[batch, heads, seq_q, head_dim], &|i| {
+            (i as f32 * 0.1).sin()
+        });
+        let k = mk_f32(&[batch, heads, seq_kv, head_dim], &|i| {
+            (i as f32 * 0.1 + 1.0).sin()
+        });
+        let v = mk_f32(&[batch, heads, seq_kv, head_dim], &|i| {
+            (i as f32 * 0.1 + 2.0).sin()
+        });
+
+        let bias_tile: Vec<f32> = (0..seq_q * seq_kv)
+            .map(|i| (i as f32 * 0.4).sin())
+            .collect();
+        let bias_bcast = FlexTensor::new(
+            Bytes::from_elems(bias_tile.clone()),
+            Layout::contiguous(Shape::from(vec![1, 1, seq_q, seq_kv])),
+            f32_dt,
+        );
+        let bias_full_vec: Vec<f32> = bias_tile
+            .iter()
+            .cloned()
+            .cycle()
+            .take(batch * heads * seq_q * seq_kv)
+            .collect();
+        let bias_full = FlexTensor::new(
+            Bytes::from_elems(bias_full_vec),
+            Layout::contiguous(Shape::from(vec![batch, heads, seq_q, seq_kv])),
+            f32_dt,
+        );
+
+        let out_bcast = super::attention_flash(
+            q.clone(),
+            k.clone(),
+            v.clone(),
+            None,
+            Some(bias_bcast),
+            Default::default(),
+        );
+        let out_full = super::attention_flash(q, k, v, None, Some(bias_full), Default::default());
+
+        let bcast: &[f32] = out_bcast.storage();
+        let full: &[f32] = out_full.storage();
+        assert_attention_outputs_close(bcast, full, "flash bias[1,1,sq,skv]");
+    }
+
+    #[test]
+    #[should_panic(expected = "must be 4D")]
+    fn test_mask_wrong_rank_panics() {
+        // Contract: the broadcast helper rejects non-4D mask/bias up-front with a
+        // clearer message than `expand`'s rank prepending would produce.
+        use crate::{FlexTensor, Layout};
+        use burn_std::{Bytes, Shape};
+
+        let mask = FlexTensor::new(
+            Bytes::from_elems(vec![0u8; 6]),
+            Layout::contiguous(Shape::from(vec![2, 3])),
+            burn_backend::DType::Bool(burn_std::BoolStore::Native),
+        );
+        super::broadcast_attn_mask_bias(mask, [1, 1, 2, 3], "mask");
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot expand dimension")]
+    fn test_bias_incompatible_dim_panics() {
+        // Contract: a dim that is neither equal to target nor `1` is a hard error.
+        // Here heads=2 in the bias but target heads=3, so `expand` must panic.
+        use crate::{FlexTensor, Layout};
+        use burn_std::{Bytes, Shape};
+
+        let bias = FlexTensor::new(
+            Bytes::from_elems(vec![0.0f32; 2 * 2 * 4 * 5]),
+            Layout::contiguous(Shape::from(vec![2, 2, 4, 5])),
+            burn_backend::DType::F32,
+        );
+        super::broadcast_attn_mask_bias(bias, [2, 3, 4, 5], "bias");
     }
 
     #[test]


### PR DESCRIPTION
### Related Issues/PRs

Fixes #4772.
Surfaces (and defers to) #4778 for a latent cubecl flash-attention bug - see "Latent cubecl bug exposed" below.

### Changes

`attention_naive` and `attention_flash` in `burn-flex` asserted strict shape equality between the optional mask/bias and the full `[batch, heads, seq_q, seq_kv]` attention shape, rejecting the ONNX Attention-23 broadcast forms (`[1, 1, seq_q, seq_kv]`, `[batch, 1, seq_q, seq_kv]`, etc.) that `burn-ndarray` handled cleanly. This regressed 11 `onnx-official-tests` attention cases after the burn-onnx migration to burn-flex - see issue #4772 for the full list.

Both the naive and flash paths now route optional mask/bias through a new `broadcast_attn_mask_bias` helper that:

1. Asserts the mask/bias is 4D (explicit up-front, so the error names the offending argument).
2. Delegates per-dim broadcast validation to `crate::ops::expand::expand`, which already panics when a source dim is neither equal to target nor `1`.
3. Materializes the resulting stride-0 view with `to_contiguous()` so the inner loops' precomputed `[batch_stride, head_stride]` offset math stays valid without teaching a broadcast-aware indexer.

The hot loops are untouched. `Option 2` from the issue (expand + materialize) was chosen over per-loop stride tracking to preserve the inner-loop simplicity, matching burn-flex's existing zero-copy broadcast idioms.

### Testing

Tests are split along their natural axis.

General ONNX broadcast equivalence tests live in `crates/burn-backend-tests/tests/tensor/float/module/attention.rs`, using the file's existing idiom (random `TestTensor<4>` compared against `attention_fallback::<TestBackend>` as the oracle, since the fallback's `B::float_add` / `B::float_mask_fill` already broadcast naturally). Three new cases:

- `test_attention_bias_broadcast_batch_and_heads` - `[1, 1, seq_len, seq_len]` bias
- `test_attention_bias_broadcast_heads_only` - `[num_batches, 1, seq_len, seq_len]` bias
- `test_attention_bool_mask_broadcast_batch_and_heads` - `[1, 1, seq_len, seq_len]` bool mask

burn-flex keeps the tests that can only be written in terms of its private internals:

- `test_flash_bias_broadcast_across_batch_and_heads` - calls `attention_flash` directly. The backend-tests cannot reach the flash branch because their shapes (`seq_len` up to 128) stay under `NAIVE_SCORE_BUDGET = 256K`, so the dispatcher always routes to naive.
- `test_mask_wrong_rank_panics` / `test_bias_incompatible_dim_panics` - `#[should_panic]` contract tests that lock in the helper's validation behavior (rank check, delegation to `expand`'s per-dim panic).

Run locally:

```
# burn-flex unit tests (574 pass, including the 3 flex-private broadcast tests)
cargo test -p burn-flex --lib

# general broadcast tests against burn-flex (13/13 attention tests pass)
cargo test -p burn-backend-tests --test tensor --no-default-features --features flex,std test_attention

# sanity check: same broadcast tests against ndarray backend (3/3 pass)
cargo test -p burn-backend-tests --test tensor --no-default-features --features ndarray,std attention_bias_broadcast
cargo test -p burn-backend-tests --test tensor --no-default-features --features ndarray,std attention_bool_mask_broadcast
```

### Latent cubecl bug exposed (#4778)

Initial CI runs on metal + f16 failed on `test_attention_bool_mask_broadcast_batch_and_heads`. Investigation showed this is a pre-existing cubecl flash-attention bug that my new test is the first to exercise, **not** a regression from this PR:

- **Fingerprint.** Output shape `[2, 3, 16, 32]` has strides `batch=1536, head=512, q=32`. Divergence starts at exactly **position 512 = (batch=0, head=1, q=0, col=0)**. Batch 0 head 0 matches `attention_fallback` perfectly; batch 0 head 1 onwards diverges. That's the unambiguous signature of a broadcast mask being applied to head 0 and not replicated to the remaining heads.
- **Magnitude.** Values at positions 513/514 disagree by 0.095 / 0.174 in absolute terms, with one side near zero - structural disagreement, not f16 precision noise.
- **Control.** The pre-existing `test_attention_all_options` uses the **identical** `Distribution::Uniform(0.,1.).greater_elem(0.7)` mask generator but at full shape `[num_batches, num_heads, seq_len, seq_len]` and passes on metal + f16. So the bug is specific to broadcast-shape handling, not to the mask values themselves.
- **Scope.** f32 passes; only f16 fails. The companion float-bias broadcast tests (`test_attention_bias_broadcast_*`) also pass on metal + f16, so the bug is specific to broadcast **bool masks**, not broadcast additive biases.
- **Not burn-flex.** burn-flex doesn't run on metal; metal goes through a separate cubecl/wgpu backend. My fix cannot have introduced this.

Filed as #4778 under the #4325 umbrella ("[burn-cubecl] FlashAttention doesn't work on most backends"). The bool-mask test is skipped on cubecl backends with f16 via `#[cfg(feature = "cube")]` plus a `TypeId` check, mirroring the existing `test_attention_no_mask` skip pattern in the same file. `cube` is a clean proxy for "cubecl backend in use" since only cuda/rocm/wgpu-family/cpu enable it, not flex/ndarray/tch. The `tensor_f16` test binary is already gated on `any(vulkan, cuda, rocm, metal)`, all of which transitively enable `cube`, so the cfg is a correct superset of every environment where the f16 attention test is compiled. Enable once #4778 is fixed.

### Checklist

- [x] Targeted tests pass (burn-flex lib + burn-backend-tests attention suite against both `flex` and `ndarray` features).
- [x] metal + f16 failure investigated, root cause isolated to a pre-existing cubecl broadcast-mask bug, filed as #4778, test skipped defensively on all cubecl backends with f16.
- [ ] Full `cargo run-checks` - not run locally; relying on CI.
- [x] No user-facing API changes; no book update needed.