### PR TITLE
Feat/add get many in dataset trait

### DIFF
--- a/crates/burn-core/src/data/dataloader/batch.rs
+++ b/crates/burn-core/src/data/dataloader/batch.rs
@@ -166,12 +166,22 @@ impl<I, O> Iterator for BatchDataloaderIterator<I, O> {
 
     fn next(&mut self) -> Option<Self::Item> {
         while self.current_index < self.len {
-            let item = match self.dataset.get(self.current_index) {
-                Ok(item) => item,
+            let chunk_size = self
+                .strategy
+                .batch_size()
+                .unwrap_or(1)
+                .min(self.len - self.current_index);
+            let indexes = (self.current_index..self.current_index + chunk_size).collect();
+
+            let items = match self.dataset.get_many(indexes) {
+                Ok(items) => items,
                 Err(err) => return Some(Err(err)),
             };
-            self.current_index += 1;
-            self.strategy.add(item);
+            self.current_index += chunk_size;
+
+            for item in items {
+                self.strategy.add(item);
+            }
 
             if let Some(items) = self.strategy.batch(false) {
                 return Some(Ok(self.batcher.batch(items, &self.device)));
@@ -264,5 +274,62 @@ mod tests {
         }
 
         assert_eq!(items_dataloader, items_dataloader_slice);
+    }
+
+    #[test]
+    fn test_batch_dataloader_incomplete_last_batch() {
+        let batcher = Arc::new(TestBatcher::new());
+        let dataset = Arc::new(FakeDataset::<String>::new(27));
+        let dataloader = BatchDataLoader::new(
+            Box::new(FixBatchStrategy::new(5)),
+            dataset,
+            batcher,
+            Default::default(),
+            None,
+        );
+
+        let batch_sizes: Vec<usize> = dataloader
+            .iter()
+            .map(Result::unwrap)
+            .map(|items| items.len())
+            .collect();
+
+        assert_eq!(batch_sizes, vec![5, 5, 5, 5, 5, 2]);
+    }
+
+    #[test]
+    fn test_batch_dataloader_exact_multiple_batches() {
+        let batcher = Arc::new(TestBatcher::new());
+        let dataset = Arc::new(FakeDataset::<String>::new(25));
+        let dataloader = BatchDataLoader::new(
+            Box::new(FixBatchStrategy::new(5)),
+            dataset,
+            batcher,
+            Default::default(),
+            None,
+        );
+
+        let batch_sizes: Vec<usize> = dataloader
+            .iter()
+            .map(Result::unwrap)
+            .map(|items| items.len())
+            .collect();
+
+        assert_eq!(batch_sizes, vec![5, 5, 5, 5, 5]);
+    }
+
+    #[test]
+    fn test_batch_dataloader_empty_dataset() {
+        let batcher = Arc::new(TestBatcher::new());
+        let dataset = Arc::new(FakeDataset::<String>::new(0));
+        let dataloader = BatchDataLoader::new(
+            Box::new(FixBatchStrategy::new(5)),
+            dataset,
+            batcher,
+            Default::default(),
+            None,
+        );
+
+        assert!(dataloader.iter().next().is_none());
     }
 }

--- a/crates/burn-dataset/src/dataset/base.rs
+++ b/crates/burn-dataset/src/dataset/base.rs
@@ -21,6 +21,27 @@ where
     /// Panics if `index >= len()`.
     fn get(&self, index: usize) -> Result<I, E>;
 
+    /// Gets the items at given indexes
+    ///
+    /// # Panics
+    ///
+    /// panics if `indexes[i] >= len()`
+    fn get_many(&self, indexes: Vec<usize>) -> Result<Vec<I>, E> {
+        let len = self.len();
+        let mut items = Vec::new();
+
+        for i in indexes {
+            assert!(i < len);
+
+            match self.get(i) {
+                Ok(item) => items.push(item),
+                Err(e) => return Err(e),
+            }
+        }
+
+        Ok(items)
+    }
+
     /// Gets the number of items in the dataset.
     fn len(&self) -> usize;
 
@@ -47,6 +68,10 @@ where
         self.as_ref().get(index)
     }
 
+    fn get_many(&self, indexes: Vec<usize>) -> Result<Vec<I>, E> {
+        self.as_ref().get_many(indexes)
+    }
+
     fn len(&self) -> usize {
         self.as_ref().len()
     }
@@ -58,6 +83,10 @@ where
 {
     fn get(&self, index: usize) -> Result<I, E> {
         self.as_ref().get(index)
+    }
+
+    fn get_many(&self, indexes: Vec<usize>) -> Result<Vec<I>, E> {
+        self.as_ref().get_many(indexes)
     }
 
     fn len(&self) -> usize {
@@ -74,6 +103,10 @@ where
         self.as_ref().get(index)
     }
 
+    fn get_many(&self, indexes: Vec<usize>) -> Result<Vec<I>, E> {
+        self.as_ref().get_many(indexes)
+    }
+
     fn len(&self) -> usize {
         self.as_ref().len()
     }
@@ -85,6 +118,10 @@ where
 {
     fn get(&self, index: usize) -> Result<I, E> {
         self.as_ref().get(index)
+    }
+
+    fn get_many(&self, indexes: Vec<usize>) -> Result<Vec<I>, E> {
+        self.as_ref().get_many(indexes)
     }
 
     fn len(&self) -> usize {

--- a/crates/burn-dataset/src/dataset/base.rs
+++ b/crates/burn-dataset/src/dataset/base.rs
@@ -31,7 +31,7 @@ where
         let mut items = Vec::new();
 
         for i in indexes {
-            assert!(i < len);
+            assert!(i < len, "Index out of bounds for dataset: {i} >= {len}");
 
             match self.get(i) {
                 Ok(item) => items.push(item),

--- a/crates/burn-dataset/src/dataset/base.rs
+++ b/crates/burn-dataset/src/dataset/base.rs
@@ -32,11 +32,8 @@ where
 
         for i in indexes {
             assert!(i < len, "Index out of bounds for dataset: {i} >= {len}");
-
-            match self.get(i) {
-                Ok(item) => items.push(item),
-                Err(e) => return Err(e),
-            }
+            let item = self.get(i)?;
+            items.push(item);
         }
 
         Ok(items)

--- a/crates/burn-dataset/src/dataset/sqlite.rs
+++ b/crates/burn-dataset/src/dataset/sqlite.rs
@@ -238,6 +238,71 @@ where
         }
     }
 
+    /// Get multiple items from the dataset in a single query.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `indexes[i] >= len()`.
+    fn get_many(&self, indexes: Vec<usize>) -> Result<Vec<I>> {
+        if indexes.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        for &index in &indexes {
+            assert!(
+                index < self.len,
+                "Index out of bounds for SqliteDataset: {} >= {}",
+                index,
+                self.len,
+            );
+        }
+
+        // Bind (row_id, ord) pairs through a CTE so SQLite returns the rows already ordered
+        // (and duplicated) to match the requested `indexes`, instead of reordering in Rust.
+        let values_clause = vec!["(?, ?)"; indexes.len()].join(", ");
+        let params: Vec<i64> = indexes
+            .iter()
+            .enumerate()
+            .flat_map(|(ord, &index)| [(index + 1) as i64, ord as i64])
+            .collect();
+
+        let split = &self.split;
+        let connection = self.conn_pool.get()?;
+
+        if self.row_serialized {
+            let query = format!(
+                "WITH req(row_id, ord) AS (VALUES {values_clause}) \
+                 SELECT t.item FROM req JOIN {split} t ON t.row_id = req.row_id ORDER BY req.ord"
+            );
+            let mut statement = connection.prepare(&query)?;
+            let mut rows = statement.query(rusqlite::params_from_iter(params.iter()))?;
+
+            let mut items = Vec::with_capacity(indexes.len());
+            while let Some(row) = rows.next()? {
+                let blob: Vec<u8> = row
+                    .get_ref(0)?
+                    .as_blob()
+                    .map_err(rusqlite::Error::from)?
+                    .to_vec();
+                items.push(rmp_serde::from_slice::<I>(&blob)?);
+            }
+            Ok(items)
+        } else {
+            let query = format!(
+                "WITH req(row_id, ord) AS (VALUES {values_clause}) \
+                 SELECT t.* FROM req JOIN {split} t ON t.row_id = req.row_id ORDER BY req.ord"
+            );
+            let mut statement = connection.prepare(&query)?;
+            let mut rows = statement.query(rusqlite::params_from_iter(params.iter()))?;
+
+            let mut items = Vec::with_capacity(indexes.len());
+            while let Some(row) = rows.next()? {
+                items.push(from_row_with_columns::<I>(row, &self.columns)?);
+            }
+            Ok(items)
+        }
+    }
+
     /// Return the number of rows in the dataset.
     fn len(&self) -> usize {
         self.len
@@ -682,6 +747,28 @@ mod tests {
     #[should_panic(expected = "Index out of bounds")]
     pub fn get_none(train_dataset: SqlDs) {
         train_dataset.get(10).unwrap();
+    }
+
+    #[rstest]
+    pub fn get_many_out_of_order_with_duplicates(train_dataset: SqlDs) {
+        // Requested out of order and with a duplicate; result must follow the requested order.
+        let items = train_dataset.get_many(vec![1, 0, 1]).unwrap();
+
+        assert_eq!(items.len(), 3);
+        assert_eq!(items[0], train_dataset.get(1).unwrap());
+        assert_eq!(items[1], train_dataset.get(0).unwrap());
+        assert_eq!(items[2], train_dataset.get(1).unwrap());
+    }
+
+    #[rstest]
+    pub fn get_many_empty(train_dataset: SqlDs) {
+        assert_eq!(train_dataset.get_many(vec![]).unwrap(), Vec::new());
+    }
+
+    #[rstest]
+    #[should_panic(expected = "Index out of bounds")]
+    pub fn get_many_out_of_bounds(train_dataset: SqlDs) {
+        train_dataset.get_many(vec![0, 10]).unwrap();
     }
 
     #[rstest]

--- a/crates/burn-dataset/src/transform/partial.rs
+++ b/crates/burn-dataset/src/transform/partial.rs
@@ -100,6 +100,23 @@ where
         self.dataset.get(index)
     }
 
+    fn get_many(&self, indexes: Vec<usize>) -> Result<Vec<I>, E> {
+        let translated = indexes
+            .into_iter()
+            .map(|index| {
+                let index = index + self.start_index;
+                assert!(
+                    index >= self.start_index && index < self.end_index,
+                    "Index out of bounds for PartialDataset: {} >= {}",
+                    index,
+                    self.end_index
+                );
+                index
+            })
+            .collect();
+        self.dataset.get_many(translated)
+    }
+
     fn len(&self) -> usize {
         usize::min(self.end_index - self.start_index, self.dataset.len())
     }
@@ -169,6 +186,34 @@ mod tests {
         for item in items_original_2 {
             assert!(!items_partial.contains(&item));
         }
+    }
+
+    #[test]
+    fn test_get_many() {
+        let dataset_original = FakeDataset::<String>::new(27);
+        let source_items: Vec<String> = dataset_original.iter().map(Result::unwrap).collect();
+
+        let dataset_partial = PartialDataset::new(dataset_original, 10, 20);
+
+        // Local indices, out of order and with a duplicate.
+        let requested = vec![5, 0, 3, 0];
+        let expected: Vec<String> = requested
+            .iter()
+            .map(|&i| source_items[10 + i].clone())
+            .collect();
+
+        let items = dataset_partial.get_many(requested).unwrap();
+
+        assert_eq!(items, expected);
+    }
+
+    #[test]
+    #[should_panic(expected = "Index out of bounds for PartialDataset: 20 >= 20")]
+    fn test_get_many_out_of_bounds() {
+        let dataset_original = FakeDataset::<String>::new(27);
+        let dataset_partial = PartialDataset::new(dataset_original, 10, 20);
+
+        let _ = dataset_partial.get_many(vec![0, 10]);
     }
 
     #[test]

--- a/crates/burn-dataset/src/transform/selection.rs
+++ b/crates/burn-dataset/src/transform/selection.rs
@@ -236,6 +236,21 @@ where
         self.wrapped.get(index)
     }
 
+    fn get_many(&self, indexes: Vec<usize>) -> Result<Vec<I>, DatasetError> {
+        let translated: Vec<usize> = indexes
+            .into_iter()
+            .map(|i| {
+                self.indices.get(i).copied().unwrap_or_else(|| {
+                    panic!(
+                        "Index out of bounds for SelectionDataset: {i} >= {}",
+                        self.indices.len()
+                    )
+                })
+            })
+            .collect();
+        self.wrapped.get_many(translated)
+    }
+
     fn len(&self) -> usize {
         self.indices.len()
     }
@@ -313,6 +328,35 @@ mod tests {
         let items = selection.iter().map(Result::unwrap).collect::<Vec<_>>();
 
         assert_eq!(items, expected);
+    }
+
+    #[test]
+    fn test_selection_dataset_get_many() {
+        let source_dataset = FakeDataset::<String>::new(27);
+
+        let indices: Vec<usize> = vec![15, 1, 12, 12];
+        let selection = SelectionDataset::from_indices_checked(source_dataset, indices);
+
+        // Local indices, out of order and with a duplicate, mapping through `selection.indices`.
+        let requested = vec![3, 0, 2, 0];
+        let expected: Vec<String> = requested
+            .iter()
+            .map(|&i| selection.get(i).unwrap())
+            .collect();
+
+        let items = selection.get_many(requested).unwrap();
+
+        assert_eq!(items, expected);
+    }
+
+    #[test]
+    #[should_panic(expected = "Index out of bounds for SelectionDataset: 4 >= 4")]
+    fn test_selection_dataset_get_many_out_of_bounds() {
+        let source_dataset = FakeDataset::<String>::new(27);
+        let indices: Vec<usize> = vec![15, 1, 12, 12];
+        let selection = SelectionDataset::from_indices_checked(source_dataset, indices);
+
+        let _ = selection.get_many(vec![0, 4]);
     }
 
     #[test]

--- a/crates/burn-dataset/src/transform/window.rs
+++ b/crates/burn-dataset/src/transform/window.rs
@@ -19,9 +19,7 @@ impl<I, T: Dataset<I> + ?Sized> Window<I> for T {
         if end > self.len() {
             return Ok(None);
         }
-        let items = (current..end)
-            .map(|x| self.get(x))
-            .collect::<Result<Vec<I>, DatasetError>>()?;
+        let items = self.get_many((current..end).collect())?;
         Ok(Some(items))
     }
 }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

_No issues_

### Changes

- Add in the `dataset<I, E>` trait a `get_many(indexes: Vec<usize>)` that lets you get many items at once from the Dataset.

- Add a Sqlite implementation of `get_many` and test 

### Testing

- ran cargo test
