### PR TITLE
fix(ndarray): avoid invalidating in-flight handles in UnsafeSharedRef

### DIFF
--- a/crates/burn-ndarray/src/ops/adaptive_avgpool.rs
+++ b/crates/burn-ndarray/src/ops/adaptive_avgpool.rs
@@ -25,7 +25,7 @@ pub(crate) fn adaptive_avg_pool2d<E: FloatNdArrayElement>(
             let b = k / channels;
             let c = k % channels;
 
-            let output = unsafe_shared_out.get();
+            let mut output = unsafe_shared_out.get();
             for h in 0..output_size[0] {
                 for w in 0..output_size[1] {
                     let ih_start = start_index(h, output_size[0], input_height);
@@ -67,7 +67,7 @@ pub(crate) fn adaptive_avg_pool2d_backward<E: FloatNdArrayElement>(
             let b = k / channels;
             let c = k % channels;
 
-            let output_grad = unsafe_shared_out.get();
+            let mut output_grad = unsafe_shared_out.get();
             for oh in 0..output_height {
                 for ow in 0..output_width {
                     let ih_start = start_index(oh, output_height, input_height);
@@ -115,7 +115,7 @@ pub(crate) fn adaptive_avg_pool3d<E: FloatNdArrayElement>(
             let b = k / channels;
             let c = k % channels;
 
-            let output = unsafe_shared_out.get();
+            let mut output = unsafe_shared_out.get();
             for d in 0..output_size[0] {
                 for h in 0..output_size[1] {
                     for w in 0..output_size[2] {
@@ -174,7 +174,7 @@ pub(crate) fn adaptive_avg_pool3d_backward<E: FloatNdArrayElement>(
             let b = k / channels;
             let c = k % channels;
 
-            let output_grad = unsafe_shared_out.get();
+            let mut output_grad = unsafe_shared_out.get();
             for od in 0..output_depth {
                 for oh in 0..output_height {
                     for ow in 0..output_width {

--- a/crates/burn-ndarray/src/ops/avgpool.rs
+++ b/crates/burn-ndarray/src/ops/avgpool.rs
@@ -48,7 +48,7 @@ pub(crate) fn avg_pool2d<E: FloatNdArrayElement>(
             let b = k / channels;
             let c = k % channels;
 
-            let output = unsafe_shared_out.get();
+            let mut output = unsafe_shared_out.get();
 
             for oh in 0..out_height {
                 for ow in 0..out_width {
@@ -125,7 +125,7 @@ pub(crate) fn avg_pool2d_backward<E: FloatNdArrayElement>(
             let b = k / channels;
             let c = k % channels;
 
-            let output_grad = unsafe_shared_grad.get();
+            let mut output_grad = unsafe_shared_grad.get();
 
             for oh in 0..out_height {
                 for ow in 0..out_width {

--- a/crates/burn-ndarray/src/ops/conv.rs
+++ b/crates/burn-ndarray/src/ops/conv.rs
@@ -267,7 +267,7 @@ pub(crate) fn conv_transpose2d<E: NdArrayElement>(
             let oc = k % out_channels;
             let g = (k / out_channels) % options.groups;
 
-            let output = unsafe_shared_out.get();
+            let mut output = unsafe_shared_out.get();
 
             let oc_out = oc + (out_channels * g);
             let ic_start = g * (in_channels / options.groups);
@@ -517,7 +517,7 @@ pub(crate) fn conv_transpose3d<E: NdArrayElement>(
             let oc = k % out_channels;
             let g = (k / out_channels) % options.groups;
 
-            let output = unsafe_shared_out.get();
+            let mut output = unsafe_shared_out.get();
 
             let oc_out = oc + (out_channels * g);
             let ic_start = g * (in_channels / options.groups);

--- a/crates/burn-ndarray/src/ops/grid_sample.rs
+++ b/crates/burn-ndarray/src/ops/grid_sample.rs
@@ -87,7 +87,7 @@ pub(crate) fn grid_sample_2d<E: FloatNdArrayElement>(
                 bilinear_interpolate(&tensor, b, c, px, py, width_in, height_in, pad_mode, align);
 
             unsafe {
-                let output = unsafe_shared_out.get();
+                let mut output = unsafe_shared_out.get();
                 output[(b, c, y, x)] = val.elem();
             }
         });

--- a/crates/burn-ndarray/src/ops/interpolate.rs
+++ b/crates/burn-ndarray/src/ops/interpolate.rs
@@ -41,7 +41,7 @@ pub(crate) fn nearest_interpolate<E: FloatNdArrayElement>(
             let x_in = (x_ratio * w as f64).floor() as usize;
 
             unsafe {
-                let output = unsafe_shared_out.get();
+                let mut output = unsafe_shared_out.get();
                 output[(b, c, h, w)] = x[(b, c, y_in, x_in)];
             }
         });
@@ -67,7 +67,7 @@ pub(crate) fn nearest_interpolate_backward<E: FloatNdArrayElement>(
             let b = k / channels;
             let c = k % channels;
 
-            let output_grad = unsafe_shared_out.get();
+            let mut output_grad = unsafe_shared_out.get();
 
             for oh in 0..output_height {
                 for ow in 0..output_width {
@@ -137,7 +137,7 @@ pub(crate) fn bilinear_interpolate<E: FloatNdArrayElement>(
                 bilinear_interpolate_single(&x, b, c, x_frac, y_frac, in_width - 1, in_height - 1);
 
             unsafe {
-                let output = unsafe_shared_out.get();
+                let mut output = unsafe_shared_out.get();
                 output[(b, c, h, w)] = val.elem();
             }
         });
@@ -248,7 +248,7 @@ pub(crate) fn bicubic_interpolate<E: FloatNdArrayElement>(
             .elem();
 
             unsafe {
-                let output = unsafe_shared_out.get();
+                let mut output = unsafe_shared_out.get();
                 output[(b, c, h, w)] = result;
             }
         });
@@ -343,7 +343,7 @@ pub(crate) fn lanczos3_interpolate<E: FloatNdArrayElement>(
             }
 
             unsafe {
-                let output = unsafe_shared_out.get();
+                let mut output = unsafe_shared_out.get();
                 output[(b, c, h, w)] = result.elem();
             }
         });

--- a/crates/burn-ndarray/src/ops/matmul.rs
+++ b/crates/burn-ndarray/src/ops/matmul.rs
@@ -49,9 +49,8 @@ pub(crate) fn matmul<E: NdArrayElement>(
             let rhs_slice = rhs_array.slice(s!(r_batch, .., ..));
 
             unsafe {
-                let mut out_slice = unsafe_shared_out_array
-                    .get()
-                    .slice_mut(s!(out_batch, .., ..));
+                let mut out_array = unsafe_shared_out_array.get();
+                let mut out_slice = out_array.slice_mut(s!(out_batch, .., ..));
 
                 ndarray::linalg::general_mat_mul(
                     alpha,

--- a/crates/burn-ndarray/src/ops/maxpool.rs
+++ b/crates/burn-ndarray/src/ops/maxpool.rs
@@ -69,7 +69,7 @@ pub(crate) fn max_pool2d<E: FloatNdArrayElement>(
             let b = k / channels;
             let c = k % channels;
 
-            let output = unsafe_shared_out.get();
+            let mut output = unsafe_shared_out.get();
 
             for oh in 0..out_height {
                 for ow in 0..out_width {
@@ -157,8 +157,8 @@ pub(crate) fn max_pool2d_with_indices<E: FloatNdArrayElement, I: IntNdArrayEleme
             let b = k / channels;
             let c = k % channels;
 
-            let output = unsafe_shared_out.get();
-            let indices = unsafe_shared_indices.get();
+            let mut output = unsafe_shared_out.get();
+            let mut indices = unsafe_shared_indices.get();
 
             for oh in 0..out_height {
                 for ow in 0..out_width {
@@ -227,7 +227,7 @@ pub(crate) fn max_pool2d_backward<E: FloatNdArrayElement, I: IntNdArrayElement>(
             let b = k / channels;
             let c = k % channels;
 
-            let output = unsafe_shared_out.get();
+            let mut output = unsafe_shared_out.get();
 
             for h in 0..height {
                 for w in 0..width {

--- a/crates/burn-ndarray/src/ops/simd/avgpool.rs
+++ b/crates/burn-ndarray/src/ops/simd/avgpool.rs
@@ -106,7 +106,7 @@ mod nhwc {
                 let block = k % blocks;
                 let b = k / blocks;
 
-                let output = unsafe_shared_out.get();
+                let mut output = unsafe_shared_out.get();
 
                 let x = x.slice(s![b, .., .., ..]);
                 let out = output.slice_mut(s![b, .., .., ..]);
@@ -118,7 +118,7 @@ mod nhwc {
                 let ch = (k % num_simd_unblocked) * lanes + blocks_end;
                 let b = k / num_simd_unblocked;
 
-                let output = unsafe_shared_out.get();
+                let mut output = unsafe_shared_out.get();
 
                 let x = x.slice(s![b, .., .., ..]);
                 let out = output.slice_mut(s![b, .., .., ..]);
@@ -130,7 +130,7 @@ mod nhwc {
                 let ch = (k % remainder) + simd_end;
                 let b = k / remainder;
 
-                let output = unsafe_shared_out.get();
+                let mut output = unsafe_shared_out.get();
 
                 let x = x.slice(s![b, .., .., ..]);
                 let out = output.slice_mut(s![b, .., .., ..]);

--- a/crates/burn-ndarray/src/ops/simd/conv.rs
+++ b/crates/burn-ndarray/src/ops/simd/conv.rs
@@ -100,7 +100,7 @@ fn conv2d<E: VMulAdd + Element, T: Element>(
             let b = k / oc_blocks;
             let ob = k % oc_blocks;
             let x = x.slice(s![b, .., .., ..]);
-            let out = unsafe_shared_out.get();
+            let mut out = unsafe_shared_out.get();
             let mut out = out.slice_mut(s![b, .., .., ..]);
             let w = weights.view();
 

--- a/crates/burn-ndarray/src/ops/simd/maxpool.rs
+++ b/crates/burn-ndarray/src/ops/simd/maxpool.rs
@@ -122,7 +122,7 @@ mod nhwc {
                 let block = k % blocks;
                 let b = k / blocks;
 
-                let output = unsafe_shared_out.get();
+                let mut output = unsafe_shared_out.get();
                 let x = x.slice(s![b, .., .., ..]);
                 let out = output.slice_mut(s![b, .., .., ..]);
                 loop_blocked(x, out, kernel_size, stride, padding, dilation, block);
@@ -132,7 +132,7 @@ mod nhwc {
                 let ch = (k % simd_unblocked) * lanes + blocks_end;
                 let b = k / simd_unblocked;
 
-                let output = unsafe_shared_out.get();
+                let mut output = unsafe_shared_out.get();
                 let x = x.slice(s![b, .., .., ..]);
                 let out = output.slice_mut(s![b, .., .., ..]);
                 loop_unblocked(x, out, kernel_size, stride, padding, dilation, ch);
@@ -142,7 +142,7 @@ mod nhwc {
                 let ch = (k % remainder) + simd_end;
                 let b = k / remainder;
 
-                let output = unsafe_shared_out.get();
+                let mut output = unsafe_shared_out.get();
                 let x = x.slice(s![b, .., .., ..]);
                 let out = output.slice_mut(s![b, .., .., ..]);
                 loop_scalar(x, out, kernel_size, stride, padding, dilation, ch);

--- a/crates/burn-ndarray/src/sharing.rs
+++ b/crates/burn-ndarray/src/sharing.rs
@@ -10,7 +10,7 @@ pub(crate) struct UnsafeSharedRef<'a, A, D> {
     _marker: PhantomData<&'a mut A>,
 }
 
-unsafe impl<A, D> Sync for UnsafeSharedRef<'_, A, D> {}
+unsafe impl<A: Send, D: Sync> Sync for UnsafeSharedRef<'_, A, D> {}
 
 impl<'a, A, D: Dimension> UnsafeSharedRef<'a, A, D> {
     pub fn new<S: RawDataMut<Elem = A>>(data: &'a mut ArrayBase<S, D>) -> Self {
@@ -22,7 +22,8 @@ impl<'a, A, D: Dimension> UnsafeSharedRef<'a, A, D> {
 
     /// # Safety
     ///
-    /// Elements written through the returned view must not be written through any other handle.
+    /// Every element accessed through the returned view must be disjoint from every element
+    /// accessed through any other live view returned by `get`.
     pub unsafe fn get(&self) -> ArrayViewMut<'a, A, D> {
         unsafe { self.view.clone().deref_into_view_mut() }
     }

--- a/crates/burn-ndarray/src/sharing.rs
+++ b/crates/burn-ndarray/src/sharing.rs
@@ -1,19 +1,51 @@
-use core::cell::UnsafeCell;
+use core::marker::PhantomData;
+use ndarray::{ArrayBase, ArrayViewMut, Dimension, RawArrayViewMut, RawDataMut};
 
-/// Similar to `SyncUnsafeCell` see [Rust issues](https://github.com/rust-lang/rust/issues/95439).
-pub(crate) struct UnsafeSharedRef<'a, T> {
-    cell: UnsafeCell<&'a mut T>,
+/// Gives parallel tasks mutable access to disjoint elements of the same array.
+///
+/// Stores a raw view rather than a `&mut`, because handing out a `&mut` retags it as unique and so
+/// invalidates every handle already in flight; only the most recent one would stay usable.
+pub(crate) struct UnsafeSharedRef<'a, A, D> {
+    view: RawArrayViewMut<A, D>,
+    _marker: PhantomData<&'a mut A>,
 }
 
-unsafe impl<T> Sync for UnsafeSharedRef<'_, T> {}
+unsafe impl<A, D> Sync for UnsafeSharedRef<'_, A, D> {}
 
-impl<'a, T> UnsafeSharedRef<'a, T> {
-    pub fn new(data: &'a mut T) -> Self {
+impl<'a, A, D: Dimension> UnsafeSharedRef<'a, A, D> {
+    pub fn new<S: RawDataMut<Elem = A>>(data: &'a mut ArrayBase<S, D>) -> Self {
         Self {
-            cell: UnsafeCell::new(data),
+            view: data.raw_view_mut(),
+            _marker: PhantomData,
         }
     }
-    pub unsafe fn get(&self) -> &'a mut T {
-        unsafe { core::ptr::read(self.cell.get()) }
+
+    /// # Safety
+    ///
+    /// Elements written through the returned view must not be written through any other handle.
+    pub unsafe fn get(&self) -> ArrayViewMut<'a, A, D> {
+        unsafe { self.view.clone().deref_into_view_mut() }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::Array4;
+
+    /// Two handles alive at once, each writing a disjoint element: the pattern
+    /// `run_par!` produces when rayon runs closures on separate threads.
+    #[test]
+    fn handles_stay_valid_while_another_is_alive() {
+        let mut output = Array4::<f32>::zeros((2, 1, 2, 2));
+        {
+            let shared = UnsafeSharedRef::new(&mut output);
+            let mut first = unsafe { shared.get() };
+            let mut second = unsafe { shared.get() };
+            second[(1, 0, 1, 1)] = 2.0;
+            first[(0, 0, 0, 0)] = 1.0;
+        }
+        assert_eq!(output[(0, 0, 0, 0)], 1.0);
+        assert_eq!(output[(1, 0, 1, 1)], 2.0);
     }
 }


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed.
- [x] Made sure the book is up to date with changes in this PR. (no book change needed: `UnsafeSharedRef` is `pub(crate)`)

### Related Issues/PRs

Fixes #5345.

### Changes

`UnsafeSharedRef::get` copied the stored `&mut T` out of its cell with `core::ptr::read`
(`sharing.rs:17`). Creating a `&mut` retags it as unique, invalidating every handle already handed
out - only the most recent one stays usable. The type is `unsafe impl Sync` (`sharing.rs:8`) and
`run_par!` hands it to rayon workers, so parallel conv, pooling, interpolate, matmul and grid_sample
write through references whose tag is dead.

It now stores a `RawArrayViewMut` and returns an independent `ArrayViewMut` per call, so no `&mut` to
the array ever exists.

Call-site churn is mechanical (`let` -> `let mut`); no behaviour change.

I see #5344 just deprecated this crate - happy to close if it no longer takes fixes, though it is
still built and tested and remains the CubeCL reference backend.

### Testing

New `sharing.rs` test with two live handles writing disjoint elements, as rayon produces: Miri
reports `Undefined Behavior: ... that tag does not exist in the borrow stack` on `main` and passes
with this PR. It fails only under `cargo miri`, not under ordinary `cargo test`, and there is no Miri
job in CI. `cargo run-checks`: 6456 passed, 0 failed.

---
AI assistance was used in developing this change: Miri-based investigation of the borrow-stack
behaviour, the fix, and the regression test, all reviewed and verified by me.
