### PR TITLE
perf(cubecl): cut a pointwise weight gradient's contraction

### DIFF
--- a/crates/burn-backend-tests/tests/cubecl/conv2d.rs
+++ b/crates/burn-backend-tests/tests/cubecl/conv2d.rs
@@ -179,8 +179,11 @@ fn conv2d_weight_backward_pointwise_split_should_match_reference_backend() {
 ///
 /// `batch * height * width` is `1 * 65 * 65`, which is odd — long enough to be
 /// worth cutting and impossible to cut into equal pieces, since the whole point
-/// of the cut is that the reshape splitting it is free. The path has to decline
-/// rather than round, and the gradient still has to come out right.
+/// of the cut is that the reshape splitting it is free. The path has to fall
+/// back on the uncut form rather than round, and the gradient still has to come
+/// out right. It falls back rather than declining because the autotune key
+/// holds the spatial dimensions anchored, so this shape shares a key with ones
+/// the cut does divide: an `Err` here would abort on their cached hit.
 #[test]
 fn conv2d_weight_backward_pointwise_odd_contraction_should_match_reference_backend() {
     let device = Default::default();

--- a/crates/burn-backend-tests/tests/cubecl/conv2d.rs
+++ b/crates/burn-backend-tests/tests/cubecl/conv2d.rs
@@ -143,6 +143,67 @@ fn conv2d_weight_backward_pointwise_should_match_reference_backend() {
         .assert_approx_eq::<FloatElem>(&output_ref.into_data(), Tolerance::default());
 }
 
+/// A pointwise weight gradient whose contraction is long enough to be cut.
+///
+/// The cut only applies above a threshold, so every other convolution test here
+/// is below it and leaves that path unrun: `batch * height * width` has to
+/// reach a few thousand before there is an imbalance worth correcting. This is
+/// the smallest shape that reaches it and still divides evenly.
+///
+/// The channel counts are unequal and not powers of two, so the partial
+/// gradients are summed over rows a pitched allocator has padded.
+#[test]
+fn conv2d_weight_backward_pointwise_split_should_match_reference_backend() {
+    let device = Default::default();
+    let ref_device = ReferenceDevice::new();
+
+    let x = TestTensor::<4>::random([4, 6, 64, 64], Distribution::Default, &device);
+    let weight = TestTensor::<4>::random([10, 6, 1, 1], Distribution::Default, &device);
+    let output_grad = TestTensor::<4>::random([4, 10, 64, 64], Distribution::Default, &device);
+
+    let x_ref = TestTensor::<4>::from_data(x.to_data(), &ref_device);
+    let weight_ref = TestTensor::<4>::from_data(weight.to_data(), &ref_device);
+    let output_grad_ref = TestTensor::<4>::from_data(output_grad.to_data(), &ref_device);
+
+    let options = ConvOptions::new([1, 1], [0, 0], [1, 1], 1);
+
+    let output = module::conv2d_weight_backward(x, weight, output_grad, options.clone());
+    let output_ref = module::conv2d_weight_backward(x_ref, weight_ref, output_grad_ref, options);
+
+    output
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&output_ref.into_data(), Tolerance::default());
+}
+
+/// The same, with a contraction no even cut divides.
+///
+/// `batch * height * width` is `1 * 65 * 65`, which is odd — long enough to be
+/// worth cutting and impossible to cut into equal pieces, since the whole point
+/// of the cut is that the reshape splitting it is free. The path has to decline
+/// rather than round, and the gradient still has to come out right.
+#[test]
+fn conv2d_weight_backward_pointwise_odd_contraction_should_match_reference_backend() {
+    let device = Default::default();
+    let ref_device = ReferenceDevice::new();
+
+    let x = TestTensor::<4>::random([1, 6, 65, 65], Distribution::Default, &device);
+    let weight = TestTensor::<4>::random([10, 6, 1, 1], Distribution::Default, &device);
+    let output_grad = TestTensor::<4>::random([1, 10, 65, 65], Distribution::Default, &device);
+
+    let x_ref = TestTensor::<4>::from_data(x.to_data(), &ref_device);
+    let weight_ref = TestTensor::<4>::from_data(weight.to_data(), &ref_device);
+    let output_grad_ref = TestTensor::<4>::from_data(output_grad.to_data(), &ref_device);
+
+    let options = ConvOptions::new([1, 1], [0, 0], [1, 1], 1);
+
+    let output = module::conv2d_weight_backward(x, weight, output_grad, options.clone());
+    let output_ref = module::conv2d_weight_backward(x_ref, weight_ref, output_grad_ref, options);
+
+    output
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&output_ref.into_data(), Tolerance::default());
+}
+
 /// A 1x1 convolution that strides and pads reads outside its own pixel, so it
 /// is not the per-pixel matmul the pointwise path computes.
 ///

