### PR TITLE
feat: support negative cumulative dimensions

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/float/ops/cumulative.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/cumulative.rs
@@ -27,6 +27,18 @@ fn test_cumsum_float_dim_1() {
 }
 
 #[test]
+fn test_cumsum_float_negative_dim() {
+    let tensor = TestTensor::<2>::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+
+    let output = tensor.cumsum(-1);
+
+    output.into_data().assert_eq(
+        &TensorData::from([[1.0, 3.0, 6.0], [4.0, 9.0, 15.0]]),
+        false,
+    );
+}
+
+#[test]
 fn test_cumsum_non_contiguous() {
     let tensor = TestTensor::<2>::from([[1., 2.], [3., 4.]]).swap_dims(0, 1);
 
@@ -74,6 +86,18 @@ fn test_cumprod_float_dim_1() {
 }
 
 #[test]
+fn test_cumprod_float_negative_dim() {
+    let tensor = TestTensor::<2>::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+
+    let output = tensor.cumprod(-1);
+
+    output.into_data().assert_eq(
+        &TensorData::from([[1.0, 2.0, 6.0], [4.0, 20.0, 120.0]]),
+        false,
+    );
+}
+
+#[test]
 fn test_cumprod_float_3d() {
     let tensor = TestTensor::<3>::from([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]);
 
@@ -108,6 +132,17 @@ fn test_cummin_float_dim_1() {
 }
 
 #[test]
+fn test_cummin_float_negative_dim() {
+    let tensor = TestTensor::<2>::from([[3.0, 1.0, 4.0], [2.0, 5.0, 1.0]]);
+
+    let output = tensor.cummin(-1);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([[3.0, 1.0, 1.0], [2.0, 2.0, 1.0]]), false);
+}
+
+#[test]
 fn test_cummin_float_3d() {
     let tensor = TestTensor::<3>::from([[[4.0, 2.0], [3.0, 1.0]], [[5.0, 6.0], [7.0, 8.0]]]);
 
@@ -135,6 +170,17 @@ fn test_cummax_float_dim_1() {
     let tensor = TestTensor::<2>::from([[3.0, 1.0, 4.0], [1.0, 5.0, 2.0]]);
 
     let output = tensor.cummax(1);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([[3.0, 3.0, 4.0], [1.0, 5.0, 5.0]]), false);
+}
+
+#[test]
+fn test_cummax_float_negative_dim() {
+    let tensor = TestTensor::<2>::from([[3.0, 1.0, 4.0], [1.0, 5.0, 2.0]]);
+
+    let output = tensor.cummax(-1);
 
     output
         .into_data()

--- a/crates/burn-backend-tests/tests/tensor/int/ops/cumulative.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/cumulative.rs
@@ -24,6 +24,17 @@ fn test_cumsum_int_dim_1() {
 }
 
 #[test]
+fn test_cumsum_int_negative_dim() {
+    let tensor = TestTensorInt::<2>::from([[1, 2, 3], [4, 5, 6]]);
+
+    let output = tensor.cumsum(-1);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([[1, 3, 6], [4, 9, 15]]), false);
+}
+
+#[test]
 fn test_cumprod_int_dim_0() {
     let tensor = TestTensorInt::<2>::from([[1, 2, 3], [4, 5, 6]]);
 
@@ -39,6 +50,17 @@ fn test_cumprod_int_dim_1() {
     let tensor = TestTensorInt::<2>::from([[1, 2, 3], [4, 5, 6]]);
 
     let output = tensor.cumprod(1);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([[1, 2, 6], [4, 20, 120]]), false);
+}
+
+#[test]
+fn test_cumprod_int_negative_dim() {
+    let tensor = TestTensorInt::<2>::from([[1, 2, 3], [4, 5, 6]]);
+
+    let output = tensor.cumprod(-1);
 
     output
         .into_data()
@@ -68,6 +90,17 @@ fn test_cummin_int_dim_1() {
 }
 
 #[test]
+fn test_cummin_int_negative_dim() {
+    let tensor = TestTensorInt::<2>::from([[3, 1, 4], [2, 5, 1]]);
+
+    let output = tensor.cummin(-1);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([[3, 1, 1], [2, 2, 1]]), false);
+}
+
+#[test]
 fn test_cummax_int_dim_0() {
     let tensor = TestTensorInt::<2>::from([[3, 1, 4], [1, 5, 2]]);
 
@@ -83,6 +116,17 @@ fn test_cummax_int_dim_1() {
     let tensor = TestTensorInt::<2>::from([[3, 1, 4], [1, 5, 2]]);
 
     let output = tensor.cummax(1);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([[3, 3, 4], [1, 5, 5]]), false);
+}
+
+#[test]
+fn test_cummax_int_negative_dim() {
+    let tensor = TestTensorInt::<2>::from([[3, 1, 4], [1, 5, 2]]);
+
+    let output = tensor.cummax(-1);
 
     output
         .into_data()

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -589,7 +589,8 @@ where
     ///
     /// # Arguments
     ///
-    /// * `dim` - The dimension or axis along which to compute the cumulative sum.
+    /// * `dim` - The dimension or axis along which to compute the cumulative sum;
+    ///   supports negative indexing.
     ///
     /// # Example
     ///
@@ -607,7 +608,8 @@ where
     ///    // [[1.0, 3.0, 6.0], [4.0, 9.0, 15.0]]
     /// }
     /// ```
-    pub fn cumsum(self, dim: usize) -> Self {
+    pub fn cumsum<I: AsIndex>(self, dim: I) -> Self {
+        let dim = dim.expect_dim_index(D);
         check!(TensorCheck::aggregate_dim::<D>("CumSum", dim));
         Self::new(K::cumsum(self.primitive, dim))
     }
@@ -616,7 +618,8 @@ where
     ///
     /// # Arguments
     ///
-    /// * `dim` - The dimension or axis along which to compute the cumulative product.
+    /// * `dim` - The dimension or axis along which to compute the cumulative product;
+    ///   supports negative indexing.
     ///
     /// # Example
     ///
@@ -634,7 +637,8 @@ where
     ///    // [[1.0, 2.0, 6.0], [4.0, 20.0, 120.0]]
     /// }
     /// ```
-    pub fn cumprod(self, dim: usize) -> Self {
+    pub fn cumprod<I: AsIndex>(self, dim: I) -> Self {
+        let dim = dim.expect_dim_index(D);
         check!(TensorCheck::aggregate_dim::<D>("CumProd", dim));
         Self::new(K::cumprod(self.primitive, dim))
     }

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -589,8 +589,8 @@ where
     ///
     /// # Arguments
     ///
-    /// * `dim` - The dimension or axis along which to compute the cumulative sum;
-    ///   supports negative indexing.
+    /// * `dim` - The dimension or axis along which to compute the cumulative sum.
+    ///   Negative dimensions are supported and count from the end.
     ///
     /// # Example
     ///
@@ -618,8 +618,8 @@ where
     ///
     /// # Arguments
     ///
-    /// * `dim` - The dimension or axis along which to compute the cumulative product;
-    ///   supports negative indexing.
+    /// * `dim` - The dimension or axis along which to compute the cumulative product.
+    ///   Negative dimensions are supported and count from the end.
     ///
     /// # Example
     ///

--- a/crates/burn-tensor/src/tensor/api/orderable.rs
+++ b/crates/burn-tensor/src/tensor/api/orderable.rs
@@ -1017,7 +1017,8 @@ where
     ///
     /// # Arguments
     ///
-    /// * `dim` - The dimension or axis along which to compute the cumulative minimum.
+    /// * `dim` - The dimension or axis along which to compute the cumulative minimum;
+    ///   supports negative indexing.
     ///
     /// # Example
     ///
@@ -1035,7 +1036,8 @@ where
     ///    // [[3.0, 3.0, 2.0], [4.0, 1.0, 1.0]]
     /// }
     /// ```
-    pub fn cummin(self, dim: usize) -> Self {
+    pub fn cummin<I: AsIndex>(self, dim: I) -> Self {
+        let dim = dim.expect_dim_index(D);
         check!(TensorCheck::aggregate_dim::<D>("CumMin", dim));
         Self::new(K::cummin(self.primitive, dim))
     }
@@ -1044,7 +1046,8 @@ where
     ///
     /// # Arguments
     ///
-    /// * `dim` - The dimension or axis along which to compute the cumulative maximum.
+    /// * `dim` - The dimension or axis along which to compute the cumulative maximum;
+    ///   supports negative indexing.
     ///
     /// # Example
     ///
@@ -1062,7 +1065,8 @@ where
     ///    // [[3.0, 3.0, 3.0], [4.0, 5.0, 5.0]]
     /// }
     /// ```
-    pub fn cummax(self, dim: usize) -> Self {
+    pub fn cummax<I: AsIndex>(self, dim: I) -> Self {
+        let dim = dim.expect_dim_index(D);
         check!(TensorCheck::aggregate_dim::<D>("CumMax", dim));
         Self::new(K::cummax(self.primitive, dim))
     }

--- a/crates/burn-tensor/src/tensor/api/orderable.rs
+++ b/crates/burn-tensor/src/tensor/api/orderable.rs
@@ -1017,8 +1017,8 @@ where
     ///
     /// # Arguments
     ///
-    /// * `dim` - The dimension or axis along which to compute the cumulative minimum;
-    ///   supports negative indexing.
+    /// * `dim` - The dimension or axis along which to compute the cumulative minimum.
+    ///   Negative dimensions are supported and count from the end.
     ///
     /// # Example
     ///
@@ -1046,8 +1046,8 @@ where
     ///
     /// # Arguments
     ///
-    /// * `dim` - The dimension or axis along which to compute the cumulative maximum;
-    ///   supports negative indexing.
+    /// * `dim` - The dimension or axis along which to compute the cumulative maximum.
+    ///   Negative dimensions are supported and count from the end.
     ///
     /// # Example
     ///


### PR DESCRIPTION
## Motivation
Burn supports negative dimension indexing across several tensor APIs, but cumulative operations still required unsigned dimensions. This prevented common calls such as cumsum(-1) even though the backend only needs a resolved positive axis.

## Modifications
- Changed cumsum, cumprod, cummin, and cummax to accept AsIndex dimensions.
- Resolve negative dimensions before validation and backend dispatch.
- Documented negative indexing support.
- Added float and integer regression tests for dim = -1.