### PR TITLE
Re-export BurnConfig with fusion/autodiff getters

### DIFF
--- a/crates/burn-fusion/src/search/optimization/stream.rs
+++ b/crates/burn-fusion/src/search/optimization/stream.rs
@@ -24,7 +24,7 @@ impl<O: NumOperations> StreamOptimizer<O> {
     /// Create a new stream optimizer.
     pub fn new(builders: Vec<Box<dyn OperationFuser<O>>>) -> Self {
         // Too high and it may break the fusion cache always retriggering explorations.
-        let max_blocks = Some(config().fusion.beam_search.max_blocks);
+        let max_blocks = Some(config().fusion().beam_search.max_blocks);
         Self {
             builders,
             blocks: Vec::new(),

--- a/crates/burn-std/src/config/base.rs
+++ b/crates/burn-std/src/config/base.rs
@@ -12,11 +12,23 @@ static BURN_GLOBAL_CONFIG: spin::Mutex<Option<Arc<BurnConfig>>> = spin::Mutex::n
 pub struct BurnConfig {
     /// Configuration for operation fusion.
     #[serde(default)]
-    pub fusion: FusionConfig,
+    fusion: FusionConfig,
 
     /// Configuration for autodiff.
     #[serde(default)]
-    pub autodiff: AutodiffConfig,
+    autodiff: AutodiffConfig,
+}
+
+impl BurnConfig {
+    /// Returns a reference to the operation-fusion configuration.
+    pub fn fusion(&self) -> &FusionConfig {
+        &self.fusion
+    }
+
+    /// Returns a reference to the autodiff configuration.
+    pub fn autodiff(&self) -> &AutodiffConfig {
+        &self.autodiff
+    }
 }
 
 impl RuntimeConfig for BurnConfig {

--- a/crates/burn-std/src/config/logger.rs
+++ b/crates/burn-std/src/config/logger.rs
@@ -65,13 +65,13 @@ impl Logger {
 
         let fusion_index = register_enabled(
             &mut sinks,
-            &config.fusion.logger,
-            config.fusion.logger.level != FusionLogLevel::Disabled,
+            &config.fusion().logger,
+            config.fusion().logger.level != FusionLogLevel::Disabled,
         );
         let autodiff_index = register_enabled(
             &mut sinks,
-            &config.autodiff.logger,
-            config.autodiff.logger.level != AutodiffLogLevel::Disabled,
+            &config.autodiff().logger,
+            config.autodiff().logger.level != AutodiffLogLevel::Disabled,
         );
 
         Self {
@@ -94,12 +94,12 @@ impl Logger {
 
     /// Returns the current fusion log level.
     pub fn log_level_fusion(&self) -> FusionLogLevel {
-        self.config.fusion.logger.level
+        self.config.fusion().logger.level
     }
 
     /// Returns the current autodiff log level.
     pub fn log_level_autodiff(&self) -> AutodiffLogLevel {
-        self.config.autodiff.logger.level
+        self.config.autodiff().logger.level
     }
 }
 
@@ -122,7 +122,7 @@ pub fn log_fusion<F>(level: FusionLogLevel, f: F)
 where
     F: FnOnce() -> String,
 {
-    let current = config().fusion.logger.level;
+    let current = config().fusion().logger.level;
     if current < level {
         return;
     }
@@ -139,7 +139,7 @@ pub fn log_autodiff<F>(level: AutodiffLogLevel, f: F)
 where
     F: FnOnce() -> String,
 {
-    let current = config().autodiff.logger.level;
+    let current = config().autodiff().logger.level;
     if current < level {
         return;
     }

--- a/crates/burn-std/tests/config.rs
+++ b/crates/burn-std/tests/config.rs
@@ -50,9 +50,9 @@ stdout = true
         let file = write_toml(EMPTY_TOML);
         let config = BurnConfig::from_file_path(file.path()).expect("parse empty toml");
 
-        assert_eq!(config.fusion.beam_search.max_blocks, 5);
-        assert_eq!(config.fusion.logger.level, FusionLogLevel::Disabled);
-        assert_eq!(config.autodiff.logger.level, AutodiffLogLevel::Disabled);
+        assert_eq!(config.fusion().beam_search.max_blocks, 5);
+        assert_eq!(config.fusion().logger.level, FusionLogLevel::Disabled);
+        assert_eq!(config.autodiff().logger.level, AutodiffLogLevel::Disabled);
     }
 
     #[test]
@@ -60,9 +60,9 @@ stdout = true
         let file = write_toml(MINIMAL_TOML);
         let config = BurnConfig::from_file_path(file.path()).expect("parse minimal toml");
 
-        assert_eq!(config.fusion.beam_search.max_blocks, 3);
+        assert_eq!(config.fusion().beam_search.max_blocks, 3);
         // Untouched sections keep defaults.
-        assert_eq!(config.autodiff.logger.level, AutodiffLogLevel::Disabled);
+        assert_eq!(config.autodiff().logger.level, AutodiffLogLevel::Disabled);
     }
 
     /// The important case: a single `burn.toml` with both Burn and CubeCL sections must
@@ -72,9 +72,9 @@ stdout = true
         let file = write_toml(FULL_TOML);
         let config = BurnConfig::from_file_path(file.path()).expect("parse full toml");
 
-        assert_eq!(config.fusion.beam_search.max_blocks, 10);
-        assert_eq!(config.fusion.logger.level, FusionLogLevel::Medium);
-        assert!(config.fusion.logger.stdout);
-        assert_eq!(config.autodiff.logger.level, AutodiffLogLevel::Basic);
+        assert_eq!(config.fusion().beam_search.max_blocks, 10);
+        assert_eq!(config.fusion().logger.level, FusionLogLevel::Medium);
+        assert!(config.fusion().logger.stdout);
+        assert_eq!(config.autodiff().logger.level, AutodiffLogLevel::Basic);
     }
 }

--- a/crates/burn/src/lib.rs
+++ b/crates/burn/src/lib.rs
@@ -146,7 +146,7 @@ pub mod nn {
     pub use burn_nn::*;
 }
 
-pub use burn_std::config::config as runtime_config;
+pub use burn_std::config::{BurnConfig, config as runtime_config};
 
 /// Optimizers module.
 #[cfg(feature = "optim")]


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Closes #4932.

### Changes

- Re-export `BurnConfig` from `burn` alongside `runtime_config` (the function was already public; the type it returns now is too).
- Privatize `BurnConfig::fusion` and `BurnConfig::autodiff`; add `fusion()` and `autodiff()` getters returning `&FusionConfig` and `&AutodiffConfig`.
- Update the two internal field-access call sites in `burn_std::config::logger` and the one in `burn_fusion::search::optimization::stream` to use the new getters.

The `impl RuntimeConfig for BurnConfig` block keeps direct field access on `self.fusion.logger.*` inside `override_from_env`; that stays inside the defining module so the visibility change does not need a mutable accessor.

### Testing

`cargo test -p burn-std` (101 passed across unit tests + the `tests/config.rs` integration suite + doctests), `cargo clippy -p burn-std -p burn -p burn-fusion -- -D warnings` clean, `cargo fmt --check` clean, `cargo build -p burn-std --no-default-features` clean for the no-std path.