### PR TITLE
autodiff for rfft/irfft

### DIFF
--- a/crates/burn-autodiff/src/ops/module.rs
+++ b/crates/burn-autodiff/src/ops/module.rs
@@ -1,3 +1,5 @@
+use alloc::{vec, vec::Vec};
+
 use crate::Autodiff;
 use crate::checkpoint::base::Checkpointer;
 use crate::checkpoint::strategy::CheckpointStrategy;
@@ -7,9 +9,11 @@ use crate::ops::{Backward, Ops, unary};
 use crate::tensor::AutodiffTensor;
 
 use burn_backend::Backend;
+use burn_backend::TensorMetadata;
 use burn_backend::ops::attention::attention_fallback;
 use burn_backend::ops::*;
 use burn_backend::tensor::{FloatTensor, IntTensor};
+use burn_std::Slice;
 
 use super::OpsKind;
 
@@ -1973,21 +1977,153 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
     }
 
     fn rfft(
-        _signal: FloatTensor<Autodiff<B, C>>,
-        _dim: usize,
-        _n: Option<usize>,
+        signal: FloatTensor<Autodiff<B, C>>,
+        dim: usize,
+        n: Option<usize>,
     ) -> (FloatTensor<Autodiff<B, C>>, FloatTensor<Autodiff<B, C>>) {
-        todo!("rfft not yet supported for autodiff")
+        #[derive(Debug)]
+        struct Rfft;
+
+        impl<B: Backend> Backward<B, 1> for Rfft {
+            type State = (usize, Option<usize>, usize, Vec<Slice>, Vec<Slice>);
+
+            fn backward(
+                self,
+                ops: Ops<Self::State, 1>,
+                grads: &mut Gradients,
+                _checkpointer: &mut Checkpointer,
+            ) {
+                unary::<B, _>(ops.parents, ops.node, grads, |grad| {
+                    let (dim, n, n_fft, slices_re, slices_im) = ops.state;
+
+                    let grad_re = B::float_slice(grad.clone(), &slices_re);
+                    let grad_im = B::float_slice(grad.clone(), &slices_im);
+
+                    let grad_re = mul_interior::<B>(grad_re, dim, n_fft, 0.5);
+                    let grad_im = mul_interior::<B>(grad_im, dim, n_fft, 0.5);
+
+                    let grad = B::irfft(grad_re, grad_im, dim, n);
+
+                    B::float_mul_scalar(grad, (n_fft as f64).into())
+                });
+            }
+        }
+
+        let n_fft = n.unwrap_or(signal.shape()[dim]);
+        let (re, im) = B::rfft(signal.primitive, dim, n);
+
+        // In order to perform only a single irfft in the backward pass, we have to temporarily
+        // bundle `re` and `im` into a single tensor. The following slice vecs are used to split
+        // them back up in both the forward and the backward pass.
+        let slices_re = re
+            .shape()
+            .iter()
+            .map(|&len| Slice::from(0..len))
+            .collect::<Vec<Slice>>();
+        let slices_im = {
+            let mut slices = slices_re.clone();
+            let len = slices[0].end.unwrap();
+            slices[0].start = len;
+            slices[0].end = Some(2 * len);
+            slices
+        };
+        let spectrum = B::float_cat(vec![re, im], 0);
+        let state = (dim, n, n_fft, slices_re.clone(), slices_im.clone());
+
+        let spectrum = match Rfft
+            .prepare::<C>([signal.node.clone()])
+            .compute_bound()
+            .stateful()
+        {
+            OpsKind::Tracked(prep) => prep.finish(state, spectrum),
+            OpsKind::UnTracked(prep) => prep.finish(spectrum),
+        };
+
+        let re = Self::float_slice(spectrum.clone(), &slices_re);
+        let im = Self::float_slice(spectrum.clone(), &slices_im);
+
+        (re, im)
     }
 
     fn irfft(
-        _spectrum_re: FloatTensor<Autodiff<B, C>>,
-        _spectrum_im: FloatTensor<Autodiff<B, C>>,
-        _dim: usize,
-        _n: Option<usize>,
+        spectrum_re: FloatTensor<Autodiff<B, C>>,
+        spectrum_im: FloatTensor<Autodiff<B, C>>,
+        dim: usize,
+        n: Option<usize>,
     ) -> FloatTensor<Autodiff<B, C>> {
-        todo!("irfft not yet supported for autodiff")
+        #[derive(Debug)]
+        struct Irfft;
+
+        impl<B: Backend> Backward<B, 2> for Irfft {
+            type State = (usize, Option<usize>, usize);
+
+            fn backward(
+                self,
+                ops: Ops<Self::State, 2>,
+                grads: &mut Gradients,
+                _checkpointer: &mut Checkpointer,
+            ) {
+                let (dim, n, n_fft) = ops.state;
+                let [node_re, node_im] = ops.parents;
+                let grad = grads.consume::<B>(&ops.node);
+
+                let grad = B::float_div_scalar(grad, (n_fft as f64).into());
+
+                let (grad_re, grad_im) = B::rfft(grad, dim, n);
+
+                let grad_re = mul_interior::<B>(grad_re, dim, n_fft, 2.0);
+                let grad_im = mul_interior::<B>(grad_im, dim, n_fft, 2.0);
+
+                if let Some(node) = node_re {
+                    grads.register::<B>(node.id, grad_re);
+                }
+                if let Some(node) = node_im {
+                    grads.register::<B>(node.id, grad_im);
+                }
+            }
+        }
+
+        let signal = B::irfft(spectrum_re.primitive, spectrum_im.primitive, dim, n);
+        let n_fft = n.unwrap_or(signal.shape()[dim]);
+        let state = (dim, n, n_fft);
+
+        match Irfft
+            .prepare::<C>([spectrum_re.node.clone(), spectrum_im.node.clone()])
+            .compute_bound()
+            .stateful()
+        {
+            OpsKind::Tracked(prep) => prep.finish(state, signal),
+            OpsKind::UnTracked(prep) => prep.finish(signal),
+        }
     }
