### PR TITLE
fix(tui): replace panic with clean shutdown on user exit

### DIFF
--- a/crates/burn-train/src/renderer/tui/renderer.rs
+++ b/crates/burn-train/src/renderer/tui/renderer.rs
@@ -114,6 +114,8 @@ impl TuiMetricsRendererWrapper {
 
     fn send_event(&self, event: TuiRendererEvent) {
         if self.kill_signal.lock().unwrap().try_recv().is_ok() {
+            self.interrupter
+                .stop(Some("Killing training from user input."));
             return;
         }
         if let Err(e) = self.sender.send(event) {
@@ -175,7 +177,9 @@ impl MetricsRendererEvaluation for TuiMetricsRendererWrapper {
 impl MetricsRenderer for TuiMetricsRendererWrapper {
     fn manual_close(&mut self) {
         self.send_event(TuiRendererEvent::ManualClose);
-        let _ = self.handle_join.take().unwrap().join();
+        if let Some(handle) = self.handle_join.take() {
+            let _ = handle.join();
+        }
     }
 
     fn register_metric(&mut self, definition: MetricDefinition) {
@@ -231,7 +235,7 @@ impl MetricsRendererTraining for TuiMetricsRendererWrapper {
 impl Drop for TuiMetricsRendererWrapper {
     fn drop(&mut self) {
         if !std::thread::panicking() {
-            self.send_event(TuiRendererEvent::Close);
+            let _ = self.sender.send(TuiRendererEvent::Close);
             if let Some(handle) = self.handle_join.take() {
                 let _ = handle.join();
             }
@@ -432,7 +436,10 @@ impl TuiMetricsRenderer {
                                  the current training fails. Any code following the training \
                                  won't be executed.",
                             'k',
-                            KillPopupAccept(self.kill_signal.clone()),
+                            KillPopupAccept {
+                                interrupter: self.interrupter.clone(),
+                                kill_signal: self.kill_signal.clone(),
+                            },
                         ),
                         Callback::new(
                             "Cancel",
@@ -528,12 +535,18 @@ impl TuiMetricsRenderer {
 }
 
 struct QuitPopupAccept(Interrupter);
-struct KillPopupAccept(Sender<()>);
+struct KillPopupAccept {
+    interrupter: Interrupter,
+    kill_signal: Sender<()>,
+}
+
 struct PopupCancel;
 
 impl CallbackFn for KillPopupAccept {
     fn call(&self) -> bool {
-        self.0.send(()).unwrap();
+        self.kill_signal.send(()).unwrap();
+        self.interrupter
+            .stop(Some("Killing training from user input."));
         true
     }
 }

--- a/crates/burn-train/src/renderer/tui/renderer.rs
+++ b/crates/burn-train/src/renderer/tui/renderer.rs
@@ -114,7 +114,7 @@ impl TuiMetricsRendererWrapper {
 
     fn send_event(&self, event: TuiRendererEvent) {
         if self.kill_signal.lock().unwrap().try_recv().is_ok() {
-            panic!("Killing training from user input.")
+            return;
         }
         if let Err(e) = self.sender.send(event) {
             log::warn!("Failed to send TUI event: {e}");
@@ -534,7 +534,7 @@ struct PopupCancel;
 impl CallbackFn for KillPopupAccept {
     fn call(&self) -> bool {
         self.0.send(()).unwrap();
-        panic!("Killing training from user input.");
+        true
     }
 }
 


### PR DESCRIPTION
When the user kills training in TUI mode (via kill popup or Ctrl+C), the renderer was calling `panic!()` instead of shutting down cleanly, producing a scary error message:

```PANIC: thread panicked at ... renderer.rs:345:9:\nKilling training from user input.```

**Changes:**- `send_event`: return early instead of panicking when kill signal is received- 
`KillPopupAccept::call`: return `true` instead of panicking 

(consistent with `QuitPopupAccept`)

Fixes #4657