### PR TITLE
refactor(tensor): seal `TensorKind` and `Parameter` traits and consolidate param impls

### DIFF
--- a/crates/burn-core/src/module/param/base.rs
+++ b/crates/burn-core/src/module/param/base.rs
@@ -152,8 +152,19 @@ impl<T: Parameter> core::fmt::Debug for Param<T> {
     }
 }
 
+pub(crate) mod sealed {
+    pub trait Sealed {}
+}
+
 /// Trait that defines what is necessary for a type to be a parameter.
-pub trait Parameter: Clone + core::fmt::Debug + Send {
+///
+/// # Notes
+/// This trait is intentionally sealed to keep the set of parameters closed.
+///
+/// Although exposed publicly, parameter types are not meant to be extensible:
+/// the parameter loading/saving, module system and optimizers assume a fixed,
+/// closed set of parameter types represented exclusively by [`Tensor`](crate::Tensor) instances.
+pub trait Parameter: sealed::Sealed + Clone + core::fmt::Debug + Send {
     /// Fetch the device.
     fn device(&self) -> Device;
 
@@ -162,6 +173,13 @@ pub trait Parameter: Clone + core::fmt::Debug + Send {
 
     /// Set the gradient requirement.
     fn set_require_grad(self, require_grad: bool) -> Self;
+
+    /// Fetch the shape of the parameter.
+    fn shape(&self) -> Shape;
+
+    /// Moves the parameter to the target device if it is not already on it,
+    /// applying any kind-specific preparation required for the loading lifecycle (e.g. detach).
+    fn load_to_device(self, device: &Device) -> Self;
 }
 
 /// The deferred initialization state for lazy parameters.
@@ -430,6 +448,68 @@ impl<T: Parameter> Param<T> {
         }
 
         self.map(|tensor| tensor.set_require_grad(require_grad))
+    }
+
+    /// The shape of the parameter, **without triggering initialization**.
+    ///
+    /// This is critical for shape validation during loading: when applying tensors to an
+    /// uninitialized parameter, we need to validate the shape without triggering the
+    /// initialization function (which would allocate an unnecessary tensor).
+    ///
+    /// Use this instead of [crate::tensor::Tensor::shape] when you need the shape but want to
+    /// preserve lazy initialization.
+    pub fn lazy_shape(&self) -> burn_tensor::Shape {
+        let initialization = match &self.initialization {
+            Some(init) => init,
+            None => return self.shape(),
+        };
+
+        let init = initialization.read().unwrap();
+
+        match init.as_ref() {
+            Some(value) => value.shape.clone(),
+            None => self.shape(),
+        }
+    }
+
+    /// Transform a parameter for loading by applying load transformations.
+    ///
+    /// This method is used to restore a parameter from a tensor (typically during deserialization).
+    /// It ensures the tensor is moved to the expected device, applies the param mapper's
+    /// `on_load` transformation, and preserves the autodiff settings (require_grad).
+    pub fn transform_for_load(self, tensor: T, param_id: ParamId) -> Self {
+        let mut new_tensor = tensor;
+
+        let mapper = self.param_mapper.clone();
+
+        let expected_device = self.lazy_device();
+        let expected_require_grad = self.lazy_is_require_grad();
+
+        // Make sure we load the tensor into the same module device.
+        new_tensor = new_tensor.load_to_device(&expected_device);
+
+        new_tensor = mapper.on_load(new_tensor);
+
+        // Make sure we load the tensor with the same autodiff setting.
+        new_tensor = new_tensor.set_require_grad(expected_require_grad);
+
+        let mut loaded = Self::initialized(param_id, new_tensor);
+        loaded.param_mapper = mapper;
+        loaded
+    }
+
+    /// Transform a parameter for saving by applying save transformations.
+    ///
+    /// This method is used to prepare a parameter for saving (typically during serialization).
+    /// It applies the param mapper's `on_save` transformation, which can be used
+    /// to modify the tensor before serialization (e.g., quantization, precision conversion).
+    pub fn transform_for_save(&self) -> Self {
+        let mut tensor = self.val();
+        let mapper = self.param_mapper.clone();
+
+        tensor = mapper.on_save(tensor);
+
+        Self::initialized(self.id, tensor)
     }
 }
 

