### PR TITLE
feat(backend): promote mask_select to a backend op with dispatch

### DIFF
--- a/crates/burn-autodiff/src/ops/bool_tensor.rs
+++ b/crates/burn-autodiff/src/ops/bool_tensor.rs
@@ -130,6 +130,13 @@ impl<B: Backend, C: CheckpointStrategy> BoolTensorOps<Self> for Autodiff<B, C> {
         B::bool_mask_fill(tensor, mask, value)
     }
 
+    async fn bool_mask_select(
+        tensor: BoolTensor<Self>,
+        mask: BoolTensor<Self>,
+    ) -> BoolTensor<Self> {
+        B::bool_mask_select(tensor, mask).await
+    }
+
     fn bool_gather(
         dim: usize,
         tensor: BoolTensor<Self>,

--- a/crates/burn-autodiff/src/ops/int_tensor.rs
+++ b/crates/burn-autodiff/src/ops/int_tensor.rs
@@ -257,6 +257,10 @@ impl<B: Backend, C: CheckpointStrategy> IntTensorOps<Self> for Autodiff<B, C> {
         B::int_mask_fill(tensor, mask, value)
     }
 
+    async fn int_mask_select(tensor: IntTensor<B>, mask: BoolTensor<B>) -> IntTensor<B> {
+        B::int_mask_select(tensor, mask).await
+    }
+
     fn int_argmax(tensor: IntTensor<B>, dim: usize) -> IntTensor<B> {
         B::int_argmax(tensor, dim)
     }

--- a/crates/burn-backend-tests/tests/autodiff/mask_select.rs
+++ b/crates/burn-backend-tests/tests/autodiff/mask_select.rs
@@ -48,3 +48,36 @@ fn test_mask_select_grad_empty_mask() {
         .into_data()
         .assert_eq(&TensorData::from([0.0, 0.0, 0.0]), false);
 }
+
+#[test]
+fn test_mask_select_int() {
+    // Int tensors are not differentiable; this covers the autodiff `int_mask_select`
+    // pass-through to the inner backend (only reachable on an autodiff device).
+    let device = AutodiffDevice::new();
+    let tensor = TestTensorInt::<2>::from_data(TensorData::from([[1, 2, 3], [4, 5, 6]]), &device);
+    let mask = TestTensorBool::<2>::from_data(
+        TensorData::from([[false, true, false], [true, false, true]]),
+        &device,
+    );
+
+    let output = tensor.mask_select(mask);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([2, 4, 6]), false);
+}
+
+#[test]
+fn test_mask_select_bool() {
+    // Bool tensors are not differentiable; this covers the autodiff `bool_mask_select`
+    // pass-through to the inner backend (only reachable on an autodiff device).
+    let device = AutodiffDevice::new();
+    let tensor = TestTensorBool::<1>::from_data(TensorData::from([true, false, true]), &device);
+    let mask = TestTensorBool::<1>::from_data(TensorData::from([true, true, false]), &device);
+
+    let output = tensor.mask_select(mask);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([true, false]), false);
+}

--- a/crates/burn-backend-tests/tests/tensor/float/quantization/ops/extended/mask.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/quantization/ops/extended/mask.rs
@@ -1,5 +1,6 @@
 use super::qtensor::*;
 use super::*;
+use burn_tensor::DType;
 use burn_tensor::TensorData;
 use burn_tensor::Tolerance;
 
