### PR TITLE
Fix fusion resolve tensor into_ir (re-entrancy bug)

### DIFF
--- a/crates/burn-backend-tests/tests/memory_cleaning.rs
+++ b/crates/burn-backend-tests/tests/memory_cleaning.rs
@@ -39,7 +39,7 @@ mod fusion {
 
     use super::*;
     use burn_fusion::inspect::FusionInspector;
-    use burn_tensor::{Device, StreamId};
+    use burn_tensor::{Device, StreamId, Transaction};
     use serial_test::serial;
     use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -978,6 +978,52 @@ mod fusion {
             assert_no_leaked_handles(
                 &inspector,
                 "both streams holding pending work on a shared tensor must converge cleanly",
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn transaction_cross_stream_no_reentrant_panic() {
+        let owner = test_stream();
+        let peer = test_stream();
+
+        owner.executes(|| {
+            let device = Default::default();
+            let inspector = install_and_baseline(&device, owner);
+
+            // Create and compute a tensor on the owner stream, leave it un-drained.
+            let a = TestTensor::<2>::ones([4, 4], &device);
+            let b = (a.clone() + 1.0) * 2.0;
+
+            // Execute the transaction from the peer stream, `b.stream == owner` but
+            // `current == peer`, so `resolve_tensor_float` hits the cross-stream mismatch
+            // and previously called `into_ir()` inside the `submit_blocking` closure,
+            // triggering the re-entrancy panic.
+            let [data] = peer.executes(|| {
+                Transaction::default()
+                    .register(b)
+                    .execute()
+                    .try_into()
+                    .unwrap()
+            });
+
+            data.assert_approx_eq::<FloatElem>(
+                &burn_tensor::TensorData::from([
+                    [4.0_f32, 4.0, 4.0, 4.0],
+                    [4.0, 4.0, 4.0, 4.0],
+                    [4.0, 4.0, 4.0, 4.0],
+                    [4.0, 4.0, 4.0, 4.0],
+                ]),
+                burn_tensor::Tolerance::default(),
+            );
+
+            drop(a);
+            sync_streams(&device, &[peer]);
+
+            assert_no_leaked_handles(
+                &inspector,
+                "transaction executed cross-stream must not panic or leak handles",
             );
         });
     }

--- a/crates/burn-fusion/src/client.rs
+++ b/crates/burn-fusion/src/client.rs
@@ -352,10 +352,15 @@ where
     where
         B: FusionBackend<FusionRuntime = R>,
     {
+        // Must evaluate `into_ir()` on the frontend thread. If evaluated inside
+        // the closure (server thread), a cross-stream tensor will trigger `shared_view` ->
+        // `submit_blocking`, causing a fatal channel re-entrancy panic (`BorrowMutError`).
+        let stream = tensor.stream;
+        let tensor = tensor.into_ir();
         self.server
             .submit_blocking(move |server| {
-                server.drain_stream(tensor.stream);
-                server.resolve_server_float::<B>(&tensor.into_ir())
+                server.drain_stream(stream);
+                server.resolve_server_float::<B>(&tensor)
             })
             .unwrap()
     }
@@ -365,10 +370,15 @@ where
     where
         B: FusionBackend<FusionRuntime = R>,
     {
+        // Must evaluate `into_ir()` on the frontend thread. If evaluated inside
+        // the closure (server thread), a cross-stream tensor will trigger `shared_view` ->
+        // `submit_blocking`, causing a fatal channel re-entrancy panic (`BorrowMutError`).
+        let stream = tensor.stream;
+        let tensor = tensor.into_ir();
         self.server
             .submit_blocking(move |server| {
-                server.drain_stream(tensor.stream);
-                server.resolve_server_int::<B>(&tensor.into_ir())
+                server.drain_stream(stream);
+                server.resolve_server_int::<B>(&tensor)
             })
             .unwrap()
     }
@@ -378,10 +388,15 @@ where
     where
         B: FusionBackend<FusionRuntime = R>,
     {
+        // Must evaluate `into_ir()` on the frontend thread. If evaluated inside
+        // the closure (server thread), a cross-stream tensor will trigger `shared_view` ->
+        // `submit_blocking`, causing a fatal channel re-entrancy panic (`BorrowMutError`).
+        let stream = tensor.stream;
+        let tensor = tensor.into_ir();
         self.server
             .submit_blocking(move |server| {
-                server.drain_stream(tensor.stream);
-                server.resolve_server_bool::<B>(&tensor.into_ir())
+                server.drain_stream(stream);
+                server.resolve_server_bool::<B>(&tensor)
             })
             .unwrap()
     }


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

#4962

Stumbled upon this issue when testing the mnist example.

<details><summary>Backtrace</summary>

```
thread 'DSU-4-0' (209127) panicked at /home/laggui/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cubecl-common-0.10.0/src/device/handle/channel.rs:361:18:
Service state is already borrowed: BorrowMutError
stack backtrace:
   0: __rustc::rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::result::unwrap_failed
   3: std::thread::local::LocalKey<T>::with
   4: std::panicking::catch_unwind::do_call
   5: <cubecl_common::device::handle::channel::ChannelDeviceHandle<S> as cubecl_common::device::handle::base::DeviceHandleSpec<S>>::submit_blocking
   6: burn_fusion::tensor::FusionTensor<R>::shared_view
   7: burn_fusion::tensor::FusionTensor<R>::into_ir
   8: cubecl_common::stream_id::StreamId::executes
   9: std::thread::local::LocalKey<T>::with
  10: std::panicking::catch_unwind::do_call
  11: core::ops::function::FnOnce::call_once
  12: cubecl_common::device::handle::channel::custom_channel::Server::start
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
=== PANIC ===
A fatal error happened, you can check the experiment logs here => '/tmp/burn-example-mnist/experiment.log'
=============

thread 'DSU-4-0' (209127) panicked at /home/laggui/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cubecl-common-0.10.0/src/device/handle/channel.rs:361:18:
Service state is already borrowed: BorrowMutError
stack backtrace:
   0: __rustc::rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::result::unwrap_failed
   3: std::thread::local::LocalKey<T>::with
   4: burn_fusion::client::GlobalFusionClient<R>::register
   5: <burn_fusion::tensor::FusionTensor<R> as core::ops::drop::Drop>::drop
   6: core::ptr::drop_in_place<burn_fusion::tensor::FusionTensor<burn_cubecl::fusion::FusionCubeRuntime<cubecl_wgpu::runtime::WgpuRuntime>>>
   7: burn_fusion::tensor::FusionTensor<R>::into_ir
   8: cubecl_common::stream_id::StreamId::executes
   9: std::thread::local::LocalKey<T>::with
  10: std::panicking::catch_unwind::do_call
  11: core::ops::function::FnOnce::call_once
  12: cubecl_common::device::handle::channel::custom_channel::Server::start
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
=== PANIC ===
A fatal error happened, you can check the experiment logs here => '/tmp/burn-example-mnist/experiment.log'
=============

thread 'DSU-4-0' (209127) panicked at /home/laggui/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cubecl-common-0.10.0/src/device/handle/channel.rs:93:14:
Can't have an error when submitting a task: CallError
stack backtrace:
   0: __rustc::rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::result::unwrap_failed
   3: burn_fusion::client::GlobalFusionClient<R>::register
   4: <burn_fusion::tensor::FusionTensor<R> as core::ops::drop::Drop>::drop
   5: core::ptr::drop_in_place<burn_fusion::tensor::FusionTensor<burn_cubecl::fusion::FusionCubeRuntime<cubecl_wgpu::runtime::WgpuRuntime>>>
   6: burn_fusion::tensor::FusionTensor<R>::into_ir
   7: cubecl_common::stream_id::StreamId::executes
   8: std::thread::local::LocalKey<T>::with
   9: std::panicking::catch_unwind::do_call
  10: core::ops::function::FnOnce::call_once
  11: cubecl_common::device::handle::channel::custom_channel::Server::start
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
=== PANIC ===
A fatal error happened, you can check the experiment logs here => '/tmp/burn-example-mnist/experiment.log'
=============

thread 'train-worker' (209149) panicked at crates/burn-fusion/src/client.rs:360:14:
called `Result::unwrap()` on an `Err` value: CallError
stack backtrace:
   0: __rustc::rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::result::unwrap_failed
   3: <alloc::vec::into_iter::IntoIter<T,A> as core::iter::traits::iterator::Iterator>::fold
   4: alloc::vec::in_place_collect::<impl alloc::vec::spec_from_iter::SpecFromIter<T,I> for alloc::vec::Vec<T>>::from_iter
   5: burn_fusion::ops::transaction::<impl burn_backend::backend::ops::transaction::TransactionOps<burn_fusion::backend::Fusion<B>> for burn_fusion::backend::Fusion<B>>::tr_execute::{{closure}}
   6: futures_lite::future::block_on
   7: <burn_train::learner::classification::ClassificationOutput<B> as burn_train::metric::processor::base::ItemLazy>::sync
   8: <burn_train::metric::processor::full::FullEventProcessorTraining<T,V> as burn_train::metric::processor::base::EventProcessorTraining<burn_train::metric::processor::base::LearnerEvent<T>,burn_train::metric::processor::base::LearnerEvent<V>>>::process_train
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
=== PANIC ===
A fatal error happened, you can check the experiment logs here => '/tmp/burn-example-mnist/experiment.log'
=============

thread 'main' (197834) panicked at crates/burn-train/src/metric/processor/async_wrapper.rs:104:58:
called `Result::unwrap()` on an `Err` value: SendError(..)
stack backtrace:
   0: __rustc::rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::result::unwrap_failed
   3: <burn_train::learner::supervised::strategies::single::strategy::SingleDeviceTrainingStrategy<LC> as burn_train::learner::supervised::strategies::base::SupervisedLearningStrategy<LC>>::fit
   4: burn_train::learner::supervised::strategies::base::SupervisedLearningStrategy::train
   5: mnist::training::run
   6: mnist::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```
</details>

`tensor.into_ir()` was evaluated inside server-thread closures, which triggered a shared view and then re-entrancy.

### Changes

Changed tensor evaluation to the current thread, before the submit.

### Testing

Example works
