### PR TITLE
Feat: add new methods in checkpoint and fix compilation errors

### DIFF
--- a/crates/burn-dispatch/src/remote_server.rs
+++ b/crates/burn-dispatch/src/remote_server.rs
@@ -120,8 +120,8 @@ macro_rules! with_backend {
 ///
 /// The dispatch device selects which backend executes operations server-side; the server
 /// then hosts that backend's devices (single host, multi-device), indexed by hardware device
-/// index. See [`with_backend`] for how the backend is resolved and [`host_devices`] for how its
-/// device list is chosen.
+/// index. The backend is resolved from the dispatch device variant, and the device list is
+/// chosen via the `host_devices` helper.
 pub fn start_websocket(device: DispatchDevice, port: u16) {
     with_backend!(device, |B, devices| {
         burn_remote::server::start_websocket::<B>(devices, port)
@@ -131,7 +131,7 @@ pub fn start_websocket(device: DispatchDevice, port: u16) {
 /// Start a websocket remote server on the caller's tokio runtime.
 ///
 /// The async counterpart of [`start_websocket`]; the two share the same backend-resolution match
-/// (see [`with_backend`]) and differ only in awaiting the server future.
+/// and differ only in awaiting the server future.
 pub async fn start_websocket_async(device: DispatchDevice, port: u16) {
     with_backend!(device, |B, devices| {
         burn_remote::server::start_websocket_async::<B>(devices, port).await

--- a/crates/burn-store/benches/unified_loading.rs
+++ b/crates/burn-store/benches/unified_loading.rs
@@ -23,7 +23,7 @@ use burn_core as burn;
 
 use burn_core::module::Module;
 use burn_core::prelude::*;
-use burn_core::record::{FullPrecisionSettings, NamedMpkFileRecorder, Recorder};
+use burn_core::store::ModuleRecord;
 // use burn_import::pytorch::{LoadArgs, PyTorchFileRecorder};
 // use burn_import::safetensors::SafetensorsFileRecorder;
 use burn_nn as nn;
@@ -83,9 +83,8 @@ fn generate_burn_formats(st_path: &Path, bp_path: &Path, mpk_path: &Path) {
     // Save as NamedMpk
     if !mpk_path.exists() {
         println!("  Creating NamedMpk file...");
-        let recorder = NamedMpkFileRecorder::<FullPrecisionSettings>::default();
         model
-            .save_file(mpk_path, &recorder)
+            .save_file(mpk_path)
             .expect("Failed to save as NamedMpk");
     }
 }
@@ -219,11 +218,8 @@ macro_rules! bench_backend {
                     .counter(divan::counter::BytesCount::new(file_size))
                     .bench(|| {
                         let device = $device;
-                        let recorder = NamedMpkFileRecorder::<FullPrecisionSettings>::default();
-                        let record = recorder
-                            .load(mpk_path.clone().into(), &device)
-                            .expect("Failed to load");
-                        let _model = LargeModel::new(&device).load_record(record);
+                        let model = LargeModel::new(&device);
+                        model.load_record(ModuleRecord::load(&mpk_path).expect("Failed to load"));
                     });
             }
 

--- a/crates/burn-store/benches/unified_saving.rs
+++ b/crates/burn-store/benches/unified_saving.rs
@@ -18,7 +18,6 @@ use burn_core as burn;
 
 use burn_core::module::Module;
 use burn_core::prelude::*;
-use burn_core::record::{FullPrecisionSettings, NamedMpkFileRecorder};
 use burn_nn as nn;
 use burn_store::{BurnpackStore, ModuleSnapshot, SafetensorsStore};
 use divan::{AllocProfiler, Bencher};
@@ -122,9 +121,8 @@ macro_rules! bench_backend {
                     let device = $device;
                     let model = LargeModel::new(&device);
                     let output_path = get_output_dir().join("test_namedmpk.mpk");
-                    let recorder = NamedMpkFileRecorder::<FullPrecisionSettings>::default();
                     model
-                        .save_file(output_path.clone(), &recorder)
+                        .save_file(output_path.clone())
                         .expect("Failed to save with NamedMpkFileRecorder");
                     // Clean up
                     let _ = fs::remove_file(output_path);

--- a/crates/burn-store/benches/zero_copy_loading.rs
+++ b/crates/burn-store/benches/zero_copy_loading.rs
@@ -1,25 +1,23 @@
 #![recursion_limit = "256"]
 
-//! Benchmark comparing zero-copy vs copy loading modes for BurnpackStore.
+//! Benchmark comparing different loading modes for BurnpackStore.
 //!
 //! This benchmark measures the performance difference between:
-//! - `zero_copy(false)` - Default mode, copies tensor data into new allocations
-//! - `zero_copy(true)` - Zero-copy mode, slices tensor data without copying
+//! - `from_file()` - File-based loading (reader handles lazy/mmap internally)
+//! - `from_static()` - Zero-copy mode from static bytes (stays in .rodata)
+//! - `from_bytes()` - Loading from owned bytes
+//! - `from_bytes()` with shared `Bytes` - Loading from shared/arc bytes
 //!
 //! ## Understanding the Results
 //!
-//! **IMPORTANT**: For the Flex backend, you'll see similar allocation numbers
-//! because Flex currently copies incoming bytes into its own `Bytes` storage
-//! on load rather than borrowing from the underlying buffer.
+//! The key difference is how tensor data reaches the backend:
+//! - **from_file**: File → reader (lazy/mmap) → backend
+//! - **from_bytes**: Owned bytes → copy to backend
+//! - **from_static**: Static .rodata → zero-copy slice → backend
+//! - **shared bytes**: Arc'd bytes → zero-copy clone → backend
 //!
-//! The zero-copy benefit is:
-//! - **Without zero-copy**: File → Copy to heap (Bytes) → Copy to Vec (backend)
-//! - **With zero-copy**: File → Zero-copy slice → Copy to Vec (backend)
-//!
-//! So zero-copy saves ONE memory copy at the store level. The `store_only_*` benchmarks
-//! show the raw store performance without backend allocation overhead.
-//!
-//! GPU backends that can consume `Bytes` directly will show larger benefits.
+//! GPU backends that can consume `Bytes` directly will show larger benefits
+//! from zero-copy paths.
 //!
 //! ## Running the benchmark
 //!
@@ -146,13 +144,13 @@ fn main() {
     println!("  Path: {}", bp_path.display());
     println!("  Size: {:.1} MB", file_size);
     println!();
-    println!("🚀 Running zero-copy loading benchmarks...");
+    println!("🚀 Running loading mode benchmarks...");
     println!();
     println!("Comparing loading modes:");
-    println!("  1. file_copy        - from_file().zero_copy(false) - copies tensor data");
-    println!("  2. file_zero_copy   - from_file().zero_copy(true)  - zero-copy via mmap");
-    println!("  3. static_copy      - from_bytes() with Vec copy   - copies from static");
-    println!("  4. static_zero_copy - from_static()                - zero-copy from static");
+    println!("  1. file             - from_file() - lazy/mmap file loading");
+    println!("  2. static_bytes     - from_bytes() with Vec copy from static");
+    println!("  3. static_zero_copy - from_static() - zero-copy from static");
+    println!("  4. memory_shared    - from_bytes() with shared Bytes (cheap Arc clone)");
     println!();
     println!("Available backends:");
     println!("  - Flex (CPU)");
@@ -179,9 +177,9 @@ macro_rules! bench_backend {
         mod $mod_name {
             use super::*;
 
-            /// File-based loading with copy mode (default)
+            /// File-based loading (reader handles lazy/mmap internally)
             #[divan::bench]
-            fn file_copy(bencher: Bencher) {
+            fn file(bencher: Bencher) {
                 let bp_path = get_burnpack_path();
                 let file_size = fs::metadata(&bp_path).unwrap().len();
 
@@ -190,30 +188,14 @@ macro_rules! bench_backend {
                     .bench(|| {
                         let device = $device;
                         let mut model = LargeModel::new(&device);
-                        let mut store = BurnpackStore::from_file(&bp_path).zero_copy(false);
+                        let mut store = BurnpackStore::from_file(&bp_path);
                         model.load_from(&mut store).expect("Failed to load");
                     });
             }
 
-            /// File-based loading with zero-copy mode (mmap + bytes::Bytes)
+            /// Static bytes with copy (simulating old behavior: copy to Vec first)
             #[divan::bench]
-            fn file_zero_copy(bencher: Bencher) {
-                let bp_path = get_burnpack_path();
-                let file_size = fs::metadata(&bp_path).unwrap().len();
-
-                bencher
-                    .counter(divan::counter::BytesCount::new(file_size))
-                    .bench(|| {
-                        let device = $device;
-                        let mut model = LargeModel::new(&device);
-                        let mut store = BurnpackStore::from_file(&bp_path).zero_copy(true);
-                        model.load_from(&mut store).expect("Failed to load");
-                    });
-            }
-
-            /// Static bytes with copy mode (simulating old behavior)
-            #[divan::bench]
-            fn static_copy(bencher: Bencher) {
+            fn static_bytes(bencher: Bencher) {
                 let static_bytes = get_static_model_bytes();
                 let file_size = static_bytes.len() as u64;
 
@@ -223,14 +205,13 @@ macro_rules! bench_backend {
                         let device = $device;
                         let mut model = LargeModel::new(&device);
 
-                        // Simulate old behavior: copy static bytes to Vec, then load
                         let bytes = Bytes::from_bytes_vec(static_bytes.to_vec());
-                        let mut store = BurnpackStore::from_bytes(Some(bytes)).zero_copy(false);
+                        let mut store = BurnpackStore::from_bytes(Some(bytes));
                         model.load_from(&mut store).expect("Failed to load");
                     });
             }
 
-            /// Static bytes with zero-copy mode (new from_static)
+            /// Static bytes with zero-copy (from_static keeps data in .rodata)
             #[divan::bench]
             fn static_zero_copy(bencher: Bencher) {
                 let static_bytes = get_static_model_bytes();
@@ -242,15 +223,14 @@ macro_rules! bench_backend {
                         let device = $device;
                         let mut model = LargeModel::new(&device);
 
-                        // Zero-copy: use from_static which keeps data in .rodata
                         let mut store = BurnpackStore::from_static(static_bytes);
                         model.load_from(&mut store).expect("Failed to load");
                     });
             }
 
-            /// In-memory shared bytes with zero-copy
+            /// In-memory shared bytes (cheap Arc clone, zero-copy)
             #[divan::bench]
-            fn memory_shared_zero_copy(bencher: Bencher) {
+            fn memory_shared(bencher: Bencher) {
                 let static_bytes = get_static_model_bytes();
                 let file_size = static_bytes.len() as u64;
 
@@ -263,9 +243,8 @@ macro_rules! bench_backend {
                         let device = $device;
                         let mut model = LargeModel::new(&device);
 
-                        // Create Bytes from shared (cheap clone of Arc)
                         let bytes = Bytes::from_shared(shared.clone(), AllocationProperty::Other);
-                        let mut store = BurnpackStore::from_bytes(Some(bytes)).zero_copy(true);
+                        let mut store = BurnpackStore::from_bytes(Some(bytes));
                         model.load_from(&mut store).expect("Failed to load");
                     });
             }
@@ -352,23 +331,23 @@ mod verification {
         println!("   - Matmul result sum: {:.4}", matmul_sum);
     }
 
-    /// Compare zero-copy vs copy: verify both produce identical results
+    /// Compare from_static vs from_bytes: verify both produce identical results
     #[divan::bench]
-    fn verify_copy_vs_zero_copy_equality() {
+    fn verify_static_vs_bytes_equality() {
         let static_bytes = get_static_model_bytes();
         let device = Device::flex();
 
-        // Load with zero-copy
+        // Load with from_static (zero-copy)
         let mut model_zc = LargeModel::new(&device);
         let mut store_zc = BurnpackStore::from_static(static_bytes);
         model_zc
             .load_from(&mut store_zc)
             .expect("Failed to load zero-copy");
 
-        // Load with copy (simulate old behavior)
+        // Load with from_bytes (copy)
         let mut model_copy = LargeModel::new(&device);
         let bytes = Bytes::from_bytes_vec(static_bytes.to_vec());
-        let mut store_copy = BurnpackStore::from_bytes(Some(bytes)).zero_copy(false);
+        let mut store_copy = BurnpackStore::from_bytes(Some(bytes));
         model_copy
             .load_from(&mut store_copy)
             .expect("Failed to load copy");
@@ -419,18 +398,16 @@ mod verification {
 mod store_only {
     use super::*;
 
-    /// File-based store with copy mode - measures store overhead only
+    /// File-based store - measures store overhead only
     #[divan::bench]
-    fn file_copy(bencher: Bencher) {
+    fn file(bencher: Bencher) {
         let bp_path = get_burnpack_path();
         let file_size = fs::metadata(&bp_path).unwrap().len();
 
         bencher
             .counter(divan::counter::BytesCount::new(file_size))
             .bench(|| {
-                let mut store = BurnpackStore::from_file(&bp_path).zero_copy(false);
-                // Just iterate through all tensor snapshots, calling to_data() on each
-                // This forces the store to read and materialize all tensor data
+                let mut store = BurnpackStore::from_file(&bp_path);
                 let snapshots = store.get_all_snapshots().expect("Failed to get snapshots");
                 for snapshot in snapshots.values() {
                     let _data = snapshot.to_data().expect("Failed to get tensor data");
@@ -438,35 +415,17 @@ mod store_only {
             });
     }
 
-    /// File-based store with zero-copy mode - measures store overhead only
+    /// Static bytes with copy - measures store overhead only
     #[divan::bench]
-    fn file_zero_copy(bencher: Bencher) {
-        let bp_path = get_burnpack_path();
-        let file_size = fs::metadata(&bp_path).unwrap().len();
-
-        bencher
-            .counter(divan::counter::BytesCount::new(file_size))
-            .bench(|| {
-                let mut store = BurnpackStore::from_file(&bp_path).zero_copy(true);
-                let snapshots = store.get_all_snapshots().expect("Failed to get snapshots");
-                for snapshot in snapshots.values() {
-                    let _data = snapshot.to_data().expect("Failed to get tensor data");
-                }
-            });
-    }
-
-    /// Static bytes with copy mode - measures store overhead only
-    #[divan::bench]
-    fn static_copy(bencher: Bencher) {
+    fn static_bytes(bencher: Bencher) {
         let static_bytes = get_static_model_bytes();
         let file_size = static_bytes.len() as u64;
 
         bencher
             .counter(divan::counter::BytesCount::new(file_size))
             .bench(|| {
-                // Simulate old behavior: copy static bytes to Vec
                 let bytes = Bytes::from_bytes_vec(static_bytes.to_vec());
-                let mut store = BurnpackStore::from_bytes(Some(bytes)).zero_copy(false);
+                let mut store = BurnpackStore::from_bytes(Some(bytes));
                 let snapshots = store.get_all_snapshots().expect("Failed to get snapshots");
                 for snapshot in snapshots.values() {
                     let _data = snapshot.to_data().expect("Failed to get tensor data");
@@ -474,7 +433,7 @@ mod store_only {
             });
     }
 
-    /// Static bytes with zero-copy mode - measures store overhead only
+    /// Static bytes with zero-copy - measures store overhead only
     #[divan::bench]
     fn static_zero_copy(bencher: Bencher) {
         let static_bytes = get_static_model_bytes();

--- a/crates/burn-train/src/checkpoint/base.rs
+++ b/crates/burn-train/src/checkpoint/base.rs
@@ -35,7 +35,7 @@ pub trait Checkpoint: Sized + Send + 'static {
     fn save(self, path: PathBuf) -> Result<(), CheckpointerError>;
     /// Load the record from `path`.
     fn load(path: PathBuf) -> Result<Self, CheckpointerError>;
-    /// Creates a checkpoint fom bytes
+    /// Creates a checkpoint from bytes
     fn checkpoint_from_bytes(bytes: Bytes) -> Result<Self, RecordError>;
     /// Transforms a checkpoint into bytes
     fn checkpoint_into_bytes(self) -> Result<Bytes, RecordError>;

--- a/crates/burn-train/src/checkpoint/base.rs
+++ b/crates/burn-train/src/checkpoint/base.rs
@@ -1,6 +1,7 @@
 use burn_core::store::{ModuleRecord, RecordError};
 use burn_optim::OptimizerRecord;
 use burn_optim::lr_scheduler::LrSchedulerRecord;
+use burn_std::Bytes;
 use std::path::PathBuf;
 use thiserror::Error;
 
@@ -34,6 +35,10 @@ pub trait Checkpoint: Sized + Send + 'static {
     fn save(self, path: PathBuf) -> Result<(), CheckpointerError>;
     /// Load the record from `path`.
     fn load(path: PathBuf) -> Result<Self, CheckpointerError>;
+    /// Creates a checkpoint fom bytes
+    fn checkpoint_from_bytes(bytes: Bytes) -> Result<Self, RecordError>;
+    /// Transforms a checkpoint into bytes
+    fn checkpoint_into_bytes(self) -> Result<Bytes, RecordError>;
 }
 
 /// A stateless record: nothing to save or load.
@@ -44,6 +49,12 @@ impl Checkpoint for () {
     fn load(_path: PathBuf) -> Result<Self, CheckpointerError> {
         Ok(())
     }
+    fn checkpoint_from_bytes(_bytes: Bytes) -> Result<Self, RecordError> {
+        Ok(())
+    }
+    fn checkpoint_into_bytes(self) -> Result<Bytes, RecordError> {
+        Ok(Bytes::from_bytes_vec(vec![0]))
+    }
 }
 
 impl Checkpoint for ModuleRecord {
@@ -52,6 +63,12 @@ impl Checkpoint for ModuleRecord {
     }
     fn load(path: PathBuf) -> Result<Self, CheckpointerError> {
         ModuleRecord::load(path).map_err(CheckpointerError::Record)
+    }
+    fn checkpoint_into_bytes(self) -> Result<Bytes, RecordError> {
+        self.into_bytes()
+    }
+    fn checkpoint_from_bytes(bytes: Bytes) -> Result<Self, RecordError> {
+        ModuleRecord::from_bytes(bytes)
     }
 }
 
@@ -62,6 +79,12 @@ impl Checkpoint for OptimizerRecord {
     fn load(path: PathBuf) -> Result<Self, CheckpointerError> {
         OptimizerRecord::load(path).map_err(CheckpointerError::Record)
     }
+    fn checkpoint_from_bytes(bytes: Bytes) -> Result<Self, RecordError> {
+        OptimizerRecord::from_bytes(bytes)
+    }
+    fn checkpoint_into_bytes(self) -> Result<Bytes, RecordError> {
+        self.into_bytes()
+    }
 }
 
 impl Checkpoint for LrSchedulerRecord {
@@ -70,6 +93,12 @@ impl Checkpoint for LrSchedulerRecord {
     }
     fn load(path: PathBuf) -> Result<Self, CheckpointerError> {
         LrSchedulerRecord::load(path).map_err(CheckpointerError::Record)
+    }
+    fn checkpoint_from_bytes(bytes: Bytes) -> Result<Self, RecordError> {
+        LrSchedulerRecord::from_bytes(bytes)
+    }
+    fn checkpoint_into_bytes(self) -> Result<Bytes, RecordError> {
+        self.into_bytes()
     }
 }
 

--- a/crates/burn-train/src/learner/supervised/paradigm.rs
+++ b/crates/burn-train/src/learner/supervised/paradigm.rs
@@ -1,7 +1,6 @@
 use crate::checkpoint::{
-    AsyncCheckpointer, Checkpoint, Checkpointer, CheckpointingStrategy,
-    ComposedCheckpointingStrategy, FileCheckpointer, KeepLastNCheckpoints,
-    MetricCheckpointingStrategy,
+    AsyncCheckpointer, Checkpointer, CheckpointingStrategy, ComposedCheckpointingStrategy,
+    FileCheckpointer, KeepLastNCheckpoints, MetricCheckpointingStrategy,
 };
 use crate::components::{InferenceModelOutput, TrainingModelOutput};
 use crate::learner::EarlyStoppingStrategy;

--- a/crates/burn-train/src/learner/supervised/paradigm.rs
+++ b/crates/burn-train/src/learner/supervised/paradigm.rs
@@ -1,6 +1,7 @@
 use crate::checkpoint::{
-    AsyncCheckpointer, CheckpointingStrategy, ComposedCheckpointingStrategy, FileCheckpointer,
-    KeepLastNCheckpoints, MetricCheckpointingStrategy,
+    AsyncCheckpointer, Checkpoint, Checkpointer, CheckpointingStrategy,
+    ComposedCheckpointingStrategy, FileCheckpointer, KeepLastNCheckpoints,
+    MetricCheckpointingStrategy,
 };
 use crate::components::{InferenceModelOutput, TrainingModelOutput};
 use crate::learner::EarlyStoppingStrategy;
@@ -24,8 +25,10 @@ use crate::{
 use crate::{Learner, SupervisedLearningStrategy};
 use burn_core::data::dataloader::DataLoader;
 use burn_core::module::{AutodiffModule, Module};
+use burn_core::store::ModuleRecord;
 use burn_core::tensor::Device;
-use burn_optim::lr_scheduler::LrScheduler;
+use burn_optim::OptimizerRecord;
+use burn_optim::lr_scheduler::{LrScheduler, LrSchedulerRecord};
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -314,7 +317,7 @@ impl<LC: LearningComponentsTypes> SupervisedTraining<LC> {
 
     /// Register a checkpointer that will save the [optimizer](burn_optim::ModuleOptimizer), the
     /// [model](AutodiffModule) and the [scheduler](LrScheduler) to separate burnpack files.
-    pub fn with_checkpointer(mut self) -> Self {
+    pub fn with_default_checkpointers(mut self) -> Self {
         let checkpoint_dir = self.directory.join("checkpoint");
         let checkpointer_model = FileCheckpointer::new(&checkpoint_dir, "model");
         let checkpointer_optimizer = FileCheckpointer::new(&checkpoint_dir, "optim");
@@ -324,6 +327,28 @@ impl<LC: LearningComponentsTypes> SupervisedTraining<LC> {
             AsyncCheckpointer::new(checkpointer_model),
             AsyncCheckpointer::new(checkpointer_optimizer),
             AsyncCheckpointer::new(checkpointer_scheduler),
+        ));
+
+        self
+    }
+
+    /// Register your own checkpointers that will save the [optimizer](burn_optim::ModuleOptimizer), the
+    /// [model](AutodiffModule) and the [scheduler](LrScheduler) to separate burnpack files.
+    pub fn with_custom_checkpointers<CM, CO, CL>(
+        mut self,
+        module_checkpointer: CM,
+        optimizer_checkpointer: CO,
+        lr_checkpointer: CL,
+    ) -> Self
+    where
+        CM: Checkpointer<ModuleRecord> + 'static,
+        CO: Checkpointer<OptimizerRecord> + 'static,
+        CL: Checkpointer<LrSchedulerRecord> + 'static,
+    {
+        self.checkpointers = Some((
+            AsyncCheckpointer::new(module_checkpointer),
+            AsyncCheckpointer::new(optimizer_checkpointer),
+            AsyncCheckpointer::new(lr_checkpointer),
         ));
 
         self

--- a/crates/burn-vision/tests/common/mod.rs
+++ b/crates/burn-vision/tests/common/mod.rs
@@ -5,22 +5,14 @@ use image::{DynamicImage, ImageBuffer, Luma, Rgb};
 
 use burn_core::tensor::{Bool, Int};
 
-#[allow(unused)]
-#[cfg(all(
-    test,
-    feature = "flex",
-    not(any(
-        feature = "wgpu",
-        feature = "vulkan",
-        feature = "metal",
-        feature = "webgpu",
-        feature = "cuda",
-        feature = "rocm",
-        feature = "cpu",
-        feature = "tch"
-    ))
-))]
-pub type TestDevice = burn_core::backend::FlexDevice;
+#[cfg(all(test, feature = "cuda"))]
+pub type TestDevice = burn_core::backend::CudaDevice;
+
+#[cfg(all(test, feature = "rocm", not(feature = "cuda")))]
+pub type TestDevice = burn_core::backend::RocmDevice;
+
+#[cfg(all(test, feature = "tch", not(any(feature = "cuda", feature = "rocm"))))]
+pub type TestDevice = burn_core::backend::LibTorchDevice;
 
 #[cfg(all(
     test,
@@ -29,21 +21,42 @@ pub type TestDevice = burn_core::backend::FlexDevice;
         feature = "vulkan",
         feature = "metal",
         feature = "webgpu"
-    )
+    ),
+    not(any(feature = "cuda", feature = "rocm", feature = "tch"))
 ))]
 pub type TestDevice = burn_core::backend::WgpuDevice;
 
-#[cfg(all(test, feature = "cuda"))]
-pub type TestDevice = burn_core::backend::CudaDevice;
-
-#[cfg(all(test, feature = "cpu"))]
+#[cfg(all(
+    test,
+    feature = "cpu",
+    not(any(
+        feature = "cuda",
+        feature = "rocm",
+        feature = "tch",
+        feature = "wgpu",
+        feature = "vulkan",
+        feature = "metal",
+        feature = "webgpu"
+    ))
+))]
 pub type TestDevice = burn_core::backend::CpuDevice;
 
-#[cfg(all(test, feature = "rocm"))]
-pub type TestDevice = burn_core::backend::RocmDevice;
-
-#[cfg(all(test, feature = "tch"))]
-pub type TestDevice = burn_core::backend::LibTorchDevice;
+#[allow(unused)]
+#[cfg(all(
+    test,
+    feature = "flex",
+    not(any(
+        feature = "cuda",
+        feature = "rocm",
+        feature = "tch",
+        feature = "wgpu",
+        feature = "vulkan",
+        feature = "metal",
+        feature = "webgpu",
+        feature = "cpu"
+    ))
+))]
+pub type TestDevice = burn_core::backend::FlexDevice;
 
 pub use burn_core::tensor::Tensor;
 pub type TestTensorInt<const D: usize> = Tensor<D, Int>;

--- a/examples/custom-image-dataset/src/training.rs
+++ b/examples/custom-image-dataset/src/training.rs
@@ -107,7 +107,7 @@ pub fn train(config: TrainingConfig, device: Device) {
         .metric_valid_numeric(AccuracyMetric::new())
         .metric_train_numeric(LossMetric::new())
         .metric_valid_numeric(LossMetric::new())
-        .with_checkpointer()
+        .with_default_checkpointers()
         .num_epochs(config.num_epochs)
         .summary();
 

--- a/examples/custom-learning-strategy/src/training.rs
+++ b/examples/custom-learning-strategy/src/training.rs
@@ -95,7 +95,7 @@ pub fn run(device: Device) {
 
     let training = SupervisedTraining::new(ARTIFACT_DIR, dataloader_train, dataloader_valid)
         .metrics((AccuracyMetric::new(), LossMetric::new()))
-        .with_checkpointer()
+        .with_default_checkpointers()
         .early_stopping(early_stopping)
         .num_epochs(config.num_epochs)
         .summary()

--- a/examples/guide/src/training.rs
+++ b/examples/guide/src/training.rs
@@ -96,7 +96,7 @@ pub fn train(artifact_dir: &str, config: TrainingConfig, device: impl Into<Devic
 
     let training = SupervisedTraining::new(artifact_dir, dataloader_train, dataloader_test)
         .metrics((AccuracyMetric::new(), LossMetric::new()))
-        .with_checkpointer()
+        .with_default_checkpointers()
         .num_epochs(config.num_epochs)
         .summary();
 

--- a/examples/mnist/src/training.rs
+++ b/examples/mnist/src/training.rs
@@ -97,7 +97,7 @@ pub fn run(device: Device) {
     let training = SupervisedTraining::new(ARTIFACT_DIR, dataloader_train, dataloader_valid)
         .metrics((AccuracyMetric::new(), LossMetric::new()))
         .metric_train_numeric(LearningRateMetric::new())
-        .with_checkpointer()
+        .with_default_checkpointers()
         .early_stopping(MetricEarlyStoppingStrategy::new(
             &LossMetric::new(),
             Aggregate::Mean,

--- a/examples/simple-regression/src/training.rs
+++ b/examples/simple-regression/src/training.rs
@@ -70,7 +70,7 @@ pub fn run(artifact_dir: &str, device: impl Into<Device>) {
     let training = SupervisedTraining::new(artifact_dir, dataloader_train, dataloader_test)
         .metric_train_numeric(LossMetric::new())
         .metric_valid_numeric(LossMetric::new())
-        .with_checkpointer()
+        .with_default_checkpointers()
         .num_epochs(config.num_epochs)
         .summary();
 

--- a/examples/text-classification/src/training.rs
+++ b/examples/text-classification/src/training.rs
@@ -97,7 +97,7 @@ pub fn train<D: TextClassificationDataset + 'static>(
         .metric_train_numeric(AccuracyMetric::new())
         .metric_valid_numeric(AccuracyMetric::new())
         .metric_train_numeric(LearningRateMetric::new())
-        .with_checkpointer()
+        .with_default_checkpointers()
         .with_training_strategy(strategy.into())
         .num_epochs(config.num_epochs)
         .summary();

--- a/examples/text-generation/src/training.rs
+++ b/examples/text-generation/src/training.rs
@@ -77,7 +77,7 @@ pub fn train<D: Dataset<TextGenerationItem> + 'static>(
         .metric_train(LossMetric::new())
         .metric_valid(LossMetric::new())
         .metric_train_numeric(LearningRateMetric::new())
-        .with_checkpointer()
+        .with_default_checkpointers()
         .grads_accumulation(accum)
         .num_epochs(config.num_epochs)
         .summary();


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

- None

### Changes

- **Added new methods for custom Checkpointers:** Introduced new capabilities to support custom checkpointers within the SDK.

- **Fixed compilation errors in the burn-vision crate:** Adjusted how dependencies are declared to resolve an error caused by a duplicate struct declaration.

- **Fixed compilation errors in the burn-store crate:** Updated how the macro defines methods and removed the obsolete `zero_copy()` method.

### Testing

- Ran `cargo test` successfully.