### PR TITLE
feat(tensor): support assign indexing updates for floats and ints

### DIFF
--- a/crates/burn-autodiff/src/ops/int_tensor.rs
+++ b/crates/burn-autodiff/src/ops/int_tensor.rs
@@ -223,6 +223,16 @@ impl<B: Backend, C: CheckpointStrategy> IntTensorOps<Self> for Autodiff<B, C> {
         B::int_scatter_add(dim, tensor, indices, value)
     }
 
+    fn int_scatter(
+        dim: usize,
+        tensor: IntTensor<B>,
+        indices: IntTensor<B>,
+        value: IntTensor<B>,
+        update: IndexingUpdateOp,
+    ) -> IntTensor<B> {
+        B::int_scatter(dim, tensor, indices, value, update)
+    }
+
     fn int_scatter_nd(
         data: IntTensor<B>,
         indices: IntTensor<B>,
@@ -243,6 +253,16 @@ impl<B: Backend, C: CheckpointStrategy> IntTensorOps<Self> for Autodiff<B, C> {
         value: IntTensor<B>,
     ) -> IntTensor<B> {
         B::int_select_add(tensor, dim, indices, value)
+    }
+
+    fn int_select_assign(
+        tensor: IntTensor<B>,
+        dim: usize,
+        indices: IntTensor<B>,
+        value: IntTensor<B>,
+        update: IndexingUpdateOp,
+    ) -> IntTensor<B> {
+        B::int_select_assign(tensor, dim, indices, value, update)
     }
 
     fn int_mask_where(

--- a/crates/burn-autodiff/src/ops/tensor.rs
+++ b/crates/burn-autodiff/src/ops/tensor.rs
@@ -25,7 +25,7 @@ use burn_backend::{
     tensor::{BoolTensor, Device, FloatTensor, IntTensor},
 };
 use burn_backend::{Scalar, ops::unfold::calculate_unfold_windows};
-use burn_std::{BoolDType, FloatDType, IntDType, Shape, Slice};
+use burn_std::{BoolDType, FloatDType, IndexingUpdateOp, IntDType, Shape, Slice};
 
 use burn_backend::distributed::DistributedParams;
 
@@ -1049,6 +1049,83 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
         }
     }
 
+    fn float_scatter(
+        dim: usize,
+        tensor: FloatTensor<Self>,
+        indices: IntTensor<B>,
+        value: FloatTensor<Self>,
+        update: IndexingUpdateOp,
+    ) -> FloatTensor<Self> {
+        match update {
+            IndexingUpdateOp::Add => Self::float_scatter_add(dim, tensor, indices, value),
+            IndexingUpdateOp::Assign => {
+                #[derive(Debug)]
+                struct ScatterAssign;
+
+                impl<B: Backend> Backward<B, 2> for ScatterAssign {
+                    type State = (usize, IntTensor<B>, Shape, B::Device);
+
+                    fn backward(
+                        self,
+                        ops: Ops<Self::State, 2>,
+                        grads: &mut Gradients,
+                        _checkpointer: &mut Checkpointer,
+                    ) {
+                        let (dim, indices, value_shape, device) = ops.state;
+                        let [indices_4lhs, indices_4rhs] = duplicate(&ops.parents, Some(indices));
+
+                        binary::<B, _, _>(
+                            ops.parents,
+                            ops.node,
+                            grads,
+                            |grad| {
+                                let zeros =
+                                    B::float_zeros(value_shape, &device, grad.dtype().into());
+                                B::float_scatter(
+                                    dim,
+                                    grad,
+                                    indices_4lhs.unwrap(),
+                                    zeros,
+                                    IndexingUpdateOp::Assign,
+                                )
+                            },
+                            |grad| B::float_gather(dim, grad, indices_4rhs.unwrap()),
+                        );
+                    }
+                }
+
+                match ScatterAssign
+                    .prepare::<C>([tensor.node, value.node])
+                    .compute_bound()
+                    .stateful()
+                {
+                    OpsKind::Tracked(prep) => {
+                        let value_shape = value.primitive.shape();
+                        let device = tensor.primitive.device();
+                        prep.finish(
+                            (dim, indices.clone(), value_shape, device),
+                            B::float_scatter(
+                                dim,
+                                tensor.primitive,
+                                indices,
+                                value.primitive,
+                                IndexingUpdateOp::Assign,
+                            ),
+                        )
+                    }
+                    OpsKind::UnTracked(prep) => prep.finish(B::float_scatter(
+                        dim,
+                        tensor.primitive,
+                        indices,
+                        value.primitive,
+                        IndexingUpdateOp::Assign,
+                    )),
+                }
+            }
+            other => unimplemented!("float_scatter with {other:?} update is not implemented"),
+        }
+    }
+
     fn float_scatter_nd(
         data: FloatTensor<Self>,
         indices: IntTensor<B>,
@@ -1527,6 +1604,115 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                 indices,
                 value.primitive,
             )),
+        }
+    }
+
+    fn float_select_assign(
+        tensor: FloatTensor<Self>,
+        dim: usize,
+        indices: IntTensor<B>,
+        value: FloatTensor<Self>,
+        update: IndexingUpdateOp,
+    ) -> FloatTensor<Self> {
+        match update {
+            IndexingUpdateOp::Add => Self::float_select_add(tensor, dim, indices, value),
+            IndexingUpdateOp::Assign => {
+                #[derive(Debug)]
+                struct IndexSelectDimAssignReplace;
+
+                #[derive(new, Debug)]
+                struct RetroSelectAssignReplace<B: Backend> {
+                    tensor_id: NodeId,
+                    dim: usize,
+                    indices: IntTensor<B>,
+                    value_id: NodeId,
+                }
+
+                impl<B: Backend> RetroForward for RetroSelectAssignReplace<B> {
+                    fn forward(&self, states: &mut BackwardStates, out_node: NodeId) {
+                        let tensor = states.get_state::<B::FloatTensorPrimitive>(&self.tensor_id);
+                        let value = states.get_state::<B::FloatTensorPrimitive>(&self.value_id);
+                        let out = B::float_select_assign(
+                            tensor,
+                            self.dim,
+                            self.indices.clone(),
+                            value,
+                            IndexingUpdateOp::Assign,
+                        );
+                        states.save(out_node, out)
+                    }
+                }
+
+                impl<B: Backend> Backward<B, 2> for IndexSelectDimAssignReplace {
+                    type State = (usize, IntTensor<B>, Shape, B::Device);
+
+                    fn backward(
+                        self,
+                        ops: Ops<Self::State, 2>,
+                        grads: &mut Gradients,
+                        _checkpointer: &mut Checkpointer,
+                    ) {
+                        let (dim, indices, value_shape, device) = ops.state;
+                        let [indices_4lhs, indices_4rhs] = duplicate(&ops.parents, Some(indices));
+
+                        binary::<B, _, _>(
+                            ops.parents,
+                            ops.node,
+                            grads,
+                            |grad| {
+                                let zeros =
+                                    B::float_zeros(value_shape, &device, grad.dtype().into());
+                                B::float_select_assign(
+                                    grad,
+                                    dim,
+                                    indices_4lhs.unwrap(),
+                                    zeros,
+                                    IndexingUpdateOp::Assign,
+                                )
+                            },
+                            |grad| B::float_select(grad, dim, indices_4rhs.unwrap()),
+                        );
+                    }
+                }
+
+                match IndexSelectDimAssignReplace
+                    .prepare::<C>([tensor.node.clone(), value.node.clone()])
+                    .memory_bound()
+                    .retro_forward(RetroSelectAssignReplace::<B>::new(
+                        tensor.node.id,
+                        dim,
+                        indices.clone(),
+                        value.node.id,
+                    ))
+                    .parents([&tensor, &value])
+                    .stateful()
+                {
+                    OpsKind::Tracked(prep) => {
+                        let value_shape = value.primitive.shape();
+                        let device = tensor.primitive.device();
+                        prep.finish(
+                            (dim, indices.clone(), value_shape, device),
+                            B::float_select_assign(
+                                tensor.primitive,
+                                dim,
+                                indices,
+                                value.primitive,
+                                IndexingUpdateOp::Assign,
+                            ),
+                        )
+                    }
+                    OpsKind::UnTracked(prep) => prep.finish(B::float_select_assign(
+                        tensor.primitive,
+                        dim,
+                        indices,
+                        value.primitive,
+                        IndexingUpdateOp::Assign,
+                    )),
+                }
+            }
+            other => {
+                unimplemented!("float_select_assign with {other:?} update is not implemented")
+            }
         }
     }
 

