### PR TITLE
feat(store): add .allow_partial(true) hint in TensorNotFound error

### DIFF
--- a/burn-book/src/saving-and-loading.md
+++ b/burn-book/src/saving-and-loading.md
@@ -198,9 +198,17 @@ model.save_into(&mut store)?;
 
 ### Handling Load Results
 
-The `load_from` method returns detailed information about the loading process:
+The `load_from` method returns detailed information about the loading process.
+
+> **Note:** Inspecting `result.missing`, `result.errors`, etc. requires the store to be configured with
+> [`.allow_partial(true)`](#partial-loading). Without it, a missing tensor causes a hard `Err`
+> before you ever receive an `ApplyResult`.
 
 ```rust, ignore
+// Use .allow_partial(true) to get an ApplyResult with structured info
+let mut store = PytorchStore::from_file("pretrained.pt")
+    .allow_partial(true);
+
 let result = model.load_from(&mut store)?;
 
 // Print a formatted summary with suggestions
@@ -213,6 +221,15 @@ println!("Errors: {:?}", result.errors);
 
 if result.is_success() {
     println!("All tensors loaded successfully");
+}
+```
+
+If you don't use `.allow_partial(true)`, use normal error handling:
+
+```rust, ignore
+match model.load_from(&mut store) {
+    Ok(result) => println!("Loaded successfully: {} tensors", result.applied.len()),
+    Err(e) => eprintln!("Failed to load: {e}"),
 }
 ```
 

--- a/crates/burn-store/src/pytorch/store.rs
+++ b/crates/burn-store/src/pytorch/store.rs
@@ -367,7 +367,11 @@ impl ModuleStore for PytorchStore {
         }
 
         if !self.allow_partial && !result.missing.is_empty() {
-            return Err(PytorchStoreError::TensorNotFound(format!("\n{}", result)));
+            return Err(PytorchStoreError::TensorNotFound(format!(
+                "\n{}\n\nHint: Use `.allow_partial(true)` on the store to get an `ApplyResult` \
+                with structured missing/error info instead of a hard failure.",
+                result
+            )));
         }
 
         Ok(result)

--- a/crates/burn-store/src/safetensors/store.rs
+++ b/crates/burn-store/src/safetensors/store.rs
@@ -718,7 +718,8 @@ impl ModuleStore for SafetensorsStore {
 
         if !self.get_allow_partial() && !result.missing.is_empty() {
             return Err(SafetensorsStoreError::TensorNotFound(format!(
-                "\n{}",
+                "\n{}\n\nHint: Use `.allow_partial(true)` on the store to get an `ApplyResult` \
+                with structured missing/error info instead of a hard failure.",
                 result
             )));
         }


### PR DESCRIPTION
When `load_from` fails due to missing tensors, the error now includes a hint suggesting `.allow_partial(true)` for structured diagnostic info via `ApplyResult`.

**Changes:**
1. **PyTorch store** (`crates/burn-store/src/pytorch/store.rs`): Added hint to `TensorNotFound` error
2. **Safetensors store** (`crates/burn-store/src/safetensors/store.rs`): Added hint to `TensorNotFound` error
3. **Docs** (`burn-book/src/saving-and-loading.md`): Clarified that `result.missing` / `result.errors` require `.allow_partial(true)`, and added error-handling example for the default (non-partial) case

Fixes #4718