### PR TITLE
feat(backend): add default int_argtopk impl and native tch support

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -268,6 +268,7 @@ Those operations are available for numeric tensor kinds: `Float` and `Int`.
 | `tensor.argmin(dim)`                                            | `tensor.argmin(dim)`                          |
 | `tensor.argsort(dim)`                                           | `tensor.argsort(dim)`                         |
 | `tensor.argsort_descending(dim)`                                | `tensor.argsort(dim, descending=True)`        |
+| `tensor.argtopk(k, dim)`                                        | `tensor.topk(k, dim).indices`                 |
 | `tensor.bool()`                                                 | `tensor.bool()`                               |
 | `tensor.clamp(min, max)`                                        | `torch.clamp(tensor, min=min, max=max)`       |
 | `tensor.clamp_max(max)`                                         | `torch.clamp(tensor, max=max)`                |

--- a/crates/burn-backend-tests/tests/tensor/int/ops/topk.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/topk.rs
@@ -58,6 +58,26 @@ fn test_topk() {
 }
 
 #[test]
+fn test_argtopk_1d() {
+    let tensor = TestTensorInt::<1>::from([1, 2, 3, 4, 5]);
+
+    let indices = tensor.argtopk(3, /*dim*/ 0);
+
+    let expected = TensorData::from([4, 3, 2]);
+    indices.into_data().assert_eq(&expected, false);
+}
+
+#[test]
+fn test_argtopk() {
+    let tensor = TestTensorInt::<3>::from([[[1, 4, 7], [2, 5, 6]], [[3, 0, 9], [8, 2, 7]]]);
+
+    let indices = tensor.argtopk(2, /*dim*/ 2);
+
+    let expected = TensorData::from([[[2, 1], [2, 1]], [[2, 0], [0, 2]]]);
+    indices.into_data().assert_eq(&expected, false);
+}
+
+#[test]
 fn test_topk_with_indices_supports_negative_dim_int() {
     let tensor = TestTensorInt::<3>::from([[[1, 4, 7], [2, 5, 6]], [[3, 0, 9], [8, 2, 7]]]);
 
@@ -67,4 +87,14 @@ fn test_topk_with_indices_supports_negative_dim_int() {
 
     let indices_expected = TensorData::from([[[2, 1], [2, 1]], [[2, 0], [0, 2]]]);
     indices.into_data().assert_eq(&indices_expected, false);
+}
+
+#[test]
+fn test_argtopk_supports_negative_dim_int() {
+    let tensor = TestTensorInt::<3>::from([[[1, 4, 7], [2, 5, 6]], [[3, 0, 9], [8, 2, 7]]]);
+
+    let indices = tensor.argtopk(2, -1);
+
+    let expected = TensorData::from([[[2, 1], [2, 1]], [[2, 0], [0, 2]]]);
+    indices.into_data().assert_eq(&expected, false);
 }

--- a/crates/burn-backend/src/backend/ops/int_tensor.rs
+++ b/crates/burn-backend/src/backend/ops/int_tensor.rs
@@ -936,7 +936,12 @@ pub trait IntTensorOps<B: Backend> {
     /// # Returns
     ///
     /// The indices of the maximum elements along the dimension.
-    fn int_argtopk(tensor: IntTensor<B>, dim: usize, k: usize) -> IntTensor<B>;
+    fn int_argtopk(tensor: IntTensor<B>, dim: usize, k: usize) -> IntTensor<B> {
+        let device = &tensor.device();
+        let dtype = get_device_settings::<B>(device).int_dtype;
+        let k_indices = B::int_arange(0..k as i64, device, dtype);
+        Self::int_select(Self::int_argsort(tensor, dim, true), dim, k_indices)
+    }
 
     /// Gets the values of the k maximum elements along a dimension.
     /// # Arguments

--- a/crates/burn-candle/src/ops/int_tensor.rs
+++ b/crates/burn-candle/src/ops/int_tensor.rs
@@ -396,10 +396,6 @@ impl IntTensorOps<Self> for Candle {
         CandleTensor::new(tensor.tensor.argmax_keepdim(dim).unwrap())
     }
 
-    fn int_argtopk(tensor: IntTensor<Self>, dim: usize, k: usize) -> IntTensor<Self> {
-        panic!("argtopk not implemented for candle backend")
-    }
-
     fn int_argmin(tensor: IntTensor<Self>, dim: usize) -> IntTensor<Self> {
         CandleTensor::new(tensor.tensor.argmin_keepdim(dim).unwrap())
     }

--- a/crates/burn-flex/src/ops/int.rs
+++ b/crates/burn-flex/src/ops/int.rs
@@ -607,10 +607,6 @@ impl IntTensorOps<Flex> for Flex {
         crate::ops::reduce::argmax(tensor, dim)
     }
 
-    fn int_argtopk(_tensor: IntTensor<Flex>, _dim: usize, _k: usize) -> IntTensor<Flex> {
-        panic!("argtopk not implemented for flex")
-    }
-
     fn int_argmin(tensor: IntTensor<Flex>, dim: usize) -> IntTensor<Flex> {
         crate::ops::reduce::argmin(tensor, dim)
     }

--- a/crates/burn-ndarray/src/ops/int_tensor.rs
+++ b/crates/burn-ndarray/src/ops/int_tensor.rs
@@ -325,10 +325,6 @@ impl IntTensorOps<Self> for NdArray {
         })
     }
 
