### PR TITLE
feat(extension): add support for custom output types wrapping tensor primitives

### DIFF
--- a/crates/burn-backend-extension/src/lib.rs
+++ b/crates/burn-backend-extension/src/lib.rs
@@ -308,7 +308,7 @@ fn lower_extension(attr: Backends, item: &ItemTrait) -> syn::Result<Extension> {
                 } else if let Some(kind) = TensorKind::from_type(ty) {
                     OperationOutput::Tensor(kind)
                 } else {
-                    // ExtensionOutput
+                    // ExtensionType
                     OperationOutput::Custom(*ty.clone())
                 }
             }
@@ -485,7 +485,7 @@ fn gen_backend_arm(ir: &Extension, op: &Operation, backend: &Backend) -> TokenSt
                     }
                     OutputKind::Custom(_) => {
                         quote! {
-                            burn::backend::ExtensionOutput::wrap_output(
+                            burn::backend::ExtensionType::map_type(
                                 _out.#idx,
                                 |tensor| burn::backend::DispatchTensorKind::#b_ident(tensor),
                                 checkpointing,
@@ -497,7 +497,7 @@ fn gen_backend_arm(ir: &Extension, op: &Operation, backend: &Backend) -> TokenSt
             quote! { (#(#elements),*) }
         }
         OperationOutput::Custom(_) => {
-            quote! { burn::backend::ExtensionOutput::wrap_output(_out, |tensor| burn::backend::DispatchTensorKind::#b_ident(tensor), checkpointing) }
+            quote! { burn::backend::ExtensionType::map_type(_out, |tensor| burn::backend::DispatchTensorKind::#b_ident(tensor), checkpointing) }
         }
     };
 
@@ -590,7 +590,7 @@ fn gen_autodiff_arm(ir: &Extension, op: &Operation) -> TokenStream2 {
                     }
                     OutputKind::Custom(_) => {
                         quote! {
-                            burn::backend::ExtensionOutput::wrap_output(
+                            burn::backend::ExtensionType::map_type(
                                 _out.#idx,
                                 |tensor| match tensor {
                                     burn::backend::BackendTensor::Float(t) => {
@@ -611,7 +611,7 @@ fn gen_autodiff_arm(ir: &Extension, op: &Operation) -> TokenStream2 {
                 quote! { (#(#elements),*) }
             }
             OperationOutput::Custom(_) => {
-                quote! { burn::backend::ExtensionOutput::wrap_output(_out, |tensor| match tensor {
+                quote! { burn::backend::ExtensionType::map_type(_out, |tensor| match tensor {
                     burn::backend::BackendTensor::Float(t) => {
                         burn::backend::DispatchTensorKind::Autodiff(
                             Box::new(burn::backend::DispatchTensorKind::#b_ident(
@@ -663,7 +663,7 @@ fn gen_tensor_wrap(
     }
 }
 
-/// Derive macro to implement `ExtensionOutput` for custom structures returned by backend extensions.
+/// Derive macro to implement `ExtensionType` for custom structures returned by backend extensions.
 ///
 /// When a custom backend extension operation needs to return multiple tensors or a mix of tensors
 /// and metadata (instead of a single tensor primitive or container of primitives), this macro automates
@@ -677,7 +677,7 @@ fn gen_tensor_wrap(
 /// # Example
 ///
 /// ```rust,ignore
-/// #[derive(ExtensionOutput)]
+/// #[derive(ExtensionType)]
 /// pub struct OperationOutput<B: Backend> {
 ///     pub bool: BoolTensor<B>,
 ///     pub int: IntTensor<B>,
@@ -685,7 +685,7 @@ fn gen_tensor_wrap(
 ///     pub count: usize, // Non-tensor field passes through automatically
 /// }
 /// ```
-#[proc_macro_derive(ExtensionOutput)]
+#[proc_macro_derive(ExtensionType)]
 pub fn derive_extension_output(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemStruct);
     let name = &input.ident;
@@ -712,14 +712,14 @@ pub fn derive_extension_output(input: TokenStream) -> TokenStream {
 
             quote! { #name { #( #field_mappings )* } }
         }
-        _ => panic!("ExtensionOutput derive only supports structs with named fields"),
+        _ => panic!("ExtensionType derive only supports structs with named fields"),
     };
 
     TokenStream::from(quote! {
-        impl #impl_generics burn::backend::ExtensionOutput<B> for #name #ty_generics #where_clause {
+        impl #impl_generics burn::backend::ExtensionType<B> for #name #ty_generics #where_clause {
             type Target = #name<burn::backend::Dispatch>;
 
-            fn wrap_output<F>(
+            fn map_type<F>(
                 self,
                 wrap_kind: F,
                 checkpointing: Option<burn::backend::CheckpointingStrategy>,

--- a/crates/burn-backend-extension/src/lib.rs
+++ b/crates/burn-backend-extension/src/lib.rs
@@ -674,6 +674,15 @@ fn gen_tensor_wrap(
 /// - The struct must have named fields.
 /// - The struct must be generic over a `Backend` type parameter (`B`).
 ///
+/// # Field Attributes
+///
+/// By default, the macro inspects the type of each field:
+/// - **Tensor Primitives**: Automatically mapped.
+/// - **Other types**: Passed through unmodified.
+///
+/// To nest another custom struct that also implements `ExtensionType`, you must annotate it with
+/// `#[extension_type]` to tell the macro to traverse it recursively.
+///
 /// # Example
 ///
 /// ```rust,ignore
@@ -685,7 +694,7 @@ fn gen_tensor_wrap(
 ///     pub count: usize, // Non-tensor field passes through automatically
 /// }
 /// ```
-#[proc_macro_derive(ExtensionType)]
+#[proc_macro_derive(ExtensionType, attributes(extension_type))]
 pub fn derive_extension_output(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemStruct);
     let name = &input.ident;
@@ -696,11 +705,23 @@ pub fn derive_extension_output(input: TokenStream) -> TokenStream {
         syn::Fields::Named(fields) => {
             let field_mappings = fields.named.iter().map(|f| {
                 let f_name = &f.ident;
-                if let Some(tensor_kind) = TensorKind::from_type(&f.ty) {
+                let is_ext = f.attrs.iter().any(|attr| attr.path().is_ident("extension_type"));
+
+                if is_ext {
+                    // It's a nested extension type
+                    quote! {
+                        #f_name: self.#f_name.map_type(
+                            &map_kind,
+                            checkpointing
+                        ),
+                    }
+                }
+                else if let Some(tensor_kind) = TensorKind::from_type(&f.ty) {
+                    // Tensor primitive
                     let variant_ident = tensor_kind.variant();
                     quote! {
                         #f_name: burn::backend::DispatchTensor {
-                            kind: wrap_kind(burn::backend::BackendTensor::#variant_ident(self.#f_name)),
+                            kind: map_kind(burn::backend::BackendTensor::#variant_ident(self.#f_name)),
                             checkpointing,
                         },
                     }
@@ -721,7 +742,7 @@ pub fn derive_extension_output(input: TokenStream) -> TokenStream {
 
             fn map_type<F>(
                 self,
-                wrap_kind: F,
+                map_kind: F,
                 checkpointing: Option<burn::backend::CheckpointingStrategy>,
             ) -> Self::Target
             where

--- a/crates/burn-backend-extension/src/lib.rs
+++ b/crates/burn-backend-extension/src/lib.rs
@@ -157,17 +157,18 @@ struct OperationArg {
     kind: ArgKind,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 enum OutputKind {
     Tensor(TensorKind),
-    Custom(syn::Type),
+    Custom(Type),
 }
 
 #[derive(Debug, Clone)]
 enum OperationOutput {
     Tensor(TensorKind),
     Tuple(Vec<OutputKind>),
-    Custom(syn::Type),
+    Custom(Type),
 }
 
 struct Operation {
@@ -290,7 +291,7 @@ fn lower_extension(attr: Backends, item: &ItemTrait) -> syn::Result<Extension> {
             }
             ReturnType::Type(_, ty) => {
                 // TODO: expand support for vec and maybe nested containers
-                if let syn::Type::Tuple(tup) = ty.as_ref() {
+                if let Type::Tuple(tup) = ty.as_ref() {
                     let elements = tup
                         .elems
                         .iter()

--- a/crates/burn-backend-extension/src/lib.rs
+++ b/crates/burn-backend-extension/src/lib.rs
@@ -164,6 +164,7 @@ enum OutputKind {
     Custom(Type),
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 enum OperationOutput {
     Tensor(TensorKind),

--- a/crates/burn-backend-extension/src/lib.rs
+++ b/crates/burn-backend-extension/src/lib.rs
@@ -5,7 +5,8 @@ use proc_macro2::TokenStream as TokenStream2;
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::{
-    FnArg, Ident, ItemTrait, Meta, Pat, ReturnType, Token, TraitItem, Type, parse_macro_input,
+    FnArg, Ident, ItemStruct, ItemTrait, Meta, Pat, ReturnType, Token, TraitItem, Type,
+    parse_macro_input,
 };
 
 /// # `backend_extension`
@@ -156,10 +157,23 @@ struct OperationArg {
     kind: ArgKind,
 }
 
+#[derive(Debug, Clone)]
+enum OutputKind {
+    Tensor(TensorKind),
+    Custom(syn::Type),
+}
+
+#[derive(Debug, Clone)]
+enum OperationOutput {
+    Tensor(TensorKind),
+    Tuple(Vec<OutputKind>),
+    Custom(syn::Type),
+}
+
 struct Operation {
     name: Ident,
     inputs: Vec<OperationArg>,
-    outputs: Vec<TensorKind>,
+    output: OperationOutput,
 }
 
 struct Extension {
@@ -266,37 +280,42 @@ fn lower_extension(attr: Backends, item: &ItemTrait) -> syn::Result<Extension> {
             inputs.push(OperationArg { name, kind });
         }
 
-        // Parse Outputs (Support single type or tuple)
-        let mut outputs = Vec::new();
-        match &f.sig.output {
-            ReturnType::Default => {}
+        // Parse outputs
+        let output = match &f.sig.output {
+            ReturnType::Default => {
+                return Err(syn::Error::new_spanned(
+                    &f.sig.output,
+                    "Operations must return a value",
+                ));
+            }
             ReturnType::Type(_, ty) => {
-                // TODO: expand support for vec, nested containers, and possibly custom structs
-                // (requires though since we have no type information)
+                // TODO: expand support for vec and maybe nested containers
                 if let syn::Type::Tuple(tup) = ty.as_ref() {
-                    for elem in &tup.elems {
-                        outputs.push(TensorKind::from_type(elem).ok_or_else(|| {
-                            syn::Error::new_spanned(
-                                elem,
-                                "Tuple elements must be Float, Int, or Bool",
-                            )
-                        })?);
-                    }
+                    let elements = tup
+                        .elems
+                        .iter()
+                        .map(|elem| {
+                            if let Some(kind) = TensorKind::from_type(elem) {
+                                Ok(OutputKind::Tensor(kind))
+                            } else {
+                                Ok(OutputKind::Custom(elem.clone()))
+                            }
+                        })
+                        .collect::<syn::Result<Vec<_>>>()?;
+                    OperationOutput::Tuple(elements)
+                } else if let Some(kind) = TensorKind::from_type(ty) {
+                    OperationOutput::Tensor(kind)
                 } else {
-                    outputs.push(TensorKind::from_type(ty).ok_or_else(|| {
-                        syn::Error::new_spanned(
-                            ty,
-                            "Return must be Float, Int, Bool, or a tuple of them",
-                        )
-                    })?);
+                    // ExtensionOutput
+                    OperationOutput::Custom(*ty.clone())
                 }
             }
-        }
+        };
 
         ops.push(Operation {
             name: f.sig.ident.clone(),
             inputs,
-            outputs,
+            output,
         });
     }
 
@@ -307,28 +326,8 @@ fn lower_extension(attr: Backends, item: &ItemTrait) -> syn::Result<Extension> {
     })
 }
 
-fn expand_extension(ir: Extension, mut original_trait: ItemTrait) -> TokenStream2 {
+fn expand_extension(ir: Extension, original_trait: ItemTrait) -> TokenStream2 {
     let trait_name = &ir.trait_name;
-
-    // Rewrite the original trait to use full Burn types
-    for item in &mut original_trait.items {
-        if let TraitItem::Fn(f) = item {
-            for arg in &mut f.sig.inputs {
-                if let FnArg::Typed(pt) = arg
-                    && let Some(kind) = TensorKind::from_type(&pt.ty)
-                {
-                    let ty = kind.to_primitive_ty();
-                    *pt.ty = syn::parse2(ty).unwrap();
-                }
-            }
-            if let ReturnType::Type(_, ty) = &mut f.sig.output
-                && let Some(kind) = TensorKind::from_type(ty)
-            {
-                let new_ty = kind.to_primitive_ty();
-                **ty = syn::parse2(new_ty).unwrap();
-            }
-        }
-    }
 
     // Generate Dispatch Implementation
     let dispatch_methods = ir.ops.iter().map(|op| gen_dispatch_method(&ir, op));
@@ -352,7 +351,6 @@ fn gen_dispatch_method(ir: &Extension, op: &Operation) -> TokenStream2 {
         .as_ref()
         .map(|meta| quote! { #[#meta] });
 
-    // Signature generation
     let sig_args = op.inputs.iter().map(|arg| {
         let name = &arg.name;
         match &arg.kind {
@@ -364,16 +362,18 @@ fn gen_dispatch_method(ir: &Extension, op: &Operation) -> TokenStream2 {
         }
     });
 
-    let ret_ty = match op.outputs.len() {
-        0 => unimplemented!(), // TODO: error?
-        1 => op.outputs[0].to_primitive_ty(),
-        _ => {
-            let types = op.outputs.iter().map(|k| k.to_primitive_ty());
+    let ret_ty = match &op.output {
+        OperationOutput::Tensor(k) => k.to_primitive_ty(),
+        OperationOutput::Tuple(elems) => {
+            let types = elems.iter().map(|e| match e {
+                OutputKind::Tensor(k) => k.to_primitive_ty(),
+                OutputKind::Custom(ty) => quote! { #ty },
+            });
             quote! { (#(#types),*) }
         }
+        OperationOutput::Custom(ty) => quote! { #ty },
     };
 
-    // Match inputs
     let tensor_inputs: Vec<_> = op
         .inputs
         .iter()
@@ -382,8 +382,9 @@ fn gen_dispatch_method(ir: &Extension, op: &Operation) -> TokenStream2 {
             _ => None,
         })
         .collect();
+
     let match_inputs = match tensor_inputs.len() {
-        0 => unimplemented!(), // TODO: error?
+        0 => quote! { () },
         1 => {
             let name = tensor_inputs[0];
             quote! { #name.kind }
@@ -394,20 +395,17 @@ fn gen_dispatch_method(ir: &Extension, op: &Operation) -> TokenStream2 {
         }
     };
 
-    // Checkpointing logic (when applicable, just check first tensor)
     let first_tensor = op.inputs.iter().find_map(|a| match &a.kind {
         ArgKind::Tensor(_) => Some(&a.name),
         _ => None,
     });
+
     let ckp_logic = if let Some(name) = first_tensor {
-        quote! {
-            let checkpointing = #name.checkpointing.clone();
-        }
+        quote! { let checkpointing = #name.checkpointing.clone(); }
     } else {
-        quote! {}
+        quote! { let checkpointing = None; }
     };
 
-    // Match arms for DispatchTensorKind::$Backends
     let concrete_arms = ir
         .backends
         .concrete
@@ -419,39 +417,15 @@ fn gen_dispatch_method(ir: &Extension, op: &Operation) -> TokenStream2 {
         None
     };
 
-    // Wrap the resulting tensor(s)
-    // If the macro is in AD-mode, we include the field. If not, we don't.
-    let wrap_output = |kinds_access: TokenStream2| {
-        quote! {
-            burn::backend::DispatchTensor {
-                kind: #kinds_access,
-                checkpointing: checkpointing.clone(), // Field always present, but None when not autodiff
-            }
-        }
-    };
-
-    let final_return = if op.outputs.len() == 1 {
-        wrap_output(quote! { _kinds })
-    } else {
-        let wraps = op.outputs.iter().enumerate().map(|(i, _)| {
-            let idx = syn::Index::from(i);
-            wrap_output(quote! { _kinds.#idx })
-        });
-        quote! { (#(#wraps),*) }
-    };
-
     quote! {
         fn #name(#(#sig_args),*) -> #ret_ty {
             #ckp_logic
-
-            let _kinds = match #match_inputs {
+            match #match_inputs {
                 #( #concrete_arms )*
                 #ad_cfg_attr
                 #ad_arm
                 _ => unimplemented!("Backend not supported for custom op `{}`", stringify!(#name)),
-            };
-
-            #final_return
+            }
         }
     }
 }
@@ -494,7 +468,36 @@ fn gen_backend_arm(ir: &Extension, op: &Operation, backend: &Backend) -> TokenSt
 
     // Call the method and wrap the result
     let call_args = op.inputs.iter().map(|a| &a.name);
-    let wrap_out = gen_result_wrap(op, &b_ident, false);
+    let wrap_out = match &op.output {
+        OperationOutput::Tensor(kind) => {
+            let wrapped = gen_tensor_wrap(kind, quote! { _out }, &b_ident, false);
+            quote! { burn::backend::DispatchTensor { kind: #wrapped, checkpointing } }
+        }
+        OperationOutput::Tuple(elems) => {
+            let elements = elems.iter().enumerate().map(|(i, elem)| {
+                let idx = syn::Index::from(i);
+                match elem {
+                    OutputKind::Tensor(kind) => {
+                        let wrapped = gen_tensor_wrap(kind, quote! { _out.#idx }, &b_ident, false);
+                        quote! { burn::backend::DispatchTensor { kind: #wrapped, checkpointing } }
+                    }
+                    OutputKind::Custom(_) => {
+                        quote! {
+                            burn::backend::ExtensionOutput::wrap_output(
+                                _out.#idx,
+                                |tensor| burn::backend::DispatchTensorKind::#b_ident(tensor),
+                                checkpointing,
+                            )
+                        }
+                    }
+                }
+            });
+            quote! { (#(#elements),*) }
+        }
+        OperationOutput::Custom(_) => {
+            quote! { burn::backend::ExtensionOutput::wrap_output(_out, |tensor| burn::backend::DispatchTensorKind::#b_ident(tensor), checkpointing) }
+        }
+    };
 
     quote! {
         #cfg_attr
@@ -570,7 +573,53 @@ fn gen_autodiff_arm(ir: &Extension, op: &Operation) -> TokenStream2 {
         });
 
         let call_args = op.inputs.iter().map(|a| &a.name);
-        let wrap_out = gen_result_wrap(op, &b_ident, true);
+        let wrap_out = match &op.output {
+            OperationOutput::Tensor(kind) => {
+                let wrapped = gen_tensor_wrap(kind, quote! { _out }, &b_ident, true);
+                quote! { burn::backend::DispatchTensor { kind: #wrapped, checkpointing } }
+            }
+            OperationOutput::Tuple(elems) => {
+                let elements = elems.iter().enumerate().map(|(i, elem)| {
+                let idx = syn::Index::from(i);
+                match elem {
+                    OutputKind::Tensor(kind) => {
+                        let wrapped = gen_tensor_wrap(kind, quote! { _out.#idx }, &b_ident, true);
+                        quote! { burn::backend::DispatchTensor { kind: #wrapped, checkpointing } }
+                    }
+                    OutputKind::Custom(_) => {
+                        quote! {
+                            burn::backend::ExtensionOutput::wrap_output(
+                                _out.#idx,
+                                |tensor| match tensor {
+                                    burn::backend::BackendTensor::Float(t) => {
+                                        burn::backend::DispatchTensorKind::Autodiff(
+                                            Box::new(burn::backend::DispatchTensorKind::#b_ident(
+                                                burn::backend::BackendTensor::Autodiff(t)
+                                            ))
+                                        )
+                                    }
+                                    _ => burn::backend::DispatchTensorKind::#b_ident(tensor),
+                                },
+                                checkpointing,
+                            )
+                        }
+                    }
+                }
+            });
+                quote! { (#(#elements),*) }
+            }
+            OperationOutput::Custom(_) => {
+                quote! { burn::backend::ExtensionOutput::wrap_output(_out, |tensor| match tensor {
+                    burn::backend::BackendTensor::Float(t) => {
+                        burn::backend::DispatchTensorKind::Autodiff(
+                            Box::new(burn::backend::DispatchTensorKind::#b_ident(
+                                burn::backend::BackendTensor::Autodiff(t)
+                            ))
+                        )
+                    }
+                }, checkpointing) }
+            }
+        };
 
         quote! {
             #cfg_attr
@@ -588,41 +637,96 @@ fn gen_autodiff_arm(ir: &Extension, op: &Operation) -> TokenStream2 {
     }
 }
 
-fn gen_result_wrap(op: &Operation, b_ident: &Ident, is_ad: bool) -> TokenStream2 {
-    let wrap_item = |kind: TensorKind, val: TokenStream2| {
-        let variant = kind.variant();
-        if is_ad && kind == TensorKind::Float {
-            // Wrap as Autodiff(Backend(Autodiff(tensor)))
-            quote! {
-                burn::backend::DispatchTensorKind::Autodiff(
-                    Box::new(burn::backend::DispatchTensorKind::#b_ident(
-                        burn::backend::BackendTensor::Autodiff(#val)
-                    ))
-                )
-            }
-        } else {
-            quote! {
-                burn::backend::DispatchTensorKind::#b_ident(
-                    burn::backend::BackendTensor::#variant(#val)
-                )
-            }
+fn gen_tensor_wrap(
+    kind: &TensorKind,
+    val: TokenStream2,
+    b_ident: &Ident,
+    is_ad: bool,
+) -> TokenStream2 {
+    let variant = kind.variant();
+    if is_ad && *kind == TensorKind::Float {
+        quote! {
+            burn::backend::DispatchTensorKind::Autodiff(
+                Box::new(burn::backend::DispatchTensorKind::#b_ident(
+                    burn::backend::BackendTensor::Autodiff(#val)
+                ))
+            )
         }
+    } else {
+        quote! {
+            burn::backend::DispatchTensorKind::#b_ident(
+                burn::backend::BackendTensor::#variant(#val)
+            )
+        }
+    }
+}
+
+/// Derive macro to implement `ExtensionOutput` for custom structures returned by backend extensions.
+///
+/// When a custom backend extension operation needs to return multiple tensors or a mix of tensors
+/// and metadata (instead of a single tensor primitive or container of primitives), this macro automates
+/// the process of wrapping the tensor primitives so they can cross the boundary into the `Dispatch` backend.
+///
+/// # Requirements
+///
+/// - The struct must have named fields.
+/// - The struct must be generic over a `Backend` type parameter (`B`).
+///
+/// # Example
+///
+/// ```rust,ignore
+/// #[derive(ExtensionOutput)]
+/// pub struct OperationOutput<B: Backend> {
+///     pub bool: BoolTensor<B>,
+///     pub int: IntTensor<B>,
+///     pub float: FloaTensor<B>,
+///     pub count: usize, // Non-tensor field passes through automatically
+/// }
+/// ```
+#[proc_macro_derive(ExtensionOutput)]
+pub fn derive_extension_output(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as ItemStruct);
+    let name = &input.ident;
+
+    // Extract generics for the trait implementation block
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let fields_wrap = match &input.fields {
+        syn::Fields::Named(fields) => {
+            let field_mappings = fields.named.iter().map(|f| {
+                let f_name = &f.ident;
+                if let Some(tensor_kind) = TensorKind::from_type(&f.ty) {
+                    let variant_ident = tensor_kind.variant();
+                    quote! {
+                        #f_name: burn::backend::DispatchTensor {
+                            kind: wrap_kind(burn::backend::BackendTensor::#variant_ident(self.#f_name)),
+                            checkpointing,
+                        },
+                    }
+                } else {
+                    // Passthrough
+                    quote! { #f_name: self.#f_name, }
+                }
+             });
+
+            quote! { #name { #( #field_mappings )* } }
+        }
+        _ => panic!("ExtensionOutput derive only supports structs with named fields"),
     };
 
-    let wrapped_kinds = match op.outputs.len() {
-        0 => quote! { () },
-        1 => {
-            let kind = wrap_item(op.outputs[0], quote! { _out });
-            quote! { #kind }
-        }
-        _ => {
-            let elements = op.outputs.iter().enumerate().map(|(i, &kind)| {
-                let idx = syn::Index::from(i);
-                wrap_item(kind, quote! { _out.#idx })
-            });
-            quote! { (#(#elements),*) }
-        }
-    };
+    TokenStream::from(quote! {
+        impl #impl_generics burn::backend::ExtensionOutput<B> for #name #ty_generics #where_clause {
+            type Target = #name<burn::backend::Dispatch>;
 
-    quote! { #wrapped_kinds }
+            fn wrap_output<F>(
+                self,
+                wrap_kind: F,
+                checkpointing: Option<burn::backend::CheckpointingStrategy>,
+            ) -> Self::Target
+            where
+                F: Fn(burn::backend::BackendTensor<B>) -> burn::backend::DispatchTensorKind,
+            {
+                #fields_wrap
+            }
+        }
+    })
 }

--- a/crates/burn-backend-tests/tests/autodiff/all_reduce.rs
+++ b/crates/burn-backend-tests/tests/autodiff/all_reduce.rs
@@ -9,6 +9,8 @@ use burn_tensor::{
 };
 use serial_test::serial;
 
+// TODO
+
 #[test]
 #[serial]
 fn should_diff_all_reduce_sum() {

--- a/crates/burn-core/src/backend.rs
+++ b/crates/burn-core/src/backend.rs
@@ -2,9 +2,42 @@
 pub use burn_ir as ir;
 
 pub use burn_backend::*;
-pub use burn_backend_extension::backend_extension;
+pub use burn_backend_extension::*;
 
 // Dispatch backend extension types
 pub use burn_dispatch::{backend::*, device::*, tensor::*};
 // Re-export backends (e.g., Cuda)
 pub use burn_dispatch::backends::*;
+
+/// A trait to allow mapping custom backend-specific structures into their generic dispatch equivalents.
+///
+/// This trait is designed to cooperate with the [`#[backend_extension]`](backend_extension) macro. When an
+/// extension operation returns a custom struct containing multiple tensor primitives rather than a single
+/// output tensor primitive, this trait provides the mechanism to traverse that struct and recursively wrap
+/// each internal field into a [`DispatchTensor`].
+///
+/// Implementations of this trait are generated automatically using `#[derive(ExtensionOutput)]`.
+pub trait ExtensionOutput<B: Backend> {
+    /// The target struct layout where all internal concrete backend tensors are transformed
+    /// into [`DispatchTensor`]s.
+    type Target;
+
+    /// Transforms the internal fields of the struct by applying a backend-specific wrapping closure.
+    ///
+    /// # Arguments
+    ///
+    /// * `wrap_kind` - A closure provided by the dispatch macro that knows how to wrap a backend-agnostic
+    ///   [`BackendTensor`] variant into the correct [`DispatchTensorKind`] variant (e.g., `Wgpu`, `Cuda`, `Cpu`).
+    /// * `checkpointing` - The active tensor recording/checkpointing strategy to attach to the [`DispatchTensor`].
+    ///
+    /// # Returns
+    ///
+    /// A new instance of the struct mapped to the [`Dispatch`] backend.
+    fn wrap_output<F>(
+        self,
+        wrap_kind: F,
+        checkpointing: Option<CheckpointingStrategy>,
+    ) -> Self::Target
+    where
+        F: Fn(BackendTensor<B>) -> DispatchTensorKind;
+}

--- a/crates/burn-core/src/backend.rs
+++ b/crates/burn-core/src/backend.rs
@@ -16,8 +16,8 @@ pub use burn_dispatch::backends::*;
 /// output tensor primitive, this trait provides the mechanism to traverse that struct and recursively wrap
 /// each internal field into a [`DispatchTensor`].
 ///
-/// Implementations of this trait are generated automatically using `#[derive(ExtensionOutput)]`.
-pub trait ExtensionOutput<B: Backend> {
+/// Implementations of this trait are generated automatically using `#[derive(ExtensionType)]`.
+pub trait ExtensionType<B: Backend> {
     /// The target struct layout where all internal concrete backend tensors are transformed
     /// into [`DispatchTensor`]s.
     type Target;
@@ -26,18 +26,14 @@ pub trait ExtensionOutput<B: Backend> {
     ///
     /// # Arguments
     ///
-    /// * `wrap_kind` - A closure provided by the dispatch macro that knows how to wrap a backend-agnostic
+    /// * `map_kind` - A closure provided by the dispatch macro that knows how to map a backend-agnostic
     ///   [`BackendTensor`] variant into the correct [`DispatchTensorKind`] variant (e.g., `Wgpu`, `Cuda`, `Cpu`).
     /// * `checkpointing` - The active tensor recording/checkpointing strategy to attach to the [`DispatchTensor`].
     ///
     /// # Returns
     ///
     /// A new instance of the struct mapped to the [`Dispatch`] backend.
-    fn wrap_output<F>(
-        self,
-        wrap_kind: F,
-        checkpointing: Option<CheckpointingStrategy>,
-    ) -> Self::Target
+    fn map_type<F>(self, map_kind: F, checkpointing: Option<CheckpointingStrategy>) -> Self::Target
     where
         F: Fn(BackendTensor<B>) -> DispatchTensorKind;
 }

--- a/crates/burn-vision/src/backends/cpu/connected_components.rs
+++ b/crates/burn-vision/src/backends/cpu/connected_components.rs
@@ -232,14 +232,14 @@ fn finalize_stats<B: Backend, I: Element>(
         B::int_from_data(data, device)
     };
 
-    (
-        into_prim(stats.area),
-        into_prim(stats.left),
-        into_prim(stats.top),
-        into_prim(stats.right),
-        into_prim(stats.bottom),
+    ConnectedStatsPrimitive {
+        area: into_prim(stats.area),
+        left: into_prim(stats.left),
+        top: into_prim(stats.top),
+        right: into_prim(stats.right),
+        bottom: into_prim(stats.bottom),
         max_label,
-    )
+    }
 }
 
 pub fn max_labels(h: usize, w: usize, conn: Connectivity) -> usize {

--- a/crates/burn-vision/src/backends/cube/connected_components/hardware_accelerated.rs
+++ b/crates/burn-vision/src/backends/cube/connected_components/hardware_accelerated.rs
@@ -467,7 +467,6 @@ fn compact_stats<I: Int>(
     bottom_new[new_label as usize] = bottom[label as usize];
 }
 
-#[allow(clippy::type_complexity)]
 pub fn hardware_accelerated<R: CubeRuntime>(
     img: CubeTensor<R>,
     stats_opt: ConnectedStatsOptions,

--- a/crates/burn-vision/src/backends/cube/connected_components/hardware_accelerated.rs
+++ b/crates/burn-vision/src/backends/cube/connected_components/hardware_accelerated.rs
@@ -3,6 +3,7 @@
 //! "A new Direct Connected Component Labeling and Analysis Algorithms for GPUs",
 //! DASIP, 2018
 
+use crate::ConnectedStatsPrimitive;
 use crate::{
     ConnectedStatsOptions, Connectivity, backends::cube::connected_components::stats_from_opts,
 };
@@ -472,18 +473,7 @@ pub fn hardware_accelerated<R: CubeRuntime>(
     stats_opt: ConnectedStatsOptions,
     connectivity: Connectivity,
     int_dtype: DType,
-) -> Result<
-    (
-        CubeTensor<R>,
-        CubeTensor<R>,
-        CubeTensor<R>,
-        CubeTensor<R>,
-        CubeTensor<R>,
-        CubeTensor<R>,
-        CubeTensor<R>,
-    ),
-    String,
-> {
+) -> Result<(CubeTensor<R>, ConnectedStatsPrimitive<CubeBackend<R>>), String> {
     let client = img.client.clone();
     let device = img.device.clone();
     let dtypes = [
@@ -578,22 +568,22 @@ pub fn hardware_accelerated<R: CubeRuntime>(
                 cube_dim,
                 img.clone().into_tensor_arg(),
                 labels.clone().into_tensor_arg(),
-                stats.0.clone().into_tensor_arg(),
-                stats.1.clone().into_tensor_arg(),
-                stats.2.clone().into_tensor_arg(),
-                stats.3.clone().into_tensor_arg(),
-                stats.4.clone().into_tensor_arg(),
-                stats.5.clone().into_tensor_arg(),
+                stats.area.clone().into_tensor_arg(),
+                stats.top.clone().into_tensor_arg(),
+                stats.left.clone().into_tensor_arg(),
+                stats.right.clone().into_tensor_arg(),
+                stats.bottom.clone().into_tensor_arg(),
+                stats.max_label.clone().into_tensor_arg(),
                 stats_opt,
                 dtypes,
             )
         };
         if stats_opt.compact_labels {
-            let max_label = CubeBackend::<R>::int_max(stats.5);
+            let max_label = CubeBackend::<R>::int_max(stats.max_label);
             let max_label = into_data_sync::<R>(max_label);
             let max_label = ToElement::to_usize(&max_label.iter::<i32>().next().unwrap());
             let sliced = kernel::slice::<R>(
-                stats.0.clone(),
+                stats.area.clone(),
                 #[allow(clippy::single_range_in_vec_init)]
                 &[0..(max_label + 1).next_multiple_of(4)],
             );
@@ -604,7 +594,8 @@ pub fn hardware_accelerated<R: CubeRuntime>(
                 (cols as u32).div_ceil(cube_dim.x),
                 (rows as u32).div_ceil(cube_dim.y),
             );
-            stats.5 = zeros_client::<R>(client.clone(), device.clone(), Shape::new([1]), int_dtype);
+            stats.max_label =
+                zeros_client::<R>(client.clone(), device.clone(), Shape::new([1]), int_dtype);
             unsafe {
                 compact_labels::launch_unchecked(
                     &client,
@@ -612,7 +603,7 @@ pub fn hardware_accelerated<R: CubeRuntime>(
                     cube_dim,
                     labels.clone().into_tensor_arg(),
                     relabel.clone().into_tensor_arg(),
-                    stats.5.clone().into_tensor_arg(),
+                    stats.max_label.clone().into_tensor_arg(),
                     int_storage,
                 )
             };
@@ -624,16 +615,16 @@ pub fn hardware_accelerated<R: CubeRuntime>(
                     &client,
                     cube_count,
                     cube_dim,
-                    stats.0.copy().into_tensor_arg(),
-                    stats.0.clone().into_tensor_arg(),
-                    stats.1.copy().into_tensor_arg(),
-                    stats.1.clone().into_tensor_arg(),
-                    stats.2.copy().into_tensor_arg(),
-                    stats.2.clone().into_tensor_arg(),
-                    stats.3.copy().into_tensor_arg(),
-                    stats.3.clone().into_tensor_arg(),
-                    stats.4.copy().into_tensor_arg(),
-                    stats.4.clone().into_tensor_arg(),
+                    stats.area.copy().into_tensor_arg(),
+                    stats.area.clone().into_tensor_arg(),
+                    stats.top.copy().into_tensor_arg(),
+                    stats.top.clone().into_tensor_arg(),
+                    stats.left.copy().into_tensor_arg(),
+                    stats.left.clone().into_tensor_arg(),
+                    stats.right.copy().into_tensor_arg(),
+                    stats.right.clone().into_tensor_arg(),
+                    stats.bottom.copy().into_tensor_arg(),
+                    stats.bottom.clone().into_tensor_arg(),
                     relabel.into_tensor_arg(),
                     int_storage,
                 )
@@ -641,5 +632,5 @@ pub fn hardware_accelerated<R: CubeRuntime>(
         }
     }
 
-    Ok((labels, stats.0, stats.1, stats.2, stats.3, stats.4, stats.5))
+    Ok((labels, stats))
 }

--- a/crates/burn-vision/src/backends/cube/connected_components/mod.rs
+++ b/crates/burn-vision/src/backends/cube/connected_components/mod.rs
@@ -49,19 +49,19 @@ pub(crate) fn stats_from_opts<R: CubeRuntime>(
             l.dtype,
         )
     };
-    (
-        (opts != ConnectedStatsOptions::none())
+    ConnectedStatsPrimitive {
+        area: (opts != ConnectedStatsOptions::none())
             .then(zeros)
             .unwrap_or_else(dummy),
-        opts.bounds_enabled.then(max).unwrap_or_else(dummy),
-        opts.bounds_enabled.then(max).unwrap_or_else(dummy),
-        opts.bounds_enabled.then(zeros).unwrap_or_else(dummy),
-        opts.bounds_enabled.then(zeros).unwrap_or_else(dummy),
-        zeros_client::<R>(
+        left: opts.bounds_enabled.then(max).unwrap_or_else(dummy),
+        top: opts.bounds_enabled.then(max).unwrap_or_else(dummy),
+        right: opts.bounds_enabled.then(zeros).unwrap_or_else(dummy),
+        bottom: opts.bounds_enabled.then(zeros).unwrap_or_else(dummy),
+        max_label: zeros_client::<R>(
             l.client.clone(),
             l.device.clone(),
             Shape::new([1]),
             int_dtype,
         ),
-    )
+    }
 }

--- a/crates/burn-vision/src/backends/cube/ops.rs
+++ b/crates/burn-vision/src/backends/cube/ops.rs
@@ -1,6 +1,6 @@
 use crate::{
-    BoolVisionOps, ConnectedStatsOptions, Connectivity, FloatVisionOps, IntVisionOps,
-    VisionBackend, backends::cpu,
+    BoolVisionOps, ConnectedStatsOptions, ConnectedStatsPrimitive, Connectivity, FloatVisionOps,
+    IntVisionOps, VisionBackend, backends::cpu,
 };
 use burn_cubecl::{CubeBackend, CubeRuntime};
 
@@ -39,34 +39,17 @@ impl<R: CubeRuntime> BoolVisionOps for CubeBackend<R> {
         connectivity: Connectivity,
         opts: ConnectedStatsOptions,
         out_dtype: IntDType,
-    ) -> (
-        IntTensor<Self>,
-        IntTensor<Self>,
-        IntTensor<Self>,
-        IntTensor<Self>,
-        IntTensor<Self>,
-        IntTensor<Self>,
-        IntTensor<Self>,
-    ) {
+    ) -> (IntTensor<Self>, ConnectedStatsPrimitive<Self>) {
         let device = Self::bool_device(&img);
         hardware_accelerated::<R>(img.clone(), opts, connectivity, out_dtype.into()).unwrap_or_else(
             |_| {
-                let (labels, (area, top, left, right, bottom, max_label)) =
-                    cpu::connected_components_with_stats::<Self>(
-                        img,
-                        connectivity,
-                        opts,
-                        out_dtype,
-                    );
-                (
-                    Self::int_from_data(labels, &device),
-                    area,
-                    top,
-                    left,
-                    right,
-                    bottom,
-                    max_label,
-                )
+                let (labels, stats) = cpu::connected_components_with_stats::<Self>(
+                    img,
+                    connectivity,
+                    opts,
+                    out_dtype,
+                );
+                (Self::int_from_data(labels, &device), stats)
             },
         )
     }
@@ -141,15 +124,7 @@ mod fusion {
             conn: Connectivity,
             opts: ConnectedStatsOptions,
             out_dtype: IntDType,
-        ) -> (
-            IntTensor<Self>,
-            IntTensor<Self>,
-            IntTensor<Self>,
-            IntTensor<Self>,
-            IntTensor<Self>,
-            IntTensor<Self>,
-            IntTensor<Self>,
-        ) {
+        ) -> (IntTensor<Self>, ConnectedStatsPrimitive<Self>) {
             let height = img.shape[0];
             let width = img.shape[1];
             let client = img.client.clone();
@@ -183,18 +158,17 @@ mod fusion {
                         ],
                     ) = self.desc.as_fixed();
                     let input = handles.get_bool_tensor::<B1>(img);
-                    let (output, area, left, top, right, bottom, max_label) =
-                        B1::connected_components_with_stats(
-                            input, self.conn, self.opts, self.dtype,
-                        );
+                    let (output, stats) = B1::connected_components_with_stats(
+                        input, self.conn, self.opts, self.dtype,
+                    );
 
                     handles.register_int_tensor::<B1>(&labels_ir.id, output);
-                    handles.register_int_tensor::<B1>(&area_ir.id, area);
-                    handles.register_int_tensor::<B1>(&left_ir.id, left);
-                    handles.register_int_tensor::<B1>(&top_ir.id, top);
-                    handles.register_int_tensor::<B1>(&right_ir.id, right);
-                    handles.register_int_tensor::<B1>(&bottom_ir.id, bottom);
-                    handles.register_int_tensor::<B1>(&max_label_ir.id, max_label);
+                    handles.register_int_tensor::<B1>(&area_ir.id, stats.area);
+                    handles.register_int_tensor::<B1>(&left_ir.id, stats.left);
+                    handles.register_int_tensor::<B1>(&top_ir.id, stats.top);
+                    handles.register_int_tensor::<B1>(&right_ir.id, stats.right);
+                    handles.register_int_tensor::<B1>(&bottom_ir.id, stats.bottom);
+                    handles.register_int_tensor::<B1>(&max_label_ir.id, stats.max_label);
                 }
             }
 
@@ -224,7 +198,15 @@ mod fusion {
                 .try_into()
                 .unwrap();
 
-            (out, area, left, top, right, bottom, max_label)
+            let stats = ConnectedStatsPrimitive {
+                area,
+                left,
+                top,
+                right,
+                bottom,
+                max_label,
+            };
+            (out, stats)
         }
     }
     impl<B: FusionBackend + IntVisionOps> IntVisionOps for Fusion<B> {}

--- a/crates/burn-vision/src/ops/base.rs
+++ b/crates/burn-vision/src/ops/base.rs
@@ -98,7 +98,6 @@ pub struct ConnectedStats {
 
 #[derive(ExtensionOutput)]
 /// Primitive version of [`ConnectedStats`], to be returned by the backend
-
 pub struct ConnectedStatsPrimitive<B: Backend> {
     /// Total area of each component
     pub area: IntTensor<B>,

--- a/crates/burn-vision/src/ops/base.rs
+++ b/crates/burn-vision/src/ops/base.rs
@@ -4,9 +4,12 @@ use crate::{
 };
 use bon::Builder;
 
-use burn_core as burn; // for backend_extension
-use burn_core::backend::{Backend, backend_extension, tensor::IntTensor};
+use burn_core::backend::{
+    Backend, ExtensionOutput, backend_extension,
+    tensor::{BoolTensor, IntTensor},
+};
 use burn_core::tensor::{Int, IntDType, Scalar, Tensor, read_sync};
+use burn_core::{self as burn, backend::tensor::FloatTensor}; // for backend_extension
 
 /// Connected components connectivity
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -93,21 +96,23 @@ pub struct ConnectedStats {
     pub max_label: Tensor<1, Int>,
 }
 
+#[derive(ExtensionOutput)]
 /// Primitive version of [`ConnectedStats`], to be returned by the backend
-pub type ConnectedStatsPrimitive<B> = (
-    // Total area of each component
-    IntTensor<B>,
-    // Leftmost x coordinate in the component
-    IntTensor<B>,
-    // Topmost y coordinate in the component
-    IntTensor<B>,
-    // Rightmost x coordinate in the component
-    IntTensor<B>,
-    // Bottommost y coordinate in the component
-    IntTensor<B>,
-    // Scalar tensor of the max label
-    IntTensor<B>,
-);
+
+pub struct ConnectedStatsPrimitive<B: Backend> {
+    /// Total area of each component
+    pub area: IntTensor<B>,
+    /// Leftmost x coordinate in the component
+    pub left: IntTensor<B>,
+    /// Topmost y coordinate in the component
+    pub top: IntTensor<B>,
+    /// Rightmost x coordinate in the component
+    pub right: IntTensor<B>,
+    /// Bottommost y coordinate in the component
+    pub bottom: IntTensor<B>,
+    /// Scalar tensor of the max label
+    pub max_label: IntTensor<B>,
+}
 
 impl Default for ConnectedStatsOptions {
     fn default() -> Self {
@@ -240,27 +245,11 @@ pub trait BoolVisionOps: Backend {
         connectivity: Connectivity,
         opts: ConnectedStatsOptions,
         out_dtype: IntDType,
-    ) -> (
-        IntTensor<Self>,
-        IntTensor<Self>,
-        IntTensor<Self>,
-        IntTensor<Self>,
-        IntTensor<Self>,
-        IntTensor<Self>,
-        IntTensor<Self>,
-    ) {
+    ) -> (IntTensor<Self>, ConnectedStatsPrimitive<Self>) {
         let device = Self::bool_device(&img);
-        let (labels, (area, top, left, right, bottom, max_label)) =
+        let (labels, stats) =
             cpu::connected_components_with_stats::<Self>(img, connectivity, opts, out_dtype);
-        (
-            Self::int_from_data(labels, &device),
-            area,
-            top,
-            left,
-            right,
-            bottom,
-            max_label,
-        )
+        (Self::int_from_data(labels, &device), stats)
     }
 
     /// Erodes an input tensor with the specified kernel.

--- a/crates/burn-vision/src/ops/base.rs
+++ b/crates/burn-vision/src/ops/base.rs
@@ -238,8 +238,6 @@ pub trait BoolVisionOps: Backend {
     /// label of each pixel, along with stats collected for each component.
     ///
     /// `img`- The boolean image tensor in the format [batches, height, width]
-    // TODO: support struct return types that encapsulate tensors with `#[backend_extension]`
-    #[allow(clippy::type_complexity)]
     fn connected_components_with_stats(
         img: BoolTensor<Self>,
         connectivity: Connectivity,

--- a/crates/burn-vision/src/ops/base.rs
+++ b/crates/burn-vision/src/ops/base.rs
@@ -5,7 +5,7 @@ use crate::{
 use bon::Builder;
 
 use burn_core::backend::{
-    Backend, ExtensionOutput, backend_extension,
+    Backend, ExtensionType, backend_extension,
     tensor::{BoolTensor, IntTensor},
 };
 use burn_core::tensor::{Int, IntDType, Scalar, Tensor, read_sync};
@@ -96,7 +96,7 @@ pub struct ConnectedStats {
     pub max_label: Tensor<1, Int>,
 }
 
-#[derive(ExtensionOutput)]
+#[derive(ExtensionType)]
 /// Primitive version of [`ConnectedStats`], to be returned by the backend
 pub struct ConnectedStatsPrimitive<B: Backend> {
     /// Total area of each component

--- a/crates/burn-vision/src/tensor.rs
+++ b/crates/burn-vision/src/tensor.rs
@@ -71,20 +71,20 @@ impl ConnectedComponents for Tensor<2, Bool> {
     ) -> (Tensor<2, Int>, ConnectedStats) {
         println!("Tensor::connected_components_with_stats");
         let settings = self.device().settings();
-        let (labels, area, left, top, right, bottom, max_label) =
-            <Dispatch as BoolVisionOps>::connected_components_with_stats(
-                self.into_primitive(),
-                connectivity,
-                options,
-                settings.int_dtype,
-            );
+        let (labels, stats) = <Dispatch as BoolVisionOps>::connected_components_with_stats(
+            self.into_primitive(),
+            connectivity,
+            options,
+            settings.int_dtype,
+        );
+
         let stats = ConnectedStats {
-            area: Tensor::from_primitive(area),
-            left: Tensor::from_primitive(left),
-            top: Tensor::from_primitive(top),
-            right: Tensor::from_primitive(right),
-            bottom: Tensor::from_primitive(bottom),
-            max_label: Tensor::from_primitive(max_label),
+            area: Tensor::from_primitive(stats.area),
+            left: Tensor::from_primitive(stats.left),
+            top: Tensor::from_primitive(stats.top),
+            right: Tensor::from_primitive(stats.right),
+            bottom: Tensor::from_primitive(stats.bottom),
+            max_label: Tensor::from_primitive(stats.max_label),
         };
         (Tensor::from_primitive(labels), stats)
     }


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Closes #4972

### Changes

Added `ExtensionType` trait and derive to support custom output types that wrap tensor primitives

Example usage:
```rust
#[derive(ExtensionType)]
pub struct ConnectedStatsPrimitive<B: Backend> {
    /// Total area of each component
    pub area: IntTensor<B>,
    /// Coordinates
    #[extension_type] // nested extension type
    pub coord: Coords<B>,
    /// Scalar tensor of the max label
    pub max_label: IntTensor<B>,
}

#[derive(ExtensionType)]
pub struct Coords<B: Backend> {
    /// Leftmost x coordinate in the component
    pub left: IntTensor<B>,
    /// Topmost y coordinate in the component
    pub top: IntTensor<B>,
    /// Rightmost x coordinate in the component
    pub right: IntTensor<B>,
    /// Bottommost y coordinate in the component
    pub bottom: IntTensor<B>,
}

// Used in a backend extension trait operation output

#[backend_extension(
    Flex: cfg(feature = "flex"),
    Wgpu: cfg(feature = "wgpu"),
    // ...
)]
/// Vision ops on bool tensors
pub trait BoolVisionOps: Backend {
    fn connected_components_with_stats(
        img: BoolTensor<Self>,
        connectivity: Connectivity,
        opts: ConnectedStatsOptions,
        out_dtype: IntDType,
    ) -> (IntTensor<Self>, ConnectedStatsPrimitive<Self>) {
        let device = Self::bool_device(&img);
        let (labels, stats) =
            cpu::connected_components_with_stats::<Self>(img, connectivity, opts, out_dtype);
        (Self::int_from_data(labels, &device), stats)
    }
}
```

Nested types have to be explicitly marked by the `#[extension_type]` attribute. I thought about inferring the intent based on the `B` backend generic, but that might be fragile.

### Testing

Unit tests
