### PR TITLE
fix(tensor): detect NaN element-wise in contains_nan to avoid f16 false positives

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/float/ops/nan.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/nan.rs
@@ -20,4 +20,12 @@ fn contains_nan() {
 
     let with_nan = TestTensor::<2>::from([[0.0, f32::NAN, 2.0], [3.0, 4.0, 5.0]]);
     assert!(with_nan.contains_nan().into_scalar::<bool>());
+
+    // Regression guard: a finite tensor must never be reported as containing NaN,
+    // even when its magnitude is large. The previous `sum().is_nan()` implementation
+    // could overflow the reduction on narrow-exponent floats (e.g. f16) and turn a
+    // finite tensor into a NaN sum, producing a false positive.
+    let device = Default::default();
+    let large_finite = TestTensor::<1>::ones([4096], &device) * 60000.0;
+    assert!(!large_finite.contains_nan().into_scalar::<bool>());
 }

--- a/crates/burn-backend-tests/tests/tensor/float/ops/nan.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/nan.rs
@@ -21,11 +21,14 @@ fn contains_nan() {
     let with_nan = TestTensor::<2>::from([[0.0, f32::NAN, 2.0], [3.0, 4.0, 5.0]]);
     assert!(with_nan.contains_nan().into_scalar::<bool>());
 
-    // Regression guard: a finite tensor must never be reported as containing NaN,
-    // even when its magnitude is large. The previous `sum().is_nan()` implementation
-    // could overflow the reduction on narrow-exponent floats (e.g. f16) and turn a
-    // finite tensor into a NaN sum, producing a false positive.
+    // Regression guard: a finite tensor must never be reported as containing NaN.
+    // The previous `sum().is_nan()` implementation could overflow the reduction
+    // on narrow-exponent floats (e.g. f16) and turn a finite tensor into a NaN sum,
+    // producing a false positive. Here, Inf + (-Inf) = NaN.
     let device = Default::default();
-    let large_finite = TestTensor::<1>::ones([4096], &device) * 60000.0;
+    let pos = TestTensor::<1>::ones([2048], &device) * 60000.0;
+    let neg = TestTensor::<1>::ones([2048], &device) * -60000.0;
+    // Large positive and large negative numbers
+    let large_finite = TestTensor::<1>::cat(vec![pos, neg], 0);
     assert!(!large_finite.contains_nan().into_scalar::<bool>());
 }

--- a/crates/burn-tensor/src/tensor/api/float.rs
+++ b/crates/burn-tensor/src/tensor/api/float.rs
@@ -540,12 +540,13 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     /// }
     /// ```
     pub fn contains_nan(self) -> Tensor<1, Bool> {
-        // Summing the tensor will result in NaN if the tensor contains any NaN values
-        // This is faster than checking each element individually
-        // because it rolls up the NaN values into a single value
-        let sum = self.sum();
-
-        sum.is_nan()
+        // Detect NaN element-wise, then reduce with `any`.
+        // A previous implementation used `self.sum().is_nan()`, but on narrow-exponent
+        // floats (e.g. f16) a finite tensor's sum can overflow and the reduction can then
+        // produce NaN (e.g. `Inf - Inf`), yielding a false positive even though no element
+        // is NaN. `is_nan()` is exact per-element and `any()` reduces a clean 0/1 mask, so
+        // this never false-positives on finite inputs.
+        self.is_nan().any()
     }
 
     /// Returns a new tensor with boolean elements indicating whether each element of the input is infinite (either +INF or -INF).

--- a/crates/burn-tensor/src/tensor/api/float.rs
+++ b/crates/burn-tensor/src/tensor/api/float.rs
@@ -540,12 +540,6 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     /// }
     /// ```
     pub fn contains_nan(self) -> Tensor<1, Bool> {
-        // Detect NaN element-wise, then reduce with `any`.
-        // A previous implementation used `self.sum().is_nan()`, but on narrow-exponent
-        // floats (e.g. f16) a finite tensor's sum can overflow and the reduction can then
-        // produce NaN (e.g. `Inf - Inf`), yielding a false positive even though no element
-        // is NaN. `is_nan()` is exact per-element and `any()` reduces a clean 0/1 mask, so
-        // this never false-positives on finite inputs.
         self.is_nan().any()
     }
 


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR. (No book change — public API and behavior contract are unchanged; only the internal implementation.)