--- a/crates/burn-backend-tests/tests/autodiff/gather_scatter.rs
+++ b/crates/burn-backend-tests/tests/autodiff/gather_scatter.rs
@@ -63,6 +63,41 @@ fn test_scatter_grad() {
         .assert_eq(&TensorData::from([[19., 19., 19.], [64., 64., 64.]]), false);
 }
 
+#[cfg(feature = "ndarray")]
+#[test]
+fn test_scatter_assign_grad() {
+    let device = AutodiffDevice::new();
+    let tensor = TestTensor::from_data(
+        TensorData::from([[0.0, 1.0, 2.0, 3.0], [4.0, 5.0, 6.0, 7.0]]),
+        &device,
+    )
+    .require_grad();
+    let values = TestTensor::from_data(TensorData::from([[10.0, 20.0], [30.0, 40.0]]), &device)
+        .require_grad();
+    let indices = TestTensorInt::<2>::from_data(TensorData::from([[2, 0], [3, 1]]), &device);
+
+    let result = tensor
+        .clone()
+        .scatter(1, indices, values.clone(), IndexingUpdateOp::Assign);
+
+    result.clone().into_data().assert_eq(
+        &TensorData::from([[20.0, 1.0, 10.0, 3.0], [4.0, 40.0, 6.0, 30.0]]),
+        false,
+    );
+
+    let grads = result.sum().backward();
+    let grad_tensor = tensor.grad(&grads).unwrap();
+    let grad_values = values.grad(&grads).unwrap();
+
+    grad_tensor.to_data().assert_eq(
+        &TensorData::from([[0., 1., 0., 1.], [1., 0., 1., 0.]]),
+        false,
+    );
+    grad_values
+        .to_data()
+        .assert_eq(&TensorData::from([[1., 1.], [1., 1.]]), false);
+}
+
 #[test]
 fn test_scatter_add_grad_partial_indices() {
     let device = AutodiffDevice::new();

--- a/crates/burn-backend-tests/tests/autodiff/select.rs
+++ b/crates/burn-backend-tests/tests/autodiff/select.rs
@@ -61,6 +61,41 @@ fn test_select_add_grad() {
         .assert_eq(&TensorData::from([[64., 64., 64.], [19., 19., 19.]]), false);
 }
 
+#[cfg(feature = "ndarray")]
+#[test]
+fn test_select_assign_grad() {
+    let device = AutodiffDevice::new();
+    let tensor = TestTensor::<2>::from_data(
+        TensorData::from([[0.0, 1.0, 2.0, 3.0], [4.0, 5.0, 6.0, 7.0]]),
+        &device,
+    )
+    .require_grad();
+    let values = TestTensor::from_data(TensorData::from([[10.0, 20.0], [30.0, 40.0]]), &device)
+        .require_grad();
+    let indices = TestTensorInt::<1>::from_data(TensorData::from([3, 1]), &device);
+
+    let result = tensor
+        .clone()
+        .select_assign(1, indices, values.clone(), IndexingUpdateOp::Assign);
+
+    result.clone().into_data().assert_eq(
+        &TensorData::from([[0.0, 20.0, 2.0, 10.0], [4.0, 40.0, 6.0, 30.0]]),
+        false,
+    );
+
+    let grads = result.sum().backward();
+    let grad_tensor = tensor.grad(&grads).unwrap();
+    let grad_values = values.grad(&grads).unwrap();
+
+    grad_tensor.into_data().assert_eq(
+        &TensorData::from([[1., 0., 1., 0.], [1., 0., 1., 0.]]),
+        false,
+    );
+    grad_values
+        .into_data()
+        .assert_eq(&TensorData::from([[1., 1.], [1., 1.]]), false);
+}
+
 #[test]
 fn test_select_add_grad_different_shapes() {
     let device = AutodiffDevice::new();

--- a/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter.rs
@@ -90,6 +90,21 @@ fn should_scatter_add_1d() {
         .assert_eq(&TensorData::from([4.0, 5.0, 3.0]), false);
 }
 
+#[cfg(feature = "ndarray")]
+#[test]
+fn should_scatter_assign_1d() {
+    let device = Default::default();
+    let tensor = TestTensor::<1>::from_data([10.0, 20.0, 30.0, 40.0], &device);
+    let values = TestTensor::from_data([7.0, 50.0], &device);
+    let indices = TestTensorInt::from_ints([1, 3], &device);
+
+    let output = tensor.scatter(0, indices, values, IndexingUpdateOp::Assign);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([10.0, 7.0, 30.0, 50.0]), false);
+}
+
 #[test]
 fn should_scatter_add_2d_dim0() {
     let device = Default::default();

--- a/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter.rs
@@ -105,6 +105,21 @@ fn should_scatter_assign_1d() {
         .assert_eq(&TensorData::from([10.0, 7.0, 30.0, 50.0]), false);
 }
 
+#[cfg(feature = "ndarray")]
+#[test]
+fn should_scatter_assign_2d_dim0() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::from_data([[10.0, 20.0, 30.0], [40.0, 50.0, 60.0]], &device);
+    let values = TestTensor::from_data([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], &device);
+    let indices = TestTensorInt::from_ints([[1, 0, 1], [0, 1, 0]], &device);
+
+    let output = tensor.scatter(0, indices, values, IndexingUpdateOp::Assign);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([[4.0, 2.0, 6.0], [1.0, 5.0, 3.0]]), false);
+}
+
 #[test]
 fn should_scatter_add_2d_dim0() {
     let device = Default::default();

--- a/crates/burn-backend-tests/tests/tensor/float/ops/select.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/select.rs
@@ -94,6 +94,20 @@ fn should_select_assign_2d_dim0() {
     output.into_data().assert_eq(&expected, false);
 }
 
+#[cfg(feature = "ndarray")]
+#[test]
+fn should_select_assign_2d_dim1() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::from_data([[10.0, 20.0, 30.0], [40.0, 50.0, 60.0]], &device);
+    let values = TestTensor::from_data([[7.0, 8.0], [9.0, 10.0]], &device);
+    let indices = TestTensorInt::from_data(TensorData::from([2, 0]), &device);
+
+    let output = tensor.select_assign(1, indices, values, IndexingUpdateOp::Assign);
+    let expected = TensorData::from([[8.0, 20.0, 7.0], [10.0, 50.0, 9.0]]);
+
+    output.into_data().assert_eq(&expected, false);
+}
+
 #[test]
 fn should_select_add_1d_int() {
     let device = Default::default();

--- a/crates/burn-backend-tests/tests/tensor/float/ops/select.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/select.rs
@@ -80,6 +80,20 @@ fn should_select_add_1d() {
     output.into_data().assert_eq(&expected, false);
 }
 
+#[cfg(feature = "ndarray")]
+#[test]
+fn should_select_assign_2d_dim0() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::from_data([[10.0, 20.0], [30.0, 40.0], [50.0, 60.0]], &device);
+    let values = TestTensor::from_data([[5.0, 70.0], [80.0, 1.0]], &device);
+    let indices = TestTensorInt::from_data(TensorData::from([2, 0]), &device);
+
+    let output = tensor.select_assign(0, indices, values, IndexingUpdateOp::Assign);
+    let expected = TensorData::from([[80.0, 1.0], [30.0, 40.0], [5.0, 70.0]]);
+
+    output.into_data().assert_eq(&expected, false);
+}
+
 #[test]
 fn should_select_add_1d_int() {
     let device = Default::default();

--- a/crates/burn-backend-tests/tests/tensor/int/ops/gather_scatter.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/gather_scatter.rs
@@ -67,3 +67,18 @@ fn should_scatter_add_1d_int() {
         .into_data()
         .assert_eq(&TensorData::from([4, 5, 3]), false);
 }
+
+#[cfg(feature = "ndarray")]
+#[test]
+fn should_scatter_assign_1d_int() {
+    let device = Default::default();
+    let tensor = TestTensorInt::<1>::from_ints([10, 20, 30, 40], &device);
+    let values = TestTensorInt::from_ints([7, 50], &device);
+    let indices = TestTensorInt::from_ints([1, 3], &device);
+
+    let output = tensor.scatter(0, indices, values, IndexingUpdateOp::Assign);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([10, 7, 30, 50]), false);
+}

