### PR TITLE
Add mouse support to TUI metric navigation

### DIFF
--- a/crates/burn-train/src/renderer/tui/base.rs
+++ b/crates/burn-train/src/renderer/tui/base.rs
@@ -11,7 +11,7 @@ use ratatui::{
 #[derive(new)]
 pub(crate) struct MetricsView<'a> {
     metric_numeric: NumericMetricView<'a>,
-    metric_text: TextMetricView,
+    metric_text: TextMetricView<'a>,
     progress: ProgressBarView,
     controls: ControlsView,
     status: StatusView,

--- a/crates/burn-train/src/renderer/tui/metric_numeric.rs
+++ b/crates/burn-train/src/renderer/tui/metric_numeric.rs
@@ -5,12 +5,15 @@ use crate::{
 
 use super::{FullHistoryPlot, RecentHistoryPlot, TerminalFrame, TuiSplit};
 use ratatui::{
-    crossterm::event::{Event, KeyCode, KeyEventKind},
-    prelude::{Alignment, Constraint, Direction, Layout, Rect},
+    crossterm::event::{
+        Event, KeyCode, KeyEvent, KeyEventKind, MouseButton, MouseEvent, MouseEventKind,
+    },
+    prelude::{Alignment, Constraint, Direction, Layout, Position, Rect},
     style::{Color, Modifier, Style, Stylize},
     text::Line,
     widgets::{
         Axis, BarChart, BarGroup, Block, Borders, Chart, LegendPosition, Padding, Paragraph, Tabs,
+        Widget,
     },
 };
 use std::collections::BTreeMap;
@@ -38,6 +41,8 @@ pub(crate) struct NumericMetricsState {
     num_samples_valid: Option<usize>,
     num_samples_test: Option<usize>,
     epoch: usize,
+    hovered: Option<usize>,
+    last_tab_rects: Vec<Rect>,
 }
 
 /// The kind of plot to display.
@@ -120,40 +125,80 @@ impl NumericMetricsState {
     }
 
     /// Create a view to display the numeric metrics.
-    pub(crate) fn view(&self) -> NumericMetricView<'_> {
-        match self.names.is_empty() {
-            true => NumericMetricView::None,
-            false => match self.kind {
-                PlotKind::Summary => {
-                    NumericMetricView::BarPlots(&self.names, self.selected, self.bar_chart())
+    pub(crate) fn view(&mut self) -> NumericMetricView<'_> {
+        if self.names.is_empty() {
+            return NumericMetricView::None;
+        }
+        match self.kind {
+            PlotKind::Summary => {
+                let chart = Self::bar_chart(&self.names, &self.data, self.selected);
+                NumericMetricView::BarPlots {
+                    titles: &self.names,
+                    selected: self.selected,
+                    hovered: self.hovered,
+                    chart,
+                    tab_rects_out: &mut self.last_tab_rects,
                 }
-                _ => NumericMetricView::LinePlots(
-                    &self.names,
-                    self.selected,
-                    self.line_chart(),
-                    self.kind,
-                ),
-            },
+            }
+            kind => {
+                let chart = Self::line_chart(&self.names, &self.data, self.selected, kind);
+                NumericMetricView::LinePlots {
+                    titles: &self.names,
+                    selected: self.selected,
+                    hovered: self.hovered,
+                    chart,
+                    kind,
+                    tab_rects_out: &mut self.last_tab_rects,
+                }
+            }
         }
     }
 
     /// Handle the current event.
     pub(crate) fn on_event(&mut self, event: &Event) {
-        if let Event::Key(key) = event {
-            match key.kind {
-                KeyEventKind::Release | KeyEventKind::Repeat => (),
-                #[cfg(target_os = "windows")] // Fix the double toggle on Windows.
-                KeyEventKind::Press => return,
-                #[cfg(not(target_os = "windows"))]
-                KeyEventKind::Press => (),
+        match event {
+            Event::Key(key) => self.on_key_event(key),
+            Event::Mouse(mouse) => self.on_mouse_event(mouse),
+            _ => {}
+        }
+    }
+
+    fn on_key_event(&mut self, key: &KeyEvent) {
+        match key.kind {
+            KeyEventKind::Release | KeyEventKind::Repeat => return,
+            #[cfg(target_os = "windows")] // Fix the double toggle on Windows.
+            KeyEventKind::Press => return,
+            #[cfg(not(target_os = "windows"))]
+            KeyEventKind::Press => (),
+        }
+        match key.code {
+            KeyCode::Right => self.next_metric(),
+            KeyCode::Left => self.previous_metric(),
+            KeyCode::Up | KeyCode::Down => self.switch_kind(),
+            _ => {}
+        }
+    }
+
+    fn on_mouse_event(&mut self, mouse: &MouseEvent) {
+        let pos = Position::new(mouse.column, mouse.row);
+        let hit = self
+            .last_tab_rects
+            .iter()
+            .position(|rect| rect.contains(pos));
+        match mouse.kind {
+            MouseEventKind::Moved => self.hovered = hit,
+            MouseEventKind::Down(MouseButton::Left) => {
+                if let Some(idx) = hit {
+                    self.selected = idx;
+                }
             }
-            match key.code {
-                KeyCode::Right => self.next_metric(),
-                KeyCode::Left => self.previous_metric(),
-                KeyCode::Up => self.switch_kind(),
-                KeyCode::Down => self.switch_kind(),
-                _ => {}
-            }
+            _ => {}
+        }
+    }
+
+    pub(crate) fn select_by_name(&mut self, name: &MetricName) {
+        if let Some(idx) = self.names.iter().position(|n| n == name) {
+            self.selected = idx;
         }
     }
 
@@ -185,11 +230,16 @@ impl NumericMetricsState {
         }
     }
 
-    fn line_chart<'a>(&'a self) -> Chart<'a> {
-        let name = self.names.get(self.selected).unwrap();
-        let (recent, full) = self.data.get(name).unwrap();
+    fn line_chart<'a>(
+        names: &'a [MetricName],
+        data: &'a BTreeMap<MetricName, (RecentHistoryPlot, FullHistoryPlot)>,
+        selected: usize,
+        kind: PlotKind,
+    ) -> Chart<'a> {
+        let name = names.get(selected).unwrap();
+        let (recent, full) = data.get(name).unwrap();
 
-        let (datasets, axes) = match self.kind {
+        let (datasets, axes) = match kind {
             PlotKind::Full => (full.datasets(), &full.axes),
             PlotKind::Recent => (recent.datasets(), &recent.axes),
             _ => unreachable!(),
@@ -213,9 +263,13 @@ impl NumericMetricsState {
             .legend_position(Some(LegendPosition::Right))
     }
 
-    fn bar_chart<'a>(&'a self) -> BarChart<'a> {
-        let name = self.names.get(self.selected).unwrap();
-        let (_recent, full) = self.data.get(name).unwrap();
+    fn bar_chart<'a>(
+        names: &'a [MetricName],
+        data: &'a BTreeMap<MetricName, (RecentHistoryPlot, FullHistoryPlot)>,
+        selected: usize,
+    ) -> BarChart<'a> {
+        let name = names.get(selected).unwrap();
+        let (_recent, full) = data.get(name).unwrap();
         let mut bar_width = 0;
         let bars = full.bars(100, &mut bar_width);
 
@@ -229,17 +283,36 @@ impl NumericMetricsState {
 }
 
 #[allow(clippy::large_enum_variant)]
-#[derive(new)]
 pub(crate) enum NumericMetricView<'a> {
-    LinePlots(&'a [MetricName], usize, Chart<'a>, PlotKind),
-    BarPlots(&'a [MetricName], usize, BarChart<'a>),
+    LinePlots {
+        titles: &'a [MetricName],
+        selected: usize,
+        hovered: Option<usize>,
+        chart: Chart<'a>,
+        kind: PlotKind,
+        tab_rects_out: &'a mut Vec<Rect>,
+    },
+    BarPlots {
+        titles: &'a [MetricName],
+        selected: usize,
+        hovered: Option<usize>,
+        chart: BarChart<'a>,
+        tab_rects_out: &'a mut Vec<Rect>,
+    },
     None,
 }
 
 impl NumericMetricView<'_> {
     pub(crate) fn render(self, frame: &mut TerminalFrame<'_>, size: Rect) {
         match self {
-            Self::LinePlots(titles, selected, chart, kind) => {
+            Self::LinePlots {
+                titles,
+                selected,
+                hovered,
+                chart,
+                kind,
+                tab_rects_out,
+            } => {
                 let plot_title = match kind {
                     PlotKind::Full => "Full History",
                     PlotKind::Recent => "Recent History",
@@ -252,10 +325,18 @@ impl NumericMetricView<'_> {
                     plot_title,
                     titles,
                     selected,
-                    |f, a| f.render_widget(chart, a),
+                    hovered,
+                    tab_rects_out,
+                    chart,
                 );
             }
-            Self::BarPlots(titles, selected, chart) => {
+            Self::BarPlots {
+                titles,
+                selected,
+                hovered,
+                chart,
+                tab_rects_out,
+            } => {
                 render_plot_panel(
                     frame,
                     size,
@@ -263,7 +344,9 @@ impl NumericMetricView<'_> {
                     "Summary",
                     titles,
                     selected,
-                    |f, a| f.render_widget(chart, a),
+                    hovered,
+                    tab_rects_out,
+                    chart,
                 );
             }
             Self::None => {}
@@ -272,14 +355,17 @@ impl NumericMetricView<'_> {
 }
 
 /// Draw the bordered plot panel: tab strip on top, centered plot title, then the chart.
-fn render_plot_panel(
+#[allow(clippy::too_many_arguments)]
+fn render_plot_panel<W: Widget>(
     frame: &mut TerminalFrame<'_>,
     size: Rect,
     block_title: &str,
     plot_title: &str,
     titles: &[MetricName],
     selected: usize,
-    render_chart: impl FnOnce(&mut TerminalFrame<'_>, Rect),
+    hovered: Option<usize>,
+    tab_rects_out: &mut Vec<Rect>,
+    chart: W,
 ) {
     let block = Block::default()
         .borders(Borders::ALL)
@@ -297,21 +383,28 @@ fn render_plot_panel(
         ])
         .split(inner);
 
-    render_tab_strip(frame, chunks[0], titles, selected);
+    render_tab_strip(frame, chunks[0], titles, selected, hovered, tab_rects_out);
     let title = Paragraph::new(Line::from(plot_title.bold())).alignment(Alignment::Center);
     frame.render_widget(title, chunks[1]);
-    render_chart(frame, chunks[2]);
+    frame.render_widget(chart, chunks[2]);
 }
 
 /// Render the metric tabs in `area`, scrolling horizontally so the `selected` tab is always
 /// visible. A `‹` / `›` indicator is drawn in a reserved cell on each side when tabs are
-/// hidden off that edge.
+/// hidden off that edge. The hovered tab gets an extra underline. Hit-test rects for the
+/// visible tabs are written into `tab_rects_out`, indexed by global tab position. Off-screen
+/// tabs get a zero-sized rect so the mouse-event hit test misses them.
 fn render_tab_strip(
     frame: &mut TerminalFrame<'_>,
     area: Rect,
     titles: &[MetricName],
     selected: usize,
+    hovered: Option<usize>,
+    tab_rects_out: &mut Vec<Rect>,
 ) {
+    tab_rects_out.clear();
+    tab_rects_out.resize(titles.len(), Rect::default());
+
     if titles.is_empty() || area.width == 0 {
         return;
     }
@@ -341,11 +434,33 @@ fn render_tab_strip(
         width: inner_width,
         ..area
     };
-    let tabs = Tabs::new(
-        titles_str[start..end]
-            .iter()
-            .map(|s| Line::from(vec![s.clone().yellow()])),
-    )
+
+    // Hit-test rects mirror the on-screen layout of the visible window. Tabs scrolled
+    // off either edge keep the zero-sized default from `resize` above so the mouse test
+    // misses them.
+    let mut x = tabs_area.x;
+    let tabs_end = tabs_area.x.saturating_add(tabs_area.width);
+    for i in start..end {
+        let w = widths[i];
+        let remaining = tabs_end.saturating_sub(x);
+        tab_rects_out[i] = Rect {
+            x: x.min(tabs_end),
+            y: tabs_area.y,
+            width: w.min(remaining),
+            height: tabs_area.height,
+        };
+        x = x.saturating_add(w).saturating_add(TAB_DIVIDER);
+    }
+
+    let tabs = Tabs::new(titles_str[start..end].iter().enumerate().map(|(local, s)| {
+        let span = s.clone().yellow();
+        let span = if hovered == Some(start + local) {
+            span.underlined()
+        } else {
+            span
+        };
+        Line::from(vec![span])
+    }))
     .select(selected - start)
     .highlight_style(
         Style::default()
@@ -400,6 +515,21 @@ fn visible_tab_window(widths: &[u16], selected: usize, available: u16) -> (usize
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ratatui::crossterm::event::{KeyModifiers, MouseEvent};
+    use std::sync::Arc;
+
+    fn name(s: &str) -> MetricName {
+        Arc::new(s.to_string())
+    }
+
+    fn mouse(kind: MouseEventKind, column: u16, row: u16) -> Event {
+        Event::Mouse(MouseEvent {
+            kind,
+            column,
+            row,
+            modifiers: KeyModifiers::NONE,
+        })
+    }
 
     #[test]
     fn metric_navigation_on_empty_state_is_a_no_op() {
@@ -413,6 +543,62 @@ mod tests {
 
         assert_eq!(state.selected, 0);
         assert!(state.data.is_empty());
+    }
+
+    #[test]
+    fn select_by_name_sets_index_on_match_and_no_ops_otherwise() {
+        let mut state = NumericMetricsState {
+            names: vec![name("loss"), name("acc"), name("lr")],
+            ..NumericMetricsState::default()
+        };
+
+        state.select_by_name(&name("acc"));
+        assert_eq!(state.selected, 1);
+
+        state.select_by_name(&name("missing"));
+        assert_eq!(state.selected, 1);
+    }
+
+    #[test]
+    fn mouse_click_on_tab_selects_it() {
+        let mut state = NumericMetricsState {
+            names: vec![name("loss"), name("acc")],
+            last_tab_rects: vec![Rect::new(0, 0, 6, 2), Rect::new(7, 0, 5, 2)],
+            ..NumericMetricsState::default()
+        };
+
+        state.on_event(&mouse(MouseEventKind::Down(MouseButton::Left), 8, 0));
+
+        assert_eq!(state.selected, 1);
+    }
+
+    #[test]
+    fn mouse_click_outside_tabs_does_not_change_selection() {
+        let mut state = NumericMetricsState {
+            names: vec![name("loss"), name("acc")],
+            selected: 0,
+            last_tab_rects: vec![Rect::new(0, 0, 6, 2), Rect::new(7, 0, 5, 2)],
+            ..NumericMetricsState::default()
+        };
+
+        state.on_event(&mouse(MouseEventKind::Down(MouseButton::Left), 50, 50));
+
+        assert_eq!(state.selected, 0);
+    }
+
+    #[test]
+    fn mouse_moved_updates_hovered() {
+        let mut state = NumericMetricsState {
+            names: vec![name("loss"), name("acc")],
+            last_tab_rects: vec![Rect::new(0, 0, 6, 2), Rect::new(7, 0, 5, 2)],
+            ..NumericMetricsState::default()
+        };
+
+        state.on_event(&mouse(MouseEventKind::Moved, 2, 0));
+        assert_eq!(state.hovered, Some(0));
+
+        state.on_event(&mouse(MouseEventKind::Moved, 50, 50));
+        assert_eq!(state.hovered, None);
     }
 
     fn cells(titles: &[&str]) -> Vec<u16> {

--- a/crates/burn-train/src/renderer/tui/metric_numeric.rs
+++ b/crates/burn-train/src/renderer/tui/metric_numeric.rs
@@ -186,7 +186,7 @@ impl NumericMetricsState {
 
     fn on_key_event(&mut self, key: &KeyEvent) -> bool {
         match key.kind {
-            KeyEventKind::Release | KeyEventKind::Repeat => return false,
+            KeyEventKind::Release | KeyEventKind::Repeat => (),
             #[cfg(target_os = "windows")] // Fix the double toggle on Windows.
             KeyEventKind::Press => return false,
             #[cfg(not(target_os = "windows"))]
@@ -776,33 +776,6 @@ mod tests {
 
         assert!(state.on_event(&mouse(MouseEventKind::Down(MouseButton::Left), 8, 0)));
         assert!(!state.on_event(&mouse(MouseEventKind::Down(MouseButton::Left), 50, 50)));
-    }
-
-    #[test]
-    fn on_event_returns_true_for_handled_keys_false_for_unhandled() {
-        use ratatui::crossterm::event::{KeyEvent, KeyModifiers};
-        fn key(code: KeyCode) -> Event {
-            Event::Key(KeyEvent::new(code, KeyModifiers::NONE))
-        }
-        let mut state = NumericMetricsState {
-            names: vec![name("loss"), name("acc")],
-            data: BTreeMap::from_iter([
-                (
-                    name("loss"),
-                    (RecentHistoryPlot::new(1), FullHistoryPlot::new(1)),
-                ),
-                (
-                    name("acc"),
-                    (RecentHistoryPlot::new(1), FullHistoryPlot::new(1)),
-                ),
-            ]),
-            ..NumericMetricsState::default()
-        };
-
-        assert!(state.on_event(&key(KeyCode::Right)));
-        assert!(state.on_event(&key(KeyCode::Left)));
-        assert!(state.on_event(&key(KeyCode::Up)));
-        assert!(!state.on_event(&key(KeyCode::Char('z'))));
     }
 
     fn cells(titles: &[&str]) -> Vec<u16> {

--- a/crates/burn-train/src/renderer/tui/metric_numeric.rs
+++ b/crates/burn-train/src/renderer/tui/metric_numeric.rs
@@ -30,6 +30,28 @@ const MAX_NUM_SAMPLES_RECENT: usize = 1000;
 /// Otherwise, there is too much points and the lines arent't smooth enough.
 const MAX_NUM_SAMPLES_FULL: usize = 250;
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum ChevronSide {
+    Left,
+    Right,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum HoverTarget {
+    Tab(usize),
+    Chevron(ChevronSide),
+}
+
+/// Hit-test geometry and hover state for the tab strip, populated by `render_tab_strip`
+/// on every frame and consumed by `on_mouse_event`.
+#[derive(Default)]
+pub(crate) struct TabStripState {
+    hovered: Option<HoverTarget>,
+    tab_rects: Vec<Rect>,
+    chevron_left: Option<Rect>,
+    chevron_right: Option<Rect>,
+}
+
 /// Numeric metrics state that handles creating plots.
 #[derive(Default)]
 pub(crate) struct NumericMetricsState {
@@ -41,8 +63,7 @@ pub(crate) struct NumericMetricsState {
     num_samples_valid: Option<usize>,
     num_samples_test: Option<usize>,
     epoch: usize,
-    hovered: Option<usize>,
-    last_tab_rects: Vec<Rect>,
+    strip: TabStripState,
 }
 
 /// The kind of plot to display.
@@ -135,9 +156,8 @@ impl NumericMetricsState {
                 NumericMetricView::BarPlots {
                     titles: &self.names,
                     selected: self.selected,
-                    hovered: self.hovered,
                     chart,
-                    tab_rects_out: &mut self.last_tab_rects,
+                    strip: &mut self.strip,
                 }
             }
             kind => {
@@ -145,10 +165,9 @@ impl NumericMetricsState {
                 NumericMetricView::LinePlots {
                     titles: &self.names,
                     selected: self.selected,
-                    hovered: self.hovered,
                     chart,
                     kind,
-                    tab_rects_out: &mut self.last_tab_rects,
+                    strip: &mut self.strip,
                 }
             }
         }
@@ -181,17 +200,15 @@ impl NumericMetricsState {
 
     fn on_mouse_event(&mut self, mouse: &MouseEvent) {
         let pos = Position::new(mouse.column, mouse.row);
-        let hit = self
-            .last_tab_rects
-            .iter()
-            .position(|rect| rect.contains(pos));
+        let target = hover_target_at(&self.strip, pos);
         match mouse.kind {
-            MouseEventKind::Moved => self.hovered = hit,
-            MouseEventKind::Down(MouseButton::Left) => {
-                if let Some(idx) = hit {
-                    self.selected = idx;
-                }
-            }
+            MouseEventKind::Moved => self.strip.hovered = target,
+            MouseEventKind::Down(MouseButton::Left) => match target {
+                Some(HoverTarget::Tab(idx)) => self.selected = idx,
+                Some(HoverTarget::Chevron(ChevronSide::Left)) => self.previous_metric(),
+                Some(HoverTarget::Chevron(ChevronSide::Right)) => self.next_metric(),
+                None => {}
+            },
             _ => {}
         }
     }
@@ -287,17 +304,15 @@ pub(crate) enum NumericMetricView<'a> {
     LinePlots {
         titles: &'a [MetricName],
         selected: usize,
-        hovered: Option<usize>,
         chart: Chart<'a>,
         kind: PlotKind,
-        tab_rects_out: &'a mut Vec<Rect>,
+        strip: &'a mut TabStripState,
     },
     BarPlots {
         titles: &'a [MetricName],
         selected: usize,
-        hovered: Option<usize>,
         chart: BarChart<'a>,
-        tab_rects_out: &'a mut Vec<Rect>,
+        strip: &'a mut TabStripState,
     },
     None,
 }
@@ -308,10 +323,9 @@ impl NumericMetricView<'_> {
             Self::LinePlots {
                 titles,
                 selected,
-                hovered,
                 chart,
                 kind,
-                tab_rects_out,
+                strip,
             } => {
                 let plot_title = match kind {
                     PlotKind::Full => "Full History",
@@ -319,34 +333,17 @@ impl NumericMetricView<'_> {
                     _ => unreachable!(),
                 };
                 render_plot_panel(
-                    frame,
-                    size,
-                    "Plots",
-                    plot_title,
-                    titles,
-                    selected,
-                    hovered,
-                    tab_rects_out,
-                    chart,
+                    frame, size, "Plots", plot_title, titles, selected, strip, chart,
                 );
             }
             Self::BarPlots {
                 titles,
                 selected,
-                hovered,
                 chart,
-                tab_rects_out,
+                strip,
             } => {
                 render_plot_panel(
-                    frame,
-                    size,
-                    "Summary",
-                    "Summary",
-                    titles,
-                    selected,
-                    hovered,
-                    tab_rects_out,
-                    chart,
+                    frame, size, "Summary", "Summary", titles, selected, strip, chart,
                 );
             }
             Self::None => {}
@@ -363,8 +360,7 @@ fn render_plot_panel<W: Widget>(
     plot_title: &str,
     titles: &[MetricName],
     selected: usize,
-    hovered: Option<usize>,
-    tab_rects_out: &mut Vec<Rect>,
+    strip: &mut TabStripState,
     chart: W,
 ) {
     let block = Block::default()
@@ -383,7 +379,7 @@ fn render_plot_panel<W: Widget>(
         ])
         .split(inner);
 
-    render_tab_strip(frame, chunks[0], titles, selected, hovered, tab_rects_out);
+    render_tab_strip(frame, chunks[0], titles, selected, strip);
     let title = Paragraph::new(Line::from(plot_title.bold())).alignment(Alignment::Center);
     frame.render_widget(title, chunks[1]);
     frame.render_widget(chart, chunks[2]);
@@ -391,19 +387,20 @@ fn render_plot_panel<W: Widget>(
 
 /// Render the metric tabs in `area`, scrolling horizontally so the `selected` tab is always
 /// visible. A `‹` / `›` indicator is drawn in a reserved cell on each side when tabs are
-/// hidden off that edge. The hovered tab gets an extra underline. Hit-test rects for the
-/// visible tabs are written into `tab_rects_out`, indexed by global tab position. Off-screen
-/// tabs get a zero-sized rect so the mouse-event hit test misses them.
+/// hidden off that edge. The hovered tab gets an extra underline, a hovered chevron gets a
+/// brighter foreground. Hit-test rects for the visible tabs and the two chevrons are written
+/// back into `strip` so `on_mouse_event` can route clicks.
 fn render_tab_strip(
     frame: &mut TerminalFrame<'_>,
     area: Rect,
     titles: &[MetricName],
     selected: usize,
-    hovered: Option<usize>,
-    tab_rects_out: &mut Vec<Rect>,
+    strip: &mut TabStripState,
 ) {
-    tab_rects_out.clear();
-    tab_rects_out.resize(titles.len(), Rect::default());
+    strip.tab_rects.clear();
+    strip.tab_rects.resize(titles.len(), Rect::default());
+    strip.chevron_left = None;
+    strip.chevron_right = None;
 
     if titles.is_empty() || area.width == 0 {
         return;
@@ -415,10 +412,11 @@ fn render_tab_strip(
     let inner_width = area.width.saturating_sub(2);
     let (start, end) = visible_tab_window(&widths, selected, inner_width);
 
-    let edge_style = Style::default().fg(Color::DarkGray);
     if start > 0 {
         let left = Rect { width: 1, ..area };
-        frame.render_widget(Paragraph::new("‹").style(edge_style), left);
+        let color = chevron_color(strip.hovered, ChevronSide::Left);
+        frame.render_widget(Paragraph::new("‹").style(Style::default().fg(color)), left);
+        strip.chevron_left = Some(left);
     }
     if end < titles.len() {
         let right = Rect {
@@ -426,7 +424,9 @@ fn render_tab_strip(
             width: 1,
             ..area
         };
-        frame.render_widget(Paragraph::new("›").style(edge_style), right);
+        let color = chevron_color(strip.hovered, ChevronSide::Right);
+        frame.render_widget(Paragraph::new("›").style(Style::default().fg(color)), right);
+        strip.chevron_right = Some(right);
     }
 
     let tabs_area = Rect {
@@ -440,10 +440,9 @@ fn render_tab_strip(
     // misses them.
     let mut x = tabs_area.x;
     let tabs_end = tabs_area.x.saturating_add(tabs_area.width);
-    for i in start..end {
-        let w = widths[i];
+    for (i, &w) in (start..end).zip(&widths[start..end]) {
         let remaining = tabs_end.saturating_sub(x);
-        tab_rects_out[i] = Rect {
+        strip.tab_rects[i] = Rect {
             x: x.min(tabs_end),
             y: tabs_area.y,
             width: w.min(remaining),
@@ -454,7 +453,7 @@ fn render_tab_strip(
 
     let tabs = Tabs::new(titles_str[start..end].iter().enumerate().map(|(local, s)| {
         let span = s.clone().yellow();
-        let span = if hovered == Some(start + local) {
+        let span = if strip.hovered == Some(HoverTarget::Tab(start + local)) {
             span.underlined()
         } else {
             span
@@ -468,6 +467,28 @@ fn render_tab_strip(
             .fg(Color::LightYellow),
     );
     frame.render_widget(tabs, tabs_area);
+}
+
+fn chevron_color(hovered: Option<HoverTarget>, side: ChevronSide) -> Color {
+    if hovered == Some(HoverTarget::Chevron(side)) {
+        Color::Gray
+    } else {
+        Color::DarkGray
+    }
+}
+
+fn hover_target_at(strip: &TabStripState, pos: Position) -> Option<HoverTarget> {
+    if strip.chevron_left.is_some_and(|r| r.contains(pos)) {
+        return Some(HoverTarget::Chevron(ChevronSide::Left));
+    }
+    if strip.chevron_right.is_some_and(|r| r.contains(pos)) {
+        return Some(HoverTarget::Chevron(ChevronSide::Right));
+    }
+    strip
+        .tab_rects
+        .iter()
+        .position(|r| r.contains(pos))
+        .map(HoverTarget::Tab)
 }
 
 /// Cells consumed by one tab. Title display width plus ratatui's default padding.
@@ -559,11 +580,18 @@ mod tests {
         assert_eq!(state.selected, 1);
     }
 
+    fn strip_with_tabs(tabs: Vec<Rect>) -> TabStripState {
+        TabStripState {
+            tab_rects: tabs,
+            ..TabStripState::default()
+        }
+    }
+
     #[test]
     fn mouse_click_on_tab_selects_it() {
         let mut state = NumericMetricsState {
             names: vec![name("loss"), name("acc")],
-            last_tab_rects: vec![Rect::new(0, 0, 6, 2), Rect::new(7, 0, 5, 2)],
+            strip: strip_with_tabs(vec![Rect::new(0, 0, 6, 2), Rect::new(7, 0, 5, 2)]),
             ..NumericMetricsState::default()
         };
 
@@ -577,7 +605,7 @@ mod tests {
         let mut state = NumericMetricsState {
             names: vec![name("loss"), name("acc")],
             selected: 0,
-            last_tab_rects: vec![Rect::new(0, 0, 6, 2), Rect::new(7, 0, 5, 2)],
+            strip: strip_with_tabs(vec![Rect::new(0, 0, 6, 2), Rect::new(7, 0, 5, 2)]),
             ..NumericMetricsState::default()
         };
 
@@ -590,15 +618,101 @@ mod tests {
     fn mouse_moved_updates_hovered() {
         let mut state = NumericMetricsState {
             names: vec![name("loss"), name("acc")],
-            last_tab_rects: vec![Rect::new(0, 0, 6, 2), Rect::new(7, 0, 5, 2)],
+            strip: strip_with_tabs(vec![Rect::new(0, 0, 6, 2), Rect::new(7, 0, 5, 2)]),
             ..NumericMetricsState::default()
         };
 
         state.on_event(&mouse(MouseEventKind::Moved, 2, 0));
-        assert_eq!(state.hovered, Some(0));
+        assert_eq!(state.strip.hovered, Some(HoverTarget::Tab(0)));
 
         state.on_event(&mouse(MouseEventKind::Moved, 50, 50));
-        assert_eq!(state.hovered, None);
+        assert_eq!(state.strip.hovered, None);
+    }
+
+    #[test]
+    fn mouse_click_on_left_chevron_goes_to_previous_metric() {
+        // Three metrics with the second one selected. A click on the left chevron should
+        // wrap-decrement the selection just like KeyCode::Left does.
+        let mut state = NumericMetricsState {
+            names: vec![name("a"), name("b"), name("c")],
+            data: BTreeMap::from_iter([
+                (
+                    name("a"),
+                    (RecentHistoryPlot::new(1), FullHistoryPlot::new(1)),
+                ),
+                (
+                    name("b"),
+                    (RecentHistoryPlot::new(1), FullHistoryPlot::new(1)),
+                ),
+                (
+                    name("c"),
+                    (RecentHistoryPlot::new(1), FullHistoryPlot::new(1)),
+                ),
+            ]),
+            selected: 1,
+            strip: TabStripState {
+                chevron_left: Some(Rect::new(0, 0, 1, 2)),
+                ..TabStripState::default()
+            },
+            ..NumericMetricsState::default()
+        };
+
+        state.on_event(&mouse(MouseEventKind::Down(MouseButton::Left), 0, 0));
+        assert_eq!(state.selected, 0);
+    }
+
+    #[test]
+    fn mouse_click_on_right_chevron_goes_to_next_metric() {
+        let mut state = NumericMetricsState {
+            names: vec![name("a"), name("b"), name("c")],
+            data: BTreeMap::from_iter([
+                (
+                    name("a"),
+                    (RecentHistoryPlot::new(1), FullHistoryPlot::new(1)),
+                ),
+                (
+                    name("b"),
+                    (RecentHistoryPlot::new(1), FullHistoryPlot::new(1)),
+                ),
+                (
+                    name("c"),
+                    (RecentHistoryPlot::new(1), FullHistoryPlot::new(1)),
+                ),
+            ]),
+            selected: 1,
+            strip: TabStripState {
+                chevron_right: Some(Rect::new(20, 0, 1, 2)),
+                ..TabStripState::default()
+            },
+            ..NumericMetricsState::default()
+        };
+
+        state.on_event(&mouse(MouseEventKind::Down(MouseButton::Left), 20, 0));
+        assert_eq!(state.selected, 2);
+    }
+
+    #[test]
+    fn mouse_moved_over_chevron_updates_hover_target() {
+        let mut state = NumericMetricsState {
+            strip: TabStripState {
+                chevron_left: Some(Rect::new(0, 0, 1, 2)),
+                chevron_right: Some(Rect::new(20, 0, 1, 2)),
+                ..TabStripState::default()
+            },
+            ..NumericMetricsState::default()
+        };
+
+        state.on_event(&mouse(MouseEventKind::Moved, 0, 0));
+        assert_eq!(
+            state.strip.hovered,
+            Some(HoverTarget::Chevron(ChevronSide::Left))
+        );
+
+        state.on_event(&mouse(MouseEventKind::Moved, 20, 0));
+        assert_eq!(
+            state.strip.hovered,
+            Some(HoverTarget::Chevron(ChevronSide::Right))
+        );
     }
 
     fn cells(titles: &[&str]) -> Vec<u16> {

--- a/crates/burn-train/src/renderer/tui/metric_numeric.rs
+++ b/crates/burn-train/src/renderer/tui/metric_numeric.rs
@@ -173,43 +173,70 @@ impl NumericMetricsState {
         }
     }
 
-    /// Handle the current event.
-    pub(crate) fn on_event(&mut self, event: &Event) {
+    /// Handle the current event. Returns `true` when visible state changed and a
+    /// redraw is warranted, `false` for events that produced no observable change
+    /// (so the caller can skip an unnecessary redraw).
+    pub(crate) fn on_event(&mut self, event: &Event) -> bool {
         match event {
             Event::Key(key) => self.on_key_event(key),
             Event::Mouse(mouse) => self.on_mouse_event(mouse),
-            _ => {}
+            _ => false,
         }
     }
 
-    fn on_key_event(&mut self, key: &KeyEvent) {
+    fn on_key_event(&mut self, key: &KeyEvent) -> bool {
         match key.kind {
-            KeyEventKind::Release | KeyEventKind::Repeat => return,
+            KeyEventKind::Release | KeyEventKind::Repeat => return false,
             #[cfg(target_os = "windows")] // Fix the double toggle on Windows.
-            KeyEventKind::Press => return,
+            KeyEventKind::Press => return false,
             #[cfg(not(target_os = "windows"))]
             KeyEventKind::Press => (),
         }
         match key.code {
-            KeyCode::Right => self.next_metric(),
-            KeyCode::Left => self.previous_metric(),
-            KeyCode::Up | KeyCode::Down => self.switch_kind(),
-            _ => {}
+            KeyCode::Right => {
+                self.next_metric();
+                true
+            }
+            KeyCode::Left => {
+                self.previous_metric();
+                true
+            }
+            KeyCode::Up | KeyCode::Down => {
+                self.switch_kind();
+                true
+            }
+            _ => false,
         }
     }
 
-    fn on_mouse_event(&mut self, mouse: &MouseEvent) {
+    fn on_mouse_event(&mut self, mouse: &MouseEvent) -> bool {
         let pos = Position::new(mouse.column, mouse.row);
         let target = hover_target_at(&self.strip, pos);
         match mouse.kind {
-            MouseEventKind::Moved => self.strip.hovered = target,
+            MouseEventKind::Moved => {
+                if self.strip.hovered == target {
+                    false
+                } else {
+                    self.strip.hovered = target;
+                    true
+                }
+            }
             MouseEventKind::Down(MouseButton::Left) => match target {
-                Some(HoverTarget::Tab(idx)) => self.selected = idx,
-                Some(HoverTarget::Chevron(ChevronSide::Left)) => self.previous_metric(),
-                Some(HoverTarget::Chevron(ChevronSide::Right)) => self.next_metric(),
-                None => {}
+                Some(HoverTarget::Tab(idx)) => {
+                    self.selected = idx;
+                    true
+                }
+                Some(HoverTarget::Chevron(ChevronSide::Left)) => {
+                    self.previous_metric();
+                    true
+                }
+                Some(HoverTarget::Chevron(ChevronSide::Right)) => {
+                    self.next_metric();
+                    true
+                }
+                None => false,
             },
-            _ => {}
+            _ => false,
         }
     }
 
@@ -713,6 +740,69 @@ mod tests {
             state.strip.hovered,
             Some(HoverTarget::Chevron(ChevronSide::Right))
         );
+    }
+
+    #[test]
+    fn on_event_returns_false_for_mouse_move_that_does_not_change_hover() {
+        let mut state = NumericMetricsState {
+            names: vec![name("loss"), name("acc")],
+            strip: TabStripState {
+                tab_rects: vec![Rect::new(0, 0, 6, 2), Rect::new(7, 0, 5, 2)],
+                ..TabStripState::default()
+            },
+            ..NumericMetricsState::default()
+        };
+
+        // First move onto tab 0: hover changes from None to Some(Tab(0)).
+        assert!(state.on_event(&mouse(MouseEventKind::Moved, 2, 0)));
+        // Second move still on tab 0: no change, no redraw needed.
+        assert!(!state.on_event(&mouse(MouseEventKind::Moved, 3, 0)));
+        // Move off any tab: hover changes back to None.
+        assert!(state.on_event(&mouse(MouseEventKind::Moved, 50, 50)));
+        // Move outside again: still None, no change.
+        assert!(!state.on_event(&mouse(MouseEventKind::Moved, 60, 60)));
+    }
+
+    #[test]
+    fn on_event_returns_true_for_tab_click_false_for_missed_click() {
+        let mut state = NumericMetricsState {
+            names: vec![name("loss"), name("acc")],
+            strip: TabStripState {
+                tab_rects: vec![Rect::new(0, 0, 6, 2), Rect::new(7, 0, 5, 2)],
+                ..TabStripState::default()
+            },
+            ..NumericMetricsState::default()
+        };
+
+        assert!(state.on_event(&mouse(MouseEventKind::Down(MouseButton::Left), 8, 0)));
+        assert!(!state.on_event(&mouse(MouseEventKind::Down(MouseButton::Left), 50, 50)));
+    }
+
+    #[test]
+    fn on_event_returns_true_for_handled_keys_false_for_unhandled() {
+        use ratatui::crossterm::event::{KeyEvent, KeyModifiers};
+        fn key(code: KeyCode) -> Event {
+            Event::Key(KeyEvent::new(code, KeyModifiers::NONE))
+        }
+        let mut state = NumericMetricsState {
+            names: vec![name("loss"), name("acc")],
+            data: BTreeMap::from_iter([
+                (
+                    name("loss"),
+                    (RecentHistoryPlot::new(1), FullHistoryPlot::new(1)),
+                ),
+                (
+                    name("acc"),
+                    (RecentHistoryPlot::new(1), FullHistoryPlot::new(1)),
+                ),
+            ]),
+            ..NumericMetricsState::default()
+        };
+
+        assert!(state.on_event(&key(KeyCode::Right)));
+        assert!(state.on_event(&key(KeyCode::Left)));
+        assert!(state.on_event(&key(KeyCode::Up)));
+        assert!(!state.on_event(&key(KeyCode::Char('z'))));
     }
 
     fn cells(titles: &[&str]) -> Vec<u16> {

--- a/crates/burn-train/src/renderer/tui/metric_text.rs
+++ b/crates/burn-train/src/renderer/tui/metric_text.rs
@@ -4,17 +4,21 @@ use crate::{
     renderer::tui::{TuiGroup, TuiSplit},
 };
 use ratatui::{
-    prelude::{Alignment, Rect},
+    crossterm::event::{Event, MouseButton, MouseEventKind},
+    prelude::{Alignment, Position, Rect},
     style::{Color, Style, Stylize},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph, Wrap},
 };
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, ops::Range, sync::Arc};
 
 #[derive(Default)]
 pub(crate) struct TextMetricsState {
     data: BTreeMap<String, MetricGroup>,
     names: Vec<MetricName>,
+    hovered: Option<MetricName>,
+    last_pane_rect: Option<Rect>,
+    last_header_rows: Vec<(MetricName, Range<u16>)>,
 }
 
 struct MetricGroup {
@@ -74,20 +78,67 @@ impl TextMetricsState {
                 .insert(key.to_string(), MetricGroup::new(group, value));
         }
     }
-    pub(crate) fn view(&self) -> TextMetricView {
-        TextMetricView::new(&self.names, &self.data)
+
+    pub(crate) fn view(&mut self) -> TextMetricView<'_> {
+        TextMetricView::new(
+            &self.names,
+            &self.data,
+            self.hovered.as_ref(),
+            &mut self.last_pane_rect,
+            &mut self.last_header_rows,
+        )
+    }
+
+    /// Updates hover state and returns the clicked metric name, if any.
+    pub(crate) fn on_event(&mut self, event: &Event) -> Option<MetricName> {
+        let Event::Mouse(mouse) = event else {
+            return None;
+        };
+        let pos = Position::new(mouse.column, mouse.row);
+        let hit = if self.last_pane_rect.is_some_and(|pane| pane.contains(pos)) {
+            self.last_header_rows
+                .iter()
+                .find(|(_, rows)| rows.contains(&pos.y))
+                .map(|(name, _)| name.clone())
+        } else {
+            None
+        };
+
+        match mouse.kind {
+            MouseEventKind::Moved => {
+                self.hovered = hit;
+                None
+            }
+            MouseEventKind::Down(MouseButton::Left) => hit,
+            _ => None,
+        }
     }
 }
 
-pub(crate) struct TextMetricView {
+pub(crate) struct TextMetricView<'a> {
     lines: Vec<Vec<Span<'static>>>,
+    /// Index into `lines` of each metric's header row, in display order.
+    header_line_indices: Vec<(MetricName, usize)>,
+    pane_rect_out: &'a mut Option<Rect>,
+    header_rows_out: &'a mut Vec<(MetricName, Range<u16>)>,
 }
 
-impl TextMetricView {
-    fn new(names: &[MetricName], data: &BTreeMap<String, MetricGroup>) -> Self {
+impl<'a> TextMetricView<'a> {
+    fn new(
+        names: &[MetricName],
+        data: &BTreeMap<String, MetricGroup>,
+        hovered: Option<&MetricName>,
+        pane_rect_out: &'a mut Option<Rect>,
+        header_rows_out: &'a mut Vec<(MetricName, Range<u16>)>,
+    ) -> Self {
         let mut lines = Vec::with_capacity(names.len() * 4);
+        let mut header_line_indices = Vec::with_capacity(names.len());
 
-        let start_line = |title: &str| vec![Span::from(format!(" {title} ")).bold().yellow()];
+        let start_line = |title: &str, is_hovered: bool| {
+            let span = Span::from(format!(" {title} ")).bold().yellow();
+            let span = if is_hovered { span.underlined() } else { span };
+            vec![span]
+        };
         let format_line = |group: &TuiGroup, split: &TuiSplit, formatted: &str| {
             vec![
                 Span::from(format!(" {group}{split} ")).bold(),
@@ -96,7 +147,9 @@ impl TextMetricView {
         };
 
         for name in names {
-            lines.push(start_line(name));
+            let is_hovered = hovered.is_some_and(|h| h.as_ref() == name.as_ref());
+            header_line_indices.push((name.clone(), lines.len()));
+            lines.push(start_line(name, is_hovered));
 
             let entry = data.get(name.as_ref()).unwrap();
 
@@ -109,16 +162,104 @@ impl TextMetricView {
             lines.push(vec![Span::from("")]);
         }
 
-        Self { lines }
+        Self {
+            lines,
+            header_line_indices,
+            pane_rect_out,
+            header_rows_out,
+        }
     }
 
     pub(crate) fn render(self, frame: &mut TerminalFrame<'_>, size: Rect) {
-        let paragraph = Paragraph::new(self.lines.into_iter().map(Line::from).collect::<Vec<_>>())
+        let Self {
+            lines,
+            header_line_indices,
+            pane_rect_out,
+            header_rows_out,
+        } = self;
+
+        // Skip the 1-cell top border. Header lines longer than the pane will
+        // wrap and misplace the hit zone, accepted as a known limitation.
+        let text_origin_y = size.y.saturating_add(1);
+        *pane_rect_out = Some(size);
+        *header_rows_out = header_line_indices
+            .into_iter()
+            .map(|(name, line_idx)| {
+                let row = text_origin_y.saturating_add(line_idx as u16);
+                (name, row..row.saturating_add(1))
+            })
+            .collect();
+
+        let paragraph = Paragraph::new(lines.into_iter().map(Line::from).collect::<Vec<_>>())
             .alignment(Alignment::Left)
             .wrap(Wrap { trim: false })
             .block(Block::default().borders(Borders::ALL).title("Metrics"))
             .style(Style::default().fg(Color::Gray));
 
         frame.render_widget(paragraph, size);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::crossterm::event::{KeyModifiers, MouseEvent};
+
+    fn name(s: &str) -> MetricName {
+        Arc::new(s.to_string())
+    }
+
+    fn mouse(kind: MouseEventKind, column: u16, row: u16) -> Event {
+        Event::Mouse(MouseEvent {
+            kind,
+            column,
+            row,
+            modifiers: KeyModifiers::NONE,
+        })
+    }
+
+    #[test]
+    fn click_on_header_row_returns_metric_name() {
+        let mut state = TextMetricsState {
+            last_pane_rect: Some(Rect::new(0, 0, 20, 10)),
+            last_header_rows: vec![(name("Loss"), 1..2), (name("Accuracy"), 5..6)],
+            ..TextMetricsState::default()
+        };
+
+        let clicked = state.on_event(&mouse(MouseEventKind::Down(MouseButton::Left), 3, 5));
+
+        assert_eq!(clicked.as_deref().map(|s| s.as_str()), Some("Accuracy"));
+    }
+
+    #[test]
+    fn click_off_any_header_returns_none() {
+        let mut state = TextMetricsState {
+            last_pane_rect: Some(Rect::new(0, 0, 20, 10)),
+            last_header_rows: vec![(name("Loss"), 1..2)],
+            ..TextMetricsState::default()
+        };
+
+        let on_data_row = state.on_event(&mouse(MouseEventKind::Down(MouseButton::Left), 3, 3));
+        let outside_pane = state.on_event(&mouse(MouseEventKind::Down(MouseButton::Left), 50, 50));
+
+        assert!(on_data_row.is_none());
+        assert!(outside_pane.is_none());
+    }
+
+    #[test]
+    fn moved_event_updates_hovered_and_returns_none() {
+        let mut state = TextMetricsState {
+            last_pane_rect: Some(Rect::new(0, 0, 20, 10)),
+            last_header_rows: vec![(name("Loss"), 1..2)],
+            ..TextMetricsState::default()
+        };
+
+        let result = state.on_event(&mouse(MouseEventKind::Moved, 3, 1));
+        assert!(result.is_none());
+        assert_eq!(state.hovered.as_deref().map(|s| s.as_str()), Some("Loss"));
+
+        let result = state.on_event(&mouse(MouseEventKind::Moved, 3, 8));
+        assert!(result.is_none());
+        assert!(state.hovered.is_none());
     }
 }

--- a/crates/burn-train/src/renderer/tui/metric_text.rs
+++ b/crates/burn-train/src/renderer/tui/metric_text.rs
@@ -12,13 +12,29 @@ use ratatui::{
 };
 use std::{collections::BTreeMap, ops::Range, sync::Arc};
 
+/// Hit-test geometry and hover state for the metrics pane, populated by
+/// `TextMetricView::render` on every frame and consumed by `on_event`.
+#[derive(Default)]
+pub(crate) struct TextHitState {
+    hovered: Option<MetricName>,
+    rect: Option<Rect>,
+    header_rows: Vec<(MetricName, Range<u16>)>,
+}
+
 #[derive(Default)]
 pub(crate) struct TextMetricsState {
     data: BTreeMap<String, MetricGroup>,
     names: Vec<MetricName>,
-    hovered: Option<MetricName>,
-    last_pane_rect: Option<Rect>,
-    last_header_rows: Vec<(MetricName, Range<u16>)>,
+    pane: TextHitState,
+}
+
+/// What a mouse event meant for the left pane. Drives both selection routing
+/// (the `Clicked` arm carries the metric name to switch to) and redraw gating
+/// (anything other than `Ignored` should cause a redraw).
+pub(crate) enum TextEventOutcome {
+    Clicked(MetricName),
+    HoverChanged,
+    Ignored,
 }
 
 struct MetricGroup {
@@ -80,23 +96,18 @@ impl TextMetricsState {
     }
 
     pub(crate) fn view(&mut self) -> TextMetricView<'_> {
-        TextMetricView::new(
-            &self.names,
-            &self.data,
-            self.hovered.as_ref(),
-            &mut self.last_pane_rect,
-            &mut self.last_header_rows,
-        )
+        TextMetricView::new(&self.names, &self.data, &mut self.pane)
     }
 
-    /// Updates hover state and returns the clicked metric name, if any.
-    pub(crate) fn on_event(&mut self, event: &Event) -> Option<MetricName> {
+    /// Updates hover state and reports what the event meant for the left pane.
+    pub(crate) fn on_event(&mut self, event: &Event) -> TextEventOutcome {
         let Event::Mouse(mouse) = event else {
-            return None;
+            return TextEventOutcome::Ignored;
         };
         let pos = Position::new(mouse.column, mouse.row);
-        let hit = if self.last_pane_rect.is_some_and(|pane| pane.contains(pos)) {
-            self.last_header_rows
+        let hit = if self.pane.rect.is_some_and(|pane| pane.contains(pos)) {
+            self.pane
+                .header_rows
                 .iter()
                 .find(|(_, rows)| rows.contains(&pos.y))
                 .map(|(name, _)| name.clone())
@@ -106,11 +117,18 @@ impl TextMetricsState {
 
         match mouse.kind {
             MouseEventKind::Moved => {
-                self.hovered = hit;
-                None
+                if self.pane.hovered == hit {
+                    TextEventOutcome::Ignored
+                } else {
+                    self.pane.hovered = hit;
+                    TextEventOutcome::HoverChanged
+                }
             }
-            MouseEventKind::Down(MouseButton::Left) => hit,
-            _ => None,
+            MouseEventKind::Down(MouseButton::Left) => match hit {
+                Some(name) => TextEventOutcome::Clicked(name),
+                None => TextEventOutcome::Ignored,
+            },
+            _ => TextEventOutcome::Ignored,
         }
     }
 }
@@ -119,21 +137,19 @@ pub(crate) struct TextMetricView<'a> {
     lines: Vec<Vec<Span<'static>>>,
     /// Index into `lines` of each metric's header row, in display order.
     header_line_indices: Vec<(MetricName, usize)>,
-    pane_rect_out: &'a mut Option<Rect>,
-    header_rows_out: &'a mut Vec<(MetricName, Range<u16>)>,
+    pane: &'a mut TextHitState,
 }
 
 impl<'a> TextMetricView<'a> {
     fn new(
         names: &[MetricName],
         data: &BTreeMap<String, MetricGroup>,
-        hovered: Option<&MetricName>,
-        pane_rect_out: &'a mut Option<Rect>,
-        header_rows_out: &'a mut Vec<(MetricName, Range<u16>)>,
+        pane: &'a mut TextHitState,
     ) -> Self {
         let mut lines = Vec::with_capacity(names.len() * 4);
         let mut header_line_indices = Vec::with_capacity(names.len());
 
+        let hovered = pane.hovered.as_ref();
         let start_line = |title: &str, is_hovered: bool| {
             let span = Span::from(format!(" {title} ")).bold().yellow();
             let span = if is_hovered { span.underlined() } else { span };
@@ -165,8 +181,7 @@ impl<'a> TextMetricView<'a> {
         Self {
             lines,
             header_line_indices,
-            pane_rect_out,
-            header_rows_out,
+            pane,
         }
     }
 
@@ -174,15 +189,14 @@ impl<'a> TextMetricView<'a> {
         let Self {
             lines,
             header_line_indices,
-            pane_rect_out,
-            header_rows_out,
+            pane,
         } = self;
 
         // Skip the 1-cell top border. Header lines longer than the pane will
         // wrap and misplace the hit zone, accepted as a known limitation.
         let text_origin_y = size.y.saturating_add(1);
-        *pane_rect_out = Some(size);
-        *header_rows_out = header_line_indices
+        pane.rect = Some(size);
+        pane.header_rows = header_line_indices
             .into_iter()
             .map(|(name, line_idx)| {
                 let row = text_origin_y.saturating_add(line_idx as u16);
@@ -218,48 +232,59 @@ mod tests {
         })
     }
 
-    #[test]
-    fn click_on_header_row_returns_metric_name() {
-        let mut state = TextMetricsState {
-            last_pane_rect: Some(Rect::new(0, 0, 20, 10)),
-            last_header_rows: vec![(name("Loss"), 1..2), (name("Accuracy"), 5..6)],
+    fn state_with(headers: Vec<(MetricName, Range<u16>)>) -> TextMetricsState {
+        TextMetricsState {
+            pane: TextHitState {
+                rect: Some(Rect::new(0, 0, 20, 10)),
+                header_rows: headers,
+                ..TextHitState::default()
+            },
             ..TextMetricsState::default()
-        };
-
-        let clicked = state.on_event(&mouse(MouseEventKind::Down(MouseButton::Left), 3, 5));
-
-        assert_eq!(clicked.as_deref().map(|s| s.as_str()), Some("Accuracy"));
+        }
     }
 
     #[test]
-    fn click_off_any_header_returns_none() {
-        let mut state = TextMetricsState {
-            last_pane_rect: Some(Rect::new(0, 0, 20, 10)),
-            last_header_rows: vec![(name("Loss"), 1..2)],
-            ..TextMetricsState::default()
-        };
+    fn click_on_header_row_returns_clicked() {
+        let mut state = state_with(vec![(name("Loss"), 1..2), (name("Accuracy"), 5..6)]);
+
+        let outcome = state.on_event(&mouse(MouseEventKind::Down(MouseButton::Left), 3, 5));
+
+        match outcome {
+            TextEventOutcome::Clicked(n) => assert_eq!(n.as_str(), "Accuracy"),
+            _ => panic!("expected Clicked"),
+        }
+    }
+
+    #[test]
+    fn click_off_any_header_returns_ignored() {
+        let mut state = state_with(vec![(name("Loss"), 1..2)]);
 
         let on_data_row = state.on_event(&mouse(MouseEventKind::Down(MouseButton::Left), 3, 3));
         let outside_pane = state.on_event(&mouse(MouseEventKind::Down(MouseButton::Left), 50, 50));
 
-        assert!(on_data_row.is_none());
-        assert!(outside_pane.is_none());
+        assert!(matches!(on_data_row, TextEventOutcome::Ignored));
+        assert!(matches!(outside_pane, TextEventOutcome::Ignored));
     }
 
     #[test]
-    fn moved_event_updates_hovered_and_returns_none() {
-        let mut state = TextMetricsState {
-            last_pane_rect: Some(Rect::new(0, 0, 20, 10)),
-            last_header_rows: vec![(name("Loss"), 1..2)],
-            ..TextMetricsState::default()
-        };
+    fn moved_event_signals_hover_change_only_when_target_changes() {
+        let mut state = state_with(vec![(name("Loss"), 1..2)]);
 
-        let result = state.on_event(&mouse(MouseEventKind::Moved, 3, 1));
-        assert!(result.is_none());
-        assert_eq!(state.hovered.as_deref().map(|s| s.as_str()), Some("Loss"));
+        // First move onto Loss: hover changes from None to Some(Loss).
+        let r1 = state.on_event(&mouse(MouseEventKind::Moved, 3, 1));
+        assert!(matches!(r1, TextEventOutcome::HoverChanged));
+        assert_eq!(
+            state.pane.hovered.as_deref().map(|s| s.as_str()),
+            Some("Loss")
+        );
 
-        let result = state.on_event(&mouse(MouseEventKind::Moved, 3, 8));
-        assert!(result.is_none());
-        assert!(state.hovered.is_none());
+        // Second move still on Loss: no change, ignored (no redraw needed).
+        let r2 = state.on_event(&mouse(MouseEventKind::Moved, 4, 1));
+        assert!(matches!(r2, TextEventOutcome::Ignored));
+
+        // Move off the header: hover changes to None.
+        let r3 = state.on_event(&mouse(MouseEventKind::Moved, 3, 8));
+        assert!(matches!(r3, TextEventOutcome::HoverChanged));
+        assert!(state.pane.hovered.is_none());
     }
 }

--- a/crates/burn-train/src/renderer/tui/popup.rs
+++ b/crates/burn-train/src/renderer/tui/popup.rs
@@ -50,8 +50,9 @@ impl PopupState {
     pub(crate) fn is_empty(&self) -> bool {
         matches!(&self, PopupState::Empty)
     }
-    /// Handle popup events.
-    pub(crate) fn on_event(&mut self, event: &Event) {
+    /// Handle popup events. Returns `true` when the popup state changed and a
+    /// redraw is warranted, `false` for events that left the popup untouched.
+    pub(crate) fn on_event(&mut self, event: &Event) -> bool {
         let mut reset = false;
 
         match self {
@@ -72,6 +73,7 @@ impl PopupState {
         if reset {
             *self = Self::Empty;
         }
+        reset
     }
     /// Create the popup view.
     pub(crate) fn view(&self) -> Option<PopupView<'_>> {

--- a/crates/burn-train/src/renderer/tui/renderer.rs
+++ b/crates/burn-train/src/renderer/tui/renderer.rs
@@ -28,7 +28,7 @@ use std::{
 
 use super::{
     Callback, CallbackFn, ControlsView, MetricsView, PopupState, ProgressBarState, StatusState,
-    TextMetricsState, TuiGroup, TuiTag,
+    TextEventOutcome, TextMetricsState, TuiGroup, TuiTag,
 };
 
 /// The current terminal backend.
@@ -386,48 +386,62 @@ impl TuiMetricsRenderer {
         Ok(())
     }
 
+    /// Dispatch a single user event to the popup / numeric / text components.
+    /// Returns `true` when something visible changed and a redraw is warranted.
+    /// The training loop ignores this (it is tick-gated); the post-training loop
+    /// uses it to skip redraws on inert events like mouse jitter.
+    fn dispatch_user_event(&mut self, event: &Event) -> bool {
+        let mut redraw = self.popup.on_event(event);
+        if self.popup.is_empty() {
+            redraw |= self.metrics_numeric.on_event(event);
+            redraw |= match self.metrics_text.on_event(event) {
+                TextEventOutcome::Clicked(name) => {
+                    self.metrics_numeric.select_by_name(&name);
+                    true
+                }
+                TextEventOutcome::HoverChanged => true,
+                TextEventOutcome::Ignored => false,
+            };
+        }
+        redraw
+    }
+
     fn handle_user_input(&mut self) -> Result<(), Box<dyn Error>> {
         while event::poll(Duration::from_secs(0))? {
             let event = event::read()?;
-            self.popup.on_event(&event);
+            let _ = self.dispatch_user_event(&event);
 
-            if self.popup.is_empty() {
-                self.metrics_numeric.on_event(&event);
-                if let Some(clicked) = self.metrics_text.on_event(&event) {
-                    self.metrics_numeric.select_by_name(&clicked);
-                }
-
-                if let Event::Key(key) = event
-                    && let KeyCode::Char('q') = key.code
-                {
-                    self.popup = PopupState::Full(
-                        "Quit".to_string(),
-                        vec![
-                            Callback::new(
-                                "Stop the training.",
-                                "Stop the training immediately. This will break from the \
-                                     training loop, but any remaining code after the loop will be \
-                                     executed.",
-                                's',
-                                QuitPopupAccept(self.interrupter.clone()),
-                            ),
-                            Callback::new(
-                                "Stop the training immediately.",
-                                "Kill the program. This will create a panic! which will make \
-                                     the current training fails. Any code following the training \
-                                     won't be executed.",
-                                'k',
-                                KillPopupAccept(self.kill_signal.clone()),
-                            ),
-                            Callback::new(
-                                "Cancel",
-                                "Cancel the action, continue the training.",
-                                'c',
-                                PopupCancel,
-                            ),
-                        ],
-                    );
-                }
+            if self.popup.is_empty()
+                && let Event::Key(key) = event
+                && let KeyCode::Char('q') = key.code
+            {
+                self.popup = PopupState::Full(
+                    "Quit".to_string(),
+                    vec![
+                        Callback::new(
+                            "Stop the training.",
+                            "Stop the training immediately. This will break from the \
+                                 training loop, but any remaining code after the loop will be \
+                                 executed.",
+                            's',
+                            QuitPopupAccept(self.interrupter.clone()),
+                        ),
+                        Callback::new(
+                            "Stop the training immediately.",
+                            "Kill the program. This will create a panic! which will make \
+                                 the current training fails. Any code following the training \
+                                 won't be executed.",
+                            'k',
+                            KillPopupAccept(self.kill_signal.clone()),
+                        ),
+                        Callback::new(
+                            "Cancel",
+                            "Cancel the action, continue the training.",
+                            'c',
+                            PopupCancel,
+                        ),
+                    ],
+                );
             }
         }
 
@@ -452,25 +466,21 @@ impl TuiMetricsRenderer {
             if let Ok(true) = event::poll(Duration::from_millis(MAX_REFRESH_RATE_MILLIS)) {
                 match event::read() {
                     Ok(event @ Event::Key(key)) => {
-                        if self.popup.is_empty() {
-                            self.metrics_numeric.on_event(&event);
-                            if let KeyCode::Char('q') = key.code {
-                                break;
-                            }
-                        } else {
-                            self.popup.on_event(&event);
+                        let redraw = self.dispatch_user_event(&event);
+                        if self.popup.is_empty()
+                            && let KeyCode::Char('q') = key.code
+                        {
+                            break;
                         }
-                        self.draw().ok();
+                        if redraw {
+                            self.draw().ok();
+                        }
                     }
 
                     Ok(event @ Event::Mouse(_)) => {
-                        if self.popup.is_empty() {
-                            self.metrics_numeric.on_event(&event);
-                            if let Some(clicked) = self.metrics_text.on_event(&event) {
-                                self.metrics_numeric.select_by_name(&clicked);
-                            }
+                        if self.dispatch_user_event(&event) {
+                            self.draw().ok();
                         }
-                        self.draw().ok();
                     }
 
                     Ok(Event::Resize(..)) => {

--- a/crates/burn-train/src/renderer/tui/renderer.rs
+++ b/crates/burn-train/src/renderer/tui/renderer.rs
@@ -9,7 +9,7 @@ use crate::{Interrupter, LearnerSummary};
 use ratatui::{
     Terminal,
     crossterm::{
-        event::{self, Event, KeyCode},
+        event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode},
         execute,
         terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
     },
@@ -273,7 +273,7 @@ impl TuiMetricsRenderer {
         kill_signal: Sender<()>,
     ) -> Self {
         let mut stdout = io::stdout();
-        execute!(stdout, EnterAlternateScreen).unwrap();
+        execute!(stdout, EnterAlternateScreen, EnableMouseCapture).unwrap();
         enable_raw_mode().unwrap();
         let terminal = Terminal::new(CrosstermBackend::new(stdout)).unwrap();
 
@@ -284,7 +284,7 @@ impl TuiMetricsRenderer {
             let previous_panic_hook = previous_panic_hook.clone();
             move |panic_info| {
                 let _ = disable_raw_mode();
-                let _ = execute!(io::stdout(), LeaveAlternateScreen);
+                let _ = execute!(io::stdout(), DisableMouseCapture, LeaveAlternateScreen);
                 previous_panic_hook(panic_info);
             }
         }));
@@ -393,6 +393,9 @@ impl TuiMetricsRenderer {
 
             if self.popup.is_empty() {
                 self.metrics_numeric.on_event(&event);
+                if let Some(clicked) = self.metrics_text.on_event(&event) {
+                    self.metrics_numeric.select_by_name(&clicked);
+                }
 
                 if let Event::Key(key) = event
                     && let KeyCode::Char('q') = key.code
@@ -460,6 +463,16 @@ impl TuiMetricsRenderer {
                         self.draw().ok();
                     }
 
+                    Ok(event @ Event::Mouse(_)) => {
+                        if self.popup.is_empty() {
+                            self.metrics_numeric.on_event(&event);
+                            if let Some(clicked) = self.metrics_text.on_event(&event) {
+                                self.metrics_numeric.select_by_name(&clicked);
+                            }
+                        }
+                        self.draw().ok();
+                    }
+
                     Ok(Event::Resize(..)) => {
                         self.draw().ok();
                     }
@@ -485,7 +498,11 @@ impl TuiMetricsRenderer {
             }
 
             disable_raw_mode()?;
-            execute!(self.terminal.backend_mut(), LeaveAlternateScreen)?;
+            execute!(
+                self.terminal.backend_mut(),
+                DisableMouseCapture,
+                LeaveAlternateScreen
+            )?;
             self.terminal.show_cursor()?;
 
             // Reinstall the previous panic hook


### PR DESCRIPTION
The TUI was keyboard-only with no on-screen hint otherwise. Hovering a metric title (top tab strip or left-pane "Metrics" list) now underlines it, and clicking switches the chart, mirroring Left/Right. Reusing the existing selected-tab `UNDERLINED` modifier keeps the meaning consistent: underlined = selectable.

The `‹` `›` chevrons added by #4995 were visual-only. Clicking them now cycles to the previous/next metric (same as the arrow keys), and hovering lightens the foreground from `DarkGray` to `Gray`.

Mouse capture is torn down on every exit path including the panic hook, otherwise the shell keeps eating mouse-protocol bytes after a crash.