### PR TITLE
perf(ndarray): read select indices from a contiguous slice

### DIFF
--- a/crates/burn-ndarray/src/ops/base.rs
+++ b/crates/burn-ndarray/src/ops/base.rs
@@ -925,10 +925,19 @@ where
         dim: usize,
         indices: SharedArray<I>,
     ) -> SharedArray<E> {
+        // Read the indices from a contiguous slice rather than through the
+        // array's own iterator: the slice walks a pointer, while the
+        // iterator advances a dynamic-rank index on every element and costs
+        // more than the selection itself. The standardization is a view, and
+        // hence free, for contiguous indices; otherwise, it pays that
+        // iteration once, which the direct consumption would pay anyway.
+        let indices = indices.as_standard_layout();
         let array = tensor.select(
             Axis(dim),
             &indices
-                .into_iter()
+                .as_slice()
+                .unwrap()
+                .iter()
                 .map(|i| i.elem::<i64>() as usize)
                 .collect::<Vec<_>>(),
         );


### PR DESCRIPTION
Hello,

I was profiling a downstream crate and discovered that one-dimensional `select`s accounted for a significant part of the total runtime. Replacing them with `gather`s suspiciously helped a lot. A closer look showed that the implementation of `select` could be improved. With the proposed change, `select` is faster than `gather` for such lookups, and the workaround becomes unnecessary.

I am not taking any credits for this. It was discovered and addressed by Claude.

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

`NdArrayMathOps::select` converts its index tensor by consuming the array with a by-value iterator. For a dynamic-rank `ArcArray`, that iterator first clones the buffer whenever it is shared (`into_owned`) and then advances a dynamic-rank index on every element: `Baseiter::next` clones the index and recomputes stride offsets per step. The conversion costs about 14 ns per index, several times the selection it feeds, and makes `select` roughly five times slower than `gather` for one-dimensional lookups.

This PR reads the indices through a contiguous slice instead. `as_standard_layout()` is a free view for contiguous index tensors, the overwhelmingly common case, and otherwise pays the slow iteration once, which the previous code paid anyway; the slice iterator is a plain pointer walk.

Measured on an Apple M2 (release build, 128-element source):

| Case                             | Before          | After           |
|----------------------------------|-----------------|-----------------|
| select, 1-D, 4,096 indices       | 14.0 ns/element | 0.55 ns/element |
| select, 1-D, 65,536 indices      | 14.0 ns/element | 0.60 ns/element |
| select, 2-D rows (64 columns)    | 1.52 ns/element | 1.31 ns/element |
| gather, 1-D (untouched, control) | 2.93 ns/element | 2.93 ns/element |