### PR TITLE
fix(cubecl): adapt matmul integration to cubek changes

### DIFF
--- a/crates/burn-cubecl-fusion/src/optim/matmul/args.rs
+++ b/crates/burn-cubecl-fusion/src/optim/matmul/args.rs
@@ -21,7 +21,7 @@ use cubecl::{
     },
 };
 use cubek::{
-    matmul::{
+    matmul::multi_level::{
         args::{BatchedCoords, MatmulArgs},
         components::global::memory::{
             BatchLayout, BlockScaledLayout, GlobalLayout, GlobalLayoutConfig, GlobalLayoutExpand,

--- a/crates/burn-cubecl-fusion/src/optim/matmul/optimization.rs
+++ b/crates/burn-cubecl-fusion/src/optim/matmul/optimization.rs
@@ -26,26 +26,31 @@ use cubecl::{
 };
 use cubek::{
     matmul::{
-        components::tile::TileMatmulKind,
         definition::{
             MatmulElems, MatmulGlobalElems, MatmulProblem, MatmulSetupError, MatmulVectorSizes,
         },
-        routines::{
-            BatchMatmulRoutine, BlueprintStrategy,
-            batch::{
-                double_buffering::{CyclicDoubleBufferingAlgorithm, DoubleBufferingArgs},
-                double_unit::DoubleUnitAlgorithm,
-                gemv_innerproduct::{
-                    DoubleVecMatInnerProductAlgorithm, VecMatInnerProductAlgorithm,
+        multi_level::{
+            BatchMatmulRoutine,
+            components::tile::TileMatmulKind,
+            launch_kernel_virtual,
+            routines::{
+                batch::{
+                    double_buffering::{CyclicDoubleBufferingAlgorithm, DoubleBufferingArgs},
+                    double_unit::DoubleUnitAlgorithm,
+                    gemv_innerproduct::{
+                        DoubleVecMatInnerProductAlgorithm, VecMatInnerProductAlgorithm,
+                    },
+                    ordered_double_buffering::{
+                        OrderedDoubleBufferingAlgorithm, OrderedSelectionArgs,
+                    },
+                    simple::{SimpleAlgorithm, SimpleArgs},
+                    simple_unit::SimpleUnitAlgorithm,
                 },
-                ordered_double_buffering::{OrderedDoubleBufferingAlgorithm, OrderedSelectionArgs},
-                simple::{SimpleAlgorithm, SimpleArgs},
-                simple_unit::SimpleUnitAlgorithm,
+                gemm::GemmRoutine,
+                gemv_unit_perpendicular::GemvUnitPerpendicularRoutine,
             },
-            gemm::GemmRoutine,
-            gemv_unit_perpendicular::GemvUnitPerpendicularRoutine,
         },
-        strategy::launch_kernel_virtual,
+        routine::BlueprintStrategy,
     },
     std::MatrixLayout,
 };

--- a/crates/burn-cubecl-fusion/src/optim/matmul/tune.rs
+++ b/crates/burn-cubecl-fusion/src/optim/matmul/tune.rs
@@ -14,9 +14,9 @@ use cubecl::{
     tune::{LocalTuner, Tunable, TunableSet, TuneGroup, local_tuner},
 };
 use cubek::matmul::{
-    components::tile::TileMatmulKind,
-    definition::{MatmulElems, MatmulGlobalElems, MatmulKind, adjust_dtypes},
-    strategy::{
+    definition::{MatmulElems, MatmulGlobalElems, MatmulKind},
+    multi_level::{components::tile::TileMatmulKind, definition::adjust_dtypes},
+    tune_key::{
         MatmulAutotuneKey, MatmulGlobalScale, MatmulProblemDefinition, should_tune_double_buffering,
     },
 };

--- a/crates/burn-cubecl/src/element.rs
+++ b/crates/burn-cubecl/src/element.rs
@@ -4,7 +4,7 @@ use cubecl::{
     prelude::{Float, Int, Numeric},
 };
 use cubek::{
-    matmul::definition::{MatmulPrecision, MatrixPrecision},
+    matmul::multi_level::definition::{MatmulPrecision, MatrixPrecision},
     reduce::ReducePrecision,
 };
 

--- a/crates/burn-cubecl/src/kernel/matmul/base.rs
+++ b/crates/burn-cubecl/src/kernel/matmul/base.rs
@@ -79,7 +79,7 @@ pub fn matmul<R: CubeRuntime>(
 
     match strategy {
         MatmulStrategy::Cube => {
-            launch_matmul(&Default::default(), lhs, rhs, out_launch)?;
+            launch_matmul(&Strategy::default(), lhs, rhs, out_launch)?;
             Ok(out)
         }
         #[cfg(feature = "autotune")]
@@ -90,8 +90,8 @@ pub fn matmul<R: CubeRuntime>(
     }
 }
 
-pub(crate) fn launch_matmul_naive<R: CubeRuntime>(
-    strategy: &Strategy,
+pub(crate) fn launch_matmul_naive<R: CubeRuntime, S: Clone + Into<Strategy>>(
+    strategy: &S,
     mut lhs: CubeTensor<R>,
     mut rhs: CubeTensor<R>,
     out: CubeTensor<R>,
@@ -116,12 +116,13 @@ pub(crate) fn launch_matmul_naive<R: CubeRuntime>(
     }
 }
 
-pub(crate) fn launch_matmul<R: CubeRuntime>(
-    strategy: &Strategy,
+pub(crate) fn launch_matmul<R: CubeRuntime, S: Clone + Into<Strategy>>(
+    strategy: &S,
     lhs: CubeTensor<R>,
     mut rhs: CubeTensor<R>,
     out: CubeTensor<R>,
 ) -> Result<(), MatmulSetupError> {
+    let strategy: Strategy = strategy.clone().into();
     let client = &out.client;
 
     let lhs_quant_handles = lhs.quantized_handles();
@@ -162,7 +163,11 @@ pub(crate) fn launch_matmul<R: CubeRuntime>(
         ),
         Some((data, scale)) => {
             // Extremely hacky fix to ensure naive can run in every case
-            if matches!(strategy, Strategy::Naive) && rhs.scheme().block_size().is_some() {
+            if matches!(
+                strategy,
+                Strategy::MultiLevel(cubek::matmul::multi_level::Strategy::Naive)
+            ) && rhs.scheme().block_size().is_some()
+            {
                 rhs = dequantize(rhs.clone(), lhs_dtype);
                 let rhs_dtype = rhs.dtype;
                 (
@@ -195,7 +200,7 @@ pub(crate) fn launch_matmul<R: CubeRuntime>(
     });
 
     cubek::matmul::launch::launch_ref(
-        strategy,
+        &strategy,
         client,
         lhs_handle,
         rhs_handle,

--- a/crates/burn-cubecl/src/kernel/matmul/tune/base.rs
+++ b/crates/burn-cubecl/src/kernel/matmul/tune/base.rs
@@ -14,21 +14,25 @@ use cubecl::{
     tune::{LocalTuner, Tunable, TunableSet, TuneGroup, local_tuner},
 };
 use cubek::matmul::{
-    components::tile::TileMatmulKind,
-    definition::{MatmulElems, MatmulGlobalElems, MatmulKind, adjust_dtypes},
-    routines::{
-        BlueprintStrategy, TileSizeSelection,
-        batch::{
-            double_buffering::DoubleBufferingArgs, double_unit::DoubleUnitSelectionArgs,
-            ordered_double_buffering::OrderedSelectionArgs, simple::SimpleArgs,
-            simple_unit::SimpleUnitSelectionArgs,
+    definition::{MatmulElems, MatmulGlobalElems, MatmulKind},
+    multi_level::{
+        Strategy,
+        components::tile::TileMatmulKind,
+        definition::adjust_dtypes,
+        routines::{
+            TileSizeSelection,
+            batch::{
+                double_buffering::DoubleBufferingArgs, double_unit::DoubleUnitSelectionArgs,
+                ordered_double_buffering::OrderedSelectionArgs, simple::SimpleArgs,
+                simple_unit::SimpleUnitSelectionArgs,
+            },
+            gemm::GemmStrategy,
         },
-        cpu_gemm::CpuGemmStrategy,
-        gemm::GemmStrategy,
     },
-    strategy::{
-        MatmulAutotuneKey, MatmulGlobalScale, MatmulProblemDefinition, Strategy,
-        should_tune_double_buffering,
+    routine::BlueprintStrategy,
+    tiled::{Strategy as TiledStrategy, cpu_gemm::CpuGemmStrategy},
+    tune_key::{
+        MatmulAutotuneKey, MatmulGlobalScale, MatmulProblemDefinition, should_tune_double_buffering,
     },
 };
 
@@ -225,7 +229,7 @@ pub fn matmul_autotune<R: CubeRuntime>(
         // First entry should always work, since it is considered the fallback.
         set = set.with(
             Tunable::new("matmul_naive", |(lhs, rhs, out)| {
-                launch_matmul_naive::<R>(&Strategy::Naive, lhs, rhs, out)
+                launch_matmul_naive::<R, _>(&Strategy::Naive, lhs, rhs, out)
                     .map_err(|err| std::format!("{err:?}"))
             })
             .group(&unit, |key| {
@@ -260,7 +264,7 @@ pub fn matmul_autotune<R: CubeRuntime>(
         ] {
             set = set.with(
                 Tunable::new(&strategy.to_string(), move |(lhs, rhs, out)| {
-                    launch_matmul::<R>(&strategy, lhs, rhs, out)
+                    launch_matmul::<R, _>(&strategy, lhs, rhs, out)
                         .map_err(|err| std::format!("{err:?}"))
                 })
                 .group(&gemv, move |key| match double_buf {
@@ -291,7 +295,7 @@ pub fn matmul_autotune<R: CubeRuntime>(
             ] {
                 set = set.with(
                     Tunable::new(&strategy.to_string(), move |(lhs, rhs, out)| {
-                        launch_matmul::<R>(&strategy, lhs, rhs, out)
+                        launch_matmul::<R, _>(&strategy, lhs, rhs, out)
                             .map_err(|err| format!("{err:?}"))
                     })
                     .group(&unit, move |key| match double_buf {
@@ -311,7 +315,7 @@ pub fn matmul_autotune<R: CubeRuntime>(
             Tunable::new(
                 &gemm_no_stage_strategy.to_string(),
                 move |(lhs, rhs, out)| {
-                    launch_matmul::<R>(&gemm_no_stage_strategy, lhs, rhs, out)
+                    launch_matmul::<R, _>(&gemm_no_stage_strategy, lhs, rhs, out)
                         .map_err(|err| format!("{err:?}"))
                 },
             )
@@ -320,10 +324,10 @@ pub fn matmul_autotune<R: CubeRuntime>(
 
         // CPU GEMM (CPU-only via the `cpu` group; the size limit is specific to this strategy).
         let cpu_gemm_strategy =
-            Strategy::CpuGemm(BlueprintStrategy::Inferred(CpuGemmStrategy::default()));
+            TiledStrategy::CpuGemm(BlueprintStrategy::Inferred(CpuGemmStrategy::default()));
         set = set.with(
             Tunable::new(&cpu_gemm_strategy.to_string(), move |(lhs, rhs, out)| {
-                launch_matmul::<R>(&cpu_gemm_strategy, lhs, rhs, out)
+                launch_matmul::<R, _>(&cpu_gemm_strategy, lhs, rhs, out)
                     .map_err(|err| format!("{err:?}"))
             })
             .group(&cpu, move |_key| PRIORITY_MAX),
@@ -529,7 +533,7 @@ pub fn matmul_autotune<R: CubeRuntime>(
             ),
         ] {
             let mut tunable = Tunable::new(&strategy.to_string(), move |(lhs, rhs, out)| {
-                launch_matmul::<R>(&strategy, lhs, rhs, out).map_err(|err| format!("{err:?}"))
+                launch_matmul::<R, _>(&strategy, lhs, rhs, out).map_err(|err| format!("{err:?}"))
             });
 
             // Accelerated kernels are demoted when the device doesn't support the tile matmul

--- a/crates/burn-cubecl/src/kernel/matmul/tune/bounds.rs
+++ b/crates/burn-cubecl/src/kernel/matmul/tune/bounds.rs
@@ -2,7 +2,7 @@ use burn_backend::cubecl::dtype_to_storage_type;
 use cubecl::{std::throughput::roofline_bounds, tune::TunableSet};
 use cubek::matmul::{
     definition::{MatmulCost, MatmulGlobalElems},
-    strategy::MatmulAutotuneKey,
+    tune_key::MatmulAutotuneKey,
 };
 
 use crate::{CubeRuntime, kernel::autotune_bounds, kernel::matmul::tune::base::Inputs};


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

> `cargo run-checks` tests with `Flex` by default. Use `cargo run-checks --backend <backend>` when
> targeting another backend. Consider running additional tests relevant to the crates changed.

### Related Issues/PRs

Missing cubek changes from #5420 which only updated the revs
