### PR TITLE
Let a caller install and read a device's memory pools

### DIFF
--- a/crates/burn-autodiff/src/backend.rs
+++ b/crates/burn-autodiff/src/backend.rs
@@ -3,11 +3,14 @@ use crate::{
     grads::Gradients,
     tensor::AutodiffTensor,
 };
-use alloc::{format, string::String};
+use alloc::{format, string::String, vec::Vec};
 use core::marker::PhantomData;
 
 use burn_backend::{
-    backend::{AutodiffBackend, Backend, BackendTypes, ExecutionError},
+    backend::{
+        AutodiffBackend, Backend, BackendTypes, ExecutionError, InstallMemoryPoolsError,
+        MemoryPoolLayout, MemoryPoolUsage, SlicedPoolReport,
+    },
     tensor::{BoolTensor, IntTensor, QuantizedTensor},
 };
 
@@ -70,6 +73,21 @@ impl<B: Backend, C: CheckpointStrategy> Backend for Autodiff<B, C> {
 
     fn memory_cleanup(device: &Self::Device) {
         B::memory_cleanup(device)
+    }
+
+    fn memory_install_pools(
+        device: &Self::Device,
+        layout: MemoryPoolLayout,
+    ) -> Result<(), InstallMemoryPoolsError> {
+        B::memory_install_pools(device, layout)
+    }
+
+    fn memory_pool_report(device: &Self::Device) -> Option<Vec<SlicedPoolReport>> {
+        B::memory_pool_report(device)
+    }
+
+    fn memory_pool_usage(device: &Self::Device) -> Option<MemoryPoolUsage> {
+        B::memory_pool_usage(device)
     }
 
     fn staging<'a, Iter>(data: Iter, device: &Self::Device)

--- a/crates/burn-backend/src/backend/base.rs
+++ b/crates/burn-backend/src/backend/base.rs
@@ -154,30 +154,30 @@ pub trait Backend:
 
     /// Install a layout for the device's dynamic memory pools.
     ///
-    /// A per-workload setting rather than a per-process one: the calling
-    /// stream's pools are rebuilt in place when nothing is live in them — so
-    /// install at a quiescent point, after the previous workload's tensors have
-    /// dropped and a [`memory_cleanup`](Self::memory_cleanup) — and streams
-    /// created afterwards use the new layout.
+    /// A per-workload setting: the calling stream's pools are rebuilt in place
+    /// when nothing is live in them — so install at a quiescent point, after
+    /// the previous workload's tensors have dropped and a
+    /// [`memory_cleanup`](Self::memory_cleanup) — and streams created
+    /// afterwards use the new layout.
     ///
-    /// Sizing a layout from a measurement rather than a guess means installing
-    /// twice: once growable, to run the workload and read
+    /// Sizing a layout from a measurement means installing twice: once
+    /// growable, to run the workload and read
     /// [`memory_pool_report`](Self::memory_pool_report), and once capped at
     /// what that reported.
     ///
     /// # Errors
     ///
     /// [`InstallMemoryPoolsError::PoolsInUse`] when something is still live in
-    /// the pools being rebuilt, which is worth retrying once it drains;
+    /// the pools being rebuilt, worth retrying once it drains;
     /// [`StreamUnavailable`](InstallMemoryPoolsError::StreamUnavailable) when
     /// the calling stream has already failed;
     /// [`InvalidLayout`](InstallMemoryPoolsError::InvalidLayout) when the
-    /// layout itself cannot be honoured, which no retry will change either;
-    /// and [`Unsupported`](InstallMemoryPoolsError::Unsupported) — the default
-    /// — on a backend with no configurable pools.
-    /// The layout in force is unchanged in every case, so a caller that cannot
-    /// proceed without it has to say so rather than assume the reservation it
-    /// asked for.
+    /// layout cannot be honoured; and
+    /// [`Unsupported`](InstallMemoryPoolsError::Unsupported) — the default — on
+    /// a backend with no configurable pools. Neither of the last two is worth a
+    /// retry. The layout in force is unchanged in every case, so a caller that
+    /// cannot proceed without it has to say so rather than assume the
+    /// reservation it asked for.
     #[allow(unused_variables)]
     fn memory_install_pools(
         device: &Self::Device,
@@ -193,10 +193,9 @@ pub trait Backend:
     /// Entries pair one-to-one with the pools of a
     /// [`Sliced`](MemoryPoolLayout::Sliced) or
     /// [`Direct`](MemoryPoolLayout::Direct) layout this caller installed, which
-    /// is the pairing a measured layout is rebuilt from. A layout nobody
-    /// installed — the runtime's own default, or a preset — routes through
-    /// pools of other kinds as well, and those are left out, so its entries
-    /// carry no position a layout can be rebuilt at.
+    /// is what a measured layout is rebuilt from. A layout nobody installed —
+    /// the runtime's default, or a preset — also routes through pools of other
+    /// kinds, which are left out, so its entries carry no rebuildable position.
     ///
     /// Reporting and installing are separate capabilities: a runtime may
     /// describe the pools it has while refusing to be given different ones, so

--- a/crates/burn-backend/src/backend/base.rs
+++ b/crates/burn-backend/src/backend/base.rs
@@ -7,11 +7,13 @@ use crate::ops::*;
 use crate::tensor::{BoolTensor, FloatTensor, IntTensor, QuantizedTensor};
 use crate::{TensorData, TensorMetadata};
 use alloc::string::String;
+use alloc::vec::Vec;
 use enumset::{EnumSet, EnumSetType};
 
 use crate::distributed::{DistributedParamId, DistributedParams};
 
 use super::DeviceOps;
+use super::{InstallMemoryPoolsError, MemoryPoolLayout, MemoryPoolUsage, SlicedPoolReport};
 
 /// The mapping of types used by Backend and traits.
 pub trait BackendTypes: Clone + Send + Sync + core::fmt::Debug + 'static {
@@ -149,6 +151,57 @@ pub trait Backend:
     /// Manually triggers a memory cleanup on the given device.
     #[allow(unused_variables)]
     fn memory_cleanup(device: &Self::Device) {}
+
+    /// Install a layout for the device's dynamic memory pools.
+    ///
+    /// A per-workload setting rather than a per-process one: the calling
+    /// stream's pools are rebuilt in place when nothing is live in them — so
+    /// install at a quiescent point, after the previous workload's tensors have
+    /// dropped and a [`memory_cleanup`](Self::memory_cleanup) — and streams
+    /// created afterwards use the new layout.
+    ///
+    /// Sizing a layout from a measurement rather than a guess means installing
+    /// twice: once growable, to run the workload and read
+    /// [`memory_pool_report`](Self::memory_pool_report), and once capped at
+    /// what that reported.
+    ///
+    /// # Errors
+    ///
+    /// [`InstallMemoryPoolsError::PoolsInUse`] when something is still live in
+    /// the pools being rebuilt, which is worth retrying once it drains;
+    /// [`StreamUnavailable`](InstallMemoryPoolsError::StreamUnavailable) when
+    /// the calling stream has already failed; and
+    /// [`Unsupported`](InstallMemoryPoolsError::Unsupported) — the default —
+    /// on a backend with no configurable pools, which no retry will change.
+    /// The layout in force is unchanged in every case, so a caller that cannot
+    /// proceed without it has to say so rather than assume the reservation it
+    /// asked for.
+    #[allow(unused_variables)]
+    fn memory_install_pools(
+        device: &Self::Device,
+        layout: MemoryPoolLayout,
+    ) -> Result<(), InstallMemoryPoolsError> {
+        Err(InstallMemoryPoolsError::Unsupported)
+    }
+
+    /// The dynamic pools' measured state, in the order they were installed.
+    /// `None` on a backend that does not report one.
+    ///
+    /// Reporting and installing are separate capabilities: a runtime may
+    /// describe the pools it has while refusing to be given different ones, so
+    /// a report is not proof that a layout was installed. Only the result of
+    /// [`memory_install_pools`](Self::memory_install_pools) says that.
+    #[allow(unused_variables)]
+    fn memory_pool_report(device: &Self::Device) -> Option<Vec<SlicedPoolReport>> {
+        None
+    }
+
+    /// The device allocator's current state. `None` on a backend that does not
+    /// report one.
+    #[allow(unused_variables)]
+    fn memory_pool_usage(device: &Self::Device) -> Option<MemoryPoolUsage> {
+        None
+    }
 
     /// Name of the backend.
     fn name(device: &Self::Device) -> String;

--- a/crates/burn-backend/src/backend/base.rs
+++ b/crates/burn-backend/src/backend/base.rs
@@ -170,9 +170,11 @@ pub trait Backend:
     /// [`InstallMemoryPoolsError::PoolsInUse`] when something is still live in
     /// the pools being rebuilt, which is worth retrying once it drains;
     /// [`StreamUnavailable`](InstallMemoryPoolsError::StreamUnavailable) when
-    /// the calling stream has already failed; and
-    /// [`Unsupported`](InstallMemoryPoolsError::Unsupported) — the default —
-    /// on a backend with no configurable pools, which no retry will change.
+    /// the calling stream has already failed;
+    /// [`InvalidLayout`](InstallMemoryPoolsError::InvalidLayout) when the
+    /// layout itself cannot be honoured, which no retry will change either;
+    /// and [`Unsupported`](InstallMemoryPoolsError::Unsupported) — the default
+    /// — on a backend with no configurable pools.
     /// The layout in force is unchanged in every case, so a caller that cannot
     /// proceed without it has to say so rather than assume the reservation it
     /// asked for.
@@ -184,8 +186,17 @@ pub trait Backend:
         Err(InstallMemoryPoolsError::Unsupported)
     }
 
-    /// The dynamic pools' measured state, in the order they were installed.
-    /// `None` on a backend that does not report one.
+    /// The dynamic pools' measured state, in the order allocations are routed
+    /// through them. `None` on a backend that does not report one, or whose
+    /// stream has failed.
+    ///
+    /// Entries pair one-to-one with the pools of a
+    /// [`Sliced`](MemoryPoolLayout::Sliced) or
+    /// [`Direct`](MemoryPoolLayout::Direct) layout this caller installed, which
+    /// is the pairing a measured layout is rebuilt from. A layout nobody
+    /// installed — the runtime's own default, or a preset — routes through
+    /// pools of other kinds as well, and those are left out, so its entries
+    /// carry no position a layout can be rebuilt at.
     ///
     /// Reporting and installing are separate capabilities: a runtime may
     /// describe the pools it has while refusing to be given different ones, so
@@ -197,7 +208,7 @@ pub trait Backend:
     }
 
     /// The device allocator's current state. `None` on a backend that does not
