### PR TITLE
Improve benchmark defaults and py script to compare benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ examples/**/Cargo.lock
 *profiler.json
 # linker maps
 *.map
+# samply profiling files
+*.json.gz
+# benchmarking helper files
+.divan_diff.json

--- a/crates/burn-backend-tests/README.md
+++ b/crates/burn-backend-tests/README.md
@@ -150,13 +150,14 @@ cargo bench-flex --bench matmul -- square
 
 ### Comparing backends
 
-Each run targets one backend. To compare (e.g. Flex vs NdArray), run twice and diff the output:
+Each run targets one backend. To compare (e.g. Flex vs NdArray), run twice while piping into divan-diff.py (python uv script):
 
 ```sh
-cargo bench-flex --bench matmul > flex.txt
-cargo bench-ndarray --bench matmul > ndarray.txt
-diff flex.txt ndarray.txt
+cargo bench-flex --bench matmul | ./divan-diff.py
+cargo bench-ndarray --bench matmul | ./divan-diff.py
 ```
+
+This can also be used to compare subsequent runs of the same benchmark after changes have been made.
 
 ### GPU sync
 

--- a/crates/burn-backend-tests/benches/attention.rs
+++ b/crates/burn-backend-tests/benches/attention.rs
@@ -20,10 +20,7 @@ static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Attention Benchmarks");
-    println!("Memory allocation tracking enabled");
-    println!();
-    divan::main();
-    common::report_failures();
+    common::bench_main();
 }
 
 /// Create Q, K, V tensors for attention benchmarking.

--- a/crates/burn-backend-tests/benches/binary_ops.rs
+++ b/crates/burn-backend-tests/benches/binary_ops.rs
@@ -18,9 +18,7 @@ static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Benchmarks");
-    println!();
-    divan::main();
-    common::report_failures();
+    common::bench_main();
 }
 
 // Tensor sizes for benchmarking

--- a/crates/burn-backend-tests/benches/cat_max_min_ops.rs
+++ b/crates/burn-backend-tests/benches/cat_max_min_ops.rs
@@ -18,10 +18,7 @@ static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Benchmarks for cat, max/min, int power, bool select, grid_sample_2d");
-    println!("Memory allocation tracking enabled");
-    println!();
-    divan::main();
-    common::report_failures();
+    common::bench_main();
 }
 
 // === Helpers ===

--- a/crates/burn-backend-tests/benches/common/mod.rs
+++ b/crates/burn-backend-tests/benches/common/mod.rs
@@ -7,6 +7,7 @@
 use std::cell::Cell;
 use std::panic::{self, AssertUnwindSafe, Location};
 use std::sync::Mutex;
+use std::time::Duration;
 
 use burn_tensor::Element;
 use ctor::ctor;
@@ -24,6 +25,22 @@ fn init_device_settings() {
                 .int_dtype(<IntElem as Element>::dtype()),
         )
         .unwrap();
+}
+
+/// Runs divan with modified defaults: 600 samples and a limit of 6 seconds per benchmark, instead of 100 samples uncapped.
+pub fn bench_main() {
+    #[cfg(not(feature = "bench-disable-alloc"))]
+    println!("Memory allocation tracking enabled");
+    println!();
+    divan::Divan::default()
+        // Divan defaults to 100 samples, which is usually not enough to get stable results run-to-run
+        .sample_count(600)
+        // stops benchmarks after 5 seconds, even if less samples have been collected.
+        // long benchmarks are less susceptible to run-to-run differences anyways
+        .max_time(Duration::from_secs(5))
+        .config_with_args()
+        .main();
+    report_failures();
 }
 
 /// Block until all outstanding ops on the default device complete.
@@ -101,7 +118,7 @@ pub fn try_setup<T>(f: impl FnOnce() -> T) -> Option<T> {
 }
 
 /// Print a summary of benches that panicked during this run, if any. Call from `main()` after
