### PR TITLE
fix(burn-tch): preserve parent storage through permute/swap_dims

### DIFF
--- a/crates/burn-tch/src/ops/base.rs
+++ b/crates/burn-tch/src/ops/base.rs
@@ -650,15 +650,22 @@ impl TchOps {
     }
 
     pub fn swap_dims(tensor: TchTensor, dim1: usize, dim2: usize) -> TchTensor {
+        // `transpose` returns a view sharing the parent's buffer, so the child
+        // must inherit the parent's storage handle. `TchTensor::new` would mint a
+        // fresh `Arc` for still-shared memory and `can_mut()` would then approve
+        // an in-place op that writes over the parent.
+        let storage = tensor.storage.clone();
         let tensor = tensor.tensor.transpose(dim1 as i64, dim2 as i64);
-        TchTensor::new(tensor)
+        TchTensor::from_existing(tensor, storage)
     }
 
     pub fn permute(tensor: TchTensor, axes: &[usize]) -> TchTensor {
+        // A view over the parent's buffer — see `swap_dims`.
+        let storage = tensor.storage.clone();
         let tensor = tensor
             .tensor
             .permute(axes.iter().map(|x| *x as i64).collect::<Vec<_>>());
-        TchTensor::new(tensor)
+        TchTensor::from_existing(tensor, storage)
     }
 
     pub fn flip(tensor: TchTensor, axes: &[usize]) -> TchTensor {

--- a/crates/burn-tch/src/tensor.rs
+++ b/crates/burn-tch/src/tensor.rs
@@ -453,6 +453,7 @@ fn f_copy_data<T: TchElement>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ops::TchOps;
     use burn_backend::ops::FloatTensorOps;
     use burn_backend::{Backend, quantization::QuantScheme, read_sync};
 
@@ -553,6 +554,53 @@ mod tests {
         let out = read_sync(B::float_into_data(tensor_3)).unwrap();
 
         out.assert_eq(&TensorData::from([[3.0], [3.0]]), false);
+    }
+
+    #[test]
+    fn view_ops_preserve_parent_storage() {
+        // Regression for #5375: a view op must inherit its parent's storage
+        // handle, so `can_mut()` still sees the buffer as shared. Building the
+        // child with `TchTensor::new` mints a fresh `Arc` for aliased memory and
+        // `can_mut()` wrongly approves writing over the parent.
+        let device = Default::default();
+        let parent: TchTensor =
+            B::float_from_data(TensorData::from([[1.0, 2.0], [3.0, 4.0]]), &device);
+
+        for (name, view) in [
+            ("permute", TchOps::permute(parent.clone(), &[1, 0])),
+            ("swap_dims", TchOps::swap_dims(parent.clone(), 0, 1)),
+        ] {
+            assert!(
+                !view.can_mut(),
+                "{name} lost the parent alias: can_mut() is true for a view whose \
+                 parent is still alive, so an in-place op would write over shared \
+                 memory"
+            );
+        }
+
+        // `flip` is intentionally not in the list above: unlike NumPy's, libtorch's
+        // `flip` allocates instead of returning a view, so the child owns its
+        // buffer and `can_mut()` is correctly true.
+        let flipped = TchOps::flip(parent.clone(), &[0]);
+        assert!(flipped.can_mut(), "flip is expected to allocate, not alias");
+    }
+
+    #[test]
+    fn bool_and_over_permuted_alias_does_not_panic() {
+        // Regression for #5375: `x & xᵀ` is the attention-mask pattern burn-import
+        // generates. With the alias lost, `bool_and` takes libtorch's in-place
+        // `logical_and_` over overlapping memory and libtorch's overlap assert
+        // aborts the op.
+        use burn_backend::ops::BoolTensorOps;
+
+        let device = Default::default();
+        let mask = B::bool_from_data(TensorData::from([[true, false], [true, true]]), &device);
+        let permuted = TchOps::permute(mask.clone(), &[1, 0]);
+
+        let out = B::bool_and(mask, permuted);
+
+        let data = read_sync(B::bool_into_data(out)).unwrap();
+        data.assert_eq(&TensorData::from([[true, false], [false, true]]), false);
     }
 }
 


