### PR TITLE
Fix scatter_nd values offset for multi-dim batches (#5195)

### DIFF
--- a/crates/burn-backend-tests/tests/cubecl/mod.rs
+++ b/crates/burn-backend-tests/tests/cubecl/mod.rs
@@ -23,6 +23,7 @@ mod quantization;
 mod reduce;
 mod repeat_dim;
 mod scatter;
+mod scatter_nd;
 mod select;
 mod select_assign;
 mod slice;

--- a/crates/burn-backend-tests/tests/cubecl/scatter_nd.rs
+++ b/crates/burn-backend-tests/tests/cubecl/scatter_nd.rs
@@ -1,0 +1,101 @@
+use super::*;
+use burn_tensor::{Device, IndexingUpdateOp, TensorData, s};
+
+/// Regression for burn-cubecl scatter_nd: values offset used `update_idx * values.stride(0)`.
+/// When `values.shape[0] == 1`, stride(0) is the full tensor volume, so update_idx >= 1 OOB-reads
+/// values and can raise CUDA_ERROR_ILLEGAL_ADDRESS. BSRoformer ONNX export uses this layout.
+#[test]
+fn scatter_nd_should_work_with_leading_batch_dim_one() {
+    let device = Device::default();
+    let ref_device = ReferenceDevice::new();
+
+    let data = TestTensor::<4>::zeros([1, 2, 4, 2], &device);
+
+    let mut indices_vec = Vec::new();
+    for i in 0..2usize {
+        for j in 0..4usize {
+            indices_vec.extend_from_slice(&[0i64, i as i64, j as i64, 0i64]);
+        }
+    }
+    let indices = TestTensorInt::<5>::from_data(
+        TensorData::new(indices_vec.clone(), [1, 2, 4, 1, 4]),
+        &device,
+    );
+
+    let mut values_vec = Vec::new();
+    for i in 0..2usize {
+        for j in 0..4usize {
+            values_vec.push(((i * 4 + j + 1) * 10) as f32);
+        }
+    }
+    let values =
+        TestTensor::<4>::from_data(TensorData::new(values_vec.clone(), [1, 2, 4, 1]), &device);
+
+    let data_ref = TestTensor::<4>::from_data(data.to_data(), &ref_device);
+    let indices_ref = TestTensorInt::<5>::from_data(
+        TensorData::new(indices_vec, [1, 2, 4, 1, 4]),
+        &ref_device,
+    );
+    let values_ref =
+        TestTensor::<4>::from_data(TensorData::new(values_vec, [1, 2, 4, 1]), &ref_device);
+
+    let actual = data.scatter_nd(indices, values, IndexingUpdateOp::Assign);
+    let expected = data_ref.scatter_nd(indices_ref, values_ref, IndexingUpdateOp::Assign);
+
+    expected
+        .into_data()
+        .assert_eq(&actual.into_data(), false);
+}
+
+#[test]
+fn scatter_nd_should_work_with_non_contiguous_values() {
+    let device = Device::default();
+    let ref_device = ReferenceDevice::new();
+
+    let data = TestTensor::<4>::zeros([1, 2, 4, 2], &device);
+
+    let mut indices_vec = Vec::new();
+    for i in 0..2usize {
+        for j in 0..4usize {
+            indices_vec.extend_from_slice(&[0i64, i as i64, j as i64, 0i64]);
+        }
+    }
+    let indices = TestTensorInt::<5>::from_data(
+        TensorData::new(indices_vec.clone(), [1, 2, 4, 1, 4]),
+        &device,
+    );
+
+    let mut values_vec = Vec::new();
+    for i in 0..2usize {
+        for j in 0..4usize {
+            values_vec.push(((i * 4 + j + 1) * 10) as f32);
+        }
+    }
+
+    // Embed values in a wider tensor and take a stepped slice so shape stays [1, 2, 4, 1]
+    // (valid for ScatterNd) while strides are non-unit / non-contiguous.
+    let mut wide_vec = vec![0.0f32; 16];
+    for i in 0..2usize {
+        for j in 0..4usize {
+            wide_vec[i * 8 + j * 2] = ((i * 4 + j + 1) * 10) as f32;
+        }
+    }
+    let values = TestTensor::<4>::from_data(TensorData::new(wide_vec, [1, 2, 8, 1]), &device)
+        .slice_dim(2, s![0..8; 2]);
+
+    let data_ref = TestTensor::<4>::from_data(data.to_data(), &ref_device);
+    let indices_ref = TestTensorInt::<5>::from_data(
+        TensorData::new(indices_vec, [1, 2, 4, 1, 4]),
+        &ref_device,
+    );
+    // NdArray scatter_nd requires contiguous values; same logical content as the stepped view.
+    let values_ref =
+        TestTensor::<4>::from_data(TensorData::new(values_vec, [1, 2, 4, 1]), &ref_device);
+
+    let actual = data.scatter_nd(indices, values, IndexingUpdateOp::Assign);
+    let expected = data_ref.scatter_nd(indices_ref, values_ref, IndexingUpdateOp::Assign);
+
+    expected
+        .into_data()
+        .assert_eq(&actual.into_data(), false);
+}

--- a/crates/burn-backend-tests/tests/cubecl/scatter_nd.rs
+++ b/crates/burn-backend-tests/tests/cubecl/scatter_nd.rs
@@ -32,19 +32,15 @@ fn scatter_nd_should_work_with_leading_batch_dim_one() {
         TestTensor::<4>::from_data(TensorData::new(values_vec.clone(), [1, 2, 4, 1]), &device);
 
     let data_ref = TestTensor::<4>::from_data(data.to_data(), &ref_device);
-    let indices_ref = TestTensorInt::<5>::from_data(
-        TensorData::new(indices_vec, [1, 2, 4, 1, 4]),
-        &ref_device,
-    );
+    let indices_ref =
+        TestTensorInt::<5>::from_data(TensorData::new(indices_vec, [1, 2, 4, 1, 4]), &ref_device);
     let values_ref =
         TestTensor::<4>::from_data(TensorData::new(values_vec, [1, 2, 4, 1]), &ref_device);
 
     let actual = data.scatter_nd(indices, values, IndexingUpdateOp::Assign);
     let expected = data_ref.scatter_nd(indices_ref, values_ref, IndexingUpdateOp::Assign);
 
-    expected
-        .into_data()
-        .assert_eq(&actual.into_data(), false);
+    expected.into_data().assert_eq(&actual.into_data(), false);
 }
 
 #[test]
@@ -84,10 +80,8 @@ fn scatter_nd_should_work_with_non_contiguous_values() {
         .slice_dim(2, s![0..8; 2]);
 
     let data_ref = TestTensor::<4>::from_data(data.to_data(), &ref_device);
-    let indices_ref = TestTensorInt::<5>::from_data(
-        TensorData::new(indices_vec, [1, 2, 4, 1, 4]),
-        &ref_device,
-    );
+    let indices_ref =
+        TestTensorInt::<5>::from_data(TensorData::new(indices_vec, [1, 2, 4, 1, 4]), &ref_device);
     // NdArray scatter_nd requires contiguous values; same logical content as the stepped view.
     let values_ref =
         TestTensor::<4>::from_data(TensorData::new(values_vec, [1, 2, 4, 1]), &ref_device);
@@ -95,7 +89,5 @@ fn scatter_nd_should_work_with_non_contiguous_values() {
     let actual = data.scatter_nd(indices, values, IndexingUpdateOp::Assign);
     let expected = data_ref.scatter_nd(indices_ref, values_ref, IndexingUpdateOp::Assign);
 
-    expected
-        .into_data()
-        .assert_eq(&actual.into_data(), false);
+    expected.into_data().assert_eq(&actual.into_data(), false);
 }

--- a/crates/burn-cubecl/src/kernel/index/scatter_nd.rs
+++ b/crates/burn-cubecl/src/kernel/index/scatter_nd.rs
@@ -54,16 +54,38 @@ fn scatter_nd_kernel<T: Numeric, I: Int, Op: BinaryOpFamily>(
         data_slice_offset += coord * data.stride(k + dim);
     }
 
-    // Decompose slice_offset over values' dims (1..n_v), with update_idx for dim 0
+    // values_shape covers values dims 1..rank.
+    // Decompose update_idx over batch dims (right-to-left), then slice_offset over
+    // trailing slice dims. Never use `update_idx * values.stride(0)` alone — when
+    // shape[0] == 1 that stride is the full volume and OOB-reads values.
     let val_rank = values_shape.len().comptime();
-    let mut val_offset = update_idx * values.stride(0);
+    let values_rank = val_rank + 1;
+    let batch_rank = values_rank - slice_rank;
+
+    let mut val_offset = 0usize;
+    let mut remainder_u = update_idx;
+    #[unroll]
+    for i in 0..batch_rank {
+        let dim = batch_rank - i - 1;
+        if dim == 0 {
+            let shape0 = values.shape(0);
+            let coord = remainder_u % shape0;
+            remainder_u = remainder_u / shape0;
+            val_offset += coord * values.stride(0);
+        } else {
+            let (rem, coord) = values_shape[dim - 1].div_mod(remainder_u);
+            remainder_u = rem;
+            val_offset += coord * values.stride(dim);
+        }
+    }
+
     let mut remainder_v = slice_offset;
     #[unroll]
-    for i in 0..val_rank {
-        let dim = val_rank - i - 1;
-        let (rem, coord) = values_shape[dim].div_mod(remainder_v);
+    for i in 0..slice_rank {
+        let dim = values_rank - i - 1;
+        let (rem, coord) = values_shape[dim - 1].div_mod(remainder_v);
         remainder_v = rem;
-        val_offset += coord * values.stride(1 + dim);
+        val_offset += coord * values.stride(dim);
     }
 
     let data_idx = base_offset + data_slice_offset;
@@ -111,7 +133,7 @@ pub(crate) fn scatter_nd<R: CubeRuntime>(
     };
 
     let data_slice_shape = shape_divmod_range(&tensor, k..data_shape.num_dims());
-    // values dims 1.. (skip the num_updates leading dim)
+    // values dims 1.. (dim 0 is read from values.shape(0) in the kernel)
     let values_slice_shape = shape_divmod_range(&values, 1..values.meta.shape.num_dims());
 
     unsafe {

--- a/crates/burn-cubecl/src/kernel/index/scatter_nd.rs
+++ b/crates/burn-cubecl/src/kernel/index/scatter_nd.rs
@@ -70,7 +70,7 @@ fn scatter_nd_kernel<T: Numeric, I: Int, Op: BinaryOpFamily>(
         if dim == 0 {
             let shape0 = values.shape(0);
             let coord = remainder_u % shape0;
-            remainder_u = remainder_u / shape0;
+            remainder_u /= shape0;
             val_offset += coord * values.stride(0);
         } else {
             let (rem, coord) = values_shape[dim - 1].div_mod(remainder_u);

--- a/crates/burn-cubecl/src/kernel/index/scatter_nd.rs
+++ b/crates/burn-cubecl/src/kernel/index/scatter_nd.rs
@@ -54,12 +54,8 @@ fn scatter_nd_kernel<T: Numeric, I: Int, Op: BinaryOpFamily>(
         data_slice_offset += coord * data.stride(k + dim);
     }
 
-    // values_shape covers values dims 1..rank.
-    // Decompose update_idx over batch dims (right-to-left), then slice_offset over
-    // trailing slice dims. Never use `update_idx * values.stride(0)` alone — when
-    // shape[0] == 1 that stride is the full volume and OOB-reads values.
-    let val_rank = values_shape.len().comptime();
-    let values_rank = val_rank + 1;
+    // values_shape covers all values dims (0..values_rank).
+    let values_rank = values_shape.len().comptime();
     let batch_rank = values_rank - slice_rank;
 
     let mut val_offset = 0usize;
@@ -67,25 +63,19 @@ fn scatter_nd_kernel<T: Numeric, I: Int, Op: BinaryOpFamily>(
     #[unroll]
     for i in 0..batch_rank {
         let dim = batch_rank - i - 1;
-        if dim == 0 {
-            let shape0 = values.shape(0);
-            let coord = remainder_u % shape0;
-            remainder_u /= shape0;
-            val_offset += coord * values.stride(0);
-        } else {
-            let (rem, coord) = values_shape[dim - 1].div_mod(remainder_u);
-            remainder_u = rem;
-            val_offset += coord * values.stride(dim);
-        }
+        let (rem, coord) = values_shape[dim].div_mod(remainder_u);
+        remainder_u = rem;
+        val_offset += coord * values.stride(dim);
     }
 
     let mut remainder_v = slice_offset;
     #[unroll]
     for i in 0..slice_rank {
-        let dim = values_rank - i - 1;
-        let (rem, coord) = values_shape[dim - 1].div_mod(remainder_v);
+        let dim = slice_rank - i - 1;
+        let val_dim = batch_rank + dim;
+        let (rem, coord) = values_shape[val_dim].div_mod(remainder_v);
         remainder_v = rem;
-        val_offset += coord * values.stride(dim);
+        val_offset += coord * values.stride(val_dim);
     }
 
     let data_idx = base_offset + data_slice_offset;
@@ -133,8 +123,7 @@ pub(crate) fn scatter_nd<R: CubeRuntime>(
     };
 
     let data_slice_shape = shape_divmod_range(&tensor, k..data_shape.num_dims());
-    // values dims 1.. (dim 0 is read from values.shape(0) in the kernel)
-    let values_slice_shape = shape_divmod_range(&values, 1..values.meta.shape.num_dims());
+    let values_shape = shape_divmod_range(&values, 0..values.meta.shape.num_dims());
 
     unsafe {
         launch(
@@ -146,7 +135,7 @@ pub(crate) fn scatter_nd<R: CubeRuntime>(
             indices.into_linear_view(),
             values.into_tensor_arg(),
             data_slice_shape,
-            values_slice_shape,
+            values_shape,
             slice_size,
             k,
             working_units,


### PR DESCRIPTION
This PR fixes scatter_nd with non-trivial and non-contiguous indices.

## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

https://github.com/tracel-ai/burn/issues/5195

### Changes

The kernel indexed values as `update_idx * values.stride(0)` and then walked trailing dims with `stride(1 + dim)`. That only works when all updates vary along dim 0. When `values.shape[0] == 1` (common in ONNX ScatterND layouts), stride(0) is the full tensor volume, so `update_idx >= 1` reads out of bounds.

Instead I decomposed `update_idx` right-to-left over all batch dims and `slice_offset` over the trailing slice dims, using `values.stride(dim)` for each.

### Testing

I've added a test `crates/burn-backend-tests/tests/cubecl/scatter_nd.rs`. It tests both contiguous and non-contiguous indices.