### PR TITLE
fix: trim padding_out in conv_transpose x-backward (#4845)

### DIFF
--- a/crates/burn-backend-tests/tests/autodiff/conv_transpose1d.rs
+++ b/crates/burn-backend-tests/tests/autodiff/conv_transpose1d.rs
@@ -211,6 +211,52 @@ fn test_conv_transpose1d_complex() {
     test.assert_grads(grads);
 }
 
+/// Regression test for #4845.
+///
+/// `ConvTranspose1d` with `padding_out != 0` and `stride == 1` used to panic in
+/// the backward pass because `conv_transpose1d_x_backward` did not account for
+/// the trailing `padding_out` cells, producing a gradient longer than `x`.
+#[test]
+fn test_conv_transpose1d_padding_out_stride1_backward_shape() {
+    let device = AutodiffDevice::new();
+    let batch_size = 2;
+    let channels_in = 2;
+    let channels_out = 2;
+    let kernel_size = 3;
+    let size_in = 4;
+    let padding_out = 1;
+
+    let shape_x = Shape::new([batch_size, channels_in, size_in]);
+    let shape_weight = Shape::new([channels_in, channels_out, kernel_size]);
+    let weight = TestTensor::from_data(
+        TestTensorInt::arange(0..shape_weight.num_elements() as i64, &device)
+            .reshape::<3, _>(shape_weight.clone())
+            .into_data(),
+        &device,
+    )
+    .require_grad();
+    let x = TestTensor::from_data(
+        TestTensorInt::arange(0..shape_x.num_elements() as i64, &device)
+            .reshape::<3, _>(shape_x.clone())
+            .into_data(),
+        &device,
+    )
+    .require_grad();
+
+    let output = conv_transpose1d(
+        x.clone(),
+        weight.clone(),
+        None,
+        ConvTransposeOptions::new([1], [0], [padding_out], [1], 1),
+    );
+    let grads = output.backward();
+
+    let x_grad = x.grad(&grads).unwrap();
+    let weight_grad = weight.grad(&grads).unwrap();
+    assert_eq!(x_grad.shape(), shape_x);
+    assert_eq!(weight_grad.shape(), shape_weight);
+}
+
 struct ConvTranspose1dTestCase {
     batch_size: usize,
     channels: [usize; 2],

--- a/crates/burn-backend/src/backend/ops/modules/conv.rs
+++ b/crates/burn-backend/src/backend/ops/modules/conv.rs
@@ -474,7 +474,7 @@ pub(crate) fn conv_transpose1d_x_backward<B: Backend>(
     output_grad: FloatTensor<B>,
     options: ConvTransposeOptions<1>,
 ) -> FloatTensor<B> {
-    B::conv1d(
+    let grad = B::conv1d(
         output_grad,
         weight,
         None,
@@ -484,7 +484,37 @@ pub(crate) fn conv_transpose1d_x_backward<B: Backend>(
             options.dilation,
             options.groups,
         ),
-    )
+    );
+    // The forward transpose conv extends its output by `padding_out` zero cells
+    // on the trailing edge; those cells carry gradient but do not depend on
+    // any input cell. The inverse conv1d above therefore produces a result
+    // longer than the original `x` by `floor(padding_out / stride)`. Trim the
+    // trailing cells to recover the input length.
+    trim_padding_out_1d::<B>(grad, options.padding_out[0], options.stride[0])
+}
+
+fn trim_padding_out_1d<B: Backend>(
+    grad: FloatTensor<B>,
+    padding_out: usize,
+    stride: usize,
+) -> FloatTensor<B> {
+    if padding_out == 0 {
+        return grad;
+    }
+    let trim = padding_out / stride.max(1);
+    if trim == 0 {
+        return grad;
+    }
+    let [batch_size, channels_in, length] = grad.shape().dims();
+    if trim >= length {
+        return grad;
+    }
+    let slices = [
+        Slice::from(0..batch_size),
+        Slice::from(0..channels_in),
+        Slice::from(0..length - trim),
+    ];
+    B::float_slice(grad, &slices)
 }
 
 /// Calculate the [1D convolution transpose](crate::ops::ModuleOps::conv_transpose1d) backward pass, returning the gradient for `weight`.
@@ -531,7 +561,7 @@ pub(crate) fn conv_transpose2d_x_backward<B: Backend>(
     output_grad: FloatTensor<B>,
     options: ConvTransposeOptions<2>,
 ) -> FloatTensor<B> {
-    B::conv2d(
+    let grad = B::conv2d(
         output_grad,
         weight,
         None,
@@ -541,7 +571,33 @@ pub(crate) fn conv_transpose2d_x_backward<B: Backend>(
             options.dilation,
             options.groups,
         ),
-    )
+    );
+    trim_padding_out_2d::<B>(grad, options.padding_out, options.stride)
+}
+
+fn trim_padding_out_2d<B: Backend>(
+    grad: FloatTensor<B>,
+    padding_out: [usize; 2],
+    stride: [usize; 2],
+) -> FloatTensor<B> {
+    if padding_out[0] == 0 && padding_out[1] == 0 {
+        return grad;
+    }
+    let h_trim = padding_out[0] / stride[0].max(1);
+    let w_trim = padding_out[1] / stride[1].max(1);
+    if h_trim == 0 && w_trim == 0 {
+        return grad;
+    }
+    let [batch_size, channels_in, height, width] = grad.shape().dims();
+    let h_trim = h_trim.min(height);
+    let w_trim = w_trim.min(width);
+    let slices = [
+        Slice::from(0..batch_size),
+        Slice::from(0..channels_in),
+        Slice::from(0..height - h_trim),
+        Slice::from(0..width - w_trim),
+    ];
+    B::float_slice(grad, &slices)
 }
 
 /// Calculate the [2D convolution transpose](crate::ops::ModuleOps::conv_transpose2d) backward pass, returning the gradient for `weight`.
@@ -591,7 +647,7 @@ pub(crate) fn conv_transpose3d_x_backward<B: Backend>(
     output_grad: FloatTensor<B>,
     options: ConvTransposeOptions<3>,
 ) -> FloatTensor<B> {
-    B::conv3d(
+    let grad = B::conv3d(
         output_grad,
         weight,
         None,
@@ -601,7 +657,36 @@ pub(crate) fn conv_transpose3d_x_backward<B: Backend>(
             options.dilation,
             options.groups,
         ),
-    )
+    );
+    trim_padding_out_3d::<B>(grad, options.padding_out, options.stride)
+}
+
+fn trim_padding_out_3d<B: Backend>(
+    grad: FloatTensor<B>,
+    padding_out: [usize; 3],
+    stride: [usize; 3],
+) -> FloatTensor<B> {
+    if padding_out[0] == 0 && padding_out[1] == 0 && padding_out[2] == 0 {
+        return grad;
+    }
+    let d_trim = padding_out[0] / stride[0].max(1);
+    let h_trim = padding_out[1] / stride[1].max(1);
+    let w_trim = padding_out[2] / stride[2].max(1);
+    if d_trim == 0 && h_trim == 0 && w_trim == 0 {
+        return grad;
+    }
+    let [batch_size, channels_in, depth, height, width] = grad.shape().dims();
+    let d_trim = d_trim.min(depth);
+    let h_trim = h_trim.min(height);
+    let w_trim = w_trim.min(width);
+    let slices = [
+        Slice::from(0..batch_size),
+        Slice::from(0..channels_in),
+        Slice::from(0..depth - d_trim),
+        Slice::from(0..height - h_trim),
+        Slice::from(0..width - w_trim),
+    ];
+    B::float_slice(grad, &slices)
 }
 
 /// Calculate the [3D convolution transpose](crate::ops::ModuleOps::conv_transpose3d) backward pass, returning the gradient for `weight`.

--- a/crates/burn-backend/src/backend/ops/modules/conv.rs
+++ b/crates/burn-backend/src/backend/ops/modules/conv.rs
@@ -166,18 +166,6 @@ pub fn calculate_conv_output_sizes(
         .collect()
 }
 
-/// Calculate the expected output size when doing a transposed convolution operation.
-pub fn calculate_conv_transpose_output_size(
-    kernel_size: usize,
-    stride: usize,
-    padding: usize,
-    padding_out: usize,
-    dilation: usize,
-    size_in: usize,
-) -> usize {
-    (size_in - 1) * stride + (dilation * (kernel_size - 1) + 1) + padding_out - 2 * padding
-}
-
 /// Calculate the expected output size when doing a pooling operation.
 ///
 /// # Arguments
@@ -205,6 +193,56 @@ pub fn calculate_pool_output_size(
         // Floor division (default)
         numerator / stride + 1
     }
+}
+
+/// Calculate the expected output size when doing a transposed convolution operation.
+pub fn calculate_conv_transpose_output_size(
+    kernel_size: usize,
+    stride: usize,
+    padding: usize,
+    padding_out: usize,
+    dilation: usize,
+    size_in: usize,
+) -> usize {
+    (size_in - 1) * stride + (dilation * (kernel_size - 1) + 1) + padding_out - 2 * padding
+}
+
+/// Calculate the original input size that was used for a transposed convolution.
+/// This is used during the backward pass to recover the correct gradient shape.
+fn calculate_conv_transpose_input_size(
+    kernel_size: usize,
+    stride: usize,
+    padding: usize,
+    padding_out: usize,
+    dilation: usize,
+    size_out: usize,
+) -> usize {
+    // We solve the forward formula for size_in:
+    // size_out = (size_in - 1) * stride + (dilation * (kernel_size - 1) + 1) + padding_out - 2 * padding
+    (size_out + 2 * padding - dilation * (kernel_size - 1) - padding_out - 1) / stride + 1
+}
+
+/// Calculate the original input sizes that were used for a transposed convolution.
+fn calculate_conv_transpose_input_sizes<const D: usize>(
+    kernel_size: [usize; D],
+    stride: [usize; D],
+    padding: [usize; D],
+    padding_out: [usize; D],
+    dilation: [usize; D],
+    size_out: [usize; D],
+) -> [usize; D] {
+    let mut res = [0; D];
+    for i in 0..D {
+        res[i] = calculate_conv_transpose_input_size(
+            kernel_size[i],
+            stride[i],
+            padding[i],
+            padding_out[i],
+            dilation[i],
+            size_out[i],
+        );
+    }
+    res
 }
 
 /// Calculate the [1D convolution](crate::ops::ModuleOps::conv1d) backward pass, returning the gradient for `x`.
@@ -474,6 +512,9 @@ pub(crate) fn conv_transpose1d_x_backward<B: Backend>(
     output_grad: FloatTensor<B>,
     options: ConvTransposeOptions<1>,
 ) -> FloatTensor<B> {
+    let [batch_size, _c_out, out_length] = output_grad.shape().dims();
+    let [c_in, _c_out_groups, kernel_size] = weight.shape().dims();
+
     let grad = B::conv1d(
         output_grad,
         weight,
@@ -485,36 +526,28 @@ pub(crate) fn conv_transpose1d_x_backward<B: Backend>(
             options.groups,
         ),
     );
-    // The forward transpose conv extends its output by `padding_out` zero cells
-    // on the trailing edge; those cells carry gradient but do not depend on
-    // any input cell. The inverse conv1d above therefore produces a result
-    // longer than the original `x` by `floor(padding_out / stride)`. Trim the
-    // trailing cells to recover the input length.
-    trim_padding_out_1d::<B>(grad, options.padding_out[0], options.stride[0])
-}
 
-fn trim_padding_out_1d<B: Backend>(
-    grad: FloatTensor<B>,
-    padding_out: usize,
-    stride: usize,
-) -> FloatTensor<B> {
-    if padding_out == 0 {
+    if options.padding_out[0] == 0 {
         return grad;
     }
-    let trim = padding_out / stride.max(1);
-    if trim == 0 {
-        return grad;
-    }
-    let [batch_size, channels_in, length] = grad.shape().dims();
-    if trim >= length {
-        return grad;
-    }
-    let slices = [
-        Slice::from(0..batch_size),
-        Slice::from(0..channels_in),
-        Slice::from(0..length - trim),
-    ];
-    B::float_slice(grad, &slices)
+
+    let exp_length = calculate_conv_transpose_input_size(
+        kernel_size,
+        options.stride[0],
+        options.padding[0],
+        options.padding_out[0],
+        options.dilation[0],
+        out_length,
+    );
+
+    B::float_slice(
+        grad,
+        &[
+            Slice::from(0..batch_size),
+            Slice::from(0..c_in),
+            Slice::from(0..exp_length),
+        ],
+    )
 }
 
 /// Calculate the [1D convolution transpose](crate::ops::ModuleOps::conv_transpose1d) backward pass, returning the gradient for `weight`.
@@ -561,6 +594,9 @@ pub(crate) fn conv_transpose2d_x_backward<B: Backend>(
     output_grad: FloatTensor<B>,
     options: ConvTransposeOptions<2>,
 ) -> FloatTensor<B> {
+    let [batch_size, _c_out, out_h, out_w] = output_grad.shape().dims();
+    let [c_in, _c_out_groups, k_h, k_w] = weight.shape().dims();
+
     let grad = B::conv2d(
         output_grad,
         weight,
@@ -572,32 +608,29 @@ pub(crate) fn conv_transpose2d_x_backward<B: Backend>(
             options.groups,
         ),
     );
-    trim_padding_out_2d::<B>(grad, options.padding_out, options.stride)
-}
 
-fn trim_padding_out_2d<B: Backend>(
-    grad: FloatTensor<B>,
-    padding_out: [usize; 2],
-    stride: [usize; 2],
-) -> FloatTensor<B> {
-    if padding_out[0] == 0 && padding_out[1] == 0 {
+    if options.padding_out[0] == 0 && options.padding_out[1] == 0 {
         return grad;
     }
-    let h_trim = padding_out[0] / stride[0].max(1);
-    let w_trim = padding_out[1] / stride[1].max(1);
-    if h_trim == 0 && w_trim == 0 {
-        return grad;
-    }
-    let [batch_size, channels_in, height, width] = grad.shape().dims();
-    let h_trim = h_trim.min(height);
-    let w_trim = w_trim.min(width);
-    let slices = [
-        Slice::from(0..batch_size),
-        Slice::from(0..channels_in),
-        Slice::from(0..height - h_trim),
-        Slice::from(0..width - w_trim),
-    ];
-    B::float_slice(grad, &slices)
+
+    let [exp_h, exp_w] = calculate_conv_transpose_input_sizes(
+        [k_h, k_w],
+        options.stride,
+        options.padding,
+        options.padding_out,
+        options.dilation,
+        [out_h, out_w],
+    );
+
+    B::float_slice(
+        grad,
+        &[
+            Slice::from(0..batch_size),
+            Slice::from(0..c_in),
+            Slice::from(0..exp_h),
+            Slice::from(0..exp_w),
+        ],
+    )
 }
 
 /// Calculate the [2D convolution transpose](crate::ops::ModuleOps::conv_transpose2d) backward pass, returning the gradient for `weight`.
@@ -647,6 +680,9 @@ pub(crate) fn conv_transpose3d_x_backward<B: Backend>(
     output_grad: FloatTensor<B>,
     options: ConvTransposeOptions<3>,
 ) -> FloatTensor<B> {
+    let [batch_size, _c_out, out_d, out_h, out_w] = output_grad.shape().dims();
+    let [c_in, _c_out_groups, k_d, k_h, k_w] = weight.shape().dims();
+
     let grad = B::conv3d(
         output_grad,
         weight,
@@ -658,35 +694,30 @@ pub(crate) fn conv_transpose3d_x_backward<B: Backend>(
             options.groups,
         ),
     );
-    trim_padding_out_3d::<B>(grad, options.padding_out, options.stride)
-}
 
-fn trim_padding_out_3d<B: Backend>(
-    grad: FloatTensor<B>,
-    padding_out: [usize; 3],
-    stride: [usize; 3],
-) -> FloatTensor<B> {
-    if padding_out[0] == 0 && padding_out[1] == 0 && padding_out[2] == 0 {
+    if options.padding_out[0] == 0 && options.padding_out[1] == 0 && options.padding_out[2] == 0 {
         return grad;
     }
-    let d_trim = padding_out[0] / stride[0].max(1);
-    let h_trim = padding_out[1] / stride[1].max(1);
-    let w_trim = padding_out[2] / stride[2].max(1);
-    if d_trim == 0 && h_trim == 0 && w_trim == 0 {
-        return grad;
-    }
-    let [batch_size, channels_in, depth, height, width] = grad.shape().dims();
-    let d_trim = d_trim.min(depth);
-    let h_trim = h_trim.min(height);
-    let w_trim = w_trim.min(width);
-    let slices = [
-        Slice::from(0..batch_size),
-        Slice::from(0..channels_in),
-        Slice::from(0..depth - d_trim),
-        Slice::from(0..height - h_trim),
-        Slice::from(0..width - w_trim),
-    ];
-    B::float_slice(grad, &slices)
+
+    let [exp_d, exp_h, exp_w] = calculate_conv_transpose_input_sizes(
+        [k_d, k_h, k_w],
+        options.stride,
+        options.padding,
+        options.padding_out,
+        options.dilation,
+        [out_d, out_h, out_w],
+    );
+
+    B::float_slice(
+        grad,
+        &[
+            Slice::from(0..batch_size),
+            Slice::from(0..c_in),
+            Slice::from(0..exp_d),
+            Slice::from(0..exp_h),
+            Slice::from(0..exp_w),
+        ],
+    )
 }
 
 /// Calculate the [3D convolution transpose](crate::ops::ModuleOps::conv_transpose3d) backward pass, returning the gradient for `weight`.


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Fixes #4845.

### Changes

`conv_transpose{1,2,3}d_x_backward` ran the inverse conv on the full `output_grad`, but the trailing `padding_out` cells of a transpose-conv output do not depend on any input cell. The inverse conv therefore produced a result longer than the original input by `floor(padding_out / stride)` on each spatial axis, which then panicked when the gradient was registered against `x`.

Slice off the trailing cells after the inverse conv to recover the original input shape. Weight and bias gradients are unaffected (weight grad already slices to `weight_shape`; bias grad sums over spatial dims).

### Testing

- `cargo test -p burn-backend-tests --test autodiff conv` (98 conv autodiff tests pass, including the new regression test)
- `cargo test -p burn-backend-tests --test tensor conv_transpose` (19 tests pass)
- Added `test_conv_transpose1d_padding_out_stride1_backward_shape` mirroring the issue reproducer (stride=1, padding_out=1).