### PR TITLE
`linalg::lu`: Improve numerical handling and small perf cleanup

### DIFF
--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -1073,7 +1073,7 @@ impl TensorCheck {
             check = check.register(
                 "Diag",
                 TensorError::new(
-                    "Diagonal operations require 
+                    "Diagonal operations require
                 tensors with at least 2 dimensions.",
                 )
                 .details(format!(
@@ -1495,8 +1495,17 @@ impl TensorCheck {
     }
 
     /// Check the input tensor for lu decomposition is valid.
-    pub fn lu_input_tensor<const D: usize>(ops: &str, dims: &[usize]) -> Self {
+    pub fn lu_input_tensor<const D: usize>(ops: &str, dims: &[usize], dtype: DType) -> Self {
         let mut check = TensorCheck::Ok;
+
+        if matches!(dtype, DType::QFloat(_)) {
+            check = check.register(
+                ops,
+                TensorError::new("The input tensor must have a real float dtype")
+                    .details("Got an input tensor with a quantized float dtype".to_string()),
+            );
+        }
+
         let n_dims = dims.len();
         if n_dims < 2 {
             check = check.register(

--- a/crates/burn-tensor/src/tensor/linalg/lu.rs
+++ b/crates/burn-tensor/src/tensor/linalg/lu.rs
@@ -270,7 +270,7 @@ fn standard_lu_with_partial_piv<B: Backend, const D: usize, const D1: usize>(
             + (k as i64);
 
         // Swap current row (k-th row) with the row with maximum absolute value
-        tensor = swap_tensor_rows(tensor, max_row_indices.clone(), k, device);
+        tensor = swap_tensor_rows(tensor, max_row_indices.clone(), k);
         // Store the max row index in the k-th entry of the permutations vector/tensor
         permutations = update_permutations(permutations, max_row_indices, k, dtype);
 
@@ -343,22 +343,19 @@ fn swap_tensor_rows<B: Backend, const D: usize>(
     tensor: Tensor<B, D>,
     mut swap_target_row_tensor: Tensor<B, D, Int>,
     k: usize,
-    device: &B::Device,
 ) -> Tensor<B, D> {
     let mut expand_dims = tensor.dims();
     expand_dims[D - 2] = 1;
     swap_target_row_tensor = swap_target_row_tensor.expand(expand_dims);
 
-    let k_index_tensor =
-        Tensor::<B, D, Int>::full(swap_target_row_tensor.shape(), k as i32, device);
-
-    let val_k = tensor.clone().gather(D - 2, k_index_tensor.clone());
+    let val_k = tensor.clone().slice_dim(D - 2, k);
     let val_r = tensor.clone().gather(D - 2, swap_target_row_tensor.clone());
-    let val_k_minus_r = val_k.clone() - val_r.clone();
-    let val_r_minus_k = val_r - val_k;
 
-    let tensor = tensor.scatter(D - 2, k_index_tensor, val_r_minus_k, IndexingUpdateOp::Add);
+    let mut slices = vec![Slice::full(); D];
+    slices[D - 2] = Slice::from(k);
+    let tensor = tensor.slice_assign(&slices, val_r.clone());
 
+    let val_k_minus_r = val_k - val_r;
     tensor.scatter(
         D - 2,
         swap_target_row_tensor,

--- a/crates/burn-tensor/src/tensor/linalg/lu.rs
+++ b/crates/burn-tensor/src/tensor/linalg/lu.rs
@@ -3,9 +3,9 @@ use alloc::vec;
 use alloc::vec::Vec;
 use burn_backend::{
     Backend, Slice,
-    tensor::{Bool, IndexingUpdateOp, Int},
+    tensor::{Bool, Float, IndexingUpdateOp, Int},
 };
-use burn_std::FloatDType;
+use burn_std::{DType, FloatDType};
 
 /// Computes the LU decomposition of a square or rectangular matrix with partial pivoting.
 ///
@@ -31,11 +31,18 @@ use burn_std::FloatDType;
 /// This function will panic if the tensor checks fail:
 /// - The input tensor has less than 2 dimensions (`D < 2`).
 /// - The generic parameters do not satisfy `D - 1 == D1`.
+/// - The input is a quantized tensor with dtype `DType::QFloat`.
 ///
 /// # Performance Note
 /// The current implementation of LU decomposition is not fully optimized. It will not
 /// be as fast as highly tuned specialized libraries, especially for very large
 /// matrices or large batch sizes.
+///
+/// # Numerical Behavior  
+/// - If the input tensor has dtype F16 or BF16, it is internally upcast to F32  
+///   for the computation and cast back to the original dtype before returning.  
+/// - In this case, values in L and U that fall outside the original dtype's  
+///   representable range will saturate or underflow on cast-back.
 ///
 /// # Example
 /// ```rust,ignore
@@ -62,16 +69,26 @@ use burn_std::FloatDType;
 /// }
 /// ```
 pub fn lu<B: Backend, const D: usize, const D1: usize>(
-    tensor: Tensor<B, D>,
+    mut tensor: Tensor<B, D>,
 ) -> (Tensor<B, D>, Tensor<B, D>, Tensor<B, D>) {
     let dims = tensor.dims();
-
+    let original_dtype = tensor.dtype();
     check!(TensorCheck::lu_generic_param::<D, D1>("linalg::lu"));
-    check!(TensorCheck::lu_input_tensor::<D>("linalg::lu", &dims));
+    check!(TensorCheck::lu_input_tensor::<D>(
+        "linalg::lu",
+        &dims,
+        original_dtype
+    ));
 
     let device = tensor.device();
     let n_rows = dims[D - 2];
     let n_cols = dims[D - 1];
+
+    // Upcast f16 and bf16 to f32
+    let needs_upcast = original_dtype == DType::F16 || original_dtype == DType::BF16;
+    if needs_upcast {
+        tensor = tensor.cast(FloatDType::F32)
+    }
 
     let (lu_tensor, p_compact) = compute_lu_decomposition::<B, D, D1>(tensor);
 
@@ -88,7 +105,15 @@ pub fn lu<B: Backend, const D: usize, const D1: usize>(
     let l = temp_l.mask_fill(mask, 1.0);
     let p = construct_full_permutation_tensor(p_compact, n_rows, &device).transpose();
 
-    (p, l, u)
+    if needs_upcast {
+        (
+            p.cast(original_dtype),
+            l.cast(original_dtype),
+            u.cast(original_dtype),
+        )
+    } else {
+        (p, l, u)
+    }
 }
 
 /// Dispatches the LU decomposition to either the block or standard algorithm based on
@@ -271,7 +296,8 @@ fn construct_full_permutation_tensor<B: Backend, const D: usize>(
     device: &B::Device,
 ) -> Tensor<B, D> {
     let dims = piv.dims();
-    let identity_2d = Tensor::eye(n_rows, device);
+    let identity_2d_uncasted: Tensor<B, 2, Float> = Tensor::eye(n_rows, device);
+    let identity_2d = identity_2d_uncasted.cast(piv.dtype());
 
     // Reshape the `identity` tensor from 2 dims to D dims
     let mut reshape_dims = [1; D];


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Addresses part 3 of [rnnt.rs and linalg/lu.rs: small perf cleanups noticed during gather_nd review #4893](https://github.com/tracel-ai/burn/issues/4893) and also addresses the numerical issues discussed in [Add native det (determinant) tensor operation #4813](https://github.com/tracel-ai/burn/pull/4813).

### Changes

- Updated TensorCheck for `linalg::lu` to reject quantized float tensors.
- Update `linalg::lu` to upcast input tensors in f16 or bf16 to f32, perform the computations in f32, and then downcast right before returning the tuple `(p, l, u)`. After this change, the `.into()` calls will no longer panic.
- Casts `Tensor::eye()` to working float dtype since it uses the default dtype. So if the default dtype is f16, it needs to be explicitly upcasted.
- Optimized `swap_tensor_rows` function to use `slice_dim` and `slice_assign` instead of `gather` and `scatter` where possible.

### Testing

The only change that can be tested is the rejection of quantized input tensors. However, creating a test case with quantized input tensors causes some weird issues that lead to removing similar test case in the `linalg::det` PR. Hence, no new test cases have been added. All existing test cases pass.
