### PR TITLE
rnnt.rs: Optimize `extract_log_probs` and `init_alpha`

### DIFF
--- a/crates/burn-nn/src/loss/rnnt.rs
+++ b/crates/burn-nn/src/loss/rnnt.rs
@@ -123,15 +123,12 @@ impl RNNTLoss {
     ) -> (Tensor<B, 3>, Tensor<B, 3>) {
         let [b, max_t, max_up1, v] = log_probs.dims();
         let max_u = max_up1 - 1;
-        let device = log_probs.device();
         let vocab_dim = 3;
 
-        // Blank probabilities: gather blank index across vocab dim
-        let blank_idx =
-            Tensor::<B, 4, Int>::full([b, max_t, max_up1, 1], self.blank as i64, &device);
+        // Blank probabilities: slice log_probs in vocab dim using the blank index
         let lpb = log_probs
             .clone()
-            .gather(vocab_dim, blank_idx)
+            .slice_dim(vocab_dim, self.blank)
             .squeeze_dim::<3>(vocab_dim);
 
         // Label probabilities: gather target labels across vocab dim (only first U positions)

--- a/crates/burn-nn/src/loss/rnnt.rs
+++ b/crates/burn-nn/src/loss/rnnt.rs
@@ -154,8 +154,8 @@ impl RNNTLoss {
         // Label probs at t=0
         let lpl_0 = lpl.clone().slice(s![.., 0..1, ..]).squeeze_dim::<2>(1);
         let zero_col = Tensor::<B, 2>::zeros([b, 1], device);
-        let prefix = Tensor::cat(vec![zero_col, lpl_0.slice(s![.., 0..max_up1 - 1])], 1);
-        
+        let prefix = Tensor::cat(vec![zero_col, lpl_0.slice(s![.., 0..(max_up1 - 1)])], 1);
+
         prefix.cumsum(1)
     }
 

--- a/crates/burn-nn/src/loss/rnnt.rs
+++ b/crates/burn-nn/src/loss/rnnt.rs
@@ -151,17 +151,12 @@ impl RNNTLoss {
         max_up1: usize,
         device: &B::Device,
     ) -> Tensor<B, 2> {
-        let mut alpha = Tensor::<B, 2>::full([b, max_up1], f32::NEG_INFINITY, device);
-        alpha = alpha.slice_assign(s![.., 0..1], Tensor::zeros([b, 1], device));
-
         // Label probs at t=0
         let lpl_0 = lpl.clone().slice(s![.., 0..1, ..]).squeeze_dim::<2>(1);
-        for u in 1..max_up1 {
-            let prev = alpha.clone().slice(s![.., (u - 1)..u]);
-            let lp = lpl_0.clone().slice(s![.., (u - 1)..u]);
-            alpha = alpha.slice_assign(s![.., u..(u + 1)], prev.add(lp));
-        }
-        alpha
+        let zero_col = Tensor::<B, 2>::zeros([b, 1], device);
+        let prefix = Tensor::cat(vec![zero_col, lpl_0.slice(s![.., 0..max_up1 - 1])], 1);
+        
+        prefix.cumsum(1)
     }
 
     /// Boolean mask `[B, U+1]` that is true where `u <= target_lengths[b]`.


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Closes [rnnt.rs and linalg/lu.rs: small perf cleanups noticed during gather_nd review #4893](https://github.com/tracel-ai/burn/issues/4893) by addressing 1 and 2.

### Changes

- `extract_log_probs`: Replaced `Tensor::full` and `gather` with `slice_dim`. 
- `init_alpha`: Replaced `slice_assign` loop with a single `cumsum`

### Testing

No new tests have been added. All existing tests pass.
