### PR TITLE
Skip unsupported accelerated kernels during autotune

### DIFF
--- a/crates/burn-cubecl-fusion/src/optim/matmul/tune.rs
+++ b/crates/burn-cubecl-fusion/src/optim/matmul/tune.rs
@@ -13,7 +13,8 @@ use cubecl::{
     tune::{LocalTuner, Tunable, TunableSet, TuneGroup, local_tuner},
 };
 use cubek::matmul::{
-    definition::MatmulKind,
+    components::tile::TileMatmulKind,
+    definition::{MatmulElems, MatmulGlobalElems, MatmulKind},
     strategy::{MatmulAutotuneKey, MatmulGlobalScale, should_tune_double_buffering},
 };
 use serde::{Deserialize, Serialize};
@@ -32,9 +33,10 @@ pub fn fused_matmul_autotune<R: Runtime>(
     optimization: MatmulOptimizationTuneArg<R>,
     context: &mut Context<CubeFusionHandle<R>>,
 ) {
+    let tune_client = optimization.info.client.clone();
     static TUNER: LocalTuner<FusedMatmulAutotuneKey, CubeTuneId> = local_tuner!();
 
-    let tunables = TUNER.init(|| {
+    let tunables = TUNER.init(move || {
         const PRIORITY_MAX: i8 = 3;
         const PRIORITY_HIGH: i8 = 2;
         const PRIORITY_MEDIUM: i8 = 1;
@@ -172,6 +174,10 @@ pub fn fused_matmul_autotune<R: Runtime>(
 
         // Accelerated matmuls
         for tile_matmul in [AcceleratedTileKind::Cmma, AcceleratedTileKind::Mma] {
+            let tm = match tile_matmul {
+                AcceleratedTileKind::Cmma => TileMatmulKind::Cmma,
+                AcceleratedTileKind::Mma => TileMatmulKind::Mma,
+            };
             for (selector, double_buf, extra_group) in [
                 (
                     FusedMatmulSelector::Simple {
@@ -211,21 +217,63 @@ pub fn fused_matmul_autotune<R: Runtime>(
                     Some(&odd),
                 ),
             ] {
-                let priority_within_group =
-                    |key: &FusedMatmulAutotuneKey, double_buf: bool| match double_buf {
-                        false => PRIORITY_MAX,
-                        true => double_buffering_priority(key, PRIORITY_MAX, PRIORITY_HIGH),
-                    };
+                let client_1 = tune_client.clone();
                 let mut tunable = Tunable::new(&selector.name(), move |input| {
                     tune_fused::<R>(input, selector)
                 })
                 .group(&accelerated, move |key| {
-                    priority_within_group(key, double_buf)
+                    let elems = MatmulElems::from_globals(&MatmulGlobalElems {
+                        lhs: key.matmul_key.definition.elem_lhs,
+                        rhs: key.matmul_key.definition.elem_rhs,
+                        out: key.matmul_key.definition.elem_out,
+                    });
+
+                    let supported = !tm
+                        .supported_sizes(
+                            &client_1,
+                            elems.lhs_register,
+                            elems.rhs_register,
+                            elems.acc_register,
+                        )
+                        .is_empty();
+
+                    if !supported {
+                        return PRIORITY_NEVER;
+                    }
+
+                    match double_buf {
+                        false => PRIORITY_MAX,
+                        true => double_buffering_priority(key, PRIORITY_MAX, PRIORITY_HIGH),
+                    }
                 });
 
                 if let Some(group) = extra_group {
-                    tunable =
-                        tunable.group(group, move |key| priority_within_group(key, double_buf));
+                    let client_2 = tune_client.clone();
+                    tunable = tunable.group(group, move |key| {
+                        let elems = MatmulElems::from_globals(&MatmulGlobalElems {
+                            lhs: key.matmul_key.definition.elem_lhs,
+                            rhs: key.matmul_key.definition.elem_rhs,
+                            out: key.matmul_key.definition.elem_out,
+                        });
+
+                        let supported = !tm
+                            .supported_sizes(
+                                &client_2,
+                                elems.lhs_register,
+                                elems.rhs_register,
+                                elems.acc_register,
+                            )
+                            .is_empty();
+
+                        if !supported {
+                            return PRIORITY_NEVER;
+                        }
+
+                        match double_buf {
+                            false => PRIORITY_MAX,
+                            true => double_buffering_priority(key, PRIORITY_MAX, PRIORITY_HIGH),
+                        }
+                    });
                 }
                 set = set.with(tunable);
             }

--- a/crates/burn-cubecl-fusion/src/optim/matmul/tune.rs
+++ b/crates/burn-cubecl-fusion/src/optim/matmul/tune.rs
@@ -15,7 +15,7 @@ use cubecl::{
 };
 use cubek::matmul::{
     components::tile::TileMatmulKind,
-    definition::{MatmulElems, MatmulGlobalElems, MatmulKind},
+    definition::{MatmulElems, MatmulGlobalElems, MatmulKind, adjust_dtypes},
     strategy::{
         MatmulAutotuneKey, MatmulGlobalScale, MatmulProblemDefinition, should_tune_double_buffering,
     },
@@ -23,16 +23,22 @@ use cubek::matmul::{
 use serde::{Deserialize, Serialize};
 
 /// Whether the device can run `tile_matmul` with the element types of the matmul `definition`.
+///
+/// The kernel runs on the *register* types, not the global ones: the selection paths promote
+/// them with [`adjust_dtypes`] when the tile matmul needs an accelerator (f32 to tf32, flex32 to
+/// f16). Without the same promotion here, every f32 problem would look unsupported and the tf32
+/// tensor core path would be lost.
 fn tile_matmul_supported<R: Runtime>(
     client: &ComputeClient<R>,
     tile_matmul: TileMatmulKind,
     definition: &MatmulProblemDefinition,
 ) -> bool {
-    let elems = MatmulElems::from_globals(&MatmulGlobalElems {
+    let mut elems = MatmulElems::from_globals(&MatmulGlobalElems {
         lhs: definition.elem_lhs,
         rhs: definition.elem_rhs,
         out: definition.elem_out,
     });
+    adjust_dtypes(client, &mut elems, tile_matmul.requires_accelerator());
 
     !tile_matmul
         .supported_sizes(
@@ -242,12 +248,14 @@ pub fn fused_matmul_autotune<R: Runtime>(
                     Some(&odd),
                 ),
             ] {
-                // Accelerated kernels are only tuned when the device supports the tile matmul
-                // they are built on, otherwise they would be compiled just to fail.
+                // Accelerated kernels are demoted when the device doesn't support the tile
+                // matmul they are built on, otherwise they would be compiled just to fail. They
+                // keep the minimum priority rather than being discarded, so they remain a last
+                // resort and the tune plan can never end up empty.
                 let accelerated_priority =
                     move |key: &FusedMatmulAutotuneKey, client: &ComputeClient<R>| {
                         if !tile_matmul_supported::<R>(client, tm, &key.matmul_key.definition) {
-                            return PRIORITY_NEVER;
+                            return PRIORITY_MIN;
                         }
 
                         match double_buf {

--- a/crates/burn-cubecl-fusion/src/optim/matmul/tune.rs
+++ b/crates/burn-cubecl-fusion/src/optim/matmul/tune.rs
@@ -9,15 +9,40 @@ use burn_backend::cubecl::dtype_to_storage_type;
 use burn_fusion::stream::Context;
 use cubecl::{
     AutotuneKey, CubeTuneId, Runtime,
+    client::ComputeClient,
     std::tensor::MatrixBatchLayout,
     tune::{LocalTuner, Tunable, TunableSet, TuneGroup, local_tuner},
 };
 use cubek::matmul::{
     components::tile::TileMatmulKind,
     definition::{MatmulElems, MatmulGlobalElems, MatmulKind},
-    strategy::{MatmulAutotuneKey, MatmulGlobalScale, should_tune_double_buffering},
+    strategy::{
+        MatmulAutotuneKey, MatmulGlobalScale, MatmulProblemDefinition, should_tune_double_buffering,
+    },
 };
 use serde::{Deserialize, Serialize};
+
+/// Whether the device can run `tile_matmul` with the element types of the matmul `definition`.
+fn tile_matmul_supported<R: Runtime>(
+    client: &ComputeClient<R>,
+    tile_matmul: TileMatmulKind,
+    definition: &MatmulProblemDefinition,
+) -> bool {
+    let elems = MatmulElems::from_globals(&MatmulGlobalElems {
+        lhs: definition.elem_lhs,
+        rhs: definition.elem_rhs,
+        out: definition.elem_out,
+    });
+
+    !tile_matmul
+        .supported_sizes(
+            client,
+            elems.lhs_register,
+            elems.rhs_register,
+            elems.acc_register,
+        )
+        .is_empty()
+}
 
 #[derive(Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize, AutotuneKey)]
 pub struct FusedMatmulAutotuneKey {
@@ -217,55 +242,11 @@ pub fn fused_matmul_autotune<R: Runtime>(
                     Some(&odd),
                 ),
             ] {
-                let client_1 = tune_client.clone();
-                let mut tunable = Tunable::new(&selector.name(), move |input| {
-                    tune_fused::<R>(input, selector)
-                })
-                .group(&accelerated, move |key| {
-                    let elems = MatmulElems::from_globals(&MatmulGlobalElems {
-                        lhs: key.matmul_key.definition.elem_lhs,
-                        rhs: key.matmul_key.definition.elem_rhs,
-                        out: key.matmul_key.definition.elem_out,
-                    });
-
-                    let supported = !tm
-                        .supported_sizes(
-                            &client_1,
-                            elems.lhs_register,
-                            elems.rhs_register,
-                            elems.acc_register,
-                        )
-                        .is_empty();
-
-                    if !supported {
-                        return PRIORITY_NEVER;
-                    }
-
-                    match double_buf {
-                        false => PRIORITY_MAX,
-                        true => double_buffering_priority(key, PRIORITY_MAX, PRIORITY_HIGH),
-                    }
-                });
-
-                if let Some(group) = extra_group {
-                    let client_2 = tune_client.clone();
-                    tunable = tunable.group(group, move |key| {
-                        let elems = MatmulElems::from_globals(&MatmulGlobalElems {
-                            lhs: key.matmul_key.definition.elem_lhs,
-                            rhs: key.matmul_key.definition.elem_rhs,
-                            out: key.matmul_key.definition.elem_out,
-                        });
-
-                        let supported = !tm
-                            .supported_sizes(
-                                &client_2,
-                                elems.lhs_register,
-                                elems.rhs_register,
-                                elems.acc_register,
-                            )
-                            .is_empty();
-
-                        if !supported {
+                // Accelerated kernels are only tuned when the device supports the tile matmul
+                // they are built on, otherwise they would be compiled just to fail.
+                let accelerated_priority =
+                    move |key: &FusedMatmulAutotuneKey, client: &ComputeClient<R>| {
+                        if !tile_matmul_supported::<R>(client, tm, &key.matmul_key.definition) {
                             return PRIORITY_NEVER;
                         }
 
@@ -273,7 +254,20 @@ pub fn fused_matmul_autotune<R: Runtime>(
                             false => PRIORITY_MAX,
                             true => double_buffering_priority(key, PRIORITY_MAX, PRIORITY_HIGH),
                         }
-                    });
+                    };
+
+                let client_accelerated = tune_client.clone();
+                let mut tunable = Tunable::new(&selector.name(), move |input| {
+                    tune_fused::<R>(input, selector)
+                })
+                .group(&accelerated, move |key| {
+                    accelerated_priority(key, &client_accelerated)
+                });
+
+                if let Some(group) = extra_group {
+                    let client_extra = tune_client.clone();
+                    tunable =
+                        tunable.group(group, move |key| accelerated_priority(key, &client_extra));
                 }
                 set = set.with(tunable);
             }

--- a/crates/burn-cubecl/src/kernel/attention/tune.rs
+++ b/crates/burn-cubecl/src/kernel/attention/tune.rs
@@ -21,11 +21,14 @@ pub fn attention_autotune<R: CubeRuntime>(
 ) -> CubeTensor<R> {
     let client = query.client.clone();
 
+    let accelerated_client = client.clone();
+
     static TUNER: LocalTuner<AttentionAutotuneKey, CubeTuneId> = local_tuner!();
 
-    let tunables = TUNER.init(|| {
+    let tunables = TUNER.init(move || {
         const PRIORITY_MAX: i8 = 3;
         const PRIORITY_MIN: i8 = 0;
+        const PRIORITY_NEVER: i8 = -1;
 
         let flash_attention =
             TuneGroup::<AttentionAutotuneKey>::new("flash_attention", |_key| PRIORITY_MAX);
@@ -76,6 +79,7 @@ pub fn attention_autotune<R: CubeRuntime>(
         let seq_kv = 1;
         for num_planes in [2, 4, 8] {
             let name = format!("blackbox_accelerated_{num_planes}_planes_p_{seq_q}-{seq_kv}");
+            let client_accelerated = client.clone();
             set = set.with(
                 Tunable::new(
                     &name,
@@ -98,7 +102,18 @@ pub fn attention_autotune<R: CubeRuntime>(
                         .map_err(|err| std::format!("{err:?}"))
                     },
                 )
-                .group(&flash_attention, |_key| PRIORITY_MAX),
+                .group(&flash_attention, move |_key| {
+                    let features = &client_accelerated.properties().features;
+                    let has_accelerated = !features.matmul.cmma.is_empty()
+                        || !features.matmul.mma.is_empty()
+                        || !features.tma.is_empty();
+
+                    if !has_accelerated {
+                        return PRIORITY_NEVER;
+                    }
+
+                    PRIORITY_MAX
+                }),
             );
         }
 
@@ -122,8 +137,8 @@ pub fn attention_autotune<R: CubeRuntime>(
     });
 
     TUNER.execute(
-        &CubeTuneId::new(&client, &query.device),
-        &client,
+        &CubeTuneId::new(&accelerated_client, &query.device),
+        &accelerated_client,
         tunables,
         (query, key, value, mask, attn_bias, options),
     )

--- a/crates/burn-cubecl/src/kernel/attention/tune.rs
+++ b/crates/burn-cubecl/src/kernel/attention/tune.rs
@@ -3,7 +3,8 @@ use crate::{
     kernel::attention::{AttentionStrategy, attention},
     tensor::CubeTensor,
 };
-use burn_backend::cubecl::dtype_to_elem_type;
+use burn_backend::DType;
+use burn_backend::cubecl::{dtype_to_elem_type, dtype_to_storage_type};
 use burn_backend::ops::AttentionModuleOptions;
 use cubecl::tune::{LocalTuner, Tunable, TunableSet, TuneGroup, local_tuner};
 use cubek::attention::forward::{
@@ -28,7 +29,6 @@ pub fn attention_autotune<R: CubeRuntime>(
     let tunables = TUNER.init(move || {
         const PRIORITY_MAX: i8 = 3;
         const PRIORITY_MIN: i8 = 0;
-        const PRIORITY_NEVER: i8 = -1;
 
         let flash_attention =
             TuneGroup::<AttentionAutotuneKey>::new("flash_attention", |_key| PRIORITY_MAX);
@@ -103,16 +103,27 @@ pub fn attention_autotune<R: CubeRuntime>(
                     },
                 )
                 .group(&flash_attention, move |_key| {
-                    let features = &client_accelerated.properties().features;
-                    let has_accelerated = !features.matmul.cmma.is_empty()
-                        || !features.matmul.mma.is_empty()
-                        || !features.tma.is_empty();
+                    // The blackbox routine runs its tile matmuls on f16 fragments whatever the
+                    // problem dtype is, and validates them against the `cmma` feature list, so
+                    // that's what has to be available here — `mma` or `tma` support alone
+                    // wouldn't let the kernel run.
+                    let f16 = dtype_to_storage_type(DType::F16);
+                    let has_accelerated = client_accelerated
+                        .properties()
+                        .features
+                        .matmul
+                        .cmma
+                        .iter()
+                        .any(|config| config.a_type == f16 && config.b_type == f16);
 
-                    if !has_accelerated {
-                        return PRIORITY_NEVER;
+                    // Unsupported kernels keep the minimum priority rather than being
+                    // discarded, so they remain a last resort and the tune plan can never end
+                    // up empty.
+                    if has_accelerated {
+                        PRIORITY_MAX
+                    } else {
+                        PRIORITY_MIN
                     }
-
-                    PRIORITY_MAX
                 }),
             );
         }

--- a/crates/burn-cubecl/src/kernel/matmul/tune/base.rs
+++ b/crates/burn-cubecl/src/kernel/matmul/tune/base.rs
@@ -14,7 +14,7 @@ use cubecl::{
 };
 use cubek::matmul::{
     components::tile::TileMatmulKind,
-    definition::MatmulKind,
+    definition::{MatmulElems, MatmulGlobalElems, MatmulKind},
     routines::{
         BlueprintStrategy, TileSizeSelection,
         batch::{
@@ -53,6 +53,7 @@ pub fn matmul_autotune<R: CubeRuntime>(
 
     let client = lhs.client.clone();
     let bounds_client = client.clone();
+    let tune_client = client.clone();
     let num_cpu_cores = client.properties().hardware.num_cpu_cores;
 
     static TUNER: LocalTuner<MatmulAutotuneKey, CubeTuneId> = local_tuner!();
@@ -298,7 +299,7 @@ pub fn matmul_autotune<R: CubeRuntime>(
         );
 
         // Accelerated matmuls
-        for (strategy, double_buf, group_extra, tile_group) in [
+        for (strategy, double_buf, group_extra, tile_group, tile_matmul) in [
             (
                 Strategy::SimpleCyclicCmma(BlueprintStrategy::Inferred(SimpleArgs {
                     multi_rows: false,
@@ -307,6 +308,7 @@ pub fn matmul_autotune<R: CubeRuntime>(
                 false,
                 None,
                 &accelerated,
+                TileMatmulKind::Cmma,
             ),
             (
                 Strategy::SimpleCyclicMma(BlueprintStrategy::Inferred(SimpleArgs {
@@ -316,6 +318,7 @@ pub fn matmul_autotune<R: CubeRuntime>(
                 false,
                 None,
                 &accelerated,
+                TileMatmulKind::Mma,
             ),
             (
                 Strategy::SimpleCyclicCmma(BlueprintStrategy::Inferred(SimpleArgs {
@@ -325,6 +328,7 @@ pub fn matmul_autotune<R: CubeRuntime>(
                 false,
                 None,
                 &accelerated,
+                TileMatmulKind::Cmma,
             ),
             (
                 Strategy::SimpleCyclicMma(BlueprintStrategy::Inferred(SimpleArgs {
@@ -334,6 +338,7 @@ pub fn matmul_autotune<R: CubeRuntime>(
                 false,
                 None,
                 &accelerated,
+                TileMatmulKind::Mma,
             ),
             (
                 Strategy::OrderedDoubleCmma(BlueprintStrategy::Inferred(OrderedSelectionArgs {
@@ -345,6 +350,7 @@ pub fn matmul_autotune<R: CubeRuntime>(
                 true,
                 None,
                 &accelerated,
+                TileMatmulKind::Cmma,
             ),
             (
                 Strategy::OrderedDoubleMma(BlueprintStrategy::Inferred(OrderedSelectionArgs {
@@ -356,6 +362,7 @@ pub fn matmul_autotune<R: CubeRuntime>(
                 true,
                 None,
                 &accelerated,
+                TileMatmulKind::Mma,
             ),
             (
                 Strategy::OrderedDoubleCmma(BlueprintStrategy::Inferred(OrderedSelectionArgs {
@@ -367,6 +374,7 @@ pub fn matmul_autotune<R: CubeRuntime>(
                 true,
                 None,
                 &accelerated,
+                TileMatmulKind::Cmma,
             ),
             (
                 Strategy::OrderedDoubleMma(BlueprintStrategy::Inferred(OrderedSelectionArgs {
@@ -378,6 +386,7 @@ pub fn matmul_autotune<R: CubeRuntime>(
                 true,
                 None,
                 &accelerated,
+                TileMatmulKind::Mma,
             ),
             (
                 Strategy::DoubleCyclicCmma(BlueprintStrategy::Inferred(DoubleBufferingArgs {
@@ -387,6 +396,7 @@ pub fn matmul_autotune<R: CubeRuntime>(
                 true,
                 None,
                 &accelerated,
+                TileMatmulKind::Cmma,
             ),
             (
                 Strategy::DoubleCyclicMma(BlueprintStrategy::Inferred(DoubleBufferingArgs {
@@ -396,6 +406,7 @@ pub fn matmul_autotune<R: CubeRuntime>(
                 true,
                 None,
                 &accelerated,
+                TileMatmulKind::Mma,
             ),
             (
                 Strategy::DoubleCyclicCmma(BlueprintStrategy::Inferred(DoubleBufferingArgs {
@@ -405,6 +416,7 @@ pub fn matmul_autotune<R: CubeRuntime>(
                 true,
                 None,
                 &accelerated,
+                TileMatmulKind::Cmma,
             ),
             (
                 Strategy::DoubleCyclicMma(BlueprintStrategy::Inferred(DoubleBufferingArgs {
@@ -414,18 +426,21 @@ pub fn matmul_autotune<R: CubeRuntime>(
                 true,
                 None,
                 &accelerated,
+                TileMatmulKind::Mma,
             ),
             (
                 Strategy::SpecializedCyclicCmma(BlueprintStrategy::Inferred(().into())),
                 true,
                 None,
                 &accelerated,
+                TileMatmulKind::Cmma,
             ),
             (
                 Strategy::SpecializedCyclicMma(BlueprintStrategy::Inferred(().into())),
                 true,
                 None,
                 &accelerated,
+                TileMatmulKind::Mma,
             ),
             (
                 Strategy::SimpleTmaCmma(BlueprintStrategy::Inferred(SimpleArgs {
@@ -435,6 +450,7 @@ pub fn matmul_autotune<R: CubeRuntime>(
                 false,
                 Some(&tma),
                 &accelerated,
+                TileMatmulKind::Cmma,
             ),
             (
                 Strategy::SimpleTmaMma(BlueprintStrategy::Inferred(SimpleArgs {
@@ -444,6 +460,7 @@ pub fn matmul_autotune<R: CubeRuntime>(
                 false,
                 Some(&tma),
                 &accelerated,
+                TileMatmulKind::Mma,
             ),
             (
                 Strategy::SimpleTmaCmma(BlueprintStrategy::Inferred(SimpleArgs {
@@ -453,6 +470,7 @@ pub fn matmul_autotune<R: CubeRuntime>(
                 false,
                 Some(&tma),
                 &accelerated,
+                TileMatmulKind::Cmma,
             ),
             (
                 Strategy::SimpleTmaMma(BlueprintStrategy::Inferred(SimpleArgs {
@@ -462,37 +480,83 @@ pub fn matmul_autotune<R: CubeRuntime>(
                 false,
                 Some(&tma),
                 &accelerated,
+                TileMatmulKind::Mma,
             ),
             (
                 Strategy::SpecializedTmaCmma(BlueprintStrategy::Inferred(().into())),
                 true,
                 Some(&tma),
                 &accelerated,
+                TileMatmulKind::Cmma,
             ),
             (
                 Strategy::SpecializedTmaMma(BlueprintStrategy::Inferred(().into())),
                 true,
                 Some(&tma),
                 &accelerated,
+                TileMatmulKind::Mma,
             ),
         ] {
-            let priority_within_group = |key: &MatmulAutotuneKey, double_buf: bool| match double_buf
-            {
-                false => PRIORITY_MAX,
-                true => double_buffering_priority(key, PRIORITY_MAX, PRIORITY_HIGH),
-            };
             let mut tunable = Tunable::new(&strategy.to_string(), move |(lhs, rhs, out)| {
                 launch_matmul::<R>(&strategy, lhs, rhs, out).map_err(|err| format!("{err:?}"))
             });
 
             // tile group
+            let client_1 = tune_client.clone();
             tunable = tunable.group(tile_group, move |key| {
-                priority_within_group(key, double_buf)
+                let elems = MatmulElems::from_globals(&MatmulGlobalElems {
+                    lhs: key.definition.elem_lhs,
+                    rhs: key.definition.elem_rhs,
+                    out: key.definition.elem_out,
+                });
+
+                let supported = !tile_matmul
+                    .supported_sizes(
+                        &client_1,
+                        elems.lhs_register,
+                        elems.rhs_register,
+                        elems.acc_register,
+                    )
+                    .is_empty();
+
+                if !supported {
+                    return PRIORITY_NEVER;
+                }
+
+                match double_buf {
+                    false => PRIORITY_MAX,
+                    true => double_buffering_priority(key, PRIORITY_MAX, PRIORITY_HIGH),
+                }
             });
 
             // extra group
             if let Some(group) = group_extra {
-                tunable = tunable.group(group, move |key| priority_within_group(key, double_buf));
+                let client_2 = tune_client.clone();
+                tunable = tunable.group(group, move |key| {
+                    let elems = MatmulElems::from_globals(&MatmulGlobalElems {
+                        lhs: key.definition.elem_lhs,
+                        rhs: key.definition.elem_rhs,
+                        out: key.definition.elem_out,
+                    });
+
+                    let supported = !tile_matmul
+                        .supported_sizes(
+                            &client_2,
+                            elems.lhs_register,
+                            elems.rhs_register,
+                            elems.acc_register,
+                        )
+                        .is_empty();
+
+                    if !supported {
+                        return PRIORITY_NEVER;
+                    }
+
+                    match double_buf {
+                        false => PRIORITY_MAX,
+                        true => double_buffering_priority(key, PRIORITY_MAX, PRIORITY_HIGH),
+                    }
+                });
             }
             set = set.with(tunable);
         }

--- a/crates/burn-cubecl/src/kernel/matmul/tune/base.rs
+++ b/crates/burn-cubecl/src/kernel/matmul/tune/base.rs
@@ -15,7 +15,7 @@ use cubecl::{
 };
 use cubek::matmul::{
     components::tile::TileMatmulKind,
-    definition::{MatmulElems, MatmulGlobalElems, MatmulKind},
+    definition::{MatmulElems, MatmulGlobalElems, MatmulKind, adjust_dtypes},
     routines::{
         BlueprintStrategy, TileSizeSelection,
         batch::{
@@ -35,16 +35,22 @@ use cubek::matmul::{
 pub(super) type Inputs<R> = (CubeTensor<R>, CubeTensor<R>, CubeTensor<R>);
 
 /// Whether the device can run `tile_matmul` with the element types of the matmul `definition`.
+///
+/// The kernel runs on the *register* types, not the global ones: the selection paths promote
+/// them with [`adjust_dtypes`] when the tile matmul needs an accelerator (f32 to tf32, flex32 to
+/// f16). Without the same promotion here, every f32 problem would look unsupported and the tf32
+/// tensor core path would be lost.
 pub(crate) fn tile_matmul_supported<R: CubeRuntime>(
     client: &ComputeClient<R>,
     tile_matmul: TileMatmulKind,
     definition: &MatmulProblemDefinition,
 ) -> bool {
-    let elems = MatmulElems::from_globals(&MatmulGlobalElems {
+    let mut elems = MatmulElems::from_globals(&MatmulGlobalElems {
         lhs: definition.elem_lhs,
         rhs: definition.elem_rhs,
         out: definition.elem_out,
     });
+    adjust_dtypes(client, &mut elems, tile_matmul.requires_accelerator());
 
     !tile_matmul
         .supported_sizes(
@@ -527,11 +533,13 @@ pub fn matmul_autotune<R: CubeRuntime>(
                 launch_matmul::<R>(&strategy, lhs, rhs, out).map_err(|err| format!("{err:?}"))
             });
 
-            // Accelerated kernels are only tuned when the device supports the tile matmul they
-            // are built on, otherwise they would be compiled just to fail.
+            // Accelerated kernels are demoted when the device doesn't support the tile matmul
+            // they are built on, otherwise they would be compiled just to fail. They keep the
+            // minimum priority rather than being discarded, so they remain a last resort and
+            // the tune plan can never end up empty.
             let accelerated_priority = move |key: &MatmulAutotuneKey, client: &ComputeClient<R>| {
                 if !tile_matmul_supported::<R>(client, tile_matmul, &key.definition) {
-                    return PRIORITY_NEVER;
+                    return PRIORITY_MIN;
                 }
 
                 match double_buf {

--- a/crates/burn-cubecl/src/kernel/matmul/tune/base.rs
+++ b/crates/burn-cubecl/src/kernel/matmul/tune/base.rs
@@ -9,6 +9,7 @@ use crate::{
 use burn_backend::DType;
 use burn_backend::cubecl::dtype_to_storage_type;
 use cubecl::{
+    client::ComputeClient,
     std::tensor::MatrixBatchLayout,
     tune::{LocalTuner, Tunable, TunableSet, TuneGroup, local_tuner},
 };
@@ -25,10 +26,35 @@ use cubek::matmul::{
         cpu_gemm::CpuGemmStrategy,
         gemm::GemmStrategy,
     },
-    strategy::{MatmulAutotuneKey, MatmulGlobalScale, Strategy, should_tune_double_buffering},
+    strategy::{
+        MatmulAutotuneKey, MatmulGlobalScale, MatmulProblemDefinition, Strategy,
+        should_tune_double_buffering,
+    },
 };
 
 pub(super) type Inputs<R> = (CubeTensor<R>, CubeTensor<R>, CubeTensor<R>);
+
+/// Whether the device can run `tile_matmul` with the element types of the matmul `definition`.
+pub(crate) fn tile_matmul_supported<R: CubeRuntime>(
+    client: &ComputeClient<R>,
+    tile_matmul: TileMatmulKind,
+    definition: &MatmulProblemDefinition,
+) -> bool {
+    let elems = MatmulElems::from_globals(&MatmulGlobalElems {
+        lhs: definition.elem_lhs,
+        rhs: definition.elem_rhs,
+        out: definition.elem_out,
+    });
+
+    !tile_matmul
+        .supported_sizes(
+            client,
+            elems.lhs_register,
+            elems.rhs_register,
+            elems.acc_register,
+        )
+        .is_empty()
+}
 
 fn matmul_input_gen<R: CubeRuntime>(
     _key: &MatmulAutotuneKey,
@@ -501,25 +527,10 @@ pub fn matmul_autotune<R: CubeRuntime>(
                 launch_matmul::<R>(&strategy, lhs, rhs, out).map_err(|err| format!("{err:?}"))
             });
 
-            // tile group
-            let client_1 = tune_client.clone();
-            tunable = tunable.group(tile_group, move |key| {
-                let elems = MatmulElems::from_globals(&MatmulGlobalElems {
-                    lhs: key.definition.elem_lhs,
-                    rhs: key.definition.elem_rhs,
-                    out: key.definition.elem_out,
-                });
-
-                let supported = !tile_matmul
-                    .supported_sizes(
-                        &client_1,
-                        elems.lhs_register,
-                        elems.rhs_register,
-                        elems.acc_register,
-                    )
-                    .is_empty();
-
-                if !supported {
+            // Accelerated kernels are only tuned when the device supports the tile matmul they
+            // are built on, otherwise they would be compiled just to fail.
+            let accelerated_priority = move |key: &MatmulAutotuneKey, client: &ComputeClient<R>| {
+                if !tile_matmul_supported::<R>(client, tile_matmul, &key.definition) {
                     return PRIORITY_NEVER;
                 }
 
@@ -527,36 +538,18 @@ pub fn matmul_autotune<R: CubeRuntime>(
                     false => PRIORITY_MAX,
                     true => double_buffering_priority(key, PRIORITY_MAX, PRIORITY_HIGH),
                 }
+            };
+
+            // tile group
+            let client_tile = tune_client.clone();
+            tunable = tunable.group(tile_group, move |key| {
+                accelerated_priority(key, &client_tile)
             });
 
             // extra group
             if let Some(group) = group_extra {
-                let client_2 = tune_client.clone();
-                tunable = tunable.group(group, move |key| {
-                    let elems = MatmulElems::from_globals(&MatmulGlobalElems {
-                        lhs: key.definition.elem_lhs,
-                        rhs: key.definition.elem_rhs,
-                        out: key.definition.elem_out,
-                    });
-
-                    let supported = !tile_matmul
-                        .supported_sizes(
-                            &client_2,
-                            elems.lhs_register,
-                            elems.rhs_register,
-                            elems.acc_register,
-                        )
-                        .is_empty();
-
-                    if !supported {
-                        return PRIORITY_NEVER;
-                    }
-
-                    match double_buf {
-                        false => PRIORITY_MAX,
-                        true => double_buffering_priority(key, PRIORITY_MAX, PRIORITY_HIGH),
-                    }
-                });
+                let client_extra = tune_client.clone();
+                tunable = tunable.group(group, move |key| accelerated_priority(key, &client_extra));
             }
             set = set.with(tunable);
         }


### PR DESCRIPTION
## Changes

- **Matmul** (`burn-cubecl`, `burn-cubecl-fusion`): each accelerated strategy now carries its `TileMatmulKind` (`Cmma`/`Mma`). Its group priority returns `PRIORITY_NEVER` when `TileMatmulKind::supported_sizes` is empty for the key's element types (`elem_lhs`/`elem_rhs`/`elem_out` via `MatmulElems::from_globals`).
- **Attention** (`burn-cubecl`): the accelerated flash-attention tunables return `PRIORITY_NEVER` when the client exposes no `matmul.cmma`, `matmul.mma`, or `tma` features.
- The compute client is cloned into the `TUNER.init` closure so priority functions can query device properties.

Negative intra-group priority is dropped by `TunePlan` before the tunable is ever handed to the benchmark loop, so unsupported kernels are never compiled. The win is autotune time on devices without CMMA/MMA (currently they compile every accelerated variant only to fail or run slowly).

## Notes 

- Matmul TMA strategies are pruned by their tile kind only; TMA support itself is not checked, so a CMMA-capable device without TMA still compiles them.
