### PR TITLE
Add CubeCL fusion lowering for int bitwise ops

### DIFF
--- a/crates/burn-backend-tests/tests/fusion/int_bitwise.rs
+++ b/crates/burn-backend-tests/tests/fusion/int_bitwise.rs
@@ -1,0 +1,94 @@
+use super::*;
+use burn_fusion::inspect::{BlockKind, FusionInspector, matchers};
+use burn_tensor::TensorData;
+
+#[test]
+fn int_bitwise_chain_and_float_cast_fuse_into_single_kernel() {
+    let stream = test_stream();
+    stream.executes(|| {
+        let device = Default::default();
+
+        let lhs = TestTensorInt::<1>::from_data([13, 7, 3, 12], &device);
+        let rhs = TestTensorInt::<1>::from_data([11, 3, 5, 9], &device);
+        device.sync().unwrap();
+
+        let inspector = FusionInspector::install(stream);
+
+        let bitwise = lhs
+            .clone()
+            .bitwise_xor(rhs)
+            .bitwise_and_scalar(7)
+            .bitwise_right_shift_scalar(1)
+            .bitwise_or(lhs.bitwise_not());
+
+        let output = bitwise.float().mul_scalar(0.5);
+        let dtype = output.dtype();
+        output
+            .into_data()
+            .assert_eq(&TensorData::from([-6.5_f32, -3.0, -0.5, -6.5]), false);
+        device.sync().unwrap();
+
+        let reports = inspector.drain();
+        let tables = reports
+            .iter()
+            .map(|report| report.format_table())
+            .collect::<Vec<_>>()
+            .join("\n\n");
+
+        let block = reports
+            .iter()
+            .flat_map(|report| report.blocks.iter())
+            .find(|block| block.operations.iter().any(matchers::is_bitwise_xor_int()))
+            .unwrap_or_else(|| panic!("no bitwise fused block found\n\n{tables}"));
+
+        assert!(
+            matches!(
+                block.kind,
+                BlockKind::Fused {
+                    name: "ElementWise",
+                    ..
+                }
+            ),
+            "expected ElementWise fused block, got {:?}\n\n{tables}",
+            block.kind,
+        );
+
+        assert!(
+            block.operations.iter().any(matchers::is_bitwise_xor_int()),
+            "BitwiseXor missing from fused block\n\n{tables}",
+        );
+        assert!(
+            block
+                .operations
+                .iter()
+                .any(matchers::is_bitwise_and_scalar_int()),
+            "BitwiseAndScalar missing from fused block\n\n{tables}",
+        );
+        assert!(
+            block
+                .operations
+                .iter()
+                .any(matchers::is_bitwise_right_shift_scalar_int()),
+            "BitwiseRightShiftScalar missing from fused block\n\n{tables}",
+        );
+        assert!(
+            block.operations.iter().any(matchers::is_bitwise_not_int()),
+            "BitwiseNot missing from fused block\n\n{tables}",
+        );
+        assert!(
+            block.operations.iter().any(matchers::is_bitwise_or_int()),
+            "BitwiseOr missing from fused block\n\n{tables}",
+        );
+        assert!(
+            block.operations.iter().any(matchers::is_int_into_float()),
+            "IntoFloat missing from fused block\n\n{tables}",
+        );
+        assert!(
+            block
+                .operations
+                .iter()
+                .any(matchers::is_mul_scalar_float(dtype)),
+            "MulScalar missing from fused block\n\n{tables}",
+        );
+    });
+}

--- a/crates/burn-backend-tests/tests/fusion/mod.rs
+++ b/crates/burn-backend-tests/tests/fusion/mod.rs
@@ -3,6 +3,7 @@ pub use super::*;
 mod fusion_f16_broadcast;
 mod fusion_f16_write_vectorization;
 mod fusion_shape;
+mod int_bitwise;
 mod reduce_broadcasted;
 
 use burn_tensor::StreamId;

