### PR TITLE
fix(store): include RMS_NORM in normalization layer detection for safetensors adapter

### DIFF
--- a/crates/burn-store/src/adapter.rs
+++ b/crates/burn-store/src/adapter.rs
@@ -374,7 +374,10 @@ enum PyTorchConversionDirection {
 fn is_normalization_layer(container_type: &str) -> bool {
     matches!(
         container_type,
-        module_names::BATCH_NORM | module_names::LAYER_NORM | module_names::GROUP_NORM
+        module_names::BATCH_NORM
+            | module_names::LAYER_NORM
+            | module_names::GROUP_NORM
+            | module_names::RMS_NORM
     )
 }
 


### PR DESCRIPTION
## Summary

`is_normalization_layer()` in the safetensors adapter checks for `BATCH_NORM`, `LAYER_NORM`, and `GROUP_NORM` but not `RMS_NORM`. This means any model using `RmsNorm` (LLaMA, Mistral, Qwen, FLUX, etc.) silently skips the `weight`↔`gamma` / `bias`↔`beta` key remapping during safetensors loading.

This one-line fix adds `module_names::RMS_NORM` to the `matches!` pattern.

## Motivation

When loading a Qwen 3 checkpoint via `SafetensorsStore`, `RmsNorm` layers were not recognized as normalization layers by the adapter. The parameter key conversion (`weight` → `gamma`) was silently skipped, causing the norm weights to load incorrectly. Adding `RMS_NORM` to the existing pattern in `is_normalization_layer()` fixes the issue for all models using `RmsNorm`.

## Changes

- `crates/burn-store/src/adapter.rs`: Add `module_names::RMS_NORM` to the `is_normalization_layer()` match pattern.