### PR TITLE
fix(fusion): don't fuse single-use view ops

### DIFF
--- a/crates/burn-backend-tests/tests/fusion/fusion_shape.rs
+++ b/crates/burn-backend-tests/tests/fusion/fusion_shape.rs
@@ -221,3 +221,57 @@ fn elementwise_and_creation_into_single_kernel() {
     );
     });
 }
+
+/// A lone view (`swap_dims`) whose original tensor isn't otherwise read must NOT be fused: it runs
+/// eagerly as a cheap shape/stride update, so the following element-wise math reads a clean,
+/// vectorizable layout instead of recomputing the transposed index on every element.
+///
+/// Regression guard for the "view fix": previously the swap-dims was fused into the element-wise
+/// kernel (the original registered as a fresh input, read *through* the transpose), which defeats
+/// vectorization for no benefit when the original is used nowhere else.
+#[test]
+fn lone_view_is_not_fused_into_kernel() {
+    let stream = test_stream();
+    stream.executes(|| {
+        let device = Default::default();
+
+        // Materialize the inputs so their `ones` init ops don't land in the inspected reports.
+        let a = TestTensor::<2>::ones([4, 8], &device);
+        let b = TestTensor::<2>::ones([8, 4], &device);
+        device.sync().unwrap();
+
+        let inspector = FusionInspector::install(stream);
+
+        // `swap_dims` is the only use of `a`.
+        let out = (a.swap_dims(0, 1) + b).exp();
+        let _ = out.into_data();
+        device.sync().unwrap();
+
+        let reports = inspector.drain();
+        let tables: String = reports
+            .iter()
+            .map(|r| r.format_table())
+            .collect::<Vec<_>>()
+            .join("\n\n");
+
+        let is_swap = matchers::is_swap_dims();
+
+        // The view must never end up inside a fused kernel.
+        assert!(
+            reports
+                .iter()
+                .flat_map(|r| r.fused_blocks())
+                .all(|blk| !blk.operations.iter().any(|op| is_swap(op))),
+            "swap_dims must not be fused (view fix):\n\n{tables}",
+        );
+
+        // ...and it must actually run, in an un-fused block.
+        assert!(
+            reports
+                .iter()
+                .flat_map(|r| r.unfused_blocks())
+                .any(|blk| blk.operations.iter().any(|op| is_swap(op))),
+            "swap_dims should run eagerly in an un-fused block:\n\n{tables}",
+        );
+    });
+}

--- a/crates/burn-cubecl-fusion/src/engine/trace/block.rs
+++ b/crates/burn-cubecl-fusion/src/engine/trace/block.rs
@@ -284,7 +284,13 @@ impl FuseBlockBuilder {
                     }
                 }
             }
-            None => resources.inputs.insert(precision, tensor.clone()),
+            // First appearance of the original: fusing a single-use view isn't worth it. The
+            // reshape/slice/swap_dims executes eagerly as a cheap shape/stride update and the result
+            // is then read with a clean, vectorizable layout. Fusing would instead recompute the view
+            // index on every read and can break vectorization. We only fuse a view when the original
+            // is already used elsewhere (the `Some` arm), i.e. when we genuinely need it in multiple
+            // layouts.
+            None => return None,
         };
 
         let out = self.output(output, resources)?;
@@ -348,7 +354,13 @@ impl FuseBlockBuilder {
                     }
                 }
             }
-            None => resources.inputs.insert(precision, tensor.clone()),
+            // First appearance of the original: fusing a single-use view isn't worth it. The
+            // reshape/slice/swap_dims executes eagerly as a cheap shape/stride update and the result
+            // is then read with a clean, vectorizable layout. Fusing would instead recompute the view
+            // index on every read and can break vectorization. We only fuse a view when the original
+            // is already used elsewhere (the `Some` arm), i.e. when we genuinely need it in multiple
+            // layouts.
+            None => return None,
         };
 
         let out = self.output(output, resources)?;

--- a/crates/burn-fusion/src/inspect.rs
+++ b/crates/burn-fusion/src/inspect.rs
@@ -472,6 +472,32 @@ pub mod matchers {
         })
     }
 
+    /// Matches a `reshape` on any element type (`BaseFloat`/`BaseInt`/`BaseBool`).
+    pub fn is_reshape() -> OpMatcher {
+        use burn_ir::BaseOperationIr;
+        Box::new(|op| {
+            matches!(
+                op,
+                OperationIr::BaseFloat(BaseOperationIr::Reshape(_))
+                    | OperationIr::BaseInt(BaseOperationIr::Reshape(_))
+                    | OperationIr::BaseBool(BaseOperationIr::Reshape(_))
+            )
+        })
+    }
+
+    /// Matches a `swap_dims` on any element type (`BaseFloat`/`BaseInt`/`BaseBool`).
+    pub fn is_swap_dims() -> OpMatcher {
+        use burn_ir::BaseOperationIr;
+        Box::new(|op| {
+            matches!(
+                op,
+                OperationIr::BaseFloat(BaseOperationIr::SwapDims(_))
+                    | OperationIr::BaseInt(BaseOperationIr::SwapDims(_))
+                    | OperationIr::BaseBool(BaseOperationIr::SwapDims(_))
+            )
+        })
+    }
+
     /// Matches the memory-bookkeeping `Drop` op emitted when a tensor is deallocated.
     /// These aren't really operations — useful to filter out when counting ops in
     /// fusion-shape tests.


### PR DESCRIPTION
A reshape/swap_dims whose original tensor isn't otherwise read inside the fused kernel was always fused: the original was registered as a fresh input and read *through* the view transform, recomputing the view index on every read and defeating vectorization (the aligned-read fallback). When the original is used nowhere else there is no benefit — it's cheaper to run the view eagerly as a shape/stride metadata update and then read the result with a clean, vectorizable layout.

Return `None` from the first-appearance (`None`) arm of `input_swap_dims` and `input_reshaped` so the view falls out of the block and executes eagerly. The `Some` arm (original already read in the block) still fuses the view, when we genuinely need it in multiple layouts.

Adds `is_reshape`/`is_swap_dims` inspect matchers and a fusion-shape test asserting a lone view is never fused into the element-wise kernel.