### PR TITLE
Support UE4M3 quantization scale params on CPU, and add an accuracy harness

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,5 +1,5 @@
 [default]
-extend-ignore-identifiers-re = ["ratatui", "Ratatui", "NdArray*", "ND", "log_lik"]
+extend-ignore-identifiers-re = ["ratatui", "Ratatui", "NdArray*", "ND", "log_lik", ".*ue4m3.*"]
 
 [default.extend-identifiers]
 UE4M3 = "UE4M3"

--- a/burn-book/src/performance/quantization.md
+++ b/burn-book/src/performance/quantization.md
@@ -126,8 +126,14 @@ Native storage is not supported for sub-byte quantization values.
 
 #### Quantization Parameters Precision
 
-| Param  | Description                    |
-| :----- | :----------------------------- |
-| `F32`  | Full floating-point precision. |
-| `F16`  | Half-precision floating point. |
-| `BF16` | Brain float 16-bit precision.  |
+| Param   | Description                                                                            |
+| :------ | :------------------------------------------------------------------------------------- |
+| `F32`   | Full floating-point precision.                                                         |
+| `F16`   | Half-precision floating point.                                                         |
+| `BF16`  | Brain float 16-bit precision.                                                          |
+| `UE4M3` | 8-bit floating point (4 exponent, 3 mantissa). Currently supported on CPU backends only. |
+
+A narrower parameter type stores less per block, but it also has a much smaller range. `UE4M3`
+cannot represent a value below `2^-9`, so a scale smaller than that rounds to zero and the block
+is lost. Scales stay in range when the quantized values are large enough, which in practice means
+it is not a drop-in replacement for `F32` on small-magnitude weights.

