### PR TITLE
fix(train): load checkpoint on the correct device

### DIFF
--- a/crates/burn-train/src/learner/base.rs
+++ b/crates/burn-train/src/learner/base.rs
@@ -184,7 +184,7 @@ impl<LC: LearningComponentsTypes> LearningCheckpointer<LC> {
     ) -> Learner<LC> {
         let record = self
             .model
-            .restore(epoch, &device)
+            .restore(epoch, device)
             .expect("Can load model checkpoint.");
         learner.load_model(record);
 

--- a/crates/burn-train/src/learner/base.rs
+++ b/crates/burn-train/src/learner/base.rs
@@ -184,19 +184,21 @@ impl<LC: LearningComponentsTypes> LearningCheckpointer<LC> {
     ) -> Learner<LC> {
         let record = self
             .model
-            .restore(epoch, device)
+            .restore(epoch, &device)
             .expect("Can load model checkpoint.");
         learner.load_model(record);
 
+        // Optimizer and scheduler should not be on the autodiff device
+        let inner_device = device.clone().inner();
         let record = self
             .optim
-            .restore(epoch, device)
+            .restore(epoch, &inner_device)
             .expect("Can load optimizer checkpoint.");
         learner.load_optim(record);
 
         let record = self
             .lr_scheduler
-            .restore(epoch, device)
+            .restore(epoch, &inner_device)
             .expect("Can load learning rate scheduler checkpoint.");
         learner.load_scheduler(record);
 

--- a/crates/burn-train/src/learner/rl/checkpointer.rs
+++ b/crates/burn-train/src/learner/rl/checkpointer.rs
@@ -65,7 +65,7 @@ impl<RLC: RLComponentsTypes> RLCheckpointer<RLC> {
 
         let record = self
             .learning_agent
-            .restore(epoch, device)
+            .restore(epoch, &device.clone().inner())
             .expect("Can load learning agent checkpoint.");
         let mut learning_agent = learning_agent.load_record(record);
         learning_agent.update_policy(policy);

--- a/crates/burn-train/src/learner/rl/paradigm.rs
+++ b/crates/burn-train/src/learner/rl/paradigm.rs
@@ -372,6 +372,14 @@ impl<RLC: RLComponentsTypes + 'static> RLTraining<RLC> {
             inference_device: self.inference_device,
         };
 
+        let mut learner_agent = learner_agent;
+        if let Some(checkpoint) = components.checkpoint
+            && let Some(checkpointer) = &components.checkpointer
+        {
+            let device = learner_agent.device();
+            learner_agent = checkpointer.load_checkpoint(learner_agent, &device, checkpoint);
+        }
+
         match self.learning_strategy {
             RLStrategies::OffPolicyStrategy(config) => {
                 let strategy = OffPolicyStrategy::new(config);

--- a/crates/burn-train/src/learner/rl/strategy.rs
+++ b/crates/burn-train/src/learner/rl/strategy.rs
@@ -51,20 +51,7 @@ pub trait RLStrategy<RLC: RLComponentsTypes> {
         mut training_components: RLComponents<RLC>,
         env_init: RLC::EnvInit,
     ) -> RLResult<RLC::Policy> {
-        let starting_epoch = match training_components.checkpoint {
-            Some(checkpoint) => {
-                if let Some(checkpointer) = &mut training_components.checkpointer {
-                    learner_agent = checkpointer.load_checkpoint(
-                        learner_agent,
-                        &Default::default(),
-                        checkpoint,
-                    );
-                }
-                checkpoint + 1
-            }
-            None => 1,
-        };
-
+        let starting_epoch = training_components.checkpoint.unwrap_or(0) + 1;
         let summary_config = training_components.summary.clone();
 
         // Event processor start training

--- a/crates/burn-train/src/learner/supervised/paradigm.rs
+++ b/crates/burn-train/src/learner/supervised/paradigm.rs
@@ -414,6 +414,21 @@ where
             )),
         ));
 
+        // Main device for checkpoint loading, falling back to the model's current device if it's a custom strategy
+        let mut learner = learner;
+        if let Some(checkpoint) = components.checkpoint
+            && let Some(checkpointer) = &components.checkpointer
+        {
+            let main_device = match &training_strategy {
+                TrainingStrategy::Default(execution_strategy) => {
+                    execution_strategy.main_device().clone()
+                }
+                TrainingStrategy::Custom(_) => learner.model.devices()[0].clone(),
+            };
+            let device_ad = autodiff_device(main_device, self.grad_checkpointing);
+            learner = checkpointer.load_checkpoint(learner, &device_ad, checkpoint);
+        }
+
         match training_strategy {
             TrainingStrategy::Custom(learning_paradigm) => learning_paradigm.train(
                 learner,

--- a/crates/burn-train/src/learner/supervised/strategies/base.rs
+++ b/crates/burn-train/src/learner/supervised/strategies/base.rs
@@ -121,22 +121,12 @@ pub trait SupervisedLearningStrategy<LC: LearningComponentsTypes> {
     /// Train the learner's model with this strategy.
     fn train(
         &self,
-        mut learner: Learner<LC>,
+        learner: Learner<LC>,
         dataloader_train: TrainLoader<LC>,
         dataloader_valid: ValidLoader<LC>,
         mut training_components: TrainingComponents<LC>,
     ) -> LearningResult<InferenceModel<LC>> {
-        let starting_epoch = match training_components.checkpoint {
-            Some(checkpoint) => {
-                if let Some(checkpointer) = &mut training_components.checkpointer {
-                    learner =
-                        checkpointer.load_checkpoint(learner, &Default::default(), checkpoint);
-                }
-                checkpoint + 1
-            }
-            None => 1,
-        };
-
+        let starting_epoch = training_components.checkpoint.unwrap_or(0) + 1;
         let summary_config = training_components.summary.clone();
 
         // Event processor start training

--- a/examples/mnist/examples/mnist.rs
+++ b/examples/mnist/examples/mnist.rs
@@ -17,7 +17,11 @@ fn select_device() -> Device {
     #[cfg(feature = "tch-cpu")]
     return Device::libtorch();
 
-    #[cfg(any(feature = "wgpu", feature = "metal", feature = "vulkan"))]
+    #[cfg(feature = "vulkan")]
+    return Device::vulkan(burn::tensor::DeviceKind::DefaultDevice);
+    #[cfg(feature = "metal")]
+    return Device::metal(burn::tensor::DeviceKind::DefaultDevice);
+    #[cfg(feature = "wgpu")]
     return Device::wgpu(burn::tensor::DeviceKind::DefaultDevice);
 
     #[cfg(feature = "cuda")]


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Fixes #5082 

Restoring a model checkpoint with the learner would load it on the `Default::default()` device, leading to invalid autodiff operations during training.

### Changes

- Fixed the `load_checkpoint` call to use the correct training device for model checkpoints, and inner device for optimizer + scheduler

### Testing

Mnist example
