### PR TITLE
feat(burn-cubecl): native argwhere/nonzero/mask_select via stream compaction

### DIFF
--- a/crates/burn-cubecl/src/kernel/index/argwhere.rs
+++ b/crates/burn-cubecl/src/kernel/index/argwhere.rs
@@ -1,0 +1,119 @@
+use crate::{
+    CubeRuntime,
+    kernel::{
+        bool_cast, into_contiguous, slice,
+        utils::{address_type, decompose_linear, shape_divmod},
+    },
+    ops::{
+        base::{into_data, reshape},
+        numeric::{cumsum, empty_device_contiguous_dtype},
+    },
+    tensor::CubeTensor,
+};
+use burn_backend::cubecl::dtype_to_storage_type;
+use burn_backend::{DType, IntDType, Shape, TensorMetadata};
+use cubecl::{CubeDim, calculate_cube_count_elemwise};
+use cubecl::{prelude::*, std::FastDivmod, std::tensor::layout::linear::LinearView};
+
+/// Scatter the coordinate of every `true` element to its output row.
+///
+/// One thread per input element. `offsets` is the inclusive prefix sum of the 0/1 mask, so for a
+/// `true` element the running count `offsets[pos]` gives its 1-based row in the output; `false`
+/// elements write nothing. `row * ndims + d` indexes the contiguous `[count, ndims]` output.
+#[cube(launch_unchecked, address_type = "dynamic")]
+fn argwhere_kernel<I: Int>(
+    mask: LinearView<'_, I>,
+    offsets: LinearView<'_, I>,
+    output: &mut Tensor<I>,
+    shape: Sequence<FastDivmod<usize>>,
+    working_units: usize,
+    #[comptime] ndims: usize,
+    #[define(I)] _dtype: StorageType,
+) {
+    if ABSOLUTE_POS >= working_units {
+        terminate!();
+    }
+
+    if usize::cast_from(mask.read(ABSOLUTE_POS)) != 0 {
+        let row = usize::cast_from(offsets.read(ABSOLUTE_POS)) - 1;
+        let (_, coords) = decompose_linear(ABSOLUTE_POS, &shape);
+        #[unroll]
+        for d in 0..ndims {
+            output[row * ndims + d] = I::cast_from(*coords.index(d));
+        }
+    }
+}
+
+/// Compute the coordinates of the `true` elements, one row per element (row-major order).
+///
+/// GPU stream compaction: cast the mask to 0/1, prefix-sum it to get each element's output row,
+/// read the total count back to the host to size the `[count, ndims]` output, then scatter each
+/// `true` element's coordinate into its row. The count read is the only host synchronization; it
+/// is data-dependent, which is why the op is asynchronous.
+pub(crate) async fn argwhere<R: CubeRuntime>(
+    tensor: CubeTensor<R>,
+    out_dtype: IntDType,
+) -> CubeTensor<R> {
+    let client = tensor.client.clone();
+    let device = tensor.device.clone();
+    let dtype: DType = out_dtype.into();
+
+    // Flat position must map to a coordinate, so the mask has to be contiguous.
+    let tensor = into_contiguous(tensor);
+    let shape = tensor.shape();
+    let ndims = shape.num_dims();
+    let n = shape.num_elements();
+
+    // 1. bool -> 0/1 int mask, keeping the original (contiguous) shape for coordinate decomposition.
+    let mask = bool_cast(tensor, dtype);
+    let coord_shape = shape_divmod(&mask);
+
+    // 2. inclusive prefix sum over the flattened mask -> per-element output rows.
+    let mask_flat = reshape(mask.clone(), Shape::new([n]));
+    let offsets = cumsum(mask_flat.clone(), 0);
+
+    // 3. total count = last prefix-sum element, read back to the host (the only sync).
+    let count = if n == 0 {
+        0
+    } else {
+        let last_row = (n - 1)..n;
+        let last = slice(offsets.clone(), &[last_row]);
+        into_data(last)
+            .await
+            .expect("Can read the count without error")
+            .iter::<i64>()
+            .next()
+            .expect("The count slice has one element") as usize
+    };
+
+    // 4. empty result: no rows to scatter.
+    if count == 0 {
+        return empty_device_contiguous_dtype(client, device, Shape::new([0, ndims]), dtype);
+    }
+
+    // 5. allocate the [count, ndims] output.
+    let output =
+        empty_device_contiguous_dtype(client.clone(), device, Shape::new([count, ndims]), dtype);
+
+    // 6. scatter each true element's coordinate to its row.
+    let working_units = n;
+    let cube_dim = CubeDim::new(&client, working_units);
+    let cube_count = calculate_cube_count_elemwise(&client, working_units, cube_dim);
+    unsafe {
+        argwhere_kernel::launch_unchecked::<R>(
+            &client,
+            cube_count,
+            cube_dim,
+            address_type!(mask_flat, offsets, output),
+            mask_flat.into_linear_view(),
+            offsets.into_linear_view(),
+            output.clone().into_tensor_arg(),
+            coord_shape,
+            working_units,
+            ndims,
+            dtype_to_storage_type(dtype),
+        );
+    }
+
+    output
+}

--- a/crates/burn-cubecl/src/kernel/index/mod.rs
+++ b/crates/burn-cubecl/src/kernel/index/mod.rs
@@ -1,3 +1,4 @@
+mod argwhere;
 mod flip;
 mod gather;
 mod gather_nd;
@@ -9,6 +10,7 @@ mod select_assign;
 mod slice;
 mod slice_assign;
 
+pub(crate) use argwhere::*;
 pub(crate) use flip::*;
 pub(crate) use gather_nd::*;
 pub(crate) use repeat_dim::*;

