### PR TITLE
Correct chained doc examples in orderable.rs

### DIFF
--- a/crates/burn-tensor/src/tensor/api/orderable.rs
+++ b/crates/burn-tensor/src/tensor/api/orderable.rs
@@ -36,7 +36,7 @@ where
     ///   // [[5.0, -2.0, 3.0], [12.0, 3.0, 6.0]]
     ///   let tensor = tensor.sort(1);
     ///   println!("{tensor}");
-    ///   // [[-2.0, 3.0, 12.0], [3.0, 5.0, 6.0]]
+    ///   // [[-2.0, 3.0, 5.0], [3.0, 6.0, 12.0]]
     /// }
     /// ```
     pub fn sort<I: AsIndex>(self, dim: I) -> Self {
@@ -70,7 +70,7 @@ where
     ///    // [[12.0, 3.0, 6.0], [5.0, -2.0, 3.0]]
     ///    let tensor = tensor.sort_descending(1);
     ///    println!("{tensor}");
-    ///    // [[12.0, 3.0, -2.0], [6.0, 5.0, 3.0]]
+    ///    // [[12.0, 6.0, 3.0], [5.0, 3.0, -2.0]]
     /// }
     /// ```
     pub fn sort_descending<I: AsIndex>(self, dim: I) -> Self {
@@ -194,7 +194,7 @@ where
     ///    // [[0, 1, 1], [1, 0, 0]]
     ///    let tensor = tensor.argsort_descending(1);
     ///    println!("{tensor}");
-    ///    // [[0, 2, 1], [2, 0, 1]]
+    ///    // [[1, 2, 0], [0, 1, 2]]
     /// }
     /// ```
     pub fn argsort_descending<I: AsIndex>(self, dim: I) -> Tensor<D, Int> {

--- a/crates/burn-tensor/src/tensor/api/orderable.rs
+++ b/crates/burn-tensor/src/tensor/api/orderable.rs
@@ -31,12 +31,12 @@ where
     /// fn example() {
     ///   let device = Default::default();
     ///   let tensor = Tensor::<2>::from_data([[12.0, -2.0, 3.0], [5.0, 3.0, 6.0]], &device);
-    ///   let tensor = tensor.sort(0);
-    ///   println!("{tensor}");
+    ///   let sorted = tensor.clone().sort(0);
+    ///   println!("{sorted}");
     ///   // [[5.0, -2.0, 3.0], [12.0, 3.0, 6.0]]
-    ///   let tensor = tensor.sort(1);
-    ///   println!("{tensor}");
-    ///   // [[-2.0, 3.0, 5.0], [3.0, 6.0, 12.0]]
+    ///   let sorted = tensor.sort(1);
+    ///   println!("{sorted}");
+    ///   // [[-2.0, 3.0, 12.0], [3.0, 5.0, 6.0]]
     /// }
     /// ```
     pub fn sort<I: AsIndex>(self, dim: I) -> Self {
@@ -65,12 +65,12 @@ where
     /// fn example() {
     ///    let device = Default::default();
     ///    let tensor = Tensor::<2>::from_data([[12.0, -2.0, 3.0], [5.0, 3.0, 6.0]], &device);
-    ///    let tensor = tensor.sort_descending(0);
-    ///    println!("{tensor}");
+    ///    let sorted = tensor.clone().sort_descending(0);
+    ///    println!("{sorted}");
     ///    // [[12.0, 3.0, 6.0], [5.0, -2.0, 3.0]]
-    ///    let tensor = tensor.sort_descending(1);
-    ///    println!("{tensor}");
-    ///    // [[12.0, 6.0, 3.0], [5.0, 3.0, -2.0]]
+    ///    let sorted = tensor.sort_descending(1);
+    ///    println!("{sorted}");
+    ///    // [[12.0, 3.0, -2.0], [6.0, 5.0, 3.0]]
     /// }
     /// ```
     pub fn sort_descending<I: AsIndex>(self, dim: I) -> Self {
@@ -189,12 +189,12 @@ where
     /// fn example() {
     ///    let device = Default::default();
     ///    let tensor = Tensor::<2>::from_data([[12.0, -2.0, 3.0], [5.0, 3.0, 6.0]], &device);
-    ///    let tensor = tensor.argsort_descending(0);
-    ///    println!("{tensor}");
+    ///    let indices = tensor.clone().argsort_descending(0);
+    ///    println!("{indices}");
     ///    // [[0, 1, 1], [1, 0, 0]]
-    ///    let tensor = tensor.argsort_descending(1);
-    ///    println!("{tensor}");
-    ///    // [[1, 2, 0], [0, 1, 2]]
+    ///    let indices = tensor.argsort_descending(1);
+    ///    println!("{indices}");
+    ///    // [[0, 2, 1], [2, 0, 1]]
     /// }
     /// ```
     pub fn argsort_descending<I: AsIndex>(self, dim: I) -> Tensor<D, Int> {


### PR DESCRIPTION
## What

Three doc examples in `orderable.rs` chain two calls and show an expected output for the second that the code does not produce. In each case the second value was computed from the **original** tensor rather than from the result of the first call.

For input `[[12.0, -2.0, 3.0], [5.0, 3.0, 6.0]]`:

| example | shown | actual |
|---|---|---|
| `sort(0).sort(1)` | `[[-2.0, 3.0, 12.0], [3.0, 5.0, 6.0]]` | `[[-2.0, 3.0, 5.0], [3.0, 6.0, 12.0]]` |
| `sort_descending(0).sort_descending(1)` | `[[12.0, 3.0, -2.0], [6.0, 5.0, 3.0]]` | `[[12.0, 6.0, 3.0], [5.0, 3.0, -2.0]]` |
| `argsort_descending(0).argsort_descending(1)` | `[[0, 2, 1], [2, 0, 1]]` | `[[1, 2, 0], [0, 1, 2]]` |

The first call in each example was already correct; only the chained second value was wrong.

## Why it was not caught

These are `println!` outputs written in comments. `cargo test --doc` compiles and runs the examples, but nothing checks the printed values, so the comments can drift from behaviour without any test failing.

## Testing

Each corrected value was produced by running the example on the `ndarray` backend rather than worked out by hand:

```rust
let t = TestTensor::<2>::from_data(
    TensorData::from([[12.0f32, -2.0, 3.0], [5.0, 3.0, 6.0]]), &Default::default());
t.clone().sort(0).sort(1);                                 // [-2.0, 3.0, 5.0, 3.0, 6.0, 12.0]
t.clone().sort_descending(0).sort_descending(1);           // [12.0, 6.0, 3.0, 5.0, 3.0, -2.0]
t.argsort_descending(0).argsort_descending(1);             // [1, 2, 0, 0, 1, 2]
```

`cargo fmt --all -- --check` is clean. Documentation only, no behaviour change.

## Not included

The `topk` example in the same file is also a chained pair with a wrong second value, but it additionally panics before reaching that line — `topk(2, 0)` on a two-row tensor trips `assert!(self.shape()[dim] > k)`. That is a behaviour question rather than a documentation one, so I have raised it separately in #5297 and left the example untouched here.
