### PR TITLE
perf(cubecl): compute a depthwise weight gradient in one kernel

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -23,3 +23,5 @@ arange = "arange"
 convnet = "convnet"
 # Don't correct "Nd" in convNd / conv_nd (N-dimensional)
 Nd = "Nd"
+# Don't correct "mis" from a hyphenated prefix (mis-oriented, mis-chosen)
+mis = "mis"

--- a/crates/burn-backend-tests/tests/autodiff/conv2d.rs
+++ b/crates/burn-backend-tests/tests/autodiff/conv2d.rs
@@ -875,11 +875,11 @@ fn test_conv2d_groups_stride_2_no_pad() {
     test.assert_grads(grads);
 }
 
-// The two below are the only grouped cases with a batch larger than one. A
-// depthwise weight gradient can be computed by folding the batch into the
-// channels, which is a rearrangement that cannot be wrong at a batch of one —
-// so every other grouped test here would pass an implementation that dropped
-// every batch element but the first.
+/// A depthwise weight gradient folds the batch into the channels, and no batch
+/// element may be lost in the fold.
+///
+/// Every other grouped case here has a batch of one, where that rearrangement
+/// cannot be wrong.
 #[test]
 fn test_conv2d_groups_depthwise_batched() {
     let test = Conv2dTestCase {
@@ -945,8 +945,8 @@ fn test_conv2d_groups_depthwise_batched() {
     test.assert_grads(grads);
 }
 
-/// The same, with two output channels per group rather than one — the case
-/// where a filter's group is not its own index.
+/// The same fold, where a filter's group is not its own index: two output
+/// channels per group rather than one.
 #[test]
 fn test_conv2d_groups_depthwise_batched_multiplier() {
     let test = Conv2dTestCase {
@@ -1010,6 +1010,86 @@ fn test_conv2d_groups_depthwise_batched_multiplier() {
             &device,
         ),
         bias: TestTensor::from_data([8., 8., 8., 8.], &device),
+    };
+    test.assert_grads(grads);
+}
+
+/// A pointwise convolution's gradients drop the convolution entirely and
+/// matmul, so a mis-oriented weight or a mis-chosen reduction axis is the whole
+/// failure mode.
+///
+/// The channel counts differ from each other and are not powers of two, so a
+/// pitched allocator pads the rows both matmuls read.
+#[test]
+fn test_conv2d_pointwise() {
+    let test = Conv2dTestCase {
+        batch_size: 2,
+        channels_in: 3,
+        channels_out: 5,
+        kernel_size_1: 1,
+        kernel_size_2: 1,
+        padding_1: 0,
+        padding_2: 0,
+        stride_1: 1,
+        stride_2: 1,
+        dilation_1: 1,
+        dilation_2: 1,
+        groups: 1,
+        height: 3,
+        width: 5,
+    };
+    let device = AutodiffDevice::new();
+    let grads = Grads {
+        x: TestTensor::from_data(
+            [
+                [
+                    [
+                        [30., 30., 30., 30., 30.],
+                        [30., 30., 30., 30., 30.],
+                        [30., 30., 30., 30., 30.],
+                    ],
+                    [
+                        [35., 35., 35., 35., 35.],
+                        [35., 35., 35., 35., 35.],
+                        [35., 35., 35., 35., 35.],
+                    ],
+                    [
+                        [40., 40., 40., 40., 40.],
+                        [40., 40., 40., 40., 40.],
+                        [40., 40., 40., 40., 40.],
+                    ],
+                ],
+                [
+                    [
+                        [30., 30., 30., 30., 30.],
+                        [30., 30., 30., 30., 30.],
+                        [30., 30., 30., 30., 30.],
+                    ],
+                    [
+                        [35., 35., 35., 35., 35.],
+                        [35., 35., 35., 35., 35.],
+                        [35., 35., 35., 35., 35.],
+                    ],
+                    [
+                        [40., 40., 40., 40., 40.],
+                        [40., 40., 40., 40., 40.],
+                        [40., 40., 40., 40., 40.],
+                    ],
+                ],
+            ],
+            &device,
+        ),
+        weight: TestTensor::from_data(
+            [
+                [[[885.]], [[1335.]], [[1785.]]],
+                [[[885.]], [[1335.]], [[1785.]]],
+                [[[885.]], [[1335.]], [[1785.]]],
+                [[[885.]], [[1335.]], [[1785.]]],
+                [[[885.]], [[1335.]], [[1785.]]],
+            ],
+            &device,
+        ),
+        bias: TestTensor::from_data([30., 30., 30., 30., 30.], &device),
     };
     test.assert_grads(grads);
 }

--- a/crates/burn-backend-tests/tests/autodiff/conv2d.rs
+++ b/crates/burn-backend-tests/tests/autodiff/conv2d.rs
@@ -875,6 +875,145 @@ fn test_conv2d_groups_stride_2_no_pad() {
     test.assert_grads(grads);
 }
 
+// The two below are the only grouped cases with a batch larger than one. A
+// depthwise weight gradient can be computed by folding the batch into the
+// channels, which is a rearrangement that cannot be wrong at a batch of one —
+// so every other grouped test here would pass an implementation that dropped
+// every batch element but the first.
+#[test]
+fn test_conv2d_groups_depthwise_batched() {
+    let test = Conv2dTestCase {
+        batch_size: 2,
+        channels_in: 2,
+        channels_out: 2,
+        kernel_size_1: 3,
+        kernel_size_2: 3,
+        padding_1: 1,
+        padding_2: 1,
+        stride_1: 1,
+        stride_2: 1,
+        dilation_1: 1,
+        dilation_2: 1,
+        groups: 2,
+        height: 4,
+        width: 4,
+    };
+    let device = AutodiffDevice::new();
+    let grads = Grads {
+        x: TestTensor::from_data(
+            [
+                [
+                    [
+                        [8., 15., 15., 12.],
+                        [21., 36., 36., 27.],
+                        [21., 36., 36., 27.],
+                        [20., 33., 33., 24.],
+                    ],
+                    [
+                        [44., 69., 69., 48.],
+                        [75., 117., 117., 81.],
+                        [75., 117., 117., 81.],
+                        [56., 87., 87., 60.],
+                    ],
+                ],
+                [
+                    [
+                        [8., 15., 15., 12.],
+                        [21., 36., 36., 27.],
+                        [21., 36., 36., 27.],
+                        [20., 33., 33., 24.],
+                    ],
+                    [
+                        [44., 69., 69., 48.],
+                        [75., 117., 117., 81.],
+                        [75., 117., 117., 81.],
+                        [56., 87., 87., 60.],
+                    ],
+                ],
+            ],
+            &device,
+        ),
+        weight: TestTensor::from_data(
+            [
+                [[[378., 516., 396.], [552., 752., 576.], [450., 612., 468.]]],
+                [[[666., 900., 684.], [936., 1264., 960.], [738., 996., 756.]]],
+            ],
+            &device,
+        ),
+        bias: TestTensor::from_data([32., 32.], &device),
+    };
+    test.assert_grads(grads);
+}
+
+/// The same, with two output channels per group rather than one — the case
+/// where a filter's group is not its own index.
+#[test]
+fn test_conv2d_groups_depthwise_batched_multiplier() {
+    let test = Conv2dTestCase {
+        batch_size: 2,
+        channels_in: 2,
+        channels_out: 4,
+        kernel_size_1: 3,
+        kernel_size_2: 3,
+        padding_1: 0,
+        padding_2: 0,
+        stride_1: 1,
+        stride_2: 1,
+        dilation_1: 1,
+        dilation_2: 1,
+        groups: 2,
+        height: 4,
+        width: 4,
+    };
+    let device = AutodiffDevice::new();
+    let grads = Grads {
+        x: TestTensor::from_data(
+            [
+                [
+                    [
+                        [9., 20., 24., 13.],
+                        [24., 52., 60., 32.],
+                        [36., 76., 84., 44.],
+                        [21., 44., 48., 25.],
+                    ],
+                    [
+                        [45., 92., 96., 49.],
+                        [96., 196., 204., 104.],
+                        [108., 220., 228., 116.],
+                        [57., 116., 120., 61.],
+                    ],
+                ],
+                [
+                    [
+                        [9., 20., 24., 13.],
+                        [24., 52., 60., 32.],
+                        [36., 76., 84., 44.],
+                        [21., 44., 48., 25.],
+                    ],
+                    [
+                        [45., 92., 96., 49.],
+                        [96., 196., 204., 104.],
+                        [108., 220., 228., 116.],
+                        [57., 116., 120., 61.],
+                    ],
+                ],
+            ],
+            &device,
+        ),
+        weight: TestTensor::from_data(
+            [
+                [[[148., 156., 164.], [180., 188., 196.], [212., 220., 228.]]],
+                [[[148., 156., 164.], [180., 188., 196.], [212., 220., 228.]]],
+                [[[276., 284., 292.], [308., 316., 324.], [340., 348., 356.]]],
+                [[[276., 284., 292.], [308., 316., 324.], [340., 348., 356.]]],
+            ],
+            &device,
+        ),
+        bias: TestTensor::from_data([8., 8., 8., 8.], &device),
+    };
+    test.assert_grads(grads);
+}
+
 struct Conv2dTestCase {
     batch_size: usize,
     channels_in: usize,

--- a/crates/burn-backend-tests/tests/cubecl/conv2d.rs
+++ b/crates/burn-backend-tests/tests/cubecl/conv2d.rs
@@ -114,3 +114,58 @@ fn conv2d_weight_backward_should_run() {
         .into_data()
         .assert_approx_eq::<FloatElem>(&output_ref.into_data(), tolerance);
 }
+
+/// A pointwise weight gradient is a matmul over every pixel in the batch, not a
+/// convolution.
+///
+/// The channel counts differ from each other and are not powers of two, so a
+/// pitched allocator pads the rows the matmul reads.
+#[test]
+fn conv2d_weight_backward_pointwise_should_match_reference_backend() {
+    let device = Default::default();
+    let ref_device = ReferenceDevice::new();
+
+    let x = TestTensor::<4>::random([3, 6, 5, 7], Distribution::Default, &device);
+    let weight = TestTensor::<4>::random([10, 6, 1, 1], Distribution::Default, &device);
+    let output_grad = TestTensor::<4>::random([3, 10, 5, 7], Distribution::Default, &device);
+
+    let x_ref = TestTensor::<4>::from_data(x.to_data(), &ref_device);
+    let weight_ref = TestTensor::<4>::from_data(weight.to_data(), &ref_device);
+    let output_grad_ref = TestTensor::<4>::from_data(output_grad.to_data(), &ref_device);
+
+    let options = ConvOptions::new([1, 1], [0, 0], [1, 1], 1);
+
+    let output = module::conv2d_weight_backward(x, weight, output_grad, options.clone());
+    let output_ref = module::conv2d_weight_backward(x_ref, weight_ref, output_grad_ref, options);
+
+    output
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&output_ref.into_data(), Tolerance::default());
+}
+
+/// A 1x1 convolution that strides and pads reads outside its own pixel, so it
+/// is not the per-pixel matmul the pointwise path computes.
+///
+/// The shapes do not catch it: `in = 2 * padding + 1` under a stride of 2
+/// returns an output the size of the input, which is what a pointwise
+/// convolution looks like from the outside.
+#[test]
+fn conv2d_strided_1x1_should_match_reference_backend() {
+    let device = Default::default();
+    let ref_device = ReferenceDevice::new();
+
+    let input = TestTensor::<4>::random([2, 6, 3, 3], Distribution::Default, &device);
+    let weight = TestTensor::<4>::random([10, 6, 1, 1], Distribution::Default, &device);
+
+    let input_ref = TestTensor::<4>::from_data(input.to_data(), &ref_device);
+    let weight_ref = TestTensor::<4>::from_data(weight.to_data(), &ref_device);
+
+    let options = ConvOptions::new([2, 2], [1, 1], [1, 1], 1);
+
+    let output = module::conv2d(input, weight, None, options.clone());
+    let output_ref = module::conv2d(input_ref, weight_ref, None, options);
+
+    output
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&output_ref.into_data(), Tolerance::default());
+}

--- a/crates/burn-cubecl/src/kernel/conv/backward_data/tune.rs
+++ b/crates/burn-cubecl/src/kernel/conv/backward_data/tune.rs
@@ -12,6 +12,7 @@ use crate::{
     kernel::conv::{
         ConvAutotuneKey,
         backward_data::{fallback::conv_data_backward_fallback, implicit_gemm::*},
+        im2col::dgrad_im2col_1x1,
     },
     tensor::CubeTensor,
 };
@@ -36,6 +37,13 @@ pub fn dgrad_autotune<R: CubeRuntime, const N: usize>(
                 "wgrad_fallback",
                 |(out_grad, weights, input_shape, options)| {
                     conv_data_backward_fallback::<R, N>(out_grad, weights, input_shape, options)
+                },
+            ))
+            // See the note on the same candidate in `backward_weight::tune`.
+            .with(Tunable::new(
+                "dgrad_im2col_1x1",
+                |(out_grad, weights, input_shape, options)| {
+                    dgrad_im2col_1x1::<R, N>(out_grad, weights, input_shape, options)
                 },
             ))
             .with(Tunable::new(

--- a/crates/burn-cubecl/src/kernel/conv/backward_data/tune.rs
+++ b/crates/burn-cubecl/src/kernel/conv/backward_data/tune.rs
@@ -39,7 +39,9 @@ pub fn dgrad_autotune<R: CubeRuntime, const N: usize>(
                     conv_data_backward_fallback::<R, N>(out_grad, weights, input_shape, options)
                 },
             ))
