### PR TITLE
Expose safetensors/pytorch support directly

### DIFF
--- a/crates/burn/Cargo.toml
+++ b/crates/burn/Cargo.toml
@@ -80,6 +80,11 @@ record-item-custom-serde = ["burn-core/record-item-custom-serde"]
 # Model storage and serialization (SafeTensors, PyTorch interop)
 store = ["burn-store"]
 
+# Enable safetensors in burn-store.
+safetensors = ["store", "burn-store?/safetensors"]
+# Enable pytorch in burn-store.
+pytorch = ["store", "burn-store?/pytorch"]
+
 # CubeCL re-export
 cubecl = ["dep:cubecl"]
 


### PR DESCRIPTION
As we currently attach `burn-store` without default features; there's no way using features=["store"] to enable either; forcing users to have a parallel dep.