### PR TITLE
feat(cubecl): wire logical any/all reductions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,7 +605,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -1662,7 +1662,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2453,7 +2453,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=e6a634f1bd0c3a72325228d308462ec0c5c96456#e6a634f1bd0c3a72325228d308462ec0c5c96456"
+source = "git+https://github.com/tracel-ai/cubek?rev=9deb872362a0756369a50737389d0051126ba8bc#9deb872362a0756369a50737389d0051126ba8bc"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2471,7 +2471,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=e6a634f1bd0c3a72325228d308462ec0c5c96456#e6a634f1bd0c3a72325228d308462ec0c5c96456"
+source = "git+https://github.com/tracel-ai/cubek?rev=9deb872362a0756369a50737389d0051126ba8bc#9deb872362a0756369a50737389d0051126ba8bc"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2485,7 +2485,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=e6a634f1bd0c3a72325228d308462ec0c5c96456#e6a634f1bd0c3a72325228d308462ec0c5c96456"
+source = "git+https://github.com/tracel-ai/cubek?rev=9deb872362a0756369a50737389d0051126ba8bc#9deb872362a0756369a50737389d0051126ba8bc"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2501,7 +2501,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=e6a634f1bd0c3a72325228d308462ec0c5c96456#e6a634f1bd0c3a72325228d308462ec0c5c96456"
+source = "git+https://github.com/tracel-ai/cubek?rev=9deb872362a0756369a50737389d0051126ba8bc#9deb872362a0756369a50737389d0051126ba8bc"
 dependencies = [
  "cubecl",
 ]
@@ -2509,7 +2509,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=e6a634f1bd0c3a72325228d308462ec0c5c96456#e6a634f1bd0c3a72325228d308462ec0c5c96456"
+source = "git+https://github.com/tracel-ai/cubek?rev=9deb872362a0756369a50737389d0051126ba8bc#9deb872362a0756369a50737389d0051126ba8bc"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2521,7 +2521,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=e6a634f1bd0c3a72325228d308462ec0c5c96456#e6a634f1bd0c3a72325228d308462ec0c5c96456"
+source = "git+https://github.com/tracel-ai/cubek?rev=9deb872362a0756369a50737389d0051126ba8bc#9deb872362a0756369a50737389d0051126ba8bc"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2535,7 +2535,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=e6a634f1bd0c3a72325228d308462ec0c5c96456#e6a634f1bd0c3a72325228d308462ec0c5c96456"
+source = "git+https://github.com/tracel-ai/cubek?rev=9deb872362a0756369a50737389d0051126ba8bc#9deb872362a0756369a50737389d0051126ba8bc"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2545,7 +2545,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=e6a634f1bd0c3a72325228d308462ec0c5c96456#e6a634f1bd0c3a72325228d308462ec0c5c96456"
+source = "git+https://github.com/tracel-ai/cubek?rev=9deb872362a0756369a50737389d0051126ba8bc#9deb872362a0756369a50737389d0051126ba8bc"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2556,7 +2556,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=e6a634f1bd0c3a72325228d308462ec0c5c96456#e6a634f1bd0c3a72325228d308462ec0c5c96456"
+source = "git+https://github.com/tracel-ai/cubek?rev=9deb872362a0756369a50737389d0051126ba8bc#9deb872362a0756369a50737389d0051126ba8bc"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2569,7 +2569,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=e6a634f1bd0c3a72325228d308462ec0c5c96456#e6a634f1bd0c3a72325228d308462ec0c5c96456"
+source = "git+https://github.com/tracel-ai/cubek?rev=9deb872362a0756369a50737389d0051126ba8bc#9deb872362a0756369a50737389d0051126ba8bc"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2582,7 +2582,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=e6a634f1bd0c3a72325228d308462ec0c5c96456#e6a634f1bd0c3a72325228d308462ec0c5c96456"
+source = "git+https://github.com/tracel-ai/cubek?rev=9deb872362a0756369a50737389d0051126ba8bc#9deb872362a0756369a50737389d0051126ba8bc"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2592,7 +2592,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=e6a634f1bd0c3a72325228d308462ec0c5c96456#e6a634f1bd0c3a72325228d308462ec0c5c96456"
+source = "git+https://github.com/tracel-ai/cubek?rev=9deb872362a0756369a50737389d0051126ba8bc#9deb872362a0756369a50737389d0051126ba8bc"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2998,7 +2998,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3340,7 +3340,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5639,7 +5639,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6000,15 +6000,6 @@ name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "ordered-float"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
 ]
