### PR TITLE
Centralize internal burn-* crates in [workspace.dependencies]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,6 +182,42 @@ portable-atomic = { version = "1.13.1" }
 portable-atomic-util = { version = "0.2.6", features = ["alloc"] }
 realfft = "3"
 
+### Internal burn crates ###
+# Declared here so each consumer Cargo.toml can use `workspace = true` instead of
+# repeating the path and version.
+burn = { path = "crates/burn", version = "=0.21.0-pre.3", default-features = false }
+burn-autodiff = { path = "crates/burn-autodiff", version = "=0.21.0-pre.3", default-features = false }
+burn-backend = { path = "crates/burn-backend", version = "=0.21.0-pre.3", default-features = false }
+burn-candle = { path = "crates/burn-candle", version = "=0.21.0-pre.3", default-features = false }
+burn-collective = { path = "crates/burn-collective", version = "=0.21.0-pre.3", default-features = false }
+burn-communication = { path = "crates/burn-communication", version = "=0.21.0-pre.3", default-features = false }
+burn-core = { path = "crates/burn-core", version = "=0.21.0-pre.3", default-features = false }
+burn-cpu = { path = "crates/burn-cpu", version = "=0.21.0-pre.3", default-features = false }
+burn-cubecl = { path = "crates/burn-cubecl", version = "=0.21.0-pre.3", default-features = false }
+burn-cubecl-fusion = { path = "crates/burn-cubecl-fusion", version = "=0.21.0-pre.3", default-features = false }
+burn-cuda = { path = "crates/burn-cuda", version = "=0.21.0-pre.3", default-features = false }
+burn-dataset = { path = "crates/burn-dataset", version = "=0.21.0-pre.3", default-features = false }
+burn-derive = { path = "crates/burn-derive", version = "=0.21.0-pre.3", default-features = false }
+burn-dispatch = { path = "crates/burn-dispatch", version = "=0.21.0-pre.3", default-features = false }
+burn-flex = { path = "crates/burn-flex", version = "=0.21.0-pre.3", default-features = false }
+burn-fusion = { path = "crates/burn-fusion", version = "=0.21.0-pre.3", default-features = false }
+burn-ir = { path = "crates/burn-ir", version = "=0.21.0-pre.3", default-features = false }
+burn-ndarray = { path = "crates/burn-ndarray", version = "=0.21.0-pre.3", default-features = false }
+burn-nn = { path = "crates/burn-nn", version = "=0.21.0-pre.3", default-features = false }
+burn-optim = { path = "crates/burn-optim", version = "=0.21.0-pre.3", default-features = false }
+burn-remote = { path = "crates/burn-remote", version = "=0.21.0-pre.3", default-features = false }
+burn-rl = { path = "crates/burn-rl", version = "=0.21.0-pre.3", default-features = false }
+burn-rocm = { path = "crates/burn-rocm", version = "=0.21.0-pre.3", default-features = false }
+burn-router = { path = "crates/burn-router", version = "=0.21.0-pre.3", default-features = false }
+burn-std = { path = "crates/burn-std", version = "=0.21.0-pre.3", default-features = false }
+burn-store = { path = "crates/burn-store", version = "=0.21.0-pre.3", default-features = false }
+burn-tch = { path = "crates/burn-tch", version = "=0.21.0-pre.3", default-features = false }
+burn-tensor = { path = "crates/burn-tensor", version = "=0.21.0-pre.3", default-features = false }
+burn-tensor-testgen = { path = "crates/burn-tensor-testgen", version = "=0.21.0-pre.3", default-features = false }
+burn-train = { path = "crates/burn-train", version = "=0.21.0-pre.3", default-features = false }
+burn-vision = { path = "crates/burn-vision", version = "=0.21.0-pre.3", default-features = false }
+burn-wgpu = { path = "crates/burn-wgpu", version = "=0.21.0-pre.3", default-features = false }
+
 ### For the main burn branch. ###
 cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "21c97057491dd8d06157897d30072e79179237c7" }
 cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "21c97057491dd8d06157897d30072e79179237c7" }

