### PR TITLE
fix(train): avoid overflow in TUI progress when extending training

### DIFF
--- a/crates/burn-train/src/renderer/tui/progress.rs
+++ b/crates/burn-train/src/renderer/tui/progress.rs
@@ -196,7 +196,11 @@ impl ProgressEstimate {
     }
 
     fn init(&mut self, progress: &ProgressSnapshot, starting_epoch: usize) {
-        let epoch = progress.global.items_processed - starting_epoch;
+        let epoch = progress
+            .global
+            .items_processed
+            .saturating_sub(starting_epoch)
+            .max(1);
         let local = &progress.split;
 
         let epoch_items = (epoch - 1) * local.items_total;
@@ -213,14 +217,18 @@ fn calculate_progress(
     starting_epoch: usize,
     ignore_num_items: usize,
 ) -> f64 {
-    let epoch_total = progress.global.items_total - starting_epoch;
-    let epoch = progress.global.items_processed - starting_epoch;
+    let epoch_total = progress.global.items_total.saturating_sub(starting_epoch);
+    let epoch = progress
+        .global
+        .items_processed
+        .saturating_sub(starting_epoch)
+        .max(1);
     let local = &progress.split;
 
     let total_items = local.items_total * epoch_total;
     let epoch_items = (epoch - 1) * local.items_total;
     let iteration_items = local.items_processed;
-    let num_items = epoch_items + iteration_items - ignore_num_items;
+    let num_items = (epoch_items + iteration_items).saturating_sub(ignore_num_items);
 
     num_items as f64 / total_items as f64
 }
@@ -292,5 +300,20 @@ mod tests {
 
         // Two epochs remaining while the first is 11% done, minus 10 warmup items.
         assert_eq!(0.05, result);
+    }
+
+    #[test]
+    fn calculate_progress_when_extending_past_completed_run() {
+        // Resuming a checkpoint to extend training can momentarily report fewer
+        // completed epochs than the starting epoch, which used to underflow.
+        let progress = ProgressSnapshot::new(
+            Progress::new(1, 3, Some("epochs".to_string())),
+            Progress::new(5, 10, Some("items".to_string())),
+        );
+
+        let result = calculate_progress(&progress, 2, 0);
+
+        // One epoch remaining, currently half done, instead of an overflow panic.
+        assert_eq!(0.5, result);
     }
 }


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Fixes #5091

### Changes

When training is extended from a checkpoint, the global progress can briefly report fewer completed epochs than `starting_epoch`. The TUI progress estimator subtracted `starting_epoch` from `items_processed` (and from `items_total`/`ignore_num_items`) with plain unsigned subtraction, so this underflowed and panicked with "attempt to subtract with overflow" in `init` and `calculate_progress`.

Switched those subtractions to `saturating_sub` and clamped the current epoch to at least 1, so the estimator reports a sensible progress value instead of crashing the `train-renderer` thread.

### Testing

Added a regression test in `progress.rs` that drives `calculate_progress` with `items_processed < starting_epoch`; it panicked before the change and now returns the expected ratio. Also ran `cargo test -p burn-train`, `cargo fmt --check`, and `cargo clippy -p burn-train`.
