### PR TITLE
perf(fusion): use cubek's dedicated any/all reduce instruction

### DIFF
--- a/crates/burn-backend-tests/tests/fusion/mod.rs
+++ b/crates/burn-backend-tests/tests/fusion/mod.rs
@@ -5,6 +5,7 @@ mod fusion_f16_write_vectorization;
 mod fusion_shape;
 mod int_bitwise;
 mod reduce_broadcasted;
+mod reduce_logical;
 
 use burn_tensor::StreamId;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/crates/burn-backend-tests/tests/fusion/reduce_logical.rs
+++ b/crates/burn-backend-tests/tests/fusion/reduce_logical.rs
@@ -1,0 +1,196 @@
+//! Fusion-path correctness for `any`/`all` reductions.
+//!
+//! Under `Fusion<CubeBackend>` these route through the recorded `AnyDim`/`AllDim`
+//! IR into cubek's dedicated Any (max-of-flags) / All (min-of-flags) instruction,
+//! instead of the default `bool->int->sum->compare` emulation. The reduced
+//! dimension is kept wide enough to exercise the multi-block (plane/cube) merge.
+
+use super::*;
+use burn_tensor::TensorData;
+
+const ROWS: usize = 4;
+// Wide reduced dim so the reduction spans several plane/cube blocks that must merge.
+const COLS: usize = 257;
+
+/// Deterministic mask: `(r + c) % stride == 0`. With `stride == 3` every row has a
+/// mix of set/unset flags; `stride == ROWS * COLS + 1` makes the whole tensor all-false.
+fn mask(rows: usize, cols: usize, stride: usize) -> Vec<bool> {
+    (0..rows * cols)
+        .map(|i| (i / cols + i % cols) % stride == 0)
+        .collect()
+}
+
+/// Non-zero <-> flag set; mixes magnitudes/signs so the flag normalization is exercised.
+fn floats(m: &[bool]) -> Vec<f32> {
+    m.iter()
+        .enumerate()
+        .map(|(i, &b)| {
+            if b {
+                if i % 2 == 0 { 2.0 } else { -3.0 }
+            } else {
+                0.0
+            }
+        })
+        .collect()
+}
+
+fn ints(m: &[bool]) -> Vec<i32> {
+    m.iter()
+        .enumerate()
+        .map(|(i, &b)| {
+            if b {
+                if i % 2 == 0 { 2 } else { -3 }
+            } else {
+                0
+            }
+        })
+        .collect()
+}
+
+fn expect_any_dim(m: &[bool], rows: usize, cols: usize) -> TensorData {
+    let v: Vec<bool> = (0..rows)
+        .map(|r| (0..cols).any(|c| m[r * cols + c]))
+        .collect();
+    TensorData::new(v, [rows, 1])
+}
+
+fn expect_all_dim(m: &[bool], rows: usize, cols: usize) -> TensorData {
+    let v: Vec<bool> = (0..rows)
+        .map(|r| (0..cols).all(|c| m[r * cols + c]))
+        .collect();
+    TensorData::new(v, [rows, 1])
+}
+
+// ---- dim reductions ----------------------------------------------------------
+
+#[test]
+fn bool_any_dim_fused() {
+    let device = Default::default();
+    let m = mask(ROWS, COLS, 3);
+    let tensor = TestTensorBool::<2>::from_data(TensorData::new(m.clone(), [ROWS, COLS]), &device);
+    device.sync().unwrap();
+
+    let actual = tensor.any_dim(1).into_data();
+    expect_any_dim(&m, ROWS, COLS).assert_eq(&actual, false);
+}
+
+#[test]
+fn bool_all_dim_fused() {
+    let device = Default::default();
+    let m = mask(ROWS, COLS, 3);
+    let tensor = TestTensorBool::<2>::from_data(TensorData::new(m.clone(), [ROWS, COLS]), &device);
+    device.sync().unwrap();
+
+    let actual = tensor.all_dim(1).into_data();
+    expect_all_dim(&m, ROWS, COLS).assert_eq(&actual, false);
+}
+
+#[test]
+fn float_any_dim_fused() {
+    let device = Default::default();
+    let m = mask(ROWS, COLS, 3);
+    let tensor = TestTensor::<2>::from_data(TensorData::new(floats(&m), [ROWS, COLS]), &device);
+    device.sync().unwrap();
+
+    let actual = tensor.any_dim(1).into_data();
+    expect_any_dim(&m, ROWS, COLS).assert_eq(&actual, false);
+}
+
+#[test]
+fn float_all_dim_fused() {
+    let device = Default::default();
+    let m = mask(ROWS, COLS, 3);
+    let tensor = TestTensor::<2>::from_data(TensorData::new(floats(&m), [ROWS, COLS]), &device);
+    device.sync().unwrap();
+
+    let actual = tensor.all_dim(1).into_data();
+    expect_all_dim(&m, ROWS, COLS).assert_eq(&actual, false);
+}
+
+#[test]
+fn int_any_dim_fused() {
+    let device = Default::default();
+    let m = mask(ROWS, COLS, 3);
+    let tensor = TestTensorInt::<2>::from_data(TensorData::new(ints(&m), [ROWS, COLS]), &device);
+    device.sync().unwrap();
+
+    let actual = tensor.any_dim(1).into_data();
+    expect_any_dim(&m, ROWS, COLS).assert_eq(&actual, false);
+}
+
+#[test]
+fn int_all_dim_fused() {
+    let device = Default::default();
+    let m = mask(ROWS, COLS, 3);
+    let tensor = TestTensorInt::<2>::from_data(TensorData::new(ints(&m), [ROWS, COLS]), &device);
+    device.sync().unwrap();
+
+    let actual = tensor.all_dim(1).into_data();
+    expect_all_dim(&m, ROWS, COLS).assert_eq(&actual, false);
+}
+
+// ---- whole-tensor reductions (flatten -> any_dim(0)) -------------------------
+
+#[test]
+fn bool_any_all_whole() {
+    let device = Default::default();
+    let mixed = mask(ROWS, COLS, 3); // at least one set and one unset flag
+    let all_false = vec![false; ROWS * COLS];
+    let all_true = vec![true; ROWS * COLS];
+
+    let t_mixed = TestTensorBool::<2>::from_data(TensorData::new(mixed, [ROWS, COLS]), &device);
+    let t_false = TestTensorBool::<2>::from_data(TensorData::new(all_false, [ROWS, COLS]), &device);
+    let t_true = TestTensorBool::<2>::from_data(TensorData::new(all_true, [ROWS, COLS]), &device);
+    device.sync().unwrap();
+
+    TensorData::new(vec![true], [1]).assert_eq(&t_mixed.clone().any().into_data(), false);
+    TensorData::new(vec![false], [1]).assert_eq(&t_mixed.all().into_data(), false);
+    TensorData::new(vec![false], [1]).assert_eq(&t_false.any().into_data(), false);
+    TensorData::new(vec![true], [1]).assert_eq(&t_true.all().into_data(), false);
+}
+
+#[test]
+fn float_int_whole() {
+    let device = Default::default();
+    let mixed = mask(ROWS, COLS, 3);
+    let tf = TestTensor::<2>::from_data(TensorData::new(floats(&mixed), [ROWS, COLS]), &device);
+    let ti = TestTensorInt::<2>::from_data(TensorData::new(ints(&mixed), [ROWS, COLS]), &device);
+    device.sync().unwrap();
+
+    TensorData::new(vec![true], [1]).assert_eq(&tf.any().into_data(), false);
+    TensorData::new(vec![true], [1]).assert_eq(&ti.any().into_data(), false);
+}
+
+// ---- fuse-on-read: a reshape feeding a bool reduce ---------------------------
+
+#[test]
+fn bool_reshape_then_any_dim() {
+    let device = Default::default();
+    let m = mask(ROWS, COLS, 3);
+    let tensor = TestTensorBool::<2>::from_data(TensorData::new(m.clone(), [ROWS, COLS]), &device);
+    device.sync().unwrap();
+
+    // Reshape (a layout-changing read op) feeding the reduce, then reduce the last dim.
+    let reshaped = tensor.reshape([COLS, ROWS]);
+    let actual = reshaped.any_dim(1).into_data();
+
+    let expected: Vec<bool> = (0..COLS)
+        .map(|a| (0..ROWS).any(|b| m[a * ROWS + b]))
+        .collect();
+    TensorData::new(expected, [COLS, 1]).assert_eq(&actual, false);
+}
+
+// ---- fuse-on-read: an elementwise op feeding the reduce ----------------------
+
+#[test]
+fn float_elemwise_then_any_dim() {
+    let device = Default::default();
+    let m = mask(ROWS, COLS, 3);
+    let tensor = TestTensor::<2>::from_data(TensorData::new(floats(&m), [ROWS, COLS]), &device);
+    device.sync().unwrap();
+
+    // Scaling preserves the non-zero pattern, so the flags (and the result) are
+    // unchanged; the multiply should fuse into the reduce's read path.
+    let actual = tensor.mul_scalar(5.0).any_dim(1).into_data();
+    expect_any_dim(&m, ROWS, COLS).assert_eq(&actual, false);
+}