--- a/crates/burn-backend-tests/tests/tensor/float/quantization/accuracy.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/quantization/accuracy.rs
@@ -1,0 +1,190 @@
+//! Quantization accuracy measurement.
+//!
+//! Reports dequantization error against bits per element, so a scheme can be judged on the
+//! accuracy it buys for the memory it costs rather than on either number alone.
+//!
+//! Run the full sweep with:
+//! `cargo test -p burn-backend-tests --features ndarray --test tensor report_quantization_accuracy -- --ignored --nocapture`
+
+use super::*;
+use burn_tensor::{
+    Shape, TensorData,
+    quantization::{QuantLevel, QuantParam, QuantScheme, QuantValue, params_shape},
+};
+
+/// Bits per stored scale.
+// TODO: replace with `QuantParam::size_bits()` once it exists upstream in cubecl. This is the
+// fourth copy of this table (see also `burn-std`'s `scale_size` and `burn-store`'s
+// `quant_param_size`).
+fn param_size_bits(param: QuantParam) -> usize {
+    match param {
+        QuantParam::F32 => 32,
+        QuantParam::F16 | QuantParam::BF16 => 16,
+        QuantParam::UE8M0 | QuantParam::UE4M3 => 8,
+    }
+}
+
+/// Total storage cost of a quantized tensor, per element of the original tensor.
+///
+/// This is the axis that makes schemes comparable: a smaller block buys accuracy but costs more
+/// scales, so only error-at-equal-bits distinguishes a real improvement from a trade.
+fn bits_per_element(scheme: &QuantScheme, shape: &Shape) -> f64 {
+    let numel = shape.num_elements();
+    let num_scales = params_shape(shape, scheme.level).num_elements();
+
+    scheme.size_bits_value() as f64
+        + (param_size_bits(scheme.param) * num_scales) as f64 / numel as f64
+}
+
+/// Deterministic standard-normal samples, so a reported number is reproducible across runs and
+/// backends. Box-Muller over a small LCG; quality beyond "plausibly weight-shaped" is not needed.
+fn normal_samples(n: usize, std: f32) -> Vec<f32> {
+    let mut state = 0x2545_F491_4F6C_DD1Du64;
+    let mut next_uniform = || {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        // Top 24 bits, mapped to (0, 1) so the log below never sees zero.
+        let bits = (state >> 40) as u32;
+        (bits as f32 + 0.5) / (1u32 << 24) as f32
+    };
+
+    (0..n)
+        .map(|_| {
+            let (u1, u2) = (next_uniform(), next_uniform());
+            let r = (-2.0 * u1.ln()).sqrt();
+            r * (core::f32::consts::TAU * u2).cos() * std
+        })
+        .collect()
+}
+
+/// Relative Frobenius error `||W - Ŵ|| / ||W||`, which is scale free and so comparable across
+/// weight magnitudes.
+fn relative_error(original: &[f32], dequantized: &[f32]) -> f32 {
+    let (mut err_sq, mut ref_sq) = (0.0f64, 0.0f64);
+    for (w, w_hat) in original.iter().zip(dequantized) {
+        let d = (w - w_hat) as f64;
+        err_sq += d * d;
+        ref_sq += (*w as f64) * (*w as f64);
+    }
+    (err_sq.sqrt() / ref_sq.sqrt()) as f32
+}
+
+/// Quantize with `scheme`, dequantize, and report the relative error.
+fn quantization_error(values: &[f32], shape: [usize; 2], scheme: &QuantScheme) -> f32 {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::from_data(TensorData::new(values.to_vec(), shape), &device)
+        .quantize_dynamic(scheme);
+
+    let dequantized = tensor.dequantize().into_data().to_vec::<f32>().unwrap();
+
+    relative_error(values, &dequantized)
+}
+
+fn scheme_for(value: QuantValue, level: QuantLevel, param: QuantParam) -> QuantScheme {
+    let device = burn_tensor::Device::default();
+    device
+        .settings()
+        .quantization
+        .scheme
+        .with_value(value)
+        .with_level(level)
+        .with_param(param)
+}
+
+const SHAPE: [usize; 2] = [64, 64];
+
+/// A scale that underflows the param's representable range is the failure the per-tensor scale of
+/// a two-level scheme exists to prevent, so it has to be visible here before that scheme is built.
+///
+/// `Q8S` divides the block maximum by 127, so for weights of a realistic magnitude the block scale
+/// lands in e4m3's subnormals or below, where almost no precision is left.
+#[test]
+fn narrow_scale_param_degrades_without_normalization() {
+    let values = normal_samples(SHAPE[0] * SHAPE[1], 0.02);
+    let level = QuantLevel::block([32]);
+
+    let exact = quantization_error(
+        &values,
+        SHAPE,
+        &scheme_for(QuantValue::Q8S, level, QuantParam::F32),
+    );
+    let narrow = quantization_error(
+        &values,
+        SHAPE,
+        &scheme_for(QuantValue::Q8S, level, QuantParam::UE4M3),
+    );
+
+    assert!(
+        narrow > exact * 2.0,
+        "8-bit block scales should degrade badly without a normalizing per-tensor scale, \
+         got f32={exact:.4} ue4m3={narrow:.4}"
+    );
+}
+
+/// At a magnitude where no scale underflows, the two 16-bit params cost nothing measurable while
+/// the 8-bit one already costs something. Pinning both directions keeps the harness honest: it
+/// has to be sensitive enough to see the 8-bit loss, and not so noisy that it invents a 16-bit one.
+///
+/// Note this is not monotone in scale width. Rounding a scale can land favourably on a given
+/// sample, so f16 sitting a hair below f32 is expected and is not a signal.
+#[test]
+fn error_responds_to_scale_param() {
+    let values = normal_samples(SHAPE[0] * SHAPE[1], 1.0);
+    let level = QuantLevel::block([32]);
+
+    let error_for =
+        |param| quantization_error(&values, SHAPE, &scheme_for(QuantValue::Q8S, level, param));
+    let (f32_err, f16_err, ue4m3_err) = (
+        error_for(QuantParam::F32),
+        error_for(QuantParam::F16),
+        error_for(QuantParam::UE4M3),
+    );
+
+    assert!(
+        (f16_err - f32_err).abs() / f32_err < 0.05,
+        "a 16-bit scale should be indistinguishable from f32, got f32={f32_err} f16={f16_err}"
+    );
+    assert!(
+        ue4m3_err > f32_err * 1.5,
+        "an 8-bit scale should cost real accuracy, got f32={f32_err} ue4m3={ue4m3_err}"
+    );
+}
+
+#[test]
+#[ignore = "reports measurements rather than asserting; run with --ignored --nocapture"]
+fn report_quantization_accuracy() {
+    let levels = [
+        ("tensor", QuantLevel::Tensor),
+        ("block16", QuantLevel::block([16])),
+        ("block32", QuantLevel::block([32])),
+    ];
+    let params = [
+        ("f32", QuantParam::F32),
+        ("f16", QuantParam::F16),
+        ("ue4m3", QuantParam::UE4M3),
+    ];
+    let shape = Shape::from(SHAPE);
+
+    for std in [1.0f32, 0.1, 0.02] {
+        let values = normal_samples(SHAPE[0] * SHAPE[1], std);
+
+        println!("\nweight std = {std}  (shape {SHAPE:?})");
+        println!(
+            "{:<10} {:<7} {:>8} {:>12}",
+            "level", "param", "bits/el", "rel. error"
+        );
+
+        for (level_name, level) in levels {
+            for (param_name, param) in params {
+                let scheme = scheme_for(QuantValue::Q8S, level, param);
+                let error = quantization_error(&values, SHAPE, &scheme);
+
+                println!(
+                    "{level_name:<10} {param_name:<7} {:>8.3} {error:>12.5}",
+                    bits_per_element(&scheme, &shape)
+                );
+            }
+        }
+    }
+}

