### PR TITLE
Make cubecl normal distribution test reproducible

### DIFF
--- a/crates/burn-backend-tests/tests/cubecl/normal.rs
+++ b/crates/burn-backend-tests/tests/cubecl/normal.rs
@@ -24,6 +24,7 @@ fn normal_respects_68_95_99_rule() {
     // https://en.wikipedia.org/wiki/68%E2%80%9395%E2%80%9399.7_rule
     let shape: Shape = [1000, 1000].into();
     let device = Default::default();
+    TestBackend::seed(&device, 0);
     let mu = 0.;
     let s = 1.;
     let tensor =


### PR DESCRIPTION
 Seed `normal_respects_68_95_99_rule` in `crates/burn-backend-tests/tests/cubecl/normal.rs` to make it reproducible.

Tested with:
```bash
   cargo test -p burn-backend-tests --test cubecl --features cube cube::kernel::normal -- --nocapture
 ```