### PR TITLE
Feature gate `Tensor::from/into_primitive` and add `from/into_bridge`

### DIFF
--- a/crates/burn-backend-tests/tests/cubecl/unary.rs
+++ b/crates/burn-backend-tests/tests/cubecl/unary.rs
@@ -4,11 +4,8 @@ use super::*;
 fn tanh_should_not_have_numerical_bugs_on_macos() {
     fn tanh_one_value(input: f32) -> f32 {
         let tensor = TestTensor::<1>::ones([1], &Default::default()) * input;
-        let output = tensor.tanh().into_primitive();
-        TestTensor::<1>::from_primitive(output)
-            .into_data()
-            .as_slice()
-            .unwrap()[0]
+        let output = tensor.tanh();
+        output.into_data().as_slice().unwrap()[0]
     }
 
     let ok = tanh_one_value(43.0); // metal tanh gives 1.0 which is the right answer

--- a/crates/burn-core/Cargo.toml
+++ b/crates/burn-core/Cargo.toml
@@ -78,7 +78,7 @@ fusion = ["burn-tensor/fusion"]
 
 # Backend extensions
 # burn-dispatch features are enabled from burn-tensor, we just re-export the public types
-extension = ["burn-backend-extension", "burn-dispatch", "burn-backend"]
+extension = ["burn-tensor/extension", "burn-backend-extension", "burn-dispatch", "burn-backend"]
 
 [dependencies]
 

--- a/crates/burn-dispatch/build.rs
+++ b/crates/burn-dispatch/build.rs
@@ -16,9 +16,6 @@ fn main() {
     let mut vulkan = cfg!(feature = "vulkan");
     let mut webgpu = cfg!(feature = "webgpu");
 
-    let no_backend_enabled =
-        !(cuda || flex || rocm || ndarray || tch || cpu || metal || vulkan || webgpu);
-
     // Detect which single wgpu backend is enabled
     let wgpu_only = cfg!(all(
         feature = "wgpu",
@@ -43,6 +40,9 @@ fn main() {
         );
     }
 
+    let no_backend_enabled =
+        !(cuda || flex || rocm || ndarray || tch || cpu || metal || vulkan || webgpu || wgpu_only);
+
     if metal {
         println!("cargo:rustc-cfg=wgpu_metal");
     }
@@ -55,6 +55,4 @@ fn main() {
     if no_backend_enabled {
         println!("cargo:rustc-cfg=default_backend");
     }
-
-    println!("cargo:warning=Detected features: [cuda={cuda}, vulkan={vulkan}].",);
 }

--- a/crates/burn-tensor/Cargo.toml
+++ b/crates/burn-tensor/Cargo.toml
@@ -46,9 +46,8 @@ metal = ["burn-dispatch/metal"]
 cpu = ["burn-dispatch/cpu"]
 autodiff = ["burn-dispatch/autodiff"]
 
-# TODO: might need to re-introduce the feature flag for from/into primitive
 # For backend extensions
-# extension = []
+extension = []
 
 # Backend features
 autotune = ["burn-dispatch/autotune"]

--- a/crates/burn-tensor/src/bridge/kind.rs
+++ b/crates/burn-tensor/src/bridge/kind.rs
@@ -18,24 +18,51 @@ pub struct Bool;
 /// Metadata access is lazy.
 pub trait TensorKind: Clone + Send + Sync + core::fmt::Debug {
     /// The name of the tensor kind.
-    fn name() -> &'static str;
+    fn name() -> &'static str {
+        Self::id().as_str()
+    }
+
+    /// The tensor kind identifier.
+    fn id() -> TensorKindId;
 }
 
 impl TensorKind for Float {
-    fn name() -> &'static str {
-        "Float"
+    fn id() -> TensorKindId {
+        TensorKindId::Float
     }
 }
 
 impl TensorKind for Int {
-    fn name() -> &'static str {
-        "Int"
+    fn id() -> TensorKindId {
+        TensorKindId::Int
     }
 }
 
 impl TensorKind for Bool {
-    fn name() -> &'static str {
-        "Bool"
+    fn id() -> TensorKindId {
+        TensorKindId::Bool
+    }
+}
+
+/// Runtime identifier for a tensor kind.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TensorKindId {
+    /// A float tensor kind.
+    Float,
+    /// An integer tensor kind.
+    Int,
+    /// A boolean tensor kind.
+    Bool,
+}
+
+impl TensorKindId {
+    /// Get the string representation of the [`TensorKindId`].
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TensorKindId::Float => "Float",
+            TensorKindId::Int => "Int",
+            TensorKindId::Bool => "Bool",
+        }
     }
 }
 

