### PR TITLE
fix(deps): update h2 transitive dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4400,9 +4400,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
Fixes cargo audit:
```
Audit Rust Dependencies
  Command line: cargo audit -q --color always
  error: 1 vulnerability found!
  Crate:     h2
  Version:   0.4.15
  Title:     h2 unbounded empty DATA frames
  Date:      2026-08-17
  ID:        RUSTSEC-2026-0258
  URL:       https://rustsec.org/advisories/RUSTSEC-2026-0258
  Solution:  Upgrade to >=0.4.16
```