### PR TITLE
fix(module): preserve LoRA factor dtype when composing weights

### DIFF
--- a/crates/burn-core/src/module/lora.rs
+++ b/crates/burn-core/src/module/lora.rs
@@ -303,7 +303,7 @@ mod tests {
     }
 
     #[test]
-    fn qlora_builds_factors_at_the_configured_dtype() {
+    fn qlora_composes_packed_base_at_the_configured_factor_dtype() {
         use crate::module::Quantizer;
         use burn_tensor::DType;
         use burn_tensor::quantization::{Calibration, QuantLevel, QuantParam, QuantValue};
@@ -328,9 +328,8 @@ mod tests {
         assert_eq!(adapter.a.val().dtype(), DType::F16);
         assert_eq!(adapter.b.val().dtype(), DType::F16);
 
-        // The compose settles on the factors' dtype: the base dequantizes to
-        // the device default and is cast before the add, rather than meeting
-        // the delta in an elementwise op that does not promote.
+        // Mixed QFloat/Float addition dequantizes the packed base directly to
+        // the factors' dtype.
         assert_eq!(weight.val().dtype(), DType::F16);
     }
 

--- a/crates/burn-core/src/module/param/lora.rs
+++ b/crates/burn-core/src/module/param/lora.rs
@@ -26,12 +26,11 @@ impl Reparameterization for LoraAdapter {
 
     fn materialize<const D: usize>(&self, base: Tensor<D>) -> Tensor<D> {
         let delta = self.delta().reshape(base.shape());
-        // The factors set the precision the compose runs at. A dense base was
-        // matched to them when they were built; a packed base dequantizes to
-        // the device default, which is not theirs whenever the model computes
-        // at another precision.
-        let base = if base.dtype() != delta.dtype() {
-            base.dequantize()
+        // Compose at the factors' dtype: cast a mismatched dense base, but leave
+        // a packed base untouched so mixed addition dequantizes it directly to
+        // the delta's dtype rather than through the device default.
+        let base = if base.dtype().is_float() && base.dtype() != delta.dtype() {
+            base.cast(delta.dtype())
         } else {
             base
         };
@@ -46,5 +45,27 @@ impl LoraAdapter {
     /// (optimizer-updated) factors and keeps them as autodiff leaves for backpropagation.
     pub fn delta(&self) -> Tensor<2> {
         self.a.val().matmul(self.b.val()).mul_scalar(self.scale)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_device;
+    use burn_tensor::DType;
+
+    #[test]
+    fn materialize_casts_a_dense_base_to_the_factor_dtype() {
+        let device = test_device();
+        let base = Tensor::<2>::ones([4, 4], (&device, DType::F32));
+        let adapter = LoraAdapter {
+            a: Param::from_tensor(Tensor::<2>::ones([4, 2], (&device, DType::F16))),
+            b: Param::from_tensor(Tensor::<2>::zeros([2, 4], (&device, DType::F16))),
+            scale: 1.0,
+        };
+
+        let materialized = adapter.materialize(base);
+
+        assert_eq!(materialized.dtype(), DType::F16);
     }
 }


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

> `cargo run-checks` tests with `Flex` by default. Use `cargo run-checks --backend <backend>` when
> targeting another backend. Consider running additional tests relevant to the crates changed.

### Related Issues/PRs

#5364

### Changes

For `base + delta` we don't need to explicitly call `.dequantize()`, which would return the float tensor with the device default. The elementise ops for mixed QFloat/Float already handle dequantize to the other operants dtype:
https://github.com/tracel-ai/burn/blob/67dbe6ea15f0fdb40043fe4316e437ff0eb8427c/crates/burn-tensor/src/bridge/ops/float.rs#L22-L36

We only need to cast when the base float dtype doesn't match delta.

### Testing

Existing test `qlora_builds_factors_at_the_configured_dtype` now passes. New unit test.
