### PR TITLE
feat: add sequential learning rate scheduler

### DIFF
--- a/burn-book/src/SUMMARY.md
+++ b/burn-book/src/SUMMARY.md
@@ -14,6 +14,7 @@
   - [Autodiff](./building-blocks/autodiff.md)
   - [Module](./building-blocks/module.md)
   - [Learner](./building-blocks/learner.md)
+  - [Learning Rate Scheduler](./building-blocks/lr-scheduler.md)
   - [Metric](./building-blocks/metric.md)
   - [Config](./building-blocks/config.md)
   - [Record](./building-blocks/record.md)

--- a/burn-book/src/building-blocks/learner.md
+++ b/burn-book/src/building-blocks/learner.md
@@ -43,6 +43,23 @@ The `launch` method will start the training and return the trained model once fi
 Again, please refer to the [training section](../basic-workflow/training.md) for a relevant code
 snippet.
 
+## Sequential learning rate schedules
+
+Use `SequentialLrSchedulerConfig` when different schedulers should run during non-overlapping parts
+of training. Milestones count scheduler steps: in this warmup example, the linear scheduler produces
+the first 1,000 learning rates and the cosine scheduler takes over on step 1,000.
+
+```rust,ignore
+let lr_scheduler = SequentialLrSchedulerConfig::new(
+    vec![
+        LinearLrSchedulerConfig::new(1e-6, 1e-3, 1_000).into(),
+        CosineAnnealingLrSchedulerConfig::new(1e-3, 9_000).into(),
+    ],
+    vec![1_000],
+)
+.init()?;
+```
+
 ## Multiple optimizers
 
 It's common practice to set different learning rates, optimizer parameters, or use different optimizers entirely, for different parts

--- a/burn-book/src/building-blocks/learner.md
+++ b/burn-book/src/building-blocks/learner.md
@@ -36,29 +36,13 @@ The `SupervisedLearning` struct must be created with the training and validation
 
 When the training is configured to your liking, you can then move forward to running the training. The
 `launch` method requires a learner object providing: the model, the optimizer and the learning rate scheduler. Note
-that the latter can be a simple float if you want it to be constant during training.
+that the latter can be a simple float if you want it to be constant during training. See the
+[learning rate scheduler section](./lr-scheduler.md) for the available schedulers.
 
 The `launch` method will start the training and return the trained model once finished.
 
 Again, please refer to the [training section](../basic-workflow/training.md) for a relevant code
 snippet.
-
-## Sequential learning rate schedules
-
-Use `SequentialLrSchedulerConfig` when different schedulers should run during non-overlapping parts
-of training. Milestones count scheduler steps: in this warmup example, the linear scheduler produces
-the first 1,000 learning rates and the cosine scheduler takes over on step 1,000.
-
-```rust,ignore
-let lr_scheduler = SequentialLrSchedulerConfig::new(
-    vec![
-        LinearLrSchedulerConfig::new(1e-6, 1e-3, 1_000).into(),
-        CosineAnnealingLrSchedulerConfig::new(1e-3, 9_000).into(),
-    ],
-    vec![1_000],
-)
-.init()?;
-```
 
 ## Multiple optimizers
 

