### PR TITLE
fix(cubecl): materialize lazy device bytes in from_data

### DIFF
--- a/crates/burn-backend-tests/tests/cubecl/quantization/quantize_dequantize.rs
+++ b/crates/burn-backend-tests/tests/cubecl/quantization/quantize_dequantize.rs
@@ -166,14 +166,17 @@ fn should_quantize_dequantize_symmetric_per_block_q2s_packed() {
 }
 
 #[test]
-// #[might] TODO
 fn should_quantize_dequantize_symmetric_arange_q8s_native() {
-    should_quantize_dequantize_symmetric_arange(QuantValue::Q8S, QuantStore::Native, [32, 32])
+    if supports_native() {
+        should_quantize_dequantize_symmetric_arange(QuantValue::Q8S, QuantStore::Native, [32, 32])
+    }
 }
 
 #[test]
 fn should_quantize_dequantize_symmetric_per_block_q8s_native() {
-    should_quantize_dequantize_symmetric_per_block(QuantValue::Q8S, 8, QuantStore::Native)
+    if supports_native() {
+        should_quantize_dequantize_symmetric_per_block(QuantValue::Q8S, 8, QuantStore::Native)
+    }
 }
 
 #[test]
@@ -188,22 +191,26 @@ fn should_quantize_dequantize_symmetric_per_block_arange_q8s_packed() {
 
 #[test]
 fn should_quantize_dequantize_symmetric_per_block_arange_q8s_native() {
-    should_quantize_dequantize_symmetric_per_block_arange(
-        QuantValue::Q8S,
-        32,
-        QuantStore::Native,
-        [32, 32],
-    )
+    if supports_native() {
+        should_quantize_dequantize_symmetric_per_block_arange(
+            QuantValue::Q8S,
+            32,
+            QuantStore::Native,
+            [32, 32],
+        )
+    }
 }
 
 #[test]
 fn should_quantize_dequantize_symmetric_arange_128x256_q8s_native() {
-    should_quantize_dequantize_symmetric_per_block_arange(
-        QuantValue::Q8S,
-        32,
-        QuantStore::Native,
-        [128, 256],
-    )
+    if supports_native() {
+        should_quantize_dequantize_symmetric_per_block_arange(
+            QuantValue::Q8S,
+            32,
+            QuantStore::Native,
+            [128, 256],
+        )
+    }
 }
 
 #[test]

--- a/crates/burn-backend-tests/tests/cubecl/quantization/slice.rs
+++ b/crates/burn-backend-tests/tests/cubecl/quantization/slice.rs
@@ -15,13 +15,11 @@ where
     // Always use the default scheme when testing `q_slice`.
     let scheme = QuantScheme::default();
 
-    let data = TestTensorInt::arange(0..numel, &device)
+    let quantized = TestTensorInt::arange(0..numel, &device)
         .float()
         .div_scalar(numel)
         .reshape::<D, _>(shape)
-        .into_data();
-
-    let quantized = TestTensor::<D>::from_data(data, &device).quantize_dynamic(&scheme);
+        .quantize_dynamic(&scheme);
 
     // Reference: dequantize, then slice in full precision.
     let output_ref = quantized

--- a/crates/burn-backend-tests/tests/tensor/float/ops/hypot.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/hypot.rs
@@ -1,5 +1,5 @@
 use super::*;
-use burn_tensor::{DType, TensorData, Tolerance};
+use burn_tensor::{TensorData, Tolerance};
 
 #[test]
 fn should_support_hypot_basic() {

--- a/crates/burn-backend-tests/tests/tensor/float/primitive.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/primitive.rs
@@ -1,5 +1,5 @@
 use super::*;
-use burn_tensor::{Element, Shape};
+use burn_tensor::{Element, Shape, TensorData};
 
 #[test]
 fn should_support_float_dtype() {
@@ -10,4 +10,18 @@ fn should_support_float_dtype() {
         tensor.dtype(),
         FloatElem::dtype() // default float elem type
     );
+}
+
+#[test]
+fn should_support_into_data_from_data() {
+    let device = Default::default();
+    let data =
+        TestTensor::<2>::from_data([[0.0, -1.0, 2.0], [3.0, 4.0, -5.0]], &device).into_data();
+    let tensor = TestTensor::<2>::from_data(data, &device).slice(0);
+
+    // Regression test for `LazyDeviceController` from_data(tensor.into_data()) roundtrips
+    // These unnecessary round-trips should be avoided, but should not panic
+    tensor
+        .into_data()
+        .assert_eq(&TensorData::from([[0.0, -1.0, 2.0]]), false);
 }

--- a/crates/burn-cubecl/src/ops/base.rs
+++ b/crates/burn-cubecl/src/ops/base.rs
@@ -13,6 +13,13 @@ use cubecl::{ir::VectorSize, server::CopyDescriptor};
 use cubecl::{quant::scheme::BlockSize, tensor_vector_size_parallel};
 
 pub(crate) fn from_data<R: CubeRuntime>(data: TensorData, device: &R::Device) -> CubeTensor<R> {
+    // `TensorData` may contain lazily materialized device-backed bytes produced
+    // by `into_data()`. These unnecessary round-trips should be avoided, but
+    // materializing before re-uploading avoids recursive runtime submission.
+    if data.bytes.property() == burn_std::AllocationProperty::Device {
+        let _ = data.bytes.read(burn_std::Reader::new());
+    }
+
     let client = R::client(device);
     let alloc = client.create_tensor(data.bytes, data.shape.clone(), data.dtype.size());
     let shape: Shape = (&data.shape).into();

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -1905,6 +1905,7 @@ where
         // Use the given dtype when provided, otherwise default device dtype
         let opt = options.into();
         let dtype = opt.resolve_dtype::<K>();
+
         Self::new(K::from_data(data, &opt.device, dtype))
     }
 


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Fixes the macos CI issue introduced #5064

```
  thread 'DSD-4-0' (30839) panicked at /Users/admin/.cargo/git/checkouts/cubecl-058c47895211d464/a307913/crates/cubecl-runtime/src/client.rs:108:14:
  called `Result::unwrap()` on an `Err` value: CallError
  
  thread 'DSD-4-0' (30839) panicked at /Users/admin/.cargo/git/checkouts/cubecl-058c47895211d464/a307913/crates/cubecl-common/src/device/handle/channel.rs:361:18:
  Service state is already borrowed: BorrowMutError
  
  thread 'DSD-4-0' (30839) panicked at /Users/admin/.cargo/git/checkouts/cubecl-058c47895211d464/a307913/crates/cubecl-runtime/src/client.rs:108:14:
  test cube::kernel::quantization::slice::should_slice_1d_range ... FAILED
```

### Changes

Users might have unnecessary `Tensor::from_data(tensor.into_data())` roundtrips, but they shouldn't panic nonetheless.

Fixed: force materialization in `from_data` when bytes has `AllocationProperty::Device` (lazy).

### Testing

Unit test
