### PR TITLE
Feat/metric flush sync

### DIFF
--- a/crates/burn-tensor/src/tensor/api/autodiff.rs
+++ b/crates/burn-tensor/src/tensor/api/autodiff.rs
@@ -101,6 +101,25 @@ impl<const D: usize, K: Autodiff> Tensor<D, K> {
         Tensor::new(K::inner(self.primitive))
     }
 
+    /// Take the tensor off the autodiff backend, dropping any graph reference
+    /// it carries. A tensor that is not on an autodiff backend is returned as
+    /// is.
+    ///
+    /// Unlike [detach](Tensor::detach), which severs the tensor from the graph
+    /// but leaves it on the autodiff backend, the result lives on the inner
+    /// backend: later operations pay no autodiff dispatch and can never be
+    /// recorded. And unlike [inner](Self::inner), which panics on a tensor
+    /// with no autodiff wrapper, this is safe to call anywhere — batchers,
+    /// metric pipelines, anything that must guarantee a tensor is off the
+    /// tape without knowing where it came from.
+    pub fn no_grad(self) -> Self {
+        if self.device().is_autodiff() {
+            self.inner()
+        } else {
+            self
+        }
+    }
+
     /// Convert a tensor to the autodiff backend.
     ///
     /// # Arguments

--- a/crates/burn-train/src/learner/classification.rs
+++ b/crates/burn-train/src/learner/classification.rs
@@ -1,8 +1,9 @@
 use crate::metric::{
     AccuracyInput, Adaptor, ConfusionStatsInput, HammingScoreInput, LossInput, PerplexityInput,
-    TopKAccuracyInput, processor::ItemLazy,
+    TopKAccuracyInput,
+    processor::ItemLazy,
 };
-use burn_core::tensor::{Device, Int, Tensor, Transaction};
+use burn_core::tensor::{Int, Tensor};
 
 /// Simple classification output adapted for multiple metrics.
 ///
