### PR TITLE
hypot function

### DIFF
--- a/crates/burn-autodiff/src/ops/tensor.rs
+++ b/crates/burn-autodiff/src/ops/tensor.rs
@@ -3537,6 +3537,63 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
         }
     }
 
+    fn float_hypot(lhs: FloatTensor<Self>, rhs: FloatTensor<Self>) -> FloatTensor<Self> {
+        #[derive(Debug)]
+        struct Hypot;
+
+        impl<B: Backend> Backward<B, 2> for Hypot {
+            type State = (NodeId, NodeId, BinaryOpsBroadcast);
+
+            fn backward(
+                self,
+                ops: Ops<Self::State, 2>,
+                grads: &mut Gradients,
+                checkpointer: &mut Checkpointer,
+            ) {
+                let (lhs_id, rhs_id, broadcast) = ops.state;
+                let lhs: B::FloatTensorPrimitive = checkpointer.retrieve_node_output(lhs_id);
+                let rhs: B::FloatTensorPrimitive = checkpointer.retrieve_node_output(rhs_id);
+
+                let [lhs_4lhs, lhs_4rhs] = duplicate(&ops.parents, Some(lhs.clone()));
+                let [rhs_4lhs, rhs_4rhs] = duplicate(&ops.parents, Some(rhs.clone()));
+
+                binary::<B, _, _>(
+                    ops.parents,
+                    ops.node,
+                    grads,
+                    |grad| {
+                        // lhs / hypot(lhs, rhs) * grad
+                        let value =
+                            B::float_div(lhs, B::float_hypot(lhs_4lhs.unwrap(), rhs_4lhs.unwrap()));
+                        broadcast.backward_lhs::<B>(B::float_mul(grad, value))
+                    },
+                    |grad| {
+                        // rhs / hypot(lhs, rhs) * grad
+                        let value =
+                            B::float_div(rhs, B::float_hypot(lhs_4rhs.unwrap(), rhs_4rhs.unwrap()));
+                        broadcast.backward_rhs::<B>(B::float_mul(grad, value))
+                    },
+                );
+            }
+        }
+        let broadcast = BinaryOpsBroadcast::new::<B>(&lhs.primitive, &rhs.primitive);
+        match Hypot
+            .prepare::<C>([lhs.node.clone(), rhs.node.clone()])
+            .compute_bound()
+            .stateful()
+        {
+            OpsKind::Tracked(mut prep) => {
+                let lhs_state = prep.checkpoint(&lhs);
+                let rhs_state = prep.checkpoint(&rhs);
+                prep.finish(
+                    (lhs_state, rhs_state, broadcast),
+                    B::float_hypot(lhs.primitive, rhs.primitive),
+                )
+            }
+            OpsKind::UnTracked(prep) => prep.finish(B::float_hypot(lhs.primitive, rhs.primitive)),
+        }
+    }
+
     fn float_sign(tensor: FloatTensor<Self>) -> FloatTensor<Self> {
         #[derive(Debug)]
         struct Sign;

--- a/crates/burn-backend-tests/tests/autodiff/hypot.rs
+++ b/crates/burn-backend-tests/tests/autodiff/hypot.rs
@@ -1,0 +1,27 @@
+use super::*;
+use burn_tensor::{TensorData, Tolerance};
+
+#[test]
+fn should_diff_hypot() {
+    let data_a = TensorData::from([[3.0, 4.0], [5.0, 12.0]]);
+    let data_b = TensorData::from([[4.0, 3.0], [12.0, 5.0]]);
+
+    let device = AutodiffDevice::new();
+    let tensor_a = TestTensor::<2>::from_data(data_a, &device).require_grad();
+    let tensor_b = TestTensor::<2>::from_data(data_b, &device).require_grad();
+
+    let tensor_c = tensor_a.clone().hypot(tensor_b.clone());
+    let grads = tensor_c.backward();
+
+    let grad_a = tensor_a.grad(&grads).unwrap();
+    let grad_b = tensor_b.grad(&grads).unwrap();
+
+    grad_a.to_data().assert_approx_eq::<FloatElem>(
+        &TensorData::from([[0.6, 0.8], [0.3846, 0.9231]]),
+        Tolerance::default(),
+    );
+    grad_b.to_data().assert_approx_eq::<FloatElem>(
+        &TensorData::from([[0.8, 0.6], [0.9231, 0.3846]]),
+        Tolerance::default(),
+    );
+}

--- a/crates/burn-backend-tests/tests/autodiff/mod.rs
+++ b/crates/burn-backend-tests/tests/autodiff/mod.rs
@@ -42,6 +42,7 @@ mod gather_scatter;
 mod gather_scatter_nd;
 mod gelu;
 mod gradients;
+mod hypot;
 mod log;
 mod log1p;
 mod log_sigmoid;

--- a/crates/burn-backend-tests/tests/tensor/float/ops/hypot.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/hypot.rs
@@ -24,7 +24,7 @@ fn should_support_hypot_broadcast() {
     let tensor_b = TestTensor::<2>::from_data(data_b, &Default::default());
 
     let result = tensor_a.hypot(tensor_b);
-    let expected = TensorData::from([[5.0, 5.0, 6.404], [3.606, 5.0, 5.831]]);
+    let expected = TensorData::from([[5.0, 5.656854, 6.404], [4.2426405, 5.0, 5.831]]);
 
     result
         .into_data()

--- a/crates/burn-backend-tests/tests/tensor/float/ops/hypot.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/hypot.rs
@@ -1,0 +1,47 @@
+use super::*;
+use burn_tensor::{DType, TensorData, Tolerance};
+
+#[test]
+fn should_support_hypot_basic() {
+    let data_a = TensorData::from([[3.0, 4.0], [5.0, 12.0]]);
+    let data_b = TensorData::from([[4.0, 3.0], [12.0, 5.0]]);
+    let tensor_a = TestTensor::<2>::from_data(data_a, &Default::default());
+    let tensor_b = TestTensor::<2>::from_data(data_b, &Default::default());
+
+    let result = tensor_a.hypot(tensor_b);
+    let expected = TensorData::from([[5.0, 5.0], [13.0, 13.0]]);
+
+    result
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
+}
+
+#[test]
+fn should_support_hypot_broadcast() {
+    let data_a = TensorData::from([[3.0, 4.0, 5.0]]);
+    let data_b = TensorData::from([[4.0], [3.0]]);
+    let tensor_a = TestTensor::<2>::from_data(data_a, &Default::default());
+    let tensor_b = TestTensor::<2>::from_data(data_b, &Default::default());
+
+    let result = tensor_a.hypot(tensor_b);
+    let expected = TensorData::from([[5.0, 5.0, 6.404], [3.606, 5.0, 5.831]]);
+
+    result
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
+}
+
+#[test]
+fn should_support_hypot_zero() {
+    let data_a = TensorData::from([[0.0, 3.0], [0.0, 0.0]]);
+    let data_b = TensorData::from([[4.0, 0.0], [0.0, 5.0]]);
+    let tensor_a = TestTensor::<2>::from_data(data_a, &Default::default());
+    let tensor_b = TestTensor::<2>::from_data(data_b, &Default::default());
+
+    let result = tensor_a.hypot(tensor_b);
+    let expected = TensorData::from([[4.0, 3.0], [0.0, 5.0]]);
+
+    result
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
+}

--- a/crates/burn-backend-tests/tests/tensor/float/ops/mod.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/mod.rs
@@ -34,6 +34,7 @@ mod gather_scatter_nd;
 mod grid_sample;
 mod hamming_window;
 mod hann_window;
+mod hypot;
 mod inf;
 mod init;
 mod iter_dim;

--- a/crates/burn-backend/src/backend/ops/tensor.rs
+++ b/crates/burn-backend/src/backend/ops/tensor.rs
@@ -1128,7 +1128,7 @@ pub trait FloatTensorOps<B: Backend> {
     /// A tensor with the same shape as `tensor` with square root values.
     fn float_sqrt(tensor: FloatTensor<B>) -> FloatTensor<B>;
 
-    /// Returns a new tensor with square root values.
+    /// Returns a new tensor with the Euclidean distance values.
     ///
     /// # Arguments
     ///
@@ -1151,27 +1151,24 @@ pub trait FloatTensorOps<B: Backend> {
         //   - If max == 0, both inputs are 0, result is 0 (division guarded by clamp)
         //   - If max is inf, result is inf (propagates naturally through sqrt)
         //   - NaN propagates naturally
-        let shape = lhs.shape();
-        let device = B::float_device(&lhs);
-        let dtype = lhs.dtype();
         let abs_lhs = B::float_abs(lhs);
         let abs_rhs = B::float_abs(rhs);
 
-        let diff = B::float_sub(abs_rhs.clone(), abs_lhs.clone());
-        let max = B::float_add(
-            abs_lhs.clone(),
-            B::float_clamp_min(diff.clone(), 0.0.into()),
-        );
-        let min = B::float_sub(abs_lhs, B::float_clamp_min(diff, 0.0.into()));
+        let diff = B::float_clamp_min(B::float_sub(abs_rhs.clone(), abs_lhs.clone()), 0.0.into());
+        let max = B::float_add(abs_lhs.clone(), diff.clone());
+        let min = B::float_sub(abs_rhs, diff);
 
         // Clamp max to at least epsilon to avoid 0/0; result will be 0 anyway
         // since min <= max, so (min/clamped_max)^2 won't blow up meaningfully.
-        let max_safe = B::float_clamp_min(max.clone(), 1e-38.into());
+        let max_safe = B::float_clamp_min(
+            max.clone(),
+            max.dtype().finfo().unwrap().min_positive.into(),
+        );
 
         let ratio = B::float_div(min, max_safe);
         let ratio_sq = B::float_mul(ratio.clone(), ratio);
 
-        let inner = B::float_add(B::float_ones(shape, &device, dtype.into()), ratio_sq);
+        let inner = B::float_add_scalar(ratio_sq, 1.0.into());
 
         B::float_mul(max, B::float_sqrt(inner))
     }

--- a/crates/burn-backend/src/backend/ops/tensor.rs
+++ b/crates/burn-backend/src/backend/ops/tensor.rs
@@ -1128,6 +1128,54 @@ pub trait FloatTensorOps<B: Backend> {
     /// A tensor with the same shape as `tensor` with square root values.
     fn float_sqrt(tensor: FloatTensor<B>) -> FloatTensor<B>;
 
+    /// Returns a new tensor with square root values.
+    ///
+    /// # Arguments
+    ///
+    /// * `lhs` - The left-hand side tensor.
+    /// * `rhs` - The right-hand side tensor.
+    ///
+    /// # Returns
+    ///
+    /// A tensor with the same shape as `lhs` and `rhs` with hypotenuse values.
+    fn float_hypot(lhs: FloatTensor<B>, rhs: FloatTensor<B>) -> FloatTensor<B> {
+        // default implementation for any backend that can't either iterator over elements or doesn't have
+        // a native hypot implementation
+
+        // Mirrors glibc's approach: scale by max(|lhs|, |rhs|) to avoid
+        // overflow/underflow in the intermediate squaring step.
+        //
+        // hypot(x, y) = |max| * sqrt(1 + (min/max)^2)
+        //
+        // Edge cases:
+        //   - If max == 0, both inputs are 0, result is 0 (division guarded by clamp)
+        //   - If max is inf, result is inf (propagates naturally through sqrt)
+        //   - NaN propagates naturally
+        let shape = lhs.shape();
+        let device = B::float_device(&lhs);
+        let dtype = lhs.dtype();
+        let abs_lhs = B::float_abs(lhs);
+        let abs_rhs = B::float_abs(rhs);
+
+        let diff = B::float_sub(abs_rhs.clone(), abs_lhs.clone());
+        let max = B::float_add(
+            abs_lhs.clone(),
+            B::float_clamp_min(diff.clone(), 0.0.into()),
+        );
+        let min = B::float_sub(abs_lhs, B::float_clamp_min(diff, 0.0.into()));
+
+        // Clamp max to at least epsilon to avoid 0/0; result will be 0 anyway
+        // since min <= max, so (min/clamped_max)^2 won't blow up meaningfully.
+        let max_safe = B::float_clamp_min(max.clone(), 1e-38.into());
+
+        let ratio = B::float_div(min, max_safe);
+        let ratio_sq = B::float_mul(ratio.clone(), ratio);
+
+        let inner = B::float_add(B::float_ones(shape, &device, dtype.into()), ratio_sq);
+
+        B::float_mul(max, B::float_sqrt(inner))
+    }
+
     /// Returns a new tensor with absolute values.
     ///
     /// # Arguments

--- a/crates/burn-dispatch/src/ops/tensor.rs
+++ b/crates/burn-dispatch/src/ops/tensor.rs
@@ -685,4 +685,8 @@ impl FloatTensorOps<Self> for Dispatch {
     fn float_is_inf(tensor: FloatTensor<Self>, out_dtype: BoolDType) -> BoolTensor<Self> {
         unary_float!(tensor, float, |tensor| B::float_is_inf(tensor, out_dtype) => Bool)
     }
+
+    fn float_hypot(lhs: FloatTensor<Self>, rhs: FloatTensor<Self>) -> FloatTensor<Self> {
+        binary_float!((lhs, float), (rhs, float), |lhs, rhs| B::float_hypot(lhs, rhs) => Float)
+    }
 }

--- a/crates/burn-flex/src/ops/float.rs
+++ b/crates/burn-flex/src/ops/float.rs
@@ -1085,6 +1085,16 @@ impl FloatTensorOps<Flex> for Flex {
             |x: f64| x.is_infinite(),
         )
     }
+
+    fn float_hypot(lhs: FloatTensor<Flex>, rhs: FloatTensor<Flex>) -> FloatTensor<Flex> {
+        binary_op(
+            lhs,
+            rhs,
+            |a: f32, b| a.hypot(b),
+            |a: f64, b| a.hypot(b),
+            None,
+        )
+    }
 }
 
 // Tests kept here exercise flex-specific behavior: direct `Flex::`

--- a/crates/burn-fusion/src/ops/tensor.rs
+++ b/crates/burn-fusion/src/ops/tensor.rs
@@ -2574,4 +2574,23 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
             )
             .output()
     }
