### PR TITLE
feat: add CosineSimilarity module

### DIFF
--- a/burn-book/src/building-blocks/module.md
+++ b/burn-book/src/building-blocks/module.md
@@ -240,6 +240,7 @@ Burn comes with built-in modules that you can use to build your own modules.
 | `GroupNorm`       | `nn.GroupNorm`                                |
 | `HardShrink`      | `nn.Hardshrink`                               |
 | `HardSigmoid`     | `nn.Hardsigmoid`                              |
+| `CosineSimilarity` | `nn.CosineSimilarity`                         |
 | `HardSwish`       | `nn.Hardswish`                                |
 | `InstanceNorm`    | `nn.InstanceNorm1d`, `nn.InstanceNorm2d` etc. |
 | `LayerNorm`       | `nn.LayerNorm`                                |

--- a/crates/burn-nn/src/modules/cosine_similarity.rs
+++ b/crates/burn-nn/src/modules/cosine_similarity.rs
@@ -1,0 +1,105 @@
+use burn_core as burn;
+
+use burn::config::Config;
+use burn::module::{Content, DisplaySettings, Module, ModuleDisplay};
+use burn::tensor::Tensor;
+use burn::tensor::linalg::cosine_similarity;
+
+/// Configuration to create a [CosineSimilarity](CosineSimilarity) layer using the
+/// [init function](CosineSimilarityConfig::init).
+#[derive(Config, Debug)]
+pub struct CosineSimilarityConfig {
+    /// The dimension along which the cosine similarity is computed. Default: `1`.
+    #[config(default = 1)]
+    pub dim: usize,
+    /// Small value to avoid division by zero. Default: `1e-8`.
+    #[config(default = 1e-8)]
+    pub eps: f64,
+}
+
+impl CosineSimilarityConfig {
+    /// Initialize a new [CosineSimilarity](CosineSimilarity) layer.
+    pub fn init(&self) -> CosineSimilarity {
+        CosineSimilarity {
+            dim: self.dim,
+            eps: self.eps,
+        }
+    }
+}
+
+/// Computes the cosine similarity between two tensors along a dimension, following
+/// [`torch.nn.CosineSimilarity`](https://pytorch.org/docs/stable/generated/torch.nn.CosineSimilarity.html).
+///
+/// The similarity is the dot product of the inputs divided by the product of their L2 norms
+/// (clamped by `eps`). The chosen dimension is reduced in the output.
+///
+/// Should be created with [CosineSimilarityConfig].
+#[derive(Module, Debug)]
+#[module(custom_display)]
+pub struct CosineSimilarity {
+    /// The dimension along which the cosine similarity is computed.
+    pub dim: usize,
+    /// Small value to avoid division by zero.
+    pub eps: f64,
+}
+
+impl ModuleDisplay for CosineSimilarity {
+    fn custom_settings(&self) -> Option<DisplaySettings> {
+        DisplaySettings::new()
+            .with_new_line_after_attribute(false)
+            .optional()
+    }
+
+    fn custom_content(&self, content: Content) -> Option<Content> {
+        content
+            .add("dim", &self.dim)
+            .add("eps", &self.eps)
+            .optional()
+    }
+}
+
+impl CosineSimilarity {
+    /// Applies the forward pass, computing one similarity per row.
+    ///
+    /// # Shapes
+    ///
+    /// - x1:     `[batch_size, features]`
+    /// - x2:     `[batch_size, features]`
+    /// - output: `[batch_size]`
+    pub fn forward(&self, x1: Tensor<2>, x2: Tensor<2>) -> Tensor<1> {
+        cosine_similarity(x1, x2, self.dim as i32, Some(self.eps)).squeeze_dim(self.dim)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use burn::tensor::TensorData;
+    use burn::tensor::Tolerance;
+    type FT = f32;
+
+    #[test]
+    fn cosine_similarity_dim1() {
+        let device = Default::default();
+        let x1 = Tensor::<2>::from_data(TensorData::from([[1.0, 0.0], [1.0, 1.0]]), &device);
+        let x2 = Tensor::<2>::from_data(TensorData::from([[1.0, 0.0], [0.0, 1.0]]), &device);
+
+        let output = CosineSimilarityConfig::new().init().forward(x1, x2);
+
+        // dot(x1, x2) / (||x1|| * ||x2||) per row; reference from PyTorch.
+        let expected = TensorData::from([1.0, 0.707107]);
+        output
+            .into_data()
+            .assert_approx_eq::<FT>(&expected, Tolerance::default());
+    }
+
+    #[test]
+    fn display() {
+        let layer = CosineSimilarityConfig::new().with_eps(0.5).init();
+
+        assert_eq!(
+            alloc::format!("{layer}"),
+            "CosineSimilarity {dim: 1, eps: 0.5}"
+        );
+    }
+}

--- a/crates/burn-nn/src/modules/mod.rs
+++ b/crates/burn-nn/src/modules/mod.rs
@@ -17,6 +17,7 @@ mod identity;
 /// Interpolate module
 pub mod interpolate;
 
+mod cosine_similarity;
 mod dropout;
 mod embedding;
 mod linear;
@@ -30,6 +31,7 @@ pub mod norm;
 
 pub use norm::{batch::*, group::*, instance::*, layer::*, local_response::*, rms::*};
 
+pub use cosine_similarity::*;
 pub use dropout::*;
 pub use embedding::*;
 pub use identity::*;


### PR DESCRIPTION
### Checklist
- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

None — new module.

### Changes

Adds `CosineSimilarity` (`nn.CosineSimilarity`): dot product of the inputs divided by the product of
their L2 norms (clamped by `eps`) along a dimension — defaults `dim = 1`, `eps = 1e-8`. Wraps the
existing `burn::tensor::linalg::cosine_similarity`, so it composes existing ops and autodiff is free.
Follows the module config pattern; added to the book's module table.

### Testing

Known-answer test against a PyTorch reference (`[1.0, 0.707107]`), plus a display test.
`cargo run-checks` passes.