### PR TITLE
Fix some test tolerances

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/float/linalg/lu.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/linalg/lu.rs
@@ -1,6 +1,20 @@
 use super::*;
 use burn_tensor::{Distribution, Tolerance, linalg::lu};
 
+#[cfg(not(feature = "cuda"))]
+const REL: f32 = 5e-3;
+#[cfg(not(feature = "cuda"))]
+const ABS: f32 = 1e-3;
+
+// CUDA may useTensor Core–accelerated matmul with reduced precision accumulation (TF32).
+// In this block LU implementation (matmul-heavy), accumulation error and pivoting
+// differences can amplify into large local elementwise deviations.
+// TODO: for correctness it might be good to allow users to disable some of these configs in burn.toml.
+#[cfg(feature = "cuda")]
+const REL: f32 = 1e-2;
+#[cfg(feature = "cuda")]
+const ABS: f32 = 1.5e-2;
+
 // ---------------------------------------------------------------------
 // Small Matrices
 // ---------------------------------------------------------------------
@@ -11,7 +25,7 @@ fn test_lu_1x1() {
     let tensor = TestTensor::<2>::from_data([[5.0]], &device);
     let (p, l, u) = lu::<TestBackend, 2, 1>(tensor.clone());
     let plu = p.matmul(l).matmul(u);
-    let tolerance = Tolerance::default().set_half_precision_absolute(5e-2);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
     plu.into_data()
         .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
 }
@@ -22,7 +36,7 @@ fn test_lu_2x2() {
     let tensor = TestTensor::<2>::from_data([[4.0, 3.0], [6.0, 3.0]], &device);
     let (p, l, u) = lu::<TestBackend, 2, 1>(tensor.clone());
     let plu = p.matmul(l).matmul(u);
-    let tolerance = Tolerance::default().set_half_precision_absolute(5e-2);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
     plu.into_data()
         .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
 }
@@ -34,7 +48,7 @@ fn test_lu_3x3() {
         TestTensor::<2>::from_data([[4.0, 7.0, 3.0], [6.0, 1.0, 3.0], [8.0, 3.0, 7.0]], &device);
     let (p, l, u) = lu::<TestBackend, 2, 1>(tensor.clone());
     let plu = p.matmul(l).matmul(u);
-    let tolerance = Tolerance::default().set_half_precision_absolute(5e-2);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
     plu.into_data()
         .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
 }
@@ -49,7 +63,7 @@ fn test_lu_identity_matrix() {
     let tensor = TestTensor::<2>::from_data([[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]], &device);
     let (p, l, u) = lu::<TestBackend, 2, 1>(tensor.clone());
     let plu = p.matmul(l).matmul(u);
-    let tolerance = Tolerance::default().set_half_precision_absolute(5e-2);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
     plu.into_data()
         .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
 }
@@ -68,7 +82,7 @@ fn test_lu_singular_zero_pivot() {
     );
     let (p, l, u) = lu::<TestBackend, 2, 1>(tensor.clone());
     let plu = p.matmul(l).matmul(u);
-    let tolerance = Tolerance::default().set_half_precision_absolute(5e-2);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
     plu.into_data()
         .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
 }
@@ -83,7 +97,7 @@ fn test_lu_2d_square() {
     let tensor = TestTensor::<2>::random([6, 6], Distribution::Default, &device);
     let (p, l, u) = lu::<TestBackend, 2, 1>(tensor.clone());
     let plu = p.matmul(l).matmul(u);
-    let tolerance = Tolerance::default().set_half_precision_absolute(5e-2);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
     plu.into_data()
         .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
 }
@@ -94,7 +108,7 @@ fn test_lu_2d_tall() {
     let tensor = TestTensor::<2>::random([8, 5], Distribution::Default, &device);
     let (p, l, u) = lu::<TestBackend, 2, 1>(tensor.clone());
     let plu = p.matmul(l).matmul(u);
-    let tolerance = Tolerance::default().set_half_precision_absolute(5e-2);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
     plu.into_data()
         .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
 }