--- a/crates/burn-backend-tests/tests/tensor/int/ops/gather_scatter.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/gather_scatter.rs
@@ -82,3 +82,18 @@ fn should_scatter_assign_1d_int() {
         .into_data()
         .assert_eq(&TensorData::from([10, 7, 30, 50]), false);
 }
+
+#[cfg(feature = "ndarray")]
+#[test]
+fn should_scatter_assign_2d_dim0_int() {
+    let device = Default::default();
+    let tensor = TestTensorInt::<2>::from_ints([[10, 20, 30], [40, 50, 60]], &device);
+    let values = TestTensorInt::from_ints([[1, 2, 3], [4, 5, 6]], &device);
+    let indices = TestTensorInt::from_ints([[1, 0, 1], [0, 1, 0]], &device);
+
+    let output = tensor.scatter(0, indices, values, IndexingUpdateOp::Assign);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([[4, 2, 6], [1, 5, 3]]), false);
+}

--- a/crates/burn-backend-tests/tests/tensor/int/ops/select.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/select.rs
@@ -40,6 +40,20 @@ fn should_select_assign_2d_dim0_int() {
     output.into_data().assert_eq(&expected, false);
 }
 
+#[cfg(feature = "ndarray")]
+#[test]
+fn should_select_assign_2d_dim1_int() {
+    let device = Default::default();
+    let tensor = TestTensorInt::<2>::from_data([[10, 20, 30], [40, 50, 60]], &device);
+    let values = TestTensorInt::from_data([[7, 8], [9, 10]], &device);
+    let indices = TestTensorInt::from_data(TensorData::from([2, 0]), &device);
+
+    let output = tensor.select_assign(1, indices, values, IndexingUpdateOp::Assign);
+    let expected = TensorData::from([[8, 20, 7], [10, 50, 9]]);
+
+    output.into_data().assert_eq(&expected, false);
+}
+
 #[test]
 #[should_panic]
 fn should_panic_select_add_invalid_num_indices() {

--- a/crates/burn-backend-tests/tests/tensor/int/ops/select.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/select.rs
@@ -26,6 +26,20 @@ fn should_select_add_1d_int() {
     output.into_data().assert_eq(&expected, false);
 }
 
+#[cfg(feature = "ndarray")]
+#[test]
+fn should_select_assign_2d_dim0_int() {
+    let device = Default::default();
+    let tensor = TestTensorInt::<2>::from_data([[10, 20], [30, 40], [50, 60]], &device);
+    let values = TestTensorInt::from_data([[5, 70], [80, 1]], &device);
+    let indices = TestTensorInt::from_data(TensorData::from([2, 0]), &device);
+
+    let output = tensor.select_assign(0, indices, values, IndexingUpdateOp::Assign);
+    let expected = TensorData::from([[80, 1], [30, 40], [5, 70]]);
+
+    output.into_data().assert_eq(&expected, false);
+}
+
 #[test]
 #[should_panic]
 fn should_panic_select_add_invalid_num_indices() {

--- a/crates/burn-backend/src/backend/ops/int_tensor.rs
+++ b/crates/burn-backend/src/backend/ops/int_tensor.rs
@@ -6,7 +6,7 @@ use crate::{Backend, Distribution, TensorData, TensorMetadata};
 use crate::{ExecutionError, Scalar, get_device_settings};
 use alloc::vec::Vec;
 use burn_std::reader::try_read_sync;
-use burn_std::{BoolDType, FloatDType, IntDType, Shape, Slice};
+use burn_std::{BoolDType, FloatDType, IndexingUpdateOp, IntDType, Shape, Slice};
 use core::ops::Range;
 
 /// Int Tensor API for basic and numeric operations, see
@@ -177,6 +177,22 @@ pub trait IntTensorOps<B: Backend> {
         value: IntTensor<B>,
     ) -> IntTensor<B>;
 
+    /// Scatter elements into a tensor using the specified update operation.
+    ///
+    /// Backend implementations may override this to support operations beyond add.
+    fn int_scatter(
+        dim: usize,
+        tensor: IntTensor<B>,
+        indices: IntTensor<B>,
+        value: IntTensor<B>,
+        update: IndexingUpdateOp,
+    ) -> IntTensor<B> {
+        match update {
+            IndexingUpdateOp::Add => Self::int_scatter_add(dim, tensor, indices, value),
+            other => unimplemented!("int_scatter with {other:?} update is not implemented"),
+        }
+    }
+
     /// Multi-dimensional scatter for int tensors.
     fn int_scatter_nd(
         _data: IntTensor<B>,
@@ -224,6 +240,22 @@ pub trait IntTensorOps<B: Backend> {
         indices: IntTensor<B>,
         value: IntTensor<B>,
     ) -> IntTensor<B>;
+
+    /// Assign selected elements along a dimension using the specified update operation.
+    ///
+    /// Backend implementations may override this to support operations beyond add.
+    fn int_select_assign(
+        tensor: IntTensor<B>,
+        dim: usize,
+        indices: IntTensor<B>,
+        value: IntTensor<B>,
+        update: IndexingUpdateOp,
+    ) -> IntTensor<B> {
+        match update {
+            IndexingUpdateOp::Add => Self::int_select_add(tensor, dim, indices, value),
+            other => unimplemented!("int_select_assign with {other:?} update is not implemented"),
+        }
+    }
 
     /// Repeats the tensor along the given dimension the given number of times.
     ///

--- a/crates/burn-backend/src/backend/ops/tensor.rs
+++ b/crates/burn-backend/src/backend/ops/tensor.rs
@@ -8,7 +8,7 @@ use crate::{Backend, Distribution, TensorData, get_device_settings};
 use crate::{ExecutionError, Scalar, TensorMetadata};
 use alloc::vec::Vec;
 use burn_std::reader::try_read_sync;
-use burn_std::{BoolDType, FloatDType, IntDType, Shape, Slice};
+use burn_std::{BoolDType, FloatDType, IndexingUpdateOp, IntDType, Shape, Slice};
 
 /// Operations on float tensors.
 pub trait FloatTensorOps<B: Backend> {
@@ -453,6 +453,22 @@ pub trait FloatTensorOps<B: Backend> {
         value: FloatTensor<B>,
     ) -> FloatTensor<B>;
 
+    /// Scatter elements into a tensor using the specified update operation.
+    ///
+    /// Backend implementations may override this to support operations beyond add.
+    fn float_scatter(
+        dim: usize,
+        tensor: FloatTensor<B>,
+        indices: IntTensor<B>,
+        value: FloatTensor<B>,
+        update: IndexingUpdateOp,
+    ) -> FloatTensor<B> {
+        match update {
+            IndexingUpdateOp::Add => Self::float_scatter_add(dim, tensor, indices, value),
+            other => unimplemented!("float_scatter with {other:?} update is not implemented"),
+        }
+    }
+
     /// Multi-dimensional scatter: update `data` at locations specified by `indices` with `values`.
     ///
     /// # Arguments
@@ -520,6 +536,24 @@ pub trait FloatTensorOps<B: Backend> {
         indices: IntTensor<B>,
         value: FloatTensor<B>,
     ) -> FloatTensor<B>;
+
+    /// Assign selected elements along a dimension using the specified update operation.
+    ///
+    /// Backend implementations may override this to support operations beyond add.
+    fn float_select_assign(
+        tensor: FloatTensor<B>,
+        dim: usize,
+        indices: IntTensor<B>,
+        value: FloatTensor<B>,
+        update: IndexingUpdateOp,
+    ) -> FloatTensor<B> {
+        match update {
+            IndexingUpdateOp::Add => Self::float_select_add(tensor, dim, indices, value),
+            other => {
+                unimplemented!("float_select_assign with {other:?} update is not implemented")
+            }
+        }
+    }
 
     /// Select tensor elements corresponding to the given slices.
     ///

--- a/crates/burn-dispatch/src/ops/int_tensor.rs
+++ b/crates/burn-dispatch/src/ops/int_tensor.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 use burn_backend::{
     BoolDType, ExecutionError, FloatDType, IntDType, Scalar, Shape, Slice, TensorData,
     ops::IntTensorOps,
-    tensor::{BoolTensor, FloatTensor, IntTensor},
+    tensor::{BoolTensor, FloatTensor, IndexingUpdateOp, IntTensor},
 };
 
 use crate::{Dispatch, DispatchDevice};
@@ -86,6 +86,19 @@ impl IntTensorOps<Self> for Dispatch {
         )
     }
 
+    fn int_scatter(
+        dim: usize,
+        tensor: IntTensor<Self>,
+        indices: IntTensor<Self>,
+        value: IntTensor<Self>,
+        update: IndexingUpdateOp,
+    ) -> IntTensor<Self> {
+        multi_op!(
+            inputs[(tensor, int), (indices, int), (value, int)], => Int,
+            B::int_scatter(dim, tensor, indices, value, update)
+        )
+    }
+
     fn int_scatter_nd(
         data: IntTensor<Self>,
         indices: IntTensor<Self>,
@@ -119,6 +132,19 @@ impl IntTensorOps<Self> for Dispatch {
         multi_op!(
             inputs[(tensor, int), (indices, int), (value, int)], => Int,
             B::int_select_add(tensor, dim, indices, value)
+        )
+    }
+
+    fn int_select_assign(
+        tensor: IntTensor<Self>,
+        dim: usize,
+        indices: IntTensor<Self>,
+        value: IntTensor<Self>,
+        update: IndexingUpdateOp,
+    ) -> IntTensor<Self> {
+        multi_op!(
+            inputs[(tensor, int), (indices, int), (value, int)], => Int,
+            B::int_select_assign(tensor, dim, indices, value, update)
         )
     }
 

--- a/crates/burn-dispatch/src/ops/tensor.rs
+++ b/crates/burn-dispatch/src/ops/tensor.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 use burn_backend::{
     BoolDType, ExecutionError, FloatDType, IntDType, Scalar, Shape, Slice, TensorData,
     ops::FloatTensorOps,
-    tensor::{BoolTensor, FloatTensor, IntTensor},
+    tensor::{BoolTensor, FloatTensor, IndexingUpdateOp, IntTensor},
 };
 
 use crate::{Dispatch, DispatchDevice};
@@ -157,6 +157,19 @@ impl FloatTensorOps<Self> for Dispatch {
         )
     }
 
+    fn float_scatter(
+        dim: usize,
+        tensor: FloatTensor<Self>,
+        indices: IntTensor<Self>,
+        value: FloatTensor<Self>,
+        update: IndexingUpdateOp,
+    ) -> FloatTensor<Self> {
+        multi_op!(
+            inputs[(tensor, float), (indices, int), (value, float)], => Float,
+            B::float_scatter(dim, tensor, indices, value, update)
+        )
+    }
+
     fn float_scatter_nd(
         data: FloatTensor<Self>,
         indices: IntTensor<Self>,
@@ -190,6 +203,19 @@ impl FloatTensorOps<Self> for Dispatch {
         multi_op!(
             inputs[(tensor, float), (indices, int), (value, float)], => Float,
             B::float_select_add(tensor, dim, indices, value)
+        )
+    }
+
+    fn float_select_assign(
+        tensor: FloatTensor<Self>,
+        dim: usize,
+        indices: IntTensor<Self>,
+        value: FloatTensor<Self>,
+        update: IndexingUpdateOp,
+    ) -> FloatTensor<Self> {
+        multi_op!(
+            inputs[(tensor, float), (indices, int), (value, float)], => Float,
+            B::float_select_assign(tensor, dim, indices, value, update)
         )
     }
 

--- a/crates/burn-fusion/src/ops/int_tensor.rs
+++ b/crates/burn-fusion/src/ops/int_tensor.rs
@@ -366,6 +366,53 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
             .output()
     }
 
+    fn int_scatter(
+        dim: usize,
+        tensor: IntTensor<Self>,
+        indices: IntTensor<Self>,
+        value: IntTensor<Self>,
+        update: IndexingUpdateOp,
+    ) -> IntTensor<Self> {
+        #[derive(new, Debug)]
+        struct ScatterOps<B: FusionBackend> {
+            desc: ScatterOpIr,
+            _b: PhantomData<B>,
+        }
+
+        impl<B: FusionBackend> Operation<B::FusionRuntime> for ScatterOps<B> {
+            fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
+                let tensor = handles.get_int_tensor::<B>(&self.desc.tensor);
+                let indices = handles.get_int_tensor::<B>(&self.desc.indices);
+                let value = handles.get_int_tensor::<B>(&self.desc.value);
+
+                let output =
+                    B::int_scatter(self.desc.dim, tensor, indices, value, self.desc.update);
+
+                handles.register_int_tensor::<B>(&self.desc.out.id, output);
+            }
+        }
+
+        let streams = StreamId::current();
+
+        let client = tensor.client.clone();
+        let desc = ScatterOpIr::create(
+            tensor.into_ir(),
+            dim,
+            indices.into_ir(),
+            value.into_ir(),
+            update,
+            || client.create_empty_handle(),
+        );
+
+        client
+            .register(
+                streams,
+                OperationIr::BaseInt(BaseOperationIr::Scatter(desc.clone())),
+                ScatterOps::<B>::new(desc),
+            )
+            .output()
+    }
+
     fn int_scatter_nd(
         data: IntTensor<Self>,
         indices: IntTensor<Self>,
@@ -514,6 +561,53 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
             indices.into_ir(),
             value.into_ir(),
             IndexingUpdateOp::Add,
+            || client.create_empty_handle(),
+        );
+
+        client
+            .register(
+                streams,
+                OperationIr::BaseInt(BaseOperationIr::SelectAssign(desc.clone())),
+                SelectAssignOps::<B>::new(desc),
+            )
+            .output()
+    }
+
+    fn int_select_assign(
+        tensor: IntTensor<Self>,
+        dim: usize,
+        indices: IntTensor<Self>,
+        value: IntTensor<Self>,
+        update: IndexingUpdateOp,
+    ) -> IntTensor<Self> {
+        #[derive(new, Debug)]
+        struct SelectAssignOps<B: FusionBackend> {
+            desc: SelectAssignOpIr,
+            _b: PhantomData<B>,
+        }
+
+        impl<B: FusionBackend> Operation<B::FusionRuntime> for SelectAssignOps<B> {
+            fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
+                let tensor = handles.get_int_tensor::<B>(&self.desc.tensor);
+                let indices = handles.get_int_tensor::<B>(&self.desc.indices);
+                let value = handles.get_int_tensor::<B>(&self.desc.value);
+
+                let output =
+                    B::int_select_assign(tensor, self.desc.dim, indices, value, self.desc.update);
+
+                handles.register_int_tensor::<B>(&self.desc.out.id, output);
+            }
+        }
+
+        let streams = StreamId::current();
+
+        let client = tensor.client.clone();
+        let desc = SelectAssignOpIr::create(
+            tensor.into_ir(),
+            dim,
+            indices.into_ir(),
+            value.into_ir(),
+            update,
             || client.create_empty_handle(),
         );
 

--- a/crates/burn-fusion/src/ops/tensor.rs
+++ b/crates/burn-fusion/src/ops/tensor.rs
@@ -701,6 +701,53 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
             .output()
     }
 
