### PR TITLE
fix(fusion): decline to fuse unsupported quant scale params

### DIFF
--- a/crates/burn-cubecl-fusion/src/engine/codegen/ir.rs
+++ b/crates/burn-cubecl-fusion/src/engine/codegen/ir.rs
@@ -918,6 +918,30 @@ impl FuseType {
         }
     }
 
+    /// The type quantized values are read as, or `None` when fusion can't read that scheme.
+    ///
+    /// Same contract as [Self::from_quant_param]: callers must decline to fuse on `None`.
+    pub fn from_quant_scheme(scheme: QuantScheme) -> Option<Self> {
+        match scheme.store {
+            QuantStore::Native => match scheme.value {
+                QuantValue::Q8F | QuantValue::Q8S => Some(Self::I8),
+                QuantValue::E4M3 | QuantValue::E5M2 => None,
+                QuantValue::Q4F
+                | QuantValue::Q4S
+                | QuantValue::Q2F
+                | QuantValue::Q2S
+                | QuantValue::E2M1 => {
+                    panic!("Can't store native sub-byte values")
+                }
+            },
+            QuantStore::PackedU32(_) => Some(Self::U32),
+            QuantStore::PackedNative(_) => match scheme.value {
+                QuantValue::E2M1 => None,
+                other => panic!("{other:?} doesn't support native packing"),
+            },
+        }
+    }
+
     /// Converts the [fused element type](FuseType) into the [cubecl element type](ElemType).
     pub fn into_elem(self) -> ElemType {
         match self {
@@ -967,26 +991,8 @@ impl From<DType> for FuseType {
             DType::Bool(BoolStore::U8) => Self::U8,
             DType::Bool(BoolStore::U32) => Self::U32,
             DType::F64 => Self::F64,
-            DType::QFloat(scheme) => match scheme.store {
-                QuantStore::Native => match scheme.value {
-                    QuantValue::Q8F | QuantValue::Q8S => Self::I8,
-                    QuantValue::E4M3 | QuantValue::E5M2 => {
-                        unimplemented!("Unsupported precision for fusion")
-                    }
-                    QuantValue::Q4F
-                    | QuantValue::Q4S
-                    | QuantValue::Q2F
-                    | QuantValue::Q2S
-                    | QuantValue::E2M1 => {
-                        panic!("Can't store native sub-byte values")
-                    }
-                },
-                QuantStore::PackedU32(_) => Self::U32,
-                QuantStore::PackedNative(_) => match scheme.value {
-                    QuantValue::E2M1 => unimplemented!("Unsupported precision for fusion"),
-                    other => panic!("{other:?} doesn't support native packing"),
-                },
-            },
+            DType::QFloat(scheme) => Self::from_quant_scheme(scheme)
+                .unwrap_or_else(|| unimplemented!("Unsupported precision for fusion")),
         }
     }
 }

--- a/crates/burn-cubecl-fusion/src/engine/codegen/ir.rs
+++ b/crates/burn-cubecl-fusion/src/engine/codegen/ir.rs
@@ -2,7 +2,7 @@ use super::tensor::GlobalTensor;
 use crate::engine::codegen::{DynElem, DynSize, DynVector};
 use burn_std::{
     BoolStore, DType, Shape, Strides, bf16, f16,
-    quantization::{QuantScheme, QuantStore, QuantValue},
+    quantization::{QuantParam, QuantScheme, QuantStore, QuantValue},
     strides,
 };
 use core::fmt::Display;
