### PR TITLE
Remove optim::optim

### DIFF
--- a/crates/burn-optim/src/lib.rs
+++ b/crates/burn-optim/src/lib.rs
@@ -11,7 +11,7 @@ extern crate derive_new;
 extern crate alloc;
 
 /// Optimizer module.
-pub mod optim;
+mod optim;
 pub use optim::*;
 
 /// Gradient clipping module.


### PR DESCRIPTION
This gets rid of `burn::optim::optim` duplication?