### PR TITLE
fix(ndarray): propagate NaN in argmax/argmin/cummin/cummax

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/float/ops/arg.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/arg.rs
@@ -128,16 +128,8 @@ fn test_argmax_permuted_correctness() {
         .assert_eq(&TensorData::from([[[1], [1], [1]], [[1], [1], [1]]]), false);
 }
 
-// NaN-propagation tests below. Only run when the `flex` backend feature
-// is active, because flex is the only burn backend that currently
-// propagates NaN from argmax/argmin (matching PyTorch/NumPy/JAX/TF).
-// ndarray and the cubecl backends follow IEEE 754 min/max and drop NaN.
-// The positive-gate form (rather than excluding specific backends) is
-// used because the default-feature CI build selects a backend
-// transitively without setting any of its identifying feature flags on
-// burn-backend-tests, so a negative gate would still run the test on a
-// NaN-dropping backend. See issue #4814.
-#[cfg(feature = "flex")]
+// NaN-propagation tests. All burn backends should propagate NaN from
+// argmax/argmin (matching PyTorch/NumPy/JAX/TF semantics). See issue #4814.
 #[test]
 fn test_argmax_nan_propagation() {
     let tensor = TestTensor::<2>::from([[1.0, f32::NAN, 3.0]]);
@@ -150,7 +142,6 @@ fn test_argmax_nan_propagation() {
 
 // First-NaN wins: when row[0] is NaN AND a later element is also NaN,
 // argmax must return 0 (the earlier NaN index), not the later one.
-#[cfg(feature = "flex")]
 #[test]
 fn test_argmax_nan_leading_with_trailing_nan() {
     let tensor = TestTensor::<2>::from([[f32::NAN, f32::NAN, 3.0]]);
@@ -160,7 +151,6 @@ fn test_argmax_nan_leading_with_trailing_nan() {
         .assert_eq(&TensorData::from([[0]]), false);
 }
 
-#[cfg(feature = "flex")]
 #[test]
 fn test_argmin_nan_leading_with_trailing_nan() {
     let tensor = TestTensor::<2>::from([[f32::NAN, f32::NAN, 3.0]]);
@@ -171,7 +161,6 @@ fn test_argmin_nan_leading_with_trailing_nan() {
 }
 
 // All-NaN row: argmax should return 0 (first NaN).
-#[cfg(feature = "flex")]
 #[test]
 fn test_argmax_all_nan_row() {
     let tensor = TestTensor::<2>::from([[f32::NAN, f32::NAN, f32::NAN]]);
@@ -183,7 +172,6 @@ fn test_argmax_all_nan_row() {
 
 // NaN propagation must also hold for non-last-dim argmax, which routes
 // through a different kernel than the last-dim fast path.
-#[cfg(feature = "flex")]
 #[test]
 fn test_argmax_nan_leading_non_last_dim() {
     // Column 0: [NaN, NaN, 3.0] -> argmax along dim 0 = 0.
@@ -198,7 +186,6 @@ fn test_argmax_nan_leading_non_last_dim() {
 // max_dim_with_indices on a leading-NaN row should return (NaN, 0).
 // Complements test_max_dim_with_indices_nan_propagation in maxmin.rs,
 // which uses a single NaN in the middle of the row.
-#[cfg(feature = "flex")]
 #[test]
 fn test_max_dim_with_indices_nan_leading() {
     let tensor = TestTensor::<2>::from([[f32::NAN, f32::NAN, 3.0]]);

--- a/crates/burn-backend-tests/tests/tensor/float/ops/cumulative.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/cumulative.rs
@@ -1,7 +1,6 @@
 use super::*;
 use burn_tensor::TensorData;
 
-#[cfg(feature = "flex")]
 use burn_tensor::ElementConversion;
 
 #[test]
@@ -154,11 +153,8 @@ fn test_cummax_float_3d() {
     );
 }
 
-// NaN-propagation tests below. Only run under the `flex` backend
-// feature; other burn backends follow IEEE 754 min/max and drop NaN.
-// Positive-gate form because the default CI build doesn't set
-// identifying feature flags on burn-backend-tests. See issue #4814.
-#[cfg(feature = "flex")]
+// NaN-propagation tests. All burn backends should propagate NaN from
+// cummin/cummax (matching PyTorch/NumPy/JAX/TF semantics). See issue #4814.
 #[test]
 fn test_cummin_nan_propagation() {
     // Once NaN appears, cummin propagates it forward.
@@ -173,7 +169,6 @@ fn test_cummin_nan_propagation() {
     assert!(data[3].is_nan());
 }
 
-#[cfg(feature = "flex")]
 #[test]
 fn test_cummax_nan_propagation() {
     let tensor = TestTensor::<1>::from([1.0, f32::NAN, 5.0, 2.0]);
@@ -187,7 +182,6 @@ fn test_cummax_nan_propagation() {
     assert!(data[3].is_nan());
 }
 
-#[cfg(feature = "flex")]
 #[test]
 fn test_cummin_nan_at_start() {
     // NaN on the first element should poison the entire output.

--- a/crates/burn-backend-tests/tests/tensor/float/ops/maxmin.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/maxmin.rs
@@ -268,16 +268,8 @@ fn test_max_abs_dim_2d_dim_1() {
     output.into_data().assert_eq(&expected, false);
 }
 
-// NaN-propagation tests below. Only run when the `flex` backend feature
-// is active, because flex is the only burn backend that currently
-// propagates NaN from min/max (matching PyTorch/NumPy/JAX/TF). ndarray
-// and the cubecl backends follow IEEE 754 min/max and drop NaN. The
-// positive-gate form (rather than excluding specific backends) is used
-// because the default-feature CI build selects a backend transitively
-// without setting any of its identifying feature flags on
-// burn-backend-tests, so a negative gate would still run the test on a
-// NaN-dropping backend. See issue #4814.
-#[cfg(feature = "flex")]
+// NaN-propagation tests. All burn backends should propagate NaN from
+// min/max (matching PyTorch/NumPy/JAX/TF semantics). See issue #4814.
 #[test]
 fn test_max_dim_nan_propagation() {
     let tensor = TestTensor::<2>::from([[1.0, f32::NAN, 3.0]]);
@@ -286,7 +278,6 @@ fn test_max_dim_nan_propagation() {
     assert!(values[0].is_nan());
 }
 
-#[cfg(feature = "flex")]
 #[test]
 fn test_min_dim_nan_propagation() {
     let tensor = TestTensor::<2>::from([[1.0, f32::NAN, 3.0]]);
@@ -295,7 +286,6 @@ fn test_min_dim_nan_propagation() {
     assert!(values[0].is_nan());
 }
 
-#[cfg(feature = "flex")]
 #[test]
 fn test_max_dim_with_indices_nan_propagation() {
     let tensor = TestTensor::<2>::from([[1.0, f32::NAN, 3.0]]);

--- a/crates/burn-ndarray/src/ops/base.rs
+++ b/crates/burn-ndarray/src/ops/base.rs
@@ -1584,6 +1584,9 @@ fn arg<E: NdArrayElement + PartialOrd, I: NdArrayElement + PartialOrd>(
 }
 
 /// View-based argmax/argmin - zero-copy for borrowed storage.
+///
+/// NaN propagation: if the current element is NaN, it is always selected (NaN
+/// propagates, matching PyTorch / NumPy / JAX / TensorFlow semantics).
 fn arg_view<E: NdArrayElement + PartialOrd, I: NdArrayElement + PartialOrd>(
     view: ArrayView<'_, E, IxDyn>,
     dim: usize,
@@ -1594,11 +1597,21 @@ fn arg_view<E: NdArrayElement + PartialOrd, I: NdArrayElement + PartialOrd>(
 
     let output = view.map_axis(Axis(dim), |arr| {
         // Find the min/max value in the array, and return its index.
+        // NaN propagation: NaN is always selected over non-NaN values,
+        // and the first NaN encountered wins (stable).
         let (_e, idx) = arr.indexed_iter().fold((arr[0], 0usize), |acc, (idx, e)| {
-            let cmp = match cmp {
-                CmpType::Min => e < &acc.0,
-                CmpType::Max => e > &acc.0,
-            };
+            // Use partial_cmp to detect NaN: partial_cmp returns None iff either
+            // operand is NaN (for IEEE 754 float types).
+            let is_acc_nan = acc.0.partial_cmp(&acc.0).is_none();
+            let is_e_nan = e.partial_cmp(e).is_none();
+
+            // Select e when:
+            // - acc is not NaN AND (e is NaN OR normal comparison holds)
+            let cmp = !is_acc_nan
+                && (is_e_nan || match cmp {
+                    CmpType::Min => e < &acc.0,
+                    CmpType::Max => e > &acc.0,
+                });
 
             if cmp { (*e, idx) } else { acc }
         });

--- a/crates/burn-ndarray/src/ops/base.rs
+++ b/crates/burn-ndarray/src/ops/base.rs
@@ -1608,10 +1608,11 @@ fn arg_view<E: NdArrayElement + PartialOrd, I: NdArrayElement + PartialOrd>(
             // Select e when:
             // - acc is not NaN AND (e is NaN OR normal comparison holds)
             let cmp = !is_acc_nan
-                && (is_e_nan || match cmp {
-                    CmpType::Min => e < &acc.0,
-                    CmpType::Max => e > &acc.0,
-                });
+                && (is_e_nan
+                    || match cmp {
+                        CmpType::Min => e < &acc.0,
+                        CmpType::Max => e > &acc.0,
+                    });
 
             if cmp { (*e, idx) } else { acc }
         });

--- a/crates/burn-ndarray/src/ops/macros.rs
+++ b/crates/burn-ndarray/src/ops/macros.rs
@@ -89,7 +89,11 @@ pub(crate) fn cummin_dim<E: NdArrayElement + core::cmp::PartialOrd<E>>(
     dim: usize,
 ) -> SharedArray<E> {
     cumulative_with_op(tensor, dim, |c, &p| {
-        if p < *c {
+        // NaN propagation: if p is NaN, it replaces c (NaN propagates forward).
+        // If c is NaN, it stays (first NaN wins, stable).
+        let is_c_nan = (*c).partial_cmp(&*c).is_none();
+        let is_p_nan = p.partial_cmp(&p).is_none();
+        if !is_c_nan && (is_p_nan || p < *c) {
             *c = p;
         }
     })
@@ -100,7 +104,11 @@ pub(crate) fn cummax_dim<E: NdArrayElement + core::cmp::PartialOrd<E>>(
     dim: usize,
 ) -> SharedArray<E> {
     cumulative_with_op(tensor, dim, |c, &p| {
-        if p > *c {
+        // NaN propagation: if p is NaN, it replaces c (NaN propagates forward).
+        // If c is NaN, it stays (first NaN wins, stable).
+        let is_c_nan = (*c).partial_cmp(&*c).is_none();
+        let is_p_nan = p.partial_cmp(&p).is_none();
+        if !is_c_nan && (is_p_nan || p > *c) {
             *c = p;
         }
     })


### PR DESCRIPTION
## Summary

Fix #4814 (ndarray part): ndarray backend now propagates NaN in `argmax`, `argmin`, `max_dim`, `min_dim`, `cummin`, and `cummax`, matching PyTorch / NumPy / JAX / TensorFlow semantics.

## What changed

- **`burn-ndarray/src/ops/base.rs`**: Updated `arg_view` to detect NaN via `partial_cmp` (returns `None` for NaN) and select NaN over non-NaN values. First NaN wins for stability.
- **`burn-ndarray/src/ops/macros.rs`**: Updated `cummin_dim` and `cummax_dim` to propagate NaN forward. First NaN wins (stable).
- **Removed `#[cfg(feature = "flex")]` gates** from 12 NaN-propagation tests in `burn-backend-tests` — these tests now run on all backends.

## Why `partial_cmp` trick?

The original code used `e < &acc.0` which is `false` for NaN (IEEE 754). Rather than adding `is_nan()` to the `NdArrayElement` trait (which would be a trait-level change), we use `partial_cmp` which returns `None` iff either operand is NaN. This works generically over all `NdArrayElement` types — integer types never return `None`, so zero overhead there.

## Before / After

| Operation | Before | After |
|-----------|--------|-------|
| `max([1.0, NaN, 3.0])` | `3.0` | `NaN` |
| `argmax([1.0, NaN, 3.0])` | `2` | `1` |
| `cummax([1.0, NaN, 5.0])` | `[1.0, NaN, 5.0]` | `[1.0, NaN, NaN]` |

## Test results

- 12 NaN-propagation tests: **all pass** on ndarray
- Full tensor test suite: **1386 passed**, 0 failed (6 ignored, unrelated)
- Pre-existing autodiff failures (2) are unrelated

## Not in this PR

The cubecl backend (used by wgpu/Metal/CUDA) still drops NaN. That requires changes to `burn-cubecl/src/ops/numeric.rs` and `kernel/binary.rs` — tracked as a follow-up in #4814.