### PR TITLE
Add Blackman window function to signal module

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -440,13 +440,13 @@ strategies.
 
 ## Signal Processing Functions
 
-| Burn API                                           | PyTorch Equivalent                     |  
-| -------------------------------------------------- | -------------------------------------- |  
-| `signal::blackman_window(size, periodic, options)` | `torch.blackman_window(size, periodic)`|
-| `signal::hamming_window(size, periodic, options)`  | `torch.hamming_window(size, periodic)` |
-| `signal::hann_window(size, periodic, options)`     | `torch.hann_window(size, periodic)`    |
-| `signal::irfft(spectrum_re, spectrum_im, dim)`     | `torch.fft.irfft(input, dim=dim)`      |
-| `signal::rfft(signal, dim)`                        | `torch.fft.rfft(signal, dim=dim)`      |  
+| Burn API                                           | PyTorch Equivalent                      |
+| -------------------------------------------------- | --------------------------------------- |
+| `signal::blackman_window(size, periodic, options)` | `torch.blackman_window(size, periodic)` |
+| `signal::hamming_window(size, periodic, options)`  | `torch.hamming_window(size, periodic)`  |
+| `signal::hann_window(size, periodic, options)`     | `torch.hann_window(size, periodic)`     |
+| `signal::irfft(spectrum_re, spectrum_im, dim)`     | `torch.fft.irfft(input, dim=dim)`       |
+| `signal::rfft(signal, dim)`                        | `torch.fft.rfft(signal, dim=dim)`       |
 
 ## Displaying Tensor Details
 

--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -440,13 +440,13 @@ strategies.
 
 ## Signal Processing Functions
 
-| Burn API                                           | PyTorch Equivalent                    |  
-| -------------------------------------------------- | ------------------------------------- |  
-| `signal::blackman_window(size, periodic, options)` | `torch.hamming_window(size, periodic)`|
-| `signal::hamming_window(size, periodic, options)`  | `torch.hamming_window(size, periodic)`|
-| `signal::hann_window(size, periodic, options)`     | `torch.hann_window(size, periodic)`   |
-| `signal::irfft(spectrum_re, spectrum_im, dim)`     | `torch.fft.irfft(input, dim=dim)`     |
-| `signal::rfft(signal, dim)`                        | `torch.fft.rfft(signal, dim=dim)`     |  
+| Burn API                                           | PyTorch Equivalent                     |  
+| -------------------------------------------------- | -------------------------------------- |  
+| `signal::blackman_window(size, periodic, options)` | `torch.blackman_window(size, periodic)`|
+| `signal::hamming_window(size, periodic, options)`  | `torch.hamming_window(size, periodic)` |
+| `signal::hann_window(size, periodic, options)`     | `torch.hann_window(size, periodic)`    |
+| `signal::irfft(spectrum_re, spectrum_im, dim)`     | `torch.fft.irfft(input, dim=dim)`      |
+| `signal::rfft(signal, dim)`                        | `torch.fft.rfft(signal, dim=dim)`      |  
 
 ## Displaying Tensor Details
 

--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -438,6 +438,16 @@ strategies.
 | `linalg::vector_norm(tensor, p, dim)`              | `torch.linalg.vector_norm(tensor, p, dim)`          |
 | `linalg::vector_normalize(tensor, norm, dim, eps)` | `nn.functional.normalize(tensor, p, dim, eps)`      |
 
+## Signal Processing Functions
+
+| Burn API                                           | PyTorch Equivalent                    |  
+| -------------------------------------------------- | ------------------------------------- |  
+| `signal::blackman_window(size, periodic, options)` | `torch.hamming_window(size, periodic)`|
+| `signal::hamming_window(size, periodic, options)`  | `torch.hamming_window(size, periodic)`|
+| `signal::hann_window(size, periodic, options)`     | `torch.hann_window(size, periodic)`   |
+| `signal::irfft(spectrum_re, spectrum_im, dim)`     | `torch.fft.irfft(input, dim=dim)`     |
+| `signal::rfft(signal, dim)`                        | `torch.fft.rfft(signal, dim=dim)`     |  
+
 ## Displaying Tensor Details
 
 Burn provides flexible options for displaying tensor information, allowing you to control the level

--- a/crates/burn-backend-tests/tests/tensor/float/ops/blackman_window.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/blackman_window.rs
@@ -75,10 +75,3 @@ fn test_blackman_window_size_8_symmetric() {
         .into_data()
         .assert_approx_eq::<FloatElem>(&expected, tolerance);
 }
