### PR TITLE
fix(docs): correct chained reduction doc examples in numeric.rs

### DIFF
--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -362,11 +362,11 @@ where
     /// fn example() {
     ///   let device = Default::default();
     ///   let tensor = Tensor::<2>::from_data([[1.0, -2.0, 3.0], [5.0, 9.0, 6.0]], &device);
-    ///   let tensor = tensor.clone().mean_dim(0);
-    ///   println!("{tensor}");
+    ///   let mean = tensor.clone().mean_dim(0);
+    ///   println!("{mean}");
     ///   // [[3.0, 3.5, 4.5]]
-    ///   let tensor = tensor.clone().mean_dim(1);
-    ///   println!("{tensor}");
+    ///   let mean = tensor.mean_dim(1);
+    ///   println!("{mean}");
     ///   // [[0.6666667], [6.6666665]]
     /// }
     /// ```
@@ -420,11 +420,11 @@ where
     /// fn example() {
     ///    let device = Default::default();
     ///    let tensor = Tensor::<2>::from_data([[1.0, -2.0, 3.0], [5.0, 9.0, 6.0]], &device);
-    ///    let tensor = tensor.clone().sum_dim(0);
-    ///    println!("{tensor}");
+    ///    let sum = tensor.clone().sum_dim(0);
+    ///    println!("{sum}");
     ///    // [[6.0, 7.0, 9.0]]
-    ///    let tensor = tensor.clone().sum_dim(1);
-    ///    println!("{tensor}");
+    ///    let sum = tensor.sum_dim(1);
+    ///    println!("{sum}");
     ///    // [[2.0], [20.0]]
     /// }
     /// ```
@@ -535,11 +535,11 @@ where
     /// fn example() {
     ///    let device = Default::default();
     ///    let tensor = Tensor::<2>::from_data([[1.0, -2.0, 3.0], [5.0, 9.0, 6.0]], &device);
-    ///    let tensor = tensor.clone().prod_dim(0);
-    ///    println!("{tensor}");
+    ///    let prod = tensor.clone().prod_dim(0);
+    ///    println!("{prod}");
     ///    // [[5.0, -18.0, 18.0]]
-    ///    let tensor = tensor.clone().prod_dim(1);
-    ///    println!("{tensor}");
+    ///    let prod = tensor.prod_dim(1);
+    ///    println!("{prod}");
     ///    // [[-6.0], [270.0]]
     /// }
     /// ```


### PR DESCRIPTION

Follow-up to #5298, same defect in a different file.

`mean_dim`, `sum_dim` and `prod_dim` each show two calls, but the second one runs on the
result of the first because `tensor` is shadowed:

```rust
let tensor = Tensor::<2>::from_data([[1.0, -2.0, 3.0], [5.0, 9.0, 6.0]], &device);
let tensor = tensor.clone().sum_dim(0);   // tensor is now [[6.0, 7.0, 9.0]]
println!("{tensor}");
// [[6.0, 7.0, 9.0]]
let tensor = tensor.clone().sum_dim(1);   // reduces [[6.0, 7.0, 9.0]], not the original
println!("{tensor}");
// [[2.0], [20.0]]                        // <- correct for the ORIGINAL tensor
```

As in #5298, the documented values are right and the example code is wrong: each second
value is what you get by applying the op to the original tensor, which is what the example
is evidently meant to demonstrate. Fixed the same way you asked for there — clone the
original for the first call and stop shadowing `tensor`.

### Verified by running it

The claims are not obvious by inspection, so I executed all three against `burn-tensor`
rather than reasoning about them:

```
MEAN_DIM0     [3.0, 3.5, 4.5]              PROD_DIM0     [5.0, -18.0, 18.0]
MEAN_DIM1     [0.6666667, 6.6666665]       PROD_DIM1     [-6.0, 270.0]
CHAINED_MEAN  [3.6666667]                  CHAINED_PROD  [-1620.0]

SUM_DIM0      [6.0, 7.0, 9.0]
SUM_DIM1      [2.0, 20.0]
CHAINED_SUM   [22.0]
```

So in each case the documented second value matches the un-chained result and not what the
code computes (`[[2.0], [20.0]]` vs `[[22.0]]` for `sum_dim`, and so on). No documented
value changes in this PR — only the example code.

### Note on a related example

`Tensor::topk` (in `orderable.rs`) has the same chaining defect, and its first call also
panics on `assert!(self.shape()[dim] > k)` because `topk(2, 0)` asks for `k == shape[0]` —
that is #5297, still open. I have left `topk` alone here so this PR stays to one concern
and does not pre-empt the decision on that assertion. Happy to fix it in either direction
once you have ruled on #5297.