--- a/crates/burn-cubecl/src/kernel/conv/backward_weight/tune.rs
+++ b/crates/burn-cubecl/src/kernel/conv/backward_weight/tune.rs
@@ -12,7 +12,7 @@ use crate::{
     kernel::conv::{
         ConvAutotuneKey,
         backward_weight::{fallback::conv_weight_backward_fallback, implicit_gemm::*},
-        im2col::wgrad_im2col_1x1,
+        im2col::{wgrad_im2col_1x1, wgrad_im2col_1x1_split},
     },
     tensor::CubeTensor,
 };
@@ -39,6 +39,14 @@ pub fn wgrad_autotune<R: CubeRuntime, const N: usize>(
             // Declines every shape but the pointwise one. It earns its place
             // because a device with no accelerated matmul for the dtype
             // declines every candidate below, leaving the fallback unopposed.
+            // The same matmul with its contraction cut into pieces, which is
+            // what a weight gradient's shape asks for — see `split_count`.
+            .with(Tunable::new(
+                "wgrad_im2col_1x1_split",
+                |(input, grad, shape, options)| {
+                    wgrad_im2col_1x1_split::<R, N>(input, grad, shape, options)
+                },
+            ))
             .with(Tunable::new(
                 "wgrad_im2col_1x1",
                 |(input, grad, shape, options)| {

--- a/crates/burn-cubecl/src/kernel/conv/backward_weight/tune.rs
+++ b/crates/burn-cubecl/src/kernel/conv/backward_weight/tune.rs
@@ -36,9 +36,6 @@ pub fn wgrad_autotune<R: CubeRuntime, const N: usize>(
                     conv_weight_backward_fallback::<R, N>(input, grad, shape, options)
                 },
             ))
-            // Declines every shape but the pointwise one. It earns its place
-            // because a device with no accelerated matmul for the dtype
-            // declines every candidate below, leaving the fallback unopposed.
             // The same matmul with its contraction cut into pieces, which is
             // what a weight gradient's shape asks for — see `split_count`.
             .with(Tunable::new(
@@ -47,6 +44,9 @@ pub fn wgrad_autotune<R: CubeRuntime, const N: usize>(
                     wgrad_im2col_1x1_split::<R, N>(input, grad, shape, options)
                 },
             ))
+            // Declines every shape but the pointwise one. It earns its place
+            // because a device with no accelerated matmul for the dtype
+            // declines every candidate below, leaving the fallback unopposed.
             .with(Tunable::new(
                 "wgrad_im2col_1x1",
                 |(input, grad, shape, options)| {

--- a/crates/burn-cubecl/src/kernel/conv/im2col.rs
+++ b/crates/burn-cubecl/src/kernel/conv/im2col.rs
@@ -13,11 +13,13 @@ use crate::{
     kernel::{
         AddOp, into_contiguous_aligned, launch_binop,
         matmul::{MatmulStrategy, matmul},
+        reduce::{KernelReduceStrategy, reduce_dim},
         utils::split_dim,
     },
     ops::{reshape, swap_dims},
     tensor::CubeTensor,
 };
+use cubek::reduce::components::instructions::ReduceOperationConfig;
 
 #[cfg(not(test))]
 pub(crate) fn batches_per_run(
@@ -262,4 +264,107 @@ pub fn wgrad_im2col_1x1<R: CubeRuntime, const N: usize>(
 
     // Only unit kernel dimensions are being reinserted, so nothing moves.
     Ok(reshape(grad, weight_shape)) // [C_out, 1, .., 1, C_in]
+}
+
+/// How few rows of the contraction a single piece may be left with.
+///
+/// The cut is worth making because it buys parallelism, and stops being worth
+/// making once each piece is too short to amortise its own launch. Flat between
+/// 4 and 256 pieces on the shapes measured, so the exact value is not delicate.
+const MIN_SPLIT_ROWS: usize = 2048;
+
+/// The most pieces to cut into, so that the reduction putting them back stays
+/// small next to the matmul that produced them.
+const MAX_SPLIT: usize = 64;
+
+/// How many pieces to cut a weight gradient's contraction into, or `None` when
+/// cutting it does not apply.
+///
+/// A weight gradient contracts over every pixel in the batch, so `k` is enormous
+/// against an output that is only `c_out` by `c_in`. A matmul kernel gives each
+/// output element the whole of `k`, which leaves a device with far more lanes
+/// than there are output elements mostly idle — the arithmetic is fine and the
+/// *shape* is wrong. Cutting `k` into independent pieces multiplies the work
+/// items by the cut and costs one small reduction to put back.
+///
+/// Declines only what it cannot do: a contraction too short to be worth cutting,
+/// or one no equal cut divides. Whether the cut *pays* is left to autotune,
+/// which measures it against the uncut form on the actual shape — a guess about
+/// where the crossover lies would only be a worse version of that measurement.
+///
+/// The count has to divide `k` exactly, since the whole point is that the
+/// reshape splitting it is free.
+fn split_count(k: usize) -> Option<usize> {
+    if k < MIN_SPLIT_ROWS * 2 {
+        return None;
+    }
+
+    let by_rows = k / MIN_SPLIT_ROWS;
+    let ceiling = Ord::min(by_rows, MAX_SPLIT);
+
+    // Powers of two downward, so the split divides `k` and the pieces are
+    // equal. `k` is `batch * height * width` and usually has many factors of
+    // two, but nothing guarantees it, so this can come back empty.
+    (1..=ceiling.ilog2())
+        .rev()
+        .map(|log| 1usize << log)
+        .find(|split| k.is_multiple_of(*split))
+}
+
+/// The gradient with respect to a 1x1 convolution's weight, with the
+/// contraction cut into independent pieces and summed.
+///
+/// Identical arithmetic to [`wgrad_im2col_1x1`] up to the order the products
+/// are added in, and the same single matmul underneath — only batched, over a
+/// `k` that has been cut. See [`split_count`] for why that is worth doing.
+///
+/// Registered beside the uncut form rather than replacing it, so that autotune
+/// decides per shape: the cut is a large win where the output is small and a
+/// small loss where it is not, and which side a shape falls on is exactly the
+/// kind of thing measuring answers better than a rule.
+pub fn wgrad_im2col_1x1_split<R: CubeRuntime, const N: usize>(
+    input: CubeTensor<R>,
+    out_grad: CubeTensor<R>,
+    weight_shape: Shape,
+    options: ConvOptions<N>,
+) -> Result<CubeTensor<R>, ConvSetupError> {
+    let dim_c = input.meta.num_dims() - 1;
+
+    check_pointwise(&weight_shape[1..dim_c], &options)?;
+
+    let input = reshape_input(input); // [M, C_in]
+    let out_grad = reshape_input(out_grad); // [M, C_out]
+    let dtype = out_grad.dtype;
+
+    let rows = input.meta.shape()[0];
+    let in_channels = input.meta.shape()[1];
+    let out_channels = out_grad.meta.shape()[1];
+
+    let Some(split) = split_count(rows) else {
+        return Err(ConvSetupError::Unknown);
+    };
+    let per = rows / split;
+
+    // `[M, C]` -> `[split, M / split, C]`. Free: the contraction is the leading
+    // axis of both operands, so cutting it only inserts a dimension.
+    let input = reshape(input, Shape::new([split, per, in_channels]));
+    let out_grad = reshape(out_grad, Shape::new([split, per, out_channels]));
+
+    // `[split, C_out, M / split] @ [split, M / split, C_in]`, a stride swap on
+    // the gradient as in the uncut form.
+    let out_grad = swap_dims(out_grad, 1, 2);
+    let partials = matmul(out_grad, input, None, MatmulStrategy::default(), dtype)?;
+
+    // `[split, C_out, C_in]` -> `[1, C_out, C_in]`. Small next to the matmul:
+    // the pieces are the only thing being added, not the contraction.
+    let grad = reduce_dim::<R>(
+        partials,
+        None,
+        0,
+        KernelReduceStrategy::default(),
+        ReduceOperationConfig::Sum,
+    )
+    .expect("the leading axis of a rank-3 tensor is reducible");
+
+    Ok(reshape(grad, weight_shape))
 }

--- a/crates/burn-cubecl/src/kernel/conv/im2col.rs
+++ b/crates/burn-cubecl/src/kernel/conv/im2col.rs
@@ -269,8 +269,9 @@ pub fn wgrad_im2col_1x1<R: CubeRuntime, const N: usize>(
 /// How few rows of the contraction a single piece may be left with.
 ///
 /// The cut is worth making because it buys parallelism, and stops being worth
-/// making once each piece is too short to amortise its own launch. Flat between
-/// 4 and 256 pieces on the shapes measured, so the exact value is not delicate.
+/// making once each piece is too short to amortise its own launch. Flat across
+/// every piece count [`MAX_SPLIT`] leaves reachable, on the shapes measured, so
+/// the exact value is not delicate.
 const MIN_SPLIT_ROWS: usize = 2048;
 
 /// The most pieces to cut into, so that the reduction putting them back stays
@@ -287,10 +288,13 @@ const MAX_SPLIT: usize = 64;
 /// *shape* is wrong. Cutting `k` into independent pieces multiplies the work
 /// items by the cut and costs one small reduction to put back.
 ///
-/// Declines only what it cannot do: a contraction too short to be worth cutting,
-/// or one no equal cut divides. Whether the cut *pays* is left to autotune,
-/// which measures it against the uncut form on the actual shape — a guess about
-/// where the crossover lies would only be a worse version of that measurement.
+/// Declines a contraction too short to be worth cutting, and one that none of
+/// the cuts it considers divides — the search tries powers of two only, which is
+/// where `k = batch * height * width` almost always has its factors, so the rare
+/// `k` whose only equal cuts are odd is left uncut rather than sent down a shape
+/// nothing measured. Whether the cut *pays* is left to autotune, which measures
+/// it against the uncut form on the actual shape — a guess about where the
+/// crossover lies would only be a worse version of that measurement.
 ///
 /// The count has to divide `k` exactly, since the whole point is that the
 /// reshape splitting it is free.
@@ -332,18 +336,35 @@ pub fn wgrad_im2col_1x1_split<R: CubeRuntime, const N: usize>(
 
     check_pointwise(&weight_shape[1..dim_c], &options)?;
 
+    // Every way of bowing out below ends in the uncut form rather than in an
+    // `Err`, so that this candidate declines exactly what [`wgrad_im2col_1x1`]
+    // declines and nothing more. What it would otherwise decline on turns on
+    // `k`, and the autotune key holds the spatial dimensions only anchored: a
+    // shape that declines can share a key with one that did not, and the tuner
+    // unwraps whatever it already picked, so declining on a cached hit aborts
+    // the process.
+    let uncut = {
+        let args = (
+            input.clone(),
+            out_grad.clone(),
+            weight_shape.clone(),
+            options.clone(),
+        );
+        move || wgrad_im2col_1x1::<R, N>(args.0, args.1, args.2, args.3)
+    };
+
+    let rows: usize = input.meta.shape()[..dim_c].iter().product();
+    let Some(split) = split_count(rows) else {
+        return uncut();
+    };
+    let per = rows / split;
+
     let input = reshape_input(input); // [M, C_in]
     let out_grad = reshape_input(out_grad); // [M, C_out]
     let dtype = out_grad.dtype;
 
-    let rows = input.meta.shape()[0];
     let in_channels = input.meta.shape()[1];
     let out_channels = out_grad.meta.shape()[1];
-
-    let Some(split) = split_count(rows) else {
-        return Err(ConvSetupError::Unknown);
-    };
-    let per = rows / split;
 
     // `[M, C]` -> `[split, M / split, C]`. Free: the contraction is the leading
     // axis of both operands, so cutting it only inserts a dimension.
@@ -353,7 +374,9 @@ pub fn wgrad_im2col_1x1_split<R: CubeRuntime, const N: usize>(
     // `[split, C_out, M / split] @ [split, M / split, C_in]`, a stride swap on
     // the gradient as in the uncut form.
     let out_grad = swap_dims(out_grad, 1, 2);
-    let partials = matmul(out_grad, input, None, MatmulStrategy::default(), dtype)?;
+    let Ok(partials) = matmul(out_grad, input, None, MatmulStrategy::default(), dtype) else {
+        return uncut();
+    };
 
     // `[split, C_out, C_in]` -> `[1, C_out, C_in]`. Small next to the matmul:
     // the pieces are the only thing being added, not the contraction.
@@ -363,8 +386,12 @@ pub fn wgrad_im2col_1x1_split<R: CubeRuntime, const N: usize>(
         0,
         KernelReduceStrategy::default(),
         ReduceOperationConfig::Sum,
-    )
-    .expect("the leading axis of a rank-3 tensor is reducible");
+    );
+    // The axis is in range, so only the strategy or the dtype can refuse here —
+    // and the uncut form adds the same products inside its own matmul.
+    let Ok(grad) = grad else {
+        return uncut();
+    };
 
     Ok(reshape(grad, weight_shape))
 }


### PR DESCRIPTION
A weight gradient contracts over every pixel in the batch, so its matmul is `[c_out, k] @ [k, c_in]` with `k = batch * height * width` — enormous against an output that is only channels by channels. A matmul kernel gives each output element the whole of `k`, which on a small output leaves a device with far more lanes than there are output elements mostly idle. The arithmetic is right and the shape is wrong.

Measured on a Radeon 8060S (gfx1151) under vulkan, f32, the same contraction with `m` and `k` traded — identical work, only the shape differing:

  19.33 GFLOP, k-dominant (a 3x3's weight gradient)     1420 GFLOP/s
  19.33 GFLOP, m-dominant (the forward it inverts)      4913 GFLOP/s
   2.15 GFLOP, k-dominant (a 1x1's weight gradient)      341 GFLOP/s
   2.15 GFLOP, m-dominant                               2771 GFLOP/s
  137.4 GFLOP, square, as a control                     5522 GFLOP/s

So `wgrad_im2col_1x1` gains a sibling that cuts `k` into equal pieces, batch-matmuls them and sums the partials. Both reshapes are free: the contraction is the leading axis of both operands' memory, so cutting it only inserts a dimension. On the shapes above the cut recovers the whole gap — 3.53 ms against 13.6 ms for the 3x3 shape, 785 us against 6.29 ms for the 1x1, both landing on their m-dominant twins.

Registered beside the uncut form rather than replacing it, and declining only what it cannot do: a contraction too short to be worth cutting, or one no equal cut divides. Whether the cut *pays* is autotune's to decide against the actual shape, which is a better answer than a threshold.

On an EfficientNet V2-S backbone at batch 4, 384x384, the cut takes five of the network's shapes, worth 2.1x to 6.5x each — the largest a 1x1 weight gradient at 2.699 ms to 0.413 ms. A training step moves 1.323 s to 1.292 s, which is small, and the reason is worth recording: what dominates that backward is the *dense* weight gradient, and it has no matmul to cut. `conv_weight_grad_no_groups` frames one as a convolution of the input by the output gradient, so the gradient is the kernel and the convolution submitted has a kernel the size of the whole feature map — 96x96 taps over 4 channels, which `conv_direct` takes 19.3 ms to do. Laying the input out as columns would make it a matmul this cut then applies to; that is a larger change and is not attempted here.