### PR TITLE
fix(xtask): apply the webgpu feature on the wgpu CI runner

### DIFF
--- a/xtask/src/commands/test.rs
+++ b/xtask/src/commands/test.rs
@@ -348,7 +348,7 @@ pub(crate) fn handle_command(
                         .get_or_insert_with(Vec::new)
                         .push("webgpu".to_string());
 
-                    let args_wgpu = args.clone().try_into().unwrap();
+                    let args_wgpu = args_wgpu.try_into().unwrap();
                     handle_wgpu_test("burn-wgpu", &args_wgpu)?;
                     handle_wgpu_test("burn-core", &args_wgpu)?;
                     handle_wgpu_test("burn-vision", &args_wgpu)?;


### PR DESCRIPTION

On the `gcp-wgpu-runner` job, `burn-wgpu`, `burn-core` and `burn-vision` are meant to be
tested with the `webgpu` feature, but the argument set carrying it is shadowed before it is
used, so they are tested with default features instead.

### The bug

`xtask/src/commands/test.rs`, `CiTestType::GcpWgpuRunner`:

```rust
let mut args_wgpu = args.clone();
args_wgpu
    .features
    .get_or_insert_with(Vec::new)
    .push("webgpu".to_string());

let args_wgpu = args.clone().try_into().unwrap();   // <- rebinds from `args`, not `args_wgpu`
handle_wgpu_test("burn-wgpu", &args_wgpu)?;
handle_wgpu_test("burn-core", &args_wgpu)?;
handle_wgpu_test("burn-vision", &args_wgpu)?;
```

The first `args_wgpu` — the one holding `webgpu` — is discarded by the second binding.

The parallel `GcpVulkanRunner` branch a few lines above shows the intended shape:

```rust
let args_vulkan = args_vulkan.try_into().unwrap();
```

### How it happened

`git blame` reads cleanly: `dbf03c516` wrote `let args_wgpu = args.clone().try_into()` when
no feature-setup block existed above it. `e18a3c2e3` then added the setup block to both the
vulkan and wgpu branches and updated the **vulkan** consumer to `args_vulkan.try_into()`,
leaving the wgpu consumer on the older `args.clone()`.

No lint fires on it: `args_wgpu` is mutated by the `.push(...)`, so it counts as used and
triggers neither `unused_variables` nor `unused_mut`, and `clippy::shadow_unrelated` is
allow-by-default.

### Impact

`WebGpu` is gated on the feature (`crates/burn-wgpu/src/lib.rs`):

```rust
#[cfg(feature = "webgpu")]
pub type WebGpu = WgpuInner<WgslCompiler>;
```

so without `webgpu` the WGSL-pinned specialization is not compiled at all, and the runner
dedicated to WGPU never builds or tests it for these three crates. The vulkan job does
exercise its equivalent (`Vulkan = WgpuInner<SpirvCompiler>`).

Scope is limited to those three calls. The `handle_backend_tests(.., TestBackend::Wgpu, ..)`
call at the top of the branch passes its own feature list and is unaffected, and the
`burn-optim` / `burn-nn` calls below push `burn-core/webgpu` onto `args` directly, so they
are correct as written.

### Fix

```diff
-                    let args_wgpu = args.clone().try_into().unwrap();
+                    let args_wgpu = args_wgpu.try_into().unwrap();
```

### Verification

`cargo check -p xtask` passes.

I could not run the GPU job itself — it is `workflow_dispatch` and needs the GCP runners — so
the behavioural confirmation (that these three crates now build with `webgpu`) would need a
maintainer dispatch.

**Worth knowing before merging:** because these three crates have not actually been built with
`webgpu` on CI since May, applying the feature may surface pre-existing compile errors or test
failures that were previously masked. That would be the fix working as intended rather than a
regression from this change, but it does mean the job could come back red on the first dispatch.
Happy to follow up on anything it turns up, or to adjust if you would rather the feature were
applied a different way.

The change to `args.target` on the line above happens before the clone, so the only behavioural
difference from this patch is the added feature — nothing else about the argument set changes.