### PR TITLE
feat(tensor): add mask_select (boolean mask indexing)

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -215,6 +215,7 @@ Those operations are available for all tensor kinds: `Int`, `Float`, and `Bool`.
 | `tensor.into_primitive()`                            | N/A                                                                       |
 | `tensor.into_scalar()`                               | `tensor.item()`                                                           |
 | `tensor.mask_fill(mask, value)`                      | `tensor.masked_fill(mask, value)`                                         |
+| `tensor.mask_select(mask)`                           | `tensor.masked_select(mask)`                                              |
 | `tensor.mask_where(mask, value_tensor)`              | `torch.where(mask, value_tensor, tensor)`                                 |
 | `tensor.movedim(src, dst)`                           | `tensor.movedim(src, dst)`                                                |
 | `tensor.narrow(dim, start, length)`                  | `tensor.narrow(dim, start, length)`                                       |

--- a/crates/burn-backend-tests/tests/autodiff/mask_select.rs
+++ b/crates/burn-backend-tests/tests/autodiff/mask_select.rs
@@ -1,0 +1,50 @@
+use super::*;
+use burn_tensor::TensorData;
+
+#[test]
+fn test_mask_select_grad() {
+    // Gradients must flow back to the selected positions and be zero elsewhere.
+    let device = AutodiffDevice::new();
+    let tensor_1 = TestTensor::<2>::from_data(
+        TensorData::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]),
+        &device,
+    )
+    .require_grad();
+    let mask = TestTensorBool::<2>::from_data(
+        TensorData::from([[true, false, true], [false, true, false]]),
+        &device,
+    );
+
+    // Selected values x = [0, 2, 4]; y = x * x, so dy/dx = 2x = [0, 4, 8].
+    let tensor_2 = tensor_1.clone().mask_select(mask);
+    let tensor_3 = tensor_2.clone() * tensor_2;
+
+    let grads = tensor_3.backward();
+
+    let grad_1 = tensor_1.grad(&grads).unwrap();
+
+    grad_1
+        .into_data()
+        .assert_eq(&TensorData::from([[0., 0., 4.], [0., 8., 0.]]), false);
+}
+
+#[test]
+fn test_mask_select_grad_empty_mask() {
+    // An all-`false` mask must produce an all-zero gradient. The backward pass scatter-adds a
+    // zero-length gradient into the input, exercising the zero-size select_add path.
+    let device = AutodiffDevice::new();
+    let tensor_1 =
+        TestTensor::<1>::from_data(TensorData::from([1.0, 2.0, 3.0]), &device).require_grad();
+    let mask = TestTensorBool::<1>::from_data(TensorData::from([false, false, false]), &device);
+
+    let tensor_2 = tensor_1.clone().mask_select(mask);
+    let tensor_3 = tensor_2.sum();
+
+    let grads = tensor_3.backward();
+
+    let grad_1 = tensor_1.grad(&grads).unwrap();
+
+    grad_1
+        .into_data()
+        .assert_eq(&TensorData::from([0.0, 0.0, 0.0]), false);
+}

--- a/crates/burn-backend-tests/tests/autodiff/mod.rs
+++ b/crates/burn-backend-tests/tests/autodiff/mod.rs
@@ -48,6 +48,7 @@ mod log;
 mod log1p;
 mod log_sigmoid;
 mod mask;
+mod mask_select;
 mod matmul;
 mod maxmin;
 mod maxpool1d;

--- a/crates/burn-backend-tests/tests/tensor/bool/ops/mask_select.rs
+++ b/crates/burn-backend-tests/tests/tensor/bool/ops/mask_select.rs
@@ -1,0 +1,15 @@
+use super::*;
+use burn_tensor::TensorData;
+
+#[test]
+fn test_mask_select_bool() {
+    // Bool-kind sources go through the dedicated bool select dispatch path.
+    let tensor = TestTensorBool::<1>::from([true, false, true]);
+    let mask = TestTensorBool::<1>::from([true, true, false]);
+
+    let output = tensor.mask_select(mask);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([true, false]), false);
+}

--- a/crates/burn-backend-tests/tests/tensor/bool/ops/mod.rs
+++ b/crates/burn-backend-tests/tests/tensor/bool/ops/mod.rs
@@ -14,6 +14,7 @@ mod gather_scatter;
 mod init;
 mod logical;
 mod mask;
+mod mask_select;
 mod movedim;
 mod permute;
 mod repeat;

