### PR TITLE
Implement int_scatter_nd for autodiff backend

### DIFF
--- a/crates/burn-autodiff/src/ops/int_tensor.rs
+++ b/crates/burn-autodiff/src/ops/int_tensor.rs
@@ -6,7 +6,7 @@ use burn_backend::{
     ops::IntTensorOps,
     tensor::{BoolTensor, Device, FloatTensor, IntTensor},
 };
-use burn_std::{BoolDType, FloatDType, IntDType, Shape};
+use burn_std::{BoolDType, FloatDType, IndexingUpdateOp, IntDType, Shape};
 
 impl<B: Backend, C: CheckpointStrategy> IntTensorOps<Self> for Autodiff<B, C> {
     fn int_from_data(data: TensorData, device: &Device<Self>) -> IntTensor<B> {
@@ -221,6 +221,15 @@ impl<B: Backend, C: CheckpointStrategy> IntTensorOps<Self> for Autodiff<B, C> {
         value: IntTensor<B>,
     ) -> IntTensor<B> {
         B::int_scatter_add(dim, tensor, indices, value)
+    }
+
+    fn int_scatter_nd(
+        data: IntTensor<B>,
+        indices: IntTensor<B>,
+        values: IntTensor<B>,
+        reduction: IndexingUpdateOp,
+    ) -> IntTensor<B> {
+        B::int_scatter_nd(data, indices, values, reduction)
     }
 
     fn int_select(tensor: IntTensor<B>, dim: usize, indices: IntTensor<B>) -> IntTensor<B> {


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

_Provide links to relevant issues and dependent PRs._

Follow up to https://github.com/tracel-ai/burn/pull/4709 and #4909, extending autodiff support to `int_scatter_nd`.

### Changes

_Summarize the problem being addressed and your solution._

Fix `not implemented: int_scatter_nd is not implemented for this backend` when using `Autodiff<Dispatch>` backend. Error was raised here:

https://github.com/tracel-ai/burn/blob/458e5727b8302d2c50bff202aa6bdb05126b94dc/crates/burn-backend/src/backend/ops/int_tensor.rs#L180-L188

### Testing

_Describe how these changes have been tested._

Have tested training a model (RF-DETR) locally through burn-onnx with this patch, seems to work. Can try to add a unit test if needed.