### PR TITLE
perf(ndarray): reshape standard-layout arrays without copying

### DIFF
--- a/crates/burn-ndarray/src/tensor.rs
+++ b/crates/burn-ndarray/src/tensor.rs
@@ -537,9 +537,14 @@ macro_rules! reshape {
     ) => {{
         let dim = $crate::to_typed_dims!($n, $shape, justdim);
         let array = match $array.is_standard_layout() {
+            // Move the array into the new shape rather than going through
+            // `to_shape`: the latter returns a borrowed view here, which
+            // `into_shared` then clones, copying the buffer on every reshape.
+            // Moving rewrites the dimensions in place, and the buffer stays
+            // shared for copy-on-write like in any other operation.
             true => {
-                match $array.to_shape(dim) {
-                    Ok(val) => val.into_shared(),
+                match $array.into_shape_with_order(dim) {
+                    Ok(val) => val,
                     Err(err) => {
                         core::panic!("Shape should be compatible shape={dim:?}: {err:?}");
                     }


### PR DESCRIPTION
Hello,

I was profiling a downstream crate and discovered that `reshape` accounted for a significant part of the total runtime, and avoiding it forced design contortions such as hoisting reshapes out of loops and constructing broadcast results at their final rank. A closer look at the implementation showed that memory copying could be avoided for standard layouts, which is what the PR proposes.

I am not taking any credits for this. It was discovered and addressed by Claude.

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Changes

The `reshape!` macro handles standard-layout arrays by calling `to_shape`, which returns a *borrowed view* for exactly that layout; the subsequent `into_shared` must then clone the view into a fresh allocation. As a result, every `reshape` — and everything built on it, such as `unsqueeze` — copies the whole buffer, regardless of whether the buffer is uniquely owned.

This PR moves the array into the new shape with `into_shape_with_order` instead, which rewrites the dimensions and strides in place and keeps the `ArcArray` storage. The output aliases the input buffer, which is safe under the backend's existing copy-on-write discipline: every mutating operation already goes through `into_owned`.

The reshape goes from an O(n) buffer copy to an O(1) metadata rewrite. Measured on an Apple M2 (release build, `f32` tensors):

| Elements          | Before        | After         | Plain copy, for reference |
|-------------------|---------------|---------------|---------------------------|
| 4,096 (16 KB)     | 0.69 us/call  | 0.09 us/call  | 0.38 us/call              |
| 65,536 (256 KB)   | 4.4 us/call   | 0.04 us/call  | 4.3 us/call               |
| 1,048,576 (4 MB)  | 74 us/call    | 0.04 us/call  | 68 us/call                |
| 16,777,216 (64 MB)| 1,886 us/call | 0.03 us/call  | 1,857 us/call             |

The before column tracks the plain-copy reference at every size, confirming the reshape was a buffer copy; the after column is constant at tens of nanoseconds. The speedup thus grows with tensor size, from roughly 7x at 16 KB to four orders of magnitude at 64 MB.