### PR TITLE
feat: support negative dimensions for statistics and losses

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/float/stats/cov.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/stats/cov.rs
@@ -64,3 +64,15 @@ fn test_cov_3() {
     let data_expected = TestTensor::<3>::zeros([4, 4, 4], &device).to_data();
     data_expected.assert_approx_eq::<FloatElem>(&data_actual, Tolerance::default());
 }
+
+#[test]
+fn test_cov_negative_dim() {
+    let data = TensorData::from([[0.5, 1.8, 0.2, -2.0], [3.0, -4.0, 5.0, 0.0]]);
+    let tensor = TestTensor::<2>::from_data(data, &Default::default());
+
+    let expected = tensor.clone().cov(1, 1).into_data();
+    tensor
+        .cov(-1, 1)
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
+}

--- a/crates/burn-backend-tests/tests/tensor/float/stats/median.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/stats/median.rs
@@ -90,3 +90,25 @@ fn test_median_all_elements() {
         .into_data()
         .assert_eq(&TensorData::from([0.5]), false);
 }
+
+#[test]
+fn test_median_negative_dim() {
+    let tensor =
+        TestTensor::<2>::from_data([[5.0, 1.0, 3.0], [2.0, 8.0, 4.0]], &Default::default());
+
+    let median = tensor.clone().median(1).into_data();
+    tensor
+        .clone()
+        .median(-1)
+        .into_data()
+        .assert_eq(&median, false);
+
+    let (values, indices) = tensor.clone().median_with_indices(1);
+    let (values_negative, indices_negative) = tensor.median_with_indices(-1);
+    values_negative
+        .into_data()
+        .assert_eq(&values.into_data(), false);
+    indices_negative
+        .into_data()
+        .assert_eq(&indices.into_data(), false);
+}

--- a/crates/burn-backend-tests/tests/tensor/float/stats/var.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/stats/var.rs
@@ -67,3 +67,43 @@ fn test_var_mean_bias() {
     mean.into_data()
         .assert_approx_eq::<FloatElem>(&mean_expected, Tolerance::default());
 }
+
+#[test]
+fn test_variance_negative_dim() {
+    let tensor = TestTensor::<2>::from_data(
+        [[0.5, 1.8, 0.2, -2.0], [3.0, -4.0, 5.0, 0.0]],
+        &Default::default(),
+    );
+
+    let var = tensor.clone().var(1).into_data();
+    tensor
+        .clone()
+        .var(-1)
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&var, Tolerance::default());
+
+    let var_bias = tensor.clone().var_bias(1).into_data();
+    tensor
+        .clone()
+        .var_bias(-1)
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&var_bias, Tolerance::default());
+
+    let (var, mean) = tensor.clone().var_mean(1);
+    let (var_negative, mean_negative) = tensor.clone().var_mean(-1);
+    var_negative
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&var.into_data(), Tolerance::default());
+    mean_negative
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&mean.into_data(), Tolerance::default());
+
+    let (var, mean) = tensor.clone().var_mean_bias(1);
+    let (var_negative, mean_negative) = tensor.var_mean_bias(-1);
+    var_negative
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&var.into_data(), Tolerance::default());
+    mean_negative
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&mean.into_data(), Tolerance::default());
+}

--- a/crates/burn-nn/src/loss/lp_loss.rs
+++ b/crates/burn-nn/src/loss/lp_loss.rs
@@ -1,7 +1,7 @@
 use super::Reduction;
 use burn::config::Config;
 use burn::module::Module;
-use burn::tensor::Tensor;
+use burn::tensor::{AsIndex, Tensor};
 use burn_core as burn;
 
 /// Configuration for the [Lp Loss](LpLoss) module.
