### PR TITLE
fix(burn-cubecl): broadcast a size-1 dim against a zero-sized dim

### DIFF
--- a/crates/burn-backend-tests/tests/cubecl/broadcast.rs
+++ b/crates/burn-backend-tests/tests/cubecl/broadcast.rs
@@ -1,0 +1,72 @@
+use super::*;
+use burn_tensor::Shape;
+
+// A size-1 dimension broadcasts to the other operand's size, including 0. Regression for #5334,
+// where broadcast_shape used the per-dimension maximum and turned a 0 into 1, panicking in debug
+// and reading out of bounds in release.
+
+#[test]
+fn broadcast_add_zero_against_one_trailing() {
+    let device = Default::default();
+    let a = TestTensor::<2>::zeros([2, 0], &device);
+    let b = TestTensor::<2>::zeros([2, 1], &device);
+    let out = a + b;
+    assert_eq!(out.shape(), Shape::new([2, 0]));
+    // Materialize to exercise the kernel launch and read-back on the empty result.
+    let _ = out.into_data();
+}
+
+#[test]
+fn broadcast_add_one_against_zero_trailing() {
+    let device = Default::default();
+    let a = TestTensor::<2>::zeros([2, 1], &device);
+    let b = TestTensor::<2>::zeros([2, 0], &device);
+    assert_eq!((a + b).shape(), Shape::new([2, 0]));
+}
+
+#[test]
+fn broadcast_add_zero_against_one_leading() {
+    let device = Default::default();
+    let a = TestTensor::<2>::zeros([0, 3], &device);
+    let b = TestTensor::<2>::zeros([1, 3], &device);
+    assert_eq!((a + b).shape(), Shape::new([0, 3]));
+}
+
+#[test]
+fn broadcast_add_zero_against_zero() {
+    let device = Default::default();
+    let a = TestTensor::<2>::zeros([2, 0], &device);
+    let b = TestTensor::<2>::zeros([2, 0], &device);
+    assert_eq!((a + b).shape(), Shape::new([2, 0]));
+}
+
+#[test]
+fn broadcast_comparison_zero_against_one() {
+    let device = Default::default();
+    let a = TestTensor::<2>::zeros([2, 0], &device);
+    let b = TestTensor::<2>::zeros([2, 1], &device);
+    assert_eq!(a.greater(b).shape(), Shape::new([2, 0]));
+}
+
+#[test]
+fn broadcast_mask_where_zero_against_one() {
+    let device = Default::default();
+    let input = TestTensor::<2>::zeros([2, 0], &device);
+    let mask = TestTensorBool::<2>::from_data([[true], [false]], &device);
+    let value = TestTensor::<2>::zeros([2, 1], &device);
+    assert_eq!(input.mask_where(mask, value).shape(), Shape::new([2, 0]));
+}
+
+// Ordinary broadcasting (1 -> N) must still produce the right shape and values.
+#[test]
+fn broadcast_add_regular_unchanged() {
+    let device = Default::default();
+    let a = TestTensor::<2>::from_data([[1.0], [2.0]], &device);
+    let b = TestTensor::<2>::from_data([[10.0, 20.0, 30.0], [40.0, 50.0, 60.0]], &device);
+    let out = a + b;
+    assert_eq!(out.shape(), Shape::new([2, 3]));
+    out.into_data().assert_eq(
+        &TestTensor::<2>::from_data([[11.0, 21.0, 31.0], [42.0, 52.0, 62.0]], &device).into_data(),
+        false,
+    );
+}

--- a/crates/burn-backend-tests/tests/cubecl/mod.rs
+++ b/crates/burn-backend-tests/tests/cubecl/mod.rs
@@ -2,6 +2,7 @@ pub use super::*;
 
 mod avg_pool2d;
 mod bernoulli;
+mod broadcast;
 mod cast;
 mod cat;
 mod clamp;