-    /// report one.
+    /// report one, or whose stream has failed.
     #[allow(unused_variables)]
     fn memory_pool_usage(device: &Self::Device) -> Option<MemoryPoolUsage> {
         None

--- a/crates/burn-backend/src/backend/memory_pools.rs
+++ b/crates/burn-backend/src/backend/memory_pools.rs
@@ -11,6 +11,7 @@
 //! [`Backend`](super::Backend) is implemented by backends with no notion of a
 //! pool at all, which is why every method here has a default saying so.
 
+use alloc::string::String;
 use alloc::vec::Vec;
 
 /// A layout for a device's dynamic memory pools, applied with
@@ -40,10 +41,17 @@ pub enum MemoryPoolLayout {
 /// One pool of a [`MemoryPoolLayout::Sliced`] layout: allocations are slices of
 /// fixed-size pages, capped at `pages` pages. An allocation that no longer fits
 /// goes to the next pool that accepts it, and fails when none does.
+///
+/// Sizes are rounded up to the device's allocation alignment, so a pool holds
+/// at least what it was asked for. A layout that cannot be honoured at all —
+/// a zero size, `max_slice` past `page_size`, `pages` outside `1..=65535` — is
+/// refused with
+/// [`InvalidLayout`](InstallMemoryPoolsError::InvalidLayout) rather than
+/// quietly adjusted.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SlicedPool {
     /// Size of each page in bytes; also the largest single allocation this pool
-    /// can serve.
+    /// can serve. Rounded up to the device's alignment.
     pub page_size: u64,
     /// How many pages the pool may hold. `None` grows without a cap, which is
     /// what a workload is measured on before its caps are known.
@@ -94,7 +102,7 @@ pub struct MemoryPoolUsage {
 /// backend with no configurable pools will refuse forever — and a caller that
 /// treats the two alike either gives up on a layout it could have installed, or
 /// repeats an expensive measurement that can never succeed.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum InstallMemoryPoolsError {
     /// The pools being rebuilt still hold live allocations, so the previous
     /// layout was kept. Transient.
@@ -108,6 +116,15 @@ pub enum InstallMemoryPoolsError {
     StreamUnavailable,
     /// This backend has no configurable dynamic pools. Permanent.
     Unsupported,
+    /// The layout itself cannot be honoured, so the previous one was kept: an
+    /// empty pool list, a zero size, a slice larger than its page, a cap too
+    /// small to hold a page or spanning more pages than a pool can address, or
+    /// a pool shape this build has none of. Permanent for this layout — what
+    /// has to change is the layout, not the moment it is installed at.
+    InvalidLayout {
+        /// What the backend objected to, in its own words.
+        reason: String,
+    },
 }
 
 impl core::fmt::Display for InstallMemoryPoolsError {
@@ -121,6 +138,9 @@ impl core::fmt::Display for InstallMemoryPoolsError {
             }
             Self::Unsupported => {
                 write!(formatter, "this backend has no configurable memory pools")
+            }
+            Self::InvalidLayout { reason } => {
+                write!(formatter, "the pool layout cannot be honoured: {reason}")
             }
         }
     }

--- a/crates/burn-backend/src/backend/memory_pools.rs
+++ b/crates/burn-backend/src/backend/memory_pools.rs
@@ -1,15 +1,14 @@
 //! The layout of a device's dynamic memory pools, and what one reports.
 //!
-//! A backend's allocator normally grows: it keeps whatever page it ever needed,
-//! so a long-running workload reserves its worst moment for the rest of its
-//! life. These types let a caller install a layout of its own instead — a pool
-//! per size class, each capped at a number of pages — and read back what a
-//! workload actually held, so the caps can be a measurement rather than a
-//! guess.
+//! An allocator that only grows keeps whatever page it ever needed, so a
+//! long-running workload reserves its worst moment for life. These types let a
+//! caller install a layout of its own — a pool per size class, each capped at a
+//! number of pages — and read back what the workload actually held, so the caps
+//! are a measurement rather than a guess.
 //!
-//! The vocabulary is deliberately the backend's own rather than any runtime's:
-//! [`Backend`](super::Backend) is implemented by backends with no notion of a
-//! pool at all, which is why every method here has a default saying so.
+//! The vocabulary is the backend's own rather than any runtime's, since
+//! [`Backend`](super::Backend) is also implemented by backends with no pools at
+//! all.
 
 use alloc::string::String;
 use alloc::vec::Vec;
@@ -23,13 +22,11 @@ pub enum MemoryPoolLayout {
     /// accepts its size, so a small pool listed before a large one captures the
     /// small-allocation traffic. Pages are allocated on first use.
     Sliced(Vec<SlicedPool>),
-    /// One direct pool for everything: every allocation is its own device
-    /// allocation, sized to the request and reused by exact size — no pages, no
-    /// sub-slicing, no padding beyond alignment.
-    ///
-    /// A layout with no page size chosen in advance, which is what a workload
-    /// has to run on for its largest allocation to be read back as it was asked
-    /// for.
+    /// One direct pool for everything: every allocation is its own, sized to
+    /// the request and reused by exact size — no pages, no sub-slicing, no
+    /// padding beyond alignment. With no page size chosen in advance, this is
+    /// what a workload runs on for its largest allocation to be read back as it
+    /// was asked for.
     Direct,
     /// The runtime's default: a ladder of size-bucketed pools that sub-slice
     /// large pages.
@@ -42,12 +39,10 @@ pub enum MemoryPoolLayout {
 /// fixed-size pages, capped at `pages` pages. An allocation that no longer fits
 /// goes to the next pool that accepts it, and fails when none does.
 ///
-/// Sizes are rounded up to the device's allocation alignment, so a pool holds
-/// at least what it was asked for. A layout that cannot be honoured at all —
-/// a zero size, `max_slice` past `page_size`, `pages` outside `1..=65535` — is
-/// refused with
-/// [`InvalidLayout`](InstallMemoryPoolsError::InvalidLayout) rather than
-/// quietly adjusted.
+/// Sizes are rounded up to the device's alignment, so a pool holds at least
+/// what it was asked for. A layout that cannot be honoured at all — a zero
+/// size, `max_slice` past `page_size`, `pages` outside `1..=65535` — is refused
+/// with [`InvalidLayout`](InstallMemoryPoolsError::InvalidLayout).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SlicedPool {
     /// Size of each page in bytes; also the largest single allocation this pool
@@ -63,10 +58,10 @@ pub struct SlicedPool {
 
 /// One dynamic pool's measured state, in the order the pools were installed.
 ///
-/// The read side of a measured layout: install a growable layout, run the
-/// workload, read these, then re-install the same layout capped at
-/// `pages_peak`. Pool placement is deterministic, so the same stream of
-/// allocation sizes fits the capped layout by construction.
+/// The read side of a measured layout: install a growable one, run the
+/// workload, read these, re-install capped at `pages_peak`. Pool placement is
+/// deterministic, so the same allocations fit the capped layout by
+/// construction.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct SlicedPoolReport {
     /// Size of each page in bytes; `0` for a [direct](MemoryPoolLayout::Direct)
@@ -97,11 +92,11 @@ pub struct MemoryPoolUsage {
 
 /// Why installing a pool layout did not take effect.
 ///
-/// The distinction a caller needs is **transient or permanent**. A refused
-/// rebuild is worth retrying once whatever holds the pools drains, whereas a
-/// backend with no configurable pools will refuse forever — and a caller that
-/// treats the two alike either gives up on a layout it could have installed, or
-/// repeats an expensive measurement that can never succeed.
+/// The distinction a caller needs is **transient or permanent**: a refused
+/// rebuild is worth retrying once whatever holds the pools drains, while a
+/// backend with no configurable pools refuses forever. Treating the two alike
+/// either gives up on a layout that would have installed, or repeats an
+/// expensive measurement that can never succeed.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum InstallMemoryPoolsError {
     /// The pools being rebuilt still hold live allocations, so the previous
@@ -117,9 +112,8 @@ pub enum InstallMemoryPoolsError {
     /// This backend has no configurable dynamic pools. Permanent.
     Unsupported,
     /// The layout itself cannot be honoured, so the previous one was kept: an
-    /// empty pool list, a zero size, a slice larger than its page, a cap too
-    /// small to hold a page or spanning more pages than a pool can address, or
-    /// a pool shape this build has none of. Permanent for this layout — what
+    /// empty pool list, a zero size, a slice larger than its page, an
+    /// unusable cap, or a pool shape this build has none of. Permanent — what
     /// has to change is the layout, not the moment it is installed at.
     InvalidLayout {
         /// What the backend objected to, in its own words.

--- a/crates/burn-backend/src/backend/memory_pools.rs
+++ b/crates/burn-backend/src/backend/memory_pools.rs
@@ -1,0 +1,129 @@
+//! The layout of a device's dynamic memory pools, and what one reports.
+//!
+//! A backend's allocator normally grows: it keeps whatever page it ever needed,
+//! so a long-running workload reserves its worst moment for the rest of its
+//! life. These types let a caller install a layout of its own instead — a pool
+//! per size class, each capped at a number of pages — and read back what a
+//! workload actually held, so the caps can be a measurement rather than a
+//! guess.
+//!
+//! The vocabulary is deliberately the backend's own rather than any runtime's:
+//! [`Backend`](super::Backend) is implemented by backends with no notion of a
+//! pool at all, which is why every method here has a default saying so.
+
+use alloc::vec::Vec;
+
+/// A layout for a device's dynamic memory pools, applied with
+/// [`Backend::memory_install_pools`](super::Backend::memory_install_pools).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MemoryPoolLayout {
+    /// An ordered list of pools that sub-slice fixed-size pages. An allocation
+    /// lands in the first pool whose [`max_slice`](SlicedPool::max_slice)
+    /// accepts its size, so a small pool listed before a large one captures the
+    /// small-allocation traffic. Pages are allocated on first use.
+    Sliced(Vec<SlicedPool>),
+    /// One direct pool for everything: every allocation is its own device
+    /// allocation, sized to the request and reused by exact size — no pages, no
+    /// sub-slicing, no padding beyond alignment.
+    ///
+    /// A layout with no page size chosen in advance, which is what a workload
+    /// has to run on for its largest allocation to be read back as it was asked
+    /// for.
+    Direct,
+    /// The runtime's default: a ladder of size-bucketed pools that sub-slice
+    /// large pages.
+    SubSlices,
+    /// One page per allocation, in exponentially spaced size buckets.
+    ExclusivePages,
+}
+
+/// One pool of a [`MemoryPoolLayout::Sliced`] layout: allocations are slices of
+/// fixed-size pages, capped at `pages` pages. An allocation that no longer fits
+/// goes to the next pool that accepts it, and fails when none does.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SlicedPool {
+    /// Size of each page in bytes; also the largest single allocation this pool
+    /// can serve.
+    pub page_size: u64,
+    /// How many pages the pool may hold. `None` grows without a cap, which is
+    /// what a workload is measured on before its caps are known.
+    pub pages: Option<u64>,
+    /// Largest allocation routed to this pool; `None` accepts anything up to
+    /// `page_size`. Later pools see only what this one declines.
+    pub max_slice: Option<u64>,
+}
+
+/// One dynamic pool's measured state, in the order the pools were installed.
+///
+/// The read side of a measured layout: install a growable layout, run the
+/// workload, read these, then re-install the same layout capped at
+/// `pages_peak`. Pool placement is deterministic, so the same stream of
+/// allocation sizes fits the capped layout by construction.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SlicedPoolReport {
+    /// Size of each page in bytes; `0` for a [direct](MemoryPoolLayout::Direct)
+    /// pool, which has no pages to size.
+    pub page_size: u64,
+    /// Pages currently held — for a direct pool, live allocations.
+    pub pages: u64,
+    /// The most pages ever held at once.
+    pub pages_peak: u64,
+    /// The largest single allocation served, in requested bytes.
+    pub largest_alloc: u64,
+}
+
+/// One reading of a device allocator's state, across the runtime's streams and
+/// pools.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct MemoryPoolUsage {
+    /// Live allocations, not pages.
+    pub number_allocs: u64,
+    /// Bytes those allocations use, excluding padding.
+    pub bytes_in_use: u64,
+    /// Bytes of padding inside them.
+    pub bytes_padding: u64,
+    /// Total bytes reserved on the device: at least `bytes_in_use`, plus pages
+    /// held for reuse.
+    pub bytes_reserved: u64,
+}
+
+/// Why installing a pool layout did not take effect.
+///
+/// The distinction a caller needs is **transient or permanent**. A refused
+/// rebuild is worth retrying once whatever holds the pools drains, whereas a
+/// backend with no configurable pools will refuse forever — and a caller that
+/// treats the two alike either gives up on a layout it could have installed, or
+/// repeats an expensive measurement that can never succeed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InstallMemoryPoolsError {
+    /// The pools being rebuilt still hold live allocations, so the previous
+    /// layout was kept. Transient.
+    PoolsInUse {
+        /// Bytes still live in those pools.
+        bytes_in_use: u64,
+    },
+    /// The calling stream is already in an error state, so its pools were not
+    /// rebuilt. The layout still applies to streams created afterwards, and the
+    /// underlying failure surfaces at the next flush or sync.
+    StreamUnavailable,
+    /// This backend has no configurable dynamic pools. Permanent.
+    Unsupported,
+}
+
+impl core::fmt::Display for InstallMemoryPoolsError {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::PoolsInUse { bytes_in_use } => {
+                write!(formatter, "{bytes_in_use} B still live in the pools")
+            }
+            Self::StreamUnavailable => {
+                write!(formatter, "the calling stream is in an error state")
+            }
+            Self::Unsupported => {
+                write!(formatter, "this backend has no configurable memory pools")
+            }
+        }
+    }
+}
+
+impl core::error::Error for InstallMemoryPoolsError {}

--- a/crates/burn-backend/src/backend/mod.rs
+++ b/crates/burn-backend/src/backend/mod.rs
@@ -1,9 +1,11 @@
 mod base;
 mod device;
+mod memory_pools;
 mod primitive;
 
 pub use base::*;
 pub use device::*;
+pub use memory_pools::*;
 pub use primitive::*;
 
 /// Backend operations on tensors.

--- a/crates/burn-cubecl/src/backend.rs
+++ b/crates/burn-cubecl/src/backend.rs
@@ -146,10 +146,9 @@ where
         let properties = &client.properties().memory;
         let config = pool_config(layout, properties.alignment.max(1))?;
 
-        // The runtime treats an unhonourable layout as a bad literal and
-        // panics on it — which lands on a device thread the caller cannot
-        // catch, and takes the device with it. Resolving the layout here first
-        // turns that into this method's own error, by the runtime's own rules
+        // The runtime panics on an unhonourable layout, on a device thread the
+        // caller cannot catch and taking the device with it. Resolving it here
+        // first turns that into this method's error, by the runtime's own rules
         // rather than a second copy of them.
         MemoryConfiguration::default()
             .resolve(Some(&config), properties)
@@ -170,10 +169,8 @@ where
         // The pools a layout can be paired with, in the order allocations are
         // routed through them: a `Sliced` layout maps onto them one to one, and
         // a `Direct` layout is the single entry with no page size. The presets
-        // mix in pools of other kinds, which no measurement is derived from —
-        // so their entries keep the routing order but not the positions of any
-        // layout, which is why only a layout this caller installed can be
-        // rebuilt from a report.
+        // mix in pools of other kinds, dropped here — so their entries keep the
+        // routing order but not the positions of any layout.
         Some(
             report
                 .dynamic
@@ -352,11 +349,10 @@ impl<R: CubeRuntime> BackendIr for CubeBackend<R> {
 }
 
 /// A pool layout in the runtime's own vocabulary, with sizes aligned to
-/// `alignment` — the same rounding the runtime applies, done here because the
-/// cap is a number of pages and has to be counted in the pages the runtime will
-/// actually build. Multiplying the *requested* page size instead buys a cap
-/// that fits fewer aligned pages than were asked for, and for a single-page
-/// pool one that cannot fit a page at all.
+/// `alignment` — the rounding the runtime applies anyway, done here because the
+/// cap has to be counted in the pages it will actually build. Multiplying the
+/// *requested* page size instead buys fewer aligned pages than were asked for,
+/// and for a single-page pool a cap that cannot fit its page at all.
 fn pool_config(
     layout: MemoryPoolLayout,
     alignment: u64,
@@ -412,8 +408,8 @@ fn pool_config(
     Ok(config)
 }
 
-/// A size rounded up to the device's alignment. Zero stays zero, which the
-/// layout's own validation rejects with the field it belongs to.
+/// A size rounded up to the device's alignment. Zero stays zero, for the
+/// layout's own validation to reject by field.
 fn align_up(size: u64, alignment: u64) -> Result<u64, InstallMemoryPoolsError> {
     size.checked_next_multiple_of(alignment)
         .ok_or_else(|| InstallMemoryPoolsError::InvalidLayout {

--- a/crates/burn-cubecl/src/backend.rs
+++ b/crates/burn-cubecl/src/backend.rs
@@ -2,11 +2,15 @@ use crate::{CubeRuntime, tensor::CubeTensor};
 use burn_backend::cubecl::dtype_to_storage_type;
 use burn_backend::{
     Backend, BackendGraph, BackendTypes, DTypeUsage, DTypeUsageSet, DeviceOps, ExecutionError,
+    InstallMemoryPoolsError, MemoryPoolLayout, MemoryPoolUsage, SlicedPool, SlicedPoolReport,
     TensorData,
 };
 use burn_std::{BoolStore, DType, quantization::quantizable};
 use cubecl::{
+    MemoryPoolKind,
     client::ComputeClient,
+    config::memory::{MemoryPoolConfig, MemoryPoolsConfig, MemoryPoolsPreset},
+    config::size::MemorySize,
     features::{MmaConfig, TypeUsage},
     ir::ElemType,
     server::ComputeServer,
@@ -132,6 +136,56 @@ where
     fn memory_cleanup(device: &Self::Device) {
         let client = R::client(device);
         client.memory_cleanup();
+    }
+
+    fn memory_install_pools(
+        device: &Self::Device,
+        layout: MemoryPoolLayout,
+    ) -> Result<(), InstallMemoryPoolsError> {
+        R::client(device)
+            .install_memory_pools(&pool_config(layout))
+            .map_err(runtime_install_error)
+    }
+
+    fn memory_pool_report(device: &Self::Device) -> Option<Vec<SlicedPoolReport>> {
+        let report = R::client(device).memory_report().ok()?;
+
+        // The pools a layout can be paired with, in the order allocations are
+        // routed through them: a `Sliced` layout maps onto them one to one, and
+        // a `Direct` layout is the single entry with no page size. The presets
+        // mix in pools of other kinds, which no measurement is derived from.
+        Some(
+            report
+                .dynamic
+                .iter()
+                .filter_map(|pool| match pool.kind {
+                    MemoryPoolKind::Sliced { page_size, .. } => Some(SlicedPoolReport {
+                        page_size,
+                        pages: pool.pages,
+                        pages_peak: pool.pages_peak,
+                        largest_alloc: pool.largest_alloc,
+                    }),
+                    MemoryPoolKind::Direct => Some(SlicedPoolReport {
+                        page_size: 0,
+                        pages: pool.pages,
+                        pages_peak: pool.pages_peak,
+                        largest_alloc: pool.largest_alloc,
+                    }),
+                    _ => None,
+                })
+                .collect(),
+        )
+    }
+
+    fn memory_pool_usage(device: &Self::Device) -> Option<MemoryPoolUsage> {
+        let usage = R::client(device).memory_usage().ok()?;
+
+        Some(MemoryPoolUsage {
+            number_allocs: usage.number_allocs,
+            bytes_in_use: usage.bytes_in_use,
+            bytes_padding: usage.bytes_padding,
+            bytes_reserved: usage.bytes_reserved,
+        })
     }
 
     fn staging<'a, Iter>(data: Iter, device: &Self::Device)
@@ -273,5 +327,52 @@ impl<R: CubeRuntime> BackendIr for CubeBackend<R> {
 
     fn quantized_tensor_handle(tensor: QuantizedTensor<Self>) -> Self::Handle {
         tensor
+    }
+}
+
+/// A pool layout in the runtime's own vocabulary.
+fn pool_config(layout: MemoryPoolLayout) -> MemoryPoolsConfig {
+    match layout {
+        MemoryPoolLayout::Sliced(pools) => MemoryPoolsConfig::Explicit(
+            pools
+                .into_iter()
+                .map(
+                    |SlicedPool {
+                         page_size,
+                         pages,
+                         max_slice,
+                     }| MemoryPoolConfig::Sliced {
+                        page_size: MemorySize(page_size),
+                        max_slice_size: max_slice.map(MemorySize),
+                        max_pool_size: pages
+                            .map(|pages| MemorySize(page_size.saturating_mul(pages))),
+                        dealloc_period: None,
+                    },
+                )
+                .collect(),
+        ),
+        // Never reclaiming on its own: a direct pool is installed to measure
+        // what a workload allocates, which is a short window with an explicit
+        // cleanup on either side of it.
+        MemoryPoolLayout::Direct => {
+            MemoryPoolsConfig::Explicit(vec![MemoryPoolConfig::Direct { reclaim_at: None }])
+        }
+        MemoryPoolLayout::SubSlices => MemoryPoolsConfig::Preset(MemoryPoolsPreset::SubSlices),
+        MemoryPoolLayout::ExclusivePages => {
+            MemoryPoolsConfig::Preset(MemoryPoolsPreset::ExclusivePages)
+        }
+    }
+}
+
+/// The runtime's refusal, in the backend's vocabulary.
+fn runtime_install_error(err: cubecl::InstallMemoryPoolsError) -> InstallMemoryPoolsError {
+    match err {
+        cubecl::InstallMemoryPoolsError::PoolsInUse { bytes_in_use } => {
+            InstallMemoryPoolsError::PoolsInUse { bytes_in_use }
+        }
+        cubecl::InstallMemoryPoolsError::StreamUnavailable => {
+            InstallMemoryPoolsError::StreamUnavailable
+        }
+        cubecl::InstallMemoryPoolsError::Unsupported => InstallMemoryPoolsError::Unsupported,
     }
 }

--- a/crates/burn-cubecl/src/backend.rs
+++ b/crates/burn-cubecl/src/backend.rs
@@ -7,7 +7,7 @@ use burn_backend::{
 };
 use burn_std::{BoolStore, DType, quantization::quantizable};
 use cubecl::{
-    MemoryPoolKind,
+    MemoryConfiguration, MemoryPoolKind,
     client::ComputeClient,
     config::memory::{MemoryPoolConfig, MemoryPoolsConfig, MemoryPoolsPreset},
     config::size::MemorySize,
@@ -142,18 +142,38 @@ where
         device: &Self::Device,
         layout: MemoryPoolLayout,
     ) -> Result<(), InstallMemoryPoolsError> {
-        R::client(device)
-            .install_memory_pools(&pool_config(layout))
+        let client = R::client(device);
+        let properties = &client.properties().memory;
+        let config = pool_config(layout, properties.alignment.max(1))?;
+
+        // The runtime treats an unhonourable layout as a bad literal and
+        // panics on it — which lands on a device thread the caller cannot
+        // catch, and takes the device with it. Resolving the layout here first
+        // turns that into this method's own error, by the runtime's own rules
+        // rather than a second copy of them.
+        MemoryConfiguration::default()
+            .resolve(Some(&config), properties)
+            .map_err(|err| InstallMemoryPoolsError::InvalidLayout {
+                reason: err.to_string(),
+            })?;
+
+        client
+            .install_memory_pools(&config)
             .map_err(runtime_install_error)
     }
 
     fn memory_pool_report(device: &Self::Device) -> Option<Vec<SlicedPoolReport>> {
+        // A failed stream reports nothing, same as a runtime that has nothing
+        // to report: the failure itself surfaces at the next flush or sync.
         let report = R::client(device).memory_report().ok()?;
 
         // The pools a layout can be paired with, in the order allocations are
         // routed through them: a `Sliced` layout maps onto them one to one, and
         // a `Direct` layout is the single entry with no page size. The presets
-        // mix in pools of other kinds, which no measurement is derived from.
+        // mix in pools of other kinds, which no measurement is derived from —
+        // so their entries keep the routing order but not the positions of any
+        // layout, which is why only a layout this caller installed can be
+        // rebuilt from a report.
         Some(
             report
                 .dynamic
@@ -178,6 +198,7 @@ where
     }
 
     fn memory_pool_usage(device: &Self::Device) -> Option<MemoryPoolUsage> {
+        // As with the report: a failed stream reads as nothing to report.
         let usage = R::client(device).memory_usage().ok()?;
 
         Some(MemoryPoolUsage {
@@ -330,9 +351,17 @@ impl<R: CubeRuntime> BackendIr for CubeBackend<R> {
     }
 }
 
-/// A pool layout in the runtime's own vocabulary.
-fn pool_config(layout: MemoryPoolLayout) -> MemoryPoolsConfig {
-    match layout {
+/// A pool layout in the runtime's own vocabulary, with sizes aligned to
+/// `alignment` — the same rounding the runtime applies, done here because the
+/// cap is a number of pages and has to be counted in the pages the runtime will
+/// actually build. Multiplying the *requested* page size instead buys a cap
+/// that fits fewer aligned pages than were asked for, and for a single-page
+/// pool one that cannot fit a page at all.
+fn pool_config(
+    layout: MemoryPoolLayout,
+    alignment: u64,
+) -> Result<MemoryPoolsConfig, InstallMemoryPoolsError> {
+    let config = match layout {
         MemoryPoolLayout::Sliced(pools) => MemoryPoolsConfig::Explicit(
             pools
                 .into_iter()
@@ -341,15 +370,32 @@ fn pool_config(layout: MemoryPoolLayout) -> MemoryPoolsConfig {
                          page_size,
                          pages,
                          max_slice,
-                     }| MemoryPoolConfig::Sliced {
-                        page_size: MemorySize(page_size),
-                        max_slice_size: max_slice.map(MemorySize),
-                        max_pool_size: pages
-                            .map(|pages| MemorySize(page_size.saturating_mul(pages))),
-                        dealloc_period: None,
+                     }| {
+                        let page_size = align_up(page_size, alignment)?;
+                        let max_pool_size = pages
+                            .map(|pages| {
+                                page_size.checked_mul(pages).ok_or_else(|| {
+                                    InstallMemoryPoolsError::InvalidLayout {
+                                        reason: format!(
+                                            "a cap of {pages} pages of {page_size} B overflows"
+                                        ),
+                                    }
+                                })
+                            })
+                            .transpose()?;
+
+                        Ok(MemoryPoolConfig::Sliced {
+                            page_size: MemorySize(page_size),
+                            max_slice_size: max_slice
+                                .map(|size| align_up(size, alignment))
+                                .transpose()?
+                                .map(MemorySize),
+                            max_pool_size: max_pool_size.map(MemorySize),
+                            dealloc_period: None,
+                        })
                     },
                 )
-                .collect(),
+                .collect::<Result<Vec<_>, _>>()?,
         ),
         // Never reclaiming on its own: a direct pool is installed to measure
         // what a workload allocates, which is a short window with an explicit
@@ -361,7 +407,18 @@ fn pool_config(layout: MemoryPoolLayout) -> MemoryPoolsConfig {
         MemoryPoolLayout::ExclusivePages => {
             MemoryPoolsConfig::Preset(MemoryPoolsPreset::ExclusivePages)
         }
-    }
+    };
+
+    Ok(config)
+}
+
+/// A size rounded up to the device's alignment. Zero stays zero, which the
+/// layout's own validation rejects with the field it belongs to.
+fn align_up(size: u64, alignment: u64) -> Result<u64, InstallMemoryPoolsError> {
+    size.checked_next_multiple_of(alignment)
+        .ok_or_else(|| InstallMemoryPoolsError::InvalidLayout {
+            reason: format!("{size} B cannot be aligned up to {alignment} B"),
+        })
 }
 
 /// The runtime's refusal, in the backend's vocabulary.

--- a/crates/burn-dispatch/src/backend.rs
+++ b/crates/burn-dispatch/src/backend.rs
@@ -12,7 +12,10 @@ use alloc::vec;
 
 #[cfg(feature = "autodiff")]
 use burn_backend::distributed::{DistributedParamId, DistributedParams};
-use burn_backend::{AutodiffBackend, Backend, BackendGraph, BackendTypes, DType, ExecutionError};
+use burn_backend::{
+    AutodiffBackend, Backend, BackendGraph, BackendTypes, DType, ExecutionError,
+    InstallMemoryPoolsError, MemoryPoolLayout, MemoryPoolUsage, SlicedPoolReport,
+};
 
 /// A captured graph from one of the dispatched backends (see
 /// [`BackendTypes::GraphPrimitive`]).
@@ -260,6 +263,24 @@ impl Backend for Dispatch {
 
     fn memory_cleanup(device: &Self::Device) {
         dispatch_device!(device, |device| B::memory_cleanup(device))
+    }
+
+    fn memory_install_pools(
+        device: &Self::Device,
+        layout: MemoryPoolLayout,
+    ) -> Result<(), InstallMemoryPoolsError> {
+        dispatch_device!(device, |device| B::memory_install_pools(
+            device,
+            layout.clone()
+        ))
+    }
+
+    fn memory_pool_report(device: &Self::Device) -> Option<Vec<SlicedPoolReport>> {
+        dispatch_device!(device, |device| B::memory_pool_report(device))
+    }
+
+    fn memory_pool_usage(device: &Self::Device) -> Option<MemoryPoolUsage> {
+        dispatch_device!(device, |device| B::memory_pool_usage(device))
     }
 
     fn staging<'a, Iter>(data: Iter, device: &Self::Device)

--- a/crates/burn-fusion/src/backend.rs
+++ b/crates/burn-fusion/src/backend.rs
@@ -4,7 +4,8 @@ use crate::{
     stream::{Context, OrderedExecution},
 };
 use burn_backend::{
-    Backend, BackendGraph, BackendTypes, DType, DeviceOps, ExecutionError,
+    Backend, BackendGraph, BackendTypes, DType, DeviceOps, ExecutionError, InstallMemoryPoolsError,
+    MemoryPoolLayout, MemoryPoolUsage, SlicedPoolReport,
     tensor::{BoolTensor, Device, FloatTensor, IntTensor, QuantizedTensor},
 };
 use burn_ir::{BackendIr, HandleContainer, OperationIr, TensorHandle, TensorIr};
@@ -90,6 +91,41 @@ impl<B: FusionBackend> Backend for Fusion<B> {
 
     fn memory_cleanup(device: &Self::Device) {
         B::memory_cleanup(device)
+    }
+
+    fn memory_install_pools(
+        device: &Self::Device,
+        layout: MemoryPoolLayout,
+    ) -> Result<(), InstallMemoryPoolsError> {
+        // Pools belong to a stream, and fused operations allocate on the fusion
+        // server thread's — so the rebuild has to be issued from that thread to
+        // reach the right one. `sync` also drains what has already been
+        // recorded, so the rebuild sees a quiescent stream rather than refusing
+        // over operations that have not run yet.
+        let client = GlobalFusionClient::<B::FusionRuntime>::load(device);
+        let device = device.clone();
+
+        client.sync(move || B::memory_install_pools(&device, layout))
+    }
+
+    fn memory_pool_report(device: &Self::Device) -> Option<Vec<SlicedPoolReport>> {
+        // Reads the *calling* stream, which is the one the layout was installed
+        // on and the one fused operations allocate from, so it hops exactly as
+        // the install does.
+        let client = GlobalFusionClient::<B::FusionRuntime>::load(device);
+        let device = device.clone();
+
+        client.sync(move || B::memory_pool_report(&device))
+    }
+
+    fn memory_pool_usage(device: &Self::Device) -> Option<MemoryPoolUsage> {
+        // Combined across the runtime's streams, so no hop is needed for the
+        // reading itself — but recorded operations have to be drained first or
+        // they are missing from it.
+        let client = GlobalFusionClient::<B::FusionRuntime>::load(device);
+        let device = device.clone();
+
+        client.sync(move || B::memory_pool_usage(&device))
     }
 
     fn staging<'a, Iter>(data: Iter, device: &Self::Device)

--- a/crates/burn-std/src/data/tensor/base.rs
+++ b/crates/burn-std/src/data/tensor/base.rs
@@ -1,6 +1,7 @@
 use core::f32;
 
 use alloc::format;
+use alloc::string::String;
 use alloc::vec::Vec;
 use bytemuck::checked::CheckedCastError;
 use rand::Rng;

--- a/crates/burn-tensor/src/device.rs
+++ b/crates/burn-tensor/src/device.rs
@@ -5,6 +5,9 @@ pub use burn_std::{
 #[cfg(feature = "cubecl")]
 pub use burn_backend::cubecl::{ThroughputKey, ThroughputMode, ThroughputValue};
 use burn_backend::{Backend, DeviceOps};
+pub use burn_backend::{
+    InstallMemoryPoolsError, MemoryPoolLayout, MemoryPoolUsage, SlicedPool, SlicedPoolReport,
+};
 #[allow(unused)]
 use burn_dispatch::DispatchDeviceId;
 #[cfg(feature = "autodiff")]
@@ -703,6 +706,54 @@ impl Device {
     /// Calling this method does not guarantee that any memory will be freed.
     pub fn memory_cleanup(&self) {
         Dispatch::memory_cleanup(self.as_dispatch());
+    }
+
+    /// Installs a layout for this device's dynamic memory pools.
+    ///
+    /// The allocator otherwise grows to whatever a workload's worst moment ever
+    /// asked for and keeps it. A caller that would rather reserve a measured
+    /// amount installs a growable layout, runs the workload, reads
+    /// [`memory_pool_report`](Self::memory_pool_report), and installs the same
+    /// layout capped at what it reported.
+    ///
+    /// Pools are rebuilt in place only while nothing is live in them, so this
+    /// belongs at a quiescent point — after the previous workload's tensors have
+    /// dropped and a [`memory_cleanup`](Self::memory_cleanup). Long-lived
+    /// allocations that would otherwise block every rebuild (a model's
+    /// parameters, say) belong in the persistent pool
+    /// → [`memory_persistent_allocations`](Self::memory_persistent_allocations).
+    ///
+    /// ```rust,ignore
+    /// device.memory_cleanup();
+    /// device.memory_install_pools(MemoryPoolLayout::Sliced(vec![SlicedPool {
+    ///     page_size: 256 * 1024 * 1024,
+    ///     pages: Some(8),
+    ///     max_slice: None,
+    /// }]))?;
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// As [`Backend::memory_install_pools`](burn_backend::Backend::memory_install_pools).
+    /// The layout in force is unchanged in every case, so discarding the error
+    /// leaves a caller believing in a reservation the device is not running.
+    pub fn memory_install_pools(
+        &self,
+        layout: MemoryPoolLayout,
+    ) -> Result<(), InstallMemoryPoolsError> {
+        Dispatch::memory_install_pools(self.as_dispatch(), layout)
+    }
+
+    /// This device's dynamic pools, in the order they were installed. `None` on
+    /// a backend that does not report them.
+    pub fn memory_pool_report(&self) -> Option<Vec<SlicedPoolReport>> {
+        Dispatch::memory_pool_report(self.as_dispatch())
+    }
+
+    /// What this device's allocator currently holds. `None` on a backend that
+    /// does not report it.
+    pub fn memory_pool_usage(&self) -> Option<MemoryPoolUsage> {
+        Dispatch::memory_pool_usage(self.as_dispatch())
     }
 
     /// Prepares the given data for transfer between the CPU and accelerator devices such as GPUs.

--- a/crates/burn-tensor/src/device.rs
+++ b/crates/burn-tensor/src/device.rs
@@ -710,17 +710,16 @@ impl Device {
 
     /// Installs a layout for this device's dynamic memory pools.
     ///
-    /// The allocator otherwise grows to whatever a workload's worst moment ever
-    /// asked for and keeps it. A caller that would rather reserve a measured
-    /// amount installs a growable layout, runs the workload, reads
-    /// [`memory_pool_report`](Self::memory_pool_report), and installs the same
-    /// layout capped at what it reported.
+    /// The allocator otherwise keeps whatever a workload's worst moment asked
+    /// for. To reserve a measured amount instead, install a growable layout,
+    /// run the workload, read [`memory_pool_report`](Self::memory_pool_report),
+    /// and install the same layout capped at what it reported.
     ///
-    /// Pools are rebuilt in place only while nothing is live in them, so this
-    /// belongs at a quiescent point — after the previous workload's tensors have
-    /// dropped and a [`memory_cleanup`](Self::memory_cleanup). Long-lived
-    /// allocations that would otherwise block every rebuild (a model's
-    /// parameters, say) belong in the persistent pool
+    /// Pools are rebuilt only while nothing is live in them, so this belongs at
+    /// a quiescent point — after the previous workload's tensors have dropped
+    /// and a [`memory_cleanup`](Self::memory_cleanup). Long-lived allocations
+    /// that would block every rebuild (a model's parameters, say) belong in the
+    /// persistent pool
     /// → [`memory_persistent_allocations`](Self::memory_persistent_allocations).
     ///
     /// ```rust,ignore

--- a/crates/burn/tests/memory_pools.rs
+++ b/crates/burn/tests/memory_pools.rs
@@ -1,9 +1,9 @@
 //! Installing and reading a device's dynamic memory pools.
 //!
 //! What these defend is the contract a measured memory plan is built on: a
-//! caller can install a layout of its own, run a workload, read back what that
-//! workload actually held, and cap the next run at it — and a backend with no
-//! pools says so rather than accepting a layout it will not honour.
+//! caller installs a layout of its own, runs a workload, reads back what it
+//! actually held, and caps the next run at that — and a backend with no pools
+//! says so rather than accepting a layout it will not honour.
 //!
 //! Only the last of those runs without an accelerator. Pool installation is
 //! implemented by the cubecl GPU runtimes; the CPU one reports
@@ -39,9 +39,9 @@ use burn::tensor::{InstallMemoryPoolsError, MemoryPoolLayout, SlicedPool};
 ))]
 use burn::prelude::Tensor;
 
-/// Pools are per device, and every test here resolves the same one: an install
-/// resets the high-water marks another test is reading, and a live tensor held
-/// across one test's window refuses another's rebuild. They take turns.
+/// Pools are per device and every test here resolves the same one: an install
+/// resets the marks another test is reading, and a tensor held across one
+/// test's window refuses another's rebuild. They take turns.
 #[cfg(any(
     feature = "cuda",
     feature = "rocm",
@@ -157,10 +157,9 @@ fn the_peak_outlives_the_allocations_that_set_it() {
 
     {
         let held = Tensor::<1>::zeros([256 * 1024], &device);
-        // Both the operands and the result stay live until the reading below:
-        // dropping them first would leave nothing in the pools to read, and
-        // dropping the result before it is used would leave the addition
-        // itself unexecuted, since the backend allocates lazily.
+        // Operands and result stay live until the reading below: dropping them
+        // leaves nothing in the pools, and dropping the result unused leaves
+        // the addition itself unexecuted, since allocation is lazy.
         let sum = held.clone() + held.clone();
         let _ = device.sync();
 
@@ -184,7 +183,7 @@ fn the_peak_outlives_the_allocations_that_set_it() {
 /// pages that was asked for.
 ///
 /// The cap is a byte count the runtime divides back into pages, so it has to be
-/// counted in the pages the device will actually build: measured against the
+/// counted in the pages the device will actually build. Measured against the
 /// requested page size instead, a one-page pool asks for a cap that cannot hold
 /// its own page, and a larger one silently gets fewer pages than the
 /// measurement it was sized from.
@@ -263,9 +262,9 @@ fn a_rebuild_is_refused_while_the_pools_are_in_use() {
 ///
 /// This is the difference between a mistake in a layout literal and a dead
 /// device: pools are installed from the stream that owns them, so a panic
-/// raised down there takes the device's runner with it and nothing the caller
-/// writes can catch it. Every unhonourable shape has to be refused before the
-/// layout leaves this thread.
+/// raised down there takes the runner with it and nothing the caller writes can
+/// catch it. Every unhonourable shape is refused before the layout leaves this
+/// thread.
 #[test]
 #[cfg(feature = "cpu")]
 fn a_layout_that_cannot_be_honoured_is_refused_rather_than_fatal() {
@@ -310,14 +309,13 @@ fn a_layout_that_cannot_be_honoured_is_refused_rather_than_fatal() {
 /// A runtime that cannot install pools refuses permanently, rather than
 /// accepting a layout it will not honour.
 ///
-/// The distinction is the point: this refusal is the one a caller must never
-/// retry, and it has to be told apart from
-/// [`PoolsInUse`](InstallMemoryPoolsError::PoolsInUse), which is worth retrying
-/// at the next quiescent point.
+/// The distinction is the point: this refusal must never be retried, unlike
+/// [`PoolsInUse`](InstallMemoryPoolsError::PoolsInUse), which is worth another
+/// try at the next quiescent point.
 ///
 /// Reporting is a separate capability, which this also pins: the cubecl CPU
 /// runtime describes the pools it has while declining to be given different
-/// ones, so a caller cannot read a report back as proof that its layout went in.
+/// ones, so a report is not proof that a layout went in.
 #[test]
 #[cfg(feature = "cpu")]
 fn a_runtime_that_cannot_install_pools_refuses_permanently() {

--- a/crates/burn/tests/memory_pools.rs
+++ b/crates/burn/tests/memory_pools.rs
@@ -1,0 +1,209 @@
+//! Installing and reading a device's dynamic memory pools.
+//!
+//! What these defend is the contract a measured memory plan is built on: a
+//! caller can install a layout of its own, run a workload, read back what that
+//! workload actually held, and cap the next run at it — and a backend with no
+//! pools says so rather than accepting a layout it will not honour.
+//!
+//! Only the last of those runs without an accelerator. Pool installation is
+//! implemented by the cubecl GPU runtimes; the CPU one reports
+//! [`Unsupported`](burn::tensor::InstallMemoryPoolsError::Unsupported) like any
+//! other backend without pools, so the working path is gated on a GPU feature:
+//!
+//! ```sh
+//! cargo test -p burn --features cuda --test memory_pools
+//! ```
+
+#[cfg(any(
+    feature = "cpu",
+    feature = "cuda",
+    feature = "rocm",
+    feature = "vulkan",
+    feature = "wgpu"
+))]
+use burn::prelude::Device;
+#[cfg(any(
+    feature = "cpu",
+    feature = "cuda",
+    feature = "rocm",
+    feature = "vulkan",
+    feature = "wgpu"
+))]
+use burn::tensor::{InstallMemoryPoolsError, MemoryPoolLayout, SlicedPool};
+
+#[cfg(any(
+    feature = "cuda",
+    feature = "rocm",
+    feature = "vulkan",
+    feature = "wgpu"
+))]
+use burn::prelude::Tensor;
+
+/// A device whose runtime installs pools, or nothing to test.
+#[cfg(any(
+    feature = "cuda",
+    feature = "rocm",
+    feature = "vulkan",
+    feature = "wgpu"
+))]
+fn device_with_pools() -> Device {
+    #[cfg(feature = "cuda")]
+    return Device::cuda(burn::tensor::DeviceIndex::Default);
+    #[cfg(all(feature = "rocm", not(feature = "cuda")))]
+    return Device::rocm(burn::tensor::DeviceIndex::Default);
+    #[cfg(all(feature = "vulkan", not(any(feature = "cuda", feature = "rocm"))))]
+    return Device::vulkan(burn::tensor::DeviceKind::DefaultDevice);
+    #[cfg(all(
+        feature = "wgpu",
+        not(any(feature = "cuda", feature = "rocm", feature = "vulkan"))
+    ))]
+    return Device::wgpu(burn::tensor::DeviceKind::DefaultDevice);
+}
+
+/// One binary megabyte, the scale pool pages are set at.
+#[cfg(any(
+    feature = "cpu",
+    feature = "cuda",
+    feature = "rocm",
+    feature = "vulkan",
+    feature = "wgpu"
+))]
+const MIB: u64 = 1024 * 1024;
+
+/// A pool layout with room for a page or two of workload, and nothing routed
+/// away from it.
+#[cfg(any(
+    feature = "cpu",
+    feature = "cuda",
+    feature = "rocm",
+    feature = "vulkan",
+    feature = "wgpu"
+))]
+fn one_pool(pages: Option<u64>) -> MemoryPoolLayout {
+    MemoryPoolLayout::Sliced(vec![SlicedPool {
+        page_size: 8 * MIB,
+        pages,
+        max_slice: None,
+    }])
+}
+
+/// A caller's layout replaces the runtime's, and the report comes back in the
+/// order the pools were installed — which is what lets a caller pair each entry
+/// with the pool it asked for, and is the whole basis of reading a peak back.
+#[test]
+#[cfg(any(
+    feature = "cuda",
+    feature = "rocm",
+    feature = "vulkan",
+    feature = "wgpu"
+))]
+fn a_report_describes_the_pools_that_were_installed() {
+    let device = device_with_pools();
+    device.memory_cleanup();
+
+    device
+        .memory_install_pools(one_pool(None))
+        .expect("this runtime installs pools");
+
+    let report = device.memory_pool_report().expect("a report");
+    assert_eq!(
+        report.len(),
+        1,
+        "one pool in, one pool reported: {report:?}"
+    );
+    assert_eq!(report[0].page_size, 8 * MIB);
+}
+
+/// A workload's high-water mark survives the workload: the peak is what a
+/// caller caps the next run at, so it must not fall back when the tensors do.
+#[test]
+#[cfg(any(
+    feature = "cuda",
+    feature = "rocm",
+    feature = "vulkan",
+    feature = "wgpu"
+))]
+fn the_peak_outlives_the_allocations_that_set_it() {
+    let device = device_with_pools();
+    device.memory_cleanup();
+    device
+        .memory_install_pools(one_pool(None))
+        .expect("this runtime installs pools");
+
+    {
+        let held = Tensor::<1>::zeros([256 * 1024], &device);
+        let _ = held.clone() + held;
+        let _ = device.sync();
+
+        let usage = device.memory_pool_usage().expect("a usage reading");
+        assert!(usage.bytes_in_use > 0, "{usage:?}");
+    }
+    let _ = device.sync();
+    device.memory_cleanup();
+
+    let report = device.memory_pool_report().expect("a report");
+    assert!(
+        report[0].pages_peak > 0 && report[0].largest_alloc > 0,
+        "the pool forgot what it served: {report:?}"
+    );
+}
+
+/// A rebuild is refused while the pools it would rebuild are still holding
+/// something, and the refusal names the bytes.
+///
+/// This is the failure a caller meets in practice — long-lived allocations left
+/// in the dynamic pools — and it has to be distinguishable from a backend that
+/// has no pools at all, because one is worth retrying and the other never is.
+#[test]
+#[cfg(any(
+    feature = "cuda",
+    feature = "rocm",
+    feature = "vulkan",
+    feature = "wgpu"
+))]
+fn a_rebuild_is_refused_while_the_pools_are_in_use() {
+    let device = device_with_pools();
+    device.memory_cleanup();
+    device
+        .memory_install_pools(one_pool(None))
+        .expect("this runtime installs pools");
+
+    let held = Tensor::<1>::zeros([256 * 1024], &device);
+    let _ = device.sync();
+
+    match device.memory_install_pools(one_pool(Some(4))) {
+        Err(InstallMemoryPoolsError::PoolsInUse { bytes_in_use }) => {
+            assert!(bytes_in_use > 0, "a refusal that names no bytes");
+        }
+        other => panic!("a live tensor did not block the rebuild: {other:?}"),
+    }
+
+    drop(held);
+    let _ = device.sync();
+    device.memory_cleanup();
+    device
+        .memory_install_pools(one_pool(Some(4)))
+        .expect("the rebuild is accepted once the pools drain");
+}
+
+/// A runtime that cannot install pools refuses permanently, rather than
+/// accepting a layout it will not honour.
+///
+/// The distinction is the point: this refusal is the one a caller must never
+/// retry, and it has to be told apart from
+/// [`PoolsInUse`](InstallMemoryPoolsError::PoolsInUse), which is worth retrying
+/// at the next quiescent point.
+///
+/// Reporting is a separate capability, which this also pins: the cubecl CPU
+/// runtime describes the pools it has while declining to be given different
+/// ones, so a caller cannot read a report back as proof that its layout went in.
+#[test]
+#[cfg(feature = "cpu")]
+fn a_runtime_that_cannot_install_pools_refuses_permanently() {
+    let device = Device::cpu();
+
+    assert_eq!(
+        device.memory_install_pools(one_pool(None)),
+        Err(InstallMemoryPoolsError::Unsupported)
+    );
+}