@@ -202,6 +202,7 @@ impl LpLoss {
     /// * `predictions` - The model's predicted values.
     /// * `targets` - The ground truth target values.
     /// * `dims` - Dimensions to reduce over.
+    ///   Negative dimensions are supported and count from the end.
     ///
     /// # Returns
     ///
@@ -216,16 +217,19 @@ impl LpLoss {
     /// // Per-image MSE for PSNR: reduce over C, H, W → [batch, 1, 1, 1]
     /// let mse_per_image = l2_loss.forward_reduce_dims(predictions, targets, &[1, 2, 3]);
     /// ```
-    pub fn forward_reduce_dims<const D: usize>(
+    pub fn forward_reduce_dims<const D: usize, I: AsIndex>(
         &self,
         predictions: Tensor<D>,
         targets: Tensor<D>,
-        dims: &[usize],
+        dims: &[I],
     ) -> Tensor<D> {
         let error = self.forward_no_reduction(predictions, targets);
 
-        // Sort the dimensions to ascending order
-        let mut sorted_dims = dims.to_vec();
+        // Normalize and sort the dimensions to ascending order.
+        let mut sorted_dims = dims
+            .iter()
+            .map(|dim| dim.expect_dim_index(D))
+            .collect::<Vec<_>>();
         sorted_dims.sort();
 
         // Reduce over specified dimensions
@@ -608,7 +612,7 @@ mod tests {
         let targets = Tensor::<2>::from_data(TensorData::from([[0.0, 2.0], [3.0, 6.0]]), &device);
         let loss_func = LpLossConfig::l2();
         let loss_reduce_dims =
-            loss_func.forward_reduce_dims(predictions.clone(), targets.clone(), &[]);
+            loss_func.forward_reduce_dims(predictions.clone(), targets.clone(), &[] as &[usize]);
         let loss_no_reduction = loss_func.forward_no_reduction(predictions, targets);
 
         // Should be equivalent
@@ -632,5 +636,23 @@ mod tests {
         // All zeros, reduced to shape: [2, 1, 1]
         let expected = TensorData::from([[[0.0]], [[0.0]]]);
         loss.into_data().assert_eq(&expected, false);
+    }
+
+    #[test]
+    fn test_forward_reduce_dims_negative_dims() {
+        let device = Default::default();
+        let predictions = Tensor::<3>::from_data(
+            TensorData::from([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]),
+            &device,
+        );
+        let targets = Tensor::<3>::zeros([2, 2, 2], &device);
+        let loss_func = LpLossConfig::l2();
+
+        let expected = loss_func.forward_reduce_dims(predictions.clone(), targets.clone(), &[1, 2]);
+        let output = loss_func.forward_reduce_dims(predictions, targets, &[-2, -1]);
+
+        output
+            .into_data()
+            .assert_approx_eq::<FT>(&expected.into_data(), Tolerance::default());
     }
 }

--- a/crates/burn-nn/src/loss/smooth_l1.rs
+++ b/crates/burn-nn/src/loss/smooth_l1.rs
@@ -1,7 +1,7 @@
 use super::Reduction;
 use burn::config::Config;
 use burn::module::Module;
-use burn::tensor::Tensor;
+use burn::tensor::{AsIndex, Tensor};
 use burn_core as burn;
 
 /// Configuration for the [SmoothL1Loss](SmoothL1Loss) module.
@@ -179,6 +179,7 @@ impl SmoothL1Loss {
     /// - `predictions` - The model's predicted values.
     /// - `targets` - The ground truth target values.
     /// - `dims` - Dimensions to reduce over.
+    ///   Negative dimensions are supported and count from the end.
     ///
     /// # Returns
     ///
@@ -193,16 +194,19 @@ impl SmoothL1Loss {
     /// // Per-image loss: reduce over C, H, W → [batch, 1, 1, 1]
     /// let loss_per_image = smooth_l1.forward_reduce_dims(predictions, targets, &[1, 2, 3]);
     /// ```
-    pub fn forward_reduce_dims<const D: usize>(
+    pub fn forward_reduce_dims<const D: usize, I: AsIndex>(
         &self,
         predictions: Tensor<D>,
         targets: Tensor<D>,
-        dims: &[usize],
+        dims: &[I],
     ) -> Tensor<D> {
         let error = self.forward(predictions, targets);
 
-        // Sort the dimensions to ascending order
-        let mut sorted_dims = dims.to_vec();
+        // Normalize and sort the dimensions to ascending order.
+        let mut sorted_dims = dims
+            .iter()
+            .map(|dim| dim.expect_dim_index(D))
+            .collect::<Vec<_>>();
         sorted_dims.sort();
 
         // Reduce over specified dimensions
@@ -491,11 +495,30 @@ mod tests {
             Tensor::<2>::from_data(TensorData::from([[0.5_f32, 2.0], [0.0, 3.0]]), &device);
         let targets = Tensor::<2>::zeros([2, 2], &device);
 
-        let loss_reduce_dims = loss.forward_reduce_dims(predictions.clone(), targets.clone(), &[]);
+        let loss_reduce_dims =
+            loss.forward_reduce_dims(predictions.clone(), targets.clone(), &[] as &[usize]);
         let loss_no_reduction = loss.forward(predictions, targets);
 
         loss_reduce_dims
             .into_data()
             .assert_eq(&loss_no_reduction.into_data(), false);
+    }
+
+    #[test]
+    fn test_smooth_l1_forward_reduce_dims_negative_dims() {
+        let device = Default::default();
+        let loss = SmoothL1LossConfig::new().init();
+        let predictions = Tensor::<3>::from_data(
+            TensorData::from([[[1.0_f32, 2.0], [3.0, 4.0]], [[5.0_f32, 6.0], [7.0, 8.0]]]),
+            &device,
+        );
+        let targets = Tensor::<3>::zeros([2, 2, 2], &device);
+
+        let expected = loss.forward_reduce_dims(predictions.clone(), targets.clone(), &[1, 2]);
+        let output = loss.forward_reduce_dims(predictions, targets, &[-2, -1]);
+
+        output
+            .into_data()
+            .assert_approx_eq::<FT>(&expected.into_data(), Tolerance::default());
     }
 }

--- a/crates/burn-tensor/src/tensor/api/float.rs
+++ b/crates/burn-tensor/src/tensor/api/float.rs
@@ -148,24 +148,36 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     }
 
     /// Calculate the variance along the given dimension.
-    pub fn var(self, dim: usize) -> Self {
+    ///
+    /// Negative dimensions are supported and count from the end.
+    pub fn var<I: AsIndex>(self, dim: I) -> Self {
+        let dim = dim.expect_dim_index(D);
         stats::var(self, dim)
     }
 
     /// Calculate the variance along the given dimension without applying the Bessel’s correction.
-    pub fn var_bias(self, dim: usize) -> Self {
+    ///
+    /// Negative dimensions are supported and count from the end.
+    pub fn var_bias<I: AsIndex>(self, dim: I) -> Self {
+        let dim = dim.expect_dim_index(D);
         stats::var_bias(self, dim)
     }
 
     /// Calculate the variance along the given dimension and also returns the mean.
-    pub fn var_mean(self, dim: usize) -> (Self, Self) {
+    ///
+    /// Negative dimensions are supported and count from the end.
+    pub fn var_mean<I: AsIndex>(self, dim: I) -> (Self, Self) {
+        let dim = dim.expect_dim_index(D);
         let mean = self.clone().mean_dim(dim);
         let var = stats::var_with_mean(self, mean.clone(), dim);
         (var, mean)
     }
 
     /// Calculate the variance along the given dimension without applying the Bessel’s correction and also returns the mean.
-    pub fn var_mean_bias(self, dim: usize) -> (Self, Self) {
+    ///
+    /// Negative dimensions are supported and count from the end.
+    pub fn var_mean_bias<I: AsIndex>(self, dim: I) -> (Self, Self) {
+        let dim = dim.expect_dim_index(D);
         let mean = self.clone().mean_dim(dim);
         let var = stats::var_with_mean_bias(self, mean.clone(), dim);
         (var, mean)
@@ -187,6 +199,7 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     /// # Arguments
     ///
     /// - `dim` - The dimension along which to compute the median.
+    ///   Negative dimensions are supported and count from the end.
     ///
     /// # Returns
     ///
@@ -224,7 +237,8 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     /// let median = flattened_tensor.median(0);
     /// // Result: [4.0]
     /// ```
-    pub fn median(self, dim: usize) -> Self {
+    pub fn median<I: AsIndex>(self, dim: I) -> Self {
+        let dim = dim.expect_dim_index(D);
         // TODO: Allow backend specialization. Optimally, implement a median kernel for cubecl
         // instead of leveraging a full sort to get the median.
         stats::median(self, dim)
@@ -246,6 +260,7 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     /// # Arguments
     ///
     /// - `dim` - The dimension along which to compute the median.
+    ///   Negative dimensions are supported and count from the end.
     ///
     /// # Returns
     ///
@@ -267,7 +282,8 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     /// let (values, indices) = tensor.median_with_indices(1);
     /// // values: [[2.0], [6.0]], indices: [[3], [2]] (position in the original tensor)
     /// ```
-    pub fn median_with_indices(self, dim: usize) -> (Self, Tensor<D, Int>) {
+    pub fn median_with_indices<I: AsIndex>(self, dim: I) -> (Self, Tensor<D, Int>) {
+        let dim = dim.expect_dim_index(D);
         // TODO: Allow backend specialization. Optimally, implement a median kernel for cubecl
         // instead of leveraging a full sort to get the median.
         stats::median_with_indices(self, dim)
@@ -339,9 +355,11 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     ///
     /// # Arguments
     ///
-    /// * `size` - The size of the square matrix.
+    /// * `dim` - The dimension along which to calculate the covariance.
+    ///   Negative dimensions are supported and count from the end.
     /// * `correction_factor` - Is usually 1 for samples and 0 for population.
-    pub fn cov(self, dim: usize, correction_factor: usize) -> Tensor<D> {
+    pub fn cov<I: AsIndex>(self, dim: I, correction_factor: usize) -> Tensor<D> {
+        let dim = dim.expect_dim_index(D);
         let n = self.dims()[dim];
         let centered = (self.clone() - self.mean_dim(dim)).swap_dims(dim, 0);
         centered


### PR DESCRIPTION
## Motivation

Burn tensor APIs increasingly support negative dimension indexing, but variance, median, covariance, and dimension-reduced loss helpers still required usize dimensions. This made common last-axis calls inconsistent with the rest of the public tensor API.

## Modifications

- Changed var, var_bias, var_mean, var_mean_bias, median, median_with_indices, and cov to accept AsIndex dimensions.
- Changed LpLoss and SmoothL1Loss forward_reduce_dims to accept AsIndex slices.
- Normalize dimensions before existing usize-only helpers and reduction operations.
- Added backend and burn-nn regression coverage for negative dimensions.