### PR TITLE
feat: support negative sort and top-k dimensions

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/float/ops/sort_argsort.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/sort_argsort.rs
@@ -214,3 +214,26 @@ fn test_sort_descending_1d() {
         .into_data()
         .assert_approx_eq::<FloatElem>(&values_expected, Tolerance::default());
 }
+
+#[test]
+fn test_sort_apis_support_negative_dims_float() {
+    let tensor = TestTensor::<2>::from([[3., 1., 5.], [2., 6., 4.]]);
+
+    let values = tensor.clone().sort(-1);
+    let values_expected = TensorData::from([[1., 3., 5.], [2., 4., 6.]]);
+    values
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&values_expected, Tolerance::default());
+
+    let (values, indices) = tensor.clone().sort_with_indices(-2);
+    let values_expected = TensorData::from([[2., 1., 4.], [3., 6., 5.]]);
+    values
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&values_expected, Tolerance::default());
+    let indices_expected = TensorData::from([[1, 0, 1], [0, 1, 0]]);
+    indices.into_data().assert_eq(&indices_expected, false);
+
+    let indices = tensor.argsort(-1);
+    let indices_expected = TensorData::from([[1, 0, 2], [0, 2, 1]]);
+    indices.into_data().assert_eq(&indices_expected, false);
+}

--- a/crates/burn-backend-tests/tests/tensor/float/ops/topk.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/topk.rs
@@ -19,3 +19,16 @@ fn test_topk_with_indices_3d() {
 
     indices.into_data().assert_eq(&indices_expected, false);
 }
+
+#[test]
+fn test_topk_supports_negative_dim_float() {
+    let tensor =
+        TestTensor::<3>::from([[[1., 4., 7.], [2., 5., 6.]], [[3., 0., 9.], [8., 2., 7.]]]);
+
+    let values = tensor.topk(2, -1);
+    let values_expected = TensorData::from([[[7., 4.], [6., 5.]], [[9., 3.], [8., 7.]]]);
+
+    values
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&values_expected, Tolerance::default());
+}

--- a/crates/burn-backend-tests/tests/tensor/int/ops/sort_argsort.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/sort_argsort.rs
@@ -151,3 +151,22 @@ fn test_sort_descending_1d() {
     let values_expected = TensorData::from([5, 4, 3, 2, 1]);
     values.into_data().assert_eq(&values_expected, false);
 }
+
+#[test]
+fn test_sort_apis_support_negative_dims_int() {
+    let tensor = TestTensorInt::<2>::from([[3, 1, 5], [2, 6, 4]]);
+
+    let values = tensor.clone().sort_descending(-1);
+    let values_expected = TensorData::from([[5, 3, 1], [6, 4, 2]]);
+    values.into_data().assert_eq(&values_expected, false);
+
+    let (values, indices) = tensor.clone().sort_descending_with_indices(-2);
+    let values_expected = TensorData::from([[3, 6, 5], [2, 1, 4]]);
+    values.into_data().assert_eq(&values_expected, false);
+    let indices_expected = TensorData::from([[0, 1, 0], [1, 0, 1]]);
+    indices.into_data().assert_eq(&indices_expected, false);
+
+    let indices = tensor.argsort_descending(-1);
+    let indices_expected = TensorData::from([[2, 0, 1], [1, 2, 0]]);
+    indices.into_data().assert_eq(&indices_expected, false);
+}

--- a/crates/burn-backend-tests/tests/tensor/int/ops/topk.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/topk.rs
@@ -56,3 +56,15 @@ fn test_topk() {
         .into_data()
         .assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
 }
+
+#[test]
+fn test_topk_with_indices_supports_negative_dim_int() {
+    let tensor = TestTensorInt::<3>::from([[[1, 4, 7], [2, 5, 6]], [[3, 0, 9], [8, 2, 7]]]);
+
+    let (values, indices) = tensor.topk_with_indices(2, -1);
+    let values_expected = TensorData::from([[[7, 4], [6, 5]], [[9, 3], [8, 7]]]);
+    values.into_data().assert_eq(&values_expected, false);
+
+    let indices_expected = TensorData::from([[[2, 1], [2, 1]], [[2, 0], [0, 2]]]);
+    indices.into_data().assert_eq(&indices_expected, false);
+}

--- a/crates/burn-tensor/src/tensor/api/orderable.rs
+++ b/crates/burn-tensor/src/tensor/api/orderable.rs
@@ -16,6 +16,7 @@ where
     /// # Arguments
     ///
     /// * `dim` - The dimension to sort along.
+    ///   Negative dimensions are supported and count from the end.
     ///
     /// # Returns
     ///
@@ -37,7 +38,8 @@ where
     ///   // [[-2.0, 3.0, 12.0], [3.0, 5.0, 6.0]]
     /// }
     /// ```
