### PR TITLE
fix(burn-flex): make float_sign branchless so it compiles on Xtensa

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/float/ops/sign.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/sign.rs
@@ -10,3 +10,16 @@ fn should_support_sign_ops_float() {
 
     output.into_data().assert_eq(&expected, false);
 }
+
+#[test]
+fn should_support_sign_ops_float_negative_zero() {
+    // Negative zero must map to +0.0, not -1.0. Guards the `x == 0.0` branch in
+    // the `copysign`-based implementations: `copysign(1.0, -0.0)` is `-1.0`, so
+    // dropping that branch silently changes the result for negative zero.
+    let tensor = TestTensor::<2>::from([[-0.0, 0.0]]);
+
+    let output = tensor.sign();
+    let expected = TensorData::from([[0.0, 0.0]]);
+
+    output.into_data().assert_eq(&expected, false);
+}

--- a/crates/burn-backend-tests/tests/tensor/float/ops/sign.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/sign.rs
@@ -18,8 +18,12 @@ fn should_support_sign_ops_float_negative_zero() {
     // dropping that branch silently changes the result for negative zero.
     let tensor = TestTensor::<2>::from([[-0.0, 0.0]]);
 
-    let output = tensor.sign();
-    let expected = TensorData::from([[0.0, 0.0]]);
+    let output = tensor.sign().into_data().convert::<f32>();
+    let output = output.as_slice::<f32>().unwrap();
 
-    output.into_data().assert_eq(&expected, false);
+    // `assert_eq` on `TensorData` uses ordinary float equality, where `-0.0 == 0.0`,
+    // so it would not catch a regression that returns negative zero here. Compare
+    // the raw bit patterns instead to actually enforce the +0.0 guarantee.
+    assert_eq!(output[0].to_bits(), 0.0f32.to_bits());
+    assert_eq!(output[1].to_bits(), 0.0f32.to_bits());
 }

--- a/crates/burn-flex/src/ops/float.rs
+++ b/crates/burn-flex/src/ops/float.rs
@@ -555,29 +555,36 @@ impl FloatTensorOps<Flex> for Flex {
         )
     }
 
+    // Uses `copysign` rather than a `> 0.0` / `< 0.0` branch chain. The branch
+    // chain is compiled into a lookup from a `[2 x float]` constant pool at -O2
+    // and above, and some backends (notably Xtensa) have no instruction
+    // selection pattern for a PC-relative reference to a constant pool, so the
+    // whole crate fails to compile for those targets. One scalar constant
+    // leaves the pool with nothing to hold.
+    //
+    // The zero branch is load bearing: `copysign(1.0, -0.0)` is `-1.0`, not
+    // `0.0`, so negative zero must be caught before it reaches there. `-0.0 ==
+    // 0.0` under IEEE 754, so one comparison covers both signed zeros, matching
+    // the previous fall-through.
     fn float_sign(tensor: FloatTensor<Flex>) -> FloatTensor<Flex> {
         unary::unary_op(
             tensor,
             |x: f32| {
                 if x.is_nan() {
                     x
-                } else if x > 0.0 {
-                    1.0
-                } else if x < 0.0 {
-                    -1.0
-                } else {
+                } else if x == 0.0 {
                     0.0
+                } else {
+                    libm::copysignf(1.0, x)
                 }
             },
             |x: f64| {
                 if x.is_nan() {
                     x
-                } else if x > 0.0 {
-                    1.0
-                } else if x < 0.0 {
-                    -1.0
-                } else {
+                } else if x == 0.0 {
                     0.0
+                } else {
+                    libm::copysign(1.0, x)
                 }
             },
         )


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR — no book change needed, this is an internal backend implementation detail with no API change and no behaviour change.

### Related Issues/PRs

Closes #5330.

The root cause is an LLVM bug, which I am fixing upstream separately. This PR does not depend on it — `burn-flex` should not have to wait for an LLVM release to build for Xtensa, and the `copysign` form is the clearer one anyway.

### Changes

`burn-flex` does not compile for `xtensa-esp32s3-none-elf` (ESP32-S3, the Espressif Rust toolchain) at `opt-level` 2 or above:

```
rustc-LLVM ERROR: Cannot select: i32 = XtensaISD::PCREL_WRAPPER
  TargetConstantPool:i32<@.LCP294_0 = internal constant [2 x float]
  [float 0.000000e+00, float -1.000000e+00]> 0
In function: burn_flex::ops::unary::unary_op::<...float_sign...>
```

The last two arms of `float_sign`'s branch chain leave a `select` between two FP constants. LLVM's `DAGCombiner::convertSelectOfFPConstantsToLoadOffset` turns that into a load from a two-element constant pool array indexed by the condition. Xtensa reads literals with `L32R`, which loads the *contents* of a PC-relative literal; there is no instruction that produces a literal's *address*, so a constant pool base plus a variable offset has no selectable form and codegen aborts.

Because `float_sign` is a trait method on the backend impl, it is codegen'd whether or not the program ever calls `sign` — so this takes down every `no_std` binary that links `burn-flex` for that target, not just ones that use `sign`.

`copysign` leaves a single scalar constant, so there is no two-element array for the combine to build:

```rust
if x.is_nan() { x } else if x == 0.0 { 0.0 } else { copysign(1.0, x) }
```

`libm` is already a `burn-flex` dependency — it is there for `erf` — so this adds nothing to the dependency graph.

**The one subtle part.** The zero branch is load bearing. `copysign(1.0, -0.0)` is `-1.0`, not `0.0`, so negative zero has to be caught before it reaches `copysign` or `sign(-0.0)` silently becomes `-1.0`. `-0.0 == 0.0` under IEEE 754, so a single `x == 0.0` covers both signed zeros, which is exactly what the previous fall-through arm did. `NaN` keeps its existing behaviour of returning the input unchanged. There is a comment above the function saying so, since this is the kind of branch a future cleanup would be tempted to remove.

Files touched:

* `crates/burn-flex/src/ops/float.rs` — `float_sign` for `f32` and `f64`
* `crates/burn-backend-tests/tests/tensor/float/ops/sign.rs` — regression test

### Testing

| Check | Result |
| --- | --- |
| Old vs new on bits, `f32`, all 2³² bit patterns | 0 mismatches |
| Old vs new on bits, `f64`, 20,000,000 random patterns + 14 edge cases | 0 mismatches |
| `sign` tests, `--features flex` | 2/2 pass |
| `sign` tests, `--features ndarray` | 2/2 pass |
| `cargo fmt --check -p burn-flex -p burn-backend-tests` | clean |
| `cargo clippy -p burn-flex --all-targets -- -D warnings` | clean |

The equivalence check compares `to_bits()` rather than values, so it covers NaN payload preservation and signed zero — the two cases a value comparison would miss. The edge cases are both zeros, both infinities, both NaN signs, the subnormal boundaries, and `MIN`/`MAX`.

New test `should_support_sign_ops_float_negative_zero` asserts `sign([-0.0, 0.0]) == [0.0, 0.0]`. The existing `sign` test covers `-0.2, -1.0, 2.0, 3.0, 0.0, -5.0` but not `-0.0` — the one case that breaks silently if the zero branch is dropped.

The test lives in the shared `burn-backend-tests` suite, so it runs against every backend. I ran it on `ndarray` as well as `flex` to confirm it does not impose a behaviour the other CPU backends do not already have. The cube/wgpu/CUDA backends I could not run locally (no GPU on this machine); those rest on CI.

Original report is from a real target: an ESP32-S3 running a `no_std` Burn model at 240 MHz.