### PR TITLE
Fix split_strides anchoring on unit dims

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter.rs
@@ -171,3 +171,25 @@ fn scatter_should_panic_on_mismatch_of_shapes() {
 
     tensor.scatter(0, indices, values, IndexingUpdateOp::Add);
 }
+
+#[test]
+fn should_scatter_add_3d_dim0_with_index_view() {
+    // Index tensor expanded from 1D via unsqueeze + repeat_dim — a common
+    // pattern to scatter whole rows along dim 0. The repeat of a unit dim
+    // is a broadcast view; reshaping it must keep stride 1 on dim 0,
+    // otherwise every iteration reads `indices[0]` and all updates pile
+    // onto one row while the other rows get none.
+    let device = Default::default();
+    let tensor = TestTensor::<3>::from_data([[[1.0]], [[2.0]], [[3.0]], [[4.0]]], &device);
+    let values = TestTensor::<3>::from_data([[[10.0]], [[20.0]]], &device);
+    let indices = TestTensorInt::<1>::from_ints([2, 0], &device);
+    let indices: TestTensorInt<2> = indices.unsqueeze_dim(1).repeat_dim(1, 1);
+    let indices: TestTensorInt<3> = indices.unsqueeze_dim(2).repeat_dim(2, 1);
+
+    let output = tensor.scatter(0, indices, values, IndexingUpdateOp::Add);
+
+    output.into_data().assert_eq(
+        &TensorData::from([[[21.0]], [[2.0]], [[13.0]], [[4.0]]]),
+        false,
+    );
+}

--- a/crates/burn-backend-tests/tests/tensor/float/ops/repeat_dim.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/repeat_dim.rs
@@ -164,3 +164,19 @@ fn should_repeat_dim_0_times_empty() {
 
     assert_eq!(output.shape(), [2, 3, 0].into());
 }
+
+#[test]
+fn should_support_unsqueeze_of_repeat_dim_view() {
+    // `repeat_dim` on a size-1 dim returns a broadcast view (stride 0 on
+    // that dim). A following unsqueeze (reshape) must not let the unit
+    // dim's stride leak onto real dims: [3, 1] with strides [1, 0]
+    // reshaped to [3, 1, 1] has to keep stride 1 on dim 0, otherwise
+    // every row reads element 0.
+    let device = Default::default();
+    let tensor = TestTensor::<1>::from_data([1.0, 2.0, 3.0], &device);
+    let view: TestTensor<2> = tensor.unsqueeze_dim(1).repeat_dim(1, 1);
+    let view: TestTensor<3> = view.unsqueeze_dim(2);
+
+    view.into_data()
+        .assert_eq(&TensorData::from([[[1.0]], [[2.0]], [[3.0]]]), false);
+}

--- a/crates/burn-std/src/tensor/mod.rs
+++ b/crates/burn-std/src/tensor/mod.rs
@@ -285,4 +285,36 @@ mod tests {
 
         assert_eq!(analysis, ReshapeAnalysis::Split)
     }
+
+    #[test]
+    fn test_split_strides_trailing_unit_dim_broadcast_view() {
+        // A `repeat_dim` broadcast view: [26, 1] with strides [1, 0],
+        // unsqueezed to [26, 1, 1]. Dim 0 must keep stride 1 — propagating
+        // the unit dim's stride 0 makes every row alias row 0 (this breaks
+        // e.g. `scatter` index tensors built via unsqueeze + repeat).
+        let strides = split_strides(&[26, 1], &[1, 0], &[26, 1, 1]);
+        assert_eq!(strides.as_ref(), &[1, 1, 1]);
+    }
+
+    #[test]
+    fn test_split_strides_trailing_unit_dims_arbitrary_strides() {
+        // Unit dims can carry arbitrary strides (broadcast 0, pitched
+        // values, ...). They must not anchor the stride walk.
+        let strides = split_strides(&[32, 1, 1, 1], &[1, 32, 32, 32], &[32, 1, 1, 1, 1]);
+        assert_eq!(strides.as_ref(), &[1, 1, 1, 1, 1]);
+    }
+
+    #[test]
+    fn test_split_strides_split_of_broadcast_dim_keeps_zero() {
+        // Splitting a real broadcast (stride 0) dim keeps 0 on the split
+        // parts; the leading real dim keeps its stride.
+        let strides = split_strides(&[26, 16], &[1, 0], &[26, 4, 4]);
+        assert_eq!(strides.as_ref(), &[1, 0, 0]);
+    }
+
+    #[test]
+    fn test_split_strides_plain_unsqueeze() {
+        let strides = split_strides(&[26, 16], &[16, 1], &[26, 16, 1]);
+        assert_eq!(strides.as_ref(), &[16, 1, 1]);
+    }
 }

