### PR TITLE
feat(autodiff): implement prod and prod_dim

### DIFF
--- a/crates/burn-autodiff/src/ops/tensor.rs
+++ b/crates/burn-autodiff/src/ops/tensor.rs
@@ -2020,6 +2020,95 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
         }
     }
 
+    fn float_prod(tensor: FloatTensor<Self>) -> FloatTensor<Self> {
+        #[derive(Debug)]
+        struct Prod;
+
+        impl<B: Backend> Backward<B, 1> for Prod {
+            // Saves the input and the output product so backward can compute
+            // `grad * prod(x) / x` without recomputing the reduction.
+            type State = (B::FloatTensorPrimitive, B::FloatTensorPrimitive);
+
+            fn backward(
+                self,
+                ops: Ops<Self::State, 1>,
+                grads: &mut Gradients,
+                _checkpointer: &mut Checkpointer,
+            ) {
+                let (input, output) = ops.state;
+
+                unary::<B, _>(ops.parents, ops.node, grads, |grad| {
+                    // d/dx_i prod(x) = prod(x) / x_i, so grad_input = grad * output / input,
+                    // broadcast over the input shape (output is a single-element tensor).
+                    //
+                    // This divides by the input, so it produces NaN gradients when the
+                    // input contains zeros. A zero-safe version requires the product of
+                    // all other elements via exclusive cumulative products, same as the
+                    // cumprod limitation tracked in https://github.com/tracel-ai/burn/issues/3864.
+                    let ones = B::float_ones(input.shape(), &input.device(), input.dtype().into());
+                    let grad = B::float_mul(grad, output);
+                    let grad = unsqueeze_like::<B>(grad, ones.shape());
+                    let grad = B::float_mul(ones, grad);
+
+                    B::float_div(grad, input)
+                });
+            }
+        }
+
+        match Prod.prepare::<C>([tensor.node]).compute_bound().stateful() {
+            OpsKind::Tracked(prep) => {
+                let output = B::float_prod(tensor.primitive.clone());
+                prep.finish((tensor.primitive, output.clone()), output)
+            }
+            OpsKind::UnTracked(prep) => prep.finish(B::float_prod(tensor.primitive)),
+        }
+    }
+
+    fn float_prod_dim(tensor: FloatTensor<Self>, dim: usize) -> FloatTensor<Self> {
+        #[derive(Debug)]
+        struct ProdDim;
+
+        impl<B: Backend> Backward<B, 1> for ProdDim {
+            // Saves the input and the reduced product (size 1 along `dim`).
+            type State = (B::FloatTensorPrimitive, B::FloatTensorPrimitive);
+
+            fn backward(
+                self,
+                ops: Ops<Self::State, 1>,
+                grads: &mut Gradients,
+                _checkpointer: &mut Checkpointer,
+            ) {
+                let (input, output) = ops.state;
+
+                unary::<B, _>(ops.parents, ops.node, grads, |grad| {
+                    // grad_input = grad * prod_dim(x) / x. The grad and output both keep
+                    // a size-1 reduced dim and broadcast back over the input along `dim`.
+                    //
+                    // Like `float_prod`, this divides by the input and produces NaN
+                    // gradients when the input contains zeros (see
+                    // https://github.com/tracel-ai/burn/issues/3864).
+                    let ones = B::float_ones(input.shape(), &input.device(), input.dtype().into());
+                    let grad = B::float_mul(grad, output);
+                    let grad = B::float_mul(ones, grad);
+
+                    B::float_div(grad, input)
+                });
+            }
+        }
+
+        match ProdDim
+            .prepare::<C>([tensor.node])
+            .compute_bound()
+            .stateful()
+        {
+            OpsKind::Tracked(prep) => {
+                let output = B::float_prod_dim(tensor.primitive.clone(), dim);
+                prep.finish((tensor.primitive, output.clone()), output)
+            }
+            OpsKind::UnTracked(prep) => prep.finish(B::float_prod_dim(tensor.primitive, dim)),
+        }
+    }
+
     fn float_cumsum(tensor: FloatTensor<Self>, dim: usize) -> FloatTensor<Self> {
         #[derive(Debug)]
         struct CumSum;
@@ -3845,9 +3934,6 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
             OpsKind::UnTracked(prep) => prep.finish(B::float_cast(tensor.primitive, dtype)),
         }
     }