+}
+
+fn mul_interior<B: Backend>(
+    bins: FloatTensor<B>,
+    dim: usize,
+    n_fft: usize,
+    factor: f64,
+) -> FloatTensor<B> {
+    // identify the interior bins (all bins except DC and Nyquist)
+    let slices_interior: Vec<Slice> = {
+        let mut ranges = bins.shape().into_ranges();
+
+        // skip the DC bin
+        ranges[dim].start += 1;
+
+        // if `n_fft` is even, we have a Nyquist bin to skip
+        if n_fft.is_multiple_of(2) {
+            ranges[dim].end -= 1;
+        }
+
+        ranges.into_iter().map(Slice::from).collect()
+    };
+
+    // multiply only the interior bins by `factor`
+    let interior = B::float_slice(bins.clone(), &slices_interior);
+    let interior = B::float_mul_scalar(interior, factor.into());
+
+    B::float_slice_assign(bins, &slices_interior, interior)
 }
 
 #[derive(Debug)]

--- a/crates/burn-autodiff/src/ops/module.rs
+++ b/crates/burn-autodiff/src/ops/module.rs
@@ -1985,7 +1985,7 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
         struct Rfft;
 
         impl<B: Backend> Backward<B, 1> for Rfft {
-            type State = (usize, Option<usize>, usize, Vec<Slice>, Vec<Slice>);
+            type State = (usize, Option<usize>, usize, usize, Vec<Slice>, Vec<Slice>);
 
             fn backward(
                 self,
@@ -1994,7 +1994,7 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                 _checkpointer: &mut Checkpointer,
             ) {
                 unary::<B, _>(ops.parents, ops.node, grads, |grad| {
-                    let (dim, n, n_fft, slices_re, slices_im) = ops.state;
+                    let (dim, n, input_len, n_fft, slices_re, slices_im) = ops.state;
 
                     let grad_re = B::float_slice(grad.clone(), &slices_re);
                     let grad_im = B::float_slice(grad.clone(), &slices_im);
@@ -2003,13 +2003,15 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                     let grad_im = mul_interior::<B>(grad_im, dim, n_fft, 0.5);
 
                     let grad = B::irfft(grad_re, grad_im, dim, n);
-
-                    B::float_mul_scalar(grad, (n_fft as f64).into())
+                    let grad = B::float_mul_scalar(grad, (n_fft as f64).into());
+                    
+                    pad_to_length::<B>(grad, dim, input_len)
                 });
             }
         }
 
