### PR TITLE
Change pwff activation to `#[module(skip)]` for backward compat (stateless)

### DIFF
--- a/crates/burn-nn/src/modules/transformer/pwff.rs
+++ b/crates/burn-nn/src/modules/transformer/pwff.rs
@@ -36,6 +36,17 @@ pub struct PositionWiseFeedForwardConfig {
 /// `FFN(x) = max(0, xW1 + b1)W2 + b2`
 ///
 /// Should be created using [PositionWiseFeedForwardConfig]
+///
+/// # Notes
+///
+/// The `activation` field is currently marked `#[module(skip)]` for backward
+/// compatibility with records saved before this field was introduced (when
+/// the activation was always `Gelu` and had no state). This means activation
+/// state is **not persisted** when saving or loading records.
+///
+/// For stateless activations (GELU, ReLU, etc.) this has no effect.
+/// **If you are using `SwiGLU`, its learnable parameters will not be saved or
+/// loaded correctly.**
 #[derive(Module, Debug)]
 #[module(custom_display)]
 pub struct PositionWiseFeedForward<B: Backend> {
@@ -46,6 +57,7 @@ pub struct PositionWiseFeedForward<B: Backend> {
     /// Dropout layer.
     pub dropout: Dropout,
     /// Activation function.
+    #[module(skip)] // for backward compatibility with previous `gelu` field name
     pub activation: Activation<B>,
 }
 


### PR DESCRIPTION
Loading a record (e.g. transformer encoder from text classification example) from previous versions would fail otherwise:

```
thread 'main' (556985) panicked at examples/text-classification/src/training.rs:78:10:
called `Result::unwrap()` on an `Err` value: Unknown("Unable to load record.\nMetadata has a different Burn version: Actual \"0.20.1\", Expected \"0.21.0\"\nError: Unknown(\"missing field `activation`\")")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```


### Change

- Marked `activation` field as `#[module(skip)]` for backward compatibility

This skips loading the `Gelu` record (empty, stateless). All activations except `SwiGlu` are stateless, so this has no effects on previous versions and preserves compatibility for this release.