-    fn int_argtopk(_tensor: NdArrayTensor, _dim: usize, _k: usize) -> NdArrayTensor {
-        unimplemented!("argtopk not implemented for ndarray");
-    }
-
     fn int_argmin(tensor: NdArrayTensor, dim: usize) -> NdArrayTensor {
         // Use view() for zero-copy on borrowed storage
         execute_with_int_dtype!(tensor, E, |array: SharedArray<E>| {

--- a/crates/burn-tch/src/ops/int_tensor.rs
+++ b/crates/burn-tch/src/ops/int_tensor.rs
@@ -340,8 +340,8 @@ impl IntTensorOps<Self> for LibTorch {
         TchOps::argmax(tensor, dim)
     }
 
-    fn int_argtopk(_tensor: TchTensor, _dim: usize, _k: usize) -> TchTensor {
-        panic!("argtopk not implemented for torch")
+    fn int_argtopk(tensor: TchTensor, dim: usize, k: usize) -> TchTensor {
+        TchOps::argtopk(tensor, dim, k)
     }
 
     fn int_topk(tensor: TchTensor, dim: usize, k: usize) -> TchTensor {


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Closes #5233.

Follows #5160, which made the same change on the float side: added a default for `float_argtopk` and removed the ndarray, candle and flex stubs. Both ops were originally introduced together in #4900, each declared without a default.

### Changes

`int_argtopk` was declared without a default, so it panicked on ndarray, candle, flex and tch. Only cubecl implemented it, while `float_argtopk` works everywhere.

- Added a default for `IntTensorOps::int_argtopk`, composed as `int_argsort` followed by `int_select`, mirroring `float_argtopk`.
- Removed the ndarray, candle and flex stubs so they inherit it.
- Gave tch a native override calling the existing `TchOps::argtopk`.
- Added `tensor.argtopk(k, dim)` to the book's tensor op table.

Index dtype and tie-breaking deliberately match current `float_argtopk` behaviour rather than changing here. Rationale in #5233.

### Testing

Three tests added to `crates/burn-backend-tests/tests/tensor/int/ops/topk.rs`: `test_argtopk_1d`, `test_argtopk` and `test_argtopk_supports_negative_dim_int`. Expected indices match what the adjacent `topk_with_indices` tests already assert for the same inputs, so the two paths cross-check each other: `int_topk_with_indices` sorts once and slices both halves, while `int_argtopk` argsorts and slices.

- `cargo test-ndarray topk`: 11 passed, 0 failed
- `cargo test-flex topk`: 11 passed, 0 failed
- `cargo run-checks`: passed

candle inherits the default and compiles, but `burn-backend-tests` has no candle feature so it is not exercised by the suite.

tch is verified indirectly. `cargo test-tch` aborts at startup on unmodified `main` with `UnsupportedDType { device: "LibTorch(Cpu)", dtype: I32 }`: the harness hardcodes `IntElem = i32` in `crates/burn-backend-tests/tests/tensor.rs` while burn-tch maps only I64. Setting `IntElem = i64` locally lets the suite run, and all three argtopk tests pass on LibTorch alongside the existing topk tests. CI does not run `burn-backend-tests` against tch. Happy to file that separately if it is not already known.
