### PR TITLE
nn: add LinearTernary — ternary-quantized linear layer {-1, 0, +1}

### DIFF
--- a/crates/burn-nn/src/modules/linear.rs
+++ b/crates/burn-nn/src/modules/linear.rs
@@ -2,7 +2,7 @@ use burn_core as burn;
 
 use burn::config::Config;
 use burn::module::Param;
-use burn::module::{Content, DisplaySettings, Initializer, Module, ModuleDisplay};
+use burn::module::{Content, DisplaySettings, Initializer, Module, ModuleDisplay, ParamId};
 use burn::tensor::module::linear;
 use burn::tensor::{Device, Tensor};
 
@@ -135,6 +135,118 @@ impl Linear {
 }
 
 impl ModuleDisplay for Linear {
+    fn custom_settings(&self) -> Option<DisplaySettings> {
+        DisplaySettings::new()
+            .with_new_line_after_attribute(false)
+            .optional()
+    }
+
+    fn custom_content(&self, content: Content) -> Option<Content> {
+        let [d_input, d_output] = self.weight.shape().dims();
+        content
+            .add("d_input", &d_input)
+            .add("d_output", &d_output)
+            .add("bias", &self.bias.is_some())
+            .optional()
+    }
+}
+
+/// Configuration to create a [`LinearTernary`] layer using the [init function](LinearTernaryConfig::init).
+#[derive(Config, Debug)]
+pub struct LinearTernaryConfig {
+    /// The size of the input features.
+    pub d_input: usize,
+    /// The size of the output features.
+    pub d_output: usize,
+    /// If a bias should be applied during the linear transformation.
+    #[config(default = true)]
+    pub bias: bool,
+    /// Weight quantization threshold. `None` uses the mean absolute weight value
+    /// (BitNet b1.58 rule: <https://arxiv.org/abs/2402.17764> §3.1).
+    /// `Some(0.0)` maps all weights to ±1 (no zeros).
+    #[config(default = "None")]
+    pub threshold: Option<f32>,
+    /// The type of function used to initialize neural network parameters before quantization.
+    #[config(
+        default = "Initializer::KaimingUniform{gain:1.0/num_traits::Float::sqrt(3.0), fan_out_only:false}"
+    )]
+    pub initializer: Initializer,
+}
+
+/// Applies a linear transformation using weights quantized to {-1, 0, +1}.
+///
+/// A drop-in replacement for [`Linear`] for ternary-weight models (BitNet b1.58, et al.).
+/// Weights are quantized at init time and remain frozen as {-1, 0, +1}. The forward pass is
+/// numerically identical to [`Linear`] — the sparsity benefit is realized by backends that
+/// specialize `linear()` on ternary weight tensors.
+///
+/// Quantization rule:
+/// ```text
+/// w_ternary = sign(w)  if |w| > threshold
+///             0        otherwise
+/// ```
+/// where `threshold` defaults to `mean(|w|)` across the weight matrix (BitNet b1.58 §3.1).
+///
+/// Should be created with [`LinearTernaryConfig`].
+#[derive(Module, Debug)]
+#[module(custom_display)]
+pub struct LinearTernary {
+    /// Ternary weight matrix of shape `[d_input, d_output]`. All values are in {-1, 0, +1}.
+    pub weight: Param<Tensor<2>>,
+    /// Optional bias vector of size `d_output`.
+    pub bias: Option<Param<Tensor<1>>>,
+}
+
+impl LinearTernaryConfig {
+    /// Initialize a new [`LinearTernary`] module.
+    pub fn init(&self, device: &Device) -> LinearTernary {
+        let shape = [self.d_input, self.d_output];
+        let raw: Param<Tensor<2>> = self
+            .initializer
+            .init_with(shape, Some(self.d_input), Some(self.d_output), device);
+
+        let w = raw.val();
+        let abs_w = w.clone().abs();
+        let threshold: f32 = match self.threshold {
+            Some(t) => t,
+            None => abs_w.clone().mean().into_scalar::<f32>(),
+        };
+        let zero_mask = abs_w.lower_equal_elem(threshold);
+        let ternary = w.sign().mask_fill(zero_mask, 0.0_f32);
+        let weight = Param::initialized(ParamId::new(), ternary);
+
+        let bias = if self.bias {
+            Some(self.initializer.init_with(
+                [self.d_output],
+                Some(self.d_input),
+                Some(self.d_output),
+                device,
+            ))
+        } else {
+            None
+        };
+
+        LinearTernary { weight, bias }
+    }
+}
+
+impl LinearTernary {
+    /// Applies the forward pass on the input tensor.
+    ///
+    /// # Shapes
+    ///
+    /// - input: `[..., d_input]`
+    /// - output: `[..., d_output]`
+    pub fn forward<const D: usize>(&self, input: Tensor<D>) -> Tensor<D> {
+        linear(
+            input,
+            self.weight.val(),
+            self.bias.as_ref().map(|b| b.val()),
+        )
+    }
+}
+
+impl ModuleDisplay for LinearTernary {
     fn custom_settings(&self) -> Option<DisplaySettings> {
         DisplaySettings::new()
             .with_new_line_after_attribute(false)
@@ -336,5 +448,108 @@ mod tests {
         let data_2 = value.into_data();
 
         data_1.assert_approx_eq::<f32>(&data_2, Default::default());
+    }
+
+    // --- LinearTernary tests ---
+
+    #[test]
+    fn ternary_weights_are_ternary() {
+        let device = Device::default();
+        device.seed(0);
+        let layer = LinearTernaryConfig::new(8, 16).init(&device);
+        let values: Vec<f32> = layer.weight.to_data().to_vec().unwrap();
+        for v in &values {
+            assert!(
+                *v == -1.0 || *v == 0.0 || *v == 1.0,
+                "weight {v} is not in {{-1, 0, 1}}"
+            );
+        }
+    }
+
+    #[test]
+    fn ternary_output_shape() {
+        let device = Device::default();
+        device.seed(0);
+        let layer = LinearTernaryConfig::new(4, 8).init(&device);
+        let input = Tensor::<2>::ones(Shape::new([2, 4]), &device);
+        let out = layer.forward(input);
+        assert_eq!(out.dims(), [2, 8]);
+    }
+
+    #[test]
+    fn ternary_threshold_zero_no_zeros() {
+        // threshold=0.0 → |w| > 0 for all Kaiming-initialised weights → all ±1
+        let device = Device::default();
+        device.seed(0);
+        let layer = LinearTernaryConfig::new(8, 16)
+            .with_threshold(Some(0.0))
+            .init(&device);
+        let values: Vec<f32> = layer.weight.to_data().to_vec().unwrap();
+        assert!(
+            values.iter().all(|v| *v == 1.0 || *v == -1.0),
+            "expected no zero weights with threshold=0.0"
+        );
+    }
+
+    #[test]
+    fn ternary_threshold_large_all_zeros() {
+        let device = Device::default();
+        device.seed(0);
+        let layer = LinearTernaryConfig::new(4, 4)
+            .with_threshold(Some(1e9))
+            .init(&device);
+        let values: Vec<f32> = layer.weight.to_data().to_vec().unwrap();
+        assert!(
+            values.iter().all(|v| *v == 0.0),
+            "expected all-zero weights with threshold=1e9"
+        );
+    }
+
+    #[test]
+    fn ternary_forward_matches_manual() {
+        // 2-input, 2-output layer with hand-crafted weights and no bias.
+        // weight = [[1, -1], [0, 1]]  (d_input=2, d_output=2)
+        // input  = [[2, 3]]
+        // expected output = [[2*1 + 3*0, 2*(-1) + 3*1]] = [[2, 1]]
+        let device = Device::default();
+        let w_data: Vec<f32> = vec![1.0, -1.0, 0.0, 1.0];
+        let w = Tensor::<2>::from_data(
+            burn::tensor::TensorData::new(w_data, Shape::new([2, 2])),
+            &device,
+        );
+        let layer = LinearTernary {
+            weight: Param::initialized(ParamId::new(), w),
+            bias: None,
+        };
+        let input = Tensor::<2>::from_data(
+            burn::tensor::TensorData::new(vec![2.0_f32, 3.0], Shape::new([1, 2])),
+            &device,
+        );
+        let expected = Tensor::<2>::from_data(
+            burn::tensor::TensorData::new(vec![2.0_f32, 1.0], Shape::new([1, 2])),
+            &device,
+        );
+        let out = layer.forward(input);
+        out.into_data()
+            .assert_approx_eq::<f32>(&expected.into_data(), Tolerance::default());
+    }
+
+    #[test]
+    fn ternary_no_bias() {
+        let device = Device::default();
+        let layer = LinearTernaryConfig::new(4, 4)
+            .with_bias(false)
+            .init(&device);
+        assert!(layer.bias.is_none());
+    }
+
+    #[test]
+    fn ternary_display() {
+        let config = LinearTernaryConfig::new(3, 5);
+        let layer = config.init(&Default::default());
+        assert_eq!(
+            alloc::format!("{layer}"),
+            "LinearTernary {d_input: 3, d_output: 5, bias: true, params: 20}"
+        );
     }
 }


### PR DESCRIPTION
## What

Adds `LinearTernary` and `LinearTernaryConfig` to `crates/burn-nn/src/modules/linear.rs` — a drop-in replacement for `Linear` that stores weights quantized to `{-1, 0, +1}`.

## Why

Ternary-weight models (BitNet b1.58 and successors) train directly in `{-γ, 0, +γ}` rather than quantizing post-training. At ≥50% sparsity, zero weights are dead MACs — no multiply needed. Providing the primitive in `burn-nn` lets any model author write:

```rust
let layer = LinearTernaryConfig::new(d_in, d_out).init(&device);
```

and immediately get a ternary-weight layer that works on every existing backend today. Backends can later specialize `linear()` on ternary-valued weight tensors to realize the compute savings at the hardware level.

## Design

```rust
let layer = LinearTernaryConfig::new(in_features, out_features)
    .with_bias(true)           // default true
    .with_threshold(None)      // default: mean(|w|) — BitNet b1.58 §3.1
    .init(&device);
```

Quantization at init time (weights are frozen after this):

```
w_ternary = sign(w)   if |w| > threshold
            0         otherwise
```

- `threshold=None` (default): uses mean absolute weight value as threshold (BitNet b1.58 arxiv.org/abs/2402.17764 §3.1)
- `threshold=Some(0.0)`: all weights become ±1, no zeros
- `threshold=Some(1e9)`: all weights become 0 (degenerate case, useful for tests)

Stored as `float32` — forward pass is identical to `Linear`, works on every backend today.

## Tests

Seven unit tests in the existing `linear.rs` test module:

| Test | Checks |
|------|--------|
| `ternary_weights_are_ternary` | all values in `{-1, 0, 1}` after init |
| `ternary_output_shape` | `[batch, d_output]` correct |
| `ternary_threshold_zero_no_zeros` | `threshold=0.0` → no zero weights |
| `ternary_threshold_large_all_zeros` | `threshold=1e9` → all zeros |
| `ternary_forward_matches_manual` | hand-computed 2×2 result |
| `ternary_no_bias` | `with_bias(false)` → `None` |
| `ternary_display` | display string format |

All 7 pass (`cargo test -p burn-nn ternary`).

## Reference

- BitNet b1.58: https://arxiv.org/abs/2402.17764
- Related prior art: tinygrad `TernaryLinear` (tinygrad/tinygrad#16281), candle `LinearTernary` (huggingface/candle#3554)

🤖 Generated with [Claude Code](https://claude.com/claude-code)