+    fn float_scatter(
+        dim: usize,
+        tensor: FloatTensor<Self>,
+        indices: IntTensor<Self>,
+        value: FloatTensor<Self>,
+        update: IndexingUpdateOp,
+    ) -> FloatTensor<Self> {
+        #[derive(new, Debug)]
+        struct ScatterOps<B: FusionBackend> {
+            desc: ScatterOpIr,
+            _b: PhantomData<B>,
+        }
+
+        impl<B: FusionBackend> Operation<B::FusionRuntime> for ScatterOps<B> {
+            fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
+                let tensor = handles.get_float_tensor::<B>(&self.desc.tensor);
+                let indices = handles.get_int_tensor::<B>(&self.desc.indices);
+                let value = handles.get_float_tensor::<B>(&self.desc.value);
+
+                let output =
+                    B::float_scatter(self.desc.dim, tensor, indices, value, self.desc.update);
+
+                handles.register_float_tensor::<B>(&self.desc.out.id, output);
+            }
+        }
+
+        let streams = StreamId::current();
+
+        let client = tensor.client.clone();
+        let desc = ScatterOpIr::create(
+            tensor.into_ir(),
+            dim,
+            indices.into_ir(),
+            value.into_ir(),
+            update,
+            || client.create_empty_handle(),
+        );
+
+        client
+            .register(
+                streams,
+                OperationIr::BaseFloat(BaseOperationIr::Scatter(desc.clone())),
+                ScatterOps::<B>::new(desc),
+            )
+            .output()
+    }
+
     fn float_scatter_nd(
         data: FloatTensor<Self>,
         indices: IntTensor<Self>,
@@ -849,6 +896,53 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
             indices.into_ir(),
             value.into_ir(),
             IndexingUpdateOp::Add,
+            || client.create_empty_handle(),
+        );
+
+        client
+            .register(
+                streams,
+                OperationIr::BaseFloat(BaseOperationIr::SelectAssign(desc.clone())),
+                SelectAssignOps::<B>::new(desc),
+            )
+            .output()
+    }
+
+    fn float_select_assign(
+        tensor: FloatTensor<Self>,
+        dim: usize,
+        indices: IntTensor<Self>,
+        value: FloatTensor<Self>,
+        update: IndexingUpdateOp,
+    ) -> FloatTensor<Self> {
+        #[derive(new, Debug)]
+        struct SelectAssignOps<B: FusionBackend> {
+            desc: SelectAssignOpIr,
+            _b: PhantomData<B>,
+        }
+
+        impl<B: FusionBackend> Operation<B::FusionRuntime> for SelectAssignOps<B> {
+            fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
+                let tensor = handles.get_float_tensor::<B>(&self.desc.tensor);
+                let indices = handles.get_int_tensor::<B>(&self.desc.indices);
+                let value = handles.get_float_tensor::<B>(&self.desc.value);
+
+                let output =
+                    B::float_select_assign(tensor, self.desc.dim, indices, value, self.desc.update);
+
+                handles.register_float_tensor::<B>(&self.desc.out.id, output);
+            }
+        }
+
+        let streams = StreamId::current();
+
+        let client = tensor.client.clone();
+        let desc = SelectAssignOpIr::create(
+            tensor.into_ir(),
+            dim,
+            indices.into_ir(),
+            value.into_ir(),
+            update,
             || client.create_empty_handle(),
         );
 