@@ -7065,7 +7056,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7694,7 +7685,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8515,7 +8506,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8534,7 +8525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8579,7 +8570,7 @@ dependencies = [
  "nix 0.29.0",
  "num-derive",
  "num-traits",
- "ordered-float 4.6.0",
+ "ordered-float",
  "pest",
  "pest_derive",
  "phf 0.11.3",
@@ -9852,7 +9843,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
 dependencies = [
  "log",
- "ordered-float 4.6.0",
+ "ordered-float",
  "strsim",
  "thiserror 1.0.69",
  "wezterm-dynamic-derive",
@@ -10008,7 +9999,7 @@ dependencies = [
  "objc2-metal",
  "objc2-quartz-core",
  "once_cell",
- "ordered-float 5.3.0",
+ "ordered-float",
  "parking_lot",
  "portable-atomic",
  "portable-atomic-util",
@@ -10085,7 +10076,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,7 +222,7 @@ burn-wgpu = { path = "crates/burn-wgpu", version = "0.22.0-pre.1", default-featu
 cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "ba103c7f118524652647338dec09abf69a24a53e" }
 cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "ba103c7f118524652647338dec09abf69a24a53e" }
 cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "ba103c7f118524652647338dec09abf69a24a53e" }
-cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "e6a634f1bd0c3a72325228d308462ec0c5c96456" }
+cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "9deb872362a0756369a50737389d0051126ba8bc" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }

--- a/crates/burn-backend-tests/tests/tensor/float/ops/all.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/all.rs
@@ -16,3 +16,32 @@ fn test_all_dim() {
     let data_expected = TensorData::from([[false], [true]]);
     data_expected.assert_eq(&data_actual, false);
 }
+
+/// Larger `all_dim` over a long, non-power-of-two axis so the reduction spans
+/// multiple blocks/planes/cubes. Same mask as the large `any_dim` test; here a
+/// row reduces to `true` only when every element is nonzero (so the single-zero
+/// row 7 must reduce to `false`). Checked for float, int and bool inputs.
+#[test]
+fn test_all_dim_large() {
+    let device = Default::default();
+    let (rows, cols) = (8usize, 513usize);
+    let mask = build_logical_mask(rows, cols);
+
+    let expected: Vec<bool> = (0..rows)
+        .map(|r| (0..cols).all(|c| mask[r * cols + c]))
+        .collect();
+    let expected = TensorData::new(expected, [rows, 1]);
+
+    let float = TestTensor::<2>::from_data(
+        TensorData::new(mask_to_floats(&mask), [rows, cols]),
+        &device,
+    );
+    expected.assert_eq(&float.all_dim(1).into_data(), false);
+
+    let int =
+        TestTensorInt::<2>::from_data(TensorData::new(mask_to_ints(&mask), [rows, cols]), &device);
+    expected.assert_eq(&int.all_dim(1).into_data(), false);
+
+    let boolean = TestTensorBool::<2>::from_data(TensorData::new(mask, [rows, cols]), &device);
+    expected.assert_eq(&boolean.all_dim(1).into_data(), false);
+}

--- a/crates/burn-backend-tests/tests/tensor/float/ops/any.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/any.rs
@@ -56,3 +56,32 @@ fn test_any_dim() {
     let data_expected = TensorData::from([[false], [true]]);
     data_expected.assert_eq(&data_actual, false);
 }
+
+/// Larger `any_dim` over a long, non-power-of-two axis so the reduction spans
+/// multiple blocks/planes/cubes. Rows cover every merge case: all-zero,
+/// all-nonzero, a single nonzero at the first/last/middle column, and an
+/// all-nonzero row with a single zero. Checked for float, int and bool inputs.
+#[test]
+fn test_any_dim_large() {
+    let device = Default::default();
+    let (rows, cols) = (8usize, 513usize);
+    let mask = build_logical_mask(rows, cols);
+
+    let expected: Vec<bool> = (0..rows)
+        .map(|r| (0..cols).any(|c| mask[r * cols + c]))
+        .collect();
+    let expected = TensorData::new(expected, [rows, 1]);
+
+    let float = TestTensor::<2>::from_data(
+        TensorData::new(mask_to_floats(&mask), [rows, cols]),
+        &device,
+    );
+    expected.assert_eq(&float.any_dim(1).into_data(), false);
+
+    let int =
+        TestTensorInt::<2>::from_data(TensorData::new(mask_to_ints(&mask), [rows, cols]), &device);
+    expected.assert_eq(&int.any_dim(1).into_data(), false);
+
+    let boolean = TestTensorBool::<2>::from_data(TensorData::new(mask, [rows, cols]), &device);
+    expected.assert_eq(&boolean.any_dim(1).into_data(), false);
+}