@@ -105,7 +119,7 @@ fn test_lu_2d_wide() {
     let tensor = TestTensor::<2>::random([5, 8], Distribution::Default, &device);
     let (p, l, u) = lu::<TestBackend, 2, 1>(tensor.clone());
     let plu = p.matmul(l).matmul(u);
-    let tolerance = Tolerance::default().set_half_precision_absolute(5e-2);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
     plu.into_data()
         .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
 }
@@ -116,7 +130,7 @@ fn test_lu_medium_tall() {
     let tensor = TestTensor::<2>::random([256, 128], Distribution::Default, &device);
     let (p, l, u) = lu::<TestBackend, 2, 1>(tensor.clone());
     let plu = p.matmul(l).matmul(u);
-    let tolerance = Tolerance::default().set_half_precision_absolute(5e-2);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
     plu.into_data()
         .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
 }
@@ -127,7 +141,7 @@ fn test_lu_medium_wide() {
     let tensor = TestTensor::<2>::random([128, 256], Distribution::Default, &device);
     let (p, l, u) = lu::<TestBackend, 2, 1>(tensor.clone());
     let plu = p.matmul(l).matmul(u);
-    let tolerance = Tolerance::default().set_half_precision_absolute(5e-2);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
     plu.into_data()
         .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
 }
@@ -142,7 +156,7 @@ fn test_lu_3d_square() {
     let tensor = TestTensor::<3>::random([3, 6, 6], Distribution::Default, &device);
     let (p, l, u) = lu::<TestBackend, 3, 2>(tensor.clone());
     let plu = p.matmul(l).matmul(u);
-    let tolerance = Tolerance::default().set_half_precision_absolute(5e-2);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
     plu.into_data()
         .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
 }
@@ -153,7 +167,7 @@ fn test_lu_3d_tall() {
     let tensor = TestTensor::<3>::random([3, 8, 5], Distribution::Default, &device);
     let (p, l, u) = lu::<TestBackend, 3, 2>(tensor.clone());
     let plu = p.matmul(l).matmul(u);
-    let tolerance = Tolerance::default().set_half_precision_absolute(5e-2);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
     plu.into_data()
         .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
 }
@@ -164,7 +178,7 @@ fn test_lu_3d_wide() {
     let tensor = TestTensor::<3>::random([3, 5, 8], Distribution::Default, &device);
     let (p, l, u) = lu::<TestBackend, 3, 2>(tensor.clone());
     let plu = p.matmul(l).matmul(u);
-    let tolerance = Tolerance::default().set_half_precision_absolute(5e-2);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
     plu.into_data()
         .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
 }
@@ -179,7 +193,7 @@ fn test_lu_4d_square() {
     let tensor = TestTensor::<4>::random([2, 2, 6, 6], Distribution::Default, &device);
     let (p, l, u) = lu::<TestBackend, 4, 3>(tensor.clone());
     let plu = p.matmul(l).matmul(u);
-    let tolerance = Tolerance::default().set_half_precision_absolute(5e-2);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
     plu.into_data()
         .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
 }
@@ -190,7 +204,7 @@ fn test_lu_4d_tall() {
     let tensor = TestTensor::<4>::random([2, 2, 8, 5], Distribution::Default, &device);
     let (p, l, u) = lu::<TestBackend, 4, 3>(tensor.clone());
     let plu = p.matmul(l).matmul(u);
-    let tolerance = Tolerance::default().set_half_precision_absolute(5e-2);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
     plu.into_data()
         .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
 }
@@ -201,7 +215,7 @@ fn test_lu_4d_wide() {
     let tensor = TestTensor::<4>::random([2, 2, 5, 8], Distribution::Default, &device);
     let (p, l, u) = lu::<TestBackend, 4, 3>(tensor.clone());
     let plu = p.matmul(l).matmul(u);
-    let tolerance = Tolerance::default().set_half_precision_absolute(5e-2);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
     plu.into_data()
         .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
 }