+
+    fn float_hypot(lhs: FloatTensor<Self>, rhs: FloatTensor<Self>) -> FloatTensor<Self> {
+        binary_float_ops!(HypotOps, B::float_hypot);
+
+        let streams = StreamId::current();
+
+        let client = lhs.client.clone();
+        let desc = BinaryOpIr::create(lhs.into_ir(), rhs.into_ir(), || {
+            client.create_empty_handle()
+        });
+
+        client
+            .register(
+                streams,
+                OperationIr::Float(desc.out.dtype, FloatOperationIr::Hypot(desc.clone())),
+                HypotOps::<B>::new(desc),
+            )
+            .output()
+    }
 }

--- a/crates/burn-fusion/src/stream/context.rs
+++ b/crates/burn-fusion/src/stream/context.rs
@@ -670,6 +670,11 @@ impl RelativeOps for FloatOperationIr {
                 rhs: desc.rhs.to_relative(converter),
                 out: desc.out.to_relative(converter),
             }),
+            FloatOperationIr::Hypot(desc) => FloatOperationIr::Hypot(BinaryOpIr {
+                lhs: desc.lhs.to_relative(converter),
+                rhs: desc.rhs.to_relative(converter),
+                out: desc.out.to_relative(converter),
+            }),
             FloatOperationIr::PowfScalar(desc) => FloatOperationIr::PowfScalar(ScalarOpIr {
                 lhs: desc.lhs.to_relative(converter),
                 rhs: desc.rhs.to_relative(converter),

--- a/crates/burn-ir/src/operation.rs
+++ b/crates/burn-ir/src/operation.rs
@@ -168,6 +168,8 @@ pub enum FloatOperationIr {
     GridSample2d(GridSample2dOpIr),
     /// Operation corresponding to [powf](burn_backend::ops::FloatTensorOps::float_powi).
     Powf(BinaryOpIr),
+    /// Operation corresponding to [hypot](burn_backend::ops::FloatTensorOps::float_hypot).
+    Hypot(BinaryOpIr),
 }
 
 /// Operation intermediate representation specific to module.
@@ -2637,6 +2639,7 @@ impl FloatOperationIr {
             FloatOperationIr::ArcTanh(repr) => Box::new([&repr.input].into_iter()),
             FloatOperationIr::ArcTan2(repr) => Box::new([&repr.lhs, &repr.rhs].into_iter()),
             FloatOperationIr::Powf(repr) => Box::new([&repr.lhs, &repr.rhs].into_iter()),
+            FloatOperationIr::Hypot(repr) => Box::new([&repr.lhs, &repr.rhs].into_iter()),
         }
     }
     fn outputs(&self) -> Box<dyn Iterator<Item = &TensorIr> + '_> {
@@ -2675,6 +2678,7 @@ impl FloatOperationIr {
             FloatOperationIr::ArcTanh(repr) => Box::new([&repr.out].into_iter()),
             FloatOperationIr::ArcTan2(repr) => Box::new([&repr.out].into_iter()),
             FloatOperationIr::Powf(repr) => Box::new([&repr.out].into_iter()),
+            FloatOperationIr::Hypot(repr) => Box::new([&repr.out].into_iter()),
         }
     }
 
