### PR TITLE
feat: support negative norm and cosine dimensions

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/float/linalg/cosine_similarity.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/linalg/cosine_similarity.rs
@@ -76,7 +76,7 @@ fn test_cosine_similarity_different_dimension() {
         .assert_approx_eq::<FloatElem>(&expected, tolerance);
 
     // Test with negative dimension (-1 is the last dimension, which is 2 in this case)
-    linalg::cosine_similarity(x1.clone(), x2.clone(), -1, None)
+    linalg::cosine_similarity(x1.clone(), x2.clone(), -1_i64, None)
         .into_data()
         .assert_approx_eq::<FloatElem>(&expected, tolerance);
 }

--- a/crates/burn-backend-tests/tests/tensor/float/linalg/vector_norm.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/linalg/vector_norm.rs
@@ -234,3 +234,49 @@ fn test_normalize() {
     let output = linalg::vector_normalize(x.clone(), 1.0, 0, 5.0).into_data();
     output.assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
 }
+
+#[test]
+fn test_negative_dimension() {
+    let x = TestTensor::<2>::from([[1., 2.], [3., 4.]]);
+    let tolerance = Tolerance::default();
+
+    let expected = linalg::vector_norm(x.clone(), linalg::Norm::L2, 1).into_data();
+    linalg::vector_norm(x.clone(), linalg::Norm::L2, -1)
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, tolerance);
+
+    let expected = linalg::lp_norm(x.clone(), 3.0, 1).into_data();
+    linalg::lp_norm(x.clone(), 3.0, -1)
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, tolerance);
+
+    let expected = linalg::vector_normalize(x.clone(), 1.0, 1, 1e-8).into_data();
+    linalg::vector_normalize(x.clone(), 1.0, -1, 1e-8)
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, tolerance);
+
+    let expected = linalg::l0_norm(x.clone(), 1).into_data();
+    linalg::l0_norm(x.clone(), -1)
+        .into_data()
+        .assert_eq(&expected, true);
+
+    let expected = linalg::l1_norm(x.clone(), 1).into_data();
+    linalg::l1_norm(x.clone(), -1)
+        .into_data()
+        .assert_eq(&expected, true);
+
+    let expected = linalg::l2_norm(x.clone(), 1).into_data();
+    linalg::l2_norm(x.clone(), -1)
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, tolerance);
+
+    let expected = linalg::max_abs_norm(x.clone(), 1).into_data();
+    linalg::max_abs_norm(x.clone(), -1)
+        .into_data()
+        .assert_eq(&expected, true);
+
+    let expected = linalg::min_abs_norm(x.clone(), 1).into_data();
+    linalg::min_abs_norm(x, -1)
+        .into_data()
+        .assert_eq(&expected, true);
+}

--- a/crates/burn-nn/src/modules/cosine_similarity.rs
+++ b/crates/burn-nn/src/modules/cosine_similarity.rs
@@ -2,16 +2,17 @@ use burn_core as burn;
 
 use burn::config::Config;
 use burn::module::{Content, DisplaySettings, Module, ModuleDisplay};
-use burn::tensor::Tensor;
 use burn::tensor::linalg::cosine_similarity;
