### PR TITLE
feat(tensor): support mul indexing updates on NdArray and Flex

### DIFF
--- a/crates/burn-autodiff/src/ops/tensor.rs
+++ b/crates/burn-autodiff/src/ops/tensor.rs
@@ -1153,18 +1153,13 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                             ops.node,
                             grads,
                             |grad| {
-                                let device = grad.device();
-                                let dtype = grad.dtype();
-                                let shape = grad.shape();
-                                let ones = B::float_ones(shape, &device, dtype.into());
-                                let multiplier = B::float_scatter(
+                                B::float_scatter(
                                     dim,
-                                    ones,
+                                    grad,
                                     indices_4lhs.unwrap(),
                                     value_state.unwrap(),
                                     IndexingUpdateOp::Mul,
-                                );
-                                B::float_mul(grad, multiplier)
+                                )
                             },
                             |grad| {
                                 let indices = indices_4rhs.unwrap();
@@ -1848,18 +1843,13 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                             ops.node,
                             grads,
                             |grad| {
-                                let device = grad.device();
-                                let dtype = grad.dtype();
-                                let shape = grad.shape();
-                                let ones = B::float_ones(shape, &device, dtype.into());
-                                let multiplier = B::float_select_assign(
-                                    ones,
+                                B::float_select_assign(
+                                    grad,
                                     dim,
                                     indices_4lhs.unwrap(),
                                     value_state.unwrap(),
                                     IndexingUpdateOp::Mul,
-                                );
-                                B::float_mul(grad, multiplier)
+                                )
                             },
                             |grad| {
                                 let indices = indices_4rhs.unwrap();

--- a/crates/burn-autodiff/src/ops/tensor.rs
+++ b/crates/burn-autodiff/src/ops/tensor.rs
@@ -1122,6 +1122,91 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                     )),
                 }
             }
+            IndexingUpdateOp::Mul => {
+                // Unique indices are required for this backward formula.
+                // Forward: out[index] = tensor[index] * value.
+                // Backward:
+                //   grad_tensor = grad * scatter(ones, indices, value, Assign)
+                //   grad_value  = gather(grad, indices) * gather(tensor, indices)
+                #[derive(Debug)]
+                struct ScatterMul;
+
+                impl<B: Backend> Backward<B, 2> for ScatterMul {
+                    type State = (
+                        usize,
+                        Option<FloatTensor<B>>,
+                        Option<FloatTensor<B>>,
+                        IntTensor<B>,
+                    );
+
+                    fn backward(
+                        self,
+                        ops: Ops<Self::State, 2>,
+                        grads: &mut Gradients,
+                        _checkpointer: &mut Checkpointer,
+                    ) {
+                        let (dim, tensor_state, value_state, indices) = ops.state;
+                        let [indices_4lhs, indices_4rhs] = duplicate(&ops.parents, Some(indices));
+
+                        binary::<B, _, _>(
+                            ops.parents,
+                            ops.node,
+                            grads,
+                            |grad| {
+                                let device = grad.device();
+                                let dtype = grad.dtype();
+                                let shape = grad.shape();
+                                let ones = B::float_ones(shape, &device, dtype.into());
+                                let multiplier = B::float_scatter(
+                                    dim,
+                                    ones,
+                                    indices_4lhs.unwrap(),
+                                    value_state.unwrap(),
+                                    IndexingUpdateOp::Assign,
+                                );
+                                B::float_mul(grad, multiplier)
+                            },
+                            |grad| {
+                                let indices = indices_4rhs.unwrap();
+                                let grad = B::float_gather(dim, grad, indices.clone());
+                                let tensor = B::float_gather(dim, tensor_state.unwrap(), indices);
+                                B::float_mul(grad, tensor)
+                            },
+                        );
+                    }
+                }
+
+                let tensor_tracked = tensor.is_tracked();
+                let value_tracked = value.is_tracked();
+
+                match ScatterMul
+                    .prepare::<C>([tensor.node, value.node])
+                    .compute_bound()
+                    .stateful()
+                {
+                    OpsKind::Tracked(prep) => {
+                        let tensor_state = value_tracked.then(|| tensor.primitive.clone());
+                        let value_state = tensor_tracked.then(|| value.primitive.clone());
+                        prep.finish(
+                            (dim, tensor_state, value_state, indices.clone()),
+                            B::float_scatter(
+                                dim,
+                                tensor.primitive,
+                                indices,
+                                value.primitive,
+                                IndexingUpdateOp::Mul,
+                            ),
+                        )
+                    }
+                    OpsKind::UnTracked(prep) => prep.finish(B::float_scatter(
+                        dim,
+                        tensor.primitive,
+                        indices,
+                        value.primitive,
+                        IndexingUpdateOp::Mul,
+                    )),
+                }
+            }
             other => unimplemented!("float_scatter with {other:?} update is not implemented"),
         }
     }
@@ -1707,6 +1792,120 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                         indices,
                         value.primitive,
                         IndexingUpdateOp::Assign,
+                    )),
+                }
+            }
+            IndexingUpdateOp::Mul => {
+                // Unique indices are required for this backward formula.
+                // Forward: out[index] = tensor[index] * value.
+                // Backward:
+                //   grad_tensor = grad * select_assign(ones, indices, value, Assign)
+                //   grad_value  = select(grad, indices) * select(tensor, indices)
+                #[derive(Debug)]
+                struct IndexSelectDimAssignMul;
+
+                #[derive(new, Debug)]
+                struct RetroSelectAssignMul<B: Backend> {
+                    tensor_id: NodeId,
+                    dim: usize,
+                    indices: IntTensor<B>,
+                    value_id: NodeId,
+                }
+
+                impl<B: Backend> RetroForward for RetroSelectAssignMul<B> {
+                    fn forward(&self, states: &mut BackwardStates, out_node: NodeId) {
+                        let tensor = states.get_state::<B::FloatTensorPrimitive>(&self.tensor_id);
+                        let value = states.get_state::<B::FloatTensorPrimitive>(&self.value_id);
+                        let out = B::float_select_assign(
+                            tensor,
+                            self.dim,
+                            self.indices.clone(),
+                            value,
+                            IndexingUpdateOp::Mul,
+                        );
+                        states.save(out_node, out)
+                    }
+                }
+
+                impl<B: Backend> Backward<B, 2> for IndexSelectDimAssignMul {
+                    type State = (usize, Option<NodeId>, Option<NodeId>, IntTensor<B>);
+
+                    fn backward(
+                        self,
+                        ops: Ops<Self::State, 2>,
+                        grads: &mut Gradients,
+                        checkpointer: &mut Checkpointer,
+                    ) {
+                        let (dim, tensor_state, value_state, indices) = ops.state;
+                        let tensor_state =
+                            tensor_state.map(|id| checkpointer.retrieve_node_output(id));
+                        let value_state =
+                            value_state.map(|id| checkpointer.retrieve_node_output(id));
+                        let [indices_4lhs, indices_4rhs] = duplicate(&ops.parents, Some(indices));
+
+                        binary::<B, _, _>(
+                            ops.parents,
+                            ops.node,
+                            grads,
+                            |grad| {
+                                let device = grad.device();
+                                let dtype = grad.dtype();
+                                let shape = grad.shape();
+                                let ones = B::float_ones(shape, &device, dtype.into());
+                                let multiplier = B::float_select_assign(
+                                    ones,
+                                    dim,
+                                    indices_4lhs.unwrap(),
+                                    value_state.unwrap(),
+                                    IndexingUpdateOp::Assign,
+                                );
+                                B::float_mul(grad, multiplier)
+                            },
+                            |grad| {
+                                let indices = indices_4rhs.unwrap();
+                                let grad = B::float_select(grad, dim, indices.clone());
+                                let tensor = B::float_select(tensor_state.unwrap(), dim, indices);
+                                B::float_mul(grad, tensor)
+                            },
+                        );
+                    }
+                }
+
+                let tensor_tracked = tensor.is_tracked();
+                let value_tracked = value.is_tracked();
+
+                match IndexSelectDimAssignMul
+                    .prepare::<C>([tensor.node.clone(), value.node.clone()])
+                    .memory_bound()
+                    .retro_forward(RetroSelectAssignMul::<B>::new(
+                        tensor.node.id,
+                        dim,
+                        indices.clone(),
+                        value.node.id,
+                    ))
+                    .parents([&tensor, &value])
+                    .stateful()
+                {
+                    OpsKind::Tracked(mut prep) => {
+                        let tensor_state = value_tracked.then(|| prep.checkpoint(&tensor));
+                        let value_state = tensor_tracked.then(|| prep.checkpoint(&value));
+                        prep.finish(
+                            (dim, tensor_state, value_state, indices.clone()),
+                            B::float_select_assign(
+                                tensor.primitive,
+                                dim,
+                                indices,
+                                value.primitive,
+                                IndexingUpdateOp::Mul,
+                            ),
+                        )
+                    }
+                    OpsKind::UnTracked(prep) => prep.finish(B::float_select_assign(
+                        tensor.primitive,
+                        dim,
+                        indices,
+                        value.primitive,
+                        IndexingUpdateOp::Mul,
                     )),
                 }
             }

