### PR TITLE
Round quantization scales up instead of to nearest

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/float/quantization/accuracy.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/quantization/accuracy.rs
@@ -136,6 +136,9 @@ fn narrow_scale_param_degrades_without_normalization() {
 /// the 8-bit one already costs something. Pinning both directions keeps the harness honest: it
 /// has to be sensitive enough to see the 8-bit loss, and not so noisy that it invents a 16-bit one.
 ///
+/// The upper bound on the 8-bit cost is what keeps `scale_to_param` rounding up. Rounding a scale
+/// to nearest instead lets a block's largest value clip, which measured several times worse.
+///
 /// Note this is not monotone in scale width. Rounding a scale can land favourably on a given
 /// sample, so f16 sitting a hair below f32 is expected and is not a signal.
 #[test]
@@ -153,14 +156,19 @@ fn error_responds_to_scale_param() {
 
     // Generous on purpose. The measured gap is near zero on the backends checked so far, but this
     // runs on every backend and float element type, and the point is only to separate
-    // "indistinguishable" from the 8-bit case below, which is worse by more than 100%.
+    // "indistinguishable" from the 8-bit case below.
     assert!(
         (f16_err - f32_err).abs() / f32_err < 0.20,
         "a 16-bit scale should be indistinguishable from f32, got f32={f32_err} f16={f16_err}"
     );
     assert!(
-        ue4m3_err > f32_err * 1.5,
-        "an 8-bit scale should cost real accuracy, got f32={f32_err} ue4m3={ue4m3_err}"
+        ue4m3_err > f32_err,
+        "an 8-bit scale should cost some accuracy, got f32={f32_err} ue4m3={ue4m3_err}"
+    );
+    assert!(
+        ue4m3_err < f32_err * 1.3,
+        "an 8-bit scale should cost only the coarser step, not a clipped block maximum, \
+         got f32={f32_err} ue4m3={ue4m3_err}"
     );
 }
 

--- a/crates/burn-backend/src/quantization/mod.rs
+++ b/crates/burn-backend/src/quantization/mod.rs
@@ -6,5 +6,5 @@ pub use scheme::*;
 
 pub use burn_std::quantization::{
     BlockSize, Calibration, QuantLevel, QuantMode, QuantParam, QuantPropagation, QuantScheme,
-    QuantStore, QuantValue, QuantizedBytes, round_to_param,
+    QuantStore, QuantValue, QuantizedBytes, scale_to_param,
 };

--- a/crates/burn-flex/src/ops/qtensor.rs
+++ b/crates/burn-flex/src/ops/qtensor.rs
@@ -10,7 +10,7 @@ use burn_backend::{
     ops::{IntTensorOps, QTensorOps},
     quantization::{
         QuantLevel, QuantParam, QuantScheme, QuantStore, QuantizationParametersPrimitive,
-        QuantizedBytes, round_to_param,
+        QuantizedBytes, scale_to_param,
     },
     tensor::{Device, FloatTensor, IntTensor, QuantizedTensor},
 };
@@ -349,11 +349,12 @@ fn block_safe_layout_op(
 /// Round the scale to the scheme's param dtype, then ensure it is finite and nonzero to avoid
 /// division by zero or NaN propagation.
 ///
-/// Rounding comes first: a narrow param can round a small scale down to zero, which the
-/// normality check then has to catch.
+/// Rounding comes first, and only an exactly zero scale is replaced: subnormals of the param are
+/// representable and carry real information for a small tensor, so substituting them would throw
+/// away what rounding up preserved.
 fn validated_scale(scale: f32, param: QuantParam) -> f32 {
-    let scale = round_to_param(scale, param);
-    if scale.is_normal() {
+    let scale = scale_to_param(scale, param);
+    if scale > 0.0 && scale.is_finite() {
         scale
     } else {
         f32::MIN_POSITIVE
@@ -509,7 +510,7 @@ mod tests {
         );
         assert_eq!(
             coarse,
-            round_to_param(exact, QuantParam::UE4M3),
+            scale_to_param(exact, QuantParam::UE4M3),
             "stored scale should be the exact scale rounded to the param"
         );
     }

--- a/crates/burn-ndarray/src/ops/qtensor.rs
+++ b/crates/burn-ndarray/src/ops/qtensor.rs
@@ -5,7 +5,7 @@ use burn_backend::{
     ops::{FloatTensorOps, QTensorOps},
     quantization::{
         QParams, QuantLevel, QuantMode, QuantPropagation, QuantScheme, QuantStore, QuantValue,
-        QuantizationParametersPrimitive, QuantizedBytes, round_to_param,
+        QuantizationParametersPrimitive, QuantizedBytes, scale_to_param,
     },
     tensor::{FloatTensor, IntTensor, QuantizedTensor},
 };
@@ -89,7 +89,7 @@ impl QTensorOps<Self> for NdArray {
         // reproduces these values instead of drifting by the param's rounding error.
         let scales: Vec<f32> = scales
             .iter::<f32>()
-            .map(|s| round_to_param(s, scheme.param))
+            .map(|s| scale_to_param(s, scheme.param))
             .collect();
 
         // Implement with ndarray instead of QuantizationStrategy?

--- a/crates/burn-std/src/tensor/quantization.rs
+++ b/crates/burn-std/src/tensor/quantization.rs
@@ -226,22 +226,44 @@ impl QuantizedBytes {
     }
 }
 
-/// Round a scale to the nearest value representable by the param dtype.
+/// Round a scale up to the smallest value representable by the param dtype that is no smaller.
 ///
 /// Backends that keep scales in `f32` must apply this when quantizing, so that the scale they
 /// divide by is the one that will actually be stored. Otherwise a tensor dequantizes differently
 /// after a save/load round trip.
 ///
-/// Narrow params can round a small scale down to zero, so callers that guard against a zero or
-/// non-finite scale must do so *after* this, not before.
-pub fn round_to_param(scale: f32, param: QuantParam) -> f32 {
-    match param {
-        QuantParam::F32 => scale,
+/// Up rather than to nearest, because a scale is derived from the largest magnitude it has to
+/// cover. Rounding down puts that value past the end of the quantized range, where it clips, which
+/// measured several times worse than the coarser step rounding up costs.
+pub fn scale_to_param(scale: f32, param: QuantParam) -> f32 {
+    let nearest = match param {
+        QuantParam::F32 => return scale,
         QuantParam::F16 => crate::f16::from_f32(scale).to_f32(),
         QuantParam::BF16 => crate::bf16::from_f32(scale).to_f32(),
         QuantParam::UE4M3 => e4m3::from_f32(scale).to_f32(),
         QuantParam::UE8M0 => unimplemented!("UE8M0 scales are not yet supported"),
+    };
+
+    if nearest >= scale || scale.is_nan() {
+        return nearest;
     }
+
+    // Positive floats are ordered by their bit pattern, so the next representable value up is the
+    // next bit pattern.
+    let next = match param {
+        QuantParam::F16 => {
+            crate::f16::from_bits(crate::f16::from_f32(nearest).to_bits() + 1).to_f32()
+        }
+        QuantParam::BF16 => {
+            crate::bf16::from_bits(crate::bf16::from_f32(nearest).to_bits() + 1).to_f32()
+        }
+        QuantParam::UE4M3 => e4m3::from_bits(e4m3::from_f32(nearest).to_bits() + 1).to_f32(),
+        QuantParam::F32 | QuantParam::UE8M0 => unreachable!(),
+    };
+
+    // Stepping off the largest finite value lands on an infinity or a NaN encoding, so the
+    // saturated value is already the best answer.
+    if next.is_finite() { next } else { nearest }
 }
 
 /// Bytes per stored scale entry for the given param dtype.
@@ -454,11 +476,11 @@ mod tests {
         assert_eq!(q_values, values);
     }
 
-    /// Backends divide by what `round_to_param` returns, while serialization stores what
-    /// `encode_scales` produces. If the two disagreed, a tensor would dequantize differently
-    /// after a save/load round trip.
+    /// Backends divide by what `scale_to_param` returns and hand that same value to
+    /// `encode_scales`. If encoding moved it, a tensor would dequantize differently after a
+    /// save/load round trip, so the codec has to leave an already-rounded scale alone.
     #[test]
-    fn round_to_param_agrees_with_the_codec() {
+    fn scale_to_param_survives_the_codec() {
         // Includes values that saturate (500), land in e4m3's subnormals (1e-3), and underflow
         // it entirely (7.7e-4).
         let scales = [0.5f32, 0.3, 1.0 / 3.0, 500.0, 1e-3, 7.7e-4];
@@ -469,13 +491,20 @@ mod tests {
             QuantParam::BF16,
             QuantParam::UE4M3,
         ] {
-            let via_codec = decode_scales(&encode_scales(&scales, param), param);
-            let via_round: Vec<f32> = scales.iter().map(|s| round_to_param(*s, param)).collect();
+            let rounded: Vec<f32> = scales.iter().map(|s| scale_to_param(*s, param)).collect();
+            let via_codec = decode_scales(&encode_scales(&rounded, param), param);
 
             assert_eq!(
-                via_round, via_codec,
-                "round_to_param disagrees with the codec for {param:?}"
+                rounded, via_codec,
+                "the codec moves a scale {param:?} can already represent"
             );
+            // 500 is past what e4m3 can hold, so it saturates rather than rounding up.
+            for (scale, rounded) in scales.iter().zip(&rounded).filter(|(s, _)| **s < 500.0) {
+                assert!(
+                    rounded >= scale,
+                    "{scale} rounded down to {rounded} for {param:?}"
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Follow-up to #5253, which added UE4M3 scale params on CPU along with the accuracy harness.

That PR introduced `round_to_param`, which rounds a scale to the nearest value its param dtype can represent. Rounding to nearest can round it *down*, and a scale is derived from the largest magnitude it has to cover, so the block's largest value then sits past the end of the quantized range and clips. Rounding up instead only makes the step slightly coarser, which costs far less.

This was not visible before #5253 for two reasons: the CPU backends ignored `scheme.param` entirely and always used f32 scales, so no scale rounding happened at all, and the effect is invisible at f32 precision anyway because consecutive f32 values are so close together. It takes both a narrow scale param and a way to measure, which is what #5253 delivered.

## Measurements

`Q8S`, 64x64 gaussian weights, relative Frobenius error, via `report_quantization_accuracy`:

| config | to nearest | up |
| ------ | ---------- | -- |
| block16 / ue4m3 | 0.01452 | 0.00512 |
| block32 / ue4m3 | 0.01144 | 0.00579 |

For scale, block16 with exact f32 scales measures 0.00467. So rounding up puts 8-bit scales within about 10% of scales costing four times the memory, where rounding to nearest was three times worse than that.

The size of the effect tracks the spacing between representable scales, so it grows as the param narrows and vanishes for f32.

## This changes behaviour

Every scheme with a narrow scale param gets more accurate. Nothing changes for f32 scales, where `scale_to_param` returns early.

Existing checkpoints are unaffected: this only changes which scale a backend picks when quantizing, not how a stored one is read. A tensor quantized before and after this will differ, the same way it would under any calibration change.

## Details

`round_to_param` becomes `scale_to_param`. The old name reads as "nearest", which is now wrong, and the new one says what the function is for: turn a computed scale into one the param can store.

It still rounds to nearest first, and steps to the next representable value only when that landed below the input. Positive floats are ordered by their bit pattern, so that step is an increment of the bits. Stepping off the largest finite value lands on an infinity or a NaN encoding, so that case keeps the saturated value.

Rounding up also means a narrow param no longer underflows a small scale to zero, since what used to round to zero now becomes the smallest subnormal. Flex's `validated_scale` was substituting `f32::MIN_POSITIVE` for anything non-normal, which would have discarded exactly what rounding up preserved, so it now only replaces a scale that is zero or not finite.

`error_responds_to_scale_param` gains an upper bound on what an 8-bit scale may cost. That bound is what holds this in place: it fails if the rounding goes back to nearest.