### PR TITLE
Fix fused in-place aliasing (never fired since #2870/#3263)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -801,6 +801,7 @@ dependencies = [
  "burn-autodiff",
  "burn-backend",
  "burn-cubecl",
+ "burn-cubecl-fusion",
  "burn-fusion",
  "burn-ndarray",
  "burn-tensor",

--- a/crates/burn-backend-tests/Cargo.toml
+++ b/crates/burn-backend-tests/Cargo.toml
@@ -44,7 +44,11 @@ remote = ["burn-tensor/remote"]
 autotune = ["burn-tensor/autotune"]
 autotune-checks = ["burn-tensor/autotune-checks"]
 memory-checks = ["burn-fusion?/memory-checks"]
-fusion = ["burn-tensor/fusion", "burn-fusion/test-util"]
+fusion = [
+    "burn-tensor/fusion",
+    "burn-fusion/test-util",
+    "burn-cubecl-fusion?/test-util",
+]
 
 # CubeCL backends
 cube = [
@@ -54,6 +58,8 @@ cube = [
     "burn-ndarray",
     # Not used directly, but included to avoid recompiling with and without fusion
     "burn-cubecl",
+    # Direct dependency so fusion tests can assert launch-level decisions (in-place aliasing).
+    "burn-cubecl-fusion",
 ]
 
 # Test configs
@@ -80,6 +86,7 @@ burn-cubecl = { workspace = true, optional = true, features = [
     "default",
     "fusion",
 ] }
+burn-cubecl-fusion = { workspace = true, optional = true }
 
 # Enabled alongside the `fusion` feature so spy-based tests can import the spy API.
 burn-fusion = { workspace = true, optional = true }

--- a/crates/burn-backend-tests/tests/fusion/inplace.rs
+++ b/crates/burn-backend-tests/tests/fusion/inplace.rs
@@ -139,6 +139,68 @@ fn read_only_input_is_not_written_inplace() {
     });
 }
 
+/// A consumed elemwise input feeding a fused reduce must alias the elemwise output.
+///
+/// The aliased output becomes the read block's reference layout, so the reduce runner
+/// resolves the reference against an aliased output argument: this covers the
+/// output-arg reference form and the `TensorArg::Alias` arms of
+/// `GlobalArgsLaunch::shape/strides`, which elemwise-only chains don't exercise.
+#[test]
+fn reduce_fusion_elemwise_output_writes_inplace() {
+    let stream = test_stream();
+    stream.executes(|| {
+        let device = Default::default();
+
+        let make_input = || {
+            let tensor =
+                TestTensor::<2>::from_data([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]], &device);
+            // Materialize the init op before the fused chain, so the chain starts from
+            // an existing buffer and the init doesn't show up in the inspected reports.
+            let _ = tensor.clone().into_data();
+            device.sync().unwrap();
+            tensor
+        };
+
+        // `out` stays alive across the reduce, so it is a global output of the fused
+        // read block, while `tensor` is consumed and can be aliased. The elemwise ops
+        // on both sides of the reduce each eliminate an intermediate, giving the reduce
+        // fuser an I/O saving over a plain elemwise fusion (which must stop at
+        // `sum_dim`) so the reduce optimization wins the block.
+        let run = |tensor: TestTensor<2>, offset: f32| {
+            let out = tensor.add_scalar(offset).mul_scalar(2.0);
+            let sum = out.clone().sum_dim(1);
+            let res = sum.mul_scalar(3.0).add_scalar(offset);
+            (out.into_data(), res.into_data())
+        };
+
+        // Warmup with the same (relative) graph: first execution may go through autotune,
+        // where benchmark trials run on forked contexts that (correctly) never alias.
+        let _ = run(make_input(), 0.0);
+        device.sync().unwrap();
+
+        let input = make_input();
+        let inspector = FusionInspector::install(stream);
+        let before = inplace_alias_count();
+        let (out, res) = run(input, 1.0);
+        device.sync().unwrap();
+        let after = inplace_alias_count();
+
+        out.assert_approx_eq::<FloatElem>(
+            &TensorData::from([[4.0, 6.0, 8.0, 10.0], [12.0, 14.0, 16.0, 18.0]]),
+            Tolerance::default(),
+        );
+        res.assert_approx_eq::<FloatElem>(
+            &TensorData::from([[85.0], [181.0]]),
+            Tolerance::default(),
+        );
+        assert_all_fused(&inspector.drain(), "reduce with consumed elemwise input");
+        assert!(
+            after > before,
+            "the elemwise output feeding the fused reduce should alias the consumed input buffer",
+        );
+    });
+}
+
 /// Repeated consuming updates (the KV-cache pattern) must alias on every iteration while
 /// the cached execution plan is reused, and values must stay correct throughout.
 #[test]

