### PR TITLE
feat(tensor): support negative dimensions

### DIFF
--- a/crates/burn-backend-tests/tests/cubecl/reduce.rs
+++ b/crates/burn-backend-tests/tests/cubecl/reduce.rs
@@ -27,7 +27,7 @@ fn reduction_argtopk_simple() {
     let device = Default::default();
 
     let tensor = TestTensor::<2>::from_data([[1, 7, 3], [8, 2, 8]], &device);
-    let actual = tensor.argtopk(2, 1);
+    let actual = tensor.argtopk(2, -1_i64);
     let expected = TestTensor::<2>::from_data([[1, 2], [0, 2]], &device);
 
     let output_shape = Shape::new([2, 2]);

--- a/crates/burn-backend-tests/tests/tensor/bool/ops/flip.rs
+++ b/crates/burn-backend-tests/tests/tensor/bool/ops/flip.rs
@@ -28,6 +28,6 @@ fn flip_bool() {
     flipped.into_data().assert_eq(&data_expected, false);
 
     // Test with no flip
-    let flipped = tensor.clone().flip([]);
+    let flipped = tensor.clone().flip([] as [isize; 0]);
     tensor.into_data().assert_eq(&flipped.into_data(), false);
 }

--- a/crates/burn-backend-tests/tests/tensor/float/ops/arg.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/arg.rs
@@ -48,6 +48,29 @@ fn test_argmin_2d_dim1() {
 }
 
 #[test]
+fn test_argmax_and_argmin_support_negative_dims() {
+    let tensor = TestTensor::<2>::from([[10.0, 11.0, 2.0], [30.0, 4.0, 5.0]]);
+
+    let output = tensor.clone().argmax(-1_i64);
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([[1], [0]]), false);
+
+    let output = tensor.argmin(-1_isize);
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([[2], [1]]), false);
+}
+
+#[test]
+#[should_panic]
+fn test_argmax_should_panic_when_negative_dim_is_out_of_bounds() {
+    let tensor = TestTensor::<2>::from([[10.0, 11.0, 2.0], [3.0, 4.0, 5.0]]);
+
+    let _ = tensor.argmax(-3_i64);
+}
+
+#[test]
 fn test_argmax_flipped() {
     // Flip [1, 5, 3, 2, 4] -> [4, 2, 3, 5, 1]; max is at index 3.
     let tensor = TestTensor::<1>::from([1.0, 5.0, 3.0, 2.0, 4.0]);

--- a/crates/burn-backend-tests/tests/tensor/float/ops/flip.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/flip.rs
@@ -23,7 +23,7 @@ fn flip_float() {
     flipped.into_data().assert_eq(&expected, false);
 
     // Test with no flip
-    let flipped = tensor.clone().flip([]);
+    let flipped = tensor.clone().flip([] as [isize; 0]);
     tensor.into_data().assert_eq(&flipped.into_data(), false);
 }
 

--- a/crates/burn-backend-tests/tests/tensor/float/ops/mod.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/mod.rs
@@ -100,6 +100,7 @@ mod mul;
 mod nan;
 mod narrow;
 mod neg;
+mod negative_dims;
 mod one_hot;
 mod padding;
 mod permute;

--- a/crates/burn-backend-tests/tests/tensor/float/ops/negative_dims.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/negative_dims.rs
@@ -1,0 +1,163 @@
+use super::*;
+use burn_tensor::IndexingUpdateOp;
+
+#[test]
+fn shape_operations_support_negative_dims() {
+    let device = Default::default();
+    let tensor = TestTensor::<4>::ones([2, 1, 3, 1], &device);
+
+    let expected: TestTensor<3> = tensor.clone().squeeze_dim(1);
+    let actual: TestTensor<3> = tensor.clone().squeeze_dim(-3_i64);
+    actual.into_data().assert_eq(&expected.into_data(), false);
+
+    let expected: TestTensor<2> = tensor.clone().squeeze_dims(&[1, 3]);
+    let actual: TestTensor<2> = tensor.squeeze_dims(&[-3_i64, -1]);
+    actual.into_data().assert_eq(&expected.into_data(), false);
+
+    let tensor = TestTensor::<2>::from_data([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], &device);
+
+    let expected: TestTensor<3> = tensor.clone().unsqueeze_dim(2);
+    let actual: TestTensor<3> = tensor.clone().unsqueeze_dim(-1_i64);
+    actual.into_data().assert_eq(&expected.into_data(), false);
+
+    let expected: TestTensor<3> = tensor.clone().unsqueeze_dim(0);
+    let actual: TestTensor<3> = tensor.unsqueeze_dim(-3_i64);
+    actual.into_data().assert_eq(&expected.into_data(), false);
+
+    // The insertion domain is based on the input rank even when the requested
+    // output rank adds more than one singleton dimension.
+    let tensor = TestTensor::<2>::from_data([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], &device);
+    let expected: TestTensor<4> = tensor.clone().unsqueeze_dim(2);
+    let actual: TestTensor<4> = tensor.clone().unsqueeze_dim(-1_i64);
+    actual.into_data().assert_eq(&expected.into_data(), false);
+
+    let expected: TestTensor<4> = tensor.clone().unsqueeze_dim(1);
+    let actual: TestTensor<4> = tensor.unsqueeze_dim(-2_i64);
+    actual.into_data().assert_eq(&expected.into_data(), false);
+}
+
+#[test]
+fn flip_and_movedim_support_all_index_types() {
+    let device = Default::default();
+    let tensor = TestTensorInt::<1>::arange(0..24, &device)
+        .reshape([2, 3, 4])
+        .float();
+
+    let expected = tensor.clone().flip([0, 2]);
+    let actual = tensor.clone().flip([-3_i64, -1]);
+    actual.into_data().assert_eq(&expected.into_data(), false);
+
+    let expected = tensor.clone().movedim(0, 2);
+    let actual = tensor.clone().movedim(0_u8, -1_i16);
+    actual.into_data().assert_eq(&expected.into_data(), false);
+
+    let expected = tensor.clone().movedim(vec![0, 1], vec![1, 0]);
+    let actual = tensor.movedim(vec![-3_i64, -2], vec![-2_i64, -3]);
+    actual.into_data().assert_eq(&expected.into_data(), false);
+}
+
+#[test]
+fn indexing_operations_support_negative_dims() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::from_data([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]], &device);
+
+    let expected = tensor.clone().slice_dim(1, 1..);
+    let actual = tensor.clone().slice_dim(-1_i64, 1..);
+    actual.into_data().assert_eq(&expected.into_data(), false);
+
+    let indices = TestTensorInt::from_ints([[2, 1, 0], [0, 2, 1]], &device);
+    let expected = tensor.clone().gather(1, indices.clone());
+    let actual = tensor.clone().gather(-1_i64, indices);
+    actual.into_data().assert_eq(&expected.into_data(), false);
+
+    let values = TestTensor::from_data([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], &device);
+    let indices = TestTensorInt::from_ints([[1, 0, 2], [1, 2, 0]], &device);
+    let base = TestTensor::<2>::zeros([2, 3], &device);
+    let expected = base
+        .clone()
+        .scatter(1, indices.clone(), values.clone(), IndexingUpdateOp::Add);
+    let actual = base.scatter(-1_i64, indices, values, IndexingUpdateOp::Add);
+    actual.into_data().assert_eq(&expected.into_data(), false);
+}
+
+#[test]
+fn concatenation_and_repeat_support_negative_dims() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::from_data([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], &device);
+
+    let expected = tensor.clone().repeat_dim(1, 2);
+    let actual = tensor.clone().repeat_dim(-1_i64, 2);
+    actual.into_data().assert_eq(&expected.into_data(), false);
+
+    let other = TestTensor::<2>::from_data([[7.0], [8.0]], &device);
+    let expected = TestTensor::cat(vec![tensor.clone(), other.clone()], 1);
+    let actual = TestTensor::cat(vec![tensor.clone(), other], -1_i64);
+    actual.into_data().assert_eq(&expected.into_data(), false);
+
+    let expected: TestTensor<3> = TestTensor::stack(vec![tensor.clone(), tensor.clone()], 2);
+    let actual: TestTensor<3> = TestTensor::stack(vec![tensor.clone(), tensor.clone()], -1_i64);
+    actual.into_data().assert_eq(&expected.into_data(), false);
+
+    let expected: TestTensor<3> = TestTensor::stack(vec![tensor.clone(), tensor.clone()], 0);
+    let actual: TestTensor<3> = TestTensor::stack(vec![tensor.clone(), tensor.clone()], -3_i64);
+    actual.into_data().assert_eq(&expected.into_data(), false);
+
+    let expected: TestTensor<4> = TestTensor::stack(vec![tensor.clone(), tensor.clone()], 2);
+    let actual: TestTensor<4> = TestTensor::stack(vec![tensor.clone(), tensor.clone()], -1_i64);
+    actual.into_data().assert_eq(&expected.into_data(), false);
+
+    let expected: TestTensor<4> = TestTensor::stack(vec![tensor.clone(), tensor.clone()], 1);
+    let actual: TestTensor<4> = TestTensor::stack(vec![tensor.clone(), tensor], -2_i64);
+    actual.into_data().assert_eq(&expected.into_data(), false);
+}
+
+#[test]
+fn partition_operations_support_negative_dims() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::from_data([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]], &device);
+
+    let expected = tensor.clone().narrow(1, 1, 2);
+    let actual = tensor.clone().narrow(-1_i64, 1, 2);
+    actual.into_data().assert_eq(&expected.into_data(), false);
+
+    let expected = tensor.clone().chunk(2, 1);
+    let actual = tensor.clone().chunk(2, -1_i64);
+    assert_eq!(actual.len(), expected.len());
+    for (actual, expected) in actual.into_iter().zip(expected) {
+        actual.into_data().assert_eq(&expected.into_data(), false);
+    }
+
+    let expected = tensor.clone().split(2, 1);
+    let actual = tensor.clone().split(2, -1_i64);
+    assert_eq!(actual.len(), expected.len());
+    for (actual, expected) in actual.into_iter().zip(expected) {
+        actual.into_data().assert_eq(&expected.into_data(), false);
+    }
+
+    let expected = tensor.clone().split_with_sizes(vec![1, 2], 1);
+    let actual = tensor.split_with_sizes(vec![1, 2], -1_i64);
+    assert_eq!(actual.len(), expected.len());
+    for (actual, expected) in actual.into_iter().zip(expected) {
+        actual.into_data().assert_eq(&expected.into_data(), false);
+    }
+}
+
+#[test]
+fn iteration_and_boolean_reductions_support_negative_dims() {
+    let tensor = TestTensor::<2>::from([[0.0, 1.0, 0.0], [1.0, -1.0, 1.0]]);
+
+    let expected = tensor.clone().iter_dim(1).collect::<Vec<_>>();
+    let actual = tensor.clone().iter_dim(-1_i64).collect::<Vec<_>>();
+    assert_eq!(actual.len(), expected.len());
+    for (actual, expected) in actual.into_iter().zip(expected) {
+        actual.into_data().assert_eq(&expected.into_data(), false);
+    }
+
+    let expected = tensor.clone().any_dim(1);
+    let actual = tensor.clone().any_dim(-1_i64);
+    actual.into_data().assert_eq(&expected.into_data(), false);
+
+    let expected = tensor.clone().all_dim(1);
+    let actual = tensor.all_dim(-1_i64);
+    actual.into_data().assert_eq(&expected.into_data(), false);
+}

