### PR TITLE
chore: cleanup remote feature flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,7 +658,6 @@ dependencies = [
  "burn-ndarray",
  "burn-nn",
  "burn-optim",
- "burn-remote",
  "burn-rl",
  "burn-rocm",
  "burn-router",

--- a/crates/burn/Cargo.toml
+++ b/crates/burn/Cargo.toml
@@ -120,11 +120,9 @@ distributed = [
     "burn-core/distributed",
     "burn-optim/distributed",
     "burn-train?/ddp",
-    "burn-router?/distributed",
 ]
-# TODO: add to burn dispatch
-remote = ["burn-remote/client", "ir", "burn-core/remote"]
 router = ["burn-router", "ir"]
+remote = ["burn-core/remote"]
 server = ["burn-core/server"]
 
 candle = ["burn-candle"]
@@ -165,7 +163,6 @@ burn-cpu = { workspace = true, optional = true }
 burn-rocm = { workspace = true, optional = true }
 burn-flex = { workspace = true, optional = true }
 burn-ndarray = { workspace = true, optional = true }
-burn-remote = { workspace = true, optional = true }
 burn-router = { workspace = true, optional = true }
 burn-tch = { workspace = true, optional = true }
 burn-wgpu = { workspace = true, optional = true }

--- a/crates/burn/src/collective.rs
+++ b/crates/burn/src/collective.rs
@@ -1,1 +1,0 @@
-pub use burn_collective::*;


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Changes

- Removed `burn-remote` direct dep from `burn` crate (transitive; enabled via `burn-core` -> `burn-tensor` -> `burn-dispatch`)
- Deleted collective.rs module (unused / leftover)