### PR TITLE
fix: improve error messages with shape/dimension context

### DIFF
--- a/crates/burn-ndarray/src/ops/matmul.rs
+++ b/crates/burn-ndarray/src/ops/matmul.rs
@@ -113,7 +113,10 @@ impl Strides {
 fn output_shape(lsh: &[usize], rsh: &[usize]) -> (Shape, Strides, Strides, Strides) {
     let ndims = lsh.num_dims();
     if ndims < 2 {
-        panic!("Matrix multiplication requires an array with at least 2 dimensions.");
+        panic!(
+            "Matrix multiplication requires an array with at least 2 dimensions. Got Rank {}",
+            ndims
+        );
     }
 
     // Fetch matrix dimensions and check compatibility.
@@ -122,7 +125,10 @@ fn output_shape(lsh: &[usize], rsh: &[usize]) -> (Shape, Strides, Strides, Strid
     let r_rows = rsh[ndims - 2];
     let r_cols = rsh[ndims - 1];
     if l_cols != r_rows {
-        panic!("Dimensions are incompatible for matrix multiplication.");
+        panic!(
+            "Dimensions are incompatible for matrix multiplication: LHS columns ({}) != ({})",
+            l_cols, r_rows
+        );
     }
     // Set matrix dimensions of the output shape.
     let mut osh = vec![0; ndims];
@@ -349,7 +355,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Dimensions are incompatible for matrix multiplication.")]
+    #[should_panic(expected = "Dimensions are incompatible for matrix multiplication: LHS columns")]
     fn test_output_shape_bad_matrix_dims() {
         output_shape(&[5, 3], &[4, 7]);
     }

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -2977,7 +2977,11 @@ impl<const D1: usize, const D2: usize, E: AsIndex> BroadcastArgs<D1, D2> for [E;
     // Passing -1 as the size for a dimension means not changing the size of that dimension.
     fn into_shape(self, shape: &Shape) -> Shape {
         if self.len() < shape.num_dims() {
-            panic!("Broadcast arguments must be greater than the number of dimensions");
+            panic!(
+                "Broadcast arguments must be greater than the number of dimensions! got {}, need at least {}",
+                self.len(),
+                shape.num_dims()
+            );
         }
 
         // Zip the two shapes in reverse order and replace -1 with the actual dimension value.
@@ -2987,7 +2991,10 @@ impl<const D1: usize, const D2: usize, E: AsIndex> BroadcastArgs<D1, D2> for [E;
             .map(|x| {
                 let primitive = x.as_index();
                 if primitive < -1 || primitive == 0 {
-                    panic!("Broadcast arguments must be positive or -1");
+                    panic!(
+                        "Broadcast arguments must be positive or -1! Got {}",
+                        primitive
+                    );
                 }
                 primitive
             })
@@ -2999,7 +3006,10 @@ impl<const D1: usize, const D2: usize, E: AsIndex> BroadcastArgs<D1, D2> for [E;
             .collect();
 
         if new_shape.contains(&0) {
-            panic!("Cannot substitute -1 for a non-existing dimension");
+            panic!(
+                "Cannot substitute -1 for a non-existing dimension! Got {:?}",
+                new_shape
+            );
         }
 
         let new_shape: [usize; D2] = new_shape.try_into().unwrap();

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -327,7 +327,11 @@ impl TensorCheck {
         if dim_indices.len() >= current_dims.len() {
             check = check.register(
                 "Squeeze",
-                TensorError::new("Attempted to squeeze too many dimensions!"),
+                TensorError::new("Attempted to squeeze too many dimensions!").details(format!(
+                    "Got {} dims, tensor has {}",
+                    dim_indices.len(),
+                    current_dims.len()
+                )),
             );
         }
 


### PR DESCRIPTION
Improve error messages across tensor, ndarray, and nn crates by adding missing shape, rank, and dimension info.

**Changes:**
- **matmul:** panic now includes tensor rank and incompatible dimensions (before: generic "incompatible" without values)
- **broadcast:** panic includes arg count and expected minimum dims
- **squeeze:** `TensorError` details now shows requested vs actual dim count
- **group norm:** error message shows rank (`num_dims()`) instead of total element count (`num_elements()`)

There are still several error messages in `check.rs` that could use more context (e.g., swap dims, axes uniqueness, channel mismatches), but keeping this PR small for easier review.