--- a/crates/burn-core/src/module/param/tensor.rs
+++ b/crates/burn-core/src/module/param/tensor.rs
@@ -6,6 +6,10 @@ use crate::module::{
 use alloc::{format, string::ToString, vec::Vec};
 use burn_tensor::{Bool, Device, Float, Int, Tensor, TensorData};
 
+impl<const D: usize> super::sealed::Sealed for Tensor<D, Float> {}
+impl<const D: usize> super::sealed::Sealed for Tensor<D, Int> {}
+impl<const D: usize> super::sealed::Sealed for Tensor<D, Bool> {}
+
 impl<const D: usize> Parameter for Tensor<D, Float> {
     fn device(&self) -> Device {
         Tensor::device(self)
@@ -17,6 +21,18 @@ impl<const D: usize> Parameter for Tensor<D, Float> {
 
     fn set_require_grad(self, require_grad: bool) -> Self {
         Tensor::set_require_grad(self, require_grad)
+    }
+
+    fn shape(&self) -> burn_std::Shape {
+        Tensor::shape(self)
+    }
+
+    fn load_to_device(self, device: &Device) -> Self {
+        if self.device() != *device {
+            Tensor::to_device(self, device).detach()
+        } else {
+            self
+        }
     }
 }
 
@@ -32,6 +48,18 @@ impl<const D: usize> Parameter for Tensor<D, Int> {
     fn set_require_grad(self, _require_grad: bool) -> Self {
         self
     }
+
+    fn shape(&self) -> burn_std::Shape {
+        Tensor::shape(self)
+    }
+
+    fn load_to_device(self, device: &Device) -> Self {
+        if self.device() != *device {
+            Tensor::to_device(self, device)
+        } else {
+            self
+        }
+    }
 }
 
 impl<const D: usize> Parameter for Tensor<D, Bool> {
@@ -45,6 +73,18 @@ impl<const D: usize> Parameter for Tensor<D, Bool> {
 
     fn set_require_grad(self, _require_grad: bool) -> Self {
         self
+    }
+
+    fn shape(&self) -> burn_std::Shape {
+        Tensor::shape(self)
+    }
+
+    fn load_to_device(self, device: &Device) -> Self {
+        if self.device() != *device {
+            Tensor::to_device(self, device)
+        } else {
+            self
+        }
     }
 }
 
@@ -62,28 +102,6 @@ impl<const D: usize> Param<Tensor<D>> {
         Param::initialized(ParamId::new(), value.require_grad())
     }
 
-    /// The shape of the parameter, **without triggering initialization**.
-    ///
-    /// This is critical for shape validation during loading: when applying tensors to an
-    /// uninitialized parameter, we need to validate the shape without triggering the
-    /// initialization function (which would allocate an unnecessary tensor).
-    ///
-    /// Use this instead of [crate::tensor::Tensor::shape] when you need the shape but want to
-    /// preserve lazy initialization.
-    pub fn lazy_shape(&self) -> burn_tensor::Shape {
-        let initialization = match &self.initialization {
-            Some(init) => init,
-            None => return self.shape(),
-        };
-
-        let init = initialization.read().unwrap();
-
-        match init.as_ref() {
-            Some(value) => value.shape.clone(),
-            None => self.shape(),
-        }
-    }
-
     /// Create a new parameter from data.
     pub fn from_data<T>(data: T, device: &Device) -> Self
     where
@@ -96,176 +114,6 @@ impl<const D: usize> Param<Tensor<D>> {
             let value = Tensor::from_data(data, device);
             Param::initialized(ParamId::new(), value.require_grad())
         })
-    }
-
-    /// Transform a parameter for loading by applying load transformations.
-    ///
-    /// This method is used to restore a parameter from a tensor (typically during deserialization).
-    /// It ensures the tensor is moved to the expected device, applies the param mapper's
-    /// `on_load` transformation, and preserves the autodiff settings (require_grad).
-    pub fn transform_for_load(self, tensor: Tensor<D>, param_id: ParamId) -> Self {
-        let mut new_tensor = tensor;
-
-        let mapper = self.param_mapper.clone();
-
-        let expected_device = self.lazy_device();
-        let expected_require_grad = self.lazy_is_require_grad();
-
-        // Make sure we load the tensor into the same module device.
-        if new_tensor.device() != expected_device {
-            new_tensor = new_tensor.to_device(&expected_device).detach();
-        }
-
-        new_tensor = mapper.on_load(new_tensor);
-
-        // Make sure we load the tensor with the same autodiff setting.
-        new_tensor = new_tensor.set_require_grad(expected_require_grad);
-
-        let mut loaded = Self::initialized(param_id, new_tensor);
-        loaded.param_mapper = mapper;
-        loaded
-    }
-
-    /// Transform a parameter for saving by applying save transformations.
-    ///
-    /// This method is used to prepare a parameter for saving (typically during serialization).
-    /// It applies the param mapper's `on_save` transformation, which can be used
-    /// to modify the tensor before serialization (e.g., quantization, precision conversion).
-    pub fn transform_for_save(&self) -> Self {
-        let mut tensor = self.val();
-        let mapper = self.param_mapper.clone();
-
-        tensor = mapper.on_save(tensor);
-
-        Self::initialized(self.id, tensor)
-    }
-}
-
-impl<const D: usize> Param<Tensor<D, Int>> {
-    /// The shape of the parameter, **without triggering initialization**.
-    ///
-    /// This is critical for shape validation during loading: when applying tensors to an
-    /// uninitialized parameter, we need to validate the shape without triggering the
-    /// initialization function (which would allocate an unnecessary tensor).
-    ///
-    /// Use this instead of [crate::tensor::Tensor::shape] when you need the shape but want to
-    /// preserve lazy initialization.
-    pub fn lazy_shape(&self) -> burn_tensor::Shape {
-        let initialization = match &self.initialization {
-            Some(init) => init,
-            None => return self.shape(),
-        };
-
-        let init = initialization.read().unwrap();
-
-        match init.as_ref() {
-            Some(value) => value.shape.clone(),
-            None => self.shape(),
-        }
-    }
-
-    /// Transform a parameter for loading by applying load transformations.
-    ///
-    /// This method is used to restore a parameter from a tensor (typically during deserialization).
-    /// It ensures the tensor is moved to the expected device and applies the param mapper's
-    /// `on_load` transformation.
-    pub fn transform_for_load(self, tensor: Tensor<D, Int>, param_id: ParamId) -> Self {
-        let mut new_tensor = tensor;
-
-        let mapper = self.param_mapper.clone();
-
-        let expected_device = self.lazy_device();
-
-        // Make sure we load the tensor into the same module device.
-        if new_tensor.device() != expected_device {
-            new_tensor = new_tensor.to_device(&expected_device);
-        }
-
-        new_tensor = mapper.on_load(new_tensor);
-
-        let mut loaded = Self::initialized(param_id, new_tensor);
-        loaded.param_mapper = mapper;
-        loaded
-    }
-
-    /// Transform a parameter for saving by applying save transformations.
-    ///
-    /// This method is used to prepare a parameter for saving (typically during serialization).
-    /// It applies the param mapper's `on_save` transformation, which can be used
-    /// to modify the tensor before serialization (e.g., quantization, precision conversion).
-    pub fn transform_for_save(&self) -> Self {
-        let mut tensor = self.val();
-        let mapper = self.param_mapper.clone();
-
-        tensor = mapper.on_save(tensor);
-
-        Self::initialized(self.id, tensor)
-    }
-}
-
-impl<const D: usize> Param<Tensor<D, Bool>> {
-    /// The shape of the parameter, **without triggering initialization**.
-    ///
-    /// This is critical for shape validation during loading: when applying tensors to an
-    /// uninitialized parameter, we need to validate the shape without triggering the
-    /// initialization function (which would allocate an unnecessary tensor).
-    ///
-    /// **Returns:**
-    /// - For uninitialized params: the shape from the `Uninitialized` struct
-    /// - For initialized params: the actual shape from the tensor
-    ///
-    /// Use this instead of [crate::tensor::Tensor::shape] when you need the shape but want to
-    /// preserve lazy initialization.
-    pub fn lazy_shape(&self) -> burn_tensor::Shape {
-        let initialization = match &self.initialization {
-            Some(init) => init,
-            None => return self.shape(),
-        };
-
-        let init = initialization.read().unwrap();
-
-        match init.as_ref() {
-            Some(value) => value.shape.clone(),
-            None => self.shape(),
-        }
-    }
-
-    /// Transform a parameter for loading by applying load transformations.
-    ///
-    /// This method is used to restore a parameter from a tensor (typically during deserialization).
-    /// It ensures the tensor is moved to the expected device and applies the param mapper's
-    /// `on_load` transformation.
-    pub fn transform_for_load(self, tensor: Tensor<D, Bool>, param_id: ParamId) -> Self {
-        let mut new_tensor = tensor;
-
-        let mapper = self.param_mapper.clone();
-
-        let expected_device = self.lazy_device();
-
-        // Make sure we load the tensor into the same module device.
-        if new_tensor.device() != expected_device {
-            new_tensor = new_tensor.to_device(&expected_device);
-        }
-
-        new_tensor = mapper.on_load(new_tensor);
-
-        let mut loaded = Self::initialized(param_id, new_tensor);
-        loaded.param_mapper = mapper;
-        loaded
-    }
-
-    /// Transform a parameter for saving by applying save transformations.
-    ///
-    /// This method is used to prepare a parameter for saving (typically during serialization).
-    /// It applies the param mapper's `on_save` transformation, which can be used
-    /// to modify the tensor before serialization (e.g., quantization, precision conversion).
-    pub fn transform_for_save(&self) -> Self {
-        let mut tensor = self.val();
-        let mapper = self.param_mapper.clone();
-
-        tensor = mapper.on_save(tensor);
-
-        Self::initialized(self.id, tensor)
     }
 }
 

--- a/crates/burn-tensor/src/bridge/kind.rs
+++ b/crates/burn-tensor/src/bridge/kind.rs
@@ -18,9 +18,25 @@ pub struct Int;
 #[derive(Clone, Debug)]
 pub struct Bool;
 
+mod sealed {
+    pub trait Sealed {}
+}
+
+impl sealed::Sealed for Float {}
+impl sealed::Sealed for Int {}
+impl sealed::Sealed for Bool {}
+
 /// A type-level representation of the kind of a tensor.
 /// Metadata access is lazy.
-pub trait TensorKind: Clone + Send + Sync + core::fmt::Debug {
+///
+/// # Notes
+/// This trait is intentionally sealed to keep the set of tensor kinds closed.
+///
+/// Although exposed publicly, tensor kinds are not meant to be extensible:
+/// the backend dispatch system, `DType`, and all tensor ops assume a fixed,
+/// closed set of tensor kinds (e.g. Float, Int, Bool), each mapping directly to a
+/// corresponding backend implementation.
+pub trait TensorKind: sealed::Sealed + Clone + Send + Sync + core::fmt::Debug {
     /// The tensor kind identifier.
     const KIND: Kind;
 


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Closes #4892

### Changes

- Explicitly sealed `TensorKind` and `Parameter` traits
- Added `shape` and `load_to_device` fn to `Parameter` trait to consolidate the implementations for `transform_for_load`, `lazy_shape`, and `transform_for_save` (the latter two could have already have been consolidated for `Tensor<D, K>`, but are implemented for `Param<T: Parameter>`)

### Testing

Unit tests