--- a/crates/burn-backend-tests/tests/fusion/inplace.rs
+++ b/crates/burn-backend-tests/tests/fusion/inplace.rs
@@ -1,0 +1,174 @@
+//! Tests that fused kernels actually write in-place (`HandleOutput::Alias`) when they can.
+//!
+//! Aliasing produces identical values to allocating a fresh output, so value-based tests
+//! cannot catch a regression — the whole mechanism silently died for over a year without a
+//! single test failing. These tests assert on the alias counter from
+//! [`burn_cubecl_fusion::inspect`].
+//!
+//! The counter is process-global, so assertions are deltas (`>=`): concurrent tests can
+//! only inflate it. "Does NOT alias" is asserted through values instead (a wrong alias
+//! corrupts the still-referenced input).
+
+use super::*;
+use burn_cubecl_fusion::inspect::inplace_alias_count;
+use burn_fusion::inspect::{BlockKind, FusionInspector};
+use burn_tensor::{TensorData, Tolerance};
+
+fn assert_all_fused(reports: &[burn_fusion::inspect::FusionReport], what: &str) {
+    let tables = reports
+        .iter()
+        .map(|report| report.format_table())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+
+    assert!(
+        !reports.is_empty()
+            && reports
+                .iter()
+                .flat_map(|report| report.blocks.iter())
+                .all(|block| matches!(block.kind, BlockKind::Fused { .. })),
+        "{what}: every block should be fused, otherwise the aliasing assertion is \
+         meaningless\n\n{tables}",
+    );
+}
+
+/// A consuming element-wise chain must reuse the input buffer for its output.
+///
+/// This covers the two launch-side regressions that killed aliasing: the `can_mut()`
+/// reference miscount (container clone kept during planning) and the reference-layout
+/// gate that rejected the first output of every block.
+#[test]
+fn consuming_elemwise_chain_writes_inplace() {
+    let stream = test_stream();
+    stream.executes(|| {
+        let device = Default::default();
+
+        let mut tensor = TestTensor::<2>::from_data([[1.0, 2.0], [3.0, 4.0]], &device);
+        // Warmup with the same (relative) graph: first execution may go through autotune,
+        // where benchmark trials run on forked contexts that (correctly) never alias.
+        tensor = tensor.add_scalar(0.0).mul_scalar(1.0);
+        let _ = tensor.clone().into_data();
+        device.sync().unwrap();
+
+        let inspector = FusionInspector::install(stream);
+        let before = inplace_alias_count();
+        for _ in 0..4 {
+            tensor = tensor.add_scalar(1.0).mul_scalar(2.0);
+            // Sync so every iteration is its own execution (own launch plan).
+            let _ = tensor.clone().into_data();
+        }
+        device.sync().unwrap();
+        let after = inplace_alias_count();
+
+        tensor.into_data().assert_approx_eq::<FloatElem>(
+            &TensorData::from([[46.0, 62.0], [78.0, 94.0]]),
+            Tolerance::default(),
+        );
+        assert_all_fused(&inspector.drain(), "consuming elemwise chain");
+        assert!(
+            after - before >= 4,
+            "each consuming iteration should alias its input buffer \
+             (got {} aliases over 4 iterations)",
+            after - before,
+        );
+    });
+}
+
+/// The consumed input keeps its buffer even when another input is broadcast: the output
+/// (same shape as the consumed input) must alias it, and values must stay correct. This
+/// is the shape that regressed with an invalid vector-size declaration on the alias.
+#[test]
+fn broadcast_elemwise_writes_inplace_and_computes_correctly() {
+    let stream = test_stream();
+    stream.executes(|| {
+        let device = Default::default();
+
+        let bias = TestTensor::<2>::from_data([[10.0, 20.0, 30.0, 40.0]], &device);
+        let mut tensor =
+            TestTensor::<2>::from_data([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]], &device);
+        tensor = tensor.add_scalar(0.0).mul_scalar(1.0);
+        let _ = tensor.clone().into_data();
+        device.sync().unwrap();
+
+        let inspector = FusionInspector::install(stream);
+        let before = inplace_alias_count();
+        let out = (tensor + bias).mul_scalar(2.0);
+        out.into_data().assert_approx_eq::<FloatElem>(
+            &TensorData::from([[22.0, 44.0, 66.0, 88.0], [30.0, 52.0, 74.0, 96.0]]),
+            Tolerance::default(),
+        );
+        device.sync().unwrap();
+        let after = inplace_alias_count();
+
+        assert_all_fused(&inspector.drain(), "broadcast elemwise");
+        assert!(
+            after > before,
+            "the broadcast chain should alias the consumed input buffer",
+        );
+    });
+}
+
+/// A tensor that stays alive (read-only use) must NOT be written in-place: its values
+/// must survive the op. Asserted through values — the alias counter is process-global,
+/// so "did not move" can't be checked under parallel tests, but a wrong alias would
+/// corrupt the still-referenced input.
+#[test]
+fn read_only_input_is_not_written_inplace() {
+    let stream = test_stream();
+    stream.executes(|| {
+        let device = Default::default();
+
+        let mut tensor = TestTensor::<2>::from_data([[1.0, 2.0], [3.0, 4.0]], &device);
+        tensor = tensor.add_scalar(0.0).mul_scalar(1.0);
+        let _ = tensor.clone().into_data();
+        device.sync().unwrap();
+
+        // `tensor` stays alive across the chain: its buffer must not be reused.
+        let out = tensor.clone().add_scalar(1.0).mul_scalar(2.0);
+        out.into_data().assert_approx_eq::<FloatElem>(
+            &TensorData::from([[4.0, 6.0], [8.0, 10.0]]),
+            Tolerance::default(),
+        );
+        device.sync().unwrap();
+
+        // The original tensor must be untouched.
+        tensor.into_data().assert_approx_eq::<FloatElem>(
+            &TensorData::from([[1.0, 2.0], [3.0, 4.0]]),
+            Tolerance::default(),
+        );
+    });
+}
+
+/// Repeated consuming updates (the KV-cache pattern) must alias on every iteration while
+/// the cached execution plan is reused, and values must stay correct throughout.
+#[test]
+fn repeated_consuming_updates_alias_with_cached_plan() {
+    let stream = test_stream();
+    stream.executes(|| {
+        let device = Default::default();
+
+        let mut acc = TestTensor::<1>::zeros([32], &device);
+        acc = acc.add_scalar(0.0).mul_scalar(1.0);
+        let _ = acc.clone().into_data();
+        device.sync().unwrap();
+
+        let inspector = FusionInspector::install(stream);
+        let before = inplace_alias_count();
+        for step in 1..=3 {
+            let values = TestTensor::<1>::full([32], step as f32, &device);
+            acc = (acc + values).add_scalar(1.0);
+            let _ = acc.clone().into_data();
+        }
+        device.sync().unwrap();
+        let after = inplace_alias_count();
+
+        acc.into_data()
+            .assert_approx_eq::<FloatElem>(&TensorData::from([9.0; 32]), Tolerance::default());
+        assert_all_fused(&inspector.drain(), "repeated consuming updates");
+        assert!(
+            after - before >= 3,
+            "each accumulation step should alias (got {} aliases over 3 steps)",
+            after - before,
+        );
+    });
+}