--- a/crates/burn/tests/memory_pools.rs
+++ b/crates/burn/tests/memory_pools.rs
@@ -39,6 +39,29 @@ use burn::tensor::{InstallMemoryPoolsError, MemoryPoolLayout, SlicedPool};
 ))]
 use burn::prelude::Tensor;
 
+/// Pools are per device, and every test here resolves the same one: an install
+/// resets the high-water marks another test is reading, and a live tensor held
+/// across one test's window refuses another's rebuild. They take turns.
+#[cfg(any(
+    feature = "cuda",
+    feature = "rocm",
+    feature = "vulkan",
+    feature = "wgpu"
+))]
+static ONE_AT_A_TIME: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Exclusive use of the device's pools, kept even if another test panicked
+/// while holding it — the poison says nothing about the pools themselves.
+#[cfg(any(
+    feature = "cuda",
+    feature = "rocm",
+    feature = "vulkan",
+    feature = "wgpu"
+))]
+fn pools_to_ourselves() -> std::sync::MutexGuard<'static, ()> {
+    ONE_AT_A_TIME.lock().unwrap_or_else(|err| err.into_inner())
+}
+
 /// A device whose runtime installs pools, or nothing to test.
 #[cfg(any(
     feature = "cuda",
@@ -98,6 +121,7 @@ fn one_pool(pages: Option<u64>) -> MemoryPoolLayout {
     feature = "wgpu"
 ))]
 fn a_report_describes_the_pools_that_were_installed() {
+    let _pools = pools_to_ourselves();
     let device = device_with_pools();
     device.memory_cleanup();
 
@@ -124,6 +148,7 @@ fn a_report_describes_the_pools_that_were_installed() {
     feature = "wgpu"
 ))]
 fn the_peak_outlives_the_allocations_that_set_it() {
+    let _pools = pools_to_ourselves();
     let device = device_with_pools();
     device.memory_cleanup();
     device
@@ -132,19 +157,65 @@ fn the_peak_outlives_the_allocations_that_set_it() {
 
     {
         let held = Tensor::<1>::zeros([256 * 1024], &device);
-        let _ = held.clone() + held;
+        // Both the operands and the result stay live until the reading below:
+        // dropping them first would leave nothing in the pools to read, and
+        // dropping the result before it is used would leave the addition
+        // itself unexecuted, since the backend allocates lazily.
+        let sum = held.clone() + held.clone();
         let _ = device.sync();
 
         let usage = device.memory_pool_usage().expect("a usage reading");
         assert!(usage.bytes_in_use > 0, "{usage:?}");
+
+        drop((held, sum));
     }
     let _ = device.sync();
     device.memory_cleanup();
 
     let report = device.memory_pool_report().expect("a report");
+    let pool = report.first().expect("the installed pool is reported");
     assert!(
-        report[0].pages_peak > 0 && report[0].largest_alloc > 0,
+        pool.pages_peak > 0 && pool.largest_alloc > 0,
         "the pool forgot what it served: {report:?}"
+    );
+}
+
+/// A page size the device has to round up is still capped at the number of
+/// pages that was asked for.
+///
+/// The cap is a byte count the runtime divides back into pages, so it has to be
+/// counted in the pages the device will actually build: measured against the
+/// requested page size instead, a one-page pool asks for a cap that cannot hold
+/// its own page, and a larger one silently gets fewer pages than the
+/// measurement it was sized from.
+#[test]
+#[cfg(any(
+    feature = "cuda",
+    feature = "rocm",
+    feature = "vulkan",
+    feature = "wgpu"
+))]
+fn a_page_size_the_device_rounds_up_still_holds_its_pages() {
+    let _pools = pools_to_ourselves();
+    let device = device_with_pools();
+    device.memory_cleanup();
+
+    // An odd byte over a page: whatever the device's alignment is, this is not
+    // a multiple of it.
+    let page_size = 8 * MIB + 1;
+    device
+        .memory_install_pools(MemoryPoolLayout::Sliced(vec![SlicedPool {
+            page_size,
+            pages: Some(1),
+            max_slice: None,
+        }]))
+        .expect("a page the device rounds up is still a page it can hold");
+
+    let report = device.memory_pool_report().expect("a report");
+    let pool = report.first().expect("the installed pool is reported");
+    assert!(
+        pool.page_size >= page_size,
+        "the pool holds less than a page of what was asked for: {report:?}"
     );
 }
 