--- a/crates/burn-backend-tests/tests/tensor/float/ops/mask_select.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/mask_select.rs
@@ -1,0 +1,122 @@
+use super::*;
+use burn_tensor::{Shape, TensorData};
+
+#[test]
+fn test_mask_select_1d() {
+    let tensor = TestTensor::<1>::from([1.0, 2.0, 3.0, 4.0, 5.0]);
+    let mask = TestTensorBool::<1>::from([false, true, false, true, true]);
+
+    let output = tensor.mask_select(mask);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([2.0, 4.0, 5.0]), false);
+}
+
+#[test]
+fn test_mask_select_2d() {
+    let tensor = TestTensor::<2>::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+    let mask = TestTensorBool::<2>::from([[true, false, true], [false, true, false]]);
+
+    let output = tensor.mask_select(mask);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([1.0, 3.0, 5.0]), false);
+}
+
+#[test]
+fn test_mask_select_3d() {
+    // Flattened order across three dimensions: flat values are 1..=8, the mask keeps 1, 4, 5, 6.
+    let tensor = TestTensor::<3>::from([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]);
+    let mask = TestTensorBool::<3>::from([
+        [[true, false], [false, true]],
+        [[true, true], [false, false]],
+    ]);
+
+    let output = tensor.mask_select(mask);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([1.0, 4.0, 5.0, 6.0]), false);
+}
+
+#[test]
+fn test_mask_select_single_element() {
+    // A single selected element exercises the `squeeze_dim(1)` path: `argwhere` returns shape
+    // `[1, 1]`, which must squeeze to `[1]` (a global `squeeze` would collapse it to rank 0).
+    let tensor = TestTensor::<2>::from([[1.0, 2.0], [3.0, 4.0]]);
+    let mask = TestTensorBool::<2>::from([[false, false], [true, false]]);
+
+    let output = tensor.mask_select(mask);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([3.0]), false);
+}
+
+#[test]
+fn test_mask_select_empty() {
+    // An all-`false` mask selects nothing and yields an empty 1D tensor (no special-casing needed).
+    let tensor = TestTensor::<1>::from([1.0, 2.0, 3.0]);
+    let mask = TestTensorBool::<1>::from([false, false, false]);
+
+    let output = tensor.mask_select(mask);
+
+    assert_eq!(output.shape(), Shape::new([0]));
+    // Read the data back to force execution on lazy backends (shape alone is metadata-only).
+    let out: Vec<FloatElem> = output.into_data().to_vec().unwrap();
+    assert!(out.is_empty());
+}
+
+#[test]
+fn test_mask_select_transposed_tensor() {
+    // [[1, 2], [3, 4]] transposed -> [[1, 3], [2, 4]]; mask [[T, F], [F, T]] selects 1 and 4.
+    // Selection must follow the logical (flattened) order of the view, not the memory layout.
+    let tensor = TestTensor::<2>::from([[1.0, 2.0], [3.0, 4.0]]).transpose();
+    let mask = TestTensorBool::<2>::from([[true, false], [false, true]]);
+
+    let output = tensor.mask_select(mask);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([1.0, 4.0]), false);
+}
+
+#[test]
+fn test_mask_select_both_flipped() {
+    // tensor [1, 2, 3, 4] flipped -> [4, 3, 2, 1]; mask [T, F, T, F] flipped -> [F, T, F, T]
+    // selects positions 1 and 3 of the flipped tensor: [3, 1].
+    let tensor = TestTensor::<1>::from([1.0, 2.0, 3.0, 4.0]).flip([0]);
+    let mask = TestTensorBool::<1>::from([true, false, true, false]).flip([0]);
+
+    let output = tensor.mask_select(mask);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([3.0, 1.0]), false);
+}
+
+#[test]
+fn test_mask_select_narrowed_tensor() {
+    // [1, 2, 3, 4, 5, 6] narrowed to [2, 3, 4, 5]; mask [T, F, F, T] selects [2, 5].
+    let tensor = TestTensor::<1>::from([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).narrow(0, 1, 4);
+    let mask = TestTensorBool::<1>::from([true, false, false, true]);
+
+    let output = tensor.mask_select(mask);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([2.0, 5.0]), false);
+}
+
+#[test]
+#[should_panic]
+fn test_mask_select_shape_mismatch() {
+    // The mask must have the same shape as the tensor: the flat indices of a differently-shaped
+    // mask would not correspond to the tensor's positions.
+    let tensor = TestTensor::<1>::from([1.0, 2.0, 3.0]);
+    let mask = TestTensorBool::<1>::from([true, false]);
+
+    let _output = tensor.mask_select(mask);
+}

--- a/crates/burn-backend-tests/tests/tensor/float/ops/mod.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/mod.rs
@@ -93,6 +93,7 @@ mod iter_dim;
 mod log;
 mod log1p;
 mod mask;
+mod mask_select;
 mod matmul;
 mod maxmin;
 mod movedim;