@@ -36,4 +37,40 @@ fn should_support_mask_fill_ops() {
         .dequantize()
         .into_data()
         .assert_approx_eq::<FloatElem>(&expected, Tolerance::absolute(1e-1));
+}
+
+#[test]
+fn should_support_mask_select_ops() {
+    let tensor = QTensor::<2>::int8([[1.0, 7.0], [2.0, 3.0]]);
+    let mask = TestTensorBool::<2>::from_bool(
+        TensorData::from([[true, false], [false, true]]),
+        &Default::default(),
+    );
+
+    let output = tensor.mask_select(mask);
+    let expected = TensorData::from([1.0, 3.0]);
+
+    // `mask_select` only moves existing elements around, so it stays quantized instead of
+    // dequantizing like `mask_where` and `mask_fill` do.
+    assert!(matches!(output.to_data().dtype, DType::QFloat(_)));
+
+    output
+        .dequantize()
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, Tolerance::absolute(1e-1));
+}
+
+#[test]
+fn should_support_mask_select_ops_empty_mask() {
+    let tensor = QTensor::<2>::int8([[1.0, 7.0], [2.0, 3.0]]);
+    let mask = TestTensorBool::<2>::from_bool(
+        TensorData::from([[false, false], [false, false]]),
+        &Default::default(),
+    );
+
+    let output = tensor.mask_select(mask);
+
+    // Selecting nothing still has to keep the quantized kind, not fall back to a float tensor.
+    assert_eq!(output.dims(), [0]);
+    assert!(matches!(output.to_data().dtype, DType::QFloat(_)));
 }

--- a/crates/burn-backend/src/backend/ops/bool_tensor.rs
+++ b/crates/burn-backend/src/backend/ops/bool_tensor.rs
@@ -187,6 +187,38 @@ pub trait BoolTensorOps<B: Backend> {
     /// The tensor with the values filled.
     fn bool_mask_fill(tensor: BoolTensor<B>, mask: BoolTensor<B>, value: Scalar) -> BoolTensor<B>;
 
+    /// Selects the elements of the tensor where the mask is true, returned as a 1D tensor.
+    ///
+    /// The elements are collected in row-major order. Because the number of selected elements
+    /// depends on the mask values, the output shape is data-dependent: computing it may require
+    /// synchronizing with the device, which is why this operation is asynchronous.
+    ///
+    /// # Arguments
+    ///
+    /// * `tensor` - The tensor to select from.
+    /// * `mask` - The boolean mask, with the same shape as the tensor.
+    ///
+    /// # Returns
+    ///
+    /// A 1D tensor containing the selected elements.
+    fn bool_mask_select(
+        tensor: BoolTensor<B>,
+        mask: BoolTensor<B>,
+    ) -> impl Future<Output = BoolTensor<B>> + 'static + Send {
+        async move {
+            // Data-dependent output length, so we defer to `bool_argwhere` (the only pre-existing
+            // data-dependent op) to collect the flat indices of the true mask values, then select.
+            let n = mask.shape().num_elements();
+            let int_dtype = get_device_settings::<B>(&mask.device()).int_dtype;
+            let mask = B::bool_reshape(mask, Shape::new([n]));
+            let indices = B::bool_argwhere(mask, int_dtype).await; // [count, 1]
+            let count = indices.shape()[0];
+            let indices = B::int_reshape(indices, Shape::new([count])); // squeeze to [count]
+            let tensor = B::bool_reshape(tensor, Shape::new([n]));
+            B::bool_select(tensor, 0, indices)
+        }
+    }
+
     /// Gather elements from the tensor at the given indices.
     ///
     /// # Arguments

