### PR TITLE
Add MSE and MAE metrics for regression tasks

### DIFF
--- a/crates/burn-train/src/metric/mae.rs
+++ b/crates/burn-train/src/metric/mae.rs
@@ -1,0 +1,83 @@
+use super::MetricMetadata;
+use super::state::{FormatOptions, NumericMetricState};
+use crate::metric::{Metric, MetricAttributes, MetricName, Numeric, SerializedEntry};
+use burn_core::tensor::Tensor;
+
+/// The Mean Absolute Error (MAE) metric for regression tasks.
+#[derive(Clone)]
+pub struct MAEMetric {
+    name: MetricName,
+    state: NumericMetricState,
+}
+
+/// The [MAE metric](MAEMetric) input type.
+#[derive(new)]
+pub struct MAEInput {
+    /// The model outputs.
+    pub outputs: Tensor<2>,
+    /// The targets.
+    pub targets: Tensor<2>,
+}
+
+impl Default for MAEMetric {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MAEMetric {
+    /// Creates the metric.
+    pub fn new() -> Self {
+        Self {
+            name: MetricName::new("MAE".to_string()),
+            state: Default::default(),
+        }
+    }
+}
+
+impl Metric for MAEMetric {
+    type Input = MAEInput;
+
+    fn update(&mut self, input: &MAEInput, _metadata: &MetricMetadata) -> SerializedEntry {
+        let targets = input.targets.clone();
+        let outputs = input.outputs.clone();
+
+        let [batch_size, _] = outputs.dims();
+
+        let diff = outputs.sub(targets);
+        let mae = diff.abs().mean();
+
+        self.state.update(
+            mae.into_scalar::<f64>(),
+            batch_size,
+            FormatOptions::new(self.name()).precision(4),
+        )
+    }
+
+    fn clear(&mut self) {
+        self.state.reset()
+    }
+
+    fn name(&self) -> MetricName {
+        self.name.clone()
+    }
+
+    fn attributes(&self) -> MetricAttributes {
+        super::NumericAttributes {
+            unit: None,
+            higher_is_better: false,
+            ..Default::default()
+        }
+        .into()
+    }
+}
+
+impl Numeric for MAEMetric {
+    fn value(&self) -> super::NumericEntry {
+        self.state.current_value()
+    }
+
+    fn running_value(&self) -> super::NumericEntry {
+        self.state.running_value()
+    }
+}

--- a/crates/burn-train/src/metric/mod.rs
+++ b/crates/burn-train/src/metric/mod.rs
@@ -49,6 +49,7 @@ mod recall;
 mod rouge;
 mod top_k_acc;
 mod wer;
+mod r2_score;
 
 pub use acc::*;
 pub use auc_pr::*;
@@ -68,6 +69,7 @@ pub use recall::*;
 pub use rouge::*;
 pub use top_k_acc::*;
 pub use wer::*;
+pub use r2_score::*;
 
 pub(crate) mod classification;
 pub(crate) mod processor;

--- a/crates/burn-train/src/metric/mod.rs
+++ b/crates/burn-train/src/metric/mod.rs
@@ -50,6 +50,8 @@ mod rouge;
 mod top_k_acc;
 mod wer;
 mod r2_score;
+mod mse;
+mod mae;
 
 pub use acc::*;
 pub use auc_pr::*;
@@ -70,6 +72,8 @@ pub use rouge::*;
 pub use top_k_acc::*;
 pub use wer::*;
 pub use r2_score::*;
+pub use mse::*;
+pub use mae::*;
 
 pub(crate) mod classification;
 pub(crate) mod processor;

--- a/crates/burn-train/src/metric/mse.rs
+++ b/crates/burn-train/src/metric/mse.rs
@@ -1,0 +1,83 @@
+use super::MetricMetadata;
+use super::state::{FormatOptions, NumericMetricState};
+use crate::metric::{Metric, MetricAttributes, MetricName, Numeric, SerializedEntry};
+use burn_core::tensor::Tensor;
+
+/// The Mean Squared Error (MSE) metric for regression tasks.
+#[derive(Clone)]
+pub struct MSEMetric {
+    name: MetricName,
+    state: NumericMetricState,
+}
+
+/// The [MSE metric](MSEMetric) input type.
+#[derive(new)]
+pub struct MSEInput {
+    /// The model outputs.
+    pub outputs: Tensor<2>,
+    /// The targets.
+    pub targets: Tensor<2>,
+}
+
+impl Default for MSEMetric {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MSEMetric {
+    /// Creates the metric.
+    pub fn new() -> Self {
+        Self {
+            name: MetricName::new("MSE".to_string()),
+            state: Default::default(),
+        }
+    }
+}
+
+impl Metric for MSEMetric {
+    type Input = MSEInput;
+
+    fn update(&mut self, input: &MSEInput, _metadata: &MetricMetadata) -> SerializedEntry {
+        let targets = input.targets.clone();
+        let outputs = input.outputs.clone();
+
+        let [batch_size, _] = outputs.dims();
+
+        let diff = outputs.sub(targets);
+        let mse = diff.powf_scalar(2.0).mean();
+
+        self.state.update(
+            mse.into_scalar::<f64>(),
+            batch_size,
+            FormatOptions::new(self.name()).precision(4),
+        )
+    }
+
+    fn clear(&mut self) {
+        self.state.reset()
+    }
+
+    fn name(&self) -> MetricName {
+        self.name.clone()
+    }
+
+    fn attributes(&self) -> MetricAttributes {
+        super::NumericAttributes {
+            unit: None,
+            higher_is_better: false,
+            ..Default::default()
+        }
+        .into()
+    }
+}
+
+impl Numeric for MSEMetric {
+    fn value(&self) -> super::NumericEntry {
+        self.state.current_value()
+    }
+
+    fn running_value(&self) -> super::NumericEntry {
+        self.state.running_value()
+    }
+}

--- a/crates/burn-train/src/metric/r2_score.rs
+++ b/crates/burn-train/src/metric/r2_score.rs
@@ -1,0 +1,91 @@
+use super::MetricMetadata;
+use super::state::{FormatOptions, NumericMetricState};
+use crate::metric::{Metric, MetricAttributes, MetricName, Numeric, SerializedEntry};
+use burn_core::tensor::Tensor;
+
+/// The R2 Score (Coefficient of Determination) metric for regression tasks.
+#[derive(Clone)]
+pub struct R2ScoreMetric {
+    name: MetricName,
+    state: NumericMetricState,
+}
+
+/// The [R2 Score metric](R2ScoreMetric) input type.
+#[derive(new)]
+pub struct RegressionInput {
+    /// The model outputs.
+    pub outputs: Tensor<2>,
+    /// The targets.
+    pub targets: Tensor<2>,
+}
+
+impl Default for R2ScoreMetric {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl R2ScoreMetric {
+    /// Creates the metric.
+    pub fn new() -> Self {
+        Self {
+            name: MetricName::new("R2 Score".to_string()),
+            state: Default::default(),
+        }
+    }
+}
+
+impl Metric for R2ScoreMetric {
+    type Input = RegressionInput;
+
+    fn update(&mut self, input: &RegressionInput, _metadata: &MetricMetadata) -> SerializedEntry {
+        let targets = input.targets.clone();
+        let outputs = input.outputs.clone();
+
+        let [batch_size, _] = outputs.dims();
+
+        // Calculate residual sum of squares (SS_res)
+        let residuals = targets.clone().sub(outputs);
+        let ss_res = residuals.powf_scalar(2.0).sum();
+
+        // Calculate total sum of squares (SS_tot)
+        let mean_targets = targets.clone().mean_dim(0);
+        let diff_mean = targets.sub(mean_targets);
+        let ss_tot = diff_mean.powf_scalar(2.0).sum();
+
+        let r2 = Tensor::ones_like(&ss_tot).sub(ss_res.div(ss_tot.add_scalar(1e-8)));
+
+        self.state.update(
+            r2.into_scalar::<f64>(),
+            batch_size,
+            FormatOptions::new(self.name()).precision(4),
+        )
+    }
+
+    fn clear(&mut self) {
+        self.state.reset()
+    }
+
+    fn name(&self) -> MetricName {
+        self.name.clone()
+    }
+
+    fn attributes(&self) -> MetricAttributes {
+        super::NumericAttributes {
+            unit: None,
+            higher_is_better: true,
+            ..Default::default()
+        }
+        .into()
+    }
+}
+
+impl Numeric for R2ScoreMetric {
+    fn value(&self) -> super::NumericEntry {
+        self.state.current_value()
+    }
+
+    fn running_value(&self) -> super::NumericEntry {
+        self.state.running_value()
+    }
+}


### PR DESCRIPTION
This PR adds the Mean Squared Error (MSE) and Mean Absolute Error (MAE) metrics to \urn-train\. This extends the regression metric suite (following #5118) to allow users to directly evaluate regression and image quality models during training.