### PR TITLE
Deprecate burn-ndarray backend

### DIFF
--- a/burn-book/src/building-blocks/backend.md
+++ b/burn-book/src/building-blocks/backend.md
@@ -34,7 +34,7 @@ and `cuda` features make `Device::wgpu` and `Device::cuda` available.
 | `Device::rocm(0)`                          | ROCm/HIP GPU at index 0            |
 | `Device::cpu()`                            | CubeCL CPU backend                 |
 | `Device::flex()`                           | Flex CPU backend                   |
-| `Device::ndarray()`                        | NdArray CPU backend                |
+| `Device::ndarray()`                        | NdArray CPU backend (deprecated)   |
 | `Device::libtorch()`                       | LibTorch CPU backend               |
 | `Device::libtorch_cuda(0)`                 | LibTorch CUDA GPU at index 0       |
 | `Device::libtorch_mps()`                   | LibTorch Metal Performance Shaders |

--- a/crates/burn-backend-tests/tests/cubecl.rs
+++ b/crates/burn-backend-tests/tests/cubecl.rs
@@ -13,6 +13,10 @@ mod cube {
         pub struct ReferenceDevice;
 
         impl ReferenceDevice {
+            // NdArray stays the reference implementation while it is deprecated: its
+            // `export_tests` feature widens the accepted quantization schemes (Q4/Q2) so it can
+            // serve as a value-equality reference, which no other CPU backend currently does.
+            #[allow(deprecated)]
             pub fn new() -> burn_tensor::Device {
                 burn_ndarray::NdArrayDevice::Cpu.into()
             }

--- a/crates/burn-dispatch/src/lib.rs
+++ b/crates/burn-dispatch/src/lib.rs
@@ -2,6 +2,14 @@
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![recursion_limit = "138"]
+// Wiring up the deprecated `NdArray` backend is this crate's job, and the backend registry macros
+// expand it into every dispatch impl, so the warnings land on `macros.rs` rather than on any site
+// we could annotate individually. `allow(deprecated)` is a lint level scoped to this crate, and
+// lint levels never propagate to dependents, so downstream code naming `NdArray` (directly or via
+// our re-export) still gets the warning. The `cfg_attr` keeps this confined to the ndarray-enabled
+// build: `ndarray` is not a default feature, so the default build that CI lints with
+// `--deny warnings` retains full deprecation signal for every other dependency.
+#![cfg_attr(feature = "ndarray", allow(deprecated))]
 
 //! Burn multi-backend dispatch.
 //!
@@ -18,7 +26,7 @@
 //! | `Vulkan`   | `vulkan`   | Vulkan backend via `wgpu` (SPIR-V) |
 //! | `Wgpu`     | `webgpu`   | WebGPU backend via `wgpu` (WGSL) |
 //! | `Flex`     | `flex`     | Pure Rust CPU backend using `burn-flex` |
-//! | `NdArray`  | `ndarray`  | Pure Rust CPU backend using `ndarray` (legacy - prefer `flex`) |
+//! | `NdArray`  | `ndarray`  | Pure Rust CPU backend using `ndarray` (deprecated - use `flex`) |
 //! | `LibTorch` | `tch`      | Libtorch backend via `tch` |
 //! | `Autodiff` | `autodiff` | Autodiff-enabled backend (used in combination with any of the backends above) |
 //!

--- a/crates/burn-ndarray/Cargo.toml
+++ b/crates/burn-ndarray/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["nathanielsimard <nathaniel.simard.42@gmail.com>"]
 categories = ["science", "no-std", "embedded", "wasm"]
-description = "Ndarray backend for the Burn framework"
+description = "[Deprecated] Ndarray backend for the Burn framework - use burn-flex, burn-cuda, burn-rocm, or burn-wgpu instead"
 documentation = "https://docs.rs/burn-ndarray"
 edition.workspace = true
 keywords = ["deep-learning", "machine-learning", "data"]

--- a/crates/burn-ndarray/README.md
+++ b/crates/burn-ndarray/README.md
@@ -5,10 +5,15 @@
 [![Current Crates.io Version](https://img.shields.io/crates/v/burn-ndarray.svg)](https://crates.io/crates/burn-ndarray)
 [![license](https://shields.io/badge/license-MIT%2FApache--2.0-blue)](https://github.com/tracel-ai/burn-ndarray/blob/master/README.md)
 
-> **New projects should use [`burn-flex`](https://crates.io/crates/burn-flex).** It is a
-> from-scratch pure-Rust CPU backend that replaces `burn-ndarray` with faster gemm, zero-copy view
-> operations, native quantization, and full support for `std`, `no_std`, and WebAssembly. See
-> [`burn-flex/COMPARISON.md`](../burn-flex/COMPARISON.md) for a migration path and
+> **Deprecated:** This crate is deprecated as of `0.22.0` and will be removed in a future release.
+> Please migrate to one of the actively maintained backends:
+>
+> - **[`burn-flex`](https://crates.io/crates/burn-flex)** for portable pure-Rust CPU execution. It is
+>   a from-scratch backend that replaces `burn-ndarray` with faster gemm, zero-copy view operations,
+>   native quantization, and full support for `std`, `no_std`, and WebAssembly.
+> - **CubeCL backends** (CUDA, ROCm, Vulkan, Metal, WebGPU) for GPU acceleration.
+>
+> See [`burn-flex/COMPARISON.md`](../burn-flex/COMPARISON.md) for a migration path and
 > operation-by-operation benchmarks.
 
 ## Feature Flags

--- a/crates/burn-ndarray/src/lib.rs
+++ b/crates/burn-ndarray/src/lib.rs
@@ -1,8 +1,20 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![deprecated(
+    since = "0.22.0",
+    note = "burn-ndarray is deprecated and will be removed in a future release. Use burn-flex for pure-Rust CPU execution (std, no_std, WebAssembly), or one of the CubeCL backends (burn-cuda, burn-rocm, burn-wgpu, burn-cpu) for GPU acceleration."
+)]
 
 //! Burn ndarray backend.
+//!
+//! **Deprecated:** This backend is deprecated and will be removed in a future release.
+//! Please migrate to one of the actively maintained backends:
+//! - Flex (`burn-flex`) for portable pure-Rust CPU execution (std, no_std, WASM)
+//! - CubeCL backends (CUDA, ROCm, Vulkan, Metal, WebGPU) for GPU acceleration
+//!
+//! See [COMPARISON.md](https://github.com/tracel-ai/burn/blob/main/crates/burn-flex/COMPARISON.md)
+//! for an operation-by-operation migration path.
 
 #[cfg(any(
     feature = "blas-netlib",

--- a/crates/burn-store/benches/unified_loading.rs
+++ b/crates/burn-store/benches/unified_loading.rs
@@ -294,7 +294,7 @@ macro_rules! bench_backend {
 }
 
 // Generate benchmarks for each backend
-bench_backend!(Device::flex(), ndarray_backend, "NdArray Backend (CPU)");
+bench_backend!(Device::flex(), flex_backend, "Flex Backend (CPU)");
 
 #[cfg(feature = "wgpu")]
 bench_backend!(

--- a/crates/burn-store/benches/unified_saving.rs
+++ b/crates/burn-store/benches/unified_saving.rs
@@ -148,7 +148,7 @@ macro_rules! bench_backend {
 }
 
 // Generate benchmarks for each backend
-bench_backend!(Device::flex(), ndarray_backend, "NdArray Backend (CPU)");
+bench_backend!(Device::flex(), flex_backend, "Flex Backend (CPU)");
 
 #[cfg(feature = "wgpu")]
 bench_backend!(

--- a/crates/burn-store/benches/zero_copy_loading.rs
+++ b/crates/burn-store/benches/zero_copy_loading.rs
@@ -456,7 +456,7 @@ mod store_only {
 // =============================================================================
 
 // Generate benchmarks for each backend
-bench_backend!(Device::flex(), ndarray_backend, "NdArray Backend (CPU)");
+bench_backend!(Device::flex(), flex_backend, "Flex Backend (CPU)");
 
 #[cfg(feature = "wgpu")]
 bench_backend!(

--- a/crates/burn-tensor/src/device.rs
+++ b/crates/burn-tensor/src/device.rs
@@ -306,6 +306,11 @@ impl Device {
 
     /// Default NdArray (CPU) device.
     #[cfg(feature = "ndarray")]
+    #[deprecated(
+        since = "0.22.0",
+        note = "burn-ndarray is deprecated and will be removed in a future release. Use `Device::flex()` for pure-Rust CPU execution instead."
+    )]
+    #[allow(deprecated)] // constructing the deprecated device is this constructor's job
     pub fn ndarray() -> Self {
         Self::new(burn_dispatch::devices::NdArrayDevice::default())
     }

--- a/crates/burn/src/lib.rs
+++ b/crates/burn/src/lib.rs
@@ -99,7 +99,7 @@
 //!   - `candle`: Makes available the Candle backend
 //!   - `tch`: Makes available the LibTorch backend
 //!   - `flex`: Makes available the Flex backend (pure-Rust CPU, std/no_std/WASM)
-//!   - `ndarray`: Makes available the NdArray backend (legacy - prefer `flex` for new projects)
+//!   - `ndarray`: Makes available the NdArray backend (deprecated - use `flex` instead)
 //! - Backend specifications
 //!   - `accelerate`: If supported, Accelerate will be used
 //!   - `blas-netlib`: If supported, Blas Netlib will be use

--- a/crates/burn/tests/backend_extension_runtime.rs
+++ b/crates/burn/tests/backend_extension_runtime.rs
@@ -5,6 +5,12 @@
 //! These actually run the generated dispatch glue end to end: the runtime backend-selection walk,
 //! the tensor-less enum variant panic, and enum-variant-dependent unwrapping.
 #![cfg(feature = "ndarray")]
+// `multi_backend_autodiff` needs two concrete backends compiled in at once to prove the dispatch
+// walk inspects the backend inside `DispatchTensorKind::Autodiff` rather than letting the first
+// generated arm capture everything. This suite still pairs NdArray with Flex (the latter coming
+// from the default features); `Cpu` + Flex would work without a GPU or libtorch too, so this
+// should move to that pair before burn-ndarray is removed.
+#![allow(deprecated)]
 
 use burn::backend::{Dispatch, ExtensionType, NdArray, backend_extension, tensor::FloatTensor};
 use burn::tensor::{Device, Tensor};


### PR DESCRIPTION
Marks `burn-ndarray` as deprecated without changing what is built or tested. The
crate stays published and supported for the duration of the deprecation window,
so its test matrix, CI jobs, and no_std builds are untouched.

- `#![deprecated]` on the crate root, with migration notes in the crate docs, the
  README, and the crates.io description
- `#[deprecated]` on `Device::ndarray()`
- `ndarray` marked deprecated in the `burn` feature list, the `burn-dispatch`
  backend table, and the book's device table
- `burn-dispatch` takes a cfg'd `allow(deprecated)`: the backend registry macros
  expand `NdArray` into every dispatch impl, so the warnings land on the macro
  definition rather than on any site that could be annotated individually. Lint
  levels do not propagate to dependents, so downstream code naming `NdArray` still
  warns
- `burn-backend-tests` keeps NdArray as the CubeCL reference backend, with a scoped
  allow recording why (its `export_tests` feature widens the accepted quantization
  schemes so it can act as a value-equality reference)

Also renames the `burn-store` CPU bench label from NdArray to Flex, where the label
named a backend the benchmark had not used since it switched to `Device::flex()`.

Users should migrate to `burn-flex`, or to a CubeCL backend (`burn-cuda`,
`burn-rocm`, `burn-wgpu`, `burn-cpu`) for GPU acceleration.