--- a/crates/burn-backend/src/backend/ops/int_tensor.rs
+++ b/crates/burn-backend/src/backend/ops/int_tensor.rs
@@ -149,6 +149,38 @@ pub trait IntTensorOps<B: Backend> {
     /// The tensor with the values filled.
     fn int_mask_fill(tensor: IntTensor<B>, mask: BoolTensor<B>, value: Scalar) -> IntTensor<B>;
 
+    /// Selects the elements of the tensor where the mask is true, returned as a 1D tensor.
+    ///
+    /// The elements are collected in row-major order. Because the number of selected elements
+    /// depends on the mask values, the output shape is data-dependent: computing it may require
+    /// synchronizing with the device, which is why this operation is asynchronous.
+    ///
+    /// # Arguments
+    ///
+    /// * `tensor` - The tensor to select from.
+    /// * `mask` - The boolean mask, with the same shape as the tensor.
+    ///
+    /// # Returns
+    ///
+    /// A 1D tensor containing the selected elements.
+    fn int_mask_select(
+        tensor: IntTensor<B>,
+        mask: BoolTensor<B>,
+    ) -> impl Future<Output = IntTensor<B>> + 'static + Send {
+        async move {
+            // Data-dependent output length, so we defer to `bool_argwhere` (the only pre-existing
+            // data-dependent op) to collect the flat indices of the true mask values, then select.
+            let n = mask.shape().num_elements();
+            let int_dtype = get_device_settings::<B>(&mask.device()).int_dtype;
+            let mask = B::bool_reshape(mask, Shape::new([n]));
+            let indices = B::bool_argwhere(mask, int_dtype).await; // [count, 1]
+            let count = indices.shape()[0];
+            let indices = B::int_reshape(indices, Shape::new([count])); // squeeze to [count]
+            let tensor = B::int_reshape(tensor, Shape::new([n]));
+            B::int_select(tensor, 0, indices)
+        }
+    }
+
     /// Gather elements from the tensor at the given indices.
     ///
     /// # Arguments

--- a/crates/burn-backend/src/backend/ops/tensor.rs
+++ b/crates/burn-backend/src/backend/ops/tensor.rs
@@ -595,6 +595,38 @@ pub trait FloatTensorOps<B: Backend> {
         value: Scalar,
     ) -> FloatTensor<B>;
 
+    /// Selects the elements of the tensor where the mask is true, returned as a 1D tensor.
+    ///
+    /// The elements are collected in row-major order. Because the number of selected elements
+    /// depends on the mask values, the output shape is data-dependent: computing it may require
+    /// synchronizing with the device, which is why this operation is asynchronous.
+    ///
+    /// # Arguments
+    ///
+    /// * `tensor` - The tensor to select from.
+    /// * `mask` - The boolean mask, with the same shape as the tensor.
+    ///
+    /// # Returns
+    ///
+    /// A 1D tensor containing the selected elements.
+    fn float_mask_select(
+        tensor: FloatTensor<B>,
+        mask: BoolTensor<B>,
+    ) -> impl Future<Output = FloatTensor<B>> + 'static + Send {
+        async move {
+            // Data-dependent output length, so we defer to `bool_argwhere` (the only pre-existing
+            // data-dependent op) to collect the flat indices of the true mask values, then select.
+            let n = mask.shape().num_elements();
+            let int_dtype = get_device_settings::<B>(&mask.device()).int_dtype;
+            let mask = B::bool_reshape(mask, Shape::new([n]));
+            let indices = B::bool_argwhere(mask, int_dtype).await; // [count, 1]
+            let count = indices.shape()[0];
+            let indices = B::int_reshape(indices, Shape::new([count])); // squeeze to [count]
+            let tensor = B::float_reshape(tensor, Shape::new([n]));
+            B::float_select(tensor, 0, indices)
+        }
+    }
+
     /// Equal comparison of two tensors.
     ///
     /// # Arguments

--- a/crates/burn-dispatch/src/ops/bool_tensor.rs
+++ b/crates/burn-dispatch/src/ops/bool_tensor.rs
@@ -86,6 +86,13 @@ impl BoolTensorOps<Self> for Dispatch {
         binary_op!((tensor, bool), (mask, bool), |tensor, mask| B::bool_mask_fill(tensor, mask, value) => Bool)
     }
 
