### PR TITLE
fix(reduce): return the identity for a zero-length axis, and reject the extrema

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/float/ops/aggregation.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/aggregation.rs
@@ -644,9 +644,8 @@ fn test_should_mean_overflow_intermediate_sum() {
         .assert_approx_eq::<FloatElem>(&TensorData::from([511.5]), Tolerance::default());
 }
 
-// Reducing zero elements returns the identity of the folded operation: 0 for `sum`, 1 for
-// `prod`. Matches numpy and torch. The extrema (`max` / `min`) have no identity and are
-// covered by the `should_panic` tests in `maxmin.rs` instead.
+// Reducing zero elements returns the identity of the folded operation. The extrema have no
+// identity; those cases live in `maxmin.rs`.
 #[test]
 fn test_should_sum_empty() {
     let tensor = TestTensor::<1>::empty([0], &Default::default());
@@ -669,7 +668,6 @@ fn test_should_prod_empty() {
         .assert_eq(&TensorData::from([1.0]), false);
 }
 
-// `mean` of nothing is `0 / 0`, so `NaN` rather than an identity.
 #[test]
 fn test_should_mean_empty_is_nan() {
     let tensor = TestTensor::<1>::empty([0], &Default::default());
@@ -681,7 +679,7 @@ fn test_should_mean_empty_is_nan() {
     assert!(values[0].is_nan(), "mean of an empty tensor should be NaN");
 }
 
-// Shape [3, 0]: the reduced axis is empty but the output is not, so one identity is written
+// Shape [3, 0]: the reduced axis is empty but the output is not, so an identity has to be written
 // per surviving position. This is the case that had no viable autotune candidate.
 #[test]
 fn test_should_sum_dim_empty_axis() {
@@ -705,6 +703,17 @@ fn test_should_prod_dim_empty_axis() {
         .assert_eq(&TensorData::from([[1.0], [1.0], [1.0]]), false);
 }
 
+#[test]
+fn test_should_mean_dim_empty_axis_is_nan() {
+    let tensor = TestTensor::<2>::empty([3, 0], &Default::default());
+
+    let output = tensor.mean_dim(1).into_data();
+
+    let values = output.as_slice::<FloatElem>().unwrap();
+    assert_eq!(values.len(), 3);
+    assert!(values.iter().all(|v| v.is_nan()));
+}
+
 // Shape [0, 3]: the reduced axis is non-empty, but every output position is eliminated by the
 // zero-length outer axis, so the result is empty rather than an identity.
 #[test]
@@ -716,22 +725,9 @@ fn test_should_sum_dim_empty_tensor_non_empty_axis() {
     assert_eq!(output.dims(), [0, 1]);
 }
 
-// Shape [3, 0] reduced over every axis: `sum` folds to a single identity.
-#[test]
-fn test_should_sum_all_dims_empty_axis() {
-    let tensor = TestTensor::<2>::empty([3, 0], &Default::default());
-
-    let output = tensor.sum();
-
-    output
-        .into_data()
-        .assert_eq(&TensorData::from([0.0]), false);
-}
-
-// Shape [0, 0]: the reduced axis is empty, so `max_dim` is rejected even though the output would
-// have been empty anyway. Whether the output is empty depends on the *other* axis, so accepting
-// this while rejecting [3, 0] would make the same operation succeed or fail based on an unrelated
-// dimension. numpy raises `ValueError` and torch raises `IndexError` for both shapes.
+// Rejected even though the output would have been empty anyway: emptiness of the output depends on
+// the *other* axis, so accepting this while rejecting [3, 0] would make the same operation succeed
+// or fail based on an unrelated dimension.
 #[test]
 #[should_panic]
 fn test_should_max_dim_empty_axis_empty_output() {

--- a/crates/burn-backend-tests/tests/tensor/float/ops/aggregation.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/aggregation.rs
@@ -643,3 +643,99 @@ fn test_should_mean_overflow_intermediate_sum() {
         .into_data()
         .assert_approx_eq::<FloatElem>(&TensorData::from([511.5]), Tolerance::default());
 }
+
+// Reducing zero elements returns the identity of the folded operation: 0 for `sum`, 1 for
+// `prod`. Matches numpy and torch. The extrema (`max` / `min`) have no identity and are
+// covered by the `should_panic` tests in `maxmin.rs` instead.
+#[test]
+fn test_should_sum_empty() {
+    let tensor = TestTensor::<1>::empty([0], &Default::default());
+
+    let output = tensor.sum();
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([0.0]), false);
+}
+
+#[test]
+fn test_should_prod_empty() {
+    let tensor = TestTensor::<1>::empty([0], &Default::default());
+
+    let output = tensor.prod();
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([1.0]), false);
+}
+
+// `mean` of nothing is `0 / 0`, so `NaN` rather than an identity.
+#[test]
+fn test_should_mean_empty_is_nan() {
+    let tensor = TestTensor::<1>::empty([0], &Default::default());
+
+    let output = tensor.mean().into_data();
+
+    let values = output.as_slice::<FloatElem>().unwrap();
+    assert_eq!(values.len(), 1);
+    assert!(values[0].is_nan(), "mean of an empty tensor should be NaN");
+}
+
+// Shape [3, 0]: the reduced axis is empty but the output is not, so one identity is written
+// per surviving position. This is the case that had no viable autotune candidate.
+#[test]
+fn test_should_sum_dim_empty_axis() {
+    let tensor = TestTensor::<2>::empty([3, 0], &Default::default());
+
+    let output = tensor.sum_dim(1);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([[0.0], [0.0], [0.0]]), false);
+}
+
+#[test]
+fn test_should_prod_dim_empty_axis() {
+    let tensor = TestTensor::<2>::empty([3, 0], &Default::default());
+
+    let output = tensor.prod_dim(1);
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([[1.0], [1.0], [1.0]]), false);
+}
+
+// Shape [0, 3]: the reduced axis is non-empty, but every output position is eliminated by the
+// zero-length outer axis, so the result is empty rather than an identity.
+#[test]
+fn test_should_sum_dim_empty_tensor_non_empty_axis() {
+    let tensor = TestTensor::<2>::empty([0, 3], &Default::default());
+
+    let output = tensor.sum_dim(1);
+
+    assert_eq!(output.dims(), [0, 1]);
+}
+
+// Shape [3, 0] reduced over every axis: `sum` folds to a single identity.
+#[test]
+fn test_should_sum_all_dims_empty_axis() {
+    let tensor = TestTensor::<2>::empty([3, 0], &Default::default());
+
+    let output = tensor.sum();
+
+    output
+        .into_data()
+        .assert_eq(&TensorData::from([0.0]), false);
+}
+
+// Shape [0, 0]: the reduced axis is empty, so `max_dim` is rejected even though the output would
+// have been empty anyway. Whether the output is empty depends on the *other* axis, so accepting
+// this while rejecting [3, 0] would make the same operation succeed or fail based on an unrelated
+// dimension. numpy raises `ValueError` and torch raises `IndexError` for both shapes.
+#[test]
+#[should_panic]
+fn test_should_max_dim_empty_axis_empty_output() {
+    let tensor = TestTensor::<2>::empty([0, 0], &Default::default());
+
+    let _ = tensor.max_dim(1).into_data();
+}

