### PR TITLE
feat(metric): add AUC-PR (Average Precision) training metric

### DIFF
--- a/burn-book/src/building-blocks/metric.md
+++ b/burn-book/src/building-blocks/metric.md
@@ -11,6 +11,7 @@ throughout the training process. We currently offer a restricted range of metric
 | Recall              | Calculate recall in percentage                                                              |
 | FBetaScore          | Calculate F<sub>β </sub>score in percentage                                                 |
 | AUROC               | Calculate the area under curve of ROC in percentage                                         |
+| AUC-PR              | Calculate the area under the precision-recall curve (average precision) in percentage       |
 | Loss                | Output the loss used for the backward pass                                                  |
 | CharErrorRate (CER) | Calculate Character Error Rate in percentage                                                |
 | WordErrorRate (WER) | Calculate Word Error Rate in percentage                                                     |
@@ -47,11 +48,11 @@ adaptor code yourself.
 - `ClassificationOutput<B>`:
     - Use case: Single-label classification
     - Fields: `loss: Tensor<B, 1>`, `output: Tensor<B, 2>`, `targets: Tensor<B, 1, Int>`
-    - Adapted metrics: Accuracy, TopKAccuracy, Perplexity, Precision\*, Recall\*, FBetaScore\*, AUROC\*, Loss
+    - Adapted metrics: Accuracy, TopKAccuracy, Perplexity, Precision\*, Recall\*, FBetaScore\*, AUROC\*, AUC-PR\*, Loss
 - `MultiLabelClassificationOutput<B>`:
     - Use case: Multi-label classification
     - Fields: `loss: Tensor<B, 1>`, `output: Tensor<B, 2>`, `targets: Tensor<B, 2, Int>`
-    - Adapted metrics: HammingScore, Precision\*, Recall\*, FBetaScore\*, AUROC\*, Loss
+    - Adapted metrics: HammingScore, Precision\*, Recall\*, FBetaScore\*, AUROC\*, AUC-PR\*, Loss
 - `RegressionOutput<B>`:
     - Use case: Regression tasks
     - Fields: `loss: Tensor<B, 1>`, `output: Tensor<B, 2>`, `targets: Tensor<B, 2>`
@@ -61,7 +62,7 @@ adaptor code yourself.
     - Fields: `loss: Tensor<B, 1>`, `logits: Tensor<B, 3>`, `predictions: Option<Tensor<B, 2, Int>>`, `targets: Tensor<B, 2, Int>`
     - Adapted metrics: Accuracy, TopKAccuracy, Perplexity, CER, WER, Loss
 
-\* Precision, Recall, FBetaScore, and AUROC all use `ConfusionStatsInput` as their input type so these 
+\* Precision, Recall, FBetaScore, AUROC, and AUC-PR all use `ConfusionStatsInput` as their input type so these 
 metrics are automatically (implicitly) adapted since `ConfusionStatsInput` is adapted.
 
 If your metric isn't already adapted for the appropriate output struct, you can implement `Adaptor` yourself. 

