### PR TITLE
fix(burn-train): correctly aggregate per-epoch metrics that require global statistics

### DIFF
--- a/burn-book/src/building-blocks/metric.md
+++ b/burn-book/src/building-blocks/metric.md
@@ -215,11 +215,11 @@ When the metric you are implementing is numeric in nature, you may want to also 
 
 ```rust, ignore
 impl<B: Backend> Numeric for LossMetric<B> {
-    fn value(&self) -> NumericEntry {
+    fn value(&self) -> Option<NumericEntry> {
         self.state.current_value()
     }
 
-    fn running_value(&self) -> NumericEntry {
+    fn running_value(&self) -> Option<NumericEntry> {
         self.state.running_value()
     }
 }

--- a/crates/burn-train/src/logger/metric.rs
+++ b/crates/burn-train/src/logger/metric.rs
@@ -182,6 +182,11 @@ impl FileMetricLogger {
 
 impl FileMetricLogger {
     fn log_item(&mut self, item: &MetricEntry, epoch: Option<usize>, split: &Split) {
+        // Skip writing placeholders to disk for global-only metrics
+        if item.serialized_entry.is_not_available() {
+            return;
+        }
+
         let name = &self.metric_definitions.get(&item.metric_id).unwrap().name;
         let key = logger_key(name, split);
         let value = &item.serialized_entry.serialized;
@@ -220,12 +225,12 @@ impl MetricLogger for FileMetricLogger {
         let entries: Vec<_> = update
             .entries
             .iter()
-            .chain(update.entries_numeric.iter().map(|numeric_update| {
-                if let Some(NumericEntry::Final(_)) = numeric_update.running_entry {
-                    log::info!("[FileMetricLogger] final entry {:?}", numeric_update.entry);
-                }
-                &numeric_update.entry
-            }))
+            .chain(
+                update
+                    .entries_numeric
+                    .iter()
+                    .map(|numeric_update| &numeric_update.entry),
+            )
             .cloned()
             .collect();
 

--- a/crates/burn-train/src/logger/metric.rs
+++ b/crates/burn-train/src/logger/metric.rs
@@ -220,12 +220,12 @@ impl MetricLogger for FileMetricLogger {
         let entries: Vec<_> = update
             .entries
             .iter()
-            .chain(
-                update
-                    .entries_numeric
-                    .iter()
-                    .map(|numeric_update| &numeric_update.entry),
-            )
+            .chain(update.entries_numeric.iter().map(|numeric_update| {
+                if let Some(NumericEntry::Final(_)) = numeric_update.running_entry {
+                    log::info!("[FileMetricLogger] final entry {:?}", numeric_update.entry);
+                }
+                &numeric_update.entry
+            }))
             .cloned()
             .collect();
 

--- a/crates/burn-train/src/metric/acc.rs
+++ b/crates/burn-train/src/metric/acc.rs
@@ -65,11 +65,14 @@ impl Metric for AccuracyMetric {
             None => outputs.equal(targets).int().sum().into_scalar::<f64>() / batch_size as f64,
         };
 
-        self.state.update(
-            100.0 * accuracy,
-            batch_size,
-            FormatOptions::new(self.name()).unit("%").precision(2),
-        )
+        self.state.update(100.0 * accuracy, batch_size);
+        self.state
+            .compute_update(FormatOptions::new(self.name()).unit("%").precision(2))
+    }
+
+    fn compute(&mut self) -> SerializedEntry {
+        self.state
+            .compute_final(FormatOptions::new(self.name()).unit("%").precision(2))
     }
 
     fn clear(&mut self) {
@@ -91,12 +94,16 @@ impl Metric for AccuracyMetric {
 }
 
 impl Numeric for AccuracyMetric {
-    fn value(&self) -> super::NumericEntry {
-        self.state.current_value()
+    fn value(&self) -> Option<super::NumericEntry> {
+        Some(self.state.current_value())
     }
 
-    fn running_value(&self) -> super::NumericEntry {
-        self.state.running_value()
+    fn running_value(&self) -> Option<super::NumericEntry> {
+        Some(self.state.running_value())
+    }
+
+    fn final_value(&self) -> super::NumericEntry {
+        self.state.final_value()
     }
 }
 
@@ -122,7 +129,7 @@ mod tests {
         );
 
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        assert_eq!(50.0, metric.value().current());
+        assert_eq!(50.0, metric.value().unwrap().current());
     }
 
     #[test]
@@ -146,6 +153,6 @@ mod tests {
         );
 
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        assert_eq!(50.0, metric.value().current());
+        assert_eq!(50.0, metric.value().unwrap().current());
     }
 }

--- a/crates/burn-train/src/metric/acc.rs
+++ b/crates/burn-train/src/metric/acc.rs
@@ -87,7 +87,6 @@ impl Metric for AccuracyMetric {
         super::NumericAttributes {
             unit: Some("%".to_string()),
             higher_is_better: true,
-            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/auc_pr.rs
+++ b/crates/burn-train/src/metric/auc_pr.rs
@@ -186,7 +186,8 @@ impl Numeric for AucPrMetric {
     }
 
     fn final_value(&self) -> super::NumericEntry {
-        self.value()
+        self.state
+            .value()
             .expect("Compute must be called to get final value")
     }
 }
@@ -285,7 +286,7 @@ mod tests {
         let _entry = metric.update(&input(data), &MetricMetadata::fake());
         let _entry = metric.compute();
 
-        TensorData::from([metric.running_value().unwrap().current()])
+        TensorData::from([metric.final_value().current()])
             .assert_approx_eq::<f64>(&TensorData::from([expected * 100.0]), Tolerance::default());
     }
 
@@ -322,10 +323,30 @@ mod tests {
         );
         split.compute();
 
-        // Epoch value is independent of batching.
-        TensorData::from([split.running_value().unwrap().current()]).assert_approx_eq::<f64>(
-            &TensorData::from([single.running_value().unwrap().current()]),
+        TensorData::from([split.final_value().current()]).assert_approx_eq::<f64>(
+            &TensorData::from([single.final_value().current()]),
             Tolerance::default(),
         );
+    }
+
+    #[test]
+    #[should_panic = "Compute must be called to get final value"]
+    fn test_auc_pr_should_panic_before_compute() {
+        let dev = Default::default();
+
+        let mut split = AucPrMetric::binary();
+        split.update(
+            &ConfusionStatsInput::new(
+                Tensor::from_data([[0.9], [0.4], [0.8]], &dev),
+                Tensor::from_data([[1], [0], [1]], &dev),
+            ),
+            &MetricMetadata::fake(),
+        );
+
+        // AUC-PR is not valid for a batch, and is not meaningful until all statistics have been accumulated
+        assert!(split.value().is_none());
+        assert!(split.running_value().is_none());
+
+        split.final_value();
     }
 }

--- a/crates/burn-train/src/metric/auc_pr.rs
+++ b/crates/burn-train/src/metric/auc_pr.rs
@@ -2,7 +2,7 @@ use super::MetricMetadata;
 use super::state::{FormatOptions, PredictionAccumulatorState};
 use crate::metric::{
     ClassReduction, ConfusionStatsInput, Metric, MetricAttributes, MetricName, Numeric,
-    NumericAggregation, NumericAttributes, SerializedEntry,
+    NumericAttributes, SerializedEntry,
 };
 use burn_core::tensor::{Int, Tensor};
 use std::sync::Arc;
@@ -105,10 +105,23 @@ impl Metric for AucPrMetric {
         input: &ConfusionStatsInput,
         _metadata: &MetricMetadata,
     ) -> SerializedEntry {
+        // Update the state
         self.state
             .accumulate(input.predictions.clone(), input.targets.clone());
 
-        // Recompute over the whole epoch: AP is rank-based, not a per-batch mean.
+        // Serialize placeholder to indicate no valid scalar exists yet mid-epoch
+        self.state
+            .serialize_placeholder(FormatOptions::new(self.name()).unit("%").precision(2))
+    }
+    fn compute(&mut self) -> SerializedEntry {
+        // Guard against an empty epoch calculation
+        if self.state.is_empty() {
+            return self
+                .state
+                .serialize_placeholder(FormatOptions::new(self.name()).unit("%").precision(2));
+        }
+
+        // Recompute over the whole epoch: AP is rank-based.
         let (predictions, targets) = self.state.tensors();
         let [n, c] = predictions.dims();
 
@@ -139,7 +152,8 @@ impl Metric for AucPrMetric {
             ap.select(0, keep).mean().into_scalar()
         };
 
-        self.state.update(
+        // Complete the state with the calculated scalar
+        self.state.compute(
             100.0 * metric,
             FormatOptions::new(self.name()).unit("%").precision(2),
         )
@@ -157,19 +171,23 @@ impl Metric for AucPrMetric {
         NumericAttributes {
             unit: Some("%".to_string()),
             higher_is_better: true,
-            aggregation: NumericAggregation::Last,
         }
         .into()
     }
 }
 
 impl Numeric for AucPrMetric {
-    fn value(&self) -> super::NumericEntry {
-        self.state.value()
+    fn value(&self) -> Option<super::NumericEntry> {
+        None // current value is invalid; requires epoch-level aggregation
     }
 
-    fn running_value(&self) -> super::NumericEntry {
-        self.state.value()
+    fn running_value(&self) -> Option<super::NumericEntry> {
+        None
+    }
+
+    fn final_value(&self) -> super::NumericEntry {
+        self.value()
+            .expect("Compute must be called to get final value")
     }
 }
 
@@ -265,8 +283,9 @@ mod tests {
         let mut metric = AucPrMetric::new(class_reduction);
 
         let _entry = metric.update(&input(data), &MetricMetadata::fake());
+        let _entry = metric.compute();
 
-        TensorData::from([metric.value().current()])
+        TensorData::from([metric.running_value().unwrap().current()])
             .assert_approx_eq::<f64>(&TensorData::from([expected * 100.0]), Tolerance::default());
     }
 
@@ -283,6 +302,7 @@ mod tests {
             ),
             &MetricMetadata::fake(),
         );
+        single.compute();
 
         // Same dataset split across two batches.
         let mut split = AucPrMetric::binary();
@@ -300,10 +320,11 @@ mod tests {
             ),
             &MetricMetadata::fake(),
         );
+        split.compute();
 
         // Epoch value is independent of batching.
-        TensorData::from([split.value().current()]).assert_approx_eq::<f64>(
-            &TensorData::from([single.value().current()]),
+        TensorData::from([split.running_value().unwrap().current()]).assert_approx_eq::<f64>(
+            &TensorData::from([single.running_value().unwrap().current()]),
             Tolerance::default(),
         );
     }

--- a/crates/burn-train/src/metric/auroc.rs
+++ b/crates/burn-train/src/metric/auroc.rs
@@ -129,11 +129,14 @@ impl Metric for AurocMetric {
 
         let metric = self.compute_auc(&input.predictions, &input.targets);
 
-        self.state.update(
-            100.0 * metric,
-            sample_size,
-            FormatOptions::new(self.name()).unit("%").precision(2),
-        )
+        self.state.update(100.0 * metric, sample_size);
+        self.state
+            .compute_update(FormatOptions::new(self.name()).unit("%").precision(2))
+    }
+
+    fn compute(&mut self) -> SerializedEntry {
+        self.state
+            .compute_final(FormatOptions::new(self.name()).unit("%").precision(2))
     }
 
     fn clear(&mut self) {
@@ -145,13 +148,18 @@ impl Metric for AurocMetric {
     }
 }
 
+// TODO: should only be epoch-level like AUC-PR
 impl Numeric for AurocMetric {
-    fn value(&self) -> super::NumericEntry {
-        self.state.current_value()
+    fn value(&self) -> Option<super::NumericEntry> {
+        Some(self.state.current_value())
     }
 
-    fn running_value(&self) -> super::NumericEntry {
-        self.state.running_value()
+    fn running_value(&self) -> Option<super::NumericEntry> {
+        Some(self.state.running_value())
+    }
+
+    fn final_value(&self) -> super::NumericEntry {
+        self.state.final_value()
     }
 }
 
@@ -248,7 +256,7 @@ mod tests {
 
         let _entry = metric.update(&input(data), &MetricMetadata::fake());
 
-        TensorData::from([metric.value().current()])
+        TensorData::from([metric.value().unwrap().current()])
             .assert_approx_eq::<f64>(&TensorData::from([expected * 100.0]), Tolerance::default());
     }
 
@@ -265,7 +273,7 @@ mod tests {
         );
 
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        assert_eq!(metric.value().current(), 100.0);
+        assert_eq!(metric.value().unwrap().current(), 100.0);
     }
 
     #[rstest]
@@ -282,7 +290,7 @@ mod tests {
         );
 
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        assert_eq!(metric.value().current(), 50.0);
+        assert_eq!(metric.value().unwrap().current(), 50.0);
     }
 
     #[test]
@@ -306,7 +314,7 @@ mod tests {
         );
 
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        assert_eq!(metric.value().current(), 100.0);
+        assert_eq!(metric.value().unwrap().current(), 100.0);
     }
 
     #[test]
@@ -322,7 +330,7 @@ mod tests {
         );
 
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        assert_eq!(metric.value().current(), 50.0);
+        assert_eq!(metric.value().unwrap().current(), 50.0);
     }
 
     #[test]

--- a/crates/burn-train/src/metric/auroc.rs
+++ b/crates/burn-train/src/metric/auroc.rs
@@ -1,7 +1,7 @@
 use core::f64;
 
 use super::MetricMetadata;
-use super::state::{FormatOptions, NumericMetricState};
+use super::state::{FormatOptions, PredictionAccumulatorState};
 use crate::metric::{
     ClassReduction, ConfusionStatsInput, Metric, MetricName, Numeric, SerializedEntry,
 };
@@ -17,7 +17,7 @@ use std::sync::Arc;
 #[derive(Clone)]
 pub struct AurocMetric {
     name: MetricName,
-    state: NumericMetricState,
+    state: PredictionAccumulatorState,
     class_reduction: ClassReduction,
 }
 
@@ -108,7 +108,7 @@ impl AurocMetric {
         if keep.dims()[0] == 0 {
             log::warn!(
                 "AUROC is undefined (no class has both positive and negative samples in the \
-                 batch); reporting 0.5 (chance level)."
+                 epoch); reporting 0.5 (chance level)."
             );
             return 0.5;
         }
@@ -125,18 +125,32 @@ impl Metric for AurocMetric {
         input: &ConfusionStatsInput,
         _metadata: &MetricMetadata,
     ) -> SerializedEntry {
-        let [sample_size, _] = input.predictions.dims();
-
-        let metric = self.compute_auc(&input.predictions, &input.targets);
-
-        self.state.update(100.0 * metric, sample_size);
+        // Update the state with predictions and targets
         self.state
-            .compute_update(FormatOptions::new(self.name()).unit("%").precision(2))
+            .accumulate(input.predictions.clone(), input.targets.clone());
+
+        // Serialize placeholder to indicate no valid scalar exists yet mid-epoch
+        self.state
+            .serialize_placeholder(FormatOptions::new(self.name()).unit("%").precision(2))
     }
 
     fn compute(&mut self) -> SerializedEntry {
-        self.state
-            .compute_final(FormatOptions::new(self.name()).unit("%").precision(2))
+        // Guard against an empty epoch calculation
+        if self.state.is_empty() {
+            return self
+                .state
+                .serialize_placeholder(FormatOptions::new(self.name()).unit("%").precision(2));
+        }
+
+        // Recompute over the whole epoch
+        let (predictions, targets) = self.state.tensors();
+        let metric = self.compute_auc(&predictions, &targets);
+
+        // Complete the state with the calculated scalar
+        self.state.compute(
+            100.0 * metric,
+            FormatOptions::new(self.name()).unit("%").precision(2),
+        )
     }
 
     fn clear(&mut self) {
@@ -148,18 +162,19 @@ impl Metric for AurocMetric {
     }
 }
 
-// TODO: should only be epoch-level like AUC-PR
 impl Numeric for AurocMetric {
     fn value(&self) -> Option<super::NumericEntry> {
-        Some(self.state.current_value())
+        None // current value is invalid; requires epoch-level aggregation
     }
 
     fn running_value(&self) -> Option<super::NumericEntry> {
-        Some(self.state.running_value())
+        None
     }
 
     fn final_value(&self) -> super::NumericEntry {
-        self.state.final_value()
+        self.state
+            .value()
+            .expect("Compute must be called to get final value")
     }
 }
 
@@ -255,8 +270,9 @@ mod tests {
         let mut metric = AurocMetric::new(class_reduction);
 
         let _entry = metric.update(&input(data), &MetricMetadata::fake());
+        let _entry = metric.compute();
 
-        TensorData::from([metric.value().unwrap().current()])
+        TensorData::from([metric.final_value().current()])
             .assert_approx_eq::<f64>(&TensorData::from([expected * 100.0]), Tolerance::default());
     }
 
@@ -273,7 +289,8 @@ mod tests {
         );
 
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        assert_eq!(metric.value().unwrap().current(), 100.0);
+        let _entry = metric.compute();
+        assert_eq!(metric.final_value().current(), 100.0);
     }
 
     #[rstest]
@@ -290,7 +307,8 @@ mod tests {
         );
 
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        assert_eq!(metric.value().unwrap().current(), 50.0);
+        let _entry = metric.compute();
+        assert_eq!(metric.final_value().current(), 50.0);
     }
 
     #[test]
@@ -314,7 +332,8 @@ mod tests {
         );
 
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        assert_eq!(metric.value().unwrap().current(), 100.0);
+        let _entry = metric.compute();
+        assert_eq!(metric.final_value().current(), 100.0);
     }
 
     #[test]
@@ -330,7 +349,8 @@ mod tests {
         );
 
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        assert_eq!(metric.value().unwrap().current(), 50.0);
+        let _entry = metric.compute();
+        assert_eq!(metric.final_value().current(), 50.0);
     }
 
     #[test]
@@ -339,5 +359,65 @@ mod tests {
         let micro_metric = AurocMetric::new(Micro);
 
         assert_ne!(macro_metric.name(), micro_metric.name());
+    }
+
+    #[test]
+    fn test_auroc_accumulates_across_batches() {
+        let dev = Default::default();
+
+        // Whole dataset as a single batch.
+        let mut single = AurocMetric::binary();
+        single.update(
+            &ConfusionStatsInput::new(
+                Tensor::from_data([[0.9], [0.4], [0.8], [0.2], [0.6], [0.1]], &dev),
+                Tensor::from_data([[1], [0], [1], [0], [1], [0]], &dev),
+            ),
+            &MetricMetadata::fake(),
+        );
+        single.compute();
+
+        // Same dataset split across two batches.
+        let mut split = AurocMetric::binary();
+        split.update(
+            &ConfusionStatsInput::new(
+                Tensor::from_data([[0.9], [0.4], [0.8]], &dev),
+                Tensor::from_data([[1], [0], [1]], &dev),
+            ),
+            &MetricMetadata::fake(),
+        );
+        split.update(
+            &ConfusionStatsInput::new(
+                Tensor::from_data([[0.2], [0.6], [0.1]], &dev),
+                Tensor::from_data([[0], [1], [0]], &dev),
+            ),
+            &MetricMetadata::fake(),
+        );
+        split.compute();
+
+        TensorData::from([split.final_value().current()]).assert_approx_eq::<f64>(
+            &TensorData::from([single.final_value().current()]),
+            Tolerance::default(),
+        );
+    }
+
+    #[test]
+    #[should_panic = "Compute must be called to get final value"]
+    fn test_auroc_should_panic_before_compute() {
+        let dev = Default::default();
+
+        let mut split = AurocMetric::binary();
+        split.update(
+            &ConfusionStatsInput::new(
+                Tensor::from_data([[0.9], [0.4], [0.8]], &dev),
+                Tensor::from_data([[1], [0], [1]], &dev),
+            ),
+            &MetricMetadata::fake(),
+        );
+
+        // AUROC is not valid for a batch, and is not meaningful until all statistics have been accumulated
+        assert!(split.value().is_none());
+        assert!(split.running_value().is_none());
+
+        split.final_value();
     }
 }

--- a/crates/burn-train/src/metric/base.rs
+++ b/crates/burn-train/src/metric/base.rs
@@ -54,7 +54,7 @@ pub struct MetricDefinition {
     /// The metric's id.
     pub metric_id: MetricId,
     /// The name of the metric.
-    pub name: String,
+    pub name: MetricName,
     /// The description of the metric.
     pub description: Option<String>,
     /// The attributes of the metric.
@@ -66,7 +66,7 @@ impl MetricDefinition {
     pub fn new<Me: Metric>(metric_id: MetricId, metric: &Me) -> Self {
         Self {
             metric_id,
-            name: metric.name().to_string(),
+            name: metric.name(),
             description: metric.description(),
             attributes: metric.attributes(),
         }
@@ -107,6 +107,9 @@ pub trait Metric: Send + Sync + Clone {
     /// Update the metric state and returns the current metric entry.
     fn update(&mut self, item: &Self::Input, metadata: &MetricMetadata) -> SerializedEntry;
 
+    /// Compute the final metric value.
+    fn compute(&mut self) -> SerializedEntry;
+
     /// Clear the metric state.
     fn clear(&mut self);
 }
@@ -127,16 +130,6 @@ impl<T> Adaptor<()> for T {
     fn adapt(&self) {}
 }
 
-/// How a numeric metric's per-batch values are reduced into an epoch value.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub enum NumericAggregation {
-    /// Sample-weighted mean of the per-batch values.
-    #[default]
-    Mean,
-    /// Last logged value, already computed over the whole epoch.
-    Last,
-}
-
 /// Attributes that describe intrinsic properties of a numeric metric.
 #[derive(Clone, Debug)]
 pub struct NumericAttributes {
@@ -144,8 +137,6 @@ pub struct NumericAttributes {
     pub unit: Option<String>,
     /// Whether larger values are better (true) or smaller are better (false).
     pub higher_is_better: bool,
-    /// How per-batch values are reduced into the epoch value.
-    pub aggregation: NumericAggregation,
 }
 
 impl From<NumericAttributes> for MetricAttributes {
@@ -159,7 +150,6 @@ impl Default for NumericAttributes {
         Self {
             unit: None,
             higher_is_better: true,
-            aggregation: NumericAggregation::default(),
         }
     }
 }
@@ -167,11 +157,25 @@ impl Default for NumericAttributes {
 /// Declare a metric to be numeric.
 ///
 /// This is useful to plot the values of a metric during training.
+///
+/// Some metrics (e.g. accuracy) produce a meaningful value on every batch,
+/// while others (e.g. AUC-PR) only accumulate state per batch and are
+/// computed once all state has been accumulated.. For the latter, [`value`](Self::value)
+/// and [`running_value`](Self::running_value) return `None` until that
+/// epoch-level computation has happened, signaling that no value has been
+/// computed for the current step.
 pub trait Numeric {
-    /// Returns the numeric value of the metric.
-    fn value(&self) -> NumericEntry;
-    /// Returns the current aggregated value of the metric over the global step (epoch).
-    fn running_value(&self) -> NumericEntry;
+    /// Returns the numeric value of the metric, or `None` if this metric has
+    /// no meaningful value yet (e.g. it only accumulates state per batch and
+    /// computes its value once all state has been accumulated).
+    fn value(&self) -> Option<NumericEntry>;
+    /// Returns the current aggregated value of the metric over the global step,
+    /// or `None` if this metric has no meaningful value yet (e.g. it only accumulates state
+    /// per batch and computes its value once all state has been accumulated).
+    fn running_value(&self) -> Option<NumericEntry>;
+    /// Returns the final, authoritative value of the metric for the epoch.
+    /// Only meaningful after [`Metric::compute`] has been called.
+    fn final_value(&self) -> NumericEntry;
 }
 
 /// Serialized form of a metric entry.
@@ -214,6 +218,9 @@ pub enum NumericEntry {
         /// The number of entries present in the aggregated value.
         count: usize,
     },
+    /// The final, authoritative value for the epoch; computed once at epoch end
+    /// and logged in addition to the regular per-batch entries.
+    Final(f64),
 }
 
 impl NumericEntry {
@@ -221,6 +228,7 @@ impl NumericEntry {
     pub fn current(&self) -> f64 {
         match self {
             NumericEntry::Value(val) => *val,
+            NumericEntry::Final(val) => *val,
             NumericEntry::Aggregated {
                 aggregated_value, ..
             } => *aggregated_value,
@@ -231,6 +239,7 @@ impl NumericEntry {
     pub fn serialize(&self) -> String {
         match self {
             Self::Value(v) => v.to_string(),
+            Self::Final(v) => format!("{v},final"),
             Self::Aggregated {
                 aggregated_value,
                 count,
@@ -251,17 +260,25 @@ impl NumericEntry {
                 Err(err) => Err(err.to_string()),
             }
         } else if num_values == 2 {
-            // Aggregated numeric (value, number of elements)
-            let (value, numel) = (values[0], values[1]);
-            match value.parse::<f64>() {
-                Ok(value) => match numel.parse::<usize>() {
-                    Ok(numel) => Ok(NumericEntry::Aggregated {
-                        aggregated_value: value,
-                        count: numel,
-                    }),
+            let (v0, v1) = (values[0], values[1]);
+            // Check if it's tagged as an explicit epoch-level final calculation
+            if v1 == "final" {
+                match v0.parse::<f64>() {
+                    Ok(value) => Ok(NumericEntry::Final(value)),
                     Err(err) => Err(err.to_string()),
-                },
-                Err(err) => Err(err.to_string()),
+                }
+            } else {
+                // Aggregated numeric (value, number of elements)
+                match v0.parse::<f64>() {
+                    Ok(value) => match v1.parse::<usize>() {
+                        Ok(numel) => Ok(NumericEntry::Aggregated {
+                            aggregated_value: value,
+                            count: numel,
+                        }),
+                        Err(err) => Err(err.to_string()),
+                    },
+                    Err(err) => Err(err.to_string()),
+                }
             }
         } else {
             Err("Invalid number of values for numeric entry".to_string())

--- a/crates/burn-train/src/metric/base.rs
+++ b/crates/burn-train/src/metric/base.rs
@@ -187,6 +187,26 @@ pub struct SerializedEntry {
     pub serialized: String,
 }
 
+impl SerializedEntry {
+    /// Canonical sentinel string for metric values that have no batch-level computation.
+    pub const NOT_AVAILABLE: &'static str = "N/A";
+
+    /// Convenience helper for standard placeholder entries when no valid data is ready.
+    pub fn not_available(unit: Option<&str>) -> Self {
+        let na = Self::NOT_AVAILABLE;
+        let formatted = match unit {
+            Some(u) => format!("epoch {na} {u} - batch {na} {u}"),
+            None => format!("epoch {na} - batch {na}"),
+        };
+        Self::new(formatted, na.to_string())
+    }
+
+    /// Returns whether this entry represents an un-serializable/skipped placeholder.
+    pub fn is_not_available(&self) -> bool {
+        self.serialized == Self::NOT_AVAILABLE || self.serialized.is_empty()
+    }
+}
+
 /// Data type that contains the current state of a metric at a given time.
 #[derive(Debug, Clone)]
 pub struct MetricEntry {

--- a/crates/burn-train/src/metric/bleu.rs
+++ b/crates/burn-train/src/metric/bleu.rs
@@ -310,7 +310,6 @@ impl Metric for BleuScore {
         NumericAttributes {
             unit: Some("%".to_string()),
             higher_is_better: true,
-            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/bleu.rs
+++ b/crates/burn-train/src/metric/bleu.rs
@@ -288,11 +288,14 @@ impl Metric for BleuScore {
         // slightly inaccurate compared to true corpus BLEU. Correct
         // accumulation would require a custom metric state that tracks raw
         // n-gram counts across batches.
-        self.state.update(
-            value,
-            batch_size,
-            FormatOptions::new(self.name()).unit("%").precision(2),
-        )
+        self.state.update(value, batch_size);
+        self.state
+            .compute_update(FormatOptions::new(self.name()).unit("%").precision(2))
+    }
+
+    fn compute(&mut self) -> SerializedEntry {
+        self.state
+            .compute_final(FormatOptions::new(self.name()).unit("%").precision(2))
     }
 
     fn clear(&mut self) {
@@ -314,12 +317,16 @@ impl Metric for BleuScore {
 }
 
 impl Numeric for BleuScore {
-    fn value(&self) -> NumericEntry {
-        self.state.current_value()
+    fn value(&self) -> Option<NumericEntry> {
+        Some(self.state.current_value())
     }
 
-    fn running_value(&self) -> NumericEntry {
-        self.state.running_value()
+    fn running_value(&self) -> Option<NumericEntry> {
+        Some(self.state.running_value())
+    }
+
+    fn final_value(&self) -> NumericEntry {
+        self.state.final_value()
     }
 }
 
@@ -338,7 +345,7 @@ mod tests {
 
         metric.update(&BleuInput::new(preds, tgts), &MetricMetadata::fake());
 
-        assert!((metric.value().current() - 100.0).abs() < 1e-6);
+        assert!((metric.value().unwrap().current() - 100.0).abs() < 1e-6);
     }
 
     /// Completely different sequences => BLEU = 0 %.
@@ -352,7 +359,7 @@ mod tests {
 
         metric.update(&BleuInput::new(preds, tgts), &MetricMetadata::fake());
 
-        assert_eq!(0.0, metric.value().current());
+        assert_eq!(0.0, metric.value().unwrap().current());
     }
 
     /// Partial overlap with BLEU-1 (unigram precision only).
@@ -368,7 +375,7 @@ mod tests {
         metric.update(&BleuInput::new(preds, tgts), &MetricMetadata::fake());
 
         // BLEU-1 = 3/5 * 100 = 60.0
-        assert!((metric.value().current() - 60.0).abs() < 1e-6);
+        assert!((metric.value().unwrap().current() - 60.0).abs() < 1e-6);
     }
 
     /// Brevity penalty applied when candidate is shorter than reference.
@@ -386,7 +393,7 @@ mod tests {
         metric.update(&BleuInput::new(preds, tgts), &MetricMetadata::fake());
 
         let expected = 100.0 * (1.0 - 5.0 / 3.0_f64).exp();
-        assert!((metric.value().current() - expected).abs() < 0.1);
+        assert!((metric.value().unwrap().current() - expected).abs() < 0.1);
     }
 
     /// With padding, padding tokens should be stripped.
@@ -402,7 +409,7 @@ mod tests {
 
         metric.update(&BleuInput::new(preds, tgts), &MetricMetadata::fake());
 
-        assert!((metric.value().current() - 100.0).abs() < 1e-6);
+        assert!((metric.value().unwrap().current() - 100.0).abs() < 1e-6);
     }
 
     /// Batch of two sequences: corpus-style accumulation.
@@ -421,7 +428,7 @@ mod tests {
 
         metric.update(&BleuInput::new(preds, tgts), &MetricMetadata::fake());
 
-        assert!((metric.value().current() - 50.0).abs() < 1e-6);
+        assert!((metric.value().unwrap().current() - 50.0).abs() < 1e-6);
     }
 
     /// `clear()` must reset the running statistics.
@@ -434,10 +441,10 @@ mod tests {
         let tgts = Tensor::from_data([[1, 2, 3, 4, 5]], &device);
 
         metric.update(&BleuInput::new(preds, tgts), &MetricMetadata::fake());
-        assert!(metric.value().current() > 0.0);
+        assert!(metric.value().unwrap().current() > 0.0);
 
         metric.clear();
-        assert!(metric.value().current().is_nan());
+        assert!(metric.value().unwrap().current().is_nan());
     }
 
     /// BLEU-2 on a partial match verifies bigram counting.
@@ -459,7 +466,7 @@ mod tests {
         metric.update(&BleuInput::new(preds, tgts), &MetricMetadata::fake());
 
         let expected = 100.0 * ((0.5_f64.ln() + (1.0 / 3.0_f64).ln()) / 2.0).exp();
-        assert!((metric.value().current() - expected).abs() < 0.1);
+        assert!((metric.value().unwrap().current() - expected).abs() < 0.1);
     }
 
     /// BLEU with custom name reflects max_n.
@@ -489,7 +496,7 @@ mod tests {
         let tgts = Tensor::from_data([[1, 2, 3, 4, 5]], &device);
 
         metric.update(&BleuInput::new(preds, tgts), &MetricMetadata::fake());
-        assert_eq!(0.0, metric.value().current());
+        assert_eq!(0.0, metric.value().unwrap().current());
     }
 
     /// Exponential smoothing produces a non-zero score for short candidates.
@@ -509,11 +516,11 @@ mod tests {
             &BleuInput::new(preds.clone(), tgts.clone()),
             &MetricMetadata::fake(),
         );
-        assert_eq!(0.0, metric_no_smooth.value().current());
+        assert_eq!(0.0, metric_no_smooth.value().unwrap().current());
 
         metric.update(&BleuInput::new(preds, tgts), &MetricMetadata::fake());
         assert!(
-            metric.value().current() > 0.0,
+            metric.value().unwrap().current() > 0.0,
             "smoothing should produce non-zero score"
         );
     }
@@ -531,7 +538,7 @@ mod tests {
 
         metric.update(&BleuInput::new(preds, tgts), &MetricMetadata::fake());
         assert!(
-            metric.value().current() > 0.0,
+            metric.value().unwrap().current() > 0.0,
             "epsilon smoothing should produce non-zero score"
         );
     }

--- a/crates/burn-train/src/metric/cer.rs
+++ b/crates/burn-train/src/metric/cer.rs
@@ -157,7 +157,6 @@ impl Metric for CharErrorRate {
         super::NumericAttributes {
             unit: Some("%".to_string()),
             higher_is_better: false,
-            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/cer.rs
+++ b/crates/burn-train/src/metric/cer.rs
@@ -127,19 +127,22 @@ impl Metric for CharErrorRate {
             })
             .sum();
 
-        let total_target_length = target_lengths.iter().map(|&x| x as f64).sum::<f64>();
+        let total_target_length = target_lengths.iter().map(|&x| x as usize).sum::<usize>();
 
-        let value = if total_target_length > 0.0 {
-            100.0 * total_edit_distance as f64 / total_target_length
+        let value = if total_target_length > 0 {
+            100.0 * total_edit_distance as f64 / total_target_length as f64
         } else {
             0.0
         };
 
-        self.state.update(
-            value,
-            batch_size,
-            FormatOptions::new(self.name()).unit("%").precision(2),
-        )
+        self.state.update(value, total_target_length);
+        self.state
+            .compute_update(FormatOptions::new(self.name()).unit("%").precision(2))
+    }
+
+    fn compute(&mut self) -> SerializedEntry {
+        self.state
+            .compute_final(FormatOptions::new(self.name()).unit("%").precision(2))
     }
 
     fn clear(&mut self) {
@@ -161,12 +164,16 @@ impl Metric for CharErrorRate {
 }
 
 impl Numeric for CharErrorRate {
-    fn value(&self) -> NumericEntry {
-        self.state.current_value()
+    fn value(&self) -> Option<NumericEntry> {
+        Some(self.state.current_value())
     }
 
-    fn running_value(&self) -> NumericEntry {
-        self.state.running_value()
+    fn running_value(&self) -> Option<NumericEntry> {
+        Some(self.state.running_value())
+    }
+
+    fn final_value(&self) -> NumericEntry {
+        self.state.final_value()
     }
 }
 
@@ -186,7 +193,7 @@ mod tests {
 
         metric.update(&CerInput::new(preds, tgts), &MetricMetadata::fake());
 
-        assert_eq!(0.0, metric.value().current());
+        assert_eq!(0.0, metric.value().unwrap().current());
     }
 
     /// Two edits in four target tokens ⇒ 50 %.
@@ -202,7 +209,7 @@ mod tests {
         metric.update(&CerInput::new(preds, tgts), &MetricMetadata::fake());
 
         // 2 edits / 4 tokens = 50 %
-        assert_eq!(50.0, metric.value().current());
+        assert_eq!(50.0, metric.value().unwrap().current());
     }
 
     /// Same scenario as above, but with right-padding (token 9) ignored.
@@ -217,7 +224,7 @@ mod tests {
         let tgts = Tensor::from_data([[1, 3, pad], [3, 4, pad]], &device);
 
         metric.update(&CerInput::new(preds, tgts), &MetricMetadata::fake());
-        assert_eq!(50.0, metric.value().current());
+        assert_eq!(50.0, metric.value().unwrap().current());
     }
 
     /// `clear()` must reset the running statistics to zero.
@@ -233,9 +240,9 @@ mod tests {
             &CerInput::new(preds.clone(), tgts.clone()),
             &MetricMetadata::fake(),
         );
-        assert!(metric.value().current() > 0.0);
+        assert!(metric.value().unwrap().current() > 0.0);
 
         metric.clear();
-        assert!(metric.value().current().is_nan());
+        assert!(metric.value().unwrap().current().is_nan());
     }
 }

--- a/crates/burn-train/src/metric/confusion_stats.rs
+++ b/crates/burn-train/src/metric/confusion_stats.rs
@@ -109,6 +109,7 @@ impl ConfusionStats {
         self.clone().true_negative() + self.false_positive()
     }
 
+    #[allow(unused)]
     pub fn predicted_positive(self) -> Tensor<1> {
         self.clone().true_positive() + self.false_positive()
     }

--- a/crates/burn-train/src/metric/cpu_temp.rs
+++ b/crates/burn-train/src/metric/cpu_temp.rs
@@ -36,6 +36,10 @@ impl Metric for CpuTemperature {
     type Input = ();
 
     fn update(&mut self, _item: &Self::Input, _metadata: &MetricMetadata) -> SerializedEntry {
+        self.compute()
+    }
+
+    fn compute(&mut self) -> SerializedEntry {
         match self.sys.cpu_temp() {
             Ok(temp) => self.temp_celsius = temp,
             Err(_) => self.temp_celsius = f32::NAN,
@@ -67,11 +71,15 @@ impl Metric for CpuTemperature {
 }
 
 impl Numeric for CpuTemperature {
-    fn value(&self) -> NumericEntry {
-        NumericEntry::Value(self.temp_celsius as f64)
+    fn value(&self) -> Option<NumericEntry> {
+        Some(NumericEntry::Value(self.temp_celsius as f64))
     }
 
-    fn running_value(&self) -> NumericEntry {
+    fn running_value(&self) -> Option<NumericEntry> {
+        Some(NumericEntry::Value(self.temp_celsius as f64))
+    }
+
+    fn final_value(&self) -> NumericEntry {
         NumericEntry::Value(self.temp_celsius as f64)
     }
 }

--- a/crates/burn-train/src/metric/cpu_temp.rs
+++ b/crates/burn-train/src/metric/cpu_temp.rs
@@ -64,7 +64,6 @@ impl Metric for CpuTemperature {
         super::NumericAttributes {
             unit: Some("°C".to_string()),
             higher_is_better: false,
-            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/cpu_use.rs
+++ b/crates/burn-train/src/metric/cpu_use.rs
@@ -90,7 +90,6 @@ impl Metric for CpuUse {
         super::NumericAttributes {
             unit: Some("%".to_string()),
             higher_is_better: false,
-            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/cpu_use.rs
+++ b/crates/burn-train/src/metric/cpu_use.rs
@@ -70,7 +70,10 @@ impl Metric for CpuUse {
             self.current = Self::refresh(&mut self.sys);
             self.last_refresh = Instant::now();
         }
+        self.compute()
+    }
 
+    fn compute(&mut self) -> SerializedEntry {
         let formatted = format!("{}: {:.2} %", self.name(), self.current);
         let raw = format!("{:.2}", self.current);
 
@@ -94,11 +97,15 @@ impl Metric for CpuUse {
 }
 
 impl Numeric for CpuUse {
-    fn value(&self) -> NumericEntry {
-        NumericEntry::Value(self.current)
+    fn value(&self) -> Option<NumericEntry> {
+        Some(NumericEntry::Value(self.current))
     }
 
-    fn running_value(&self) -> NumericEntry {
+    fn running_value(&self) -> Option<NumericEntry> {
+        Some(NumericEntry::Value(self.current))
+    }
+
+    fn final_value(&self) -> NumericEntry {
         NumericEntry::Value(self.current)
     }
 }

--- a/crates/burn-train/src/metric/cuda.rs
+++ b/crates/burn-train/src/metric/cuda.rs
@@ -34,6 +34,10 @@ impl Metric for CudaMetric {
     type Input = ();
 
     fn update(&mut self, _item: &(), _metadata: &MetricMetadata) -> SerializedEntry {
+        self.compute()
+    }
+
+    fn compute(&mut self) -> SerializedEntry {
         let not_available =
             || SerializedEntry::new("Unavailable".to_string(), "Unavailable".to_string());
 

--- a/crates/burn-train/src/metric/fbetascore.rs
+++ b/crates/burn-train/src/metric/fbetascore.rs
@@ -1,12 +1,11 @@
-use crate::metric::{MetricName, Numeric};
+use crate::metric::{MetricName, Numeric, state::ConfusionStatsState};
 
 use super::{
     Metric, MetricAttributes, MetricMetadata, NumericAttributes, NumericEntry, SerializedEntry,
     classification::{ClassReduction, ClassificationMetricConfig, DecisionRule},
     confusion_stats::{ConfusionStats, ConfusionStatsInput},
-    state::{FormatOptions, NumericMetricState},
+    state::FormatOptions,
 };
-use burn_core::prelude::Tensor;
 use std::{num::NonZeroUsize, sync::Arc};
 
 /// The [F-beta score](https://en.wikipedia.org/wiki/F-score) metric.
@@ -16,7 +15,7 @@ use std::{num::NonZeroUsize, sync::Arc};
 #[derive(Clone)]
 pub struct FBetaScoreMetric {
     name: MetricName,
-    state: NumericMetricState,
+    state: ConfusionStatsState,
     config: ClassificationMetricConfig,
     beta: f64,
 }
@@ -97,23 +96,6 @@ impl FBetaScoreMetric {
             beta,
         )
     }
-
-    fn class_average(&self, mut aggregated_metric: Tensor<1>) -> f64 {
-        use ClassReduction::{Macro, Micro};
-        let avg_tensor = match self.config.class_reduction {
-            Micro => aggregated_metric,
-            Macro => {
-                if aggregated_metric.clone().contains_nan().any().into_scalar() {
-                    let nan_mask = aggregated_metric.clone().is_nan();
-                    aggregated_metric = aggregated_metric
-                        .clone()
-                        .select(0, nan_mask.bool_not().argwhere().squeeze_dim(1))
-                }
-                aggregated_metric.mean()
-            }
-        };
-        avg_tensor.into_scalar()
-    }
 }
 
 impl Metric for FBetaScoreMetric {
@@ -122,20 +104,29 @@ impl Metric for FBetaScoreMetric {
     fn update(&mut self, input: &Self::Input, _metadata: &MetricMetadata) -> SerializedEntry {
         let [sample_size, _] = input.predictions.dims();
 
-        let cf_stats = ConfusionStats::new(input, &self.config);
-        let scaled_true_positive = cf_stats.clone().true_positive() * (1.0 + self.beta.powi(2));
-        let metric = self.class_average(
-            scaled_true_positive.clone()
-                / (scaled_true_positive
-                    + cf_stats.clone().false_negative() * self.beta.powi(2)
-                    + cf_stats.false_positive()),
-        );
+        let stats = ConfusionStats::new(input, &self.config);
+        let tp = Some(stats.clone().true_positive());
+        let fp = Some(stats.clone().false_positive());
+        let fn_ = Some(stats.false_negative());
 
-        self.state.update(
-            100.0 * metric,
-            sample_size,
+        self.state.update(tp, fp, fn_, sample_size);
+        self.state.compute_update(
+            self.config.class_reduction,
             FormatOptions::new(self.name()).unit("%").precision(2),
+            |tp, fp, fn_| {
+                let (tp, fp, fn_) = (tp.unwrap(), fp.unwrap(), fn_.unwrap());
+                let beta_sq = self.beta.powi(2);
+                let scaled_tp = tp.clone() * (1.0 + beta_sq);
+                let denom = scaled_tp.clone() + (fn_ * beta_sq) + fp;
+
+                (scaled_tp / denom) * 100.0
+            },
         )
+    }
+
+    fn compute(&mut self) -> SerializedEntry {
+        self.state
+            .compute_final(FormatOptions::new(self.name()).unit("%").precision(2))
     }
 
     fn clear(&mut self) {
@@ -157,12 +148,16 @@ impl Metric for FBetaScoreMetric {
 }
 
 impl Numeric for FBetaScoreMetric {
-    fn value(&self) -> NumericEntry {
+    fn value(&self) -> Option<NumericEntry> {
         self.state.current_value()
     }
 
-    fn running_value(&self) -> NumericEntry {
+    fn running_value(&self) -> Option<NumericEntry> {
         self.state.running_value()
+    }
+
+    fn final_value(&self) -> NumericEntry {
+        self.state.final_value()
     }
 }
 
@@ -185,7 +180,7 @@ mod tests {
         let input = dummy_classification_input(&ClassificationType::Binary).into();
         let mut metric = FBetaScoreMetric::binary(beta, threshold);
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        TensorData::from([metric.value().current()])
+        TensorData::from([metric.value().unwrap().current()])
             .assert_approx_eq::<f32>(&TensorData::from([expected * 100.0]), Tolerance::default())
     }
 
@@ -207,7 +202,7 @@ mod tests {
         let input = dummy_classification_input(&ClassificationType::Multiclass).into();
         let mut metric = FBetaScoreMetric::multiclass(beta, top_k, class_reduction);
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        TensorData::from([metric.value().current()])
+        TensorData::from([metric.value().unwrap().current()])
             .assert_approx_eq::<f32>(&TensorData::from([expected * 100.0]), Tolerance::default())
     }
 
@@ -225,7 +220,7 @@ mod tests {
         let input = dummy_classification_input(&ClassificationType::Multilabel).into();
         let mut metric = FBetaScoreMetric::multilabel(beta, threshold, class_reduction);
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        TensorData::from([metric.value().current()])
+        TensorData::from([metric.value().unwrap().current()])
             .assert_approx_eq::<f32>(&TensorData::from([expected * 100.0]), Tolerance::default())
     }
 

--- a/crates/burn-train/src/metric/fbetascore.rs
+++ b/crates/burn-train/src/metric/fbetascore.rs
@@ -141,7 +141,6 @@ impl Metric for FBetaScoreMetric {
         NumericAttributes {
             unit: Some("%".to_string()),
             higher_is_better: true,
-            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/hamming.rs
+++ b/crates/burn-train/src/metric/hamming.rs
@@ -84,11 +84,14 @@ impl Metric for HammingScore {
             .mean()
             .into_scalar::<f64>();
 
-        self.state.update(
-            100.0 * score,
-            batch_size,
-            FormatOptions::new(self.name()).unit("%").precision(2),
-        )
+        self.state.update(100.0 * score, batch_size);
+        self.state
+            .compute_update(FormatOptions::new(self.name()).unit("%").precision(2))
+    }
+
+    fn compute(&mut self) -> SerializedEntry {
+        self.state
+            .compute_final(FormatOptions::new(self.name()).unit("%").precision(2))
     }
 
     fn clear(&mut self) {
@@ -110,12 +113,16 @@ impl Metric for HammingScore {
 }
 
 impl Numeric for HammingScore {
-    fn value(&self) -> NumericEntry {
-        self.state.current_value()
+    fn value(&self) -> Option<NumericEntry> {
+        Some(self.state.current_value())
     }
 
-    fn running_value(&self) -> NumericEntry {
-        self.state.running_value()
+    fn running_value(&self) -> Option<NumericEntry> {
+        Some(self.state.running_value())
+    }
+
+    fn final_value(&self) -> NumericEntry {
+        self.state.final_value()
     }
 }
 
@@ -151,7 +158,7 @@ mod tests {
             &HammingScoreInput::new(x.clone(), y.clone()),
             &MetricMetadata::fake(),
         );
-        assert_eq!(100.0, metric.value().current());
+        assert_eq!(100.0, metric.value().unwrap().current());
 
         // Invert all targets: y = (1 - y)
         let y = y.neg().add_scalar(1);
@@ -159,7 +166,7 @@ mod tests {
             &HammingScoreInput::new(x.clone(), y), // invert targets (1 - y)
             &MetricMetadata::fake(),
         );
-        assert_eq!(0.0, metric.value().current());
+        assert_eq!(0.0, metric.value().unwrap().current());
 
         // Invert 5 target values -> 1 - (5/20) = 0.75
         let y = Tensor::from_data(
@@ -175,7 +182,7 @@ mod tests {
             &HammingScoreInput::new(x, y), // invert targets (1 - y)
             &MetricMetadata::fake(),
         );
-        assert_eq!(75.0, metric.value().current());
+        assert_eq!(75.0, metric.value().unwrap().current());
     }
 
     #[test]

--- a/crates/burn-train/src/metric/hamming.rs
+++ b/crates/burn-train/src/metric/hamming.rs
@@ -106,7 +106,6 @@ impl Metric for HammingScore {
         NumericAttributes {
             unit: Some("%".to_string()),
             higher_is_better: true,
-            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/iteration.rs
+++ b/crates/burn-train/src/metric/iteration.rs
@@ -52,9 +52,16 @@ impl Metric for IterationSpeedMetric {
             }
         };
 
-        self.state.update(
-            raw,
-            1,
+        self.state.update(raw, 1);
+        self.state.compute_update(
+            FormatOptions::new(self.name())
+                .unit("iter/sec")
+                .precision(2),
+        )
+    }
+
+    fn compute(&mut self) -> SerializedEntry {
+        self.state.compute_final(
             FormatOptions::new(self.name())
                 .unit("iter/sec")
                 .precision(2),
@@ -80,11 +87,15 @@ impl Metric for IterationSpeedMetric {
 }
 
 impl Numeric for IterationSpeedMetric {
-    fn value(&self) -> NumericEntry {
-        self.state.current_value()
+    fn value(&self) -> Option<NumericEntry> {
+        Some(self.state.current_value())
     }
 
-    fn running_value(&self) -> NumericEntry {
-        self.state.running_value()
+    fn running_value(&self) -> Option<NumericEntry> {
+        Some(self.state.running_value())
+    }
+
+    fn final_value(&self) -> NumericEntry {
+        self.state.final_value()
     }
 }

--- a/crates/burn-train/src/metric/iteration.rs
+++ b/crates/burn-train/src/metric/iteration.rs
@@ -80,7 +80,6 @@ impl Metric for IterationSpeedMetric {
         NumericAttributes {
             unit: Some("iter/sec".to_string()),
             higher_is_better: true,
-            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/learning_rate.rs
+++ b/crates/burn-train/src/metric/learning_rate.rs
@@ -36,8 +36,14 @@ impl Metric for LearningRateMetric {
         // TODO: We only log the default learning rate. Yet another motivation to introduce metric groups.
         let lr = metadata.lr.as_ref().map(|val| val.base()).unwrap_or(0.0);
 
+        self.state.update(lr, 1);
         self.state
-            .update(lr, 1, FormatOptions::new(self.name()).precision(2))
+            .compute_update(FormatOptions::new(self.name()).precision(2))
+    }
+
+    fn compute(&mut self) -> SerializedEntry {
+        self.state
+            .compute_final(FormatOptions::new(self.name()).precision(2))
     }
 
     fn clear(&mut self) {
@@ -58,12 +64,17 @@ impl Metric for LearningRateMetric {
     }
 }
 
+// TODO: LR should probably just report the current value, the aggregated values don't make as much sense esp. for visualization
 impl Numeric for LearningRateMetric {
-    fn value(&self) -> NumericEntry {
-        self.state.current_value()
+    fn value(&self) -> Option<NumericEntry> {
+        Some(self.state.current_value())
     }
 
-    fn running_value(&self) -> NumericEntry {
-        self.state.running_value()
+    fn running_value(&self) -> Option<NumericEntry> {
+        Some(self.state.running_value())
+    }
+
+    fn final_value(&self) -> NumericEntry {
+        self.state.final_value()
     }
 }

--- a/crates/burn-train/src/metric/learning_rate.rs
+++ b/crates/burn-train/src/metric/learning_rate.rs
@@ -58,7 +58,6 @@ impl Metric for LearningRateMetric {
         NumericAttributes {
             unit: None,
             higher_is_better: false,
-            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/loss.rs
+++ b/crates/burn-train/src/metric/loss.rs
@@ -73,7 +73,6 @@ impl Metric for LossMetric {
         NumericAttributes {
             unit: None,
             higher_is_better: false,
-            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/loss.rs
+++ b/crates/burn-train/src/metric/loss.rs
@@ -51,11 +51,14 @@ impl Metric for LossMetric {
             .next()
             .unwrap();
 
-        self.state.update(
-            loss,
-            batch_size,
-            FormatOptions::new(self.name()).precision(2),
-        )
+        self.state.update(loss, batch_size);
+        self.state
+            .compute_update(FormatOptions::new(self.name()).precision(2))
+    }
+
+    fn compute(&mut self) -> SerializedEntry {
+        self.state
+            .compute_final(FormatOptions::new(self.name()).precision(2))
     }
 
     fn clear(&mut self) {
@@ -77,11 +80,15 @@ impl Metric for LossMetric {
 }
 
 impl Numeric for LossMetric {
-    fn value(&self) -> NumericEntry {
-        self.state.current_value()
+    fn value(&self) -> Option<NumericEntry> {
+        Some(self.state.current_value())
     }
 
-    fn running_value(&self) -> NumericEntry {
-        self.state.running_value()
+    fn running_value(&self) -> Option<NumericEntry> {
+        Some(self.state.running_value())
+    }
+
+    fn final_value(&self) -> NumericEntry {
+        self.state.final_value()
     }
 }

--- a/crates/burn-train/src/metric/memory_use.rs
+++ b/crates/burn-train/src/metric/memory_use.rs
@@ -71,6 +71,10 @@ impl Metric for CpuMemory {
             self.refresh();
         }
 
+        self.compute()
+    }
+
+    fn compute(&mut self) -> SerializedEntry {
         let raw = bytes2gb(self.ram_bytes_used);
         let formatted = format!(
             "RAM Used: {:.2} / {:.2} Gb",
@@ -98,11 +102,15 @@ impl Metric for CpuMemory {
 }
 
 impl Numeric for CpuMemory {
-    fn value(&self) -> NumericEntry {
-        NumericEntry::Value(bytes2gb(self.ram_bytes_used))
+    fn value(&self) -> Option<NumericEntry> {
+        Some(NumericEntry::Value(bytes2gb(self.ram_bytes_used)))
     }
 
-    fn running_value(&self) -> NumericEntry {
+    fn running_value(&self) -> Option<NumericEntry> {
+        Some(NumericEntry::Value(bytes2gb(self.ram_bytes_used)))
+    }
+
+    fn final_value(&self) -> NumericEntry {
         NumericEntry::Value(bytes2gb(self.ram_bytes_used))
     }
 }

--- a/crates/burn-train/src/metric/memory_use.rs
+++ b/crates/burn-train/src/metric/memory_use.rs
@@ -95,7 +95,6 @@ impl Metric for CpuMemory {
         NumericAttributes {
             unit: Some("Gb".to_string()),
             higher_is_better: false,
-            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/perplexity.rs
+++ b/crates/burn-train/src/metric/perplexity.rs
@@ -232,7 +232,6 @@ impl Metric for PerplexityMetric {
         NumericAttributes {
             unit: None,
             higher_is_better: false,
-            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/perplexity.rs
+++ b/crates/burn-train/src/metric/perplexity.rs
@@ -90,20 +90,20 @@ impl PerplexityState {
         SerializedEntry::new(formatted, serialized)
     }
 
-    fn value(&self) -> NumericEntry {
+    fn value(&self) -> Option<NumericEntry> {
         let perplexity = if self.total_tokens > 0 {
             (self.sum_nll / self.total_tokens as f64).exp()
         } else {
             f64::INFINITY
         };
 
-        NumericEntry::Aggregated {
+        Some(NumericEntry::Aggregated {
             aggregated_value: perplexity,
             count: self.total_tokens,
-        }
+        })
     }
 
-    fn running_value(&self) -> NumericEntry {
+    fn running_value(&self) -> Option<NumericEntry> {
         self.value()
     }
 }
@@ -216,6 +216,10 @@ impl Metric for PerplexityMetric {
         )
     }
 
+    fn compute(&mut self) -> SerializedEntry {
+        todo!()
+    }
+
     fn clear(&mut self) {
         self.state.reset()
     }
@@ -235,12 +239,16 @@ impl Metric for PerplexityMetric {
 }
 
 impl Numeric for PerplexityMetric {
-    fn value(&self) -> NumericEntry {
+    fn value(&self) -> Option<NumericEntry> {
         self.state.value()
     }
 
-    fn running_value(&self) -> NumericEntry {
+    fn running_value(&self) -> Option<NumericEntry> {
         self.state.running_value()
+    }
+
+    fn final_value(&self) -> NumericEntry {
+        todo!()
     }
 }
 
@@ -267,7 +275,7 @@ mod tests {
         );
 
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        let perplexity = metric.value().current();
+        let perplexity = metric.value().unwrap().current();
 
         // Perfect predictions should result in very low perplexity (close to 1.0)
         assert!(
@@ -296,7 +304,7 @@ mod tests {
         );
 
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        let perplexity = metric.value().current();
+        let perplexity = metric.value().unwrap().current();
 
         // Uniform distribution over 3 classes should have perplexity ≈ 3.0
         assert!(
@@ -325,7 +333,7 @@ mod tests {
         );
 
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        let perplexity = metric.value().current();
+        let perplexity = metric.value().unwrap().current();
 
         // Should only consider the first two predictions, both of which are confident
         assert!(
@@ -354,7 +362,7 @@ mod tests {
         );
 
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        let perplexity = metric.value().current();
+        let perplexity = metric.value().unwrap().current();
 
         // Wrong predictions should result in high perplexity
         assert!(
@@ -396,7 +404,7 @@ mod tests {
         let _entry1 = metric.update(&input1, &MetricMetadata::fake());
         let _entry2 = metric.update(&input2, &MetricMetadata::fake());
 
-        let aggregated_perplexity = metric.value().current();
+        let aggregated_perplexity = metric.value().unwrap().current();
 
         // For uniform distribution over 3 classes: log_prob ≈ -log(3) ≈ -1.0986
         // Total negative log-likelihood: 3 * 1.0986 ≈ 3.2958
@@ -416,7 +424,7 @@ mod tests {
         );
 
         let _single_entry = single_batch_metric.update(&single_input, &MetricMetadata::fake());
-        let single_batch_perplexity = single_batch_metric.value().current();
+        let single_batch_perplexity = single_batch_metric.value().unwrap().current();
 
         // Multi-batch and single-batch should give the same result
         assert!(

--- a/crates/burn-train/src/metric/perplexity.rs
+++ b/crates/burn-train/src/metric/perplexity.rs
@@ -17,6 +17,7 @@ struct PerplexityState {
     total_tokens: usize,
     /// Current batch perplexity (for display purposes)
     current: f64,
+    current_tokens: usize,
 }
 
 impl PerplexityState {
@@ -25,6 +26,7 @@ impl PerplexityState {
             sum_nll: 0.0,
             total_tokens: 0,
             current: f64::NAN,
+            current_tokens: 0,
         }
     }
 
@@ -32,15 +34,11 @@ impl PerplexityState {
         self.sum_nll = 0.0;
         self.total_tokens = 0;
         self.current = f64::NAN;
+        self.current_tokens = 0;
     }
 
     /// Update state with negative log-likelihood and token count from current batch
-    fn update(
-        &mut self,
-        sum_log_prob: f64,
-        effective_tokens: usize,
-        format: FormatOptions,
-    ) -> SerializedEntry {
+    fn update(&mut self, sum_log_prob: f64, effective_tokens: usize) {
         // sum_log_prob is already the sum of log probabilities (negative values)
         // We need to negate it to get negative log-likelihood
         let batch_nll = -sum_log_prob;
@@ -56,6 +54,21 @@ impl PerplexityState {
             f64::INFINITY
         };
         self.current = batch_perplexity;
+        self.current_tokens = effective_tokens;
+    }
+
+    /// Compute the metric for the current update.
+    pub fn compute_update(&self, format: FormatOptions) -> SerializedEntry {
+        self.compute(format, false)
+    }
+
+    /// Compute the final metric for the accumulated global state.
+    pub fn compute_final(&self, format: FormatOptions) -> SerializedEntry {
+        self.compute(format, true)
+    }
+
+    fn compute(&self, format: FormatOptions, final_entry: bool) -> SerializedEntry {
+        let batch_perplexity = self.current;
 
         // Compute running epoch perplexity
         let epoch_perplexity = if self.total_tokens > 0 {
@@ -81,30 +94,44 @@ impl PerplexityState {
         };
 
         // Serialize the state for aggregation
-        let serialized = NumericEntry::Aggregated {
-            aggregated_value: epoch_perplexity,
-            count: self.total_tokens,
-        }
-        .serialize();
+        let serialized = if final_entry {
+            NumericEntry::Final(epoch_perplexity).serialize()
+        } else {
+            NumericEntry::Aggregated {
+                aggregated_value: batch_perplexity,
+                count: self.current_tokens,
+            }
+            .serialize()
+        };
 
         SerializedEntry::new(formatted, serialized)
     }
 
-    fn value(&self) -> Option<NumericEntry> {
-        let perplexity = if self.total_tokens > 0 {
-            (self.sum_nll / self.total_tokens as f64).exp()
-        } else {
-            f64::INFINITY
-        };
-
+    fn current_value(&self) -> Option<NumericEntry> {
         Some(NumericEntry::Aggregated {
-            aggregated_value: perplexity,
-            count: self.total_tokens,
+            // self.current is already exp(batch_nll / effective_tokens)
+            aggregated_value: self.current,
+            count: self.current_tokens,
         })
     }
 
     fn running_value(&self) -> Option<NumericEntry> {
-        self.value()
+        Some(NumericEntry::Aggregated {
+            aggregated_value: entry_value(self.sum_nll, self.total_tokens),
+            count: self.total_tokens,
+        })
+    }
+
+    fn final_value(&self) -> NumericEntry {
+        NumericEntry::Final(entry_value(self.sum_nll, self.total_tokens))
+    }
+}
+
+fn entry_value(value: f64, count: usize) -> f64 {
+    if count > 0 {
+        (value / count as f64).exp()
+    } else {
+        f64::INFINITY
     }
 }
 
@@ -209,15 +236,14 @@ impl Metric for PerplexityMetric {
 
         // Pass the sum_log_prob and effective_tokens to the state
         // The state will handle the correct accumulation and perplexity calculation
-        self.state.update(
-            sum_log_prob,
-            effective_tokens,
-            FormatOptions::new(self.name()).precision(2),
-        )
+        self.state.update(sum_log_prob, effective_tokens);
+        self.state
+            .compute_update(FormatOptions::new(self.name()).precision(2))
     }
 
     fn compute(&mut self) -> SerializedEntry {
-        todo!()
+        self.state
+            .compute_final(FormatOptions::new(self.name()).precision(2))
     }
 
     fn clear(&mut self) {
@@ -239,7 +265,7 @@ impl Metric for PerplexityMetric {
 
 impl Numeric for PerplexityMetric {
     fn value(&self) -> Option<NumericEntry> {
-        self.state.value()
+        self.state.current_value()
     }
 
     fn running_value(&self) -> Option<NumericEntry> {
@@ -247,7 +273,7 @@ impl Numeric for PerplexityMetric {
     }
 
     fn final_value(&self) -> NumericEntry {
-        todo!()
+        self.state.final_value()
     }
 }
 
@@ -431,6 +457,61 @@ mod tests {
             "Multi-batch ({}) and single-batch ({}) perplexity should match",
             aggregated_perplexity,
             single_batch_perplexity
+        );
+    }
+
+    #[test]
+    fn test_perplexity_global_aggregation_end_to_end() {
+        let device = Default::default();
+        let mut metric = PerplexityMetric::new();
+
+        // Batch 1 (1 token, confident prediction -> low NLL):
+        // logits lead to log_prob ≈ -0.1 -> NLL = 0.1
+        let input_batch1 = PerplexityInput::new(
+            Tensor::from_data([[5.0, 0.0, 0.0]], &device),
+            Tensor::from_data([0], &device),
+        );
+        let _ = metric.update(&input_batch1, &MetricMetadata::fake());
+
+        let batch1_current = metric.value().unwrap().current();
+        let batch1_running = metric.running_value().unwrap().current();
+        assert_eq!(batch1_current, batch1_running);
+
+        // Batch 2 (5 tokens, uniform predictions -> higher NLL):
+        // uniform over 3 classes -> log_prob ≈ -log(3) ≈ -1.0986 -> NLL = 1.0986 per token
+        let input_batch2 = PerplexityInput::new(
+            Tensor::from_data(
+                [
+                    [0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0],
+                ],
+                &device,
+            ),
+            Tensor::from_data([0, 1, 2, 0, 1], &device),
+        );
+        let _ = metric.update(&input_batch2, &MetricMetadata::fake());
+
+        // Batch 2 current batch perplexity should be ≈ 3.0
+        let batch2_current = metric.value().unwrap().current();
+        assert!((batch2_current - 3.0).abs() < 0.1);
+
+        // Compute final epoch entry
+        let _serialized_compute = metric.compute();
+        let final_ppl = metric.final_value().current();
+
+        // Total NLL = 0.013416 + 5.493061 = 5.506477
+        // Global PPL = exp(5.506477 / 6 tokens) ≈ 2.5036
+        // Note: Simple unweighted average of batch PPLs would incorrectly give (1.0135 + 3.0) / 2 = 2.0067
+        let expected_global_ppl = 2.5036;
+
+        assert!(
+            (final_ppl - expected_global_ppl).abs() < 1e-3,
+            "Expected final aggregated perplexity ~{}, got {}",
+            expected_global_ppl,
+            final_ppl
         );
     }
 }

--- a/crates/burn-train/src/metric/precision.rs
+++ b/crates/burn-train/src/metric/precision.rs
@@ -127,7 +127,6 @@ impl Metric for PrecisionMetric {
         NumericAttributes {
             unit: Some("%".to_string()),
             higher_is_better: true,
-            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/precision.rs
+++ b/crates/burn-train/src/metric/precision.rs
@@ -6,7 +6,6 @@ use super::{
     confusion_stats::{ConfusionStats, ConfusionStatsInput},
     state::FormatOptions,
 };
-use burn_core::prelude::Tensor;
 use std::{num::NonZeroUsize, sync::Arc};
 
 /// The Precision Metric
@@ -83,23 +82,6 @@ impl PrecisionMetric {
             ..Default::default()
         }
     }
-
-    fn class_average(&self, mut aggregated_metric: Tensor<1>) -> f64 {
-        use ClassReduction::{Macro, Micro};
-        let avg_tensor = match self.config.class_reduction {
-            Micro => aggregated_metric,
-            Macro => {
-                if aggregated_metric.clone().contains_nan().any().into_scalar() {
-                    let nan_mask = aggregated_metric.clone().is_nan();
-                    aggregated_metric = aggregated_metric
-                        .clone()
-                        .select(0, nan_mask.bool_not().argwhere().squeeze_dim(1))
-                }
-                aggregated_metric.mean()
-            }
-        };
-        avg_tensor.into_scalar()
-    }
 }
 
 impl Metric for PrecisionMetric {
@@ -117,11 +99,6 @@ impl Metric for PrecisionMetric {
             self.config.class_reduction,
             FormatOptions::new(self.name()).unit("%").precision(2),
             |tp, fp, _| {
-                log::info!(
-                    "[PrecisionMetric] compute fn ({}; {})",
-                    tp.is_some(),
-                    fp.is_some()
-                );
                 let (tp, fp) = (tp.unwrap(), fp.unwrap());
                 let denominator = tp.clone() + fp;
                 // Avoid division by zero on empty classes
@@ -237,4 +214,6 @@ mod tests {
         let metric_b = PrecisionMetric::binary(0.75);
         assert_ne!(metric_a.name(), metric_b.name());
     }
+
+    // TODO: multiple update calls + compute final for global precision
 }

--- a/crates/burn-train/src/metric/precision.rs
+++ b/crates/burn-train/src/metric/precision.rs
@@ -153,10 +153,10 @@ mod tests {
         ClassReduction::{self, *},
         Metric, MetricMetadata, PrecisionMetric,
     };
-    use crate::metric::Numeric;
+    use crate::metric::{ConfusionStatsInput, Numeric};
     use crate::tests::{ClassificationType, THRESHOLD, dummy_classification_input};
-    use burn_core::tensor::TensorData;
     use burn_core::tensor::Tolerance;
+    use burn_core::{Tensor, tensor::TensorData};
     use rstest::rstest;
 
     #[rstest]
@@ -215,5 +215,46 @@ mod tests {
         assert_ne!(metric_a.name(), metric_b.name());
     }
 
-    // TODO: multiple update calls + compute final for global precision
+    #[test]
+    fn test_precision_global_aggregation() {
+        // Batch 1 (3 samples):
+        //   preds:   [[0.9], [0.8], [0.1]] -> binary threshold 0.5 -> [1, 1, 0]
+        //   targets: [1, 0, 0]             -> TP = 1, FP = 1 (denom = 2, Batch Precision = 50.0%)
+        //
+        // Batch 2 (6 samples):
+        //   preds:   [[0.9], [0.9], [0.9], [0.9], [0.9], [0.1]] -> binary threshold 0.5 -> [1, 1, 1, 1, 1, 0]
+        //   targets: [1, 0, 0, 0, 0, 0]                         -> TP = 1, FP = 4 (denom = 5, Batch Precision = 20.0%)
+        //
+        // Previously, using `NumericMetricState` would give a weighted average based on sample count N:
+        //   (3 * 50.0% + 6 * 20.0%) / (3 + 6) = 270 / 9 = 30.0% (incorrectly weighting by total samples N)
+        //
+        // Correct Global Aggregation = Total TP / Total (TP + FP) = (1 + 1) / (2 + 5) = 2 / 7 = 28.5714%
+
+        let mut metric = PrecisionMetric::binary(THRESHOLD);
+
+        // Batch 1
+        let input_batch1 = ConfusionStatsInput {
+            predictions: Tensor::from([[0.9], [0.8], [0.1]]),
+            targets: Tensor::from([[1], [0], [0]]),
+        };
+        let _ = metric.update(&input_batch1, &MetricMetadata::fake());
+
+        // Batch 2
+        let input_batch2 = ConfusionStatsInput {
+            predictions: Tensor::from([[0.9], [0.9], [0.9], [0.9], [0.9], [0.1]]),
+            targets: Tensor::from([[1], [0], [0], [0], [0], [0]]),
+        };
+        let _ = metric.update(&input_batch2, &MetricMetadata::fake());
+
+        // Compute final aggregated metric
+        let _final_entry = metric.compute();
+        let global_precision = metric.final_value().current();
+
+        let expected_global_precision = (2.0 / 7.0) * 100.0;
+
+        TensorData::from([global_precision]).assert_approx_eq::<f32>(
+            &TensorData::from([expected_global_precision]),
+            Tolerance::default(),
+        );
+    }
 }

--- a/crates/burn-train/src/metric/precision.rs
+++ b/crates/burn-train/src/metric/precision.rs
@@ -1,10 +1,10 @@
-use crate::metric::{MetricName, Numeric};
+use crate::metric::{MetricName, Numeric, state::ConfusionStatsState};
 
 use super::{
     Metric, MetricAttributes, MetricMetadata, NumericAttributes, NumericEntry, SerializedEntry,
     classification::{ClassReduction, ClassificationMetricConfig, DecisionRule},
     confusion_stats::{ConfusionStats, ConfusionStatsInput},
-    state::{FormatOptions, NumericMetricState},
+    state::FormatOptions,
 };
 use burn_core::prelude::Tensor;
 use std::{num::NonZeroUsize, sync::Arc};
@@ -13,7 +13,7 @@ use std::{num::NonZeroUsize, sync::Arc};
 #[derive(Clone)]
 pub struct PrecisionMetric {
     name: MetricName,
-    state: NumericMetricState,
+    state: ConfusionStatsState,
     config: ClassificationMetricConfig,
 }
 
@@ -108,15 +108,34 @@ impl Metric for PrecisionMetric {
     fn update(&mut self, input: &Self::Input, _metadata: &MetricMetadata) -> SerializedEntry {
         let [sample_size, _] = input.predictions.dims();
 
-        let cf_stats = ConfusionStats::new(input, &self.config);
-        let metric =
-            self.class_average(cf_stats.clone().true_positive() / cf_stats.predicted_positive());
+        let stats = ConfusionStats::new(input, &self.config);
+        let tp = Some(stats.clone().true_positive());
+        let fp = Some(stats.clone().false_positive());
 
-        self.state.update(
-            100.0 * metric,
-            sample_size,
+        self.state.update(tp, fp, None, sample_size);
+        self.state.compute_update(
+            self.config.class_reduction,
             FormatOptions::new(self.name()).unit("%").precision(2),
+            |tp, fp, _| {
+                log::info!(
+                    "[PrecisionMetric] compute fn ({}; {})",
+                    tp.is_some(),
+                    fp.is_some()
+                );
+                let (tp, fp) = (tp.unwrap(), fp.unwrap());
+                let denominator = tp.clone() + fp;
+                // Avoid division by zero on empty classes
+                let mask = denominator.clone().equal_elem(0.0);
+                let predicted_positive = denominator.mask_fill(mask, 1.0);
+
+                (tp / predicted_positive) * 100.0
+            },
         )
+    }
+
+    fn compute(&mut self) -> SerializedEntry {
+        self.state
+            .compute_final(FormatOptions::new(self.name()).unit("%").precision(2))
     }
 
     fn clear(&mut self) {
@@ -138,12 +157,16 @@ impl Metric for PrecisionMetric {
 }
 
 impl Numeric for PrecisionMetric {
-    fn value(&self) -> NumericEntry {
+    fn value(&self) -> Option<NumericEntry> {
         self.state.current_value()
     }
 
-    fn running_value(&self) -> NumericEntry {
+    fn running_value(&self) -> Option<NumericEntry> {
         self.state.running_value()
+    }
+
+    fn final_value(&self) -> NumericEntry {
+        self.state.final_value()
     }
 }
 
@@ -165,7 +188,7 @@ mod tests {
         let input = dummy_classification_input(&ClassificationType::Binary).into();
         let mut metric = PrecisionMetric::binary(threshold);
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        TensorData::from([metric.value().current()])
+        TensorData::from([metric.value().unwrap().current()])
             .assert_approx_eq::<f64>(&TensorData::from([expected * 100.0]), Tolerance::default())
     }
 
@@ -182,7 +205,7 @@ mod tests {
         let input = dummy_classification_input(&ClassificationType::Multiclass).into();
         let mut metric = PrecisionMetric::multiclass(top_k, class_reduction);
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        TensorData::from([metric.value().current()])
+        TensorData::from([metric.value().unwrap().current()])
             .assert_approx_eq::<f64>(&TensorData::from([expected * 100.0]), Tolerance::default())
     }
 
@@ -197,7 +220,7 @@ mod tests {
         let input = dummy_classification_input(&ClassificationType::Multilabel).into();
         let mut metric = PrecisionMetric::multilabel(threshold, class_reduction);
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        TensorData::from([metric.value().current()])
+        TensorData::from([metric.value().unwrap().current()])
             .assert_approx_eq::<f64>(&TensorData::from([expected * 100.0]), Tolerance::default())
     }
 

--- a/crates/burn-train/src/metric/processor/full.rs
+++ b/crates/burn-train/src/metric/processor/full.rs
@@ -2,7 +2,7 @@ use super::{EventProcessorTraining, ItemLazy, LearnerEvent, MetricsTraining};
 use crate::logger::{EvaluationProgressLogger, TrainingProgressLogger};
 use crate::metric::MetricMetadata;
 use crate::metric::processor::{EvaluatorEvent, EventProcessorEvaluation, MetricsEvaluation};
-use crate::metric::store::{EpochSummary, EventStoreClient, Split};
+use crate::metric::store::{EpochSummary, EventStoreClient, MetricsUpdate, Split};
 use crate::renderer::{MetricState, MetricsRenderer};
 use std::sync::Arc;
 
@@ -49,6 +49,65 @@ impl<T: ItemLazy, V: ItemLazy> FullEventProcessorTraining<T, V> {
     pub(crate) fn with_progress_logger(mut self, logger: Box<dyn TrainingProgressLogger>) -> Self {
         self.progress_logger = Some(logger);
         self
+    }
+
+    fn handle_train_metrics_update(&mut self, update: MetricsUpdate) {
+        self.store
+            .add_event_train(crate::metric::store::Event::MetricsUpdate(update.clone()));
+
+        update
+            .entries
+            .into_iter()
+            .for_each(|entry| self.renderer.update_train(MetricState::Generic(entry)));
+
+        update
+            .entries_numeric
+            .into_iter()
+            .for_each(|numeric_update| {
+                /*
+                In compute:
+                NumericMetricUpdate {
+                    entry: update,
+                    // Current value is not applicable. This is the final epoch-level value computed.
+                    numeric_entry: None,
+                    running_entry: running, /* NumericEntry */
+                }
+
+                TUI: NumericEntry
+                */
+                let state = match numeric_update.numeric_entry {
+                    Some(value) => MetricState::Numeric(numeric_update.entry, value),
+                    None => match numeric_update.running_entry {
+                        Some(value) => MetricState::Numeric(numeric_update.entry, value),
+                        None => MetricState::Generic(numeric_update.entry),
+                    },
+                };
+                self.renderer.update_train(state)
+            });
+    }
+
+    fn handle_valid_metrics_update(&mut self, update: MetricsUpdate) {
+        self.store
+            .add_event_valid(crate::metric::store::Event::MetricsUpdate(update.clone()));
+
+        update
+            .entries
+            .into_iter()
+            .for_each(|entry| self.renderer.update_valid(MetricState::Generic(entry)));
+
+        update
+            .entries_numeric
+            .into_iter()
+            .for_each(|numeric_update| {
+                let state = match numeric_update.numeric_entry {
+                    Some(value) => MetricState::Numeric(numeric_update.entry, value),
+                    None => match numeric_update.running_entry {
+                        Some(value) => MetricState::Numeric(numeric_update.entry, value),
+                        None => MetricState::Generic(numeric_update.entry),
+                    },
+                };
+                self.renderer.update_valid(state)
+            });
     }
 }
 
@@ -125,13 +184,11 @@ impl<T: ItemLazy> EventProcessorEvaluation for FullEventProcessorEvaluation<T> {
                     .entries_numeric
                     .into_iter()
                     .for_each(|numeric_update| {
-                        self.renderer.update_test(
-                            name.clone(),
-                            MetricState::Numeric(
-                                numeric_update.entry,
-                                numeric_update.numeric_entry,
-                            ),
-                        )
+                        let state = match numeric_update.numeric_entry {
+                            Some(value) => MetricState::Numeric(numeric_update.entry, value),
+                            None => MetricState::Generic(numeric_update.entry),
+                        };
+                        self.renderer.update_test(name.clone(), state)
                     });
 
                 if let Some(logger) = &mut self.progress_logger {
@@ -207,24 +264,7 @@ impl<T: ItemLazy, V: ItemLazy> EventProcessorTraining<LearnerEvent<T>, LearnerEv
                 };
 
                 let update = self.metrics.update_train(&item, &metadata);
-
-                self.store
-                    .add_event_train(crate::metric::store::Event::MetricsUpdate(update.clone()));
-
-                update
-                    .entries
-                    .into_iter()
-                    .for_each(|entry| self.renderer.update_train(MetricState::Generic(entry)));
-
-                update
-                    .entries_numeric
-                    .into_iter()
-                    .for_each(|numeric_update| {
-                        self.renderer.update_train(MetricState::Numeric(
-                            numeric_update.entry,
-                            numeric_update.numeric_entry,
-                        ))
-                    });
+                self.handle_train_metrics_update(update);
 
                 if let Some(logger) = &mut self.progress_logger {
                     logger.update_split(item.progress.items_processed);
@@ -234,6 +274,9 @@ impl<T: ItemLazy, V: ItemLazy> EventProcessorTraining<LearnerEvent<T>, LearnerEv
                 self.renderer.log_event_training("Iteration".to_string());
             }
             LearnerEvent::EndSplit(epoch) => {
+                let update = self.metrics.end_epoch_train();
+                self.handle_train_metrics_update(update);
+
                 self.store
                     .add_event_train(crate::metric::store::Event::EndEpoch(EpochSummary::new(
                         epoch,
@@ -243,7 +286,6 @@ impl<T: ItemLazy, V: ItemLazy> EventProcessorTraining<LearnerEvent<T>, LearnerEv
                     logger.end_split();
                 }
                 self.renderer.end_split();
-                self.metrics.end_epoch_train();
             }
             LearnerEvent::EndEpoch(epoch) => {
                 self.current_epoch = epoch + 1;
@@ -285,24 +327,7 @@ impl<T: ItemLazy, V: ItemLazy> EventProcessorTraining<LearnerEvent<T>, LearnerEv
                 };
 
                 let update = self.metrics.update_valid(&item, &metadata);
-
-                self.store
-                    .add_event_valid(crate::metric::store::Event::MetricsUpdate(update.clone()));
-
-                update
-                    .entries
-                    .into_iter()
-                    .for_each(|entry| self.renderer.update_valid(MetricState::Generic(entry)));
-
-                update
-                    .entries_numeric
-                    .into_iter()
-                    .for_each(|numeric_update| {
-                        self.renderer.update_valid(MetricState::Numeric(
-                            numeric_update.entry,
-                            numeric_update.numeric_entry,
-                        ))
-                    });
+                self.handle_valid_metrics_update(update);
 
                 if let Some(logger) = &mut self.progress_logger {
                     logger.update_split(item.progress.items_processed);
@@ -312,6 +337,9 @@ impl<T: ItemLazy, V: ItemLazy> EventProcessorTraining<LearnerEvent<T>, LearnerEv
                 self.renderer.log_event_training("Iteration".to_string());
             }
             LearnerEvent::EndSplit(epoch) => {
+                let update = self.metrics.end_epoch_valid();
+                self.handle_valid_metrics_update(update);
+
                 self.store
                     .add_event_valid(crate::metric::store::Event::EndEpoch(EpochSummary::new(
                         epoch,
@@ -321,7 +349,6 @@ impl<T: ItemLazy, V: ItemLazy> EventProcessorTraining<LearnerEvent<T>, LearnerEv
                     logger.end_split();
                 }
                 self.renderer.end_split();
-                self.metrics.end_epoch_valid();
             }
             LearnerEvent::EndEpoch(_) => {} // update_epoch is handled in process_train(EndEpoch)
             LearnerEvent::End(_) => {}      // no-op

--- a/crates/burn-train/src/metric/processor/full.rs
+++ b/crates/burn-train/src/metric/processor/full.rs
@@ -64,25 +64,10 @@ impl<T: ItemLazy, V: ItemLazy> FullEventProcessorTraining<T, V> {
             .entries_numeric
             .into_iter()
             .for_each(|numeric_update| {
-                /*
-                In compute:
-                NumericMetricUpdate {
-                    entry: update,
-                    // Current value is not applicable. This is the final epoch-level value computed.
-                    numeric_entry: None,
-                    running_entry: running, /* NumericEntry */
-                }
-
-                TUI: NumericEntry
-                */
-                let state = match numeric_update.numeric_entry {
-                    Some(value) => MetricState::Numeric(numeric_update.entry, value),
-                    None => match numeric_update.running_entry {
-                        Some(value) => MetricState::Numeric(numeric_update.entry, value),
-                        None => MetricState::Generic(numeric_update.entry),
-                    },
-                };
-                self.renderer.update_train(state)
+                self.renderer.update_train(MetricState::Numeric(
+                    numeric_update.entry,
+                    numeric_update.numeric_entry,
+                ))
             });
     }
 
@@ -99,14 +84,10 @@ impl<T: ItemLazy, V: ItemLazy> FullEventProcessorTraining<T, V> {
             .entries_numeric
             .into_iter()
             .for_each(|numeric_update| {
-                let state = match numeric_update.numeric_entry {
-                    Some(value) => MetricState::Numeric(numeric_update.entry, value),
-                    None => match numeric_update.running_entry {
-                        Some(value) => MetricState::Numeric(numeric_update.entry, value),
-                        None => MetricState::Generic(numeric_update.entry),
-                    },
-                };
-                self.renderer.update_valid(state)
+                self.renderer.update_valid(MetricState::Numeric(
+                    numeric_update.entry,
+                    numeric_update.numeric_entry,
+                ))
             });
     }
 }
@@ -184,11 +165,13 @@ impl<T: ItemLazy> EventProcessorEvaluation for FullEventProcessorEvaluation<T> {
                     .entries_numeric
                     .into_iter()
                     .for_each(|numeric_update| {
-                        let state = match numeric_update.numeric_entry {
-                            Some(value) => MetricState::Numeric(numeric_update.entry, value),
-                            None => MetricState::Generic(numeric_update.entry),
-                        };
-                        self.renderer.update_test(name.clone(), state)
+                        self.renderer.update_test(
+                            name.clone(),
+                            MetricState::Numeric(
+                                numeric_update.entry,
+                                numeric_update.numeric_entry,
+                            ),
+                        )
                     });
 
                 if let Some(logger) = &mut self.progress_logger {

--- a/crates/burn-train/src/metric/processor/metrics.rs
+++ b/crates/burn-train/src/metric/processor/metrics.rs
@@ -168,6 +168,14 @@ impl<T: ItemLazy, V: ItemLazy> MetricsTraining<T, V> {
         let mut entries = Vec::with_capacity(self.train.len());
         let mut entries_numeric = Vec::with_capacity(self.train_numeric.len());
 
+        // `*_train` used as reference, but could be valid or test
+        // FullEventProcessorTraining::process_train -> MetricsTraining::update_train -> NumericMetricUpdater::update -> Metric::update
+        // in parallel:
+        // EventStoreClient::add_event_train(Event::MetricsUpdate(update)) -> LogEventStore::add_event -> MetricLogger::log_item
+        // where MetricLogger is FileLogger
+
+        // Also in parrallel for the full event processor implementation (which includes TUI):
+        // FullEventProcessorTraining::process_train -> MetricsRendererTraining::update_train (TUI renderer updates)
         for metric in self.train.iter_mut() {
             let state = metric.update(&item.item, metadata);
             entries.push(state);
@@ -204,23 +212,40 @@ impl<T: ItemLazy, V: ItemLazy> MetricsTraining<T, V> {
     }
 
     /// Signal the end of a training epoch.
-    pub(crate) fn end_epoch_train(&mut self) {
+    /// Returns the final metric entries for the epoch.
+    pub(crate) fn end_epoch_train(&mut self) -> MetricsUpdate {
+        let mut entries = Vec::with_capacity(self.train.len());
+        let mut entries_numeric = Vec::with_capacity(self.train_numeric.len());
+
+        log::info!("[MetricsTraining] end_epoch_train");
         for metric in self.train.iter_mut() {
+            entries.push(metric.compute());
             metric.clear();
         }
         for metric in self.train_numeric.iter_mut() {
+            entries_numeric.push(metric.compute());
             metric.clear();
         }
+
+        MetricsUpdate::new(entries, entries_numeric)
     }
 
     /// Signal the end of a validation epoch.
-    pub(crate) fn end_epoch_valid(&mut self) {
+    /// Returns the final metric entries for the epoch.
+    pub(crate) fn end_epoch_valid(&mut self) -> MetricsUpdate {
+        let mut entries = Vec::with_capacity(self.valid.len());
+        let mut entries_numeric = Vec::with_capacity(self.valid_numeric.len());
+
         for metric in self.valid.iter_mut() {
+            entries.push(metric.compute());
             metric.clear();
         }
         for metric in self.valid_numeric.iter_mut() {
+            entries_numeric.push(metric.compute());
             metric.clear();
         }
+
+        MetricsUpdate::new(entries, entries_numeric)
     }
 }
 
@@ -246,11 +271,13 @@ impl<T> From<&EvaluationItem<T>> for MetricMetadata {
 
 pub(crate) trait NumericMetricUpdater<T>: Send + Sync {
     fn update(&mut self, item: &T, metadata: &MetricMetadata) -> NumericMetricUpdate;
+    fn compute(&mut self) -> NumericMetricUpdate;
     fn clear(&mut self);
 }
 
 pub(crate) trait MetricUpdater<T>: Send + Sync {
     fn update(&mut self, item: &T, metadata: &MetricMetadata) -> MetricEntry;
+    fn compute(&mut self) -> MetricEntry;
     fn clear(&mut self);
 }
 
@@ -287,6 +314,24 @@ where
         }
     }
 
+    fn compute(&mut self) -> NumericMetricUpdate {
+        let serialized_entry = self.metric.compute();
+
+        log::info!(
+            "[NumericMetricUpdater] compute final value for {:?}",
+            self.id
+        );
+        let update = MetricEntry::new(self.id.clone(), serialized_entry);
+        let final_entry = self.metric.final_value();
+
+        NumericMetricUpdate {
+            entry: update,
+            // Current value is not applicable. This is the final epoch-level value computed.
+            numeric_entry: None,
+            running_entry: Some(final_entry),
+        }
+    }
+
     fn clear(&mut self) {
         self.metric.clear()
     }
@@ -300,6 +345,11 @@ where
 {
     fn update(&mut self, item: &T, metadata: &MetricMetadata) -> MetricEntry {
         let serialized_entry = self.metric.update(&item.adapt(), metadata);
+        MetricEntry::new(self.id.clone(), serialized_entry)
+    }
+
+    fn compute(&mut self) -> MetricEntry {
+        let serialized_entry = self.metric.compute();
         MetricEntry::new(self.id.clone(), serialized_entry)
     }
 

--- a/crates/burn-train/src/metric/processor/metrics.rs
+++ b/crates/burn-train/src/metric/processor/metrics.rs
@@ -217,7 +217,6 @@ impl<T: ItemLazy, V: ItemLazy> MetricsTraining<T, V> {
         let mut entries = Vec::with_capacity(self.train.len());
         let mut entries_numeric = Vec::with_capacity(self.train_numeric.len());
 
-        log::info!("[MetricsTraining] end_epoch_train");
         for metric in self.train.iter_mut() {
             entries.push(metric.compute());
             metric.clear();
@@ -316,19 +315,14 @@ where
 
     fn compute(&mut self) -> NumericMetricUpdate {
         let serialized_entry = self.metric.compute();
-
-        log::info!(
-            "[NumericMetricUpdater] compute final value for {:?}",
-            self.id
-        );
         let update = MetricEntry::new(self.id.clone(), serialized_entry);
         let final_entry = self.metric.final_value();
 
         NumericMetricUpdate {
             entry: update,
-            // Current value is not applicable. This is the final epoch-level value computed.
-            numeric_entry: None,
-            running_entry: Some(final_entry),
+            // Running entry is not applicable. This is the final epoch-level value computed.
+            numeric_entry: Some(final_entry),
+            running_entry: None,
         }
     }
 

--- a/crates/burn-train/src/metric/processor/metrics.rs
+++ b/crates/burn-train/src/metric/processor/metrics.rs
@@ -14,7 +14,8 @@ pub(crate) struct MetricsTraining<T: ItemLazy, V: ItemLazy> {
     valid: Vec<Box<dyn MetricUpdater<V>>>,
     train_numeric: Vec<Box<dyn NumericMetricUpdater<T>>>,
     valid_numeric: Vec<Box<dyn NumericMetricUpdater<V>>>,
-    metric_definitions: HashMap<MetricId, MetricDefinition>,
+    // Vec preserves metrics registration order; reflected in TUI tabs order
+    metric_definitions: Vec<MetricDefinition>,
 }
 
 pub(crate) struct MetricsEvaluation<T: ItemLazy> {
@@ -40,7 +41,7 @@ impl<T: ItemLazy, V: ItemLazy> Default for MetricsTraining<T, V> {
             valid: Vec::default(),
             train_numeric: Vec::default(),
             valid_numeric: Vec::default(),
-            metric_definitions: HashMap::default(),
+            metric_definitions: Vec::default(),
         }
     }
 }
@@ -148,15 +149,20 @@ impl<T: ItemLazy, V: ItemLazy> MetricsTraining<T, V> {
     }
 
     fn register_definition<Me: Metric>(&mut self, metric: &MetricWrapper<Me>) {
-        self.metric_definitions.insert(
-            metric.id.clone(),
-            MetricDefinition::new(metric.id.clone(), &metric.metric),
-        );
+        // Avoid duplicate definitions if the same metric is registered for both train and valid
+        if !self
+            .metric_definitions
+            .iter()
+            .any(|def| def.metric_id == metric.id)
+        {
+            self.metric_definitions
+                .push(MetricDefinition::new(metric.id.clone(), &metric.metric));
+        }
     }
 
     /// Get metric definitions for all splits
     pub(crate) fn metric_definitions(&mut self) -> Vec<MetricDefinition> {
-        self.metric_definitions.values().cloned().collect()
+        self.metric_definitions.clone()
     }
 
     /// Update the training information from the training item.

--- a/crates/burn-train/src/metric/processor/metrics.rs
+++ b/crates/burn-train/src/metric/processor/metrics.rs
@@ -168,14 +168,6 @@ impl<T: ItemLazy, V: ItemLazy> MetricsTraining<T, V> {
         let mut entries = Vec::with_capacity(self.train.len());
         let mut entries_numeric = Vec::with_capacity(self.train_numeric.len());
 
-        // `*_train` used as reference, but could be valid or test
-        // FullEventProcessorTraining::process_train -> MetricsTraining::update_train -> NumericMetricUpdater::update -> Metric::update
-        // in parallel:
-        // EventStoreClient::add_event_train(Event::MetricsUpdate(update)) -> LogEventStore::add_event -> MetricLogger::log_item
-        // where MetricLogger is FileLogger
-
-        // Also in parrallel for the full event processor implementation (which includes TUI):
-        // FullEventProcessorTraining::process_train -> MetricsRendererTraining::update_train (TUI renderer updates)
         for metric in self.train.iter_mut() {
             let state = metric.update(&item.item, metadata);
             entries.push(state);

--- a/crates/burn-train/src/metric/processor/minimal.rs
+++ b/crates/burn-train/src/metric/processor/minimal.rs
@@ -63,15 +63,18 @@ impl<T: ItemLazy, V: ItemLazy> EventProcessorTraining<LearnerEvent<T>, LearnerEv
                 let metadata = (&item).into();
 
                 let update = self.metrics.update_train(&item, &metadata);
-
                 self.store
                     .add_event_train(crate::metric::store::Event::MetricsUpdate(update));
+
                 if let Some(logger) = &mut self.progress_logger {
                     logger.update_split(item.progress.items_processed);
                 }
             }
             LearnerEvent::EndSplit(epoch) => {
-                self.metrics.end_epoch_train();
+                let update = self.metrics.end_epoch_train();
+                self.store
+                    .add_event_train(crate::metric::store::Event::MetricsUpdate(update));
+
                 self.store
                     .add_event_train(crate::metric::store::Event::EndEpoch(EpochSummary::new(
                         epoch,
@@ -112,15 +115,18 @@ impl<T: ItemLazy, V: ItemLazy> EventProcessorTraining<LearnerEvent<T>, LearnerEv
                 let metadata = (&item).into();
 
                 let update = self.metrics.update_valid(&item, &metadata);
-
                 self.store
                     .add_event_valid(crate::metric::store::Event::MetricsUpdate(update));
+
                 if let Some(logger) = &mut self.progress_logger {
                     logger.update_split(item.progress.items_processed);
                 }
             }
             LearnerEvent::EndSplit(epoch) => {
-                self.metrics.end_epoch_valid();
+                let update = self.metrics.end_epoch_valid();
+                self.store
+                    .add_event_valid(crate::metric::store::Event::MetricsUpdate(update));
+
                 self.store
                     .add_event_valid(crate::metric::store::Event::EndEpoch(EpochSummary::new(
                         epoch,

--- a/crates/burn-train/src/metric/processor/rl_processor.rs
+++ b/crates/burn-train/src/metric/processor/rl_processor.rs
@@ -73,11 +73,10 @@ impl<TS: ItemLazy, ES: ItemLazy> RLEventProcessor<TS, ES> {
             .entries_numeric
             .into_iter()
             .for_each(|numeric_update| {
-                let state = match numeric_update.numeric_entry {
-                    Some(value) => MetricState::Numeric(numeric_update.entry, value),
-                    None => MetricState::Generic(numeric_update.entry),
-                };
-                self.renderer.update_train(state)
+                self.renderer.update_train(MetricState::Numeric(
+                    numeric_update.entry,
+                    numeric_update.numeric_entry,
+                ))
             });
     }
 
@@ -94,11 +93,10 @@ impl<TS: ItemLazy, ES: ItemLazy> RLEventProcessor<TS, ES> {
             .entries_numeric
             .into_iter()
             .for_each(|numeric_update| {
-                let state = match numeric_update.numeric_entry {
-                    Some(value) => MetricState::Numeric(numeric_update.entry, value),
-                    None => MetricState::Generic(numeric_update.entry),
-                };
-                self.renderer.update_valid(state)
+                self.renderer.update_valid(MetricState::Numeric(
+                    numeric_update.entry,
+                    numeric_update.numeric_entry,
+                ))
             });
     }
 }

--- a/crates/burn-train/src/metric/processor/rl_processor.rs
+++ b/crates/burn-train/src/metric/processor/rl_processor.rs
@@ -73,10 +73,11 @@ impl<TS: ItemLazy, ES: ItemLazy> RLEventProcessor<TS, ES> {
             .entries_numeric
             .into_iter()
             .for_each(|numeric_update| {
-                self.renderer.update_train(MetricState::Numeric(
-                    numeric_update.entry,
-                    numeric_update.numeric_entry,
-                ))
+                let state = match numeric_update.numeric_entry {
+                    Some(value) => MetricState::Numeric(numeric_update.entry, value),
+                    None => MetricState::Generic(numeric_update.entry),
+                };
+                self.renderer.update_train(state)
             });
     }
 
@@ -93,10 +94,11 @@ impl<TS: ItemLazy, ES: ItemLazy> RLEventProcessor<TS, ES> {
             .entries_numeric
             .into_iter()
             .for_each(|numeric_update| {
-                self.renderer.update_valid(MetricState::Numeric(
-                    numeric_update.entry,
-                    numeric_update.numeric_entry,
-                ))
+                let state = match numeric_update.numeric_entry {
+                    Some(value) => MetricState::Numeric(numeric_update.entry, value),
+                    None => MetricState::Generic(numeric_update.entry),
+                };
+                self.renderer.update_valid(state)
             });
     }
 }

--- a/crates/burn-train/src/metric/recall.rs
+++ b/crates/burn-train/src/metric/recall.rs
@@ -1,19 +1,18 @@
-use crate::metric::{MetricName, Numeric};
+use crate::metric::{MetricName, Numeric, state::ConfusionStatsState};
 
 use super::{
     Metric, MetricAttributes, MetricMetadata, NumericAttributes, NumericEntry, SerializedEntry,
     classification::{ClassReduction, ClassificationMetricConfig, DecisionRule},
     confusion_stats::{ConfusionStats, ConfusionStatsInput},
-    state::{FormatOptions, NumericMetricState},
+    state::FormatOptions,
 };
-use burn_core::prelude::Tensor;
 use std::{num::NonZeroUsize, sync::Arc};
 
 ///The Recall Metric
 #[derive(Clone)]
 pub struct RecallMetric {
     name: MetricName,
-    state: NumericMetricState,
+    state: ConfusionStatsState,
     config: ClassificationMetricConfig,
 }
 
@@ -80,23 +79,6 @@ impl RecallMetric {
             class_reduction,
         })
     }
-
-    fn class_average(&self, mut aggregated_metric: Tensor<1>) -> f64 {
-        use ClassReduction::{Macro, Micro};
-        let avg_tensor = match self.config.class_reduction {
-            Micro => aggregated_metric,
-            Macro => {
-                if aggregated_metric.clone().contains_nan().any().into_scalar() {
-                    let nan_mask = aggregated_metric.clone().is_nan();
-                    aggregated_metric = aggregated_metric
-                        .clone()
-                        .select(0, nan_mask.bool_not().argwhere().squeeze_dim(1))
-                }
-                aggregated_metric.mean()
-            }
-        };
-        avg_tensor.into_scalar()
-    }
 }
 
 impl Metric for RecallMetric {
@@ -105,14 +87,29 @@ impl Metric for RecallMetric {
     fn update(&mut self, input: &Self::Input, _metadata: &MetricMetadata) -> SerializedEntry {
         let [sample_size, _] = input.predictions.dims();
 
-        let cf_stats = ConfusionStats::new(input, &self.config);
-        let metric = self.class_average(cf_stats.clone().true_positive() / cf_stats.positive());
+        let stats = ConfusionStats::new(input, &self.config);
+        let tp = Some(stats.clone().true_positive());
+        let fn_ = Some(stats.false_negative());
 
-        self.state.update(
-            100.0 * metric,
-            sample_size,
+        self.state.update(tp, None, fn_, sample_size);
+        self.state.compute_update(
+            self.config.class_reduction,
             FormatOptions::new(self.name()).unit("%").precision(2),
+            |tp, _, fn_| {
+                let (tp, fn_) = (tp.unwrap(), fn_.unwrap());
+                let denominator = tp.clone() + fn_;
+                // Avoid division by zero on empty classes
+                let mask = denominator.clone().equal_elem(0.0);
+                let actual_positive = denominator.mask_fill(mask, 1.0);
+
+                (tp / actual_positive) * 100.0
+            },
         )
+    }
+
+    fn compute(&mut self) -> SerializedEntry {
+        self.state
+            .compute_final(FormatOptions::new(self.name()).unit("%").precision(2))
     }
 
     fn clear(&mut self) {
@@ -134,12 +131,16 @@ impl Metric for RecallMetric {
 }
 
 impl Numeric for RecallMetric {
-    fn value(&self) -> NumericEntry {
+    fn value(&self) -> Option<NumericEntry> {
         self.state.current_value()
     }
 
-    fn running_value(&self) -> NumericEntry {
+    fn running_value(&self) -> Option<NumericEntry> {
         self.state.running_value()
+    }
+
+    fn final_value(&self) -> NumericEntry {
+        self.state.final_value()
     }
 }
 
@@ -160,7 +161,7 @@ mod tests {
         let input = dummy_classification_input(&ClassificationType::Binary).into();
         let mut metric = RecallMetric::binary(threshold);
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        TensorData::from([metric.value().current()])
+        TensorData::from([metric.value().unwrap().current()])
             .assert_approx_eq::<f64>(&TensorData::from([expected * 100.0]), Tolerance::default())
     }
 
@@ -177,7 +178,7 @@ mod tests {
         let input = dummy_classification_input(&ClassificationType::Multiclass).into();
         let mut metric = RecallMetric::multiclass(top_k, class_reduction);
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        TensorData::from([metric.value().current()])
+        TensorData::from([metric.value().unwrap().current()])
             .assert_approx_eq::<f64>(&TensorData::from([expected * 100.0]), Tolerance::default())
     }
 
@@ -192,7 +193,7 @@ mod tests {
         let input = dummy_classification_input(&ClassificationType::Multilabel).into();
         let mut metric = RecallMetric::multilabel(threshold, class_reduction);
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        TensorData::from([metric.value().current()])
+        TensorData::from([metric.value().unwrap().current()])
             .assert_approx_eq::<f64>(&TensorData::from([expected * 100.0]), Tolerance::default())
     }
 

--- a/crates/burn-train/src/metric/recall.rs
+++ b/crates/burn-train/src/metric/recall.rs
@@ -8,7 +8,7 @@ use super::{
 };
 use std::{num::NonZeroUsize, sync::Arc};
 
-///The Recall Metric
+/// The Recall Metric
 #[derive(Clone)]
 pub struct RecallMetric {
     name: MetricName,
@@ -150,9 +150,12 @@ mod tests {
         ClassReduction::{self, *},
         Metric, MetricMetadata, RecallMetric,
     };
-    use crate::metric::Numeric;
+    use crate::metric::{ConfusionStatsInput, Numeric};
     use crate::tests::{ClassificationType, THRESHOLD, dummy_classification_input};
-    use burn_core::tensor::{TensorData, Tolerance};
+    use burn_core::{
+        Tensor,
+        tensor::{TensorData, Tolerance},
+    };
     use rstest::rstest;
 
     #[rstest]
@@ -209,5 +212,48 @@ mod tests {
         let metric_a = RecallMetric::binary(0.5);
         let metric_b = RecallMetric::binary(0.75);
         assert_ne!(metric_a.name(), metric_b.name());
+    }
+
+    #[test]
+    fn test_recall_global_aggregation() {
+        // Batch 1 (3 samples):
+        //   preds:   [[0.9], [0.1], [0.1]] -> binary threshold 0.5 -> [1, 0, 0]
+        //   targets: [[1],   [1],   [0]]   -> TP = 1, FN = 1 (denom = 2, Batch Recall = 50.0%)
+        //
+        // Batch 2 (6 samples):
+        //   preds:   [[0.9], [0.1], [0.1], [0.1], [0.1], [0.1]] -> binary threshold 0.5 -> [1, 0, 0, 0, 0, 0]
+        //   targets: [[1],   [1],   [1],   [1],   [1],   [0]]   -> TP = 1, FN = 4 (denom = 5, Batch Recall = 20.0%)
+        //
+        // Previously, using `NumericMetricState` would give a weighted average based on sample count N:
+        //   (3 * 50.0% + 6 * 20.0%) / (3 + 6) = 270 / 9 = 30.0% (incorrectly weighting by total samples N)
+        //
+        // Correct Global Aggregation = Total TP / Total (TP + FN) = (1 + 1) / (2 + 5) = 2 / 7 = 28.5714%
+
+        let mut metric = RecallMetric::binary(THRESHOLD);
+
+        // Batch 1
+        let input_batch1 = ConfusionStatsInput {
+            predictions: Tensor::from([[0.9], [0.1], [0.1]]),
+            targets: Tensor::from([[1], [1], [0]]),
+        };
+        let _ = metric.update(&input_batch1, &MetricMetadata::fake());
+
+        // Batch 2
+        let input_batch2 = ConfusionStatsInput {
+            predictions: Tensor::from([[0.9], [0.1], [0.1], [0.1], [0.1], [0.1]]),
+            targets: Tensor::from([[1], [1], [1], [1], [1], [0]]),
+        };
+        let _ = metric.update(&input_batch2, &MetricMetadata::fake());
+
+        // Compute final aggregated metric
+        let _final_entry = metric.compute();
+        let global_recall = metric.final_value().current();
+
+        let expected_global_recall = (2.0 / 7.0) * 100.0;
+
+        TensorData::from([global_recall]).assert_approx_eq::<f32>(
+            &TensorData::from([expected_global_recall]),
+            Tolerance::default(),
+        );
     }
 }

--- a/crates/burn-train/src/metric/recall.rs
+++ b/crates/burn-train/src/metric/recall.rs
@@ -124,7 +124,6 @@ impl Metric for RecallMetric {
         NumericAttributes {
             unit: Some("%".to_string()),
             higher_is_better: true,
-            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/rl/cum_reward.rs
+++ b/crates/burn-train/src/metric/rl/cum_reward.rs
@@ -43,11 +43,14 @@ impl Metric for CumulativeRewardMetric {
         item: &CumulativeRewardInput,
         _metadata: &MetricMetadata,
     ) -> SerializedEntry {
-        self.state.update(
-            item.cum_reward,
-            1,
-            FormatOptions::new(self.name()).precision(2),
-        )
+        self.state.update(item.cum_reward, 1);
+        self.state
+            .compute_update(FormatOptions::new(self.name()).precision(2))
+    }
+
+    fn compute(&mut self) -> SerializedEntry {
+        self.state
+            .compute_final(FormatOptions::new(self.name()).precision(2))
     }
 
     fn clear(&mut self) {
@@ -69,11 +72,15 @@ impl Metric for CumulativeRewardMetric {
 }
 
 impl Numeric for CumulativeRewardMetric {
-    fn value(&self) -> NumericEntry {
-        self.state.current_value()
+    fn value(&self) -> Option<NumericEntry> {
+        Some(self.state.current_value())
     }
 
-    fn running_value(&self) -> NumericEntry {
-        self.state.running_value()
+    fn running_value(&self) -> Option<NumericEntry> {
+        Some(self.state.running_value())
+    }
+
+    fn final_value(&self) -> NumericEntry {
+        self.state.final_value()
     }
 }

--- a/crates/burn-train/src/metric/rl/cum_reward.rs
+++ b/crates/burn-train/src/metric/rl/cum_reward.rs
@@ -65,7 +65,6 @@ impl Metric for CumulativeRewardMetric {
         NumericAttributes {
             unit: None,
             higher_is_better: true,
-            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/rl/ep_len.rs
+++ b/crates/burn-train/src/metric/rl/ep_len.rs
@@ -39,8 +39,14 @@ impl Metric for EpisodeLengthMetric {
     type Input = EpisodeLengthInput;
 
     fn update(&mut self, item: &EpisodeLengthInput, _metadata: &MetricMetadata) -> SerializedEntry {
+        self.state.update(item.ep_len, 1);
         self.state
-            .update(item.ep_len, 1, FormatOptions::new(self.name()).precision(0))
+            .compute_update(FormatOptions::new(self.name()).precision(0))
+    }
+
+    fn compute(&mut self) -> SerializedEntry {
+        self.state
+            .compute_final(FormatOptions::new(self.name()).precision(0))
     }
 
     fn clear(&mut self) {
@@ -62,11 +68,15 @@ impl Metric for EpisodeLengthMetric {
 }
 
 impl Numeric for EpisodeLengthMetric {
-    fn value(&self) -> NumericEntry {
-        self.state.current_value()
+    fn value(&self) -> Option<NumericEntry> {
+        Some(self.state.current_value())
     }
 
-    fn running_value(&self) -> NumericEntry {
-        self.state.running_value()
+    fn running_value(&self) -> Option<NumericEntry> {
+        Some(self.state.running_value())
+    }
+
+    fn final_value(&self) -> NumericEntry {
+        self.state.final_value()
     }
 }

--- a/crates/burn-train/src/metric/rl/ep_len.rs
+++ b/crates/burn-train/src/metric/rl/ep_len.rs
@@ -61,7 +61,6 @@ impl Metric for EpisodeLengthMetric {
         NumericAttributes {
             unit: Some(String::from("steps")),
             higher_is_better: true,
-            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/rl/exploration_rate.rs
+++ b/crates/burn-train/src/metric/rl/exploration_rate.rs
@@ -43,11 +43,14 @@ impl Metric for ExplorationRateMetric {
         item: &ExplorationRateInput,
         _metadata: &MetricMetadata,
     ) -> SerializedEntry {
-        self.state.update(
-            item.exploration_rate,
-            1,
-            FormatOptions::new(self.name()).precision(3),
-        )
+        self.state.update(item.exploration_rate, 1);
+        self.state
+            .compute_update(FormatOptions::new(self.name()).precision(3))
+    }
+
+    fn compute(&mut self) -> SerializedEntry {
+        self.state
+            .compute_final(FormatOptions::new(self.name()).precision(3))
     }
 
     fn clear(&mut self) {
@@ -69,11 +72,15 @@ impl Metric for ExplorationRateMetric {
 }
 
 impl Numeric for ExplorationRateMetric {
-    fn value(&self) -> NumericEntry {
-        self.state.current_value()
+    fn value(&self) -> Option<NumericEntry> {
+        Some(self.state.current_value())
     }
 
-    fn running_value(&self) -> NumericEntry {
-        self.state.running_value()
+    fn running_value(&self) -> Option<NumericEntry> {
+        Some(self.state.running_value())
+    }
+
+    fn final_value(&self) -> NumericEntry {
+        self.state.final_value()
     }
 }

--- a/crates/burn-train/src/metric/rl/exploration_rate.rs
+++ b/crates/burn-train/src/metric/rl/exploration_rate.rs
@@ -65,7 +65,6 @@ impl Metric for ExplorationRateMetric {
         NumericAttributes {
             unit: Some(String::from("%")),
             higher_is_better: false,
-            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/rouge.rs
+++ b/crates/burn-train/src/metric/rouge.rs
@@ -157,7 +157,6 @@ impl Metric for RougeLScore {
         NumericAttributes {
             unit: Some("%".to_string()),
             higher_is_better: true,
-            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/rouge.rs
+++ b/crates/burn-train/src/metric/rouge.rs
@@ -135,11 +135,14 @@ impl Metric for RougeLScore {
 
         let value = total_f1 / batch_size as f64;
 
-        self.state.update(
-            value,
-            batch_size,
-            FormatOptions::new(self.name()).unit("%").precision(2),
-        )
+        self.state.update(value, batch_size);
+        self.state
+            .compute_update(FormatOptions::new(self.name()).unit("%").precision(2))
+    }
+
+    fn compute(&mut self) -> SerializedEntry {
+        self.state
+            .compute_final(FormatOptions::new(self.name()).unit("%").precision(2))
     }
 
     fn clear(&mut self) {
@@ -160,13 +163,18 @@ impl Metric for RougeLScore {
     }
 }
 
+// TODO: can be computed per batch, but epoch-level value should be aggregated properly (not just mean of each batch)
 impl Numeric for RougeLScore {
-    fn value(&self) -> NumericEntry {
-        self.state.current_value()
+    fn value(&self) -> Option<NumericEntry> {
+        Some(self.state.current_value())
     }
 
-    fn running_value(&self) -> NumericEntry {
-        self.state.running_value()
+    fn running_value(&self) -> Option<NumericEntry> {
+        Some(self.state.running_value())
+    }
+
+    fn final_value(&self) -> NumericEntry {
+        todo!()
     }
 }
 
@@ -184,7 +192,7 @@ mod tests {
         let tgts = Tensor::from_data([[1, 2, 3, 4, 5]], &device);
 
         metric.update(&RougeLInput::new(preds, tgts), &MetricMetadata::fake());
-        assert!((metric.value().current() - 100.0).abs() < 1e-6);
+        assert!((metric.value().unwrap().current() - 100.0).abs() < 1e-6);
     }
 
     #[test]
@@ -196,7 +204,7 @@ mod tests {
         let tgts = Tensor::from_data([[6, 7, 8, 9, 10]], &device);
 
         metric.update(&RougeLInput::new(preds, tgts), &MetricMetadata::fake());
-        assert_eq!(0.0, metric.value().current());
+        assert_eq!(0.0, metric.value().unwrap().current());
     }
 
     #[test]
@@ -210,7 +218,7 @@ mod tests {
         metric.update(&RougeLInput::new(preds, tgts), &MetricMetadata::fake());
 
         let expected = 60.0;
-        assert!((metric.value().current() - expected).abs() < 1e-6);
+        assert!((metric.value().unwrap().current() - expected).abs() < 1e-6);
     }
 
     #[test]
@@ -225,7 +233,7 @@ mod tests {
         metric.update(&RougeLInput::new(preds, tgts), &MetricMetadata::fake());
 
         let expected = 75.0;
-        assert!((metric.value().current() - expected).abs() < 1e-6);
+        assert!((metric.value().unwrap().current() - expected).abs() < 1e-6);
     }
 
     #[test]
@@ -238,7 +246,7 @@ mod tests {
         let tgts = Tensor::from_data([[1, 2, 3, 4, 5, pad, pad]], &device);
 
         metric.update(&RougeLInput::new(preds, tgts), &MetricMetadata::fake());
-        assert!((metric.value().current() - 100.0).abs() < 1e-6);
+        assert!((metric.value().unwrap().current() - 100.0).abs() < 1e-6);
     }
 
     #[test]
@@ -250,7 +258,7 @@ mod tests {
         let tgts = Tensor::from_data([[1, 2, 3, 4, 5], [11, 12, 13, 14, 15]], &device);
 
         metric.update(&RougeLInput::new(preds, tgts), &MetricMetadata::fake());
-        assert!((metric.value().current() - 50.0).abs() < 1e-6);
+        assert!((metric.value().unwrap().current() - 50.0).abs() < 1e-6);
     }
 
     #[test]
@@ -262,7 +270,7 @@ mod tests {
         let tgts = Tensor::<2, Int>::from_data(TensorData::from([[0i32; 0]; 1]), &device);
 
         metric.update(&RougeLInput::new(preds, tgts), &MetricMetadata::fake());
-        assert!((metric.value().current() - 100.0).abs() < 1e-6);
+        assert!((metric.value().unwrap().current() - 100.0).abs() < 1e-6);
     }
 
     #[test]
@@ -274,9 +282,9 @@ mod tests {
         let tgts = Tensor::from_data([[1, 2, 3, 4, 5]], &device);
 
         metric.update(&RougeLInput::new(preds, tgts), &MetricMetadata::fake());
-        assert!(metric.value().current() > 0.0);
+        assert!(metric.value().unwrap().current() > 0.0);
 
         metric.clear();
-        assert!(metric.value().current().is_nan());
+        assert!(metric.value().unwrap().current().is_nan());
     }
 }

--- a/crates/burn-train/src/metric/state.rs
+++ b/crates/burn-train/src/metric/state.rs
@@ -420,7 +420,7 @@ impl ConfusionStatsState {
 
     /// Get the current batch value.
     pub fn current_value(&self) -> Option<NumericEntry> {
-        (!self.current_value.is_nan()).then(|| NumericEntry::Aggregated {
+        (!self.current_value.is_nan()).then_some(NumericEntry::Aggregated {
             aggregated_value: self.current_value,
             count: self.current_count,
         })
@@ -428,7 +428,7 @@ impl ConfusionStatsState {
 
     /// Get the running aggregated value.
     pub fn running_value(&self) -> Option<NumericEntry> {
-        (!self.running_value.is_nan()).then(|| NumericEntry::Aggregated {
+        (!self.running_value.is_nan()).then_some(NumericEntry::Aggregated {
             aggregated_value: self.running_value,
             count: self.running_count,
         })

--- a/crates/burn-train/src/metric/state.rs
+++ b/crates/burn-train/src/metric/state.rs
@@ -17,6 +17,7 @@ pub struct NumericMetricState {
     current: f64,
     current_count: usize,
 }
+
 /// Accumulates raw predictions and targets across batches.
 ///
 /// Used by rank-based metrics (AUROC, AUC-PR) that must recompute over the
@@ -80,6 +81,7 @@ impl PredictionAccumulatorState {
         SerializedEntry::new(formatted, serialized)
     }
 
+    /// Get the current metric value, when available.
     pub fn value(&self) -> Option<NumericEntry> {
         self.current.map(NumericEntry::Value)
     }
@@ -96,11 +98,7 @@ impl PredictionAccumulatorState {
     }
 
     pub(crate) fn serialize_placeholder(&self, format: FormatOptions) -> SerializedEntry {
-        let formatted = match format.unit {
-            Some(unit) => format!("epoch N/A {unit} - batch N/A {unit}"),
-            None => "epoch N/A - batch N/A".to_string(),
-        };
-        SerializedEntry::new(formatted, "N/A".into())
+        SerializedEntry::not_available(format.unit.as_deref())
     }
 }
 
@@ -179,10 +177,12 @@ impl NumericMetricState {
         self.current_count = count;
     }
 
+    /// Compute the metric for the current update.
     pub fn compute_update(&self, format: FormatOptions) -> SerializedEntry {
         self.compute(format, false)
     }
 
+    /// Compute the final metric for the accumulated global state.
     pub fn compute_final(&self, format: FormatOptions) -> SerializedEntry {
         self.compute(format, true)
     }
@@ -282,6 +282,7 @@ impl Default for ConfusionStatsState {
 }
 
 impl ConfusionStatsState {
+    /// Create a new [ConfusionStatsState].
     pub fn new() -> Self {
         Self {
             true_positive: None,
@@ -297,6 +298,7 @@ impl ConfusionStatsState {
         }
     }
 
+    /// Reset the state.
     pub fn reset(&mut self) {
         self.true_positive = None;
         self.false_positive = None;
@@ -328,23 +330,8 @@ impl ConfusionStatsState {
         sample_size: usize,
     ) {
         // Accumulate running totals for global metric value
-        log::info!(
-            "[ConfusionStatsState] accumulate tp ({}; {})",
-            self.true_positive.is_some(),
-            tp.is_some()
-        );
         Self::accumulate(&mut self.true_positive, tp.clone());
-        log::info!(
-            "[ConfusionStatsState] accumulate fp ({}; {})",
-            self.false_positive.is_some(),
-            fp.is_some()
-        );
         Self::accumulate(&mut self.false_positive, fp.clone());
-        log::info!(
-            "[ConfusionStatsState] accumulate fn ({}; {})",
-            self.false_negative.is_some(),
-            fn_.is_some()
-        );
         Self::accumulate(&mut self.false_negative, fn_.clone());
         self.running_count += sample_size;
 
@@ -387,6 +374,7 @@ impl ConfusionStatsState {
         self.serialized_entry(format, serialized)
     }
 
+    /// Compute the final metric for the accumulated global state.
     pub fn compute_final(&mut self, format: FormatOptions) -> SerializedEntry {
         self.serialized_entry(format, NumericEntry::Final(self.running_value).serialize())
     }
@@ -446,6 +434,7 @@ impl ConfusionStatsState {
         })
     }
 
+    /// Get the final value of the metric.
     pub fn final_value(&self) -> NumericEntry {
         // The running value holds the epoch-level value from accumulated totals, which should hold
         // the correct final value after all batches have been processed

--- a/crates/burn-train/src/metric/state.rs
+++ b/crates/burn-train/src/metric/state.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use burn_core::tensor::{Bool, Tensor};
 
-use crate::metric::{MetricName, NumericEntry, SerializedEntry, format_float};
+use crate::metric::{ClassReduction, MetricName, NumericEntry, SerializedEntry, format_float};
 
 /// Useful utility to implement numeric metrics.
 ///
@@ -25,7 +25,7 @@ pub struct NumericMetricState {
 pub struct PredictionAccumulatorState {
     predictions: Vec<Tensor<2>>,
     targets: Vec<Tensor<2, Bool>>,
-    current: f64,
+    current: Option<f64>,
 }
 
 /// Formatting options for the [numeric metric state](NumericMetricState).
@@ -41,7 +41,7 @@ impl PredictionAccumulatorState {
         Self {
             predictions: vec![],
             targets: vec![],
-            current: f64::NAN,
+            current: None,
         }
     }
 
@@ -60,10 +60,9 @@ impl PredictionAccumulatorState {
     }
 
     /// Record the value computed over the accumulated set and return the entry
-    /// to log. Metrics using this state must declare
-    /// [`NumericAggregation::Last`](crate::metric::NumericAggregation).
-    pub fn update(&mut self, value: f64, format: FormatOptions) -> SerializedEntry {
-        self.current = value;
+    /// to log.
+    pub fn compute(&mut self, value: f64, format: FormatOptions) -> SerializedEntry {
+        self.current = Some(value);
 
         let serialized = NumericEntry::Value(value).serialize();
 
@@ -71,24 +70,37 @@ impl PredictionAccumulatorState {
             Some(precision) => format_float(value, precision),
             None => format!("{value}"),
         };
+
+        // Rank-based metrics have no mathematically valid "batch" slice, so we render N/A
         let formatted = match format.unit {
-            Some(unit) => format!("epoch {formatted_value} {unit}"),
-            None => format!("epoch {formatted_value}"),
+            Some(unit) => format!("epoch {formatted_value} {unit} - batch N/A {unit}"),
+            None => format!("epoch {formatted_value} - batch N/A"),
         };
 
         SerializedEntry::new(formatted, serialized)
     }
 
-    /// Current value (computed over the accumulated set).
-    pub fn value(&self) -> NumericEntry {
-        NumericEntry::Value(self.current)
+    pub fn value(&self) -> Option<NumericEntry> {
+        self.current.map(NumericEntry::Value)
     }
 
     /// Reset the state, freeing the accumulated tensors.
     pub fn reset(&mut self) {
         self.predictions.clear();
         self.targets.clear();
-        self.current = f64::NAN;
+        self.current = None;
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.predictions.is_empty()
+    }
+
+    pub(crate) fn serialize_placeholder(&self, format: FormatOptions) -> SerializedEntry {
+        let formatted = match format.unit {
+            Some(unit) => format!("epoch N/A {unit} - batch N/A {unit}"),
+            None => "epoch N/A - batch N/A".to_string(),
+        };
+        SerializedEntry::new(formatted, "N/A".into())
     }
 }
 
@@ -156,25 +168,39 @@ impl NumericMetricState {
     }
 
     /// Update the state.
-    pub fn update(
-        &mut self,
-        value: f64,
-        batch_size: usize,
-        format: FormatOptions,
-    ) -> SerializedEntry {
-        self.sum += value * batch_size as f64;
-        self.count += batch_size;
+    ///
+    /// `count` is the number of underlying units `value` is averaged over.
+    /// This is typically the batch size (e.g. for accuracy, loss), but it can be any
+    /// unit the metric's `value` is implicitly a rate over.
+    pub fn update(&mut self, value: f64, count: usize) {
+        self.sum += value * count as f64;
+        self.count += count;
         self.current = value;
-        self.current_count = batch_size;
+        self.current_count = count;
+    }
 
-        let value_current = value;
+    pub fn compute_update(&self, format: FormatOptions) -> SerializedEntry {
+        self.compute(format, false)
+    }
+
+    pub fn compute_final(&self, format: FormatOptions) -> SerializedEntry {
+        self.compute(format, true)
+    }
+
+    fn compute(&self, format: FormatOptions, final_entry: bool) -> SerializedEntry {
+        let value_current = self.current;
+        let count = self.current_count;
         let value_running = self.sum / self.count as f64;
         // Numeric metric state is an aggregated value
-        let serialized = NumericEntry::Aggregated {
-            aggregated_value: value_current,
-            count: batch_size,
-        }
-        .serialize();
+        let serialized = if final_entry {
+            NumericEntry::Final(value_running).serialize()
+        } else {
+            NumericEntry::Aggregated {
+                aggregated_value: value_current,
+                count,
+            }
+            .serialize()
+        };
 
         let (formatted_current, formatted_running) = match format.precision {
             Some(precision) => (
@@ -210,10 +236,219 @@ impl NumericMetricState {
             count: self.count,
         }
     }
+
+    /// Get the final aggregated value.
+    pub fn final_value(&self) -> NumericEntry {
+        NumericEntry::Final(self.sum / self.count as f64)
+    }
 }
 
 impl Default for NumericMetricState {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Accumulates confusion-matrix counts (TP, FP, FN) across an epoch.
+///
+/// Used by metrics derived from confusion-matrix ratios (precision, recall, etc.)
+/// which must accumulate raw counts and compute the ratio over the summed counts.
+/// Averaging the per-batch ratios (using [NumericMetricState]) is not equivalent;
+/// it is biased whenever per-batch class support varies.
+/// Accumulates confusion-matrix counts (TP, FP, FN) across an epoch using native tensors.
+#[derive(Clone)]
+pub struct ConfusionStatsState {
+    // Epoch-level accumulated totals
+    true_positive: Option<Tensor<1>>,
+    false_positive: Option<Tensor<1>>,
+    false_negative: Option<Tensor<1>>,
+    running_count: usize,
+
+    // Most recent batch snapshots (retained for the compute split)
+    current_tp: Option<Tensor<1>>,
+    current_fp: Option<Tensor<1>>,
+    current_fn: Option<Tensor<1>>,
+    current_count: usize,
+
+    // Already computed values
+    current_value: f64,
+    running_value: f64,
+}
+
+impl Default for ConfusionStatsState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ConfusionStatsState {
+    pub fn new() -> Self {
+        Self {
+            true_positive: None,
+            false_positive: None,
+            false_negative: None,
+            running_count: 0,
+            current_tp: None,
+            current_fp: None,
+            current_fn: None,
+            current_count: 0,
+            current_value: f64::NAN,
+            running_value: f64::NAN,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.true_positive = None;
+        self.false_positive = None;
+        self.false_negative = None;
+        self.running_count = 0;
+        self.current_tp = None;
+        self.current_fp = None;
+        self.current_fn = None;
+        self.current_count = 0;
+        self.current_value = f64::NAN;
+        self.running_value = f64::NAN;
+    }
+
+    fn accumulate(running: &mut Option<Tensor<1>>, batch: Option<Tensor<1>>) {
+        if let Some(b) = batch {
+            *running = Some(match running.take() {
+                Some(acc) => acc + b,
+                None => b,
+            });
+        }
+    }
+
+    /// Accumulate running totals and capture the batch snapshot.
+    pub fn update(
+        &mut self,
+        tp: Option<Tensor<1>>,
+        fp: Option<Tensor<1>>,
+        fn_: Option<Tensor<1>>,
+        sample_size: usize,
+    ) {
+        // Accumulate running totals for global metric value
+        log::info!(
+            "[ConfusionStatsState] accumulate tp ({}; {})",
+            self.true_positive.is_some(),
+            tp.is_some()
+        );
+        Self::accumulate(&mut self.true_positive, tp.clone());
+        log::info!(
+            "[ConfusionStatsState] accumulate fp ({}; {})",
+            self.false_positive.is_some(),
+            fp.is_some()
+        );
+        Self::accumulate(&mut self.false_positive, fp.clone());
+        log::info!(
+            "[ConfusionStatsState] accumulate fn ({}; {})",
+            self.false_negative.is_some(),
+            fn_.is_some()
+        );
+        Self::accumulate(&mut self.false_negative, fn_.clone());
+        self.running_count += sample_size;
+
+        // Retain current batch tensors for the subsequent compute pass
+        self.current_tp = tp;
+        self.current_fp = fp;
+        self.current_fn = fn_;
+        self.current_count = sample_size;
+    }
+
+    /// Compute the batch-level value and the running epoch-level value (from all accumulated counts)
+    pub fn compute_update(
+        &mut self,
+        class_reduction: ClassReduction,
+        format: FormatOptions,
+        compute_fn: impl Fn(Option<Tensor<1>>, Option<Tensor<1>>, Option<Tensor<1>>) -> Tensor<1>,
+    ) -> SerializedEntry {
+        let current_tp = self.current_tp.take();
+        let current_fp = self.current_fp.take();
+        let current_fn = self.current_fn.take();
+
+        // Compute batch-level value
+        let batch_metric = compute_fn(current_tp, current_fp, current_fn);
+        self.current_value = Self::class_average(batch_metric, class_reduction);
+
+        // Compute epoch-level value from running totals
+        let total_tp = self.true_positive.clone();
+        let total_fp = self.false_positive.clone();
+        let total_fn = self.false_negative.clone();
+
+        let epoch_metric = compute_fn(total_tp, total_fp, total_fn);
+        self.running_value = Self::class_average(epoch_metric, class_reduction);
+
+        // Serialize and format
+        let serialized = NumericEntry::Aggregated {
+            aggregated_value: self.current_value,
+            count: self.current_count,
+        }
+        .serialize();
+        self.serialized_entry(format, serialized)
+    }
+
+    pub fn compute_final(&mut self, format: FormatOptions) -> SerializedEntry {
+        self.serialized_entry(format, NumericEntry::Final(self.running_value).serialize())
+    }
+
+    fn serialized_entry(&mut self, format: FormatOptions, serialized: String) -> SerializedEntry {
+        let (formatted_current, formatted_running) = match format.precision {
+            Some(p) => (
+                format_float(self.current_value, p),
+                format_float(self.running_value, p),
+            ),
+            None => (
+                format!("{}", self.current_value),
+                format!("{}", self.running_value),
+            ),
+        };
+
+        let formatted = match format.unit {
+            Some(unit) => {
+                format!("epoch {formatted_running} {unit} - batch {formatted_current} {unit}")
+            }
+            None => format!("epoch {formatted_running} - batch {formatted_current}"),
+        };
+
+        SerializedEntry::new(formatted, serialized)
+    }
+
+    fn class_average(mut metric: Tensor<1>, class_reduction: ClassReduction) -> f64 {
+        use ClassReduction::{Macro, Micro};
+        let avg = match class_reduction {
+            Micro => metric,
+            Macro => {
+                if metric.clone().contains_nan().any().into_scalar() {
+                    let mask = metric.clone().is_nan();
+                    metric = metric
+                        .clone()
+                        .select(0, mask.bool_not().argwhere().squeeze_dim(1));
+                }
+                metric.mean()
+            }
+        };
+        avg.into_scalar()
+    }
+
+    /// Get the current batch value.
+    pub fn current_value(&self) -> Option<NumericEntry> {
+        (!self.current_value.is_nan()).then(|| NumericEntry::Aggregated {
+            aggregated_value: self.current_value,
+            count: self.current_count,
+        })
+    }
+
+    /// Get the running aggregated value.
+    pub fn running_value(&self) -> Option<NumericEntry> {
+        (!self.running_value.is_nan()).then(|| NumericEntry::Aggregated {
+            aggregated_value: self.running_value,
+            count: self.running_count,
+        })
+    }
+
+    pub fn final_value(&self) -> NumericEntry {
+        // The running value holds the epoch-level value from accumulated totals, which should hold
+        // the correct final value after all batches have been processed
+        NumericEntry::Final(self.running_value)
     }
 }

--- a/crates/burn-train/src/metric/store/aggregate.rs
+++ b/crates/burn-train/src/metric/store/aggregate.rs
@@ -1,6 +1,6 @@
 use crate::{
     logger::MetricLogger,
-    metric::{MetricAttributes, MetricDefinition, NumericAggregation, NumericEntry, store::Split},
+    metric::{NumericEntry, store::Split},
 };
 use std::collections::HashMap;
 
@@ -10,7 +10,6 @@ use super::{Aggregate, Direction};
 #[derive(Default, Debug)]
 pub(crate) struct NumericMetricsAggregate {
     value_for_each_epoch: HashMap<Key, f64>,
-    aggregations: HashMap<String, NumericAggregation>,
 }
 
 #[derive(new, Hash, PartialEq, Eq, Debug)]
@@ -22,16 +21,6 @@ struct Key {
 }
 
 impl NumericMetricsAggregate {
-    /// Record each numeric metric's epoch-aggregation strategy from its definition.
-    pub(crate) fn register_definitions(&mut self, definitions: &[MetricDefinition]) {
-        for def in definitions {
-            if let MetricAttributes::Numeric(numeric) = &def.attributes {
-                self.aggregations
-                    .insert(def.name.clone(), numeric.aggregation);
-            }
-        }
-    }
-
     pub(crate) fn aggregate(
         &mut self,
         name: &str,
@@ -45,9 +34,6 @@ impl NumericMetricsAggregate {
         if let Some(value) = self.value_for_each_epoch.get(&key) {
             return Some(*value);
         }
-
-        // How this metric reduces its per-batch points (defaults to a weighted mean).
-        let aggregation = self.aggregations.get(name).copied().unwrap_or_default();
 
         let points = || {
             let mut errors = Vec::new();
@@ -67,27 +53,26 @@ impl NumericMetricsAggregate {
             return None;
         }
 
-        let value = match aggregation {
-            // Already computed over the whole epoch; do not average.
-            NumericAggregation::Last => points.last().expect("Points are not empty").current(),
-            // Weighted by the *actual* number of points since mini-batches may differ in size.
-            NumericAggregation::Mean => {
-                let (sum, num_points) = points
-                    .into_iter()
-                    .map(|entry| match entry {
-                        NumericEntry::Value(v) => (v, 1),
-                        // Right now the mean is the only aggregate available, so we can assume that the sum
-                        // of an entry corresponds to (value * number of elements)
-                        NumericEntry::Aggregated {
-                            aggregated_value,
-                            count,
-                        } => (aggregated_value * count as f64, count),
-                    })
-                    .reduce(|(acc_v, acc_n), (v, n)| (acc_v + v, acc_n + n))
-                    .unwrap();
-                match aggregate {
-                    Aggregate::Mean => sum / num_points as f64,
-                }
+        let value = if let NumericEntry::Final(v) = points.last().expect("Points are not empty") {
+            // The last line is always the true epoch calculation.
+            *v
+        } else {
+            let (sum, num_points) = points
+                .into_iter()
+                .map(|entry| match entry {
+                    NumericEntry::Value(v) => (v, 1),
+                    // Right now the mean is the only aggregate available, so we can assume that the sum
+                    // of an entry corresponds to (value * number of elements)
+                    NumericEntry::Aggregated {
+                        aggregated_value,
+                        count,
+                    } => (aggregated_value * count as f64, count),
+                    NumericEntry::Final(_) => unreachable!(),
+                })
+                .reduce(|(acc_v, acc_n), (v, n)| (acc_v + v, acc_n + n))
+                .unwrap();
+            match aggregate {
+                Aggregate::Mean => sum / num_points as f64,
             }
         };
 
@@ -177,7 +162,7 @@ mod tests {
         fn log_definition(&mut self) {
             let definition = MetricDefinition {
                 metric_id: MetricId::new(Arc::new(NAME.into())),
-                name: NAME.into(),
+                name: Arc::new(NAME.into()),
                 attributes: crate::metric::MetricAttributes::None,
                 description: None,
             };
@@ -223,7 +208,7 @@ mod tests {
         let metric_id = MetricId::new(metric_name.clone());
         let definition = MetricDefinition {
             metric_id: metric_id.clone(),
-            name: metric_name.to_string(),
+            name: metric_name.clone(),
             attributes: crate::metric::MetricAttributes::None,
             description: None,
         };
@@ -276,25 +261,31 @@ mod tests {
         let metric_id = MetricId::new(metric_name.clone());
         let definition = MetricDefinition {
             metric_id: metric_id.clone(),
-            name: metric_name.to_string(),
+            name: metric_name.clone(),
             attributes: crate::metric::NumericAttributes {
                 unit: None,
                 higher_is_better: true,
-                aggregation: NumericAggregation::Last,
             }
             .into(),
             description: None,
         };
         logger.log_metric_definition(definition.clone());
-        aggregate.register_definitions(&[definition]);
 
-        for value in [0.6, 0.7, 0.85] {
+        for value in [0.6, 0.7] {
             let entry = MetricEntry::new(
                 metric_id.clone(),
                 SerializedEntry::new(value.to_string(), NumericEntry::Value(value).serialize()),
             );
             logger.log(MetricsUpdate::new(vec![entry], vec![]), 1, &Split::Train);
         }
+
+        // Final value (global)
+        let value = 0.85;
+        let entry = MetricEntry::new(
+            metric_id.clone(),
+            SerializedEntry::new(value.to_string(), NumericEntry::Final(value).serialize()),
+        );
+        logger.log(MetricsUpdate::new(vec![entry], vec![]), 1, &Split::Train);
 
         let value = aggregate
             .aggregate(

--- a/crates/burn-train/src/metric/store/base.rs
+++ b/crates/burn-train/src/metric/store/base.rs
@@ -20,9 +20,9 @@ pub struct NumericMetricUpdate {
     /// Generic metric information.
     pub entry: MetricEntry,
     /// The numeric information.
-    pub numeric_entry: NumericEntry,
+    pub numeric_entry: Option<NumericEntry>,
     /// Numeric value averaged over the global step (epoch).
-    pub running_entry: NumericEntry,
+    pub running_entry: Option<NumericEntry>,
 }
 
 /// Contains all metric information.

--- a/crates/burn-train/src/metric/store/log.rs
+++ b/crates/burn-train/src/metric/store/log.rs
@@ -19,7 +19,6 @@ impl EventStore for LogEventStore {
                 self.epochs.insert(split, epoch);
             }
             Event::MetricsInit(definitions) => {
-                self.aggregate.register_definitions(&definitions);
                 definitions.iter().for_each(|def| {
                     self.loggers
                         .iter_mut()

--- a/crates/burn-train/src/metric/top_k_acc.rs
+++ b/crates/burn-train/src/metric/top_k_acc.rs
@@ -80,13 +80,15 @@ impl Metric for TopKAccuracyMetric {
             .into_scalar::<f64>()
             / (batch_size as f64 - num_pad);
 
-        self.state.update(
-            100.0 * accuracy,
-            batch_size,
-            FormatOptions::new(self.name()).unit("%").precision(2),
-        )
+        self.state.update(100.0 * accuracy, batch_size);
+        self.state
+            .compute_update(FormatOptions::new(self.name()).unit("%").precision(2))
     }
 
+    fn compute(&mut self) -> SerializedEntry {
+        self.state
+            .compute_final(FormatOptions::new(self.name()).unit("%").precision(2))
+    }
     fn clear(&mut self) {
         self.state.reset()
     }
@@ -106,12 +108,16 @@ impl Metric for TopKAccuracyMetric {
 }
 
 impl Numeric for TopKAccuracyMetric {
-    fn value(&self) -> NumericEntry {
-        self.state.current_value()
+    fn value(&self) -> Option<NumericEntry> {
+        Some(self.state.current_value())
     }
 
-    fn running_value(&self) -> NumericEntry {
-        self.state.running_value()
+    fn running_value(&self) -> Option<NumericEntry> {
+        Some(self.state.running_value())
+    }
+
+    fn final_value(&self) -> NumericEntry {
+        self.state.final_value()
     }
 }
 
@@ -137,7 +143,7 @@ mod tests {
         );
 
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        assert_eq!(50.0, metric.value().current());
+        assert_eq!(50.0, metric.value().unwrap().current());
     }
 
     #[test]
@@ -161,7 +167,7 @@ mod tests {
         );
 
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        assert_eq!(50.0, metric.value().current());
+        assert_eq!(50.0, metric.value().unwrap().current());
     }
 
     #[test]

--- a/crates/burn-train/src/metric/top_k_acc.rs
+++ b/crates/burn-train/src/metric/top_k_acc.rs
@@ -101,7 +101,6 @@ impl Metric for TopKAccuracyMetric {
         NumericAttributes {
             unit: Some("%".to_string()),
             higher_is_better: true,
-            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/vision/dice.rs
+++ b/crates/burn-train/src/metric/vision/dice.rs
@@ -6,7 +6,7 @@ use super::super::{
 };
 use burn_core::{
     prelude::Tensor,
-    tensor::{ElementConversion, Int, s},
+    tensor::{Int, s},
 };
 
 /// Input type for the [DiceMetric].
@@ -155,11 +155,14 @@ impl<const D: usize> Metric for DiceMetric<D> {
         let dice =
             (2.0 * intersection_val + epsilon) / (outputs_sum_val + targets_sum_val + epsilon);
 
-        self.state.update(
-            dice,
-            batch_size,
-            FormatOptions::new(self.name()).precision(4),
-        )
+        self.state.update(dice, batch_size);
+        self.compute()
+    }
+
+    // TODO: Dice should be using a state similar to precision & recall (accumulate state for epoch-level compute)
+    fn compute(&mut self) -> SerializedEntry {
+        self.state
+            .compute(FormatOptions::new(self.name()).precision(4))
     }
 
     /// Clears the metric state.
@@ -178,12 +181,12 @@ impl<const D: usize> Metric for DiceMetric<D> {
 }
 
 impl<const D: usize> crate::metric::Numeric for DiceMetric<D> {
-    fn value(&self) -> crate::metric::NumericEntry {
-        self.state.current_value()
+    fn value(&self) -> Option<crate::metric::NumericEntry> {
+        Some(self.state.current_value())
     }
 
-    fn running_value(&self) -> crate::metric::NumericEntry {
-        self.state.running_value()
+    fn running_value(&self) -> Option<crate::metric::NumericEntry> {
+        Some(self.state.running_value())
     }
 }
 
@@ -202,7 +205,7 @@ mod tests {
             Tensor::from_data([[[[1, 0], [1, 0]]]], &device),
         );
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        assert!((metric.value().current() - 1.0).abs() < 1e-6);
+        assert!((metric.value().unwrap().current() - 1.0).abs() < 1e-6);
     }
 
     #[test]
@@ -214,7 +217,7 @@ mod tests {
             Tensor::from_data([[[[0, 1], [0, 1]]]], &device),
         );
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        assert!(metric.value().current() < 1e-6);
+        assert!(metric.value().unwrap().current() < 1e-6);
     }
 
     #[test]
@@ -227,7 +230,7 @@ mod tests {
         );
         let _entry = metric.update(&input, &MetricMetadata::fake());
         // intersection = 1, sum = 2+2=4, dice = 2*1/4 = 0.5
-        assert!((metric.value().current() - 0.5).abs() < 1e-6);
+        assert!((metric.value().unwrap().current() - 0.5).abs() < 1e-6);
     }
 
     #[test]
@@ -239,7 +242,7 @@ mod tests {
             Tensor::from_data([[[[0, 0], [0, 0]]]], &device),
         );
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        assert!((metric.value().current() - 1.0).abs() < 1e-6);
+        assert!((metric.value().unwrap().current() - 1.0).abs() < 1e-6);
     }
 
     #[test]
@@ -251,7 +254,7 @@ mod tests {
             Tensor::ones(Shape::new([1, 1, 2, 2]), &device),
         );
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        assert!((metric.value().current() - 1.0).abs() < 1e-6);
+        assert!((metric.value().unwrap().current() - 1.0).abs() < 1e-6);
     }
 
     #[test]
@@ -267,7 +270,7 @@ mod tests {
             Tensor::ones(Shape::new([1, 2, 2, 2]), &device),
         );
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        assert!((metric.value().current() - 1.0).abs() < 1e-6);
+        assert!((metric.value().unwrap().current() - 1.0).abs() < 1e-6);
     }
 
     #[test]
@@ -283,7 +286,7 @@ mod tests {
             Tensor::ones(Shape::new([1, 2, 2, 2]), &device),
         );
         let _entry = metric.update(&input, &MetricMetadata::fake());
-        assert!((metric.value().current() - 1.0).abs() < 1e-6);
+        assert!((metric.value().unwrap().current() - 1.0).abs() < 1e-6);
     }
 
     #[test]

--- a/crates/burn-train/src/metric/vision/dice.rs
+++ b/crates/burn-train/src/metric/vision/dice.rs
@@ -156,13 +156,14 @@ impl<const D: usize> Metric for DiceMetric<D> {
             (2.0 * intersection_val + epsilon) / (outputs_sum_val + targets_sum_val + epsilon);
 
         self.state.update(dice, batch_size);
-        self.compute()
+        self.state
+            .compute_update(FormatOptions::new(self.name()).precision(4))
     }
 
     // TODO: Dice should be using a state similar to precision & recall (accumulate state for epoch-level compute)
     fn compute(&mut self) -> SerializedEntry {
         self.state
-            .compute(FormatOptions::new(self.name()).precision(4))
+            .compute_final(FormatOptions::new(self.name()).precision(4))
     }
 
     /// Clears the metric state.
@@ -187,6 +188,10 @@ impl<const D: usize> crate::metric::Numeric for DiceMetric<D> {
 
     fn running_value(&self) -> Option<crate::metric::NumericEntry> {
         Some(self.state.running_value())
+    }
+
+    fn final_value(&self) -> crate::metric::NumericEntry {
+        self.state.final_value()
     }
 }
 

--- a/crates/burn-train/src/metric/vision/dice.rs
+++ b/crates/burn-train/src/metric/vision/dice.rs
@@ -175,7 +175,6 @@ impl<const D: usize> Metric for DiceMetric<D> {
         crate::metric::NumericAttributes {
             unit: None,
             higher_is_better: true,
-            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/vision/ms_ssim.rs
+++ b/crates/burn-train/src/metric/vision/ms_ssim.rs
@@ -471,12 +471,13 @@ impl Metric for MsSsimMetric {
         let avg_ms_ssim = ms_ssim_per_image.mean().into_scalar::<f64>();
 
         self.state.update(avg_ms_ssim, batch_size);
-        self.compute()
+        self.state
+            .compute_update(FormatOptions::new(self.name()).precision(4))
     }
 
     fn compute(&mut self) -> SerializedEntry {
         self.state
-            .compute(FormatOptions::new(self.name()).precision(4))
+            .compute_final(FormatOptions::new(self.name()).precision(4))
     }
 
     /// Clears the metric state.
@@ -501,6 +502,10 @@ impl Numeric for MsSsimMetric {
 
     fn running_value(&self) -> Option<NumericEntry> {
         Some(self.state.running_value())
+    }
+
+    fn final_value(&self) -> NumericEntry {
+        self.state.final_value()
     }
 }
 

--- a/crates/burn-train/src/metric/vision/ms_ssim.rs
+++ b/crates/burn-train/src/metric/vision/ms_ssim.rs
@@ -489,7 +489,6 @@ impl Metric for MsSsimMetric {
         NumericAttributes {
             unit: None,
             higher_is_better: true,
-            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/vision/ms_ssim.rs
+++ b/crates/burn-train/src/metric/vision/ms_ssim.rs
@@ -6,7 +6,6 @@ use crate::metric::{
 use burn_core::{
     prelude::{Device, Int, Tensor},
     tensor::{
-        ElementConversion,
         module::{avg_pool2d, conv2d},
         ops::{ConvOptions, PadMode},
     },
@@ -471,11 +470,13 @@ impl Metric for MsSsimMetric {
         let ms_ssim_per_image = ms_ssim_tensor.mean_dim(1);
         let avg_ms_ssim = ms_ssim_per_image.mean().into_scalar::<f64>();
 
-        self.state.update(
-            avg_ms_ssim,
-            batch_size,
-            FormatOptions::new(self.name()).precision(4),
-        )
+        self.state.update(avg_ms_ssim, batch_size);
+        self.compute()
+    }
+
+    fn compute(&mut self) -> SerializedEntry {
+        self.state
+            .compute(FormatOptions::new(self.name()).precision(4))
     }
 
     /// Clears the metric state.
@@ -494,12 +495,12 @@ impl Metric for MsSsimMetric {
 }
 
 impl Numeric for MsSsimMetric {
-    fn value(&self) -> NumericEntry {
-        self.state.current_value()
+    fn value(&self) -> Option<NumericEntry> {
+        Some(self.state.current_value())
     }
 
-    fn running_value(&self) -> NumericEntry {
-        self.state.running_value()
+    fn running_value(&self) -> Option<NumericEntry> {
+        Some(self.state.running_value())
     }
 }
 
@@ -534,7 +535,7 @@ mod tests {
         let input = MsSsimInput::new(outputs, targets);
         let _entry = metric.update(&input, &MetricMetadata::fake());
 
-        let ms_ssim = metric.value().current();
+        let ms_ssim = metric.value().unwrap().current();
         assert!(
             ms_ssim > 0.99,
             "MS-SSIM for identical images should be 1.0, got {}",
@@ -553,7 +554,7 @@ mod tests {
         let input = MsSsimInput::new(outputs, targets);
         let _entry = metric.update(&input, &MetricMetadata::fake());
 
-        let ms_ssim = metric.value().current();
+        let ms_ssim = metric.value().unwrap().current();
         assert!(
             (ms_ssim - 0.3).abs() < 0.01,
             "MS-SSIM for black vs white should be low (around 0.3), got {}",
@@ -572,7 +573,7 @@ mod tests {
         let input = MsSsimInput::new(outputs, targets);
         let _entry = metric.update(&input, &MetricMetadata::fake());
 
-        let ms_ssim = metric.value().current();
+        let ms_ssim = metric.value().unwrap().current();
         assert!(
             ms_ssim > 0.95,
             "MS-SSIM for very similar images should be close to 1.0, got {}",
@@ -603,7 +604,7 @@ mod tests {
         let input = MsSsimInput::new(outputs, targets);
         let _entry = metric.update(&input, &MetricMetadata::fake());
 
-        let ms_ssim = metric.value().current();
+        let ms_ssim = metric.value().unwrap().current();
         // Average of ~1.0 and ~0.292 should be around 0.64
         assert!(
             (ms_ssim - 0.64).abs() < 0.02,
@@ -628,7 +629,7 @@ mod tests {
         let input = MsSsimInput::new(outputs, targets);
         let _entry = metric.update(&input, &MetricMetadata::fake());
 
-        let ms_ssim = metric.value().current();
+        let ms_ssim = metric.value().unwrap().current();
         assert!(
             ms_ssim > 0.99,
             "MS-SSIM for identical RGB images should be 1.0, got {}",
@@ -647,7 +648,7 @@ mod tests {
         metric.update(&input1, &MetricMetadata::fake());
 
         assert!(
-            metric.value().current() > 0.99,
+            metric.value().unwrap().current() > 0.99,
             "First update should be approximately 1.0"
         );
 
@@ -657,7 +658,7 @@ mod tests {
         let input2 = MsSsimInput::new(black, white);
         metric.update(&input2, &MetricMetadata::fake());
 
-        let running = metric.running_value().current();
+        let running = metric.running_value().unwrap().current();
         assert!(
             (running - 0.64).abs() < 0.02,
             "Running average should be approximately 0.64, got {}",
@@ -687,7 +688,7 @@ mod tests {
         let _ = metric.update(&input, &MetricMetadata::fake());
 
         // Identical images should still yield ~1.0
-        let ms_ssim = metric.value().current();
+        let ms_ssim = metric.value().unwrap().current();
         assert!(
             ms_ssim > 0.99,
             "1-scale MS-SSIM for identical images should be 1.0, got {}",
@@ -711,12 +712,12 @@ mod tests {
         let mut metric1 = MsSsimMetric::new(config.clone(), &device);
         let input1 = MsSsimInput::new(img1.clone(), img2.clone());
         let _entry = metric1.update(&input1, &MetricMetadata::fake());
-        let ms_ssim1 = metric1.value().current();
+        let ms_ssim1 = metric1.value().unwrap().current();
 
         let mut metric2 = MsSsimMetric::new(config, &device);
         let input2 = MsSsimInput::new(img2, img1);
         let _entry = metric2.update(&input2, &MetricMetadata::fake());
-        let ms_ssim2 = metric2.value().current();
+        let ms_ssim2 = metric2.value().unwrap().current();
 
         assert!(
             (ms_ssim1 - ms_ssim2).abs() < 0.001,
@@ -735,10 +736,10 @@ mod tests {
         let input = MsSsimInput::new(img.clone(), img);
         metric.update(&input, &MetricMetadata::fake());
 
-        assert!(metric.value().current() > 0.99);
+        assert!(metric.value().unwrap().current() > 0.99);
 
         metric.clear();
-        assert!(metric.running_value().current().is_nan());
+        assert!(metric.running_value().unwrap().current().is_nan());
     }
 
     #[test]

--- a/crates/burn-train/src/metric/vision/psnr.rs
+++ b/crates/burn-train/src/metric/vision/psnr.rs
@@ -180,12 +180,13 @@ impl Metric for PsnrMetric {
         let avg_psnr = psnr_per_image.mean().into_scalar::<f64>();
 
         self.state.update(avg_psnr, batch_size);
-        self.compute()
+        self.state
+            .compute_update(FormatOptions::new(self.name()).unit("dB").precision(2))
     }
 
     fn compute(&mut self) -> SerializedEntry {
         self.state
-            .compute(FormatOptions::new(self.name()).unit("dB").precision(2))
+            .compute_final(FormatOptions::new(self.name()).unit("dB").precision(2))
     }
 
     /// Clears the metric state.
@@ -210,6 +211,10 @@ impl Numeric for PsnrMetric {
 
     fn running_value(&self) -> Option<NumericEntry> {
         Some(self.state.running_value())
+    }
+
+    fn final_value(&self) -> NumericEntry {
+        self.state.final_value()
     }
 }
 

--- a/crates/burn-train/src/metric/vision/psnr.rs
+++ b/crates/burn-train/src/metric/vision/psnr.rs
@@ -198,7 +198,6 @@ impl Metric for PsnrMetric {
         NumericAttributes {
             unit: Some("dB".to_string()),
             higher_is_better: true,
-            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/vision/psnr.rs
+++ b/crates/burn-train/src/metric/vision/psnr.rs
@@ -3,7 +3,7 @@ use crate::metric::{
     SerializedEntry,
     state::{FormatOptions, NumericMetricState},
 };
-use burn_core::{prelude::Tensor, tensor::ElementConversion};
+use burn_core::prelude::Tensor;
 use std::f64::consts::LN_10;
 
 /// Input type for the [PsnrMetric].
@@ -179,11 +179,13 @@ impl Metric for PsnrMetric {
             .mul_scalar(10.0 / LN_10);
         let avg_psnr = psnr_per_image.mean().into_scalar::<f64>();
 
-        self.state.update(
-            avg_psnr,
-            batch_size,
-            FormatOptions::new(self.name()).unit("dB").precision(2),
-        )
+        self.state.update(avg_psnr, batch_size);
+        self.compute()
+    }
+
+    fn compute(&mut self) -> SerializedEntry {
+        self.state
+            .compute(FormatOptions::new(self.name()).unit("dB").precision(2))
     }
 
     /// Clears the metric state.
@@ -202,12 +204,12 @@ impl Metric for PsnrMetric {
 }
 
 impl Numeric for PsnrMetric {
-    fn value(&self) -> NumericEntry {
-        self.state.current_value()
+    fn value(&self) -> Option<NumericEntry> {
+        Some(self.state.current_value())
     }
 
-    fn running_value(&self) -> NumericEntry {
-        self.state.running_value()
+    fn running_value(&self) -> Option<NumericEntry> {
+        Some(self.state.running_value())
     }
 }
 
@@ -235,7 +237,7 @@ mod tests {
 
         // With epsilon = 1e-10 and max=1.0:
         // PSNR = 10 * log10(1.0 / 1e-10) = 100 dB
-        let psnr = metric.value().current();
+        let psnr = metric.value().unwrap().current();
         assert!(
             psnr >= 99.0,
             "PSNR for perfect reconstruction should be ~100 dB, got {} dB",
@@ -258,7 +260,7 @@ mod tests {
         let input = PsnrInput::new(outputs, targets);
         let _entry = metric.update(&input, &MetricMetadata::fake());
 
-        let psnr = metric.value().current();
+        let psnr = metric.value().unwrap().current();
         assert!(
             (psnr - 20.0).abs() < 0.01,
             "Expected PSNR ~20 dB, got {} dB",
@@ -281,7 +283,7 @@ mod tests {
         let input = PsnrInput::new(outputs, targets);
         let _entry = metric.update(&input, &MetricMetadata::fake());
 
-        let psnr = metric.value().current();
+        let psnr = metric.value().unwrap().current();
         let expected_psnr = 10.0 * (1.0_f64 / 0.075).log10();
         assert!(
             (psnr - expected_psnr).abs() < 0.01,
@@ -309,7 +311,7 @@ mod tests {
         let input = PsnrInput::new(outputs, targets);
         let _entry = metric.update(&input, &MetricMetadata::fake());
 
-        let psnr = metric.value().current();
+        let psnr = metric.value().unwrap().current();
         let expected_psnr = 10.0 * (255.0_f64 * 255.0 / 100.0).log10();
         assert!(
             (psnr - expected_psnr).abs() < 0.01,
@@ -346,7 +348,7 @@ mod tests {
         let input = PsnrInput::new(outputs, targets);
         let _entry = metric.update(&input, &MetricMetadata::fake());
 
-        let psnr = metric.value().current();
+        let psnr = metric.value().unwrap().current();
         let expected_psnr = 30.0;
         assert!(
             (psnr - expected_psnr).abs() < 0.01,
@@ -376,7 +378,7 @@ mod tests {
         let input = PsnrInput::new(outputs, targets);
         let _entry = metric.update(&input, &MetricMetadata::fake());
 
-        let psnr = metric.value().current();
+        let psnr = metric.value().unwrap().current();
         let expected_psnr = 20.0;
         assert!(
             (psnr - expected_psnr).abs() < 0.01,
@@ -400,7 +402,7 @@ mod tests {
         let input1 = PsnrInput::new(outputs1, targets1);
         let _entry = metric.update(&input1, &MetricMetadata::fake());
 
-        let psnr1 = metric.value().current();
+        let psnr1 = metric.value().unwrap().current();
         let expected_psnr1 = 20.0;
         assert!(
             (psnr1 - expected_psnr1).abs() < 0.01,
@@ -419,7 +421,7 @@ mod tests {
         let _entry = metric.update(&input2, &MetricMetadata::fake());
 
         // Running average: (20 + 40) / 2 = 30 dB
-        let running_avg_psnr = metric.running_value().current();
+        let running_avg_psnr = metric.running_value().unwrap().current();
         let expected_running_avg_psnr = 30.0;
         assert!(
             (running_avg_psnr - expected_running_avg_psnr).abs() < 0.01,
@@ -442,7 +444,7 @@ mod tests {
         let input = PsnrInput::new(outputs, targets);
         let _entry = metric.update(&input, &MetricMetadata::fake());
 
-        let psnr = metric.value().current();
+        let psnr = metric.value().unwrap().current();
         let expected_psnr = 20.0;
         assert!(
             (psnr - expected_psnr).abs() < 0.01,
@@ -453,7 +455,7 @@ mod tests {
 
         // Clear and verify reset
         metric.clear();
-        let psnr = metric.running_value().current();
+        let psnr = metric.running_value().unwrap().current();
         assert!(psnr.is_nan(), "Expected NaN after clear, got {} dB", psnr)
     }
 
@@ -479,7 +481,7 @@ mod tests {
         let _entry = metric.update(&input, &MetricMetadata::fake());
 
         // With epsilon = 0.01, PSNR = 10 * log10(1.0 / 0.01) = 20 dB
-        let psnr = metric.value().current();
+        let psnr = metric.value().unwrap().current();
         let expected_psnr = 20.0;
         assert!(
             (psnr - expected_psnr).abs() < 0.01,
@@ -504,7 +506,7 @@ mod tests {
         let _entry = metric.update(&input, &MetricMetadata::fake());
 
         // Same MSE as positive errors (0.01), so PSNR = 20 dB
-        let psnr = metric.value().current();
+        let psnr = metric.value().unwrap().current();
         let expected_psnr = 20.0;
         assert!(
             (psnr - expected_psnr).abs() < 0.01,
@@ -529,7 +531,7 @@ mod tests {
         let input = PsnrInput::new(outputs, targets);
         let _entry = metric.update(&input, &MetricMetadata::fake());
 
-        let psnr = metric.value().current();
+        let psnr = metric.value().unwrap().current();
         let expected_psnr = 20.0;
         assert!(
             (psnr - expected_psnr).abs() < 0.01,

--- a/crates/burn-train/src/metric/vision/ssim.rs
+++ b/crates/burn-train/src/metric/vision/ssim.rs
@@ -369,7 +369,6 @@ impl Metric for SsimMetric {
         NumericAttributes {
             unit: None,
             higher_is_better: true,
-            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/metric/vision/ssim.rs
+++ b/crates/burn-train/src/metric/vision/ssim.rs
@@ -5,7 +5,7 @@ use crate::metric::{
 };
 use burn_core::{
     prelude::{Device, Tensor},
-    tensor::{ElementConversion, module::conv2d, ops::ConvOptions},
+    tensor::{module::conv2d, ops::ConvOptions},
 };
 
 /// Input type for the [SsimMetric].
@@ -350,11 +350,13 @@ impl Metric for SsimMetric {
         let ssim_per_image = ssim_tensor.mean_dims(&[1, 2, 3]);
         let avg_ssim = ssim_per_image.mean().into_scalar::<f64>();
 
-        self.state.update(
-            avg_ssim,
-            batch_size,
-            FormatOptions::new(self.name()).precision(4),
-        )
+        self.state.update(avg_ssim, batch_size);
+        self.compute()
+    }
+
+    fn compute(&mut self) -> SerializedEntry {
+        self.state
+            .compute(FormatOptions::new(self.name()).precision(4))
     }
 
     /// Clears the metric state.
@@ -373,12 +375,12 @@ impl Metric for SsimMetric {
 }
 
 impl Numeric for SsimMetric {
-    fn value(&self) -> NumericEntry {
-        self.state.current_value()
+    fn value(&self) -> Option<NumericEntry> {
+        Some(self.state.current_value())
     }
 
-    fn running_value(&self) -> NumericEntry {
-        self.state.running_value()
+    fn running_value(&self) -> Option<NumericEntry> {
+        Some(self.state.running_value())
     }
 }
 
@@ -414,7 +416,7 @@ mod tests {
         let input = SsimInput::new(outputs, targets);
         let _entry = metric.update(&input, &MetricMetadata::fake());
 
-        let ssim = metric.value().current();
+        let ssim = metric.value().unwrap().current();
         assert!(
             (ssim - 1.0).abs() < 0.001,
             "SSIM for identical images should be 1.0, got {}",
@@ -435,7 +437,7 @@ mod tests {
         let input = SsimInput::new(outputs, targets);
         let _entry = metric.update(&input, &MetricMetadata::fake());
 
-        let ssim = metric.value().current();
+        let ssim = metric.value().unwrap().current();
         assert!(
             ssim < 0.0001,
             "SSIM for black vs white images should be very low, got {}",
@@ -454,7 +456,7 @@ mod tests {
         let input = SsimInput::new(outputs, targets);
         let _entry = metric.update(&input, &MetricMetadata::fake());
 
-        let ssim = metric.value().current();
+        let ssim = metric.value().unwrap().current();
         assert!(
             ssim > 0.99,
             "SSIM for very similar images should be close to 1.0, got {}",
@@ -507,7 +509,7 @@ mod tests {
         let input = SsimInput::new(outputs, targets);
         let _entry = metric.update(&input, &MetricMetadata::fake());
 
-        let ssim = metric.value().current();
+        let ssim = metric.value().unwrap().current();
         // Average of ~1.0 and ~0.0 should be around 0.5
         assert!(
             ssim > 0.49 && ssim < 0.51,
@@ -549,7 +551,7 @@ mod tests {
         let input = SsimInput::new(outputs, targets);
         let _entry = metric.update(&input, &MetricMetadata::fake());
 
-        let ssim = metric.value().current();
+        let ssim = metric.value().unwrap().current();
         assert!(
             (ssim - 1.0).abs() < 0.001,
             "SSIM for identical RGB images should be 1.0, got {}",
@@ -586,12 +588,12 @@ mod tests {
         let mut metric1 = SsimMetric::new(config);
         let input1 = SsimInput::new(img1.clone(), img2.clone());
         let _entry = metric1.update(&input1, &MetricMetadata::fake());
-        let ssim1 = metric1.value().current();
+        let ssim1 = metric1.value().unwrap().current();
 
         let mut metric2 = SsimMetric::new(config);
         let input2 = SsimInput::new(img2, img1);
         let _entry = metric2.update(&input2, &MetricMetadata::fake());
-        let ssim2 = metric2.value().current();
+        let ssim2 = metric2.value().unwrap().current();
 
         assert!(
             (ssim1 - ssim2).abs() < 0.001,
@@ -614,7 +616,7 @@ mod tests {
         let input = SsimInput::new(outputs, targets);
         let _entry = metric.update(&input, &MetricMetadata::fake());
 
-        let ssim = metric.value().current();
+        let ssim = metric.value().unwrap().current();
         assert!(
             ssim >= -1.0 && ssim <= 1.0,
             "SSIM should be in range [-1, 1], got {}",
@@ -641,7 +643,7 @@ mod tests {
         let input1 = SsimInput::new(outputs1, targets1);
         let _entry = metric.update(&input1, &MetricMetadata::fake());
 
-        let ssim1 = metric.value().current();
+        let ssim1 = metric.value().unwrap().current();
         assert!(
             (ssim1 - 1.0).abs() < 0.001,
             "First update SSIM should be ~1.0, got {}",
@@ -655,7 +657,7 @@ mod tests {
         let _entry = metric.update(&input2, &MetricMetadata::fake());
 
         // Running average should be around 0.5
-        let running_avg = metric.running_value().current();
+        let running_avg = metric.running_value().unwrap().current();
         assert!(
             running_avg > 0.49 && running_avg < 0.51,
             "Running average should be around 0.5, got {}",
@@ -681,7 +683,7 @@ mod tests {
         let input = SsimInput::new(outputs, targets);
         let _entry = metric.update(&input, &MetricMetadata::fake());
 
-        let ssim = metric.value().current();
+        let ssim = metric.value().unwrap().current();
         assert!(
             (ssim - 1.0).abs() < 0.001,
             "Expected SSIM ~1.0, got {}",
@@ -690,7 +692,7 @@ mod tests {
 
         // Clear and verify reset
         metric.clear();
-        let ssim = metric.running_value().current();
+        let ssim = metric.running_value().unwrap().current();
         assert!(ssim.is_nan(), "Expected NaN after clear, got {}", ssim);
     }
 
@@ -722,7 +724,7 @@ mod tests {
         let input = SsimInput::new(outputs, targets);
         let _entry = metric.update(&input, &MetricMetadata::fake());
 
-        let ssim = metric.value().current();
+        let ssim = metric.value().unwrap().current();
         assert!(
             (ssim - 1.0).abs() < 0.001,
             "SSIM for identical 8-bit images should be 1.0, got {}",
@@ -742,7 +744,7 @@ mod tests {
         let input = SsimInput::new(outputs, targets);
         let _entry = metric.update(&input, &MetricMetadata::fake());
 
-        let ssim = metric.value().current();
+        let ssim = metric.value().unwrap().current();
         assert!(
             (ssim - 1.0).abs() < 0.001,
             "SSIM for identical batch should be 1.0, got {}",
@@ -764,7 +766,7 @@ mod tests {
         let input = SsimInput::new(outputs, targets);
         let _entry = metric.update(&input, &MetricMetadata::fake());
 
-        let ssim = metric.value().current();
+        let ssim = metric.value().unwrap().current();
         assert!(
             (ssim - 1.0).abs() < 0.001,
             "SSIM with default window size should work and SSIM should be ~0.0, got {}",

--- a/crates/burn-train/src/metric/vision/ssim.rs
+++ b/crates/burn-train/src/metric/vision/ssim.rs
@@ -351,12 +351,13 @@ impl Metric for SsimMetric {
         let avg_ssim = ssim_per_image.mean().into_scalar::<f64>();
 
         self.state.update(avg_ssim, batch_size);
-        self.compute()
+        self.state
+            .compute_update(FormatOptions::new(self.name()).precision(4))
     }
 
     fn compute(&mut self) -> SerializedEntry {
         self.state
-            .compute(FormatOptions::new(self.name()).precision(4))
+            .compute_final(FormatOptions::new(self.name()).precision(4))
     }
 
     /// Clears the metric state.
@@ -381,6 +382,10 @@ impl Numeric for SsimMetric {
 
     fn running_value(&self) -> Option<NumericEntry> {
         Some(self.state.running_value())
+    }
+
+    fn final_value(&self) -> NumericEntry {
+        self.state.final_value()
     }
 }
 

--- a/crates/burn-train/src/metric/wer.rs
+++ b/crates/burn-train/src/metric/wer.rs
@@ -72,7 +72,7 @@ impl Metric for WordErrorRate {
         let pad_token = self.pad_token.map(|p| p as i32);
 
         let mut total_edit_distance = 0.0;
-        let mut total_target_length = 0.0;
+        let mut total_target_length = 0usize;
 
         // Process each sequence in the batch
         for i in 0..batch_size {
@@ -106,21 +106,24 @@ impl Metric for WordErrorRate {
             };
 
             total_edit_distance += ed as f64;
-            total_target_length += target_len as f64;
+            total_target_length += target_len;
         }
 
         // Compute current WER value as a percentage
-        let value = if total_target_length > 0.0 {
-            100.0 * total_edit_distance / total_target_length
+        let value = if total_target_length > 0 {
+            100.0 * total_edit_distance / total_target_length as f64
         } else {
             0.0
         };
 
-        self.state.update(
-            value,
-            batch_size,
-            FormatOptions::new(self.name()).unit("%").precision(2),
-        )
+        self.state.update(value, total_target_length);
+        self.state
+            .compute_update(FormatOptions::new(self.name()).unit("%").precision(2))
+    }
+
+    fn compute(&mut self) -> SerializedEntry {
+        self.state
+            .compute_final(FormatOptions::new(self.name()).unit("%").precision(2))
     }
 
     fn name(&self) -> MetricName {
@@ -142,12 +145,16 @@ impl Metric for WordErrorRate {
 }
 
 impl Numeric for WordErrorRate {
-    fn value(&self) -> NumericEntry {
-        self.state.current_value()
+    fn value(&self) -> Option<NumericEntry> {
+        Some(self.state.current_value())
     }
 
-    fn running_value(&self) -> NumericEntry {
-        self.state.running_value()
+    fn running_value(&self) -> Option<NumericEntry> {
+        Some(self.state.running_value())
+    }
+
+    fn final_value(&self) -> NumericEntry {
+        self.state.final_value()
     }
 }
 
@@ -167,7 +174,7 @@ mod tests {
 
         metric.update(&WerInput::new(preds, tgts), &MetricMetadata::fake());
 
-        assert_eq!(0.0, metric.value().current());
+        assert_eq!(0.0, metric.value().unwrap().current());
     }
 
     /// Two word edits in four target words => 50 %.
@@ -185,7 +192,7 @@ mod tests {
         metric.update(&WerInput::new(preds, tgts), &MetricMetadata::fake());
 
         // Total errors = 2, Total target words = 4. WER = (2/4) * 100 = 50 %
-        assert_eq!(50.0, metric.value().current());
+        assert_eq!(50.0, metric.value().unwrap().current());
     }
 
     /// Same scenario as above, but with right-padding (token 9) ignored.
@@ -202,7 +209,7 @@ mod tests {
         let tgts = Tensor::from_data([[1, 3, pad], [3, 4, pad]], &device);
 
         metric.update(&WerInput::new(preds, tgts), &MetricMetadata::fake());
-        assert_eq!(50.0, metric.value().current());
+        assert_eq!(50.0, metric.value().unwrap().current());
     }
 
     /// `clear()` must reset the running statistics to NaN.
@@ -218,9 +225,9 @@ mod tests {
             &WerInput::new(preds.clone(), tgts.clone()),
             &MetricMetadata::fake(),
         );
-        assert!(metric.value().current() > 0.0);
+        assert!(metric.value().unwrap().current() > 0.0);
 
         metric.clear();
-        assert!(metric.value().current().is_nan());
+        assert!(metric.value().unwrap().current().is_nan());
     }
 }

--- a/crates/burn-train/src/metric/wer.rs
+++ b/crates/burn-train/src/metric/wer.rs
@@ -138,7 +138,6 @@ impl Metric for WordErrorRate {
         NumericAttributes {
             unit: Some("%".to_string()),
             higher_is_better: false,
-            ..Default::default()
         }
         .into()
     }

--- a/crates/burn-train/src/renderer/base.rs
+++ b/crates/burn-train/src/renderer/base.rs
@@ -108,7 +108,12 @@ pub enum MetricState {
     /// A generic metric.
     Generic(MetricEntry),
     /// A numeric metric.
-    Numeric(MetricEntry, NumericEntry),
+    ///
+    /// - `MetricEntry`: ID, formatted text string ("epoch N/A - batch N/A").
+    /// - `Option<NumericEntry>`:
+    ///     - `Some(entry)`: A plottable point.
+    ///     - `None`: A valid step tick on the X-axis, but with no drawable Y-coordinate point.
+    Numeric(MetricEntry, Option<NumericEntry>),
 }
 
 fn default_summary_action(summary: Option<LearnerSummary>) {

--- a/crates/burn-train/src/renderer/tui/base.rs
+++ b/crates/burn-train/src/renderer/tui/base.rs
@@ -49,7 +49,7 @@ impl MetricsView<'_> {
     }
 }
 
-#[derive(Hash, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Hash, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub(crate) enum TuiSplit {
     Train,
     Valid,

--- a/crates/burn-train/src/renderer/tui/full_history.rs
+++ b/crates/burn-train/src/renderer/tui/full_history.rs
@@ -60,7 +60,6 @@ impl FullHistoryPlot {
 
     /// Register a training data point.
     pub(crate) fn push(&mut self, tag: TuiTag, data: NumericEntry) {
-        let x_current = self.next_x();
         let points = match self.points.get_mut(&tag) {
             Some(val) => val,
             None => {
@@ -74,6 +73,23 @@ impl FullHistoryPlot {
                 self.points.get_mut(&tag).unwrap()
             }
         };
+
+        // TODO: hmmm I think the next_x_state might be incorrect if we only ever increment it when an entry
+        // is logged (at least, compared to other numeric entries). TBD.
+
+        // If we already have batch points registered, ignore this for the line graph
+        // to prevent an N+1 visual step artifact.
+        if let NumericEntry::Final(val) = data
+            && !points.points.is_empty()
+        {
+            log::info!("[FullHistoryPlot] set_final {val}");
+            points.set_final(val);
+            return;
+        }
+
+        // let x_current = self.next_x();
+        let x_current = self.next_x_state as f64;
+        self.next_x_state += 1;
 
         points.push((x_current, data));
 
@@ -103,12 +119,6 @@ impl FullHistoryPlot {
         bars
     }
 
-    fn next_x(&mut self) -> f64 {
-        let value = self.next_x_state;
-        self.next_x_state += 1;
-        value as f64
-    }
-
     fn update_bounds(&mut self) {
         let (mut x_min, mut x_max) = (f64::MAX, f64::MIN);
         let (mut y_min, mut y_max) = (f64::MAX, f64::MIN);
@@ -119,6 +129,11 @@ impl FullHistoryPlot {
             y_min = f64::min(y_min, points.min_y);
             y_max = f64::max(y_max, points.max_y);
         }
+
+        log::info!(
+            "[FullHistoryPlot] update_bounds ({x_min}, {x_max}) | x_current={}",
+            self.next_x_state - 1
+        );
 
         self.axes.update_bounds((x_min, x_max), (y_min, y_max));
     }
@@ -158,6 +173,11 @@ impl FullHistoryPoints {
                 self.avg_counter += count as f64;
                 aggregated_value
             }
+            NumericEntry::Final(val) => {
+                // For global-only metrics (e.g., AUC-PR), this is our single valid line anchor
+                self.set_final(val);
+                val
+            }
         };
 
         if x > self.max_x {
@@ -178,6 +198,11 @@ impl FullHistoryPoints {
         if self.points.len() > self.max_samples {
             self.resize();
         }
+    }
+
+    fn set_final(&mut self, val: f64) {
+        self.avg_sum = val;
+        self.avg_counter = 1.0;
     }
 
     /// We keep only half the points and we double the step size.

--- a/crates/burn-train/src/renderer/tui/full_history.rs
+++ b/crates/burn-train/src/renderer/tui/full_history.rs
@@ -59,7 +59,8 @@ impl FullHistoryPlot {
     }
 
     /// Register a training data point.
-    pub(crate) fn push(&mut self, tag: TuiTag, data: NumericEntry) {
+    pub(crate) fn push(&mut self, tag: TuiTag, data: Option<NumericEntry>) {
+        let x_current = self.next_x_state as f64;
         let points = match self.points.get_mut(&tag) {
             Some(val) => val,
             None => {
@@ -74,24 +75,25 @@ impl FullHistoryPlot {
             }
         };
 
-        // TODO: hmmm I think the next_x_state might be incorrect if we only ever increment it when an entry
-        // is logged (at least, compared to other numeric entries). TBD.
+        match data {
+            Some(y) => {
+                // If we already have batch points registered, ignore this for the line graph
+                // to prevent an N+1 visual step artifact.
+                if let NumericEntry::Final(val) = y
+                    && !points.points.is_empty()
+                {
+                    points.set_final(val);
+                    return;
+                }
 
-        // If we already have batch points registered, ignore this for the line graph
-        // to prevent an N+1 visual step artifact.
-        if let NumericEntry::Final(val) = data
-            && !points.points.is_empty()
-        {
-            log::info!("[FullHistoryPlot] set_final {val}");
-            points.set_final(val);
-            return;
+                self.next_x_state += 1;
+                points.push((x_current, y));
+            }
+            None => {
+                // Null step -> advance X to keep step alignment across metrics
+                self.next_x_state += 1;
+            }
         }
-
-        // let x_current = self.next_x();
-        let x_current = self.next_x_state as f64;
-        self.next_x_state += 1;
-
-        points.push((x_current, data));
 
         self.update_bounds();
     }
@@ -129,11 +131,6 @@ impl FullHistoryPlot {
             y_min = f64::min(y_min, points.min_y);
             y_max = f64::max(y_max, points.max_y);
         }
-
-        log::info!(
-            "[FullHistoryPlot] update_bounds ({x_min}, {x_max}) | x_current={}",
-            self.next_x_state - 1
-        );
 
         self.axes.update_bounds((x_min, x_max), (y_min, y_max));
     }
@@ -201,6 +198,7 @@ impl FullHistoryPoints {
     }
 
     fn set_final(&mut self, val: f64) {
+        // Final value does not affect plot points, but should affect the bar graph
         self.avg_sum = val;
         self.avg_counter = 1.0;
     }
@@ -288,10 +286,10 @@ mod tests {
         chart.update_max_sample(tag_valid.split, 0.6);
 
         for i in 0..100 {
-            chart.push(tag_train.clone(), NumericEntry::Value(i as f64));
+            chart.push(tag_train.clone(), Some(NumericEntry::Value(i as f64)));
         }
         for i in 0..60 {
-            chart.push(tag_valid.clone(), NumericEntry::Value(i as f64));
+            chart.push(tag_valid.clone(), Some(NumericEntry::Value(i as f64)));
         }
 
         let expected_train = vec![
@@ -316,5 +314,53 @@ mod tests {
             expected_valid,
             "Expected valid data points"
         );
+    }
+
+    #[test]
+    fn test_points_with_none_gaps() {
+        let mut chart = FullHistoryPlot::new(10);
+        let tag_train = TuiTag::new(TuiSplit::Train, TuiGroup::Default);
+
+        // Push 3 gap (None) steps -> should advance X ticks without adding points
+        chart.push(tag_train.clone(), None);
+        chart.push(tag_train.clone(), None);
+        chart.push(tag_train.clone(), None);
+
+        // Push valid point -> should land at X = 3.0
+        chart.push(tag_train.clone(), Some(NumericEntry::Value(10.0)));
+
+        let points = &chart.points.get(&tag_train).unwrap().points;
+
+        // The line plot should only hold 1 actual coordinate
+        assert_eq!(points.len(), 1);
+        assert_eq!(points[0], (3.0, 10.0));
+        assert_eq!(chart.next_x_state, 4);
+    }
+
+    #[test]
+    fn test_points_final_ignored_when_points_exist() {
+        let mut chart = FullHistoryPlot::new(10);
+        let tag_train = TuiTag::new(TuiSplit::Train, TuiGroup::Default);
+
+        // Push two normal batch points
+        chart.push(tag_train.clone(), Some(NumericEntry::Value(1.0))); // X = 0.0
+        chart.push(tag_train.clone(), Some(NumericEntry::Value(2.0))); // X = 1.0
+
+        let expected_points = vec![(0.0, 1.0), (1.0, 2.0)];
+        assert_eq!(chart.next_x_state, 2);
+        assert_eq!(
+            chart.points.get(&tag_train).unwrap().points,
+            expected_points
+        );
+
+        // Push Final entry -> should update `final_value` but NOT advance next_x_state or add to points
+        chart.push(tag_train.clone(), Some(NumericEntry::Final(1.5)));
+        assert_eq!(chart.next_x_state, 2); // X state remains 2
+        let history = chart.points.get(&tag_train).unwrap();
+        assert_eq!(history.points.len(), 2);
+        assert_eq!(history.points, expected_points);
+        // The avg sum and counters are overwritten (used in bar graph)
+        assert_eq!(history.avg_sum, 1.5);
+        assert_eq!(history.avg_counter, 1.0);
     }
 }

--- a/crates/burn-train/src/renderer/tui/metric_numeric.rs
+++ b/crates/burn-train/src/renderer/tui/metric_numeric.rs
@@ -90,16 +90,10 @@ impl NumericMetricsState {
     }
 
     /// Push a new value for the metric with the given name.
-    pub(crate) fn push(&mut self, tag: TuiTag, name: MetricName, data: NumericEntry) {
-        if matches!(data, NumericEntry::Final(_)) {
-            log::info!(
-                "[FINAL] push final metric value for {name} ({:?})",
-                tag.split
-            );
-        }
+    pub(crate) fn push(&mut self, tag: TuiTag, name: MetricName, data: Option<NumericEntry>) {
         self.register(name.clone());
         let (recent, full) = self.data.get_mut(name.as_ref()).unwrap();
-        recent.push(tag.clone(), data.current());
+        recent.push(tag.clone(), data.clone());
         full.push(tag, data);
     }
 

--- a/crates/burn-train/src/renderer/tui/metric_numeric.rs
+++ b/crates/burn-train/src/renderer/tui/metric_numeric.rs
@@ -79,21 +79,28 @@ pub(crate) enum PlotKind {
 }
 
 impl NumericMetricsState {
-    /// Register a new training value for the metric with the given name.
-    pub(crate) fn push(&mut self, tag: TuiTag, name: MetricName, data: NumericEntry) {
-        if let Some((recent, full)) = self.data.get_mut(name.as_ref()) {
-            recent.push(tag.clone(), data.current());
-            full.push(tag, data);
-        } else {
-            let mut recent = RecentHistoryPlot::new(MAX_NUM_SAMPLES_RECENT);
-            let mut full = FullHistoryPlot::new(MAX_NUM_SAMPLES_FULL);
-
-            recent.push(tag.clone(), data.current());
-            full.push(tag, data);
-
+    /// Register a new metric with the given name.
+    pub(crate) fn register(&mut self, name: MetricName) {
+        if !self.data.contains_key(name.as_ref()) {
+            let recent = RecentHistoryPlot::new(MAX_NUM_SAMPLES_RECENT);
+            let full = FullHistoryPlot::new(MAX_NUM_SAMPLES_FULL);
             self.names.push(name.clone());
             self.data.insert(name, (recent, full));
         }
+    }
+
+    /// Push a new value for the metric with the given name.
+    pub(crate) fn push(&mut self, tag: TuiTag, name: MetricName, data: NumericEntry) {
+        if matches!(data, NumericEntry::Final(_)) {
+            log::info!(
+                "[FINAL] push final metric value for {name} ({:?})",
+                tag.split
+            );
+        }
+        self.register(name.clone());
+        let (recent, full) = self.data.get_mut(name.as_ref()).unwrap();
+        recent.push(tag.clone(), data.current());
+        full.push(tag, data);
     }
 
     /// Update the state with the training progress.

--- a/crates/burn-train/src/renderer/tui/recent_history.rs
+++ b/crates/burn-train/src/renderer/tui/recent_history.rs
@@ -69,10 +69,10 @@ impl RecentHistoryPlot {
         };
 
         for (s, entry) in self.points.iter_mut() {
-            if let Some(y) = plot_value {
-                if s == &tag {
-                    entry.push((x_current, y));
-                }
+            if let Some(y) = plot_value
+                && s == &tag
+            {
+                entry.push((x_current, y));
             }
             entry.update_cursor(x_min);
         }

--- a/crates/burn-train/src/renderer/tui/recent_history.rs
+++ b/crates/burn-train/src/renderer/tui/recent_history.rs
@@ -1,5 +1,5 @@
 use super::PlotAxes;
-use crate::renderer::tui::TuiTag;
+use crate::{metric::NumericEntry, renderer::tui::TuiTag};
 use ratatui::{
     style::{Color, Style},
     symbols,
@@ -14,6 +14,7 @@ pub(crate) struct RecentHistoryPlot {
     pub(crate) axes: PlotAxes,
     points: BTreeMap<TuiTag, RecentHistoryPoints>,
     max_samples: usize,
+    next_x_state: usize,
 }
 
 struct RecentHistoryPoints {
@@ -33,20 +34,45 @@ impl RecentHistoryPlot {
             axes: PlotAxes::default(),
             points: BTreeMap::default(),
             max_samples,
+            next_x_state: 0,
         }
     }
 
-    pub(crate) fn push(&mut self, tag: TuiTag, data: f64) {
+    pub(crate) fn push(&mut self, tag: TuiTag, data: Option<NumericEntry>) {
         if !self.points.contains_key(&tag) {
             self.points
                 .insert(tag.clone(), RecentHistoryPoints::new(self.max_samples));
         }
 
-        let (x_min, x_current) = self.point_x();
+        // Convert the NumericEntry into a plottable f64.
+        // We filter out `Final` if we already have batch points for this tag.
+        let plot_value = match data {
+            Some(NumericEntry::Final(val)) => {
+                let has_points = !self.points.get(&tag).unwrap().points.is_empty();
+                if has_points {
+                    return; // Ignore the N+1 artifact
+                } else {
+                    Some(val) // Fallback for global-only metrics
+                }
+            }
+            Some(entry) => Some(entry.current()),
+            None => None,
+        };
+
+        let x_current = self.next_x_state as f64;
+        self.next_x_state += 1;
+
+        let x_min = if self.next_x_state > self.max_samples {
+            (self.next_x_state - self.max_samples) as f64
+        } else {
+            0.0
+        };
 
         for (s, entry) in self.points.iter_mut() {
-            if s == &tag {
-                entry.push((x_current, data));
+            if let Some(y) = plot_value {
+                if s == &tag {
+                    entry.push((x_current, y));
+                }
             }
             entry.update_cursor(x_min);
         }
@@ -62,22 +88,6 @@ impl RecentHistoryPlot {
         }
 
         datasets
-    }
-
-    fn point_x(&mut self) -> (f64, f64) {
-        let mut x_current = f64::MIN;
-        let mut x_min = f64::MAX;
-
-        for point in self.points.values() {
-            x_current = f64::max(x_current, point.max_x);
-            x_min = f64::min(x_min, point.min_x);
-        }
-
-        if x_current - x_min >= self.max_samples as f64 {
-            x_min += 1.0;
-        }
-
-        (x_min, x_current + 1.0)
     }
 
     fn update_bounds(&mut self) {
@@ -221,29 +231,53 @@ mod tests {
 
     #[test]
     fn test_push_update_bounds_max_y() {
-        let mut chart = RecentHistoryPlot::new(2);
+        let mut chart = RecentHistoryPlot::new(3);
         let tag = TuiTag::new(TuiSplit::Train, TuiGroup::Default);
 
-        chart.push(tag.clone(), 15.0);
-        chart.push(tag.clone(), 10.0);
-        chart.push(tag.clone(), 14.0);
+        chart.push(tag.clone(), Some(NumericEntry::Value(15.0)));
+        chart.push(tag.clone(), Some(NumericEntry::Value(10.0)));
+        chart.push(tag.clone(), Some(NumericEntry::Value(14.0)));
 
         assert_eq!(chart.axes.bounds_y[1], 15.);
-        chart.push(tag, 10.0);
+        chart.push(tag, Some(NumericEntry::Value(10.0)));
         assert_eq!(chart.axes.bounds_y[1], 14.);
     }
 
     #[test]
     fn test_push_update_bounds_min_y() {
+        let mut chart = RecentHistoryPlot::new(3);
+        let tag = TuiTag::new(TuiSplit::Train, TuiGroup::Default);
+
+        chart.push(tag.clone(), Some(NumericEntry::Value(5.0)));
+        chart.push(tag.clone(), Some(NumericEntry::Value(10.0)));
+        chart.push(tag.clone(), Some(NumericEntry::Value(14.0)));
+
+        assert_eq!(chart.axes.bounds_y[0], 5.);
+        chart.push(tag, Some(NumericEntry::Value(10.0)));
+        assert_eq!(chart.axes.bounds_y[0], 10.);
+    }
+
+    #[test]
+    fn test_push_update_no_value_bounds_min_x() {
         let mut chart = RecentHistoryPlot::new(2);
         let tag = TuiTag::new(TuiSplit::Train, TuiGroup::Default);
 
-        chart.push(tag.clone(), 5.0);
-        chart.push(tag.clone(), 10.0);
-        chart.push(tag.clone(), 14.0);
+        // Push 1: None -> tick 0. bounds_x = (0, 0)
+        chart.push(tag.clone(), None);
+        assert_eq!(chart.axes.bounds_x, [0.0, 0.0]);
 
-        assert_eq!(chart.axes.bounds_y[0], 5.);
-        chart.push(tag, 10.0);
-        assert_eq!(chart.axes.bounds_y[0], 10.);
+        // Push 2: None -> tick 1. bounds_x unchanged because no point was actually added
+        chart.push(tag.clone(), None);
+        assert_eq!(chart.axes.bounds_x, [0.0, 0.0]);
+
+        // Push 3: Some(5.0) -> tick 2. Sliding window max_samples=2 -> bounds_x = (1, 2)
+        chart.push(tag.clone(), Some(NumericEntry::Value(5.0)));
+        assert_eq!(chart.axes.bounds_x, [1.0, 2.0]);
+        assert_eq!(chart.axes.bounds_y, [5.0, 5.0]);
+
+        // Push 4: Some(10.0) -> tick 3. bounds_x = (2, 3)
+        chart.push(tag, Some(NumericEntry::Value(10.0)));
+        assert_eq!(chart.axes.bounds_x, [2.0, 3.0]);
+        assert_eq!(chart.axes.bounds_y, [5.0, 10.0]);
     }
 }

--- a/crates/burn-train/src/renderer/tui/renderer.rs
+++ b/crates/burn-train/src/renderer/tui/renderer.rs
@@ -1,5 +1,5 @@
 use crate::logger::{EvaluationProgressLogger, ProgressSnapshot, TrainingProgressLogger};
-use crate::metric::{MetricDefinition, MetricId};
+use crate::metric::{MetricAttributes, MetricDefinition, MetricId};
 use crate::renderer::tui::TuiSplit;
 use crate::renderer::{EvaluationName, MetricState, MetricsRenderer, MetricsRendererEvaluation};
 use crate::renderer::{MetricsRendererTraining, tui::NumericMetricsState};
@@ -378,6 +378,12 @@ impl TuiMetricsRenderer {
     fn handle_event(&mut self, event: TuiRendererEvent) {
         match event {
             TuiRendererEvent::MetricRegistration(definition) => {
+                if let MetricAttributes::Numeric(_) = &definition.attributes {
+                    // Register numeric metrics so even epoch-level metrics already appear
+                    // in the registry (i.e., TUI tabs) before a value is actually pushed.
+                    // This also preserves order
+                    self.metrics_numeric.register(definition.name.clone());
+                }
                 self.metric_definitions
                     .insert(definition.metric_id.clone(), definition);
             }

--- a/crates/burn-train/src/renderer/tui/renderer.rs
+++ b/crates/burn-train/src/renderer/tui/renderer.rs
@@ -381,7 +381,6 @@ impl TuiMetricsRenderer {
                 if let MetricAttributes::Numeric(_) = &definition.attributes {
                     // Register numeric metrics so even epoch-level metrics already appear
                     // in the registry (i.e., TUI tabs) before a value is actually pushed.
-                    // This also preserves order
                     self.metrics_numeric.register(definition.name.clone());
                 }
                 self.metric_definitions

--- a/crates/burn-train/src/renderer/tui/renderer.rs
+++ b/crates/burn-train/src/renderer/tui/renderer.rs
@@ -315,8 +315,7 @@ impl TuiMetricsRenderer {
                     .get(&entry.metric_id)
                     .unwrap()
                     .name
-                    .clone()
-                    .into();
+                    .clone();
                 self.metrics_text.update(split, group, entry, name);
             }
             MetricState::Numeric(entry, value) => {
@@ -325,8 +324,7 @@ impl TuiMetricsRenderer {
                     .get(&entry.metric_id)
                     .unwrap()
                     .name
-                    .clone()
-                    .into();
+                    .clone();
                 self.metrics_numeric
                     .push(TuiTag::new(split, group.clone()), name.clone(), value);
                 self.metrics_text.update(split, group, entry, name);


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Fixes #2758

Previously, metrics like Precision, Recall, and AUROC incorrectly assumed that global epoch-level scores could be computed by averaging individual batch-level metrics (weighted by sample count in `NumericMetricState`). This approach is biased for metrics requiring global statistics and sometimes entirely incorrect for metrics like AUROC and AUC-PR which cannot be meaningfully evaluated per-batch.

### Changes

- **Updated `Numeric` Trait:** Changed `value()` and `running_value()` to return `Option<NumericEntry>` (returning `None` for epoch-only metrics mid-epoch) and added `final_value()` to retrieve the computed metric at epoch completion.
- **Split `Metric` Execution:** Updated the `Metric` trait to decouple batch steps (`update`) from epoch-level finalization (`compute`). Updated `NumericMetricState` with `compute_update` and `compute_final` methods so that global aggregation is explicitly triggered at the end of each epoch (`end_epoch_train` in the event processor).
- **Added `ConfusionStatsState`:** Introduced a state structure that aggregates raw confusion matrix statistics (TP, FP, FN) across batches, enabling accurate global metric evaluation.
- **Updated `AurocMetric` & `AucPrMetric` via `PredictionAccumulatorState`:** Refactored `AurocMetric` to use `PredictionAccumulatorState` alongside `AucPrMetric`, accumulating raw prediction/target tensors during `update` and evaluating AUROC once over the full dataset during `compute`.

### Testing

Unit tests and mnist example
