### PR TITLE
Fix/remote async read

### DIFF
--- a/crates/burn-cubecl/src/ops/base.rs
+++ b/crates/burn-cubecl/src/ops/base.rs
@@ -41,13 +41,17 @@ pub(crate) async fn into_data<R: CubeRuntime>(
     let shape = tensor.meta.shape().clone();
     let strides = tensor.meta.strides().clone();
     let binding = CopyDescriptor::new(tensor.handle.binding(), shape, strides, elem_size);
-    let bytes = tensor
-        .client
-        .read_lazy_async(binding)
-        .await
-        .map_err(|err| ExecutionError::WithContext {
-            reason: format!("{err}"),
-        })?;
+    // Under an async runtime (e.g. a remote server), a lazy read defers the device→host
+    // copy to first access, where a blocking read would run on — and starve — an executor
+    // worker. Read eagerly there so the copy happens inside this awaited future. On a
+    // sync/threaded runtime the lazy read keeps the streaming optimization.
+    let read = match burn_std::runtime_kind() {
+        burn_std::RuntimeKind::Async => tensor.client.read_one_tensor_async(binding).await,
+        _ => tensor.client.read_lazy_async(binding).await,
+    };
+    let bytes = read.map_err(|err| ExecutionError::WithContext {
+        reason: format!("{err}"),
+    })?;
 
     Ok(TensorData::from_bytes(
         bytes,

--- a/crates/burn-remote/src/server/builder.rs
+++ b/crates/burn-remote/src/server/builder.rs
@@ -128,6 +128,10 @@ impl<B: BackendIr> RemoteServerBuilder<B> {
     /// Start the server on the caller's async runtime, serving until shutdown.
     #[cfg(not(target_family = "wasm"))]
     pub async fn start_async(self) {
+        // The backend is hosted on an async runtime: tensor readbacks must materialize
+        // eagerly rather than deferring a blocking device→host copy onto an executor worker.
+        burn_std::set_runtime_kind(burn_std::RuntimeKind::Async);
+
         match self.channel {
             #[cfg(feature = "websocket")]
             Channel::WebSocket { port } => {

--- a/crates/burn-remote/src/server/worker.rs
+++ b/crates/burn-remote/src/server/worker.rs
@@ -35,13 +35,9 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-#[cfg(not(target_family = "wasm"))]
-use burn_backend::ExecutionError;
 use burn_ir::{BackendIr, GraphBindings, GraphId};
 use burn_router::{Graph, TensorInterpreter};
 use burn_std::id::StreamId;
-#[cfg(not(target_family = "wasm"))]
-use burn_std::{AllocationProperty, Reader};
 #[cfg(not(target_family = "wasm"))]
 use tokio::runtime::Handle;
 use tokio::sync::mpsc;
@@ -385,30 +381,10 @@ where
                 let fut = stream_id.executes(|| self.runner.read_tensor_async(tensor));
                 let sender = self.response_sender.clone();
                 spawn_detached(async move {
+                    // Under an async runtime the backend reads eagerly (see `RuntimeKind::Async`),
+                    // so `data` is already host-resident here — the fetch handler only serializes
+                    // resident bytes and no blocking device→host copy runs on the shared runtime.
                     let data = fut.await;
-                    // `read_tensor_async` may hand back *lazy* device-backed bytes whose GPU→host
-                    // copy is deferred to first access. Left lazy, that copy runs inside
-                    // `rmp_serde::to_vec` on the fetch handler — an async task on the shared
-                    // runtime — where a synchronous read pins a runtime worker for the whole copy
-                    // and starves op delivery under concurrent reads. Force the copy here on the
-                    // blocking pool instead, so the fetch handler only serializes resident host
-                    // bytes and the shared runtime's workers stay free. A no-op for backends whose
-                    // read is already host-resident (the property check skips the copy). Native
-                    // only: the wasm server is single-threaded, so there is no worker to starve.
-                    #[cfg(not(target_family = "wasm"))]
-                    let data = match data {
-                        Ok(data) => tokio::task::spawn_blocking(move || {
-                            if data.bytes.property() == AllocationProperty::Device {
-                                let _ = data.bytes.read(Reader::new());
-                            }
-                            data
-                        })
-                        .await
-                        .map_err(|err| ExecutionError::WithContext {
-                            reason: format!("readback materialization task failed: {err}"),
-                        }),
-                        Err(err) => Err(err),
-                    };
                     if sender
                         .send(TaskResponse {
                             content: TaskResponseContent::ReadTensor(data),

--- a/crates/burn-std/src/lib.rs
+++ b/crates/burn-std/src/lib.rs
@@ -34,6 +34,10 @@ pub use element::*;
 mod device_settings;
 pub use device_settings::*;
 
+/// Runtime kind of the host program (async / sync / no-std).
+pub mod runtime_kind;
+pub use runtime_kind::*;
+
 /// Distributed configurations.
 pub mod distributed;
 

--- a/crates/burn-std/src/runtime_kind.rs
+++ b/crates/burn-std/src/runtime_kind.rs
@@ -1,0 +1,62 @@
+//! Runtime kind of the host program.
+//!
+//! Some backend decisions depend not on the device but on *how the host program itself is
+//! being driven* — whether `main` runs on an asynchronous runtime, a synchronous
+//! thread-based runtime, or a restricted no-std environment. This module stores that kind
+//! in a process global so backends can read it and adapt their behavior.
+//!
+//! The canonical example is tensor readback (`into_data`): deferring the device→host copy
+//! lazily is fine under a sync/threaded runtime (a later blocking read just parks a thread),
+//! but under an async runtime the same blocking read parks an executor worker and starves
+//! the runtime, so the read must materialize eagerly instead.
+
+use core::sync::atomic::{AtomicU8, Ordering};
+
+/// How the host program is being driven.
+///
+/// Set once near program start with [`set_runtime_kind`]; read anywhere with
+/// [`runtime_kind`]. Defaults to [`RuntimeKind::Sync`].
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RuntimeKind {
+    /// Synchronous, thread-based runtime (the default).
+    ///
+    /// Blocking readbacks are fine here, so tensor reads may defer the device→host copy
+    /// lazily and materialize it on first access.
+    #[default]
+    Sync = 0,
+    /// Asynchronous runtime (e.g. tokio).
+    ///
+    /// Blocking a runtime worker starves the executor, so tensor reads must materialize
+    /// eagerly inside the awaited future rather than deferring a blocking copy.
+    Async = 1,
+    /// Restricted no-std environment.
+    NoStd = 2,
+}
+
+impl RuntimeKind {
+    fn from_u8(value: u8) -> Self {
+        match value {
+            1 => RuntimeKind::Async,
+            2 => RuntimeKind::NoStd,
+            _ => RuntimeKind::Sync,
+        }
+    }
+}
+
+static RUNTIME_KIND: AtomicU8 = AtomicU8::new(RuntimeKind::Sync as u8);
+
+/// Declare the [kind](RuntimeKind) of runtime the host program is running on.
+///
+/// Intended to be called once near program start (e.g. when a remote server declares that
+/// it hosts the backend on an async runtime). Backends read it via [`runtime_kind`].
+pub fn set_runtime_kind(kind: RuntimeKind) {
+    RUNTIME_KIND.store(kind as u8, Ordering::Relaxed);
+}
+
+/// Return the currently declared [kind](RuntimeKind) of runtime the host program runs on.
+///
+/// Defaults to [`RuntimeKind::Sync`] until [`set_runtime_kind`] is called.
+pub fn runtime_kind() -> RuntimeKind {
+    RuntimeKind::from_u8(RUNTIME_KIND.load(Ordering::Relaxed))
+}

--- a/examples/text-classification/examples/ag-news-train.rs
+++ b/examples/text-classification/examples/ag-news-train.rs
@@ -108,11 +108,11 @@ mod wgpu {
 
 #[cfg(feature = "remote")]
 mod remote {
-    use burn::tensor::{Device, DeviceType};
     #[cfg(feature = "ddp")]
     use crate::ElemType;
     #[cfg(feature = "ddp")]
     use burn::tensor::distributed::{DistributedConfig, ReduceOperation};
+    use burn::tensor::{Device, DeviceType};
     #[cfg(feature = "ddp")]
     use burn::tensor::{DeviceConfig, Element};
     #[cfg(feature = "ddp")]

--- a/examples/text-classification/examples/ag-news-train.rs
+++ b/examples/text-classification/examples/ag-news-train.rs
@@ -108,24 +108,27 @@ mod wgpu {
 
 #[cfg(feature = "remote")]
 mod remote {
+    use burn::tensor::{Device, DeviceType};
+    #[cfg(feature = "ddp")]
     use crate::ElemType;
     #[cfg(feature = "ddp")]
     use burn::tensor::distributed::{DistributedConfig, ReduceOperation};
-    use burn::tensor::{Device, DeviceConfig, DeviceType, Element};
+    #[cfg(feature = "ddp")]
+    use burn::tensor::{DeviceConfig, Element};
     #[cfg(feature = "ddp")]
     use burn::train::ExecutionStrategy;
 
     /// Address of the `burn-remote` server to train against.
     const ADDRESS: &str = "ws://localhost:3000";
 
-    /// List every device the remote server hosts and train across all of them.
+    /// Train on a single one of the devices the remote server hosts.
+    ///
+    /// `launch_single` configures the device it receives, so don't configure the enumerated
+    /// set here too — doing both locks the device's settings twice and returns
+    /// [`DeviceError::AlreadyInitialized`](burn::tensor::DeviceError::AlreadyInitialized).
     #[cfg(not(feature = "ddp"))]
     pub fn run() {
-        let mut devices = Device::enumerate(DeviceType::remote_websocket(ADDRESS));
-        devices
-            .configure(DeviceConfig::default().float_dtype(ElemType::dtype()))
-            .unwrap();
-
+        let devices = Device::enumerate(DeviceType::remote_websocket(ADDRESS));
         crate::launch_single(devices.into_vec().pop().unwrap());
     }
 


### PR DESCRIPTION
When the runtime is async, the lazy into_data is currently problematic, so we skip it.