### PR TITLE
feat(cubecl): support AdaptiveAvgPool3d

### DIFF
--- a/crates/burn-backend-tests/tests/autodiff/adaptive_avgpool3d.rs
+++ b/crates/burn-backend-tests/tests/autodiff/adaptive_avgpool3d.rs
@@ -1,5 +1,3 @@
-#![cfg(any(feature = "flex", feature = "ndarray", feature = "tch"))]
-
 use super::*;
 use burn_tensor::module::adaptive_avg_pool3d;
 use burn_tensor::{Shape, Tolerance};
@@ -79,29 +77,51 @@ fn test_adaptive_avg_pool3d_backward_output_1() {
 
 #[test]
 fn test_adaptive_avg_pool3d_backward_dyn_filter() {
-    // 4x6x8 -> 2x3x4 with non-trivial window sizes
-    // Verify backward produces valid gradients
-    let shape_x = Shape::new([1, 1, 4, 6, 8]);
-    let device = AutodiffDevice::new();
-    let x = TestTensor::from_data(
-        TestTensorInt::arange(0..shape_x.num_elements() as i64, &device)
-            .reshape::<5, _>(shape_x)
-            .into_data(),
-        &device,
-    )
-    .require_grad();
-    let output = adaptive_avg_pool3d(x.clone(), [2, 3, 4]);
-    let grads = output.backward();
-    let x_grad = x.grad(&grads).unwrap();
-    let grad_data: Vec<f32> = x_grad.into_data().iter::<f32>().collect();
+    let test = AdaptiveAvgPool3dTestCase {
+        batch_size: 1,
+        channels: 1,
+        depth: 2,
+        height: 3,
+        width: 4,
+        depth_out: 1,
+        height_out: 2,
+        width_out: 3,
+    };
 
-    // All gradients should be non-negative
-    for v in &grad_data {
-        assert!(*v >= 0.0, "Expected non-negative grad, got {}", v);
-    }
-    // Gradients should be non-zero (something flowed backward)
-    let total: f32 = grad_data.iter().sum();
-    assert!(total > 0.0, "Total grad should be positive, got {}", total);
+    test.assert_output(TestTensor::from_data(
+        [[[
+            [
+                [0.125, 0.25, 0.25, 0.125],
+                [0.25, 0.5, 0.5, 0.25],
+                [0.125, 0.25, 0.25, 0.125],
+            ],
+            [
+                [0.125, 0.25, 0.25, 0.125],
+                [0.25, 0.5, 0.5, 0.25],
+                [0.125, 0.25, 0.25, 0.125],
+            ],
+        ]]],
+        &AutodiffDevice::new(),
+    ));
+}
+
+#[test]
+fn test_adaptive_avg_pool3d_backward_divisible_dyn_filter() {
+    let test = AdaptiveAvgPool3dTestCase {
+        batch_size: 1,
+        channels: 1,
+        depth: 4,
+        height: 6,
+        width: 8,
+        depth_out: 2,
+        height_out: 3,
+        width_out: 4,
+    };
+
+    test.assert_output(TestTensor::from_data(
+        [[[[[0.125; 8]; 6]; 4]]],
+        &AutodiffDevice::new(),
+    ));
 }
 
 struct AdaptiveAvgPool3dTestCase {

--- a/crates/burn-backend-tests/tests/autodiff/adaptive_avgpool3d.rs
+++ b/crates/burn-backend-tests/tests/autodiff/adaptive_avgpool3d.rs
@@ -124,6 +124,30 @@ fn test_adaptive_avg_pool3d_backward_divisible_dyn_filter() {
     ));
 }
 