-        let n_fft = n.unwrap_or(signal.shape()[dim]);
+        let input_len = signal.shape()[dim];
+        let n_fft = n.unwrap_or(input_len);
         let (re, im) = B::rfft(signal.primitive, dim, n);
 
         // In order to perform only a single irfft in the backward pass, we have to temporarily
@@ -2028,7 +2030,7 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
             slices
         };
         let spectrum = B::float_cat(vec![re, im], 0);
-        let state = (dim, n, n_fft, slices_re.clone(), slices_im.clone());
+        let state = (dim, n, input_len, n_fft, slices_re.clone(), slices_im.clone());
 
         let spectrum = match Rfft
             .prepare::<C>([signal.node.clone()])
@@ -2055,7 +2057,7 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
         struct Irfft;
 
         impl<B: Backend> Backward<B, 2> for Irfft {
-            type State = (usize, Option<usize>, usize);
+            type State = (usize, Option<usize>, usize, usize);
 
             fn backward(
                 self,
@@ -2063,7 +2065,7 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                 grads: &mut Gradients,
                 _checkpointer: &mut Checkpointer,
             ) {
-                let (dim, n, n_fft) = ops.state;
+                let (dim, n, input_len, n_fft) = ops.state;
                 let [node_re, node_im] = ops.parents;
                 let grad = grads.consume::<B>(&ops.node);
 
@@ -2073,6 +2075,9 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
 
                 let grad_re = mul_interior::<B>(grad_re, dim, n_fft, 2.0);
                 let grad_im = mul_interior::<B>(grad_im, dim, n_fft, 2.0);
+                
+                let grad_re = pad_to_length::<B>(grad_re, dim, input_len);
+                let grad_im = pad_to_length::<B>(grad_im, dim, input_len);
 
                 if let Some(node) = node_re {
                     grads.register::<B>(node.id, grad_re);
@@ -2083,9 +2088,10 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
             }
         }
 
+        let input_len = spectrum_re.shape()[dim];
         let signal = B::irfft(spectrum_re.primitive, spectrum_im.primitive, dim, n);
         let n_fft = n.unwrap_or(signal.shape()[dim]);
-        let state = (dim, n, n_fft);
+        let state = (dim, n, input_len, n_fft);
 
         match Irfft
             .prepare::<C>([spectrum_re.node.clone(), spectrum_im.node.clone()])
@@ -2096,6 +2102,32 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
             OpsKind::UnTracked(prep) => prep.finish(signal),
         }
     }
+}
+
+// adapted from: burn_cubecl::kernel::fft::pad_to_length
+fn pad_to_length<B: Backend>(
+    tensor: FloatTensor<B>,
+    dim: usize,
+    target: usize,
+) -> FloatTensor<B> {
+    let shape = tensor.shape();
+    let current = shape[dim];
+    if current == target {
+        return tensor;
+    }
+    if current > target {
+        let slices: Vec<_> = shape
+            .iter()
+            .enumerate()
+            .map(|(i, &s)| Slice::from(if i == dim { 0..target } else { 0..s }))
+            .collect();
+        return B::float_slice(tensor, &slices);
+    }
+    let mut padded_shape = shape.clone();
+    padded_shape[dim] = target;
+    let padded = B::float_zeros(padded_shape, &B::float_device(&tensor), tensor.dtype().into());
+    let slices: Vec<Slice> = shape.iter().map(|&s| Slice::from(0..s)).collect();
+    B::float_slice_assign(padded, &slices, tensor)
 }
 
 fn mul_interior<B: Backend>(

--- a/crates/burn-autodiff/src/ops/module.rs
+++ b/crates/burn-autodiff/src/ops/module.rs
@@ -2004,7 +2004,7 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
 
                     let grad = B::irfft(grad_re, grad_im, dim, n);
                     let grad = B::float_mul_scalar(grad, (n_fft as f64).into());
-                    
+
                     pad_to_length::<B>(grad, dim, input_len)
                 });
             }
@@ -2030,7 +2030,14 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
             slices
         };
         let spectrum = B::float_cat(vec![re, im], 0);