--- a/crates/burn-backend-tests/tests/tensor/float/ops/all.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/all.rs
@@ -65,3 +65,30 @@ fn test_all_empty() {
         false,
     );
 }
+
+// Shape [3, 0]: the identity has to be written once per surviving position, which the whole-tensor
+// case above cannot cover.
+#[test]
+fn test_all_dim_empty_axis() {
+    let device = Default::default();
+    let expected = TensorData::from([[true], [true], [true]]);
+
+    expected.assert_eq(
+        &TestTensor::<2>::empty([3, 0], &device)
+            .all_dim(1)
+            .into_data(),
+        false,
+    );
+    expected.assert_eq(
+        &TestTensorInt::<2>::empty([3, 0], &device)
+            .all_dim(1)
+            .into_data(),
+        false,
+    );
+    expected.assert_eq(
+        &TestTensorBool::<2>::empty([3, 0], &device)
+            .all_dim(1)
+            .into_data(),
+        false,
+    );
+}

--- a/crates/burn-backend-tests/tests/tensor/float/ops/all.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/all.rs
@@ -45,3 +45,24 @@ fn test_all_dim_large() {
     let boolean = TestTensorBool::<2>::from_data(TensorData::new(mask, [rows, cols]), &device);
     expected.assert_eq(&boolean.all_dim(1).into_data(), false);
 }
+
+/// `all` folds with AND, whose identity is `true`, so an empty input is vacuously `true`.
+/// Matches numpy and torch; `any` (identity `false`) is covered in `any.rs`.
+#[test]
+fn test_all_empty() {
+    let device = Default::default();
+    let expected = TensorData::from([true]);
+
+    expected.assert_eq(
+        &TestTensor::<1>::empty([0], &device).all().into_data(),
+        false,
+    );
+    expected.assert_eq(
+        &TestTensorInt::<1>::empty([0], &device).all().into_data(),
+        false,
+    );
+    expected.assert_eq(
+        &TestTensorBool::<1>::empty([0], &device).all().into_data(),
+        false,
+    );
+}

--- a/crates/burn-backend-tests/tests/tensor/float/ops/all.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/all.rs
@@ -46,8 +46,7 @@ fn test_all_dim_large() {
     expected.assert_eq(&boolean.all_dim(1).into_data(), false);
 }
 
-/// `all` folds with AND, whose identity is `true`, so an empty input is vacuously `true`.
-/// Matches numpy and torch; `any` (identity `false`) is covered in `any.rs`.
+// Vacuously true: `all` folds with AND, whose identity is `true`.
 #[test]
 fn test_all_empty() {
     let device = Default::default();

--- a/crates/burn-backend-tests/tests/tensor/float/ops/any.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/any.rs
@@ -105,3 +105,30 @@ fn test_any_empty() {
         false,
     );
 }
+
+// Shape [3, 0]: the identity has to be written once per surviving position, which the whole-tensor
+// case above cannot cover.
+#[test]
+fn test_any_dim_empty_axis() {
+    let device = Default::default();
+    let expected = TensorData::from([[false], [false], [false]]);
+
+    expected.assert_eq(
+        &TestTensor::<2>::empty([3, 0], &device)
+            .any_dim(1)
+            .into_data(),
+        false,
+    );
+    expected.assert_eq(
+        &TestTensorInt::<2>::empty([3, 0], &device)
+            .any_dim(1)
+            .into_data(),
+        false,
+    );
+    expected.assert_eq(
+        &TestTensorBool::<2>::empty([3, 0], &device)
+            .any_dim(1)
+            .into_data(),
+        false,
+    );
+}

--- a/crates/burn-backend-tests/tests/tensor/float/ops/any.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/any.rs
@@ -85,3 +85,24 @@ fn test_any_dim_large() {
     let boolean = TestTensorBool::<2>::from_data(TensorData::new(mask, [rows, cols]), &device);
     expected.assert_eq(&boolean.any_dim(1).into_data(), false);
 }
+
+/// `any` folds with OR, whose identity is `false`, so an empty input is `false`. Unlike the
+/// numeric extrema this is well defined, and `all` (identity `true`) is covered in `all.rs`.
+#[test]
+fn test_any_empty() {
+    let device = Default::default();
+    let expected = TensorData::from([false]);
+
+    expected.assert_eq(
+        &TestTensor::<1>::empty([0], &device).any().into_data(),
+        false,
+    );
+    expected.assert_eq(
+        &TestTensorInt::<1>::empty([0], &device).any().into_data(),
+        false,
+    );
+    expected.assert_eq(
+        &TestTensorBool::<1>::empty([0], &device).any().into_data(),
+        false,
+    );
+}

--- a/crates/burn-backend-tests/tests/tensor/float/ops/any.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/any.rs
@@ -86,8 +86,7 @@ fn test_any_dim_large() {
     expected.assert_eq(&boolean.any_dim(1).into_data(), false);
 }
 
