### PR TITLE
Add argtopk (Cubecl backend)

### DIFF
--- a/crates/burn-autodiff/src/ops/int_tensor.rs
+++ b/crates/burn-autodiff/src/ops/int_tensor.rs
@@ -255,6 +255,11 @@ impl<B: Backend, C: CheckpointStrategy> IntTensorOps<Self> for Autodiff<B, C> {
     fn int_argmax(tensor: IntTensor<B>, dim: usize) -> IntTensor<B> {
         B::int_argmax(tensor, dim)
     }
+
+    fn int_argtopk(tensor: IntTensor<B>, dim: usize, k: usize) -> IntTensor<B> {
+        B::int_argtopk(tensor, dim, k)
+    }
+
     fn int_argmin(tensor: IntTensor<B>, dim: usize) -> IntTensor<B> {
         B::int_argmin(tensor, dim)
     }

--- a/crates/burn-autodiff/src/ops/tensor.rs
+++ b/crates/burn-autodiff/src/ops/tensor.rs
@@ -2133,12 +2133,12 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
     }
 
     fn float_argtopk(
-        _tensor: FloatTensor<Self>,
-        _dim: usize,
-        _k: usize,
-        _out_dtype: IntDType,
+        tensor: FloatTensor<Self>,
+        dim: usize,
+        k: usize,
+        out_dtype: IntDType,
     ) -> IntTensor<B> {
-        todo!();
+        B::float_argtopk(tensor.primitive, dim, k, out_dtype)
     }
 
     fn float_argmin(tensor: FloatTensor<Self>, dim: usize, out_dtype: IntDType) -> IntTensor<B> {

--- a/crates/burn-autodiff/src/ops/tensor.rs
+++ b/crates/burn-autodiff/src/ops/tensor.rs
@@ -2132,6 +2132,15 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
         B::float_argmax(tensor.primitive, dim, out_dtype)
     }
 
+    fn float_argtopk(
+        _tensor: FloatTensor<Self>,
+        _dim: usize,
+        _k: usize,
+        _out_dtype: IntDType,
+    ) -> IntTensor<B> {
+        todo!();
+    }
+
     fn float_argmin(tensor: FloatTensor<Self>, dim: usize, out_dtype: IntDType) -> IntTensor<B> {
         B::float_argmin(tensor.primitive, dim, out_dtype)
     }

--- a/crates/burn-backend-tests/tests/cubecl/reduce.rs
+++ b/crates/burn-backend-tests/tests/cubecl/reduce.rs
@@ -22,6 +22,15 @@ fn reduction_argmax_should_match_reference_backend() {
 }
 
 #[test]
