### PR TITLE
feat: support negative dimensions in statistics and norms

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/float/linalg/cosine_similarity.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/linalg/cosine_similarity.rs
@@ -76,7 +76,7 @@ fn test_cosine_similarity_different_dimension() {
         .assert_approx_eq::<FloatElem>(&expected, tolerance);
 
     // Test with negative dimension (-1 is the last dimension, which is 2 in this case)
-    linalg::cosine_similarity(x1.clone(), x2.clone(), -1, None)
+    linalg::cosine_similarity(x1.clone(), x2.clone(), -1_i64, None)
         .into_data()
         .assert_approx_eq::<FloatElem>(&expected, tolerance);
 }

--- a/crates/burn-backend-tests/tests/tensor/float/linalg/vector_norm.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/linalg/vector_norm.rs
@@ -234,3 +234,49 @@ fn test_normalize() {
     let output = linalg::vector_normalize(x.clone(), 1.0, 0, 5.0).into_data();
     output.assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
 }
+
+#[test]
+fn test_negative_dimension() {
+    let x = TestTensor::<2>::from([[1., 2.], [3., 4.]]);
+    let tolerance = Tolerance::default();
+
+    let expected = linalg::vector_norm(x.clone(), linalg::Norm::L2, 1).into_data();
+    linalg::vector_norm(x.clone(), linalg::Norm::L2, -1)
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, tolerance);
+
+    let expected = linalg::lp_norm(x.clone(), 3.0, 1).into_data();
+    linalg::lp_norm(x.clone(), 3.0, -1)
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, tolerance);
+
+    let expected = linalg::vector_normalize(x.clone(), 1.0, 1, 1e-8).into_data();
+    linalg::vector_normalize(x.clone(), 1.0, -1, 1e-8)
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, tolerance);
+
+    let expected = linalg::l0_norm(x.clone(), 1).into_data();
+    linalg::l0_norm(x.clone(), -1)
+        .into_data()
+        .assert_eq(&expected, true);
+
+    let expected = linalg::l1_norm(x.clone(), 1).into_data();
+    linalg::l1_norm(x.clone(), -1)
+        .into_data()
+        .assert_eq(&expected, true);
+
+    let expected = linalg::l2_norm(x.clone(), 1).into_data();
+    linalg::l2_norm(x.clone(), -1)
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, tolerance);
+
+    let expected = linalg::max_abs_norm(x.clone(), 1).into_data();
+    linalg::max_abs_norm(x.clone(), -1)
+        .into_data()
+        .assert_eq(&expected, true);
+
+    let expected = linalg::min_abs_norm(x.clone(), 1).into_data();
+    linalg::min_abs_norm(x, -1)
+        .into_data()
+        .assert_eq(&expected, true);
+}

--- a/crates/burn-backend-tests/tests/tensor/float/stats/cov.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/stats/cov.rs
@@ -64,3 +64,15 @@ fn test_cov_3() {
     let data_expected = TestTensor::<3>::zeros([4, 4, 4], &device).to_data();
     data_expected.assert_approx_eq::<FloatElem>(&data_actual, Tolerance::default());
 }
+
+#[test]
+fn test_cov_negative_dim() {
+    let data = TensorData::from([[0.5, 1.8, 0.2, -2.0], [3.0, -4.0, 5.0, 0.0]]);
+    let tensor = TestTensor::<2>::from_data(data, &Default::default());
+
+    let expected = tensor.clone().cov(1, 1).into_data();
+    tensor
+        .cov(-1, 1)
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
+}

--- a/crates/burn-backend-tests/tests/tensor/float/stats/median.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/stats/median.rs
@@ -90,3 +90,25 @@ fn test_median_all_elements() {
         .into_data()
         .assert_eq(&TensorData::from([0.5]), false);
 }
+
+#[test]
+fn test_median_negative_dim() {
+    let tensor =
+        TestTensor::<2>::from_data([[5.0, 1.0, 3.0], [2.0, 8.0, 4.0]], &Default::default());
+
+    let median = tensor.clone().median(1).into_data();
+    tensor
+        .clone()
+        .median(-1)
+        .into_data()
+        .assert_eq(&median, false);
+
+    let (values, indices) = tensor.clone().median_with_indices(1);
+    let (values_negative, indices_negative) = tensor.median_with_indices(-1);
+    values_negative
+        .into_data()
+        .assert_eq(&values.into_data(), false);
+    indices_negative
+        .into_data()
+        .assert_eq(&indices.into_data(), false);
+}

