### PR TITLE
Fix deadlock when a Backward step runs a nested backward

### DIFF
--- a/crates/burn-autodiff/src/runtime/graph.rs
+++ b/crates/burn-autodiff/src/runtime/graph.rs
@@ -147,7 +147,15 @@ impl<'a> GraphCleaner<'a> {
         let mut should_remove = Vec::new();
         for graph in graphs.values() {
             {
-                let mut guard = graph.state.lock();
+                // Best-effort sweep: a graph whose mutex is contended is in
+                // use — possibly by this very thread, when a `Backward` step
+                // itself runs an inner `backward()` (the outer backward holds
+                // its graph's lock across step execution, and this mutex is
+                // not reentrant). Skip it; a later backward's sweep will
+                // collect its orphans.
+                let Some(mut guard) = graph.state.try_lock() else {
+                    continue;
+                };
                 // Double safety: in case it was marked as no longer useful, but other
                 // nodes are still relevant, we only check which nodes can safely be removed.
                 if !guard.server.maybe_useful() {


### PR DESCRIPTION
Fixes #5193.

## Problem

`GraphCleaner::cleanup_orphaned_entries` locks every registered graph's `state` mutex, but a `Backward::backward` step executes while its own graph's lock is held (`GraphMutexClient::backward` wraps `server.backward` in `graph.state.lock()`). Any `Tensor::backward()` call made inside a step — the natural shape of op-level gradient checkpointing — therefore self-deadlocks in the inner call's cleanup sweep on the non-reentrant `parking_lot::Mutex`, even when the inner graph is fully disjoint. Full mechanism, line links, and a standalone runnable repro are in #5193.

## Change

Make the sweep best-effort: `try_lock()` and skip contended graphs. A graph whose mutex is contended is by definition still in use (possibly by this very thread, mid-backward), and any genuinely orphaned entries it holds are collected by the sweep at the end of a later `backward()` call. No change to backward semantics or the step-execution locking.

## Testing

- Verified with the repro from #5193: with this change applied, the nested inner backward returns and the outer backward completes with the correct gradient; without it, the program hangs permanently. (Executed against a v0.21.0 checkout carrying this same patch — the cleanup loop is identical there; `cargo check -p burn-autodiff` and `cargo fmt --check` pass on this branch.)
- Happy to add a regression test if you can point me at the preferred home for one — the repro needs a concrete backend plus a watchdog/timeout, so it doesn't slot into the existing `export_tests` op-macro suites naturally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4RXVd4mQcLnRpryKqF2Re