--- a/crates/burn-ir/src/operation.rs
+++ b/crates/burn-ir/src/operation.rs
@@ -405,8 +405,8 @@ pub enum BaseOperationIr {
     Select(SelectOpIr),
     /// Operation corresponding to:
     ///
-    /// Float => [select assign](burn_backend::ops::FloatTensorOps::float_select_add).
-    /// Int => [select assign](burn_backend::ops::IntTensorOps::int_select_add).
+    /// Float => [select assign](burn_backend::ops::FloatTensorOps::float_select_assign).
+    /// Int => [select assign](burn_backend::ops::IntTensorOps::int_select_assign).
     /// Bool => [select assign](burn_backend::ops::BoolTensorOps::bool_select_or).
     SelectAssign(SelectAssignOpIr),
     /// Operation corresponding to:

--- a/crates/burn-ndarray/src/ops/base.rs
+++ b/crates/burn-ndarray/src/ops/base.rs
@@ -187,6 +187,58 @@ where
         output
     }
 
+    pub fn scatter_assign<I: NdArrayElement>(
+        dim: usize,
+        mut tensor: SharedArray<E>,
+        mut indices: SharedArray<I>,
+        mut value: SharedArray<E>,
+    ) -> SharedArray<E> {
+        let ndims = tensor.shape().num_dims();
+        if dim != ndims - 1 {
+            tensor.swap_axes(ndims - 1, dim);
+            indices.swap_axes(ndims - 1, dim);
+            value.swap_axes(ndims - 1, dim);
+        }
+
+        let (shape_tensor, shape_indices, shape_value) =
+            (tensor.shape().into_shape(), indices.shape(), value.shape());
+        let (size_tensor, size_index, size_value) = (
+            shape_tensor[ndims - 1],
+            shape_indices[ndims - 1],
+            shape_value[ndims - 1],
+        );
+        let batch_size = Self::gather_batch_size(&shape_tensor, shape_indices);
+
+        if shape_value != shape_indices {
+            panic!(
+                "Invalid dimension: the shape of the index tensor should be the same as the value \
+                 tensor: Index {:?} value {:?}",
+                shape_indices, shape_value
+            );
+        }
+
+        let indices = NdArrayOps::reshape(indices, Shape::new([batch_size, size_index]));
+        let value = NdArrayOps::reshape(value, Shape::new([batch_size, size_value]));
+        let mut tensor = NdArrayOps::reshape(tensor, Shape::new([batch_size, size_tensor]));
+
+        for b in 0..batch_size {
+            let indices = indices.slice(s!(b, ..));
+
+            for (i, index) in indices.iter().enumerate() {
+                let index = index.elem::<i64>() as usize;
+                let value = value[[b, i]];
+                let out = &mut tensor[[b, index]];
+                *out = value;
+            }
+        }
+
+        let mut output = NdArrayOps::reshape(tensor.into_shared().into_dyn(), shape_tensor);
+        if dim != ndims - 1 {
+            output.swap_axes(ndims - 1, dim);
+        }
+        output
+    }
+
     pub fn scatter_nd<I: NdArrayElement>(
         data: SharedArray<E>,
         indices: SharedArray<I>,
@@ -959,6 +1011,24 @@ where
             let value = value.index_axis(Axis(dim), index_value);
 
             view.zip_mut_with(&value, |a, b| *a += *b);
+        }
+
+        output_array.into_shared()
+    }
+
+    pub fn select_assign_replace<I: NdArrayElement>(
+        tensor: SharedArray<E>,
+        dim: usize,
+        indices: SharedArray<I>,
+        value: SharedArray<E>,
+    ) -> SharedArray<E> {
+        let mut output_array = tensor.into_owned();
+
+        for (index_value, index) in indices.into_iter().enumerate() {
+            let mut view = output_array.index_axis_mut(Axis(dim), index.elem::<i64>() as usize);
+            let value = value.index_axis(Axis(dim), index_value);
+
+            view.zip_mut_with(&value, |a, b| *a = *b);
         }
 
         output_array.into_shared()

--- a/crates/burn-ndarray/src/ops/int_tensor.rs
+++ b/crates/burn-ndarray/src/ops/int_tensor.rs
@@ -279,6 +279,28 @@ impl IntTensorOps<Self> for NdArray {
         })
     }
 