--- a/crates/burn-backend-tests/tests/fusion/mod.rs
+++ b/crates/burn-backend-tests/tests/fusion/mod.rs
@@ -4,6 +4,9 @@ mod cat;
 mod fusion_f16_broadcast;
 mod fusion_f16_write_vectorization;
 mod fusion_shape;
+// Asserts on launch-level decisions from `burn-cubecl-fusion`, which only the `cube`
+// feature pulls in; the rest of this suite also runs on non-cube fusion backends (flex).
+#[cfg(feature = "cube")]
 mod inplace;
 mod int_bitwise;
 mod reduce_broadcasted;

--- a/crates/burn-backend-tests/tests/fusion/mod.rs
+++ b/crates/burn-backend-tests/tests/fusion/mod.rs
@@ -4,6 +4,7 @@ mod cat;
 mod fusion_f16_broadcast;
 mod fusion_f16_write_vectorization;
 mod fusion_shape;
+mod inplace;
 mod int_bitwise;
 mod reduce_broadcasted;
 

--- a/crates/burn-cubecl-fusion/Cargo.toml
+++ b/crates/burn-cubecl-fusion/Cargo.toml
@@ -20,6 +20,7 @@ default = ["autotune", "std", "cubecl/default", "burn-fusion/default"]
 autotune = []
 autotune-checks = ["cubecl/autotune-checks", "half"]
 doc = ["default"]
