### PR TITLE
Fix cubecl cross product on non-last dimension

### DIFF
--- a/crates/burn-backend-tests/tests/autodiff/cross.rs
+++ b/crates/burn-backend-tests/tests/autodiff/cross.rs
@@ -1,9 +1,6 @@
 use super::*;
 use burn_tensor::{TensorData, Tolerance};
 
-#[cfg(feature = "std")]
-use burn_backend_tests::might_panic;
-
 #[test]
 fn backward_basic() {
     let device = AutodiffDevice::new();
@@ -62,21 +59,15 @@ fn backward_after_sum() {
     b_grad.assert_approx_eq::<FloatElem>(&expected_b, Tolerance::default());
 }
 
-#[cfg(feature = "std")]
-#[might_panic(reason = "not implemented: Cross product on non-last dimension")]
 #[test]
 fn different_dim() {
-    // Also check when the cross is along a different dimension (e.g. dim 0).
+    // Cross along a non-last dimension (dim 0) treats columns as 3-vectors.
     let device = AutodiffDevice::new();
     let a_raw = [[1.0, 4.0, 7.0], [2.0, 5.0, 8.0], [3.0, 6.0, 9.0]];
     let b_raw = [[9.0, 6.0, 3.0], [8.0, 5.0, 2.0], [7.0, 4.0, 1.0]];
 
     let a = TestTensor::<2>::from_data(TensorData::from(a_raw), &device);
     let b = TestTensor::<2>::from_data(TensorData::from(b_raw), &device);
-    // Cross along dim 0. Some backends (for example CubeCL) may not support
-    // cross on non-last dimensions and will intentionally panic with a
-    // message like "Cross product on non-last dimension not yet implemented".
-    // In that case we treat the panic as a skipped test for that backend.
     let out = a.cross(b.clone(), 0);
 
     // Manually compute cross of each column vector using raw arrays
@@ -100,4 +91,40 @@ fn different_dim() {
 
     out.to_data()
         .assert_approx_eq::<FloatElem>(&TensorData::from(expected), Tolerance::default());
+}
+
+#[test]
+fn backward_non_last_dim() {
+    // Backward through a cross on dim 0. The autodiff rule recurses through
+    // float_cross with the same dim, so this also exercises the non-last-dim
+    // forward path on the gradient pass.
+    let device = AutodiffDevice::new();
+    let a = TestTensor::<2>::from_data(
+        TensorData::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]),
+        &device,
+    )
+    .require_grad();
+    let b = TestTensor::<2>::from_data(
+        TensorData::from([[9.0, 8.0, 7.0], [6.0, 5.0, 4.0], [3.0, 2.0, 1.0]]),
+        &device,
+    )
+    .require_grad();
+
+    // Cross on the column dimension, then permute and cross on the last dim.
+    // Both paths share the same expected gradient magnitudes; we compare the
+    // dim-0 output against the reference last-dim output to keep the check
+    // backend-agnostic.
+    let c0 = a.clone().cross(b.clone(), 0);
+    let c_ref = a
+        .clone()
+        .permute([1, 0])
+        .cross(b.clone().permute([1, 0]), 1)
+        .permute([1, 0]);
+
+    c0.to_data()
+        .assert_approx_eq::<FloatElem>(&c_ref.to_data(), Tolerance::default());
+
+    let grads = c0.sum().backward();
+    assert!(a.grad(&grads).is_some());
+    assert!(b.grad(&grads).is_some());
 }

--- a/crates/burn-backend-tests/tests/tensor/float/ops/cross.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/cross.rs
@@ -1,9 +1,6 @@
 use super::*;
 use burn_tensor::TensorData;
 
-#[cfg(feature = "std")]
-use burn_backend_tests::might_panic;
-
 #[test]
 fn test_cross_3d_last_dim() {
     let tensor_1 = TestTensor::<2>::from([[1.0, 3.0, -5.0], [2.0, -1.0, 4.0]]);
@@ -30,8 +27,6 @@ fn test_cross_3d_non_contiguous_last_dim() {
     );
 }
 
-#[cfg(feature = "std")]
-#[might_panic(reason = "not implemented: Cross product on non-last dimension")]
 #[test]
 fn test_cross_3d_dim0() {
     let tensor_1 = TestTensor::<2>::from([[1.0, 0.0], [0.0, 1.0], [0.0, 0.0]]);
@@ -43,6 +38,58 @@ fn test_cross_3d_dim0() {
         &TensorData::from([[0.0, 0.0], [-1.0, 0.0], [0.0, -1.0]]),
         false,
     );
+}
+
+#[test]
+fn test_cross_4d_middle_dim() {
+    // Shape [1, 3, 2]; cross along dim=1 should match the corresponding
+    // permuted last-dim cross.
+    let tensor_1 = TestTensor::<3>::from([[[1.0, 0.0], [0.0, 1.0], [0.0, 0.0]]]);
+    let tensor_2 = TestTensor::from([[[0.0, 1.0], [0.0, 0.0], [1.0, 0.0]]]);
+
+    let output = tensor_1.cross(tensor_2, 1);
+
+    output.into_data().assert_eq(
+        &TensorData::from([[[0.0, 0.0], [-1.0, 0.0], [0.0, -1.0]]]),
+        false,
+    );
+}
+
+#[test]
+fn test_cross_non_last_dim_broadcast() {
+    // Broadcast on a non-last cross dim: lhs shape [3, 1] vs rhs shape [3, 4]
+    // crossed along dim=0 must equal the same op on the permuted [1, 3] vs
+    // [4, 3] along dim=1 (last) and then permuted back.
+    let lhs = TestTensor::<2>::from([[1.0], [2.0], [3.0]]);
+    let rhs = TestTensor::<2>::from([
+        [4.0, 5.0, 6.0, 7.0],
+        [8.0, 9.0, 10.0, 11.0],
+        [12.0, 13.0, 14.0, 15.0],
+    ]);
+
+    let non_last = lhs.clone().cross(rhs.clone(), 0);
+    let last_dim = lhs
+        .permute([1, 0])
+        .cross(rhs.permute([1, 0]), 1)
+        .permute([1, 0]);
+
+    non_last.into_data().assert_eq(&last_dim.into_data(), false);
+}
+
+#[test]
+fn test_cross_non_last_dim_matches_permuted_last_dim() {
+    // Cross on a non-last dim must equal: permute -> cross on last dim ->
+    // permute back. Here we cross [N, 3] along dim=1 (last) and along dim=0
+    // after a transpose of the same data.
+    let a = TestTensor::<2>::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+    let b = TestTensor::<2>::from([[7.0, 8.0, 9.0], [1.0, 0.0, -1.0]]);
+
+    let last_dim = a.clone().cross(b.clone(), 1);
+    let non_last = a.permute([1, 0]).cross(b.permute([1, 0]), 0);
+
+    last_dim
+        .into_data()
+        .assert_eq(&non_last.permute([1, 0]).into_data(), false);
 }
 
 #[test]

