### PR TITLE
feat: add missing `Device` staging and memory cleanup methods

### DIFF
--- a/crates/burn-tensor/src/device.rs
+++ b/crates/burn-tensor/src/device.rs
@@ -6,7 +6,7 @@ use burn_backend::{Backend, DeviceOps};
 #[allow(unused)]
 use burn_dispatch::DispatchDeviceId;
 use burn_dispatch::{Dispatch, DispatchDevice};
-use burn_std::{BoolDType, FloatDType, IntDType};
+use burn_std::{BoolDType, FloatDType, IntDType, TensorData};
 
 use alloc::vec::Vec;
 use enumset::{EnumSet, EnumSetType};
@@ -517,6 +517,25 @@ impl Device {
         func: Func,
     ) -> Output {
         Dispatch::memory_persistent_allocations(self.as_dispatch(), input, func)
+    }
+
+    /// Triggers a memory cleanup on this device.
+    ///
+    /// The amount of memory reclaimed depends on the allocator implementation.
+    /// Calling this method does not guarantee that any memory will be freed.
+    pub fn memory_cleanup(&self) {
+        Dispatch::memory_cleanup(self.as_dispatch());
+    }
+
+    /// Prepares the given data for transfer between the CPU and accelerator devices such as GPUs.
+    ///
+    /// Depending on the backend, the data may be transferred to pinned memory
+    /// or another transfer-optimized format to improve transfer performance.
+    pub fn staging<'a, Iter>(&self, data: Iter)
+    where
+        Iter: Iterator<Item = &'a mut TensorData>,
+    {
+        Dispatch::staging(data, self.as_dispatch());
     }
 
     /// Returns the [`DeviceSettings`] for this device.


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Stumbled upon these missing APIs when reviewing https://github.com/tracel-ai/burn-lm/pull/55

### Changes

- Added missing `device.staging(...)` and `device.memory_cleanup(...)` methods