-
-    // TODO: Implement float_prod and float_sum
-    // https://github.com/tracel-ai/burn/issues/1458
 
     fn float_unfold(
         tensor: FloatTensor<Self>,

--- a/crates/burn-backend-tests/tests/autodiff/aggregation.rs
+++ b/crates/burn-backend-tests/tests/autodiff/aggregation.rs
@@ -136,3 +136,126 @@ fn should_diff_sum_dim() {
         .to_data()
         .assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
 }
+
+#[test]
+fn should_diff_prod() {
+    let device = AutodiffDevice::new();
+    let tensor =
+        TestTensor::<1>::from_data(TensorData::from([2.0, 3.0, 4.0]), &device).require_grad();
+
+    let output = tensor.clone().prod();
+    let grads = output.backward();
+    let grad = tensor.grad(&grads).unwrap();
+
+    // grad_i = prod(x) / x_i = [24/2, 24/3, 24/4]
+    let expected = TensorData::from([12.0, 8.0, 6.0]);
+    grad.to_data()
+        .assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
+}
+
+#[test]
+fn should_diff_prod_with_negatives() {
+    let device = AutodiffDevice::new();
+    let tensor =
+        TestTensor::<1>::from_data(TensorData::from([2.0, -3.0, 4.0]), &device).require_grad();
+
+    let output = tensor.clone().prod();
+
+    // The forward value keeps its sign. The previous default impl computed
+    // exp(sum(log(x))), which returns NaN for any negative input.
+    output
+        .to_data()
+        .assert_approx_eq::<FloatElem>(&TensorData::from([-24.0]), Tolerance::default());
+
+    let grads = output.backward();
+    let grad = tensor.grad(&grads).unwrap();
+
+    // grad_i = prod(x) / x_i = [-24/2, -24/-3, -24/4]
+    let expected = TensorData::from([-12.0, 8.0, -6.0]);
+    grad.to_data()
+        .assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
+}
+
+#[test]
+fn should_diff_prod_dim() {
+    let device = AutodiffDevice::new();
+    let tensor = TestTensor::<2>::from_data(
+        TensorData::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
+        &device,
+    )
+    .require_grad();
+
+    let output = tensor.clone().prod_dim(1);
+    let grads = output.sum().backward();
+    let grad = tensor.grad(&grads).unwrap();
+
+    // Per row: grad_ij = prod(row_i) / x_ij
+    let expected = TensorData::from([[6.0, 3.0, 2.0], [30.0, 24.0, 20.0]]);
+    grad.to_data()
+        .assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
+}
+
+#[test]
+fn should_diff_prod_dim_with_negatives() {
+    let device = AutodiffDevice::new();
+    let tensor = TestTensor::<2>::from_data(
+        TensorData::from([[1.0, -2.0, 3.0], [-4.0, 5.0, 6.0]]),
+        &device,
+    )
+    .require_grad();
+
+    let output = tensor.clone().prod_dim(0);
+
+    output.clone().to_data().assert_approx_eq::<FloatElem>(
+        &TensorData::from([[-4.0, -10.0, 18.0]]),
+        Tolerance::default(),
+    );
+
+    let grads = output.sum().backward();
+    let grad = tensor.grad(&grads).unwrap();
+
+    // Per column: grad_ij = prod(col_j) / x_ij
+    let expected = TensorData::from([[-4.0, 5.0, 6.0], [1.0, -2.0, 3.0]]);
+    grad.to_data()
+        .assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
+}
+
+// The following tests are ignored due to the same limitation as cumprod: the
+// gradient divides by the input, which produces NaN when the input contains
+// zeros. The true gradient at a zero is finite (the product of the other
+// elements), but recovering it needs the zero-safe exclusive-cumulative-product
+// algorithm tracked in https://github.com/tracel-ai/burn/issues/3864.
+
+#[test]
+#[ignore = "prod gradient with zeros not yet implemented - produces NaN due to division by zero"]
+fn should_diff_prod_single_zero() {
+    let device = AutodiffDevice::new();
+    let tensor =
+        TestTensor::<1>::from_data(TensorData::from([2.0, 0.0, 3.0, 4.0]), &device).require_grad();
+
+    let output = tensor.clone().prod();
+    let grads = output.backward();
+    let grad = tensor.grad(&grads).unwrap();
+
+    // Only the zero slot has a non-zero gradient (product of the others = 24).
+    let expected = TensorData::from([0.0, 24.0, 0.0, 0.0]);
+    grad.to_data()
+        .assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
+}
+
+#[test]
+#[ignore = "prod gradient with zeros not yet implemented - produces NaN due to division by zero"]
+fn should_diff_prod_multiple_zeros() {
+    let device = AutodiffDevice::new();
+    let tensor = TestTensor::<1>::from_data(TensorData::from([2.0, 0.0, 3.0, 0.0, 5.0]), &device)
+        .require_grad();
+
+    let output = tensor.clone().prod();
+    let grads = output.backward();
+    let grad = tensor.grad(&grads).unwrap();
+
+    // Every leave-one-out product still contains a zero, so the gradient is zero.
+    let expected = TensorData::from([0.0, 0.0, 0.0, 0.0, 0.0]);
+    grad.to_data()
+        .assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
+}


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Closes #1458. Shares the zero-gradient limitation already tracked for `cumprod` in #3864.

### Changes

The Autodiff backend never overrode `float_prod`/`float_prod_dim`, so it fell through to
the default implementation in `burn-backend` (`crates/burn-backend/src/backend/ops/tensor.rs`),
which computes the product as `exp(sum(log(x)))`. On the Autodiff path that has two problems:

- `log` is only defined for positive inputs, so `prod` returns `NaN` for any tensor that
  contains a negative value, and the gradient blows up around zeros. The base backends
  compute the real signed product (e.g. `[[1, -2, 3], [5, 9, 6]].prod() == -1620`), so
  `Autodiff<NdArray>` and `NdArray` disagreed on the exact same input.
- It builds three graph nodes (`log -> sum -> exp`), each with its own saved state and
  backward pass, for what is a single reduction.

This PR adds dedicated `float_prod` and `float_prod_dim` ops. The forward calls the backend's
real product, and the backward uses the analytic gradient `grad * prod(x) / x`
(the leave-one-out product). The forward now agrees with the other backends on negatives,
and it is one graph node instead of three. The structure follows the existing `Sum` and
`CumProd` ops in the same file.

Important limitation: the gradient divides by the input, so it returns `NaN` when an element is
exactly zero. This is the same issue `cumprod` already has (#3864). I kept that out as it takes more care and to keep this change focused. Note it is still strictly better than the old default, 
which also produced `NaN` on zeros and additionally on every negative input. The zero cases are covered
by `#[ignore]`d tests carrying the expected reference values, so they are ready to enable
once the zero-safe path lands.

### Testing

Added gradient tests under `crates/burn-backend-tests/tests/autodiff/aggregation.rs`:
`prod`, `prod_dim` over both a trailing and a leading dim, the negative-input cases (which
also assert the forward value), and the `#[ignore]`d single-zero / multiple-zeros cases with
PyTorch reference gradients. Expected values were checked by hand against the leave-one-out
product.

```
cargo test -p burn-backend-tests --test autodiff --features ndarray
cargo fmt --check
cargo clippy -p burn-autodiff --features export_tests
```

All pass; the two zero-input tests are `#[ignore]`d as described above.
