### PR TITLE
Allow metadata-only reshape of sub-byte quantized tensors

### DIFF
--- a/crates/burn-backend-tests/tests/cubecl/quantization/reshape.rs
+++ b/crates/burn-backend-tests/tests/cubecl/quantization/reshape.rs
@@ -149,3 +149,45 @@ fn should_quantize_dequantize_per_block_reshaped_2d_q8s_packed() {
 // - multi-block successful reshape (all current success tests use exactly 1 block, e.g. [4, 32] -> [1, 4, 32] with block_size 32)
 // - packed dimension alignment failure (invalid shape for packed num_quants)
 // - ND-block unsqueeze (should succeed per the is_unsqueeze exemption, but nothing tests it)
+
+/// Reshape correctness isolated from quantization error: dequantize the *same*
+/// quantized tensor via both orders. Any difference is the reshape's doing.
+fn reshape_matches_dequantize_then_reshape(value: QuantValue, level: QuantLevel) {
+    let numel = 32i64;
+    let device = Default::default();
+    let ref_device = ReferenceDevice::new();
+    let scheme = QuantScheme::default()
+        .with_level(level)
+        .with_value(value)
+        .with_store(QuantStore::PackedU32(0));
+
+    let data = TestTensorInt::arange(0..numel, &ref_device)
+        .float()
+        .div_scalar(numel)
+        .into_data();
+
+    let q = TestTensor::<1>::from_data(data, &device).quantize_dynamic(&scheme);
+
+    let reshaped_then_deq = q.clone().reshape::<2, _>([2, 16]).dequantize().into_data();
+    let deq_then_reshaped = q.dequantize().reshape::<2, _>([2, 16]).into_data();
+
+    reshaped_then_deq.assert_eq(&deq_then_reshaped, true);
+}
+
+#[test]
+fn q8s_reshape_matches_dequantize_then_reshape() {
+    reshape_matches_dequantize_then_reshape(QuantValue::Q8S, QuantLevel::Tensor);
+}
+
+#[test]
+fn q4s_reshape_matches_dequantize_then_reshape() {
+    reshape_matches_dequantize_then_reshape(QuantValue::Q4S, QuantLevel::Tensor);
+}
+
+#[test]
+fn q4s_block_reshape_matches_dequantize_then_reshape() {
+    reshape_matches_dequantize_then_reshape(
+        QuantValue::Q4S,
+        QuantLevel::Block(BlockSize::new([16])),
+    );
+}

--- a/crates/burn-cubecl/src/ops/base.rs
+++ b/crates/burn-cubecl/src/ops/base.rs
@@ -356,16 +356,6 @@ pub fn q_reshape<R: CubeRuntime>(mut tensor: CubeTensor<R>, shape: Shape) -> Cub
     let n_new_dims = shape.num_dims().saturating_sub(curr_shape.num_dims());
     let is_unsqueeze = n_new_dims > 0 && shape[n_new_dims..] == **curr_shape;
 
-    if !is_unsqueeze
-        && matches!(
-            scheme.value,
-            QuantValue::Q4S | QuantValue::Q4F | QuantValue::Q2S | QuantValue::Q2F
-        )
-    {
-        // FIXME
-        todo!("Reshape with sub-byte values is not supported")
-    }
-
     // Check valid reshapes
     if let ReshapeAction::UpdateStrides { .. } = &action_values {
         match analysis_values {
@@ -448,6 +438,19 @@ pub fn q_reshape<R: CubeRuntime>(mut tensor: CubeTensor<R>, shape: Shape) -> Cub
         }
         // Any action to recompute
         (ReshapeAction::Recompute, _) | (_, ReshapeAction::Recompute) => {
+            // Rewriting the buffer would have to repack values that share a
+            // storage element; a metadata-only reshape leaves the packing alone.
+            if !is_unsqueeze
+                && matches!(
+                    scheme.value,
+                    QuantValue::Q4S | QuantValue::Q4F | QuantValue::Q2S | QuantValue::Q2F
+                )
+            {
+                todo!(
+                    "Reshape with sub-byte values is not supported when the buffer must be recomputed"
+                )
+            }
+
             if let QuantLevel::Block(_) = scheme.level
                 && shape_scales.num_elements() > 1
             {


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

None.

### Changes

`q_reshape` rejected every non-unsqueeze reshape of a `Q4`/`Q2` tensor before checking what the reshape required. Metadata-only reshapes leave the packed bytes untouched (`shape_values` already divides the packed dimension by `num_quants` and rejects a misaligned one), so only `Recompute`, which rewrites the buffer through `into_contiguous`, is genuinely unsupported. The guard moves there.

This also fixes `linear()` with a rank-2 input and a quantized weight, where `unsqueeze_leading` adds no dimensions and the guard fired on a shape-preserving no-op.

### Testing

New tests dequantize the same quantized tensor through both orders (reshape then dequantize, dequantize then reshape) and compare exactly, so quantization error cancels. Vulkan quantization suite: 42 passed / 1 failed, the same single pre-existing failure as `main`.

The existing `#[should_panic]` `Q4S` cases are left alone: their helper compares a 4-bit round-trip against an unquantized float reference at `Tolerance::permissive()`, so they fail on tolerance regardless of this fix.

`run-checks` aborts at format on three files already unformatted on `main`; both files touched here pass `rustfmt --check`.