### PR TITLE
fix(cosine): remove erroneous restart, match PyTorch CosineAnnealingLR behavior

### DIFF
--- a/crates/burn-optim/src/lr_scheduler/cosine.rs
+++ b/crates/burn-optim/src/lr_scheduler/cosine.rs
@@ -6,12 +6,17 @@ use crate::RecordState;
 use crate::lr_scheduler::module_lr_scheduler::ModuleLrScheduler;
 use burn::config::Config;
 
-/// The configuration for creating a [Cosine Annealing learning rate scheduler with warm
-/// restarts](CosineAnnealingLrScheduler).
+/// The configuration for creating a [Cosine Annealing learning rate
+/// scheduler](CosineAnnealingLrScheduler).
 ///
-/// This scheduler returns the learning rate `initial_lr` at the first step, then changes it by
-/// following a cosine function. After `num_iters` iterations, the learning rate is reset to
-/// `initial_lr`.
+/// This scheduler uses a cosine annealing schedule without warm restarts,
+/// where the learning rate follows a cosine curve from `initial_lr` down to
+/// `min_lr` over `num_iters` steps. After `num_iters` steps, the learning rate
+/// continues along the cosine curve without restarting.
+///
+/// This corresponds to PyTorch's `CosineAnnealingLR` and is based on the
+/// closed-form schedule proposed in [SGDR: Stochastic Gradient Descent with Warm
+/// Restarts](https://arxiv.org/abs/1608.03983).
 #[derive(Config, Debug)]
 pub struct CosineAnnealingLrSchedulerConfig {
     // The initial learning rate.
@@ -19,8 +24,7 @@ pub struct CosineAnnealingLrSchedulerConfig {
     // The final learning rate.
     #[config(default = 0.0)]
     min_lr: LearningRate,
-    // The number of iterations between two restarts. The two restart iterations themselves are not
-    // included.
+    // The number of iterations for the learning rate to reach `min_lr` along the cosine curve.
     num_iters: usize,
 }
 

--- a/crates/burn-optim/src/lr_scheduler/cosine.rs
+++ b/crates/burn-optim/src/lr_scheduler/cosine.rs
@@ -67,11 +67,15 @@ impl CosineAnnealingLrSchedulerConfig {
     }
 }
 
-/// A Cosine Annealing learning rate scheduler.
+/// A Cosine Annealing learning rate scheduler without warm restarts.
 ///
-/// This scheduler is described in [SGDR: Stochastic Gradient Descent with Warm
-/// Restarts](https://arxiv.org/abs/1608.03983). See [CosineAnnealingLrSchedulerConfig] for more
-/// information.
+/// The learning rate follows the closed-form schedule proposed in
+/// [SGDR: Stochastic Gradient Descent with Warm
+/// Restarts](https://arxiv.org/abs/1608.03983), but without the periodic
+/// restarts. The iteration counter increases monotonically, so the learning
+/// rate continues along the cosine curve past `num_iters` without resetting.
+///
+/// See [CosineAnnealingLrSchedulerConfig] for configuration options.
 #[derive(Clone, Copy, Debug)]
 pub struct CosineAnnealingLrScheduler {
     min_lr: LearningRate,

--- a/crates/burn-optim/src/lr_scheduler/cosine.rs
+++ b/crates/burn-optim/src/lr_scheduler/cosine.rs
@@ -81,7 +81,7 @@ impl LrScheduler for CosineAnnealingLrScheduler {
         // Make current_iter overflow from usize::MAX to 0 to get the initial learning rate on the
         // first call. We could've used i64 with an initial value -1, but keeping it in usize saves
         // us from some type casting here.
-        self.current_iter = self.current_iter.wrapping_add(1) % (self.num_iters + 1);
+        self.current_iter = self.current_iter.wrapping_add(1);
         self.min_lr
             + 0.5
                 * (self.max_lr - self.min_lr)
@@ -188,7 +188,8 @@ mod tests {
             INITIAL_LR,                  // cos(0)
             (INITIAL_LR + MIN_LR) * 0.5, // cos(PI/2)
             MIN_LR,                      // cos(PI)
-            INITIAL_LR,                  // restart
+            (INITIAL_LR + MIN_LR) * 0.5, // cos(3PI/2)
+            INITIAL_LR,                  // cos(2PI)
         ];
         test_utils::check_lr_sequence(scheduler, expected_lrs);
     }


### PR DESCRIPTION
## Summary

Fixes #5128

The `CosineAnnealingLrScheduler` was wrapping its iteration counter with `% (self.num_iters + 1)`, causing the learning rate to abruptly jump back to `max_lr` after every `num_iters + 1` steps. This created an erroneous half-cosine restarting waveform instead of the standard cosine annealing schedule.

## Changes

- **Line 92:** Removed the `% (self.num_iters + 1)` wrapping from `step()`. The `current_iter` now increases monotonically (via `wrapping_add(1)`), matching PyTorch's `CosineAnnealingLR` which explicitly states *"performs cosine annealing without restarts, so `T_cur = t` and increases monotonically with each call to `step()`"*
- **Doc updates:** Config and struct docs now describe the scheduler as performing cosine annealing **without** warm restarts, with the iteration counter increasing monotonically
- **Test update:** `test_lr_change` now verifies a full 5-step smooth cosine curve rather than the previous 4-step sequence that expected an artificial restart

## Verification

- All 7 cosine tests pass (`cargo test -p burn-optim -- lr_scheduler::cosine`)
- All 95 burn-optim tests pass (`cargo test -p burn-optim`)
- The fix is a one-line code change (removing `% (self.num_iters + 1)`); the rest is documentation and test updates

## Reference

[PyTorch CosineAnnealingLR docs](https://pytorch.org/docs/2.12/generated/torch.optim.lr_scheduler.CosineAnnealingLR.html)