+    fn int_scatter(
+        dim: usize,
+        tensor: NdArrayTensor,
+        indices: NdArrayTensor,
+        value: NdArrayTensor,
+        update: burn_backend::tensor::IndexingUpdateOp,
+    ) -> NdArrayTensor {
+        match update {
+            burn_backend::tensor::IndexingUpdateOp::Add => {
+                Self::int_scatter_add(dim, tensor, indices, value)
+            }
+            burn_backend::tensor::IndexingUpdateOp::Assign => {
+                execute_with_int_dtype!((tensor, value), I, |tensor, value| -> NdArrayTensor {
+                    execute_with_int_dtype!(indices, |idx_array| NdArrayOps::<I>::scatter_assign(
+                        dim, tensor, idx_array, value
+                    ))
+                })
+            }
+            other => unimplemented!("int_scatter with {other:?} update is not implemented"),
+        }
+    }
+
     fn int_scatter_nd(
         data: NdArrayTensor,
         indices: NdArrayTensor,
@@ -317,6 +339,28 @@ impl IntTensorOps<Self> for NdArray {
                 tensor, dim, idx_array, value
             ))
         })
+    }
+
+    fn int_select_assign(
+        tensor: NdArrayTensor,
+        dim: usize,
+        indices: NdArrayTensor,
+        value: NdArrayTensor,
+        update: burn_backend::tensor::IndexingUpdateOp,
+    ) -> NdArrayTensor {
+        match update {
+            burn_backend::tensor::IndexingUpdateOp::Add => {
+                Self::int_select_add(tensor, dim, indices, value)
+            }
+            burn_backend::tensor::IndexingUpdateOp::Assign => {
+                execute_with_int_dtype!((tensor, value), I, |tensor, value| -> NdArrayTensor {
+                    execute_with_int_dtype!(indices, |idx_array| {
+                        NdArrayMathOps::<I>::select_assign_replace(tensor, dim, idx_array, value)
+                    })
+                })
+            }
+            other => unimplemented!("int_select_assign with {other:?} update is not implemented"),
+        }
     }
     fn int_argmax(tensor: NdArrayTensor, dim: usize) -> NdArrayTensor {
         // Use view() for zero-copy on borrowed storage

--- a/crates/burn-ndarray/src/ops/tensor.rs
+++ b/crates/burn-ndarray/src/ops/tensor.rs
@@ -196,6 +196,32 @@ impl FloatTensorOps<Self> for NdArray {
         )
     }
 
+    fn float_scatter(
+        dim: usize,
+        tensor: FloatTensor<Self>,
+        indices: NdArrayTensor,
+        value: FloatTensor<Self>,
+        update: burn_backend::tensor::IndexingUpdateOp,
+    ) -> FloatTensor<Self> {
+        match update {
+            burn_backend::tensor::IndexingUpdateOp::Add => {
+                Self::float_scatter_add(dim, tensor, indices, value)
+            }
+            burn_backend::tensor::IndexingUpdateOp::Assign => {
+                execute_with_int_dtype!(
+                    indices,
+                    IntElem,
+                    |idx_array: SharedArray<IntElem>| -> NdArrayTensor {
+                        execute_with_float_dtype!((tensor, value), |tensor, value| {
+                            NdArrayOps::scatter_assign(dim, tensor, idx_array, value)
+                        })
+                    }
+                )
+            }
+            other => unimplemented!("float_scatter with {other:?} update is not implemented"),
+        }
+    }
+
     fn float_scatter_nd(
         data: FloatTensor<Self>,
         indices: NdArrayTensor,
@@ -256,6 +282,34 @@ impl FloatTensorOps<Self> for NdArray {
                 })
             }
         )
