### PR TITLE
feat(train): expose ClassificationMetricConfig and metric constructors

### DIFF
--- a/crates/burn-train/src/metric/classification.rs
+++ b/crates/burn-train/src/metric/classification.rs
@@ -3,7 +3,9 @@ use std::num::NonZeroUsize;
 /// Necessary data for classification metrics.
 #[derive(Default, Debug, Clone)]
 pub struct ClassificationMetricConfig {
+    /// The rule used to turn predicted probabilities into class predictions.
     pub decision_rule: DecisionRule,
+    /// The reduction strategy applied across classes.
     pub class_reduction: ClassReduction,
 }
 

--- a/crates/burn-train/src/metric/fbetascore.rs
+++ b/crates/burn-train/src/metric/fbetascore.rs
@@ -28,8 +28,9 @@ impl Default for FBetaScoreMetric {
 }
 
 impl FBetaScoreMetric {
-    #[allow(dead_code)]
-    fn new(config: ClassificationMetricConfig, beta: f64) -> Self {
+    /// Create the F-beta score metric from a [classification configuration](ClassificationMetricConfig)
+    /// and the `beta` weight.
+    pub fn new(config: ClassificationMetricConfig, beta: f64) -> Self {
         let name = Arc::new(format!(
             "FBetaScore ({}) @ {:?} [{:?}]",
             beta, config.decision_rule, config.class_reduction

--- a/crates/burn-train/src/metric/mod.rs
+++ b/crates/burn-train/src/metric/mod.rs
@@ -70,6 +70,6 @@ pub use wer::*;
 pub(crate) mod classification;
 pub(crate) mod processor;
 
-pub use crate::metric::classification::ClassReduction;
+pub use crate::metric::classification::{ClassReduction, ClassificationMetricConfig, DecisionRule};
 // Expose `ItemLazy` so it can be implemented for custom types
 pub use processor::ItemLazy;

--- a/crates/burn-train/src/metric/precision.rs
+++ b/crates/burn-train/src/metric/precision.rs
@@ -24,7 +24,8 @@ impl Default for PrecisionMetric {
 }
 
 impl PrecisionMetric {
-    fn new(config: ClassificationMetricConfig) -> Self {
+    /// Create the precision metric from a [classification configuration](ClassificationMetricConfig).
+    pub fn new(config: ClassificationMetricConfig) -> Self {
         let state = Default::default();
         let name = Arc::new(format!(
             "Precision @ {:?} [{:?}]",

--- a/crates/burn-train/src/metric/recall.rs
+++ b/crates/burn-train/src/metric/recall.rs
@@ -24,7 +24,8 @@ impl Default for RecallMetric {
 }
 
 impl RecallMetric {
-    fn new(config: ClassificationMetricConfig) -> Self {
+    /// Create the recall metric from a [classification configuration](ClassificationMetricConfig).
+    pub fn new(config: ClassificationMetricConfig) -> Self {
         let state = Default::default();
         let name = Arc::new(format!(
             "Recall @ {:?} [{:?}]",


### PR DESCRIPTION
### Related Issues/PRs

Closes #5068

### Changes

`ClassificationMetricConfig`, `DecisionRule`, and `ClassReduction` were already declared `pub`, but the `classification` module is `pub(crate)` and only `ClassReduction` was re-exported, so the config type and its `DecisionRule` couldn't be named from outside the crate.

On top of that, `RecallMetric::new`, `PrecisionMetric::new`, and `FBetaScoreMetric::new` (the constructors that take a `ClassificationMetricConfig`) were private — only `multiclass` / `multilabel` were public — so exposing the config type alone wouldn't let a user pass a custom config.

This PR:

- Re-exports `ClassificationMetricConfig` and `DecisionRule` from `burn::train::metric` (alongside the existing `ClassReduction`), matching how the other metrics are exported.
- Makes `RecallMetric::new`, `PrecisionMetric::new`, and `FBetaScoreMetric::new` public, with doc comments.
- Adds the now-required field docs to `ClassificationMetricConfig`.

This enables the use case from the issue:

```rust
RecallMetric::new(ClassificationMetricConfig {
    decision_rule: DecisionRule::TopK(NonZeroUsize::new(3).unwrap()),
    class_reduction: ClassReduction::Macro,
})
```

Not a breaking change — purely additive visibility.

### Testing

- `cargo fmt -p burn-train -- --check`
- `cargo check -p burn-train` (clean, no warnings)
- `cargo clippy -p burn-train --all-targets`
