### PR TITLE
Add features to burn-backend-tests to: enable simd/rayon for flex, disable allocation tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,6 +804,7 @@ dependencies = [
  "burn-backend",
  "burn-cubecl",
  "burn-cubecl-fusion",
+ "burn-flex",
  "burn-fusion",
  "burn-ndarray",
  "burn-tensor",

--- a/crates/burn-backend-tests/Cargo.toml
+++ b/crates/burn-backend-tests/Cargo.toml
@@ -25,11 +25,14 @@ default = [
     "std",
 ]
 std = ["burn-tensor/std"]
-
+bench-disable-alloc = []
 # Backends
 cuda = ["burn-tensor/cuda", "quantization", "cube"]
 rocm = ["burn-tensor/rocm", "quantization", "cube"]
-flex = ["burn-tensor/flex", "quantization"]
+flex = ["flex-base"]
+flex-base = ["burn-tensor/flex", "quantization"]
+flex-simd = ["flex-base", "burn-flex/simd"]
+flex-rayon = ["flex-base", "burn-flex/rayon"]
 ndarray = ["burn-tensor/ndarray", "quantization"]
 tch = ["burn-tensor/tch"]
 vulkan = ["wgpu", "burn-tensor/vulkan"]
@@ -90,6 +93,9 @@ burn-cubecl-fusion = { workspace = true, optional = true }
 
 # Enabled alongside the `fusion` feature so spy-based tests can import the spy API.
 burn-fusion = { workspace = true, optional = true }
+
+# allows us to explicitly enable simd without rayon
+burn-flex = { workspace = true, optional = true }
 
 num-traits = { workspace = true }
 serial_test = { workspace = true }

--- a/crates/burn-backend-tests/README.md
+++ b/crates/burn-backend-tests/README.md
@@ -118,10 +118,21 @@ cargo bench-metal
 
 # Flex
 cargo bench-flex
+# Flex+Simd
+cargo bench-flex --features flex-simd
+# Flex+Rayon
+cargo bench-flex --features flex-rayon
+# Flex+Simd+Rayon
+cargo bench-flex --features flex-simd,flex-rayon
 # NdArray
 cargo bench-ndarray
 # LibTorch
 cargo bench-tch
+```
+
+Get a more compact output without memory allocations using:
+```sh
+cargo bench-* --features bench-disable-alloc
 ```
 
 Run a single bench file by passing `--bench <name>`:

--- a/crates/burn-backend-tests/benches/attention.rs
+++ b/crates/burn-backend-tests/benches/attention.rs
@@ -12,10 +12,11 @@ use common::BencherExt;
 use burn_tensor::module::attention;
 use burn_tensor::ops::AttentionModuleOptions;
 use burn_tensor::{Tensor, TensorData};
-use divan::{AllocProfiler, Bencher};
+use divan::Bencher;
 
+#[cfg(not(feature = "bench-disable-alloc"))]
 #[global_allocator]
-static ALLOC: AllocProfiler = AllocProfiler::system();
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Attention Benchmarks");

--- a/crates/burn-backend-tests/benches/binary_ops.rs
+++ b/crates/burn-backend-tests/benches/binary_ops.rs
@@ -10,10 +10,11 @@ mod common;
 use common::BencherExt;
 
 use burn_tensor::{Int, Tensor, TensorData};
-use divan::{AllocProfiler, Bencher};
+use divan::Bencher;
 
+#[cfg(not(feature = "bench-disable-alloc"))]
 #[global_allocator]
-static ALLOC: AllocProfiler = AllocProfiler::system();
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Benchmarks");

--- a/crates/burn-backend-tests/benches/cat_max_min_ops.rs
+++ b/crates/burn-backend-tests/benches/cat_max_min_ops.rs
@@ -10,10 +10,11 @@ mod common;
 use common::BencherExt;
 
 use burn_tensor::{Bool, Int, Tensor, TensorData, ops::GridSampleOptions};
-use divan::{AllocProfiler, Bencher};
+use divan::Bencher;
 
+#[cfg(not(feature = "bench-disable-alloc"))]
 #[global_allocator]
-static ALLOC: AllocProfiler = AllocProfiler::system();
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Benchmarks for cat, max/min, int power, bool select, grid_sample_2d");

--- a/crates/burn-backend-tests/benches/comparison_ops.rs
+++ b/crates/burn-backend-tests/benches/comparison_ops.rs
@@ -10,10 +10,11 @@ mod common;
 use common::BencherExt;
 
 use burn_tensor::{Tensor, TensorData};
-use divan::{AllocProfiler, Bencher};
+use divan::Bencher;
 
+#[cfg(not(feature = "bench-disable-alloc"))]
 #[global_allocator]
-static ALLOC: AllocProfiler = AllocProfiler::system();
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Benchmarking comparison and broadcast operations");

--- a/crates/burn-backend-tests/benches/conv_ops.rs
+++ b/crates/burn-backend-tests/benches/conv_ops.rs
@@ -12,10 +12,11 @@ mod common;
 use common::BencherExt;
 
 use burn_tensor::{Tensor, TensorData, module, ops::ConvOptions};
-use divan::{AllocProfiler, Bencher};
+use divan::Bencher;
 
+#[cfg(not(feature = "bench-disable-alloc"))]
 #[global_allocator]
-static ALLOC: AllocProfiler = AllocProfiler::system();
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Convolution Benchmarks");

--- a/crates/burn-backend-tests/benches/conv_transpose_ops.rs
+++ b/crates/burn-backend-tests/benches/conv_transpose_ops.rs
@@ -13,10 +13,11 @@ use common::BencherExt;
 
 use burn_tensor::ops::ConvTransposeOptions;
 use burn_tensor::{Tensor, TensorData, module};
-use divan::{AllocProfiler, Bencher};
+use divan::Bencher;
 
+#[cfg(not(feature = "bench-disable-alloc"))]
 #[global_allocator]
-static ALLOC: AllocProfiler = AllocProfiler::system();
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Conv Transpose Benchmarks");

--- a/crates/burn-backend-tests/benches/cross_unfold_ops.rs
+++ b/crates/burn-backend-tests/benches/cross_unfold_ops.rs
@@ -10,10 +10,11 @@ mod common;
 use common::BencherExt;
 
 use burn_tensor::{Tensor, TensorData};
-use divan::{AllocProfiler, Bencher};
+use divan::Bencher;
 
+#[cfg(not(feature = "bench-disable-alloc"))]
 #[global_allocator]
-static ALLOC: AllocProfiler = AllocProfiler::system();
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Cross and unfold ops Benchmarks");

--- a/crates/burn-backend-tests/benches/cumulative_ops.rs
+++ b/crates/burn-backend-tests/benches/cumulative_ops.rs
@@ -10,10 +10,11 @@ mod common;
 use common::BencherExt;
 
 use burn_tensor::{Tensor, TensorData};
-use divan::{AllocProfiler, Bencher};
+use divan::Bencher;
 
+#[cfg(not(feature = "bench-disable-alloc"))]
 #[global_allocator]
-static ALLOC: AllocProfiler = AllocProfiler::system();
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Cumulative ops Benchmarks");

--- a/crates/burn-backend-tests/benches/default_ops.rs
+++ b/crates/burn-backend-tests/benches/default_ops.rs
@@ -15,10 +15,11 @@ mod common;
 use common::BencherExt;
 
 use burn_tensor::{Int, Tensor, TensorData};
-use divan::{AllocProfiler, Bencher};
+use divan::Bencher;
 
+#[cfg(not(feature = "bench-disable-alloc"))]
 #[global_allocator]
-static ALLOC: AllocProfiler = AllocProfiler::system();
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Default ops Benchmarks");

--- a/crates/burn-backend-tests/benches/deform_conv_ops.rs
+++ b/crates/burn-backend-tests/benches/deform_conv_ops.rs
@@ -12,10 +12,11 @@ mod common;
 use common::BencherExt;
 
 use burn_tensor::{Tensor, TensorData, module, ops::DeformConvOptions};
-use divan::{AllocProfiler, Bencher};
+use divan::Bencher;
 
+#[cfg(not(feature = "bench-disable-alloc"))]
 #[global_allocator]
-static ALLOC: AllocProfiler = AllocProfiler::system();
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Deformable Convolution Benchmarks");

--- a/crates/burn-backend-tests/benches/fft_ops.rs
+++ b/crates/burn-backend-tests/benches/fft_ops.rs
@@ -13,10 +13,11 @@ use burn_tensor::{
     Tensor, TensorData,
     signal::{irfft, rfft},
 };
-use divan::{AllocProfiler, Bencher};
+use divan::Bencher;
 
+#[cfg(not(feature = "bench-disable-alloc"))]
 #[global_allocator]
-static ALLOC: AllocProfiler = AllocProfiler::system();
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("rfft / irfft benchmarks");

--- a/crates/burn-backend-tests/benches/gather_scatter_ops.rs
+++ b/crates/burn-backend-tests/benches/gather_scatter_ops.rs
@@ -10,10 +10,11 @@ mod common;
 use common::BencherExt;
 
 use burn_tensor::{IndexingUpdateOp, Int, Tensor, TensorData};
-use divan::{AllocProfiler, Bencher};
+use divan::Bencher;
 
+#[cfg(not(feature = "bench-disable-alloc"))]
 #[global_allocator]
-static ALLOC: AllocProfiler = AllocProfiler::system();
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Gather/scatter ops Benchmarks");

--- a/crates/burn-backend-tests/benches/int_ops.rs
+++ b/crates/burn-backend-tests/benches/int_ops.rs
@@ -10,10 +10,11 @@ mod common;
 use common::BencherExt;
 
 use burn_tensor::{DType, Distribution, Int, Tensor, TensorData};
-use divan::{AllocProfiler, Bencher};
+use divan::Bencher;
 
+#[cfg(not(feature = "bench-disable-alloc"))]
 #[global_allocator]
-static ALLOC: AllocProfiler = AllocProfiler::system();
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Integer Operations Benchmarks");

--- a/crates/burn-backend-tests/benches/interpolate_ops.rs
+++ b/crates/burn-backend-tests/benches/interpolate_ops.rs
@@ -15,10 +15,11 @@ use burn_tensor::{
     Tensor, TensorData, module,
     ops::{InterpolateMode, InterpolateOptions},
 };
-use divan::{AllocProfiler, Bencher};
+use divan::Bencher;
 
+#[cfg(not(feature = "bench-disable-alloc"))]
 #[global_allocator]
-static ALLOC: AllocProfiler = AllocProfiler::system();
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Interpolate Benchmarks");

--- a/crates/burn-backend-tests/benches/matmul.rs
+++ b/crates/burn-backend-tests/benches/matmul.rs
@@ -12,10 +12,11 @@ mod common;
 use common::BencherExt;
 
 use burn_tensor::{Tensor, TensorData};
-use divan::{AllocProfiler, Bencher};
+use divan::Bencher;
 
+#[cfg(not(feature = "bench-disable-alloc"))]
 #[global_allocator]
-static ALLOC: AllocProfiler = AllocProfiler::system();
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Matrix Multiplication Benchmarks");

--- a/crates/burn-backend-tests/benches/norm_ops.rs
+++ b/crates/burn-backend-tests/benches/norm_ops.rs
@@ -15,7 +15,7 @@ mod common;
 use common::BencherExt;
 
 use burn_tensor::{Tensor, TensorData};
-use divan::{AllocProfiler, Bencher};
+use divan::Bencher;
 
 /// Route through the `B::layer_norm` backend hook. On Flex this hits the
 /// fused override; on NdArray this hits the `ModuleOps` default decomposition.
@@ -28,8 +28,9 @@ fn trait_layer_norm<const D: usize>(
     burn_tensor::module::layer_norm(input, gamma, Some(beta), epsilon)
 }
 
+#[cfg(not(feature = "bench-disable-alloc"))]
 #[global_allocator]
-static ALLOC: AllocProfiler = AllocProfiler::system();
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Normalization Benchmarks");

--- a/crates/burn-backend-tests/benches/pool_ops.rs
+++ b/crates/burn-backend-tests/benches/pool_ops.rs
@@ -12,10 +12,11 @@ mod common;
 use common::BencherExt;
 
 use burn_tensor::{Tensor, TensorData, module};
-use divan::{AllocProfiler, Bencher};
+use divan::Bencher;
 
+#[cfg(not(feature = "bench-disable-alloc"))]
 #[global_allocator]
-static ALLOC: AllocProfiler = AllocProfiler::system();
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Pooling Benchmarks");

--- a/crates/burn-backend-tests/benches/quantization_ops.rs
+++ b/crates/burn-backend-tests/benches/quantization_ops.rs
@@ -10,10 +10,11 @@ mod common;
 use common::BencherExt;
 
 use burn_tensor::{Device, Tensor, TensorData};
-use divan::{AllocProfiler, Bencher};
+use divan::Bencher;
 
+#[cfg(not(feature = "bench-disable-alloc"))]
 #[global_allocator]
-static ALLOC: AllocProfiler = AllocProfiler::system();
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Quantized ops Benchmarks");

--- a/crates/burn-backend-tests/benches/reduce_ops.rs
+++ b/crates/burn-backend-tests/benches/reduce_ops.rs
@@ -10,10 +10,11 @@ mod common;
 use common::BencherExt;
 
 use burn_tensor::{FloatDType, Tensor, TensorData};
-use divan::{AllocProfiler, Bencher};
+use divan::Bencher;
 
+#[cfg(not(feature = "bench-disable-alloc"))]
 #[global_allocator]
-static ALLOC: AllocProfiler = AllocProfiler::system();
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Reduction ops Benchmarks");

--- a/crates/burn-backend-tests/benches/slice_ops.rs
+++ b/crates/burn-backend-tests/benches/slice_ops.rs
@@ -12,10 +12,11 @@ mod common;
 use common::BencherExt;
 
 use burn_tensor::{Tensor, TensorData, s};
-use divan::{AllocProfiler, Bencher};
+use divan::Bencher;
 
+#[cfg(not(feature = "bench-disable-alloc"))]
 #[global_allocator]
-static ALLOC: AllocProfiler = AllocProfiler::system();
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Slice Operations Benchmarks");

--- a/crates/burn-backend-tests/benches/softmax_ops.rs
+++ b/crates/burn-backend-tests/benches/softmax_ops.rs
@@ -11,10 +11,11 @@ mod common;
 use common::BencherExt;
 
 use burn_tensor::{Element, Tensor, TensorData};
-use divan::{AllocProfiler, Bencher};
+use divan::Bencher;
 
+#[cfg(not(feature = "bench-disable-alloc"))]
 #[global_allocator]
-static ALLOC: AllocProfiler = AllocProfiler::system();
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Softmax Benchmarks: fused (via B::softmax) vs decomposed");

--- a/crates/burn-backend-tests/benches/unary_ops.rs
+++ b/crates/burn-backend-tests/benches/unary_ops.rs
@@ -10,10 +10,11 @@ mod common;
 use common::BencherExt;
 
 use burn_tensor::{Tensor, TensorData};
-use divan::{AllocProfiler, Bencher};
+use divan::Bencher;
 
+#[cfg(not(feature = "bench-disable-alloc"))]
 #[global_allocator]
-static ALLOC: AllocProfiler = AllocProfiler::system();
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Unary ops Benchmarks");


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
      Caveat: it failed during the `cargo audit -q --color always` step because i had a subdirectory open, it takes a long time to run so i didn't re-run it, these are only benchmarks after all.
- [ ] ~~Made sure the book is up to date with changes in this PR.~~

### Related Issues/PRs

For #5267 i was primarily working on autovectorization withing macerator::with_simd blocks, something which the burn-backend-tests benchmarks didn't check for.

This PR allows for benchmarking that, and also adds a feature to disable the memory allocation tracking, because i found it to be annoyingly verbose.

### Changes

- Added `flex-base` feature, the old `flex` feature is an alias for compatibility
- Added `flex-simd` feature which enables `flex-base` and `burn-flex?/simd`
- Added `flex-rayon` feature which enables `flex-base` and `burn-flex?/rayon`
- Added `bench-disable-alloc` and gated `divan::AllocProfiler` behind `#[cfg(not(feature = "bench-disable-alloc"))]`
- Updated readme to reflect the above

### Testing

Running a few benchmarks
Example: `cargo bench-flex --features flex-simd,flex-rayon,bench-disable-alloc --bench conv_ops conv2d_small_channel`