@@ -2767,6 +2771,10 @@ impl FloatOperationIr {
                 repr.rhs.mark_read_only(nodes, &mut output);
             }
             FloatOperationIr::Powf(repr) => {
+                repr.lhs.mark_read_only(nodes, &mut output);
+                repr.rhs.mark_read_only(nodes, &mut output);
+            }
+            FloatOperationIr::Hypot(repr) => {
                 repr.lhs.mark_read_only(nodes, &mut output);
                 repr.rhs.mark_read_only(nodes, &mut output);
             }

--- a/crates/burn-ndarray/src/ops/base.rs
+++ b/crates/burn-ndarray/src/ops/base.rs
@@ -4,6 +4,7 @@ use burn_backend::element::{Element, ElementConversion};
 use burn_backend::{DType, quantization::QuantValue};
 use core::fmt::Debug;
 use core::marker::PhantomData;
+use ndarray::Dimension;
 use ndarray::IntoDimension;
 use ndarray::SliceInfo;
 use ndarray::Zip;
@@ -954,15 +955,67 @@ where
         output_array.into_shared()
     }
 
+    fn broadcast_dims<D>(lhs: D::Pattern, rhs: D::Pattern) -> Option<D::Pattern>
+    where
+        D: Dimension + IntoDimension<Dim = D>,
+    {
+        if lhs == rhs {
+            Some(lhs)
+        } else {
+            let lhs = lhs.into_dimension();
+            let rhs = rhs.into_dimension();
+            let lhs = lhs.slice();
+            let rhs = rhs.slice();
+
+            let total_dims = core::cmp::max(lhs.len(), rhs.len());
+            let mut target_shape = vec![0; total_dims];
+            // Iterate backwards (from the trailing dimensions inward)
+            for i in 0..total_dims {
+                let lhs_dim = lhs
+                    .len()
+                    .checked_sub(1 + i)
+                    .map(|idx| lhs[idx])
+                    .unwrap_or(1);
+                let rhs_dim = rhs
+                    .len()
+                    .checked_sub(1 + i)
+                    .map(|idx| rhs[idx])
+                    .unwrap_or(1);
+
+                if lhs_dim == rhs_dim {
+                    target_shape[total_dims - 1 - i] = lhs_dim;
+                } else if lhs_dim == 1 {
+                    target_shape[total_dims - 1 - i] = rhs_dim;
+                } else if rhs_dim == 1 {
+                    target_shape[total_dims - 1 - i] = lhs_dim;
+                } else {
+                    // Dimensions are completely incompatible (e.g., trying to match 3 and 5)
+                    return None;
+                }
+            }
+
+            let dyn_dim = IxDyn(&target_shape);
+            D::Dim::from_dimension(&dyn_dim).map(|d| d.into_pattern())
+        }
+    }
+
     pub(crate) fn elementwise_op<OtherE>(
         lhs: SharedArray<E>,
         rhs: SharedArray<OtherE>,
         var_name: impl FnMut(&E, &OtherE) -> E,
     ) -> SharedArray<E> {
-        let lhs = lhs.broadcast(rhs.dim()).unwrap_or(lhs.view());
-        let rhs = rhs.broadcast(lhs.dim()).unwrap_or(rhs.view());
+        if let Some(target) = Self::broadcast_dims::<IxDyn>(lhs.dim(), rhs.dim()) {
+            let lhs = lhs.broadcast(target.clone()).unwrap();
+            let rhs = rhs.broadcast(target).unwrap();
 
-        Zip::from(lhs).and(rhs).map_collect(var_name).into_shared()
+            Zip::from(lhs).and(rhs).map_collect(var_name).into_shared()
+        } else {
+            panic!(
+                "Incompatible shapes for broadcasting: {:?} and {:?}",
+                lhs.shape(),
+                rhs.shape()
+            );
+        }
     }
 
     pub(crate) fn elementwise_op_scalar(

--- a/crates/burn-ndarray/src/ops/tensor.rs
+++ b/crates/burn-ndarray/src/ops/tensor.rs
@@ -764,4 +764,10 @@ impl FloatTensorOps<Self> for NdArray {
             NdArrayOps::unfold(array, dim, size, step)
         })
     }