+    }
+
+    fn float_select_assign(
+        tensor: FloatTensor<Self>,
+        dim: usize,
+        indices: NdArrayTensor,
+        value: FloatTensor<Self>,
+        update: burn_backend::tensor::IndexingUpdateOp,
+    ) -> FloatTensor<Self> {
+        match update {
+            burn_backend::tensor::IndexingUpdateOp::Add => {
+                Self::float_select_add(tensor, dim, indices, value)
+            }
+            burn_backend::tensor::IndexingUpdateOp::Assign => {
+                execute_with_int_dtype!(
+                    indices,
+                    IntElem,
+                    |idx_array: SharedArray<IntElem>| -> NdArrayTensor {
+                        execute_with_float_dtype!((tensor, value), |tensor, value| {
+                            NdArrayMathOps::select_assign_replace(tensor, dim, idx_array, value)
+                        })
+                    }
+                )
+            }
+            other => {
+                unimplemented!("float_select_assign with {other:?} update is not implemented")
+            }
+        }
     }
 
     fn float_slice(tensor: FloatTensor<Self>, slices: &[burn_backend::Slice]) -> FloatTensor<Self> {

--- a/crates/burn-router/src/interpreter.rs
+++ b/crates/burn-router/src/interpreter.rs
@@ -283,12 +283,7 @@ impl<B: BackendIr> TensorInterpreter<B> {
                     let indices = handles.get_int_tensor::<B>(&desc.indices);
                     let value = handles.get_float_tensor::<B>(&desc.value);
 
-                    let output = match desc.update {
-                        IndexingUpdateOp::Add => {
-                            B::float_scatter_add(desc.dim, tensor, indices, value)
-                        }
-                        _ => unimplemented!(),
-                    };
+                    let output = B::float_scatter(desc.dim, tensor, indices, value, desc.update);
                     handles.register_float_tensor::<B>(&desc.out.id, output);
                 }
                 BaseOperationIr::ScatterNd(desc) => {
@@ -318,12 +313,8 @@ impl<B: BackendIr> TensorInterpreter<B> {
                     let indices = handles.get_int_tensor::<B>(&desc.indices);
                     let value = handles.get_float_tensor::<B>(&desc.value);
 
-                    let output = match desc.update {
-                        IndexingUpdateOp::Add => {
-                            B::float_select_add(tensor, desc.dim, indices, value)
-                        }
-                        _ => unimplemented!(),
-                    };
+                    let output =
+                        B::float_select_assign(tensor, desc.dim, indices, value, desc.update);
                     handles.register_float_tensor::<B>(&desc.out.id, output);
                 }
                 BaseOperationIr::MaskWhere(desc) => {
@@ -472,12 +463,7 @@ impl<B: BackendIr> TensorInterpreter<B> {
                     let indices = handles.get_int_tensor::<B>(&desc.indices);
                     let value = handles.get_int_tensor::<B>(&desc.value);
 
-                    let output = match desc.update {
-                        IndexingUpdateOp::Add => {
-                            B::int_scatter_add(desc.dim, tensor, indices, value)
-                        }
-                        _ => unimplemented!(),
-                    };
+                    let output = B::int_scatter(desc.dim, tensor, indices, value, desc.update);
                     handles.register_int_tensor::<B>(&desc.out.id, output);
                 }
                 BaseOperationIr::ScatterNd(desc) => {
@@ -507,12 +493,8 @@ impl<B: BackendIr> TensorInterpreter<B> {
                     let indices = handles.get_int_tensor::<B>(&desc.indices);
                     let value = handles.get_int_tensor::<B>(&desc.value);
 
-                    let output = match desc.update {
-                        IndexingUpdateOp::Add => {
-                            B::int_select_add(tensor, desc.dim, indices, value)
-                        }
-                        _ => unimplemented!(),
-                    };
+                    let output =
+                        B::int_select_assign(tensor, desc.dim, indices, value, desc.update);
                     handles.register_int_tensor::<B>(&desc.out.id, output);
                 }
                 BaseOperationIr::MaskWhere(desc) => {

--- a/crates/burn-router/src/ops/int_tensor.rs
+++ b/crates/burn-router/src/ops/int_tensor.rs
@@ -163,6 +163,28 @@ impl<R: RouterChannel> IntTensorOps<Self> for BackendRouter<R> {
             .output()
     }
 
+    fn int_scatter(
+        dim: usize,
+        tensor: IntTensor<Self>,
+        indices: IntTensor<Self>,
+        value: IntTensor<Self>,
+        update: IndexingUpdateOp,
+    ) -> IntTensor<Self> {
+        let client = tensor.client.clone();
+        let desc = ScatterOpIr::create(
+            tensor.into_ir(),
+            dim,
+            indices.into_ir(),
+            value.into_ir(),
+            update,
+            || client.create_empty_handle(),
+        );
+
+        client
+            .register(OperationIr::BaseInt(BaseOperationIr::Scatter(desc)))
+            .output()
+    }
+
     fn int_scatter_nd(
         data: IntTensor<Self>,
         indices: IntTensor<Self>,
@@ -222,6 +244,28 @@ impl<R: RouterChannel> IntTensorOps<Self> for BackendRouter<R> {
             indices.into_ir(),
             value.into_ir(),
             IndexingUpdateOp::Add,
+            || client.create_empty_handle(),
+        );
+
+        client
+            .register(OperationIr::BaseInt(BaseOperationIr::SelectAssign(desc)))
+            .output()
+    }
+
+    fn int_select_assign(
+        tensor: IntTensor<Self>,
+        dim: usize,
+        indices: IntTensor<Self>,
+        value: IntTensor<Self>,
+        update: IndexingUpdateOp,
+    ) -> IntTensor<Self> {
+        let client = tensor.client.clone();
+        let desc = SelectAssignOpIr::create(
+            tensor.into_ir(),
+            dim,
+            indices.into_ir(),
+            value.into_ir(),
+            update,
             || client.create_empty_handle(),
         );
 

--- a/crates/burn-router/src/ops/tensor.rs
+++ b/crates/burn-router/src/ops/tensor.rs
@@ -372,6 +372,28 @@ impl<R: RouterChannel> FloatTensorOps<Self> for BackendRouter<R> {
             .output()
     }
 
+    fn float_scatter(
+        dim: usize,
+        tensor: FloatTensor<Self>,
+        indices: IntTensor<Self>,
+        value: FloatTensor<Self>,
+        update: IndexingUpdateOp,
+    ) -> FloatTensor<Self> {
+        let client = tensor.client.clone();
+        let desc = ScatterOpIr::create(
+            tensor.into_ir(),
+            dim,
+            indices.into_ir(),
+            value.into_ir(),
+            update,
+            || client.create_empty_handle(),
+        );
+
+        client
+            .register(OperationIr::BaseFloat(BaseOperationIr::Scatter(desc)))
+            .output()
+    }
+
     fn float_scatter_nd(
         data: FloatTensor<Self>,
         indices: IntTensor<Self>,
@@ -431,6 +453,28 @@ impl<R: RouterChannel> FloatTensorOps<Self> for BackendRouter<R> {
             indices.into_ir(),
             value.into_ir(),
             IndexingUpdateOp::Add,
+            || client.create_empty_handle(),
+        );
+
+        client
+            .register(OperationIr::BaseFloat(BaseOperationIr::SelectAssign(desc)))
+            .output()
+    }
+
+    fn float_select_assign(
+        tensor: FloatTensor<Self>,
+        dim: usize,
+        indices: IntTensor<Self>,
+        value: FloatTensor<Self>,
+        update: IndexingUpdateOp,
+    ) -> FloatTensor<Self> {
+        let client = tensor.client.clone();
+        let desc = SelectAssignOpIr::create(
+            tensor.into_ir(),
+            dim,
+            indices.into_ir(),
+            value.into_ir(),
+            update,
             || client.create_empty_handle(),
         );
 

--- a/crates/burn-tensor/src/bridge/ops/float.rs
+++ b/crates/burn-tensor/src/bridge/ops/float.rs
@@ -146,15 +146,13 @@ impl BasicOps for Float {
         update: IndexingUpdateOp,
     ) -> BridgeTensor {
         // Select assign is ambiguous for QFloat
-        match update {
-            IndexingUpdateOp::Add => BridgeTensor::float(Dispatch::float_select_add(
-                tensor.into_float(),
-                dim,
-                indices.into(),
-                values.into_float(),
-            )),
-            other => unimplemented!("Unsupported update op {other:?}"),
-        }
+        BridgeTensor::float(Dispatch::float_select_assign(
+            tensor.into_float(),
+            dim,
+            indices.into(),
+            values.into_float(),
+            update,
+        ))
     }
 
     fn mask_where(tensor: BridgeTensor, mask: BridgeTensor, source: BridgeTensor) -> BridgeTensor {
@@ -193,15 +191,13 @@ impl BasicOps for Float {
         values: BridgeTensor,
         update: IndexingUpdateOp,
     ) -> BridgeTensor {
-        match update {
-            IndexingUpdateOp::Add => BridgeTensor::float(Dispatch::float_scatter_add(
-                dim,
-                tensor.into_float(),
-                indices.into(),
-                values.into_float(),
-            )),
-            other => unimplemented!("Unsupported update op {other:?}"),
-        }
+        BridgeTensor::float(Dispatch::float_scatter(
+            dim,
+            tensor.into_float(),
+            indices.into(),
+            values.into_float(),
+            update,
+        ))
     }
 
     fn scatter_nd(

--- a/crates/burn-tensor/src/bridge/ops/int.rs
+++ b/crates/burn-tensor/src/bridge/ops/int.rs
@@ -85,15 +85,13 @@ impl BasicOps for Int {
         values: BridgeTensor,
         update: IndexingUpdateOp,
     ) -> BridgeTensor {
-        match update {
-            IndexingUpdateOp::Add => BridgeTensor::int(Dispatch::int_select_add(
-                tensor.into(),
-                dim,
-                indices.into(),
-                values.into(),
-            )),
-            _ => unimplemented!(),
-        }
+        BridgeTensor::int(Dispatch::int_select_assign(
+            tensor.into(),
+            dim,
+            indices.into(),
+            values.into(),
+            update,
+        ))
     }
 
     fn mask_where(tensor: BridgeTensor, mask: BridgeTensor, source: BridgeTensor) -> BridgeTensor {
@@ -119,15 +117,13 @@ impl BasicOps for Int {
         values: BridgeTensor,
         update: IndexingUpdateOp,
     ) -> BridgeTensor {
-        match update {
-            IndexingUpdateOp::Add => BridgeTensor::int(Dispatch::int_scatter_add(
-                dim,
-                tensor.into(),
-                indices.into(),
-                values.into(),
-            )),
-            _ => unimplemented!(),
-        }
+        BridgeTensor::int(Dispatch::int_scatter(
+            dim,
+            tensor.into(),
+            indices.into(),
+            values.into(),
+            update,
+        ))
     }
 
     fn scatter_nd(

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -1679,26 +1679,46 @@ where
     }
 
     /// Assign the selected elements along the given dimension corresponding to the given indices
-    /// from the value tensor to the original tensor using sum reduction.
+    /// from the value tensor to the original tensor using the requested update operation.
     ///
     /// # Note
-    /// For booleans, the sum operator is logical or.
+    /// - `IndexingUpdateOp::Add` accumulates values at the selected positions (`+=`). For
+    ///   booleans, `Add` is logical or.
+    /// - `IndexingUpdateOp::Assign` replaces values at the selected positions (`=`), when
+    ///   supported by the backend.
+    ///
+    /// When `indices` contains duplicate entries, behavior varies by operation:
+    /// - For `Add`, accumulation is supported, though results may be non-deterministic on GPU
+    ///   backends.
+    /// - For `Assign`, duplicate indices result in undefined behavior for both the forward result
+    ///   and the backward gradients.
+    ///
+    /// For deterministic results and correct gradient calculation across all operations,
+    /// `indices` should contain unique entries.
     ///
     /// # Arguments
     ///
     /// * `dim` - The dimension along which to select. Supports negative indexing.
     /// * `indices` - The indices to select from the tensor.
     /// * `values` - The values to assign to the selected indices.
-    /// * `update` - The operation used to update the existing values at the indexed positions (e.g., add).
+    /// * `update` - The operation used to update the existing values at the indexed positions.
     ///
     /// # Example
     ///
     /// Example using a 3D tensor:
     ///
+    /// With `IndexingUpdateOp::Add`:
+    ///
     /// `input[indices[i], j, k] += values[i, j, k]; // dim = 0`
     /// `input[i, indices[j], k] += values[i, j, k]; // dim = 1`
     /// `input[i, j, indices[k]] += values[i, j, k]; // dim = 2`
-    /// `input[i, j, indices[k]] += values[i, j, k]; // dim = -1 (same as dim = 2)`
+    ///
+    /// With `IndexingUpdateOp::Assign`, when supported by the backend, the same indexed locations
+    /// are replaced instead:
+    ///
+    /// `input[indices[i], j, k] = values[i, j, k]; // dim = 0`
+    /// `input[i, indices[j], k] = values[i, j, k]; // dim = 1`
+    /// `input[i, j, indices[k]] = values[i, j, k]; // dim = 2`
     ///
     /// # Warning
     ///
@@ -1883,24 +1903,42 @@ where
     }
 
     /// Assign the gathered elements corresponding to the given indices along the specified dimension
-    /// from the value tensor to the original tensor using sum reduction.
+    /// from the value tensor to the original tensor using the requested update operation.
     ///
     /// Example using a 3D tensor:
+    ///
+    /// With `IndexingUpdateOp::Add`:
     ///
     /// `input[indices[i, j, k], j, k] += values[i, j, k]; // dim = 0`
     /// `input[i, indices[i, j, k], k] += values[i, j, k]; // dim = 1`
     /// `input[i, j, indices[i, j, k]] += values[i, j, k]; // dim = 2`
     ///
+    /// With `IndexingUpdateOp::Assign`, when supported by the backend, the same indexed locations
+    /// are replaced instead:
+    ///
+    /// `input[indices[i, j, k], j, k] = values[i, j, k]; // dim = 0`
+    /// `input[i, indices[i, j, k], k] = values[i, j, k]; // dim = 1`
+    /// `input[i, j, indices[i, j, k]] = values[i, j, k]; // dim = 2`
+    ///
     /// # Arguments
     /// * `dim` - The axis along which to scatter elements. Supports negative indexing.
     /// * `indices` - The indices of the elements to scatter.
     /// * `values` - The values to scatter into the tensor.
-    /// * `update` - The operation used to update the existing values at the indexed positions (e.g., add).
+    /// * `update` - The operation used to update the existing values at the indexed positions.
     ///
     /// # Notes
     ///
     /// The index tensor should have the same shape as the original tensor except for the specified
     /// dimension. The value and index tensors should have the same shape.
+    ///
+    /// When `indices` contains duplicate entries, behavior varies by operation:
+    /// - For `Add`, accumulation is supported, though results may be non-deterministic on GPU
+    ///   backends.
+    /// - For `Assign`, duplicate indices result in undefined behavior for both the forward result
+    ///   and the backward gradients.
+    ///
+    /// For deterministic results and correct gradient calculation across all operations,
+    /// `indices` should contain unique entries.
     ///
     /// Other references to the input tensor will not be modified by this operation.
     ///

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -1704,6 +1704,9 @@ where
     ///
     /// Not all backends have runtime bound checks for the indices, so make sure they are valid.
     /// Otherwise, out of bounds indices could lead to unexpected results instead of panicking.
+    ///
+    /// # Panics
+    /// If the backend doesn't support the requested update operation.
     pub fn select_assign(
         self,
         dim: impl AsIndex,
@@ -1906,7 +1909,7 @@ where
     /// Otherwise, out of bounds indices could lead to unexpected results instead of panicking.
     ///
     /// # Panics
-    /// If the `update` is not `IndexingUpdateOp::Add`. Other operations are currently not implemented.
+    /// If the backend doesn't support the requested update operation.
     pub fn scatter(
         self,
         dim: impl AsIndex,


### PR DESCRIPTION
## Motivation
`scatter` and `select_assign` accept `IndexingUpdateOp`, but the bridge/router/fusion path only allowed `Add`, even though overwrite-style indexed updates are already supported by `scatter_nd`. This follows the `ScatterElements` and native `scatter_nd` / `gather_nd` work from tracel-ai/burn-onnx#131 and tracel-ai/burn#4709 by adding `Assign` support to the plain indexed update APIs for float and int tensors.

Bool tensors keep the existing `Add` / logical-or behavior, and `Mul`, `Min`, and `Max` remain explicitly unimplemented for these plain APIs so they can be handled in separate operation-focused PRs.

## Modifications
- Add update-aware float/int backend trait methods that delegate `Add` to the existing `*_add` implementations by default.
- Forward `IndexingUpdateOp` through bridge, dispatch, router, and fusion for `scatter` and `select_assign`.
- Implement `Assign` for ndarray float/int `scatter` and `select_assign`.
- Support float autodiff gradients for `scatter(..., Assign)` and `select_assign(..., Assign)`, and delegate int autodiff indexed updates to the inner backend.
- Document `Add` vs `Assign` behavior and duplicate-index semantics for the public tensor APIs.
- Add ndarray-scoped backend tests and autodiff tests for `Assign` on `scatter` and `select_assign`.