### PR DESCRIPTION
### Related Issues/PRs

Fixes #5375

### Changes

`permute` and `swap_dims` return views over the parent's buffer, but built the child with `TchTensor::new`, which mints a fresh storage `Arc` for memory that is still shared. `Storage::can_mut` counts references on that `Arc`, so it reported an aliased buffer as exclusively owned.

A binary op between a tensor and a view of itself then took libtorch's in-place path over overlapping memory and tripped libtorch's own overlap assert:

```
unsupported operation: some elements of the input tensor and the written-to
tensor refer to a single memory location. Please clone() the tensor before
performing the operation.
(assert_no_partial_overlap at ATen/MemoryOverlap.cpp:97)
```

The fix captures the parent's storage before the shadowing binding and builds the child with `TchTensor::from_existing`, which compares data pointers and shares the handle when the buffer is aliased:

```rust
pub fn permute(tensor: TchTensor, axes: &[usize]) -> TchTensor {
    let storage = tensor.storage.clone();
    let tensor = tensor
        .tensor
        .permute(axes.iter().map(|x| *x as i64).collect::<Vec<_>>());
    TchTensor::from_existing(tensor, storage)
}
```

**`flip` is deliberately not changed**, although the issue names it. Unlike NumPy's, libtorch's `flip` allocates rather than returning a view, so the child legitimately owns its buffer and `can_mut() == true` is correct there. I found this while writing the regression test — an early version asserted the aliasing invariant for all three ops and failed on `flip`; the assertion was wrong, not the code. The test now asserts the opposite for `flip` so the distinction is pinned rather than rediscovered later.

### Tests

Two regression tests in `crates/burn-tch/src/tensor.rs`, both failing before the change:

- `view_ops_preserve_parent_storage` — `can_mut()` must be false for a live `permute`/`swap_dims` view, and true for `flip`.
- `bool_and_over_permuted_alias_does_not_panic` — reproduces the reported crash directly via `x & xᵀ`, the attention-mask pattern `burn-import` generates.

### Validation beyond the unit tests

The workload that surfaced this is a `burn-import`-generated FastConformer streaming ASR encoder, whose generated code contains `tile1_out1.bool_and(tile1_out1.permute([0, 2, 1]))`. We had been carrying a hand patch on the generated file (a `Bool -> Int -> Bool` round trip to break the alias). With this change **the hand patch is removed** and the model runs unmodified:

| host | lane | result |
| --- | --- | --- |
| EPYC 7302P | `tch-cpu` f32 | 30/30 exact, 0 token edits vs onnxruntime |
| Ryzen 9 7950X3D | `tch-cpu` f32 | 30/30 exact, 0 token edits |
| RX 7900 XTX | `tch-rocm` f32 | 30/30 exact, 0 token edits |

"30/30 exact" is token-for-token equality against an onnxruntime reference implementation over a 30-clip corpus, so the change is exercised on both the CPU and HIP backends with no numerical difference.

### Checklist

- [x] Confirmed that `cargo run-checks` command has been executed. (passes, 05:32, no failures)
- [x] Made sure the book is up to date with changes in this PR. (no user-facing behaviour change; nothing in the book describes this internal invariant)

### Note

`crates/burn-tch`'s own unit tests were run against libtorch 2.11 with `LIBTORCH_BYPASS_VERSION_CHECK=1`, since that is the toolchain I have built locally; the aliasing logic is version-independent. On that setup the pre-existing `should_support_dtypes` test fails on `main` as well (it asserts I32 support, which differs between 2.9 and 2.11) — unrelated to this change, and it is unaffected by it.
