### PR TITLE
Fix inconsistent assertion

### DIFF
--- a/crates/burn-dataset/src/transform/options.rs
+++ b/crates/burn-dataset/src/transform/options.rs
@@ -109,7 +109,7 @@ impl SizeConfig {
         match self {
             SizeConfig::Default => source_size,
             SizeConfig::Ratio(ratio) => {
-                assert!(ratio >= 0.0, "Ratio must be positive: {ratio}");
+                assert!(ratio >= 0.0, "Ratio must be non-negative: {ratio}");
                 ((source_size as f64) * ratio) as usize
             }
             SizeConfig::Fixed(size) => size,


### PR DESCRIPTION
## Pull Request Template

### Changes

The assertion's predicate is ratio >= 0.0 while assertion's message is "Ratio must be positive" which indicates ratio > 0.0. So I changed the message into "Ratio must be non-negative".