+    async fn bool_mask_select(
+        tensor: BoolTensor<Self>,
+        mask: BoolTensor<Self>,
+    ) -> BoolTensor<Self> {
+        binary_op!((tensor, bool), (mask, bool), |tensor, mask| B::bool_mask_select(tensor, mask).await => Bool)
+    }
+
     fn bool_gather(
         dim: usize,
         tensor: BoolTensor<Self>,

--- a/crates/burn-dispatch/src/ops/int_tensor.rs
+++ b/crates/burn-dispatch/src/ops/int_tensor.rs
@@ -66,6 +66,10 @@ impl IntTensorOps<Self> for Dispatch {
         binary_op!((tensor, int), (mask, bool), |tensor, mask| B::int_mask_fill(tensor, mask, value) => Int)
     }
 
+    async fn int_mask_select(tensor: IntTensor<Self>, mask: BoolTensor<Self>) -> IntTensor<Self> {
+        binary_op!((tensor, int), (mask, bool), |tensor, mask| B::int_mask_select(tensor, mask).await => Int)
+    }
+
     fn int_gather(
         dim: usize,
         tensor: IntTensor<Self>,

--- a/crates/burn-dispatch/src/ops/tensor.rs
+++ b/crates/burn-dispatch/src/ops/tensor.rs
@@ -224,6 +224,13 @@ impl FloatTensorOps<Self> for Dispatch {
         binary_float!((tensor, float), (mask, bool), |tensor, mask| B::float_mask_fill(tensor, mask, value) => Float)
     }
 
+    async fn float_mask_select(
+        tensor: FloatTensor<Self>,
+        mask: BoolTensor<Self>,
+    ) -> FloatTensor<Self> {
+        binary_float!((tensor, float), (mask, bool), |tensor, mask| B::float_mask_select(tensor, mask).await => Float)
+    }
+
     fn float_equal(
         lhs: FloatTensor<Self>,
         rhs: FloatTensor<Self>,

--- a/crates/burn-tch/src/ops/bool_tensor.rs
+++ b/crates/burn-tch/src/ops/bool_tensor.rs
@@ -198,6 +198,13 @@ impl BoolTensorOps<Self> for LibTorch {
         )
     }
 
+    async fn bool_mask_select(
+        tensor: BoolTensor<Self>,
+        mask: BoolTensor<Self>,
+    ) -> BoolTensor<Self> {
+        TchTensor::new(tensor.tensor.masked_select(&mask.tensor))
+    }
+
     fn bool_gather(
         dim: usize,
         tensor: BoolTensor<Self>,

--- a/crates/burn-tch/src/ops/int_tensor.rs
+++ b/crates/burn-tch/src/ops/int_tensor.rs
@@ -336,6 +336,10 @@ impl IntTensorOps<Self> for LibTorch {
         )
     }
 
+    async fn int_mask_select(tensor: TchTensor, mask: TchTensor) -> TchTensor {
+        TchTensor::new(tensor.tensor.masked_select(&mask.tensor))
+    }
+
     fn int_argmax(tensor: TchTensor, dim: usize) -> TchTensor {
         TchOps::argmax(tensor, dim)
     }

--- a/crates/burn-tch/src/ops/tensor.rs
+++ b/crates/burn-tch/src/ops/tensor.rs
@@ -256,6 +256,10 @@ impl FloatTensorOps<Self> for LibTorch {
         )
     }
 
+    async fn float_mask_select(tensor: TchTensor, mask: TchTensor) -> TchTensor {
+        TchTensor::new(tensor.tensor.masked_select(&mask.tensor))
+    }
+
     fn float_equal(lhs: TchTensor, rhs: TchTensor, _out_dtype: BoolDType) -> TchTensor {
         TchOps::equal(lhs, rhs)
     }

--- a/crates/burn-tensor/src/bridge/ops/base.rs
+++ b/crates/burn-tensor/src/bridge/ops/base.rs
@@ -336,6 +336,30 @@ pub(crate) trait BasicOps: TensorKind {
     /// function, which is more high-level and designed for public use.
     fn mask_fill(tensor: BridgeTensor, mask: BridgeTensor, value: Scalar) -> BridgeTensor;
 
+    /// Selects the elements of the tensor where the mask is true, returned as a 1D tensor.
+    ///
+    /// # Arguments
+    ///
+    /// * `tensor` - The tensor to select from.
+    /// * `mask` - The boolean mask, with the same shape as the tensor.
+    ///
+    /// # Returns
+    ///
+    /// A 1D tensor containing the selected elements, in the order of the flattened input tensor.
+    ///
+    /// # Remarks
+    ///
+    /// This is a low-level function used internally by the library to call different backend functions
+    /// with static dispatch. It is not designed for direct usage by users, and not recommended to import
+    /// or use this function directly.
+    ///
+    /// For selecting the elements of a tensor where a mask is true, users should prefer the [`Tensor::mask_select`](crate::Tensor::mask_select)
+    /// function, which is more high-level and designed for public use.
+    fn mask_select(
+        tensor: BridgeTensor,
+        mask: BridgeTensor,
+    ) -> impl Future<Output = BridgeTensor> + Send;
+
     /// Gathers elements from a tensor along an axis.
     ///
     /// # Arguments

--- a/crates/burn-tensor/src/bridge/ops/bool.rs
+++ b/crates/burn-tensor/src/bridge/ops/bool.rs
@@ -128,6 +128,10 @@ impl BasicOps for Bool {
         BridgeTensor::bool(Dispatch::bool_mask_fill(tensor.into(), mask.into(), value))
     }
 
+    async fn mask_select(tensor: BridgeTensor, mask: BridgeTensor) -> BridgeTensor {
+        BridgeTensor::bool(Dispatch::bool_mask_select(tensor.into(), mask.into()).await)
+    }
+
     fn gather(dim: usize, tensor: BridgeTensor, indices: BridgeTensor) -> BridgeTensor {
         BridgeTensor::bool(Dispatch::bool_gather(dim, tensor.into(), indices.into()))
     }

--- a/crates/burn-tensor/src/bridge/ops/float.rs
+++ b/crates/burn-tensor/src/bridge/ops/float.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 use burn_backend::{
     AutodiffBackend, Distribution, Scalar, TensorData, TensorMetadata, TensorPrimitive,
-    ops::{FloatTensorOps, QTensorOps, TransactionPrimitive},
+    ops::{BoolTensorOps, FloatTensorOps, IntTensorOps, QTensorOps, TransactionPrimitive},
 };
 use burn_dispatch::Dispatch;
 use burn_std::{DType, ExecutionError, IndexingUpdateOp, Shape, Slice};
@@ -171,6 +171,29 @@ impl BasicOps for Float {
             mask.into(),
             value,
         ))
+    }
+
+    async fn mask_select(tensor: BridgeTensor, mask: BridgeTensor) -> BridgeTensor {
+        let (kind, tensor) = tensor.into_parts();
+        match kind {
+            BridgeKind::Float => {
+                BridgeTensor::float(Dispatch::float_mask_select(tensor, mask.into()).await)
+            }
+            BridgeKind::QFloat => {
+                // Preserve the quantized kind by composing `argwhere` + `q_select` on the
+                // quantized primitive, mirroring the default backend op (there is no
+                // `q_mask_select`). Using `into_float` here would silently drop quantization.
+                let out_dtype = mask.device_settings().int_dtype;
+                let n = mask.shape().num_elements();
+                let mask = Dispatch::bool_reshape(mask.into(), Shape::new([n]));
+                let indices = Dispatch::bool_argwhere(mask, out_dtype).await; // [count, 1]
+                let count = indices.shape()[0];
+                let indices = Dispatch::int_reshape(indices, Shape::new([count])); // squeeze
+                let tensor = Dispatch::q_reshape(tensor, Shape::new([n]));
+                BridgeTensor::qfloat(Dispatch::q_select(tensor, 0, indices))
+            }
+            _ => panic!("Should be Float primitive kind"),
+        }
     }
 
     fn gather(dim: usize, tensor: BridgeTensor, indices: BridgeTensor) -> BridgeTensor {

--- a/crates/burn-tensor/src/bridge/ops/int.rs
+++ b/crates/burn-tensor/src/bridge/ops/int.rs
@@ -108,6 +108,10 @@ impl BasicOps for Int {
         BridgeTensor::int(Dispatch::int_mask_fill(tensor.into(), mask.into(), value))
     }
 
+    async fn mask_select(tensor: BridgeTensor, mask: BridgeTensor) -> BridgeTensor {
+        BridgeTensor::int(Dispatch::int_mask_select(tensor.into(), mask.into()).await)
+    }
+
     fn gather(dim: usize, tensor: BridgeTensor, indices: BridgeTensor) -> BridgeTensor {
         BridgeTensor::int(Dispatch::int_gather(dim, tensor.into(), indices.into()))
     }

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -1787,11 +1787,11 @@ where
     ///
     /// # Notes
     ///
-    /// The number of selected elements is data-dependent, so this performs a synchronous read of
-    /// the mask, consistent with [`argwhere`](Tensor::argwhere) and [`nonzero`](Tensor::nonzero).
-    /// On backends without a native `argwhere` implementation, this reads the entire mask back to
-    /// the host and computes the indices on the CPU; on lazy backends, it also forces the
-    /// execution of pending operations.
+    /// The number of selected elements is data-dependent, so this synchronizes with the device,
+    /// consistent with [`argwhere`](Tensor::argwhere) and [`nonzero`](Tensor::nonzero). On backends
+    /// without a native implementation, this reads the entire mask back to the host and computes
+    /// the indices on the CPU; on lazy backends, it also forces the execution of pending
+    /// operations.
     ///
     /// This makes each call a synchronization point between the host and the device: prefer
     /// calling it once on final results (e.g. filtering predictions) rather than inside
@@ -1830,25 +1830,15 @@ where
     /// order of the flattened input tensor.
     ///
     /// Asynchronous version of [`mask_select`](Tensor::mask_select), for backends where the
-    /// mask cannot be read synchronously (e.g. wasm). The mask read and its synchronization cost
-    /// remain; only the waiting is non-blocking.
+    /// mask cannot be read synchronously (e.g. wasm). The synchronization cost remains; only the
+    /// waiting is non-blocking.
     ///
     /// # Panics
     ///
     /// If `mask` does not have the same shape as the tensor.
     pub async fn mask_select_async(self, mask: Tensor<D, Bool>) -> Tensor<1, K> {
         check!(TensorCheck::mask_select(&self.shape(), &mask.shape()));
-
-        // Flatten the mask to 1D and collect the flat indices of its `true` values. `argwhere`
-        // returns a `[count, 1]` tensor, which we squeeze to a 1D `[count]` index tensor.
-        let indices = mask
-            .flatten::<1>(0, D - 1)
-            .argwhere_async()
-            .await
-            .squeeze_dim::<1>(1);
-
-        // Flatten the tensor to 1D and gather the selected elements.
-        self.flatten::<1>(0, D - 1).select(0, indices)
+        Tensor::new(K::mask_select(self.primitive, mask.primitive).await)
     }
 
     /// Gather tensor elements corresponding to the given indices from the specified dim.


### PR DESCRIPTION
## Promote mask_select to a backend op (#5248)

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Closes #5248. Follow-up to #5238 (the initial `mask_select` implementation), as requested in that
PR's review.

### Changes

`mask_select` was implemented in #5238 purely at the `burn-tensor` API level (composing `argwhere` +
`select`), so no backend could provide a native implementation. This PR promotes it to a backend op:

- `burn-backend`: add `float_mask_select`, `int_mask_select`, `bool_mask_select` to the ops traits,
  each with a default implementation that composes `argwhere` + `select` on the primitives (async,
  modeled on `bool_argwhere` since the output length is data-dependent). No parameter changes.
- `burn-dispatch`: add the matching wrappers so the op is routable per backend. `float` uses
  `binary_float!` (its `(float, any)` arm handles autodiff-wrapped tensors); `int`/`bool` use
  `binary_op!`.
- `burn-tensor`: add `mask_select` to the internal `BasicOps` bridge trait and route the public
  `mask_select_async` body through it. The public API signatures are unchanged. The `Float` bridge
  impl preserves the `QFloat` kind (composes `argwhere` + `q_select`), matching the previous behavior
  rather than dequantizing.
- `burn-autodiff`: `float_mask_select` is intentionally omitted so it inherits the default, which
  composes the tracked `reshape`/`select` ops (writing a pass-through here would silently break the
  gradient). This means a tracked float `mask_select` keeps composing `argwhere` + `select` even on
  a backend with a native op, which seems like the right trade: the backward pass needs the indices
  for the scatter-add anyway, so a dedicated `Backward` impl would have to recompute `argwhere`.
  `int`/`bool` get one-line pass-throughs so `Autodiff<Tch>` reaches the native op.
