### PR TITLE
Feat/rocm and cpu throughput

### DIFF
--- a/crates/burn-cpu/src/lib.rs
+++ b/crates/burn-cpu/src/lib.rs
@@ -4,13 +4,24 @@ extern crate alloc;
 
 use burn_cubecl::CubeBackend;
 pub use cubecl::cpu::CpuDevice;
-use cubecl::cpu::CpuRuntime;
+use cubecl::{
+    cpu::CpuRuntime,
+    throughput::{ThroughputKey, ThroughputValue},
+};
 
 #[cfg(not(feature = "fusion"))]
 pub type Cpu = CubeBackend<CpuRuntime>;
 
 #[cfg(feature = "fusion")]
 pub type Cpu = burn_fusion::Fusion<CubeBackend<CpuRuntime>>;
+
+/// Measure peak throughput on a CPU `device` for each of the given `keys`.
+pub fn device_throughput(
+    device: &CpuDevice,
+    keys: &[ThroughputKey],
+) -> alloc::vec::Vec<ThroughputValue> {
+    cubecl::std::throughput::device_throughput::<CpuRuntime>(device, keys)
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/burn-dispatch/src/device.rs
+++ b/crates/burn-dispatch/src/device.rs
@@ -83,13 +83,18 @@ impl DispatchDevice {
     /// Measure peak throughput for this device against the given `keys`.
     ///
     /// Only cubecl-backed devices can measure throughput; other backends
-    /// (ndarray, libtorch, remote, ...) return an empty vector. Each returned
+    /// (ndarray, libtorch, remote, ...) return an empty vector. An autodiff
+    /// device reports the peaks of the device it wraps. Each returned
     /// [`ThroughputValue`](burn_backend::cubecl::ThroughputValue) corresponds
     /// positionally to the key at the same index.
     pub fn performance_stats(&self, keys: &[ThroughputKey]) -> Vec<ThroughputValue> {
         match self {
+            #[cfg(feature = "cpu")]
+            DispatchDevice::Cpu(device) => burn_cpu::device_throughput(device, keys),
             #[cfg(feature = "cuda")]
             DispatchDevice::Cuda(device) => burn_cuda::device_throughput(device, keys),
+            #[cfg(feature = "rocm")]
+            DispatchDevice::Rocm(device) => burn_rocm::device_throughput(device, keys),
             #[cfg(feature = "wgpu")]
             DispatchDevice::Wgpu(device) => burn_wgpu::device_throughput(device, keys),
             #[cfg(feature = "vulkan")]
@@ -98,6 +103,9 @@ impl DispatchDevice {
             DispatchDevice::Metal(device) => burn_wgpu::device_throughput(device, keys),
             #[cfg(feature = "webgpu")]
             DispatchDevice::WebGpu(device) => burn_wgpu::device_throughput(device, keys),
+            // Autodiff changes nothing about the hardware, so measure the device it wraps.
+            #[cfg(feature = "autodiff")]
+            DispatchDevice::Autodiff(device) => device.performance_stats(keys),
             #[allow(unreachable_patterns)]
             _ => Vec::new(),
         }

--- a/crates/burn-dispatch/src/device.rs
+++ b/crates/burn-dispatch/src/device.rs
@@ -88,9 +88,8 @@ impl DispatchDevice {
     /// [`ThroughputValue`](burn_backend::cubecl::ThroughputValue) corresponds
     /// positionally to the key at the same index.
     pub fn performance_stats(&self, keys: &[ThroughputKey]) -> Vec<ThroughputValue> {
-        // Deliberately exhaustive, with no catch-all: a backend that cannot
-        // measure has to say so by name. A `_` arm here is what let ROCm report
-        // no peaks at all rather than fail to compile when the variant landed.
+        // No catch-all arm: a new backend must fail to compile here rather
+        // than silently report no peaks.
         match self {
             #[cfg(feature = "cpu")]
             DispatchDevice::Cpu(device) => burn_cpu::device_throughput(device, keys),
@@ -106,9 +105,10 @@ impl DispatchDevice {
             DispatchDevice::Metal(device) => burn_wgpu::device_throughput(device, keys),
             #[cfg(feature = "webgpu")]
             DispatchDevice::WebGpu(device) => burn_wgpu::device_throughput(device, keys),
-            // Autodiff changes nothing about the hardware, so measure the device it wraps.
+            // Autodiff does not change the hardware, so measure the wrapped device.
             #[cfg(feature = "autodiff")]
             DispatchDevice::Autodiff(device) => device.performance_stats(keys),
+
             // Not cubecl-backed, so there are no kernels to measure.
             #[cfg(any(feature = "flex", default_backend))]
             DispatchDevice::Flex(_) => Vec::new(),
@@ -116,6 +116,7 @@ impl DispatchDevice {
             DispatchDevice::NdArray(_) => Vec::new(),
             #[cfg(feature = "tch")]
             DispatchDevice::LibTorch(_) => Vec::new(),
+
             // The kernels run on the server, which this local API cannot reach.
             #[cfg(feature = "remote")]
             DispatchDevice::Remote(_) => Vec::new(),

--- a/crates/burn-dispatch/src/device.rs
+++ b/crates/burn-dispatch/src/device.rs
@@ -88,6 +88,9 @@ impl DispatchDevice {
     /// [`ThroughputValue`](burn_backend::cubecl::ThroughputValue) corresponds
     /// positionally to the key at the same index.
     pub fn performance_stats(&self, keys: &[ThroughputKey]) -> Vec<ThroughputValue> {
+        // Deliberately exhaustive, with no catch-all: a backend that cannot
+        // measure has to say so by name. A `_` arm here is what let ROCm report
+        // no peaks at all rather than fail to compile when the variant landed.
         match self {
             #[cfg(feature = "cpu")]
             DispatchDevice::Cpu(device) => burn_cpu::device_throughput(device, keys),
@@ -106,8 +109,16 @@ impl DispatchDevice {
             // Autodiff changes nothing about the hardware, so measure the device it wraps.
             #[cfg(feature = "autodiff")]
             DispatchDevice::Autodiff(device) => device.performance_stats(keys),
-            #[allow(unreachable_patterns)]
-            _ => Vec::new(),
+            // Not cubecl-backed, so there are no kernels to measure.
+            #[cfg(any(feature = "flex", default_backend))]
+            DispatchDevice::Flex(_) => Vec::new(),
+            #[cfg(feature = "ndarray")]
+            DispatchDevice::NdArray(_) => Vec::new(),
+            #[cfg(feature = "tch")]
+            DispatchDevice::LibTorch(_) => Vec::new(),
+            // The kernels run on the server, which this local API cannot reach.
+            #[cfg(feature = "remote")]
+            DispatchDevice::Remote(_) => Vec::new(),
         }
     }
 }

--- a/crates/burn-rocm/src/lib.rs
+++ b/crates/burn-rocm/src/lib.rs
@@ -5,10 +5,21 @@ use burn_cubecl::CubeBackend;
 
 pub use cubecl::hip::AmdDevice as RocmDevice;
 
-use cubecl::hip::HipRuntime;
+use cubecl::{
+    hip::HipRuntime,
+    throughput::{ThroughputKey, ThroughputValue},
+};
 
 #[cfg(not(feature = "fusion"))]
 pub type Rocm = CubeBackend<HipRuntime>;
 
 #[cfg(feature = "fusion")]
 pub type Rocm = burn_fusion::Fusion<CubeBackend<HipRuntime>>;
+
+/// Measure peak throughput on a ROCm `device` for each of the given `keys`.
+pub fn device_throughput(
+    device: &RocmDevice,
+    keys: &[ThroughputKey],
+) -> alloc::vec::Vec<ThroughputValue> {
+    cubecl::std::throughput::device_throughput::<HipRuntime>(device, keys)
+}


### PR DESCRIPTION
Adds the missing backends for the device throughput calculations.

This now makes it deliberately exhaustive to make sure a device determines itself if it can report throughputs rather than letting it silently "fail".