### PR TITLE
fix(deps): update cubecl and use correct windows crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -172,7 +172,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -683,7 +683,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -1777,7 +1777,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2255,7 +2255,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7d983b7be23228d8b731820882f80b1de04b1192#7d983b7be23228d8b731820882f80b1de04b1192"
+source = "git+https://github.com/tracel-ai/cubecl?rev=11aec302f1b008f8540938a26f26cc46298d1fab#11aec302f1b008f8540938a26f26cc46298d1fab"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -2272,7 +2272,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7d983b7be23228d8b731820882f80b1de04b1192#7d983b7be23228d8b731820882f80b1de04b1192"
+source = "git+https://github.com/tracel-ai/cubecl?rev=11aec302f1b008f8540938a26f26cc46298d1fab#11aec302f1b008f8540938a26f26cc46298d1fab"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -2296,7 +2296,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7d983b7be23228d8b731820882f80b1de04b1192#7d983b7be23228d8b731820882f80b1de04b1192"
+source = "git+https://github.com/tracel-ai/cubecl?rev=11aec302f1b008f8540938a26f26cc46298d1fab#11aec302f1b008f8540938a26f26cc46298d1fab"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -2326,7 +2326,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7d983b7be23228d8b731820882f80b1de04b1192#7d983b7be23228d8b731820882f80b1de04b1192"
+source = "git+https://github.com/tracel-ai/cubecl?rev=11aec302f1b008f8540938a26f26cc46298d1fab#11aec302f1b008f8540938a26f26cc46298d1fab"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2343,7 +2343,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7d983b7be23228d8b731820882f80b1de04b1192#7d983b7be23228d8b731820882f80b1de04b1192"
+source = "git+https://github.com/tracel-ai/cubecl?rev=11aec302f1b008f8540938a26f26cc46298d1fab#11aec302f1b008f8540938a26f26cc46298d1fab"
 dependencies = [
  "bytemuck",
  "crossbeam-utils",
@@ -2370,7 +2370,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7d983b7be23228d8b731820882f80b1de04b1192#7d983b7be23228d8b731820882f80b1de04b1192"
+source = "git+https://github.com/tracel-ai/cubecl?rev=11aec302f1b008f8540938a26f26cc46298d1fab#11aec302f1b008f8540938a26f26cc46298d1fab"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2389,7 +2389,7 @@ dependencies = [
 [[package]]
 name = "cubecl-environment"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7d983b7be23228d8b731820882f80b1de04b1192#7d983b7be23228d8b731820882f80b1de04b1192"
+source = "git+https://github.com/tracel-ai/cubecl?rev=11aec302f1b008f8540938a26f26cc46298d1fab#11aec302f1b008f8540938a26f26cc46298d1fab"
 dependencies = [
  "async-channel",
  "backtrace",
@@ -2424,7 +2424,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7d983b7be23228d8b731820882f80b1de04b1192#7d983b7be23228d8b731820882f80b1de04b1192"
+source = "git+https://github.com/tracel-ai/cubecl?rev=11aec302f1b008f8540938a26f26cc46298d1fab#11aec302f1b008f8540938a26f26cc46298d1fab"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2454,7 +2454,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7d983b7be23228d8b731820882f80b1de04b1192#7d983b7be23228d8b731820882f80b1de04b1192"
+source = "git+https://github.com/tracel-ai/cubecl?rev=11aec302f1b008f8540938a26f26cc46298d1fab#11aec302f1b008f8540938a26f26cc46298d1fab"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -2479,7 +2479,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7d983b7be23228d8b731820882f80b1de04b1192#7d983b7be23228d8b731820882f80b1de04b1192"
+source = "git+https://github.com/tracel-ai/cubecl?rev=11aec302f1b008f8540938a26f26cc46298d1fab#11aec302f1b008f8540938a26f26cc46298d1fab"
 dependencies = [
  "cubecl-common",
  "darling 0.23.0",
@@ -2496,7 +2496,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7d983b7be23228d8b731820882f80b1de04b1192#7d983b7be23228d8b731820882f80b1de04b1192"
+source = "git+https://github.com/tracel-ai/cubecl?rev=11aec302f1b008f8540938a26f26cc46298d1fab#11aec302f1b008f8540938a26f26cc46298d1fab"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -2507,7 +2507,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7d983b7be23228d8b731820882f80b1de04b1192#7d983b7be23228d8b731820882f80b1de04b1192"
+source = "git+https://github.com/tracel-ai/cubecl?rev=11aec302f1b008f8540938a26f26cc46298d1fab#11aec302f1b008f8540938a26f26cc46298d1fab"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2526,7 +2526,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7d983b7be23228d8b731820882f80b1de04b1192#7d983b7be23228d8b731820882f80b1de04b1192"
+source = "git+https://github.com/tracel-ai/cubecl?rev=11aec302f1b008f8540938a26f26cc46298d1fab#11aec302f1b008f8540938a26f26cc46298d1fab"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2554,7 +2554,7 @@ dependencies = [
 [[package]]
 name = "cubecl-spirv"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7d983b7be23228d8b731820882f80b1de04b1192#7d983b7be23228d8b731820882f80b1de04b1192"
+source = "git+https://github.com/tracel-ai/cubecl?rev=11aec302f1b008f8540938a26f26cc46298d1fab#11aec302f1b008f8540938a26f26cc46298d1fab"
 dependencies = [
  "bitflags 2.13.1",
  "cubecl-common",
@@ -2571,7 +2571,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7d983b7be23228d8b731820882f80b1de04b1192#7d983b7be23228d8b731820882f80b1de04b1192"
+source = "git+https://github.com/tracel-ai/cubecl?rev=11aec302f1b008f8540938a26f26cc46298d1fab#11aec302f1b008f8540938a26f26cc46298d1fab"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2588,7 +2588,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7d983b7be23228d8b731820882f80b1de04b1192#7d983b7be23228d8b731820882f80b1de04b1192"
+source = "git+https://github.com/tracel-ai/cubecl?rev=11aec302f1b008f8540938a26f26cc46298d1fab#11aec302f1b008f8540938a26f26cc46298d1fab"
 dependencies = [
  "ash",
  "bytemuck",
@@ -2617,7 +2617,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7d983b7be23228d8b731820882f80b1de04b1192#7d983b7be23228d8b731820882f80b1de04b1192"
+source = "git+https://github.com/tracel-ai/cubecl?rev=11aec302f1b008f8540938a26f26cc46298d1fab#11aec302f1b008f8540938a26f26cc46298d1fab"
 dependencies = [
  "derive-new",
  "serde",
@@ -2627,7 +2627,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=6dbfc30866fd5d73cc9fae4cda29e88d78cd9ed9#6dbfc30866fd5d73cc9fae4cda29e88d78cd9ed9"
+source = "git+https://github.com/tracel-ai/cubek?rev=e9a524d2f27dde3000a478a2604052be9b8e30b0#e9a524d2f27dde3000a478a2604052be9b8e30b0"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2645,7 +2645,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=6dbfc30866fd5d73cc9fae4cda29e88d78cd9ed9#6dbfc30866fd5d73cc9fae4cda29e88d78cd9ed9"
+source = "git+https://github.com/tracel-ai/cubek?rev=e9a524d2f27dde3000a478a2604052be9b8e30b0#e9a524d2f27dde3000a478a2604052be9b8e30b0"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2659,7 +2659,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=6dbfc30866fd5d73cc9fae4cda29e88d78cd9ed9#6dbfc30866fd5d73cc9fae4cda29e88d78cd9ed9"
+source = "git+https://github.com/tracel-ai/cubek?rev=e9a524d2f27dde3000a478a2604052be9b8e30b0#e9a524d2f27dde3000a478a2604052be9b8e30b0"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2675,7 +2675,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=6dbfc30866fd5d73cc9fae4cda29e88d78cd9ed9#6dbfc30866fd5d73cc9fae4cda29e88d78cd9ed9"
+source = "git+https://github.com/tracel-ai/cubek?rev=e9a524d2f27dde3000a478a2604052be9b8e30b0#e9a524d2f27dde3000a478a2604052be9b8e30b0"
 dependencies = [
  "cubecl",
 ]
@@ -2683,7 +2683,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=6dbfc30866fd5d73cc9fae4cda29e88d78cd9ed9#6dbfc30866fd5d73cc9fae4cda29e88d78cd9ed9"
+source = "git+https://github.com/tracel-ai/cubek?rev=e9a524d2f27dde3000a478a2604052be9b8e30b0#e9a524d2f27dde3000a478a2604052be9b8e30b0"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2695,7 +2695,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=6dbfc30866fd5d73cc9fae4cda29e88d78cd9ed9#6dbfc30866fd5d73cc9fae4cda29e88d78cd9ed9"
+source = "git+https://github.com/tracel-ai/cubek?rev=e9a524d2f27dde3000a478a2604052be9b8e30b0#e9a524d2f27dde3000a478a2604052be9b8e30b0"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2709,7 +2709,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=6dbfc30866fd5d73cc9fae4cda29e88d78cd9ed9#6dbfc30866fd5d73cc9fae4cda29e88d78cd9ed9"
+source = "git+https://github.com/tracel-ai/cubek?rev=e9a524d2f27dde3000a478a2604052be9b8e30b0#e9a524d2f27dde3000a478a2604052be9b8e30b0"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2719,7 +2719,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=6dbfc30866fd5d73cc9fae4cda29e88d78cd9ed9#6dbfc30866fd5d73cc9fae4cda29e88d78cd9ed9"
+source = "git+https://github.com/tracel-ai/cubek?rev=e9a524d2f27dde3000a478a2604052be9b8e30b0#e9a524d2f27dde3000a478a2604052be9b8e30b0"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2731,7 +2731,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=6dbfc30866fd5d73cc9fae4cda29e88d78cd9ed9#6dbfc30866fd5d73cc9fae4cda29e88d78cd9ed9"
+source = "git+https://github.com/tracel-ai/cubek?rev=e9a524d2f27dde3000a478a2604052be9b8e30b0#e9a524d2f27dde3000a478a2604052be9b8e30b0"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2745,7 +2745,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=6dbfc30866fd5d73cc9fae4cda29e88d78cd9ed9#6dbfc30866fd5d73cc9fae4cda29e88d78cd9ed9"
+source = "git+https://github.com/tracel-ai/cubek?rev=e9a524d2f27dde3000a478a2604052be9b8e30b0#e9a524d2f27dde3000a478a2604052be9b8e30b0"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2758,7 +2758,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=6dbfc30866fd5d73cc9fae4cda29e88d78cd9ed9#6dbfc30866fd5d73cc9fae4cda29e88d78cd9ed9"
+source = "git+https://github.com/tracel-ai/cubek?rev=e9a524d2f27dde3000a478a2604052be9b8e30b0#e9a524d2f27dde3000a478a2604052be9b8e30b0"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2768,7 +2768,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=6dbfc30866fd5d73cc9fae4cda29e88d78cd9ed9#6dbfc30866fd5d73cc9fae4cda29e88d78cd9ed9"
+source = "git+https://github.com/tracel-ai/cubek?rev=e9a524d2f27dde3000a478a2604052be9b8e30b0#e9a524d2f27dde3000a478a2604052be9b8e30b0"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -3268,7 +3268,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3630,7 +3630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4317,8 +4317,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -4561,7 +4561,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.19",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -4950,7 +4950,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -6607,7 +6607,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7070,6 +7070,15 @@ name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
 ]
@@ -8381,7 +8390,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9102,7 +9111,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9160,7 +9169,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9313,7 +9322,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9699,7 +9708,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9827,7 +9836,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10093,7 +10102,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10115,7 +10124,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook 0.3.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10125,7 +10134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10170,7 +10179,7 @@ dependencies = [
  "nix 0.29.0",
  "num-derive",
  "num-traits",
- "ordered-float",
+ "ordered-float 4.6.0",
  "pest",
  "pest_derive",
  "phf 0.11.3",
@@ -10726,9 +10735,9 @@ dependencies = [
 
 [[package]]
 name = "tracel-rspirv"
-version = "0.13.3+sdk-1.4.357.0"
+version = "0.14.0+sdk-1.4.357.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b0d2ea2c587d60af18cee8cb48d85048a3b03565f58f02005a3813e3283be0f"
+checksum = "e18ed0062c1f1236d9c51523b310974352778b0dd3b8598f70eac580afbed27b"
 dependencies = [
  "bitflags 2.13.1",
  "rustc-hash 2.1.3",
@@ -11475,7 +11484,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
 dependencies = [
  "log",
- "ordered-float",
+ "ordered-float 4.6.0",
  "strsim",
  "thiserror 1.0.69",
  "wezterm-dynamic-derive",
@@ -11638,7 +11647,7 @@ dependencies = [
  "objc2-metal",
  "objc2-quartz-core",
  "once_cell",
- "ordered-float",
+ "ordered-float 5.3.0",
  "parking_lot",
  "portable-atomic",
  "portable-atomic-util",
@@ -11726,7 +11735,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12214,8 +12223,8 @@ dependencies = [
  "log",
  "serde",
  "thiserror 2.0.19",
- "windows 0.61.3",
- "windows-core 0.61.2",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2627,7 +2627,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=e9a524d2f27dde3000a478a2604052be9b8e30b0#e9a524d2f27dde3000a478a2604052be9b8e30b0"
+source = "git+https://github.com/tracel-ai/cubek?rev=1ebbead836e5737a26e9f6a54b6ddab96a965f65#1ebbead836e5737a26e9f6a54b6ddab96a965f65"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2645,7 +2645,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=e9a524d2f27dde3000a478a2604052be9b8e30b0#e9a524d2f27dde3000a478a2604052be9b8e30b0"
+source = "git+https://github.com/tracel-ai/cubek?rev=1ebbead836e5737a26e9f6a54b6ddab96a965f65#1ebbead836e5737a26e9f6a54b6ddab96a965f65"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2659,7 +2659,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=e9a524d2f27dde3000a478a2604052be9b8e30b0#e9a524d2f27dde3000a478a2604052be9b8e30b0"
+source = "git+https://github.com/tracel-ai/cubek?rev=1ebbead836e5737a26e9f6a54b6ddab96a965f65#1ebbead836e5737a26e9f6a54b6ddab96a965f65"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2675,7 +2675,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=e9a524d2f27dde3000a478a2604052be9b8e30b0#e9a524d2f27dde3000a478a2604052be9b8e30b0"
+source = "git+https://github.com/tracel-ai/cubek?rev=1ebbead836e5737a26e9f6a54b6ddab96a965f65#1ebbead836e5737a26e9f6a54b6ddab96a965f65"
 dependencies = [
  "cubecl",
 ]
@@ -2683,7 +2683,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=e9a524d2f27dde3000a478a2604052be9b8e30b0#e9a524d2f27dde3000a478a2604052be9b8e30b0"
+source = "git+https://github.com/tracel-ai/cubek?rev=1ebbead836e5737a26e9f6a54b6ddab96a965f65#1ebbead836e5737a26e9f6a54b6ddab96a965f65"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2695,7 +2695,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=e9a524d2f27dde3000a478a2604052be9b8e30b0#e9a524d2f27dde3000a478a2604052be9b8e30b0"
+source = "git+https://github.com/tracel-ai/cubek?rev=1ebbead836e5737a26e9f6a54b6ddab96a965f65#1ebbead836e5737a26e9f6a54b6ddab96a965f65"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2709,7 +2709,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=e9a524d2f27dde3000a478a2604052be9b8e30b0#e9a524d2f27dde3000a478a2604052be9b8e30b0"
+source = "git+https://github.com/tracel-ai/cubek?rev=1ebbead836e5737a26e9f6a54b6ddab96a965f65#1ebbead836e5737a26e9f6a54b6ddab96a965f65"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2719,7 +2719,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=e9a524d2f27dde3000a478a2604052be9b8e30b0#e9a524d2f27dde3000a478a2604052be9b8e30b0"
+source = "git+https://github.com/tracel-ai/cubek?rev=1ebbead836e5737a26e9f6a54b6ddab96a965f65#1ebbead836e5737a26e9f6a54b6ddab96a965f65"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2731,7 +2731,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=e9a524d2f27dde3000a478a2604052be9b8e30b0#e9a524d2f27dde3000a478a2604052be9b8e30b0"
+source = "git+https://github.com/tracel-ai/cubek?rev=1ebbead836e5737a26e9f6a54b6ddab96a965f65#1ebbead836e5737a26e9f6a54b6ddab96a965f65"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2745,7 +2745,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=e9a524d2f27dde3000a478a2604052be9b8e30b0#e9a524d2f27dde3000a478a2604052be9b8e30b0"
+source = "git+https://github.com/tracel-ai/cubek?rev=1ebbead836e5737a26e9f6a54b6ddab96a965f65#1ebbead836e5737a26e9f6a54b6ddab96a965f65"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2758,7 +2758,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=e9a524d2f27dde3000a478a2604052be9b8e30b0#e9a524d2f27dde3000a478a2604052be9b8e30b0"
+source = "git+https://github.com/tracel-ai/cubek?rev=1ebbead836e5737a26e9f6a54b6ddab96a965f65#1ebbead836e5737a26e9f6a54b6ddab96a965f65"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2768,7 +2768,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=e9a524d2f27dde3000a478a2604052be9b8e30b0#e9a524d2f27dde3000a478a2604052be9b8e30b0"
+source = "git+https://github.com/tracel-ai/cubek?rev=1ebbead836e5737a26e9f6a54b6ddab96a965f65#1ebbead836e5737a26e9f6a54b6ddab96a965f65"
 dependencies = [
  "bytemuck",
  "cubecl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,11 +223,11 @@ burn-vision = { path = "crates/burn-vision", version = "=0.22.0-pre.1", default-
 burn-wgpu = { path = "crates/burn-wgpu", version = "=0.22.0-pre.1", default-features = false }
 
 ### For the main burn branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "7d983b7be23228d8b731820882f80b1de04b1192" }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "7d983b7be23228d8b731820882f80b1de04b1192" }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "7d983b7be23228d8b731820882f80b1de04b1192" }
-cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "7d983b7be23228d8b731820882f80b1de04b1192" }
-cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "6dbfc30866fd5d73cc9fae4cda29e88d78cd9ed9" }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "11aec302f1b008f8540938a26f26cc46298d1fab" }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "11aec302f1b008f8540938a26f26cc46298d1fab" }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "11aec302f1b008f8540938a26f26cc46298d1fab" }
+cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "11aec302f1b008f8540938a26f26cc46298d1fab" }
+cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "e9a524d2f27dde3000a478a2604052be9b8e30b0" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,7 +227,7 @@ cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false
 cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "11aec302f1b008f8540938a26f26cc46298d1fab" }
 cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "11aec302f1b008f8540938a26f26cc46298d1fab" }
 cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "11aec302f1b008f8540938a26f26cc46298d1fab" }
-cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "e9a524d2f27dde3000a478a2604052be9b8e30b0" }
+cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "1ebbead836e5737a26e9f6a54b6ddab96a965f65" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

#5322 dang it claude, you broke the windows crate versions (and thus the CI)

### Changes

- Updated cubecl/cubek (tracel-rspirv yanked, requires https://github.com/tracel-ai/cubek/pull/472)
- Fixed windows deps versions
