### PR TITLE
fix: fix inconsistent assertions

### DIFF
--- a/crates/burn-core/src/module/initializer.rs
+++ b/crates/burn-core/src/module/initializer.rs
@@ -350,11 +350,11 @@ mod tests {
         let mean_act: f32 = mean_act.into_scalar();
 
         assert!(
-            var_act > 0.9 && var_act < 1.1,
+            var_act >= 0.9 && var_act <= 1.1,
             "Expected variance to be between 1.0 += 0.1, but got {var_act}"
         );
         assert!(
-            mean_act > -0.1 && mean_act < 0.1,
+            mean_act >= -0.1 && mean_act <= 0.1,
             "Expected mean to be between 0.0 += 0.1, but got {mean_act}"
         );
     }

--- a/crates/burn-fusion/src/stream/store/index.rs
+++ b/crates/burn-fusion/src/stream/store/index.rs
@@ -202,7 +202,7 @@ mod tests {
             stream_1_key, stream_2_key,
             "Ops 1 and Ops 3 should not have the same hash"
         ); // ops 1 and 3 have different variants, so the hash differs
-        assert_ne!(stream_1[0], stream_2[0], "Ops 1 and Ops 3 are different.");
+        assert_ne!(stream_1[0], stream_2[0], "Ops 1 and Ops 3 should be different.");
 
         index.insert(InsertQuery::NewPlan {
             operations: &stream_1,

--- a/crates/burn-fusion/src/stream/store/index.rs
+++ b/crates/burn-fusion/src/stream/store/index.rs
@@ -202,7 +202,10 @@ mod tests {
             stream_1_key, stream_2_key,
             "Ops 1 and Ops 3 should not have the same hash"
         ); // ops 1 and 3 have different variants, so the hash differs
-        assert_ne!(stream_1[0], stream_2[0], "Ops 1 and Ops 3 should be different.");
+        assert_ne!(
+            stream_1[0], stream_2[0],
+            "Ops 1 and Ops 3 should be different."
+        );
 
         index.insert(InsertQuery::NewPlan {
             operations: &stream_1,

--- a/crates/burn-nn/src/modules/pos_encoding.rs
+++ b/crates/burn-nn/src/modules/pos_encoding.rs
@@ -146,7 +146,7 @@ pub fn generate_sinusoids(
     assert!(d_model.is_multiple_of(2), "d_model must be even");
     assert!(
         max_timescale >= length,
-        "max_timescale must be greater than length"
+        "max_timescale must be greater than or equal to length"
     );
 
     // Calculate the increment for the logarithmic timescale


### PR DESCRIPTION
## Pull Request Template

For `assert!(max_timescale >= length,"max_timescale must be greater than length");`, message means max_timescale > length, which should be changed.

For `assert_ne!(stream_1[0], stream_2[0], "Ops 1 and Ops 3 are different.");`, message may cause confusion as it appears when assertion failed, which may implies stream_1[0] != stream_2[0](are different) is the reason of failure, so it needs to be changed into "should be different".

For `assert!(var_act > 0.9 && var_act < 1.1,"Expected variance to be between 1.0 += 0.1, but got {var_act}");` and `assert!(mean_act > -0.1 && mean_act < 0.1,"Expected mean to be between 0.0 += 0.1, but got {mean_act}");` message use "between ... and" which usually means closed interval while predicate use open interval. What's more, in function above, 2 assertion `assert!((expected_var - actual_var).abs() <= 0.1,"Expected variance to be between {expected_var} += 0.1, but got {actual_var}");` and `assert!((expected_mean - actual_mean).abs() <= 0.1,"Expected mean to be between {expected_mean} += 0.1, but got {actual_mean}");` has similar messages and use .abs() <=,  so these 2 assertion should be changed to use <= and >= to be consistent.