--- a/crates/burn-backend-tests/tests/tensor/float/ops/mod.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/mod.rs
@@ -1,5 +1,57 @@
 use super::*;
 
+/// Build a `[rows, cols]` row-major boolean mask whose rows exercise every
+/// logical-reduction merge case along the last axis: all-zero, all-nonzero, a
+/// single nonzero at the first/last/middle column, and an all-nonzero row with
+/// a single zero. Used by the large `any_dim`/`all_dim` tests (`rows == 8`).
+pub fn build_logical_mask(rows: usize, cols: usize) -> Vec<bool> {
+    assert!(
+        rows >= 8 && cols > 100,
+        "mask layout assumes rows>=8, cols>100"
+    );
+    let mut mask = vec![false; rows * cols];
+    for c in 0..cols {
+        mask[cols + c] = true; // row 1: all nonzero
+        mask[5 * cols + c] = true; // row 5: all nonzero
+        mask[7 * cols + c] = true; // row 7: all nonzero (one zero punched below)
+    }
+    mask[2 * cols] = true; // row 2: single nonzero at the first column
+    mask[3 * cols + (cols - 1)] = true; // row 3: single nonzero at the last column
+    mask[6 * cols + cols / 2] = true; // row 6: single nonzero in the middle
+    mask[7 * cols + 100] = false; // row 7: a single zero deep inside an all-nonzero row
+    // rows 0 and 4 stay all-zero
+    mask
+}
+
+/// Map the mask to float input, using alternating nonzero magnitudes so the
+/// reduction must normalize arbitrary nonzero values (not just `1.0`) to true.
+pub fn mask_to_floats(mask: &[bool]) -> Vec<f32> {
+    mask.iter()
+        .enumerate()
+        .map(|(i, &m)| {
+            if m {
+                if i % 2 == 0 { 2.0 } else { -3.0 }
+            } else {
+                0.0
+            }
+        })
+        .collect()
+}
+
+/// Map the mask to int input with alternating nonzero magnitudes.
+pub fn mask_to_ints(mask: &[bool]) -> Vec<i32> {
+    mask.iter()
+        .enumerate()
+        .map(|(i, &m)| {
+            if m {
+                if i % 2 == 0 { 2 } else { -3 }
+            } else {
+                0
+            }
+        })
+        .collect()
+}
+
 mod abs;
 mod add;
 mod aggregation;

--- a/crates/burn-cubecl-fusion/src/optim/matmul/args.rs
+++ b/crates/burn-cubecl-fusion/src/optim/matmul/args.rs
@@ -22,11 +22,11 @@ use cubecl::{
 };
 use cubek::{
     matmul::{
+        args::{BatchedCoords, MatmulArgs},
         components::global::memory::{
             BatchLayout, BlockScaledLayout, GlobalLayout, GlobalLayoutConfig, GlobalLayoutExpand,
             GlobalScaleLayout, GlobalScaleLayoutExpand, NoopLayout,
         },
-        launch::{BatchedCoords, MatmulArgs},
     },
     std::MatrixLayout,
 };