+
+    fn float_hypot(lhs: FloatTensor<Self>, rhs: FloatTensor<Self>) -> FloatTensor<Self> {
+        execute_with_float_dtype!((lhs, rhs), FloatElem, |lhs, rhs| {
+            NdArrayMathOps::elementwise_op(lhs, rhs, |a: &FloatElem, b: &FloatElem| a.hypot(*b))
+        })
+    }
 }

--- a/crates/burn-router/src/interpreter.rs
+++ b/crates/burn-router/src/interpreter.rs
@@ -1278,6 +1278,7 @@ impl<B: BackendIr> RouterClient for TensorInterpreter<B> {
                 FloatOperationIr::ArcTan(desc) => unary_float_ops!(handles, desc, B::float_atan),
                 FloatOperationIr::ArcTanh(desc) => unary_float_ops!(handles, desc, B::float_atanh),
                 FloatOperationIr::ArcTan2(desc) => binary_float_ops!(handles, desc, B::float_atan2),
+                FloatOperationIr::Hypot(desc) => binary_float_ops!(handles, desc, B::float_hypot),
                 FloatOperationIr::Round(desc) => {
                     unary_float_ops!(handles, desc, B::float_round)
                 }

--- a/crates/burn-router/src/ops/tensor.rs
+++ b/crates/burn-router/src/ops/tensor.rs
@@ -1036,6 +1036,20 @@ impl<R: RouterChannel> FloatTensorOps<Self> for BackendRouter<R> {
             .output()
     }
 
+    fn float_hypot(lhs: FloatTensor<Self>, rhs: FloatTensor<Self>) -> FloatTensor<Self> {
+        let client = lhs.client.clone();
+        let desc = BinaryOpIr::create(lhs.into_ir(), rhs.into_ir(), || {
+            client.create_empty_handle()
+        });
+
+        client
+            .register(OperationIr::Float(
+                desc.out.dtype,
+                FloatOperationIr::Hypot(desc),
+            ))
+            .output()
+    }
+
     fn float_round(tensor: FloatTensor<Self>) -> FloatTensor<Self> {
         let client = tensor.client.clone();
         let desc = UnaryOpIr::create(tensor.into_ir(), || client.create_empty_handle());

--- a/crates/burn-tensor/src/tensor/api/float.rs
+++ b/crates/burn-tensor/src/tensor/api/float.rs
@@ -50,6 +50,14 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
         Self::new(erf_impl(self.primitive))
     }
 
+    /// Applies [hypotenuse operation](https://en.wikipedia.org/wiki/Hypotenuse) element wise.
+    ///
+    #[cfg_attr(doc, doc = r#"$y_i = \sqrt{x_i^2 + y_i^2}$"#)]
+    #[cfg_attr(not(doc), doc = "`y_i = sqrt(x_i^2 + y_i^2)`")]
+    pub fn hypot(self, other: Self) -> Self {
+        Self::new(hypot_impl(self.primitive, other.primitive))
+    }
+
     /// Applies [reciprocal operation](https://en.wikipedia.org/wiki/Multiplicative_inverse)
     /// (or multiplicative inverse) element wise.
     ///
@@ -1094,6 +1102,10 @@ fn erf_impl(p: BridgeTensor) -> BridgeTensor {
 
 fn recip_impl(p: BridgeTensor) -> BridgeTensor {
     BridgeTensor::float(Dispatch::float_recip(p.into_float()))
+}
+
+fn hypot_impl(lhs: BridgeTensor, rhs: BridgeTensor) -> BridgeTensor {
+    BridgeTensor::float(Dispatch::float_hypot(lhs.into_float(), rhs.into_float()))
 }
 
 fn round_impl(p: BridgeTensor) -> BridgeTensor {


### PR DESCRIPTION
## Pull Request Template

This will be useful for any complex backends that use split representation. has a default implementation for backends that don't have an intrinsic that tries to do something close to what is happening in libc.

There is a [simd implementation](https://github.com/ChillFish8/cfavml/pull/15/changes#diff-b59d9b3bf35c7796ff8dd9e664fee8a0a365110699777378bcb39f7694354f44) I wrote before that I could try to adapt to burn to provide a better default. If I remember correctly it almost all inputs it matched the standard libraries output and specific input combinations would cause a 1 ulp deviation. It would involve an unsafe cast from float to int (to do a bitwise xor), and would be off by 1 bit from std on certain inputs, but it is branchless so it should work on a gpu. without the bitwise ops, I could probably implement it with a log_with_base function (need base 2)

NOTE: the broadcast was passing for flex but failing for ndarray, and it looks as though the issue was how ndarray was attempting to broadcast the arrays to compatible shapes. I added a function to create the broadcast shape for both from the current shapes (rather than just trying to broadcast both sides to the other's shape)

### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

_Provide links to relevant issues and dependent PRs._

### Changes

_Summarize the problem being addressed and your solution._

### Testing

added a few test mirroring the structure found for other ops
