### PR TITLE
feat: support negative softmax dimensions

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/float/activation/log_softmax.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/activation/log_softmax.rs
@@ -14,3 +14,16 @@ fn test_log_softmax_d2() {
         .into_data()
         .assert_approx_eq::<FloatElem>(&expected, tolerance);
 }
+
+#[test]
+fn test_log_softmax_negative_dim() {
+    let tensor = TestTensor::<2>::from([[1.0, 0.0], [0.0, 1.0]]);
+
+    let output = activation::log_softmax(tensor, -1);
+    let expected = TensorData::from([[-0.3132617, -1.3132617], [-1.3132617, -0.3132617]]);
+
+    let tolerance = Tolerance::rel_abs(0.01, 0.0001);
+    output
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, tolerance);
+}

--- a/crates/burn-backend-tests/tests/tensor/float/activation/quiet_softmax.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/activation/quiet_softmax.rs
@@ -13,3 +13,15 @@ fn test_quiet_softmax_d2() {
         .into_data()
         .assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
 }
+
+#[test]
+fn test_quiet_softmax_negative_dim() {
+    let tensor = TestTensor::<2>::from([[1.0, 7.0], [13.0, -3.0]]);
+
+    let output = activation::quiet_softmax(tensor, -1);
+    let expected = TensorData::from([[2.47e-03, 9.975e-01], [1.0, 1.1254e-07]]);
+
+    output
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
+}

--- a/crates/burn-backend-tests/tests/tensor/float/activation/softmax.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/activation/softmax.rs
@@ -15,6 +15,18 @@ fn test_softmax_d2() {
 }
 
 #[test]
+fn test_softmax_negative_dim() {
+    let tensor = TestTensor::<2>::from([[1.0, 7.0], [13.0, -3.0]]);
+
+    let output = activation::softmax(tensor, -1);
+    let expected = TensorData::from([[2.472623e-03, 9.975274e-01], [1.0, 1.125352e-07]]);
+
+    output
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
+}
+
+#[test]
 fn test_softmax_d1() {
     let tensor = TestTensor::<1>::from([1.0, 2.0, 3.0]);
 

--- a/crates/burn-backend-tests/tests/tensor/float/activation/softmin.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/activation/softmin.rs
@@ -13,3 +13,15 @@ fn test_softmin_d2() {
         .into_data()
         .assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
 }
+
+#[test]
+fn test_softmin_negative_dim() {
+    let tensor = TestTensor::<2>::from([[1.0, 7.0], [13.0, -3.0]]);
+
+    let output = activation::softmin(tensor, -1);
+    let expected = TensorData::from([[9.975274e-01, 2.472623e-03], [1.125352e-07, 1.0000]]);
+
+    output
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
+}

--- a/crates/burn-tensor/src/tensor/activation/base.rs
+++ b/crates/burn-tensor/src/tensor/activation/base.rs
@@ -180,10 +180,12 @@ $$
 ///
 /// # Arguments
 /// - `dim`: the dimension along which Softmax will be computed.
+///   Negative dimensions are supported and count from the end.
 ///
 /// # Panics
-/// - If `dim` is outside [0, D)
-pub fn softmax<const D: usize>(tensor: Tensor<D>, dim: usize) -> Tensor<D> {
+/// - If `dim` is outside [-D, D)
+pub fn softmax<const D: usize>(tensor: Tensor<D>, dim: impl AsIndex) -> Tensor<D> {
+    let dim = dim.expect_dim_index(D);
     check!(TensorCheck::dim_ops::<D>("softmax", dim));
 
     Tensor::new(softmax_impl(tensor.primitive, dim))
@@ -202,11 +204,13 @@ $$
 #[cfg_attr(not(doc), doc = "`softmin(x_i) = exp(-x_i) / sum_j(exp(-x_j)`")]
 ///
 /// # Arguments
-/// - `dim`: the dimension along which Softmax will be computed.
+/// - `dim`: the dimension along which Softmin will be computed.
+///   Negative dimensions are supported and count from the end.
 ///
 /// # Panics
-/// - If `dim` is outside [0, D)
-pub fn softmin<const D: usize>(tensor: Tensor<D>, dim: usize) -> Tensor<D> {
+/// - If `dim` is outside [-D, D)
+pub fn softmin<const D: usize>(tensor: Tensor<D>, dim: impl AsIndex) -> Tensor<D> {
+    let dim = dim.expect_dim_index(D);
     check!(TensorCheck::dim_ops::<D>("softmin", dim));
 
     Tensor::new(softmin_impl(tensor.primitive, dim))
@@ -251,11 +255,13 @@ $$
 )]
 ///
 /// # Arguments
-/// - `dim`: the dimension along which Softmax will be computed.
+/// - `dim`: the dimension along which Quiet Softmax will be computed.
+///   Negative dimensions are supported and count from the end.
 ///
 /// # Panics
-/// - If `dim` is outside [0, D)
-pub fn quiet_softmax<const D: usize>(tensor: Tensor<D>, dim: usize) -> Tensor<D> {
+/// - If `dim` is outside [-D, D)
+pub fn quiet_softmax<const D: usize>(tensor: Tensor<D>, dim: impl AsIndex) -> Tensor<D> {
+    let dim = dim.expect_dim_index(D);
     check!(TensorCheck::dim_ops::<D>("softmax", dim));
 
     let max_vals = tensor.clone().detach().max_dim(dim);
@@ -283,11 +289,13 @@ $$
 )]
 ///
 /// # Arguments
-/// - `dim`: the dimension along which Softmax will be computed.
+/// - `dim`: the dimension along which Log Softmax will be computed.
+///   Negative dimensions are supported and count from the end.
 ///
 /// # Panics
-/// - If `dim` is outside [0, D)
-pub fn log_softmax<const D: usize>(tensor: Tensor<D>, dim: usize) -> Tensor<D> {
+/// - If `dim` is outside [-D, D)
+pub fn log_softmax<const D: usize>(tensor: Tensor<D>, dim: impl AsIndex) -> Tensor<D> {
+    let dim = dim.expect_dim_index(D);
     check!(TensorCheck::dim_ops::<D>("log softmax", dim));
 
     Tensor::new(log_softmax_impl(tensor.primitive, dim))


### PR DESCRIPTION
## Motivation
Burn already supports negative dimension indexing in several tensor APIs, including GLU. The softmax family still required `usize` dimensions, so common PyTorch-style calls like `dim = -1` were not accepted even though backend ops only need a resolved positive axis.

This makes the activation APIs more consistent with the rest of Burn's tensor API and with common Python tensor libraries.

## Modifications
- Changed `activation::softmax`, `activation::softmin`, `activation::quiet_softmax`, and `activation::log_softmax` to accept `impl AsIndex`.
- Resolve dimensions before validation and backend dispatch.
- Document negative dimension support on the public APIs.
- Added backend regression tests for `dim = -1` across the softmax family.

## Testing
- `cargo fmt --all`
- `cargo +nightly check -p burn-tensor`
- `cargo +nightly test -p burn-backend-tests --test tensor --features ndarray softmax_negative_dim -- --nocapture`
- `cargo +nightly test -p burn-backend-tests --test tensor --features ndarray softmin_negative_dim -- --nocapture`
