### PR TITLE
Flex pooling impl optimization by rewriting inner kernel loop

### DIFF
--- a/crates/burn-flex/src/ops/pool.rs
+++ b/crates/burn-flex/src/ops/pool.rs
@@ -73,7 +73,7 @@ macro_rules! avg_pool3d_typed {
 macro_rules! adaptive_avg_pool3d_typed {
     ($fn_name:ident, $T:ty, $dtype:expr, $zero:expr, $div_fn:expr) => {
         pub fn $fn_name(x: FlexTensor, output_size: [usize; 3]) -> FlexTensor {
-            adaptive_avg_pool3d_impl::<$T>(x, output_size, $dtype, $zero, $div_fn)
+            adaptive_avg_pool3d_impl::<$T, _>(x, output_size, $dtype, $zero, $div_fn)
         }
     };
 }
@@ -193,6 +193,33 @@ pub fn max_pool3d_with_indices_bf16(
     (convert_f32_to_bf16(&output_f32), indices)
 }
 
+#[inline]
+fn valid_range_maxpool(
+    out: usize,
+    kernel: usize,
+    stride: usize,
+    pad: usize,
+    dilation: usize,
+    input: usize,
+) -> (usize, usize) {
+    let out = out as isize;
+    let kernel = kernel as isize;
+    let stride = stride as isize;
+    let pad = pad as isize;
+    let dilation = dilation as isize;
+    let input = input as isize;
+
+    let p = pad - out * stride;
+    let start = if p > 0 { (p - 1) / dilation + 1 } else { 0 };
+    let start = start.max(0).min(kernel);
+
+    let c = input + pad - out * stride;
+    let end = if c > 0 { (c - 1) / dilation + 1 } else { 0 };
+    let end = end.max(0).min(kernel).max(start);
+
+    (start as usize, end as usize)
+}
+
 /// Generic 3D max pooling with indices implementation.
 #[allow(clippy::too_many_arguments)]
 fn max_pool3d_with_indices_impl<T>(
@@ -229,40 +256,40 @@ where
     let spatial_out = out_d * out_h * out_w;
     let x_data: &[T] = x.storage();
     let kernel = |od: usize, oh: usize, ow: usize, x_offset: usize| {
+        let (kd_start, kd_end) =
+            valid_range_maxpool(od, kernel_d, stride_d, pad_d, dilation_d, in_d);
+        let (kh_start, kh_end) =
+            valid_range_maxpool(oh, kernel_h, stride_h, pad_h, dilation_h, in_h);
+        let (kw_start, kw_end) =
+            valid_range_maxpool(ow, kernel_w, stride_w, pad_w, dilation_w, in_w);
+
         let mut max_val = neg_inf;
         let mut max_idx: i64 = -1;
 
-        for kd in 0..kernel_d {
-            let id = (od * stride_d + kd * dilation_d) as isize - pad_d as isize;
-            if id < 0 || id >= in_d as isize {
-                continue;
-            }
-            let id = id as usize;
+        for kd in kd_start..kd_end {
+            // These subtractions are safe because valid_range guarantees no underflow.
+            let id = od * stride_d + kd * dilation_d - pad_d;
+            let id_base = id * in_h * in_w;
 
-            for kh in 0..kernel_h {
-                let ih = (oh * stride_h + kh * dilation_h) as isize - pad_h as isize;
-                if ih < 0 || ih >= in_h as isize {
-                    continue;
-                }
-                let ih = ih as usize;
+            for kh in kh_start..kh_end {
+                let ih = oh * stride_h + kh * dilation_h - pad_h;
+                let ih_base = ih * in_w;
 
-                for kw in 0..kernel_w {
-                    let iw = (ow * stride_w + kw * dilation_w) as isize - pad_w as isize;
-                    if iw < 0 || iw >= in_w as isize {
-                        continue;
-                    }
-                    let iw = iw as usize;
+                for kw in kw_start..kw_end {
+                    let iw = ow * stride_w + kw * dilation_w - pad_w;
 
-                    let x_idx = x_offset + id * in_h * in_w + ih * in_w + iw;
+                    let x_idx = x_offset + id_base + ih_base + iw;
                     let val = x_data[x_idx];
 
-                    if max_idx < 0 || val > max_val {
+                    // The only remaining conditional is the max comparison itself.
+                    if val > max_val {
                         max_val = val;
-                        max_idx = (id * in_h * in_w + ih * in_w + iw) as i64;
+                        max_idx = (id_base + ih_base + iw) as i64;
                     }
                 }
             }
         }
+
         (max_val, max_idx)
     };
 
@@ -599,6 +626,40 @@ pub fn avg_pool3d_bf16(
     );
     convert_f32_to_bf16(&result_f32)
 }
+#[inline(always)]
+fn padded_len_avgpool(out: usize, kernel: usize, stride: usize, pad: usize, input: usize) -> usize {
+    let out = out as isize;
+    let kernel = kernel as isize;
+    let stride = stride as isize;
+    let pad = pad as isize;
+    let input = input as isize;
+
+    let start = 0isize;
+    let end = (input + 2 * pad - out * stride).max(0).min(kernel);
+
+    (end - start).max(0) as usize
+}
+
+#[inline(always)]
+fn valid_range_avgpool(
+    out: usize,
+    kernel: usize,
+    stride: usize,
+    pad: usize,
+    input: usize,
+) -> (usize, usize) {
+    let out = out as isize;
+    let kernel = kernel as isize;
+    let stride = stride as isize;
+    let pad = pad as isize;
+    let input = input as isize;
+
+    let start = (pad - out * stride).max(0).min(kernel);
+    let end = (input + pad - out * stride).max(0).min(kernel);
+    let end = end.max(start);
+
+    (start as usize, end as usize)
+}
 
 /// Generic 3D average pooling implementation.
 #[allow(clippy::too_many_arguments)]
@@ -645,53 +706,35 @@ where
     let _kernel_volume = kernel_d * kernel_h * kernel_w;
 
     let kernel = |od: usize, oh: usize, ow: usize, x_offset: usize| {
+        let pd_len = padded_len_avgpool(od, kernel_d, stride_d, pad_d, in_d);
+        let ph_len = padded_len_avgpool(oh, kernel_h, stride_h, pad_h, in_h);
+        let pw_len = padded_len_avgpool(ow, kernel_w, stride_w, pad_w, in_w);
+
+        let pad_count = pd_len * ph_len * pw_len;
+
+        let (kd_start, kd_end) = valid_range_avgpool(od, kernel_d, stride_d, pad_d, in_d);
+        let (kh_start, kh_end) = valid_range_avgpool(oh, kernel_h, stride_h, pad_h, in_h);
+        let (kw_start, kw_end) = valid_range_avgpool(ow, kernel_w, stride_w, pad_w, in_w);
+
+        let count = (kd_end - kd_start) * (kh_end - kh_start) * (kw_end - kw_start);
+
         let mut sum = zero;
-        let mut count = 0usize;
 
-        // Track count for count_include_pad (positions within padded bounds)
-        let mut pad_count = 0usize;
+        for kd in kd_start..kd_end {
+            let id = od * stride_d + kd - pad_d; // safe: valid range guarantees no underflow
+            let id_base = id * in_h * in_w;
 
-        for kd in 0..kernel_d {
-            let id = (od * stride_d + kd) as isize - pad_d as isize;
-            // Check if within padded bounds (not ceil_mode extension)
-            let id_in_bounds = id >= -(pad_d as isize) && id < (in_d + pad_d) as isize;
-            if !id_in_bounds {
-                continue; // ceil_mode extension - skip entirely
-            }
-            let id_valid = id >= 0 && id < in_d as isize;
+            for kh in kh_start..kh_end {
+                let ih = oh * stride_h + kh - pad_h;
+                let ih_base = ih * in_w;
 
-            for kh in 0..kernel_h {
-                let ih = (oh * stride_h + kh) as isize - pad_h as isize;
-                let ih_in_bounds = ih >= -(pad_h as isize) && ih < (in_h + pad_h) as isize;
-                if !ih_in_bounds {
-                    continue;
-                }
-                let ih_valid = ih >= 0 && ih < in_h as isize;
-
-                for kw in 0..kernel_w {
-                    let iw = (ow * stride_w + kw) as isize - pad_w as isize;
-                    let iw_in_bounds = iw >= -(pad_w as isize) && iw < (in_w + pad_w) as isize;
-                    if !iw_in_bounds {
-                        continue;
-                    }
-
-                    // Position is within padded bounds
-                    pad_count += 1;
-
-                    let iw_valid = iw >= 0 && iw < in_w as isize;
-                    if !id_valid || !ih_valid || !iw_valid {
-                        continue; // In padding zone - count but don't add
-                    }
-
-                    let id = id as usize;
-                    let ih = ih as usize;
-                    let iw = iw as usize;
-                    let x_idx = x_offset + id * in_h * in_w + ih * in_w + iw;
-                    sum = T::add(sum, x_data[x_idx]);
-                    count += 1;
+                for kw in kw_start..kw_end {
+                    let iw = ow * stride_w + kw - pad_w;
+                    sum = T::add(sum, x_data[x_offset + id_base + ih_base + iw]);
                 }
             }
         }
+
         (sum, count, pad_count)
     };
 
@@ -923,15 +966,17 @@ pub fn adaptive_avg_pool3d_backward_bf16(x: FlexTensor, grad: FlexTensor) -> Fle
 }
 
 /// Generic 3D adaptive average pooling implementation.
-fn adaptive_avg_pool3d_impl<T>(
+#[cfg_attr(feature = "simd", macerator::with_simd)]
+fn adaptive_avg_pool3d_impl<#[cfg(feature = "simd")] S: macerator::Simd, T, Div>(
     x: FlexTensor,
     output_size: [usize; 3],
     dtype: DType,
     zero: T,
-    div_fn: impl Fn(T, usize) -> T + Copy + Send + Sync,
+    div_fn: Div,
 ) -> FlexTensor
 where
     T: bytemuck::Pod + Copy + Send + Sync + Element + ElementAdd,
+    Div: Fn(T, usize) -> T + Copy + Send + Sync,
 {
     let x = x.to_contiguous();
     let x_shape = x.layout().shape();

--- a/crates/burn-flex/src/ops/pool.rs
+++ b/crates/burn-flex/src/ops/pool.rs
@@ -663,6 +663,7 @@ fn valid_range_avgpool(
 
 /// Generic 3D average pooling implementation.
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::extra_unused_type_parameters)]
 #[cfg_attr(feature = "simd", macerator::with_simd)]
 fn avg_pool3d_impl<#[cfg(feature = "simd")] S: macerator::Simd, T, Div>(
     x: FlexTensor,
@@ -966,6 +967,7 @@ pub fn adaptive_avg_pool3d_backward_bf16(x: FlexTensor, grad: FlexTensor) -> Fle
 }
 
 /// Generic 3D adaptive average pooling implementation.
+#[allow(clippy::extra_unused_type_parameters)]
 #[cfg_attr(feature = "simd", macerator::with_simd)]
 fn adaptive_avg_pool3d_impl<#[cfg(feature = "simd")] S: macerator::Simd, T, Div>(
     x: FlexTensor,

--- a/crates/burn-flex/src/ops/pool.rs
+++ b/crates/burn-flex/src/ops/pool.rs
@@ -282,7 +282,7 @@ where
                     let val = x_data[x_idx];
 
                     // The only remaining conditional is the max comparison itself.
-                    if val > max_val {
+                    if max_idx < 0 || val > max_val {
                         max_val = val;
                         max_idx = (id_base + ih_base + iw) as i64;
                     }

--- a/crates/burn-flex/src/ops/pool.rs
+++ b/crates/burn-flex/src/ops/pool.rs
@@ -54,7 +54,7 @@ macro_rules! avg_pool3d_typed {
             count_include_pad: bool,
             ceil_mode: bool,
         ) -> FlexTensor {
-            avg_pool3d_impl::<$T>(
+            avg_pool3d_impl::<$T, _>(
                 x,
                 kernel_size,
                 stride,
@@ -228,6 +228,43 @@ where
 
     let spatial_out = out_d * out_h * out_w;
     let x_data: &[T] = x.storage();
+    let kernel = |od: usize, oh: usize, ow: usize, x_offset: usize| {
+        let mut max_val = neg_inf;
+        let mut max_idx: i64 = -1;
+
+        for kd in 0..kernel_d {
+            let id = (od * stride_d + kd * dilation_d) as isize - pad_d as isize;
+            if id < 0 || id >= in_d as isize {
+                continue;
+            }
+            let id = id as usize;
+
+            for kh in 0..kernel_h {
+                let ih = (oh * stride_h + kh * dilation_h) as isize - pad_h as isize;
+                if ih < 0 || ih >= in_h as isize {
+                    continue;
+                }
+                let ih = ih as usize;
+
+                for kw in 0..kernel_w {
+                    let iw = (ow * stride_w + kw * dilation_w) as isize - pad_w as isize;
+                    if iw < 0 || iw >= in_w as isize {
+                        continue;
+                    }
+                    let iw = iw as usize;
+
+                    let x_idx = x_offset + id * in_h * in_w + ih * in_w + iw;
+                    let val = x_data[x_idx];
+
+                    if max_idx < 0 || val > max_val {
+                        max_val = val;
+                        max_idx = (id * in_h * in_w + ih * in_w + iw) as i64;
+                    }
+                }
+            }
+        }
+        (max_val, max_idx)
+    };
 
     let (output, indices) = {
         #[cfg(feature = "rayon")]
@@ -252,43 +289,7 @@ where
                     for oh in 0..out_h {
                         for ow in 0..out_w {
                             let out_idx = out_offset + od * out_h * out_w + oh * out_w + ow;
-                            let mut max_val = neg_inf;
-                            let mut max_idx: i64 = -1;
-
-                            for kd in 0..kernel_d {
-                                let id =
-                                    (od * stride_d + kd * dilation_d) as isize - pad_d as isize;
-                                if id < 0 || id >= in_d as isize {
-                                    continue;
-                                }
-                                let id = id as usize;
-
-                                for kh in 0..kernel_h {
-                                    let ih =
-                                        (oh * stride_h + kh * dilation_h) as isize - pad_h as isize;
-                                    if ih < 0 || ih >= in_h as isize {
-                                        continue;
-                                    }
-                                    let ih = ih as usize;
-
-                                    for kw in 0..kernel_w {
-                                        let iw = (ow * stride_w + kw * dilation_w) as isize
-                                            - pad_w as isize;
-                                        if iw < 0 || iw >= in_w as isize {
-                                            continue;
-                                        }
-                                        let iw = iw as usize;
-
-                                        let x_idx = x_offset + id * in_h * in_w + ih * in_w + iw;
-                                        let val = x_data[x_idx];
-
-                                        if max_idx < 0 || val > max_val {
-                                            max_val = val;
-                                            max_idx = (id * in_h * in_w + ih * in_w + iw) as i64;
-                                        }
-                                    }
-                                }
-                            }
+                            let (max_val, max_idx) = kernel(od, oh, ow, x_offset);
 
                             unsafe {
                                 out_ptr.write(out_idx, max_val);
@@ -314,45 +315,7 @@ where
                         for oh in 0..out_h {
                             for ow in 0..out_w {
                                 let out_idx = out_offset + od * out_h * out_w + oh * out_w + ow;
-                                let mut max_val = neg_inf;
-                                let mut max_idx: i64 = -1;
-
-                                for kd in 0..kernel_d {
-                                    let id =
-                                        (od * stride_d + kd * dilation_d) as isize - pad_d as isize;
-                                    if id < 0 || id >= in_d as isize {
-                                        continue;
-                                    }
-                                    let id = id as usize;
-
-                                    for kh in 0..kernel_h {
-                                        let ih = (oh * stride_h + kh * dilation_h) as isize
-                                            - pad_h as isize;
-                                        if ih < 0 || ih >= in_h as isize {
-                                            continue;
-                                        }
-                                        let ih = ih as usize;
-
-                                        for kw in 0..kernel_w {
-                                            let iw = (ow * stride_w + kw * dilation_w) as isize
-                                                - pad_w as isize;
-                                            if iw < 0 || iw >= in_w as isize {
-                                                continue;
-                                            }
-                                            let iw = iw as usize;
-
-                                            let x_idx =
-                                                x_offset + id * in_h * in_w + ih * in_w + iw;
-                                            let val = x_data[x_idx];
-
-                                            if max_idx < 0 || val > max_val {
-                                                max_val = val;
-                                                max_idx =
-                                                    (id * in_h * in_w + ih * in_w + iw) as i64;
-                                            }
-                                        }
-                                    }
-                                }
+                                let (max_val, max_idx) = kernel(od, oh, ow, x_offset);
 
                                 output[out_idx] = max_val;
                                 indices[out_idx] = max_idx;
@@ -639,7 +602,8 @@ pub fn avg_pool3d_bf16(
 
 /// Generic 3D average pooling implementation.
 #[allow(clippy::too_many_arguments)]
-fn avg_pool3d_impl<T>(
+#[cfg_attr(feature = "simd", macerator::with_simd)]
+fn avg_pool3d_impl<#[cfg(feature = "simd")] S: macerator::Simd, T, Div>(
     x: FlexTensor,
     kernel_size: [usize; 3],
     stride: [usize; 3],
@@ -648,10 +612,11 @@ fn avg_pool3d_impl<T>(
     ceil_mode: bool,
     dtype: DType,
     zero: T,
-    div_fn: impl Fn(T, usize) -> T + Copy + Send + Sync,
+    div_fn: Div,
 ) -> FlexTensor
 where
     T: bytemuck::Pod + Copy + Send + Sync + Element + ElementAdd,
+    Div: Fn(T, usize) -> T + Copy + Send + Sync,
 {
     let x = x.to_contiguous();
     let x_shape = x.layout().shape();
@@ -679,6 +644,57 @@ where
     let x_data: &[T] = x.storage();
     let _kernel_volume = kernel_d * kernel_h * kernel_w;
 
+    let kernel = |od: usize, oh: usize, ow: usize, x_offset: usize| {
+        let mut sum = zero;
+        let mut count = 0usize;
+
+        // Track count for count_include_pad (positions within padded bounds)
+        let mut pad_count = 0usize;
+
+        for kd in 0..kernel_d {
+            let id = (od * stride_d + kd) as isize - pad_d as isize;
+            // Check if within padded bounds (not ceil_mode extension)
+            let id_in_bounds = id >= -(pad_d as isize) && id < (in_d + pad_d) as isize;
+            if !id_in_bounds {
+                continue; // ceil_mode extension - skip entirely
+            }
+            let id_valid = id >= 0 && id < in_d as isize;
+
+            for kh in 0..kernel_h {
+                let ih = (oh * stride_h + kh) as isize - pad_h as isize;
+                let ih_in_bounds = ih >= -(pad_h as isize) && ih < (in_h + pad_h) as isize;
+                if !ih_in_bounds {
+                    continue;
+                }
+                let ih_valid = ih >= 0 && ih < in_h as isize;
+
+                for kw in 0..kernel_w {
+                    let iw = (ow * stride_w + kw) as isize - pad_w as isize;
+                    let iw_in_bounds = iw >= -(pad_w as isize) && iw < (in_w + pad_w) as isize;
+                    if !iw_in_bounds {
+                        continue;
+                    }
+
+                    // Position is within padded bounds
+                    pad_count += 1;
+
+                    let iw_valid = iw >= 0 && iw < in_w as isize;
+                    if !id_valid || !ih_valid || !iw_valid {
+                        continue; // In padding zone - count but don't add
+                    }
+
+                    let id = id as usize;
+                    let ih = ih as usize;
+                    let iw = iw as usize;
+                    let x_idx = x_offset + id * in_h * in_w + ih * in_w + iw;
+                    sum = T::add(sum, x_data[x_idx]);
+                    count += 1;
+                }
+            }
+        }
+        (sum, count, pad_count)
+    };
+
     let output = {
         #[cfg(feature = "rayon")]
         {
@@ -698,52 +714,7 @@ where
                     for oh in 0..out_h {
                         for ow in 0..out_w {
                             let out_idx = out_offset + od * out_h * out_w + oh * out_w + ow;
-                            let mut sum = zero;
-                            let mut count = 0usize;
-                            let mut pad_count = 0usize;
-
-                            for kd in 0..kernel_d {
-                                let id = (od * stride_d + kd) as isize - pad_d as isize;
-                                let id_in_bounds =
-                                    id >= -(pad_d as isize) && id < (in_d + pad_d) as isize;
-                                if !id_in_bounds {
-                                    continue;
-                                }
-                                let id_valid = id >= 0 && id < in_d as isize;
-
-                                for kh in 0..kernel_h {
-                                    let ih = (oh * stride_h + kh) as isize - pad_h as isize;
-                                    let ih_in_bounds =
-                                        ih >= -(pad_h as isize) && ih < (in_h + pad_h) as isize;
-                                    if !ih_in_bounds {
-                                        continue;
-                                    }
-                                    let ih_valid = ih >= 0 && ih < in_h as isize;
-
-                                    for kw in 0..kernel_w {
-                                        let iw = (ow * stride_w + kw) as isize - pad_w as isize;
-                                        let iw_in_bounds =
-                                            iw >= -(pad_w as isize) && iw < (in_w + pad_w) as isize;
-                                        if !iw_in_bounds {
-                                            continue;
-                                        }
-
-                                        pad_count += 1;
-
-                                        let iw_valid = iw >= 0 && iw < in_w as isize;
-                                        if !id_valid || !ih_valid || !iw_valid {
-                                            continue;
-                                        }
-
-                                        let id = id as usize;
-                                        let ih = ih as usize;
-                                        let iw = iw as usize;
-                                        let x_idx = x_offset + id * in_h * in_w + ih * in_w + iw;
-                                        sum = T::add(sum, x_data[x_idx]);
-                                        count += 1;
-                                    }
-                                }
-                            }
+                            let (sum, count, pad_count) = kernel(od, oh, ow, x_offset);
 
                             let divisor = if count_include_pad {
                                 pad_count.max(1)
@@ -773,57 +744,7 @@ where
                         for oh in 0..out_h {
                             for ow in 0..out_w {
                                 let out_idx = out_offset + od * out_h * out_w + oh * out_w + ow;
-                                let mut sum = zero;
-                                let mut count = 0usize;
-
-                                // Track count for count_include_pad (positions within padded bounds)
-                                let mut pad_count = 0usize;
-
-                                for kd in 0..kernel_d {
-                                    let id = (od * stride_d + kd) as isize - pad_d as isize;
-                                    // Check if within padded bounds (not ceil_mode extension)
-                                    let id_in_bounds =
-                                        id >= -(pad_d as isize) && id < (in_d + pad_d) as isize;
-                                    if !id_in_bounds {
-                                        continue; // ceil_mode extension - skip entirely
-                                    }
-                                    let id_valid = id >= 0 && id < in_d as isize;
-
-                                    for kh in 0..kernel_h {
-                                        let ih = (oh * stride_h + kh) as isize - pad_h as isize;
-                                        let ih_in_bounds =
-                                            ih >= -(pad_h as isize) && ih < (in_h + pad_h) as isize;
-                                        if !ih_in_bounds {
-                                            continue;
-                                        }
-                                        let ih_valid = ih >= 0 && ih < in_h as isize;
-
-                                        for kw in 0..kernel_w {
-                                            let iw = (ow * stride_w + kw) as isize - pad_w as isize;
-                                            let iw_in_bounds = iw >= -(pad_w as isize)
-                                                && iw < (in_w + pad_w) as isize;
-                                            if !iw_in_bounds {
-                                                continue;
-                                            }
-
-                                            // Position is within padded bounds
-                                            pad_count += 1;
-
-                                            let iw_valid = iw >= 0 && iw < in_w as isize;
-                                            if !id_valid || !ih_valid || !iw_valid {
-                                                continue; // In padding zone - count but don't add
-                                            }
-
-                                            let id = id as usize;
-                                            let ih = ih as usize;
-                                            let iw = iw as usize;
-                                            let x_idx =
-                                                x_offset + id * in_h * in_w + ih * in_w + iw;
-                                            sum = T::add(sum, x_data[x_idx]);
-                                            count += 1;
-                                        }
-                                    }
-                                }
+                                let (sum, count, pad_count) = kernel(od, oh, ow, x_offset);
 
                                 let divisor = if count_include_pad {
                                     pad_count.max(1) // Positions within padded bounds


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

N/A

### Changes

- Rewrote the kernels for avg/max pooling to make them more obvious to autovectorization/optimisation
  - this probably deserves some scrutiny. i *think* i got the logic to be the same, but i'm not sure. Alas, its the kind of complex which takes a while to even start to have a mental model...
- added macerator simd to avg pooling

### Testing

- `cd crates/burn-backend-tests && cargo test-flex --features flex-simd -- pool`
- benckmarked against main flex, see results below:

<details><summary>Benchmark results</summary>
<p>

command used: `cargo bench-flex --features bench-disable-alloc --bench pool_ops -- --sample-count 100 --sample-size 25 --max-time 4 --threads 1 pool` with the flex-simd feature added depending on benchmark

## baseline (main branch)

```
Timer precision: 10 ns
pool_ops                                         fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ backend                                                     │               │               │               │         │
   ├─ adaptive_avg_pool2d                                      │               │               │               │         │
   │  ├─ adaptive_avg_pool2d_1x256x56x56_to_7x7  247 µs        │ 279 µs        │ 257.3 µs      │ 255.7 µs      │ 100     │ 2500
   │  ├─ adaptive_avg_pool2d_1x512x7x7_to_1x1    10.06 µs      │ 12.45 µs      │ 10.14 µs      │ 10.46 µs      │ 100     │ 2500
   │  ├─ adaptive_avg_pool2d_8x512x7x7_to_1x1    79.28 µs      │ 98.02 µs      │ 82.05 µs      │ 82.32 µs      │ 100     │ 2500
   │  ╰─ adaptive_avg_pool2d_16x2048x7x7_to_1x1  638.7 µs      │ 685.4 µs      │ 652.6 µs      │ 653.6 µs      │ 100     │ 2500
   ├─ avg_pool2d                                               │               │               │               │         │
   │  ├─ avg_pool2d_1x64x56x56_k3x3_s2           464.4 µs      │ 526.9 µs      │ 482.4 µs      │ 485.5 µs      │ 100     │ 2500
   │  ├─ avg_pool2d_8x64x56x56_k3x3_s2           3.945 ms      │ 4.196 ms      │ 4.032 ms      │ 4.051 ms      │ 40      │ 1000
   │  ╰─ avg_pool2d_16x128x28x28_k2x2_s2         2.551 ms      │ 2.728 ms      │ 2.639 ms      │ 2.63 ms       │ 61      │ 1525
   ├─ max_pool1d                                               │               │               │               │         │
   │  ├─ max_pool1d_1x64x256_k3_s2               74.13 µs      │ 85.04 µs      │ 76.55 µs      │ 76.62 µs      │ 100     │ 2500
   │  ├─ max_pool1d_8x128x512_k3_s2              2.461 ms      │ 2.626 ms      │ 2.576 ms      │ 2.572 ms      │ 62      │ 1550
   │  ╰─ max_pool1d_16x256x1024_k3_s2            20.11 ms      │ 20.49 ms      │ 20.39 ms      │ 20.35 ms      │ 8       │ 200
   ├─ max_pool2d                                               │               │               │               │         │
   │  ├─ max_pool2d_1x64x56x56_k3x3_s2           786.8 µs      │ 850.5 µs      │ 792 µs        │ 799.4 µs      │ 100     │ 2500
   │  ├─ max_pool2d_1x512x14x14_k2x2_s2          229.2 µs      │ 258.6 µs      │ 234.7 µs      │ 235 µs        │ 100     │ 2500
   │  ├─ max_pool2d_8x64x56x56_k3x3_s2           6.544 ms      │ 6.941 ms      │ 6.779 ms      │ 6.755 ms      │ 24      │ 600
   │  ╰─ max_pool2d_16x128x28x28_k2x2_s2         4.004 ms      │ 4.15 ms       │ 4.073 ms      │ 4.066 ms      │ 39      │ 975
   ├─ max_pool2d_resnet                                        │               │               │               │         │
   │  ├─ resnet_maxpool_1x64x112x112_k3x3_s2     3.261 ms      │ 3.456 ms      │ 3.309 ms      │ 3.31 ms       │ 49      │ 1225
   │  ├─ resnet_maxpool_8x64x112x112_k3x3_s2     26.23 ms      │ 27.13 ms      │ 26.46 ms      │ 26.6 ms       │ 6       │ 150
   │  ╰─ resnet_maxpool_16x64x112x112_k3x3_s2    53.34 ms      │ 54.13 ms      │ 54.12 ms      │ 53.86 ms      │ 3       │ 75
   ╰─ pool_kernel_sizes                                        │               │               │               │         │
      ├─ max_pool2d_k2x2                         1.816 ms      │ 1.988 ms      │ 1.892 ms      │ 1.89 ms       │ 85      │ 2125
      ├─ max_pool2d_k3x3                         3.164 ms      │ 3.346 ms      │ 3.296 ms      │ 3.28 ms       │ 49      │ 1225
      ╰─ max_pool2d_k5x5                         7.167 ms      │ 7.446 ms      │ 7.385 ms      │ 7.372 ms      │ 22      │ 550
```

## new kernel without flex-simd

```
Timer precision: 10 ns
pool_ops                                         fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ backend                                                     │               │               │               │         │
   ├─ adaptive_avg_pool2d                                      │               │               │               │         │
   │  ├─ adaptive_avg_pool2d_1x256x56x56_to_7x7  257.5 µs      │ 279.2 µs      │ 260.5 µs      │ 261.5 µs      │ 100     │ 2500
   │  ├─ adaptive_avg_pool2d_1x512x7x7_to_1x1    10.1 µs       │ 12.72 µs      │ 10.25 µs      │ 10.55 µs      │ 100     │ 2500
   │  ├─ adaptive_avg_pool2d_8x512x7x7_to_1x1    79.93 µs      │ 97.4 µs       │ 82.23 µs      │ 83 µs         │ 100     │ 2500
   │  ╰─ adaptive_avg_pool2d_16x2048x7x7_to_1x1  633.1 µs      │ 682.9 µs      │ 658.3 µs      │ 657.7 µs      │ 100     │ 2500
   ├─ avg_pool2d                                               │               │               │               │         │
   │  ├─ avg_pool2d_1x64x56x56_k3x3_s2           249 µs        │ 304.9 µs      │ 259.4 µs      │ 261 µs        │ 100     │ 2500
   │  ├─ avg_pool2d_8x64x56x56_k3x3_s2           2.143 ms      │ 2.284 ms      │ 2.198 ms      │ 2.194 ms      │ 72      │ 1800
   │  ╰─ avg_pool2d_16x128x28x28_k2x2_s2         1.653 ms      │ 1.844 ms      │ 1.72 ms       │ 1.725 ms      │ 92      │ 2300
   ├─ max_pool1d                                               │               │               │               │         │
   │  ├─ max_pool1d_1x64x256_k3_s2               65.43 µs      │ 69.38 µs      │ 66.48 µs      │ 66.69 µs      │ 100     │ 2500
   │  ├─ max_pool1d_8x128x512_k3_s2              2.174 ms      │ 2.337 ms      │ 2.273 ms      │ 2.271 ms      │ 70      │ 1750
   │  ╰─ max_pool1d_16x256x1024_k3_s2            17.39 ms      │ 17.99 ms      │ 17.94 ms      │ 17.83 ms      │ 9       │ 225
   ├─ max_pool2d                                               │               │               │               │         │
   │  ├─ max_pool2d_1x64x56x56_k3x3_s2           508.1 µs      │ 548.4 µs      │ 518.5 µs      │ 519.4 µs      │ 100     │ 2500
   │  ├─ max_pool2d_1x512x14x14_k2x2_s2          188.7 µs      │ 205.7 µs      │ 189.5 µs      │ 190.7 µs      │ 100     │ 2500
   │  ├─ max_pool2d_8x64x56x56_k3x3_s2           4.177 ms      │ 4.434 ms      │ 4.359 ms      │ 4.33 ms       │ 37      │ 925
   │  ╰─ max_pool2d_16x128x28x28_k2x2_s2         3.425 ms      │ 3.576 ms      │ 3.494 ms      │ 3.492 ms      │ 46      │ 1150
   ├─ max_pool2d_resnet                                        │               │               │               │         │
   │  ├─ resnet_maxpool_1x64x112x112_k3x3_s2     2.017 ms      │ 2.165 ms      │ 2.074 ms      │ 2.071 ms      │ 78      │ 1950
   │  ├─ resnet_maxpool_8x64x112x112_k3x3_s2     16.82 ms      │ 17.18 ms      │ 17.06 ms      │ 17 ms         │ 10      │ 250
   │  ╰─ resnet_maxpool_16x64x112x112_k3x3_s2    34.37 ms      │ 34.57 ms      │ 34.49 ms      │ 34.47 ms      │ 5       │ 125
   ╰─ pool_kernel_sizes                                        │               │               │               │         │
      ├─ max_pool2d_k2x2                         1.541 ms      │ 1.728 ms      │ 1.618 ms      │ 1.611 ms      │ 100     │ 2500
      ├─ max_pool2d_k3x3                         2.052 ms      │ 2.177 ms      │ 2.078 ms      │ 2.08 ms       │ 77      │ 1925
      ╰─ max_pool2d_k5x5                         3.549 ms      │ 3.679 ms      │ 3.618 ms      │ 3.62 ms       │ 45      │ 1125
```

## flex-simd

```
Timer precision: 10 ns
pool_ops                                         fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ backend                                                     │               │               │               │         │
   ├─ adaptive_avg_pool2d                                      │               │               │               │         │
   │  ├─ adaptive_avg_pool2d_1x256x56x56_to_7x7  250.2 µs      │ 271.6 µs      │ 255.1 µs      │ 255.8 µs      │ 100     │ 2500
   │  ├─ adaptive_avg_pool2d_1x512x7x7_to_1x1    10.07 µs      │ 12.6 µs       │ 10.1 µs       │ 10.48 µs      │ 100     │ 2500
   │  ├─ adaptive_avg_pool2d_8x512x7x7_to_1x1    78.98 µs      │ 87.58 µs      │ 80.35 µs      │ 80.7 µs       │ 100     │ 2500
   │  ╰─ adaptive_avg_pool2d_16x2048x7x7_to_1x1  626 µs        │ 668.9 µs      │ 637.2 µs      │ 638.6 µs      │ 100     │ 2500
   ├─ avg_pool2d                                               │               │               │               │         │
   │  ├─ avg_pool2d_1x64x56x56_k3x3_s2           225.2 µs      │ 244.1 µs      │ 225.7 µs      │ 226.8 µs      │ 100     │ 2500
   │  ├─ avg_pool2d_8x64x56x56_k3x3_s2           1.962 ms      │ 2.114 ms      │ 2.045 ms      │ 2.032 ms      │ 78      │ 1950
   │  ╰─ avg_pool2d_16x128x28x28_k2x2_s2         1.546 ms      │ 1.645 ms      │ 1.601 ms      │ 1.598 ms      │ 99      │ 2475
   ├─ max_pool1d                                               │               │               │               │         │
   │  ├─ max_pool1d_1x64x256_k3_s2               68.45 µs      │ 91.49 µs      │ 71.19 µs      │ 71.62 µs      │ 100     │ 2500
   │  ├─ max_pool1d_8x128x512_k3_s2              2.278 ms      │ 2.459 ms      │ 2.375 ms      │ 2.362 ms      │ 68      │ 1700
   │  ╰─ max_pool1d_16x256x1024_k3_s2            18.53 ms      │ 18.96 ms      │ 18.85 ms      │ 18.82 ms      │ 9       │ 225
   ├─ max_pool2d                                               │               │               │               │         │
   │  ├─ max_pool2d_1x64x56x56_k3x3_s2           531.1 µs      │ 613.8 µs      │ 543.5 µs      │ 544 µs        │ 100     │ 2500
   │  ├─ max_pool2d_1x512x14x14_k2x2_s2          195.9 µs      │ 228.3 µs      │ 204.6 µs      │ 204.6 µs      │ 100     │ 2500
   │  ├─ max_pool2d_8x64x56x56_k3x3_s2           4.38 ms       │ 4.698 ms      │ 4.55 ms       │ 4.519 ms      │ 36      │ 900
   │  ╰─ max_pool2d_16x128x28x28_k2x2_s2         3.42 ms       │ 3.738 ms      │ 3.583 ms      │ 3.551 ms      │ 45      │ 1125
   ├─ max_pool2d_resnet                                        │               │               │               │         │
   │  ├─ resnet_maxpool_1x64x112x112_k3x3_s2     2.074 ms      │ 2.215 ms      │ 2.125 ms      │ 2.135 ms      │ 75      │ 1875
   │  ├─ resnet_maxpool_8x64x112x112_k3x3_s2     17.32 ms      │ 17.96 ms      │ 17.65 ms      │ 17.63 ms      │ 10      │ 250
   │  ╰─ resnet_maxpool_16x64x112x112_k3x3_s2    34.91 ms      │ 35.6 ms       │ 35.31 ms      │ 35.3 ms       │ 5       │ 125
   ╰─ pool_kernel_sizes                                        │               │               │               │         │
      ├─ max_pool2d_k2x2                         1.61 ms       │ 1.729 ms      │ 1.644 ms      │ 1.646 ms      │ 98      │ 2450
      ├─ max_pool2d_k3x3                         2.147 ms      │ 2.244 ms      │ 2.189 ms      │ 2.188 ms      │ 74      │ 1850
      ╰─ max_pool2d_k5x5                         3.658 ms      │ 3.846 ms      │ 3.8 ms        │ 3.776 ms      │ 43      │ 1075
```

As you can see, it seems the max pooling suffers a slight downgrade when simd is enabled. For this reason i've removed the macerator macro from it.

</p>
</details> 