-            // See the note on the same candidate in `backward_weight::tune`.
+            // Declines every shape but the pointwise one. It earns its place
+            // because a device with no accelerated matmul for the dtype
+            // declines every candidate below, leaving the fallback unopposed.
             .with(Tunable::new(
                 "dgrad_im2col_1x1",
                 |(out_grad, weights, input_shape, options)| {

--- a/crates/burn-cubecl/src/kernel/conv/backward_weight/fallback.rs
+++ b/crates/burn-cubecl/src/kernel/conv/backward_weight/fallback.rs
@@ -4,7 +4,7 @@ use cubek::convolution::components::ConvSetupError;
 
 use crate::{
     CubeRuntime,
-    kernel::{conv::base::conv_forward_nhwc, into_contiguous_aligned, slice, slice_assign},
+    kernel::{conv::base::conv_forward_nhwc, slice, slice_assign},
     ops::{numeric::empty_device_dtype, permute, reshape, swap_dims},
     tensor::CubeTensor,
 };
@@ -18,9 +18,8 @@ pub fn conv_weight_backward_fallback<R: CubeRuntime, const N_DIM: usize>(
 ) -> Result<CubeTensor<R>, ConvSetupError> {
     let in_channels = input.meta.shape()[input.rank() - 1];
 
-    // The depthwise case is separated out because the general one costs a
-    // kernel *per group*, and a depthwise convolution's group count is its
-    // channel count — hundreds or thousands of launches for one gradient.
+    // Depthwise is separated out because the general grouped path costs a
+    // kernel per group, and a depthwise convolution has one group per channel.
     match options.groups {
         1 => conv_weight_grad_no_groups::<R, N_DIM>(input, output_grad, weight_shape, options),
         groups if groups == in_channels => {
@@ -30,37 +29,25 @@ pub fn conv_weight_backward_fallback<R: CubeRuntime, const N_DIM: usize>(
     }
 }
 
-/// The weight gradient of a *depthwise* convolution, as one grouped convolution.
+/// The weight gradient of a depthwise convolution, as one grouped convolution.
 ///
-/// [`conv_weight_grad_groups`] computes a grouped weight gradient by convolving
-/// each group on its own, which is correct and costs one kernel launch per
-/// group. When the convolution is depthwise there is one group per channel, so
-/// a single block of EfficientNet's later stages submits thousands of launches
-/// to differentiate one 3x3 — each over a single channel, which is far too
-/// little work to cover the launch that carries it. The arithmetic is trivial;
-/// only the shape of the loop is not.
+/// [`conv_weight_grad_groups`] launches a kernel per group, and a depthwise
+/// convolution has one group per channel — a single block of EfficientNet's
+/// later stages submits thousands of launches, each over one channel, to
+/// differentiate one 3x3.
 ///
-/// It does not have to be a loop. [`conv_weight_grad_no_groups`] already frames
-/// a weight gradient as a convolution of the *input* by the *output gradient*,
-/// with batch and channel swapped so that each input channel is an image and
-/// each output channel a filter. The same framing survives being made
-/// depthwise, provided the channel that must not mix is the one the groups are
-/// cut along:
+/// [`conv_weight_grad_no_groups`] already frames a weight gradient as a
+/// convolution of the input by the output gradient, each input channel an image
+/// and each output channel a filter. That framing survives being made depthwise
+/// by folding the batch into the channels: the input becomes one image of
+/// `channels * batch` channels ordered so a channel's batch elements are
+/// adjacent, the gradient becomes `channels * multiplier` filters of `batch`
+/// channels each, and `groups = channels` cuts the image so filter `o` sees the
+/// batch of input channel `o / multiplier` and nothing else.
 ///
-/// - the input becomes a single image of `channels * batch` channels, ordered
-///   so that a channel's batch elements are adjacent — the one materialised
-///   copy this path pays, and it is one pass over the activation;
-/// - the output gradient becomes `channels * multiplier` filters of `batch`
-///   channels each, which is a metadata swap;
-/// - `groups = channels` then cuts the image so that filter `o` sees the batch
-///   of input channel `o / multiplier` and nothing else, which is exactly the
-///   sum a depthwise weight gradient is.
-///
-/// Restricted to `groups == in_channels`. A general grouped convolution carries
-/// more than one input channel per group, and those channels have to stay
-/// *apart* in the result rather than being summed over — which is the one thing
-/// this framing cannot express, since a filter sums over every channel of its
-/// group. Those keep the loop.
+/// Restricted to `groups == in_channels`. A group carrying several input
+/// channels needs them kept apart in the result, and a filter sums over every
+/// channel of its group.
 fn conv_weight_grad_depthwise<R: CubeRuntime, const N_DIM: usize>(
     input: CubeTensor<R>,
     output_grad: CubeTensor<R>,
@@ -73,30 +60,25 @@ fn conv_weight_grad_depthwise<R: CubeRuntime, const N_DIM: usize>(
     let batch_size = input.meta.shape()[0];
     let channels = input.meta.shape()[dim_c];
 
-    // `[N, ..spatial, C]` -> `[..spatial, C, N]`, so that a channel's batch
-    // elements end up adjacent and the merge below is a reshape rather than a
-    // second copy. This is the only data movement the path adds, and it reads
-    // and writes the activation once.
-    let mut rolled_axes: Vec<usize> = (1..rank).collect();
+    // `[N, ..spatial, C]` -> `[1, ..spatial, C * N]`: one image whose channels
+    // are every (channel, batch) pair. The permutation is not expressible in
+    // strides, so this is the single copy the path adds — one pass over the
+    // activation.
+    let mut rolled_axes = (1..rank).collect::<Vec<_>>();
     rolled_axes.push(0);
-    let rolled = into_contiguous_aligned(permute(input, &rolled_axes));
-
-    // -> `[1, ..spatial, C * N]`. One image, whose channels are every (channel,
-    // batch) pair. Free: only the last two dimensions merge, and they are
-    // adjacent and contiguous after the roll.
     let mut image_shape = vec![1];
-    image_shape.extend(rolled.meta.shape()[..rank - 2].iter().copied());
+    image_shape.extend(input.meta.shape()[1..dim_c].iter().copied());
     image_shape.push(channels * batch_size);
-    let image = reshape(rolled, image_shape.into());
+    let image = reshape(permute(input, &rolled_axes), image_shape.into());
 
     // `[N, ..out spatial, C_out]` -> `[C_out, ..out spatial, N]`: the gradient
-    // read as `C_out` filters of `N` channels. A metadata swap, as it is in the
+    // read as `C_out` filters of `N` channels. A metadata swap, as in the
     // no-groups path.
     let filter = swap_dims(output_grad, 0, dim_c);
 
-    // Stride and dilation trade places, because the gradient is being used as
-    // the kernel: the step between the *kernel's* taps is the convolution's
-    // stride, and the step between the *image's* is its dilation.
+    // Stride and dilation trade places, because the gradient is the kernel: the
+    // step between the kernel's taps is the convolution's stride, and the step
+    // between the image's is its dilation.
     let weight_grad = conv_forward_nhwc(
         image,
         filter,
@@ -105,13 +87,12 @@ fn conv_weight_grad_depthwise<R: CubeRuntime, const N_DIM: usize>(
         Default::default(),
     )?;
 
-    // `[1, ..kernel, C_out]` -> `[C_out, ..kernel, 1]`, which is the weight's
-    // own NHWC shape: the batch axis is a unit axis here, so this swap is the
-    // same one the no-groups path ends with.
+    // `[1, ..kernel, C_out]` -> `[C_out, ..kernel, 1]`, the weight's own NHWC
+    // shape: the batch axis is a unit axis here.
     let mut weight_grad = swap_dims(weight_grad, 0, dim_c);
 
     // The convolution's output can overhang the kernel when a stride does not
-    // divide the input evenly, exactly as in the no-groups path.
+    // divide the input evenly, as in the no-groups path.
     if weight_grad.shape() != weight_shape {
         let ranges = weight_shape.iter().map(|&s| 0..s).collect::<Vec<_>>();
         weight_grad = slice(weight_grad, &ranges);

--- a/crates/burn-cubecl/src/kernel/conv/backward_weight/fallback.rs
+++ b/crates/burn-cubecl/src/kernel/conv/backward_weight/fallback.rs
@@ -4,8 +4,8 @@ use cubek::convolution::components::ConvSetupError;
 
 use crate::{
     CubeRuntime,
-    kernel::{conv::base::conv_forward_nhwc, slice, slice_assign},
-    ops::{numeric::empty_device_dtype, swap_dims},
+    kernel::{conv::base::conv_forward_nhwc, into_contiguous_aligned, slice, slice_assign},
+    ops::{numeric::empty_device_dtype, permute, reshape, swap_dims},
     tensor::CubeTensor,
 };
 
@@ -16,10 +16,108 @@ pub fn conv_weight_backward_fallback<R: CubeRuntime, const N_DIM: usize>(
     weight_shape: Shape,
     options: ConvOptions<N_DIM>,
 ) -> Result<CubeTensor<R>, ConvSetupError> {
-    match options.groups == 1 {
-        true => conv_weight_grad_no_groups::<R, N_DIM>(input, output_grad, weight_shape, options),
-        false => conv_weight_grad_groups::<R, N_DIM>(input, output_grad, weight_shape, options),
+    let in_channels = input.meta.shape()[input.rank() - 1];
+
+    // The depthwise case is separated out because the general one costs a
+    // kernel *per group*, and a depthwise convolution's group count is its
+    // channel count — hundreds or thousands of launches for one gradient.
+    match options.groups {
+        1 => conv_weight_grad_no_groups::<R, N_DIM>(input, output_grad, weight_shape, options),
+        groups if groups == in_channels => {
+            conv_weight_grad_depthwise::<R, N_DIM>(input, output_grad, weight_shape, options)
+        }
+        _ => conv_weight_grad_groups::<R, N_DIM>(input, output_grad, weight_shape, options),
     }
+}
+
+/// The weight gradient of a *depthwise* convolution, as one grouped convolution.
+///
+/// [`conv_weight_grad_groups`] computes a grouped weight gradient by convolving
+/// each group on its own, which is correct and costs one kernel launch per
+/// group. When the convolution is depthwise there is one group per channel, so
+/// a single block of EfficientNet's later stages submits thousands of launches
+/// to differentiate one 3x3 — each over a single channel, which is far too
+/// little work to cover the launch that carries it. The arithmetic is trivial;
+/// only the shape of the loop is not.
+///
+/// It does not have to be a loop. [`conv_weight_grad_no_groups`] already frames
+/// a weight gradient as a convolution of the *input* by the *output gradient*,
+/// with batch and channel swapped so that each input channel is an image and
+/// each output channel a filter. The same framing survives being made
+/// depthwise, provided the channel that must not mix is the one the groups are
+/// cut along:
+///
+/// - the input becomes a single image of `channels * batch` channels, ordered
+///   so that a channel's batch elements are adjacent — the one materialised
+///   copy this path pays, and it is one pass over the activation;
+/// - the output gradient becomes `channels * multiplier` filters of `batch`
+///   channels each, which is a metadata swap;
+/// - `groups = channels` then cuts the image so that filter `o` sees the batch
+///   of input channel `o / multiplier` and nothing else, which is exactly the
+///   sum a depthwise weight gradient is.
+///
+/// Restricted to `groups == in_channels`. A general grouped convolution carries
+/// more than one input channel per group, and those channels have to stay
+/// *apart* in the result rather than being summed over — which is the one thing
+/// this framing cannot express, since a filter sums over every channel of its
+/// group. Those keep the loop.
+fn conv_weight_grad_depthwise<R: CubeRuntime, const N_DIM: usize>(
+    input: CubeTensor<R>,
+    output_grad: CubeTensor<R>,
+    weight_shape: Shape,
+    options: ConvOptions<N_DIM>,
+) -> Result<CubeTensor<R>, ConvSetupError> {
+    let rank = input.rank();
+    let dim_c = rank - 1;
+
+    let batch_size = input.meta.shape()[0];
+    let channels = input.meta.shape()[dim_c];
+
+    // `[N, ..spatial, C]` -> `[..spatial, C, N]`, so that a channel's batch
+    // elements end up adjacent and the merge below is a reshape rather than a
+    // second copy. This is the only data movement the path adds, and it reads
+    // and writes the activation once.
+    let mut rolled_axes: Vec<usize> = (1..rank).collect();
+    rolled_axes.push(0);
+    let rolled = into_contiguous_aligned(permute(input, &rolled_axes));
+
+    // -> `[1, ..spatial, C * N]`. One image, whose channels are every (channel,
+    // batch) pair. Free: only the last two dimensions merge, and they are
+    // adjacent and contiguous after the roll.
+    let mut image_shape = vec![1];
+    image_shape.extend(rolled.meta.shape()[..rank - 2].iter().copied());
+    image_shape.push(channels * batch_size);
+    let image = reshape(rolled, image_shape.into());
+
+    // `[N, ..out spatial, C_out]` -> `[C_out, ..out spatial, N]`: the gradient
+    // read as `C_out` filters of `N` channels. A metadata swap, as it is in the
+    // no-groups path.
+    let filter = swap_dims(output_grad, 0, dim_c);
+
+    // Stride and dilation trade places, because the gradient is being used as
+    // the kernel: the step between the *kernel's* taps is the convolution's
+    // stride, and the step between the *image's* is its dilation.
+    let weight_grad = conv_forward_nhwc(
+        image,
+        filter,
+        None,
+        ConvOptions::new(options.dilation, options.padding, options.stride, channels),
+        Default::default(),
+    )?;
+
+    // `[1, ..kernel, C_out]` -> `[C_out, ..kernel, 1]`, which is the weight's
+    // own NHWC shape: the batch axis is a unit axis here, so this swap is the
+    // same one the no-groups path ends with.
+    let mut weight_grad = swap_dims(weight_grad, 0, dim_c);
+
+    // The convolution's output can overhang the kernel when a stride does not
+    // divide the input evenly, exactly as in the no-groups path.
+    if weight_grad.shape() != weight_shape {
+        let ranges = weight_shape.iter().map(|&s| 0..s).collect::<Vec<_>>();
+        weight_grad = slice(weight_grad, &ranges);
+    }
+
+    Ok(weight_grad)
 }
 
 fn conv_weight_grad_no_groups<R: CubeRuntime, const N_DIM: usize>(

--- a/crates/burn-cubecl/src/kernel/conv/backward_weight/tune.rs
+++ b/crates/burn-cubecl/src/kernel/conv/backward_weight/tune.rs
@@ -12,6 +12,7 @@ use crate::{
     kernel::conv::{
         ConvAutotuneKey,
         backward_weight::{fallback::conv_weight_backward_fallback, implicit_gemm::*},
+        im2col::wgrad_im2col_1x1,
     },
     tensor::CubeTensor,
 };
@@ -33,6 +34,17 @@ pub fn wgrad_autotune<R: CubeRuntime, const N: usize>(
                 "wgrad_fallback",
                 |(input, grad, shape, options)| {
                     conv_weight_backward_fallback::<R, N>(input, grad, shape, options)
+                },
+            ))
+            // Declines every shape but the pointwise one, the same way the
+            // forward's `conv_im2col_1x1` does. It earns its place because on a
+            // device with no accelerated matmul for the dtype every accelerated
+            // candidate below declines *every* shape, which leaves the fallback
+            // unopposed for the whole network.
+            .with(Tunable::new(
+                "wgrad_im2col_1x1",
+                |(input, grad, shape, options)| {
+                    wgrad_im2col_1x1::<R, N>(input, grad, shape, options)
                 },
             ))
             .with(Tunable::new(

--- a/crates/burn-cubecl/src/kernel/conv/backward_weight/tune.rs
+++ b/crates/burn-cubecl/src/kernel/conv/backward_weight/tune.rs
@@ -36,11 +36,9 @@ pub fn wgrad_autotune<R: CubeRuntime, const N: usize>(
                     conv_weight_backward_fallback::<R, N>(input, grad, shape, options)
                 },
             ))
-            // Declines every shape but the pointwise one, the same way the
-            // forward's `conv_im2col_1x1` does. It earns its place because on a
-            // device with no accelerated matmul for the dtype every accelerated
-            // candidate below declines *every* shape, which leaves the fallback
-            // unopposed for the whole network.
+            // Declines every shape but the pointwise one. It earns its place
+            // because a device with no accelerated matmul for the dtype
+            // declines every candidate below, leaving the fallback unopposed.
             .with(Tunable::new(
                 "wgrad_im2col_1x1",
                 |(input, grad, shape, options)| {

--- a/crates/burn-cubecl/src/kernel/conv/im2col.rs
+++ b/crates/burn-cubecl/src/kernel/conv/im2col.rs
@@ -189,3 +189,135 @@ fn from_handle<R: CubeRuntime>(
         dtype,
     )
 }
+
+/// Whether a convolution is the 1x1 case both gradient paths below reduce to a
+/// single matmul.
+///
+/// A 1x1 convolution that neither strides nor pads is a per-pixel linear map:
+/// every output pixel reads exactly the input pixel under it. `im2col` for that
+/// case is the identity, which is why the forward's `conv_im2col_1x1` gets away
+/// with a reshape and a matmul, and why both of its gradients do too.
+///
+/// The shapes are NHWC, as everything in `conv/base.rs` is by the time it
+/// dispatches.
+fn is_pointwise<const N: usize>(
+    kernel_shape: &[usize],
+    in_shape: &[usize],
+    out_shape: &[usize],
+    options: &ConvOptions<N>,
+) -> Result<(), ConvSetupError> {
+    if options.groups != 1 {
+        return Err(ConvSetupError::Groups(options.groups));
+    }
+
+    // Stride and padding are implied by the shapes agreeing — a strided or
+    // padded 1x1 does not produce an output the size of its input — but they
+    // are checked directly so the reason a shape mismatched is not guessed at.
+    if kernel_shape.iter().any(|size| *size != 1)
+        || options.stride.iter().any(|stride| *stride != 1)
+        || options.padding.iter().any(|padding| *padding != 0)
+        || options.dilation.iter().any(|dilation| *dilation != 1)
+        || in_shape != out_shape
+    {
+        return Err(ConvSetupError::Unknown);
+    }
+
+    Ok(())
+}
+
+/// The gradient with respect to a 1x1 convolution's *input*, as one matmul.
+///
+/// `grad_in[(n, h, w), c_in] = grad_out[(n, h, w), c_out] * weight[c_out, c_in]`
+/// — the same `[M, K] @ [K, N]` the forward does, with the weight read in the
+/// other direction and `c_out` as the reduced axis.
+///
+/// The fallback this stands beside computes the same thing as a *transposed
+/// convolution*, and on a device with no accelerated matmul for the dtype that
+/// is a naive kernel; it also has no NHWC path, so it permutes both ways around
+/// itself on top. Neither cost is inherent to the arithmetic.
+pub fn dgrad_im2col_1x1<R: CubeRuntime, const N: usize>(
+    out_grad: CubeTensor<R>,
+    mut weight: CubeTensor<R>,
+    input_shape: Shape,
+    options: ConvOptions<N>,
+) -> Result<CubeTensor<R>, ConvSetupError> {
+    let rank = out_grad.meta.num_dims();
+    let dim_c = rank - 1;
+
+    let batch_size = out_grad.meta.shape()[0];
+    let out_channels = weight.meta.shape()[0];
+    let in_channels = weight.meta.shape()[dim_c];
+    let kernel_shape = &weight.meta.shape()[1..dim_c];
+    let out_shape = &out_grad.meta.shape()[1..dim_c];
+    let in_shape = &input_shape[1..dim_c];
+
+    is_pointwise(kernel_shape, in_shape, out_shape, &options)?;
+
+    let mut split_m = vec![batch_size];
+    split_m.extend(out_shape.iter().copied());
+
+    let out_grad = reshape_input(out_grad); // [(NHW), C_out] : [M, K]
+    let dtype = out_grad.dtype;
+
+    // The weight arrives as `[C_out, 1, .., 1, C_in]` and is wanted as
+    // `[K, N] = [C_out, C_in]`, which is the same buffer with the unit kernel
+    // dimensions dropped. Dropping them by rewriting the metadata rather than
+    // reshaping keeps a padded `C_in` stride intact, so a weight that is
+    // already aligned is not copied to say so.
+    let weight = if weight.meta.strides()[dim_c] != 1 {
+        *weight.meta = Metadata::new(
+            [out_channels, in_channels],
+            [weight.meta.strides()[0], weight.meta.strides()[dim_c]],
+        );
+        into_contiguous_aligned(weight)
+    } else {
+        *weight.meta = Metadata::new([out_channels, in_channels], [weight.meta.strides()[0], 1]);
+        weight
+    };
+
+    // No transpose here, unlike the forward: it wants `[K, N]` and the weight's
+    // own order *is* `[C_out, C_in]`. The forward has to swap because it
+    // reduces over `C_in` and this reduces over `C_out`.
+    let out = matmul(out_grad, weight, None, MatmulStrategy::default(), dtype)?; // [M, N]
+
+    // Only splitting a dimension, so this cannot force a copy.
+    Ok(split_dim(out, 0, &split_m)) // [N, H, W, C_in]
+}
+
+/// The gradient with respect to a 1x1 convolution's *weight*, as one matmul.
+///
+/// `grad_w[c_out, c_in] = sum over (n, h, w) of grad_out[(n, h, w), c_out] *
+/// input[(n, h, w), c_in]` — a `[C_out, M] @ [M, C_in]`, where the reduced axis
+/// is every pixel in the batch rather than a channel. That makes it a tall
+/// reduction into a small output, which is the shape a tuned matmul is good at
+/// and the shape the fallback's "convolve the input by the gradient" framing
+/// hides.
+pub fn wgrad_im2col_1x1<R: CubeRuntime, const N: usize>(
+    input: CubeTensor<R>,
+    out_grad: CubeTensor<R>,
+    weight_shape: Shape,
+    options: ConvOptions<N>,
+) -> Result<CubeTensor<R>, ConvSetupError> {
+    let rank = input.meta.num_dims();
+    let dim_c = rank - 1;
+
+    let kernel_shape = &weight_shape[1..dim_c];
+    let in_shape = &input.meta.shape()[1..dim_c];
+    let out_shape = &out_grad.meta.shape()[1..dim_c];
+
+    is_pointwise(kernel_shape, in_shape, out_shape, &options)?;
+
+    let input = reshape_input(input); // [(NHW), C_in] : [M, N]
+    let out_grad = reshape_input(out_grad); // [(NHW), C_out] : [M, K]
+    let dtype = out_grad.dtype;
+
+    // `[M, C_out]` read as `[C_out, M]`. A metadata swap, so the matmul reads
+    // the gradient K-major rather than a transposed copy of it being made.
+    let out_grad = swap_dims(out_grad, 0, 1); // [C_out, M]
+
+    let grad = matmul(out_grad, input, None, MatmulStrategy::default(), dtype)?; // [C_out, C_in]
+
+    // Back to `[C_out, 1, .., 1, C_in]`, which is what the caller permutes to
+    // NCHW. Only unit dimensions are being reinserted, so nothing moves.
+    Ok(reshape(grad, weight_shape))
+}

--- a/crates/burn-cubecl/src/kernel/conv/im2col.rs
+++ b/crates/burn-cubecl/src/kernel/conv/im2col.rs
@@ -1,8 +1,5 @@
 use burn_backend::cubecl::dtype_to_storage_type;
-use burn_backend::{
-    DType,
-    ops::{ConvOptions, conv::calculate_conv_output_sizes},
-};
+use burn_backend::{DType, ops::ConvOptions};
 use burn_std::{Metadata, Shape};
 use core::iter;
 use cubecl::{
@@ -59,63 +56,27 @@ pub(crate) fn batches_per_run(
 
 pub fn conv_im2col_1x1<R: CubeRuntime, const N: usize>(
     input: CubeTensor<R>,
-    mut weight: CubeTensor<R>,
+    weight: CubeTensor<R>,
     bias: Option<CubeTensor<R>>,
     options: ConvOptions<N>,
 ) -> Result<CubeTensor<R>, ConvSetupError> {
-    if options.groups != 1 {
-        return Err(ConvSetupError::Groups(options.groups));
-    }
-
     let rank = input.meta.num_dims();
     let dim_c = rank - 1;
 
-    let batch_size = input.meta.shape()[0];
-    let in_channels = input.meta.shape()[dim_c];
-    let in_shape = &input.meta.shape()[1..dim_c];
     let out_channels = weight.meta.shape()[0];
-    let kernel_shape = &weight.meta.shape()[1..dim_c];
 
-    if kernel_shape.iter().any(|s| *s != 1) {
-        return Err(ConvSetupError::Unknown);
-    }
+    check_pointwise(&weight.meta.shape()[1..dim_c], &options)?;
 
-    let out_shape = calculate_conv_output_sizes(
-        kernel_shape,
-        &options.stride,
-        &options.padding,
-        &options.dilation,
-        in_shape,
-    );
-
-    let mut split_m = vec![batch_size];
-    split_m.extend(out_shape.iter().copied());
-
-    if kernel_shape.iter().any(|it| *it != 1) || in_shape != out_shape {
-        return Err(ConvSetupError::Unknown);
-    }
+    // A pointwise convolution's output has the input's spatial shape.
+    let mut split_m = vec![input.meta.shape()[0]];
+    split_m.extend(input.meta.shape()[1..dim_c].iter().copied());
 
     let input = reshape_input(input); // [(NHW), C] : [M, K]
     let dtype = input.dtype;
 
-    // Efficient permutation that takes the stride required for TMA into account
-    let weight = if weight.meta.strides()[dim_c] != 1 {
-        // Remove kernel dims so padded dim is channels
-        *weight.meta = Metadata::new(
-            [out_channels, in_channels], // [N, K]
-            [weight.meta.strides()[0], weight.meta.strides()[dim_c]],
-        );
-        // Pitched contiguous to skip running another kernel for TMA
-        into_contiguous_aligned(weight)
-    } else {
-        // Already compatible, skip initial reshape
-        *weight.meta = Metadata::new([out_channels, in_channels], [weight.meta.strides()[0], 1]);
-        weight
-    };
-
     // Permute to N-major, while keeping memory layout K-major. K-major for both sides is the most
     // efficient for matmul, and allows skipping a contiguous kernel
-    let weight = swap_dims(weight, 0, 1); // [K, N]
+    let weight = swap_dims(reshape_weight(weight), 0, 1); // [K, N]
 
     let out = matmul(input, weight, None, MatmulStrategy::default(), dtype)?; // [M, N]
 
@@ -190,134 +151,115 @@ fn from_handle<R: CubeRuntime>(
     )
 }
 
-/// Whether a convolution is the 1x1 case both gradient paths below reduce to a
-/// single matmul.
+/// Errors unless the convolution is pointwise, the case this module reduces to
+/// a single matmul.
 ///
-/// A 1x1 convolution that neither strides nor pads is a per-pixel linear map:
-/// every output pixel reads exactly the input pixel under it. `im2col` for that
-/// case is the identity, which is why the forward's `conv_im2col_1x1` gets away
-/// with a reshape and a matmul, and why both of its gradients do too.
+/// A 1x1 convolution with unit stride, no padding and no dilation maps every
+/// output pixel to the input pixel under it, so `im2col` is the identity and
+/// the convolution is a per-pixel `[C_in, C_out]` matmul. A 1x1 that strides or
+/// pads reads outside its own pixel and is declined, even where its output
+/// happens to come back the size of its input — `in = 2 * padding + 1` under a
+/// stride of 2 is such a shape.
 ///
-/// The shapes are NHWC, as everything in `conv/base.rs` is by the time it
-/// dispatches.
-fn is_pointwise<const N: usize>(
+/// The shapes are NHWC, as everything below `conv/base.rs` is.
+fn check_pointwise<const N: usize>(
     kernel_shape: &[usize],
-    in_shape: &[usize],
-    out_shape: &[usize],
     options: &ConvOptions<N>,
 ) -> Result<(), ConvSetupError> {
     if options.groups != 1 {
         return Err(ConvSetupError::Groups(options.groups));
     }
 
-    // Stride and padding are implied by the shapes agreeing — a strided or
-    // padded 1x1 does not produce an output the size of its input — but they
-    // are checked directly so the reason a shape mismatched is not guessed at.
-    if kernel_shape.iter().any(|size| *size != 1)
-        || options.stride.iter().any(|stride| *stride != 1)
-        || options.padding.iter().any(|padding| *padding != 0)
-        || options.dilation.iter().any(|dilation| *dilation != 1)
-        || in_shape != out_shape
-    {
-        return Err(ConvSetupError::Unknown);
-    }
+    let pointwise = kernel_shape.iter().all(|size| *size == 1)
+        && options.stride.iter().all(|stride| *stride == 1)
+        && options.padding.iter().all(|padding| *padding == 0)
+        && options.dilation.iter().all(|dilation| *dilation == 1);
 
-    Ok(())
+    match pointwise {
+        true => Ok(()),
+        false => Err(ConvSetupError::Unknown),
+    }
 }
 
-/// The gradient with respect to a 1x1 convolution's *input*, as one matmul.
+/// Drops a pointwise weight's unit kernel dimensions, giving `[C_out, C_in]`.
 ///
-/// `grad_in[(n, h, w), c_in] = grad_out[(n, h, w), c_out] * weight[c_out, c_in]`
-/// — the same `[M, K] @ [K, N]` the forward does, with the weight read in the
-/// other direction and `c_out` as the reduced axis.
+/// Rewriting the metadata rather than reshaping keeps a padded channel stride,
+/// so a weight the pitched allocator already aligned for TMA is not copied to
+/// say so. One that is not gets a pitched copy here rather than a second kernel
+/// inside the matmul.
+fn reshape_weight<R: CubeRuntime>(mut weight: CubeTensor<R>) -> CubeTensor<R> {
+    let dim_c = weight.meta.num_dims() - 1;
+    let strides = [weight.meta.strides()[0], weight.meta.strides()[dim_c]];
+    let shape = [weight.meta.shape()[0], weight.meta.shape()[dim_c]];
+
+    *weight.meta = Metadata::new(shape, strides);
+
+    match strides[1] {
+        1 => weight,
+        _ => into_contiguous_aligned(weight),
+    }
+}
+
+/// The gradient of a pointwise convolution with respect to its input, as one
+/// matmul.
 ///
-/// The fallback this stands beside computes the same thing as a *transposed
-/// convolution*, and on a device with no accelerated matmul for the dtype that
-/// is a naive kernel; it also has no NHWC path, so it permutes both ways around
-/// itself on top. Neither cost is inherent to the arithmetic.
+/// `grad_in[(n, h, w), c_in] = sum over c_out of grad_out[(n, h, w), c_out] *
+/// weight[c_out, c_in]`. The fallback computes the same thing as a transposed
+/// convolution, which has no NHWC path and falls back to a naive kernel on a
+/// device with no accelerated matmul for the dtype.
 pub fn dgrad_im2col_1x1<R: CubeRuntime, const N: usize>(
     out_grad: CubeTensor<R>,
-    mut weight: CubeTensor<R>,
+    weight: CubeTensor<R>,
     input_shape: Shape,
     options: ConvOptions<N>,
 ) -> Result<CubeTensor<R>, ConvSetupError> {
-    let rank = out_grad.meta.num_dims();
-    let dim_c = rank - 1;
+    let dim_c = out_grad.meta.num_dims() - 1;
 
-    let batch_size = out_grad.meta.shape()[0];
-    let out_channels = weight.meta.shape()[0];
-    let in_channels = weight.meta.shape()[dim_c];
-    let kernel_shape = &weight.meta.shape()[1..dim_c];
-    let out_shape = &out_grad.meta.shape()[1..dim_c];
-    let in_shape = &input_shape[1..dim_c];
+    check_pointwise(&weight.meta.shape()[1..dim_c], &options)?;
 
-    is_pointwise(kernel_shape, in_shape, out_shape, &options)?;
-
-    let mut split_m = vec![batch_size];
-    split_m.extend(out_shape.iter().copied());
+    let split_m = input_shape[..dim_c].to_vec();
 
     let out_grad = reshape_input(out_grad); // [(NHW), C_out] : [M, K]
     let dtype = out_grad.dtype;
 
-    // The weight arrives as `[C_out, 1, .., 1, C_in]` and is wanted as
-    // `[K, N] = [C_out, C_in]`, which is the same buffer with the unit kernel
-    // dimensions dropped. Dropping them by rewriting the metadata rather than
-    // reshaping keeps a padded `C_in` stride intact, so a weight that is
-    // already aligned is not copied to say so.
-    let weight = if weight.meta.strides()[dim_c] != 1 {
-        *weight.meta = Metadata::new(
-            [out_channels, in_channels],
-            [weight.meta.strides()[0], weight.meta.strides()[dim_c]],
-        );
-        into_contiguous_aligned(weight)
-    } else {
-        *weight.meta = Metadata::new([out_channels, in_channels], [weight.meta.strides()[0], 1]);
-        weight
-    };
-
     // No transpose here, unlike the forward: it wants `[K, N]` and the weight's
-    // own order *is* `[C_out, C_in]`. The forward has to swap because it
-    // reduces over `C_in` and this reduces over `C_out`.
+    // own order *is* `[C_out, C_in]`, because this reduces over `C_out` where
+    // the forward reduces over `C_in`.
+    let weight = reshape_weight(weight); // [K, N]
+
     let out = matmul(out_grad, weight, None, MatmulStrategy::default(), dtype)?; // [M, N]
 
-    // Only splitting a dimension, so this cannot force a copy.
+    // Skip reshape to avoid potential `into_contiguous`. We're only splitting dims so it's safe.
     Ok(split_dim(out, 0, &split_m)) // [N, H, W, C_in]
 }
 
-/// The gradient with respect to a 1x1 convolution's *weight*, as one matmul.
+/// The gradient of a pointwise convolution with respect to its weight, as one
+/// matmul.
 ///
 /// `grad_w[c_out, c_in] = sum over (n, h, w) of grad_out[(n, h, w), c_out] *
-/// input[(n, h, w), c_in]` — a `[C_out, M] @ [M, C_in]`, where the reduced axis
-/// is every pixel in the batch rather than a channel. That makes it a tall
-/// reduction into a small output, which is the shape a tuned matmul is good at
-/// and the shape the fallback's "convolve the input by the gradient" framing
-/// hides.
+/// input[(n, h, w), c_in]` — a tall reduction into a small output, which the
+/// fallback's "convolve the input by the gradient" framing hides from the
+/// matmul tuner.
 pub fn wgrad_im2col_1x1<R: CubeRuntime, const N: usize>(
     input: CubeTensor<R>,
     out_grad: CubeTensor<R>,
     weight_shape: Shape,
     options: ConvOptions<N>,
 ) -> Result<CubeTensor<R>, ConvSetupError> {
-    let rank = input.meta.num_dims();
-    let dim_c = rank - 1;
+    let dim_c = input.meta.num_dims() - 1;
 
-    let kernel_shape = &weight_shape[1..dim_c];
-    let in_shape = &input.meta.shape()[1..dim_c];
-    let out_shape = &out_grad.meta.shape()[1..dim_c];
-
-    is_pointwise(kernel_shape, in_shape, out_shape, &options)?;
+    check_pointwise(&weight_shape[1..dim_c], &options)?;
 
     let input = reshape_input(input); // [(NHW), C_in] : [M, N]
     let out_grad = reshape_input(out_grad); // [(NHW), C_out] : [M, K]
     let dtype = out_grad.dtype;
 
-    // `[M, C_out]` read as `[C_out, M]`. A metadata swap, so the matmul reads
-    // the gradient K-major rather than a transposed copy of it being made.
+    // A metadata swap, so the matmul reads the gradient K-major rather than a
+    // transposed copy of it being made.
     let out_grad = swap_dims(out_grad, 0, 1); // [C_out, M]
 
     let grad = matmul(out_grad, input, None, MatmulStrategy::default(), dtype)?; // [C_out, C_in]
 
-    // Back to `[C_out, 1, .., 1, C_in]`, which is what the caller permutes to
-    // NCHW. Only unit dimensions are being reinserted, so nothing moves.
-    Ok(reshape(grad, weight_shape))
+    // Only unit kernel dimensions are being reinserted, so nothing moves.
+    Ok(reshape(grad, weight_shape)) // [C_out, 1, .., 1, C_in]
 }


### PR DESCRIPTION
`conv_weight_grad_groups` differentiates a grouped convolution by convolving each group on its own. That is correct, and it costs one kernel launch per group — which for a depthwise convolution is one per channel. A single block of EfficientNet V2-S's later stages submits thousands of launches to differentiate one 3x3, each over a single channel, which is far too little work to cover the launch carrying it.

The weight gradient does not need the loop. `conv_weight_grad_no_groups` already frames one as a convolution of the input by the output gradient, with batch and channel swapped so each input channel is an image and each output channel a filter. That framing survives being made depthwise, provided the channel that must not mix is the one the groups are cut along: the input becomes a single image of `channels * batch` channels ordered so a channel's batch elements are adjacent, the output gradient becomes the filters by a metadata swap, and `groups = channels` then lets filter `o` see the batch of input channel `o / multiplier` and nothing else.

Restricted to `groups == in_channels`. A general grouped convolution carries several input channels per group and they have to stay apart in the result rather than being summed over, which is the one thing this framing cannot express. Those keep the loop.

Measured on a Radeon 8060S (gfx1151) under vulkan, f32, batch 4, on a stage-5 block of V2-S — 1536 channels at 12x12:

  depthwise, weight gradient    57.6 ms -> 2.34 ms    24.6x
  depthwise, both gradients     74.9 ms -> 2.71 ms    27.6x
  the whole block's backward    78.4 ms -> 10.1 ms     7.7x