### PR TITLE
fix(dataset): fully qualify HuggingFace dataset repo ids

### DIFF
--- a/burn-book/src/building-blocks/dataset.md
+++ b/burn-book/src/building-blocks/dataset.md
@@ -54,7 +54,7 @@ found at the [API reference](https://burn.dev/docs/burn/data/dataset/transform/i
 
 ```rust, ignore
 type DbPedia = SqliteDataset<DbPediaItem>;
-let dataset: DbPedia = HuggingfaceDatasetLoader::new("dbpedia_14")
+let dataset: DbPedia = HuggingfaceDatasetLoader::new("fancyzhx/dbpedia_14")
         .dataset("train").
         .unwrap();
 
@@ -140,7 +140,7 @@ For now, there are only a couple of dataset sources available with Burn, but mor
 You can easily import any Hugging Face dataset with Burn. We use SQLite as the storage to avoid
 downloading the model each time or starting a Python process. You need to know the format of each
 item in the dataset beforehand. Here's an example with the
-[dbpedia dataset](https://huggingface.co/datasets/dbpedia_14).
+[dbpedia dataset](https://huggingface.co/datasets/fancyzhx/dbpedia_14).
 
 ```rust, ignore
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -151,7 +151,7 @@ pub struct DbPediaItem {
 }
 
 fn main() {
-    let dataset: SqliteDataset<DbPediaItem> = HuggingfaceDatasetLoader::new("dbpedia_14")
+    let dataset: SqliteDataset<DbPediaItem> = HuggingfaceDatasetLoader::new("fancyzhx/dbpedia_14")
         .dataset("train") // The training split.
         .unwrap();
 }

--- a/crates/burn-dataset/examples/hf_dataset.rs
+++ b/crates/burn-dataset/examples/hf_dataset.rs
@@ -10,7 +10,7 @@ struct MnistItemRaw {
 fn main() {
     // There are some datasets, such as https://huggingface.co/datasets/ylecun/mnist/tree/main that contains a script,
     // In this cases you must enable trusting remote code execution if you want to use it.
-    let _train_ds: SqliteDataset<MnistItemRaw> = HuggingfaceDatasetLoader::new("mnist")
+    let _train_ds: SqliteDataset<MnistItemRaw> = HuggingfaceDatasetLoader::new("ylecun/mnist")
         .with_trust_remote_code(true)
         .dataset("train")
         .unwrap();

--- a/crates/burn-dataset/src/audio/speech_commands.rs
+++ b/crates/burn-dataset/src/audio/speech_commands.rs
@@ -11,7 +11,7 @@ type MappedDataset = MapperDataset<SqliteDataset<SpeechItemRaw>, ConvertSamples,
 
 /// Enum representing speech command classes in the Speech Commands dataset.
 /// Class names are based on the Speech Commands dataset from Huggingface.
-/// See [speech_commands](https://huggingface.co/datasets/speech_commands)
+/// See [speech_commands](https://huggingface.co/datasets/google/speech_commands)
 /// for more information.
 #[allow(missing_docs)]
 #[derive(Debug, Display, Clone, Copy, FromRepr, Serialize, Deserialize, EnumCount)]
@@ -98,7 +98,7 @@ pub struct SpeechItem {
 }
 
 /// Speech Commands dataset from Huggingface v0.02.
-/// See [Speech Commands dataset](https://huggingface.co/datasets/speech_commands).
+/// See [Speech Commands dataset](https://huggingface.co/datasets/google/speech_commands).
 ///
 /// The data is downloaded from Huggingface and stored in a SQLite database (3.0 GB).
 /// The dataset contains 99,720 audio samples of 2,607 people saying 35 different words.
@@ -120,7 +120,7 @@ impl SpeechCommandsDataset {
     /// Create a new dataset with the given split.
     pub fn new(split: &str) -> Self {
         let dataset: SqliteDataset<SpeechItemRaw> =
-            HuggingfaceDatasetLoader::new("speech_commands")
+            HuggingfaceDatasetLoader::new("google/speech_commands")
                 .with_subset("v0.02")
                 .dataset(split)
                 .unwrap();

--- a/examples/text-classification/src/data/dataset.rs
+++ b/examples/text-classification/src/data/dataset.rs
@@ -61,7 +61,7 @@ impl AgNewsDataset {
 
     /// Constructs the dataset from a split (either "train" or "test")
     pub fn new(split: &str) -> Self {
-        let dataset: SqliteDataset<AgNewsItem> = HuggingfaceDatasetLoader::new("ag_news")
+        let dataset: SqliteDataset<AgNewsItem> = HuggingfaceDatasetLoader::new("fancyzhx/ag_news")
             .dataset(split)
             .unwrap();
         Self { dataset }
@@ -133,9 +133,10 @@ impl DbPediaDataset {
 
     /// Constructs the dataset from a split (either "train" or "test")
     pub fn new(split: &str) -> Self {
-        let dataset: SqliteDataset<DbPediaItem> = HuggingfaceDatasetLoader::new("dbpedia_14")
-            .dataset(split)
-            .unwrap();
+        let dataset: SqliteDataset<DbPediaItem> =
+            HuggingfaceDatasetLoader::new("fancyzhx/dbpedia_14")
+                .dataset(split)
+                .unwrap();
         Self { dataset }
     }
 }

--- a/examples/text-generation/src/data/dataset.rs
+++ b/examples/text-generation/src/data/dataset.rs
@@ -35,9 +35,10 @@ impl DbPediaDataset {
         Self::new("test")
     }
     pub fn new(split: &str) -> Self {
-        let dataset: SqliteDataset<DbPediaItem> = HuggingfaceDatasetLoader::new("dbpedia_14")
-            .dataset(split)
-            .unwrap();
+        let dataset: SqliteDataset<DbPediaItem> =
+            HuggingfaceDatasetLoader::new("fancyzhx/dbpedia_14")
+                .dataset(split)
+                .unwrap();
         Self { dataset }
     }
 }


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

Newer huggingface_hub/datasets releases reject bare canonical dataset names (e.g. "dbpedia_14") and require the "namespace/name" form, causing example/dataset downloads to fail with HfUriError.

Qualify the relocated canonical datasets to their current repo ids:
- `dbpedia_14`             -> `fancyzhx/dbpedia_14`
- `ag_news`                 -> `fancyzhx/ag_news`
- `mnist`                       -> `ylecun/mnist`
- `speech_commands` -> `google/speech_commands`

### Testing

All of the examples relating to these datasets were run (`text-generation`, `ag-news-train`, `db-pedia-train`, `hf_dataset`, `speech_commands`) and they managed to download the datasets successfully.

`speech_commands` still cannot run succesfully, but for an unrelated reason (external scripts are not longer supported) `RuntimeError: Dataset scripts are no longer supported, but found speech_commands.py`.
