### PR TITLE
Remove incorrect checkpointing assertion in grad_replace

### DIFF
--- a/crates/burn-dispatch/src/backend.rs
+++ b/crates/burn-dispatch/src/backend.rs
@@ -463,15 +463,13 @@ impl AutodiffBackend for Dispatch {
     }
 
     fn grad_replace(tensor: &DispatchTensor, grads: &mut Self::Gradients, grad: DispatchTensor) {
-        let DispatchTensor {
-            kind,
-            checkpointing,
-        } = tensor;
-        let DispatchTensor {
-            kind: grad,
-            checkpointing: grad_ckp,
-        } = grad;
-        debug_assert_eq!(checkpointing, &grad_ckp);
+        // The replacement gradient is an inner-backend tensor, so it carries no
+        // checkpointing strategy of its own. Only a gradient obtained from `grad()` does,
+        // because that getter copies the source tensor's strategy onto its result.
+        // Comparing the two therefore only holds when a gradient is round-tripped through
+        // `grad()`, which the public API does not require.
+        let DispatchTensor { kind, .. } = tensor;
+        let DispatchTensor { kind: grad, .. } = grad;
 
         match &kind {
             DispatchTensorKind::Autodiff(inner_kind) => match (&**inner_kind, grad) {


### PR DESCRIPTION
## What

`Dispatch::grad_replace` asserts that the replacement gradient carries the same checkpointing strategy as the tensor whose gradient it replaces:

```rust
debug_assert_eq!(checkpointing, &grad_ckp);
```

That invariant only holds when the gradient came from `grad()`, which copies the source tensor's strategy onto the gradient it returns. The public API takes an inner-backend tensor, so a gradient constructed any other way carries no strategy at all and the assertion fails:

```
assertion `left == right` failed
  left: Some(None)
 right: None
```

`should_update_tensor_when_grad_replace` does exactly that — it passes `grad_1_updated.clone().inner()` — so the test fails on `main` today, on every backend, in debug builds.

Neither `checkpointing` nor `grad_ckp` is used elsewhere in the function, so both bindings are removed with the assertion.

## Why it isn't visible in CI

`debug_assert_eq!` is compiled out in release, and CI runs the suite with `--release`, so the failure only appears to someone running plain `cargo test`.

## Testing

`cargo test -p burn-backend-tests --no-default-features --features ndarray --features std`

| | before | after |
|---|---|---|
| ndarray, debug | 2 failed | **1728 passed, 0 failed** |
| ndarray, release | clean | clean |
| metal, debug | 4 failed | 2 failed |
| metal, release | 2 failed | 2 failed |

The two remaining metal failures are #5293 and are unrelated to this change — they are reductions over empty `f16` tensors, which fail with or without this patch.

`cargo fmt --all -- --check` and `cargo clippy -p burn-dispatch` are clean.

## Note on process

CONTRIBUTING asks for an issue first where one does not exist. I did not open one because this is a two-line behavioural change to a test that is already failing in the repository, and the failure itself documents the problem — but I am happy to move the discussion to an issue if you would prefer that.

I also checked #3608, which touches `grad_replace` in the same file: it only adds match arms for the complex backend and does not touch this assertion or either binding, so the two should not conflict logically.