-    pub fn sort(self, dim: usize) -> Self {
+    pub fn sort<I: AsIndex>(self, dim: I) -> Self {
+        let dim = dim.expect_dim_index(D);
         check!(TensorCheck::sort_dim::<D>("Sort", dim));
         Tensor::new(K::sort(self.primitive, dim, /*descending*/ false))
     }
@@ -49,6 +51,7 @@ where
     /// # Arguments
     ///
     /// * `dim` - The dimension to sort along.
+    ///   Negative dimensions are supported and count from the end.
     ///
     /// # Returns
     ///
@@ -70,7 +73,8 @@ where
     ///    // [[12.0, 3.0, -2.0], [6.0, 5.0, 3.0]]
     /// }
     /// ```
-    pub fn sort_descending(self, dim: usize) -> Self {
+    pub fn sort_descending<I: AsIndex>(self, dim: I) -> Self {
+        let dim = dim.expect_dim_index(D);
         check!(TensorCheck::sort_dim::<D>("Sort", dim));
         Tensor::new(K::sort(self.primitive, dim, /*descending*/ true))
     }
@@ -83,6 +87,7 @@ where
     /// # Arguments
     ///
     /// * `dim` - The dimension to sort along.
+    ///   Negative dimensions are supported and count from the end.
     ///
     /// # Returns
     ///
@@ -103,7 +108,8 @@ where
     ///   // [[1, 0, 0], [0, 1, 1]]
     /// }
     /// ```
-    pub fn sort_with_indices(self, dim: usize) -> (Self, Tensor<D, Int>) {
+    pub fn sort_with_indices<I: AsIndex>(self, dim: I) -> (Self, Tensor<D, Int>) {
+        let dim = dim.expect_dim_index(D);
         check!(TensorCheck::sort_dim::<D>("Sort_with_indices", dim));
         let (values, indices) =
             K::sort_with_indices(self.primitive, dim, /*descending*/ false);
@@ -118,6 +124,7 @@ where
     /// # Arguments
     ///
     /// * `dim` - The dimension to sort along.
+    ///   Negative dimensions are supported and count from the end.
     ///
     /// # Example
     ///
@@ -134,7 +141,8 @@ where
     ///    // [[0, 1, 1], [1, 0, 0]]
     /// }
     /// ```
-    pub fn sort_descending_with_indices(self, dim: usize) -> (Self, Tensor<D, Int>) {
+    pub fn sort_descending_with_indices<I: AsIndex>(self, dim: I) -> (Self, Tensor<D, Int>) {
+        let dim = dim.expect_dim_index(D);
         check!(TensorCheck::sort_dim::<D>("Sort_with_indices", dim));
         let (values, indices) = K::sort_with_indices(self.primitive, dim, /*descending*/ true);
         (Tensor::new(values), Tensor::new(indices))
@@ -147,6 +155,7 @@ where
     /// # Arguments
     ///
     /// * `dim` - The dimension to sort along.
+    ///   Negative dimensions are supported and count from the end.
     ///
     /// # Example
     ///
@@ -161,7 +170,8 @@ where
     ///    // [[1, 0, 0], [0, 1, 1]]
     /// }
     /// ```
-    pub fn argsort(self, dim: usize) -> Tensor<D, Int> {
+    pub fn argsort<I: AsIndex>(self, dim: I) -> Tensor<D, Int> {
+        let dim = dim.expect_dim_index(D);
         check!(TensorCheck::sort_dim::<D>("Argsort", dim));
         Tensor::new(K::argsort(self.primitive, dim, /*descending*/ false))
     }
@@ -173,6 +183,7 @@ where
     /// # Arguments
     ///
     /// * `dim` - The dimension to sort along.
+    ///   Negative dimensions are supported and count from the end.
     ///
     /// # Example
     ///
@@ -190,7 +201,8 @@ where
     ///    // [[0, 2, 1], [2, 0, 1]]
     /// }
     /// ```
-    pub fn argsort_descending(self, dim: usize) -> Tensor<D, Int> {
+    pub fn argsort_descending<I: AsIndex>(self, dim: I) -> Tensor<D, Int> {
+        let dim = dim.expect_dim_index(D);
         check!(TensorCheck::sort_dim::<D>("Argsort", dim));
         Tensor::new(K::argsort(self.primitive, dim, /*descending*/ true))
     }
@@ -200,6 +212,8 @@ where
     /// # Arguments
     ///
     /// * `k` - The number of elements to return.
+    /// * `dim` - The dimension to sort along.
+    ///   Negative dimensions are supported and count from the end.
     ///
     /// # Returns
     ///
@@ -221,7 +235,8 @@ where
     ///   // [[12.0], [6.0]]
     /// }
     /// ```
-    pub fn topk(self, k: usize, dim: usize) -> Self {
+    pub fn topk<I: AsIndex>(self, k: usize, dim: I) -> Self {
+        let dim = dim.expect_dim_index(D);
         assert!(self.shape()[dim] > k);
         Tensor::new(K::topk(self.primitive, dim, k))
     }
@@ -233,6 +248,7 @@ where
     ///
     /// * `k` - The number of elements to return.
     /// * `dim` - The dimension to sort along.
+    ///   Negative dimensions are supported and count from the end.
     ///
     /// # Example
     ///
@@ -254,7 +270,8 @@ where
     ///    // [[0], [2]]
     /// }
     /// ```
-    pub fn topk_with_indices(self, k: usize, dim: usize) -> (Self, Tensor<D, Int>) {
+    pub fn topk_with_indices<I: AsIndex>(self, k: usize, dim: I) -> (Self, Tensor<D, Int>) {
+        let dim = dim.expect_dim_index(D);
         let (values, indices) = K::topk_with_indices(self.primitive, dim, k);
         (Tensor::new(values), Tensor::new(indices))
     }


### PR DESCRIPTION
## Motivation

Burn tensor APIs increasingly support negative dimension indexing, but sort and top-k operations still required usize dimensions. This made common last-axis calls such as dim = -1 inconsistent with the rest of the public tensor API.

## Modifications

- Changed sort, descending sort, indexed sort, argsort, topk, and topk_with_indices public APIs to accept AsIndex dimensions.
- Resolve each dimension once before existing validation and usize backend calls.
- Added float and integer regression coverage across all eight APIs.