--- a/crates/burn-cubecl/src/ops/bool_tensor.rs
+++ b/crates/burn-cubecl/src/ops/bool_tensor.rs
@@ -58,6 +58,10 @@ impl<R: CubeRuntime> BoolTensorOps<Self> for CubeBackend<R> {
         kernel::bool_cast(tensor, out_dtype.into())
     }
 
+    async fn bool_argwhere(tensor: BoolTensor<Self>, out_dtype: IntDType) -> IntTensor<Self> {
+        kernel::argwhere(tensor, out_dtype).await
+    }
+
     fn bool_to_device(tensor: BoolTensor<Self>, device: &Device<Self>) -> BoolTensor<Self> {
         super::to_device(tensor, device)
     }


### PR DESCRIPTION
## Native argwhere/nonzero/mask_select via stream compaction (#5286)

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR. (No book change: this is a backend-internal op override with no user-facing API change.)

### Related Issues/PRs

Part of #5286. Follows the discussion on #5283, where `mask_select` was promoted to a backend op with a host-read default and a native cubecl implementation was left as a follow-up.

This is a **draft**: it lands the native implementations but deliberately leaves the parallel-scan optimization for a follow-up (see the note at the bottom).

### Changes

Today the cubecl backend inherits the host-read default for `bool_argwhere`: it copies the whole mask back to the host and computes the coordinates on the CPU. This PR implements `argwhere` natively on the device using stream compaction, so the mask never leaves the GPU (except for one scalar).

A single override, `bool_argwhere` in `burn-cubecl`, is the only new op. The other two operations improve for free because they compose on it:
- `nonzero` builds on `argwhere` at the tensor layer.
- `mask_select` uses the backend default that composes `argwhere` with `select`.

**Pipeline** (all on device unless noted):
1. `into_contiguous` so a flat position maps to a reliable coordinate.
2. `bool_cast` to a 0/1 int mask, flattened to `[n]`.
3. `cumsum` (inclusive prefix sum) so each element learns its output row.
4. Read back the last prefix-sum entry, the total count. This is a single scalar and the only host synchronization. It is data dependent, which is why the op is asynchronous.
5. Allocate the `[count, ndims]` output (`[0, ndims]` when the count is zero).
6. A new compaction kernel writes each `true` element's coordinate to its row.

The count read is the only sync. It is irreducible because the output size depends on the data, but it moves a single scalar instead of the entire mask, and it fits the existing `async` signature of the trait method.

### Testing

Validated on a real NVIDIA GPU (RTX 4090, CUDA 12.8.1, driver 580.159.04) with `--features cuda`, and cross-checked on the cubecl CPU backend.

`cargo test -p burn-backend-tests --features cuda --test tensor -- argwhere nonzero mask_select`:

```
running 20 tests
test tensor::bool::ops::argwhere_nonzero::test_argwhere_empty ... ok
test tensor::bool::ops::argwhere_nonzero::test_argwhere_3d ... ok
test tensor::bool::ops::argwhere_nonzero::test_argwhere_2d ... ok
test tensor::bool::ops::argwhere_nonzero::test_argwhere_1d ... ok
test tensor::bool::ops::argwhere_nonzero::test_nonzero_1d ... ok
test tensor::bool::ops::argwhere_nonzero::test_nonzero_2d ... ok
test tensor::bool::ops::argwhere_nonzero::test_nonzero_empty ... ok
test tensor::bool::ops::argwhere_nonzero::test_nonzero_3d ... ok
test tensor::bool::ops::mask_select::test_mask_select_bool ... ok
test tensor::float::ops::mask_select::test_mask_select_2d ... ok
test tensor::float::ops::mask_select::test_mask_select_1d ... ok
test tensor::float::ops::mask_select::test_mask_select_shape_mismatch - should panic ... ok
test tensor::float::ops::mask_select::test_mask_select_both_flipped ... ok
test tensor::float::ops::mask_select::test_mask_select_3d ... ok
test tensor::float::ops::mask_select::test_mask_select_narrowed_tensor ... ok
test tensor::float::ops::mask_select::test_mask_select_empty ... ok
test tensor::float::ops::mask_select::test_mask_select_transposed_tensor ... ok
test tensor::float::ops::mask_select::test_mask_select_single_element ... ok
test tensor::int::ops::mask_select::test_mask_select_int_1d ... ok
test tensor::int::ops::mask_select::test_mask_select_int_2d ... ok

test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 1499 filtered out; finished in 1.06s
```

The forward path passes on every shape and dtype, including the empty cases.

**Note on a pre-existing failure.** The autodiff suite has two red tests on the cuda backend, `test_mask_select_grad_empty_mask` (base and checkpointing). They fail with `plane_vectorized_parallel_reduce: input reduce axis length (currently 0) should be at least k (1)`, which comes from the autotune of a `Sum` reduction over a zero length axis in the backward pass. This is unrelated to `argwhere`: it lives in the reduce path, not the index computation. I confirmed it pre-exists on the same GPU by reverting this patch to the pristine base commit and rerunning the two tests, which fail identically. So this PR neither introduces nor fixes them.

### Follow-up (not in this PR)

The prefix sum reuses the existing `numeric::cumsum`, which is a naive O(n^2) scan (see the `TODO: efficient parallel scan` in `numeric.rs`). Replacing it with a work-efficient parallel scan (plane/warp-level) is the performance half of #5286 and is being worked on as a separate change. It is deliberately excluded here so the correctness base can land and be reviewed on its own. Before and after numbers will come with that follow-up, since benchmarking against the current naive scan would not be representative of the intended performance.