--- a/crates/burn-backend-tests/tests/tensor/float/quantization/accuracy.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/quantization/accuracy.rs
@@ -70,15 +70,25 @@ fn relative_error(original: &[f32], dequantized: &[f32]) -> f32 {
     (err_sq.sqrt() / ref_sq.sqrt()) as f32
 }
 
+/// Read a tensor back as `f32`, whatever float type the backend is built with.
+fn to_f32(tensor: TestTensor<2>) -> Vec<f32> {
+    tensor.into_data().convert::<f32>().to_vec::<f32>().unwrap()
+}
+
 /// Quantize with `scheme`, dequantize, and report the relative error.
+///
+/// The reference is the tensor as the backend actually holds it, not the `f32` input. Under a
+/// narrower float element type the input is rounded on the way in, and charging that to
+/// quantization would inflate every measurement by a constant that has nothing to do with the
+/// scheme.
 fn quantization_error(values: &[f32], shape: [usize; 2], scheme: &QuantScheme) -> f32 {
     let device = Default::default();
-    let tensor = TestTensor::<2>::from_data(TensorData::new(values.to_vec(), shape), &device)
-        .quantize_dynamic(scheme);
+    let tensor = TestTensor::<2>::from_data(TensorData::new(values.to_vec(), shape), &device);
 
-    let dequantized = tensor.dequantize().into_data().to_vec::<f32>().unwrap();
+    let reference = to_f32(tensor.clone());
+    let dequantized = to_f32(tensor.quantize_dynamic(scheme).dequantize());
 
-    relative_error(values, &dequantized)
+    relative_error(&reference, &dequantized)
 }
 
 fn scheme_for(value: QuantValue, level: QuantLevel, param: QuantParam) -> QuantScheme {
@@ -141,8 +151,11 @@ fn error_responds_to_scale_param() {
         error_for(QuantParam::UE4M3),
     );
 
+    // Generous on purpose. The measured gap is near zero on the backends checked so far, but this
+    // runs on every backend and float element type, and the point is only to separate
+    // "indistinguishable" from the 8-bit case below, which is worse by more than 100%.
     assert!(
-        (f16_err - f32_err).abs() / f32_err < 0.05,
+        (f16_err - f32_err).abs() / f32_err < 0.20,
         "a 16-bit scale should be indistinguishable from f32, got f32={f32_err} f16={f16_err}"
     );
     assert!(

--- a/crates/burn-backend-tests/tests/tensor/float/quantization/mod.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/quantization/mod.rs
@@ -1,5 +1,6 @@
 pub use super::*; // re-export test types
 
+mod accuracy;
 mod calibration;
 mod data;
 mod ops;

--- a/crates/burn-backend/src/quantization/mod.rs
+++ b/crates/burn-backend/src/quantization/mod.rs
@@ -6,5 +6,5 @@ pub use scheme::*;
 
 pub use burn_std::quantization::{
     BlockSize, Calibration, QuantLevel, QuantMode, QuantParam, QuantPropagation, QuantScheme,
-    QuantStore, QuantValue, QuantizedBytes,
+    QuantStore, QuantValue, QuantizedBytes, round_to_param,
 };

--- a/crates/burn-flex/src/ops/qtensor.rs
+++ b/crates/burn-flex/src/ops/qtensor.rs
@@ -9,7 +9,8 @@ use burn_backend::{
     DType, ExecutionError, FloatDType, TensorData, TensorMetadata,
     ops::{IntTensorOps, QTensorOps},
     quantization::{
-        QuantLevel, QuantScheme, QuantStore, QuantizationParametersPrimitive, QuantizedBytes,
+        QuantLevel, QuantParam, QuantScheme, QuantStore, QuantizationParametersPrimitive,
+        QuantizedBytes, round_to_param,
     },
     tensor::{Device, FloatTensor, IntTensor, QuantizedTensor},
 };
@@ -61,7 +62,7 @@ impl QTensorOps<Flex> for Flex {
                         alpha = abs;
                     }
                 }
-                let scale = validated_scale(2.0 * alpha / range);
+                let scale = validated_scale(2.0 * alpha / range, scheme.param);
                 let inv_scale = 1.0 / scale;
 
                 // Pass 2: quantize
@@ -93,7 +94,7 @@ impl QTensorOps<Flex> for Flex {
                             alpha = abs;
                         }
                     }