--- a/crates/burn-cubecl/src/kernel/cross.rs
+++ b/crates/burn-cubecl/src/kernel/cross.rs
@@ -1,7 +1,10 @@
 use crate::{
     CubeRuntime,
-    kernel::utils::{address_type, broadcast_shape},
-    ops::numeric::empty_device_dtype,
+    kernel::{
+        into_contiguous,
+        utils::{address_type, broadcast_shape},
+    },
+    ops::{numeric::empty_device_dtype, swap_dims},
     tensor::CubeTensor,
 };
 use cubecl::std::tensor::layout::linear::LinearView;
@@ -58,11 +61,17 @@ pub(crate) fn cross<R: CubeRuntime>(
         );
     }
 
-    // For now, only support cross on the last dimension
+    // The kernel reads each 3-vector from contiguous memory, so it expects the
+    // cross dimension to be the last (innermost) and physically contiguous.
+    // For non-last dims we permute the cross dim to the last position, run the
+    // kernel, then permute the result back. swap_dims only updates strides, so
+    // make the permuted operands contiguous before launch.
     if dim != ndims - 1 {
-        unimplemented!(
-            "Cross product on non-last dimension not yet implemented for CubeCL backend"
-        );
+        let last = ndims - 1;
+        let lhs = into_contiguous(swap_dims(lhs, dim, last));
+        let rhs = into_contiguous(swap_dims(rhs, dim, last));
+        let result = cross(lhs, rhs, last);
+        return swap_dims(result, dim, last);
     }
 
     let output_shape = broadcast_shape(&[&lhs, &rhs]);


### PR DESCRIPTION
### Related Issues/PRs

Closes #4850.

### Changes

The cubecl cross kernel reads each 3-vector from contiguous memory along the innermost axis, so it could only run when the cross dim was the last one. For other dims it bailed out with `unimplemented!()`, panicking on every cubecl-family backend (cuda, wgpu, metal, vulkan, rocm) and poisoning the fusion stream.

Fix in `crates/burn-cubecl/src/kernel/cross.rs`: permute the cross dim to the last position, contiguize the operands (`swap_dims` is metadata-only), run the existing kernel, and permute the result back. Recursion terminates after one swap because the inner call always hits `dim == ndims - 1`.

```rust
if dim != ndims - 1 {
    let last = ndims - 1;
    let lhs = into_contiguous(swap_dims(lhs, dim, last));
    let rhs = into_contiguous(swap_dims(rhs, dim, last));
    let result = cross(lhs, rhs, last);
    return swap_dims(result, dim, last);
}
```

The two `into_contiguous` copies are the price of reusing the existing kernel for non-last-dim cases. A bespoke strided kernel would avoid them but is a much bigger change; happy to follow up if the perf cost matters.

The cascading `burn-fusion` panic mentioned in the issue goes away as a side effect once `cross` stops panicking. Making fusion resilient to upstream panics in general is left as the follow-up the issue itself flags.

### Testing

`cargo test-metal --test tensor cross` — 10/10 pass, including:
- Existing `test_cross_3d_dim0` (drops the `might_panic` guard).
- New `test_cross_4d_middle_dim` — cross on a middle dim of a rank-3 tensor.
- New `test_cross_non_last_dim_broadcast` — `[3,1]` × `[3,4]` cross dim=0, validated against the permuted last-dim equivalent.
- New `test_cross_non_last_dim_matches_permuted_last_dim`.

`cargo test-metal --test autodiff cross` — 18/18 pass:
- Existing `different_dim` (drops the `might_panic` guard).
- New `backward_non_last_dim` — gradients flow through cross on dim 0 (the autodiff rule recurses into `float_cross` with the same dim, so this also exercises the non-last-dim forward path on the gradient pass).

`cargo test-metal-nofuse --test cubecl cross` — 7/7 pass.

Also re-ran the same tests on `wgpu` (10/10) and `cpu` (10/10) to make sure nothing else regressed. The kernel fix lives in shared cubecl code, so cuda/vulkan/rocm get the same fix without separate changes.

### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR. (no book changes needed.)