- `burn-tch`: override all three with the native `Tensor::masked_select`.
- `burn-tensor` (docs): reword the public `mask_select` rustdoc (`# Notes`) to describe the new backend dispatch instead of the now-stale `argwhere` fallback, and document the new backend-trait methods. No behavior change.
- `burn-backend-tests`: add 2 quantization tests covering the QFloat branch (the only new behavior the existing suite could not reach), and 2 autodiff tests covering the int/bool pass-throughs.

All other backends (ndarray, cubecl, candle, flex, fusion, router) inherit the default and need no
changes.

The public API and its behavior are unchanged, so the 14 tests added in #5238 pass without any
modification.

### Testing

- The 14 existing `mask_select` tests (float/int/bool + autodiff) pass unchanged on the default
  (ndarray) backend, which is the non-regression proof. They run as 16 cases, since the 2 autodiff
  tests are instantiated in both the `base` and `checkpointing` suites.
- Added 2 quantization tests (`should_support_mask_select_ops` and its empty-mask variant, in
  `tensor/float/quantization/ops/extended/mask.rs`, alongside the existing `mask_where`/`mask_fill`
  ones). They assert that the output is still `QFloat`, not just that the dequantized values match.
  This is the only new logic in the PR that the existing suite could not reach: replacing the
  `QFloat` branch with a dequantizing one leaves all 14 pre-existing tests green, and fails these 2.
