### PR TITLE
Add Identity Module, extend Activation and Normalization.

### DIFF
--- a/crates/burn-nn/src/activation/activation_wrapper.rs
+++ b/crates/burn-nn/src/activation/activation_wrapper.rs
@@ -1,5 +1,6 @@
 use burn_core as burn;
 
+use crate::Identity;
 use crate::activation::{
     Celu, CeluConfig, Elu, EluConfig, Gelu, HardShrink, HardShrinkConfig, HardSigmoid,
     HardSigmoidConfig, HardSwish, LeakyRelu, LeakyReluConfig, PRelu, PReluConfig, Relu, Selu,
@@ -15,6 +16,9 @@ use burn::tensor::Tensor;
 #[derive(Config, Debug)]
 #[non_exhaustive]
 pub enum ActivationConfig {
+    /// Identity activation layer.
+    Identity,
+
     /// [`Gelu`] activation layer.
     Gelu,
 
@@ -143,6 +147,7 @@ impl ActivationConfig {
     /// Initialize a wrapped activation layer.
     pub fn init(&self, device: &Device) -> Activation {
         match self {
+            ActivationConfig::Identity => Activation::Identity(Identity::new()),
             ActivationConfig::Relu => Relu.into(),
             ActivationConfig::LeakyRelu(conf) => conf.init().into(),
             ActivationConfig::Gelu => Gelu::new().into(),
@@ -173,6 +178,9 @@ impl ActivationConfig {
 #[non_exhaustive]
 #[allow(clippy::large_enum_variant)]
 pub enum Activation {
+    /// Identity activation layer.
+    Identity(Identity),
+
     /// [`Gelu`] activation layer.
     Gelu(Gelu),
 
@@ -226,6 +234,12 @@ pub enum Activation {
 
     /// [`Shrink`] activation layer.
     Shrink(Shrink),
+}
+
+impl From<Identity> for Activation {
+    fn from(layer: Identity) -> Self {
+        Self::Identity(layer)
+    }
 }
 
 impl From<Gelu> for Activation {
@@ -340,6 +354,7 @@ impl Activation {
     /// Forward pass.
     pub fn forward<const D: usize>(&self, input: Tensor<D>) -> Tensor<D> {
         match self {
+            Activation::Identity(layer) => layer.forward(input),
             Activation::Relu(layer) => layer.forward(input),
             Activation::LeakyRelu(layer) => layer.forward(input),
             Activation::Gelu(layer) => layer.forward(input),
@@ -384,6 +399,16 @@ mod tests {
         let act = config.init(device);
         let output = act.forward(input);
         expect_tensor(output, expected);
+    }
+
+    #[test]
+    fn test_identity() {
+        let device = Default::default();
+        let input = make_input(&device);
+
+        let expected = input.clone();
+
+        check_stateless_config_output(ActivationConfig::Identity, input, expected, &device)
     }
 
     #[test]

--- a/crates/burn-nn/src/lib.rs
+++ b/crates/burn-nn/src/lib.rs
@@ -20,6 +20,7 @@ pub use activation::{
 };
 
 mod padding;
+
 pub use padding::*;
 
 // For backward compat, `burn::nn::Initializer`

--- a/crates/burn-nn/src/modules/identity.rs
+++ b/crates/burn-nn/src/modules/identity.rs
@@ -1,0 +1,32 @@
+use burn_core as burn;
+
+use burn::Tensor;
+use burn::module::Module;
+
+/// Identity Module.
+#[derive(Module, Default, Debug)]
+pub struct Identity;
+
+impl Identity {
+    /// Create the module.
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    /// Forward pass, returns the input tensor.
+    pub fn forward<const R: usize>(&self, input: Tensor<R>) -> Tensor<R> {
+        input
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display() {
+        let layer = Identity::new();
+
+        assert_eq!(alloc::format!("{layer}"), "Identity");
+    }
+}

--- a/crates/burn-nn/src/modules/mod.rs
+++ b/crates/burn-nn/src/modules/mod.rs
@@ -13,6 +13,7 @@ pub mod pool;
 /// Transformer module
 pub mod transformer;
 
+mod identity;
 /// Interpolate module
 pub mod interpolate;
 
@@ -26,10 +27,12 @@ mod rope_encoding;
 mod unfold;
 
 pub mod norm;
+
 pub use norm::{batch::*, group::*, instance::*, layer::*, local_response::*, rms::*};
 
 pub use dropout::*;
 pub use embedding::*;
+pub use identity::*;
 pub use linear::*;
 pub use noise::*;
 pub use pos_encoding::*;

--- a/crates/burn-nn/src/modules/norm/normalization_wrapper.rs
+++ b/crates/burn-nn/src/modules/norm/normalization_wrapper.rs
@@ -1,8 +1,8 @@
 use burn_core as burn;
 
 use crate::{
-    BatchNorm, BatchNormConfig, GroupNorm, GroupNormConfig, InstanceNorm, InstanceNormConfig,
-    LayerNorm, LayerNormConfig, RmsNorm, RmsNormConfig,
+    BatchNorm, BatchNormConfig, GroupNorm, GroupNormConfig, Identity, InstanceNorm,
+    InstanceNormConfig, LayerNorm, LayerNormConfig, RmsNorm, RmsNormConfig,
 };
 use burn::prelude::{Config, Module};
 use burn::tensor::Device;
@@ -19,6 +19,9 @@ use burn::tensor::Tensor;
 #[derive(Config, Debug)]
 #[non_exhaustive]
 pub enum NormalizationConfig {
+    /// ['Identity'] Configuration.
+    Identity,
+
     /// ['BatchNorm'] Configuration.
     Batch(BatchNormConfig),
 
@@ -69,6 +72,7 @@ impl NormalizationConfig {
     /// Initialize a ['Norm'] layer.
     pub fn init(&self, device: &Device) -> Normalization {
         match self {
+            NormalizationConfig::Identity => Identity::new().into(),
             NormalizationConfig::Batch(config) => config.init(device).into(),
             NormalizationConfig::Group(config) => config.init(device).into(),
             NormalizationConfig::Instance(config) => config.init(device).into(),
@@ -80,6 +84,7 @@ impl NormalizationConfig {
     /// Set the number of features.
     pub fn with_num_features(self, num_features: usize) -> Self {
         match self {
+            NormalizationConfig::Identity => self,
             NormalizationConfig::Batch(config) => BatchNormConfig {
                 num_features,
                 ..config
@@ -111,6 +116,7 @@ impl NormalizationConfig {
     /// Get the number of features.
     pub fn num_features(&self) -> usize {
         match self {
+            NormalizationConfig::Identity => 0,
             NormalizationConfig::Batch(config) => config.num_features,
             NormalizationConfig::Group(config) => config.num_channels,
             NormalizationConfig::Instance(config) => config.num_channels,
@@ -133,6 +139,9 @@ impl NormalizationConfig {
 #[derive(Module, Debug)]
 #[non_exhaustive]
 pub enum Normalization {
+    /// ['Identity'] layer.
+    Identity(Identity),
+
     /// [`BatchNorm`] layer.
     Batch(BatchNorm),
 
@@ -147,6 +156,12 @@ pub enum Normalization {
 
     /// ['RmsNorm'] layer.
     Rms(RmsNorm),
+}
+
+impl From<Identity> for Normalization {
+    fn from(layer: Identity) -> Self {
+        Self::Identity(layer)
+    }
 }
 
 impl From<BatchNorm> for Normalization {
@@ -187,6 +202,7 @@ impl Normalization {
     /// and produce an output of the same rank and shape.
     pub fn forward<const D: usize>(&self, input: Tensor<D>) -> Tensor<D> {
         match self {
+            Normalization::Identity(norm) => norm.forward(input),
             Normalization::Batch(norm) => norm.forward(input),
             Normalization::Group(norm) => norm.forward(input),
             Normalization::Instance(norm) => norm.forward(input),
@@ -198,6 +214,7 @@ impl Normalization {
     /// Get the number of features.
     pub fn num_features(&self) -> usize {
         match self {
+            Normalization::Identity(_) => 0,
             Normalization::Batch(norm) => norm.gamma.shape()[0],
             Normalization::Group(norm) => norm.num_channels,
             Normalization::Instance(norm) => norm.num_channels,
@@ -240,6 +257,24 @@ mod tests {
         assert_eq!(config.num_features(), 0);
         let config = config.with_num_features(12);
         assert_eq!(config.num_features(), 12);
+    }
+
+    #[test]
+    fn test_identity_norm() {
+        let device = Device::default().autodiff();
+
+        let num_features = 12;
+        let input: Tensor<4> = Tensor::ones([2, num_features, 3, 4], &device);
+
+        let config: NormalizationConfig = NormalizationConfig::Identity;
+
+        let layer = config.init(&device);
+        assert_eq!(layer.num_features(), 0);
+
+        let expected = input.clone();
+        let output = layer.forward(input);
+
+        output.to_data().assert_eq(&expected.to_data(), true);
     }
 
     #[test]


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Being able to model layers as "do nothing" in reusable blocks is pretty standard. This adds a basic `Identity` module, and support in the `Activation` and `Normalization` wrappers.
