### PR TITLE
add autodiff for scatter_nd min/max/mul

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -171,7 +171,7 @@ Those operations are available for all tensor kinds: `Int`, `Float`, and `Bool`.
 | `tensor.roll(shifts, dims)`                          | `tensor.roll(shifts, dims)`                                               |
 | `tensor.roll_dim(shift, dim)`                        | `tensor.roll([shift], [dim])`                                             |
 | `tensor.scatter(dim, indices, values, update)`       | `tensor.scatter_add(dim, indices, values)`                                |
-| `tensor.scatter_nd(indices, values, update)`[^1]     | N/A                                                                       |
+| `tensor.scatter_nd(indices, values, update)`         | N/A                                                                       |
 | `tensor.gather_nd(indices)`                          | N/A                                                                       |
 | `tensor.select(dim, indices)`                        | `tensor.index_select(dim, indices)`                                       |
 | `tensor.select_assign(dim, indices, values, update)` | `tensor.index_add(dim, indices, values)`                                  |
@@ -196,9 +196,6 @@ Those operations are available for all tensor kinds: `Int`, `Float`, and `Bool`.
 | `Tensor::full(shape, fill_value, options)`           | `torch.full(shape, fill_value, device=device, dtype=dtype)`               |
 | `Tensor::ones(shape, options)`                       | `torch.ones(shape, device=device, dtype=dtype)`                           |
 | `Tensor::zeros(shape, options)`                      | `torch.zeros(shape, device=device, dtype=dtype)`                          |
-
-[^1]: Forward pass only. Autodiff is supported for `scatter_nd` assign and add;
-mul/min/max reductions do not support backward.
 
 ### Numeric Operations
 

--- a/crates/burn-autodiff/src/ops/tensor.rs
+++ b/crates/burn-autodiff/src/ops/tensor.rs
@@ -1062,18 +1062,6 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
     ) -> FloatTensor<Self> {
         use burn_backend::tensor::IndexingUpdateOp;
 
-        if matches!(
-            reduction,
-            IndexingUpdateOp::Mul | IndexingUpdateOp::Min | IndexingUpdateOp::Max
-        ) && (!data.node.requirement.is_none() || !values.node.requirement.is_none())
-        {
-            panic!(
-                "scatter_nd with {:?} reduction does not support autograd. \
-                 Detach the input tensors or use Assign/Add reduction instead.",
-                reduction,
-            );
-        }
-
         match reduction {
             IndexingUpdateOp::Add => {
                 #[derive(Debug)]
@@ -1185,36 +1173,177 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                     )),
                 }
             }
