### PR TITLE
fix(example): `Device::enumerate` configure

### DIFF
--- a/examples/text-classification/examples/ag-news-train.rs
+++ b/examples/text-classification/examples/ag-news-train.rs
@@ -21,12 +21,13 @@ type ElemType = burn::tensor::flex32;
 
 #[cfg(all(feature = "cuda", not(feature = "ddp")))]
 pub fn launch_multi() {
-    let devices = Device::enumerate(burn::tensor::DeviceType::Cuda)
+    let mut devices = Device::enumerate(burn::tensor::DeviceType::Cuda);
+    devices
         .configure(DeviceConfig::default().float_dtype(ElemType::dtype()))
         .unwrap();
 
     launch(ExecutionStrategy::MultiDevice(
-        devices,
+        devices.into_vec(),
         burn::train::MultiDeviceOptim::OptimSharded,
     ))
 }


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Missed in #5013

### Changes

`Devices::configure` has the same signature as `Device::configure`: it takes `&mut self`, it's not a builder pattern (consume `self` -> return `Self`).