### PR TITLE
fix(tensor-data): convert to bool stores by truthiness

### DIFF
--- a/crates/burn-std/src/data/tensor.rs
+++ b/crates/burn-std/src/data/tensor.rs
@@ -520,17 +520,32 @@ impl TensorData {
             DType::U32 => self.convert_inplace::<Current, u32>(),
             DType::U16 => self.convert_inplace::<Current, u16>(),
             DType::U8 => self.convert_inplace::<Current, u8>(),
-            DType::Bool(BoolStore::U8) => self.convert_inplace::<Current, u8>().into_bool_u8(),
-            DType::Bool(BoolStore::U32) => self.convert_inplace::<Current, u32>().into_bool_u32(),
+            DType::Bool(BoolStore::U8) => self.convert_inplace_bool::<Current, u8>().into_bool_u8(),
+            DType::Bool(BoolStore::U32) => {
+                self.convert_inplace_bool::<Current, u32>().into_bool_u32()
+            }
             DType::Bool(BoolStore::Native) | DType::QFloat(_) => unreachable!(),
         }
     }
 
     fn convert_inplace<Current: Element + AnyBitPattern, Target: Element + AnyBitPattern>(
+        self,
+    ) -> Self {
+        self.convert_inplace_with::<Current, Target>(|x| x.elem())
+    }
+
+    fn convert_inplace_bool<Current: Element + AnyBitPattern, Target: Element + AnyBitPattern>(
+        self,
+    ) -> Self {
+        self.convert_inplace_with::<Current, Target>(|x| x.to_bool().elem())
+    }
+
+    fn convert_inplace_with<Current: Element + AnyBitPattern, Target: Element + AnyBitPattern>(
         mut self,
+        transform: impl Fn(&Current) -> Target,
     ) -> Self {
         for x in bytemuck::cast_slice_mut::<_, Current>(&mut self.bytes) {
-            let t: Target = x.elem();
+            let t = transform(x);
             let x = cast_mut::<_, Target>(x);
             *x = t;
         }
@@ -555,8 +570,10 @@ impl TensorData {
             DType::U16 => self.convert_clone::<Current, u16>(),
             DType::U8 => self.convert_clone::<Current, u8>(),
             DType::Bool(BoolStore::Native) => self.convert_clone::<Current, bool>(),
-            DType::Bool(BoolStore::U8) => self.convert_clone::<Current, u8>().into_bool_u8(),
-            DType::Bool(BoolStore::U32) => self.convert_clone::<Current, u32>().into_bool_u32(),
+            DType::Bool(BoolStore::U8) => self.convert_clone_bool::<Current, u8>().into_bool_u8(),
+            DType::Bool(BoolStore::U32) => {
+                self.convert_clone_bool::<Current, u32>().into_bool_u32()
+            }
             DType::QFloat(_) => unreachable!(),
         }
     }
@@ -564,11 +581,24 @@ impl TensorData {
     fn convert_clone<Current: Element + CheckedBitPattern, Target: Element + Zeroable>(
         self,
     ) -> Self {
+        self.convert_clone_with::<Current, Target>(|x| x.elem())
+    }
+
+    fn convert_clone_bool<Current: Element + CheckedBitPattern, Target: Element + Zeroable>(
+        self,
+    ) -> Self {
+        self.convert_clone_with::<Current, Target>(|x| x.to_bool().elem())
+    }
+
+    fn convert_clone_with<Current: Element + CheckedBitPattern, Target: Element + Zeroable>(
+        self,
+        transform: impl Fn(&Current) -> Target,
+    ) -> Self {
         let this = bytemuck::checked::cast_slice::<_, Current>(&self.bytes);
         let mut out: Vec<Target> = ::alloc::vec![Zeroable::zeroed(); self.num_elements()];
 
         for (x, out) in this.iter().zip(&mut out) {
-            *out = x.elem();
+            *out = transform(x);
         }
 
         Self::new(out, self.shape)
@@ -858,6 +888,21 @@ mod tests {
         test_precision::<f16>();
         test_precision::<i64>();
         test_precision::<i32>();
+    }
+
+    #[test]
+    fn should_convert_negative_values_to_bool_store() {
+        for store in [BoolStore::U8, BoolStore::U32, BoolStore::Native] {
+            let data = TensorData::from([-1i32, 0, 1, -12]).convert_dtype(DType::Bool(store));
+            assert_eq!(data.dtype, DType::Bool(store));
+            assert_eq!(
+                data.iter::<bool>().collect::<Vec<_>>(),
+                [true, false, true, true]
+            );
+
+            let data = TensorData::from([-1.5f32, 0.0, 0.5]).convert_dtype(DType::Bool(store));
+            assert_eq!(data.iter::<bool>().collect::<Vec<_>>(), [true, false, true]);
+        }
     }
 
     macro_rules! test_dtypes {


### PR DESCRIPTION
Converting numeric `TensorData` into a boolean tensor used the numeric `elem()` conversion for the `U8` and `U32` bool stores. That conversion is range checked, so a negative source value panicked with `Element cannot be represented in the target type: "i32"(-1) => "u32"`, and float sources were truncated so `0.5` became `false`. `NaN` panicked as well.

The `Native` store already converted through `to_bool`, which adopts C semantics (anything non zero is true), so the same conversion behaved differently depending on the backend's bool storage: `Bool(U32)` on WebGPU, `Bool(U8)` on CUDA/Metal/Vulkan, `Bool(Native)` elsewhere. Identical user code panicked on one backend and worked on another.

This routes the bool store targets through `to_bool` too, for both the in place and clone conversion paths, so values are converted by truthiness and normalized to 0/1 (the canonical `true_val`/`false_val` form). Numeric targets are untouched: `i32 -> u32` still range checks and panics as documented.

Added `should_convert_negative_values_to_bool_store` covering int and float sources across the three stores.