### PR TITLE
feat(cubecl): add native GEMM autotune candidate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2254,7 +2254,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -2271,7 +2271,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -2295,7 +2295,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -2325,7 +2325,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2342,7 +2342,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "bytemuck",
  "crossbeam-utils",
@@ -2369,7 +2369,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2388,7 +2388,7 @@ dependencies = [
 [[package]]
 name = "cubecl-environment"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "async-channel",
  "backtrace",
@@ -2423,7 +2423,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2453,7 +2453,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -2478,7 +2478,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "cubecl-common",
  "darling 0.23.0",
@@ -2495,7 +2495,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -2506,7 +2506,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2525,7 +2525,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2553,7 +2553,7 @@ dependencies = [
 [[package]]
 name = "cubecl-spirv"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "bitflags 2.13.1",
  "cubecl-common",
@@ -2570,7 +2570,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2587,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "ash",
  "bytemuck",
@@ -2616,7 +2616,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "derive-new",
  "serde",
@@ -2626,7 +2626,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
+source = "git+https://github.com/tracel-ai/cubek?rev=7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90#7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2644,7 +2644,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
+source = "git+https://github.com/tracel-ai/cubek?rev=7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90#7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2658,7 +2658,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
+source = "git+https://github.com/tracel-ai/cubek?rev=7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90#7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2674,7 +2674,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
+source = "git+https://github.com/tracel-ai/cubek?rev=7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90#7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90"
 dependencies = [
  "cubecl",
 ]
@@ -2682,7 +2682,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
+source = "git+https://github.com/tracel-ai/cubek?rev=7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90#7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2694,7 +2694,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
+source = "git+https://github.com/tracel-ai/cubek?rev=7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90#7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2708,7 +2708,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
+source = "git+https://github.com/tracel-ai/cubek?rev=7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90#7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2718,7 +2718,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
+source = "git+https://github.com/tracel-ai/cubek?rev=7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90#7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2730,7 +2730,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
+source = "git+https://github.com/tracel-ai/cubek?rev=7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90#7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2744,7 +2744,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
+source = "git+https://github.com/tracel-ai/cubek?rev=7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90#7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2757,7 +2757,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
+source = "git+https://github.com/tracel-ai/cubek?rev=7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90#7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2767,7 +2767,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
+source = "git+https://github.com/tracel-ai/cubek?rev=7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90#7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90"
 dependencies = [
  "bytemuck",
  "cubecl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -172,7 +172,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -683,7 +683,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -1776,7 +1776,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2626,7 +2626,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
+source = "git+https://github.com/tracel-ai/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2644,7 +2644,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
+source = "git+https://github.com/tracel-ai/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2658,7 +2658,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
+source = "git+https://github.com/tracel-ai/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2674,7 +2674,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
+source = "git+https://github.com/tracel-ai/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
 dependencies = [
  "cubecl",
 ]
@@ -2682,7 +2682,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
+source = "git+https://github.com/tracel-ai/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2694,7 +2694,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
+source = "git+https://github.com/tracel-ai/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2708,7 +2708,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
+source = "git+https://github.com/tracel-ai/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2718,7 +2718,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
+source = "git+https://github.com/tracel-ai/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2730,7 +2730,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
+source = "git+https://github.com/tracel-ai/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2744,7 +2744,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
+source = "git+https://github.com/tracel-ai/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2757,7 +2757,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
+source = "git+https://github.com/tracel-ai/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2767,7 +2767,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
+source = "git+https://github.com/tracel-ai/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -3267,7 +3267,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3629,7 +3629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4316,8 +4316,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -4560,7 +4560,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.19",
- "windows 0.62.2",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4949,7 +4949,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -6606,7 +6606,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7069,15 +7069,6 @@ name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "ordered-float"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
 ]
@@ -8389,7 +8380,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9110,7 +9101,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9168,7 +9159,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9321,7 +9312,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9707,7 +9698,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9835,7 +9826,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10101,7 +10092,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10123,7 +10114,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook 0.3.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10133,7 +10124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10178,7 +10169,7 @@ dependencies = [
  "nix 0.29.0",
  "num-derive",
  "num-traits",
- "ordered-float 4.6.0",
+ "ordered-float",
  "pest",
  "pest_derive",
  "phf 0.11.3",
@@ -11483,7 +11474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
 dependencies = [
  "log",
- "ordered-float 4.6.0",
+ "ordered-float",
  "strsim",
  "thiserror 1.0.69",
  "wezterm-dynamic-derive",
@@ -11646,7 +11637,7 @@ dependencies = [
  "objc2-metal",
  "objc2-quartz-core",
  "once_cell",
- "ordered-float 5.3.0",
+ "ordered-float",
  "parking_lot",
  "portable-atomic",
  "portable-atomic-util",
@@ -11734,7 +11725,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12222,8 +12213,8 @@ dependencies = [
  "log",
  "serde",
  "thiserror 2.0.19",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2254,7 +2254,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=05cac67370653ef6ed6b76730b20a0cb4bede117#05cac67370653ef6ed6b76730b20a0cb4bede117"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -2271,7 +2271,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=05cac67370653ef6ed6b76730b20a0cb4bede117#05cac67370653ef6ed6b76730b20a0cb4bede117"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -2295,7 +2295,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=05cac67370653ef6ed6b76730b20a0cb4bede117#05cac67370653ef6ed6b76730b20a0cb4bede117"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -2325,7 +2325,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=05cac67370653ef6ed6b76730b20a0cb4bede117#05cac67370653ef6ed6b76730b20a0cb4bede117"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2342,7 +2342,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=05cac67370653ef6ed6b76730b20a0cb4bede117#05cac67370653ef6ed6b76730b20a0cb4bede117"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
  "bytemuck",
  "crossbeam-utils",
@@ -2369,7 +2369,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=05cac67370653ef6ed6b76730b20a0cb4bede117#05cac67370653ef6ed6b76730b20a0cb4bede117"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2388,7 +2388,7 @@ dependencies = [
 [[package]]
 name = "cubecl-environment"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=05cac67370653ef6ed6b76730b20a0cb4bede117#05cac67370653ef6ed6b76730b20a0cb4bede117"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
  "async-channel",
  "backtrace",
@@ -2423,7 +2423,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=05cac67370653ef6ed6b76730b20a0cb4bede117#05cac67370653ef6ed6b76730b20a0cb4bede117"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2453,7 +2453,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=05cac67370653ef6ed6b76730b20a0cb4bede117#05cac67370653ef6ed6b76730b20a0cb4bede117"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -2478,7 +2478,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=05cac67370653ef6ed6b76730b20a0cb4bede117#05cac67370653ef6ed6b76730b20a0cb4bede117"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
  "cubecl-common",
  "darling 0.23.0",
@@ -2495,7 +2495,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=05cac67370653ef6ed6b76730b20a0cb4bede117#05cac67370653ef6ed6b76730b20a0cb4bede117"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -2506,7 +2506,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=05cac67370653ef6ed6b76730b20a0cb4bede117#05cac67370653ef6ed6b76730b20a0cb4bede117"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2525,7 +2525,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=05cac67370653ef6ed6b76730b20a0cb4bede117#05cac67370653ef6ed6b76730b20a0cb4bede117"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2553,7 +2553,7 @@ dependencies = [
 [[package]]
 name = "cubecl-spirv"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=05cac67370653ef6ed6b76730b20a0cb4bede117#05cac67370653ef6ed6b76730b20a0cb4bede117"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
  "bitflags 2.13.1",
  "cubecl-common",
@@ -2570,7 +2570,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=05cac67370653ef6ed6b76730b20a0cb4bede117#05cac67370653ef6ed6b76730b20a0cb4bede117"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2587,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=05cac67370653ef6ed6b76730b20a0cb4bede117#05cac67370653ef6ed6b76730b20a0cb4bede117"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
  "ash",
  "bytemuck",
@@ -2616,7 +2616,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=05cac67370653ef6ed6b76730b20a0cb4bede117#05cac67370653ef6ed6b76730b20a0cb4bede117"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
  "derive-new",
  "serde",
@@ -2626,7 +2626,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=a495e4f68be2d18dc5d367e0d4467ed1aa6d5b80#a495e4f68be2d18dc5d367e0d4467ed1aa6d5b80"
+source = "git+https://github.com/tracel-ai/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2644,7 +2644,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=a495e4f68be2d18dc5d367e0d4467ed1aa6d5b80#a495e4f68be2d18dc5d367e0d4467ed1aa6d5b80"
+source = "git+https://github.com/tracel-ai/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2658,7 +2658,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=a495e4f68be2d18dc5d367e0d4467ed1aa6d5b80#a495e4f68be2d18dc5d367e0d4467ed1aa6d5b80"
+source = "git+https://github.com/tracel-ai/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2674,7 +2674,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=a495e4f68be2d18dc5d367e0d4467ed1aa6d5b80#a495e4f68be2d18dc5d367e0d4467ed1aa6d5b80"
+source = "git+https://github.com/tracel-ai/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
 dependencies = [
  "cubecl",
 ]
@@ -2682,7 +2682,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=a495e4f68be2d18dc5d367e0d4467ed1aa6d5b80#a495e4f68be2d18dc5d367e0d4467ed1aa6d5b80"
+source = "git+https://github.com/tracel-ai/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2694,7 +2694,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=a495e4f68be2d18dc5d367e0d4467ed1aa6d5b80#a495e4f68be2d18dc5d367e0d4467ed1aa6d5b80"
+source = "git+https://github.com/tracel-ai/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2708,7 +2708,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=a495e4f68be2d18dc5d367e0d4467ed1aa6d5b80#a495e4f68be2d18dc5d367e0d4467ed1aa6d5b80"
+source = "git+https://github.com/tracel-ai/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2718,7 +2718,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=a495e4f68be2d18dc5d367e0d4467ed1aa6d5b80#a495e4f68be2d18dc5d367e0d4467ed1aa6d5b80"
+source = "git+https://github.com/tracel-ai/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2730,7 +2730,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=a495e4f68be2d18dc5d367e0d4467ed1aa6d5b80#a495e4f68be2d18dc5d367e0d4467ed1aa6d5b80"
+source = "git+https://github.com/tracel-ai/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2744,7 +2744,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=a495e4f68be2d18dc5d367e0d4467ed1aa6d5b80#a495e4f68be2d18dc5d367e0d4467ed1aa6d5b80"
+source = "git+https://github.com/tracel-ai/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2757,7 +2757,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=a495e4f68be2d18dc5d367e0d4467ed1aa6d5b80#a495e4f68be2d18dc5d367e0d4467ed1aa6d5b80"
+source = "git+https://github.com/tracel-ai/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2767,7 +2767,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=a495e4f68be2d18dc5d367e0d4467ed1aa6d5b80#a495e4f68be2d18dc5d367e0d4467ed1aa6d5b80"
+source = "git+https://github.com/tracel-ai/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
 dependencies = [
  "bytemuck",
  "cubecl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,7 +227,7 @@ cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false
 cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "45ed466abf28e404e1d3d1f3c25263941fb440e9" }
 cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "45ed466abf28e404e1d3d1f3c25263941fb440e9" }
 cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "45ed466abf28e404e1d3d1f3c25263941fb440e9" }
-cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "17fcf4a084cb3344800bc928ad2a3bc7a89e0318" }
+cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "20949c37a43e3b4b0e8f4f06e3f8623a626d78f2" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,11 +223,11 @@ burn-vision = { path = "crates/burn-vision", version = "=0.22.0-pre.1", default-
 burn-wgpu = { path = "crates/burn-wgpu", version = "=0.22.0-pre.1", default-features = false }
 
 ### For the main burn branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "45ed466abf28e404e1d3d1f3c25263941fb440e9" }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "45ed466abf28e404e1d3d1f3c25263941fb440e9" }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "45ed466abf28e404e1d3d1f3c25263941fb440e9" }
-cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "45ed466abf28e404e1d3d1f3c25263941fb440e9" }
-cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "20949c37a43e3b4b0e8f4f06e3f8623a626d78f2" }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "c0efe74d3d4b820fbf992dbbe443ed7125c5205c" }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "c0efe74d3d4b820fbf992dbbe443ed7125c5205c" }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "c0efe74d3d4b820fbf992dbbe443ed7125c5205c" }
+cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "c0efe74d3d4b820fbf992dbbe443ed7125c5205c" }
+cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,11 +223,11 @@ burn-vision = { path = "crates/burn-vision", version = "=0.22.0-pre.1", default-
 burn-wgpu = { path = "crates/burn-wgpu", version = "=0.22.0-pre.1", default-features = false }
 
 ### For the main burn branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "05cac67370653ef6ed6b76730b20a0cb4bede117" }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "05cac67370653ef6ed6b76730b20a0cb4bede117" }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "05cac67370653ef6ed6b76730b20a0cb4bede117" }
-cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "05cac67370653ef6ed6b76730b20a0cb4bede117" }
-cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "a495e4f68be2d18dc5d367e0d4467ed1aa6d5b80" }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "45ed466abf28e404e1d3d1f3c25263941fb440e9" }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "45ed466abf28e404e1d3d1f3c25263941fb440e9" }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "45ed466abf28e404e1d3d1f3c25263941fb440e9" }
+cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "45ed466abf28e404e1d3d1f3c25263941fb440e9" }
+cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "17fcf4a084cb3344800bc928ad2a3bc7a89e0318" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }

