### PR TITLE
Tensor::select_dim(self, dim, index)

### DIFF
--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -239,7 +239,7 @@ Those operations are available for all tensor kinds: `Int`, `Float`, and `Bool`.
 | `tensor.slice_assign(slices, values)`                | `tensor[(*ranges,)] = values`                                             |
 | `tensor.slice_fill(slices, value)`                   | `tensor[(*ranges,)] = value`                                              |
 | `tensor.slice_dim(dim, slice)`                       | N/A                                                                       |
-| `tensor.select_dim(dim, slice)`                      | `torch.select(tensor, dim, index)`                                        |
+| `tensor.select_dim(dim, index)`                      | `torch.select(tensor, dim, index)`                                        |
 | `tensor.squeeze()`                                   | `tensor.squeeze()`                                                        |
 | `tensor.squeeze_dim(dim)`                            | `tensor.squeeze(dim)`                                                     |
 | `tensor.squeeze_dims(dims)`                          | `tensor.squeeze(dims)` where `dims` is a tuple of ints                    |

--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -239,6 +239,7 @@ Those operations are available for all tensor kinds: `Int`, `Float`, and `Bool`.
 | `tensor.slice_assign(slices, values)`                | `tensor[(*ranges,)] = values`                                             |
 | `tensor.slice_fill(slices, value)`                   | `tensor[(*ranges,)] = value`                                              |
 | `tensor.slice_dim(dim, slice)`                       | N/A                                                                       |
+| `tensor.select_dim(dim, slice)`                      | `torch.select(tensor, dim, index)`                                        |
 | `tensor.squeeze()`                                   | `tensor.squeeze()`                                                        |
 | `tensor.squeeze_dim(dim)`                            | `tensor.squeeze(dim)`                                                     |
 | `tensor.squeeze_dims(dims)`                          | `tensor.squeeze(dims)` where `dims` is a tuple of ints                    |

--- a/crates/burn-backend-tests/tests/tensor/float/ops/slice.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/slice.rs
@@ -2,6 +2,20 @@ use super::*;
 use burn_tensor::{ElementConversion, Slice, TensorData, s};
 
 #[test]
+fn should_support_select_dim() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::from_data([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], &device);
+
+    let row1: Tensor<1> = tensor.clone().select_dim(0, 1);
+    row1.to_data()
+        .assert_eq(&TensorData::from([4.0, 5.0, 6.0]), false);
+
+    let col1: Tensor<1> = tensor.clone().select_dim(1, 1);
+    col1.to_data()
+        .assert_eq(&TensorData::from([2.0, 5.0]), false);
+}
+
+#[test]
 fn should_support_slice_dim_1d() {
     let data = TensorData::from([0.0, 1.0, 2.0]);
     let tensor = TestTensor::<1>::from_data(data.clone(), &Default::default());

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -1610,7 +1610,7 @@ where
     ///
     /// # Example
     /// ```rust
-    /// use burn_tensor::{Tensor, s};
+    /// use burn_tensor::{Tensor, TensorData, s};
     ///
     /// fn example() {
     ///     let device = Default::default();

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -1600,6 +1600,48 @@ where
         self.slice(&slices)
     }
 
+    /// Returns a new tensor selecting a dimension index, and then squeezing that dim.
+    ///
+    /// This is defined as equivalent to `t.slice_dim(dim, index).squeeze_dim::<D2>(dim)`
+    ///
+    /// # Arguments
+    /// * `dim`: The dimension to slice. Supports negative indexing.
+    /// * `index`: the dimension index. Supports negative indexing.
+    ///
+    /// # Example
+    /// ```rust
+    /// use burn_tensor::{Tensor, s};
+    ///
+    /// fn example() {
+    ///     let device = Default::default();
+    ///     let tensor = Tensor::<2>::from_data(
+    ///         [
+    ///             [1.0, 2.0, 3.0],
+    ///             [4.0, 5.0, 6.0],
+    ///         ],
+    ///         &device,
+    ///     );
+    ///
+    ///     let row1 : Tensor<1> = tensor.clone().select_dim(0, 1);
+    ///     row1
+    ///         .to_data()
+    ///         .assert_eq(&TensorData::from([4.0, 5.0, 6.0]), false);
+    ///
+    ///     let col1 : Tensor<1> = tensor.clone().select_dim(1, 1);
+    ///     col1
+    ///         .to_data()
+    ///         .assert_eq(&TensorData::from([2.0, 5.0]), false);
+    /// }
+    /// ```
+    pub fn select_dim<const D2: usize, Dim: AsIndex, Idx: AsIndex>(
+        self,
+        dim: Dim,
+        index: Idx,
+    ) -> Tensor<D2, K> {
+        let index = index.as_index();
+        self.slice_dim(dim, index).squeeze_dim(dim)
+    }
+
     /// Returns the device of the current tensor.
     pub fn device(&self) -> Device {
         K::device(&self.primitive)

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -1633,10 +1633,10 @@ where
     ///         .assert_eq(&TensorData::from([2.0, 5.0]), false);
     /// }
     /// ```
-    pub fn select_dim<const D2: usize, Dim: AsIndex, Idx: AsIndex>(
+    pub fn select_dim<const D2: usize>(
         self,
-        dim: Dim,
-        index: Idx,
+        dim: impl AsIndex,
+        index: impl AsIndex,
     ) -> Tensor<D2, K> {
         let index = index.as_index();
         self.slice_dim(dim, index).squeeze_dim(dim)


### PR DESCRIPTION
Add a `torch.select(t, dim, idx)` equivalent which selects and removes a dimension.

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Testing

Test added.