### PR TITLE
fix(derive): clearer error when generic used in both module and skip fields

### DIFF
--- a/crates/burn-derive/src/module/codegen_struct.rs
+++ b/crates/burn-derive/src/module/codegen_struct.rs
@@ -397,13 +397,9 @@ pub(crate) fn parse_module_fields(
     };
 
     for ident in module_generics.intersection(&skip_generics) {
-        if let Some(param) = ast.generics.params.iter().find_map(|p| {
-            if let syn::GenericParam::Type(tp) = p {
-                if tp.ident == *ident {
-                    return Some(tp);
-                }
-            }
-            None
+        if let Some(param) = ast.generics.params.iter().find_map(|p| match p {
+            syn::GenericParam::Type(tp) if tp.ident == *ident => Some(tp),
+            _ => None,
         }) {
             return Err(syn::Error::new(
                 param.ident.span(),

--- a/crates/burn-derive/src/module/codegen_struct.rs
+++ b/crates/burn-derive/src/module/codegen_struct.rs
@@ -377,17 +377,44 @@ pub(crate) fn parse_module_fields(
     generics: &mut ModuleGenerics,
 ) -> syn::Result<Vec<ModuleField>> {
     let mut fields = Vec::new();
+    let mut module_generics = HashSet::new();
+    let mut skip_generics = HashSet::new();
 
     match &ast.data {
         syn::Data::Struct(struct_data) => {
             for field in struct_data.fields.iter() {
                 let field_type = parse_module_field_type(field, generics)?;
+                if field_type.is_module {
+                    module_generics.extend(field_type.generic_idents.iter().cloned());
+                } else if matches!(field_type.attr, Some(ModuleFieldAttribute::Skip)) {
+                    skip_generics.extend(field_type.generic_idents.iter().cloned());
+                }
                 fields.push(ModuleField::new(field.clone(), field_type));
             }
         }
         syn::Data::Enum(_) => panic!("Only struct can be derived"),
         syn::Data::Union(_) => panic!("Only struct can be derived"),
     };
+
+    for ident in module_generics.intersection(&skip_generics) {
+        if let Some(param) = ast.generics.params.iter().find_map(|p| {
+            if let syn::GenericParam::Type(tp) = p {
+                if tp.ident == *ident {
+                    return Some(tp);
+                }
+            }
+            None
+        }) {
+            return Err(syn::Error::new(
+                param.ident.span(),
+                format!(
+                    "Generic type `{ident}` is used in both a module field and a skipped field. \
+                     Consider removing `#[module(skip)]` or using a different type for one of the fields.",
+                ),
+            ));
+        }
+    }
+
     Ok(fields)
 }
 

--- a/crates/burn-derive/src/module/codegen_struct.rs
+++ b/crates/burn-derive/src/module/codegen_struct.rs
@@ -404,7 +404,7 @@ pub(crate) fn parse_module_fields(
             return Err(syn::Error::new(
                 param.ident.span(),
                 format!(
-                    "Generic type `{ident}` is used in both a module field and a skipped field. \
+                    "Generic type `{ident}` should not be used on both a module field and a skipped field. \
                      Consider removing `#[module(skip)]` or using a different type for one of the fields.",
                 ),
             ));


### PR DESCRIPTION
When a generic type parameter is used in both a module field and a `#[module(skip)]` field, the derive macro now emits a clear error pointing to the generic declaration, instead of a confusing compiler error about a missing `Module` trait bound.

**Before:** Two confusing errors depending on whether `T: Module` is added:
- Without bound: cryptic `the trait bound `T: Module` is not satisfied`
- With bound: `Fields with module generics should not be marked as 'skip'`

**After:** Single clear error at the generic declaration:
```
error: Generic type `T` is used in both a module field and a skipped field. Consider removing `#[module(skip)]` or using a different type for one of the fields.
```

Fixes #5007