@@ -29,20 +30,18 @@ pub struct ClassificationOutput {
 
 impl ItemLazy for ClassificationOutput {
     fn sync(self) -> Self {
-        let [output, loss, targets] = Transaction::default()
-            .register(self.output)
-            .register(self.loss)
-            .register(self.targets)
-            .execute()
-            .try_into()
-            .expect("Correct amount of tensor data");
-
-        let device: Device = Device::flex();
+        // No readback: the metrics compute on the device the tensors live on
+        // and read back only their final scalars. Flushing dispatches the
+        // producing stream's buffered work so the metric thread doesn't wait
+        // on an idle queue; a training item's float tensors come off the
+        // autodiff backend entirely, so the metric thread neither retains the
+        // tape nor pays its dispatch.
+        self.loss.device().flush();
 
         ClassificationOutput {
-            output: Tensor::from_data(output, &device),
-            loss: Tensor::from_data(loss, &device),
-            targets: Tensor::from_data(targets, &device),
+            output: self.output.no_grad(),
+            loss: self.loss.no_grad(),
+            targets: self.targets,
         }
     }
 }
@@ -110,20 +109,14 @@ pub struct MultiLabelClassificationOutput {
 
 impl ItemLazy for MultiLabelClassificationOutput {
     fn sync(self) -> Self {
-        let [output, loss, targets] = Transaction::default()
-            .register(self.output)
-            .register(self.loss)
-            .register(self.targets)
-            .execute()
-            .try_into()
-            .expect("Correct amount of tensor data");
-
-        let device: Device = Device::flex();
+        // Same contract as `ClassificationOutput::sync`: flush and take the
+        // floats off the tape, no readback.
+        self.loss.device().flush();
 
         MultiLabelClassificationOutput {
-            output: Tensor::from_data(output, &device),
-            loss: Tensor::from_data(loss, &device),
-            targets: Tensor::from_data(targets, &device),
+            output: self.output.no_grad(),
+            loss: self.loss.no_grad(),
+            targets: self.targets,
         }
     }
 }

--- a/crates/burn-train/src/learner/regression.rs
+++ b/crates/burn-train/src/learner/regression.rs
@@ -1,6 +1,6 @@
 use crate::metric::processor::ItemLazy;
 use crate::metric::{Adaptor, LossInput};
-use burn_core::tensor::{Device, Tensor, Transaction};
+use burn_core::tensor::Tensor;
 
 /// Regression output adapted for the loss metric.
 #[derive(new)]
@@ -23,20 +23,18 @@ impl Adaptor<LossInput> for RegressionOutput {
 
 impl ItemLazy for RegressionOutput {
     fn sync(self) -> Self {
-        let [output, loss, targets] = Transaction::default()
-            .register(self.output)
-            .register(self.loss)
-            .register(self.targets)
-            .execute()
-            .try_into()
-            .expect("Correct amount of tensor data");
-
-        let device: Device = Device::flex();
+        // No readback: the metrics compute on the device the tensors live on
+        // and read back only their final scalars. Flushing dispatches the
+        // producing stream's buffered work so the metric thread doesn't wait
+        // on an idle queue; a training item's float tensors come off the
+        // autodiff backend entirely, so the metric thread neither retains the
+        // tape nor pays its dispatch.
+        self.loss.device().flush();
 
         RegressionOutput {
-            output: Tensor::from_data(output, &device),
-            loss: Tensor::from_data(loss, &device),
-            targets: Tensor::from_data(targets, &device),
+            output: self.output.no_grad(),
+            loss: self.loss.no_grad(),
+            targets: self.targets.no_grad(),
         }
     }
 }

--- a/crates/burn-train/src/learner/sequence.rs
+++ b/crates/burn-train/src/learner/sequence.rs
@@ -1,6 +1,9 @@
 use crate::metric::{AccuracyInput, PerplexityInput, TopKAccuracyInput};
-use crate::metric::{Adaptor, CerInput, LossInput, WerInput, processor::ItemLazy};
-use burn_core::tensor::{Device, Int, Tensor, Transaction};
+use crate::metric::{
+    Adaptor, CerInput, LossInput, WerInput,
+    processor::ItemLazy,
+};
+use burn_core::tensor::{Int, Tensor};
 
 /// Sequence prediction output adapted for multiple metrics.
 ///
@@ -50,42 +53,20 @@ impl SequenceOutput {
 
 impl ItemLazy for SequenceOutput {
     fn sync(self) -> Self {
-        let device: Device = Device::flex();
+        // No readback: the metrics compute on the device the tensors live on
+        // and read back only their final scalars, which matters here because
+        // the logits carry the full vocabulary dimension. Flushing dispatches
+        // the producing stream's buffered work so the metric thread doesn't
+        // wait on an idle queue; a training item's float tensors come off the
+        // autodiff backend entirely, so the metric thread neither retains the
+        // tape nor pays its dispatch.
+        self.loss.device().flush();
 
-        match self.predictions {
-            Some(preds) => {
-                let [logits, loss, targets, predictions] = Transaction::default()
-                    .register(self.logits)
-                    .register(self.loss)
-                    .register(self.targets)
-                    .register(preds)
-                    .execute()
-                    .try_into()
-                    .expect("Correct amount of tensor data");
-
-                SequenceOutput {
-                    logits: Tensor::from_data(logits, &device),
-                    loss: Tensor::from_data(loss, &device),
-                    targets: Tensor::from_data(targets, &device),
-                    predictions: Some(Tensor::from_data(predictions, &device)),
-                }
-            }
-            None => {
-                let [logits, loss, targets] = Transaction::default()
-                    .register(self.logits)
-                    .register(self.loss)
-                    .register(self.targets)
-                    .execute()
-                    .try_into()
-                    .expect("Correct amount of tensor data");
-
-                SequenceOutput {
-                    logits: Tensor::from_data(logits, &device),
-                    loss: Tensor::from_data(loss, &device),
-                    targets: Tensor::from_data(targets, &device),
-                    predictions: None,
-                }
-            }
+        SequenceOutput {
+            logits: self.logits.no_grad(),
+            loss: self.loss.no_grad(),
+            targets: self.targets,
+            predictions: self.predictions,
         }
     }
 }


### PR DESCRIPTION
`ItemLazy::sync` for the supervised outputs read every tensor back to the CPU. For SequenceOutput that is the full `[batch, seq, vocab]` logits on every step of both splits, and the metrics then computed on the host. The metrics are already device-generic and end in scalar reads, so sync now only flushes the producing stream and takes the float tensors off the autodiff backend, the vocabulary-sized transfer disappears.

Taking them off the tape matters for a training item: a detached tensor still lives on the autodiff backend, so the metric thread would retain graph references and pay the autodiff dispatch on every op. The new `Tensor::no_grad` does the stripping safely,  `inner()` on a tensor without the wrapper panics, a validation item's tensors already being plain.