### PR TITLE
Fix is_nonoverlapping underflow on empty tensors

### DIFF
--- a/crates/burn-cubecl/src/tensor/base.rs
+++ b/crates/burn-cubecl/src/tensor/base.rs
@@ -345,6 +345,10 @@ where
         let shape = self.meta.shape();
         let strides = self.meta.strides();
 
+        // An empty tensor has no elements to overlap.
+        if shape.iter().any(|&s| s == 0) {
+            return true;
+        }
         if strides.contains(&0) {
             return false;
         }


### PR DESCRIPTION
`CubeTensor::is_nonoverlapping` does `(*shape - 1) * *stride` in a `usize` accumulator. When any axis has `shape == 0`, the subtraction underflows and panics under overflow checks (e.g. debug builds, wasm tests).

On native this is hidden because `ChannelDeviceHandle` swallows worker-thread panics with `catch_unwind`. on wasm `ReentrantMutexDeviceHandle` propagates the panic and additionally poisons the device handle (the `service` cell stays `None` after the panic skips its `replace`), turning every later test into "State ... is already borrowed by the current thread".

Fix: an empty tensor has no elements that can overlap, so return `true` early when any dim is zero.