Related Issues: #5026

### Changes

`Tensor::contains_nan()` was implemented as `self.sum().is_nan()`. That relies on the
assumption that *a finite tensor always has a finite sum* — true for wide-range floats
(f32/f64) but **not** for narrow-exponent floats like f16 (max ≈ 65504). On a CUDA f16
tensor the reduction can overflow intermediate partial sums to ±Inf and then produce NaN
(e.g. `Inf - Inf`), so `contains_nan()` returns `true` for a tensor whose elements are all
finite.

Detect NaN element-wise instead of via summation:

```rust
pub fn contains_nan(self) -> Tensor<1, Bool> {
    self.is_nan().any()
}
```

`is_nan()` is exact per element and `any()` reduces a clean 0/1 mask, so the result no
longer depends on the reduction path or accumulator precision and can never false-positive
on finite inputs. One-line change in `crates/burn-tensor/src/tensor/api/float.rs`, plus a
regression guard in the backend tests.

### Why this only triggers on CUDA f16

The false positive requires `sum()` to produce NaN from a finite tensor, which only happens
when the reduction accumulates in a **narrow** type that overflows:

- **f32 / f64 (any backend):** range ≈ 3.4e38 — a realistic tensor's sum never overflows,
  so it never triggers.
- **f16 via the `Chained` reduce path:** cubek's `precision()` upcasts the f16 accumulator
  to **f32**, so no overflow → no NaN.
- **f16 via the `OneShot` / `shared_sum` path:** accumulates in the tensor's own dtype
  (**f16**); partial sums overflow to ±Inf and combining them yields `Inf - Inf = NaN`,
  even though every element is finite.

`autotune` selects the sum strategy per tensor/shape/hardware, and the original
model-output tensor happened to hit the f16-accumulating path on CUDA. CPU (ndarray) and
wgpu/Vulkan did not reproduce it with the same inputs (their reductions don't yield NaN
from finite f16 here). Because the fix never sums, it is correct regardless of which path
autotune picks, on every backend and dtype.

### Testing

Platforms:

- **RTX 3090 — CUDA, f16** (reproduction + fix verified)
- **Intel Arc A750 — Vulkan/wgpu, f16** (fix verified; bug does not reproduce here)
- **CPU — ndarray, f32** + burn-tensor doctest (fix verified)

Reproduction on the 3090 (same finite tensor, elements all `±60000`):

```
[REPRO] sum = NaN   is_nan().any() = false   old contains_nan (sum-based) = true
```

`is_nan().any() == false` proves the tensor has no NaN element, yet the old sum-based check
reported `true`. The new implementation returns `false`. Existing `contains_nan` / `is_nan`
tests pass on all three platforms; a regression guard for a large finite tensor was added.

### Performance

`contains_nan` per-call latency on the RTX 3090 (100 iters after warmup; `into_scalar()`
forces a sync each call, so this is latency/launch-bound, not throughput):

| elements   | dtype | old `sum().is_nan()` | new `is_nan().any()` | new/old |
| ---------- | ----- | -------------------- | -------------------- | ------- |
| 1,024      | f16   | 788 µs               | 1.122 ms             | 1.42×   |
| 65,536     | f16   | 785 µs               | 1.465 ms             | 1.87×   |
| 1,048,576  | f16   | 951 µs               | 1.253 ms             | 1.32×   |
| 16,777,216 | f16   | 1.036 ms             | 1.466 ms             | 1.41×   |
| 1,024      | f32   | 815 µs               | 1.150 ms             | 1.41×   |
| 16,777,216 | f32   | 1.261 ms             | 1.874 ms             | 1.49×   |

The new path adds ~0.3–0.7 ms per call (≈1.2–1.9×, typically ~1.4×) from a few extra kernel
launches (`is_nan` + `any` = `bool_into_int` → `int_sum` → `greater_elem` vs a single `sum`).
`contains_nan` is an occasional sanity check, so the absolute cost is negligible in practice;
correctness over a fast-but-wrong shortcut. A follow-up that refactors `bool_any` into a
native boolean-OR reduction would recover most of this overhead.
