### PR TITLE
fix(audit): update quinn-proto version in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7174,9 +7174,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Fixes audit failure on main

```
  Command line: cargo audit -q --color always
  error: 1 vulnerability found!
  Crate:     quinn-proto
  Version:   0.11.14
  Title:      Remote memory exhaustion in quinn-proto from unbounded out-of-order stream reassembly
  Date:      2026-06-22
  ID:        RUSTSEC-2026-0185
  URL:       https://rustsec.org/advisories/RUSTSEC-2026-0185
  Severity:  7.5 (high)
  Solution:  Upgrade to >=0.11.15
  
  Error: Audit check execution failed (exit status: 1)
  Error: Process completed with exit code 1.
```

### Changes

Update `quinn-proto` to 0.11.15