### PR TITLE
Bump cubecl and cubek revs for the pliron codegen fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2224,7 +2224,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f0721ea4b11bd56d30c2a24e6a0548246df9724f#f0721ea4b11bd56d30c2a24e6a0548246df9724f"
+source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -2241,7 +2241,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f0721ea4b11bd56d30c2a24e6a0548246df9724f#f0721ea4b11bd56d30c2a24e6a0548246df9724f"
+source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -2265,7 +2265,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f0721ea4b11bd56d30c2a24e6a0548246df9724f#f0721ea4b11bd56d30c2a24e6a0548246df9724f"
+source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -2296,7 +2296,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f0721ea4b11bd56d30c2a24e6a0548246df9724f#f0721ea4b11bd56d30c2a24e6a0548246df9724f"
+source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2319,7 +2319,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f0721ea4b11bd56d30c2a24e6a0548246df9724f#f0721ea4b11bd56d30c2a24e6a0548246df9724f"
+source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
 dependencies = [
  "bytemuck",
  "crossbeam-utils",
@@ -2347,7 +2347,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f0721ea4b11bd56d30c2a24e6a0548246df9724f#f0721ea4b11bd56d30c2a24e6a0548246df9724f"
+source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2366,7 +2366,7 @@ dependencies = [
 [[package]]
 name = "cubecl-environment"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f0721ea4b11bd56d30c2a24e6a0548246df9724f#f0721ea4b11bd56d30c2a24e6a0548246df9724f"
+source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
 dependencies = [
  "async-channel",
  "backtrace",
@@ -2401,7 +2401,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f0721ea4b11bd56d30c2a24e6a0548246df9724f#f0721ea4b11bd56d30c2a24e6a0548246df9724f"
+source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f0721ea4b11bd56d30c2a24e6a0548246df9724f#f0721ea4b11bd56d30c2a24e6a0548246df9724f"
+source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -2462,7 +2462,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f0721ea4b11bd56d30c2a24e6a0548246df9724f#f0721ea4b11bd56d30c2a24e6a0548246df9724f"
+source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
 dependencies = [
  "cubecl-common",
  "darling 0.23.0",
@@ -2480,7 +2480,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f0721ea4b11bd56d30c2a24e6a0548246df9724f#f0721ea4b11bd56d30c2a24e6a0548246df9724f"
+source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
 dependencies = [
  "darling 0.23.0",
  "inflections",
@@ -2492,7 +2492,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f0721ea4b11bd56d30c2a24e6a0548246df9724f#f0721ea4b11bd56d30c2a24e6a0548246df9724f"
+source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2514,7 +2514,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f0721ea4b11bd56d30c2a24e6a0548246df9724f#f0721ea4b11bd56d30c2a24e6a0548246df9724f"
+source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2543,7 +2543,7 @@ dependencies = [
 [[package]]
 name = "cubecl-spirv"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f0721ea4b11bd56d30c2a24e6a0548246df9724f#f0721ea4b11bd56d30c2a24e6a0548246df9724f"
+source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
 dependencies = [
  "bitflags 2.13.1",
  "cubecl-common",
@@ -2566,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f0721ea4b11bd56d30c2a24e6a0548246df9724f#f0721ea4b11bd56d30c2a24e6a0548246df9724f"
+source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2583,7 +2583,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f0721ea4b11bd56d30c2a24e6a0548246df9724f#f0721ea4b11bd56d30c2a24e6a0548246df9724f"
+source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
 dependencies = [
  "ash",
  "bytemuck",
@@ -2603,6 +2603,9 @@ dependencies = [
  "hashbrown 0.17.1",
  "itertools 0.15.0",
  "log",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
  "pliron",
  "sanitize-filename",
  "thiserror 2.0.20",
@@ -2615,7 +2618,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f0721ea4b11bd56d30c2a24e6a0548246df9724f#f0721ea4b11bd56d30c2a24e6a0548246df9724f"
+source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
 dependencies = [
  "derive-new",
  "serde",
@@ -2625,7 +2628,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=611491b48fb2ca0d6062611efffc10fecb7b8176#611491b48fb2ca0d6062611efffc10fecb7b8176"
+source = "git+https://github.com/tracel-ai/cubek?rev=93a278260f55fb693c5068be1fc6def7786ca810#93a278260f55fb693c5068be1fc6def7786ca810"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2643,7 +2646,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=611491b48fb2ca0d6062611efffc10fecb7b8176#611491b48fb2ca0d6062611efffc10fecb7b8176"
+source = "git+https://github.com/tracel-ai/cubek?rev=93a278260f55fb693c5068be1fc6def7786ca810#93a278260f55fb693c5068be1fc6def7786ca810"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2657,7 +2660,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=611491b48fb2ca0d6062611efffc10fecb7b8176#611491b48fb2ca0d6062611efffc10fecb7b8176"
+source = "git+https://github.com/tracel-ai/cubek?rev=93a278260f55fb693c5068be1fc6def7786ca810#93a278260f55fb693c5068be1fc6def7786ca810"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2673,7 +2676,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=611491b48fb2ca0d6062611efffc10fecb7b8176#611491b48fb2ca0d6062611efffc10fecb7b8176"
+source = "git+https://github.com/tracel-ai/cubek?rev=93a278260f55fb693c5068be1fc6def7786ca810#93a278260f55fb693c5068be1fc6def7786ca810"
 dependencies = [
  "cubecl",
 ]
@@ -2681,7 +2684,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=611491b48fb2ca0d6062611efffc10fecb7b8176#611491b48fb2ca0d6062611efffc10fecb7b8176"
+source = "git+https://github.com/tracel-ai/cubek?rev=93a278260f55fb693c5068be1fc6def7786ca810#93a278260f55fb693c5068be1fc6def7786ca810"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2693,7 +2696,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=611491b48fb2ca0d6062611efffc10fecb7b8176#611491b48fb2ca0d6062611efffc10fecb7b8176"
+source = "git+https://github.com/tracel-ai/cubek?rev=93a278260f55fb693c5068be1fc6def7786ca810#93a278260f55fb693c5068be1fc6def7786ca810"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2707,7 +2710,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=611491b48fb2ca0d6062611efffc10fecb7b8176#611491b48fb2ca0d6062611efffc10fecb7b8176"
+source = "git+https://github.com/tracel-ai/cubek?rev=93a278260f55fb693c5068be1fc6def7786ca810#93a278260f55fb693c5068be1fc6def7786ca810"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2717,7 +2720,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=611491b48fb2ca0d6062611efffc10fecb7b8176#611491b48fb2ca0d6062611efffc10fecb7b8176"
+source = "git+https://github.com/tracel-ai/cubek?rev=93a278260f55fb693c5068be1fc6def7786ca810#93a278260f55fb693c5068be1fc6def7786ca810"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2729,7 +2732,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=611491b48fb2ca0d6062611efffc10fecb7b8176#611491b48fb2ca0d6062611efffc10fecb7b8176"
+source = "git+https://github.com/tracel-ai/cubek?rev=93a278260f55fb693c5068be1fc6def7786ca810#93a278260f55fb693c5068be1fc6def7786ca810"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2743,7 +2746,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=611491b48fb2ca0d6062611efffc10fecb7b8176#611491b48fb2ca0d6062611efffc10fecb7b8176"
+source = "git+https://github.com/tracel-ai/cubek?rev=93a278260f55fb693c5068be1fc6def7786ca810#93a278260f55fb693c5068be1fc6def7786ca810"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2756,7 +2759,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=611491b48fb2ca0d6062611efffc10fecb7b8176#611491b48fb2ca0d6062611efffc10fecb7b8176"
+source = "git+https://github.com/tracel-ai/cubek?rev=93a278260f55fb693c5068be1fc6def7786ca810#93a278260f55fb693c5068be1fc6def7786ca810"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2766,7 +2769,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=611491b48fb2ca0d6062611efffc10fecb7b8176#611491b48fb2ca0d6062611efffc10fecb7b8176"
+source = "git+https://github.com/tracel-ai/cubek?rev=93a278260f55fb693c5068be1fc6def7786ca810#93a278260f55fb693c5068be1fc6def7786ca810"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -6725,7 +6728,9 @@ checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
+ "dispatch2",
  "objc2",
+ "objc2-core-foundation",
  "objc2-foundation",
 ]
 
@@ -7354,9 +7359,9 @@ dependencies = [
 
 [[package]]
 name = "pliron-spirv"
-version = "0.14.0+sdk-1.4.357.0"
+version = "0.14.1+sdk-1.4.357.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e775b2401a6ca1c46ac3e749ca3c6b44329c156f42fb263eb52499099543182d"
+checksum = "2919774bd35911798e824286a15c2c3c6fedbfd56d06a33e071dc1af5d5e7030"
 dependencies = [
  "derive-new",
  "derive_more",
@@ -10657,9 +10662,9 @@ dependencies = [
 
 [[package]]
 name = "tracel-rspirv"
-version = "0.14.0+sdk-1.4.357.0"
+version = "0.14.1+sdk-1.4.357.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e18ed0062c1f1236d9c51523b310974352778b0dd3b8598f70eac580afbed27b"
+checksum = "d1f062140c2875c072de7ab05019970906105a9a2c971af922b8d16bd3b5cbea"
 dependencies = [
  "bitflags 2.13.1",
  "pliron",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,11 +221,11 @@ burn-vision = { path = "crates/burn-vision", version = "=0.22.0-pre.2", default-
 burn-wgpu = { path = "crates/burn-wgpu", version = "=0.22.0-pre.2", default-features = false }
 
 ### For the main burn branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "f0721ea4b11bd56d30c2a24e6a0548246df9724f" }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "f0721ea4b11bd56d30c2a24e6a0548246df9724f" }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "f0721ea4b11bd56d30c2a24e6a0548246df9724f" }
-cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "f0721ea4b11bd56d30c2a24e6a0548246df9724f" }
-cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "611491b48fb2ca0d6062611efffc10fecb7b8176" }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "088dd7053c039775f73cf4d1645d30706d0ddf7d" }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "088dd7053c039775f73cf4d1645d30706d0ddf7d" }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "088dd7053c039775f73cf4d1645d30706d0ddf7d" }
+cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "088dd7053c039775f73cf4d1645d30706d0ddf7d" }
+cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "93a278260f55fb693c5068be1fc6def7786ca810" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }

--- a/crates/burn-cubecl-fusion/src/optim/matmul/args.rs
+++ b/crates/burn-cubecl-fusion/src/optim/matmul/args.rs
@@ -469,7 +469,9 @@ fn create_quant_view<E: Numeric, N: Size, Q: Scalar, S: Scalar>(
         View::new::<GlobalInput, Coords1d>(data_buf, data_layout);
     let scales_view: View<S, BatchedCoords> =
         View::new::<GlobalInput, Coords1d>(scales_buf, scales_layout);
-    QuantizedView::new(data_view, scales_view, scheme).view()
+    // No per-tensor scale on top of the block scales: two-level schemes are rejected where the
+    // scale layout is built, so there is never a second factor to fold in here.
+    QuantizedView::new(data_view, scales_view, ComptimeOption::new_None(), scheme).view()
 }
 
 #[derive(CubeType)]


### PR DESCRIPTION
Adapt the fused quant matmul to QuantizedView::new's per-tensor scale parameter (cubecl#1479): two-level schemes are rejected where the scale layout is built, so there is never a second factor to fold in here.