--- a/crates/burn-backend-tests/tests/tensor/float/ops/one_hot.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/one_hot.rs
@@ -43,9 +43,19 @@ fn one_hot_fill_with_negative_axis_and_indices() {
         [[0.0, 5.0, 0.0], [0.0, 0.0, 5.0]],
     ]);
 
-    let one_hot_tensor: TestTensor<3> = tensor.one_hot_fill(3, 5.0, 0.0, -1);
+    let one_hot_tensor: TestTensor<3> = tensor.one_hot_fill(3, 5.0, 0.0, -1_isize);
 
     one_hot_tensor.into_data().assert_eq(&expected, false);
+}
+
+#[test]
+fn one_hot_fill_with_negative_axis_at_start() {
+    let tensor = TestTensor::<2>::from([[0, 1], [1, 0]]);
+
+    let expected: TestTensor<3> = tensor.clone().one_hot_fill(2, 1.0, 0.0, 0);
+    let actual: TestTensor<3> = tensor.one_hot_fill(2, 1.0, 0.0, -3_i8);
+
+    actual.into_data().assert_eq(&expected.into_data(), false);
 }
 
 #[test]
@@ -68,4 +78,12 @@ fn one_hot_fill_should_panic_when_axis_out_range_of_rank() {
     let tensor = TestTensor::<2>::from([[0.0, 2.0], [1.0, -1.0]]);
 
     let _one_hot_tensor: TestTensor<3> = tensor.one_hot_fill(2, 5.0, 0.0, 3);
+}
+
+#[should_panic]
+#[test]
+fn one_hot_fill_should_panic_when_negative_axis_out_range_of_rank() {
+    let tensor = TestTensor::<2>::from([[0.0, 2.0], [1.0, -1.0]]);
+
+    let _one_hot_tensor: TestTensor<3> = tensor.one_hot_fill(2, 5.0, 0.0, -4_i64);
 }

