### PR TITLE
feat(burn-nn): support negative dimensions

### DIFF
--- a/crates/burn-nn/src/loss/lp_loss.rs
+++ b/crates/burn-nn/src/loss/lp_loss.rs
@@ -1,7 +1,7 @@
 use super::Reduction;
 use burn::config::Config;
 use burn::module::Module;
-use burn::tensor::Tensor;
+use burn::tensor::{AsIndex, Tensor};
 use burn_core as burn;
 
 /// Configuration for the [Lp Loss](LpLoss) module.
@@ -194,14 +194,14 @@ impl LpLoss {
     /// over the specified dimensions. Useful for per-sample or per-channel losses (e.g., when
     /// working with images).
     ///
-    /// Dimensions can be provided in any order. They are sorted internally and
-    /// reduced from highest to lowest to ensure indices remain valid.
+    /// Dimensions can be provided in any order. They are normalized and sorted internally.
     ///
     /// # Arguments
     ///
     /// * `predictions` - The model's predicted values.
     /// * `targets` - The ground truth target values.
     /// * `dims` - Dimensions to reduce over.
+    ///   Negative dimensions are supported and count from the end.
     ///
     /// # Returns
     ///
@@ -220,12 +220,15 @@ impl LpLoss {
         &self,
         predictions: Tensor<D>,
         targets: Tensor<D>,
-        dims: &[usize],
+        dims: &[impl AsIndex],
     ) -> Tensor<D> {
         let error = self.forward_no_reduction(predictions, targets);
 
-        // Sort the dimensions to ascending order
-        let mut sorted_dims = dims.to_vec();
+        // Normalize and sort the dimensions to ascending order.
+        let mut sorted_dims = dims
+            .iter()
+            .map(|dim| dim.expect_dim_index(D))
+            .collect::<Vec<_>>();
         sorted_dims.sort();
 
         // Reduce over specified dimensions
@@ -607,8 +610,11 @@ mod tests {
             Tensor::<2>::from_data(TensorData::from([[1.0, 2.0], [3.0, 4.0]]), &device);
         let targets = Tensor::<2>::from_data(TensorData::from([[0.0, 2.0], [3.0, 6.0]]), &device);
         let loss_func = LpLossConfig::l2();
-        let loss_reduce_dims =
-            loss_func.forward_reduce_dims(predictions.clone(), targets.clone(), &[]);
+        let loss_reduce_dims = loss_func.forward_reduce_dims::<2>(
+            predictions.clone(),
+            targets.clone(),
+            &[] as &[usize],
+        );
         let loss_no_reduction = loss_func.forward_no_reduction(predictions, targets);
 
         // Should be equivalent
@@ -632,5 +638,23 @@ mod tests {
         // All zeros, reduced to shape: [2, 1, 1]
         let expected = TensorData::from([[[0.0]], [[0.0]]]);
         loss.into_data().assert_eq(&expected, false);
+    }
+
+    #[test]
+    fn test_forward_reduce_dims_negative_dims() {
+        let device = Default::default();
+        let predictions = Tensor::<3>::from_data(
+            TensorData::from([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]),
+            &device,
+        );
+        let targets = Tensor::<3>::zeros([2, 2, 2], &device);
+        let loss_func = LpLossConfig::l2();
+
+        let expected = loss_func.forward_reduce_dims(predictions.clone(), targets.clone(), &[1, 2]);
+        let output = loss_func.forward_reduce_dims(predictions, targets, &[-2, -1]);
+
+        output
+            .into_data()
+            .assert_approx_eq::<FT>(&expected.into_data(), Tolerance::default());
     }
 }

--- a/crates/burn-nn/src/loss/lp_loss.rs
+++ b/crates/burn-nn/src/loss/lp_loss.rs
@@ -1,4 +1,5 @@
 use super::Reduction;
+use alloc::vec::Vec;
 use burn::config::Config;
 use burn::module::Module;
 use burn::tensor::{AsIndex, Tensor};

--- a/crates/burn-nn/src/loss/smooth_l1.rs
+++ b/crates/burn-nn/src/loss/smooth_l1.rs
@@ -1,4 +1,5 @@
 use super::Reduction;
+use alloc::vec::Vec;
 use burn::config::Config;
 use burn::module::Module;
 use burn::tensor::{AsIndex, Tensor};

--- a/crates/burn-nn/src/loss/smooth_l1.rs
+++ b/crates/burn-nn/src/loss/smooth_l1.rs
@@ -1,7 +1,7 @@
 use super::Reduction;
 use burn::config::Config;
 use burn::module::Module;
-use burn::tensor::Tensor;
+use burn::tensor::{AsIndex, Tensor};
 use burn_core as burn;
 
 /// Configuration for the [SmoothL1Loss](SmoothL1Loss) module.
@@ -171,14 +171,14 @@ impl SmoothL1Loss {
     /// Calculates element-wise smooth L1 loss, then takes the mean
     /// over the specified dimensions. Useful for per-sample or per-channel losses.
     ///
-    /// Dimensions can be provided in any order. They are sorted internally and
-    /// reduced from highest to lowest to ensure indices remain valid.
+    /// Dimensions can be provided in any order. They are normalized and sorted internally.
     ///
     /// # Arguments
     ///
     /// - `predictions` - The model's predicted values.
     /// - `targets` - The ground truth target values.
     /// - `dims` - Dimensions to reduce over.
+    ///   Negative dimensions are supported and count from the end.
     ///
     /// # Returns
     ///
@@ -197,12 +197,15 @@ impl SmoothL1Loss {
         &self,
         predictions: Tensor<D>,
         targets: Tensor<D>,
-        dims: &[usize],
+        dims: &[impl AsIndex],
     ) -> Tensor<D> {
         let error = self.forward(predictions, targets);
 
-        // Sort the dimensions to ascending order
-        let mut sorted_dims = dims.to_vec();
+        // Normalize and sort the dimensions to ascending order.
+        let mut sorted_dims = dims
+            .iter()
+            .map(|dim| dim.expect_dim_index(D))
+            .collect::<Vec<_>>();
         sorted_dims.sort();
 
         // Reduce over specified dimensions
@@ -491,11 +494,30 @@ mod tests {
             Tensor::<2>::from_data(TensorData::from([[0.5_f32, 2.0], [0.0, 3.0]]), &device);
         let targets = Tensor::<2>::zeros([2, 2], &device);
 
-        let loss_reduce_dims = loss.forward_reduce_dims(predictions.clone(), targets.clone(), &[]);
+        let loss_reduce_dims =
+            loss.forward_reduce_dims::<2>(predictions.clone(), targets.clone(), &[] as &[usize]);
         let loss_no_reduction = loss.forward(predictions, targets);
 
         loss_reduce_dims
             .into_data()
             .assert_eq(&loss_no_reduction.into_data(), false);
+    }
+
+    #[test]
+    fn test_smooth_l1_forward_reduce_dims_negative_dims() {
+        let device = Default::default();
+        let loss = SmoothL1LossConfig::new().init();
+        let predictions = Tensor::<3>::from_data(
+            TensorData::from([[[1.0_f32, 2.0], [3.0, 4.0]], [[5.0_f32, 6.0], [7.0, 8.0]]]),
+            &device,
+        );
+        let targets = Tensor::<3>::zeros([2, 2, 2], &device);
+
+        let expected = loss.forward_reduce_dims(predictions.clone(), targets.clone(), &[1, 2]);
+        let output = loss.forward_reduce_dims(predictions, targets, &[-2, -1]);
+
+        output
+            .into_data()
+            .assert_approx_eq::<FT>(&expected.into_data(), Tolerance::default());
     }
 }

--- a/crates/burn-nn/src/modules/cosine_similarity.rs
+++ b/crates/burn-nn/src/modules/cosine_similarity.rs
@@ -2,16 +2,17 @@ use burn_core as burn;
 
 use burn::config::Config;
 use burn::module::{Content, DisplaySettings, Module, ModuleDisplay};
-use burn::tensor::Tensor;
 use burn::tensor::linalg::cosine_similarity;
+use burn::tensor::{AsIndex, Tensor};
 
 /// Configuration to create a [CosineSimilarity](CosineSimilarity) layer using the
 /// [init function](CosineSimilarityConfig::init).
 #[derive(Config, Debug)]
 pub struct CosineSimilarityConfig {
     /// The dimension along which the cosine similarity is computed. Default: `1`.
+    /// Negative dimensions are supported and count from the end.
     #[config(default = 1)]
-    pub dim: usize,
+    pub dim: isize,
     /// Small value to avoid division by zero. Default: `1e-8`.
     #[config(default = 1e-8)]
     pub eps: f64,
@@ -38,7 +39,8 @@ impl CosineSimilarityConfig {
 #[module(custom_display)]
 pub struct CosineSimilarity {
     /// The dimension along which the cosine similarity is computed.
-    pub dim: usize,
+    /// Negative dimensions are supported and count from the end.
+    pub dim: isize,
     /// Small value to avoid division by zero.
     pub eps: f64,
 }
@@ -67,7 +69,8 @@ impl CosineSimilarity {
     /// - x2:     `[batch_size, features]`
     /// - output: `[batch_size]`
     pub fn forward(&self, x1: Tensor<2>, x2: Tensor<2>) -> Tensor<1> {
-        cosine_similarity(x1, x2, self.dim as i32, Some(self.eps)).squeeze_dim(self.dim)
+        let dim = self.dim.expect_dim_index(2);
+        cosine_similarity(x1, x2, dim, Some(self.eps)).squeeze_dim(dim)
     }
 }
 
@@ -94,12 +97,32 @@ mod tests {
     }
 
     #[test]
+    fn cosine_similarity_negative_dim() {
+        let device = Default::default();
+        let x1 = Tensor::<2>::from_data(TensorData::from([[1.0, 0.0], [1.0, 1.0]]), &device);
+        let x2 = Tensor::<2>::from_data(TensorData::from([[1.0, 0.0], [0.0, 1.0]]), &device);
+
+        let output = CosineSimilarityConfig::new()
+            .with_dim(-1)
+            .init()
+            .forward(x1, x2);
+
+        let expected = TensorData::from([1.0, 0.707107]);
+        output
+            .into_data()
+            .assert_approx_eq::<FT>(&expected, Tolerance::default());
+    }
+
+    #[test]
     fn display() {
-        let layer = CosineSimilarityConfig::new().with_eps(0.5).init();
+        let layer = CosineSimilarityConfig::new()
+            .with_dim(-1)
+            .with_eps(0.5)
+            .init();
 
         assert_eq!(
             alloc::format!("{layer}"),
-            "CosineSimilarity {dim: 1, eps: 0.5}"
+            "CosineSimilarity {dim: -1, eps: 0.5}"
         );
     }
 }

--- a/crates/burn-nn/src/modules/rnn/lstm/lstm_state.rs
+++ b/crates/burn-nn/src/modules/rnn/lstm/lstm_state.rs
@@ -1,9 +1,9 @@
 use burn_core as burn;
 
 use alloc::vec::Vec;
-use burn::Tensor;
 use burn::prelude::SliceArg;
 use burn::prelude::{Device, Shape};
+use burn::tensor::{AsIndex, Tensor};
 
 /// State bundle for LSTM implementations.
 #[derive(Debug, Clone)]
@@ -94,22 +94,31 @@ impl<const D: usize> LstmState<D> {
 
     /// Squeeze a dimension from the state.
     ///
+    /// Negative dimensions are supported and count from the end.
+    ///
     /// See: [`Tensor::squeeze_dim`].
-    pub fn squeeze_dim<const D2: usize>(self, dim: usize) -> LstmState<D2> {
+    pub fn squeeze_dim<const D2: usize>(self, dim: impl AsIndex) -> LstmState<D2> {
+        let dim = dim.expect_dim_index(D);
         self.map_state(|t| t.squeeze_dim(dim))
     }
 
     /// Unsqueeze a dimension in the state.
     ///
+    /// Negative dimensions are supported and count from the end of the valid insertion positions.
+    ///
     /// See: [`Tensor::unsqueeze_dim`].
-    pub fn unsqueeze_dim<const D2: usize>(self, dim: usize) -> LstmState<D2> {
+    pub fn unsqueeze_dim<const D2: usize>(self, dim: impl AsIndex) -> LstmState<D2> {
+        let dim = dim.expect_dim_index(D + 1);
         self.map_state(|t| t.unsqueeze_dim(dim))
     }
 
     /// Stack the states along the given dimension.
     ///
+    /// Negative dimensions are supported and count from the end of the valid insertion positions.
+    ///
     /// See: [`Tensor::stack`].
-    pub fn stack<const D2: usize>(states: Vec<LstmState<D>>, dim: usize) -> LstmState<D2> {
+    pub fn stack<const D2: usize>(states: Vec<LstmState<D>>, dim: impl AsIndex) -> LstmState<D2> {
+        let dim = dim.expect_dim_index(D + 1);
         let (c_it, h_it): (Vec<_>, Vec<_>) = states.into_iter().map(|s| s.unpack()).unzip();
         LstmState {
             cell: Tensor::stack(c_it, dim),
@@ -122,8 +131,11 @@ impl<const D: usize> LstmState<D> {
     /// This is the inverse of stacking — useful for splitting
     /// multi-layer states back into per-layer states.
     ///
+    /// Negative dimensions are supported and count from the end.
+    ///
     /// See: [`Tensor::chunk`].
-    pub fn chunk(self, n: usize, dim: usize) -> Vec<LstmState<D>> {
+    pub fn chunk(self, n: usize, dim: impl AsIndex) -> Vec<LstmState<D>> {
+        let dim = dim.expect_dim_index(D);
         let cells = self.cell.chunk(n, dim);
         let hiddens = self.hidden.chunk(n, dim);
         cells
@@ -272,14 +284,14 @@ mod tests {
     }
 
     #[test]
-    fn test_squeeze_dim() {
+    fn test_squeeze_negative_dim() {
         let device = Device::default();
         let state: LstmState<3> = random_state([2, 1, 3], &device);
 
         let expected_cell = state.cell.clone().squeeze_dim::<2>(1).to_data();
         let expected_hidden = state.hidden.clone().squeeze_dim::<2>(1).to_data();
 
-        let squeezed: LstmState<2> = state.squeeze_dim(1);
+        let squeezed: LstmState<2> = state.squeeze_dim(-2);
 
         assert_eq!(squeezed.shape(), Shape::from([2, 3]));
         squeezed.cell.to_data().assert_eq(&expected_cell, true);
@@ -287,16 +299,29 @@ mod tests {
     }
 
     #[test]
-    fn test_unsqueeze_dim() {
+    fn test_unsqueeze_negative_dim() {
         let device = Device::default();
         let state: LstmState<2> = random_state([2, 3], &device);
 
         let expected_cell = state.cell.clone().unsqueeze_dim::<3>(1).to_data();
         let expected_hidden = state.hidden.clone().unsqueeze_dim::<3>(1).to_data();
 
-        let unsqueezed: LstmState<3> = state.unsqueeze_dim(1);
+        let unsqueezed: LstmState<3> = state.clone().unsqueeze_dim(-2);
 
         assert_eq!(unsqueezed.shape(), Shape::from([2, 1, 3]));
+        unsqueezed.cell.to_data().assert_eq(&expected_cell, true);
+        unsqueezed
+            .hidden
+            .to_data()
+            .assert_eq(&expected_hidden, true);
+
+        // Negative insertion positions are based on D + 1 even when D2 adds
+        // more than one singleton dimension.
+        let expected_cell = state.cell.clone().unsqueeze_dim::<4>(2).to_data();
+        let expected_hidden = state.hidden.clone().unsqueeze_dim::<4>(2).to_data();
+        let unsqueezed: LstmState<4> = state.unsqueeze_dim(-1_i64);
+
+        assert_eq!(unsqueezed.shape(), Shape::from([2, 3, 1, 1]));
         unsqueezed.cell.to_data().assert_eq(&expected_cell, true);
         unsqueezed
             .hidden
@@ -318,7 +343,7 @@ mod tests {
     }
 
     #[test]
-    fn test_stack() {
+    fn test_stack_negative_dim() {
         let device = Device::default();
         let a: LstmState<2> = random_state([2, 3], &device);
         let b: LstmState<2> = random_state([2, 3], &device);
@@ -327,15 +352,24 @@ mod tests {
         let expected_hidden =
             Tensor::stack::<3>(vec![a.hidden.clone(), b.hidden.clone()], 1).to_data();
 
-        let stacked: LstmState<3> = LstmState::stack(vec![a, b], 1);
+        let stacked: LstmState<3> = LstmState::stack(vec![a.clone(), b.clone()], -2);
 
         assert_eq!(stacked.shape(), Shape::from([2, 2, 3]));
+        stacked.cell.to_data().assert_eq(&expected_cell, true);
+        stacked.hidden.to_data().assert_eq(&expected_hidden, true);
+
+        let expected_cell = Tensor::stack::<4>(vec![a.cell.clone(), b.cell.clone()], 2).to_data();
+        let expected_hidden =
+            Tensor::stack::<4>(vec![a.hidden.clone(), b.hidden.clone()], 2).to_data();
+        let stacked: LstmState<4> = LstmState::stack(vec![a.clone(), b.clone()], -1_i64);
+
+        assert_eq!(stacked.shape(), Shape::from([2, 3, 2, 1]));
         stacked.cell.to_data().assert_eq(&expected_cell, true);
         stacked.hidden.to_data().assert_eq(&expected_hidden, true);
     }
 
     #[test]
-    fn test_chunk() {
+    fn test_chunk_negative_dim() {
         let device = Device::default();
 
         let a: LstmState<2> = random_state([2, 3], &device);
@@ -346,7 +380,7 @@ mod tests {
 
         assert_eq!(stacked.shape(), Shape::from([3, 2, 3]));
 
-        let chunks = stacked.chunk(3, 0);
+        let chunks = stacked.chunk(3, -3);
 
         assert_eq!(chunks.len(), 3);
         for chunk in chunks {


### PR DESCRIPTION
## Motivation

Several `burn-nn` abstractions still require positive dimensions even though their underlying tensor operations support negative indexing. Allowing dimensions such as `-1` keeps loss reduction, cosine similarity, and LSTM state manipulation consistent with the Tensor API and makes dimension choices less dependent on rank-specific positive indices.

## Modifications

- Accept `AsIndex` in `LstmState::squeeze_dim`, `unsqueeze_dim`, `stack`, and `chunk`.
- Accept `AsIndex` element types in `LpLoss::forward_reduce_dims` and `SmoothL1Loss::forward_reduce_dims`.
- Normalize and sort loss reduction dimensions before applying the reduction.
- Change `CosineSimilarityConfig::dim` and `CosineSimilarity::dim` from `usize` to `isize`, then normalize during `forward`.
- Add negative-dimension tests and update documentation.

## Compatibility

This intentionally changes six public method signatures and two public cosine dimension fields. Existing typed dimension values and integer literals remain compatible for the generic methods. Untyped empty loss dimension slices now need an annotation such as `&[] as &[usize]`. Typed `usize` values passed to the cosine configuration need conversion to `isize`, and the serialized configuration schema changes from unsigned to signed.