### PR TITLE
fix(tensor): preserve autodiff device for non-float tensors

### DIFF
--- a/crates/burn-backend-tests/tests/autodiff/bridge.rs
+++ b/crates/burn-backend-tests/tests/autodiff/bridge.rs
@@ -37,5 +37,6 @@ fn one_hot_preserves_autodiff_device() {
     let loss = (logits.clone() * one_hot).sum();
     let grads = loss.backward();
 
-    assert!(logits.grad(&grads).is_some());
+    let logits_grad = logits.grad(&grads).expect("logits should have gradients");
+    assert!(!logits_grad.device().is_autodiff());
 }

--- a/crates/burn-backend-tests/tests/autodiff/bridge.rs
+++ b/crates/burn-backend-tests/tests/autodiff/bridge.rs
@@ -23,3 +23,19 @@ fn test_full_precision() {
     assert!(x1_grad.is_some());
     assert!(x2_grad.is_some());
 }
+
+#[test]
+fn one_hot_preserves_autodiff_device() {
+    let device = AutodiffDevice::new();
+    let targets = TestTensorInt::<1>::from_data([0, 1], &device);
+    assert!(targets.device().is_autodiff());
+    let one_hot = targets.one_hot::<2>(2).float();
+
+    assert!(one_hot.device().is_autodiff());
+
+    let logits = TestTensor::<2>::ones([2, 2], &device).require_grad();
+    let loss = (logits.clone() * one_hot).sum();
+    let grads = loss.backward();
+
+    assert!(logits.grad(&grads).is_some());
+}

--- a/crates/burn-dispatch/src/tensor.rs
+++ b/crates/burn-dispatch/src/tensor.rs
@@ -413,10 +413,13 @@ impl TensorMetadata for DispatchTensor {
 
         #[cfg(feature = "autodiff")]
         if let Some(checkpointing) = &self.checkpointing {
-            // Non-float tensors travel beside the tape untracked, but their device
-            // must retain the autodiff capability so tensors derived from them can
-            // join the graph (for example, an integer one-hot tensor cast to float).
-            if !matches!(device, DispatchDevice::Autodiff(_)) {
+            // Int, bool, and quantized tensors travel beside the tape untracked, but
+            // their device must retain the autodiff capability so tensors derived
+            // from them can join the graph (for example, an integer one-hot tensor
+            // cast to float). Plain float gradients can also carry checkpointing
+            // metadata copied from their source tensor, but remain on the inner
+            // backend and must continue to report that device.
+            if !self.dtype().is_float() && !matches!(device, DispatchDevice::Autodiff(_)) {
                 device = DispatchDevice::autodiff(device);
             }
             if let DispatchDevice::Autodiff(device) = &mut device {

--- a/crates/burn-dispatch/src/tensor.rs
+++ b/crates/burn-dispatch/src/tensor.rs
@@ -411,19 +411,12 @@ impl TensorMetadata for DispatchTensor {
         #[allow(unused_mut)]
         let mut device = self.kind.device();
 
-        // TODO: should int and bool kinds return an autodiff device?
-        // It would be much easier once there is a single underlying primitive type, which
-        // we can wrap with Autodiff in all cases.
-
         #[cfg(feature = "autodiff")]
         if let Some(checkpointing) = &self.checkpointing {
-            // A packed (quantized) tensor is float-kind data that travels beside
-            // the tape untracked, so its device is the autodiff one: whatever is
-            // built from it — its dequantized form, LoRA factors over it — must
-            // land on the tape.
-            if matches!(self.dtype(), DType::QFloat(_))
-                && !matches!(device, DispatchDevice::Autodiff(_))
-            {
+            // Non-float tensors travel beside the tape untracked, but their device
+            // must retain the autodiff capability so tensors derived from them can
+            // join the graph (for example, an integer one-hot tensor cast to float).
+            if !matches!(device, DispatchDevice::Autodiff(_)) {
                 device = DispatchDevice::autodiff(device);
             }
             if let DispatchDevice::Autodiff(device) = &mut device {


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Fixes #5337.

### Changes

`DispatchTensor::device` only reconstructed an autodiff device for quantized float tensors. Integer labels still reported the inner backend device, so operations such as `one_hot(...).float()` left the autodiff backend and could not be combined with logits on the tape.

Preserve the autodiff capability whenever checkpointing metadata is present, including for integer and boolean tensors. The regression test covers both regular and checkpointing autodiff backends and verifies that gradients still reach the logits after multiplying by one-hot labels.

### Testing

- `cargo test -p burn-backend-tests --test autodiff --no-default-features --features std,ndarray bridge:: -- --nocapture` (4 passed)
- `cargo fmt --all -- --check`
- `cargo clippy -p burn-dispatch --no-default-features --features std,autodiff,ndarray -- -D warnings`
