### PR TITLE
QR decomposition

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -432,6 +432,7 @@ strategies.
 | `linalg::l2_norm(tensor, dim)`                     | _No direct equivalent_                              |
 | `linalg::lp_norm(tensor, p, dim)`                  | _No direct equivalent_                              |
 | `linalg::lu(tensor)`                               | `torch.linalg.lu(tensor)`                           |
+| `linalg::qr(tensor)`                               | `torch.linalg.qr(tensor)`                           |
 | `linalg::matvec(matrix, vector)`                   | `torch.matmul(matrix, vector)` / `@` operator       |
 | `linalg::max_abs_norm(tensor, dim)`                | _No direct equivalent_                              |
 | `linalg::min_abs_norm(tensor, dim)`                | _No direct equivalent_                              |

--- a/crates/burn-backend-tests/tests/tensor/float/linalg/mod.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/linalg/mod.rs
@@ -6,5 +6,6 @@ pub(crate) mod diag;
 pub(crate) mod lu;
 pub(crate) mod matvec;
 pub(crate) mod outer;
+pub(crate) mod qr;
 pub(crate) mod trace;
 pub(crate) mod vector_norm;

--- a/crates/burn-backend-tests/tests/tensor/float/linalg/qr.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/linalg/qr.rs
@@ -1,0 +1,466 @@
+use super::*;
+use burn_tensor::{Distribution, Tolerance, linalg::qr, s};
+
+const REL: f32 = 5e-3;
+const ABS: f32 = 1e-3;
+
+// ---------------------------------------------------------------------
+// Small Matrices
+// ---------------------------------------------------------------------
+
+#[test]
+fn test_qr_1x1() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::from_data([[5.0]], &device);
+    let (q, r) = qr::<2>(tensor.clone(), false);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_2x2() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::from_data([[4.0, 3.0], [6.0, 3.0]], &device);
+    let (q, r) = qr::<2>(tensor.clone(), false);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_3x3() {
+    let device = Default::default();
+    let tensor =
+        TestTensor::<2>::from_data([[4.0, 7.0, 3.0], [6.0, 1.0, 3.0], [8.0, 3.0, 7.0]], &device);
+    let (q, r) = qr::<2>(tensor.clone(), false);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_identity_matrix() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::from_data([[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]], &device);
+    let (q, r) = qr::<2>(tensor.clone(), false);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_zero_matrix() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::from_data([[0., 0., 0.], [0., 0., 0.], [0., 0., 0.]], &device);
+    let (q, r) = qr::<2>(tensor.clone(), false);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_singular_maxtrix() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::from_data(
+        [
+            [0.0, 4.0, 2.0, 6.0],
+            [0.0, 2.0, 2.0, 11.0],
+            [0.0, 3.0, 9.0, 6.0],
+            [0.0, 7.0, 10.0, 9.0],
+        ],
+        &device,
+    );
+    let (q, r) = qr::<2>(tensor.clone(), false);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_identity_singular_maxtrix() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::ones([4, 4], &device);
+    let (q, r) = qr::<2>(tensor.clone(), false);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_v0_zero() {
+    let device = Default::default();
+    let tensor =
+        TestTensor::<2>::from_data([[0.0, 4.0, 2.0], [1.0, 2.0, 2.0], [2.0, 3.0, 9.0]], &device);
+    let (q, r) = qr::<2>(tensor.clone(), false);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_diagonilized_col() {
+    let device = Default::default();
+    let tensor =
+        TestTensor::<2>::from_data([[1.0, 4.0, 2.0], [0.0, 2.0, 2.0], [0.0, 3.0, 9.0]], &device);
+    let (q, r) = qr::<2>(tensor.clone(), false);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_5x5_reduced_shape() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::ones([5, 5], &device);
+    let (q, r) = qr::<2>(tensor.clone(), true);
+    assert_eq!(q.dims(), [5, 5]);
+    assert_eq!(r.dims(), [5, 5]);
+}
+
+#[test]
+fn test_qr_10x5_reduced_shape() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::ones([10, 5], &device);
+    let (q, r) = qr::<2>(tensor.clone(), true);
+    assert_eq!(q.dims(), [10, 5]);
+    assert_eq!(r.dims(), [5, 5]);
+}
+
+#[test]
+fn test_qr_5x10_reduced_shape() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::ones([5, 10], &device);
+    let (q, r) = qr::<2>(tensor.clone(), true);
+    assert_eq!(q.dims(), [5, 5]);
+    assert_eq!(r.dims(), [5, 10]);
+}
+
+#[test]
+fn test_qr_2d_square() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::random([6, 6], Distribution::Default, &device);
+    let (q, r) = qr::<2>(tensor.clone(), false);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_2d_square_reduced() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::random([6, 6], Distribution::Default, &device);
+    let (q, r) = qr::<2>(tensor.clone(), true);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_2d_tall() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::random([8, 5], Distribution::Default, &device);
+    let (q, r) = qr::<2>(tensor.clone(), false);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_2d_tall_reduced() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::random([8, 5], Distribution::Default, &device);
+    let (q, r) = qr::<2>(tensor.clone(), false);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_singular_2d_tall() {
+    let device = Default::default();
+    let zeros = TestTensor::<2>::zeros([8, 1], &device);
+    let mut tensor = TestTensor::<2>::random([8, 5], Distribution::Default, &device);
+    tensor = tensor.slice_assign(s![.., 0..1], zeros);
+    let (q, r) = qr::<2>(tensor.clone(), false);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_singular_2d_tall_reduces() {
+    let device = Default::default();
+    let zeros = TestTensor::<2>::zeros([8, 1], &device);
+    let mut tensor = TestTensor::<2>::random([8, 5], Distribution::Default, &device);
+    tensor = tensor.slice_assign(s![.., 0..1], zeros);
+    let (q, r) = qr::<2>(tensor.clone(), false);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_2d_wide() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::random([5, 8], Distribution::Default, &device);
+    let (q, r) = qr::<2>(tensor.clone(), false);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_2d_wide_reduced() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::random([5, 8], Distribution::Default, &device);
+    let (q, r) = qr::<2>(tensor.clone(), true);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_singular_2d_wide() {
+    let device = Default::default();
+    let zeros = TestTensor::<2>::zeros([5, 1], &device);
+    let mut tensor = TestTensor::<2>::random([5, 8], Distribution::Default, &device);
+    tensor = tensor.slice_assign(s![.., 0..1], zeros);
+    let (q, r) = qr::<2>(tensor.clone(), false);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_singular_2d_wide_reduced() {
+    let device = Default::default();
+    let zeros = TestTensor::<2>::zeros([5, 1], &device);
+    let mut tensor = TestTensor::<2>::random([5, 8], Distribution::Default, &device);
+    tensor = tensor.slice_assign(s![.., 0..1], zeros);
+    let (q, r) = qr::<2>(tensor.clone(), true);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_medium_tall() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::random([256, 128], Distribution::Default, &device);
+    let (q, r) = qr::<2>(tensor.clone(), false);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_medium_wide() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::random([128, 256], Distribution::Default, &device);
+    let (q, r) = qr::<2>(tensor.clone(), false);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_500x500() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::random([128, 256], Distribution::Default, &device);
+    let (q, r) = qr::<2>(tensor.clone(), false);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_500x300() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::random([128, 256], Distribution::Default, &device);
+    let (q, r) = qr::<2>(tensor.clone(), false);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_300x500() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::random([128, 256], Distribution::Default, &device);
+    let (q, r) = qr::<2>(tensor.clone(), false);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+// ---------------------------------------------------------------------
+// 3D Tensors (1 batch dimension)
+// ---------------------------------------------------------------------
+
+#[test]
+fn test_qr_3d_square() {
+    let device = Default::default();
+    let tensor = TestTensor::<3>::random([3, 6, 6], Distribution::Default, &device);
+    let (q, r) = qr::<3>(tensor.clone(), false);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_3d_tall() {
+    let device = Default::default();
+    let tensor = TestTensor::<3>::random([3, 8, 5], Distribution::Default, &device);
+    let (q, r) = qr::<3>(tensor.clone(), false);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_3d_wide() {
+    let device = Default::default();
+    let tensor = TestTensor::<3>::random([3, 5, 8], Distribution::Default, &device);
+    let (q, r) = qr::<3>(tensor.clone(), false);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_3d_8x6_reduced_shape() {
+    let device = Default::default();
+    let tensor = TestTensor::<3>::random([3, 8, 6], Distribution::Default, &device);
+    let (q, r) = qr::<3>(tensor.clone(), true);
+    assert_eq!(q.dims(), [3, 8, 6]);
+    assert_eq!(r.dims(), [3, 6, 6]);
+}
+
+// ---------------------------------------------------------------------
+// 4D Tensors (2 batch dimensions)
+// ---------------------------------------------------------------------
+
+#[test]
+fn test_qr_4d_square() {
+    let device = Default::default();
+    let tensor = TestTensor::<4>::random([2, 2, 6, 6], Distribution::Default, &device);
+    let (q, r) = qr::<4>(tensor.clone(), false);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_4d_square_with_singularities() {
+    let device = Default::default();
+    let ones = TestTensor::<4>::ones([1, 1, 6, 6], &device);
+    let mut tensor = TestTensor::<4>::random([2, 2, 6, 6], Distribution::Default, &device);
+    tensor = tensor.slice_assign(s![0..1, 0..1, .., ..], ones.clone());
+    tensor = tensor.slice_assign(s![2..3, 1..2, .., ..], ones.clone());
+    let (q, r) = qr::<4>(tensor.clone(), false);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_4d_tall() {
+    let device = Default::default();
+    let tensor = TestTensor::<4>::random([2, 2, 8, 5], Distribution::Default, &device);
+    let (q, r) = qr::<4>(tensor.clone(), false);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_4d_tall_with_singularities() {
+    let device = Default::default();
+    let ones = TestTensor::<4>::ones([1, 1, 8, 5], &device);
+    let mut tensor = TestTensor::<4>::random([2, 2, 8, 5], Distribution::Default, &device);
+    tensor = tensor.slice_assign(s![0..1, 0..1, .., ..], ones.clone());
+    tensor = tensor.slice_assign(s![2..3, 1..2, .., ..], ones.clone());
+    let (q, r) = qr::<4>(tensor.clone(), false);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_4d_wide() {
+    let device = Default::default();
+    let tensor = TestTensor::<4>::random([2, 2, 5, 8], Distribution::Default, &device);
+    let (q, r) = qr::<4>(tensor.clone(), false);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_4d_wide_with_singularities() {
+    let device = Default::default();
+    let ones = TestTensor::<4>::ones([1, 1, 5, 8], &device);
+    let mut tensor = TestTensor::<4>::random([2, 2, 5, 8], Distribution::Default, &device);
+    tensor = tensor.slice_assign(s![0..1, 0..1, .., ..], ones.clone());
+    tensor = tensor.slice_assign(s![2..3, 1..2, .., ..], ones.clone());
+    let (q, r) = qr::<4>(tensor.clone(), false);
+    let qr = q.matmul(r);
+    let tolerance = Tolerance::rel_abs(REL, ABS).set_half_precision_absolute(5e-2);
+    qr.into_data()
+        .assert_approx_eq::<FloatElem>(&tensor.into_data(), tolerance);
+}
+
+#[test]
+fn test_qr_4d_12x4_reduced_shape() {
+    let device = Default::default();
+    let tensor = TestTensor::<4>::random([2, 3, 12, 4], Distribution::Default, &device);
+    let (q, r) = qr::<4>(tensor.clone(), true);
+    assert_eq!(q.dims(), [2, 3, 12, 4]);
+    assert_eq!(r.dims(), [2, 3, 4, 4]);
+}
+
+// ---------------------------------------------------------------------
+// Tensor Check Panics
+// ---------------------------------------------------------------------
+
+#[test]
+#[should_panic]
+fn test_qr_panic_rank_less_than_2() {
+    // Fails check: D >= 2
+    let device = Default::default();
+    let tensor = TestTensor::<1>::from_data([1.0, 2.0, 3.0], &device);
+    let _ = qr::<1>(tensor, false);
+}

--- a/crates/burn-core/src/module/initializer.rs
+++ b/crates/burn-core/src/module/initializer.rs
@@ -2,11 +2,11 @@ use crate::tensor::Shape;
 
 use crate::config::Config;
 use crate::module::{Param, ParamId};
-use crate::tensor::{Distribution, Tensor, s};
+use crate::tensor::{Distribution, Tensor};
 
 use crate as burn;
 
-use burn_tensor::Device;
+use burn_tensor::{Device, linalg};
 #[cfg(not(feature = "std"))]
 #[allow(unused_imports)]
 use num_traits::Float as _;
@@ -178,7 +178,7 @@ impl Initializer {
                     t = t.transpose();
                 }
 
-                let (q, r) = qr_decomposition(t, device);
+                let (q, r) = linalg::qr(t, true);
                 let [r_rows, r_cols] = r.clone().dims();
 
                 let diag_r = Tensor::<2>::ones([1, r_rows], device)
@@ -242,48 +242,6 @@ fn normal_draw<const D: usize, S: Into<Shape>>(
 ) -> Tensor<D> {
     let distribution = Distribution::Normal(mean, std);
     Tensor::<D>::random(shape, distribution, device)
-}
-
-fn qr_decomposition(a: Tensor<2>, device: &Device) -> (Tensor<2>, Tensor<2>) {
-    // Calculate the QR decomposition using Gram-Schmidt-process: https://en.wikipedia.org/wiki/Gram%E2%80%93Schmidt_process
-
-    let [m, n] = a.clone().dims();
-    let mut q = Tensor::<2>::zeros([m, n], device);
-    let mut r = Tensor::<2>::zeros([n, n], device);
-
-    for j in 0..n {
-        let mut v: Tensor<1> = a.clone().slice(s![.., j..=j]).squeeze_dim(1);
-
-        for i in 0..j {
-            let q_i: Tensor<1> = q.clone().slice(s![.., i..=i]).squeeze_dim(1);
-            let r_ij = q_i.clone().mul(v.clone()).sum();
-
-            r = r
-                .clone()
-                .slice_assign([i..i + 1, j..j + 1], r_ij.clone().unsqueeze());
-
-            v = v - q_i.mul(r_ij);
-        }
-
-        // norm of v
-        let r_jj = v
-            .clone()
-            .powf(Tensor::from_floats([2.0], device))
-            .sum()
-            .sqrt();
-
-        r = r
-            .clone()
-            .slice_assign([j..j + 1, j..j + 1], r_jj.clone().unsqueeze());
-
-        let q_j = v / r_jj;
-
-        q = q
-            .clone()
-            .slice_assign([0..m, j..j + 1], q_j.unsqueeze_dim(1));
-    }
-
-    (q, r)
 }
 
 #[cfg(test)]
@@ -525,27 +483,6 @@ mod tests {
         let _: Tensor<2> = Initializer::XavierUniform { gain }
             .init([fan_out, fan_in], &device)
             .into_value();
-    }
-
-    #[test]
-    fn test_qr_decomposition() {
-        let device = test_device();
-        device.seed(0);
-
-        // test values follow the example from https://pytorch.org/docs/stable/generated/torch.linalg.qr.html#torch.linalg.qr
-        let a = Tensor::<2>::from_floats(
-            [[12., -51., 4.], [6., 167., -68.], [-4., 24., -41.]],
-            &device,
-        );
-        let qr = qr_decomposition(a.clone(), &device);
-
-        // Q @ R should reconstruct input `a`
-        let q_matmul_r = qr.0.clone().matmul(qr.1.clone());
-
-        // assert that the difference between input (`a`) and Q @ R is (almost) zero
-        q_matmul_r
-            .into_data()
-            .assert_approx_eq::<FT>(&a.into_data(), Tolerance::rel_abs(0.1, 0.1));
     }
 
     #[test]

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -1521,6 +1521,11 @@ impl TensorCheck {
         check
     }
 
+    /// Check if input tensor for qr decomposition is valid
+    pub fn qr_input_tensor<const D: usize>(ops: &str, dims: &[usize], dtype: DType) -> Self {
+        Self::lu_input_tensor::<D>(ops, dims, dtype)
+    }
+
     /// Check if input tensor and generic parameters of `linalg::det()` are valid.
     pub fn det<const D: usize, const D1: usize, const D2: usize>(
         dims: [usize; D],

--- a/crates/burn-tensor/src/tensor/linalg/mod.rs
+++ b/crates/burn-tensor/src/tensor/linalg/mod.rs
@@ -4,6 +4,7 @@ mod diag;
 mod lu;
 mod matvec;
 mod outer;
+mod qr;
 mod trace;
 mod vector_norm;
 
@@ -13,5 +14,6 @@ pub use diag::*;
 pub use lu::*;
 pub use matvec::*;
 pub use outer::*;
+pub use qr::*;
 pub use trace::*;
 pub use vector_norm::*;

--- a/crates/burn-tensor/src/tensor/linalg/qr.rs
+++ b/crates/burn-tensor/src/tensor/linalg/qr.rs
@@ -1,0 +1,129 @@
+use crate::{Tensor, check, check::TensorCheck, linalg::l2_norm, s};
+use alloc::vec;
+use burn_std::Slice;
+
+/// Computes the QR decomposition of a square or rectangular matrix using Householder reflections.
+///
+/// This function decomposes the input tensor A into two tensors Q, R
+/// such that A = QR, where Q is an orthonormal matrix and R is an upper triangular matrix.
+/// If `reduced` is true then it returns reduced Q, R.
+/// The reduced QR decomposition agrees with the full QR decomposition when n_cols >= n_rows (wide matrix).
+///
+/// # Arguments
+/// - `tensor` - The input tensor of shape `[..., n_rows, n_cols]`.
+/// - `reduced` - The bool value
+///
+/// # Returns
+/// A tuple of two tensors `(Q, R)`:
+/// - `Q` - The orthonormal tensor of shape `[..., n_rows, n_rows]` in case of `n_cols >= n_rows` or `reduced=false` otherwise `[..., n_rows, n_cols]`
+/// - `R` - The upper triangular tensor of shape `[..., n_rows, n_cols]` in case of `n_cols >= n_rows` or `reduced=false` otherwise `[..., n_cols, n_cols]`
+///
+/// # Generic Parameters
+///
+/// - `D`: The number of dimensions of the input tensor.
+///
+/// # Panics
+/// This function will panic if the tensor checks fail:
+/// - The input tensor has less than 2 dimensions (`D < 2`).
+/// - The input is a quantized tensor with dtype `DType::QFloat`.
+///
+/// # Example
+/// ```rust,ignore
+/// use burn::tensor::Tensor;
+/// use burn::backend::Flex;
+/// use burn::tensor::linalg;
+///
+/// fn example() {
+///     let device = Default::default();
+///     let tensor = Tensor::<2>::from_data([[3.0, 2.0], [4.0, 6.0]], &device);
+///
+///     // Compute Q, R
+///     let (q, r) = linalg::qr::<2>(tensor);
+///
+///     // Expected Output:
+///     // q: [[-0.6, 0.8],
+///     //     [-0.8, -0.6]]
+///     //
+///     // r: [[-5.0, -6.0],
+///     //     [0.0, -2.0]]
+/// }
+/// ```
+pub fn qr<const D: usize>(tensor: Tensor<D>, reduced: bool) -> (Tensor<D>, Tensor<D>) {
+    let dims = tensor.dims();
+    let original_dtype = tensor.dtype();
+    check!(TensorCheck::qr_input_tensor::<D>(
+        "linalg::qr",
+        &dims,
+        original_dtype
+    ));
+
+    let device = tensor.device();
+    let (n_rows, n_cols) = (dims[D - 2], dims[D - 1]);
+
+    let max_iters = n_rows.min(n_cols);
+    let mut r = tensor.clone();
+
+    // Create tensor for storing Q
+    let identity: Tensor<2> = Tensor::eye(n_rows, &device);
+    let mut reshape_dims = [1; D];
+    reshape_dims[D - 2] = n_rows;
+    reshape_dims[D - 1] = n_rows;
+    let reshaped_identity = identity.reshape(reshape_dims);
+    let mut expand_dims = [n_rows; D];
+    expand_dims[..(D - 2)].copy_from_slice(&dims[..(D - 2)]);
+    let mut q = reshaped_identity.expand(expand_dims);
+
+    let mut slices = vec![Slice::full(); D];
+    for i in 0..max_iters {
+        let sub_tensor = r
+            .clone()
+            .slice_dim(D - 2, s![i..])
+            .slice_dim(D - 1, s![i..]);
+        let v = sub_tensor.clone().slice_dim(D - 1, 0..1);
+        let v0 = v.clone().slice_dim(D - 2, s![0]);
+        let zeros = v0.clone().zeros_like();
+        let norm_v = l2_norm(v.clone().slice_dim(D - 2, s![..]), D - 2);
+
+        // removing zeros from the sign
+        let sign = -v0.clone().sign();
+        let mask = sign.clone().is_close(zeros.clone(), None, None);
+        let sign = sign.mask_fill(mask, -1.0);
+
+        // if norm_v==0, the vector w has to be zero and no reflection is applied
+        let u0 = v0.clone().sub(norm_v.clone().mul(sign.clone()));
+
+        let mask = norm_v.clone().is_close(zeros.clone(), None, None);
+        let mut tau = -u0.clone().div(norm_v.clone()).mul(sign.clone());
+        tau = tau.clone().mask_fill(mask.clone(), 0.0);
+
+        let e0 = v0.clone().mul_scalar(0.0).add_scalar(1.0);
+        let mut w = v.clone().div(u0.clone());
+        slices[D - 2] = s![0];
+        w = w.slice_assign(&slices, e0.clone());
+        w = w.clone().mask_fill(mask, 0.0);
+
+        // a closure to calculate tau*(w,w^{T} A)
+        let f = |a: Tensor<D>| -> Tensor<D> {
+            let aw = a.matmul(w.clone()).mul(tau.clone());
+            w.clone().matmul(aw.transpose())
+        };
+
+        slices[D - 2] = s![i..];
+        slices[D - 1] = s![i..];
+        r = r.slice_assign(&slices, sub_tensor.clone() - f(sub_tensor.transpose()));
+
+        slices[D - 2] = Slice::full();
+        let q_sub_tensor = q.clone().slice(&slices);
+        q = q.slice_assign(&slices, q_sub_tensor.clone() - f(q_sub_tensor).transpose());
+
+        slices[D - 1] = Slice::full();
+    }
+    if reduced & (n_rows > n_cols) {
+        slices[D - 1] = s![0..n_cols];
+        let result_q = q.clone().slice(&slices);
+        slices[D - 2] = s![0..n_cols];
+        let result_r = r.clone().slice(&slices);
+        return (result_q, result_r);
+    }
+    (q, r)
+}


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs
Linear algebra operations: #1538 

### Changes

- Add QR decomposition (Householder reflection) with reduced form support in `crates/burn-tensor/src/tensor/linalg/`. 
- Add numerical and generic parameters (copied from LU decomposition tests) tests.
- Removed QR decomposition (Gram–Schmidt process) from `crates/burn-core/src/module/initializer.rs`

### Testing

_Describe how these changes have been tested._

- `cargo run-checks`
- Multiple numerical tests with predefined and random matrices. The tests include square, tall, wide, singular matrices, batches of matrices, and several special cases. The tests check the tolerance between the original tensor and the product of its QR decomposition.
- Tests for panic situations.
- Dimensions/shape tests for `reduced=true`

P.S. It may be worth adding tests for the orthonormality of `Q` and the upper-triangular property of `R`.
