### PR TITLE
Support struct and enum inputs for backend extensions

### DIFF
--- a/burn-book/src/advanced/backend-extension/README.md
+++ b/burn-book/src/advanced/backend-extension/README.md
@@ -80,3 +80,54 @@ The specifics of each implementation will be covered by the examples provided in
 `cubecl` compiler frontend is the recommended method of implementing custom kernels, since it
 supports multiple backends, including `wgpu` and `CUDA`, and is the way first-party `burn` kernels
 are written.
+
+## Passing structs and enums of tensors
+
+An extension operation is not limited to individual tensor arguments. A custom struct or enum whose
+fields are tensor primitives can be passed to and returned from an operation by deriving
+`ExtensionType`. Fields that are not tensors pass through unchanged, and a field that is itself an
+`ExtensionType` can be nested by annotating it with `#[extension_type]`.
+
+```rust, ignore
+use burn::backend::{
+    ExtensionType, backend_extension,
+    tensor::{FloatTensor, IntTensor},
+};
+
+#[derive(ExtensionType)]
+pub struct Boxes<B: Backend> {
+    pub coords: FloatTensor<B>,
+    pub scores: FloatTensor<B>,
+    pub count: usize, // Non-tensor fields pass through unchanged.
+}
+
+#[derive(ExtensionType)]
+pub enum Operand<B: Backend> {
+    Dense(FloatTensor<B>),
+    Sparse { values: FloatTensor<B>, indices: IntTensor<B> },
+    Empty,
+}
+```
+
+Such a type can be returned from an operation directly. To pass one as an input, mark the argument
+with `#[extension_type]`:
+
+```rust, ignore
+#[backend_extension(Wgpu, Cuda, Autodiff)]
+pub trait Backend: burn::backend::Backend {
+    // Struct as an output.
+    fn detect(image: FloatTensor<Self>) -> Boxes<Self>;
+
+    // Struct or enum as an input.
+    fn nms(#[extension_type] boxes: Boxes<Self>, iou_threshold: f32) -> Boxes<Self>;
+}
+```
+
+Inputs marked this way can be freely mixed with plain tensor arguments and with each other, and an
+operation can take several of them. The backend is selected by looking at a representative tensor
+across the inputs, so an enum currently on a variant that holds no tensor simply defers to the next
+input; if no input holds a tensor at all, the backend cannot be resolved and the operation panics.
+
+Struct and enum inputs also work with `Autodiff`. Float fields carry the gradient; other fields do
+not. Your `impl ... for Autodiff<B>` writes the backward pass by hand, exactly as it does for plain
+tensor inputs.

--- a/crates/burn-backend-extension/src/lib.rs
+++ b/crates/burn-backend-extension/src/lib.rs
@@ -5,8 +5,8 @@ use proc_macro2::TokenStream as TokenStream2;
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::{
-    FnArg, GenericArgument, Ident, ItemStruct, ItemTrait, Meta, Pat, PathArguments, ReturnType,
-    Token, TraitItem, Type, TypeParamBound, parse_macro_input,
+    Data, DeriveInput, Fields, FnArg, GenericArgument, Ident, ItemTrait, Meta, Pat, PathArguments,
+    ReturnType, Token, TraitItem, Type, TypeParamBound, parse_macro_input,
 };
 
 /// # `backend_extension`
