### PR TITLE
Fix burn-flex sum_dim reading contiguous storage on transposed input

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/float/ops/aggregation.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/aggregation.rs
@@ -468,16 +468,16 @@ fn test_multiple_reduce_dims_permuted() {
 
 #[test]
 fn test_sum_transposed() {
-    // Stress the sum kernel on a non-contiguous (transposed) input. Uses
-    // total reduction so the assertion doesn't depend on traversal order;
-    // a stronger per-axis variant would require flex issue #4816 to be
-    // resolved first.
+    // Stress the sum kernel on a non-contiguous (transposed) input. Reducing
+    // the (now last) dim with stride != 1 previously hit a fast path that
+    // read contiguous storage, producing sliding-pair sums instead of column
+    // sums.
     let tensor = TestTensor::<2>::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
-    let output = tensor.transpose().sum();
+    let output = tensor.transpose().sum_dim(1);
 
     output
         .into_data()
-        .assert_eq(&TensorData::from([21.0]), false);
+        .assert_eq(&TensorData::from([[5.0], [7.0], [9.0]]), false);
 }
 
 #[test]

--- a/crates/burn-backend-tests/tests/tensor/float/ops/aggregation.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/aggregation.rs
@@ -236,6 +236,10 @@ fn test_sum_dim_1_reshape_maybe_fused() {
 
 #[test]
 fn test_sum_dim_1_swap_dims_maybe_fused() {
+    // Note: the `+ 2` elementwise op materializes a contiguous intermediate,
+    // so the subsequent sum_dim sees contiguous strides - it does not
+    // exercise the transposed-reduce-last-dim path. That path is covered
+    // by `test_sum_transposed`.
     let tensor = TestTensorInt::arange(0..9, &Default::default()).float();
     let tensor = tensor.reshape([3, 3]);
     TestBackend::sync(&tensor.device()).unwrap();
@@ -478,6 +482,31 @@ fn test_sum_transposed() {
     output
         .into_data()
         .assert_eq(&TensorData::from([[5.0], [7.0], [9.0]]), false);
+}
+
+#[test]
+fn test_prod_dim_transposed() {
+    // Same fast-path gate as sum_dim: prod_dim on a transposed 2D input must
+    // honor the reduce-dim stride.
+    let tensor = TestTensor::<2>::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+    let output = tensor.transpose().prod_dim(1);
+
+    output.into_data().assert_approx_eq::<FloatElem>(
+        &TensorData::from([[4.0], [10.0], [18.0]]),
+        Tolerance::default(),
+    );
+}
+
+#[test]
+fn test_mean_dim_transposed() {
+    // mean_dim routes through sum_dim, so it inherits the same gate.
+    let tensor = TestTensor::<2>::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+    let output = tensor.transpose().mean_dim(1);
+
+    output.into_data().assert_approx_eq::<FloatElem>(
+        &TensorData::from([[2.5], [3.5], [4.5]]),
+        Tolerance::default(),
+    );
 }
 
 #[test]

--- a/crates/burn-flex/src/ops/reduce.rs
+++ b/crates/burn-flex/src/ops/reduce.rs
@@ -790,8 +790,12 @@ fn reduce_dim_f32(tensor: &FlexTensor, dim: usize, op: ReduceOp) -> FlexTensor {
     // Check if inner dimension is contiguous (stride = 1) and no negative strides
     let inner_contiguous = !has_negative_strides && (dim + 1 >= ndims || strides[ndims - 1] == 1);
 
-    let result: Vec<f32> = if inner_contiguous && dim == ndims - 1 {
-        // Reducing last dimension with contiguous data: use SIMD
+    let result: Vec<f32> = if inner_contiguous && dim == ndims - 1 && dim_stride == 1 {
+        // Reducing last dimension with contiguous data: use SIMD.
+        // `reduce_last_dim_f32` reads each row as `&data[start..start + dim_size]`,
+        // which only matches the logical row when the reduce dim itself has
+        // stride 1. Transposed views (e.g. shape [3,2] strides [1,3]) would
+        // otherwise read contiguous storage and return wrong sums.
         reduce_last_dim_f32(data, start_offset, outer_size, dim_size, strides, dim, op)
     } else if dim == 0 && inner_contiguous && matches!(op, ReduceOp::Sum) {
         // First-dim reduction with contiguous inner: use cache-friendly accumulation


### PR DESCRIPTION
## Summary
- `reduce_dim_f32` routed any last-dim reduction into `reduce_last_dim_f32` via a vacuously-true `inner_contiguous` check, but that kernel reads each row as `&data[start..start + dim_size]` and only matches the logical row when the reduce dim itself has stride 1. Transposed 2D views (shape `[3,2]` strides `[1,3]`) fell in and returned sliding-pair sums of raw storage instead of column sums.
- Fix: add `&& dim_stride == 1` to the gate so transposed-then-reduce-last-dim tensors fall through to the existing strided fallback.
- Same gate covers `prod_dim`/`mean_dim` f32; added regression tests for all three.

Fixes #4816.

## Test plan
- [x] `cargo test -p burn-backend-tests --features flex --test tensor` (1306 pass, +3 new regression tests)
- [x] `cargo test -p burn-flex --lib` (341 pass)
- [x] Verified all three new tests fail with the fix reverted