### PR TITLE
fix(examples/modern-lstm) swapped lstm args

### DIFF
--- a/examples/modern-lstm/src/model.rs
+++ b/examples/modern-lstm/src/model.rs
@@ -137,7 +137,7 @@ impl LstmCell {
 
         let h_t = self.dropout.forward(h_t);
 
-        LstmState::new(h_t, c_t)
+        LstmState::new(c_t, h_t)
     }
 
     // Initialize cell state and hidden state if provided or with zeros


### PR DESCRIPTION
Fix argument order in examples/modern-lstm/model
https://github.com/ra1u/burn/blob/5dce4daac5b2443392ac7fbcb4cd6a0288a7747e/crates/burn-nn/src/modules/rnn/lstm/lstm_state.rs#L28
