### PR TITLE
perf(remote): materialize tensor readback off the shared runtime

### DIFF
--- a/crates/burn-remote/src/server/worker.rs
+++ b/crates/burn-remote/src/server/worker.rs
@@ -31,9 +31,11 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
+use burn_backend::ExecutionError;
 use burn_communication::{Protocol, external_comm::ExternalCommService};
 use burn_ir::{BackendIr, GraphId};
 use burn_router::{Graph, TensorInterpreter};
+use burn_std::{AllocationProperty, Reader};
 use tokio::{runtime::Handle, sync::mpsc};
 
 use crate::metrics::{MetricSide, TrafficMetrics};
@@ -337,7 +339,27 @@ where
                 let fut = stream_id.executes(|| self.runner.read_tensor_async(tensor));
                 let sender = self.response_sender.clone();
                 tokio::spawn(async move {
-                    let data = fut.await;
+                    // `read_tensor_async` may hand back *lazy* device-backed bytes whose GPU→host
+                    // copy is deferred to first access. Left lazy, that copy runs inside
+                    // `rmp_serde::to_vec` on the fetch handler — an async task on the shared
+                    // runtime — where a synchronous read pins a runtime worker for the whole copy
+                    // and starves op delivery under concurrent reads. Force the copy here on the
+                    // blocking pool instead, so the fetch handler only serializes resident host
+                    // bytes and the shared runtime's workers stay free. A no-op for backends whose
+                    // read is already host-resident (the property check skips the copy).
+                    let data = match fut.await {
+                        Ok(data) => tokio::task::spawn_blocking(move || {
+                            if data.bytes.property() == AllocationProperty::Device {
+                                let _ = data.bytes.read(Reader::new());
+                            }
+                            data
+                        })
+                        .await
+                        .map_err(|err| ExecutionError::WithContext {
+                            reason: format!("readback materialization task failed: {err}"),
+                        }),
+                        Err(err) => Err(err),
+                    };
                     if sender
                         .send(TaskResponse {
                             content: TaskResponseContent::ReadTensor(data),


### PR DESCRIPTION
The server's `Task::ReadTensor` returns a `TensorData` whose device-backed bytes are read lazily — the GPU→host copy is deferred to first access. Left lazy, that access happens inside `rmp_serde::to_vec` on the fetch handler, an async task on the shared runtime, where the synchronous read pins a runtime worker for the whole copy. With several devices reading concurrently this starves the submit handlers that deliver ops, draining device queues into bubbles and costing GPU utilization even across devices that share no work.

Force the copy on the blocking pool (`spawn_blocking`) in the already-detached readback task, so the fetch handler only serializes resident host bytes and the shared runtime's workers stay free. No-op for backends whose read is already host-resident — the allocation-property check skips the copy.

In a local multi-device read-contention benchmark (8 sessions reading frequently) this removes the runtime-worker-count sensitivity: wall-clock stays flat across worker counts instead of scaling with readers/workers (e.g. ~2x faster at a constrained worker count).