### PR TITLE
fix(fusion): reject a padded reference layout

### DIFF
--- a/crates/burn-cubecl-fusion/src/engine/launch/output.rs
+++ b/crates/burn-cubecl-fusion/src/engine/launch/output.rs
@@ -18,7 +18,7 @@ use burn_ir::{TensorId, TensorIr};
 use burn_std::Shape;
 use burn_std::{
     Strides,
-    tensor::{ReshapeAction, contiguous_strides, is_contiguous, reshape_action},
+    tensor::{ReshapeAction, contiguous_strides, is_contiguous, is_dense, reshape_action},
 };
 use cubecl::{Runtime, client::ComputeClient};
 
@@ -269,7 +269,16 @@ impl<'a, R: Runtime> OutputPlanner<'a, R> {
                     };
 
                     match block.settings.ref_layout {
-                        RefLayoutSetting::Any => set_ref_as_concrete(block_plan),
+                        RefLayoutSetting::Any => {
+                            // A padded reference would make the kernel walk a prefix of the
+                            // buffer: the launch is sized from the logical element count while a
+                            // position indexes the buffer.
+                            if is_dense(&reference.global_ir.shape, &reference.handle.strides) {
+                                set_ref_as_concrete(block_plan)
+                            } else {
+                                set_ref_as_virtual(block_plan)
+                            }
+                        }
                         RefLayoutSetting::SameAsBlock { .. } => {
                             // Skip set ref.
                         }

--- a/crates/burn-std/src/tensor/mod.rs
+++ b/crates/burn-std/src/tensor/mod.rs
@@ -47,16 +47,27 @@ pub fn is_contiguous(shape: &[usize], strides: &[usize]) -> bool {
 /// dense, a tensor whose rows were padded by a pitched allocator is not. Dimensions of size one
 /// carry no information about the layout and are ignored.
 pub fn is_dense(shape: &[usize], strides: &[usize]) -> bool {
-    let mut remaining = shape.iter().filter(|&&dim| dim > 1).count();
+    if shape.len() != strides.len() {
+        return false;
+    }
+
+    let mut dims: SmallVec<[(usize, usize); 5]> = shape
+        .iter()
+        .zip(strides)
+        .filter(|&(&dim, _)| dim > 1)
+        .map(|(&dim, &stride)| (dim, stride))
+        .collect();
+
+    dims.sort_unstable_by_key(|&(_, stride)| stride);
+
     let mut expected = 1;
 
-    while remaining > 0 {
-        let Some(dim) = (0..shape.len()).find(|&i| shape[i] > 1 && strides[i] == expected) else {
+    for (dim, stride) in dims {
+        if stride != expected {
             return false;
-        };
+        }
 
-        expected *= shape[dim];
-        remaining -= 1;
+        expected *= dim;
     }
 
     true
@@ -369,6 +380,11 @@ mod tests {
     fn test_is_dense_unit_dims_carry_no_layout() {
         // A unit dim can hold any stride, a broadcast 0 included, without leaving a gap.
         assert!(is_dense(&[1, 4, 1], &[0, 1, 7]));
+    }
+
+    #[test]
+    fn test_is_dense_rank_mismatch() {
+        assert!(!is_dense(&[2, 3], &[1]));
     }
 
     #[test]

--- a/crates/burn-std/src/tensor/mod.rs
+++ b/crates/burn-std/src/tensor/mod.rs
@@ -41,6 +41,27 @@ pub fn is_contiguous(shape: &[usize], strides: &[usize]) -> bool {
     true
 }
 
+/// Check if the current tensor fills its buffer without gaps.
+///
+/// Unlike [is_contiguous], this holds for any ordering of the dimensions: a permuted tensor is
+/// dense, a tensor whose rows were padded by a pitched allocator is not. Dimensions of size one
+/// carry no information about the layout and are ignored.
+pub fn is_dense(shape: &[usize], strides: &[usize]) -> bool {
+    let mut remaining = shape.iter().filter(|&&dim| dim > 1).count();
+    let mut expected = 1;
+
+    while remaining > 0 {
+        let Some(dim) = (0..shape.len()).find(|&i| shape[i] > 1 && strides[i] == expected) else {
+            return false;
+        };
+
+        expected *= shape[dim];
+        remaining -= 1;
+    }
+
+    true
+}
+
 /// Computes the strides for a contiguous tensor with the given shape.
 ///
 /// In a contiguous row-major tensor, the stride for each dimension
@@ -326,6 +347,28 @@ mod tests {
         // parts; the leading real dim keeps its stride.
         let strides = split_strides(&[26, 16], &[1, 0], &[26, 4, 4]);
         assert_eq!(strides.as_ref(), &[1, 0, 0]);
+    }
+
+    #[test]
+    fn test_is_dense_contiguous() {
+        assert!(is_dense(&[2, 2, 2, 2], &[8, 4, 2, 1]));
+    }
+
+    #[test]
+    fn test_is_dense_permuted() {
+        assert!(is_dense(&[2, 2, 2, 2], &[8, 1, 4, 2]));
+    }
+
+    #[test]
+    fn test_is_dense_pitched_row() {
+        assert!(!is_dense(&[2, 2, 2, 2], &[16, 8, 4, 1]));
+        assert!(!is_dense(&[1, 8, 6, 6], &[384, 48, 8, 1]));
+    }
+
+    #[test]
+    fn test_is_dense_unit_dims_carry_no_layout() {
+        // A unit dim can hold any stride, a broadcast 0 included, without leaving a gap.
+        assert!(is_dense(&[1, 4, 1], &[0, 1, 7]));
     }
 
     #[test]


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ ] Confirmed that `cargo run-checks` has been executed.
- [x] Made sure the book is up to date with changes in this PR.

> `cargo run-checks` has not been run on this branch. The targeted testing that was
> run is listed under Testing below, including the CUDA suite from the issue, which
> is the one that reproduces the bug.

### Related Issues/PRs

Closes #5388.

### Changes

CUDA pitches its allocations, padding rows so they align. A tensor backed by such a
buffer has strides that leave gaps, and the fusion launcher was not accounting for
that when it picked a block's reference layout.

Under `RefLayoutSetting::Any`, a candidate input became the block's *concrete*
reference unconditionally, adopting its strides as the layout every other tensor in
the block is indexed against. A reference tagged `IsRef` / `SameAsRef` has its buffer
offset read straight off the flat thread position, while the launch is sized from the
logical element count. Those two agree only when the reference fills its buffer
without gaps. Given a padded reference they disagree, and the kernel walks a prefix of
the buffer, so elements past the first row of padding are read and written at the
wrong offsets.

The fix adopts a candidate as a concrete reference only when its layout is gap-free,
and otherwise falls back to a virtual contiguous reference, which indexes every tensor
through full stride multiplication and is correct regardless of padding.

The new predicate is `is_dense` rather than the existing `is_contiguous` on purpose.
The kernel recovers coordinates from a position with `pos / ref_strides[i] % shape[i]`,
a mixed-radix decomposition that is valid for *any* permutation of contiguous strides,
not just row-major ones. NHWC relayout deliberately produces dense-but-permuted
strides, so gating on `is_contiguous` would have rejected the layouts this feature
exists to produce and sent them all down the slow path. `is_dense` also rejects
broadcast dimensions (stride 0 on a dimension larger than 1), which could previously
be adopted as a concrete reference here.

### Testing

Run on an RTX 4070 Ti SUPER:

```
cargo test -p burn-backend-tests --no-default-features --features "cuda,fusion,std" --test tensor fusion::nhwc_relayout
```

All 7 tests pass. Six of them fail on `main`, which is the set reported in #5388.

Also run:

- `cargo test -p burn-std --lib tensor::tests`, covering `is_dense` against contiguous,
  permuted, pitched-row, unit-dimension and rank-mismatch inputs.
- `cargo clippy -p burn-std --lib` and `cargo fmt -p burn-std -- --check`, both clean.

`is_dense` returns `false` for a shape and strides of differing length rather than
indexing past the end of the shorter slice. That routes the caller to the virtual
reference layout, which stays correct for any input, where truncating to the shorter
slice would have reported a malformed layout as dense and picked the concrete path.