-/// `divan::main()`.
+/// `common::divan_setup();`.
 pub fn report_failures() {
     let failures = FAILURES.lock().unwrap();
     if failures.is_empty() {

--- a/crates/burn-backend-tests/benches/comparison_ops.rs
+++ b/crates/burn-backend-tests/benches/comparison_ops.rs
@@ -18,9 +18,7 @@ static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Benchmarking comparison and broadcast operations");
-    println!();
-    divan::main();
-    common::report_failures();
+    common::bench_main();
 }
 
 const SMALL: usize = 64 * 64; // 4K elements

--- a/crates/burn-backend-tests/benches/conv_ops.rs
+++ b/crates/burn-backend-tests/benches/conv_ops.rs
@@ -20,10 +20,7 @@ static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Convolution Benchmarks");
-    println!("Memory allocation tracking enabled");
-    println!();
-    divan::main();
-    common::report_failures();
+    common::bench_main();
 }
 
 fn make_input_2d(batch: usize, channels: usize, height: usize, width: usize) -> Tensor<4> {

--- a/crates/burn-backend-tests/benches/conv_transpose_ops.rs
+++ b/crates/burn-backend-tests/benches/conv_transpose_ops.rs
@@ -21,10 +21,7 @@ static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Conv Transpose Benchmarks");
-    println!("Memory allocation tracking enabled");
-    println!();
-    divan::main();
-    common::report_failures();
+    common::bench_main();
 }
 
 fn make_input_2d(batch: usize, channels: usize, height: usize, width: usize) -> Tensor<4> {

--- a/crates/burn-backend-tests/benches/cross_unfold_ops.rs
+++ b/crates/burn-backend-tests/benches/cross_unfold_ops.rs
@@ -18,9 +18,7 @@ static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Cross and unfold ops Benchmarks");
-    println!();
-    divan::main();
-    common::report_failures();
+    common::bench_main();
 }
 
 // Cross product requires 3 elements along the specified dimension

--- a/crates/burn-backend-tests/benches/cumulative_ops.rs
+++ b/crates/burn-backend-tests/benches/cumulative_ops.rs
@@ -18,9 +18,7 @@ static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Cumulative ops Benchmarks");
-    println!();
-    divan::main();
-    common::report_failures();
+    common::bench_main();
 }
 
 fn make_tensor_1d(size: usize) -> Tensor<1> {

--- a/crates/burn-backend-tests/benches/default_ops.rs
+++ b/crates/burn-backend-tests/benches/default_ops.rs
@@ -23,9 +23,7 @@ static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Default ops Benchmarks");
-    println!();
-    divan::main();
-    common::report_failures();
+    common::bench_main();
 }
 
 const SMALL: usize = 64 * 64;

--- a/crates/burn-backend-tests/benches/deform_conv_ops.rs
+++ b/crates/burn-backend-tests/benches/deform_conv_ops.rs
@@ -20,10 +20,7 @@ static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Deformable Convolution Benchmarks");
-    println!("Memory allocation tracking enabled");
-    println!();
-    divan::main();
-    common::report_failures();
+    common::bench_main();
 }
 
 /// Create input tensor [batch, channels, height, width]

--- a/crates/burn-backend-tests/benches/fft_ops.rs
+++ b/crates/burn-backend-tests/benches/fft_ops.rs
@@ -21,9 +21,7 @@ static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("rfft / irfft benchmarks");
-    println!();
-    divan::main();
-    common::report_failures();
+    common::bench_main();
 }
 
 fn make_signal_1d(n: usize) -> Tensor<1> {

--- a/crates/burn-backend-tests/benches/gather_scatter_ops.rs
+++ b/crates/burn-backend-tests/benches/gather_scatter_ops.rs
@@ -18,9 +18,7 @@ static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Gather/scatter ops Benchmarks");
-    println!();
-    divan::main();
-    common::report_failures();
+    common::bench_main();
 }
 
 fn make_tensor_2d(rows: usize, cols: usize) -> Tensor<2> {

--- a/crates/burn-backend-tests/benches/int_ops.rs
+++ b/crates/burn-backend-tests/benches/int_ops.rs
@@ -18,10 +18,7 @@ static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Integer Operations Benchmarks");
-    println!("Memory allocation tracking enabled");
-    println!();
-    divan::main();
-    common::report_failures();
+    common::bench_main();
 }
 
 fn make_int_tensor(shape: &[usize]) -> Option<Tensor<2, Int>> {

--- a/crates/burn-backend-tests/benches/interpolate_ops.rs
+++ b/crates/burn-backend-tests/benches/interpolate_ops.rs
@@ -23,10 +23,7 @@ static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Interpolate Benchmarks");
-    println!("Memory allocation tracking enabled");
-    println!();
-    divan::main();
-    common::report_failures();
+    common::bench_main();
 }
 
 fn make_input(batch: usize, channels: usize, height: usize, width: usize) -> Tensor<4> {

--- a/crates/burn-backend-tests/benches/matmul.rs
+++ b/crates/burn-backend-tests/benches/matmul.rs
@@ -20,10 +20,7 @@ static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Matrix Multiplication Benchmarks");
-    println!("Memory allocation tracking enabled");
-    println!();
-    divan::main();
-    common::report_failures();
+    common::bench_main();
 }
 
 fn make_matrix(rows: usize, cols: usize) -> Tensor<2> {

--- a/crates/burn-backend-tests/benches/norm_ops.rs
+++ b/crates/burn-backend-tests/benches/norm_ops.rs
@@ -34,9 +34,7 @@ static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Normalization Benchmarks");
-    println!();
-    divan::main();
-    common::report_failures();
+    common::bench_main();
 }
 
 fn make_tensor_3d(d0: usize, d1: usize, d2: usize) -> Tensor<3> {

--- a/crates/burn-backend-tests/benches/pool_ops.rs
+++ b/crates/burn-backend-tests/benches/pool_ops.rs
@@ -20,10 +20,7 @@ static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Pooling Benchmarks");
-    println!("Memory allocation tracking enabled");
-    println!();
-    divan::main();
-    common::report_failures();
+    common::bench_main();
 }
 
 fn make_input_2d(batch: usize, channels: usize, height: usize, width: usize) -> Tensor<4> {

--- a/crates/burn-backend-tests/benches/quantization_ops.rs
+++ b/crates/burn-backend-tests/benches/quantization_ops.rs
@@ -18,9 +18,7 @@ static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Quantized ops Benchmarks");
-    println!();
-    divan::main();
-    common::report_failures();
+    common::bench_main();
 }
 
 const SMALL: usize = 64 * 64; // 4K elements