--- a/crates/burn-cubecl-fusion/src/engine/codegen/ir.rs
+++ b/crates/burn-cubecl-fusion/src/engine/codegen/ir.rs
@@ -164,6 +164,12 @@ pub enum FuseOp {
     LowerEqual(BinaryFuseArgs),
     Rem(BinaryFuseArgs),
     GreaterEqual(BinaryFuseArgs),
+    BitwiseAnd(BinaryFuseArgs),
+    BitwiseOr(BinaryFuseArgs),
+    BitwiseXor(BinaryFuseArgs),
+    BitwiseLeftShift(BinaryFuseArgs),
+    BitwiseRightShift(BinaryFuseArgs),
+    BitwiseNot(UnaryFuseArgs),
     Clamp {
         input: FuseArg,
         min: FuseArg,
@@ -221,6 +227,16 @@ impl Display for FuseOp {
             FuseOp::LowerEqual(args) => write!(f, "{} = {} <= {}", args.out, args.lhs, args.rhs),
             FuseOp::Rem(args) => write!(f, "{} = {} % {}", args.out, args.lhs, args.rhs),
             FuseOp::GreaterEqual(args) => write!(f, "{} = {} >= {}", args.out, args.lhs, args.rhs),
+            FuseOp::BitwiseAnd(args) => write!(f, "{} = {} & {}", args.out, args.lhs, args.rhs),
+            FuseOp::BitwiseOr(args) => write!(f, "{} = {} | {}", args.out, args.lhs, args.rhs),
+            FuseOp::BitwiseXor(args) => write!(f, "{} = {} ^ {}", args.out, args.lhs, args.rhs),
+            FuseOp::BitwiseLeftShift(args) => {
+                write!(f, "{} = {} << {}", args.out, args.lhs, args.rhs)
+            }
+            FuseOp::BitwiseRightShift(args) => {
+                write!(f, "{} = {} >> {}", args.out, args.lhs, args.rhs)
+            }
+            FuseOp::BitwiseNot(args) => write!(f, "{} = !{}", args.out, args.input),
             FuseOp::Clamp {
                 input,
                 min,
@@ -304,6 +320,12 @@ impl FuseOp {
             FuseOp::Greater(op) => op.lhs.precision().into_elem(),
             FuseOp::LowerEqual(op) => op.lhs.precision().into_elem(),
             FuseOp::GreaterEqual(op) => op.lhs.precision().into_elem(),
+            FuseOp::BitwiseAnd(op) => op.lhs.precision().into_elem(),
+            FuseOp::BitwiseOr(op) => op.lhs.precision().into_elem(),
+            FuseOp::BitwiseXor(op) => op.lhs.precision().into_elem(),
+            FuseOp::BitwiseLeftShift(op) => op.lhs.precision().into_elem(),
+            FuseOp::BitwiseRightShift(op) => op.lhs.precision().into_elem(),
+            FuseOp::BitwiseNot(op) => op.out.precision().into_elem(),
             FuseOp::ConditionalAssign { out, .. } => out.precision().into_elem(),
             FuseOp::Gather { output, .. } => output.precision().into_elem(),
             FuseOp::Select { output, .. } => output.precision().into_elem(),
@@ -671,7 +693,12 @@ impl FuseOp {
             | FuseOp::Greater(binary_fuse_args)
             | FuseOp::LowerEqual(binary_fuse_args)
             | FuseOp::Rem(binary_fuse_args)
-            | FuseOp::GreaterEqual(binary_fuse_args) => {
+            | FuseOp::GreaterEqual(binary_fuse_args)
+            | FuseOp::BitwiseAnd(binary_fuse_args)
+            | FuseOp::BitwiseOr(binary_fuse_args)
+            | FuseOp::BitwiseXor(binary_fuse_args)
+            | FuseOp::BitwiseLeftShift(binary_fuse_args)
+            | FuseOp::BitwiseRightShift(binary_fuse_args) => {
                 binary_fuse_args.lhs.multi_block_variable(registers);
                 binary_fuse_args.rhs.multi_block_variable(registers);
                 binary_fuse_args.out.multi_block_variable(registers);
@@ -686,7 +713,8 @@ impl FuseOp {
             | FuseOp::Erf(unary_fuse_args)
             | FuseOp::Sqrt(unary_fuse_args)
             | FuseOp::Recip(unary_fuse_args)
-            | FuseOp::Assign(unary_fuse_args) => {
+            | FuseOp::Assign(unary_fuse_args)
+            | FuseOp::BitwiseNot(unary_fuse_args) => {
                 unary_fuse_args.input.multi_block_variable(registers);
                 unary_fuse_args.out.multi_block_variable(registers);
             }

--- a/crates/burn-cubecl-fusion/src/engine/codegen/kernel.rs
+++ b/crates/burn-cubecl-fusion/src/engine/codegen/kernel.rs
@@ -270,6 +270,16 @@ fn fuse(
             }
             FuseOp::Lower(op) => lower::<E, N>(inputs, outputs, locals, pos, op, config),
             FuseOp::LowerEqual(op) => lower_equal::<E, N>(inputs, outputs, locals, pos, op, config),
+            FuseOp::BitwiseAnd(op) => bitwise_and::<E, N>(inputs, outputs, locals, pos, op, config),
+            FuseOp::BitwiseOr(op) => bitwise_or::<E, N>(inputs, outputs, locals, pos, op, config),
+            FuseOp::BitwiseXor(op) => bitwise_xor::<E, N>(inputs, outputs, locals, pos, op, config),
+            FuseOp::BitwiseLeftShift(op) => {
+                bitwise_left_shift::<E, N>(inputs, outputs, locals, pos, op, config)
+            }
+            FuseOp::BitwiseRightShift(op) => {
+                bitwise_right_shift::<E, N>(inputs, outputs, locals, pos, op, config)
+            }
+            FuseOp::BitwiseNot(op) => bitwise_not::<E, N>(inputs, outputs, locals, pos, op, config),
             FuseOp::ConditionalAssign {
                 cond,
                 lhs,
@@ -335,6 +345,45 @@ macro_rules! binary_op {
             let lhs = read::<C, N>(inputs, &*outputs, &*locals, write_pos, op.lhs, config);
             let rhs = read::<C, N>(inputs, &*outputs, &*locals, write_pos, op.rhs, config);
             let result = lhs $op rhs;
+
+            write::<C, N>(inputs, outputs, locals, write_pos, result, op.out, config);
+        }
+    };
+}
+
+macro_rules! binary_int_op {
+    ($ident:ident, $op:tt) => {
+        #[cube]
+        fn $ident<C: Int, N: Size>(
+            inputs: &GlobalArgs,
+            outputs: &mut GlobalArgs,
+            locals: &mut LocalArgs,
+            write_pos: usize,
+            #[comptime] op: BinaryFuseArgs,
+            #[comptime] config: &FuseBlockConfig,
+        ) {
+            let lhs = read::<C, N>(inputs, &*outputs, &*locals, write_pos, op.lhs, config);
+            let rhs = read::<C, N>(inputs, &*outputs, &*locals, write_pos, op.rhs, config);
+            let result = lhs $op rhs;
+
+            write::<C, N>(inputs, outputs, locals, write_pos, result, op.out, config);
+        }
+    };
+}
+
+macro_rules! unary_int_op {
+    ($ident:ident, $op:tt) => {
+        #[cube]
+        fn $ident<C: Int, N: Size>(
+            inputs: &GlobalArgs,
+            outputs: &mut GlobalArgs,
+            locals: &mut LocalArgs,
+            write_pos: usize,
+            #[comptime] op: UnaryFuseArgs,
+            #[comptime] config: &FuseBlockConfig,
+        ) {
+            let input = read::<C, N>(inputs, &*outputs, &*locals, write_pos, op.input, config);
+            let result = $op input;
 
             write::<C, N>(inputs, outputs, locals, write_pos, result, op.out, config);
         }
@@ -843,6 +892,13 @@ binary_op!(add, +);
 binary_op!(mul, *);
 binary_op!(div, /);
 binary_op!(sub, -);
+
+binary_int_op!(bitwise_and, &);
+binary_int_op!(bitwise_or, |);
+binary_int_op!(bitwise_xor, ^);
+binary_int_op!(bitwise_left_shift, <<);
+binary_int_op!(bitwise_right_shift, >>);
+unary_int_op!(bitwise_not, !);
 
 comparison_op!(equal, ==);
 comparison_op!(greater, >);

--- a/crates/burn-cubecl-fusion/src/engine/fuser.rs
+++ b/crates/burn-cubecl-fusion/src/engine/fuser.rs
@@ -7,8 +7,8 @@ use crate::engine::{codegen::ir::QuantSchemeFuse, scoring::Scoring};
 use burn_backend::cubecl::dtype_to_elem_type;
 use burn_fusion::{FuserProperties, FuserStatus, OperationFuser};
 use burn_ir::{
-    BaseOperationIr, BinaryOpIr, FloatOperationIr, NumericOperationIr, OperationIr, ScalarOpIr,
-    TensorIr, UnaryOpIr,
+    BaseOperationIr, BinaryOpIr, FloatOperationIr, IntOperationIr, NumericOperationIr, OperationIr,
+    ScalarOpIr, TensorIr, UnaryOpIr,
 };
 use burn_std::{
     DType, Shape,
@@ -111,6 +111,13 @@ impl OperationFuser<FuseTrace> for TraceOperationFuser {
                 if !self.fuse_float(ops) {
                     self.status = FuserStatus::Closed;
                     self.log_closed(op, prev_num_ops, "float fuse rejected");
+                    return;
+                }
+            }
+            OperationIr::Int(ops) => {
+                if !self.fuse_int(ops) {
+                    self.status = FuserStatus::Closed;
+                    self.log_closed(op, prev_num_ops, "int fuse rejected");
                     return;
                 }
             }
@@ -524,6 +531,56 @@ impl TraceOperationFuser {
                     Some(())
                 })
             }
+            _ => false,
+        }
+    }
+
+    fn fuse_int(&mut self, ops: &IntOperationIr) -> bool {
+        match ops {
+            IntOperationIr::IntoFloat(desc) => {
+                self.fuse_unary_op(&desc.input, &desc.out, |input, out| {
+                    FuseOp::Assign(UnaryFuseArgs { input, out })
+                })
+            }
+            IntOperationIr::BitwiseAnd(desc) => self.fuse_binary_ops(desc, |lhs, rhs, out| {
+                FuseOp::BitwiseAnd(BinaryFuseArgs { lhs, rhs, out })
+            }),
+            IntOperationIr::BitwiseAndScalar(desc) => self
+                .fuse_scalar_ops(desc, |lhs, rhs, out| {
+                    FuseOp::BitwiseAnd(BinaryFuseArgs { lhs, rhs, out })
+                }),
+            IntOperationIr::BitwiseOr(desc) => self.fuse_binary_ops(desc, |lhs, rhs, out| {
+                FuseOp::BitwiseOr(BinaryFuseArgs { lhs, rhs, out })
+            }),
+            IntOperationIr::BitwiseOrScalar(desc) => self.fuse_scalar_ops(desc, |lhs, rhs, out| {
+                FuseOp::BitwiseOr(BinaryFuseArgs { lhs, rhs, out })
+            }),
+            IntOperationIr::BitwiseXor(desc) => self.fuse_binary_ops(desc, |lhs, rhs, out| {
+                FuseOp::BitwiseXor(BinaryFuseArgs { lhs, rhs, out })
+            }),
+            IntOperationIr::BitwiseXorScalar(desc) => self
+                .fuse_scalar_ops(desc, |lhs, rhs, out| {
+                    FuseOp::BitwiseXor(BinaryFuseArgs { lhs, rhs, out })
+                }),
+            IntOperationIr::BitwiseNot(desc) => self.fuse_unary_ops(desc, |input, out| {
+                FuseOp::BitwiseNot(UnaryFuseArgs { input, out })
+            }),
+            IntOperationIr::BitwiseLeftShift(desc) => self
+                .fuse_binary_ops(desc, |lhs, rhs, out| {
+                    FuseOp::BitwiseLeftShift(BinaryFuseArgs { lhs, rhs, out })
+                }),
+            IntOperationIr::BitwiseLeftShiftScalar(desc) => self
+                .fuse_scalar_ops(desc, |lhs, rhs, out| {
+                    FuseOp::BitwiseLeftShift(BinaryFuseArgs { lhs, rhs, out })
+                }),
+            IntOperationIr::BitwiseRightShift(desc) => self
+                .fuse_binary_ops(desc, |lhs, rhs, out| {
+                    FuseOp::BitwiseRightShift(BinaryFuseArgs { lhs, rhs, out })
+                }),
+            IntOperationIr::BitwiseRightShiftScalar(desc) => self
+                .fuse_scalar_ops(desc, |lhs, rhs, out| {
+                    FuseOp::BitwiseRightShift(BinaryFuseArgs { lhs, rhs, out })
+                }),
             _ => false,
         }
     }

--- a/crates/burn-fusion/src/inspect.rs
+++ b/crates/burn-fusion/src/inspect.rs
@@ -330,7 +330,7 @@ pub(crate) fn emit_handle_snapshot(stream_id: StreamId, ids: impl IntoIterator<I
 pub mod matchers {
     use super::OpMatcher;
     use burn_backend::DType;
-    use burn_ir::{FloatOperationIr, NumericOperationIr, OperationIr};
+    use burn_ir::{FloatOperationIr, IntOperationIr, NumericOperationIr, OperationIr};
 
     /// Matches a float add (`a + b`) on the given dtype.
     pub fn is_add_float(dtype: DType) -> OpMatcher {
@@ -350,6 +350,86 @@ pub mod matchers {
                 OperationIr::NumericFloat(d, NumericOperationIr::Mul(_)) if *d == dtype
             )
         })
+    }
+
+    /// Matches a float multiply by scalar on the given dtype.
+    pub fn is_mul_scalar_float(dtype: DType) -> OpMatcher {
+        Box::new(move |op| {
+            matches!(
+                op,
+                OperationIr::NumericFloat(d, NumericOperationIr::MulScalar(_)) if *d == dtype
+            )
+        })
+    }
+
+    /// Matches an int bitwise and.
+    pub fn is_bitwise_and_int() -> OpMatcher {
+        Box::new(|op| matches!(op, OperationIr::Int(IntOperationIr::BitwiseAnd(_))))
+    }
+
+    /// Matches an int bitwise and by scalar.
+    pub fn is_bitwise_and_scalar_int() -> OpMatcher {
+        Box::new(|op| matches!(op, OperationIr::Int(IntOperationIr::BitwiseAndScalar(_))))
+    }
+
+    /// Matches an int bitwise or.
+    pub fn is_bitwise_or_int() -> OpMatcher {
+        Box::new(|op| matches!(op, OperationIr::Int(IntOperationIr::BitwiseOr(_))))
+    }
+
+    /// Matches an int bitwise or by scalar.
+    pub fn is_bitwise_or_scalar_int() -> OpMatcher {
+        Box::new(|op| matches!(op, OperationIr::Int(IntOperationIr::BitwiseOrScalar(_))))
+    }
+
+    /// Matches an int bitwise xor.
+    pub fn is_bitwise_xor_int() -> OpMatcher {
+        Box::new(|op| matches!(op, OperationIr::Int(IntOperationIr::BitwiseXor(_))))
+    }
+
+    /// Matches an int bitwise xor by scalar.
+    pub fn is_bitwise_xor_scalar_int() -> OpMatcher {
+        Box::new(|op| matches!(op, OperationIr::Int(IntOperationIr::BitwiseXorScalar(_))))
+    }
+
+    /// Matches an int bitwise not.
+    pub fn is_bitwise_not_int() -> OpMatcher {
+        Box::new(|op| matches!(op, OperationIr::Int(IntOperationIr::BitwiseNot(_))))
+    }
+
+    /// Matches an int bitwise left shift.
+    pub fn is_bitwise_left_shift_int() -> OpMatcher {
+        Box::new(|op| matches!(op, OperationIr::Int(IntOperationIr::BitwiseLeftShift(_))))
+    }
+
+    /// Matches an int bitwise left shift by scalar.
+    pub fn is_bitwise_left_shift_scalar_int() -> OpMatcher {
+        Box::new(|op| {
+            matches!(
+                op,
+                OperationIr::Int(IntOperationIr::BitwiseLeftShiftScalar(_))
+            )
+        })
+    }
+
+    /// Matches an int bitwise right shift.
+    pub fn is_bitwise_right_shift_int() -> OpMatcher {
+        Box::new(|op| matches!(op, OperationIr::Int(IntOperationIr::BitwiseRightShift(_))))
+    }
+
+    /// Matches an int bitwise right shift by scalar.
+    pub fn is_bitwise_right_shift_scalar_int() -> OpMatcher {
+        Box::new(|op| {
+            matches!(
+                op,
+                OperationIr::Int(IntOperationIr::BitwiseRightShiftScalar(_))
+            )
+        })
+    }
+
+    /// Matches an int-to-float cast.
+    pub fn is_int_into_float() -> OpMatcher {
+        Box::new(|op| matches!(op, OperationIr::Int(IntOperationIr::IntoFloat(_))))
     }
 
     /// Matches a float subtraction (`a - b`) on the given dtype.

--- a/crates/burn-fusion/src/stream/context.rs
+++ b/crates/burn-fusion/src/stream/context.rs
@@ -945,7 +945,7 @@ impl RelativeOps for IntOperationIr {
             IntOperationIr::BitwiseAndScalar(desc) => {
                 IntOperationIr::BitwiseAndScalar(ScalarOpIr {
                     lhs: desc.lhs.to_relative(converter),
-                    rhs: desc.rhs,
+                    rhs: desc.rhs.to_relative(converter),
                     out: desc.out.to_relative(converter),
                 })
             }
@@ -956,7 +956,7 @@ impl RelativeOps for IntOperationIr {
             }),
             IntOperationIr::BitwiseOrScalar(desc) => IntOperationIr::BitwiseOrScalar(ScalarOpIr {
                 lhs: desc.lhs.to_relative(converter),
-                rhs: desc.rhs,
+                rhs: desc.rhs.to_relative(converter),
                 out: desc.out.to_relative(converter),
             }),
             IntOperationIr::BitwiseXor(desc) => IntOperationIr::BitwiseXor(BinaryOpIr {
@@ -967,7 +967,7 @@ impl RelativeOps for IntOperationIr {
             IntOperationIr::BitwiseXorScalar(desc) => {
                 IntOperationIr::BitwiseXorScalar(ScalarOpIr {
                     lhs: desc.lhs.to_relative(converter),
-                    rhs: desc.rhs,
+                    rhs: desc.rhs.to_relative(converter),
                     out: desc.out.to_relative(converter),
                 })
             }
@@ -985,7 +985,7 @@ impl RelativeOps for IntOperationIr {
             IntOperationIr::BitwiseLeftShiftScalar(desc) => {
                 IntOperationIr::BitwiseLeftShiftScalar(ScalarOpIr {
                     lhs: desc.lhs.to_relative(converter),
-                    rhs: desc.rhs,
+                    rhs: desc.rhs.to_relative(converter),
                     out: desc.out.to_relative(converter),
                 })
             }
@@ -999,7 +999,7 @@ impl RelativeOps for IntOperationIr {
             IntOperationIr::BitwiseRightShiftScalar(desc) => {
                 IntOperationIr::BitwiseRightShiftScalar(ScalarOpIr {
                     lhs: desc.lhs.to_relative(converter),
-                    rhs: desc.rhs,
+                    rhs: desc.rhs.to_relative(converter),
                     out: desc.out.to_relative(converter),
                 })
             }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR. No book changes are required.

### Related Issues/PRs

Closes #5052

### Changes

Adds CubeCL fusion lowering for integer bitwise operations:

- binary `and`, `or`, and `xor`
- scalar right-hand-side bitwise operands
- left and right shifts
- unary bitwise not

Adds backend regression coverage showing an integer bitwise chain can stay in one `ElementWise` fused block through `IntoFloat` and a downstream float scalar op.

### Testing

- `cargo run-checks`
- `cargo fmt --all -- --check`
- `cargo check -p burn-cubecl-fusion`
- `BURN_FUSION_LOG=full cargo test -p burn-backend-tests --test tensor --no-default-features --features "metal fusion" fusion::int_bitwise -- --nocapture`


#### Fusion evidence from the added test:

```text
fusion trace (7 ops, 1 block)
idx  block                                      op                            inputs                outputs
---  -----------------------------------------  ----------------------------  --------------------  ---------
0    ▸ fused ElementWise (score=1360, 7 ops)    Int::BitwiseXor               t0:i32[4], t1:i32[4]  t2:i32[4]
1                                               Int::BitwiseAndScalar         t2:i32[4]             t3:i32[4]
2                                               Int::BitwiseRightShiftScalar  t3:i32[4]             t4:i32[4]
3                                               Int::BitwiseNot               t0:i32[4]             t5:i32[4]
4                                               Int::BitwiseOr                t4:i32[4], t5:i32[4]  t6:i32[4]
5                                               Int::IntoFloat                t6:i32[4]             t7:f32[4]
6                                               NumericFloat::MulScalar       t7:f32[4]             t8:f32[4]
test fusion::int_bitwise::int_bitwise_chain_and_float_cast_fuse_into_single_kernel ... ok
```


#### Baseline evidence from `origin/main` with the same integer bitwise chain:

```text
[fuser] closed on Int (unsupported op variant); had 0 ops, est_bindings=1/7

fusion trace (1 op, 1 block)
idx  block                op               inputs                outputs
---  -------------------  ---------------  --------------------  ---------
0    ▸ un-fused (1 op)    Int::BitwiseXor  t0:i32[4], t1:i32[4]  t2:i32[4]

fusion trace (1 op, 1 block)
idx  block                op                     inputs     outputs
---  -------------------  ---------------------  ---------  ---------
0    ▸ un-fused (1 op)    Int::BitwiseAndScalar  t2:i32[4]  t3:i32[4]

fusion trace (1 op, 1 block)
idx  block                op                            inputs     outputs
---  -------------------  ----------------------------  ---------  ---------
0    ▸ un-fused (1 op)    Int::BitwiseRightShiftScalar  t3:i32[4]  t4:i32[4]

fusion trace (1 op, 1 block)
idx  block                op               inputs     outputs
---  -------------------  ---------------  ---------  ---------
0    ▸ un-fused (1 op)    Int::BitwiseNot  t0:i32[4]  t5:i32[4]

fusion trace (1 op, 1 block)
idx  block                op              inputs                outputs
---  -------------------  --------------  --------------------  ---------
0    ▸ un-fused (1 op)    Int::BitwiseOr  t4:i32[4], t5:i32[4]  t6:i32[4]

fusion trace (1 op, 1 block)
idx  block                op              inputs     outputs
---  -------------------  --------------  ---------  ---------
0    ▸ un-fused (1 op)    Int::IntoFloat  t6:i32[4]  t7:f32[4]

fusion trace (1 op, 1 block)
idx  block                op                       inputs     outputs
---  -------------------  -----------------------  ---------  ---------
0    ▸ un-fused (1 op)    NumericFloat::MulScalar  t7:f32[4]  t8:f32[4]

test fusion::int_bitwise_probe::int_bitwise_chain_probe ... FAILED
```


#### Run-checks output excerpt:

```text
$ cargo run-checks
...
test result: ok. 1576 passed; 0 failed; 19 ignored; 0 measured; 0 filtered out; finished in 1.39s
...
test result: ok. 1174 passed; 0 failed; 15 ignored; 0 measured; 0 filtered out; finished in 0.57s
...
Generated /Users/orlando/.cargo-target/doc/burn/index.html and 60 other files
...
Doc Tests: wgan

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

Time elapsed for the current execution: 00:13:04
```

