### PR TITLE
refactor(tensor): make `_elem` comparison methods aliases to unify `_scalar` methods

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -43,16 +43,16 @@ device.configure((FloatDType::F16, IntDType::I32))?;
 let floats = Tensor::<Backend, 2>::zeros([2, 3], &device);
 ```
 
-> **Default data types lock on first use.** A device's defaults can only be initialized **once**, and
-> that initialization must happen *before* the first tensor operation on the device. The first tensor
-> created on an unconfigured device permanently locks the defaults to the backend's values. Any later
-> call to `configure` (or `set_default_dtypes`) for that device returns a
+> **Default data types lock on first use.** A device's defaults can only be initialized **once**,
+> and that initialization must happen _before_ the first tensor operation on the device. The first
+> tensor created on an unconfigured device permanently locks the defaults to the backend's values.
+> Any later call to `configure` (or `set_default_dtypes`) for that device returns a
 > `DeviceError::AlreadyInitialized` error instead of silently changing (or ignoring) the width.
 
-Because the default width is a per-device property, you cannot have two different default float widths
-active on the same device within a single process. If you need values at more than one precision,
-create the other tensors with an explicit dtype by passing a `(&device, dtype)` tuple as the creation
-options (this tuple is just a convenient conversion into
+Because the default width is a per-device property, you cannot have two different default float
+widths active on the same device within a single process. If you need values at more than one
+precision, create the other tensors with an explicit dtype by passing a `(&device, dtype)` tuple as
+the creation options (this tuple is just a convenient conversion into
 [`TensorCreationOptions`](https://docs.rs/burn/latest/burn/tensor/struct.TensorCreationOptions.html)):
 
 ```rust, ignore
@@ -63,7 +63,7 @@ let x = Tensor::<Backend, 2>::zeros([2, 3], &device);                   // f32
 let x_f64 = Tensor::<Backend, 2>::zeros([2, 3], (&device, DType::F64)); // explicit f64
 ```
 
-To convert an *existing* tensor to another element type, use
+To convert an _existing_ tensor to another element type, use
 [`cast`](https://docs.rs/burn/latest/burn/tensor/struct.Tensor.html#method.cast):
 
 ```rust, ignore
@@ -205,7 +205,7 @@ Those operations are available for all tensor kinds: `Int`, `Float`, and `Bool`.
 | `tensor.dtype()`                                     | `tensor.dtype`                                                            |
 | `tensor.dims()`                                      | `tensor.size()`                                                           |
 | `tensor.equal(other)`                                | `x == y`                                                                  |
-| `tensor.equal_scalar(other)`                           | `tensor.eq(other)`                                                        |
+| `tensor.equal_scalar(other)`                         | `tensor.eq(other)`                                                        |
 | `tensor.expand(shape)`                               | `tensor.expand(shape)`                                                    |
 | `tensor.flatten(start_dim, end_dim)`                 | `tensor.flatten(start_dim, end_dim)`                                      |
 | `tensor.flip(axes)`                                  | `tensor.flip(axes)`                                                       |
@@ -219,7 +219,7 @@ Those operations are available for all tensor kinds: `Int`, `Float`, and `Bool`.
 | `tensor.movedim(src, dst)`                           | `tensor.movedim(src, dst)`                                                |
 | `tensor.narrow(dim, start, length)`                  | `tensor.narrow(dim, start, length)`                                       |
 | `tensor.not_equal(other)`                            | `x != y`                                                                  |
-| `tensor.not_equal_scalar(scalar)`                      | `tensor.ne(scalar)`                                                       |
+| `tensor.not_equal_scalar(scalar)`                    | `tensor.ne(scalar)`                                                       |
 | `tensor.ones_like()`                                 | `torch.ones_like(tensor)`                                                 |
 | `tensor.permute(axes)`                               | `tensor.permute(axes)`                                                    |
 | `tensor.repeat_dim(dim, times)`                      | `tensor.repeat(*[times if i == dim else 1 for i in range(tensor.dim())])` |
@@ -280,13 +280,13 @@ Those operations are available for numeric tensor kinds: `Float` and `Int`.
 | `tensor.div_scalar(scalar)` or `tensor / scalar`                | `tensor / scalar`                             |
 | `tensor.dot(other)`                                             | `torch.dot(tensor, other)`                    |
 | `tensor.greater(other)`                                         | `tensor.gt(other)`                            |
-| `tensor.greater_scalar(scalar)`                                   | `tensor.gt(scalar)`                           |
+| `tensor.greater_scalar(scalar)`                                 | `tensor.gt(scalar)`                           |
 | `tensor.greater_equal(other)`                                   | `tensor.ge(other)`                            |
-| `tensor.greater_equal_scalar(scalar)`                             | `tensor.ge(scalar)`                           |
+| `tensor.greater_equal_scalar(scalar)`                           | `tensor.ge(scalar)`                           |
 | `tensor.lower(other)`                                           | `tensor.lt(other)`                            |
-| `tensor.lower_scalar(scalar)`                                     | `tensor.lt(scalar)`                           |
+| `tensor.lower_scalar(scalar)`                                   | `tensor.lt(scalar)`                           |
 | `tensor.lower_equal(other)`                                     | `tensor.le(other)`                            |
-| `tensor.lower_equal_scalar(scalar)`                               | `tensor.le(scalar)`                           |
+| `tensor.lower_equal_scalar(scalar)`                             | `tensor.le(scalar)`                           |
 | `tensor.max()`                                                  | `tensor.max()`                                |
 | `tensor.max_abs()`                                              | `tensor.abs().max()`                          |
 | `tensor.max_abs_dim(dim)`                                       | `tensor.abs().max(dim, keepdim=True)`         |
@@ -391,24 +391,24 @@ Those operations are only available for `Float` tensors.
 
 Those operations are only available for `Int` tensors.
 
-| Burn API                                         | PyTorch Equivalent                                      |
-| ------------------------------------------------ | ------------------------------------------------------- |
-| `Tensor::arange(5..10, device)`                  | `tensor.arange(start=5, end=10, device=device)`         |
-| `Tensor::arange_step(5..10, 2, device)`          | `tensor.arange(start=5, end=10, step=2, device=device)` |
-| `tensor.bitwise_and(other)`                      | `torch.bitwise_and(tensor, other)`                      |
-| `tensor.bitwise_and_scalar(scalar)`              | `torch.bitwise_and(tensor, scalar)`                     |
-| `tensor.bitwise_not()`                           | `torch.bitwise_not(tensor)`                             |
-| `tensor.bitwise_left_shift(other)`               | `torch.bitwise_left_shift(tensor, other)`               |
-| `tensor.bitwise_left_shift_scalar(scalar)`       | `torch.bitwise_left_shift(tensor, scalar)`              |
-| `tensor.bitwise_right_shift(other)`              | `torch.bitwise_right_shift(tensor, other)`              |
-| `tensor.bitwise_right_shift_scalar(scalar)`      | `torch.bitwise_right_shift(tensor, scalar)`             |
-| `tensor.bitwise_or(other)`                       | `torch.bitwise_or(tensor, other)`                       |
-| `tensor.bitwise_or_scalar(scalar)`               | `torch.bitwise_or(tensor, scalar)`                      |
-| `tensor.bitwise_xor(other)`                      | `torch.bitwise_xor(tensor, other)`                      |
-| `tensor.bitwise_xor_scalar(scalar)`              | `torch.bitwise_xor(tensor, scalar)`                     |
-| `tensor.float()`                                 | `tensor.to(torch.float)`                                |
-| `tensor.from_ints(ints)`                         | N/A                                                     |
-| `tensor.cartesian_grid(shape, device)`           | N/A                                                     |
+| Burn API                                    | PyTorch Equivalent                                      |
+| ------------------------------------------- | ------------------------------------------------------- |
+| `Tensor::arange(5..10, device)`             | `tensor.arange(start=5, end=10, device=device)`         |
+| `Tensor::arange_step(5..10, 2, device)`     | `tensor.arange(start=5, end=10, step=2, device=device)` |
+| `tensor.bitwise_and(other)`                 | `torch.bitwise_and(tensor, other)`                      |
+| `tensor.bitwise_and_scalar(scalar)`         | `torch.bitwise_and(tensor, scalar)`                     |
+| `tensor.bitwise_not()`                      | `torch.bitwise_not(tensor)`                             |
+| `tensor.bitwise_left_shift(other)`          | `torch.bitwise_left_shift(tensor, other)`               |
+| `tensor.bitwise_left_shift_scalar(scalar)`  | `torch.bitwise_left_shift(tensor, scalar)`              |
+| `tensor.bitwise_right_shift(other)`         | `torch.bitwise_right_shift(tensor, other)`              |
+| `tensor.bitwise_right_shift_scalar(scalar)` | `torch.bitwise_right_shift(tensor, scalar)`             |
+| `tensor.bitwise_or(other)`                  | `torch.bitwise_or(tensor, other)`                       |
+| `tensor.bitwise_or_scalar(scalar)`          | `torch.bitwise_or(tensor, scalar)`                      |
+| `tensor.bitwise_xor(other)`                 | `torch.bitwise_xor(tensor, other)`                      |
+| `tensor.bitwise_xor_scalar(scalar)`         | `torch.bitwise_xor(tensor, scalar)`                     |
+| `tensor.float()`                            | `tensor.to(torch.float)`                                |
+| `tensor.from_ints(ints)`                    | N/A                                                     |
+| `tensor.cartesian_grid(shape, device)`      | N/A                                                     |
 
 ### Bool Operations
 
