### PR TITLE
fix(tensor): preserve error formatting for invalid dimensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -172,7 +172,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -681,7 +681,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -1778,7 +1778,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2255,7 +2255,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=31c5506cfc1dd9d350124910fb51cee8b54a31e1#31c5506cfc1dd9d350124910fb51cee8b54a31e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7c6a9e79565c2d496fd4825649535850fdcc5006#7c6a9e79565c2d496fd4825649535850fdcc5006"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -2271,7 +2271,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=31c5506cfc1dd9d350124910fb51cee8b54a31e1#31c5506cfc1dd9d350124910fb51cee8b54a31e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7c6a9e79565c2d496fd4825649535850fdcc5006#7c6a9e79565c2d496fd4825649535850fdcc5006"
 dependencies = [
  "backtrace",
  "bytemuck",
@@ -2312,7 +2312,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=31c5506cfc1dd9d350124910fb51cee8b54a31e1#31c5506cfc1dd9d350124910fb51cee8b54a31e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7c6a9e79565c2d496fd4825649535850fdcc5006#7c6a9e79565c2d496fd4825649535850fdcc5006"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -2341,7 +2341,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=31c5506cfc1dd9d350124910fb51cee8b54a31e1#31c5506cfc1dd9d350124910fb51cee8b54a31e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7c6a9e79565c2d496fd4825649535850fdcc5006#7c6a9e79565c2d496fd4825649535850fdcc5006"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2357,7 +2357,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=31c5506cfc1dd9d350124910fb51cee8b54a31e1#31c5506cfc1dd9d350124910fb51cee8b54a31e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7c6a9e79565c2d496fd4825649535850fdcc5006#7c6a9e79565c2d496fd4825649535850fdcc5006"
 dependencies = [
  "bytemuck",
  "crossbeam-utils",
@@ -2383,7 +2383,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=31c5506cfc1dd9d350124910fb51cee8b54a31e1#31c5506cfc1dd9d350124910fb51cee8b54a31e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7c6a9e79565c2d496fd4825649535850fdcc5006#7c6a9e79565c2d496fd4825649535850fdcc5006"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2401,7 +2401,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=31c5506cfc1dd9d350124910fb51cee8b54a31e1#31c5506cfc1dd9d350124910fb51cee8b54a31e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7c6a9e79565c2d496fd4825649535850fdcc5006#7c6a9e79565c2d496fd4825649535850fdcc5006"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2430,7 +2430,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=31c5506cfc1dd9d350124910fb51cee8b54a31e1#31c5506cfc1dd9d350124910fb51cee8b54a31e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7c6a9e79565c2d496fd4825649535850fdcc5006#7c6a9e79565c2d496fd4825649535850fdcc5006"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -2454,7 +2454,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=31c5506cfc1dd9d350124910fb51cee8b54a31e1#31c5506cfc1dd9d350124910fb51cee8b54a31e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7c6a9e79565c2d496fd4825649535850fdcc5006#7c6a9e79565c2d496fd4825649535850fdcc5006"
 dependencies = [
  "cubecl-common",
  "darling 0.23.0",
@@ -2471,7 +2471,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=31c5506cfc1dd9d350124910fb51cee8b54a31e1#31c5506cfc1dd9d350124910fb51cee8b54a31e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7c6a9e79565c2d496fd4825649535850fdcc5006#7c6a9e79565c2d496fd4825649535850fdcc5006"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -2482,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=31c5506cfc1dd9d350124910fb51cee8b54a31e1#31c5506cfc1dd9d350124910fb51cee8b54a31e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7c6a9e79565c2d496fd4825649535850fdcc5006#7c6a9e79565c2d496fd4825649535850fdcc5006"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2500,7 +2500,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=31c5506cfc1dd9d350124910fb51cee8b54a31e1#31c5506cfc1dd9d350124910fb51cee8b54a31e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7c6a9e79565c2d496fd4825649535850fdcc5006#7c6a9e79565c2d496fd4825649535850fdcc5006"
 dependencies = [
  "ahash",
  "async-channel",
@@ -2532,7 +2532,7 @@ dependencies = [
 [[package]]
 name = "cubecl-spirv"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=31c5506cfc1dd9d350124910fb51cee8b54a31e1#31c5506cfc1dd9d350124910fb51cee8b54a31e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7c6a9e79565c2d496fd4825649535850fdcc5006#7c6a9e79565c2d496fd4825649535850fdcc5006"
 dependencies = [
  "bitflags 2.13.1",
  "cubecl-common",
@@ -2548,7 +2548,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=31c5506cfc1dd9d350124910fb51cee8b54a31e1#31c5506cfc1dd9d350124910fb51cee8b54a31e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7c6a9e79565c2d496fd4825649535850fdcc5006#7c6a9e79565c2d496fd4825649535850fdcc5006"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2564,7 +2564,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=31c5506cfc1dd9d350124910fb51cee8b54a31e1#31c5506cfc1dd9d350124910fb51cee8b54a31e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7c6a9e79565c2d496fd4825649535850fdcc5006#7c6a9e79565c2d496fd4825649535850fdcc5006"
 dependencies = [
  "ash",
  "async-channel",
@@ -2593,7 +2593,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=31c5506cfc1dd9d350124910fb51cee8b54a31e1#31c5506cfc1dd9d350124910fb51cee8b54a31e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7c6a9e79565c2d496fd4825649535850fdcc5006#7c6a9e79565c2d496fd4825649535850fdcc5006"
 dependencies = [
  "derive-new",
  "serde",
@@ -2603,7 +2603,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=55567e4ff2708499b0a329e57655208c2a77f71a#55567e4ff2708499b0a329e57655208c2a77f71a"
+source = "git+https://github.com/tracel-ai/cubek?rev=5381d3a11a36713ebe3967ec94251eb4f51b0cff#5381d3a11a36713ebe3967ec94251eb4f51b0cff"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2621,7 +2621,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=55567e4ff2708499b0a329e57655208c2a77f71a#55567e4ff2708499b0a329e57655208c2a77f71a"
+source = "git+https://github.com/tracel-ai/cubek?rev=5381d3a11a36713ebe3967ec94251eb4f51b0cff#5381d3a11a36713ebe3967ec94251eb4f51b0cff"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2635,7 +2635,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=55567e4ff2708499b0a329e57655208c2a77f71a#55567e4ff2708499b0a329e57655208c2a77f71a"
+source = "git+https://github.com/tracel-ai/cubek?rev=5381d3a11a36713ebe3967ec94251eb4f51b0cff#5381d3a11a36713ebe3967ec94251eb4f51b0cff"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2651,7 +2651,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=55567e4ff2708499b0a329e57655208c2a77f71a#55567e4ff2708499b0a329e57655208c2a77f71a"
+source = "git+https://github.com/tracel-ai/cubek?rev=5381d3a11a36713ebe3967ec94251eb4f51b0cff#5381d3a11a36713ebe3967ec94251eb4f51b0cff"
 dependencies = [
  "cubecl",
 ]
@@ -2659,7 +2659,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=55567e4ff2708499b0a329e57655208c2a77f71a#55567e4ff2708499b0a329e57655208c2a77f71a"
+source = "git+https://github.com/tracel-ai/cubek?rev=5381d3a11a36713ebe3967ec94251eb4f51b0cff#5381d3a11a36713ebe3967ec94251eb4f51b0cff"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2671,7 +2671,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=55567e4ff2708499b0a329e57655208c2a77f71a#55567e4ff2708499b0a329e57655208c2a77f71a"
+source = "git+https://github.com/tracel-ai/cubek?rev=5381d3a11a36713ebe3967ec94251eb4f51b0cff#5381d3a11a36713ebe3967ec94251eb4f51b0cff"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2685,7 +2685,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=55567e4ff2708499b0a329e57655208c2a77f71a#55567e4ff2708499b0a329e57655208c2a77f71a"
+source = "git+https://github.com/tracel-ai/cubek?rev=5381d3a11a36713ebe3967ec94251eb4f51b0cff#5381d3a11a36713ebe3967ec94251eb4f51b0cff"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2695,7 +2695,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=55567e4ff2708499b0a329e57655208c2a77f71a#55567e4ff2708499b0a329e57655208c2a77f71a"
+source = "git+https://github.com/tracel-ai/cubek?rev=5381d3a11a36713ebe3967ec94251eb4f51b0cff#5381d3a11a36713ebe3967ec94251eb4f51b0cff"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2707,7 +2707,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=55567e4ff2708499b0a329e57655208c2a77f71a#55567e4ff2708499b0a329e57655208c2a77f71a"
+source = "git+https://github.com/tracel-ai/cubek?rev=5381d3a11a36713ebe3967ec94251eb4f51b0cff#5381d3a11a36713ebe3967ec94251eb4f51b0cff"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2720,7 +2720,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=55567e4ff2708499b0a329e57655208c2a77f71a#55567e4ff2708499b0a329e57655208c2a77f71a"
+source = "git+https://github.com/tracel-ai/cubek?rev=5381d3a11a36713ebe3967ec94251eb4f51b0cff#5381d3a11a36713ebe3967ec94251eb4f51b0cff"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2733,7 +2733,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=55567e4ff2708499b0a329e57655208c2a77f71a#55567e4ff2708499b0a329e57655208c2a77f71a"
+source = "git+https://github.com/tracel-ai/cubek?rev=5381d3a11a36713ebe3967ec94251eb4f51b0cff#5381d3a11a36713ebe3967ec94251eb4f51b0cff"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2743,7 +2743,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=55567e4ff2708499b0a329e57655208c2a77f71a#55567e4ff2708499b0a329e57655208c2a77f71a"
+source = "git+https://github.com/tracel-ai/cubek?rev=5381d3a11a36713ebe3967ec94251eb4f51b0cff#5381d3a11a36713ebe3967ec94251eb4f51b0cff"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -3243,7 +3243,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3605,7 +3605,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4290,8 +4290,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -4923,7 +4923,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -6580,7 +6580,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7043,15 +7043,6 @@ name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "ordered-float"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
 ]
@@ -8363,7 +8354,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9073,7 +9064,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9131,7 +9122,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9284,7 +9275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9670,7 +9661,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9786,7 +9777,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10052,7 +10043,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10074,7 +10065,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook 0.3.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10084,7 +10075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10129,7 +10120,7 @@ dependencies = [
  "nix 0.29.0",
  "num-derive",
  "num-traits",
- "ordered-float 4.6.0",
+ "ordered-float",
  "pest",
  "pest_derive",
  "phf 0.11.3",
@@ -11428,7 +11419,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
 dependencies = [
  "log",
- "ordered-float 4.6.0",
+ "ordered-float",
  "strsim",
  "thiserror 1.0.69",
  "wezterm-dynamic-derive",
@@ -11591,7 +11582,7 @@ dependencies = [
  "objc2-metal",
  "objc2-quartz-core",
  "once_cell",
- "ordered-float 5.3.0",
+ "ordered-float",
  "parking_lot",
  "portable-atomic",
  "portable-atomic-util",
@@ -11679,7 +11670,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12167,8 +12158,8 @@ dependencies = [
  "log",
  "serde",
  "thiserror 2.0.19",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,10 +223,10 @@ burn-vision = { path = "crates/burn-vision", version = "0.22.0-pre.1", default-f
 burn-wgpu = { path = "crates/burn-wgpu", version = "0.22.0-pre.1", default-features = false }
 
 ### For the main burn branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "31c5506cfc1dd9d350124910fb51cee8b54a31e1" }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "31c5506cfc1dd9d350124910fb51cee8b54a31e1" }
-cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "31c5506cfc1dd9d350124910fb51cee8b54a31e1" }
-cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "55567e4ff2708499b0a329e57655208c2a77f71a" }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "7c6a9e79565c2d496fd4825649535850fdcc5006" }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "7c6a9e79565c2d496fd4825649535850fdcc5006" }
+cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "7c6a9e79565c2d496fd4825649535850fdcc5006" }
+cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "5381d3a11a36713ebe3967ec94251eb4f51b0cff" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }

--- a/crates/burn-backend-tests/tests/tensor/float/ops/chunk.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/chunk.rs
@@ -79,7 +79,7 @@ fn test_chunk_not_divisible() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "=== Tensor Operation Error ===")]
 fn test_invalid_dim() {
     let _tensors = TestTensorInt::arange(0..12, &Default::default()).chunk(6, 1);
 }

--- a/crates/burn-backend-tests/tests/tensor/float/ops/flip.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/flip.rs
@@ -38,7 +38,7 @@ fn flip_duplicated_axes() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "=== Tensor Operation Error ===")]
 fn flip_out_of_bound_axis() {
     let device = Default::default();
     let tensor = TestTensorInt::<1>::arange(0..24, &device).reshape([2, 3, 4]);

--- a/crates/burn-backend-tests/tests/tensor/float/ops/iter_dim.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/iter_dim.rs
@@ -15,7 +15,7 @@ fn test_1d_iter_last_item() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "=== Tensor Operation Error ===")]
 fn test_too_high_dimension() {
     TestTensor::<1>::zeros([10], &Default::default()).iter_dim(1);
 }

--- a/crates/burn-backend-tests/tests/tensor/float/ops/movedim.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/movedim.rs
@@ -93,7 +93,7 @@ fn edge_different_sizes() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "=== Tensor Operation Error ===")]
 fn edge_out_of_bound_axis() {
     let device = Default::default();
     let tensor = TestTensorInt::<1>::arange(0..24, &device).reshape([2, 3, 4]);
@@ -113,7 +113,7 @@ fn edge_vec_is_not_a_set() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "=== Tensor Operation Error ===")]
 fn edge_out_of_bound_axis_vec() {
     let device = Default::default();
     let tensor = TestTensorInt::<1>::arange(0..24, &device).reshape([2, 3, 4]);

--- a/crates/burn-backend-tests/tests/tensor/float/ops/narrow.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/narrow.rs
@@ -54,7 +54,7 @@ fn test_narrow_3() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "=== Tensor Operation Error ===")]
 fn test_narrow_invalid_dim() {
     let tensor = TestTensor::<2>::from_data(
         TensorData::from([[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]]),

--- a/crates/burn-backend-tests/tests/tensor/float/ops/slice.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/slice.rs
@@ -21,12 +21,20 @@ fn should_support_slice_dim_1d() {
 }
 
 #[test]
-#[should_panic(expected = "Index { kind: Dimension, index: 1, bounds: 0..1 }")]
+#[should_panic(expected = "=== Tensor Operation Error ===")]
 fn should_panic_when_slice_dim_1d_bad_dim() {
     let data = TensorData::from([0.0, 1.0, 2.0]);
     let tensor = TestTensor::<1>::from_data(data.clone(), &Default::default());
 
     let _output = tensor.slice_dim(1, 1..);
+}
+
+#[test]
+#[should_panic(expected = "=== Tensor Operation Error ===")]
+fn should_panic_when_slice_dim_negative_dim_is_out_of_bounds() {
+    let tensor = TestTensor::<1>::from([0.0, 1.0, 2.0]);
+
+    let _output = tensor.slice_dim(-2_i64, 1..);
 }
 
 #[test]

--- a/crates/burn-backend-tests/tests/tensor/float/ops/split.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/split.rs
@@ -105,12 +105,28 @@ fn test_split_with_zero_split_size_non_zero_tensor() {
 }
 
 #[test]
-#[should_panic(expected = "Index { kind: Dimension, index: 2, bounds: 0..1 }")]
+#[should_panic(expected = "=== Tensor Operation Error ===")]
 fn test_split_invalid_dim() {
     let device = Default::default();
     let tensors = TestTensor::<1>::from_data([0, 1, 2], &device);
 
     let _split_tensors = tensors.split(1, 2);
+}
+
+#[test]
+#[should_panic(expected = "=== Tensor Operation Error ===")]
+fn test_split_negative_dim_out_of_bounds() {
+    let tensor = TestTensor::<1>::from([0, 1, 2]);
+
+    let _split_tensors = tensor.split(1, -2_i64);
+}
+
+#[test]
+#[should_panic(expected = "=== Tensor Operation Error ===")]
+fn test_split_with_sizes_negative_dim_out_of_bounds() {
+    let tensor = TestTensor::<1>::from([0, 1, 2]);
+
+    let _split_tensors = tensor.split_with_sizes(vec![1, 2], -2_i64);
 }
 
 #[test]

--- a/crates/burn-backend-tests/tests/tensor/float/ops/squeeze.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/squeeze.rs
@@ -139,7 +139,7 @@ fn should_unsqueeze_dim_last() {
 
 /// Test if the function panics when the unsqueezed dimension is out of bounds.
 #[test]
-#[should_panic]
+#[should_panic(expected = "=== Tensor Operation Error ===")]
 fn should_unsqueeze_dim_panic() {
     let tensor = TestTensor::<4>::ones(Shape::new([2, 3, 4, 5]), &Default::default());
     let _unsqueezed_tensor: TestTensor<5> = tensor.unsqueeze_dim(5);

--- a/crates/burn-backend-tests/tests/tensor/float/quantization/ops/extended/split.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/quantization/ops/extended/split.rs
@@ -95,7 +95,7 @@ fn test_split_with_zero_split_size_non_zero_tensor() {
 }
 
 #[test]
-#[should_panic(expected = "Index { kind: Dimension, index: 2, bounds: 0..1 }")]
+#[should_panic(expected = "=== Tensor Operation Error ===")]
 fn test_split_invalid_dim() {
     let tensor = QTensor::<1>::int8([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]);
 

--- a/crates/burn-tensor/src/tensor/activation/base.rs
+++ b/crates/burn-tensor/src/tensor/activation/base.rs
@@ -2,6 +2,7 @@ use burn_backend::ops::ActivationOps;
 use burn_dispatch::Dispatch;
 
 use crate::check::TensorCheck;
+use crate::check::unwrap_dim_index;
 use crate::ops::BridgeTensor;
 use crate::{AsIndex, Tensor, check, s};
 
@@ -185,9 +186,7 @@ $$
 /// # Panics
 /// - If `dim` is outside [-D, D)
 pub fn softmax<const D: usize>(tensor: Tensor<D>, dim: impl AsIndex) -> Tensor<D> {
-    let dim = dim.expect_dim_index(D);
-    check!(TensorCheck::dim_ops::<D>("softmax", dim));
-
+    let dim = unwrap_dim_index(dim.try_dim_index(D));
     Tensor::new(softmax_impl(tensor.primitive, dim))
 }
 
@@ -210,9 +209,7 @@ $$
 /// # Panics
 /// - If `dim` is outside [-D, D)
 pub fn softmin<const D: usize>(tensor: Tensor<D>, dim: impl AsIndex) -> Tensor<D> {
-    let dim = dim.expect_dim_index(D);
-    check!(TensorCheck::dim_ops::<D>("softmin", dim));
-
+    let dim = unwrap_dim_index(dim.try_dim_index(D));
     Tensor::new(softmin_impl(tensor.primitive, dim))
 }
 
@@ -261,9 +258,7 @@ $$
 /// # Panics
 /// - If `dim` is outside [-D, D)
 pub fn quiet_softmax<const D: usize>(tensor: Tensor<D>, dim: impl AsIndex) -> Tensor<D> {
-    let dim = dim.expect_dim_index(D);
-    check!(TensorCheck::dim_ops::<D>("softmax", dim));
-
+    let dim = unwrap_dim_index(dim.try_dim_index(D));
     let max_vals = tensor.clone().detach().max_dim(dim);
     let exp_x = (tensor - max_vals.clone()).exp();
     let sum_exp = exp_x.clone().sum_dim(dim);
@@ -295,9 +290,7 @@ $$
 /// # Panics
 /// - If `dim` is outside [-D, D)
 pub fn log_softmax<const D: usize>(tensor: Tensor<D>, dim: impl AsIndex) -> Tensor<D> {
-    let dim = dim.expect_dim_index(D);
-    check!(TensorCheck::dim_ops::<D>("log softmax", dim));
-
+    let dim = unwrap_dim_index(dim.try_dim_index(D));
     Tensor::new(log_softmax_impl(tensor.primitive, dim))
 }
 
@@ -553,7 +546,7 @@ pub fn threshold<const D: usize>(tensor: Tensor<D>, threshold: f64, value: f64) 
 /// ### Returns
 /// * A tensor with the same shape as the input, except the size along `dim` is halved.
 pub fn glu<const D: usize>(tensor: Tensor<D>, dim: impl AsIndex) -> Tensor<D> {
-    let dim = dim.expect_dim_index(D);
+    let dim = unwrap_dim_index(dim.try_dim_index(D));
     assert!(
         tensor.dims()[dim].is_multiple_of(2),
         "Input tensor along dimension {dim} must have an even size. N is divisible by 2."

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::single_range_in_vec_init)]
-use crate::check::unwrap_shape_reshape;
+use crate::check::{unwrap_dim_index, unwrap_shape_reshape};
 use crate::kind::Basic;
 use crate::ops::BridgeTensor;
 
@@ -461,8 +461,8 @@ where
         Dim1: AsIndex,
         Dim2: AsIndex,
     {
-        let dim1 = dim1.expect_dim_index(D);
-        let dim2 = dim2.expect_dim_index(D);
+        let dim1 = unwrap_dim_index(dim1.try_dim_index(D));
+        let dim2 = unwrap_dim_index(dim2.try_dim_index(D));
         check!(TensorCheck::swap_dims::<D>(dim1, dim2));
         if dim1 == dim2 {
             self
@@ -510,7 +510,7 @@ where
         let mut no_op = true;
         let mut fixed_axes = [0; D];
         for (i, axis) in axes.into_iter().enumerate() {
-            let dim = axis.expect_dim_index(D);
+            let dim = unwrap_dim_index(axis.try_dim_index(D));
             no_op &= dim == i;
             fixed_axes[i] = dim;
         }
@@ -642,7 +642,7 @@ where
         // Convert the axes to usize without allocating.
         let mut transformed_axes: [usize; N] = [0; N];
         for (i, axis) in axes.into_iter().enumerate() {
-            transformed_axes[i] = axis.expect_dim_index(D);
+            transformed_axes[i] = unwrap_dim_index(axis.try_dim_index(D));
         }
 
         // Check if the axes are valid
@@ -693,8 +693,8 @@ where
         start_dim: impl AsIndex,
         end_dim: impl AsIndex,
     ) -> Tensor<D2, K> {
-        let start_dim = start_dim.expect_dim_index(D);
-        let end_dim = end_dim.expect_dim_index(D);
+        let start_dim = unwrap_dim_index(start_dim.try_dim_index(D));
+        let end_dim = unwrap_dim_index(end_dim.try_dim_index(D));
         check!(TensorCheck::flatten::<D, D2>(start_dim, end_dim));
         let new_shape = self.shape().flatten_dims(start_dim, end_dim);
 
@@ -783,7 +783,7 @@ where
     /// }
     /// ```
     pub fn squeeze_dim<const D2: usize>(self, dim: impl AsIndex) -> Tensor<D2, K> {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         check!(TensorCheck::squeeze::<D2>(dim, &self.shape()));
 
         let current_dims = self.shape();
@@ -844,7 +844,10 @@ where
                 .filter_map(|(index, &dim)| if dim == 1 { Some(index) } else { None })
                 .collect();
         } else {
-            dim_indices = dims.iter().map(|dim| dim.expect_dim_index(D)).collect();
+            dim_indices = dims
+                .iter()
+                .map(|dim| unwrap_dim_index(dim.try_dim_index(D)))
+                .collect();
         }
 
         // Sort indices and remove duplicates
@@ -936,7 +939,7 @@ where
     /// }
     /// ```
     pub fn unsqueeze_dim<const D2: usize>(self, dim: impl AsIndex) -> Tensor<D2, K> {
-        let dim = dim.expect_dim_index(D + 1);
+        let dim = unwrap_dim_index(dim.try_dim_index(D + 1));
         check!(TensorCheck::unsqueeze_dim::<D, D2>(dim));
 
         let mut dims = [1; D2];
@@ -1061,7 +1064,7 @@ where
         Shift: AsIndex,
         Dim: AsIndex,
     {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         let size = self.shape()[dim];
         if size == 0 {
             // If the dimension is empty, return the tensor as is.
@@ -1150,7 +1153,7 @@ where
         // Accumulate the effective shifts for each dimension.
         let mut accumulated_shifts: Vec<isize> = vec![0; shape.len()];
         for i in 0..item_count {
-            let dim = dims[i].expect_dim_index(D);
+            let dim = unwrap_dim_index(dims[i].try_dim_index(D));
             accumulated_shifts[dim] += shifts[i].as_index();
         }
 
@@ -1560,7 +1563,7 @@ where
     where
         S: Into<Slice>,
     {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         let slice: Slice = slice.into();
 
         let mut slices = vec![Slice::full(); D];
@@ -1601,7 +1604,7 @@ where
     /// }
     /// ```
     pub fn select(self, dim: impl AsIndex, indices: Tensor<1, Int>) -> Self {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         check!(TensorCheck::select::<D>(dim));
         Self::new(K::select(self.primitive, dim, indices.primitive))
     }
@@ -1639,7 +1642,7 @@ where
         values: Tensor<D, K>,
         update: IndexingUpdateOp,
     ) -> Self {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         check!(TensorCheck::select_assign::<D>(
             dim,
             &indices.shape(),
@@ -1725,7 +1728,7 @@ where
     /// Not all backends have runtime bound checks for the indices, so make sure the they are valid.
     /// Otherwise, out of bounds indices could lead to unexpected results instead of panicking.
     pub fn gather(self, dim: impl AsIndex, indices: Tensor<D, Int>) -> Self {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         check!(TensorCheck::gather::<D>(
             dim,
             &self.shape(),
@@ -1770,7 +1773,7 @@ where
         values: Self,
         update: IndexingUpdateOp,
     ) -> Self {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         check!(TensorCheck::scatter::<D>(
             dim,
             &self.shape(),
@@ -1947,7 +1950,7 @@ where
     /// }
     /// ```
     pub fn repeat_dim(self, dim: impl AsIndex, times: usize) -> Self {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         if times > 0 {
             Self::new(K::repeat_dim(self.primitive, dim, times))
         } else {
@@ -2147,7 +2150,7 @@ where
     /// }
     /// ```
     pub fn cat(tensors: Vec<Self>, dim: impl AsIndex) -> Self {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         check!(TensorCheck::cat(tensors.as_slice(), dim));
 
         // Filter out tensors with size 0 along the concatenation dimension.
@@ -2202,7 +2205,7 @@ where
     /// }
     /// ```
     pub fn stack<const D2: usize>(tensors: Vec<Tensor<D, K>>, dim: impl AsIndex) -> Tensor<D2, K> {
-        let dim = dim.expect_dim_index(D + 1);
+        let dim = unwrap_dim_index(dim.try_dim_index(D + 1));
         check!(TensorCheck::stack::<D, K, D2>(tensors.as_slice(), dim));
         let tensors = tensors.into_iter().map(|t| t.unsqueeze_dim(dim)).collect();
         Tensor::<D2, K>::cat(tensors, dim)
@@ -2236,8 +2239,7 @@ where
     /// }
     /// ```
     pub fn iter_dim(self, dim: impl AsIndex) -> DimIter<D, K> {
-        let dim = dim.expect_dim_index(D);
-        check!(TensorCheck::dim_ops::<D>("iter_dim", dim));
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         DimIter::new(self, dim)
     }
 
@@ -2278,8 +2280,7 @@ where
     /// }
     /// ```
     pub fn narrow(self, dim: impl AsIndex, start: usize, length: usize) -> Self {
-        let dim = dim.expect_dim_index(D);
-        check!(TensorCheck::dim_ops::<D>("narrow", dim));
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         check!(TensorCheck::narrow(&self, dim, start, length));
         let dims = self.dims();
 
@@ -2341,8 +2342,7 @@ where
     /// }
     /// ```
     pub fn chunk(self, chunks: usize, dim: impl AsIndex) -> Vec<Self> {
-        let dim = dim.expect_dim_index(D);
-        check!(TensorCheck::dim_ops::<D>("chunk", dim));
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         let size = self.shape()[dim];
         if size < chunks {
             return (0..size)
@@ -2402,7 +2402,7 @@ where
     /// }
     /// ```
     pub fn split(self, split_size: usize, dim: impl AsIndex) -> Vec<Self> {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         check!(TensorCheck::split::<D>(&self.shape(), split_size, dim));
         let size = self.shape()[dim];
         let mut tensors = Vec::new();
@@ -2449,7 +2449,7 @@ where
     /// }
     /// ```
     pub fn split_with_sizes(self, split_sizes: Vec<usize>, dim: impl AsIndex) -> Vec<Self> {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         check!(TensorCheck::split_with_sizes::<D>(
             &self.shape(),
             &split_sizes,
@@ -2534,7 +2534,7 @@ where
     /// }
     /// ```
     pub fn any_dim(self, dim: impl AsIndex) -> Tensor<D, Bool> {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         Tensor::new(K::any_dim(self.primitive, dim))
     }
 
@@ -2597,7 +2597,7 @@ where
     /// }
     /// ```
     pub fn all_dim(self, dim: impl AsIndex) -> Tensor<D, Bool> {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         Tensor::new(K::all_dim(self.primitive, dim))
     }
 
@@ -2748,7 +2748,7 @@ where
         size: usize,
         step: usize,
     ) -> Tensor<D2, K> {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         check!(TensorCheck::unfold::<D, D2>(
             "unfold",
             &self.shape(),
@@ -2942,7 +2942,7 @@ impl<I: AsIndex> MovedimArgs for Vec<I> {
     fn into_dim_vec<const D: usize>(self) -> Vec<usize> {
         let set = self
             .into_iter()
-            .map(|dim| dim.expect_dim_index(D))
+            .map(|dim| unwrap_dim_index(dim.try_dim_index(D)))
             .collect::<Vec<usize>>();
         check!(TensorCheck::movedim_args_vec::<D>(&set));
 
@@ -2955,7 +2955,7 @@ macro_rules! impl_movedim_args {
         $(
             impl MovedimArgs for $ty {
                 fn into_dim_vec<const D: usize>(self) -> Vec<usize> {
-                    vec![self.expect_dim_index(D)]
+                    vec![unwrap_dim_index(self.try_dim_index(D))]
                 }
             }
         )*

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -66,20 +66,6 @@ impl TensorCheck {
         check
     }
 
-    pub(crate) fn dim_ops<const D: usize>(ops: &str, dim: usize) -> Self {
-        let mut check = Self::Ok;
-
-        if dim >= D {
-            check = check.register(
-                ops,
-                TensorError::new("Given dimension is higher than the tensor rank.")
-                    .details(format!("Tensor rank: '{D}', given dimension: '{dim}'.")),
-            );
-        }
-
-        check
-    }
-
     pub(crate) fn creation_ops<const D: usize>(ops: &str, dims: &[usize]) -> Self {
         let mut check = Self::Ok;
 
@@ -840,21 +826,6 @@ impl TensorCheck {
         check
     }
 
-    pub(crate) fn check_dim<const D: usize>(dim: usize) -> Self {
-        let mut check = Self::Ok;
-
-        if dim >= D {
-            check = check.register(
-                "Check Dim",
-                TensorError::new("The provided dimension exceeds the tensor dimensions.").details(
-                    format!("Tensor has {D} dimensions, but the provided dimension is {dim}."),
-                ),
-            );
-        }
-
-        check
-    }
-
     pub(crate) fn gather<const D: usize>(dim: usize, shape: &Shape, shape_indices: &Shape) -> Self {
         Self::check_gather_scatter_indices::<D>(Self::Ok, "Gather", dim, shape, shape_indices)
     }
@@ -1207,23 +1178,14 @@ impl TensorCheck {
     ) -> Self {
         let mut check = Self::Ok;
         let op = "split";
-        let tensor_rank = tensor_dims.len();
 
-        if dim >= tensor_rank {
+        let tensor_size = tensor_dims[dim];
+        if split_size == 0 && tensor_size != 0 {
             check = check.register(
                 op,
-                TensorError::new("Given dimension is greater than or equal to the tensor rank.")
-                    .details(format!("Tensor rank: '{D}', given dimension: '{dim}'")),
+                TensorError::new("split_size must be greater than 0 unless the tensor size along the dimension is 0.")
+                    .details(format!("split_size: '{split_size}', tensor size along dim '{dim}': '{tensor_size}'.")),
             );
-        } else {
-            let tensor_size = tensor_dims[dim];
-            if split_size == 0 && tensor_size != 0 {
-                check = check.register(
-                    op,
-                    TensorError::new("split_size must be greater than 0 unless the tensor size along the dimension is 0.")
-                        .details(format!("split_size: '{split_size}', tensor size along dim '{dim}': '{tensor_size}'.")),
-                );
-            }
         }
 
         check
@@ -1236,25 +1198,16 @@ impl TensorCheck {
     ) -> Self {
         let mut check = Self::Ok;
         let op = "split_with_sizes";
-        let tensor_rank = tensor_dims.len();
 
-        if dim >= tensor_rank {
+        // Validate split_sizes add up to size of dimension to split along
+        let tensor_size = tensor_dims[dim];
+        let total_split_size: usize = split_sizes.iter().sum();
+        if total_split_size != tensor_size {
             check = check.register(
                 op,
-                TensorError::new("Given dimension is greater than or equal to the tensor rank.")
-                    .details(format!("Tensor rank: '{D}', given dimension: '{dim}'.")),
+                TensorError::new("The sum of split_sizes must equal the tensor size along the specified dimension.")
+                    .details(format!("Sum of split_sizes: '{total_split_size}', tensor size along dim '{dim}': '{tensor_size}'.")),
             );
-        } else {
-            // Validate split_sizes add up to size of dimension to split along
-            let tensor_size = tensor_dims[dim];
-            let total_split_size: usize = split_sizes.iter().sum();
-            if total_split_size != tensor_size {
-                check = check.register(
-                    op,
-                    TensorError::new("The sum of split_sizes must equal the tensor size along the specified dimension.")
-                        .details(format!("Sum of split_sizes: '{total_split_size}', tensor size along dim '{dim}': '{tensor_size}'.")),
-                );
-            }
         }
 
         check
@@ -1617,6 +1570,22 @@ pub(crate) fn unwrap_shape_reshape(result: Result<Shape, burn_std::MetadataError
             unreachable!()
         }
         Err(e) => panic!("{e:?}"),
+    }
+}
+
+#[track_caller]
+pub(crate) fn unwrap_dim_index<E>(result: Result<usize, E>) -> usize
+where
+    E: core::fmt::Display,
+{
+    match result {
+        Ok(dim) => dim,
+        Err(error) => {
+            macros::check!({
+                TensorCheck::Ok.register("Dimension Indexing", TensorError::new(error.to_string()))
+            });
+            unreachable!()
+        }
     }
 }
 

--- a/crates/burn-tensor/src/tensor/api/float.rs
+++ b/crates/burn-tensor/src/tensor/api/float.rs
@@ -5,6 +5,7 @@ use crate::Tensor;
 use crate::cast::ToElement;
 use crate::check;
 use crate::check::TensorCheck;
+use crate::check::unwrap_dim_index;
 use crate::kind::FloatMath;
 use crate::ops::{BridgeKind, BridgeTensor};
 use crate::quantization::{QuantScheme, QuantizationParameters};
@@ -151,7 +152,7 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     ///
     /// Negative dimensions are supported and count from the end.
     pub fn var<I: AsIndex>(self, dim: I) -> Self {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         stats::var(self, dim)
     }
 
@@ -159,7 +160,7 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     ///
     /// Negative dimensions are supported and count from the end.
     pub fn var_bias<I: AsIndex>(self, dim: I) -> Self {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         stats::var_bias(self, dim)
     }
 
@@ -167,7 +168,7 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     ///
     /// Negative dimensions are supported and count from the end.
     pub fn var_mean<I: AsIndex>(self, dim: I) -> (Self, Self) {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         let mean = self.clone().mean_dim(dim);
         let var = stats::var_with_mean(self, mean.clone(), dim);
         (var, mean)
@@ -177,7 +178,7 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     ///
     /// Negative dimensions are supported and count from the end.
     pub fn var_mean_bias<I: AsIndex>(self, dim: I) -> (Self, Self) {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         let mean = self.clone().mean_dim(dim);
         let var = stats::var_with_mean_bias(self, mean.clone(), dim);
         (var, mean)
@@ -238,7 +239,7 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     /// // Result: [4.0]
     /// ```
     pub fn median<I: AsIndex>(self, dim: I) -> Self {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         // TODO: Allow backend specialization. Optimally, implement a median kernel for cubecl
         // instead of leveraging a full sort to get the median.
         stats::median(self, dim)
@@ -283,7 +284,7 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     /// // values: [[2.0], [6.0]], indices: [[3], [2]] (position in the original tensor)
     /// ```
     pub fn median_with_indices<I: AsIndex>(self, dim: I) -> (Self, Tensor<D, Int>) {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         // TODO: Allow backend specialization. Optimally, implement a median kernel for cubecl
         // instead of leveraging a full sort to get the median.
         stats::median_with_indices(self, dim)
@@ -359,7 +360,7 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     ///   Negative dimensions are supported and count from the end.
     /// * `correction_factor` - Is usually 1 for samples and 0 for population.
     pub fn cov<I: AsIndex>(self, dim: I, correction_factor: usize) -> Tensor<D> {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         let n = self.dims()[dim];
         let centered = (self.clone() - self.mean_dim(dim)).swap_dims(dim, 0);
         centered
@@ -672,7 +673,7 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     ///
     /// A tensor containing the cross product of `self` and `other` along `dim`.
     pub fn cross<Dim: AsIndex>(self, other: Tensor<D>, dim: Dim) -> Tensor<D> {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         check!(TensorCheck::cross(&self, &other, dim));
         Tensor::new(cross_impl(self.primitive, other.primitive, dim))
     }

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -1,6 +1,7 @@
 use burn_backend::Scalar;
 
 use crate::alloc::borrow::ToOwned;
+use crate::check::unwrap_dim_index;
 use crate::kind::Numeric;
 
 use crate::{
@@ -370,7 +371,7 @@ where
     /// }
     /// ```
     pub fn mean_dim<I: AsIndex>(self, dim: I) -> Self {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         check!(TensorCheck::aggregate_dim::<D>("Mean", dim));
         Self::new(K::mean_dim(self.primitive, dim))
     }
@@ -429,7 +430,7 @@ where
     /// }
     /// ```
     pub fn sum_dim<I: AsIndex>(self, dim: I) -> Self {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         check!(TensorCheck::aggregate_dim::<D>("Sum", dim));
         Self::new(K::sum_dim(self.primitive, dim))
     }
@@ -545,7 +546,7 @@ where
     /// }
     /// ```
     pub fn prod_dim<I: AsIndex>(self, dim: I) -> Self {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         check!(TensorCheck::aggregate_dim::<D>("Prod", dim));
         Self::new(K::prod_dim(self.primitive, dim))
     }
@@ -603,7 +604,7 @@ where
     /// }
     /// ```
     pub fn cumsum<I: AsIndex>(self, dim: I) -> Self {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         check!(TensorCheck::aggregate_dim::<D>("CumSum", dim));
         Self::new(K::cumsum(self.primitive, dim))
     }
@@ -632,7 +633,7 @@ where
     /// }
     /// ```
     pub fn cumprod<I: AsIndex>(self, dim: I) -> Self {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         check!(TensorCheck::aggregate_dim::<D>("CumProd", dim));
         Self::new(K::cumprod(self.primitive, dim))
     }

--- a/crates/burn-tensor/src/tensor/api/orderable.rs
+++ b/crates/burn-tensor/src/tensor/api/orderable.rs
@@ -1,6 +1,7 @@
 use burn_backend::{ElementConversion, Scalar};
 use burn_std::{AsIndex, IndexingUpdateOp};
 
+use crate::check::unwrap_dim_index;
 use crate::kind::Ordered;
 use crate::{Bool, Int, check};
 use crate::{Tensor, check::TensorCheck};
@@ -39,7 +40,7 @@ where
     /// }
     /// ```
     pub fn sort<I: AsIndex>(self, dim: I) -> Self {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         check!(TensorCheck::sort_dim::<D>("Sort", dim));
         Tensor::new(K::sort(self.primitive, dim, /*descending*/ false))
     }
@@ -74,7 +75,7 @@ where
     /// }
     /// ```
     pub fn sort_descending<I: AsIndex>(self, dim: I) -> Self {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         check!(TensorCheck::sort_dim::<D>("Sort", dim));
         Tensor::new(K::sort(self.primitive, dim, /*descending*/ true))
     }
@@ -109,7 +110,7 @@ where
     /// }
     /// ```
     pub fn sort_with_indices<I: AsIndex>(self, dim: I) -> (Self, Tensor<D, Int>) {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         check!(TensorCheck::sort_dim::<D>("Sort_with_indices", dim));
         let (values, indices) =
             K::sort_with_indices(self.primitive, dim, /*descending*/ false);
@@ -142,7 +143,7 @@ where
     /// }
     /// ```
     pub fn sort_descending_with_indices<I: AsIndex>(self, dim: I) -> (Self, Tensor<D, Int>) {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         check!(TensorCheck::sort_dim::<D>("Sort_with_indices", dim));
         let (values, indices) = K::sort_with_indices(self.primitive, dim, /*descending*/ true);
         (Tensor::new(values), Tensor::new(indices))
@@ -171,7 +172,7 @@ where
     /// }
     /// ```
     pub fn argsort<I: AsIndex>(self, dim: I) -> Tensor<D, Int> {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         check!(TensorCheck::sort_dim::<D>("Argsort", dim));
         Tensor::new(K::argsort(self.primitive, dim, /*descending*/ false))
     }
@@ -202,7 +203,7 @@ where
     /// }
     /// ```
     pub fn argsort_descending<I: AsIndex>(self, dim: I) -> Tensor<D, Int> {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         check!(TensorCheck::sort_dim::<D>("Argsort", dim));
         Tensor::new(K::argsort(self.primitive, dim, /*descending*/ true))
     }
@@ -236,7 +237,7 @@ where
     /// }
     /// ```
     pub fn topk<I: AsIndex>(self, k: usize, dim: I) -> Self {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         assert!(self.shape()[dim] > k);
         Tensor::new(K::topk(self.primitive, dim, k))
     }
@@ -271,7 +272,7 @@ where
     /// }
     /// ```
     pub fn topk_with_indices<I: AsIndex>(self, k: usize, dim: I) -> (Self, Tensor<D, Int>) {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         let (values, indices) = K::topk_with_indices(self.primitive, dim, k);
         (Tensor::new(values), Tensor::new(indices))
     }
@@ -333,7 +334,7 @@ where
         axis: impl AsIndex,
     ) -> Tensor<D2, K> {
         check!(TensorCheck::one_hot_tensor_rank::<D, D2>());
-        let axis = axis.expect_dim_index(D + 1);
+        let axis = unwrap_dim_index(axis.try_dim_index(D + 1));
 
         // Initialize shape from the current tensor dimensions and prepare for modification
         let mut shape = self.shape();
@@ -604,7 +605,7 @@ where
     /// }
     /// ```
     pub fn argmax(self, dim: impl AsIndex) -> Tensor<D, Int> {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         Tensor::new(K::argmax(self.primitive, dim))
     }
 
@@ -629,7 +630,7 @@ where
     /// }
     /// ```
     pub fn argtopk(self, k: usize, dim: impl AsIndex) -> Tensor<D, Int> {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         assert!(self.shape()[dim] > k);
         Tensor::new(K::argtopk(self.primitive, dim, k))
     }
@@ -673,7 +674,7 @@ where
     /// }
     /// ```
     pub fn max_dim_with_indices<I: AsIndex>(self, dim: I) -> (Self, Tensor<D, Int>) {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         check!(TensorCheck::aggregate_dim::<D>("Max", dim));
 
         let (tensor, index) = K::max_dim_with_indices(self.primitive, dim);
@@ -759,7 +760,7 @@ where
     /// }
     /// ```
     pub fn max_abs_dim<I: AsIndex>(self, dim: I) -> Self {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         check!(TensorCheck::aggregate_dim::<D>("MaxAbs", dim));
 
         Tensor::new(K::max_abs_dim(self.primitive, dim))
@@ -816,7 +817,7 @@ where
     /// }
     /// ```
     pub fn argmin(self, dim: impl AsIndex) -> Tensor<D, Int> {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         Tensor::new(K::argmin(self.primitive, dim))
     }
 
@@ -865,7 +866,7 @@ where
     /// }
     /// ```
     pub fn min_dim<I: AsIndex>(self, dim: I) -> Self {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         check!(TensorCheck::aggregate_dim::<D>("Min", dim));
         Tensor::new(K::min_dim(self.primitive, dim))
     }
@@ -919,7 +920,7 @@ where
     /// }
     /// ```
     pub fn min_dim_with_indices<I: AsIndex>(self, dim: I) -> (Self, Tensor<D, Int>) {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         check!(TensorCheck::aggregate_dim::<D>("Min", dim));
 
         let (tensor, index) = K::min_dim_with_indices(self.primitive, dim);
@@ -1084,7 +1085,7 @@ where
     /// }
     /// ```
     pub fn cummin<I: AsIndex>(self, dim: I) -> Self {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         check!(TensorCheck::aggregate_dim::<D>("CumMin", dim));
         Self::new(K::cummin(self.primitive, dim))
     }
@@ -1113,7 +1114,7 @@ where
     /// }
     /// ```
     pub fn cummax<I: AsIndex>(self, dim: I) -> Self {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         check!(TensorCheck::aggregate_dim::<D>("CumMax", dim));
         Self::new(K::cummax(self.primitive, dim))
     }
@@ -1143,7 +1144,7 @@ where
     /// }
     /// ```
     pub fn max_dim<I: AsIndex>(self, dim: I) -> Self {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         check!(TensorCheck::aggregate_dim::<D>("Max", dim));
         Tensor::new(K::max_dim(self.primitive, dim))
     }

--- a/crates/burn-tensor/src/tensor/api/take.rs
+++ b/crates/burn-tensor/src/tensor/api/take.rs
@@ -1,4 +1,6 @@
-use crate::{AsIndex, Int, Tensor, check, check::TensorCheck, kind::Basic};
+use crate::{
+    AsIndex, Int, Tensor, check, check::TensorCheck, check::unwrap_dim_index, kind::Basic,
+};
 use alloc::vec::Vec;
 
 impl<const D: usize, K> Tensor<D, K>
@@ -43,7 +45,7 @@ where
         dim: impl AsIndex,
         indices: Tensor<DI, Int>,
     ) -> Tensor<DO, K> {
-        let dim = dim.expect_dim_index(D);
+        let dim = unwrap_dim_index(dim.try_dim_index(D));
         check!(TensorCheck::take::<D, DI, DO>(dim));
 
         // Store the indices shape for reshaping later

--- a/crates/burn-tensor/src/tensor/linalg/cosine_similarity.rs
+++ b/crates/burn-tensor/src/tensor/linalg/cosine_similarity.rs
@@ -1,6 +1,6 @@
 use burn_std::FloatDType;
 
-use crate::{AsIndex, tensor::Tensor};
+use crate::{AsIndex, check::unwrap_dim_index, tensor::Tensor};
 
 use super::vector_norm::l2_norm_impl;
 
@@ -26,7 +26,7 @@ pub fn cosine_similarity<const D: usize>(
     dim: impl AsIndex,
     eps: Option<f64>,
 ) -> Tensor<D> {
-    let dim = dim.expect_dim_index(D);
+    let dim = unwrap_dim_index(dim.try_dim_index(D));
     let eps = eps.unwrap_or_else(|| {
         x1.dtype()
             .finfo()

--- a/crates/burn-tensor/src/tensor/linalg/outer.rs
+++ b/crates/burn-tensor/src/tensor/linalg/outer.rs
@@ -1,3 +1,4 @@
+use crate::check::unwrap_dim_index;
 use crate::tensor::Tensor;
 use crate::{AsIndex, kind::Numeric};
 
@@ -62,7 +63,7 @@ where
         "`outer` with D={D} expects R={} (got R={R})",
         D + 1
     );
-    let dim = dim.expect_dim_index(D);
+    let dim = unwrap_dim_index(dim.try_dim_index(D));
 
     // (..., i, 1, ...)
     let x = lhs.unsqueeze_dim::<R>(dim + 1);

--- a/crates/burn-tensor/src/tensor/linalg/vector_norm.rs
+++ b/crates/burn-tensor/src/tensor/linalg/vector_norm.rs
@@ -1,3 +1,4 @@
+use crate::check::unwrap_dim_index;
 use crate::tensor::Tensor;
 use crate::{
     AsIndex, ElementConversion,
@@ -120,7 +121,7 @@ pub fn vector_norm<const D: usize>(
     norm: impl Into<Norm>,
     dim: impl AsIndex,
 ) -> Tensor<D> {
-    let dim = dim.expect_dim_index(D);
+    let dim = unwrap_dim_index(dim.try_dim_index(D));
     lp_norm_impl(x, norm.into().to_exponent(), dim)
 }
 
@@ -145,7 +146,7 @@ pub fn vector_norm<const D: usize>(
 ///
 /// The ``L(p)`` norm of the input tensor.
 pub fn lp_norm<const D: usize>(x: Tensor<D>, p: f64, dim: impl AsIndex) -> Tensor<D> {
-    let dim = dim.expect_dim_index(D);
+    let dim = unwrap_dim_index(dim.try_dim_index(D));
     lp_norm_impl(x, p, dim)
 }
 
@@ -182,7 +183,7 @@ pub fn vector_normalize<const D: usize, E: ElementConversion>(
     dim: impl AsIndex,
     eps: E,
 ) -> Tensor<D> {
-    let dim = dim.expect_dim_index(D);
+    let dim = unwrap_dim_index(dim.try_dim_index(D));
     let norm = lp_norm_impl(x.clone(), norm.into().to_exponent(), dim).clamp_min(eps);
     x / norm
 }
@@ -202,7 +203,7 @@ pub fn l0_norm<const D: usize, K>(x: Tensor<D, K>, dim: impl AsIndex) -> Tensor<
 where
     K: Numeric,
 {
-    let dim = dim.expect_dim_index(D);
+    let dim = unwrap_dim_index(dim.try_dim_index(D));
     l0_norm_impl(x, dim)
 }
 
@@ -232,7 +233,7 @@ pub fn l1_norm<const D: usize, K>(x: Tensor<D, K>, dim: impl AsIndex) -> Tensor<
 where
     K: Numeric,
 {
-    let dim = dim.expect_dim_index(D);
+    let dim = unwrap_dim_index(dim.try_dim_index(D));
     l1_norm_impl(x, dim)
 }
 
@@ -255,7 +256,7 @@ where
 ///
 /// The L2 norm of the input tensor.
 pub fn l2_norm<const D: usize>(x: Tensor<D>, dim: impl AsIndex) -> Tensor<D> {
-    let dim = dim.expect_dim_index(D);
+    let dim = unwrap_dim_index(dim.try_dim_index(D));
     l2_norm_impl(x, dim)
 }
 
@@ -299,7 +300,7 @@ pub fn max_abs_norm<const D: usize, K>(x: Tensor<D, K>, dim: impl AsIndex) -> Te
 where
     K: Ordered,
 {
-    let dim = dim.expect_dim_index(D);
+    let dim = unwrap_dim_index(dim.try_dim_index(D));
     max_abs_norm_impl(x, dim)
 }
 
@@ -325,7 +326,7 @@ pub fn min_abs_norm<const D: usize, K>(x: Tensor<D, K>, dim: impl AsIndex) -> Te
 where
     K: Ordered,
 {
-    let dim = dim.expect_dim_index(D);
+    let dim = unwrap_dim_index(dim.try_dim_index(D));
     min_abs_norm_impl(x, dim)
 }
 

--- a/crates/burn-tensor/src/tensor/signal/fft.rs
+++ b/crates/burn-tensor/src/tensor/signal/fft.rs
@@ -4,6 +4,7 @@ use burn_dispatch::Dispatch;
 
 use crate::check;
 use crate::check::TensorCheck;
+use crate::check::unwrap_dim_index;
 use crate::ops::BridgeTensor;
 use crate::{AsIndex, Tensor};
 
@@ -58,8 +59,7 @@ pub fn rfft<const D: usize>(
     dim: impl AsIndex,
     n: Option<usize>,
 ) -> (Tensor<D>, Tensor<D>) {
-    let dim = dim.expect_dim_index(D);
-    check!(TensorCheck::check_dim::<D>(dim));
+    let dim = unwrap_dim_index(dim.try_dim_index(D));
 
     match n {
         None => check!(TensorCheck::check_is_power_of_two::<D>(
@@ -135,8 +135,7 @@ pub fn irfft<const D: usize>(
     dim: impl AsIndex,
     n: Option<usize>,
 ) -> Tensor<D> {
-    let dim = dim.expect_dim_index(D);
-    check!(TensorCheck::check_dim::<D>(dim));
+    let dim = unwrap_dim_index(dim.try_dim_index(D));
 
     if let Some(n) = n {
         assert!(n >= 1, "irfft: n must be >= 1, got {n}");
@@ -232,8 +231,7 @@ pub fn cfft<const D: usize>(
         signal_im.shape(),
     );
 
-    let dim = dim.expect_dim_index(D);
-    check!(TensorCheck::check_dim::<D>(dim));
+    let dim = unwrap_dim_index(dim.try_dim_index(D));
     let fft_size = n.unwrap_or(signal_re.dims()[dim]);
 
     // rfft validates power-of-two and n constraints internally


### PR DESCRIPTION
## Motivation

Follow-up to #5226 and [this review comment](https://github.com/tracel-ai/burn/pull/5226#discussion_r3645601079).

Dimension-taking tensor APIs canonicalized indices with `expect_dim_index`, which panicked inside CubeCL when a positive or negative dimension was out of bounds. Those failures bypassed Burn's structured `TensorCheck` formatting and exposed a raw dependency error instead.

CubeCL now provides the fallible `AsIndex::try_dim_index` API from tracel-ai/cubecl#1445. Burn can therefore handle conversion failures itself while retaining CubeCL's precise bounds reason.

## Modifications

- Update the CubeCL revision to include tracel-ai/cubecl#1445.
- Update Cubek through tracel-ai/cubek#433 so Burn and Cubek use the same CubeCL revision.
- Add `unwrap_dim_index`, following the existing `unwrap_shape_reshape` pattern, to format failed dimension conversions as Burn tensor errors.
- Replace every `expect_dim_index` call in `burn-tensor` with `try_dim_index` and the centralized unwrap helper.
- Remove redundant dimension-bound checks while preserving operation-specific validation after successful conversion.
- Verify invalid positive and overly negative dimensions produce the `=== Tensor Operation Error ===` format under `Dimension Indexing` with the CubeCL bounds reason.

## Testing

- `cargo +nightly fmt --all -- --check`
- `cargo +nightly check -p burn-tensor --features cubecl --locked`
- `cargo +nightly test --locked -p burn-backend-tests --features ndarray --test tensor` (1,641 passed, 19 ignored)
- `cargo +1.95.0 xtask check lint` reached and checked the Burn fusion/Cubek dependency path; the remaining local workspace build was blocked by the macOS LibTorch environment.
- `cargo +1.95.0 xtask doc build` reached the corrected dependency path; the remaining local build failed because the downloaded macOS LibTorch headers were unavailable.