--- a/crates/burn-backend-tests/tests/tensor/float/ops/slice.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/slice.rs
@@ -21,7 +21,7 @@ fn should_support_slice_dim_1d() {
 }
 
 #[test]
-#[should_panic(expected = "The provided dimension exceeds the tensor dimensions")]
+#[should_panic(expected = "Index { kind: Dimension, index: 1, bounds: 0..1 }")]
 fn should_panic_when_slice_dim_1d_bad_dim() {
     let data = TensorData::from([0.0, 1.0, 2.0]);
     let tensor = TestTensor::<1>::from_data(data.clone(), &Default::default());

--- a/crates/burn-backend-tests/tests/tensor/float/ops/split.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/split.rs
@@ -105,7 +105,7 @@ fn test_split_with_zero_split_size_non_zero_tensor() {
 }
 
 #[test]
-#[should_panic(expected = "Given dimension is greater than or equal to the tensor rank.")]
+#[should_panic(expected = "Index { kind: Dimension, index: 2, bounds: 0..1 }")]
 fn test_split_invalid_dim() {
     let device = Default::default();
     let tensors = TestTensor::<1>::from_data([0, 1, 2], &device);

--- a/crates/burn-backend-tests/tests/tensor/float/ops/squeeze.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/squeeze.rs
@@ -46,7 +46,7 @@ fn should_squeeze_panic() {
 #[test]
 fn should_squeeze_dims_with_empty_slice() {
     let tensor = TestTensor::<3>::ones(Shape::new([1, 1, 3]), &Default::default());
-    let squeezed_tensor: TestTensor<1> = tensor.squeeze_dims(&[]);
+    let squeezed_tensor: TestTensor<1> = tensor.squeeze_dims(&[] as &[isize]);
     let expected_shape = Shape::new([3]);
     assert_eq!(squeezed_tensor.shape(), expected_shape);
 }

--- a/crates/burn-backend-tests/tests/tensor/float/quantization/ops/extended/flip.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/quantization/ops/extended/flip.rs
@@ -16,7 +16,7 @@ fn flip_float() {
         .assert_approx_eq::<FloatElem>(&expected, Tolerance::absolute(1e-1));
 
     // Test with no flip
-    let flipped = tensor.clone().flip([]);
+    let flipped = tensor.clone().flip([] as [isize; 0]);
     tensor.into_data().assert_eq(&flipped.into_data(), true);
 }
 

--- a/crates/burn-backend-tests/tests/tensor/float/quantization/ops/extended/split.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/quantization/ops/extended/split.rs
@@ -95,7 +95,7 @@ fn test_split_with_zero_split_size_non_zero_tensor() {
 }
 
 #[test]
-#[should_panic(expected = "Given dimension is greater than or equal to the tensor rank.")]
+#[should_panic(expected = "Index { kind: Dimension, index: 2, bounds: 0..1 }")]
 fn test_split_invalid_dim() {
     let tensor = QTensor::<1>::int8([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]);
 

--- a/crates/burn-backend-tests/tests/tensor/int/ops/flip.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/flip.rs
@@ -17,6 +17,6 @@ fn flip_int() {
     flipped.into_data().assert_eq(&expected, false);
 
     // Test with no flip
-    let flipped = tensor.clone().flip([]);
+    let flipped = tensor.clone().flip([] as [isize; 0]);
     assert_eq!(tensor.into_data(), flipped.into_data());
 }

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -534,6 +534,7 @@ where
     ///   The values can be negative, in which case they are used as an offset from the end.
     ///
     /// * `dst` - Destination positions for each of the original dims. These must also be unique.
+    ///   Negative dimensions are counted from the end.
     ///
     /// # Panics
     ///
@@ -637,15 +638,11 @@ where
     ///     println!("{flipped}");
     /// }
     /// ```
-    pub fn flip<const N: usize>(self, axes: [isize; N]) -> Tensor<D, K> {
-        // Convert the axes to usize and handle negative values without using vector
+    pub fn flip<const N: usize>(self, axes: [impl AsIndex; N]) -> Tensor<D, K> {
+        // Convert the axes to usize without allocating.
         let mut transformed_axes: [usize; N] = [0; N];
-        for (i, &x) in axes.iter().enumerate() {
-            transformed_axes[i] = if x < 0 {
-                (D as isize + x) as usize
-            } else {
-                x as usize
-            };
+        for (i, axis) in axes.into_iter().enumerate() {
+            transformed_axes[i] = axis.expect_dim_index(D);
         }
 
         // Check if the axes are valid
@@ -751,7 +748,7 @@ where
     ///
     /// # Arguments
     ///
-    /// - `dim`: The dimension to be squeezed.
+    /// - `dim`: The dimension to be squeezed. Supports negative indexing.
     ///
     /// # Type Parameters
     ///
@@ -785,7 +782,8 @@ where
     ///     println!("{squeezed}");
     /// }
     /// ```
-    pub fn squeeze_dim<const D2: usize>(self, dim: usize) -> Tensor<D2, K> {
+    pub fn squeeze_dim<const D2: usize>(self, dim: impl AsIndex) -> Tensor<D2, K> {
+        let dim = dim.expect_dim_index(D);
         check!(TensorCheck::squeeze::<D2>(dim, &self.shape()));
 
         let current_dims = self.shape();
@@ -834,7 +832,7 @@ where
     ///     println!("{squeezed}");
     /// }
     /// ```
-    pub fn squeeze_dims<const D2: usize>(self, dims: &[isize]) -> Tensor<D2, K> {
+    pub fn squeeze_dims<const D2: usize>(self, dims: &[impl AsIndex]) -> Tensor<D2, K> {
         let current_dims = self.shape();
         let mut dim_indices: Vec<usize>;
 
@@ -846,17 +844,7 @@ where
                 .filter_map(|(index, &dim)| if dim == 1 { Some(index) } else { None })
                 .collect();
         } else {
-            // If negative dims, count from the back
-            dim_indices = dims
-                .iter()
-                .map(|&d| {
-                    if d < 0 {
-                        (current_dims.len() as isize + d) as usize
-                    } else {
-                        d as usize
-                    }
-                })
-                .collect();
+            dim_indices = dims.iter().map(|dim| dim.expect_dim_index(D)).collect();
         }
 
         // Sort indices and remove duplicates
@@ -930,6 +918,8 @@ where
 
     /// Creates a new tensor with a dimension of size one inserted at the specified position.
     ///
+    /// Negative dimensions are counted from the end of the valid insertion positions.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -945,7 +935,8 @@ where
     ///     println!("{unsqueezed}");
     /// }
     /// ```
-    pub fn unsqueeze_dim<const D2: usize>(self, dim: usize) -> Tensor<D2, K> {
+    pub fn unsqueeze_dim<const D2: usize>(self, dim: impl AsIndex) -> Tensor<D2, K> {
+        let dim = dim.expect_dim_index(D + 1);
         check!(TensorCheck::unsqueeze_dim::<D, D2>(dim));
 
         let mut dims = [1; D2];
@@ -955,7 +946,7 @@ where
 
         if dim < D {
             dims[dim] = 1;
-            dims[(dim + 1)..].copy_from_slice(&shape[dim..]);
+            dims[(dim + 1)..(D + 1)].copy_from_slice(&shape[dim..]);
         } else {
             dims[dim] = 1;
         }
@@ -1516,7 +1507,7 @@ where
     ///
     /// # Arguments
     ///
-    /// * `dim`: The dimension to slice.
+    /// * `dim`: The dimension to slice. Supports negative indexing.
     /// * `slice`: The slice specification for the dimension. Can be a range (e.g., `2..5`),
     ///   slice with step (via `s!` macro, e.g., `s![0..10;2]`), or any type that implements `Into<Slice>`.
     ///
@@ -1565,11 +1556,11 @@ where
     /// - [`s!`] - The macro for creating complex slice specifications
     ///
     /// [`s!`]: crate::s!
-    pub fn slice_dim<S>(self, dim: usize, slice: S) -> Self
+    pub fn slice_dim<S>(self, dim: impl AsIndex, slice: S) -> Self
     where
         S: Into<Slice>,
     {
-        check!(TensorCheck::check_dim::<D>(dim));
+        let dim = dim.expect_dim_index(D);
         let slice: Slice = slice.into();
 
         let mut slices = vec![Slice::full(); D];
@@ -1717,6 +1708,7 @@ where
     }
 
     /// Gather tensor elements corresponding to the given indices from the specified dim.
+    /// The dimension supports negative indexing.
     ///
     /// Example using a 3D tensor:
     ///
@@ -1732,7 +1724,8 @@ where
     /// # Warning
     /// Not all backends have runtime bound checks for the indices, so make sure the they are valid.
     /// Otherwise, out of bounds indices could lead to unexpected results instead of panicking.
-    pub fn gather(self, dim: usize, indices: Tensor<D, Int>) -> Self {
+    pub fn gather(self, dim: impl AsIndex, indices: Tensor<D, Int>) -> Self {
+        let dim = dim.expect_dim_index(D);
         check!(TensorCheck::gather::<D>(
             dim,
             &self.shape(),
@@ -1752,7 +1745,7 @@ where
     /// `input[i, j, indices[i, j, k]] += values[i, j, k]; // dim = 2`
     ///
     /// # Arguments
-    /// * `dim` - The axis along which to scatter elements.
+    /// * `dim` - The axis along which to scatter elements. Supports negative indexing.
     /// * `indices` - The indices of the elements to scatter.
     /// * `values` - The values to scatter into the tensor.
     /// * `update` - The operation used to update the existing values at the indexed positions (e.g., add).
@@ -1772,11 +1765,12 @@ where
     /// If the `update` is not `IndexingUpdateOp::Add`. Other operations are currently not implemented.
     pub fn scatter(
         self,
-        dim: usize,
+        dim: impl AsIndex,
         indices: Tensor<D, Int>,
         values: Self,
         update: IndexingUpdateOp,
     ) -> Self {
+        let dim = dim.expect_dim_index(D);
         check!(TensorCheck::scatter::<D>(
             dim,
             &self.shape(),
@@ -1928,7 +1922,7 @@ where
     /// The output tensor has the same shape, except along the given dimension.
     ///
     /// # Arguments
-    /// - `dim`: The dimension to repeat.
+    /// - `dim`: The dimension to repeat. Supports negative indexing.
     /// - `times`: The number of times to repeat the tensor along the given dimension in the new tensor.
     ///
     /// # Returns
@@ -1952,7 +1946,8 @@ where
     ///     println!("{repeated}");
     /// }
     /// ```
-    pub fn repeat_dim(self, dim: usize, times: usize) -> Self {
+    pub fn repeat_dim(self, dim: impl AsIndex, times: usize) -> Self {
+        let dim = dim.expect_dim_index(D);
         if times > 0 {
             Self::new(K::repeat_dim(self.primitive, dim, times))
         } else {
@@ -2116,6 +2111,7 @@ where
     }
 
     /// Concatenates all tensors into a new one along the given dimension.
+    /// The dimension supports negative indexing.
     ///
     /// # Panics
     ///
@@ -2140,7 +2136,8 @@ where
     ///     println!("{concat}");
     /// }
     /// ```
-    pub fn cat(tensors: Vec<Self>, dim: usize) -> Self {
+    pub fn cat(tensors: Vec<Self>, dim: impl AsIndex) -> Self {
+        let dim = dim.expect_dim_index(D);
         check!(TensorCheck::cat(tensors.as_slice(), dim));
 
         // Filter out tensors with size 0 along the concatenation dimension.
@@ -2167,11 +2164,12 @@ where
     }
 
     /// Concatenates all tensors into a new one along a new dimension.
+    /// The dimension supports negative indexing.
     ///
     /// # Panics
     ///
     /// - If all tensors don't have the same shape.
-    /// - If given dimension is not with range of 0..D2
+    /// - If the given dimension is outside the `D + 1` valid insertion positions.
     ///
     /// # Example
     ///
@@ -2193,13 +2191,15 @@ where
     ///     println!("{stacked}");
     /// }
     /// ```
-    pub fn stack<const D2: usize>(tensors: Vec<Tensor<D, K>>, dim: usize) -> Tensor<D2, K> {
+    pub fn stack<const D2: usize>(tensors: Vec<Tensor<D, K>>, dim: impl AsIndex) -> Tensor<D2, K> {
+        let dim = dim.expect_dim_index(D + 1);
         check!(TensorCheck::stack::<D, K, D2>(tensors.as_slice(), dim));
         let tensors = tensors.into_iter().map(|t| t.unsqueeze_dim(dim)).collect();
         Tensor::<D2, K>::cat(tensors, dim)
     }
 
     /// Iterate over slices of tensors alongside a given dimension.
+    /// The dimension supports negative indexing.
     ///
     /// # Panics
     ///
@@ -2225,12 +2225,14 @@ where
     ///  }
     /// }
     /// ```
-    pub fn iter_dim(self, dim: usize) -> DimIter<D, K> {
+    pub fn iter_dim(self, dim: impl AsIndex) -> DimIter<D, K> {
+        let dim = dim.expect_dim_index(D);
         check!(TensorCheck::dim_ops::<D>("iter_dim", dim));
         DimIter::new(self, dim)
     }
 
     /// Returns a new tensor with the given dimension narrowed to the given range.
+    /// The dimension supports negative indexing.
     ///
     /// # Panics
     ///
@@ -2265,7 +2267,8 @@ where
     ///     println!("{narrowed}");
     /// }
     /// ```
-    pub fn narrow(self, dim: usize, start: usize, length: usize) -> Self {
+    pub fn narrow(self, dim: impl AsIndex, start: usize, length: usize) -> Self {
+        let dim = dim.expect_dim_index(D);
         check!(TensorCheck::dim_ops::<D>("narrow", dim));
         check!(TensorCheck::narrow(&self, dim, start, length));
         let dims = self.dims();
@@ -2288,6 +2291,7 @@ where
     }
 
     /// Attempts to split the tensor into a specified number of chunks along a given dimension.
+    /// The dimension supports negative indexing.
     /// May return less chunks than requested if the tensor size is not divisible by the number of chunks.
     ///
     /// When the given dimension is evenly divisible by the number of chunks, the chunks will be of equal size.
@@ -2326,7 +2330,8 @@ where
     ///     println!("{chunks:?}");
     /// }
     /// ```
-    pub fn chunk(self, chunks: usize, dim: usize) -> Vec<Self> {
+    pub fn chunk(self, chunks: usize, dim: impl AsIndex) -> Vec<Self> {
+        let dim = dim.expect_dim_index(D);
         check!(TensorCheck::dim_ops::<D>("chunk", dim));
         let size = self.shape()[dim];
         if size < chunks {
@@ -2357,6 +2362,7 @@ where
     }
 
     /// Splits the tensor into chunks of a specified size along a given dimension.
+    /// The dimension supports negative indexing.
     /// Each chunk is a view of the original tensor.
     ///
     /// If the tensor size along the given dimension is not divisible by `split_size`,
@@ -2385,7 +2391,8 @@ where
     ///     println!("{:?}", chunks);
     /// }
     /// ```
-    pub fn split(self, split_size: usize, dim: usize) -> Vec<Self> {
+    pub fn split(self, split_size: usize, dim: impl AsIndex) -> Vec<Self> {
+        let dim = dim.expect_dim_index(D);
         check!(TensorCheck::split::<D>(&self.shape(), split_size, dim));
         let size = self.shape()[dim];
         let mut tensors = Vec::new();
@@ -2401,6 +2408,7 @@ where
     }
 
     /// Splits the tensor into chunks with the specified sizes along a given dimension.
+    /// The dimension supports negative indexing.
     /// Each chunk is a view of the original tensor.
     ///
     /// The sizes of the chunks are specified in the `split_sizes` vector. The sum of the sizes
@@ -2430,7 +2438,8 @@ where
     ///     println!("{:?}", chunks);
     /// }
     /// ```
-    pub fn split_with_sizes(self, split_sizes: Vec<usize>, dim: usize) -> Vec<Self> {
+    pub fn split_with_sizes(self, split_sizes: Vec<usize>, dim: impl AsIndex) -> Vec<Self> {
+        let dim = dim.expect_dim_index(D);
         check!(TensorCheck::split_with_sizes::<D>(
             &self.shape(),
             &split_sizes,
@@ -2491,7 +2500,7 @@ where
     /// # Arguments
     ///
     /// * `tensor` - The tensor to test. All input tensor types (Float, Int, Bool) are supported.
-    /// * `dim` - The axis along which to test.
+    /// * `dim` - The axis along which to test. Supports negative indexing.
     ///
     /// # Returns
     ///
@@ -2514,7 +2523,8 @@ where
     ///     println!("{any_dim}");
     /// }
     /// ```
-    pub fn any_dim(self, dim: usize) -> Tensor<D, Bool> {
+    pub fn any_dim(self, dim: impl AsIndex) -> Tensor<D, Bool> {
+        let dim = dim.expect_dim_index(D);
         Tensor::new(K::any_dim(self.primitive, dim))
     }
 
@@ -2553,7 +2563,7 @@ where
     /// # Arguments
     ///
     /// * `tensor` - The tensor to test. All input tensor types (Float, Int, Bool) are supported.
-    /// * `dim` - The axis along which to test.
+    /// * `dim` - The axis along which to test. Supports negative indexing.
     ///
     /// # Returns
     ///
@@ -2576,7 +2586,8 @@ where
     ///     println!("{all_dim}");
     /// }
     /// ```
-    pub fn all_dim(self, dim: usize) -> Tensor<D, Bool> {
+    pub fn all_dim(self, dim: impl AsIndex) -> Tensor<D, Bool> {
+        let dim = dim.expect_dim_index(D);
         Tensor::new(K::all_dim(self.primitive, dim))
     }
 
@@ -2917,17 +2928,11 @@ pub trait MovedimArgs {
     fn into_dim_vec<const D: usize>(self) -> Vec<usize>;
 }
 
-impl MovedimArgs for Vec<i32> {
+impl<I: AsIndex> MovedimArgs for Vec<I> {
     fn into_dim_vec<const D: usize>(self) -> Vec<usize> {
         let set = self
-            .iter()
-            .map(|&dim| {
-                if dim < 0 {
-                    (D as i32 + dim) as usize
-                } else {
-                    dim as usize
-                }
-            })
+            .into_iter()
+            .map(|dim| dim.expect_dim_index(D))
             .collect::<Vec<usize>>();
         check!(TensorCheck::movedim_args_vec::<D>(&set));
 
@@ -2935,42 +2940,19 @@ impl MovedimArgs for Vec<i32> {
     }
 }
 
-impl MovedimArgs for Vec<usize> {
-    fn into_dim_vec<const D: usize>(self) -> Vec<usize> {
-        check!(TensorCheck::movedim_args_vec::<D>(&self));
-        self
-    }
+macro_rules! impl_movedim_args {
+    ($($ty:ty),*) => {
+        $(
+            impl MovedimArgs for $ty {
+                fn into_dim_vec<const D: usize>(self) -> Vec<usize> {
+                    vec![self.expect_dim_index(D)]
+                }
+            }
+        )*
+    };
 }
 
-impl MovedimArgs for usize {
-    #[allow(clippy::vec_init_then_push)]
-    fn into_dim_vec<const D: usize>(self) -> Vec<usize> {
-        check!(TensorCheck::movedim_args_usize::<D>(self));
-
-        let mut set = Vec::with_capacity(1);
-        set.push(self);
-
-        set
-    }
-}
-
-impl MovedimArgs for i32 {
-    #[allow(clippy::vec_init_then_push)]
-    fn into_dim_vec<const D: usize>(self) -> Vec<usize> {
-        check!(TensorCheck::movedim_args_i32::<D>(self));
-
-        let dim = if self < 0 {
-            (D as i32 + self) as usize
-        } else {
-            self as usize
-        };
-
-        let mut set = Vec::with_capacity(1);
-        set.push(dim);
-
-        set
-    }
-}
+impl_movedim_args!(usize, isize, i64, u64, i32, u32, i16, u16, i8, u8);
 
 /// Trait used for reshape arguments.
 pub trait ReshapeArgs<const D2: usize>: Debug {

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -144,42 +144,6 @@ impl TensorCheck {
         check
     }
 
-    pub(crate) fn movedim_args_usize<const D: usize>(dim: usize) -> Self {
-        let mut check = Self::Ok;
-
-        if dim >= D {
-            check = check.register(
-                "Movedim",
-                TensorError::new(
-                    "The given dimension exceeds the number of dimensions of the current tensor.",
-                )
-                .details(format!(
-                    "Current tensor has {D} dimensions, but the given dimension is {dim}.",
-                )),
-            );
-        }
-
-        check
-    }
-
-    pub(crate) fn movedim_args_i32<const D: usize>(dim: i32) -> Self {
-        let mut check = Self::Ok;
-
-        if dim < -(D as i32) || dim >= D as i32 {
-            check = check.register(
-                "Movedim",
-                TensorError::new(
-                    "The given dimension is out of bounds for the current tensor dimensions.",
-                )
-                .details(format!(
-                    "Current tensor has {D} dimensions, but the given dimension is {dim}.",
-                )),
-            );
-        }
-
-        check
-    }
-
     pub(crate) fn movedim_args_vec<const D: usize>(dims: &Vec<usize>) -> Self {
         let mut check = Self::Ok;
 
@@ -1705,23 +1669,6 @@ mod tests {
             &5, // We can pass anything that implements PartialEq as device
             &8
         ));
-    }
-
-    #[test]
-    #[should_panic]
-    fn movedim_args_out_of_bounds() {
-        check!(TensorCheck::movedim_args_usize::<3>(5));
-    }
-
-    #[test]
-    fn movedim_args_i32() {
-        check!(TensorCheck::movedim_args_i32::<3>(-3));
-    }
-
-    #[test]
-    #[should_panic]
-    fn movedim_args_too_negative() {
-        check!(TensorCheck::movedim_args_i32::<3>(-4));
     }
 
     #[test]

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -2,7 +2,6 @@ use burn_backend::Scalar;
 
 use crate::alloc::borrow::ToOwned;
 use crate::kind::Numeric;
-use alloc::vec::Vec;
 
 use crate::{
     AsIndex, Bool, Distribution, ElementConversion, Int, Shape, Tensor, check, check::TensorCheck,
@@ -494,12 +493,7 @@ where
     /// }
     /// ```
     pub fn sum_dims_squeeze<const D2: usize, I: AsIndex>(self, dims: &[I]) -> Tensor<D2, K> {
-        // TODO: remove idims when squeeze_dims uses AsIndex.
-        let idims = dims
-            .iter()
-            .map(|&dim| (dim.expect_dim_index(D)) as isize)
-            .collect::<Vec<_>>();
-        self.sum_dims(dims).squeeze_dims::<D2>(&idims)
+        self.sum_dims(dims).squeeze_dims::<D2>(dims)
     }
 
     /// Aggregate all elements in the tensor with the product operation.

--- a/crates/burn-tensor/src/tensor/api/orderable.rs
+++ b/crates/burn-tensor/src/tensor/api/orderable.rs
@@ -303,7 +303,8 @@ where
     /// * `num_classes`: The number of classes for the one-hot encoding, which defines the size of the one-hot dimension.
     /// * `on_value`: The value to assign for active positions (corresponding to indices).
     /// * `off_value`: The value to assign for inactive positions.
-    /// * `axis`: The axis along which the one-hot dimension is added. Supports negative indexing.
+    /// * `axis`: The axis along which the one-hot dimension is added.
+    ///   Negative dimensions are supported and count from the end.
     ///
     /// # Returns
     ///
@@ -329,36 +330,26 @@ where
         num_classes: usize,
         on_value: f32,
         off_value: f32,
-        axis: i64,
+        axis: impl AsIndex,
     ) -> Tensor<D2, K> {
         check!(TensorCheck::one_hot_tensor_rank::<D, D2>());
+        let axis = axis.expect_dim_index(D + 1);
+
         // Initialize shape from the current tensor dimensions and prepare for modification
         let mut shape = self.shape();
         let device = self.device();
-        let rank = self.dims().len();
 
-        // Adjust negative axis to a positive index
-        let axis = if axis < 0 {
-            axis + rank as i64 + 1
-        } else {
-            axis
-        };
-
-        // Ensure axis is within valid range
-        if axis < 0 || axis > rank as i64 {
-            panic!("Axis out of range. Accepted range is [-r-1, r] where r = rank(indices).");
-        }
         // Convert the input tensor to integer indices
         let indices: Tensor<D, Int> = Tensor::from_data(self.to_data().convert::<i64>(), &device);
         // Insert the new dimension for the one-hot representation
-        shape.insert(axis as usize, num_classes);
+        shape.insert(axis, num_classes);
         // Adjust indices to valid range and handle invalid indices
         let adjusted_indices = indices
             .clone()
             .mask_fill(self.clone().lower_elem(0), num_classes as i64) // Handle negative indices
             .add(indices.clone().mask_fill(self.clone().greater_elem(0), 0)); // Handle positive indices
         // Unsqueeze the indices tensor along the specified axis
-        let indices_unsqueezed: Tensor<D2, Int> = adjusted_indices.unsqueeze_dim(axis as usize);
+        let indices_unsqueezed: Tensor<D2, Int> = adjusted_indices.unsqueeze_dim(axis);
 
         // Initialize the output tensor with the off_value
         let output = Tensor::full(shape.clone(), off_value, &device);
@@ -369,7 +360,7 @@ where
 
         // Scatter on_value at the appropriate indices to create the one-hot representation
         output.scatter(
-            axis as usize,
+            axis,
             indices_unsqueezed,
             scatter_on_values,
             IndexingUpdateOp::Add,
@@ -574,6 +565,11 @@ where
 
     /// Applies the argmax function along the given dimension and returns an integer tensor.
     ///
+    /// # Arguments
+    ///
+    /// * `dim` - The dimension along which to find the maximum value.
+    ///   Negative dimensions are supported and count from the end.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -587,11 +583,18 @@ where
     ///     // Shape { dims: [2, 1, 3] }
     /// }
     /// ```
-    pub fn argmax(self, dim: usize) -> Tensor<D, Int> {
+    pub fn argmax(self, dim: impl AsIndex) -> Tensor<D, Int> {
+        let dim = dim.expect_dim_index(D);
         Tensor::new(K::argmax(self.primitive, dim))
     }
 
     /// Applies the argtopk function along the given dimension and returns an integer tensor.
+    ///
+    /// # Arguments
+    ///
+    /// * `k` - The number of indices to return.
+    /// * `dim` - The dimension along which to find the largest values.
+    ///   Negative dimensions are supported and count from the end.
     ///
     /// # Example
     ///
@@ -605,7 +608,8 @@ where
     ///     println!("{:?}", tensor.shape());
     /// }
     /// ```
-    pub fn argtopk(self, k: usize, dim: usize) -> Tensor<D, Int> {
+    pub fn argtopk(self, k: usize, dim: impl AsIndex) -> Tensor<D, Int> {
+        let dim = dim.expect_dim_index(D);
         assert!(self.shape()[dim] > k);
         Tensor::new(K::argtopk(self.primitive, dim, k))
     }
@@ -773,6 +777,11 @@ where
 
     /// Applies the argmin function along the given dimension and returns an integer tensor.
     ///
+    /// # Arguments
+    ///
+    /// * `dim` - The dimension along which to find the minimum value.
+    ///   Negative dimensions are supported and count from the end.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -786,7 +795,8 @@ where
     ///     // Shape { dims: [2, 1, 3] }
     /// }
     /// ```
-    pub fn argmin(self, dim: usize) -> Tensor<D, Int> {
+    pub fn argmin(self, dim: impl AsIndex) -> Tensor<D, Int> {
+        let dim = dim.expect_dim_index(D);
         Tensor::new(K::argmin(self.primitive, dim))
     }
 


### PR DESCRIPTION
## Motivation

Recent changes added negative-dimension support to activations, cumulative operations, FFTs, sorting, statistics, and norms. Several remaining high-level tensor APIs still use a mix of `usize`, signed integer types, and custom argument handling. Standardizing these public boundaries makes negative indexing available consistently while keeping backend and IR boundaries canonicalized as `usize`.


## Modifications

- Migrate the remaining Tensor base and orderable dimension parameters to `AsIndex`.
- Support `AsIndex` element types in `flip`, `squeeze_dims`, and `one_hot_fill`.
- Broaden `MovedimArgs` integer support while preserving its public trait shape.
- Normalize insertion dimensions against `D + 1` and fix middle insertion when `D2 > D + 1`.
- Add negative-dimension tests and update API documentation.

## Compatibility

This intentionally changes 21 public method signatures. Most existing typed values and integer literals remain source-compatible. Untyped empty inputs now require annotations, for example `flip([] as [isize; 0])` and `squeeze_dims(&[] as &[isize])`.
