### PR TITLE
fix(burn-optim): correct LBFGSConfig::init doc comment

### DIFF
--- a/crates/burn-optim/src/optim/lbfgs.rs
+++ b/crates/burn-optim/src/optim/lbfgs.rs
@@ -339,7 +339,7 @@ pub struct LBFGSConfig {
 }
 
 impl LBFGSConfig {
-    /// Initialize AdamW optimizer
+    /// Initialize LBFGS optimizer.
     ///
     /// # Returns
     ///


### PR DESCRIPTION
## What

`LBFGSConfig::init` is documented as *"Initialize AdamW optimizer"*. It builds an `LBFGS`.

```rust
impl LBFGSConfig {
    /// Initialize AdamW optimizer   // <-- wrong optimizer
    pub fn init(&self) -> LBFGS {
```

## Why

The doc comment is a copy-paste from `AdamWConfig::init`, so the rendered
[`LBFGSConfig`](https://docs.rs/burn-optim/latest/burn_optim/struct.LBFGSConfig.html)
page on docs.rs currently describes an unrelated optimizer. Same text shows up on IDE hover.

Every other optimizer config in the crate names itself correctly — this was the only outlier:

| file | doc |
|---|---|
| `adam.rs:107` | Initialize Adam optimizer. |
| `adan.rs:117` | Initialize Adan optimizer. |
| `adagrad.rs:87` | Initialize AdaGrad optimizer. |
| `adamw.rs:130` | Initialize AdamW optimizer. |
| **`lbfgs.rs:342`** | **Initialize AdamW optimizer** ← |
| `sgd.rs:50` | Initializes the SGD optimizer from the configuration. |
| `rmsprop.rs:51` | Initialize RmsProp optimizer. |

Also adds the trailing period the siblings use.

## How tested

Rebuilt the docs and diffed the generated HTML against the `AdamWConfig` page as a control:

```
$ cargo doc -p burn-optim --no-deps
$ grep -oE "Initialize [A-Za-z]+ optimizer" target/doc/burn_optim/struct.LBFGSConfig.html
Initialize LBFGS optimizer
$ grep -oE "Initialize [A-Za-z]+ optimizer" target/doc/burn_optim/struct.AdamWConfig.html
Initialize AdamW optimizer
```

`cargo fmt --check -p burn-optim` clean. Doc-comment-only change; no behavior affected.

## Related issue

None — trivial docs fix, opened directly per CONTRIBUTING's "keep it focused".