+use burn::tensor::{AsIndex, Tensor};
 
 /// Configuration to create a [CosineSimilarity](CosineSimilarity) layer using the
 /// [init function](CosineSimilarityConfig::init).
 #[derive(Config, Debug)]
 pub struct CosineSimilarityConfig {
     /// The dimension along which the cosine similarity is computed. Default: `1`.
+    /// Negative dimensions are supported and count from the end.
     #[config(default = 1)]
-    pub dim: usize,
+    pub dim: isize,
     /// Small value to avoid division by zero. Default: `1e-8`.
     #[config(default = 1e-8)]
     pub eps: f64,
@@ -38,7 +39,8 @@ impl CosineSimilarityConfig {
 #[module(custom_display)]
 pub struct CosineSimilarity {
     /// The dimension along which the cosine similarity is computed.
-    pub dim: usize,
+    /// Negative dimensions are supported and count from the end.
+    pub dim: isize,
     /// Small value to avoid division by zero.
     pub eps: f64,
 }
@@ -67,7 +69,8 @@ impl CosineSimilarity {
     /// - x2:     `[batch_size, features]`
     /// - output: `[batch_size]`
     pub fn forward(&self, x1: Tensor<2>, x2: Tensor<2>) -> Tensor<1> {
-        cosine_similarity(x1, x2, self.dim as i32, Some(self.eps)).squeeze_dim(self.dim)
+        let dim = self.dim.expect_dim_index(2);
+        cosine_similarity(x1, x2, dim, Some(self.eps)).squeeze_dim(dim)
     }
 }
 
@@ -87,6 +90,23 @@ mod tests {
         let output = CosineSimilarityConfig::new().init().forward(x1, x2);
 
         // dot(x1, x2) / (||x1|| * ||x2||) per row; reference from PyTorch.
+        let expected = TensorData::from([1.0, 0.707107]);
+        output
+            .into_data()
+            .assert_approx_eq::<FT>(&expected, Tolerance::default());
+    }
+
+    #[test]
+    fn cosine_similarity_negative_dim() {
+        let device = Default::default();
+        let x1 = Tensor::<2>::from_data(TensorData::from([[1.0, 0.0], [1.0, 1.0]]), &device);
+        let x2 = Tensor::<2>::from_data(TensorData::from([[1.0, 0.0], [0.0, 1.0]]), &device);
+
+        let output = CosineSimilarityConfig::new()
+            .with_dim(-1)
+            .init()
+            .forward(x1, x2);
+
         let expected = TensorData::from([1.0, 0.707107]);
         output
             .into_data()

--- a/crates/burn-tensor/src/tensor/linalg/cosine_similarity.rs
+++ b/crates/burn-tensor/src/tensor/linalg/cosine_similarity.rs
@@ -1,8 +1,8 @@
 use burn_std::FloatDType;
 
-use crate::tensor::Tensor;
+use crate::{AsIndex, tensor::Tensor};
 
-use super::l2_norm;
+use super::vector_norm::l2_norm_impl;
 
 /// Computes the cosine similarity between two tensors along a specified dimension.
 ///
@@ -13,8 +13,8 @@ use super::l2_norm;
 ///
 /// * `x1` - First input tensor
 /// * `x2` - Second input tensor
-/// * `dim` - Dimension along which to compute the similarity
-///   (negative indices allowed: -1 for last dimension)
+/// * `dim` - Dimension along which to compute the similarity.
+///   Negative dimensions are supported and count from the end.
 /// * `eps` - Small value to avoid division by zero (default: dtype's smallest positive normal)
 ///
 /// # Returns
@@ -23,9 +23,10 @@ use super::l2_norm;
 pub fn cosine_similarity<const D: usize>(
     x1: Tensor<D>,
     x2: Tensor<D>,
-    dim: i32,
+    dim: impl AsIndex,
     eps: Option<f64>,
 ) -> Tensor<D> {
+    let dim = dim.expect_dim_index(D);
     let eps = eps.unwrap_or_else(|| {
         x1.dtype()
             .finfo()
@@ -33,15 +34,12 @@ pub fn cosine_similarity<const D: usize>(
             .min_positive
     });
 
-    // Convert negative dimension to positive
-    let dim_idx = if dim < 0 { D as i32 + dim } else { dim } as usize;
-
     // Compute dot product: sum(x1 * x2) along the specified dimension
-    let dot_product = (x1.clone() * x2.clone()).sum_dim(dim_idx);
+    let dot_product = (x1.clone() * x2.clone()).sum_dim(dim);
 
     // Compute L2 norms: ||x1|| and ||x2||
-    let norm_x1 = l2_norm(x1, dim_idx);
-    let norm_x2 = l2_norm(x2, dim_idx);
+    let norm_x1 = l2_norm_impl(x1, dim);
+    let norm_x2 = l2_norm_impl(x2, dim);
 
     // Calculate the denominator (product of the norms) with epsilon to avoid division by zero
     let denominator = norm_x1.clamp_min(eps) * norm_x2.clamp_min(eps);

--- a/crates/burn-tensor/src/tensor/linalg/vector_norm.rs
+++ b/crates/burn-tensor/src/tensor/linalg/vector_norm.rs
@@ -1,6 +1,6 @@
 use crate::tensor::Tensor;
 use crate::{
-    ElementConversion,
+    AsIndex, ElementConversion,
     kind::{Numeric, Ordered},
 };
 #[allow(unused_imports)]
@@ -110,12 +110,18 @@ impl From<f64> for Norm {
 /// * `x` - The input tensor.
 /// * `norm` - The selected norm.
 /// * `dim` - The dimension to compute the norm over.
+///   Negative dimensions are supported and count from the end.
 ///
 /// # Returns
 ///
 /// The vector norm of the input tensor.
-pub fn vector_norm<const D: usize>(x: Tensor<D>, norm: impl Into<Norm>, dim: usize) -> Tensor<D> {
-    lp_norm(x, norm.into().to_exponent(), dim)
+pub fn vector_norm<const D: usize>(
+    x: Tensor<D>,
+    norm: impl Into<Norm>,
+    dim: impl AsIndex,
+) -> Tensor<D> {
+    let dim = dim.expect_dim_index(D);
+    lp_norm_impl(x, norm.into().to_exponent(), dim)
 }
 
 /// Computes the general ``L(p)`` norm of a tensor along a specified dimension.
@@ -133,18 +139,24 @@ pub fn vector_norm<const D: usize>(x: Tensor<D>, norm: impl Into<Norm>, dim: usi
 /// * `x` - The input tensor.
 /// * `p` - The exponent of the Lp norm.
 /// * `dim` - The dimension to compute the norm over.
+///   Negative dimensions are supported and count from the end.
 ///
 /// # Returns
 ///
 /// The ``L(p)`` norm of the input tensor.
-pub fn lp_norm<const D: usize>(x: Tensor<D>, p: f64, dim: usize) -> Tensor<D> {
+pub fn lp_norm<const D: usize>(x: Tensor<D>, p: f64, dim: impl AsIndex) -> Tensor<D> {
+    let dim = dim.expect_dim_index(D);
+    lp_norm_impl(x, p, dim)
+}
+
+fn lp_norm_impl<const D: usize>(x: Tensor<D>, p: f64, dim: usize) -> Tensor<D> {
     match p {
-        0.0 => l0_norm(x, dim),
-        1.0 => l1_norm(x, dim),
-        2.0 => l2_norm(x, dim),
+        0.0 => l0_norm_impl(x, dim),
+        1.0 => l1_norm_impl(x, dim),
+        2.0 => l2_norm_impl(x, dim),
         p if is_even_integer(p) => lp_signed_norm(x, p as u32, dim),
-        f64::INFINITY => max_abs_norm(x, dim),
-        f64::NEG_INFINITY => min_abs_norm(x, dim),
+        f64::INFINITY => max_abs_norm_impl(x, dim),
+        f64::NEG_INFINITY => min_abs_norm_impl(x, dim),
         _ => lp_norm_base(x, p, dim),
     }
 }
@@ -158,6 +170,7 @@ pub fn lp_norm<const D: usize>(x: Tensor<D>, p: f64, dim: usize) -> Tensor<D> {
 /// * `x` - The input tensor.
 /// * `norm` - The selected norm.
 /// * `dim` - The dimension to compute the norm over.
+///   Negative dimensions are supported and count from the end.
 /// * `eps` - The epsilon for the norm.
 ///
 /// # Returns
@@ -166,10 +179,11 @@ pub fn lp_norm<const D: usize>(x: Tensor<D>, p: f64, dim: usize) -> Tensor<D> {
 pub fn vector_normalize<const D: usize, E: ElementConversion>(
     x: Tensor<D>,
     norm: impl Into<Norm>,
-    dim: usize,
+    dim: impl AsIndex,
     eps: E,
 ) -> Tensor<D> {
-    let norm = vector_norm(x.clone(), norm, dim).clamp_min(eps);
+    let dim = dim.expect_dim_index(D);
+    let norm = lp_norm_impl(x.clone(), norm.into().to_exponent(), dim).clamp_min(eps);
     x / norm
 }
 
@@ -179,11 +193,20 @@ pub fn vector_normalize<const D: usize, E: ElementConversion>(
 ///
 /// * `x` - The input tensor.
 /// * `dim` - The dimension to compute the norm over.
+///   Negative dimensions are supported and count from the end.
 ///
 /// # Returns
 ///
 /// The L0 norm of the input tensor.
-pub fn l0_norm<const D: usize, K>(x: Tensor<D, K>, dim: usize) -> Tensor<D, K>
+pub fn l0_norm<const D: usize, K>(x: Tensor<D, K>, dim: impl AsIndex) -> Tensor<D, K>
+where
+    K: Numeric,
+{
+    let dim = dim.expect_dim_index(D);
+    l0_norm_impl(x, dim)
+}
+
+fn l0_norm_impl<const D: usize, K>(x: Tensor<D, K>, dim: usize) -> Tensor<D, K>
 where
     K: Numeric,
 {
@@ -200,11 +223,20 @@ where
 ///
 /// * `x` - The input tensor.
 /// * `dim` - The dimension to compute the norm over.
+///   Negative dimensions are supported and count from the end.
 ///
 /// # Returns
 ///
 /// The L1 norm of the input tensor.
-pub fn l1_norm<const D: usize, K>(x: Tensor<D, K>, dim: usize) -> Tensor<D, K>
+pub fn l1_norm<const D: usize, K>(x: Tensor<D, K>, dim: impl AsIndex) -> Tensor<D, K>
+where
+    K: Numeric,
+{
+    let dim = dim.expect_dim_index(D);
+    l1_norm_impl(x, dim)
+}
+
+fn l1_norm_impl<const D: usize, K>(x: Tensor<D, K>, dim: usize) -> Tensor<D, K>
 where
     K: Numeric,
 {
@@ -217,11 +249,17 @@ where
 ///
 /// * `x` - The input tensor.
 /// * `dim` - The dimension to compute the norm over.
+///   Negative dimensions are supported and count from the end.
 ///
 /// # Returns
 ///
 /// The L2 norm of the input tensor.
-pub fn l2_norm<const D: usize>(x: Tensor<D>, dim: usize) -> Tensor<D> {
+pub fn l2_norm<const D: usize>(x: Tensor<D>, dim: impl AsIndex) -> Tensor<D> {
+    let dim = dim.expect_dim_index(D);
+    l2_norm_impl(x, dim)
+}
+
+pub(super) fn l2_norm_impl<const D: usize>(x: Tensor<D>, dim: usize) -> Tensor<D> {
     x.square().sum_dim(dim).sqrt()
 }
 
@@ -252,11 +290,20 @@ fn lp_norm_base<const D: usize>(x: Tensor<D>, p: f64, dim: usize) -> Tensor<D> {
 ///
 /// * `x` - The input tensor.
 /// * `dim` - The dimension to compute the norm over.
+///   Negative dimensions are supported and count from the end.
 ///
 /// # Returns
 ///
 /// The L:INFINITY norm of the input tensor.
-pub fn max_abs_norm<const D: usize, K>(x: Tensor<D, K>, dim: usize) -> Tensor<D, K>
+pub fn max_abs_norm<const D: usize, K>(x: Tensor<D, K>, dim: impl AsIndex) -> Tensor<D, K>
+where
+    K: Ordered,
+{
+    let dim = dim.expect_dim_index(D);
+    max_abs_norm_impl(x, dim)
+}
+
+fn max_abs_norm_impl<const D: usize, K>(x: Tensor<D, K>, dim: usize) -> Tensor<D, K>
 where
     K: Ordered,
 {
@@ -269,11 +316,20 @@ where
 ///
 /// * `x` - The input tensor.
 /// * `dim` - The dimension to compute the norm over.
+///   Negative dimensions are supported and count from the end.
 ///
 /// # Returns
 ///
 /// The L:NEG_INFINITY norm of the input tensor.
-pub fn min_abs_norm<const D: usize, K>(x: Tensor<D, K>, dim: usize) -> Tensor<D, K>
+pub fn min_abs_norm<const D: usize, K>(x: Tensor<D, K>, dim: impl AsIndex) -> Tensor<D, K>
+where
+    K: Ordered,
+{
+    let dim = dim.expect_dim_index(D);
+    min_abs_norm_impl(x, dim)
+}
+
+fn min_abs_norm_impl<const D: usize, K>(x: Tensor<D, K>, dim: usize) -> Tensor<D, K>
 where
     K: Ordered,
 {


### PR DESCRIPTION
## Motivation

Burn tensor APIs increasingly support negative dimension indexing, but vector norm helpers and the cosine similarity module were inconsistent about accepted dimension types. The module could not represent common last-axis calls such as dim = -1.

## Modifications

- Changed all eight public vector norm APIs to accept AsIndex dimensions.
- Standardized free cosine_similarity on AsIndex with checked normalization.
- Changed CosineSimilarityConfig and CosineSimilarity to store signed dimensions.
- Keep canonical usize dimensions in private helpers and lower layers.
- Added regression coverage for all vector norm APIs and both cosine interfaces.
