### PR TITLE
fix(tensor): preserve dtype in padding operations

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/float/ops/padding.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/padding.rs
@@ -1,5 +1,5 @@
 use super::*;
-use burn_tensor::{TensorData, ops::PadMode};
+use burn_tensor::{DType, TensorData, ops::PadMode};
 
 #[test]
 fn padding_constant_2d_test() {
@@ -456,6 +456,83 @@ fn padding_edge_batch_dim_3d_test() {
         [[1.0, 2.0]],
         [[3.0, 4.0]],
         [[3.0, 4.0]],
+    ]);
+    padded.into_data().assert_eq(&expected, false);
+}
+
+fn tensor_with_non_default_dtype() -> Option<TestTensor<2>> {
+    let device = burn_tensor::Device::default();
+    let default_dtype = <FloatElem as burn_tensor::Element>::dtype();
+    let dtype = if default_dtype == DType::F16 {
+        DType::F32
+    } else {
+        DType::F16
+    };
+
+    device.supports_dtype(dtype).then(|| {
+        TestTensor::<2>::from_data(
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
+            (&device, dtype),
+        )
+    })
+}
+
+#[test]
+fn padding_constant_preserves_non_default_dtype() {
+    let Some(tensor) = tensor_with_non_default_dtype() else {
+        return;
+    };
+    let dtype = tensor.dtype();
+
+    let padded = tensor.pad([(1, 1), (1, 1)], PadMode::Constant(0.0));
+
+    assert_eq!(padded.dtype(), dtype);
+    let expected = TensorData::from([
+        [0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 1.0, 2.0, 3.0, 0.0],
+        [0.0, 4.0, 5.0, 6.0, 0.0],
+        [0.0, 7.0, 8.0, 9.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0],
+    ]);
+    padded.into_data().assert_eq(&expected, false);
+}
+
+#[test]
+fn padding_reflect_preserves_non_default_dtype() {
+    let Some(tensor) = tensor_with_non_default_dtype() else {
+        return;
+    };
+    let dtype = tensor.dtype();
+
+    let padded = tensor.pad([(1, 1), (1, 1)], PadMode::Reflect);
+
+    assert_eq!(padded.dtype(), dtype);
+    let expected = TensorData::from([
+        [5.0, 4.0, 5.0, 6.0, 5.0],
+        [2.0, 1.0, 2.0, 3.0, 2.0],
+        [5.0, 4.0, 5.0, 6.0, 5.0],
+        [8.0, 7.0, 8.0, 9.0, 8.0],
+        [5.0, 4.0, 5.0, 6.0, 5.0],
+    ]);
+    padded.into_data().assert_eq(&expected, false);
+}
+
+#[test]
+fn padding_edge_preserves_non_default_dtype() {
+    let Some(tensor) = tensor_with_non_default_dtype() else {
+        return;
+    };
+    let dtype = tensor.dtype();
+
+    let padded = tensor.pad([(1, 1), (1, 1)], PadMode::Edge);
+
+    assert_eq!(padded.dtype(), dtype);
+    let expected = TensorData::from([
+        [1.0, 1.0, 2.0, 3.0, 3.0],
+        [1.0, 1.0, 2.0, 3.0, 3.0],
+        [4.0, 4.0, 5.0, 6.0, 6.0],
+        [7.0, 7.0, 8.0, 9.0, 9.0],
+        [7.0, 7.0, 8.0, 9.0, 9.0],
     ]);
     padded.into_data().assert_eq(&expected, false);
 }

--- a/crates/burn-tensor/src/tensor/api/pad.rs
+++ b/crates/burn-tensor/src/tensor/api/pad.rs
@@ -169,6 +169,7 @@ where
     E: ElementConversion,
 {
     let mut padded_dims: [usize; D] = tensor.dims();
+    let (device, dtype) = (tensor.device(), tensor.dtype());
 
     for (i, &(before, after)) in padding.iter().enumerate() {
         padded_dims[i] += before + after;
@@ -185,7 +186,7 @@ where
         .try_into()
         .unwrap();
 
-    let padded_tensor = Tensor::full(padded_dims, value, &tensor.device());
+    let padded_tensor = Tensor::full(padded_dims, value, (&device, dtype));
 
     padded_tensor.slice_assign(ranges, tensor)
 }
@@ -239,13 +240,14 @@ where
 {
     let dims = tensor.dims();
     let dim_size = dims[dim];
+    let (device, dtype) = (tensor.device(), tensor.dtype());
 
     // Calculate output dimensions
     let mut output_dims = dims;
     output_dims[dim] += pad_before + pad_after;
 
     // Create output tensor and place original in the center
-    let output = Tensor::zeros(output_dims, &tensor.device());
+    let output = Tensor::zeros(output_dims, (&device, dtype));
     let original_range = build_slice_ranges(output_dims, dim, pad_before, dim_size);
     let mut output = output.slice_assign(original_range, tensor.clone());
 
@@ -313,13 +315,14 @@ where
 {
     let dims = tensor.dims();
     let dim_size = dims[dim];
+    let (device, dtype) = (tensor.device(), tensor.dtype());
 
     // Calculate output dimensions
     let mut output_dims = dims;
     output_dims[dim] += pad_before + pad_after;
 
     // Create output tensor and place original in the center
-    let output = Tensor::zeros(output_dims, &tensor.device());
+    let output = Tensor::zeros(output_dims, (&device, dtype));
     let original_range = build_slice_ranges(output_dims, dim, pad_before, dim_size);
     let mut output = output.slice_assign(original_range, tensor.clone());
 


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

> `cargo run-checks` tests with `Flex` by default. Use `cargo run-checks --backend <backend>` when
> targeting another backend. Consider running additional tests relevant to the crates changed.

### Related Issues/PRs

Origin: [discord convo](https://discord.com/channels/1038839012602941528/1059209073784008835/1539466848867975269)

### Changes

Updated all pad operations to create the output with same dtype as input tensor

### Testing

Regression tests