+#[test]
+fn test_adaptive_avg_pool3d_backward_preserves_gradient_layout() {
+    let shape = Shape::new([2, 3, 2, 4, 5]);
+    let device = AutodiffDevice::new();
+    let x = TestTensor::zeros(shape.clone(), &device).require_grad();
+    let output_grad = TestTensor::from_data(
+        TestTensorInt::arange(0..shape.num_elements() as i64, &device)
+            .reshape::<5, _>(shape)
+            .into_data(),
+        &device,
+    );
+    let expected = output_grad.to_data();
+
+    // Keeping the spatial shape unchanged makes adaptive pooling the identity. A distinct
+    // output gradient at every position verifies the NCDHW <-> NDHWC gradient conversions.
+    let output = adaptive_avg_pool3d(x.clone(), [2, 4, 5]);
+    let grads = output.mul(output_grad).sum().backward();
+    let x_grad = x.grad(&grads).unwrap();
+
+    x_grad
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
+}
+
 struct AdaptiveAvgPool3dTestCase {
     batch_size: usize,
     channels: usize,

--- a/crates/burn-backend-tests/tests/tensor/float/module/adaptive_avgpool3d.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/module/adaptive_avgpool3d.rs
@@ -1,5 +1,3 @@
-#![cfg(any(feature = "flex", feature = "ndarray", feature = "tch"))]
-
 use super::*;
 use burn_tensor::Shape;
 use burn_tensor::TensorData;
@@ -47,36 +45,46 @@ fn test_adaptive_avg_pool3d_output_1() {
 
 #[test]
 fn test_adaptive_avg_pool3d_asymmetric() {
-    // For this test, we compute the expected values by running the reference implementation
-    let shape_x = Shape::new([1, 2, 4, 6, 8]);
-    let device = Default::default();
-    let x = TestTensor::from(
-        TestTensorInt::arange(0..shape_x.num_elements() as i64, &device)
-            .reshape::<5, _>(shape_x)
-            .into_data(),
-    );
-    let output = adaptive_avg_pool3d(x, [2, 3, 2]);
-    let output_data = output.into_data();
+    let test = AdaptiveAvgPool3dTestCase {
+        batch_size: 1,
+        channels: 1,
+        depth: 2,
+        height: 3,
+        width: 4,
+        depth_out: 1,
+        height_out: 2,
+        width_out: 3,
+    };
 
-    // Verify output shape
-    assert_eq!(output_data.shape, Shape::new([1, 2, 2, 3, 2]));
+    test.assert_output(TestTensor::from([[[[
+        [8.5, 9.5, 10.5],
+        [12.5, 13.5, 14.5],
+    ]]]]));
+}
 
-    // Verify all values are finite and positive
-    let values: Vec<f32> = output_data.iter::<f32>().collect();
-    for v in &values {
-        assert!(v.is_finite(), "Expected finite, got {}", v);
-        assert!(*v >= 0.0, "Expected non-negative, got {}", v);
-    }
+#[test]
+fn test_adaptive_avg_pool3d_multichannel_divisible_asymmetric() {
+    let test = AdaptiveAvgPool3dTestCase {
+        batch_size: 1,
+        channels: 2,
+        depth: 4,
+        height: 6,
+        width: 8,
+        depth_out: 2,
+        height_out: 3,
+        width_out: 2,
+    };
 
-    // Verify the average is reasonable (should be around the mean of input)
-    let mean: f32 = values.iter().sum::<f32>() / values.len() as f32;
-    let input_mean = (383.0) / 2.0; // mean of 0..384 per channel
-    assert!(
-        (mean - input_mean).abs() < 1.0,
-        "Mean {} too far from expected {}",
-        mean,
-        input_mean
-    );
+    test.assert_output(TestTensor::from([[
+        [
+            [[29.5, 33.5], [45.5, 49.5], [61.5, 65.5]],
+            [[125.5, 129.5], [141.5, 145.5], [157.5, 161.5]],
+        ],
+        [
+            [[221.5, 225.5], [237.5, 241.5], [253.5, 257.5]],
+            [[317.5, 321.5], [333.5, 337.5], [349.5, 353.5]],
+        ],
+    ]]));
 }
 
 #[test]

--- a/crates/burn-cubecl/src/kernel/pool/base.rs
+++ b/crates/burn-cubecl/src/kernel/pool/base.rs
@@ -10,7 +10,8 @@ use burn_backend::cubecl::dtype_to_storage_type;
 use burn_backend::{DType, Shape, ops::conv::calculate_pool_output_size};
 use cubek::pool::{
     definition::{AdaptiveAvgPoolOptions, AvgPoolOptions, MaxPoolOptions, PoolError, PoolMode},
-    pool2d, pool2d_backward, pool2d_with_indices, pool2d_with_indices_backward,
+    pool2d, pool2d_backward, pool2d_with_indices, pool2d_with_indices_backward, pool3d,
+    pool3d_backward,
 };
 use cubek::reduce::components::instructions::ReduceOperationConfig;
 
@@ -377,6 +378,67 @@ pub(crate) fn adaptive_avg_pool2d_backward(x: CubeTensor, out_grad: CubeTensor) 
         dtype_to_storage_type(output.dtype),
     )
     .unwrap_or_else(|e| pool_panic("adaptive_avg_pool2d_backward", &input, e));
+
+    permute_nhwc_to_nchw(output)
+}
+
+pub(crate) fn adaptive_avg_pool3d(input: CubeTensor, output_size: [usize; 3]) -> CubeTensor {
+    let [batch_size, channels, _, _, _] = input.meta.shape().dims();
+    let input = into_contiguous_aligned(permute_nchw_to_nhwc(input));
+    let output_shape = Shape::new([
+        batch_size,
+        output_size[0],
+        output_size[1],
+        output_size[2],
+        channels,
+    ]);
+    let output = empty_device_dtype(
+        input.client.clone(),
+        input.device.clone(),
+        output_shape,
+        input.dtype,
+    );
+    let mode = PoolMode::from(AdaptiveAvgPoolOptions::new(output_size));
+
+    pool3d(
+        &output.client,
+        input.clone().binding(),
+        output.clone().binding(),
+        mode,
+        dtype_to_storage_type(output.dtype),
+    )
+    .unwrap_or_else(|e| pool_panic("adaptive_avg_pool3d", &input, e));
+
+    permute_nhwc_to_nchw(output)
+}
+
+pub(crate) fn adaptive_avg_pool3d_backward(x: CubeTensor, out_grad: CubeTensor) -> CubeTensor {
+    let [batches, channels, depth, height, width] = x.meta.shape().dims();
+    let [_, _, out_depth, out_height, out_width] = out_grad.meta.shape().dims();
+    // Cubek only reads the input binding's shape during adaptive average pool 3d backward.
+    let input = permute_nchw_to_nhwc(x);
+    let out_grad = into_contiguous_aligned(permute_nchw_to_nhwc(out_grad));
+
+    let output_shape = Shape::new([batches, depth, height, width, channels]);
+    let output = empty_device_dtype(
+        input.client.clone(),
+        input.device.clone(),
+        output_shape,
+        input.dtype,
+    );
+    let mode = PoolMode::from(AdaptiveAvgPoolOptions::new([
+        out_depth, out_height, out_width,
+    ]));
+
+    pool3d_backward(
+        &output.client,
+        input.clone().binding(),
+        out_grad.binding(),
+        output.clone().binding(),
+        mode,
+        dtype_to_storage_type(output.dtype),
+    )
+    .unwrap_or_else(|e| pool_panic("adaptive_avg_pool3d_backward", &input, e));
 
     permute_nhwc_to_nchw(output)
 }

