### PR TITLE
Fix checkpointing + minor stuff

### DIFF
--- a/burn-book/src/basic-workflow/training.md
+++ b/burn-book/src/basic-workflow/training.md
@@ -148,6 +148,8 @@ Book.
 Let us move on to establishing the practical training configuration.
 
 ```rust , ignore
+# use std::path::PathBuf;
+#
 # use crate::{
 #     data::{MnistBatch, MnistBatcher},
 #     model::{Model, ModelConfig},
@@ -215,8 +217,7 @@ pub struct TrainingConfig {
 }
 
 fn create_artifact_dir(artifact_dir: &str) {
-    // Remove existing artifacts before to get an accurate learner summary
-    std::fs::remove_dir_all(artifact_dir).ok();
+    std::fs::remove_file(PathBuf::from(artifact_dir).join("experiment.log")).ok();
     std::fs::create_dir_all(artifact_dir).ok();
 }
 

--- a/crates/burn-train/src/checkpoint/strategy/metric.rs
+++ b/crates/burn-train/src/checkpoint/strategy/metric.rs
@@ -97,7 +97,10 @@ mod tests {
         metrics.register_train_metric_numeric(loss);
         let store = Arc::new(EventStoreClient::new(store));
         let mut processor = MinimalEventProcessor::new(metrics, store.clone());
-        processor.process_train(crate::LearnerEvent::Start { total_epochs: 0 });
+        processor.process_train(crate::LearnerEvent::Start {
+            total_epochs: 0,
+            starting_epoch: 0,
+        });
 
         // Two points for the first epoch. Mean 0.75
         let mut epoch = 1;

--- a/crates/burn-train/src/learner/early_stopping.rs
+++ b/crates/burn-train/src/learner/early_stopping.rs
@@ -279,7 +279,10 @@ mod tests {
         let store = Arc::new(EventStoreClient::new(store));
         let mut processor = MinimalEventProcessor::new(metrics, store.clone());
 
-        processor.process_train(crate::LearnerEvent::Start { total_epochs: 0 });
+        processor.process_train(crate::LearnerEvent::Start {
+            total_epochs: 0,
+            starting_epoch: 0,
+        });
         for (epoch, (points, should_start, comment)) in (1..).zip(data.iter()) {
             for point in points.iter() {
                 process_train(&mut processor, *point, epoch);

--- a/crates/burn-train/src/learner/supervised/strategies/base.rs
+++ b/crates/burn-train/src/learner/supervised/strategies/base.rs
@@ -134,6 +134,7 @@ pub trait SupervisedLearningStrategy<LC: LearningComponentsTypes> {
             .event_processor
             .process_train(LearnerEvent::Start {
                 total_epochs: training_components.num_epochs,
+                starting_epoch,
             });
         // Training loop
         let (model, mut event_processor) = self.fit(

--- a/crates/burn-train/src/logger/metric.rs
+++ b/crates/burn-train/src/logger/metric.rs
@@ -229,8 +229,9 @@ impl MetricLogger for FileMetricLogger {
             .cloned()
             .collect();
 
+        let epoch = if !self.is_eval { Some(epoch) } else { None };
         for item in entries.iter() {
-            self.log_item(item, Some(epoch), split);
+            self.log_item(item, epoch, split);
         }
     }
 
@@ -287,7 +288,16 @@ impl MetricLogger for FileMetricLogger {
 }
 
 fn logger_key(name: &str, split: &Split) -> String {
-    format!("{name}_{split}")
+    match split {
+        Split::Train | Split::Valid => format!("{name}_{split}"),
+        Split::Test(tag) => {
+            if let Some(t) = tag {
+                format!("{name}_{split}_{}", *t)
+            } else {
+                format!("{name}_{split}")
+            }
+        }
+    }
 }
 
 /// In memory metric logger, useful when testing and debugging.

--- a/crates/burn-train/src/logger/progress.rs
+++ b/crates/burn-train/src/logger/progress.rs
@@ -29,7 +29,7 @@ pub trait TrainingProgressLogger: Send {
     /// Called once at the start of training, providing the total number of epochs.
     ///
     /// The total number of items of the training can optionally be provided if it is known.
-    fn start(&mut self, total_epochs: usize, total_items: Option<usize>);
+    fn start(&mut self, total_epochs: usize, starting_epoch: usize, total_items: Option<usize>);
 
     /// Called at the end of each full epoch (after both train and valid splits complete).
     fn update_epoch(&mut self, epoch: usize);

--- a/crates/burn-train/src/metric/processor/base.rs
+++ b/crates/burn-train/src/metric/processor/base.rs
@@ -12,6 +12,8 @@ pub enum LearnerEvent<T> {
     Start {
         /// The total number of training epochs.
         total_epochs: usize,
+        /// The starting epoch.
+        starting_epoch: usize,
     },
     /// Signal that an item have been processed.
     ProcessedItem(TrainingItem<T>),

--- a/crates/burn-train/src/metric/processor/full.rs
+++ b/crates/burn-train/src/metric/processor/full.rs
@@ -168,7 +168,10 @@ impl<T: ItemLazy, V: ItemLazy> EventProcessorTraining<LearnerEvent<T>, LearnerEv
 {
     fn process_train(&mut self, event: LearnerEvent<T>) {
         match event {
-            LearnerEvent::Start { total_epochs } => {
+            LearnerEvent::Start {
+                total_epochs,
+                starting_epoch,
+            } => {
                 self.total_epochs = total_epochs;
                 self.current_epoch = 1;
                 let definitions = self.metrics.metric_definitions();
@@ -180,9 +183,9 @@ impl<T: ItemLazy, V: ItemLazy> EventProcessorTraining<LearnerEvent<T>, LearnerEv
                     .iter()
                     .for_each(|definition| self.renderer.register_metric(definition.clone()));
                 if let Some(logger) = &mut self.progress_logger {
-                    logger.start(total_epochs, None);
+                    logger.start(total_epochs, starting_epoch, None);
                 }
-                self.renderer.start(total_epochs, None);
+                self.renderer.start(total_epochs, starting_epoch, None);
             }
             LearnerEvent::StartSplit(total_items) => {
                 self.renderer.start_split("train", total_items);

--- a/crates/burn-train/src/metric/processor/minimal.rs
+++ b/crates/burn-train/src/metric/processor/minimal.rs
@@ -37,12 +37,15 @@ impl<T: ItemLazy, V: ItemLazy> EventProcessorTraining<LearnerEvent<T>, LearnerEv
 {
     fn process_train(&mut self, event: LearnerEvent<T>) {
         match event {
-            LearnerEvent::Start { total_epochs } => {
+            LearnerEvent::Start {
+                total_epochs,
+                starting_epoch,
+            } => {
                 let definitions = self.metrics.metric_definitions();
                 self.store
                     .add_event_train(crate::metric::store::Event::MetricsInit(definitions));
                 if let Some(logger) = &mut self.progress_logger {
-                    logger.start(total_epochs, None);
+                    logger.start(total_epochs, starting_epoch, None);
                 }
             }
             LearnerEvent::StartSplit(total_items) => {

--- a/crates/burn-train/src/metric/processor/rl_processor.rs
+++ b/crates/burn-train/src/metric/processor/rl_processor.rs
@@ -114,9 +114,9 @@ impl<TS: ItemLazy, ES: ItemLazy> EventProcessorTraining<RLEvent<TS, ES>, AgentEv
                     .iter()
                     .for_each(|definition| self.renderer.register_metric(definition.clone()));
                 if let Some(logger) = &mut self.training_progress_logger {
-                    logger.start(0, Some(total_items));
+                    logger.start(0, 0, Some(total_items));
                 }
-                self.renderer.start(0, Some(total_items));
+                self.renderer.start(0, 0, Some(total_items));
             }
             RLEvent::TrainStep(item) => {
                 let item = item.sync();

--- a/crates/burn-train/src/renderer/cli.rs
+++ b/crates/burn-train/src/renderer/cli.rs
@@ -30,8 +30,9 @@ impl MetricsRendererTraining for CliMetricsRenderer {
 }
 
 impl TrainingProgressLogger for CliMetricsRenderer {
-    fn start(&mut self, total_epochs: usize, total_items: Option<usize>) {
-        self.training_progress.global = Progress::new(1, total_epochs, Some("epochs".to_string()));
+    fn start(&mut self, total_epochs: usize, starting_epoch: usize, total_items: Option<usize>) {
+        self.training_progress.global =
+            Progress::new(starting_epoch, total_epochs, Some("epochs".to_string()));
         if let Some(items) = total_items {
             self.training_progress.split = Progress::new(0, items, Some("items".to_string()));
         }

--- a/crates/burn-train/src/renderer/tui/renderer.rs
+++ b/crates/burn-train/src/renderer/tui/renderer.rs
@@ -215,8 +215,9 @@ impl MetricsRendererTraining for TuiMetricsRendererWrapper {
 }
 
 impl TrainingProgressLogger for TuiMetricsRendererWrapper {
-    fn start(&mut self, total_epochs: usize, total_items: Option<usize>) {
-        self.training_progress.global = Progress::new(1, total_epochs, Some("epochs".to_string()));
+    fn start(&mut self, total_epochs: usize, starting_epoch: usize, total_items: Option<usize>) {
+        self.training_progress.global =
+            Progress::new(starting_epoch, total_epochs, Some("epochs".to_string()));
         if let Some(items) = total_items {
             self.training_progress.split = Progress::new(0, items, Some("items".to_string()));
         }

--- a/examples/custom-image-dataset/src/training.rs
+++ b/examples/custom-image-dataset/src/training.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use std::{path::PathBuf, time::Instant};
 
 use crate::{
     data::{ClassificationBatch, ClassificationBatcher},
@@ -70,8 +70,7 @@ pub struct TrainingConfig {
 }
 
 fn create_artifact_dir(artifact_dir: &str) {
-    // Remove existing artifacts before to get an accurate learner summary
-    std::fs::remove_dir_all(artifact_dir).ok();
+    std::fs::remove_file(PathBuf::from(artifact_dir).join("experiment.log")).ok();
     std::fs::create_dir_all(artifact_dir).ok();
 }
 

--- a/examples/custom-learning-strategy/src/training.rs
+++ b/examples/custom-learning-strategy/src/training.rs
@@ -26,6 +26,7 @@ use burn::{
     },
 };
 use guide::data::MnistBatcher;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 static ARTIFACT_DIR: &str = "/tmp/burn-example-custom-train-strategy";
@@ -47,8 +48,7 @@ pub struct MnistTrainingConfig {
 }
 
 fn create_artifact_dir(artifact_dir: &str) {
-    // Remove existing artifacts before to get an accurate learner summary
-    std::fs::remove_dir_all(artifact_dir).ok();
+    std::fs::remove_file(PathBuf::from(artifact_dir).join("experiment.log")).ok();
     std::fs::create_dir_all(artifact_dir).ok();
 }
 

--- a/examples/custom-renderer/src/lib.rs
+++ b/examples/custom-renderer/src/lib.rs
@@ -39,7 +39,8 @@ impl MetricsRendererTraining for CustomRenderer {
 }
 
 impl TrainingProgressLogger for CustomRenderer {
-    fn start(&mut self, _total_epochs: usize, _total_items: Option<usize>) {}
+    fn start(&mut self, _total_epochs: usize, _starting_epoch: usize, _total_items: Option<usize>) {
+    }
 
     fn update_epoch(&mut self, _epoch: usize) {}
 

--- a/examples/guide/src/training.rs
+++ b/examples/guide/src/training.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use crate::{
     data::{MnistBatch, MnistBatcher},
     model::{Model, ModelConfig},
@@ -65,8 +67,7 @@ pub struct TrainingConfig {
 }
 
 fn create_artifact_dir(artifact_dir: &str) {
-    // Remove existing artifacts before to get an accurate learner summary
-    std::fs::remove_dir_all(artifact_dir).ok();
+    std::fs::remove_file(PathBuf::from(artifact_dir).join("experiment.log")).ok();
     std::fs::create_dir_all(artifact_dir).ok();
 }
 

--- a/examples/mnist/src/file_progress.rs
+++ b/examples/mnist/src/file_progress.rs
@@ -43,12 +43,12 @@ impl FileTrainingProgressLogger {
 }
 
 impl TrainingProgressLogger for FileTrainingProgressLogger {
-    fn start(&mut self, total_epochs: usize, total_items: Option<usize>) {
+    fn start(&mut self, total_epochs: usize, starting_epoch: usize, total_items: Option<usize>) {
         match total_items {
             Some(n) => self.write(&format!(
-                "[Training] start  epochs={total_epochs} total_items={n}"
+                "[Training] start  epochs={total_epochs} total_items={n} starting_epoch={starting_epoch}"
             )),
-            None => self.write(&format!("[Training] start  epochs={total_epochs}")),
+            None => self.write(&format!("[Training] start  epochs={total_epochs} starting_epoch={starting_epoch}")),
         }
     }
 

--- a/examples/mnist/src/training.rs
+++ b/examples/mnist/src/training.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 use crate::{
     data::{MnistBatcher, MnistItemPrepared, MnistMapper, Transform},
@@ -50,8 +50,7 @@ pub struct MnistTrainingConfig {
 }
 
 fn create_artifact_dir(artifact_dir: &str) {
-    // Remove existing artifacts before to get an accurate learner summary
-    std::fs::remove_dir_all(artifact_dir).ok();
+    std::fs::remove_file(PathBuf::from(artifact_dir).join("experiment.log")).ok();
     std::fs::create_dir_all(artifact_dir).ok();
 }
 

--- a/examples/modern-lstm/src/training.rs
+++ b/examples/modern-lstm/src/training.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use crate::dataset::{
     NOISE_LEVEL, NUM_SEQUENCES, RANDOM_SEED, SEQ_LENGTH, SequenceBatcher, SequenceDataset,
 };
@@ -27,8 +29,7 @@ pub struct TrainingConfig {
 
 // Create the directory to save the model and model config
 fn create_artifact_dir(artifact_dir: &str) {
-    // Remove existing artifacts
-    std::fs::remove_dir_all(artifact_dir).ok();
+    std::fs::remove_file(PathBuf::from(artifact_dir).join("experiment.log")).ok();
     std::fs::create_dir_all(artifact_dir).ok();
 }
 

--- a/examples/simple-regression/src/training.rs
+++ b/examples/simple-regression/src/training.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use crate::dataset::{HousingBatcher, HousingDataset};
 use crate::model::RegressionModelConfig;
 use burn::optim::AdamConfig;
@@ -26,8 +28,7 @@ pub struct ExpConfig {
 }
 
 fn create_artifact_dir(artifact_dir: &str) {
-    // Remove existing artifacts before to get an accurate learner summary
-    std::fs::remove_dir_all(artifact_dir).ok();
+    std::fs::remove_file(PathBuf::from(artifact_dir).join("experiment.log")).ok();
     std::fs::create_dir_all(artifact_dir).ok();
 }
 

--- a/examples/text-classification/examples/db-pedia-train.rs
+++ b/examples/text-classification/examples/db-pedia-train.rs
@@ -2,6 +2,7 @@ use burn::{
     nn::transformer::TransformerEncoderConfig,
     optim::{AdamConfig, decay::WeightDecayConfig},
     tensor::{Device, DeviceConfig, Element},
+    train::ExecutionStrategy,
 };
 
 use text_classification::{DbPediaDataset, training::ExperimentConfig};
@@ -12,18 +13,14 @@ type ElemType = f32;
 #[cfg(feature = "f16")]
 type ElemType = burn::tensor::f16;
 
-pub fn launch(mut device: Device) {
+pub fn launch(strategy: ExecutionStrategy) {
     let config = ExperimentConfig::new(
         TransformerEncoderConfig::new(256, 1024, 8, 4).with_norm_first(true),
         AdamConfig::new().with_weight_decay(Some(WeightDecayConfig::new(5e-5))),
     );
 
-    device
-        .configure(DeviceConfig::default().float_dtype(ElemType::dtype()))
-        .unwrap();
-
     text_classification::training::train::<DbPediaDataset>(
-        burn::train::ExecutionStrategy::SingleDevice(device),
+        strategy,
         DbPediaDataset::train(),
         DbPediaDataset::test(),
         config,
@@ -31,12 +28,48 @@ pub fn launch(mut device: Device) {
     );
 }
 
+pub fn launch_single(mut device: Device) {
+    device
+        .configure(DeviceConfig::default().float_dtype(ElemType::dtype()))
+        .unwrap();
+
+    launch(ExecutionStrategy::SingleDevice(device))
+}
+
+#[cfg(all(feature = "cuda", not(feature = "ddp")))]
+pub fn launch_multi() {
+    let mut devices = Device::enumerate(burn::tensor::DeviceType::Cuda);
+    devices
+        .configure(DeviceConfig::default().float_dtype(ElemType::dtype()))
+        .unwrap();
+
+    launch(ExecutionStrategy::MultiDevice(
+        devices.into_vec(),
+        burn::train::MultiDeviceOptim::OptimSharded,
+    ))
+}
+
+#[cfg(all(feature = "cuda", feature = "ddp"))]
+pub fn launch_multi() {
+    let mut devices = Device::enumerate(burn::tensor::DeviceType::Cuda);
+    devices
+        .configure(DeviceConfig::default().float_dtype(ElemType::dtype()))
+        .unwrap();
+
+    launch(ExecutionStrategy::ddp(
+        devices.into_vec(),
+        DistributedConfig {
+            all_reduce_op: ReduceOperation::Mean,
+        },
+    ))
+}
+
 #[cfg(feature = "flex")]
 mod flex {
     use burn::tensor::Device;
 
     pub fn run() {
-        crate::launch(Device::flex());
+        crate::launch_single(Device::flex());
     }
 }
 
@@ -50,7 +83,7 @@ mod tch_gpu {
         #[cfg(target_os = "macos")]
         let device = Device::libtorch_mps();
 
-        crate::launch(device);
+        crate::launch_single(device);
     }
 }
 
@@ -59,16 +92,72 @@ mod tch_cpu {
     use burn::tensor::Device;
 
     pub fn run() {
-        crate::launch(Device::libtorch());
+        crate::launch_single(Device::libtorch());
     }
 }
 
-#[cfg(feature = "wgpu")]
+#[cfg(any(feature = "wgpu", feature = "vulkan", feature = "metal"))]
 mod wgpu {
     use burn::tensor::{Device, DeviceKind};
 
     pub fn run() {
-        crate::launch(Device::wgpu(DeviceKind::DefaultDevice));
+        crate::launch_single(Device::wgpu(DeviceKind::DefaultDevice));
+    }
+}
+
+#[cfg(feature = "remote")]
+mod remote {
+    use crate::ElemType;
+    #[cfg(feature = "ddp")]
+    use burn::tensor::distributed::{DistributedConfig, ReduceOperation};
+    use burn::tensor::{Device, DeviceConfig, DeviceType, Element};
+    #[cfg(feature = "ddp")]
+    use burn::train::ExecutionStrategy;
+
+    /// Address of the `burn-remote` server to train against.
+    const ADDRESS: &str = "ws://localhost:3000";
+
+    /// List every device the remote server hosts and train across all of them.
+    #[cfg(not(feature = "ddp"))]
+    pub fn run() {
+        let mut devices = Device::enumerate(DeviceType::remote(ADDRESS));
+        devices
+            .configure(DeviceConfig::default().float_dtype(ElemType::dtype()))
+            .unwrap();
+
+        crate::launch_single(devices.into_vec().pop().unwrap());
+    }
+
+    /// Same enumeration, but drive the devices with distributed data-parallel training.
+    #[cfg(feature = "ddp")]
+    pub fn run() {
+        let mut devices = Device::enumerate(DeviceType::remote(ADDRESS));
+        devices
+            .configure(DeviceConfig::default().float_dtype(ElemType::dtype()))
+            .unwrap();
+
+        crate::launch_single(ExecutionStrategy::ddp(
+            devices.into_vec(),
+            DistributedConfig {
+                all_reduce_op: ReduceOperation::Mean,
+            },
+        ));
+    }
+}
+
+#[cfg(feature = "cuda")]
+mod cuda {
+    pub fn run() {
+        crate::launch_multi();
+    }
+}
+
+#[cfg(feature = "rocm")]
+mod rocm {
+    use burn::tensor::{Device, DeviceIndex};
+
+    pub fn run() {
+        crate::launch_single(Device::rocm(DeviceIndex::Default));
     }
 }
 
@@ -79,6 +168,12 @@ fn main() {
     tch_gpu::run();
     #[cfg(feature = "tch-cpu")]
     tch_cpu::run();
-    #[cfg(feature = "wgpu")]
+    #[cfg(any(feature = "wgpu", feature = "vulkan", feature = "metal"))]
     wgpu::run();
+    #[cfg(feature = "cuda")]
+    cuda::run();
+    #[cfg(feature = "rocm")]
+    rocm::run();
+    #[cfg(feature = "remote")]
+    remote::run();
 }

--- a/examples/text-classification/src/training.rs
+++ b/examples/text-classification/src/training.rs
@@ -21,7 +21,7 @@ use burn::{
         AccuracyMetric, CudaMetric, IterationSpeedMetric, LearningRateMetric, LossMetric,
     },
 };
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 // Define configuration struct for the experiment
 #[derive(Config, Debug)]
@@ -37,8 +37,7 @@ pub struct ExperimentConfig {
 }
 
 fn create_artifact_dir(artifact_dir: &str) {
-    // Remove existing artifacts before to get an accurate learner summary
-    std::fs::remove_dir_all(artifact_dir).ok();
+    std::fs::remove_file(PathBuf::from(artifact_dir).join("experiment.log")).ok();
     std::fs::create_dir_all(artifact_dir).ok();
 }
 

--- a/examples/wgan/src/training.rs
+++ b/examples/wgan/src/training.rs
@@ -7,7 +7,7 @@ use burn::{
     tensor::Distribution,
 };
 use image::{Rgb32FImage, RgbImage, buffer::ConvertBuffer, error::ImageResult};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 #[derive(Config, Debug)]
 pub struct TrainingConfig {
@@ -38,8 +38,7 @@ pub struct TrainingConfig {
 
 // Create the directory to save the model and model config
 fn create_artifact_dir(artifact_dir: &str) {
-    // Remove existing artifacts
-    std::fs::remove_dir_all(artifact_dir).ok();
+    std::fs::remove_file(PathBuf::from(artifact_dir).join("experiment.log")).ok();
     std::fs::create_dir_all(artifact_dir).ok();
 }
 


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [X] Confirmed that `cargo run-checks` command has been executed.
- [X] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

### Changes

- Fix bug where starting_epoch wasn't used by progress loggers.
- Fix test split metric logging in the `FileMetricLogger`.
- Update db-pedia-train in text-classification example.
- Update all examples to NOT "remove existing artifacts before [training] to get an accurate learner summary". Now, only the logs are removed. This prevented checkpointing by default since it deleted the artifacts. Also, This could delete a whole directory if the path already contained other stuff. We could add a `reset` feature flag or something if we really wanted to keep the behaviour but I think we can keep it like this.

### Testing

Tested with examples.
