### PR TITLE
feat: support negative FFT dimensions

### DIFF
--- a/crates/burn-backend-tests/tests/cubecl/fft.rs
+++ b/crates/burn-backend-tests/tests/cubecl/fft.rs
@@ -126,6 +126,21 @@ fn rfft_dim1_2d_tensor_distinct_rows() {
 }
 
 #[test]
+fn rfft_negative_dim_matches_positive_dim() {
+    let signal = TestTensor::<2>::from([[1.0, 2.0, 3.0, 4.0], [0.0, 1.0, 0.0, -1.0]]);
+
+    let (expected_re, expected_im) = rfft(signal.clone(), 1, None);
+    let (actual_re, actual_im) = rfft(signal, -1, None);
+
+    actual_re
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected_re.into_data(), Tolerance::absolute(1e-4));
+    actual_im
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected_im.into_data(), Tolerance::absolute(1e-4));
+}
+
+#[test]
 fn rfft_dim0_2d_tensor() {
     let signal = TestTensor::<2>::from([
         [0.0, 0.0],
@@ -271,6 +286,19 @@ fn irfft_dim1_2d_tensor_distinct_rows() {
     signal
         .into_data()
         .assert_approx_eq::<FloatElem>(&expected, Tolerance::absolute(1e-3));
+}
+
+#[test]
+fn irfft_negative_dim_matches_positive_dim() {
+    let spectrum_re = TestTensor::<2>::from([[10.0, -2.0, -2.0], [0.0, 0.0, 0.0]]);
+    let spectrum_im = TestTensor::<2>::from([[0.0, 2.0, 0.0], [0.0, -2.0, 0.0]]);
+
+    let expected = irfft(spectrum_re.clone(), spectrum_im.clone(), 1, None);
+    let actual = irfft(spectrum_re, spectrum_im, -1, None);
+
+    actual
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected.into_data(), Tolerance::absolute(1e-4));
 }
 
 #[test]
@@ -593,6 +621,22 @@ fn cfft_dim1_2d_tensor() {
     cfft_im
         .into_data()
         .assert_approx_eq::<FloatElem>(&expected_im, Tolerance::absolute(1e-3));
+}
+
+#[test]
+fn cfft_negative_dim_matches_positive_dim() {
+    let re = TestTensor::<2>::from([[1.0, 2.0, 3.0, 4.0], [1.0, 0.0, -1.0, 0.0]]);
+    let im = TestTensor::<2>::from([[0.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, -1.0]]);
+
+    let (expected_re, expected_im) = cfft(re.clone(), im.clone(), 1, None);
+    let (actual_re, actual_im) = cfft(re, im, -1, None);
+
+    actual_re
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected_re.into_data(), Tolerance::absolute(1e-4));
+    actual_im
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected_im.into_data(), Tolerance::absolute(1e-4));
 }
 
 #[test]

--- a/crates/burn-tensor/src/tensor/signal/fft.rs
+++ b/crates/burn-tensor/src/tensor/signal/fft.rs
@@ -2,10 +2,10 @@ use alloc::vec;
 use burn_backend::ops::ModuleOps;
 use burn_dispatch::Dispatch;
 
-use crate::Tensor;
 use crate::check;
 use crate::check::TensorCheck;
 use crate::ops::BridgeTensor;
+use crate::{AsIndex, Tensor};
 
 /// Computes the 1-dimensional discrete Fourier Transform of real-valued input.
 ///
@@ -29,6 +29,7 @@ where $N$ is the size of the signal along the specified dimension.
 ///
 /// * `signal` - The input tensor containing the real-valued signal.
 /// * `dim` - The dimension along which to take the FFT.
+///   Negative dimensions are supported and count from the end.
 /// * `n` - Optional FFT length. When `None`, the signal must be a power of two along `dim`.
 ///   When `Some(n)`, `n` must also be a power of two; the signal is truncated or zero-padded
 ///   to length `n`. Non-power-of-two `n` is rejected with a panic (true arbitrary-size DFT
@@ -54,9 +55,10 @@ where $N$ is the size of the signal along the specified dimension.
 /// ```
 pub fn rfft<const D: usize>(
     signal: Tensor<D>,
-    dim: usize,
+    dim: impl AsIndex,
     n: Option<usize>,
 ) -> (Tensor<D>, Tensor<D>) {
+    let dim = dim.expect_dim_index(D);
     check!(TensorCheck::check_dim::<D>(dim));
 
     match n {
@@ -106,6 +108,7 @@ where $N$ is the size of the reconstructed signal.
 /// * `spectrum_re` - The real part of the spectrum.
 /// * `spectrum_im` - The imaginary part of the spectrum.
 /// * `dim` - The dimension along which to take the inverse FFT.
+///   Negative dimensions are supported and count from the end.
 /// * `n` - Optional output signal length. When `None`, the reconstructed signal length
 ///   `2 * (size - 1)` must be a power of two. When `Some(n)`, `n` must also be a power of
 ///   two and the output has exactly `n` samples. Non-power-of-two `n` is rejected.
@@ -129,9 +132,10 @@ where $N$ is the size of the reconstructed signal.
 pub fn irfft<const D: usize>(
     spectrum_re: Tensor<D>,
     spectrum_im: Tensor<D>,
-    dim: usize,
+    dim: impl AsIndex,
     n: Option<usize>,
 ) -> Tensor<D> {
+    let dim = dim.expect_dim_index(D);
     check!(TensorCheck::check_dim::<D>(dim));
 
     if let Some(n) = n {
@@ -192,6 +196,7 @@ Since $x_{re}\[n\]$ and $x_{im}\[n\]$ are purely real, their transforms can be c
 /// * `signal_im` - The imaginary part of the complex input signal. Must have the
 ///   same shape as `signal_re`.
 /// * `dim` - The dimension along which to take the FFT.
+///   Negative dimensions are supported and count from the end.
 /// * `n` - Optional FFT length. When `None`, the signal must be a power of two
 ///   along `dim`. When `Some(n)`, `n` must also be a power of two; the signal is
 ///   truncated or zero-padded to length `n`.
@@ -216,7 +221,7 @@ Since $x_{re}\[n\]$ and $x_{im}\[n\]$ are purely real, their transforms can be c
 pub fn cfft<const D: usize>(
     signal_re: Tensor<D>,
     signal_im: Tensor<D>,
-    dim: usize,
+    dim: impl AsIndex,
     n: Option<usize>,
 ) -> (Tensor<D>, Tensor<D>) {
     assert!(
@@ -227,6 +232,7 @@ pub fn cfft<const D: usize>(
         signal_im.shape(),
     );
 
+    let dim = dim.expect_dim_index(D);
     check!(TensorCheck::check_dim::<D>(dim));
     let fft_size = n.unwrap_or(signal_re.dims()[dim]);
 


### PR DESCRIPTION
## Motivation

Burn tensor APIs increasingly support negative dimension indexing, but the public FFT helpers still required usize dimensions. This prevented common calls such as dim = -1 even though the backend only needs a resolved positive axis.

## Modifications

- Changed signal::rfft, signal::irfft, and signal::cfft to accept AsIndex dimensions.
- Resolve dimensions before validation, shape access, and backend dispatch.
- Document negative dimension support using the convention from PR #5205.
- Added CPU backend regression tests comparing dim = -1 with the equivalent positive dimension.

## Testing

- cargo fmt --all -- --check
- cargo +nightly check -p burn-tensor
- cargo +stable test -p burn-backend-tests --test cubecl --features cpu negative_dim_matches_positive_dim -- --nocapture (3 passed)