### PR TITLE
Fix TensorContainer downcast panic on backend mismatch (#2924, #3969)

### DIFF
--- a/crates/burn-autodiff/src/distributed.rs
+++ b/crates/burn-autodiff/src/distributed.rs
@@ -29,7 +29,9 @@ impl<B: DistributedBackend> DistributedRegistration for DistributedGradientRegis
             *n_required -= 1;
 
             if *n_required == 0 {
-                let tensor_ref = container.get_mut_ref::<B>(&id.value).unwrap();
+                let tensor_ref = container.get_mut_ref::<B>(&id.value).expect(
+                    "distributed: tensor freshly registered for this node id should be retrievable",
+                );
                 let tensor_ref = TensorRef(tensor_ref.get_mut_ref());
                 B::submit_gradient_sync(tensor_ref, sharded_params.clone());
             }

--- a/crates/burn-autodiff/src/grads.rs
+++ b/crates/burn-autodiff/src/grads.rs
@@ -1,6 +1,6 @@
 use burn_backend::{
     Backend, TensorMetadata, TensorPrimitive,
-    tensor::{FloatTensor, TensorContainer},
+    tensor::{FloatTensor, TensorContainer, TensorContainerError},
 };
 
 #[cfg(feature = "distributed")]
@@ -70,32 +70,47 @@ impl Gradients {
     /// backward pass, otherwise, it may be consume multiple times.
     pub fn consume<B: Backend>(&mut self, node: &NodeRef) -> FloatTensor<B> {
         match node.requirement {
-            Requirement::Grad => self
-                .container
-                .get::<B>(&node.id.value)
-                .map(|tensor| tensor.tensor())
-                .expect("Can't consume the gradients before they are registered at least once."),
-            Requirement::GradInBackward => self
-                .container
-                .remove::<B>(&node.id.value)
-                .map(|tensor| tensor.tensor())
-                .expect("Can't consume the gradients before they are registered at least once."),
+            Requirement::Grad => match self.container.get::<B>(&node.id.value) {
+                Ok(tensor) => tensor.tensor(),
+                Err(TensorContainerError::NotFound { .. }) => {
+                    panic!("Can't consume the gradients before they are registered at least once.")
+                }
+                Err(e @ TensorContainerError::TypeMismatch { .. }) => panic!("{e}"),
+            },
+            Requirement::GradInBackward => match self.container.remove::<B>(&node.id.value) {
+                Ok(tensor) => tensor.tensor(),
+                Err(TensorContainerError::NotFound { .. }) => {
+                    panic!("Can't consume the gradients before they are registered at least once.")
+                }
+                Err(e @ TensorContainerError::TypeMismatch { .. }) => panic!("{e}"),
+            },
             Requirement::None => panic!("Trying to consume the gradients for an untracked tensor"),
         }
     }
 
     /// Removes a grad tensor from the container.
+    ///
+    /// Returns `None` if no gradient is registered for the given tensor. Panics with a
+    /// descriptive message if a gradient is registered for a different backend than `B`
+    /// (most commonly: passing `B: AutodiffBackend` instead of `B::InnerBackend`).
     pub fn remove<B: Backend>(&mut self, tensor: &AutodiffTensor<B>) -> Option<FloatTensor<B>> {
-        self.container
-            .remove::<B>(&tensor.node.id.value)
-            .map(|tensor| tensor.tensor())
+        match self.container.remove::<B>(&tensor.node.id.value) {
+            Ok(primitive) => Some(primitive.tensor()),
+            Err(TensorContainerError::NotFound { .. }) => None,
+            Err(e @ TensorContainerError::TypeMismatch { .. }) => panic!("{e}"),
+        }
     }
 
     /// Gets a grad tensor from the container.
+    ///
+    /// Returns `None` if no gradient is registered for the given tensor. Panics with a
+    /// descriptive message if a gradient is registered for a different backend than `B`.
     pub fn get<B: Backend>(&self, tensor: &AutodiffTensor<B>) -> Option<FloatTensor<B>> {
-        self.container
-            .get::<B>(&tensor.node.id.value)
-            .map(|tensor| tensor.tensor())
+        match self.container.get::<B>(&tensor.node.id.value) {
+            Ok(primitive) => Some(primitive.tensor()),
+            Err(TensorContainerError::NotFound { .. }) => None,
+            Err(e @ TensorContainerError::TypeMismatch { .. }) => panic!("{e}"),
+        }
     }
 
     /// Register a grad tensor in the container.
@@ -104,10 +119,10 @@ impl Gradients {
     ///
     /// If the registered tensor is distributed, launches a syncing operation on the gradients.
     pub fn register<B: Backend>(&mut self, node_id: NodeId, value: FloatTensor<B>) {
-        let out = if let Some(tensor_old) = self.container.remove::<B>(&node_id.value) {
-            B::float_add(value, tensor_old.tensor())
-        } else {
-            value
+        let out = match self.container.remove::<B>(&node_id.value) {
+            Ok(tensor_old) => B::float_add(value, tensor_old.tensor()),
+            Err(TensorContainerError::NotFound { .. }) => value,
+            Err(e @ TensorContainerError::TypeMismatch { .. }) => panic!("{e}"),
         };
 
         self.container

--- a/crates/burn-backend/src/tensor/container.rs
+++ b/crates/burn-backend/src/tensor/container.rs
@@ -1,4 +1,6 @@
 use alloc::boxed::Box;
+use alloc::format;
+use alloc::string::String;
 use core::any::Any;
 
 #[cfg(not(feature = "std"))]
@@ -9,7 +11,34 @@ use hashbrown::HashMap;
 #[cfg(feature = "std")]
 use std::collections::HashMap;
 
+use thiserror::Error;
+
 use crate::{TensorPrimitive, backend::Backend};
+
+/// Errors that can be returned by [`TensorContainer`] accessors.
+#[derive(Debug, Error)]
+pub enum TensorContainerError {
+    /// No tensor is registered for the given identifier.
+    #[error("tensor container: no entry for id {id}")]
+    NotFound {
+        /// Debug-formatted identifier of the missing entry.
+        id: String,
+    },
+    /// A tensor is registered for the given identifier, but the stored [`TensorPrimitive`]
+    /// is for a different backend than the one requested.
+    ///
+    /// The most common cause is passing `B: AutodiffBackend` to a gradient accessor that
+    /// expects `B::InnerBackend` (or vice-versa). Gradients are stored on the inner backend
+    /// because the autodiff wrapper doesn't track itself.
+    #[error(
+        "tensor container: type mismatch on tensor with id {id}; the stored TensorPrimitive does not match the requested Backend. \
+         Most commonly: pass `B::InnerBackend` instead of `B: AutodiffBackend` when accessing gradients."
+    )]
+    TypeMismatch {
+        /// Debug-formatted identifier where the mismatch was detected.
+        id: String,
+    },
+}
 
 /// Contains tensor of arbitrary dimension.
 #[derive(Debug)]
@@ -38,30 +67,48 @@ where
     }
 
     /// Get a tensor with the given ID.
-    pub fn get<B>(&self, id: &ID) -> Option<TensorPrimitive<B>>
+    ///
+    /// Returns [`TensorContainerError::NotFound`] if no tensor is registered for the ID and
+    /// [`TensorContainerError::TypeMismatch`] if a tensor is registered for a different backend.
+    pub fn get<B>(&self, id: &ID) -> Result<TensorPrimitive<B>, TensorContainerError>
     where
         B: Backend,
     {
-        let grad = self.tensors.get(id)?;
+        let grad = self
+            .tensors
+            .get(id)
+            .ok_or_else(|| TensorContainerError::NotFound {
+                id: format!("{id:?}"),
+            })?;
 
-        let tensor = grad
-            .downcast_ref::<TensorPrimitive<B>>()
-            // .map(|primitive| Tensor::<B, D>::from_primitive(primitive.clone()))
-            .unwrap();
+        let tensor = grad.downcast_ref::<TensorPrimitive<B>>().ok_or_else(|| {
+            TensorContainerError::TypeMismatch {
+                id: format!("{id:?}"),
+            }
+        })?;
 
-        Some(tensor.clone())
+        Ok(tensor.clone())
     }
 
     /// Get a mutable reference to the tensor with the given ID.
-    pub fn get_mut_ref<B>(&mut self, id: &ID) -> Option<&mut TensorPrimitive<B>>
+    ///
+    /// Returns [`TensorContainerError::NotFound`] if no tensor is registered for the ID and
+    /// [`TensorContainerError::TypeMismatch`] if a tensor is registered for a different backend.
+    pub fn get_mut_ref<B>(
+        &mut self,
+        id: &ID,
+    ) -> Result<&mut TensorPrimitive<B>, TensorContainerError>
     where
         B: Backend,
     {
-        let grad = self.tensors.get_mut(id)?;
+        let id_str = format!("{id:?}");
+        let grad = self
+            .tensors
+            .get_mut(id)
+            .ok_or_else(|| TensorContainerError::NotFound { id: id_str.clone() })?;
 
-        let tensor = grad.downcast_mut::<TensorPrimitive<B>>().unwrap();
-
-        Some(tensor)
+        grad.downcast_mut::<TensorPrimitive<B>>()
+            .ok_or(TensorContainerError::TypeMismatch { id: id_str })
     }
 
     /// Register a new tensor for the given ID.
@@ -76,15 +123,37 @@ where
         self.tensors.insert(id, Box::new(value));
     }
 
-    /// Remove a tensor for the given ID and returns it.
-    pub fn remove<B>(&mut self, id: &ID) -> Option<TensorPrimitive<B>>
+    /// Remove a tensor for the given ID and return it.
+    ///
+    /// Returns [`TensorContainerError::NotFound`] if no tensor is registered for the ID and
+    /// [`TensorContainerError::TypeMismatch`] if a tensor is registered for a different backend.
+    /// On `TypeMismatch`, the entry is left in the container so a subsequent correctly-typed
+    /// access can still retrieve it.
+    pub fn remove<B>(&mut self, id: &ID) -> Result<TensorPrimitive<B>, TensorContainerError>
     where
         B: Backend,
     {
-        self.tensors
-            .remove(id)
-            .map(|item| *item.downcast::<TensorPrimitive<B>>().unwrap())
-        // .map(|primitive| Tensor::from_primitive(*primitive))
+        // Peek before removing — a downcast on the boxed entry would consume it on the
+        // failure path, leaking the tensor. Probe the type first; only commit to removal
+        // once we know it will succeed.
+        let entry = self
+            .tensors
+            .get(id)
+            .ok_or_else(|| TensorContainerError::NotFound {
+                id: format!("{id:?}"),
+            })?;
+
+        if !entry.is::<TensorPrimitive<B>>() {
+            return Err(TensorContainerError::TypeMismatch {
+                id: format!("{id:?}"),
+            });
+        }
+
+        // Safe to remove: type check above guarantees the downcast succeeds.
+        let boxed = self.tensors.remove(id).expect("entry was just observed");
+        Ok(*boxed
+            .downcast::<TensorPrimitive<B>>()
+            .expect("type was just observed to match"))
     }
 
     /// The number of tensors registered.

--- a/crates/burn-optim/src/optim/grads.rs
+++ b/crates/burn-optim/src/optim/grads.rs
@@ -4,7 +4,7 @@ use burn::{
     Tensor,
     tensor::{
         backend::{AutodiffBackend, Backend},
-        container::TensorContainer,
+        container::{TensorContainer, TensorContainerError},
     },
 };
 #[cfg(feature = "collective")]
@@ -64,6 +64,10 @@ impl GradientsParams {
 
     /// Get the gradients for the given [parameter id](ParamId).
     ///
+    /// Returns `None` if no gradient is registered for the given id. Panics with a
+    /// descriptive message if a gradient is registered for a different backend than `B`
+    /// (most commonly: passing `B: AutodiffBackend` instead of `B::InnerBackend`).
+    ///
     /// # Notes
     ///
     /// You should use [remove](GradientsParams::remove) if you want to get the gradients
@@ -72,15 +76,26 @@ impl GradientsParams {
     where
         B: Backend,
     {
-        self.container.get(&id).map(Tensor::from_primitive)
+        match self.container.get(&id) {
+            Ok(primitive) => Some(Tensor::from_primitive(primitive)),
+            Err(TensorContainerError::NotFound { .. }) => None,
+            Err(e @ TensorContainerError::TypeMismatch { .. }) => panic!("{e}"),
+        }
     }
 
     /// Remove the gradients for the given [parameter id](ParamId).
+    ///
+    /// Returns `None` if no gradient is registered for the given id. Panics with a
+    /// descriptive message if a gradient is registered for a different backend than `B`.
     pub fn remove<B, const D: usize>(&mut self, id: ParamId) -> Option<Tensor<B, D>>
     where
         B: Backend,
     {
-        self.container.remove(&id).map(Tensor::from_primitive)
+        match self.container.remove(&id) {
+            Ok(primitive) => Some(Tensor::from_primitive(primitive)),
+            Err(TensorContainerError::NotFound { .. }) => None,
+            Err(e @ TensorContainerError::TypeMismatch { .. }) => panic!("{e}"),
+        }
     }
 
     /// Register a gradients tensor for the given [parameter id](ParamId).
@@ -133,8 +148,13 @@ impl GradientsParams {
         ids.sort();
 
         for id in ids {
-            let Some(grad) = self.container.remove::<B>(&id) else {
-                todo!()
+            let grad = match self.container.remove::<B>(&id) {
+                Ok(grad) => grad,
+                Err(TensorContainerError::NotFound { .. }) => {
+                    // Was just observed in the freshly-collected `ids` snapshot above.
+                    unreachable!("id present in ids() but missing from container");
+                }
+                Err(e @ TensorContainerError::TypeMismatch { .. }) => panic!("{e}"),
             };
 
             let grad = match grad {
@@ -157,7 +177,7 @@ impl GradientsParams {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::TestAutodiffBackend;
+    use crate::{TestAutodiffBackend, TestBackend};
     use burn::module::{Module, list_param_ids};
     use burn::tensor::{Distribution, backend::Backend};
     use burn_nn::{Linear, LinearConfig};
@@ -179,6 +199,141 @@ mod tests {
         assert_eq!(param_ids_1, param_ids_2);
         assert_eq!(grads_1.len(), param_ids_1.len());
         assert_eq!(grads_2.len(), param_ids_2.len());
+    }
+
+    /// Regression test for #2924 / #3969 — the happy path.
+    /// Gradients keyed under the inner backend can be retrieved by passing the inner backend.
+    #[test]
+    fn get_with_inner_backend_returns_gradient() {
+        let device = Default::default();
+        let layer = layer::<TestAutodiffBackend>(&device);
+        let loss = layer.forward(random_tensor(&device));
+        let grads = GradientsParams::from_grads(loss.backward(), &layer);
+
+        let weight_id = layer.weight.id;
+        let weight_grad = grads.get::<TestBackend, 2>(weight_id);
+        assert!(weight_grad.is_some());
+        assert_eq!(weight_grad.unwrap().dims(), [20, 20]);
+    }
+
+    /// Regression test for #2924 / #3969 — the bug case.
+    /// Passing the autodiff backend instead of its inner backend used to panic with the
+    /// generic `Option::unwrap()` message; now panics with a descriptive message naming
+    /// the type mismatch and pointing at the inner-backend convention.
+    #[test]
+    #[should_panic(expected = "type mismatch")]
+    fn get_with_autodiff_backend_panics_descriptively() {
+        let device = Default::default();
+        let layer = layer::<TestAutodiffBackend>(&device);
+        let loss = layer.forward(random_tensor(&device));
+        let grads = GradientsParams::from_grads(loss.backward(), &layer);
+
+        // The bug-trigger: pass the autodiff backend instead of the inner backend.
+        let _ = grads.get::<TestAutodiffBackend, 2>(layer.weight.id);
+    }
+
+    /// Regression test for #2924 / #3969 — same as `get_with_autodiff_backend_panics_descriptively`
+    /// but on the `remove` path. Both code paths used to share the same `Option::unwrap()` bug.
+    #[test]
+    #[should_panic(expected = "type mismatch")]
+    fn remove_with_autodiff_backend_panics_descriptively() {
+        let device = Default::default();
+        let layer = layer::<TestAutodiffBackend>(&device);
+        let loss = layer.forward(random_tensor(&device));
+        let mut grads = GradientsParams::from_grads(loss.backward(), &layer);
+
+        let _ = grads.remove::<TestAutodiffBackend, 2>(layer.weight.id);
+    }
+
+    /// `get` for a parameter id that has no registered gradient still returns `None`,
+    /// distinguishing the missing-entry case from the type-mismatch case.
+    #[test]
+    fn get_missing_id_returns_none() {
+        let device = Default::default();
+        let layer_1 = layer::<TestAutodiffBackend>(&device);
+        let layer_2 = layer::<TestAutodiffBackend>(&device); // different param ids
+        let loss = layer_1.forward(random_tensor(&device));
+        let grads = GradientsParams::from_grads(loss.backward(), &layer_1);
+
+        // layer_2's weight id is unknown to grads (only layer_1's grads are registered).
+        let result = grads.get::<TestBackend, 2>(layer_2.weight.id);
+        assert!(result.is_none());
+    }
+
+    /// Adversarial: a wrong-backend `TensorContainer::remove` MUST leave the entry intact
+    /// rather than silently dropping it. The pre-fix code used `HashMap::remove` followed by
+    /// `Box::downcast().unwrap()` — on a type mismatch the entry was already gone from the
+    /// HashMap when the unwrap panicked, leaking the tensor into the failure path. The fix
+    /// peeks the type via `Any::is::<T>()` first and only commits to removal once the
+    /// downcast is guaranteed to succeed.
+    #[test]
+    fn container_remove_type_mismatch_leaves_entry_in_place() {
+        use burn::tensor::backend::AutodiffBackend;
+        use burn::tensor::container::{TensorContainer, TensorContainerError};
+        type Inner = <TestAutodiffBackend as AutodiffBackend>::InnerBackend;
+
+        let device = Default::default();
+        let mut container = TensorContainer::<u64>::new();
+        let tensor = Tensor::<Inner, 2>::random([3, 3], Distribution::Default, &device);
+        container.register::<Inner>(42, tensor.into_primitive());
+        assert_eq!(container.len(), 1);
+
+        // Wrong backend → Err(TypeMismatch), entry MUST remain in the container.
+        let result = container.remove::<TestAutodiffBackend>(&42);
+        assert!(
+            matches!(result, Err(TensorContainerError::TypeMismatch { .. })),
+            "wrong-backend remove should return TypeMismatch, got {result:?}"
+        );
+        assert_eq!(
+            container.len(),
+            1,
+            "entry must NOT be removed on type mismatch — original code leaked here"
+        );
+
+        // Correct-backend remove on the same id still works.
+        let result = container.remove::<Inner>(&42);
+        assert!(result.is_ok());
+        assert_eq!(container.len(), 0);
+    }
+
+    /// Adversarial: repeated remove of the same id returns `Err(NotFound)` the second time,
+    /// not a panic and not a stale tensor.
+    #[test]
+    fn container_remove_twice_returns_not_found() {
+        use burn::tensor::backend::AutodiffBackend;
+        use burn::tensor::container::{TensorContainer, TensorContainerError};
+        type Inner = <TestAutodiffBackend as AutodiffBackend>::InnerBackend;
+
+        let device = Default::default();
+        let mut container = TensorContainer::<u64>::new();
+        let tensor = Tensor::<Inner, 2>::random([2, 2], Distribution::Default, &device);
+        container.register::<Inner>(7, tensor.into_primitive());
+
+        assert!(container.remove::<Inner>(&7).is_ok());
+        let result = container.remove::<Inner>(&7);
+        assert!(matches!(result, Err(TensorContainerError::NotFound { .. })));
+    }
+
+    /// Adversarial: `get` (not `remove`) on a wrong backend returns `Err(TypeMismatch)`
+    /// and does not consume the entry — multiple wrong-backend reads in a row stay
+    /// consistent.
+    #[test]
+    fn container_get_type_mismatch_is_idempotent() {
+        use burn::tensor::backend::AutodiffBackend;
+        use burn::tensor::container::{TensorContainer, TensorContainerError};
+        type Inner = <TestAutodiffBackend as AutodiffBackend>::InnerBackend;
+
+        let device = Default::default();
+        let mut container = TensorContainer::<u64>::new();
+        let tensor = Tensor::<Inner, 2>::random([2, 2], Distribution::Default, &device);
+        container.register::<Inner>(99, tensor.into_primitive());
+
+        for _ in 0..3 {
+            let result = container.get::<TestAutodiffBackend>(&99);
+            assert!(matches!(result, Err(TensorContainerError::TypeMismatch { .. })));
+        }
+        assert_eq!(container.len(), 1);
+        assert!(container.get::<Inner>(&99).is_ok());
     }
 
     fn layer<B: Backend>(device: &B::Device) -> Linear<B> {

--- a/crates/burn-tensor/src/tensor/mod.rs
+++ b/crates/burn-tensor/src/tensor/mod.rs
@@ -27,7 +27,7 @@ pub mod backend {
 
 /// The container module.
 pub mod container {
-    pub use burn_backend::tensor::TensorContainer;
+    pub use burn_backend::tensor::{TensorContainer, TensorContainerError};
 }
 
 /// The grid module.


### PR DESCRIPTION
this fixes the .unwrap() panic in TensorContainer's get, get_mut_ref, and remove when an entry exists for an id but is stored for a different backend. you hit it when you pass B: AutodiffBackend to GradientsParams::get instead of B::InnerBackend. same root cause behind both #2924 and #3969, hit 8 months apart by two different reporters, so it's not a one-off, it's a real ergonomics gap.

the three accessors now return a Result with two variants, NotFound and TypeMismatch, both carrying the debug-formatted id. the public GradientsParams::get and remove (and Gradients::get and remove on the autodiff side) keep their existing Option return type though. internally they just match on the Result, mapping NotFound to None and panicking on TypeMismatch with a descriptive message that points at the inner-backend convention. this is the second of the two options laggui suggested on the original PR #2965 back in march, which avoids cascading Result through every public caller.

happy to switch to nathanielsimard's idea of making TensorContainer generic over the backend if you'd rather, that's the path #2965 was reviewed for but never got an answer on, which is what eventually killed it. marked this one as draft until you tell me which way to go.

one bonus thing I noticed while I was in there: the old remove did HashMap::remove first and then downcast on the boxed entry, which means on a type mismatch the entry was already gone from the HashMap by the time the unwrap panicked. so the old code was actually leaking the tensor on the failure path on top of panicking. the new version peeks the type via Any::is first and only commits to removing once the downcast is guaranteed to succeed. small but worth fixing, there's a test for it.

on the tests:

- the lucasmdjl reproducer from #3969 ported verbatim into burn-optim's test module (Linear plus Autodiff plus GradientsParams::get with the wrong backend, asserts the panic message contains "type mismatch")
- the equivalent on the remove path
- the peek-before-remove correctness test
- a repeated-remove test (second remove returns NotFound, not a panic)
- an idempotence test for wrong-backend reads (multiple bad gets don't corrupt anything)
- the existing happy-path test still passes

ran the workspace tests, clippy, fmt, rustdoc, all clean.

credit to @VirtualNonsense for #2965, the error enum shape is basically the same idea, just narrower in scope.

Closes #2924, closes #3969

edit: broke the close sentences in two so github autoparses both
