### PR TITLE
chore(deps): bump tracel-ai/github-actions from v9 to v11

### DIFF
--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@v7
       # --------------------------------------------------------------------------------
       - name: Install Rust
-        uses: tracel-ai/github-actions/install-rust@v9
+        uses: tracel-ai/github-actions/install-rust@v11
         with:
           rust-toolchain: ${{ matrix.toolchain }}
           enable-cache: false
@@ -115,7 +115,7 @@ jobs:
         uses: actions/checkout@v7
       # --------------------------------------------------------------------------------
       - name: Setup Rust
-        uses: tracel-ai/github-actions/install-rust@v9
+        uses: tracel-ai/github-actions/install-rust@v11
         with:
           rust-toolchain: ${{ matrix.toolchain }}
           enable-cache: false
@@ -153,7 +153,7 @@ jobs:
         uses: actions/checkout@v7
       # --------------------------------------------------------------------------------
       - name: Setup Rust
-        uses: tracel-ai/github-actions/install-rust@v9
+        uses: tracel-ai/github-actions/install-rust@v11
         with:
           rust-toolchain: ${{ matrix.toolchain }}
           enable-cache: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v7
       # --------------------------------------------------------------------------------
       - name: Setup Rust
-        uses: tracel-ai/github-actions/install-rust@v9
+        uses: tracel-ai/github-actions/install-rust@v11
         with:
           rust-toolchain: ${{ matrix.toolchain }}
           cache-key: ${{ matrix.rust }}-linux
@@ -91,7 +91,7 @@ jobs:
         run: cargo xtask check lint
       # --------------------------------------------------------------------------------
       - name: Typos
-        uses: tracel-ai/github-actions/check-typos@v9
+        uses: tracel-ai/github-actions/check-typos@v11
 
   documentation:
     runs-on: ubuntu-22.04
@@ -107,7 +107,7 @@ jobs:
         uses: actions/checkout@v7
       # --------------------------------------------------------------------------------
       - name: Setup Rust
-        uses: tracel-ai/github-actions/install-rust@v9
+        uses: tracel-ai/github-actions/install-rust@v11
         with:
           rust-toolchain: ${{ matrix.toolchain }}
           cache-key: ${{ matrix.rust }}-linux
@@ -142,7 +142,7 @@ jobs:
         uses: actions/checkout@v7
       # --------------------------------------------------------------------------------
       - name: Setup Rust
-        uses: tracel-ai/github-actions/install-rust@v9
+        uses: tracel-ai/github-actions/install-rust@v11
         with:
           rust-toolchain: ${{ matrix.toolchain }}
           # Keep caches isolated per shard to prevent race conditions or bloated sizes
@@ -212,7 +212,7 @@ jobs:
         uses: actions/checkout@v7
       # --------------------------------------------------------------------------------
       - name: Setup Rust
-        uses: tracel-ai/github-actions/install-rust@v9
+        uses: tracel-ai/github-actions/install-rust@v11
         with:
           rust-toolchain: ${{ matrix.toolchain }}
           cache-key: ${{ matrix.rust }}-linux-no-std
@@ -242,7 +242,7 @@ jobs:
         uses: actions/checkout@v7
       # --------------------------------------------------------------------------------
       - name: Setup Rust
-        uses: tracel-ai/github-actions/install-rust@v9
+        uses: tracel-ai/github-actions/install-rust@v11
         with:
           rust-toolchain: ${{ matrix.toolchain }}
           cache-key: ${{ matrix.rust }}-${{ matrix.ci_type }}-windows
@@ -266,7 +266,7 @@ jobs:
         uses: actions/checkout@v7
       # --------------------------------------------------------------------------------
       - name: Setup Rust
-        uses: tracel-ai/github-actions/install-rust@v9
+        uses: tracel-ai/github-actions/install-rust@v11
         with:
           rust-toolchain: ${{ matrix.toolchain }}
           cache-key: ${{ matrix.rust }}-macos

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v7
       # --------------------------------------------------------------------------------
       - name: Install Mesa
