### PR TITLE
Re-enable fusion f16 conv + bn regression tests

### DIFF
--- a/crates/burn-backend-tests/tests/cubecl.rs
+++ b/crates/burn-backend-tests/tests/cubecl.rs
@@ -1,7 +1,7 @@
 //! CubeCL kernel tests.
-
+#![cfg(feature = "cube")]
 #![recursion_limit = "256"]
-#[cfg(feature = "cube")]
+
 #[path = "."]
 mod cube {
     type FloatElem = f32;

--- a/crates/burn-backend-tests/tests/fusion/fusion_f16_broadcast.rs
+++ b/crates/burn-backend-tests/tests/fusion/fusion_f16_broadcast.rs
@@ -7,13 +7,11 @@
 //! The sqrt(v + eps) computation on the [1,256,1,1] parameter tensor gets
 //! fused into the same kernel as the broadcast ops on the [1,256,16,16] conv output
 
-use burn::backend::wgpu::{CubeBackend, WgpuRuntime};
-use burn::nn::conv::Conv2dConfig;
-use burn::prelude::*;
-use burn_fusion::Fusion;
-
-type Fused = Fusion<CubeBackend<WgpuRuntime, half::f16, i32, u8>>;
-type Unfused = CubeBackend<WgpuRuntime, half::f16, i32, u8>;
+use super::*;
+use burn_tensor::{
+    DType, Device, TensorCreationOptions, TensorData, Tolerance, backend::Backend, module::conv2d,
+    ops::ConvOptions,
+};
 
 const EPS: f64 = 1e-5;
 
@@ -23,35 +21,27 @@ fn pseudo_random(n: usize, seed: f32, scale: f32) -> Vec<f32> {
         .collect()
 }
 
-fn make_conv<B: Backend>(
+fn make_conv_weight(
     in_ch: usize,
     out_ch: usize,
     seed: f32,
-    dev: &B::Device,
-) -> burn::nn::conv::Conv2d<B> {
-    let conv = Conv2dConfig::new([in_ch, out_ch], [1, 1])
-        .with_bias(false)
-        .init::<B>(dev);
+    opts: TensorCreationOptions<TestBackend>,
+) -> TestTensor<4> {
+    // kernel_size=[1, 1]; stride=[1, 1]; dilation=[1, 1]; groups=1;
     let n = out_ch * in_ch;
     let scale = (2.0 / in_ch as f32).sqrt();
-    let data = pseudo_random(n, seed, scale);
-    let weight = Tensor::<B, 1>::from_floats(data.as_slice(), dev).reshape([out_ch, in_ch, 1, 1]);
-    let mut record = conv.into_record();
-    record.weight = burn::module::Param::initialized(burn::module::ParamId::new(), weight);
-    Conv2dConfig::new([in_ch, out_ch], [1, 1])
-        .with_bias(false)
-        .init::<B>(dev)
-        .load_record(record)
+    let data = TensorData::new(pseudo_random(n, seed, scale), [out_ch, in_ch, 1, 1]);
+    TestTensor::from_data(data, opts)
 }
 
-fn manual_bn<B: Backend>(
-    x: Tensor<B, 4>,
+fn manual_bn(
+    x: TestTensor<4>,
     ch: usize,
-    mean: &Tensor<B, 1>,
-    var: &Tensor<B, 1>,
-    gamma: &Tensor<B, 1>,
-    beta: &Tensor<B, 1>,
-) -> Tensor<B, 4> {
+    mean: &TestTensor<1>,
+    var: &TestTensor<1>,
+    gamma: &TestTensor<1>,
+    beta: &TestTensor<1>,
+) -> TestTensor<4> {
     let m = mean.clone().reshape([1, ch, 1, 1]);
     let v = var.clone().reshape([1, ch, 1, 1]);
     let g = gamma.clone().reshape([1, ch, 1, 1]);
@@ -60,85 +50,59 @@ fn manual_bn<B: Backend>(
     (x - m) / std * g + b
 }
 
-fn two_conv_bn_branches<B: Backend>() -> Vec<f32> {
-    let dev = B::Device::default();
-    let conv_a = make_conv::<B>(64, 256, 1.0, &dev);
-    let conv_b = make_conv::<B>(64, 256, 2.0, &dev);
+fn two_conv_bn_branches(dev: Device<TestBackend>, dtype: DType) -> TensorData {
+    let opts: TensorCreationOptions<TestBackend> = (&dev, dtype).into();
+    let weight_a = make_conv_weight(64, 256, 1.0, opts.clone());
+    let weight_b = make_conv_weight(64, 256, 2.0, opts.clone());
 
     let ch = 256;
     let make_params = |seed: f32| {
-        let mean =
-            Tensor::<B, 1>::from_floats(pseudo_random(ch, seed + 300.0, 0.5).as_slice(), &dev);
+        let mean = TestTensor::<1>::from_data(
+            TensorData::new(pseudo_random(ch, seed + 300.0, 0.5), [ch]),
+            opts.clone(),
+        );
         let var_data: Vec<f32> = pseudo_random(ch, seed + 400.0, 0.3)
             .iter()
             .map(|v| 0.5 + v.abs())
             .collect();
-        let var = Tensor::<B, 1>::from_floats(var_data.as_slice(), &dev);
+        let var = TestTensor::<1>::from_data(TensorData::new(var_data, [ch]), opts.clone());
         let gamma_data: Vec<f32> = pseudo_random(ch, seed + 100.0, 0.5)
             .iter()
             .map(|v| 1.0 + v * 0.1)
             .collect();
-        let gamma = Tensor::<B, 1>::from_floats(gamma_data.as_slice(), &dev);
-        let beta =
-            Tensor::<B, 1>::from_floats(pseudo_random(ch, seed + 200.0, 0.3).as_slice(), &dev);
+        let gamma = TestTensor::<1>::from_data(TensorData::new(gamma_data, [ch]), opts.clone());
+        let beta = TestTensor::<1>::from_data(
+            TensorData::new(pseudo_random(ch, seed + 200.0, 0.3), [ch]),
+            opts.clone(),
+        );
         (mean, var, gamma, beta)
     };
     let (mean_a, var_a, gamma_a, beta_a) = make_params(1.0);
     let (mean_b, var_b, gamma_b, beta_b) = make_params(2.0);
-    B::sync(&dev).unwrap();
+    TestBackend::sync(&dev).unwrap();
 
     let numel = 64 * 16 * 16;
     let data: Vec<f32> = (0..numel).map(|i| (i as f32 * 7.13).sin() * 0.5).collect();
-    let input: Tensor<B, 4> =
-        Tensor::<B, 1>::from_floats(data.as_slice(), &dev).reshape([1, 64, 16, 16]);
+    let input = TestTensor::<4>::from_data(TensorData::new(data, [1, 64, 16, 16]), opts);
 
-    let a = manual_bn(
-        conv_a.forward(input.clone()),
-        ch,
-        &mean_a,
-        &var_a,
-        &gamma_a,
-        &beta_a,
-    );
-    let b = manual_bn(
-        conv_b.forward(input),
-        ch,
-        &mean_b,
-        &var_b,
-        &gamma_b,
-        &beta_b,
-    );
+    let options = ConvOptions::new([1, 1], [0, 0], [1, 1], 1);
+    let conv_a_out = conv2d(input.clone(), weight_a, None, options.clone());
+    let conv_b_out = conv2d(input, weight_b, None, options);
+
+    let a = manual_bn(conv_a_out, ch, &mean_a, &var_a, &gamma_a, &beta_a);
+    let b = manual_bn(conv_b_out, ch, &mean_b, &var_b, &gamma_b, &beta_b);
     let out = a + b;
 
-    let data = out.into_data();
-    let vals: &[half::f16] = data.as_slice().unwrap();
-    vals.iter().map(|v| f32::from(*v)).collect()
+    out.into_data()
 }
 
 /// This test was failing only on Vulkan+Fusion+f16
 #[test]
 fn fusion_f16_two_branch_conv_manual_bn() {
-    let fused = two_conv_bn_branches::<Fused>();
-    let reference = two_conv_bn_branches::<Unfused>();
+    let fused_f16 = two_conv_bn_branches(Default::default(), DType::F16);
+    let reference_f32 = two_conv_bn_branches(Default::default(), DType::F32);
 
-    assert_eq!(fused.len(), reference.len(), "output length mismatch");
-
-    let max_diff = fused
-        .iter()
-        .zip(reference.iter())
-        .map(|(f, r)| (f - r).abs())
-        .fold(0.0f32, f32::max);
-
-    let first_bad = fused
-        .iter()
-        .zip(reference.iter())
-        .enumerate()
-        .find(|(_, (f, r))| (*f - *r).abs() > 0.01 || f.is_nan() || f.is_infinite());
-
-    if let Some((idx, (f, r))) = first_bad {
-        panic!(
-            "fused vs unfused mismatch: max_diff={max_diff:.6}, first bad at idx={idx}/{}: fused={f} ref={r}",
-            fused.len()
-        );
-    }
+    fused_f16
+        .convert_dtype(DType::F32)
+        .assert_approx_eq::<FloatElem>(&reference_f32, Tolerance::rel_abs(5e-3, 1e-2));
 }

--- a/crates/burn-backend-tests/tests/fusion/fusion_f16_broadcast.rs
+++ b/crates/burn-backend-tests/tests/fusion/fusion_f16_broadcast.rs
@@ -97,6 +97,7 @@ fn two_conv_bn_branches(dev: Device<TestBackend>, dtype: DType) -> TensorData {
 }
 
 /// This test was failing only on Vulkan+Fusion+f16
+/// Reference: https://github.com/tracel-ai/burn/pull/4675
 #[test]
 fn fusion_f16_two_branch_conv_manual_bn() {
     let fused_f16 = two_conv_bn_branches(Default::default(), DType::F16);

--- a/crates/burn-backend-tests/tests/fusion/fusion_f16_write_vectorization.rs
+++ b/crates/burn-backend-tests/tests/fusion/fusion_f16_write_vectorization.rs
@@ -11,66 +11,92 @@
 //! are added: the BatchNorm inplace running-stats outputs are alias tensors
 //! registered with vector_size=1, while the fused block runs at width=4.
 
-use burn::backend::wgpu::{CubeBackend, WgpuRuntime};
-use burn::module::Initializer;
-use burn::nn::BatchNormConfig;
-use burn::nn::conv::Conv2dConfig;
-use burn::prelude::*;
-use burn_fusion::Fusion;
-
-type Fused = Fusion<CubeBackend<WgpuRuntime, half::f16, i32, u8>>;
-type Unfused = CubeBackend<WgpuRuntime, half::f16, i32, u8>;
+use super::*;
+use burn_tensor::{
+    DType, Device, TensorCreationOptions, TensorData, Tolerance, module::conv2d, ops::ConvOptions,
+};
+use std::sync::{Arc, Mutex};
 
 const CH: usize = 8;
-const INIT: Initializer = Initializer::Constant { value: 0.02 };
+const INIT: f64 = 0.02;
 const EPS: f64 = 1e-5;
 
-/// Runs conv+BN on two parallel branches and adds the results.
-/// Generic over backend so we can compare Fusion vs non-Fusion output.
-fn two_branch_conv_bn_add<B: Backend>(dev: &B::Device) -> Vec<f32> {
-    let conv_a = Conv2dConfig::new([3, CH], [1, 1])
-        .with_bias(false)
-        .with_initializer(INIT)
-        .init::<B>(dev);
-    let bn_a = BatchNormConfig::new(CH).with_epsilon(EPS).init(dev);
-
-    let conv_b = Conv2dConfig::new([3, CH], [1, 1])
-        .with_bias(false)
-        .with_initializer(INIT)
-        .init::<B>(dev);
-    let bn_b: burn::nn::BatchNorm<B> = BatchNormConfig::new(CH).with_epsilon(EPS).init(dev);
-
-    B::sync(dev).unwrap();
-
-    let input: Tensor<B, 4> = Tensor::ones([1, 3, 32, 32], dev) * 0.5;
-    let a = bn_a.forward(conv_a.forward(input.clone()));
-    let b = bn_b.forward(conv_b.forward(input));
-    let out = a + b;
-
-    let data = out.into_data();
-    let vals: &[half::f16] = data.as_slice().unwrap();
-    vals.iter().map(|v| f32::from(*v)).collect()
+struct RunningState {
+    value: Arc<Mutex<TestTensor<1>>>,
 }
 
-/// Two parallel conv+BN branches added together — the Fusion<f16> result must
-/// match the non-fused reference.
-///
-/// This test was failing only on Vulkan+Fusion+f16
+impl RunningState {
+    fn new(value: TestTensor<1>) -> Self {
+        Self {
+            value: Arc::new(Mutex::new(value)),
+        }
+    }
+
+    fn value(&self) -> TestTensor<1> {
+        self.value.lock().unwrap().clone()
+    }
+}
+
+/// Minimal clone of `BatchNorm` w/ `RunningState` for inference only.
+struct BatchNorm {
+    gamma: TestTensor<1>,
+    beta: TestTensor<1>,
+    running_mean: RunningState,
+    running_var: RunningState,
+}
+
+impl BatchNorm {
+    fn new(opts: TensorCreationOptions<TestBackend>) -> Self {
+        Self {
+            gamma: TestTensor::<1>::ones([CH], opts.clone()),
+            beta: TestTensor::<1>::zeros([CH], opts.clone()),
+            running_mean: RunningState::new(TestTensor::<1>::zeros([CH], opts.clone())),
+            running_var: RunningState::new(TestTensor::<1>::ones([CH], opts)),
+        }
+    }
+
+    fn forward(&self, input: TestTensor<4>) -> TestTensor<4> {
+        let device = input.device();
+        let channels = input.dims()[1];
+        let mean = self.running_mean.value().to_device(&device);
+        let var = self.running_var.value().to_device(&device);
+
+        let mean = mean.reshape([1, channels, 1, 1]);
+        let var = var.reshape([1, channels, 1, 1]);
+        let std = (var + EPS).sqrt();
+
+        let x = (input - mean) / std;
+        let x = x * self.gamma.clone().reshape([1, channels, 1, 1]);
+        x + self.beta.clone().reshape([1, channels, 1, 1])
+    }
+}
+
+fn make_conv_weight(opts: TensorCreationOptions<TestBackend>) -> TestTensor<4> {
+    TestTensor::full([CH, 3, 1, 1], INIT, opts)
+}
+
+fn two_branch_conv_bn_add(dev: Device<TestBackend>, dtype: DType) -> TensorData {
+    let opts: TensorCreationOptions<TestBackend> = (&dev, dtype).into();
+    let weight_a = make_conv_weight(opts.clone());
+    let weight_b = make_conv_weight(opts.clone());
+    let bn_a = BatchNorm::new(opts.clone());
+    let bn_b = BatchNorm::new(opts.clone());
+
+    TestBackend::sync(&dev).unwrap();
+
+    let input = TestTensor::<4>::ones([1, 3, 32, 32], opts) * 0.5;
+    let options = ConvOptions::new([1, 1], [0, 0], [1, 1], 1);
+    let a = bn_a.forward(conv2d(input.clone(), weight_a, None, options.clone()));
+    let b = bn_b.forward(conv2d(input, weight_b, None, options));
+    (a + b).into_data()
+}
+
 #[test]
 fn fusion_f16_two_branch_conv_bn_add_matches_reference() {
-    let fused = two_branch_conv_bn_add::<Fused>(&Default::default());
-    let reference = two_branch_conv_bn_add::<Unfused>(&Default::default());
+    let fused_f16 = two_branch_conv_bn_add(Default::default(), DType::F16);
+    let reference_f32 = two_branch_conv_bn_add(Default::default(), DType::F32);
 
-    assert_eq!(fused.len(), reference.len(), "output length mismatch");
-
-    for (i, (f, r)) in fused.iter().zip(reference.iter()).enumerate() {
-        assert!(
-            (f - r).abs() < 1e-3,
-            "mismatch at element {i}: fused={f} reference={r}"
-        );
-        assert!(
-            f.is_finite(),
-            "fused output contains non-finite value at element {i}: {f}"
-        );
-    }
+    fused_f16
+        .convert_dtype(DType::F32)
+        .assert_approx_eq::<FloatElem>(&reference_f32, Tolerance::rel_abs(5e-3, 1e-2));
 }

--- a/crates/burn-backend-tests/tests/fusion/fusion_f16_write_vectorization.rs
+++ b/crates/burn-backend-tests/tests/fusion/fusion_f16_write_vectorization.rs
@@ -13,7 +13,8 @@
 
 use super::*;
 use burn_tensor::{
-    DType, Device, TensorCreationOptions, TensorData, Tolerance, module::conv2d, ops::ConvOptions,
+    DType, Device, TensorCreationOptions, TensorData, Tolerance, backend::Backend, module::conv2d,
+    ops::ConvOptions,
 };
 use std::sync::{Arc, Mutex};
 

--- a/crates/burn-backend-tests/tests/fusion/fusion_f16_write_vectorization.rs
+++ b/crates/burn-backend-tests/tests/fusion/fusion_f16_write_vectorization.rs
@@ -91,6 +91,11 @@ fn two_branch_conv_bn_add(dev: Device<TestBackend>, dtype: DType) -> TensorData 
     (a + b).into_data()
 }
 
+/// Two parallel conv+BN branches added together — the Fusion<f16> result must
+/// match reference.
+///
+/// This test was failing only on Vulkan+Fusion+f16
+/// Reference: https://github.com/tracel-ai/burn/pull/4675
 #[test]
 fn fusion_f16_two_branch_conv_bn_add_matches_reference() {
     let fused_f16 = two_branch_conv_bn_add(Default::default(), DType::F16);

--- a/crates/burn-backend-tests/tests/fusion/fusion_shape.rs
+++ b/crates/burn-backend-tests/tests/fusion/fusion_shape.rs
@@ -12,7 +12,6 @@
 use super::*;
 use burn_fusion::inspect::{BlockKind, FusionInspector, matchers};
 use burn_tensor::backend::Backend;
-use serial_test::serial;
 
 /// `a + b` followed by `exp` should collapse into a single element-wise fused kernel.
 #[test]

--- a/crates/burn-backend-tests/tests/fusion/mod.rs
+++ b/crates/burn-backend-tests/tests/fusion/mod.rs
@@ -1,8 +1,7 @@
 pub use super::*;
 
-// TODO: remove nn usage and re-include
-// mod fusion_f16_broadcast;
-// mod fusion_f16_write_vectorization;
+mod fusion_f16_broadcast;
+mod fusion_f16_write_vectorization;
 mod fusion_shape;
 mod reduce_broadcasted;
 

--- a/crates/burn-backend-tests/tests/memory_cleaning.rs
+++ b/crates/burn-backend-tests/tests/memory_cleaning.rs
@@ -1,15 +1,22 @@
 //! Tests that the fusion backend releases every tensor handle once the corresponding
-//! [`FusionTensor`](burn_fusion::FusionTensor) wrappers are dropped — both for tensors
+//! [`FusionTensor`](burn_fusion::FusionTensor) wrappers are dropped; both for tensors
 //! that live on a single stream and for tensors that are shared across streams.
 //!
+//! # Assertion Strategy
 //! The assertion target is [`FusionInspector::new_handles_since_baseline`], which
 //! returns every [`TensorId`](burn_ir::TensorId) that appeared in the
-//! [`HandleContainer`](burn_ir::HandleContainer) *after* the baseline was set. The
-//! [`HandleContainer`](burn_ir::HandleContainer) is shared per-device across the whole
-//! process, so other tests running in parallel can add unrelated handles. Baselining
-//! lets us diff against that noise and assert only on handles born during our test.
-//! The inspector's install-mutex serializes inspector-based tests so their IDs do not
-//! leak into the baseline window.
+//! [`HandleContainer`](burn_ir::HandleContainer) *after* the baseline was set.
+//!
+//! Because the [`HandleContainer`](burn_ir::HandleContainer) is a global, per-device
+//! registry, these tests call [`FusionInspector::enable_leak_detection`] to acquire
+//! an exclusive lock on the device's handle state. This prevents concurrent tests
+//! from allocating tensors that would otherwise appear as "leaks" in the baseline diff.
+//!
+//! # Threading and Concurrency
+//! While execution reports are stream-isolated, memory handles are not. Therefore:
+//! 1. These tests are isolated in this test binary to avoid false "leaks".
+//! 2. Every test is marked `#[serial]` to ensure they take turns capturing the
+//!    device-wide handle state.
 //!
 //! Cross-stream cases are simulated with [`StreamId::executes`], which swaps the
 //! per-thread stream id for the duration of a closure. This is fast and deterministic;


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Temporarily disabled in #4757 

The tests were initially added by #4675 under `burn-cubecl-fusion` and added `burn` as a dev dependency which prevented cargo publish due to circular dep.

### Changes

Refactored tests to use the `TestBackend` and compare against f32 results (regression was specifically for f16, I validated with a prior revision that didn't include the fix).

### Testing

Unit tests pass