@@ -440,46 +440,46 @@ strategies.
 
 ## Activation Functions
 
-| Burn API                                         | PyTorch Equivalent                                 |
-| ------------------------------------------------ | -------------------------------------------------- |
-| `activation::celu(tensor, alpha)`                | `nn.functional.celu(tensor, alpha)`                |
-| `activation::elu(tensor, alpha)`                 | `nn.functional.elu(tensor, alpha)`                 |
-| `activation::gelu(tensor)`                       | `nn.functional.gelu(tensor)`                       |
-| `activation::glu(tensor, dim)`                   | `nn.functional.glu(tensor, dim)`                   |
-| `activation::hard_shrink(tensor, lambda)`        | `nn.functional.hardshrink(tensor, lambd)`          |
-| `activation::hard_sigmoid(tensor, alpha, beta)`  | `nn.functional.hardsigmoid(tensor)`                |
-| `activation::hard_swish(tensor)`                 | `nn.functional.hardswish(tensor)`                  |
-| `activation::hardtanh(tensor, min_val, max_val)` | `nn.functional.hardtanh(tensor, min_val, max_val)` |
-| `activation::leaky_relu(tensor, negative_slope)` | `nn.functional.leaky_relu(tensor, negative_slope)` |
-| `activation::log_sigmoid(tensor)`                | `nn.functional.log_sigmoid(tensor)`                |
-| `activation::log_softmax(tensor, dim)`           | `nn.functional.log_softmax(tensor, dim)`           |
-| `activation::mish(tensor)`                       | `nn.functional.mish(tensor)`                       |
-| `activation::prelu(tensor,alpha)`                | `nn.functional.prelu(tensor,weight)`               |
-| `activation::quiet_softmax(tensor, dim)`         | `nn.functional.quiet_softmax(tensor, dim)`         |
-| `activation::relu(tensor)`                       | `nn.functional.relu(tensor)`                       |
-| `activation::relu6(tensor)`                      | `nn.functional.relu6(tensor)`                      |
-| `activation::shrink(tensor, lambda, bias)`       | _No direct equivalent_                             |
-| `activation::soft_shrink(tensor, lambda)`        | `nn.functional.softshrink(tensor, lambd)`          |
-| `activation::sigmoid(tensor)`                    | `nn.functional.sigmoid(tensor)`                    |
-| `activation::selu(tensor)`                       | `nn.functional.selu(tensor)`                       |
-| `activation::silu(tensor)`                       | `nn.functional.silu(tensor)`                       |
-| `activation::softmax(tensor, dim)`               | `nn.functional.softmax(tensor, dim)`               |
-| `activation::softmin(tensor, dim)`               | `nn.functional.softmin(tensor, dim)`               |
-| `activation::softplus(tensor, beta)`             | `nn.functional.softplus(tensor, beta)`             |
-| `activation::softsign(tensor)`                   | `nn.functional.softsign(tensor)`                   |
-| `activation::tanh(tensor)`                       | `nn.functional.tanh(tensor)`                       |
-| `activation::tanhshrink(tensor)`                 | `nn.functional.tanhshrink(tensor)`                 |
-| `activation::threshold(tensor, threshold, value)`| `nn.functional.threshold(tensor, threshold, value)`|
-| `activation::thresholded_relu(tensor, alpha)`    | `nn.functional.threshold(tensor, alpha, 0)`        |
+| Burn API                                          | PyTorch Equivalent                                  |
+| ------------------------------------------------- | --------------------------------------------------- |
+| `activation::celu(tensor, alpha)`                 | `nn.functional.celu(tensor, alpha)`                 |
+| `activation::elu(tensor, alpha)`                  | `nn.functional.elu(tensor, alpha)`                  |
+| `activation::gelu(tensor)`                        | `nn.functional.gelu(tensor)`                        |
+| `activation::glu(tensor, dim)`                    | `nn.functional.glu(tensor, dim)`                    |
+| `activation::hard_shrink(tensor, lambda)`         | `nn.functional.hardshrink(tensor, lambd)`           |
+| `activation::hard_sigmoid(tensor, alpha, beta)`   | `nn.functional.hardsigmoid(tensor)`                 |
+| `activation::hard_swish(tensor)`                  | `nn.functional.hardswish(tensor)`                   |
+| `activation::hardtanh(tensor, min_val, max_val)`  | `nn.functional.hardtanh(tensor, min_val, max_val)`  |
+| `activation::leaky_relu(tensor, negative_slope)`  | `nn.functional.leaky_relu(tensor, negative_slope)`  |
+| `activation::log_sigmoid(tensor)`                 | `nn.functional.log_sigmoid(tensor)`                 |
+| `activation::log_softmax(tensor, dim)`            | `nn.functional.log_softmax(tensor, dim)`            |
+| `activation::mish(tensor)`                        | `nn.functional.mish(tensor)`                        |
+| `activation::prelu(tensor,alpha)`                 | `nn.functional.prelu(tensor,weight)`                |
+| `activation::quiet_softmax(tensor, dim)`          | `nn.functional.quiet_softmax(tensor, dim)`          |
+| `activation::relu(tensor)`                        | `nn.functional.relu(tensor)`                        |
+| `activation::relu6(tensor)`                       | `nn.functional.relu6(tensor)`                       |
+| `activation::shrink(tensor, lambda, bias)`        | _No direct equivalent_                              |
+| `activation::soft_shrink(tensor, lambda)`         | `nn.functional.softshrink(tensor, lambd)`           |
+| `activation::sigmoid(tensor)`                     | `nn.functional.sigmoid(tensor)`                     |
+| `activation::selu(tensor)`                        | `nn.functional.selu(tensor)`                        |
+| `activation::silu(tensor)`                        | `nn.functional.silu(tensor)`                        |
+| `activation::softmax(tensor, dim)`                | `nn.functional.softmax(tensor, dim)`                |
+| `activation::softmin(tensor, dim)`                | `nn.functional.softmin(tensor, dim)`                |
+| `activation::softplus(tensor, beta)`              | `nn.functional.softplus(tensor, beta)`              |
+| `activation::softsign(tensor)`                    | `nn.functional.softsign(tensor)`                    |
+| `activation::tanh(tensor)`                        | `nn.functional.tanh(tensor)`                        |
+| `activation::tanhshrink(tensor)`                  | `nn.functional.tanhshrink(tensor)`                  |
+| `activation::threshold(tensor, threshold, value)` | `nn.functional.threshold(tensor, threshold, value)` |
+| `activation::thresholded_relu(tensor, alpha)`     | `nn.functional.threshold(tensor, alpha, 0)`         |
 
 ## Grid Functions
 
-| Burn API                                            | PyTorch Equivalent                                                   |
-| --------------------------------------------------- | -------------------------------------------------------------------- |
+| Burn API                                            | PyTorch Equivalent                                             |
+| --------------------------------------------------- | -------------------------------------------------------------- |
 | `grid::affine_grid_2d(transformation_tensor, dims)` | `nn.functional.affine_grid(theta_tensor, size, align_corners)` |
-| `grid::meshgrid(tensors, GridIndexing::Matrix)`     | `torch.meshgrid(tensors, indexing="ij")`                             |
-| `grid::meshgrid(tensors, GridIndexing::Cartesian)`  | `torch.meshgrid(tensors, indexing="xy")`                             |
-| `grid::meshgrid_stack(tensors, index_pos)`          | _No direct equivalent_                                               |
+| `grid::meshgrid(tensors, GridIndexing::Matrix)`     | `torch.meshgrid(tensors, indexing="ij")`                       |
+| `grid::meshgrid(tensors, GridIndexing::Cartesian)`  | `torch.meshgrid(tensors, indexing="xy")`                       |
+| `grid::meshgrid_stack(tensors, index_pos)`          | _No direct equivalent_                                         |
 
 ## Linalg Functions
 
@@ -504,11 +504,11 @@ strategies.
 
 ## Signal Processing Functions
 