--- a/burn-book/src/building-blocks/lr-scheduler.md
+++ b/burn-book/src/building-blocks/lr-scheduler.md
@@ -1,0 +1,34 @@
+# Learning Rate Scheduler
+
+Learning rate schedulers control how the learning rate evolves during training. A scheduler is
+built from its configuration and passed to the learner along with the model and the optimizer, as
+shown in the [learner section](./learner.md). A constant learning rate can be provided as a simple
+float. We currently offer the following schedulers.
+
+| Scheduler        | Description                                                                       |
+| ---------------- | --------------------------------------------------------------------------------- |
+| Constant         | Keep the learning rate fixed during training                                       |
+| Linear           | Interpolate linearly between an initial and final learning rate                    |
+| Cosine Annealing | Anneal the learning rate following a cosine curve                                  |
+| Exponential      | Multiply the learning rate by a constant factor at every step                      |
+| Noam             | Warm up linearly, then decay proportionally to the inverse square root of the step |
+| Step             | Multiply the learning rate by a constant factor at fixed intervals                 |
+| Composed         | Combine schedulers per parameter group (see the [learner section](./learner.md#multiple-optimizers)) |
+| Sequential       | Run different schedulers during non-overlapping parts of training                  |
+
+## Sequential learning rate schedules
+
+Use `SequentialLrSchedulerConfig` when different schedulers should run during non-overlapping parts
+of training. Milestones count scheduler steps: in this warmup example, the linear scheduler produces
+the first 1,000 learning rates and the cosine scheduler takes over on step 1,000.
+
+```rust,ignore
+let lr_scheduler = SequentialLrSchedulerConfig::new(
+    vec![
+        LinearLrSchedulerConfig::new(1e-6, 1e-3, 1_000).into(),
+        CosineAnnealingLrSchedulerConfig::new(1e-3, 9_000).into(),
+    ],
+    vec![1_000],
+)
+.init()?;
+```

--- a/crates/burn-optim/src/lr_scheduler/base.rs
+++ b/crates/burn-optim/src/lr_scheduler/base.rs
@@ -11,6 +11,7 @@ use crate::lr_scheduler::cosine::CosineAnnealingLrSchedulerConfig;
 use crate::lr_scheduler::exponential::ExponentialLrSchedulerConfig;
 use crate::lr_scheduler::linear::LinearLrSchedulerConfig;
 use crate::lr_scheduler::noam::NoamLrSchedulerConfig;
+use crate::lr_scheduler::sequential::SequentialLrSchedulerConfig;
 use crate::lr_scheduler::step::StepLrSchedulerConfig;
 use crate::{RecordState, StateSink, StateSource, join_path};
 use burn::store::RecordError;
@@ -238,6 +239,23 @@ pub enum LrSchedulerConfig {
     Step(StepLrSchedulerConfig),
     /// A [`ComposedLrSchedulerConfig`]
     Composed(ComposedLrSchedulerConfig),
+    /// A [`SequentialLrSchedulerConfig`]
+    Sequential(SequentialLrSchedulerConfig),
+}
+
+impl LrSchedulerConfig {
+    pub(crate) fn build(&self) -> Result<DynLrScheduler, String> {
+        Ok(match self {
+            Self::Constant(lr) => (*lr).into(),
+            Self::Linear(config) => config.build()?.into(),
+            Self::Cosine(config) => config.build()?.into(),
+            Self::Exponential(config) => config.build()?.into(),
+            Self::Noam(config) => config.build()?.into(),
+            Self::Step(config) => config.build()?.into(),
+            Self::Composed(config) => config.build()?.into(),
+            Self::Sequential(config) => config.build()?.into(),
+        })
+    }
 }
 
 impl_from_for_scheduler!(
@@ -248,6 +266,7 @@ impl_from_for_scheduler!(
     Noam(NoamLrSchedulerConfig),
     Step(StepLrSchedulerConfig),
     Composed(ComposedLrSchedulerConfig),
+    Sequential(SequentialLrSchedulerConfig),
 );
 
 #[cfg(test)]

--- a/crates/burn-optim/src/lr_scheduler/composed.rs
+++ b/crates/burn-optim/src/lr_scheduler/composed.rs
@@ -44,16 +44,7 @@ impl ComposedLrSchedulerConfig {
     pub(crate) fn build(&self) -> Result<ComposedLrScheduler, String> {
         let mut schedulers: Vec<DynLrScheduler> = Vec::with_capacity(self.schedulers.len());
         for config in self.schedulers.iter() {
-            let config = match config {
-                LrSchedulerConfig::Constant(lr) => (*lr).into(),
-                LrSchedulerConfig::Linear(config) => config.build()?.into(),
-                LrSchedulerConfig::Cosine(config) => config.build()?.into(),
-                LrSchedulerConfig::Exponential(config) => config.build()?.into(),
-                LrSchedulerConfig::Noam(config) => config.build()?.into(),
-                LrSchedulerConfig::Step(config) => config.build()?.into(),
-                LrSchedulerConfig::Composed(config) => config.build()?.into(),
-            };
-            schedulers.push(config);
+            schedulers.push(config.build()?);
         }
 
         Ok(ComposedLrScheduler {

--- a/crates/burn-optim/src/lr_scheduler/mod.rs
+++ b/crates/burn-optim/src/lr_scheduler/mod.rs
@@ -22,6 +22,9 @@ pub mod cosine;
 /// Step learning rate scheduler
 pub mod step;
 
+/// Sequential learning rate scheduler
+pub mod sequential;
+
 mod base;
 
 pub use base::*;

--- a/crates/burn-optim/src/lr_scheduler/module_lr_scheduler.rs
+++ b/crates/burn-optim/src/lr_scheduler/module_lr_scheduler.rs
@@ -84,30 +84,14 @@ impl ModuleLrSchedulerConfig {
     pub fn init(&self) -> Result<ModuleLrScheduler, String> {
         let mut groups = Vec::with_capacity(self.scheduler_groups.len());
 
-        let base = match &self.base {
-            LrSchedulerConfig::Constant(lr) => (*lr).into(),
-            LrSchedulerConfig::Linear(config) => config.build()?.into(),
-            LrSchedulerConfig::Cosine(config) => config.build()?.into(),
-            LrSchedulerConfig::Exponential(config) => config.build()?.into(),
-            LrSchedulerConfig::Noam(config) => config.build()?.into(),
-            LrSchedulerConfig::Step(config) => config.build()?.into(),
-            LrSchedulerConfig::Composed(config) => config.build()?.into(),
-        };
+        let base = self.base.build()?;
         groups.push(LrSchedulerGroup {
             group: ParamGroup::all(),
             scheduler: base,
         });
 
         for group in self.scheduler_groups.iter() {
-            let scheduler = match &group.scheduler {
-                LrSchedulerConfig::Constant(lr) => (*lr).into(),
-                LrSchedulerConfig::Linear(config) => config.build()?.into(),
-                LrSchedulerConfig::Cosine(config) => config.build()?.into(),
-                LrSchedulerConfig::Exponential(config) => config.build()?.into(),
-                LrSchedulerConfig::Noam(config) => config.build()?.into(),
-                LrSchedulerConfig::Step(config) => config.build()?.into(),
-                LrSchedulerConfig::Composed(config) => config.build()?.into(),
-            };
+            let scheduler = group.scheduler.build()?;
             groups.push(LrSchedulerGroup::new(group.group.clone(), scheduler));
         }
 

--- a/crates/burn-optim/src/lr_scheduler/sequential.rs
+++ b/crates/burn-optim/src/lr_scheduler/sequential.rs
@@ -1,0 +1,216 @@
+use alloc::vec::Vec;
+use burn_core as burn;
+
+use burn::config::Config;
+
+use super::module_lr_scheduler::ModuleLrScheduler;
+use super::{DynLrScheduler, LrScheduler, LrSchedulerConfig, LrSchedulerRecord, String};
+use crate::{LearningRate, RecordState};
+
+/// Configuration for a [sequential learning rate scheduler](SequentialLrScheduler).
+///
+/// Each milestone is the number of completed calls to [`LrScheduler::step`] at which the next
+/// scheduler takes over. Therefore, `N` schedulers require exactly `N - 1` milestones. Milestones
+/// must be greater than zero and strictly increasing.
+///
+/// # Example
+///
+/// The linear scheduler below handles the first 100 steps, after which the cosine scheduler starts
+/// from its own first step.
+///
+/// ```
+/// use burn_optim::lr_scheduler::{
+///     LrSchedulerConfig,
+///     cosine::CosineAnnealingLrSchedulerConfig, linear::LinearLrSchedulerConfig,
+///     sequential::SequentialLrSchedulerConfig,
+/// };
+///
+/// let config = SequentialLrSchedulerConfig::new(
+///     vec![
+///         LrSchedulerConfig::Linear(LinearLrSchedulerConfig::new(1e-5, 1e-2, 100)),
+///         LrSchedulerConfig::Cosine(CosineAnnealingLrSchedulerConfig::new(1e-2, 900)),
+///     ],
+///     vec![100],
+/// );
+/// let scheduler = config.init().unwrap();
+/// ```
+#[derive(Config, Debug)]
+pub struct SequentialLrSchedulerConfig {
+    schedulers: Vec<LrSchedulerConfig>,
+    milestones: Vec<usize>,
+}
+
+impl SequentialLrSchedulerConfig {
+    pub(crate) fn build(&self) -> Result<SequentialLrScheduler, String> {
+        if self.schedulers.is_empty() {
+            return Err("At least one scheduler is required".into());
+        }
+        if self.milestones.len() + 1 != self.schedulers.len() {
+            return Err(
+                "The number of milestones must be one less than the number of schedulers".into(),
+            );
+        }
+        if self
+            .milestones
+            .iter()
+            .enumerate()
+            .any(|(index, milestone)| {
+                *milestone == 0 || index > 0 && *milestone <= self.milestones[index - 1]
+            })
+        {
+            return Err("Milestones must be greater than zero and strictly increasing".into());
+        }
+
+        let schedulers = self
+            .schedulers
+            .iter()
+            .map(LrSchedulerConfig::build)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(SequentialLrScheduler {
+            schedulers,
+            milestones: self.milestones.clone(),
+            step: 0,
+        })
+    }
+
+    /// Initializes a [module learning rate scheduler](ModuleLrScheduler).
+    ///
+    /// # Errors
+    ///
+    /// An error is returned when there are no schedulers, the number of milestones is not one less
+    /// than the number of schedulers, milestones are zero or not strictly increasing, or a child
+    /// scheduler configuration is invalid.
+    pub fn init(&self) -> Result<ModuleLrScheduler, String> {
+        self.build().map(Into::into)
+    }
+}
+
+/// Runs learning rate schedulers one after another at configured milestones.
+#[derive(Clone)]
+pub struct SequentialLrScheduler {
+    schedulers: Vec<DynLrScheduler>,
+    milestones: Vec<usize>,
+    step: usize,
+}
+
+impl SequentialLrScheduler {
+    fn active_scheduler(&self) -> usize {
+        self.milestones
+            .iter()
+            .take_while(|milestone| self.step >= **milestone)
+            .count()
+    }
+}
+
+impl LrScheduler for SequentialLrScheduler {
+    fn step(&mut self) -> LearningRate {
+        let index = self.active_scheduler();
+        let lr = self.schedulers[index].step();
+        self.step = self
+            .step
+            .checked_add(1)
+            .expect("The sequential scheduler step counter overflowed");
+        lr
+    }
+
+    fn to_record(&self) -> LrSchedulerRecord {
+        let mut record =
+            LrSchedulerRecord::from_state(&SequentialLrSchedulerState { step: self.step });
+        for (index, scheduler) in self.schedulers.iter().enumerate() {
+            record = record.with_record(&index.to_string(), scheduler.to_record());
+        }
+        record
+    }
+
+    fn load_record(&mut self, record: LrSchedulerRecord) {
+        if let Some(state) = record.into_state::<SequentialLrSchedulerState>() {
+            self.step = state.step;
+        }
+
+        self.schedulers = self
+            .schedulers
+            .clone()
+            .into_iter()
+            .enumerate()
+            .map(|(index, scheduler)| scheduler.load_record(record.record(&index.to_string())))
+            .collect();
+    }
+}
+
+#[derive(RecordState, Clone, Debug)]
+struct SequentialLrSchedulerState {
+    step: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::cosine::CosineAnnealingLrSchedulerConfig;
+    use super::super::exponential::ExponentialLrSchedulerConfig;
+    use super::super::linear::LinearLrSchedulerConfig;
+    use super::super::test_utils;
+    use super::*;
+
+    fn config(milestones: Vec<usize>) -> SequentialLrSchedulerConfig {
+        SequentialLrSchedulerConfig::new(
+            vec![
+                LinearLrSchedulerConfig::new(0.1, 0.3, 2).into(),
+                ExponentialLrSchedulerConfig::new(0.5, 0.5).into(),
+                CosineAnnealingLrSchedulerConfig::new(0.8, 2).into(),
+            ],
+            milestones,
+        )
+    }
+
+    #[test]
+    fn switches_schedulers_at_milestones() {
+        let scheduler = config(vec![2, 5]).build().unwrap();
+        test_utils::check_lr_sequence(scheduler, [0.1, 0.2, 0.5, 0.25, 0.125, 0.8, 0.4, 0.0]);
+    }
+
+    #[test]
+    fn rejects_empty_scheduler_list() {
+        let result = SequentialLrSchedulerConfig::new(vec![], vec![]).build();
+        assert_eq!(result.err().unwrap(), "At least one scheduler is required");
+    }
+
+    #[test]
+    fn rejects_wrong_milestone_count() {
+        let result = config(vec![2]).build();
+        assert_eq!(
+            result.err().unwrap(),
+            "The number of milestones must be one less than the number of schedulers"
+        );
+    }
+
+    #[test]
+    fn rejects_zero_or_non_increasing_milestones() {
+        for milestones in [vec![0, 2], vec![2, 2], vec![3, 2]] {
+            let result = config(milestones).build();
+            assert_eq!(
+                result.err().unwrap(),
+                "Milestones must be greater than zero and strictly increasing"
+            );
+        }
+    }
+
+    #[test]
+    fn reports_invalid_child_config() {
+        let result = SequentialLrSchedulerConfig::new(
+            vec![LinearLrSchedulerConfig::new(0.1, 0.2, 0).into()],
+            vec![],
+        )
+        .build();
+        assert_eq!(
+            result.err().unwrap(),
+            "Number of iterations must be at least 1"
+        );
+    }
+
+    #[test]
+    fn saves_and_loads_before_and_after_transitions() {
+        test_utils::check_save_load(config(vec![2, 5]).build().unwrap(), 1);
+        test_utils::check_save_load(config(vec![2, 5]).build().unwrap(), 4);
+        test_utils::check_save_load(config(vec![2, 5]).build().unwrap(), 6);
+    }
+}

--- a/crates/burn-optim/src/lr_scheduler/sequential.rs
+++ b/crates/burn-optim/src/lr_scheduler/sequential.rs
@@ -96,10 +96,7 @@ pub struct SequentialLrScheduler {
 
 impl SequentialLrScheduler {
     fn active_scheduler(&self) -> usize {
-        self.milestones
-            .iter()
-            .take_while(|milestone| self.step >= **milestone)
-            .count()
+        self.milestones.partition_point(|&m| self.step >= m)
     }
 }
 
@@ -128,9 +125,8 @@ impl LrScheduler for SequentialLrScheduler {
             self.step = state.step;
         }
 
-        self.schedulers = self
-            .schedulers
-            .clone()
+        let schedulers = core::mem::take(&mut self.schedulers);
+        self.schedulers = schedulers
             .into_iter()
             .enumerate()
             .map(|(index, scheduler)| scheduler.load_record(record.record(&index.to_string())))


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Closes #5127.
Depends on the scheduler config and record infrastructure merged in #5121.

### Changes

Adds `SequentialLrSchedulerConfig` and `SequentialLrScheduler` for running non-overlapping learning rate schedules at step milestones. Only the active child scheduler advances; each later child begins from its own initial learning rate when its milestone is reached.

The scheduler participates in `LrSchedulerConfig`, can be nested inside composed or module schedulers, validates scheduler/milestone cardinality and ordering, and checkpoints the global step plus every child state. The learner book now includes a linear-warmup-to-cosine example.

The shared `LrSchedulerConfig::build` path removes duplicated exhaustive matches from composed and module schedulers, which also keeps nested scheduler support consistent.

### Testing

- `cargo test -p burn-optim` (101 passed)
- `cargo test -p burn-optim --doc` (1 passed, 3 ignored)
- `cargo clippy -p burn-optim --lib --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo run-checks` progressed successfully through dependency audit, formatting, workspace Clippy with warnings denied, typo checks, and the full optimized workspace build. It was stopped during subsequent custom all-feature backend rebuilds after the relevant workspace gates passed.