### PR TITLE
fix(burn-cubecl): fill the reduction identity over a zero-length axis

### DIFF
--- a/crates/burn-backend-tests/tests/cubecl/reduce.rs
+++ b/crates/burn-backend-tests/tests/cubecl/reduce.rs
@@ -350,6 +350,65 @@ fn reduction_sum_should_match_reference_backend() {
         .assert_approx_eq::<FloatElem>(&tensor_ref.clone().sum().into_data(), Tolerance::default());
 }
 
+// Reducing over a zero-length axis folds no elements, so the result is the reduction identity.
+// The reduce kernels reject a zero-length axis, so these exercise the host-side identity fill.
+
+#[test]
+fn reduction_sum_dim_empty_axis() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::zeros([2, 0], &device);
+    let expected = TestTensor::<2>::from_data([[0.0], [0.0]], &device);
+    tensor
+        .sum_dim(1)
+        .into_data()
+        .assert_eq(&expected.into_data(), false);
+}
+
+#[test]
+fn reduction_prod_dim_empty_axis() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::zeros([2, 0], &device);
+    let expected = TestTensor::<2>::from_data([[1.0], [1.0]], &device);
+    tensor
+        .prod_dim(1)
+        .into_data()
+        .assert_eq(&expected.into_data(), false);
+}
+
+#[test]
+fn reduction_max_dim_empty_axis() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::zeros([2, 0], &device);
+    let expected = TestTensor::<2>::from_data([[f32::NEG_INFINITY], [f32::NEG_INFINITY]], &device);
+    tensor
+        .max_dim(1)
+        .into_data()
+        .assert_eq(&expected.into_data(), false);
+}
+
+#[test]
+fn reduction_min_dim_empty_axis() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::zeros([2, 0], &device);
+    let expected = TestTensor::<2>::from_data([[f32::INFINITY], [f32::INFINITY]], &device);
+    tensor
+        .min_dim(1)
+        .into_data()
+        .assert_eq(&expected.into_data(), false);
+}
+
+#[test]
+fn reduction_mean_dim_empty_axis() {
+    // Mean over an empty axis is 0 / 0 = NaN, which cannot be compared with equality.
+    let device = Default::default();
+    let tensor = TestTensor::<2>::zeros([2, 0], &device);
+    let data = tensor.mean_dim(1).into_data();
+    assert!(
+        data.iter::<f32>().all(|x| x.is_nan()),
+        "mean over an empty axis should be NaN, got {data:?}"
+    );
+}
+
 #[test]
 #[ignore = "Impossible to run unless you have tons of VRAM. Also reference backend is broken."]
 fn reduction_sum_should_match_reference_backend_64bit() {

--- a/crates/burn-cubecl/src/kernel/reduce/base.rs
+++ b/crates/burn-cubecl/src/kernel/reduce/base.rs
@@ -63,6 +63,13 @@ pub fn sum<Run: CubeRuntime>(
     let client = tensor.client.clone();
     let device = tensor.device.clone();
 
+    // A sum over an empty tensor folds no elements, so the result is the additive identity 0.
+    // The reduce kernels reject a zero-length axis (they require at least one element), so
+    // return the identity directly instead of dispatching to them.
+    if tensor.shape().num_elements() == 0 {
+        return Ok(zeros_client(client, device, [1].into(), tensor.dtype));
+    }
+
     match strategy {
         SumStrategy::OneShot(cube_count) => {
             let output = zeros_client(client.clone(), device, [1].into(), tensor.dtype);
@@ -225,6 +232,12 @@ pub fn reduce_dim<Run: CubeRuntime>(
         },
     )?;
 
+    // Reducing over a zero-length axis folds no elements, so every output position is the
+    // reduction identity. The kernels reject a zero-length axis, so fill the identity directly.
+    if input.shape()[dim] == 0 {
+        return super::empty::reduce_empty_axis(output, config);
+    }
+
     let result = match strategy {
         KernelReduceStrategy::Unspecified => cubek::reduce::reduce::<Run>(
             &client,
@@ -296,6 +309,14 @@ pub fn reduce_dim_with_indices<Run: CubeRuntime>(
         ReduceOperationConfig::Any => return Err(unsupported("Any")),
         ReduceOperationConfig::All => return Err(unsupported("All")),
     };
+
+    // Index-producing reductions have no result over a zero-length axis: there is no element
+    // to point at. Return an error rather than dispatching to a kernel that rejects length 0.
+    if dim < input.meta.num_dims() && input.shape()[dim] == 0 {
+        return Err(ReduceError::Validation {
+            details: "reducing over a zero-length axis has no result index",
+        });
+    }
 
     let out_len = accumulator_len(config);
 

--- a/crates/burn-cubecl/src/kernel/reduce/empty.rs
+++ b/crates/burn-cubecl/src/kernel/reduce/empty.rs
@@ -1,0 +1,104 @@
+use crate::{CubeRuntime, kernel::utils::address_type, tensor::CubeTensor};
+use burn_backend::cubecl::dtype_to_storage_type;
+use cubecl::{CubeDim, calculate_cube_count_elemwise};
+use cubecl::{prelude::*, std::tensor::layout::linear::LinearViewMut};
+use cubek::reduce::{ReduceError, components::instructions::ReduceOperationConfig};
+
+// Identity kinds selected on the host and baked into the fill kernel at comptime.
+const KIND_ZERO: u32 = 0;
+const KIND_ONE: u32 = 1;
+const KIND_NAN: u32 = 2;
+const KIND_TYPE_MIN: u32 = 3;
+const KIND_TYPE_MAX: u32 = 4;
+
+/// Fill every output element with a reduction's identity value.
+///
+/// The extrema identities mirror `cubek`'s `max_identity` / `min_identity`: the identity for a max
+/// reduction is the type minimum and for a min reduction the type maximum. Floats have no infinity
+/// literal on every target, so they are built from their IEEE-754 bits, exactly as `cubek` does.
+#[cube(launch_unchecked, address_type = "dynamic")]
+fn fill_reduce_identity_kernel<E: Numeric>(
+    mut output: LinearViewMut<'_, E>,
+    #[comptime] kind: u32,
+    #[define(E)] _dtype: StorageType,
+) {
+    if !output.is_in_bounds(ABSOLUTE_POS) {
+        terminate!();
+    }
+
+    let elem_type = type_of::<E>();
+    let value = if comptime!(kind == KIND_ZERO) {
+        E::from_int(0)
+    } else if comptime!(kind == KIND_ONE) {
+        E::from_int(1)
+    } else if comptime!(kind == KIND_NAN) {
+        E::cast_from(f32::reinterpret(0x7fc0_0000u32))
+    } else if comptime!(kind == KIND_TYPE_MAX) {
+        if comptime!(elem_type.is_float()) {
+            E::cast_from(f32::reinterpret(0x7f80_0000u32))
+        } else {
+            E::max_value()
+        }
+    } else {
+        if comptime!(elem_type.is_float()) {
+            E::cast_from(f32::reinterpret(0xff80_0000u32))
+        } else {
+            E::min_value()
+        }
+    };
+
+    output.write(ABSOLUTE_POS, value);
+}
+
+/// Result of reducing over a zero-length axis: every output position is the reduction identity.
+///
+/// `output` is the already-allocated reduce output (the reduced axis has length 1). There is no
+/// element to fold, so the kernels (which require an axis length of at least 1) are skipped and the
+/// identity is written directly. Operations whose result is an index (`ArgMax`, `ArgMin`, `TopK`,
+/// `ArgTopK`) have no answer over an empty axis and return an error instead.
+pub(crate) fn reduce_empty_axis<R: CubeRuntime>(
+    output: CubeTensor<R>,
+    config: ReduceOperationConfig,
+) -> Result<CubeTensor<R>, ReduceError> {
+    let kind = match config {
+        ReduceOperationConfig::Sum | ReduceOperationConfig::MaxAbs | ReduceOperationConfig::Any => {
+            KIND_ZERO
+        }
+        ReduceOperationConfig::Prod | ReduceOperationConfig::All => KIND_ONE,
+        ReduceOperationConfig::Mean => KIND_NAN,
+        ReduceOperationConfig::Max => KIND_TYPE_MIN,
+        ReduceOperationConfig::Min => KIND_TYPE_MAX,
+        ReduceOperationConfig::ArgMax
+        | ReduceOperationConfig::ArgMin
+        | ReduceOperationConfig::ArgTopK(_)
+        | ReduceOperationConfig::TopK(_) => {
+            return Err(ReduceError::Validation {
+                details: "reducing over a zero-length axis has no result for this operation",
+            });
+        }
+    };
+
+    let num_elems = output.meta.num_elements();
+    if num_elems == 0 {
+        // Another axis is empty too, so the output holds no elements: nothing to fill.
+        return Ok(output);
+    }
+
+    let client = output.client.clone();
+    let dtype = output.dtype;
+    let cube_dim = CubeDim::new(&client, num_elems);
+    let cube_count = calculate_cube_count_elemwise(&client, num_elems, cube_dim);
+    unsafe {
+        fill_reduce_identity_kernel::launch_unchecked::<R>(
+            &client,
+            cube_count,
+            cube_dim,
+            address_type!(output),
+            output.clone().into_linear_view(),
+            kind,
+            dtype_to_storage_type(dtype),
+        );
+    }
+
+    Ok(output)
+}

--- a/crates/burn-cubecl/src/kernel/reduce/mod.rs
+++ b/crates/burn-cubecl/src/kernel/reduce/mod.rs
@@ -1,6 +1,7 @@
 mod base;
 #[cfg(feature = "autotune")]
 mod bounds;
+mod empty;
 #[cfg(feature = "autotune")]
 mod tune;
 


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Closes #5310. Related to #5305, which fixed the same class of panic on the
tch backend.

### Changes

Reducing a tensor over an axis of length 0 panicked on the cubecl backends:
the reduce kernels require an axis length of at least 1. The trigger in
practice is the `mask_select` backward pass on an all-false mask, which
reduces over a zero-length axis:

```
input reduce axis length (currently 0) should be at least k (1)
```

Since there is nothing to fold, the result is the reduction identity (the
neutral element of the operation). Fill it directly instead of dispatching to
a kernel that rejects length 0.

- `crates/burn-cubecl/src/kernel/reduce/empty.rs` (new): `reduce_empty_axis`
  maps each operation to its identity and launches a small fill kernel
  (`fill_reduce_identity_kernel`) that writes it into every output position.
- `crates/burn-cubecl/src/kernel/reduce/base.rs`: a zero-length guard at each
  entry point that can reach a reduce kernel. `sum()` returns `zeros([1])`,
  `reduce_dim()` calls `reduce_empty_axis`, and `reduce_dim_with_indices()`
  returns a `ReduceError`.

**Identity per operation:**

| identity | operations | reason |
| --- | --- | --- |
| 0 | sum, maxabs, any | adding nothing |
| 1 | prod, all | multiplying nothing |
| -inf | max | loses to any value |
| +inf | min | beats any value |
| NaN | mean | sum 0 / count 0 |
| error | argmax, argmin, topk, argtopk | no index exists |

**Design decisions (confirmation welcome)**:

I made the following choices deliberately and would like your sign-off before
they land. They are laid out transparently so you can redirect any of them.

- Max / min identity and NumPy divergence. The mathematical identity of `max`
  over an empty set is `-inf` (and `+inf` for `min`), which is what this PR
  fills, so every reduction that has a neutral element returns it. NumPy instead
  raises for `max` / `min` over an empty axis ("zero-size array to reduction
  operation which has no identity"), while it returns 0 / 1 for sum / prod and
  NaN for mean. Filling the extreme keeps the behavior uniform across
  operations. This is the main decision I would like confirmed: I am happy to
  switch max / min to an error instead if you prefer NumPy parity.
- Index reductions error. `argmax` / `argmin` / `topk` / `argtopk` return an
  index; over an empty axis there is no position to point at, so they return
  `ReduceError::Validation` rather than fabricating an index. This one seems
  clearly correct, but I am flagging it too in case you would rather surface it
  differently.

Extrema built from bits is an implementation detail rather than a behavioral
choice: floats have no portable infinity literal across cubecl targets, so
`+/-inf` and `NaN` are built from their IEEE-754 bits via `f32::reinterpret`,
matching how cubek forms its own `max_identity` / `min_identity`. Integers use
`E::max_value()` / `E::min_value()`, with the identity kind selected on the host
and baked into the kernel at comptime.

I will adjust any of these to your preference before this is ready to merge.

### Testing

Five value tests were added in
`crates/burn-backend-tests/tests/cubecl/reduce.rs`, covering `sum` / `prod` /
`max` / `min` / `mean` over a `[2, 0]` axis (mean asserted as NaN, which cannot
be compared by equality). The existing reduce suite and the `mask_select`
gradient tests pass unchanged.

- CPU (cubecl-cpu): 5/5 empty-axis tests, full reduce suite with no regression,
  `test_mask_select_grad_empty_mask` green.
- GPU (RTX 4090, CUDA 12.8.1): `test_mask_select_grad_empty_mask` 2 passed;
  cubecl reduce suite 22 passed, 0 failed (including the 5 empty-axis tests).
  The extreme fill kernel (`+/-inf` via `f32::reinterpret`) produces correct
  values on a real GPU.
- `cargo run-checks` passes (format, clippy, build, unit tests, doc tests,
  integration).