-        uses: tracel-ai/github-actions/install-mesa@v9
+        uses: tracel-ai/github-actions/install-mesa@v11
       # --------------------------------------------------------------------------------
       - name: Install valgrind
         run: |

--- a/.github/workflows/vulnerabilities.yml
+++ b/.github/workflows/vulnerabilities.yml
@@ -28,7 +28,7 @@ jobs:
           components: rustfmt, rust-src
       # --------------------------------------------------------------------------------
       - name: Install Mesa
-        uses: tracel-ai/github-actions/install-mesa@v9
+        uses: tracel-ai/github-actions/install-mesa@v11
       # --------------------------------------------------------------------------------
       - name: Install cargo-careful
         env:
@@ -55,7 +55,7 @@ jobs:
           components: rustfmt, rust-src
       # --------------------------------------------------------------------------------
       - name: Install Mesa
-        uses: tracel-ai/github-actions/install-mesa@v9
+        uses: tracel-ai/github-actions/install-mesa@v11
       # --------------------------------------------------------------------------------
       - name: Run AddressSanitizer
         env:
@@ -77,7 +77,7 @@ jobs:
           components: rustfmt, rust-src
       # --------------------------------------------------------------------------------
       - name: Install Mesa
-        uses: tracel-ai/github-actions/install-mesa@v9
+        uses: tracel-ai/github-actions/install-mesa@v11
       # --------------------------------------------------------------------------------
       - name: Run ThreadSanitizer
         env:
@@ -99,7 +99,7 @@ jobs:
           components: rustfmt, rust-src
       # --------------------------------------------------------------------------------
       - name: Install Mesa
-        uses: tracel-ai/github-actions/install-mesa@v9
+        uses: tracel-ai/github-actions/install-mesa@v11
       # --------------------------------------------------------------------------------
       - name: Run MemorySanitizer
         env:
@@ -121,7 +121,7 @@ jobs:
           components: rustfmt, rust-src
       # --------------------------------------------------------------------------------
       - name: Install Mesa
-        uses: tracel-ai/github-actions/install-mesa@v9
+        uses: tracel-ai/github-actions/install-mesa@v11
       # --------------------------------------------------------------------------------
       - name: Run SafeStack
         env:


### PR DESCRIPTION
Bumps the 16 shared-action pins in burn's CI workflows from `@v9` to `@v11`. `publish.yml` is deliberately untouched and is a separate PR.

## Why

v11 bounds every apt and curl call in `tracel-ai/github-actions` (tracel-ai/github-actions#5). Canonical's `azure.archive.ubuntu.com` intermittently stops answering from GitHub runners, apt fails over to `archive.ubuntu.com`, which accepts the connection and then delivers nothing. With nothing bounding it, the step runs to GitHub's 6 hour job ceiling.

burn lost 5 jobs that way over roughly 20 CI runs between 2026-08-17 and 2026-08-19, plus 3 more that stalled for 78 to 103 minutes. Note `v9` and `v10` were not moved when the fix landed, so burn gets nothing until this bump.

## What burn picks up beyond the timeout fix

For the three actions used here (`install-rust`, `install-mesa`, `check-typos`), v9 to v11 is:

- the apt and curl timeout bounds
- a new optional `rust-additional-targets` input, defaulting to empty, so a no-op unless passed
- the xtask install moved from two inline steps into `install-xtask-cli@v11`, which runs the same `cargo install tracel-xtask-cli`

cubecl has been running that last refactor on `@v10` since February.

## Potential issues

- **The timeout changes have not run on a GitHub runner before.** They were verified locally against a server that accepts a connection and then delivers nothing, but this PR is their first real execution. burn's Windows and macOS jobs are the first run anywhere for the `curl.exe` and macOS curl sites, since I had no way to exercise those.
- **If a mirror stalls during this run, the expected result is a red step in about 15 minutes**, not a hung job. That is the intended behavior, not a regression. A job that fails in `Install Rust` with an apt error is the fix working.
- `install-xtask-cli` still does an unpinned `cargo install tracel-xtask-cli`, unchanged from v9. Not introduced here, but it is the likely cause of the slow Windows `Setup Rust` steps (107 to 343s), which this PR does not address.
