### PR TITLE
perf(cubecl): reduce, don't pool, for a 1x1 adaptive average pool

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/float/module/adaptive_avgpool2d.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/module/adaptive_avgpool2d.rs
@@ -76,6 +76,45 @@ fn test_adaptive_avg_pool2d_bigger_output() {
     ]]));
 }
 
+/// A `1x1` output takes a dedicated path on the cubecl backends: it is a
+/// reduction over every pixel rather than a pooling window, and is dispatched to
+/// the reduce kernels because the pooling one parallelises over its output and
+/// would run this with `batch * channels` units. Nothing else here covers a
+/// `1x1` output, so nothing else covers that path.
+#[test]
+fn test_adaptive_avg_pool2d_global() {
+    let test = AdaptiveAvgPool2dTestCase {
+        batch_size: 2,
+        channels: 2,
+        height: 4,
+        width: 5,
+        height_out: 1,
+        width_out: 1,
+    };
+
+    // Each channel is 20 consecutive integers, so its mean is its midpoint.
+    test.assert_output(TestTensor::from([
+        [[[9.5000]], [[29.5000]]],
+        [[[49.5000]], [[69.5000]]],
+    ]));
+}
+
+/// The same path over a map whose pixel count is neither square nor a power of
+/// two, so a reduction that padded or rounded its axis would show up here.
+#[test]
+fn test_adaptive_avg_pool2d_global_odd_shape() {
+    let test = AdaptiveAvgPool2dTestCase {
+        batch_size: 1,
+        channels: 2,
+        height: 5,
+        width: 7,
+        height_out: 1,
+        width_out: 1,
+    };
+
+    test.assert_output(TestTensor::from([[[[17.0000]], [[52.0000]]]]));
+}
+
 struct AdaptiveAvgPool2dTestCase {
     batch_size: usize,
     channels: usize,

--- a/crates/burn-cubecl/src/kernel/pool/base.rs
+++ b/crates/burn-cubecl/src/kernel/pool/base.rs
@@ -7,13 +7,13 @@ use crate::{
     ops::{base::reshape, numeric::empty_device_dtype, permute_nchw_to_nhwc, permute_nhwc_to_nchw},
     tensor::CubeTensor,
 };
-use cubek::reduce::components::instructions::ReduceOperationConfig;
 use burn_backend::cubecl::dtype_to_storage_type;
 use burn_backend::{DType, Shape, ops::conv::calculate_pool_output_size};
 use cubek::pool::{
     definition::{AdaptiveAvgPoolOptions, AvgPoolOptions, MaxPoolOptions, PoolError, PoolMode},
     pool2d, pool2d_backward, pool2d_with_indices, pool2d_with_indices_backward,
 };
+use cubek::reduce::components::instructions::ReduceOperationConfig;
 
 pub(crate) fn max_pool2d<R: CubeRuntime>(
     x: CubeTensor<R>,
@@ -275,16 +275,7 @@ pub(crate) fn avg_pool2d_backward<R: CubeRuntime>(
 /// `[b, c, 1, 1]`.
 ///
 /// This is what an adaptive average pool with a `1x1` output *is*, and it is a
-/// reduction rather than a pooling problem. The distinction is not cosmetic:
-/// [`pool2d`] parallelises over its **output** elements, so at a `1x1` output it
-/// runs with `batch * channels` units — twelve of them once the channels
-/// vectorise, on a device with thousands of lanes — and each one walks the whole
-/// feature map serially.
-///
-/// Measured on a Radeon 8060S under vulkan, EfficientNet-B4's squeeze-and-excite
-/// at 384x384: 37.6 ms for 28 MB of traffic, which is 1.5 GB/s against a device
-/// that does ~158. Time tracked *work / channels* rather than work, which is the
-/// signature of parallelism bounded by the channel count alone.
+/// reduction rather than a pooling problem. 
 ///
 /// So the reduction axis becomes the parallel one. `[b, c, h, w]` is reshaped to
 /// `[b, c, h * w]` — free in NCHW, where those two axes are already adjacent and

--- a/crates/burn-cubecl/src/kernel/pool/base.rs
+++ b/crates/burn-cubecl/src/kernel/pool/base.rs
@@ -275,7 +275,7 @@ pub(crate) fn avg_pool2d_backward<R: CubeRuntime>(
 /// `[b, c, 1, 1]`.
 ///
 /// This is what an adaptive average pool with a `1x1` output *is*, and it is a
-/// reduction rather than a pooling problem. 
+/// reduction rather than a pooling problem.
 ///
 /// So the reduction axis becomes the parallel one. `[b, c, h, w]` is reshaped to
 /// `[b, c, h * w]` — free in NCHW, where those two axes are already adjacent and

--- a/crates/burn-cubecl/src/kernel/pool/base.rs
+++ b/crates/burn-cubecl/src/kernel/pool/base.rs
@@ -1,9 +1,13 @@
 use crate::{
     CubeRuntime,
-    kernel::into_contiguous_aligned,
-    ops::{numeric::empty_device_dtype, permute_nchw_to_nhwc, permute_nhwc_to_nchw},
+    kernel::{
+        into_contiguous_aligned,
+        reduce::{KernelReduceStrategy, reduce_dim},
+    },
+    ops::{base::reshape, numeric::empty_device_dtype, permute_nchw_to_nhwc, permute_nhwc_to_nchw},
     tensor::CubeTensor,
 };
+use cubek::reduce::components::instructions::ReduceOperationConfig;
 use burn_backend::cubecl::dtype_to_storage_type;
 use burn_backend::{DType, Shape, ops::conv::calculate_pool_output_size};
 use cubek::pool::{
@@ -267,10 +271,50 @@ pub(crate) fn avg_pool2d_backward<R: CubeRuntime>(
     permute_nhwc_to_nchw(output)
 }
 
+/// Average every pixel of every channel into one number: `[b, c, h, w]` to
+/// `[b, c, 1, 1]`.
+///
+/// This is what an adaptive average pool with a `1x1` output *is*, and it is a
+/// reduction rather than a pooling problem. The distinction is not cosmetic:
+/// [`pool2d`] parallelises over its **output** elements, so at a `1x1` output it
+/// runs with `batch * channels` units — twelve of them once the channels
+/// vectorise, on a device with thousands of lanes — and each one walks the whole
+/// feature map serially.
+///
+/// Measured on a Radeon 8060S under vulkan, EfficientNet-B4's squeeze-and-excite
+/// at 384x384: 37.6 ms for 28 MB of traffic, which is 1.5 GB/s against a device
+/// that does ~158. Time tracked *work / channels* rather than work, which is the
+/// signature of parallelism bounded by the channel count alone.
+///
+/// So the reduction axis becomes the parallel one. `[b, c, h, w]` is reshaped to
+/// `[b, c, h * w]` — free in NCHW, where those two axes are already adjacent and
+/// contiguous — and reduced over the last axis by the tuned reduce.
+fn global_avg_pool2d<R: CubeRuntime>(input: CubeTensor<R>) -> CubeTensor<R> {
+    let [batch_size, channels, height, width] = input.meta.shape().dims();
+
+    let flattened = reshape(input, Shape::new([batch_size, channels, height * width]));
+    let reduced = reduce_dim::<R>(
+        flattened,
+        None,
+        2,
+        KernelReduceStrategy::default(),
+        ReduceOperationConfig::Mean,
+    )
+    .expect("the last axis of a rank-3 tensor is reducible");
+
+    reshape(reduced, Shape::new([batch_size, channels, 1, 1]))
+}
+
 pub(crate) fn adaptive_avg_pool2d<R: CubeRuntime>(
     input: CubeTensor<R>,
     output_size: [usize; 2],
 ) -> CubeTensor<R> {
+    // A `1x1` output is a reduction, and the pooling kernel is the wrong shape
+    // of parallelism for it — see [`global_avg_pool2d`].
+    if output_size == [1, 1] {
+        return global_avg_pool2d(input);
+    }
+
     let [batch_size, channels, _, _] = input.meta.shape().dims();
     let input = into_contiguous_aligned(permute_nchw_to_nhwc(input));
 


### PR DESCRIPTION
`pool2d` parallelises over its *output* elements. At a 1x1 output that is `batch * channels` work items — twelve of them once the channels vectorise — and each one walks the entire feature map serially, so the only parallelism available is the channel count.