-        let state = (dim, n, input_len, n_fft, slices_re.clone(), slices_im.clone());
+        let state = (
+            dim,
+            n,
+            input_len,
+            n_fft,
+            slices_re.clone(),
+            slices_im.clone(),
+        );
 
         let spectrum = match Rfft
             .prepare::<C>([signal.node.clone()])
@@ -2075,7 +2082,7 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
 
                 let grad_re = mul_interior::<B>(grad_re, dim, n_fft, 2.0);
                 let grad_im = mul_interior::<B>(grad_im, dim, n_fft, 2.0);
-                
+
                 let grad_re = pad_to_length::<B>(grad_re, dim, input_len);
                 let grad_im = pad_to_length::<B>(grad_im, dim, input_len);
 
@@ -2104,12 +2111,8 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
     }
 }
 
-// adapted from: burn_cubecl::kernel::fft::pad_to_length
-fn pad_to_length<B: Backend>(
-    tensor: FloatTensor<B>,
-    dim: usize,
-    target: usize,
-) -> FloatTensor<B> {
+// adapted from: burn_cubecl::kernel::fft::base::pad_to_length
+fn pad_to_length<B: Backend>(tensor: FloatTensor<B>, dim: usize, target: usize) -> FloatTensor<B> {
     let shape = tensor.shape();
     let current = shape[dim];
     if current == target {
@@ -2125,7 +2128,11 @@ fn pad_to_length<B: Backend>(
     }
     let mut padded_shape = shape.clone();
     padded_shape[dim] = target;
-    let padded = B::float_zeros(padded_shape, &B::float_device(&tensor), tensor.dtype().into());
+    let padded = B::float_zeros(
+        padded_shape,
+        &B::float_device(&tensor),
+        tensor.dtype().into(),
+    );
     let slices: Vec<Slice> = shape.iter().map(|&s| Slice::from(0..s)).collect();
     B::float_slice_assign(padded, &slices, tensor)
 }

--- a/crates/burn-backend-tests/tests/autodiff/mod.rs
+++ b/crates/burn-backend-tests/tests/autodiff/mod.rs
@@ -63,6 +63,7 @@ mod relu;
 mod remainder;
 mod repeat_dim;
 mod reshape;
+mod rfft;
 mod round;
 mod select;
 mod sigmoid;

--- a/crates/burn-backend-tests/tests/autodiff/rfft.rs
+++ b/crates/burn-backend-tests/tests/autodiff/rfft.rs
@@ -1,0 +1,52 @@
+use super::*;
+use burn_tensor::TensorData;
+use burn_tensor::Tolerance;
+use burn_tensor::signal;
+
+#[test]
+#[ignore = "rfft is not supported for ndarray"]
+fn should_diff_rfft() {
+    let device = AutodiffDevice::new();
+
+    let random1 = TensorData::from([0.26, 0.13, 0.36, 0.24, 0.40, 0.93, 0.12, 0.18]);
+    let random2 = TensorData::from([0.03, 0.74, 0.33, 0.70, 0.07, 0.61, 0.32, 0.66]);
+
+    let x = TestTensor::<1>::from_data(random1, &device).require_grad();
+    let y = TestTensor::<1>::from_data(random2, &device);
+
+    let (x_re, x_im) = signal::rfft(x.clone(), 0, None);
+    let (y_re, y_im) = signal::rfft(y.clone(), 0, None);
+
+    let loss = (x_re * y_re + x_im * y_im).sum();
+    let grads = loss.backward();
+    let x_grad = x.grad(&grads).unwrap();
+    let prod = x_grad.mul(x.inner()).sum();
+
+    TensorData::assert_approx_eq::<FloatElem>(
+        &prod.to_data(),
+        &loss.to_data(),
+        Tolerance::default(),
+    );
+}
+
+#[test]
+#[ignore = "rfft is not supported for ndarray"]
+fn round_trip() {
+    let device = AutodiffDevice::new();
+
+    let random = TensorData::from([
+        0.26, 0.13, 0.36, 0.24, 0.40, 0.93, 0.12, 0.18, 0.03, 0.74, 0.33, 0.70, 0.07, 0.61, 0.32,
+        0.66,
+    ]);
+
+    let tensor = TestTensor::<1>::from_data(random.clone(), &device).require_grad();
+
+    let y = signal::rfft(tensor.clone() * 3.0, 0, None);
+    let x = signal::irfft(y.0 * 2.0, y.1 * 2.0, 0, None) / 6.0;
+
+    let loss = x.powi_scalar(2).sum() * 0.5;
+    let grads = loss.backward();
+    let grad = tensor.grad(&grads).unwrap();
+
+    TensorData::assert_approx_eq::<FloatElem>(&grad.to_data(), &random, Tolerance::default());
+}

--- a/crates/burn-backend-tests/tests/autodiff/rfft.rs
+++ b/crates/burn-backend-tests/tests/autodiff/rfft.rs
@@ -3,9 +3,17 @@ use burn_tensor::TensorData;
 use burn_tensor::Tolerance;
 use burn_tensor::signal;
 
+#[cfg(not(feature = "ndarray"))]
+use burn_tensor::{DType, Element};
+
 #[test]
-#[cfg(not(any(feature = "ndarray", feature = "candle")))]
+#[cfg(not(feature = "ndarray"))]
 fn should_diff_rfft() {
+    // Lower precisions not supported
+    if !matches!(FloatElem::dtype(), DType::F32 | DType::F64) {
+        return;
+    }
+
     let device = AutodiffDevice::new();
 
     let random1 = TensorData::from([0.26, 0.13, 0.36, 0.24, 0.40, 0.93, 0.12, 0.18]);
@@ -30,8 +38,12 @@ fn should_diff_rfft() {
 }
 
 #[test]
-#[cfg(not(any(feature = "ndarray", feature = "candle")))]
+#[cfg(not(feature = "ndarray"))]
 fn round_trip() {
+    if !matches!(FloatElem::dtype(), DType::F32 | DType::F64) {
+        return;
+    }
+
     let device = AutodiffDevice::new();
 
     let random = TensorData::from([
@@ -52,8 +64,12 @@ fn round_trip() {
 }
 
 #[test]
-#[cfg(not(any(feature = "ndarray", feature = "candle")))]
+#[cfg(not(feature = "ndarray"))]
 fn round_trip_with_dim_nonzero() {
+    if !matches!(FloatElem::dtype(), DType::F32 | DType::F64) {
+        return;
+    }
+
     let device = AutodiffDevice::new();
 
     let random = TensorData::from([
@@ -76,8 +92,12 @@ fn round_trip_with_dim_nonzero() {
 }
 
 #[test]
-#[cfg(not(any(feature = "ndarray", feature = "candle")))]
+#[cfg(not(feature = "ndarray"))]
 fn round_trip_with_some_n_greater() {
+    if !matches!(FloatElem::dtype(), DType::F32 | DType::F64) {
+        return;
+    }
+
     let device = AutodiffDevice::new();
 
     let random = TensorData::from([
@@ -98,8 +118,12 @@ fn round_trip_with_some_n_greater() {
 }
 
 #[test]
-#[cfg(not(any(feature = "ndarray", feature = "candle")))]
+#[cfg(not(feature = "ndarray"))]
 fn round_trip_with_some_n_less() {
+    if !matches!(FloatElem::dtype(), DType::F32 | DType::F64) {
+        return;
+    }
+
     let device = AutodiffDevice::new();
 
     let random = TensorData::from([
@@ -124,8 +148,12 @@ fn round_trip_with_some_n_less() {
 }
 
 #[test]
-#[cfg(not(any(feature = "ndarray", feature = "candle")))]
+#[cfg(not(feature = "ndarray"))]
 fn round_trip_inverse_with_some_n_greater() {
+    if !matches!(FloatElem::dtype(), DType::F32 | DType::F64) {
+        return;
+    }
+
     let device = AutodiffDevice::new();
 
     let random = TensorData::from([0.26, 0.13, 0.36, 0.24, 0.40, 0.93, 0.12]);
@@ -144,8 +172,12 @@ fn round_trip_inverse_with_some_n_greater() {
 }
 
 #[test]
-#[cfg(not(any(feature = "ndarray", feature = "candle")))]
+#[cfg(not(feature = "ndarray"))]
 fn round_trip_inverse_with_some_n_less() {
+    if !matches!(FloatElem::dtype(), DType::F32 | DType::F64) {
+        return;
+    }
+
     let device = AutodiffDevice::new();
 
     let random = TensorData::from([

--- a/crates/burn-backend-tests/tests/autodiff/rfft.rs
+++ b/crates/burn-backend-tests/tests/autodiff/rfft.rs
@@ -4,7 +4,6 @@ use burn_tensor::Tolerance;
 use burn_tensor::signal;
 
 #[test]
-#[ignore = "rfft is not supported for ndarray"]
 fn should_diff_rfft() {
     let device = AutodiffDevice::new();
 
@@ -30,7 +29,6 @@ fn should_diff_rfft() {
 }
 
 #[test]
-#[ignore = "rfft is not supported for ndarray"]
 fn round_trip() {
     let device = AutodiffDevice::new();
 

--- a/crates/burn-backend-tests/tests/autodiff/rfft.rs
+++ b/crates/burn-backend-tests/tests/autodiff/rfft.rs
@@ -74,3 +74,96 @@ fn round_trip_with_dim_nonzero() {
 
     TensorData::assert_approx_eq::<FloatElem>(&grad.to_data(), &random, Tolerance::default());
 }
+
+#[test]
+#[cfg(not(any(feature = "ndarray", feature = "candle")))]
+fn round_trip_with_some_n_greater() {
+    let device = AutodiffDevice::new();
+
+    let random = TensorData::from([
+        0.26, 0.13, 0.36, 0.24, 0.40, 0.93, 0.12, 0.18, 0.03, 0.74, 0.33, 0.70, 0.07,
+    ]);
+    let n = Some(16);
+
+    let tensor = TestTensor::<1>::from_data(random.clone(), &device).require_grad();
+
+    let y = signal::rfft(tensor.clone() * 3.0, 0, n);
+    let x = signal::irfft(y.0 * 2.0, y.1 * 2.0, 0, n) / 6.0;
+
+    let loss = x.powi_scalar(2).sum() * 0.5;
+    let grads = loss.backward();
+    let grad = tensor.grad(&grads).unwrap();
+
+    TensorData::assert_approx_eq::<FloatElem>(&grad.to_data(), &random, Tolerance::default());
+}
+
+#[test]
+#[cfg(not(any(feature = "ndarray", feature = "candle")))]
+fn round_trip_with_some_n_less() {
+    let device = AutodiffDevice::new();
+
+    let random = TensorData::from([
+        0.26, 0.13, 0.36, 0.24, 0.40, 0.93, 0.12, 0.18, 0.03, 0.74, 0.33, 0.70, 0.07, 0.61, 0.32,
+        0.66, 0.16, 0.05, 0.69,
+    ]);
+    let n = Some(16);
+
+    let tensor = TestTensor::<1>::from_data(random.clone(), &device).require_grad();
+
+    let y = signal::rfft(tensor.clone() * 3.0, 0, n);
+    let x = signal::irfft(y.0 * 2.0, y.1 * 2.0, 0, n) / 6.0;
+
+    let loss = x.powi_scalar(2).sum() * 0.5;
+    let grads = loss.backward();
+    let grad = tensor.grad(&grads).unwrap();
+
+    let lhs = grad.slice_dim(0, 0..16);
+    let rhs = tensor.slice_dim(0, 0..16);
+
+    TensorData::assert_approx_eq::<FloatElem>(&lhs.to_data(), &rhs.to_data(), Tolerance::default());
+}
+
+#[test]
+#[cfg(not(any(feature = "ndarray", feature = "candle")))]
+fn round_trip_inverse_with_some_n_greater() {
+    let device = AutodiffDevice::new();
+
+    let random = TensorData::from([0.26, 0.13, 0.36, 0.24, 0.40, 0.93, 0.12]);
+    let n = Some(16);
+
+    let tensor = TestTensor::<1>::from_data(random.clone(), &device).require_grad();
+
+    let x = signal::irfft(tensor.clone() * 2.0, tensor.zeros_like(), 0, n) / 6.0;
+    let (y, _) = signal::rfft(x * 3.0, 0, n);
+
+    let loss = y.powi_scalar(2).sum() * 0.5;
+    let grads = loss.backward();
+    let grad = tensor.grad(&grads).unwrap();
+
+    TensorData::assert_approx_eq::<FloatElem>(&grad.to_data(), &random, Tolerance::default());
+}
+
+#[test]
+#[cfg(not(any(feature = "ndarray", feature = "candle")))]
+fn round_trip_inverse_with_some_n_less() {
+    let device = AutodiffDevice::new();
+
+    let random = TensorData::from([
+        0.26, 0.13, 0.36, 0.24, 0.40, 0.93, 0.12, 0.18, 0.03, 0.74, 0.33, 0.70,
+    ]);
+    let n = Some(16);
+
+    let tensor = TestTensor::<1>::from_data(random.clone(), &device).require_grad();
+
+    let x = signal::irfft(tensor.clone() * 2.0, tensor.zeros_like(), 0, n) / 6.0;
+    let (y, _) = signal::rfft(x * 3.0, 0, n);
+
+    let loss = y.powi_scalar(2).sum() * 0.5;
+    let grads = loss.backward();
+    let grad = tensor.grad(&grads).unwrap();
+
+    let lhs = grad.slice_dim(0, 0..9);
+    let rhs = tensor.slice_dim(0, 0..9);
+
+    TensorData::assert_approx_eq::<FloatElem>(&lhs.to_data(), &rhs.to_data(), Tolerance::default());
+}

--- a/crates/burn-backend-tests/tests/autodiff/rfft.rs
+++ b/crates/burn-backend-tests/tests/autodiff/rfft.rs
@@ -4,6 +4,7 @@ use burn_tensor::Tolerance;
 use burn_tensor::signal;
 
 #[test]
+#[cfg(not(any(feature = "ndarray", feature = "candle")))]
 fn should_diff_rfft() {
     let device = AutodiffDevice::new();
 
@@ -29,6 +30,7 @@ fn should_diff_rfft() {
 }
 
 #[test]
+#[cfg(not(any(feature = "ndarray", feature = "candle")))]
 fn round_trip() {
     let device = AutodiffDevice::new();
 
@@ -45,6 +47,30 @@ fn round_trip() {
     let loss = x.powi_scalar(2).sum() * 0.5;
     let grads = loss.backward();
     let grad = tensor.grad(&grads).unwrap();
+
+    TensorData::assert_approx_eq::<FloatElem>(&grad.to_data(), &random, Tolerance::default());
+}
+
+#[test]
+#[cfg(not(any(feature = "ndarray", feature = "candle")))]
+fn round_trip_with_dim_nonzero() {
+    let device = AutodiffDevice::new();
+
+    let random = TensorData::from([
+        0.26, 0.13, 0.36, 0.24, 0.40, 0.93, 0.12, 0.18, 0.03, 0.74, 0.33, 0.70, 0.07, 0.61, 0.32,
+        0.66,
+    ]);
+
+    let tensor = TestTensor::<1>::from_data(random.clone(), &device);
+    let tensor = tensor.reshape([1, 1, -1, 1, 1]).require_grad();
+
+    let y = signal::rfft(tensor.clone() * 3.0, 2, None);
+    let x = signal::irfft(y.0 * 2.0, y.1 * 2.0, 2, None) / 6.0;
+
+    let loss = x.powi_scalar(2).sum() * 0.5;
+    let grads = loss.backward();
+    let grad = tensor.grad(&grads).unwrap();
+    let grad = grad.reshape([-1]);
 
     TensorData::assert_approx_eq::<FloatElem>(&grad.to_data(), &random, Tolerance::default());
 }


### PR DESCRIPTION
## Autodiff for `rfft` and `irfft`

Apologies in advance if something is off about the PR, I'm new to this 🥹 

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.*
- [x] Made sure the book is up to date with changes in this PR.**

*~~Unable to finish due to eventual linker errors (https://github.com/tracel-ai/burn/issues/3591 related?).~~ Has now been successfully run, but seemed to skip the autodiff tests?
**I'm not aware of any changes to be made.

### Related Issues/PRs

Solves https://github.com/tracel-ai/burn/issues/4945

### Changes

Implemented the missing module ops `rfft` and `irfft` in the autodiff backend.

### Testing

`cargo run-checks` was unable to run the tests because the `ndarray` backend has not implemented `rfft` yet (these tests are marked as `ignore` for now). The tests were run manually on `Autodiff<Wgpu>` instead.