-Signal-processing helpers live in `burn::tensor::signal` and operate on real-valued float
-tensors. FFT length `n` (and `n_fft` in STFT) must currently be a power of two: when `n` is
-`Some(size)`, the input is truncated or zero-padded to `size` and the output has
-`size / 2 + 1` frequency bins. Non-power-of-two sizes panic at the public API boundary;
-general arbitrary-size DFT support (Bluestein's algorithm) is a tracked follow-up.
+Signal-processing helpers live in `burn::tensor::signal` and operate on real-valued float tensors.
+FFT length `n` (and `n_fft` in STFT) must currently be a power of two: when `n` is `Some(size)`, the
+input is truncated or zero-padded to `size` and the output has `size / 2 + 1` frequency bins.
+Non-power-of-two sizes panic at the public API boundary; general arbitrary-size DFT support
+(Bluestein's algorithm) is a tracked follow-up.
 
 | Burn API                                              | PyTorch Equivalent                                                                |
 | ----------------------------------------------------- | --------------------------------------------------------------------------------- |
@@ -520,11 +520,11 @@ general arbitrary-size DFT support (Bluestein's algorithm) is a tracked follow-u
 | `signal::hamming_window(size, periodic, options)`     | `torch.hamming_window(size, periodic)`                                            |
 | `signal::hann_window(size, periodic, options)`        | `torch.hann_window(size, periodic)`                                               |
 
-`stft` and `istft` share a `StftOptions` struct with fields `n_fft`, `hop_length`,
-`win_length`, `center`, and `onesided`. Use `StftOptions::new(n_fft)` for PyTorch-style
-defaults (`hop_length = n_fft / 4`, `win_length = None`, `center = true`, `onesided = true`).
-The option set is validated on entry to both `stft` and `istft`; `n_fft` must be a power of
-two and `hop_length <= effective_win_length` (the COLA prerequisite for invertibility).
+`stft` and `istft` share a `StftOptions` struct with fields `n_fft`, `hop_length`, `win_length`,
+`center`, and `onesided`. Use `StftOptions::new(n_fft)` for PyTorch-style defaults
+(`hop_length = n_fft / 4`, `win_length = None`, `center = true`, `onesided = true`). The option set
+is validated on entry to both `stft` and `istft`; `n_fft` must be a power of two and
+`hop_length <= effective_win_length` (the COLA prerequisite for invertibility).
 
 ## Displaying Tensor Details
 
@@ -638,7 +638,6 @@ Options:
   operations that may introduce small numerical discrepancies.
 
   The function uses color-coded output to highlight the results:
-
   - Green [PASS]: All elements are within the specified tolerance.
   - Yellow [WARN]: Most elements (90% or more) are within tolerance.
   - Red [FAIL]: Significant differences are detected.

--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -205,7 +205,7 @@ Those operations are available for all tensor kinds: `Int`, `Float`, and `Bool`.
 | `tensor.dtype()`                                     | `tensor.dtype`                                                            |
 | `tensor.dims()`                                      | `tensor.size()`                                                           |
 | `tensor.equal(other)`                                | `x == y`                                                                  |
-| `tensor.equal_elem(other)`                           | `tensor.eq(other)`                                                        |
+| `tensor.equal_scalar(other)`                           | `tensor.eq(other)`                                                        |
 | `tensor.expand(shape)`                               | `tensor.expand(shape)`                                                    |
 | `tensor.flatten(start_dim, end_dim)`                 | `tensor.flatten(start_dim, end_dim)`                                      |
 | `tensor.flip(axes)`                                  | `tensor.flip(axes)`                                                       |
@@ -219,7 +219,7 @@ Those operations are available for all tensor kinds: `Int`, `Float`, and `Bool`.
 | `tensor.movedim(src, dst)`                           | `tensor.movedim(src, dst)`                                                |
 | `tensor.narrow(dim, start, length)`                  | `tensor.narrow(dim, start, length)`                                       |
 | `tensor.not_equal(other)`                            | `x != y`                                                                  |
-| `tensor.not_equal_elem(scalar)`                      | `tensor.ne(scalar)`                                                       |
+| `tensor.not_equal_scalar(scalar)`                      | `tensor.ne(scalar)`                                                       |
 | `tensor.ones_like()`                                 | `torch.ones_like(tensor)`                                                 |
 | `tensor.permute(axes)`                               | `tensor.permute(axes)`                                                    |
 | `tensor.repeat_dim(dim, times)`                      | `tensor.repeat(*[times if i == dim else 1 for i in range(tensor.dim())])` |
@@ -280,13 +280,13 @@ Those operations are available for numeric tensor kinds: `Float` and `Int`.
 | `tensor.div_scalar(scalar)` or `tensor / scalar`                | `tensor / scalar`                             |
 | `tensor.dot(other)`                                             | `torch.dot(tensor, other)`                    |
 | `tensor.greater(other)`                                         | `tensor.gt(other)`                            |
-| `tensor.greater_elem(scalar)`                                   | `tensor.gt(scalar)`                           |
+| `tensor.greater_scalar(scalar)`                                   | `tensor.gt(scalar)`                           |
 | `tensor.greater_equal(other)`                                   | `tensor.ge(other)`                            |
-| `tensor.greater_equal_elem(scalar)`                             | `tensor.ge(scalar)`                           |
+| `tensor.greater_equal_scalar(scalar)`                             | `tensor.ge(scalar)`                           |
 | `tensor.lower(other)`                                           | `tensor.lt(other)`                            |
-| `tensor.lower_elem(scalar)`                                     | `tensor.lt(scalar)`                           |
+| `tensor.lower_scalar(scalar)`                                     | `tensor.lt(scalar)`                           |
 | `tensor.lower_equal(other)`                                     | `tensor.le(other)`                            |
-| `tensor.lower_equal_elem(scalar)`                               | `tensor.le(scalar)`                           |
+| `tensor.lower_equal_scalar(scalar)`                               | `tensor.le(scalar)`                           |
 | `tensor.max()`                                                  | `tensor.max()`                                |
 | `tensor.max_abs()`                                              | `tensor.abs().max()`                          |
 | `tensor.max_abs_dim(dim)`                                       | `tensor.abs().max(dim, keepdim=True)`         |

--- a/crates/burn-nn/src/activation/rrelu.rs
+++ b/crates/burn-nn/src/activation/rrelu.rs
@@ -83,7 +83,7 @@ impl RRelu {
 
         // Training: sample a per-element slope in [lower, upper) and apply it to
         // the negative part only (positives pass through unchanged).
-        let is_negative = input.clone().lower_elem(0.0);
+        let is_negative = input.clone().lower_scalar(0.0);
         let slope = input.random_like(Distribution::Uniform(self.lower, self.upper));
         let scaled = input.clone() * slope;
         input.mask_where(is_negative, scaled)

--- a/crates/burn-nn/src/loss/cosine_embedding.rs
+++ b/crates/burn-nn/src/loss/cosine_embedding.rs
@@ -126,12 +126,12 @@ impl CosineEmbeddingLoss {
         let mut loss = cos_sim.zeros_like();
 
         // Similar pairs (target == 1) - Formula: L = 1 - cos_sim
-        let similar_mask = target.clone().equal_elem(1);
+        let similar_mask = target.clone().equal_scalar(1);
         let similar_loss = cos_sim.clone().neg().add_scalar(1);
         loss = loss.mask_where(similar_mask, similar_loss);
 
         // Dissimilar pairs (target == -1) - Formula: L = max(0, cos_sim - margin)
-        let dissimilar_mask = target.equal_elem(-1);
+        let dissimilar_mask = target.equal_scalar(-1);
         let dissimilar_loss = relu(cos_sim.clone().sub_scalar(self.margin));
         loss = loss.mask_where(dissimilar_mask, dissimilar_loss);
 

--- a/crates/burn-nn/src/loss/cross_entropy.rs
+++ b/crates/burn-nn/src/loss/cross_entropy.rs
@@ -215,11 +215,11 @@ impl CrossEntropyLoss {
     fn padding_mask(&self, targets: &Tensor<1, Int>) -> Option<Tensor<1, Bool>> {
         let mut mask = None;
         if let Some(pad_tokens) = &self.pad_tokens {
-            let mut res = targets.clone().equal_elem(pad_tokens[0] as i64).int();
+            let mut res = targets.clone().equal_scalar(pad_tokens[0] as i64).int();
             for x in pad_tokens {
-                res = res + targets.clone().equal_elem(*x as i64).int();
+                res = res + targets.clone().equal_scalar(*x as i64).int();
             }
-            mask = Some(res.greater_elem(0));
+            mask = Some(res.greater_scalar(0));
         }
 
         mask

--- a/crates/burn-nn/src/loss/hinge_embedding.rs
+++ b/crates/burn-nn/src/loss/hinge_embedding.rs
@@ -94,7 +94,7 @@ impl HingeEmbeddingLoss {
     ) -> Tensor<D> {
         // y == 1  -> x ;  y == -1 -> max(0, margin - x)
         let negative = input.clone().neg().add_scalar(self.margin).clamp_min(0.0);
-        let positive_mask = target.equal_elem(1);
+        let positive_mask = target.equal_scalar(1);
         negative.mask_where(positive_mask, input)
     }
 }

--- a/crates/burn-nn/src/loss/huber.rs
+++ b/crates/burn-nn/src/loss/huber.rs
@@ -117,7 +117,7 @@ impl HuberLoss {
     /// - residuals: [...dims]
     /// - output: [...dims]
     pub fn forward_residuals<const D: usize>(&self, residuals: Tensor<D>) -> Tensor<D> {
-        let is_large = residuals.clone().abs().greater_elem(self.delta);
+        let is_large = residuals.clone().abs().greater_scalar(self.delta);
         // We are interested in `sign(r)` when `abs(r) > self.delta`. Note that the
         // `sign()` function, in general, suffers from a jump at 0.
         // Instead the following tensor implements `delta * sign(r)` for values outside

--- a/crates/burn-nn/src/loss/poisson.rs
+++ b/crates/burn-nn/src/loss/poisson.rs
@@ -172,7 +172,7 @@ impl PoissonNllLoss {
                 + (targets.clone() * 2. * PI).log() * 0.5;
             loss = loss
                 + log_stirling_term
-                    .mask_where(targets.clone().lower_equal_elem(1), targets.zeros_like());
+                    .mask_where(targets.clone().lower_equal_scalar(1), targets.zeros_like());
         }
         loss
     }
@@ -193,7 +193,7 @@ impl PoissonNllLoss {
         assert!(
             targets
                 .clone()
-                .greater_equal_elem(0.)
+                .greater_equal_scalar(0.)
                 .all()
                 .into_scalar::<bool>(),
             "All the values of `targets` must be non-negative."
@@ -202,7 +202,7 @@ impl PoissonNllLoss {
             assert!(
                 predictions
                     .clone()
-                    .greater_equal_elem(0.)
+                    .greater_equal_scalar(0.)
                     .all()
                     .into_scalar::<bool>(),
                 "When `log_input` is `false`, all the values of `predictions` must be non-negative."

--- a/crates/burn-nn/src/loss/rnnt.rs
+++ b/crates/burn-nn/src/loss/rnnt.rs
@@ -90,7 +90,7 @@ impl RNNTLoss {
             let new = neg_inf.clone().mask_where(u_mask.clone(), new);
 
             // Only update alpha for samples where t < logit_lengths[b]
-            let valid = logit_lengths_exp.clone().greater_elem(t as i64);
+            let valid = logit_lengths_exp.clone().greater_scalar(t as i64);
             alpha = alpha.mask_where(valid, new);
         }
 
@@ -285,8 +285,8 @@ impl RNNTLoss {
 
     /// Numerically stable `log(exp(a) + exp(b))`, handling `-inf` inputs.
     fn log_sum_exp<const D: usize>(&self, a: Tensor<D>, b: Tensor<D>) -> Tensor<D> {
-        let a_inf = a.clone().equal_elem(f32::NEG_INFINITY);
-        let b_inf = b.clone().equal_elem(f32::NEG_INFINITY);
+        let a_inf = a.clone().equal_scalar(f32::NEG_INFINITY);
+        let b_inf = b.clone().equal_scalar(f32::NEG_INFINITY);
 
         // Replace -inf with 0 to prevent NaN in the subtraction (masked out below)
         let a_safe = a.clone().mask_fill(a_inf.clone(), 0.0);

--- a/crates/burn-nn/src/loss/smooth_l1.rs
+++ b/crates/burn-nn/src/loss/smooth_l1.rs
@@ -128,7 +128,7 @@ impl SmoothL1Loss {
         // The L2 case: 0.5 * (error)^2 / beta (when |error| < beta)
         let l2_loss = error.square().mul_scalar(0.5).div_scalar(self.beta);
 
-        let l2_mask = abs_error.lower_elem(self.beta);
+        let l2_mask = abs_error.lower_scalar(self.beta);
         l1_loss.mask_where(l2_mask, l2_loss)
     }
 

--- a/crates/burn-nn/src/modules/attention/cross_attention.rs
+++ b/crates/burn-nn/src/modules/attention/cross_attention.rs
@@ -498,7 +498,7 @@ mod tests {
             [0..batch_size, seq_len_context - num_padded..seq_len_context],
             Tensor::ones([batch_size, num_padded], &device),
         );
-        let mask_bool = mask.equal_elem(1);
+        let mask_bool = mask.equal_scalar(1);
 
         let query = Tensor::<3>::random(
             [batch_size, seq_len_query, d_model],

--- a/crates/burn-nn/src/modules/attention/mask.rs
+++ b/crates/burn-nn/src/modules/attention/mask.rs
@@ -96,7 +96,7 @@ pub fn generate_padding_mask(
         );
     }
 
-    let mask = tensor.clone().equal_elem(pad_token as i64);
+    let mask = tensor.clone().equal_scalar(pad_token as i64);
 
     GeneratePaddingMask { tensor, mask }
 }

--- a/crates/burn-nn/src/modules/attention/mha.rs
+++ b/crates/burn-nn/src/modules/attention/mha.rs
@@ -486,7 +486,7 @@ mod tests {
             [0..batch_size, seq_length - num_padded..seq_length],
             Tensor::ones([batch_size, num_padded], &device),
         );
-        let mask_pad = mask_pad.equal_elem(1).to_device(&device);
+        let mask_pad = mask_pad.equal_scalar(1).to_device(&device);
 
         let tensor_1 = Tensor::<3>::random(
             [batch_size, seq_length, d_model],

--- a/crates/burn-nn/src/modules/rope_encoding.rs
+++ b/crates/burn-nn/src/modules/rope_encoding.rs
@@ -444,7 +444,7 @@ mod tests {
         let wavelen = freqs.clone().recip().mul_scalar(2. * core::f32::consts::PI);
 
         // if wavelen >= high_freq_wavelen
-        let cond = wavelen.clone().greater_equal_elem(high_freq_wavelen);
+        let cond = wavelen.clone().greater_equal_scalar(high_freq_wavelen);
         let smooth = wavelen
             .clone()
             .recip()
@@ -461,11 +461,11 @@ mod tests {
         let new_freqs = freqs.clone().mask_where(cond, new_freqs);
 
         // if wavelen > low_freq_wavelen
-        let cond = wavelen.clone().greater_elem(low_freq_wavelen);
+        let cond = wavelen.clone().greater_scalar(low_freq_wavelen);
         let new_freqs = new_freqs.mask_where(cond, freqs.clone().div_scalar(scale_factor));
 
         // if wavelen < high_freq_wavelen
-        let cond = wavelen.lower_elem(high_freq_wavelen);
+        let cond = wavelen.lower_scalar(high_freq_wavelen);
         new_freqs.mask_where(cond, freqs)
     }
 

--- a/crates/burn-optim/src/grad_clipping/base.rs
+++ b/crates/burn-optim/src/grad_clipping/base.rs
@@ -56,8 +56,8 @@ impl GradientClipping {
     }
 
     fn clip_by_value<const D: usize>(&self, grad: Tensor<D>, threshold: f32) -> Tensor<D> {
-        let greater_mask = grad.clone().greater_elem(threshold);
-        let lower_mask = grad.clone().lower_elem(-threshold);
+        let greater_mask = grad.clone().greater_scalar(threshold);
+        let lower_mask = grad.clone().lower_scalar(-threshold);
 
         let clipped_grad = grad.mask_fill(greater_mask, threshold);
 

--- a/crates/burn-optim/src/optim/adamw.rs
+++ b/crates/burn-optim/src/optim/adamw.rs
@@ -87,8 +87,8 @@ impl Optimizer for AdamW {
         } else if self.cautious_weight_decay {
             // Cautious weight decay.
             // See: https://arxiv.org/abs/2510.12402
-            let tensor_pos = tensor.clone().greater_equal_elem(0.0);
-            let grad_pos = momentum_state.moment_1.clone().greater_equal_elem(0.0);
+            let tensor_pos = tensor.clone().greater_equal_scalar(0.0);
+            let grad_pos = momentum_state.moment_1.clone().greater_equal_scalar(0.0);
             let differ = tensor_pos.not_equal(grad_pos);
 
             // Zero out the decay where the decay is counter to the update direction.

--- a/crates/burn-tensor/src/bridge/ops/base.rs
+++ b/crates/burn-tensor/src/bridge/ops/base.rs
@@ -568,9 +568,9 @@ pub(crate) trait BasicOps: TensorKind {
     /// with static dispatch. It is not designed for direct usage by users, and not recommended to import
     /// or use this function directly.
     ///
-    /// For element-wise equality between two tensors, users should prefer the [`Tensor::equal_elem`](crate::Tensor::equal_elem)
+    /// For element-wise equality between two tensors, users should prefer the [`Tensor::equal_scalar`](crate::Tensor::equal_scalar)
     /// function, which is more high-level and designed for public use.
-    fn equal_elem(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor;
+    fn equal_scalar(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor;
 
     /// Applies element-wise non-equality comparison between the given tensors.
     ///
@@ -611,9 +611,9 @@ pub(crate) trait BasicOps: TensorKind {
     /// with static dispatch. It is not designed for direct usage by users, and not recommended to import
     /// or use this function directly.
     ///
-    /// For element-wise non-equality between two tensors, users should prefer the [`Tensor::not_equal_elem`](crate::Tensor::not_equal_elem)
+    /// For element-wise non-equality between two tensors, users should prefer the [`Tensor::not_equal_scalar`](crate::Tensor::not_equal_scalar)
     /// function, which is more high-level and designed for public use.
-    fn not_equal_elem(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor;
+    fn not_equal_scalar(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor;
 
     /// Tests if any element in the `tensor` evaluates to True.
     ///

--- a/crates/burn-tensor/src/bridge/ops/bool.rs
+++ b/crates/burn-tensor/src/bridge/ops/bool.rs
@@ -197,11 +197,11 @@ impl BasicOps for Bool {
         BridgeTensor::bool(Dispatch::bool_not_equal(lhs.into(), rhs.into()))
     }
 
-    fn equal_elem(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor {
+    fn equal_scalar(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor {
         BridgeTensor::bool(Dispatch::bool_equal_elem(lhs.into(), rhs))
     }
 
-    fn not_equal_elem(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor {
+    fn not_equal_scalar(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor {
         BridgeTensor::bool(Dispatch::bool_not_equal_elem(lhs.into(), rhs))
     }
 

--- a/crates/burn-tensor/src/bridge/ops/float.rs
+++ b/crates/burn-tensor/src/bridge/ops/float.rs
@@ -304,13 +304,13 @@ impl BasicOps for Float {
         BridgeTensor::bool(Dispatch::float_not_equal(lhs, rhs.into_float(), bool_dtype))
     }
 
-    fn equal_elem(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor {
+    fn equal_scalar(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor {
         let bool_dtype = lhs.device_settings().bool_dtype;
         let lhs = lhs.into_float();
         BridgeTensor::bool(Dispatch::float_equal_elem(lhs, rhs, bool_dtype))
     }
 
-    fn not_equal_elem(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor {
+    fn not_equal_scalar(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor {
         let bool_dtype = lhs.device_settings().bool_dtype;
         let lhs = lhs.into_float();
         BridgeTensor::bool(Dispatch::float_not_equal_elem(lhs, rhs, bool_dtype))
@@ -704,7 +704,7 @@ impl Ordered for Float {
         BridgeTensor::bool(Dispatch::float_greater(lhs, rhs.into_float(), bool_dtype))
     }
 
-    fn greater_elem(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor {
+    fn greater_scalar(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor {
         let bool_dtype = lhs.device_settings().bool_dtype;
         let lhs = lhs.into_float();
         BridgeTensor::bool(Dispatch::float_greater_elem(lhs, rhs, bool_dtype))
@@ -720,7 +720,7 @@ impl Ordered for Float {
         ))
     }
 
-    fn greater_equal_elem(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor {
+    fn greater_equal_scalar(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor {
         let bool_dtype = lhs.device_settings().bool_dtype;
         let lhs = lhs.into_float();
         BridgeTensor::bool(Dispatch::float_greater_equal_elem(lhs, rhs, bool_dtype))
@@ -732,7 +732,7 @@ impl Ordered for Float {
         BridgeTensor::bool(Dispatch::float_lower(lhs, rhs.into_float(), bool_dtype))
     }
 
-    fn lower_elem(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor {
+    fn lower_scalar(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor {
         let bool_dtype = lhs.device_settings().bool_dtype;
         let lhs = lhs.into_float();
         BridgeTensor::bool(Dispatch::float_lower_elem(lhs, rhs, bool_dtype))
@@ -748,7 +748,7 @@ impl Ordered for Float {
         ))
     }
 
-    fn lower_equal_elem(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor {
+    fn lower_equal_scalar(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor {
         let bool_dtype = lhs.device_settings().bool_dtype;
         let lhs = lhs.into_float();
         BridgeTensor::bool(Dispatch::float_lower_equal_elem(lhs, rhs, bool_dtype))

--- a/crates/burn-tensor/src/bridge/ops/int.rs
+++ b/crates/burn-tensor/src/bridge/ops/int.rs
@@ -181,12 +181,12 @@ impl BasicOps for Int {
         BridgeTensor::int(Dispatch::int_not_equal(lhs.into(), rhs.into(), bool_dtype))
     }
 
-    fn equal_elem(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor {
+    fn equal_scalar(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor {
         let bool_dtype = lhs.device_settings().bool_dtype;
         BridgeTensor::int(Dispatch::int_equal_elem(lhs.into(), rhs, bool_dtype))
     }
 
-    fn not_equal_elem(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor {
+    fn not_equal_scalar(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor {
         let bool_dtype = lhs.device_settings().bool_dtype;
         BridgeTensor::int(Dispatch::int_not_equal_elem(lhs.into(), rhs, bool_dtype))
     }
@@ -372,7 +372,7 @@ impl Ordered for Int {
         BridgeTensor::int(Dispatch::int_greater(lhs.into(), rhs.into(), bool_dtype))
     }
 
-    fn greater_elem(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor {
+    fn greater_scalar(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor {
         let bool_dtype = lhs.device_settings().bool_dtype;
         BridgeTensor::bool(Dispatch::int_greater_elem(lhs.into(), rhs, bool_dtype))
     }
@@ -386,7 +386,7 @@ impl Ordered for Int {
         ))
     }
 
-    fn greater_equal_elem(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor {
+    fn greater_equal_scalar(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor {
         let bool_dtype = lhs.device_settings().bool_dtype;
         BridgeTensor::bool(Dispatch::int_greater_equal_elem(
             lhs.into(),
@@ -400,7 +400,7 @@ impl Ordered for Int {
         BridgeTensor::bool(Dispatch::int_lower(lhs.into(), rhs.into(), bool_dtype))
     }
 
-    fn lower_elem(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor {
+    fn lower_scalar(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor {
         let bool_dtype = lhs.device_settings().bool_dtype;
         BridgeTensor::bool(Dispatch::int_lower_elem(lhs.into(), rhs, bool_dtype))
     }
@@ -414,7 +414,7 @@ impl Ordered for Int {
         ))
     }
 
-    fn lower_equal_elem(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor {
+    fn lower_equal_scalar(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor {
         let bool_dtype = lhs.device_settings().bool_dtype;
         BridgeTensor::bool(Dispatch::int_lower_equal_elem(lhs.into(), rhs, bool_dtype))
     }

--- a/crates/burn-tensor/src/bridge/ops/ordered.rs
+++ b/crates/burn-tensor/src/bridge/ops/ordered.rs
@@ -174,8 +174,8 @@ pub(crate) trait Ordered: Numeric {
     /// or use this function directly.
     ///
     /// For element-wise greater than comparison between a tensor and a scalar, users should prefer the
-    /// [`Tensor::greater_elem`](crate::Tensor::greater_elem) function, which is more high-level and designed for public use.
-    fn greater_elem(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor;
+    /// [`Tensor::greater_scalar`](crate::Tensor::greater_scalar) function, which is more high-level and designed for public use.
+    fn greater_scalar(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor;
 
     /// Element-wise greater than or equal comparison between two tensors.
     ///
@@ -220,8 +220,8 @@ pub(crate) trait Ordered: Numeric {
     /// or use this function directly.
     ///
     /// For element-wise greater than or equal comparison between a tensor and a scalar, users should prefer the
-    /// [`Tensor::greater_equal_elem`](crate::Tensor::greater_equal_elem) function, which is more high-level and designed for public use.
-    fn greater_equal_elem(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor;
+    /// [`Tensor::greater_equal_scalar`](crate::Tensor::greater_equal_scalar) function, which is more high-level and designed for public use.
+    fn greater_equal_scalar(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor;
 
     /// Element-wise less than comparison between two tensors.
     ///
@@ -266,8 +266,8 @@ pub(crate) trait Ordered: Numeric {
     /// or use this function directly.
     ///
     /// For element-wise less than comparison between a tensor and a scalar, users should prefer the
-    /// [`Tensor::lower_elem`](crate::Tensor::lower_elem) function, which is more high-level and designed for public use.
-    fn lower_elem(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor;
+    /// [`Tensor::lower_scalar`](crate::Tensor::lower_scalar) function, which is more high-level and designed for public use.
+    fn lower_scalar(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor;
 
     /// Element-wise less than or equal comparison between two tensors.
     ///
@@ -312,8 +312,8 @@ pub(crate) trait Ordered: Numeric {
     /// or use this function directly.
     ///
     /// For element-wise less than or equal comparison between a tensor and a scalar, users should prefer the
-    /// [`Tensor::lower_equal_elem`](crate::Tensor::lower_equal_elem) function, which is more high-level and designed for public use.
-    fn lower_equal_elem(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor;
+    /// [`Tensor::lower_equal_scalar`](crate::Tensor::lower_equal_scalar) function, which is more high-level and designed for public use.
+    fn lower_equal_scalar(lhs: BridgeTensor, rhs: Scalar) -> BridgeTensor;
 
     /// Gets the indices of the maximum elements of a tensor along an axis.
     ///

--- a/crates/burn-tensor/src/tensor/activation/base.rs
+++ b/crates/burn-tensor/src/tensor/activation/base.rs
@@ -426,7 +426,7 @@ $$
     doc = "`f(x) =`\n- `x for x > 0`\n- `alpha * (exp(x) - 1) for x <= 0`"
 )]
 pub fn elu<const D: usize>(tensor: Tensor<D>, alpha: f64) -> Tensor<D> {
-    let mask = tensor.clone().lower_equal_elem(0);
+    let mask = tensor.clone().lower_equal_scalar(0);
     let scaled = tensor.clone().exp().sub_scalar(1).mul_scalar(alpha);
     tensor.mask_where(mask, scaled)
 }
@@ -455,7 +455,7 @@ $$
 /// # Arguments
 /// - `alpha`: scaling parameter for the negative part.
 pub fn celu<const D: usize>(tensor: Tensor<D>, alpha: f64) -> Tensor<D> {
-    let mask = tensor.clone().lower_equal_elem(0);
+    let mask = tensor.clone().lower_equal_scalar(0);
     let scaled = tensor
         .clone()
         .div_scalar(alpha)
@@ -491,7 +491,7 @@ pub fn selu<const D: usize>(tensor: Tensor<D>) -> Tensor<D> {
     const ALPHA: f64 = 1.6732632423543772848170429916717_f64;
     const GAMMA: f64 = 1.0507009873554804934193349852946_f64;
 
-    let mask = tensor.clone().greater_equal_elem(0.0);
+    let mask = tensor.clone().greater_equal_scalar(0.0);
     let positive = tensor.clone().mul_scalar(GAMMA);
     let negative = tensor.exp().sub_scalar(1.0).mul_scalar(ALPHA * GAMMA);
 
@@ -517,7 +517,7 @@ $$
 /// # Arguments
 /// - `alpha`: threshold value (default in ONNX is 1.0).
 pub fn thresholded_relu<const D: usize>(tensor: Tensor<D>, alpha: f64) -> Tensor<D> {
-    let mask = tensor.clone().lower_equal_elem(alpha);
+    let mask = tensor.clone().lower_equal_scalar(alpha);
     tensor.mask_fill(mask, 0)
 }
 
@@ -534,7 +534,7 @@ pub fn thresholded_relu<const D: usize>(tensor: Tensor<D>, alpha: f64) -> Tensor
 /// - `threshold`: the value to threshold at.
 /// - `value`: the value to replace with where `x <= threshold`.
 pub fn threshold<const D: usize>(tensor: Tensor<D>, threshold: f64, value: f64) -> Tensor<D> {
-    let mask = tensor.clone().lower_equal_elem(threshold);
+    let mask = tensor.clone().lower_equal_scalar(threshold);
     tensor.mask_fill(mask, value)
 }
 
@@ -603,7 +603,7 @@ $$
 /// # Arguments
 /// - `lambda`: the lambda value for the Hard Shrink formulation. Default is 0.5.
 pub fn hard_shrink<const D: usize>(tensor: Tensor<D>, lambda: f64) -> Tensor<D> {
-    let mask = tensor.clone().abs().lower_equal_elem(lambda);
+    let mask = tensor.clone().abs().lower_equal_scalar(lambda);
     tensor.mask_fill(mask, 0)
 }
 
@@ -658,7 +658,7 @@ pub fn shrink<const D: usize>(tensor: Tensor<D>, lambda: f64, bias: f64) -> Tens
     let abs_tensor = tensor.clone().abs();
     let sign = tensor.clone().sign();
     let shrunk = tensor.sub(sign.mul_scalar(bias));
-    let mask = abs_tensor.lower_equal_elem(lambda);
+    let mask = abs_tensor.lower_equal_scalar(lambda);
     shrunk.mask_fill(mask, 0)
 }
 

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -2066,7 +2066,7 @@ where
     ///
     /// # Arguments
     ///
-    /// * `other` - The element to compare.
+    /// * `other` - The scalar to compare.
     ///
     /// # Example
     ///
@@ -2076,21 +2076,21 @@ where
     /// fn example() {
     ///    let device = Default::default();
     ///    let tensor = Tensor::<2>::from_data([[1.0, -2.0, 3.0], [5.0, 9.0, 6.0]], &device);
-    ///    let tensor = tensor.equal_elem(3.0);
+    ///    let tensor = tensor.equal_scalar(3.0);
     ///    println!("{tensor}");
     ///    // [[false, false, true], [false, false, false]]
     /// }
     /// ```
-    pub fn equal_elem<E: Element>(self, other: E) -> Tensor<D, Bool> {
+    pub fn equal_scalar<E: Element>(self, other: E) -> Tensor<D, Bool> {
         let other = Scalar::new(other, &self.dtype());
-        Tensor::new(K::equal_elem(self.primitive, other))
+        Tensor::new(K::equal_scalar(self.primitive, other))
     }
 
     /// Applies element wise non-equality comparison and returns a boolean tensor.
     ///
     /// # Arguments
     ///
-    /// * `other` - The element to compare.
+    /// * `other` - The scalar to compare.
     ///
     /// # Example
     ///
@@ -2100,14 +2100,24 @@ where
     /// fn example() {
     ///    let device = Default::default();
     ///    let tensor = Tensor::<2>::from_data([[1.0, -2.0, 3.0], [5.0, 9.0, 6.0]], &device);
-    ///    let tensor = tensor.not_equal_elem(3.0);
+    ///    let tensor = tensor.not_equal_scalar(3.0);
     ///    println!("{tensor}");
     ///    // [[true, true, false], [true, true, true]]
     /// }
     /// ```
-    pub fn not_equal_elem<E: Element>(self, other: E) -> Tensor<D, Bool> {
+    pub fn not_equal_scalar<E: Element>(self, other: E) -> Tensor<D, Bool> {
         let other = Scalar::new(other, &self.dtype());
-        Tensor::new(K::not_equal_elem(self.primitive, other))
+        Tensor::new(K::not_equal_scalar(self.primitive, other))
+    }
+
+    /// Alias for [equal_scalar](Self::equal_scalar).
+    pub fn equal_elem<E: Element>(self, other: E) -> Tensor<D, Bool> {
+        self.equal_scalar(other)
+    }
+
+    /// Alias for [not_equal_scalar](Self::not_equal_scalar).
+    pub fn not_equal_elem<E: Element>(self, other: E) -> Tensor<D, Bool> {
+        self.not_equal_scalar(other)
     }
 
     /// Concatenates all tensors into a new one along the given dimension.

--- a/crates/burn-tensor/src/tensor/api/bool.rs
+++ b/crates/burn-tensor/src/tensor/api/bool.rs
@@ -331,9 +331,9 @@ impl<const D: usize> Tensor<D, Bool> {
 
         // Select the appropriate comparison function based on `tri_part`.
         let compare = match tri_part {
-            TriPart::Upper => Tensor::greater_elem,
-            TriPart::Lower => Tensor::lower_elem,
-            TriPart::Diagonal => Tensor::not_equal_elem,
+            TriPart::Upper => Tensor::greater_scalar,
+            TriPart::Lower => Tensor::lower_scalar,
+            TriPart::Diagonal => Tensor::not_equal_scalar,
         };
 
         // Generate and return the mask by applying the comparison to the matrix.

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -394,7 +394,7 @@ impl TensorCheck {
         let mut check = Self::Ok;
         if index_tensor
             .clone()
-            .greater_equal_elem(num_classes as i32)
+            .greater_equal_scalar(num_classes as i32)
             .any()
             .into_scalar::<i64>()
             .to_bool()

--- a/crates/burn-tensor/src/tensor/api/fmod.rs
+++ b/crates/burn-tensor/src/tensor/api/fmod.rs
@@ -47,7 +47,7 @@ impl<const D: usize> Tensor<D, Float> {
         // We need to handle this case by replacing NaN with 0 when appropriate
 
         // Check if the product is NaN due to 0 * inf
-        let is_zero_times_inf = truncated.equal_elem(0.0).bool_and(other.is_inf());
+        let is_zero_times_inf = truncated.equal_scalar(0.0).bool_and(other.is_inf());
         let zero_tensor = self.clone().mul_scalar(0.0);
         let corrected_product = product.mask_where(is_zero_times_inf, zero_tensor);
 

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -823,7 +823,7 @@ where
     ///   // ]
     /// }
     pub fn bool(self) -> Tensor<D, Bool> {
-        self.not_equal_elem(0)
+        self.not_equal_scalar(0)
     }
 
     /// Create a random tensor of the given shape on the given device where each element is

--- a/crates/burn-tensor/src/tensor/api/orderable.rs
+++ b/crates/burn-tensor/src/tensor/api/orderable.rs
@@ -346,8 +346,8 @@ where
         // Adjust indices to valid range and handle invalid indices
         let adjusted_indices = indices
             .clone()
-            .mask_fill(self.clone().lower_elem(0), num_classes as i64) // Handle negative indices
-            .add(indices.clone().mask_fill(self.clone().greater_elem(0), 0)); // Handle positive indices
+            .mask_fill(self.clone().lower_scalar(0), num_classes as i64) // Handle negative indices
+            .add(indices.clone().mask_fill(self.clone().greater_scalar(0), 0)); // Handle positive indices
         // Unsqueeze the indices tensor along the specified axis
         let indices_unsqueezed: Tensor<D2, Int> = adjusted_indices.unsqueeze_dim(axis);
 
@@ -471,7 +471,7 @@ where
     ///
     /// # Arguments
     ///
-    /// * `other` - The element to compare.
+    /// * `other` - The scalar to compare.
     ///
     /// # Example
     ///
@@ -481,21 +481,21 @@ where
     /// fn example() {
     ///    let device = Default::default();
     ///    let tensor = Tensor::<2>::from_data([[1.0, -2.0, 3.0], [5.0, 9.0, 6.0]], &device);
-    ///    let tensor = tensor.greater_elem(3.0);
+    ///    let tensor = tensor.greater_scalar(3.0);
     ///    println!("{tensor}");
     ///    // [[false, false, true], [true, true, true]]
     /// }
     /// ```
-    pub fn greater_elem<E: ElementConversion>(self, other: E) -> Tensor<D, Bool> {
+    pub fn greater_scalar<E: ElementConversion>(self, other: E) -> Tensor<D, Bool> {
         let other = Scalar::new(other, &self.dtype());
-        Tensor::new(K::greater_elem(self.primitive, other))
+        Tensor::new(K::greater_scalar(self.primitive, other))
     }
 
     /// Applies greater-equal than `other` comparison and returns a boolean tensor.
     ///
     /// # Arguments
     ///
-    /// * `other` - The element to compare.
+    /// * `other` - The scalar to compare.
     ///
     /// # Example
     ///
@@ -505,21 +505,21 @@ where
     /// fn example() {
     ///    let device = Default::default();
     ///    let tensor = Tensor::<2>::from_data([[1.0, -2.0, 3.0], [5.0, 9.0, 6.0]], &device);
-    ///    let tensor = tensor.greater_equal_elem(3.0);
+    ///    let tensor = tensor.greater_equal_scalar(3.0);
     ///    println!("{tensor}");
     ///    // [[false, false, true], [true, true, true]]
     /// }
     /// ```
-    pub fn greater_equal_elem<E: ElementConversion>(self, other: E) -> Tensor<D, Bool> {
+    pub fn greater_equal_scalar<E: ElementConversion>(self, other: E) -> Tensor<D, Bool> {
         let other = Scalar::new(other, &self.dtype());
-        Tensor::new(K::greater_equal_elem(self.primitive, other))
+        Tensor::new(K::greater_equal_scalar(self.primitive, other))
     }
 
     /// Applies lower than `other` comparison and returns a boolean tensor.
     ///
     /// # Arguments
     ///
-    /// * `other` - The element to compare.
+    /// * `other` - The scalar to compare.
     ///
     /// # Example
     ///
@@ -529,21 +529,21 @@ where
     /// fn example() {
     ///     let device = Default::default();
     ///     let tensor = Tensor::<2>::from_data([[1.0, -2.0, 3.0], [5.0, 9.0, 6.0]], &device);
-    ///     let tensor = tensor.lower_elem(3.0);
+    ///     let tensor = tensor.lower_scalar(3.0);
     ///     println!("{tensor}");
     ///     // [[true, true, false], [false, false, false]]
     /// }
     /// ```
-    pub fn lower_elem<E: ElementConversion>(self, other: E) -> Tensor<D, Bool> {
+    pub fn lower_scalar<E: ElementConversion>(self, other: E) -> Tensor<D, Bool> {
         let other = Scalar::new(other, &self.dtype());
-        Tensor::new(K::lower_elem(self.primitive, other))
+        Tensor::new(K::lower_scalar(self.primitive, other))
     }
 
     /// Applies lower-equal than `other` comparison and returns a boolean tensor.
     ///
     /// # Arguments
     ///
-    /// * `other` - The element to compare.
+    /// * `other` - The scalar to compare.
     ///
     /// # Example
     ///
@@ -553,14 +553,34 @@ where
     /// fn example() {
     ///    let device = Default::default();
     ///    let tensor = Tensor::<2>::from_data([[1.0, -2.0, 3.0], [5.0, 9.0, 6.0]], &device);
-    ///    let tensor = tensor.lower_equal_elem(3.0);
+    ///    let tensor = tensor.lower_equal_scalar(3.0);
     ///    println!("{tensor}");
     ///    // [[true, true, true], [false, false, false]]
     /// }
     /// ```
-    pub fn lower_equal_elem<E: ElementConversion>(self, other: E) -> Tensor<D, Bool> {
+    pub fn lower_equal_scalar<E: ElementConversion>(self, other: E) -> Tensor<D, Bool> {
         let other = Scalar::new(other, &self.dtype());
-        Tensor::new(K::lower_equal_elem(self.primitive, other))
+        Tensor::new(K::lower_equal_scalar(self.primitive, other))
+    }
+
+    /// Alias for [greater_scalar](Self::greater_scalar).
+    pub fn greater_elem<E: ElementConversion>(self, other: E) -> Tensor<D, Bool> {
+        self.greater_scalar(other)
+    }
+
+    /// Alias for [greater_equal_scalar](Self::greater_equal_scalar).
+    pub fn greater_equal_elem<E: ElementConversion>(self, other: E) -> Tensor<D, Bool> {
+        self.greater_equal_scalar(other)
+    }
+
+    /// Alias for [lower_scalar](Self::lower_scalar).
+    pub fn lower_elem<E: ElementConversion>(self, other: E) -> Tensor<D, Bool> {
+        self.lower_scalar(other)
+    }
+
+    /// Alias for [lower_equal_scalar](Self::lower_equal_scalar).
+    pub fn lower_equal_elem<E: ElementConversion>(self, other: E) -> Tensor<D, Bool> {
+        self.lower_equal_scalar(other)
     }
 
     /// Applies the argmax function along the given dimension and returns an integer tensor.

--- a/crates/burn-tensor/src/tensor/linalg/det.rs
+++ b/crates/burn-tensor/src/tensor/linalg/det.rs
@@ -147,7 +147,7 @@ pub fn det<const D: usize, const D1: usize, const D2: usize>(mut tensor: Tensor<
         .not_equal(batched_range_tensor)
         .int()
         .sum_dim(D1 - 1);
-    let odd_mask = n_row_swaps.clone().remainder_scalar(2).equal_elem(1);
+    let odd_mask = n_row_swaps.clone().remainder_scalar(2).equal_scalar(1);
     let p_det = n_row_swaps
         .cast(working_float_dtype)
         .ones_like()

--- a/crates/burn-tensor/src/tensor/linalg/lu.rs
+++ b/crates/burn-tensor/src/tensor/linalg/lu.rs
@@ -383,7 +383,7 @@ fn update_kth_column<const D: usize>(tensor: Tensor<D>, k: usize) -> Tensor<D> {
     // A singular matrix will have a pivot of exactly 0.
     // Due to partial pivoting, if the pivot is 0, all elements below it are also 0.
     // We replace 0 with 1.0 to avoid NaN when dividing 0.0 / 0.0.
-    let is_zero_mask = a_kk.clone().equal_elem(0.0);
+    let is_zero_mask = a_kk.clone().equal_scalar(0.0);
     let safe_a_kk = a_kk.mask_fill(is_zero_mask, 1.0);
     let updated_column = a_rho_k / safe_a_kk;
 

--- a/crates/burn-tensor/src/tensor/linalg/vector_norm.rs
+++ b/crates/burn-tensor/src/tensor/linalg/vector_norm.rs
@@ -211,7 +211,7 @@ where
     K: Numeric,
 {
     x.zeros_like()
-        .mask_fill(x.not_equal_elem(0), 1)
+        .mask_fill(x.not_equal_scalar(0), 1)
         .sum_dim(dim)
 }
 

--- a/crates/burn-train/src/metric/acc.rs
+++ b/crates/burn-train/src/metric/acc.rs
@@ -54,7 +54,7 @@ impl Metric for AccuracyMetric {
 
         let accuracy = match self.pad_token {
             Some(pad_token) => {
-                let mask = targets.clone().equal_elem(pad_token as i64);
+                let mask = targets.clone().equal_scalar(pad_token as i64);
                 let matches = outputs.equal(targets).float().mask_fill(mask.clone(), 0);
                 let num_pad = mask.float().sum();
 

--- a/crates/burn-train/src/metric/cer.rs
+++ b/crates/burn-train/src/metric/cer.rs
@@ -83,8 +83,8 @@ impl Metric for CharErrorRate {
 
         let (output_lengths, target_lengths) = if let Some(pad) = self.pad_token {
             // Create boolean masks for non-padding tokens.
-            let output_mask = outputs.clone().not_equal_elem(pad as i64);
-            let target_mask = targets.clone().not_equal_elem(pad as i64);
+            let output_mask = outputs.clone().not_equal_scalar(pad as i64);
+            let target_mask = targets.clone().not_equal_scalar(pad as i64);
 
             let output_lengths_tensor = output_mask.int().sum_dim(1);
             let target_lengths_tensor = target_mask.int().sum_dim(1);

--- a/crates/burn-train/src/metric/confusion_stats.rs
+++ b/crates/burn-train/src/metric/confusion_stats.rs
@@ -56,7 +56,9 @@ impl ConfusionStats {
     /// Expects `predictions` to be normalized.
     pub fn new(input: &ConfusionStatsInput, config: &ClassificationMetricConfig) -> Self {
         let prediction_mask = match config.decision_rule {
-            DecisionRule::Threshold(threshold) => input.predictions.clone().greater_elem(threshold),
+            DecisionRule::Threshold(threshold) => {
+                input.predictions.clone().greater_scalar(threshold)
+            }
             DecisionRule::TopK(top_k) => {
                 let mask = input.predictions.zeros_like();
                 let indexes =
@@ -86,19 +88,19 @@ impl ConfusionStats {
     }
 
     pub fn true_positive(self) -> Tensor<1> {
-        Self::aggregate(self.confusion_classes.equal_elem(3), self.class_reduction)
+        Self::aggregate(self.confusion_classes.equal_scalar(3), self.class_reduction)
     }
 
     pub fn true_negative(self) -> Tensor<1> {
-        Self::aggregate(self.confusion_classes.equal_elem(0), self.class_reduction)
+        Self::aggregate(self.confusion_classes.equal_scalar(0), self.class_reduction)
     }
 
     pub fn false_positive(self) -> Tensor<1> {
-        Self::aggregate(self.confusion_classes.equal_elem(1), self.class_reduction)
+        Self::aggregate(self.confusion_classes.equal_scalar(1), self.class_reduction)
     }
 
     pub fn false_negative(self) -> Tensor<1> {
-        Self::aggregate(self.confusion_classes.equal_elem(2), self.class_reduction)
+        Self::aggregate(self.confusion_classes.equal_scalar(2), self.class_reduction)
     }
 
     pub fn positive(self) -> Tensor<1> {

--- a/crates/burn-train/src/metric/hamming.rs
+++ b/crates/burn-train/src/metric/hamming.rs
@@ -78,7 +78,7 @@ impl Metric for HammingScore {
         }
 
         let score = outputs
-            .greater_elem(self.threshold)
+            .greater_scalar(self.threshold)
             .equal(targets.bool())
             .float()
             .mean()

--- a/crates/burn-train/src/metric/perplexity.rs
+++ b/crates/burn-train/src/metric/perplexity.rs
@@ -189,7 +189,7 @@ impl Metric for PerplexityMetric {
         let (sum_log_prob, effective_tokens) = match self.pad_token {
             Some(pad_token) => {
                 // Create a mask for non-padding tokens
-                let mask = targets.clone().not_equal_elem(pad_token as i64);
+                let mask = targets.clone().not_equal_scalar(pad_token as i64);
 
                 // Apply mask to log probabilities (set padding log probs to 0)
                 let masked_log_probs = target_log_probs.mask_fill(mask.clone().bool_not(), 0.0);

--- a/crates/burn-train/src/metric/top_k_acc.rs
+++ b/crates/burn-train/src/metric/top_k_acc.rs
@@ -64,7 +64,7 @@ impl Metric for TopKAccuracyMetric {
         let (targets, num_pad) = match self.pad_token {
             Some(pad_token) => {
                 // we ignore the samples where the target is equal to the pad token
-                let mask = targets.clone().equal_elem(pad_token as i64);
+                let mask = targets.clone().equal_scalar(pad_token as i64);
                 let num_pad = mask.clone().int().sum().into_scalar::<f64>();
                 (targets.clone().mask_fill(mask, -1_i64), num_pad)
             }

--- a/crates/burn-vision/tests/morphology.rs
+++ b/crates/burn-vision/tests/morphology.rs
@@ -299,13 +299,13 @@ fn should_support_dilate_rgb_anchor_cross() {
 #[test]
 fn should_support_dilate_boolean_rect() {
     let device = TestDevice::default().into();
-    let tensor = test_image("morphology/Base_1.png", &device, true).greater_elem(0);
+    let tensor = test_image("morphology/Base_1.png", &device, true).greater_scalar(0);
     let kernel = create_structuring_element(KernelShape::Rect, Size::new(5, 5), None, &device);
 
     // With default border, bottom left pixel is undefined with this particular kernel and anchor
     // Use replicate instead for comparability
     let output = tensor.dilate(kernel, MorphOptions::default());
-    let expected = test_image("morphology/Dilate_1_5x5_Rect.png", &device, true).greater_elem(0);
+    let expected = test_image("morphology/Dilate_1_5x5_Rect.png", &device, true).greater_scalar(0);
     let expected = TestTensorBool::<3>::from(expected);
 
     output
@@ -316,13 +316,13 @@ fn should_support_dilate_boolean_rect() {
 #[test]
 fn should_support_dilate_boolean_cross() {
     let device = TestDevice::default().into();
-    let tensor = test_image("morphology/Base_1.png", &device, true).greater_elem(0);
+    let tensor = test_image("morphology/Base_1.png", &device, true).greater_scalar(0);
     let kernel = create_structuring_element(KernelShape::Cross, Size::new(5, 5), None, &device);
 
     // With default border, bottom left pixel is undefined with this particular kernel and anchor
     // Use replicate instead for comparability
     let output = tensor.dilate(kernel, MorphOptions::default());
-    let expected = test_image("morphology/Dilate_1_5x5_Cross.png", &device, true).greater_elem(0);
+    let expected = test_image("morphology/Dilate_1_5x5_Cross.png", &device, true).greater_scalar(0);
     let expected = TestTensorBool::<3>::from(expected);
 
     output

--- a/examples/notebook/basic-tensor-op.ipynb
+++ b/examples/notebook/basic-tensor-op.ipynb
@@ -1068,13 +1068,13 @@
     "let a: Tensor<B, 1> = Tensor::from_floats([1.0, 5.0, 3.0, 8.0], &device);\n",
     "\n",
     "// mask_where: where condition is true, use replacement value, else keep original value\n",
-    "let condition = a.clone().greater_elem(4.0);\n",
+    "let condition = a.clone().greater_scalar(4.0);\n",
     "let result = a.clone().mask_where(condition, Tensor::zeros([4], &device));\n",
     "println!(\"Original: {}\", a);\n",
     "println!(\"Where > 4, replace with 0: {}\", result);\n",
     "\n",
     "// mask_fill: simpler - just replace values matching condition\n",
-    "let result = a.clone().mask_fill(a.clone().greater_elem(4.0), -1.0);\n",
+    "let result = a.clone().mask_fill(a.clone().greater_scalar(4.0), -1.0);\n",
     "println!(\"Where > 4, replace with -1: {}\", result);"
    ]
   },


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Changes

Comparison methods were the only ones in the tensor API that referred to scalars as `_elem`.

This renames each method with the `_scalar` prefix and preserves the previous methods as aliases for backward compat. I also replaced all usage to the `_scalar` methods.

For now, the backend tensor ops traits still have the elem suffix (e.g. `float_equal_elem`).

### Testing

Unit tests (kept `_elem` methods as test, so the alias and the scalar method are tested).