--- a/crates/burn-backend-tests/tests/tensor/int/ops/mask_select.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/mask_select.rs
@@ -1,0 +1,26 @@
+use super::*;
+use burn_tensor::TensorData;
+
+#[test]
+fn test_mask_select_int_1d() {
+    let tensor = TestTensorInt::<1>::from([10, 20, 30, 40]);
+    let mask = TestTensorBool::<1>::from([true, false, false, true]);
+
+    let output = tensor.mask_select(mask);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([10, 40]), false);
+}
+
+#[test]
+fn test_mask_select_int_2d() {
+    let tensor = TestTensorInt::<2>::from([[1, 2, 3], [4, 5, 6]]);
+    let mask = TestTensorBool::<2>::from([[false, true, false], [true, false, true]]);
+
+    let output = tensor.mask_select(mask);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([2, 4, 6]), false);
+}

--- a/crates/burn-backend-tests/tests/tensor/int/ops/mod.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/mod.rs
@@ -23,6 +23,7 @@ mod gather_scatter;
 mod gather_scatter_nd;
 mod init;
 mod mask;
+mod mask_select;
 mod matmul;
 mod movedim;
 mod mul;

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -1707,6 +1707,78 @@ where
         Self::new(K::mask_fill(self.primitive, mask.primitive, value))
     }
 
+    /// Selects the elements of the tensor where `mask` is `true`, returned as a 1D tensor in the
+    /// order of the flattened input tensor.
+    ///
+    /// The mask must have the same shape as the tensor. Unlike `torch.masked_select`, the mask is
+    /// not broadcast against the tensor.
+    ///
+    /// # Notes
+    ///
+    /// The number of selected elements is data-dependent, so this performs a synchronous read of
+    /// the mask, consistent with [`argwhere`](Tensor::argwhere) and [`nonzero`](Tensor::nonzero).
+    /// On backends without a native `argwhere` implementation, this reads the entire mask back to
+    /// the host and computes the indices on the CPU; on lazy backends, it also forces the
+    /// execution of pending operations.
+    ///
+    /// This makes each call a synchronization point between the host and the device: prefer
+    /// calling it once on final results (e.g. filtering predictions) rather than inside
+    /// performance-critical loops.
+    ///
+    /// On an autodiff backend, gradients flow back to the selected elements; positions where
+    /// `mask` is `false` receive a zero gradient.
+    ///
+    /// # Panics
+    ///
+    /// - If `mask` does not have the same shape as the tensor.
+    /// - If the mask data cannot be read synchronously (e.g. on wasm); use
+    ///   [`mask_select_async`](Tensor::mask_select_async) instead.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use burn_tensor::{Tensor, Bool};
+    ///
+    /// fn example() {
+    ///   let device = Default::default();
+    ///   let tensor = Tensor::<2>::from_data([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], &device);
+    ///   let mask = Tensor::<2, Bool>::from_data([[true, false, true], [false, true, false]], &device);
+    ///   let selected = tensor.mask_select(mask);
+    ///   println!("{selected}");
+    ///   // [1.0, 3.0, 5.0]
+    /// }
+    /// ```
+    pub fn mask_select(self, mask: Tensor<D, Bool>) -> Tensor<1, K> {
+        crate::try_read_sync(self.mask_select_async(mask)).expect(
+            "Failed to read tensor data synchronously. Try using mask_select_async instead.",
+        )
+    }
+
+    /// Selects the elements of the tensor where `mask` is `true`, returned as a 1D tensor in the
+    /// order of the flattened input tensor.
+    ///
+    /// Asynchronous version of [`mask_select`](Tensor::mask_select), for backends where the
+    /// mask cannot be read synchronously (e.g. wasm). The mask read and its synchronization cost
+    /// remain; only the waiting is non-blocking.
+    ///
+    /// # Panics
+    ///
+    /// If `mask` does not have the same shape as the tensor.
+    pub async fn mask_select_async(self, mask: Tensor<D, Bool>) -> Tensor<1, K> {
+        check!(TensorCheck::mask_select(&self.shape(), &mask.shape()));
+
+        // Flatten the mask to 1D and collect the flat indices of its `true` values. `argwhere`
+        // returns a `[count, 1]` tensor, which we squeeze to a 1D `[count]` index tensor.
+        let indices = mask
+            .flatten::<1>(0, D - 1)
+            .argwhere_async()
+            .await
+            .squeeze_dim::<1>(1);
+
+        // Flatten the tensor to 1D and gather the selected elements.
+        self.flatten::<1>(0, D - 1).select(0, indices)
+    }
+
     /// Gather tensor elements corresponding to the given indices from the specified dim.
     /// The dimension supports negative indexing.
     ///

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -1008,6 +1008,21 @@ impl TensorCheck {
         Self::check_select_basic::<D>(Self::Ok, "select", dim)
     }
 
