### PR TITLE
chore: fix clippy lints

### DIFF
--- a/crates/burn-ndarray/src/ops/simd/binary_elemwise.rs
+++ b/crates/burn-ndarray/src/ops/simd/binary_elemwise.rs
@@ -390,9 +390,9 @@ unsafe fn binary_scalar_slice_inplace<
     for elem in head.iter_mut().chain(tail) {
         *elem = cast(Op::apply(*elem, rhs));
     }
-    let mut chunks = main.chunks_exact_mut(8);
+    let chunks = main.as_chunks_mut::<8>();
     let rhs = Op::splat::<S>(rhs);
-    for elem in chunks.by_ref() {
+    for elem in chunks.0.iter_mut() {
         seq!(N in 0..8 {
             // Load a full vector from the aligned portion of the buffer.
             // SAFETY: `align_to_mut` guarantees we're aligned to `T::Vector`'s size, and there is
@@ -405,7 +405,7 @@ unsafe fn binary_scalar_slice_inplace<
         });
     }
 
-    for elem in chunks.into_remainder() {
+    for elem in chunks.1 {
         // Load a full vector from the aligned portion of the buffer.
         // SAFETY: `align_to_mut` guarantees we're aligned to `T::Vector`'s size, and there is
         // always a full vector in bounds.

--- a/crates/burn-ndarray/src/ops/simd/cmp.rs
+++ b/crates/burn-ndarray/src/ops/simd/cmp.rs
@@ -344,9 +344,9 @@ mod elemwise {
         for elem in head.iter_mut().chain(tail) {
             *elem = cast(Op::apply(*elem, rhs));
         }
-        let mut chunks = main.chunks_exact_mut(8);
+        let chunks = main.as_chunks_mut::<8>();
         let rhs = rhs.splat::<S>();
-        for elem in chunks.by_ref() {
+        for elem in chunks.0.iter_mut() {
             seq!(N in 0..8 {
                 // Load a full vector from the aligned portion of the buffer.
                 // SAFETY: `align_to_mut` guarantees we're aligned to `T::Vector`'s size, and there is
@@ -359,7 +359,7 @@ mod elemwise {
             });
         }
 
-        for elem in chunks.into_remainder() {
+        for elem in chunks.1 {
             // Load a full vector from the aligned portion of the buffer.
             // SAFETY: `align_to_mut` guarantees we're aligned to `T::Vector`'s size, and there is
             // always a full vector in bounds.

--- a/crates/burn-ndarray/src/ops/simd/unary.rs
+++ b/crates/burn-ndarray/src/ops/simd/unary.rs
@@ -206,8 +206,8 @@ unsafe fn unary_slice_inplace<
     for elem in head.iter_mut().chain(tail) {
         *elem = cast(Op::apply(*elem));
     }
-    let mut chunks = main.chunks_exact_mut(8);
-    for elem in chunks.by_ref() {
+    let chunks = main.as_chunks_mut::<8>();
+    for elem in chunks.0.iter_mut() {
         seq!(N in 0..8 {
             // Load a full vector from the aligned portion of the buffer.
             // SAFETY: `align_to_mut` guarantees we're aligned to `T::Vector`'s size, and there is
@@ -220,7 +220,7 @@ unsafe fn unary_slice_inplace<
         });
     }
 
-    for elem in chunks.into_remainder() {
+    for elem in chunks.1 {
         // Load a full vector from the aligned portion of the buffer.
         // SAFETY: `align_to_mut` guarantees we're aligned to `T::Vector`'s size, and there is
         // always a full vector in bounds.

--- a/crates/burn-pack/tests/common/mod.rs
+++ b/crates/burn-pack/tests/common/mod.rs
@@ -38,7 +38,9 @@ pub fn raw_tensor(
 pub fn read_f32(tensor: &Tensor) -> Vec<f32> {
     let slice: &[u8] = &tensor.bytes;
     slice
-        .chunks_exact(4)
+        .as_chunks::<4>()
+        .0
+        .iter()
         .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
         .collect()
 }

--- a/crates/burn-pack/tests/round_trip.rs
+++ b/crates/burn-pack/tests/round_trip.rs
@@ -220,7 +220,9 @@ fn read_single_tensor_data_by_name() {
     let reader = Reader::from_bytes(packed).unwrap();
     let raw = reader.tensor_data("a").unwrap();
     let values: Vec<f32> = raw
-        .chunks_exact(4)
+        .as_chunks::<4>()
+        .0
+        .iter()
         .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
         .collect();
     assert_eq!(values, vec![1.0, 2.0]);

--- a/crates/burn-std/src/tensor/quantization.rs
+++ b/crates/burn-std/src/tensor/quantization.rs
@@ -397,15 +397,21 @@ pub fn scale_size(dtype: ScaleDtype) -> usize {
 fn decode_scales(bytes: &[u8], dtype: ScaleDtype) -> Vec<f32> {
     match dtype {
         ScaleDtype::F32 => bytes
-            .chunks_exact(4)
+            .as_chunks::<4>()
+            .0
+            .iter()
             .map(|c| f32::from_ne_bytes([c[0], c[1], c[2], c[3]]))
             .collect(),
         ScaleDtype::F16 => bytes
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|c| crate::f16::from_ne_bytes([c[0], c[1]]).to_f32())
             .collect(),
         ScaleDtype::BF16 => bytes
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|c| crate::bf16::from_ne_bytes([c[0], c[1]]).to_f32())
             .collect(),
         ScaleDtype::UE4M3 => bytes.iter().map(|b| e4m3::from_bits(*b).to_f32()).collect(),


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

> `cargo run-checks` tests with `Flex` by default. Use `cargo run-checks --backend <backend>` when
> targeting another backend. Consider running additional tests relevant to the crates changed.