### PR TITLE
fix(train): use recv_timeout instead of try_recv.

### DIFF
--- a/crates/burn-train/src/renderer/tui/renderer.rs
+++ b/crates/burn-train/src/renderer/tui/renderer.rs
@@ -82,10 +82,11 @@ impl TuiMetricsRendererWrapper {
 
                 let tick_rate = Duration::from_millis(MAX_REFRESH_RATE_MILLIS);
                 loop {
-                    match receiver.try_recv() {
+                    let remaining_time = tick_rate.saturating_sub(renderer.last_update.elapsed());
+                    match receiver.recv_timeout(remaining_time) {
                         Ok(event) => renderer.handle_event(event),
-                        Err(mpsc::TryRecvError::Empty) => (),
-                        Err(mpsc::TryRecvError::Disconnected) => {
+                        Err(mpsc::RecvTimeoutError::Timeout) => (),
+                        Err(mpsc::RecvTimeoutError::Disconnected) => {
                             log::error!("Renderer thread disconnected.");
                             break;
                         }


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

In the train-renderer thread `try_recv` is called in the loop without a sleep condition causing the CPU to spin at full speed mostly calling `try_recv`.

This changes it so that `recv_timeout` waits for the remainder of the tick and then proceed to render if necessary.

This showed up as ~20% CPU time spent when profiling with perf.

### Testing

Ran the `examples/mnist` example and the TUI kept working as normal.

And on main and my branch to compare:

```
cd examples/mnist
cargo run --example mnist --features vulkan
setarch x86_64 -R perf record ../../target/debug/examples/mnist # -R disables addr randomization
perf report
```

And train-renderer thread with the `try_recv` symbol should be the highest percentage in the overhead. In this case it was 3% for me and on this PR it disappeared. On another project I saw 20% usage.