-            // The early check above ensures no input requires grad for Mul/Min/Max,
-            // so we can safely forward to the inner backend without registering a
-            // backward op.
-            IndexingUpdateOp::Mul | IndexingUpdateOp::Min | IndexingUpdateOp::Max => {
+            IndexingUpdateOp::Mul => {
+                // Forward: out[idx[i]] = data[idx[i]] * values[i] (unique indices assumed).
+                // Backward:
+                //   grad_data   = grad * scatter_nd(ones_like(data), idx, values, Assign)
+                //   grad_values = gather_nd(grad, idx) * gather_nd(data, idx)
                 #[derive(Debug)]
-                struct ScatterNdNoBackward;
+                struct ScatterNdMul;
 
-                impl<B: Backend> Backward<B, 2> for ScatterNdNoBackward {
-                    type State = ();
+                impl<B: Backend> Backward<B, 2> for ScatterNdMul {
+                    type State = (Option<FloatTensor<B>>, Option<FloatTensor<B>>, IntTensor<B>);
 
                     fn backward(
                         self,
-                        _ops: Ops<Self::State, 2>,
-                        _grads: &mut Gradients,
+                        ops: Ops<Self::State, 2>,
+                        grads: &mut Gradients,
                         _checkpointer: &mut Checkpointer,
                     ) {
-                        unreachable!(
-                            "scatter_nd Mul/Min/Max backward must not run; \
-                             the forward path rejects grad-tracked inputs."
-                        )
+                        let (data_state, values_state, indices) = ops.state;
+                        let [indices_4lhs, indices_4rhs] = duplicate(&ops.parents, Some(indices));
+
+                        binary::<B, _, _>(
+                            ops.parents,
+                            ops.node,
+                            grads,
+                            |grad| {
+                                let device = B::float_device(&grad);
+                                let dtype = grad.dtype();
+                                let shape = grad.shape();
+                                let ones = B::float_ones(shape, &device, dtype.into());
+                                let mult = B::float_scatter_nd(
+                                    ones,
+                                    indices_4lhs.unwrap(),
+                                    values_state.unwrap(),
+                                    IndexingUpdateOp::Assign,
+                                );
+                                B::float_mul(grad, mult)
+                            },
+                            |grad| {
+                                let indices = indices_4rhs.unwrap();
+                                let g_idx = B::float_gather_nd(grad, indices.clone());
+                                let d_idx = B::float_gather_nd(data_state.unwrap(), indices);
+                                B::float_mul(g_idx, d_idx)
+                            },
+                        );
                     }
                 }
 
-                match ScatterNdNoBackward
+                let data_tracked = data.is_tracked();
+                let values_tracked = values.is_tracked();
+
+                match ScatterNdMul
                     .prepare::<C>([data.node, values.node])
                     .compute_bound()
                     .stateful()
                 {
-                    OpsKind::Tracked(_) => unreachable!(
-                        "scatter_nd Mul/Min/Max forward path rejects grad-tracked inputs."
+                    OpsKind::Tracked(prep) => {
+                        let data_state = values_tracked.then(|| data.primitive.clone());
+                        let values_state = data_tracked.then(|| values.primitive.clone());
+                        prep.finish(
+                            (data_state, values_state, indices.clone()),
+                            B::float_scatter_nd(
+                                data.primitive,
+                                indices,
+                                values.primitive,
+                                IndexingUpdateOp::Mul,
+                            ),
+                        )
+                    }
+                    OpsKind::UnTracked(prep) => prep.finish(B::float_scatter_nd(
+                        data.primitive,
+                        indices,
+                        values.primitive,
+                        IndexingUpdateOp::Mul,
+                    )),
+                }
+            }
+            IndexingUpdateOp::Min | IndexingUpdateOp::Max => {
+                // Unique indices are required for this backward formula; duplicate indices have
+                // undefined behavior for scatter_nd Min/Max gradients.
+                // Forward (Max): out[idx] = max(data[idx], values); non-scattered: out = data.
+                // Backward, with ties contributing to both sides (matches cummin/cummax convention):
+                //   data_at_idx  = gather_nd(data, idx)
+                //   data_won     = data_at_idx >= values   (Max)  /  <= values (Min)
+                //   values_won   = values >= data_at_idx   (Max)  /  <= data_at_idx (Min)
+                //   data_mask    = scatter_nd(ones_like(data), idx, data_won, Assign)
+                //   grad_data    = grad * data_mask
+                //   grad_values  = gather_nd(grad, idx) * values_won
+                #[derive(Debug)]
+                struct ScatterNdMinMax;
+
+                impl<B: Backend> Backward<B, 2> for ScatterNdMinMax {
+                    type State = (FloatTensor<B>, FloatTensor<B>, IntTensor<B>, bool);
+
+                    fn backward(
+                        self,
+                        ops: Ops<Self::State, 2>,
+                        grads: &mut Gradients,
+                        _checkpointer: &mut Checkpointer,
+                    ) {
+                        let (data, values, indices, is_max) = ops.state;
+                        let device = B::float_device(&data);
+                        let data_dtype = data.dtype();
+                        let data_shape = data.shape();
+                        let settings = get_device_settings::<B>(&device);
+                        let bool_dtype = settings.bool_dtype;
+
+                        // data_at_idx — needed for both winner masks
+                        let data_at_idx = B::float_gather_nd(data, indices.clone());
+
+                        let (data_won_bool, values_won_bool) = if is_max {
+                            (
+                                B::float_greater_equal(
+                                    data_at_idx.clone(),
+                                    values.clone(),
+                                    bool_dtype,
+                                ),
+                                B::float_greater_equal(values, data_at_idx, bool_dtype),
+                            )
+                        } else {
+                            (
+                                B::float_lower_equal(
+                                    data_at_idx.clone(),
+                                    values.clone(),
+                                    bool_dtype,
+                                ),
+                                B::float_lower_equal(values, data_at_idx, bool_dtype),
+                            )
+                        };
+
+                        let data_won_float = B::bool_into_float(data_won_bool, data_dtype.into());
+                        let values_won_float =
+                            B::bool_into_float(values_won_bool, data_dtype.into());
+
+                        // Build the full-shape data mask: 1 at non-scattered positions,
+                        // data_won_float at scattered positions.
+                        let ones = B::float_ones(data_shape, &device, data_dtype.into());
+                        let data_mask = B::float_scatter_nd(
+                            ones,
+                            indices.clone(),
+                            data_won_float,
+                            IndexingUpdateOp::Assign,
+                        );
+
+                        binary::<B, _, _>(
+                            ops.parents,
+                            ops.node,
+                            grads,
+                            |grad| B::float_mul(grad, data_mask),
+                            |grad| {
+                                let g_idx = B::float_gather_nd(grad, indices);
+                                B::float_mul(g_idx, values_won_float)
+                            },
+                        );
+                    }
+                }
+
+                let is_max = matches!(reduction, IndexingUpdateOp::Max);
+
+                match ScatterNdMinMax
+                    .prepare::<C>([data.node, values.node])
+                    .compute_bound()
+                    .stateful()
+                {
+                    OpsKind::Tracked(prep) => prep.finish(
+                        (
+                            data.primitive.clone(),
+                            values.primitive.clone(),
+                            indices.clone(),
+                            is_max,
+                        ),
+                        B::float_scatter_nd(data.primitive, indices, values.primitive, reduction),
                     ),
                     OpsKind::UnTracked(prep) => prep.finish(B::float_scatter_nd(
                         data.primitive,

--- a/crates/burn-backend-tests/tests/autodiff/gather_scatter_nd.rs
+++ b/crates/burn-backend-tests/tests/autodiff/gather_scatter_nd.rs
@@ -139,6 +139,289 @@ fn test_gather_nd_grad_k_equals_d() {
 }
 
 #[test]
+fn test_scatter_nd_mul_grad() {
+    let device = AutodiffDevice::new();
+    let data: TestTensor<2> = TestTensor::from_data(
+        TensorData::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]),
+        &device,
+    )
+    .require_grad();
+    let values: TestTensor<2> =
+        TestTensor::from_data(TensorData::from([[10.0, 20.0, 30.0]]), &device).require_grad();
+    let indices = TestTensorInt::<2>::from_data(TensorData::from([[1]]), &device);
+
+    // scatter_nd_mul: data[1, :] *= values[0, :]
+    let result: TestTensor<2> =
+        data.clone()
+            .scatter_nd(indices, values.clone(), IndexingUpdateOp::Mul);
+    let grads = result.sum().backward();
+
+    let grad_data = data.grad(&grads).unwrap();
+    let grad_values = values.grad(&grads).unwrap();
+
+    // grad_data = grad * scatter_nd(ones, indices, values, Assign)
+    //   row 1 gets the values, others stay at 1.
+    grad_data.to_data().assert_eq(
+        &TensorData::from([[1.0, 1.0, 1.0], [10.0, 20.0, 30.0], [1.0, 1.0, 1.0]]),
+        false,
+    );
+    // grad_values = gather_nd(grad, indices) * gather_nd(data, indices)
+    //             = ones * data[1, :] = [4.0, 5.0, 6.0]
+    grad_values
+        .to_data()
+        .assert_eq(&TensorData::from([[4.0, 5.0, 6.0]]), false);
+}
+
+#[test]
+fn test_scatter_nd_max_grad_data_wins() {
+    // values < data at scattered positions: gradient flows fully to data.
+    let device = AutodiffDevice::new();
+    let data: TestTensor<2> = TestTensor::from_data(
+        TensorData::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]),
+        &device,
+    )
+    .require_grad();
+    let values: TestTensor<2> =
+        TestTensor::from_data(TensorData::from([[1.0, 2.0, 3.0]]), &device).require_grad();
+    let indices = TestTensorInt::<2>::from_data(TensorData::from([[1]]), &device);
+
+    let result: TestTensor<2> =
+        data.clone()
+            .scatter_nd(indices, values.clone(), IndexingUpdateOp::Max);
+    let grads = result.sum().backward();
+
+    let grad_data = data.grad(&grads).unwrap();
+    let grad_values = values.grad(&grads).unwrap();
+
+    // data wins everywhere on row 1, so grad_data = ones (full flow).
+    grad_data.to_data().assert_eq(
+        &TensorData::from([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]),
+        false,
+    );
+    // values lose, so grad_values is zero.
+    grad_values
+        .to_data()
+        .assert_eq(&TensorData::from([[0.0, 0.0, 0.0]]), false);
+}
+
+#[test]
+fn test_scatter_nd_max_grad_values_win() {
+    // values > data at scattered positions: grad_data zeroed at scattered positions.
+    let device = AutodiffDevice::new();
+    let data: TestTensor<2> = TestTensor::from_data(
+        TensorData::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]),
+        &device,
+    )
+    .require_grad();
+    let values: TestTensor<2> =
+        TestTensor::from_data(TensorData::from([[10.0, 20.0, 30.0]]), &device).require_grad();
+    let indices = TestTensorInt::<2>::from_data(TensorData::from([[1]]), &device);
+
+    let result: TestTensor<2> =
+        data.clone()
+            .scatter_nd(indices, values.clone(), IndexingUpdateOp::Max);
+    let grads = result.sum().backward();
+
+    let grad_data = data.grad(&grads).unwrap();
+    let grad_values = values.grad(&grads).unwrap();
+
+    // grad_data zeroed at row 1 (values won), ones elsewhere.
+    grad_data.to_data().assert_eq(
+        &TensorData::from([[1.0, 1.0, 1.0], [0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]),
+        false,
+    );
+    grad_values
+        .to_data()
+        .assert_eq(&TensorData::from([[1.0, 1.0, 1.0]]), false);
+}
+
+#[test]
+fn test_scatter_nd_max_grad_tie() {
+    // Mixed: column 0 -> data wins, column 1 -> tie (both get grad), column 2 -> values wins.
+    let device = AutodiffDevice::new();
+    let data: TestTensor<2> = TestTensor::from_data(
+        TensorData::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]),
+        &device,
+    )
+    .require_grad();
+    let values: TestTensor<2> =
+        TestTensor::from_data(TensorData::from([[1.0, 5.0, 10.0]]), &device).require_grad();
+    let indices = TestTensorInt::<2>::from_data(TensorData::from([[1]]), &device);
+
+    let result: TestTensor<2> =
+        data.clone()
+            .scatter_nd(indices, values.clone(), IndexingUpdateOp::Max);
+    let grads = result.sum().backward();
+
+    let grad_data = data.grad(&grads).unwrap();
+    let grad_values = values.grad(&grads).unwrap();
+
+    // Row 1: data_won = [T, T, F], values_won = [F, T, T] (tie at col 1 contributes to both).
+    grad_data.to_data().assert_eq(
+        &TensorData::from([[1.0, 1.0, 1.0], [1.0, 1.0, 0.0], [1.0, 1.0, 1.0]]),
+        false,
+    );
+    grad_values
+        .to_data()
+        .assert_eq(&TensorData::from([[0.0, 1.0, 1.0]]), false);
+}
+
+#[test]
+fn test_scatter_nd_min_grad() {
+    // Min mirror of test_scatter_nd_max_grad_values_win: values < data => values win for Min.
+    let device = AutodiffDevice::new();
+    let data: TestTensor<2> = TestTensor::from_data(
+        TensorData::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]),
+        &device,
+    )
+    .require_grad();
+    let values: TestTensor<2> =
+        TestTensor::from_data(TensorData::from([[1.0, 2.0, 3.0]]), &device).require_grad();
+    let indices = TestTensorInt::<2>::from_data(TensorData::from([[1]]), &device);
+
+    let result: TestTensor<2> =
+        data.clone()
+            .scatter_nd(indices, values.clone(), IndexingUpdateOp::Min);
+    let grads = result.sum().backward();
+
+    let grad_data = data.grad(&grads).unwrap();
+    let grad_values = values.grad(&grads).unwrap();
+
+    grad_data.to_data().assert_eq(
+        &TensorData::from([[1.0, 1.0, 1.0], [0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]),
+        false,
+    );
+    grad_values
+        .to_data()
+        .assert_eq(&TensorData::from([[1.0, 1.0, 1.0]]), false);
+}
+
+#[test]
+fn test_scatter_nd_min_grad_tie() {
+    // Mixed: column 0 -> values win, column 1 -> tie, column 2 -> data wins.
+    let device = AutodiffDevice::new();
+    let data: TestTensor<2> = TestTensor::from_data(
+        TensorData::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]),
+        &device,
+    )
+    .require_grad();
+    let values: TestTensor<2> =
+        TestTensor::from_data(TensorData::from([[1.0, 5.0, 10.0]]), &device).require_grad();
+    let indices = TestTensorInt::<2>::from_data(TensorData::from([[1]]), &device);
+
+    let result: TestTensor<2> =
+        data.clone()
+            .scatter_nd(indices, values.clone(), IndexingUpdateOp::Min);
+    let grads = result.sum().backward();
+
+    let grad_data = data.grad(&grads).unwrap();
+    let grad_values = values.grad(&grads).unwrap();
+
+    // Row 1: data_won = [F, T, T], values_won = [T, T, F].
+    grad_data.to_data().assert_eq(
+        &TensorData::from([[1.0, 1.0, 1.0], [0.0, 1.0, 1.0], [1.0, 1.0, 1.0]]),
+        false,
+    );
+    grad_values
+        .to_data()
+        .assert_eq(&TensorData::from([[1.0, 1.0, 0.0]]), false);
+}
+
+#[test]
+fn test_scatter_nd_max_grad_k_equals_d() {
+    // K=D scalar-level Max: each index targets one element.
+    let device = AutodiffDevice::new();
+    let data: TestTensor<2> =
+        TestTensor::from_data(TensorData::from([[1.0, 2.0], [3.0, 4.0]]), &device).require_grad();
+    let values: TestTensor<1> =
+        TestTensor::from_data(TensorData::from([10.0, 1.0]), &device).require_grad();
+    let indices = TestTensorInt::<2>::from_data(TensorData::from([[0, 1], [1, 0]]), &device);
+
+    let result: TestTensor<2> =
+        data.clone()
+            .scatter_nd(indices, values.clone(), IndexingUpdateOp::Max);
+    let grads = result.sum().backward();
+
+    let grad_data = data.grad(&grads).unwrap();
+    let grad_values = values.grad(&grads).unwrap();
+
+    grad_data
+        .to_data()
+        .assert_eq(&TensorData::from([[1.0, 0.0], [1.0, 1.0]]), false);
+    grad_values
+        .to_data()
+        .assert_eq(&TensorData::from([1.0, 0.0]), false);
+}
+
+#[test]
+fn test_scatter_nd_mul_grad_k_equals_d() {
+    // K=D scalar-level Mul: each index targets one element.
+    let device = AutodiffDevice::new();
+    let data: TestTensor<2> =
+        TestTensor::from_data(TensorData::from([[1.0, 2.0], [3.0, 4.0]]), &device).require_grad();
+    let values: TestTensor<1> =
+        TestTensor::from_data(TensorData::from([10.0, 20.0]), &device).require_grad();
+    // Multiply data[0,1] by 10 and data[1,0] by 20.
+    let indices = TestTensorInt::<2>::from_data(TensorData::from([[0, 1], [1, 0]]), &device);
+
+    let result: TestTensor<2> =
+        data.clone()
+            .scatter_nd(indices, values.clone(), IndexingUpdateOp::Mul);
+    let grads = result.sum().backward();
+
+    let grad_data = data.grad(&grads).unwrap();
+    let grad_values = values.grad(&grads).unwrap();
+
+    // grad_data[0,1] = 10 (multiplier), grad_data[1,0] = 20, others = 1.
+    grad_data
+        .to_data()
+        .assert_eq(&TensorData::from([[1.0, 10.0], [20.0, 1.0]]), false);
+    // grad_values = data at [0,1]=2, [1,0]=3.
+    grad_values
+        .to_data()
+        .assert_eq(&TensorData::from([2.0, 3.0]), false);
+}
+
+#[test]
+fn test_scatter_nd_mul_grad_only_data_tracked() {
+    let device = AutodiffDevice::new();
+    let data: TestTensor<2> =
+        TestTensor::from_data(TensorData::from([[1.0, 2.0], [3.0, 4.0]]), &device).require_grad();
+    let values: TestTensor<1> = TestTensor::from_data(TensorData::from([10.0]), &device);
+    let indices = TestTensorInt::<2>::from_data(TensorData::from([[0, 1]]), &device);
+
+    let result: TestTensor<2> = data
+        .clone()
+        .scatter_nd(indices, values, IndexingUpdateOp::Mul);
+    let grads = result.sum().backward();
+
+    let grad_data = data.grad(&grads).unwrap();
+
+    grad_data
+        .to_data()
+        .assert_eq(&TensorData::from([[1.0, 10.0], [1.0, 1.0]]), false);
+}
+
+#[test]
+fn test_scatter_nd_mul_grad_only_values_tracked() {
+    let device = AutodiffDevice::new();
+    let data: TestTensor<2> =
+        TestTensor::from_data(TensorData::from([[1.0, 2.0], [3.0, 4.0]]), &device);
+    let values: TestTensor<1> =
+        TestTensor::from_data(TensorData::from([10.0]), &device).require_grad();
+    let indices = TestTensorInt::<2>::from_data(TensorData::from([[0, 1]]), &device);
+
+    let result: TestTensor<2> = data.scatter_nd(indices, values.clone(), IndexingUpdateOp::Mul);
+    let grads = result.sum().backward();
+
+    let grad_values = values.grad(&grads).unwrap();
+
+    grad_values
+        .to_data()
+        .assert_eq(&TensorData::from([2.0]), false);
+}
+
+#[test]
 fn test_scatter_nd_assign_grad_k_equals_d() {
     // K=D: scalar-level assign, each index overwrites a single element
     let device = AutodiffDevice::new();

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -1824,7 +1824,7 @@ where
         ))
     }
 