@@ -37,14 +37,17 @@ use syn::{
 /// backend still quantized — the op reads the packed values/scales directly instead
 /// of going through a dequantize).
 ///
-/// ### Struct-of-tensors inputs
+/// ### Struct / enum inputs
 ///
-/// A custom struct of tensor primitives (deriving [`ExtensionType`](macro@ExtensionType)) can be
-/// passed as an **input** by marking the argument with `#[extension_type]`:
+/// A custom struct or enum of tensor primitives (deriving [`ExtensionType`](macro@ExtensionType))
+/// can be passed as an **input** by marking the argument with `#[extension_type]`:
 ///
 /// ```rust,ignore
 /// #[derive(ExtensionType)]
 /// pub struct Inputs<B: Backend> { pub lhs: FloatTensor<B>, pub rhs: FloatTensor<B> }
+///
+/// #[derive(ExtensionType)]
+/// pub enum Operand<B: Backend> { Dense(FloatTensor<B>), Empty }
 ///
 /// #[backend_extension(Wgpu)]
 /// pub trait MyExtension: Backend {
@@ -52,11 +55,15 @@ use syn::{
 /// }
 /// ```
 ///
-/// The macro selects the backend from a representative tensor field of the struct and unwraps the
-/// dispatch form (`Inputs<Dispatch>`) back into the concrete `Inputs<Wgpu>` before calling the
-/// backend impl. Struct inputs may be freely mixed with bare tensor inputs, and several struct
-/// inputs are allowed, and the op may be combined with `Autodiff` (the op's own
+/// The macro unwraps the dispatch form (`Inputs<Dispatch>`) back into the concrete `Inputs<Wgpu>`
+/// before calling the backend impl. Such inputs may be freely mixed with bare tensor inputs and with
+/// each other (several are allowed), and the op may be combined with `Autodiff` (the op's own
 /// `impl ... for Autodiff<B>` hand-writes the backward pass, as for bare-tensor autodiff ops).
+///
+/// The backend is selected by walking the inputs at runtime for a representative tensor (preferring a
+/// float). Because an enum's tensors depend on its active variant, a tensor-less variant contributes
+/// no representative and the walk falls through to the next input; if no input carries any tensor the
+/// backend is unresolvable and the op panics.
 #[proc_macro_attribute]
 pub fn backend_extension(attr: TokenStream, item: TokenStream) -> TokenStream {
     // Parse the backend list
@@ -177,9 +184,9 @@ enum TensorKind {
 #[allow(clippy::large_enum_variant)]
 enum ArgKind {
     Tensor(TensorKind),
-    // A custom struct of tensor primitives, marked `#[extension_type]` on the argument. Unwrapped
-    // back into the concrete backend's `Struct<B>` before the backend call via `ExtensionType`.
-    ExtensionStruct(Type),
+    // A custom struct or enum of tensor primitives, marked `#[extension_type]` on the argument.
+    // Unwrapped back into the concrete backend's `Ty<B>` before the backend call via `ExtensionType`.
+    Extension(Type),
     // Passthrough - unhandled by the macro
     Other(Type),
 }
@@ -337,15 +344,15 @@ fn lower_extension(attr: Backends, item: &ItemTrait) -> syn::Result<Extension> {
                 Pat::Ident(p) => p.ident.clone(),
                 _ => return Err(syn::Error::new_spanned(&pt.pat, "Unsupported pattern")),
             };
-            // An argument annotated with `#[extension_type]` is a custom struct of tensor
+            // An argument annotated with `#[extension_type]` is a custom struct or enum of tensor
             // primitives (the input counterpart of the `#[derive(ExtensionType)]` output path).
             let is_ext = pt
                 .attrs
                 .iter()
                 .any(|attr| attr.path().is_ident("extension_type"));
             let kind = if is_ext {
-                validate_extension_struct_ty(&pt.ty)?;
-                ArgKind::ExtensionStruct((*pt.ty).clone())
+                validate_extension_ty(&pt.ty)?;
+                ArgKind::Extension((*pt.ty).clone())
             } else if let Some(k) = TensorKind::from_type(&pt.ty) {
                 ArgKind::Tensor(k)
             } else {
@@ -471,7 +478,7 @@ fn gen_dispatch_method(ir: &Extension, op: &Operation) -> TokenStream2 {
                 }
                 // Keep the original `Struct<Self>` type. Inside `impl Trait for Dispatch`, `Self`
                 // resolves to `Dispatch`, so the incoming value is the dispatch form `Struct<Dispatch>`.
-                ArgKind::ExtensionStruct(ty) => quote! { #name: #ty },
+                ArgKind::Extension(ty) => quote! { #name: #ty },
                 ArgKind::Other(ty) => quote! { #name: #ty },
             }
         })
@@ -480,7 +487,7 @@ fn gen_dispatch_method(ir: &Extension, op: &Operation) -> TokenStream2 {
     let has_struct_input = op
         .inputs
         .iter()
-        .any(|a| matches!(a.kind, ArgKind::ExtensionStruct(_)));
+        .any(|a| matches!(a.kind, ArgKind::Extension(_)));
 
     let ret_ty = match &op.output {
         OperationOutput::Tensor(k) => k.to_primitive_ty(),
@@ -527,8 +534,8 @@ fn gen_dispatch_method(ir: &Extension, op: &Operation) -> TokenStream2 {
     };
 
     let body = if has_struct_input {
-        // At least one custom struct of tensors is passed as input (marked `#[extension_type]`).
-        // This path also covers mixing structs with bare tensors and multiple struct inputs.
+        // At least one custom struct/enum of tensors is passed as input (marked `#[extension_type]`).
+        // This path also covers mixing them with bare tensors and multiple such inputs.
         gen_mixed_dispatch_body(ir, op)
     } else if tensor_inputs.is_empty() {
         // No tensor input to select the backend from (e.g. `fn load_data(i: usize) -> FloatTensor`).
@@ -645,28 +652,31 @@ fn struct_ty_with_param(ty: &Type, param: TokenStream2) -> TokenStream2 {
 /// Validate the type of a `#[extension_type]`-marked argument, emitting a clear `compile_error!` for
 /// the common misuses instead of letting them surface as obscure trait/type errors deeper in codegen.
 ///
-/// The argument must be a struct with exactly one generic backend parameter (`MyStruct<Self>`), since
-/// [`struct_ty_with_param`] rewrites that single parameter to the backend when unwrapping. Marking a
-/// bare tensor, a non-path type, or a multi-parameter type is rejected here.
-fn validate_extension_struct_ty(ty: &Type) -> syn::Result<()> {
+/// The argument must be a struct or enum with exactly one generic backend parameter (`MyType<Self>`),
+/// since [`struct_ty_with_param`] rewrites that single parameter to the backend when unwrapping.
+/// Marking a bare tensor, a non-path type, or a multi-parameter type is rejected here.
+fn validate_extension_ty(ty: &Type) -> syn::Result<()> {
     if TensorKind::from_type(ty).is_some() {
         return Err(syn::Error::new_spanned(
             ty,
-            "`#[extension_type]` marks a struct of tensor primitives, not a tensor argument. Remove \
-             the attribute to pass a plain tensor.",
+            "`#[extension_type]` marks a struct or enum of tensor primitives, not a tensor argument. \
+             Remove the attribute to pass a plain tensor.",
         ));
     }
 
     let Type::Path(tp) = ty else {
         return Err(syn::Error::new_spanned(
             ty,
-            "`#[extension_type]` requires a struct type with a single generic backend parameter, e.g. \
-             `MyStruct<Self>`.",
+            "`#[extension_type]` requires a struct or enum type with a single generic backend \
+             parameter, e.g. `MyType<Self>`.",
         ));
     };
 
     let last = tp.path.segments.last().ok_or_else(|| {
-        syn::Error::new_spanned(ty, "`#[extension_type]` type must be a named struct")
+        syn::Error::new_spanned(
+            ty,
+            "`#[extension_type]` type must be a named struct or enum",
+        )
     })?;
     let type_args = match &last.arguments {
         PathArguments::AngleBracketed(args) => args
@@ -679,8 +689,8 @@ fn validate_extension_struct_ty(ty: &Type) -> syn::Result<()> {
     if type_args != 1 {
         return Err(syn::Error::new_spanned(
             ty,
-            "`#[extension_type]` struct must have exactly one generic backend parameter, e.g. \
-             `MyStruct<Self>`.",
+            "`#[extension_type]` type must have exactly one generic backend parameter, e.g. \
+             `MyType<Self>`.",
         ));
     }
 
@@ -717,28 +727,49 @@ fn gen_mixed_dispatch_body(ir: &Extension, op: &Operation) -> TokenStream2 {
         .as_ref()
         .map(|meta| quote! { #[#meta] });
 
-    // Representative `DispatchTensor` expression: a bare tensor input itself, or a struct's
-    // representative field. Read twice below (for `.kind` selection and `.checkpointing`); both are
-    // cheap accessors whose borrows end within their statement, before any input is moved.
-    let repr_expr = op
-        .inputs
-        .iter()
-        .find_map(|a| match &a.kind {
-            ArgKind::Tensor(_) => {
-                let n = &a.name;
-                Some(quote! { #n })
-            }
-            ArgKind::ExtensionStruct(ty) => {
-                let n = &a.name;
-                let target_ty = struct_ty_with_param(ty, quote! { burn::backend::Dispatch });
-                Some(quote! {
-                    <#target_ty as burn::backend::ExtensionType<burn::backend::Dispatch>>::dispatch_repr(&#n)
-                })
-            }
-            ArgKind::Other(_) => None,
-        })
-        // Only ever reached when a struct input exists, so a representative is always present.
-        .expect("mixed dispatch requires at least one tensor-ish input");
+    // Backend selection walks all inputs at runtime, preferring a *float* tensor (floats carry the
+    // autodiff tracking that decides the concrete-vs-autodiff arm, and the checkpointing strategy)
+    // and falling back to any tensor. `dispatch_repr` / `dispatch_float_repr` recurse into structs
+    // and enums and return `None` for a tensor-less value (e.g. an enum on a tensor-less variant),
+    // so the walk simply defers to the next input. If no input carries a tensor at runtime the
+    // backend is unresolvable and the op panics.
+    let repr_option = |float_only: bool| -> Vec<TokenStream2> {
+        op.inputs
+            .iter()
+            .filter_map(|a| match &a.kind {
+                ArgKind::Tensor(k) => {
+                    if float_only && *k != TensorKind::Float {
+                        return None;
+                    }
+                    let n = &a.name;
+                    Some(quote! { Some(&#n) })
+                }
+                ArgKind::Extension(ty) => {
+                    let n = &a.name;
+                    let target_ty = struct_ty_with_param(ty, quote! { burn::backend::Dispatch });
+                    let method = if float_only {
+                        quote! { dispatch_float_repr }
+                    } else {
+                        quote! { dispatch_repr }
+                    };
+                    Some(quote! {
+                        <#target_ty as burn::backend::ExtensionType<burn::backend::Dispatch>>::#method(&#n)
+                    })
+                }
+                ArgKind::Other(_) => None,
+            })
+            .collect()
+    };
+    // Chain the per-input options lazily: the first `Some` wins, later `dispatch_repr` calls run only
+    // if earlier inputs had no tensor.
+    let chain = |opts: Vec<TokenStream2>| -> TokenStream2 {
+        match opts.split_first() {
+            None => quote! { Option::<&burn::backend::DispatchTensor>::None },
+            Some((first, rest)) => quote! { #first #( .or_else(|| #rest) )* },
+        }
+    };
+    let float_chain = chain(repr_option(true));
+    let any_chain = chain(repr_option(false));
 
     // Tag arms fold the representative kind into `(is_autodiff, backend_index)`. cfg-gated backends
     // drop the same arm from both the tag match and the dispatch match, keeping indices aligned.
@@ -813,12 +844,24 @@ fn gen_mixed_dispatch_body(ir: &Extension, op: &Operation) -> TokenStream2 {
     };
 
     quote! {
-        let checkpointing = #repr_expr.checkpointing.clone();
-        let __burn_backend_tag: (bool, usize) = match &#repr_expr.kind {
-            #ad_tag_arm
-            #( #concrete_tag_arms )*
-            #[allow(unreachable_patterns)]
-            _ => (false, usize::MAX),
+        // Compute the checkpointing strategy and backend tag in a scoped block so the representative's
+        // borrow of the inputs ends before the dispatch arms below move them.
+        let (checkpointing, __burn_backend_tag): (
+            Option<burn::backend::CheckpointingStrategy>,
+            (bool, usize),
+        ) = {
+            let __repr: &burn::backend::DispatchTensor = (#float_chain)
+                .or_else(|| #any_chain)
+                .expect("backend extension op received no tensor input to select a backend from (e.g. an enum input on a tensor-less variant with no other tensor input)");
+            (
+                __repr.checkpointing.clone(),
+                match &__repr.kind {
+                    #ad_tag_arm
+                    #( #concrete_tag_arms )*
+                    #[allow(unreachable_patterns)]
+                    _ => (false, usize::MAX),
+                },
+            )
         };
         match __burn_backend_tag {
             #( #concrete_call_arms )*
@@ -881,7 +924,7 @@ fn gen_mixed_ad_arm(
         }
         // Struct: reconstruct `Struct<Autodiff<B>>`. The closure maps each field's dispatch kind to a
         // `BackendTensor<Autodiff<B>>` — float fields carry the autodiff nesting, others stay plain.
-        ArgKind::ExtensionStruct(ty) => {
+        ArgKind::Extension(ty) => {
             let n = &a.name;
             let ad_ty = struct_ty_with_param(ty, quote! { Autodiff<#b_ident> });
             Some(quote! {
@@ -1005,7 +1048,7 @@ fn gen_backend_call(ir: &Extension, op: &Operation, backend: &Backend) -> TokenS
         }
         // Reconstruct `Struct<B>` from the incoming `Struct<Dispatch>` by unwrapping each tensor
         // field into this backend's `BackendTensor`. Inverse of the `map_to_dispatch` output path.
-        ArgKind::ExtensionStruct(ty) => {
+        ArgKind::Extension(ty) => {
             let name = &a.name;
             let b_ty = struct_ty_with_param(ty, quote! { #b_ident });
             Some(quote! {
@@ -1152,25 +1195,202 @@ fn gen_tensor_wrap(
     }
 }
 
-/// Derive macro to implement `ExtensionType` for custom structures returned by backend extensions.
-///
-/// When a custom backend extension operation needs to return multiple tensors or a mix of tensors
-/// and metadata (instead of a single tensor primitive or container of primitives), this macro automates
-/// the process of wrapping the tensor primitives so they can cross the boundary into the `Dispatch` backend.
+/// Field layout of a struct or a single enum variant.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum CaseStyle {
+    Named,
+    Unnamed,
+    Unit,
+}
+
+/// One derive "case": a struct is a single case; an enum contributes one case per variant. Unifies
+/// struct and enum handling — the generated methods are a `match` over cases (trivial for a struct).
+struct DeriveCase {
+    /// Path to match / construct, e.g. `Name` or `Name::Variant`.
+    path: TokenStream2,
+    style: CaseStyle,
+    fields: Vec<CaseField>,
+}
+
+struct CaseField {
+    /// Synthesized binding (`__ext_f{i}`), used for both named and tuple fields so the bindings never
+    /// collide with method params like `map_kind` / `checkpointing`.
+    bind: Ident,
+    /// Field name for named fields; `None` for tuple fields (constructed positionally).
+    member: Option<Ident>,
+    ty: Type,
+    is_ext: bool,
+    tensor_kind: Option<TensorKind>,
+}
+
+fn build_case(path: TokenStream2, fields: &Fields) -> DeriveCase {
+    let (style, raw): (CaseStyle, Vec<&syn::Field>) = match fields {
+        Fields::Named(f) => (CaseStyle::Named, f.named.iter().collect()),
+        Fields::Unnamed(f) => (CaseStyle::Unnamed, f.unnamed.iter().collect()),
+        Fields::Unit => (CaseStyle::Unit, Vec::new()),
+    };
+    let fields = raw
+        .iter()
+        .enumerate()
+        .map(|(i, f)| CaseField {
+            bind: format_ident!("__ext_f{}", i),
+            member: f.ident.clone(),
+            ty: f.ty.clone(),
+            is_ext: f.attrs.iter().any(|a| a.path().is_ident("extension_type")),
+            tensor_kind: TensorKind::from_type(&f.ty),
+        })
+        .collect();
+    DeriveCase {
+        path,
+        style,
+        fields,
+    }
+}
+
+fn collect_cases(input: &DeriveInput) -> syn::Result<Vec<DeriveCase>> {
+    let name = &input.ident;
+    match &input.data {
+        Data::Struct(s) => Ok(vec![build_case(quote! { #name }, &s.fields)]),
+        Data::Enum(e) => Ok(e
+            .variants
+            .iter()
+            .map(|v| {
+                let vident = &v.ident;
+                build_case(quote! { #name::#vident }, &v.fields)
+            })
+            .collect()),
+        Data::Union(_) => Err(syn::Error::new_spanned(
+            name,
+            "ExtensionType cannot be derived for unions",
+        )),
+    }
+}
+
+/// Destructuring pattern binding the fields for which `needed(i)` is true and `_`-ignoring the rest.
+/// The same pattern serves an owned scrutinee (`self` / `target`) and a reference (`&target`); match
+/// ergonomics binds by reference in the latter.
+fn gen_case_pattern(case: &DeriveCase, needed: impl Fn(usize) -> bool) -> TokenStream2 {
+    let path = &case.path;
+    match case.style {
+        CaseStyle::Unit => quote! { #path },
+        CaseStyle::Named => {
+            let entries = case.fields.iter().enumerate().map(|(i, f)| {
+                let member = f.member.as_ref().expect("named field has an ident");
+                if needed(i) {
+                    let bind = &f.bind;
+                    quote! { #member: #bind }
+                } else {
+                    quote! { #member: _ }
+                }
+            });
+            quote! { #path { #( #entries ),* } }
+        }
+        CaseStyle::Unnamed => {
+            let entries = case.fields.iter().enumerate().map(|(i, f)| {
+                if needed(i) {
+                    let bind = &f.bind;
+                    quote! { #bind }
+                } else {
+                    quote! { _ }
+                }
+            });
+            quote! { #path ( #( #entries ),* ) }
+        }
+    }
+}
+
+/// Reconstruct the case from one transformed expression per field (same order as `case.fields`).
+fn gen_case_ctor(case: &DeriveCase, exprs: &[TokenStream2]) -> TokenStream2 {
+    let path = &case.path;
+    match case.style {
+        CaseStyle::Unit => quote! { #path },
+        CaseStyle::Named => {
+            let entries = case.fields.iter().zip(exprs).map(|(f, e)| {
+                let member = f.member.as_ref().expect("named field has an ident");
+                quote! { #member: #e }
+            });
+            quote! { #path { #( #entries ),* } }
+        }
+        CaseStyle::Unnamed => quote! { #path ( #( #exprs ),* ) },
+    }
+}
+
+/// One `dispatch_repr` / `dispatch_float_repr` match arm for a case: bind only the field(s) the
+/// representative needs and return an `Option<&DispatchTensor>`. Prefers a float tensor field, then
+/// (unless `float_only`) any tensor field, then chains over nested `#[extension_type]` fields.
+fn gen_repr_arm(case: &DeriveCase, float_only: bool) -> TokenStream2 {
+    let float_i = case
+        .fields
+        .iter()
+        .position(|f| !f.is_ext && f.tensor_kind == Some(TensorKind::Float));
+    let any_i = case
+        .fields
+        .iter()
+        .position(|f| !f.is_ext && f.tensor_kind.is_some());
+    let ext_is: Vec<usize> = case
+        .fields
+        .iter()
+        .enumerate()
+        .filter(|(_, f)| f.is_ext)
+        .map(|(i, _)| i)
+        .collect();
+    let method = if float_only {
+        format_ident!("dispatch_float_repr")
+    } else {
+        format_ident!("dispatch_repr")
+    };
+
+    let (needed, expr): (Vec<usize>, TokenStream2) = if let Some(i) = float_i {
+        let bind = &case.fields[i].bind;
+        (vec![i], quote! { Some(#bind) })
+    } else if let Some(i) = any_i.filter(|_| !float_only) {
+        let bind = &case.fields[i].bind;
+        (vec![i], quote! { Some(#bind) })
+    } else if !ext_is.is_empty() {
+        let calls = ext_is.iter().map(|&i| {
+            let bind = &case.fields[i].bind;
+            let dispatch_ty = struct_ty_with_param(&case.fields[i].ty, quote! { burn::backend::Dispatch });
+            quote! { .or_else(|| <#dispatch_ty as burn::backend::ExtensionType<burn::backend::Dispatch>>::#method(#bind)) }
+        });
+        (
+            ext_is.clone(),
+            quote! { Option::<&burn::backend::DispatchTensor>::None #( #calls )* },
+        )
+    } else {
+        (
+            Vec::new(),
+            quote! { Option::<&burn::backend::DispatchTensor>::None },
+        )
+    };
+
+    let pattern = gen_case_pattern(case, |i| needed.contains(&i));
+    quote! { #pattern => #expr, }
+}
+
+/// Derive macro to implement `ExtensionType` for custom structs and enums of tensor primitives,
+/// letting them cross the `Dispatch` boundary as backend extension operation inputs or outputs.
 ///
 /// # Requirements
 ///
-/// - The struct must have named fields.
-/// - The struct must be generic over a `Backend` type parameter (`B`).
+/// - Applies to a `struct` (named or tuple fields) or an `enum` (any mix of named/tuple/unit
+///   variants). Unions are unsupported.
+/// - The type must be generic over a single `Backend` type parameter named `B`.
 ///
-/// # Field Attributes
+/// # Field attributes
 ///
-/// By default, the macro inspects the type of each field:
-/// - **Tensor Primitives**: Automatically mapped.
-/// - **Other types**: Passed through unmodified.
+/// Each field is inspected by type:
+/// - **Tensor primitives** (`FloatTensor<B>`, `IntTensor<B>`, ...): mapped automatically.
+/// - **Other types**: passed through unmodified.
 ///
-/// To nest another custom struct that also implements `ExtensionType`, you must annotate it with
-/// `#[extension_type]` to tell the macro to traverse it recursively.
+/// To nest another `ExtensionType` struct/enum, annotate the field with `#[extension_type]` so the
+/// macro traverses it recursively.
+///
+/// # Backend selection for inputs
+///
+/// When used as an input, the dispatch glue selects the backend from a representative tensor. For an
+/// enum this depends on the active variant, and a tensor-less variant (or unit variant) yields no
+/// representative — the glue then walks the op's other inputs. If no input carries a tensor at
+/// runtime the backend is unresolvable and the op panics.
 ///
 /// # Example
 ///
@@ -1179,127 +1399,84 @@ fn gen_tensor_wrap(
 /// pub struct OperationOutput<B: Backend> {
 ///     pub bool: BoolTensor<B>,
 ///     pub int: IntTensor<B>,
-///     pub float: FloaTensor<B>,
+///     pub float: FloatTensor<B>,
 ///     pub count: usize, // Non-tensor field passes through automatically
+/// }
+///
+/// #[derive(ExtensionType)]
+/// pub enum Input<B: Backend> {
+///     Dense(FloatTensor<B>),
+///     Sparse { values: FloatTensor<B>, indices: IntTensor<B> },
 /// }
 /// ```
 #[proc_macro_derive(ExtensionType, attributes(extension_type))]
 pub fn derive_extension_output(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as ItemStruct);
+    let input = parse_macro_input!(input as DeriveInput);
     let name = &input.ident;
-
-    // Extract generics for the trait implementation block
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
-    let fields_wrap = match &input.fields {
-        syn::Fields::Named(fields) => {
-            let field_mappings = fields.named.iter().map(|f| {
-                let f_name = &f.ident;
-                let is_ext = f.attrs.iter().any(|attr| attr.path().is_ident("extension_type"));
 
-                if is_ext {
-                    // It's a nested extension type
+    let cases = match collect_cases(&input) {
+        Ok(cases) => cases,
+        Err(err) => return err.to_compile_error().into(),
+    };
+
+    // `map_to_dispatch`: wrap every field's concrete primitive into a `DispatchTensor`.
+    let wrap_arms = cases.iter().map(|case| {
+        let pattern = gen_case_pattern(case, |_| true);
+        let exprs: Vec<_> = case
+            .fields
+            .iter()
+            .map(|f| {
+                let bind = &f.bind;
+                if f.is_ext {
+                    quote! { #bind.map_to_dispatch(&map_kind, checkpointing) }
+                } else if let Some(kind) = f.tensor_kind {
+                    let variant = kind.variant();
                     quote! {
-                        #f_name: self.#f_name.map_to_dispatch(
-                            &map_kind,
-                            checkpointing
-                        ),
-                    }
-                }
-                else if let Some(tensor_kind) = TensorKind::from_type(&f.ty) {
-                    // Tensor primitive
-                    let variant_ident = tensor_kind.variant();
-                    quote! {
-                        #f_name: burn::backend::DispatchTensor {
-                            kind: map_kind(burn::backend::BackendTensor::#variant_ident(self.#f_name)),
+                        burn::backend::DispatchTensor {
+                            kind: map_kind(burn::backend::BackendTensor::#variant(#bind)),
                             checkpointing,
-                        },
+                        }
                     }
                 } else {
-                    // Passthrough
-                    quote! { #f_name: self.#f_name, }
+                    quote! { #bind }
                 }
-             });
+            })
+            .collect();
+        let ctor = gen_case_ctor(case, &exprs);
+        quote! { #pattern => #ctor, }
+    });
 
-            quote! { #name { #( #field_mappings )* } }
-        }
-        _ => panic!("ExtensionType derive only supports structs with named fields"),
-    };
-
-    // Reverse of `fields_wrap`: rebuild `Struct<B>` from the incoming `Struct<Dispatch>` (`target`).
-    let fields_unwrap = match &input.fields {
-        syn::Fields::Named(fields) => {
-            let field_mappings = fields.named.iter().map(|f| {
-                let f_name = &f.ident;
-                let is_ext = f.attrs.iter().any(|attr| attr.path().is_ident("extension_type"));
-
-                if is_ext {
-                    // Nested extension type: recurse with the same unwrap closure.
-                    quote! {
-                        #f_name: burn::backend::ExtensionType::map_from_dispatch(target.#f_name, &unwrap_kind),
-                    }
-                } else if let Some(tensor_kind) = TensorKind::from_type(&f.ty) {
-                    // Tensor primitive: unwrap the DispatchTensor kind, then pull out the concrete
-                    // primitive with the accessor matching this field's kind (`.float()`, ...).
-                    let method = tensor_kind.unwrap_method();
-                    quote! {
-                        #f_name: unwrap_kind(target.#f_name.kind).#method(),
-                    }
+    // `map_from_dispatch`: reverse of `wrap_arms`, recovering each concrete primitive.
+    let unwrap_arms = cases.iter().map(|case| {
+        let pattern = gen_case_pattern(case, |_| true);
+        let exprs: Vec<_> = case
+            .fields
+            .iter()
+            .map(|f| {
+                let bind = &f.bind;
+                if f.is_ext {
+                    quote! { burn::backend::ExtensionType::map_from_dispatch(#bind, &unwrap_kind) }
+                } else if let Some(kind) = f.tensor_kind {
+                    let method = kind.unwrap_method();
+                    quote! { unwrap_kind(#bind.kind).#method() }
                 } else {
-                    // Passthrough
-                    quote! { #f_name: target.#f_name, }
+                    quote! { #bind }
                 }
-            });
+            })
+            .collect();
+        let ctor = gen_case_ctor(case, &exprs);
+        quote! { #pattern => #ctor, }
+    });
 
-            quote! { #name { #( #field_mappings )* } }
-        }
-        _ => unreachable!("named-fields check already happened above"),
-    };
-
-    // Representative field: identifies the backend (`.kind`) and carries the checkpointing strategy
-    // (`.checkpointing`). Prefer the first float field (the tracked one under autodiff), then any
-    // tensor field, then recurse into the first nested `#[extension_type]` field.
-    let dispatch_repr_expr = match &input.fields {
-        syn::Fields::Named(fields) => {
-            let is_plain_tensor = |f: &&syn::Field| {
-                !f.attrs
-                    .iter()
-                    .any(|attr| attr.path().is_ident("extension_type"))
-                    && TensorKind::from_type(&f.ty).is_some()
-            };
-            let first_float = fields.named.iter().find(|f| {
-                is_plain_tensor(f) && TensorKind::from_type(&f.ty) == Some(TensorKind::Float)
-            });
-            let repr = first_float.or_else(|| fields.named.iter().find(is_plain_tensor));
-            if let Some(f) = repr {
-                let f_name = &f.ident;
-                quote! { &target.#f_name }
-            } else if let Some(f) = fields.named.iter().find(|f| {
-                f.attrs
-                    .iter()
-                    .any(|attr| attr.path().is_ident("extension_type"))
-            }) {
-                let f_name = &f.ident;
-                quote! { burn::backend::ExtensionType::dispatch_repr(&target.#f_name) }
-            } else {
-                // No tensor or nested field to represent the struct. This only matters when the
-                // struct is used as an *input* (where the dispatch glue calls `dispatch_repr` to
-                // select a backend); an output-only struct never calls it. So panic at runtime rather
-                // than `compile_error!`, which would otherwise break valid output-only structs.
-                quote! {
-                    {
-                        let _ = target;
-                        panic!("an ExtensionType struct used as a backend extension input must contain at least one tensor field to select the backend from")
-                    }
-                }
-            }
-        }
-        _ => unreachable!("named-fields check already happened above"),
-    };
+    let any_repr_arms = cases.iter().map(|case| gen_repr_arm(case, false));
+    let float_repr_arms = cases.iter().map(|case| gen_repr_arm(case, true));
 
     TokenStream::from(quote! {
         impl #impl_generics burn::backend::ExtensionType<B> for #name #ty_generics #where_clause {
             type Target = #name<burn::backend::Dispatch>;
 
+            #[allow(unused_variables)]
             fn map_to_dispatch<F>(
                 self,
                 map_kind: F,
@@ -1308,18 +1485,23 @@ pub fn derive_extension_output(input: TokenStream) -> TokenStream {
             where
                 F: Fn(burn::backend::BackendTensor<B>) -> burn::backend::DispatchTensorKind,
             {
-                #fields_wrap
+                match self { #( #wrap_arms )* }
             }
 
+            #[allow(unused_variables)]
             fn map_from_dispatch<F>(target: Self::Target, unwrap_kind: F) -> Self
             where
                 F: Fn(burn::backend::DispatchTensorKind) -> burn::backend::BackendTensor<B>,
             {
-                #fields_unwrap
+                match target { #( #unwrap_arms )* }
             }
 
-            fn dispatch_repr(target: &Self::Target) -> &burn::backend::DispatchTensor {
-                #dispatch_repr_expr
+            fn dispatch_repr(target: &Self::Target) -> Option<&burn::backend::DispatchTensor> {
+                match target { #( #any_repr_arms )* }
+            }
+
+            fn dispatch_float_repr(target: &Self::Target) -> Option<&burn::backend::DispatchTensor> {
+                match target { #( #float_repr_arms )* }
             }
         }
     })

--- a/crates/burn-backend-extension/src/lib.rs
+++ b/crates/burn-backend-extension/src/lib.rs
@@ -36,6 +36,26 @@ use syn::{
 /// `BoolTensor<Self>`, and `QuantizedTensor<Self>` (a QFloat tensor passed to the
 /// backend still quantized — the op reads the packed values/scales directly instead
 /// of going through a dequantize).
+///
+/// ### Struct-of-tensors inputs
+///
+/// A custom struct of tensor primitives (deriving [`ExtensionType`](macro@ExtensionType)) can be
+/// passed as an **input** by marking the argument with `#[extension_type]`:
+///
+/// ```rust,ignore
+/// #[derive(ExtensionType)]
+/// pub struct Inputs<B: Backend> { pub lhs: FloatTensor<B>, pub rhs: FloatTensor<B> }
+///
+/// #[backend_extension(Wgpu)]
+/// pub trait MyExtension: Backend {
+///     fn fused(#[extension_type] inputs: Inputs<Self>, alpha: f32) -> FloatTensor<Self>;
+/// }
+/// ```
+///
+/// The macro selects the backend from a representative tensor field of the struct and unwraps the
+/// dispatch form (`Inputs<Dispatch>`) back into the concrete `Inputs<Wgpu>` before calling the
+/// backend impl. Struct inputs may be freely mixed with bare tensor inputs, and several struct
+/// inputs are allowed. Current limitation of this path (sketch): not combinable with `Autodiff`.
 #[proc_macro_attribute]
 pub fn backend_extension(attr: TokenStream, item: TokenStream) -> TokenStream {
     // Parse the backend list
@@ -156,6 +176,9 @@ enum TensorKind {
 #[allow(clippy::large_enum_variant)]
 enum ArgKind {
     Tensor(TensorKind),
+    // A custom struct of tensor primitives, marked `#[extension_type]` on the argument. Unwrapped
+    // back into the concrete backend's `Struct<B>` before the backend call via `ExtensionType`.
+    ExtensionStruct(Type),
     // Passthrough - unhandled by the macro
     Other(Type),
 }
@@ -313,9 +336,19 @@ fn lower_extension(attr: Backends, item: &ItemTrait) -> syn::Result<Extension> {
                 Pat::Ident(p) => p.ident.clone(),
                 _ => return Err(syn::Error::new_spanned(&pt.pat, "Unsupported pattern")),
             };
-            let kind = TensorKind::from_type(&pt.ty)
-                .map(ArgKind::Tensor)
-                .unwrap_or_else(|| ArgKind::Other((*pt.ty).clone()));
+            // An argument annotated with `#[extension_type]` is a custom struct of tensor
+            // primitives (the input counterpart of the `#[derive(ExtensionType)]` output path).
+            let is_ext = pt
+                .attrs
+                .iter()
+                .any(|attr| attr.path().is_ident("extension_type"));
+            let kind = if is_ext {
+                ArgKind::ExtensionStruct((*pt.ty).clone())
+            } else if let Some(k) = TensorKind::from_type(&pt.ty) {
+                ArgKind::Tensor(k)
+            } else {
+                ArgKind::Other((*pt.ty).clone())
+            };
             inputs.push(OperationArg { name, kind });
         }
 
@@ -380,8 +413,21 @@ fn lower_extension(attr: Backends, item: &ItemTrait) -> syn::Result<Extension> {
     })
 }
 
-fn expand_extension(ir: Extension, original_trait: ItemTrait) -> TokenStream2 {
+fn expand_extension(ir: Extension, mut original_trait: ItemTrait) -> TokenStream2 {
     let trait_name = &ir.trait_name;
+
+    // `#[extension_type]` is a helper attribute understood only by this macro. Strip it from the
+    // argument list before re-emitting the trait, otherwise rustc rejects it as an unknown attribute.
+    for item in &mut original_trait.items {
+        if let TraitItem::Fn(f) = item {
+            for arg in &mut f.sig.inputs {
+                if let FnArg::Typed(pt) = arg {
+                    pt.attrs
+                        .retain(|attr| !attr.path().is_ident("extension_type"));
+                }
+            }
+        }
+    }
 
     // Generate Dispatch Implementation
     let dispatch_methods = ir.ops.iter().map(|op| gen_dispatch_method(&ir, op));
@@ -411,16 +457,32 @@ fn gen_dispatch_method(ir: &Extension, op: &Operation) -> TokenStream2 {
         quote! {}
     };
 
-    let sig_args = op.inputs.iter().map(|arg| {
-        let name = &arg.name;
-        match &arg.kind {
-            ArgKind::Tensor(k) => {
-                let ty = k.to_primitive_ty();
-                quote! { #name: #ty }
+    let sig_args: Vec<_> = op
+        .inputs
+        .iter()
+        .map(|arg| {
+            let name = &arg.name;
+            match &arg.kind {
+                ArgKind::Tensor(k) => {
+                    let ty = k.to_primitive_ty();
+                    quote! { #name: #ty }
+                }
+                // Keep the original `Struct<Self>` type. Inside `impl Trait for Dispatch`, `Self`
+                // resolves to `Dispatch`, so the incoming value is the dispatch form `Struct<Dispatch>`.
+                ArgKind::ExtensionStruct(ty) => quote! { #name: #ty },
+                ArgKind::Other(ty) => quote! { #name: #ty },
             }
-            ArgKind::Other(ty) => quote! { #name: #ty },
-        }
-    });
+        })
+        .collect();
+
+    let struct_inputs: Vec<_> = op
+        .inputs
+        .iter()
+        .filter_map(|a| match &a.kind {
+            ArgKind::ExtensionStruct(ty) => Some((&a.name, ty)),
+            _ => None,
+        })
+        .collect();
 
     let ret_ty = match &op.output {
         OperationOutput::Tensor(k) => k.to_primitive_ty(),
@@ -466,7 +528,11 @@ fn gen_dispatch_method(ir: &Extension, op: &Operation) -> TokenStream2 {
         quote! { let checkpointing = None; }
     };
 
-    let body = if tensor_inputs.is_empty() {
+    let body = if !struct_inputs.is_empty() {
+        // At least one custom struct of tensors is passed as input (marked `#[extension_type]`).
+        // This path also covers mixing structs with bare tensors and multiple struct inputs.
+        gen_mixed_dispatch_body(ir, op)
+    } else if tensor_inputs.is_empty() {
         // No tensor input to select the backend from (e.g. `fn load_data(i: usize) -> FloatTensor`).
         // There is nothing to match on, so this is only well-defined for a single backend — the
         // remote backend is the motivating case (`#[backend_extension(Remote)]`), where the op is
@@ -562,6 +628,143 @@ fn gen_backend_arm(ir: &Extension, op: &Operation, backend: &Backend) -> TokenSt
     }
 }
 
+/// Rewrite a struct type's single generic argument to `param`, e.g. `MyStruct<Self>` -> `MyStruct<Wgpu>`.
+/// Used to name the concrete `Struct<B>` (and the dispatch `Struct<Dispatch>`) from the `Struct<Self>`
+/// written in the trait signature.
+fn struct_ty_with_param(ty: &Type, param: TokenStream2) -> TokenStream2 {
+    if let Type::Path(tp) = ty {
+        let mut path = tp.path.clone();
+        if let Some(last) = path.segments.last_mut() {
+            last.arguments = PathArguments::None;
+        }
+        quote! { #path<#param> }
+    } else {
+        // Not a path type; leave it untouched and let rustc surface a clear error.
+        quote! { #ty }
+    }
+}
+
+/// Generate the dispatch body for an operation that takes a custom struct of tensors as input.
+///
+/// Unlike a bare tensor input (which carries its own `DispatchTensorKind` to match on), a struct
+/// input has no top-level tag, so we peek a representative field via `ExtensionType::dispatch_kind`
+/// to select the backend, then reconstruct the concrete `Struct<B>` inside the matched arm.
+///
+/// Sketch scope: exactly one struct input, no bare tensor inputs, non-autodiff only. The remaining
+/// cases are rejected with a `compile_error!` describing the limitation.
+/// Generate the dispatch body for an operation whose inputs include at least one `#[extension_type]`
+/// struct. This is the general "peek then unwrap" path and handles any mix of bare tensors and
+/// structs (including several structs), unlike the pure-tensor path which selects the backend by
+/// destructuring every tensor in the match pattern (impossible for a struct).
+///
+/// Strategy:
+/// 1. Peek a single representative [`DispatchTensorKind`] from the first tensor-ish input (a bare
+///    tensor's own `.kind`, or a struct's via `ExtensionType::dispatch_kind`) and fold it into a
+///    small backend index. Folding to an index drops the borrow before any input is moved.
+/// 2. In the matched arm, unwrap every input for that backend: bare tensors are pulled out of their
+///    `DispatchTensor`, structs are reconstructed via `ExtensionType::map_from_dispatch`, then the backend
+///    impl is called and the output re-wrapped (via the shared [`gen_backend_call`]).
+///
+/// Sketch scope: non-autodiff only. Autodiff would need each struct's tensor fields flattened into
+/// the fixed-arity `Backward` node/checkpoint machinery.
+fn gen_mixed_dispatch_body(ir: &Extension, op: &Operation) -> TokenStream2 {
+    let name = &op.name;
+
+    if ir.backends.autodiff.0 {
+        return quote! { compile_error!("A backend extension operation with a `#[extension_type]` struct input can't be combined with `Autodiff` yet. Each struct's tensor fields would need to be flattened into the fixed-arity `Backward` node/checkpoint machinery.") };
+    }
+
+    // Representative kind, used only to select the backend: the first bare tensor if any, else the
+    // first struct's representative field.
+    let selector = op
+        .inputs
+        .iter()
+        .find_map(|a| match &a.kind {
+            ArgKind::Tensor(_) => {
+                let n = &a.name;
+                Some(quote! { &#n.kind })
+            }
+            ArgKind::ExtensionStruct(ty) => {
+                let n = &a.name;
+                let target_ty = struct_ty_with_param(ty, quote! { burn::backend::Dispatch });
+                Some(quote! {
+                    <#target_ty as burn::backend::ExtensionType<burn::backend::Dispatch>>::dispatch_kind(&#n)
+                })
+            }
+            ArgKind::Other(_) => None,
+        })
+        // Only ever reached when a struct input exists, so a selector is always present.
+        .expect("mixed dispatch requires at least one tensor-ish input");
+
+    // Propagate the checkpointing strategy from the first bare tensor, if any (non-autodiff here, so
+    // it is `None` in practice, but kept consistent with the pure-tensor path).
+    let checkpointing = op
+        .inputs
+        .iter()
+        .find_map(|a| match &a.kind {
+            ArgKind::Tensor(_) => {
+                let n = &a.name;
+                Some(quote! { let checkpointing = #n.checkpointing.clone(); })
+            }
+            _ => None,
+        })
+        .unwrap_or_else(|| quote! { let checkpointing = None; });
+
+    // Fold the representative kind into a backend index. cfg-gated backends drop the same arm from
+    // both this match and the dispatch match below, so the indices stay aligned per compilation.
+    let tag_arms = ir.backends.concrete.iter().enumerate().map(|(i, backend)| {
+        let cfg_attr = backend.cfg.as_ref().map(|meta| quote! { #[#meta] });
+        let b_ident = backend_to_ident(backend);
+        quote! {
+            #cfg_attr
+            burn::backend::DispatchTensorKind::#b_ident(_) => #i,
+        }
+    });
+
+    let call_arms = ir.backends.concrete.iter().enumerate().map(|(i, backend)| {
+        let cfg_attr = backend.cfg.as_ref().map(|meta| quote! { #[#meta] });
+        let b_ident = backend_to_ident(backend);
+
+        // Pull each bare tensor out of its `DispatchTensor` into a `BackendTensor<B>`, matching what
+        // the pure-tensor path binds in its pattern. `gen_backend_call` then applies `.float()`/etc.
+        let pre_extract = op.inputs.iter().filter_map(|a| match &a.kind {
+            ArgKind::Tensor(_) => {
+                let n = &a.name;
+                Some(quote! {
+                    let #n = match #n.kind {
+                        burn::backend::DispatchTensorKind::#b_ident(bt) => bt,
+                        #[allow(unreachable_patterns)]
+                        _ => unreachable!("tensor input routed to the wrong backend"),
+                    };
+                })
+            }
+            _ => None,
+        });
+
+        let call = gen_backend_call(ir, op, backend);
+        quote! {
+            #cfg_attr
+            #i => {
+                #( #pre_extract )*
+                #call
+            }
+        }
+    });
+
+    quote! {
+        #checkpointing
+        let __burn_backend_tag: usize = match #selector {
+            #( #tag_arms )*
+            #[allow(unreachable_patterns)]
+            _ => usize::MAX,
+        };
+        match __burn_backend_tag {
+            #( #call_arms )*
+            _ => unimplemented!("Backend not supported for custom op `{}`", stringify!(#name)),
+        }
+    }
+}
+
 /// Generate the body that unwraps the dispatch tensors, calls the backend's trait impl and wraps the
 /// result back into a [`DispatchTensor`]. Shared by [`gen_backend_arm`] (inside a match) and the
 /// no-tensor-input dispatch path (direct call).
@@ -576,6 +779,22 @@ fn gen_backend_call(ir: &Extension, op: &Operation, backend: &Backend) -> TokenS
             let name = &a.name;
             let method = kind.unwrap_method();
             Some(quote! { let #name = #name.#method(); })
+        }
+        // Reconstruct `Struct<B>` from the incoming `Struct<Dispatch>` by unwrapping each tensor
+        // field into this backend's `BackendTensor`. Inverse of the `map_to_dispatch` output path.
+        ArgKind::ExtensionStruct(ty) => {
+            let name = &a.name;
+            let b_ty = struct_ty_with_param(ty, quote! { #b_ident });
+            Some(quote! {
+                let #name = <#b_ty as burn::backend::ExtensionType<#b_ident>>::map_from_dispatch(
+                    #name,
+                    |kind| match kind {
+                        burn::backend::DispatchTensorKind::#b_ident(bt) => bt,
+                        #[allow(unreachable_patterns)]
+                        _ => unreachable!("extension struct routed to the wrong backend"),
+                    },
+                );
+            })
         }
         _ => None,
     });
@@ -602,7 +821,7 @@ fn gen_backend_call(ir: &Extension, op: &Operation, backend: &Backend) -> TokenS
                     }
                     OutputKind::Custom(_) => {
                         quote! {
-                            burn::backend::ExtensionType::map_type(
+                            burn::backend::ExtensionType::map_to_dispatch(
                                 _out.#idx,
                                 |tensor| burn::backend::DispatchTensorKind::#b_ident(tensor),
                                 checkpointing,
@@ -614,7 +833,7 @@ fn gen_backend_call(ir: &Extension, op: &Operation, backend: &Backend) -> TokenS
             quote! { (#(#elements),*) }
         }
         OperationOutput::Custom(_) => {
-            quote! { burn::backend::ExtensionType::map_type(_out, |tensor| burn::backend::DispatchTensorKind::#b_ident(tensor), checkpointing) }
+            quote! { burn::backend::ExtensionType::map_to_dispatch(_out, |tensor| burn::backend::DispatchTensorKind::#b_ident(tensor), checkpointing) }
         }
     };
 
@@ -710,7 +929,7 @@ fn gen_autodiff_arm(ir: &Extension, op: &Operation) -> TokenStream2 {
                     }
                     OutputKind::Custom(_) => {
                         quote! {
-                            burn::backend::ExtensionType::map_type(
+                            burn::backend::ExtensionType::map_to_dispatch(
                                 _out.#idx,
                                 |tensor| match tensor {
                                     burn::backend::BackendTensor::Float(t) => {
@@ -731,7 +950,7 @@ fn gen_autodiff_arm(ir: &Extension, op: &Operation) -> TokenStream2 {
                 quote! { (#(#elements),*) }
             }
             OperationOutput::Custom(_) => {
-                quote! { burn::backend::ExtensionType::map_type(_out, |tensor| match tensor {
+                quote! { burn::backend::ExtensionType::map_to_dispatch(_out, |tensor| match tensor {
                     burn::backend::BackendTensor::Float(t) => {
                         burn::backend::DispatchTensorKind::Autodiff(
                             Box::new(burn::backend::DispatchTensorKind::#b_ident(
@@ -830,7 +1049,7 @@ pub fn derive_extension_output(input: TokenStream) -> TokenStream {
                 if is_ext {
                     // It's a nested extension type
                     quote! {
-                        #f_name: self.#f_name.map_type(
+                        #f_name: self.#f_name.map_to_dispatch(
                             &map_kind,
                             checkpointing
                         ),
@@ -856,11 +1075,66 @@ pub fn derive_extension_output(input: TokenStream) -> TokenStream {
         _ => panic!("ExtensionType derive only supports structs with named fields"),
     };
 
+    // Reverse of `fields_wrap`: rebuild `Struct<B>` from the incoming `Struct<Dispatch>` (`target`).
+    let fields_unwrap = match &input.fields {
+        syn::Fields::Named(fields) => {
+            let field_mappings = fields.named.iter().map(|f| {
+                let f_name = &f.ident;
+                let is_ext = f.attrs.iter().any(|attr| attr.path().is_ident("extension_type"));
+
+                if is_ext {
+                    // Nested extension type: recurse with the same unwrap closure.
+                    quote! {
+                        #f_name: burn::backend::ExtensionType::map_from_dispatch(target.#f_name, &unwrap_kind),
+                    }
+                } else if let Some(tensor_kind) = TensorKind::from_type(&f.ty) {
+                    // Tensor primitive: unwrap the DispatchTensor kind, then pull out the concrete
+                    // primitive with the accessor matching this field's kind (`.float()`, ...).
+                    let method = tensor_kind.unwrap_method();
+                    quote! {
+                        #f_name: unwrap_kind(target.#f_name.kind).#method(),
+                    }
+                } else {
+                    // Passthrough
+                    quote! { #f_name: target.#f_name, }
+                }
+            });
+
+            quote! { #name { #( #field_mappings )* } }
+        }
+        _ => unreachable!("named-fields check already happened above"),
+    };
+
+    // Representative field whose runtime backend tag identifies the whole struct. Prefer a direct
+    // tensor field; otherwise recurse into the first nested `#[extension_type]` field.
+    let dispatch_kind_expr = match &input.fields {
+        syn::Fields::Named(fields) => {
+            let first_tensor = fields.named.iter().find(|f| {
+                !f.attrs.iter().any(|attr| attr.path().is_ident("extension_type"))
+                    && TensorKind::from_type(&f.ty).is_some()
+            });
+            if let Some(f) = first_tensor {
+                let f_name = &f.ident;
+                quote! { &target.#f_name.kind }
+            } else if let Some(f) = fields
+                .named
+                .iter()
+                .find(|f| f.attrs.iter().any(|attr| attr.path().is_ident("extension_type")))
+            {
+                let f_name = &f.ident;
+                quote! { burn::backend::ExtensionType::dispatch_kind(&target.#f_name) }
+            } else {
+                quote! { compile_error!("An ExtensionType struct used as an input must contain at least one tensor field to select the backend from") }
+            }
+        }
+        _ => unreachable!("named-fields check already happened above"),
+    };
+
     TokenStream::from(quote! {
         impl #impl_generics burn::backend::ExtensionType<B> for #name #ty_generics #where_clause {
             type Target = #name<burn::backend::Dispatch>;
 
-            fn map_type<F>(
+            fn map_to_dispatch<F>(
                 self,
                 map_kind: F,
                 checkpointing: Option<burn::backend::CheckpointingStrategy>,
@@ -869,6 +1143,17 @@ pub fn derive_extension_output(input: TokenStream) -> TokenStream {
                 F: Fn(burn::backend::BackendTensor<B>) -> burn::backend::DispatchTensorKind,
             {
                 #fields_wrap
+            }
+
+            fn map_from_dispatch<F>(target: Self::Target, unwrap_kind: F) -> Self
+            where
+                F: Fn(burn::backend::DispatchTensorKind) -> burn::backend::BackendTensor<B>,
+            {
+                #fields_unwrap
+            }
+
+            fn dispatch_kind(target: &Self::Target) -> &burn::backend::DispatchTensorKind {
+                #dispatch_kind_expr
             }
         }
     })

--- a/crates/burn-backend-extension/src/lib.rs
+++ b/crates/burn-backend-extension/src/lib.rs
@@ -55,7 +55,8 @@ use syn::{
 /// The macro selects the backend from a representative tensor field of the struct and unwraps the
 /// dispatch form (`Inputs<Dispatch>`) back into the concrete `Inputs<Wgpu>` before calling the
 /// backend impl. Struct inputs may be freely mixed with bare tensor inputs, and several struct
-/// inputs are allowed. Current limitation of this path (sketch): not combinable with `Autodiff`.
+/// inputs are allowed, and the op may be combined with `Autodiff` (the op's own
+/// `impl ... for Autodiff<B>` hand-writes the backward pass, as for bare-tensor autodiff ops).
 #[proc_macro_attribute]
 pub fn backend_extension(attr: TokenStream, item: TokenStream) -> TokenStream {
     // Parse the backend list
@@ -644,84 +645,78 @@ fn struct_ty_with_param(ty: &Type, param: TokenStream2) -> TokenStream2 {
     }
 }
 
-/// Generate the dispatch body for an operation that takes a custom struct of tensors as input.
-///
-/// Unlike a bare tensor input (which carries its own `DispatchTensorKind` to match on), a struct
-/// input has no top-level tag, so we peek a representative field via `ExtensionType::dispatch_kind`
-/// to select the backend, then reconstruct the concrete `Struct<B>` inside the matched arm.
-///
-/// Sketch scope: exactly one struct input, no bare tensor inputs, non-autodiff only. The remaining
-/// cases are rejected with a `compile_error!` describing the limitation.
 /// Generate the dispatch body for an operation whose inputs include at least one `#[extension_type]`
-/// struct. This is the general "peek then unwrap" path and handles any mix of bare tensors and
-/// structs (including several structs), unlike the pure-tensor path which selects the backend by
-/// destructuring every tensor in the match pattern (impossible for a struct).
+/// struct. General "peek then unwrap" path: handles any mix of bare tensors and structs (including
+/// several structs), for both concrete backends and (when `Autodiff` is listed) the autodiff wrapper.
 ///
-/// Strategy:
-/// 1. Peek a single representative [`DispatchTensorKind`] from the first tensor-ish input (a bare
-///    tensor's own `.kind`, or a struct's via `ExtensionType::dispatch_kind`) and fold it into a
-///    small backend index. Folding to an index drops the borrow before any input is moved.
-/// 2. In the matched arm, unwrap every input for that backend: bare tensors are pulled out of their
-///    `DispatchTensor`, structs are reconstructed via `ExtensionType::map_from_dispatch`, then the backend
-///    impl is called and the output re-wrapped (via the shared [`gen_backend_call`]).
+/// The pure-tensor path selects the backend by destructuring every tensor in the match pattern,
+/// which is impossible for a struct. Instead we:
+/// 1. Peek a representative [`DispatchTensor`] (a bare tensor itself, or a struct's via
+///    `ExtensionType::dispatch_repr`) and fold its `.kind` into a `(is_autodiff, backend_index)`
+///    tag. Folding to a small value drops the borrow before any input is moved.
+/// 2. In the matched arm, unwrap every input for the selected backend and re-wrap the output.
 ///
-/// Sketch scope: non-autodiff only. Autodiff would need each struct's tensor fields flattened into
-/// the fixed-arity `Backward` node/checkpoint machinery.
+/// For an autodiff arm the target backend is `Autodiff<B>`: float tensors/fields unwrap through the
+/// `Autodiff(Box(#b(BackendTensor::Autodiff(_))))` nesting into `FloatTensor<Autodiff<B>>`, while
+/// int/bool/quantized ones stay plain (autodiff only tracks floats). The op's own
+/// `impl ... for Autodiff<B>` still hand-writes the backward pass exactly as for a bare-tensor
+/// autodiff op; the macro only routes and re-wraps.
 fn gen_mixed_dispatch_body(ir: &Extension, op: &Operation) -> TokenStream2 {
     let name = &op.name;
+    let has_ad = ir.backends.autodiff.0;
 
-    if ir.backends.autodiff.0 {
-        return quote! { compile_error!("A backend extension operation with a `#[extension_type]` struct input can't be combined with `Autodiff` yet. Each struct's tensor fields would need to be flattened into the fixed-arity `Backward` node/checkpoint machinery.") };
-    }
-
-    // Representative kind, used only to select the backend: the first bare tensor if any, else the
-    // first struct's representative field.
-    let selector = op
+    // Representative `DispatchTensor` expression: a bare tensor input itself, or a struct's
+    // representative field. Read twice below (for `.kind` selection and `.checkpointing`); both are
+    // cheap accessors whose borrows end within their statement, before any input is moved.
+    let repr_expr = op
         .inputs
         .iter()
         .find_map(|a| match &a.kind {
             ArgKind::Tensor(_) => {
                 let n = &a.name;
-                Some(quote! { &#n.kind })
+                Some(quote! { #n })
             }
             ArgKind::ExtensionStruct(ty) => {
                 let n = &a.name;
                 let target_ty = struct_ty_with_param(ty, quote! { burn::backend::Dispatch });
                 Some(quote! {
-                    <#target_ty as burn::backend::ExtensionType<burn::backend::Dispatch>>::dispatch_kind(&#n)
+                    <#target_ty as burn::backend::ExtensionType<burn::backend::Dispatch>>::dispatch_repr(&#n)
                 })
             }
             ArgKind::Other(_) => None,
         })
-        // Only ever reached when a struct input exists, so a selector is always present.
+        // Only ever reached when a struct input exists, so a representative is always present.
         .expect("mixed dispatch requires at least one tensor-ish input");
 
-    // Propagate the checkpointing strategy from the first bare tensor, if any (non-autodiff here, so
-    // it is `None` in practice, but kept consistent with the pure-tensor path).
-    let checkpointing = op
-        .inputs
-        .iter()
-        .find_map(|a| match &a.kind {
-            ArgKind::Tensor(_) => {
-                let n = &a.name;
-                Some(quote! { let checkpointing = #n.checkpointing.clone(); })
-            }
-            _ => None,
-        })
-        .unwrap_or_else(|| quote! { let checkpointing = None; });
-
-    // Fold the representative kind into a backend index. cfg-gated backends drop the same arm from
-    // both this match and the dispatch match below, so the indices stay aligned per compilation.
-    let tag_arms = ir.backends.concrete.iter().enumerate().map(|(i, backend)| {
+    // Tag arms fold the representative kind into `(is_autodiff, backend_index)`. cfg-gated backends
+    // drop the same arm from both the tag match and the dispatch match, keeping indices aligned.
+    let concrete_tag_arms = ir.backends.concrete.iter().enumerate().map(|(i, backend)| {
         let cfg_attr = backend.cfg.as_ref().map(|meta| quote! { #[#meta] });
         let b_ident = backend_to_ident(backend);
         quote! {
             #cfg_attr
-            burn::backend::DispatchTensorKind::#b_ident(_) => #i,
+            burn::backend::DispatchTensorKind::#b_ident(_) => (false, #i),
+        }
+    });
+    let ad_tag_arm = has_ad.then(|| {
+        let inner = ir.backends.concrete.iter().enumerate().map(|(i, backend)| {
+            let cfg_attr = backend.cfg.as_ref().map(|meta| quote! { #[#meta] });
+            let b_ident = backend_to_ident(backend);
+            quote! {
+                #cfg_attr
+                burn::backend::DispatchTensorKind::#b_ident(_) => #i,
+            }
+        });
+        quote! {
+            burn::backend::DispatchTensorKind::Autodiff(inner) => (true, match inner.as_ref() {
+                #( #inner )*
+                #[allow(unreachable_patterns)]
+                _ => usize::MAX,
+            }),
         }
     });
 
-    let call_arms = ir.backends.concrete.iter().enumerate().map(|(i, backend)| {
+    let concrete_call_arms = ir.backends.concrete.iter().enumerate().map(|(i, backend)| {
         let cfg_attr = backend.cfg.as_ref().map(|meta| quote! { #[#meta] });
         let b_ident = backend_to_ident(backend);
 
@@ -744,24 +739,182 @@ fn gen_mixed_dispatch_body(ir: &Extension, op: &Operation) -> TokenStream2 {
         let call = gen_backend_call(ir, op, backend);
         quote! {
             #cfg_attr
-            #i => {
+            (false, #i) => {
                 #( #pre_extract )*
                 #call
             }
         }
     });
 
+    let ad_call_arms: Vec<_> = if has_ad {
+        ir.backends
+            .concrete
+            .iter()
+            .enumerate()
+            .map(|(i, backend)| gen_mixed_ad_arm(ir, op, backend, i))
+            .collect()
+    } else {
+        Vec::new()
+    };
+
     quote! {
-        #checkpointing
-        let __burn_backend_tag: usize = match #selector {
-            #( #tag_arms )*
+        let checkpointing = #repr_expr.checkpointing.clone();
+        let __burn_backend_tag: (bool, usize) = match &#repr_expr.kind {
+            #ad_tag_arm
+            #( #concrete_tag_arms )*
             #[allow(unreachable_patterns)]
-            _ => usize::MAX,
+            _ => (false, usize::MAX),
         };
         match __burn_backend_tag {
-            #( #call_arms )*
+            #( #concrete_call_arms )*
+            #( #ad_call_arms )*
             _ => unimplemented!("Backend not supported for custom op `{}`", stringify!(#name)),
         }
+    }
+}
+
+/// Generate a single `(true, backend_index)` autodiff arm for the mixed dispatch path: unwrap every
+/// input into its `Autodiff<B>` primitive, call `<Autodiff<B> as Trait>::op`, and re-wrap the output.
+fn gen_mixed_ad_arm(ir: &Extension, op: &Operation, backend: &Backend, i: usize) -> TokenStream2 {
+    let cfg_attr = backend.cfg.as_ref().map(|meta| quote! { #[#meta] });
+    let b_ident = backend_to_ident(backend);
+    let trait_name = &ir.trait_name;
+    let fn_name = &op.name;
+    let maybe_await = if op.asyncness {
+        quote! { .await }
+    } else {
+        quote! {}
+    };
+
+    let unwraps = op.inputs.iter().filter_map(|a| match &a.kind {
+        // Float tensor: peel the autodiff nesting to recover `FloatTensor<Autodiff<B>>`.
+        ArgKind::Tensor(TensorKind::Float) => {
+            let n = &a.name;
+            Some(quote! {
+                let #n = match #n.kind {
+                    burn::backend::DispatchTensorKind::Autodiff(inner) => match *inner {
+                        burn::backend::DispatchTensorKind::#b_ident(bt) => bt.autodiff(),
+                        #[allow(unreachable_patterns)]
+                        _ => unreachable!("autodiff float tensor backend mismatch"),
+                    },
+                    #[allow(unreachable_patterns)]
+                    _ => unreachable!("expected an autodiff-wrapped float tensor"),
+                };
+            })
+        }
+        // Int/bool/quantized tensor: not autodiff-tracked, unwrap as usual.
+        ArgKind::Tensor(kind) => {
+            let n = &a.name;
+            let method = kind.unwrap_method();
+            Some(quote! {
+                let #n = match #n.kind {
+                    burn::backend::DispatchTensorKind::#b_ident(bt) => bt.#method(),
+                    #[allow(unreachable_patterns)]
+                    _ => unreachable!("tensor input routed to the wrong backend"),
+                };
+            })
+        }
+        // Struct: reconstruct `Struct<Autodiff<B>>`. The closure maps each field's dispatch kind to a
+        // `BackendTensor<Autodiff<B>>` — float fields carry the autodiff nesting, others stay plain.
+        ArgKind::ExtensionStruct(ty) => {
+            let n = &a.name;
+            let ad_ty = struct_ty_with_param(ty, quote! { Autodiff<#b_ident> });
+            Some(quote! {
+                let #n = <#ad_ty as burn::backend::ExtensionType<Autodiff<#b_ident>>>::map_from_dispatch(
+                    #n,
+                    |kind| match kind {
+                        burn::backend::DispatchTensorKind::Autodiff(inner) => match *inner {
+                            burn::backend::DispatchTensorKind::#b_ident(burn::backend::BackendTensor::Autodiff(t)) =>
+                                burn::backend::BackendTensor::Float(t),
+                            #[allow(unreachable_patterns)]
+                            _ => unreachable!("autodiff struct float field backend mismatch"),
+                        },
+                        burn::backend::DispatchTensorKind::#b_ident(bt) => match bt {
+                            burn::backend::BackendTensor::Int(t) => burn::backend::BackendTensor::Int(t),
+                            burn::backend::BackendTensor::Bool(t) => burn::backend::BackendTensor::Bool(t),
+                            burn::backend::BackendTensor::Quantized(t) => burn::backend::BackendTensor::Quantized(t),
+                            #[allow(unreachable_patterns)]
+                            _ => unreachable!("autodiff struct non-float field unexpected variant"),
+                        },
+                        #[allow(unreachable_patterns)]
+                        _ => unreachable!("autodiff struct field backend mismatch"),
+                    },
+                );
+            })
+        }
+        ArgKind::Other(_) => None,
+    });
+
+    let call_args = op.inputs.iter().map(|a| &a.name);
+    let wrap_out = gen_output_wrap(op, &b_ident, true);
+
+    quote! {
+        #cfg_attr
+        (true, #i) => {
+            #( #unwraps )*
+            type _ADBackend = Autodiff<#b_ident>;
+            let _out = <_ADBackend as #trait_name>::#fn_name(#( #call_args ),*)#maybe_await;
+            #wrap_out
+        }
+    }
+}
+
+/// Wrap the backend call's result `_out` back into the dispatch representation. Shared by every
+/// dispatch arm (concrete and autodiff). `is_ad` toggles the autodiff nesting: float outputs of an
+/// `Autodiff<B>` op are re-wrapped as `Autodiff(Box(#b(BackendTensor::Autodiff(_))))`, while int/bool/
+/// quantized outputs stay plain (autodiff only tracks floats).
+fn gen_output_wrap(op: &Operation, b_ident: &Ident, is_ad: bool) -> TokenStream2 {
+    // Wrap a single custom (`ExtensionType`) output value read via `accessor`.
+    let wrap_custom = |accessor: TokenStream2| -> TokenStream2 {
+        if is_ad {
+            quote! {
+                burn::backend::ExtensionType::map_to_dispatch(
+                    #accessor,
+                    |tensor| match tensor {
+                        burn::backend::BackendTensor::Float(t) => burn::backend::DispatchTensorKind::Autodiff(
+                            Box::new(burn::backend::DispatchTensorKind::#b_ident(
+                                burn::backend::BackendTensor::Autodiff(t),
+                            )),
+                        ),
+                        burn::backend::BackendTensor::Int(t) => burn::backend::DispatchTensorKind::#b_ident(burn::backend::BackendTensor::Int(t)),
+                        burn::backend::BackendTensor::Bool(t) => burn::backend::DispatchTensorKind::#b_ident(burn::backend::BackendTensor::Bool(t)),
+                        burn::backend::BackendTensor::Quantized(t) => burn::backend::DispatchTensorKind::#b_ident(burn::backend::BackendTensor::Quantized(t)),
+                        #[allow(unreachable_patterns)]
+                        _ => unreachable!("unexpected output tensor variant"),
+                    },
+                    checkpointing,
+                )
+            }
+        } else {
+            quote! {
+                burn::backend::ExtensionType::map_to_dispatch(
+                    #accessor,
+                    |tensor| burn::backend::DispatchTensorKind::#b_ident(tensor),
+                    checkpointing,
+                )
+            }
+        }
+    };
+
+    match &op.output {
+        OperationOutput::Tensor(kind) => {
+            let wrapped = gen_tensor_wrap(kind, quote! { _out }, b_ident, is_ad);
+            quote! { burn::backend::DispatchTensor { kind: #wrapped, checkpointing } }
+        }
+        OperationOutput::Tuple(elems) => {
+            let elements = elems.iter().enumerate().map(|(i, elem)| {
+                let idx = syn::Index::from(i);
+                match elem {
+                    OutputKind::Tensor(kind) => {
+                        let wrapped = gen_tensor_wrap(kind, quote! { _out.#idx }, b_ident, is_ad);
+                        quote! { burn::backend::DispatchTensor { kind: #wrapped, checkpointing } }
+                    }
+                    OutputKind::Custom(_) => wrap_custom(quote! { _out.#idx }),
+                }
+            });
+            quote! { (#(#elements),*) }
+        }
+        OperationOutput::Custom(_) => wrap_custom(quote! { _out }),
     }
 }
 
@@ -806,36 +959,7 @@ fn gen_backend_call(ir: &Extension, op: &Operation, backend: &Backend) -> TokenS
         quote! {}
     };
 
-    let wrap_out = match &op.output {
-        OperationOutput::Tensor(kind) => {
-            let wrapped = gen_tensor_wrap(kind, quote! { _out }, &b_ident, false);
-            quote! { burn::backend::DispatchTensor { kind: #wrapped, checkpointing } }
-        }
-        OperationOutput::Tuple(elems) => {
-            let elements = elems.iter().enumerate().map(|(i, elem)| {
-                let idx = syn::Index::from(i);
-                match elem {
-                    OutputKind::Tensor(kind) => {
-                        let wrapped = gen_tensor_wrap(kind, quote! { _out.#idx }, &b_ident, false);
-                        quote! { burn::backend::DispatchTensor { kind: #wrapped, checkpointing } }
-                    }
-                    OutputKind::Custom(_) => {
-                        quote! {
-                            burn::backend::ExtensionType::map_to_dispatch(
-                                _out.#idx,
-                                |tensor| burn::backend::DispatchTensorKind::#b_ident(tensor),
-                                checkpointing,
-                            )
-                        }
-                    }
-                }
-            });
-            quote! { (#(#elements),*) }
-        }
-        OperationOutput::Custom(_) => {
-            quote! { burn::backend::ExtensionType::map_to_dispatch(_out, |tensor| burn::backend::DispatchTensorKind::#b_ident(tensor), checkpointing) }
-        }
-    };
+    let wrap_out = gen_output_wrap(op, &b_ident, false);
 
     quote! {
         #(#unwraps)*
@@ -914,53 +1038,7 @@ fn gen_autodiff_arm(ir: &Extension, op: &Operation) -> TokenStream2 {
             quote! {}
         };
 
-        let wrap_out = match &op.output {
-            OperationOutput::Tensor(kind) => {
-                let wrapped = gen_tensor_wrap(kind, quote! { _out }, &b_ident, true);
-                quote! { burn::backend::DispatchTensor { kind: #wrapped, checkpointing } }
-            }
-            OperationOutput::Tuple(elems) => {
-                let elements = elems.iter().enumerate().map(|(i, elem)| {
-                let idx = syn::Index::from(i);
-                match elem {
-                    OutputKind::Tensor(kind) => {
-                        let wrapped = gen_tensor_wrap(kind, quote! { _out.#idx }, &b_ident, true);
-                        quote! { burn::backend::DispatchTensor { kind: #wrapped, checkpointing } }
-                    }
-                    OutputKind::Custom(_) => {
-                        quote! {
-                            burn::backend::ExtensionType::map_to_dispatch(
-                                _out.#idx,
-                                |tensor| match tensor {
-                                    burn::backend::BackendTensor::Float(t) => {
-                                        burn::backend::DispatchTensorKind::Autodiff(
-                                            Box::new(burn::backend::DispatchTensorKind::#b_ident(
-                                                burn::backend::BackendTensor::Autodiff(t)
-                                            ))
-                                        )
-                                    }
-                                    _ => burn::backend::DispatchTensorKind::#b_ident(tensor),
-                                },
-                                checkpointing,
-                            )
-                        }
-                    }
-                }
-            });
-                quote! { (#(#elements),*) }
-            }
-            OperationOutput::Custom(_) => {
-                quote! { burn::backend::ExtensionType::map_to_dispatch(_out, |tensor| match tensor {
-                    burn::backend::BackendTensor::Float(t) => {
-                        burn::backend::DispatchTensorKind::Autodiff(
-                            Box::new(burn::backend::DispatchTensorKind::#b_ident(
-                                burn::backend::BackendTensor::Autodiff(t)
-                            ))
-                        )
-                    }
-                }, checkpointing) }
-            }
-        };
+        let wrap_out = gen_output_wrap(op, &b_ident, true);
 
         quote! {
             #cfg_attr
@@ -1105,24 +1183,31 @@ pub fn derive_extension_output(input: TokenStream) -> TokenStream {
         _ => unreachable!("named-fields check already happened above"),
     };
 
-    // Representative field whose runtime backend tag identifies the whole struct. Prefer a direct
-    // tensor field; otherwise recurse into the first nested `#[extension_type]` field.
-    let dispatch_kind_expr = match &input.fields {
+    // Representative field: identifies the backend (`.kind`) and carries the checkpointing strategy
+    // (`.checkpointing`). Prefer the first float field (the tracked one under autodiff), then any
+    // tensor field, then recurse into the first nested `#[extension_type]` field.
+    let dispatch_repr_expr = match &input.fields {
         syn::Fields::Named(fields) => {
-            let first_tensor = fields.named.iter().find(|f| {
-                !f.attrs.iter().any(|attr| attr.path().is_ident("extension_type"))
+            let is_plain_tensor = |f: &&syn::Field| {
+                !f.attrs
+                    .iter()
+                    .any(|attr| attr.path().is_ident("extension_type"))
                     && TensorKind::from_type(&f.ty).is_some()
+            };
+            let first_float = fields.named.iter().find(|f| {
+                is_plain_tensor(f) && TensorKind::from_type(&f.ty) == Some(TensorKind::Float)
             });
-            if let Some(f) = first_tensor {
+            let repr = first_float.or_else(|| fields.named.iter().find(is_plain_tensor));
+            if let Some(f) = repr {
                 let f_name = &f.ident;
-                quote! { &target.#f_name.kind }
-            } else if let Some(f) = fields
-                .named
-                .iter()
-                .find(|f| f.attrs.iter().any(|attr| attr.path().is_ident("extension_type")))
-            {
+                quote! { &target.#f_name }
+            } else if let Some(f) = fields.named.iter().find(|f| {
+                f.attrs
+                    .iter()
+                    .any(|attr| attr.path().is_ident("extension_type"))
+            }) {
                 let f_name = &f.ident;
-                quote! { burn::backend::ExtensionType::dispatch_kind(&target.#f_name) }
+                quote! { burn::backend::ExtensionType::dispatch_repr(&target.#f_name) }
             } else {
                 quote! { compile_error!("An ExtensionType struct used as an input must contain at least one tensor field to select the backend from") }
             }
@@ -1152,8 +1237,8 @@ pub fn derive_extension_output(input: TokenStream) -> TokenStream {
                 #fields_unwrap
             }
 
-            fn dispatch_kind(target: &Self::Target) -> &burn::backend::DispatchTensorKind {
-                #dispatch_kind_expr
+            fn dispatch_repr(target: &Self::Target) -> &burn::backend::DispatchTensor {
+                #dispatch_repr_expr
             }
         }
     })

--- a/crates/burn-backend-extension/src/lib.rs
+++ b/crates/burn-backend-extension/src/lib.rs
@@ -344,6 +344,7 @@ fn lower_extension(attr: Backends, item: &ItemTrait) -> syn::Result<Extension> {
                 .iter()
                 .any(|attr| attr.path().is_ident("extension_type"));
             let kind = if is_ext {
+                validate_extension_struct_ty(&pt.ty)?;
                 ArgKind::ExtensionStruct((*pt.ty).clone())
             } else if let Some(k) = TensorKind::from_type(&pt.ty) {
                 ArgKind::Tensor(k)
@@ -476,14 +477,10 @@ fn gen_dispatch_method(ir: &Extension, op: &Operation) -> TokenStream2 {
         })
         .collect();
 
-    let struct_inputs: Vec<_> = op
+    let has_struct_input = op
         .inputs
         .iter()
-        .filter_map(|a| match &a.kind {
-            ArgKind::ExtensionStruct(ty) => Some((&a.name, ty)),
-            _ => None,
-        })
-        .collect();
+        .any(|a| matches!(a.kind, ArgKind::ExtensionStruct(_)));
 
     let ret_ty = match &op.output {
         OperationOutput::Tensor(k) => k.to_primitive_ty(),
@@ -529,7 +526,7 @@ fn gen_dispatch_method(ir: &Extension, op: &Operation) -> TokenStream2 {
         quote! { let checkpointing = None; }
     };
 
-    let body = if !struct_inputs.is_empty() {
+    let body = if has_struct_input {
         // At least one custom struct of tensors is passed as input (marked `#[extension_type]`).
         // This path also covers mixing structs with bare tensors and multiple struct inputs.
         gen_mixed_dispatch_body(ir, op)
@@ -645,6 +642,51 @@ fn struct_ty_with_param(ty: &Type, param: TokenStream2) -> TokenStream2 {
     }
 }
 
+/// Validate the type of a `#[extension_type]`-marked argument, emitting a clear `compile_error!` for
+/// the common misuses instead of letting them surface as obscure trait/type errors deeper in codegen.
+///
+/// The argument must be a struct with exactly one generic backend parameter (`MyStruct<Self>`), since
+/// [`struct_ty_with_param`] rewrites that single parameter to the backend when unwrapping. Marking a
+/// bare tensor, a non-path type, or a multi-parameter type is rejected here.
+fn validate_extension_struct_ty(ty: &Type) -> syn::Result<()> {
+    if TensorKind::from_type(ty).is_some() {
+        return Err(syn::Error::new_spanned(
+            ty,
+            "`#[extension_type]` marks a struct of tensor primitives, not a tensor argument. Remove \
+             the attribute to pass a plain tensor.",
+        ));
+    }
+
+    let Type::Path(tp) = ty else {
+        return Err(syn::Error::new_spanned(
+            ty,
+            "`#[extension_type]` requires a struct type with a single generic backend parameter, e.g. \
+             `MyStruct<Self>`.",
+        ));
+    };
+
+    let last = tp.path.segments.last().ok_or_else(|| {
+        syn::Error::new_spanned(ty, "`#[extension_type]` type must be a named struct")
+    })?;
+    let type_args = match &last.arguments {
+        PathArguments::AngleBracketed(args) => args
+            .args
+            .iter()
+            .filter(|a| matches!(a, GenericArgument::Type(_)))
+            .count(),
+        _ => 0,
+    };
+    if type_args != 1 {
+        return Err(syn::Error::new_spanned(
+            ty,
+            "`#[extension_type]` struct must have exactly one generic backend parameter, e.g. \
+             `MyStruct<Self>`.",
+        ));
+    }
+
+    Ok(())
+}
+
 /// Generate the dispatch body for an operation whose inputs include at least one `#[extension_type]`
 /// struct. General "peek then unwrap" path: handles any mix of bare tensors and structs (including
 /// several structs), for both concrete backends and (when `Autodiff` is listed) the autodiff wrapper.
@@ -664,6 +706,16 @@ fn struct_ty_with_param(ty: &Type, param: TokenStream2) -> TokenStream2 {
 fn gen_mixed_dispatch_body(ir: &Extension, op: &Operation) -> TokenStream2 {
     let name = &op.name;
     let has_ad = ir.backends.autodiff.0;
+    // cfg gating the `Autodiff` entry itself (e.g. `Autodiff: cfg(feature = "autodiff")`). Every
+    // generated autodiff arm must carry it, mirroring the pure-tensor path, so the arms vanish when
+    // autodiff is compiled out — otherwise their `DispatchTensorKind::Autodiff` / `Autodiff<B>`
+    // references (themselves feature-gated) would fail to compile.
+    let ad_cfg_attr = ir
+        .backends
+        .autodiff
+        .1
+        .as_ref()
+        .map(|meta| quote! { #[#meta] });
 
     // Representative `DispatchTensor` expression: a bare tensor input itself, or a struct's
     // representative field. Read twice below (for `.kind` selection and `.checkpointing`); both are
@@ -708,6 +760,7 @@ fn gen_mixed_dispatch_body(ir: &Extension, op: &Operation) -> TokenStream2 {
             }
         });
         quote! {
+            #ad_cfg_attr
             burn::backend::DispatchTensorKind::Autodiff(inner) => (true, match inner.as_ref() {
                 #( #inner )*
                 #[allow(unreachable_patterns)]
@@ -729,7 +782,9 @@ fn gen_mixed_dispatch_body(ir: &Extension, op: &Operation) -> TokenStream2 {
                     let #n = match #n.kind {
                         burn::backend::DispatchTensorKind::#b_ident(bt) => bt,
                         #[allow(unreachable_patterns)]
-                        _ => unreachable!("tensor input routed to the wrong backend"),
+                        _ => panic!(
+                            "backend extension op received tensor inputs on mismatched backends; all inputs must be on the same backend"
+                        ),
                     };
                 })
             }
@@ -751,7 +806,7 @@ fn gen_mixed_dispatch_body(ir: &Extension, op: &Operation) -> TokenStream2 {
             .concrete
             .iter()
             .enumerate()
-            .map(|(i, backend)| gen_mixed_ad_arm(ir, op, backend, i))
+            .map(|(i, backend)| gen_mixed_ad_arm(ir, op, backend, i, &ad_cfg_attr))
             .collect()
     } else {
         Vec::new()
@@ -775,7 +830,13 @@ fn gen_mixed_dispatch_body(ir: &Extension, op: &Operation) -> TokenStream2 {
 
 /// Generate a single `(true, backend_index)` autodiff arm for the mixed dispatch path: unwrap every
 /// input into its `Autodiff<B>` primitive, call `<Autodiff<B> as Trait>::op`, and re-wrap the output.
-fn gen_mixed_ad_arm(ir: &Extension, op: &Operation, backend: &Backend, i: usize) -> TokenStream2 {
+fn gen_mixed_ad_arm(
+    ir: &Extension,
+    op: &Operation,
+    backend: &Backend,
+    i: usize,
+    ad_cfg_attr: &Option<TokenStream2>,
+) -> TokenStream2 {
     let cfg_attr = backend.cfg.as_ref().map(|meta| quote! { #[#meta] });
     let b_ident = backend_to_ident(backend);
     let trait_name = &ir.trait_name;
@@ -795,10 +856,14 @@ fn gen_mixed_ad_arm(ir: &Extension, op: &Operation, backend: &Backend, i: usize)
                     burn::backend::DispatchTensorKind::Autodiff(inner) => match *inner {
                         burn::backend::DispatchTensorKind::#b_ident(bt) => bt.autodiff(),
                         #[allow(unreachable_patterns)]
-                        _ => unreachable!("autodiff float tensor backend mismatch"),
+                        _ => panic!(
+                            "backend extension op received tensor inputs on mismatched backends; all inputs must be on the same backend"
+                        ),
                     },
                     #[allow(unreachable_patterns)]
-                    _ => unreachable!("expected an autodiff-wrapped float tensor"),
+                    _ => panic!(
+                        "backend extension op mixes autodiff-tracked and untracked float tensors; all float inputs must share the same tracking"
+                    ),
                 };
             })
         }
@@ -827,7 +892,9 @@ fn gen_mixed_ad_arm(ir: &Extension, op: &Operation, backend: &Backend, i: usize)
                             burn::backend::DispatchTensorKind::#b_ident(burn::backend::BackendTensor::Autodiff(t)) =>
                                 burn::backend::BackendTensor::Float(t),
                             #[allow(unreachable_patterns)]
-                            _ => unreachable!("autodiff struct float field backend mismatch"),
+                            _ => panic!(
+                                "backend extension op received tensor inputs on mismatched backends; all inputs must be on the same backend"
+                            ),
                         },
                         burn::backend::DispatchTensorKind::#b_ident(bt) => match bt {
                             burn::backend::BackendTensor::Int(t) => burn::backend::BackendTensor::Int(t),
@@ -837,7 +904,9 @@ fn gen_mixed_ad_arm(ir: &Extension, op: &Operation, backend: &Backend, i: usize)
                             _ => unreachable!("autodiff struct non-float field unexpected variant"),
                         },
                         #[allow(unreachable_patterns)]
-                        _ => unreachable!("autodiff struct field backend mismatch"),
+                        _ => panic!(
+                            "backend extension op received tensor inputs on mismatched backends; all inputs must be on the same backend"
+                        ),
                     },
                 );
             })
@@ -849,6 +918,7 @@ fn gen_mixed_ad_arm(ir: &Extension, op: &Operation, backend: &Backend, i: usize)
     let wrap_out = gen_output_wrap(op, &b_ident, true);
 
     quote! {
+        #ad_cfg_attr
         #cfg_attr
         (true, #i) => {
             #( #unwraps )*
@@ -944,7 +1014,9 @@ fn gen_backend_call(ir: &Extension, op: &Operation, backend: &Backend) -> TokenS
                     |kind| match kind {
                         burn::backend::DispatchTensorKind::#b_ident(bt) => bt,
                         #[allow(unreachable_patterns)]
-                        _ => unreachable!("extension struct routed to the wrong backend"),
+                        _ => panic!(
+                            "backend extension op received tensor inputs on mismatched backends; all inputs must be on the same backend"
+                        ),
                     },
                 );
             })
@@ -1209,7 +1281,16 @@ pub fn derive_extension_output(input: TokenStream) -> TokenStream {
                 let f_name = &f.ident;
                 quote! { burn::backend::ExtensionType::dispatch_repr(&target.#f_name) }
             } else {
-                quote! { compile_error!("An ExtensionType struct used as an input must contain at least one tensor field to select the backend from") }
+                // No tensor or nested field to represent the struct. This only matters when the
+                // struct is used as an *input* (where the dispatch glue calls `dispatch_repr` to
+                // select a backend); an output-only struct never calls it. So panic at runtime rather
+                // than `compile_error!`, which would otherwise break valid output-only structs.
+                quote! {
+                    {
+                        let _ = target;
+                        panic!("an ExtensionType struct used as a backend extension input must contain at least one tensor field to select the backend from")
+                    }
+                }
             }
         }
         _ => unreachable!("named-fields check already happened above"),

--- a/crates/burn-backend-extension/src/lib.rs
+++ b/crates/burn-backend-extension/src/lib.rs
@@ -922,34 +922,31 @@ fn gen_mixed_ad_arm(
                 };
             })
         }
-        // Struct: reconstruct `Struct<Autodiff<B>>`. The closure maps each field's dispatch kind to a
-        // `BackendTensor<Autodiff<B>>` — float fields carry the autodiff nesting, others stay plain.
+        // Struct/enum: reconstruct `Ty<Autodiff<B>>`. The closure pulls each field's `BackendTensor`
+        // out of its dispatch kind (float fields arrive autodiff-wrapped, others plain) and lifts it
+        // to `Autodiff<B>` via `into_autodiff`.
         ArgKind::Extension(ty) => {
             let n = &a.name;
             let ad_ty = struct_ty_with_param(ty, quote! { Autodiff<#b_ident> });
             Some(quote! {
                 let #n = <#ad_ty as burn::backend::ExtensionType<Autodiff<#b_ident>>>::map_from_dispatch(
                     #n,
-                    |kind| match kind {
-                        burn::backend::DispatchTensorKind::Autodiff(inner) => match *inner {
-                            burn::backend::DispatchTensorKind::#b_ident(burn::backend::BackendTensor::Autodiff(t)) =>
-                                burn::backend::BackendTensor::Float(t),
+                    |kind| {
+                        let bt = match kind {
+                            burn::backend::DispatchTensorKind::Autodiff(inner) => match *inner {
+                                burn::backend::DispatchTensorKind::#b_ident(bt) => bt,
+                                #[allow(unreachable_patterns)]
+                                _ => panic!(
+                                    "backend extension op received tensor inputs on mismatched backends; all inputs must be on the same backend"
+                                ),
+                            },
+                            burn::backend::DispatchTensorKind::#b_ident(bt) => bt,
                             #[allow(unreachable_patterns)]
                             _ => panic!(
                                 "backend extension op received tensor inputs on mismatched backends; all inputs must be on the same backend"
                             ),
-                        },
-                        burn::backend::DispatchTensorKind::#b_ident(bt) => match bt {
-                            burn::backend::BackendTensor::Int(t) => burn::backend::BackendTensor::Int(t),
-                            burn::backend::BackendTensor::Bool(t) => burn::backend::BackendTensor::Bool(t),
-                            burn::backend::BackendTensor::Quantized(t) => burn::backend::BackendTensor::Quantized(t),
-                            #[allow(unreachable_patterns)]
-                            _ => unreachable!("autodiff struct non-float field unexpected variant"),
-                        },
-                        #[allow(unreachable_patterns)]
-                        _ => panic!(
-                            "backend extension op received tensor inputs on mismatched backends; all inputs must be on the same backend"
-                        ),
+                        };
+                        bt.into_autodiff()
                     },
                 );
             })

--- a/crates/burn-backend-extension/src/lib.rs
+++ b/crates/burn-backend-extension/src/lib.rs
@@ -814,7 +814,7 @@ fn gen_mixed_dispatch_body(ir: &Extension, op: &Operation) -> TokenStream2 {
                         burn::backend::DispatchTensorKind::#b_ident(bt) => bt,
                         #[allow(unreachable_patterns)]
                         _ => panic!(
-                            "backend extension op received tensor inputs on mismatched backends; all inputs must be on the same backend"
+                            "backend extension op received tensor inputs on mismatched backends, or mixed autodiff-tracked and untracked float tensors; all tensor inputs must share one backend and tracking"
                         ),
                     };
                 })
@@ -1058,7 +1058,7 @@ fn gen_backend_call(ir: &Extension, op: &Operation, backend: &Backend) -> TokenS
                         burn::backend::DispatchTensorKind::#b_ident(bt) => bt,
                         #[allow(unreachable_patterns)]
                         _ => panic!(
-                            "backend extension op received tensor inputs on mismatched backends; all inputs must be on the same backend"
+                            "backend extension op received tensor inputs on mismatched backends, or mixed autodiff-tracked and untracked float tensors; all tensor inputs must share one backend and tracking"
                         ),
                     },
                 );
@@ -1323,10 +1323,14 @@ fn gen_repr_arm(case: &DeriveCase, float_only: bool) -> TokenStream2 {
         .fields
         .iter()
         .position(|f| !f.is_ext && f.tensor_kind == Some(TensorKind::Float));
-    let any_i = case
-        .fields
-        .iter()
-        .position(|f| !f.is_ext && f.tensor_kind.is_some());
+    // Only relevant as a non-float fallback, i.e. never in the `float_only` expansion.
+    let any_i = if float_only {
+        None
+    } else {
+        case.fields
+            .iter()
+            .position(|f| !f.is_ext && f.tensor_kind.is_some())
+    };
     let ext_is: Vec<usize> = case
         .fields
         .iter()
@@ -1343,7 +1347,7 @@ fn gen_repr_arm(case: &DeriveCase, float_only: bool) -> TokenStream2 {
     let (needed, expr): (Vec<usize>, TokenStream2) = if let Some(i) = float_i {
         let bind = &case.fields[i].bind;
         (vec![i], quote! { Some(#bind) })
-    } else if let Some(i) = any_i.filter(|_| !float_only) {
+    } else if let Some(i) = any_i {
         let bind = &case.fields[i].bind;
         (vec![i], quote! { Some(#bind) })
     } else if !ext_is.is_empty() {
@@ -1472,6 +1476,10 @@ pub fn derive_extension_output(input: TokenStream) -> TokenStream {
     let any_repr_arms = cases.iter().map(|case| gen_repr_arm(case, false));
     let float_repr_arms = cases.iter().map(|case| gen_repr_arm(case, true));
 
+    // `#[allow(unused_variables)]` on the two map methods: `map_kind`/`unwrap_kind`/`checkpointing`
+    // are genuinely unused for all-passthrough or unit types. The trade-off is that it also hides the
+    // warning that would otherwise flag a field whose tensor type went unrecognized (e.g. written
+    // through an opaque type alias) and was silently treated as a passthrough.
     TokenStream::from(quote! {
         impl #impl_generics burn::backend::ExtensionType<B> for #name #ty_generics #where_clause {
             type Target = #name<burn::backend::Dispatch>;

--- a/crates/burn-backend-extension/src/lib.rs
+++ b/crates/burn-backend-extension/src/lib.rs
@@ -362,8 +362,6 @@ fn lower_extension(attr: Backends, item: &ItemTrait) -> syn::Result<Extension> {
         }
 
         // Parse outputs
-
-        // Parse outputs
         let (actual_ty, is_async) = match &f.sig.output {
             ReturnType::Default => {
                 return Err(syn::Error::new_spanned(
@@ -697,6 +695,25 @@ fn validate_extension_ty(ty: &Type) -> syn::Result<()> {
     Ok(())
 }
 
+/// `panic!` emitted in a concrete-path unwrap arm that a valid single-backend call never reaches: it
+/// can only be hit by a genuine backend mismatch or by mixed autodiff tracking across inputs.
+fn panic_backend_or_tracking_mismatch() -> TokenStream2 {
+    quote! {
+        panic!(
+            "backend extension op received tensor inputs on mismatched backends, or mixed autodiff-tracked and untracked float tensors; all tensor inputs must share one backend and tracking"
+        )
+    }
+}
+
+/// `panic!` emitted in an autodiff unwrap arm, only reachable on a genuine backend mismatch.
+fn panic_backend_mismatch() -> TokenStream2 {
+    quote! {
+        panic!(
+            "backend extension op received tensor inputs on mismatched backends; all tensor inputs must be on the same backend"
+        )
+    }
+}
+
 /// Generate the dispatch body for an operation whose inputs include at least one `#[extension_type]`
 /// struct. General "peek then unwrap" path: handles any mix of bare tensors and structs (including
 /// several structs), for both concrete backends and (when `Autodiff` is listed) the autodiff wrapper.
@@ -715,6 +732,7 @@ fn validate_extension_ty(ty: &Type) -> syn::Result<()> {
 /// autodiff op; the macro only routes and re-wraps.
 fn gen_mixed_dispatch_body(ir: &Extension, op: &Operation) -> TokenStream2 {
     let name = &op.name;
+    let mismatch = panic_backend_or_tracking_mismatch();
     let has_ad = ir.backends.autodiff.0;
     // cfg gating the `Autodiff` entry itself (e.g. `Autodiff: cfg(feature = "autodiff")`). Every
     // generated autodiff arm must carry it, mirroring the pure-tensor path, so the arms vanish when
@@ -813,9 +831,7 @@ fn gen_mixed_dispatch_body(ir: &Extension, op: &Operation) -> TokenStream2 {
                     let #n = match #n.kind {
                         burn::backend::DispatchTensorKind::#b_ident(bt) => bt,
                         #[allow(unreachable_patterns)]
-                        _ => panic!(
-                            "backend extension op received tensor inputs on mismatched backends, or mixed autodiff-tracked and untracked float tensors; all tensor inputs must share one backend and tracking"
-                        ),
+                        _ => #mismatch,
                     };
                 })
             }
@@ -884,6 +900,7 @@ fn gen_mixed_ad_arm(
     let b_ident = backend_to_ident(backend);
     let trait_name = &ir.trait_name;
     let fn_name = &op.name;
+    let mismatch = panic_backend_mismatch();
     let maybe_await = if op.asyncness {
         quote! { .await }
     } else {
@@ -899,9 +916,7 @@ fn gen_mixed_ad_arm(
                     burn::backend::DispatchTensorKind::Autodiff(inner) => match *inner {
                         burn::backend::DispatchTensorKind::#b_ident(bt) => bt.autodiff(),
                         #[allow(unreachable_patterns)]
-                        _ => panic!(
-                            "backend extension op received tensor inputs on mismatched backends; all inputs must be on the same backend"
-                        ),
+                        _ => #mismatch,
                     },
                     #[allow(unreachable_patterns)]
                     _ => panic!(
@@ -936,15 +951,11 @@ fn gen_mixed_ad_arm(
                             burn::backend::DispatchTensorKind::Autodiff(inner) => match *inner {
                                 burn::backend::DispatchTensorKind::#b_ident(bt) => bt,
                                 #[allow(unreachable_patterns)]
-                                _ => panic!(
-                                    "backend extension op received tensor inputs on mismatched backends; all inputs must be on the same backend"
-                                ),
+                                _ => #mismatch,
                             },
                             burn::backend::DispatchTensorKind::#b_ident(bt) => bt,
                             #[allow(unreachable_patterns)]
-                            _ => panic!(
-                                "backend extension op received tensor inputs on mismatched backends; all inputs must be on the same backend"
-                            ),
+                            _ => #mismatch,
                         };
                         bt.into_autodiff()
                     },
@@ -1035,6 +1046,7 @@ fn gen_backend_call(ir: &Extension, op: &Operation, backend: &Backend) -> TokenS
     let b_ident = backend_to_ident(backend);
     let trait_name = &ir.trait_name;
     let fn_name = &op.name;
+    let mismatch = panic_backend_or_tracking_mismatch();
 
     // Unwrap inner kind: lhs.float(), rhs.int(), etc. (no-op when there are no tensor inputs).
     let unwraps = op.inputs.iter().filter_map(|a| match &a.kind {
@@ -1054,9 +1066,7 @@ fn gen_backend_call(ir: &Extension, op: &Operation, backend: &Backend) -> TokenS
                     |kind| match kind {
                         burn::backend::DispatchTensorKind::#b_ident(bt) => bt,
                         #[allow(unreachable_patterns)]
-                        _ => panic!(
-                            "backend extension op received tensor inputs on mismatched backends, or mixed autodiff-tracked and untracked float tensors; all tensor inputs must share one backend and tracking"
-                        ),
+                        _ => #mismatch,
                     },
                 );
             })
@@ -1411,7 +1421,7 @@ fn gen_repr_arm(case: &DeriveCase, float_only: bool) -> TokenStream2 {
 /// }
 /// ```
 #[proc_macro_derive(ExtensionType, attributes(extension_type))]
-pub fn derive_extension_output(input: TokenStream) -> TokenStream {
+pub fn derive_extension_type(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = &input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();

--- a/crates/burn-backend-extension/src/lib.rs
+++ b/crates/burn-backend-extension/src/lib.rs
@@ -736,7 +736,7 @@ fn gen_mixed_dispatch_body(ir: &Extension, op: &Operation) -> TokenStream2 {
     let has_ad = ir.backends.autodiff.0;
     // cfg gating the `Autodiff` entry itself (e.g. `Autodiff: cfg(feature = "autodiff")`). Every
     // generated autodiff arm must carry it, mirroring the pure-tensor path, so the arms vanish when
-    // autodiff is compiled out — otherwise their `DispatchTensorKind::Autodiff` / `Autodiff<B>`
+    // autodiff is compiled out. Otherwise their `DispatchTensorKind::Autodiff` / `Autodiff<B>`
     // references (themselves feature-gated) would fail to compile.
     let ad_cfg_attr = ir
         .backends
@@ -1211,7 +1211,7 @@ enum CaseStyle {
 }
 
 /// One derive "case": a struct is a single case; an enum contributes one case per variant. Unifies
-/// struct and enum handling — the generated methods are a `match` over cases (trivial for a struct).
+/// struct and enum handling. The generated methods are a `match` over cases (trivial for a struct).
 struct DeriveCase {
     /// Path to match / construct, e.g. `Name` or `Name::Variant`.
     path: TokenStream2,
@@ -1400,7 +1400,7 @@ fn gen_repr_arm(case: &DeriveCase, float_only: bool) -> TokenStream2 {
 ///
 /// When used as an input, the dispatch glue selects the backend from a representative tensor. For an
 /// enum this depends on the active variant, and a tensor-less variant (or unit variant) yields no
-/// representative — the glue then walks the op's other inputs. If no input carries a tensor at
+/// representative, so the glue then walks the op's other inputs. If no input carries a tensor at
 /// runtime the backend is unresolvable and the op panics.
 ///
 /// # Example

--- a/crates/burn-core/src/backend.rs
+++ b/crates/burn-core/src/backend.rs
@@ -33,7 +33,11 @@ pub trait ExtensionType<B: Backend> {
     /// # Returns
     ///
     /// A new instance of the struct mapped to the [`Dispatch`] backend.
-    fn map_to_dispatch<F>(self, map_kind: F, checkpointing: Option<CheckpointingStrategy>) -> Self::Target
+    fn map_to_dispatch<F>(
+        self,
+        map_kind: F,
+        checkpointing: Option<CheckpointingStrategy>,
+    ) -> Self::Target
     where
         F: Fn(BackendTensor<B>) -> DispatchTensorKind;
 
@@ -54,11 +58,14 @@ pub trait ExtensionType<B: Backend> {
     where
         F: Fn(DispatchTensorKind) -> BackendTensor<B>;
 
-    /// Peek the runtime backend tag from a representative tensor field of the dispatch form.
+    /// Return a representative tensor field of the dispatch form.
     ///
-    /// A struct input carries no top-level [`DispatchTensorKind`] of its own, so the dispatch glue
-    /// uses this to decide which backend arm to route the operation to. Returns a reference to the
-    /// first tensor field's kind (recursing into the first nested `#[extension_type]` field if the
-    /// struct has no direct tensor fields).
-    fn dispatch_kind(target: &Self::Target) -> &DispatchTensorKind;
+    /// A struct input carries no top-level [`DispatchTensor`] of its own, so the dispatch glue uses
+    /// this to (a) read the runtime backend tag (`.kind`) to select which backend arm to route to,
+    /// and (b) propagate the autodiff checkpointing strategy (`.checkpointing`) to the output.
+    ///
+    /// Prefers the first float field (the one that carries a checkpointing strategy when tracked),
+    /// falling back to the first tensor field of any kind, then recursing into the first nested
+    /// `#[extension_type]` field.
+    fn dispatch_repr(target: &Self::Target) -> &DispatchTensor;
 }

--- a/crates/burn-core/src/backend.rs
+++ b/crates/burn-core/src/backend.rs
@@ -58,14 +58,20 @@ pub trait ExtensionType<B: Backend> {
     where
         F: Fn(DispatchTensorKind) -> BackendTensor<B>;
 
-    /// Return a representative tensor field of the dispatch form.
+    /// Return a representative tensor of the dispatch form, of any kind, or `None` if this value
+    /// currently holds no tensor (e.g. an enum on a tensor-less variant).
     ///
-    /// A struct input carries no top-level [`DispatchTensor`] of its own, so the dispatch glue uses
-    /// this to (a) read the runtime backend tag (`.kind`) to select which backend arm to route to,
-    /// and (b) propagate the autodiff checkpointing strategy (`.checkpointing`) to the output.
+    /// A struct/enum input carries no top-level [`DispatchTensor`] of its own, so the dispatch glue
+    /// uses this to read the runtime backend tag (`.kind`) and propagate the autodiff checkpointing
+    /// strategy (`.checkpointing`). Recurses into nested `#[extension_type]` fields.
+    fn dispatch_repr(target: &Self::Target) -> Option<&DispatchTensor>;
+
+    /// Like [`dispatch_repr`](Self::dispatch_repr) but returns only a *float* tensor, or `None` if
+    /// there is none.
     ///
-    /// Prefers the first float field (the one that carries a checkpointing strategy when tracked),
-    /// falling back to the first tensor field of any kind, then recursing into the first nested
-    /// `#[extension_type]` field.
-    fn dispatch_repr(target: &Self::Target) -> &DispatchTensor;
+    /// The dispatch glue prefers a float representative because floats are the tensors that carry
+    /// autodiff tracking (so this decides whether the op routes to the autodiff arm) and the
+    /// checkpointing strategy. It falls back to [`dispatch_repr`](Self::dispatch_repr) only when no
+    /// float tensor exists anywhere in the inputs.
+    fn dispatch_float_repr(target: &Self::Target) -> Option<&DispatchTensor>;
 }

--- a/crates/burn-core/src/backend.rs
+++ b/crates/burn-core/src/backend.rs
@@ -33,7 +33,32 @@ pub trait ExtensionType<B: Backend> {
     /// # Returns
     ///
     /// A new instance of the struct mapped to the [`Dispatch`] backend.
-    fn map_type<F>(self, map_kind: F, checkpointing: Option<CheckpointingStrategy>) -> Self::Target
+    fn map_to_dispatch<F>(self, map_kind: F, checkpointing: Option<CheckpointingStrategy>) -> Self::Target
     where
         F: Fn(BackendTensor<B>) -> DispatchTensorKind;
+
+    /// Reconstruct the concrete `Struct<B>` from its dispatch form `Struct<Dispatch>`.
+    ///
+    /// This is the inverse of [`map_to_dispatch`](Self::map_to_dispatch), used when a custom struct is passed as
+    /// an **input** to a backend extension operation. The dispatch glue has already selected the
+    /// target backend `B`; `unwrap_kind` pulls the matching [`BackendTensor`] out of each field's
+    /// [`DispatchTensorKind`], and the derived impl calls the right accessor (`.float()`, `.int()`,
+    /// ...) per field to recover the concrete primitive.
+    ///
+    /// # Arguments
+    ///
+    /// * `unwrap_kind` - A closure provided by the dispatch macro that unwraps a
+    ///   [`DispatchTensorKind`] into the [`BackendTensor`] for the selected backend `B`, panicking
+    ///   on a backend mismatch (which the dispatch layer guarantees never happens).
+    fn map_from_dispatch<F>(target: Self::Target, unwrap_kind: F) -> Self
+    where
+        F: Fn(DispatchTensorKind) -> BackendTensor<B>;
+
+    /// Peek the runtime backend tag from a representative tensor field of the dispatch form.
+    ///
+    /// A struct input carries no top-level [`DispatchTensorKind`] of its own, so the dispatch glue
+    /// uses this to decide which backend arm to route the operation to. Returns a reference to the
+    /// first tensor field's kind (recursing into the first nested `#[extension_type]` field if the
+    /// struct has no direct tensor fields).
+    fn dispatch_kind(target: &Self::Target) -> &DispatchTensorKind;
 }

--- a/crates/burn-core/src/backend.rs
+++ b/crates/burn-core/src/backend.rs
@@ -9,14 +9,17 @@ pub use burn_dispatch::{backend::*, device::*, tensor::*};
 // Re-export backends (e.g., Cuda)
 pub use burn_dispatch::backends::*;
 
-/// A trait to allow mapping custom backend-specific structures into their generic dispatch equivalents.
+/// A trait to map custom structs and enums of tensor primitives across the [`Dispatch`] boundary, in
+/// both directions.
 ///
-/// This trait is designed to cooperate with the [`#[backend_extension]`](backend_extension) macro. When an
-/// extension operation returns a custom struct containing multiple tensor primitives rather than a single
-/// output tensor primitive, this trait provides the mechanism to traverse that struct and recursively wrap
-/// each internal field into a [`DispatchTensor`].
+/// This trait cooperates with the [`#[backend_extension]`](backend_extension) macro. When an extension
+/// operation returns such a type, [`map_to_dispatch`](Self::map_to_dispatch) wraps each internal tensor
+/// into a [`DispatchTensor`]; when it takes one as an input, [`map_from_dispatch`](Self::map_from_dispatch)
+/// reconstructs the concrete value and [`dispatch_repr`](Self::dispatch_repr) /
+/// [`dispatch_float_repr`](Self::dispatch_float_repr) locate a representative tensor for backend
+/// selection. Nested `#[extension_type]` fields are traversed recursively.
 ///
-/// Implementations of this trait are generated automatically using `#[derive(ExtensionType)]`.
+/// Implementations are generated automatically using `#[derive(ExtensionType)]`.
 pub trait ExtensionType<B: Backend> {
     /// The target struct layout where all internal concrete backend tensors are transformed
     /// into [`DispatchTensor`]s.

--- a/crates/burn-dispatch/src/tensor.rs
+++ b/crates/burn-dispatch/src/tensor.rs
@@ -121,8 +121,8 @@ impl<B: Backend> BackendTensor<B> {
     ///
     /// An already-tracked float (`Autodiff`) becomes the `Float` handle of `Autodiff<B>`; int/bool/
     /// quantized handles are re-tagged unchanged (those primitives are shared between `B` and
-    /// `Autodiff<B>`). An untracked `Float` handle is invalid here — under autodiff, float tensors
-    /// arrive tracked — so it panics.
+    /// `Autodiff<B>`). An untracked `Float` handle is invalid here (under autodiff, float tensors
+    /// arrive tracked), so it panics.
     #[cfg(feature = "autodiff")]
     pub fn into_autodiff(self) -> BackendTensor<Autodiff<B>> {
         match self {

--- a/crates/burn-dispatch/src/tensor.rs
+++ b/crates/burn-dispatch/src/tensor.rs
@@ -117,6 +117,25 @@ impl<B: Backend> BackendTensor<B> {
         }
     }
 
+    /// Lift a handle for backend `B` into the equivalent handle for `Autodiff<B>`.
+    ///
+    /// An already-tracked float (`Autodiff`) becomes the `Float` handle of `Autodiff<B>`; int/bool/
+    /// quantized handles are re-tagged unchanged (those primitives are shared between `B` and
+    /// `Autodiff<B>`). An untracked `Float` handle is invalid here — under autodiff, float tensors
+    /// arrive tracked — so it panics.
+    #[cfg(feature = "autodiff")]
+    pub fn into_autodiff(self) -> BackendTensor<Autodiff<B>> {
+        match self {
+            BackendTensor::Autodiff(tensor) => BackendTensor::Float(tensor),
+            BackendTensor::Int(tensor) => BackendTensor::Int(tensor),
+            BackendTensor::Bool(tensor) => BackendTensor::Bool(tensor),
+            BackendTensor::Quantized(tensor) => BackendTensor::Quantized(tensor),
+            BackendTensor::Float(_) => {
+                unreachable!("an untracked float handle can't be lifted to Autodiff<B>")
+            }
+        }
+    }
+
     /// Returns the tensor primitive kind name.
     pub fn name(&self) -> &'static str {
         match self {

--- a/crates/burn/tests/backend_extension_remote.rs
+++ b/crates/burn/tests/backend_extension_remote.rs
@@ -104,3 +104,49 @@ fn remote_backend_extension_gated_no_input_falls_back() {
     // expanded into valid code.
     let _ = <Dispatch as GatedBackend>::gated_load(0);
 }
+
+// Struct inputs combined with `Autodiff`. The generated dispatch glue must, for the autodiff arm,
+// peel the `Autodiff(..)` nesting on each float field to rebuild `Pair<Autodiff<Remote>>`, call the
+// user's `impl ... for Autodiff<Remote>`, and re-wrap the output as an autodiff dispatch tensor.
+#[cfg(feature = "autodiff")]
+mod autodiff_struct_input {
+    use super::*;
+    use burn::backend::Autodiff;
+
+    #[backend_extension(Autodiff, Remote)]
+    pub trait AdBackend: burn::backend::Backend {
+        fn ad_combine(#[extension_type] pair: Pair<Self>, factor: f32) -> FloatTensor<Self>;
+        // Struct mixed with a bare (autodiff-tracked) float tensor.
+        fn ad_mix(x: FloatTensor<Self>, #[extension_type] pair: Pair<Self>) -> FloatTensor<Self>;
+    }
+
+    // Client side for the plain remote backend (stubbed).
+    impl AdBackend for Remote {
+        fn ad_combine(_pair: Pair<Self>, _factor: f32) -> FloatTensor<Self> {
+            unimplemented!("the client builds a CustomOpIr and ships it to the server")
+        }
+        fn ad_mix(_x: FloatTensor<Self>, _pair: Pair<Self>) -> FloatTensor<Self> {
+            unimplemented!("stub")
+        }
+    }
+
+    // User-written autodiff side: normally registers a `Backward` step; stubbed here since the test
+    // only checks that the generated dispatch glue type-checks.
+    impl AdBackend for Autodiff<Remote> {
+        fn ad_combine(_pair: Pair<Self>, _factor: f32) -> FloatTensor<Self> {
+            unimplemented!("would register the backward pass over the struct's tracked fields")
+        }
+        fn ad_mix(_x: FloatTensor<Self>, _pair: Pair<Self>) -> FloatTensor<Self> {
+            unimplemented!("stub")
+        }
+    }
+
+    #[test]
+    fn autodiff_struct_input_dispatch_compiles() {
+        // Referencing the dispatch methods proves the macro expanded a well-typed `impl for Dispatch`
+        // whose match routes both concrete (`Remote`) and autodiff (`Autodiff<Remote>`) inputs.
+        let _a: fn(Pair<Dispatch>, f32) -> FloatTensor<Dispatch> = <Dispatch as AdBackend>::ad_combine;
+        let _b: fn(FloatTensor<Dispatch>, Pair<Dispatch>) -> FloatTensor<Dispatch> =
+            <Dispatch as AdBackend>::ad_mix;
+    }
+}

--- a/crates/burn/tests/backend_extension_remote.rs
+++ b/crates/burn/tests/backend_extension_remote.rs
@@ -23,6 +23,17 @@ pub trait Backend: burn::backend::Backend {
     fn scale(x: FloatTensor<Self>, factor: f32) -> FloatTensor<Self>;
     fn split(x: FloatTensor<Self>) -> (FloatTensor<Self>, IntTensor<Self>);
     fn make_pair(x: FloatTensor<Self>) -> Pair<Self>;
+    // Struct-of-tensors as an *input*: the `#[extension_type]` marker tells the macro to unwrap the
+    // incoming `Pair<Dispatch>` back into `Pair<Remote>` before the backend call.
+    fn combine_pair(#[extension_type] pair: Pair<Self>, factor: f32) -> FloatTensor<Self>;
+    // A struct input mixed with a bare tensor input: the backend is selected from the bare tensor,
+    // and the struct is unwrapped for that same backend inside the arm.
+    fn mix(x: FloatTensor<Self>, #[extension_type] pair: Pair<Self>) -> FloatTensor<Self>;
+    // Multiple struct inputs: each is unwrapped independently for the selected backend.
+    fn combine_two(
+        #[extension_type] lhs: Pair<Self>,
+        #[extension_type] rhs: Pair<Self>,
+    ) -> FloatTensor<Self>;
 }
 
 // User-written client side: builds a `CustomOpIr` and ships it to the server. Stubbed here.
@@ -39,6 +50,15 @@ impl Backend for Remote {
     fn make_pair(_x: FloatTensor<Self>) -> Pair<Self> {
         unimplemented!("the client builds a CustomOpIr and ships it to the server")
     }
+    fn combine_pair(_pair: Pair<Self>, _factor: f32) -> FloatTensor<Self> {
+        unimplemented!("the client builds a CustomOpIr and ships it to the server")
+    }
+    fn mix(_x: FloatTensor<Self>, _pair: Pair<Self>) -> FloatTensor<Self> {
+        unimplemented!("the client builds a CustomOpIr and ships it to the server")
+    }
+    fn combine_two(_lhs: Pair<Self>, _rhs: Pair<Self>) -> FloatTensor<Self> {
+        unimplemented!("the client builds a CustomOpIr and ships it to the server")
+    }
 }
 
 #[test]
@@ -48,6 +68,14 @@ fn remote_backend_extension_dispatch_compiles() {
     // tensor-input `scale` op.
     let _f: fn(usize) -> FloatTensor<Dispatch> = <Dispatch as Backend>::load_data;
     let _g: fn(FloatTensor<Dispatch>, f32) -> FloatTensor<Dispatch> = <Dispatch as Backend>::scale;
+    // The struct-input op expands into a well-typed dispatch method: it takes the dispatch form
+    // `Pair<Dispatch>`, peeks its backend tag, and unwraps to `Pair<Remote>` before the call.
+    let _h: fn(Pair<Dispatch>, f32) -> FloatTensor<Dispatch> = <Dispatch as Backend>::combine_pair;
+    // Mixed bare-tensor + struct input, and multiple struct inputs, both expand to well-typed glue.
+    let _i: fn(FloatTensor<Dispatch>, Pair<Dispatch>) -> FloatTensor<Dispatch> =
+        <Dispatch as Backend>::mix;
+    let _j: fn(Pair<Dispatch>, Pair<Dispatch>) -> FloatTensor<Dispatch> =
+        <Dispatch as Backend>::combine_two;
 }
 
 // A no-tensor-input op on a `cfg`-gated single backend. The backend is gated on

--- a/crates/burn/tests/backend_extension_remote.rs
+++ b/crates/burn/tests/backend_extension_remote.rs
@@ -124,7 +124,7 @@ fn remote_backend_extension_dispatch_compiles() {
 // Struct input combined with a `cfg`-gated `Autodiff`. The gate `cfg(not(feature = "remote"))` is
 // always false in this `#![cfg(feature = "remote")]` build, so every generated autodiff arm must be
 // stripped. If the mixed path failed to propagate the autodiff cfg (the pre-fix bug), the arms would
-// remain and reference the unimported `Autodiff` type, failing to compile — so this trait building at
+// remain and reference the unimported `Autodiff` type, failing to compile, so this trait building at
 // all is the assertion. Mirrors `GatedBackend`, but exercises the autodiff-gate path specifically.
 #[backend_extension(Autodiff: cfg(not(feature = "remote")), Remote)]
 pub trait AdGatedBackend: burn::backend::Backend {

--- a/crates/burn/tests/backend_extension_remote.rs
+++ b/crates/burn/tests/backend_extension_remote.rs
@@ -76,6 +76,35 @@ fn remote_backend_extension_dispatch_compiles() {
         <Dispatch as Backend>::mix;
     let _j: fn(Pair<Dispatch>, Pair<Dispatch>) -> FloatTensor<Dispatch> =
         <Dispatch as Backend>::combine_two;
+    // Struct input on an op whose `Autodiff` entry is `cfg`-gated off in this build. The generated
+    // autodiff arms must carry that cfg and be stripped; otherwise they reference a bare `Autodiff`
+    // that isn't in scope here. This compiling proves the mixed path honors the autodiff cfg gate
+    // (regression test for the review's finding #1). (See `AdGatedBackend`.)
+    let _k: fn(Pair<Dispatch>) -> FloatTensor<Dispatch> = <Dispatch as AdGatedBackend>::ad_gated;
+}
+
+// Struct input combined with a `cfg`-gated `Autodiff`. The gate `cfg(not(feature = "remote"))` is
+// always false in this `#![cfg(feature = "remote")]` build, so every generated autodiff arm must be
+// stripped. If the mixed path failed to propagate the autodiff cfg (the pre-fix bug), the arms would
+// remain and reference the unimported `Autodiff` type, failing to compile — so this trait building at
+// all is the assertion. Mirrors `GatedBackend`, but exercises the autodiff-gate path specifically.
+#[backend_extension(Autodiff: cfg(not(feature = "remote")), Remote)]
+pub trait AdGatedBackend: burn::backend::Backend {
+    fn ad_gated(#[extension_type] pair: Pair<Self>) -> FloatTensor<Self>;
+}
+
+impl AdGatedBackend for Remote {
+    fn ad_gated(_pair: Pair<Self>) -> FloatTensor<Self> {
+        unimplemented!("the client builds a CustomOpIr and ships it to the server")
+    }
+}
+
+// Only referenced by the generated autodiff arms, which are gated off in this build.
+#[cfg(not(feature = "remote"))]
+impl AdGatedBackend for burn::backend::Autodiff<Remote> {
+    fn ad_gated(_pair: Pair<Self>) -> FloatTensor<Self> {
+        unimplemented!("would register the backward pass")
+    }
 }
 
 // A no-tensor-input op on a `cfg`-gated single backend. The backend is gated on

--- a/crates/burn/tests/backend_extension_remote.rs
+++ b/crates/burn/tests/backend_extension_remote.rs
@@ -207,7 +207,8 @@ fn enum_and_tuple_input_dispatch_compiles() {
     // Enum input, tuple-struct input, and enum-mixed-with-bare-tensor input all expand into
     // well-typed dispatch methods routing concrete `Remote` and autodiff `Autodiff<Remote>`.
     let _a: fn(Operand<Dispatch>) -> FloatTensor<Dispatch> = <Dispatch as EnumBackend>::use_operand;
-    let _b: fn(TupleInputs<Dispatch>) -> FloatTensor<Dispatch> = <Dispatch as EnumBackend>::use_tuple;
+    let _b: fn(TupleInputs<Dispatch>) -> FloatTensor<Dispatch> =
+        <Dispatch as EnumBackend>::use_tuple;
     let _c: fn(FloatTensor<Dispatch>, Operand<Dispatch>) -> FloatTensor<Dispatch> =
         <Dispatch as EnumBackend>::mix_enum;
 }
@@ -278,7 +279,8 @@ mod autodiff_struct_input {
     fn autodiff_struct_input_dispatch_compiles() {
         // Referencing the dispatch methods proves the macro expanded a well-typed `impl for Dispatch`
         // whose match routes both concrete (`Remote`) and autodiff (`Autodiff<Remote>`) inputs.
-        let _a: fn(Pair<Dispatch>, f32) -> FloatTensor<Dispatch> = <Dispatch as AdBackend>::ad_combine;
+        let _a: fn(Pair<Dispatch>, f32) -> FloatTensor<Dispatch> =
+            <Dispatch as AdBackend>::ad_combine;
         let _b: fn(FloatTensor<Dispatch>, Pair<Dispatch>) -> FloatTensor<Dispatch> =
             <Dispatch as AdBackend>::ad_mix;
     }

--- a/crates/burn/tests/backend_extension_remote.rs
+++ b/crates/burn/tests/backend_extension_remote.rs
@@ -10,11 +10,49 @@ use burn::backend::{
     Dispatch, ExtensionType, Remote, backend_extension,
     tensor::{FloatTensor, IntTensor},
 };
+// Autodiff is enabled transitively by the default features in this test build. Several traits below
+// list `Autodiff`, whose generated arms reference the bare `Autodiff` type.
+#[cfg(feature = "autodiff")]
+use burn::backend::Autodiff;
 
 #[derive(ExtensionType)]
 pub struct Pair<B: burn::backend::Backend> {
     pub a: FloatTensor<B>,
     pub b: IntTensor<B>,
+}
+
+// Tuple struct: exercises the derive's unnamed-field (positional) handling.
+#[derive(ExtensionType)]
+pub struct TupleInputs<B: burn::backend::Backend>(pub FloatTensor<B>, pub IntTensor<B>);
+
+// Enum input: a tensor-tuple variant, a named-fields variant, and a tensor-less unit variant. The
+// unit variant has no representative tensor, so `dispatch_repr`/`dispatch_float_repr` return `None`
+// for it and backend selection must defer to another input (or panic if there is none).
+#[derive(ExtensionType)]
+pub enum Operand<B: burn::backend::Backend> {
+    Dense(FloatTensor<B>),
+    Sparse {
+        values: FloatTensor<B>,
+        indices: IntTensor<B>,
+    },
+    Empty,
+}
+
+// Nested `#[extension_type]` field plus a non-tensor passthrough field, mirroring burn-vision's
+// `ConnectedStatsPrimitive`. Guards the derive's recursion and passthrough handling for the new
+// enum-capable codegen (used as both output and input below).
+#[derive(ExtensionType)]
+pub struct Coords<B: burn::backend::Backend> {
+    pub left: IntTensor<B>,
+    pub top: IntTensor<B>,
+}
+
+#[derive(ExtensionType)]
+pub struct Stats<B: burn::backend::Backend> {
+    pub area: IntTensor<B>,
+    #[extension_type]
+    pub coords: Coords<B>,
+    pub count: usize,
 }
 
 #[backend_extension(Remote)]
@@ -107,6 +145,73 @@ impl AdGatedBackend for burn::backend::Autodiff<Remote> {
     }
 }
 
+// Nested `#[extension_type]` struct as both an output and an input, with a passthrough field.
+#[backend_extension(Remote)]
+pub trait NestedBackend: burn::backend::Backend {
+    fn make_stats(x: FloatTensor<Self>) -> Stats<Self>;
+    fn use_stats(#[extension_type] s: Stats<Self>) -> IntTensor<Self>;
+}
+
+impl NestedBackend for Remote {
+    fn make_stats(_x: FloatTensor<Self>) -> Stats<Self> {
+        unimplemented!("stub")
+    }
+    fn use_stats(_s: Stats<Self>) -> IntTensor<Self> {
+        unimplemented!("stub")
+    }
+}
+
+#[test]
+fn nested_extension_type_dispatch_compiles() {
+    let _a: fn(FloatTensor<Dispatch>) -> Stats<Dispatch> = <Dispatch as NestedBackend>::make_stats;
+    let _b: fn(Stats<Dispatch>) -> IntTensor<Dispatch> = <Dispatch as NestedBackend>::use_stats;
+}
+
+// Enum and tuple-struct inputs, including mixing an enum with a bare tensor. Combined with
+// `Autodiff` to exercise the autodiff enum unwrap (per-variant, per-field float nesting).
+#[backend_extension(Autodiff, Remote)]
+pub trait EnumBackend: burn::backend::Backend {
+    fn use_operand(#[extension_type] op: Operand<Self>) -> FloatTensor<Self>;
+    fn use_tuple(#[extension_type] inp: TupleInputs<Self>) -> FloatTensor<Self>;
+    // Enum mixed with a bare tensor: if the enum lands on `Empty`, the backend is selected from `x`.
+    fn mix_enum(x: FloatTensor<Self>, #[extension_type] op: Operand<Self>) -> FloatTensor<Self>;
+}
+
+impl EnumBackend for Remote {
+    fn use_operand(_op: Operand<Self>) -> FloatTensor<Self> {
+        unimplemented!("stub")
+    }
+    fn use_tuple(_inp: TupleInputs<Self>) -> FloatTensor<Self> {
+        unimplemented!("stub")
+    }
+    fn mix_enum(_x: FloatTensor<Self>, _op: Operand<Self>) -> FloatTensor<Self> {
+        unimplemented!("stub")
+    }
+}
+
+#[cfg(feature = "autodiff")]
+impl EnumBackend for burn::backend::Autodiff<Remote> {
+    fn use_operand(_op: Operand<Self>) -> FloatTensor<Self> {
+        unimplemented!("would register the backward pass over the active variant's tracked fields")
+    }
+    fn use_tuple(_inp: TupleInputs<Self>) -> FloatTensor<Self> {
+        unimplemented!("stub")
+    }
+    fn mix_enum(_x: FloatTensor<Self>, _op: Operand<Self>) -> FloatTensor<Self> {
+        unimplemented!("stub")
+    }
+}
+
+#[test]
+fn enum_and_tuple_input_dispatch_compiles() {
+    // Enum input, tuple-struct input, and enum-mixed-with-bare-tensor input all expand into
+    // well-typed dispatch methods routing concrete `Remote` and autodiff `Autodiff<Remote>`.
+    let _a: fn(Operand<Dispatch>) -> FloatTensor<Dispatch> = <Dispatch as EnumBackend>::use_operand;
+    let _b: fn(TupleInputs<Dispatch>) -> FloatTensor<Dispatch> = <Dispatch as EnumBackend>::use_tuple;
+    let _c: fn(FloatTensor<Dispatch>, Operand<Dispatch>) -> FloatTensor<Dispatch> =
+        <Dispatch as EnumBackend>::mix_enum;
+}
+
 // A no-tensor-input op on a `cfg`-gated single backend. The backend is gated on
 // `cfg(not(feature = "remote"))`, which is always false in this `#![cfg(feature = "remote")]` test
 // build, so the backend is compiled out — exercising the macro's no-input + gated codegen path,
@@ -140,7 +245,6 @@ fn remote_backend_extension_gated_no_input_falls_back() {
 #[cfg(feature = "autodiff")]
 mod autodiff_struct_input {
     use super::*;
-    use burn::backend::Autodiff;
 
     #[backend_extension(Autodiff, Remote)]
     pub trait AdBackend: burn::backend::Backend {

--- a/crates/burn/tests/backend_extension_runtime.rs
+++ b/crates/burn/tests/backend_extension_runtime.rs
@@ -82,13 +82,13 @@ fn all_tensorless_input_panics() {
 mod autodiff_gradients {
     use super::*;
     use burn::backend::Backend;
-    use burn::backend::ops::FloatTensorOps;
     use burn::backend::autodiff::{
         Autodiff,
         checkpoint::{base::Checkpointer, strategy::CheckpointStrategy},
         grads::Gradients,
         ops::{Backward, Ops, OpsKind},
     };
+    use burn::backend::ops::FloatTensorOps;
     use burn::tensor::TensorData;
 
     #[derive(ExtensionType)]

--- a/crates/burn/tests/backend_extension_runtime.rs
+++ b/crates/burn/tests/backend_extension_runtime.rs
@@ -74,3 +74,114 @@ fn all_tensorless_input_panics() {
     // `.expect(...)` fires. `pick`'s `NdArray` impl is never reached.
     let _ = <Dispatch as RtBackend>::pick(Operand::Empty);
 }
+
+// End-to-end autodiff: a differentiable op over a struct input, with a hand-written `Backward`, run
+// on `NdArray` through `Dispatch`. Verifies gradients actually flow back into the struct's fields
+// (not just that the dispatch glue type-checks).
+#[cfg(feature = "autodiff")]
+mod autodiff_gradients {
+    use super::*;
+    use burn::backend::Backend;
+    use burn::backend::ops::FloatTensorOps;
+    use burn::backend::autodiff::{
+        Autodiff,
+        checkpoint::{base::Checkpointer, strategy::CheckpointStrategy},
+        grads::Gradients,
+        ops::{Backward, Ops, OpsKind},
+    };
+    use burn::tensor::TensorData;
+
+    #[derive(ExtensionType)]
+    pub struct FloatPair<B: burn::backend::Backend> {
+        pub x: FloatTensor<B>,
+        pub y: FloatTensor<B>,
+    }
+
+    #[backend_extension(Autodiff, NdArray)]
+    pub trait GradBackend: burn::backend::Backend {
+        /// Elementwise `x * y`, differentiable in both fields.
+        fn mul_pair(#[extension_type] p: FloatPair<Self>) -> FloatTensor<Self>;
+    }
+
+    // Concrete forward.
+    impl GradBackend for NdArray {
+        fn mul_pair(p: FloatPair<Self>) -> FloatTensor<Self> {
+            NdArray::float_mul(p.x, p.y)
+        }
+    }
+
+    // Autodiff: register the backward step over the struct's two tracked float fields.
+    impl<C: CheckpointStrategy> GradBackend for Autodiff<NdArray, C> {
+        fn mul_pair(p: FloatPair<Self>) -> FloatTensor<Self> {
+            #[derive(Debug)]
+            struct MulPairBackward;
+
+            impl<B: Backend> Backward<B, 2> for MulPairBackward {
+                // d(x*y): grad_x = grad * y, grad_y = grad * x. Save the forward inputs.
+                type State = (FloatTensor<B>, FloatTensor<B>);
+
+                fn backward(
+                    self,
+                    ops: Ops<Self::State, 2>,
+                    grads: &mut Gradients,
+                    _checkpointer: &mut Checkpointer,
+                ) {
+                    let [node_x, node_y] = ops.parents;
+                    let grad = grads.consume::<B>(&ops.node);
+                    let (x, y) = ops.state;
+
+                    if let Some(node) = node_x {
+                        grads.register::<B>(node.id, B::float_mul(grad.clone(), y));
+                    }
+                    if let Some(node) = node_y {
+                        grads.register::<B>(node.id, B::float_mul(grad, x));
+                    }
+                }
+            }
+
+            match MulPairBackward
+                .prepare::<C>([p.x.node.clone(), p.y.node.clone()])
+                .compute_bound()
+                .stateful()
+            {
+                OpsKind::Tracked(prep) => {
+                    let x = p.x.primitive.clone();
+                    let y = p.y.primitive.clone();
+                    let output = NdArray::float_mul(x.clone(), y.clone());
+                    prep.finish((x, y), output)
+                }
+                OpsKind::UnTracked(prep) => {
+                    prep.finish(NdArray::float_mul(p.x.primitive, p.y.primitive))
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn autodiff_struct_input_propagates_gradients() {
+        let device = Device::ndarray().autodiff();
+        let x = Tensor::<1>::from_floats([2.0, 3.0], &device).require_grad();
+        let y = Tensor::<1>::from_floats([4.0, 5.0], &device).require_grad();
+
+        let out = Tensor::<1>::from_dispatch(<Dispatch as GradBackend>::mul_pair(FloatPair {
+            x: x.clone().into_dispatch(),
+            y: y.clone().into_dispatch(),
+        }));
+
+        // Forward: x * y.
+        out.clone()
+            .into_data()
+            .assert_eq(&TensorData::from([8.0f32, 15.0]), true);
+
+        let grads = out.backward();
+        // grad_x = y, grad_y = x.
+        x.grad(&grads)
+            .unwrap()
+            .into_data()
+            .assert_eq(&TensorData::from([4.0f32, 5.0]), true);
+        y.grad(&grads)
+            .unwrap()
+            .into_data()
+            .assert_eq(&TensorData::from([2.0f32, 3.0]), true);
+    }
+}

--- a/crates/burn/tests/backend_extension_runtime.rs
+++ b/crates/burn/tests/backend_extension_runtime.rs
@@ -1,0 +1,76 @@
+//! Runtime (executing) tests for enum/struct backend extension inputs, using the CPU `NdArray`
+//! backend through `Dispatch`.
+//!
+//! The `backend_extension_remote` tests are compile-only (stubbed impls, function-pointer coercions).
+//! These actually run the generated dispatch glue end to end: the runtime backend-selection walk,
+//! the tensor-less enum variant panic, and enum-variant-dependent unwrapping.
+#![cfg(feature = "ndarray")]
+
+use burn::backend::{Dispatch, ExtensionType, NdArray, backend_extension, tensor::FloatTensor};
+use burn::tensor::{Device, Tensor};
+
+#[derive(ExtensionType)]
+pub enum Operand<B: burn::backend::Backend> {
+    Dense(FloatTensor<B>),
+    Empty,
+}
+
+#[backend_extension(NdArray)]
+pub trait RtBackend: burn::backend::Backend {
+    /// Returns the active variant's tensor. Exercises enum-variant-dependent unwrapping.
+    fn pick(#[extension_type] op: Operand<Self>) -> FloatTensor<Self>;
+    /// Returns the bare tensor. When `op` is `Empty` the backend must be selected from `x`.
+    fn mix_pick(x: FloatTensor<Self>, #[extension_type] op: Operand<Self>) -> FloatTensor<Self>;
+}
+
+impl RtBackend for NdArray {
+    fn pick(op: Operand<Self>) -> FloatTensor<Self> {
+        match op {
+            Operand::Dense(x) => x,
+            Operand::Empty => {
+                unreachable!("Empty carries no tensor; the dispatch walk panics before calling")
+            }
+        }
+    }
+
+    fn mix_pick(x: FloatTensor<Self>, _op: Operand<Self>) -> FloatTensor<Self> {
+        x
+    }
+}
+
+fn device() -> Device {
+    Device::ndarray()
+}
+
+#[test]
+fn enum_input_runs_on_selected_backend() {
+    let d = device();
+    let t = Tensor::<1>::from_floats([1.0, 2.0, 3.0], &d);
+    let expected = t.clone().into_data();
+
+    let out = <Dispatch as RtBackend>::pick(Operand::Dense(t.into_dispatch()));
+    let out = Tensor::<1>::from_dispatch(out);
+
+    out.into_data().assert_eq(&expected, true);
+}
+
+#[test]
+fn mixed_input_selects_backend_from_bare_tensor_when_enum_is_tensorless() {
+    let d = device();
+    let x = Tensor::<1>::from_floats([4.0, 5.0], &d);
+    let expected = x.clone().into_data();
+
+    // The enum is `Empty` (no tensor), so the walk must select the backend from `x`.
+    let out = <Dispatch as RtBackend>::mix_pick(x.into_dispatch(), Operand::Empty);
+    let out = Tensor::<1>::from_dispatch(out);
+
+    out.into_data().assert_eq(&expected, true);
+}
+
+#[test]
+#[should_panic(expected = "no tensor input to select a backend from")]
+fn all_tensorless_input_panics() {
+    // The only input is a tensor-less enum variant, so the backend is unresolvable: the walk's
+    // `.expect(...)` fires. `pick`'s `NdArray` impl is never reached.
+    let _ = <Dispatch as RtBackend>::pick(Operand::Empty);
+}


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Closes #5222. This is the input-side counterpart of #5030, which added struct outputs and closed #4972.

### Changes

Backend extension ops could return a custom `#[derive(ExtensionType)]` struct but couldn't take one as an argument (an input struct was forwarded to the backend without being unwrapped, so it didn't type-check). This adds the input direction, for both structs and enums.

The `ExtensionType` trait (burn-core) gains `map_from_dispatch`, which rebuilds `Ty<B>` from the incoming `Ty<Dispatch>` and is the inverse of `map_to_dispatch`, plus `dispatch_repr` and `dispatch_float_repr`, which find a representative tensor to select the backend from.

`#[derive(ExtensionType)]` now works on any struct (named or tuple fields) and any enum (named, tuple, or unit variants), not just named-field structs. The four generated methods share one match-over-cases codegen. Existing output usage such as burn-vision's `ConnectedStatsPrimitive` is unchanged.

For dispatch, an argument marked `#[extension_type]` is unwrapped to the concrete backend before the call. A struct or enum has no top-level backend tag, so the backend is chosen by walking the inputs at runtime for a representative tensor, preferring a float (floats are the tensors that carry autodiff tracking and the checkpointing strategy). These inputs can be freely mixed with bare tensors and with each other, and you can pass several. An enum on a tensor-less variant contributes no representative, so the walk moves on to the next input; if nothing carries a tensor the op panics.

Struct and enum inputs also work with `Autodiff`. Float fields unwrap through the autodiff nesting into `FloatTensor<Autodiff<B>>` while int, bool, and quantized fields stay plain. The op's `impl ... for Autodiff<B>` still writes the backward pass by hand, the same as a bare-tensor autodiff op. A new `BackendTensor::into_autodiff` in burn-dispatch keeps the generated code readable.

Misusing `#[extension_type]` (on a tensor, a non-path type, or a type with more than one generic) now produces a clear compile error rather than an obscure trait error. While factoring out the shared output-wrap helper I also fixed a latent non-exhaustive match in the existing autodiff custom-output path.

Example:

```rust
#[derive(ExtensionType)]
pub enum Operand<B: Backend> {
    Dense(FloatTensor<B>),
    Sparse { values: FloatTensor<B>, indices: IntTensor<B> },
    Empty,
}

#[backend_extension(Wgpu)]
pub trait MyExt: Backend {
    fn run(#[extension_type] op: Operand<Self>, x: FloatTensor<Self>) -> FloatTensor<Self>;
}
```

### Testing

The compile-only tests in `backend_extension_remote.rs` (run with `--features remote`) cover struct inputs, a struct mixed with a bare tensor, multiple structs, tuple structs, enums with tensor/named/unit variants, a nested `#[extension_type]` struct, and the autodiff cfg gating. Each is routed to both concrete `Remote` and `Autodiff<Remote>`.

The executing tests in `backend_extension_runtime.rs` (run with `--features ndarray`) run the dispatch glue on the CPU `NdArray` backend: an enum input on a tensor variant, backend selection from a bare tensor when the enum is `Empty`, and the panic when the only input is tensor-less. One test also goes end to end through autodiff: a differentiable `x * y` op over a struct input with a hand-written `Backward`, checking that the forward result and the gradients that flow back into the struct's fields are correct.

`cargo check -p burn-vision` confirms the existing output derive still compiles.