--- a/crates/burn-backend-tests/tests/tensor/float/stats/var.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/stats/var.rs
@@ -67,3 +67,43 @@ fn test_var_mean_bias() {
     mean.into_data()
         .assert_approx_eq::<FloatElem>(&mean_expected, Tolerance::default());
 }
+
+#[test]
+fn test_variance_negative_dim() {
+    let tensor = TestTensor::<2>::from_data(
+        [[0.5, 1.8, 0.2, -2.0], [3.0, -4.0, 5.0, 0.0]],
+        &Default::default(),
+    );
+
+    let var = tensor.clone().var(1).into_data();
+    tensor
+        .clone()
+        .var(-1)
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&var, Tolerance::default());
+
+    let var_bias = tensor.clone().var_bias(1).into_data();
+    tensor
+        .clone()
+        .var_bias(-1)
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&var_bias, Tolerance::default());
+
+    let (var, mean) = tensor.clone().var_mean(1);
+    let (var_negative, mean_negative) = tensor.clone().var_mean(-1);
+    var_negative
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&var.into_data(), Tolerance::default());
+    mean_negative
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&mean.into_data(), Tolerance::default());
+
+    let (var, mean) = tensor.clone().var_mean_bias(1);
+    let (var_negative, mean_negative) = tensor.var_mean_bias(-1);
+    var_negative
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&var.into_data(), Tolerance::default());
+    mean_negative
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&mean.into_data(), Tolerance::default());
+}

--- a/crates/burn-tensor/src/tensor/api/float.rs
+++ b/crates/burn-tensor/src/tensor/api/float.rs
@@ -148,24 +148,36 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     }
 
     /// Calculate the variance along the given dimension.