- Added 2 autodiff tests (test_mask_select_int and test_mask_select_bool) exercising the new int/bool autodiff pass-throughs, which are only reachable on an autodiff device and had no coverage otherwise.
- The `burn-tch` override was validated locally (CI does not run `burn-backend-tests` on tch): all
  forward tensor tests pass on tch for float, int and bool, including the empty, transposed and
  narrowed cases, plus the non-empty autodiff gradient test.

**Note on one tch edge case**, for transparency: `test_mask_select_grad_empty_mask` fails on tch. This is
a pre-existing tch bug, in files this PR does not touch, and any `backward()` on a zero-sized root
hits it. The implicit sum's backward computes `float_mul(ones([0]), grad([1]))`;
`TchTensor::binary_ops_tensor` derives the output shape with an elementwise `max`, so it gets `[1]`
instead of `[0]`, concludes the rhs already has the output element count, and takes the in-place
`rhs.f_mul_(lhs)` fast path, which libtorch rejects with `output with shape [1] doesn't match the broadcast shape [0]`. It reproduces in plain torch with `torch.ones(1).mul_(torch.ones(0))`, and in burn with `tensor.select(0, empty_indices).sum()
.backward()` (no `mask_select` involved); the same case passes on ndarray. `mask_select` only
produces the empty tensor that feeds this existing weakness, and the #5238 code path behaves
identically. The fix looks like treating a `0` dim as `0` rather than `max` in `TchTensor::binary_ops_tensor`, or skipping the in-place fast paths when either operand is empty. Happy to file it separately.

**One caveat on tch coverage**: the `burn-backend-tests` harness hardcodes `IntElem = i32`, which
LibTorch rejects (it forces `I64`), so the tch runs above needed a local `i64` harness edit. That
edit is not part of this PR.

### Book

No book change: the public API and behavior are unchanged, so the existing `mask_select` entry stays
accurate.