### PR TITLE
Fix dispatch webgpu re-export

### DIFF
--- a/crates/burn-dispatch/src/lib.rs
+++ b/crates/burn-dispatch/src/lib.rs
@@ -80,8 +80,10 @@ pub mod backends {
     pub use burn_wgpu::Metal;
     #[cfg(wgpu_vulkan)]
     pub use burn_wgpu::Vulkan;
+    #[cfg(all(wgpu_webgpu, feature = "webgpu"))]
+    pub use burn_wgpu::WebGpu;
     #[cfg(wgpu_webgpu)]
-    pub use burn_wgpu::{WebGpu, Wgpu};
+    pub use burn_wgpu::Wgpu;
 
     #[cfg(feature = "flex")]
     pub use burn_flex as flex;


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs
When trying `cargo test-wgpu`:
```
error[E0432]: unresolved import `burn_wgpu::WebGpu`
   --> crates/burn-dispatch/src/lib.rs:84:25
    |
 84 |     pub use burn_wgpu::{WebGpu, Wgpu};
    |                         ^^^^^^ no `WebGpu` in the root
    |
```

This is likely due to changes in the `build.rs` when only `wgpu` feature is enabled.

### Changes

Changed the feature gate for `Wgpu` and `WebGpu`.

