### PR TITLE
fix(cubecl): use real out_channels in conv_transpose2d autotune key

### DIFF
--- a/crates/burn-cubecl/src/kernel/conv/conv_transpose2d/tune.rs
+++ b/crates/burn-cubecl/src/kernel/conv/conv_transpose2d/tune.rs
@@ -73,7 +73,7 @@ fn create_key<R: CubeRuntime>(
     ),
 ) -> CubeAutotuneKey {
     let [batch_size, in_channels, height, width] = input.meta.shape().dims();
-    let [out_channels, _, kernel_h, kernel_w] = weights.meta.shape().dims();
+    let [_, out_channels_per_group, kernel_h, kernel_w] = weights.meta.shape().dims();
     let ConvTransposeOptions {
         stride,
         padding,
@@ -81,6 +81,7 @@ fn create_key<R: CubeRuntime>(
         groups,
         padding_out,
     } = options.clone();
+    let out_channels = out_channels_per_group * groups;
     CubeAutotuneKey::ConvTranspose(ConvTranspose2dAutotuneKey::new(
         [kernel_h, kernel_w],
         stride,


### PR DESCRIPTION
`create_key` for `conv_transpose2d` bound `weights.shape[0]` to `out_channels`, but the transpose weight layout is `[in_channels, out_channels / groups, k_h, k_w]`. Dim 0 is `in_channels`, so the key stored `in_channels` twice and never recorded the output channel count. Convolutions differing only in output channels (or in `groups`) collapsed onto the same autotune key.

Now derived from dim 1: `out_channels = out_channels_per_group * groups`, matching how `transpose_direct` and `col2im` read the same tensor.

No change to `ConvTranspose2dAutotuneKey`'s schema, the field was already there and just fed the wrong value. Existing persisted autotune caches will re-tune once for transpose convs since entries hash to new keys.