### PR TITLE
Implement mean for cube backends

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/float/ops/aggregation.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/aggregation.rs
@@ -580,3 +580,12 @@ fn test_sum_dim_4d_middle_dim() {
         .into_data()
         .assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
 }
+
+#[test]
+fn test_should_mean_overflow_intermediate_sum() {
+    let tensor = TestTensorInt::arange(0..1024, &Default::default()).float();
+    let output = tensor.mean();
+    output
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&TensorData::from([511.5]), Tolerance::default());
+}

--- a/crates/burn-backend-tests/tests/tensor/float/ops/cumulative.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/cumulative.rs
@@ -1,5 +1,8 @@
 use super::*;
-use burn_tensor::{ElementConversion, TensorData};
+use burn_tensor::TensorData;
+
+#[cfg(feature = "flex")]
+use burn_tensor::ElementConversion;
 
 #[test]
 fn test_cumsum_float_dim_0() {

--- a/crates/burn-cubecl/src/ops/tensor.rs
+++ b/crates/burn-cubecl/src/ops/tensor.rs
@@ -420,6 +420,16 @@ where
         .unwrap()
     }
 
+    fn float_mean(tensor: FloatTensor<Self>) -> FloatTensor<Self> {
+        reduce::reduce(
+            tensor,
+            None,
+            Default::default(),
+            ReduceOperationConfig::Mean,
+        )
+        .unwrap()
+    }
+
     fn float_cumsum(tensor: FloatTensor<Self>, dim: usize) -> FloatTensor<Self> {
         numeric::cumsum(tensor, dim)
     }


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Fixes https://github.com/tracel-ai/burn/issues/4770

### Changes

Override `float_mean`in  cubecl backends to call `reduce`, which already handles accumulating in full precision

### Testing

Unit tests