-    /// Multi-dimensional scatter: update `self` at locations given by `indices` using the specified `update` operation.
+    /// Multi-dimensional scatter: update the tensor at locations given by `indices` using the specified `update` operation.
     ///
     /// The size of `indices`'s last axis (call it `K`) indexes the leading `K` dims of `self`;
     /// the batch shape `indices.shape[0..M-1]` is preserved. `values` has shape
@@ -1837,9 +1837,14 @@ where
     ///
     /// # Note
     ///
-    /// When `indices` contains duplicate entries, the result is non-deterministic on GPU
-    /// backends (matching ONNX ScatterND semantics). CPU backends are deterministic regardless
-    /// of reduction. For deterministic accumulation with duplicates, run on a CPU backend.
+    /// When `indices` contains duplicate entries, behavior varies by operation:
+    /// - For `Add`, accumulation is supported, though results may be non-deterministic on GPU
+    ///   backends.
+    /// - For other operations (`Assign`, `Mul`, `Min`, `Max`), duplicate indices result in
+    ///   undefined behavior for both the forward result and the backward gradients.
+    ///
+    /// For deterministic results and correct gradient calculation across all operations,
+    /// `indices` should contain unique entries.
     ///
     /// # Warning
     ///


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Builds on top of #4709 

Closes issue #4433 

### Changes

At the moment backward pass throws for `scatter_nd` min, max, and mul. this provides an implementation for the backward pass

### Testing

Unit tests
