### PR TITLE
Gate async-copy matmul strategies on real stride alignment

### DIFF
--- a/crates/burn-cubecl/src/kernel/matmul/tune/base.rs
+++ b/crates/burn-cubecl/src/kernel/matmul/tune/base.rs
@@ -96,6 +96,9 @@ pub fn matmul_autotune<R: CubeRuntime>(
         const PRIORITY_MIN: i8 = 0;
         const PRIORITY_NEVER: i8 = -1;
 
+        /// Stride factor of the 16-byte alignment the async-copy and TMA loaders require.
+        const ASYNC_COPY_STRIDE_FACTOR: u8 = 4;
+
         let accelerated = TuneGroup::<MatmulAutotuneKey>::new("accelerated", |key| {
             if matches!(key.analysis.kind, MatmulKind::General) {
                 match key.analysis.scale_global {
@@ -151,7 +154,9 @@ pub fn matmul_autotune<R: CubeRuntime>(
                 PRIORITY_HIGH
             };
 
-            if key.definition.lhs_stride_factor >= 4 && key.definition.rhs_stride_factor >= 4 {
+            if key.definition.lhs_stride_factor >= ASYNC_COPY_STRIDE_FACTOR
+                && key.definition.rhs_stride_factor >= ASYNC_COPY_STRIDE_FACTOR
+            {
                 priority_max
             } else {
                 PRIORITY_NEVER
@@ -528,6 +533,17 @@ pub fn matmul_autotune<R: CubeRuntime>(
                 TileMatmulKind::Mma,
             ),
         ] {
+            // Strategies reading through an async-copy loader need both operands strided on a
+            // 16-byte boundary, which the loader validates against the real strides when the
+            // kernel is set up. The TMA strategies are gated on that threshold through the
+            // `tma` group; the specialized cyclic ones are only in `accelerated`, so without
+            // this an under-aligned problem can select them and fail once autotune has already
+            // committed to the winner.
+            let needs_aligned_strides = matches!(
+                strategy,
+                Strategy::SpecializedCyclicCmma(_) | Strategy::SpecializedCyclicMma(_)
+            );
+
             let mut tunable = Tunable::new(&strategy.to_string(), move |(lhs, rhs, out)| {
                 launch_matmul::<R>(&strategy, lhs, rhs, out).map_err(|err| format!("{err:?}"))
             });
@@ -539,6 +555,13 @@ pub fn matmul_autotune<R: CubeRuntime>(
             let accelerated_priority = move |key: &MatmulAutotuneKey, client: &ComputeClient<R>| {
                 if !tile_matmul_supported::<R>(client, tile_matmul, &key.definition) {
                     return PRIORITY_MIN;
+                }
+
+                if needs_aligned_strides
+                    && (key.definition.lhs_stride_factor < ASYNC_COPY_STRIDE_FACTOR
+                        || key.definition.rhs_stride_factor < ASYNC_COPY_STRIDE_FACTOR)
+                {
+                    return PRIORITY_NEVER;
                 }
 
                 match double_buf {


### PR DESCRIPTION
Fixes the kernel-selection half of #5352.

## Problem

`Strategy::SpecializedCyclicCmma` / `SpecializedCyclicMma` bind `L = AsyncPartialCyclicLoading` in `SpecializedAlgorithm<L, AL>`, and that single `L` serves both operands' partial loads. `AsyncPartialCyclicLoading`'s validation calls `validate_async_copy_with_problem`, which checks the **real** strides for 16-byte alignment when the kernel is set up.

The matmul tuner already has a gate for exactly this: the `tma` group returns `PRIORITY_NEVER` unless `lhs_stride_factor` and `rhs_stride_factor` both clear the threshold. But that group is only attached to the `*Tma*` strategies. The two specialized cyclic strategies are registered in `accelerated` with no extra group, and every other entry in that list reads through sync loaders (`Simple*`, `DoubleCyclic*` → `CyclicDoubleBufferingAlgorithm`, `OrderedDouble*`), so nothing else there needs the check.

The result is that an under-aligned problem can hand `PRIORITY_MAX` to a kernel that cannot launch on it. Selection commits to the winner, setup validation then rejects it, and the error surfaces where it can no longer be handled — `.expect("Should run when selected by autotune.")` on a cache hit in `LocalTuner::execute`. On an async device runner that panic is caught and warn-logged while the op's registered outputs stay unwritten, which is how it reaches training as NaN weights or a corrupted fusion stream (#5352 has the full chain and a ~60-line reproduction).

A `Linear(126, 7)` layer is enough to hit it: the head matmul `[512,128] @ [128,7]` has rhs strides `[7,1]`, a 28-byte canonical stride.

## Fix

Extend the existing threshold to the two async-copy strategies, evaluated from the key like every other priority decision — no fallback, no re-running, and no cloning of real autotune inputs. Under-aligned problems keep the entire sync accelerated pool plus the naive fallback, so the tune plan can never end up empty.

The check is `lhs < T || rhs < T` rather than per-operand because both operands load through the same `L`.

Also replaces the two bare `4`s in the `tma` group with the named `ASYNC_COPY_STRIDE_FACTOR` so the threshold has one definition.

## Depends on tracel-ai/cubek#488

**This gate is inert without that PR.** `MatmulAutotuneKey` currently derives its stride factors from the *anchored* dims, so a 7-wide dim (`anchor(7) = 8`) reports as 32-byte aligned and a 126-wide dim (`anchor(126) = 128`) as 512-byte aligned. Every under-aligned problem therefore clears any threshold read off the key. cubek#488 makes those fields reflect the real strides; this PR is what consumes them. They need to land together — merging either alone is a no-op for the bug.

That dependency also explains an observation in #5352 that looked contradictory: fixing the key alone did not stop the crash, because splitting the buckets does not help when nothing gates these strategies on alignment in the first place.

## Testing

`cargo check -p burn-cubecl --features cuda`, plus verification on a real CUDA training workload (RTX 4080 SUPER, sm_89) running both fixes backported onto the 0.22.0-pre.2 releases:

- The gate fires on 14 of 20 matmul autotune keys in that workload — the two strategies are recorded with no benchmark result on those keys and tune normally on the remaining 6, so aligned shapes still see the full candidate pool.
- The training numerics suites pass on both the `cuda` and `cuda-fusion` configurations, where previously the fused one died on the step after the first optimizer update.

## Still open from #5352

A task that panics on the device-runner thread is caught and only `log::warn!`-ed while its outputs stay registered and unwritten. This PR removes the trigger we hit, but any other panic on that path still corrupts state silently; that is worth addressing separately.