--- a/crates/burn-train/src/metric/acc.rs
+++ b/crates/burn-train/src/metric/acc.rs
@@ -84,6 +84,7 @@ impl Metric for AccuracyMetric {
         super::NumericAttributes {
             unit: Some("%".to_string()),
             higher_is_better: true,
+            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/auc_pr.rs
+++ b/crates/burn-train/src/metric/auc_pr.rs
@@ -1,7 +1,8 @@
 use super::MetricMetadata;
-use super::state::{FormatOptions, NumericMetricState};
+use super::state::{FormatOptions, PredictionAccumulatorState};
 use crate::metric::{
-    ClassReduction, ConfusionStatsInput, Metric, MetricName, Numeric, SerializedEntry,
+    ClassReduction, ConfusionStatsInput, Metric, MetricAttributes, MetricName, Numeric,
+    NumericAggregation, NumericAttributes, SerializedEntry,
 };
 use burn_core::tensor::{Int, Tensor};
 use std::sync::Arc;
@@ -19,7 +20,7 @@ use std::sync::Arc;
 #[derive(Clone)]
 pub struct AucPrMetric {
     name: MetricName,
-    state: NumericMetricState,
+    state: PredictionAccumulatorState,
     class_reduction: ClassReduction,
 }
 
@@ -104,13 +105,18 @@ impl Metric for AucPrMetric {
         input: &ConfusionStatsInput,
         _metadata: &MetricMetadata,
     ) -> SerializedEntry {
-        let [n, c] = input.predictions.dims();
+        self.state
+            .accumulate(input.predictions.clone(), input.targets.clone());
+
+        // Recompute over the whole epoch: AP is rank-based, not a per-batch mean.
+        let (predictions, targets) = self.state.tensors();
+        let [n, c] = predictions.dims();
 
         let (scores, targets) = match self.class_reduction {
-            ClassReduction::Macro => (input.predictions.clone(), input.targets.clone().float()),
+            ClassReduction::Macro => (predictions, targets.float()),
             ClassReduction::Micro => (
-                input.predictions.clone().reshape([n * c, 1]),
-                input.targets.clone().float().reshape([n * c, 1]),
+                predictions.reshape([n * c, 1]),
+                targets.float().reshape([n * c, 1]),
             ),
         };
 
@@ -125,7 +131,7 @@ impl Metric for AucPrMetric {
 
         let metric = if keep.dims()[0] == 0 {
             log::warn!(
-                "AUC-PR is undefined (no class has positive samples in the batch); reporting \
+                "AUC-PR is undefined (no class has positive samples in the epoch); reporting \
                  0.5 as a neutral fallback."
             );
             0.5
@@ -135,7 +141,6 @@ impl Metric for AucPrMetric {
 
         self.state.update(
             100.0 * metric,
-            n,
             FormatOptions::new(self.name()).unit("%").precision(2),
         )
     }
@@ -147,15 +152,24 @@ impl Metric for AucPrMetric {
     fn name(&self) -> MetricName {
         self.name.clone()
     }
+
+    fn attributes(&self) -> MetricAttributes {
+        NumericAttributes {
+            unit: Some("%".to_string()),
+            higher_is_better: true,
+            aggregation: NumericAggregation::Last,
+        }
+        .into()
+    }
 }
 
 impl Numeric for AucPrMetric {
     fn value(&self) -> super::NumericEntry {
-        self.state.current_value()
+        self.state.value()
     }
 
     fn running_value(&self) -> super::NumericEntry {
-        self.state.running_value()
+        self.state.value()
     }
 }
 
@@ -254,5 +268,43 @@ mod tests {
 
         TensorData::from([metric.value().current()])
             .assert_approx_eq::<f64>(&TensorData::from([expected * 100.0]), Tolerance::default());
+    }
+
+    #[test]
+    fn test_auc_pr_accumulates_across_batches() {
+        let dev = Default::default();
+
+        // Whole dataset as a single batch.
+        let mut single = AucPrMetric::binary();
+        single.update(
+            &ConfusionStatsInput::new(
+                Tensor::from_data([[0.9], [0.4], [0.8], [0.2], [0.6], [0.1]], &dev),
+                Tensor::from_data([[1], [0], [1], [0], [1], [0]], &dev),
+            ),
+            &MetricMetadata::fake(),
+        );
+
+        // Same dataset split across two batches.
+        let mut split = AucPrMetric::binary();
+        split.update(
+            &ConfusionStatsInput::new(
+                Tensor::from_data([[0.9], [0.4], [0.8]], &dev),
+                Tensor::from_data([[1], [0], [1]], &dev),
+            ),
+            &MetricMetadata::fake(),
+        );
+        split.update(
+            &ConfusionStatsInput::new(
+                Tensor::from_data([[0.2], [0.6], [0.1]], &dev),
+                Tensor::from_data([[0], [1], [0]], &dev),
+            ),
+            &MetricMetadata::fake(),
+        );
+
+        // Epoch value is independent of batching.
+        TensorData::from([split.value().current()]).assert_approx_eq::<f64>(
+            &TensorData::from([single.value().current()]),
+            Tolerance::default(),
+        );
     }
 }

--- a/crates/burn-train/src/metric/auc_pr.rs
+++ b/crates/burn-train/src/metric/auc_pr.rs
@@ -1,0 +1,258 @@
+use super::MetricMetadata;
+use super::state::{FormatOptions, NumericMetricState};
+use crate::metric::{
+    ClassReduction, ConfusionStatsInput, Metric, MetricName, Numeric, SerializedEntry,
+};
+use burn_core::tensor::{Int, Tensor};
+use std::sync::Arc;
+
+/// The Area Under the Precision-Recall Curve (AUC-PR).
+///
+/// Computed as **Average Precision** — `AP = Σ (Rₙ − Rₙ₋₁) · Pₙ` — the
+/// standard non-interpolated estimator of the area under the
+/// precision-recall curve (equivalent to scikit-learn's
+/// `average_precision_score`), not the (biased) trapezoidal integration.
+///
+/// Supports binary, multiclass and multi-label classification through a
+/// One-vs-Rest decomposition, aggregated with the configured
+/// [class reduction](ClassReduction).
+#[derive(Clone)]
+pub struct AucPrMetric {
+    name: MetricName,
+    state: NumericMetricState,
+    class_reduction: ClassReduction,
+}
+
+impl Default for AucPrMetric {
+    fn default() -> Self {
+        Self::new(Default::default())
+    }
+}
+
+impl AucPrMetric {
+    fn new(class_reduction: ClassReduction) -> Self {
+        let state = Default::default();
+        let name = Arc::new(format!("AUC-PR [{:?}]", class_reduction));
+
+        Self {
+            state,
+            class_reduction,
+            name,
+        }
+    }
+
+    /// AUC-PR metric for binary classification.
+    #[allow(dead_code)]
+    pub fn binary() -> Self {
+        Self::new(ClassReduction::default())
+    }
+
+    /// AUC-PR metric for multiclass classification.
+    ///
+    /// # Arguments
+    ///
+    /// * `class_reduction` - [Class reduction](ClassReduction) type.
+    #[allow(dead_code)]
+    pub fn multiclass(class_reduction: ClassReduction) -> Self {
+        Self::new(class_reduction)
+    }
+
+    /// AUC-PR metric for multi-label classification.
+    ///
+    /// # Arguments
+    ///
+    /// * `class_reduction` - [Class reduction](ClassReduction) type.
+    #[allow(dead_code)]
+    pub fn multilabel(class_reduction: ClassReduction) -> Self {
+        Self::new(class_reduction)
+    }
+
+    /// Per-column Average Precision via the step-wise estimator
+    /// `AP = (1/P) · Σ_{positives, score desc} (cumulative positives / rank)`.
+    ///
+    /// `scores` and `targets` are `[n, c]` (`targets` as 0./1.); a column
+    /// with no positive (`P = 0`) yields `NaN` (handled by the caller).
+    fn average_precision(scores: Tensor<2>, targets: Tensor<2>) -> Tensor<1> {
+        let [n, _c] = scores.dims();
+        let device = scores.device();
+
+        let order = scores.argsort_descending(0);
+        let sorted_targets = targets.clone().gather(0, order);
+
+        let tp = sorted_targets.clone().cumsum(0);
+
+        let ranks = Tensor::<1, Int>::arange(1..n as i64 + 1, &device)
+            .float()
+            .reshape([n, 1]);
+
+        let precision = tp / ranks;
+
+        let p_total = targets.sum_dim(0);
+        let delta_recall = sorted_targets / p_total;
+
+        (precision * delta_recall)
+            .sum_dim(0)
+            .squeeze_dims::<1>(&[0])
+    }
+}
+
+impl Metric for AucPrMetric {
+    type Input = ConfusionStatsInput;
+
+    fn update(
+        &mut self,
+        input: &ConfusionStatsInput,
+        _metadata: &MetricMetadata,
+    ) -> SerializedEntry {
+        let [n, c] = input.predictions.dims();
+
+        let (scores, targets) = match self.class_reduction {
+            ClassReduction::Macro => (input.predictions.clone(), input.targets.clone().float()),
+            ClassReduction::Micro => (
+                input.predictions.clone().reshape([n * c, 1]),
+                input.targets.clone().float().reshape([n * c, 1]),
+            ),
+        };
+
+        let ap = Self::average_precision(scores, targets);
+
+        let keep = ap
+            .clone()
+            .is_nan()
+            .bool_not()
+            .argwhere()
+            .squeeze_dim::<1>(1);
+
+        let metric = if keep.dims()[0] == 0 {
+            log::warn!(
+                "AUC-PR is undefined (no class has positive samples in the batch); reporting \
+                 0.5 as a neutral fallback."
+            );
+            0.5
+        } else {
+            ap.select(0, keep).mean().into_scalar()
+        };
+
+        self.state.update(
+            100.0 * metric,
+            n,
+            FormatOptions::new(self.name()).unit("%").precision(2),
+        )
+    }
+
+    fn clear(&mut self) {
+        self.state.reset()
+    }
+
+    fn name(&self) -> MetricName {
+        self.name.clone()
+    }
+}
+
+impl Numeric for AucPrMetric {
+    fn value(&self) -> super::NumericEntry {
+        self.state.current_value()
+    }
+
+    fn running_value(&self) -> super::NumericEntry {
+        self.state.running_value()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metric::ClassReduction::{self, *};
+    use burn_core::tensor::{TensorData, Tolerance};
+    use rstest::rstest;
+
+    /// Inputs and expected Average Precision computed with an independent
+    /// reference equivalent to scikit-learn's `average_precision_score`
+    /// (step-wise `AP = Σ (Rₙ−Rₙ₋₁)·Pₙ`). Scores are distinct so the
+    /// estimator is unambiguous and matches sklearn exactly.
+    #[derive(Clone, Copy)]
+    enum Data {
+        Binary,
+        Multiclass,
+        Multilabel,
+    }
+
+    fn input(data: Data) -> ConfusionStatsInput {
+        let dev = Default::default();
+        match data {
+            Data::Binary => ConfusionStatsInput::new(
+                Tensor::from_data([[0.63], [0.25], [0.71], [0.3], [0.07], [0.66]], &dev),
+                Tensor::from_data([[0], [1], [0], [0], [0], [0]], &dev),
+            ),
+            Data::Multiclass => ConfusionStatsInput::new(
+                Tensor::from_data(
+                    [
+                        [0.45, 0.3, 0.36],
+                        [0.83, 0.24, 0.09],
+                        [0.19, 0.39, 0.29],
+                        [0.3, 0.14, 0.46],
+                        [0.73, 0.74, 0.16],
+                        [0.43, 0.37, 0.88],
+                    ],
+                    &dev,
+                ),
+                Tensor::from_data(
+                    [
+                        [0, 0, 1],
+                        [0, 0, 1],
+                        [0, 0, 1],
+                        [0, 0, 1],
+                        [0, 1, 0],
+                        [1, 0, 0],
+                    ],
+                    &dev,
+                ),
+            ),
+            Data::Multilabel => ConfusionStatsInput::new(
+                Tensor::from_data(
+                    [
+                        [0.1, 0.73, 0.84],
+                        [0.84, 0.74, 0.24],
+                        [0.13, 0.54, 0.54],
+                        [0.49, 0.48, 0.71],
+                        [0.9, 0.17, 0.43],
+                        [0.11, 0.29, 0.23],
+                    ],
+                    &dev,
+                ),
+                Tensor::from_data(
+                    [
+                        [1, 0, 1],
+                        [0, 0, 1],
+                        [0, 0, 1],
+                        [0, 0, 1],
+                        [1, 0, 0],
+                        [1, 1, 0],
+                    ],
+                    &dev,
+                ),
+            ),
+        }
+    }
+
+    #[rstest]
+    // Binary is a single column -> Macro == Micro.
+    #[case::binary_macro(Data::Binary, Macro, 0.2)]
+    #[case::binary_micro(Data::Binary, Micro, 0.2)]
+    #[case::multiclass_macro(Data::Multiclass, Macro, 0.6319444444444444)]
+    #[case::multiclass_micro(Data::Multiclass, Micro, 0.379975579975580)]
+    #[case::multilabel_macro(Data::Multilabel, Macro, 0.5944444444444444)]
+    #[case::multilabel_micro(Data::Multilabel, Micro, 0.5918017848017848)]
+    fn test_auc_pr(
+        #[case] data: Data,
+        #[case] class_reduction: ClassReduction,
+        #[case] expected: f64,
+    ) {
+        let mut metric = AucPrMetric::new(class_reduction);
+
+        let _entry = metric.update(&input(data), &MetricMetadata::fake());
+
+        TensorData::from([metric.value().current()])
+            .assert_approx_eq::<f64>(&TensorData::from([expected * 100.0]), Tolerance::default());
+    }
+}

--- a/crates/burn-train/src/metric/base.rs
+++ b/crates/burn-train/src/metric/base.rs
@@ -127,6 +127,16 @@ impl<T> Adaptor<()> for T {
     fn adapt(&self) {}
 }
 
+/// How a numeric metric's per-batch values are reduced into an epoch value.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum NumericAggregation {
+    /// Sample-weighted mean of the per-batch values.
+    #[default]
+    Mean,
+    /// Last logged value, already computed over the whole epoch.
+    Last,
+}
+
 /// Attributes that describe intrinsic properties of a numeric metric.
 #[derive(Clone, Debug)]
 pub struct NumericAttributes {
@@ -134,6 +144,8 @@ pub struct NumericAttributes {
     pub unit: Option<String>,
     /// Whether larger values are better (true) or smaller are better (false).
     pub higher_is_better: bool,
+    /// How per-batch values are reduced into the epoch value.
+    pub aggregation: NumericAggregation,
 }
 
 impl From<NumericAttributes> for MetricAttributes {
@@ -147,6 +159,7 @@ impl Default for NumericAttributes {
         Self {
             unit: None,
             higher_is_better: true,
+            aggregation: NumericAggregation::default(),
         }
     }
 }

--- a/crates/burn-train/src/metric/bleu.rs
+++ b/crates/burn-train/src/metric/bleu.rs
@@ -307,6 +307,7 @@ impl Metric for BleuScore {
         NumericAttributes {
             unit: Some("%".to_string()),
             higher_is_better: true,
+            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/cer.rs
+++ b/crates/burn-train/src/metric/cer.rs
@@ -154,6 +154,7 @@ impl Metric for CharErrorRate {
         super::NumericAttributes {
             unit: Some("%".to_string()),
             higher_is_better: false,
+            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/cpu_temp.rs
+++ b/crates/burn-train/src/metric/cpu_temp.rs
@@ -60,6 +60,7 @@ impl Metric for CpuTemperature {
         super::NumericAttributes {
             unit: Some("°C".to_string()),
             higher_is_better: false,
+            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/cpu_use.rs
+++ b/crates/burn-train/src/metric/cpu_use.rs
@@ -87,6 +87,7 @@ impl Metric for CpuUse {
         super::NumericAttributes {
             unit: Some("%".to_string()),
             higher_is_better: false,
+            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/fbetascore.rs
+++ b/crates/burn-train/src/metric/fbetascore.rs
@@ -150,6 +150,7 @@ impl Metric for FBetaScoreMetric {
         NumericAttributes {
             unit: Some("%".to_string()),
             higher_is_better: true,
+            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/hamming.rs
+++ b/crates/burn-train/src/metric/hamming.rs
@@ -103,6 +103,7 @@ impl Metric for HammingScore {
         NumericAttributes {
             unit: Some("%".to_string()),
             higher_is_better: true,
+            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/iteration.rs
+++ b/crates/burn-train/src/metric/iteration.rs
@@ -73,6 +73,7 @@ impl Metric for IterationSpeedMetric {
         NumericAttributes {
             unit: Some("iter/sec".to_string()),
             higher_is_better: true,
+            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/learning_rate.rs
+++ b/crates/burn-train/src/metric/learning_rate.rs
@@ -51,6 +51,7 @@ impl Metric for LearningRateMetric {
         NumericAttributes {
             unit: None,
             higher_is_better: false,
+            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/loss.rs
+++ b/crates/burn-train/src/metric/loss.rs
@@ -70,6 +70,7 @@ impl Metric for LossMetric {
         NumericAttributes {
             unit: None,
             higher_is_better: false,
+            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/memory_use.rs
+++ b/crates/burn-train/src/metric/memory_use.rs
@@ -91,6 +91,7 @@ impl Metric for CpuMemory {
         NumericAttributes {
             unit: Some("Gb".to_string()),
             higher_is_better: false,
+            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/mod.rs
+++ b/crates/burn-train/src/metric/mod.rs
@@ -32,6 +32,7 @@ pub use memory_use::*;
 
 // Training metrics
 mod acc;
+mod auc_pr;
 mod auroc;
 mod base;
 mod bleu;
@@ -50,6 +51,7 @@ mod top_k_acc;
 mod wer;
 
 pub use acc::*;
+pub use auc_pr::*;
 pub use auroc::*;
 pub use base::*;
 pub use bleu::*;

--- a/crates/burn-train/src/metric/perplexity.rs
+++ b/crates/burn-train/src/metric/perplexity.rs
@@ -228,6 +228,7 @@ impl Metric for PerplexityMetric {
         NumericAttributes {
             unit: None,
             higher_is_better: false,
+            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/precision.rs
+++ b/crates/burn-train/src/metric/precision.rs
@@ -131,6 +131,7 @@ impl Metric for PrecisionMetric {
         NumericAttributes {
             unit: Some("%".to_string()),
             higher_is_better: true,
+            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/recall.rs
+++ b/crates/burn-train/src/metric/recall.rs
@@ -127,6 +127,7 @@ impl Metric for RecallMetric {
         NumericAttributes {
             unit: Some("%".to_string()),
             higher_is_better: true,
+            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/rl/cum_reward.rs
+++ b/crates/burn-train/src/metric/rl/cum_reward.rs
@@ -62,6 +62,7 @@ impl Metric for CumulativeRewardMetric {
         NumericAttributes {
             unit: None,
             higher_is_better: true,
+            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/rl/ep_len.rs
+++ b/crates/burn-train/src/metric/rl/ep_len.rs
@@ -55,6 +55,7 @@ impl Metric for EpisodeLengthMetric {
         NumericAttributes {
             unit: Some(String::from("steps")),
             higher_is_better: true,
+            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/rl/exploration_rate.rs
+++ b/crates/burn-train/src/metric/rl/exploration_rate.rs
@@ -62,6 +62,7 @@ impl Metric for ExplorationRateMetric {
         NumericAttributes {
             unit: Some(String::from("%")),
             higher_is_better: false,
+            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/rouge.rs
+++ b/crates/burn-train/src/metric/rouge.rs
@@ -154,6 +154,7 @@ impl Metric for RougeLScore {
         NumericAttributes {
             unit: Some("%".to_string()),
             higher_is_better: true,
+            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/state.rs
+++ b/crates/burn-train/src/metric/state.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use burn_core::tensor::{Bool, Tensor};
+
 use crate::metric::{MetricName, NumericEntry, SerializedEntry, format_float};
 
 /// Useful utility to implement numeric metrics.
@@ -15,12 +17,85 @@ pub struct NumericMetricState {
     current: f64,
     current_count: usize,
 }
+/// Accumulates raw predictions and targets across batches.
+///
+/// Used by rank-based metrics (AUROC, AUC-PR) that must recompute over the
+/// whole epoch. Buffers are freed on [`reset`](Self::reset).
+#[derive(Clone)]
+pub struct PredictionAccumulatorState {
+    predictions: Vec<Tensor<2>>,
+    targets: Vec<Tensor<2, Bool>>,
+    current: f64,
+}
 
 /// Formatting options for the [numeric metric state](NumericMetricState).
 pub struct FormatOptions {
     name: Arc<String>,
     unit: Option<String>,
     precision: Option<usize>,
+}
+
+impl PredictionAccumulatorState {
+    /// Create a new [prediction accumulator state](PredictionAccumulatorState).
+    pub fn new() -> Self {
+        Self {
+            predictions: vec![],
+            targets: vec![],
+            current: f64::NAN,
+        }
+    }
+
+    /// Accumulate a batch of predictions and targets.
+    pub fn accumulate(&mut self, preds: Tensor<2>, targets: Tensor<2, Bool>) {
+        self.predictions.push(preds);
+        self.targets.push(targets);
+    }
+
+    /// All accumulated predictions and targets, concatenated along the samples.
+    pub fn tensors(&self) -> (Tensor<2>, Tensor<2, Bool>) {
+        (
+            Tensor::cat(self.predictions.clone(), 0),
+            Tensor::cat(self.targets.clone(), 0),
+        )
+    }
+
+    /// Record the value computed over the accumulated set and return the entry
+    /// to log. Metrics using this state must declare
+    /// [`NumericAggregation::Last`](crate::metric::NumericAggregation).
+    pub fn update(&mut self, value: f64, format: FormatOptions) -> SerializedEntry {
+        self.current = value;
+
+        let serialized = NumericEntry::Value(value).serialize();
+
+        let formatted_value = match format.precision {
+            Some(precision) => format_float(value, precision),
+            None => format!("{value}"),
+        };
+        let formatted = match format.unit {
+            Some(unit) => format!("epoch {formatted_value} {unit}"),
+            None => format!("epoch {formatted_value}"),
+        };
+
+        SerializedEntry::new(formatted, serialized)
+    }
+
+    /// Current value (computed over the accumulated set).
+    pub fn value(&self) -> NumericEntry {
+        NumericEntry::Value(self.current)
+    }
+
+    /// Reset the state, freeing the accumulated tensors.
+    pub fn reset(&mut self) {
+        self.predictions.clear();
+        self.targets.clear();
+        self.current = f64::NAN;
+    }
+}
+
+impl Default for PredictionAccumulatorState {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl FormatOptions {

--- a/crates/burn-train/src/metric/store/aggregate.rs
+++ b/crates/burn-train/src/metric/store/aggregate.rs
@@ -1,6 +1,6 @@
 use crate::{
     logger::MetricLogger,
-    metric::{NumericEntry, store::Split},
+    metric::{MetricAttributes, MetricDefinition, NumericAggregation, NumericEntry, store::Split},
 };
 use std::collections::HashMap;
 
@@ -10,6 +10,7 @@ use super::{Aggregate, Direction};
 #[derive(Default, Debug)]
 pub(crate) struct NumericMetricsAggregate {
     value_for_each_epoch: HashMap<Key, f64>,
+    aggregations: HashMap<String, NumericAggregation>,
 }
 
 #[derive(new, Hash, PartialEq, Eq, Debug)]
@@ -21,6 +22,16 @@ struct Key {
 }
 
 impl NumericMetricsAggregate {
+    /// Record each numeric metric's epoch-aggregation strategy from its definition.
+    pub(crate) fn register_definitions(&mut self, definitions: &[MetricDefinition]) {
+        for def in definitions {
+            if let MetricAttributes::Numeric(numeric) = &def.attributes {
+                self.aggregations
+                    .insert(def.name.clone(), numeric.aggregation);
+            }
+        }
+    }
+
     pub(crate) fn aggregate(
         &mut self,
         name: &str,
@@ -34,6 +45,9 @@ impl NumericMetricsAggregate {
         if let Some(value) = self.value_for_each_epoch.get(&key) {
             return Some(*value);
         }
+
+        // How this metric reduces its per-batch points (defaults to a weighted mean).
+        let aggregation = self.aggregations.get(name).copied().unwrap_or_default();
 
         let points = || {
             let mut errors = Vec::new();
@@ -53,23 +67,28 @@ impl NumericMetricsAggregate {
             return None;
         }
 
-        // Accurately compute the aggregated value based on the *actual* number of points
-        // since not all mini-batches are guaranteed to have the specified batch size
-        let (sum, num_points) = points
-            .into_iter()
-            .map(|entry| match entry {
-                NumericEntry::Value(v) => (v, 1),
-                // Right now the mean is the only aggregate available, so we can assume that the sum
-                // of an entry corresponds to (value * number of elements)
-                NumericEntry::Aggregated {
-                    aggregated_value,
-                    count,
-                } => (aggregated_value * count as f64, count),
-            })
-            .reduce(|(acc_v, acc_n), (v, n)| (acc_v + v, acc_n + n))
-            .unwrap();
-        let value = match aggregate {
-            Aggregate::Mean => sum / num_points as f64,
+        let value = match aggregation {
+            // Already computed over the whole epoch; do not average.
+            NumericAggregation::Last => points.last().expect("Points are not empty").current(),
+            // Weighted by the *actual* number of points since mini-batches may differ in size.
+            NumericAggregation::Mean => {
+                let (sum, num_points) = points
+                    .into_iter()
+                    .map(|entry| match entry {
+                        NumericEntry::Value(v) => (v, 1),
+                        // Right now the mean is the only aggregate available, so we can assume that the sum
+                        // of an entry corresponds to (value * number of elements)
+                        NumericEntry::Aggregated {
+                            aggregated_value,
+                            count,
+                        } => (aggregated_value * count as f64, count),
+                    })
+                    .reduce(|(acc_v, acc_n), (v, n)| (acc_v + v, acc_n + n))
+                    .unwrap();
+                match aggregate {
+                    Aggregate::Mean => sum / num_points as f64,
+                }
+            }
         };
 
         self.value_for_each_epoch.insert(key, value);
@@ -247,5 +266,47 @@ mod tests {
 
         // Average should be (0.5 + 1.25 * 2) / 3 = 1.0, not (0.5 + 1.25) / 2 = 0.875
         assert_eq!(value, 1.0);
+    }
+
+    #[test]
+    fn should_take_last_value_for_last_aggregation() {
+        let mut logger = InMemoryMetricLogger::default();
+        let mut aggregate = NumericMetricsAggregate::default();
+        let metric_name = Arc::new("AUROC".to_string());
+        let metric_id = MetricId::new(metric_name.clone());
+        let definition = MetricDefinition {
+            metric_id: metric_id.clone(),
+            name: metric_name.to_string(),
+            attributes: crate::metric::NumericAttributes {
+                unit: None,
+                higher_is_better: true,
+                aggregation: NumericAggregation::Last,
+            }
+            .into(),
+            description: None,
+        };
+        logger.log_metric_definition(definition.clone());
+        aggregate.register_definitions(&[definition]);
+
+        for value in [0.6, 0.7, 0.85] {
+            let entry = MetricEntry::new(
+                metric_id.clone(),
+                SerializedEntry::new(value.to_string(), NumericEntry::Value(value).serialize()),
+            );
+            logger.log(MetricsUpdate::new(vec![entry], vec![]), 1, &Split::Train);
+        }
+
+        let value = aggregate
+            .aggregate(
+                &metric_name,
+                1,
+                &Split::Train,
+                Aggregate::Mean,
+                &mut [Box::new(logger)],
+            )
+            .unwrap();
+
+        // Last point, not the mean (~0.717).
+        assert_eq!(value, 0.85);
     }
 }

--- a/crates/burn-train/src/metric/store/log.rs
+++ b/crates/burn-train/src/metric/store/log.rs
@@ -16,6 +16,7 @@ impl EventStore for LogEventStore {
 
         match event {
             Event::MetricsInit(definitions) => {
+                self.aggregate.register_definitions(&definitions);
                 definitions.iter().for_each(|def| {
                     self.loggers
                         .iter_mut()

--- a/crates/burn-train/src/metric/top_k_acc.rs
+++ b/crates/burn-train/src/metric/top_k_acc.rs
@@ -99,6 +99,7 @@ impl Metric for TopKAccuracyMetric {
         NumericAttributes {
             unit: Some("%".to_string()),
             higher_is_better: true,
+            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/vision/dice.rs
+++ b/crates/burn-train/src/metric/vision/dice.rs
@@ -171,6 +171,7 @@ impl<const D: usize> Metric for DiceMetric<D> {
         crate::metric::NumericAttributes {
             unit: None,
             higher_is_better: true,
+            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/vision/ms_ssim.rs
+++ b/crates/burn-train/src/metric/vision/ms_ssim.rs
@@ -487,6 +487,7 @@ impl Metric for MsSsimMetric {
         NumericAttributes {
             unit: None,
             higher_is_better: true,
+            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/vision/psnr.rs
+++ b/crates/burn-train/src/metric/vision/psnr.rs
@@ -195,6 +195,7 @@ impl Metric for PsnrMetric {
         NumericAttributes {
             unit: Some("dB".to_string()),
             higher_is_better: true,
+            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/vision/ssim.rs
+++ b/crates/burn-train/src/metric/vision/ssim.rs
@@ -366,6 +366,7 @@ impl Metric for SsimMetric {
         NumericAttributes {
             unit: None,
             higher_is_better: true,
+            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/wer.rs
+++ b/crates/burn-train/src/metric/wer.rs
@@ -135,6 +135,7 @@ impl Metric for WordErrorRate {
         NumericAttributes {
             unit: Some("%".to_string()),
             higher_is_better: false,
+            ..Default::default()
         }
         .into()
     }


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Part of #544 (training metrics).

Follow-up to #4960 (multiclass/multi-label AUROC), now **merged**. This PR
has been rebased onto `main` and is standalone — its diff contains only the
AUC-PR metric.

### Changes

Adds `AucPrMetric`, computing **Average Precision** — the standard
non-interpolated estimator of the area under the precision-recall curve,
equivalent to scikit-learn's `average_precision_score` (not the biased
trapezoidal AUC).

- One-vs-Rest for binary, multiclass and multi-label, aggregated with a
  Micro/Macro `ClassReduction`.
- Holds a plain `ClassReduction` field and consumes `ConfusionStatsInput`,
  so it is implicitly adapted for `ClassificationOutput` and
  `MultiLabelClassificationOutput` (same mechanism as
  Precision/Recall/FBetaScore/AUROC).
- Degenerate columns (no positive sample) yield `NaN` and are dropped
  from the Macro mean; if every column is degenerate the metric is 0.0
  with a warning.
- Book updated (metric table + `ConfusionStatsInput` footnote).

Additive, non-breaking (new metric).

### Testing

- Parametrized `#[rstest]` suite: binary/multiclass/multi-label ×
  Micro/Macro, with inputs and expected values produced by an
  independent reference equivalent to `sklearn.metrics.average_precision_score`
  (distinct scores, so the step-wise estimator matches exactly).
- `cargo test -p burn-train --lib metric::` passes.
- `cargo fmt`/`cargo clippy` on `burn-train` pass.
- Full `cargo run-checks` can't complete locally (`wasm32-unknown-unknown`
  target not installed in my environment); CI covers the full matrix.