-
-#[test]
-#[should_panic(expected = "The argument `size` should be less than or equal to `i64::MAX`.")]
-fn test_blackman_window_invalid_size_panics() {
-    let window_len = (i64::MAX as usize) + 1;
-    let _: TestTensor<1> = blackman_window(window_len, false, &Default::default());
-}

--- a/crates/burn-backend-tests/tests/tensor/float/ops/blackman_window.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/blackman_window.rs
@@ -40,14 +40,7 @@ fn should_handle_blackman_window_size_1_periodic() {
 fn should_support_blackman_window_size_8_periodic() {
     let tensor: TestTensor<1> = blackman_window(8, true, &Default::default());
     let expected = TensorData::from([
-        -2.9802e-08,
-        6.6447e-02,
-        3.4000e-01,
-        7.7355e-01,
-        1.0000e+00,
-        7.7355e-01,
-        3.4000e-01,
-        6.6447e-02,
+        0.0, 6.6447e-02, 3.4000e-01, 7.7355e-01, 1.0000e+00, 7.7355e-01, 3.4000e-01, 6.6447e-02,
     ]);
 
     // Positions 0 and 7 have values close to 0, hence setting absolute tolerance
@@ -61,14 +54,7 @@ fn should_support_blackman_window_size_8_periodic() {
 fn should_support_blackman_window_size_8_symmetric() {
     let tensor: TestTensor<1> = blackman_window(8, false, &Default::default());
     let expected = TensorData::from([
-        -2.9802e-08,
-        9.0453e-02,
-        4.5918e-01,
-        9.2036e-01,
-        9.2036e-01,
-        4.5918e-01,
-        9.0453e-02,
-        -2.9802e-08,
+        0.0, 9.0453e-02, 4.5918e-01, 9.2036e-01, 9.2036e-01, 4.5918e-01, 9.0453e-02, 0.0,
     ]);
 
     // Positions 0 and 7 have values close to 0, hence setting absolute tolerance

--- a/crates/burn-backend-tests/tests/tensor/float/ops/blackman_window.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/blackman_window.rs
@@ -1,0 +1,84 @@
+use super::*;
+use burn_tensor::signal::blackman_window;
+use burn_tensor::{DType, TensorData, Tolerance};
+
+#[test]
+fn test_blackman_window_options_dtype() {
+    let tensor: TestTensor<1> = blackman_window(4, true, (&Default::default(), DType::F32));
+    assert_eq!(tensor.dtype(), DType::F32);
+}
+
+#[test]
+fn test_blackman_window_size_0_symmetric() {
+    let tensor: TestTensor<1> = blackman_window(0, false, &Default::default());
+    assert_eq!(tensor.dims(), [0]);
+}
+
+#[test]
+fn test_blackman_window_size_0_periodic() {
+    let tensor: TestTensor<1> = blackman_window(0, true, &Default::default());
+    assert_eq!(tensor.dims(), [0]);
+}
+
+#[test]
+fn test_blackman_window_size_1_symmetric() {
+    let tensor: TestTensor<1> = blackman_window(1, false, &Default::default());
+    let expected = TensorData::from([1.0]);
+
+    tensor.into_data().assert_eq(&expected, false);
+}
+
+#[test]
+fn test_blackman_window_size_1_periodic() {
+    let tensor: TestTensor<1> = blackman_window(1, true, &Default::default());
+    let expected = TensorData::from([1.0]);
+
+    tensor.into_data().assert_eq(&expected, false);
+}
+
+#[test]
+fn test_blackman_window_size_8_periodic() {
+    let tensor: TestTensor<1> = blackman_window(8, true, &Default::default());
+    let expected = TensorData::from([
+        -2.9802e-08,
+        6.6447e-02,
+        3.4000e-01,
+        7.7355e-01,
+        1.0000e+00,
+        7.7355e-01,
+        3.4000e-01,
+        6.6447e-02,
+    ]);
+
+    let tolerance = Tolerance::default().set_half_precision_absolute(1e-3);
+    tensor
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, tolerance);
+}
+
+#[test]
+fn test_blackman_window_size_8_symmetric() {
+    let tensor: TestTensor<1> = blackman_window(8, false, &Default::default());
+    let expected = TensorData::from([
+        -2.9802e-08,
+        9.0453e-02,
+        4.5918e-01,
+        9.2036e-01,
+        9.2036e-01,
+        4.5918e-01,
+        9.0453e-02,
+        -2.9802e-08,
+    ]);
+
+    let tolerance = Tolerance::default().set_half_precision_absolute(1e-3);
+    tensor
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, tolerance);
+}
+
+#[test]
+#[should_panic(expected = "The argument `size` should be less than or equal to `i64::MAX`.")]
+fn test_blackman_window_invalid_size_panics() {
+    let window_len = (i64::MAX as usize) + 1;
+    let _: TestTensor<1> = blackman_window(window_len, false, &Default::default());
+}

--- a/crates/burn-backend-tests/tests/tensor/float/ops/blackman_window.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/blackman_window.rs
@@ -50,6 +50,7 @@ fn test_blackman_window_size_8_periodic() {
         6.6447e-02,
     ]);
 
+    // Positions 0 and 7 have values close to 0, hence setting absolute tolerance
     let tolerance = Tolerance::default().set_half_precision_absolute(1e-3);
     tensor
         .into_data()
@@ -70,6 +71,7 @@ fn test_blackman_window_size_8_symmetric() {
         -2.9802e-08,
     ]);
 