-                    let scale = validated_scale(2.0 * alpha / range);
+                    let scale = validated_scale(2.0 * alpha / range, scheme.param);
                     let inv_scale = 1.0 / scale;
                     scales.push(scale);
 
@@ -129,7 +130,11 @@ impl QTensorOps<Flex> for Flex {
         // assuming f32 storage.
         let scales_tensor = qparams.scales.to_contiguous();
         let scales_data = float_storage_as_f32(&scales_tensor);
-        let scales: Vec<f32> = scales_data.iter().copied().map(validated_scale).collect();
+        let scales: Vec<f32> = scales_data
+            .iter()
+            .copied()
+            .map(|s| validated_scale(s, scheme.param))
+            .collect();
 
         let (a, b) = scheme.value.range();
 
@@ -341,8 +346,13 @@ fn block_safe_layout_op(
     }
 }
 
-/// Ensure scale is finite and nonzero to avoid division by zero or NaN propagation.
-fn validated_scale(scale: f32) -> f32 {
+/// Round the scale to the scheme's param dtype, then ensure it is finite and nonzero to avoid
+/// division by zero or NaN propagation.
+///
+/// Rounding comes first: a narrow param can round a small scale down to zero, which the
+/// normality check then has to catch.
+fn validated_scale(scale: f32, param: QuantParam) -> f32 {
+    let scale = round_to_param(scale, param);
     if scale.is_normal() {
         scale
     } else {
@@ -472,6 +482,36 @@ mod tests {
         let qtensor = Flex::quantize(tensor, &scheme, qparams);
         let q_vals: &[i8] = qtensor.tensor.storage();
         assert_eq!(q_vals, &[0, 0, 0, 0]);
+    }
+
+    /// The scale a narrow param can represent is coarser than the exact one, so the stored scale
+    /// must reflect the param rather than staying at full `f32` precision. Before scales were
+    /// rounded, every param produced byte-identical results here.
+    #[test]
+    fn test_quantize_dynamic_honors_param_precision() {
+        // 4.5 / 127 is not representable in e4m3, so rounding is observable.
+        let values = vec![-3.0f32, -1.5, 0.0, 1.5, 3.0, 4.5];
+        let scheme = QuantScheme::default()
+            .with_value(QuantValue::Q8S)
+            .with_store(QuantStore::Native);
+
+        let quantize_with = |param| {
+            let tensor = FlexTensor::from_data(TensorData::new(values.clone(), [2, 3]));
+            Flex::quantize_dynamic(tensor, &scheme.with_param(param)).scales[0]
+        };
+
+        let exact = quantize_with(QuantParam::F32);
+        let coarse = quantize_with(QuantParam::UE4M3);
+
+        assert_ne!(
+            exact, coarse,
+            "UE4M3 scale should differ from the exact f32 scale"
+        );
+        assert_eq!(
+            coarse,
+            round_to_param(exact, QuantParam::UE4M3),
+            "stored scale should be the exact scale rounded to the param"
+        );
     }
 
     #[test]

--- a/crates/burn-ndarray/src/ops/qtensor.rs
+++ b/crates/burn-ndarray/src/ops/qtensor.rs
@@ -5,7 +5,7 @@ use burn_backend::{
     ops::{FloatTensorOps, QTensorOps},
     quantization::{
         QParams, QuantLevel, QuantMode, QuantPropagation, QuantScheme, QuantStore, QuantValue,
-        QuantizationParametersPrimitive, QuantizedBytes,
+        QuantizationParametersPrimitive, QuantizedBytes, round_to_param,
     },
     tensor::{FloatTensor, IntTensor, QuantizedTensor},
 };
@@ -85,6 +85,12 @@ impl QTensorOps<Self> for NdArray {
         let shape = tensor.shape();
         let data_f = tensor.into_data();
         let scales = qparams.scales.into_data().convert::<f32>();
+        // Quantize against the scale that will actually be stored, so a save/load round trip
+        // reproduces these values instead of drifting by the param's rounding error.
+        let scales: Vec<f32> = scales
+            .iter::<f32>()
+            .map(|s| round_to_param(s, scheme.param))
+            .collect();
 
         // Implement with ndarray instead of QuantizationStrategy?
         let (data, qparams) = match scheme {
@@ -108,7 +114,7 @@ impl QTensorOps<Self> for NdArray {
                 store: QuantStore::Native,
                 ..
             } => {
-                let scales = scales.iter().next().unwrap();
+                let scales = scales[0];
                 let strategy = QuantizationStrategy::PerTensorSymmetric(
                     SymmetricQuantization::init(scales, scheme.value),
                 );
@@ -134,7 +140,7 @@ impl QTensorOps<Self> for NdArray {
                 store: QuantStore::Native,
                 ..
             } => {
-                let scales = scales.as_slice().unwrap();
+                let scales = scales.as_slice();
                 let (strategy, qparams) = scales
                     .iter()
                     .map(|&s| {

--- a/crates/burn-std/Cargo.toml
+++ b/crates/burn-std/Cargo.toml
@@ -44,6 +44,7 @@ uuid = { workspace = true }
 cubecl-common = { workspace = true, default-features = false, features = [
     "serde",
     "shared-bytes",
+    "fp8",
 ] }
 cubecl-zspace = { workspace = true, default-features = false }
 # Enable extra-platforms for portable-atomic support on targets without native atomics (e.g., thumbv6m)

--- a/crates/burn-std/src/tensor/quantization.rs
+++ b/crates/burn-std/src/tensor/quantization.rs
@@ -14,6 +14,7 @@ pub const QPARAM_ALIGN: usize = core::mem::align_of::<f32>();
 
 use alloc::vec::Vec;
 use core::any::TypeId;
+use cubecl_common::e4m3;
 use num_traits::PrimInt;
 use serde::{Deserialize, Serialize};
 
@@ -225,6 +226,24 @@ impl QuantizedBytes {
     }
 }
 
+/// Round a scale to the nearest value representable by the param dtype.
+///
+/// Backends that keep scales in `f32` must apply this when quantizing, so that the scale they
+/// divide by is the one that will actually be stored. Otherwise a tensor dequantizes differently
+/// after a save/load round trip.
+///
+/// Narrow params can round a small scale down to zero, so callers that guard against a zero or
+/// non-finite scale must do so *after* this, not before.
+pub fn round_to_param(scale: f32, param: QuantParam) -> f32 {
+    match param {
+        QuantParam::F32 => scale,
+        QuantParam::F16 => crate::f16::from_f32(scale).to_f32(),
+        QuantParam::BF16 => crate::bf16::from_f32(scale).to_f32(),
+        QuantParam::UE4M3 => e4m3::from_f32(scale).to_f32(),
+        QuantParam::UE8M0 => unimplemented!("UE8M0 scales are not yet supported"),
+    }
+}
+
 /// Bytes per stored scale entry for the given param dtype.
 fn scale_size(param: QuantParam) -> usize {
     match param {
@@ -249,7 +268,8 @@ fn decode_scales(bytes: &[u8], param: QuantParam) -> Vec<f32> {
             .chunks_exact(2)
             .map(|c| crate::bf16::from_ne_bytes([c[0], c[1]]).to_f32())
             .collect(),
-        QuantParam::UE8M0 | QuantParam::UE4M3 => unimplemented!("Not yet supported"),
+        QuantParam::UE4M3 => bytes.iter().map(|b| e4m3::from_bits(*b).to_f32()).collect(),
+        QuantParam::UE8M0 => unimplemented!("UE8M0 scales are not yet supported"),
     }
 }
 
@@ -265,7 +285,11 @@ fn encode_scales(scales: &[f32], param: QuantParam) -> Vec<u8> {
             .iter()
             .flat_map(|s| crate::bf16::from_f32(*s).to_ne_bytes())
             .collect(),
-        QuantParam::UE8M0 | QuantParam::UE4M3 => unimplemented!("Not yet supported"),
+        QuantParam::UE4M3 => scales
+            .iter()
+            .map(|s| e4m3::from_f32(*s).to_bits())
+            .collect(),
+        QuantParam::UE8M0 => unimplemented!("UE8M0 scales are not yet supported"),
     }
 }
 
@@ -427,6 +451,74 @@ mod tests {
 
         assert_eq!(qparams.scales, vec![scale]);
 
+        assert_eq!(q_values, values);
+    }
+
+    /// Backends divide by what `round_to_param` returns, while serialization stores what
+    /// `encode_scales` produces. If the two disagreed, a tensor would dequantize differently
+    /// after a save/load round trip.
+    #[test]
+    fn round_to_param_agrees_with_the_codec() {
+        // Includes values that saturate (500), land in e4m3's subnormals (1e-3), and underflow
+        // it entirely (7.7e-4).
+        let scales = [0.5f32, 0.3, 1.0 / 3.0, 500.0, 1e-3, 7.7e-4];
+
+        for param in [
+            QuantParam::F32,
+            QuantParam::F16,
+            QuantParam::BF16,
+            QuantParam::UE4M3,
+        ] {
+            let via_codec = decode_scales(&encode_scales(&scales, param), param);
+            let via_round: Vec<f32> = scales.iter().map(|s| round_to_param(*s, param)).collect();
+
+            assert_eq!(
+                via_round, via_codec,
+                "round_to_param disagrees with the codec for {param:?}"
+            );
+        }
+    }
+
+    /// `scale_size` is what the readers use to locate the scales in the buffer, so an encoding
+    /// wider or narrower than it claims silently misreads every scale.
+    #[test]
+    fn encoded_scale_width_matches_scale_size() {
+        let scales = [0.5f32, 0.25, 0.125];
+
+        for param in [
+            QuantParam::F32,
+            QuantParam::F16,
+            QuantParam::BF16,
+            QuantParam::UE4M3,
+        ] {
+            assert_eq!(
+                encode_scales(&scales, param).len(),
+                scale_size(param) * scales.len(),
+                "encoded width disagrees with scale_size for {param:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn should_pack_unpack_ue4m3_block_scales() {
+        // Exactly representable in e4m3, so the round trip is lossless and the test pins the
+        // layout rather than the format's rounding.
+        let scales = [0.5f32, 0.125];
+        let values = vec![0i8, 25, 51, 76, 102, 127, -128, -1];
+
+        let q_bytes = QuantizedBytes::new(
+            values.clone(),
+            QuantScheme::default()
+                .with_value(QuantValue::Q8S)
+                .with_store(QuantStore::Native)
+                .with_level(QuantLevel::block([4]))
+                .with_param(QuantParam::UE4M3),
+            &scales,
+        );
+
+        let (q_values, qparams) = q_bytes.into_vec_i8();
+
+        assert_eq!(qparams.scales, scales);
         assert_eq!(q_values, values);
     }
 }


### PR DESCRIPTION
## Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

`run-checks` surfaced one failure, in the typos check rather than anything substantive. The checker
reads the "ue" in `ue4m3` as a misspelling of "use". `_typos.toml` already lists `UE4M3`, `UE8M0` and
`ue8m0`, so this was an existing gap, but an exact identifier entry does not cover compound names
like `ue4m3_err`, so the last commit adds a regex instead. Everything else passed: 2587 tests across
35 targets, plus clippy, fmt and the release build.

## Related Issues/PRs

No existing issue.

tracel-ai/cubecl#1450 fixes the `QuantParam::UE4M3` to `ElemType` mapping in cubecl. This PR does
not depend on it, nothing here calls `from_quant_param`, but that fix is needed before UE4M3 can
work on the GPU side.

#5096 changes the same line of `crates/burn-std/Cargo.toml` to enable the `fp8` feature. I matched
its placement so the two should merge cleanly, and if #5096 lands first that one line here can just
be dropped.

## Changes

Two separate things, one commit each, plus a book update and a typos config fix.

### 1. UE4M3 scale params work on CPU

`encode_scales` and `decode_scales` in burn-std handled F32, F16 and BF16 only, and both CPU
backends kept scales in f32 no matter what `QuantScheme::param` said. So setting a non-F32 param
had no real effect. A tensor quantized on CPU was computed with full precision scales and then lost
that precision when it got serialized, which means it dequantized differently after a save/load
round trip. That part is a bug fix for the existing F16 and BF16 schemes, not just groundwork for
UE4M3.

- Implemented UE4M3 in the codec using `cubecl_common::e4m3`. That is the same type
  `run_with_quant_type` already dispatches to, so host and device round scales the same way instead
  of possibly disagreeing on the last bit.
- Added `round_to_param` and applied it when quantizing in burn-ndarray and burn-flex, so a backend
  divides by the scale that will actually be stored. In flex it sits inside `validated_scale` and
  runs before the normality check, since a narrow param can round a small scale down to zero and
  that check is what has to catch it.

UE8M0 is left `unimplemented!()`. Its f32 conversions are gated behind cubecl's `float4` feature, so
supporting it would mean pulling a new dependency into burn-std for a format nothing uses yet.

F32 behaviour is unchanged because `round_to_param` is the identity there, and F32 is the default,
every existing test, and the only param the matmul path accepts today.

### 2. Quantization accuracy harness

Nothing in the repo measured quantization accuracy. The existing tests assert a round trip within a
tolerance and the benchmarks measure throughput, so there was no way to answer whether a scheme's
memory saving is worth the error it costs.

The harness reports relative Frobenius error alongside bits per element. Both numbers are needed,
because a smaller block buys accuracy but costs more scales, so only comparing error at equal bits
tells you whether something is an improvement or just a trade. Samples are generated
deterministically so a reported number is reproducible. It lives in burn-backend-tests and uses
`TestTensor`, so it measures whichever backend the crate is built against rather than only CPU.

Output on ndarray, Q8S, 64x64, at three weight magnitudes:

| level   | param | bits/el | std=1.0 | std=0.1 | std=0.02 |
| :------ | :---- | ------: | ------: | ------: | -------: |
| tensor  | f32   |   8.008 |  0.0094 |  0.0094 |   0.0094 |
| tensor  | ue4m3 |   8.002 |  0.0094 |  0.0112 |    0.976 |
| block16 | f32   |  10.000 |  0.0047 |  0.0047 |   0.0047 |
| block16 | f16   |   9.000 |  0.0047 |  0.0047 |   0.0047 |
| block16 | ue4m3 |   8.500 |  0.0145 |  0.0669 |    0.976 |
| block32 | f32   |   9.000 |  0.0054 |  0.0054 |   0.0054 |
| block32 | f16   |   8.500 |  0.0054 |  0.0054 |   0.0054 |
| block32 | ue4m3 |   8.250 |  0.0114 |  0.0509 |    0.976 |

Two things worth pointing out from that table:

- f16 block scales match f32 to five decimals while costing a full bit per element less, so f16 looks
  like a free win over the f32 default for per-block schemes.
- 8-bit block scales are not usable as-is. At a realistic weight magnitude (std 0.02) the scale
  underflows e4m3, rounds to zero, and the tensor is destroyed. This is why the table has a 0.976
  column and not a slightly worse one. The fix is normalizing scales before storing them, which is
  not in this PR.

## Testing

- 9 unit tests in burn-std, including one that checks `round_to_param` agrees with what
  `encode_scales` and `decode_scales` produce. If those two ever disagree, a tensor would dequantize
  differently after a save/load round trip, which is silent and annoying to track down.
- 15 tests in burn-flex, including a new one asserting that a UE4M3 scheme now stores a different
  scale than F32 and that it is specifically the exact scale rounded to the param. Before this change
  every param produced identical output.
- 219 quantization tests in burn-backend-tests on ndarray, which is the 217 that existed before plus
  the 2 new assertions in the harness.
- 30 burn-ndarray unit tests.
- fmt and clippy clean on burn-std, burn-flex, burn-ndarray, burn-backend and burn-backend-tests.
- `cargo check -p burn-std --no-default-features` passes, so the added `fp8` feature does not break
  the no_std build.

To see the full sweep:

```
cargo test -p burn-backend-tests --features ndarray --test tensor report_quantization_accuracy -- --ignored --nocapture
```