--- a/crates/burn-cubecl-fusion/src/optim/matmul/optimization.rs
+++ b/crates/burn-cubecl-fusion/src/optim/matmul/optimization.rs
@@ -29,18 +29,22 @@ use cubek::{
         definition::{
             MatmulElems, MatmulGlobalElems, MatmulProblem, MatmulSetupError, MatmulVectorSizes,
         },
-        launch::launch_kernel_virtual,
         routines::{
-            BlueprintStrategy, Routine,
-            double_buffering::{CyclicDoubleBufferingAlgorithm, DoubleBufferingArgs},
-            double_unit::DoubleUnitAlgorithm,
+            BatchMatmulRoutine, BlueprintStrategy,
+            batch::{
+                double_buffering::{CyclicDoubleBufferingAlgorithm, DoubleBufferingArgs},
+                double_unit::DoubleUnitAlgorithm,
+                gemv_innerproduct::{
+                    DoubleVecMatInnerProductAlgorithm, VecMatInnerProductAlgorithm,
+                },
+                ordered_double_buffering::{OrderedDoubleBufferingAlgorithm, OrderedSelectionArgs},
+                simple::{SimpleAlgorithm, SimpleArgs},
+                simple_unit::SimpleUnitAlgorithm,
+            },
             gemm::GemmRoutine,
-            gemv_innerproduct::{DoubleVecMatInnerProductAlgorithm, VecMatInnerProductAlgorithm},
             gemv_unit_perpendicular::GemvUnitPerpendicularRoutine,
-            ordered_double_buffering::{OrderedDoubleBufferingAlgorithm, OrderedSelectionArgs},
-            simple::{SimpleAlgorithm, SimpleArgs},
-            simple_unit::SimpleUnitAlgorithm,
         },
+        strategy::launch_kernel_virtual,
     },
     std::MatrixLayout,
 };
@@ -684,7 +688,7 @@ impl FusedMatmulLaunch<'_> {
     }
 }
 