--- a/crates/burn-cubecl-fusion/src/optim/matmul/fuser.rs
+++ b/crates/burn-cubecl-fusion/src/optim/matmul/fuser.rs
@@ -4,12 +4,10 @@ use crate::{
     optim::CubeOptimization,
     optim::matmul::args::MatmulArg,
 };
-use burn_backend::cubecl::dtype_to_storage_type;
 use burn_fusion::{FuserStatus, OperationFuser};
 use burn_ir::{FloatOperationIr, OperationIr};
 use burn_std::DType;
-use cubecl::{Runtime, ir::ElemType};
-use std::collections::BTreeSet;
+use cubecl::Runtime;
 
 /// Fused element wise operations that are normally memory bound.
 pub struct MatmulFuser<R: Runtime> {
@@ -17,7 +15,6 @@ pub struct MatmulFuser<R: Runtime> {
     fuser_fallback: TraceOperationFuser,
     device: R::Device,
     matmul: Option<FusedMatmul>,
-    accelerated_gemm: BTreeSet<ElemType>,
 }
 
 impl<R: Runtime> Clone for MatmulFuser<R> {
@@ -27,7 +24,6 @@ impl<R: Runtime> Clone for MatmulFuser<R> {
             fuser_fallback: self.fuser_fallback.clone(),
             device: self.device.clone(),
             matmul: self.matmul.clone(),
-            accelerated_gemm: self.accelerated_gemm.clone(),
         }
     }
 }