-/// `any` folds with OR, whose identity is `false`, so an empty input is `false`. Unlike the
-/// numeric extrema this is well defined, and `all` (identity `true`) is covered in `all.rs`.
+// `any` folds with OR, whose identity is `false`.
 #[test]
 fn test_any_empty() {
     let device = Default::default();

--- a/crates/burn-backend-tests/tests/tensor/float/ops/maxmin.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/maxmin.rs
@@ -300,3 +300,41 @@ fn test_max_dim_with_indices_nan_propagation() {
         .into_data()
         .assert_eq(&TensorData::from([[1]]), false);
 }
+
+// Unlike `sum` and `prod`, the extrema have no identity to return for an empty input: there is
+// no value below `i32::MIN` for an int tensor, and `argmax` would have to name an element that
+// does not exist. numpy raises `ValueError` and torch raises `IndexError` here, so burn must
+// fail rather than invent a value.
+#[test]
+#[should_panic]
+fn test_max_empty_should_panic() {
+    let tensor = TestTensor::<1>::empty([0], &Default::default());
+
+    let _ = tensor.max().into_data();
+}
+
+#[test]
+#[should_panic]
+fn test_min_empty_should_panic() {
+    let tensor = TestTensor::<1>::empty([0], &Default::default());
+
+    let _ = tensor.min().into_data();
+}
+
+// Shape [3, 0]: the reduced axis is empty while the output is not, so a value would have to be
+// invented for each of the three surviving positions.
+#[test]
+#[should_panic]
+fn test_max_dim_empty_axis_should_panic() {
+    let tensor = TestTensor::<2>::empty([3, 0], &Default::default());
+
+    let _ = tensor.max_dim(1).into_data();
+}
+
+#[test]
+#[should_panic]
+fn test_argmax_empty_axis_should_panic() {
+    let tensor = TestTensor::<2>::empty([3, 0], &Default::default());
+
+    let _ = tensor.argmax(1).into_data();
+}

--- a/crates/burn-backend-tests/tests/tensor/float/ops/maxmin.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/maxmin.rs
@@ -333,8 +333,35 @@ fn test_max_dim_empty_axis_should_panic() {
 
 #[test]
 #[should_panic]
+fn test_min_dim_empty_axis_should_panic() {
+    let tensor = TestTensor::<2>::empty([3, 0], &Default::default());
+
+    let _ = tensor.min_dim(1).into_data();
+}
+
+#[test]
+#[should_panic]
 fn test_argmax_empty_axis_should_panic() {
     let tensor = TestTensor::<2>::empty([3, 0], &Default::default());
+
+    let _ = tensor.argmax(1).into_data();
+}
+
+#[test]
+#[should_panic]
+fn test_argmin_empty_axis_should_panic() {
+    let tensor = TestTensor::<2>::empty([3, 0], &Default::default());
+
+    let _ = tensor.argmin(1).into_data();
+}
+
+// Shape [0, 0]: the output is empty too, so nothing would have to be invented — but emptiness of
+// the output depends on the *other* axis, and honouring it would make `argmax(1)` succeed here and
+// panic for [3, 0]. Rejected either way, matching numpy, torch and the cubecl backends.
+#[test]
+#[should_panic]
+fn test_argmax_empty_axis_empty_output_should_panic() {
+    let tensor = TestTensor::<2>::empty([0, 0], &Default::default());
 
     let _ = tensor.argmax(1).into_data();
 }

--- a/crates/burn-backend-tests/tests/tensor/float/ops/maxmin.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/maxmin.rs
@@ -301,10 +301,9 @@ fn test_max_dim_with_indices_nan_propagation() {
         .assert_eq(&TensorData::from([[1]]), false);
 }
 
-// Unlike `sum` and `prod`, the extrema have no identity to return for an empty input: there is
-// no value below `i32::MIN` for an int tensor, and `argmax` would have to name an element that
-// does not exist. numpy raises `ValueError` and torch raises `IndexError` here, so burn must
-// fail rather than invent a value.
+// Unlike `sum` and `prod`, the extrema have no identity to return for an empty input: there is no
+// value below `i32::MIN` for an int tensor, and `argmax` would have to name an element that does
+// not exist. numpy raises `ValueError` and torch raises `IndexError` here.
 #[test]
 #[should_panic]
 fn test_max_empty_should_panic() {
@@ -321,8 +320,6 @@ fn test_min_empty_should_panic() {
     let _ = tensor.min().into_data();
 }
 
-// Shape [3, 0]: the reduced axis is empty while the output is not, so a value would have to be
-// invented for each of the three surviving positions.
 #[test]
 #[should_panic]
 fn test_max_dim_empty_axis_should_panic() {
@@ -353,15 +350,4 @@ fn test_argmin_empty_axis_should_panic() {
     let tensor = TestTensor::<2>::empty([3, 0], &Default::default());
 
     let _ = tensor.argmin(1).into_data();
-}
-
-// Shape [0, 0]: the output is empty too, so nothing would have to be invented — but emptiness of
-// the output depends on the *other* axis, and honouring it would make `argmax(1)` succeed here and
-// panic for [3, 0]. Rejected either way, matching numpy, torch and the cubecl backends.
-#[test]
-#[should_panic]
-fn test_argmax_empty_axis_empty_output_should_panic() {
-    let tensor = TestTensor::<2>::empty([0, 0], &Default::default());
-
-    let _ = tensor.argmax(1).into_data();
 }

--- a/crates/burn-backend-tests/tests/tensor/int/ops/aggregation.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/aggregation.rs
@@ -79,3 +79,40 @@ fn test_prod_dim_int() {
         .into_data()
         .assert_eq(&TensorData::from([[0], [60]]), false);
 }
+
+// `sum` and `prod` over zero elements return their identity for ints just as for floats.
+#[test]
+fn test_should_sum_empty_int() {
+    let tensor = TestTensorInt::<1>::empty([0], &Default::default());
+
+    let output = tensor.sum();
+
+    output.into_data().assert_eq(&TensorData::from([0]), false);
+}
+
+#[test]
+fn test_should_prod_empty_int() {
+    let tensor = TestTensorInt::<1>::empty([0], &Default::default());
+
+    let output = tensor.prod();
+
+    output.into_data().assert_eq(&TensorData::from([1]), false);
+}
+
+// A float mean of nothing is `NaN`, but an integer has no such value, so the empty integer mean
+// is rejected instead of reporting whatever a division by a zero count produces.
+#[test]
+#[should_panic]
+fn test_mean_empty_int_should_panic() {
+    let tensor = TestTensorInt::<1>::empty([0], &Default::default());
+
+    let _ = tensor.mean().into_data();
+}
+
+#[test]
+#[should_panic]
+fn test_mean_dim_empty_axis_int_should_panic() {
+    let tensor = TestTensorInt::<2>::empty([3, 0], &Default::default());
+
+    let _ = tensor.mean_dim(1).into_data();
+}

--- a/crates/burn-backend-tests/tests/tensor/int/ops/aggregation.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/aggregation.rs
@@ -80,7 +80,6 @@ fn test_prod_dim_int() {
         .assert_eq(&TensorData::from([[0], [60]]), false);
 }
 
-// `sum` and `prod` over zero elements return their identity for ints just as for floats.
 #[test]
 fn test_should_sum_empty_int() {
     let tensor = TestTensorInt::<1>::empty([0], &Default::default());
@@ -99,8 +98,8 @@ fn test_should_prod_empty_int() {
     output.into_data().assert_eq(&TensorData::from([1]), false);
 }
 
-// A float mean of nothing is `NaN`, but an integer has no such value, so the empty integer mean
-// is rejected instead of reporting whatever a division by a zero count produces.
+// A float mean of nothing is `NaN`, but an integer has no such value, so this is rejected rather
+// than reporting whatever a division by a zero count produces.
 #[test]
 #[should_panic]
 fn test_mean_empty_int_should_panic() {

--- a/crates/burn-backend/src/backend/ops/int_tensor.rs
+++ b/crates/burn-backend/src/backend/ops/int_tensor.rs
@@ -909,6 +909,9 @@ pub trait IntTensorOps<B: Backend> {
     /// The mean of all elements in the tensor.
     fn int_mean(tensor: IntTensor<B>) -> IntTensor<B> {
         let num_elems = tensor.shape().num_elements() as i64;
+        // Dividing by a zero count has no integer answer, and unlike a float there is no `NaN`
+        // to fall back on, so reject it rather than return whatever the device's division gives.
+        assert!(num_elems > 0, "Cannot compute mean of empty tensor");
         B::int_div_scalar(B::int_sum(tensor), num_elems.into())
     }
 

--- a/crates/burn-backend/src/backend/ops/int_tensor.rs
+++ b/crates/burn-backend/src/backend/ops/int_tensor.rs
@@ -909,8 +909,8 @@ pub trait IntTensorOps<B: Backend> {
     /// The mean of all elements in the tensor.
     fn int_mean(tensor: IntTensor<B>) -> IntTensor<B> {
         let num_elems = tensor.shape().num_elements() as i64;
-        // Dividing by a zero count has no integer answer, and unlike a float there is no `NaN`
-        // to fall back on, so reject it rather than return whatever the device's division gives.
+        // Unlike a float there is no `NaN` to fall back on, so reject rather than return whatever
+        // the device's division by zero gives.
         assert!(num_elems > 0, "Cannot compute mean of empty tensor");
         B::int_div_scalar(B::int_sum(tensor), num_elems.into())
     }

--- a/crates/burn-backend/src/backend/ops/int_tensor.rs
+++ b/crates/burn-backend/src/backend/ops/int_tensor.rs
@@ -909,9 +909,6 @@ pub trait IntTensorOps<B: Backend> {
     /// The mean of all elements in the tensor.
     fn int_mean(tensor: IntTensor<B>) -> IntTensor<B> {
         let num_elems = tensor.shape().num_elements() as i64;
-        // Unlike a float there is no `NaN` to fall back on, so reject rather than return whatever
-        // the device's division by zero gives.
-        assert!(num_elems > 0, "Cannot compute mean of empty tensor");
         B::int_div_scalar(B::int_sum(tensor), num_elems.into())
     }
 

--- a/crates/burn-cubecl/src/kernel/reduce/base.rs
+++ b/crates/burn-cubecl/src/kernel/reduce/base.rs
@@ -30,19 +30,12 @@ pub struct SumAutotuneKey {
     length: usize,
 }
 
-/// The value a reduction over zero elements must produce, if one exists.
+/// The value a reduction over zero elements must produce, or `None` if there is none.
 ///
-/// A reduction folds a binary operation along the axis, so reducing zero elements yields that
-/// operation's identity: `Sum` and `Any` fold with `+` / `OR` (identity `0`), `Prod` and `All`
-/// with `*` / `AND` (identity `1`). `Mean` divides a zero sum by a zero count, which is `NaN` -
-/// the same answer numpy and torch give.
-///
-/// The extrema return `None`, meaning "no defined result". `Max` / `Min` / `TopK` have no
-/// identity in a bounded numeric type (there is no integer below `i32::MIN`), an `Arg*` would
-/// have to name an element that does not exist, and `MaxAbs` is an extremum too. numpy raises
-/// `ValueError` and torch raises `IndexError` for all of these, so reporting an error rather
-/// than inventing a value keeps burn consistent with both, and with the CPU backends, which
-/// already reject an empty `max` / `min`.
+/// Reducing zero elements yields the folded operation's identity. The extrema have no identity in
+/// a bounded numeric type (there is no integer below `i32::MIN`) and an `Arg*` would have to name
+/// an element that does not exist, so they return `None`: numpy raises `ValueError` and torch
+/// raises `IndexError` for all of them, as do burn's CPU backends for an empty `max`/`min`.
 fn empty_reduce_identity(config: ReduceOperationConfig, dtype: DType) -> Option<f64> {
     match config {
         ReduceOperationConfig::Sum | ReduceOperationConfig::Any => Some(0.0),
@@ -61,14 +54,12 @@ fn empty_reduce_identity(config: ReduceOperationConfig, dtype: DType) -> Option<
 
 /// Fill `output` with the identity of `config`, or report that `config` has none.
 ///
-/// The reduce kernels require at least one element along the reduced axis (cubek's
-/// `validate_shapes` rejects a zero-length axis with [`ReduceError::ReduceAxisTooSmall`]), so a
-/// zero-length axis never reaches a kernel and the identity is written directly instead.
+/// Written directly rather than launched as a kernel because cubek's `validate_shapes` rejects a
+/// zero-length axis with [`ReduceError::ReduceAxisTooSmall`], so no kernel can run.
 ///
-/// An operation with no identity is rejected even when `output` is itself empty. Emptiness of
-/// the output depends on the *other* axes, so allowing it would make `max` over a zero-length
-/// axis succeed for shape `[0, 0]` and fail for `[3, 0]` - and numpy, torch and the CPU
-/// backends all reject both.
+/// An operation with no identity is rejected even when `output` is itself empty: emptiness of the
+/// output depends on the *other* axes, so allowing it would make `max` succeed for shape `[0, 0]`
+/// and fail for `[3, 0]`.
 fn reduce_empty_axis<Run: CubeRuntime>(
     output: CubeTensor<Run>,
     axis_length: usize,
@@ -128,8 +119,7 @@ pub fn sum<Run: CubeRuntime>(
     let client = tensor.client.clone();
     let device = tensor.device.clone();
 
-    // No element to sum: the result is the additive identity, and no strategy can launch a
-    // kernel over an empty input.
+    // No strategy can launch a kernel over an empty input, so write the additive identity.
     if tensor.meta.num_elements() == 0 {
         return Ok(zeros_client(client, device, [1].into(), tensor.dtype));
     }
@@ -296,9 +286,7 @@ pub fn reduce_dim<Run: CubeRuntime>(
         },
     )?;
 
-    // A zero-length reduced axis has nothing to fold, so write the identity into `output`
-    // instead of launching a kernel. `output` already carries the right shape, with `dim` set
-    // to `accumulator_len`.
+    // `output` already carries the right shape here, with `dim` set to `accumulator_len`.
     let axis_length = input.meta.shape[dim];
     if axis_length == 0 {
         return reduce_empty_axis::<Run>(output, axis_length, config);
@@ -404,10 +392,9 @@ pub fn reduce_dim_with_indices<Run: CubeRuntime>(
     let indices = init_reduce_output_dtype::<Run>(&input, dim, indices_dtype, out_len)
         .ok_or_else(invalid_axis)?;
 
-    // Every `config` reaching this point is `Max`, `Min` or `TopK`: an empty axis leaves each of
-    // them with no value to report and no index to name, so it is always rejected - including
-    // when the outputs are themselves empty, which depends on the other axes rather than on this
-    // one.
+    // Every `config` reaching this point is an extremum, so an empty axis leaves it with no value
+    // to report and no index to name. Always rejected, including when the outputs are themselves
+    // empty — see `reduce_empty_axis`.
     if input.meta.shape[dim] == 0 {
         return Err(ReduceError::ReduceAxisTooSmall {
             axis_length: 0,

--- a/crates/burn-cubecl/src/kernel/reduce/base.rs
+++ b/crates/burn-cubecl/src/kernel/reduce/base.rs
@@ -2,7 +2,7 @@
 use super::{autotune_reduce, autotune_reduce_with_indices, autotune_sum};
 use crate::{
     CubeRuntime,
-    ops::numeric::{empty_device_contiguous_dtype, full_device_dtype, zeros_client},
+    ops::numeric::{empty_device_contiguous_dtype, fill_device_dtype, zeros_client},
     tensor::CubeTensor,
 };
 use burn_backend::cubecl::{dtype_to_elem_type, dtype_to_storage_type, elem_type_to_dtype};
@@ -54,8 +54,8 @@ fn empty_reduce_identity(config: ReduceOperationConfig, dtype: DType) -> Option<
 
 /// Fill `output` with the identity of `config`, or report that `config` has none.
 ///
-/// Written directly rather than launched as a kernel because cubek's `validate_shapes` rejects a
-/// zero-length axis with [`ReduceError::ReduceAxisTooSmall`], so no kernel can run.
+/// Filled directly rather than by a reduce kernel because cubek's `validate_shapes` rejects a
+/// zero-length axis with [`ReduceError::ReduceAxisTooSmall`], so no reduction can run.
 ///
 /// An operation with no identity is rejected even when `output` is itself empty: emptiness of the
 /// output depends on the *other* axes, so allowing it would make `max` succeed for shape `[0, 0]`
@@ -75,13 +75,9 @@ fn reduce_empty_axis<Run: CubeRuntime>(
         return Ok(output);
     }
 
-    Ok(full_device_dtype(
-        output.client.clone(),
-        output.shape(),
-        output.device.clone(),
-        InputScalar::new(identity, dtype_to_storage_type(output.dtype)),
-        output.dtype,
-    ))
+    let identity = InputScalar::new(identity, dtype_to_storage_type(output.dtype));
+
+    Ok(fill_device_dtype(output, identity))
 }
 
 /// Check if the client supports atomic add for the given element type.
@@ -394,7 +390,7 @@ pub fn reduce_dim_with_indices<Run: CubeRuntime>(
 
     // Every `config` reaching this point is an extremum, so an empty axis leaves it with no value
     // to report and no index to name. Always rejected, including when the outputs are themselves
-    // empty — see `reduce_empty_axis`.
+    // empty - see `reduce_empty_axis`.
     if input.meta.shape[dim] == 0 {
         return Err(ReduceError::ReduceAxisTooSmall {
             axis_length: 0,

--- a/crates/burn-cubecl/src/kernel/reduce/base.rs
+++ b/crates/burn-cubecl/src/kernel/reduce/base.rs
@@ -2,13 +2,15 @@
 use super::{autotune_reduce, autotune_reduce_with_indices, autotune_sum};
 use crate::{
     CubeRuntime,
-    ops::numeric::{empty_device_contiguous_dtype, zeros_client},
+    ops::numeric::{empty_device_contiguous_dtype, full_device_dtype, zeros_client},
     tensor::CubeTensor,
 };
-use burn_backend::cubecl::{dtype_to_elem_type, elem_type_to_dtype};
+use burn_backend::cubecl::{dtype_to_elem_type, dtype_to_storage_type, elem_type_to_dtype};
 use burn_backend::{DType, TensorMetadata};
 use burn_std::{BoolDType, Metadata};
-use cubecl::{AutotuneKey, client::ComputeClient, features::AtomicUsage, ir::Type};
+use cubecl::{
+    AutotuneKey, client::ComputeClient, features::AtomicUsage, ir::Type, prelude::InputScalar,
+};
 use cubek::reduce::{
     ReduceDtypes, ReduceError, ReduceStrategy, ReduceWithIndicesDtypes,
     components::instructions::ReduceOperationConfig,
@@ -26,6 +28,69 @@ pub struct SumAutotuneKey {
     /// The anchored length of the tensor
     #[autotune(anchor)]
     length: usize,
+}
+
+/// The value a reduction over zero elements must produce, if one exists.
+///
+/// A reduction folds a binary operation along the axis, so reducing zero elements yields that
+/// operation's identity: `Sum` and `Any` fold with `+` / `OR` (identity `0`), `Prod` and `All`
+/// with `*` / `AND` (identity `1`). `Mean` divides a zero sum by a zero count, which is `NaN` -
+/// the same answer numpy and torch give.
+///
+/// The extrema return `None`, meaning "no defined result". `Max` / `Min` / `TopK` have no
+/// identity in a bounded numeric type (there is no integer below `i32::MIN`), an `Arg*` would
+/// have to name an element that does not exist, and `MaxAbs` is an extremum too. numpy raises
+/// `ValueError` and torch raises `IndexError` for all of these, so reporting an error rather
+/// than inventing a value keeps burn consistent with both, and with the CPU backends, which
+/// already reject an empty `max` / `min`.
+fn empty_reduce_identity(config: ReduceOperationConfig, dtype: DType) -> Option<f64> {
+    match config {
+        ReduceOperationConfig::Sum | ReduceOperationConfig::Any => Some(0.0),
+        ReduceOperationConfig::Prod | ReduceOperationConfig::All => Some(1.0),
+        // Only floats can carry `NaN`; an integer mean of nothing has no representable value.
+        ReduceOperationConfig::Mean => dtype.is_float().then_some(f64::NAN),
+        ReduceOperationConfig::Max
+        | ReduceOperationConfig::Min
+        | ReduceOperationConfig::MaxAbs
+        | ReduceOperationConfig::TopK(_)
+        | ReduceOperationConfig::ArgMax
+        | ReduceOperationConfig::ArgMin
+        | ReduceOperationConfig::ArgTopK(_) => None,
+    }
+}
+
+/// Fill `output` with the identity of `config`, or report that `config` has none.
+///
+/// The reduce kernels require at least one element along the reduced axis (cubek's
+/// `validate_shapes` rejects a zero-length axis with [`ReduceError::ReduceAxisTooSmall`]), so a
+/// zero-length axis never reaches a kernel and the identity is written directly instead.
+///
+/// An operation with no identity is rejected even when `output` is itself empty. Emptiness of
+/// the output depends on the *other* axes, so allowing it would make `max` over a zero-length
+/// axis succeed for shape `[0, 0]` and fail for `[3, 0]` - and numpy, torch and the CPU
+/// backends all reject both.
+fn reduce_empty_axis<Run: CubeRuntime>(
+    output: CubeTensor<Run>,
+    axis_length: usize,
+    config: ReduceOperationConfig,
+) -> Result<CubeTensor<Run>, ReduceError> {
+    let identity =
+        empty_reduce_identity(config, output.dtype).ok_or(ReduceError::ReduceAxisTooSmall {
+            axis_length,
+            k: accumulator_len(config),
+        })?;
+
+    if output.meta.num_elements() == 0 {
+        return Ok(output);
+    }
+
+    Ok(full_device_dtype(
+        output.client.clone(),
+        output.shape(),
+        output.device.clone(),
+        InputScalar::new(identity, dtype_to_storage_type(output.dtype)),
+        output.dtype,
+    ))
 }
 
 /// Check if the client supports atomic add for the given element type.
@@ -62,6 +127,12 @@ pub fn sum<Run: CubeRuntime>(
 ) -> Result<CubeTensor<Run>, ReduceError> {
     let client = tensor.client.clone();
     let device = tensor.device.clone();
+
+    // No element to sum: the result is the additive identity, and no strategy can launch a
+    // kernel over an empty input.
+    if tensor.meta.num_elements() == 0 {
+        return Ok(zeros_client(client, device, [1].into(), tensor.dtype));
+    }
 
     match strategy {
         SumStrategy::OneShot(cube_count) => {
@@ -225,6 +296,14 @@ pub fn reduce_dim<Run: CubeRuntime>(
         },
     )?;
 
+    // A zero-length reduced axis has nothing to fold, so write the identity into `output`
+    // instead of launching a kernel. `output` already carries the right shape, with `dim` set
+    // to `accumulator_len`.
+    let axis_length = input.meta.shape[dim];
+    if axis_length == 0 {
+        return reduce_empty_axis::<Run>(output, axis_length, config);
+    }
+
     let result = match strategy {
         KernelReduceStrategy::Unspecified => cubek::reduce::reduce::<Run>(
             &client,
@@ -324,6 +403,17 @@ pub fn reduce_dim_with_indices<Run: CubeRuntime>(
     .ok_or_else(invalid_axis)?;
     let indices = init_reduce_output_dtype::<Run>(&input, dim, indices_dtype, out_len)
         .ok_or_else(invalid_axis)?;
+
+    // Every `config` reaching this point is `Max`, `Min` or `TopK`: an empty axis leaves each of
+    // them with no value to report and no index to name, so it is always rejected - including
+    // when the outputs are themselves empty, which depends on the other axes rather than on this
+    // one.
+    if input.meta.shape[dim] == 0 {
+        return Err(ReduceError::ReduceAxisTooSmall {
+            axis_length: 0,
+            k: out_len,
+        });
+    }
 
     let client = input.client.clone();
 

--- a/crates/burn-cubecl/src/ops/numeric.rs
+++ b/crates/burn-cubecl/src/ops/numeric.rs
@@ -57,6 +57,14 @@ pub fn full_device_dtype<R: CubeRuntime>(
 ) -> CubeTensor<R> {
     let empty = empty_device_dtype(client, device, shape, dtype);
 
+    fill_device_dtype(empty, value)
+}
+
+/// Fills an existing tensor with `value`
+pub(crate) fn fill_device_dtype<R: CubeRuntime>(
+    tensor: CubeTensor<R>,
+    value: InputScalar,
+) -> CubeTensor<R> {
     #[cube(launch_unchecked, address_type = "dynamic")]
     pub fn full_kernel<C: Numeric, N: Size>(
         mut tensor: LinearViewMut<'_, Vector<C, N>>,
@@ -70,27 +78,27 @@ pub fn full_device_dtype<R: CubeRuntime>(
         tensor.write(ABSOLUTE_POS, Vector::new(value.get::<C>()));
     }
 
-    let num_elems = empty.meta.num_elements();
-    let vector_size = max_vector_size(&empty);
+    let num_elems = tensor.meta.num_elements();
+    let vector_size = max_vector_size(&tensor);
 
     let working_units = num_elems / vector_size as usize;
-    let cube_dim = CubeDim::new(&empty.client, working_units);
-    let cube_count = calculate_cube_count_elemwise(&empty.client, working_units, cube_dim);
+    let cube_dim = CubeDim::new(&tensor.client, working_units);
+    let cube_count = calculate_cube_count_elemwise(&tensor.client, working_units, cube_dim);
 
     unsafe {
         full_kernel::launch_unchecked(
-            &empty.client,
+            &tensor.client,
             cube_count,
             cube_dim,
-            address_type!(empty),
+            address_type!(tensor),
             vector_size,
-            empty.clone().into_linear_view(),
+            tensor.clone().into_linear_view(),
             value,
-            dtype_to_storage_type(empty.dtype),
+            dtype_to_storage_type(tensor.dtype),
         );
     }
 
-    empty
+    tensor
 }
 
 /// Creates a tensor filled with zeros

--- a/crates/burn-flex/src/ops/reduce.rs
+++ b/crates/burn-flex/src/ops/reduce.rs
@@ -630,6 +630,10 @@ fn min_impl<E: Element + bytemuck::Pod + PartialOrd>(tensor: &FlexTensor) -> Fle
 
 /// Argmax along a dimension, returning indices as isize (INDEX_DTYPE).
 pub fn argmax(tensor: FlexTensor, dim: usize) -> FlexTensor {
+    assert!(
+        tensor.layout().shape()[dim] > 0,
+        "argmax: dimension {dim} has size 0"
+    );
     assert_dim_fits_isize(tensor.layout().shape()[dim], dim);
     // f32 last-dim fast path: 2-pass SIMD for large rows, 1-pass scalar for small rows
     if tensor.dtype() == DType::F32 && dim == tensor.layout().shape().num_dims() - 1 {
@@ -682,6 +686,10 @@ pub fn argmax(tensor: FlexTensor, dim: usize) -> FlexTensor {
 
 /// Argmin along a dimension, returning indices as isize (INDEX_DTYPE).
 pub fn argmin(tensor: FlexTensor, dim: usize) -> FlexTensor {
+    assert!(
+        tensor.layout().shape()[dim] > 0,
+        "argmin: dimension {dim} has size 0"
+    );
     assert_dim_fits_isize(tensor.layout().shape()[dim], dim);
     // f32 last-dim fast path: 2-pass SIMD for large rows, 1-pass scalar for small rows
     if tensor.dtype() == DType::F32 && dim == tensor.layout().shape().num_dims() - 1 {

--- a/crates/burn-flex/src/ops/reduce.rs
+++ b/crates/burn-flex/src/ops/reduce.rs
@@ -277,11 +277,14 @@ pub fn sum_dim(tensor: FlexTensor, dim: usize) -> FlexTensor {
 /// Mean along a dimension, keeping the dimension with size 1.
 pub fn mean_dim(tensor: FlexTensor, dim: usize) -> FlexTensor {
     let dim_size = tensor.layout().shape()[dim];
-    assert!(
-        dim_size > 0,
-        "mean_dim: cannot take mean of empty dimension"
-    );
     let dtype = tensor.dtype();
+    // Floats divide by a zero `dim_size` to `NaN`, which is what `mean()` already returns for an
+    // empty input and what the other backends return here. Only the integer arms below have no
+    // such value, so only they are rejected.
+    assert!(
+        dim_size > 0 || dtype.is_float(),
+        "mean_dim: cannot take mean of an empty dimension for the integer type {dtype:?}"
+    );
 
     // Half-precision types fuse sum+divide in f32 to avoid overflow when the
     // intermediate sum exceeds f16::MAX, so they don't go through sum_dim.
@@ -423,8 +426,8 @@ pub fn prod_dim(tensor: FlexTensor, dim: usize) -> FlexTensor {
 
 /// Max of all elements, returning a scalar tensor of shape \[1\].
 pub fn max(tensor: FlexTensor) -> FlexTensor {
-    // Asserted here rather than per dtype: the half paths seed the fold with an infinity, so
-    // without this they would report that seed as the max of nothing instead of failing.
+    // Asserted here rather than per dtype: every path seeds the fold with an infinity, so without
+    // this they report that seed as the max of nothing instead of failing.
     assert!(
         tensor.layout().shape().num_elements() > 0,
         "max: cannot reduce an empty tensor"
@@ -1400,10 +1403,6 @@ where
     );
 
     let dim_size = shape[dim];
-    assert!(
-        dim_size > 0,
-        "mean_dim: cannot take mean of empty dimension"
-    );
     let mut out_shape: Vec<usize> = shape.to_vec();
     out_shape[dim] = 1;
 

--- a/crates/burn-flex/src/ops/reduce.rs
+++ b/crates/burn-flex/src/ops/reduce.rs
@@ -423,6 +423,12 @@ pub fn prod_dim(tensor: FlexTensor, dim: usize) -> FlexTensor {
 
 /// Max of all elements, returning a scalar tensor of shape \[1\].
 pub fn max(tensor: FlexTensor) -> FlexTensor {
+    // Asserted here rather than per dtype: the half paths seed the fold with an infinity, so
+    // without this they would report that seed as the max of nothing instead of failing.
+    assert!(
+        tensor.layout().shape().num_elements() > 0,
+        "max: cannot reduce an empty tensor"
+    );
     match tensor.dtype() {
         DType::F32 => max_f32_reduce(&tensor),
         DType::F64 => max_impl::<f64>(&tensor),
@@ -454,6 +460,10 @@ pub fn max(tensor: FlexTensor) -> FlexTensor {
 
 /// Min of all elements, returning a scalar tensor of shape \[1\].
 pub fn min(tensor: FlexTensor) -> FlexTensor {
+    assert!(
+        tensor.layout().shape().num_elements() > 0,
+        "min: cannot reduce an empty tensor"
+    );
     match tensor.dtype() {
         DType::F32 => min_f32_reduce(&tensor),
         DType::F64 => min_impl::<f64>(&tensor),

--- a/crates/burn-ndarray/src/ops/base.rs
+++ b/crates/burn-ndarray/src/ops/base.rs
@@ -787,6 +787,19 @@ where
     (lhs_broadcast, rhs_broadcast)
 }
 
+/// The mean of zero elements, which is `0 / 0`.
+///
+/// Floats represent that as `NaN`, matching numpy and torch. Integers have no such value, so an
+/// integer mean of nothing is rejected rather than silently reported as some other number.
+pub(crate) fn empty_mean<E: NdArrayElement>() -> E {
+    assert!(
+        E::dtype().is_float(),
+        "Cannot compute mean of empty tensor for the integer type {:?}",
+        E::dtype()
+    );
+    0.elem::<E>() / 0.elem::<E>()
+}
+
 impl<E> NdArrayMathOps<E>
 where
     E: Copy + NdArrayElement,
@@ -931,7 +944,10 @@ where
 
     /// Mean of all elements - zero-copy for borrowed storage.
     pub fn mean_view(view: ArrayView<'_, E, IxDyn>) -> SharedArray<E> {
-        let mean = view.mean().unwrap();
+        // `ndarray::mean` returns `None` for an empty view. The mean of nothing is `0 / 0`, which
+        // is `NaN` for a float (as numpy and torch report) but has no integer value, so an
+        // integer mean of nothing is rejected the same way an empty `max` is.
+        let mean = view.mean().unwrap_or_else(empty_mean);
         ArrayD::from_elem(IxDyn(&[1]), mean).into_shared()
     }
 
@@ -1662,6 +1678,14 @@ fn arg_view<E: NdArrayElement + PartialOrd, I: NdArrayElement + PartialOrd>(
     dim: usize,
     cmp: CmpType,
 ) -> SharedArray<I> {
+    // There is no element to name along an empty axis. Checked before `map_axis`, which skips the
+    // closure entirely when another axis is also zero-length and would otherwise let that case
+    // through while `[3, 0]` panics on `arr[0]`.
+    assert!(
+        view.shape()[dim] > 0,
+        "Cannot compute arg over an empty axis"
+    );
+
     let mut reshape = view.shape().to_vec();
     reshape[dim] = 1;
 

--- a/crates/burn-ndarray/src/ops/base.rs
+++ b/crates/burn-ndarray/src/ops/base.rs
@@ -789,8 +789,8 @@ where
 
 /// The mean of zero elements, which is `0 / 0`.
 ///
-/// Floats represent that as `NaN`, matching numpy and torch. Integers have no such value, so an
-/// integer mean of nothing is rejected rather than silently reported as some other number.
+/// `NaN` for a float, matching numpy and torch. Integers have no such value, so an integer mean of
+/// nothing is rejected rather than silently reported as some other number.
 pub(crate) fn empty_mean<E: NdArrayElement>() -> E {
     assert!(
         E::dtype().is_float(),
@@ -944,9 +944,7 @@ where
 
     /// Mean of all elements - zero-copy for borrowed storage.
     pub fn mean_view(view: ArrayView<'_, E, IxDyn>) -> SharedArray<E> {
-        // `ndarray::mean` returns `None` for an empty view. The mean of nothing is `0 / 0`, which
-        // is `NaN` for a float (as numpy and torch report) but has no integer value, so an
-        // integer mean of nothing is rejected the same way an empty `max` is.
+        // `ndarray::mean` returns `None` for an empty view.
         let mean = view.mean().unwrap_or_else(empty_mean);
         ArrayD::from_elem(IxDyn(&[1]), mean).into_shared()
     }
@@ -1678,9 +1676,8 @@ fn arg_view<E: NdArrayElement + PartialOrd, I: NdArrayElement + PartialOrd>(
     dim: usize,
     cmp: CmpType,
 ) -> SharedArray<I> {
-    // There is no element to name along an empty axis. Checked before `map_axis`, which skips the
-    // closure entirely when another axis is also zero-length and would otherwise let that case
-    // through while `[3, 0]` panics on `arr[0]`.
+    // Checked before `map_axis`, which skips its closure entirely when another axis is also
+    // zero-length and would otherwise let `[0, 0]` through while `[3, 0]` panics on `arr[0]`.
     assert!(
         view.shape()[dim] > 0,
         "Cannot compute arg over an empty axis"

--- a/crates/burn-ndarray/src/ops/macros.rs
+++ b/crates/burn-ndarray/src/ops/macros.rs
@@ -41,8 +41,8 @@ use ndarray::{Axis, Zip};
 use crate::{SharedArray, element::NdArrayElement, ops::base::empty_mean};
 
 pub(crate) fn mean_dim<E: NdArrayElement>(tensor: SharedArray<E>, dim: usize) -> SharedArray<E> {
-    // `mean_axis` returns `None` when the reduced axis is empty. Each output element is then the
-    // mean of nothing, so fill with that instead of panicking on the `None`.
+    // `mean_axis` returns `None` when the reduced axis is empty; `fold_axis` still yields one
+    // element per surviving position, which `mean_axis` cannot.
     match tensor.mean_axis(Axis(dim)) {
         Some(mean) => mean.into_shared(),
         None => tensor

--- a/crates/burn-ndarray/src/ops/macros.rs
+++ b/crates/burn-ndarray/src/ops/macros.rs
@@ -38,10 +38,17 @@ use burn_backend::ElementConversion;
 pub(crate) use keepdim;
 use ndarray::{Axis, Zip};
 
-use crate::{SharedArray, element::NdArrayElement};
+use crate::{SharedArray, element::NdArrayElement, ops::base::empty_mean};
 
 pub(crate) fn mean_dim<E: NdArrayElement>(tensor: SharedArray<E>, dim: usize) -> SharedArray<E> {
-    tensor.mean_axis(Axis(dim)).unwrap().into_shared()
+    // `mean_axis` returns `None` when the reduced axis is empty. Each output element is then the
+    // mean of nothing, so fill with that instead of panicking on the `None`.
+    match tensor.mean_axis(Axis(dim)) {
+        Some(mean) => mean.into_shared(),
+        None => tensor
+            .fold_axis(Axis(dim), empty_mean(), |acc, _| *acc)
+            .into_shared(),
+    }
 }
 
 pub(crate) fn sum_dim<E: NdArrayElement>(tensor: SharedArray<E>, dim: usize) -> SharedArray<E> {

--- a/crates/burn-tensor/src/bridge/ops/int.rs
+++ b/crates/burn-tensor/src/bridge/ops/int.rs
@@ -287,9 +287,19 @@ impl Numeric for Int {
     }
 
     fn mean(tensor: BridgeTensor) -> BridgeTensor {
+        // A float mean of nothing is `NaN`; an integer has no such value. Checked here rather than
+        // in `int_mean` so a backend that overrides it cannot report an arbitrary number instead.
+        assert!(
+            tensor.shape().num_elements() > 0,
+            "Cannot compute mean of an empty int tensor"
+        );
         BridgeTensor::int(Dispatch::int_mean(tensor.into()))
     }
     fn mean_dim(tensor: BridgeTensor, dim: usize) -> BridgeTensor {
+        assert!(
+            tensor.shape()[dim] > 0,
+            "Cannot compute mean of an empty axis for an int tensor"
+        );
         BridgeTensor::int(Dispatch::int_mean_dim(tensor.into(), dim))
     }
     fn cumsum(tensor: BridgeTensor, dim: usize) -> BridgeTensor {


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Fixes #5293. Contributes to #5310.

Overlaps #5313 (open), which fixes the burn-cubecl half. It fills the type's min/max for an empty
`max`/`min` and NaN for `mean` on every dtype; this PR errors on the extrema and keeps NaN to floats,
since `i32::MIN` is a value the tensor never held and an integer `mean` has no NaN. numpy and torch raise
on both. Happy to defer and rebase if #5313 lands first.

### Changes

Reducing over a zero-length axis panicked on the cubecl backends: `validate_shapes` rejects an empty
reduced axis, so every autotune candidate failed and the panic came out of plan selection.

Folding zero elements yields the operation's identity: `Sum`/`Any` -> 0, `Prod`/`All` -> 1, `Mean` -> NaN
for floats, as in numpy and torch, so those are written straight to the output. The extrema have no
identity in a bounded type and now return `ReduceError`. 

The shared tests then failed on the CPU backends for four pre-existing reasons:

- burn-flex `max`/`min` returned the `±inf` fold seed as the extremum of nothing.
- burn-flex `argmax`/`argmin` indexed `row[0]`: `index out of bounds`.
- burn-flex `mean_dim` rejected an empty axis for every dtype; now integers only, so a float
  `mean_dim` gives NaN like `mean()` and like the other backends. Behaviour change on that path.
- burn-ndarray `arg_view` accepted `[0, 0]` but panicked on `[3, 0]`

### Testing

`cargo run-checks`: exit 0, 0 failures. It needs `--ignore-typos` for a typo in
`burn-core/src/module/param/base.rs:330`, untouched here and failing on `main` too.

20 empty-input cases added to the shared suite (sum, prod, mean, max, min, argmax, argmin, all, any) over
`[0]`, `[3, 0]`, `[0, 3]` and `[0, 0]`. The case #5310 was filed about now passes:

    cargo test --release -p burn-backend-tests --no-default-features \
        --features metal,std,autotune --test autodiff -- mask_select

    main:  The input reduce axis length (currently 0) should be at least k (1)
    here:  8 passed; 0 failed

Full `--test tensor` suites: flex 1738 passed, ndarray 1753 passed, metal `--release` 1527 passed. The
only metal failures are `quantization::accuracy` cases, which fail on unmodified `main` too and vary run
to run.

---
AI assistance was used in developing this change: investigation, validation, additional testing