### PR TITLE
fix metric logging when checkpoint + burn-train integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,6 +1219,7 @@ dependencies = [
  "serde",
  "sysinfo 0.38.4",
  "systemstat",
+ "tempfile",
  "thiserror 2.0.18",
  "tracing-appender",
  "tracing-core",

--- a/crates/burn-train/Cargo.toml
+++ b/crates/burn-train/Cargo.toml
@@ -64,6 +64,9 @@ rstest.workspace = true
 thiserror.workspace = true
 rand.workspace = true
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [package.metadata.docs.rs]
 features = ["doc"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/burn-train/src/checkpoint/strategy/metric.rs
+++ b/crates/burn-train/src/checkpoint/strategy/metric.rs
@@ -75,6 +75,7 @@ mod tests {
             },
             store::LogEventStore,
         },
+        test_utils::start_epoch,
     };
 
     use super::*;
@@ -104,6 +105,7 @@ mod tests {
 
         // Two points for the first epoch. Mean 0.75
         let mut epoch = 1;
+        start_epoch(&mut processor, epoch, 2);
         process_train(&mut processor, 1.0, epoch);
         process_train(&mut processor, 0.5, epoch);
         end_epoch(&mut processor, epoch);
@@ -116,6 +118,7 @@ mod tests {
 
         // Two points for the second epoch. Mean 0.4
         epoch += 1;
+        start_epoch(&mut processor, epoch, 2);
         process_train(&mut processor, 0.5, epoch);
         process_train(&mut processor, 0.3, epoch);
         end_epoch(&mut processor, epoch);
@@ -128,6 +131,7 @@ mod tests {
 
         // Two points for the last epoch. Mean 2.0
         epoch += 1;
+        start_epoch(&mut processor, epoch, 2);
         process_train(&mut processor, 1.0, epoch);
         process_train(&mut processor, 3.0, epoch);
         end_epoch(&mut processor, epoch);

--- a/crates/burn-train/src/learner/early_stopping.rs
+++ b/crates/burn-train/src/learner/early_stopping.rs
@@ -181,6 +181,7 @@ mod tests {
             },
             store::LogEventStore,
         },
+        test_utils::start_epoch,
     };
 
     use super::*;
@@ -284,6 +285,7 @@ mod tests {
             starting_epoch: 0,
         });
         for (epoch, (points, should_start, comment)) in (1..).zip(data.iter()) {
+            start_epoch(&mut processor, epoch, points.len());
             for point in points.iter() {
                 process_train(&mut processor, *point, epoch);
             }

--- a/crates/burn-train/src/learner/supervised/strategies/ddp/worker.rs
+++ b/crates/burn-train/src/learner/supervised/strategies/ddp/worker.rs
@@ -85,7 +85,10 @@ where
                 self.event_processor
                     .lock()
                     .unwrap()
-                    .process_train(LearnerEvent::StartSplit(self.components.train_total_items));
+                    .process_train(LearnerEvent::StartSplit {
+                        epoch_number: epoch,
+                        total_items: self.components.train_total_items,
+                    });
             }
 
             epoch_train.run(
@@ -113,7 +116,10 @@ where
                     self.event_processor
                         .lock()
                         .unwrap()
-                        .process_valid(LearnerEvent::StartSplit(self.components.valid_total_items));
+                        .process_valid(LearnerEvent::StartSplit {
+                            epoch_number: epoch,
+                            total_items: self.components.valid_total_items,
+                        });
                 }
                 let mut event_processor = self.event_processor.lock().unwrap();
                 runner.run(

--- a/crates/burn-train/src/learner/supervised/strategies/multi/strategy.rs
+++ b/crates/burn-train/src/learner/supervised/strategies/multi/strategy.rs
@@ -51,7 +51,10 @@ impl<LC: LearningComponentsTypes> SupervisedLearningStrategy<LC> for MultiDevice
         for training_progress in TrainingLoop::new(starting_epoch, training_components.num_epochs) {
             let epoch = training_progress.items_processed;
 
-            event_processor.process_train(LearnerEvent::StartSplit(train_total_items));
+            event_processor.process_train(LearnerEvent::StartSplit {
+                epoch_number: epoch,
+                total_items: train_total_items,
+            });
             epoch_train.run(
                 &mut learner,
                 &training_progress,
@@ -77,7 +80,10 @@ impl<LC: LearningComponentsTypes> SupervisedLearningStrategy<LC> for MultiDevice
                 learner.fork(main_device);
             }
 
-            event_processor.process_valid(LearnerEvent::StartSplit(valid_total_items));
+            event_processor.process_valid(LearnerEvent::StartSplit {
+                epoch_number: epoch,
+                total_items: valid_total_items,
+            });
             epoch_valid.run(
                 &learner,
                 &training_progress,

--- a/crates/burn-train/src/learner/supervised/strategies/single/strategy.rs
+++ b/crates/burn-train/src/learner/supervised/strategies/single/strategy.rs
@@ -69,7 +69,10 @@ impl<LC: LearningComponentsTypes> SupervisedLearningStrategy<LC> for SingleDevic
         for training_progress in TrainingLoop::new(starting_epoch, training_components.num_epochs) {
             let epoch = training_progress.items_processed;
 
-            event_processor.process_train(LearnerEvent::StartSplit(train_total_items));
+            event_processor.process_train(LearnerEvent::StartSplit {
+                epoch_number: epoch,
+                total_items: train_total_items,
+            });
             epoch_train.run(
                 &mut learner,
                 &training_progress,
@@ -87,7 +90,10 @@ impl<LC: LearningComponentsTypes> SupervisedLearningStrategy<LC> for SingleDevic
                 break;
             }
 
-            event_processor.process_valid(LearnerEvent::StartSplit(valid_total_items));
+            event_processor.process_valid(LearnerEvent::StartSplit {
+                epoch_number: epoch,
+                total_items: valid_total_items,
+            });
             epoch_valid.run(
                 &learner,
                 &training_progress,

--- a/crates/burn-train/src/metric/processor/base.rs
+++ b/crates/burn-train/src/metric/processor/base.rs
@@ -17,8 +17,13 @@ pub enum LearnerEvent<T> {
     },
     /// Signal that an item have been processed.
     ProcessedItem(TrainingItem<T>),
-    /// Signal the start of a split, carrying the total number of items in that split.
-    StartSplit(usize),
+    /// Signal the start of a split.
+    StartSplit {
+        /// The epoch number.
+        epoch_number: usize,
+        /// The total number of items to be processed during this split.
+        total_items: usize,
+    },
     /// Signal the end of a split, carrying the current epoch number.
     EndSplit(usize),
     /// Signal the end of a full epoch.

--- a/crates/burn-train/src/metric/processor/full.rs
+++ b/crates/burn-train/src/metric/processor/full.rs
@@ -187,10 +187,15 @@ impl<T: ItemLazy, V: ItemLazy> EventProcessorTraining<LearnerEvent<T>, LearnerEv
                 }
                 self.renderer.start(total_epochs, starting_epoch, None);
             }
-            LearnerEvent::StartSplit(total_items) => {
-                self.renderer.start_split("train", total_items);
+            LearnerEvent::StartSplit {
+                epoch_number,
+                total_items,
+            } => {
+                self.store
+                    .add_event_train(crate::metric::store::Event::StartSplit(epoch_number));
+                self.renderer.start_split(Split::Train.into(), total_items);
                 if let Some(logger) = &mut self.progress_logger {
-                    logger.start_split("train", total_items);
+                    logger.start_split(Split::Train.into(), total_items);
                 }
             }
             LearnerEvent::ProcessedItem(item) => {
@@ -260,11 +265,16 @@ impl<T: ItemLazy, V: ItemLazy> EventProcessorTraining<LearnerEvent<T>, LearnerEv
     fn process_valid(&mut self, event: LearnerEvent<V>) {
         match event {
             LearnerEvent::Start { .. } => {} // no-op: valid has no separate start event
-            LearnerEvent::StartSplit(total_items) => {
+            LearnerEvent::StartSplit {
+                epoch_number,
+                total_items,
+            } => {
+                self.store
+                    .add_event_valid(crate::metric::store::Event::StartSplit(epoch_number));
                 if let Some(logger) = &mut self.progress_logger {
-                    logger.start_split("valid", total_items);
+                    logger.start_split(Split::Valid.into(), total_items);
                 }
-                self.renderer.start_split("valid", total_items);
+                self.renderer.start_split(Split::Valid.into(), total_items);
             }
             LearnerEvent::ProcessedItem(item) => {
                 let item = item.sync();

--- a/crates/burn-train/src/metric/processor/minimal.rs
+++ b/crates/burn-train/src/metric/processor/minimal.rs
@@ -48,9 +48,14 @@ impl<T: ItemLazy, V: ItemLazy> EventProcessorTraining<LearnerEvent<T>, LearnerEv
                     logger.start(total_epochs, starting_epoch, None);
                 }
             }
-            LearnerEvent::StartSplit(total_items) => {
+            LearnerEvent::StartSplit {
+                epoch_number,
+                total_items,
+            } => {
+                self.store
+                    .add_event_train(crate::metric::store::Event::StartSplit(epoch_number));
                 if let Some(logger) = &mut self.progress_logger {
-                    logger.start_split("train", total_items);
+                    logger.start_split(Split::Train.into(), total_items);
                 }
             }
             LearnerEvent::ProcessedItem(item) => {
@@ -92,9 +97,14 @@ impl<T: ItemLazy, V: ItemLazy> EventProcessorTraining<LearnerEvent<T>, LearnerEv
     fn process_valid(&mut self, event: LearnerEvent<V>) {
         match event {
             LearnerEvent::Start { .. } => {} // no-op
-            LearnerEvent::StartSplit(total_items) => {
+            LearnerEvent::StartSplit {
+                epoch_number,
+                total_items,
+            } => {
+                self.store
+                    .add_event_valid(crate::metric::store::Event::StartSplit(epoch_number));
                 if let Some(logger) = &mut self.progress_logger {
-                    logger.start_split("valid", total_items);
+                    logger.start_split(Split::Valid.into(), total_items);
                 }
             }
             LearnerEvent::ProcessedItem(item) => {

--- a/crates/burn-train/src/metric/processor/mod.rs
+++ b/crates/burn-train/src/metric/processor/mod.rs
@@ -63,6 +63,21 @@ pub(crate) mod test_utils {
         )));
     }
 
+    pub(crate) fn start_epoch(
+        processor: &mut MinimalEventProcessor<f64, f64>,
+        epoch: usize,
+        num_items: usize,
+    ) {
+        processor.process_train(LearnerEvent::StartSplit {
+            epoch_number: epoch,
+            total_items: num_items,
+        });
+        processor.process_valid(LearnerEvent::StartSplit {
+            epoch_number: epoch,
+            total_items: num_items,
+        });
+    }
+
     pub(crate) fn end_epoch(processor: &mut MinimalEventProcessor<f64, f64>, epoch: usize) {
         processor.process_train(LearnerEvent::EndSplit(epoch));
         processor.process_valid(LearnerEvent::EndSplit(epoch));

--- a/crates/burn-train/src/metric/store/base.rs
+++ b/crates/burn-train/src/metric/store/base.rs
@@ -97,9 +97,9 @@ impl std::fmt::Display for Split {
     }
 }
 
-impl Into<&'static str> for Split {
-    fn into(self) -> &'static str {
-        match self {
+impl From<Split> for &'static str {
+    fn from(value: Split) -> Self {
+        match value {
             Split::Train => "train",
             Split::Valid => "valid",
             Split::Test(_) => "test",

--- a/crates/burn-train/src/metric/store/base.rs
+++ b/crates/burn-train/src/metric/store/base.rs
@@ -4,7 +4,9 @@ use crate::metric::{MetricDefinition, MetricEntry, NumericEntry};
 
 /// Event happening during the training/validation process.
 pub enum Event {
-    /// Signal the iniialization of the metrics
+    /// Signal the start of an epoch with the wpoch number.
+    StartSplit(usize),
+    /// Signal the initialization of the metrics
     MetricsInit(Vec<MetricDefinition>),
     /// Signal that metrics have been updated.
     MetricsUpdate(MetricsUpdate),
@@ -91,6 +93,16 @@ impl std::fmt::Display for Split {
             Split::Train => write!(f, "train"),
             Split::Valid => write!(f, "valid"),
             Split::Test(_) => write!(f, "test"),
+        }
+    }
+}
+
+impl Into<&'static str> for Split {
+    fn into(self) -> &'static str {
+        match self {
+            Split::Train => "train",
+            Split::Valid => "valid",
+            Split::Test(_) => "test",
         }
     }
 }

--- a/crates/burn-train/src/metric/store/log.rs
+++ b/crates/burn-train/src/metric/store/log.rs
@@ -15,6 +15,9 @@ impl EventStore for LogEventStore {
         let epoch = *self.epochs.entry(split.clone()).or_insert(1);
 
         match event {
+            Event::StartSplit(epoch) => {
+                self.epochs.insert(split, epoch);
+            }
             Event::MetricsInit(definitions) => {
                 self.aggregate.register_definitions(&definitions);
                 definitions.iter().for_each(|def| {
@@ -29,7 +32,6 @@ impl EventStore for LogEventStore {
                     .for_each(|logger| logger.log(update.clone(), epoch, &split));
             }
             Event::EndEpoch(summary) => {
-                self.epochs.insert(split, summary.epoch_number + 1);
                 self.loggers
                     .iter_mut()
                     .for_each(|logger| logger.log_epoch_summary(summary.clone()));

--- a/crates/burn-train/tests/checkpoint.rs
+++ b/crates/burn-train/tests/checkpoint.rs
@@ -80,7 +80,7 @@ fn checkpoint_resume_continues_training() {
             .launch(make_learner(&device));
     }
 
-    for epoch in 0..=4 {
+    for epoch in 1..=4 {
         let path = dir_path
             .join("checkpoint")
             .join(format!("model-{epoch}.bpk"));

--- a/crates/burn-train/tests/checkpoint.rs
+++ b/crates/burn-train/tests/checkpoint.rs
@@ -1,0 +1,261 @@
+//! Integration tests for checkpoint saving/loading in a minimal supervised training loop.
+
+mod common;
+use std::fs;
+
+use common::*;
+
+use burn_core::tensor::Device;
+use burn_train::{
+    SupervisedTraining, checkpoint::KeepLastNCheckpoints, logger::InMemoryMetricLogger,
+    metric::LossMetric,
+};
+
+#[test]
+fn checkpoint_saves_bpk_files() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let dir_path = dir.path().to_path_buf();
+    let checkpoint_dir = dir_path.join("checkpoint");
+
+    let device = Device::flex().autodiff();
+    let (dl_train, dl_valid) = make_dataloaders();
+
+    SupervisedTraining::new(&dir_path, dl_train, dl_valid)
+        .num_epochs(3)
+        .with_default_checkpointers()
+        .with_checkpointing_strategy(KeepLastNCheckpoints::new(3))
+        .with_metric_logger(InMemoryMetricLogger::new())
+        .metric_train_numeric(LossMetric::new())
+        .metric_valid_numeric(LossMetric::new())
+        .with_application_logger(None)
+        .launch(make_learner(&device));
+
+    for epoch in 1..=3 {
+        let model_path = checkpoint_dir.join(format!("model-{epoch}.bpk"));
+        assert!(
+            model_path.exists(),
+            "expected checkpoint file: {}",
+            model_path.display()
+        );
+    }
+}
+
+/// Training can resume from a saved checkpoint: `SupervisedTraining::checkpoint(epoch)` loads
+/// the model/optimizer/scheduler and continues from the next epoch.
+#[test]
+fn checkpoint_resume_continues_training() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let dir_path = dir.path().to_path_buf();
+
+    let device = Device::flex().autodiff();
+
+    {
+        let (dl_train, dl_valid) = make_dataloaders();
+        SupervisedTraining::new(&dir_path, dl_train, dl_valid)
+            .num_epochs(2)
+            .with_default_checkpointers()
+            .with_checkpointing_strategy(KeepLastNCheckpoints::new(2))
+            .with_metric_logger(InMemoryMetricLogger::new())
+            .metric_train_numeric(LossMetric::new())
+            .metric_valid_numeric(LossMetric::new())
+            .with_application_logger(None)
+            .launch(make_learner(&device));
+    }
+
+    let ckpt = dir_path.join("checkpoint").join("model-2.bpk");
+    assert!(ckpt.exists(), "epoch-2 checkpoint must exist before resume");
+
+    // Resume from epoch 2 and train up to epoch 4.
+    {
+        let (dl_train, dl_valid) = make_dataloaders();
+        SupervisedTraining::new(&dir_path, dl_train, dl_valid)
+            .num_epochs(4)
+            .checkpoint(2)
+            .with_default_checkpointers()
+            .with_checkpointing_strategy(KeepLastNCheckpoints::new(4))
+            .with_metric_logger(InMemoryMetricLogger::new())
+            .metric_train_numeric(LossMetric::new())
+            .metric_valid_numeric(LossMetric::new())
+            .with_application_logger(None)
+            .launch(make_learner(&device));
+    }
+
+    for epoch in 0..=4 {
+        let path = dir_path
+            .join("checkpoint")
+            .join(format!("model-{epoch}.bpk"));
+        assert!(
+            path.exists(),
+            "expected checkpoint file for epoch {epoch}: {}",
+            path.display()
+        );
+    }
+}
+
+#[test]
+fn checkpoint_restores_model_weights() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let dir_path = dir.path().to_path_buf();
+
+    let device = Device::flex().autodiff();
+    let (dl_train, dl_valid) = make_dataloaders();
+
+    let result = SupervisedTraining::new(&dir_path, dl_train, dl_valid)
+        .num_epochs(1)
+        .with_default_checkpointers()
+        .with_checkpointing_strategy(KeepLastNCheckpoints::new(1))
+        .with_metric_logger(InMemoryMetricLogger::new())
+        .metric_train_numeric(LossMetric::new())
+        .metric_valid_numeric(LossMetric::new())
+        .with_application_logger(None)
+        .launch(make_learner(&device));
+
+    let trained_weights = result
+        .model
+        .weight
+        .val()
+        .into_data()
+        .to_vec::<f32>()
+        .unwrap();
+
+    // Load the checkpoint into a fresh learner
+    use burn_train::{
+        LearningCheckpointer,
+        checkpoint::{AsyncCheckpointer, FileCheckpointer},
+    };
+
+    let ckpt_dir = dir_path.join("checkpoint");
+    let checkpointer = LearningCheckpointer::new(
+        AsyncCheckpointer::new(FileCheckpointer::new(&ckpt_dir, "model")),
+        AsyncCheckpointer::new(FileCheckpointer::new(&ckpt_dir, "optim")),
+        AsyncCheckpointer::new(FileCheckpointer::new(&ckpt_dir, "scheduler")),
+        Box::new(KeepLastNCheckpoints::new(1)),
+    );
+
+    let fresh = make_learner(&device);
+    let restored = checkpointer.load_checkpoint(fresh, 1);
+
+    let restored_weights = restored
+        .model()
+        .weight
+        .val()
+        .into_data()
+        .to_vec::<f32>()
+        .unwrap();
+
+    assert_eq!(
+        trained_weights, restored_weights,
+        "restored weights must match the saved checkpoint"
+    );
+}
+
+#[test]
+fn file_metric_logger_creates_log_directories() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let dir_path = dir.path().to_path_buf();
+
+    let device = Device::flex().autodiff();
+    let (dl_train, dl_valid) = make_dataloaders();
+
+    use burn_train::logger::FileMetricLogger;
+
+    SupervisedTraining::new(&dir_path, dl_train, dl_valid)
+        .num_epochs(2)
+        .with_metric_logger(FileMetricLogger::new(&dir_path))
+        .metric_train_numeric(LossMetric::new())
+        .metric_valid_numeric(LossMetric::new())
+        .with_application_logger(None)
+        .launch(make_learner(&device));
+
+    for epoch in 1..=2 {
+        let train_dir = dir_path.join("train").join(format!("epoch-{epoch}"));
+        let valid_dir = dir_path.join("valid").join(format!("epoch-{epoch}"));
+
+        assert!(
+            train_dir.exists(),
+            "missing train log dir for epoch {epoch}: {}",
+            train_dir.display()
+        );
+        assert!(
+            valid_dir.exists(),
+            "missing valid log dir for epoch {epoch}: {}",
+            valid_dir.display()
+        );
+    }
+}
+
+#[test]
+fn file_metric_logger_resumes_logging_at_checkpoint() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let dir_path = dir.path().to_path_buf();
+
+    let device = Device::flex().autodiff();
+    let (dl_train, dl_valid) = make_dataloaders();
+
+    use burn_train::logger::FileMetricLogger;
+
+    {
+        SupervisedTraining::new(&dir_path, dl_train, dl_valid)
+            .num_epochs(1)
+            .with_metric_logger(FileMetricLogger::new(&dir_path))
+            .metric_train_numeric(LossMetric::new())
+            .metric_valid_numeric(LossMetric::new())
+            .with_default_checkpointers()
+            .with_application_logger(None)
+            .launch(make_learner(&device));
+    }
+
+    let loss_file_train = dir_path.join("train").join("epoch-1/Loss.log");
+    let loss_file_valid = dir_path.join("valid").join("epoch-1/Loss.log");
+
+    let content_train_expected = fs::read(loss_file_train).expect("Cannot read file.");
+    let content_valid_expected = fs::read(loss_file_valid).expect("Cannot read file.");
+
+    // Resume from epoch 1 and train up to epoch 2.
+    {
+        let (dl_train, dl_valid) = make_dataloaders();
+        SupervisedTraining::new(&dir_path, dl_train, dl_valid)
+            .num_epochs(2)
+            .checkpoint(1)
+            .with_default_checkpointers()
+            .with_metric_logger(FileMetricLogger::new(&dir_path))
+            .metric_train_numeric(LossMetric::new())
+            .metric_valid_numeric(LossMetric::new())
+            .with_application_logger(None)
+            .launch(make_learner(&device));
+    }
+
+    for epoch in 1..=2 {
+        let train_dir = dir_path.join("train").join(format!("epoch-{epoch}"));
+        let valid_dir = dir_path.join("valid").join(format!("epoch-{epoch}"));
+
+        assert!(
+            train_dir.exists(),
+            "missing train log dir for epoch {epoch}: {}",
+            train_dir.display()
+        );
+        assert!(
+            valid_dir.exists(),
+            "missing valid log dir for epoch {epoch}: {}",
+            valid_dir.display()
+        );
+
+        // First epoch's logs remain unchanged.
+        if epoch == 1 {
+            let loss_file_train = train_dir.join("Loss.log");
+            let loss_file_valid = valid_dir.join("Loss.log");
+
+            let content_train = fs::read(loss_file_train).expect("Cannot read file.");
+            let content_valid = fs::read(loss_file_valid).expect("Cannot read file.");
+
+            assert_eq!(
+                content_train, content_train_expected,
+                "First epoch's logs should remain unchanged",
+            );
+            assert_eq!(
+                content_valid, content_valid_expected,
+                "First epoch's logs should remain unchanged",
+            );
+        }
+    }
+}

--- a/crates/burn-train/tests/common/mod.rs
+++ b/crates/burn-train/tests/common/mod.rs
@@ -1,0 +1,98 @@
+use std::sync::Arc;
+
+use burn_core as burn;
+
+use burn_core::{
+    data::{
+        dataloader::{DataLoaderBuilder, batcher::Batcher},
+        dataset::InMemDataset,
+    },
+    module::{Module, Param},
+    tensor::{Device, Distribution, Tensor},
+};
+use burn_optim::{ModuleOptimizer, SgdConfig, lr_scheduler::constant::ConstantLr};
+use burn_train::{
+    InferenceStep, Learner, LearningComponentsMarker, RegressionOutput, TrainOutput, TrainStep,
+};
+
+// Minimal toy model
+#[derive(Module, Debug)]
+pub struct ToyModel {
+    pub weight: Param<Tensor<2>>,
+}
+
+impl ToyModel {
+    pub fn new(device: &Device) -> Self {
+        Self {
+            weight: Param::from_tensor(Tensor::random([1, 2], Distribution::Default, device)),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DummyBatch {
+    target: Tensor<2>,
+}
+
+pub struct DummyBatcher;
+
+impl Batcher<(), DummyBatch> for DummyBatcher {
+    fn batch(&self, _items: Vec<()>, device: &Device) -> DummyBatch {
+        DummyBatch {
+            target: Tensor::zeros([1, 2], device),
+        }
+    }
+}
+
+impl TrainStep for ToyModel {
+    type Input = DummyBatch;
+    type Output = RegressionOutput;
+
+    fn step(&self, item: DummyBatch) -> TrainOutput<RegressionOutput> {
+        let output = self.weight.val();
+        let loss = output
+            .clone()
+            .sub(item.target.clone())
+            .powi_scalar(2)
+            .mean();
+        let regression = RegressionOutput::new(loss.clone(), output, item.target);
+        TrainOutput::new(self, loss.backward(), regression)
+    }
+}
+
+impl InferenceStep for ToyModel {
+    type Input = DummyBatch;
+    type Output = RegressionOutput;
+
+    fn step(&self, item: DummyBatch) -> RegressionOutput {
+        let output = self.weight.val();
+        let loss = output
+            .clone()
+            .sub(item.target.clone())
+            .powi_scalar(2)
+            .mean();
+        RegressionOutput::new(loss, output, item.target)
+    }
+}
+
+pub type ToyLearner = Learner<LearningComponentsMarker<ConstantLr, ToyModel>>;
+
+pub fn make_dataloaders() -> (
+    Arc<dyn burn_core::data::dataloader::DataLoader<DummyBatch>>,
+    Arc<dyn burn_core::data::dataloader::DataLoader<DummyBatch>>,
+) {
+    let dl_train = DataLoaderBuilder::new(DummyBatcher)
+        .batch_size(2)
+        .build(InMemDataset::new(vec![(); 4]));
+    let dl_valid = DataLoaderBuilder::new(DummyBatcher)
+        .batch_size(2)
+        .build(InMemDataset::new(vec![(); 4]));
+    (dl_train, dl_valid)
+}
+
+pub fn make_learner(device: &Device) -> ToyLearner {
+    let model = ToyModel::new(device);
+    let optim: ModuleOptimizer = SgdConfig::new().init();
+    let scheduler = ConstantLr::new(1e-3);
+    Learner::new(model, optim, scheduler)
+}

--- a/examples/custom-learning-strategy/src/training.rs
+++ b/examples/custom-learning-strategy/src/training.rs
@@ -150,7 +150,10 @@ impl<LC: LearningComponentsTypes> SupervisedLearningStrategy<LC> for MyCustomLea
             log::info!("Executing training step for epoch {}", epoch,);
 
             // Single device / dataloader
-            event_processor.process_train(LearnerEvent::StartSplit(train_total_items));
+            event_processor.process_train(LearnerEvent::StartSplit {
+                epoch_number: epoch,
+                total_items: train_total_items,
+            });
             let mut iterator = dataloader_train.iter();
             let mut iteration = 0;
 
@@ -184,7 +187,10 @@ impl<LC: LearningComponentsTypes> SupervisedLearningStrategy<LC> for MyCustomLea
 
             let model_valid = learner.model().valid();
 
-            event_processor.process_valid(LearnerEvent::StartSplit(valid_total_items));
+            event_processor.process_valid(LearnerEvent::StartSplit {
+                epoch_number: epoch,
+                total_items: valid_total_items,
+            });
             let mut iterator = dataloader_valid.iter();
             let mut iteration = 0;
 


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [X] Confirmed that `cargo run-checks` command has been executed.
- [X] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

#5109 
#5091  


### Changes

- Added a store event for the start of a split, fixing the default behaviour of always logging metrics to first epoch by default.
- Added integration tests to burn-train (only testing checkpointing behaviour for now, but can be extended in the future).

### Testing

New integration tests
Tested with MNIST example.