@@ -162,6 +233,7 @@ fn the_peak_outlives_the_allocations_that_set_it() {
     feature = "wgpu"
 ))]
 fn a_rebuild_is_refused_while_the_pools_are_in_use() {
+    let _pools = pools_to_ourselves();
     let device = device_with_pools();
     device.memory_cleanup();
     device
@@ -184,6 +256,55 @@ fn a_rebuild_is_refused_while_the_pools_are_in_use() {
     device
         .memory_install_pools(one_pool(Some(4)))
         .expect("the rebuild is accepted once the pools drain");
+}
+
+/// A layout the runtime cannot honour comes back as an error, not as a panic
+/// on whichever thread the device happens to run on.
+///
+/// This is the difference between a mistake in a layout literal and a dead
+/// device: pools are installed from the stream that owns them, so a panic
+/// raised down there takes the device's runner with it and nothing the caller
+/// writes can catch it. Every unhonourable shape has to be refused before the
+/// layout leaves this thread.
+#[test]
+#[cfg(feature = "cpu")]
+fn a_layout_that_cannot_be_honoured_is_refused_rather_than_fatal() {
+    let device = Device::cpu();
+
+    let unhonourable = [
+        // Nothing to route allocations through.
+        MemoryPoolLayout::Sliced(vec![]),
+        // A page of no size.
+        MemoryPoolLayout::Sliced(vec![SlicedPool {
+            page_size: 0,
+            pages: None,
+            max_slice: None,
+        }]),
+        // A slice that no page of this pool could hold.
+        MemoryPoolLayout::Sliced(vec![SlicedPool {
+            page_size: MIB,
+            pages: None,
+            max_slice: Some(8 * MIB),
+        }]),
+        // More pages than a pool can address.
+        MemoryPoolLayout::Sliced(vec![SlicedPool {
+            page_size: MIB,
+            pages: Some(100_000),
+            max_slice: None,
+        }]),
+    ];
+
+    for layout in unhonourable {
+        match device.memory_install_pools(layout.clone()) {
+            Err(InstallMemoryPoolsError::InvalidLayout { reason }) => {
+                assert!(
+                    !reason.is_empty(),
+                    "a refusal that says nothing: {layout:?}"
+                );
+            }
+            other => panic!("{layout:?} was not refused as a layout: {other:?}"),
+        }
+    }
 }
 
 /// A runtime that cannot install pools refuses permanently, rather than


### PR DESCRIPTION
A backend's allocator grows to whatever a workload's worst moment ever asked for and keeps it, which for a long training run means reserving a peak that one step in a thousand needed. There was no way to say otherwise from outside the runtime: `Backend` carried `memory_cleanup` and `memory_persistent_allocations`, but nothing to shape the pools those allocations come from.

`Backend` gains three methods beside them — `memory_install_pools`, `memory_pool_report` and `memory_pool_usage` — so a caller can install a growable layout, run the workload, read back what it actually held, and re-install the same layout capped at that. Pool placement is deterministic, so a layout capped at one run's peaks fits the same run by construction, with the runtime's own allocations counted in rather than predicted.

All three default to "this backend has no pools" (`Unsupported` / `None`), so every backend in tree and out of it keeps compiling untouched. `burn-cubecl` implements them against the compute client; `burn-fusion` hops to the fusion server thread, because pools belong to a stream and fused operations allocate on its one, not the caller's; `burn-autodiff` forwards; `burn-dispatch` generates the ladder through `dispatch_device!`, which is what makes the autodiff wrapper transparent to callers.

The vocabulary is the backend's own — `MemoryPoolLayout`, `SlicedPool`, `SlicedPoolReport`, `InstallMemoryPoolsError` — rather than cubecl's, because `Backend` is implemented by backends with no notion of a pool. The translation lives in `burn-cubecl` alone.

Reporting and installing turn out to be separate capabilities: the cubecl CPU runtime describes the pools it has while refusing to be given different ones. Documented on the trait and pinned by a test, since a caller that reads a report back as proof of an install would be wrong on that runtime.