### PR TITLE
Drop from foreign stream drains home stream

### DIFF
--- a/crates/burn-fusion/src/client.rs
+++ b/crates/burn-fusion/src/client.rs
@@ -135,6 +135,21 @@ where
         outputs
     }
 
+    /// Register a `Drop` issued from a thread other than the tensor's home `stream`.
+    ///
+    /// Routes to [`FusionServer::register_foreign_drop`], which drains the home stream to a clean
+    /// segment boundary before enqueuing the drop so the free cannot reorder into an in-flight
+    /// fused segment. Same-stream drops must keep using [`Self::register`].
+    pub(crate) fn register_foreign_drop<O>(&self, stream: StreamId, ir: TensorIr, operation: O)
+    where
+        O: Operation<R> + 'static,
+    {
+        self.server.submit(move |server| {
+            let operation = UnfusedOp::new(operation, stream);
+            server.register_foreign_drop(stream, ir, operation);
+        });
+    }
+
     /// Register all lazy computation.
     pub fn sync<Re: Send + 'static>(&self, sync_fn: impl FnOnce() -> Re + Send + 'static) -> Re {
         let id = StreamId::current();

--- a/crates/burn-fusion/src/server.rs
+++ b/crates/burn-fusion/src/server.rs
@@ -38,6 +38,28 @@ where
             .register(stream, repr, operation, &mut self.handles)
     }
 
+    /// Register a `Drop` that originates from a thread other than the tensor's home stream.
+    ///
+    /// A same-thread drop is naturally ordered after that thread's last use of the id, so the
+    /// fusion lifetime analysis frees it safely. A *foreign* drop is enqueued onto the home
+    /// stream at a nondeterministic point relative to the home thread's own registrations. If it
+    /// lands inside the home stream's still-building fused segment, the block DAG (#5135) can
+    /// reorder the free ahead of a pending read and let the buffer be reused in place while an
+    /// in-flight kernel still reads it.
+    ///
+    /// Draining the home stream first flushes its pending ops as their own segment, so the drop
+    /// lands in a fresh segment and cannot reorder against the ops that preceded it.
+    pub fn register_foreign_drop(
+        &mut self,
+        stream: StreamId,
+        ir: TensorIr,
+        operation: UnfusedOp<R>,
+    ) {
+        self.streams.drain(&mut self.handles, stream);
+        self.streams
+            .register(stream, OperationIr::Drop(ir), operation, &mut self.handles);
+    }
+
     pub fn tag_shared_view(&mut self, src_stream: StreamId, src: TensorId, dst: TensorId) {
         self.streams
             .tag_shared_view(src_stream, src, dst, &mut self.handles)

--- a/crates/burn-fusion/src/tensor.rs
+++ b/crates/burn-fusion/src/tensor.rs
@@ -254,10 +254,21 @@ impl<R: FusionRuntime> Drop for FusionTensor<R> {
                     dtype: self.dtype,
                 };
 
-                // Drop is targeted at the tensor's home stream so it runs after any pending ops
-                // on this id, regardless of the thread we happen to be dropping from.
-                self.client
-                    .register(self.stream, OperationIr::Drop(ir), DropOp { id: self.id });
+                // A drop issued from a *different* thread than the home stream interleaves at a
+                // nondeterministic point in that stream's pending fused segment, where the block
+                // DAG can reorder the free ahead of a still-pending read and let the buffer be
+                // reused while an in-flight kernel still reads it. Route those through a path that
+                // flushes the home stream to a clean boundary first.
+                if StreamId::current() == self.stream {
+                    self.client.register(
+                        self.stream,
+                        OperationIr::Drop(ir),
+                        DropOp { id: self.id },
+                    );
+                } else {
+                    self.client
+                        .register_foreign_drop(self.stream, ir, DropOp { id: self.id });
+                }
             }
             TensorStatus::ReadOnly => {}
             TensorStatus::NotInit => {}


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [X] Confirmed that `cargo run-checks` command has been executed.
- [X] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Random loss spikes during training eventually leading to NaNs. Especially bad on the guide example.

E.g. :

<img width="393" height="267" alt="Screenshot_2026-07-15_14-34-22" src="https://github.com/user-attachments/assets/614c1ad2-77e5-4a34-85b2-ff0b6e836375" />


### Changes

Dropping a read-write fusion tensor used to simply register a drop operation on the id regardless of the thread we happened to be dropping from. However, #5135 's DAG can reorder the free ahead of a still-pending read and let the buffer be reused while an in-flight kernel still reads it. This is possible because a drop issued from a thread different from the home stream interleaves at a nondeterministic point in the pending fused segment.

Fix : Drain the home stream when the drop happens on a different stream.

### Testing

Basically impossible to reproduce a minimal example for unit testing.

Tested multiple runs of the guide and other examples. No values spikes/NaNs during training. Training is still just as fast.
 