### PR TITLE
docs: document per-device default dtypes; make AlreadyInitialized error actionable

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -15,10 +15,11 @@ backend implementations.
 
 ### Data types
 
-The element type used for a tensor is not encoded in the `Tensor` type. Instead, each device keeps a
-set of **default data types** that determine the width used when a tensor is created without an
-explicit dtype (for example with `Tensor::zeros`, `Tensor::ones` or `from_floats`). You can inspect
-the current defaults with [`Device::settings`](https://docs.rs/burn/latest/burn/tensor/struct.Device.html):
+A tensor has an element type, but unlike its `Float`/`Int`/`Bool` kind that type is a runtime
+property rather than a generic parameter on `Tensor`. When a tensor is created without an explicit
+dtype (for example with `Tensor::zeros`, `Tensor::ones` or `from_floats`), the element type comes
+from a set of **default data types** that each device keeps. You can inspect the current defaults
+with [`Device::settings`](https://docs.rs/burn/latest/burn/tensor/struct.Device.html):
 
 ```rust, ignore
 use burn::tensor::Device;
@@ -49,14 +50,24 @@ let floats = Tensor::<Backend, 2>::zeros([2, 3], &device);
 > `DeviceError::AlreadyInitialized` error instead of silently changing (or ignoring) the width.
 
 Because the default width is a per-device property, you cannot have two different default float widths
-active on the same device within a single process. If you need values at more than one precision, set
-the default once up front and create the other tensors with an explicit dtype instead, using
+active on the same device within a single process. If you need values at more than one precision,
+create the other tensors with an explicit dtype by passing a `(&device, dtype)` tuple as the creation
+options (this tuple is just a convenient conversion into
+[`TensorCreationOptions`](https://docs.rs/burn/latest/burn/tensor/struct.TensorCreationOptions.html)):
+
+```rust, ignore
+use burn::tensor::DType;
+
+// device defaults to f32
+let x = Tensor::<Backend, 2>::zeros([2, 3], &device);                   // f32
+let x_f64 = Tensor::<Backend, 2>::zeros([2, 3], (&device, DType::F64)); // explicit f64
+```
+
+To convert an *existing* tensor to another element type, use
 [`cast`](https://docs.rs/burn/latest/burn/tensor/struct.Tensor.html#method.cast):
 
 ```rust, ignore
-// device defaults to f32
-let x = Tensor::<Backend, 2>::zeros([2, 3], &device); // f32
-let x_f64 = x.cast(FloatDType::F64);                  // explicit f64
+let x_f64 = x.cast(FloatDType::F64); // convert the f32 tensor above to f64
 ```
 
 Burn Tensors are defined by the number of dimensions D in its declaration as opposed to its shape.

--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -13,6 +13,52 @@ Tensor<B, D, Bool>     // Bool tensor
 Note that the specific element types used for `Float`, `Int`, and `Bool` tensors are defined by
 backend implementations.
 
+### Data types
+
+The element type used for a tensor is not encoded in the `Tensor` type. Instead, each device keeps a
+set of **default data types** that determine the width used when a tensor is created without an
+explicit dtype (for example with `Tensor::zeros`, `Tensor::ones` or `from_floats`). You can inspect
+the current defaults with [`Device::settings`](https://docs.rs/burn/latest/burn/tensor/struct.Device.html):
+
+```rust, ignore
+use burn::tensor::Device;
+
+let device = Device::default();
+let settings = device.settings();
+// settings.float_dtype, settings.int_dtype, settings.bool_dtype
+```
+
+To use a different default (e.g. `f16` for floats), configure the device with
+[`Device::configure`](https://docs.rs/burn/latest/burn/tensor/struct.Device.html) before creating
+any tensor on it:
+
+```rust, ignore
+use burn::tensor::{Device, FloatDType, IntDType};
+
+let mut device = Device::default();
+device.configure((FloatDType::F16, IntDType::I32))?;
+
+// Float tensors created after this default to F16
+let floats = Tensor::<Backend, 2>::zeros([2, 3], &device);
+```
+
+> **Default data types lock on first use.** A device's defaults can only be initialized **once**, and
+> that initialization must happen *before* the first tensor operation on the device. The first tensor
+> created on an unconfigured device permanently locks the defaults to the backend's values. Any later
+> call to `configure` (or `set_default_dtypes`) for that device returns a
+> `DeviceError::AlreadyInitialized` error instead of silently changing (or ignoring) the width.
+
+Because the default width is a per-device property, you cannot have two different default float widths
+active on the same device within a single process. If you need values at more than one precision, set
+the default once up front and create the other tensors with an explicit dtype instead, using
+[`cast`](https://docs.rs/burn/latest/burn/tensor/struct.Tensor.html#method.cast):
+
+```rust, ignore
+// device defaults to f32
+let x = Tensor::<Backend, 2>::zeros([2, 3], &device); // f32
+let x_f64 = x.cast(FloatDType::F64);                  // explicit f64
+```
+
 Burn Tensors are defined by the number of dimensions D in its declaration as opposed to its shape.
 The actual shape of the tensor is inferred from its initialization. For example, a Tensor of size
 (5,) is initialized as below:

--- a/crates/burn-std/src/device_settings.rs
+++ b/crates/burn-std/src/device_settings.rs
@@ -70,7 +70,12 @@ pub enum DeviceError {
         dtype: DType,
     },
     /// Device settings have already been initialized.
-    #[error("Device {device} settings have already been initialized")]
+    #[error(
+        "Device {device} settings have already been initialized and cannot be changed.\n\
+         Default data types lock on the first tensor operation for a device (or on a previous \
+         `set_default_dtypes`/`configure` call). Configure the device before creating any tensor \
+         on it, or create tensors with an explicit dtype instead."
+    )]
     AlreadyInitialized {
         /// The string representation of the device.
         device: String,


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

> Note: `cargo run-checks` was not run here — the workspace requires rustc 1.95 and the two changed
> crates were checked individually (`cargo check -p burn-std` passes). Docs-only book change plus a
> single error-message string; happy to run full checks on request.

### Related Issues/PRs

- Addresses tracel-ai/burn#5192 — `NdArray<f64>` silently produced F32 tensors after any
  `NdArray<f32>` use on the same device (device dtype locked on first use).

### Changes

Follow-up to the maintainer note on #5192: the mixed-width footgun came from backends' *default
associated element types*, which were removed in #5000. On `main` the float width is now a runtime,
**per-device** setting held in a global registry that locks on first use — so the original silent
mismatch is structurally gone, and configuring a device after it is locked already returns
`DeviceError::AlreadyInitialized` (the issue's "preferred" fix). What was missing was documentation
of the new semantics and a helpful error message.

- **Book (`building-blocks/tensor.md`)**: new **Data types** section explaining that the element type
  is not part of the `Tensor` type but a per-device default. Covers inspecting defaults
  (`Device::settings`), changing them (`Device::configure` / `set_default_dtypes`) *before* the first
  tensor op, the "lock on first use" semantics, and how to work with more than one precision via
  explicit per-tensor `cast` (rather than expecting two default float widths on one device).
- **`DeviceError::AlreadyInitialized`**: the message now explains that defaults lock on the first
  tensor operation and how to avoid it, instead of only stating that settings were already
  initialized.

This implements the issue's "minimum" ask (document that the width becomes non-authoritative /
mixed-width backends cannot coexist) on the current design, and sharpens the error users hit when
they configure a device too late.

### Testing

- `cargo check -p burn-std` passes (with rustc 1.95, required by the workspace).
- Book change is documentation only; all code snippets are `rust, ignore` and mirror real API usage
  in the codebase (e.g. `tensor.cast(FloatDType::F64)` per `burn-tensor` doctests).
- Existing `device` registry tests already assert the `AlreadyInitialized` variant is returned; the
  change only edits the human-readable message string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oxLsZydYJrw3AWBePecc2

---
_Generated by [Claude Code](https://claude.ai/code/session_015oxLsZydYJrw3AWBePecc2)_