--- a/crates/burn-backend-tests/benches/reduce_ops.rs
+++ b/crates/burn-backend-tests/benches/reduce_ops.rs
@@ -18,9 +18,7 @@ static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Reduction ops Benchmarks");
-    println!();
-    divan::main();
-    common::report_failures();
+    common::bench_main();
 }
 
 fn make_tensor_1d(size: usize) -> Tensor<1> {

--- a/crates/burn-backend-tests/benches/slice_ops.rs
+++ b/crates/burn-backend-tests/benches/slice_ops.rs
@@ -20,10 +20,7 @@ static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Slice Operations Benchmarks");
-    println!("Memory allocation tracking enabled");
-    println!();
-    divan::main();
-    common::report_failures();
+    common::bench_main();
 }
 
 fn make_tensor_1d(size: usize) -> Tensor<1> {

--- a/crates/burn-backend-tests/benches/softmax_ops.rs
+++ b/crates/burn-backend-tests/benches/softmax_ops.rs
@@ -19,9 +19,7 @@ static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Softmax Benchmarks: fused (via B::softmax) vs decomposed");
-    println!();
-    divan::main();
-    common::report_failures();
+    common::bench_main();
 }
 
 fn make_tensor_3d<E: Element + From<f32>>(d0: usize, d1: usize, d2: usize) -> Tensor<3> {

--- a/crates/burn-backend-tests/benches/unary_ops.rs
+++ b/crates/burn-backend-tests/benches/unary_ops.rs
@@ -18,9 +18,7 @@ static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     println!("Unary ops Benchmarks");
-    println!();
-    divan::main();
-    common::report_failures();
+    common::bench_main();
 }
 
 const SMALL: usize = 64 * 64; // 4K elements