+fn reduction_argtopk_simple() {
+    let device = Default::default();
+
+    let tensor = TestTensor::<2>::from_data([[1, 7, 3], [5, 2, 8]], &device);
+
+    panic!("tensor: {}", tensor.argtopk(1, 0));
+}
+
+#[test]
 fn reduction_argmin_should_match_reference_backend() {
     let device = Default::default();
     let ref_device = ReferenceDevice::new();

--- a/crates/burn-backend-tests/tests/cubecl/reduce.rs
+++ b/crates/burn-backend-tests/tests/cubecl/reduce.rs
@@ -1,5 +1,6 @@
 use super::*;
 use burn_tensor::Distribution;
+use burn_tensor::Shape;
 use burn_tensor::Tolerance;
 
 const RANK: usize = 4;
@@ -25,9 +26,13 @@ fn reduction_argmax_should_match_reference_backend() {
 fn reduction_argtopk_simple() {
     let device = Default::default();
 
-    let tensor = TestTensor::<2>::from_data([[1, 7, 3], [5, 2, 8]], &device);
+    let tensor = TestTensor::<2>::from_data([[1, 7, 3], [8, 2, 8]], &device);
+    let actual = tensor.argtopk(1, 2);
+    let expected = TestTensor::<2>::from_data([[1, 2], [0, 2]], &device);
 
-    panic!("tensor: {}", tensor.argtopk(1, 2));
+    let output_shape = Shape::new([2, 2]);
+    assert_eq!(actual.shape(), output_shape);
+    actual.into_data().assert_eq(&expected.into_data(), false);
 }
 
 #[test]

--- a/crates/burn-backend-tests/tests/cubecl/reduce.rs
+++ b/crates/burn-backend-tests/tests/cubecl/reduce.rs
@@ -27,7 +27,7 @@ fn reduction_argtopk_simple() {
 
     let tensor = TestTensor::<2>::from_data([[1, 7, 3], [5, 2, 8]], &device);
 
-    panic!("tensor: {}", tensor.argtopk(1, 0));
+    panic!("tensor: {}", tensor.argtopk(1, 2));
 }
 
 #[test]

--- a/crates/burn-backend/src/backend/ops/int_tensor.rs
+++ b/crates/burn-backend/src/backend/ops/int_tensor.rs
@@ -904,6 +904,20 @@ pub trait IntTensorOps<B: Backend> {
     /// The indices of the maximum elements along the dimension.
     fn int_argmax(tensor: IntTensor<B>, dim: usize) -> IntTensor<B>;
 
+
+    /// Gets the indices of the k maximum elements along a dimension.
+    /// If two elements share the same value, it will be ordered by the lowest
+    /// coordinate
+    ///
+    /// # Arguments
+    ///
+    /// * `tensor` - The tensor to get the maximum indices of.
+    /// * `dim` - The dimension to get the maximum indices along.
+    /// * `k` - number of maximum elements.
+    ///
+    /// # Returns
+    ///
+    /// The indices of the maximum elements along the dimension.
     fn int_argtopk(tensor: IntTensor<B>, dim: usize, k: usize) -> IntTensor<B>;
 
     /// Gets the indices of the minimum elements along a dimension.

--- a/crates/burn-backend/src/backend/ops/int_tensor.rs
+++ b/crates/burn-backend/src/backend/ops/int_tensor.rs
@@ -904,7 +904,6 @@ pub trait IntTensorOps<B: Backend> {
     /// The indices of the maximum elements along the dimension.
     fn int_argmax(tensor: IntTensor<B>, dim: usize) -> IntTensor<B>;
 
-
     /// Gets the indices of the k maximum elements along a dimension.
     /// If two elements share the same value, it will be ordered by the lowest
     /// coordinate

--- a/crates/burn-backend/src/backend/ops/int_tensor.rs
+++ b/crates/burn-backend/src/backend/ops/int_tensor.rs
@@ -904,6 +904,8 @@ pub trait IntTensorOps<B: Backend> {
     /// The indices of the maximum elements along the dimension.
     fn int_argmax(tensor: IntTensor<B>, dim: usize) -> IntTensor<B>;
 
+    fn int_argtopk(tensor: IntTensor<B>, dim: usize, k: usize) -> IntTensor<B>;
+
     /// Gets the indices of the minimum elements along a dimension.
     ///
     /// # Arguments

--- a/crates/burn-backend/src/backend/ops/qtensor.rs
+++ b/crates/burn-backend/src/backend/ops/qtensor.rs
@@ -953,7 +953,6 @@ pub trait QTensorOps<B: Backend> {
         B::float_argmax(tensor_f, dim, out_dtype)
     }
 
-
     /// Gets the indices of the k maximum elements of a tensor along an axis.
     /// If two elements are equals, order them by the lowest indices
     ///

--- a/crates/burn-backend/src/backend/ops/qtensor.rs
+++ b/crates/burn-backend/src/backend/ops/qtensor.rs
@@ -953,6 +953,20 @@ pub trait QTensorOps<B: Backend> {
         B::float_argmax(tensor_f, dim, out_dtype)
     }
 
+
+    /// Gets the indices of the k maximum elements of a tensor along an axis.
+    /// If two elements are equals, order them by the lowest indices
+    ///
+    /// # Arguments
+    ///
+    /// * `tensor` - The tensor to get the k maximum elements of.
+    /// * `dim` - The dimension along which to get the maximum elements.
+    /// * `k` - number of k maximums to keep
+    /// * `out_dtype` - The output tensor dtype.
+    ///
+    /// # Returns
+    ///
+    /// A tensor with the indices of the `k` maximum elements of `tensor` along `dim`.
     fn q_argtopk(
         tensor: QuantizedTensor<B>,
         dim: usize,

--- a/crates/burn-backend/src/backend/ops/qtensor.rs
+++ b/crates/burn-backend/src/backend/ops/qtensor.rs
@@ -953,6 +953,17 @@ pub trait QTensorOps<B: Backend> {
         B::float_argmax(tensor_f, dim, out_dtype)
     }
 
+    fn q_argtopk(
+        tensor: QuantizedTensor<B>,
+        dim: usize,
+        k: usize,
+        out_dtype: IntDType,
+    ) -> IntTensor<B> {
+        let dtype = get_device_settings::<B>(&Self::q_device(&tensor)).float_dtype;
+        let tensor_f = Self::dequantize(tensor, dtype);
+        B::float_argtopk(tensor_f, dim, k, out_dtype)
+    }
+
     /// Gets the indices of the minimum elements of a tensor along an axis.
     ///
     /// # Arguments

--- a/crates/burn-backend/src/backend/ops/tensor.rs
+++ b/crates/burn-backend/src/backend/ops/tensor.rs
@@ -1369,6 +1369,14 @@ pub trait FloatTensorOps<B: Backend> {
     /// A tensor with the indices of the maximum elements of `tensor` along `dim`.
     fn float_argmax(tensor: FloatTensor<B>, dim: usize, out_dtype: IntDType) -> IntTensor<B>;
 
+    /// todo!()
+    fn float_argtopk(
+        tensor: FloatTensor<B>,
+        dim: usize,
+        k: usize,
+        out_dtype: IntDType,
+    ) -> IntTensor<B>;
+
     /// Gets the indices of the minimum elements of a tensor along an axis.
     ///
     /// # Arguments

--- a/crates/burn-backend/src/backend/ops/tensor.rs
+++ b/crates/burn-backend/src/backend/ops/tensor.rs
@@ -1369,7 +1369,19 @@ pub trait FloatTensorOps<B: Backend> {
     /// A tensor with the indices of the maximum elements of `tensor` along `dim`.
     fn float_argmax(tensor: FloatTensor<B>, dim: usize, out_dtype: IntDType) -> IntTensor<B>;
 
-    /// todo!()
+    /// Gets the indices of the k maximum elements of a tensor along an axis.
+    /// if two elements are equals, it will be ordered by lowest indices
+    ///
+    /// # Arguments
+    ///
+    /// * `tensor` - The tensor to get the maximum elements of.
+    /// * `dim` - The dimension along which to get the maximum elements.
+    /// * `k` - number of maximum elements
+    /// * `out_dtype` - The output tensor dtype.
+    ///
+    /// # Returns
+    ///
+    /// A tensor with the indices of the maximum elements of `tensor` along `dim`.
     fn float_argtopk(
         tensor: FloatTensor<B>,
         dim: usize,

--- a/crates/burn-backend/src/tensor/ops/float.rs
+++ b/crates/burn-backend/src/tensor/ops/float.rs
@@ -620,6 +620,19 @@ impl<B: Backend> Ordered<B> for Float {
         }
     }
 
+    fn argtopk(tensor: Self::Primitive, dim: usize, k: usize) -> IntTensor<B> {
+        match tensor {
+            TensorPrimitive::Float(tensor) => {
+                let out_dtype = get_device_settings::<B>(&B::float_device(&tensor)).int_dtype;
+                B::float_argtopk(tensor, dim, k, out_dtype)
+            }
+            TensorPrimitive::QFloat(tensor) => {
+                let out_dtype = get_device_settings::<B>(&B::q_device(&tensor)).int_dtype;
+                B::q_argtopk(tensor, dim, k, out_dtype)
+            }
+        }
+    }
+
     fn argmin(tensor: Self::Primitive, dim: usize) -> IntTensor<B> {
         match tensor {
             TensorPrimitive::Float(tensor) => {

--- a/crates/burn-backend/src/tensor/ops/int.rs
+++ b/crates/burn-backend/src/tensor/ops/int.rs
@@ -376,6 +376,10 @@ impl<B: Backend> Ordered<B> for Int {
         B::int_argmax(tensor, dim)
     }
 
+    fn argtopk(tensor: Self::Primitive, dim: usize, k: usize) -> IntTensor<B> {
+        B::int_argtopk(tensor, dim, k)
+    }
+
     fn argmin(tensor: Self::Primitive, dim: usize) -> IntTensor<B> {
         B::int_argmin(tensor, dim)
     }

--- a/crates/burn-backend/src/tensor/ops/ordered.rs
+++ b/crates/burn-backend/src/tensor/ops/ordered.rs
@@ -369,6 +369,29 @@ pub trait Ordered<B: Backend>: Numeric<B> {
     /// function, which is more high-level and designed for public use.
     fn argmax(tensor: Self::Primitive, dim: usize) -> IntTensor<B>;
 
+    /// Gets the indices of the k maximum elements of a tensor along an axis.
+    ///
+    /// # Arguments
+    ///
+    /// * `dim` - The axis along which to get the indices of the maximum elements.
+    /// * `tensor` - The tensor to get the indices of the maximum elements from.
+    /// * `k` - k maximum elements to get
+    ///
+    /// # Returns
+    ///
+    /// A tensor with the same shape as the input tensor, where each element is the index of the
+    /// k maximums elements of the input tensor at the corresponding index along the specified axis.
+    ///
+    /// # Remarks
+    ///
+    /// This is a low-level function used internally by the library to call different backend functions
+    /// with static dispatch. It is not designed for direct usage by users, and not recommended to import
+    /// or use this function directly.
+    ///
+    /// For getting the indices of the k maximum elements of a tensor along an axis, users should prefer the
+    #[cfg_attr(doc, doc = crate::doc_tensor!("argtopk"))]
+    #[cfg_attr(not(doc), doc = "`Tensor::argtopk`")]
+    /// function, which is more high-level and designed for public use.
     fn argtopk(tensor: Self::Primitive, dim: usize, k: usize) -> IntTensor<B>;
 
     /// Gets the indices of the minimum elements of a tensor along an axis.

--- a/crates/burn-backend/src/tensor/ops/ordered.rs
+++ b/crates/burn-backend/src/tensor/ops/ordered.rs
@@ -369,6 +369,8 @@ pub trait Ordered<B: Backend>: Numeric<B> {
     /// function, which is more high-level and designed for public use.
     fn argmax(tensor: Self::Primitive, dim: usize) -> IntTensor<B>;
 
+    fn argtopk(tensor: Self::Primitive, dim: usize, k: usize) -> IntTensor<B>;
+
     /// Gets the indices of the minimum elements of a tensor along an axis.
     ///
     /// # Arguments

--- a/crates/burn-backend/src/tensor/ops/ordered.rs
+++ b/crates/burn-backend/src/tensor/ops/ordered.rs
@@ -354,8 +354,9 @@ pub trait Ordered<B: Backend>: Numeric<B> {
     ///
     /// # Returns
     ///
-    /// A tensor with the same shape as the input tensor, where each element is the index of the
-    /// maximum element of the input tensor at the corresponding index along the specified axis.
+    /// A tensor where the dimension `dim` has size 1 and all other dimensions
+    /// are the same as the input tensor. Each element is the index of the maximum
+    /// value.
     ///
     /// # Remarks
     ///
@@ -379,8 +380,9 @@ pub trait Ordered<B: Backend>: Numeric<B> {
     ///
     /// # Returns
     ///
-    /// A tensor with the same shape as the input tensor, where each element is the index of the
-    /// k maximums elements of the input tensor at the corresponding index along the specified axis.
+    /// A tensor where the dimension `dim` has size `k` and all other dimensions
+    /// are the same as the input tensor. Each element is the index of one of the
+    /// `k` largest values along the specified axis.
     ///
     /// # Remarks
     ///
@@ -403,8 +405,9 @@ pub trait Ordered<B: Backend>: Numeric<B> {
     ///
     /// # Returns
     ///
-    /// A tensor with the same shape as the input tensor, where each element is the index of the
-    /// minimum element of the input tensor at the corresponding index along the specified axis.
+    /// A tensor where the dimension `dim` has size 1 and all other dimensions
+    /// are the same as the input tensor. Each element is the index of the minimum
+    /// value.
     ///
     /// # Remarks
     ///

--- a/crates/burn-candle/src/ops/int_tensor.rs
+++ b/crates/burn-candle/src/ops/int_tensor.rs
@@ -410,6 +410,10 @@ impl<F: FloatCandleElement, I: IntCandleElement> IntTensorOps<Self> for Candle<F
         )
     }
 
+    fn int_argtopk(tensor: IntTensor<Self>, dim: usize, k: usize) -> IntTensor<Self> {
+        panic!("argtopk not implemented for candle backend")
+    }
+
     fn int_argmin(tensor: IntTensor<Self>, dim: usize) -> IntTensor<Self> {
         CandleTensor::new(
             tensor

--- a/crates/burn-candle/src/ops/tensor.rs
+++ b/crates/burn-candle/src/ops/tensor.rs
@@ -584,6 +584,15 @@ impl<F: FloatCandleElement, I: IntCandleElement> FloatTensorOps<Self> for Candle
         )
     }
 
+    fn float_argtopk(
+        tensor: FloatTensor<Self>,
+        dim: usize,
+        k: usize,
+        out_dtype: IntDType,
+    ) -> IntTensor<Self> {
+        panic!("argtopk not implemented for candle backend")
+    }
+
     fn float_argmin(tensor: FloatTensor<Self>, dim: usize, out_dtype: IntDType) -> IntTensor<Self> {
         CandleTensor::new(
             tensor

--- a/crates/burn-cubecl/src/kernel/reduce/base.rs
+++ b/crates/burn-cubecl/src/kernel/reduce/base.rs
@@ -167,8 +167,8 @@ pub fn reduce_dim<Run: CubeRuntime>(
     );
 
     let reduce_len = match config {
-        ReduceOperationConfig::ArgTopK(k) => Some(k),
-        _ => Some(1),
+        ReduceOperationConfig::ArgTopK(k) => k,
+        _ => 1,
     };
     let dtypes = config.precision(input.dtype.into(), output_dtype.map(Into::into));
     let client = input.client.clone();
@@ -218,9 +218,8 @@ pub fn init_reduce_output<Run: CubeRuntime>(
     input: &CubeTensor<Run>,
     dim: usize,
     dtypes: &ReduceDtypes,
-    reduce_len: Option<usize>,
+    reduce_len: usize,
 ) -> Option<CubeTensor<Run>> {
-    let reduce_len = reduce_len.unwrap_or(1);
     (dim < input.meta.num_dims()).then(|| {
         let mut shape_out = input.shape();
         shape_out[dim] = reduce_len;

--- a/crates/burn-cubecl/src/kernel/reduce/base.rs
+++ b/crates/burn-cubecl/src/kernel/reduce/base.rs
@@ -162,7 +162,7 @@ pub fn reduce_dim<Run: CubeRuntime>(
                 | ReduceOperationConfig::ArgMin
                 | ReduceOperationConfig::ArgTopK(_)
         ) || output_dtype.is_some(),
-        "The `output_dtype` has to be `Some` only when the `config` is `ArgMax` or `ArgMin`.
+        "The `output_dtype` has to be `Some` only when the `config` is `ArgMax`, `ArgMin` or `ArgTopK`.
         "
     );
 

--- a/crates/burn-cubecl/src/kernel/reduce/base.rs
+++ b/crates/burn-cubecl/src/kernel/reduce/base.rs
@@ -158,15 +158,21 @@ pub fn reduce_dim<Run: CubeRuntime>(
     debug_assert!(
         !matches!(
             config,
-            ReduceOperationConfig::ArgMax | ReduceOperationConfig::ArgMin
+            ReduceOperationConfig::ArgMax
+                | ReduceOperationConfig::ArgMin
+                | ReduceOperationConfig::ArgTopK(_)
         ) || output_dtype.is_some(),
         "The `output_dtype` has to be `Some` only when the `config` is `ArgMax` or `ArgMin`.
         "
     );
 
+    let reduce_len = match config {
+        ReduceOperationConfig::ArgTopK(k) => Some(k),
+        _ => Some(1),
+    };
     let dtypes = config.precision(input.dtype.into(), output_dtype.map(Into::into));
     let client = input.client.clone();
-    let output = init_reduce_output::<Run>(&input, dim, &dtypes).ok_or(
+    let output = init_reduce_output::<Run>(&input, dim, &dtypes, reduce_len).ok_or(
         cubek::reduce::ReduceError::InvalidAxis {
             axis: dim,
             rank: input.meta.num_dims(),
@@ -212,10 +218,12 @@ pub fn init_reduce_output<Run: CubeRuntime>(
     input: &CubeTensor<Run>,
     dim: usize,
     dtypes: &ReduceDtypes,
+    reduce_len: Option<usize>,
 ) -> Option<CubeTensor<Run>> {
+    let reduce_len = reduce_len.unwrap_or(1);
     (dim < input.meta.num_dims()).then(|| {
         let mut shape_out = input.shape();
-        shape_out[dim] = 1;
+        shape_out[dim] = reduce_len;
         empty_device_contiguous_dtype(
             input.client.clone(),
             input.device.clone(),

--- a/crates/burn-cubecl/src/ops/int_tensor.rs
+++ b/crates/burn-cubecl/src/ops/int_tensor.rs
@@ -441,6 +441,18 @@ where
         .unwrap()
     }
 
+    fn int_argtopk(tensor: IntTensor<Self>, dim: usize, k: usize) -> IntTensor<Self> {
+        let dtype = tensor.dtype;
+        reduce::reduce_dim(
+            tensor,
+            Some(dtype),
+            dim,
+            Default::default(),
+            ReduceOperationConfig::ArgTopK(k),
+        )
+        .unwrap()
+    }
+
     fn int_argmin(tensor: IntTensor<Self>, dim: usize) -> IntTensor<Self> {
         let dtype = tensor.dtype;
         reduce::reduce_dim(

--- a/crates/burn-cubecl/src/ops/tensor.rs
+++ b/crates/burn-cubecl/src/ops/tensor.rs
@@ -608,6 +608,22 @@ where
         .unwrap()
     }
 
+    fn float_argtopk(
+        tensor: FloatTensor<Self>,
+        dim: usize,
+        k: usize,
+        out_dtype: IntDType,
+    ) -> IntTensor<Self> {
+        reduce::reduce_dim(
+            tensor,
+            Some(out_dtype.into()),
+            dim,
+            Default::default(),
+            ReduceOperationConfig::ArgTopK(k),
+        )
+        .unwrap()
+    }
+
     fn float_argmin(tensor: FloatTensor<Self>, dim: usize, out_dtype: IntDType) -> IntTensor<Self> {
         reduce::reduce_dim(
             tensor,

--- a/crates/burn-dispatch/src/ops/int_tensor.rs
+++ b/crates/burn-dispatch/src/ops/int_tensor.rs
@@ -283,6 +283,10 @@ impl IntTensorOps<Self> for Dispatch {
         unary_op!(tensor, int, |tensor| B::int_argmax(tensor, dim) => Int)
     }
 
+    fn int_argtopk(tensor: IntTensor<Self>, dim: usize, k: usize) -> IntTensor<Self> {
+        unary_op!(tensor, int, |tensor| B::int_argtopk(tensor, dim, k) => Int)
+    }
+
     fn int_argmin(tensor: IntTensor<Self>, dim: usize) -> IntTensor<Self> {
         unary_op!(tensor, int, |tensor| B::int_argmin(tensor, dim) => Int)
     }

--- a/crates/burn-dispatch/src/ops/tensor.rs
+++ b/crates/burn-dispatch/src/ops/tensor.rs
@@ -433,6 +433,15 @@ impl FloatTensorOps<Self> for Dispatch {
         unary_float!(tensor, float, |tensor| B::float_argmax(tensor, dim, out_dtype) => Int)
     }
 
+    fn float_argtopk(
+        tensor: FloatTensor<Self>,
+        dim: usize,
+        k: usize,
+        out_dtype: IntDType,
+    ) -> IntTensor<Self> {
+        unary_float!(tensor, float, |tensor| B::float_argtopk(tensor, dim, k, out_dtype) => Int)
+    }
+
     fn float_argmin(tensor: FloatTensor<Self>, dim: usize, out_dtype: IntDType) -> IntTensor<Self> {
         unary_float!(tensor, float, |tensor| B::float_argmin(tensor, dim, out_dtype) => Int)
     }

--- a/crates/burn-flex/src/ops/float.rs
+++ b/crates/burn-flex/src/ops/float.rs
@@ -915,6 +915,15 @@ impl FloatTensorOps<Flex> for Flex {
         }
     }
 
+    fn float_argtopk(
+        _tensor: FloatTensor<Flex>,
+        _dim: usize,
+        _k: usize,
+        _out_dtype: burn_std::IntDType,
+    ) -> IntTensor<Flex> {
+        panic!("argtopk not implemented for flex")
+    }
+
     fn float_argmin(
         tensor: FloatTensor<Flex>,
         dim: usize,

--- a/crates/burn-flex/src/ops/int.rs
+++ b/crates/burn-flex/src/ops/int.rs
@@ -611,6 +611,10 @@ impl IntTensorOps<Flex> for Flex {
         crate::ops::reduce::argmax(tensor, dim)
     }
 
+    fn int_argtopk(_tensor: IntTensor<Flex>, _dim: usize, _k: usize) -> IntTensor<Flex> {
+        panic!("argtopk not implemented for flex")
+    }
+
     fn int_argmin(tensor: IntTensor<Flex>, dim: usize) -> IntTensor<Flex> {
         crate::ops::reduce::argmin(tensor, dim)
     }

--- a/crates/burn-fusion/src/ops/int_tensor.rs
+++ b/crates/burn-fusion/src/ops/int_tensor.rs
@@ -1341,6 +1341,10 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
             .output()
     }
 
+    fn int_argtopk(_tensor: IntTensor<Self>, _dim: usize, _k: usize) -> IntTensor<Self> {
+        todo!()
+    }
+
     fn int_argmin(tensor: IntTensor<Self>, dim: usize) -> IntTensor<Self> {
         reduce_int_ops!(ArgMinOps, B::int_argmin);
 

--- a/crates/burn-fusion/src/ops/tensor.rs
+++ b/crates/burn-fusion/src/ops/tensor.rs
@@ -1924,6 +1924,15 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
             .output()
     }
 
+    fn float_argtopk(
+        _tensor: FloatTensor<Self>,
+        _dim: usize,
+        _k: usize,
+        _out_dtype: IntDType,
+    ) -> IntTensor<Self> {
+        todo!();
+    }
+
     fn float_repeat_dim(tensor: FloatTensor<Self>, dim: usize, times: usize) -> FloatTensor<Self> {
         #[derive(new, Debug)]
         struct RepeatDimOps<B: FusionBackend> {

--- a/crates/burn-ndarray/src/ops/int_tensor.rs
+++ b/crates/burn-ndarray/src/ops/int_tensor.rs
@@ -334,6 +334,10 @@ where
         })
     }
 
+    fn int_argtopk(_tensor: NdArrayTensor, _dim: usize, _k: usize) -> NdArrayTensor {
+        todo!();
+    }
+
     fn int_argmin(tensor: NdArrayTensor, dim: usize) -> NdArrayTensor {
         // Use view() for zero-copy on borrowed storage
         execute_with_int_dtype!(tensor, E, |array: SharedArray<E>| {

--- a/crates/burn-ndarray/src/ops/tensor.rs
+++ b/crates/burn-ndarray/src/ops/tensor.rs
@@ -461,6 +461,15 @@ where
         })
     }
 
+    fn float_argtopk(
+        _tensor: FloatTensor<Self>,
+        _dim: usize,
+        _k: usize,
+        _out_dtype: IntDType,
+    ) -> NdArrayTensor {
+        todo!();
+    }
+
     fn float_argmin(tensor: FloatTensor<Self>, dim: usize, out_dtype: IntDType) -> NdArrayTensor {
         // Use view() for zero-copy on borrowed storage
         execute_with_int_out_dtype!(out_dtype, I, {

--- a/crates/burn-ndarray/src/ops/tensor.rs
+++ b/crates/burn-ndarray/src/ops/tensor.rs
@@ -467,7 +467,7 @@ where
         _k: usize,
         _out_dtype: IntDType,
     ) -> NdArrayTensor {
-        todo!();
+        unimplemented!("float_argtopk not implemented for ndarray")
     }
 
     fn float_argmin(tensor: FloatTensor<Self>, dim: usize, out_dtype: IntDType) -> NdArrayTensor {

--- a/crates/burn-router/src/ops/int_tensor.rs
+++ b/crates/burn-router/src/ops/int_tensor.rs
@@ -710,6 +710,10 @@ impl<R: RunnerChannel> IntTensorOps<Self> for BackendRouter<R> {
             .output()
     }
 
+    fn int_argtopk(_tensor: IntTensor<Self>, _dim: usize, _k: usize) -> IntTensor<Self> {
+        panic!("argtopk not implemented for burn router")
+    }
+
     fn int_argmin(tensor: IntTensor<Self>, dim: usize) -> IntTensor<Self> {
         let client = tensor.client.clone();
         let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, || client.create_empty_handle());

--- a/crates/burn-router/src/ops/int_tensor.rs
+++ b/crates/burn-router/src/ops/int_tensor.rs
@@ -711,7 +711,7 @@ impl<R: RunnerChannel> IntTensorOps<Self> for BackendRouter<R> {
     }
 
     fn int_argtopk(_tensor: IntTensor<Self>, _dim: usize, _k: usize) -> IntTensor<Self> {
-        panic!("argtopk not implemented for burn router")
+        todo!("argtopk not implemented for burn router")
     }
 
     fn int_argmin(tensor: IntTensor<Self>, dim: usize) -> IntTensor<Self> {

--- a/crates/burn-router/src/ops/tensor.rs
+++ b/crates/burn-router/src/ops/tensor.rs
@@ -1116,6 +1116,26 @@ impl<R: RunnerChannel> FloatTensorOps<Self> for BackendRouter<R> {
             .output()
     }
 
+    fn float_argtopk(
+        _tensor: FloatTensor<Self>,
+        _dim: usize,
+        _k: usize,
+        _out_dtype: IntDType,
+    ) -> IntTensor<Self> {
+        todo!()
+        //let client = tensor.client.clone();
+        //let desc = ReduceDimOpIr::create_arg(tensor.into_ir(), dim, out_dtype.into(), || {
+        //    client.create_empty_handle()
+        //});
+        //
+        //client
+        //    .register(OperationIr::NumericFloat(
+        //        desc.input.dtype,
+        //        NumericOperationIr::ArgTopK(desc, k),
+        //    ))
+        //    .output()
+    }
+
     fn float_repeat_dim(tensor: FloatTensor<Self>, dim: usize, times: usize) -> FloatTensor<Self> {
         let client = tensor.client.clone();
         let desc = RepeatDimOpIr::create(tensor.into_ir(), dim, times, || {

--- a/crates/burn-router/src/ops/tensor.rs
+++ b/crates/burn-router/src/ops/tensor.rs
@@ -1122,7 +1122,7 @@ impl<R: RunnerChannel> FloatTensorOps<Self> for BackendRouter<R> {
         _k: usize,
         _out_dtype: IntDType,
     ) -> IntTensor<Self> {
-        panic!("argtopk not yet implemented for burn-router")
+        todo!("argtopk not yet implemented for burn-router")
     }
 
     fn float_repeat_dim(tensor: FloatTensor<Self>, dim: usize, times: usize) -> FloatTensor<Self> {

--- a/crates/burn-router/src/ops/tensor.rs
+++ b/crates/burn-router/src/ops/tensor.rs
@@ -1122,18 +1122,7 @@ impl<R: RunnerChannel> FloatTensorOps<Self> for BackendRouter<R> {
         _k: usize,
         _out_dtype: IntDType,
     ) -> IntTensor<Self> {
-        todo!()
-        //let client = tensor.client.clone();
-        //let desc = ReduceDimOpIr::create_arg(tensor.into_ir(), dim, out_dtype.into(), || {
-        //    client.create_empty_handle()
-        //});
-        //
-        //client
-        //    .register(OperationIr::NumericFloat(
-        //        desc.input.dtype,
-        //        NumericOperationIr::ArgTopK(desc, k),
-        //    ))
-        //    .output()
+        panic!("argtopk not yet implemented for burn-router")
     }
 
     fn float_repeat_dim(tensor: FloatTensor<Self>, dim: usize, times: usize) -> FloatTensor<Self> {

--- a/crates/burn-tch/src/ops/int_tensor.rs
+++ b/crates/burn-tch/src/ops/int_tensor.rs
@@ -344,6 +344,10 @@ impl<E: TchElement> IntTensorOps<Self> for LibTorch<E> {
         TchOps::argmax(tensor, dim)
     }
 
+    fn int_argtopk(_tensor: TchTensor, _dim: usize, _k: usize) -> TchTensor {
+        panic!("argtopk not implemented for torch")
+    }
+
     fn int_argmin(tensor: TchTensor, dim: usize) -> TchTensor {
         TchOps::argmin(tensor, dim)
     }

--- a/crates/burn-tch/src/ops/tensor.rs
+++ b/crates/burn-tch/src/ops/tensor.rs
@@ -344,6 +344,15 @@ impl<E: TchElement> FloatTensorOps<Self> for LibTorch<E> {
         TchOps::argmax(tensor, dim)
     }
 
+    fn float_argtopk(
+        _tensor: TchTensor,
+        _dim: usize,
+        _k: usize,
+        _indices_dtype: IntDType,
+    ) -> TchTensor {
+        panic!("argtopk not implemented for Torch")
+    }
+
     fn float_argmin(tensor: TchTensor, dim: usize, _out_dtype: IntDType) -> TchTensor {
         TchOps::argmin(tensor, dim)
     }

--- a/crates/burn-tensor/src/tensor/api/orderable.rs
+++ b/crates/burn-tensor/src/tensor/api/orderable.rs
@@ -601,6 +601,11 @@ where
         Tensor::new(K::argmax(self.primitive, dim))
     }
 
+    pub fn argtopk(self, dim: usize, k: usize) -> Tensor<B, D, Int> {
+        assert!(self.shape()[dim] > k);
+        Tensor::new(K::argtopk(self.primitive, dim, k))
+    }
+
     /// Find the maximum value.
     ///
     /// # Example

--- a/crates/burn-tensor/src/tensor/api/orderable.rs
+++ b/crates/burn-tensor/src/tensor/api/orderable.rs
@@ -601,6 +601,21 @@ where
         Tensor::new(K::argmax(self.primitive, dim))
     }
 
+    /// Applies the argtopk function along the given dimension and returns an integer tensor.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use burn_tensor::backend::Backend;
+    /// use burn_tensor::{Tensor, Shape};
+    ///
+    /// fn example<B: Backend>() {
+    ///     let device = B::Device::default();
+    ///     let tensor = Tensor::<B, 3>::ones(Shape::new([2, 3, 3]), &device);
+    ///     let tensor = tensor.argtopk(1, 2);
+    ///     println!("{:?}", tensor.shape());
+    /// }
+    /// ```
     pub fn argtopk(self, dim: usize, k: usize) -> Tensor<B, D, Int> {
         assert!(self.shape()[dim] > k);
         Tensor::new(K::argtopk(self.primitive, dim, k))


### PR DESCRIPTION
Add argtopk

### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Changes
add argtopk to float, int and q tensors

### Testing
```sh
cargo test-wgpu-nofuse argtopk
```
