### PR TITLE
feat(extension): support async fn + futures and add `Tensor` low-level backend primitive interop

### DIFF
--- a/crates/burn-backend-extension/src/lib.rs
+++ b/crates/burn-backend-extension/src/lib.rs
@@ -5,8 +5,8 @@ use proc_macro2::TokenStream as TokenStream2;
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::{
-    FnArg, Ident, ItemStruct, ItemTrait, Meta, Pat, ReturnType, Token, TraitItem, Type,
-    parse_macro_input,
+    FnArg, GenericArgument, Ident, ItemStruct, ItemTrait, Meta, Pat, PathArguments, ReturnType,
+    Token, TraitItem, Type, TypeParamBound, parse_macro_input,
 };
 
 /// # `backend_extension`
@@ -176,6 +176,7 @@ struct Operation {
     name: Ident,
     inputs: Vec<OperationArg>,
     output: OperationOutput,
+    asyncness: bool,
 }
 
 struct Extension {
@@ -260,6 +261,28 @@ fn backend_to_ident(b: &Backend) -> Ident {
     format_ident!("{}", format!("{:?}", b.kind))
 }
 
+fn extract_future_output_type(ty: &Type) -> Option<&Type> {
+    if let Type::ImplTrait(impl_trait) = ty {
+        for bound in &impl_trait.bounds {
+            if let TypeParamBound::Trait(trait_bound) = bound {
+                let last_segment = trait_bound.path.segments.last()?;
+                if last_segment.ident == "Future" {
+                    if let PathArguments::AngleBracketed(args) = &last_segment.arguments {
+                        for arg in &args.args {
+                            if let GenericArgument::AssocType(assoc) = arg {
+                                if assoc.ident == "Output" {
+                                    return Some(&assoc.ty);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
 fn lower_extension(attr: Backends, item: &ItemTrait) -> syn::Result<Extension> {
     let mut ops = Vec::new();
 
@@ -283,7 +306,9 @@ fn lower_extension(attr: Backends, item: &ItemTrait) -> syn::Result<Extension> {
         }
 
         // Parse outputs
-        let output = match &f.sig.output {
+
+        // Parse outputs
+        let (actual_ty, is_async) = match &f.sig.output {
             ReturnType::Default => {
                 return Err(syn::Error::new_spanned(
                     &f.sig.output,
@@ -291,26 +316,38 @@ fn lower_extension(attr: Backends, item: &ItemTrait) -> syn::Result<Extension> {
                 ));
             }
             ReturnType::Type(_, ty) => {
-                // TODO: expand support for vec and maybe nested containers
-                if let Type::Tuple(tup) = ty.as_ref() {
-                    let elements = tup
-                        .elems
-                        .iter()
-                        .map(|elem| {
-                            if let Some(kind) = TensorKind::from_type(elem) {
-                                Ok(OutputKind::Tensor(kind))
-                            } else {
-                                Ok(OutputKind::Custom(elem.clone()))
-                            }
-                        })
-                        .collect::<syn::Result<Vec<_>>>()?;
-                    OperationOutput::Tuple(elements)
-                } else if let Some(kind) = TensorKind::from_type(ty) {
-                    OperationOutput::Tensor(kind)
+                // If it's `impl Future<Output = T>`, extract T and mark as async.
+                // Otherwise, use the type as-is and check for `async fn`.
+                if let Some(out_ty) = extract_future_output_type(ty) {
+                    (out_ty, true)
                 } else {
-                    // ExtensionType
-                    OperationOutput::Custom(*ty.clone())
+                    (ty.as_ref(), f.sig.asyncness.is_some())
                 }
+            }
+        };
+
+        let output = match actual_ty {
+            // TODO: expand support for vec and maybe nested containers
+            Type::Tuple(tup) => {
+                let elements = tup
+                    .elems
+                    .iter()
+                    .map(|elem| {
+                        if let Some(kind) = TensorKind::from_type(elem) {
+                            Ok(OutputKind::Tensor(kind))
+                        } else {
+                            Ok(OutputKind::Custom(elem.clone()))
+                        }
+                    })
+                    .collect::<syn::Result<Vec<_>>>()?;
+                OperationOutput::Tuple(elements)
+            }
+            ty if TensorKind::from_type(ty).is_some() => {
+                OperationOutput::Tensor(TensorKind::from_type(ty).unwrap())
+            }
+            ty => {
+                // ExtensionType
+                OperationOutput::Custom(ty.clone())
             }
         };
 
@@ -318,6 +355,7 @@ fn lower_extension(attr: Backends, item: &ItemTrait) -> syn::Result<Extension> {
             name: f.sig.ident.clone(),
             inputs,
             output,
+            asyncness: is_async,
         });
     }
 
@@ -353,12 +391,18 @@ fn gen_dispatch_method(ir: &Extension, op: &Operation) -> TokenStream2 {
         .as_ref()
         .map(|meta| quote! { #[#meta] });
 
+    let maybe_async = if op.asyncness {
+        quote! { async }
+    } else {
+        quote! {}
+    };
+
     let sig_args = op.inputs.iter().map(|arg| {
         let name = &arg.name;
         match &arg.kind {
             ArgKind::Tensor(k) => {
                 let ty = k.to_primitive_ty();
-                quote! { mut #name: #ty }
+                quote! { #name: #ty }
             }
             ArgKind::Other(ty) => quote! { #name: #ty },
         }
@@ -420,7 +464,7 @@ fn gen_dispatch_method(ir: &Extension, op: &Operation) -> TokenStream2 {
     };
 
     quote! {
-        fn #name(#(#sig_args),*) -> #ret_ty {
+        #maybe_async fn #name(#(#sig_args),*) -> #ret_ty {
             #ckp_logic
             match #match_inputs {
                 #( #concrete_arms )*
@@ -470,6 +514,12 @@ fn gen_backend_arm(ir: &Extension, op: &Operation, backend: &Backend) -> TokenSt
 
     // Call the method and wrap the result
     let call_args = op.inputs.iter().map(|a| &a.name);
+    let maybe_await = if op.asyncness {
+        quote! { .await }
+    } else {
+        quote! {}
+    };
+
     let wrap_out = match &op.output {
         OperationOutput::Tensor(kind) => {
             let wrapped = gen_tensor_wrap(kind, quote! { _out }, &b_ident, false);
@@ -505,7 +555,7 @@ fn gen_backend_arm(ir: &Extension, op: &Operation, backend: &Backend) -> TokenSt
         #cfg_attr
         #pattern => {
             #(#unwraps)*
-            let _out = <#b_ident as #trait_name>::#fn_name(#(#call_args),*);
+            let _out = <#b_ident as #trait_name>::#fn_name(#(#call_args),*)#maybe_await;
             #wrap_out
         }
     }
@@ -575,6 +625,12 @@ fn gen_autodiff_arm(ir: &Extension, op: &Operation) -> TokenStream2 {
         });
 
         let call_args = op.inputs.iter().map(|a| &a.name);
+        let maybe_await = if op.asyncness {
+            quote! { .await }
+        } else {
+            quote! {}
+        };
+
         let wrap_out = match &op.output {
             OperationOutput::Tensor(kind) => {
                 let wrapped = gen_tensor_wrap(kind, quote! { _out }, &b_ident, true);
@@ -628,7 +684,7 @@ fn gen_autodiff_arm(ir: &Extension, op: &Operation) -> TokenStream2 {
             #pattern => {
                 #(#unwraps)*
                 type _ADBackend = Autodiff<#b_ident>;
-                let _out = <_ADBackend as #trait_name>::#fn_name(#(#call_args),*);
+                let _out = <_ADBackend as #trait_name>::#fn_name(#(#call_args),*)#maybe_await;
                 #wrap_out
             }
         }

--- a/crates/burn-backend-extension/src/lib.rs
+++ b/crates/burn-backend-extension/src/lib.rs
@@ -266,14 +266,14 @@ fn extract_future_output_type(ty: &Type) -> Option<&Type> {
         for bound in &impl_trait.bounds {
             if let TypeParamBound::Trait(trait_bound) = bound {
                 let last_segment = trait_bound.path.segments.last()?;
-                if last_segment.ident == "Future" {
-                    if let PathArguments::AngleBracketed(args) = &last_segment.arguments {
-                        for arg in &args.args {
-                            if let GenericArgument::AssocType(assoc) = arg {
-                                if assoc.ident == "Output" {
-                                    return Some(&assoc.ty);
-                                }
-                            }
+                if last_segment.ident == "Future"
+                    && let PathArguments::AngleBracketed(args) = &last_segment.arguments
+                {
+                    for arg in &args.args {
+                        if let GenericArgument::AssocType(assoc) = arg
+                            && assoc.ident == "Output"
+                        {
+                            return Some(&assoc.ty);
                         }
                     }
                 }

--- a/crates/burn-dispatch/src/backend.rs
+++ b/crates/burn-dispatch/src/backend.rs
@@ -416,7 +416,7 @@ impl AutodiffBackend for Dispatch {
     fn inner(tensor: DispatchTensor) -> DispatchTensor {
         let DispatchTensor {
             kind,
-            checkpointing,
+            checkpointing: _,
         } = tensor;
 
         let kind = match kind {
@@ -477,7 +477,7 @@ impl AutodiffBackend for Dispatch {
         };
         DispatchTensor {
             kind,
-            checkpointing,
+            checkpointing: None,
         }
     }
 
@@ -573,6 +573,7 @@ impl AutodiffBackend for Dispatch {
             other => panic!("Distributed operations are not supported for tensor kind {other:?}"),
         };
 
+        // TODO: should use C::STRATEGY
         let checkpointing = if let Some(strategy) = checkpointing {
             Some(strategy)
         } else {

--- a/crates/burn-dispatch/src/tensor.rs
+++ b/crates/burn-dispatch/src/tensor.rs
@@ -345,6 +345,7 @@ impl DispatchTensorKind {
     }
 }
 
+#[cfg(feature = "autodiff")]
 trait IntoCheckpointingStrategy {
     const STRATEGY: CheckpointingStrategy;
 }

--- a/crates/burn-dispatch/src/tensor.rs
+++ b/crates/burn-dispatch/src/tensor.rs
@@ -12,6 +12,8 @@ use alloc::boxed::Box;
 #[cfg(feature = "autodiff")]
 use burn_backend::tensor::FloatTensor;
 
+use alloc::{format, string::String};
+
 // TODO: if we reduce the different associated types for float/int/bool/quantized tensor primitives down to a single
 // `B::TensorPrimitive` we can simplify this.
 

--- a/crates/burn-dispatch/src/tensor.rs
+++ b/crates/burn-dispatch/src/tensor.rs
@@ -1,5 +1,9 @@
 use crate::backends::*;
 
+#[cfg(feature = "autodiff")]
+use burn_autodiff::checkpoint::strategy::{
+    BalancedCheckpointing, CheckpointStrategy, NoCheckpointing,
+};
 use burn_backend::{Backend, DType, Shape, TensorMetadata};
 
 use crate::CheckpointingStrategy;
@@ -122,6 +126,18 @@ impl<B: Backend> BackendTensor<B> {
             BackendTensor::Autodiff(tensor) => B::float_device(&tensor.primitive),
         }
     }
+
+    /// Returns the tensor primitive kind name.
+    pub fn name(&self) -> &'static str {
+        match self {
+            BackendTensor::Float(_) => "Float",
+            BackendTensor::Int(_) => "Int",
+            BackendTensor::Bool(_) => "Bool",
+            BackendTensor::Quantized(_) => "Quantized",
+            #[cfg(feature = "autodiff")]
+            BackendTensor::Autodiff(_) => "Autodiff",
+        }
+    }
 }
 
 impl<B: Backend> TensorMetadata for BackendTensor<B> {
@@ -165,13 +181,6 @@ pub struct DispatchTensor {
     /// - `None`: tensor is not tracked by autodiff
     /// - `Some(strategy)`: tensor is tracked by autodiff, and uses the checkpointing `strategy`
     pub checkpointing: Option<CheckpointingStrategy>,
-}
-
-impl DispatchTensor {
-    /// Returns the tensor kind primitive.
-    pub fn into_primitive(self) -> DispatchTensorKind {
-        self.kind
-    }
 }
 
 /// Internal representation of a [`DispatchTensor`].
@@ -301,3 +310,161 @@ impl TensorMetadata for DispatchTensor {
         self.kind.shape()
     }
 }
+
+impl DispatchTensorKind {
+    /// Returns the backend tensor kind name.
+    pub(crate) fn name(&self) -> &'static str {
+        match self {
+            #[cfg(feature = "cpu")]
+            DispatchTensorKind::Cpu(_) => "Cpu",
+            #[cfg(feature = "cuda")]
+            DispatchTensorKind::Cuda(_) => "Cuda",
+            #[cfg(feature = "metal")]
+            DispatchTensorKind::Metal(_) => "Metal",
+            #[cfg(feature = "rocm")]
+            DispatchTensorKind::Rocm(_) => "Rocm",
+            #[cfg(feature = "vulkan")]
+            DispatchTensorKind::Vulkan(_) => "Vulkan",
+            #[cfg(feature = "wgpu")]
+            DispatchTensorKind::Wgpu(_) => "Wgpu",
+            #[cfg(feature = "webgpu")]
+            DispatchTensorKind::WebGpu(_) => "WebGpu",
+            #[cfg(any(feature = "flex", default_backend))]
+            DispatchTensorKind::Flex(_) => "Flex",
+            #[cfg(feature = "ndarray")]
+            DispatchTensorKind::NdArray(_) => "NdArray",
+            #[cfg(feature = "tch")]
+            DispatchTensorKind::LibTorch(_) => "LibTorch",
+            #[cfg(feature = "remote")]
+            DispatchTensorKind::Remote(_) => "Remote",
+            #[cfg(feature = "autodiff")]
+            DispatchTensorKind::Autodiff(_) => "Autodiff",
+        }
+    }
+}
+
+trait IntoCheckpointingStrategy {
+    const STRATEGY: CheckpointingStrategy;
+}
+
+#[cfg(feature = "autodiff")]
+impl IntoCheckpointingStrategy for NoCheckpointing {
+    const STRATEGY: CheckpointingStrategy = CheckpointingStrategy::None;
+}
+
+#[cfg(feature = "autodiff")]
+impl IntoCheckpointingStrategy for BalancedCheckpointing {
+    const STRATEGY: CheckpointingStrategy = CheckpointingStrategy::Balanced;
+}
+
+/// Trait to execute runtime routing conversions between the dynamic dispatch layer and specific backends.
+pub trait DispatchKindConversion<B: Backend> {
+    /// Attempts to extract a backend-specific [`BackendTensor`] wrapper from a generic, dynamically-routed [`DispatchTensor`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the dynamic routing state does not match the requested backend `B`.
+    fn try_into_backend(tensor: DispatchTensor) -> Result<BackendTensor<B>, String>;
+
+    /// Encapsulates a backend-specific tensor variant back into a globally routing [`DispatchTensor`].
+    fn from_backend(tensor: BackendTensor<B>) -> DispatchTensor;
+}
+
+macro_rules! impl_dispatch_conversion {
+    ($backend:ident, $cfg:meta) => {
+        #[cfg($cfg)]
+        impl DispatchKindConversion<$backend> for DispatchTensor {
+            fn try_into_backend(tensor: DispatchTensor) -> Result<BackendTensor<$backend>, String> {
+                match tensor.kind {
+                    DispatchTensorKind::$backend(t) => Ok(t),
+                    other => Err(format!(
+                        "Expected {} tensor, got variant: {}",
+                        stringify!($backend),
+                        other.name()
+                    )),
+                }
+            }
+
+            fn from_backend(tensor: BackendTensor<$backend>) -> DispatchTensor {
+                DispatchTensor {
+                    kind: DispatchTensorKind::$backend(tensor),
+                    checkpointing: None,
+                }
+            }
+        }
+
+        #[cfg(all($cfg, feature = "autodiff"))]
+        impl<C: CheckpointStrategy + IntoCheckpointingStrategy>
+            DispatchKindConversion<Autodiff<$backend, C>> for DispatchTensor
+        {
+            fn try_into_backend(
+                tensor: DispatchTensor,
+            ) -> Result<BackendTensor<Autodiff<$backend, C>>, String> {
+                match tensor.kind {
+                    DispatchTensorKind::Autodiff(t) => match *t {
+                        DispatchTensorKind::$backend(t) => match t {
+                            // Encode as `BackendTensor::Float` for `Autodiff<B, C>`
+                            BackendTensor::Autodiff(t) => Ok(BackendTensor::Float(t)),
+                            other => Err(format!(
+                                "Expected Autodiff {} float tensor, got Autodiff variant: {}",
+                                stringify!($backend),
+                                other.name()
+                            )),
+                        },
+                        other => Err(format!(
+                            "Expected Autodiff {} tensor, got Autodiff variant: {}",
+                            stringify!($backend),
+                            other.name()
+                        )),
+                    },
+                    other => Err(format!(
+                        "Expected Autodiff tensor, got backend: {}",
+                        other.name()
+                    )),
+                }
+            }
+
+            fn from_backend(tensor: BackendTensor<Autodiff<$backend, C>>) -> DispatchTensor {
+                // Unwrap the Autodiff backend representation back into the inner hardware representation
+                let kind = match tensor {
+                    // Inverse: Wrap the `Float` variant back into the backend's `Autodiff` primitive variant
+                    BackendTensor::Float(t) => {
+                        let ad_tensor = BackendTensor::Autodiff(t);
+                        // Wrap in the concrete backend's dispatch container
+                        let inner_dispatch = DispatchTensorKind::$backend(ad_tensor);
+                        // Re-apply the outer Autodiff dispatch wrapper
+                        DispatchTensorKind::Autodiff(Box::new(inner_dispatch))
+                    }
+
+                    // Pass-throughs for non-differentiable types
+                    BackendTensor::Int(t) => DispatchTensorKind::$backend(BackendTensor::Int(t)),
+                    BackendTensor::Bool(t) => DispatchTensorKind::$backend(BackendTensor::Bool(t)),
+                    BackendTensor::Quantized(t) => {
+                        DispatchTensorKind::$backend(BackendTensor::Quantized(t))
+                    }
+
+                    BackendTensor::Autodiff(_) => {
+                        panic!("Unexpected Autodiff variant provided to `from_backend`",)
+                    }
+                };
+
+                DispatchTensor {
+                    kind,
+                    checkpointing: Some(C::STRATEGY),
+                }
+            }
+        }
+    };
+}
+
+impl_dispatch_conversion!(Flex, any(feature = "flex", default_backend));
+impl_dispatch_conversion!(Cpu, feature = "cpu");
+impl_dispatch_conversion!(Cuda, feature = "cuda");
+impl_dispatch_conversion!(Rocm, feature = "rocm");
+impl_dispatch_conversion!(Remote, feature = "remote");
+impl_dispatch_conversion!(Metal, feature = "metal");
+impl_dispatch_conversion!(Vulkan, feature = "vulkan");
+impl_dispatch_conversion!(Wgpu, feature = "wgpu");
+impl_dispatch_conversion!(WebGpu, feature = "webgpu");
+impl_dispatch_conversion!(NdArray, feature = "ndarray");
+impl_dispatch_conversion!(LibTorch, feature = "tch");

--- a/crates/burn-tensor/src/tensor/api/extension.rs
+++ b/crates/burn-tensor/src/tensor/api/extension.rs
@@ -1,9 +1,10 @@
-use burn_backend::TensorMetadata;
+use burn_backend::{Backend, TensorMetadata};
 pub use burn_dispatch::DispatchTensor;
+use burn_dispatch::{BackendTensor, DispatchKindConversion};
 use burn_std::DType;
 
 use crate::{
-    Tensor,
+    Bool, Float, Int, Tensor,
     kind::Basic,
     ops::{BridgeKind, BridgeTensor, Kind},
 };
@@ -44,11 +45,11 @@ where
         }
     }
 
-    /// Converts from a primitive tensor into a tensor.
+    /// Converts from a dispatch tensor into a tensor.
     ///
     /// # Panics
-    /// Panis if the primitive dtype does not match the tensor kind `K`.
-    pub fn from_primitive(tensor: DispatchTensor) -> Self {
+    /// Panis if the dispatch dtype does not match the tensor kind `K`.
+    pub fn from_dispatch(tensor: DispatchTensor) -> Self {
         match (tensor.dtype(), K::KIND) {
             (DType::QFloat(_), Kind::Float) => Self::new(BridgeTensor::qfloat(tensor)),
             (dtype, Kind::Float) if dtype.is_float() => Self::new(BridgeTensor::float(tensor)),
@@ -60,9 +61,137 @@ where
         }
     }
 
-    /// Converts the tensor into a primitive tensor.
-    pub fn into_primitive(self) -> DispatchTensor {
+    /// Converts the tensor into a dispatch tensor.
+    pub fn into_dispatch(self) -> DispatchTensor {
         self.primitive.into()
+    }
+
+    /// Safely downcasts a [`Tensor`] into its low-level backend primitive.
+    ///
+    /// This is primarily intended for backend extensions where interfacing with the direct backend
+    /// primitive (e.g., `B::FloatTensorPrimitive` or `AutodiffTensor<B>`) is necessary.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// // Extract the underlying CubeCL tensor primitive on the `Wgpu` backend
+    /// let cube_tensor = tensor.try_into_primitive::<Wgpu>()?;
+    ///
+    /// // For an autodiff tensor, we can get the wrapped CubeCL tensor primitive on the `Autodiff<Wgpu>` backend
+    /// let ad_tensor = tensor.try_into_primitive::<Autodiff<Wgpu>>()?;
+    ///
+    /// # Errors
+    ///
+    /// Returns a `Result::Err` string if:
+    /// * The tensor does not currently live on backend `B`.
+    /// * The target backend is an `Autodiff` wrapper but the tensor lacks an active computation graph.
+    /// * The requested tensor kind `K` (e.g., `Float`) does not match the data variant inside the backend wrapper.
+    ///
+    /// ```
+    pub fn try_into_primitive<B: Backend>(
+        self,
+    ) -> Result<<K as BackendPrimitive<B>>::Primitive, String>
+    where
+        K: BackendPrimitive<B>,
+        DispatchTensor: DispatchKindConversion<B>,
+    {
+        let dispatch = self.primitive.into();
+        // `tensor.try_into_backend::<Autodiff<B>>()` returns a `BackendTensor::Float(AutodiffTensor<B>)`
+        // so it is automatically handled by the `try_into_primitive` impl for `Float`
+        let tensor = <DispatchTensor as DispatchKindConversion<B>>::try_into_backend(dispatch)?;
+        <K as BackendPrimitive<B>>::try_into_primitive(tensor)
+    }
+
+    /// Reconstructs a high-level [`Tensor`] from a concrete backend primitive.
+    ///
+    /// This is the inverse of [`Tensor::try_into_primitive`].
+    ///
+    /// # Panics
+    /// Panis if the tensor kind `K` does not match the tensor underlying primitive kind.
+    pub fn from_primitive<B: Backend>(primitive: <K as BackendPrimitive<B>>::Primitive) -> Self
+    where
+        K: BackendPrimitive<B>,
+        DispatchTensor: DispatchKindConversion<B>,
+    {
+        let tensor = <K as BackendPrimitive<B>>::from_primitive(primitive);
+        let dispatch = <DispatchTensor as DispatchKindConversion<B>>::from_backend(tensor);
+        Self::from_dispatch(dispatch)
+    }
+}
+
+/// Trait to safely extract and wrap backend-specific primitives based on the high-level tensor kind.
+///
+/// This trait functions as a type-level map linking frontend kinds (`Float`, `Int`, `Bool`)
+/// to their corresponding backend-associated types (`B::FloatTensorPrimitive`, `B::IntTensorPrimitive`, etc.).
+pub trait BackendPrimitive<B: Backend> {
+    /// The backend tensor primitive.
+    type Primitive;
+
+    /// Attempts to unpack the type-erased [`BackendTensor`] enum wrapper into the concrete
+    /// variant expected by this kind.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if there is a variant type mismatch (e.g., attempting to extract an
+    /// `Int` primitive out of a `BackendTensor::Float` enum variant).
+    fn try_into_primitive(tensor: BackendTensor<B>) -> Result<Self::Primitive, String>;
+
+    /// Wraps a backend tensor primitive into its corresponding `BackendTensor` enum variant.
+    fn from_primitive(primitive: Self::Primitive) -> BackendTensor<B>;
+}
+
+impl<B: Backend> BackendPrimitive<B> for Float {
+    // NOTE: not implemented for QFloat
+    type Primitive = B::FloatTensorPrimitive;
+
+    fn try_into_primitive(tensor: BackendTensor<B>) -> Result<Self::Primitive, String> {
+        match tensor {
+            BackendTensor::Float(t) => Ok(t),
+            other => Err(format!(
+                "Expected Float primitive, got variant: {}",
+                other.name()
+            )),
+        }
+    }
+
+    fn from_primitive(primitive: Self::Primitive) -> BackendTensor<B> {
+        BackendTensor::Float(primitive)
+    }
+}
+
+impl<B: Backend> BackendPrimitive<B> for Int {
+    type Primitive = B::IntTensorPrimitive;
+
+    fn try_into_primitive(tensor: BackendTensor<B>) -> Result<Self::Primitive, String> {
+        match tensor {
+            BackendTensor::Int(t) => Ok(t),
+            other => Err(format!(
+                "Expected Int primitive, got variant: {}",
+                other.name()
+            )),
+        }
+    }
+
+    fn from_primitive(primitive: Self::Primitive) -> BackendTensor<B> {
+        BackendTensor::Int(primitive)
+    }
+}
+
+impl<B: Backend> BackendPrimitive<B> for Bool {
+    type Primitive = B::BoolTensorPrimitive;
+
+    fn try_into_primitive(tensor: BackendTensor<B>) -> Result<Self::Primitive, String> {
+        match tensor {
+            BackendTensor::Bool(t) => Ok(t),
+            other => Err(format!(
+                "Expected Bool primitive, got variant: {}",
+                other.name()
+            )),
+        }
+    }
+
+    fn from_primitive(primitive: Self::Primitive) -> BackendTensor<B> {
+        BackendTensor::Bool(primitive)
     }
 }
 
@@ -71,6 +200,9 @@ mod tests {
     use crate::{Bool, Int};
 
     use super::*;
+
+    type TestBackend = burn_dispatch::backends::Flex;
+    type TestAutodiffBackend = burn_dispatch::backends::Autodiff<burn_dispatch::backends::Flex>;
 
     // -- into_bridge / from_bridge roundtrip --
 
@@ -139,19 +271,19 @@ mod tests {
     fn from_bridge_qfloat_variant_with_int_dtype_panics() {
         // Construct a QFloat bridge tensor wrapping a non-qfloat dispatch tensor:
         // kind tag says Float but dtype says otherwise.
-        let inner = Tensor::<2, Int>::zeros([2, 3], &Default::default()).into_primitive();
+        let inner = Tensor::<2, Int>::zeros([2, 3], &Default::default()).into_dispatch();
         let bridge = BridgeTensor::qfloat(inner);
         let _tensor = Tensor::<2>::from_bridge(bridge);
     }
 
-    // -- into_primitive / from_primitive roundtrip --
+    // -- into_dispatch / from_dispatch roundtrip --
 
     #[test]
     fn float_primitive_roundtrip() {
         let tensor = Tensor::<2>::zeros([2, 3], &Default::default());
         let shape = tensor.shape();
-        let primitive = tensor.into_primitive();
-        let tensor = Tensor::<2>::from_primitive(primitive);
+        let primitive = tensor.into_dispatch();
+        let tensor = Tensor::<2>::from_dispatch(primitive);
         assert_eq!(tensor.shape(), shape);
     }
 
@@ -159,8 +291,8 @@ mod tests {
     fn int_primitive_roundtrip() {
         let tensor = Tensor::<2, Int>::zeros([2, 3], &Default::default());
         let shape = tensor.shape();
-        let primitive = tensor.into_primitive();
-        let tensor = Tensor::<2, Int>::from_primitive(primitive);
+        let primitive = tensor.into_dispatch();
+        let tensor = Tensor::<2, Int>::from_dispatch(primitive);
         assert_eq!(tensor.shape(), shape);
     }
 
@@ -168,31 +300,144 @@ mod tests {
     fn bool_primitive_roundtrip() {
         let tensor = Tensor::<2, Bool>::empty([2, 3], &Default::default());
         let shape = tensor.shape();
-        let primitive = tensor.into_primitive();
-        let tensor = Tensor::<2, Bool>::from_primitive(primitive);
+        let primitive = tensor.into_dispatch();
+        let tensor = Tensor::<2, Bool>::from_dispatch(primitive);
         assert_eq!(tensor.shape(), shape);
     }
 
-    // -- from_primitive panics on dtype/kind mismatch --
+    // -- from_dispatch panics on dtype/kind mismatch --
 
     #[test]
     #[should_panic(expected = "Expected kind Float")]
-    fn from_primitive_int_dtype_as_float_panics() {
-        let primitive = Tensor::<2, Int>::zeros([2, 3], &Default::default()).into_primitive();
-        let _tensor = Tensor::<2>::from_primitive(primitive);
+    fn from_dispatch_int_dtype_as_float_panics() {
+        let primitive = Tensor::<2, Int>::zeros([2, 3], &Default::default()).into_dispatch();
+        let _tensor = Tensor::<2>::from_dispatch(primitive);
     }
 
     #[test]
     #[should_panic(expected = "Expected kind Int")]
-    fn from_primitive_float_dtype_as_int_panics() {
-        let primitive = Tensor::<2>::zeros([2, 3], &Default::default()).into_primitive();
-        let _tensor = Tensor::<2, Int>::from_primitive(primitive);
+    fn from_dispatch_float_dtype_as_int_panics() {
+        let primitive = Tensor::<2>::zeros([2, 3], &Default::default()).into_dispatch();
+        let _tensor = Tensor::<2, Int>::from_dispatch(primitive);
     }
 
     #[test]
     #[should_panic(expected = "Expected kind Bool")]
-    fn from_primitive_float_dtype_as_bool_panics() {
-        let primitive = Tensor::<2>::zeros([2, 3], &Default::default()).into_primitive();
-        let _tensor = Tensor::<2, Bool>::from_primitive(primitive);
+    fn from_dispatch_float_dtype_as_bool_panics() {
+        let primitive = Tensor::<2>::zeros([2, 3], &Default::default()).into_dispatch();
+        let _tensor = Tensor::<2, Bool>::from_dispatch(primitive);
+    }
+
+    // -- try_into_primitive / from_primitive roundtrip --
+
+    #[test]
+    fn float_backend_primitive_roundtrip() {
+        let device = Default::default();
+        let tensor = Tensor::<2>::zeros([2, 3], &device);
+        let shape = tensor.shape();
+
+        let primitive = tensor
+            .try_into_primitive::<TestBackend>()
+            .expect("Failed to extract Float primitive");
+        let tensor = Tensor::<2>::from_primitive::<TestBackend>(primitive);
+
+        assert_eq!(tensor.shape(), shape);
+    }
+
+    #[test]
+    fn int_backend_primitive_roundtrip() {
+        let device = Default::default();
+        let tensor = Tensor::<2, Int>::zeros([2, 3], &device);
+        let shape = tensor.shape();
+
+        let primitive = tensor
+            .try_into_primitive::<TestBackend>()
+            .expect("Failed to extract Int primitive");
+        let tensor = Tensor::<2, Int>::from_primitive::<TestBackend>(primitive);
+
+        assert_eq!(tensor.shape(), shape);
+    }
+
+    #[test]
+    fn bool_backend_primitive_roundtrip() {
+        let device = Default::default();
+        let tensor = Tensor::<2, Bool>::empty([2, 3], &device);
+        let shape = tensor.shape();
+
+        let primitive = tensor
+            .try_into_primitive::<TestBackend>()
+            .expect("Failed to extract Bool primitive");
+        let tensor = Tensor::<2, Bool>::from_primitive::<TestBackend>(primitive);
+
+        assert_eq!(tensor.shape(), shape);
+    }
+
+    #[cfg(feature = "autodiff")]
+    #[test]
+    fn autodiff_backend_primitive_roundtrip() {
+        let device = crate::Device::default().autodiff();
+        let tensor = Tensor::<2, Float>::empty([2, 3], &device).require_grad();
+        let require_grad = tensor.is_require_grad();
+
+        let primitive = tensor
+            .try_into_primitive::<TestAutodiffBackend>()
+            .expect("Failed to extract Autodiff primitive");
+        let tensor = Tensor::<2, Float>::from_primitive::<TestAutodiffBackend>(primitive);
+
+        assert_eq!(tensor.is_require_grad(), require_grad);
+    }
+
+    // -- try_into_primitive panics on backend or kind mismatch --
+
+    #[cfg(feature = "autodiff")]
+    #[test]
+    fn try_into_primitive_backend_mismatch() {
+        let device = Default::default();
+        let tensor = Tensor::<2>::zeros([2, 3], &device);
+
+        let result = tensor.try_into_primitive::<TestAutodiffBackend>();
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .contains("Expected Autodiff tensor, got backend:")
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Expected kind Float")]
+    fn try_into_primitive_kind_mismatch() {
+        let device = Default::default();
+        let tensor = Tensor::<2, Int>::zeros([2, 3], &device);
+
+        let primitive = tensor
+            .try_into_primitive::<TestBackend>()
+            .expect("Failed to extract Int primitive");
+        let _tensor = Tensor::<2, Float>::from_primitive::<TestBackend>(primitive);
+    }
+
+    // -- BackendPrimitive trait error handling on mismatched variants --
+
+    #[test]
+    fn try_into_primitive_float_with_int_variant_returns_err() {
+        let device = Default::default();
+
+        // Valid Int primitive
+        let int_tensor = Tensor::<2, Int>::zeros([2, 3], &device);
+        let int_primitive = int_tensor.try_into_primitive::<TestBackend>().unwrap();
+
+        // Wrap it artificially into the Backend layer
+        let backend_tensor = BackendTensor::<TestBackend>::Int(int_primitive);
+
+        // Attempt to extract it as a Float primitive using the BackendPrimitive trait
+        let result = <Float as BackendPrimitive<TestBackend>>::try_into_primitive(backend_tensor);
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .contains("Expected Float primitive, got variant: Int")
+        );
     }
 }

--- a/crates/burn-tensor/src/tensor/api/extension.rs
+++ b/crates/burn-tensor/src/tensor/api/extension.rs
@@ -9,6 +9,8 @@ use crate::{
     ops::{BridgeKind, BridgeTensor, Kind},
 };
 
+use alloc::{format, string::String};
+
 impl<const D: usize, K> Tensor<D, K>
 where
     K: Basic,

--- a/crates/burn-tensor/src/tensor/api/extension.rs
+++ b/crates/burn-tensor/src/tensor/api/extension.rs
@@ -79,18 +79,17 @@ where
     ///
     /// // For an autodiff tensor, we can get the wrapped CubeCL tensor primitive on the `Autodiff<Wgpu>` backend
     /// let ad_tensor = tensor.try_into_primitive::<Autodiff<Wgpu>>()?;
+    ///```
     ///
     /// # Errors
     ///
-    /// Returns a `Result::Err` string if:
-    /// * The tensor does not currently live on backend `B`.
-    /// * The target backend is an `Autodiff` wrapper but the tensor lacks an active computation graph.
-    /// * The requested tensor kind `K` (e.g., `Float`) does not match the data variant inside the backend wrapper.
+    /// Returns a [`PrimitiveConversionError`] if the tensor does not currently live on the requested
+    /// backend `B` (including `Autodiff<B>` mismatch).
     ///
     /// ```
     pub fn try_into_primitive<B: Backend>(
         self,
-    ) -> Result<<K as BackendPrimitive<B>>::Primitive, String>
+    ) -> Result<<K as BackendPrimitive<B>>::Primitive, PrimitiveConversionError>
     where
         K: BackendPrimitive<B>,
         DispatchTensor: DispatchKindConversion<B>,
@@ -98,7 +97,8 @@ where
         let dispatch = self.primitive.into();
         // `tensor.try_into_backend::<Autodiff<B>>()` returns a `BackendTensor::Float(AutodiffTensor<B>)`
         // so it is automatically handled by the `try_into_primitive` impl for `Float`
-        let tensor = <DispatchTensor as DispatchKindConversion<B>>::try_into_backend(dispatch)?;
+        let tensor = <DispatchTensor as DispatchKindConversion<B>>::try_into_backend(dispatch)
+            .map_err(PrimitiveConversionError::BackendMismatch)?;
         <K as BackendPrimitive<B>>::try_into_primitive(tensor)
     }
 
@@ -119,6 +119,19 @@ where
     }
 }
 
+/// Error returned when a [`DispatchTensor`] cannot be converted to the requested concrete primitive type.
+#[derive(Debug, PartialEq)]
+pub enum PrimitiveConversionError {
+    /// The dispatch tensor's backend variant does not match the requested backend.
+    ///
+    /// For example, extracting a `Wgpu` primitive from a `Cuda` dispatch tensor.
+    BackendMismatch(String),
+    /// The tensor kind does not match the requested primitive kind.
+    ///
+    /// For example, extracting a float primitive from an int tensor.
+    KindMismatch(String),
+}
+
 /// Trait to safely extract and wrap backend-specific primitives based on the high-level tensor kind.
 ///
 /// This trait functions as a type-level map linking frontend kinds (`Float`, `Int`, `Bool`)
@@ -134,7 +147,9 @@ pub trait BackendPrimitive<B: Backend> {
     ///
     /// Returns an error if there is a variant type mismatch (e.g., attempting to extract an
     /// `Int` primitive out of a `BackendTensor::Float` enum variant).
-    fn try_into_primitive(tensor: BackendTensor<B>) -> Result<Self::Primitive, String>;
+    fn try_into_primitive(
+        tensor: BackendTensor<B>,
+    ) -> Result<Self::Primitive, PrimitiveConversionError>;
 
     /// Wraps a backend tensor primitive into its corresponding `BackendTensor` enum variant.
     fn from_primitive(primitive: Self::Primitive) -> BackendTensor<B>;
@@ -144,13 +159,15 @@ impl<B: Backend> BackendPrimitive<B> for Float {
     // NOTE: not implemented for QFloat
     type Primitive = B::FloatTensorPrimitive;
 
-    fn try_into_primitive(tensor: BackendTensor<B>) -> Result<Self::Primitive, String> {
+    fn try_into_primitive(
+        tensor: BackendTensor<B>,
+    ) -> Result<Self::Primitive, PrimitiveConversionError> {
         match tensor {
             BackendTensor::Float(t) => Ok(t),
-            other => Err(format!(
+            other => Err(PrimitiveConversionError::KindMismatch(format!(
                 "Expected Float primitive, got variant: {}",
                 other.name()
-            )),
+            ))),
         }
     }
 
@@ -162,13 +179,15 @@ impl<B: Backend> BackendPrimitive<B> for Float {
 impl<B: Backend> BackendPrimitive<B> for Int {
     type Primitive = B::IntTensorPrimitive;
 
-    fn try_into_primitive(tensor: BackendTensor<B>) -> Result<Self::Primitive, String> {
+    fn try_into_primitive(
+        tensor: BackendTensor<B>,
+    ) -> Result<Self::Primitive, PrimitiveConversionError> {
         match tensor {
             BackendTensor::Int(t) => Ok(t),
-            other => Err(format!(
+            other => Err(PrimitiveConversionError::KindMismatch(format!(
                 "Expected Int primitive, got variant: {}",
                 other.name()
-            )),
+            ))),
         }
     }
 
@@ -180,13 +199,15 @@ impl<B: Backend> BackendPrimitive<B> for Int {
 impl<B: Backend> BackendPrimitive<B> for Bool {
     type Primitive = B::BoolTensorPrimitive;
 
-    fn try_into_primitive(tensor: BackendTensor<B>) -> Result<Self::Primitive, String> {
+    fn try_into_primitive(
+        tensor: BackendTensor<B>,
+    ) -> Result<Self::Primitive, PrimitiveConversionError> {
         match tensor {
             BackendTensor::Bool(t) => Ok(t),
-            other => Err(format!(
+            other => Err(PrimitiveConversionError::KindMismatch(format!(
                 "Expected Bool primitive, got variant: {}",
                 other.name()
-            )),
+            ))),
         }
     }
 
@@ -395,14 +416,12 @@ mod tests {
         let device = Default::default();
         let tensor = Tensor::<2>::zeros([2, 3], &device);
 
-        let result = tensor.try_into_primitive::<TestAutodiffBackend>();
+        let err = tensor
+            .try_into_primitive::<TestAutodiffBackend>()
+            .unwrap_err();
 
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .contains("Expected Autodiff tensor, got backend:")
-        );
+        assert!(matches!(err, PrimitiveConversionError::BackendMismatch(_)));
+        assert!(format!("{err:?}").contains("Expected Autodiff tensor, got backend:"));
     }
 
     #[test]
@@ -431,13 +450,14 @@ mod tests {
         let backend_tensor = BackendTensor::<TestBackend>::Int(int_primitive);
 
         // Attempt to extract it as a Float primitive using the BackendPrimitive trait
-        let result = <Float as BackendPrimitive<TestBackend>>::try_into_primitive(backend_tensor);
+        let err = <Float as BackendPrimitive<TestBackend>>::try_into_primitive(backend_tensor)
+            .unwrap_err();
 
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .contains("Expected Float primitive, got variant: Int")
+        assert_eq!(
+            err,
+            PrimitiveConversionError::KindMismatch(
+                "Expected Float primitive, got variant: Int".into()
+            )
         );
     }
 }

--- a/crates/burn-vision/src/tensor.rs
+++ b/crates/burn-vision/src/tensor.rs
@@ -57,8 +57,8 @@ pub trait Nms {
 impl ConnectedComponents for Tensor<2, Bool> {
     fn connected_components(self, connectivity: Connectivity) -> Tensor<2, Int> {
         let settings = self.device().settings();
-        Tensor::from_primitive(<Dispatch as BoolVisionOps>::connected_components(
-            self.into_primitive(),
+        Tensor::from_dispatch(<Dispatch as BoolVisionOps>::connected_components(
+            self.into_dispatch(),
             connectivity,
             settings.int_dtype,
         ))
@@ -72,21 +72,21 @@ impl ConnectedComponents for Tensor<2, Bool> {
         println!("Tensor::connected_components_with_stats");
         let settings = self.device().settings();
         let (labels, stats) = <Dispatch as BoolVisionOps>::connected_components_with_stats(
-            self.into_primitive(),
+            self.into_dispatch(),
             connectivity,
             options,
             settings.int_dtype,
         );
 
         let stats = ConnectedStats {
-            area: Tensor::from_primitive(stats.area),
-            left: Tensor::from_primitive(stats.left),
-            top: Tensor::from_primitive(stats.top),
-            right: Tensor::from_primitive(stats.right),
-            bottom: Tensor::from_primitive(stats.bottom),
-            max_label: Tensor::from_primitive(stats.max_label),
+            area: Tensor::from_dispatch(stats.area),
+            left: Tensor::from_dispatch(stats.left),
+            top: Tensor::from_dispatch(stats.top),
+            right: Tensor::from_dispatch(stats.right),
+            bottom: Tensor::from_dispatch(stats.bottom),
+            max_label: Tensor::from_dispatch(stats.max_label),
         };
-        (Tensor::from_primitive(labels), stats)
+        (Tensor::from_dispatch(labels), stats)
     }
 }
 
@@ -97,11 +97,11 @@ impl Morphology for Tensor<3, Float> {
         }
 
         let out = <Dispatch as FloatVisionOps>::float_erode(
-            self.into_primitive(),
-            kernel.into_primitive(),
+            self.into_dispatch(),
+            kernel.into_dispatch(),
             opts,
         );
-        Tensor::from_primitive(out)
+        Tensor::from_dispatch(out)
     }
 
     fn dilate(self, kernel: Tensor<2, Bool>, opts: MorphOptions) -> Self {
@@ -110,27 +110,27 @@ impl Morphology for Tensor<3, Float> {
         }
 
         let out = <Dispatch as FloatVisionOps>::float_dilate(
-            self.into_primitive(),
-            kernel.into_primitive(),
+            self.into_dispatch(),
+            kernel.into_dispatch(),
             opts,
         );
-        Tensor::from_primitive(out)
+        Tensor::from_dispatch(out)
     }
 }
 
 impl Morphology for Tensor<3, Int> {
     fn erode(self, kernel: Tensor<2, Bool>, opts: MorphOptions) -> Self {
-        Tensor::from_primitive(<Dispatch as IntVisionOps>::int_erode(
-            self.into_primitive(),
-            kernel.into_primitive(),
+        Tensor::from_dispatch(<Dispatch as IntVisionOps>::int_erode(
+            self.into_dispatch(),
+            kernel.into_dispatch(),
             opts,
         ))
     }
 
     fn dilate(self, kernel: Tensor<2, Bool>, opts: MorphOptions) -> Self {
-        Tensor::from_primitive(<Dispatch as IntVisionOps>::int_dilate(
-            self.into_primitive(),
-            kernel.into_primitive(),
+        Tensor::from_dispatch(<Dispatch as IntVisionOps>::int_dilate(
+            self.into_dispatch(),
+            kernel.into_dispatch(),
             opts,
         ))
     }
@@ -138,17 +138,17 @@ impl Morphology for Tensor<3, Int> {
 
 impl Morphology for Tensor<3, Bool> {
     fn erode(self, kernel: Tensor<2, Bool>, opts: MorphOptions) -> Self {
-        Tensor::from_primitive(<Dispatch as BoolVisionOps>::bool_erode(
-            self.into_primitive(),
-            kernel.into_primitive(),
+        Tensor::from_dispatch(<Dispatch as BoolVisionOps>::bool_erode(
+            self.into_dispatch(),
+            kernel.into_dispatch(),
             opts,
         ))
     }
 
     fn dilate(self, kernel: Tensor<2, Bool>, opts: MorphOptions) -> Self {
-        Tensor::from_primitive(<Dispatch as BoolVisionOps>::bool_dilate(
-            self.into_primitive(),
-            kernel.into_primitive(),
+        Tensor::from_dispatch(<Dispatch as BoolVisionOps>::bool_dilate(
+            self.into_dispatch(),
+            kernel.into_dispatch(),
             opts,
         ))
     }
@@ -162,9 +162,9 @@ impl Nms for Tensor<2> {
 
         let settings = self.device().settings();
 
-        Tensor::from_primitive(<Dispatch as FloatVisionOps>::nms(
-            self.into_primitive(),
-            scores.into_primitive(),
+        Tensor::from_dispatch(<Dispatch as FloatVisionOps>::nms(
+            self.into_dispatch(),
+            scores.into_dispatch(),
             options,
             settings.int_dtype,
         ))

--- a/examples/custom-cubecl-kernel/src/backward.rs
+++ b/examples/custom-cubecl-kernel/src/backward.rs
@@ -1,6 +1,6 @@
 use crate::FloatTensor;
 
-use super::{AutodiffBackend, Backend};
+use super::Backend;
 use burn::{
     backend::{
         TensorMetadata,
@@ -13,9 +13,6 @@ use burn::{
     },
     tensor::Shape,
 };
-use burn_cubecl::{CubeBackend, CubeRuntime};
-
-impl<R: CubeRuntime> AutodiffBackend for Autodiff<CubeBackend<R>> {}
 
 // Implement our custom backend trait for any backend that also implements our custom backend trait.
 impl<B: Backend, C: CheckpointStrategy> Backend for Autodiff<B, C> {

--- a/examples/custom-cubecl-kernel/src/lib.rs
+++ b/examples/custom-cubecl-kernel/src/lib.rs
@@ -23,12 +23,12 @@ pub trait AutodiffBackend: Backend + burn::backend::AutodiffBackend {}
 /// We define our custom implementation using the added function on our custom backend.
 pub fn matmul_add_relu_custom(lhs: Tensor<3>, rhs: Tensor<3>, bias: Tensor<3>) -> Tensor<3> {
     let output = Dispatch::fused_matmul_add_relu(
-        lhs.into_primitive(),
-        rhs.into_primitive(),
-        bias.into_primitive(),
+        lhs.into_dispatch(),
+        rhs.into_dispatch(),
+        bias.into_dispatch(),
     );
 
-    Tensor::from_primitive(output)
+    Tensor::from_dispatch(output)
 }
 
 /// We define a reference implementation using basic tensor operations.

--- a/examples/custom-wgpu-kernel/src/backward.rs
+++ b/examples/custom-wgpu-kernel/src/backward.rs
@@ -1,6 +1,6 @@
 use crate::FloatTensor;
 
-use super::{AutodiffBackend, Backend};
+use super::Backend;
 use burn::{
     backend::{
         TensorMetadata,
@@ -10,12 +10,9 @@ use burn::{
             grads::Gradients,
             ops::{Backward, Ops, OpsKind, broadcast_shape},
         },
-        wgpu::{CubeBackend, WgpuRuntime},
     },
     tensor::Shape,
 };
-
-impl AutodiffBackend for Autodiff<CubeBackend<WgpuRuntime>> {}
 
 // Implement our custom backend trait for any backend that also implements our custom backend trait.
 //

--- a/examples/custom-wgpu-kernel/src/lib.rs
+++ b/examples/custom-wgpu-kernel/src/lib.rs
@@ -22,12 +22,12 @@ pub trait AutodiffBackend: Backend + burn::backend::AutodiffBackend {}
 /// We define our custom implementation using the added function on our custom backend.
 pub fn matmul_add_relu_custom(lhs: Tensor<3>, rhs: Tensor<3>, bias: Tensor<3>) -> Tensor<3> {
     let output = Dispatch::fused_matmul_add_relu(
-        lhs.into_primitive(),
-        rhs.into_primitive(),
-        bias.into_primitive(),
+        lhs.into_dispatch(),
+        rhs.into_dispatch(),
+        bias.into_dispatch(),
     );
 
-    Tensor::from_primitive(output)
+    Tensor::from_dispatch(output)
 }
 
 /// We define a reference implementation using basic tensor operations.

--- a/examples/custom-wgpu-kernel/src/lib.rs
+++ b/examples/custom-wgpu-kernel/src/lib.rs
@@ -16,9 +16,6 @@ pub trait Backend: burn::backend::Backend {
     ) -> FloatTensor<Self>;
 }
 
-/// We create our own AutodiffBackend trait that extends the Burn autodiff backend trait.
-pub trait AutodiffBackend: Backend + burn::backend::AutodiffBackend {}
-
 /// We define our custom implementation using the added function on our custom backend.
 pub fn matmul_add_relu_custom(lhs: Tensor<3>, rhs: Tensor<3>, bias: Tensor<3>) -> Tensor<3> {
     let output = Dispatch::fused_matmul_add_relu(


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Closes #5035

### Changes

- Added support to `#[backend_extension(...)]` for traits with async fn / futures
- Added `Tensor::from_primitive` / `try_into_primitive` for low-level backend primitive interop
  - Renamed `from_primitive` / `into_primitive` -> `from_dispatch` / `into_dispatch` (clear boundaries for bridge, dispatch and backend primitive

```rust
let device = Device::wgpu(Default::default());
let tensor = Tensor::<2>::zeros([2, 3], &device);

// Extract the underlying CubeCL tensor primitive on the `Wgpu` backend
let primitive = tensor.try_into_primitive::<Wgpu>().unwrap();
// Reconstruct the `Tensor` from a concrete backend primitive.
let tensor = Tensor::<2>::from_primitive::<Wgpu>(primitive);
```
### Testing

Unit tests