--- a/crates/burn-autodiff/src/ops/tensor.rs
+++ b/crates/burn-autodiff/src/ops/tensor.rs
@@ -1123,10 +1123,8 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                 }
             }
             IndexingUpdateOp::Mul => {
-                // Unique indices are required for this backward formula.
-                // Forward: out[index] = tensor[index] * value.
-                // Backward:
-                //   grad_tensor = grad * scatter(ones, indices, value, Mul)
+                // Backward assumes unique indices:
+                //   grad_tensor = scatter(grad, indices, value, Mul)
                 //   grad_value  = gather(grad, indices) * gather(tensor, indices)
                 #[derive(Debug)]
                 struct ScatterMul;
@@ -1791,10 +1789,8 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                 }
             }
             IndexingUpdateOp::Mul => {
-                // Unique indices are required for this backward formula.
-                // Forward: out[index] = tensor[index] * value.
-                // Backward:
-                //   grad_tensor = grad * select_assign(ones, indices, value, Mul)
+                // Backward assumes unique indices:
+                //   grad_tensor = select_assign(grad, dim, indices, value, Mul)
                 //   grad_value  = select(grad, indices) * select(tensor, indices)
                 #[derive(Debug)]
                 struct IndexSelectDimAssignMul;

--- a/crates/burn-autodiff/src/ops/tensor.rs
+++ b/crates/burn-autodiff/src/ops/tensor.rs
@@ -1126,7 +1126,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                 // Unique indices are required for this backward formula.
                 // Forward: out[index] = tensor[index] * value.
                 // Backward:
-                //   grad_tensor = grad * scatter(ones, indices, value, Assign)
+                //   grad_tensor = grad * scatter(ones, indices, value, Mul)
                 //   grad_value  = gather(grad, indices) * gather(tensor, indices)
                 #[derive(Debug)]
                 struct ScatterMul;
@@ -1162,7 +1162,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                                     ones,
                                     indices_4lhs.unwrap(),
                                     value_state.unwrap(),
-                                    IndexingUpdateOp::Assign,
+                                    IndexingUpdateOp::Mul,
                                 );
                                 B::float_mul(grad, multiplier)
                             },
@@ -1799,7 +1799,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                 // Unique indices are required for this backward formula.
                 // Forward: out[index] = tensor[index] * value.
                 // Backward:
-                //   grad_tensor = grad * select_assign(ones, indices, value, Assign)
+                //   grad_tensor = grad * select_assign(ones, indices, value, Mul)
                 //   grad_value  = select(grad, indices) * select(tensor, indices)
                 #[derive(Debug)]
                 struct IndexSelectDimAssignMul;
@@ -1857,7 +1857,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                                     dim,
                                     indices_4lhs.unwrap(),
                                     value_state.unwrap(),
-                                    IndexingUpdateOp::Assign,
+                                    IndexingUpdateOp::Mul,
                                 );
                                 B::float_mul(grad, multiplier)
                             },

--- a/crates/burn-backend-tests/tests/autodiff/gather_scatter.rs
+++ b/crates/burn-backend-tests/tests/autodiff/gather_scatter.rs
@@ -98,6 +98,45 @@ fn test_scatter_assign_grad() {
         .assert_eq(&TensorData::from([[1., 1.], [1., 1.]]), false);
 }
 
