### PR TITLE
flex: improve add_bias perf a lot, and improve conv_plane_accumulate autovectorization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5906,9 +5906,9 @@ dependencies = [
 
 [[package]]
 name = "macerator"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "508a2f720538bb7e3ea3cb6d098615b107cb82ae387d77d906276905e9ec894b"
+checksum = "2ddeaadb76e307b1d2b4836adee77910d405b9f6c1ca031bc81a7a398e2b22f2"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -5922,9 +5922,9 @@ dependencies = [
 
 [[package]]
 name = "macerator-macros"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5ce85961d618ce9794bdf822bfe96fe9dd341aa5b033b454f7a8d96e79b9b1"
+checksum = "d2a397d020af346358830d6f28579f26283003ce87af3dd79173ac9ee2d3ac28"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ half = { version = "2.7.1", features = [
     "num-traits",
     "serde",
 ], default-features = false }
-macerator = { version = "0.3.3" }
+macerator = { version = "0.3.4" }
 matrixmultiply = { version = "0.3.10", default-features = false }
 ndarray = { version = "0.17.2", default-features = false }
 num-traits = { version = "0.2.19", default-features = false, features = [

--- a/crates/burn-backend/src/lib.rs
+++ b/crates/burn-backend/src/lib.rs
@@ -17,9 +17,9 @@ pub use backend::*;
 pub use burn_std::reader::*; // Useful so that backends don't have to add `burn_std` as a dependency.
 pub use burn_std::{
     AllocationProperty, BoolDType, BoolStore, Bytes, DType, DataError, DeviceHandle, Distribution,
-    DistributionSampler, DistributionSamplerKind, Element, ElementConversion, ElementEq,
-    ElementOrdered, ElementRandom, FloatDType, IntDType, Scalar, SplitPolicy, TensorData,
-    Tolerance, bf16, distribution, element, f16, stream::StreamId,
+    DistributionSampler, DistributionSamplerKind, Element, ElementAdd, ElementConversion,
+    ElementEq, ElementOrdered, ElementRandom, FloatDType, IntDType, Scalar, SplitPolicy,
+    TensorData, Tolerance, bf16, distribution, element, f16, stream::StreamId,
 };
 
 /// Shape definition.

--- a/crates/burn-flex/src/ops/conv.rs
+++ b/crates/burn-flex/src/ops/conv.rs
@@ -41,14 +41,14 @@ use super::conv_common::{add_bias, squeeze_3d_to_1d, squeeze_3d_to_2d};
 
 /// Generates a conv3d_1x1 function that uses the optimized gemm fast path.
 macro_rules! conv3d_1x1_typed {
-    ($fn_name:ident, $T:ty, $dtype:expr, $zero:expr, $one:expr, $add_fn:expr) => {
+    ($fn_name:ident, $T:ty, $dtype:expr, $zero:expr, $one:expr) => {
         fn $fn_name(
             x: FlexTensor,
             weight: FlexTensor,
             bias: Option<FlexTensor>,
             options: &ConvOptions<3>,
         ) -> FlexTensor {
-            conv3d_1x1_impl::<$T>(x, weight, bias, options, $dtype, $zero, $one, $add_fn)
+            conv3d_1x1_impl::<$T>(x, weight, bias, options, $dtype, $zero, $one)
         }
     };
 }
@@ -56,7 +56,7 @@ macro_rules! conv3d_1x1_typed {
 /// Generates a conv3d typed function with 1x1, depthwise, small-channel, and
 /// direct fast-path checks.
 macro_rules! conv3d_typed {
-    ($fn_name:ident, $T:ty, $dtype:expr, $zero:expr, $gemm_fn:ident, $add_fn:expr, $fn_1x1:ident, $fn_depthwise:ident, $fn_small_channel:ident $(, $fn_direct:ident)?) => {
+    ($fn_name:ident, $T:ty, $dtype:expr, $zero:expr, $gemm_fn:ident, $fn_1x1:ident, $fn_depthwise:ident, $fn_small_channel:ident $(, $fn_direct:ident)?) => {
         pub fn $fn_name(
             x: FlexTensor,
             weight: FlexTensor,
@@ -79,7 +79,7 @@ macro_rules! conv3d_typed {
                     return $fn_direct(x, weight, bias, options);
                 }
             )?
-            conv3d_impl::<$T>(x, weight, bias, options, $dtype, $zero, $gemm_fn, $add_fn)
+            conv3d_impl::<$T>(x, weight, bias, options, $dtype, $zero, $gemm_fn)
         }
     };
 }
@@ -200,7 +200,6 @@ conv3d_typed!(
     DType::F32,
     0.0f32,
     gemm_f32,
-    |a, b| a + b,
     conv3d_1x1_f32,
     conv3d_depthwise_f32,
     conv3d_small_channel_f32,
@@ -212,7 +211,6 @@ conv3d_typed!(
     DType::F64,
     0.0f64,
     gemm_f64,
-    |a, b| a + b,
     conv3d_1x1_f64,
     conv3d_depthwise_f64,
     conv3d_small_channel_f64,
@@ -224,7 +222,6 @@ conv3d_typed!(
     DType::F16,
     f16::from_f32(0.0),
     gemm_f16,
-    |a: f16, b: f16| f16::from_f32(a.to_f32() + b.to_f32()),
     conv3d_1x1_f16,
     conv3d_depthwise_f16,
     conv3d_small_channel_f16
@@ -238,7 +235,9 @@ bf16_via_f32!(conv3d_bf16, conv3d_f32, 3, ConvOptions);
 /// - Enables tile-level parallelism
 /// - Improves cache utilization
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
-fn conv3d_impl<T: bytemuck::Pod + Clone + Copy + burn_backend::Element + Send + Sync>(
+fn conv3d_impl<
+    T: bytemuck::Pod + Clone + Copy + burn_backend::Element + burn_backend::ElementAdd + Send + Sync,
+>(
     x: FlexTensor,
     weight: FlexTensor,
     bias: Option<FlexTensor>,
@@ -246,7 +245,6 @@ fn conv3d_impl<T: bytemuck::Pod + Clone + Copy + burn_backend::Element + Send + 
     dtype: DType,
     zero: T,
     gemm_fn: fn(&[T], &[T], usize, usize, usize) -> Vec<T>,
-    add_fn: fn(T, T) -> T,
 ) -> FlexTensor {
     let x = x.to_contiguous();
     let weight = weight.to_contiguous();
@@ -525,7 +523,6 @@ fn conv3d_impl<T: bytemuck::Pod + Clone + Copy + burn_backend::Element + Send + 
             batch_size,
             channels_out,
             spatial_out,
-            add_fn,
         );
     }
 
@@ -634,7 +631,9 @@ fn is_1x1_conv(
 /// to gemm as the RHS with appropriate strides, avoiding the transpose allocation
 /// and the intermediate result buffer.
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
-fn conv3d_1x1_impl<T: bytemuck::Pod + Clone + Copy + burn_backend::Element + Send + Sync>(
+fn conv3d_1x1_impl<
+    T: bytemuck::Pod + Clone + Copy + burn_backend::Element + burn_backend::ElementAdd + Send + Sync,
+>(
     x: FlexTensor,
     weight: FlexTensor,
     bias: Option<FlexTensor>,
@@ -642,7 +641,6 @@ fn conv3d_1x1_impl<T: bytemuck::Pod + Clone + Copy + burn_backend::Element + Sen
     dtype: DType,
     zero: T,
     one: T,
-    add_fn: fn(T, T) -> T,
 ) -> FlexTensor {
     let x = x.to_contiguous();
     let weight = weight.to_contiguous();
@@ -766,14 +764,7 @@ fn conv3d_1x1_impl<T: bytemuck::Pod + Clone + Copy + burn_backend::Element + Sen
     if let Some(bias) = bias {
         let bias = bias.to_contiguous();
         let bias_data: &[T] = bias.storage();
-        add_bias(
-            &mut output,
-            bias_data,
-            batch_size,
-            channels_out,
-            spatial,
-            add_fn,
-        );
+        add_bias(&mut output, bias_data, batch_size, channels_out, spatial);
     }
 
     let out_shape = Shape::from(vec![
@@ -790,17 +781,14 @@ fn conv3d_1x1_impl<T: bytemuck::Pod + Clone + Copy + burn_backend::Element + Sen
     )
 }
 
-conv3d_1x1_typed!(conv3d_1x1_f32, f32, DType::F32, 0.0f32, 1.0f32, |a, b| a
-    + b);
-conv3d_1x1_typed!(conv3d_1x1_f64, f64, DType::F64, 0.0f64, 1.0f64, |a, b| a
-    + b);
+conv3d_1x1_typed!(conv3d_1x1_f32, f32, DType::F32, 0.0f32, 1.0f32);
+conv3d_1x1_typed!(conv3d_1x1_f64, f64, DType::F64, 0.0f64, 1.0f64);
 conv3d_1x1_typed!(
     conv3d_1x1_f16,
     f16,
     DType::F16,
     f16::from_f32(0.0),
-    f16::from_f32(1.0),
-    |a: f16, b: f16| f16::from_f32(a.to_f32() + b.to_f32())
+    f16::from_f32(1.0)
 );
 
 // ============================================================================
@@ -1030,8 +1018,8 @@ fn conv_plane_accumulate_oh_outer<T: num_traits::Float + Copy>(
                     let run_len = ow_end - ow_start;
                     let in_slice = &in_row[iw_start..iw_start + run_len];
                     let out_slice = &mut out_row[ow_start..ow_end];
-                    for (o, &xv) in out_slice.iter_mut().zip(in_slice.iter()) {
-                        *o = *o + w_val * xv;
+                    for i in 0..run_len {
+                        out_slice[i] = in_slice[i] * w_val + out_slice[i];
                     }
                 } else {
                     let mut iw = iw_start;
@@ -1140,7 +1128,14 @@ fn conv3d_depthwise_impl<T>(
     dtype: DType,
 ) -> FlexTensor
 where
-    T: num_traits::Float + bytemuck::Pod + Clone + Copy + burn_backend::Element + Send + Sync,
+    T: num_traits::Float
+        + bytemuck::Pod
+        + Clone
+        + Copy
+        + burn_backend::Element
+        + burn_backend::ElementAdd
+        + Send
+        + Sync,
 {
     let zero = <T as num_traits::Zero>::zero();
     let x = x.to_contiguous();
@@ -1243,14 +1238,7 @@ where
             "conv depthwise: bias length ({}) must equal channels ({channels})",
             bias_data.len()
         );
-        add_bias(
-            &mut output,
-            bias_data,
-            batch_size,
-            channels,
-            out_spatial,
-            |a, b| a + b,
-        );
+        add_bias(&mut output, bias_data, batch_size, channels, out_spatial);
     }
 
     let out_shape = Shape::from(vec![batch_size, channels, 1, out_h, out_w]);
@@ -1362,7 +1350,14 @@ fn conv3d_small_channel_impl<T>(
     dtype: DType,
 ) -> FlexTensor
 where
-    T: num_traits::Float + bytemuck::Pod + Clone + Copy + burn_backend::Element + Send + Sync,
+    T: num_traits::Float
+        + bytemuck::Pod
+        + Clone
+        + Copy
+        + burn_backend::Element
+        + burn_backend::ElementAdd
+        + Send
+        + Sync,
 {
     let zero = <T as num_traits::Zero>::zero();
     let x = x.to_contiguous();
@@ -1481,7 +1476,6 @@ where
             batch_size,
             channels_out,
             out_spatial,
-            |a, b| a + b,
         );
     }
 
@@ -1531,34 +1525,20 @@ fn should_use_direct_conv(x_shape: &[usize], w_shape: &[usize], options: &ConvOp
 }
 
 macro_rules! conv3d_direct_typed {
-    ($fn_name:ident, $T:ty, $dtype:expr, $zero:expr, $one:expr, $add_fn:expr) => {
+    ($fn_name:ident, $T:ty, $dtype:expr, $zero:expr, $one:expr) => {
         fn $fn_name(
             x: FlexTensor,
             weight: FlexTensor,
             bias: Option<FlexTensor>,
             options: &ConvOptions<3>,
         ) -> FlexTensor {
-            conv3d_direct_impl::<$T>(x, weight, bias, options, $dtype, $zero, $one, $add_fn)
+            conv3d_direct_impl::<$T>(x, weight, bias, options, $dtype, $zero, $one)
         }
     };
 }
 
-conv3d_direct_typed!(
-    conv3d_direct_f32,
-    f32,
-    DType::F32,
-    0.0f32,
-    1.0f32,
-    |a, b| a + b
-);
-conv3d_direct_typed!(
-    conv3d_direct_f64,
-    f64,
-    DType::F64,
-    0.0f64,
-    1.0f64,
-    |a, b| a + b
-);
+conv3d_direct_typed!(conv3d_direct_f32, f32, DType::F32, 0.0f32, 1.0f32);
+conv3d_direct_typed!(conv3d_direct_f64, f64, DType::F64, 0.0f64, 1.0f64);
 
 /// Direct conv3d: decompose into kw gemm calls on NCHW data directly.
 ///
@@ -1572,7 +1552,9 @@ conv3d_direct_typed!(
 ///
 /// Constraints: groups=1, padding=0, dilation=1, 1D-like (d=1, h=1).
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
-fn conv3d_direct_impl<T: bytemuck::Pod + Clone + Copy + burn_backend::Element + Send + Sync>(
+fn conv3d_direct_impl<
+    T: bytemuck::Pod + Clone + Copy + burn_backend::Element + burn_backend::ElementAdd + Send + Sync,
+>(
     x: FlexTensor,
     weight: FlexTensor,
     bias: Option<FlexTensor>,
@@ -1580,7 +1562,6 @@ fn conv3d_direct_impl<T: bytemuck::Pod + Clone + Copy + burn_backend::Element + 
     dtype: DType,
     zero: T,
     one: T,
-    add_fn: fn(T, T) -> T,
 ) -> FlexTensor {
     let x = x.to_contiguous();
     let weight = weight.to_contiguous();
@@ -1706,14 +1687,7 @@ fn conv3d_direct_impl<T: bytemuck::Pod + Clone + Copy + burn_backend::Element + 
     if let Some(bias) = bias {
         let bias = bias.to_contiguous();
         let bias_data: &[T] = bias.storage();
-        add_bias(
-            &mut output,
-            bias_data,
-            batch_size,
-            channels_out,
-            out_w,
-            add_fn,
-        );
+        add_bias(&mut output, bias_data, batch_size, channels_out, out_w);
     }
 
     let out_shape = Shape::from(vec![batch_size, channels_out, 1, 1, out_w]);

--- a/crates/burn-flex/src/ops/conv.rs
+++ b/crates/burn-flex/src/ops/conv.rs
@@ -916,7 +916,7 @@ const CONV_PLANE_OH_OUTER_THRESHOLD: usize = 8192;
 /// themselves stay `inline(always)` so LLVM sees the concrete inner loop
 /// pattern and emits SIMD fmuladd. Using `num_traits::Float` bounds (rather
 /// than fn-pointer arithmetic) is load-bearing for vectorization.
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::extra_unused_type_parameters)]
 #[cfg_attr(feature = "simd", macerator::with_simd)]
 fn conv_plane_accumulate<
     #[cfg(feature = "simd")] S: macerator::Simd,

--- a/crates/burn-flex/src/ops/conv.rs
+++ b/crates/burn-flex/src/ops/conv.rs
@@ -1019,7 +1019,10 @@ fn conv_plane_accumulate_oh_outer<T: num_traits::Float + Copy>(
                     let in_slice = &in_row[iw_start..iw_start + run_len];
                     let out_slice = &mut out_row[ow_start..ow_end];
                     for i in 0..run_len {
-                        out_slice[i] = in_slice[i] * w_val + out_slice[i];
+                        unsafe {
+                            *out_slice.get_unchecked_mut(i) =
+                                *in_slice.get_unchecked(i) * w_val + *out_slice.get_unchecked(i);
+                        }
                     }
                 } else {
                     let mut iw = iw_start;
@@ -1077,8 +1080,11 @@ fn conv_plane_accumulate_kh_outer<T: num_traits::Float + Copy>(
                 if stride_w == 1 {
                     let in_slice = &in_row[iw_start..iw_start + run_len];
                     let out_slice = &mut out_row[ow_start..ow_end];
-                    for (o, &xv) in out_slice.iter_mut().zip(in_slice.iter()) {
-                        *o = *o + w_val * xv;
+                    for i in 0..run_len {
+                        unsafe {
+                            *out_slice.get_unchecked_mut(i) =
+                                *in_slice.get_unchecked(i) * w_val + *out_slice.get_unchecked(i);
+                        }
                     }
                 } else {
                     let mut iw = iw_start;

--- a/crates/burn-flex/src/ops/conv.rs
+++ b/crates/burn-flex/src/ops/conv.rs
@@ -916,9 +916,12 @@ const CONV_PLANE_OH_OUTER_THRESHOLD: usize = 8192;
 /// themselves stay `inline(always)` so LLVM sees the concrete inner loop
 /// pattern and emits SIMD fmuladd. Using `num_traits::Float` bounds (rather
 /// than fn-pointer arithmetic) is load-bearing for vectorization.
-#[inline]
 #[allow(clippy::too_many_arguments)]
-fn conv_plane_accumulate<T: num_traits::Float + Copy>(
+#[cfg_attr(feature = "simd", macerator::with_simd)]
+fn conv_plane_accumulate<
+    #[cfg(feature = "simd")] S: macerator::Simd,
+    T: num_traits::Float + Copy,
+>(
     out_plane: &mut [T],
     in_plane: &[T],
     w_plane: &[T],
@@ -1027,7 +1030,7 @@ fn conv_plane_accumulate_oh_outer<T: num_traits::Float + Copy>(
                 } else {
                     let mut iw = iw_start;
                     for o in &mut out_row[ow_start..ow_end] {
-                        *o = *o + w_val * in_row[iw];
+                        *o = *o + w_val * unsafe { *in_row.get_unchecked(iw) };
                         iw += stride_w;
                     }
                 }
@@ -1089,7 +1092,7 @@ fn conv_plane_accumulate_kh_outer<T: num_traits::Float + Copy>(
                 } else {
                     let mut iw = iw_start;
                     for o in &mut out_row[ow_start..ow_end] {
-                        *o = *o + w_val * in_row[iw];
+                        *o = *o + w_val * unsafe { *in_row.get_unchecked(iw) };
                         iw += stride_w;
                     }
                 }

--- a/crates/burn-flex/src/ops/conv_common.rs
+++ b/crates/burn-flex/src/ops/conv_common.rs
@@ -89,7 +89,8 @@ pub(crate) fn convert_f32_to_bf16(tensor: &FlexTensor) -> FlexTensor {
 // ============================================================================
 
 #[allow(clippy::needless_range_loop)]
-pub(crate) fn add_bias<T: Element + ElementAdd>(
+#[cfg_attr(feature = "simd", macerator::with_simd)]
+pub(crate) fn add_bias<#[cfg(feature = "simd")] S: macerator::Simd, T: Element + ElementAdd>(
     output: &mut [T],
     bias: &[T],
     batch: usize,

--- a/crates/burn-flex/src/ops/conv_common.rs
+++ b/crates/burn-flex/src/ops/conv_common.rs
@@ -1,10 +1,9 @@
 //! Shared macros and helpers for forward and transposed convolution.
 
+use crate::{FlexTensor, Layout};
 use alloc::vec::Vec;
 use burn_backend::DType;
-use burn_std::{Bytes, Shape, bf16};
-
-use crate::{FlexTensor, Layout};
+use burn_std::{Bytes, Element, ElementAdd, Shape, bf16};
 
 // ============================================================================
 // Macros for dtype wrappers
@@ -90,20 +89,19 @@ pub(crate) fn convert_f32_to_bf16(tensor: &FlexTensor) -> FlexTensor {
 // ============================================================================
 
 #[allow(clippy::needless_range_loop)]
-pub(crate) fn add_bias<T: Copy>(
+pub(crate) fn add_bias<T: Element + ElementAdd>(
     output: &mut [T],
     bias: &[T],
     batch: usize,
     channels: usize,
     spatial: usize,
-    add_fn: fn(T, T) -> T,
 ) {
     for b in 0..batch {
         for c in 0..channels {
             let offset = b * channels * spatial + c * spatial;
             let bias_val = bias[c];
             for i in 0..spatial {
-                output[offset + i] = add_fn(output[offset + i], bias_val);
+                output[offset + i] = T::add(output[offset + i], bias_val);
             }
         }
     }

--- a/crates/burn-flex/src/ops/conv_common.rs
+++ b/crates/burn-flex/src/ops/conv_common.rs
@@ -88,7 +88,7 @@ pub(crate) fn convert_f32_to_bf16(tensor: &FlexTensor) -> FlexTensor {
 // Bias addition
 // ============================================================================
 
-#[allow(clippy::needless_range_loop)]
+#[allow(clippy::needless_range_loop, clippy::extra_unused_type_parameters)]
 #[cfg_attr(feature = "simd", macerator::with_simd)]
 pub(crate) fn add_bias<#[cfg(feature = "simd")] S: macerator::Simd, T: Element + ElementAdd>(
     output: &mut [T],

--- a/crates/burn-flex/src/ops/conv_transpose.rs
+++ b/crates/burn-flex/src/ops/conv_transpose.rs
@@ -197,7 +197,9 @@ type ConvTransposeGemmFn<T> = fn(&mut [T], &[T], &[T], usize, usize, usize);
 
 /// 3D transposed convolution via GEMM + col2im.
 #[allow(clippy::too_many_arguments)]
-fn conv_transpose3d_impl<T: bytemuck::Pod + Clone + Copy + Send + Sync + burn_backend::Element>(
+fn conv_transpose3d_impl<
+    T: bytemuck::Pod + Clone + Copy + Send + Sync + burn_backend::Element + burn_backend::ElementAdd,
+>(
     x: FlexTensor,
     weight: FlexTensor,
     bias: Option<FlexTensor>,
@@ -359,7 +361,6 @@ fn conv_transpose3d_impl<T: bytemuck::Pod + Clone + Copy + Send + Sync + burn_ba
             batch_size,
             out_channels,
             out_spatial,
-            add_fn,
         );
     }
 

--- a/crates/burn-std/src/element/base.rs
+++ b/crates/burn-std/src/element/base.rs
@@ -91,6 +91,12 @@ pub trait ElementLimits {
     const MAX: Self;
 }
 
+/// Element addition trait.
+pub trait ElementAdd {
+    /// Addition between `self` and `other`.
+    fn add(self, other: Self) -> Self;
+}
+
 /// Macro to implement the element trait for a type.
 #[macro_export]
 macro_rules! make_element {
@@ -99,9 +105,29 @@ macro_rules! make_element {
         convert $convert:expr,
         random $random:expr,
         cmp $cmp:expr,
+        add $add:expr,
         dtype $dtype:expr
     ) => {
-        make_element!(ty $type, convert $convert, random $random, cmp $cmp, dtype $dtype, min $type::MIN, max $type::MAX);
+        make_element!(ty $type, convert $convert, random $random, cmp $cmp, add $add, dtype $dtype, min $type::MIN, max $type::MAX);
+    };
+        (
+        ty $type:ident,
+        convert $convert:expr,
+        random $random:expr,
+        cmp $cmp:expr,
+        add $add:expr,
+        dtype $dtype:expr,
+        min $min:expr,
+        max $max:expr
+    ) => {
+        make_element!(ty $type, convert $convert, random $random, cmp $cmp, dtype $dtype, min $min, max $max);
+
+        impl ElementAdd for $type {
+            #[inline(always)]
+            fn add(self, other: Self) -> Self {
+                $add(self, other)
+            }
+        }
     };
     (
         ty $type:ident,
@@ -167,6 +193,7 @@ make_element!(
     convert ToElement::to_f64,
     random |distribution: Distribution, rng: &mut R| distribution.sampler(rng).sample(),
     cmp |a: &f64, b: &f64| a.total_cmp(b),
+    add |a, b| a + b,
     dtype DType::F64
 );
 
@@ -175,6 +202,7 @@ make_element!(
     convert ToElement::to_f32,
     random |distribution: Distribution, rng: &mut R| distribution.sampler(rng).sample(),
     cmp |a: &f32, b: &f32| a.total_cmp(b),
+    add |a, b| a + b,
     dtype DType::F32
 );
 
@@ -183,6 +211,7 @@ make_element!(
     convert ToElement::to_i64,
     random |distribution: Distribution, rng: &mut R| distribution.sampler(rng).sample(),
     cmp |a: &i64, b: &i64| Ord::cmp(a, b),
+    add |a, b| a + b,
     dtype DType::I64
 );
 
@@ -191,6 +220,7 @@ make_element!(
     convert ToElement::to_u64,
     random |distribution: Distribution, rng: &mut R| distribution.sampler(rng).sample(),
     cmp |a: &u64, b: &u64| Ord::cmp(a, b),
+    add |a, b| a + b,
     dtype DType::U64
 );
 
@@ -199,6 +229,7 @@ make_element!(
     convert ToElement::to_i32,
     random |distribution: Distribution, rng: &mut R| distribution.sampler(rng).sample(),
     cmp |a: &i32, b: &i32| Ord::cmp(a, b),
+    add |a, b| a + b,
     dtype DType::I32
 );
 
@@ -207,6 +238,7 @@ make_element!(
     convert ToElement::to_u32,
     random |distribution: Distribution, rng: &mut R| distribution.sampler(rng).sample(),
     cmp |a: &u32, b: &u32| Ord::cmp(a, b),
+    add |a, b| a + b,
     dtype DType::U32
 );
 
@@ -215,6 +247,7 @@ make_element!(
     convert ToElement::to_i16,
     random |distribution: Distribution, rng: &mut R| distribution.sampler(rng).sample(),
     cmp |a: &i16, b: &i16| Ord::cmp(a, b),
+    add |a, b| a + b,
     dtype DType::I16
 );
 
@@ -223,6 +256,7 @@ make_element!(
     convert ToElement::to_u16,
     random |distribution: Distribution, rng: &mut R| distribution.sampler(rng).sample(),
     cmp |a: &u16, b: &u16| Ord::cmp(a, b),
+    add |a, b| a + b,
     dtype DType::U16
 );
 
@@ -231,6 +265,7 @@ make_element!(
     convert ToElement::to_i8,
     random |distribution: Distribution, rng: &mut R| distribution.sampler(rng).sample(),
     cmp |a: &i8, b: &i8| Ord::cmp(a, b),
+    add |a, b| a + b,
     dtype DType::I8
 );
 
@@ -239,6 +274,7 @@ make_element!(
     convert ToElement::to_u8,
     random |distribution: Distribution, rng: &mut R| distribution.sampler(rng).sample(),
     cmp |a: &u8, b: &u8| Ord::cmp(a, b),
+    add |a, b| a + b,
     dtype DType::U8
 );
 
@@ -250,6 +286,7 @@ make_element!(
         f16::from_elem(sample)
     },
     cmp |a: &f16, b: &f16| a.total_cmp(b),
+    add |a: f16, b: f16| f16::from_f32(a.to_f32() + b.to_f32()),
     dtype DType::F16
 );
 make_element!(
@@ -260,6 +297,7 @@ make_element!(
         bf16::from_elem(sample)
     },
     cmp |a: &bf16, b: &bf16| a.total_cmp(b),
+    add |a, b| a + b,
     dtype DType::BF16
 );
 
@@ -271,6 +309,7 @@ make_element!(
         flex32::from_elem(sample)
     },
     cmp |a: &flex32, b: &flex32| a.total_cmp(b),
+    add |a: flex32, b: flex32| flex32::from_f32(a.to_f32() + b.to_f32()),
     dtype DType::Flex32,
     min flex32::from_f32(f16::MIN.to_f32_const()),
     max flex32::from_f32(f16::MAX.to_f32_const())


### PR DESCRIPTION
30-40% small convolution speedup!

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [ ] ~~Made sure the book is up to date with changes in this PR.~~

### Related Issues/PRs

None

### Changes

- Optimized bias_add: Added a Element-trait for addition, ElementAdd, which allows spezializing addition for some Elements without passing a function pointer through, like bias_add did previously. This change has allowed bias_add to complete disappear from my benchmark, relative to the convolutional layer.

- improved `conv_plane_accumulate` used in `conv3d_depthwise_impl` and `conv3d_small_channel_impl` by switching away from a iterator and to a range loop with unchecked indexing.

### Testing

- by running the model used in my project over it
- by running `cargo run-checks`, which showed one strange failure in f16::linalg::qr::test_qr_medium_tall even tho i can't think of anything i did affecting that.
- by running convolution benchmarks