+test-util = []
 std = ["cubecl/std", "burn-backend/std", "burn-fusion/std"]
 tracing = [
     "cubecl/tracing",

--- a/crates/burn-cubecl-fusion/src/engine/codegen/ir.rs
+++ b/crates/burn-cubecl-fusion/src/engine/codegen/ir.rs
@@ -484,7 +484,7 @@ impl<R: Runtime> GlobalArgsLaunch<R> {
     pub fn shape(&self, arg: &FuseArg) -> Shape {
         match self.resolve_arg(arg) {
             TensorArg::Handle { handle, .. } => handle.shape.clone(),
-            TensorArg::Alias { .. } => panic!("Unsupported yet"),
+            TensorArg::Alias { shape, .. } => shape.clone(),
         }
     }
 
@@ -524,7 +524,7 @@ impl<R: Runtime> GlobalArgsLaunch<R> {
     pub fn strides(&self, arg: &FuseArg) -> Strides {
         match self.resolve_arg(arg) {
             TensorArg::Handle { handle, .. } => handle.strides.clone(),
-            TensorArg::Alias { .. } => panic!("Unsupported yet"),
+            TensorArg::Alias { strides, .. } => strides.clone(),
         }
     }
 

--- a/crates/burn-cubecl-fusion/src/engine/launch/executor.rs
+++ b/crates/burn-cubecl-fusion/src/engine/launch/executor.rs
@@ -73,6 +73,19 @@ impl<'a, R: Runtime> LaunchPlanExecutor<'a, R> {
         let mut inputs = GlobalArgsLaunch::default();
         let mut outputs = GlobalArgsLaunch::default();
 
+        // An aliased output reuses the input's buffer variable in the compiled kernel
+        // (`builder.inplace`), so it must be declared with the exact type the input was
+        // launched with — including its vector size.
+        let input_vector_sizes: Vec<usize> = plan
+            .handle_inputs
+            .iter()
+            .map(|hi| match hi {
+                HandleInput::Normal(hi) => hi.vector_size,
+                HandleInput::QuantValues(hi) => hi.vector_size,
+                HandleInput::QuantParams(_) => 1,
+            })
+            .collect();
+
         register_inputs(plan.handle_inputs.clone(), &mut inputs);
         register_scalars(
             self.resources.scalars.iter(),
@@ -80,7 +93,12 @@ impl<'a, R: Runtime> LaunchPlanExecutor<'a, R> {
             context,
             &mut inputs,
         );
-        register_outputs::<R>(plan.handle_outputs.clone(), &mut outputs, &mut tune_output);
+        register_outputs::<R>(
+            plan.handle_outputs.clone(),
+            &input_vector_sizes,
+            &mut outputs,
+            &mut tune_output,
+        );
 
         for layout in plan.runtime_layouts {
             for s in layout.shape.iter() {
@@ -201,6 +219,7 @@ fn register_inputs<R: Runtime>(
 
 fn register_outputs<R: Runtime>(
     handle_outputs: Vec<HandleOutput<R>>,
+    input_vector_sizes: &[usize],
     outputs: &mut GlobalArgsLaunch<R>,
     #[allow(unused_variables)] tune_output: &mut TuneOutput<R>,
 ) {
@@ -220,7 +239,11 @@ fn register_outputs<R: Runtime>(
                         strides,
                         shape: global_shape,
                     },
-                    precision.into_type(1),
+                    // Must match the aliased input's launched type: the compiled kernel
+                    // reuses the input's buffer variable, so declaring another vector
+                    // size here would make the comptime type disagree with the actual
+                    // variable and produce invalid casts on the write path.
+                    precision.into_type(input_vector_sizes[input_pos]),
                     false,
                     AddressType::default(),
                 ));

--- a/crates/burn-cubecl-fusion/src/engine/launch/input.rs
+++ b/crates/burn-cubecl-fusion/src/engine/launch/input.rs
@@ -33,19 +33,15 @@ impl<'a, R: Runtime> InputPlanner<'a, R> {
                 RegisterTensor::Normal(tensor_relative, precision) => {
                     let mut tensor_global =
                         context.tensors.get(&tensor_relative.id).unwrap().clone();
+                    // Fetching with the real status pops consumed (`ReadWrite`) tensors
+                    // out of the container so that `can_mut()` sees the true reference
+                    // count (memory pool + this handle). Fetching `ReadOnly` and keeping
+                    // a clone in the container during planning made `can_mut()` always
+                    // false, disabling every in-place alias. On execution failure the
+                    // handle is restored by [FuseTraceLauncher::rollback](super::base).
                     let handle = context
                         .handles
-                        .get_handle(&tensor_global.id, &TensorStatus::ReadOnly);
-
-                    if let TensorStatus::ReadWrite = tensor_relative.status {
-                        // This execution consumes the tensor: take back the clone that
-                        // `get_handle` left in the container so that `can_mut()` sees the
-                        // true reference count (memory pool + this handle). Keeping the
-                        // clone around during planning made `can_mut()` always false,
-                        // disabling every in-place alias. On execution failure the handle
-                        // is restored by [FuseTraceLauncher::rollback](super::base).
-                        context.handles.remove_handle(tensor_global.id);
-                    }
+                        .get_handle(&tensor_global.id, &tensor_relative.status);
 
                     let mut new_strides = handle.strides.clone();
 
@@ -175,6 +171,9 @@ impl<'a, R: Runtime> InputPlanner<'a, R> {
 
             let block_plan = &mut plan.blocks[idx];
             if tensor_relative.status == TensorStatus::ReadWrite {
+                // TODO: Autotune trials run on forked contexts whose extra handle clone
+                // makes `can_mut()` false, so trials never alias: the tuner measures the
+                // non-aliased kernel while the winner then executes the aliased one.
                 if self.blocks[idx].settings.inplace && handle.handle.can_mut() {
                     block_plan.potential_inplaces.push(PotentialInplace {
                         input_pos: pos,

--- a/crates/burn-cubecl-fusion/src/engine/launch/input.rs
+++ b/crates/burn-cubecl-fusion/src/engine/launch/input.rs
@@ -38,7 +38,13 @@ impl<'a, R: Runtime> InputPlanner<'a, R> {
                         .get_handle(&tensor_global.id, &TensorStatus::ReadOnly);
 
                     if let TensorStatus::ReadWrite = tensor_relative.status {
-                        plan.cleared.push(tensor_global.id);
+                        // This execution consumes the tensor: take back the clone that
+                        // `get_handle` left in the container so that `can_mut()` sees the
+                        // true reference count (memory pool + this handle). Keeping the
+                        // clone around during planning made `can_mut()` always false,
+                        // disabling every in-place alias. On execution failure the handle
+                        // is restored by [FuseTraceLauncher::rollback](super::base).
+                        context.handles.remove_handle(tensor_global.id);
                     }
 
                     let mut new_strides = handle.strides.clone();

--- a/crates/burn-cubecl-fusion/src/engine/launch/output.rs
+++ b/crates/burn-cubecl-fusion/src/engine/launch/output.rs
@@ -212,9 +212,6 @@ impl<'a, R: Runtime> OutputPlanner<'a, R> {
                 context.handles.remove_handle(tensor_global.id);
             }
         }
-        for id in plan.cleared.drain(..) {
-            context.handles.remove_handle(id);
-        }
     }
 
     fn select_reference_from_inputs(
@@ -353,7 +350,13 @@ impl<'a, R: Runtime> OutputPlanner<'a, R> {
                 pi.tensor_relative.dtype == tensor_global.dtype
                     && pi.tensor_relative.shape == output.tensor_relative.shape
                     && &*pi.strides == strides
-                    && block.reference.compatible_strides_for_inplace(strides)
+                    // When no reference has been selected yet, this output becomes the
+                    // reference (see [Self::inplace_output]); an already-selected
+                    // reference must have compatible strides. Requiring an existing
+                    // reference here made the first output of every block ineligible,
+                    // since the reference is only selected while processing outputs.
+                    && (!block.reference.is_found()
+                        || block.reference.compatible_strides_for_inplace(strides))
             })
             .map(|(pos, _)| OutputKind::Inplace { input_pos: pos })
             .unwrap_or(OutputKind::Normal);
@@ -373,6 +376,8 @@ impl<'a, R: Runtime> OutputPlanner<'a, R> {
         block_idx: usize,
     ) {
         let block = &mut plan.blocks[block_idx];
+        #[cfg(feature = "test-util")]
+        crate::inspect::record_inplace_alias();
         let potential_inplace = block.potential_inplaces.remove(input_index);
         let handle_input = match plan.handle_inputs.get(potential_inplace.input_pos).unwrap() {
             HandleInput::Normal(handle) => handle,
@@ -387,14 +392,12 @@ impl<'a, R: Runtime> OutputPlanner<'a, R> {
                 RefLayoutSetting::SameAsBlock { .. }
             )
         {
-            let index_input = self
-                .resources
-                .inputs
-                .get_index(potential_inplace.tensor_relative.id)
-                .unwrap();
-
+            // The aliased output shares the input's buffer and layout, so the reference
+            // is expressed with the output argument. Runners assume references are
+            // either output-concrete or virtual; an input-concrete reference here would
+            // be resolved against the wrong argument list.
             block.reference = ReferenceSelection::Concrete {
-                layout: FuseArg::Input(index_input, output.precision, LayoutInfo::IsRef),
+                layout: FuseArg::Output(output.pos_original, output.precision, LayoutInfo::IsRef),
                 shape: tensor_global.shape.clone(),
                 strides: handle_input.handle.strides.clone(),
             };

--- a/crates/burn-cubecl-fusion/src/engine/launch/output.rs
+++ b/crates/burn-cubecl-fusion/src/engine/launch/output.rs
@@ -342,6 +342,7 @@ impl<'a, R: Runtime> OutputPlanner<'a, R> {
         }
 
         let block = &plan.blocks[block_idx];
+        let ref_layout_setting = &self.blocks[block_idx].settings.ref_layout;
         let kind = block
             .potential_inplaces
             .iter()
@@ -350,13 +351,20 @@ impl<'a, R: Runtime> OutputPlanner<'a, R> {
                 pi.tensor_relative.dtype == tensor_global.dtype
                     && pi.tensor_relative.shape == output.tensor_relative.shape
                     && &*pi.strides == strides
-                    // When no reference has been selected yet, this output becomes the
-                    // reference (see [Self::inplace_output]); an already-selected
-                    // reference must have compatible strides. Requiring an existing
-                    // reference here made the first output of every block ineligible,
-                    // since the reference is only selected while processing outputs.
-                    && (!block.reference.is_found()
-                        || block.reference.compatible_strides_for_inplace(strides))
+                    && if block.reference.is_found() {
+                        // An already-selected reference must have compatible strides.
+                        block.reference.compatible_strides_for_inplace(strides)
+                    } else {
+                        // When no reference has been selected yet, this output becomes
+                        // the reference (see [Self::inplace_output]); requiring an
+                        // existing reference here made the first output of every block
+                        // ineligible, since the reference is only selected while
+                        // processing outputs. Blocks that inherit their reference from
+                        // another block are excluded: the inherited layout is unknown
+                        // at this point, so it cannot be validated against the
+                        // candidate's strides.
+                        !matches!(ref_layout_setting, RefLayoutSetting::SameAsBlock { .. })
+                    }
             })
             .map(|(pos, _)| OutputKind::Inplace { input_pos: pos })
             .unwrap_or(OutputKind::Normal);
@@ -386,12 +394,19 @@ impl<'a, R: Runtime> OutputPlanner<'a, R> {
             }
         };
 
-        if !block.reference.is_found()
-            && !matches!(
-                self.blocks[block_idx].settings.ref_layout,
-                RefLayoutSetting::SameAsBlock { .. }
-            )
-        {
+        // [Self::output_kind] only selects inplace when the reference is already
+        // validated or this output can become the reference, which blocks inheriting
+        // their reference from another block (`SameAsBlock`) never can.
+        debug_assert!(
+            block.reference.is_found()
+                || !matches!(
+                    self.blocks[block_idx].settings.ref_layout,
+                    RefLayoutSetting::SameAsBlock { .. }
+                ),
+            "inplace alias selected for a `SameAsBlock` block without a validated reference",
+        );
+
+        if !block.reference.is_found() {
             // The aliased output shares the input's buffer and layout, so the reference
             // is expressed with the output argument. Runners assume references are
             // either output-concrete or virtual; an input-concrete reference here would

--- a/crates/burn-cubecl-fusion/src/engine/launch/plan.rs
+++ b/crates/burn-cubecl-fusion/src/engine/launch/plan.rs
@@ -32,8 +32,6 @@ pub struct LaunchPlan<'a, R: Runtime> {
     pub blocks: Vec<BlockPlan<'a>>,
     /// Mapping of tensor IDs to their specific vectorization factors.
     pub vectorizations: BTreeMap<TensorId, Vect>,
-    /// Tensors that can be cleared or deallocated after this plan executes.
-    pub cleared: Vec<TensorId>,
     /// Metadata for shapes and strides passed from the host when they cannot be
     /// inferred from input tensors (e.g., complex deep fusions).
     pub runtime_layouts: Vec<RuntimeLayout>,
@@ -129,7 +127,6 @@ impl<R: Runtime> LaunchPlan<'_, R> {
             rank,
             blocks,
             vectorizations: Default::default(),
-            cleared: Default::default(),
             runtime_layouts: Default::default(),
         }
     }

--- a/crates/burn-cubecl-fusion/src/inspect.rs
+++ b/crates/burn-cubecl-fusion/src/inspect.rs
@@ -1,0 +1,23 @@
+//! Test-only introspection into launch-level decisions.
+//!
+//! Some launch decisions — like whether a fused kernel wrote its output in-place into an
+//! input buffer — produce identical results either way, so value-based tests cannot catch
+//! a silent regression. The counters here make those decisions observable.
+//!
+//! Counters are process-global: concurrent tests on the same process all increment them.
+//! Assert on deltas (`>= n`), or serialize the test (e.g. `#[serial]`) when asserting that
+//! a counter did *not* move.
+
+use core::sync::atomic::{AtomicU64, Ordering};
+
+static INPLACE_ALIAS_COUNT: AtomicU64 = AtomicU64::new(0);
+
+/// The number of fused-kernel outputs that aliased (reused) an input buffer instead of
+/// allocating their own, since process start.
+pub fn inplace_alias_count() -> u64 {
+    INPLACE_ALIAS_COUNT.load(Ordering::Relaxed)
+}
+
+pub(crate) fn record_inplace_alias() {
+    INPLACE_ALIAS_COUNT.fetch_add(1, Ordering::Relaxed);
+}

--- a/crates/burn-cubecl-fusion/src/inspect.rs
+++ b/crates/burn-cubecl-fusion/src/inspect.rs
@@ -12,8 +12,11 @@ use core::sync::atomic::{AtomicU64, Ordering};
 
 static INPLACE_ALIAS_COUNT: AtomicU64 = AtomicU64::new(0);
 
-/// The number of fused-kernel outputs that aliased (reused) an input buffer instead of
-/// allocating their own, since process start.
+/// The number of fused-kernel outputs planned to alias (reuse) an input buffer instead
+/// of allocating their own, since process start.
+///
+/// Counted at plan time: a plan whose execution later fails and rolls back still
+/// increments the counter, so treat it as an upper bound on executed aliases.
 pub fn inplace_alias_count() -> u64 {
     INPLACE_ALIAS_COUNT.load(Ordering::Relaxed)
 }

--- a/crates/burn-cubecl-fusion/src/lib.rs
+++ b/crates/burn-cubecl-fusion/src/lib.rs
@@ -3,6 +3,9 @@ extern crate derive_new;
 
 pub mod optim;
 
+#[cfg(feature = "test-util")]
+pub mod inspect;
+
 mod base;
 
 pub(crate) mod engine;


### PR DESCRIPTION
HandleOutput::Alias has been dead for over a year — every fused kernel allocated a fresh output buffer. Nothing caught it because aliasing produces identical values; only allocation behavior differs. Four fixes:

- can_mut accounting: since #3263, InputPlanner fetched every input with ReadOnly status, leaving a clone in the HandleContainer during planning. cubecl's can_mut() budget is "pool + one user handle", so the extra clone made it always false. ReadWrite inputs now take back the container clone at fetch time (this execution consumes them; rollback restores handles on failure), replacing the deferred plan.cleared mechanism.

- output_kind gate: since #2870, inplace candidates required an already-selected reference layout, but the reference is only selected while processing outputs — the first output of every block (i.e. the only output of typical elemwise blocks) could never alias. The gate now passes when no reference is selected yet; the aliased output becomes the reference, as inplace_output always intended.

- alias vector size: alias outputs were declared with vector size 1, but the compiled kernel reuses the input's buffer variable (builder.inplace), so the comptime type disagreed with the actual variable for vectorized inputs, producing invalid casts on the write path. Alias outputs are now declared with the aliased input's launched type.

- reference form: the revived inplace reference used a Concrete(Input) layout, which runners written after #2870 (matmul, reduce) don't handle — they resolve the reference against the output args. The reference is now expressed with the aliased output arg (same buffer and layout), and GlobalArgsLaunch::shape/strides support TensorArg::Alias.

Adds a test-util feature to burn-cubecl-fusion with an in-place alias counter, and fusion tests that fail if aliasing silently dies again. Each fix was mutation-tested against the new and existing suites.

