### PR TITLE
Fix fusion plan re-exploration for sync segments with a drained tail

### DIFF
--- a/crates/burn-fusion/src/search/block.rs
+++ b/crates/burn-fusion/src/search/block.rs
@@ -344,6 +344,47 @@ impl<O> BlockOptimization<O> {
         }
         self.strategy.map_ordering(mapping);
     }
+
+    /// Extend the optimization to cover all `num_operations` of its segment: the
+    /// positions the search left uncovered (the drained tail of a block whose best
+    /// fusion stopped early) are appended as un-fused
+    /// [operations](ExecutionStrategy::Operations) in a
+    /// [composed](ExecutionStrategy::Composed) strategy.
+    ///
+    /// Leaving the tail out is right in lazy mode — it seeds the next exploration
+    /// round, where more incoming operations may fuse with it. At a sync the segment
+    /// is final: no later round can pick the tail up, and a plan covering only part
+    /// of the segment can never be matched again (plan lookup at a sync compares the
+    /// whole remaining segment). Covering the full segment makes the cached plan
+    /// reusable on every subsequent identical sync.
+    ///
+    /// The uncovered positions are always a trailing run of the segment (interior
+    /// holes are re-optimized by the stream optimizer before this is called), so
+    /// appending them last preserves the hazard-respecting execution order.
+    pub fn include_trailing(&mut self, num_operations: usize) {
+        if self.ordering.len() >= num_operations {
+            return;
+        }
+
+        let mut resolved = vec![false; num_operations];
+        for &position in &self.ordering {
+            resolved[position] = true;
+        }
+        let trailing: Vec<usize> = (0..num_operations).filter(|&i| !resolved[i]).collect();
+
+        let tail = ExecutionStrategy::Operations {
+            ordering: Arc::new(trailing.clone()),
+        };
+        let strategy = core::mem::replace(&mut self.strategy, ExecutionStrategy::Composed(vec![]));
+        self.strategy = match strategy {
+            ExecutionStrategy::Composed(mut items) => {
+                items.push(Box::new(tail));
+                ExecutionStrategy::Composed(items)
+            }
+            single => ExecutionStrategy::Composed(vec![Box::new(single), Box::new(tail)]),
+        };
+        self.ordering.extend(trailing);
+    }
 }
 
 impl<O> ExecutionStrategy<O> {

--- a/crates/burn-fusion/src/search/block.rs
+++ b/crates/burn-fusion/src/search/block.rs
@@ -359,18 +359,26 @@ impl<O> BlockOptimization<O> {
     /// reusable on every subsequent identical sync.
     ///
     /// The uncovered positions are always a trailing run of the segment (interior
-    /// holes are re-optimized by the stream optimizer before this is called), so
-    /// appending them last preserves the hazard-respecting execution order.
+    /// holes are re-optimized by the stream optimizer before this is called — enforced
+    /// by a debug assertion), so appending them last preserves the hazard-respecting
+    /// execution order.
     pub fn include_trailing(&mut self, num_operations: usize) {
         if self.ordering.len() >= num_operations {
             return;
         }
 
-        let mut resolved = vec![false; num_operations];
-        for &position in &self.ordering {
-            resolved[position] = true;
+        #[cfg(debug_assertions)]
+        {
+            let mut resolved = vec![false; num_operations];
+            for &position in &self.ordering {
+                resolved[position] = true;
+            }
+            debug_assert!(
+                resolved[..self.ordering.len()].iter().all(|&r| r),
+                "uncovered positions must be a trailing run of the segment"
+            );
         }
-        let trailing: Vec<usize> = (0..num_operations).filter(|&i| !resolved[i]).collect();
+        let trailing: Vec<usize> = (self.ordering.len()..num_operations).collect();
 
         let tail = ExecutionStrategy::Operations {
             ordering: Arc::new(trailing.clone()),

--- a/crates/burn-fusion/src/stream/execution/explorer.rs
+++ b/crates/burn-fusion/src/stream/execution/explorer.rs
@@ -96,10 +96,25 @@ impl<O: NumOperations> Explorer<O> {
             return ExplorationAction::Continue;
         }
 
-        let optimization = self.optimizer.optimize(operations);
+        let mut optimization = self.optimizer.optimize(operations);
         self.num_explorations += 1;
 
+        // At a sync the segment is final: fold the drained tail the search left for
+        // "the next round" into the plan as un-fused operations, so the cached plan
+        // covers the whole segment and can be matched by the policy on the next
+        // identical sync instead of re-exploring the same graph every time.
+        if let ExecutionMode::Sync = mode {
+            optimization.include_trailing(operations.len());
+        }
+
         ExplorationAction::Completed(optimization)
+    }
+
+    /// Number of optimizations built so far; a cached plan that is reused does not
+    /// count. Used by tests to assert that recurring graphs stop exploring.
+    #[cfg(test)]
+    pub(crate) fn num_explorations(&self) -> usize {
+        self.num_explorations
     }
 
     /// Reset the state of the explorer to the provided list of operations.

--- a/crates/burn-fusion/src/stream/execution/processor.rs
+++ b/crates/burn-fusion/src/stream/execution/processor.rs
@@ -136,6 +136,13 @@ impl<O: NumOperations> Processor<O> {
         }
     }
 
+    /// Number of optimizations built so far; a cached plan that is reused does not
+    /// count. Used by tests to assert that recurring graphs stop exploring.
+    #[cfg(test)]
+    pub(crate) fn num_explorations(&self) -> usize {
+        self.explorer.num_explorations()
+    }
+
     fn reset(&mut self, store: &mut ExecutionPlanStore<O>, operations: &[OperationIr]) {
         self.explorer.reset(operations);
         self.policy.reset();

--- a/crates/burn-fusion/src/stream/execution/tests.rs
+++ b/crates/burn-fusion/src/stream/execution/tests.rs
@@ -391,7 +391,9 @@ fn should_support_overlapping_optimizations() {
 
     stream.sync();
     stream.assert_number_of_operations(0);
-    stream.assert_number_of_executions(6);
+    // The sync executes a single plan covering the whole remaining segment: the
+    // fused pair composed with the un-fused trailing operation.
+    stream.assert_number_of_executions(5);
     stream.assert_plan(
         plan_id_1,
         ExecutionPlan {
@@ -399,7 +401,6 @@ fn should_support_overlapping_optimizations() {
             triggers: vec![
                 ExecutionTrigger::OnOperations(vec![operation_1(), operation_2()]),
                 ExecutionTrigger::OnOperations(vec![operation_2()]),
-                ExecutionTrigger::OnSync,
             ],
             optimization: BlockOptimization {
                 strategy: ExecutionStrategy::optimization(TestOptimization::new(builder_id_1, 2)),
@@ -410,11 +411,11 @@ fn should_support_overlapping_optimizations() {
     stream.assert_plan(
         plan_id_4,
         ExecutionPlan {
-            operations: vec![operation_1()],
+            operations: vec![operation_1(), operation_2(), operation_1()],
             triggers: vec![ExecutionTrigger::OnSync],
             optimization: BlockOptimization {
-                strategy: ExecutionStrategy::operations(1),
-                ordering: vec![0],
+                strategy: ExecutionStrategy::operations(3),
+                ordering: vec![0, 1, 2],
             },
         },
     );
@@ -435,6 +436,65 @@ fn should_support_overlapping_optimizations() {
 
     stream.add(operation_3());
     stream.assert_last_executed(plan_id_5);
+}
+
+/// A plan discovered at a sync point must cover the whole segment and be reusable on
+/// the next identical pass without re-exploring.
+///
+/// This is the shape of an autoregressive inference step: the graph defers past the
+/// fusable prefix because some fuser is still open, and the step ends on a sync. The
+/// search leaves the still-open tail out of its optimization (in lazy mode the tail
+/// seeds the next round), but at a sync there is no next round: the tail is folded
+/// into the plan as un-fused operations in a composed strategy. The plan then matches
+/// the whole segment, so every subsequent identical step executes it directly instead
+/// of re-running the whole exploration.
+#[test]
+fn should_reuse_sync_plan_on_next_pass() {
+    let plan_id = 0;
+
+    let pair_builder = TestOptimizationBuilder::new(0, vec![operation_1(), operation_2()]);
+    // A builder that wants a longer sequence: it stays open past the tail op, which is
+    // what defers the whole segment until the sync.
+    let hungry_builder = TestOptimizationBuilder::new(
+        1,
+        vec![operation_1(), operation_2(), operation_3(), operation_1()],
+    );
+    let mut stream = TestStream::new(vec![Box::new(pair_builder), Box::new(hungry_builder)]);
+
+    // First pass: everything defers, the sync explores once and executes one plan
+    // covering the whole segment.
+    stream.add(operation_1());
+    stream.add(operation_2());
+    stream.add(operation_3());
+    stream.assert_number_of_executions(0);
+    stream.sync();
+    stream.assert_number_of_operations(0);
+    stream.assert_number_of_executions(1);
+    stream.assert_last_executed(plan_id);
+    stream.assert_number_of_explorations(1);
+    stream.assert_plan(
+        plan_id,
+        ExecutionPlan {
+            operations: vec![operation_1(), operation_2(), operation_3()],
+            triggers: vec![ExecutionTrigger::OnSync],
+            optimization: BlockOptimization {
+                strategy: ExecutionStrategy::optimization(TestOptimization::new(0, 2)),
+                ordering: vec![0, 1, 2],
+            },
+        },
+    );
+
+    // Second pass: the identical stream ends at the same sync; the cached plan
+    // matches the whole segment and executes without any re-exploration.
+    stream.add(operation_1());
+    stream.add(operation_2());
+    stream.add(operation_3());
+    stream.assert_number_of_executions(1);
+    stream.sync();
+    stream.assert_number_of_operations(0);
+    stream.assert_number_of_executions(2);
+    stream.assert_last_executed(plan_id);
+    stream.assert_number_of_explorations(1);
 }
 
 impl TestStream {
@@ -490,6 +550,16 @@ impl TestStream {
     /// Assert the number of operations queued.
     fn assert_number_of_operations(&self, number: usize) {
         assert_eq!(self.operations.len(), number);
+    }
+
+    /// Assert the number of optimizations built since the start of the stream;
+    /// reusing a cached plan does not count.
+    fn assert_number_of_explorations(&self, number: usize) {
+        assert_eq!(
+            self.processor.num_explorations(),
+            number,
+            "Number of explorations match"
+        );
     }
 }
 

--- a/crates/burn-fusion/src/stream/execution/tests.rs
+++ b/crates/burn-fusion/src/stream/execution/tests.rs
@@ -414,7 +414,15 @@ fn should_support_overlapping_optimizations() {
             operations: vec![operation_1(), operation_2(), operation_1()],
             triggers: vec![ExecutionTrigger::OnSync],
             optimization: BlockOptimization {
-                strategy: ExecutionStrategy::operations(3),
+                strategy: ExecutionStrategy::Composed(vec![
+                    Box::new(ExecutionStrategy::optimization(TestOptimization::new(
+                        builder_id_1,
+                        2,
+                    ))),
+                    Box::new(ExecutionStrategy::Operations {
+                        ordering: Arc::new(vec![2]),
+                    }),
+                ]),
                 ordering: vec![0, 1, 2],
             },
         },
@@ -478,7 +486,12 @@ fn should_reuse_sync_plan_on_next_pass() {
             operations: vec![operation_1(), operation_2(), operation_3()],
             triggers: vec![ExecutionTrigger::OnSync],
             optimization: BlockOptimization {
-                strategy: ExecutionStrategy::optimization(TestOptimization::new(0, 2)),
+                strategy: ExecutionStrategy::Composed(vec![
+                    Box::new(ExecutionStrategy::optimization(TestOptimization::new(0, 2))),
+                    Box::new(ExecutionStrategy::Operations {
+                        ordering: Arc::new(vec![2]),
+                    }),
+                ]),
                 ordering: vec![0, 1, 2],
             },
         },


### PR DESCRIPTION
When the search's best optimization stops before the end of a block, the trailing operations are drained and left in the queue for the next exploration round. That is right in lazy mode — more incoming operations may fuse with the tail — but at a sync the segment is final and there is no next round: the tail was executed as its own follow-up segment, and the cached plan covered only a prefix of the sync segment.

Such a plan can never be matched again. Plan lookup at a sync compares a stored plan against the whole remaining segment by length, so the prefix plan missed on every subsequent pass, and recurring graphs that end on a sync — an autoregressive decoding step is the canonical case — re-ran the whole exploration once per step, forever.

Fold the drained tail into the plan at sync-time exploration instead: `BlockOptimization::include_trailing` appends the uncovered positions as un-fused operations in a composed strategy, so the cached plan covers the whole segment and is matched directly on the next identical sync. Lazy exploration is unchanged: streams that keep going still explore for bigger fusions.