+    // Positions 0 and 7 have values close to 0, hence setting absolute tolerance
     let tolerance = Tolerance::default().set_half_precision_absolute(1e-3);
     tensor
         .into_data()

--- a/crates/burn-backend-tests/tests/tensor/float/ops/blackman_window.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/blackman_window.rs
@@ -3,25 +3,25 @@ use burn_tensor::signal::blackman_window;
 use burn_tensor::{DType, TensorData, Tolerance};
 
 #[test]
-fn test_blackman_window_options_dtype() {
+fn should_support_blackman_window_options_dtype() {
     let tensor: TestTensor<1> = blackman_window(4, true, (&Default::default(), DType::F32));
     assert_eq!(tensor.dtype(), DType::F32);
 }
 
 #[test]
-fn test_blackman_window_size_0_symmetric() {
+fn should_support_blackman_window_size_0_symmetric() {
     let tensor: TestTensor<1> = blackman_window(0, false, &Default::default());
     assert_eq!(tensor.dims(), [0]);
 }
 
 #[test]
-fn test_blackman_window_size_0_periodic() {
+fn should_support_blackman_window_size_0_periodic() {
     let tensor: TestTensor<1> = blackman_window(0, true, &Default::default());
     assert_eq!(tensor.dims(), [0]);
 }
 
 #[test]
-fn test_blackman_window_size_1_symmetric() {
+fn should_handle_blackman_window_size_1_symmetric() {
     let tensor: TestTensor<1> = blackman_window(1, false, &Default::default());
     let expected = TensorData::from([1.0]);
 
@@ -29,7 +29,7 @@ fn test_blackman_window_size_1_symmetric() {
 }
 
 #[test]
-fn test_blackman_window_size_1_periodic() {
+fn should_handle_blackman_window_size_1_periodic() {
     let tensor: TestTensor<1> = blackman_window(1, true, &Default::default());
     let expected = TensorData::from([1.0]);
 
@@ -37,7 +37,7 @@ fn test_blackman_window_size_1_periodic() {
 }
 
 #[test]
-fn test_blackman_window_size_8_periodic() {
+fn should_support_blackman_window_size_8_periodic() {
     let tensor: TestTensor<1> = blackman_window(8, true, &Default::default());
     let expected = TensorData::from([
         -2.9802e-08,
@@ -58,7 +58,7 @@ fn test_blackman_window_size_8_periodic() {
 }
 
 #[test]
-fn test_blackman_window_size_8_symmetric() {
+fn should_support_blackman_window_size_8_symmetric() {
     let tensor: TestTensor<1> = blackman_window(8, false, &Default::default());
     let expected = TensorData::from([
         -2.9802e-08,

--- a/crates/burn-backend-tests/tests/tensor/float/ops/mod.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/mod.rs
@@ -6,6 +6,7 @@ mod aggregation;
 mod all;
 mod any;
 mod arg;
+mod blackman_window;
 mod cast;
 mod cat;
 mod categorical;

--- a/crates/burn-tensor/src/tensor/signal/blackman_window.rs
+++ b/crates/burn-tensor/src/tensor/signal/blackman_window.rs
@@ -7,10 +7,18 @@ use crate::{Tensor, TensorCreationOptions, check, check::TensorCheck};
 
 /// Creates a 1D Blackman window tensor.
 ///
-/// # Equation
-/// The standard Blackman window is defined as:
-/// `w[n] = 0.42 - 0.5 * cos(2πn / N) + 0.08 * cos(4πn / N)`
-/// where `N` is `size` if periodic, or `size - 1` if symmetric.
+#[cfg_attr(
+    doc,
+    doc = r#"
+$$w_n = 0.42 - 0.5 \cos\left(\frac{2\pi n}{N}\right) + 0.08 \cos\left(\frac{4\pi n}{N}\right)$$
+
+where $N$ = `size` when `periodic` is `true`, or $N$ = `size - 1` when `periodic` is `false`.
+"#
+)]
+#[cfg_attr(
+    not(doc),
+    doc = "`w_n = 0.42 - 0.5 * cos(2πn / N) + 0.08 * cos(4πn / N)` where N = size (periodic) or N = size-1 (symmetric)"
+)]
 ///
 /// # Arguments
 /// - `size`: Size of the returned 1D window tensor.

--- a/crates/burn-tensor/src/tensor/signal/blackman_window.rs
+++ b/crates/burn-tensor/src/tensor/signal/blackman_window.rs
@@ -1,0 +1,83 @@
+use burn_backend::{Backend, tensor::Float};
+
+use crate::{Tensor, TensorCreationOptions, check, check::TensorCheck};
+
+/// Creates a 1D Blackman window tensor.
+///
+/// # Arguments
+/// - `size`: Size of the returned 1D window tensor.
+/// - `periodic`: If `true`, the window is treated as periodic (i.e., `N = size`).
+///   If `false`, the window is symmetric (i.e., `N = size - 1`).
+/// - `options`: Controls the output device and optional dtype. Accepts:
+///     - `&device` - uses the devices' default float dtype
+///     - `(&device, DType::F32)` - uses an explicit dtype
+///     - `TensorCreationOptions` directly for full control.
+///
+/// # Returns
+/// - A 1D tensor of shape `[size]` containing the window.
+///
+/// # Notes
+/// - If `size == 0`, the function returns an empty tensor.
+/// - If `size == 1`, the returned window contains a single value 1.0 which overrides the formula.
+///
+/// # Panics
+/// Panics if `size` exceeds `i64::MAX`.
+///
+/// # Example
+/// ```rust,ignore
+/// use burn_tensor::{backend::Backend, DType, signal::blackman_window};
+///
+/// fn example<B: Backend>() {
+///     // Creating a window with default dtype
+///     let device = B::Device::default();
+///     let window_tensor = blackman_window::<B>(5, true, &device);
+///     // Output: [0.0, 0.20077015, 0.84922993, 0.8492298, 0.2007701]
+///
+///     // Creating a window with explicit dtype
+///     let device = B::Device::default();
+///     let window_tensor_f64 = blackman_window::<B>(5, true, (&device, DType::F64));
+///     // Output: [0.0, 0.20077015, 0.84922993, 0.8492298, 0.2007701]
+/// }
+/// ```
+pub fn blackman_window<B: Backend>(
+    size: usize,
+    periodic: bool,
+    options: impl Into<TensorCreationOptions<B>>,
+) -> Tensor<B, 1> {
+    let opt = options.into();
+    let dtype = opt.resolve_dtype::<Float>();
+    let shape = [size];
+    check!(TensorCheck::creation_ops::<1>(
+        "signal::blackman_window",
+        &shape
+    ));
+
+    if size == 0 {
+        return Tensor::<B, 1>::empty(shape, opt).cast(dtype);
+    }
+
+    if size == 1 {
+        return Tensor::<B, 1>::ones(shape, opt).cast(dtype);
+    }
+
+    let size_i64 = i64::try_from(size)
+        .expect("The argument `size` should be less than or equal to `i64::MAX`.");
+    let denominator = if periodic { size } else { size - 1 };
+    let angular_increment = (2.0 * core::f64::consts::PI) / denominator as f64;
+    let cos_val = Tensor::arange(0..size_i64, &opt.device)
+        .float()
+        .mul_scalar(angular_increment)
+        .cos();
+
+    // Using the double angle property of cosine: cos(2θ) = 2cos^2(θ) - 1
+    // w[n] = 0.42 - 0.5cos(2πn / (N - 1)) + 0.08cos(4πn / (N - 1))
+    // w[n] = 0.42 - 0.5cos(2πn / (N - 1)) + 0.08cos(2 * (2πn / (N - 1)))
+    // w[n] = 0.42 - 0.5cos(2πn / (N - 1)) + 0.08(2cos^2(2πn / (N - 1)) - 1)
+    // w[n] = 0.34 - 0.5cos(2πn / (N - 1)) + 0.16cos^2(2πn / (N - 1))
+    let first_cos_term = cos_val.clone().mul_scalar(-0.5);
+    let second_cos_term = cos_val.powi_scalar(2).mul_scalar(0.16);
+    first_cos_term
+        .add(second_cos_term)
+        .add_scalar(0.34)
+        .cast(dtype)
+}

--- a/crates/burn-tensor/src/tensor/signal/blackman_window.rs
+++ b/crates/burn-tensor/src/tensor/signal/blackman_window.rs
@@ -75,8 +75,7 @@ pub fn blackman_window<B: Backend>(
         return Tensor::<B, 1>::ones(shape, opt).cast(dtype);
     }
 
-    let size_i64 = i64::try_from(size)
-        .expect("The argument `size` should be less than or equal to `i64::MAX`.");
+    let size_i64 = i64::try_from(size).expect("BlackmanWindow size doesn't fit in i64 range.");
     let denominator = if periodic { size } else { size - 1 };
     let angular_increment = (2.0 * core::f64::consts::PI) / denominator as f64;
     let cos_val = Tensor::<B, 1, Int>::arange(0..size_i64, &opt.device)

--- a/crates/burn-tensor/src/tensor/signal/blackman_window.rs
+++ b/crates/burn-tensor/src/tensor/signal/blackman_window.rs
@@ -49,7 +49,9 @@ where $N$ = `size` when `periodic` is `true`, or $N$ = `size - 1` when `periodic
 ///     let window_tensor = blackman_window::<B>(5, true, &device);
 ///     // Output: [0.0, 0.20077015, 0.84922993, 0.8492298, 0.2007701]
 ///
-///     // Creating a window with explicit dtype
+///     // Creating a window with explicit dtype.
+///     // Note that this does not perform the computation at higher precision but it
+///     // widens the storage of the returned tensor to F64.
 ///     let device = B::Device::default();
 ///     let window_tensor_f64 = blackman_window::<B>(5, true, (&device, DType::F64));
 ///     // Output: [0.0, 0.20077015, 0.84922993, 0.8492298, 0.2007701]

--- a/crates/burn-tensor/src/tensor/signal/blackman_window.rs
+++ b/crates/burn-tensor/src/tensor/signal/blackman_window.rs
@@ -1,4 +1,7 @@
-use burn_backend::{Backend, tensor::Float};
+use burn_backend::{
+    Backend,
+    tensor::{Float, Int},
+};
 
 use crate::{Tensor, TensorCreationOptions, check, check::TensorCheck};
 
@@ -29,7 +32,7 @@ use crate::{Tensor, TensorCreationOptions, check, check::TensorCheck};
 /// Panics if `size` exceeds `i64::MAX`.
 ///
 /// # Example
-/// ```rust,ignore
+/// ```rust
 /// use burn_tensor::{backend::Backend, DType, signal::blackman_window};
 ///
 /// fn example<B: Backend>() {
@@ -52,10 +55,7 @@ pub fn blackman_window<B: Backend>(
     let opt = options.into();
     let dtype = opt.resolve_dtype::<Float>();
     let shape = [size];
-    check!(TensorCheck::creation_ops::<1>(
-        "signal::blackman_window",
-        &shape
-    ));
+    check!(TensorCheck::creation_ops::<1>("BlackmanWindow", &shape));
 
     if size == 0 {
         return Tensor::<B, 1>::empty(shape, opt).cast(dtype);
@@ -69,16 +69,16 @@ pub fn blackman_window<B: Backend>(
         .expect("The argument `size` should be less than or equal to `i64::MAX`.");
     let denominator = if periodic { size } else { size - 1 };
     let angular_increment = (2.0 * core::f64::consts::PI) / denominator as f64;
-    let cos_val = Tensor::arange(0..size_i64, &opt.device)
+    let cos_val = Tensor::<B, 1, Int>::arange(0..size_i64, &opt.device)
         .float()
         .mul_scalar(angular_increment)
         .cos();
 
     // Using the double angle property of cosine: cos(2θ) = 2cos^2(θ) - 1
-    // w[n] = 0.42 - 0.5cos(2πn / (N - 1)) + 0.08cos(4πn / (N - 1))
-    // w[n] = 0.42 - 0.5cos(2πn / (N - 1)) + 0.08cos(2 * (2πn / (N - 1)))
-    // w[n] = 0.42 - 0.5cos(2πn / (N - 1)) + 0.08(2cos^2(2πn / (N - 1)) - 1)
-    // w[n] = 0.34 - 0.5cos(2πn / (N - 1)) + 0.16cos^2(2πn / (N - 1))
+    // w[n] = 0.42 - 0.5cos(2πn / N) + 0.08cos(4πn / N)
+    // w[n] = 0.42 - 0.5cos(2πn / N) + 0.08cos(2 * (2πn / N))
+    // w[n] = 0.42 - 0.5cos(2πn / N) + 0.08(2cos^2(2πn / N) - 1)
+    // w[n] = 0.34 - 0.5cos(2πn / N) + 0.16cos^2(2πn / N)
     let first_cos_term = cos_val.clone().mul_scalar(-0.5);
     let second_cos_term = cos_val.powi_scalar(2).mul_scalar(0.16);
     first_cos_term

--- a/crates/burn-tensor/src/tensor/signal/blackman_window.rs
+++ b/crates/burn-tensor/src/tensor/signal/blackman_window.rs
@@ -4,6 +4,11 @@ use crate::{Tensor, TensorCreationOptions, check, check::TensorCheck};
 
 /// Creates a 1D Blackman window tensor.
 ///
+/// # Equation
+/// The standard Blackman window is defined as:
+/// `w[n] = 0.42 - 0.5 * cos(2πn / N) + 0.08 * cos(4πn / N)`
+/// where `N` is `size` if periodic, or `size - 1` if symmetric.
+///
 /// # Arguments
 /// - `size`: Size of the returned 1D window tensor.
 /// - `periodic`: If `true`, the window is treated as periodic (i.e., `N = size`).

--- a/crates/burn-tensor/src/tensor/signal/blackman_window.rs
+++ b/crates/burn-tensor/src/tensor/signal/blackman_window.rs
@@ -25,7 +25,7 @@ where $N$ = `size` when `periodic` is `true`, or $N$ = `size - 1` when `periodic
 /// - `periodic`: If `true`, the window is treated as periodic (i.e., `N = size`).
 ///   If `false`, the window is symmetric (i.e., `N = size - 1`).
 /// - `options`: Controls the output device and optional dtype. Accepts:
-///     - `&device` - uses the devices' default float dtype
+///     - `&device` - uses the device's default float dtype
 ///     - `(&device, DType::F32)` - uses an explicit dtype
 ///     - `TensorCreationOptions` directly for full control.
 ///

--- a/crates/burn-tensor/src/tensor/signal/mod.rs
+++ b/crates/burn-tensor/src/tensor/signal/mod.rs
@@ -1,7 +1,9 @@
+mod blackman_window;
 mod fft;
 mod hamming_window;
 mod hann_window;
 
+pub use blackman_window::*;
 pub use fft::*;
 pub use hamming_window::*;
 pub use hann_window::*;


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Related to [Implement signal processing operators (DFT, STFT, MelWeightMatrix, window functions) #161](https://github.com/tracel-ai/burn-onnx/issues/161) and closes [Add Blackman window to signal module #4783](https://github.com/tracel-ai/burn/issues/4783)

### Changes

Added Blackman window function using the following formula instead to only compute cosine once instead of twice from the original formula.

$$
\begin{aligned}
w[n] &= 0.42 - 0.5\cos\left(\frac{2\pi n}{N - 1}\right) + 0.08\cos\left(\frac{4\pi n}{N - 1}\right) \\
w[n] &= 0.42 - 0.5\cos\left(\frac{2\pi n}{N - 1}\right) + 0.08\cos\left(2 \left(\frac{2\pi n}{N - 1}\right)\right) \\
w[n] &= 0.42 - 0.5\cos\left(\frac{2\pi n}{N - 1}\right) + 0.08\left(2\cos^2\left(\frac{2\pi n}{N - 1}\right) - 1\right) \\
w[n] &= 0.34 - 0.5\cos\left(\frac{2\pi n}{N - 1}\right) + 0.16\cos^2\left(\frac{2\pi n}{N - 1}\right)
\end{aligned}
$$

### Testing

Added 8 test cases covering sizes of 0, 1, and 8 with `periodic` set to `true` and `false`, explicitly setting dtype, and panics. 