--- a/crates/burn-backend-tests/tests/fusion/reduce_logical.rs
+++ b/crates/burn-backend-tests/tests/fusion/reduce_logical.rs
@@ -12,11 +12,17 @@ const ROWS: usize = 4;
 // Wide reduced dim so the reduction spans several plane/cube blocks that must merge.
 const COLS: usize = 257;
 
-/// Deterministic mask: `(r + c) % stride == 0`. With `stride == 3` every row has a
-/// mix of set/unset flags; `stride == ROWS * COLS + 1` makes the whole tensor all-false.
-fn mask(rows: usize, cols: usize, stride: usize) -> Vec<bool> {
+/// Deterministic mask with all-false, all-true, and mixed rows.
+fn mask(rows: usize, cols: usize) -> Vec<bool> {
     (0..rows * cols)
-        .map(|i| (i / cols + i % cols) % stride == 0)
+        .map(|i| {
+            let (r, c) = (i / cols, i % cols);
+            match r % 3 {
+                0 => false,
+                1 => true,
+                _ => c % 3 == 0,
+            }
+        })
         .collect()
 }
 
@@ -66,7 +72,7 @@ fn expect_all_dim(m: &[bool], rows: usize, cols: usize) -> TensorData {
 #[test]
 fn bool_any_dim_fused() {
     let device = Default::default();
-    let m = mask(ROWS, COLS, 3);
+    let m = mask(ROWS, COLS);
     let tensor = TestTensorBool::<2>::from_data(TensorData::new(m.clone(), [ROWS, COLS]), &device);
     device.sync().unwrap();
 
@@ -77,7 +83,7 @@ fn bool_any_dim_fused() {
 #[test]
 fn bool_all_dim_fused() {
     let device = Default::default();
-    let m = mask(ROWS, COLS, 3);
+    let m = mask(ROWS, COLS);
     let tensor = TestTensorBool::<2>::from_data(TensorData::new(m.clone(), [ROWS, COLS]), &device);
     device.sync().unwrap();
 
@@ -88,7 +94,7 @@ fn bool_all_dim_fused() {
 #[test]
 fn float_any_dim_fused() {
     let device = Default::default();
-    let m = mask(ROWS, COLS, 3);
+    let m = mask(ROWS, COLS);
     let tensor = TestTensor::<2>::from_data(TensorData::new(floats(&m), [ROWS, COLS]), &device);
     device.sync().unwrap();
 
@@ -99,7 +105,7 @@ fn float_any_dim_fused() {
 #[test]
 fn float_all_dim_fused() {
     let device = Default::default();
-    let m = mask(ROWS, COLS, 3);
+    let m = mask(ROWS, COLS);
     let tensor = TestTensor::<2>::from_data(TensorData::new(floats(&m), [ROWS, COLS]), &device);
     device.sync().unwrap();
 
@@ -110,7 +116,7 @@ fn float_all_dim_fused() {
 #[test]
 fn int_any_dim_fused() {
     let device = Default::default();
-    let m = mask(ROWS, COLS, 3);
+    let m = mask(ROWS, COLS);
     let tensor = TestTensorInt::<2>::from_data(TensorData::new(ints(&m), [ROWS, COLS]), &device);
     device.sync().unwrap();
 
@@ -121,7 +127,7 @@ fn int_any_dim_fused() {
 #[test]
 fn int_all_dim_fused() {
     let device = Default::default();
-    let m = mask(ROWS, COLS, 3);
+    let m = mask(ROWS, COLS);
     let tensor = TestTensorInt::<2>::from_data(TensorData::new(ints(&m), [ROWS, COLS]), &device);
     device.sync().unwrap();
 
@@ -129,12 +135,46 @@ fn int_all_dim_fused() {
     expect_all_dim(&m, ROWS, COLS).assert_eq(&actual, false);
 }
 
+#[test]
+fn bool_any_all_dim_broadcasted() {
+    let device = Default::default();
+    let m = mask(ROWS, COLS);
+    let tensor = TestTensorBool::<2>::from_data(TensorData::new(m.clone(), [ROWS, COLS]), &device);
+    device.sync().unwrap();
+
+    let actual_any = tensor
+        .clone()
+        .any_dim(1)
+        .bool_or(tensor.clone())
+        .into_data();
+    let actual_all = tensor.clone().all_dim(1).bool_and(tensor).into_data();
+    let any_rows: Vec<bool> = (0..ROWS)
+        .map(|r| (0..COLS).any(|c| m[r * COLS + c]))
+        .collect();
+    let all_rows: Vec<bool> = (0..ROWS)
+        .map(|r| (0..COLS).all(|c| m[r * COLS + c]))
+        .collect();
+    let expected_any: Vec<bool> = m
+        .iter()
+        .enumerate()
+        .map(|(i, &value)| any_rows[i / COLS] || value)
+        .collect();
+    let expected_all: Vec<bool> = m
+        .iter()
+        .enumerate()
+        .map(|(i, &value)| all_rows[i / COLS] && value)
+        .collect();
+
+    TensorData::new(expected_any, [ROWS, COLS]).assert_eq(&actual_any, false);
+    TensorData::new(expected_all, [ROWS, COLS]).assert_eq(&actual_all, false);
+}
+
 // ---- whole-tensor reductions (flatten -> any_dim(0)) -------------------------
 
 #[test]
 fn bool_any_all_whole() {
     let device = Default::default();
-    let mixed = mask(ROWS, COLS, 3); // at least one set and one unset flag
+    let mixed = mask(ROWS, COLS);
     let all_false = vec![false; ROWS * COLS];
     let all_true = vec![true; ROWS * COLS];
 
@@ -152,7 +192,7 @@ fn bool_any_all_whole() {
 #[test]
 fn float_int_whole() {
     let device = Default::default();
-    let mixed = mask(ROWS, COLS, 3);
+    let mixed = mask(ROWS, COLS);
     let tf = TestTensor::<2>::from_data(TensorData::new(floats(&mixed), [ROWS, COLS]), &device);
     let ti = TestTensorInt::<2>::from_data(TensorData::new(ints(&mixed), [ROWS, COLS]), &device);
     device.sync().unwrap();
@@ -166,7 +206,7 @@ fn float_int_whole() {
 #[test]
 fn bool_reshape_then_any_dim() {
     let device = Default::default();
-    let m = mask(ROWS, COLS, 3);
+    let m = mask(ROWS, COLS);
     let tensor = TestTensorBool::<2>::from_data(TensorData::new(m.clone(), [ROWS, COLS]), &device);
     device.sync().unwrap();
 
@@ -185,7 +225,7 @@ fn bool_reshape_then_any_dim() {
 #[test]
 fn float_elemwise_then_any_dim() {
     let device = Default::default();
-    let m = mask(ROWS, COLS, 3);
+    let m = mask(ROWS, COLS);
     let tensor = TestTensor::<2>::from_data(TensorData::new(floats(&m), [ROWS, COLS]), &device);
     device.sync().unwrap();
 

--- a/crates/burn-cubecl-fusion/src/optim/reduce/fuser.rs
+++ b/crates/burn-cubecl-fusion/src/optim/reduce/fuser.rs
@@ -257,20 +257,21 @@ impl<R: Runtime> OperationFuser<CubeOptimization<R>> for ReduceFuser<R> {
                         self.on_elemwise_read(operation);
                     }
                 };
-            } else if let OperationIr::BaseBool(BaseOperationIr::AnyDim(op))
-            | OperationIr::BaseFloat(BaseOperationIr::AnyDim(op))
-            | OperationIr::BaseInt(BaseOperationIr::AnyDim(op)) = operation
+            } else if let OperationIr::BaseBool(op)
+            | OperationIr::BaseFloat(op)
+            | OperationIr::BaseInt(op) = operation
             {
-                // `any`/`all` are bool-output `BaseOperationIr` reductions (not
-                // `NumericOperationIr::*Dim`), so they need their own arms to be
-                // recognized as fusible reductions and routed to cubek's dedicated
-                // Any (max-of-flags) / All (min-of-flags) instruction.
-                self.on_reduce(op, ReduceInstruction::Any);
-            } else if let OperationIr::BaseBool(BaseOperationIr::AllDim(op))
-            | OperationIr::BaseFloat(BaseOperationIr::AllDim(op))
-            | OperationIr::BaseInt(BaseOperationIr::AllDim(op)) = operation
-            {
-                self.on_reduce(op, ReduceInstruction::All);
+                match op {
+                    BaseOperationIr::AnyDim(op) => {
+                        self.on_reduce(op, ReduceInstruction::Any);
+                    }
+                    BaseOperationIr::AllDim(op) => {
+                        self.on_reduce(op, ReduceInstruction::All);
+                    }
+                    _ => {
+                        self.on_elemwise_read(operation);
+                    }
+                }
             } else {
                 self.on_elemwise_read(operation);
             }

--- a/crates/burn-cubecl-fusion/src/optim/reduce/fuser.rs
+++ b/crates/burn-cubecl-fusion/src/optim/reduce/fuser.rs
@@ -11,7 +11,7 @@ use crate::{
     optim::CubeOptimization,
 };
 use burn_fusion::{FuserStatus, OperationFuser};
-use burn_ir::{NumericOperationIr, OperationIr, ReduceDimOpIr};
+use burn_ir::{BaseOperationIr, NumericOperationIr, OperationIr, ReduceDimOpIr};
 use burn_std::Shape;
 use cubecl::Runtime;
 
@@ -257,6 +257,20 @@ impl<R: Runtime> OperationFuser<CubeOptimization<R>> for ReduceFuser<R> {
                         self.on_elemwise_read(operation);
                     }
                 };
+            } else if let OperationIr::BaseBool(BaseOperationIr::AnyDim(op))
+            | OperationIr::BaseFloat(BaseOperationIr::AnyDim(op))
+            | OperationIr::BaseInt(BaseOperationIr::AnyDim(op)) = operation
+            {
+                // `any`/`all` are bool-output `BaseOperationIr` reductions (not
+                // `NumericOperationIr::*Dim`), so they need their own arms to be
+                // recognized as fusible reductions and routed to cubek's dedicated
+                // Any (max-of-flags) / All (min-of-flags) instruction.
+                self.on_reduce(op, ReduceInstruction::Any);
+            } else if let OperationIr::BaseBool(BaseOperationIr::AllDim(op))
+            | OperationIr::BaseFloat(BaseOperationIr::AllDim(op))
+            | OperationIr::BaseInt(BaseOperationIr::AllDim(op)) = operation
+            {
+                self.on_reduce(op, ReduceInstruction::All);
             } else {
                 self.on_elemwise_read(operation);
             }

--- a/crates/burn-cubecl-fusion/src/optim/reduce/optimization.rs
+++ b/crates/burn-cubecl-fusion/src/optim/reduce/optimization.rs
@@ -120,6 +120,8 @@ pub enum ReduceInstruction {
     Max,
     Min,
     MaxAbs,
+    Any,
+    All,
 }
 
 pub trait ReduceFallbackFn<R: Runtime>: Send + Sync {
@@ -456,6 +458,8 @@ pub(crate) fn reduce_instruction2config(instruction: &ReduceInstruction) -> Redu
         ReduceInstruction::Max => ReduceOperationConfig::Max,
         ReduceInstruction::Min => ReduceOperationConfig::Min,
         ReduceInstruction::MaxAbs => ReduceOperationConfig::MaxAbs,
+        ReduceInstruction::Any => ReduceOperationConfig::Any,
+        ReduceInstruction::All => ReduceOperationConfig::All,
     }
 }
 

--- a/crates/burn-cubecl-fusion/src/optim/reduce_broadcasted/fuser/full.rs
+++ b/crates/burn-cubecl-fusion/src/optim/reduce_broadcasted/fuser/full.rs
@@ -90,6 +90,8 @@ impl ReduceBroadcastedFullFuser {
                         ReduceInstruction::Max => ReduceOperationConfig::Max,
                         ReduceInstruction::Min => ReduceOperationConfig::Min,
                         ReduceInstruction::MaxAbs => ReduceOperationConfig::MaxAbs,
+                        ReduceInstruction::Any => ReduceOperationConfig::Any,
+                        ReduceInstruction::All => ReduceOperationConfig::All,
                     };
 
                     let block = ReduceBroadcastedFuseBlock {

--- a/crates/burn-fusion/src/ops/bool_tensor.rs
+++ b/crates/burn-fusion/src/ops/bool_tensor.rs
@@ -1,7 +1,7 @@
 use crate::{
     Fusion, FusionBackend,
     client::GlobalFusionClient,
-    get_client,
+    get_client, reduce_bool_ops, reduce_bool_whole_ops,
     stream::{StreamId, execution::Operation},
 };
 use burn_backend::{
@@ -12,9 +12,9 @@ use burn_backend::{
 use burn_ir::{
     BaseOperationIr, BinaryOpIr, BoolOperationIr, CastOpIr, CatOpIr, CreationOpIr, FlipOpIr,
     GatherOpIr, HandleContainer, InitOperationIr, MaskFillOpIr, MaskWhereOpIr, OperationIr,
-    OperationOutput, PermuteOpIr, RepeatDimOpIr, ScalarOpIr, ScatterOpIr, SelectAssignOpIr,
-    SelectOpIr, ShapeOpIr, SliceAssignOpIr, SliceOpIr, SwapDimsOpIr, TensorIr, UnaryOpIr,
-    UnfoldOpIr,
+    OperationOutput, PermuteOpIr, ReduceDimOpIr, ReduceOpIr, RepeatDimOpIr, ScalarOpIr,
+    ScatterOpIr, SelectAssignOpIr, SelectOpIr, ShapeOpIr, SliceAssignOpIr, SliceOpIr, SwapDimsOpIr,
+    TensorIr, UnaryOpIr, UnfoldOpIr,
 };
 use std::marker::PhantomData;
 
@@ -191,6 +191,90 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
                 streams,
                 OperationIr::Bool(BoolOperationIr::IntoFloat(desc.clone())),
                 IntoFloatOps::<B>::new(desc),
+            )
+            .output()
+    }
+
+    fn bool_any_dim(tensor: BoolTensor<Self>, dim: usize) -> BoolTensor<Self> {
+        reduce_bool_ops!(BoolAnyDimOps, |tensor, axis| B::bool_any_dim(tensor, axis));
+
+        let streams = StreamId::current();
+
+        let client = tensor.client.clone();
+        let dtype = tensor.dtype;
+        // Record a single `AnyDim` reduce (bool output) so the cubecl reduce fuser
+        // routes it to cubek's dedicated Any instruction instead of the default
+        // bool->int->sum->compare emulation.
+        let desc = ReduceDimOpIr::create_bool(tensor.into_ir(), dim, 1, dtype, || {
+            client.create_empty_handle()
+        });
+
+        client
+            .register(
+                streams,
+                OperationIr::BaseBool(BaseOperationIr::AnyDim(desc.clone())),
+                BoolAnyDimOps::<B>::new(desc),
+            )
+            .output()
+    }
+
+    fn bool_all_dim(tensor: BoolTensor<Self>, dim: usize) -> BoolTensor<Self> {
+        reduce_bool_ops!(BoolAllDimOps, |tensor, axis| B::bool_all_dim(tensor, axis));
+
+        let streams = StreamId::current();
+
+        let client = tensor.client.clone();
+        let dtype = tensor.dtype;
+        let desc = ReduceDimOpIr::create_bool(tensor.into_ir(), dim, 1, dtype, || {
+            client.create_empty_handle()
+        });
+
+        client
+            .register(
+                streams,
+                OperationIr::BaseBool(BaseOperationIr::AllDim(desc.clone())),
+                BoolAllDimOps::<B>::new(desc),
+            )
+            .output()
+    }
+
+    fn bool_any(tensor: BoolTensor<Self>) -> BoolTensor<Self> {
+        reduce_bool_whole_ops!(BoolAnyOps, |tensor| B::bool_any(tensor));
+
+        let streams = StreamId::current();
+
+        let client = tensor.client.clone();
+        let dtype = tensor.dtype;
+        // Whole-tensor `Any`: the reduce fuser only fuses `*Dim` reductions, so this
+        // op is not fused and runs via the fallback, i.e. the bare backend's
+        // dedicated cubek Any instruction rather than the default sum-emulation.
+        let desc =
+            ReduceOpIr::create_bool(tensor.into_ir(), dtype, || client.create_empty_handle());
+
+        client
+            .register(
+                streams,
+                OperationIr::BaseBool(BaseOperationIr::Any(desc.clone())),
+                BoolAnyOps::<B>::new(desc),
+            )
+            .output()
+    }
+
+    fn bool_all(tensor: BoolTensor<Self>) -> BoolTensor<Self> {
+        reduce_bool_whole_ops!(BoolAllOps, |tensor| B::bool_all(tensor));
+
+        let streams = StreamId::current();
+
+        let client = tensor.client.clone();
+        let dtype = tensor.dtype;
+        let desc =
+            ReduceOpIr::create_bool(tensor.into_ir(), dtype, || client.create_empty_handle());
+
+        client
+            .register(
+                streams,
+                OperationIr::BaseBool(BaseOperationIr::All(desc.clone())),
+                BoolAllOps::<B>::new(desc),
             )
             .output()
     }

--- a/crates/burn-fusion/src/ops/bool_tensor.rs
+++ b/crates/burn-fusion/src/ops/bool_tensor.rs
@@ -1,7 +1,7 @@
 use crate::{
     Fusion, FusionBackend,
     client::GlobalFusionClient,
-    get_client, reduce_bool_ops, reduce_bool_whole_ops,
+    get_client, reduce_ops,
     stream::{StreamId, execution::Operation},
 };
 use burn_backend::{
@@ -196,7 +196,9 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
     }
 
     fn bool_any_dim(tensor: BoolTensor<Self>, dim: usize) -> BoolTensor<Self> {
-        reduce_bool_ops!(BoolAnyDimOps, |tensor, axis| B::bool_any_dim(tensor, axis));
+        reduce_ops!(BoolAnyDimOps, bool, |tensor, axis| B::bool_any_dim(
+            tensor, axis
+        ));
 
         let streams = StreamId::current();
 
@@ -219,7 +221,9 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
     }
 
     fn bool_all_dim(tensor: BoolTensor<Self>, dim: usize) -> BoolTensor<Self> {
-        reduce_bool_ops!(BoolAllDimOps, |tensor, axis| B::bool_all_dim(tensor, axis));
+        reduce_ops!(BoolAllDimOps, bool, |tensor, axis| B::bool_all_dim(
+            tensor, axis
+        ));
 
         let streams = StreamId::current();
 
@@ -239,7 +243,7 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
     }
 
     fn bool_any(tensor: BoolTensor<Self>) -> BoolTensor<Self> {
-        reduce_bool_whole_ops!(BoolAnyOps, |tensor| B::bool_any(tensor));
+        reduce_ops!(BoolAnyOps, bool, whole, |tensor| B::bool_any(tensor));
 
         let streams = StreamId::current();
 
@@ -261,7 +265,7 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
     }
 
     fn bool_all(tensor: BoolTensor<Self>) -> BoolTensor<Self> {
-        reduce_bool_whole_ops!(BoolAllOps, |tensor| B::bool_all(tensor));
+        reduce_ops!(BoolAllOps, bool, whole, |tensor| B::bool_all(tensor));
 
         let streams = StreamId::current();
 

--- a/crates/burn-fusion/src/ops/int_tensor.rs
+++ b/crates/burn-fusion/src/ops/int_tensor.rs
@@ -2,7 +2,8 @@ use super::NoOp;
 use crate::{
     Fusion, FusionBackend, binary_int_cmp_ops, binary_int_ops,
     client::GlobalFusionClient,
-    get_client, reduce_int_ops, scalar_int_cmp_ops, scalar_int_ops,
+    get_client, reduce_int_ops, reduce_int2bool_ops, reduce_int2bool_whole_ops, scalar_int_cmp_ops,
+    scalar_int_ops,
     stream::{StreamId, execution::Operation},
     unary_int_ops,
 };
@@ -1133,6 +1134,88 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
                 streams,
                 OperationIr::NumericInt(desc.out.dtype, NumericOperationIr::SumDim(desc.clone())),
                 SumDimOps::<B>::new(desc),
+            )
+            .output()
+    }
+
+    fn int_any(tensor: IntTensor<Self>, out_dtype: BoolDType) -> BoolTensor<Self> {
+        reduce_int2bool_whole_ops!(IntAnyOps, |tensor, dtype| B::int_any(tensor, dtype));
+
+        let streams = StreamId::current();
+
+        let client = tensor.client.clone();
+        // Whole-tensor `Any`: not fused (the reduce fuser only fuses `*Dim`), so it
+        // runs the bare backend's dedicated cubek Any instruction via the fallback.
+        let desc = ReduceOpIr::create_bool(tensor.into_ir(), out_dtype.into(), || {
+            client.create_empty_handle()
+        });
+
+        client
+            .register(
+                streams,
+                OperationIr::BaseInt(BaseOperationIr::Any(desc.clone())),
+                IntAnyOps::<B>::new(desc),
+            )
+            .output()
+    }
+
+    fn int_any_dim(tensor: IntTensor<Self>, dim: usize, out_dtype: BoolDType) -> BoolTensor<Self> {
+        reduce_int2bool_ops!(IntAnyDimOps, |tensor, axis, dtype| B::int_any_dim(
+            tensor, axis, dtype
+        ));
+
+        let streams = StreamId::current();
+
+        let client = tensor.client.clone();
+        let desc = ReduceDimOpIr::create_bool(tensor.into_ir(), dim, 1, out_dtype.into(), || {
+            client.create_empty_handle()
+        });
+
+        client
+            .register(
+                streams,
+                OperationIr::BaseInt(BaseOperationIr::AnyDim(desc.clone())),
+                IntAnyDimOps::<B>::new(desc),
+            )
+            .output()
+    }
+
+    fn int_all(tensor: IntTensor<Self>, out_dtype: BoolDType) -> BoolTensor<Self> {
+        reduce_int2bool_whole_ops!(IntAllOps, |tensor, dtype| B::int_all(tensor, dtype));
+
+        let streams = StreamId::current();
+
+        let client = tensor.client.clone();
+        let desc = ReduceOpIr::create_bool(tensor.into_ir(), out_dtype.into(), || {
+            client.create_empty_handle()
+        });
+
+        client
+            .register(
+                streams,
+                OperationIr::BaseInt(BaseOperationIr::All(desc.clone())),
+                IntAllOps::<B>::new(desc),
+            )
+            .output()
+    }
+
+    fn int_all_dim(tensor: IntTensor<Self>, dim: usize, out_dtype: BoolDType) -> BoolTensor<Self> {
+        reduce_int2bool_ops!(IntAllDimOps, |tensor, axis, dtype| B::int_all_dim(
+            tensor, axis, dtype
+        ));
+
+        let streams = StreamId::current();
+
+        let client = tensor.client.clone();
+        let desc = ReduceDimOpIr::create_bool(tensor.into_ir(), dim, 1, out_dtype.into(), || {
+            client.create_empty_handle()
+        });
+
+        client
+            .register(
+                streams,
+                OperationIr::BaseInt(BaseOperationIr::AllDim(desc.clone())),
+                IntAllDimOps::<B>::new(desc),
             )
             .output()
     }

--- a/crates/burn-fusion/src/ops/int_tensor.rs
+++ b/crates/burn-fusion/src/ops/int_tensor.rs
@@ -2,8 +2,7 @@ use super::NoOp;
 use crate::{
     Fusion, FusionBackend, binary_int_cmp_ops, binary_int_ops,
     client::GlobalFusionClient,
-    get_client, reduce_int_ops, reduce_int2bool_ops, reduce_int2bool_whole_ops, scalar_int_cmp_ops,
-    scalar_int_ops,
+    get_client, reduce_ops, scalar_int_cmp_ops, scalar_int_ops,
     stream::{StreamId, execution::Operation},
     unary_int_ops,
 };
@@ -1121,7 +1120,9 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
     }
 
     fn int_sum_dim(tensor: IntTensor<Self>, axis: usize) -> IntTensor<Self> {
-        reduce_int_ops!(SumDimOps, |tensor, axis, _| B::int_sum_dim(tensor, axis));
+        reduce_ops!(SumDimOps, int, |tensor, axis, _| B::int_sum_dim(
+            tensor, axis
+        ));
 
         let streams = StreamId::current();
 
@@ -1139,7 +1140,7 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
     }
 
     fn int_any(tensor: IntTensor<Self>, out_dtype: BoolDType) -> BoolTensor<Self> {
-        reduce_int2bool_whole_ops!(IntAnyOps, |tensor, dtype| B::int_any(tensor, dtype));
+        reduce_ops!(IntAnyOps, int => bool, whole, |tensor, dtype| B::int_any(tensor, dtype));
 
         let streams = StreamId::current();
 
@@ -1160,9 +1161,7 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
     }
 
     fn int_any_dim(tensor: IntTensor<Self>, dim: usize, out_dtype: BoolDType) -> BoolTensor<Self> {
-        reduce_int2bool_ops!(IntAnyDimOps, |tensor, axis, dtype| B::int_any_dim(
-            tensor, axis, dtype
-        ));
+        reduce_ops!(IntAnyDimOps, int => bool, |tensor, axis, dtype| B::int_any_dim(tensor, axis, dtype));
 
         let streams = StreamId::current();
 
@@ -1181,7 +1180,7 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
     }
 
     fn int_all(tensor: IntTensor<Self>, out_dtype: BoolDType) -> BoolTensor<Self> {
-        reduce_int2bool_whole_ops!(IntAllOps, |tensor, dtype| B::int_all(tensor, dtype));
+        reduce_ops!(IntAllOps, int => bool, whole, |tensor, dtype| B::int_all(tensor, dtype));
 
         let streams = StreamId::current();
 
@@ -1200,9 +1199,7 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
     }
 
     fn int_all_dim(tensor: IntTensor<Self>, dim: usize, out_dtype: BoolDType) -> BoolTensor<Self> {
-        reduce_int2bool_ops!(IntAllDimOps, |tensor, axis, dtype| B::int_all_dim(
-            tensor, axis, dtype
-        ));
+        reduce_ops!(IntAllDimOps, int => bool, |tensor, axis, dtype| B::int_all_dim(tensor, axis, dtype));
 
         let streams = StreamId::current();
 
@@ -1238,7 +1235,9 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
     }
 
     fn int_prod_dim(tensor: IntTensor<Self>, dim: usize) -> IntTensor<Self> {
-        reduce_int_ops!(ProdDimOps, |tensor, axis, _| B::int_prod_dim(tensor, axis));
+        reduce_ops!(ProdDimOps, int, |tensor, axis, _| B::int_prod_dim(
+            tensor, axis
+        ));
 
         let streams = StreamId::current();
 
@@ -1272,7 +1271,9 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
     }
 
     fn int_mean_dim(tensor: IntTensor<Self>, dim: usize) -> IntTensor<Self> {
-        reduce_int_ops!(MeanDimOps, |tensor, axis, _| B::int_mean_dim(tensor, axis));
+        reduce_ops!(MeanDimOps, int, |tensor, axis, _| B::int_mean_dim(
+            tensor, axis
+        ));
 
         let streams = StreamId::current();
 
@@ -1432,7 +1433,9 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
     }
 
     fn int_argmax(tensor: IntTensor<Self>, dim: usize) -> IntTensor<Self> {
-        reduce_int_ops!(ArgMaxOps, |tensor, axis, _| B::int_argmax(tensor, axis));
+        reduce_ops!(ArgMaxOps, int, |tensor, axis, _| B::int_argmax(
+            tensor, axis
+        ));
 
         let streams = StreamId::current();
 
@@ -1449,7 +1452,7 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
     }
 
     fn int_argtopk(tensor: IntTensor<Self>, dim: usize, k: usize) -> IntTensor<Self> {
-        reduce_int_ops!(ArgTopKOps, B::int_argtopk);
+        reduce_ops!(ArgTopKOps, int, B::int_argtopk);
 
         let streams = StreamId::current();
 
@@ -1466,7 +1469,7 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
     }
 
     fn int_topk(tensor: IntTensor<Self>, dim: usize, k: usize) -> IntTensor<Self> {
-        reduce_int_ops!(TopKOps, B::int_topk);
+        reduce_ops!(TopKOps, int, B::int_topk);
 
         let streams = StreamId::current();
 
@@ -1483,7 +1486,9 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
     }
 
     fn int_argmin(tensor: IntTensor<Self>, dim: usize) -> IntTensor<Self> {
-        reduce_int_ops!(ArgMinOps, |tensor, axis, _| B::int_argmin(tensor, axis));
+        reduce_ops!(ArgMinOps, int, |tensor, axis, _| B::int_argmin(
+            tensor, axis
+        ));
 
         let streams = StreamId::current();
 
@@ -1627,7 +1632,9 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
     }
 
     fn int_max_dim(tensor: IntTensor<Self>, dim: usize) -> IntTensor<Self> {
-        reduce_int_ops!(MaxDimOps, |tensor, axis, _| B::int_max_dim(tensor, axis));
+        reduce_ops!(MaxDimOps, int, |tensor, axis, _| B::int_max_dim(
+            tensor, axis
+        ));
 
         let streams = StreamId::current();
 
@@ -1716,7 +1723,7 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
     }
 
     fn int_max_abs_dim(tensor: IntTensor<Self>, dim: usize) -> IntTensor<Self> {
-        reduce_int_ops!(MaxAbsDimOps, |tensor, axis, _| B::int_max_abs_dim(
+        reduce_ops!(MaxAbsDimOps, int, |tensor, axis, _| B::int_max_abs_dim(
             tensor, axis
         ));
 
@@ -1738,7 +1745,9 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
     }
 
     fn int_min_dim(tensor: IntTensor<Self>, dim: usize) -> IntTensor<Self> {
-        reduce_int_ops!(MinDimOps, |tensor, axis, _| B::int_min_dim(tensor, axis));
+        reduce_ops!(MinDimOps, int, |tensor, axis, _| B::int_min_dim(
+            tensor, axis
+        ));
 
         let streams = StreamId::current();
 

--- a/crates/burn-fusion/src/ops/tensor.rs
+++ b/crates/burn-fusion/src/ops/tensor.rs
@@ -2,8 +2,7 @@ use super::NoOp;
 use crate::{
     Fusion, FusionBackend, binary_float_cmp_ops, binary_float_ops,
     client::GlobalFusionClient,
-    get_client, reduce_float_ops, reduce_float2bool_ops, reduce_float2bool_whole_ops,
-    reduce_float2int_ops, scalar_float_cmp_ops, scalar_float_ops,
+    get_client, reduce_ops, scalar_float_cmp_ops, scalar_float_ops,
     stream::{StreamId, execution::Operation},
     unary_float_ops,
 };
@@ -1291,7 +1290,9 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
     }
 
     fn float_sum_dim(tensor: FloatTensor<Self>, axis: usize) -> FloatTensor<Self> {
-        reduce_float_ops!(SumDimOps, |tensor, axis, _| B::float_sum_dim(tensor, axis));
+        reduce_ops!(SumDimOps, float, |tensor, axis, _| B::float_sum_dim(
+            tensor, axis
+        ));
 
         let streams = StreamId::current();
 
@@ -1309,7 +1310,7 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
     }
 
     fn float_any(tensor: FloatTensor<Self>, out_dtype: BoolDType) -> BoolTensor<Self> {
-        reduce_float2bool_whole_ops!(FloatAnyOps, |tensor, dtype| B::float_any(tensor, dtype));
+        reduce_ops!(FloatAnyOps, float => bool, whole, |tensor, dtype| B::float_any(tensor, dtype));
 
         let streams = StreamId::current();
 
@@ -1334,9 +1335,7 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
         dim: usize,
         out_dtype: BoolDType,
     ) -> BoolTensor<Self> {
-        reduce_float2bool_ops!(FloatAnyDimOps, |tensor, axis, dtype| B::float_any_dim(
-            tensor, axis, dtype
-        ));
+        reduce_ops!(FloatAnyDimOps, float => bool, |tensor, axis, dtype| B::float_any_dim(tensor, axis, dtype));
 
         let streams = StreamId::current();
 
@@ -1355,7 +1354,7 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
     }
 
     fn float_all(tensor: FloatTensor<Self>, out_dtype: BoolDType) -> BoolTensor<Self> {
-        reduce_float2bool_whole_ops!(FloatAllOps, |tensor, dtype| B::float_all(tensor, dtype));
+        reduce_ops!(FloatAllOps, float => bool, whole, |tensor, dtype| B::float_all(tensor, dtype));
 
         let streams = StreamId::current();
 
@@ -1378,9 +1377,7 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
         dim: usize,
         out_dtype: BoolDType,
     ) -> BoolTensor<Self> {
-        reduce_float2bool_ops!(FloatAllDimOps, |tensor, axis, dtype| B::float_all_dim(
-            tensor, axis, dtype
-        ));
+        reduce_ops!(FloatAllDimOps, float => bool, |tensor, axis, dtype| B::float_all_dim(tensor, axis, dtype));
 
         let streams = StreamId::current();
 
@@ -1416,7 +1413,7 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
     }
 
     fn float_prod_dim(tensor: FloatTensor<Self>, dim: usize) -> FloatTensor<Self> {
-        reduce_float_ops!(ProdDimOps, |tensor, axis, _| B::float_prod_dim(
+        reduce_ops!(ProdDimOps, float, |tensor, axis, _| B::float_prod_dim(
             tensor, axis
         ));
 
@@ -1455,7 +1452,7 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
     }
 
     fn float_mean_dim(tensor: FloatTensor<Self>, dim: usize) -> FloatTensor<Self> {
-        reduce_float_ops!(MeanDimOps, |tensor, axis, _| B::float_mean_dim(
+        reduce_ops!(MeanDimOps, float, |tensor, axis, _| B::float_mean_dim(
             tensor, axis
         ));
 
@@ -1993,9 +1990,7 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
     }
 
     fn float_argmax(tensor: FloatTensor<Self>, dim: usize, out_dtype: IntDType) -> IntTensor<Self> {
-        reduce_float2int_ops!(ArgMaxOps, |input, axis, _, dtype| B::float_argmax(
-            input, axis, dtype
-        ));
+        reduce_ops!(ArgMaxOps, float => int, |input, axis, _, dtype| B::float_argmax(input, axis, dtype));
 
         let streams = StreamId::current();
 
@@ -2022,7 +2017,7 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
         k: usize,
         out_dtype: IntDType,
     ) -> IntTensor<Self> {
-        reduce_float2int_ops!(ArgTopKOps, B::float_argtopk);
+        reduce_ops!(ArgTopKOps, float => int, B::float_argtopk);
 
         let streams = StreamId::current();
 
@@ -2044,7 +2039,7 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
     }
 
     fn float_topk(tensor: FloatTensor<Self>, dim: usize, k: usize) -> FloatTensor<Self> {
-        reduce_float_ops!(TopKOps, B::float_topk);
+        reduce_ops!(TopKOps, float, B::float_topk);
 
         let streams = StreamId::current();
 
@@ -2094,9 +2089,7 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
     }
 
     fn float_argmin(tensor: FloatTensor<Self>, dim: usize, out_dtype: IntDType) -> IntTensor<Self> {
-        reduce_float2int_ops!(ArgMinOps, |input, axis, _, dtype| B::float_argmin(
-            input, axis, dtype
-        ));
+        reduce_ops!(ArgMinOps, float => int, |input, axis, _, dtype| B::float_argmin(input, axis, dtype));
 
         let streams = StreamId::current();
 
@@ -2135,7 +2128,9 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
     }
 
     fn float_max_dim(tensor: FloatTensor<Self>, dim: usize) -> FloatTensor<Self> {
-        reduce_float_ops!(MaxDimOps, |tensor, axis, _| B::float_max_dim(tensor, axis));
+        reduce_ops!(MaxDimOps, float, |tensor, axis, _| B::float_max_dim(
+            tensor, axis
+        ));
 
         let streams = StreamId::current();
 
@@ -2215,7 +2210,9 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
     }
 
     fn float_min_dim(tensor: FloatTensor<Self>, dim: usize) -> FloatTensor<Self> {
-        reduce_float_ops!(MinDimOps, |tensor, axis, _| B::float_min_dim(tensor, axis));
+        reduce_ops!(MinDimOps, float, |tensor, axis, _| B::float_min_dim(
+            tensor, axis
+        ));
 
         let streams = StreamId::current();
 
@@ -2294,7 +2291,7 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
     }
 
     fn float_max_abs_dim(tensor: FloatTensor<Self>, dim: usize) -> FloatTensor<Self> {
-        reduce_float_ops!(MaxAbsDimOps, |tensor, axis, _| B::float_max_abs_dim(
+        reduce_ops!(MaxAbsDimOps, float, |tensor, axis, _| B::float_max_abs_dim(
             tensor, axis
         ));
 

--- a/crates/burn-fusion/src/ops/tensor.rs
+++ b/crates/burn-fusion/src/ops/tensor.rs
@@ -2,7 +2,8 @@ use super::NoOp;
 use crate::{
     Fusion, FusionBackend, binary_float_cmp_ops, binary_float_ops,
     client::GlobalFusionClient,
-    get_client, reduce_float_ops, reduce_float2int_ops, scalar_float_cmp_ops, scalar_float_ops,
+    get_client, reduce_float_ops, reduce_float2bool_ops, reduce_float2bool_whole_ops,
+    reduce_float2int_ops, scalar_float_cmp_ops, scalar_float_ops,
     stream::{StreamId, execution::Operation},
     unary_float_ops,
 };
@@ -1303,6 +1304,96 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
                 streams,
                 OperationIr::NumericFloat(desc.out.dtype, NumericOperationIr::SumDim(desc.clone())),
                 SumDimOps::<B>::new(desc),
+            )
+            .output()
+    }
+
+    fn float_any(tensor: FloatTensor<Self>, out_dtype: BoolDType) -> BoolTensor<Self> {
+        reduce_float2bool_whole_ops!(FloatAnyOps, |tensor, dtype| B::float_any(tensor, dtype));
+
+        let streams = StreamId::current();
+
+        let client = tensor.client.clone();
+        // Whole-tensor `Any`: not fused (the reduce fuser only fuses `*Dim`), so it
+        // runs the bare backend's dedicated cubek Any instruction via the fallback.
+        let desc = ReduceOpIr::create_bool(tensor.into_ir(), out_dtype.into(), || {
+            client.create_empty_handle()
+        });
+
+        client
+            .register(
+                streams,
+                OperationIr::BaseFloat(BaseOperationIr::Any(desc.clone())),
+                FloatAnyOps::<B>::new(desc),
+            )
+            .output()
+    }
+
+    fn float_any_dim(
+        tensor: FloatTensor<Self>,
+        dim: usize,
+        out_dtype: BoolDType,
+    ) -> BoolTensor<Self> {
+        reduce_float2bool_ops!(FloatAnyDimOps, |tensor, axis, dtype| B::float_any_dim(
+            tensor, axis, dtype
+        ));
+
+        let streams = StreamId::current();
+
+        let client = tensor.client.clone();
+        let desc = ReduceDimOpIr::create_bool(tensor.into_ir(), dim, 1, out_dtype.into(), || {
+            client.create_empty_handle()
+        });
+
+        client
+            .register(
+                streams,
+                OperationIr::BaseFloat(BaseOperationIr::AnyDim(desc.clone())),
+                FloatAnyDimOps::<B>::new(desc),
+            )
+            .output()
+    }
+
+    fn float_all(tensor: FloatTensor<Self>, out_dtype: BoolDType) -> BoolTensor<Self> {
+        reduce_float2bool_whole_ops!(FloatAllOps, |tensor, dtype| B::float_all(tensor, dtype));
+
+        let streams = StreamId::current();
+
+        let client = tensor.client.clone();
+        let desc = ReduceOpIr::create_bool(tensor.into_ir(), out_dtype.into(), || {
+            client.create_empty_handle()
+        });
+
+        client
+            .register(
+                streams,
+                OperationIr::BaseFloat(BaseOperationIr::All(desc.clone())),
+                FloatAllOps::<B>::new(desc),
+            )
+            .output()
+    }
+
+    fn float_all_dim(
+        tensor: FloatTensor<Self>,
+        dim: usize,
+        out_dtype: BoolDType,
+    ) -> BoolTensor<Self> {
+        reduce_float2bool_ops!(FloatAllDimOps, |tensor, axis, dtype| B::float_all_dim(
+            tensor, axis, dtype
+        ));
+
+        let streams = StreamId::current();
+
+        let client = tensor.client.clone();
+        let desc = ReduceDimOpIr::create_bool(tensor.into_ir(), dim, 1, out_dtype.into(), || {
+            client.create_empty_handle()
+        });
+
+        client
+            .register(
+                streams,
+                OperationIr::BaseFloat(BaseOperationIr::AllDim(desc.clone())),
+                FloatAllDimOps::<B>::new(desc),
             )
             .output()
     }

--- a/crates/burn-fusion/src/ops/unary.rs
+++ b/crates/burn-fusion/src/ops/unary.rs
@@ -44,220 +44,55 @@ macro_rules! scalar_float_ops {
 
 #[allow(missing_docs)]
 #[macro_export(local_inner_macros)]
-macro_rules! reduce_float_ops {
-    (
-        $name:ident,
-        $ops:expr
-    ) => {
-        #[derive(new, Debug)]
-        struct $name<B: FusionBackend> {
-            desc: ReduceDimOpIr,
-            _b: PhantomData<B>,
-        }
-
-        impl<B: FusionBackend> Operation<B::FusionRuntime> for $name<B> {
-            fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
-                let input = handles.get_float_tensor::<B>(&self.desc.input);
-                let output = $ops(input, self.desc.axis, self.desc.accumulator_len);
-
-                handles.register_float_tensor::<B>(&self.desc.out.id, output);
-            }
-        }
+macro_rules! reduce_ops {
+    ($name:ident, float, $ops:expr) => {
+        $crate::reduce_ops!(@impl $name, ReduceDimOpIr, get_float_tensor, register_float_tensor, |input, desc| $ops(input, desc.axis, desc.accumulator_len));
     };
-}
-
-#[allow(missing_docs)]
-#[macro_export(local_inner_macros)]
-macro_rules! reduce_float2int_ops {
-    (
-        $name:ident,
-        $ops:expr
-    ) => {
-        #[derive(new, Debug)]
-        struct $name<B: FusionBackend> {
-            desc: ReduceDimOpIr,
-            _b: PhantomData<B>,
-        }
-
-        impl<B: FusionBackend> Operation<B::FusionRuntime> for $name<B> {
-            fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
-                let input = handles.get_float_tensor::<B>(&self.desc.input);
-                let output = $ops(
-                    input,
-                    self.desc.axis,
-                    self.desc.accumulator_len,
-                    self.desc.out.dtype.into(),
-                );
-
-                handles.register_int_tensor::<B>(&self.desc.out.id, output);
-            }
-        }
+    ($name:ident, float => int, $ops:expr) => {
+        $crate::reduce_ops!(@impl $name, ReduceDimOpIr, get_float_tensor, register_int_tensor, |input, desc| $ops(input, desc.axis, desc.accumulator_len, desc.out.dtype.into()));
     };
-}
-
-#[allow(missing_docs)]
-#[macro_export(local_inner_macros)]
-macro_rules! reduce_int_ops {
-    (
-        $name:ident,
-        $ops:expr
-    ) => {
-        #[derive(new, Debug)]
-        struct $name<B: FusionBackend> {
-            desc: ReduceDimOpIr,
-            _b: PhantomData<B>,
-        }
-
-        impl<B: FusionBackend> Operation<B::FusionRuntime> for $name<B> {
-            fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
-                let input = handles.get_int_tensor::<B>(&self.desc.input);
-                let output = $ops(input, self.desc.axis, self.desc.accumulator_len);
-
-                handles.register_int_tensor::<B>(&self.desc.out.id, output);
-            }
-        }
+    ($name:ident, int, $ops:expr) => {
+        $crate::reduce_ops!(@impl $name, ReduceDimOpIr, get_int_tensor, register_int_tensor, |input, desc| $ops(input, desc.axis, desc.accumulator_len));
     };
-}
-
-#[allow(missing_docs)]
-#[macro_export(local_inner_macros)]
-macro_rules! reduce_bool_ops {
-    (
-        $name:ident,
-        $ops:expr
-    ) => {
-        #[derive(new, Debug)]
-        struct $name<B: FusionBackend> {
-            desc: ReduceDimOpIr,
-            _b: PhantomData<B>,
-        }
-
-        impl<B: FusionBackend> Operation<B::FusionRuntime> for $name<B> {
-            fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
-                let input = handles.get_bool_tensor::<B>(&self.desc.input);
-                let output = $ops(input, self.desc.axis);
-
-                handles.register_bool_tensor::<B>(&self.desc.out.id, output);
-            }
-        }
+    ($name:ident, bool, $ops:expr) => {
+        $crate::reduce_ops!(@impl $name, ReduceDimOpIr, get_bool_tensor, register_bool_tensor, |input, desc| $ops(input, desc.axis));
     };
-}
-
-#[allow(missing_docs)]
-#[macro_export(local_inner_macros)]
-macro_rules! reduce_float2bool_ops {
-    (
-        $name:ident,
-        $ops:expr
-    ) => {
-        #[derive(new, Debug)]
-        struct $name<B: FusionBackend> {
-            desc: ReduceDimOpIr,
-            _b: PhantomData<B>,
-        }
-
-        impl<B: FusionBackend> Operation<B::FusionRuntime> for $name<B> {
-            fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
-                let input = handles.get_float_tensor::<B>(&self.desc.input);
-                let output = $ops(input, self.desc.axis, self.desc.out.dtype.into());
-
-                handles.register_bool_tensor::<B>(&self.desc.out.id, output);
-            }
-        }
+    ($name:ident, float => bool, $ops:expr) => {
+        $crate::reduce_ops!(@impl $name, ReduceDimOpIr, get_float_tensor, register_bool_tensor, |input, desc| $ops(input, desc.axis, desc.out.dtype.into()));
     };
-}
-
-#[allow(missing_docs)]
-#[macro_export(local_inner_macros)]
-macro_rules! reduce_int2bool_ops {
-    (
-        $name:ident,
-        $ops:expr
-    ) => {
-        #[derive(new, Debug)]
-        struct $name<B: FusionBackend> {
-            desc: ReduceDimOpIr,
-            _b: PhantomData<B>,
-        }
-
-        impl<B: FusionBackend> Operation<B::FusionRuntime> for $name<B> {
-            fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
-                let input = handles.get_int_tensor::<B>(&self.desc.input);
-                let output = $ops(input, self.desc.axis, self.desc.out.dtype.into());
-
-                handles.register_bool_tensor::<B>(&self.desc.out.id, output);
-            }
-        }
+    ($name:ident, int => bool, $ops:expr) => {
+        $crate::reduce_ops!(@impl $name, ReduceDimOpIr, get_int_tensor, register_bool_tensor, |input, desc| $ops(input, desc.axis, desc.out.dtype.into()));
     };
-}
-
-#[allow(missing_docs)]
-#[macro_export(local_inner_macros)]
-macro_rules! reduce_bool_whole_ops {
-    (
-        $name:ident,
-        $ops:expr
-    ) => {
-        #[derive(new, Debug)]
-        struct $name<B: FusionBackend> {
-            desc: ReduceOpIr,
-            _b: PhantomData<B>,
-        }
-
-        impl<B: FusionBackend> Operation<B::FusionRuntime> for $name<B> {
-            fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
-                let input = handles.get_bool_tensor::<B>(&self.desc.input);
-                let output = $ops(input);
-
-                handles.register_bool_tensor::<B>(&self.desc.out.id, output);
-            }
-        }
+    ($name:ident, bool, whole, $ops:expr) => {
+        $crate::reduce_ops!(@impl $name, ReduceOpIr, get_bool_tensor, register_bool_tensor, |input, _desc| $ops(input));
     };
-}
-
-#[allow(missing_docs)]
-#[macro_export(local_inner_macros)]
-macro_rules! reduce_float2bool_whole_ops {
-    (
-        $name:ident,
-        $ops:expr
-    ) => {
-        #[derive(new, Debug)]
-        struct $name<B: FusionBackend> {
-            desc: ReduceOpIr,
-            _b: PhantomData<B>,
-        }
-
-        impl<B: FusionBackend> Operation<B::FusionRuntime> for $name<B> {
-            fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
-                let input = handles.get_float_tensor::<B>(&self.desc.input);
-                let output = $ops(input, self.desc.out.dtype.into());
-
-                handles.register_bool_tensor::<B>(&self.desc.out.id, output);
-            }
-        }
+    ($name:ident, float => bool, whole, $ops:expr) => {
+        $crate::reduce_ops!(@impl $name, ReduceOpIr, get_float_tensor, register_bool_tensor, |input, desc| $ops(input, desc.out.dtype.into()));
     };
-}
-
-#[allow(missing_docs)]
-#[macro_export(local_inner_macros)]
-macro_rules! reduce_int2bool_whole_ops {
+    ($name:ident, int => bool, whole, $ops:expr) => {
+        $crate::reduce_ops!(@impl $name, ReduceOpIr, get_int_tensor, register_bool_tensor, |input, desc| $ops(input, desc.out.dtype.into()));
+    };
     (
+        @impl
         $name:ident,
-        $ops:expr
+        $desc:ty,
+        $get:ident,
+        $register:ident,
+        |$input:ident, $ir:ident| $ops:expr
     ) => {
         #[derive(new, Debug)]
         struct $name<B: FusionBackend> {
-            desc: ReduceOpIr,
+            desc: $desc,
             _b: PhantomData<B>,
         }
 
         impl<B: FusionBackend> Operation<B::FusionRuntime> for $name<B> {
             fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
-                let input = handles.get_int_tensor::<B>(&self.desc.input);
-                let output = $ops(input, self.desc.out.dtype.into());
+                let $input = handles.$get::<B>(&self.desc.input);
+                let $ir = &self.desc;
+                let output = $ops;
 
-                handles.register_bool_tensor::<B>(&self.desc.out.id, output);
+                handles.$register::<B>(&self.desc.out.id, output);
             }
         }
     };

--- a/crates/burn-fusion/src/ops/unary.rs
+++ b/crates/burn-fusion/src/ops/unary.rs
@@ -121,6 +121,150 @@ macro_rules! reduce_int_ops {
 
 #[allow(missing_docs)]
 #[macro_export(local_inner_macros)]
+macro_rules! reduce_bool_ops {
+    (
+        $name:ident,
+        $ops:expr
+    ) => {
+        #[derive(new, Debug)]
+        struct $name<B: FusionBackend> {
+            desc: ReduceDimOpIr,
+            _b: PhantomData<B>,
+        }
+
+        impl<B: FusionBackend> Operation<B::FusionRuntime> for $name<B> {
+            fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
+                let input = handles.get_bool_tensor::<B>(&self.desc.input);
+                let output = $ops(input, self.desc.axis);
+
+                handles.register_bool_tensor::<B>(&self.desc.out.id, output);
+            }
+        }
+    };
+}
+
+#[allow(missing_docs)]
+#[macro_export(local_inner_macros)]
+macro_rules! reduce_float2bool_ops {
+    (
+        $name:ident,
+        $ops:expr
+    ) => {
+        #[derive(new, Debug)]
+        struct $name<B: FusionBackend> {
+            desc: ReduceDimOpIr,
+            _b: PhantomData<B>,
+        }
+
+        impl<B: FusionBackend> Operation<B::FusionRuntime> for $name<B> {
+            fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
+                let input = handles.get_float_tensor::<B>(&self.desc.input);
+                let output = $ops(input, self.desc.axis, self.desc.out.dtype.into());
+
+                handles.register_bool_tensor::<B>(&self.desc.out.id, output);
+            }
+        }
+    };
+}
+
+#[allow(missing_docs)]
+#[macro_export(local_inner_macros)]
+macro_rules! reduce_int2bool_ops {
+    (
+        $name:ident,
+        $ops:expr
+    ) => {
+        #[derive(new, Debug)]
+        struct $name<B: FusionBackend> {
+            desc: ReduceDimOpIr,
+            _b: PhantomData<B>,
+        }
+
+        impl<B: FusionBackend> Operation<B::FusionRuntime> for $name<B> {
+            fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
+                let input = handles.get_int_tensor::<B>(&self.desc.input);
+                let output = $ops(input, self.desc.axis, self.desc.out.dtype.into());
+
+                handles.register_bool_tensor::<B>(&self.desc.out.id, output);
+            }
+        }
+    };
+}
+
+#[allow(missing_docs)]
+#[macro_export(local_inner_macros)]
+macro_rules! reduce_bool_whole_ops {
+    (
+        $name:ident,
+        $ops:expr
+    ) => {
+        #[derive(new, Debug)]
+        struct $name<B: FusionBackend> {
+            desc: ReduceOpIr,
+            _b: PhantomData<B>,
+        }
+
+        impl<B: FusionBackend> Operation<B::FusionRuntime> for $name<B> {
+            fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
+                let input = handles.get_bool_tensor::<B>(&self.desc.input);
+                let output = $ops(input);
+
+                handles.register_bool_tensor::<B>(&self.desc.out.id, output);
+            }
+        }
+    };
+}
+
+#[allow(missing_docs)]
+#[macro_export(local_inner_macros)]
+macro_rules! reduce_float2bool_whole_ops {
+    (
+        $name:ident,
+        $ops:expr
+    ) => {
+        #[derive(new, Debug)]
+        struct $name<B: FusionBackend> {
+            desc: ReduceOpIr,
+            _b: PhantomData<B>,
+        }
+
+        impl<B: FusionBackend> Operation<B::FusionRuntime> for $name<B> {
+            fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
+                let input = handles.get_float_tensor::<B>(&self.desc.input);
+                let output = $ops(input, self.desc.out.dtype.into());
+
+                handles.register_bool_tensor::<B>(&self.desc.out.id, output);
+            }
+        }
+    };
+}
+
+#[allow(missing_docs)]
+#[macro_export(local_inner_macros)]
+macro_rules! reduce_int2bool_whole_ops {
+    (
+        $name:ident,
+        $ops:expr
+    ) => {
+        #[derive(new, Debug)]
+        struct $name<B: FusionBackend> {
+            desc: ReduceOpIr,
+            _b: PhantomData<B>,
+        }
+
+        impl<B: FusionBackend> Operation<B::FusionRuntime> for $name<B> {
+            fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
+                let input = handles.get_int_tensor::<B>(&self.desc.input);
+                let output = $ops(input, self.desc.out.dtype.into());
+
+                handles.register_bool_tensor::<B>(&self.desc.out.id, output);
+            }
+        }
+    };
+}
+
+#[allow(missing_docs)]
+#[macro_export(local_inner_macros)]
 macro_rules! scalar_float2int_ops {
     (
         $name:ident,


### PR DESCRIPTION
`Fusion<CubeBackend>` (the default Wgpu/Cuda backend) didn't override `*_any`/`*_all`, so they fell back to the default `into_int -> sum ->compare` emulation. The reduce fuser also only matched `NumericOperationIr::*Dim`, never `BaseOperationIr::AnyDim/AllDim`, so cubek's dedicated single-pass Any (max-of-flags) / All (min-of-flags) instruction was dead code on the default backends — leaving `any`/`all` ~2-7x slower than necessary for a memory-bound reduce.

- burn-cubecl-fusion: add `ReduceInstruction::Any/All`, map them to `ReduceOperationConfig::Any/All`, and recognize `BaseOperationIr::AnyDim/AllDim` in the reduce fuser (and the broadcasted fuser).
- burn-fusion: override `{bool,float,int}_{any,all}{,_dim}` for `Fusion<B>`. The `*_dim` variants record `AnyDim/AllDim` so they fuse through cubek's instruction; the whole-tensor variants record `BaseOperationIr::Any/All` and run via the bare-backend reduce, the same way whole-tensor `sum`/`prod` are handled.

No IR or cubek changes were needed: the IR variants and their relativization already existed (used by the bare backend and burn-router).
Tested on wgpu and cuda (RTX 5060 Ti): new fusion correctness tests in `tests/fusion/reduce_logical.rs` plus the existing any/all suite pass on both backends; measured 2.2-7.6x faster than the sum-emulation it replaces.

## Pull Request Template

### Checklist

- [x ] Confirmed that `cargo run-checks` command has been executed.
- [ x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

#5108 


### Testing

| shape         | wgpu before | wgpu after | cuda before | cuda after |
|---------------|-------------|------------|-------------|------------|
| 4096×4096     | 0.90        | 0.36   | 0.58        | 0.17  |
| 1048576×64    | 3.01        | 1.02   | 2.80        | 0.94   |
| 256×262144    | 2.81        | 0.82   | 2.19        | 0.78   |

 Added `tests/fusion/reduce_logical.rs` covering the fused `any`/`all` path for bool / float / int inputs, both `*_dim` and whole-tensor reductions, against a CPU reference. The reduced dimension is deliberately wide (257) so the reduction spans several plane/cube blocks that must merge, and the float/int inputs mix magnitudes and signs (incl. negatives) to exercise the bool→flag normalization inside the instruction.

Verified on:
- **CUDA** (RTX 5060 Ti, CUDA 13.0) — new `reduce_logical` suite (10/10) and the existing `any`/`all` tensor tests pass.
- **wgpu** — same suites pass.