--- a/crates/burn-autodiff/Cargo.toml
+++ b/crates/burn-autodiff/Cargo.toml
@@ -28,8 +28,8 @@ tracing = [
 distributed = ["std", "burn-backend/distributed"]
 
 [dependencies]
-burn-std = { path = "../burn-std", version = "=0.21.0-pre.3", default-features = false }
-burn-backend = { path = "../burn-backend", version = "=0.21.0-pre.3", default-features = false }
+burn-std = { workspace = true }
+burn-backend = { workspace = true }
 
 
 derive-new = { workspace = true }

--- a/crates/burn-backend-tests/Cargo.toml
+++ b/crates/burn-backend-tests/Cargo.toml
@@ -58,9 +58,9 @@ cube = [
 quantization = []
 
 [dependencies]
-burn-tensor = { path = "../burn-tensor", version = "=0.21.0-pre.3", default-features = false }
-burn-tensor-testgen = { path = "../burn-tensor-testgen", version = "=0.21.0-pre.3" }
-burn-dispatch = { path = "../burn-dispatch", version = "=0.21.0-pre.3", default-features = false, features = [
+burn-tensor = { workspace = true }
+burn-tensor-testgen = { workspace = true }
+burn-dispatch = { workspace = true, features = [
     "autodiff",
 ] }
 
@@ -68,15 +68,16 @@ burn-dispatch = { path = "../burn-dispatch", version = "=0.21.0-pre.3", default-
 cubek = { workspace = true, features = ["random"], optional = true }
 
 # Explicitly enable test-only checks
-burn-autodiff = { path = "../burn-autodiff", version = "=0.21.0-pre.3", default-features = false, features = [
+burn-autodiff = { workspace = true, features = [
     "export_tests",
 ] }
-burn-ndarray = { path = "../burn-ndarray", version = "=0.21.0-pre.3", optional = true, default-features = false, features = [
+burn-ndarray = { workspace = true, optional = true, features = [
     "export_tests",
 ] }
 
 # Manually enable so running the tests again with fusion feature doesn't have to compile other crates
-burn-cubecl = { path = "../burn-cubecl", version = "=0.21.0-pre.3", optional = true, features = [
+burn-cubecl = { workspace = true, optional = true, features = [
+    "default",
     "fusion",
 ] }
 

--- a/crates/burn-backend/Cargo.toml
+++ b/crates/burn-backend/Cargo.toml
@@ -32,7 +32,7 @@ cubecl-wgpu = ["cubecl", "cubecl/wgpu"]
 cubecl-cpu = ["cubecl", "cubecl/cpu"]
 
 [dependencies]
-burn-std = { path = "../burn-std", version = "=0.21.0-pre.3", default-features = false }
+burn-std = { workspace = true }
 cubecl = { workspace = true, optional = true, default-features = false }
 
 bytemuck = { workspace = true, features = ["extern_crate_alloc"] }
@@ -53,5 +53,5 @@ portable-atomic-util = { workspace = true }
 [dev-dependencies]
 rand = { workspace = true, features = ["thread_rng"] }
 paste = { workspace = true }
-serde_json = { workspace = true, features = ["alloc"]}
+serde_json = { workspace = true, features = ["alloc"] }
 serial_test = { workspace = true }

--- a/crates/burn-candle/Cargo.toml
+++ b/crates/burn-candle/Cargo.toml
@@ -28,16 +28,15 @@ metal = ["candle-core/metal"]
 accelerate = ["candle-core/accelerate"]
 
 [dependencies]
-burn-backend = { path = "../burn-backend", version = "=0.21.0-pre.3", default-features = false }
+burn-backend = { workspace = true }
 # For rand utils and stub mutex
-burn-std = { path = "../burn-std", version = "=0.21.0-pre.3", default-features = false }
+burn-std = { workspace = true }
 
 candle-core = { workspace = true }
 derive-new = { workspace = true }
 
 [dev-dependencies]
-burn-tch = { path = "../burn-tch", version = "=0.21.0-pre.3", default-features = false, features = [
-] }
+burn-tch = { workspace = true }
 
 [package.metadata.docs.rs]
 features = ["doc"]

--- a/crates/burn-collective/Cargo.toml
+++ b/crates/burn-collective/Cargo.toml
@@ -32,12 +32,12 @@ test-vulkan = []
 cubecl = []
 
 [dependencies]
-burn-backend = { path = "../burn-backend", version = "=0.21.0-pre.3", default-features = true }
-burn-std = { path = "../burn-std", version = "=0.21.0-pre.3", default-features = true }
+burn-backend = { workspace = true, features = ["default"] }
+burn-std = { workspace = true, features = ["default"] }
 
 log = { workspace = true }
 
-burn-communication = { path = "../burn-communication", version = "=0.21.0-pre.3", features = [
+burn-communication = { workspace = true, features = [
     "data-service",
     "websocket",
 ] }
@@ -58,10 +58,10 @@ tracing = { workspace = true, optional = true }
 [dev-dependencies]
 serial_test = { workspace = true }
 # Tests
-burn-tensor = { path = "../burn-tensor", version = "=0.21.0-pre.3", default-features = true }
-burn-flex = { path = "../burn-flex", version = "=0.21.0-pre.3" }
-burn-wgpu = { path = "../burn-wgpu", version = "=0.21.0-pre.3" }
-burn-cuda = { path = "../burn-cuda", version = "=0.21.0-pre.3" }
+burn-tensor = { workspace = true, features = ["default"] }
+burn-flex = { workspace = true, features = ["default"] }
+burn-wgpu = { workspace = true, features = ["default"] }
+burn-cuda = { workspace = true, features = ["default"] }
 
 
 [package.metadata.docs.rs]

--- a/crates/burn-collective/multinode-tests/Cargo.toml
+++ b/crates/burn-collective/multinode-tests/Cargo.toml
@@ -9,10 +9,10 @@ default = ["flex"]
 flex = ["burn/flex"]
 
 [dependencies]
-burn = { path = "../../burn", default-features = false, features = ["std"] }
-burn-std = { path = "../../burn-std", default-features = false }
-burn-collective = { path = "..", features = ["orchestrator"] }
-burn-communication = { path = "../../burn-communication" }
+burn = { workspace = true, features = ["std"] }
+burn-std = { workspace = true }
+burn-collective = { workspace = true, features = ["default", "orchestrator"] }
+burn-communication = { workspace = true }
 
 tokio = { workspace = true, features = ["rt-multi-thread", "process"] }
 

--- a/crates/burn-communication/Cargo.toml
+++ b/crates/burn-communication/Cargo.toml
@@ -21,7 +21,7 @@ data-service = ["burn-tensor"]
 websocket = ["axum", "tokio-tungstenite", "futures"]
 
 [dependencies]
-burn-std = { path = "../burn-std", version = "=0.21.0-pre.3", default-features = true }
+burn-std = { workspace = true, features = ["default"] }
 bytes = { workspace = true }
 derive-new = { workspace = true }
 futures-util = { workspace = true }
@@ -36,7 +36,7 @@ tracing-core = { workspace = true, features = ["default"] }
 tracing-subscriber = { workspace = true, features = ["default", "fmt", "env-filter"] }
 
 # Tensor Data Service
-burn-tensor = { path = "../burn-tensor", version = "=0.21.0-pre.3", optional = true }
+burn-tensor = { workspace = true, optional = true, features = ["default"] }
 
 # Websocket
 axum = { workspace = true, features = ["ws"], optional = true }

--- a/crates/burn-core/Cargo.toml
+++ b/crates/burn-core/Cargo.toml
@@ -95,10 +95,10 @@ test-memory-checks = ["burn-fusion/memory-checks"]
 
 # ** Please make sure all dependencies support no_std when std is disabled **
 
-burn-std = { path = "../burn-std", version = "=0.21.0-pre.3", default-features = false }
-burn-dataset = { path = "../burn-dataset", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-derive = { path = "../burn-derive", version = "=0.21.0-pre.3" }
-burn-tensor = { path = "../burn-tensor", version = "=0.21.0-pre.3", default-features = false }
+burn-std = { workspace = true }
+burn-dataset = { workspace = true, optional = true }
+burn-derive = { workspace = true }
+burn-tensor = { workspace = true }
 
 data-encoding = { workspace = true }
 uuid = { workspace = true }
@@ -127,22 +127,23 @@ thiserror = { workspace = true, optional = true }
 regex = { workspace = true }
 
 # FOR TESTING
-burn-cuda = { path = "../burn-cuda", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-rocm = { path = "../burn-rocm", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-remote = { path = "../burn-remote", version = "=0.21.0-pre.3", default-features = false, optional = true }
-burn-router = { path = "../burn-router", version = "=0.21.0-pre.3", default-features = false, optional = true }
-burn-tch = { path = "../burn-tch", version = "=0.21.0-pre.3", optional = true }
-burn-wgpu = { path = "../burn-wgpu", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-fusion = { path = "../burn-fusion", version = "=0.21.0-pre.3", optional = true }
+burn-cuda = { workspace = true, optional = true }
+burn-rocm = { workspace = true, optional = true }
+burn-remote = { workspace = true, optional = true }
+burn-router = { workspace = true, optional = true }
+burn-tch = { workspace = true, optional = true, features = ["default"] }
+burn-wgpu = { workspace = true, optional = true }
+burn-fusion = { workspace = true, optional = true, features = ["default"] }
 
 [target.'cfg(not(target_has_atomic = "ptr"))'.dependencies]
 portable-atomic-util = { workspace = true }
 portable-atomic = { workspace = true }
 
 [dev-dependencies]
-burn-flex = { path = "../burn-flex", version = "=0.21.0-pre.3" }
-burn-autodiff = { path = "../burn-autodiff", version = "=0.21.0-pre.3" }
-burn-dataset = { path = "../burn-dataset", version = "=0.21.0-pre.3", features = [
+burn-flex = { workspace = true, features = ["default"] }
+burn-autodiff = { workspace = true, features = ["default"] }
+burn-dataset = { workspace = true, features = [
+    "default",
     "fake",
 ] }
 rstest = { workspace = true }

--- a/crates/burn-cpu/Cargo.toml
+++ b/crates/burn-cpu/Cargo.toml
@@ -30,9 +30,10 @@ autotune = ["burn-cubecl/autotune"]
 autotune-checks = ["burn-cubecl/autotune-checks"]
 
 [dependencies]
-burn-fusion = { path = "../burn-fusion", version = "=0.21.0-pre.3", optional = true }
-burn-cubecl = { path = "../burn-cubecl", version = "=0.21.0-pre.3", default-features = false }
-burn-backend = { path = "../burn-backend", version = "=0.21.0-pre.3", features = [
+burn-fusion = { workspace = true, optional = true, features = ["default"] }
+burn-cubecl = { workspace = true }
+burn-backend = { workspace = true, features = [
+    "default",
     "cubecl-cpu",
 ] }
 cubecl = { workspace = true, features = ["cpu"] }

--- a/crates/burn-cubecl-fusion/Cargo.toml
+++ b/crates/burn-cubecl-fusion/Cargo.toml
@@ -29,9 +29,10 @@ tracing = [
 ]
 
 [dependencies]
-burn-fusion = { path = "../burn-fusion", version = "=0.21.0-pre.3", default-features = false }
-burn-ir = { path = "../burn-ir", version = "=0.21.0-pre.3", default-features = false }
-burn-std = { path = "../burn-std", version = "=0.21.0-pre.3", features = [
+burn-fusion = { workspace = true }
+burn-ir = { workspace = true }
+burn-std = { workspace = true, features = [
+    "default",
     "cubecl",
 ] }
 cubecl = { workspace = true }
@@ -44,7 +45,7 @@ cubek = { workspace = true, features = [
 half = { workspace = true, optional = true }
 
 # Only for `TensorData` with autotune-checks
-burn-backend = { path = "../burn-backend", version = "=0.21.0-pre.3", default-features = false, optional = true }
+burn-backend = { workspace = true, optional = true }
 
 derive-new = { workspace = true }
 hashbrown = { workspace = true }

--- a/crates/burn-cubecl/Cargo.toml
+++ b/crates/burn-cubecl/Cargo.toml
@@ -60,13 +60,13 @@ distributed = [
 ]
 
 [dependencies]
-burn-cubecl-fusion = { path = "../burn-cubecl-fusion", version = "=0.21.0-pre.3", default-features = false, optional = true }
-burn-fusion = { path = "../burn-fusion", version = "=0.21.0-pre.3", default-features = false, optional = true }
-burn-ir = { path = "../burn-ir", version = "=0.21.0-pre.3", default-features = false }
-burn-std = { path = "../burn-std", version = "=0.21.0-pre.3", default-features = false, features = [
+burn-cubecl-fusion = { workspace = true, optional = true }
+burn-fusion = { workspace = true, optional = true }
+burn-ir = { workspace = true }
+burn-std = { workspace = true, features = [
     "cubecl",
 ] }
-burn-backend = { path = "../burn-backend", version = "=0.21.0-pre.3", default-features = false, features = [
+burn-backend = { workspace = true, features = [
     "cubecl",
 ] }
 cubecl = { workspace = true, features = ["stdlib"] }

--- a/crates/burn-cuda/Cargo.toml
+++ b/crates/burn-cuda/Cargo.toml
@@ -34,9 +34,9 @@ distributed = [
 ]
 
 [dependencies]
-burn-fusion = { path = "../burn-fusion", version = "=0.21.0-pre.3", optional = true }
-burn-cubecl = { path = "../burn-cubecl", version = "=0.21.0-pre.3", default-features = false }
-burn-backend = { path = "../burn-backend", version = "=0.21.0-pre.3", default-features = false, features = [
+burn-fusion = { workspace = true, optional = true, features = ["default"] }
+burn-cubecl = { workspace = true }
+burn-backend = { workspace = true, features = [
     "cubecl-cuda",
 ] }
 cubecl = { workspace = true, features = ["cuda"] }

--- a/crates/burn-dataset/Cargo.toml
+++ b/crates/burn-dataset/Cargo.toml
@@ -40,7 +40,8 @@ __sqlite-shared = [
 dataframe = ["dep:polars", "dep:planus"]
 
 [dependencies]
-burn-std = { path = "../burn-std", version = "=0.21.0-pre.3", optional = true, features = [
+burn-std = { workspace = true, optional = true, features = [
+    "default",
     "network",
 ] }
 csv = { workspace = true }

--- a/crates/burn-dispatch/Cargo.toml
+++ b/crates/burn-dispatch/Cargo.toml
@@ -93,17 +93,17 @@ fusion = [
 ]
 
 [dependencies]
-burn-backend = { path = "../burn-backend", version = "=0.21.0-pre.3", default-features = false }
+burn-backend = { workspace = true }
 
 # Backends
-burn-autodiff = { path = "../burn-autodiff", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-cpu = { path = "../burn-cpu", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-cuda = { path = "../burn-cuda", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-flex = { path = "../burn-flex", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-ndarray = { path = "../burn-ndarray", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-tch = { path = "../burn-tch", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-rocm = { path = "../burn-rocm", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-wgpu = { path = "../burn-wgpu", version = "=0.21.0-pre.3", optional = true, default-features = false }
+burn-autodiff = { workspace = true, optional = true }
+burn-cpu = { workspace = true, optional = true }
+burn-cuda = { workspace = true, optional = true }
+burn-flex = { workspace = true, optional = true }
+burn-ndarray = { workspace = true, optional = true }
+burn-tch = { workspace = true, optional = true }
+burn-rocm = { workspace = true, optional = true }
+burn-wgpu = { workspace = true, optional = true }
 
 # Op macros with `.as_$inner_kind()`
 paste = { workspace = true }

--- a/crates/burn-flex/Cargo.toml
+++ b/crates/burn-flex/Cargo.toml
@@ -45,9 +45,9 @@ critical-section = [
 
 # ** Please make sure all dependencies support no_std when std is disabled **
 
-burn-backend = { path = "../burn-backend", version = "=0.21.0-pre.3", default-features = false }
-burn-ir = { path = "../burn-ir", version = "=0.21.0-pre.3", default-features = false }
-burn-std = { path = "../burn-std", version = "=0.21.0-pre.3", default-features = false }
+burn-backend = { workspace = true }
+burn-ir = { workspace = true }
+burn-std = { workspace = true }
 
 bytemuck = { workspace = true }
 half = { workspace = true }

--- a/crates/burn-fusion/Cargo.toml
+++ b/crates/burn-fusion/Cargo.toml
@@ -32,9 +32,9 @@ tracing = [
 ]
 
 [dependencies]
-burn-backend = { path = "../burn-backend", version = "=0.21.0-pre.3" }
-burn-std = { path = "../burn-std", version = "=0.21.0-pre.3" }
-burn-ir = { path = "../burn-ir", version = "=0.21.0-pre.3" }
+burn-backend = { workspace = true, features = ["default"] }
+burn-std = { workspace = true, features = ["default"] }
+burn-ir = { workspace = true, features = ["default"] }
 tracing = { workspace = true, optional = true, features = ["attributes"] }
 smallvec = { workspace = true }
 

--- a/crates/burn-ir/Cargo.toml
+++ b/crates/burn-ir/Cargo.toml
@@ -27,7 +27,7 @@ distributed = ["burn-backend/distributed"]
 serde = { workspace = true }
 hashbrown = { workspace = true } # no_std compatible
 
-burn-backend = { path = "../burn-backend", version = "=0.21.0-pre.3", default-features = false }
+burn-backend = { workspace = true }
 
 [package.metadata.docs.rs]
 features = ["doc"]

--- a/crates/burn-ndarray/Cargo.toml
+++ b/crates/burn-ndarray/Cargo.toml
@@ -60,10 +60,10 @@ export_tests = []
 
 # ** Please make sure all dependencies support no_std when std is disabled **
 
-burn-autodiff = { path = "../burn-autodiff", version = "=0.21.0-pre.3", default-features = false, optional = true }
-burn-std = { path = "../burn-std", version = "=0.21.0-pre.3", default-features = false }
-burn-ir = { path = "../burn-ir", version = "=0.21.0-pre.3", default-features = false }
-burn-backend = { path = "../burn-backend", version = "=0.21.0-pre.3", default-features = false }
+burn-autodiff = { workspace = true, optional = true }
+burn-std = { workspace = true }
+burn-ir = { workspace = true }
+burn-backend = { workspace = true }
 
 atomic_float = { workspace = true }
 blas-src = { workspace = true, default-features = false, optional = true }      # no-std compatible

--- a/crates/burn-nn/Cargo.toml
+++ b/crates/burn-nn/Cargo.toml
@@ -64,22 +64,22 @@ test-memory-checks = ["burn-fusion/memory-checks"]
 [dependencies]
 
 # ** Please make sure all dependencies support no_std when std is disabled **
-burn-core = { path = "../burn-core", version = "=0.21.0-pre.3", default-features = false }
+burn-core = { workspace = true }
 
 num-traits = { workspace = true }
 
 # FOR TESTING
-burn-cuda = { path = "../burn-cuda", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-rocm = { path = "../burn-rocm", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-remote = { path = "../burn-remote", version = "=0.21.0-pre.3", default-features = false, optional = true }
-burn-router = { path = "../burn-router", version = "=0.21.0-pre.3", default-features = false, optional = true }
-burn-tch = { path = "../burn-tch", version = "=0.21.0-pre.3", optional = true }
-burn-wgpu = { path = "../burn-wgpu", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-fusion = { path = "../burn-fusion", version = "=0.21.0-pre.3", optional = true }
+burn-cuda = { workspace = true, optional = true }
+burn-rocm = { workspace = true, optional = true }
+burn-remote = { workspace = true, optional = true }
+burn-router = { workspace = true, optional = true }
+burn-tch = { workspace = true, optional = true, features = ["default"] }
+burn-wgpu = { workspace = true, optional = true }
+burn-fusion = { workspace = true, optional = true, features = ["default"] }
 
 [dev-dependencies]
-burn-flex = { path = "../burn-flex", version = "=0.21.0-pre.3" }
-burn-autodiff = { path = "../burn-autodiff", version = "=0.21.0-pre.3" }
+burn-flex = { workspace = true, features = ["default"] }
+burn-autodiff = { workspace = true, features = ["default"] }
 rstest = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/crates/burn-no-std-tests/Cargo.toml
+++ b/crates/burn-no-std-tests/Cargo.toml
@@ -30,7 +30,7 @@ tracing = [
 
 # ** Please make sure all dependencies support no_std **
 
-burn = { path = "../burn", version = "=0.21.0-pre.3", default-features = false }
-burn-flex = { path = "../burn-flex", version = "=0.21.0-pre.3", default-features = false }
+burn = { workspace = true }
+burn-flex = { workspace = true }
 
-burn-store = { path = "../burn-store", version = "=0.21.0-pre.3", default-features = false, features = ["safetensors", "burnpack"]}
+burn-store = { workspace = true, features = ["safetensors", "burnpack"] }

--- a/crates/burn-optim/Cargo.toml
+++ b/crates/burn-optim/Cargo.toml
@@ -72,8 +72,8 @@ test-memory-checks = ["burn-fusion/memory-checks"]
 [dependencies]
 
 # ** Please make sure all dependencies support no_std when std is disabled **
-burn-core = { path = "../burn-core", version = "=0.21.0-pre.3", default-features = false }
-burn-collective = { path = "../burn-collective", version = "=0.21.0-pre.3", optional = true, default-features = false }
+burn-core = { workspace = true }
+burn-collective = { workspace = true, optional = true }
 
 num-traits = { workspace = true }
 derive-new = { workspace = true }
@@ -84,18 +84,18 @@ serde = { workspace = true, features = ["derive"] }
 hashbrown = { workspace = true, features = ["serde"] } # no_std compatible
 
 # FOR TESTING
-burn-cuda = { path = "../burn-cuda", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-rocm = { path = "../burn-rocm", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-remote = { path = "../burn-remote", version = "=0.21.0-pre.3", default-features = false, optional = true }
-burn-router = { path = "../burn-router", version = "=0.21.0-pre.3", default-features = false, optional = true }
-burn-tch = { path = "../burn-tch", version = "=0.21.0-pre.3", optional = true }
-burn-wgpu = { path = "../burn-wgpu", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-fusion = { path = "../burn-fusion", version = "=0.21.0-pre.3", optional = true }
+burn-cuda = { workspace = true, optional = true }
+burn-rocm = { workspace = true, optional = true }
+burn-remote = { workspace = true, optional = true }
+burn-router = { workspace = true, optional = true }
+burn-tch = { workspace = true, optional = true, features = ["default"] }
+burn-wgpu = { workspace = true, optional = true }
+burn-fusion = { workspace = true, optional = true, features = ["default"] }
 
 [dev-dependencies]
-burn-nn = { path = "../burn-nn", version = "=0.21.0-pre.3" }
-burn-flex = { path = "../burn-flex", version = "=0.21.0-pre.3" }
-burn-autodiff = { path = "../burn-autodiff", version = "=0.21.0-pre.3" }
+burn-nn = { workspace = true, features = ["default"] }
+burn-flex = { workspace = true, features = ["default"] }
+burn-autodiff = { workspace = true, features = ["default"] }
 rstest = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/crates/burn-remote/Cargo.toml
+++ b/crates/burn-remote/Cargo.toml
@@ -37,13 +37,14 @@ server = [
 
 
 [dependencies]
-burn-ir = { path = "../burn-ir", version = "=0.21.0-pre.3", default-features = true }
-burn-backend = { path = "../burn-backend", version = "=0.21.0-pre.3", default-features = true, features = [
+burn-ir = { workspace = true, features = ["default"] }
+burn-backend = { workspace = true, features = [
+    "default",
     "serde", # For DTypeUsageSet to be de/serialized
 ] }
-burn-std = { path = "../burn-std", version = "=0.21.0-pre.3", default-features = true }
-burn-router = { path = "../burn-router", version = "=0.21.0-pre.3", default-features = true }
-burn-communication = { path = "../burn-communication", version = "=0.21.0-pre.3", features = [
+burn-std = { workspace = true, features = ["default"] }
+burn-router = { workspace = true, features = ["default"] }
+burn-communication = { workspace = true, features = [
     "data-service",
     "websocket",
 ] }
@@ -72,8 +73,8 @@ tracing-subscriber = { workspace = true, optional = true }
 tokio-util = { workspace = true }
 
 [dev-dependencies]
-burn-flex = { path = "../burn-flex", version = "=0.21.0-pre.3" }
-burn-tensor = { path = "../burn-tensor", version = "=0.21.0-pre.3", default-features = true }
+burn-flex = { workspace = true, features = ["default"] }
+burn-tensor = { workspace = true, features = ["default"] }
 
 [package.metadata.docs.rs]
 features = ["doc"]

--- a/crates/burn-rl/Cargo.toml
+++ b/crates/burn-rl/Cargo.toml
@@ -12,20 +12,20 @@ documentation = "https://docs.rs/burn-rl"
 version.workspace = true
 
 [dependencies]
-burn-core = { path = "../burn-core", version = "=0.21.0-pre.3", features = [
+burn-core = { workspace = true, features = [
     "dataset",
     "std",
-], default-features = false }
-burn-optim = { path = "../burn-optim", version = "=0.21.0-pre.3", features = [
+] }
+burn-optim = { workspace = true, features = [
     "std",
-], default-features = false }
+] }
 
 derive-new.workspace = true
 log = { workspace = true }
 rand.workspace = true
 
 [dev-dependencies]
-burn-flex = { path = "../burn-flex", version = "=0.21.0-pre.3" }
+burn-flex = { workspace = true, features = ["default"] }
 
 [lints]
 workspace = true

--- a/crates/burn-rocm/Cargo.toml
+++ b/crates/burn-rocm/Cargo.toml
@@ -31,11 +31,12 @@ std = ["burn-cubecl/std", "cubecl/std"]
 
 [dependencies]
 cubecl = { workspace = true, features = ["hip"] }
-burn-cubecl = { path = "../burn-cubecl", version = "=0.21.0-pre.3", default-features = true }
-burn-backend = { path = "../burn-backend", version = "=0.21.0-pre.3", features = [
+burn-cubecl = { workspace = true, features = ["default"] }
+burn-backend = { workspace = true, features = [
+    "default",
     "cubecl-hip",
 ] }
-burn-fusion = { path = "../burn-fusion", version = "=0.21.0-pre.3", optional = true }
+burn-fusion = { workspace = true, optional = true, features = ["default"] }
 
 [package.metadata.docs.rs]
 features = ["doc"]

--- a/crates/burn-router/Cargo.toml
+++ b/crates/burn-router/Cargo.toml
@@ -29,17 +29,17 @@ tracing = [
 distributed = ["burn-ir/distributed"]
 
 [dependencies]
-burn-ir = { path = "../burn-ir", version = "=0.21.0-pre.3", default-features = false }
-burn-backend = { path = "../burn-backend", version = "=0.21.0-pre.3", default-features = false }
-burn-std = { path = "../burn-std", version = "=0.21.0-pre.3", default-features = false }
+burn-ir = { workspace = true }
+burn-backend = { workspace = true }
+burn-std = { workspace = true }
 hashbrown = { workspace = true }
 spin = { workspace = true }
 log = { workspace = true }
 
 [dev-dependencies]
-burn-tensor = { path = "../burn-tensor", version = "=0.21.0-pre.3", default-features = false }
-burn-flex = { path = "../burn-flex", version = "=0.21.0-pre.3" }
-burn-wgpu = { path = "../burn-wgpu", version = "=0.21.0-pre.3", default-features = false, features = [
+burn-tensor = { workspace = true }
+burn-flex = { workspace = true, features = ["default"] }
+burn-wgpu = { workspace = true, features = [
     "std",
 ] }
 

--- a/crates/burn-store/Cargo.toml
+++ b/crates/burn-store/Cargo.toml
@@ -52,8 +52,8 @@ safetensors = ["dep:safetensors"]
 pytorch = ["burn-core/record-item-custom-serde", "zip", "serde", "tar"]
 
 [dependencies]
-burn-core = { path = "../burn-core", version = "=0.21.0-pre.3", default-features = false }
-burn-tensor = { path = "../burn-tensor", version = "=0.21.0-pre.3", default-features = false }
+burn-core = { workspace = true }
+burn-tensor = { workspace = true }
 
 # External dependencies
 byteorder = { workspace = true, default-features = false }
@@ -74,14 +74,14 @@ lzma-rust2 = { workspace = true, optional = true }
 safetensors = { workspace = true, optional = true }
 
 # Optional backend dependencies for benchmarks
-burn-cuda = { path = "../burn-cuda", version = "=0.21.0-pre.3", optional = true }
-burn-tch = { path = "../burn-tch", version = "=0.21.0-pre.3", optional = true }
-burn-wgpu = { path = "../burn-wgpu", version = "=0.21.0-pre.3", optional = true }
+burn-cuda = { workspace = true, optional = true, features = ["default"] }
+burn-tch = { workspace = true, optional = true, features = ["default"] }
+burn-wgpu = { workspace = true, optional = true, features = ["default"] }
 
 [dev-dependencies]
 # burn-import = { path = "../burn-import", version = "=0.21.0-pre.3" } # disabled (circular dep in publish, only for bench)
-burn-flex = { path = "../burn-flex", version = "=0.21.0-pre.3" }
-burn-nn = { path = "../burn-nn", version = "=0.21.0-pre.3", default-features = false }
+burn-flex = { workspace = true, features = ["default"] }
+burn-nn = { workspace = true }
 divan = "0.1"
 tempfile = { workspace = true }
 

--- a/crates/burn-store/pytorch-tests/Cargo.toml
+++ b/crates/burn-store/pytorch-tests/Cargo.toml
@@ -5,9 +5,9 @@ edition.workspace = true
 license.workspace = true
 
 [dev-dependencies]
-burn = { path = "../../burn" }
-burn-flex = { path = "../../burn-flex" }
-burn-autodiff = { path = "../../burn-autodiff" }
-burn-store = { path = "../", features = ["std", "pytorch"] }
+burn = { workspace = true, features = ["default"] }
+burn-flex = { workspace = true, features = ["default"] }
+burn-autodiff = { workspace = true, features = ["default"] }
+burn-store = { workspace = true, features = ["default", "std", "pytorch"] }
 serde = { workspace = true }
 float-cmp = { workspace = true }

--- a/crates/burn-store/safetensors-tests/Cargo.toml
+++ b/crates/burn-store/safetensors-tests/Cargo.toml
@@ -5,9 +5,9 @@ edition.workspace = true
 license.workspace = true
 
 [dev-dependencies]
-burn = { path = "../../burn" }
-burn-flex = { path = "../../burn-flex" }
-burn-autodiff = { path = "../../burn-autodiff" }
-burn-store = { path = "../", features = ["std", "safetensors"] }
+burn = { workspace = true, features = ["default"] }
+burn-flex = { workspace = true, features = ["default"] }
+burn-autodiff = { workspace = true, features = ["default"] }
+burn-store = { workspace = true, features = ["default", "std", "safetensors"] }
 serde = { workspace = true }
 float-cmp = { workspace = true }

--- a/crates/burn-tch/Cargo.toml
+++ b/crates/burn-tch/Cargo.toml
@@ -23,7 +23,7 @@ tracing = [
 ]
 
 [dependencies]
-burn-backend = { path = "../burn-backend", version = "=0.21.0-pre.3", default-features = false }
+burn-backend = { workspace = true }
 
 libc = { workspace = true }
 log = { workspace = true }

--- a/crates/burn-tensor/Cargo.toml
+++ b/crates/burn-tensor/Cargo.toml
@@ -36,8 +36,8 @@ cubecl-wgpu = ["burn-backend/cubecl-wgpu"]
 cubecl-cpu = ["burn-backend/cubecl-cpu"]
 
 [dependencies]
-burn-std = { path = "../burn-std", version = "=0.21.0-pre.3", default-features = false }
-burn-backend = { path = "../burn-backend", version = "=0.21.0-pre.3", default-features = false }
+burn-std = { workspace = true }
+burn-backend = { workspace = true }
 
 colored = { workspace = true, optional = true }
 derive-new = { workspace = true }

--- a/crates/burn-train/Cargo.toml
+++ b/crates/burn-train/Cargo.toml
@@ -31,17 +31,17 @@ rl = ["burn-rl"]
 ddp = ["burn-optim/distributed", "burn-core/distributed"]
 
 [dependencies]
-burn-core = { path = "../burn-core", version = "=0.21.0-pre.3", features = [
+burn-core = { workspace = true, features = [
     "dataset",
     "std",
-], default-features = false }
-burn-optim = { path = "../burn-optim", version = "=0.21.0-pre.3", features = [
+] }
+burn-optim = { workspace = true, features = [
     "std",
-], default-features = false }
-burn-rl = { path = "../burn-rl", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-nn = { path = "../burn-nn", version = "=0.21.0-pre.3", optional = true, default-features = false, features = ["std"] }
-burn-store = { path = "../burn-store", version = "=0.21.0-pre.3", optional = true, default-features = false, features = ["std"] }
-burn-std = { path = "../burn-std", version = "=0.21.0-pre.3", optional = true, default-features = false, features = ["std"] }
+] }
+burn-rl = { workspace = true, optional = true }
+burn-nn = { workspace = true, optional = true, features = ["std"] }
+burn-store = { workspace = true, optional = true, features = ["std"] }
+burn-std = { workspace = true, optional = true, features = ["std"] }
 dirs = { workspace = true, optional = true }
 
 log = { workspace = true }
@@ -64,14 +64,14 @@ ratatui = { workspace = true, optional = true, features = [
 derive-new = { workspace = true }
 serde = { workspace = true, features = ["std", "derive"] }
 async-channel = { workspace = true }
-burn-flex = { path = "../burn-flex", version = "=0.21.0-pre.3" }
+burn-flex = { workspace = true, features = ["default"] }
 rstest.workspace = true
 thiserror.workspace = true
 rand.workspace = true
 
 [dev-dependencies]
-burn-flex = { path = "../burn-flex", version = "=0.21.0-pre.3" }
-burn-autodiff = { path = "../burn-autodiff", version = "=0.21.0-pre.3" }
+burn-flex = { workspace = true, features = ["default"] }
+burn-autodiff = { workspace = true, features = ["default"] }
 
 [package.metadata.docs.rs]
 features = ["doc"]

--- a/crates/burn-vision/Cargo.toml
+++ b/crates/burn-vision/Cargo.toml
@@ -48,17 +48,17 @@ test-metal = ["burn-wgpu/metal", "test-wgpu"]
 [dependencies]
 aligned-vec = { workspace = true }
 bon = { workspace = true }
-burn-cubecl = { path = "../burn-cubecl", version = "=0.21.0-pre.3", optional = true }
-burn-fusion = { path = "../burn-fusion", version = "=0.21.0-pre.3", optional = true }
-burn-flex = { path = "../burn-flex", version = "=0.21.0-pre.3", optional = true }
-burn-ir = { path = "../burn-ir", version = "=0.21.0-pre.3" }
-burn-tch = { path = "../burn-tch", version = "=0.21.0-pre.3", optional = true }
-burn-tensor = { path = "../burn-tensor", version = "=0.21.0-pre.3" }
-burn-tensor-testgen = { path = "../burn-tensor-testgen", version = "=0.21.0-pre.3", optional = true }
+burn-cubecl = { workspace = true, optional = true, features = ["default"] }
+burn-fusion = { workspace = true, optional = true, features = ["default"] }
+burn-flex = { workspace = true, optional = true, features = ["default"] }
+burn-ir = { workspace = true, features = ["default"] }
+burn-tch = { workspace = true, optional = true, features = ["default"] }
+burn-tensor = { workspace = true, features = ["default"] }
+burn-tensor-testgen = { workspace = true, optional = true }
 
 # For loss functions requiring pretrained models (e.g., Gram Matrix Loss)
-burn-store = { path = "../burn-store", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-std = { path = "../burn-std", version = "=0.21.0-pre.3", optional = true, default-features = false }
+burn-store = { workspace = true, optional = true }
+burn-std = { workspace = true, optional = true }
 dirs = { workspace = true, optional = true }
 
 bytemuck = { workspace = true }
@@ -73,7 +73,7 @@ paste = { workspace = true }
 serde = { workspace = true }
 
 [dev-dependencies]
-burn-cuda = { path = "../burn-cuda", version = "=0.21.0-pre.3", default-features = false }
-burn-flex = { path = "../burn-flex", version = "=0.21.0-pre.3" }
-burn-wgpu = { path = "../burn-wgpu", version = "=0.21.0-pre.3", default-features = false }
+burn-cuda = { workspace = true }
+burn-flex = { workspace = true, features = ["default"] }
+burn-wgpu = { workspace = true }
 cubecl = { workspace = true }

--- a/crates/burn-wgpu/Cargo.toml
+++ b/crates/burn-wgpu/Cargo.toml
@@ -44,9 +44,9 @@ cubecl-wgsl = []
 [dependencies]
 cubecl = { workspace = true, features = ["wgpu"] }
 
-burn-cubecl = { path = "../burn-cubecl", version = "=0.21.0-pre.3", default-features = false }
-burn-fusion = { path = "../burn-fusion", version = "=0.21.0-pre.3", optional = true }
-burn-backend = { path = "../burn-backend", version = "=0.21.0-pre.3", default-features = false, features = [
+burn-cubecl = { workspace = true }
+burn-fusion = { workspace = true, optional = true, features = ["default"] }
+burn-backend = { workspace = true, features = [
     "cubecl-wgpu",
 ] }
 

--- a/crates/burn/Cargo.toml
+++ b/crates/burn/Cargo.toml
@@ -199,29 +199,29 @@ dispatch = ["burn-dispatch"]
 
 # ** Please make sure all dependencies support no_std when std is disabled **
 
-burn-core = { path = "../burn-core", version = "=0.21.0-pre.3", default-features = false }
-burn-train = { path = "../burn-train", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-collective = { path = "../burn-collective", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-store = { path = "../burn-store", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-nn = { path = "../burn-nn", version = "=0.21.0-pre.3", default-features = false }
-burn-optim = { path = "../burn-optim", version = "=0.21.0-pre.3", default-features = false }
-burn-rl = { path = "../burn-rl", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-vision = { path = "../burn-vision", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-std = { path = "../burn-std", version = "=0.21.0-pre.3", default-features = false }
+burn-core = { workspace = true }
+burn-train = { workspace = true, optional = true }
+burn-collective = { workspace = true, optional = true }
+burn-store = { workspace = true, optional = true }
+burn-nn = { workspace = true }
+burn-optim = { workspace = true }
+burn-rl = { workspace = true, optional = true }
+burn-vision = { workspace = true, optional = true }
+burn-std = { workspace = true }
 
 # Backends
-burn-autodiff = { path = "../burn-autodiff", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-candle = { path = "../burn-candle", version = "=0.21.0-pre.3", optional = true }
-burn-cuda = { path = "../burn-cuda", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-cpu = { path = "../burn-cpu", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-flex = { path = "../burn-flex", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-rocm = { path = "../burn-rocm", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-ndarray = { path = "../burn-ndarray", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-remote = { path = "../burn-remote", version = "=0.21.0-pre.3", default-features = false, optional = true }
-burn-router = { path = "../burn-router", version = "=0.21.0-pre.3", default-features = false, optional = true }
-burn-tch = { path = "../burn-tch", version = "=0.21.0-pre.3", default-features = false, optional = true }
-burn-wgpu = { path = "../burn-wgpu", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-ir = { path = "../burn-ir", version = "=0.21.0-pre.3", optional = true, default-features = false }
-burn-dispatch = { path = "../burn-dispatch", version = "=0.21.0-pre.3", optional = true, default-features = false }
+burn-autodiff = { workspace = true, optional = true }
+burn-candle = { workspace = true, optional = true, features = ["default"] }
+burn-cuda = { workspace = true, optional = true }
+burn-cpu = { workspace = true, optional = true }
+burn-flex = { workspace = true, optional = true }
+burn-rocm = { workspace = true, optional = true }
+burn-ndarray = { workspace = true, optional = true }
+burn-remote = { workspace = true, optional = true }
+burn-router = { workspace = true, optional = true }
+burn-tch = { workspace = true, optional = true }
+burn-wgpu = { workspace = true, optional = true }
+burn-ir = { workspace = true, optional = true }
+burn-dispatch = { workspace = true, optional = true }
 
 cubecl = { workspace = true, default-features = false, optional = true }

--- a/examples/custom-csv-dataset/Cargo.toml
+++ b/examples/custom-csv-dataset/Cargo.toml
@@ -15,18 +15,18 @@ default = ["burn/dataset"]
 dataframe = ["dep:burn-dataset", "polars"]
 
 [dependencies]
-burn = {path = "../../crates/burn"}
-burn-dataset = { path = "../../crates/burn-dataset", features = ["dataframe"], optional = true }
+burn = {workspace = true, features = ["default"] }
+burn-dataset = { workspace = true, features = ["default", "dataframe"], optional = true }
 
 # File download
-reqwest = {workspace = true, features = ["blocking"]}
+reqwest = {workspace = true, features = ["blocking"] }
 
 # CSV parsing
 csv = {workspace = true}
-serde = {workspace = true, features = ["std", "derive"]}
+serde = {workspace = true, features = ["std", "derive"] }
 
 # Dataframe support (optional)
-polars = {workspace = true, optional = true, features = ["csv", "temporal"]}
+polars = {workspace = true, optional = true, features = ["csv", "temporal"] }
 
 [[example]]
 name = "dataframe-dataset"

--- a/examples/custom-cubecl-kernel/Cargo.toml
+++ b/examples/custom-cubecl-kernel/Cargo.toml
@@ -10,13 +10,13 @@ version.workspace = true
 workspace = true
 
 [dependencies]
-burn = { path = "../../crates/burn", default-features = false, features = [
+burn = { workspace = true, features = [
     "autodiff",
     "wgpu",
     "autotune",
     "template",
 ] }
-burn-cubecl = { path = "../../crates/burn-cubecl" }
+burn-cubecl = { workspace = true, features = ["default"] }
 cubecl = { workspace = true, features = ["wgpu"] }
 
 # Serialization

--- a/examples/custom-image-dataset/Cargo.toml
+++ b/examples/custom-image-dataset/Cargo.toml
@@ -18,11 +18,11 @@ metal = ["burn/metal", "burn/fusion"]
 
 [dependencies]
 # Disable autotune default for now (convolutions not optimized)
-burn = { path = "../../crates/burn", features = [
+burn = { workspace = true, features = [
     "train",
     "vision",
     "network",
-], default-features = false }
+] }
 
 
 # File download

--- a/examples/custom-learning-strategy/Cargo.toml
+++ b/examples/custom-learning-strategy/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 workspace = true
 
 [dependencies]
-burn = {path = "../../crates/burn", default-features = false, features=["autodiff", "webgpu", "vision"]}
+burn = {workspace = true, features=["autodiff", "webgpu", "vision"] }
 guide = {path = "../guide"}
 derive-new = { workspace = true }
 log = { workspace = true }

--- a/examples/custom-renderer/Cargo.toml
+++ b/examples/custom-renderer/Cargo.toml
@@ -11,12 +11,12 @@ version.workspace = true
 workspace = true
 
 [dependencies]
-burn = {path = "../../crates/burn", features=["autodiff", "wgpu", "train", "dataset", "vision"], default-features=false}
+burn = {workspace = true, features=["autodiff", "wgpu", "train", "dataset", "vision"] }
 guide = {path = "../guide", default-features=false}
 
 # Serialization
 log = {workspace = true}
-serde = {workspace = true, features = ["std", "derive"]}
+serde = {workspace = true, features = ["std", "derive"] }
 
 # Wgpu internal dependencies
 derive-new = { workspace = true }

--- a/examples/custom-training-loop/Cargo.toml
+++ b/examples/custom-training-loop/Cargo.toml
@@ -10,12 +10,12 @@ version.workspace = true
 workspace = true
 
 [dependencies]
-burn = {path = "../../crates/burn", features=["autodiff", "webgpu", "vision"]}
+burn = {workspace = true, features=["default", "autodiff", "webgpu", "vision"] }
 guide = {path = "../guide"}
 
 # Serialization
 log = {workspace = true}
-serde = {workspace = true, features = ["std", "derive"]}
+serde = {workspace = true, features = ["std", "derive"] }
 
 # Wgpu internal dependencies
 derive-new = { workspace = true }

--- a/examples/custom-wgpu-kernel/Cargo.toml
+++ b/examples/custom-wgpu-kernel/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 workspace = true
 
 [dependencies]
-burn = { path = "../../crates/burn", default-features = false, features = [
+burn = { workspace = true, features = [
     "autodiff",
     "wgpu",
     "autotune",

--- a/examples/dop_timer/Cargo.toml
+++ b/examples/dop_timer/Cargo.toml
@@ -19,7 +19,8 @@ metal = ["burn/metal"]
 
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
-burn = { path = "../../crates/burn", version = "=0.21.0-pre.3", features = [
+burn = { workspace = true, features = [
+    "default",
     "collective",
     "tracing",
 ] }

--- a/examples/dqn-agent/Cargo.toml
+++ b/examples/dqn-agent/Cargo.toml
@@ -19,7 +19,7 @@ rocm = ["burn/rocm", "burn/default"]
 
 [dependencies]
 # Disable autotune default for now.
-burn = { path = "../../crates/burn", features = [
+burn = { workspace = true, features = [
     "train",
     "metrics",
     "std",
@@ -27,7 +27,7 @@ burn = { path = "../../crates/burn", features = [
     # "fusion",
     "flex",
     # "autotune",
-], default-features = false }
+] }
 # Just for this example.
 gym-rs = { version = "0.3.1", branch = "main", git = "https://github.com/MathisWellmann/gym-rs" }
 rand.workspace = true

--- a/examples/guide/Cargo.toml
+++ b/examples/guide/Cargo.toml
@@ -15,14 +15,14 @@ default = ["burn/default", "burn/tui"]
 vulkan = ["burn/vulkan"]
 
 [dependencies]
-burn = { path = "../../crates/burn", features = [
+burn = { workspace = true, features = [
     "webgpu",
     "train",
     "vision",
-], default-features = false }
+] }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-burn = { path = "../../crates/burn", features = ["vulkan"] }
+burn = { workspace = true, features = ["default", "vulkan"] }
 
 # Serialization
 log = { workspace = true }

--- a/examples/import-model-weights/Cargo.toml
+++ b/examples/import-model-weights/Cargo.toml
@@ -11,15 +11,16 @@ workspace = true
 
 [dependencies]
 
-burn = { path = "../../crates/burn", features = [
+burn = { workspace = true, features = [
+    "default",
     "flex",
     "dataset",
     "vision",
 ] }
 
-burn-store = { path = "../../crates/burn-store", features = [
+burn-store = { workspace = true, features = [
     "std",
     "pytorch",
     "safetensors",
     "burnpack",
-], default-features = false }
+] }

--- a/examples/mnist-inference-web/Cargo.toml
+++ b/examples/mnist-inference-web/Cargo.toml
@@ -19,7 +19,7 @@ flex = ["burn/flex"]
 wgpu = ["burn/wgpu"]
 
 [dependencies]
-burn = { path = "../../crates/burn", default-features = false }
+burn = { workspace = true }
 serde = { workspace = true }
 console_error_panic_hook = { workspace = true }
 

--- a/examples/mnist/Cargo.toml
+++ b/examples/mnist/Cargo.toml
@@ -21,14 +21,14 @@ vulkan = ["burn/vulkan"]
 rocm = ["burn/rocm"]
 
 [dependencies]
-burn = { path = "../../crates/burn", features = [
+burn = { workspace = true, features = [
     "train",
     "vision",
     "metrics",
     "fusion",
     "dispatch",
     "flex",
-], default-features = false }
+] }
 
 # Serialization
 log = { workspace = true }

--- a/examples/modern-lstm/Cargo.toml
+++ b/examples/modern-lstm/Cargo.toml
@@ -14,7 +14,7 @@ tch-gpu = ["burn/tch"]
 wgpu = ["burn/wgpu"]
 
 [dependencies]
-burn = { path = "../../crates/burn", features = ["train"] }
+burn = { workspace = true, features = ["default", "train"] }
 
 # Random number generator
 rand = { workspace = true, features = ["thread_rng"] }

--- a/examples/multi-gpus/Cargo.toml
+++ b/examples/multi-gpus/Cargo.toml
@@ -19,11 +19,11 @@ rocm = ["burn/rocm"]
 
 [dependencies]
 # Burn
-burn = { path = "../../crates/burn", features = [
+burn = { workspace = true, features = [
     "autotune",
     "fusion",
     "collective",
     "train",
     "std",
-], default-features = false }
+] }
 text-classification = { path = "../text-classification" }

--- a/examples/server/Cargo.toml
+++ b/examples/server/Cargo.toml
@@ -18,5 +18,5 @@ flex = ["burn/flex"]
 
 [dependencies]
 cfg-if = { workspace = true }
-burn = { path = "../../crates/burn", version = "=0.21.0-pre.3", features = ["server"] }
+burn = { workspace = true, features = ["default", "server"] }
 cubecl = { workspace = true }

--- a/examples/simple-regression/Cargo.toml
+++ b/examples/simple-regression/Cargo.toml
@@ -18,11 +18,11 @@ wgpu = ["burn/wgpu"]
 remote = ["burn/remote"]
 
 [dependencies]
-burn = {path = "../../crates/burn", features=["train"]}
+burn = {workspace = true, features=["default", "train"] }
 
 # Serialization
 log = {workspace = true}
-serde = {workspace = true, features = ["std", "derive"]}
+serde = {workspace = true, features = ["std", "derive"] }
 
 # Displaying results
 textplots = "0.8.7"

--- a/examples/text-classification/Cargo.toml
+++ b/examples/text-classification/Cargo.toml
@@ -26,7 +26,7 @@ ddp = ["burn/distributed"]
 
 [dependencies]
 # Burn
-burn = { path = "../../crates/burn", features = [
+burn = { workspace = true, features = [
     "train",
     "tui",
     "sqlite-bundled",
@@ -35,7 +35,7 @@ burn = { path = "../../crates/burn", features = [
     "autotune",
     "fusion",
     "std",
-], default-features = false }
+] }
 log = { workspace = true }
 
 # Tokenizer

--- a/examples/text-generation/Cargo.toml
+++ b/examples/text-generation/Cargo.toml
@@ -15,7 +15,7 @@ f16 = []
 
 [dependencies]
 # Burn
-burn = {path = "../../crates/burn", features=["train", "tch"]}
+burn = {workspace = true, features=["default", "train", "tch"] }
 
 # Tokenizer
 tokenizers = {version = "0.22.2", default-features = false, features = [
@@ -26,4 +26,4 @@ tokenizers = {version = "0.22.2", default-features = false, features = [
 # Utils
 derive-new = {workspace = true}
 log = {workspace = true}
-serde = {workspace = true, features = ["std", "derive"]}
+serde = {workspace = true, features = ["std", "derive"] }

--- a/examples/wgan/Cargo.toml
+++ b/examples/wgan/Cargo.toml
@@ -14,5 +14,5 @@ wgpu = ["burn/wgpu"]
 cuda = ["burn/cuda"]
 
 [dependencies]
-burn = { path = "../../crates/burn", features=["train", "vision"] }
+burn = { workspace = true, features=["default", "train", "vision"] }
 image = { workspace = true }


### PR DESCRIPTION
## Summary

- Added the 32 internal `burn-*` crates to `[workspace.dependencies]` in the root `Cargo.toml`.
- Swept 54 consumer manifests so each internal dep is now `workspace = true` instead of repeating `path = "../burn-X", version = "=0.21.0-pre.3"`.
- Version bumps now touch only the root manifest.

## Cargo gotcha

Cargo forbids consumers from overriding a workspace dep's `default-features` when inheriting via `workspace = true`. Workspace deps therefore pin `default-features = false`, and consumers that previously had defaults ON now opt in via `features = ["default"]`. For the four internal crates without a `default` feature (`burn-communication`, `burn-derive`, `burn-rl`, `burn-tensor-testgen`), nothing is added.

## Test plan

- [x] `cargo check` on all internal crates (all backends, no_std target, sub-test crates, examples)
- [x] `cargo metadata --no-deps` dep-shape diff: `uses_default_features: true` -> `false` + `"default"` in features list, semantically identical