### PR TITLE
feat(quant)!: support two-level quantization scales

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,6 +785,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "buildid"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b8e278b5bdc31756d01d65c17662e23692e0dbaa19e65adae9b58fc4683bc09"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
+ "winapi",
+]
+
+[[package]]
 name = "built"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2224,7 +2236,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
+source = "git+https://github.com/tracel-ai/cubecl?rev=1e735584ad9ef78893448583ee7d9008a2f2a904#1e735584ad9ef78893448583ee7d9008a2f2a904"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -2241,7 +2253,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
+source = "git+https://github.com/tracel-ai/cubecl?rev=1e735584ad9ef78893448583ee7d9008a2f2a904#1e735584ad9ef78893448583ee7d9008a2f2a904"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -2265,7 +2277,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
+source = "git+https://github.com/tracel-ai/cubecl?rev=1e735584ad9ef78893448583ee7d9008a2f2a904#1e735584ad9ef78893448583ee7d9008a2f2a904"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -2296,7 +2308,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
+source = "git+https://github.com/tracel-ai/cubecl?rev=1e735584ad9ef78893448583ee7d9008a2f2a904#1e735584ad9ef78893448583ee7d9008a2f2a904"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2319,7 +2331,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
+source = "git+https://github.com/tracel-ai/cubecl?rev=1e735584ad9ef78893448583ee7d9008a2f2a904#1e735584ad9ef78893448583ee7d9008a2f2a904"
 dependencies = [
  "bytemuck",
  "crossbeam-utils",
@@ -2347,7 +2359,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
+source = "git+https://github.com/tracel-ai/cubecl?rev=1e735584ad9ef78893448583ee7d9008a2f2a904#1e735584ad9ef78893448583ee7d9008a2f2a904"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2366,7 +2378,7 @@ dependencies = [
 [[package]]
 name = "cubecl-environment"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
+source = "git+https://github.com/tracel-ai/cubecl?rev=1e735584ad9ef78893448583ee7d9008a2f2a904#1e735584ad9ef78893448583ee7d9008a2f2a904"
 dependencies = [
  "async-channel",
  "backtrace",
@@ -2401,7 +2413,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
+source = "git+https://github.com/tracel-ai/cubecl?rev=1e735584ad9ef78893448583ee7d9008a2f2a904#1e735584ad9ef78893448583ee7d9008a2f2a904"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2431,7 +2443,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
+source = "git+https://github.com/tracel-ai/cubecl?rev=1e735584ad9ef78893448583ee7d9008a2f2a904#1e735584ad9ef78893448583ee7d9008a2f2a904"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -2462,7 +2474,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
+source = "git+https://github.com/tracel-ai/cubecl?rev=1e735584ad9ef78893448583ee7d9008a2f2a904#1e735584ad9ef78893448583ee7d9008a2f2a904"
 dependencies = [
  "cubecl-common",
  "darling 0.24.0",
@@ -2480,7 +2492,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
+source = "git+https://github.com/tracel-ai/cubecl?rev=1e735584ad9ef78893448583ee7d9008a2f2a904#1e735584ad9ef78893448583ee7d9008a2f2a904"
 dependencies = [
  "darling 0.24.0",
  "inflections",
@@ -2492,7 +2504,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
+source = "git+https://github.com/tracel-ai/cubecl?rev=1e735584ad9ef78893448583ee7d9008a2f2a904#1e735584ad9ef78893448583ee7d9008a2f2a904"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2514,9 +2526,10 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
+source = "git+https://github.com/tracel-ai/cubecl?rev=1e735584ad9ef78893448583ee7d9008a2f2a904#1e735584ad9ef78893448583ee7d9008a2f2a904"
 dependencies = [
  "ahash",
+ "buildid",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
@@ -2544,7 +2557,7 @@ dependencies = [
 [[package]]
 name = "cubecl-spirv"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
+source = "git+https://github.com/tracel-ai/cubecl?rev=1e735584ad9ef78893448583ee7d9008a2f2a904#1e735584ad9ef78893448583ee7d9008a2f2a904"
 dependencies = [
  "bitflags 2.13.1",
  "cubecl-common",
@@ -2567,7 +2580,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
+source = "git+https://github.com/tracel-ai/cubecl?rev=1e735584ad9ef78893448583ee7d9008a2f2a904#1e735584ad9ef78893448583ee7d9008a2f2a904"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2584,7 +2597,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
+source = "git+https://github.com/tracel-ai/cubecl?rev=1e735584ad9ef78893448583ee7d9008a2f2a904#1e735584ad9ef78893448583ee7d9008a2f2a904"
 dependencies = [
  "ash",
  "bytemuck",
@@ -2619,7 +2632,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
+source = "git+https://github.com/tracel-ai/cubecl?rev=1e735584ad9ef78893448583ee7d9008a2f2a904#1e735584ad9ef78893448583ee7d9008a2f2a904"
 dependencies = [
  "derive-new",
  "serde",
@@ -2629,7 +2642,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=c4c2c4d1794a6922280b24209b285b7d08c3f9d2#c4c2c4d1794a6922280b24209b285b7d08c3f9d2"
+source = "git+https://github.com/tracel-ai/cubek?rev=83599b4d456ae45710b17e240983153768fcc9af#83599b4d456ae45710b17e240983153768fcc9af"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2647,7 +2660,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=c4c2c4d1794a6922280b24209b285b7d08c3f9d2#c4c2c4d1794a6922280b24209b285b7d08c3f9d2"
+source = "git+https://github.com/tracel-ai/cubek?rev=83599b4d456ae45710b17e240983153768fcc9af#83599b4d456ae45710b17e240983153768fcc9af"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2661,7 +2674,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=c4c2c4d1794a6922280b24209b285b7d08c3f9d2#c4c2c4d1794a6922280b24209b285b7d08c3f9d2"
+source = "git+https://github.com/tracel-ai/cubek?rev=83599b4d456ae45710b17e240983153768fcc9af#83599b4d456ae45710b17e240983153768fcc9af"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2677,7 +2690,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=c4c2c4d1794a6922280b24209b285b7d08c3f9d2#c4c2c4d1794a6922280b24209b285b7d08c3f9d2"
+source = "git+https://github.com/tracel-ai/cubek?rev=83599b4d456ae45710b17e240983153768fcc9af#83599b4d456ae45710b17e240983153768fcc9af"
 dependencies = [
  "cubecl",
 ]
@@ -2685,7 +2698,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=c4c2c4d1794a6922280b24209b285b7d08c3f9d2#c4c2c4d1794a6922280b24209b285b7d08c3f9d2"
+source = "git+https://github.com/tracel-ai/cubek?rev=83599b4d456ae45710b17e240983153768fcc9af#83599b4d456ae45710b17e240983153768fcc9af"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2697,7 +2710,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=c4c2c4d1794a6922280b24209b285b7d08c3f9d2#c4c2c4d1794a6922280b24209b285b7d08c3f9d2"
+source = "git+https://github.com/tracel-ai/cubek?rev=83599b4d456ae45710b17e240983153768fcc9af#83599b4d456ae45710b17e240983153768fcc9af"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2711,7 +2724,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=c4c2c4d1794a6922280b24209b285b7d08c3f9d2#c4c2c4d1794a6922280b24209b285b7d08c3f9d2"
+source = "git+https://github.com/tracel-ai/cubek?rev=83599b4d456ae45710b17e240983153768fcc9af#83599b4d456ae45710b17e240983153768fcc9af"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2721,7 +2734,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=c4c2c4d1794a6922280b24209b285b7d08c3f9d2#c4c2c4d1794a6922280b24209b285b7d08c3f9d2"
+source = "git+https://github.com/tracel-ai/cubek?rev=83599b4d456ae45710b17e240983153768fcc9af#83599b4d456ae45710b17e240983153768fcc9af"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2733,7 +2746,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=c4c2c4d1794a6922280b24209b285b7d08c3f9d2#c4c2c4d1794a6922280b24209b285b7d08c3f9d2"
+source = "git+https://github.com/tracel-ai/cubek?rev=83599b4d456ae45710b17e240983153768fcc9af#83599b4d456ae45710b17e240983153768fcc9af"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2747,7 +2760,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=c4c2c4d1794a6922280b24209b285b7d08c3f9d2#c4c2c4d1794a6922280b24209b285b7d08c3f9d2"
+source = "git+https://github.com/tracel-ai/cubek?rev=83599b4d456ae45710b17e240983153768fcc9af#83599b4d456ae45710b17e240983153768fcc9af"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2760,7 +2773,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=c4c2c4d1794a6922280b24209b285b7d08c3f9d2#c4c2c4d1794a6922280b24209b285b7d08c3f9d2"
+source = "git+https://github.com/tracel-ai/cubek?rev=83599b4d456ae45710b17e240983153768fcc9af#83599b4d456ae45710b17e240983153768fcc9af"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2770,7 +2783,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=c4c2c4d1794a6922280b24209b285b7d08c3f9d2#c4c2c4d1794a6922280b24209b285b7d08c3f9d2"
+source = "git+https://github.com/tracel-ai/cubek?rev=83599b4d456ae45710b17e240983153768fcc9af#83599b4d456ae45710b17e240983153768fcc9af"
 dependencies = [
  "bytemuck",
  "cubecl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2224,7 +2224,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -2241,7 +2241,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -2265,7 +2265,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -2296,7 +2296,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2319,7 +2319,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "bytemuck",
  "crossbeam-utils",
@@ -2347,7 +2347,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2366,7 +2366,7 @@ dependencies = [
 [[package]]
 name = "cubecl-environment"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "async-channel",
  "backtrace",
@@ -2401,7 +2401,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -2462,7 +2462,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "cubecl-common",
  "darling 0.23.0",
@@ -2480,7 +2480,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "darling 0.23.0",
  "inflections",
@@ -2492,7 +2492,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2514,7 +2514,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2543,7 +2543,7 @@ dependencies = [
 [[package]]
 name = "cubecl-spirv"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "bitflags 2.13.1",
  "cubecl-common",
@@ -2566,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2583,7 +2583,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "ash",
  "bytemuck",
@@ -2618,7 +2618,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "derive-new",
  "serde",
@@ -2628,7 +2628,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=143b427cd759440b7c70fbb2cf333ad182b1d48c#143b427cd759440b7c70fbb2cf333ad182b1d48c"
+source = "git+https://github.com/tracel-ai/cubek?rev=863bead5331a204b2383c7660b331719f181c38e#863bead5331a204b2383c7660b331719f181c38e"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2646,7 +2646,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=143b427cd759440b7c70fbb2cf333ad182b1d48c#143b427cd759440b7c70fbb2cf333ad182b1d48c"
+source = "git+https://github.com/tracel-ai/cubek?rev=863bead5331a204b2383c7660b331719f181c38e#863bead5331a204b2383c7660b331719f181c38e"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2660,7 +2660,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=143b427cd759440b7c70fbb2cf333ad182b1d48c#143b427cd759440b7c70fbb2cf333ad182b1d48c"
+source = "git+https://github.com/tracel-ai/cubek?rev=863bead5331a204b2383c7660b331719f181c38e#863bead5331a204b2383c7660b331719f181c38e"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2676,7 +2676,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=143b427cd759440b7c70fbb2cf333ad182b1d48c#143b427cd759440b7c70fbb2cf333ad182b1d48c"
+source = "git+https://github.com/tracel-ai/cubek?rev=863bead5331a204b2383c7660b331719f181c38e#863bead5331a204b2383c7660b331719f181c38e"
 dependencies = [
  "cubecl",
 ]
@@ -2684,7 +2684,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=143b427cd759440b7c70fbb2cf333ad182b1d48c#143b427cd759440b7c70fbb2cf333ad182b1d48c"
+source = "git+https://github.com/tracel-ai/cubek?rev=863bead5331a204b2383c7660b331719f181c38e#863bead5331a204b2383c7660b331719f181c38e"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2696,7 +2696,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=143b427cd759440b7c70fbb2cf333ad182b1d48c#143b427cd759440b7c70fbb2cf333ad182b1d48c"
+source = "git+https://github.com/tracel-ai/cubek?rev=863bead5331a204b2383c7660b331719f181c38e#863bead5331a204b2383c7660b331719f181c38e"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2710,7 +2710,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=143b427cd759440b7c70fbb2cf333ad182b1d48c#143b427cd759440b7c70fbb2cf333ad182b1d48c"
+source = "git+https://github.com/tracel-ai/cubek?rev=863bead5331a204b2383c7660b331719f181c38e#863bead5331a204b2383c7660b331719f181c38e"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2720,7 +2720,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=143b427cd759440b7c70fbb2cf333ad182b1d48c#143b427cd759440b7c70fbb2cf333ad182b1d48c"
+source = "git+https://github.com/tracel-ai/cubek?rev=863bead5331a204b2383c7660b331719f181c38e#863bead5331a204b2383c7660b331719f181c38e"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2732,7 +2732,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=143b427cd759440b7c70fbb2cf333ad182b1d48c#143b427cd759440b7c70fbb2cf333ad182b1d48c"
+source = "git+https://github.com/tracel-ai/cubek?rev=863bead5331a204b2383c7660b331719f181c38e#863bead5331a204b2383c7660b331719f181c38e"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2746,7 +2746,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=143b427cd759440b7c70fbb2cf333ad182b1d48c#143b427cd759440b7c70fbb2cf333ad182b1d48c"
+source = "git+https://github.com/tracel-ai/cubek?rev=863bead5331a204b2383c7660b331719f181c38e#863bead5331a204b2383c7660b331719f181c38e"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2759,7 +2759,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=143b427cd759440b7c70fbb2cf333ad182b1d48c#143b427cd759440b7c70fbb2cf333ad182b1d48c"
+source = "git+https://github.com/tracel-ai/cubek?rev=863bead5331a204b2383c7660b331719f181c38e#863bead5331a204b2383c7660b331719f181c38e"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2769,7 +2769,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=143b427cd759440b7c70fbb2cf333ad182b1d48c#143b427cd759440b7c70fbb2cf333ad182b1d48c"
+source = "git+https://github.com/tracel-ai/cubek?rev=863bead5331a204b2383c7660b331719f181c38e#863bead5331a204b2383c7660b331719f181c38e"
 dependencies = [
  "bytemuck",
  "cubecl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2224,7 +2224,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -2241,7 +2241,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -2265,7 +2265,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -2296,7 +2296,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2319,7 +2319,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
 dependencies = [
  "bytemuck",
  "crossbeam-utils",
@@ -2347,7 +2347,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2366,7 +2366,7 @@ dependencies = [
 [[package]]
 name = "cubecl-environment"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
 dependencies = [
  "async-channel",
  "backtrace",
@@ -2401,7 +2401,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -2462,7 +2462,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
 dependencies = [
  "cubecl-common",
  "darling 0.23.0",
@@ -2480,7 +2480,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
 dependencies = [
  "darling 0.23.0",
  "inflections",
@@ -2492,7 +2492,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2514,7 +2514,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2543,7 +2543,7 @@ dependencies = [
 [[package]]
 name = "cubecl-spirv"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
 dependencies = [
  "bitflags 2.13.1",
  "cubecl-common",
@@ -2566,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2583,7 +2583,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
 dependencies = [
  "ash",
  "bytemuck",
@@ -2618,7 +2618,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
 dependencies = [
  "derive-new",
  "serde",
@@ -2628,7 +2628,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=e60610d775a9e2193974ebd6521685ebd2d639ad#e60610d775a9e2193974ebd6521685ebd2d639ad"
+source = "git+https://github.com/tracel-ai/cubek?rev=c755c40271c5f6aafb9a9037e1e5ce24e21f254b#c755c40271c5f6aafb9a9037e1e5ce24e21f254b"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2646,7 +2646,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=e60610d775a9e2193974ebd6521685ebd2d639ad#e60610d775a9e2193974ebd6521685ebd2d639ad"
+source = "git+https://github.com/tracel-ai/cubek?rev=c755c40271c5f6aafb9a9037e1e5ce24e21f254b#c755c40271c5f6aafb9a9037e1e5ce24e21f254b"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2660,7 +2660,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=e60610d775a9e2193974ebd6521685ebd2d639ad#e60610d775a9e2193974ebd6521685ebd2d639ad"
+source = "git+https://github.com/tracel-ai/cubek?rev=c755c40271c5f6aafb9a9037e1e5ce24e21f254b#c755c40271c5f6aafb9a9037e1e5ce24e21f254b"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2676,7 +2676,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=e60610d775a9e2193974ebd6521685ebd2d639ad#e60610d775a9e2193974ebd6521685ebd2d639ad"
+source = "git+https://github.com/tracel-ai/cubek?rev=c755c40271c5f6aafb9a9037e1e5ce24e21f254b#c755c40271c5f6aafb9a9037e1e5ce24e21f254b"
 dependencies = [
  "cubecl",
 ]
@@ -2684,7 +2684,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=e60610d775a9e2193974ebd6521685ebd2d639ad#e60610d775a9e2193974ebd6521685ebd2d639ad"
+source = "git+https://github.com/tracel-ai/cubek?rev=c755c40271c5f6aafb9a9037e1e5ce24e21f254b#c755c40271c5f6aafb9a9037e1e5ce24e21f254b"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2696,7 +2696,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=e60610d775a9e2193974ebd6521685ebd2d639ad#e60610d775a9e2193974ebd6521685ebd2d639ad"
+source = "git+https://github.com/tracel-ai/cubek?rev=c755c40271c5f6aafb9a9037e1e5ce24e21f254b#c755c40271c5f6aafb9a9037e1e5ce24e21f254b"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2710,7 +2710,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=e60610d775a9e2193974ebd6521685ebd2d639ad#e60610d775a9e2193974ebd6521685ebd2d639ad"
+source = "git+https://github.com/tracel-ai/cubek?rev=c755c40271c5f6aafb9a9037e1e5ce24e21f254b#c755c40271c5f6aafb9a9037e1e5ce24e21f254b"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2720,7 +2720,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=e60610d775a9e2193974ebd6521685ebd2d639ad#e60610d775a9e2193974ebd6521685ebd2d639ad"
+source = "git+https://github.com/tracel-ai/cubek?rev=c755c40271c5f6aafb9a9037e1e5ce24e21f254b#c755c40271c5f6aafb9a9037e1e5ce24e21f254b"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2732,7 +2732,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=e60610d775a9e2193974ebd6521685ebd2d639ad#e60610d775a9e2193974ebd6521685ebd2d639ad"
+source = "git+https://github.com/tracel-ai/cubek?rev=c755c40271c5f6aafb9a9037e1e5ce24e21f254b#c755c40271c5f6aafb9a9037e1e5ce24e21f254b"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2746,7 +2746,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=e60610d775a9e2193974ebd6521685ebd2d639ad#e60610d775a9e2193974ebd6521685ebd2d639ad"
+source = "git+https://github.com/tracel-ai/cubek?rev=c755c40271c5f6aafb9a9037e1e5ce24e21f254b#c755c40271c5f6aafb9a9037e1e5ce24e21f254b"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2759,7 +2759,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=e60610d775a9e2193974ebd6521685ebd2d639ad#e60610d775a9e2193974ebd6521685ebd2d639ad"
+source = "git+https://github.com/tracel-ai/cubek?rev=c755c40271c5f6aafb9a9037e1e5ce24e21f254b#c755c40271c5f6aafb9a9037e1e5ce24e21f254b"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2769,7 +2769,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=e60610d775a9e2193974ebd6521685ebd2d639ad#e60610d775a9e2193974ebd6521685ebd2d639ad"
+source = "git+https://github.com/tracel-ai/cubek?rev=c755c40271c5f6aafb9a9037e1e5ce24e21f254b#c755c40271c5f6aafb9a9037e1e5ce24e21f254b"
 dependencies = [
  "bytemuck",
  "cubecl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2628,7 +2628,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=cc66d28e43f42ebf28de43885e9fc34c13d0c2e1#cc66d28e43f42ebf28de43885e9fc34c13d0c2e1"
+source = "git+https://github.com/tracel-ai/cubek?rev=143b427cd759440b7c70fbb2cf333ad182b1d48c#143b427cd759440b7c70fbb2cf333ad182b1d48c"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2646,7 +2646,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=cc66d28e43f42ebf28de43885e9fc34c13d0c2e1#cc66d28e43f42ebf28de43885e9fc34c13d0c2e1"
+source = "git+https://github.com/tracel-ai/cubek?rev=143b427cd759440b7c70fbb2cf333ad182b1d48c#143b427cd759440b7c70fbb2cf333ad182b1d48c"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2660,7 +2660,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=cc66d28e43f42ebf28de43885e9fc34c13d0c2e1#cc66d28e43f42ebf28de43885e9fc34c13d0c2e1"
+source = "git+https://github.com/tracel-ai/cubek?rev=143b427cd759440b7c70fbb2cf333ad182b1d48c#143b427cd759440b7c70fbb2cf333ad182b1d48c"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2676,7 +2676,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=cc66d28e43f42ebf28de43885e9fc34c13d0c2e1#cc66d28e43f42ebf28de43885e9fc34c13d0c2e1"
+source = "git+https://github.com/tracel-ai/cubek?rev=143b427cd759440b7c70fbb2cf333ad182b1d48c#143b427cd759440b7c70fbb2cf333ad182b1d48c"
 dependencies = [
  "cubecl",
 ]
@@ -2684,7 +2684,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=cc66d28e43f42ebf28de43885e9fc34c13d0c2e1#cc66d28e43f42ebf28de43885e9fc34c13d0c2e1"
+source = "git+https://github.com/tracel-ai/cubek?rev=143b427cd759440b7c70fbb2cf333ad182b1d48c#143b427cd759440b7c70fbb2cf333ad182b1d48c"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2696,7 +2696,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=cc66d28e43f42ebf28de43885e9fc34c13d0c2e1#cc66d28e43f42ebf28de43885e9fc34c13d0c2e1"
+source = "git+https://github.com/tracel-ai/cubek?rev=143b427cd759440b7c70fbb2cf333ad182b1d48c#143b427cd759440b7c70fbb2cf333ad182b1d48c"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2710,7 +2710,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=cc66d28e43f42ebf28de43885e9fc34c13d0c2e1#cc66d28e43f42ebf28de43885e9fc34c13d0c2e1"
+source = "git+https://github.com/tracel-ai/cubek?rev=143b427cd759440b7c70fbb2cf333ad182b1d48c#143b427cd759440b7c70fbb2cf333ad182b1d48c"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2720,7 +2720,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=cc66d28e43f42ebf28de43885e9fc34c13d0c2e1#cc66d28e43f42ebf28de43885e9fc34c13d0c2e1"
+source = "git+https://github.com/tracel-ai/cubek?rev=143b427cd759440b7c70fbb2cf333ad182b1d48c#143b427cd759440b7c70fbb2cf333ad182b1d48c"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2732,7 +2732,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=cc66d28e43f42ebf28de43885e9fc34c13d0c2e1#cc66d28e43f42ebf28de43885e9fc34c13d0c2e1"
+source = "git+https://github.com/tracel-ai/cubek?rev=143b427cd759440b7c70fbb2cf333ad182b1d48c#143b427cd759440b7c70fbb2cf333ad182b1d48c"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2746,7 +2746,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=cc66d28e43f42ebf28de43885e9fc34c13d0c2e1#cc66d28e43f42ebf28de43885e9fc34c13d0c2e1"
+source = "git+https://github.com/tracel-ai/cubek?rev=143b427cd759440b7c70fbb2cf333ad182b1d48c#143b427cd759440b7c70fbb2cf333ad182b1d48c"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2759,7 +2759,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=cc66d28e43f42ebf28de43885e9fc34c13d0c2e1#cc66d28e43f42ebf28de43885e9fc34c13d0c2e1"
+source = "git+https://github.com/tracel-ai/cubek?rev=143b427cd759440b7c70fbb2cf333ad182b1d48c#143b427cd759440b7c70fbb2cf333ad182b1d48c"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2769,7 +2769,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=cc66d28e43f42ebf28de43885e9fc34c13d0c2e1#cc66d28e43f42ebf28de43885e9fc34c13d0c2e1"
+source = "git+https://github.com/tracel-ai/cubek?rev=143b427cd759440b7c70fbb2cf333ad182b1d48c#143b427cd759440b7c70fbb2cf333ad182b1d48c"
 dependencies = [
  "bytemuck",
  "cubecl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,9 +758,9 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -2224,7 +2224,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -2241,7 +2241,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -2265,7 +2265,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -2296,7 +2296,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2319,7 +2319,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
 dependencies = [
  "bytemuck",
  "crossbeam-utils",
@@ -2347,7 +2347,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2366,7 +2366,7 @@ dependencies = [
 [[package]]
 name = "cubecl-environment"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
 dependencies = [
  "async-channel",
  "backtrace",
@@ -2401,7 +2401,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -2462,37 +2462,37 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
 dependencies = [
  "cubecl-common",
- "darling 0.23.0",
+ "darling 0.24.0",
  "derive-new",
  "derive_more",
  "ident_case",
  "inflections",
  "itertools 0.15.0",
- "prettyplease",
+ "prettyplease 0.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.24.0",
  "inflections",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2514,7 +2514,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2538,12 +2538,13 @@ dependencies = [
  "thiserror 2.0.20",
  "toml 1.1.4+spec-1.1.0",
  "tracing",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "cubecl-spirv"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
 dependencies = [
  "bitflags 2.13.1",
  "cubecl-common",
@@ -2566,7 +2567,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2583,7 +2584,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
 dependencies = [
  "ash",
  "bytemuck",
@@ -2618,7 +2619,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=6906371fe870ed609beaa9860f8692ac5cce8202#6906371fe870ed609beaa9860f8692ac5cce8202"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7ca428f71335d2876861a8628b637149eed9abff#7ca428f71335d2876861a8628b637149eed9abff"
 dependencies = [
  "derive-new",
  "serde",
@@ -2628,7 +2629,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=c755c40271c5f6aafb9a9037e1e5ce24e21f254b#c755c40271c5f6aafb9a9037e1e5ce24e21f254b"
+source = "git+https://github.com/tracel-ai/cubek?rev=c4c2c4d1794a6922280b24209b285b7d08c3f9d2#c4c2c4d1794a6922280b24209b285b7d08c3f9d2"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2646,7 +2647,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=c755c40271c5f6aafb9a9037e1e5ce24e21f254b#c755c40271c5f6aafb9a9037e1e5ce24e21f254b"
+source = "git+https://github.com/tracel-ai/cubek?rev=c4c2c4d1794a6922280b24209b285b7d08c3f9d2#c4c2c4d1794a6922280b24209b285b7d08c3f9d2"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2660,7 +2661,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=c755c40271c5f6aafb9a9037e1e5ce24e21f254b#c755c40271c5f6aafb9a9037e1e5ce24e21f254b"
+source = "git+https://github.com/tracel-ai/cubek?rev=c4c2c4d1794a6922280b24209b285b7d08c3f9d2#c4c2c4d1794a6922280b24209b285b7d08c3f9d2"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2676,7 +2677,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=c755c40271c5f6aafb9a9037e1e5ce24e21f254b#c755c40271c5f6aafb9a9037e1e5ce24e21f254b"
+source = "git+https://github.com/tracel-ai/cubek?rev=c4c2c4d1794a6922280b24209b285b7d08c3f9d2#c4c2c4d1794a6922280b24209b285b7d08c3f9d2"
 dependencies = [
  "cubecl",
 ]
@@ -2684,7 +2685,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=c755c40271c5f6aafb9a9037e1e5ce24e21f254b#c755c40271c5f6aafb9a9037e1e5ce24e21f254b"
+source = "git+https://github.com/tracel-ai/cubek?rev=c4c2c4d1794a6922280b24209b285b7d08c3f9d2#c4c2c4d1794a6922280b24209b285b7d08c3f9d2"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2696,7 +2697,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=c755c40271c5f6aafb9a9037e1e5ce24e21f254b#c755c40271c5f6aafb9a9037e1e5ce24e21f254b"
+source = "git+https://github.com/tracel-ai/cubek?rev=c4c2c4d1794a6922280b24209b285b7d08c3f9d2#c4c2c4d1794a6922280b24209b285b7d08c3f9d2"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2710,7 +2711,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=c755c40271c5f6aafb9a9037e1e5ce24e21f254b#c755c40271c5f6aafb9a9037e1e5ce24e21f254b"
+source = "git+https://github.com/tracel-ai/cubek?rev=c4c2c4d1794a6922280b24209b285b7d08c3f9d2#c4c2c4d1794a6922280b24209b285b7d08c3f9d2"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2720,7 +2721,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=c755c40271c5f6aafb9a9037e1e5ce24e21f254b#c755c40271c5f6aafb9a9037e1e5ce24e21f254b"
+source = "git+https://github.com/tracel-ai/cubek?rev=c4c2c4d1794a6922280b24209b285b7d08c3f9d2#c4c2c4d1794a6922280b24209b285b7d08c3f9d2"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2732,7 +2733,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=c755c40271c5f6aafb9a9037e1e5ce24e21f254b#c755c40271c5f6aafb9a9037e1e5ce24e21f254b"
+source = "git+https://github.com/tracel-ai/cubek?rev=c4c2c4d1794a6922280b24209b285b7d08c3f9d2#c4c2c4d1794a6922280b24209b285b7d08c3f9d2"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2746,7 +2747,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=c755c40271c5f6aafb9a9037e1e5ce24e21f254b#c755c40271c5f6aafb9a9037e1e5ce24e21f254b"
+source = "git+https://github.com/tracel-ai/cubek?rev=c4c2c4d1794a6922280b24209b285b7d08c3f9d2#c4c2c4d1794a6922280b24209b285b7d08c3f9d2"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2759,7 +2760,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=c755c40271c5f6aafb9a9037e1e5ce24e21f254b#c755c40271c5f6aafb9a9037e1e5ce24e21f254b"
+source = "git+https://github.com/tracel-ai/cubek?rev=c4c2c4d1794a6922280b24209b285b7d08c3f9d2#c4c2c4d1794a6922280b24209b285b7d08c3f9d2"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2769,7 +2770,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=c755c40271c5f6aafb9a9037e1e5ce24e21f254b#c755c40271c5f6aafb9a9037e1e5ce24e21f254b"
+source = "git+https://github.com/tracel-ai/cubek?rev=c4c2c4d1794a6922280b24209b285b7d08c3f9d2#c4c2c4d1794a6922280b24209b285b7d08c3f9d2"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2912,16 +2913,6 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
-dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
@@ -2959,19 +2950,6 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
-dependencies = [
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "darling_core"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
@@ -3001,17 +2979,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
-dependencies = [
- "darling_core 0.23.0",
  "quote",
  "syn 2.0.119",
 ]
@@ -4445,6 +4412,10 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hashbrown"
@@ -6953,15 +6924,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-float"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7311,7 +7273,7 @@ dependencies = [
  "combine",
  "downcast-rs",
  "dyn-clone",
- "hashbrown 0.17.1",
+ "hashbrown 0.14.5",
  "hi_sparse_bitset",
  "indexmap",
  "inventory",
@@ -7324,7 +7286,7 @@ dependencies = [
  "rustc_apfloat",
  "slotmap",
  "smallvec",
- "spin 0.12.2",
+ "spin 0.11.1",
  "thiserror 2.0.20",
  "utf8-chars",
 ]
@@ -8143,6 +8105,16 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bfe0f4c752e450fc2faf62654f1c134747922825d5b04ca717b8874f41a40c0"
+dependencies = [
+ "proc-macro2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -10152,7 +10124,7 @@ dependencies = [
  "nix 0.29.0",
  "num-derive",
  "num-traits",
- "ordered-float 4.6.0",
+ "ordered-float",
  "pest",
  "pest_derive",
  "phf 0.11.3",
@@ -11359,7 +11331,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
 dependencies = [
  "log",
- "ordered-float 4.6.0",
+ "ordered-float",
  "strsim",
  "thiserror 1.0.69",
  "wezterm-dynamic-derive",
@@ -11522,7 +11494,7 @@ dependencies = [
  "objc2-metal",
  "objc2-quartz-core",
  "once_cell",
- "ordered-float 5.3.0",
+ "ordered-float",
  "parking_lot",
  "portable-atomic",
  "portable-atomic-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2628,7 +2628,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=863bead5331a204b2383c7660b331719f181c38e#863bead5331a204b2383c7660b331719f181c38e"
+source = "git+https://github.com/tracel-ai/cubek?rev=e60610d775a9e2193974ebd6521685ebd2d639ad#e60610d775a9e2193974ebd6521685ebd2d639ad"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2646,7 +2646,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=863bead5331a204b2383c7660b331719f181c38e#863bead5331a204b2383c7660b331719f181c38e"
+source = "git+https://github.com/tracel-ai/cubek?rev=e60610d775a9e2193974ebd6521685ebd2d639ad#e60610d775a9e2193974ebd6521685ebd2d639ad"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2660,7 +2660,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=863bead5331a204b2383c7660b331719f181c38e#863bead5331a204b2383c7660b331719f181c38e"
+source = "git+https://github.com/tracel-ai/cubek?rev=e60610d775a9e2193974ebd6521685ebd2d639ad#e60610d775a9e2193974ebd6521685ebd2d639ad"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2676,7 +2676,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=863bead5331a204b2383c7660b331719f181c38e#863bead5331a204b2383c7660b331719f181c38e"
+source = "git+https://github.com/tracel-ai/cubek?rev=e60610d775a9e2193974ebd6521685ebd2d639ad#e60610d775a9e2193974ebd6521685ebd2d639ad"
 dependencies = [
  "cubecl",
 ]
@@ -2684,7 +2684,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=863bead5331a204b2383c7660b331719f181c38e#863bead5331a204b2383c7660b331719f181c38e"
+source = "git+https://github.com/tracel-ai/cubek?rev=e60610d775a9e2193974ebd6521685ebd2d639ad#e60610d775a9e2193974ebd6521685ebd2d639ad"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2696,7 +2696,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=863bead5331a204b2383c7660b331719f181c38e#863bead5331a204b2383c7660b331719f181c38e"
+source = "git+https://github.com/tracel-ai/cubek?rev=e60610d775a9e2193974ebd6521685ebd2d639ad#e60610d775a9e2193974ebd6521685ebd2d639ad"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2710,7 +2710,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=863bead5331a204b2383c7660b331719f181c38e#863bead5331a204b2383c7660b331719f181c38e"
+source = "git+https://github.com/tracel-ai/cubek?rev=e60610d775a9e2193974ebd6521685ebd2d639ad#e60610d775a9e2193974ebd6521685ebd2d639ad"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2720,7 +2720,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=863bead5331a204b2383c7660b331719f181c38e#863bead5331a204b2383c7660b331719f181c38e"
+source = "git+https://github.com/tracel-ai/cubek?rev=e60610d775a9e2193974ebd6521685ebd2d639ad#e60610d775a9e2193974ebd6521685ebd2d639ad"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2732,7 +2732,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=863bead5331a204b2383c7660b331719f181c38e#863bead5331a204b2383c7660b331719f181c38e"
+source = "git+https://github.com/tracel-ai/cubek?rev=e60610d775a9e2193974ebd6521685ebd2d639ad#e60610d775a9e2193974ebd6521685ebd2d639ad"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2746,7 +2746,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=863bead5331a204b2383c7660b331719f181c38e#863bead5331a204b2383c7660b331719f181c38e"
+source = "git+https://github.com/tracel-ai/cubek?rev=e60610d775a9e2193974ebd6521685ebd2d639ad#e60610d775a9e2193974ebd6521685ebd2d639ad"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2759,7 +2759,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=863bead5331a204b2383c7660b331719f181c38e#863bead5331a204b2383c7660b331719f181c38e"
+source = "git+https://github.com/tracel-ai/cubek?rev=e60610d775a9e2193974ebd6521685ebd2d639ad#e60610d775a9e2193974ebd6521685ebd2d639ad"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2769,7 +2769,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=863bead5331a204b2383c7660b331719f181c38e#863bead5331a204b2383c7660b331719f181c38e"
+source = "git+https://github.com/tracel-ai/cubek?rev=e60610d775a9e2193974ebd6521685ebd2d639ad#e60610d775a9e2193974ebd6521685ebd2d639ad"
 dependencies = [
  "bytemuck",
  "cubecl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2224,7 +2224,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -2241,7 +2241,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -2265,7 +2265,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -2296,7 +2296,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2319,7 +2319,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "bytemuck",
  "crossbeam-utils",
@@ -2347,7 +2347,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2366,7 +2366,7 @@ dependencies = [
 [[package]]
 name = "cubecl-environment"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "async-channel",
  "backtrace",
@@ -2401,7 +2401,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -2462,7 +2462,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "cubecl-common",
  "darling 0.23.0",
@@ -2480,7 +2480,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "darling 0.23.0",
  "inflections",
@@ -2492,7 +2492,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2514,7 +2514,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2543,7 +2543,7 @@ dependencies = [
 [[package]]
 name = "cubecl-spirv"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "bitflags 2.13.1",
  "cubecl-common",
@@ -2566,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2583,7 +2583,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "ash",
  "bytemuck",
@@ -2618,7 +2618,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "derive-new",
  "serde",
@@ -2628,7 +2628,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=93a278260f55fb693c5068be1fc6def7786ca810#93a278260f55fb693c5068be1fc6def7786ca810"
+source = "git+https://github.com/tracel-ai/cubek?rev=cc66d28e43f42ebf28de43885e9fc34c13d0c2e1#cc66d28e43f42ebf28de43885e9fc34c13d0c2e1"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2646,7 +2646,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=93a278260f55fb693c5068be1fc6def7786ca810#93a278260f55fb693c5068be1fc6def7786ca810"
+source = "git+https://github.com/tracel-ai/cubek?rev=cc66d28e43f42ebf28de43885e9fc34c13d0c2e1#cc66d28e43f42ebf28de43885e9fc34c13d0c2e1"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2660,7 +2660,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=93a278260f55fb693c5068be1fc6def7786ca810#93a278260f55fb693c5068be1fc6def7786ca810"
+source = "git+https://github.com/tracel-ai/cubek?rev=cc66d28e43f42ebf28de43885e9fc34c13d0c2e1#cc66d28e43f42ebf28de43885e9fc34c13d0c2e1"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2676,7 +2676,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=93a278260f55fb693c5068be1fc6def7786ca810#93a278260f55fb693c5068be1fc6def7786ca810"
+source = "git+https://github.com/tracel-ai/cubek?rev=cc66d28e43f42ebf28de43885e9fc34c13d0c2e1#cc66d28e43f42ebf28de43885e9fc34c13d0c2e1"
 dependencies = [
  "cubecl",
 ]
@@ -2684,7 +2684,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=93a278260f55fb693c5068be1fc6def7786ca810#93a278260f55fb693c5068be1fc6def7786ca810"
+source = "git+https://github.com/tracel-ai/cubek?rev=cc66d28e43f42ebf28de43885e9fc34c13d0c2e1#cc66d28e43f42ebf28de43885e9fc34c13d0c2e1"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2696,7 +2696,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=93a278260f55fb693c5068be1fc6def7786ca810#93a278260f55fb693c5068be1fc6def7786ca810"
+source = "git+https://github.com/tracel-ai/cubek?rev=cc66d28e43f42ebf28de43885e9fc34c13d0c2e1#cc66d28e43f42ebf28de43885e9fc34c13d0c2e1"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2710,7 +2710,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=93a278260f55fb693c5068be1fc6def7786ca810#93a278260f55fb693c5068be1fc6def7786ca810"
+source = "git+https://github.com/tracel-ai/cubek?rev=cc66d28e43f42ebf28de43885e9fc34c13d0c2e1#cc66d28e43f42ebf28de43885e9fc34c13d0c2e1"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2720,7 +2720,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=93a278260f55fb693c5068be1fc6def7786ca810#93a278260f55fb693c5068be1fc6def7786ca810"
+source = "git+https://github.com/tracel-ai/cubek?rev=cc66d28e43f42ebf28de43885e9fc34c13d0c2e1#cc66d28e43f42ebf28de43885e9fc34c13d0c2e1"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2732,7 +2732,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=93a278260f55fb693c5068be1fc6def7786ca810#93a278260f55fb693c5068be1fc6def7786ca810"
+source = "git+https://github.com/tracel-ai/cubek?rev=cc66d28e43f42ebf28de43885e9fc34c13d0c2e1#cc66d28e43f42ebf28de43885e9fc34c13d0c2e1"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2746,7 +2746,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=93a278260f55fb693c5068be1fc6def7786ca810#93a278260f55fb693c5068be1fc6def7786ca810"
+source = "git+https://github.com/tracel-ai/cubek?rev=cc66d28e43f42ebf28de43885e9fc34c13d0c2e1#cc66d28e43f42ebf28de43885e9fc34c13d0c2e1"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2759,7 +2759,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=93a278260f55fb693c5068be1fc6def7786ca810#93a278260f55fb693c5068be1fc6def7786ca810"
+source = "git+https://github.com/tracel-ai/cubek?rev=cc66d28e43f42ebf28de43885e9fc34c13d0c2e1#cc66d28e43f42ebf28de43885e9fc34c13d0c2e1"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2769,7 +2769,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=93a278260f55fb693c5068be1fc6def7786ca810#93a278260f55fb693c5068be1fc6def7786ca810"
+source = "git+https://github.com/tracel-ai/cubek?rev=cc66d28e43f42ebf28de43885e9fc34c13d0c2e1#cc66d28e43f42ebf28de43885e9fc34c13d0c2e1"
 dependencies = [
  "bytemuck",
  "cubecl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,13 +220,12 @@ burn-train = { path = "crates/burn-train", version = "=0.22.0-pre.2", default-fe
 burn-vision = { path = "crates/burn-vision", version = "=0.22.0-pre.2", default-features = false }
 burn-wgpu = { path = "crates/burn-wgpu", version = "=0.22.0-pre.2", default-features = false }
 
-### For the cubecl feat/quant-scale-levels and cubek feat/quant-two-level-scheme branches. ###
-# cubek's branch pins this cubecl revision, and both sides have to agree on one.
-cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "7ca428f71335d2876861a8628b637149eed9abff" }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "7ca428f71335d2876861a8628b637149eed9abff" }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "7ca428f71335d2876861a8628b637149eed9abff" }
-cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "7ca428f71335d2876861a8628b637149eed9abff" }
-cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "c4c2c4d1794a6922280b24209b285b7d08c3f9d2" }
+### For the main burn branch. ###
+cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "1e735584ad9ef78893448583ee7d9008a2f2a904" }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "1e735584ad9ef78893448583ee7d9008a2f2a904" }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "1e735584ad9ef78893448583ee7d9008a2f2a904" }
+cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "1e735584ad9ef78893448583ee7d9008a2f2a904" }
+cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "83599b4d456ae45710b17e240983153768fcc9af" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,11 +222,11 @@ burn-wgpu = { path = "crates/burn-wgpu", version = "=0.22.0-pre.2", default-feat
 
 ### For the cubecl feat/quant-scale-levels and cubek feat/quant-two-level-scheme branches. ###
 # cubek's branch pins this cubecl revision, and both sides have to agree on one.
-cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "2d058e53a691645ec1d964beb69ddac0601e27e1" }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "2d058e53a691645ec1d964beb69ddac0601e27e1" }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "2d058e53a691645ec1d964beb69ddac0601e27e1" }
-cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "2d058e53a691645ec1d964beb69ddac0601e27e1" }
-cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "e60610d775a9e2193974ebd6521685ebd2d639ad" }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "6906371fe870ed609beaa9860f8692ac5cce8202" }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "6906371fe870ed609beaa9860f8692ac5cce8202" }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "6906371fe870ed609beaa9860f8692ac5cce8202" }
+cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "6906371fe870ed609beaa9860f8692ac5cce8202" }
+cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "c755c40271c5f6aafb9a9037e1e5ce24e21f254b" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,7 +226,7 @@ cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false
 cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "2d058e53a691645ec1d964beb69ddac0601e27e1" }
 cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "2d058e53a691645ec1d964beb69ddac0601e27e1" }
 cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "2d058e53a691645ec1d964beb69ddac0601e27e1" }
-cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "863bead5331a204b2383c7660b331719f181c38e" }
+cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "e60610d775a9e2193974ebd6521685ebd2d639ad" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,11 +222,11 @@ burn-wgpu = { path = "crates/burn-wgpu", version = "=0.22.0-pre.2", default-feat
 
 ### For the cubecl feat/quant-scale-levels and cubek feat/quant-two-level-scheme branches. ###
 # cubek's branch pins this cubecl revision, and both sides have to agree on one.
-cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "bdf991825e25a4708ce817a32cac6452dd792465" }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "bdf991825e25a4708ce817a32cac6452dd792465" }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "bdf991825e25a4708ce817a32cac6452dd792465" }
-cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "bdf991825e25a4708ce817a32cac6452dd792465" }
-cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "143b427cd759440b7c70fbb2cf333ad182b1d48c" }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "2d058e53a691645ec1d964beb69ddac0601e27e1" }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "2d058e53a691645ec1d964beb69ddac0601e27e1" }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "2d058e53a691645ec1d964beb69ddac0601e27e1" }
+cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "2d058e53a691645ec1d964beb69ddac0601e27e1" }
+cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "863bead5331a204b2383c7660b331719f181c38e" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,7 +226,7 @@ cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false
 cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "bdf991825e25a4708ce817a32cac6452dd792465" }
 cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "bdf991825e25a4708ce817a32cac6452dd792465" }
 cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "bdf991825e25a4708ce817a32cac6452dd792465" }
-cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "cc66d28e43f42ebf28de43885e9fc34c13d0c2e1" }
+cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "143b427cd759440b7c70fbb2cf333ad182b1d48c" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,11 +222,11 @@ burn-wgpu = { path = "crates/burn-wgpu", version = "=0.22.0-pre.2", default-feat
 
 ### For the cubecl feat/quant-scale-levels and cubek feat/quant-two-level-scheme branches. ###
 # cubek's branch pins this cubecl revision, and both sides have to agree on one.
-cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "6906371fe870ed609beaa9860f8692ac5cce8202" }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "6906371fe870ed609beaa9860f8692ac5cce8202" }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "6906371fe870ed609beaa9860f8692ac5cce8202" }
-cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "6906371fe870ed609beaa9860f8692ac5cce8202" }
-cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "c755c40271c5f6aafb9a9037e1e5ce24e21f254b" }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "7ca428f71335d2876861a8628b637149eed9abff" }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "7ca428f71335d2876861a8628b637149eed9abff" }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "7ca428f71335d2876861a8628b637149eed9abff" }
+cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "7ca428f71335d2876861a8628b637149eed9abff" }
+cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "c4c2c4d1794a6922280b24209b285b7d08c3f9d2" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,12 +220,13 @@ burn-train = { path = "crates/burn-train", version = "=0.22.0-pre.2", default-fe
 burn-vision = { path = "crates/burn-vision", version = "=0.22.0-pre.2", default-features = false }
 burn-wgpu = { path = "crates/burn-wgpu", version = "=0.22.0-pre.2", default-features = false }
 
-### For the main burn branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "088dd7053c039775f73cf4d1645d30706d0ddf7d" }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "088dd7053c039775f73cf4d1645d30706d0ddf7d" }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "088dd7053c039775f73cf4d1645d30706d0ddf7d" }
-cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "088dd7053c039775f73cf4d1645d30706d0ddf7d" }
-cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "93a278260f55fb693c5068be1fc6def7786ca810" }
+### For the cubecl feat/quant-scale-levels and cubek feat/quant-two-level-scheme branches. ###
+# cubek's branch pins this cubecl revision, and both sides have to agree on one.
+cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "bdf991825e25a4708ce817a32cac6452dd792465" }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "bdf991825e25a4708ce817a32cac6452dd792465" }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "bdf991825e25a4708ce817a32cac6452dd792465" }
+cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "bdf991825e25a4708ce817a32cac6452dd792465" }
+cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "cc66d28e43f42ebf28de43885e9fc34c13d0c2e1" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }

--- a/burn-book/src/performance/quantization.md
+++ b/burn-book/src/performance/quantization.md
@@ -45,13 +45,12 @@ tensors and can collect their statistics, such as the min and max value when usi
 
 ```rust , ignore
 # use burn::module::Quantizer;
-# use burn::tensor::quantization::{Calibration, QuantLevel, QuantParam, QuantScheme, QuantValue};
+# use burn::tensor::quantization::{Calibration, QuantScheme, QuantValue, ScaleDtype};
 #
 // Quantization config
 let scheme = QuantScheme::default()
-    .with_level(QuantLevel::Block(32))
-    .with_value(QuantValue::Q4F)
-    .with_param(QuantParam::F16);
+    .per_block([32], ScaleDtype::F16)
+    .with_value(QuantValue::Q4F);
 let mut quantizer = Quantizer {
     calibration: Calibration::MinMax,
     scheme,
@@ -80,12 +79,25 @@ values, storage format, granularity, and how the values are scaled.
 
 ```rust
 let scheme = QuantScheme::default()
-    .with_mode(QuantMode::Symmetric)         // Quantization mode
-    .with_level(QuantLevel::block([2, 16]))  // Granularity (per-tensor or per-block)
-    .with_value(QuantValue::Q8S)             // Data type of quantized values, independent of how they're stored
-    .with_store(QuantStore::Native)          // Storage format for quantized values
-    .with_param(QuantParam::F16);            // Precision for quantization parameters
+    .with_mode(QuantMode::Symmetric)          // Quantization mode
+    .per_block([2, 16], ScaleDtype::F16)      // One scale per block of values, stored as f16
+    .with_value(QuantValue::Q8S)              // Data type of quantized values, independent of how they're stored
+    .with_store(QuantStore::Native);          // Storage format for quantized values
 ```
+
+A scheme carries up to two scale levels, each set in any order and each owning the type its scales
+are stored in. `per_tensor` is one scale for the whole tensor, which is also what a scheme with no
+level set resolves to; `per_block` is one scale per block of values.
+
+```rust
+// Block scales in ue4m3, normalized by a single per-tensor f32 scale.
+let scheme = QuantScheme::default()
+    .per_block([16], ScaleDtype::UE4M3)
+    .per_tensor(ScaleDtype::F32);
+```
+
+Two levels exist so the block scales can live in a narrow type: the per-tensor scale absorbs the
+tensor's dynamic range, and the block type only has to cover the spread between blocks.
 
 #### Quantization Mode
 
@@ -93,12 +105,15 @@ let scheme = QuantScheme::default()
 | :---------- | :------------------------------------------- |
 | `Symmetric` | Values are scaled symmetrically around zero. |
 
-#### Quantization Level
+#### Scale Levels
 
-| Level                          | Description                                                                                                  |
-| :----------------------------- | :----------------------------------------------------------------------------------------------------------- |
-| `Tensor`                       | A single quantization parameter set for the entire tensor.                                                   |
-| `Block(block_size: BlockSize)` | Tensor divided into blocks (1D, 2D, or higher) defined by block_size, each with its own quantization params. |
+| Level                        | Description                                                                                     |
+| :--------------------------- | :---------------------------------------------------------------------------------------------- |
+| `per_tensor(dtype)`          | A single scale for the entire tensor.                                                           |
+| `per_block(block, dtype)`    | Tensor divided into blocks (1D, 2D, or higher) defined by `block`, each with its own scale.     |
+
+Setting both nests the blocks inside the tensor: the per-tensor scale is the factor the block
+scales are relative to, and it has to be `F32`.
 
 #### Quantization Value
 
@@ -124,16 +139,16 @@ let scheme = QuantScheme::default()
 
 Native storage is not supported for sub-byte quantization values.
 
-#### Quantization Parameters Precision
+#### Scale Data Type
 
-| Param   | Description                                                                            |
+| Dtype   | Description                                                                            |
 | :------ | :------------------------------------------------------------------------------------- |
 | `F32`   | Full floating-point precision.                                                         |
 | `F16`   | Half-precision floating point.                                                         |
 | `BF16`  | Brain float 16-bit precision.                                                          |
 | `UE4M3` | 8-bit floating point (4 exponent, 3 mantissa). Currently supported on CPU backends only. |
 
-A narrower parameter type stores less per block, but it also has a much smaller range. `UE4M3`
+A narrower scale type stores less per block, but it also has a much smaller range. `UE4M3`
 cannot represent a value below `2^-9`, so a scale smaller than that rounds to zero and the block
 is lost. Scales stay in range when the quantized values are large enough, which in practice means
 it is not a drop-in replacement for `F32` on small-magnitude weights.

--- a/burn-book/src/performance/quantization.md
+++ b/burn-book/src/performance/quantization.md
@@ -112,6 +112,11 @@ tensor's dynamic range, and the block type only has to cover the spread between 
 | `per_tensor(dtype)`          | A single scale for the entire tensor.                                                           |
 | `per_block(block, dtype)`    | Tensor divided into blocks (1D, 2D, or higher) defined by `block`, each with its own scale.     |
 
+Block dimensions are relative to the tensor rank and describe per-axis rectangles, not flat chunks
+of contiguous values. For example, `[16]` divides the trailing dimension into groups of 16, while
+`[2, 16]` divides the final two dimensions into rectangular blocks. Dynamic calibration currently
+requires every affected tensor dimension to be evenly divisible by its block extent.
+
 Setting both nests the blocks inside the tensor: the per-tensor scale is the factor the block
 scales are relative to, and it has to be `F32`.
 
@@ -134,7 +139,7 @@ scales are relative to, and it has to be `F32`.
 | Store               | Description                                                                                                                                       |
 | :------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `Native`            | Each quantized value is stored directly in a native format, which doesn't require packing and unpacking.                                          |
-| `PackedNative(dim)` | Multiple quantized values packed into a 32-bit integer. Argument is the dimension the tensor is packed on, starting from the innermost dimension. |
+| `PackedNative(dim)` | Multiple quantized values packed into a natively supported representation. Argument is the dimension the tensor is packed on, starting from the innermost dimension. |
 | `PackedU32(dim)`    | Multiple quantized values packed into a 32-bit integer. Argument is the dimension the tensor is packed on, starting from the innermost dimension. |
 
 Native storage is not supported for sub-byte quantization values.
@@ -148,7 +153,9 @@ Native storage is not supported for sub-byte quantization values.
 | `BF16`  | Brain float 16-bit precision.                                                          |
 | `UE4M3` | 8-bit floating point (4 exponent, 3 mantissa). Currently supported on CPU backends only. |
 
-A narrower scale type stores less per block, but it also has a much smaller range. `UE4M3`
-cannot represent a value below `2^-9`, so a scale smaller than that rounds to zero and the block
-is lost. Scales stay in range when the quantized values are large enough, which in practice means
-it is not a drop-in replacement for `F32` on small-magnitude weights.
+A narrower scale type stores less per block, but it also has a much smaller range. The smallest
+positive `UE4M3` value is `2^-9`; Burn rounds a smaller positive scale up to `2^-9` rather than
+down to zero. The resulting scale can nevertheless be so coarse that the block's values quantize
+to zero. A two-level scheme lets the per-tensor `F32` scale carry the absolute magnitude, but the
+differences between block scales can still exceed `UE4M3`'s range and make smaller blocks
+quantize too coarsely.

--- a/crates/burn-autodiff/src/ops/qtensor.rs
+++ b/crates/burn-autodiff/src/ops/qtensor.rs
@@ -26,6 +26,7 @@ impl<B: Backend, C: CheckpointStrategy> QTensorOps<Self> for Autodiff<B, C> {
             scheme,
             QuantizationParametersPrimitive {
                 scales: qparams.scales.primitive,
+                global: qparams.global.map(|global| global.primitive),
             },
         )
     }

--- a/crates/burn-backend-tests/tests/cubecl/quantization/quantize_dequantize.rs
+++ b/crates/burn-backend-tests/tests/cubecl/quantization/quantize_dequantize.rs
@@ -2,7 +2,7 @@ use super::*;
 use burn_tensor::Tolerance;
 use burn_tensor::{
     Shape,
-    quantization::{QuantLevel, QuantScheme, QuantStore, QuantValue},
+    quantization::{QuantScheme, QuantStore, QuantValue, ScaleDtype},
 };
 
 fn should_quantize_dequantize_symmetric_arange<S: Into<Shape>>(
@@ -48,7 +48,7 @@ fn should_quantize_dequantize_symmetric_per_block_arange<S: Into<Shape>>(
 
     let scheme = QuantScheme::default()
         .with_value(value)
-        .with_level(QuantLevel::block([block_size as u8]))
+        .per_block([block_size as u8], ScaleDtype::F32)
         .with_store(store);
     let scheme_ref = scheme.clone().with_store(QuantStore::Native);
 
@@ -78,7 +78,7 @@ fn should_quantize_dequantize_symmetric_per_block(
 ) {
     let scheme = QuantScheme::default()
         .with_value(value)
-        .with_level(QuantLevel::block([block_size as u8]))
+        .per_block([block_size as u8], ScaleDtype::F32)
         .with_store(store);
     let scheme_ref = scheme.clone().with_store(QuantStore::Native);
 

--- a/crates/burn-backend-tests/tests/cubecl/quantization/reshape.rs
+++ b/crates/burn-backend-tests/tests/cubecl/quantization/reshape.rs
@@ -2,11 +2,19 @@ use super::*;
 use burn_tensor::Tolerance;
 use burn_tensor::{
     Shape,
-    quantization::{BlockSize, QuantLevel, QuantScheme, QuantStore, QuantValue},
+    quantization::{BlockSize, QuantScheme, QuantStore, QuantValue, ScaleDtype},
 };
 
+fn scheme_for(block: Option<BlockSize>, value: QuantValue, store: QuantStore) -> QuantScheme {
+    let scheme = QuantScheme::default().with_value(value).with_store(store);
+    match block {
+        Some(block) => scheme.per_block(block.as_slice(), ScaleDtype::F32),
+        None => scheme,
+    }
+}
+
 fn should_quantize_dequantize_per_block_arange_reshaped<const D1: usize, const D2: usize>(
-    level: QuantLevel,
+    block: Option<BlockSize>,
     value: QuantValue,
     store: QuantStore,
     shape: [usize; D1],
@@ -17,10 +25,7 @@ fn should_quantize_dequantize_per_block_arange_reshaped<const D1: usize, const D
     let device = Default::default();
     let ref_device = ReferenceDevice::new();
 
-    let scheme = QuantScheme::default()
-        .with_level(level)
-        .with_value(value)
-        .with_store(store);
+    let scheme = scheme_for(block, value, store);
 
     let data = TestTensorInt::arange(0..numel, &ref_device)
         .float()
@@ -41,10 +46,10 @@ fn should_quantize_dequantize_per_block_arange_reshaped<const D1: usize, const D
 
 #[test]
 // https://github.com/tracel-ai/burn/issues/4659
-// Edge case where a single block is used, essentially like `QuantLevel::Tensor`
+// Edge case where a single block is used, essentially like per-tensor quantization
 fn should_quantize_dequantize_per_block_reshaped_global_block_q8s_packed() {
     should_quantize_dequantize_per_block_arange_reshaped(
-        QuantLevel::Block(BlockSize::new([16])),
+        Some(BlockSize::new([16])),
         QuantValue::Q8S,
         QuantStore::PackedU32(0),
         [32],
@@ -57,7 +62,7 @@ fn should_quantize_dequantize_per_block_reshaped_global_block_q8s_packed() {
 #[should_panic] // "Reshape with sub-byte values is not supported"] error is shadowed by the CallError
 fn should_quantize_dequantize_per_block_reshaped_global_block_q4s_packed() {
     should_quantize_dequantize_per_block_arange_reshaped(
-        QuantLevel::Block(BlockSize::new([16])),
+        Some(BlockSize::new([16])),
         QuantValue::Q4S,
         QuantStore::PackedU32(0),
         [32],
@@ -70,7 +75,7 @@ fn should_quantize_dequantize_per_block_reshaped_global_block_q4s_packed() {
 #[should_panic] // "Reshape with sub-byte values is not supported" error is shadowed by the CallError
 fn should_quantize_dequantize_per_tensor_reshaped_q4s_packed() {
     should_quantize_dequantize_per_block_arange_reshaped(
-        QuantLevel::Tensor,
+        None,
         QuantValue::Q4S,
         QuantStore::PackedU32(0),
         [32],
@@ -82,7 +87,7 @@ fn should_quantize_dequantize_per_tensor_reshaped_q4s_packed() {
 fn should_quantize_dequantize_per_block_reshaped_1d_q8s_native() {
     if supports_native() {
         should_quantize_dequantize_per_block_arange_reshaped(
-            QuantLevel::Block(BlockSize::new([16])),
+            Some(BlockSize::new([16])),
             QuantValue::Q8S,
             QuantStore::Native,
             [32],
@@ -94,7 +99,7 @@ fn should_quantize_dequantize_per_block_reshaped_1d_q8s_native() {
 #[test]
 fn should_quantize_dequantize_per_block_unsqueezed_q8s_packed() {
     should_quantize_dequantize_per_block_arange_reshaped(
-        QuantLevel::Block(BlockSize::new([32])),
+        Some(BlockSize::new([32])),
         QuantValue::Q8S,
         QuantStore::PackedU32(0),
         [32],
@@ -106,7 +111,7 @@ fn should_quantize_dequantize_per_block_unsqueezed_q8s_packed() {
 #[should_panic] // "Reshape of ND block-quantized tensor is not yet supported" error is shadowed by the CallError
 fn quantize_2d_block_reshape_should_panic() {
     should_quantize_dequantize_per_block_arange_reshaped(
-        QuantLevel::Block(BlockSize::new([2, 4])),
+        Some(BlockSize::new([2, 4])),
         QuantValue::Q8S,
         QuantStore::PackedU32(0),
         [4, 8],
@@ -119,7 +124,7 @@ fn quantize_2d_block_reshape_should_panic() {
 fn quantize_per_block_reshaped_should_not_split_block() {
     if supports_native() {
         should_quantize_dequantize_per_block_arange_reshaped(
-            QuantLevel::Block(BlockSize::new([32])),
+            Some(BlockSize::new([32])),
             QuantValue::Q8S,
             QuantStore::Native,
             [2, 32],
@@ -135,7 +140,7 @@ fn quantize_per_block_reshaped_should_not_split_block() {
 #[should_panic] // "Reshape would split a block across multiple rows"] error is shadowed by the CallError
 fn should_quantize_dequantize_per_block_reshaped_2d_q8s_packed() {
     should_quantize_dequantize_per_block_arange_reshaped(
-        QuantLevel::Block(BlockSize::new([32])),
+        Some(BlockSize::new([32])),
         QuantValue::Q8S,
         QuantStore::PackedU32(0),
         [2, 32],
@@ -152,14 +157,11 @@ fn should_quantize_dequantize_per_block_reshaped_2d_q8s_packed() {
 
 /// Reshape correctness isolated from quantization error: dequantize the *same*
 /// quantized tensor via both orders. Any difference is the reshape's doing.
-fn reshape_matches_dequantize_then_reshape(value: QuantValue, level: QuantLevel) {
+fn reshape_matches_dequantize_then_reshape(value: QuantValue, block: Option<BlockSize>) {
     let numel = 32i64;
     let device = Default::default();
     let ref_device = ReferenceDevice::new();
-    let scheme = QuantScheme::default()
-        .with_level(level)
-        .with_value(value)
-        .with_store(QuantStore::PackedU32(0));
+    let scheme = scheme_for(block, value, QuantStore::PackedU32(0));
 
     let data = TestTensorInt::arange(0..numel, &ref_device)
         .float()
@@ -176,18 +178,15 @@ fn reshape_matches_dequantize_then_reshape(value: QuantValue, level: QuantLevel)
 
 #[test]
 fn q8s_reshape_matches_dequantize_then_reshape() {
-    reshape_matches_dequantize_then_reshape(QuantValue::Q8S, QuantLevel::Tensor);
+    reshape_matches_dequantize_then_reshape(QuantValue::Q8S, None);
 }
 
 #[test]
 fn q4s_reshape_matches_dequantize_then_reshape() {
-    reshape_matches_dequantize_then_reshape(QuantValue::Q4S, QuantLevel::Tensor);
+    reshape_matches_dequantize_then_reshape(QuantValue::Q4S, None);
 }
 
 #[test]
 fn q4s_block_reshape_matches_dequantize_then_reshape() {
-    reshape_matches_dequantize_then_reshape(
-        QuantValue::Q4S,
-        QuantLevel::Block(BlockSize::new([16])),
-    );
+    reshape_matches_dequantize_then_reshape(QuantValue::Q4S, Some(BlockSize::new([16])));
 }

--- a/crates/burn-backend-tests/tests/tensor/float/quantization/accuracy.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/quantization/accuracy.rs
@@ -9,20 +9,10 @@
 use super::*;
 use burn_tensor::{
     Shape, TensorData,
-    quantization::{QuantLevel, QuantParam, QuantScheme, QuantValue, params_shape},
+    quantization::{
+        QuantScheme, QuantValue, ScaleDtype, global_scale_size, params_shape, scale_size,
+    },
 };
-
-/// Bits per stored scale.
-// TODO: replace with `QuantParam::size_bits()` once it exists upstream in cubecl. This is the
-// fourth copy of this table (see also `burn-std`'s `scale_size` and `burn-store`'s
-// `quant_param_size`).
-fn param_size_bits(param: QuantParam) -> usize {
-    match param {
-        QuantParam::F32 => 32,
-        QuantParam::F16 | QuantParam::BF16 => 16,
-        QuantParam::UE8M0 | QuantParam::UE4M3 => 8,
-    }
-}
 
 /// Total storage cost of a quantized tensor, per element of the original tensor.
 ///
@@ -30,10 +20,10 @@ fn param_size_bits(param: QuantParam) -> usize {
 /// scales, so only error-at-equal-bits distinguishes a real improvement from a trade.
 fn bits_per_element(scheme: &QuantScheme, shape: &Shape) -> f64 {
     let numel = shape.num_elements();
-    let num_scales = params_shape(shape, scheme.level).num_elements();
-
+    let num_scales = params_shape(shape, scheme).num_elements();
     scheme.size_bits_value() as f64
-        + (param_size_bits(scheme.param) * num_scales) as f64 / numel as f64
+        + ((scale_size(scheme.scale_dtype()) * num_scales + global_scale_size(scheme)) * 8) as f64
+            / numel as f64
 }
 
 /// Deterministic standard-normal samples, so a reported number is reproducible across runs and
@@ -91,38 +81,48 @@ fn quantization_error(values: &[f32], shape: [usize; 2], scheme: &QuantScheme) -
     relative_error(&reference, &dequantized)
 }
 
-fn scheme_for(value: QuantValue, level: QuantLevel, param: QuantParam) -> QuantScheme {
+/// The scale levels a case measures, with the block extent it quantizes on.
+#[derive(Clone, Copy, PartialEq)]
+enum Levels {
+    Tensor,
+    Block(u8),
+    BlockUnderTensor(u8),
+}
+
+fn scheme_for(value: QuantValue, levels: Levels, dtype: ScaleDtype) -> QuantScheme {
     let device = burn_tensor::Device::default();
-    device
-        .settings()
-        .quantization
-        .scheme
-        .with_value(value)
-        .with_level(level)
-        .with_param(param)
+    let scheme = device.settings().quantization.scheme.with_value(value);
+
+    match levels {
+        Levels::Tensor => scheme.per_tensor(dtype),
+        Levels::Block(block) => scheme.per_block([block], dtype),
+        Levels::BlockUnderTensor(block) => {
+            scheme.per_block([block], dtype).per_tensor(ScaleDtype::F32)
+        }
+    }
 }
 
 const SHAPE: [usize; 2] = [64, 64];
 
-/// A scale that underflows the param's representable range is the failure the per-tensor scale of
+/// A scale that underflows the dtype's representable range is the failure the per-tensor scale of
 /// a two-level scheme exists to prevent, so it has to be visible here before that scheme is built.
 ///
 /// `Q8S` divides the block maximum by 127, so for weights of a realistic magnitude the block scale
 /// lands in e4m3's subnormals or below, where almost no precision is left.
 #[test]
-fn narrow_scale_param_degrades_without_normalization() {
+fn narrow_scale_dtype_degrades_without_normalization() {
     let values = normal_samples(SHAPE[0] * SHAPE[1], 0.02);
-    let level = QuantLevel::block([32]);
+    let levels = Levels::Block(32);
 
     let exact = quantization_error(
         &values,
         SHAPE,
-        &scheme_for(QuantValue::Q8S, level, QuantParam::F32),
+        &scheme_for(QuantValue::Q8S, levels, ScaleDtype::F32),
     );
     let narrow = quantization_error(
         &values,
         SHAPE,
-        &scheme_for(QuantValue::Q8S, level, QuantParam::UE4M3),
+        &scheme_for(QuantValue::Q8S, levels, ScaleDtype::UE4M3),
     );
 
     assert!(
@@ -132,26 +132,26 @@ fn narrow_scale_param_degrades_without_normalization() {
     );
 }
 
-/// At a magnitude where no scale underflows, the two 16-bit params cost nothing measurable while
+/// At a magnitude where no scale underflows, the two 16-bit dtypes cost nothing measurable while
 /// the 8-bit one already costs something. Pinning both directions keeps the harness honest: it
 /// has to be sensitive enough to see the 8-bit loss, and not so noisy that it invents a 16-bit one.
 ///
-/// The upper bound on the 8-bit cost is what keeps `scale_to_param` rounding up. Rounding a scale
+/// The upper bound on the 8-bit cost is what keeps `scale_to_dtype` rounding up. Rounding a scale
 /// to nearest instead lets a block's largest value clip, which measured several times worse.
 ///
 /// Note this is not monotone in scale width. Rounding a scale can land favourably on a given
 /// sample, so f16 sitting a hair below f32 is expected and is not a signal.
 #[test]
-fn error_responds_to_scale_param() {
+fn error_responds_to_scale_dtype() {
     let values = normal_samples(SHAPE[0] * SHAPE[1], 1.0);
-    let level = QuantLevel::block([32]);
+    let levels = Levels::Block(32);
 
     let error_for =
-        |param| quantization_error(&values, SHAPE, &scheme_for(QuantValue::Q8S, level, param));
+        |dtype| quantization_error(&values, SHAPE, &scheme_for(QuantValue::Q8S, levels, dtype));
     let (f32_err, f16_err, ue4m3_err) = (
-        error_for(QuantParam::F32),
-        error_for(QuantParam::F16),
-        error_for(QuantParam::UE4M3),
+        error_for(ScaleDtype::F32),
+        error_for(ScaleDtype::F16),
+        error_for(ScaleDtype::UE4M3),
     );
 
     // Generous on purpose. The measured gap is near zero on the backends checked so far, but this
@@ -175,15 +175,17 @@ fn error_responds_to_scale_param() {
 #[test]
 #[ignore = "reports measurements rather than asserting; run with --ignored --nocapture"]
 fn report_quantization_accuracy() {
-    let levels = [
-        ("tensor", QuantLevel::Tensor),
-        ("block16", QuantLevel::block([16])),
-        ("block32", QuantLevel::block([32])),
+    let cases = [
+        ("tensor", Levels::Tensor),
+        ("block16", Levels::Block(16)),
+        ("block32", Levels::Block(32)),
+        ("block16+f32", Levels::BlockUnderTensor(16)),
+        ("block32+f32", Levels::BlockUnderTensor(32)),
     ];
-    let params = [
-        ("f32", QuantParam::F32),
-        ("f16", QuantParam::F16),
-        ("ue4m3", QuantParam::UE4M3),
+    let dtypes = [
+        ("f32", ScaleDtype::F32),
+        ("f16", ScaleDtype::F16),
+        ("ue4m3", ScaleDtype::UE4M3),
     ];
     let shape = Shape::from(SHAPE);
 
@@ -192,17 +194,21 @@ fn report_quantization_accuracy() {
 
         println!("\nweight std = {std}  (shape {SHAPE:?})");
         println!(
-            "{:<10} {:<7} {:>8} {:>12}",
-            "level", "param", "bits/el", "rel. error"
+            "{:<13} {:<7} {:>8} {:>12}",
+            "levels", "scale", "bits/el", "rel. error"
         );
 
-        for (level_name, level) in levels {
-            for (param_name, param) in params {
-                let scheme = scheme_for(QuantValue::Q8S, level, param);
+        for (case_name, levels) in cases {
+            for (dtype_name, dtype) in dtypes {
+                // A per-tensor scale has nothing to absorb at f32 block scales.
+                if matches!(levels, Levels::BlockUnderTensor(_)) && dtype == ScaleDtype::F32 {
+                    continue;
+                }
+                let scheme = scheme_for(QuantValue::Q8S, levels, dtype);
                 let error = quantization_error(&values, SHAPE, &scheme);
 
                 println!(
-                    "{level_name:<10} {param_name:<7} {:>8.3} {error:>12.5}",
+                    "{case_name:<13} {dtype_name:<7} {:>8.3} {error:>12.5}",
                     bits_per_element(&scheme, &shape)
                 );
             }

--- a/crates/burn-backend-tests/tests/tensor/float/quantization/accuracy.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/quantization/accuracy.rs
@@ -31,9 +31,10 @@ fn param_size_bits(param: QuantParam) -> usize {
 fn bits_per_element(scheme: &QuantScheme, shape: &Shape) -> f64 {
     let numel = shape.num_elements();
     let num_scales = params_shape(shape, scheme.level).num_elements();
+    let global_bits = scheme.level.global_param().map_or(0, param_size_bits);
 
     scheme.size_bits_value() as f64
-        + (param_size_bits(scheme.param) * num_scales) as f64 / numel as f64
+        + (param_size_bits(scheme.param) * num_scales + global_bits) as f64 / numel as f64
 }
 
 /// Deterministic standard-normal samples, so a reported number is reproducible across runs and
@@ -179,6 +180,14 @@ fn report_quantization_accuracy() {
         ("tensor", QuantLevel::Tensor),
         ("block16", QuantLevel::block([16])),
         ("block32", QuantLevel::block([32])),
+        (
+            "block16+f16",
+            QuantLevel::block_tensor([16], QuantParam::F16),
+        ),
+        (
+            "block32+f16",
+            QuantLevel::block_tensor([32], QuantParam::F16),
+        ),
     ];
     let params = [
         ("f32", QuantParam::F32),
@@ -192,17 +201,22 @@ fn report_quantization_accuracy() {
 
         println!("\nweight std = {std}  (shape {SHAPE:?})");
         println!(
-            "{:<10} {:<7} {:>8} {:>12}",
+            "{:<13} {:<7} {:>8} {:>12}",
             "level", "param", "bits/el", "rel. error"
         );
 
         for (level_name, level) in levels {
             for (param_name, param) in params {
+                // A two-level scheme requires block scales narrower than its per-tensor scale.
+                if level.global_param().is_some_and(|g| param_size_bits(param) >= param_size_bits(g))
+                {
+                    continue;
+                }
                 let scheme = scheme_for(QuantValue::Q8S, level, param);
                 let error = quantization_error(&values, SHAPE, &scheme);
 
                 println!(
-                    "{level_name:<10} {param_name:<7} {:>8.3} {error:>12.5}",
+                    "{level_name:<13} {param_name:<7} {:>8.3} {error:>12.5}",
                     bits_per_element(&scheme, &shape)
                 );
             }

--- a/crates/burn-backend-tests/tests/tensor/float/quantization/accuracy.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/quantization/accuracy.rs
@@ -208,7 +208,9 @@ fn report_quantization_accuracy() {
         for (level_name, level) in levels {
             for (param_name, param) in params {
                 // A two-level scheme requires block scales narrower than its per-tensor scale.
-                if level.global_param().is_some_and(|g| param_size_bits(param) >= param_size_bits(g))
+                if level
+                    .global_param()
+                    .is_some_and(|g| param_size_bits(param) >= param_size_bits(g))
                 {
                     continue;
                 }

--- a/crates/burn-backend-tests/tests/tensor/float/quantization/accuracy.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/quantization/accuracy.rs
@@ -181,14 +181,6 @@ fn report_quantization_accuracy() {
         ("block16", QuantLevel::block([16])),
         ("block32", QuantLevel::block([32])),
         (
-            "block16+f16",
-            QuantLevel::block_tensor([16], QuantParam::F16),
-        ),
-        (
-            "block32+f16",
-            QuantLevel::block_tensor([32], QuantParam::F16),
-        ),
-        (
             "block16+f32",
             QuantLevel::block_tensor([16], QuantParam::F32),
         ),
@@ -215,11 +207,9 @@ fn report_quantization_accuracy() {
 
         for (level_name, level) in levels {
             for (param_name, param) in params {
-                // A two-level scheme requires block scales narrower than its per-tensor scale.
-                if level
-                    .global_param()
-                    .is_some_and(|g| param_size_bits(param) >= param_size_bits(g))
-                {
+                // A per-tensor scale has nothing to absorb when the block scales already reach
+                // f32's range.
+                if level.global_param().is_some() && param == QuantParam::F32 {
                     continue;
                 }
                 let scheme = scheme_for(QuantValue::Q8S, level, param);

--- a/crates/burn-backend-tests/tests/tensor/float/quantization/accuracy.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/quantization/accuracy.rs
@@ -188,6 +188,14 @@ fn report_quantization_accuracy() {
             "block32+f16",
             QuantLevel::block_tensor([32], QuantParam::F16),
         ),
+        (
+            "block16+f32",
+            QuantLevel::block_tensor([16], QuantParam::F32),
+        ),
+        (
+            "block32+f32",
+            QuantLevel::block_tensor([32], QuantParam::F32),
+        ),
     ];
     let params = [
         ("f32", QuantParam::F32),

--- a/crates/burn-backend-tests/tests/tensor/float/quantization/calibration.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/quantization/calibration.rs
@@ -1,7 +1,7 @@
 use super::*;
 use burn_tensor::{
     TensorData, Tolerance,
-    quantization::{Calibration, QuantLevel, QuantValue, compute_range},
+    quantization::{Calibration, QuantValue, ScaleDtype, compute_range},
 };
 
 // NOTE: The scheme variant fields are not important for calibration, only the "main" variant (e.g., per-tensor)
@@ -44,7 +44,7 @@ fn min_max_calibration_range_per_block() {
         .quantization
         .scheme
         .with_value(QuantValue::Q8S)
-        .with_level(QuantLevel::block([4]));
+        .per_block([4], ScaleDtype::F32);
 
     let range = compute_range(&scheme, &tensor, &Calibration::MinMax);
 
@@ -95,7 +95,7 @@ fn abs_mean_calibration_range_per_block() {
         .quantization
         .scheme
         .with_value(QuantValue::Q2S)
-        .with_level(QuantLevel::block([4]));
+        .per_block([4], ScaleDtype::F32);
 
     let range = compute_range(&scheme, &tensor, &Calibration::AbsMean);
 

--- a/crates/burn-backend-tests/tests/tensor/float/quantization/data.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/quantization/data.rs
@@ -15,6 +15,7 @@ fn should_support_per_tensor_symmetric_int8() {
             .scheme
             .with_value(QuantValue::Q8S),
         &[0.014_173_228],
+        None,
     );
     let tensor = TestTensor::<1>::from_data(data.clone(), &device);
 
@@ -41,6 +42,7 @@ fn should_support_per_block_symmetric_int8() {
             .with_value(QuantValue::Q8S)
             .with_level(QuantLevel::block([8])),
         &[0.014_173_228, 0.000_314_96],
+        None,
     );
     let tensor = TestTensor::<1>::from_data(data.clone(), &device);
 

--- a/crates/burn-backend-tests/tests/tensor/float/quantization/data.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/quantization/data.rs
@@ -1,6 +1,6 @@
 use super::*;
 use alloc::vec;
-use burn_tensor::quantization::{QuantLevel, QuantValue};
+use burn_tensor::quantization::{QuantValue, ScaleDtype};
 use burn_tensor::{Device, TensorData};
 
 #[test]
@@ -15,6 +15,7 @@ fn should_support_per_tensor_symmetric_int8() {
             .scheme
             .with_value(QuantValue::Q8S),
         &[0.014_173_228],
+        None,
     );
     let tensor = TestTensor::<1>::from_data(data.clone(), &device);
 
@@ -39,8 +40,9 @@ fn should_support_per_block_symmetric_int8() {
             .quantization
             .scheme
             .with_value(QuantValue::Q8S)
-            .with_level(QuantLevel::block([8])),
+            .per_block([8], ScaleDtype::F32),
         &[0.014_173_228, 0.000_314_96],
+        None,
     );
     let tensor = TestTensor::<1>::from_data(data.clone(), &device);
 

--- a/crates/burn-backend-tests/tests/tensor/float/quantization/mod.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/quantization/mod.rs
@@ -10,8 +10,10 @@ mod scheme;
 pub mod qtensor {
     use super::TestTensor;
 
-    use burn_tensor::quantization::QuantLevel;
-    use burn_tensor::{TensorData, quantization::QuantValue};
+    use burn_tensor::{
+        TensorData,
+        quantization::{QuantValue, ScaleDtype},
+    };
 
     pub struct QTensor<const D: usize>;
 
@@ -31,7 +33,7 @@ pub mod qtensor {
                     .quantization
                     .scheme
                     .with_value(QuantValue::Q8S)
-                    .with_level(QuantLevel::block([16])),
+                    .per_block([16], ScaleDtype::F32),
             )
         }
 

--- a/crates/burn-backend-tests/tests/tensor/float/quantization/ops/matmul.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/quantization/ops/matmul.rs
@@ -2,6 +2,7 @@ use super::qtensor::*;
 use super::*;
 use burn_tensor::TensorData;
 use burn_tensor::Tolerance;
+use burn_tensor::quantization::{QuantValue, ScaleDtype};
 
 #[test]
 #[ignore]
@@ -245,4 +246,37 @@ fn test_matmul_mixed_block_scale() {
 
     // Default quantization scheme does not propagate quantization with matmul
     assert!(output.dtype.is_float());
+}
+
+/// No matmul kernel applies a per-tensor scale, and the autotune candidates panic on the level
+/// instead of declining it, so failing to fall back takes down the whole tuning run.
+#[test]
+fn should_matmul_two_level_rhs() {
+    let device = Default::default();
+
+    let lhs: TestTensor<2> = TestTensorInt::arange(0..256, &device)
+        .float()
+        .div_scalar(256.)
+        .reshape([16, 16]);
+    let rhs: TestTensor<2> = TestTensorInt::arange(0..256, &device)
+        .float()
+        .div_scalar(256.)
+        .reshape([16, 16]);
+
+    let scheme = device
+        .settings()
+        .quantization
+        .scheme
+        .with_value(QuantValue::Q8S)
+        .per_block([2, 16], ScaleDtype::F16)
+        .per_tensor(ScaleDtype::F32);
+
+    let quantized = rhs.quantize_dynamic(&scheme);
+    let expected = lhs
+        .clone()
+        .matmul(quantized.clone().dequantize())
+        .into_data();
+    let actual = lhs.matmul(quantized).into_data();
+
+    actual.assert_approx_eq::<FloatElem>(&expected, Tolerance::relative(1e-2));
 }

--- a/crates/burn-backend-tests/tests/tensor/float/quantization/ops/quantize.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/quantization/ops/quantize.rs
@@ -8,7 +8,6 @@ use burn_tensor::quantization::{
 use burn_tensor::{DType, Element, TensorData};
 
 fn get_q_params(data: TensorData) -> DecodedScales {
-    let num_elements = data.num_elements();
     let scheme = if let DType::QFloat(scheme) = data.dtype {
         scheme
     } else {

--- a/crates/burn-backend-tests/tests/tensor/float/quantization/ops/quantize.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/quantization/ops/quantize.rs
@@ -2,12 +2,11 @@ use super::*;
 use alloc::{vec, vec::Vec};
 use burn_tensor::Tolerance;
 use burn_tensor::quantization::{
-    QParams, QuantLevel, QuantScheme, QuantStore, QuantValue, QuantizationParameters,
-    QuantizedBytes,
+    QuantLevel, QuantScheme, QuantStore, QuantValue, QuantizationParameters, QuantizedBytes,
 };
 use burn_tensor::{DType, Element, TensorData};
 
-fn get_q_params(data: TensorData) -> QParams<Vec<f32>> {
+fn get_q_params(data: TensorData) -> Vec<f32> {
     let num_elements = data.num_elements();
     let scheme = if let DType::QFloat(scheme) = data.dtype {
         scheme
@@ -19,7 +18,7 @@ fn get_q_params(data: TensorData) -> QParams<Vec<f32>> {
         scheme,
         num_elements,
     };
-    q_bytes.into_vec_i8().1
+    q_bytes.into_vec_i8().1.block
 }
 
 #[test]
@@ -46,7 +45,8 @@ fn should_support_quantize_symmetric_int8() {
         vec![-127i8, -71, 0, 35],
         [4],
         scheme.with_store(QuantStore::Native),
-        &[0.014_173_228], // scale
+        &[0.014_173_228], // scale,
+        None,
     );
 
     // Values equality
@@ -55,9 +55,9 @@ fn should_support_quantize_symmetric_int8() {
     // Quantization parameters check
     let qparams = get_q_params(x_q_data);
     let expected = get_q_params(expected);
-    assert_eq!(qparams.scales.len(), 1);
+    assert_eq!(qparams.len(), 1);
     // TODO: check scales
-    assert_eq!(qparams.scales, expected.scales);
+    assert_eq!(qparams, expected);
 
     // Dequantize
     let x = x_q.dequantize();
@@ -84,7 +84,8 @@ fn should_support_quantize_dynamic_int8() {
         vec![50i8, 0, 40, -127],
         [4],
         scheme.with_store(QuantStore::Native),
-        &[0.1], // scale
+        &[0.1], // scale,
+        None,
     );
 
     x_q.into_data().assert_eq(&expected, false);

--- a/crates/burn-backend-tests/tests/tensor/float/quantization/ops/quantize.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/quantization/ops/quantize.rs
@@ -342,3 +342,30 @@ fn should_quantize_symmetric_int8_permuted_batch_dims() {
         Tolerance::absolute(1e-1).set_relative(1e-2),
     );
 }
+
+#[test]
+fn should_quantize_symmetric_two_level_f16_block_scales() {
+    let device = Default::default();
+
+    let input: TestTensor<2> = TestTensorInt::arange(0..256, &device)
+        .float()
+        .div_scalar(256.)
+        .reshape([16, 16]);
+
+    let scheme = device
+        .settings()
+        .quantization
+        .scheme
+        .with_value(QuantValue::Q8S)
+        .with_level(QuantLevel::block_tensor([2, 16], QuantParam::F32))
+        .with_param(QuantParam::F16);
+
+    let quantized = input.clone().quantize_dynamic(&scheme);
+    let direct = quantized.clone().dequantize().into_data();
+
+    let reloaded = TestTensor::<2>::from_data(quantized.into_data(), &device);
+    let round_tripped = reloaded.dequantize().into_data();
+
+    round_tripped.assert_eq(&direct, true);
+    direct.assert_approx_eq(&input.into_data(), Tolerance::<f32>::rel_abs(1e-2, 1e-2));
+}

--- a/crates/burn-backend-tests/tests/tensor/float/quantization/ops/quantize.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/quantization/ops/quantize.rs
@@ -36,6 +36,7 @@ fn should_support_quantize_symmetric_int8() {
         .with_value(QuantValue::Q8S);
     let qparams = QuantizationParameters {
         scales: TestTensor::from_data([0.014_173_228], &device),
+        global: None,
     };
 
     let x_q = tensor.clone().quantize(&scheme, qparams);

--- a/crates/burn-backend-tests/tests/tensor/float/quantization/ops/quantize.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/quantization/ops/quantize.rs
@@ -2,9 +2,10 @@ use super::*;
 use alloc::{vec, vec::Vec};
 use burn_tensor::Tolerance;
 use burn_tensor::quantization::{
-    QuantLevel, QuantScheme, QuantStore, QuantValue, QuantizationParameters, QuantizedBytes,
+    QuantLevel, QuantParam, QuantScheme, QuantStore, QuantValue, QuantizationParameters,
+    QuantizedBytes,
 };
-use burn_tensor::{DType, Element, TensorData};
+use burn_tensor::{DType, Element, ElementConversion, TensorData};
 
 fn get_q_params(data: TensorData) -> Vec<f32> {
     let num_elements = data.num_elements();
@@ -160,6 +161,92 @@ fn should_quantize_dequantize_symmetric_per_block_arange_16x16() {
     output.into_data().assert_approx_eq::<FloatElem>(
         &input.into_data(),
         Tolerance::absolute(1e-1).set_relative(1e-2),
+    );
+}
+
+/// A two-level tensor keeps its two scale levels apart in memory and folds them only where
+/// dequantization reconstructs the product. Writing it to bytes and reading it back has to land on
+/// exactly the same values, which is what makes a saved model reproduce the accuracy it was
+/// measured at.
+///
+/// Bit equality rather than a tolerance: both paths reconstruct from the same stored scales, so
+/// any difference means a level was rounded, folded or sliced differently on one of them.
+///
+/// What this can still catch is the block scales, which are ue4m3 and so genuinely rounded, and
+/// the byte layout: two scale regions of different widths, sliced apart on the way back in.
+#[test]
+fn should_round_trip_two_level_through_bytes() {
+    let device = Default::default();
+
+    let input: TestTensor<2> = TestTensorInt::arange(0..256, &device)
+        .float()
+        .div_scalar(256.)
+        .reshape([16, 16]);
+
+    let scheme = device
+        .settings()
+        .quantization
+        .scheme
+        .with_value(QuantValue::Q8S)
+        .with_level(QuantLevel::block_tensor([2, 16], QuantParam::F32))
+        .with_param(QuantParam::UE4M3);
+
+    let quantized = input.quantize_dynamic(&scheme);
+    let direct = quantized.clone().dequantize().into_data();
+
+    let reloaded = TestTensor::<2>::from_data(quantized.into_data(), &device);
+    let round_tripped = reloaded.dequantize().into_data();
+
+    round_tripped.assert_eq(&direct, true);
+}
+
+/// The per-tensor scale exists so that accuracy stops depending on how large the weights happen to
+/// be. That is the claim the whole feature rests on, and unlike the calibration test it cannot pass
+/// by restating the formula: it fails if any backend drops the global, folds it twice, or
+/// reconstructs with a copy that was not rounded to what it stores.
+#[test]
+fn two_level_error_should_not_track_weight_magnitude() {
+    let device = Default::default();
+
+    let big: TestTensor<2> = TestTensorInt::arange(-128..128, &device)
+        .float()
+        .div_scalar(128.)
+        .reshape([16, 16]);
+    let small = big.clone().mul_scalar(0.02);
+
+    let two_level = device
+        .settings()
+        .quantization
+        .scheme
+        .with_value(QuantValue::Q8S)
+        .with_level(QuantLevel::block_tensor([2, 16], QuantParam::F32))
+        .with_param(QuantParam::UE4M3);
+    let one_level = two_level.with_level(QuantLevel::block([2, 16]));
+
+    let error = |tensor: TestTensor<2>, scheme: &QuantScheme| -> f32 {
+        let reference = tensor.clone();
+        let dequantized = tensor.quantize_dynamic(scheme).dequantize();
+        let diff: FloatElem = (reference.clone() - dequantized).abs().sum().into_scalar();
+        let total: FloatElem = reference.abs().sum().into_scalar();
+        diff.elem::<f32>() / total.elem::<f32>()
+    };
+
+    let big_error = error(big.clone(), &two_level);
+    let small_error = error(small.clone(), &two_level);
+
+    assert!(
+        (small_error - big_error).abs() / big_error < 0.2,
+        "two-level error should be the same at either magnitude, \
+         got {big_error} and {small_error}"
+    );
+
+    // The same weights under a one-level scheme with the same 8-bit block param: its scales have
+    // to cover the magnitude themselves, and at this size they underflow.
+    let small_one_level = error(small, &one_level);
+    assert!(
+        small_one_level > small_error * 2.0,
+        "one-level 8-bit scales should degrade on small weights where two-level does not, \
+         got one-level {small_one_level} and two-level {small_error}"
     );
 }
 

--- a/crates/burn-backend-tests/tests/tensor/float/quantization/ops/quantize.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/quantization/ops/quantize.rs
@@ -15,9 +15,9 @@ fn get_q_params(data: TensorData) -> DecodedScales {
         unreachable!()
     };
     let q_bytes = QuantizedBytes {
+        shape: data.shape.clone(),
         bytes: data.into_bytes(),
         scheme,
-        num_elements,
     };
     q_bytes.into_vec_i8().1
 }
@@ -162,6 +162,48 @@ fn should_quantize_dequantize_symmetric_per_block_arange_16x16() {
         &input.into_data(),
         Tolerance::absolute(1e-1).set_relative(1e-2),
     );
+}
+
+/// A block that does not span the trailing dimension is a rectangle, not a run of the flat
+/// storage. Each `[2, 4]` block here holds one magnitude, so its scale is that magnitude over
+/// 127; chunking the flat storage in eights would instead pair the two blocks of a row and give
+/// both the larger scale. Four wide, so a packed store still keeps one word inside one block.
+#[test]
+fn should_quantize_blocks_that_do_not_span_the_trailing_dim() {
+    let device = Default::default();
+
+    let input = TestTensor::<2>::from_data(
+        [
+            [1.0, 1.0, 1.0, 1.0, 10.0, 10.0, 10.0, 10.0],
+            [1.0, 1.0, 1.0, 1.0, 10.0, 10.0, 10.0, 10.0],
+            [100.0, 100.0, 100.0, 100.0, 1000.0, 1000.0, 1000.0, 1000.0],
+            [100.0, 100.0, 100.0, 100.0, 1000.0, 1000.0, 1000.0, 1000.0],
+        ],
+        &device,
+    );
+
+    let scheme = device
+        .settings()
+        .quantization
+        .scheme
+        .with_value(QuantValue::Q8S)
+        .per_block([2, 4], ScaleDtype::F32);
+
+    let quantized = input.clone().quantize_dynamic(&scheme);
+
+    let scales = get_q_params(quantized.to_data()).block;
+    let expected = [1.0f32, 10.0, 100.0, 1000.0].map(|magnitude| magnitude / 127.0);
+    TensorData::new(scales, [2, 2]).assert_approx_eq::<f32>(
+        &TensorData::new(expected.to_vec(), [2, 2]),
+        Tolerance::relative(1e-3),
+    );
+
+    // Every block is uniform, so a right grid reconstructs it exactly and a wrong one is off by
+    // the ratio between the two magnitudes it merged.
+    quantized
+        .dequantize()
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&input.into_data(), Tolerance::relative(1e-2));
 }
 
 /// Bit equality rather than a tolerance: both paths reconstruct from the same stored scales, so

--- a/crates/burn-backend-tests/tests/tensor/float/quantization/ops/quantize.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/quantization/ops/quantize.rs
@@ -2,12 +2,12 @@ use super::*;
 use alloc::{vec, vec::Vec};
 use burn_tensor::Tolerance;
 use burn_tensor::quantization::{
-    QParams, QuantLevel, QuantScheme, QuantStore, QuantValue, QuantizationParameters,
-    QuantizedBytes,
+    DecodedScales, QuantScheme, QuantStore, QuantValue, QuantizationParameters, QuantizedBytes,
+    ScaleDtype,
 };
 use burn_tensor::{DType, Element, TensorData};
 
-fn get_q_params(data: TensorData) -> QParams<Vec<f32>> {
+fn get_q_params(data: TensorData) -> DecodedScales {
     let num_elements = data.num_elements();
     let scheme = if let DType::QFloat(scheme) = data.dtype {
         scheme
@@ -37,6 +37,7 @@ fn should_support_quantize_symmetric_int8() {
         .with_value(QuantValue::Q8S);
     let qparams = QuantizationParameters {
         scales: TestTensor::from_data([0.014_173_228], &device),
+        global: None,
     };
 
     let x_q = tensor.clone().quantize(&scheme, qparams);
@@ -46,7 +47,8 @@ fn should_support_quantize_symmetric_int8() {
         vec![-127i8, -71, 0, 35],
         [4],
         scheme.with_store(QuantStore::Native),
-        &[0.014_173_228], // scale
+        &[0.014_173_228], // scale,
+        None,
     );
 
     // Values equality
@@ -55,9 +57,9 @@ fn should_support_quantize_symmetric_int8() {
     // Quantization parameters check
     let qparams = get_q_params(x_q_data);
     let expected = get_q_params(expected);
-    assert_eq!(qparams.scales.len(), 1);
+    assert_eq!(qparams.block.len(), 1);
     // TODO: check scales
-    assert_eq!(qparams.scales, expected.scales);
+    assert_eq!(qparams, expected);
 
     // Dequantize
     let x = x_q.dequantize();
@@ -84,7 +86,8 @@ fn should_support_quantize_dynamic_int8() {
         vec![50i8, 0, 40, -127],
         [4],
         scheme.with_store(QuantStore::Native),
-        &[0.1], // scale
+        &[0.1], // scale,
+        None,
     );
 
     x_q.into_data().assert_eq(&expected, false);
@@ -150,7 +153,7 @@ fn should_quantize_dequantize_symmetric_per_block_arange_16x16() {
         .quantization
         .scheme
         .with_value(QuantValue::Q8S)
-        .with_level(QuantLevel::block([2, 16]));
+        .per_block([2, 16], ScaleDtype::F32);
 
     let output = input.clone().quantize_dynamic(&scheme);
     let output = output.dequantize();
@@ -158,6 +161,90 @@ fn should_quantize_dequantize_symmetric_per_block_arange_16x16() {
     output.into_data().assert_approx_eq::<FloatElem>(
         &input.into_data(),
         Tolerance::absolute(1e-1).set_relative(1e-2),
+    );
+}
+
+/// Bit equality rather than a tolerance: both paths reconstruct from the same stored scales, so
+/// any difference means a level was rounded, folded or sliced differently on one of them.
+///
+/// WGSL has no e4m3, so a ue4m3 scale reconstructs as NaN there. The f16 sibling below covers the
+/// byte layout on those backends.
+#[cfg(not(feature = "wgpu"))]
+#[test]
+fn should_round_trip_two_level_through_bytes() {
+    let device = Default::default();
+
+    let input: TestTensor<2> = TestTensorInt::arange(0..256, &device)
+        .float()
+        .div_scalar(256.)
+        .reshape([16, 16]);
+
+    let scheme = device
+        .settings()
+        .quantization
+        .scheme
+        .with_value(QuantValue::Q8S)
+        .per_block([2, 16], ScaleDtype::UE4M3)
+        .per_tensor(ScaleDtype::F32);
+
+    let quantized = input.quantize_dynamic(&scheme);
+    let direct = quantized.clone().dequantize().into_data();
+
+    let reloaded = TestTensor::<2>::from_data(quantized.into_data(), &device);
+    let round_tripped = reloaded.dequantize().into_data();
+
+    round_tripped.assert_eq(&direct, true);
+}
+
+/// The per-tensor scale exists so that accuracy stops depending on how large the weights are.
+///
+/// WGSL has no e4m3, so a ue4m3 scale reconstructs as NaN there.
+#[cfg(not(feature = "wgpu"))]
+#[test]
+fn two_level_error_should_not_track_weight_magnitude() {
+    use burn_tensor::ElementConversion;
+
+    let device = Default::default();
+
+    let big: TestTensor<2> = TestTensorInt::arange(-128..128, &device)
+        .float()
+        .div_scalar(128.)
+        .reshape([16, 16]);
+    let small = big.clone().mul_scalar(0.02);
+
+    let base = device
+        .settings()
+        .quantization
+        .scheme
+        .with_value(QuantValue::Q8S);
+    let two_level = base
+        .per_block([2, 16], ScaleDtype::UE4M3)
+        .per_tensor(ScaleDtype::F32);
+    let one_level = base.per_block([2, 16], ScaleDtype::UE4M3);
+
+    let error = |tensor: TestTensor<2>, scheme: &QuantScheme| -> f32 {
+        let reference = tensor.clone();
+        let dequantized = tensor.quantize_dynamic(scheme).dequantize();
+        let diff: FloatElem = (reference.clone() - dequantized).abs().sum().into_scalar();
+        let total: FloatElem = reference.abs().sum().into_scalar();
+        diff.elem::<f32>() / total.elem::<f32>()
+    };
+
+    let big_error = error(big.clone(), &two_level);
+    let small_error = error(small.clone(), &two_level);
+
+    assert!(
+        (small_error - big_error).abs() / big_error < 0.2,
+        "two-level error should be the same at either magnitude, \
+         got {big_error} and {small_error}"
+    );
+
+    // A one-level scheme's scales have to cover the magnitude themselves, and underflow here.
+    let small_one_level = error(small, &one_level);
+    assert!(
+        small_one_level > small_error * 2.0,
+        "one-level 8-bit scales should degrade on small weights where two-level does not, \
+         got one-level {small_one_level} and two-level {small_error}"
     );
 }
 
@@ -251,7 +338,7 @@ fn should_quantize_symmetric_per_block_int8_transposed_32x64() {
         .quantization
         .scheme
         .with_value(QuantValue::Q8S)
-        .with_level(QuantLevel::block([32]));
+        .per_block([32], ScaleDtype::F32);
     should_quantize_transposed(tensor, scheme);
 }
 
@@ -269,7 +356,7 @@ fn should_dequantize_symmetric_per_block_int8_transposed_32x64() {
         .quantization
         .scheme
         .with_value(QuantValue::Q8S)
-        .with_level(QuantLevel::block([32]));
+        .per_block([32], ScaleDtype::F32);
 
     should_dequantize_transposed(tensor, scheme);
 }
@@ -288,7 +375,7 @@ fn should_dequantize_symmetric_per_block_int8_permuted_2x8x16() {
         .quantization
         .scheme
         .with_value(QuantValue::Q8S)
-        .with_level(QuantLevel::block([1, 2, 16]));
+        .per_block([1, 2, 16], ScaleDtype::F32);
     let expected = tensor.clone().permute([1, 2, 0]);
     let output = tensor
         .quantize_dynamic(&scheme)
@@ -315,7 +402,7 @@ fn should_dequantize_symmetric_per_block_int8_permuted_packed_axis_first() {
         .quantization
         .scheme
         .with_value(QuantValue::Q8S)
-        .with_level(QuantLevel::block([1, 2, 16]));
+        .per_block([1, 2, 16], ScaleDtype::F32);
     let expected = tensor.clone().permute([2, 0, 1]);
     let output = tensor
         .quantize_dynamic(&scheme)
@@ -356,4 +443,31 @@ fn should_quantize_symmetric_int8_permuted_batch_dims() {
         &output.into_data(),
         Tolerance::absolute(1e-1).set_relative(1e-2),
     );
+}
+
+#[test]
+fn should_quantize_symmetric_two_level_f16_block_scales() {
+    let device = Default::default();
+
+    let input: TestTensor<2> = TestTensorInt::arange(0..256, &device)
+        .float()
+        .div_scalar(256.)
+        .reshape([16, 16]);
+
+    let scheme = device
+        .settings()
+        .quantization
+        .scheme
+        .with_value(QuantValue::Q8S)
+        .per_block([2, 16], ScaleDtype::F16)
+        .per_tensor(ScaleDtype::F32);
+
+    let quantized = input.clone().quantize_dynamic(&scheme);
+    let direct = quantized.clone().dequantize().into_data();
+
+    let reloaded = TestTensor::<2>::from_data(quantized.into_data(), &device);
+    let round_tripped = reloaded.dequantize().into_data();
+
+    round_tripped.assert_eq(&direct, true);
+    direct.assert_approx_eq(&input.into_data(), Tolerance::<f32>::rel_abs(1e-2, 1e-2));
 }

--- a/crates/burn-backend-tests/tests/tensor/float/quantization/scheme.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/quantization/scheme.rs
@@ -1,8 +1,8 @@
 use super::*;
 use burn_tensor::Tolerance;
 use burn_tensor::{
-    Device, Element, TensorData,
-    quantization::{CalibrationRange, QuantLevel, QuantValue, compute_q_params},
+    Device, Element, FloatDType, TensorData,
+    quantization::{CalibrationRange, QuantValue, ScaleDtype, compute_q_params},
 };
 
 #[test]
@@ -38,13 +38,92 @@ fn per_block_symmetric_int8() {
         .quantization
         .scheme
         .with_value(QuantValue::Q8S)
-        .with_level(QuantLevel::block([4]));
+        .per_block([4], ScaleDtype::F32);
 
     let qparams = compute_q_params(&scheme, range);
 
     qparams.scales.into_data().assert_approx_eq::<FloatElem>(
         &TensorData::from([0.014_173_23, 0.014_173_23, 0.000_314_96, 0.000_314_96]),
         Tolerance::default(),
+    );
+}
+
+#[test]
+fn block_tensor_symmetric_int8() {
+    let device = Default::default();
+    let min = TestTensor::<1>::from_data([-1.8, -0.5, 0.01, -0.04], &device);
+    let max = TestTensor::<1>::from_data([0.5, 1.8, 0.04, -0.01], &device);
+    let range = || CalibrationRange {
+        min: min.clone(),
+        max: max.clone(),
+    };
+
+    let scheme = device
+        .settings()
+        .quantization
+        .scheme
+        .with_value(QuantValue::Q8S);
+    let one_level = scheme.per_block([4], ScaleDtype::F32);
+    let two_level = scheme
+        .per_block([4], ScaleDtype::UE4M3)
+        .per_tensor(ScaleDtype::F32);
+
+    let expected = compute_q_params(&one_level, range()).scales.into_data();
+    let qparams = compute_q_params(&two_level, range());
+    let global = qparams
+        .global
+        .expect("a two-level scheme should produce a per-tensor scale");
+
+    // The largest block scale is pushed to the top of what ue4m3 can hold, which is the point of
+    // splitting the scale in two.
+    qparams
+        .scales
+        .clone()
+        .max()
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&TensorData::from([448.0]), Tolerance::default());
+
+    // The global is f32 whatever the element type is, hence the cast.
+    qparams
+        .scales
+        .mul(global.cast(FloatDType::from(FloatElem::dtype())))
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
+}
+
+/// A tensor with nothing in it divides `0` by `448`, and dividing the block scales by that
+/// quotient is where a zero becomes a NaN.
+#[test]
+fn block_tensor_symmetric_int8_all_zero() {
+    let device = Device::default();
+    let zeros = TestTensor::<1>::zeros([4], &device);
+    let range = CalibrationRange {
+        min: zeros.clone(),
+        max: zeros,
+    };
+
+    let scheme = device
+        .settings()
+        .quantization
+        .scheme
+        .with_value(QuantValue::Q8S)
+        .per_block([4], ScaleDtype::UE4M3)
+        .per_tensor(ScaleDtype::F32);
+
+    let qparams = compute_q_params(&scheme, range);
+    let global: f32 = qparams
+        .global
+        .expect("a two-level scheme should produce a per-tensor scale")
+        .into_scalar();
+    let scales: Vec<f32> = qparams.scales.into_data().iter::<f32>().collect();
+
+    assert!(
+        global > 0.0,
+        "a per-tensor scale of {global} leaves nothing to divide the block scales by"
+    );
+    assert!(
+        scales.iter().all(|scale| scale.is_finite()),
+        "block scales should stay finite for an empty tensor, got {scales:?}"
     );
 }
 

--- a/crates/burn-backend-tests/tests/tensor/float/quantization/scheme.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/quantization/scheme.rs
@@ -2,7 +2,7 @@ use super::*;
 use burn_tensor::Tolerance;
 use burn_tensor::{
     Device, Element, TensorData,
-    quantization::{CalibrationRange, QuantLevel, QuantValue, compute_q_params},
+    quantization::{CalibrationRange, QuantLevel, QuantParam, QuantValue, compute_q_params},
 };
 
 #[test]
@@ -46,6 +46,49 @@ fn per_block_symmetric_int8() {
         &TensorData::from([0.014_173_23, 0.014_173_23, 0.000_314_96, 0.000_314_96]),
         Tolerance::default(),
     );
+}
+
+#[test]
+fn block_tensor_symmetric_int8() {
+    let device = Default::default();
+    let min = TestTensor::<1>::from_data([-1.8, -0.5, 0.01, -0.04], &device);
+    let max = TestTensor::<1>::from_data([0.5, 1.8, 0.04, -0.01], &device);
+    let range = || CalibrationRange {
+        min: min.clone(),
+        max: max.clone(),
+    };
+
+    let scheme = device
+        .settings()
+        .quantization
+        .scheme
+        .with_value(QuantValue::Q8S);
+    let one_level = scheme.with_level(QuantLevel::block([4]));
+    let two_level = scheme
+        .with_level(QuantLevel::block_tensor([4], QuantParam::F32))
+        .with_param(QuantParam::UE4M3);
+
+    let expected = compute_q_params(&one_level, range()).scales.into_data();
+    let qparams = compute_q_params(&two_level, range());
+    let global = qparams
+        .global
+        .expect("a two-level scheme should produce a per-tensor scale");
+
+    // The largest block scale is pushed to the top of what ue4m3 can hold, which is the whole
+    // point of splitting the scale in two.
+    qparams
+        .scales
+        .clone()
+        .max()
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&TensorData::from([448.0]), Tolerance::default());
+
+    // The two levels multiply back to the scales a one-level scheme would have used.
+    qparams
+        .scales
+        .mul(global)
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
 }
 
 #[test]

--- a/crates/burn-backend/src/quantization/mod.rs
+++ b/crates/burn-backend/src/quantization/mod.rs
@@ -5,6 +5,7 @@ pub use parameters::*;
 pub use scheme::*;
 
 pub use burn_std::quantization::{
-    BlockSize, Calibration, QuantLevel, QuantMode, QuantParam, QuantPropagation, QuantScheme,
-    QuantStore, QuantValue, QuantizedBytes, scale_to_param,
+    BlockScale, BlockSize, Calibration, QuantMode, QuantPropagation, QuantScheme, QuantStore,
+    QuantValue, QuantizedBytes, ScaleDtype, global_scale_dtype, levels_supported, scale_to_dtype,
+    validate_levels,
 };

--- a/crates/burn-backend/src/quantization/mod.rs
+++ b/crates/burn-backend/src/quantization/mod.rs
@@ -6,5 +6,5 @@ pub use scheme::*;
 
 pub use burn_std::quantization::{
     BlockSize, Calibration, QuantLevel, QuantMode, QuantParam, QuantPropagation, QuantScheme,
-    QuantStore, QuantValue, QuantizedBytes, scale_to_param,
+    QuantStore, QuantValue, QuantizedBytes, scale_to_param, validate_levels,
 };

--- a/crates/burn-backend/src/quantization/mod.rs
+++ b/crates/burn-backend/src/quantization/mod.rs
@@ -6,6 +6,5 @@ pub use scheme::*;
 
 pub use burn_std::quantization::{
     BlockScale, BlockSize, Calibration, QuantMode, QuantPropagation, QuantScheme, QuantStore,
-    QuantValue, QuantizedBytes, ScaleDtype, global_scale_dtype, levels_supported, scale_to_dtype,
-    validate_levels,
+    QuantValue, QuantizedBytes, ScaleDtype, global_scale_dtype, quantizable, scale_to_dtype,
 };

--- a/crates/burn-backend/src/quantization/parameters.rs
+++ b/crates/burn-backend/src/quantization/parameters.rs
@@ -10,6 +10,11 @@ pub use burn_std::quantization::{QParamTensor, QParams};
 /// to the backends. It is not designed for direct usage by users, and not recommended to import
 /// or use this struct directly.
 pub struct QuantizationParametersPrimitive<B: Backend> {
-    /// The scaling factor.
+    /// The scaling factor, one per block or a single one for a per-tensor level, in the quantized
+    /// tensor's float dtype.
     pub scales: B::FloatTensorPrimitive,
+    /// The per-tensor scale that [`scales`](Self::scales) are expressed relative to, for a
+    /// two-level scheme. Always `f32`, unlike `scales`, so the two cannot go into a binary op
+    /// without a cast.
+    pub global: Option<B::FloatTensorPrimitive>,
 }

--- a/crates/burn-backend/src/quantization/parameters.rs
+++ b/crates/burn-backend/src/quantization/parameters.rs
@@ -10,6 +10,9 @@ pub use burn_std::quantization::{QParamTensor, QParams};
 /// to the backends. It is not designed for direct usage by users, and not recommended to import
 /// or use this struct directly.
 pub struct QuantizationParametersPrimitive<B: Backend> {
-    /// The scaling factor.
+    /// The scaling factor, one per block or a single one for a per-tensor level.
     pub scales: B::FloatTensorPrimitive,
+    /// The per-tensor scale that [`scales`](Self::scales) are expressed relative to, for a
+    /// two-level scheme. A value is reconstructed as `q * global * scale`.
+    pub global: Option<B::FloatTensorPrimitive>,
 }

--- a/crates/burn-backend/src/quantization/scheme.rs
+++ b/crates/burn-backend/src/quantization/scheme.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 pub use burn_std::{BlockLayout, QPARAM_ALIGN, params_shape};
 use burn_std::{FloatDType, QuantScheme, ScaleDtype, Shape, quantization::global_scale_dtype};
 

--- a/crates/burn-backend/src/quantization/scheme.rs
+++ b/crates/burn-backend/src/quantization/scheme.rs
@@ -31,8 +31,9 @@ fn reduce_blocks<B: Backend>(
         split.push(extent);
     }
     let mut blocks = B::float_reshape(tensor, Shape::from(split.clone()));
-    // Reductions keep their axis at size 1, so the block axes stay where they were.
-    for axis in (1..split.len()).step_by(2) {
+    // Reductions keep their axis at size 1, so the block axes stay where they were; an axis
+    // already at 1 has nothing to fold and would only cost a launch.
+    for axis in (1..split.len()).step_by(2).filter(|&axis| split[axis] > 1) {
         blocks = reduce(blocks, axis);
     }
     B::float_reshape(blocks, params_shape(&shape, scheme))

--- a/crates/burn-backend/src/quantization/scheme.rs
+++ b/crates/burn-backend/src/quantization/scheme.rs
@@ -1,5 +1,5 @@
-use burn_std::{QuantLevel, QuantMode, QuantParam, QuantScheme, Shape};
 pub use burn_std::{QPARAM_ALIGN, params_shape};
+use burn_std::{QuantLevel, QuantMode, QuantParam, QuantScheme, Shape};
 
 use super::{Calibration, QuantizationParametersPrimitive};
 use crate::{Backend, TensorMetadata, get_device_settings};

--- a/crates/burn-backend/src/quantization/scheme.rs
+++ b/crates/burn-backend/src/quantization/scheme.rs
@@ -1,11 +1,11 @@
-pub use burn_std::{BlockGrid, QPARAM_ALIGN, params_shape};
+pub use burn_std::{BlockLayout, QPARAM_ALIGN, params_shape};
 use burn_std::{FloatDType, QuantScheme, ScaleDtype, Shape, quantization::global_scale_dtype};
 
 use super::{Calibration, QuantizationParametersPrimitive};
 use crate::{Backend, TensorMetadata, get_device_settings};
 
-/// One value per block of `scheme`'s grid: `tensor` viewed as `[g0, b0, g1, b1, ...]`, every
-/// block axis folded by `reduce`, and the result in the grid's shape ([`params_shape`]).
+/// One value per block: `tensor` viewed as `[n0, b0, n1, b1, ...]`, every block axis folded by
+/// `reduce`, and the result shaped as the block scales are ([`params_shape`]).
 ///
 /// A block is a rectangle, not a run of elements: `[2, 2]` on a `[2, 4]` tensor holds
 /// `[a, b, e, f]`, so chunking the flat storage would only be right for a block that spans the

--- a/crates/burn-backend/src/quantization/scheme.rs
+++ b/crates/burn-backend/src/quantization/scheme.rs
@@ -1,8 +1,42 @@
+pub use burn_std::{BlockGrid, QPARAM_ALIGN, params_shape};
 use burn_std::{FloatDType, QuantScheme, ScaleDtype, Shape, quantization::global_scale_dtype};
-pub use burn_std::{QPARAM_ALIGN, params_shape};
 
 use super::{Calibration, QuantizationParametersPrimitive};
 use crate::{Backend, TensorMetadata, get_device_settings};
+
+/// One value per block of `scheme`'s grid: `tensor` viewed as `[g0, b0, g1, b1, ...]`, every
+/// block axis folded by `reduce`, and the result in the grid's shape ([`params_shape`]).
+///
+/// A block is a rectangle, not a run of elements: `[2, 2]` on a `[2, 4]` tensor holds
+/// `[a, b, e, f]`, so chunking the flat storage would only be right for a block that spans the
+/// trailing dimension.
+fn reduce_blocks<B: Backend>(
+    tensor: B::FloatTensorPrimitive,
+    scheme: &QuantScheme,
+    reduce: impl Fn(B::FloatTensorPrimitive, usize) -> B::FloatTensorPrimitive,
+) -> B::FloatTensorPrimitive {
+    let shape = tensor.shape();
+    let block = scheme
+        .block_size()
+        .expect("only a block scheme has blocks to reduce");
+    let block = block.to_dim_vec(shape.num_dims());
+    let mut split = Vec::with_capacity(2 * shape.num_dims());
+    for (&dim, &extent) in shape.iter().zip(&block) {
+        let extent = extent as usize;
+        assert!(
+            dim.is_multiple_of(extent),
+            "Tensor {shape:?} must be evenly divisible by block size {block:?}"
+        );
+        split.push(dim / extent);
+        split.push(extent);
+    }
+    let mut blocks = B::float_reshape(tensor, Shape::from(split.clone()));
+    // Reductions keep their axis at size 1, so the block axes stay where they were.
+    for axis in (1..split.len()).step_by(2) {
+        blocks = reduce(blocks, axis);
+    }
+    B::float_reshape(blocks, params_shape(&shape, scheme))
+}
 
 /// Compute the quantization range mapping.
 pub fn compute_range<B: Backend>(
@@ -13,27 +47,10 @@ pub fn compute_range<B: Backend>(
     match calibration {
         Calibration::MinMax => match scheme.block_size() {
             None => (B::float_min(tensor.clone()), B::float_max(tensor)),
-            Some(block_size) => {
-                let block_elems = block_size.num_elements();
-                let shape = tensor.shape();
-                let numel = shape.num_elements();
-
-                assert_eq!(
-                    numel % block_elems,
-                    0,
-                    "Tensor {shape:?} must be evenly divisible by block size {block_elems}"
-                );
-
-                let num_blocks = numel / block_elems;
-
-                let params_shape = params_shape(&shape, scheme);
-
-                let blocks = B::float_reshape(tensor, Shape::new([num_blocks, block_elems]));
-                let blocks_min =
-                    B::float_reshape(B::float_min_dim(blocks.clone(), 1), params_shape.clone());
-                let blocks_max = B::float_reshape(B::float_max_dim(blocks, 1), params_shape);
-                (blocks_min, blocks_max)
-            }
+            Some(_) => (
+                reduce_blocks::<B>(tensor.clone(), scheme, B::float_min_dim),
+                reduce_blocks::<B>(tensor, scheme, B::float_max_dim),
+            ),
         },
         Calibration::AbsMean => {
             // gamma = mean(|W|) per tensor or block — symmetric range [-gamma, +gamma]
@@ -44,25 +61,7 @@ pub fn compute_range<B: Backend>(
             );
             let gamma = match scheme.block_size() {
                 None => B::float_mean(B::float_abs(tensor)),
-                Some(block_size) => {
-                    let block_elems = block_size.num_elements();
-                    let shape = tensor.shape();
-                    let numel = shape.num_elements();
-
-                    assert_eq!(
-                        numel % block_elems,
-                        0,
-                        "Tensor {shape:?} must be evenly divisible by block size {block_elems}"
-                    );
-
-                    let num_blocks = numel / block_elems;
-                    let params_shape = params_shape(&shape, scheme);
-                    let blocks = B::float_reshape(
-                        B::float_abs(tensor),
-                        Shape::new([num_blocks, block_elems]),
-                    );
-                    B::float_reshape(B::float_mean_dim(blocks, 1), params_shape)
-                }
+                Some(_) => reduce_blocks::<B>(B::float_abs(tensor), scheme, B::float_mean_dim),
             };
             let neg_gamma = B::float_neg(gamma.clone());
             (neg_gamma, gamma)

--- a/crates/burn-backend/src/quantization/scheme.rs
+++ b/crates/burn-backend/src/quantization/scheme.rs
@@ -109,6 +109,13 @@ fn normalize_scales<B: Backend>(
     scales: B::FloatTensorPrimitive,
     block_dtype: ScaleDtype,
 ) -> (B::FloatTensorPrimitive, B::FloatTensorPrimitive) {
+    // Dividing by the block dtype's maximum is what lands the largest block scale exactly on it,
+    // so a dtype whose maximum reaches f32's range drives the per-tensor scale subnormal instead.
+    assert!(
+        block_dtype.max_representable() <= burn_std::f16::MAX.to_f32(),
+        "block scales in {block_dtype:?} reach f32's range, which a per-tensor scale cannot absorb"
+    );
+
     let dtype = scales.dtype().into();
     let scales_f32 = B::float_cast(scales, FloatDType::F32);
 

--- a/crates/burn-backend/src/quantization/scheme.rs
+++ b/crates/burn-backend/src/quantization/scheme.rs
@@ -1,5 +1,5 @@
+use burn_std::{FloatDType, QuantScheme, ScaleDtype, Shape, quantization::global_scale_dtype};
 pub use burn_std::{QPARAM_ALIGN, params_shape};
-use burn_std::{QuantLevel, QuantMode, QuantScheme, Shape};
 
 use super::{Calibration, QuantizationParametersPrimitive};
 use crate::{Backend, TensorMetadata, get_device_settings};
@@ -11,9 +11,9 @@ pub fn compute_range<B: Backend>(
     calibration: &Calibration,
 ) -> (B::FloatTensorPrimitive, B::FloatTensorPrimitive) {
     match calibration {
-        Calibration::MinMax => match scheme.level {
-            QuantLevel::Tensor => (B::float_min(tensor.clone()), B::float_max(tensor)),
-            QuantLevel::Block(block_size) => {
+        Calibration::MinMax => match scheme.block_size() {
+            None => (B::float_min(tensor.clone()), B::float_max(tensor)),
+            Some(block_size) => {
                 let block_elems = block_size.num_elements();
                 let shape = tensor.shape();
                 let numel = shape.num_elements();
@@ -26,7 +26,7 @@ pub fn compute_range<B: Backend>(
 
                 let num_blocks = numel / block_elems;
 
-                let params_shape = params_shape(&shape, scheme.level);
+                let params_shape = params_shape(&shape, scheme);
 
                 let blocks = B::float_reshape(tensor, Shape::new([num_blocks, block_elems]));
                 let blocks_min =
@@ -34,15 +34,17 @@ pub fn compute_range<B: Backend>(
                 let blocks_max = B::float_reshape(B::float_max_dim(blocks, 1), params_shape);
                 (blocks_min, blocks_max)
             }
-            QuantLevel::BlockTensor { .. } => {
-                unimplemented!("two-level quantization is not supported yet")
-            }
         },
         Calibration::AbsMean => {
             // gamma = mean(|W|) per tensor or block — symmetric range [-gamma, +gamma]
-            let gamma = match scheme.level {
-                QuantLevel::Tensor => B::float_mean(B::float_abs(tensor)),
-                QuantLevel::Block(block_size) => {
+            assert!(
+                global_scale_dtype(scheme).is_none(),
+                "AbsMean calibration has no two-level form: BitNet's gamma is a mean over \
+                 the whole tensor or block, which a per-tensor scale cannot decompose"
+            );
+            let gamma = match scheme.block_size() {
+                None => B::float_mean(B::float_abs(tensor)),
+                Some(block_size) => {
                     let block_elems = block_size.num_elements();
                     let shape = tensor.shape();
                     let numel = shape.num_elements();
@@ -54,15 +56,12 @@ pub fn compute_range<B: Backend>(
                     );
 
                     let num_blocks = numel / block_elems;
-                    let params_shape = params_shape(&shape, scheme.level);
+                    let params_shape = params_shape(&shape, scheme);
                     let blocks = B::float_reshape(
                         B::float_abs(tensor),
                         Shape::new([num_blocks, block_elems]),
                     );
                     B::float_reshape(B::float_mean_dim(blocks, 1), params_shape)
-                }
-                QuantLevel::BlockTensor { .. } => {
-                    unimplemented!("two-level quantization is not supported yet")
                 }
             };
             let neg_gamma = B::float_neg(gamma.clone());
@@ -77,32 +76,51 @@ pub fn compute_q_params<B: Backend>(
     min: B::FloatTensorPrimitive,
     max: B::FloatTensorPrimitive,
 ) -> QuantizationParametersPrimitive<B> {
-    match scheme {
-        QuantScheme {
-            level: QuantLevel::Tensor | QuantLevel::Block(_),
-            mode: QuantMode::Symmetric,
-            ..
-        } => {
-            let bool_dtype = get_device_settings::<B>(&min.device()).bool_dtype;
-            // Quantized range `[a, b]`
-            let (a, b) = scheme.value.range();
+    let bool_dtype = get_device_settings::<B>(&min.device()).bool_dtype;
+    // Quantized range `[a, b]`
+    let (a, b) = scheme.value.range();
 
-            // Compute scale to convert an input value in range `[-alpha, alpha]`
-            let min_abs = B::float_abs(min);
-            let max_abs = B::float_abs(max);
+    // Compute scale to convert an input value in range `[-alpha, alpha]`
+    let min_abs = B::float_abs(min);
+    let max_abs = B::float_abs(max);
 
-            // `min_abs.max_pair(max_abs)`
-            let mask = B::float_lower(min_abs.clone(), max_abs.clone(), bool_dtype);
-            let values_range =
-                B::float_mul_scalar(B::float_mask_where(min_abs, mask, max_abs), 2f32.into());
+    // `min_abs.max_pair(max_abs)`
+    let mask = B::float_lower(min_abs.clone(), max_abs.clone(), bool_dtype);
+    let values_range =
+        B::float_mul_scalar(B::float_mask_where(min_abs, mask, max_abs), 2f32.into());
 
-            QuantizationParametersPrimitive {
-                scales: B::float_div_scalar(values_range, (b - a).into()),
-            }
+    let scales = B::float_div_scalar(values_range, (b - a).into());
+
+    let (scales, global) = match global_scale_dtype(scheme) {
+        None => (scales, None),
+        Some(_) => {
+            let (scales, global) = normalize_scales::<B>(scales, scheme.scale_dtype());
+            (scales, Some(global))
         }
-        QuantScheme {
-            level: QuantLevel::BlockTensor { .. },
-            ..
-        } => unimplemented!("two-level quantization is not supported yet"),
-    }
+    };
+
+    QuantizationParametersPrimitive { scales, global }
+}
+
+/// Splits block scales into a per-tensor scale and block scales relative to it, returned as
+/// `(scales, global)`. `global` is `f32`: at the block scales' precision it would land among the
+/// subnormals, keeping a number of bits that depends on the weights' magnitude.
+fn normalize_scales<B: Backend>(
+    scales: B::FloatTensorPrimitive,
+    block_dtype: ScaleDtype,
+) -> (B::FloatTensorPrimitive, B::FloatTensorPrimitive) {
+    let dtype = scales.dtype().into();
+    let scales_f32 = B::float_cast(scales, FloatDType::F32);
+
+    let global = B::float_div_scalar(
+        B::float_max(scales_f32.clone()),
+        block_dtype.max_representable().into(),
+    );
+    // Guards `0 / 0` for an all-zero tensor, and an underflow to zero for a very small one.
+    let global = B::float_clamp_min(global, f32::MIN_POSITIVE.into());
+
+    let broadcast = Shape::from(core::iter::repeat_n(1usize, scales_f32.shape().num_dims()));
+    let scales = B::float_div(scales_f32, B::float_reshape(global.clone(), broadcast));
+
+    (B::float_cast(scales, dtype), global)
 }

--- a/crates/burn-backend/src/quantization/scheme.rs
+++ b/crates/burn-backend/src/quantization/scheme.rs
@@ -13,7 +13,10 @@ pub fn compute_range<B: Backend>(
     match calibration {
         Calibration::MinMax => match scheme.level {
             QuantLevel::Tensor => (B::float_min(tensor.clone()), B::float_max(tensor)),
-            QuantLevel::Block(block_size) => {
+            QuantLevel::Block(block_size)
+            | QuantLevel::BlockTensor {
+                block: block_size, ..
+            } => {
                 let block_elems = block_size.num_elements();
                 let shape = tensor.shape();
                 let numel = shape.num_elements();
@@ -38,6 +41,10 @@ pub fn compute_range<B: Backend>(
         Calibration::AbsMean => {
             // gamma = mean(|W|) per tensor or block — symmetric range [-gamma, +gamma]
             let gamma = match scheme.level {
+                QuantLevel::BlockTensor { .. } => panic!(
+                    "AbsMean calibration has no two-level form: BitNet's gamma is a mean over \
+                     the whole tensor or block, which a per-tensor scale cannot decompose"
+                ),
                 QuantLevel::Tensor => B::float_mean(B::float_abs(tensor)),
                 QuantLevel::Block(block_size) => {
                     let block_elems = block_size.num_elements();
@@ -72,6 +79,12 @@ pub fn compute_q_params<B: Backend>(
     max: B::FloatTensorPrimitive,
 ) -> QuantizationParametersPrimitive<B> {
     match scheme {
+        // A two-level scheme needs the per-tensor scale computed first, then the block scales
+        // divided through by it, which this signature has nowhere to return.
+        QuantScheme {
+            level: QuantLevel::BlockTensor { .. },
+            ..
+        } => unimplemented!("two-level calibration is not implemented yet"),
         QuantScheme {
             level: QuantLevel::Tensor | QuantLevel::Block(_),
             mode: QuantMode::Symmetric,

--- a/crates/burn-backend/src/quantization/scheme.rs
+++ b/crates/burn-backend/src/quantization/scheme.rs
@@ -132,7 +132,8 @@ fn normalize_scales<B: Backend>(
         B::float_max(scales.clone()),
         block_param.max_representable().into(),
     );
-    // Only reachable for an all-zero tensor, where the block scales would otherwise be `0 / 0`.
+    // Guards `0 / 0` for an all-zero tensor, and the flush to zero when the largest block scale is
+    // small enough that dividing it by the block param's maximum underflows.
     let global = B::float_clamp_min(global, f32::MIN_POSITIVE.into());
 
     let broadcast = Shape::from(vec![1usize; scales.shape().num_dims()]);

--- a/crates/burn-backend/src/quantization/scheme.rs
+++ b/crates/burn-backend/src/quantization/scheme.rs
@@ -1,5 +1,5 @@
+use burn_std::{QuantLevel, QuantMode, QuantParam, QuantScheme, Shape};
 pub use burn_std::{QPARAM_ALIGN, params_shape};
-use burn_std::{QuantLevel, QuantMode, QuantScheme, Shape};
 
 use super::{Calibration, QuantizationParametersPrimitive};
 use crate::{Backend, TensorMetadata, get_device_settings};
@@ -79,14 +79,7 @@ pub fn compute_q_params<B: Backend>(
     max: B::FloatTensorPrimitive,
 ) -> QuantizationParametersPrimitive<B> {
     match scheme {
-        // A two-level scheme needs the per-tensor scale computed first, then the block scales
-        // divided through by it, which this signature has nowhere to return.
         QuantScheme {
-            level: QuantLevel::BlockTensor { .. },
-            ..
-        } => unimplemented!("two-level calibration is not implemented yet"),
-        QuantScheme {
-            level: QuantLevel::Tensor | QuantLevel::Block(_),
             mode: QuantMode::Symmetric,
             ..
         } => {
@@ -103,9 +96,47 @@ pub fn compute_q_params<B: Backend>(
             let values_range =
                 B::float_mul_scalar(B::float_mask_where(min_abs, mask, max_abs), 2f32.into());
 
-            QuantizationParametersPrimitive {
-                scales: B::float_div_scalar(values_range, (b - a).into()),
+            let scales = B::float_div_scalar(values_range, (b - a).into());
+
+            match scheme.level.global_param() {
+                None => QuantizationParametersPrimitive {
+                    scales,
+                    global: None,
+                },
+                Some(_) => {
+                    let (scales, global) = normalize_scales::<B>(scales, scheme.param);
+                    QuantizationParametersPrimitive {
+                        scales,
+                        global: Some(global),
+                    }
+                }
             }
         }
     }
+}
+
+/// Split block scales into a per-tensor scale and block scales relative to it.
+///
+/// The global is picked so the largest block scale lands at the top of `block_param`'s range, which
+/// is what lets a narrow type cover a tensor whose raw scales would otherwise overflow or underflow
+/// it.
+///
+/// Both levels come back unrounded, as the one-level scales do. Backends round each to the
+/// precision it is stored in and quantize against that product, so the values they write already
+/// account for it.
+fn normalize_scales<B: Backend>(
+    scales: B::FloatTensorPrimitive,
+    block_param: QuantParam,
+) -> (B::FloatTensorPrimitive, B::FloatTensorPrimitive) {
+    let global = B::float_div_scalar(
+        B::float_max(scales.clone()),
+        block_param.max_representable().into(),
+    );
+    // Only reachable for an all-zero tensor, where the block scales would otherwise be `0 / 0`.
+    let global = B::float_clamp_min(global, f32::MIN_POSITIVE.into());
+
+    let broadcast = Shape::from(vec![1usize; scales.shape().num_dims()]);
+    let scales = B::float_div(scales, B::float_reshape(global.clone(), broadcast));
+
+    (scales, global)
 }

--- a/crates/burn-core/src/module/lora.rs
+++ b/crates/burn-core/src/module/lora.rs
@@ -275,16 +275,14 @@ mod tests {
     #[test]
     fn qlora_quantizes_base_and_attaches_adapter() {
         use crate::module::Quantizer;
-        use burn_tensor::quantization::{Calibration, QuantLevel, QuantParam, QuantValue};
+        use burn_tensor::quantization::{Calibration, QuantValue};
 
         let device = test_device();
         let scheme = device
             .settings()
             .quantization
             .scheme
-            .with_value(QuantValue::Q8S)
-            .with_level(QuantLevel::Tensor)
-            .with_param(QuantParam::F32);
+            .with_value(QuantValue::Q8S);
         let quantizer = Quantizer::new(Calibration::MinMax, scheme);
 
         let original = SimpleLinear::new(8, 8, &device).weight.val();
@@ -306,16 +304,14 @@ mod tests {
     fn qlora_composes_packed_base_at_the_configured_factor_dtype() {
         use crate::module::Quantizer;
         use burn_tensor::DType;
-        use burn_tensor::quantization::{Calibration, QuantLevel, QuantParam, QuantValue};
+        use burn_tensor::quantization::{Calibration, QuantValue};
 
         let device = test_device();
         let scheme = device
             .settings()
             .quantization
             .scheme
-            .with_value(QuantValue::Q8S)
-            .with_level(QuantLevel::Tensor)
-            .with_param(QuantParam::F32);
+            .with_value(QuantValue::Q8S);
         let quantizer = Quantizer::new(Calibration::MinMax, scheme);
 
         // A packed base carries no float dtype, so the configured one is the

--- a/crates/burn-core/src/module/quantize.rs
+++ b/crates/burn-core/src/module/quantize.rs
@@ -75,7 +75,7 @@ mod tests {
     use crate::test_utils::SimpleLinear;
     use burn_tensor::{
         Device, Tensor, Tolerance,
-        quantization::{Calibration, QuantLevel, QuantParam, QuantScheme, QuantValue},
+        quantization::{Calibration, QuantScheme, QuantValue},
     };
 
     /// Per-tensor Q8 symmetric scheme used across these tests.
@@ -85,8 +85,6 @@ mod tests {
             .quantization
             .scheme
             .with_value(QuantValue::Q8S)
-            .with_level(QuantLevel::Tensor)
-            .with_param(QuantParam::F32)
     }
 
     /// Whether a tensor currently holds quantized (`QFloat`) data.

--- a/crates/burn-cubecl-fusion/src/base.rs
+++ b/crates/burn-cubecl-fusion/src/base.rs
@@ -1,6 +1,10 @@
 use burn_fusion::stream::Context;
-use burn_std::{DType, Shape, Strides, quantization::QParamTensor, strides};
-use cubecl::quant::scheme::{QuantParam, QuantScheme};
+use burn_std::{
+    DType, Shape, Strides,
+    quantization::{QParamTensor, global_scale_dtype},
+    strides,
+};
+use cubecl::quant::scheme::{QuantScheme, ScaleDtype};
 use cubecl::{
     Runtime,
     client::ComputeClient,
@@ -91,6 +95,12 @@ impl<R: Runtime> CubeFusionHandle<R> {
     /// Construct a separate tensor for the quantization scales, if present
     pub fn params(&self, scheme: QuantScheme) -> Option<Self> {
         let qparams = self.qparams.as_ref()?;
+        // Only the block scale is threaded through below; a two-level scheme's per-tensor scale
+        // would be silently dropped, so refuse rather than build a handle short one factor.
+        assert!(
+            global_scale_dtype(&scheme).is_none(),
+            "fused kernels don't yet support a two-level scheme's per-tensor scale"
+        );
         let mut handle = self.handle.clone();
         handle.offset_start = Some(qparams.scales.offset_start as u64);
         handle.offset_end = Some(qparams.scales.offset_end as u64);
@@ -99,11 +109,11 @@ impl<R: Runtime> CubeFusionHandle<R> {
             client: self.client.clone(),
             handle,
             device: self.device.clone(),
-            dtype: match scheme.param {
-                QuantParam::F32 => DType::F32,
-                QuantParam::F16 => DType::F16,
-                QuantParam::BF16 => DType::BF16,
-                QuantParam::UE8M0 | QuantParam::UE4M3 => unimplemented!("Not yet supported"),
+            dtype: match scheme.scale_dtype() {
+                ScaleDtype::F32 => DType::F32,
+                ScaleDtype::F16 => DType::F16,
+                ScaleDtype::BF16 => DType::BF16,
+                ScaleDtype::UE8M0 | ScaleDtype::UE4M3 => unimplemented!("Not yet supported"),
             },
             strides: qparams.scales.metadata.strides().clone(),
             qparams: None,

--- a/crates/burn-cubecl-fusion/src/base.rs
+++ b/crates/burn-cubecl-fusion/src/base.rs
@@ -17,7 +17,16 @@ pub trait FallbackOperation<R: Runtime>: Send + Sync {
 
 /// Runtime parameters for quantization. Can be used to construct a scales handle from the base
 /// tensor handle.
-pub type QParams = burn_std::quantization::QParams<QParamTensor>;
+///
+/// Carries the per-tensor scale even though no fused kernel applies one, because every quantized
+/// tensor on a fused backend round trips through this handle whether or not anything fuses.
+#[derive(Clone, Debug)]
+pub struct QParams {
+    /// The block scales.
+    pub scales: QParamTensor,
+    /// The per-tensor scale of a two-level scheme.
+    pub global: Option<QParamTensor>,
+}
 
 /// Handle to be used when fusing operations.
 pub struct CubeFusionHandle<R: Runtime> {

--- a/crates/burn-cubecl-fusion/src/engine/codegen/io.rs
+++ b/crates/burn-cubecl-fusion/src/engine/codegen/io.rs
@@ -3,7 +3,7 @@ use crate::engine::codegen::{DynElem, DynSize};
 
 use super::{ir::*, tensor::GlobalTensor};
 use burn_std::quantization::QuantScheme;
-use cubecl::quant::scheme::{QuantLevel, QuantStore};
+use cubecl::quant::scheme::QuantStore;
 use cubecl::{
     intrinsic,
     prelude::*,
@@ -318,20 +318,21 @@ pub fn input_as_scales_view<C: Scalar, N: Size>(
     inputs: &GlobalArgs,
     #[comptime] pos: usize,
     #[comptime] tensor_pos: usize,
-    #[comptime] level: QuantLevel,
+    #[comptime] scheme: QuantScheme,
     #[comptime] config: &FuseBlockConfig,
 ) -> View<'static, C, usize> {
+    comptime!(assert!(
+        burn_std::quantization::global_scale_dtype(&scheme).is_none(),
+        "two-level quantization is not supported in fused kernels yet"
+    ));
     set_polyfill_typed::<Vector<C, N>, DynElem, DynSize>();
     let tensor = inputs.tensors.index(tensor_pos);
     let scales = inputs.tensors.index(pos);
     let tensor_len = tensor.tensor.len();
     let rank = config.rank;
-    let layout = match level {
-        QuantLevel::BlockTensor { .. } => {
-            unimplemented!("two-level quantization is not supported yet")
-        }
-        QuantLevel::Tensor => ScalesLayout::new_PerTensor(PerTensorLayout::new(tensor_len)),
-        QuantLevel::Block(block_size) => {
+    let layout = match comptime![scheme.block_size()] {
+        None => ScalesLayout::new_PerTensor(PerTensorLayout::new(tensor_len)),
+        Some(block_size) => {
             let block_size = comptime![block_size.to_dim_vec(rank)];
             let mut tensor_shape = Sequence::new();
             let mut scales_strides = Sequence::new();

--- a/crates/burn-cubecl-fusion/src/engine/codegen/io.rs
+++ b/crates/burn-cubecl-fusion/src/engine/codegen/io.rs
@@ -295,6 +295,9 @@ pub fn input_as_scales_view<C: Scalar, N: Size>(
     let tensor_len = tensor.tensor.len();
     let rank = config.rank;
     let layout = match level {
+        QuantLevel::BlockTensor { .. } => {
+            unimplemented!("two-level quantization is not supported in fused kernels yet")
+        }
         QuantLevel::Tensor => ScalesLayout::new_PerTensor(PerTensorLayout::new(tensor_len)),
         QuantLevel::Block(block_size) => {
             let block_size = comptime![block_size.to_dim_vec(rank)];

--- a/crates/burn-cubecl-fusion/src/engine/codegen/ir.rs
+++ b/crates/burn-cubecl-fusion/src/engine/codegen/ir.rs
@@ -2,7 +2,7 @@ use super::tensor::GlobalTensor;
 use crate::engine::codegen::{DynElem, DynSize, DynVector};
 use burn_std::{
     BoolStore, DType, Shape, Strides, bf16, f16,
-    quantization::{QuantParam, QuantScheme, QuantStore, QuantValue},
+    quantization::{QuantScheme, QuantStore, QuantValue, ScaleDtype, global_scale_dtype},
     strides,
 };
 use core::fmt::Display;
@@ -900,23 +900,28 @@ impl From<ElemType> for FuseType {
 }
 
 impl FuseType {
-    /// The type quantization scales are read as, or `None` when fusion can't read that param.
+    /// The type quantization scales are read as, or `None` when fusion can't read that dtype.
     ///
-    /// Callers must decline to fuse on `None` rather than fail: an unsupported param is only a
+    /// Callers must decline to fuse on `None` rather than fail: an unsupported dtype is only a
     /// missing feature here, and the unfused path still handles it.
-    pub fn from_quant_param(param: QuantParam) -> Option<Self> {
-        match param {
-            QuantParam::F32 => Some(Self::F32),
-            QuantParam::F16 => Some(Self::F16),
-            QuantParam::BF16 => Some(Self::BF16),
-            QuantParam::UE8M0 | QuantParam::UE4M3 => None,
+    pub fn from_scale_dtype(dtype: ScaleDtype) -> Option<Self> {
+        match dtype {
+            ScaleDtype::F32 => Some(Self::F32),
+            ScaleDtype::F16 => Some(Self::F16),
+            ScaleDtype::BF16 => Some(Self::BF16),
+            ScaleDtype::UE8M0 | ScaleDtype::UE4M3 => None,
         }
     }
 
     /// The type quantized values are read as, or `None` when fusion can't read that scheme.
     ///
-    /// Same contract as [Self::from_quant_param]: callers must decline to fuse on `None`.
+    /// Same contract as [Self::from_scale_dtype]: callers must decline to fuse on `None`.
     pub fn from_quant_scheme(scheme: QuantScheme) -> Option<Self> {
+        // No fused kernel applies a per-tensor scale.
+        if global_scale_dtype(&scheme).is_some() {
+            return None;
+        }
+
         match scheme.store {
             QuantStore::Native => match scheme.value {
                 QuantValue::Q8F | QuantValue::Q8S => Some(Self::I8),

--- a/crates/burn-cubecl-fusion/src/engine/codegen/kernel.rs
+++ b/crates/burn-cubecl-fusion/src/engine/codegen/kernel.rs
@@ -6,7 +6,9 @@ use cubecl::{
     ir::{ElemType, FloatKind, UIntKind},
     prelude::*,
 };
-use cubek::quantization::{dequantize::dequantize_symmetric_packed_value_at, scheme::QuantMode};
+use cubek::quantization::{
+    dequantize::dequantize_symmetric_packed_value_at, scale::Scales, scheme::QuantMode,
+};
 
 #[cube]
 /// Fuse element-wise operations at the given write position.
@@ -1003,15 +1005,9 @@ fn dequantize<C: Float, N: Size>(
             other => panic!("{other:?} doesn't support native packing"),
         },
     }];
-    let param_ty = comptime![match scheme.param {
-        cubecl::quant::scheme::QuantParam::F32 => ElemType::Float(FloatKind::F32),
-        cubecl::quant::scheme::QuantParam::F16 => ElemType::Float(FloatKind::F16),
-        cubecl::quant::scheme::QuantParam::BF16 => ElemType::Float(FloatKind::BF16),
-        cubecl::quant::scheme::QuantParam::UE8M0 => ElemType::Float(FloatKind::UE8M0),
-        cubecl::quant::scheme::QuantParam::UE4M3 => ElemType::Float(FloatKind::E4M3),
-    }];
+    let scale_ty = comptime![ElemType::from_scale_dtype(scheme.scale_dtype())];
     let define!(QStoreType) = quant_ty;
-    let define!(QParamType) = param_ty;
+    let define!(QScaleType) = scale_ty;
     let size!(NumQuant) = scheme.num_quants();
 
     let tensor_pos = comptime!(match input {
@@ -1026,8 +1022,10 @@ fn dequantize<C: Float, N: Size>(
     let num_quants = scheme.num_quants();
 
     set_polyfill_typed::<Vector<C, N>, DynElem, DynSize>();
-    let scales =
-        input_as_scales_view::<QParamType, Const<1>>(inputs, pos, tensor_pos, scheme.level, config);
+    let grid =
+        input_as_scales_view::<QScaleType, Const<1>>(inputs, pos, tensor_pos, scheme, config);
+    // A two-level scheme never reaches a fused kernel, so there is no per-tensor scale to apply.
+    let scales = Scales::<QScaleType>::new(&grid, ComptimeOption::new_None());
 
     let mut vector = Vector::empty();
     let packed_dim = comptime![match scheme.store {
@@ -1044,7 +1042,7 @@ fn dequantize<C: Float, N: Size>(
         let result = dequantize_symmetric_packed_value_at::<
             C,
             NumQuant,
-            QParamType,
+            QScaleType,
             QStoreType,
             QStoreSize,
         >(write_pos * num_quants, input, &scales, scheme);
@@ -1094,7 +1092,7 @@ fn dequantize<C: Float, N: Size>(
             let result = dequantize_symmetric_packed_value_at::<
                 C,
                 NumQuant,
-                QParamType,
+                QScaleType,
                 QStoreType,
                 Const<1>,
             >(logical_position, input, &scales, scheme);

--- a/crates/burn-cubecl-fusion/src/engine/codegen/kernel.rs
+++ b/crates/burn-cubecl-fusion/src/engine/codegen/kernel.rs
@@ -1044,9 +1044,17 @@ fn dequantize<C: Float, N: Size>(
         C,
         NumQuant,
         QParamType,
+        f32,
         QStoreType,
         QStoreSize,
-    >(write_pos * num_quants, input, &scales, scheme);
+    >(
+        write_pos * num_quants,
+        input,
+        &scales,
+        // `input_as_scales_view` above rejects two-level schemes, so there is none to apply here.
+        ComptimeOption::new_None(),
+        scheme,
+    );
 
     let mut vector = Vector::empty();
 

--- a/crates/burn-cubecl-fusion/src/engine/launch/input.rs
+++ b/crates/burn-cubecl-fusion/src/engine/launch/input.rs
@@ -79,7 +79,7 @@ impl<'a, R: Runtime> InputPlanner<'a, R> {
                     let precision_scales = params.dtype.into();
 
                     let global_shape = tensor_global.shape.clone();
-                    let shape_params = params_shape(&global_shape, scheme.level);
+                    let shape_params = params_shape(&global_shape, &scheme);
                     plan.handle_inputs
                         .push(HandleInput::QuantValues(QuantValuesHandleInput {
                             relative_id: tensor_relative.id,

--- a/crates/burn-cubecl-fusion/src/engine/trace/block.rs
+++ b/crates/burn-cubecl-fusion/src/engine/trace/block.rs
@@ -217,6 +217,9 @@ impl FuseBlockBuilder {
         }
 
         let (precision, precision_scales) = match tensor.dtype {
+            // No fused kernel applies a per-tensor scale, so declining here leaves the op to the
+            // unfused path rather than reconstructing every value short by that factor.
+            DType::QFloat(scheme) if scheme.level.global_param().is_some() => return None,
             DType::QFloat(scheme) => (
                 FuseType::from_quant_scheme(scheme)?,
                 FuseType::from_quant_param(scheme.param)?,

--- a/crates/burn-cubecl-fusion/src/engine/trace/block.rs
+++ b/crates/burn-cubecl-fusion/src/engine/trace/block.rs
@@ -219,7 +219,7 @@ impl FuseBlockBuilder {
         let (precision, precision_scales) = match tensor.dtype {
             DType::QFloat(scheme) => (
                 FuseType::from_quant_scheme(scheme)?,
-                FuseType::from_quant_param(scheme.param)?,
+                FuseType::from_scale_dtype(scheme.scale_dtype())?,
             ),
             _ => return None,
         };

--- a/crates/burn-cubecl-fusion/src/engine/trace/fuser.rs
+++ b/crates/burn-cubecl-fusion/src/engine/trace/fuser.rs
@@ -190,6 +190,9 @@ impl TraceFuser {
         }
 
         let (precision, precision_scales) = match tensor.dtype {
+            // No fused kernel applies a per-tensor scale, so declining here leaves the op to the
+            // unfused path rather than reconstructing every value short by that factor.
+            DType::QFloat(scheme) if scheme.level.global_param().is_some() => return None,
             DType::QFloat(scheme) => (
                 FuseType::from_quant_scheme(scheme)?,
                 FuseType::from_quant_param(scheme.param)?,

--- a/crates/burn-cubecl-fusion/src/engine/trace/fuser.rs
+++ b/crates/burn-cubecl-fusion/src/engine/trace/fuser.rs
@@ -192,7 +192,7 @@ impl TraceFuser {
         let (precision, precision_scales) = match tensor.dtype {
             DType::QFloat(scheme) => (
                 FuseType::from_quant_scheme(scheme)?,
-                FuseType::from_quant_param(scheme.param)?,
+                FuseType::from_scale_dtype(scheme.scale_dtype())?,
             ),
             _ => return None,
         };

--- a/crates/burn-cubecl-fusion/src/optim/matmul/args.rs
+++ b/crates/burn-cubecl-fusion/src/optim/matmul/args.rs
@@ -7,7 +7,7 @@ use crate::engine::codegen::{
 use cubecl::{
     intrinsic,
     prelude::*,
-    quant::scheme::{QuantLevel, QuantScheme},
+    quant::scheme::QuantScheme,
     std::{
         FastDivmod,
         quant::{
@@ -293,12 +293,13 @@ fn global_view<E: CubePrimitive>(
     match comptime![arg.clone()] {
         MatmulArg::Normal(_) => View::new::<GlobalInput, Coords1d>(data_buf, data_layout),
         MatmulArg::Quantized { scales, scheme, .. } => {
-            let scales_layout = match comptime![scheme.level] {
-                QuantLevel::BlockTensor { .. } => {
-                    unimplemented!("two-level quantization is not supported yet")
-                }
-                QuantLevel::Tensor => GlobalScaleLayout::new_PerTensor(shape),
-                QuantLevel::Block(block_size) => {
+            comptime!(assert!(
+                burn_std::quantization::global_scale_dtype(&scheme).is_none(),
+                "two-level quantization is not supported in fused matmul yet"
+            ));
+            let scales_layout = match comptime![scheme.block_size()] {
+                None => GlobalScaleLayout::new_PerTensor(shape),
+                Some(block_size) => {
                     let block_size = comptime![block_size.as_dim::<2>()];
 
                     let scales_arg = comptime![MatmulArg::Normal(scales.clone())];
@@ -469,9 +470,9 @@ fn create_quant_view<E: Numeric, N: Size, Q: Scalar, S: Scalar>(
         View::new::<GlobalInput, Coords1d>(data_buf, data_layout);
     let scales_view: View<S, BatchedCoords> =
         View::new::<GlobalInput, Coords1d>(scales_buf, scales_layout);
-    // No per-tensor scale on top of the block scales: two-level schemes are rejected where the
-    // scale layout is built, so there is never a second factor to fold in here.
-    QuantizedView::new(data_view, scales_view, ComptimeOption::new_None(), scheme).view()
+    // One binding: two-level schemes are rejected where the scale layout is built, so there is
+    // never a per-tensor scale to fold in here.
+    QuantizedView::new(data_view, scales_view, scheme).view()
 }
 
 #[derive(CubeType)]

--- a/crates/burn-cubecl-fusion/src/optim/matmul/args.rs
+++ b/crates/burn-cubecl-fusion/src/optim/matmul/args.rs
@@ -294,6 +294,9 @@ fn global_view<E: CubePrimitive>(
         MatmulArg::Normal(_) => View::new::<GlobalInput, Coords1d>(data_buf, data_layout),
         MatmulArg::Quantized { scales, scheme, .. } => {
             let scales_layout = match comptime![scheme.level] {
+                QuantLevel::BlockTensor { .. } => {
+                    unimplemented!("two-level quantization is not supported in fused matmul yet")
+                }
                 QuantLevel::Tensor => GlobalScaleLayout::new_PerTensor(shape),
                 QuantLevel::Block(block_size) => {
                     let block_size = comptime![block_size.as_dim::<2>()];

--- a/crates/burn-cubecl/src/backend.rs
+++ b/crates/burn-cubecl/src/backend.rs
@@ -4,7 +4,7 @@ use burn_backend::{
     Backend, BackendGraph, BackendTypes, DTypeUsage, DTypeUsageSet, DeviceOps, ExecutionError,
     TensorData,
 };
-use burn_std::{BoolStore, DType, quantization::levels_supported};
+use burn_std::{BoolStore, DType, quantization::quantizable};
 use cubecl::{
     client::ComputeClient,
     features::{MmaConfig, TypeUsage},
@@ -25,7 +25,7 @@ fn qfloat_params_usable<R: CubeRuntime>(client: &ComputeClient<R>, dtype: DType)
         return true;
     };
 
-    levels_supported(&scheme)
+    quantizable(&scheme)
         && client
             .properties()
             .type_usage(ElemType::from_scale_dtype(scheme.scale_dtype()))

--- a/crates/burn-cubecl/src/backend.rs
+++ b/crates/burn-cubecl/src/backend.rs
@@ -4,9 +4,11 @@ use burn_backend::{
     Backend, BackendGraph, BackendTypes, DTypeUsage, DTypeUsageSet, DeviceOps, ExecutionError,
     TensorData,
 };
-use burn_std::{BoolStore, DType};
+use burn_std::{BoolStore, DType, quantization::levels_supported};
 use cubecl::{
+    client::ComputeClient,
     features::{MmaConfig, TypeUsage},
+    ir::ElemType,
     server::ComputeServer,
 };
 use std::marker::PhantomData;
@@ -15,6 +17,20 @@ use std::marker::PhantomData;
 use burn_backend::tensor::{BoolTensor, FloatTensor, IntTensor, QuantizedTensor};
 #[cfg(not(feature = "fusion"))]
 use burn_ir::{BackendIr, TensorHandle};
+
+/// Whether the runtime can hold a quantized dtype's scales, which `dtype_to_storage_type` misses
+/// because it doesn't see the scheme's scale levels. Non-quantized dtypes always pass.
+fn qfloat_params_usable<R: CubeRuntime>(client: &ComputeClient<R>, dtype: DType) -> bool {
+    let DType::QFloat(scheme) = dtype else {
+        return true;
+    };
+
+    levels_supported(&scheme)
+        && client
+            .properties()
+            .type_usage(ElemType::from_scale_dtype(scheme.scale_dtype()))
+            .is_superset(TypeUsage::Buffer | TypeUsage::Conversion)
+}
 
 /// Turn a cubecl graph-capture error into a backend [`ExecutionError`].
 fn graph_err(err: impl core::fmt::Display) -> ExecutionError {
@@ -132,8 +148,11 @@ where
         if let DType::Bool(BoolStore::Native) = dtype {
             return false;
         }
-
         let client = R::client(device);
+
+        if !qfloat_params_usable::<R>(&client, dtype) {
+            return false;
+        }
 
         let type_usage = client.properties().type_usage(dtype_to_storage_type(dtype));
         // Same as `TypeUsage::all_scalar()`, but we make the usage explicit here
@@ -151,8 +170,11 @@ where
         if let DType::Bool(BoolStore::Native) = dtype {
             return DTypeUsageSet::empty();
         }
-
         let client = R::client(device);
+
+        if !qfloat_params_usable::<R>(&client, dtype) {
+            return DTypeUsageSet::empty();
+        }
 
         let props = client.properties();
         let storage = dtype_to_storage_type(dtype);

--- a/crates/burn-cubecl/src/fusion.rs
+++ b/crates/burn-cubecl/src/fusion.rs
@@ -1,4 +1,4 @@
-use crate::{CubeBackend, CubeRuntime, kernel, tensor::CubeTensor};
+use crate::{CubeBackend, CubeRuntime, kernel, tensor::CubeTensor, tensor::QParams};
 use burn_backend::tensor::{BoolTensor, FloatTensor, IntTensor, QuantizedTensor};
 use burn_backend::{DType, Shape};
 pub use burn_cubecl_fusion::{CubeFusionHandle, FallbackOperation};
@@ -153,7 +153,10 @@ fn into_tensor<R: CubeRuntime>(handle: CubeFusionHandle<R>, shape: Shape) -> Cub
         device: handle.device.clone(),
         meta: Box::new(Metadata::new(shape, handle.strides.clone())),
         dtype: handle.dtype,
-        qparams: handle.qparams.clone(),
+        qparams: handle.qparams.clone().map(|qparams| QParams {
+            scales: qparams.scales,
+            global: qparams.global,
+        }),
     }
 }
 
@@ -165,7 +168,13 @@ impl<R: CubeRuntime> From<CubeTensor<R>> for CubeFusionHandle<R> {
             device: value.device.clone(),
             strides: value.meta.strides.clone(),
             dtype: value.dtype,
-            qparams: value.qparams.clone(),
+            qparams: value
+                .qparams
+                .clone()
+                .map(|qparams| burn_cubecl_fusion::QParams {
+                    scales: qparams.scales,
+                    global: qparams.global,
+                }),
         }
     }
 }

--- a/crates/burn-cubecl/src/kernel/contiguous.rs
+++ b/crates/burn-cubecl/src/kernel/contiguous.rs
@@ -121,5 +121,15 @@ fn into_contiguous_quantized<R: CubeRuntime>(
         dtype_to_storage_type(dtype_scales),
     );
 
+    if let (Some(global), Some(out_global)) = (tensor.global(), output.global()) {
+        let dtype_global = global.dtype;
+        cubecl::std::tensor::copy_into(
+            &client,
+            global.binding(),
+            out_global.binding(),
+            dtype_to_storage_type(dtype_global),
+        );
+    }
+
     output
 }

--- a/crates/burn-cubecl/src/kernel/matmul/base.rs
+++ b/crates/burn-cubecl/src/kernel/matmul/base.rs
@@ -2,7 +2,7 @@ use super::init_matmul_output;
 use crate::{CubeRuntime, kernel::quantization::dequantize, tensor::CubeTensor};
 use burn_backend::cubecl::dtype_to_storage_type;
 use burn_backend::{DType, TensorMetadata};
-use burn_std::{MatmulTransformAnalysis, MatmulTransformPolicy, QuantLevel};
+use burn_std::{MatmulTransformAnalysis, MatmulTransformPolicy};
 use cubek::{
     matmul::{
         definition::{MatmulElems, MatmulGlobalElems, MatmulSetupError},
@@ -34,15 +34,35 @@ impl Default for MatmulStrategy {
     }
 }
 
+fn is_two_level<R: CubeRuntime>(tensor: &CubeTensor<R>) -> bool {
+    match tensor.dtype {
+        DType::QFloat(scheme) => burn_backend::quantization::global_scale_dtype(&scheme).is_some(),
+        _ => false,
+    }
+}
+
+fn maybe_dequantize<R: CubeRuntime>(tensor: CubeTensor<R>, dtype: DType) -> CubeTensor<R> {
+    if is_two_level(&tensor) {
+        dequantize(tensor, dtype)
+    } else {
+        tensor
+    }
+}
+
 /// Launch a matmul kernel using the given strategy.
 pub fn matmul<R: CubeRuntime>(
-    mut lhs: CubeTensor<R>,
+    lhs: CubeTensor<R>,
     rhs: CubeTensor<R>,
     out: Option<CubeTensor<R>>,
     strategy: MatmulStrategy,
     out_dtype: DType,
 ) -> Result<CubeTensor<R>, MatmulSetupError> {
     let out = out.unwrap_or_else(|| init_matmul_output(&lhs, &rhs, out_dtype));
+
+    // No quantized matmul kernel applies a per-tensor scale, and the autotune candidates panic on
+    // the level rather than decline it, taking the whole tuning run down with them.
+    let mut lhs = maybe_dequantize(lhs, out_dtype);
+    let rhs = maybe_dequantize(rhs, out_dtype);
 
     // A broadcast-rhs batched matmul that would tile poorly is folded into a
     // single matmul: `[.., b, m, k] @ [.., 1, k, n]` runs as `[.., 1, b*m, k]`
@@ -142,9 +162,7 @@ pub(crate) fn launch_matmul<R: CubeRuntime>(
         ),
         Some((data, scale)) => {
             // Extremely hacky fix to ensure naive can run in every case
-            if matches!(strategy, Strategy::Naive)
-                && matches!(rhs.scheme().level, QuantLevel::Block(_))
-            {
+            if matches!(strategy, Strategy::Naive) && rhs.scheme().block_size().is_some() {
                 rhs = dequantize(rhs.clone(), lhs_dtype);
                 let rhs_dtype = rhs.dtype;
                 (

--- a/crates/burn-cubecl/src/kernel/quantization/dequantize.rs
+++ b/crates/burn-cubecl/src/kernel/quantization/dequantize.rs
@@ -46,13 +46,18 @@ where
         tensor.shape(),
         dtype,
     );
+    let global = tensor.global();
     let (values, params) = tensor.quantized_handles().unwrap();
+
+    // Innermost first: the block scales, then the per-tensor scale they are normalized against.
+    let mut scales = vec![params.binding()];
+    scales.extend(global.map(|g| g.binding()));
 
     cubek::quantization::dequantize::launch_ref(
         &output.client,
         values.binding(),
         output.clone().binding(),
-        params.binding(),
+        &scales,
         &scheme,
         dtype_to_storage_type(dtype),
     )

--- a/crates/burn-cubecl/src/kernel/quantization/dequantize.rs
+++ b/crates/burn-cubecl/src/kernel/quantization/dequantize.rs
@@ -19,6 +19,7 @@ where
         tensor.shape(),
         dtype,
     );
+    let global = tensor.global();
     let (values, params) = tensor.quantized_handles().unwrap();
 
     cubek::quantization::dequantize::launch_ref(
@@ -26,6 +27,7 @@ where
         values.binding(),
         output.clone().binding(),
         params.binding(),
+        global.map(|g| g.binding()),
         &scheme,
         dtype_to_storage_type(dtype),
     )

--- a/crates/burn-cubecl/src/kernel/quantization/quantize.rs
+++ b/crates/burn-cubecl/src/kernel/quantization/quantize.rs
@@ -8,20 +8,29 @@ pub fn quantize<R>(
     tensor: CubeTensor<R>,
     scheme: &QuantScheme,
     scale: CubeTensor<R>,
+    global: Option<CubeTensor<R>>,
 ) -> CubeTensor<R>
 where
     R: CubeRuntime,
 {
     let output = empty_qtensor_optimized(tensor.shape(), *scheme, &tensor.device);
     let (out_values, out_params) = output.clone().quantized_handles().unwrap();
+    let out_global = output.global();
     let dtype = tensor.dtype;
+
+    // Innermost first: the block scales, then the per-tensor scale they are normalized against.
+    let mut scales = vec![scale.binding()];
+    scales.extend(global.map(|global| global.binding()));
+
+    let mut out_scales = vec![out_params.binding()];
+    out_scales.extend(out_global.map(|global| global.binding()));
 
     cubek::quantization::quantize::launch_ref(
         &output.client,
         tensor.binding(),
         out_values.binding(),
-        scale.binding(),
-        out_params.binding(),
+        &scales,
+        &out_scales,
         scheme,
         dtype_to_elem_type(dtype),
     )

--- a/crates/burn-cubecl/src/kernel/quantization/quantize.rs
+++ b/crates/burn-cubecl/src/kernel/quantization/quantize.rs
@@ -8,12 +8,14 @@ pub fn quantize<R>(
     tensor: CubeTensor<R>,
     scheme: &QuantScheme,
     scale: CubeTensor<R>,
+    global: Option<CubeTensor<R>>,
 ) -> CubeTensor<R>
 where
     R: CubeRuntime,
 {
     let output = empty_qtensor_optimized(tensor.shape(), *scheme, &tensor.device);
     let (out_values, out_params) = output.clone().quantized_handles().unwrap();
+    let out_global = output.global();
     let dtype = tensor.dtype;
 
     cubek::quantization::quantize::launch_ref(
@@ -21,7 +23,9 @@ where
         tensor.binding(),
         out_values.binding(),
         scale.binding(),
+        global.map(|g| g.binding()),
         out_params.binding(),
+        out_global.map(|g| g.binding()),
         scheme,
         dtype_to_elem_type(dtype),
     )

--- a/crates/burn-cubecl/src/ops/base.rs
+++ b/crates/burn-cubecl/src/ops/base.rs
@@ -2,7 +2,7 @@ use crate::{CubeRuntime, kernel, ops::numeric::empty_device_dtype, tensor::CubeT
 use burn_backend::cubecl::dtype_to_storage_type;
 use burn_backend::{
     DType, ExecutionError, Shape, TensorData,
-    quantization::{QuantLevel, QuantStore, params_shape},
+    quantization::{QuantLevel, QuantParam, QuantStore, params_shape},
 };
 use burn_backend::{TensorMetadata, ops::unfold::calculate_unfold_shape};
 use burn_std::{
@@ -100,6 +100,26 @@ pub(crate) fn empty<R: CubeRuntime>(
     )
 }
 
+/// The block size of a level that has one, with the per-tensor param needed to rebuild it.
+///
+/// A permutation moves the block's dimensions around. The per-tensor scale is a scalar and is
+/// unaffected by that, but it has to survive the rebuild, or a two-level tensor quietly comes back
+/// as a single-level one and every value reconstructs short by that factor.
+fn block_level(level: QuantLevel) -> Option<(BlockSize, Option<QuantParam>)> {
+    match level {
+        QuantLevel::Tensor => None,
+        QuantLevel::Block(block) => Some((block, None)),
+        QuantLevel::BlockTensor { block, global } => Some((block, Some(global))),
+    }
+}
+
+fn rebuild_level(block: BlockSize, global: Option<QuantParam>) -> QuantLevel {
+    match global {
+        Some(global) => QuantLevel::BlockTensor { block, global },
+        None => QuantLevel::Block(block),
+    }
+}
+
 pub(crate) fn swap_dims<R: CubeRuntime>(
     mut tensor: CubeTensor<R>,
     dim1: usize,
@@ -108,7 +128,7 @@ pub(crate) fn swap_dims<R: CubeRuntime>(
     tensor.meta.swap(dim1, dim2);
 
     if let DType::QFloat(scheme) = tensor.dtype
-        && let QuantLevel::Block(block_size) = scheme.level
+        && let Some((block_size, global)) = block_level(scheme.level)
     {
         let rank = tensor.rank();
         let qparams = tensor.qparams.as_mut().unwrap();
@@ -123,7 +143,7 @@ pub(crate) fn swap_dims<R: CubeRuntime>(
 
         qparams.scales.metadata.swap(dim1, dim2);
 
-        tensor.dtype = DType::QFloat(scheme.with_level(QuantLevel::Block(block_size)))
+        tensor.dtype = DType::QFloat(scheme.with_level(rebuild_level(block_size, global)))
     }
 
     if let DType::QFloat(scheme) = &mut tensor.dtype
@@ -147,7 +167,7 @@ pub fn permute<R: CubeRuntime>(mut tensor: CubeTensor<R>, axes: &[usize]) -> Cub
     tensor.meta.permute(axes).unwrap();
 
     if let DType::QFloat(scheme) = tensor.dtype
-        && let QuantLevel::Block(block_size) = scheme.level
+        && let Some((block_size, global)) = block_level(scheme.level)
     {
         let rank = tensor.rank();
         let qparams = tensor.qparams.as_mut().unwrap();
@@ -166,7 +186,8 @@ pub fn permute<R: CubeRuntime>(mut tensor: CubeTensor<R>, axes: &[usize]) -> Cub
 
         qparams.scales.metadata.permute(axes).unwrap();
 
-        tensor.dtype = DType::QFloat(scheme.with_level(QuantLevel::block(&block_size)))
+        tensor.dtype =
+            DType::QFloat(scheme.with_level(rebuild_level(BlockSize::new(&block_size), global)))
     }
 
     if let DType::QFloat(scheme) = &mut tensor.dtype

--- a/crates/burn-cubecl/src/ops/base.rs
+++ b/crates/burn-cubecl/src/ops/base.rs
@@ -2,15 +2,15 @@ use crate::{CubeRuntime, kernel, ops::numeric::empty_device_dtype, tensor::CubeT
 use burn_backend::cubecl::dtype_to_storage_type;
 use burn_backend::{
     DType, ExecutionError, Shape, TensorData,
-    quantization::{QuantLevel, QuantStore, params_shape},
+    quantization::{QuantStore, params_shape},
 };
 use burn_backend::{TensorMetadata, ops::unfold::calculate_unfold_shape};
 use burn_std::{
     Metadata, QuantValue, ReshapeAnalysis, reshape_analysis, strides,
     tensor::{ReshapeAction, contiguous_strides, reshape_action},
 };
+use cubecl::tensor_vector_size_parallel;
 use cubecl::{ir::VectorSize, server::CopyDescriptor};
-use cubecl::{quant::scheme::BlockSize, tensor_vector_size_parallel};
 
 pub(crate) fn from_data<R: CubeRuntime>(data: TensorData, device: &R::Device) -> CubeTensor<R> {
     // `TensorData` may contain lazily materialized device-backed bytes produced
@@ -107,23 +107,14 @@ pub(crate) fn swap_dims<R: CubeRuntime>(
 ) -> CubeTensor<R> {
     tensor.meta.swap(dim1, dim2);
 
-    if let DType::QFloat(scheme) = tensor.dtype
-        && let QuantLevel::Block(block_size) = scheme.level
+    if let DType::QFloat(scheme) = &mut tensor.dtype
+        && scheme.block_size().is_some()
     {
-        let rank = tensor.rank();
+        let rank = tensor.meta.num_dims();
+        scheme.swap_block_dims(rank, dim1, dim2);
+
         let qparams = tensor.qparams.as_mut().unwrap();
-        let mut block_size = block_size.to_dim_vec(rank);
-        block_size.swap(dim1, dim2);
-
-        // Truncate unit dims from the start
-        let block_size = BlockSize::new_trim(block_size);
-        if block_size.len() > BlockSize::MAX_DIMS {
-            panic!("Swapped block size would exceed max dims");
-        }
-
         qparams.scales.metadata.swap(dim1, dim2);
-
-        tensor.dtype = DType::QFloat(scheme.with_level(QuantLevel::Block(block_size)))
     }
 
     if let DType::QFloat(scheme) = &mut tensor.dtype
@@ -146,27 +137,14 @@ pub(crate) fn swap_dims<R: CubeRuntime>(
 pub fn permute<R: CubeRuntime>(mut tensor: CubeTensor<R>, axes: &[usize]) -> CubeTensor<R> {
     tensor.meta.permute(axes).unwrap();
 
-    if let DType::QFloat(scheme) = tensor.dtype
-        && let QuantLevel::Block(block_size) = scheme.level
+    if let DType::QFloat(scheme) = &mut tensor.dtype
+        && scheme.block_size().is_some()
     {
-        let rank = tensor.rank();
+        let rank = tensor.meta.num_dims();
+        scheme.permute_block_dims(rank, axes);
+
         let qparams = tensor.qparams.as_mut().unwrap();
-
-        let mut block_size = block_size.to_dim_vec(rank);
-        block_size = axes.iter().map(|i| block_size[*i]).collect();
-
-        // Truncate unit dims from the start
-        let block_size = block_size
-            .into_iter()
-            .skip_while(|it| *it == 1)
-            .collect::<Vec<_>>();
-        if block_size.len() > BlockSize::MAX_DIMS {
-            panic!("Swapped block size would exceed max dims");
-        }
-
         qparams.scales.metadata.permute(axes).unwrap();
-
-        tensor.dtype = DType::QFloat(scheme.with_level(QuantLevel::block(&block_size)))
     }
 
     if let DType::QFloat(scheme) = &mut tensor.dtype
@@ -272,12 +250,8 @@ pub(crate) fn expand<R: CubeRuntime>(tensor: CubeTensor<R>, target_shape: Shape)
     }
 
     // Extra check to ensure block scales must be properly handled once they're added
-    if tensor.qparams.is_some() {
-        match tensor.scheme().level {
-            QuantLevel::BlockTensor { .. } => todo!(),
-            QuantLevel::Tensor => {}
-            QuantLevel::Block(_) => todo!(),
-        }
+    if tensor.qparams.is_some() && tensor.scheme().block_size().is_some() {
+        todo!()
     }
 
     CubeTensor {
@@ -361,7 +335,7 @@ pub fn q_reshape<R: CubeRuntime>(mut tensor: CubeTensor<R>, shape: Shape) -> Cub
     if let ReshapeAction::UpdateStrides { .. } = &action_values {
         match analysis_values {
             ReshapeAnalysis::IsContiguous => {
-                if let QuantLevel::Block(block_size) = scheme.level
+                if let Some(block_size) = scheme.block_size()
                     && block_size.len() > 1
                     && !is_unsqueeze
                 {
@@ -372,7 +346,7 @@ pub fn q_reshape<R: CubeRuntime>(mut tensor: CubeTensor<R>, shape: Shape) -> Cub
             }
             ReshapeAnalysis::Broadcasted => {} // only preprends unit dims
             ReshapeAnalysis::Split => {
-                if let QuantLevel::Block(block_size) = scheme.level
+                if let Some(block_size) = scheme.block_size()
                     && block_size.len() > 1
                 {
                     // Split reshape (e.g. [32, 4] -> [32, 2, 2]): only valid if
@@ -388,14 +362,10 @@ pub fn q_reshape<R: CubeRuntime>(mut tensor: CubeTensor<R>, shape: Shape) -> Cub
 
     let shape_last = *shape.last().unwrap();
 
-    let shape_scales = match scheme.level {
-        QuantLevel::BlockTensor { .. } => {
-            unimplemented!("two-level quantization is not supported yet")
-        }
-        QuantLevel::Tensor => scales.meta.shape().clone(), // always [1], invariant under reshape
-        QuantLevel::Block(block_size)
-            if block_size.len() == 1 && shape_last < (block_size[0] as usize) =>
-        {
+    // The per-tensor scale is a scalar in its own region, so only the block grid moves.
+    let shape_scales = match scheme.block_size() {
+        None => scales.meta.shape().clone(), // always [1], invariant under reshape
+        Some(block_size) if block_size.len() == 1 && shape_last < (block_size[0] as usize) => {
             // If the new last dimension is smaller than the block size,
             // it means a single block now spans across multiple rows.
             if scales.meta.shape().num_elements() > 1 {
@@ -404,9 +374,9 @@ pub fn q_reshape<R: CubeRuntime>(mut tensor: CubeTensor<R>, shape: Shape) -> Cub
             // Exception: allow if there is exactly 1 block total (essentially per-tensor quantization)
             scales.meta.shape().clone()
         }
-        QuantLevel::Block(_) => {
+        Some(_) => {
             // ND blocks: derive scales shape from the new tensor shape
-            params_shape(&shape, scheme.level)
+            params_shape(&shape, &scheme)
         }
     };
 
@@ -452,9 +422,7 @@ pub fn q_reshape<R: CubeRuntime>(mut tensor: CubeTensor<R>, shape: Shape) -> Cub
                 )
             }
 
-            if let QuantLevel::Block(_) = scheme.level
-                && shape_scales.num_elements() > 1
-            {
+            if scheme.block_size().is_some() && shape_scales.num_elements() > 1 {
                 // Original block boundaries no longer align with the layout, would have to be recomputed
                 unimplemented!(
                     "Cannot reshape a block-quantized tensor when the reshape requires recomputing the buffer."

--- a/crates/burn-cubecl/src/ops/base.rs
+++ b/crates/burn-cubecl/src/ops/base.rs
@@ -274,7 +274,7 @@ pub(crate) fn expand<R: CubeRuntime>(tensor: CubeTensor<R>, target_shape: Shape)
     if tensor.qparams.is_some() {
         match tensor.scheme().level {
             QuantLevel::Tensor => {}
-            QuantLevel::Block(_) => todo!(),
+            QuantLevel::Block(_) | QuantLevel::BlockTensor { .. } => todo!(),
         }
     }
 
@@ -397,6 +397,9 @@ pub fn q_reshape<R: CubeRuntime>(mut tensor: CubeTensor<R>, shape: Shape) -> Cub
     let shape_last = *shape.last().unwrap();
 
     let shape_scales = match scheme.level {
+        QuantLevel::BlockTensor { .. } => {
+            unimplemented!("two-level quantization is not supported on cubecl backends yet")
+        }
         QuantLevel::Tensor => scales.meta.shape().clone(), // always [1], invariant under reshape
         QuantLevel::Block(block_size)
             if block_size.len() == 1 && shape_last < (block_size[0] as usize) =>

--- a/crates/burn-cubecl/src/ops/qtensor.rs
+++ b/crates/burn-cubecl/src/ops/qtensor.rs
@@ -3,12 +3,13 @@ use burn_backend::{
     get_device_settings,
     ops::QTensorOps,
     quantization::{
-        QParamTensor, QuantLevel, QuantMode, QuantParam, QuantPropagation, QuantScheme, QuantValue,
-        QuantizationParametersPrimitive, params_shape,
+        QParamTensor, QuantMode, QuantPropagation, QuantScheme, QuantValue,
+        QuantizationParametersPrimitive, ScaleDtype, global_scale_dtype, params_shape,
+        validate_levels,
     },
     tensor::{Device, FloatTensor, QuantizedTensor},
 };
-use burn_std::{FloatDType, Metadata};
+use burn_std::{FloatDType, Metadata, quantization::global_scale_size};
 use cubecl::server::{MemoryLayout, MemoryLayoutDescriptor, MemoryLayoutStrategy};
 use cubecl::{e2m1x2, quant::scheme::QuantStore};
 
@@ -19,6 +20,13 @@ use crate::{
 };
 
 use super::{into_data, permute, swap_dims};
+
+/// Length of the block-scales region within a combined scales+global byte buffer.
+fn scales_region_len(total: usize, scheme: &QuantScheme) -> usize {
+    total
+        .checked_sub(global_scale_size(scheme))
+        .expect("quantized tensor data is shorter than the scheme's global scale")
+}
 
 /// Create a quantized tensor with packed values (u32).
 fn new_qtensor_optimized<R: CubeRuntime>(
@@ -67,6 +75,8 @@ fn new_quantized<R: CubeRuntime>(
     data: Option<Bytes>,
     alloc_kind: MemoryLayoutStrategy,
 ) -> CubeTensor<R> {
+    validate_levels(&scheme);
+
     let client = R::client(device);
     let shape: Shape = shape.into();
     let mut shape_value: Shape = shape.clone();
@@ -101,34 +111,81 @@ fn new_quantized<R: CubeRuntime>(
         },
     };
 
-    let scales_dtype = match scheme.param {
-        QuantParam::F32 => DType::F32,
-        QuantParam::F16 => DType::F16,
-        QuantParam::BF16 => DType::BF16,
+    let scales_dtype = match scheme.scale_dtype() {
+        ScaleDtype::F32 => DType::F32,
+        ScaleDtype::F16 => DType::F16,
+        ScaleDtype::BF16 => DType::BF16,
         // Represented by U8 and reinterpreted in the kernel
-        QuantParam::UE8M0 | QuantParam::UE4M3 => DType::U8,
+        ScaleDtype::UE8M0 | ScaleDtype::UE4M3 => DType::U8,
     };
 
-    let scales_shape = params_shape(&shape, scheme.level);
+    let scales_shape = params_shape(&shape, &scheme);
     let data_desc = MemoryLayoutDescriptor::new(alloc_kind, shape_value.clone(), data_size);
     let scales_desc =
         MemoryLayoutDescriptor::new(alloc_kind, scales_shape.clone(), scales_dtype.size());
 
+    let global_shape = Shape::new([1]);
+    // validate_levels above guarantees any per-tensor scale over blocks is f32.
+    let global_dtype = global_scale_dtype(&scheme).map(|_| DType::F32);
+    let global_desc = global_dtype
+        .map(|dtype| MemoryLayoutDescriptor::new(alloc_kind, global_shape.clone(), dtype.size()));
+
     let mut tensors = match data {
         Some(data) => {
             let num_bytes = shape_value.num_elements() * data_size;
+            let split = data.split(num_bytes, SplitPolicy::Shared);
 
-            match data.split(num_bytes, SplitPolicy::Shared) {
-                Ok((bytes_data, bytes_scales)) => client
-                    .create_tensors(vec![(data_desc, bytes_data), (scales_desc, bytes_scales)]),
-                Err((data, _)) => client.create_tensors_from_slices(vec![
-                    (data_desc, &data[..num_bytes]),
-                    (scales_desc, &data[num_bytes..]),
-                ]),
+            match (split, global_desc.clone()) {
+                (Ok((bytes_data, bytes_params)), None) => client
+                    .create_tensors(vec![(data_desc, bytes_data), (scales_desc, bytes_params)]),
+                (Ok((bytes_data, bytes_params)), Some(global_desc)) => {
+                    let scales_bytes = scales_region_len(bytes_params.len(), &scheme);
+                    match bytes_params.split(scales_bytes, SplitPolicy::Shared) {
+                        Ok((block, global)) => client.create_tensors(vec![
+                            (data_desc, bytes_data),
+                            (scales_desc, block),
+                            (global_desc, global),
+                        ]),
+                        Err((params, _)) => client.create_tensors_from_slices(vec![
+                            (data_desc, &bytes_data[..]),
+                            (scales_desc, &params[..scales_bytes]),
+                            (global_desc, &params[scales_bytes..]),
+                        ]),
+                    }
+                }
+                (Err((data, _)), global_desc) => {
+                    let params = &data[num_bytes..];
+                    let scales_bytes = scales_region_len(params.len(), &scheme);
+                    let mut entries = vec![
+                        (data_desc, &data[..num_bytes]),
+                        (scales_desc, &params[..scales_bytes]),
+                    ];
+                    if let Some(global_desc) = global_desc {
+                        entries.push((global_desc, &params[scales_bytes..]));
+                    }
+                    client.create_tensors_from_slices(entries)
+                }
             }
         }
-        None => client.empty_tensors(vec![data_desc, scales_desc]),
+        None => {
+            let mut descs = vec![data_desc, scales_desc];
+            descs.extend(global_desc);
+            client.empty_tensors(descs)
+        }
     };
+
+    let global = global_dtype.map(|dtype| {
+        let MemoryLayout {
+            memory: handle,
+            strides,
+        } = tensors.remove(2);
+        QParamTensor {
+            offset_start: handle.offset_start.unwrap_or(0) as usize,
+            offset_end: handle.offset_end.unwrap_or(0) as usize,
+            metadata: Metadata::new(global_shape, strides),
+            dtype,
+        }
+    });
     let MemoryLayout {
         memory: scales_handle,
         strides: scales_strides,
@@ -141,7 +198,7 @@ fn new_quantized<R: CubeRuntime>(
         metadata: Metadata::new(scales_shape, scales_strides),
         dtype: scales_dtype,
     };
-    let qparams = QParams { scales };
+    let qparams = QParams { scales, global };
 
     CubeTensor::new_quantized(
         client,
@@ -159,11 +216,6 @@ impl<R: CubeRuntime> QTensorOps<Self> for CubeBackend<R> {
         match data.dtype {
             DType::QFloat(scheme) => match scheme {
                 QuantScheme {
-                    level: QuantLevel::BlockTensor { .. },
-                    ..
-                } => unimplemented!("two-level quantization is not supported yet"),
-                QuantScheme {
-                    level: QuantLevel::Tensor | QuantLevel::Block(_),
                     mode: QuantMode::Symmetric,
                     value:
                         QuantValue::Q8F
@@ -196,7 +248,16 @@ impl<R: CubeRuntime> QTensorOps<Self> for CubeBackend<R> {
         scheme: &QuantScheme,
         qparams: QuantizationParametersPrimitive<Self>,
     ) -> QuantizedTensor<Self> {
-        kernel::quantization::quantize(tensor, scheme, qparams.scales)
+        // The kernel reads this at the scheme's param width, not the tensor's actual dtype.
+        if let Some(global) = &qparams.global {
+            assert_eq!(
+                global.dtype,
+                DType::F32,
+                "a two-level scheme's per-tensor scale must be an f32 tensor, got {:?}",
+                global.dtype
+            );
+        }
+        kernel::quantization::quantize(tensor, scheme, qparams.scales, qparams.global)
     }
 
     fn dequantize(tensor: QuantizedTensor<Self>, dtype: FloatDType) -> FloatTensor<Self> {
@@ -217,12 +278,18 @@ impl<R: CubeRuntime> QTensorOps<Self> for CubeBackend<R> {
         }
 
         let (shape, dtype) = (tensor.shape(), tensor.dtype);
+        let global = tensor.global();
         let (values, params) = tensor.quantized_handles().unwrap();
 
         let mut data_values = into_data(values).await?;
         let data_params = into_data(params).await?;
 
         data_values.bytes.extend_from_byte_slice(&data_params.bytes);
+
+        if let Some(global) = global {
+            let data_global = into_data(global).await?;
+            data_values.bytes.extend_from_byte_slice(&data_global.bytes);
+        }
 
         Ok(TensorData {
             bytes: data_values.bytes,

--- a/crates/burn-cubecl/src/ops/qtensor.rs
+++ b/crates/burn-cubecl/src/ops/qtensor.rs
@@ -252,7 +252,7 @@ impl<R: CubeRuntime> QTensorOps<Self> for CubeBackend<R> {
         scheme: &QuantScheme,
         qparams: QuantizationParametersPrimitive<Self>,
     ) -> QuantizedTensor<Self> {
-        // The kernel reads this at the scheme's param width, not the tensor's actual dtype.
+        // The kernel reads this at the scheme's scale dtype, not the tensor's actual dtype.
         if let Some(global) = &qparams.global {
             assert_eq!(
                 global.dtype,

--- a/crates/burn-cubecl/src/ops/qtensor.rs
+++ b/crates/burn-cubecl/src/ops/qtensor.rs
@@ -5,7 +5,6 @@ use burn_backend::{
     quantization::{
         QParamTensor, QuantMode, QuantPropagation, QuantScheme, QuantValue,
         QuantizationParametersPrimitive, ScaleDtype, global_scale_dtype, params_shape,
-        validate_levels,
     },
     tensor::{Device, FloatTensor, QuantizedTensor},
 };
@@ -75,8 +74,6 @@ fn new_quantized<R: CubeRuntime>(
     data: Option<Bytes>,
     alloc_kind: MemoryLayoutStrategy,
 ) -> CubeTensor<R> {
-    validate_levels(&scheme);
-
     let client = R::client(device);
     let shape: Shape = shape.into();
     let mut shape_value: Shape = shape.clone();
@@ -125,8 +122,15 @@ fn new_quantized<R: CubeRuntime>(
         MemoryLayoutDescriptor::new(alloc_kind, scales_shape.clone(), scales_dtype.size());
 
     let global_shape = Shape::new([1]);
-    // validate_levels above guarantees any per-tensor scale over blocks is f32.
-    let global_dtype = global_scale_dtype(&scheme).map(|_| DType::F32);
+    let global_dtype = global_scale_dtype(&scheme).map(|dtype| {
+        // The region is f32-sized and the kernels bind it as f32.
+        assert_eq!(
+            dtype,
+            ScaleDtype::F32,
+            "a two-level scheme binds its per-tensor scale as f32, got {scheme:?}"
+        );
+        DType::F32
+    });
     let global_desc = global_dtype
         .map(|dtype| MemoryLayoutDescriptor::new(alloc_kind, global_shape.clone(), dtype.size()));
 

--- a/crates/burn-cubecl/src/ops/qtensor.rs
+++ b/crates/burn-cubecl/src/ops/qtensor.rs
@@ -4,7 +4,7 @@ use burn_backend::{
     ops::QTensorOps,
     quantization::{
         QParamTensor, QuantLevel, QuantMode, QuantParam, QuantPropagation, QuantScheme, QuantValue,
-        QuantizationParametersPrimitive, params_shape,
+        QuantizationParametersPrimitive, params_shape, validate_levels,
     },
     tensor::{Device, FloatTensor, QuantizedTensor},
 };
@@ -67,13 +67,7 @@ fn new_quantized<R: CubeRuntime>(
     data: Option<Bytes>,
     alloc_kind: MemoryLayoutStrategy,
 ) -> CubeTensor<R> {
-    // This allocates one values buffer and one scales buffer. A two-level scheme needs a third
-    // for the per-tensor scale, so serving one here would quietly under-allocate.
-    assert!(
-        scheme.level.global_param().is_none(),
-        "two-level quantization is not supported on cubecl backends yet, got {:?}",
-        scheme.level
-    );
+    validate_levels(&scheme);
 
     let client = R::client(device);
     let shape: Shape = shape.into();
@@ -122,21 +116,70 @@ fn new_quantized<R: CubeRuntime>(
     let scales_desc =
         MemoryLayoutDescriptor::new(alloc_kind, scales_shape.clone(), scales_dtype.size());
 
+    let global_shape = Shape::new([1]);
+    let global_dtype = scheme.level.global_param().map(|param| match param {
+        QuantParam::F32 => DType::F32,
+        other => panic!("a two-level scheme requires an f32 per-tensor scale, got {other:?}"),
+    });
+    let global_desc = global_dtype
+        .map(|dtype| MemoryLayoutDescriptor::new(alloc_kind, global_shape.clone(), dtype.size()));
+
+    let mut descs = vec![data_desc.clone(), scales_desc.clone()];
+    descs.extend(global_desc.clone());
+
     let mut tensors = match data {
         Some(data) => {
             let num_bytes = shape_value.num_elements() * data_size;
+            let split = data.split(num_bytes, SplitPolicy::Shared);
 
-            match data.split(num_bytes, SplitPolicy::Shared) {
-                Ok((bytes_data, bytes_scales)) => client
-                    .create_tensors(vec![(data_desc, bytes_data), (scales_desc, bytes_scales)]),
-                Err((data, _)) => client.create_tensors_from_slices(vec![
-                    (data_desc, &data[..num_bytes]),
-                    (scales_desc, &data[num_bytes..]),
-                ]),
+            match (split, global_desc.clone()) {
+                (Ok((bytes_data, bytes_params)), None) => client
+                    .create_tensors(vec![(data_desc, bytes_data), (scales_desc, bytes_params)]),
+                (Ok((bytes_data, bytes_params)), Some(global_desc)) => {
+                    let scales_bytes = bytes_params.len() - global_desc.elem_size;
+                    match bytes_params.split(scales_bytes, SplitPolicy::Shared) {
+                        Ok((block, global)) => client.create_tensors(vec![
+                            (data_desc, bytes_data),
+                            (scales_desc, block),
+                            (global_desc, global),
+                        ]),
+                        Err((params, _)) => client.create_tensors_from_slices(vec![
+                            (data_desc, &bytes_data[..]),
+                            (scales_desc, &params[..scales_bytes]),
+                            (global_desc, &params[scales_bytes..]),
+                        ]),
+                    }
+                }
+                (Err((data, _)), global_desc) => {
+                    let params = &data[num_bytes..];
+                    let scales_bytes =
+                        params.len() - global_desc.as_ref().map_or(0, |d| d.elem_size);
+                    let mut entries = vec![
+                        (data_desc, &data[..num_bytes]),
+                        (scales_desc, &params[..scales_bytes]),
+                    ];
+                    if let Some(global_desc) = global_desc {
+                        entries.push((global_desc, &params[scales_bytes..]));
+                    }
+                    client.create_tensors_from_slices(entries)
+                }
             }
         }
-        None => client.empty_tensors(vec![data_desc, scales_desc]),
+        None => client.empty_tensors(descs),
     };
+
+    let global = global_dtype.map(|dtype| {
+        let MemoryLayout {
+            memory: handle,
+            strides,
+        } = tensors.remove(2);
+        QParamTensor {
+            offset_start: handle.offset_start.unwrap_or(0) as usize,
+            offset_end: handle.offset_end.unwrap_or(0) as usize,
+            metadata: Metadata::new(global_shape, strides),
+            dtype,
+        }
+    });
     let MemoryLayout {
         memory: scales_handle,
         strides: scales_strides,
@@ -149,7 +192,7 @@ fn new_quantized<R: CubeRuntime>(
         metadata: Metadata::new(scales_shape, scales_strides),
         dtype: scales_dtype,
     };
-    let qparams = QParams { scales };
+    let qparams = QParams { scales, global };
 
     CubeTensor::new_quantized(
         client,
@@ -166,16 +209,9 @@ impl<R: CubeRuntime> QTensorOps<Self> for CubeBackend<R> {
     fn q_from_data(data: TensorData, device: &Device<Self>) -> QuantizedTensor<Self> {
         match data.dtype {
             DType::QFloat(scheme) => match scheme {
-                // Nothing on this path applies a per-tensor scale, so serving one would
-                // silently drop it.
                 QuantScheme {
-                    level: QuantLevel::BlockTensor { .. },
-                    ..
-                } => {
-                    unimplemented!("two-level quantization is not supported on cubecl backends yet")
-                }
-                QuantScheme {
-                    level: QuantLevel::Tensor | QuantLevel::Block(_),
+                    level:
+                        QuantLevel::Tensor | QuantLevel::Block(_) | QuantLevel::BlockTensor { .. },
                     mode: QuantMode::Symmetric,
                     value:
                         QuantValue::Q8F
@@ -208,15 +244,7 @@ impl<R: CubeRuntime> QTensorOps<Self> for CubeBackend<R> {
         scheme: &QuantScheme,
         qparams: QuantizationParametersPrimitive<Self>,
     ) -> QuantizedTensor<Self> {
-        // Rejected here as well as in the allocation below it, because dropping the per-tensor
-        // scale silently is the failure mode, and relying on a guard three frames away means the
-        // next fast path that allocates differently reintroduces it with nothing to say so.
-        assert!(
-            qparams.global.is_none(),
-            "two-level quantization is not supported on cubecl backends yet, got {:?}",
-            scheme.level
-        );
-        kernel::quantization::quantize(tensor, scheme, qparams.scales)
+        kernel::quantization::quantize(tensor, scheme, qparams.scales, qparams.global)
     }
 
     fn dequantize(tensor: QuantizedTensor<Self>, dtype: FloatDType) -> FloatTensor<Self> {
@@ -237,12 +265,18 @@ impl<R: CubeRuntime> QTensorOps<Self> for CubeBackend<R> {
         }
 
         let (shape, dtype) = (tensor.shape(), tensor.dtype);
+        let global = tensor.global();
         let (values, params) = tensor.quantized_handles().unwrap();
 
         let mut data_values = into_data(values).await?;
         let data_params = into_data(params).await?;
 
         data_values.bytes.extend_from_byte_slice(&data_params.bytes);
+
+        if let Some(global) = global {
+            let data_global = into_data(global).await?;
+            data_values.bytes.extend_from_byte_slice(&data_global.bytes);
+        }
 
         Ok(TensorData {
             bytes: data_values.bytes,

--- a/crates/burn-cubecl/src/ops/qtensor.rs
+++ b/crates/burn-cubecl/src/ops/qtensor.rs
@@ -67,6 +67,14 @@ fn new_quantized<R: CubeRuntime>(
     data: Option<Bytes>,
     alloc_kind: MemoryLayoutStrategy,
 ) -> CubeTensor<R> {
+    // This allocates one values buffer and one scales buffer. A two-level scheme needs a third
+    // for the per-tensor scale, so serving one here would quietly under-allocate.
+    assert!(
+        scheme.level.global_param().is_none(),
+        "two-level quantization is not supported on cubecl backends yet, got {:?}",
+        scheme.level
+    );
+
     let client = R::client(device);
     let shape: Shape = shape.into();
     let mut shape_value: Shape = shape.clone();
@@ -158,6 +166,14 @@ impl<R: CubeRuntime> QTensorOps<Self> for CubeBackend<R> {
     fn q_from_data(data: TensorData, device: &Device<Self>) -> QuantizedTensor<Self> {
         match data.dtype {
             DType::QFloat(scheme) => match scheme {
+                // Nothing on this path applies a per-tensor scale, so serving one would
+                // silently drop it.
+                QuantScheme {
+                    level: QuantLevel::BlockTensor { .. },
+                    ..
+                } => {
+                    unimplemented!("two-level quantization is not supported on cubecl backends yet")
+                }
                 QuantScheme {
                     level: QuantLevel::Tensor | QuantLevel::Block(_),
                     mode: QuantMode::Symmetric,

--- a/crates/burn-cubecl/src/ops/qtensor.rs
+++ b/crates/burn-cubecl/src/ops/qtensor.rs
@@ -208,6 +208,14 @@ impl<R: CubeRuntime> QTensorOps<Self> for CubeBackend<R> {
         scheme: &QuantScheme,
         qparams: QuantizationParametersPrimitive<Self>,
     ) -> QuantizedTensor<Self> {
+        // Rejected here as well as in the allocation below it, because dropping the per-tensor
+        // scale silently is the failure mode, and relying on a guard three frames away means the
+        // next fast path that allocates differently reintroduces it with nothing to say so.
+        assert!(
+            qparams.global.is_none(),
+            "two-level quantization is not supported on cubecl backends yet, got {:?}",
+            scheme.level
+        );
         kernel::quantization::quantize(tensor, scheme, qparams.scales)
     }
 

--- a/crates/burn-cubecl/src/tensor/quantization.rs
+++ b/crates/burn-cubecl/src/tensor/quantization.rs
@@ -9,7 +9,16 @@ use super::CubeTensor;
 
 /// Runtime parameters for quantization. Can be used to construct a scales handle from the base
 /// tensor handle.
-pub type QParams = burn_backend::quantization::QParams<QParamTensor>;
+///
+/// Not [`burn_backend::quantization::QParams`], which also stands in for a *single* block's scale
+/// and so has no place for a per-tensor one.
+#[derive(Clone, Debug)]
+pub struct QParams {
+    /// The block scales.
+    pub scales: QParamTensor,
+    /// The per-tensor scale of a two-level scheme, in its own region after the block scales.
+    pub global: Option<QParamTensor>,
+}
 
 impl<R: CubeRuntime> CubeTensor<R> {
     /// Create a new quantized tensor
@@ -106,17 +115,29 @@ impl<R: CubeRuntime> CubeTensor<R> {
 
     /// Construct a separate tensor for the quantization scales, if present
     pub fn scales(&self) -> Option<CubeTensor<R>> {
-        let qparams = self.qparams.as_ref()?;
+        self.param_tensor(|qparams| Some(&qparams.scales))
+    }
+
+    /// Construct a separate tensor for the per-tensor scale, for a two-level scheme.
+    pub fn global(&self) -> Option<CubeTensor<R>> {
+        self.param_tensor(|qparams| qparams.global.as_ref())
+    }
+
+    fn param_tensor(
+        &self,
+        select: impl Fn(&QParams) -> Option<&QParamTensor>,
+    ) -> Option<CubeTensor<R>> {
+        let param = select(self.qparams.as_ref()?)?;
         let mut handle = self.handle.clone();
-        handle.offset_start = Some(qparams.scales.offset_start as u64);
-        handle.offset_end = Some(qparams.scales.offset_end as u64);
+        handle.offset_start = Some(param.offset_start as u64);
+        handle.offset_end = Some(param.offset_end as u64);
 
         Some(CubeTensor::new(
             self.client.clone(),
             handle,
-            qparams.scales.metadata.clone(),
+            param.metadata.clone(),
             self.device.clone(),
-            qparams.scales.dtype,
+            param.dtype,
         ))
     }
 }

--- a/crates/burn-cubecl/src/tensor/quantization.rs
+++ b/crates/burn-cubecl/src/tensor/quantization.rs
@@ -106,17 +106,29 @@ impl<R: CubeRuntime> CubeTensor<R> {
 
     /// Construct a separate tensor for the quantization scales, if present
     pub fn scales(&self) -> Option<CubeTensor<R>> {
-        let qparams = self.qparams.as_ref()?;
+        self.param_tensor(|qparams| Some(&qparams.scales))
+    }
+
+    /// Construct a separate tensor for the per-tensor scale, for a two-level scheme.
+    pub fn global(&self) -> Option<CubeTensor<R>> {
+        self.param_tensor(|qparams| qparams.global.as_ref())
+    }
+
+    fn param_tensor(
+        &self,
+        select: impl Fn(&QParams) -> Option<&QParamTensor>,
+    ) -> Option<CubeTensor<R>> {
+        let param = select(self.qparams.as_ref()?)?;
         let mut handle = self.handle.clone();
-        handle.offset_start = Some(qparams.scales.offset_start as u64);
-        handle.offset_end = Some(qparams.scales.offset_end as u64);
+        handle.offset_start = Some(param.offset_start as u64);
+        handle.offset_end = Some(param.offset_end as u64);
 
         Some(CubeTensor::new(
             self.client.clone(),
             handle,
-            qparams.scales.metadata.clone(),
+            param.metadata.clone(),
             self.device.clone(),
-            qparams.scales.dtype,
+            param.dtype,
         ))
     }
 }

--- a/crates/burn-dispatch/src/ops/qtensor.rs
+++ b/crates/burn-dispatch/src/ops/qtensor.rs
@@ -18,15 +18,14 @@ impl QTensorOps<Self> for Dispatch {
         scheme: &QuantScheme,
         qparams: QuantizationParametersPrimitive<Self>,
     ) -> QuantizedTensor<Self> {
-        // `binary_float` rather than `binary_op`: on an autodiff device the
-        // tensor and its scales arrive autodiff-wrapped, and quantization
-        // detaches them (the packed result carries no graph).
-        binary_float!(
-            (tensor, float),
-            (qparams.scales, float),
-            |tensor, scales| {
-                B::quantize(tensor, scheme, QuantizationParametersPrimitive { scales })
-            } => Quantized
+        let QuantizationParametersPrimitive { scales, global } = qparams;
+        // On an autodiff device the tensor and its scales arrive autodiff-wrapped, and
+        // quantization detaches them: the packed result carries no graph.
+        multi_op!(
+            inputs[(tensor, float), (scales, float)],
+            opt_inputs[(global, float)],
+            => Quantized,
+            B::quantize(tensor, scheme, QuantizationParametersPrimitive { scales, global })
         )
     }
 

--- a/crates/burn-dispatch/src/ops/qtensor.rs
+++ b/crates/burn-dispatch/src/ops/qtensor.rs
@@ -18,12 +18,12 @@ impl QTensorOps<Self> for Dispatch {
         scheme: &QuantScheme,
         qparams: QuantizationParametersPrimitive<Self>,
     ) -> QuantizedTensor<Self> {
-        binary_op!(
-            (tensor, float),
-            (qparams.scales, float),
-            |tensor, scales| {
-                B::quantize(tensor, scheme, QuantizationParametersPrimitive { scales })
-            } => Quantized
+        let QuantizationParametersPrimitive { scales, global } = qparams;
+        multi_op!(
+            inputs[(tensor, float), (scales, float)],
+            opt_inputs[(global, float)],
+            => Quantized,
+            B::quantize(tensor, scheme, QuantizationParametersPrimitive { scales, global })
         )
     }
 

--- a/crates/burn-flex/src/backend.rs
+++ b/crates/burn-flex/src/backend.rs
@@ -156,7 +156,10 @@ impl Backend for Flex {
             }
             DType::Bool(burn_std::BoolStore::U32) => DTypeUsageSet::empty(),
             // Quantized types: storage only for now
-            DType::QFloat(_) => DTypeUsage::Storage.into(),
+            DType::QFloat(scheme) if burn_std::quantization::levels_supported(&scheme) => {
+                DTypeUsage::Storage.into()
+            }
+            DType::QFloat(_) => DTypeUsageSet::empty(),
             _ => DTypeUsageSet::empty(),
         }
     }

--- a/crates/burn-flex/src/backend.rs
+++ b/crates/burn-flex/src/backend.rs
@@ -156,7 +156,7 @@ impl Backend for Flex {
             }
             DType::Bool(burn_std::BoolStore::U32) => DTypeUsageSet::empty(),
             // Quantized types: storage only for now
-            DType::QFloat(scheme) if burn_std::quantization::levels_supported(&scheme) => {
+            DType::QFloat(scheme) if burn_std::quantization::quantizable(&scheme) => {
                 DTypeUsage::Storage.into()
             }
             DType::QFloat(_) => DTypeUsageSet::empty(),

--- a/crates/burn-flex/src/ops/qtensor.rs
+++ b/crates/burn-flex/src/ops/qtensor.rs
@@ -9,7 +9,7 @@ use burn_backend::{
     DType, ExecutionError, FloatDType, TensorData, TensorMetadata,
     ops::{IntTensorOps, QTensorOps},
     quantization::{
-        BlockGrid, BlockSize, QuantScheme, QuantStore, QuantizationParametersPrimitive,
+        BlockLayout, BlockSize, QuantScheme, QuantStore, QuantizationParametersPrimitive,
         QuantizedBytes, ScaleDtype, global_scale_dtype, scale_to_dtype,
     },
     tensor::{Device, FloatTensor, IntTensor, QuantizedTensor},
@@ -19,21 +19,21 @@ use burn_std::{Bytes, Shape, Slice, bf16, f16};
 use super::float_storage_as_f32;
 use crate::{Flex, FlexQTensor, FlexTensor, Layout};
 
-/// The block grid over `shape`, which must be a whole number of blocks along every axis.
-fn block_grid(shape: &Shape, block: &BlockSize) -> BlockGrid {
-    let grid = BlockGrid::new(shape, block);
+/// The blocks over `shape`, which must be a whole number of blocks along every axis.
+fn block_layout(shape: &Shape, block: &BlockSize) -> BlockLayout {
+    let blocks = BlockLayout::new(shape, block);
     debug_assert!(
-        grid.divides(),
+        blocks.divides(),
         "tensor {shape:?} is not a whole number of {block:?} blocks"
     );
-    grid
+    blocks
 }
 
-/// The largest magnitude in each block of `values`, laid out as `grid`.
-fn block_max_abs(values: &[f32], grid: &BlockGrid) -> Vec<f32> {
-    let mut peaks = alloc::vec![0.0f32; grid.num_blocks()];
+/// The largest magnitude in each block of `values`, laid out as `blocks`.
+fn block_max_abs(values: &[f32], blocks: &BlockLayout) -> Vec<f32> {
+    let mut peaks = alloc::vec![0.0f32; blocks.num_blocks()];
     for (index, &x) in values.iter().enumerate() {
-        let peak = &mut peaks[grid.block_of(index)];
+        let peak = &mut peaks[blocks.block_of(index)];
         *peak = peak.max(x.abs());
     }
     peaks
@@ -73,8 +73,8 @@ impl QTensorOps<Flex> for Flex {
 
         let (quantized, scales, global) = match (scheme.block_size(), global_scale_dtype(scheme)) {
             (Some(block), Some(global_dtype)) => {
-                let grid = block_grid(&shape, &block);
-                let raw: Vec<f32> = block_max_abs(&float_data, &grid)
+                let blocks = block_layout(&shape, &block);
+                let raw: Vec<f32> = block_max_abs(&float_data, &blocks)
                     .into_iter()
                     .map(|alpha| 2.0 * alpha / range)
                     .collect();
@@ -93,7 +93,7 @@ impl QTensorOps<Flex> for Flex {
                     .iter()
                     .enumerate()
                     .map(|(index, &x)| {
-                        let inv_scale = 1.0 / (global * scales[grid.block_of(index)]);
+                        let inv_scale = 1.0 / (global * scales[blocks.block_of(index)]);
                         (x * inv_scale).round().clamp(a, b) as i8
                     })
                     .collect();
@@ -116,8 +116,8 @@ impl QTensorOps<Flex> for Flex {
                 (quantized, alloc::vec![scale], None)
             }
             (Some(block_size), None) => {
-                let grid = block_grid(&shape, &block_size);
-                let scales: Vec<f32> = block_max_abs(&float_data, &grid)
+                let blocks = block_layout(&shape, &block_size);
+                let scales: Vec<f32> = block_max_abs(&float_data, &blocks)
                     .into_iter()
                     .map(|alpha| validated_scale(2.0 * alpha / range, scheme.scale_dtype()))
                     .collect();
@@ -125,7 +125,7 @@ impl QTensorOps<Flex> for Flex {
                     .iter()
                     .enumerate()
                     .map(|(index, &x)| {
-                        let inv_scale = 1.0 / scales[grid.block_of(index)];
+                        let inv_scale = 1.0 / scales[blocks.block_of(index)];
                         (x * inv_scale).round().clamp(a, b) as i8
                     })
                     .collect();
@@ -180,13 +180,13 @@ impl QTensorOps<Flex> for Flex {
                     .collect::<Vec<i8>>()
             }
             Some(block_size) => {
-                let grid = block_grid(&shape, &block_size);
+                let blocks = block_layout(&shape, &block_size);
                 let multiplier = global.unwrap_or(1.0);
                 float_data
                     .iter()
                     .enumerate()
                     .map(|(index, &x)| {
-                        let inv_scale = 1.0 / (multiplier * scales[grid.block_of(index)]);
+                        let inv_scale = 1.0 / (multiplier * scales[blocks.block_of(index)]);
                         (x * inv_scale).round().clamp(a, b) as i8
                     })
                     .collect()
@@ -214,13 +214,13 @@ impl QTensorOps<Flex> for Flex {
                     .collect::<Vec<f32>>()
             }
             Some(block_size) => {
-                let grid = BlockGrid::new(&shape, &block_size);
+                let blocks = BlockLayout::new(&shape, &block_size);
                 let multiplier = tensor.global.unwrap_or(1.0);
                 q_data
                     .iter()
                     .enumerate()
                     .map(|(index, &x_q)| {
-                        multiplier * tensor.scales[grid.block_of(index)] * x_q as f32
+                        multiplier * tensor.scales[blocks.block_of(index)] * x_q as f32
                     })
                     .collect::<Vec<f32>>()
             }

--- a/crates/burn-flex/src/ops/qtensor.rs
+++ b/crates/burn-flex/src/ops/qtensor.rs
@@ -9,8 +9,8 @@ use burn_backend::{
     DType, ExecutionError, FloatDType, TensorData, TensorMetadata,
     ops::{IntTensorOps, QTensorOps},
     quantization::{
-        QuantLevel, QuantParam, QuantScheme, QuantStore, QuantizationParametersPrimitive,
-        QuantizedBytes, scale_to_param,
+        QuantScheme, QuantStore, QuantizationParametersPrimitive, QuantizedBytes, ScaleDtype,
+        global_scale_dtype, scale_to_dtype,
     },
     tensor::{Device, FloatTensor, IntTensor, QuantizedTensor},
 };
@@ -18,6 +18,13 @@ use burn_std::{Bytes, Shape, Slice, bf16, f16};
 
 use super::float_storage_as_f32;
 use crate::{Flex, FlexQTensor, FlexTensor, Layout};
+
+fn assert_block_divides(len: usize, block_elems: usize) {
+    debug_assert!(
+        len.is_multiple_of(block_elems),
+        "tensor length {len} not divisible by block size {block_elems}"
+    );
+}
 
 impl QTensorOps<Flex> for Flex {
     fn q_from_data(data: TensorData, _device: &Device<Flex>) -> QuantizedTensor<Flex> {
@@ -42,7 +49,7 @@ impl QTensorOps<Flex> for Flex {
         // Use native storage since we've unpacked to i8
         let scheme = scheme.with_store(QuantStore::Native);
 
-        FlexQTensor::new(tensor, scheme, qparams.scales)
+        FlexQTensor::new(tensor, scheme, qparams.block, qparams.global)
     }
 
     fn quantize_dynamic(tensor: FloatTensor<Flex>, scheme: &QuantScheme) -> QuantizedTensor<Flex> {
@@ -52,20 +59,42 @@ impl QTensorOps<Flex> for Flex {
         let (a, b) = scheme.value.range();
         let range = b - a;
 
-        let (quantized, scales) = match scheme.level {
-            QuantLevel::BlockTensor { .. } => {
-                unimplemented!("two-level quantization is not supported yet")
-            }
-            QuantLevel::Tensor => {
-                // Pass 1: find alpha = max(|min|, |max|)
-                let mut alpha: f32 = 0.0;
-                for &x in &*float_data {
-                    let abs = x.abs();
-                    if abs > alpha {
-                        alpha = abs;
+        let (quantized, scales, global) = match (scheme.block_size(), global_scale_dtype(scheme)) {
+            (Some(block), Some(global_dtype)) => {
+                let block_elems = block.num_elements();
+                assert_block_divides(float_data.len(), block_elems);
+                let num_blocks = float_data.len() / block_elems;
+
+                let raw: Vec<f32> = float_data
+                    .chunks(block_elems)
+                    .map(|block| block_max_abs_scale(block, range))
+                    .collect();
+                let peak = raw.iter().copied().fold(0.0f32, f32::max);
+
+                let global = validated_scale(
+                    peak / scheme.scale_dtype().max_representable(),
+                    global_dtype,
+                );
+
+                let mut scales = Vec::with_capacity(num_blocks);
+                let mut quantized = Vec::with_capacity(float_data.len());
+                for (block, &raw) in float_data.chunks(block_elems).zip(raw.iter()) {
+                    let scale = validated_scale(raw / global, scheme.scale_dtype());
+                    let inv_scale = 1.0 / (global * scale);
+                    scales.push(scale);
+
+                    for &x in block {
+                        quantized.push((x * inv_scale).round().clamp(a, b) as i8);
                     }
                 }
-                let scale = validated_scale(2.0 * alpha / range, scheme.param);
+
+                (quantized, scales, Some(global))
+            }
+            (None, _) => {
+                let scale = validated_scale(
+                    block_max_abs_scale(&float_data, range),
+                    scheme.scale_dtype(),
+                );
                 let inv_scale = 1.0 / scale;
 
                 // Pass 2: quantize
@@ -74,30 +103,18 @@ impl QTensorOps<Flex> for Flex {
                     .map(|&x| (x * inv_scale).round().clamp(a, b) as i8)
                     .collect::<Vec<i8>>();
 
-                (quantized, alloc::vec![scale])
+                (quantized, alloc::vec![scale], None)
             }
-            QuantLevel::Block(block_size) => {
+            (Some(block_size), None) => {
                 let block_elems = block_size.num_elements();
-                debug_assert!(
-                    float_data.len().is_multiple_of(block_elems),
-                    "tensor length {} not divisible by block size {}",
-                    float_data.len(),
-                    block_elems
-                );
+                assert_block_divides(float_data.len(), block_elems);
                 let num_blocks = float_data.len() / block_elems;
                 let mut scales = Vec::with_capacity(num_blocks);
                 let mut quantized = Vec::with_capacity(float_data.len());
 
                 for block in float_data.chunks(block_elems) {
-                    // Find alpha for this block
-                    let mut alpha: f32 = 0.0;
-                    for &x in block {
-                        let abs = x.abs();
-                        if abs > alpha {
-                            alpha = abs;
-                        }
-                    }
-                    let scale = validated_scale(2.0 * alpha / range, scheme.param);
+                    let scale =
+                        validated_scale(block_max_abs_scale(block, range), scheme.scale_dtype());
                     let inv_scale = 1.0 / scale;
                     scales.push(scale);
 
@@ -107,7 +124,7 @@ impl QTensorOps<Flex> for Flex {
                     }
                 }
 
-                (quantized, scales)
+                (quantized, scales, None)
             }
         };
 
@@ -115,7 +132,7 @@ impl QTensorOps<Flex> for Flex {
         let layout = Layout::contiguous(shape);
         let qt = FlexTensor::new(bytes, layout, DType::I8);
 
-        FlexQTensor::new(qt, scheme.with_store(QuantStore::Native), scales)
+        FlexQTensor::new(qt, scheme.with_store(QuantStore::Native), scales, global)
     }
 
     fn quantize(
@@ -136,33 +153,33 @@ impl QTensorOps<Flex> for Flex {
         let scales: Vec<f32> = scales_data
             .iter()
             .copied()
-            .map(|s| validated_scale(s, scheme.param))
+            .map(|s| validated_scale(s, scheme.scale_dtype()))
             .collect();
+
+        let global = qparams.global.map(|global| {
+            let dtype = global_scale_dtype(scheme)
+                .expect("a per-tensor scale should come with a two-level scheme");
+            let global = global.to_contiguous();
+            validated_scale(float_storage_as_f32(&global)[0], dtype)
+        });
 
         let (a, b) = scheme.value.range();
 
-        let quantized = match scheme.level {
-            QuantLevel::BlockTensor { .. } => {
-                unimplemented!("two-level quantization is not supported yet")
-            }
-            QuantLevel::Tensor => {
+        let quantized = match scheme.block_size() {
+            None => {
                 let inv_scale = 1.0 / scales[0];
                 float_data
                     .iter()
                     .map(|&x| (x * inv_scale).round().clamp(a, b) as i8)
                     .collect::<Vec<i8>>()
             }
-            QuantLevel::Block(block_size) => {
+            Some(block_size) => {
                 let block_elems = block_size.num_elements();
-                debug_assert!(
-                    float_data.len().is_multiple_of(block_elems),
-                    "tensor length {} not divisible by block size {}",
-                    float_data.len(),
-                    block_elems
-                );
+                assert_block_divides(float_data.len(), block_elems);
+                let multiplier = global.unwrap_or(1.0);
                 let mut quantized = Vec::with_capacity(float_data.len());
                 for (block, &scale) in float_data.chunks(block_elems).zip(scales.iter()) {
-                    let inv_scale = 1.0 / scale;
+                    let inv_scale = 1.0 / (multiplier * scale);
                     for &x in block {
                         quantized.push((x * inv_scale).round().clamp(a, b) as i8);
                     }
@@ -175,7 +192,7 @@ impl QTensorOps<Flex> for Flex {
         let layout = Layout::contiguous(shape);
         let qt = FlexTensor::new(bytes, layout, DType::I8);
 
-        FlexQTensor::new(qt, scheme.with_store(QuantStore::Native), scales)
+        FlexQTensor::new(qt, scheme.with_store(QuantStore::Native), scales, global)
     }
 
     fn dequantize(tensor: QuantizedTensor<Flex>, dtype: FloatDType) -> FloatTensor<Flex> {
@@ -183,23 +200,24 @@ impl QTensorOps<Flex> for Flex {
         let qt = tensor.tensor.to_contiguous();
         let q_data: &[i8] = qt.storage();
 
-        let dequantized = match tensor.scheme.level {
-            QuantLevel::BlockTensor { .. } => {
-                unimplemented!("two-level quantization is not supported yet")
-            }
-            QuantLevel::Tensor => {
+        let dequantized = match tensor.scheme.block_size() {
+            None => {
                 let scale = tensor.scales[0];
                 q_data
                     .iter()
                     .map(|&x_q| scale * x_q as f32)
                     .collect::<Vec<f32>>()
             }
-            QuantLevel::Block(block_size) => {
+            Some(block_size) => {
                 let block_elems = block_size.num_elements();
+                let multiplier = tensor.global.unwrap_or(1.0);
                 q_data
                     .chunks(block_elems)
                     .zip(tensor.scales.iter())
-                    .flat_map(|(block, &scale)| block.iter().map(move |&x_q| scale * x_q as f32))
+                    .flat_map(|(block, &scale)| {
+                        let scale = multiplier * scale;
+                        block.iter().map(move |&x_q| scale * x_q as f32)
+                    })
                     .collect::<Vec<f32>>()
             }
         };
@@ -243,6 +261,7 @@ impl QTensorOps<Flex> for Flex {
             shape.to_vec(),
             scheme,
             &tensor.scales,
+            tensor.global,
         ))
     }
 
@@ -271,16 +290,14 @@ impl QTensorOps<Flex> for Flex {
         dim: usize,
         indices: IntTensor<Flex>,
     ) -> QuantizedTensor<Flex> {
-        match tensor.scheme.level {
-            QuantLevel::BlockTensor { .. } => {
-                unimplemented!("two-level quantization is not supported yet")
-            }
-            QuantLevel::Tensor => FlexQTensor::new(
+        match tensor.scheme.block_size() {
+            None => FlexQTensor::new(
                 crate::ops::gather_scatter::select::<i8>(tensor.tensor, dim, indices),
                 tensor.scheme,
                 tensor.scales,
+                tensor.global,
             ),
-            QuantLevel::Block(_) => {
+            Some(_) => {
                 let scheme = tensor.scheme;
                 let float_tensor = Flex::dequantize(tensor, FloatDType::F32);
                 let result = crate::ops::gather_scatter::select::<f32>(float_tensor, dim, indices);
@@ -324,16 +341,14 @@ impl QTensorOps<Flex> for Flex {
         tensor: QuantizedTensor<Flex>,
         indices: IntTensor<Flex>,
     ) -> QuantizedTensor<Flex> {
-        match tensor.scheme.level {
-            QuantLevel::BlockTensor { .. } => {
-                unimplemented!("two-level quantization is not supported yet")
-            }
-            QuantLevel::Tensor => FlexQTensor::new(
+        match tensor.scheme.block_size() {
+            None => FlexQTensor::new(
                 crate::ops::gather_scatter::gather::<i8>(tensor.tensor, dim, indices),
                 tensor.scheme,
                 tensor.scales,
+                tensor.global,
             ),
-            QuantLevel::Block(_) => {
+            Some(_) => {
                 let scheme = tensor.scheme;
                 let float_tensor = Flex::dequantize(tensor, FloatDType::F32);
                 let result = crate::ops::gather_scatter::gather::<f32>(float_tensor, dim, indices);
@@ -350,12 +365,14 @@ fn block_safe_layout_op(
     qtensor: FlexQTensor,
     op: impl FnOnce(FlexTensor) -> FlexTensor,
 ) -> FlexQTensor {
-    match qtensor.scheme.level {
-        QuantLevel::BlockTensor { .. } => {
-            unimplemented!("two-level quantization is not supported yet")
-        }
-        QuantLevel::Tensor => FlexQTensor::new(op(qtensor.tensor), qtensor.scheme, qtensor.scales),
-        QuantLevel::Block(_) => {
+    match qtensor.scheme.block_size() {
+        None => FlexQTensor::new(
+            op(qtensor.tensor),
+            qtensor.scheme,
+            qtensor.scales,
+            qtensor.global,
+        ),
+        Some(_) => {
             let scheme = qtensor.scheme;
             let float_tensor = Flex::dequantize(qtensor, FloatDType::F32);
             let result = op(float_tensor);
@@ -364,18 +381,21 @@ fn block_safe_layout_op(
     }
 }
 
-/// Round the scale to the scheme's param dtype, then ensure it is finite and nonzero to avoid
-/// division by zero or NaN propagation.
-///
-/// Rounding comes first, and only an exactly zero scale is replaced: subnormals of the param are
-/// representable and carry real information for a small tensor, so substituting them would throw
-/// away what rounding up preserved.
-fn validated_scale(scale: f32, param: QuantParam) -> f32 {
-    let scale = scale_to_param(scale, param);
+/// Unrounded; callers round separately.
+fn block_max_abs_scale(block: &[f32], range: f32) -> f32 {
+    let alpha = block.iter().fold(0.0f32, |alpha, &x| alpha.max(x.abs()));
+    2.0 * alpha / range
+}
+
+/// Only an exactly zero scale is replaced: the param's subnormals carry real information for a
+/// small tensor, and the replacement goes back through the param because `f32::MIN_POSITIVE`
+/// would itself encode to zero in a narrow one.
+fn validated_scale(scale: f32, param: ScaleDtype) -> f32 {
+    let scale = scale_to_dtype(scale, param);
     if scale > 0.0 && scale.is_finite() {
         scale
     } else {
-        f32::MIN_POSITIVE
+        scale_to_dtype(f32::MIN_POSITIVE, param)
     }
 }
 
@@ -409,6 +429,7 @@ mod tests {
 
         let qparams = QuantizationParametersPrimitive {
             scales: scales_tensor,
+            global: None,
         };
 
         // Quantize
@@ -449,6 +470,7 @@ mod tests {
 
         let qparams = QuantizationParametersPrimitive {
             scales: scales_tensor,
+            global: None,
         };
 
         let qtensor = Flex::quantize(tensor, &scheme, qparams);
@@ -469,7 +491,7 @@ mod tests {
             .with_value(QuantValue::Q8S)
             .with_store(QuantStore::Native);
 
-        let data = TensorData::quantized(values.clone(), [2, 3], scheme, &[scale]);
+        let data = TensorData::quantized(values.clone(), [2, 3], scheme, &[scale], None);
 
         // Load into FlexQTensor
         let qtensor = Flex::q_from_data(data, &Default::default());
@@ -496,6 +518,7 @@ mod tests {
         let scales_tensor = FlexTensor::from_data(TensorData::new(vec![0.0f32], [1]));
         let qparams = QuantizationParametersPrimitive {
             scales: scales_tensor,
+            global: None,
         };
 
         let qtensor = Flex::quantize(tensor, &scheme, qparams);
@@ -503,24 +526,24 @@ mod tests {
         assert_eq!(q_vals, &[0, 0, 0, 0]);
     }
 
-    /// The scale a narrow param can represent is coarser than the exact one, so the stored scale
-    /// must reflect the param rather than staying at full `f32` precision. Before scales were
-    /// rounded, every param produced byte-identical results here.
+    /// The scale a narrow dtype can represent is coarser than the exact one, so the stored scale
+    /// must reflect the dtype rather than staying at full `f32` precision. Before scales were
+    /// rounded, every scale dtype produced byte-identical results here.
     #[test]
-    fn test_quantize_dynamic_honors_param_precision() {
+    fn test_quantize_dynamic_honors_scale_dtype_precision() {
         // 4.5 / 127 is not representable in e4m3, so rounding is observable.
         let values = vec![-3.0f32, -1.5, 0.0, 1.5, 3.0, 4.5];
         let scheme = QuantScheme::default()
             .with_value(QuantValue::Q8S)
             .with_store(QuantStore::Native);
 
-        let quantize_with = |param| {
+        let quantize_with = |dtype| {
             let tensor = FlexTensor::from_data(TensorData::new(values.clone(), [2, 3]));
-            Flex::quantize_dynamic(tensor, &scheme.with_param(param)).scales[0]
+            Flex::quantize_dynamic(tensor, &scheme.per_tensor(dtype)).scales[0]
         };
 
-        let exact = quantize_with(QuantParam::F32);
-        let coarse = quantize_with(QuantParam::UE4M3);
+        let exact = quantize_with(ScaleDtype::F32);
+        let coarse = quantize_with(ScaleDtype::UE4M3);
 
         assert_ne!(
             exact, coarse,
@@ -528,8 +551,8 @@ mod tests {
         );
         assert_eq!(
             coarse,
-            scale_to_param(exact, QuantParam::UE4M3),
-            "stored scale should be the exact scale rounded to the param"
+            scale_to_dtype(exact, ScaleDtype::UE4M3),
+            "stored scale should be the exact scale rounded to the scale dtype"
         );
     }
 
@@ -572,7 +595,7 @@ mod tests {
         let block_size = BlockSize::new([4]);
         let scheme = QuantScheme::default()
             .with_value(QuantValue::Q8S)
-            .with_level(QuantLevel::Block(block_size))
+            .per_block(block_size.as_slice(), ScaleDtype::F32)
             .with_store(QuantStore::Native);
 
         // Block 1: [0, 1, 2, 3] -> max_abs=3, scale = 6/254
@@ -583,6 +606,7 @@ mod tests {
 
         let qparams = QuantizationParametersPrimitive {
             scales: scales_tensor,
+            global: None,
         };
 
         let qtensor = Flex::quantize(tensor, &scheme, qparams);
@@ -606,7 +630,7 @@ mod tests {
         let block_size = BlockSize::new([4]);
         let scheme = QuantScheme::default()
             .with_value(QuantValue::Q8S)
-            .with_level(QuantLevel::Block(block_size))
+            .per_block(block_size.as_slice(), ScaleDtype::F32)
             .with_store(QuantStore::Native);
 
         let qtensor = Flex::quantize_dynamic(tensor, &scheme);
@@ -666,7 +690,7 @@ mod tests {
         let block_size = BlockSize::new([4]);
         let scheme = QuantScheme::default()
             .with_value(QuantValue::Q8S)
-            .with_level(QuantLevel::Block(block_size))
+            .per_block(block_size.as_slice(), ScaleDtype::F32)
             .with_store(QuantStore::Native);
 
         let qtensor = Flex::quantize_dynamic(tensor, &scheme);
@@ -699,7 +723,7 @@ mod tests {
         let block_size = BlockSize::new([4]);
         let scheme = QuantScheme::default()
             .with_value(QuantValue::Q8S)
-            .with_level(QuantLevel::Block(block_size))
+            .per_block(block_size.as_slice(), ScaleDtype::F32)
             .with_store(QuantStore::Native);
 
         let qtensor = Flex::quantize_dynamic(tensor, &scheme);
@@ -727,7 +751,7 @@ mod tests {
         let block_size = BlockSize::new([4]);
         let scheme = QuantScheme::default()
             .with_value(QuantValue::Q8S)
-            .with_level(QuantLevel::Block(block_size))
+            .per_block(block_size.as_slice(), ScaleDtype::F32)
             .with_store(QuantStore::Native);
 
         let qtensor = Flex::quantize_dynamic(tensor, &scheme);

--- a/crates/burn-flex/src/ops/qtensor.rs
+++ b/crates/burn-flex/src/ops/qtensor.rs
@@ -42,7 +42,7 @@ impl QTensorOps<Flex> for Flex {
         // Use native storage since we've unpacked to i8
         let scheme = scheme.with_store(QuantStore::Native);
 
-        FlexQTensor::new(tensor, scheme, qparams.block)
+        FlexQTensor::new(tensor, scheme, qparams.block, qparams.global)
     }
 
     fn quantize_dynamic(tensor: FloatTensor<Flex>, scheme: &QuantScheme) -> QuantizedTensor<Flex> {
@@ -52,9 +52,54 @@ impl QTensorOps<Flex> for Flex {
         let (a, b) = scheme.value.range();
         let range = b - a;
 
-        let (quantized, scales) = match scheme.level {
-            QuantLevel::BlockTensor { .. } => {
-                unimplemented!("two-level quantization is not supported on flex yet")
+        let (quantized, scales, global) = match scheme.level {
+            QuantLevel::BlockTensor {
+                block,
+                global: global_param,
+            } => {
+                let block_elems = block.num_elements();
+                debug_assert!(
+                    float_data.len().is_multiple_of(block_elems),
+                    "tensor length {} not divisible by block size {}",
+                    float_data.len(),
+                    block_elems
+                );
+                let num_blocks = float_data.len() / block_elems;
+
+                let mut raw = Vec::with_capacity(num_blocks);
+                let mut peak: f32 = 0.0;
+                for block in float_data.chunks(block_elems) {
+                    let mut alpha: f32 = 0.0;
+                    for &x in block {
+                        let abs = x.abs();
+                        if abs > alpha {
+                            alpha = abs;
+                        }
+                    }
+                    let scale = 2.0 * alpha / range;
+                    if scale > peak {
+                        peak = scale;
+                    }
+                    raw.push(scale);
+                }
+
+                // The global carries the tensor's dynamic range, leaving the block param to cover
+                // only the spread between blocks.
+                let global = validated_scale(peak / scheme.param.max_representable(), global_param);
+
+                let mut scales = Vec::with_capacity(num_blocks);
+                let mut quantized = Vec::with_capacity(float_data.len());
+                for (block, &raw) in float_data.chunks(block_elems).zip(raw.iter()) {
+                    let scale = validated_scale(raw / global, scheme.param);
+                    let inv_scale = 1.0 / (global * scale);
+                    scales.push(scale);
+
+                    for &x in block {
+                        quantized.push((x * inv_scale).round().clamp(a, b) as i8);
+                    }
+                }
+
+                (quantized, scales, Some(global))
             }
             QuantLevel::Tensor => {
                 // Pass 1: find alpha = max(|min|, |max|)
@@ -74,7 +119,7 @@ impl QTensorOps<Flex> for Flex {
                     .map(|&x| (x * inv_scale).round().clamp(a, b) as i8)
                     .collect::<Vec<i8>>();
 
-                (quantized, alloc::vec![scale])
+                (quantized, alloc::vec![scale], None)
             }
             QuantLevel::Block(block_size) => {
                 let block_elems = block_size.num_elements();
@@ -107,7 +152,7 @@ impl QTensorOps<Flex> for Flex {
                     }
                 }
 
-                (quantized, scales)
+                (quantized, scales, None)
             }
         };
 
@@ -115,7 +160,7 @@ impl QTensorOps<Flex> for Flex {
         let layout = Layout::contiguous(shape);
         let qt = FlexTensor::new(bytes, layout, DType::I8);
 
-        FlexQTensor::new(qt, scheme.with_store(QuantStore::Native), scales)
+        FlexQTensor::new(qt, scheme.with_store(QuantStore::Native), scales, global)
     }
 
     fn quantize(
@@ -139,11 +184,29 @@ impl QTensorOps<Flex> for Flex {
             .map(|s| validated_scale(s, scheme.param))
             .collect();
 
+        let global = qparams.global.map(|global| {
+            let param = scheme
+                .level
+                .global_param()
+                .expect("a per-tensor scale should come with a two-level scheme");
+            let global = global.to_contiguous();
+            validated_scale(float_storage_as_f32(&global)[0], param)
+        });
+
         let (a, b) = scheme.value.range();
 
         let quantized = match scheme.level {
-            QuantLevel::BlockTensor { .. } => {
-                unimplemented!("two-level quantization is not supported on flex yet")
+            QuantLevel::BlockTensor { block, .. } => {
+                let block_elems = block.num_elements();
+                let global = global.expect("a two-level scheme should have a per-tensor scale");
+                let mut quantized = Vec::with_capacity(float_data.len());
+                for (block, &scale) in float_data.chunks(block_elems).zip(scales.iter()) {
+                    let inv_scale = 1.0 / (global * scale);
+                    for &x in block {
+                        quantized.push((x * inv_scale).round().clamp(a, b) as i8);
+                    }
+                }
+                quantized
             }
             QuantLevel::Tensor => {
                 let inv_scale = 1.0 / scales[0];
@@ -175,7 +238,7 @@ impl QTensorOps<Flex> for Flex {
         let layout = Layout::contiguous(shape);
         let qt = FlexTensor::new(bytes, layout, DType::I8);
 
-        FlexQTensor::new(qt, scheme.with_store(QuantStore::Native), scales)
+        FlexQTensor::new(qt, scheme.with_store(QuantStore::Native), scales, global)
     }
 
     fn dequantize(tensor: QuantizedTensor<Flex>, dtype: FloatDType) -> FloatTensor<Flex> {
@@ -184,8 +247,19 @@ impl QTensorOps<Flex> for Flex {
         let q_data: &[i8] = qt.storage();
 
         let dequantized = match tensor.scheme.level {
-            QuantLevel::BlockTensor { .. } => {
-                unimplemented!("two-level quantization is not supported on flex yet")
+            QuantLevel::BlockTensor { block, .. } => {
+                let block_elems = block.num_elements();
+                let global = tensor
+                    .global
+                    .expect("a two-level tensor should carry a per-tensor scale");
+                q_data
+                    .chunks(block_elems)
+                    .zip(tensor.scales.iter())
+                    .flat_map(|(block, &scale)| {
+                        let scale = global * scale;
+                        block.iter().map(move |&x_q| scale * x_q as f32)
+                    })
+                    .collect::<Vec<f32>>()
             }
             QuantLevel::Tensor => {
                 let scale = tensor.scales[0];
@@ -243,7 +317,7 @@ impl QTensorOps<Flex> for Flex {
             shape.to_vec(),
             scheme,
             &tensor.scales,
-            None,
+            tensor.global,
         ))
     }
 
@@ -273,15 +347,13 @@ impl QTensorOps<Flex> for Flex {
         indices: IntTensor<Flex>,
     ) -> QuantizedTensor<Flex> {
         match tensor.scheme.level {
-            QuantLevel::BlockTensor { .. } => {
-                unimplemented!("two-level quantization is not supported on flex yet")
-            }
             QuantLevel::Tensor => FlexQTensor::new(
                 crate::ops::gather_scatter::select::<i8>(tensor.tensor, dim, indices),
                 tensor.scheme,
                 tensor.scales,
+                tensor.global,
             ),
-            QuantLevel::Block(_) => {
+            QuantLevel::Block(_) | QuantLevel::BlockTensor { .. } => {
                 let scheme = tensor.scheme;
                 let float_tensor = Flex::dequantize(tensor, FloatDType::F32);
                 let result = crate::ops::gather_scatter::select::<f32>(float_tensor, dim, indices);
@@ -326,15 +398,13 @@ impl QTensorOps<Flex> for Flex {
         indices: IntTensor<Flex>,
     ) -> QuantizedTensor<Flex> {
         match tensor.scheme.level {
-            QuantLevel::BlockTensor { .. } => {
-                unimplemented!("two-level quantization is not supported on flex yet")
-            }
             QuantLevel::Tensor => FlexQTensor::new(
                 crate::ops::gather_scatter::gather::<i8>(tensor.tensor, dim, indices),
                 tensor.scheme,
                 tensor.scales,
+                tensor.global,
             ),
-            QuantLevel::Block(_) => {
+            QuantLevel::Block(_) | QuantLevel::BlockTensor { .. } => {
                 let scheme = tensor.scheme;
                 let float_tensor = Flex::dequantize(tensor, FloatDType::F32);
                 let result = crate::ops::gather_scatter::gather::<f32>(float_tensor, dim, indices);
@@ -352,11 +422,13 @@ fn block_safe_layout_op(
     op: impl FnOnce(FlexTensor) -> FlexTensor,
 ) -> FlexQTensor {
     match qtensor.scheme.level {
-        QuantLevel::BlockTensor { .. } => {
-            unimplemented!("two-level quantization is not supported on flex yet")
-        }
-        QuantLevel::Tensor => FlexQTensor::new(op(qtensor.tensor), qtensor.scheme, qtensor.scales),
-        QuantLevel::Block(_) => {
+        QuantLevel::Tensor => FlexQTensor::new(
+            op(qtensor.tensor),
+            qtensor.scheme,
+            qtensor.scales,
+            qtensor.global,
+        ),
+        QuantLevel::Block(_) | QuantLevel::BlockTensor { .. } => {
             let scheme = qtensor.scheme;
             let float_tensor = Flex::dequantize(qtensor, FloatDType::F32);
             let result = op(float_tensor);
@@ -410,6 +482,7 @@ mod tests {
 
         let qparams = QuantizationParametersPrimitive {
             scales: scales_tensor,
+            global: None,
         };
 
         // Quantize
@@ -450,6 +523,7 @@ mod tests {
 
         let qparams = QuantizationParametersPrimitive {
             scales: scales_tensor,
+            global: None,
         };
 
         let qtensor = Flex::quantize(tensor, &scheme, qparams);
@@ -497,6 +571,7 @@ mod tests {
         let scales_tensor = FlexTensor::from_data(TensorData::new(vec![0.0f32], [1]));
         let qparams = QuantizationParametersPrimitive {
             scales: scales_tensor,
+            global: None,
         };
 
         let qtensor = Flex::quantize(tensor, &scheme, qparams);
@@ -584,6 +659,7 @@ mod tests {
 
         let qparams = QuantizationParametersPrimitive {
             scales: scales_tensor,
+            global: None,
         };
 
         let qtensor = Flex::quantize(tensor, &scheme, qparams);

--- a/crates/burn-flex/src/ops/qtensor.rs
+++ b/crates/burn-flex/src/ops/qtensor.rs
@@ -9,8 +9,8 @@ use burn_backend::{
     DType, ExecutionError, FloatDType, TensorData, TensorMetadata,
     ops::{IntTensorOps, QTensorOps},
     quantization::{
-        QuantScheme, QuantStore, QuantizationParametersPrimitive, QuantizedBytes, ScaleDtype,
-        global_scale_dtype, scale_to_dtype,
+        BlockGrid, BlockSize, QuantScheme, QuantStore, QuantizationParametersPrimitive,
+        QuantizedBytes, ScaleDtype, global_scale_dtype, scale_to_dtype,
     },
     tensor::{Device, FloatTensor, IntTensor, QuantizedTensor},
 };
@@ -19,11 +19,24 @@ use burn_std::{Bytes, Shape, Slice, bf16, f16};
 use super::float_storage_as_f32;
 use crate::{Flex, FlexQTensor, FlexTensor, Layout};
 
-fn assert_block_divides(len: usize, block_elems: usize) {
+/// The block grid over `shape`, which must be a whole number of blocks along every axis.
+fn block_grid(shape: &Shape, block: &BlockSize) -> BlockGrid {
+    let grid = BlockGrid::new(shape, block);
     debug_assert!(
-        len.is_multiple_of(block_elems),
-        "tensor length {len} not divisible by block size {block_elems}"
+        grid.divides(),
+        "tensor {shape:?} is not a whole number of {block:?} blocks"
     );
+    grid
+}
+
+/// The largest magnitude in each block of `values`, laid out as `grid`.
+fn block_max_abs(values: &[f32], grid: &BlockGrid) -> Vec<f32> {
+    let mut peaks = alloc::vec![0.0f32; grid.num_blocks()];
+    for (index, &x) in values.iter().enumerate() {
+        let peak = &mut peaks[grid.block_of(index)];
+        *peak = peak.max(x.abs());
+    }
+    peaks
 }
 
 impl QTensorOps<Flex> for Flex {
@@ -34,12 +47,11 @@ impl QTensorOps<Flex> for Flex {
         };
 
         let shape = data.shape.clone();
-        let num_elements = data.num_elements();
 
         let q_bytes = QuantizedBytes {
+            shape: shape.clone(),
             bytes: data.into_bytes(),
             scheme,
-            num_elements,
         };
 
         let (values, qparams) = q_bytes.into_vec_i8();
@@ -61,13 +73,10 @@ impl QTensorOps<Flex> for Flex {
 
         let (quantized, scales, global) = match (scheme.block_size(), global_scale_dtype(scheme)) {
             (Some(block), Some(global_dtype)) => {
-                let block_elems = block.num_elements();
-                assert_block_divides(float_data.len(), block_elems);
-                let num_blocks = float_data.len() / block_elems;
-
-                let raw: Vec<f32> = float_data
-                    .chunks(block_elems)
-                    .map(|block| block_max_abs_scale(block, range))
+                let grid = block_grid(&shape, &block);
+                let raw: Vec<f32> = block_max_abs(&float_data, &grid)
+                    .into_iter()
+                    .map(|alpha| 2.0 * alpha / range)
                     .collect();
                 let peak = raw.iter().copied().fold(0.0f32, f32::max);
 
@@ -76,17 +85,18 @@ impl QTensorOps<Flex> for Flex {
                     global_dtype,
                 );
 
-                let mut scales = Vec::with_capacity(num_blocks);
-                let mut quantized = Vec::with_capacity(float_data.len());
-                for (block, &raw) in float_data.chunks(block_elems).zip(raw.iter()) {
-                    let scale = validated_scale(raw / global, scheme.scale_dtype());
-                    let inv_scale = 1.0 / (global * scale);
-                    scales.push(scale);
-
-                    for &x in block {
-                        quantized.push((x * inv_scale).round().clamp(a, b) as i8);
-                    }
-                }
+                let scales: Vec<f32> = raw
+                    .iter()
+                    .map(|&raw| validated_scale(raw / global, scheme.scale_dtype()))
+                    .collect();
+                let quantized = float_data
+                    .iter()
+                    .enumerate()
+                    .map(|(index, &x)| {
+                        let inv_scale = 1.0 / (global * scales[grid.block_of(index)]);
+                        (x * inv_scale).round().clamp(a, b) as i8
+                    })
+                    .collect();
 
                 (quantized, scales, Some(global))
             }
@@ -106,23 +116,19 @@ impl QTensorOps<Flex> for Flex {
                 (quantized, alloc::vec![scale], None)
             }
             (Some(block_size), None) => {
-                let block_elems = block_size.num_elements();
-                assert_block_divides(float_data.len(), block_elems);
-                let num_blocks = float_data.len() / block_elems;
-                let mut scales = Vec::with_capacity(num_blocks);
-                let mut quantized = Vec::with_capacity(float_data.len());
-
-                for block in float_data.chunks(block_elems) {
-                    let scale =
-                        validated_scale(block_max_abs_scale(block, range), scheme.scale_dtype());
-                    let inv_scale = 1.0 / scale;
-                    scales.push(scale);
-
-                    // Quantize this block
-                    for &x in block {
-                        quantized.push((x * inv_scale).round().clamp(a, b) as i8);
-                    }
-                }
+                let grid = block_grid(&shape, &block_size);
+                let scales: Vec<f32> = block_max_abs(&float_data, &grid)
+                    .into_iter()
+                    .map(|alpha| validated_scale(2.0 * alpha / range, scheme.scale_dtype()))
+                    .collect();
+                let quantized = float_data
+                    .iter()
+                    .enumerate()
+                    .map(|(index, &x)| {
+                        let inv_scale = 1.0 / scales[grid.block_of(index)];
+                        (x * inv_scale).round().clamp(a, b) as i8
+                    })
+                    .collect();
 
                 (quantized, scales, None)
             }
@@ -174,17 +180,16 @@ impl QTensorOps<Flex> for Flex {
                     .collect::<Vec<i8>>()
             }
             Some(block_size) => {
-                let block_elems = block_size.num_elements();
-                assert_block_divides(float_data.len(), block_elems);
+                let grid = block_grid(&shape, &block_size);
                 let multiplier = global.unwrap_or(1.0);
-                let mut quantized = Vec::with_capacity(float_data.len());
-                for (block, &scale) in float_data.chunks(block_elems).zip(scales.iter()) {
-                    let inv_scale = 1.0 / (multiplier * scale);
-                    for &x in block {
-                        quantized.push((x * inv_scale).round().clamp(a, b) as i8);
-                    }
-                }
-                quantized
+                float_data
+                    .iter()
+                    .enumerate()
+                    .map(|(index, &x)| {
+                        let inv_scale = 1.0 / (multiplier * scales[grid.block_of(index)]);
+                        (x * inv_scale).round().clamp(a, b) as i8
+                    })
+                    .collect()
             }
         };
 
@@ -209,14 +214,13 @@ impl QTensorOps<Flex> for Flex {
                     .collect::<Vec<f32>>()
             }
             Some(block_size) => {
-                let block_elems = block_size.num_elements();
+                let grid = BlockGrid::new(&shape, &block_size);
                 let multiplier = tensor.global.unwrap_or(1.0);
                 q_data
-                    .chunks(block_elems)
-                    .zip(tensor.scales.iter())
-                    .flat_map(|(block, &scale)| {
-                        let scale = multiplier * scale;
-                        block.iter().map(move |&x_q| scale * x_q as f32)
+                    .iter()
+                    .enumerate()
+                    .map(|(index, &x_q)| {
+                        multiplier * tensor.scales[grid.block_of(index)] * x_q as f32
                     })
                     .collect::<Vec<f32>>()
             }
@@ -247,7 +251,8 @@ impl QTensorOps<Flex> for Flex {
     }
 
     fn q_reshape(tensor: QuantizedTensor<Flex>, shape: Shape) -> QuantizedTensor<Flex> {
-        block_safe_layout_op(tensor, |t| t.reshape(shape))
+        let scheme = tensor.scheme;
+        block_safe_layout_op(tensor, scheme, |t| t.reshape(shape))
     }
 
     async fn q_into_data(tensor: QuantizedTensor<Flex>) -> Result<TensorData, ExecutionError> {
@@ -270,19 +275,25 @@ impl QTensorOps<Flex> for Flex {
         dim1: usize,
         dim2: usize,
     ) -> QuantizedTensor<Flex> {
-        block_safe_layout_op(tensor, |t| t.transpose(dim1, dim2))
+        let mut scheme = tensor.scheme;
+        scheme.swap_block_dims(tensor.tensor.shape().num_dims(), dim1, dim2);
+        block_safe_layout_op(tensor, scheme, |t| t.transpose(dim1, dim2))
     }
 
     fn q_permute(tensor: QuantizedTensor<Flex>, axes: &[usize]) -> QuantizedTensor<Flex> {
-        block_safe_layout_op(tensor, |t| t.permute(axes))
+        let mut scheme = tensor.scheme;
+        scheme.permute_block_dims(tensor.tensor.shape().num_dims(), axes);
+        block_safe_layout_op(tensor, scheme, |t| t.permute(axes))
     }
 
     fn q_flip(tensor: QuantizedTensor<Flex>, axes: &[usize]) -> QuantizedTensor<Flex> {
-        block_safe_layout_op(tensor, |t| crate::ops::flip::flip(t, axes))
+        let scheme = tensor.scheme;
+        block_safe_layout_op(tensor, scheme, |t| crate::ops::flip::flip(t, axes))
     }
 
     fn q_expand(tensor: QuantizedTensor<Flex>, shape: Shape) -> QuantizedTensor<Flex> {
-        block_safe_layout_op(tensor, |t| crate::ops::expand::expand(t, shape))
+        let scheme = tensor.scheme;
+        block_safe_layout_op(tensor, scheme, |t| crate::ops::expand::expand(t, shape))
     }
 
     fn q_select(
@@ -307,7 +318,8 @@ impl QTensorOps<Flex> for Flex {
     }
 
     fn q_slice(tensor: QuantizedTensor<Flex>, slices: &[Slice]) -> QuantizedTensor<Flex> {
-        block_safe_layout_op(tensor, |t| crate::ops::slice::slice(t, slices))
+        let scheme = tensor.scheme;
+        block_safe_layout_op(tensor, scheme, |t| crate::ops::slice::slice(t, slices))
     }
 
     fn q_argmax(
@@ -358,11 +370,12 @@ impl QTensorOps<Flex> for Flex {
     }
 }
 
-/// Apply a layout operation to a quantized tensor.
-/// For block-quantized tensors, dequantizes and requantizes to preserve
-/// correct scale-to-block mapping.
+/// Apply a layout operation to a quantized tensor. A block-quantized tensor is dequantized,
+/// moved, and requantized under `scheme`, which the caller has already rewritten to follow the
+/// move (a permuted tensor's blocks are permuted with it, as every other backend keeps them).
 fn block_safe_layout_op(
     qtensor: FlexQTensor,
+    scheme: QuantScheme,
     op: impl FnOnce(FlexTensor) -> FlexTensor,
 ) -> FlexQTensor {
     match qtensor.scheme.block_size() {
@@ -373,7 +386,6 @@ fn block_safe_layout_op(
             qtensor.global,
         ),
         Some(_) => {
-            let scheme = qtensor.scheme;
             let float_tensor = Flex::dequantize(qtensor, FloatDType::F32);
             let result = op(float_tensor);
             Flex::quantize_dynamic(result, &scheme)
@@ -387,15 +399,15 @@ fn block_max_abs_scale(block: &[f32], range: f32) -> f32 {
     2.0 * alpha / range
 }
 
-/// Only an exactly zero scale is replaced: the param's subnormals carry real information for a
-/// small tensor, and the replacement goes back through the param because `f32::MIN_POSITIVE`
+/// Only an exactly zero scale is replaced: the dtype's subnormals carry real information for a
+/// small tensor, and the replacement goes back through the dtype because `f32::MIN_POSITIVE`
 /// would itself encode to zero in a narrow one.
-fn validated_scale(scale: f32, param: ScaleDtype) -> f32 {
-    let scale = scale_to_dtype(scale, param);
+fn validated_scale(scale: f32, dtype: ScaleDtype) -> f32 {
+    let scale = scale_to_dtype(scale, dtype);
     if scale > 0.0 && scale.is_finite() {
         scale
     } else {
-        scale_to_dtype(f32::MIN_POSITIVE, param)
+        scale_to_dtype(f32::MIN_POSITIVE, dtype)
     }
 }
 

--- a/crates/burn-flex/src/ops/qtensor.rs
+++ b/crates/burn-flex/src/ops/qtensor.rs
@@ -443,12 +443,16 @@ fn block_safe_layout_op(
 /// Rounding comes first, and only an exactly zero scale is replaced: subnormals of the param are
 /// representable and carry real information for a small tensor, so substituting them would throw
 /// away what rounding up preserved.
+///
+/// The replacement goes back through the param so that the scale held in memory is the one that
+/// gets stored. `f32::MIN_POSITIVE` on its own is not representable in a narrow param and would
+/// encode to zero, leaving a reloaded tensor dequantizing differently from the one in hand.
 fn validated_scale(scale: f32, param: QuantParam) -> f32 {
     let scale = scale_to_param(scale, param);
     if scale > 0.0 && scale.is_finite() {
         scale
     } else {
-        f32::MIN_POSITIVE
+        scale_to_param(f32::MIN_POSITIVE, param)
     }
 }
 

--- a/crates/burn-flex/src/ops/qtensor.rs
+++ b/crates/burn-flex/src/ops/qtensor.rs
@@ -42,7 +42,7 @@ impl QTensorOps<Flex> for Flex {
         // Use native storage since we've unpacked to i8
         let scheme = scheme.with_store(QuantStore::Native);
 
-        FlexQTensor::new(tensor, scheme, qparams.scales)
+        FlexQTensor::new(tensor, scheme, qparams.block)
     }
 
     fn quantize_dynamic(tensor: FloatTensor<Flex>, scheme: &QuantScheme) -> QuantizedTensor<Flex> {
@@ -53,6 +53,9 @@ impl QTensorOps<Flex> for Flex {
         let range = b - a;
 
         let (quantized, scales) = match scheme.level {
+            QuantLevel::BlockTensor { .. } => {
+                unimplemented!("two-level quantization is not supported on flex yet")
+            }
             QuantLevel::Tensor => {
                 // Pass 1: find alpha = max(|min|, |max|)
                 let mut alpha: f32 = 0.0;
@@ -139,6 +142,9 @@ impl QTensorOps<Flex> for Flex {
         let (a, b) = scheme.value.range();
 
         let quantized = match scheme.level {
+            QuantLevel::BlockTensor { .. } => {
+                unimplemented!("two-level quantization is not supported on flex yet")
+            }
             QuantLevel::Tensor => {
                 let inv_scale = 1.0 / scales[0];
                 float_data
@@ -178,6 +184,9 @@ impl QTensorOps<Flex> for Flex {
         let q_data: &[i8] = qt.storage();
 
         let dequantized = match tensor.scheme.level {
+            QuantLevel::BlockTensor { .. } => {
+                unimplemented!("two-level quantization is not supported on flex yet")
+            }
             QuantLevel::Tensor => {
                 let scale = tensor.scales[0];
                 q_data
@@ -234,6 +243,7 @@ impl QTensorOps<Flex> for Flex {
             shape.to_vec(),
             scheme,
             &tensor.scales,
+            None,
         ))
     }
 
@@ -263,6 +273,9 @@ impl QTensorOps<Flex> for Flex {
         indices: IntTensor<Flex>,
     ) -> QuantizedTensor<Flex> {
         match tensor.scheme.level {
+            QuantLevel::BlockTensor { .. } => {
+                unimplemented!("two-level quantization is not supported on flex yet")
+            }
             QuantLevel::Tensor => FlexQTensor::new(
                 crate::ops::gather_scatter::select::<i8>(tensor.tensor, dim, indices),
                 tensor.scheme,
@@ -313,6 +326,9 @@ impl QTensorOps<Flex> for Flex {
         indices: IntTensor<Flex>,
     ) -> QuantizedTensor<Flex> {
         match tensor.scheme.level {
+            QuantLevel::BlockTensor { .. } => {
+                unimplemented!("two-level quantization is not supported on flex yet")
+            }
             QuantLevel::Tensor => FlexQTensor::new(
                 crate::ops::gather_scatter::gather::<i8>(tensor.tensor, dim, indices),
                 tensor.scheme,
@@ -336,6 +352,9 @@ fn block_safe_layout_op(
     op: impl FnOnce(FlexTensor) -> FlexTensor,
 ) -> FlexQTensor {
     match qtensor.scheme.level {
+        QuantLevel::BlockTensor { .. } => {
+            unimplemented!("two-level quantization is not supported on flex yet")
+        }
         QuantLevel::Tensor => FlexQTensor::new(op(qtensor.tensor), qtensor.scheme, qtensor.scales),
         QuantLevel::Block(_) => {
             let scheme = qtensor.scheme;
@@ -451,7 +470,7 @@ mod tests {
             .with_value(QuantValue::Q8S)
             .with_store(QuantStore::Native);
 
-        let data = TensorData::quantized(values.clone(), [2, 3], scheme, &[scale]);
+        let data = TensorData::quantized(values.clone(), [2, 3], scheme, &[scale], None);
 
         // Load into FlexQTensor
         let qtensor = Flex::q_from_data(data, &Default::default());

--- a/crates/burn-flex/src/qtensor.rs
+++ b/crates/burn-flex/src/qtensor.rs
@@ -1,10 +1,7 @@
 use alloc::vec::Vec;
 
 use burn_backend::{DType, TensorMetadata};
-use burn_std::{
-    QuantScheme, Shape,
-    quantization::{global_scale_dtype, validate_levels},
-};
+use burn_std::{QuantScheme, Shape, quantization::global_scale_dtype};
 
 use crate::{FlexDevice, tensor::FlexTensor};
 
@@ -46,7 +43,6 @@ impl FlexQTensor {
             !scales.is_empty(),
             "quantized tensor must have at least one scale factor"
         );
-        validate_levels(&scheme);
         assert_eq!(
             global_scale_dtype(&scheme).is_some(),
             global.is_some(),

--- a/crates/burn-flex/src/qtensor.rs
+++ b/crates/burn-flex/src/qtensor.rs
@@ -1,7 +1,10 @@
 use alloc::vec::Vec;
 
 use burn_backend::{DType, TensorMetadata};
-use burn_std::{QuantScheme, Shape};
+use burn_std::{
+    QuantScheme, Shape,
+    quantization::{global_scale_dtype, validate_levels},
+};
 
 use crate::{FlexDevice, tensor::FlexTensor};
 
@@ -17,13 +20,22 @@ pub struct FlexQTensor {
     pub(crate) scheme: QuantScheme,
     /// Per-tensor or per-block scale factors.
     pub(crate) scales: Vec<f32>,
+    /// The per-tensor scale that [`scales`](Self::scales) are expressed relative to, for a
+    /// two-level scheme.
+    pub(crate) global: Option<f32>,
 }
 
 impl FlexQTensor {
     /// Create a new quantized tensor.
     ///
-    /// The tensor must store i8 data and scales must be non-empty.
-    pub fn new(tensor: FlexTensor, scheme: QuantScheme, scales: Vec<f32>) -> Self {
+    /// The tensor must store i8 data and scales must be non-empty. A two-level scheme takes a
+    /// per-tensor scale, and no other level does.
+    pub fn new(
+        tensor: FlexTensor,
+        scheme: QuantScheme,
+        scales: Vec<f32>,
+        global: Option<f32>,
+    ) -> Self {
         assert_eq!(
             tensor.dtype(),
             DType::I8,
@@ -34,10 +46,17 @@ impl FlexQTensor {
             !scales.is_empty(),
             "quantized tensor must have at least one scale factor"
         );
+        validate_levels(&scheme);
+        assert_eq!(
+            global_scale_dtype(&scheme).is_some(),
+            global.is_some(),
+            "{scheme:?} does not match a per-tensor scale of {global:?}"
+        );
         Self {
             tensor,
             scheme,
             scales,
+            global,
         }
     }
 

--- a/crates/burn-flex/src/qtensor.rs
+++ b/crates/burn-flex/src/qtensor.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 
 use burn_backend::{DType, TensorMetadata};
-use burn_std::{QuantScheme, Shape};
+use burn_std::{QuantScheme, Shape, quantization::validate_levels};
 
 use crate::{FlexDevice, tensor::FlexTensor};
 
@@ -43,6 +43,7 @@ impl FlexQTensor {
             !scales.is_empty(),
             "quantized tensor must have at least one scale factor"
         );
+        validate_levels(&scheme);
         assert_eq!(
             scheme.level.global_param().is_some(),
             global.is_some(),

--- a/crates/burn-flex/src/qtensor.rs
+++ b/crates/burn-flex/src/qtensor.rs
@@ -17,13 +17,22 @@ pub struct FlexQTensor {
     pub(crate) scheme: QuantScheme,
     /// Per-tensor or per-block scale factors.
     pub(crate) scales: Vec<f32>,
+    /// The per-tensor scale that [`scales`](Self::scales) are expressed relative to, for a
+    /// two-level scheme.
+    pub(crate) global: Option<f32>,
 }
 
 impl FlexQTensor {
     /// Create a new quantized tensor.
     ///
-    /// The tensor must store i8 data and scales must be non-empty.
-    pub fn new(tensor: FlexTensor, scheme: QuantScheme, scales: Vec<f32>) -> Self {
+    /// The tensor must store i8 data and scales must be non-empty. A two-level scheme takes a
+    /// per-tensor scale, and no other level does.
+    pub fn new(
+        tensor: FlexTensor,
+        scheme: QuantScheme,
+        scales: Vec<f32>,
+        global: Option<f32>,
+    ) -> Self {
         assert_eq!(
             tensor.dtype(),
             DType::I8,
@@ -34,10 +43,17 @@ impl FlexQTensor {
             !scales.is_empty(),
             "quantized tensor must have at least one scale factor"
         );
+        assert_eq!(
+            scheme.level.global_param().is_some(),
+            global.is_some(),
+            "{:?} does not match a per-tensor scale of {global:?}",
+            scheme.level
+        );
         Self {
             tensor,
             scheme,
             scales,
+            global,
         }
     }
 

--- a/crates/burn-fusion/src/ops/qtensor.rs
+++ b/crates/burn-fusion/src/ops/qtensor.rs
@@ -56,8 +56,14 @@ impl<B: FusionBackend> QTensorOps<Self> for Fusion<B> {
             fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
                 let tensor = handles.get_float_tensor::<B>(&self.desc.tensor);
                 let scales = handles.get_float_tensor::<B>(&self.desc.qparams.scales);
+                let global = self
+                    .desc
+                    .qparams
+                    .global
+                    .as_ref()
+                    .map(|global| handles.get_float_tensor::<B>(global));
 
-                let qparams = QuantizationParametersPrimitive { scales };
+                let qparams = QuantizationParametersPrimitive { scales, global };
                 let output = B::quantize(tensor, &self.desc.scheme, qparams);
                 handles.register_quantized_tensor::<B>(&self.desc.out.id, output);
             }
@@ -68,6 +74,7 @@ impl<B: FusionBackend> QTensorOps<Self> for Fusion<B> {
         let client = tensor.client.clone();
         let qparams = QuantizationParametersIr {
             scales: qparams.scales.into_ir(),
+            global: qparams.global.map(|global| global.into_ir()),
         };
         let desc = QuantizeOpIr::create(tensor.into_ir(), qparams, *scheme, || {
             client.create_empty_handle()

--- a/crates/burn-fusion/src/stream/context.rs
+++ b/crates/burn-fusion/src/stream/context.rs
@@ -812,6 +812,11 @@ impl RelativeOps for FloatOperationIr {
                 tensor: desc.tensor.to_relative(converter),
                 qparams: QuantizationParametersIr {
                     scales: desc.qparams.scales.to_relative(converter),
+                    global: desc
+                        .qparams
+                        .global
+                        .as_ref()
+                        .map(|global| global.to_relative(converter)),
                 },
                 scheme: desc.scheme,
                 out: desc.out.to_relative(converter),

--- a/crates/burn-fusion/src/stream/context.rs
+++ b/crates/burn-fusion/src/stream/context.rs
@@ -789,6 +789,11 @@ impl RelativeOps for FloatOperationIr {
                 tensor: desc.tensor.to_relative(converter),
                 qparams: QuantizationParametersIr {
                     scales: desc.qparams.scales.to_relative(converter),
+                    global: desc
+                        .qparams
+                        .global
+                        .as_ref()
+                        .map(|global| global.to_relative(converter)),
                 },
                 scheme: desc.scheme,
                 out: desc.out.to_relative(converter),

--- a/crates/burn-ir/src/builder.rs
+++ b/crates/burn-ir/src/builder.rs
@@ -10,7 +10,7 @@ use burn_backend::{
         },
         unfold::calculate_unfold_shape,
     },
-    quantization::{QuantLevel, QuantScheme, QuantStore},
+    quantization::{QuantScheme, QuantStore},
     tensor::IndexingUpdateOp,
 };
 
@@ -23,14 +23,7 @@ fn permute_quantized_dtype(dtype: DType, rank: usize, axes: &[usize]) -> DType {
         return dtype;
     };
 
-    if let QuantLevel::Block(block_size) = scheme.level {
-        let block_size = block_size.to_dim_vec(rank);
-        let block_size = axes
-            .iter()
-            .map(|axis| block_size[*axis])
-            .collect::<Vec<_>>();
-        scheme = scheme.with_level(QuantLevel::block(&block_size));
-    }
+    scheme.permute_block_dims(rank, axes);
 
     if let QuantStore::PackedU32(packed_dim) | QuantStore::PackedNative(packed_dim) =
         &mut scheme.store

--- a/crates/burn-ir/src/operation.rs
+++ b/crates/burn-ir/src/operation.rs
@@ -1524,8 +1524,11 @@ pub struct ConvTranspose3dOptionsIr {
 /// Quantization parameters intermediate representation.
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct QuantizationParametersIr {
-    /// The scaling factor.
+    /// The scaling factor, one per block or a single one for a per-tensor level.
     pub scales: TensorIr,
+    /// The per-tensor scale that [`scales`](Self::scales) are expressed relative to, for a
+    /// two-level scheme.
+    pub global: Option<TensorIr>,
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Serialize, Deserialize)]
@@ -3178,9 +3181,11 @@ impl FloatOperationIr {
             FloatOperationIr::Ceil(repr) => Box::new([&repr.input].into_iter()),
             FloatOperationIr::Trunc(repr) => Box::new([&repr.input].into_iter()),
             FloatOperationIr::IntoInt(repr) => Box::new([&repr.input].into_iter()),
-            FloatOperationIr::Quantize(repr) => {
-                Box::new([&repr.tensor, &repr.qparams.scales].into_iter())
-            }
+            FloatOperationIr::Quantize(repr) => Box::new(
+                [&repr.tensor, &repr.qparams.scales]
+                    .into_iter()
+                    .chain(repr.qparams.global.iter()),
+            ),
             FloatOperationIr::Dequantize(repr) => Box::new([&repr.input].into_iter()),
             FloatOperationIr::IsNan(repr) => Box::new([&repr.input].into_iter()),
             FloatOperationIr::IsInf(repr) => Box::new([&repr.input].into_iter()),
@@ -3299,6 +3304,9 @@ impl FloatOperationIr {
             FloatOperationIr::Quantize(repr) => {
                 repr.tensor.mark_read_only(nodes, &mut output);
                 repr.qparams.scales.mark_read_only(nodes, &mut output);
+                if let Some(global) = &mut repr.qparams.global {
+                    global.mark_read_only(nodes, &mut output);
+                }
             }
             FloatOperationIr::Dequantize(repr) => {
                 repr.input.mark_read_only(nodes, &mut output);
@@ -3421,6 +3429,9 @@ impl FloatOperationIr {
             FloatOperationIr::Quantize(repr) => {
                 v.visit_tensor_mut(&mut repr.tensor);
                 v.visit_tensor_mut(&mut repr.qparams.scales);
+                if let Some(global) = &mut repr.qparams.global {
+                    v.visit_tensor_mut(global);
+                }
                 v.visit_tensor_mut(&mut repr.out);
             }
             FloatOperationIr::Dequantize(repr) => {

--- a/crates/burn-ir/src/operation.rs
+++ b/crates/burn-ir/src/operation.rs
@@ -1500,8 +1500,11 @@ pub struct ConvTranspose3dOptionsIr {
 /// Quantization parameters intermediate representation.
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct QuantizationParametersIr {
-    /// The scaling factor.
+    /// The scaling factor, one per block or a single one for a per-tensor level.
     pub scales: TensorIr,
+    /// The per-tensor scale that [`scales`](Self::scales) are expressed relative to, for a
+    /// two-level scheme.
+    pub global: Option<TensorIr>,
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Serialize, Deserialize)]
@@ -3138,9 +3141,11 @@ impl FloatOperationIr {
             FloatOperationIr::Ceil(repr) => Box::new([&repr.input].into_iter()),
             FloatOperationIr::Trunc(repr) => Box::new([&repr.input].into_iter()),
             FloatOperationIr::IntoInt(repr) => Box::new([&repr.input].into_iter()),
-            FloatOperationIr::Quantize(repr) => {
-                Box::new([&repr.tensor, &repr.qparams.scales].into_iter())
-            }
+            FloatOperationIr::Quantize(repr) => Box::new(
+                [&repr.tensor, &repr.qparams.scales]
+                    .into_iter()
+                    .chain(repr.qparams.global.iter()),
+            ),
             FloatOperationIr::Dequantize(repr) => Box::new([&repr.input].into_iter()),
             FloatOperationIr::IsNan(repr) => Box::new([&repr.input].into_iter()),
             FloatOperationIr::IsInf(repr) => Box::new([&repr.input].into_iter()),
@@ -3259,6 +3264,9 @@ impl FloatOperationIr {
             FloatOperationIr::Quantize(repr) => {
                 repr.tensor.mark_read_only(nodes, &mut output);
                 repr.qparams.scales.mark_read_only(nodes, &mut output);
+                if let Some(global) = &mut repr.qparams.global {
+                    global.mark_read_only(nodes, &mut output);
+                }
             }
             FloatOperationIr::Dequantize(repr) => {
                 repr.input.mark_read_only(nodes, &mut output);
@@ -3381,6 +3389,9 @@ impl FloatOperationIr {
             FloatOperationIr::Quantize(repr) => {
                 v.visit_tensor_mut(&mut repr.tensor);
                 v.visit_tensor_mut(&mut repr.qparams.scales);
+                if let Some(global) = &mut repr.qparams.global {
+                    v.visit_tensor_mut(global);
+                }
                 v.visit_tensor_mut(&mut repr.out);
             }
             FloatOperationIr::Dequantize(repr) => {

--- a/crates/burn-ndarray/src/backend.rs
+++ b/crates/burn-ndarray/src/backend.rs
@@ -1,9 +1,7 @@
 use crate::rand::NdArrayRng;
 use crate::{NdArrayQTensor, NdArrayTensor};
 use alloc::string::String;
-use burn_backend::quantization::{
-    QuantMode, QuantScheme, QuantStore, QuantValue, levels_supported,
-};
+use burn_backend::quantization::{QuantMode, QuantScheme, QuantStore, QuantValue, quantizable};
 use burn_backend::tensor::{BoolTensor, FloatTensor, IntTensor, QuantizedTensor};
 use burn_backend::{Backend, BackendTypes, DType, DeviceId, DeviceOps};
 use burn_ir::{BackendIr, HandleKind, TensorHandle};
@@ -116,7 +114,7 @@ impl Backend for NdArray {
                         store: QuantStore::Native,
                         ..
                     // The value and store alone do not say which levels `quantize` will accept.
-                    } if levels_supported(&scheme) => burn_backend::DTypeUsage::general(),
+                    } if quantizable(&scheme) => burn_backend::DTypeUsage::general(),
                     _scheme => burn_backend::DTypeUsageSet::empty(),
                 }
             }

--- a/crates/burn-ndarray/src/backend.rs
+++ b/crates/burn-ndarray/src/backend.rs
@@ -1,7 +1,9 @@
 use crate::rand::NdArrayRng;
 use crate::{NdArrayQTensor, NdArrayTensor};
 use alloc::string::String;
-use burn_backend::quantization::{QuantLevel, QuantMode, QuantScheme, QuantStore, QuantValue};
+use burn_backend::quantization::{
+    QuantMode, QuantScheme, QuantStore, QuantValue, levels_supported,
+};
 use burn_backend::tensor::{BoolTensor, FloatTensor, IntTensor, QuantizedTensor};
 use burn_backend::{Backend, BackendTypes, DType, DeviceId, DeviceOps};
 use burn_ir::{BackendIr, HandleKind, TensorHandle};
@@ -98,7 +100,6 @@ impl Backend for NdArray {
             DType::QFloat(scheme) => {
                 match scheme {
                     QuantScheme {
-                        level: QuantLevel::Tensor | QuantLevel::Block(_),
                         mode: QuantMode::Symmetric,
                         #[cfg(not(feature = "export_tests"))]
                             value: QuantValue::Q8F | QuantValue::Q8S,
@@ -114,7 +115,8 @@ impl Backend for NdArray {
                             | QuantValue::Q2S,
                         store: QuantStore::Native,
                         ..
-                    } => burn_backend::DTypeUsage::general(),
+                    // The value and store alone do not say which levels `quantize` will accept.
+                    } if levels_supported(&scheme) => burn_backend::DTypeUsage::general(),
                     _scheme => burn_backend::DTypeUsageSet::empty(),
                 }
             }
@@ -206,6 +208,39 @@ mod tests {
         assert!(!B::supports_dtype(
             &device,
             DType::QFloat(QuantScheme::default())
+        ));
+    }
+
+    /// A scheme this claims and then panics on is worse than one it declines, because the panic
+    /// lands on the first tensor rather than where the scheme was chosen.
+    #[test]
+    fn should_support_the_two_level_schemes_it_can_quantize() {
+        use burn_backend::ops::{FloatTensorOps, QTensorOps};
+        use burn_std::{ScaleDtype, TensorData};
+
+        type B = NdArray;
+        let device = NdArrayDevice::Cpu;
+        let scheme = device
+            .defaults()
+            .quantization
+            .scheme
+            .with_value(QuantValue::Q8S)
+            .per_block([4], ScaleDtype::UE4M3)
+            .per_tensor(ScaleDtype::F32);
+
+        assert!(B::supports_dtype(&device, DType::QFloat(scheme)));
+
+        let tensor = B::float_from_data(
+            TensorData::from([0.1f32, -0.4, 0.2, 0.9, -1.5, 0.3, 0.05, -0.02]),
+            &device,
+        );
+        let quantized = B::quantize_dynamic(tensor, &scheme);
+        assert_eq!(quantized.scheme.num_levels(), 2);
+
+        // Block scales already spanning f32's range are rejected by `quantize`.
+        assert!(!B::supports_dtype(
+            &device,
+            DType::QFloat(scheme.per_block([4], ScaleDtype::F32))
         ));
     }
 }

--- a/crates/burn-ndarray/src/ops/qtensor.rs
+++ b/crates/burn-ndarray/src/ops/qtensor.rs
@@ -6,7 +6,7 @@ use burn_backend::{
     quantization::{
         BlockSize, QuantMode, QuantPropagation, QuantScheme, QuantStore, QuantValue,
         QuantizationParametersPrimitive, QuantizedBytes, global_scale_dtype, params_shape,
-        scale_to_dtype, validate_levels,
+        scale_to_dtype,
     },
     tensor::{FloatTensor, IntTensor, QuantizedTensor},
 };
@@ -26,7 +26,6 @@ impl QTensorOps<Self> for NdArray {
     fn q_from_data(data: TensorData, _device: &NdArrayDevice) -> QuantizedTensor<Self> {
         match data.dtype {
             DType::QFloat(scheme) => {
-                validate_levels(&scheme);
                 let shape = data.shape.clone();
                 let num_elements = data.num_elements();
                 let q_bytes = QuantizedBytes {
@@ -82,7 +81,6 @@ impl QTensorOps<Self> for NdArray {
         scheme: &QuantScheme,
         qparams: QuantizationParametersPrimitive<Self>,
     ) -> QuantizedTensor<Self> {
-        validate_levels(scheme);
         let shape = tensor.shape();
         let data_f = tensor.into_data();
         let scales = qparams.scales.into_data().convert::<f32>();

--- a/crates/burn-ndarray/src/ops/qtensor.rs
+++ b/crates/burn-ndarray/src/ops/qtensor.rs
@@ -19,7 +19,7 @@ use crate::{
     execute_with_numeric_dtype, slice,
 };
 
-use super::quantization::{Quantization, QuantizationStrategy, SymmetricQuantization};
+use super::quantization::{QuantizationStrategy, SymmetricQuantization};
 use super::{NdArrayMathOps, NdArrayOps};
 
 impl QTensorOps<Self> for NdArray {
@@ -27,11 +27,10 @@ impl QTensorOps<Self> for NdArray {
         match data.dtype {
             DType::QFloat(scheme) => {
                 let shape = data.shape.clone();
-                let num_elements = data.num_elements();
                 let q_bytes = QuantizedBytes {
+                    shape: shape.clone(),
                     bytes: data.into_bytes(),
                     scheme,
-                    num_elements,
                 };
 
                 match scheme {
@@ -125,7 +124,7 @@ impl QTensorOps<Self> for NdArray {
                 let strategy = QuantizationStrategy::PerTensorSymmetric(
                     SymmetricQuantization::init(scales, scheme.value),
                 );
-                let values = strategy.quantize(data_f.as_slice().unwrap());
+                let values = strategy.quantize(data_f.as_slice().unwrap(), &shape);
                 (
                     TensorData::quantized(values, shape.clone(), *scheme, &[scales], None),
                     vec![scales],
@@ -166,11 +165,10 @@ impl QTensorOps<Self> for NdArray {
             (_, scheme) => unimplemented!("Quantization not supported for scheme {scheme:?}"),
         };
 
-        let num_elements = data.num_elements();
         let q_bytes = QuantizedBytes {
+            shape: data.shape.clone(),
             bytes: data.into_bytes(),
             scheme: *scheme,
-            num_elements,
         };
         let (values, _) = q_bytes.into_vec_i8();
         let data = TensorData::new(values, shape);
@@ -529,7 +527,7 @@ fn quantize_per_block(
         .map(|&s| (SymmetricQuantization::init(multiplier * s, scheme.value), s))
         .unzip();
     let strategy = QuantizationStrategy::PerBlockSymmetric(strategy, block);
-    let values = strategy.quantize(data_f);
+    let values = strategy.quantize(data_f, &shape);
     (
         TensorData::quantized(values, shape, *scheme, scales, global),
         qparams,
@@ -545,33 +543,8 @@ fn dequantize<Q: QuantElement>(
     global: Option<f32>,
     dtype: DType,
 ) -> TensorData {
-    let q_bytes = QuantizedBytes::new(data, scheme, qparams, global);
+    let q_bytes = QuantizedBytes::new(data, shape.clone(), scheme, qparams, global);
     let (values, _qparams) = q_bytes.into_vec_i8();
-    let values = match strategy {
-        QuantizationStrategy::PerTensorSymmetric(quant) => quant.dequantize(&values),
-        QuantizationStrategy::PerBlockSymmetric(quant, block_size) => {
-            let block_size = block_size.to_dim_vec(shape.num_dims());
-            let qparams_shape = params_shape(&shape, &scheme);
-
-            values
-                .into_iter()
-                .enumerate()
-                .map(|(index, value)| {
-                    let mut index = index;
-                    let mut qparam_index = 0;
-                    let mut qparam_stride = 1;
-
-                    for dim in (0..shape.num_dims()).rev() {
-                        let coordinate = index % shape[dim];
-                        index /= shape[dim];
-                        qparam_index += coordinate / block_size[dim] as usize * qparam_stride;
-                        qparam_stride *= qparams_shape[dim];
-                    }
-
-                    quant[qparam_index].dequantize_one(value)
-                })
-                .collect()
-        }
-    };
+    let values = strategy.dequantize(&values, &shape);
     TensorData::new(values, shape).convert_dtype(dtype)
 }

--- a/crates/burn-ndarray/src/ops/qtensor.rs
+++ b/crates/burn-ndarray/src/ops/qtensor.rs
@@ -4,8 +4,9 @@ use burn_backend::{
     DType, ExecutionError, Shape, TensorData, TensorMetadata, TensorPrimitive, get_device_settings,
     ops::{FloatTensorOps, QTensorOps},
     quantization::{
-        QParams, QuantLevel, QuantMode, QuantPropagation, QuantScheme, QuantStore, QuantValue,
-        QuantizationParametersPrimitive, QuantizedBytes, params_shape, scale_to_param,
+        BlockSize, QuantMode, QuantPropagation, QuantScheme, QuantStore, QuantValue,
+        QuantizationParametersPrimitive, QuantizedBytes, global_scale_dtype, params_shape,
+        scale_to_dtype, validate_levels,
     },
     tensor::{FloatTensor, IntTensor, QuantizedTensor},
 };
@@ -25,6 +26,7 @@ impl QTensorOps<Self> for NdArray {
     fn q_from_data(data: TensorData, _device: &NdArrayDevice) -> QuantizedTensor<Self> {
         match data.dtype {
             DType::QFloat(scheme) => {
+                validate_levels(&scheme);
                 let shape = data.shape.clone();
                 let num_elements = data.num_elements();
                 let q_bytes = QuantizedBytes {
@@ -35,7 +37,6 @@ impl QTensorOps<Self> for NdArray {
 
                 match scheme {
                     QuantScheme {
-                        level: QuantLevel::Tensor | QuantLevel::Block(_),
                         mode: QuantMode::Symmetric,
                         value: QuantValue::Q8F | QuantValue::Q8S,
                         ..
@@ -46,16 +47,14 @@ impl QTensorOps<Self> for NdArray {
                         // Overwrite storage
                         let scheme = scheme.with_store(QuantStore::Native);
 
-                        let qparams = qparams
-                            .scales
-                            .into_iter()
-                            .map(|scales| QParams { scales })
-                            .collect();
+                        let global = qparams.global;
+                        let qparams = qparams.block;
 
                         NdArrayQTensor {
                             qtensor: NdArrayTensor::from_data(data),
                             scheme,
                             qparams,
+                            global,
                         }
                     }
                     QuantScheme {
@@ -69,10 +68,6 @@ impl QTensorOps<Self> for NdArray {
                             | QuantValue::E5M2,
                         ..
                     } => unimplemented!("from_data not supported for scheme {scheme:?}"),
-                    QuantScheme {
-                        level: QuantLevel::BlockTensor { .. },
-                        ..
-                    } => unimplemented!("two-level quantization is not supported yet"),
                 }
             }
             _ => panic!(
@@ -87,82 +82,90 @@ impl QTensorOps<Self> for NdArray {
         scheme: &QuantScheme,
         qparams: QuantizationParametersPrimitive<Self>,
     ) -> QuantizedTensor<Self> {
+        validate_levels(scheme);
         let shape = tensor.shape();
         let data_f = tensor.into_data();
         let scales = qparams.scales.into_data().convert::<f32>();
         // Quantize against the scale that will actually be stored, so a save/load round trip
-        // reproduces these values instead of drifting by the param's rounding error.
+        // reproduces these values instead of drifting by the scale dtype's rounding error.
         let scales: Vec<f32> = scales
             .iter::<f32>()
-            .map(|s| scale_to_param(s, scheme.param))
+            .map(|s| scale_to_dtype(s, scheme.scale_dtype()))
             .collect();
+        let global = qparams.global.map(|global| {
+            let dtype = global_scale_dtype(scheme)
+                .expect("a per-tensor scale should come with a two-level scheme");
+            let global = global.into_data().convert::<f32>();
+            scale_to_dtype(global.iter::<f32>().next().unwrap(), dtype)
+        });
 
         // Implement with ndarray instead of QuantizationStrategy?
-        let (data, qparams) = match scheme {
-            QuantScheme {
-                level: QuantLevel::Tensor,
-                mode: QuantMode::Symmetric,
-                // `Q2S` is supported natively (stored as i8) — it feeds the multiply-free
-                // ternary matmul fast path in `q_matmul` (BitNet b1.58).
-                #[cfg(not(feature = "export_tests"))]
-                    value: QuantValue::Q8F | QuantValue::Q8S | QuantValue::Q2S,
-                // For tests, "native" sub-byte quant serves as a reference for value equality.
-                // Values are stored as i8 regardless.
-                #[cfg(feature = "export_tests")]
-                    value:
-                    QuantValue::Q8F
-                    | QuantValue::Q8S
-                    | QuantValue::Q4F
-                    | QuantValue::Q4S
-                    | QuantValue::Q2F
-                    | QuantValue::Q2S,
-                store: QuantStore::Native,
-                ..
-            } => {
+        let (data, qparams) = match (scheme.block_size(), scheme) {
+            (
+                None,
+                QuantScheme {
+                    mode: QuantMode::Symmetric,
+                    // `Q2S` is supported natively (stored as i8): it feeds the multiply-free
+                    // ternary matmul fast path in `q_matmul` (BitNet b1.58).
+                    #[cfg(not(feature = "export_tests"))]
+                        value: QuantValue::Q8F | QuantValue::Q8S | QuantValue::Q2S,
+                    // For tests, "native" sub-byte quant serves as a reference for value equality.
+                    // Values are stored as i8 regardless.
+                    #[cfg(feature = "export_tests")]
+                        value:
+                        QuantValue::Q8F
+                        | QuantValue::Q8S
+                        | QuantValue::Q4F
+                        | QuantValue::Q4S
+                        | QuantValue::Q2F
+                        | QuantValue::Q2S,
+                    store: QuantStore::Native,
+                    ..
+                },
+            ) => {
                 let scales = scales[0];
                 let strategy = QuantizationStrategy::PerTensorSymmetric(
                     SymmetricQuantization::init(scales, scheme.value),
                 );
                 let values = strategy.quantize(data_f.as_slice().unwrap());
                 (
-                    TensorData::quantized(values, shape.clone(), *scheme, &[scales]),
-                    vec![QParams { scales }],
+                    TensorData::quantized(values, shape.clone(), *scheme, &[scales], None),
+                    vec![scales],
                 )
             }
-            QuantScheme {
-                level: QuantLevel::Block(block_size),
-                mode: QuantMode::Symmetric,
-                #[cfg(not(feature = "export_tests"))]
-                    value: QuantValue::Q8F | QuantValue::Q8S,
-                #[cfg(feature = "export_tests")]
-                    value:
-                    QuantValue::Q8F
-                    | QuantValue::Q8S
-                    | QuantValue::Q4F
-                    | QuantValue::Q4S
-                    | QuantValue::Q2F
-                    | QuantValue::Q2S,
-                store: QuantStore::Native,
-                ..
-            } => {
-                let scales = scales.as_slice();
-                let (strategy, qparams) = scales
-                    .iter()
-                    .map(|&s| {
-                        (
-                            SymmetricQuantization::init(s, scheme.value),
-                            QParams { scales: s },
-                        )
-                    })
-                    .unzip();
-                let strategy = QuantizationStrategy::PerBlockSymmetric(strategy, *block_size);
-                let values = strategy.quantize(data_f.as_slice().unwrap());
-                (
-                    TensorData::quantized(values, shape.clone(), *scheme, scales),
-                    qparams,
+            (
+                Some(block_size),
+                QuantScheme {
+                    mode: QuantMode::Symmetric,
+                    #[cfg(not(feature = "export_tests"))]
+                        value: QuantValue::Q8F | QuantValue::Q8S,
+                    #[cfg(feature = "export_tests")]
+                        value:
+                        QuantValue::Q8F
+                        | QuantValue::Q8S
+                        | QuantValue::Q4F
+                        | QuantValue::Q4S
+                        | QuantValue::Q2F
+                        | QuantValue::Q2S,
+                    store: QuantStore::Native,
+                    ..
+                },
+            ) => {
+                let global = if global_scale_dtype(scheme).is_some() {
+                    Some(global.expect("a two-level scheme should have a per-tensor scale"))
+                } else {
+                    None
+                };
+                quantize_per_block(
+                    data_f.as_slice().unwrap(),
+                    shape.clone(),
+                    scheme,
+                    block_size,
+                    scales.as_slice(),
+                    global,
                 )
             }
-            scheme => unimplemented!("Quantization not supported for scheme {scheme:?}"),
+            (_, scheme) => unimplemented!("Quantization not supported for scheme {scheme:?}"),
         };
 
         let num_elements = data.num_elements();
@@ -178,6 +181,7 @@ impl QTensorOps<Self> for NdArray {
             qtensor: NdArrayTensor::from_data(data),
             scheme: *scheme,
             qparams,
+            global,
         }
     }
 
@@ -185,10 +189,20 @@ impl QTensorOps<Self> for NdArray {
         let strategy = tensor.strategy();
         let scheme = tensor.scheme;
         let shape = tensor.shape();
+        let scales = tensor.qparams;
+        let global = tensor.global;
         let data = match tensor.qtensor {
             NdArrayTensor::I8(storage) => {
                 let data = storage.into_shared().into_iter().collect();
-                dequantize(data, shape, scheme, &strategy, dtype.into())
+                dequantize(
+                    data,
+                    shape,
+                    scheme,
+                    &strategy,
+                    &scales,
+                    global,
+                    dtype.into(),
+                )
             }
             _ => unreachable!(),
         };
@@ -266,18 +280,19 @@ impl QTensorOps<Self> for NdArray {
             }),
             scheme: tensor.scheme,
             qparams: tensor.qparams,
+            global: tensor.global,
         }
     }
 
     async fn q_into_data(tensor: QuantizedTensor<Self>) -> Result<TensorData, ExecutionError> {
         let shape = tensor.qtensor.shape();
-        let scales = tensor.qparams.iter().map(|q| q.scales).collect::<Vec<_>>();
+        let scales = tensor.qparams;
         Ok(execute_with_numeric_dtype!(
             tensor.qtensor,
             E,
             |array: SharedArray<E>| {
                 let values = array.into_iter().collect();
-                TensorData::quantized(values, shape, tensor.scheme, &scales)
+                TensorData::quantized(values, shape, tensor.scheme, &scales, tensor.global)
             }
         ))
     }
@@ -293,38 +308,20 @@ impl QTensorOps<Self> for NdArray {
     }
 
     fn q_permute(tensor: QuantizedTensor<Self>, axes: &[usize]) -> QuantizedTensor<Self> {
-        let (scheme, qparams) = match tensor.scheme.level {
-            QuantLevel::Tensor => (tensor.scheme, tensor.qparams),
-            QuantLevel::Block(block_size) => {
+        let (scheme, qparams) = match tensor.scheme.block_size() {
+            None => (tensor.scheme, tensor.qparams),
+            Some(_) => {
                 let shape = tensor.qtensor.shape();
-                let qparams_shape = params_shape(&shape, tensor.scheme.level);
-                let scales = tensor
-                    .qparams
-                    .into_iter()
-                    .map(|params| params.scales)
-                    .collect();
-                let scales = ArrayD::from_shape_vec(qparams_shape.as_slice(), scales)
+                let qparams_shape = params_shape(&shape, &tensor.scheme);
+                let scales = ArrayD::from_shape_vec(qparams_shape.as_slice(), tensor.qparams)
                     .unwrap()
                     .into_shared();
-                let scales = NdArrayOps::permute(scales, axes);
-                let qparams = scales
-                    .into_iter()
-                    .map(|scales| QParams { scales })
-                    .collect();
+                let qparams = NdArrayOps::permute(scales, axes).into_iter().collect();
 
-                let block_size = block_size.to_dim_vec(shape.num_dims());
-                let block_size = axes
-                    .iter()
-                    .map(|axis| block_size[*axis])
-                    .collect::<Vec<_>>();
-                let scheme = tensor
-                    .scheme
-                    .with_level(QuantLevel::block(block_size.as_slice()));
+                let mut scheme = tensor.scheme;
+                scheme.permute_block_dims(shape.num_dims(), axes);
 
                 (scheme, qparams)
-            }
-            QuantLevel::BlockTensor { .. } => {
-                unimplemented!("two-level quantization is not supported yet")
             }
         };
 
@@ -334,6 +331,7 @@ impl QTensorOps<Self> for NdArray {
             }),
             scheme,
             qparams,
+            global: tensor.global,
         }
     }
 
@@ -344,6 +342,7 @@ impl QTensorOps<Self> for NdArray {
             }),
             scheme: tensor.scheme,
             qparams: tensor.qparams,
+            global: tensor.global,
         }
     }
 
@@ -364,6 +363,7 @@ impl QTensorOps<Self> for NdArray {
             qtensor,
             scheme: tensor.scheme,
             qparams: tensor.qparams,
+            global: tensor.global,
         }
     }
 
@@ -384,6 +384,7 @@ impl QTensorOps<Self> for NdArray {
             qtensor,
             scheme: tensor.scheme,
             qparams: tensor.qparams,
+            global: tensor.global,
         }
     }
 
@@ -395,6 +396,7 @@ impl QTensorOps<Self> for NdArray {
             qtensor: slice!(tensor.qtensor, slices),
             scheme: tensor.scheme,
             qparams: tensor.qparams,
+            global: tensor.global,
         }
     }
 
@@ -421,6 +423,7 @@ impl QTensorOps<Self> for NdArray {
             }),
             scheme: tensor.scheme,
             qparams: tensor.qparams,
+            global: tensor.global,
         }
     }
 }
@@ -441,15 +444,16 @@ fn ternary_matmul(
     rhs: &NdArrayQTensor,
 ) -> Option<FloatTensor<NdArray>> {
     // Canonical BitNet b1.58 weight quantization: Q2S, symmetric, per-tensor.
-    if !matches!(
-        rhs.scheme,
-        QuantScheme {
-            value: QuantValue::Q2S,
-            mode: QuantMode::Symmetric,
-            level: QuantLevel::Tensor,
-            ..
-        }
-    ) {
+    if rhs.scheme.block_size().is_some()
+        || !matches!(
+            rhs.scheme,
+            QuantScheme {
+                value: QuantValue::Q2S,
+                mode: QuantMode::Symmetric,
+                ..
+            }
+        )
+    {
         return None;
     }
     // Only an f32 activation (the reference float dtype) takes the fast path.
@@ -472,7 +476,7 @@ fn ternary_matmul(
     let m: usize = ldims[..ldims.len() - 1].iter().product();
 
     // Per-tensor scale γ.
-    let gamma = rhs.qparams.first()?.scales;
+    let gamma = *rhs.qparams.first()?;
 
     // Canonical row-major values for both operands (`into_data` normalizes any strided layout).
     let a_data = lhs.clone().into_data();
@@ -512,26 +516,44 @@ fn ternary_matmul(
     )))
 }
 
+/// `global: None` is a one-level block scheme (multiplier 1.0).
+fn quantize_per_block(
+    data_f: &[f32],
+    shape: Shape,
+    scheme: &QuantScheme,
+    block: BlockSize,
+    scales: &[f32],
+    global: Option<f32>,
+) -> (TensorData, Vec<f32>) {
+    let multiplier = global.unwrap_or(1.0);
+    let (strategy, qparams): (Vec<_>, Vec<_>) = scales
+        .iter()
+        .map(|&s| (SymmetricQuantization::init(multiplier * s, scheme.value), s))
+        .unzip();
+    let strategy = QuantizationStrategy::PerBlockSymmetric(strategy, block);
+    let values = strategy.quantize(data_f);
+    (
+        TensorData::quantized(values, shape, *scheme, scales, global),
+        qparams,
+    )
+}
+
 fn dequantize<Q: QuantElement>(
     data: Vec<Q>,
     shape: Shape,
     scheme: QuantScheme,
     strategy: &QuantizationStrategy,
+    qparams: &[f32],
+    global: Option<f32>,
     dtype: DType,
 ) -> TensorData {
-    let qparams = match strategy {
-        QuantizationStrategy::PerTensorSymmetric(quant) => vec![quant.scale],
-        QuantizationStrategy::PerBlockSymmetric(quant, _block_size) => {
-            quant.iter().map(|q| q.scale).collect()
-        }
-    };
-    let q_bytes = QuantizedBytes::new(data, scheme, &qparams);
+    let q_bytes = QuantizedBytes::new(data, scheme, qparams, global);
     let (values, _qparams) = q_bytes.into_vec_i8();
     let values = match strategy {
         QuantizationStrategy::PerTensorSymmetric(quant) => quant.dequantize(&values),
         QuantizationStrategy::PerBlockSymmetric(quant, block_size) => {
             let block_size = block_size.to_dim_vec(shape.num_dims());
-            let qparams_shape = params_shape(&shape, scheme.level);
+            let qparams_shape = params_shape(&shape, &scheme);
 
             values
                 .into_iter()

--- a/crates/burn-ndarray/src/ops/qtensor.rs
+++ b/crates/burn-ndarray/src/ops/qtensor.rs
@@ -34,6 +34,10 @@ impl QTensorOps<Self> for NdArray {
 
                 match scheme {
                     QuantScheme {
+                        level: QuantLevel::BlockTensor { .. },
+                        ..
+                    } => unimplemented!("two-level quantization is not supported on ndarray yet"),
+                    QuantScheme {
                         level: QuantLevel::Tensor | QuantLevel::Block(_),
                         mode: QuantMode::Symmetric,
                         value: QuantValue::Q8F | QuantValue::Q8S,
@@ -46,7 +50,7 @@ impl QTensorOps<Self> for NdArray {
                         let scheme = scheme.with_store(QuantStore::Native);
 
                         let qparams = qparams
-                            .scales
+                            .block
                             .into_iter()
                             .map(|scales| QParams { scales })
                             .collect();
@@ -120,7 +124,7 @@ impl QTensorOps<Self> for NdArray {
                 );
                 let values = strategy.quantize(data_f.as_slice().unwrap());
                 (
-                    TensorData::quantized(values, shape.clone(), *scheme, &[scales]),
+                    TensorData::quantized(values, shape.clone(), *scheme, &[scales], None),
                     vec![QParams { scales }],
                 )
             }
@@ -153,7 +157,7 @@ impl QTensorOps<Self> for NdArray {
                 let strategy = QuantizationStrategy::PerBlockSymmetric(strategy, *block_size);
                 let values = strategy.quantize(data_f.as_slice().unwrap());
                 (
-                    TensorData::quantized(values, shape.clone(), *scheme, scales),
+                    TensorData::quantized(values, shape.clone(), *scheme, scales, None),
                     qparams,
                 )
             }
@@ -272,7 +276,7 @@ impl QTensorOps<Self> for NdArray {
             E,
             |array: SharedArray<E>| {
                 let values = array.into_iter().collect();
-                TensorData::quantized(values, shape, tensor.scheme, &scales)
+                TensorData::quantized(values, shape, tensor.scheme, &scales, None)
             }
         ))
     }
@@ -489,7 +493,7 @@ fn dequantize<Q: QuantElement>(
             quant.iter().map(|q| q.scale).collect()
         }
     };
-    let q_bytes = QuantizedBytes::new(data, scheme, &qparams);
+    let q_bytes = QuantizedBytes::new(data, scheme, &qparams, None);
     let (values, _qparams) = q_bytes.into_vec_i8();
     TensorData::new(strategy.dequantize(&values), shape).convert_dtype(dtype)
 }

--- a/crates/burn-ndarray/src/ops/qtensor.rs
+++ b/crates/burn-ndarray/src/ops/qtensor.rs
@@ -5,7 +5,7 @@ use burn_backend::{
     ops::{FloatTensorOps, QTensorOps},
     quantization::{
         QParams, QuantLevel, QuantMode, QuantPropagation, QuantScheme, QuantStore, QuantValue,
-        QuantizationParametersPrimitive, QuantizedBytes, scale_to_param,
+        QuantizationParametersPrimitive, QuantizedBytes, scale_to_param, validate_levels,
     },
     tensor::{FloatTensor, IntTensor, QuantizedTensor},
 };
@@ -24,6 +24,7 @@ impl QTensorOps<Self> for NdArray {
     fn q_from_data(data: TensorData, _device: &NdArrayDevice) -> QuantizedTensor<Self> {
         match data.dtype {
             DType::QFloat(scheme) => {
+                validate_levels(&scheme);
                 let shape = data.shape.clone();
                 let num_elements = data.num_elements();
                 let q_bytes = QuantizedBytes {
@@ -85,6 +86,7 @@ impl QTensorOps<Self> for NdArray {
         scheme: &QuantScheme,
         qparams: QuantizationParametersPrimitive<Self>,
     ) -> QuantizedTensor<Self> {
+        validate_levels(scheme);
         let shape = tensor.shape();
         let data_f = tensor.into_data();
         let scales = qparams.scales.into_data().convert::<f32>();

--- a/crates/burn-ndarray/src/ops/qtensor.rs
+++ b/crates/burn-ndarray/src/ops/qtensor.rs
@@ -231,7 +231,15 @@ impl QTensorOps<Self> for NdArray {
         let data = match tensor.qtensor {
             NdArrayTensor::I8(storage) => {
                 let data = storage.into_shared().into_iter().collect();
-                dequantize(data, shape, scheme, &strategy, &scales, global, dtype.into())
+                dequantize(
+                    data,
+                    shape,
+                    scheme,
+                    &strategy,
+                    &scales,
+                    global,
+                    dtype.into(),
+                )
             }
             _ => unreachable!(),
         };

--- a/crates/burn-ndarray/src/ops/qtensor.rs
+++ b/crates/burn-ndarray/src/ops/qtensor.rs
@@ -34,11 +34,8 @@ impl QTensorOps<Self> for NdArray {
 
                 match scheme {
                     QuantScheme {
-                        level: QuantLevel::BlockTensor { .. },
-                        ..
-                    } => unimplemented!("two-level quantization is not supported on ndarray yet"),
-                    QuantScheme {
-                        level: QuantLevel::Tensor | QuantLevel::Block(_),
+                        level:
+                            QuantLevel::Tensor | QuantLevel::Block(_) | QuantLevel::BlockTensor { .. },
                         mode: QuantMode::Symmetric,
                         value: QuantValue::Q8F | QuantValue::Q8S,
                         ..
@@ -49,6 +46,7 @@ impl QTensorOps<Self> for NdArray {
                         // Overwrite storage
                         let scheme = scheme.with_store(QuantStore::Native);
 
+                        let global = qparams.global;
                         let qparams = qparams
                             .block
                             .into_iter()
@@ -59,6 +57,7 @@ impl QTensorOps<Self> for NdArray {
                             qtensor: NdArrayTensor::from_data(data),
                             scheme,
                             qparams,
+                            global,
                         }
                     }
                     QuantScheme {
@@ -95,6 +94,14 @@ impl QTensorOps<Self> for NdArray {
             .iter::<f32>()
             .map(|s| scale_to_param(s, scheme.param))
             .collect();
+        let global = qparams.global.map(|global| {
+            let param = scheme
+                .level
+                .global_param()
+                .expect("a per-tensor scale should come with a two-level scheme");
+            let global = global.into_data().convert::<f32>();
+            scale_to_param(global.iter::<f32>().next().unwrap(), param)
+        });
 
         // Implement with ndarray instead of QuantizationStrategy?
         let (data, qparams) = match scheme {
@@ -161,6 +168,40 @@ impl QTensorOps<Self> for NdArray {
                     qparams,
                 )
             }
+            QuantScheme {
+                level: QuantLevel::BlockTensor { block, .. },
+                mode: QuantMode::Symmetric,
+                #[cfg(not(feature = "export_tests"))]
+                    value: QuantValue::Q8F | QuantValue::Q8S,
+                #[cfg(feature = "export_tests")]
+                    value:
+                    QuantValue::Q8F
+                    | QuantValue::Q8S
+                    | QuantValue::Q4F
+                    | QuantValue::Q4S
+                    | QuantValue::Q2F
+                    | QuantValue::Q2S,
+                store: QuantStore::Native,
+                ..
+            } => {
+                let global = global.expect("a two-level scheme should have a per-tensor scale");
+                let scales = scales.as_slice();
+                let (strategy, qparams) = scales
+                    .iter()
+                    .map(|&s| {
+                        (
+                            SymmetricQuantization::init(global * s, scheme.value),
+                            QParams { scales: s },
+                        )
+                    })
+                    .unzip();
+                let strategy = QuantizationStrategy::PerBlockSymmetric(strategy, *block);
+                let values = strategy.quantize(data_f.as_slice().unwrap());
+                (
+                    TensorData::quantized(values, shape.clone(), *scheme, scales, Some(global)),
+                    qparams,
+                )
+            }
             scheme => unimplemented!("Quantization not supported for scheme {scheme:?}"),
         };
 
@@ -177,6 +218,7 @@ impl QTensorOps<Self> for NdArray {
             qtensor: NdArrayTensor::from_data(data),
             scheme: *scheme,
             qparams,
+            global,
         }
     }
 
@@ -184,10 +226,12 @@ impl QTensorOps<Self> for NdArray {
         let strategy = tensor.strategy();
         let scheme = tensor.scheme;
         let shape = tensor.shape();
+        let scales = tensor.qparams.iter().map(|q| q.scales).collect::<Vec<_>>();
+        let global = tensor.global;
         let data = match tensor.qtensor {
             NdArrayTensor::I8(storage) => {
                 let data = storage.into_shared().into_iter().collect();
-                dequantize(data, shape, scheme, &strategy, dtype.into())
+                dequantize(data, shape, scheme, &strategy, &scales, global, dtype.into())
             }
             _ => unreachable!(),
         };
@@ -265,6 +309,7 @@ impl QTensorOps<Self> for NdArray {
             }),
             scheme: tensor.scheme,
             qparams: tensor.qparams,
+            global: tensor.global,
         }
     }
 
@@ -276,7 +321,7 @@ impl QTensorOps<Self> for NdArray {
             E,
             |array: SharedArray<E>| {
                 let values = array.into_iter().collect();
-                TensorData::quantized(values, shape, tensor.scheme, &scales, None)
+                TensorData::quantized(values, shape, tensor.scheme, &scales, tensor.global)
             }
         ))
     }
@@ -292,6 +337,7 @@ impl QTensorOps<Self> for NdArray {
             }),
             scheme: tensor.scheme,
             qparams: tensor.qparams,
+            global: tensor.global,
         }
     }
 
@@ -302,6 +348,7 @@ impl QTensorOps<Self> for NdArray {
             }),
             scheme: tensor.scheme,
             qparams: tensor.qparams,
+            global: tensor.global,
         }
     }
 
@@ -312,6 +359,7 @@ impl QTensorOps<Self> for NdArray {
             }),
             scheme: tensor.scheme,
             qparams: tensor.qparams,
+            global: tensor.global,
         }
     }
 
@@ -332,6 +380,7 @@ impl QTensorOps<Self> for NdArray {
             qtensor,
             scheme: tensor.scheme,
             qparams: tensor.qparams,
+            global: tensor.global,
         }
     }
 
@@ -352,6 +401,7 @@ impl QTensorOps<Self> for NdArray {
             qtensor,
             scheme: tensor.scheme,
             qparams: tensor.qparams,
+            global: tensor.global,
         }
     }
 
@@ -363,6 +413,7 @@ impl QTensorOps<Self> for NdArray {
             qtensor: slice!(tensor.qtensor, slices),
             scheme: tensor.scheme,
             qparams: tensor.qparams,
+            global: tensor.global,
         }
     }
 
@@ -389,6 +440,7 @@ impl QTensorOps<Self> for NdArray {
             }),
             scheme: tensor.scheme,
             qparams: tensor.qparams,
+            global: tensor.global,
         }
     }
 }
@@ -485,15 +537,11 @@ fn dequantize<Q: QuantElement>(
     shape: Shape,
     scheme: QuantScheme,
     strategy: &QuantizationStrategy,
+    qparams: &[f32],
+    global: Option<f32>,
     dtype: DType,
 ) -> TensorData {
-    let qparams = match strategy {
-        QuantizationStrategy::PerTensorSymmetric(quant) => vec![quant.scale],
-        QuantizationStrategy::PerBlockSymmetric(quant, _block_size) => {
-            quant.iter().map(|q| q.scale).collect()
-        }
-    };
-    let q_bytes = QuantizedBytes::new(data, scheme, &qparams, None);
+    let q_bytes = QuantizedBytes::new(data, scheme, qparams, global);
     let (values, _qparams) = q_bytes.into_vec_i8();
     TensorData::new(strategy.dequantize(&values), shape).convert_dtype(dtype)
 }

--- a/crates/burn-ndarray/src/ops/quantization.rs
+++ b/crates/burn-ndarray/src/ops/quantization.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 use num_traits::{Float, PrimInt};
 
 use burn_backend::Shape;
-use burn_backend::quantization::{BlockGrid, BlockSize, QuantValue};
+use burn_backend::quantization::{BlockLayout, BlockSize, QuantValue};
 
 // NOTE: this mainly serves as a simple reference implementation.
 // The de/quantization ops should be refactored to use ndarray.
@@ -22,7 +22,7 @@ impl QuantizationStrategy {
         match self {
             QuantizationStrategy::PerTensorSymmetric(strategy) => strategy.quantize(values),
             QuantizationStrategy::PerBlockSymmetric(strategy, block_size) => {
-                let blocks = block_grid(shape, block_size, strategy.len());
+                let blocks = block_layout(shape, block_size, strategy.len());
                 values
                     .iter()
                     .enumerate()
@@ -37,7 +37,7 @@ impl QuantizationStrategy {
         match self {
             QuantizationStrategy::PerTensorSymmetric(strategy) => strategy.dequantize(values),
             QuantizationStrategy::PerBlockSymmetric(strategy, block_size) => {
-                let blocks = block_grid(shape, block_size, strategy.len());
+                let blocks = block_layout(shape, block_size, strategy.len());
                 values
                     .iter()
                     .enumerate()
@@ -48,16 +48,16 @@ impl QuantizationStrategy {
     }
 }
 
-/// The block grid over `shape`, checked against the number of per-block strategies.
-fn block_grid(shape: &Shape, block_size: &BlockSize, num_blocks: usize) -> BlockGrid {
-    let grid = BlockGrid::new(shape, block_size);
+/// The blocks over `shape`, checked against the number of per-block strategies.
+fn block_layout(shape: &Shape, block_size: &BlockSize, num_blocks: usize) -> BlockLayout {
+    let layout = BlockLayout::new(shape, block_size);
     assert_eq!(
-        grid.num_blocks(),
+        layout.num_blocks(),
         num_blocks,
         "Invalid per-block quantization: {num_blocks} blocks for a {shape:?} tensor with \
          {block_size:?} blocks"
     );
-    grid
+    layout
 }
 
 /// Quantization scheme to convert elements of a higher precision data type `E` to a lower precision

--- a/crates/burn-ndarray/src/ops/quantization.rs
+++ b/crates/burn-ndarray/src/ops/quantization.rs
@@ -1,7 +1,8 @@
 use alloc::vec::Vec;
 use num_traits::{Float, PrimInt};
 
-use burn_backend::quantization::{BlockSize, QuantValue};
+use burn_backend::Shape;
+use burn_backend::quantization::{BlockGrid, BlockSize, QuantValue};
 
 // NOTE: this mainly serves as a simple reference implementation.
 // The de/quantization ops should be refactored to use ndarray.
@@ -16,49 +17,47 @@ pub enum QuantizationStrategy {
 }
 
 impl QuantizationStrategy {
-    /// Quantize the values to a lower precision data type.
-    pub fn quantize(&self, values: &[f32]) -> Vec<i8> {
+    /// Quantize the values of a tensor of `shape`, laid out row-major, to a lower precision.
+    pub fn quantize(&self, values: &[f32], shape: &Shape) -> Vec<i8> {
         match self {
             QuantizationStrategy::PerTensorSymmetric(strategy) => strategy.quantize(values),
             QuantizationStrategy::PerBlockSymmetric(strategy, block_size) => {
-                let block_elems = block_size.num_elements();
-                let num_blocks = strategy.len();
-                let numel = values.len();
-                assert_eq!(
-                    numel / block_elems,
-                    num_blocks,
-                    "Invalid per-block quantization with num blocks {num_blocks} and {numel} values"
-                );
+                let blocks = block_grid(shape, block_size, strategy.len());
                 values
-                    .chunks(block_elems)
+                    .iter()
                     .enumerate()
-                    .flat_map(|(block_id, block)| strategy[block_id].quantize(block))
+                    .map(|(index, &value)| strategy[blocks.block_of(index)].quantize_one(value))
                     .collect()
             }
         }
     }
 
-    /// Dequantize the values to a higher precision data type.
-    pub fn dequantize(&self, values: &[i8]) -> Vec<f32> {
+    /// Dequantize the values of a tensor of `shape`, laid out row-major, to a higher precision.
+    pub fn dequantize(&self, values: &[i8], shape: &Shape) -> Vec<f32> {
         match self {
             QuantizationStrategy::PerTensorSymmetric(strategy) => strategy.dequantize(values),
             QuantizationStrategy::PerBlockSymmetric(strategy, block_size) => {
-                let block_elems = block_size.num_elements();
-                let num_blocks = strategy.len();
-                let numel = values.len();
-                assert_eq!(
-                    numel / block_elems,
-                    num_blocks,
-                    "Invalid per-block quantization with block size {block_elems}, num blocks {num_blocks} and {numel} values"
-                );
+                let blocks = block_grid(shape, block_size, strategy.len());
                 values
-                    .chunks(block_elems)
+                    .iter()
                     .enumerate()
-                    .flat_map(|(block_id, block)| strategy[block_id].dequantize(block))
+                    .map(|(index, &value)| strategy[blocks.block_of(index)].dequantize_one(value))
                     .collect()
             }
         }
     }
+}
+
+/// The block grid over `shape`, checked against the number of per-block strategies.
+fn block_grid(shape: &Shape, block_size: &BlockSize, num_blocks: usize) -> BlockGrid {
+    let grid = BlockGrid::new(shape, block_size);
+    assert_eq!(
+        grid.num_blocks(),
+        num_blocks,
+        "Invalid per-block quantization: {num_blocks} blocks for a {shape:?} tensor with \
+         {block_size:?} blocks"
+    );
+    grid
 }
 
 /// Quantization scheme to convert elements of a higher precision data type `E` to a lower precision
@@ -191,7 +190,7 @@ mod tests {
             BlockSize::new([4]),
         );
 
-        let q: Vec<i8> = strategy.quantize(&x);
+        let q: Vec<i8> = strategy.quantize(&x, &Shape::new([8]));
         assert_eq!(q, expected_q);
 
         let d = symmetric.dequantize(&expected_q);
@@ -206,7 +205,7 @@ mod tests {
             value: QuantValue::Q8S,
         });
 
-        let output = strategy.dequantize(&[-127i8, -77, -26, 25, 76, 127]);
+        let output = strategy.dequantize(&[-127i8, -77, -26, 25, 76, 127], &Shape::new([2, 3]));
 
         let output = TensorData::new(output, [2, 3]);
 

--- a/crates/burn-ndarray/src/tensor.rs
+++ b/crates/burn-ndarray/src/tensor.rs
@@ -1,6 +1,6 @@
 use burn_backend::{
     AllocationProperty, DType, Element, Shape, TensorData, TensorMetadata,
-    quantization::{QParams, QuantLevel, QuantMode, QuantScheme, QuantValue},
+    quantization::{QuantMode, QuantScheme},
 };
 use burn_std::BoolStore;
 
@@ -704,57 +704,32 @@ pub struct NdArrayQTensor {
     pub qtensor: NdArrayTensor,
     /// The quantization scheme.
     pub scheme: QuantScheme,
-    /// The quantization parameters.
-    pub qparams: Vec<QParams<f32>>,
+    /// The block scales.
+    pub qparams: Vec<f32>,
+    /// The per-tensor scale that [`qparams`](Self::qparams) are expressed relative to, for a
+    /// two-level scheme.
+    pub global: Option<f32>,
 }
 
 impl NdArrayQTensor {
     /// Returns the quantization strategy, including quantization parameters, for the given tensor.
     pub fn strategy(&self) -> QuantizationStrategy {
-        match self.scheme {
-            QuantScheme {
-                level: QuantLevel::Tensor,
-                mode: QuantMode::Symmetric,
-                value:
-                    QuantValue::Q8F
-                    | QuantValue::Q8S
-                    | QuantValue::E4M3
-                    | QuantValue::E5M2
-                    | QuantValue::Q4F
-                    | QuantValue::Q4S
-                    | QuantValue::E2M1
-                    | QuantValue::Q2F
-                    | QuantValue::Q2S,
-                ..
-            } => QuantizationStrategy::PerTensorSymmetric(SymmetricQuantization::init(
-                self.qparams[0].scales,
-                self.scheme.value,
-            )),
-            QuantScheme {
-                level: QuantLevel::Block(block_size),
-                mode: QuantMode::Symmetric,
-                value:
-                    QuantValue::Q8F
-                    | QuantValue::Q8S
-                    | QuantValue::E4M3
-                    | QuantValue::E5M2
-                    | QuantValue::Q4F
-                    | QuantValue::Q4S
-                    | QuantValue::E2M1
-                    | QuantValue::Q2F
-                    | QuantValue::Q2S,
-                ..
-            } => QuantizationStrategy::PerBlockSymmetric(
+        match (self.scheme.mode, self.scheme.block_size()) {
+            (QuantMode::Symmetric, None) => QuantizationStrategy::PerTensorSymmetric(
+                SymmetricQuantization::init(self.qparams[0], self.scheme.value),
+            ),
+            (QuantMode::Symmetric, Some(block_size)) => QuantizationStrategy::PerBlockSymmetric(
                 self.qparams
                     .iter()
-                    .map(|q| SymmetricQuantization::init(q.scales, self.scheme.value))
+                    .map(|&s| {
+                        SymmetricQuantization::init(
+                            self.global.unwrap_or(1.0) * s,
+                            self.scheme.value,
+                        )
+                    })
                     .collect(),
                 block_size,
             ),
-            QuantScheme {
-                level: QuantLevel::BlockTensor { .. },
-                ..
-            } => unimplemented!("two-level quantization is not supported yet"),
         }
     }
 }
@@ -791,7 +766,7 @@ mod tests {
     use burn_backend::{
         Distribution,
         ops::{FloatTensorOps, QTensorOps},
-        quantization::{QuantStore, QuantizationParametersPrimitive},
+        quantization::{QuantStore, QuantValue, QuantizationParametersPrimitive},
     };
     use burn_std::rand::get_seeded_rng;
 
@@ -863,6 +838,7 @@ mod tests {
             .with_store(QuantStore::Native);
         let qparams = QuantizationParametersPrimitive {
             scales: B::float_from_data(TensorData::from([scale]), &device),
+            global: None,
         };
         let qtensor: NdArrayQTensor = B::quantize(tensor, &scheme, qparams);
 

--- a/crates/burn-ndarray/src/tensor.rs
+++ b/crates/burn-ndarray/src/tensor.rs
@@ -713,6 +713,10 @@ impl NdArrayQTensor {
     pub fn strategy(&self) -> QuantizationStrategy {
         match self.scheme {
             QuantScheme {
+                level: QuantLevel::BlockTensor { .. },
+                ..
+            } => unimplemented!("two-level quantization is not supported on ndarray yet"),
+            QuantScheme {
                 level: QuantLevel::Tensor,
                 mode: QuantMode::Symmetric,
                 value:

--- a/crates/burn-ndarray/src/tensor.rs
+++ b/crates/burn-ndarray/src/tensor.rs
@@ -706,6 +706,9 @@ pub struct NdArrayQTensor {
     pub scheme: QuantScheme,
     /// The quantization parameters.
     pub qparams: Vec<QParams<f32>>,
+    /// The per-tensor scale that [`qparams`](Self::qparams) are expressed relative to, for a
+    /// two-level scheme.
+    pub global: Option<f32>,
 }
 
 impl NdArrayQTensor {
@@ -713,9 +716,24 @@ impl NdArrayQTensor {
     pub fn strategy(&self) -> QuantizationStrategy {
         match self.scheme {
             QuantScheme {
-                level: QuantLevel::BlockTensor { .. },
+                level: QuantLevel::BlockTensor { block, .. },
+                mode: QuantMode::Symmetric,
                 ..
-            } => unimplemented!("two-level quantization is not supported on ndarray yet"),
+            } => {
+                // Kept apart on the tensor so a round trip through bytes preserves each level at
+                // the precision it is stored in, folded here because that is what dequantization
+                // reconstructs.
+                let global = self
+                    .global
+                    .expect("a two-level tensor should carry a per-tensor scale");
+                QuantizationStrategy::PerBlockSymmetric(
+                    self.qparams
+                        .iter()
+                        .map(|q| SymmetricQuantization::init(global * q.scales, self.scheme.value))
+                        .collect(),
+                    block,
+                )
+            }
             QuantScheme {
                 level: QuantLevel::Tensor,
                 mode: QuantMode::Symmetric,
@@ -863,6 +881,7 @@ mod tests {
             .with_store(QuantStore::Native);
         let qparams = QuantizationParametersPrimitive {
             scales: B::float_from_data(TensorData::from([scale]), &device),
+            global: None,
         };
         let qtensor: NdArrayQTensor = B::quantize(tensor, &scheme, qparams);
 

--- a/crates/burn-nn/tests/quantize.rs
+++ b/crates/burn-nn/tests/quantize.rs
@@ -3,7 +3,7 @@ use burn_core as burn;
 use burn::module::{Module, Quantizer};
 use burn::tensor::{
     Distribution, Tensor, Tolerance,
-    quantization::{Calibration, QuantLevel, QuantParam, QuantScheme, QuantValue},
+    quantization::{Calibration, QuantScheme, QuantValue, ScaleDtype},
 };
 use burn_nn::{
     LinearConfig,
@@ -39,8 +39,7 @@ fn should_quantize_transformer() {
         .quantization
         .scheme
         .with_value(QuantValue::Q8S)
-        .with_level(QuantLevel::block([32]))
-        .with_param(QuantParam::F32);
+        .per_block([32], ScaleDtype::F32);
 
     should_quantize_module(
         transformer,
@@ -59,9 +58,7 @@ fn should_quantize_linear_128_256() {
         .settings()
         .quantization
         .scheme
-        .with_value(QuantValue::Q8S)
-        .with_level(QuantLevel::Tensor)
-        .with_param(QuantParam::F32);
+        .with_value(QuantValue::Q8S);
 
     should_quantize_module(
         transformer,
@@ -82,10 +79,8 @@ fn should_quantize_linear() {
         .settings()
         .quantization
         .scheme
-        .with_value(QuantValue::Q8S)
-        .with_level(QuantLevel::Tensor)
         // .with_store(QuantStore::Native)
-        .with_param(QuantParam::F32);
+        .with_value(QuantValue::Q8S);
 
     should_quantize_module(
         transformer,
@@ -103,9 +98,7 @@ fn should_quantize_linear_weights() {
         .settings()
         .quantization
         .scheme
-        .with_value(QuantValue::Q8S)
-        .with_level(QuantLevel::Tensor)
-        .with_param(QuantParam::F32);
+        .with_value(QuantValue::Q8S);
 
     should_quantize_module(
         transformer,
@@ -125,9 +118,8 @@ fn should_quantize_linear_blocks() {
         .quantization
         .scheme
         .with_value(QuantValue::Q8S)
-        .with_level(QuantLevel::block([16]))
         // .with_store(QuantStore::Native)
-        .with_param(QuantParam::F32);
+        .per_block([16], ScaleDtype::F32);
 
     should_quantize_module(
         transformer,
@@ -146,9 +138,8 @@ fn should_quantize_linear_weights_blocks() {
         .quantization
         .scheme
         .with_value(QuantValue::Q8S)
-        .with_level(QuantLevel::block([16]))
         // .with_store(QuantStore::Native)
-        .with_param(QuantParam::F32);
+        .per_block([16], ScaleDtype::F32);
 
     should_quantize_module(
         transformer,

--- a/crates/burn-std/src/data/compare.rs
+++ b/crates/burn-std/src/data/compare.rs
@@ -3,7 +3,9 @@ use alloc::string::String;
 use num_traits::{Float, ToPrimitive};
 
 use super::TensorData;
-use crate::{BoolStore, DType, Element, ElementOrdered, bf16, f16};
+use crate::{
+    BoolStore, DType, Element, ElementOrdered, bf16, f16, quantization::global_scale_dtype,
+};
 
 /// The tolerance used to compare to floating point numbers.
 ///
@@ -246,8 +248,11 @@ impl TensorData {
                     panic!("Quantized data differs from other not quantized data")
                 };
 
-                // Data equality mostly depends on input quantization type, but we also check level
-                if q.value == q_other.value && q.level == q_other.level {
+                // Data equality mostly depends on input quantization type, but we also check levels
+                if q.value == q_other.value
+                    && q.block_size() == q_other.block_size()
+                    && global_scale_dtype(&q) == global_scale_dtype(&q_other)
+                {
                     self.assert_eq_elem::<i8>(other)
                 } else {
                     panic!("Quantization schemes differ ({q:?} != {q_other:?})")

--- a/crates/burn-std/src/data/tensor.rs
+++ b/crates/burn-std/src/data/tensor.rs
@@ -13,8 +13,7 @@ use crate::distribution::Distribution;
 use crate::element::{Element, ElementConversion};
 use crate::tensor::DType;
 use crate::{
-    BoolStore, Bytes, QuantLevel, QuantMode, QuantScheme, QuantValue, QuantizedBytes, Shape, bf16,
-    f16,
+    BoolStore, Bytes, QuantMode, QuantScheme, QuantValue, QuantizedBytes, Shape, bf16, f16,
 };
 
 use serde::{Deserialize, Serialize};
@@ -74,11 +73,12 @@ impl TensorData {
         shape: S,
         scheme: QuantScheme,
         qparams: &[f32],
+        global: Option<f32>,
     ) -> Self {
         let shape = shape.into();
         Self::check_data_len(&value, &shape);
 
-        let q_bytes = QuantizedBytes::new(value, scheme, qparams);
+        let q_bytes = QuantizedBytes::new(value, scheme, qparams, global);
 
         Self {
             bytes: q_bytes.bytes,
@@ -297,7 +297,6 @@ impl TensorData {
                 ),
                 DType::QFloat(scheme) => match scheme {
                     QuantScheme {
-                        level: QuantLevel::Tensor | QuantLevel::Block(_),
                         mode: QuantMode::Symmetric,
                         value:
                             QuantValue::Q8F
@@ -326,19 +325,12 @@ impl TensorData {
                         )
                     }
                     QuantScheme {
-                        level: QuantLevel::Tensor | QuantLevel::Block(_),
                         mode: QuantMode::Symmetric,
                         value:
                             QuantValue::E4M3 | QuantValue::E5M2 | QuantValue::E2M1,
                         ..
                     } => {
                         unimplemented!("Not yet implemented for iteration");
-                    }
-                    QuantScheme {
-                        level: QuantLevel::BlockTensor { .. },
-                        ..
-                    } => {
-                        unimplemented!("two-level quantization is not supported yet")
                     }
                 },
             }
@@ -747,7 +739,6 @@ impl core::fmt::Display for TensorData {
             DType::Bool(BoolStore::U32) => format!("{:?}", self.as_slice::<u32>().unwrap()),
             DType::QFloat(scheme) => match scheme {
                 QuantScheme {
-                    level: QuantLevel::Tensor | QuantLevel::Block(_),
                     mode: QuantMode::Symmetric,
                     value:
                         QuantValue::Q8F
@@ -762,7 +753,6 @@ impl core::fmt::Display for TensorData {
                     format!("{:?} {scheme:?}", self.iter::<i8>().collect::<Vec<_>>())
                 },
                 QuantScheme {
-                        level: QuantLevel::Tensor | QuantLevel::Block(_),
                         mode: QuantMode::Symmetric,
                         value:
                             QuantValue::E4M3 | QuantValue::E5M2 | QuantValue::E2M1,
@@ -770,12 +760,6 @@ impl core::fmt::Display for TensorData {
                     } => {
                         unimplemented!("Can't format yet");
                     }
-                QuantScheme {
-                    level: QuantLevel::BlockTensor { .. },
-                    ..
-                } => {
-                    unimplemented!("two-level quantization is not supported yet")
-                }
             },
         };
         f.write_str(fmt.as_str())

--- a/crates/burn-std/src/data/tensor.rs
+++ b/crates/burn-std/src/data/tensor.rs
@@ -74,11 +74,12 @@ impl TensorData {
         shape: S,
         scheme: QuantScheme,
         qparams: &[f32],
+        global: Option<f32>,
     ) -> Self {
         let shape = shape.into();
         Self::check_data_len(&value, &shape);
 
-        let q_bytes = QuantizedBytes::new(value, scheme, qparams);
+        let q_bytes = QuantizedBytes::new(value, scheme, qparams, global);
 
         Self {
             bytes: q_bytes.bytes,
@@ -297,7 +298,7 @@ impl TensorData {
                 ),
                 DType::QFloat(scheme) => match scheme {
                     QuantScheme {
-                        level: QuantLevel::Tensor | QuantLevel::Block(_),
+                        level: QuantLevel::Tensor | QuantLevel::Block(_) | QuantLevel::BlockTensor { .. },
                         mode: QuantMode::Symmetric,
                         value:
                             QuantValue::Q8F
@@ -326,7 +327,7 @@ impl TensorData {
                         )
                     }
                     QuantScheme {
-                        level: QuantLevel::Tensor | QuantLevel::Block(_),
+                        level: QuantLevel::Tensor | QuantLevel::Block(_) | QuantLevel::BlockTensor { .. },
                         mode: QuantMode::Symmetric,
                         value:
                             QuantValue::E4M3 | QuantValue::E5M2 | QuantValue::E2M1,
@@ -741,7 +742,7 @@ impl core::fmt::Display for TensorData {
             DType::Bool(BoolStore::U32) => format!("{:?}", self.as_slice::<u32>().unwrap()),
             DType::QFloat(scheme) => match scheme {
                 QuantScheme {
-                    level: QuantLevel::Tensor | QuantLevel::Block(_),
+                    level: QuantLevel::Tensor | QuantLevel::Block(_) | QuantLevel::BlockTensor { .. },
                     mode: QuantMode::Symmetric,
                     value:
                         QuantValue::Q8F
@@ -756,7 +757,7 @@ impl core::fmt::Display for TensorData {
                     format!("{:?} {scheme:?}", self.iter::<i8>().collect::<Vec<_>>())
                 },
                 QuantScheme {
-                        level: QuantLevel::Tensor | QuantLevel::Block(_),
+                        level: QuantLevel::Tensor | QuantLevel::Block(_) | QuantLevel::BlockTensor { .. },
                         mode: QuantMode::Symmetric,
                         value:
                             QuantValue::E4M3 | QuantValue::E5M2 | QuantValue::E2M1,

--- a/crates/burn-std/src/data/tensor/base.rs
+++ b/crates/burn-std/src/data/tensor/base.rs
@@ -151,7 +151,7 @@ impl TensorData {
         let shape = shape.into();
         Self::check_data_len(&value, &shape);
 
-        let q_bytes = QuantizedBytes::new(value, scheme, qparams, global);
+        let q_bytes = QuantizedBytes::new(value, shape.clone(), scheme, qparams, global);
 
         Self {
             bytes: q_bytes.bytes,

--- a/crates/burn-std/src/data/tensor/conversion.rs
+++ b/crates/burn-std/src/data/tensor/conversion.rs
@@ -188,7 +188,7 @@ impl TensorData {
                         let q_bytes = QuantizedBytes {
                             bytes: self.bytes.clone(),
                             scheme,
-                            num_elements: self.num_elements(),
+                            shape: self.shape.clone(),
                         };
                         let (values, _) = q_bytes.into_vec_i8();
 

--- a/crates/burn-std/src/tensor/quantization.rs
+++ b/crates/burn-std/src/tensor/quantization.rs
@@ -2,13 +2,13 @@
 
 // Re-exported types
 pub use cubecl_common::quant::scheme::{
-    BlockSize, QuantLevel, QuantMode, QuantParam, QuantScheme, QuantStore, QuantValue,
+    BlockScale, BlockSize, QuantMode, QuantScheme, QuantStore, QuantValue, ScaleDtype,
 };
 
 /// Alignment (in bytes) for quantization parameters in serialized tensor data.
 ///
 /// NOTE: This is currently f32-based since scales were originally always f32.
-/// With `QuantParam` now supporting different precisions (F16, BF16, etc.),
+/// With `ScaleDtype` now supporting different precisions (F16, BF16, etc.),
 /// this alignment may need to be revisited in the future.
 pub const QPARAM_ALIGN: usize = core::mem::align_of::<f32>();
 
@@ -79,6 +79,17 @@ pub enum QuantPropagation {
 pub struct QParams<S> {
     /// The scaling factor.
     pub scales: S,
+    /// The per-tensor scale [`scales`](Self::scales) are relative to, for a two-level scheme.
+    pub global: Option<S>,
+}
+
+/// Scales recovered from a quantized byte buffer.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DecodedScales {
+    /// One scale per block, or a single entry for a per-tensor level.
+    pub block: Vec<f32>,
+    /// The per-tensor scale, for a level that carries one.
+    pub global: Option<f32>,
 }
 
 /// A quantization parameter tensor descriptor.
@@ -94,23 +105,53 @@ pub struct QParamTensor {
     pub dtype: DType,
 }
 
-/// Calculate the shape of the quantization parameters for a given tensor and level
-pub fn params_shape(data_shape: &Shape, level: QuantLevel) -> Shape {
-    match level {
-        QuantLevel::Tensor => Shape::new([1]),
-        QuantLevel::Block(block_size) => {
-            let mut params_shape = data_shape.clone();
-            let block_size = block_size.to_dim_vec(data_shape.num_dims());
+/// Panic unless the scheme's levels are ones a backend can quantize against.
+pub fn validate_levels(scheme: &QuantScheme) {
+    if let Some(problem) = level_problem(scheme) {
+        panic!("{problem}, got {scheme:?}");
+    }
+}
 
-            for (shape, block_size) in params_shape.iter_mut().zip(block_size) {
-                *shape = (*shape).div_ceil(block_size as usize);
-            }
+/// Whether the scheme's levels are ones a backend can quantize against.
+///
+/// A backend reporting what it supports wants this rather than [`validate_levels`], so that an
+/// unsupported scheme is declined where it is chosen instead of panicking at the first quantize.
+pub fn levels_supported(scheme: &QuantScheme) -> bool {
+    level_problem(scheme).is_none()
+}
 
-            params_shape
-        }
-        QuantLevel::BlockTensor { .. } => {
-            unimplemented!("two-level quantization is not supported yet, got {level:?}")
-        }
+fn level_problem(scheme: &QuantScheme) -> Option<&'static str> {
+    let block = scheme.block_scale()?;
+    let global = global_scale_dtype(scheme)?;
+
+    if global != ScaleDtype::F32 {
+        // Any precision the per-tensor scale loses becomes a mismatch on every block.
+        return Some("a two-level scheme currently requires an f32 per-tensor scale");
+    }
+
+    if block.dtype.max_representable() > crate::f16::MAX.to_f32() {
+        // Block scales reaching close to f32's range drive the per-tensor scale subnormal.
+        return Some("a two-level scheme needs block scales narrower than f32");
+    }
+
+    None
+}
+
+/// The dtype of the per-tensor scale block scales are normalized against, for a two-level scheme.
+///
+/// [`QuantScheme::tensor_scale`] answers for a per-tensor scheme too, where the scale is the whole
+/// reconstruction rather than a factor over block scales.
+pub fn global_scale_dtype(scheme: &QuantScheme) -> Option<ScaleDtype> {
+    scheme.block_scale().and(scheme.tensor_scale())
+}
+
+/// Calculate the shape of the block scale grid for a given tensor and scheme.
+///
+/// A two-level scheme's per-tensor scale is not part of this grid.
+pub fn params_shape(data_shape: &Shape, scheme: &QuantScheme) -> Shape {
+    match scheme.block_size() {
+        None => Shape::new([1]),
+        Some(block_size) => Shape::from(block_size.grid(data_shape.as_slice())),
     }
 }
 
@@ -134,10 +175,14 @@ pub struct QuantizedBytes {
 
 impl QuantizedBytes {
     /// Creates a new quantized bytes representation.
+    ///
+    /// `global` is the per-tensor scale, required by a two-level scheme and rejected by a
+    /// one-level one.
     pub fn new<E: bytemuck::CheckedBitPattern + bytemuck::NoUninit>(
         value: Vec<E>,
         scheme: QuantScheme,
         scales: &[f32],
+        global: Option<f32>,
     ) -> Self {
         let num_elements = value.len();
         // Only used for 8-bit quantization data comparison in tests
@@ -149,16 +194,24 @@ impl QuantizedBytes {
         let i8s: Vec<i8> = bytemuck::allocation::cast_vec(value);
         let mut bytes = Bytes::from_elems(i8s);
 
-        let scales = match scheme.level {
-            QuantLevel::Tensor => &scales[..1],
-            QuantLevel::Block(_block_size) => scales,
-            QuantLevel::BlockTensor { .. } => unimplemented!(
-                "two-level quantization is not supported yet, got {:?}",
-                scheme.level
-            ),
+        let scales = match scheme.block_size() {
+            None => &scales[..1],
+            Some(_) => scales,
         };
-        let scale_bytes = encode_scales(scales, scheme.param);
+        let scale_bytes = encode_scales(scales, scheme.scale_dtype());
         bytes.extend_from_byte_slice_aligned(scale_bytes.as_slice(), QPARAM_ALIGN);
+
+        // Last, so a reader can peel it off the end before the block scales it normalizes.
+        match (global_scale_dtype(&scheme), global) {
+            (Some(dtype), Some(global)) => {
+                validate_levels(&scheme);
+                let global_bytes = encode_scales(&[global], dtype);
+                bytes.extend_from_byte_slice_aligned(global_bytes.as_slice(), QPARAM_ALIGN);
+            }
+            (Some(_), None) => panic!("{scheme:?} requires a per-tensor scale"),
+            (None, Some(_)) => panic!("{scheme:?} does not take a per-tensor scale"),
+            (None, None) => {}
+        }
 
         Self {
             bytes,
@@ -168,25 +221,34 @@ impl QuantizedBytes {
     }
 
     /// Returns the int8 quantized values with the quantization parameters.
-    pub fn into_vec_i8(self) -> (Vec<i8>, QParams<Vec<f32>>) {
-        let param = self.scheme.param;
+    pub fn into_vec_i8(self) -> (Vec<i8>, DecodedScales) {
+        let scheme = self.scheme;
         let (values, (qparams, num_params)) = self.split_values_off();
 
-        // Quantization parameters are added at the end of the tensor data.
-        // As such, the last bytes always correspond to the scale parameter(s),
-        // stored at the scheme's param dtype. For example, per-block
-        // quantization can have multiple parameters for a single tensor:
-        // [scale, scale, scale, ...]
-        let scales_size = scale_size(param) * num_params;
-        let scales = decode_scales(&qparams[qparams.len() - scales_size..], param);
+        // Laid out as `[block scale, ...]` optionally followed by the per-tensor scale.
+        let global_bytes = global_scale_size(&scheme);
+        let block_end = qparams
+            .len()
+            .checked_sub(global_bytes)
+            .expect("quantized parameter buffer is shorter than the scheme's global scale");
+        let block_start = block_end
+            .checked_sub(scale_size(scheme.scale_dtype()) * num_params)
+            .expect("quantized parameter buffer is shorter than the scheme's block scales");
 
-        (values, QParams { scales })
+        let block = decode_scales(&qparams[block_start..block_end], scheme.scale_dtype());
+        let global =
+            global_scale_dtype(&scheme).map(|dtype| decode_scales(&qparams[block_end..], dtype)[0]);
+
+        (values, DecodedScales { block, global })
     }
 
     fn split_i8_values(self, scale_bytes: usize) -> (Vec<i8>, Vec<u8>) {
         let mut values = read_bytes_to_i8(self.bytes);
 
-        let values_end = values.len() - scale_bytes;
+        let values_end = values
+            .len()
+            .checked_sub(scale_bytes)
+            .expect("quantized tensor data is shorter than its scheme's parameters");
         let qparams = values.split_off(values_end);
 
         (values, bytemuck::cast_vec(qparams))
@@ -197,15 +259,13 @@ impl QuantizedBytes {
     /// Returns the values in i8 and a newly allocated vector containing the
     /// quantization parameter bytes.
     fn split_values_off(self) -> (Vec<i8>, (Vec<u8>, usize)) {
-        let num_params = match self.scheme.level {
-            QuantLevel::Tensor => 1,
-            QuantLevel::Block(block_size) => self.num_elements / block_size.num_elements(),
-            QuantLevel::BlockTensor { .. } => unimplemented!(
-                "two-level quantization is not supported yet, got {:?}",
-                self.scheme.level
-            ),
-        };
-        let scale_bytes = scale_size(self.scheme.param) * num_params;
+        // Rounded up, so a trailing partial block still gets its scale.
+        let num_params = self
+            .scheme
+            .block_size()
+            .map_or(1, |block| self.num_elements.div_ceil(block.num_elements()));
+        let scale_bytes =
+            scale_size(self.scheme.scale_dtype()) * num_params + global_scale_size(&self.scheme);
 
         if let QuantStore::PackedU32(packed_dim) = self.scheme.store {
             assert_eq!(
@@ -219,7 +279,10 @@ impl QuantizedBytes {
             QuantStore::PackedU32(_) => match self.scheme.value {
                 QuantValue::Q8F | QuantValue::Q8S => self.split_i8_values(scale_bytes),
                 QuantValue::Q4F | QuantValue::Q4S | QuantValue::Q2F | QuantValue::Q2S => {
-                    let split_at = self.bytes.len() - scale_bytes;
+                    let split_at =
+                        self.bytes.len().checked_sub(scale_bytes).expect(
+                            "quantized tensor data is shorter than its scheme's parameters",
+                        );
                     let qparams = self.bytes[split_at..].to_vec();
                     let values = bytemuck::cast_slice::<_, u32>(&self.bytes[..split_at]);
                     // Sub-byte values are unpacked as i8s for value equality tests
@@ -237,7 +300,7 @@ impl QuantizedBytes {
     }
 }
 
-/// Round a scale up to the smallest value representable by the param dtype that is no smaller.
+/// Round a scale up to the smallest value representable by the scale dtype that is no smaller.
 ///
 /// Backends that keep scales in `f32` must apply this when quantizing, so that the scale they
 /// divide by is the one that will actually be stored. Otherwise a tensor dequantizes differently
@@ -246,83 +309,75 @@ impl QuantizedBytes {
 /// Up rather than to nearest, because a scale is derived from the largest magnitude it has to
 /// cover. Rounding down puts that value past the end of the quantized range, where it clips, which
 /// measured several times worse than the coarser step rounding up costs.
-pub fn scale_to_param(scale: f32, param: QuantParam) -> f32 {
-    let nearest = match param {
-        QuantParam::F32 => return scale,
-        QuantParam::F16 => crate::f16::from_f32(scale).to_f32(),
-        QuantParam::BF16 => crate::bf16::from_f32(scale).to_f32(),
-        QuantParam::UE4M3 => e4m3::from_f32(scale).to_f32(),
-        QuantParam::UE8M0 => unimplemented!("UE8M0 scales are not yet supported"),
-    };
-
-    if nearest >= scale || scale.is_nan() {
-        return nearest;
-    }
-
-    // Positive floats are ordered by their bit pattern, so the next representable value up is the
-    // next bit pattern.
-    let next = match param {
-        QuantParam::F16 => {
-            crate::f16::from_bits(crate::f16::from_f32(nearest).to_bits() + 1).to_f32()
-        }
-        QuantParam::BF16 => {
-            crate::bf16::from_bits(crate::bf16::from_f32(nearest).to_bits() + 1).to_f32()
-        }
-        QuantParam::UE4M3 => e4m3::from_bits(e4m3::from_f32(nearest).to_bits() + 1).to_f32(),
-        QuantParam::F32 | QuantParam::UE8M0 => unreachable!(),
-    };
-
-    // Stepping off the largest finite value lands on an infinity or a NaN encoding, so the
-    // saturated value is already the best answer.
-    if next.is_finite() { next } else { nearest }
+pub fn scale_to_dtype(scale: f32, dtype: ScaleDtype) -> f32 {
+    dtype
+        .round_up(scale)
+        .expect("UE8M0 scales are not yet supported")
 }
 
-/// Bytes per stored scale entry for the given param dtype.
-fn scale_size(param: QuantParam) -> usize {
-    match param {
-        QuantParam::F32 => 4,
-        QuantParam::F16 | QuantParam::BF16 => 2,
-        QuantParam::UE8M0 | QuantParam::UE4M3 => 1,
+/// Bytes taken by the per-tensor scale, zero for a scheme that does not carry one over blocks.
+pub fn global_scale_size(scheme: &QuantScheme) -> usize {
+    global_scale_dtype(scheme).map_or(0, scale_size)
+}
+
+/// Total bytes a tensor of `shape` occupies under `scheme`, laid out as [`QuantizedBytes::new`]
+/// writes it: values, then block scales, then (for a two-level scheme) the per-tensor scale.
+pub fn quantized_data_len(scheme: &QuantScheme, shape: &Shape) -> usize {
+    let num_storage_elements = shape.num_elements().div_ceil(scheme.num_quants());
+    let value_bytes = num_storage_elements * scheme.size_bits_stored().div_ceil(8);
+
+    let num_params = params_shape(shape, scheme).num_elements();
+    let scale_bytes = num_params * scale_size(scheme.scale_dtype());
+
+    value_bytes + scale_bytes + global_scale_size(scheme)
+}
+
+/// Bytes per stored scale entry for the given scale dtype.
+pub fn scale_size(dtype: ScaleDtype) -> usize {
+    match dtype {
+        ScaleDtype::F32 => 4,
+        ScaleDtype::F16 | ScaleDtype::BF16 => 2,
+        ScaleDtype::UE8M0 | ScaleDtype::UE4M3 => 1,
     }
 }
 
 /// Decode stored scale entries into f32.
-fn decode_scales(bytes: &[u8], param: QuantParam) -> Vec<f32> {
-    match param {
-        QuantParam::F32 => bytes
+fn decode_scales(bytes: &[u8], dtype: ScaleDtype) -> Vec<f32> {
+    match dtype {
+        ScaleDtype::F32 => bytes
             .chunks_exact(4)
             .map(|c| f32::from_ne_bytes([c[0], c[1], c[2], c[3]]))
             .collect(),
-        QuantParam::F16 => bytes
+        ScaleDtype::F16 => bytes
             .chunks_exact(2)
             .map(|c| crate::f16::from_ne_bytes([c[0], c[1]]).to_f32())
             .collect(),
-        QuantParam::BF16 => bytes
+        ScaleDtype::BF16 => bytes
             .chunks_exact(2)
             .map(|c| crate::bf16::from_ne_bytes([c[0], c[1]]).to_f32())
             .collect(),
-        QuantParam::UE4M3 => bytes.iter().map(|b| e4m3::from_bits(*b).to_f32()).collect(),
-        QuantParam::UE8M0 => unimplemented!("UE8M0 scales are not yet supported"),
+        ScaleDtype::UE4M3 => bytes.iter().map(|b| e4m3::from_bits(*b).to_f32()).collect(),
+        ScaleDtype::UE8M0 => unimplemented!("UE8M0 scales are not yet supported"),
     }
 }
 
-/// Encode f32 scales at the param dtype for serialization.
-fn encode_scales(scales: &[f32], param: QuantParam) -> Vec<u8> {
-    match param {
-        QuantParam::F32 => scales.iter().flat_map(|s| s.to_ne_bytes()).collect(),
-        QuantParam::F16 => scales
+/// Encode f32 scales at the scale dtype for serialization.
+fn encode_scales(scales: &[f32], dtype: ScaleDtype) -> Vec<u8> {
+    match dtype {
+        ScaleDtype::F32 => scales.iter().flat_map(|s| s.to_ne_bytes()).collect(),
+        ScaleDtype::F16 => scales
             .iter()
             .flat_map(|s| crate::f16::from_f32(*s).to_ne_bytes())
             .collect(),
-        QuantParam::BF16 => scales
+        ScaleDtype::BF16 => scales
             .iter()
             .flat_map(|s| crate::bf16::from_f32(*s).to_ne_bytes())
             .collect(),
-        QuantParam::UE4M3 => scales
+        ScaleDtype::UE4M3 => scales
             .iter()
             .map(|s| e4m3::from_f32(*s).to_bits())
             .collect(),
-        QuantParam::UE8M0 => unimplemented!("UE8M0 scales are not yet supported"),
+        ScaleDtype::UE8M0 => unimplemented!("UE8M0 scales are not yet supported"),
     }
 }
 
@@ -478,45 +533,97 @@ mod tests {
                 .with_value(QuantValue::Q8S)
                 .with_store(QuantStore::Native),
             &[scale],
+            None,
         );
 
         let (q_values, qparams) = q_bytes.into_vec_i8();
 
-        assert_eq!(qparams.scales, vec![scale]);
+        assert_eq!(qparams.block, vec![scale]);
 
         assert_eq!(q_values, values);
     }
 
-    /// Backends divide by what `scale_to_param` returns and hand that same value to
+    /// Backends divide by what `scale_to_dtype` returns and hand that same value to
     /// `encode_scales`. If encoding moved it, a tensor would dequantize differently after a
     /// save/load round trip, so the codec has to leave an already-rounded scale alone.
     #[test]
-    fn scale_to_param_survives_the_codec() {
+    fn scale_to_dtype_survives_the_codec() {
         // Includes values that saturate (500), land in e4m3's subnormals (1e-3), and underflow
         // it entirely (7.7e-4).
         let scales = [0.5f32, 0.3, 1.0 / 3.0, 500.0, 1e-3, 7.7e-4];
 
-        for param in [
-            QuantParam::F32,
-            QuantParam::F16,
-            QuantParam::BF16,
-            QuantParam::UE4M3,
+        for dtype in [
+            ScaleDtype::F32,
+            ScaleDtype::F16,
+            ScaleDtype::BF16,
+            ScaleDtype::UE4M3,
         ] {
-            let rounded: Vec<f32> = scales.iter().map(|s| scale_to_param(*s, param)).collect();
-            let via_codec = decode_scales(&encode_scales(&rounded, param), param);
+            let rounded: Vec<f32> = scales.iter().map(|s| scale_to_dtype(*s, dtype)).collect();
+            let via_codec = decode_scales(&encode_scales(&rounded, dtype), dtype);
 
             assert_eq!(
                 rounded, via_codec,
-                "the codec moves a scale {param:?} can already represent"
+                "the codec moves a scale {dtype:?} can already represent"
             );
             // 500 is past what e4m3 can hold, so it saturates rather than rounding up.
             for (scale, rounded) in scales.iter().zip(&rounded).filter(|(s, _)| **s < 500.0) {
                 assert!(
                     rounded >= scale,
-                    "{scale} rounded down to {rounded} for {param:?}"
+                    "{scale} rounded down to {rounded} for {dtype:?}"
                 );
             }
         }
+    }
+
+    /// The two scale regions have different widths, and the length assertion pins the layout as
+    /// dense: nothing is padded between them.
+    #[test]
+    fn should_pack_unpack_two_level_scales() {
+        // Exactly representable, so this pins the layout rather than the formats' rounding.
+        let block_scales = [0.5f32, 0.125];
+        let global = 3.0f32;
+        let values = vec![0i8, 25, 51, 76, 102, 127, -128, -1];
+
+        let scheme = QuantScheme::default()
+            .with_value(QuantValue::Q8S)
+            .with_store(QuantStore::Native)
+            .per_block([4], ScaleDtype::UE4M3)
+            .per_tensor(ScaleDtype::F32);
+
+        let q_bytes = QuantizedBytes::new(values.clone(), scheme, &block_scales, Some(global));
+
+        // 8 values, one byte per UE4M3 block scale, a 4 byte f32 per-tensor scale.
+        assert_eq!(q_bytes.bytes.len(), 8 + 2 + 4);
+
+        let (q_values, scales) = q_bytes.into_vec_i8();
+
+        assert_eq!(q_values, values);
+        assert_eq!(scales.block, block_scales);
+        assert_eq!(scales.global, Some(global));
+    }
+
+    #[test]
+    #[should_panic(expected = "requires a per-tensor scale")]
+    fn two_level_scheme_without_a_global_scale_is_rejected() {
+        let scheme = QuantScheme::default()
+            .with_value(QuantValue::Q8S)
+            .with_store(QuantStore::Native)
+            .per_block([4], ScaleDtype::F32)
+            .per_tensor(ScaleDtype::F32);
+
+        QuantizedBytes::new(vec![0i8; 8], scheme, &[0.5, 0.125], None);
+    }
+
+    #[test]
+    #[should_panic(expected = "needs block scales narrower than f32")]
+    fn two_level_scheme_with_f32_block_scales_is_rejected() {
+        let scheme = QuantScheme::default()
+            .with_value(QuantValue::Q8S)
+            .with_store(QuantStore::Native)
+            .per_block([4], ScaleDtype::F32)
+            .per_tensor(ScaleDtype::F32);
+
+        QuantizedBytes::new(vec![0i8; 8], scheme, &[0.5, 0.125], Some(3.0));
     }
 
     /// `scale_size` is what the readers use to locate the scales in the buffer, so an encoding
@@ -525,16 +632,16 @@ mod tests {
     fn encoded_scale_width_matches_scale_size() {
         let scales = [0.5f32, 0.25, 0.125];
 
-        for param in [
-            QuantParam::F32,
-            QuantParam::F16,
-            QuantParam::BF16,
-            QuantParam::UE4M3,
+        for dtype in [
+            ScaleDtype::F32,
+            ScaleDtype::F16,
+            ScaleDtype::BF16,
+            ScaleDtype::UE4M3,
         ] {
             assert_eq!(
-                encode_scales(&scales, param).len(),
-                scale_size(param) * scales.len(),
-                "encoded width disagrees with scale_size for {param:?}"
+                encode_scales(&scales, dtype).len(),
+                scale_size(dtype) * scales.len(),
+                "encoded width disagrees with scale_size for {dtype:?}"
             );
         }
     }
@@ -551,14 +658,14 @@ mod tests {
             QuantScheme::default()
                 .with_value(QuantValue::Q8S)
                 .with_store(QuantStore::Native)
-                .with_level(QuantLevel::block([4]))
-                .with_param(QuantParam::UE4M3),
+                .per_block([4], ScaleDtype::UE4M3),
             &scales,
+            None,
         );
 
         let (q_values, qparams) = q_bytes.into_vec_i8();
 
-        assert_eq!(qparams.scales, scales);
+        assert_eq!(qparams.block, scales);
         assert_eq!(q_values, values);
     }
 }

--- a/crates/burn-std/src/tensor/quantization.rs
+++ b/crates/burn-std/src/tensor/quantization.rs
@@ -145,6 +145,58 @@ pub fn params_shape(data_shape: &Shape, scheme: &QuantScheme) -> Shape {
     }
 }
 
+/// The grid of blocks a block scheme lays over a tensor: which block a row-major element index
+/// falls in. A block is a rectangle, so its members are a run of the flat storage only when it
+/// spans the trailing dimension; anything walking values against block scales asks here.
+#[derive(Debug, Clone)]
+pub struct BlockGrid {
+    shape: Shape,
+    block: Vec<u8>,
+    grid: Shape,
+}
+
+impl BlockGrid {
+    /// The grid `block` lays over a tensor of `shape`.
+    pub fn new(shape: &Shape, block: &BlockSize) -> Self {
+        Self {
+            shape: shape.clone(),
+            block: block.to_dim_vec(shape.num_dims()),
+            grid: Shape::from(block.grid(shape.as_slice())),
+        }
+    }
+
+    /// The grid's shape, one scale per block: [`params_shape`] for a block scheme.
+    pub fn grid(&self) -> &Shape {
+        &self.grid
+    }
+
+    /// How many blocks the grid holds.
+    pub fn num_blocks(&self) -> usize {
+        self.grid.num_elements()
+    }
+
+    /// Whether every dimension is a whole number of blocks.
+    pub fn divides(&self) -> bool {
+        self.shape
+            .iter()
+            .zip(&self.block)
+            .all(|(&dim, &extent)| dim.is_multiple_of(extent as usize))
+    }
+
+    /// The row-major index of the block holding row-major element `index`.
+    pub fn block_of(&self, mut index: usize) -> usize {
+        let mut block = 0;
+        let mut stride = 1;
+        for dim in (0..self.shape.num_dims()).rev() {
+            let coordinate = index % self.shape[dim];
+            index /= self.shape[dim];
+            block += coordinate / self.block[dim] as usize * stride;
+            stride *= self.grid[dim];
+        }
+        block
+    }
+}
+
 /// Quantized data bytes representation.
 ///
 /// # Notes
@@ -159,8 +211,9 @@ pub struct QuantizedBytes {
     pub bytes: Bytes,
     /// The quantization scheme.
     pub scheme: QuantScheme,
-    /// The number of quantized elements.
-    pub num_elements: usize,
+    /// The shape of the quantized tensor. The block grid, and so the scale count, follows from
+    /// it per axis: a block that does not span the trailing dimension is not a run of elements.
+    pub shape: Shape,
 }
 
 impl QuantizedBytes {
@@ -170,11 +223,18 @@ impl QuantizedBytes {
     /// one-level one.
     pub fn new<E: bytemuck::CheckedBitPattern + bytemuck::NoUninit>(
         value: Vec<E>,
+        shape: impl Into<Shape>,
         scheme: QuantScheme,
         scales: &[f32],
         global: Option<f32>,
     ) -> Self {
-        let num_elements = value.len();
+        let shape = shape.into();
+        assert_eq!(
+            value.len(),
+            shape.num_elements(),
+            "{} quantized values do not fill a tensor of shape {shape:?}",
+            value.len()
+        );
         // Only used for 8-bit quantization data comparison in tests
         if TypeId::of::<E>() != TypeId::of::<i8>() {
             panic!("Invalid quantized type");
@@ -212,8 +272,13 @@ impl QuantizedBytes {
         Self {
             bytes,
             scheme,
-            num_elements,
+            shape,
         }
+    }
+
+    /// The number of quantized elements.
+    pub fn num_elements(&self) -> usize {
+        self.shape.num_elements()
     }
 
     /// Returns the int8 quantized values with the quantization parameters.
@@ -255,11 +320,7 @@ impl QuantizedBytes {
     /// Returns the values in i8 and a newly allocated vector containing the
     /// quantization parameter bytes.
     fn split_values_off(self) -> (Vec<i8>, (Vec<u8>, usize)) {
-        // Rounded up, so a trailing partial block still gets its scale.
-        let num_params = self
-            .scheme
-            .block_size()
-            .map_or(1, |block| self.num_elements.div_ceil(block.num_elements()));
+        let num_params = params_shape(&self.shape, &self.scheme).num_elements();
         let scale_bytes =
             scale_size(self.scheme.scale_dtype()) * num_params + global_scale_size(&self.scheme);
 
@@ -282,7 +343,7 @@ impl QuantizedBytes {
                     let qparams = self.bytes[split_at..].to_vec();
                     let values = bytemuck::cast_slice::<_, u32>(&self.bytes[..split_at]);
                     // Sub-byte values are unpacked as i8s for value equality tests
-                    let values = unpack_q_to_i8s(values, self.num_elements, &self.scheme.value);
+                    let values = unpack_q_to_i8s(values, self.num_elements(), &self.scheme.value);
                     (values, qparams)
                 }
                 QuantValue::E4M3 | QuantValue::E5M2 | QuantValue::E2M1 => {
@@ -525,6 +586,7 @@ mod tests {
 
         let q_bytes = QuantizedBytes::new(
             values.clone(),
+            [2, 3],
             QuantScheme::default()
                 .with_value(QuantValue::Q8S)
                 .with_store(QuantStore::Native),
@@ -586,7 +648,7 @@ mod tests {
             .per_block([4], ScaleDtype::UE4M3)
             .per_tensor(ScaleDtype::F32);
 
-        let q_bytes = QuantizedBytes::new(values.clone(), scheme, &block_scales, Some(global));
+        let q_bytes = QuantizedBytes::new(values.clone(), [8], scheme, &block_scales, Some(global));
 
         // 8 values, one byte per UE4M3 block scale, a 4 byte f32 per-tensor scale.
         assert_eq!(q_bytes.bytes.len(), 8 + 2 + 4);
@@ -607,7 +669,7 @@ mod tests {
             .per_block([4], ScaleDtype::F32)
             .per_tensor(ScaleDtype::F32);
 
-        QuantizedBytes::new(vec![0i8; 8], scheme, &[0.5, 0.125], None);
+        QuantizedBytes::new(vec![0i8; 8], [8], scheme, &[0.5, 0.125], None);
     }
 
     #[test]
@@ -619,7 +681,7 @@ mod tests {
             .per_block([4], ScaleDtype::UE4M3)
             .per_tensor(ScaleDtype::F16);
 
-        QuantizedBytes::new(vec![0i8; 8], scheme, &[0.5, 0.125], Some(3.0));
+        QuantizedBytes::new(vec![0i8; 8], [8], scheme, &[0.5, 0.125], Some(3.0));
     }
 
     /// What a backend answers `supports_dtype` with, so a scheme it declines here is one no path
@@ -687,6 +749,7 @@ mod tests {
 
         let q_bytes = QuantizedBytes::new(
             values.clone(),
+            [8],
             QuantScheme::default()
                 .with_value(QuantValue::Q8S)
                 .with_store(QuantStore::Native)

--- a/crates/burn-std/src/tensor/quantization.rs
+++ b/crates/burn-std/src/tensor/quantization.rs
@@ -145,34 +145,29 @@ pub fn params_shape(data_shape: &Shape, scheme: &QuantScheme) -> Shape {
     }
 }
 
-/// The grid of blocks a block scheme lays over a tensor: which block a row-major element index
-/// falls in. A block is a rectangle, so its members are a run of the flat storage only when it
-/// spans the trailing dimension; anything walking values against block scales asks here.
+/// Which block each element of a tensor falls in, for a block scheme. A block is a rectangle, so
+/// its members are a run of the flat storage only when it spans the trailing dimension; anything
+/// walking values against block scales asks here rather than chunking.
 #[derive(Debug, Clone)]
-pub struct BlockGrid {
+pub struct BlockLayout {
     shape: Shape,
     block: Vec<u8>,
-    grid: Shape,
+    blocks: Shape,
 }
 
-impl BlockGrid {
-    /// The grid `block` lays over a tensor of `shape`.
+impl BlockLayout {
+    /// How `block` tiles a tensor of `shape`.
     pub fn new(shape: &Shape, block: &BlockSize) -> Self {
         Self {
             shape: shape.clone(),
             block: block.to_dim_vec(shape.num_dims()),
-            grid: Shape::from(block.num_blocks(shape.as_slice())),
+            blocks: Shape::from(block.num_blocks(shape.as_slice())),
         }
     }
 
-    /// The grid's shape, one scale per block: [`params_shape`] for a block scheme.
-    pub fn grid(&self) -> &Shape {
-        &self.grid
-    }
-
-    /// How many blocks the grid holds.
+    /// How many blocks the tensor holds, which is how many block scales it has.
     pub fn num_blocks(&self) -> usize {
-        self.grid.num_elements()
+        self.blocks.num_elements()
     }
 
     /// Whether every dimension is a whole number of blocks.
@@ -191,7 +186,7 @@ impl BlockGrid {
             let coordinate = index % self.shape[dim];
             index /= self.shape[dim];
             block += coordinate / self.block[dim] as usize * stride;
-            stride *= self.grid[dim];
+            stride *= self.blocks[dim];
         }
         block
     }
@@ -211,7 +206,7 @@ pub struct QuantizedBytes {
     pub bytes: Bytes,
     /// The quantization scheme.
     pub scheme: QuantScheme,
-    /// The shape of the quantized tensor. The block grid, and so the scale count, follows from
+    /// The shape of the quantized tensor. The block count, and so the scale count, follows from
     /// it per axis: a block that does not span the trailing dimension is not a run of elements.
     pub shape: Shape,
 }

--- a/crates/burn-std/src/tensor/quantization.rs
+++ b/crates/burn-std/src/tensor/quantization.rs
@@ -141,7 +141,7 @@ pub fn global_scale_dtype(scheme: &QuantScheme) -> Option<ScaleDtype> {
 pub fn params_shape(data_shape: &Shape, scheme: &QuantScheme) -> Shape {
     match scheme.block_size() {
         None => Shape::new([1]),
-        Some(block_size) => Shape::from(block_size.grid(data_shape.as_slice())),
+        Some(block_size) => Shape::from(block_size.num_blocks(data_shape.as_slice())),
     }
 }
 
@@ -161,7 +161,7 @@ impl BlockGrid {
         Self {
             shape: shape.clone(),
             block: block.to_dim_vec(shape.num_dims()),
-            grid: Shape::from(block.grid(shape.as_slice())),
+            grid: Shape::from(block.num_blocks(shape.as_slice())),
         }
     }
 

--- a/crates/burn-std/src/tensor/quantization.rs
+++ b/crates/burn-std/src/tensor/quantization.rs
@@ -105,36 +105,26 @@ pub struct QParamTensor {
     pub dtype: DType,
 }
 
-/// Panic unless the scheme's levels are ones a backend can quantize against.
-pub fn validate_levels(scheme: &QuantScheme) {
-    if let Some(problem) = level_problem(scheme) {
-        panic!("{problem}, got {scheme:?}");
-    }
-}
-
-/// Whether the scheme's levels are ones a backend can quantize against.
+/// Whether a backend can quantize against this scheme's scales.
 ///
-/// A backend reporting what it supports wants this rather than [`validate_levels`], so that an
-/// unsupported scheme is declined where it is chosen instead of panicking at the first quantize.
-pub fn levels_supported(scheme: &QuantScheme) -> bool {
-    level_problem(scheme).is_none()
-}
-
-fn level_problem(scheme: &QuantScheme) -> Option<&'static str> {
-    let block = scheme.block_scale()?;
-    let global = global_scale_dtype(scheme)?;
-
-    if global != ScaleDtype::F32 {
-        // Any precision the per-tensor scale loses becomes a mismatch on every block.
-        return Some("a two-level scheme currently requires an f32 per-tensor scale");
+/// A backend answers `supports_dtype` with this, so an unsupported scheme is declined where it is
+/// chosen rather than at the first quantize. Each condition is asserted again where it is relied
+/// on, so bypassing this reports the specific rule rather than this general one.
+pub fn quantizable(scheme: &QuantScheme) -> bool {
+    // Quantizing divides by the scale it will store, which needs the round-up rule.
+    if scheme.scale_dtype().round_up(1.0).is_none() {
+        return false;
     }
 
-    if block.dtype.max_representable() > crate::f16::MAX.to_f32() {
-        // Block scales reaching close to f32's range drive the per-tensor scale subnormal.
-        return Some("a two-level scheme needs block scales narrower than f32");
+    match (scheme.block_scale(), global_scale_dtype(scheme)) {
+        (Some(block), Some(global)) => {
+            // The per-tensor scale is the largest block scale over the block dtype's maximum, so a
+            // block dtype reaching f32's range drives it subnormal. Any precision the per-tensor
+            // scale itself loses becomes a mismatch applied to every block.
+            block.dtype.max_representable() <= crate::f16::MAX.to_f32() && global == ScaleDtype::F32
+        }
+        _ => true,
     }
-
-    None
 }
 
 /// The dtype of the per-tensor scale block scales are normalized against, for a two-level scheme.
@@ -204,7 +194,13 @@ impl QuantizedBytes {
         // Last, so a reader can peel it off the end before the block scales it normalizes.
         match (global_scale_dtype(&scheme), global) {
             (Some(dtype), Some(global)) => {
-                validate_levels(&scheme);
+                // Encoding the per-tensor scale narrower would round it, and the block scales were
+                // normalized against the unrounded one.
+                assert_eq!(
+                    dtype,
+                    ScaleDtype::F32,
+                    "a two-level scheme stores its per-tensor scale as f32, got {scheme:?}"
+                );
                 let global_bytes = encode_scales(&[global], dtype);
                 bytes.extend_from_byte_slice_aligned(global_bytes.as_slice(), QPARAM_ALIGN);
             }
@@ -615,15 +611,51 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "needs block scales narrower than f32")]
-    fn two_level_scheme_with_f32_block_scales_is_rejected() {
+    #[should_panic(expected = "stores its per-tensor scale as f32")]
+    fn a_narrower_per_tensor_scale_is_rejected() {
         let scheme = QuantScheme::default()
             .with_value(QuantValue::Q8S)
             .with_store(QuantStore::Native)
-            .per_block([4], ScaleDtype::F32)
-            .per_tensor(ScaleDtype::F32);
+            .per_block([4], ScaleDtype::UE4M3)
+            .per_tensor(ScaleDtype::F16);
 
         QuantizedBytes::new(vec![0i8; 8], scheme, &[0.5, 0.125], Some(3.0));
+    }
+
+    /// What a backend answers `supports_dtype` with, so a scheme it declines here is one no path
+    /// reaches: each of these panics further in, where the rule is relied on.
+    #[test]
+    fn quantizable_declines_what_no_backend_can_store() {
+        assert!(quantizable(&QuantScheme::default()));
+        assert!(quantizable(
+            &QuantScheme::default().per_block([4], ScaleDtype::F16)
+        ));
+        assert!(quantizable(
+            &QuantScheme::default()
+                .per_block([4], ScaleDtype::UE4M3)
+                .per_tensor(ScaleDtype::F32)
+        ));
+
+        // No round-up rule, so quantizing cannot store the scale it divides by.
+        assert!(!quantizable(
+            &QuantScheme::default().per_block([4], ScaleDtype::UE8M0)
+        ));
+        assert!(!quantizable(
+            &QuantScheme::default().per_tensor(ScaleDtype::UE8M0)
+        ));
+
+        // Block scales reaching f32's range leave the per-tensor scale subnormal, and a narrower
+        // per-tensor scale rounds away precision every block was normalized against.
+        assert!(!quantizable(
+            &QuantScheme::default()
+                .per_block([4], ScaleDtype::F32)
+                .per_tensor(ScaleDtype::F32)
+        ));
+        assert!(!quantizable(
+            &QuantScheme::default()
+                .per_block([4], ScaleDtype::UE4M3)
+                .per_tensor(ScaleDtype::BF16)
+        ));
     }
 
     /// `scale_size` is what the readers use to locate the scales in the buffer, so an encoding

--- a/crates/burn-std/src/tensor/quantization.rs
+++ b/crates/burn-std/src/tensor/quantization.rs
@@ -81,6 +81,18 @@ pub struct QParams<S> {
     pub scales: S,
 }
 
+/// Scales recovered from a quantized byte buffer.
+///
+/// Kept separate from [`QParams`], which is also used to hold a *single* block's scale, so a
+/// per-tensor value has no place on it.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DecodedScales {
+    /// One scale per block, or a single entry for a per-tensor level.
+    pub block: Vec<f32>,
+    /// The per-tensor scale, for a level that carries one.
+    pub global: Option<f32>,
+}
+
 /// A quantization parameter tensor descriptor.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QParamTensor {
@@ -94,11 +106,17 @@ pub struct QParamTensor {
     pub dtype: DType,
 }
 
-/// Calculate the shape of the quantization parameters for a given tensor and level
+/// Calculate the shape of the block scale grid for a given tensor and level.
+///
+/// This covers the block scales only. A [`QuantLevel::BlockTensor`] additionally carries a single
+/// per-tensor scale, which is not part of this grid.
 pub fn params_shape(data_shape: &Shape, level: QuantLevel) -> Shape {
     match level {
         QuantLevel::Tensor => Shape::new([1]),
-        QuantLevel::Block(block_size) => {
+        QuantLevel::Block(block_size)
+        | QuantLevel::BlockTensor {
+            block: block_size, ..
+        } => {
             let mut params_shape = data_shape.clone();
             let block_size = block_size.to_dim_vec(data_shape.num_dims());
 
@@ -131,10 +149,14 @@ pub struct QuantizedBytes {
 
 impl QuantizedBytes {
     /// Creates a new quantized bytes representation.
+    ///
+    /// `global` is the per-tensor scale, required by [`QuantLevel::BlockTensor`] and rejected by
+    /// every other level.
     pub fn new<E: bytemuck::CheckedBitPattern + bytemuck::NoUninit>(
         value: Vec<E>,
         scheme: QuantScheme,
         scales: &[f32],
+        global: Option<f32>,
     ) -> Self {
         let num_elements = value.len();
         // Only used for 8-bit quantization data comparison in tests
@@ -148,10 +170,22 @@ impl QuantizedBytes {
 
         let scales = match scheme.level {
             QuantLevel::Tensor => &scales[..1],
-            QuantLevel::Block(_block_size) => scales,
+            QuantLevel::Block(_) | QuantLevel::BlockTensor { .. } => scales,
         };
         let scale_bytes = encode_scales(scales, scheme.param);
         bytes.extend_from_byte_slice_aligned(scale_bytes.as_slice(), QPARAM_ALIGN);
+
+        // The per-tensor scale goes last, so a reader can peel it off the end before the block
+        // scales it normalizes.
+        match (scheme.level.global_param(), global) {
+            (Some(param), Some(global)) => {
+                let global_bytes = encode_scales(&[global], param);
+                bytes.extend_from_byte_slice_aligned(global_bytes.as_slice(), QPARAM_ALIGN);
+            }
+            (Some(_), None) => panic!("{:?} requires a per-tensor scale", scheme.level),
+            (None, Some(_)) => panic!("{:?} does not take a per-tensor scale", scheme.level),
+            (None, None) => {}
+        }
 
         Self {
             bytes,
@@ -161,19 +195,23 @@ impl QuantizedBytes {
     }
 
     /// Returns the int8 quantized values with the quantization parameters.
-    pub fn into_vec_i8(self) -> (Vec<i8>, QParams<Vec<f32>>) {
-        let param = self.scheme.param;
+    pub fn into_vec_i8(self) -> (Vec<i8>, DecodedScales) {
+        let scheme = self.scheme;
         let (values, (qparams, num_params)) = self.split_values_off();
 
-        // Quantization parameters are added at the end of the tensor data.
-        // As such, the last bytes always correspond to the scale parameter(s),
-        // stored at the scheme's param dtype. For example, per-block
-        // quantization can have multiple parameters for a single tensor:
-        // [scale, scale, scale, ...]
-        let scales_size = scale_size(param) * num_params;
-        let scales = decode_scales(&qparams[qparams.len() - scales_size..], param);
+        // Quantization parameters are appended to the tensor data as
+        // `[block scale, block scale, ...]` optionally followed by the per-tensor scale.
+        let global_bytes = global_scale_size(&scheme);
+        let block_end = qparams.len() - global_bytes;
+        let block_start = block_end - scale_size(scheme.param) * num_params;
 
-        (values, QParams { scales })
+        let block = decode_scales(&qparams[block_start..block_end], scheme.param);
+        let global = scheme
+            .level
+            .global_param()
+            .map(|param| decode_scales(&qparams[block_end..], param)[0]);
+
+        (values, DecodedScales { block, global })
     }
 
     fn split_i8_values(self, scale_bytes: usize) -> (Vec<i8>, Vec<u8>) {
@@ -192,9 +230,13 @@ impl QuantizedBytes {
     fn split_values_off(self) -> (Vec<i8>, (Vec<u8>, usize)) {
         let num_params = match self.scheme.level {
             QuantLevel::Tensor => 1,
-            QuantLevel::Block(block_size) => self.num_elements / block_size.num_elements(),
+            QuantLevel::Block(block_size)
+            | QuantLevel::BlockTensor {
+                block: block_size, ..
+            } => self.num_elements / block_size.num_elements(),
         };
-        let scale_bytes = scale_size(self.scheme.param) * num_params;
+        let scale_bytes =
+            scale_size(self.scheme.param) * num_params + global_scale_size(&self.scheme);
 
         if let QuantStore::PackedU32(packed_dim) = self.scheme.store {
             assert_eq!(
@@ -264,6 +306,11 @@ pub fn scale_to_param(scale: f32, param: QuantParam) -> f32 {
     // Stepping off the largest finite value lands on an infinity or a NaN encoding, so the
     // saturated value is already the best answer.
     if next.is_finite() { next } else { nearest }
+}
+
+/// Bytes taken by the per-tensor scale, zero for levels that do not carry one.
+fn global_scale_size(scheme: &QuantScheme) -> usize {
+    scheme.level.global_param().map_or(0, scale_size)
 }
 
 /// Bytes per stored scale entry for the given param dtype.
@@ -467,11 +514,12 @@ mod tests {
                 .with_value(QuantValue::Q8S)
                 .with_store(QuantStore::Native),
             &[scale],
+            None,
         );
 
         let (q_values, qparams) = q_bytes.into_vec_i8();
 
-        assert_eq!(qparams.scales, vec![scale]);
+        assert_eq!(qparams.block, vec![scale]);
 
         assert_eq!(q_values, values);
     }
@@ -506,6 +554,45 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// A two-level scheme stores narrow block scales followed by one wider per-tensor scale, so
+    /// the two regions have different widths and a reader has to split them at the right byte.
+    /// The length assertion pins the layout as dense: nothing is padded between the regions.
+    #[test]
+    fn should_pack_unpack_two_level_scales() {
+        // All exactly representable, so this pins the layout rather than the formats' rounding.
+        let block_scales = [0.5f32, 0.125];
+        let global = 3.0f32;
+        let values = vec![0i8, 25, 51, 76, 102, 127, -128, -1];
+
+        let scheme = QuantScheme::default()
+            .with_value(QuantValue::Q8S)
+            .with_store(QuantStore::Native)
+            .with_level(QuantLevel::block_tensor([4], QuantParam::F32))
+            .with_param(QuantParam::UE4M3);
+
+        let q_bytes = QuantizedBytes::new(values.clone(), scheme, &block_scales, Some(global));
+
+        // 8 values, then one byte per UE4M3 block scale, then a 4 byte f32 per-tensor scale.
+        assert_eq!(q_bytes.bytes.len(), 8 + 2 + 4);
+
+        let (q_values, scales) = q_bytes.into_vec_i8();
+
+        assert_eq!(q_values, values);
+        assert_eq!(scales.block, block_scales);
+        assert_eq!(scales.global, Some(global));
+    }
+
+    #[test]
+    #[should_panic(expected = "requires a per-tensor scale")]
+    fn two_level_scheme_without_a_global_scale_is_rejected() {
+        let scheme = QuantScheme::default()
+            .with_value(QuantValue::Q8S)
+            .with_store(QuantStore::Native)
+            .with_level(QuantLevel::block_tensor([4], QuantParam::F32));
+
+        QuantizedBytes::new(vec![0i8; 8], scheme, &[0.5, 0.125], None);
     }
 
     /// `scale_size` is what the readers use to locate the scales in the buffer, so an encoding
@@ -543,11 +630,12 @@ mod tests {
                 .with_level(QuantLevel::block([4]))
                 .with_param(QuantParam::UE4M3),
             &scales,
+            None,
         );
 
         let (q_values, qparams) = q_bytes.into_vec_i8();
 
-        assert_eq!(qparams.scales, scales);
+        assert_eq!(qparams.block, scales);
         assert_eq!(q_values, values);
     }
 }

--- a/crates/burn-std/src/tensor/quantization.rs
+++ b/crates/burn-std/src/tensor/quantization.rs
@@ -315,34 +315,7 @@ impl QuantizedBytes {
 /// cover. Rounding down puts that value past the end of the quantized range, where it clips, which
 /// measured several times worse than the coarser step rounding up costs.
 pub fn scale_to_param(scale: f32, param: QuantParam) -> f32 {
-    let nearest = match param {
-        QuantParam::F32 => return scale,
-        QuantParam::F16 => crate::f16::from_f32(scale).to_f32(),
-        QuantParam::BF16 => crate::bf16::from_f32(scale).to_f32(),
-        QuantParam::UE4M3 => e4m3::from_f32(scale).to_f32(),
-        QuantParam::UE8M0 => unimplemented!("UE8M0 scales are not yet supported"),
-    };
-
-    if nearest >= scale || scale.is_nan() {
-        return nearest;
-    }
-
-    // Positive floats are ordered by their bit pattern, so the next representable value up is the
-    // next bit pattern.
-    let next = match param {
-        QuantParam::F16 => {
-            crate::f16::from_bits(crate::f16::from_f32(nearest).to_bits() + 1).to_f32()
-        }
-        QuantParam::BF16 => {
-            crate::bf16::from_bits(crate::bf16::from_f32(nearest).to_bits() + 1).to_f32()
-        }
-        QuantParam::UE4M3 => e4m3::from_bits(e4m3::from_f32(nearest).to_bits() + 1).to_f32(),
-        QuantParam::F32 | QuantParam::UE8M0 => unreachable!(),
-    };
-
-    // Stepping off the largest finite value lands on an infinity or a NaN encoding, so the
-    // saturated value is already the best answer.
-    if next.is_finite() { next } else { nearest }
+    param.round_up(scale)
 }
 
 /// Bytes taken by the per-tensor scale, zero for levels that do not carry one.

--- a/crates/burn-std/src/tensor/quantization.rs
+++ b/crates/burn-std/src/tensor/quantization.rs
@@ -128,6 +128,17 @@ pub fn validate_levels(scheme: &QuantScheme) {
             QuantParam::F32,
             "a two-level scheme currently requires an f32 per-tensor scale"
         );
+        // Backends divide the largest block scale by the block param's maximum to get the
+        // per-tensor scale. A param reaching f32's exponent range, which f32, bf16 and ue8m0 all
+        // do, drives that quotient subnormal for any realistic tensor and the renormalized block
+        // scales to infinity, reconstructing the largest block as zeros. Such a param has nothing
+        // to gain from a second level anyway, since it already spans the range the second level
+        // exists to absorb.
+        assert!(
+            scheme.param.max_representable() <= crate::f16::MAX.to_f32(),
+            "a two-level scheme needs block scales narrower than f32, got {:?}",
+            scheme.param
+        );
     }
 }
 
@@ -619,6 +630,20 @@ mod tests {
             .with_level(QuantLevel::block_tensor([4], QuantParam::F32));
 
         QuantizedBytes::new(vec![0i8; 8], scheme, &[0.5, 0.125], None);
+    }
+
+    /// Block scales spanning f32's range leave the per-tensor scale nothing to absorb, and the
+    /// division that produces it underflows, so the largest block reconstructs as zeros.
+    #[test]
+    #[should_panic(expected = "needs block scales narrower than f32")]
+    fn two_level_scheme_with_f32_block_scales_is_rejected() {
+        let scheme = QuantScheme::default()
+            .with_value(QuantValue::Q8S)
+            .with_store(QuantStore::Native)
+            .with_param(QuantParam::F32)
+            .with_level(QuantLevel::block_tensor([4], QuantParam::F32));
+
+        QuantizedBytes::new(vec![0i8; 8], scheme, &[0.5, 0.125], Some(3.0));
     }
 
     /// `scale_size` is what the readers use to locate the scales in the buffer, so an encoding

--- a/crates/burn-std/src/tensor/quantization.rs
+++ b/crates/burn-std/src/tensor/quantization.rs
@@ -106,6 +106,31 @@ pub struct QParamTensor {
     pub dtype: DType,
 }
 
+/// Panic unless a two-level scheme keeps its per-tensor scale in `f32`. A no-op for levels that
+/// carry only one scale.
+///
+/// Calibration returns both levels unrounded and each backend rounds them to what it stores. A
+/// block scale absorbs that rounding, because the values are quantized against the rounded scale.
+/// The per-tensor scale does not: the block scales were divided by the unrounded one, so whatever
+/// precision the per-tensor param loses becomes a mismatch applied to every block. `f32` is the
+/// only param that loses none.
+///
+/// The width saved by anything narrower is one value per tensor, which no tensor large enough to
+/// want block quantization will notice. Measured with an `f16` per-tensor scale, the error stops
+/// being flat across weight magnitudes, which is the one property the second level exists for.
+///
+/// The field stays in [`QuantLevel::BlockTensor`] rather than being dropped, so that widening this
+/// later does not change the serialized shape.
+pub fn validate_levels(scheme: &QuantScheme) {
+    if let Some(global) = scheme.level.global_param() {
+        assert_eq!(
+            global,
+            QuantParam::F32,
+            "a two-level scheme currently requires an f32 per-tensor scale"
+        );
+    }
+}
+
 /// Calculate the shape of the block scale grid for a given tensor and level.
 ///
 /// This covers the block scales only. A [`QuantLevel::BlockTensor`] additionally carries a single
@@ -179,14 +204,7 @@ impl QuantizedBytes {
         // scales it normalizes.
         match (scheme.level.global_param(), global) {
             (Some(param), Some(global)) => {
-                // At equal width there is nothing to gain, and the per-tensor scale needed to
-                // bring a wide type's maximum into range underflows, taking the tensor with it.
-                assert!(
-                    scale_size(scheme.param) < scale_size(param),
-                    "a two-level scheme needs block scales narrower than its per-tensor scale, \
-                     got {:?} blocks under a {param:?} per-tensor scale",
-                    scheme.param
-                );
+                validate_levels(&scheme);
                 let global_bytes = encode_scales(&[global], param);
                 bytes.extend_from_byte_slice_aligned(global_bytes.as_slice(), QPARAM_ALIGN);
             }

--- a/crates/burn-std/src/tensor/quantization.rs
+++ b/crates/burn-std/src/tensor/quantization.rs
@@ -179,6 +179,14 @@ impl QuantizedBytes {
         // scales it normalizes.
         match (scheme.level.global_param(), global) {
             (Some(param), Some(global)) => {
+                // At equal width there is nothing to gain, and the per-tensor scale needed to
+                // bring a wide type's maximum into range underflows, taking the tensor with it.
+                assert!(
+                    scale_size(scheme.param) < scale_size(param),
+                    "a two-level scheme needs block scales narrower than its per-tensor scale, \
+                     got {:?} blocks under a {param:?} per-tensor scale",
+                    scheme.param
+                );
                 let global_bytes = encode_scales(&[global], param);
                 bytes.extend_from_byte_slice_aligned(global_bytes.as_slice(), QPARAM_ALIGN);
             }

--- a/crates/burn-store/src/tensor_snapshot.rs
+++ b/crates/burn-store/src/tensor_snapshot.rs
@@ -3,19 +3,8 @@ use alloc::string::String;
 use alloc::string::ToString;
 use alloc::vec::Vec;
 use burn_core::module::ParamId;
-use burn_core::tensor::quantization::{QPARAM_ALIGN, QuantParam, params_shape};
+use burn_core::tensor::quantization::quantized_data_len;
 use burn_core::tensor::{Bool, DType, Int, Shape, Tensor, TensorData};
-use half::f16;
-
-/// Returns the byte size of a quantization parameter type.
-// TODO: Add `size_bytes()` method to `QuantParam` in cubecl and use it here.
-const fn quant_param_size(param: QuantParam) -> usize {
-    match param {
-        QuantParam::F32 => core::mem::size_of::<f32>(),
-        QuantParam::F16 | QuantParam::BF16 => core::mem::size_of::<f16>(),
-        QuantParam::UE8M0 | QuantParam::UE4M3 => core::mem::size_of::<u8>(),
-    }
-}
 
 /// Error type for TensorSnapshot operations
 #[derive(Debug, Clone)]
@@ -244,29 +233,12 @@ impl TensorSnapshot {
     ///
     /// For quantized types (`QFloat`), this accounts for:
     /// - The quantized values (packed according to the quantization scheme)
-    /// - Alignment padding (values are aligned to 4-byte boundary)
-    /// - Quantization parameters (scale values appended to the data)
+    /// - Quantization parameters (scale values appended to the data), including the per-tensor
+    ///   scale of a two-level scheme
     pub fn data_len(&self) -> usize {
-        const BITS_PER_BYTE: usize = 8;
-
-        let num_elements: usize = self.shape.iter().product();
-
         match self.dtype {
-            DType::QFloat(scheme) => {
-                // Calculate value bytes using scheme's packing information
-                let num_storage_elements = num_elements.div_ceil(scheme.num_quants());
-                let value_bytes =
-                    num_storage_elements * (scheme.size_bits_stored() / BITS_PER_BYTE);
-
-                // Calculate number of quantization parameters (scales)
-                let num_params = params_shape(&self.shape, scheme.level).num_elements();
-
-                let aligned_value_bytes = value_bytes.div_ceil(QPARAM_ALIGN) * QPARAM_ALIGN;
-                let scale_bytes = num_params * quant_param_size(scheme.param);
-
-                aligned_value_bytes + scale_bytes
-            }
-            _ => num_elements * self.dtype.size(),
+            DType::QFloat(scheme) => quantized_data_len(&scheme, &self.shape),
+            _ => self.shape.iter().product::<usize>() * self.dtype.size(),
         }
     }
 
@@ -373,6 +345,41 @@ mod tests {
         let data = snapshot.to_data().unwrap();
         assert_eq!(data.shape, shape![2, 2]);
         assert_eq!(data.dtype, DType::Bool(BoolStore::Native));
+    }
+
+    /// `data_len` predicts the serialized size without materializing the tensor, and a mismatch
+    /// with what `TensorData::quantized` writes silently truncates or over-reserves on save.
+    #[test]
+    fn data_len_matches_quantized_bytes() {
+        use burn_core::tensor::quantization::{QuantScheme, QuantStore, QuantValue, ScaleDtype};
+
+        let base = QuantScheme::default()
+            .with_value(QuantValue::Q8S)
+            .with_store(QuantStore::Native);
+
+        // 8 values in blocks of 4 lands on `QPARAM_ALIGN`, which would hide a padding assumption;
+        // 6 in blocks of 3 and 10 in blocks of 5 do not.
+        for (values, block) in [(8usize, 4usize), (6, 3), (10, 5)] {
+            let scales = vec![0.5f32; values / block];
+            let one_level = base.per_block([block as u8], ScaleDtype::UE4M3);
+            let two_level = base
+                .per_block([block as u8], ScaleDtype::UE4M3)
+                .per_tensor(ScaleDtype::F32);
+
+            for (scheme, global) in [(one_level, None), (two_level, Some(3.0f32))] {
+                let data =
+                    TensorData::quantized(vec![0i8; values], [values], scheme, &scales, global);
+                let snapshot =
+                    TensorSnapshot::from_data(data.clone(), vec![], vec![], ParamId::new());
+
+                assert_eq!(
+                    snapshot.data_len(),
+                    data.bytes.len(),
+                    "predicted size disagrees with the written bytes for {values} values \
+                     in blocks of {block}, {scheme:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/burn-store/src/tensor_snapshot.rs
+++ b/crates/burn-store/src/tensor_snapshot.rs
@@ -263,8 +263,11 @@ impl TensorSnapshot {
 
                 let aligned_value_bytes = value_bytes.div_ceil(QPARAM_ALIGN) * QPARAM_ALIGN;
                 let scale_bytes = num_params * quant_param_size(scheme.param);
+                // A two-level scheme appends one more scale, at its own precision, after the
+                // block scales.
+                let global_bytes = scheme.level.global_param().map_or(0, quant_param_size);
 
-                aligned_value_bytes + scale_bytes
+                aligned_value_bytes + scale_bytes + global_bytes
             }
             _ => num_elements * self.dtype.size(),
         }
@@ -373,6 +376,35 @@ mod tests {
         let data = snapshot.to_data().unwrap();
         assert_eq!(data.shape, shape![2, 2]);
         assert_eq!(data.dtype, DType::Bool(BoolStore::Native));
+    }
+
+    /// `data_len` predicts the serialized size without materializing the tensor, so it has to
+    /// agree with what `TensorData::quantized` actually writes. A mismatch silently truncates or
+    /// over-reserves on save.
+    #[test]
+    fn data_len_matches_quantized_bytes() {
+        use burn_core::tensor::quantization::{
+            QuantLevel, QuantParam, QuantScheme, QuantStore, QuantValue,
+        };
+
+        let one_level = QuantScheme::default()
+            .with_value(QuantValue::Q8S)
+            .with_store(QuantStore::Native)
+            .with_level(QuantLevel::block([4]))
+            .with_param(QuantParam::UE4M3);
+        let two_level = one_level.with_level(QuantLevel::block_tensor([4], QuantParam::F32));
+
+        for (scheme, global) in [(one_level, None), (two_level, Some(3.0f32))] {
+            let data = TensorData::quantized(vec![0i8; 8], [8], scheme, &[0.5, 0.125], global);
+            let snapshot = TensorSnapshot::from_data(data.clone(), vec![], vec![], ParamId::new());
+
+            assert_eq!(
+                snapshot.data_len(),
+                data.bytes.len(),
+                "predicted size disagrees with the written bytes for {:?}",
+                scheme.level
+            );
+        }
     }
 
     #[test]

--- a/crates/burn-store/src/tensor_snapshot.rs
+++ b/crates/burn-store/src/tensor_snapshot.rs
@@ -3,7 +3,7 @@ use alloc::string::String;
 use alloc::string::ToString;
 use alloc::vec::Vec;
 use burn_core::module::ParamId;
-use burn_core::tensor::quantization::{QPARAM_ALIGN, QuantParam, params_shape};
+use burn_core::tensor::quantization::{QuantParam, params_shape};
 use burn_core::tensor::{Bool, DType, Int, Shape, Tensor, TensorData};
 use half::f16;
 
@@ -261,13 +261,14 @@ impl TensorSnapshot {
                 // Calculate number of quantization parameters (scales)
                 let num_params = params_shape(&self.shape, scheme.level).num_elements();
 
-                let aligned_value_bytes = value_bytes.div_ceil(QPARAM_ALIGN) * QPARAM_ALIGN;
                 let scale_bytes = num_params * quant_param_size(scheme.param);
                 // A two-level scheme appends one more scale, at its own precision, after the
                 // block scales.
                 let global_bytes = scheme.level.global_param().map_or(0, quant_param_size);
 
-                aligned_value_bytes + scale_bytes + global_bytes
+                // No padding between the regions. The alignment `QuantizedBytes` passes when it
+                // appends the scales only sizes the allocation, it does not move the write offset.
+                value_bytes + scale_bytes + global_bytes
             }
             _ => num_elements * self.dtype.size(),
         }
@@ -381,29 +382,43 @@ mod tests {
     /// `data_len` predicts the serialized size without materializing the tensor, so it has to
     /// agree with what `TensorData::quantized` actually writes. A mismatch silently truncates or
     /// over-reserves on save.
+    ///
+    /// The block sizes matter here. A value count that is a multiple of `QPARAM_ALIGN` hides the
+    /// interesting case, because the two regions happen to line up whether or not the prediction
+    /// assumes padding between them.
     #[test]
     fn data_len_matches_quantized_bytes() {
         use burn_core::tensor::quantization::{
             QuantLevel, QuantParam, QuantScheme, QuantStore, QuantValue,
         };
 
-        let one_level = QuantScheme::default()
+        let base = QuantScheme::default()
             .with_value(QuantValue::Q8S)
             .with_store(QuantStore::Native)
-            .with_level(QuantLevel::block([4]))
             .with_param(QuantParam::UE4M3);
-        let two_level = one_level.with_level(QuantLevel::block_tensor([4], QuantParam::F32));
 
-        for (scheme, global) in [(one_level, None), (two_level, Some(3.0f32))] {
-            let data = TensorData::quantized(vec![0i8; 8], [8], scheme, &[0.5, 0.125], global);
-            let snapshot = TensorSnapshot::from_data(data.clone(), vec![], vec![], ParamId::new());
+        // 8 values in blocks of 4 lands on the alignment; 6 in blocks of 3 and 10 in blocks of 5
+        // do not, and 10 leaves an odd number of one-byte block scales as well.
+        for (values, block) in [(8usize, 4usize), (6, 3), (10, 5)] {
+            let scales = vec![0.5f32; values / block];
+            let one_level = base.with_level(QuantLevel::block([block as u8]));
+            let two_level =
+                base.with_level(QuantLevel::block_tensor([block as u8], QuantParam::F32));
 
-            assert_eq!(
-                snapshot.data_len(),
-                data.bytes.len(),
-                "predicted size disagrees with the written bytes for {:?}",
-                scheme.level
-            );
+            for (scheme, global) in [(one_level, None), (two_level, Some(3.0f32))] {
+                let data =
+                    TensorData::quantized(vec![0i8; values], [values], scheme, &scales, global);
+                let snapshot =
+                    TensorSnapshot::from_data(data.clone(), vec![], vec![], ParamId::new());
+
+                assert_eq!(
+                    snapshot.data_len(),
+                    data.bytes.len(),
+                    "predicted size disagrees with the written bytes for {values} values \
+                     in blocks of {block}, {:?}",
+                    scheme.level
+                );
+            }
         }
     }
 

--- a/crates/burn-tensor/src/tensor/api/float.rs
+++ b/crates/burn-tensor/src/tensor/api/float.rs
@@ -1,5 +1,6 @@
 use crate::AsIndex;
 use crate::Cast;
+use crate::DType;
 use crate::Device;
 use crate::Tensor;
 use crate::cast::ToElement;
@@ -8,7 +9,7 @@ use crate::check::TensorCheck;
 use crate::check::unwrap_dim_index;
 use crate::kind::FloatMath;
 use crate::ops::{BridgeKind, BridgeTensor};
-use crate::quantization::{QuantScheme, QuantizationParameters};
+use crate::quantization::{QuantScheme, QuantizationParameters, global_scale_dtype};
 use crate::tensor::stats;
 use crate::tensor::{Distribution, TensorData};
 use crate::{Bool, Float, Int, TensorPrimitive};
@@ -375,10 +376,31 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     ///
     /// The quantized tensor.
     pub fn quantize(self, scheme: &QuantScheme, qparams: QuantizationParameters) -> Tensor<D> {
+        assert_eq!(
+            global_scale_dtype(scheme).is_some(),
+            qparams.global.is_some(),
+            "{scheme:?} does not match a per-tensor scale of {:?}",
+            qparams.global,
+        );
+        if let Some(global) = &qparams.global {
+            assert_eq!(
+                global.dims()[0],
+                1,
+                "the per-tensor scale must have exactly one element, got {:?}",
+                global.dims()
+            );
+            assert_eq!(
+                global.dtype(),
+                DType::F32,
+                "the per-tensor scale must be an f32 tensor, got {:?}",
+                global.dtype()
+            );
+        }
         Tensor::new(quantize_impl(
             self.primitive,
             scheme,
             qparams.scales.primitive,
+            qparams.global.map(|global| global.primitive),
         ))
     }
 
@@ -1139,12 +1161,18 @@ fn relu_impl(p: BridgeTensor) -> BridgeTensor {
     BridgeTensor::float(Dispatch::relu(p.into_float()))
 }
 
-fn quantize_impl(p: BridgeTensor, scheme: &QuantScheme, scales: BridgeTensor) -> BridgeTensor {
+fn quantize_impl(
+    p: BridgeTensor,
+    scheme: &QuantScheme,
+    scales: BridgeTensor,
+    global: Option<BridgeTensor>,
+) -> BridgeTensor {
     BridgeTensor::qfloat(Dispatch::quantize(
         p.into_float(),
         scheme,
         QuantizationParametersPrimitive {
             scales: scales.into_float(),
+            global: global.map(|global| global.into_float()),
         },
     ))
 }

--- a/crates/burn-tensor/src/tensor/api/float.rs
+++ b/crates/burn-tensor/src/tensor/api/float.rs
@@ -385,6 +385,7 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
             self.primitive,
             scheme,
             qparams.scales.primitive,
+            qparams.global.map(|global| global.primitive),
         ))
     }
 
@@ -1183,12 +1184,18 @@ fn relu_impl(p: BridgeTensor) -> BridgeTensor {
     BridgeTensor::float(Dispatch::relu(p.into_float()))
 }
 
-fn quantize_impl(p: BridgeTensor, scheme: &QuantScheme, scales: BridgeTensor) -> BridgeTensor {
+fn quantize_impl(
+    p: BridgeTensor,
+    scheme: &QuantScheme,
+    scales: BridgeTensor,
+    global: Option<BridgeTensor>,
+) -> BridgeTensor {
     BridgeTensor::qfloat(Dispatch::quantize(
         p.into_float(),
         scheme,
         QuantizationParametersPrimitive {
             scales: scales.into_float(),
+            global: global.map(|global| global.into_float()),
         },
     ))
 }

--- a/crates/burn-tensor/src/tensor/quantization.rs
+++ b/crates/burn-tensor/src/tensor/quantization.rs
@@ -50,6 +50,9 @@ pub fn compute_q_params(scheme: &QuantScheme, range: CalibrationRange) -> Quanti
             let qparams = quantization::compute_q_params::<Dispatch>(scheme, min, max);
             QuantizationParameters {
                 scales: Tensor::new(BridgeTensor::float(qparams.scales)),
+                global: qparams
+                    .global
+                    .map(|global| Tensor::new(BridgeTensor::float(global))),
             }
         }
         _ => unreachable!(),

--- a/crates/burn-tensor/src/tensor/quantization.rs
+++ b/crates/burn-tensor/src/tensor/quantization.rs
@@ -9,7 +9,17 @@ use burn_dispatch::Dispatch;
 pub use burn_std::quantization::*;
 
 /// The tensor quantization parameters.
-pub type QuantizationParameters = QParams<Tensor<1>>;
+///
+/// Kept separate from [`QParams`], which also stands in for a *single* block's scale, so a
+/// per-tensor value has no place on it.
+#[derive(Clone, Debug)]
+pub struct QuantizationParameters {
+    /// The scaling factor, one per block or a single one for a per-tensor level.
+    pub scales: Tensor<1>,
+    /// The per-tensor scale that [`scales`](Self::scales) are expressed relative to, for a
+    /// two-level scheme. A value is reconstructed as `q * global * scale`.
+    pub global: Option<Tensor<1>>,
+}
 
 /// The observed input calibration range.
 #[derive(Clone, Debug)]
@@ -50,6 +60,9 @@ pub fn compute_q_params(scheme: &QuantScheme, range: CalibrationRange) -> Quanti
             let qparams = quantization::compute_q_params::<Dispatch>(scheme, min, max);
             QuantizationParameters {
                 scales: Tensor::new(BridgeTensor::float(qparams.scales)),
+                global: qparams
+                    .global
+                    .map(|global| Tensor::new(BridgeTensor::float(global))),
             }
         }
         _ => unreachable!(),


### PR DESCRIPTION
Adds two-level quantization: per-block scales that are themselves normalized by a single per-tensor scale, so the block scales can live in a narrow dtype while the per-tensor scale absorbs the tensor's dynamic range. NVFP4 is the inspiration and the validation target, not the spec, so nothing here hardcodes E2M1 values, ue4m3 block scales, or a block size of 16.

The scheme comes from cubecl#1514; what this PR adds is everything burn needs to carry a second scale: calibration, the serialized byte layout, and the ndarray, flex and cube backends.

Before, one scale per block of 32 stored as f16, with the scale precision living in a scheme-wide field:

```rust
let scheme = QuantScheme::default()
    .with_value(QuantValue::Q8S)
    .with_level(QuantLevel::block([32]))
    .with_param(QuantParam::F16);

let tensor = tensor.quantize_dynamic(&scheme);
```

After, each level owns the dtype its scales are stored in, and a second level is one more setter:

```rust
let scheme = QuantScheme::default()
    .with_value(QuantValue::Q8S)
    .per_block([32], ScaleDtype::F16);

// Two levels: ue4m3 block scales, normalized by one per-tensor f32 scale.
let two_level = QuantScheme::default()
    .with_value(QuantValue::Q8S)
    .per_block([16], ScaleDtype::UE4M3)
    .per_tensor(ScaleDtype::F32);

let tensor = tensor.quantize_dynamic(&two_level);
```

## What changed in burn

- The per-tensor scale rides beside the block scales the whole way: `QuantizationParameters { scales, global }`, `QParams.global`, and a third allocation region in a `CubeTensor`. Backends keep the two apart on the tensor and fold them only where dequantization reconstructs the product, so a save and load round trip preserves each at its stored precision.
- Calibration returns both levels unrounded, as the one-level scales already did. Each backend rounds each level to what its dtype can store and quantizes against that product, so the values written already account for the rounding. The round-up rule (store the smallest value *not below* the scale, so a block maximum never clips) lives in cubecl and is called from both the host and the kernel path, so CPU and GPU reconstruct identically.
- `burn-std`: `params_shape` takes the scheme, `scale_to_param` becomes `scale_to_dtype`, and `global_scale_dtype` answers "does this scheme have a per-tensor scale over its blocks", which `tensor_scale()` alone cannot, since that also answers for a one-level per-tensor scheme.
- burn's `block_level` helper is gone. Swap and permute rewrite the block dimensions through the scheme's own `swap_block_dims`/`permute_block_dims`, which also fixes `burn-ir`'s `permute_quantized_dtype` silently skipping that rewrite for two-level tensors.

## Rejected rather than half-supported

- The fused elementwise kernels and the fused matmul decline a scheme with a per-tensor scale rather than dropping the factor, which would reconstruct every value short by it. The quantized matmul dequantizes a two-level operand and runs in float instead, so the path exists but buys nothing yet.
- `AbsMean` calibration. BitNet's gamma is a mean over the whole tensor or block, which a per-tensor scale cannot decompose.
- A per-tensor scale in anything but f32, and block scales already spanning f32's range, both refused where the scheme is chosen rather than at the first quantize.

## Does it earn its keep

The bar set before starting: beat what one-level already achieves at the same bits per element. That is 0.0054 relative error at 8.5 bits, from `block32` with f16 scales. f16 block scales match f32 to five decimals for a full bit per element less, so f16 is the honest baseline, not f32.

`block16` with ue4m3 block scales under an f32 per-tensor scale, 8.508 bits:

| weight std | two-level | one-level block32/f16 |
| ---------- | --------- | --------------------- |
| 1.0 | 0.00503 | 0.00539 |
| 0.1 | 0.00503 | 0.00540 |
| 0.02 | 0.00503 | 0.00539 |

The margin is about 7 percent, which on its own would be thin. The result that matters is the flatness, which holds to five decimals. Every one-level ue4m3 config degrades as weights shrink, with `block16/ue4m3` going 0.00512, 0.00710, 0.02858 across those same three magnitudes, because the block scale underflows what e4m3 can represent. Two-level does not, and a realistic `Linear` weight sits in that range. Numbers come from `report_quantization_accuracy` in the test harness, extended here to cover two-level.

## Known limit

The per-tensor scale takes the tensor's range out of the block scales, but the spread *between* blocks is still bounded. A block whose scale falls further below the largest one than the block dtype can express is stored at that dtype's smallest value and quantizes entirely to zero. UE4M3 spans about 2^18 this way, so a tensor holding a genuine outlier alongside ordinary values can lose the ordinary ones. Documented on the scheme upstream.

## Not in this PR

The matmul tile path, which is where a two-level operand would stop being a fallback. It is the largest remaining piece and belongs with the tile work upstream.

## Testing

Quantization suites green on ndarray, flex and CUDA, two-level cases included. wgpu has no e4m3, so the ue4m3 cases are gated off it.

