### PR TITLE
fix(tensor): topk check for k <= shape[dim]

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/float/ops/topk.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/topk.rs
@@ -32,3 +32,56 @@ fn test_topk_supports_negative_dim_float() {
         .into_data()
         .assert_approx_eq::<FloatElem>(&values_expected, Tolerance::default());
 }
+
+#[test]
+fn test_topk_supports_k_dim_size() {
+    let tensor = TestTensor::<2>::from_data(
+        TensorData::from([[12., -2., 3.], [5., 3., 6.]]),
+        &Default::default(),
+    );
+
+    let values = tensor.clone().topk(2, 0);
+    values.into_data().assert_approx_eq::<FloatElem>(
+        &TensorData::from([[12., 3., 6.], [5., -2., 3.]]),
+        Tolerance::default(),
+    );
+
+    let values = tensor.topk(3, 1);
+    values.into_data().assert_approx_eq::<FloatElem>(
+        &TensorData::from([[12., 3., -2.], [6., 5., 3.]]),
+        Tolerance::default(),
+    );
+
+    let tensor =
+        TestTensor::<3>::from([[[1., 4., 7.], [2., 5., 6.]], [[3., 0., 9.], [8., 2., 7.]]]);
+
+    let values = tensor.topk(2, 0);
+    values.into_data().assert_approx_eq::<FloatElem>(
+        &TensorData::from([[[3., 4., 9.], [8., 5., 7.]], [[1., 0., 7.], [2., 2., 6.]]]),
+        Tolerance::default(),
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_topk_should_panic_k_larger() {
+    let tensor = TestTensor::<2>::from_data(
+        TensorData::from([[12., -2., 3.], [5., 3., 6.]]),
+        &Default::default(),
+    );
+
+    // k=3 is too large for dim of size 2
+    let _values = tensor.topk(3, 0);
+}
+
+#[test]
+#[should_panic]
+fn test_topk_with_indices_should_panic_k_larger() {
+    let tensor = TestTensor::<2>::from_data(
+        TensorData::from([[12., -2., 3.], [5., 3., 6.]]),
+        &Default::default(),
+    );
+
+    // k=3 is too large for dim of size 2
+    let (_values, _indices) = tensor.topk_with_indices(3, 0);
+}

--- a/crates/burn-backend-tests/tests/tensor/float/ops/topk.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/topk.rs
@@ -63,6 +63,35 @@ fn test_topk_supports_k_dim_size() {
 }
 
 #[test]
+fn test_topk_with_indices_supports_k_dim_size() {
+    let tensor = TestTensor::<2>::from_data(
+        TensorData::from([[12., -2., 3.], [5., 3., 6.]]),
+        &Default::default(),
+    );
+
+    let values = tensor.clone().topk_with_indices(2, 0).0;
+    values.into_data().assert_approx_eq::<FloatElem>(
+        &TensorData::from([[12., 3., 6.], [5., -2., 3.]]),
+        Tolerance::default(),
+    );
+
+    let values = tensor.topk_with_indices(3, 1).0;
+    values.into_data().assert_approx_eq::<FloatElem>(
+        &TensorData::from([[12., 3., -2.], [6., 5., 3.]]),
+        Tolerance::default(),
+    );
+
+    let tensor =
+        TestTensor::<3>::from([[[1., 4., 7.], [2., 5., 6.]], [[3., 0., 9.], [8., 2., 7.]]]);
+
+    let values = tensor.topk_with_indices(2, 0).0;
+    values.into_data().assert_approx_eq::<FloatElem>(
+        &TensorData::from([[[3., 4., 9.], [8., 5., 7.]], [[1., 0., 7.], [2., 2., 6.]]]),
+        Tolerance::default(),
+    );
+}
+
+#[test]
 #[should_panic]
 fn test_topk_should_panic_k_larger() {
     let tensor = TestTensor::<2>::from_data(

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -1406,6 +1406,22 @@ impl TensorCheck {
 
         check
     }
+
+    pub(crate) fn topk(op: &str, k: usize, dim: usize, shape: &Shape) -> Self {
+        let mut check = Self::Ok;
+
+        if k > shape[dim] {
+            check = check.register(
+                op,
+                TensorError::new("The selected index k is out of range.").details(format!(
+                    "Got k={k} for dimension {dim} with input shape {:?}.",
+                    shape.as_slice(),
+                )),
+            );
+        }
+
+        check
+    }
 }
 
 pub(crate) struct FailedTensorCheck {

--- a/crates/burn-tensor/src/tensor/api/orderable.rs
+++ b/crates/burn-tensor/src/tensor/api/orderable.rs
@@ -232,7 +232,7 @@ where
     /// ```
     pub fn topk<I: AsIndex>(self, k: usize, dim: I) -> Self {
         let dim = unwrap_dim_index(dim.try_dim_index(D), "Top K");
-        assert!(self.shape()[dim] > k);
+        check!(TensorCheck::topk("Top K", k, dim, &self.shape()));
         Tensor::new(K::topk(self.primitive, dim, k))
     }
 
@@ -267,6 +267,12 @@ where
     /// ```
     pub fn topk_with_indices<I: AsIndex>(self, k: usize, dim: I) -> (Self, Tensor<D, Int>) {
         let dim = unwrap_dim_index(dim.try_dim_index(D), "Top K With Indices");
+        check!(TensorCheck::topk(
+            "Top K With Indices",
+            k,
+            dim,
+            &self.shape()
+        ));
         let (values, indices) = K::topk_with_indices(self.primitive, dim, k);
         (Tensor::new(values), Tensor::new(indices))
     }


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Fixes #5297

### Changes

Updated `topk` and `topk_with_indices` tensor check that fails when `k > shape[dim]` (so any `k <= shape[dim]` is valid).

### Testing

Unit tests
