### PR TITLE
add fusion integration for argtopk (cubecl)

### DIFF
--- a/crates/burn-backend-tests/tests/cubecl/reduce.rs
+++ b/crates/burn-backend-tests/tests/cubecl/reduce.rs
@@ -36,6 +36,103 @@ fn reduction_argtopk_simple() {
 }
 
 #[test]
+fn reduction_argtopk_1d() {
+    let device = Default::default();
+
+    let tensor = TestTensor::<1>::from_data([10.0, 50.0, 20.0, 40.0, 30.0], &device);
+    let k = 3;
+    let actual = tensor.argtopk(0, k);
+
+    let expected = TestTensor::<1>::from_data([1, 3, 4], &device);
+
+    assert_eq!(actual.shape(), Shape::new([k]));
+    actual.into_data().assert_eq(&expected.into_data(), false);
+}
+
+#[test]
+fn reduction_argtopk_3d_dim0() {
+    let device = Default::default();
+
+    // Shape [2, 2, 2]
+    let tensor = TestTensor::<3>::from_data(
+        [[[10.0, 1.0], [5.0, 20.0]], [[1.0, 10.0], [20.0, 5.0]]],
+        &device,
+    );
+    let k = 1;
+    let actual = tensor.argtopk(0, k);
+
+    let expected = TestTensor::<3>::from_data([[[0, 1], [1, 0]]], &device);
+
+    assert_eq!(actual.shape(), Shape::new([1, 2, 2]));
+    actual.into_data().assert_eq(&expected.into_data(), false);
+}
+
+#[test]
+fn reduction_argtopk_ties() {
+    let device = Default::default();
+
+    let tensor = TestTensor::<1>::from_data([5.0, 2.0, 5.0, 5.0], &device);
+    let k = 2;
+    let actual = tensor.argtopk(0, k);
+
+    let expected = TestTensor::<1>::from_data([0, 2], &device);
+
+    assert_eq!(actual.shape(), Shape::new([k]));
+    actual.into_data().assert_eq(&expected.into_data(), false);
+}
+
+#[test]
+fn reduction_argtopk_3d_random_complex() {
+    let device = Default::default();
+
+    #[rustfmt::skip]
+    let tensor = TestTensor::<3>::from_data(
+        [
+            [
+                [0.5, 1.2, 0.8, 3.3],
+                [4.4, 2.1, 9.9, 0.1],
+                [7.7, 8.8, 6.6, 5.5],
+            ],
+            [
+                [1.1, 0.2, 4.4, 2.2],
+                [6.0, 7.0, 5.0, 8.0],
+                [3.0, 3.0, 1.0, 2.0],
+            ],
+        ],
+        &device,
+    );
+
+    let k = 2;
+    let dim = 2;
+    let actual = tensor.argtopk(dim, k);
+
+    #[rustfmt::skip]
+    let expected = TestTensor::<3>::from_data(
+        [
+            [
+                [3, 1],
+                [2, 0],
+                [1, 0],
+            ],
+            [
+                [2, 3],
+                [3, 1],
+                [0, 1],
+            ],
+        ],
+        &device,
+    );
+
+    let output_shape = Shape::new([2, 3, 2]);
+    assert_eq!(
+        actual.shape(),
+        output_shape,
+        "Output shape should be [2, 3, 2]"
+    );
+    actual.into_data().assert_eq(&expected.into_data(), false);
+}
+
+#[test]
 fn reduction_argmin_should_match_reference_backend() {
     let device = Default::default();
     let ref_device = ReferenceDevice::new();

--- a/crates/burn-cubecl/src/kernel/reduce/base.rs
+++ b/crates/burn-cubecl/src/kernel/reduce/base.rs
@@ -166,13 +166,13 @@ pub fn reduce_dim<Run: CubeRuntime>(
         "
     );
 
-    let reduce_len = match config {
+    let accumulator_len = match config {
         ReduceOperationConfig::ArgTopK(k) => k,
         _ => 1,
     };
     let dtypes = config.precision(input.dtype.into(), output_dtype.map(Into::into));
     let client = input.client.clone();
-    let output = init_reduce_output::<Run>(&input, dim, &dtypes, reduce_len).ok_or(
+    let output = init_reduce_output::<Run>(&input, dim, &dtypes, accumulator_len).ok_or(
         cubek::reduce::ReduceError::InvalidAxis {
             axis: dim,
             rank: input.meta.num_dims(),
@@ -218,11 +218,11 @@ pub fn init_reduce_output<Run: CubeRuntime>(
     input: &CubeTensor<Run>,
     dim: usize,
     dtypes: &ReduceDtypes,
-    reduce_len: usize,
+    accumulator_len: usize,
 ) -> Option<CubeTensor<Run>> {
     (dim < input.meta.num_dims()).then(|| {
         let mut shape_out = input.shape();
-        shape_out[dim] = reduce_len;
+        shape_out[dim] = accumulator_len;
         empty_device_contiguous_dtype(
             input.client.clone(),
             input.device.clone(),

--- a/crates/burn-fusion/src/ops/int_tensor.rs
+++ b/crates/burn-fusion/src/ops/int_tensor.rs
@@ -1129,7 +1129,8 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
         let streams = OperationStreams::with_inputs([&tensor]);
 
         let client = tensor.client.clone();
-        let desc = ReduceDimOpIr::create(tensor.into_ir(), axis, || client.create_empty_handle());
+        let desc =
+            ReduceDimOpIr::create(tensor.into_ir(), axis, 1, || client.create_empty_handle());
 
         client
             .register(
@@ -1163,7 +1164,7 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
         let streams = OperationStreams::with_inputs([&tensor]);
 
         let client = tensor.client.clone();
-        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, || client.create_empty_handle());
+        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, 1, || client.create_empty_handle());
 
         client
             .register(
@@ -1197,7 +1198,7 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
         let streams = OperationStreams::with_inputs([&tensor]);
 
         let client = tensor.client.clone();
-        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, || client.create_empty_handle());
+        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, 1, || client.create_empty_handle());
 
         client
             .register(
@@ -1330,7 +1331,7 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
         let streams = OperationStreams::with_inputs([&tensor]);
 
         let client = tensor.client.clone();
-        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, || client.create_empty_handle());
+        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, 1, || client.create_empty_handle());
 
         client
             .register(
@@ -1351,7 +1352,7 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
         let streams = OperationStreams::with_inputs([&tensor]);
 
         let client = tensor.client.clone();
-        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, || client.create_empty_handle());
+        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, 1, || client.create_empty_handle());
 
         client
             .register(
@@ -1495,7 +1496,7 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
         let streams = OperationStreams::with_inputs([&tensor]);
 
         let client = tensor.client.clone();
-        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, || client.create_empty_handle());
+        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, 1, || client.create_empty_handle());
 
         client
             .register(
@@ -1584,7 +1585,7 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
         let streams = OperationStreams::with_inputs([&tensor]);
 
         let client = tensor.client.clone();
-        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, || client.create_empty_handle());
+        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, 1, || client.create_empty_handle());
 
         client
             .register(
@@ -1604,7 +1605,7 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
         let streams = OperationStreams::with_inputs([&tensor]);
 
         let client = tensor.client.clone();
-        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, || client.create_empty_handle());
+        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, 1, || client.create_empty_handle());
 
         client
             .register(

--- a/crates/burn-fusion/src/ops/tensor.rs
+++ b/crates/burn-fusion/src/ops/tensor.rs
@@ -1299,7 +1299,8 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
         let streams = OperationStreams::with_inputs([&tensor]);
 
         let client = tensor.client.clone();
-        let desc = ReduceDimOpIr::create(tensor.into_ir(), axis, || client.create_empty_handle());
+        let desc =
+            ReduceDimOpIr::create(tensor.into_ir(), axis, 1, || client.create_empty_handle());
 
         client
             .register(
@@ -1333,7 +1334,7 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
         let streams = OperationStreams::with_inputs([&tensor]);
 
         let client = tensor.client.clone();
-        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, || client.create_empty_handle());
+        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, 1, || client.create_empty_handle());
 
         client
             .register(
@@ -1370,7 +1371,7 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
         let streams = OperationStreams::with_inputs([&tensor]);
 
         let client = tensor.client.clone();
-        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, || client.create_empty_handle());
+        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, 1, || client.create_empty_handle());
 
         client
             .register(
@@ -1901,14 +1902,16 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
     }
 
     fn float_argmax(tensor: FloatTensor<Self>, dim: usize, out_dtype: IntDType) -> IntTensor<Self> {
-        reduce_float2int_ops!(ArgMaxOps, B::float_argmax);
+        reduce_float2int_ops!(ArgMaxOps, |input, axis, _, dtype| B::float_argmax(
+            input, axis, dtype
+        ));
 
         let streams = OperationStreams::with_inputs([&tensor]);
 
         // TODO: output dtype should be defined by the device policy
         let client = tensor.client.clone();
         // TODO: rename `create_with_dtype` specifically for ARG / indices
-        let desc = ReduceDimOpIr::create_arg(tensor.into_ir(), dim, out_dtype.into(), || {
+        let desc = ReduceDimOpIr::create_arg(tensor.into_ir(), dim, 1, out_dtype.into(), || {
             client.create_empty_handle()
         });
 
@@ -1925,12 +1928,32 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
     }
 
     fn float_argtopk(
-        _tensor: FloatTensor<Self>,
-        _dim: usize,
-        _k: usize,
-        _out_dtype: IntDType,
+        tensor: FloatTensor<Self>,
+        dim: usize,
+        k: usize,
+        out_dtype: IntDType,
     ) -> IntTensor<Self> {
-        todo!();
+        reduce_float2int_ops!(ArgTopKOps, B::float_argtopk);
+
+        let streams = OperationStreams::with_inputs([&tensor]);
+
+        // TODO: output dtype should be defined by the device policy
+        let client = tensor.client.clone();
+        // TODO: rename `create_with_dtype` specifically for ARG / indices
+        let desc = ReduceDimOpIr::create_arg(tensor.into_ir(), dim, k, out_dtype.into(), || {
+            client.create_empty_handle()
+        });
+
+        client
+            .register(
+                streams,
+                OperationIr::NumericFloat(
+                    desc.input.dtype,
+                    NumericOperationIr::ArgTopK(desc.clone()),
+                ),
+                ArgTopKOps::<B>::new(desc),
+            )
+            .output()
     }
 
     fn float_repeat_dim(tensor: FloatTensor<Self>, dim: usize, times: usize) -> FloatTensor<Self> {
@@ -1967,12 +1990,14 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
     }
 
     fn float_argmin(tensor: FloatTensor<Self>, dim: usize, out_dtype: IntDType) -> IntTensor<Self> {
-        reduce_float2int_ops!(ArgMinOps, B::float_argmin);
+        reduce_float2int_ops!(ArgMinOps, |input, axis, _, dtype| B::float_argmin(
+            input, axis, dtype
+        ));
 
         let streams = OperationStreams::with_inputs([&tensor]);
 
         let client = tensor.client.clone();
-        let desc = ReduceDimOpIr::create_arg(tensor.into_ir(), dim, out_dtype.into(), || {
+        let desc = ReduceDimOpIr::create_arg(tensor.into_ir(), dim, 1, out_dtype.into(), || {
             client.create_empty_handle()
         });
 
@@ -2011,7 +2036,7 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
         let streams = OperationStreams::with_inputs([&tensor]);
 
         let client = tensor.client.clone();
-        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, || client.create_empty_handle());
+        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, 1, || client.create_empty_handle());
 
         client
             .register(
@@ -2091,7 +2116,7 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
         let streams = OperationStreams::with_inputs([&tensor]);
 
         let client = tensor.client.clone();
-        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, || client.create_empty_handle());
+        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, 1, || client.create_empty_handle());
 
         client
             .register(
@@ -2170,7 +2195,7 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
         let streams = OperationStreams::with_inputs([&tensor]);
 
         let client = tensor.client.clone();
-        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, || client.create_empty_handle());
+        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, 1, || client.create_empty_handle());
 
         client
             .register(

--- a/crates/burn-fusion/src/ops/tensor.rs
+++ b/crates/burn-fusion/src/ops/tensor.rs
@@ -1908,9 +1908,7 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
 
         let streams = OperationStreams::with_inputs([&tensor]);
 
-        // TODO: output dtype should be defined by the device policy
         let client = tensor.client.clone();
-        // TODO: rename `create_with_dtype` specifically for ARG / indices
         let desc = ReduceDimOpIr::create_arg(tensor.into_ir(), dim, 1, out_dtype.into(), || {
             client.create_empty_handle()
         });
@@ -1937,9 +1935,7 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
 
         let streams = OperationStreams::with_inputs([&tensor]);
 
-        // TODO: output dtype should be defined by the device policy
         let client = tensor.client.clone();
-        // TODO: rename `create_with_dtype` specifically for ARG / indices
         let desc = ReduceDimOpIr::create_arg(tensor.into_ir(), dim, k, out_dtype.into(), || {
             client.create_empty_handle()
         });

--- a/crates/burn-fusion/src/ops/unary.rs
+++ b/crates/burn-fusion/src/ops/unary.rs
@@ -85,7 +85,7 @@ macro_rules! reduce_float2int_ops {
                 let output = $ops(
                     input,
                     self.desc.axis,
-                    self.desc.reduce_len,
+                    self.desc.accumulator_len,
                     self.desc.out.dtype.into(),
                 );
 

--- a/crates/burn-fusion/src/ops/unary.rs
+++ b/crates/burn-fusion/src/ops/unary.rs
@@ -82,7 +82,12 @@ macro_rules! reduce_float2int_ops {
         impl<B: FusionBackend> Operation<B::FusionRuntime> for $name<B> {
             fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
                 let input = handles.get_float_tensor::<B>(&self.desc.input);
-                let output = $ops(input, self.desc.axis, self.desc.out.dtype.into());
+                let output = $ops(
+                    input,
+                    self.desc.axis,
+                    self.desc.reduce_len,
+                    self.desc.out.dtype.into(),
+                );
 
                 handles.register_int_tensor::<B>(&self.desc.out.id, output);
             }

--- a/crates/burn-fusion/src/stream/context.rs
+++ b/crates/burn-fusion/src/stream/context.rs
@@ -927,6 +927,7 @@ impl RelativeOps for NumericOperationIr {
             NumericOperationIr::MeanDim(desc) => NumericOperationIr::MeanDim(ReduceDimOpIr {
                 input: desc.input.to_relative(converter),
                 axis: desc.axis,
+                reduce_len: desc.reduce_len,
                 out: desc.out.to_relative(converter),
             }),
             NumericOperationIr::Mean(desc) => NumericOperationIr::Mean(ReduceOpIr {
@@ -942,6 +943,7 @@ impl RelativeOps for NumericOperationIr {
                     input: desc.input.to_relative(converter),
                     out: desc.out.to_relative(converter),
                     axis: desc.axis, // Axis should stay the same.
+                    reduce_len: desc.reduce_len,
                 })
             }
             NumericOperationIr::Prod(desc) => NumericOperationIr::Prod(ReduceOpIr {
@@ -951,6 +953,7 @@ impl RelativeOps for NumericOperationIr {
             NumericOperationIr::ProdDim(desc) => NumericOperationIr::ProdDim(ReduceDimOpIr {
                 input: desc.input.to_relative(converter),
                 axis: desc.axis,
+                reduce_len: desc.reduce_len,
                 out: desc.out.to_relative(converter),
             }),
             NumericOperationIr::Greater(desc) => NumericOperationIr::Greater(BinaryOpIr {
@@ -1003,11 +1006,19 @@ impl RelativeOps for NumericOperationIr {
                 input: desc.input.to_relative(converter),
                 out: desc.out.to_relative(converter),
                 axis: desc.axis, // Axis should stay the same.
+                reduce_len: desc.reduce_len,
+            }),
+            NumericOperationIr::ArgTopK(desc) => NumericOperationIr::ArgTopK(ReduceDimOpIr {
+                input: desc.input.to_relative(converter),
+                out: desc.out.to_relative(converter),
+                axis: desc.axis, // Axis should stay the same.
+                reduce_len: desc.reduce_len,
             }),
             NumericOperationIr::ArgMin(desc) => NumericOperationIr::ArgMin(ReduceDimOpIr {
                 input: desc.input.to_relative(converter),
                 out: desc.out.to_relative(converter),
                 axis: desc.axis, // Axis should stay the same.
+                reduce_len: desc.reduce_len,
             }),
             NumericOperationIr::Max(desc) => NumericOperationIr::Max(ReduceOpIr {
                 input: desc.input.to_relative(converter),
@@ -1036,11 +1047,13 @@ impl RelativeOps for NumericOperationIr {
             NumericOperationIr::MaxDim(desc) => NumericOperationIr::MaxDim(ReduceDimOpIr {
                 input: desc.input.to_relative(converter),
                 axis: desc.axis,
+                reduce_len: desc.reduce_len,
                 out: desc.out.to_relative(converter),
             }),
             NumericOperationIr::MinDim(desc) => NumericOperationIr::MinDim(ReduceDimOpIr {
                 input: desc.input.to_relative(converter),
                 axis: desc.axis,
+                reduce_len: desc.reduce_len,
                 out: desc.out.to_relative(converter),
             }),
             NumericOperationIr::MaxAbs(desc) => NumericOperationIr::MaxAbs(ReduceOpIr {
@@ -1050,6 +1063,7 @@ impl RelativeOps for NumericOperationIr {
             NumericOperationIr::MaxAbsDim(desc) => NumericOperationIr::MaxAbsDim(ReduceDimOpIr {
                 input: desc.input.to_relative(converter),
                 axis: desc.axis,
+                reduce_len: desc.reduce_len,
                 out: desc.out.to_relative(converter),
             }),
             NumericOperationIr::Clamp(desc) => NumericOperationIr::Clamp(ClampOpIr {

--- a/crates/burn-fusion/src/stream/context.rs
+++ b/crates/burn-fusion/src/stream/context.rs
@@ -927,7 +927,7 @@ impl RelativeOps for NumericOperationIr {
             NumericOperationIr::MeanDim(desc) => NumericOperationIr::MeanDim(ReduceDimOpIr {
                 input: desc.input.to_relative(converter),
                 axis: desc.axis,
-                reduce_len: desc.reduce_len,
+                accumulator_len: desc.accumulator_len,
                 out: desc.out.to_relative(converter),
             }),
             NumericOperationIr::Mean(desc) => NumericOperationIr::Mean(ReduceOpIr {
@@ -943,7 +943,7 @@ impl RelativeOps for NumericOperationIr {
                     input: desc.input.to_relative(converter),
                     out: desc.out.to_relative(converter),
                     axis: desc.axis, // Axis should stay the same.
-                    reduce_len: desc.reduce_len,
+                    accumulator_len: desc.accumulator_len,
                 })
             }
             NumericOperationIr::Prod(desc) => NumericOperationIr::Prod(ReduceOpIr {
@@ -953,7 +953,7 @@ impl RelativeOps for NumericOperationIr {
             NumericOperationIr::ProdDim(desc) => NumericOperationIr::ProdDim(ReduceDimOpIr {
                 input: desc.input.to_relative(converter),
                 axis: desc.axis,
-                reduce_len: desc.reduce_len,
+                accumulator_len: desc.accumulator_len,
                 out: desc.out.to_relative(converter),
             }),
             NumericOperationIr::Greater(desc) => NumericOperationIr::Greater(BinaryOpIr {
@@ -1006,19 +1006,19 @@ impl RelativeOps for NumericOperationIr {
                 input: desc.input.to_relative(converter),
                 out: desc.out.to_relative(converter),
                 axis: desc.axis, // Axis should stay the same.
-                reduce_len: desc.reduce_len,
+                accumulator_len: desc.accumulator_len,
             }),
             NumericOperationIr::ArgTopK(desc) => NumericOperationIr::ArgTopK(ReduceDimOpIr {
                 input: desc.input.to_relative(converter),
                 out: desc.out.to_relative(converter),
                 axis: desc.axis, // Axis should stay the same.
-                reduce_len: desc.reduce_len,
+                accumulator_len: desc.accumulator_len,
             }),
             NumericOperationIr::ArgMin(desc) => NumericOperationIr::ArgMin(ReduceDimOpIr {
                 input: desc.input.to_relative(converter),
                 out: desc.out.to_relative(converter),
                 axis: desc.axis, // Axis should stay the same.
-                reduce_len: desc.reduce_len,
+                accumulator_len: desc.accumulator_len,
             }),
             NumericOperationIr::Max(desc) => NumericOperationIr::Max(ReduceOpIr {
                 input: desc.input.to_relative(converter),
@@ -1047,13 +1047,13 @@ impl RelativeOps for NumericOperationIr {
             NumericOperationIr::MaxDim(desc) => NumericOperationIr::MaxDim(ReduceDimOpIr {
                 input: desc.input.to_relative(converter),
                 axis: desc.axis,
-                reduce_len: desc.reduce_len,
+                accumulator_len: desc.accumulator_len,
                 out: desc.out.to_relative(converter),
             }),
             NumericOperationIr::MinDim(desc) => NumericOperationIr::MinDim(ReduceDimOpIr {
                 input: desc.input.to_relative(converter),
                 axis: desc.axis,
-                reduce_len: desc.reduce_len,
+                accumulator_len: desc.accumulator_len,
                 out: desc.out.to_relative(converter),
             }),
             NumericOperationIr::MaxAbs(desc) => NumericOperationIr::MaxAbs(ReduceOpIr {
@@ -1063,7 +1063,7 @@ impl RelativeOps for NumericOperationIr {
             NumericOperationIr::MaxAbsDim(desc) => NumericOperationIr::MaxAbsDim(ReduceDimOpIr {
                 input: desc.input.to_relative(converter),
                 axis: desc.axis,
-                reduce_len: desc.reduce_len,
+                accumulator_len: desc.accumulator_len,
                 out: desc.out.to_relative(converter),
             }),
             NumericOperationIr::Clamp(desc) => NumericOperationIr::Clamp(ClampOpIr {

--- a/crates/burn-ir/src/builder.rs
+++ b/crates/burn-ir/src/builder.rs
@@ -338,12 +338,19 @@ impl_ir_create!(
     dtype = input.dtype
 );
 
+fn reduce_output_shape(mut output_shape: Shape, axis: usize, reduce_len: usize) -> Shape {
+    assert!(output_shape.rank() > axis);
+    output_shape[axis] = reduce_len;
+    output_shape
+}
+
 impl_ir_create!(
     ReduceDimOpIr {
         input: TensorIr,
-        axis: usize
+        axis: usize,
+        reduce_len: usize
     },
-    shape = input.shape.clone().reduce(axis).unwrap(),
+    shape = reduce_output_shape(input.shape.clone(), axis, reduce_len),
     dtype = input.dtype,
     // Additional constructor for argument reduction
     create_arg(ind_dtype: DType)

--- a/crates/burn-ir/src/builder.rs
+++ b/crates/burn-ir/src/builder.rs
@@ -338,9 +338,9 @@ impl_ir_create!(
     dtype = input.dtype
 );
 
-fn reduce_output_shape(mut output_shape: Shape, axis: usize, reduce_len: usize) -> Shape {
+fn reduce_output_shape(mut output_shape: Shape, axis: usize, accumulator_len: usize) -> Shape {
     assert!(output_shape.rank() > axis);
-    output_shape[axis] = reduce_len;
+    output_shape[axis] = accumulator_len;
     output_shape
 }
 
@@ -348,9 +348,9 @@ impl_ir_create!(
     ReduceDimOpIr {
         input: TensorIr,
         axis: usize,
-        reduce_len: usize
+        accumulator_len: usize,
     },
-    shape = reduce_output_shape(input.shape.clone(), axis, reduce_len),
+    shape = reduce_output_shape(input.shape.clone(), axis, accumulator_len),
     dtype = input.dtype,
     // Additional constructor for argument reduction
     create_arg(ind_dtype: DType)

--- a/crates/burn-ir/src/operation.rs
+++ b/crates/burn-ir/src/operation.rs
@@ -867,7 +867,7 @@ pub struct ReduceDimOpIr {
     pub input: TensorIr,
     pub out: TensorIr,
     pub axis: usize,
-    pub reduce_len: usize,
+    pub accumulator_len: usize,
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Serialize, Deserialize)]

--- a/crates/burn-ir/src/operation.rs
+++ b/crates/burn-ir/src/operation.rs
@@ -553,6 +553,11 @@ pub enum NumericOperationIr {
     ArgMax(ReduceDimOpIr),
     /// Operation corresponding to:
     ///
+    /// Float => [argtopk](burn_backend::ops::FloatTensorOps::float_argtopk).
+    /// Int => [argtopk](burn_backend::ops::IntTensorOps::int_argtopk).
+    ArgTopK(ReduceDimOpIr),
+    /// Operation corresponding to:
+    ///
     /// Float => [argmin](burn_backend::ops::FloatTensorOps::float_argmin).
     /// Int => [argmin](burn_backend::ops::IntTensorOps::int_argmin).
     ArgMin(ReduceDimOpIr),
@@ -862,6 +867,7 @@ pub struct ReduceDimOpIr {
     pub input: TensorIr,
     pub out: TensorIr,
     pub axis: usize,
+    pub reduce_len: usize,
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Serialize, Deserialize)]
@@ -2196,6 +2202,7 @@ impl NumericOperationIr {
             NumericOperationIr::Lower(repr) => Box::new([&repr.lhs, &repr.rhs].into_iter()),
             NumericOperationIr::LowerEqual(repr) => Box::new([&repr.lhs, &repr.rhs].into_iter()),
             NumericOperationIr::ArgMax(repr) => Box::new([&repr.input].into_iter()),
+            NumericOperationIr::ArgTopK(repr) => Box::new([&repr.input].into_iter()),
             NumericOperationIr::ArgMin(repr) => Box::new([&repr.input].into_iter()),
             NumericOperationIr::Clamp(repr) => Box::new([&repr.tensor].into_iter()),
             NumericOperationIr::Abs(repr) => Box::new([&repr.input].into_iter()),
@@ -2245,6 +2252,7 @@ impl NumericOperationIr {
             NumericOperationIr::Lower(repr) => Box::new([&repr.out].into_iter()),
             NumericOperationIr::LowerEqual(repr) => Box::new([&repr.out].into_iter()),
             NumericOperationIr::ArgMax(repr) => Box::new([&repr.out].into_iter()),
+            NumericOperationIr::ArgTopK(repr) => Box::new([&repr.out].into_iter()),
             NumericOperationIr::ArgMin(repr) => Box::new([&repr.out].into_iter()),
             NumericOperationIr::Clamp(repr) => Box::new([&repr.out].into_iter()),
             NumericOperationIr::Abs(repr) => Box::new([&repr.out].into_iter()),
@@ -2344,6 +2352,9 @@ impl NumericOperationIr {
                 repr.rhs.mark_read_only(nodes, &mut output);
             }
             NumericOperationIr::ArgMax(repr) => {
+                repr.input.mark_read_only(nodes, &mut output);
+            }
+            NumericOperationIr::ArgTopK(repr) => {
                 repr.input.mark_read_only(nodes, &mut output);
             }
             NumericOperationIr::ArgMin(repr) => {

--- a/crates/burn-router/src/ops/int_tensor.rs
+++ b/crates/burn-router/src/ops/int_tensor.rs
@@ -592,7 +592,8 @@ impl<R: RunnerChannel> IntTensorOps<Self> for BackendRouter<R> {
 
     fn int_sum_dim(tensor: IntTensor<Self>, axis: usize) -> IntTensor<Self> {
         let client = tensor.client.clone();
-        let desc = ReduceDimOpIr::create(tensor.into_ir(), axis, || client.create_empty_handle());
+        let desc =
+            ReduceDimOpIr::create(tensor.into_ir(), axis, 1, || client.create_empty_handle());
 
         client
             .register(OperationIr::NumericInt(
@@ -616,7 +617,7 @@ impl<R: RunnerChannel> IntTensorOps<Self> for BackendRouter<R> {
 
     fn int_prod_dim(tensor: IntTensor<Self>, dim: usize) -> IntTensor<Self> {
         let client = tensor.client.clone();
-        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, || client.create_empty_handle());
+        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, 1, || client.create_empty_handle());
 
         client
             .register(OperationIr::NumericInt(
@@ -640,7 +641,7 @@ impl<R: RunnerChannel> IntTensorOps<Self> for BackendRouter<R> {
 
     fn int_mean_dim(tensor: IntTensor<Self>, dim: usize) -> IntTensor<Self> {
         let client = tensor.client.clone();
-        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, || client.create_empty_handle());
+        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, 1, || client.create_empty_handle());
 
         client
             .register(OperationIr::NumericInt(
@@ -700,7 +701,7 @@ impl<R: RunnerChannel> IntTensorOps<Self> for BackendRouter<R> {
 
     fn int_argmax(tensor: IntTensor<Self>, dim: usize) -> IntTensor<Self> {
         let client = tensor.client.clone();
-        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, || client.create_empty_handle());
+        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, 1, || client.create_empty_handle());
 
         client
             .register(OperationIr::NumericInt(
@@ -710,13 +711,21 @@ impl<R: RunnerChannel> IntTensorOps<Self> for BackendRouter<R> {
             .output()
     }
 
-    fn int_argtopk(_tensor: IntTensor<Self>, _dim: usize, _k: usize) -> IntTensor<Self> {
-        todo!("argtopk not implemented for burn router")
+    fn int_argtopk(tensor: IntTensor<Self>, dim: usize, k: usize) -> IntTensor<Self> {
+        let client = tensor.client.clone();
+        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, k, || client.create_empty_handle());
+
+        client
+            .register(OperationIr::NumericInt(
+                desc.out.dtype,
+                NumericOperationIr::ArgTopK(desc),
+            ))
+            .output()
     }
 
     fn int_argmin(tensor: IntTensor<Self>, dim: usize) -> IntTensor<Self> {
         let client = tensor.client.clone();
-        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, || client.create_empty_handle());
+        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, 1, || client.create_empty_handle());
 
         client
             .register(OperationIr::NumericInt(
@@ -788,7 +797,7 @@ impl<R: RunnerChannel> IntTensorOps<Self> for BackendRouter<R> {
 
     fn int_max_dim(tensor: IntTensor<Self>, dim: usize) -> IntTensor<Self> {
         let client = tensor.client.clone();
-        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, || client.create_empty_handle());
+        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, 1, || client.create_empty_handle());
 
         client
             .register(OperationIr::NumericInt(
@@ -833,7 +842,7 @@ impl<R: RunnerChannel> IntTensorOps<Self> for BackendRouter<R> {
 
     fn int_max_abs_dim(tensor: IntTensor<Self>, dim: usize) -> IntTensor<Self> {
         let client = tensor.client.clone();
-        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, || client.create_empty_handle());
+        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, 1, || client.create_empty_handle());
 
         client
             .register(OperationIr::NumericInt(
@@ -857,7 +866,7 @@ impl<R: RunnerChannel> IntTensorOps<Self> for BackendRouter<R> {
 
     fn int_min_dim(tensor: IntTensor<Self>, dim: usize) -> IntTensor<Self> {
         let client = tensor.client.clone();
-        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, || client.create_empty_handle());
+        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, 1, || client.create_empty_handle());
 
         client
             .register(OperationIr::NumericInt(

--- a/crates/burn-router/src/ops/tensor.rs
+++ b/crates/burn-router/src/ops/tensor.rs
@@ -683,7 +683,8 @@ impl<R: RunnerChannel> FloatTensorOps<Self> for BackendRouter<R> {
 
     fn float_sum_dim(tensor: FloatTensor<Self>, axis: usize) -> FloatTensor<Self> {
         let client = tensor.client.clone();
-        let desc = ReduceDimOpIr::create(tensor.into_ir(), axis, || client.create_empty_handle());
+        let desc =
+            ReduceDimOpIr::create(tensor.into_ir(), axis, 1, || client.create_empty_handle());
 
         client
             .register(OperationIr::NumericFloat(
@@ -707,7 +708,7 @@ impl<R: RunnerChannel> FloatTensorOps<Self> for BackendRouter<R> {
 
     fn float_prod_dim(tensor: IntTensor<Self>, dim: usize) -> IntTensor<Self> {
         let client = tensor.client.clone();
-        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, || client.create_empty_handle());
+        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, 1, || client.create_empty_handle());
 
         client
             .register(OperationIr::NumericFloat(
@@ -731,7 +732,7 @@ impl<R: RunnerChannel> FloatTensorOps<Self> for BackendRouter<R> {
 
     fn float_mean_dim(tensor: FloatTensor<Self>, dim: usize) -> FloatTensor<Self> {
         let client = tensor.client.clone();
-        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, || client.create_empty_handle());
+        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, 1, || client.create_empty_handle());
 
         client
             .register(OperationIr::NumericFloat(
@@ -1104,7 +1105,7 @@ impl<R: RunnerChannel> FloatTensorOps<Self> for BackendRouter<R> {
 
     fn float_argmax(tensor: FloatTensor<Self>, dim: usize, out_dtype: IntDType) -> IntTensor<Self> {
         let client = tensor.client.clone();
-        let desc = ReduceDimOpIr::create_arg(tensor.into_ir(), dim, out_dtype.into(), || {
+        let desc = ReduceDimOpIr::create_arg(tensor.into_ir(), dim, 1, out_dtype.into(), || {
             client.create_empty_handle()
         });
 
@@ -1117,12 +1118,22 @@ impl<R: RunnerChannel> FloatTensorOps<Self> for BackendRouter<R> {
     }
 
     fn float_argtopk(
-        _tensor: FloatTensor<Self>,
-        _dim: usize,
-        _k: usize,
-        _out_dtype: IntDType,
+        tensor: FloatTensor<Self>,
+        dim: usize,
+        k: usize,
+        out_dtype: IntDType,
     ) -> IntTensor<Self> {
-        todo!("argtopk not yet implemented for burn-router")
+        let client = tensor.client.clone();
+        let desc = ReduceDimOpIr::create_arg(tensor.into_ir(), dim, k, out_dtype.into(), || {
+            client.create_empty_handle()
+        });
+
+        client
+            .register(OperationIr::NumericFloat(
+                desc.input.dtype,
+                NumericOperationIr::ArgTopK(desc),
+            ))
+            .output()
     }
 
     fn float_repeat_dim(tensor: FloatTensor<Self>, dim: usize, times: usize) -> FloatTensor<Self> {
@@ -1138,7 +1149,7 @@ impl<R: RunnerChannel> FloatTensorOps<Self> for BackendRouter<R> {
 
     fn float_argmin(tensor: FloatTensor<Self>, dim: usize, out_dtype: IntDType) -> IntTensor<Self> {
         let client = tensor.client.clone();
-        let desc = ReduceDimOpIr::create_arg(tensor.into_ir(), dim, out_dtype.into(), || {
+        let desc = ReduceDimOpIr::create_arg(tensor.into_ir(), dim, 1, out_dtype.into(), || {
             client.create_empty_handle()
         });
 
@@ -1164,7 +1175,7 @@ impl<R: RunnerChannel> FloatTensorOps<Self> for BackendRouter<R> {
 
     fn float_max_dim(tensor: FloatTensor<Self>, dim: usize) -> FloatTensor<Self> {
         let client = tensor.client.clone();
-        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, || client.create_empty_handle());
+        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, 1, || client.create_empty_handle());
 
         client
             .register(OperationIr::NumericFloat(
@@ -1208,7 +1219,7 @@ impl<R: RunnerChannel> FloatTensorOps<Self> for BackendRouter<R> {
 
     fn float_min_dim(tensor: FloatTensor<Self>, dim: usize) -> FloatTensor<Self> {
         let client = tensor.client.clone();
-        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, || client.create_empty_handle());
+        let desc = ReduceDimOpIr::create(tensor.into_ir(), dim, 1, || client.create_empty_handle());
 
         client
             .register(OperationIr::NumericFloat(

--- a/crates/burn-router/src/ops/unary.rs
+++ b/crates/burn-router/src/ops/unary.rs
@@ -44,7 +44,12 @@ macro_rules! reduce_float2int_dim_ops {
         $handles:expr, $desc:expr, $ops:expr
     ) => {{
         let input = $handles.get_float_tensor::<B>(&$desc.input);
-        let output = $ops(input, $desc.axis, $desc.reduce_len, $desc.out.dtype.into());
+        let output = $ops(
+            input,
+            $desc.axis,
+            $desc.accumulator_len,
+            $desc.out.dtype.into(),
+        );
 
         $handles.register_int_tensor::<B>(&$desc.out.id, output);
     }};
@@ -57,7 +62,7 @@ macro_rules! reduce_int_dim_ops {
         $handles:expr, $desc:expr, $ops:expr
     ) => {{
         let input = $handles.get_int_tensor::<B>(&$desc.input);
-        let output = $ops(input, $desc.axis, $desc.reduce_len);
+        let output = $ops(input, $desc.axis, $desc.accumulator_len);
 
         $handles.register_int_tensor::<B>(&$desc.out.id, output);
     }};

--- a/crates/burn-router/src/ops/unary.rs
+++ b/crates/burn-router/src/ops/unary.rs
@@ -44,7 +44,7 @@ macro_rules! reduce_float2int_dim_ops {
         $handles:expr, $desc:expr, $ops:expr
     ) => {{
         let input = $handles.get_float_tensor::<B>(&$desc.input);
-        let output = $ops(input, $desc.axis, $desc.out.dtype.into());
+        let output = $ops(input, $desc.axis, $desc.reduce_len, $desc.out.dtype.into());
 
         $handles.register_int_tensor::<B>(&$desc.out.id, output);
     }};
@@ -57,7 +57,7 @@ macro_rules! reduce_int_dim_ops {
         $handles:expr, $desc:expr, $ops:expr
     ) => {{
         let input = $handles.get_int_tensor::<B>(&$desc.input);
-        let output = $ops(input, $desc.axis);
+        let output = $ops(input, $desc.axis, $desc.reduce_len);
 
         $handles.register_int_tensor::<B>(&$desc.out.id, output);
     }};

--- a/crates/burn-router/src/runner.rs
+++ b/crates/burn-router/src/runner.rs
@@ -712,10 +712,17 @@ impl<B: BackendIr> RunnerClient for Runner<B> {
                     scalar_float_cmp_ops!(handles, desc, B::float_lower_equal_elem)
                 }
                 NumericOperationIr::ArgMax(desc) => {
-                    reduce_float2int_dim_ops!(handles, desc, B::float_argmax)
+                    reduce_float2int_dim_ops!(handles, desc, |tensor, axis, _, dtype| {
+                        B::float_argmax(tensor, axis, dtype)
+                    })
+                }
+                NumericOperationIr::ArgTopK(desc) => {
+                    reduce_float2int_dim_ops!(handles, desc, B::float_argtopk)
                 }
                 NumericOperationIr::ArgMin(desc) => {
-                    reduce_float2int_dim_ops!(handles, desc, B::float_argmin)
+                    reduce_float2int_dim_ops!(handles, desc, |tensor, axis, _, dtype| {
+                        B::float_argmin(tensor, axis, dtype)
+                    })
                 }
                 NumericOperationIr::Max(desc) => {
                     unary_float_ops!(handles, desc, B::float_max)
@@ -839,7 +846,9 @@ impl<B: BackendIr> RunnerClient for Runner<B> {
                     handles.register_int_tensor::<B>(&desc.out.id, output);
                 }
                 NumericOperationIr::MeanDim(desc) => {
-                    reduce_int_dim_ops!(handles, desc, B::int_mean_dim)
+                    reduce_int_dim_ops!(handles, desc, |tensor, axis, _| B::int_mean_dim(
+                        tensor, axis
+                    ))
                 }
                 NumericOperationIr::Mean(desc) => {
                     unary_int_ops!(handles, desc, B::int_mean)
@@ -848,13 +857,17 @@ impl<B: BackendIr> RunnerClient for Runner<B> {
                     unary_int_ops!(handles, desc, B::int_sum)
                 }
                 NumericOperationIr::SumDim(desc) => {
-                    reduce_int_dim_ops!(handles, desc, B::int_sum_dim)
+                    reduce_int_dim_ops!(handles, desc, |tensor, axis, _| B::int_sum_dim(
+                        tensor, axis
+                    ))
                 }
                 NumericOperationIr::Prod(desc) => {
                     unary_int_ops!(handles, desc, B::int_prod)
                 }
                 NumericOperationIr::ProdDim(desc) => {
-                    reduce_int_dim_ops!(handles, desc, B::int_prod_dim)
+                    reduce_int_dim_ops!(handles, desc, |tensor, axis, _| B::int_prod_dim(
+                        tensor, axis
+                    ))
                 }
                 NumericOperationIr::Greater(desc) => {
                     binary_int_cmp_ops!(handles, desc, B::int_greater)
@@ -881,10 +894,17 @@ impl<B: BackendIr> RunnerClient for Runner<B> {
                     scalar_int_cmp_ops!(handles, desc, B::int_lower_equal_elem)
                 }
                 NumericOperationIr::ArgMax(desc) => {
-                    reduce_int_dim_ops!(handles, desc, B::int_argmax)
+                    reduce_int_dim_ops!(handles, desc, |tensor, axis, _| B::int_argmax(
+                        tensor, axis
+                    ))
+                }
+                NumericOperationIr::ArgTopK(desc) => {
+                    reduce_int_dim_ops!(handles, desc, B::int_argtopk)
                 }
                 NumericOperationIr::ArgMin(desc) => {
-                    reduce_int_dim_ops!(handles, desc, B::int_argmin)
+                    reduce_int_dim_ops!(handles, desc, |tensor, axis, _| B::int_argmin(
+                        tensor, axis
+                    ))
                 }
                 NumericOperationIr::Max(desc) => {
                     unary_int_ops!(handles, desc, B::int_max)
@@ -907,16 +927,22 @@ impl<B: BackendIr> RunnerClient for Runner<B> {
                     unary_int_ops!(handles, desc, B::int_min)
                 }
                 NumericOperationIr::MaxDim(desc) => {
-                    reduce_int_dim_ops!(handles, desc, B::int_max_dim)
+                    reduce_int_dim_ops!(handles, desc, |tensor, axis, _| B::int_max_dim(
+                        tensor, axis
+                    ))
                 }
                 NumericOperationIr::MinDim(desc) => {
-                    reduce_int_dim_ops!(handles, desc, B::int_min_dim)
+                    reduce_int_dim_ops!(handles, desc, |tensor, axis, _| B::int_min_dim(
+                        tensor, axis
+                    ))
                 }
                 NumericOperationIr::MaxAbs(desc) => {
                     unary_int_ops!(handles, desc, B::int_max_abs)
                 }
                 NumericOperationIr::MaxAbsDim(desc) => {
-                    reduce_int_dim_ops!(handles, desc, B::int_max_abs_dim)
+                    reduce_int_dim_ops!(handles, desc, |tensor, axis, _| B::int_max_abs_dim(
+                        tensor, axis
+                    ))
                 }
                 NumericOperationIr::Clamp(desc) => {
                     let tensor = handles.get_int_tensor::<B>(&desc.tensor);


### PR DESCRIPTION

### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

_Provide links to relevant issues and dependent PRs._

### Changes

implement argtopk functions for fusion

### Testing

```sh
# activate cubecl tests in burn-backend-tests/**/cubecl.rs
cargo test-wgpu argtopk
# also tested that other arg function stills works
cargo test-wgpu arg
```
