### PR TITLE
fix: standardize NaN propagation in extrema reductions

### DIFF
--- a/crates/burn-backend-tests/tests/fusion/reduce_broadcasted.rs
+++ b/crates/burn-backend-tests/tests/fusion/reduce_broadcasted.rs
@@ -1,4 +1,6 @@
 use super::*;
+#[cfg(feature = "cube")]
+use burn_fusion::inspect::FusionInspector;
 use burn_tensor::{ElementConversion, TensorData, Tolerance};
 
 #[test]
@@ -219,4 +221,49 @@ fn test_reduce_broadcasted_masked_softmax() {
         &TensorData::new(expected, [d0, q, k]),
         Tolerance::permissive(),
     );
+}
+
+#[test]
+fn test_reduce_broadcasted_max_nan() {
+    let stream = test_stream();
+    stream.executes(|| {
+        let device = Default::default();
+        let tensor = TestTensor::<2>::zeros([2, 4], &device);
+        let fused_on_read = TestTensor::<2>::from_data(
+            TensorData::from([[1.0, f32::NAN, 3.0, 2.0], [1.0, 4.0, 3.0, 2.0]]),
+            &device,
+        );
+        let fused_on_write = TestTensor::<2>::zeros([2, 1], &device);
+
+        // Materialize the inputs before recording the fused graph.
+        device.sync().unwrap();
+        #[cfg(feature = "cube")]
+        let inspector = FusionInspector::install(stream);
+
+        let output = tensor + fused_on_read.clone();
+        let output = output.max_dim(1);
+        let output = output + fused_on_write;
+        let output = output + fused_on_read;
+        let output = output + 1.0;
+        let actual = output.into_data();
+        device.sync().unwrap();
+
+        let expected = TensorData::from([
+            [f32::NAN, f32::NAN, f32::NAN, f32::NAN],
+            [6.0, 9.0, 8.0, 7.0],
+        ]);
+        actual.assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
+
+        #[cfg(feature = "cube")]
+        {
+            let reports = inspector.drain();
+            assert!(
+                reports
+                    .iter()
+                    .flat_map(|report| report.fused_blocks())
+                    .any(|block| block.fuser_name() == Some("ReduceBroadcasted")),
+                "expected ReduceBroadcasted fusion, got {reports:#?}"
+            );
+        }
+    });
 }

--- a/crates/burn-backend-tests/tests/fusion/reduce_broadcasted.rs
+++ b/crates/burn-backend-tests/tests/fusion/reduce_broadcasted.rs
@@ -1,5 +1,4 @@
 use super::*;
-#[cfg(feature = "cube")]
 use burn_fusion::inspect::FusionInspector;
 use burn_tensor::{ElementConversion, TensorData, Tolerance};
 
@@ -237,7 +236,6 @@ fn test_reduce_broadcasted_max_nan() {
 
         // Materialize the inputs before recording the fused graph.
         device.sync().unwrap();
-        #[cfg(feature = "cube")]
         let inspector = FusionInspector::install(stream);
 
         let output = tensor + fused_on_read.clone();
@@ -254,16 +252,13 @@ fn test_reduce_broadcasted_max_nan() {
         ]);
         actual.assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
 
-        #[cfg(feature = "cube")]
-        {
-            let reports = inspector.drain();
-            assert!(
-                reports
-                    .iter()
-                    .flat_map(|report| report.fused_blocks())
-                    .any(|block| block.fuser_name() == Some("ReduceBroadcasted")),
-                "expected ReduceBroadcasted fusion, got {reports:#?}"
-            );
-        }
+        let reports = inspector.drain();
+        assert!(
+            reports
+                .iter()
+                .flat_map(|report| report.fused_blocks())
+                .any(|block| block.fuser_name() == Some("ReduceBroadcasted")),
+            "expected ReduceBroadcasted fusion, got {reports:#?}"
+        );
     });
 }

--- a/crates/burn-backend-tests/tests/tensor/float/ops/arg.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/arg.rs
@@ -151,78 +151,102 @@ fn test_argmax_permuted_correctness() {
         .assert_eq(&TensorData::from([[[1], [1], [1]], [[1], [1], [1]]]), false);
 }
 
+#[test]
+fn test_arg_extrema_ties_use_lowest_index() {
+    let tensor = TestTensor::<2>::from([[3.0, 3.0, -2.0, -2.0]]);
+
+    tensor
+        .clone()
+        .argmax(1)
+        .into_data()
+        .assert_eq(&TensorData::from([[0]]), false);
+    tensor
+        .clone()
+        .argmin(1)
+        .into_data()
+        .assert_eq(&TensorData::from([[2]]), false);
+
+    let (_, max_indices) = tensor.clone().max_dim_with_indices(1);
+    max_indices
+        .into_data()
+        .assert_eq(&TensorData::from([[0]]), false);
+
+    let (_, min_indices) = tensor.min_dim_with_indices(1);
+    min_indices
+        .into_data()
+        .assert_eq(&TensorData::from([[2]]), false);
+}
+
 // NaN-propagation tests. All burn backends should propagate NaN from
 // argmax/argmin (matching PyTorch/NumPy/JAX/TF semantics). See issue #4814.
-#[cfg(any(feature = "flex", feature = "ndarray"))]
 #[test]
