### PR TITLE
Override conv2d backward in burn-tch via at::convolution_backward FFI…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1656,6 +1656,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cnn_min_repro"
+version = "0.21.0-pre.3"
+dependencies = [
+ "burn",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "codespan-reporting"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/burn-backend/src/backend/distributed/ops.rs
+++ b/crates/burn-backend/src/backend/distributed/ops.rs
@@ -19,7 +19,7 @@ unsafe impl<B> Send for TensorRef<B> where B: Backend {}
 
 // TODO : The following functions should be moved in the `burn-autodiff` crate. The difficulty is in not discriminating between
 // the dispatch backend and its inner dispatched backend when calling the communication server API. This implementation makes
-// it easy by implementing `DisributedBackend` for `DispatchBackend`.
+// it easy by implementing `DistributedBackend` for `DispatchBackend`.
 // The functions in question :
 // * `start_communication_server`
 // * `close_communication_server`

--- a/crates/burn-tch/build.rs
+++ b/crates/burn-tch/build.rs
@@ -98,8 +98,18 @@ impl SystemInfo {
             let lib = env_var_rerun("LIBTORCH_LIB")
                 .map(PathBuf::from)
                 .unwrap_or_else(|_| libtorch.clone());
-            libtorch_include_dirs.push(includes.join("include"));
-            libtorch_include_dirs.push(includes.join("include/torch/csrc/api/include"));
+            // When DEP_TCH_LIBTORCH_LIB is propagated from torch-sys it points
+            // at .../libtorch/lib; the headers live in the parent's `include`.
+            let include_root = if includes.ends_with("lib") {
+                includes
+                    .parent()
+                    .map(|p| p.to_path_buf())
+                    .unwrap_or(includes)
+            } else {
+                includes
+            };
+            libtorch_include_dirs.push(include_root.join("include"));
+            libtorch_include_dirs.push(include_root.join("include/torch/csrc/api/include"));
             if lib.ends_with("lib") {
                 // DEP_TCH_LIBTORCH_LIB might already point to /lib
                 libtorch_lib_dir = Some(lib);
@@ -144,7 +154,9 @@ impl SystemInfo {
         } else {
             "src/cuda_hack/fake_cuda_dependency.cpp"
         };
+        let conv_backward = "src/cpp/conv_backward.cpp";
         println!("cargo:rerun-if-changed={cuda_dependency}");
+        println!("cargo:rerun-if-changed={conv_backward}");
 
         match self.os {
             Os::Linux | Os::Macos => {
@@ -156,7 +168,7 @@ impl SystemInfo {
                     .flag(format!("-Wl,-rpath={}", self.libtorch_lib_dir.display()))
                     .flag("-std=c++17")
                     .flag(format!("-D_GLIBCXX_USE_CXX11_ABI={}", self.cxx11_abi))
-                    .files(&[cuda_dependency])
+                    .files(&[cuda_dependency, conv_backward])
                     .compile("burn-tch");
             }
             Os::Windows => {
@@ -166,7 +178,7 @@ impl SystemInfo {
                     .warnings(false)
                     .includes(&self.libtorch_include_dirs)
                     .flag("/std:c++17")
-                    .files(&[cuda_dependency])
+                    .files(&[cuda_dependency, conv_backward])
                     .compile("burn-tch");
             }
         };

--- a/crates/burn-tch/src/cpp/conv_backward.cpp
+++ b/crates/burn-tch/src/cpp/conv_backward.cpp
@@ -1,0 +1,70 @@
+// FFI shim around `at::convolution_backward`.
+//
+// Pattern matches torch-sys's auto-generated wrappers:
+// - Inputs are `torch::Tensor*` (passed as `void*`)
+// - Output is a `tensor*` (i.e. `torch::Tensor**`) whose three slots are
+//   filled with `new torch::Tensor(...)` for masks set to true; nullptr otherwise.
+// - Errors set the global error string used by `read_and_clean_error` in tch
+//   so the Rust side can surface them via the `unsafe_torch_err` macro.
+
+#include <torch/torch.h>
+#include <ATen/ATen.h>
+#include <array>
+#include <cstring>
+#include <exception>
+
+extern "C" thread_local char *torch_last_err;
+
+extern "C" void burn_tch_convolution_backward(
+    void **out__,
+    void *grad_output,
+    void *input,
+    void *weight,
+    int64_t const *bias_sizes_data, size_t bias_sizes_len, int has_bias_sizes,
+    int64_t const *stride_data, size_t stride_len,
+    int64_t const *padding_data, size_t padding_len,
+    int64_t const *dilation_data, size_t dilation_len,
+    int transposed,
+    int64_t const *output_padding_data, size_t output_padding_len,
+    int64_t groups,
+    int input_mask, int weight_mask, int bias_mask) {
+    out__[0] = nullptr;
+    out__[1] = nullptr;
+    out__[2] = nullptr;
+    try {
+        const torch::Tensor &go = *static_cast<const torch::Tensor *>(grad_output);
+        const torch::Tensor &in = *static_cast<const torch::Tensor *>(input);
+        const torch::Tensor &w = *static_cast<const torch::Tensor *>(weight);
+
+        c10::OptionalArrayRef<int64_t> bias_sizes_opt;
+        if (has_bias_sizes) {
+            bias_sizes_opt = c10::ArrayRef<int64_t>(bias_sizes_data, bias_sizes_len);
+        }
+
+        std::array<bool, 3> output_mask{
+            input_mask != 0, weight_mask != 0, bias_mask != 0};
+
+        auto result = at::convolution_backward(
+            go, in, w,
+            bias_sizes_opt,
+            c10::IntArrayRef(stride_data, stride_len),
+            c10::IntArrayRef(padding_data, padding_len),
+            c10::IntArrayRef(dilation_data, dilation_len),
+            transposed != 0,
+            c10::IntArrayRef(output_padding_data, output_padding_len),
+            groups,
+            output_mask);
+
+        if (input_mask && std::get<0>(result).defined()) {
+            out__[0] = new torch::Tensor(std::get<0>(result));
+        }
+        if (weight_mask && std::get<1>(result).defined()) {
+            out__[1] = new torch::Tensor(std::get<1>(result));
+        }
+        if (bias_mask && std::get<2>(result).defined()) {
+            out__[2] = new torch::Tensor(std::get<2>(result));
+        }
+    } catch (const std::exception &e) {
+        torch_last_err = strdup(e.what());
+    }
+}

--- a/crates/burn-tch/src/ops/module.rs
+++ b/crates/burn-tch/src/ops/module.rs
@@ -8,6 +8,107 @@ use burn_backend::{
     },
     tensor::FloatTensor,
 };
+use std::os::raw::c_int;
+use torch_sys::C_tensor;
+
+unsafe extern "C" {
+    fn burn_tch_convolution_backward(
+        out__: *mut *mut C_tensor,
+        grad_output: *mut C_tensor,
+        input: *mut C_tensor,
+        weight: *mut C_tensor,
+        bias_sizes_data: *const i64,
+        bias_sizes_len: usize,
+        has_bias_sizes: c_int,
+        stride_data: *const i64,
+        stride_len: usize,
+        padding_data: *const i64,
+        padding_len: usize,
+        dilation_data: *const i64,
+        dilation_len: usize,
+        transposed: c_int,
+        output_padding_data: *const i64,
+        output_padding_len: usize,
+        groups: i64,
+        input_mask: c_int,
+        weight_mask: c_int,
+        bias_mask: c_int,
+    );
+}
+
+/// Safe wrapper around `at::convolution_backward`.
+///
+/// `output_mask` selects which gradients to compute; the corresponding tensor
+/// in the returned tuple is `Some` only if its mask bit was true and libtorch
+/// returned a defined tensor. The returned tensors are taken ownership of from
+/// the heap pointers allocated on the C++ side via shallow_clone + `at_free`.
+#[allow(clippy::too_many_arguments)]
+fn convolution_backward(
+    grad_output: &tch::Tensor,
+    input: &tch::Tensor,
+    weight: &tch::Tensor,
+    bias_sizes: Option<&[i64]>,
+    stride: &[i64],
+    padding: &[i64],
+    dilation: &[i64],
+    transposed: bool,
+    output_padding: &[i64],
+    groups: i64,
+    input_mask: bool,
+    weight_mask: bool,
+    bias_mask: bool,
+) -> (
+    Option<tch::Tensor>,
+    Option<tch::Tensor>,
+    Option<tch::Tensor>,
+) {
+    let mut out: [*mut C_tensor; 3] = [std::ptr::null_mut(); 3];
+    let (bias_sizes_ptr, bias_sizes_len, has_bias) = match bias_sizes {
+        Some(s) => (s.as_ptr(), s.len(), 1 as c_int),
+        None => (std::ptr::null(), 0, 0 as c_int),
+    };
+
+    unsafe {
+        burn_tch_convolution_backward(
+            out.as_mut_ptr(),
+            grad_output.as_ptr() as *mut C_tensor,
+            input.as_ptr() as *mut C_tensor,
+            weight.as_ptr() as *mut C_tensor,
+            bias_sizes_ptr,
+            bias_sizes_len,
+            has_bias,
+            stride.as_ptr(),
+            stride.len(),
+            padding.as_ptr(),
+            padding.len(),
+            dilation.as_ptr(),
+            dilation.len(),
+            transposed as c_int,
+            output_padding.as_ptr(),
+            output_padding.len(),
+            groups,
+            input_mask as c_int,
+            weight_mask as c_int,
+            bias_mask as c_int,
+        );
+    }
+
+    let take = |p: *mut C_tensor| -> Option<tch::Tensor> {
+        if p.is_null() {
+            None
+        } else {
+            // SAFETY: p was returned by `new torch::Tensor(...)` on the C++ side
+            // and ownership is transferred to us. clone_from_ptr does a refcount
+            // bump (shallow_clone) producing a valid wrapper; we then free the
+            // original heap-allocated wrapper to balance the `new`.
+            let t = unsafe { tch::Tensor::clone_from_ptr(p) };
+            unsafe { torch_sys::at_free(p) };
+            Some(t)
+        }
+    };
+
+    (take(out[0]), take(out[1]), take(out[2]))
+}
 
 impl<E: TchElement> ModuleOps<Self> for LibTorch<E> {
     fn embedding(weights: TchTensor, indices: TchTensor) -> TchTensor {
@@ -96,6 +197,72 @@ impl<E: TchElement> ModuleOps<Self> for LibTorch<E> {
         );
 
         TchTensor::new(tensor)
+    }
+
+    fn conv2d_x_backward(
+        x: TchTensor,
+        weight: TchTensor,
+        output_grad: TchTensor,
+        options: ConvOptions<2>,
+    ) -> TchTensor {
+        let stride = options.stride.map(|i| i as i64);
+        let padding = options.padding.map(|i| i as i64);
+        let dilation = options.dilation.map(|i| i as i64);
+        let output_padding = [0i64, 0];
+
+        let (x_grad, _, _) = convolution_backward(
+            &output_grad.tensor,
+            &x.tensor,
+            &weight.tensor,
+            None,
+            &stride,
+            &padding,
+            &dilation,
+            false,
+            &output_padding,
+            options.groups as i64,
+            true,
+            false,
+            false,
+        );
+        TchTensor::new(x_grad.expect("convolution_backward returned no input grad"))
+    }
+
+    fn conv2d_weight_backward(
+        x: TchTensor,
+        weight: TchTensor,
+        output_grad: TchTensor,
+        options: ConvOptions<2>,
+    ) -> TchTensor {
+        let stride = options.stride.map(|i| i as i64);
+        let padding = options.padding.map(|i| i as i64);
+        let dilation = options.dilation.map(|i| i as i64);
+        let output_padding = [0i64, 0];
+
+        let (_, w_grad, _) = convolution_backward(
+            &output_grad.tensor,
+            &x.tensor,
+            &weight.tensor,
+            None,
+            &stride,
+            &padding,
+            &dilation,
+            false,
+            &output_padding,
+            options.groups as i64,
+            false,
+            true,
+            false,
+        );
+        TchTensor::new(w_grad.expect("convolution_backward returned no weight grad"))
+    }
+
+    fn conv2d_bias_backward(_x: TchTensor, _bias: TchTensor, output_grad: TchTensor) -> TchTensor {
+        let kind = output_grad.tensor.kind();
+        let grad = output_grad
+            .tensor
+            .sum_dim_intlist(Some([0_i64, 2, 3].as_slice()), false, kind);
+        TchTensor::new(grad)
     }
 
     fn conv3d(


### PR DESCRIPTION
## Summary

overrides the three conv2d backward methods in `burn-tch` to call `at::convolution_backward` directly via a small C++ FFI shim — the same path PyTorch's autograd uses internally on MPS.

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

#4875 

### Changes

`burn-tch` did not implement `conv2d_x_backward` / `conv2d_weight_backward` / `conv2d_bias_backward`, so it inherited the default in `burn-backend`, which expresses conv backward via forward primitives:
- `conv_transpose2d` for input gradient
- `swap_dims + conv2d + swap_dims` for weight gradient
- `swap_dims + reshape + sum_dim + reshape` for bias gradient

This bypasses libtorch's specialized MPS kernels (`mps_convolution_backward_input` / `_weight`) — exactly the kernels PyTorch's autograd dispatches to for `loss.backward()`.

### Testing

Reproduced and measured #4875 

| Run                          | ms/step (40 steps × 5 runs avg) | vs PyTorch |
|------------------------------|--------------------------------:|-----------:|
| Burn (default)               | 169.3                           | 2.23× slower |
| **Burn (this PR)**           | **81.1**                        | **1.07×** |
| PyTorch (async, reference)   | 75.9                            | 1.0× |

