### PR TITLE
Forward gemm perf features and fix burn-flex SIMD flag cascade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ flate2 = "1.1.9"
 float-cmp = "0.10.0"
 futures = "0.3"
 futures-util = "0.3"
+gemm = { version = "0.19", default-features = false }
 gix-tempfile = { version = "21.0.2", features = ["signals"] }
 globwalk = "0.9.1"
 hashbrown = "0.16"

--- a/crates/burn-flex/ARCHITECTURE.md
+++ b/crates/burn-flex/ARCHITECTURE.md
@@ -58,13 +58,41 @@ production. This includes:
 default = ["std", "simd", "rayon"]
 ```
 
-| Feature | Default | Description                                                      |
-| ------- | ------- | ---------------------------------------------------------------- |
-| `std`   | Yes     | Standard library support                                         |
-| `simd`  | Yes     | Portable SIMD via macerator (enables `macerator`, `aligned-vec`) |
-| `rayon` | Yes     | Parallel execution for large tensors                             |
+| Feature     | Default | Description                                                                 |
+| ----------- | ------- | --------------------------------------------------------------------------- |
+| `std`       | Yes     | Standard library support                                                    |
+| `simd`      | Yes     | Portable SIMD via macerator (enables `macerator`, `aligned-vec`)            |
+| `rayon`     | Yes     | Parallel execution for large tensors (forwards `gemm/rayon`)                |
+| `x86-v4`    | No      | AVX-512 kernels in gemm for x86_64 (Sapphire Rapids, Zen 4/5, etc.)         |
+| `apple-amx` | No      | Apple Silicon AMX matrix coprocessor in gemm (experimental upstream)        |
+
+The `simd` feature also forwards `gemm/wasm-simd128-enable`, a no-op outside WASM.
 
 `gemm` is an always-on required dependency (not behind a feature flag).
+
+### Performance impact on Apple M3 Max (median speedup vs serial baseline)
+
+Measured via `cargo bench -p burn-flex --bench {matmul,attention,conv_ops}` with features
+`std,simd` (serial), `std,simd,rayon` (default), and `std,simd,rayon,apple-amx`.
+
+| Workload                                | rayon vs serial | +apple-amx vs rayon | combined |
+| --------------------------------------- | --------------- | ------------------- | -------- |
+| matmul 1024×1024 f32                    | 7.0x            | 1.7x                | **12.2x** |
+| matmul 512×512 f32                      | 3.8x            | 1.5x                | 5.8x     |
+| attention self b1·h32·s256·d128         | 1.0x            | 2.0x                | 2.0x     |
+| attention self b1·h12·s512·d64          | 1.0x            | 1.6x                | 1.6x     |
+| conv2d first_layer 4×3×224×224 k7×7 s2  | 9.8x            | 1.2x                | **11.6x** |
+| conv2d large 16×128×64×64 k3×3          | 7.7x            | 1.5x                | 11.1x    |
+| conv2d k7×7                             | 6.5x            | 1.4x                | 9.2x     |
+
+Notes:
+- Attention ops currently see no rayon uplift; the per-head matmul pipeline does not
+  propagate `Parallelism::Rayon` to gemm. AMX still delivers a standalone speedup.
+- Small shapes (e.g. `batch8_64x64` matmul, `depthwise_k3_8x32x512` conv1d) can regress
+  under rayon due to thread-spawn overhead; a size-based gating in the matmul/conv
+  paths would recover those without losing the large-shape wins.
+- AMX regresses on transposed operands (`both/rhs_transposed_256x256` matmul drop to
+  ~0.55x vs rayon). Avoid `apple-amx` for workloads dominated by transposed GEMM.
 
 ---
 

--- a/crates/burn-flex/Cargo.toml
+++ b/crates/burn-flex/Cargo.toml
@@ -25,8 +25,13 @@ std = [
     "half/std",
     "num-traits/std",
 ]
-simd = ["dep:macerator", "dep:aligned-vec"]
+simd = ["dep:macerator", "dep:aligned-vec", "gemm/wasm-simd128-enable"]
 rayon = ["dep:rayon", "gemm/rayon"]
+# Opt-in gemm codegen paths. Not enabled by default.
+# AVX-512 kernels for x86_64 (Sapphire Rapids, Zen 4/5, etc.).
+x86-v4 = ["gemm/x86-v4"]
+# Apple AMX matrix coprocessor (M-series). Experimental upstream; requires std.
+apple-amx = ["std", "gemm/experimental-apple-amx"]
 tracing = ["burn-std/tracing", "burn-backend/tracing", "burn-ir/tracing"]
 critical-section = [
     "dep:once_cell",
@@ -49,7 +54,7 @@ half = { workspace = true }
 num-traits = { workspace = true }
 
 # Matmul
-gemm = { version = "0.19", default-features = false, features = ["f16"] }
+gemm = { workspace = true, features = ["f16"] }
 
 # SIMD
 aligned-vec = { version = "0.6", default-features = false, optional = true }

--- a/crates/burn-flex/README.md
+++ b/crates/burn-flex/README.md
@@ -44,6 +44,33 @@ is thread-safe by design.
 - **Built on Burn**: Leverages Burn's native infrastructure (`Bytes`, `Shape`, `TensorData`,
   `Element` trait) from burn-backend and burn-std
 
+### Feature Flags
+
+Default: `std`, `simd`, `rayon`.
+
+| Flag                | Default | Description                                                         |
+| ------------------- | ------- | ------------------------------------------------------------------- |
+| `std`               | Yes     | Standard library support                                            |
+| `simd`              | Yes     | Portable SIMD via macerator; also enables `gemm/wasm-simd128-enable`|
+| `rayon`             | Yes     | Parallel execution for large tensors (forwards `gemm/rayon`)        |
+| `x86-v4`            | No      | AVX-512 kernels in gemm for x86_64 (Sapphire Rapids, Zen 4/5)       |
+| `apple-amx`         | No      | Apple Silicon AMX matrix coprocessor in gemm (experimental)         |
+| `tracing`           | No      | Propagate `tracing` instrumentation                                 |
+| `critical-section`  | No      | Support for no_std targets without atomic CAS                       |
+
+Enable opt-in paths by passing them to Cargo, either directly on `burn-flex` or through the
+top-level `burn` crate:
+
+```toml
+# Direct
+burn-flex = { version = "0.21", features = ["apple-amx"] }
+
+# Via burn
+burn = { version = "0.21", features = ["flex", "apple-amx"] }
+```
+
+See [ARCHITECTURE.md#feature-flags](./ARCHITECTURE.md#feature-flags) for per-case benchmark impact.
+
 ### Why replace burn-ndarray?
 
 burn-ndarray depends on the [ndarray](https://crates.io/crates/ndarray) crate, which has been slow

--- a/crates/burn/Cargo.toml
+++ b/crates/burn/Cargo.toml
@@ -161,7 +161,11 @@ openblas-system = ["burn-ndarray?/blas-openblas-system"]
 remote = ["burn-remote/client", "ir"]
 router = ["burn-router", "ir"]
 server = ["burn-remote/server"]
-simd = ["burn-ndarray?/simd"]
+simd = ["burn-ndarray?/simd", "burn-flex?/simd"]
+
+# burn-flex opt-in CPU codegen paths.
+x86-v4 = ["burn-flex?/x86-v4"]
+apple-amx = ["burn-flex?/apple-amx"]
 template = ["burn-wgpu?/template"]
 collective = ["burn-collective", "burn-optim/collective"]
 distributed = ["std",


### PR DESCRIPTION
Adds opt-in forwarding for gemm performance features and fixes the burn-flex SIMD cascade.

## Changes
- `burn-flex`: new `x86-v4` and `apple-amx` features forward to `gemm/x86-v4` and `gemm/experimental-apple-amx`. `simd` now also forwards `gemm/wasm-simd128-enable` (no-op off WASM).
- `burn`: `simd` feature now forwards to both `burn-ndarray` and `burn-flex`. New `x86-v4` and `apple-amx` passthroughs for users with only `flex`. Fixes #4802.
- `gemm` promoted to `[workspace.dependencies]`.
- `ARCHITECTURE.md` documents the new flags plus a benchmark-impact table.

## Performance benchmarks

Measured on Apple M3 Max (16 cores) via `cargo bench -p burn-flex --bench {matmul,attention,conv_ops}` with three feature combos: `std,simd` (serial), `std,simd,rayon` (default), and `std,simd,rayon,apple-amx`. Full per-case tables in `crates/burn-flex/ARCHITECTURE.md`.

Headline speedups vs the serial baseline:

| Workload                               | rayon | +apple-amx | combined |
| -------------------------------------- | ----- | ---------- | -------- |
| matmul 1024x1024 f32                   | 7.0x  | 1.7x       | **12.2x** |
| conv2d first_layer 4x3x224x224 k7x7 s2 | 9.8x  | 1.2x       | **11.6x** |
| conv2d 16x128x64x64 k3x3               | 7.7x  | 1.5x       | **11.1x** |
| conv2d k7x7                            | 6.5x  | 1.4x       | 9.2x     |
| attention self b1_h32_s256_d128        | 1.0x  | 2.0x       | 2.0x     |

Caveats that justify keeping AMX opt-in (not default):
- Transposed-operand matmul regresses to ~0.55x vs rayon.
- Tiny shapes (e.g. `batch8_64x64` matmul, `depthwise_k3_8x32x512` conv1d) regress under rayon due to thread-spawn overhead.
- Attention ops do not currently propagate rayon parallelism to gemm; AMX still delivers its standalone win. Worth a follow-up.

## Test plan
- [x] `cargo check -p burn-flex` for each feature combo (`std,simd,rayon` default, `+x86-v4`, `+apple-amx`)
- [x] `cargo check -p burn --no-default-features --features flex,simd` and `flex,apple-amx`
- [x] `cargo bench -p burn-flex --bench {matmul,attention,conv_ops}` across all three configs