+    pub(crate) fn mask_select(shape: &Shape, shape_mask: &Shape) -> Self {
+        let mut check = Self::Ok;
+
+        if shape != shape_mask {
+            check = check.register(
+                "Mask Select",
+                TensorError::new("The mask must have the same shape as the tensor.").details(
+                    format!("Tensor shape {shape:?}, mask shape {shape_mask:?}."),
+                ),
+            );
+        }
+
+        check
+    }
+
     pub(crate) fn take<const D: usize, const DI: usize, const DO: usize>(dim: usize) -> Self {
         let mut check = Self::check_select_basic::<D>(Self::Ok, "Take", dim);
 


### PR DESCRIPTION
# PR : masked_select (boolean mask indexing)

**Title:** `feat(tensor): add mask_select (boolean mask indexing)`

**Base:** `tracel-ai:main` ← **Compare:** `Yashiru:feat/masked-select`

---

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Closes #3669.

### Changes

This implements the approach I proposed in #3669: mirror the existing `nonzero`/`argwhere` design
and keep the PR small. Digging into the codebase refined it in two ways: no new shared helper is
needed at all (the op composes entirely from existing operations), and I ended up diverging from
my own naming proposal to follow a repo convention I discovered along the way (see the naming note
below).

Adds `mask_select`, the equivalent of numpy `tensor[mask]` / `torch.masked_select(tensor, mask)`:
it returns a 1D tensor containing the elements of `self` where the same-shaped `Bool` mask is
`true`, in the order of the flattened input tensor.

Because the number of selected elements is data-dependent, the output shape can't be known without
reading the mask, so this makes the same synchronous-read tradeoff already accepted by `argwhere`
and `nonzero`. A `mask_select_async` variant is provided for non-blocking contexts (e.g. wasm),
mirroring the `nonzero`/`nonzero_async` pattern.

The implementation is a small composition of existing ops, with **no backend trait changes**:

```rust
pub async fn mask_select_async(self, mask: Tensor<D, Bool>) -> Tensor<1, K> {
    check!(TensorCheck::mask_select(&self.shape(), &mask.shape()));
    let indices = mask.flatten::<1>(0, D - 1).argwhere_async().await.squeeze_dim::<1>(1);
    self.flatten::<1>(0, D - 1).select(0, indices)
}
```

Notes:
- Purely additive: no changes to existing APIs, no breaking change.
- Lives in the `K: Basic` block, so it works for `Float`, `Int`, and `Bool` tensors.
- The gradient composes from the existing `reshape`/`select` backwards; no autodiff code is needed
  (covered by autodiff tests).
- `mask` must have the same shape as `self`, enforced by a `TensorCheck` (a mismatched mask would
  otherwise select the wrong elements, or read out of bounds on backends without bounds checks).
  Unlike `torch.masked_select`, the mask is not broadcast; that could be added later if wanted.
- An all-`false` mask yields an empty `[0]` tensor with no special-casing (via `argwhere`'s
  `[0, 1]` shape).
- The docs explicitly flag each call as a host-device synchronization point, with guidance to keep
  it on final results rather than inside performance-critical loops.

**Naming note:** in the issue I proposed `masked_select` for PyTorch parity, but while studying
the codebase I noticed burn deliberately renamed `masked_fill` to `mask_fill` and `torch.where` to
`mask_where`, so I followed the local `mask_*` convention with `mask_select`. Discoverability is
preserved by the book table, which maps it to `tensor.masked_select(mask)` exactly like the
`mask_fill` row. Happy to switch back if you prefer PyTorch-parity naming, it's a quick change.

**Possible follow-ups**, out of scope here: the main cost on GPU backends is inherited from the default
`bool_argwhere` (full mask readback + host loop). A device-side `bool_argwhere` for cubecl (stream
compaction, count-only readback) would speed up `argwhere`, `nonzero`, and `mask_select` at once;
a dedicated fused kernel could come on top of it. I'd be happy to tackle that next if there's
interest.

### Testing

- `tensor/float/ops/mask_select.rs`: 1D, 2D, 3D (flattened order across dims), single-element
  (exercises the `squeeze_dim` path), empty mask (forces execution via `into_data`), transposed /
  flipped / narrowed inputs (non-contiguous views), and a `#[should_panic]` shape-mismatch case.
- `tensor/int/ops/mask_select.rs` and `tensor/bool/ops/mask_select.rs`: `Int` and `Bool` kinds
  (the `Bool` source goes through the dedicated bool select dispatch path).
- `autodiff/mask_select.rs`: gradients flow to the selected positions (zeros elsewhere), plus the
  all-`false` mask backward (zero-size scatter-add).
- The doc example runs as a doctest.
- `cargo run-checks` passes locally.
