### PR TITLE
Fix non-finite padding in Flex conv fast paths

### DIFF
--- a/crates/burn-flex/src/ops/conv.rs
+++ b/crates/burn-flex/src/ops/conv.rs
@@ -935,6 +935,7 @@ fn conv_plane_accumulate<
     pad_w: usize,
     dilation_h: usize,
     dilation_w: usize,
+    has_non_finite_weights: bool,
     oh_ranges: &[(usize, usize)],
     ow_ranges: &[(usize, usize)],
 ) {
@@ -948,6 +949,50 @@ fn conv_plane_accumulate<
             out_plane, in_plane, w_plane, kernel_h, kernel_w, in_w, out_w, stride_h, stride_w,
             pad_h, pad_w, dilation_h, dilation_w, oh_ranges, ow_ranges,
         );
+    }
+
+    // The vectorized paths skip padded positions. That is equivalent to
+    // multiplying materialized zeros only while every weight is finite; IEEE
+    // arithmetic requires `0 * inf` and `0 * NaN` to produce NaN. Preserve
+    // that result after the fast accumulation without changing its hot loops.
+    if has_non_finite_weights && (pad_h != 0 || pad_w != 0) {
+        propagate_non_finite_padding(out_plane, w_plane, kernel_w, out_w, oh_ranges, ow_ranges);
+    }
+}
+
+/// Mark outputs where a skipped padding term would multiply a non-finite weight.
+fn propagate_non_finite_padding<T: num_traits::Float + Copy>(
+    out_plane: &mut [T],
+    w_plane: &[T],
+    kernel_w: usize,
+    out_w: usize,
+    oh_ranges: &[(usize, usize)],
+    ow_ranges: &[(usize, usize)],
+) {
+    if out_plane.is_empty() || out_w == 0 {
+        return;
+    }
+
+    debug_assert_eq!(out_plane.len() % out_w, 0);
+    let out_h = out_plane.len() / out_w;
+    let nan = T::nan();
+
+    for (kh, &(oh_start, oh_end)) in oh_ranges.iter().enumerate() {
+        for (kw, &(ow_start, ow_end)) in ow_ranges.iter().enumerate() {
+            if w_plane[kh * kernel_w + kw].is_finite() {
+                continue;
+            }
+
+            for oh in 0..out_h {
+                let out_row = &mut out_plane[oh * out_w..(oh + 1) * out_w];
+                if oh < oh_start || oh >= oh_end {
+                    out_row.fill(nan);
+                } else {
+                    out_row[..ow_start].fill(nan);
+                    out_row[ow_end..].fill(nan);
+                }
+            }
+        }
     }
 }
 
@@ -1175,6 +1220,8 @@ where
 
     let x_data: &[T] = x.storage();
     let w_data: &[T] = weight.storage();
+    let has_non_finite_weights =
+        (pad_h != 0 || pad_w != 0) && w_data.iter().any(|value| !value.is_finite());
 
     let in_spatial = in_h * in_w;
     let out_spatial = out_h * out_w;
@@ -1211,6 +1258,7 @@ where
             pad_w,
             dilation_h,
             dilation_w,
+            has_non_finite_weights,
             &oh_ranges,
             &ow_ranges,
         );
@@ -1398,6 +1446,8 @@ where
 
     let x_data: &[T] = x.storage();
     let w_data: &[T] = weight.storage();
+    let has_non_finite_weights =
+        (pad_h != 0 || pad_w != 0) && w_data.iter().any(|value| !value.is_finite());
 
     let in_spatial = in_h * in_w;
     let out_spatial = out_h * out_w;
@@ -1437,6 +1487,7 @@ where
                 pad_w,
                 dilation_h,
                 dilation_w,
+                has_non_finite_weights,
                 &oh_ranges,
                 &ow_ranges,
             );
@@ -2674,6 +2725,7 @@ mod tests {
             /* pad_w */ 0,
             /* dilation_h */ 1,
             /* dilation_w */ 1,
+            /* has_non_finite_weights */ false,
             &oh_ranges,
             &ow_ranges,
         );
@@ -2948,5 +3000,56 @@ mod tests {
         // dilation 2, pad 2, stride 1: kernel position 0 iw = o*1 + 0 - 2 -> o >= 2.
         let (s, e) = valid_out_range(0, 2, 2, 1, 5, 5);
         assert_eq!((s, e), (2, 5));
+    }
+
+    fn conv2d_with_non_finite_weight(
+        channels_in: usize,
+        channels_out: usize,
+        groups: usize,
+    ) -> Vec<f32> {
+        let x_data: Vec<f32> = (0..channels_in * 16).map(|i| i as f32 + 1.0).collect();
+        let channels_per_group = channels_in / groups;
+        let mut w_data = vec![1.0; channels_out * channels_per_group * 9];
+        w_data[0] = f32::NEG_INFINITY;
+
+        let x = FlexTensor::from_data(TensorData::new(x_data, vec![1, channels_in, 4, 4]));
+        let weight = FlexTensor::from_data(TensorData::new(
+            w_data,
+            vec![channels_out, channels_per_group, 3, 3],
+        ));
+        let options = ConvOptions::new([1, 1], [1, 1], [1, 1], groups);
+
+        conv2d_f32(x, weight, None, &options)
+            .into_data()
+            .try_into_vec::<f32>()
+            .unwrap()
+    }
+
+    fn assert_non_finite_padding_pattern(output: &[f32]) {
+        for row in 0..4 {
+            for col in 0..4 {
+                let value = output[row * 4 + col];
+                if row == 0 || col == 0 {
+                    assert!(
+                        value.is_nan(),
+                        "expected NaN at ({row}, {col}), got {value}"
+                    );
+                } else {
+                    assert_eq!(value, f32::NEG_INFINITY);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_conv2d_padding_with_non_finite_weight_is_path_independent() {
+        // Zero padding participates in convolution just like materialized zeros, so
+        // multiplying it by a non-finite weight must produce NaN on every fast path.
+        assert_non_finite_padding_pattern(&conv2d_with_non_finite_weight(4, 1, 1));
+        assert_non_finite_padding_pattern(&conv2d_with_non_finite_weight(5, 1, 1));
+
+        let depthwise = conv2d_with_non_finite_weight(2, 2, 2);
+        assert_non_finite_padding_pattern(&depthwise[..16]);
+        assert!(depthwise[16..].iter().all(|value| value.is_finite()));
     }
 }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Closes #5385.

### Changes

Flex's depthwise and small-channel convolution paths skip padded input positions, while the generic im2col path materializes them as zeros. Those operations are equivalent for finite weights, but not for non-finite weights: IEEE arithmetic requires `0 * inf` and `0 * NaN` to produce NaN. As a result, changing only the channel count could change padded outputs between finite/infinite values and NaN.

This change detects non-finite weights once per padded fast-path convolution and marks only the output positions where an omitted zero-padding term would participate. The existing vectorized accumulation remains unchanged for finite weights, and convolutions without padding avoid the scan entirely.

The regression covers the small-channel, generic, and depthwise dispatch paths. It also verifies that a finite depthwise channel is not affected by a non-finite weight in another channel.

### Testing

- `cargo test -p burn-flex` (391 passed)
- `cargo test -p burn-flex --no-default-features --features std` (331 passed)
- `BURN_DEVICE=flex cargo test -p burn-backend-tests --no-default-features --features flex,std --test tensor conv2d` (19 passed)
- `cargo clippy -p burn-flex --all-targets -- -D warnings`
- `cargo run-checks`