-    pub fn var(self, dim: usize) -> Self {
+    ///
+    /// Negative dimensions are supported and count from the end.
+    pub fn var<I: AsIndex>(self, dim: I) -> Self {
+        let dim = dim.expect_dim_index(D);
         stats::var(self, dim)
     }
 
     /// Calculate the variance along the given dimension without applying the Bessel’s correction.
-    pub fn var_bias(self, dim: usize) -> Self {
+    ///
+    /// Negative dimensions are supported and count from the end.
+    pub fn var_bias<I: AsIndex>(self, dim: I) -> Self {
+        let dim = dim.expect_dim_index(D);
         stats::var_bias(self, dim)
     }
 
     /// Calculate the variance along the given dimension and also returns the mean.
-    pub fn var_mean(self, dim: usize) -> (Self, Self) {
+    ///
+    /// Negative dimensions are supported and count from the end.
+    pub fn var_mean<I: AsIndex>(self, dim: I) -> (Self, Self) {
+        let dim = dim.expect_dim_index(D);
         let mean = self.clone().mean_dim(dim);
         let var = stats::var_with_mean(self, mean.clone(), dim);
         (var, mean)
     }
 
     /// Calculate the variance along the given dimension without applying the Bessel’s correction and also returns the mean.
-    pub fn var_mean_bias(self, dim: usize) -> (Self, Self) {
+    ///
+    /// Negative dimensions are supported and count from the end.
+    pub fn var_mean_bias<I: AsIndex>(self, dim: I) -> (Self, Self) {
+        let dim = dim.expect_dim_index(D);
         let mean = self.clone().mean_dim(dim);
         let var = stats::var_with_mean_bias(self, mean.clone(), dim);
         (var, mean)
@@ -187,6 +199,7 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     /// # Arguments
     ///
     /// - `dim` - The dimension along which to compute the median.
+    ///   Negative dimensions are supported and count from the end.
     ///
     /// # Returns
     ///
@@ -224,7 +237,8 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     /// let median = flattened_tensor.median(0);
     /// // Result: [4.0]
     /// ```
-    pub fn median(self, dim: usize) -> Self {
+    pub fn median<I: AsIndex>(self, dim: I) -> Self {
+        let dim = dim.expect_dim_index(D);
         // TODO: Allow backend specialization. Optimally, implement a median kernel for cubecl
         // instead of leveraging a full sort to get the median.
         stats::median(self, dim)
@@ -246,6 +260,7 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     /// # Arguments
     ///
     /// - `dim` - The dimension along which to compute the median.
+    ///   Negative dimensions are supported and count from the end.
     ///
     /// # Returns
     ///
@@ -267,7 +282,8 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     /// let (values, indices) = tensor.median_with_indices(1);
     /// // values: [[2.0], [6.0]], indices: [[3], [2]] (position in the original tensor)
     /// ```
-    pub fn median_with_indices(self, dim: usize) -> (Self, Tensor<D, Int>) {
+    pub fn median_with_indices<I: AsIndex>(self, dim: I) -> (Self, Tensor<D, Int>) {
+        let dim = dim.expect_dim_index(D);
         // TODO: Allow backend specialization. Optimally, implement a median kernel for cubecl
         // instead of leveraging a full sort to get the median.
         stats::median_with_indices(self, dim)
@@ -339,9 +355,11 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     ///
     /// # Arguments
     ///
-    /// * `size` - The size of the square matrix.
+    /// * `dim` - The dimension along which to calculate the covariance.
+    ///   Negative dimensions are supported and count from the end.
     /// * `correction_factor` - Is usually 1 for samples and 0 for population.
-    pub fn cov(self, dim: usize, correction_factor: usize) -> Tensor<D> {
+    pub fn cov<I: AsIndex>(self, dim: I, correction_factor: usize) -> Tensor<D> {
+        let dim = dim.expect_dim_index(D);
         let n = self.dims()[dim];
         let centered = (self.clone() - self.mean_dim(dim)).swap_dims(dim, 0);
         centered

--- a/crates/burn-tensor/src/tensor/linalg/cosine_similarity.rs
+++ b/crates/burn-tensor/src/tensor/linalg/cosine_similarity.rs
@@ -1,8 +1,8 @@
 use burn_std::FloatDType;
 
-use crate::tensor::Tensor;
+use crate::{AsIndex, tensor::Tensor};
 
-use super::l2_norm;
+use super::vector_norm::l2_norm_impl;
 
 /// Computes the cosine similarity between two tensors along a specified dimension.
 ///
@@ -13,8 +13,8 @@ use super::l2_norm;
 ///
 /// * `x1` - First input tensor
 /// * `x2` - Second input tensor
-/// * `dim` - Dimension along which to compute the similarity
-///   (negative indices allowed: -1 for last dimension)
+/// * `dim` - Dimension along which to compute the similarity.
+///   Negative dimensions are supported and count from the end.
 /// * `eps` - Small value to avoid division by zero (default: dtype's smallest positive normal)
 ///
 /// # Returns
@@ -23,9 +23,10 @@ use super::l2_norm;
 pub fn cosine_similarity<const D: usize>(
     x1: Tensor<D>,
     x2: Tensor<D>,
-    dim: i32,
+    dim: impl AsIndex,
     eps: Option<f64>,
 ) -> Tensor<D> {
+    let dim = dim.expect_dim_index(D);
     let eps = eps.unwrap_or_else(|| {
         x1.dtype()
             .finfo()
@@ -33,15 +34,12 @@ pub fn cosine_similarity<const D: usize>(
             .min_positive
     });
 
-    // Convert negative dimension to positive
-    let dim_idx = if dim < 0 { D as i32 + dim } else { dim } as usize;
-
     // Compute dot product: sum(x1 * x2) along the specified dimension
-    let dot_product = (x1.clone() * x2.clone()).sum_dim(dim_idx);
+    let dot_product = (x1.clone() * x2.clone()).sum_dim(dim);
 
     // Compute L2 norms: ||x1|| and ||x2||
-    let norm_x1 = l2_norm(x1, dim_idx);
-    let norm_x2 = l2_norm(x2, dim_idx);
+    let norm_x1 = l2_norm_impl(x1, dim);
+    let norm_x2 = l2_norm_impl(x2, dim);
 
     // Calculate the denominator (product of the norms) with epsilon to avoid division by zero
     let denominator = norm_x1.clamp_min(eps) * norm_x2.clamp_min(eps);

--- a/crates/burn-tensor/src/tensor/linalg/vector_norm.rs
+++ b/crates/burn-tensor/src/tensor/linalg/vector_norm.rs
@@ -1,6 +1,6 @@
 use crate::tensor::Tensor;
 use crate::{
-    ElementConversion,
+    AsIndex, ElementConversion,
     kind::{Numeric, Ordered},
 };
 #[allow(unused_imports)]
@@ -110,12 +110,18 @@ impl From<f64> for Norm {
 /// * `x` - The input tensor.
 /// * `norm` - The selected norm.
 /// * `dim` - The dimension to compute the norm over.
+///   Negative dimensions are supported and count from the end.
 ///
 /// # Returns
 ///
 /// The vector norm of the input tensor.
-pub fn vector_norm<const D: usize>(x: Tensor<D>, norm: impl Into<Norm>, dim: usize) -> Tensor<D> {
-    lp_norm(x, norm.into().to_exponent(), dim)
+pub fn vector_norm<const D: usize>(
+    x: Tensor<D>,
+    norm: impl Into<Norm>,
+    dim: impl AsIndex,
+) -> Tensor<D> {
+    let dim = dim.expect_dim_index(D);
+    lp_norm_impl(x, norm.into().to_exponent(), dim)
 }
 
 /// Computes the general ``L(p)`` norm of a tensor along a specified dimension.
@@ -133,18 +139,24 @@ pub fn vector_norm<const D: usize>(x: Tensor<D>, norm: impl Into<Norm>, dim: usi
 /// * `x` - The input tensor.
 /// * `p` - The exponent of the Lp norm.
 /// * `dim` - The dimension to compute the norm over.
+///   Negative dimensions are supported and count from the end.
 ///
 /// # Returns
 ///
 /// The ``L(p)`` norm of the input tensor.
-pub fn lp_norm<const D: usize>(x: Tensor<D>, p: f64, dim: usize) -> Tensor<D> {
+pub fn lp_norm<const D: usize>(x: Tensor<D>, p: f64, dim: impl AsIndex) -> Tensor<D> {
+    let dim = dim.expect_dim_index(D);
+    lp_norm_impl(x, p, dim)
+}
+
+fn lp_norm_impl<const D: usize>(x: Tensor<D>, p: f64, dim: usize) -> Tensor<D> {
     match p {
-        0.0 => l0_norm(x, dim),
-        1.0 => l1_norm(x, dim),
-        2.0 => l2_norm(x, dim),
+        0.0 => l0_norm_impl(x, dim),
+        1.0 => l1_norm_impl(x, dim),
+        2.0 => l2_norm_impl(x, dim),
         p if is_even_integer(p) => lp_signed_norm(x, p as u32, dim),
-        f64::INFINITY => max_abs_norm(x, dim),
-        f64::NEG_INFINITY => min_abs_norm(x, dim),
+        f64::INFINITY => max_abs_norm_impl(x, dim),
+        f64::NEG_INFINITY => min_abs_norm_impl(x, dim),
         _ => lp_norm_base(x, p, dim),
     }
 }
@@ -158,6 +170,7 @@ pub fn lp_norm<const D: usize>(x: Tensor<D>, p: f64, dim: usize) -> Tensor<D> {
 /// * `x` - The input tensor.
 /// * `norm` - The selected norm.
 /// * `dim` - The dimension to compute the norm over.
+///   Negative dimensions are supported and count from the end.
 /// * `eps` - The epsilon for the norm.
 ///
 /// # Returns
@@ -166,10 +179,11 @@ pub fn lp_norm<const D: usize>(x: Tensor<D>, p: f64, dim: usize) -> Tensor<D> {
 pub fn vector_normalize<const D: usize, E: ElementConversion>(
     x: Tensor<D>,
     norm: impl Into<Norm>,
-    dim: usize,
+    dim: impl AsIndex,
     eps: E,
 ) -> Tensor<D> {
-    let norm = vector_norm(x.clone(), norm, dim).clamp_min(eps);
+    let dim = dim.expect_dim_index(D);
+    let norm = lp_norm_impl(x.clone(), norm.into().to_exponent(), dim).clamp_min(eps);
     x / norm
 }
 
@@ -179,11 +193,20 @@ pub fn vector_normalize<const D: usize, E: ElementConversion>(
 ///
 /// * `x` - The input tensor.
 /// * `dim` - The dimension to compute the norm over.
+///   Negative dimensions are supported and count from the end.
 ///
 /// # Returns
 ///
 /// The L0 norm of the input tensor.
-pub fn l0_norm<const D: usize, K>(x: Tensor<D, K>, dim: usize) -> Tensor<D, K>
+pub fn l0_norm<const D: usize, K>(x: Tensor<D, K>, dim: impl AsIndex) -> Tensor<D, K>
+where
+    K: Numeric,
+{
+    let dim = dim.expect_dim_index(D);
+    l0_norm_impl(x, dim)
+}
+
+fn l0_norm_impl<const D: usize, K>(x: Tensor<D, K>, dim: usize) -> Tensor<D, K>
 where
     K: Numeric,
 {
@@ -200,11 +223,20 @@ where
 ///
 /// * `x` - The input tensor.
 /// * `dim` - The dimension to compute the norm over.
+///   Negative dimensions are supported and count from the end.
 ///
 /// # Returns
 ///
 /// The L1 norm of the input tensor.
-pub fn l1_norm<const D: usize, K>(x: Tensor<D, K>, dim: usize) -> Tensor<D, K>
+pub fn l1_norm<const D: usize, K>(x: Tensor<D, K>, dim: impl AsIndex) -> Tensor<D, K>
+where
+    K: Numeric,
+{
+    let dim = dim.expect_dim_index(D);
+    l1_norm_impl(x, dim)
+}
+
+fn l1_norm_impl<const D: usize, K>(x: Tensor<D, K>, dim: usize) -> Tensor<D, K>
 where
     K: Numeric,
 {
@@ -217,11 +249,17 @@ where
 ///
 /// * `x` - The input tensor.
 /// * `dim` - The dimension to compute the norm over.
+///   Negative dimensions are supported and count from the end.
 ///
 /// # Returns
 ///
 /// The L2 norm of the input tensor.
-pub fn l2_norm<const D: usize>(x: Tensor<D>, dim: usize) -> Tensor<D> {
+pub fn l2_norm<const D: usize>(x: Tensor<D>, dim: impl AsIndex) -> Tensor<D> {
+    let dim = dim.expect_dim_index(D);
+    l2_norm_impl(x, dim)
+}
+
+pub(super) fn l2_norm_impl<const D: usize>(x: Tensor<D>, dim: usize) -> Tensor<D> {
     x.square().sum_dim(dim).sqrt()
 }
 
@@ -252,11 +290,20 @@ fn lp_norm_base<const D: usize>(x: Tensor<D>, p: f64, dim: usize) -> Tensor<D> {
 ///
 /// * `x` - The input tensor.
 /// * `dim` - The dimension to compute the norm over.
+///   Negative dimensions are supported and count from the end.
 ///
 /// # Returns
 ///
 /// The L:INFINITY norm of the input tensor.
-pub fn max_abs_norm<const D: usize, K>(x: Tensor<D, K>, dim: usize) -> Tensor<D, K>
+pub fn max_abs_norm<const D: usize, K>(x: Tensor<D, K>, dim: impl AsIndex) -> Tensor<D, K>
+where
+    K: Ordered,
+{
+    let dim = dim.expect_dim_index(D);
+    max_abs_norm_impl(x, dim)
+}
+
+fn max_abs_norm_impl<const D: usize, K>(x: Tensor<D, K>, dim: usize) -> Tensor<D, K>
 where
     K: Ordered,
 {
@@ -269,11 +316,20 @@ where
 ///
 /// * `x` - The input tensor.
 /// * `dim` - The dimension to compute the norm over.
+///   Negative dimensions are supported and count from the end.
 ///
 /// # Returns
 ///
 /// The L:NEG_INFINITY norm of the input tensor.
-pub fn min_abs_norm<const D: usize, K>(x: Tensor<D, K>, dim: usize) -> Tensor<D, K>
+pub fn min_abs_norm<const D: usize, K>(x: Tensor<D, K>, dim: impl AsIndex) -> Tensor<D, K>
+where
+    K: Ordered,
+{
+    let dim = dim.expect_dim_index(D);
+    min_abs_norm_impl(x, dim)
+}
+
+fn min_abs_norm_impl<const D: usize, K>(x: Tensor<D, K>, dim: usize) -> Tensor<D, K>
 where
     K: Ordered,
 {


### PR DESCRIPTION
## Motivation

Burn increasingly supports negative dimension indexing, but statistics and vector norm APIs still required `usize` dimensions. This made common last-axis calls such as `dim = -1` inconsistent with the rest of the tensor API.

The free cosine similarity helper also used a separate `i32` conversion path. Using `AsIndex` consistently provides checked normalization at the public API boundary while keeping internal and backend dimensions as `usize`. 

## Modifications

- Changed `var`, `var_bias`, `var_mean`, `var_mean_bias`, `median`, `median_with_indices`, and `cov` to accept `AsIndex` dimensions.
- Changed `vector_norm`, `lp_norm`, `vector_normalize`, `l0_norm`, `l1_norm`, `l2_norm`, `max_abs_norm`, and `min_abs_norm` to accept `AsIndex` dimensions.
- Standardized the free `cosine_similarity` helper on checked `AsIndex` normalization.
- Kept canonical `usize` dimensions in private helpers and lower layers.
- Documented negative dimension support and added regression coverage for `dim = -1`.