--- a/crates/burn-tensor/src/tensor/activation/base.rs
+++ b/crates/burn-tensor/src/tensor/activation/base.rs
@@ -39,7 +39,7 @@ $$
     doc = "`f(x) =`\n- `x for x >= 0`\n- `negative_slope * x if x < 0`"
 )]
 pub fn leaky_relu<const D: usize>(tensor: Tensor<D>, negative_slope: f64) -> Tensor<D> {
-    Tensor::from_primitive(BridgeTensor::Float(Dispatch::leaky_relu(
+    Tensor::new(BridgeTensor::Float(Dispatch::leaky_relu(
         tensor.primitive.into_float(),
         negative_slope.into(),
     )))
@@ -69,7 +69,7 @@ where `Φ(x)` is the cumulative distribution function for the Gaussian distribut
 "#
 )]
 pub fn gelu<const D: usize>(tensor: Tensor<D>) -> Tensor<D> {
-    Tensor::from_primitive(BridgeTensor::Float(Dispatch::gelu(
+    Tensor::new(BridgeTensor::Float(Dispatch::gelu(
         tensor.primitive.into_float(),
     )))
 }
@@ -144,7 +144,7 @@ pub fn prelu<const D: usize>(tensor: Tensor<D>, alpha: Tensor<1>) -> Tensor<D> {
         alpha.reshape(s)
     };
 
-    Tensor::from_primitive(BridgeTensor::Float(Dispatch::prelu(
+    Tensor::new(BridgeTensor::Float(Dispatch::prelu(
         tensor.primitive.into_float(),
         weight.primitive.into_float(),
     )))
@@ -170,7 +170,7 @@ $$
 pub fn softmax<const D: usize>(tensor: Tensor<D>, dim: usize) -> Tensor<D> {
     check!(TensorCheck::dim_ops::<D>("softmax", dim));
 
-    Tensor::from_primitive(BridgeTensor::Float(Dispatch::softmax(
+    Tensor::new(BridgeTensor::Float(Dispatch::softmax(
         tensor.primitive.into_float(),
         dim,
     )))
@@ -196,7 +196,7 @@ $$
 pub fn softmin<const D: usize>(tensor: Tensor<D>, dim: usize) -> Tensor<D> {
     check!(TensorCheck::dim_ops::<D>("softmin", dim));
 
-    Tensor::from_primitive(BridgeTensor::Float(Dispatch::softmin(
+    Tensor::new(BridgeTensor::Float(Dispatch::softmin(
         tensor.primitive.into_float(),
         dim,
     )))
@@ -280,7 +280,7 @@ $$
 pub fn log_softmax<const D: usize>(tensor: Tensor<D>, dim: usize) -> Tensor<D> {
     check!(TensorCheck::dim_ops::<D>("log softmax", dim));
 
-    Tensor::from_primitive(BridgeTensor::Float(Dispatch::log_softmax(
+    Tensor::new(BridgeTensor::Float(Dispatch::log_softmax(
         tensor.primitive.into_float(),
         dim,
     )))
@@ -300,7 +300,7 @@ $$
 )]
 #[cfg_attr(not(doc), doc = "`sigmoid(x) = 1 / (1 + exp(-x))`")]
 pub fn sigmoid<const D: usize>(tensor: Tensor<D>) -> Tensor<D> {
-    Tensor::from_primitive(BridgeTensor::Float(Dispatch::sigmoid(
+    Tensor::new(BridgeTensor::Float(Dispatch::sigmoid(
         tensor.primitive.into_float(),
     )))
 }
@@ -317,7 +317,7 @@ $$
 )]
 #[cfg_attr(not(doc), doc = "`hard_sigmoid(x) = max(0, min(1, alpha * x + beta))`")]
 pub fn hard_sigmoid<const D: usize>(tensor: Tensor<D>, alpha: f64, beta: f64) -> Tensor<D> {
-    Tensor::from_primitive(BridgeTensor::Float(Dispatch::hard_sigmoid(
+    Tensor::new(BridgeTensor::Float(Dispatch::hard_sigmoid(
         tensor.primitive.into_float(),
         alpha.into(),
         beta.into(),
@@ -336,7 +336,7 @@ $$
 )]
 #[cfg_attr(not(doc), doc = "`log_sigmoid(x) = log(1 / (1 + exp(-x)))`")]
 pub fn log_sigmoid<const D: usize>(tensor: Tensor<D>) -> Tensor<D> {
-    Tensor::from_primitive(BridgeTensor::Float(Dispatch::log_sigmoid(
+    Tensor::new(BridgeTensor::Float(Dispatch::log_sigmoid(
         tensor.primitive.into_float(),
     )))
 }

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -111,19 +111,6 @@ where
         core::mem::swap(&mut tensor_new, self);
     }
 
-    // TODO: feature gated for backend extensions? Note that `Tensor::new(primitive)` also exists right now
-    // The primitive kind will be opaque, but for these public extension feature-gated methods
-    // we could return/use the dispatch tensor type.
-    /// Converts the tensor into a primitive tensor.
-    pub fn into_primitive(self) -> BridgeTensor {
-        self.primitive
-    }
-
-    /// Converts from a primitive tensor into a tensor.
-    pub fn from_primitive(tensor: BridgeTensor) -> Self {
-        Self::new(tensor)
-    }
-
     /// Returns the number of dimensions of the tensor.
     pub fn rank(&self) -> usize {
         self.primitive.rank()

--- a/crates/burn-tensor/src/tensor/api/extension.rs
+++ b/crates/burn-tensor/src/tensor/api/extension.rs
@@ -1,0 +1,202 @@
+use burn_backend::TensorMetadata;
+pub use burn_dispatch::DispatchTensor;
+use burn_std::DType;
+
+use crate::{
+    Tensor,
+    kind::Basic,
+    ops::{BridgeTensor, TensorKindId},
+};
+
+impl<const D: usize, K> Tensor<D, K>
+where
+    K: Basic,
+{
+    /// Converts the tensor into its bridge-layer representation.
+    ///
+    /// This is primarily intended for backend extensions, allowing custom operations
+    /// to be inserted between the high-level tensor API and the dispatch layer before
+    /// deferring to a concrete backend.
+    pub fn into_bridge(self) -> BridgeTensor {
+        self.primitive
+    }
+
+    /// Reconstructs a tensor from its [`BridgeTensor`] bridge representation.
+    ///
+    /// This is the inverse of [`Tensor::into_bridge`] and is primarily intended
+    /// for backend extensions, to wrap the output of a custom operation back into
+    /// the high-level tensor API.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the [`BridgeTensor`] variant does not match the tensor kind `K`
+    /// (e.g. passing [`BridgeTensor::Int`] when `K` is [`Float`]).
+    pub fn from_bridge(tensor: BridgeTensor) -> Self {
+        let dtype = tensor.dtype();
+        match (&tensor, K::id()) {
+            (BridgeTensor::Bool(_), TensorKindId::Bool) if dtype.is_bool() => Self::new(tensor),
+            (BridgeTensor::Int(_), TensorKindId::Int) if dtype.is_int() || dtype.is_uint() => {
+                Self::new(tensor)
+            }
+            (BridgeTensor::Float(_), TensorKindId::Float) if dtype.is_float() => Self::new(tensor),
+            (BridgeTensor::QFloat(_), TensorKindId::Float) if matches!(dtype, DType::QFloat(_)) => {
+                Self::new(tensor)
+            }
+            (_, kind) => panic!("Expected kind {kind:?}, got dtype {dtype:?}"),
+        }
+    }
+
+    /// Converts from a primitive tensor into a tensor.
+    ///
+    /// # Panics
+    /// Panis if the primitive dtype does not match the tensor kind `K`.
+    pub fn from_primitive(tensor: DispatchTensor) -> Self {
+        match (tensor.dtype(), K::id()) {
+            (DType::QFloat(_), TensorKindId::Float) => Self::new(BridgeTensor::QFloat(tensor)),
+            (dtype, TensorKindId::Float) if dtype.is_float() => {
+                Self::new(BridgeTensor::Float(tensor))
+            }
+            (dtype, TensorKindId::Int) if dtype.is_int() || dtype.is_uint() => {
+                Self::new(BridgeTensor::Int(tensor))
+            }
+            (dtype, TensorKindId::Bool) if dtype.is_bool() => Self::new(BridgeTensor::Bool(tensor)),
+            (dtype, kind) => panic!("Expected kind {kind:?}, got dtype {dtype:?}"),
+        }
+    }
+
+    /// Converts the tensor into a primitive tensor.
+    pub fn into_primitive(self) -> DispatchTensor {
+        self.primitive.into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Bool, Int};
+
+    use super::*;
+
+    // -- into_bridge / from_bridge roundtrip --
+
+    #[test]
+    fn float_tensor_bridge_roundtrip() {
+        let tensor = Tensor::<2>::zeros([2, 3], &Default::default());
+        let shape = tensor.shape();
+        let bridge = tensor.into_bridge();
+        assert!(matches!(bridge, BridgeTensor::Float(_)));
+        let tensor = Tensor::<2>::from_bridge(bridge);
+        assert_eq!(tensor.shape(), shape);
+    }
+
+    #[test]
+    fn int_tensor_bridge_roundtrip() {
+        let tensor = Tensor::<2, Int>::zeros([2, 3], &Default::default());
+        let shape = tensor.shape();
+        let bridge = tensor.into_bridge();
+        assert!(matches!(bridge, BridgeTensor::Int(_)));
+        let tensor = Tensor::<2, Int>::from_bridge(bridge);
+        assert_eq!(tensor.shape(), shape);
+    }
+
+    #[test]
+    fn bool_tensor_bridge_roundtrip() {
+        let tensor = Tensor::<2, Bool>::empty([2, 3], &Default::default());
+        let shape = tensor.shape();
+        let bridge = tensor.into_bridge();
+        assert!(matches!(bridge, BridgeTensor::Bool(_)));
+        let tensor = Tensor::<2, Bool>::from_bridge(bridge);
+        assert_eq!(tensor.shape(), shape);
+    }
+
+    // -- from_bridge panics on kind mismatch --
+
+    #[test]
+    #[should_panic(expected = "Expected kind Float")]
+    fn from_bridge_int_as_float_panics() {
+        let bridge = Tensor::<2, Int>::zeros([2, 3], &Default::default()).into_bridge();
+        let _tensor = Tensor::<2>::from_bridge(bridge);
+    }
+
+    #[test]
+    #[should_panic(expected = "Expected kind Float")]
+    fn from_bridge_bool_as_float_panics() {
+        let bridge = Tensor::<2, Bool>::empty([2, 3], &Default::default()).into_bridge();
+        let _tensor = Tensor::<2>::from_bridge(bridge);
+    }
+
+    #[test]
+    #[should_panic(expected = "Expected kind Int")]
+    fn from_bridge_float_as_int_panics() {
+        let bridge = Tensor::<2>::zeros([2, 3], &Default::default()).into_bridge();
+        let _tensor = Tensor::<2, Int>::from_bridge(bridge);
+    }
+
+    #[test]
+    #[should_panic(expected = "Expected kind Bool")]
+    fn from_bridge_int_as_bool_panics() {
+        let bridge = Tensor::<2, Int>::zeros([2, 3], &Default::default()).into_bridge();
+        let _tensor = Tensor::<2, Bool>::from_bridge(bridge);
+    }
+
+    #[test]
+    #[should_panic(expected = "Expected kind Float")]
+    fn from_bridge_qfloat_variant_with_int_dtype_panics() {
+        // Construct a BridgeTensor::QFloat wrapping a non-qfloat dispatch tensor
+        // kind tag says Float but dtype says otherwise.
+        let inner = Tensor::<2, Int>::zeros([2, 3], &Default::default()).into_primitive();
+        let bridge = BridgeTensor::QFloat(inner);
+        let _tensor = Tensor::<2>::from_bridge(bridge);
+    }
+
+    // -- into_primitive / from_primitive roundtrip --
+
+    #[test]
+    fn float_primitive_roundtrip() {
+        let tensor = Tensor::<2>::zeros([2, 3], &Default::default());
+        let shape = tensor.shape();
+        let primitive = tensor.into_primitive();
+        let tensor = Tensor::<2>::from_primitive(primitive);
+        assert_eq!(tensor.shape(), shape);
+    }
+
+    #[test]
+    fn int_primitive_roundtrip() {
+        let tensor = Tensor::<2, Int>::zeros([2, 3], &Default::default());
+        let shape = tensor.shape();
+        let primitive = tensor.into_primitive();
+        let tensor = Tensor::<2, Int>::from_primitive(primitive);
+        assert_eq!(tensor.shape(), shape);
+    }
+
+    #[test]
+    fn bool_primitive_roundtrip() {
+        let tensor = Tensor::<2, Bool>::empty([2, 3], &Default::default());
+        let shape = tensor.shape();
+        let primitive = tensor.into_primitive();
+        let tensor = Tensor::<2, Bool>::from_primitive(primitive);
+        assert_eq!(tensor.shape(), shape);
+    }
+
+    // -- from_primitive panics on dtype/kind mismatch --
+
+    #[test]
+    #[should_panic(expected = "Expected kind Float")]
+    fn from_primitive_int_dtype_as_float_panics() {
+        let primitive = Tensor::<2, Int>::zeros([2, 3], &Default::default()).into_primitive();
+        let _tensor = Tensor::<2>::from_primitive(primitive);
+    }
+
+    #[test]
+    #[should_panic(expected = "Expected kind Int")]
+    fn from_primitive_float_dtype_as_int_panics() {
+        let primitive = Tensor::<2>::zeros([2, 3], &Default::default()).into_primitive();
+        let _tensor = Tensor::<2, Int>::from_primitive(primitive);
+    }
+
+    #[test]
+    #[should_panic(expected = "Expected kind Bool")]
+    fn from_primitive_float_dtype_as_bool_panics() {
+        let primitive = Tensor::<2>::zeros([2, 3], &Default::default()).into_primitive();
+        let _tensor = Tensor::<2, Bool>::from_primitive(primitive);
+    }
+}

--- a/crates/burn-tensor/src/tensor/api/extension.rs
+++ b/crates/burn-tensor/src/tensor/api/extension.rs
@@ -30,7 +30,7 @@ where
     /// # Panics
     ///
     /// Panics if the [`BridgeTensor`] variant does not match the tensor kind `K`
-    /// (e.g. passing [`BridgeTensor::Int`] when `K` is [`Float`]).
+    /// (e.g. passing [`BridgeTensor::Int`] when `K` is [`Float`](crate::Float).
     pub fn from_bridge(tensor: BridgeTensor) -> Self {
         let dtype = tensor.dtype();
         match (&tensor, K::id()) {

--- a/crates/burn-tensor/src/tensor/api/mod.rs
+++ b/crates/burn-tensor/src/tensor/api/mod.rs
@@ -27,3 +27,8 @@ pub use cast::*;
 pub use float::{DEFAULT_ATOL, DEFAULT_RTOL};
 pub use options::*;
 pub use transaction::*;
+
+#[cfg(feature = "extension")]
+mod extension;
+#[cfg(feature = "extension")]
+pub use extension::*;

--- a/crates/burn-tensor/src/tensor/api/options.rs
+++ b/crates/burn-tensor/src/tensor/api/options.rs
@@ -1,6 +1,6 @@
 use burn_std::DType;
 
-use crate::{Device, bridge::BasicOps};
+use crate::{Device, bridge::BasicOps, ops::TensorKindId};
 
 /// Options for tensor creation.
 ///
@@ -56,16 +56,13 @@ impl TensorCreationOptions {
 
     /// Returns the tensor data type, or the default from the [device settings](crate::DeviceSettings).
     pub(crate) fn resolve_dtype<K: BasicOps>(&self) -> DType {
-        let kind_name = K::name();
-        // TODO: tensor kind enum?
+        let kind = K::id();
         self.dtype.unwrap_or_else(|| {
             let settings = self.device.settings();
-            if kind_name == "Float" {
-                settings.float_dtype.into()
-            } else if kind_name == "Int" {
-                settings.int_dtype.into()
-            } else {
-                settings.bool_dtype.into()
+            match kind {
+                TensorKindId::Float => settings.float_dtype.into(),
+                TensorKindId::Int => settings.int_dtype.into(),
+                TensorKindId::Bool => settings.bool_dtype.into(),
             }
         })
     }

--- a/crates/burn-tensor/src/tensor/api/orderable.rs
+++ b/crates/burn-tensor/src/tensor/api/orderable.rs
@@ -303,7 +303,7 @@ where
     ///     let device = Default::default();
     ///     let indices: Tensor<2, Float> = Tensor::from_floats([[0., 2.], [1., -1.]], &device);
     ///     // One-hot encoding
-    ///     let tensor:Tensor<3, Float> = indices.one_hot_fill(3, 5.0.into(), 0.0.into(), -1);
+    ///     let tensor: Tensor<3, Float> = indices.one_hot_fill(3, 5.0.into(), 0.0.into(), -1);
     ///     println!("{tensor}");
     ///     // [[[5.0, 0.0, 0.0],
     ///     // [0.0, 0.0, 5.0]],

--- a/crates/burn-tensor/src/tensor/api/transaction.rs
+++ b/crates/burn-tensor/src/tensor/api/transaction.rs
@@ -29,7 +29,7 @@ impl Transaction {
         mut self,
         tensor: Tensor<D, K>,
     ) -> Self {
-        K::register_transaction(&mut self.op, tensor.into_primitive());
+        K::register_transaction(&mut self.op, tensor.primitive);
         self
     }
 

--- a/crates/burn-tensor/src/tensor/kind.rs
+++ b/crates/burn-tensor/src/tensor/kind.rs
@@ -1,7 +1,10 @@
 // Sealed traits, limited to Bool, Float and Int types which implement the pub(crate) traits.
 #![allow(private_bounds)]
 
-pub use crate::bridge::{Bool, BridgeTensor, Float, Int};
+#[cfg(feature = "extension")]
+pub use crate::bridge::BridgeTensor;
+
+pub use crate::bridge::{Bool, Float, Int, TensorKind, TensorKindId};
 
 /// The base trait for any tensor kind.
 pub trait Basic: crate::ops::BasicOps {}

--- a/crates/burn-tensor/src/tensor/module.rs
+++ b/crates/burn-tensor/src/tensor/module.rs
@@ -600,7 +600,7 @@ pub fn layer_norm<const D: usize>(
     beta: Option<Tensor<1>>,
     epsilon: f64,
 ) -> Tensor<D> {
-    Tensor::from_primitive(BridgeTensor::Float(Dispatch::layer_norm(
+    Tensor::new(BridgeTensor::Float(Dispatch::layer_norm(
         input.primitive.into_float(),
         gamma.primitive.into_float(),
         beta.map(|b| b.primitive.into_float()),

--- a/crates/burn-tensor/src/tensor/quantization.rs
+++ b/crates/burn-tensor/src/tensor/quantization.rs
@@ -32,8 +32,8 @@ pub fn compute_range<const D: usize>(
     };
 
     CalibrationRange {
-        min: Tensor::from_primitive(BridgeTensor::Float(min)),
-        max: Tensor::from_primitive(BridgeTensor::Float(max)),
+        min: Tensor::new(BridgeTensor::Float(min)),
+        max: Tensor::new(BridgeTensor::Float(max)),
     }
 }
 
@@ -43,7 +43,7 @@ pub fn compute_q_params(scheme: &QuantScheme, range: CalibrationRange) -> Quanti
         (BridgeTensor::Float(min), BridgeTensor::Float(max)) => {
             let qparams = quantization::compute_q_params::<Dispatch>(scheme, min, max);
             QuantizationParameters {
-                scales: Tensor::from_primitive(BridgeTensor::Float(qparams.scales)),
+                scales: Tensor::new(BridgeTensor::Float(qparams.scales)),
             }
         }
         _ => unreachable!(),

--- a/crates/burn-vision/src/tensor.rs
+++ b/crates/burn-vision/src/tensor.rs
@@ -1,6 +1,5 @@
 use burn_core::backend::Dispatch;
-use burn_core::tensor::kind::BridgeTensor;
-use burn_core::tensor::{Bool, Float, Int, Tensor};
+use burn_core::tensor::{Bool, DType, Float, Int, Tensor};
 
 use crate::{
     BoolVisionOps, ConnectedStats, ConnectedStatsOptions, Connectivity, FloatVisionOps,
@@ -37,22 +36,6 @@ pub trait Morphology {
     fn dilate(self, kernel: Tensor<2, Bool>, opts: MorphOptions) -> Self;
 }
 
-// /// Morphology tensor operations
-// pub trait MorphologyKind: BasicOps<B> {
-//     /// Erodes this tensor using the specified kernel
-//     fn erode(
-//         tensor: Self::Primitive,
-//         kernel: BoolTensor<B>,
-//         opts: MorphOptions<B, Self>,
-//     ) -> Self::Primitive;
-//     /// Dilates this tensor using the specified kernel
-//     fn dilate(
-//         tensor: Self::Primitive,
-//         kernel: BoolTensor<B>,
-//         opts: MorphOptions<B, Self>,
-//     ) -> Self::Primitive;
-// }
-
 /// Non-maximum suppression tensor operations
 pub trait Nms {
     /// Perform Non-Maximum Suppression on this tensor of bounding boxes.
@@ -71,16 +54,13 @@ pub trait Nms {
     fn nms(self, scores: Tensor<1, Float>, opts: NmsOptions) -> Tensor<1, Int>;
 }
 
-// THE IMPLEMENTATION WHICH SHOULD CALL DISPATCH
 impl ConnectedComponents for Tensor<2, Bool> {
     fn connected_components(self, connectivity: Connectivity) -> Tensor<2, Int> {
         let settings = self.device().settings();
-        Tensor::new(BridgeTensor::Int(
-            <Dispatch as BoolVisionOps>::connected_components(
-                self.into_primitive().into(),
-                connectivity,
-                settings.int_dtype,
-            ),
+        Tensor::from_primitive(<Dispatch as BoolVisionOps>::connected_components(
+            self.into_primitive(),
+            connectivity,
+            settings.int_dtype,
         ))
     }
 
@@ -92,104 +72,100 @@ impl ConnectedComponents for Tensor<2, Bool> {
         let settings = self.device().settings();
         let (labels, area, left, top, right, bottom, max_label) =
             <Dispatch as BoolVisionOps>::connected_components_with_stats(
-                self.into_primitive().into(),
+                self.into_primitive(),
                 connectivity,
                 options,
                 settings.int_dtype,
             );
         let stats = ConnectedStats {
-            area: Tensor::new(BridgeTensor::Int(area)),
-            left: Tensor::new(BridgeTensor::Int(left)),
-            top: Tensor::new(BridgeTensor::Int(top)),
-            right: Tensor::new(BridgeTensor::Int(right)),
-            bottom: Tensor::new(BridgeTensor::Int(bottom)),
-            max_label: Tensor::new(BridgeTensor::Int(max_label)),
+            area: Tensor::from_primitive(area),
+            left: Tensor::from_primitive(left),
+            top: Tensor::from_primitive(top),
+            right: Tensor::from_primitive(right),
+            bottom: Tensor::from_primitive(bottom),
+            max_label: Tensor::from_primitive(max_label),
         };
-        (Tensor::new(BridgeTensor::Int(labels)), stats)
+        (Tensor::from_primitive(labels), stats)
     }
 }
 
 impl Morphology for Tensor<3, Float> {
     fn erode(self, kernel: Tensor<2, Bool>, opts: MorphOptions) -> Self {
-        let out = match self.into_primitive() {
-            BridgeTensor::Float(tensor) => {
-                BridgeTensor::Float(<Dispatch as FloatVisionOps>::float_erode(
-                    tensor,
-                    kernel.into_primitive().into(),
-                    opts,
-                ))
-            }
-            _ => unimplemented!(),
-        };
-        Tensor::new(out)
+        if matches!(self.dtype(), DType::QFloat(_)) {
+            unimplemented!("Quantized float is not supported");
+        }
+
+        let out = <Dispatch as FloatVisionOps>::float_erode(
+            self.into_primitive(),
+            kernel.into_primitive(),
+            opts,
+        );
+        Tensor::from_primitive(out)
     }
 
     fn dilate(self, kernel: Tensor<2, Bool>, opts: MorphOptions) -> Self {
-        let out = match self.into_primitive() {
-            BridgeTensor::Float(tensor) => {
-                BridgeTensor::Float(<Dispatch as FloatVisionOps>::float_dilate(
-                    tensor,
-                    kernel.into_primitive().into(),
-                    opts,
-                ))
-            }
-            _ => unimplemented!(),
-        };
-        Tensor::new(out)
+        if matches!(self.dtype(), DType::QFloat(_)) {
+            unimplemented!("Quantized float is not supported");
+        }
+
+        let out = <Dispatch as FloatVisionOps>::float_dilate(
+            self.into_primitive(),
+            kernel.into_primitive(),
+            opts,
+        );
+        Tensor::from_primitive(out)
     }
 }
 
 impl Morphology for Tensor<3, Int> {
     fn erode(self, kernel: Tensor<2, Bool>, opts: MorphOptions) -> Self {
-        Tensor::new(BridgeTensor::Int(<Dispatch as IntVisionOps>::int_erode(
-            self.into_primitive().into(),
-            kernel.into_primitive().into(),
+        Tensor::from_primitive(<Dispatch as IntVisionOps>::int_erode(
+            self.into_primitive(),
+            kernel.into_primitive(),
             opts,
-        )))
+        ))
     }
 
     fn dilate(self, kernel: Tensor<2, Bool>, opts: MorphOptions) -> Self {
-        Tensor::new(BridgeTensor::Int(<Dispatch as IntVisionOps>::int_dilate(
-            self.into_primitive().into(),
-            kernel.into_primitive().into(),
+        Tensor::from_primitive(<Dispatch as IntVisionOps>::int_dilate(
+            self.into_primitive(),
+            kernel.into_primitive(),
             opts,
-        )))
+        ))
     }
 }
 
 impl Morphology for Tensor<3, Bool> {
     fn erode(self, kernel: Tensor<2, Bool>, opts: MorphOptions) -> Self {
-        Tensor::new(BridgeTensor::Int(<Dispatch as BoolVisionOps>::bool_erode(
-            self.into_primitive().into(),
-            kernel.into_primitive().into(),
+        Tensor::from_primitive(<Dispatch as BoolVisionOps>::bool_erode(
+            self.into_primitive(),
+            kernel.into_primitive(),
             opts,
-        )))
+        ))
     }
 
     fn dilate(self, kernel: Tensor<2, Bool>, opts: MorphOptions) -> Self {
-        Tensor::new(BridgeTensor::Int(
-            <Dispatch as BoolVisionOps>::bool_dilate(
-                self.into_primitive().into(),
-                kernel.into_primitive().into(),
-                opts,
-            ),
+        Tensor::from_primitive(<Dispatch as BoolVisionOps>::bool_dilate(
+            self.into_primitive(),
+            kernel.into_primitive(),
+            opts,
         ))
     }
 }
 
 impl Nms for Tensor<2> {
     fn nms(self, scores: Tensor<1>, options: NmsOptions) -> Tensor<1, Int> {
-        let settings = self.device().settings();
-        match (self.into_primitive(), scores.into_primitive()) {
-            (BridgeTensor::Float(boxes), BridgeTensor::Float(scores)) => {
-                Tensor::new(BridgeTensor::Int(<Dispatch as FloatVisionOps>::nms(
-                    boxes,
-                    scores,
-                    options,
-                    settings.int_dtype,
-                )))
-            }
-            _ => unimplemented!("Other inputs are not yet supported"),
+        if matches!(self.dtype(), DType::QFloat(_)) {
+            unimplemented!("Quantized float is not supported");
         }
+
+        let settings = self.device().settings();
+
+        Tensor::from_primitive(<Dispatch as FloatVisionOps>::nms(
+            self.into_primitive(),
+            scores.into_primitive(),
+            options,
+            settings.int_dtype,
+        ))
     }
 }

--- a/examples/custom-cubecl-kernel/src/lib.rs
+++ b/examples/custom-cubecl-kernel/src/lib.rs
@@ -4,7 +4,7 @@ mod kernel;
 
 use burn::{
     backend::{Autodiff, Dispatch, Wgpu, backend_extension, tensor::FloatTensor},
-    tensor::{Tensor, activation, kind::BridgeTensor},
+    tensor::{Tensor, activation},
 };
 
 /// We create our own Backend trait that extends the Burn backend trait.
@@ -23,12 +23,12 @@ pub trait AutodiffBackend: Backend + burn::backend::AutodiffBackend {}
 /// We define our custom implementation using the added function on our custom backend.
 pub fn matmul_add_relu_custom(lhs: Tensor<3>, rhs: Tensor<3>, bias: Tensor<3>) -> Tensor<3> {
     let output = Dispatch::fused_matmul_add_relu(
-        lhs.into_primitive().into(),
-        rhs.into_primitive().into(),
-        bias.into_primitive().into(),
+        lhs.into_primitive(),
+        rhs.into_primitive(),
+        bias.into_primitive(),
     );
 
-    Tensor::from_primitive(BridgeTensor::Float(output))
+    Tensor::from_primitive(output)
 }
 
 /// We define a reference implementation using basic tensor operations.

--- a/examples/custom-wgpu-kernel/src/lib.rs
+++ b/examples/custom-wgpu-kernel/src/lib.rs
@@ -3,7 +3,7 @@ mod forward;
 
 use burn::{
     backend::{Autodiff, Dispatch, Wgpu, backend_extension, tensor::FloatTensor},
-    tensor::{Tensor, activation, kind::BridgeTensor},
+    tensor::{Tensor, activation},
 };
 
 /// We create our own Backend trait that extends the Burn backend trait.
@@ -22,12 +22,12 @@ pub trait AutodiffBackend: Backend + burn::backend::AutodiffBackend {}
 /// We define our custom implementation using the added function on our custom backend.
 pub fn matmul_add_relu_custom(lhs: Tensor<3>, rhs: Tensor<3>, bias: Tensor<3>) -> Tensor<3> {
     let output = Dispatch::fused_matmul_add_relu(
-        lhs.into_primitive().into(),
-        rhs.into_primitive().into(),
-        bias.into_primitive().into(),
+        lhs.into_primitive(),
+        rhs.into_primitive(),
+        bias.into_primitive(),
     );
 
-    Tensor::from_primitive(BridgeTensor::Float(output))
+    Tensor::from_primitive(output)
 }
 
 /// We define a reference implementation using basic tensor operations.


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

#4934

### Changes

- Fixed `burn-dispatch` default backend condition when `wgpu_only`
- Feature-gated `Tensor::from_primitive` and `tensor.into_primitive()` for backend `extension` only so the types are never publicly exported otherwise
  - Also introduced `from_bridge` and `into_bridge` for intermediate bridge layer conversion
  - Added tensor kind / dtype validation (introduced `TensorKindId` enum; linked #4892)

### Testing

Unit tests
