### PR TITLE
fix(fusion): use dtype_to_storage_type in autotune checks

### DIFF
--- a/crates/burn-cubecl-fusion/src/engine/trace/base.rs
+++ b/crates/burn-cubecl-fusion/src/engine/trace/base.rs
@@ -16,6 +16,8 @@ use crate::CubeFusionHandle;
 #[cfg(feature = "autotune-checks")]
 use burn_backend::TensorData;
 #[cfg(feature = "autotune-checks")]
+use burn_backend::cubecl::dtype_to_storage_type;
+#[cfg(feature = "autotune-checks")]
 use std::collections::HashMap;
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -105,7 +107,7 @@ impl<R: Runtime> cubecl::tune::AutotuneOutput for TuneOutput<R> {
                         into_contiguous::<R>(
                             &handle.client,
                             handle.clone().binding(shape.clone()),
-                            handle.dtype.into(),
+                            dtype_to_storage_type(handle.dtype),
                         )
                         .handle
                     } else {
@@ -115,7 +117,7 @@ impl<R: Runtime> cubecl::tune::AutotuneOutput for TuneOutput<R> {
                         into_contiguous::<R>(
                             &other.client,
                             other.clone().binding(shape.clone()),
-                            other.dtype.into(),
+                            dtype_to_storage_type(other.dtype),
                         )
                         .handle
                     } else {

--- a/crates/burn-dispatch/src/ops/tensor.rs
+++ b/crates/burn-dispatch/src/ops/tensor.rs
@@ -31,10 +31,6 @@ impl FloatTensorOps<Self> for Dispatch {
     }
 
     fn float_device(tensor: &FloatTensor<Self>) -> DispatchDevice {
-        // println!("float_device: {tensor:?}");
-        // let device = tensor.device();
-        // println!("  {device:?}");
-        // device
         tensor.device()
     }
 


### PR DESCRIPTION
Missed this change during the recent refactors