### PR TITLE
Fix more cases for 0 sized tensors.

### DIFF
--- a/crates/burn-cubecl/src/kernel/index/slice_assign.rs
+++ b/crates/burn-cubecl/src/kernel/index/slice_assign.rs
@@ -100,9 +100,11 @@ pub(crate) fn slice_assign<R: CubeRuntime>(
     indices: &[burn_backend::Slice],
     value: CubeTensor<R>,
 ) -> CubeTensor<R> {
+    let num_elems = value.meta.num_elements();
+
     // Empty assignments have no work — launching a kernel here divides by
     // zero in `FastDivmod` registration when a shape dim is 0.
-    if value.meta.num_elements() == 0 {
+    if num_elems == 0 {
         return tensor;
     }
     // Check if any slice has non-unit step
@@ -164,7 +166,7 @@ pub(crate) fn slice_assign<R: CubeRuntime>(
         offsets.push(start);
     }
 
-    let working_units = value.meta.num_elements() / vector_size;
+    let working_units = num_elems / vector_size;
     let cube_dim = CubeDim::new(&tensor.client, working_units);
     let cube_count = calculate_cube_count_elemwise(&tensor.client, working_units, cube_dim);
 
@@ -200,9 +202,14 @@ pub(crate) fn slice_assign_with_steps<R: CubeRuntime>(
     slices: &[burn_backend::Slice],
     value: CubeTensor<R>,
 ) -> CubeTensor<R> {
-    if value.meta.num_elements() == 0 {
+    // Launch kernel
+    let working_units = value.meta.num_elements();
+
+    if working_units == 0 {
+        // Nothing to do
         return tensor;
     }
+
     let tensor = match tensor.can_mut() && tensor.is_nonoverlapping() {
         true => tensor,
         false => tensor.copy(),
@@ -227,8 +234,6 @@ pub(crate) fn slice_assign_with_steps<R: CubeRuntime>(
         steps.push(1);
     }
 
-    // Launch kernel
-    let working_units = value.meta.num_elements();
     let cube_dim = CubeDim::new(&tensor.client, working_units);
     let cube_count = calculate_cube_count_elemwise(&tensor.client, working_units, cube_dim);
 

--- a/crates/burn-cubecl/src/kernel/index/slice_assign.rs
+++ b/crates/burn-cubecl/src/kernel/index/slice_assign.rs
@@ -100,6 +100,11 @@ pub(crate) fn slice_assign<R: CubeRuntime>(
     indices: &[burn_backend::Slice],
     value: CubeTensor<R>,
 ) -> CubeTensor<R> {
+    // Empty assignments have no work — launching a kernel here divides by
+    // zero in `FastDivmod` registration when a shape dim is 0.
+    if value.meta.num_elements() == 0 {
+        return tensor;
+    }
     // Check if any slice has non-unit step
     let has_non_unit_step = indices.iter().any(|s| s.step != 1 && s.step != 0);
 
@@ -195,6 +200,9 @@ pub(crate) fn slice_assign_with_steps<R: CubeRuntime>(
     slices: &[burn_backend::Slice],
     value: CubeTensor<R>,
 ) -> CubeTensor<R> {
+    if value.meta.num_elements() == 0 {
+        return tensor;
+    }
     let tensor = match tensor.can_mut() && tensor.is_nonoverlapping() {
         true => tensor,
         false => tensor.copy(),

--- a/crates/burn-cubecl/src/tensor/base.rs
+++ b/crates/burn-cubecl/src/tensor/base.rs
@@ -345,6 +345,10 @@ where
         let shape = self.meta.shape();
         let strides = self.meta.strides();
 
+        // An empty tensor has no elements to overlap.
+        if shape.iter().any(|&s| s == 0) {
+            return true;
+        }
         if strides.contains(&0) {
             return false;
         }


### PR DESCRIPTION
shape == 0, the subtraction underflows and panics under overflow checks (e.g. debug builds, wasm tests).

On native this is hidden because ChannelDeviceHandle swallows worker-thread panics with catch_unwind. on wasm ReentrantMutexDeviceHandle propagates the panic and additionally poisons the device handle (the service cell stays None after the panic skips its replace), turning every later test into "State ... is already borrowed by the current thread". Fix: an empty tensor has no elements that can overlap, so return true early when any dim is zero.

For slice assign, the kernel does no useful work when `value` has 0 elements anyway, so just early-return. After https://github.com/tracel-ai/cubecl/pull/1297 this wouldn't panic anymore anyway, but, might as well skip the work here entirely.