### PR TITLE
CI failure fix  for burn-flex to_contiguous fast path for prefix views

### DIFF
--- a/crates/burn-flex/src/tensor.rs
+++ b/crates/burn-flex/src/tensor.rs
@@ -289,7 +289,15 @@ impl FlexTensor {
 
     /// Copy to contiguous layout if needed.
     pub fn to_contiguous(&self) -> Self {
-        if self.is_contiguous() && self.layout.start_offset() == 0 {
+        // Fast path requires the logical tensor to cover the whole buffer.
+        // A contiguous prefix view (e.g. [8, 5] sliced to [5, 5]) has
+        // canonical strides and offset 0 but an oversized buffer, and would
+        // otherwise mislead callers that read `storage()` / `bytes()` by
+        // length (e.g. the SIMD `mask_fill_*` kernels).
+        if self.is_contiguous()
+            && self.layout.start_offset() == 0
+            && self.data.len() == self.layout.num_elements() * dtype_size(self.dtype)
+        {
             return self.clone();
         }
 
@@ -693,6 +701,33 @@ mod tests {
         assert_eq!(contig.shape().to_vec(), vec![0]);
         assert_eq!(contig.layout().start_offset(), 0);
         assert_eq!(contig.into_data().bytes.len(), 0);
+    }
+
+    /// Regression for #4855: a prefix view (e.g. `narrow(dim, 0, n)`) has
+    /// canonical contiguous strides and start_offset 0, but its underlying
+    /// buffer is still the larger original. `to_contiguous` must materialize
+    /// a right-sized copy so callers keying off `storage().len()` (like the
+    /// SIMD `mask_fill_*` kernels reached from `triu`/`tril` in LU on tall
+    /// matrices) don't walk past the logical shape.
+    #[test]
+    fn test_to_contiguous_prefix_view_shrinks_buffer() {
+        let data: Vec<f32> = (0..40).map(|i| i as f32).collect();
+        let t = FlexTensor::from_data(TensorData::new(data, vec![8, 5]));
+
+        let prefix = t.narrow(0, 0, 5);
+        assert_eq!(prefix.shape().to_vec(), vec![5, 5]);
+        assert_eq!(prefix.layout().strides(), &[5, 1]);
+        assert_eq!(prefix.layout().start_offset(), 0);
+        assert!(prefix.is_contiguous());
+        assert_eq!(prefix.storage::<f32>().len(), 40);
+
+        let contig = prefix.to_contiguous();
+        assert_eq!(contig.storage::<f32>().len(), 25);
+        assert_eq!(contig.layout().num_elements(), 25);
+        assert_eq!(
+            contig.storage::<f32>(),
+            &(0..5).flat_map(|r| (0..5).map(move |c| (r * 5 + c) as f32)).collect::<Vec<_>>()[..]
+        );
     }
 
     /// 4D permuted layout round-trips through the collapse + tiled

--- a/crates/burn-flex/src/tensor.rs
+++ b/crates/burn-flex/src/tensor.rs
@@ -726,7 +726,9 @@ mod tests {
         assert_eq!(contig.layout().num_elements(), 25);
         assert_eq!(
             contig.storage::<f32>(),
-            &(0..5).flat_map(|r| (0..5).map(move |c| (r * 5 + c) as f32)).collect::<Vec<_>>()[..]
+            &(0..5)
+                .flat_map(|r| (0..5).map(move |c| (r * 5 + c) as f32))
+                .collect::<Vec<_>>()[..]
         );
     }
 


### PR DESCRIPTION
Fixes #4855.

### Root cause
A contiguous prefix view (e.g. `[8, 5].narrow(0, 0, 5)` or `lu_tensor.slice_dim(D-2, 0..n_cols)`) has canonical strides `[5, 1]` and `start_offset == 0`, but its backing buffer is still the 40-element original. The old `to_contiguous` fast path returned `self.clone()` in this case, leaving callers that key off `storage().len()` / `bytes().len()` reading past the logical shape. The SIMD `mask_fill_*` kernels in `burn-flex/src/ops/mask.rs` (reached from `triu`/`tril` in LU on tall matrices) tripped on this and panicked with `index out of bounds` / `assertion left == right`.

### Fix
Add `data.len() == num_elements * dtype_size(dtype)` to the fast path. Mismatched sizes fall through to `copy_contiguous`, which materializes a right-sized buffer. This matches the invariant `into_data` already enforces on the same struct (it has an explicit `else` branch that truncates oversized buffers).

### Verification
- The three failing tests (`test_lu_2d_tall`, `test_lu_medium_tall`, `test_lu_500x300_block_dispatch`) now pass.
- Full `burn-flex` suite (339 tests) and `burn-backend-tests --features flex` (1304 tensor + 428 + 901) all pass.
- Added `test_to_contiguous_prefix_view_shrinks_buffer` as a unit-level regression; verified it fails on the pre-fix code with `left: 40, right: 25`.