--- a/crates/burn-cubecl/src/ops/module.rs
+++ b/crates/burn-cubecl/src/ops/module.rs
@@ -292,15 +292,15 @@ impl ModuleOps<Self> for CubeBackend {
         kernel::pool::adaptive_avg_pool2d_backward(x, grad)
     }
 
-    fn adaptive_avg_pool3d(_x: FloatTensor<Self>, _output_size: [usize; 3]) -> FloatTensor<Self> {
-        todo!("CubeCL backend does not yet support adaptive_avg_pool3d.")
+    fn adaptive_avg_pool3d(x: FloatTensor<Self>, output_size: [usize; 3]) -> FloatTensor<Self> {
+        kernel::pool::adaptive_avg_pool3d(x, output_size)
     }
 
     fn adaptive_avg_pool3d_backward(
-        _x: FloatTensor<Self>,
-        _grad: FloatTensor<Self>,
+        x: FloatTensor<Self>,
+        grad: FloatTensor<Self>,
     ) -> FloatTensor<Self> {
-        todo!("CubeCL backend does not yet support adaptive_avg_pool3d_backward.")
+        kernel::pool::adaptive_avg_pool3d_backward(x, grad)
     }
 
     fn interpolate(


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` has been executed.
- [x] Made sure the book is up to date with changes in this PR.

> `cargo run-checks` tests with `Flex` by default. Use `cargo run-checks --backend <backend>` when
> targeting another backend. Consider running additional tests relevant to the crates changed.

No book change is required because AdaptiveAvgPool3d is already part of Burn's public tensor API; this PR adds CubeCL backend support for the existing operation.

### Related Issues/PRs

- Closes #5288.
- Upstream kernel support landed in [tracel-ai/cubek#521](https://github.com/tracel-ai/cubek/pull/521), merged as `e4d614ce87762b2d4439398a677cdff160cfd943`.
- Burn `main` currently pins Cubek revision `85d71f514b07ef773a67916d9d3e09ccca36ed7a`, which contains that merge.
- Cubek #521 replaced the auto-closed [tracel-ai/cubek#497](https://github.com/tracel-ai/cubek/pull/497).

### Changes

- Dispatch CubeCL AdaptiveAvgPool3d forward and backward operations to the native Cubek kernels.
- Convert Burn's NCDHW tensors to the channels-last layout expected by Cubek and restore NCDHW output layout.
- Pass a channels-last input view for backward shape metadata and materialize the output gradient in the layout required by Cubek.
- Extend forward and backward backend tests with exact reference values for dynamic, asymmetric, multichannel, divisible, output-one, and larger-output cases.

This does not change Burn's public API, fallback behavior for other backends, or quantization behavior.

### Testing

Passed on Burn commit `bbfd53bdebfda2960df0172c3ce22dfc313dc617`, based directly on `main` commit `d16f7ba2ed0d41408189384044cc886fb4c8f957`:

- macOS Metal, no fusion:
  `BURN_DEVICE=metal cargo test --release -p burn-backend-tests --no-default-features --features metal,std adaptive_avgpool3d -- --nocapture`
  — 32 passed
- macOS Metal with fusion:
  `BURN_DEVICE=metal cargo test --release -p burn-backend-tests --no-default-features --features metal,std,fusion adaptive_avgpool3d -- --nocapture`
  — 32 passed
- `cargo run-checks --backend metal`
- `cargo fmt --all -- --check`
- `cargo metadata --format-version 1 --locked --no-deps`
- `git diff origin/main...HEAD --check`

`cargo run-checks --backend metal` passed on this exact commit, including formatting, typos, audit, Clippy with warnings denied, no-std checks, and the complete Metal backend suites with and without fusion.

Two workspace-wide documentation commands are currently blocked locally by failures that reproduce unchanged on clean `main`:

- `cargo xtask doc build` fails on the existing unresolved `Vulkan` intra-doc link in `crates/burn-wgpu/src/lib.rs:79`.
- `cargo xtask doc tests` fails while linking 176 existing `burn-tensor` doctests on arm64 macOS because the LLVM AMDGPU initialization symbols are unavailable (`8 passed; 176 failed; 25 ignored`).

Before this rebase, the same pooling logic and test cases also passed targeted no-fusion and fusion runs on WSL2/Linux CUDA and native Windows CUDA — 32 passed in each configuration. The rebase only adapted the CubeCL function signatures to Burn's runtime-erased `CubeTensor` API and removed the temporary Cubek manifest override now that #521 is included by `main`.

Hosted [Burn CI on the exact rebased commit](https://github.com/tracel-ai/burn/actions/runs/33944520698) passed code quality, documentation, Windows backends/crates/examples, Linux stable and previous backends/crates/examples/no-std, and coverage upload. The macOS job failed only in the existing `tensor::int::ops::powi::should_support_powi_broadcast` test (`8 != 9` and `26 != 27`), after 1,673 other tests passed. The latest [CI run for the exact base commit](https://github.com/tracel-ai/burn/actions/runs/33912372235) fails the same test with the same mismatches, so this is a current-`main` baseline failure unrelated to this four-file PR.

No benchmarks were added or used, and this PR makes no performance claim.
