### PR TITLE
refactor(burn-tensor): remove duplicate dimension checks

### DIFF
--- a/crates/burn-tensor/src/tensor/activation/base.rs
+++ b/crates/burn-tensor/src/tensor/activation/base.rs
@@ -186,7 +186,7 @@ $$
 /// # Panics
 /// - If `dim` is outside [-D, D)
 pub fn softmax<const D: usize>(tensor: Tensor<D>, dim: impl AsIndex) -> Tensor<D> {
-    let dim = unwrap_dim_index(dim.try_dim_index(D));
+    let dim = unwrap_dim_index(dim.try_dim_index(D), "Softmax");
     Tensor::new(softmax_impl(tensor.primitive, dim))
 }
 
@@ -209,7 +209,7 @@ $$
 /// # Panics
 /// - If `dim` is outside [-D, D)
 pub fn softmin<const D: usize>(tensor: Tensor<D>, dim: impl AsIndex) -> Tensor<D> {
-    let dim = unwrap_dim_index(dim.try_dim_index(D));
+    let dim = unwrap_dim_index(dim.try_dim_index(D), "Softmin");
     Tensor::new(softmin_impl(tensor.primitive, dim))
 }
 
@@ -258,7 +258,7 @@ $$
 /// # Panics
 /// - If `dim` is outside [-D, D)
 pub fn quiet_softmax<const D: usize>(tensor: Tensor<D>, dim: impl AsIndex) -> Tensor<D> {
-    let dim = unwrap_dim_index(dim.try_dim_index(D));
+    let dim = unwrap_dim_index(dim.try_dim_index(D), "Quiet Softmax");
     let max_vals = tensor.clone().detach().max_dim(dim);
     let exp_x = (tensor - max_vals.clone()).exp();
     let sum_exp = exp_x.clone().sum_dim(dim);
@@ -290,7 +290,7 @@ $$
 /// # Panics
 /// - If `dim` is outside [-D, D)
 pub fn log_softmax<const D: usize>(tensor: Tensor<D>, dim: impl AsIndex) -> Tensor<D> {
-    let dim = unwrap_dim_index(dim.try_dim_index(D));
+    let dim = unwrap_dim_index(dim.try_dim_index(D), "Log Softmax");
     Tensor::new(log_softmax_impl(tensor.primitive, dim))
 }
 
@@ -546,7 +546,7 @@ pub fn threshold<const D: usize>(tensor: Tensor<D>, threshold: f64, value: f64) 
 /// ### Returns
 /// * A tensor with the same shape as the input, except the size along `dim` is halved.
 pub fn glu<const D: usize>(tensor: Tensor<D>, dim: impl AsIndex) -> Tensor<D> {
-    let dim = unwrap_dim_index(dim.try_dim_index(D));
+    let dim = unwrap_dim_index(dim.try_dim_index(D), "GLU");
     assert!(
         tensor.dims()[dim].is_multiple_of(2),
         "Input tensor along dimension {dim} must have an even size. N is divisible by 2."

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -480,9 +480,8 @@ where
         Dim1: AsIndex,
         Dim2: AsIndex,
     {
-        let dim1 = unwrap_dim_index(dim1.try_dim_index(D));
-        let dim2 = unwrap_dim_index(dim2.try_dim_index(D));
-        check!(TensorCheck::swap_dims::<D>(dim1, dim2));
+        let dim1 = unwrap_dim_index(dim1.try_dim_index(D), "Swap Dims");
+        let dim2 = unwrap_dim_index(dim2.try_dim_index(D), "Swap Dims");
         if dim1 == dim2 {
             self
         } else {
@@ -529,7 +528,7 @@ where
         let mut no_op = true;
         let mut fixed_axes = [0; D];
         for (i, axis) in axes.into_iter().enumerate() {
-            let dim = unwrap_dim_index(axis.try_dim_index(D));
+            let dim = unwrap_dim_index(axis.try_dim_index(D), "Permute");
             no_op &= dim == i;
             fixed_axes[i] = dim;
         }
@@ -661,7 +660,7 @@ where
         // Convert the axes to usize without allocating.
         let mut transformed_axes: [usize; N] = [0; N];
         for (i, axis) in axes.into_iter().enumerate() {
-            transformed_axes[i] = unwrap_dim_index(axis.try_dim_index(D));
+            transformed_axes[i] = unwrap_dim_index(axis.try_dim_index(D), "Flip");
         }
 
         // Check if the axes are valid
@@ -712,8 +711,8 @@ where
         start_dim: impl AsIndex,
         end_dim: impl AsIndex,
     ) -> Tensor<D2, K> {
-        let start_dim = unwrap_dim_index(start_dim.try_dim_index(D));
-        let end_dim = unwrap_dim_index(end_dim.try_dim_index(D));
+        let start_dim = unwrap_dim_index(start_dim.try_dim_index(D), "Flatten");
+        let end_dim = unwrap_dim_index(end_dim.try_dim_index(D), "Flatten");
         check!(TensorCheck::flatten::<D, D2>(start_dim, end_dim));
         let new_shape = self.shape().flatten_dims(start_dim, end_dim);
 
@@ -802,7 +801,7 @@ where
     /// }
     /// ```
     pub fn squeeze_dim<const D2: usize>(self, dim: impl AsIndex) -> Tensor<D2, K> {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Squeeze");
         check!(TensorCheck::squeeze::<D2>(dim, &self.shape()));
 
         let current_dims = self.shape();
@@ -865,7 +864,7 @@ where
         } else {
             dim_indices = dims
                 .iter()
-                .map(|dim| unwrap_dim_index(dim.try_dim_index(D)))
+                .map(|dim| unwrap_dim_index(dim.try_dim_index(D), "Squeeze"))
                 .collect();
         }
 
@@ -958,7 +957,7 @@ where
     /// }
     /// ```
     pub fn unsqueeze_dim<const D2: usize>(self, dim: impl AsIndex) -> Tensor<D2, K> {
-        let dim = unwrap_dim_index(dim.try_dim_index(D + 1));
+        let dim = unwrap_dim_index(dim.try_dim_index(D + 1), "Unsqueeze");
         check!(TensorCheck::unsqueeze_dim::<D, D2>(dim));
 
         let mut dims = [1; D2];
@@ -1083,7 +1082,7 @@ where
         Shift: AsIndex,
         Dim: AsIndex,
     {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Roll");
         let size = self.shape()[dim];
         if size == 0 {
             // If the dimension is empty, return the tensor as is.
@@ -1172,7 +1171,7 @@ where
         // Accumulate the effective shifts for each dimension.
         let mut accumulated_shifts: Vec<isize> = vec![0; shape.len()];
         for i in 0..item_count {
-            let dim = unwrap_dim_index(dims[i].try_dim_index(D));
+            let dim = unwrap_dim_index(dims[i].try_dim_index(D), "Roll");
             accumulated_shifts[dim] += shifts[i].as_index();
         }
 
@@ -1582,7 +1581,7 @@ where
     where
         S: Into<Slice>,
     {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Slice");
         let slice: Slice = slice.into();
 
         let mut slices = vec![Slice::full(); D];
@@ -1623,8 +1622,7 @@ where
     /// }
     /// ```
     pub fn select(self, dim: impl AsIndex, indices: Tensor<1, Int>) -> Self {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
-        check!(TensorCheck::select::<D>(dim));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Select");
         Self::new(K::select(self.primitive, dim, indices.primitive))
     }
 
@@ -1661,7 +1659,7 @@ where
         values: Tensor<D, K>,
         update: IndexingUpdateOp,
     ) -> Self {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Select Assign");
         check!(TensorCheck::select_assign::<D>(
             dim,
             &indices.shape(),
@@ -1819,7 +1817,7 @@ where
     /// Not all backends have runtime bound checks for the indices, so make sure the they are valid.
     /// Otherwise, out of bounds indices could lead to unexpected results instead of panicking.
     pub fn gather(self, dim: impl AsIndex, indices: Tensor<D, Int>) -> Self {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Gather");
         check!(TensorCheck::gather::<D>(
             dim,
             &self.shape(),
@@ -1864,7 +1862,7 @@ where
         values: Self,
         update: IndexingUpdateOp,
     ) -> Self {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Scatter");
         check!(TensorCheck::scatter::<D>(
             dim,
             &self.shape(),
@@ -2041,7 +2039,7 @@ where
     /// }
     /// ```
     pub fn repeat_dim(self, dim: impl AsIndex, times: usize) -> Self {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Repeat");
         if times > 0 {
             Self::new(K::repeat_dim(self.primitive, dim, times))
         } else {
@@ -2241,7 +2239,7 @@ where
     /// }
     /// ```
     pub fn cat(tensors: Vec<Self>, dim: impl AsIndex) -> Self {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Cat");
         check!(TensorCheck::cat(tensors.as_slice(), dim));
 
         // Filter out tensors with size 0 along the concatenation dimension.
@@ -2296,7 +2294,7 @@ where
     /// }
     /// ```
     pub fn stack<const D2: usize>(tensors: Vec<Tensor<D, K>>, dim: impl AsIndex) -> Tensor<D2, K> {
-        let dim = unwrap_dim_index(dim.try_dim_index(D + 1));
+        let dim = unwrap_dim_index(dim.try_dim_index(D + 1), "Stack");
         check!(TensorCheck::stack::<D, K, D2>(tensors.as_slice(), dim));
         let tensors = tensors.into_iter().map(|t| t.unsqueeze_dim(dim)).collect();
         Tensor::<D2, K>::cat(tensors, dim)
@@ -2330,7 +2328,7 @@ where
     /// }
     /// ```
     pub fn iter_dim(self, dim: impl AsIndex) -> DimIter<D, K> {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Iter Dim");
         DimIter::new(self, dim)
     }
 
@@ -2371,7 +2369,7 @@ where
     /// }
     /// ```
     pub fn narrow(self, dim: impl AsIndex, start: usize, length: usize) -> Self {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Narrow");
         check!(TensorCheck::narrow(&self, dim, start, length));
         let dims = self.dims();
 
@@ -2433,7 +2431,7 @@ where
     /// }
     /// ```
     pub fn chunk(self, chunks: usize, dim: impl AsIndex) -> Vec<Self> {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Chunk");
         let size = self.shape()[dim];
         if size < chunks {
             return (0..size)
@@ -2493,7 +2491,7 @@ where
     /// }
     /// ```
     pub fn split(self, split_size: usize, dim: impl AsIndex) -> Vec<Self> {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Split");
         check!(TensorCheck::split::<D>(&self.shape(), split_size, dim));
         let size = self.shape()[dim];
         let mut tensors = Vec::new();
@@ -2540,7 +2538,7 @@ where
     /// }
     /// ```
     pub fn split_with_sizes(self, split_sizes: Vec<usize>, dim: impl AsIndex) -> Vec<Self> {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Split With Sizes");
         check!(TensorCheck::split_with_sizes::<D>(
             &self.shape(),
             &split_sizes,
@@ -2625,7 +2623,7 @@ where
     /// }
     /// ```
     pub fn any_dim(self, dim: impl AsIndex) -> Tensor<D, Bool> {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Any");
         Tensor::new(K::any_dim(self.primitive, dim))
     }
 
@@ -2688,7 +2686,7 @@ where
     /// }
     /// ```
     pub fn all_dim(self, dim: impl AsIndex) -> Tensor<D, Bool> {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "All");
         Tensor::new(K::all_dim(self.primitive, dim))
     }
 
@@ -2800,7 +2798,7 @@ where
     pub fn expand<const D2: usize, S: BroadcastArgs<D, D2>>(self, shape: S) -> Tensor<D2, K> {
         let shape = shape.into_shape(&self.shape());
         check!(TensorCheck::expand::<D, D2>(
-            "expand",
+            "Expand",
             &self.shape(),
             &shape,
         ));
@@ -2839,9 +2837,9 @@ where
         size: usize,
         step: usize,
     ) -> Tensor<D2, K> {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Unfold");
         check!(TensorCheck::unfold::<D, D2>(
-            "unfold",
+            "Unfold",
             &self.shape(),
             dim,
             size,
@@ -3033,7 +3031,7 @@ impl<I: AsIndex> MovedimArgs for Vec<I> {
     fn into_dim_vec<const D: usize>(self) -> Vec<usize> {
         let set = self
             .into_iter()
-            .map(|dim| unwrap_dim_index(dim.try_dim_index(D)))
+            .map(|dim| unwrap_dim_index(dim.try_dim_index(D), "Movedim"))
             .collect::<Vec<usize>>();
         check!(TensorCheck::movedim_args_vec::<D>(&set));
 
@@ -3046,7 +3044,7 @@ macro_rules! impl_movedim_args {
         $(
             impl MovedimArgs for $ty {
                 fn into_dim_vec<const D: usize>(self) -> Vec<usize> {
-                    vec![unwrap_dim_index(self.try_dim_index(D))]
+                    vec![unwrap_dim_index(self.try_dim_index(D), "Movedim")]
                 }
             }
         )*

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -414,29 +414,13 @@ impl TensorCheck {
         check
     }
 
-    pub(crate) fn swap_dims<const D: usize>(dim1: usize, dim2: usize) -> Self {
-        let mut check = Self::Ok;
-
-        if dim1 > D || dim2 > D {
-            check = check.register(
-                "Swap Dims",
-                TensorError::new("The swap dimensions must be smaller than the tensor dimension")
-                    .details(format!(
-                        "Swap dims ({dim1}, {dim2}) on tensor with ({D}) dimensions."
-                    )),
-            );
-        }
-
-        check
-    }
-
     pub(crate) fn permute<const D: usize>(axes: [usize; D]) -> Self {
         let check = Self::Ok;
 
         // Check if the axes are within the tensor dimensions
         if let Some(axis) = axes.iter().find(|&x| *x >= D) {
             return check.register(
-                "permute",
+                "Permute",
                 TensorError::new("The axes must be smaller than the tensor dimension.")
                     .details(format!("The '{axis}' axis is greater than {D} dimensions.")),
             );
@@ -447,7 +431,7 @@ impl TensorCheck {
         axes.iter().for_each(|&x| seen[x] = true);
         if seen.iter().any(|&x| !x) {
             return check.register(
-                "permute",
+                "Permute",
                 TensorError::new("The axes must be unique.")
                     .details(format!("The axes '{axes:?}' are not unique.")),
             );
@@ -534,16 +518,6 @@ impl TensorCheck {
         let shape_lhs = lhs.shape();
         let shape_rhs = rhs.shape();
 
-        if dim >= D {
-            check = check.register(
-                "Cross",
-                TensorError::new(format!(
-                    "Dimension {dim} is out of bounds for tensors with {D} dimensions."
-                )),
-            );
-            return check;
-        }
-
         let dim_size_lhs = shape_lhs[dim];
         let dim_size_rhs = shape_rhs[dim];
 
@@ -580,18 +554,6 @@ impl TensorCheck {
         dim: usize,
     ) -> Self {
         let mut check = Self::Ok;
-
-        if dim > D1 {
-            check = check.register(
-                "Stack",
-                TensorError::new(
-                    "Can't stack tensors on a dim that exceeds the tensors dimension (inclusive)",
-                )
-                .details(format!(
-                    "Trying to concatenate tensors with {D1} dimensions on axis {dim}."
-                )),
-            );
-        }
 
         if D1 == D2 {
             check = check.register(
@@ -630,19 +592,7 @@ impl TensorCheck {
     }
 
     pub(crate) fn cat<const D: usize, K: BasicOps>(tensors: &[Tensor<D, K>], dim: usize) -> Self {
-        let mut check = Self::Ok;
-
-        if dim >= D {
-            check = check.register(
-                "Cat",
-                TensorError::new(
-                    "Can't concatenate tensors on a dim that exceeds the tensors dimension",
-                )
-                .details(format!(
-                    "Trying to concatenate tensors with {D} dimensions on axis {dim}."
-                )),
-            );
-        }
+        let check = Self::Ok;
 
         if tensors.is_empty() {
             return check.register(
@@ -975,10 +925,6 @@ impl TensorCheck {
         check
     }
 
-    pub(crate) fn select<const D: usize>(dim: usize) -> Self {
-        Self::check_select_basic::<D>(Self::Ok, "select", dim)
-    }
-
     pub(crate) fn mask_select(shape: &Shape, shape_mask: &Shape) -> Self {
         let mut check = Self::Ok;
 
@@ -994,8 +940,8 @@ impl TensorCheck {
         check
     }
 
-    pub(crate) fn take<const D: usize, const DI: usize, const DO: usize>(dim: usize) -> Self {
-        let mut check = Self::check_select_basic::<D>(Self::Ok, "Take", dim);
+    pub(crate) fn take<const D: usize, const DI: usize, const DO: usize>() -> Self {
+        let mut check = Self::Ok;
 
         // Calculate expected output dimensions
         // DO = D - 1 + DI (remove 1 dim, add DI dims)
@@ -1046,7 +992,7 @@ impl TensorCheck {
         shape_indices: &Shape,
         shape_value: &Shape,
     ) -> Self {
-        let mut check = Self::check_select_basic::<D>(Self::Ok, "Select Assign", dim);
+        let mut check = Self::Ok;
 
         if shape_value[dim] != shape_indices[0] {
             check = check.register(
@@ -1064,18 +1010,6 @@ impl TensorCheck {
         check
     }
 
-    fn check_select_basic<const D: usize>(mut check: Self, ops: &str, dim: usize) -> Self {
-        if dim > D {
-            check = check.register(
-                ops,
-                TensorError::new(format!(
-                    "Can't index a tensor with ({D}) dimensions on axis ({dim})"
-                )),
-            );
-        }
-
-        check
-    }
     fn check_gather_scatter_indices<const D: usize>(
         mut check: Self,
         ops: &str,
@@ -1083,15 +1017,6 @@ impl TensorCheck {
         shape: &Shape,
         shape_indices: &Shape,
     ) -> Self {
-        if dim > D {
-            check = check.register(
-                ops,
-                TensorError::new(format!(
-                    "Can't index a tensor with ({D}) dimensions on axis ({dim})"
-                )),
-            );
-        }
-
         for i in 0..D {
             if i == dim {
                 continue;
@@ -1155,44 +1080,13 @@ impl TensorCheck {
         }
     }
 
-    /// Checks aggregate dimension such as mean and sum.
-    pub(crate) fn aggregate_dim<const D: usize>(ops: &str, dim: usize) -> Self {
-        let mut check = Self::Ok;
-
-        if dim > D {
-            check = check.register(
-                ops,
-                TensorError::new(format!(
-                    "Can't aggregate a tensor with ({D}) dimensions on axis ({dim})"
-                )),
-            );
-        }
-
-        check
-    }
-
-    pub(crate) fn sort_dim<const D: usize>(ops: &str, dim: usize) -> Self {
-        let mut check = Self::Ok;
-
-        if dim > D {
-            check = check.register(
-                ops,
-                TensorError::new(format!(
-                    "Can't sort a tensor with ({D}) dimensions on axis ({dim})"
-                )),
-            );
-        }
-
-        check
-    }
-
     pub(crate) fn split<const D: usize>(
         tensor_dims: &[usize],
         split_size: usize,
         dim: usize,
     ) -> Self {
         let mut check = Self::Ok;
-        let op = "split";
+        let op = "Split";
 
         let tensor_size = tensor_dims[dim];
         if split_size == 0 && tensor_size != 0 {
@@ -1212,7 +1106,7 @@ impl TensorCheck {
         dim: usize,
     ) -> Self {
         let mut check = Self::Ok;
-        let op = "split_with_sizes";
+        let op = "Split With Sizes";
 
         // Validate split_sizes add up to size of dimension to split along
         let tensor_size = tensor_dims[dim];
@@ -1589,16 +1483,14 @@ pub(crate) fn unwrap_shape_reshape(result: Result<Shape, burn_std::MetadataError
 }
 
 #[track_caller]
-pub(crate) fn unwrap_dim_index<E>(result: Result<usize, E>) -> usize
+pub(crate) fn unwrap_dim_index<E>(result: Result<usize, E>, op: &str) -> usize
 where
     E: core::fmt::Display,
 {
     match result {
         Ok(dim) => dim,
         Err(error) => {
-            macros::check!({
-                TensorCheck::Ok.register("Dimension Indexing", TensorError::new(error.to_string()))
-            });
+            macros::check!({ TensorCheck::Ok.register(op, TensorError::new(error.to_string())) });
             unreachable!()
         }
     }
@@ -1680,5 +1572,11 @@ mod tests {
     #[should_panic]
     fn unsqueeze_dim_same_rank() {
         check!(TensorCheck::unsqueeze_dim::<3, 3>(2));
+    }
+
+    #[test]
+    #[should_panic(expected = "Operation: 'Select'")]
+    fn unwrap_dim_index_uses_operation_origin() {
+        unwrap_dim_index(Err("dimension -3 out of bounds: 0..2"), "Select");
     }
 }

--- a/crates/burn-tensor/src/tensor/api/float.rs
+++ b/crates/burn-tensor/src/tensor/api/float.rs
@@ -152,7 +152,7 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     ///
     /// Negative dimensions are supported and count from the end.
     pub fn var<I: AsIndex>(self, dim: I) -> Self {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Var");
         stats::var(self, dim)
     }
 
@@ -160,7 +160,7 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     ///
     /// Negative dimensions are supported and count from the end.
     pub fn var_bias<I: AsIndex>(self, dim: I) -> Self {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Var Bias");
         stats::var_bias(self, dim)
     }
 
@@ -168,7 +168,7 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     ///
     /// Negative dimensions are supported and count from the end.
     pub fn var_mean<I: AsIndex>(self, dim: I) -> (Self, Self) {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Var Mean");
         let mean = self.clone().mean_dim(dim);
         let var = stats::var_with_mean(self, mean.clone(), dim);
         (var, mean)
@@ -178,7 +178,7 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     ///
     /// Negative dimensions are supported and count from the end.
     pub fn var_mean_bias<I: AsIndex>(self, dim: I) -> (Self, Self) {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Var Mean Bias");
         let mean = self.clone().mean_dim(dim);
         let var = stats::var_with_mean_bias(self, mean.clone(), dim);
         (var, mean)
@@ -239,7 +239,7 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     /// // Result: [4.0]
     /// ```
     pub fn median<I: AsIndex>(self, dim: I) -> Self {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Median");
         // TODO: Allow backend specialization. Optimally, implement a median kernel for cubecl
         // instead of leveraging a full sort to get the median.
         stats::median(self, dim)
@@ -284,7 +284,7 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     /// // values: [[2.0], [6.0]], indices: [[3], [2]] (position in the original tensor)
     /// ```
     pub fn median_with_indices<I: AsIndex>(self, dim: I) -> (Self, Tensor<D, Int>) {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Median With Indices");
         // TODO: Allow backend specialization. Optimally, implement a median kernel for cubecl
         // instead of leveraging a full sort to get the median.
         stats::median_with_indices(self, dim)
@@ -360,7 +360,7 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     ///   Negative dimensions are supported and count from the end.
     /// * `correction_factor` - Is usually 1 for samples and 0 for population.
     pub fn cov<I: AsIndex>(self, dim: I, correction_factor: usize) -> Tensor<D> {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Cov");
         let n = self.dims()[dim];
         let centered = (self.clone() - self.mean_dim(dim)).swap_dims(dim, 0);
         centered
@@ -673,7 +673,7 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     ///
     /// A tensor containing the cross product of `self` and `other` along `dim`.
     pub fn cross<Dim: AsIndex>(self, other: Tensor<D>, dim: Dim) -> Tensor<D> {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Cross");
         check!(TensorCheck::cross(&self, &other, dim));
         Tensor::new(cross_impl(self.primitive, other.primitive, dim))
     }

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -371,8 +371,7 @@ where
     /// }
     /// ```
     pub fn mean_dim<I: AsIndex>(self, dim: I) -> Self {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
-        check!(TensorCheck::aggregate_dim::<D>("Mean", dim));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Mean Dim");
         Self::new(K::mean_dim(self.primitive, dim))
     }
 
@@ -430,8 +429,7 @@ where
     /// }
     /// ```
     pub fn sum_dim<I: AsIndex>(self, dim: I) -> Self {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
-        check!(TensorCheck::aggregate_dim::<D>("Sum", dim));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Sum Dim");
         Self::new(K::sum_dim(self.primitive, dim))
     }
 
@@ -546,8 +544,7 @@ where
     /// }
     /// ```
     pub fn prod_dim<I: AsIndex>(self, dim: I) -> Self {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
-        check!(TensorCheck::aggregate_dim::<D>("Prod", dim));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Prod Dim");
         Self::new(K::prod_dim(self.primitive, dim))
     }
 
@@ -604,8 +601,7 @@ where
     /// }
     /// ```
     pub fn cumsum<I: AsIndex>(self, dim: I) -> Self {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
-        check!(TensorCheck::aggregate_dim::<D>("CumSum", dim));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Cumsum");
         Self::new(K::cumsum(self.primitive, dim))
     }
 
@@ -633,8 +629,7 @@ where
     /// }
     /// ```
     pub fn cumprod<I: AsIndex>(self, dim: I) -> Self {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
-        check!(TensorCheck::aggregate_dim::<D>("CumProd", dim));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Cumprod");
         Self::new(K::cumprod(self.primitive, dim))
     }
 

--- a/crates/burn-tensor/src/tensor/api/orderable.rs
+++ b/crates/burn-tensor/src/tensor/api/orderable.rs
@@ -40,8 +40,7 @@ where
     /// }
     /// ```
     pub fn sort<I: AsIndex>(self, dim: I) -> Self {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
-        check!(TensorCheck::sort_dim::<D>("Sort", dim));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Sort");
         Tensor::new(K::sort(self.primitive, dim, /*descending*/ false))
     }
 
@@ -75,8 +74,7 @@ where
     /// }
     /// ```
     pub fn sort_descending<I: AsIndex>(self, dim: I) -> Self {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
-        check!(TensorCheck::sort_dim::<D>("Sort", dim));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Sort Descending");
         Tensor::new(K::sort(self.primitive, dim, /*descending*/ true))
     }
 
@@ -110,8 +108,7 @@ where
     /// }
     /// ```
     pub fn sort_with_indices<I: AsIndex>(self, dim: I) -> (Self, Tensor<D, Int>) {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
-        check!(TensorCheck::sort_dim::<D>("Sort_with_indices", dim));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Sort With Indices");
         let (values, indices) =
             K::sort_with_indices(self.primitive, dim, /*descending*/ false);
         (Tensor::new(values), Tensor::new(indices))
@@ -143,8 +140,7 @@ where
     /// }
     /// ```
     pub fn sort_descending_with_indices<I: AsIndex>(self, dim: I) -> (Self, Tensor<D, Int>) {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
-        check!(TensorCheck::sort_dim::<D>("Sort_with_indices", dim));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Sort Descending With Indices");
         let (values, indices) = K::sort_with_indices(self.primitive, dim, /*descending*/ true);
         (Tensor::new(values), Tensor::new(indices))
     }
@@ -172,8 +168,7 @@ where
     /// }
     /// ```
     pub fn argsort<I: AsIndex>(self, dim: I) -> Tensor<D, Int> {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
-        check!(TensorCheck::sort_dim::<D>("Argsort", dim));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Argsort");
         Tensor::new(K::argsort(self.primitive, dim, /*descending*/ false))
     }
 
@@ -203,8 +198,7 @@ where
     /// }
     /// ```
     pub fn argsort_descending<I: AsIndex>(self, dim: I) -> Tensor<D, Int> {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
-        check!(TensorCheck::sort_dim::<D>("Argsort", dim));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Argsort Descending");
         Tensor::new(K::argsort(self.primitive, dim, /*descending*/ true))
     }
 
@@ -237,7 +231,7 @@ where
     /// }
     /// ```
     pub fn topk<I: AsIndex>(self, k: usize, dim: I) -> Self {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Top K");
         assert!(self.shape()[dim] > k);
         Tensor::new(K::topk(self.primitive, dim, k))
     }
@@ -272,7 +266,7 @@ where
     /// }
     /// ```
     pub fn topk_with_indices<I: AsIndex>(self, k: usize, dim: I) -> (Self, Tensor<D, Int>) {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Top K With Indices");
         let (values, indices) = K::topk_with_indices(self.primitive, dim, k);
         (Tensor::new(values), Tensor::new(indices))
     }
@@ -334,7 +328,7 @@ where
         axis: impl AsIndex,
     ) -> Tensor<D2, K> {
         check!(TensorCheck::one_hot_tensor_rank::<D, D2>());
-        let axis = unwrap_dim_index(axis.try_dim_index(D + 1));
+        let axis = unwrap_dim_index(axis.try_dim_index(D + 1), "One Hot");
 
         // Initialize shape from the current tensor dimensions and prepare for modification
         let mut shape = self.shape();
@@ -605,7 +599,7 @@ where
     /// }
     /// ```
     pub fn argmax(self, dim: impl AsIndex) -> Tensor<D, Int> {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Argmax");
         Tensor::new(K::argmax(self.primitive, dim))
     }
 
@@ -630,7 +624,7 @@ where
     /// }
     /// ```
     pub fn argtopk(self, k: usize, dim: impl AsIndex) -> Tensor<D, Int> {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Argtopk");
         assert!(self.shape()[dim] > k);
         Tensor::new(K::argtopk(self.primitive, dim, k))
     }
@@ -674,8 +668,7 @@ where
     /// }
     /// ```
     pub fn max_dim_with_indices<I: AsIndex>(self, dim: I) -> (Self, Tensor<D, Int>) {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
-        check!(TensorCheck::aggregate_dim::<D>("Max", dim));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Max Dim With Indices");
 
         let (tensor, index) = K::max_dim_with_indices(self.primitive, dim);
 
@@ -760,8 +753,7 @@ where
     /// }
     /// ```
     pub fn max_abs_dim<I: AsIndex>(self, dim: I) -> Self {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
-        check!(TensorCheck::aggregate_dim::<D>("MaxAbs", dim));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Max Abs Dim");
 
         Tensor::new(K::max_abs_dim(self.primitive, dim))
     }
@@ -817,7 +809,7 @@ where
     /// }
     /// ```
     pub fn argmin(self, dim: impl AsIndex) -> Tensor<D, Int> {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Argmin");
         Tensor::new(K::argmin(self.primitive, dim))
     }
 
@@ -866,8 +858,7 @@ where
     /// }
     /// ```
     pub fn min_dim<I: AsIndex>(self, dim: I) -> Self {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
-        check!(TensorCheck::aggregate_dim::<D>("Min", dim));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Min Dim");
         Tensor::new(K::min_dim(self.primitive, dim))
     }
 
@@ -920,8 +911,7 @@ where
     /// }
     /// ```
     pub fn min_dim_with_indices<I: AsIndex>(self, dim: I) -> (Self, Tensor<D, Int>) {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
-        check!(TensorCheck::aggregate_dim::<D>("Min", dim));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Min Dim With Indices");
 
         let (tensor, index) = K::min_dim_with_indices(self.primitive, dim);
 
@@ -1085,8 +1075,7 @@ where
     /// }
     /// ```
     pub fn cummin<I: AsIndex>(self, dim: I) -> Self {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
-        check!(TensorCheck::aggregate_dim::<D>("CumMin", dim));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Cummin");
         Self::new(K::cummin(self.primitive, dim))
     }
 
@@ -1114,8 +1103,7 @@ where
     /// }
     /// ```
     pub fn cummax<I: AsIndex>(self, dim: I) -> Self {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
-        check!(TensorCheck::aggregate_dim::<D>("CumMax", dim));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Cummax");
         Self::new(K::cummax(self.primitive, dim))
     }
     /// Find the maximum value along the given dimension.
@@ -1144,8 +1132,7 @@ where
     /// }
     /// ```
     pub fn max_dim<I: AsIndex>(self, dim: I) -> Self {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
-        check!(TensorCheck::aggregate_dim::<D>("Max", dim));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Max Dim");
         Tensor::new(K::max_dim(self.primitive, dim))
     }
 

--- a/crates/burn-tensor/src/tensor/api/take.rs
+++ b/crates/burn-tensor/src/tensor/api/take.rs
@@ -45,8 +45,8 @@ where
         dim: impl AsIndex,
         indices: Tensor<DI, Int>,
     ) -> Tensor<DO, K> {
-        let dim = unwrap_dim_index(dim.try_dim_index(D));
-        check!(TensorCheck::take::<D, DI, DO>(dim));
+        let dim = unwrap_dim_index(dim.try_dim_index(D), "Take");
+        check!(TensorCheck::take::<D, DI, DO>());
 
         // Store the indices shape for reshaping later
         let indices_shape = indices.shape();

--- a/crates/burn-tensor/src/tensor/linalg/cosine_similarity.rs
+++ b/crates/burn-tensor/src/tensor/linalg/cosine_similarity.rs
@@ -26,7 +26,7 @@ pub fn cosine_similarity<const D: usize>(
     dim: impl AsIndex,
     eps: Option<f64>,
 ) -> Tensor<D> {
-    let dim = unwrap_dim_index(dim.try_dim_index(D));
+    let dim = unwrap_dim_index(dim.try_dim_index(D), "Cosine Similarity");
     let eps = eps.unwrap_or_else(|| {
         x1.dtype()
             .finfo()

--- a/crates/burn-tensor/src/tensor/linalg/outer.rs
+++ b/crates/burn-tensor/src/tensor/linalg/outer.rs
@@ -63,7 +63,7 @@ where
         "`outer` with D={D} expects R={} (got R={R})",
         D + 1
     );
-    let dim = unwrap_dim_index(dim.try_dim_index(D));
+    let dim = unwrap_dim_index(dim.try_dim_index(D), "Outer");
 
     // (..., i, 1, ...)
     let x = lhs.unsqueeze_dim::<R>(dim + 1);

--- a/crates/burn-tensor/src/tensor/linalg/vector_norm.rs
+++ b/crates/burn-tensor/src/tensor/linalg/vector_norm.rs
@@ -121,7 +121,7 @@ pub fn vector_norm<const D: usize>(
     norm: impl Into<Norm>,
     dim: impl AsIndex,
 ) -> Tensor<D> {
-    let dim = unwrap_dim_index(dim.try_dim_index(D));
+    let dim = unwrap_dim_index(dim.try_dim_index(D), "Vector Norm");
     lp_norm_impl(x, norm.into().to_exponent(), dim)
 }
 
@@ -146,7 +146,7 @@ pub fn vector_norm<const D: usize>(
 ///
 /// The ``L(p)`` norm of the input tensor.
 pub fn lp_norm<const D: usize>(x: Tensor<D>, p: f64, dim: impl AsIndex) -> Tensor<D> {
-    let dim = unwrap_dim_index(dim.try_dim_index(D));
+    let dim = unwrap_dim_index(dim.try_dim_index(D), "Lp Norm");
     lp_norm_impl(x, p, dim)
 }
 
@@ -183,7 +183,7 @@ pub fn vector_normalize<const D: usize, E: ElementConversion>(
     dim: impl AsIndex,
     eps: E,
 ) -> Tensor<D> {
-    let dim = unwrap_dim_index(dim.try_dim_index(D));
+    let dim = unwrap_dim_index(dim.try_dim_index(D), "Vector Normalize");
     let norm = lp_norm_impl(x.clone(), norm.into().to_exponent(), dim).clamp_min(eps);
     x / norm
 }
@@ -203,7 +203,7 @@ pub fn l0_norm<const D: usize, K>(x: Tensor<D, K>, dim: impl AsIndex) -> Tensor<
 where
     K: Numeric,
 {
-    let dim = unwrap_dim_index(dim.try_dim_index(D));
+    let dim = unwrap_dim_index(dim.try_dim_index(D), "L0 Norm");
     l0_norm_impl(x, dim)
 }
 
@@ -233,7 +233,7 @@ pub fn l1_norm<const D: usize, K>(x: Tensor<D, K>, dim: impl AsIndex) -> Tensor<
 where
     K: Numeric,
 {
-    let dim = unwrap_dim_index(dim.try_dim_index(D));
+    let dim = unwrap_dim_index(dim.try_dim_index(D), "L1 Norm");
     l1_norm_impl(x, dim)
 }
 
@@ -256,7 +256,7 @@ where
 ///
 /// The L2 norm of the input tensor.
 pub fn l2_norm<const D: usize>(x: Tensor<D>, dim: impl AsIndex) -> Tensor<D> {
-    let dim = unwrap_dim_index(dim.try_dim_index(D));
+    let dim = unwrap_dim_index(dim.try_dim_index(D), "L2 Norm");
     l2_norm_impl(x, dim)
 }
 
@@ -300,7 +300,7 @@ pub fn max_abs_norm<const D: usize, K>(x: Tensor<D, K>, dim: impl AsIndex) -> Te
 where
     K: Ordered,
 {
-    let dim = unwrap_dim_index(dim.try_dim_index(D));
+    let dim = unwrap_dim_index(dim.try_dim_index(D), "Max Abs Norm");
     max_abs_norm_impl(x, dim)
 }
 
@@ -326,7 +326,7 @@ pub fn min_abs_norm<const D: usize, K>(x: Tensor<D, K>, dim: impl AsIndex) -> Te
 where
     K: Ordered,
 {
-    let dim = unwrap_dim_index(dim.try_dim_index(D));
+    let dim = unwrap_dim_index(dim.try_dim_index(D), "Min Abs Norm");
     min_abs_norm_impl(x, dim)
 }
 

--- a/crates/burn-tensor/src/tensor/signal/fft.rs
+++ b/crates/burn-tensor/src/tensor/signal/fft.rs
@@ -59,7 +59,7 @@ pub fn rfft<const D: usize>(
     dim: impl AsIndex,
     n: Option<usize>,
 ) -> (Tensor<D>, Tensor<D>) {
-    let dim = unwrap_dim_index(dim.try_dim_index(D));
+    let dim = unwrap_dim_index(dim.try_dim_index(D), "RFFT");
 
     match n {
         None => check!(TensorCheck::check_is_power_of_two::<D>(
@@ -135,7 +135,7 @@ pub fn irfft<const D: usize>(
     dim: impl AsIndex,
     n: Option<usize>,
 ) -> Tensor<D> {
-    let dim = unwrap_dim_index(dim.try_dim_index(D));
+    let dim = unwrap_dim_index(dim.try_dim_index(D), "IRFFT");
 
     if let Some(n) = n {
         assert!(n >= 1, "irfft: n must be >= 1, got {n}");
@@ -231,7 +231,7 @@ pub fn cfft<const D: usize>(
         signal_im.shape(),
     );
 
-    let dim = unwrap_dim_index(dim.try_dim_index(D));
+    let dim = unwrap_dim_index(dim.try_dim_index(D), "CFFT");
     let fft_size = n.unwrap_or(signal_re.dims()[dim]);
 
     // rfft validates power-of-two and n constraints internally


### PR DESCRIPTION
## Motivation
The Tensor API now normalizes dimension arguments through `AsIndex` before reaching backend calls. Several `TensorCheck` helpers repeated the same bounds validation immediately after `try_dim_index`, which makes dimension validation ownership less clear and leaves dead validators after `burn-nn` delegates into Tensor APIs.

This cleanup keeps the remaining shape and rank validation in `TensorCheck`, while relying on `AsIndex` and `unwrap_dim_index` for dimension bounds.

## Modifications
- Removed redundant dimension bounds checks after `try_dim_index` in aggregation, sorting, selection, stacking, concatenation, gather/scatter, cross, and take paths.
- Deleted no-longer-used `TensorCheck` helpers for duplicate dimension validation.
- Kept validators that still check output rank, empty inputs, and shape compatibility.