-fn launch_inner_fix_dtype<R: Runtime, A: Routine<()>>(
+fn launch_inner_fix_dtype<R: Runtime, A: BatchMatmulRoutine<()>>(
     client: &ComputeClient<R>,
     input: FusedMatmulInputLaunch<R>,
     output: GlobalArgsLaunch<R>,

--- a/crates/burn-cubecl-fusion/src/optim/matmul/tune.rs
+++ b/crates/burn-cubecl-fusion/src/optim/matmul/tune.rs
@@ -14,7 +14,7 @@ use cubecl::{
 };
 use cubek::matmul::{
     definition::MatmulKind,
-    launch::{MatmulAutotuneKey, MatmulGlobalScale, should_tune_double_buffering},
+    strategy::{MatmulAutotuneKey, MatmulGlobalScale, should_tune_double_buffering},
 };
 use serde::{Deserialize, Serialize};
 

--- a/crates/burn-cubecl/src/kernel/matmul/base.rs
+++ b/crates/burn-cubecl/src/kernel/matmul/base.rs
@@ -6,7 +6,7 @@ use burn_std::QuantLevel;
 use cubek::{
     matmul::{
         definition::{MatmulElems, MatmulGlobalElems, MatmulSetupError},
-        launch::Strategy,
+        strategy::Strategy,
     },
     std::InputBinding,
 };

--- a/crates/burn-cubecl/src/kernel/matmul/tune/base.rs
+++ b/crates/burn-cubecl/src/kernel/matmul/tune/base.rs
@@ -12,13 +12,16 @@ use cubecl::{
 use cubek::matmul::{
     components::tile::TileMatmulKind,
     definition::MatmulKind,
-    launch::{MatmulAutotuneKey, MatmulGlobalScale, Strategy, should_tune_double_buffering},
     routines::{
-        BlueprintStrategy, TileSizeSelection, double_buffering::DoubleBufferingArgs,
-        double_unit::DoubleUnitSelectionArgs, gemm::GemmStrategy,
-        ordered_double_buffering::OrderedSelectionArgs, simple::SimpleArgs,
-        simple_unit::SimpleUnitSelectionArgs,
+        BlueprintStrategy, TileSizeSelection,
+        batch::{
+            double_buffering::DoubleBufferingArgs, double_unit::DoubleUnitSelectionArgs,
+            ordered_double_buffering::OrderedSelectionArgs, simple::SimpleArgs,
+            simple_unit::SimpleUnitSelectionArgs,
+        },
+        gemm::GemmStrategy,
     },
+    strategy::{MatmulAutotuneKey, MatmulGlobalScale, Strategy, should_tune_double_buffering},
 };
 
 fn matmul_input_gen<R: CubeRuntime>(

--- a/crates/burn-cubecl/src/kernel/reduce/base.rs
+++ b/crates/burn-cubecl/src/kernel/reduce/base.rs
@@ -2,7 +2,6 @@
 use super::{autotune_reduce, autotune_sum};
 use crate::{
     CubeRuntime,
-    kernel::cast,
     ops::numeric::{empty_device_contiguous_dtype, zeros_client},
     tensor::CubeTensor,
 };
@@ -135,12 +134,10 @@ pub fn reduce<Run: CubeRuntime>(
 /// Reduce with a logical instruction ([`Any`](ReduceOperationConfig::Any) /
 /// [`All`](ReduceOperationConfig::All)) and return the result as a boolean tensor.
 ///
-/// The reduction itself produces a numeric `0/1` tensor whose dtype matches the
-/// input (cubek's `precision()` keeps `output = input` for `Any`/`All`). We then
-/// convert those flags to the boolean backing storage and relabel the tensor as
-/// `Bool`. For a boolean input the storage already matches, so the cast is a
-/// no-op and only the (kernel-free) dtype relabel happens; for float/int inputs
-/// the cast runs on the already-reduced (small) tensor.
+/// `Any` / `All` require the output dtype (like `Arg*` index outputs): the
+/// kernel writes the `0/1` flags directly into the numeric backing of the
+/// boolean storage (cubek has no bool elem), so the only step left here is the
+/// kernel-free relabel to `Bool`.
 ///
 /// `dim == None` reduces the whole tensor to a scalar; `Some(dim)` reduces a
 /// single axis, keeping it with length 1.
@@ -158,15 +155,14 @@ pub fn reduce_logical<Run: CubeRuntime>(
         "reduce_logical only supports Any / All, got {config:?}"
     );
     let out_bool = DType::Bool(out_dtype);
+    let backing = elem_type_to_dtype(dtype_to_elem_type(out_bool));
 
-    let reduced = match dim {
-        Some(d) => reduce_dim::<Run>(tensor, None, d, Default::default(), config),
-        None => reduce::<Run>(tensor, None, Default::default(), config),
+    let mut out = match dim {
+        Some(d) => reduce_dim::<Run>(tensor, Some(backing), d, Default::default(), config),
+        None => reduce::<Run>(tensor, Some(backing), Default::default(), config),
     }
     .expect("Any/All reduce on a valid axis cannot fail");
 
-    let backing = elem_type_to_dtype(dtype_to_elem_type(out_bool));
-    let mut out = cast(reduced, backing);
     out.dtype = out_bool; // same storage, relabel as Bool (no kernel)
     out
 }
@@ -197,8 +193,10 @@ pub fn reduce_dim<Run: CubeRuntime>(
             ReduceOperationConfig::ArgMax
                 | ReduceOperationConfig::ArgMin
                 | ReduceOperationConfig::ArgTopK(_)
+                | ReduceOperationConfig::Any
+                | ReduceOperationConfig::All
         ) || output_dtype.is_some(),
-        "The `output_dtype` has to be `Some` only when the `config` is `ArgMax`, `ArgMin` or `ArgTopK`.
+        "The `output_dtype` has to be `Some` when the `config` is `ArgMax`, `ArgMin`, `ArgTopK`, `Any` or `All`.
         "
     );
 

--- a/crates/burn-cubecl/src/kernel/reduce/base.rs
+++ b/crates/burn-cubecl/src/kernel/reduce/base.rs
@@ -2,12 +2,13 @@
 use super::{autotune_reduce, autotune_sum};
 use crate::{
     CubeRuntime,
+    kernel::cast,
     ops::numeric::{empty_device_contiguous_dtype, zeros_client},
     tensor::CubeTensor,
 };
 use burn_backend::cubecl::{dtype_to_elem_type, elem_type_to_dtype};
 use burn_backend::{DType, TensorMetadata};
-use burn_std::Metadata;
+use burn_std::{BoolDType, Metadata};
 use cubecl::{AutotuneKey, client::ComputeClient, features::AtomicUsage, ir::Type};
 use cubek::reduce::{
     ReduceDtypes, ReduceError, ReduceStrategy,
@@ -129,6 +130,45 @@ pub fn reduce<Run: CubeRuntime>(
     // reshape to scalar tensor
     *tensor.meta = Metadata::new([1], [1]);
     Ok(tensor)
+}
+
+/// Reduce with a logical instruction ([`Any`](ReduceOperationConfig::Any) /
+/// [`All`](ReduceOperationConfig::All)) and return the result as a boolean tensor.
+///
+/// The reduction itself produces a numeric `0/1` tensor whose dtype matches the
+/// input (cubek's `precision()` keeps `output = input` for `Any`/`All`). We then
+/// convert those flags to the boolean backing storage and relabel the tensor as
+/// `Bool`. For a boolean input the storage already matches, so the cast is a
+/// no-op and only the (kernel-free) dtype relabel happens; for float/int inputs
+/// the cast runs on the already-reduced (small) tensor.
+///
+/// `dim == None` reduces the whole tensor to a scalar; `Some(dim)` reduces a
+/// single axis, keeping it with length 1.
+pub fn reduce_logical<Run: CubeRuntime>(
+    tensor: CubeTensor<Run>,
+    dim: Option<usize>,
+    config: ReduceOperationConfig,
+    out_dtype: BoolDType,
+) -> CubeTensor<Run> {
+    debug_assert!(
+        matches!(
+            config,
+            ReduceOperationConfig::Any | ReduceOperationConfig::All
+        ),
+        "reduce_logical only supports Any / All, got {config:?}"
+    );
+    let out_bool = DType::Bool(out_dtype);
+
+    let reduced = match dim {
+        Some(d) => reduce_dim::<Run>(tensor, None, d, Default::default(), config),
+        None => reduce::<Run>(tensor, None, Default::default(), config),
+    }
+    .expect("Any/All reduce on a valid axis cannot fail");
+
+    let backing = elem_type_to_dtype(dtype_to_elem_type(out_bool));
+    let mut out = cast(reduced, backing);
+    out.dtype = out_bool; // same storage, relabel as Bool (no kernel)
+    out
 }
 
 fn argsort(shape: &[usize]) -> Vec<usize> {

--- a/crates/burn-cubecl/src/ops/bool_tensor.rs
+++ b/crates/burn-cubecl/src/ops/bool_tensor.rs
@@ -2,6 +2,7 @@ use crate::{
     CubeBackend, CubeRuntime,
     element::BoolElement,
     kernel::{self, AndOp, OrOp},
+    tensor::CubeTensor,
 };
 use burn_backend::cubecl::dtype_to_storage_type;
 use burn_backend::{
@@ -12,9 +13,19 @@ use burn_backend::{
 use burn_backend::{Scalar, Shape, TensorData};
 use burn_std::{BoolDType, BoolStore, DType, FloatDType, IntDType};
 use cubecl::prelude::InputScalar;
+use cubek::reduce::components::instructions::ReduceOperationConfig;
 use std::ops::Range;
 
 use super::{expand, numeric, permute, unfold};
+
+/// The boolean storage of a cubecl bool tensor. Cubecl backends never use
+/// native bool (see `CubeBackend::supports_dtype`), so it is always `U8`/`U32`.
+fn bool_store<R: CubeRuntime>(tensor: &CubeTensor<R>) -> BoolDType {
+    match tensor.dtype {
+        DType::Bool(store) => store,
+        other => unreachable!("cubecl bool tensors are always Bool(_): {other:?}"),
+    }
+}
 
 impl<R: CubeRuntime> BoolTensorOps<Self> for CubeBackend<R> {
     fn bool_empty(shape: Shape, device: &Device<Self>, dtype: BoolDType) -> BoolTensor<Self> {
@@ -108,6 +119,26 @@ impl<R: CubeRuntime> BoolTensorOps<Self> for CubeBackend<R> {
 
     fn bool_or(lhs: BoolTensor<Self>, rhs: BoolTensor<Self>) -> BoolTensor<Self> {
         kernel::launch_binop::<R, OrOp>(lhs, rhs)
+    }
+
+    fn bool_any(tensor: BoolTensor<Self>) -> BoolTensor<Self> {
+        let store = bool_store(&tensor);
+        kernel::reduce::reduce_logical(tensor, None, ReduceOperationConfig::Any, store)
+    }
+
+    fn bool_any_dim(tensor: BoolTensor<Self>, dim: usize) -> BoolTensor<Self> {
+        let store = bool_store(&tensor);
+        kernel::reduce::reduce_logical(tensor, Some(dim), ReduceOperationConfig::Any, store)
+    }
+
+    fn bool_all(tensor: BoolTensor<Self>) -> BoolTensor<Self> {
+        let store = bool_store(&tensor);
+        kernel::reduce::reduce_logical(tensor, None, ReduceOperationConfig::All, store)
+    }
+
+    fn bool_all_dim(tensor: BoolTensor<Self>, dim: usize) -> BoolTensor<Self> {
+        let store = bool_store(&tensor);
+        kernel::reduce::reduce_logical(tensor, Some(dim), ReduceOperationConfig::All, store)
     }
 
     fn bool_into_float(tensor: BoolTensor<Self>, out_dtype: FloatDType) -> FloatTensor<Self> {

--- a/crates/burn-cubecl/src/ops/int_tensor.rs
+++ b/crates/burn-cubecl/src/ops/int_tensor.rs
@@ -347,6 +347,22 @@ impl<R: CubeRuntime> IntTensorOps<Self> for CubeBackend<R> {
         .unwrap()
     }
 
+    fn int_any(tensor: IntTensor<Self>, out_dtype: BoolDType) -> BoolTensor<Self> {
+        reduce::reduce_logical(tensor, None, ReduceOperationConfig::Any, out_dtype)
+    }
+
+    fn int_any_dim(tensor: IntTensor<Self>, dim: usize, out_dtype: BoolDType) -> BoolTensor<Self> {
+        reduce::reduce_logical(tensor, Some(dim), ReduceOperationConfig::Any, out_dtype)
+    }
+
+    fn int_all(tensor: IntTensor<Self>, out_dtype: BoolDType) -> BoolTensor<Self> {
+        reduce::reduce_logical(tensor, None, ReduceOperationConfig::All, out_dtype)
+    }
+
+    fn int_all_dim(tensor: IntTensor<Self>, dim: usize, out_dtype: BoolDType) -> BoolTensor<Self> {
+        reduce::reduce_logical(tensor, Some(dim), ReduceOperationConfig::All, out_dtype)
+    }
+
     fn int_prod(tensor: IntTensor<Self>) -> IntTensor<Self> {
         reduce::reduce(
             tensor,

--- a/crates/burn-cubecl/src/ops/tensor.rs
+++ b/crates/burn-cubecl/src/ops/tensor.rs
@@ -431,6 +431,30 @@ where
         .unwrap()
     }
 
+    fn float_any(tensor: FloatTensor<Self>, out_dtype: BoolDType) -> BoolTensor<Self> {
+        reduce::reduce_logical(tensor, None, ReduceOperationConfig::Any, out_dtype)
+    }
+
+    fn float_any_dim(
+        tensor: FloatTensor<Self>,
+        dim: usize,
+        out_dtype: BoolDType,
+    ) -> BoolTensor<Self> {
+        reduce::reduce_logical(tensor, Some(dim), ReduceOperationConfig::Any, out_dtype)
+    }
+
+    fn float_all(tensor: FloatTensor<Self>, out_dtype: BoolDType) -> BoolTensor<Self> {
+        reduce::reduce_logical(tensor, None, ReduceOperationConfig::All, out_dtype)
+    }
+
+    fn float_all_dim(
+        tensor: FloatTensor<Self>,
+        dim: usize,
+        out_dtype: BoolDType,
+    ) -> BoolTensor<Self> {
+        reduce::reduce_logical(tensor, Some(dim), ReduceOperationConfig::All, out_dtype)
+    }
+
     fn float_sum_dim(tensor: FloatTensor<Self>, dim: usize) -> FloatTensor<Self> {
         reduce::reduce_dim(
             tensor,


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed. 
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Depends on tracel-ai/cubek#302
Related with tracel-ai/burn#5046

### Changes

This PR wires Burn's CubeCL backend to cubek's logical `any` / `all` reductions.

Changes include:

  - update `cubek` to the cubek PR commit from tracel-ai/cubek#302
  - update `cubecl`, `cubecl-common`, and `cubecl-zspace` to the matching cubek dependency revision
  - implement CubeCL backend overrides for:
    - `bool_any` / `bool_all`
    - `float_any` / `float_all`
    - `int_any` / `int_all`
  - route logical reductions through cubek `ReduceOperationConfig::Any` / `All`
  - add large-dimension float tests for `any_dim` / `all_dim`
  - adapt `GlobalMemoryStrategy` initialization to the newer cubek interpolate API

  This makes Burn's `contains_nan()` path use a real logical reduction through `is_nan().any()` on CubeCL instead of relying on sum based behavior.

  ### Testing

  ```bash
  cargo check -p burn-cubecl
  cargo test -p burn-backend-tests --features flex test_any_dim_large -- --nocapture
  cargo test -p burn-backend-tests --features flex test_all_dim_large -- --nocapture
  cargo test -p burn-backend-tests --features flex test_any -- --nocapture
  cargo test -p burn-backend-tests --features flex test_all -- --nocapture
  cargo test -p burn-backend-tests --features flex contains_nan -- --nocapture
  cargo fmt --all -- --check
  git diff --check