### PR TITLE
feat(burn-cubecl): add deterministic feature for reproducible float reductions

### DIFF
--- a/crates/burn-cubecl/Cargo.toml
+++ b/crates/burn-cubecl/Cargo.toml
@@ -53,6 +53,9 @@ fusion-experimental = ["fusion"]
 
 template = []
 
+# Prefer chained float sum / reduce (no cross-cube atomics) for bit-reproducible training.
+deterministic = []
+
 distributed = [
     "std",
     "burn-backend/distributed",

--- a/crates/burn-cubecl/Cargo.toml
+++ b/crates/burn-cubecl/Cargo.toml
@@ -95,6 +95,10 @@ futures-lite = { workspace = true, features = ["std"] }
 serde = { workspace = true }
 text_placeholder = { workspace = true, features = ["struct_context"] }
 
+[dev-dependencies]
+# WgpuRuntime for GPU sum A/B tests in `kernel/reduce/base` (enables `cubecl/wgpu` via unification).
+burn-wgpu = { workspace = true }
+
 [package.metadata.docs.rs]
 features = ["doc"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/burn-cubecl/src/kernel/reduce/base.rs
+++ b/crates/burn-cubecl/src/kernel/reduce/base.rs
@@ -104,11 +104,19 @@ pub enum SumStrategy {
 
 impl Default for SumStrategy {
     fn default() -> Self {
-        #[cfg(feature = "autotune")]
-        return Self::Autotune;
+        // `deterministic`: chained reduce avoids cross-cube float atomics in OneShot
+        // shared_sum (non-associative + undefined completion order → multi-step drift).
+        #[cfg(feature = "deterministic")]
+        return Self::Chained(KernelReduceStrategy::Unspecified);
 
-        #[cfg(not(feature = "autotune"))]
-        return Self::OneShot(4);
+        #[cfg(not(feature = "deterministic"))]
+        {
+            #[cfg(feature = "autotune")]
+            return Self::Autotune;
+
+            #[cfg(not(feature = "autotune"))]
+            return Self::OneShot(4);
+        }
     }
 }
 
@@ -248,10 +256,16 @@ pub enum KernelReduceStrategy {
 
 impl Default for KernelReduceStrategy {
     fn default() -> Self {
-        #[cfg(feature = "autotune")]
-        return Self::Autotune;
-
-        #[cfg(not(feature = "autotune"))]
+        #[cfg(feature = "deterministic")]
         return Self::Unspecified;
+
+        #[cfg(not(feature = "deterministic"))]
+        {
+            #[cfg(feature = "autotune")]
+            return Self::Autotune;
+
+            #[cfg(not(feature = "autotune"))]
+            return Self::Unspecified;
+        }
     }
 }

--- a/crates/burn-cubecl/src/kernel/reduce/base.rs
+++ b/crates/burn-cubecl/src/kernel/reduce/base.rs
@@ -269,3 +269,122 @@ impl Default for KernelReduceStrategy {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Feature contract: `deterministic` selects chained float sum (no OneShot atomics).
+    #[test]
+    #[cfg(feature = "deterministic")]
+    fn default_sum_strategy_is_chained_with_deterministic() {
+        assert!(matches!(
+            SumStrategy::default(),
+            SumStrategy::Chained(KernelReduceStrategy::Unspecified)
+        ));
+        assert!(matches!(
+            KernelReduceStrategy::default(),
+            KernelReduceStrategy::Unspecified
+        ));
+    }
+
+    /// Feature contract: without `deterministic`, keep upstream Autotune/OneShot defaults.
+    #[test]
+    #[cfg(all(not(feature = "deterministic"), feature = "autotune"))]
+    fn default_sum_strategy_is_autotune_without_deterministic() {
+        assert!(matches!(SumStrategy::default(), SumStrategy::Autotune));
+        assert!(matches!(
+            KernelReduceStrategy::default(),
+            KernelReduceStrategy::Autotune
+        ));
+    }
+
+    /// Multi-step float-sum feedback: each step's `sum` scales the next input.
+    ///
+    /// A/B via feature (two separate `cargo test` invocations):
+    /// - `--features deterministic`: `SumStrategy::default()` (Chained) → reproducible
+    /// - default features: `SumStrategy::OneShot` (what Autotune often selects) → diverges
+    ///
+    /// ```text
+    /// cargo test -p burn-cubecl --features deterministic multi_step_float_sum
+    /// cargo test -p burn-cubecl multi_step_float_sum
+    /// ```
+    mod multi_step_float_sum {
+        use super::*;
+        use crate::ops::{from_data, into_data_sync};
+        use burn_backend::TensorData;
+        use cubecl::wgpu::{WgpuDevice, WgpuRuntime};
+
+        const N: usize = 1 << 18;
+        const STEPS: usize = 40;
+        const EPS: f32 = 1e-5;
+
+        fn fixed_values() -> Vec<f32> {
+            (0..N)
+                .map(|i| ((i % 997) as f32 * 0.0017).sin() * 0.5)
+                .collect()
+        }
+
+        fn feedback_probe(mut strategy: impl FnMut() -> SumStrategy) -> f32 {
+            let device = WgpuDevice::default();
+            let mut values = fixed_values();
+            let mut last = 0.0f32;
+            for _ in 0..STEPS {
+                let t = from_data::<WgpuRuntime>(TensorData::new(values.clone(), [N]), &device);
+                let out = sum(t, strategy()).expect("sum");
+                last = into_data_sync::<WgpuRuntime>(out)
+                    .as_slice::<f32>()
+                    .unwrap()[0];
+                // Feed a *mean-scale* back so noise accumulates without exploding to NaN.
+                let mean = last / N as f32;
+                let scale = (1.0 - 0.05 * mean).clamp(0.5, 1.5);
+                for v in &mut values {
+                    *v *= scale;
+                }
+            }
+            last
+        }
+
+        #[test]
+        #[cfg(feature = "deterministic")]
+        fn multi_step_float_sum_is_reproducible_with_deterministic() {
+            assert!(
+                matches!(
+                    SumStrategy::default(),
+                    SumStrategy::Chained(KernelReduceStrategy::Unspecified)
+                ),
+                "deterministic feature must select Chained as default"
+            );
+            let a = feedback_probe(SumStrategy::default);
+            let b = feedback_probe(SumStrategy::default);
+            let delta = (a - b).abs();
+            assert!(
+                delta < EPS,
+                "Chained default should be bit-stable across runs: \
+                 run1={a}, run2={b}, Δ={delta}"
+            );
+        }
+
+        #[test]
+        #[cfg(not(feature = "deterministic"))]
+        fn multi_step_float_sum_diverges_without_deterministic() {
+            // Upstream default is Autotune, which frequently selects OneShot shared_sum
+            // (cross-cube float atomics). Probe that hazardous path directly.
+            assert!(
+                matches!(SumStrategy::default(), SumStrategy::Autotune),
+                "without deterministic, default should remain Autotune"
+            );
+            let mut max_delta = 0.0f32;
+            for _ in 0..3 {
+                let a = feedback_probe(|| SumStrategy::OneShot(8));
+                let b = feedback_probe(|| SumStrategy::OneShot(8));
+                max_delta = max_delta.max((a - b).abs());
+            }
+            assert!(
+                max_delta > EPS,
+                "OneShot (Autotune's common pick) should diverge across runs; max Δ={max_delta}"
+            );
+        }
+    }
+}
+

--- a/crates/burn-wgpu/Cargo.toml
+++ b/crates/burn-wgpu/Cargo.toml
@@ -30,6 +30,8 @@ autotune-checks = ["burn-cubecl/autotune-checks"]
 exclusive-memory-only = ["cubecl/exclusive-memory-only"]
 fusion = ["burn-fusion", "burn-cubecl/fusion"]
 template = ["burn-cubecl/template", "cubecl/template"]
+# Opt-in bit-reproducible float sum/reduce (no cross-cube float atomics).
+deterministic = ["burn-cubecl/deterministic"]
 
 # Backends
 metal = ["cubecl-msl"]

--- a/crates/burn/Cargo.toml
+++ b/crates/burn/Cargo.toml
@@ -167,6 +167,8 @@ simd = ["burn-ndarray?/simd", "burn-flex?/simd"]
 x86-v4 = ["burn-flex?/x86-v4"]
 apple-amx = ["burn-flex?/apple-amx"]
 template = ["burn-wgpu?/template"]
+# Opt-in bit-reproducible GPU float reductions (forwards to burn-cubecl).
+deterministic = ["burn-wgpu?/deterministic"]
 collective = ["burn-collective", "burn-optim/collective"]
 distributed = ["std",
     "burn-core/distributed",


### PR DESCRIPTION
## Summary

Multi-step GPU training can produce different weights across identical runs even when application-level seeds, data order, and initialization are fixed. The root cause is in CubeCL float reduction: `Tensor::mean()` / `float_sum` use `SumStrategy::default()`, which with the default `autotune` feature resolves to `SumStrategy::Autotune`. Autotune frequently selects `OneShot`, whose `shared_sum` kernel finishes with a cross-cube **float `atomicAdd`** (`fetch_add` on the output). Floating-point addition is not associative, and atomic completion order is undefined, so the summed value (and therefore gradients / optimizer updates) can drift from run to run. After many Adam steps the drift is large enough to change early-stopping and final checkpoints.

This PR adds an **opt-in** `deterministic` feature on `burn-cubecl` that does **not** change default behavior:

- With `deterministic`: `SumStrategy::default()` → `Chained(Unspecified)` and `KernelReduceStrategy::default()` → `Unspecified` (tree/chained reduce, no cross-cube float atomics).
- Without `deterministic`: keep the existing Autotune / OneShot defaults.

Users who need bit-reproducible GPU training can enable the feature through the usual Cargo feature graph (e.g. via `burn-wgpu` / `burn` once forwarded, or by depending on `burn-cubecl` with `features = [deterministic]`).

## Tests

Unit tests live next to the change in `crates/burn-cubecl/src/kernel/reduce/base.rs`:

| Build | What it checks |
|-------|----------------|
| `--features deterministic` | Default strategies are Chained/Unspecified; multi-step float-sum feedback with `SumStrategy::default()` is bit-stable across two runs |
| default features (no `deterministic`) | Defaults remain Autotune; multi-step feedback with `OneShot(8)` (Autotune’s common pick) **diverges** across runs |

```bash
cargo test -p burn-cubecl --features deterministic multi_step_float_sum
cargo test -p burn-cubecl multi_step_float_sum
cargo test -p burn-cubecl --features deterministic default_sum_strategy
cargo test -p burn-cubecl default_sum_strategy
```

(GPU / Wgpu required for the multi-step probes; contract tests for `Default` are CPU-only.)

## Test plan

- [ ] CI / local: contract tests pass with and without `deterministic`
- [ ] Local GPU: multi-step probe passes with `deterministic` (Δ ≈ 0) and fails/asserts divergence without it on OneShot
- [ ] Confirm default feature set (no `deterministic`) still builds and behaves as before
- [ ] Optional follow-up: forward `deterministic` from `burn-wgpu` / `burn` for a single user-facing switch