--- a/crates/burn-backend-tests/divan-diff.py
+++ b/crates/burn-backend-tests/divan-diff.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
+import json
+import re
+import sys
+from pathlib import Path
+
+FILE = Path(".divan_diff.json")
+FILE.touch(exist_ok=True)
+NEG_PAD = 6
+SEPARATOR = "│"
+EXCLUDE_HEADERS = ["fastest", "slowest", "samples"]
+MIN_PERCENT = 5 / 100
+
+header_pattern = re.compile(
+    r"^(?P<bench>\w+) *|(?P<header>\w+) *(?P<separator>│)?", flags=re.MULTILINE
+)
+line_pattern = re.compile(
+    r"(?:^(?P<indent>[ ─╰│├]+))?(?P<name>[a-zA-Z]\w*)? +?(?P<value>[0-9\.]+)? ?(?P<unit>\w+)?(?:(?P<colend> *)│|$)",
+    flags=re.MULTILINE,
+)
+
+
+to_ms = {"ns": 1 / 1e6, "µs": 1 / 1000, "ms": 1, "s": 1000, "m": 1000 * 60}
+
+
+def parse_value(val: str, unit: str):
+    unit = unit.strip()
+    if len(unit) == 0:
+        return int(val)
+    else:
+        return float(val) * to_ms[unit]
+
+
+def to_unit(val: float, unit: str) -> float:
+    unit = unit.strip()
+    return val / to_ms[unit]
+
+
+diff_template = " {sign}{percent:.2%} {sign}{delta:.3}  "
+diff_template_len = len(diff_template.format(sign="+", delta=234.5678, percent=0.98899))
+in_divan = False
+benchg = []
+headers = []
+col_ranges = []
+line_len = 0
+last_indent_l = 0
+
+
+def dim(s: str) -> str:
+    return f"\x1b[2;37m{s}\x1b[0m"
+
+
+def green(s: str) -> str:
+    return f"\x1b[32m{s}\x1b[0m"
+
+
+def red(s: str) -> str:
+    return f"\x1b[31m{s}\x1b[0m"
+
+
+def buffer_line(line: str) -> str:
+    offset = 0
+    for start, end in col_ranges:
+        prev_len = len(line)
+        line = line[: offset + start] + " " * diff_template_len + line[offset + end :]
+        offset += len(line) - prev_len
+    return line
+
+
+for line in sys.stdin:
+    if len(benchg) == 0 and SEPARATOR in line:
+        first, *head = header_pattern.finditer(line)
+        benchg.append(first.group("bench"))
+        for h in head:
+            header = h.group("header")
+            headers.append(header)
+            sep = h.start("separator")
+            if sep > 0 and all(excl not in header for excl in EXCLUDE_HEADERS):
+                col_ranges.append((sep - 1 - NEG_PAD, sep - 1))
+        last_indent_l = 1
+        line_len = len(line)
+        print(buffer_line(line), end="")
+        continue
+
+    if len(benchg) > 0:
+        if SEPARATOR not in line or not all(
+            line[sep + 1] == SEPARATOR for (_, sep) in col_ranges
+        ):
+            in_divan = False
+            benchg.clear()
+            headers.clear()
+            col_ranges.clear()
+            print(line, end="")
+            continue
+
+        values = {}
+        indent = ""
+        matches = list(line_pattern.finditer(line))
+        for i, col in enumerate(matches):
+            if i == 0:
+                indent = col.group("indent")
+                indent_l = len(indent)
+                if indent_l < last_indent_l:
+                    benchg.pop()
+                elif indent_l == last_indent_l:
+                    benchg.pop()
+                    benchg.append(col.group("name"))
+                elif indent_l > last_indent_l:
+                    benchg.append(col.group("name"))
+                last_indent_l = indent_l
+            if headers[i] in EXCLUDE_HEADERS:
+                continue
+            val = col.group("value") or ""
+            if len(val.strip()) > 0:
+                unit = col.group("unit") or ""
+                if len(unit) > 0:
+                    values[headers[i]] = (
+                        parse_value(val, unit),
+                        unit,
+                        (col.end("colend") - NEG_PAD, col.end("colend")),
+                    )
+        with FILE.open("r") as f:
+            try:
+                data: dict = json.load(f)
+            except Exception as e:
+                print(e)
+                data = {}
+        datakey = ".".join(benchg)
+        vals = data.get(datakey, {})
+        col_diffs = {}
+        offset = 0
+        for k, (v, unit, (start, end)) in values.items():
+            prev = vals.get(k)
+            if prev is None:
+                diff = " " * diff_template_len
+            else:
+                delta = v - prev
+                p_diff = (v - prev) / prev
+                diff = diff_template.format(
+                    sign="" if delta < 0 else "+",
+                    delta=to_unit(delta, unit),
+                    percent=p_diff,
+                ).ljust(diff_template_len)
+                if abs(p_diff) < MIN_PERCENT:
+                    diff = dim(diff)
+                elif delta < 0:
+                    diff = green(diff)
+                elif delta > 0:
+                    diff = red(diff)
+            vals[k] = v
+            len_pre = len(line)
+            line = line[: offset + start] + diff + line[offset + end :]
+            offset += len(line) - len_pre
+        if len(values) == 0:
+            line = buffer_line(line)
+        data[datakey] = vals
+        with open(".divan_diff.json", "w+") as f:
+            json.dump(data, f)
+    print(line, end="")


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

N/A

### Changes

- Moved the divan call and memory print into a `common` benchmark run function
- Changed sample-count away from divan default, 100 -> 600
- Added max time limit, so long-running benchmarks use less samples
- Added a python script which saves divan benchmark results and compares them to the previous run.

TODO: verify how the diff script works with memory profiling enabled

### Testing

Ran benchmarks
For example, heres me testing whether the CONV_PLANE_OH_OUTER_THRESHOLD does anything by setting it to 0 during the second run:
<img width="2111" height="1732" alt="image" src="https://github.com/user-attachments/assets/850b1bbe-61fc-4237-964e-0fd73fc0edd8" />