@@ -48,7 +44,6 @@ impl<R: Runtime> MatmulFuser<R> {
             fuser_fallback: TraceOperationFuser::new(max_bindings, settings_fallback),
             device,
             matmul: None,
-            accelerated_gemm: props.features.matmul.accelerated_gemm.clone(),
         }
     }
 }
@@ -61,19 +56,6 @@ impl<R: Runtime> OperationFuser<CubeOptimization<R>> for MatmulFuser<R> {
 
         if self.matmul.is_none() {
             if let OperationIr::Float(_, FloatOperationIr::Matmul(op)) = operation {
-                let elem = dtype_to_storage_type(op.out.dtype).elem_type();
-                if op.lhs.dtype == op.out.dtype
-                    && op.rhs.dtype == op.out.dtype
-                    && self.accelerated_gemm.contains(&elem)
-                {
-                    // Let the backend execute its native GEMM. Subsequent
-                    // elementwise operations can start a separate fusion
-                    // optimization; folding them into CubeK would bypass the
-                    // faster backend primitive entirely.
-                    self.fuser.close();
-                    self.fuser_fallback.close();
-                    return;
-                }
                 // Precision shouldn't be hardcoded but I don't know how to get float precision of the backend
                 let lhs = match op.lhs.dtype {
                     DType::QFloat(scheme) => {

--- a/crates/burn-cubecl-fusion/src/optim/matmul/fuser.rs
+++ b/crates/burn-cubecl-fusion/src/optim/matmul/fuser.rs
@@ -4,10 +4,12 @@ use crate::{
     optim::CubeOptimization,
     optim::matmul::args::MatmulArg,
 };
+use burn_backend::cubecl::dtype_to_storage_type;
 use burn_fusion::{FuserStatus, OperationFuser};
 use burn_ir::{FloatOperationIr, OperationIr};
 use burn_std::DType;
-use cubecl::Runtime;
+use cubecl::{Runtime, ir::ElemType};
+use std::collections::BTreeSet;
 
 /// Fused element wise operations that are normally memory bound.
 pub struct MatmulFuser<R: Runtime> {
@@ -15,6 +17,7 @@ pub struct MatmulFuser<R: Runtime> {
     fuser_fallback: TraceOperationFuser,
     device: R::Device,
     matmul: Option<FusedMatmul>,
+    accelerated_gemm: BTreeSet<ElemType>,
 }
 
 impl<R: Runtime> Clone for MatmulFuser<R> {
@@ -24,6 +27,7 @@ impl<R: Runtime> Clone for MatmulFuser<R> {
             fuser_fallback: self.fuser_fallback.clone(),
             device: self.device.clone(),
             matmul: self.matmul.clone(),
+            accelerated_gemm: self.accelerated_gemm.clone(),
         }
     }
 }
@@ -44,6 +48,7 @@ impl<R: Runtime> MatmulFuser<R> {
             fuser_fallback: TraceOperationFuser::new(max_bindings, settings_fallback),
             device,
             matmul: None,
+            accelerated_gemm: props.features.matmul.accelerated_gemm.clone(),
         }
     }
 }
@@ -56,6 +61,19 @@ impl<R: Runtime> OperationFuser<CubeOptimization<R>> for MatmulFuser<R> {
 
         if self.matmul.is_none() {
             if let OperationIr::Float(_, FloatOperationIr::Matmul(op)) = operation {
+                let elem = dtype_to_storage_type(op.out.dtype).elem_type();
+                if op.lhs.dtype == op.out.dtype
+                    && op.rhs.dtype == op.out.dtype
+                    && self.accelerated_gemm.contains(&elem)
+                {
+                    // Let the backend execute its native GEMM. Subsequent
+                    // elementwise operations can start a separate fusion
+                    // optimization; folding them into CubeK would bypass the
+                    // faster backend primitive entirely.
+                    self.fuser.close();
+                    self.fuser_fallback.close();
+                    return;
+                }
                 // Precision shouldn't be hardcoded but I don't know how to get float precision of the backend
                 let lhs = match op.lhs.dtype {
                     DType::QFloat(scheme) => {

--- a/crates/burn-cubecl/src/kernel/matmul/base.rs
+++ b/crates/burn-cubecl/src/kernel/matmul/base.rs
@@ -230,6 +230,11 @@ fn try_accelerated_gemm<R: CubeRuntime>(
     if rhs_shape[rank - 2] != k || out_shape[rank - 2] != m || out_shape[rank - 1] != n {
         return None;
     }
+    // The native primitive intentionally has no zero-fill side path for a
+    // nonempty zero-K result. CubeK retains the complete tensor semantics.
+    if k == 0 && m != 0 && n != 0 {
+        return None;
+    }
 
     let batch_shape = &out_shape[..rank - 2];
     let batch_count = batch_shape.iter().product::<usize>();

--- a/crates/burn-cubecl/src/kernel/matmul/base.rs
+++ b/crates/burn-cubecl/src/kernel/matmul/base.rs
@@ -3,6 +3,7 @@ use crate::{CubeRuntime, kernel::quantization::dequantize, tensor::CubeTensor};
 use burn_backend::cubecl::dtype_to_storage_type;
 use burn_backend::{DType, TensorMetadata};
 use burn_std::{MatmulTransformAnalysis, MatmulTransformPolicy, QuantLevel};
+use cubecl::server::{GemmDescriptor, GemmMatrix};
 use cubek::{
     matmul::{
         definition::{MatmulElems, MatmulGlobalElems, MatmulSetupError},
@@ -55,6 +56,13 @@ pub fn matmul<R: CubeRuntime>(
         let action = MatmulTransformPolicy::default().action(&analysis);
         action.apply(&mut lhs.meta);
         action.apply(&mut out_launch.meta);
+    }
+
+    if lhs.qparams.is_none()
+        && rhs.qparams.is_none()
+        && try_accelerated_gemm(&lhs, &rhs, &out_launch).is_some()
+    {
+        return Ok(out);
     }
 
     match strategy {
@@ -186,4 +194,124 @@ pub(crate) fn launch_matmul<R: CubeRuntime>(
     )?;
 
     Ok(())
+}
+
+fn try_accelerated_gemm<R: CubeRuntime>(
+    lhs: &CubeTensor<R>,
+    rhs: &CubeTensor<R>,
+    out: &CubeTensor<R>,
+) -> Option<()> {
+    if lhs.dtype != rhs.dtype || lhs.dtype != out.dtype {
+        return None;
+    }
+    let elem = dtype_to_storage_type(lhs.dtype).elem_type();
+    if !out
+        .client
+        .properties()
+        .features
+        .matmul
+        .accelerated_gemm
+        .contains(&elem)
+    {
+        return None;
+    }
+
+    let lhs_shape = lhs.meta.shape();
+    let rhs_shape = rhs.meta.shape();
+    let out_shape = out.meta.shape();
+    let rank = lhs_shape.rank();
+    if rank < 2 || rhs_shape.rank() != rank || out_shape.rank() != rank {
+        return None;
+    }
+
+    let m = lhs_shape[rank - 2];
+    let k = lhs_shape[rank - 1];
+    let n = rhs_shape[rank - 1];
+    if rhs_shape[rank - 2] != k || out_shape[rank - 2] != m || out_shape[rank - 1] != n {
+        return None;
+    }
+
+    let batch_shape = &out_shape[..rank - 2];
+    let batch_count = batch_shape.iter().product::<usize>();
+    let mut lhs_desc = matrix_descriptor(lhs, m, k, batch_shape)?;
+    let rhs_desc = matrix_descriptor(rhs, k, n, batch_shape)?;
+    let mut out_desc = matrix_descriptor(out, m, n, batch_shape)?;
+    if out_desc.transposed {
+        return None;
+    }
+
+    let mut launch_m = m;
+    let mut launch_batches = batch_count;
+    if batch_count > 1
+        && rhs_desc.batch_stride == 0
+        && !lhs_desc.transposed
+        && lhs_desc.batch_stride == m.checked_mul(lhs_desc.leading_dimension as usize)? as u64
+        && out_desc.batch_stride == m.checked_mul(out_desc.leading_dimension as usize)? as u64
+    {
+        launch_m = m.checked_mul(batch_count)?;
+        launch_batches = 1;
+        lhs_desc.batch_stride = 0;
+        out_desc.batch_stride = 0;
+    }
+
+    let descriptor = GemmDescriptor::new(
+        lhs_desc,
+        rhs_desc,
+        out_desc,
+        launch_m.try_into().ok()?,
+        n.try_into().ok()?,
+        k.try_into().ok()?,
+        launch_batches.try_into().ok()?,
+        elem,
+    );
+
+    out.client.gemm(descriptor);
+    Some(())
+}
+
+fn matrix_descriptor<R: CubeRuntime>(
+    tensor: &CubeTensor<R>,
+    rows: usize,
+    cols: usize,
+    batch_shape: &[usize],
+) -> Option<GemmMatrix> {
+    let rank = tensor.meta.rank();
+    let shape = tensor.meta.shape();
+    let strides = tensor.meta.strides();
+    let row_stride = strides[rank - 2];
+    let col_stride = strides[rank - 1];
+    let (leading_dimension, transposed) = if col_stride == 1 && row_stride >= cols {
+        (row_stride, false)
+    } else if row_stride == 1 && col_stride >= rows {
+        (col_stride, true)
+    } else {
+        return None;
+    };
+
+    let batch_stride = if batch_shape.is_empty() {
+        0
+    } else if shape[..rank - 2].iter().all(|dim| *dim == 1) {
+        0
+    } else {
+        if shape[..rank - 2] != *batch_shape {
+            return None;
+        }
+        for dim in 0..rank.saturating_sub(3) {
+            if strides[dim]
+                != shape[dim + 1]
+                    .checked_mul(strides[dim + 1])
+                    .unwrap_or(usize::MAX)
+            {
+                return None;
+            }
+        }
+        strides[rank - 3] as u64
+    };
+
+    Some(GemmMatrix::new(
+        tensor.handle.clone().binding(),
+        leading_dimension.try_into().ok()?,
+        batch_stride,
+        transposed,
+    ))
 }

--- a/crates/burn-cubecl/src/kernel/matmul/base.rs
+++ b/crates/burn-cubecl/src/kernel/matmul/base.rs
@@ -280,9 +280,30 @@ fn matrix_descriptor<R: CubeRuntime>(
     cols: usize,
     batch_shape: &[usize],
 ) -> Option<GemmMatrix> {
-    let rank = tensor.meta.rank();
     let shape = tensor.meta.shape();
     let strides = tensor.meta.strides();
+    let (leading_dimension, batch_stride, transposed) =
+        matrix_layout(shape, strides, rows, cols, batch_shape)?;
+
+    Some(GemmMatrix::new(
+        tensor.handle.clone().binding(),
+        leading_dimension,
+        batch_stride,
+        transposed,
+    ))
+}
+
+fn matrix_layout(
+    shape: &[usize],
+    strides: &[usize],
+    rows: usize,
+    cols: usize,
+    batch_shape: &[usize],
+) -> Option<(u32, u64, bool)> {
+    let rank = shape.len();
+    if rank < 2 || strides.len() != rank || batch_shape.len() != rank - 2 {
+        return None;
+    }
     let row_stride = strides[rank - 2];
     let col_stride = strides[rank - 1];
     let (leading_dimension, transposed) = if col_stride == 1 && row_stride >= cols {
@@ -313,10 +334,36 @@ fn matrix_descriptor<R: CubeRuntime>(
         strides[rank - 3] as u64
     };
 
-    Some(GemmMatrix::new(
-        tensor.handle.clone().binding(),
-        leading_dimension.try_into().ok()?,
-        batch_stride,
-        transposed,
-    ))
+    Some((leading_dimension.try_into().ok()?, batch_stride, transposed))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::matrix_layout;
+
+    #[test]
+    fn accelerated_gemm_layouts_cover_transpose_batch_and_broadcast() {
+        assert_eq!(
+            matrix_layout(&[2, 3, 4], &[12, 4, 1], 3, 4, &[2]),
+            Some((4, 12, false))
+        );
+        assert_eq!(
+            matrix_layout(&[2, 4, 3], &[12, 1, 4], 4, 3, &[2]),
+            Some((4, 12, true))
+        );
+        assert_eq!(
+            matrix_layout(&[1, 3, 4], &[12, 4, 1], 3, 4, &[2]),
+            Some((4, 0, false))
+        );
+    }
+
+    #[test]
+    fn accelerated_gemm_rejects_noncontiguous_or_mismatched_batches() {
+        assert_eq!(matrix_layout(&[2, 3, 4], &[12, 4, 1], 3, 4, &[3]), None);
+        assert_eq!(
+            matrix_layout(&[2, 3, 4, 5], &[64, 20, 5, 1], 4, 5, &[2, 3]),
+            None
+        );
+        assert_eq!(matrix_layout(&[3, 4], &[1, 2], 3, 4, &[]), None);
+    }
 }

--- a/crates/burn-cubecl/src/kernel/matmul/base.rs
+++ b/crates/burn-cubecl/src/kernel/matmul/base.rs
@@ -314,20 +314,14 @@ fn matrix_layout(
         return None;
     };
 
-    let batch_stride = if batch_shape.is_empty() {
-        0
-    } else if shape[..rank - 2].iter().all(|dim| *dim == 1) {
+    let batch_stride = if batch_shape.is_empty() || shape[..rank - 2].iter().all(|dim| *dim == 1) {
         0
     } else {
         if shape[..rank - 2] != *batch_shape {
             return None;
         }
         for dim in 0..rank.saturating_sub(3) {
-            if strides[dim]
-                != shape[dim + 1]
-                    .checked_mul(strides[dim + 1])
-                    .unwrap_or(usize::MAX)
-            {
+            if strides[dim] != shape[dim + 1].saturating_mul(strides[dim + 1]) {
                 return None;
             }
         }


### PR DESCRIPTION
Closes #5189.

Depends on CubeCL PR tracel-ai/cubecl#1440 and CubeK PR tracel-ai/cubek#428. This branch pins both current heads for compatibility validation.

## Change

Burn's regular CubeCL matmul path can enqueue a backend-advertised native GEMM for compatible unquantized layouts. Unsupported layouts, mixed or quantized dtypes, and nonempty zero-K products continue through CubeK.

The fusion fuser is unchanged. Its fallback candidate invokes the regular backend matmul, so autotuning compares native GEMM plus a separately fused epilogue against fully fused CubeK candidates.

Descriptor translation supports packed row-major and transposed row-major views, contiguous batch dimensions, whole-input broadcast, and folding a broadcast-RHS batch into one larger M dimension when storage is contiguous.

This is not a breaking change. The path is gated on backend capability and falls back whenever a contract cannot be represented.

## Dependency validation

- [x] CubeCL PR tracel-ai/cubecl#1440 provides deterministic allocator coverage and CUDA GEMM contract checks.
- [x] CubeK PR tracel-ai/cubek#428 compiles against the consolidated CubeCL head and separates matmul async-copy legality classes.
- [x] Upstream `main` is the direct base of this branch.
- [x] Cargo manifests reference only `tracel-ai/*` repositories.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p burn-cuda`
- `cargo test -p burn-cubecl accelerated_gemm_`
- A100 BF16 linear forward plus `dx`/`dW`/`db` parity under CUDA, fusion, autotune, and autodiff with a non-uniform upstream gradient
- A100 299.9M-parameter MoE training smoke completed without the previously reproducible matmul-autotune launch failure
- downstream end-to-end loss and gradient norms match; per-shape autotune improved training throughput by 15.6% at batch 16 and 14.8% at batch 20

The PR remains a draft until the dependency PRs are accepted; pins should move to their merge revisions before this is marked ready.
