### PR TITLE
fix(dispatch): keep a WgpuDevice conversion when wgpu features unify

### DIFF
--- a/crates/burn-dispatch/src/device.rs
+++ b/crates/burn-dispatch/src/device.rs
@@ -647,6 +647,10 @@ impl From<RocmDevice> for DispatchDevice {
 
 // A bare `WgpuDevice` maps to the auto-compiler [`DispatchDevice::Wgpu`] variant. To target a
 // specific wgpu specialization (Metal, Vulkan, WebGpu) construct the variant explicitly.
+//
+// The gates form a priority chain (metal, then vulkan, then webgpu) rather than mutually
+// exclusive conditions: cargo unifies features across a workspace, so several specializations
+// can be on at once and exclusive gates would leave the conversion with no impl at all.
 #[cfg(all(
     feature = "wgpu",
     not(any(feature = "metal", feature = "vulkan", feature = "webgpu"))
@@ -657,14 +661,14 @@ impl From<WgpuDevice> for DispatchDevice {
     }
 }
 
-#[cfg(all(feature = "metal", not(any(feature = "vulkan", feature = "webgpu"))))]
+#[cfg(feature = "metal")]
 impl From<WgpuDevice> for DispatchDevice {
     fn from(device: WgpuDevice) -> Self {
         DispatchDevice::Metal(device)
     }
 }
 
-#[cfg(all(feature = "vulkan", not(any(feature = "metal", feature = "webgpu"))))]
+#[cfg(all(feature = "vulkan", not(feature = "metal")))]
 impl From<WgpuDevice> for DispatchDevice {
     fn from(device: WgpuDevice) -> Self {
         DispatchDevice::Vulkan(device)


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

None.

### Changes

The four `From<WgpuDevice> for DispatchDevice` impls were gated on mutually exclusive conditions, so enabling two or more of `metal`, `vulkan` and `webgpu` compiled none of them and the conversion disappeared.

Cargo unifies features across a workspace, so this is reachable without asking for it. `cargo check -p burn-vision --tests` passes, while a workspace-wide resolution (what rust-analyzer uses) enables `vulkan` and `webgpu` together and fails with `the trait bound DispatchDevice: From<WgpuDevice> is not satisfied`.

The gates are now a priority chain, so exactly one impl survives for any combination:

| feature | gate |
| --- | --- |
| `metal` | `metal` |
| `vulkan` | `vulkan, not(metal)` |
| `webgpu` | `webgpu, not(metal, vulkan)` |
| `wgpu` | `wgpu, not(metal, vulkan, webgpu)` |

The order matches the one `DispatchDevice::default()` already falls through, so the conversion and the default agree on which specialization wins. Single-feature builds are unaffected: each still selects the impl it did before.

### Testing

`cargo check -p burn-vision --tests` over every combination buildable on Linux. `vulkan,webgpu` and `wgpu,vulkan,webgpu` failed on `main` with 29 errors and now pass; `wgpu`, `wgpu,vulkan` and `wgpu,webgpu` passed before and still do.

The `metal` combinations cannot be compiled on Linux, so the gate logic was checked separately by extracting the four `cfg` attributes into a standalone file and compiling it under all eight subsets of `{metal, vulkan, webgpu}`. Each yields exactly one impl. Removing any single remaining exclusion produces a `conflicting implementations` error, so the gates are minimal as well as complete.

`cargo run-checks` was run with `--ignore-typos`: it otherwise aborts before clippy and the tests on a pre-existing typo in `burn-core/src/module/param/base.rs:330` that is unrelated to this PR. With that flag it passes, 112 test suites and no failures.
