### PR TITLE
fix(train): guard TUI metric navigation against empty state

### DIFF
--- a/crates/burn-train/src/renderer/tui/metric_numeric.rs
+++ b/crates/burn-train/src/renderer/tui/metric_numeric.rs
@@ -160,20 +160,22 @@ impl NumericMetricsState {
     }
 
     fn next_metric(&mut self) {
-        self.selected = (self.selected + 1) % {
-            let this = &self;
-            this.data.len()
-        };
+        let len = self.data.len();
+        if len == 0 {
+            return;
+        }
+        self.selected = (self.selected + 1) % len;
     }
 
     fn previous_metric(&mut self) {
+        let len = self.data.len();
+        if len == 0 {
+            return;
+        }
         if self.selected > 0 {
             self.selected -= 1;
         } else {
-            self.selected = ({
-                let this = &self;
-                this.data.len()
-            }) - 1;
+            self.selected = len - 1;
         }
     }
 
@@ -322,5 +324,24 @@ impl NumericMetricView<'_> {
             }
             Self::None => {}
         };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metric_navigation_on_empty_state_is_a_no_op() {
+        // Pressing Right or Left before any metric has been recorded must not
+        // panic. Previously this triggered `(0 + 1) % 0` and `0usize - 1` on
+        // the empty `data` map.
+        let mut state = NumericMetricsState::default();
+
+        state.next_metric();
+        state.previous_metric();
+
+        assert_eq!(state.selected, 0);
+        assert!(state.data.is_empty());
     }
 }


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Fixes #4964.

### Changes

The TUI dashboard's Left/Right arrow handlers call `next_metric` and `previous_metric` in `renderer/tui/metric_numeric.rs`, which do `(selected + 1) % data.len()` and `data.len() - 1` unconditionally. Before the first metric is recorded (e.g. during backend autotune at startup), `data` is empty, so the first arrow press panics:

- Right arrow: `attempt to calculate the remainder with a divisor of zero` at `metric_numeric.rs:163`.
- Left arrow: `attempt to subtract with overflow` (`0usize - 1`).

The panic kills the TUI render thread; the remainder of the run floods the log with `Failed to send TUI event: sending on a closed channel`.

Return early when `data` is empty in both methods. This matches the empty state that `view()` already handles by returning `NumericMetricView::None`, and is a no-op for any non-empty state.

### Testing

- New unit test `metric_navigation_on_empty_state_is_a_no_op` in `renderer/tui/metric_numeric.rs` exercises both methods on the default (empty) state and asserts they do not panic. The test fails on `main` with the exact panic from the issue at `metric_numeric.rs:163` and passes with the fix.
- `cargo test -p burn-train --lib` — all 7 TUI-renderer tests pass (the new one plus the 6 existing).
- `cargo clippy -p burn-train --lib --tests --no-deps -- -D warnings` — clean.
- `cargo fmt --check -p burn-train` — clean.
