### PR TITLE
Add ParamId::try_deserialize()

### DIFF
--- a/crates/burn-core/src/module/param/id.rs
+++ b/crates/burn-core/src/module/param/id.rs
@@ -52,7 +52,7 @@ impl ParamId {
     /// # Panics
     /// On invalid id format
     pub fn deserialize(encoded: &str) -> ParamId {
-        Self::try_deserialize(&encoded).expect("Invalid id.")
+        Self::try_deserialize(encoded).expect("Invalid id.")
     }
 
     /// Deserialize a param id.
@@ -60,7 +60,7 @@ impl ParamId {
     /// Preserves compatibility with previous formats (6 bytes, 16-byte uuid).
     ///
     /// # Returns
-    /// An Option<ParamId>
+    /// An `Option<ParamId>`
     pub fn try_deserialize(encoded: &str) -> Option<ParamId> {
         let u64_id: Option<u64> = match BASE32_DNSSEC.decode(encoded.as_bytes()) {
             Ok(bytes) => {

--- a/crates/burn-core/src/module/param/id.rs
+++ b/crates/burn-core/src/module/param/id.rs
@@ -62,17 +62,26 @@ impl ParamId {
     /// # Returns
     /// An Option<ParamId>
     pub fn try_deserialize(encoded: &str) -> Option<ParamId> {
-        match BASE32_DNSSEC.decode(encoded.as_bytes()) {
+        let u64_id: Option<u64> = match BASE32_DNSSEC.decode(encoded.as_bytes()) {
             Ok(bytes) => {
                 let mut buffer = [0u8; 8];
                 buffer[..bytes.len()].copy_from_slice(&bytes);
-                Some(ParamId::from(u64::from_le_bytes(buffer)))
+                Some(u64::from_le_bytes(buffer))
             }
             Err(_) => match uuid::Uuid::try_parse(encoded) {
-                Ok(id) => Some(ParamId::deserialize(&id.to_string())),
+                // Backward compatibility with uuid parameter identifiers
+                Ok(id) => {
+                    // Hash the 128-bit uuid to 64-bit
+                    // Though not *theoretically* unique, the probability of a collision should be extremely low
+                    let mut hasher = DefaultHashBuilder::default().build_hasher();
+                    // let mut hasher = DefaultHasher::new();
+                    hasher.write(id.as_bytes());
+                    Some(hasher.finish())
+                }
                 Err(_) => None,
             },
-        }
+        };
+        u64_id.map(Self::from)
     }
 }
 

--- a/crates/burn-core/src/module/param/id.rs
+++ b/crates/burn-core/src/module/param/id.rs
@@ -48,28 +48,31 @@ impl ParamId {
     /// Deserialize a param id.
     ///
     /// Preserves compatibility with previous formats (6 bytes, 16-byte uuid).
+    ///
+    /// # Panics
+    /// On invalid id format
     pub fn deserialize(encoded: &str) -> ParamId {
-        let u64_id = match BASE32_DNSSEC.decode(encoded.as_bytes()) {
+        Self::try_deserialize(&encoded).expect("Invalid id.")
+    }
+
+    /// Deserialize a param id.
+    ///
+    /// Preserves compatibility with previous formats (6 bytes, 16-byte uuid).
+    ///
+    /// # Returns
+    /// An Option<ParamId>
+    pub fn try_deserialize(encoded: &str) -> Option<ParamId> {
+        match BASE32_DNSSEC.decode(encoded.as_bytes()) {
             Ok(bytes) => {
                 let mut buffer = [0u8; 8];
                 buffer[..bytes.len()].copy_from_slice(&bytes);
-                u64::from_le_bytes(buffer)
+                Some(ParamId::from(u64::from_le_bytes(buffer)))
             }
-            Err(err) => match uuid::Uuid::try_parse(encoded) {
-                // Backward compatibility with uuid parameter identifiers
-                Ok(id) => {
-                    // Hash the 128-bit uuid to 64-bit
-                    // Though not *theoretically* unique, the probability of a collision should be extremely low
-                    let mut hasher = DefaultHashBuilder::default().build_hasher();
-                    // let mut hasher = DefaultHasher::new();
-                    hasher.write(id.as_bytes());
-                    hasher.finish()
-                }
-                Err(_) => panic!("Invalid id. {err}"),
+            Err(_) => match uuid::Uuid::try_parse(encoded) {
+                Ok(id) => Some(ParamId::deserialize(&id.to_string())),
+                Err(_) => None,
             },
-        };
-
-        ParamId::from(u64_id)
+        }
     }
 }
 
@@ -82,6 +85,15 @@ impl core::fmt::Display for ParamId {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn param_serde_try_deserialize() {
+        let val = ParamId::from(123456u64);
+        let deserialized = ParamId::try_deserialize(&val.serialize()).unwrap();
+        assert_eq!(val, deserialized);
+
+        assert_eq!(ParamId::try_deserialize("invalid_id"), None);
+    }
 
     #[test]
     fn param_serde_deserialize() {


### PR DESCRIPTION
Deserialization should not panic on failure, or should have non-panic pathways.