+#[cfg(feature = "ndarray")]
+#[test]
+fn test_scatter_mul_grad() {
+    let device = AutodiffDevice::new();
+    let tensor = TestTensor::from_data(
+        TensorData::from([[2.0, 3.0, 4.0, 5.0], [6.0, 7.0, 8.0, 9.0]]),
+        &device,
+    )
+    .require_grad();
+    let values = TestTensor::from_data(TensorData::from([[10.0, 20.0], [30.0, 40.0]]), &device)
+        .require_grad();
+    let indices = TestTensorInt::<2>::from_data(TensorData::from([[3, 0], [1, 2]]), &device);
+    let weights = TestTensor::from_data(
+        TensorData::from([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]]),
+        &device,
+    );
+
+    let result = tensor
+        .clone()
+        .scatter(1, indices, values.clone(), IndexingUpdateOp::Mul);
+
+    result.clone().into_data().assert_eq(
+        &TensorData::from([[40.0, 3.0, 4.0, 50.0], [6.0, 210.0, 320.0, 9.0]]),
+        false,
+    );
+
+    let grads = result.mul(weights).sum().backward();
+    let grad_tensor = tensor.grad(&grads).unwrap();
+    let grad_values = values.grad(&grads).unwrap();
+
+    grad_tensor.to_data().assert_eq(
+        &TensorData::from([[20.0, 2.0, 3.0, 40.0], [5.0, 180.0, 280.0, 8.0]]),
+        false,
+    );
+    grad_values
+        .to_data()
+        .assert_eq(&TensorData::from([[20.0, 2.0], [42.0, 56.0]]), false);
+}
+
 #[test]
 fn test_scatter_add_grad_partial_indices() {
     let device = AutodiffDevice::new();

--- a/crates/burn-backend-tests/tests/autodiff/gather_scatter.rs
+++ b/crates/burn-backend-tests/tests/autodiff/gather_scatter.rs
@@ -98,7 +98,7 @@ fn test_scatter_assign_grad() {
         .assert_eq(&TensorData::from([[1., 1.], [1., 1.]]), false);
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(any(feature = "flex", feature = "ndarray"))]
 #[test]
 fn test_scatter_mul_grad() {
     let device = AutodiffDevice::new();

--- a/crates/burn-backend-tests/tests/autodiff/select.rs
+++ b/crates/burn-backend-tests/tests/autodiff/select.rs
@@ -96,7 +96,7 @@ fn test_select_assign_grad() {
         .assert_eq(&TensorData::from([[1., 1.], [1., 1.]]), false);
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(any(feature = "flex", feature = "ndarray"))]
 #[test]
 fn test_select_assign_mul_grad() {
     let device = AutodiffDevice::new();

--- a/crates/burn-backend-tests/tests/autodiff/select.rs
+++ b/crates/burn-backend-tests/tests/autodiff/select.rs
@@ -96,6 +96,45 @@ fn test_select_assign_grad() {
         .assert_eq(&TensorData::from([[1., 1.], [1., 1.]]), false);
 }
 
+#[cfg(feature = "ndarray")]
+#[test]
+fn test_select_assign_mul_grad() {
+    let device = AutodiffDevice::new();
+    let tensor = TestTensor::<2>::from_data(
+        TensorData::from([[2.0, 3.0, 4.0], [5.0, 6.0, 7.0]]),
+        &device,
+    )
+    .require_grad();
+    let values = TestTensor::from_data(TensorData::from([[10.0, 20.0], [30.0, 40.0]]), &device)
+        .require_grad();
+    let indices = TestTensorInt::<1>::from_data(TensorData::from([2, 0]), &device);
+    let weights = TestTensor::from_data(
+        TensorData::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
+        &device,
+    );
+
+    let result = tensor
+        .clone()
+        .select_assign(1, indices, values.clone(), IndexingUpdateOp::Mul);
+
+    result.clone().into_data().assert_eq(
+        &TensorData::from([[40.0, 3.0, 40.0], [200.0, 6.0, 210.0]]),
+        false,
+    );
+
+    let grads = result.mul(weights).sum().backward();
+    let grad_tensor = tensor.grad(&grads).unwrap();
+    let grad_values = values.grad(&grads).unwrap();
+
+    grad_tensor.into_data().assert_eq(
+        &TensorData::from([[20.0, 2.0, 30.0], [160.0, 5.0, 180.0]]),
+        false,
+    );
+    grad_values
+        .into_data()
+        .assert_eq(&TensorData::from([[12.0, 2.0], [42.0, 20.0]]), false);
+}
+
 #[test]
 fn test_select_add_grad_different_shapes() {
     let device = AutodiffDevice::new();

--- a/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter.rs
@@ -120,7 +120,7 @@ fn should_scatter_assign_2d_dim0() {
         .assert_eq(&TensorData::from([[4.0, 2.0, 6.0], [1.0, 5.0, 3.0]]), false);
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(any(feature = "flex", feature = "ndarray"))]
 #[test]
 fn should_scatter_mul_1d() {
     let device = Default::default();
@@ -135,7 +135,7 @@ fn should_scatter_mul_1d() {
         .assert_eq(&TensorData::from([10.0, 140.0, 30.0, 2000.0]), false);
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(any(feature = "flex", feature = "ndarray"))]
 #[test]
 fn should_scatter_mul_2d_dim0() {
     let device = Default::default();

--- a/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter.rs
@@ -120,6 +120,37 @@ fn should_scatter_assign_2d_dim0() {
         .assert_eq(&TensorData::from([[4.0, 2.0, 6.0], [1.0, 5.0, 3.0]]), false);
 }
 
+#[cfg(feature = "ndarray")]
+#[test]
+fn should_scatter_mul_1d() {
+    let device = Default::default();
+    let tensor = TestTensor::<1>::from_data([10.0, 20.0, 30.0, 40.0], &device);
+    let values = TestTensor::from_data([7.0, 50.0], &device);
+    let indices = TestTensorInt::from_ints([1, 3], &device);
+
+    let output = tensor.scatter(0, indices, values, IndexingUpdateOp::Mul);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([10.0, 140.0, 30.0, 2000.0]), false);
+}
+
+#[cfg(feature = "ndarray")]
+#[test]
+fn should_scatter_mul_2d_dim0() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::from_data([[10.0, 20.0, 30.0], [40.0, 50.0, 60.0]], &device);
+    let values = TestTensor::from_data([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], &device);
+    let indices = TestTensorInt::from_ints([[1, 0, 1], [0, 1, 0]], &device);
+
+    let output = tensor.scatter(0, indices, values, IndexingUpdateOp::Mul);
+
+    output.into_data().assert_eq(
+        &TensorData::from([[40.0, 40.0, 180.0], [40.0, 250.0, 180.0]]),
+        false,
+    );
+}
+
 #[test]
 fn should_scatter_add_2d_dim0() {
     let device = Default::default();

--- a/crates/burn-backend-tests/tests/tensor/float/ops/select.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/select.rs
@@ -108,6 +108,34 @@ fn should_select_assign_2d_dim1() {
     output.into_data().assert_eq(&expected, false);
 }
 
+#[cfg(feature = "ndarray")]
+#[test]
+fn should_select_assign_mul_2d_dim0() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::from_data([[10.0, 20.0], [30.0, 40.0], [50.0, 60.0]], &device);
+    let values = TestTensor::from_data([[5.0, 70.0], [80.0, 1.0]], &device);
+    let indices = TestTensorInt::from_data(TensorData::from([2, 0]), &device);
+
+    let output = tensor.select_assign(0, indices, values, IndexingUpdateOp::Mul);
+    let expected = TensorData::from([[800.0, 20.0], [30.0, 40.0], [250.0, 4200.0]]);
+
+    output.into_data().assert_eq(&expected, false);
+}
+
+#[cfg(feature = "ndarray")]
+#[test]
+fn should_select_assign_mul_2d_dim1() {
+    let device = Default::default();
+    let tensor = TestTensor::<2>::from_data([[2.0, 3.0, 4.0], [5.0, 6.0, 7.0]], &device);
+    let values = TestTensor::from_data([[10.0, 20.0], [30.0, 40.0]], &device);
+    let indices = TestTensorInt::from_ints([2, 0], &device);
+
+    let output = tensor.select_assign(1, indices, values, IndexingUpdateOp::Mul);
+    let expected = TensorData::from([[40.0, 3.0, 40.0], [200.0, 6.0, 210.0]]);
+
+    output.into_data().assert_eq(&expected, false);
+}
+
 #[test]
 fn should_select_add_1d_int() {
     let device = Default::default();

--- a/crates/burn-backend-tests/tests/tensor/float/ops/select.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/select.rs
@@ -108,7 +108,7 @@ fn should_select_assign_2d_dim1() {
     output.into_data().assert_eq(&expected, false);
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(any(feature = "flex", feature = "ndarray"))]
 #[test]
 fn should_select_assign_mul_2d_dim0() {
     let device = Default::default();
@@ -122,7 +122,7 @@ fn should_select_assign_mul_2d_dim0() {
     output.into_data().assert_eq(&expected, false);
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(any(feature = "flex", feature = "ndarray"))]
 #[test]
 fn should_select_assign_mul_2d_dim1() {
     let device = Default::default();

--- a/crates/burn-backend-tests/tests/tensor/int/ops/gather_scatter.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/gather_scatter.rs
@@ -98,7 +98,7 @@ fn should_scatter_assign_2d_dim0_int() {
         .assert_eq(&TensorData::from([[4, 2, 6], [1, 5, 3]]), false);
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(any(feature = "flex", feature = "ndarray"))]
 #[test]
 fn should_scatter_mul_1d_int() {
     let device = Default::default();
@@ -113,7 +113,7 @@ fn should_scatter_mul_1d_int() {
         .assert_eq(&TensorData::from([10, 140, 30, 2000]), false);
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(any(feature = "flex", feature = "ndarray"))]
 #[test]
 fn should_scatter_mul_2d_dim0_int() {
     let device = Default::default();

--- a/crates/burn-backend-tests/tests/tensor/int/ops/gather_scatter.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/gather_scatter.rs
@@ -97,3 +97,33 @@ fn should_scatter_assign_2d_dim0_int() {
         .into_data()
         .assert_eq(&TensorData::from([[4, 2, 6], [1, 5, 3]]), false);
 }
+
+#[cfg(feature = "ndarray")]
+#[test]
+fn should_scatter_mul_1d_int() {
+    let device = Default::default();
+    let tensor = TestTensorInt::<1>::from_ints([10, 20, 30, 40], &device);
+    let values = TestTensorInt::from_ints([7, 50], &device);
+    let indices = TestTensorInt::from_ints([1, 3], &device);
+
+    let output = tensor.scatter(0, indices, values, IndexingUpdateOp::Mul);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([10, 140, 30, 2000]), false);
+}
+
+#[cfg(feature = "ndarray")]
+#[test]
+fn should_scatter_mul_2d_dim0_int() {
+    let device = Default::default();
+    let tensor = TestTensorInt::<2>::from_ints([[10, 20, 30], [40, 50, 60]], &device);
+    let values = TestTensorInt::from_ints([[1, 2, 3], [4, 5, 6]], &device);
+    let indices = TestTensorInt::from_ints([[1, 0, 1], [0, 1, 0]], &device);
+
+    let output = tensor.scatter(0, indices, values, IndexingUpdateOp::Mul);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([[40, 40, 180], [40, 250, 180]]), false);
+}

--- a/crates/burn-backend-tests/tests/tensor/int/ops/select.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/select.rs
@@ -54,6 +54,34 @@ fn should_select_assign_2d_dim1_int() {
     output.into_data().assert_eq(&expected, false);
 }
 
+#[cfg(feature = "ndarray")]
+#[test]
+fn should_select_assign_mul_2d_dim0_int() {
+    let device = Default::default();
+    let tensor = TestTensorInt::<2>::from_data([[10, 20], [30, 40], [50, 60]], &device);
+    let values = TestTensorInt::from_data([[5, 70], [80, 1]], &device);
+    let indices = TestTensorInt::from_data(TensorData::from([2, 0]), &device);
+
+    let output = tensor.select_assign(0, indices, values, IndexingUpdateOp::Mul);
+    let expected = TensorData::from([[800, 20], [30, 40], [250, 4200]]);
+
+    output.into_data().assert_eq(&expected, false);
+}
+
+#[cfg(feature = "ndarray")]
+#[test]
+fn should_select_assign_mul_2d_dim1_int() {
+    let device = Default::default();
+    let tensor = TestTensorInt::<2>::from_ints([[2, 3, 4], [5, 6, 7]], &device);
+    let values = TestTensorInt::from_ints([[10, 20], [30, 40]], &device);
+    let indices = TestTensorInt::from_ints([2, 0], &device);
+
+    let output = tensor.select_assign(1, indices, values, IndexingUpdateOp::Mul);
+    let expected = TensorData::from([[40, 3, 40], [200, 6, 210]]);
+
+    output.into_data().assert_eq(&expected, false);
+}
+
 #[test]
 #[should_panic]
 fn should_panic_select_add_invalid_num_indices() {

--- a/crates/burn-backend-tests/tests/tensor/int/ops/select.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/select.rs
@@ -54,7 +54,7 @@ fn should_select_assign_2d_dim1_int() {
     output.into_data().assert_eq(&expected, false);
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(any(feature = "flex", feature = "ndarray"))]
 #[test]
 fn should_select_assign_mul_2d_dim0_int() {
     let device = Default::default();
@@ -68,7 +68,7 @@ fn should_select_assign_mul_2d_dim0_int() {
     output.into_data().assert_eq(&expected, false);
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(any(feature = "flex", feature = "ndarray"))]
 #[test]
 fn should_select_assign_mul_2d_dim1_int() {
     let device = Default::default();

--- a/crates/burn-flex/src/ops/float.rs
+++ b/crates/burn-flex/src/ops/float.rs
@@ -305,6 +305,36 @@ impl FloatTensorOps<Flex> for Flex {
         }
     }
 
+    fn float_scatter(
+        dim: usize,
+        tensor: FloatTensor<Flex>,
+        indices: IntTensor<Flex>,
+        value: FloatTensor<Flex>,
+        update: burn_backend::tensor::IndexingUpdateOp,
+    ) -> FloatTensor<Flex> {
+        match update {
+            burn_backend::tensor::IndexingUpdateOp::Add => {
+                Self::float_scatter_add(dim, tensor, indices, value)
+            }
+            burn_backend::tensor::IndexingUpdateOp::Mul => match tensor.dtype() {
+                DType::F32 => {
+                    crate::ops::gather_scatter::scatter_mul::<f32>(tensor, dim, indices, value)
+                }
+                DType::F64 => {
+                    crate::ops::gather_scatter::scatter_mul::<f64>(tensor, dim, indices, value)
+                }
+                DType::F16 => {
+                    crate::ops::gather_scatter::scatter_mul::<f16>(tensor, dim, indices, value)
+                }
+                DType::BF16 => {
+                    crate::ops::gather_scatter::scatter_mul::<bf16>(tensor, dim, indices, value)
+                }
+                _ => panic!("float_scatter: unsupported dtype {:?}", tensor.dtype()),
+            },
+            other => unimplemented!("float_scatter with {other:?} update is not implemented"),
+        }
+    }
+
     fn float_scatter_nd(
         data: FloatTensor<Flex>,
         indices: IntTensor<Flex>,
@@ -372,6 +402,41 @@ impl FloatTensorOps<Flex> for Flex {
                 crate::ops::gather_scatter::select_add::<bf16>(tensor, dim, indices, value)
             }
             _ => panic!("float_select_add: unsupported dtype {:?}", tensor.dtype()),
+        }
+    }
+
+    fn float_select_assign(
+        tensor: FloatTensor<Flex>,
+        dim: usize,
+        indices: IntTensor<Flex>,
+        value: FloatTensor<Flex>,
+        update: burn_backend::tensor::IndexingUpdateOp,
+    ) -> FloatTensor<Flex> {
+        match update {
+            burn_backend::tensor::IndexingUpdateOp::Add => {
+                Self::float_select_add(tensor, dim, indices, value)
+            }
+            burn_backend::tensor::IndexingUpdateOp::Mul => match tensor.dtype() {
+                DType::F32 => {
+                    crate::ops::gather_scatter::select_mul::<f32>(tensor, dim, indices, value)
+                }
+                DType::F64 => {
+                    crate::ops::gather_scatter::select_mul::<f64>(tensor, dim, indices, value)
+                }
+                DType::F16 => {
+                    crate::ops::gather_scatter::select_mul::<f16>(tensor, dim, indices, value)
+                }
+                DType::BF16 => {
+                    crate::ops::gather_scatter::select_mul::<bf16>(tensor, dim, indices, value)
+                }
+                _ => panic!(
+                    "float_select_assign: unsupported dtype {:?}",
+                    tensor.dtype()
+                ),
+            },
+            other => {
+                unimplemented!("float_select_assign with {other:?} update is not implemented")
+            }
         }
     }
 

--- a/crates/burn-flex/src/ops/gather_scatter.rs
+++ b/crates/burn-flex/src/ops/gather_scatter.rs
@@ -150,28 +150,6 @@ fn checked_index(raw: isize, dim_size: usize) -> usize {
     raw as usize
 }
 
-trait ElementUpdate<E> {
-    fn apply(target: &mut E, value: E);
-}
-
-struct AddUpdate;
-
-impl<E: core::ops::AddAssign> ElementUpdate<E> for AddUpdate {
-    #[inline(always)]
-    fn apply(target: &mut E, value: E) {
-        *target += value;
-    }
-}
-
-struct MulUpdate;
-
-impl<E: Copy + core::ops::Mul<Output = E>> ElementUpdate<E> for MulUpdate {
-    #[inline(always)]
-    fn apply(target: &mut E, value: E) {
-        *target = *target * value;
-    }
-}
-
 /// Gather values from tensor along a dimension using indices.
 ///
 /// For a 2D tensor with dim=1:
@@ -389,7 +367,14 @@ pub fn scatter_add<E: Element + Pod + Default + Copy + core::ops::AddAssign + Se
     indices: FlexTensor,
     value: FlexTensor,
 ) -> FlexTensor {
-    scatter_update::<E, AddUpdate>(tensor, dim, indices, value, "scatter_add")
+    scatter_update::<E, _>(
+        tensor,
+        dim,
+        indices,
+        value,
+        "scatter_add",
+        |target, value| *target += value,
+    )
 }
 
 /// Scatter multiply: multiplies values into tensor at positions specified by indices.
@@ -399,19 +384,27 @@ pub fn scatter_mul<E: Element + Pod + Default + Copy + core::ops::Mul<Output = E
     indices: FlexTensor,
     value: FlexTensor,
 ) -> FlexTensor {
-    scatter_update::<E, MulUpdate>(tensor, dim, indices, value, "scatter_mul")
+    scatter_update::<E, _>(
+        tensor,
+        dim,
+        indices,
+        value,
+        "scatter_mul",
+        |target, value| *target = *target * value,
+    )
 }
 
-fn scatter_update<E, U>(
+fn scatter_update<E, F>(
     tensor: FlexTensor,
     dim: usize,
     indices: FlexTensor,
     value: FlexTensor,
     operation: &str,
+    update: F,
 ) -> FlexTensor
 where
     E: Element + Pod + Default + Copy + Send + Sync,
-    U: ElementUpdate<E>,
+    F: Fn(&mut E, E) + Copy,
 {
     let tensor = tensor.to_contiguous();
     let indices = indices.to_contiguous();
@@ -459,7 +452,7 @@ where
 
     // Use specialized 2D implementation
     if ndims == 2 {
-        scatter_update_2d::<E, U>(
+        scatter_update_2d(
             &mut result,
             &indices_data,
             value_data,
@@ -468,6 +461,7 @@ where
             indices_shape[0],
             indices_shape[1],
             dim,
+            update,
         );
     } else {
         // General N-D case (sequential due to potential index conflicts)
@@ -484,7 +478,7 @@ where
                 &tensor_strides,
                 ndims,
             );
-            U::apply(&mut result[dst_idx], value_data[idx]);
+            update(&mut result[dst_idx], value_data[idx]);
         }
     }
 
@@ -495,7 +489,7 @@ where
 /// Optimized 2D scatter update implementation.
 #[inline]
 #[allow(clippy::too_many_arguments)]
-fn scatter_update_2d<E: Copy, U: ElementUpdate<E>>(
+fn scatter_update_2d<E: Copy, F: Fn(&mut E, E)>(
     result: &mut [E],
     indices_data: &[isize],
     value_data: &[E],
@@ -504,6 +498,7 @@ fn scatter_update_2d<E: Copy, U: ElementUpdate<E>>(
     indices_rows: usize,
     indices_cols: usize,
     dim: usize,
+    update: F,
 ) {
     let dim_size = if dim == 0 { tensor_rows } else { tensor_cols };
     if dim == 0 {
@@ -511,7 +506,7 @@ fn scatter_update_2d<E: Copy, U: ElementUpdate<E>>(
             for j in 0..indices_cols {
                 let idx = i * indices_cols + j;
                 let dst_row = checked_index(indices_data[idx], dim_size);
-                U::apply(&mut result[dst_row * tensor_cols + j], value_data[idx]);
+                update(&mut result[dst_row * tensor_cols + j], value_data[idx]);
             }
         }
     } else {
@@ -519,7 +514,7 @@ fn scatter_update_2d<E: Copy, U: ElementUpdate<E>>(
             for j in 0..indices_cols {
                 let idx = i * indices_cols + j;
                 let dst_col = checked_index(indices_data[idx], dim_size);
-                U::apply(&mut result[i * tensor_cols + dst_col], value_data[idx]);
+                update(&mut result[i * tensor_cols + dst_col], value_data[idx]);
             }
         }
     }
@@ -798,7 +793,14 @@ pub fn select_add<E: Element + Pod + Default + Copy + core::ops::AddAssign + Sen
     indices: FlexTensor,
     value: FlexTensor,
 ) -> FlexTensor {
-    select_update::<E, AddUpdate>(tensor, dim, indices, value, "select_add")
+    select_update::<E, _>(
+        tensor,
+        dim,
+        indices,
+        value,
+        "select_add",
+        |target, value| *target += value,
+    )
 }
 
 /// Select multiply: multiplies values into tensor at positions specified by 1D indices.
@@ -808,19 +810,27 @@ pub fn select_mul<E: Element + Pod + Default + Copy + core::ops::Mul<Output = E>
     indices: FlexTensor,
     value: FlexTensor,
 ) -> FlexTensor {
-    select_update::<E, MulUpdate>(tensor, dim, indices, value, "select_mul")
+    select_update::<E, _>(
+        tensor,
+        dim,
+        indices,
+        value,
+        "select_mul",
+        |target, value| *target = *target * value,
+    )
 }
 
-fn select_update<E, U>(
+fn select_update<E, F>(
     tensor: FlexTensor,
     dim: usize,
     indices: FlexTensor,
     value: FlexTensor,
     operation: &str,
+    update: F,
 ) -> FlexTensor
 where
     E: Element + Pod + Default + Copy + Send + Sync,
-    U: ElementUpdate<E>,
+    F: Fn(&mut E, E) + Copy,
 {
     let tensor = tensor.to_contiguous();
     let indices = indices.to_contiguous();
@@ -868,7 +878,7 @@ where
 
     // Use optimized 2D implementation
     if ndims == 2 {
-        select_update_2d::<E, U>(
+        select_update_2d(
             &mut result,
             &indices_data,
             value_data,
@@ -876,6 +886,7 @@ where
             tensor_shape[1],
             num_indices,
             dim,
+            update,
         );
         let bytes = Bytes::from_elems(result);
         return FlexTensor::new(bytes, Layout::contiguous(tensor_shape), E::dtype());
@@ -899,7 +910,7 @@ where
                 dst_idx += coord * tensor_strides[d];
             }
         }
-        U::apply(&mut result[dst_idx], val);
+        update(&mut result[dst_idx], val);
     }
 
     let bytes = Bytes::from_elems(result);
@@ -908,7 +919,8 @@ where
 
 /// Optimized 2D select update.
 #[inline]
-fn select_update_2d<E: Copy, U: ElementUpdate<E>>(
+#[allow(clippy::too_many_arguments)]
+fn select_update_2d<E: Copy, F: Fn(&mut E, E)>(
     result: &mut [E],
     indices_data: &[isize],
     value_data: &[E],
@@ -916,6 +928,7 @@ fn select_update_2d<E: Copy, U: ElementUpdate<E>>(
     tensor_cols: usize,
     num_indices: usize,
     dim: usize,
+    update: F,
 ) {
     let dim_size = if dim == 0 { tensor_rows } else { tensor_cols };
     if dim == 0 {
@@ -924,14 +937,14 @@ fn select_update_2d<E: Copy, U: ElementUpdate<E>>(
             let dst_start = dst_row * tensor_cols;
             let src_start = i * tensor_cols;
             for j in 0..tensor_cols {
-                U::apply(&mut result[dst_start + j], value_data[src_start + j]);
+                update(&mut result[dst_start + j], value_data[src_start + j]);
             }
         }
     } else {
         for row in 0..tensor_rows {
             for (j, &idx) in indices_data.iter().enumerate() {
                 let dst_col = checked_index(idx, dim_size);
-                U::apply(
+                update(
                     &mut result[row * tensor_cols + dst_col],
                     value_data[row * num_indices + j],
                 );

--- a/crates/burn-flex/src/ops/gather_scatter.rs
+++ b/crates/burn-flex/src/ops/gather_scatter.rs
@@ -16,11 +16,10 @@ use crate::{FlexTensor, Layout};
 /// gather/scatter/select kernels in this module.
 ///
 /// This is the internal index layer for burn-flex: every indexed op
-/// ([`gather`], [`scatter_add`], [`select`], [`select_add`], and the
-/// [`scatter_min`]/[`scatter_max`] variants) routes its index tensor through
-/// this helper before touching the element buffer. Normalising to `isize`
-/// lets the kernels use a single inner-loop signature regardless of how the
-/// caller's index tensor was dtyped.
+/// ([`gather`], [`scatter_add`], [`scatter_mul`], [`select`], [`select_add`],
+/// [`select_mul`], and the [`scatter_min`]/[`scatter_max`] variants) routes its index tensor
+/// through this helper before touching the element buffer. Normalising to `isize` lets the kernels
+/// use a single inner-loop signature regardless of how the caller's index tensor was dtyped.
 ///
 /// # Accepted widths
 ///
@@ -149,6 +148,28 @@ fn checked_index(raw: isize, dim_size: usize) -> usize {
         index_oob(raw, dim_size);
     }
     raw as usize
+}
+
+trait ElementUpdate<E> {
+    fn apply(target: &mut E, value: E);
+}
+
+struct AddUpdate;
+
+impl<E: core::ops::AddAssign> ElementUpdate<E> for AddUpdate {
+    #[inline(always)]
+    fn apply(target: &mut E, value: E) {
+        *target += value;
+    }
+}
+
+struct MulUpdate;
+
+impl<E: Copy + core::ops::Mul<Output = E>> ElementUpdate<E> for MulUpdate {
+    #[inline(always)]
+    fn apply(target: &mut E, value: E) {
+        *target = *target * value;
+    }
 }
 
 /// Gather values from tensor along a dimension using indices.
@@ -368,6 +389,30 @@ pub fn scatter_add<E: Element + Pod + Default + Copy + core::ops::AddAssign + Se
     indices: FlexTensor,
     value: FlexTensor,
 ) -> FlexTensor {
+    scatter_update::<E, AddUpdate>(tensor, dim, indices, value, "scatter_add")
+}
+
+/// Scatter multiply: multiplies values into tensor at positions specified by indices.
+pub fn scatter_mul<E: Element + Pod + Default + Copy + core::ops::Mul<Output = E> + Send + Sync>(
+    tensor: FlexTensor,
+    dim: usize,
+    indices: FlexTensor,
+    value: FlexTensor,
+) -> FlexTensor {
+    scatter_update::<E, MulUpdate>(tensor, dim, indices, value, "scatter_mul")
+}
+
+fn scatter_update<E, U>(
+    tensor: FlexTensor,
+    dim: usize,
+    indices: FlexTensor,
+    value: FlexTensor,
+    operation: &str,
+) -> FlexTensor
+where
+    E: Element + Pod + Default + Copy + Send + Sync,
+    U: ElementUpdate<E>,
+{
     let tensor = tensor.to_contiguous();
     let indices = indices.to_contiguous();
     let value = value.to_contiguous();
@@ -386,7 +431,7 @@ pub fn scatter_add<E: Element + Pod + Default + Copy + core::ops::AddAssign + Se
     assert_eq!(
         indices_shape,
         value_shape,
-        "scatter_add: indices shape {:?} must match value shape {:?}",
+        "{operation}: indices shape {:?} must match value shape {:?}",
         indices_shape.to_vec(),
         value_shape.to_vec()
     );
@@ -395,7 +440,7 @@ pub fn scatter_add<E: Element + Pod + Default + Copy + core::ops::AddAssign + Se
         if i != dim {
             assert_eq!(
                 tensor_shape[i], indices_shape[i],
-                "scatter_add: shape mismatch at dim {}: tensor {} vs indices {}",
+                "{operation}: shape mismatch at dim {}: tensor {} vs indices {}",
                 i, tensor_shape[i], indices_shape[i]
             );
         }
@@ -414,7 +459,7 @@ pub fn scatter_add<E: Element + Pod + Default + Copy + core::ops::AddAssign + Se
 
     // Use specialized 2D implementation
     if ndims == 2 {
-        scatter_add_2d(
+        scatter_update_2d::<E, U>(
             &mut result,
             &indices_data,
             value_data,
@@ -439,7 +484,7 @@ pub fn scatter_add<E: Element + Pod + Default + Copy + core::ops::AddAssign + Se
                 &tensor_strides,
                 ndims,
             );
-            result[dst_idx] += value_data[idx];
+            U::apply(&mut result[dst_idx], value_data[idx]);
         }
     }
 
@@ -447,10 +492,10 @@ pub fn scatter_add<E: Element + Pod + Default + Copy + core::ops::AddAssign + Se
     FlexTensor::new(bytes, Layout::contiguous(tensor_shape), E::dtype())
 }
 
-/// Optimized 2D scatter_add implementation.
+/// Optimized 2D scatter update implementation.
 #[inline]
 #[allow(clippy::too_many_arguments)]
-fn scatter_add_2d<E: Copy + core::ops::AddAssign>(
+fn scatter_update_2d<E: Copy, U: ElementUpdate<E>>(
     result: &mut [E],
     indices_data: &[isize],
     value_data: &[E],
@@ -466,7 +511,7 @@ fn scatter_add_2d<E: Copy + core::ops::AddAssign>(
             for j in 0..indices_cols {
                 let idx = i * indices_cols + j;
                 let dst_row = checked_index(indices_data[idx], dim_size);
-                result[dst_row * tensor_cols + j] += value_data[idx];
+                U::apply(&mut result[dst_row * tensor_cols + j], value_data[idx]);
             }
         }
     } else {
@@ -474,7 +519,7 @@ fn scatter_add_2d<E: Copy + core::ops::AddAssign>(
             for j in 0..indices_cols {
                 let idx = i * indices_cols + j;
                 let dst_col = checked_index(indices_data[idx], dim_size);
-                result[i * tensor_cols + dst_col] += value_data[idx];
+                U::apply(&mut result[i * tensor_cols + dst_col], value_data[idx]);
             }
         }
     }
@@ -753,6 +798,30 @@ pub fn select_add<E: Element + Pod + Default + Copy + core::ops::AddAssign + Sen
     indices: FlexTensor,
     value: FlexTensor,
 ) -> FlexTensor {
+    select_update::<E, AddUpdate>(tensor, dim, indices, value, "select_add")
+}
+
+/// Select multiply: multiplies values into tensor at positions specified by 1D indices.
+pub fn select_mul<E: Element + Pod + Default + Copy + core::ops::Mul<Output = E> + Send + Sync>(
+    tensor: FlexTensor,
+    dim: usize,
+    indices: FlexTensor,
+    value: FlexTensor,
+) -> FlexTensor {
+    select_update::<E, MulUpdate>(tensor, dim, indices, value, "select_mul")
+}
+
+fn select_update<E, U>(
+    tensor: FlexTensor,
+    dim: usize,
+    indices: FlexTensor,
+    value: FlexTensor,
+    operation: &str,
+) -> FlexTensor
+where
+    E: Element + Pod + Default + Copy + Send + Sync,
+    U: ElementUpdate<E>,
+{
     let tensor = tensor.to_contiguous();
     let indices = indices.to_contiguous();
     let value = value.to_contiguous();
@@ -770,7 +839,7 @@ pub fn select_add<E: Element + Pod + Default + Copy + core::ops::AddAssign + Sen
     assert_eq!(
         indices.layout().num_dims(),
         1,
-        "select_add: indices must be 1D"
+        "{operation}: indices must be 1D"
     );
 
     let tensor_data: &[E] = tensor.storage();
@@ -783,13 +852,13 @@ pub fn select_add<E: Element + Pod + Default + Copy + core::ops::AddAssign + Sen
         if d == dim {
             assert_eq!(
                 value_shape[d], num_indices,
-                "select_add: value dim {} should be {} (num indices), got {}",
+                "{operation}: value dim {} should be {} (num indices), got {}",
                 d, num_indices, value_shape[d]
             );
         } else {
             assert_eq!(
                 value_shape[d], tensor_shape[d],
-                "select_add: value dim {} should match tensor dim {}, got {}",
+                "{operation}: value dim {} should match tensor dim {}, got {}",
                 d, tensor_shape[d], value_shape[d]
             );
         }
@@ -799,7 +868,7 @@ pub fn select_add<E: Element + Pod + Default + Copy + core::ops::AddAssign + Sen
 
     // Use optimized 2D implementation
     if ndims == 2 {
-        select_add_2d(
+        select_update_2d::<E, U>(
             &mut result,
             &indices_data,
             value_data,
@@ -815,7 +884,7 @@ pub fn select_add<E: Element + Pod + Default + Copy + core::ops::AddAssign + Sen
     // General N-D case
     let tensor_strides: Vec<usize> = compute_strides(&tensor_shape);
     let value_strides: Vec<usize> = compute_strides(value_shape);
-    let select_add_dim_size = tensor_shape[dim];
+    let select_dim_size = tensor_shape[dim];
 
     for (val_idx, &val) in value_data.iter().enumerate() {
         let mut remaining = val_idx;
@@ -824,22 +893,22 @@ pub fn select_add<E: Element + Pod + Default + Copy + core::ops::AddAssign + Sen
             let coord = remaining / value_strides[d];
             remaining %= value_strides[d];
             if d == dim {
-                let index_val = checked_index(indices_data[coord], select_add_dim_size);
+                let index_val = checked_index(indices_data[coord], select_dim_size);
                 dst_idx += index_val * tensor_strides[d];
             } else {
                 dst_idx += coord * tensor_strides[d];
             }
         }
-        result[dst_idx] += val;
+        U::apply(&mut result[dst_idx], val);
     }
 
     let bytes = Bytes::from_elems(result);
     FlexTensor::new(bytes, Layout::contiguous(tensor_shape), E::dtype())
 }
 
-/// Optimized 2D select_add.
+/// Optimized 2D select update.
 #[inline]
-fn select_add_2d<E: Copy + core::ops::AddAssign>(
+fn select_update_2d<E: Copy, U: ElementUpdate<E>>(
     result: &mut [E],
     indices_data: &[isize],
     value_data: &[E],
@@ -855,14 +924,17 @@ fn select_add_2d<E: Copy + core::ops::AddAssign>(
             let dst_start = dst_row * tensor_cols;
             let src_start = i * tensor_cols;
             for j in 0..tensor_cols {
-                result[dst_start + j] += value_data[src_start + j];
+                U::apply(&mut result[dst_start + j], value_data[src_start + j]);
             }
         }
     } else {
         for row in 0..tensor_rows {
             for (j, &idx) in indices_data.iter().enumerate() {
                 let dst_col = checked_index(idx, dim_size);
-                result[row * tensor_cols + dst_col] += value_data[row * num_indices + j];
+                U::apply(
+                    &mut result[row * tensor_cols + dst_col],
+                    value_data[row * num_indices + j],
+                );
             }
         }
     }

--- a/crates/burn-flex/src/ops/int.rs
+++ b/crates/burn-flex/src/ops/int.rs
@@ -167,6 +167,51 @@ impl IntTensorOps<Flex> for Flex {
         }
     }
 
+    fn int_scatter(
+        dim: usize,
+        tensor: IntTensor<Flex>,
+        indices: IntTensor<Flex>,
+        value: IntTensor<Flex>,
+        update: burn_backend::tensor::IndexingUpdateOp,
+    ) -> IntTensor<Flex> {
+        match update {
+            burn_backend::tensor::IndexingUpdateOp::Add => {
+                Self::int_scatter_add(dim, tensor, indices, value)
+            }
+            burn_backend::tensor::IndexingUpdateOp::Mul => {
+                debug_assert_eq!(tensor.dtype(), value.dtype(), "int_scatter: dtype mismatch");
+                match tensor.dtype() {
+                    DType::I64 => {
+                        crate::ops::gather_scatter::scatter_mul::<i64>(tensor, dim, indices, value)
+                    }
+                    DType::I32 => {
+                        crate::ops::gather_scatter::scatter_mul::<i32>(tensor, dim, indices, value)
+                    }
+                    DType::I16 => {
+                        crate::ops::gather_scatter::scatter_mul::<i16>(tensor, dim, indices, value)
+                    }
+                    DType::I8 => {
+                        crate::ops::gather_scatter::scatter_mul::<i8>(tensor, dim, indices, value)
+                    }
+                    DType::U64 => {
+                        crate::ops::gather_scatter::scatter_mul::<u64>(tensor, dim, indices, value)
+                    }
+                    DType::U32 => {
+                        crate::ops::gather_scatter::scatter_mul::<u32>(tensor, dim, indices, value)
+                    }
+                    DType::U16 => {
+                        crate::ops::gather_scatter::scatter_mul::<u16>(tensor, dim, indices, value)
+                    }
+                    DType::U8 => {
+                        crate::ops::gather_scatter::scatter_mul::<u8>(tensor, dim, indices, value)
+                    }
+                    dt => panic!("int_scatter: unsupported dtype {:?}", dt),
+                }
+            }
+            other => unimplemented!("int_scatter with {other:?} update is not implemented"),
+        }
+    }
+
     fn int_scatter_nd(
         data: IntTensor<Flex>,
         indices: IntTensor<Flex>,
@@ -276,6 +321,57 @@ impl IntTensorOps<Flex> for Flex {
             }
             DType::U8 => crate::ops::gather_scatter::select_add::<u8>(tensor, dim, indices, value),
             dt => panic!("int_select_add: unsupported dtype {:?}", dt),
+        }
+    }
+
+    fn int_select_assign(
+        tensor: IntTensor<Flex>,
+        dim: usize,
+        indices: IntTensor<Flex>,
+        value: IntTensor<Flex>,
+        update: burn_backend::tensor::IndexingUpdateOp,
+    ) -> IntTensor<Flex> {
+        match update {
+            burn_backend::tensor::IndexingUpdateOp::Add => {
+                Self::int_select_add(tensor, dim, indices, value)
+            }
+            burn_backend::tensor::IndexingUpdateOp::Mul => {
+                debug_assert_eq!(
+                    tensor.dtype(),
+                    value.dtype(),
+                    "int_select_assign: dtype mismatch"
+                );
+                match tensor.dtype() {
+                    DType::I64 => {
+                        crate::ops::gather_scatter::select_mul::<i64>(tensor, dim, indices, value)
+                    }
+                    DType::I32 => {
+                        crate::ops::gather_scatter::select_mul::<i32>(tensor, dim, indices, value)
+                    }
+                    DType::I16 => {
+                        crate::ops::gather_scatter::select_mul::<i16>(tensor, dim, indices, value)
+                    }
+                    DType::I8 => {
+                        crate::ops::gather_scatter::select_mul::<i8>(tensor, dim, indices, value)
+                    }
+                    DType::U64 => {
+                        crate::ops::gather_scatter::select_mul::<u64>(tensor, dim, indices, value)
+                    }
+                    DType::U32 => {
+                        crate::ops::gather_scatter::select_mul::<u32>(tensor, dim, indices, value)
+                    }
+                    DType::U16 => {
+                        crate::ops::gather_scatter::select_mul::<u16>(tensor, dim, indices, value)
+                    }
+                    DType::U8 => {
+                        crate::ops::gather_scatter::select_mul::<u8>(tensor, dim, indices, value)
+                    }
+                    dt => panic!("int_select_assign: unsupported dtype {:?}", dt),
+                }
+            }
+            other => {
+                unimplemented!("int_select_assign with {other:?} update is not implemented")
+            }
         }
     }
 

--- a/crates/burn-ndarray/src/ops/base.rs
+++ b/crates/burn-ndarray/src/ops/base.rs
@@ -239,6 +239,60 @@ where
         output
     }
 
+    pub fn scatter_mul<I: NdArrayElement>(
+        dim: usize,
+        mut tensor: SharedArray<E>,
+        mut indices: SharedArray<I>,
+        mut value: SharedArray<E>,
+    ) -> SharedArray<E>
+    where
+        E: core::ops::Mul<Output = E>,
+    {
+        let ndims = tensor.shape().num_dims();
+        if dim != ndims - 1 {
+            tensor.swap_axes(ndims - 1, dim);
+            indices.swap_axes(ndims - 1, dim);
+            value.swap_axes(ndims - 1, dim);
+        }
+
+        let (shape_tensor, shape_indices, shape_value) =
+            (tensor.shape().into_shape(), indices.shape(), value.shape());
+        let (size_tensor, size_index, size_value) = (
+            shape_tensor[ndims - 1],
+            shape_indices[ndims - 1],
+            shape_value[ndims - 1],
+        );
+        let batch_size = Self::gather_batch_size(&shape_tensor, shape_indices);
+
+        if shape_value != shape_indices {
+            panic!(
+                "Invalid dimension: the shape of the index tensor should be the same as the value \
+                 tensor: Index {:?} value {:?}",
+                shape_indices, shape_value
+            );
+        }
+
+        let indices = NdArrayOps::reshape(indices, Shape::new([batch_size, size_index]));
+        let value = NdArrayOps::reshape(value, Shape::new([batch_size, size_value]));
+        let mut tensor = NdArrayOps::reshape(tensor, Shape::new([batch_size, size_tensor]));
+
+        for b in 0..batch_size {
+            let indices = indices.slice(s!(b, ..));
+
+            for (i, index) in indices.iter().enumerate() {
+                let index = index.elem::<i64>() as usize;
+                let out = &mut tensor[[b, index]];
+                *out = *out * value[[b, i]];
+            }
+        }
+
+        let mut output = NdArrayOps::reshape(tensor.into_shared().into_dyn(), shape_tensor);
+        if dim != ndims - 1 {
+            output.swap_axes(ndims - 1, dim);
+        }
+        output
+    }
+
     pub fn scatter_nd<I: NdArrayElement>(
         data: SharedArray<E>,
         indices: SharedArray<I>,
@@ -1043,6 +1097,24 @@ where
             let value = value.index_axis(Axis(dim), index_value);
 
             view.zip_mut_with(&value, |a, b| *a = *b);
+        }
+
+        output_array.into_shared()
+    }
+
+    pub fn select_assign_mul<I: NdArrayElement>(
+        tensor: SharedArray<E>,
+        dim: usize,
+        indices: SharedArray<I>,
+        value: SharedArray<E>,
+    ) -> SharedArray<E> {
+        let mut output_array = tensor.into_owned();
+
+        for (index_value, index) in indices.into_iter().enumerate() {
+            let mut view = output_array.index_axis_mut(Axis(dim), index.elem::<i64>() as usize);
+            let value = value.index_axis(Axis(dim), index_value);
+
+            view.zip_mut_with(&value, |a, b| *a = *a * *b);
         }
 
         output_array.into_shared()

--- a/crates/burn-ndarray/src/ops/int_tensor.rs
+++ b/crates/burn-ndarray/src/ops/int_tensor.rs
@@ -297,6 +297,13 @@ impl IntTensorOps<Self> for NdArray {
                     ))
                 })
             }
+            burn_backend::tensor::IndexingUpdateOp::Mul => {
+                execute_with_int_dtype!((tensor, value), I, |tensor, value| -> NdArrayTensor {
+                    execute_with_int_dtype!(indices, |idx_array| NdArrayOps::<I>::scatter_mul(
+                        dim, tensor, idx_array, value
+                    ))
+                })
+            }
             other => unimplemented!("int_scatter with {other:?} update is not implemented"),
         }
     }
@@ -356,6 +363,13 @@ impl IntTensorOps<Self> for NdArray {
                 execute_with_int_dtype!((tensor, value), I, |tensor, value| -> NdArrayTensor {
                     execute_with_int_dtype!(indices, |idx_array| {
                         NdArrayMathOps::<I>::select_assign_replace(tensor, dim, idx_array, value)
+                    })
+                })
+            }
+            burn_backend::tensor::IndexingUpdateOp::Mul => {
+                execute_with_int_dtype!((tensor, value), I, |tensor, value| -> NdArrayTensor {
+                    execute_with_int_dtype!(indices, |idx_array| {
+                        NdArrayMathOps::<I>::select_assign_mul(tensor, dim, idx_array, value)
                     })
                 })
             }

--- a/crates/burn-ndarray/src/ops/tensor.rs
+++ b/crates/burn-ndarray/src/ops/tensor.rs
@@ -218,6 +218,17 @@ impl FloatTensorOps<Self> for NdArray {
                     }
                 )
             }
+            burn_backend::tensor::IndexingUpdateOp::Mul => {
+                execute_with_int_dtype!(
+                    indices,
+                    IntElem,
+                    |idx_array: SharedArray<IntElem>| -> NdArrayTensor {
+                        execute_with_float_dtype!((tensor, value), |tensor, value| {
+                            NdArrayOps::scatter_mul(dim, tensor, idx_array, value)
+                        })
+                    }
+                )
+            }
             other => unimplemented!("float_scatter with {other:?} update is not implemented"),
         }
     }
@@ -302,6 +313,17 @@ impl FloatTensorOps<Self> for NdArray {
                     |idx_array: SharedArray<IntElem>| -> NdArrayTensor {
                         execute_with_float_dtype!((tensor, value), |tensor, value| {
                             NdArrayMathOps::select_assign_replace(tensor, dim, idx_array, value)
+                        })
+                    }
+                )
+            }
+            burn_backend::tensor::IndexingUpdateOp::Mul => {
+                execute_with_int_dtype!(
+                    indices,
+                    IntElem,
+                    |idx_array: SharedArray<IntElem>| -> NdArrayTensor {
+                        execute_with_float_dtype!((tensor, value), |tensor, value| {
+                            NdArrayMathOps::select_assign_mul(tensor, dim, idx_array, value)
                         })
                     }
                 )

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -1631,12 +1631,16 @@ where
     ///   booleans, `Add` is logical or.
     /// - `IndexingUpdateOp::Assign` replaces values at the selected positions (`=`), when
     ///   supported by the backend.
+    /// - `IndexingUpdateOp::Mul` multiplies values at the selected positions (`*=`), when
+    ///   supported by the backend.
     ///
     /// When `indices` contains duplicate entries, behavior varies by operation:
     /// - For `Add`, accumulation is supported, though results may be non-deterministic on GPU
     ///   backends.
     /// - For `Assign`, duplicate indices result in undefined behavior for both the forward result
     ///   and the backward gradients.
+    /// - For `Mul`, duplicate indices are multiplied in an unspecified order and backward
+    ///   gradients are undefined.
     ///
     /// For deterministic results and correct gradient calculation across all operations,
     /// `indices` should contain unique entries.
@@ -1664,6 +1668,13 @@ where
     /// `input[indices[i], j, k] = values[i, j, k]; // dim = 0`
     /// `input[i, indices[j], k] = values[i, j, k]; // dim = 1`
     /// `input[i, j, indices[k]] = values[i, j, k]; // dim = 2`
+    ///
+    /// With `IndexingUpdateOp::Mul`, when supported by the backend, the selected values are
+    /// multiplied instead:
+    ///
+    /// `input[indices[i], j, k] *= values[i, j, k]; // dim = 0`
+    /// `input[i, indices[j], k] *= values[i, j, k]; // dim = 1`
+    /// `input[i, j, indices[k]] *= values[i, j, k]; // dim = 2`
     ///
     /// # Warning
     ///
@@ -1849,6 +1860,13 @@ where
     /// `input[i, indices[i, j, k], k] = values[i, j, k]; // dim = 1`
     /// `input[i, j, indices[i, j, k]] = values[i, j, k]; // dim = 2`
     ///
+    /// With `IndexingUpdateOp::Mul`, when supported by the backend, the indexed values are
+    /// multiplied instead:
+    ///
+    /// `input[indices[i, j, k], j, k] *= values[i, j, k]; // dim = 0`
+    /// `input[i, indices[i, j, k], k] *= values[i, j, k]; // dim = 1`
+    /// `input[i, j, indices[i, j, k]] *= values[i, j, k]; // dim = 2`
+    ///
     /// # Arguments
     /// * `dim` - The axis along which to scatter elements. Supports negative indexing.
     /// * `indices` - The indices of the elements to scatter.
@@ -1865,6 +1883,8 @@ where
     ///   backends.
     /// - For `Assign`, duplicate indices result in undefined behavior for both the forward result
     ///   and the backward gradients.
+    /// - For `Mul`, duplicate indices are multiplied in an unspecified order and backward
+    ///   gradients are undefined.
     ///
     /// For deterministic results and correct gradient calculation across all operations,
     /// `indices` should contain unique entries.


### PR DESCRIPTION
## Motivation

`scatter` and `select_assign` accept `IndexingUpdateOp`, but the plain indexed update APIs did not support `Mul`, even though multiply-style updates are available through `scatter_nd`. This adds consistent multiply updates for float and integer tensors on the Flex and NdArray CPU backends, including float autodiff support.

The backward formulas require unique indices. Duplicate-index behavior is therefore documented explicitly so callers do not rely on backend-specific update ordering or undefined gradients.

## Modifications

- Implement `Mul` for float and integer `scatter` and `select_assign` on Flex and NdArray.
- Share Flex's add and multiply index traversal while retaining its specialized 2D paths.
- Add float autodiff gradients for `scatter(..., Mul)` and `select_assign(..., Mul)` without depending on backend-specific `Assign` support.
- Document `Mul` behavior and duplicate-index semantics on the public tensor APIs.
- Add forward and autodiff coverage for both supported CPU backends.