--- a/crates/burn-std/src/tensor/mod.rs
+++ b/crates/burn-std/src/tensor/mod.rs
@@ -143,7 +143,20 @@ pub fn broadcast_strides(
 pub fn split_strides(shape: &[usize], strides: &[usize], shape_new: &[usize]) -> Strides {
     let mut strides_new = strides![1; shape_new.len()];
 
-    let mut old_idx = shape.len() - 1;
+    // Unit dims in the old shape never anchor a group of new dims, and their
+    // stride can be arbitrary (0 for broadcast views, pitched values, ...).
+    // Skip them so a real new dim never inherits a unit dim's stride —
+    // e.g. reshaping [26, 1] with strides [1, 0] (a `repeat_dim` broadcast
+    // view) to [26, 1, 1] must keep stride 1 on dim 0; propagating the 0
+    // would make every index along dim 0 alias the first element.
+    let skip_unit_dims = |mut idx: usize| {
+        while idx > 0 && shape[idx] == 1 {
+            idx -= 1;
+        }
+        idx
+    };
+
+    let mut old_idx = skip_unit_dims(shape.len() - 1);
     let mut current_stride = strides[old_idx];
     let mut dim_prod = 1;
 
@@ -153,7 +166,7 @@ pub fn split_strides(shape: &[usize], strides: &[usize], shape_new: &[usize]) ->
         if *dim == 1 {
             continue;
         } else if dim_prod == shape[old_idx] {
-            old_idx = old_idx.saturating_sub(1);
+            old_idx = skip_unit_dims(old_idx.saturating_sub(1));
             current_stride = strides[old_idx];
             dim_prod = 1;
         } else {


### PR DESCRIPTION
`split_strides` (used by reshape's `ReshapeAnalysis::Split` path) anchors its stride walk on the old shape's trailing dim. A size-1 trailing dim can never anchor a group — `dim_prod == shape[old_idx]` compares a real dim against 1 and never matches — so the walk multiplies the unit dim's stride instead of advancing, and that stride leaks onto the next real dim.

Unit dims also carry arbitrary strides: `repeat_dim` on a size-1 dim legitimately returns a broadcast view with stride 0. Combining the two:

```
[26, 1] strides [1, 0]   --unsqueeze-->   [26, 1, 1] strides [0, 0, 0]
```

Every index along dim 0 now aliases element 0. Any consumer that trusts strides misbehaves; the way this surfaced in practice was `scatter(Add)` with index tensors built via `unsqueeze_dim` + `repeat_dim` (a `[k, 1, 1]` index view): all `k` updates landed on `indices[0]` and none on the other rows.

The fix skips unit dims when anchoring (at the start and after each group advance), so a real new dim can never inherit a unit dim's stride. Stride values assigned to size-1 *new* dims don't matter for addressing.


### Testing

On the repro commit (fix reverted):

```
test tensor::tests::test_split_strides_trailing_unit_dim_broadcast_view ... FAILED
  left: [0, 0, 0]   right: [1, 1, 1]
test tensor::tests::test_split_strides_trailing_unit_dims_arbitrary_strides ... FAILED
  left: [32, 32, 32, 32, 32]   right: [1, 1, 1, 1, 1]
```

and both backend tests fail on wgpu. 