@@ -224,7 +238,7 @@ fn test_lu_500x500_block_dispatch() {
     let tensor = TestTensor::<2>::random([500, 500], Distribution::Default, &device);
     let (p, l, u) = lu::<TestBackend, 2, 1>(tensor.clone());
     let plu = p.matmul(l).matmul(u);
-    let tolerance = Tolerance::default().set_half_precision_absolute(1.5e-1);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(1.5e-1);
     plu.into_data()
         .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
 }
@@ -235,7 +249,7 @@ fn test_lu_500x300_block_dispatch() {
     let tensor = TestTensor::<2>::random([500, 300], Distribution::Default, &device);
     let (p, l, u) = lu::<TestBackend, 2, 1>(tensor.clone());
     let plu = p.matmul(l).matmul(u);
-    let tolerance = Tolerance::default().set_half_precision_absolute(1.5e-1);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(1.5e-1);
     plu.into_data()
         .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
 }
@@ -246,7 +260,7 @@ fn test_lu_300x500_block_dispatch() {
     let tensor = TestTensor::<2>::random([300, 500], Distribution::Default, &device);
     let (p, l, u) = lu::<TestBackend, 2, 1>(tensor.clone());
     let plu = p.matmul(l).matmul(u);
-    let tolerance = Tolerance::default().set_half_precision_absolute(1.5e-1);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(1.5e-1);
     plu.into_data()
         .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
 }
@@ -257,7 +271,7 @@ fn test_lu_5x300x300_block_dispatch() {
     let tensor = TestTensor::<3>::random([5, 300, 300], Distribution::Default, &device);
     let (p, l, u) = lu::<TestBackend, 3, 2>(tensor.clone());
     let plu = p.matmul(l).matmul(u);
-    let tolerance = Tolerance::default().set_half_precision_absolute(1.5e-1);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(1.5e-1);
     plu.into_data()
         .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
 }
@@ -268,7 +282,7 @@ fn test_lu_3x300x500_block_dispatch() {
     let tensor = TestTensor::<3>::random([3, 300, 500], Distribution::Default, &device);
     let (p, l, u) = lu::<TestBackend, 3, 2>(tensor.clone());
     let plu = p.matmul(l).matmul(u);
-    let tolerance = Tolerance::default().set_half_precision_absolute(1.5e-1);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(1.5e-1);
     plu.into_data()
         .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
 }
@@ -279,7 +293,7 @@ fn test_lu_3x500x300_block_dispatch() {
     let tensor = TestTensor::<3>::random([3, 500, 300], Distribution::Default, &device);
     let (p, l, u) = lu::<TestBackend, 3, 2>(tensor.clone());
     let plu = p.matmul(l).matmul(u);
-    let tolerance = Tolerance::default().set_half_precision_absolute(1.5e-1);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(1.5e-1);
     plu.into_data()
         .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
 }

--- a/crates/burn-backend-tests/tests/tensor/float/module/attention.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/module/attention.rs
@@ -313,7 +313,7 @@ fn test_attention_softcap_preserves_causal_mask() {
 
     output_row0
         .into_data()
-        .assert_approx_eq::<FloatElem>(&value_row0.into_data(), Tolerance::rel_abs(1e-4, 1e-4));
+        .assert_approx_eq::<FloatElem>(&value_row0.into_data(), Tolerance::rel_abs(1e-4, 1e-3));
 }
 
 /// Regression: fully-masked rows must produce 0, not NaN.


### PR DESCRIPTION
- Fix `linalg::lu` tests tolerances for cuda (accumulation error when using reduced precision accumulation)
- Change `test_attention_softcap_preserves_causal_mask` absolute tolerance from `1e-4` -> `1e-3` (some values were right on the tolerance limit on cuda