--- a/crates/burn-cubecl/src/kernel/binary.rs
+++ b/crates/burn-cubecl/src/kernel/binary.rs
@@ -234,6 +234,12 @@ pub(crate) fn launch_binop<R: CubeRuntime, O: BinaryOpFamily>(
     let shape_out = broadcast_shape(&[&lhs, &rhs]);
     let dtype = lhs.dtype;
 
+    // A zero-sized broadcast output has no elements to compute, and the in-place/kernel paths
+    // below assume a non-empty output. Return the empty output directly.
+    if shape_out.num_elements() == 0 {
+        return empty_device_dtype(lhs.client.clone(), lhs.device.clone(), shape_out, dtype);
+    }
+
     let client = lhs.client.clone();
     let num_elems = shape_out.num_elements();
     let working_units = num_elems / vector_size as usize;

--- a/crates/burn-cubecl/src/kernel/binary_float.rs
+++ b/crates/burn-cubecl/src/kernel/binary_float.rs
@@ -61,6 +61,12 @@ pub(crate) fn launch_binop_float<R: CubeRuntime, O: BinaryOpFloatFamily>(
     let shape_out = broadcast_shape(&[&lhs, &rhs]);
     let dtype = lhs.dtype;
 
+    // A zero-sized broadcast output has no elements to compute, and the in-place/kernel paths
+    // below assume a non-empty output. Return the empty output directly.
+    if shape_out.num_elements() == 0 {
+        return empty_device_dtype(lhs.client.clone(), lhs.device.clone(), shape_out, dtype);
+    }
+
     let client = lhs.client.clone();
     let num_elems = shape_out.num_elements();
     let working_units = num_elems / vector_size as usize;

--- a/crates/burn-cubecl/src/kernel/binary_int.rs
+++ b/crates/burn-cubecl/src/kernel/binary_int.rs
@@ -127,6 +127,12 @@ pub(crate) fn launch_binop_int<R: CubeRuntime, O: BinaryOpIntFamily>(
 
     let shape_out = broadcast_shape(&[&lhs, &rhs]);
 
+    // A zero-sized broadcast output has no elements to compute, and the in-place/kernel paths
+    // below assume a non-empty output. Return the empty output directly.
+    if shape_out.num_elements() == 0 {
+        return empty_device_dtype(lhs.client.clone(), lhs.device.clone(), shape_out, lhs.dtype);
+    }
+
     let client = lhs.client.clone();
     let num_elems = shape_out.num_elements();
 

--- a/crates/burn-cubecl/src/kernel/comparison.rs
+++ b/crates/burn-cubecl/src/kernel/comparison.rs
@@ -136,6 +136,18 @@ pub(crate) fn launch_cmp<R: CubeRuntime, O: ComparisonOpFamily>(
 
     let shape_out = broadcast_shape(&[&lhs, &rhs]);
     let client = lhs.client.clone();
+
+    // A zero-sized broadcast output has no elements to compute, and the in-place/kernel paths
+    // below assume a non-empty output. Return the empty output directly.
+    if shape_out.num_elements() == 0 {
+        return empty_device_dtype(
+            lhs.client.clone(),
+            lhs.device.clone(),
+            shape_out,
+            dtype_bool,
+        );
+    }
+
     let num_elems = shape_out.num_elements();
 
     let working_units = num_elems / vector_size as usize;

--- a/crates/burn-cubecl/src/kernel/cross.rs
+++ b/crates/burn-cubecl/src/kernel/cross.rs
@@ -77,6 +77,16 @@ pub(crate) fn cross<R: CubeRuntime>(
 
     let output_shape = broadcast_shape(&[&lhs, &rhs]);
 
+    // A zero-sized broadcast output has no elements to compute. Return the empty output directly.
+    if output_shape.num_elements() == 0 {
+        return empty_device_dtype(
+            lhs.client.clone(),
+            lhs.device.clone(),
+            output_shape,
+            lhs.dtype,
+        );
+    }
+
     let output = empty_device_dtype(
         lhs.client.clone(),
         lhs.device.clone(),

--- a/crates/burn-cubecl/src/kernel/mask/mask_where.rs
+++ b/crates/burn-cubecl/src/kernel/mask/mask_where.rs
@@ -67,6 +67,17 @@ pub fn mask_where<R: CubeRuntime>(
 
     let out_shape = broadcast_shape(&[&input, &mask, &value]);
 
+    // A zero-sized broadcast output has no elements to compute, and the strategies below assume a
+    // non-empty output. Return the empty output directly.
+    if out_shape.num_elements() == 0 {
+        return empty_device_dtype(
+            input.client.clone(),
+            input.device.clone(),
+            out_shape,
+            input.dtype,
+        );
+    }
+
     let output = match strategy {
         MaskWhereStrategy::Readonly => empty_device_dtype(
             input.client.clone(),

--- a/crates/burn-cubecl/src/kernel/utils.rs
+++ b/crates/burn-cubecl/src/kernel/utils.rs
@@ -51,15 +51,21 @@ pub fn broadcast_shape<R: CubeRuntime>(tensors: &[&CubeTensor<R>]) -> Shape {
     );
 
     let dims = (0..rank).map(|dim| {
-        let max = tensors.iter().map(|it| it.meta.shape()[dim]).max();
-        let max = max.unwrap_or(1);
-        debug_assert!(
-            tensors
-                .iter()
-                .all(|it| it.meta.shape()[dim] == max || it.meta.shape()[dim] == 1),
-            "Broadcast dims must be size 1"
-        );
-        max
+        // Broadcasting stretches a size-1 dim to the other operand's size, which may be 0.
+        // Every size that is not 1 must agree, and that shared size (0 included) is the result.
+        // Taking the max would be wrong when a 0 meets a 1: max picks 1 and drops the 0.
+        let mut broadcast = 1;
+        for tensor in tensors {
+            let size = tensor.meta.shape()[dim];
+            if size != 1 {
+                debug_assert!(
+                    broadcast == 1 || broadcast == size,
+                    "Broadcast dims must match or be 1"
+                );
+                broadcast = size;
+            }
+        }
+        broadcast
     });
 
     Shape::from(dims)


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Fixes #5334.

### Changes

`broadcast_shape` computed each output dimension as the maximum size across the operands. Broadcasting instead stretches a size-1 dimension to the other operand's size, which may be 0, and `max(0, 1)` is 1, not 0. A broadcast involving a zero-sized dimension therefore produced the wrong output shape. In debug this tripped the shape assert. In release the assert is compiled out, so the op returned a wrong-shaped result and, through the `can_mut_broadcast` in-place path, indexed out of bounds (SIGSEGV).

- `broadcast_shape` (`kernel/utils.rs`): compute the result as the shared size that is not 1 (0 included) rather than the maximum.
- Each broadcast launcher (`binary`, `binary_float`, `binary_int`, `comparison`, `cross`, `mask_where`): in a valid broadcast a zero-sized dimension always yields an empty output, which has nothing to compute. Return the empty output directly, before the in-place and kernel paths that assume a non-empty output. This also sidesteps `can_mut_broadcast` and the layout code, which are not zero-aware either.

Reproducible directly on `main`, with no dependency on other changes:

```rust
let a = Tensor::<B, 2>::zeros([2, 0], &device);
let b = Tensor::<B, 2>::zeros([2, 1], &device);
let _ = (a + b).into_data();
// debug: panics in kernel/utils.rs. release: wrong shape and out-of-bounds read.
```

### Testing

New `tests/cubecl/broadcast.rs`: broadcasting a zero-sized dimension against a size-1 dimension for `add` (trailing, leading, both zero), `comparison`, and `mask_where` (three operands), plus a regular `1 -> N` broadcast checked by value to guard against regressions.

- 7/7 pass on the cpu backend in both debug and release, so the release out-of-bounds path is exercised.
- Full cubecl test suite: 199 passed, 0 failed. `cargo fmt --check` and `cargo clippy -p burn-cubecl` are clean.
- `cargo run-checks` passes with `--ignore-typos`. The only failure without the flag is a pre-existing typo in `burn-core/src/module/param/base.rs:330`, untouched here and failing on `main` too.
