### PR TITLE
fix(tests): correct FFT fixture and linalg tolerances

### DIFF
--- a/crates/burn-backend-tests/tests/cubecl/fft.rs
+++ b/crates/burn-backend-tests/tests/cubecl/fft.rs
@@ -4,7 +4,7 @@ use burn_tensor::{TensorData, Tolerance};
 
 const SQ2INV: f64 = std::f64::consts::FRAC_1_SQRT_2;
 const SQ2INV_PLUS_HALF: f64 = SQ2INV + 0.5;
-const SQ2INV_MINUS_HALF: f64 = SQ2INV + 0.5;
+const SQ2INV_MINUS_HALF: f64 = SQ2INV - 0.5;
 
 #[test]
 fn rfft_zeros() {

--- a/crates/burn-backend-tests/tests/tensor/float/linalg/det.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/linalg/det.rs
@@ -120,9 +120,11 @@ fn test_det_3x3_singular_linearly_dependent() {
 fn test_det_20x20_singular_linearly_dependent() {
     let device = Default::default();
     let mut tensor = TestTensor::random([1, 20, 20], Distribution::Default, &device);
-    let lin_dep_row1 = tensor.clone().slice(s![.., 5, ..]);
-    let lin_dep_row2 = lin_dep_row1.mul_scalar(3);
-    tensor = tensor.slice_assign(s![.., 17, ..], lin_dep_row2);
+    // Copy the row directly so the matrix is exactly singular in the working dtype.
+    // Scaling a random f32 row can round each element independently and only produce
+    // an approximately dependent row.
+    let lin_dep_row = tensor.clone().slice(s![.., 5, ..]);
+    tensor = tensor.slice_assign(s![.., 17, ..], lin_dep_row);
     let det_tensor = det::<3, 2, 1>(tensor);
     let expected = TestTensor::<1>::from_data([0.0], &device);
     let tolerance = Tolerance::default().set_half_precision_absolute(5e-3);

--- a/crates/burn-backend-tests/tests/tensor/float/linalg/qr.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/linalg/qr.rs
@@ -2,7 +2,9 @@ use super::*;
 use burn_tensor::{DType, Distribution, Element, Tolerance, linalg::qr, s};
 
 const REL: f32 = 5e-3;
-const ABS: f32 = 1e-3;
+// Householder updates are expressed as matmuls, for which accelerated CUDA
+// kernels can use reduced-precision inputs and accumulate errors around 1e-3.
+const ABS: f32 = 2e-3;
 
 // ---------------------------------------------------------------------
 // Small Matrices


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

> `cargo run-checks` tests with `Flex` by default. Use `cargo run-checks --backend <backend>` when
> targeting another backend. Consider running additional tests relevant to the crates changed.

### Related Issues/PRs

Typo introduced in #5316

### Testing

`cargo test-vulkan` / `test-cuda` pass. MacOS CI should also now pass.
