### PR TITLE
fix(optim): keep tensor data in optimizer records

### DIFF
--- a/crates/burn-optim/src/optim/lbfgs.rs
+++ b/crates/burn-optim/src/optim/lbfgs.rs
@@ -3,12 +3,12 @@
 use burn_core as burn;
 
 use super::GradientsParams;
-use crate::{LearningRate, OptimizerRecord};
+use crate::{LearningRate, OptimizerRecord, RecordTensor};
 use crate::{RecordState, StateSink, StateSource};
 use burn::config::Config;
 use burn::module::{AutodiffModule, Module, ModuleMapper, ModuleVisitor, Param};
 use burn::store::RecordError;
-use burn::tensor::{Bytes, Device, Tensor, TensorData};
+use burn::tensor::{Bytes, Device, Tensor};
 use serde::{Deserialize, Serialize};
 
 use alloc::vec;
@@ -541,8 +541,10 @@ impl LBFGS {
         let tensors = sink
             .tensors
             .into_iter()
-            .map(|(name, data)| {
-                burn_pack::Tensor::new(name, data.dtype, data.shape, None, data.bytes)
+            .map(|(name, data)| RecordTensor {
+                name,
+                param_id: None,
+                data,
             })
             .collect();
         let scalars = sink.scalars.into_iter().collect();
@@ -562,9 +564,7 @@ impl LBFGS {
         let device = Device::default();
         let mut source = StateSource::new(record.scalars);
         for tensor in record.tensors {
-            let (name, dtype, shape, _, bytes) =
-                tensor.into_parts().expect("record tensors are resident");
-            source.insert_tensor(name, TensorData::from_bytes(bytes, shape, dtype));
+            source.insert_tensor(tensor.name, tensor.data);
         }
         if let Some(state) = LBFGSState::state_unflatten("", &mut source, &device) {
             self.state = state;

--- a/crates/burn-optim/src/optim/module/module_optimizer.rs
+++ b/crates/burn-optim/src/optim/module/module_optimizer.rs
@@ -4,8 +4,8 @@ use burn_core::module::ParamGroup;
 use super::Optimizer;
 use crate::lr_scheduler::module_lr_scheduler::ModuleLearningRate;
 use crate::{
-    DynOptimizer, DynState, MultiGradientsParams, OptimizerRecord, StateSink, StateSource,
-    grad_clipping::GradientClipping, optim::GradientsParams, optim::state::join_path,
+    DynOptimizer, DynState, MultiGradientsParams, OptimizerRecord, RecordTensor, StateSink,
+    StateSource, grad_clipping::GradientClipping, optim::GradientsParams, optim::state::join_path,
 };
 
 use alloc::collections::BTreeMap;
@@ -14,7 +14,7 @@ use alloc::sync::Arc;
 use alloc::vec::Vec;
 use burn::module::{AutodiffModule, ModuleMapper, Param, ParamId};
 use burn::store::RecordError;
-use burn::tensor::{Bytes, Device, Tensor, TensorData};
+use burn::tensor::{Bytes, Device, Tensor};
 use hashbrown::HashMap;
 
 /// Scalar key (per parameter) under which the parameter's state rank is persisted.
@@ -220,13 +220,11 @@ impl ModuleOptimizer {
             }
 
             for (name, data) in sink.tensors {
-                tensors.push(burn_pack::Tensor::new(
+                tensors.push(RecordTensor {
                     name,
-                    data.dtype,
-                    data.shape,
-                    Some(id.val()),
-                    data.bytes,
-                ));
+                    param_id: Some(id.val()),
+                    data,
+                });
             }
             for (name, value) in sink.scalars {
                 scalars.insert(name, value);
@@ -271,12 +269,12 @@ impl ModuleOptimizer {
         let mut source = StateSource::new(record.scalars);
 
         for tensor in record.tensors {
-            let id = tensor
-                .param_id
-                .expect("Optimizer record tensors should carry a parameter id.");
-            let (name, dtype, shape, _, bytes) =
-                tensor.into_parts().expect("record tensors are resident");
-            let data = TensorData::from_bytes(bytes, shape, dtype);
+            let RecordTensor {
+                name,
+                param_id,
+                data,
+            } = tensor;
+            let id = param_id.expect("Optimizer record tensors should carry a parameter id.");
             // Fall back to inferring rank from a tensor shape if no `__rank` scalar was present.
             ranks.entry(id).or_insert(data.shape.len());
             source.insert_tensor(name, data);

--- a/crates/burn-optim/src/optim/module/record/mod.rs
+++ b/crates/burn-optim/src/optim/module/record/mod.rs
@@ -3,10 +3,17 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 use burn::store::RecordError;
-use burn::tensor::Bytes;
+use burn::tensor::{Bytes, TensorData};
 use burn_core as burn;
 
 use burn_pack::{Reader, Scalar, Writer};
+
+/// A single optimizer state tensor and its optional originating parameter id.
+pub(crate) struct RecordTensor {
+    pub(crate) name: String,
+    pub(crate) param_id: Option<u64>,
+    pub(crate) data: TensorData,
+}
 
 /// A serialized optimizer state, stored in the [burnpack](burn_pack) format.
 ///
@@ -20,7 +27,7 @@ use burn_pack::{Reader, Scalar, Writer};
 /// [`load_record`](crate::optim::ModuleOptimizer::load_record).
 #[derive(Default)]
 pub struct OptimizerRecord {
-    pub(crate) tensors: Vec<burn_pack::Tensor>,
+    pub(crate) tensors: Vec<RecordTensor>,
     pub(crate) scalars: BTreeMap<String, Scalar>,
     pub(crate) paths: BTreeMap<String, String>,
 }
@@ -69,7 +76,20 @@ impl OptimizerRecord {
     }
 
     fn into_writer(self) -> Writer {
-        let mut writer = Writer::new(self.tensors);
+        let tensors = self
+            .tensors
+            .into_iter()
+            .map(|tensor| {
+                burn_pack::Tensor::new(
+                    tensor.name,
+                    tensor.data.dtype,
+                    tensor.data.shape,
+                    tensor.param_id,
+                    tensor.data.bytes,
+                )
+            })
+            .collect();
+        let mut writer = Writer::new(tensors);
         for (key, value) in &self.scalars {
             writer = writer.with_scalar(key, *value);
         }
@@ -82,11 +102,76 @@ impl OptimizerRecord {
     fn from_reader(reader: Reader) -> Result<Self, RecordError> {
         let scalars = reader.scalars().clone();
         let paths = reader.metadata().clone();
-        let tensors = reader.into_tensors()?;
+        let tensors = reader
+            .into_tensors()?
+            .into_iter()
+            .map(|tensor| {
+                let (name, dtype, shape, param_id, bytes) = tensor.into_parts()?;
+                Ok(RecordTensor {
+                    name,
+                    param_id,
+                    data: TensorData::from_bytes(bytes, shape, dtype),
+                })
+            })
+            .collect::<Result<Vec<_>, RecordError>>()?;
         Ok(Self {
             tensors,
             scalars,
             paths,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use burn::tensor::TensorData;
+
+    fn record(data: TensorData) -> OptimizerRecord {
+        OptimizerRecord {
+            tensors: alloc::vec![RecordTensor {
+                name: "42.moment".into(),
+                param_id: Some(42),
+                data,
+            }],
+            scalars: Default::default(),
+            paths: Default::default(),
+        }
+    }
+
+    fn assert_record(decoded: &OptimizerRecord, expected: &TensorData) {
+        let tensor = &decoded.tensors[0];
+
+        assert_eq!(tensor.name, "42.moment");
+        assert_eq!(tensor.param_id, Some(42));
+        assert_eq!(tensor.data.dtype, expected.dtype);
+        assert_eq!(tensor.data.shape, expected.shape);
+        assert_eq!(&tensor.data.bytes[..], &expected.bytes[..]);
+    }
+
+    #[test]
+    fn tensor_data_stays_internal_across_burnpack_boundary() {
+        let expected = TensorData::from([1.0_f32, 2.0, 3.0]);
+        let decoded =
+            OptimizerRecord::from_bytes(record(expected.clone()).into_bytes().unwrap()).unwrap();
+
+        assert_record(&decoded, &expected);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn tensor_data_round_trips_through_burnpack_file() {
+        let expected = TensorData::from([1.0_f32, 2.0, 3.0]);
+        let path = std::env::temp_dir().join(format!(
+            "burn_optim_record_{}_tensor_data.bpk",
+            std::process::id()
+        ));
+
+        record(expected.clone()).save(&path).unwrap();
+        let decoded = OptimizerRecord::load(&path).unwrap();
+        assert_record(&decoded, &expected);
+
+        drop(decoded);
+        std::fs::remove_file(path).unwrap();
     }
 }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` has been executed.
- [x] Made sure the book is up to date with changes in this PR (no documentation changes are needed for this internal refactor).

### Related Issues/PRs

Fixes #5379.

### Changes

`OptimizerRecord` previously stored `burn_pack::Tensor` transport objects internally. Module optimizers and LBFGS therefore converted state to the transport representation in memory and later required those tensors to be resident before converting them back.

This change adds a crate-private optimizer record tensor that retains the name, optional parameter id, and `TensorData`. Burnpack tensors are now constructed only when writing and are converted back to `TensorData` immediately when reading. Module optimizer and LBFGS state move that data directly, removing the resident-tensor expectations without changing the public API or dependencies.

Regression tests cover both the in-memory serialization boundary and file-backed burnpack round trips.

### Testing

- `CARGO_INCREMENTAL=0 cargo test -p burn-optim` (103 unit tests passed; 1 doctest passed and 3 existing doctests ignored)
- Focused optimizer-record, module-optimizer, and LBFGS round-trip tests
- `CARGO_INCREMENTAL=0 cargo run-checks`