@@ -905,6 +905,19 @@ impl From<StorageType> for FuseType {
 }
 
 impl FuseType {
+    /// The type quantization scales are read as, or `None` when fusion can't read that param.
+    ///
+    /// Callers must decline to fuse on `None` rather than fail: an unsupported param is only a
+    /// missing feature here, and the unfused path still handles it.
+    pub fn from_quant_param(param: QuantParam) -> Option<Self> {
+        match param {
+            QuantParam::F32 => Some(Self::F32),
+            QuantParam::F16 => Some(Self::F16),
+            QuantParam::BF16 => Some(Self::BF16),
+            QuantParam::UE8M0 | QuantParam::UE4M3 => None,
+        }
+    }
+
     /// Converts the [fused element type](FuseType) into the [cubecl element type](ElemType).
     pub fn into_elem(self) -> ElemType {
         match self {

--- a/crates/burn-cubecl-fusion/src/engine/trace/block.rs
+++ b/crates/burn-cubecl-fusion/src/engine/trace/block.rs
@@ -4,7 +4,7 @@ use crate::engine::{
     settings::FuseSettings,
 };
 use burn_ir::{TensorId, TensorIr, TensorStatus};
-use burn_std::{DType, Shape, quantization::QuantParam};
+use burn_std::{DType, Shape};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, btree_map::Entry};
 
@@ -218,14 +218,7 @@ impl FuseBlockBuilder {
 
         let precision = tensor.dtype.into();
         let precision_scales = match tensor.dtype {
-            DType::QFloat(scheme) => match scheme.param {
-                QuantParam::F32 => FuseType::F32,
-                QuantParam::F16 => FuseType::F16,
-                QuantParam::BF16 => FuseType::BF16,
-                QuantParam::UE8M0 | QuantParam::UE4M3 => {
-                    unimplemented!("Unsupported fuse precision");
-                }
-            },
+            DType::QFloat(scheme) => FuseType::from_quant_param(scheme.param)?,
             _ => return None,
         };
 

--- a/crates/burn-cubecl-fusion/src/engine/trace/block.rs
+++ b/crates/burn-cubecl-fusion/src/engine/trace/block.rs
@@ -216,9 +216,11 @@ impl FuseBlockBuilder {
             return None;
         }
 
-        let precision = tensor.dtype.into();
-        let precision_scales = match tensor.dtype {
-            DType::QFloat(scheme) => FuseType::from_quant_param(scheme.param)?,
+        let (precision, precision_scales) = match tensor.dtype {
+            DType::QFloat(scheme) => (
+                FuseType::from_quant_scheme(scheme)?,
+                FuseType::from_quant_param(scheme.param)?,
+            ),
             _ => return None,
         };
 

--- a/crates/burn-cubecl-fusion/src/engine/trace/fuser.rs
+++ b/crates/burn-cubecl-fusion/src/engine/trace/fuser.rs
@@ -189,9 +189,11 @@ impl TraceFuser {
             panic!("Can't add a new input that is already used in an index operation");
         }
 
-        let precision = tensor.dtype.into();
-        let precision_scales = match tensor.dtype {
-            DType::QFloat(scheme) => FuseType::from_quant_param(scheme.param)?,
+        let (precision, precision_scales) = match tensor.dtype {
+            DType::QFloat(scheme) => (
+                FuseType::from_quant_scheme(scheme)?,
+                FuseType::from_quant_param(scheme.param)?,
+            ),
             _ => return None,
         };
 

--- a/crates/burn-cubecl-fusion/src/engine/trace/fuser.rs
+++ b/crates/burn-cubecl-fusion/src/engine/trace/fuser.rs
@@ -11,7 +11,6 @@ use crate::engine::trace::{TensorView, block::QuantInput};
 use burn_fusion::stream::ScalarId;
 use burn_ir::{ScalarIr, TensorIr};
 use burn_std::{DType, Shape};
-use cubecl::quant::scheme::QuantParam;
 
 #[derive(Clone, Debug)]
 /// It is responsible to create a [trace](FuseTrace) composed of multiple [blocks](super::block::FuseBlock).
@@ -189,20 +188,14 @@ impl TraceFuser {
         if self.resources.indexed.contains_key(&tensor.id) {
             panic!("Can't add a new input that is already used in an index operation");
         }
-        self.resources.outputs.update(tensor);
 
         let precision = tensor.dtype.into();
         let precision_scales = match tensor.dtype {
-            DType::QFloat(scheme) => match scheme.param {
-                QuantParam::F32 => FuseType::F32,
-                QuantParam::F16 => FuseType::F16,
-                QuantParam::BF16 => FuseType::BF16,
-                QuantParam::UE8M0 | QuantParam::UE4M3 => {
-                    unimplemented!("Unsupported fuse precision");
-                }
-            },
+            DType::QFloat(scheme) => FuseType::from_quant_param(scheme.param)?,
             _ => return None,
         };
+
+        self.resources.outputs.update(tensor);
 
         let (new_input, q_index) = self.resources.inputs.insert_quant(tensor.clone());
         let input = FuseArg::Input(new_input, precision, LayoutInfo::Unknown);

--- a/crates/burn-cubecl-fusion/src/optim/matmul/fuser.rs
+++ b/crates/burn-cubecl-fusion/src/optim/matmul/fuser.rs
@@ -5,7 +5,7 @@ use crate::{
     optim::matmul::args::MatmulArg,
 };
 use burn_fusion::{FuserStatus, OperationFuser};
-use burn_ir::{FloatOperationIr, OperationIr};
+use burn_ir::{FloatOperationIr, OperationIr, TensorIr};
 use burn_std::DType;
 use cubecl::Runtime;
 
@@ -46,6 +46,22 @@ impl<R: Runtime> MatmulFuser<R> {
             matmul: None,
         }
     }
+
+    /// Register a matmul operand, or return `None` when it can't be read by a fused kernel.
+    fn matmul_arg(&mut self, tensor: &TensorIr, out: DType) -> Option<MatmulArg> {
+        match tensor.dtype {
+            DType::QFloat(scheme) => {
+                let (data, scales) = self.fuser.input_quantized_unhandled(tensor)?;
+                Some(MatmulArg::Quantized {
+                    data,
+                    scales,
+                    precision: out.into(),
+                    scheme,
+                })
+            }
+            _ => Some(MatmulArg::Normal(self.fuser.input_unhandled(tensor))),
+        }
+    }
 }
 
 impl<R: Runtime> OperationFuser<CubeOptimization<R>> for MatmulFuser<R> {
@@ -57,40 +73,26 @@ impl<R: Runtime> OperationFuser<CubeOptimization<R>> for MatmulFuser<R> {
         if self.matmul.is_none() {
             if let OperationIr::Float(_, FloatOperationIr::Matmul(op)) = operation {
                 // Precision shouldn't be hardcoded but I don't know how to get float precision of the backend
-                let lhs = match op.lhs.dtype {
-                    DType::QFloat(scheme) => {
-                        let (data, scales) = self.fuser.input_quantized_unhandled(&op.lhs).unwrap();
-                        MatmulArg::Quantized {
-                            data,
-                            scales,
-                            precision: op.out.dtype.into(),
-                            scheme,
-                        }
-                    }
-                    _ => MatmulArg::Normal(self.fuser.input_unhandled(&op.lhs)),
-                };
-                let rhs = match op.rhs.dtype {
-                    DType::QFloat(scheme) => {
-                        let (data, scales) = self.fuser.input_quantized_unhandled(&op.rhs).unwrap();
-                        MatmulArg::Quantized {
-                            data,
-                            scales,
-                            precision: op.out.dtype.into(),
-                            scheme,
-                        }
-                    }
-                    _ => MatmulArg::Normal(self.fuser.input_unhandled(&op.rhs)),
-                };
+                let lhs = self.matmul_arg(&op.lhs, op.out.dtype);
+                let rhs = self.matmul_arg(&op.rhs, op.out.dtype);
 
-                let out = self.fuser.output_unhandled(&op.out);
+                match (lhs, rhs) {
+                    (Some(lhs), Some(rhs)) => {
+                        let out = self.fuser.output_unhandled(&op.out);
 
-                self.matmul = Some(FusedMatmul::new(
-                    lhs,
-                    rhs,
-                    out,
-                    op.clone().into(),
-                    Default::default(),
-                ));
+                        self.matmul = Some(FusedMatmul::new(
+                            lhs,
+                            rhs,
+                            out,
+                            op.clone().into(),
+                            Default::default(),
+                        ));
+                    }
+                    _ => {
+                        self.fuser.close();
+                        self.fuser_fallback.close();
+                    }
+                }
             } else {
                 self.fuser.close();
                 self.fuser_fallback.close();


### PR DESCRIPTION
Fixes the deterministic half of #5270.

## Problem

Any `Fusion<CubeBackend>` device panics when it reads a quantized tensor whose scales are `UE4M3` or `UE8M0`:

```
CallError(task panicked on device runner thread: not implemented: Unsupported fuse precision)
```

`QuantParam::UE4M3` became reachable in #5253, and the two accuracy tests it added hit this on every run on CUDA and Vulkan. The unfused path handles the scheme, so the panic is the fusion trace refusing an input rather than a missing capability elsewhere.

## Fix

`FuseType::from_quant_param` returns `Option<FuseType>`, and the two trace entry points that read quantization scales propagate `None`. That is how the builders already report an input they cannot take (see the `indexed` and `QFloat` early returns next to them), so the operation is simply not fused and falls back to unfused execution. Any future param degrades the same way instead of aborting.

`MatmulFuser` was `unwrap`ing that `Option`. It now closes both fusers instead. Mixed operands are unaffected: a non-quantized operand still yields `Some(MatmulArg::Normal(..))`, so float x float, float x quant, quant x float and quant x quant all still fuse. `None` means only "quantized with a scale param fusion cannot read".

## Verification

CUDA, RTX 4070 Ti SUPER, `cargo test -p burn-backend-tests --features cuda --test tensor -- quantization`:

- the `Unsupported fuse precision` panic is gone in 8 consecutive runs
- `quantization::accuracy::narrow_scale_param_degrades_without_normalization` passes

Vulkan, `-- quantization --skip accuracy`: 24 passed, 0 failed. `burn-fusion` (80) and `burn-cubecl-fusion` (9) lib tests pass.

## What this does not fix

The other two groups in #5270 are not burn bugs, and both need upstream work:

- The flaky symmetric int8 failures are a failed kernel *compilation* recording an error on a pooled cubecl hardware stream, which unrelated burn streams then inherit through `stream_id.value % max_streams`. Fixed by tracel-ai/cubecl#1463; with that applied the flake goes from 3 of 4 runs to 0 of 16.
- `quantization::accuracy::error_responds_to_scale_param` still fails, because the cube path rounds scales to nearest rather than up, so #5261's fix is still missing its GPU half. The reported `block16/ue4m3 = 0.01452` and `block32/ue4m3 = 0.01144` are exactly the pre-#5261 numbers.

This makes fusion decline `UE4M3` scales permanently, so those dequantizations always run unfused. `FuseType` has no e4m3 variant, and adding one plus its codegen is a feature rather than part of this fix.