-fn test_argmax_nan_propagation() {
-    let tensor = TestTensor::<2>::from([[1.0, f32::NAN, 3.0]]);
-    let output = tensor.argmax(1);
+fn test_argmax_and_argmin_nan_propagation() {
+    let tensor = TestTensor::<2>::from([[1.0, f32::NAN, -3.0]]);
 
-    output
-        .into_data()
-        .assert_eq(&TensorData::from([[1]]), false);
+    for output in [tensor.clone().argmax(1), tensor.argmin(1)] {
+        output
+            .into_data()
+            .assert_eq(&TensorData::from([[1]]), false);
+    }
 }
 
 // First-NaN wins: when row[0] is NaN AND a later element is also NaN,
-// argmax must return 0 (the earlier NaN index), not the later one.
-#[cfg(any(feature = "flex", feature = "ndarray"))]
+// argmax and argmin must return 0 (the earlier NaN index), not the later one.
 #[test]
-fn test_argmax_nan_leading_with_trailing_nan() {
+fn test_argmax_and_argmin_nan_leading_with_trailing_nan() {
     let tensor = TestTensor::<2>::from([[f32::NAN, f32::NAN, 3.0]]);
-    let output = tensor.argmax(1);
-    output
-        .into_data()
-        .assert_eq(&TensorData::from([[0]]), false);
+
+    for output in [tensor.clone().argmax(1), tensor.argmin(1)] {
+        output
+            .into_data()
+            .assert_eq(&TensorData::from([[0]]), false);
+    }
 }
 
-#[cfg(any(feature = "flex", feature = "ndarray"))]
+// All-NaN row: argmax and argmin should return 0 (first NaN).
 #[test]
-fn test_argmin_nan_leading_with_trailing_nan() {
-    let tensor = TestTensor::<2>::from([[f32::NAN, f32::NAN, 3.0]]);
-    let output = tensor.argmin(1);
-    output
-        .into_data()
-        .assert_eq(&TensorData::from([[0]]), false);
-}
-
-// All-NaN row: argmax should return 0 (first NaN).
-#[cfg(any(feature = "flex", feature = "ndarray"))]
-#[test]
-fn test_argmax_all_nan_row() {
+fn test_argmax_and_argmin_all_nan_row() {
     let tensor = TestTensor::<2>::from([[f32::NAN, f32::NAN, f32::NAN]]);
-    let output = tensor.argmax(1);
-    output
-        .into_data()
-        .assert_eq(&TensorData::from([[0]]), false);
+    for output in [tensor.clone().argmax(1), tensor.argmin(1)] {
+        output
+            .into_data()
+            .assert_eq(&TensorData::from([[0]]), false);
+    }
 }
 
-// NaN propagation must also hold for non-last-dim argmax, which routes
+// NaN propagation must also hold for non-last-dim argmax and argmin, which route
 // through a different kernel than the last-dim fast path.
-#[cfg(any(feature = "flex", feature = "ndarray"))]
 #[test]
-fn test_argmax_nan_leading_non_last_dim() {
+fn test_argmax_and_argmin_nan_leading_non_last_dim() {
     // Column 0: [NaN, NaN, 3.0] -> argmax along dim 0 = 0.
     // Column 1: [1.0, 2.0, 4.0] -> argmax along dim 0 = 2.
-    let tensor = TestTensor::<2>::from([[f32::NAN, 1.0], [f32::NAN, 2.0], [3.0, 4.0]]);
-    let output = tensor.argmax(0);
-    output
+    let tensor = TestTensor::<2>::from([[f32::NAN, 1.0], [f32::NAN, 2.0], [-3.0, 4.0]]);
+    tensor
+        .clone()
+        .argmax(0)
         .into_data()
         .assert_eq(&TensorData::from([[0, 2]]), false);
+    tensor
+        .argmin(0)
+        .into_data()
+        .assert_eq(&TensorData::from([[0, 0]]), false);
 }
 
-// max_dim_with_indices on a leading-NaN row should return (NaN, 0).
-// Complements test_max_dim_with_indices_nan_propagation in maxmin.rs,
+// max/min_dim_with_indices on a leading-NaN row should return (NaN, 0).
+// Complements test_max_min_dim_with_indices_nan_propagation in maxmin.rs,
 // which uses a single NaN in the middle of the row.
-#[cfg(any(feature = "flex", feature = "ndarray"))]
 #[test]
-fn test_max_dim_with_indices_nan_leading() {
-    let tensor = TestTensor::<2>::from([[f32::NAN, f32::NAN, 3.0]]);
-    let (values, indices) = tensor.max_dim_with_indices(1);
-    let vdata = values.into_data();
-    let slice = vdata.as_slice::<FloatElem>().unwrap();
-    assert!(slice[0].is_nan());
-    indices
-        .into_data()
-        .assert_eq(&TensorData::from([[0]]), false);
+fn test_max_min_dim_with_indices_nan_leading() {
+    let tensor = TestTensor::<2>::from([[f32::NAN, f32::NAN, -3.0]]);
+
+    for (values, indices) in [
+        tensor.clone().max_dim_with_indices(1),
+        tensor.min_dim_with_indices(1),
+    ] {
+        let values = values.into_data();
+        assert!(values.as_slice::<FloatElem>().unwrap()[0].is_nan());
+        indices
+            .into_data()
+            .assert_eq(&TensorData::from([[0]]), false);
+    }
 }

--- a/crates/burn-backend-tests/tests/tensor/float/ops/arg.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/arg.rs
@@ -177,8 +177,7 @@ fn test_arg_extrema_ties_use_lowest_index() {
         .assert_eq(&TensorData::from([[2]]), false);
 }
 
-// NaN-propagation tests. All burn backends should propagate NaN from
-// argmax/argmin (matching PyTorch/NumPy/JAX/TF semantics). See issue #4814.
+// All burn backends should propagate NaN from argmax/argmin. See issue #4814.
 #[test]
 fn test_argmax_and_argmin_nan_propagation() {
     let tensor = TestTensor::<2>::from([[1.0, f32::NAN, -3.0]]);

--- a/crates/burn-backend-tests/tests/tensor/float/ops/cumulative.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/cumulative.rs
@@ -199,8 +199,7 @@ fn test_cummax_float_3d() {
     );
 }
 
-// NaN-propagation tests. All burn backends should propagate NaN from
-// cummin/cummax (matching PyTorch/NumPy/JAX/TF semantics). See issue #4814.
+// All burn backends should propagate NaN from cummin/cummax. See issue #4814.
 #[test]
 fn test_cummin_nan_propagation() {
     // Once NaN appears, cummin propagates it forward.

--- a/crates/burn-backend-tests/tests/tensor/float/ops/cumulative.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/cumulative.rs
@@ -1,7 +1,6 @@
 use super::*;
 use burn_tensor::TensorData;
 
-#[cfg(any(feature = "flex", feature = "ndarray"))]
 use burn_tensor::ElementConversion;
 
 #[test]
@@ -202,7 +201,6 @@ fn test_cummax_float_3d() {
 
 // NaN-propagation tests. All burn backends should propagate NaN from
 // cummin/cummax (matching PyTorch/NumPy/JAX/TF semantics). See issue #4814.
-#[cfg(any(feature = "flex", feature = "ndarray"))]
 #[test]
 fn test_cummin_nan_propagation() {
     // Once NaN appears, cummin propagates it forward.
@@ -217,7 +215,6 @@ fn test_cummin_nan_propagation() {
     assert!(data[3].is_nan());
 }
 
-#[cfg(any(feature = "flex", feature = "ndarray"))]
 #[test]
 fn test_cummax_nan_propagation() {
     let tensor = TestTensor::<1>::from([1.0, f32::NAN, 5.0, 2.0]);
@@ -231,16 +228,15 @@ fn test_cummax_nan_propagation() {
     assert!(data[3].is_nan());
 }
 
-#[cfg(any(feature = "flex", feature = "ndarray"))]
 #[test]
-fn test_cummin_nan_at_start() {
+fn test_cummin_and_cummax_nan_at_start() {
     // NaN on the first element should poison the entire output.
     let tensor = TestTensor::<1>::from([f32::NAN, 1.0, 2.0]);
 
-    let output = tensor.cummin(0);
-
-    let data: Vec<FloatElem> = output.into_data().to_vec().unwrap();
-    assert!(data[0].is_nan());
-    assert!(data[1].is_nan());
-    assert!(data[2].is_nan());
+    for output in [tensor.clone().cummin(0), tensor.cummax(0)] {
+        let data: Vec<FloatElem> = output.into_data().to_vec().unwrap();
+        assert!(data[0].is_nan());
+        assert!(data[1].is_nan());
+        assert!(data[2].is_nan());
+    }
 }

--- a/crates/burn-backend-tests/tests/tensor/float/ops/maxmin.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/maxmin.rs
@@ -401,8 +401,7 @@ fn test_whole_max_min_nan_flex_half_dtypes() {
     }
 }
 
-// NaN-propagation tests. All burn backends should propagate NaN from
-// min/max (matching PyTorch/NumPy/JAX/TF semantics). See issue #4814.
+// All burn backends should propagate NaN from min/max. See issue #4814.
 #[test]
 fn test_max_min_dim_nan_propagation() {
     let tensor = TestTensor::<2>::from([[1.0, f32::NAN, 3.0]]);

--- a/crates/burn-backend-tests/tests/tensor/float/ops/maxmin.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/maxmin.rs
@@ -1,5 +1,5 @@
 use super::*;
-use burn_tensor::TensorData;
+use burn_tensor::{ElementConversion, TensorData};
 
 #[test]
 fn test_max_dim_2d() {
@@ -268,35 +268,163 @@ fn test_max_abs_dim_2d_dim_1() {
     output.into_data().assert_eq(&expected, false);
 }
 
+#[test]
+fn test_whole_max_min_finite_and_infinite_values() {
+    let tensor = TestTensor::<1>::from([f32::NEG_INFINITY, -2.0, 7.0, 7.0, f32::INFINITY]);
+
+    tensor
+        .clone()
+        .max()
+        .into_data()
+        .assert_eq(&TensorData::from([f32::INFINITY]), false);
+    tensor
+        .min()
+        .into_data()
+        .assert_eq(&TensorData::from([f32::NEG_INFINITY]), false);
+}
+
+#[test]
+fn test_whole_max_min_integer_control() {
+    let tensor = TestTensor::<1>::from([3.0, -2.0, 7.0, 1.0]).int();
+
+    tensor
+        .clone()
+        .max()
+        .into_data()
+        .assert_eq(&TensorData::from([7]), false);
+    tensor
+        .min()
+        .into_data()
+        .assert_eq(&TensorData::from([-2]), false);
+}
+
+#[test]
+fn test_whole_max_min_nan_propagation_by_position() {
+    for values in [
+        [f32::NAN, 1.0, 2.0],
+        [1.0, f32::NAN, 2.0],
+        [1.0, 2.0, f32::NAN],
+    ] {
+        let tensor = TestTensor::<1>::from(values);
+
+        let max = tensor.clone().max().into_data();
+        assert!(max.as_slice::<FloatElem>().unwrap()[0].is_nan());
+
+        let min = tensor.min().into_data();
+        assert!(min.as_slice::<FloatElem>().unwrap()[0].is_nan());
+    }
+}
+
+#[test]
+fn test_whole_max_min_nan_non_contiguous_view() {
+    let tensor = TestTensor::<2>::from([[1.0, f32::NAN, 2.0], [3.0, 4.0, 5.0]])
+        .narrow(0, 0, 1)
+        .swap_dims(0, 1);
+
+    let max = tensor.clone().max().into_data();
+    assert!(max.as_slice::<FloatElem>().unwrap()[0].is_nan());
+
+    let min = tensor.min().into_data();
+    assert!(min.as_slice::<FloatElem>().unwrap()[0].is_nan());
+}
+
+#[test]
+fn test_whole_max_min_ignore_nan_outside_logical_view() {
+    let tensor = TestTensor::<2>::from([[f32::NAN, 1.0, 2.0], [3.0, 4.0, 5.0]])
+        .narrow(0, 1, 1)
+        .swap_dims(0, 1);
+
+    tensor
+        .clone()
+        .max()
+        .into_data()
+        .assert_eq(&TensorData::from([5.0]), false);
+    tensor
+        .min()
+        .into_data()
+        .assert_eq(&TensorData::from([3.0]), false);
+}
+
+#[test]
+fn test_whole_max_min_expanded_view_uses_only_logical_elements() {
+    let tensor = TestTensor::<2>::from([[f32::NAN, 1.0], [2.0, 3.0]])
+        .narrow(0, 1, 1)
+        .expand([2, 2]);
+
+    tensor
+        .clone()
+        .max()
+        .into_data()
+        .assert_eq(&TensorData::from([3.0]), false);
+    tensor
+        .min()
+        .into_data()
+        .assert_eq(&TensorData::from([2.0]), false);
+}
+
+#[test]
+fn test_whole_max_abs_nan_propagation() {
+    let tensor = TestTensor::<1>::from([-3.0, f32::NAN, 2.0]);
+    let output = tensor.max_abs().into_data();
+    assert!(output.as_slice::<FloatElem>().unwrap()[0].is_nan());
+}
+
+#[test]
+fn test_max_abs_dim_nan_propagation() {
+    let tensor = TestTensor::<2>::from([[1.0, f32::NAN, -3.0], [1.0, -4.0, 3.0]]);
+    let output = tensor.max_abs_dim(1).into_data();
+    let values = output.as_slice::<FloatElem>().unwrap();
+
+    assert!(values[0].is_nan());
+    assert_eq!(values[1], 4.0f32.elem::<FloatElem>());
+}
+
+#[cfg(any(feature = "flex", feature = "ndarray"))]
+#[test]
+fn test_whole_max_min_nan_f64_cpu_backends() {
+    let tensor = TestTensor::<1>::from([1.0, f32::NAN, 2.0]).cast(burn_tensor::DType::F64);
+
+    assert!(tensor.clone().max().into_data().as_slice::<f64>().unwrap()[0].is_nan());
+    assert!(tensor.min().into_data().as_slice::<f64>().unwrap()[0].is_nan());
+}
+
+#[cfg(feature = "flex")]
+#[test]
+fn test_whole_max_min_nan_flex_half_dtypes() {
+    for dtype in [burn_tensor::DType::F16, burn_tensor::DType::BF16] {
+        let tensor = TestTensor::<1>::from([1.0, f32::NAN, 2.0]).cast(dtype);
+
+        for output in [tensor.clone().max(), tensor.min()] {
+            let output = output.into_data().convert::<f32>();
+            assert!(output.as_slice::<f32>().unwrap()[0].is_nan());
+        }
+    }
+}
+
 // NaN-propagation tests. All burn backends should propagate NaN from
 // min/max (matching PyTorch/NumPy/JAX/TF semantics). See issue #4814.
-#[cfg(any(feature = "flex", feature = "ndarray"))]
 #[test]
-fn test_max_dim_nan_propagation() {
+fn test_max_min_dim_nan_propagation() {
     let tensor = TestTensor::<2>::from([[1.0, f32::NAN, 3.0]]);
-    let data = tensor.max_dim(1).into_data();
-    let values = data.as_slice::<FloatElem>().unwrap();
-    assert!(values[0].is_nan());
+
+    for output in [tensor.clone().max_dim(1), tensor.min_dim(1)] {
+        let data = output.into_data();
+        assert!(data.as_slice::<FloatElem>().unwrap()[0].is_nan());
+    }
 }
 
-#[cfg(any(feature = "flex", feature = "ndarray"))]
 #[test]
-fn test_min_dim_nan_propagation() {
-    let tensor = TestTensor::<2>::from([[1.0, f32::NAN, 3.0]]);
-    let data = tensor.min_dim(1).into_data();
-    let values = data.as_slice::<FloatElem>().unwrap();
-    assert!(values[0].is_nan());
-}
+fn test_max_min_dim_with_indices_nan_propagation() {
+    let tensor = TestTensor::<2>::from([[1.0, f32::NAN, -3.0]]);
 
-#[cfg(any(feature = "flex", feature = "ndarray"))]
-#[test]
-fn test_max_dim_with_indices_nan_propagation() {
-    let tensor = TestTensor::<2>::from([[1.0, f32::NAN, 3.0]]);
-    let (values, indices) = tensor.max_dim_with_indices(1);
-    let vdata = values.into_data();
-    let slice = vdata.as_slice::<FloatElem>().unwrap();
-    assert!(slice[0].is_nan());
-    indices
-        .into_data()
-        .assert_eq(&TensorData::from([[1]]), false);
+    for (values, indices) in [
+        tensor.clone().max_dim_with_indices(1),
+        tensor.min_dim_with_indices(1),
+    ] {
+        let values = values.into_data();
+        assert!(values.as_slice::<FloatElem>().unwrap()[0].is_nan());
+        indices
+            .into_data()
+            .assert_eq(&TensorData::from([[1]]), false);
+    }
 }

--- a/crates/burn-cubecl/src/ops/numeric.rs
+++ b/crates/burn-cubecl/src/ops/numeric.rs
@@ -1,12 +1,12 @@
-use crate::{
-    CubeRuntime,
-    kernel::utils::{address_type, shape_divmod},
-};
 use crate::{element::CubeElement, tensor::CubeTensor};
 use crate::{
+    kernel::utils::{address_type, shape_divmod},
+    CubeRuntime,
+};
+use crate::{
     kernel::{
-        AddOp, BitwiseAndOp, BitwiseOrOp, BitwiseXorOp, DivOp, MulOp, PowOp, RemainderOp, SubOp,
-        launch_binop, launch_binop_int, launch_scalar_binop, launch_scalar_binop_int,
+        launch_binop, launch_binop_int, launch_scalar_binop, launch_scalar_binop_int, AddOp,
+        BitwiseAndOp, BitwiseOrOp, BitwiseXorOp, DivOp, MulOp, PowOp, RemainderOp, SubOp,
     },
     ops::max_vector_size,
 };
@@ -14,7 +14,10 @@ use burn_backend::cubecl::dtype_to_storage_type;
 use burn_backend::{DType, Shape, TensorMetadata};
 use burn_std::Metadata;
 use cubecl::{
-    calculate_cube_count_elemwise, prelude::*, std::tensor::layout::linear::LinearViewMut,
+    calculate_cube_count_elemwise,
+    ir::{Comparison, ElemType, Instruction, Type, UnaryOperands},
+    prelude::*,
+    std::tensor::layout::linear::LinearViewMut,
 };
 use cubecl::{client::ComputeClient, server::MemoryLayout};
 use cubecl::{server::MemoryLayoutDescriptor, std::FastDivmod};
@@ -297,6 +300,54 @@ struct ProdOp;
 struct MaxOp;
 struct MinOp;
 
+// `N: Numeric` can't call the float-only `IsNan` trait after a comptime type check, so emit
+// the same Cube IR operation directly. Callers keep this inside float-only comptime branches.
+#[cube]
+fn numeric_is_nan<N: Numeric>(value: N) -> bool {
+    intrinsic!(|scope| {
+        let output = scope.create_value(Type::scalar(ElemType::Bool));
+        scope.register(Instruction::new(
+            Comparison::IsNan(UnaryOperands {
+                input: value.expand,
+            }),
+            output,
+        ));
+        output.into()
+    })
+}
+
+#[cube]
+fn cumulative_max<N: Numeric>(lhs: N, rhs: N) -> N {
+    let elem_type = type_of::<N>();
+    if comptime!(elem_type.is_float()) {
+        if numeric_is_nan::<N>(lhs) {
+            lhs
+        } else if numeric_is_nan::<N>(rhs) {
+            rhs
+        } else {
+            max(lhs, rhs)
+        }
+    } else {
+        max(lhs, rhs)
+    }
+}
+
+#[cube]
+fn cumulative_min<N: Numeric>(lhs: N, rhs: N) -> N {
+    let elem_type = type_of::<N>();
+    if comptime!(elem_type.is_float()) {
+        if numeric_is_nan::<N>(lhs) {
+            lhs
+        } else if numeric_is_nan::<N>(rhs) {
+            rhs
+        } else {
+            min(lhs, rhs)
+        }
+    } else {
+        min(lhs, rhs)
+    }
+}
+
 // Implement CumulativeOpFamily for each operation
 impl CumulativeOpFamily for SumOp {
     type CumulativeOp<C: Numeric> = Self;
@@ -340,7 +391,7 @@ impl<N: Numeric> CumulativeOp<N> for ProdOp {
 #[cube]
 impl<N: Numeric> CumulativeOp<N> for MaxOp {
     fn execute(lhs: N, rhs: N) -> N {
-        max(lhs, rhs)
+        cumulative_max::<N>(lhs, rhs)
     }
 
     fn init_value(first_element: N) -> N {
@@ -351,7 +402,7 @@ impl<N: Numeric> CumulativeOp<N> for MaxOp {
 #[cube]
 impl<N: Numeric> CumulativeOp<N> for MinOp {
     fn execute(lhs: N, rhs: N) -> N {
-        min(lhs, rhs)
+        cumulative_min::<N>(lhs, rhs)
     }
 
     fn init_value(first_element: N) -> N {

--- a/crates/burn-cubecl/src/ops/numeric.rs
+++ b/crates/burn-cubecl/src/ops/numeric.rs
@@ -1,12 +1,12 @@
+use crate::{
+    CubeRuntime,
+    kernel::utils::{address_type, shape_divmod},
+};
 use crate::{element::CubeElement, tensor::CubeTensor};
 use crate::{
-    kernel::utils::{address_type, shape_divmod},
-    CubeRuntime,
-};
-use crate::{
     kernel::{
-        launch_binop, launch_binop_int, launch_scalar_binop, launch_scalar_binop_int, AddOp,
-        BitwiseAndOp, BitwiseOrOp, BitwiseXorOp, DivOp, MulOp, PowOp, RemainderOp, SubOp,
+        AddOp, BitwiseAndOp, BitwiseOrOp, BitwiseXorOp, DivOp, MulOp, PowOp, RemainderOp, SubOp,
+        launch_binop, launch_binop_int, launch_scalar_binop, launch_scalar_binop_int,
     },
     ops::max_vector_size,
 };

--- a/crates/burn-flex/src/ops/reduce.rs
+++ b/crates/burn-flex/src/ops/reduce.rs
@@ -8,12 +8,13 @@
 use alloc::vec;
 use alloc::vec::Vec;
 use burn_backend::{DType, Element};
-use burn_std::{Bytes, Shape, bf16, f16};
+use burn_std::{bf16, f16, Bytes, Shape};
+use num_traits::Float;
 
 use crate::strided_index::StridedIter;
 use crate::{FlexTensor, Layout};
 
-use super::{INDEX_DTYPE, float_storage_as_f32};
+use super::{float_storage_as_f32, INDEX_DTYPE};
 
 /// Assert that a dimension size fits in `isize`, which is required for index-producing
 /// operations (argmax, argmin, *_with_indices) that store dimension indices as `isize`.
@@ -425,17 +426,17 @@ pub fn prod_dim(tensor: FlexTensor, dim: usize) -> FlexTensor {
 pub fn max(tensor: FlexTensor) -> FlexTensor {
     match tensor.dtype() {
         DType::F32 => max_f32_reduce(&tensor),
-        DType::F64 => max_impl::<f64>(&tensor),
+        DType::F64 => float_extremum_f64_reduce::<true>(&tensor),
         DType::F16 => reduce_scalar_half(
             &tensor,
-            f32::max,
+            select_float_extremum::<f32, true>,
             f32::NEG_INFINITY,
             f16::to_f32,
             f16::from_f32,
         ),
         DType::BF16 => reduce_scalar_half(
             &tensor,
-            f32::max,
+            select_float_extremum::<f32, true>,
             f32::NEG_INFINITY,
             bf16::to_f32,
             bf16::from_f32,
@@ -456,13 +457,17 @@ pub fn max(tensor: FlexTensor) -> FlexTensor {
 pub fn min(tensor: FlexTensor) -> FlexTensor {
     match tensor.dtype() {
         DType::F32 => min_f32_reduce(&tensor),
-        DType::F64 => min_impl::<f64>(&tensor),
-        DType::F16 => {
-            reduce_scalar_half(&tensor, f32::min, f32::INFINITY, f16::to_f32, f16::from_f32)
-        }
+        DType::F64 => float_extremum_f64_reduce::<false>(&tensor),
+        DType::F16 => reduce_scalar_half(
+            &tensor,
+            select_float_extremum::<f32, false>,
+            f32::INFINITY,
+            f16::to_f32,
+            f16::from_f32,
+        ),
         DType::BF16 => reduce_scalar_half(
             &tensor,
-            f32::min,
+            select_float_extremum::<f32, false>,
             f32::INFINITY,
             bf16::to_f32,
             bf16::from_f32,
@@ -479,6 +484,33 @@ pub fn min(tensor: FlexTensor) -> FlexTensor {
     }
 }
 
+#[inline(always)]
+fn select_float_extremum<E: Float, const MAX: bool>(current: E, candidate: E) -> E {
+    let keep_current = if MAX {
+        current >= candidate
+    } else {
+        current <= candidate
+    };
+    if current.is_nan() || keep_current {
+        current
+    } else {
+        candidate
+    }
+}
+
+#[inline(always)]
+fn float_extremum_contiguous<E: Float, const MAX: bool>(data: &[E]) -> E {
+    let empty_message = if MAX {
+        "max: tensor must not be empty"
+    } else {
+        "min: tensor must not be empty"
+    };
+    let (&first, rest) = data.split_first().expect(empty_message);
+    rest.iter()
+        .copied()
+        .fold(first, select_float_extremum::<E, MAX>)
+}
+
 fn max_f32_reduce(tensor: &FlexTensor) -> FlexTensor {
     let result = match tensor.layout().contiguous_offsets() {
         Some((start, end)) => {
@@ -487,16 +519,10 @@ fn max_f32_reduce(tensor: &FlexTensor) -> FlexTensor {
         }
         None => {
             let data: &[f32] = tensor.storage();
-            let elem_count = tensor.layout().num_elements();
-            if data.len() == elem_count {
-                // Non-contiguous but uses all elements (e.g., transposed)
-                max_f32_contiguous(data)
-            } else {
-                StridedIter::new(tensor.layout())
-                    .map(|idx| data[idx])
-                    .reduce(|a, b| if a >= b { a } else { b })
-                    .expect("max: tensor must not be empty")
-            }
+            StridedIter::new(tensor.layout())
+                .map(|idx| data[idx])
+                .reduce(select_float_extremum::<f32, true>)
+                .expect("max: tensor must not be empty")
         }
     };
 
@@ -513,10 +539,7 @@ fn max_f32_contiguous(data: &[f32]) -> f32 {
 
     #[cfg(not(feature = "simd"))]
     {
-        data.iter()
-            .copied()
-            .reduce(|a, b| if a >= b { a } else { b })
-            .expect("max: tensor must not be empty")
+        float_extremum_contiguous::<f32, true>(data)
     }
 }
 
@@ -528,15 +551,10 @@ fn min_f32_reduce(tensor: &FlexTensor) -> FlexTensor {
         }
         None => {
             let data: &[f32] = tensor.storage();
-            let elem_count = tensor.layout().num_elements();
-            if data.len() == elem_count {
-                min_f32_contiguous(data)
-            } else {
-                StridedIter::new(tensor.layout())
-                    .map(|idx| data[idx])
-                    .reduce(|a, b| if a <= b { a } else { b })
-                    .expect("min: tensor must not be empty")
-            }
+            StridedIter::new(tensor.layout())
+                .map(|idx| data[idx])
+                .reduce(select_float_extremum::<f32, false>)
+                .expect("min: tensor must not be empty")
         }
     };
 
@@ -553,11 +571,32 @@ fn min_f32_contiguous(data: &[f32]) -> f32 {
 
     #[cfg(not(feature = "simd"))]
     {
-        data.iter()
-            .copied()
-            .reduce(|a, b| if a <= b { a } else { b })
-            .expect("min: tensor must not be empty")
+        float_extremum_contiguous::<f32, false>(data)
     }
+}
+
+fn float_extremum_f64_reduce<const MAX: bool>(tensor: &FlexTensor) -> FlexTensor {
+    let empty_message = if MAX {
+        "max: tensor must not be empty"
+    } else {
+        "min: tensor must not be empty"
+    };
+    let result = match tensor.layout().contiguous_offsets() {
+        Some((start, end)) => {
+            let data: &[f64] = tensor.storage();
+            float_extremum_contiguous::<f64, MAX>(&data[start..end])
+        }
+        None => {
+            let data: &[f64] = tensor.storage();
+            StridedIter::new(tensor.layout())
+                .map(|idx| data[idx])
+                .reduce(select_float_extremum::<f64, MAX>)
+                .expect(empty_message)
+        }
+    };
+
+    let bytes = Bytes::from_elems(vec![result]);
+    FlexTensor::new(bytes, Layout::contiguous(Shape::from(vec![1])), DType::F64)
 }
 
 fn max_impl<E: Element + bytemuck::Pod + PartialOrd>(tensor: &FlexTensor) -> FlexTensor {
@@ -1849,22 +1888,10 @@ fn extremum_dim_f32_last_simd(
     let mut out_shape: Vec<usize> = shape.to_vec();
     out_shape[dim] = 1;
 
-    let reduce_row = |outer: usize| -> f32 {
+    let reduce_row = |outer: usize| {
         let row_start = start + outer * dim_size;
         let row = &data[row_start..row_start + dim_size];
-        let ext = simd_reduce(row);
-        // SIMD max/min may silently drop NaN (architecture-dependent).
-        // If the result is already NaN, we're done. Otherwise, scan to
-        // check for any NaN the SIMD op missed.
-        if ext.is_nan() {
-            return f32::NAN;
-        }
-        for &v in row {
-            if v.is_nan() {
-                return f32::NAN;
-            }
-        }
-        ext
+        simd_reduce(row)
     };
 
     #[cfg(feature = "rayon")]
@@ -2260,8 +2287,8 @@ fn scalar_div<E: Element + bytemuck::Pod + core::ops::Div<Output = E> + Copy>(
 #[cfg(test)]
 mod tests {
     use alloc::vec;
-    use burn_backend::TensorData;
     use burn_backend::ops::{FloatTensorOps, IntTensorOps};
+    use burn_backend::TensorData;
     use burn_std::{bf16, f16};
 
     use crate::{Flex, FlexTensor};

--- a/crates/burn-flex/src/ops/reduce.rs
+++ b/crates/burn-flex/src/ops/reduce.rs
@@ -8,13 +8,13 @@
 use alloc::vec;
 use alloc::vec::Vec;
 use burn_backend::{DType, Element};
-use burn_std::{bf16, f16, Bytes, Shape};
+use burn_std::{Bytes, Shape, bf16, f16};
 use num_traits::Float;
 
 use crate::strided_index::StridedIter;
 use crate::{FlexTensor, Layout};
 
-use super::{float_storage_as_f32, INDEX_DTYPE};
+use super::{INDEX_DTYPE, float_storage_as_f32};
 
 /// Assert that a dimension size fits in `isize`, which is required for index-producing
 /// operations (argmax, argmin, *_with_indices) that store dimension indices as `isize`.
@@ -2287,8 +2287,8 @@ fn scalar_div<E: Element + bytemuck::Pod + core::ops::Div<Output = E> + Copy>(
 #[cfg(test)]
 mod tests {
     use alloc::vec;
-    use burn_backend::ops::{FloatTensorOps, IntTensorOps};
     use burn_backend::TensorData;
+    use burn_backend::ops::{FloatTensorOps, IntTensorOps};
     use burn_std::{bf16, f16};
 
     use crate::{Flex, FlexTensor};

--- a/crates/burn-flex/src/ops/reduce.rs
+++ b/crates/burn-flex/src/ops/reduce.rs
@@ -511,6 +511,52 @@ fn float_extremum_contiguous<E: Float, const MAX: bool>(data: &[E]) -> E {
         .fold(first, select_float_extremum::<E, MAX>)
 }
 
+/// Returns whether the layout visits every storage element exactly once.
+///
+/// Dense permutations and flips can reduce the raw storage directly because
+/// extrema are independent of traversal order. Partial, broadcast, overlapping,
+/// or gapped views must preserve their logical indexing through `StridedIter`.
+fn layout_covers_storage_once(layout: &Layout, storage_len: usize) -> bool {
+    if storage_len == 0 || layout.num_elements() != storage_len {
+        return false;
+    }
+
+    let mut dimensions: Vec<_> = layout
+        .shape()
+        .iter()
+        .copied()
+        .zip(layout.strides().iter().copied())
+        .filter(|(size, _)| *size > 1)
+        .map(|(size, stride)| (stride.unsigned_abs(), size, stride < 0))
+        .collect();
+    dimensions.sort_unstable_by_key(|&(stride, _, _)| stride);
+
+    let mut expected_stride = 1usize;
+    let mut min_offset = layout.start_offset();
+    for (stride, size, is_negative) in dimensions {
+        if stride != expected_stride {
+            return false;
+        }
+
+        if is_negative {
+            let Some(reach) = stride.checked_mul(size - 1) else {
+                return false;
+            };
+            let Some(offset) = min_offset.checked_sub(reach) else {
+                return false;
+            };
+            min_offset = offset;
+        }
+
+        let Some(next_stride) = expected_stride.checked_mul(size) else {
+            return false;
+        };
+        expected_stride = next_stride;
+    }
+
+    min_offset == 0 && expected_stride == storage_len
+}
+
 fn max_f32_reduce(tensor: &FlexTensor) -> FlexTensor {
     let result = match tensor.layout().contiguous_offsets() {
         Some((start, end)) => {
@@ -519,10 +565,14 @@ fn max_f32_reduce(tensor: &FlexTensor) -> FlexTensor {
         }
         None => {
             let data: &[f32] = tensor.storage();
-            StridedIter::new(tensor.layout())
-                .map(|idx| data[idx])
-                .reduce(select_float_extremum::<f32, true>)
-                .expect("max: tensor must not be empty")
+            if layout_covers_storage_once(tensor.layout(), data.len()) {
+                max_f32_contiguous(data)
+            } else {
+                StridedIter::new(tensor.layout())
+                    .map(|idx| data[idx])
+                    .reduce(select_float_extremum::<f32, true>)
+                    .expect("max: tensor must not be empty")
+            }
         }
     };
 
@@ -551,10 +601,14 @@ fn min_f32_reduce(tensor: &FlexTensor) -> FlexTensor {
         }
         None => {
             let data: &[f32] = tensor.storage();
-            StridedIter::new(tensor.layout())
-                .map(|idx| data[idx])
-                .reduce(select_float_extremum::<f32, false>)
-                .expect("min: tensor must not be empty")
+            if layout_covers_storage_once(tensor.layout(), data.len()) {
+                min_f32_contiguous(data)
+            } else {
+                StridedIter::new(tensor.layout())
+                    .map(|idx| data[idx])
+                    .reduce(select_float_extremum::<f32, false>)
+                    .expect("min: tensor must not be empty")
+            }
         }
     };
 
@@ -2289,9 +2343,65 @@ mod tests {
     use alloc::vec;
     use burn_backend::TensorData;
     use burn_backend::ops::{FloatTensorOps, IntTensorOps};
-    use burn_std::{bf16, f16};
+    use burn_std::{Shape, bf16, f16};
 
-    use crate::{Flex, FlexTensor};
+    use crate::strided_index::StridedIter;
+    use crate::{Flex, FlexTensor, Layout};
+
+    #[test]
+    fn test_layout_covers_storage_once() {
+        fn reference(layout: &Layout, storage_len: usize) -> bool {
+            if storage_len == 0 || layout.num_elements() != storage_len {
+                return false;
+            }
+
+            let mut indices: Vec<_> = StridedIter::new(layout).collect();
+            indices.sort_unstable();
+            indices.into_iter().eq(0..storage_len)
+        }
+
+        let base = Layout::contiguous(Shape::from(vec![2, 3, 4]));
+        let cases = [
+            ("contiguous", base.clone(), 24),
+            ("permuted", base.permute(&[2, 0, 1]), 24),
+            ("flipped", base.flip(&[0, 2]), 24),
+            (
+                "permuted singleton dimension",
+                Layout::contiguous(Shape::from(vec![2, 1, 3])).permute(&[1, 2, 0]),
+                6,
+            ),
+            ("narrowed", base.narrow(1, 1, 1), 24),
+            (
+                "expanded",
+                Layout::new(Shape::from(vec![2, 2]), vec![0, 1], 2),
+                4,
+            ),
+            (
+                "overlapping",
+                Layout::new(Shape::from(vec![2, 2]), vec![1, 1], 0),
+                4,
+            ),
+            (
+                "gapped",
+                Layout::new(Shape::from(vec![2, 2]), vec![3, 1], 0),
+                4,
+            ),
+            (
+                "offset",
+                Layout::new(Shape::from(vec![2, 2]), vec![2, 1], 1),
+                4,
+            ),
+            ("empty", Layout::contiguous(Shape::from(vec![0, 3])), 0),
+        ];
+
+        for (name, layout, storage_len) in cases {
+            assert_eq!(
+                super::layout_covers_storage_once(&layout, storage_len),
+                reference(&layout, storage_len),
+                "{name}"
+            );
+        }
+    }
 
     #[test]
     fn test_mean_f16_overflow_intermediate_sum() {

--- a/crates/burn-flex/src/simd/kernels.rs
+++ b/crates/burn-flex/src/simd/kernels.rs
@@ -10,7 +10,7 @@ use core::iter::Sum;
 use core::ops::AddAssign;
 
 use macerator::{
-    vload_unaligned, vstore_unaligned, ReduceAdd, ReduceMax, ReduceMin, Simd, VAdd, VOrd,
+    ReduceAdd, ReduceMax, ReduceMin, Simd, VAdd, VOrd, vload_unaligned, vstore_unaligned,
 };
 use num_traits::Float;
 
@@ -221,11 +221,7 @@ fn macerator_max<S: Simd, F: VOrd + ReduceMax + Float>(mut xs: &[F], init: F) ->
     unsafe { nan_mask.store_as_bool(nan_lanes.as_mut_ptr()) };
     has_nan |= nan_lanes[..lanes].iter().any(|value| *value);
 
-    if has_nan {
-        F::nan()
-    } else {
-        result
-    }
+    if has_nan { F::nan() } else { result }
 }
 
 #[macerator::with_simd]
@@ -263,11 +259,7 @@ fn macerator_min<S: Simd, F: VOrd + ReduceMin + Float>(mut xs: &[F], init: F) ->
     unsafe { nan_mask.store_as_bool(nan_lanes.as_mut_ptr()) };
     has_nan |= nan_lanes[..lanes].iter().any(|value| *value);
 
-    if has_nan {
-        F::nan()
-    } else {
-        result
-    }
+    if has_nan { F::nan() } else { result }
 }
 
 #[cfg(test)]

--- a/crates/burn-flex/src/simd/kernels.rs
+++ b/crates/burn-flex/src/simd/kernels.rs
@@ -191,13 +191,15 @@ fn macerator_max<S: Simd, F: VOrd + ReduceMax + Float>(mut xs: &[F], init: F) ->
     let lanes = F::lanes::<S>();
     let initial = init.splat::<S>();
     let mut acc = initial;
-    let mut nan_mask = initial.ne(initial);
+    // Ordered self-comparison is false only for NaN. Vector equality has
+    // backend-specific unordered behavior, so it can't be used here.
+    let mut nan_mask = initial.lt(initial);
 
     while xs.len() >= lanes {
         // SAFETY: The loop condition proves that one vector-width load stays
         // within `xs`.
         let v = unsafe { vload_unaligned::<S, F>(xs.as_ptr()) };
-        nan_mask = nan_mask | v.ne(v);
+        nan_mask = nan_mask | !v.le(v);
         acc = acc.max(v);
         xs = &xs[lanes..];
     }
@@ -229,13 +231,15 @@ fn macerator_min<S: Simd, F: VOrd + ReduceMin + Float>(mut xs: &[F], init: F) ->
     let lanes = F::lanes::<S>();
     let initial = init.splat::<S>();
     let mut acc = initial;
-    let mut nan_mask = initial.ne(initial);
+    // Ordered self-comparison is false only for NaN. Vector equality has
+    // backend-specific unordered behavior, so it can't be used here.
+    let mut nan_mask = initial.lt(initial);
 
     while xs.len() >= lanes {
         // SAFETY: The loop condition proves that one vector-width load stays
         // within `xs`.
         let v = unsafe { vload_unaligned::<S, F>(xs.as_ptr()) };
-        nan_mask = nan_mask | v.ne(v);
+        nan_mask = nan_mask | !v.le(v);
         acc = acc.min(v);
         xs = &xs[lanes..];
     }

--- a/crates/burn-flex/src/simd/kernels.rs
+++ b/crates/burn-flex/src/simd/kernels.rs
@@ -10,8 +10,9 @@ use core::iter::Sum;
 use core::ops::AddAssign;
 
 use macerator::{
-    ReduceAdd, ReduceMax, ReduceMin, Simd, VAdd, VOrd, vload_unaligned, vstore_unaligned,
+    vload_unaligned, vstore_unaligned, ReduceAdd, ReduceMax, ReduceMin, Simd, VAdd, VOrd,
 };
+use num_traits::Float;
 
 // ============================================================================
 // Sum reduction
@@ -186,43 +187,87 @@ pub fn min_f32(data: &[f32]) -> f32 {
 }
 
 #[macerator::with_simd]
-fn macerator_max<S: Simd, F: VOrd + ReduceMax + PartialOrd>(mut xs: &[F], init: F) -> F {
+fn macerator_max<S: Simd, F: VOrd + ReduceMax + Float>(mut xs: &[F], init: F) -> F {
     let lanes = F::lanes::<S>();
-    let mut acc = init.splat::<S>();
+    let initial = init.splat::<S>();
+    let mut acc = initial;
+    let mut nan_mask = initial.ne(initial);
 
     while xs.len() >= lanes {
-        let v = unsafe { vload_unaligned(xs.as_ptr()) };
+        // SAFETY: The loop condition proves that one vector-width load stays
+        // within `xs`.
+        let v = unsafe { vload_unaligned::<S, F>(xs.as_ptr()) };
+        nan_mask = nan_mask | v.ne(v);
         acc = acc.max(v);
         xs = &xs[lanes..];
     }
 
     let mut result = acc.reduce_max();
+    let mut has_nan = false;
     for &x in xs {
+        has_nan |= x.is_nan();
         if x > result {
             result = x;
         }
     }
-    result
+
+    let mut nan_lanes = [false; 64];
+    assert!(
+        lanes <= nan_lanes.len(),
+        "SIMD f32 lane count {lanes} exceeds the supported maximum"
+    );
+    // SAFETY: `nan_lanes` is valid for 64 contiguous booleans, and the
+    // assertion above proves that the SIMD mask writes at most that many.
+    unsafe { nan_mask.store_as_bool(nan_lanes.as_mut_ptr()) };
+    has_nan |= nan_lanes[..lanes].iter().any(|value| *value);
+
+    if has_nan {
+        F::nan()
+    } else {
+        result
+    }
 }
 
 #[macerator::with_simd]
-fn macerator_min<S: Simd, F: VOrd + ReduceMin + PartialOrd>(mut xs: &[F], init: F) -> F {
+fn macerator_min<S: Simd, F: VOrd + ReduceMin + Float>(mut xs: &[F], init: F) -> F {
     let lanes = F::lanes::<S>();
-    let mut acc = init.splat::<S>();
+    let initial = init.splat::<S>();
+    let mut acc = initial;
+    let mut nan_mask = initial.ne(initial);
 
     while xs.len() >= lanes {
-        let v = unsafe { vload_unaligned(xs.as_ptr()) };
+        // SAFETY: The loop condition proves that one vector-width load stays
+        // within `xs`.
+        let v = unsafe { vload_unaligned::<S, F>(xs.as_ptr()) };
+        nan_mask = nan_mask | v.ne(v);
         acc = acc.min(v);
         xs = &xs[lanes..];
     }
 
     let mut result = acc.reduce_min();
+    let mut has_nan = false;
     for &x in xs {
+        has_nan |= x.is_nan();
         if x < result {
             result = x;
         }
     }
-    result
+
+    let mut nan_lanes = [false; 64];
+    assert!(
+        lanes <= nan_lanes.len(),
+        "SIMD f32 lane count {lanes} exceeds the supported maximum"
+    );
+    // SAFETY: `nan_lanes` is valid for 64 contiguous booleans, and the
+    // assertion above proves that the SIMD mask writes at most that many.
+    unsafe { nan_mask.store_as_bool(nan_lanes.as_mut_ptr()) };
+    has_nan |= nan_lanes[..lanes].iter().any(|value| *value);
+
+    if has_nan {
+        F::nan()
+    } else {
+        result
+    }
 }
 
 #[cfg(test)]
@@ -313,5 +358,21 @@ mod tests {
     fn test_min_f32_negative() {
         let data = vec![-3.0, -1.0, -4.0, -1.0, -5.0];
         assert_eq!(min_f32(&data), -5.0);
+    }
+
+    #[test]
+    fn test_max_min_f32_nan_propagation() {
+        for nan_index in [0, 32, 64] {
+            let mut data = vec![1.0; 65];
+            data[nan_index] = f32::NAN;
+            assert!(
+                max_f32(&data).is_nan(),
+                "max failed with NaN at index {nan_index}"
+            );
+            assert!(
+                min_f32(&data).is_nan(),
+                "min failed with NaN at index {nan_index}"
+            );
+        }
     }
 }

--- a/crates/burn-ndarray/src/ops/base.rs
+++ b/crates/burn-ndarray/src/ops/base.rs
@@ -1176,7 +1176,13 @@ where
         let max = view
             .iter()
             .copied()
-            .reduce(|a, b| if a > b { a } else { b })
+            .reduce(|a, b| {
+                if a.partial_cmp(&a).is_none() || a > b {
+                    a
+                } else {
+                    b
+                }
+            })
             .expect("Cannot compute max of empty tensor");
         ArrayD::from_elem(IxDyn(&[1]), max).into_shared()
     }
@@ -1186,7 +1192,13 @@ where
         let min = view
             .iter()
             .copied()
-            .reduce(|a, b| if a < b { a } else { b })
+            .reduce(|a, b| {
+                if a.partial_cmp(&a).is_none() || a < b {
+                    a
+                } else {
+                    b
+                }
+            })
             .expect("Cannot compute min of empty tensor");
         ArrayD::from_elem(IxDyn(&[1]), min).into_shared()
     }

--- a/crates/burn-ndarray/src/ops/base.rs
+++ b/crates/burn-ndarray/src/ops/base.rs
@@ -33,7 +33,7 @@ use crate::ops::simd::{
 };
 use crate::reshape;
 use crate::{
-    IntNdArrayElement, ShapeOps,
+    FloatNdArrayElement, IntNdArrayElement, ShapeOps,
     ops::macros::{
         cummax_dim, cummin_dim, cumprod_dim, cumsum_dim, keepdim, mean_dim, prod_dim, sum_dim,
     },
@@ -1176,6 +1176,19 @@ where
         let max = view
             .iter()
             .copied()
+            .reduce(|a, b| if a > b { a } else { b })
+            .expect("Cannot compute max of empty tensor");
+        ArrayD::from_elem(IxDyn(&[1]), max).into_shared()
+    }
+
+    /// Max of all floating-point elements with NaN propagation.
+    pub fn max_float_view(view: ArrayView<'_, E, IxDyn>) -> SharedArray<E>
+    where
+        E: FloatNdArrayElement,
+    {
+        let max = view
+            .iter()
+            .copied()
             .reduce(|a, b| {
                 if a.partial_cmp(&a).is_none() || a > b {
                     a
@@ -1189,6 +1202,19 @@ where
 
     /// Min of all elements - zero-copy for borrowed storage.
     pub fn min_view(view: ArrayView<'_, E, IxDyn>) -> SharedArray<E> {
+        let min = view
+            .iter()
+            .copied()
+            .reduce(|a, b| if a < b { a } else { b })
+            .expect("Cannot compute min of empty tensor");
+        ArrayD::from_elem(IxDyn(&[1]), min).into_shared()
+    }
+
+    /// Min of all floating-point elements with NaN propagation.
+    pub fn min_float_view(view: ArrayView<'_, E, IxDyn>) -> SharedArray<E>
+    where
+        E: FloatNdArrayElement,
+    {
         let min = view
             .iter()
             .copied()

--- a/crates/burn-ndarray/src/ops/tensor.rs
+++ b/crates/burn-ndarray/src/ops/tensor.rs
@@ -540,14 +540,14 @@ impl FloatTensorOps<Self> for NdArray {
     fn float_max(tensor: FloatTensor<Self>) -> FloatTensor<Self> {
         // Use view() for zero-copy on borrowed storage
         execute_with_float_dtype!(tensor, FloatElem, |array: SharedArray<FloatElem>| {
-            NdArrayMathOps::max_view(array.view())
+            NdArrayMathOps::max_float_view(array.view())
         })
     }
 
     fn float_min(tensor: FloatTensor<Self>) -> FloatTensor<Self> {
         // Use view() for zero-copy on borrowed storage
         execute_with_float_dtype!(tensor, FloatElem, |array: SharedArray<FloatElem>| {
-            NdArrayMathOps::min_view(array.view())
+            NdArrayMathOps::min_float_view(array.view())
         })
     }
 

--- a/crates/burn-tensor/src/tensor/api/orderable.rs
+++ b/crates/burn-tensor/src/tensor/api/orderable.rs
@@ -3,8 +3,8 @@ use burn_std::{AsIndex, IndexingUpdateOp};
 
 use crate::check::unwrap_dim_index;
 use crate::kind::Ordered;
-use crate::{check, Bool, Int};
-use crate::{check::TensorCheck, Tensor};
+use crate::{Bool, Int, check};
+use crate::{Tensor, check::TensorCheck};
 
 impl<const D: usize, K> Tensor<D, K>
 where

--- a/crates/burn-tensor/src/tensor/api/orderable.rs
+++ b/crates/burn-tensor/src/tensor/api/orderable.rs
@@ -3,8 +3,8 @@ use burn_std::{AsIndex, IndexingUpdateOp};
 
 use crate::check::unwrap_dim_index;
 use crate::kind::Ordered;
-use crate::{Bool, Int, check};
-use crate::{Tensor, check::TensorCheck};
+use crate::{check, Bool, Int};
+use crate::{check::TensorCheck, Tensor};
 
 impl<const D: usize, K> Tensor<D, K>
 where
@@ -331,6 +331,7 @@ where
             .clone()
             .mask_fill(self.clone().lower_scalar(0), num_classes as i64) // Handle negative indices
             .add(indices.clone().mask_fill(self.clone().greater_scalar(0), 0)); // Handle positive indices
+
         // Unsqueeze the indices tensor along the specified axis
         let indices_unsqueezed: Tensor<D2, Int> = adjusted_indices.unsqueeze_dim(axis);
 
@@ -557,6 +558,12 @@ where
     /// * `dim` - The dimension along which to find the maximum value.
     ///   Negative dimensions are supported and count from the end.
     ///
+    /// # NaN behavior
+    ///
+    /// For floating-point tensors, NaNs take precedence over non-NaN values. If a reduced slice
+    /// contains multiple NaNs, the lowest coordinate along `dim` is returned. Non-NaN ties also
+    /// return the lowest coordinate.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -567,6 +574,10 @@ where
     /// let tensor = tensor.argmax(1);
     /// println!("{:?}", tensor.shape());
     /// // Shape { dims: [2, 1, 3] }
+    ///
+    /// let tensor = Tensor::<1>::from_data([3.0, f32::NAN, f32::NAN], &device);
+    /// let index: i32 = tensor.argmax(0).into_scalar();
+    /// assert_eq!(index, 1);
     /// ```
     pub fn argmax(self, dim: impl AsIndex) -> Tensor<D, Int> {
         let dim = unwrap_dim_index(dim.try_dim_index(D), "Argmax");
@@ -599,6 +610,8 @@ where
 
     /// Find the maximum value.
     ///
+    /// For floating-point tensors, the result is NaN if any element is NaN.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -609,6 +622,10 @@ where
     /// let tensor = tensor.max();
     /// println!("{tensor}");
     /// // [9.0]
+    ///
+    /// let tensor = Tensor::<1>::from_data([1.0, f32::NAN, 3.0], &device);
+    /// let value: f32 = tensor.max().into_scalar();
+    /// assert!(value.is_nan());
     /// ```
     pub fn max(self) -> Tensor<1, K> {
         Tensor::new(K::max(self.primitive))
@@ -617,6 +634,10 @@ where
     /// Find the maximum value along the given dimension.
     ///
     /// Also returns the indices.
+    ///
+    /// For floating-point tensors, a NaN in a reduced slice produces a NaN value. The returned
+    /// index is the lowest coordinate containing NaN. Non-NaN ties also return the lowest
+    /// coordinate.
     ///
     /// # Example
     ///
@@ -643,6 +664,8 @@ where
     }
 
     /// Find the maximum absolute value.
+    ///
+    /// For floating-point tensors, the result is NaN if any element is NaN.
     ///
     /// # Example
     ///
@@ -699,6 +722,8 @@ where
     /// The returned tensor will have the same rank,
     /// but the aggregated dimension will have size 1.
     ///
+    /// For floating-point tensors, a reduced slice produces NaN if it contains a NaN.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -728,6 +753,8 @@ where
     /// The returned tensor will have the same rank,
     /// but the aggregated dimensions will have size 1.
     ///
+    /// For floating-point tensors, a reduced region produces NaN if it contains a NaN.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -751,6 +778,12 @@ where
     /// * `dim` - The dimension along which to find the minimum value.
     ///   Negative dimensions are supported and count from the end.
     ///
+    /// # NaN behavior
+    ///
+    /// For floating-point tensors, NaNs take precedence over non-NaN values. If a reduced slice
+    /// contains multiple NaNs, the lowest coordinate along `dim` is returned. Non-NaN ties also
+    /// return the lowest coordinate.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -768,6 +801,8 @@ where
     }
 
     /// Find the minimum value.
+    ///
+    /// For floating-point tensors, the result is NaN if any element is NaN.
     ///
     /// # Example
     ///
@@ -795,6 +830,8 @@ where
     ///
     /// The returned tensor will have the same rank,
     /// but the aggregated dimension will have size 1.
+    ///
+    /// For floating-point tensors, a reduced slice produces NaN if it contains a NaN.
     ///
     /// # Example
     ///
@@ -824,6 +861,8 @@ where
     /// The returned tensor will have the same rank,
     /// but the aggregated dimensions will have size 1.
     ///
+    /// For floating-point tensors, a reduced region produces NaN if it contains a NaN.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -842,6 +881,10 @@ where
     /// Find the minimum value along the given dimension.
     ///
     /// Also returns the indices.
+    ///
+    /// For floating-point tensors, a NaN in a reduced slice produces a NaN value. The returned
+    /// index is the lowest coordinate containing NaN. Non-NaN ties also return the lowest
+    /// coordinate.
     ///
     /// # Example
     ///
@@ -997,6 +1040,9 @@ where
     /// * `dim` - The dimension or axis along which to compute the cumulative minimum.
     ///   Negative dimensions are supported and count from the end.
     ///
+    /// For floating-point tensors, once a NaN is encountered in a scan, the output at that
+    /// position and every later position in the scan is NaN.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -1022,6 +1068,9 @@ where
     ///
     /// * `dim` - The dimension or axis along which to compute the cumulative maximum.
     ///   Negative dimensions are supported and count from the end.
+    ///
+    /// For floating-point tensors, once a NaN is encountered in a scan, the output at that
+    /// position and every later position in the scan is NaN.
     ///
     /// # Example
     ///
@@ -1053,6 +1102,8 @@ where
     /// The returned tensor will have the same rank,
     /// but the aggregated dimension will have size 1.
     ///
+    /// For floating-point tensors, a reduced slice produces NaN if it contains a NaN.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -1080,6 +1131,8 @@ where
     ///
     /// The returned tensor will have the same rank,
     /// but the aggregated dimensions will have size 1.
+    ///
+    /// For floating-point tensors, a reduced region produces NaN if it contains a NaN.
     ///
     /// # Example
     ///


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Related to #4814.

Depends on tracel-ai/cubek#457.

### Changes

- Standardize floating-point `max`, `min`, `max_abs`, arg-extrema, and cumulative extrema NaN propagation across NdArray, Flex scalar/SIMD, and CubeCL/Cubek.
- Preserve the lowest-index result for equal arg-extrema values and for rows containing multiple or only NaNs.
- Use true floating-point extrema identities in the dependent Cubek reduction kernels while preserving the existing Burn integer paths.
- Fix whole Flex reductions over non-contiguous logical views so they do not read values outside the view.
- Retain the raw-storage Flex extrema fast path for dense permuted and flipped views only when `layout_covers_storage_once(...)` verifies that the layout visits every storage element exactly once. Partial, broadcast, overlapping, gapped, and offset views continue through `StridedIter`.
- Keep public API signatures and TopK unchanged. NaN-ignoring `nan_*` variants remain follow-up work for #4814.

The layout guard has differential coverage against `StridedIter` across contiguous, permuted, flipped, singleton, narrowed, expanded, overlapping, gapped, offset, and empty layouts.

No book change is required because this changes existing reduction behavior without adding or renaming a public API; the affected tensor method documentation is updated in source.

### Testing

- `cargo run-checks` — passed. This includes dependency audit, formatting, Clippy with warnings denied, typo checks, release builds, NdArray/Flex backend tests, documentation, and doctests.
- `cargo check -p burn-flex --no-default-features` — passed.
- `BURN_DEVICE=wgpu cargo test -p burn-backend-tests --no-default-features --features wgpu,std,fusion --test tensor nan -- --nocapture` — 24 passed.
- `BURN_DEVICE=wgpu cargo test -p burn-backend-tests --no-default-features --features wgpu,std,fusion --test tensor whole_max_min -- --nocapture` — 6 passed.
- `BURN_DEVICE=wgpu cargo test -p burn-backend-tests --no-default-features --features wgpu,std,fusion --test tensor arg_extrema_ties_use_lowest_index -- --nocapture` — 1 passed.
