### PR TITLE
Use gather_nd in RNN-T gather_loss

### DIFF
--- a/crates/burn-nn/src/loss/rnnt.rs
+++ b/crates/burn-nn/src/loss/rnnt.rs
@@ -1,4 +1,5 @@
 use super::Reduction;
+use alloc::vec;
 use burn::config::Config;
 use burn::module::Module;
 use burn::tensor::{Bool, Int, Tensor, backend::Backend, s};

--- a/crates/burn-nn/src/loss/rnnt.rs
+++ b/crates/burn-nn/src/loss/rnnt.rs
@@ -235,9 +235,13 @@ impl RNNTLoss {
         b: usize,
     ) -> Tensor<B, 1> {
         let device = alpha.device();
-        let t_idx = logit_lengths.sub_scalar(1);
+        // Anchor the index dtype on `u_idx` so all three coordinate tensors share a
+        // common int dtype before stacking - `cat` panics on dtype mismatch and the
+        // caller's lengths may not use the device's default IntElem.
         let u_idx = target_lengths;
-        let b_idx = Tensor::<B, 1, Int>::arange(0..b as i64, &device);
+        let int_dtype = u_idx.dtype();
+        let t_idx = logit_lengths.sub_scalar(1).cast(int_dtype);
+        let b_idx = Tensor::<B, 1, Int>::arange(0..b as i64, (&device, int_dtype));
 
         let alpha_tu: Tensor<B, 1> =
             alpha.gather_nd(Tensor::stack::<2>(vec![b_idx.clone(), u_idx.clone()], 1));

--- a/crates/burn-nn/src/loss/rnnt.rs
+++ b/crates/burn-nn/src/loss/rnnt.rs
@@ -240,8 +240,9 @@ impl RNNTLoss {
 
         let alpha_tu: Tensor<B, 1> =
             alpha.gather_nd(Tensor::stack::<2>(vec![b_idx.clone(), u_idx.clone()], 1));
-        let lpb_tu: Tensor<B, 1> =
-            lpb.clone().gather_nd(Tensor::stack::<2>(vec![b_idx, t_idx, u_idx], 1));
+        let lpb_tu: Tensor<B, 1> = lpb
+            .clone()
+            .gather_nd(Tensor::stack::<2>(vec![b_idx, t_idx, u_idx], 1));
 
         alpha_tu.add(lpb_tu).neg()
     }

--- a/crates/burn-nn/src/loss/rnnt.rs
+++ b/crates/burn-nn/src/loss/rnnt.rs
@@ -93,7 +93,7 @@ impl RNNTLoss {
             alpha = alpha.mask_where(valid, new);
         }
 
-        self.gather_loss(alpha, &lpb, logit_lengths, target_lengths, b, max_up1)
+        self.gather_loss(alpha, &lpb, logit_lengths, target_lengths, b)
     }
 
     /// Computes RNNT loss with the given reduction. Returns shape `[1]`.
@@ -232,19 +232,16 @@ impl RNNTLoss {
         logit_lengths: Tensor<B, 1, Int>,
         target_lengths: Tensor<B, 1, Int>,
         b: usize,
-        max_up1: usize,
     ) -> Tensor<B, 1> {
+        let device = alpha.device();
         let t_idx = logit_lengths.sub_scalar(1);
         let u_idx = target_lengths;
+        let b_idx = Tensor::<B, 1, Int>::arange(0..b as i64, &device);
 
-        let alpha_tu = alpha
-            .gather(1, u_idx.clone().reshape([b, 1]))
-            .squeeze_dim::<1>(1);
-
-        // Gather blank prob at (T_b, U_b)
-        let t_exp = t_idx.reshape([b, 1, 1]).expand([b, 1, max_up1]);
-        let lpb_t = lpb.clone().gather(1, t_exp).squeeze_dim::<2>(1);
-        let lpb_tu = lpb_t.gather(1, u_idx.reshape([b, 1])).squeeze_dim::<1>(1);
+        let alpha_tu: Tensor<B, 1> =
+            alpha.gather_nd(Tensor::stack::<2>(vec![b_idx.clone(), u_idx.clone()], 1));
+        let lpb_tu: Tensor<B, 1> =
+            lpb.clone().gather_nd(Tensor::stack::<2>(vec![b_idx, t_idx, u_idx], 1));
 
         alpha_tu.add(lpb_tu).neg()
     }


### PR DESCRIPTION
## Summary

- Replaces the chained `reshape` + `expand` + `gather` pattern in `RNNTLoss::gather_loss` with two `gather_nd` calls (#4709).
- Drops one fully-broadcast `[B, 1, U+1]` index materialization and one kernel launch per loss evaluation.
- Removes the now-orphaned `max_up1` parameter from the private signature and its single call site.

## Test plan

- [x] `cargo test -p burn-nn --lib loss::rnnt` - all 13 tests pass, including the 5 PyTorch numerical-parity cases (`basic_b1`, `batched_b2`, `variable_lengths_b3`, `mean_reduction`, `sum_reduction`).

Related cleanup ideas not in scope here are tracked in #4893.
