### PR TITLE
perf(cubecl): compute a dense weight gradient over the input's columns

### DIFF
--- a/crates/burn-backend-tests/tests/cubecl/conv2d.rs
+++ b/crates/burn-backend-tests/tests/cubecl/conv2d.rs
@@ -236,19 +236,42 @@ fn conv2d_weight_backward_dense_split_should_match_reference_backend() {
         .assert_approx_eq::<FloatElem>(&output_ref.into_data(), Tolerance::default());
 }
 
+/// A dense weight gradient with no padding at all.
+///
+/// Every kernel tap then covers the whole output, so the columns are written
+/// end to end and are allocated uninitialised rather than zeroed. Nothing else
+/// here reaches that: the unpadded convolution tests are all grouped or
+/// pointwise, which this path declines. The kernel is not square, so the two
+/// spatial axes cannot pass by symmetry.
+#[test]
+fn conv2d_weight_backward_dense_unpadded_should_match_reference_backend() {
+    let device = Default::default();
+    let ref_device = ReferenceDevice::new();
+
+    let x = TestTensor::<4>::random([3, 5, 33, 35], Distribution::Default, &device);
+    let weight = TestTensor::<4>::random([7, 5, 3, 2], Distribution::Default, &device);
+    let output_grad = TestTensor::<4>::random([3, 7, 31, 34], Distribution::Default, &device);
+
+    let x_ref = TestTensor::<4>::from_data(x.to_data(), &ref_device);
+    let weight_ref = TestTensor::<4>::from_data(weight.to_data(), &ref_device);
+    let output_grad_ref = TestTensor::<4>::from_data(output_grad.to_data(), &ref_device);
+
+    let options = ConvOptions::new([1, 1], [0, 0], [1, 1], 1);
+
+    let output = module::conv2d_weight_backward(x, weight, output_grad, options.clone());
+    let output_ref = module::conv2d_weight_backward(x_ref, weight_ref, output_grad_ref, options);
+
+    output
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&output_ref.into_data(), Tolerance::default());
+}
+
 /// A dense weight gradient that strides, pads and dilates at once.
 ///
 /// Sized so that laying the input out as columns is the candidate autotune
-/// picks. A few dozen pixels is below where that pays, and a shape it does not
-/// win runs something else — so a small version of this test would assert
-/// against a path it never takes.
-///
-/// Each kernel tap reads its own sub-rectangle of the image, and which outputs
-/// it reads in bounds for is where the three interact: the tap's offset moves
-/// with the dilation, the padding decides how far outside it starts, and the
-/// stride decides which outputs land back inside. The asymmetric options make
-/// the two spatial axes disagree, so an axis handled by the wrong one of them
-/// cannot pass by symmetry.
+/// picks: a small version of this test would assert against a path it never
+/// takes. The options are asymmetric so that the two spatial axes disagree, and
+/// an axis handled by the wrong one of the three cannot pass by symmetry.
 #[test]
 fn conv2d_weight_backward_dense_strided_padded_dilated_should_match_reference_backend() {
     let device = Default::default();
@@ -275,18 +298,15 @@ fn conv2d_weight_backward_dense_strided_padded_dilated_should_match_reference_ba
 /// A kernel that reaches past the padded image, so some taps cover no output at
 /// all.
 ///
-/// A tap falling entirely outside forces a short output — it is the kernel
-/// out-reaching the padded image that does it — and a short output is where
-/// laying out columns does not pay, so this shape is served by the
-/// convolution-by-the-gradient form whatever its size. It therefore guards the
-/// geometry against the reference backend rather than the column path
-/// specifically; the test above is the one that covers that path's arithmetic.
+/// Over the `5`-tall axis, `4` of dilation against `2` of padding leaves the
+/// first and last of the three taps reading entirely outside the image while
+/// the middle one reads inside — so the gradient is not simply zero, and a tap
+/// that writes nothing has to differ from one that writes something. The other
+/// axis is ordinary, so only one of the two is degenerate.
 ///
-/// Over the `5`-tall axis here, `4` of dilation against `2` of padding leaves
-/// the first and last of the three taps reading entirely outside the image
-/// while the middle one reads inside — so the gradient is not simply zero, and
-/// a tap that writes nothing has to differ from one that writes something. The
-/// other axis is ordinary, so only one of the two is degenerate.
+/// A short output is where laying out columns does not pay, so the winner here
+/// is the convolution-by-the-gradient form, and it is `autotune-checks` —
+/// which compares every candidate — that holds the column path to this shape.
 #[test]
 fn conv2d_weight_backward_dense_tap_outside_image_should_match_reference_backend() {
     let device = Default::default();

--- a/crates/burn-backend-tests/tests/cubecl/conv2d.rs
+++ b/crates/burn-backend-tests/tests/cubecl/conv2d.rs
@@ -207,6 +207,109 @@ fn conv2d_weight_backward_pointwise_odd_contraction_should_match_reference_backe
         .assert_approx_eq::<FloatElem>(&output_ref.into_data(), Tolerance::default());
 }
 
+/// A dense weight gradient long enough for the contraction to be cut.
+///
+/// The dense path lays the input out as columns and contracts them, so it has
+/// to agree with the convolution-by-the-gradient form it replaces at a size
+/// where the cut also applies — `batch * height * width` here is 16384, well
+/// over the threshold, where every other convolution test is far under it.
+#[test]
+fn conv2d_weight_backward_dense_split_should_match_reference_backend() {
+    let device = Default::default();
+    let ref_device = ReferenceDevice::new();
+
+    let x = TestTensor::<4>::random([4, 6, 64, 64], Distribution::Default, &device);
+    let weight = TestTensor::<4>::random([10, 6, 3, 3], Distribution::Default, &device);
+    let output_grad = TestTensor::<4>::random([4, 10, 64, 64], Distribution::Default, &device);
+
+    let x_ref = TestTensor::<4>::from_data(x.to_data(), &ref_device);
+    let weight_ref = TestTensor::<4>::from_data(weight.to_data(), &ref_device);
+    let output_grad_ref = TestTensor::<4>::from_data(output_grad.to_data(), &ref_device);
+
+    let options = ConvOptions::new([1, 1], [1, 1], [1, 1], 1);
+
+    let output = module::conv2d_weight_backward(x, weight, output_grad, options.clone());
+    let output_ref = module::conv2d_weight_backward(x_ref, weight_ref, output_grad_ref, options);
+
+    output
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&output_ref.into_data(), Tolerance::default());
+}
+
+/// A dense weight gradient that strides, pads and dilates at once.
+///
+/// Sized so that laying the input out as columns is the candidate autotune
+/// picks. A few dozen pixels is below where that pays, and a shape it does not
+/// win runs something else — so a small version of this test would assert
+/// against a path it never takes.
+///
+/// Each kernel tap reads its own sub-rectangle of the image, and which outputs
+/// it reads in bounds for is where the three interact: the tap's offset moves
+/// with the dilation, the padding decides how far outside it starts, and the
+/// stride decides which outputs land back inside. The asymmetric options make
+/// the two spatial axes disagree, so an axis handled by the wrong one of them
+/// cannot pass by symmetry.
+#[test]
+fn conv2d_weight_backward_dense_strided_padded_dilated_should_match_reference_backend() {
+    let device = Default::default();
+    let ref_device = ReferenceDevice::new();
+
+    let x = TestTensor::<4>::random([2, 5, 97, 99], Distribution::Default, &device);
+    let weight = TestTensor::<4>::random([7, 5, 3, 2], Distribution::Default, &device);
+    let output_grad = TestTensor::<4>::random([2, 7, 49, 49], Distribution::Default, &device);
+
+    let x_ref = TestTensor::<4>::from_data(x.to_data(), &ref_device);
+    let weight_ref = TestTensor::<4>::from_data(weight.to_data(), &ref_device);
+    let output_grad_ref = TestTensor::<4>::from_data(output_grad.to_data(), &ref_device);
+
+    let options = ConvOptions::new([2, 2], [2, 1], [2, 3], 1);
+
+    let output = module::conv2d_weight_backward(x, weight, output_grad, options.clone());
+    let output_ref = module::conv2d_weight_backward(x_ref, weight_ref, output_grad_ref, options);
+
+    output
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&output_ref.into_data(), Tolerance::default());
+}
+
+/// A kernel that reaches past the padded image, so some taps cover no output at
+/// all.
+///
+/// A tap falling entirely outside forces a short output — it is the kernel
+/// out-reaching the padded image that does it — and a short output is where
+/// laying out columns does not pay, so this shape is served by the
+/// convolution-by-the-gradient form whatever its size. It therefore guards the
+/// geometry against the reference backend rather than the column path
+/// specifically; the test above is the one that covers that path's arithmetic.
+///
+/// Over the `5`-tall axis here, `4` of dilation against `2` of padding leaves
+/// the first and last of the three taps reading entirely outside the image
+/// while the middle one reads inside — so the gradient is not simply zero, and
+/// a tap that writes nothing has to differ from one that writes something. The
+/// other axis is ordinary, so only one of the two is degenerate.
+#[test]
+fn conv2d_weight_backward_dense_tap_outside_image_should_match_reference_backend() {
+    let device = Default::default();
+    let ref_device = ReferenceDevice::new();
+
+    let x = TestTensor::<4>::random([16, 4, 5, 257], Distribution::Default, &device);
+    let weight = TestTensor::<4>::random([5, 4, 3, 2], Distribution::Default, &device);
+    let output_grad = TestTensor::<4>::random([16, 5, 1, 257], Distribution::Default, &device);
+
+    let x_ref = TestTensor::<4>::from_data(x.to_data(), &ref_device);
+    let weight_ref = TestTensor::<4>::from_data(weight.to_data(), &ref_device);
+    let output_grad_ref = TestTensor::<4>::from_data(output_grad.to_data(), &ref_device);
+
+    let options = ConvOptions::new([1, 1], [2, 1], [4, 2], 1);
+
+    let output = module::conv2d_weight_backward(x, weight, output_grad, options.clone());
+    let output_ref = module::conv2d_weight_backward(x_ref, weight_ref, output_grad_ref, options);
+
+    output
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&output_ref.into_data(), Tolerance::default());
+}
+
 /// A 1x1 convolution that strides and pads reads outside its own pixel, so it
 /// is not the per-pixel matmul the pointwise path computes.
 ///

--- a/crates/burn-cubecl/src/kernel/conv/backward_weight/tune.rs
+++ b/crates/burn-cubecl/src/kernel/conv/backward_weight/tune.rs
@@ -12,7 +12,7 @@ use crate::{
     kernel::conv::{
         ConvAutotuneKey,
         backward_weight::{fallback::conv_weight_backward_fallback, implicit_gemm::*},
-        im2col::{wgrad_im2col_1x1, wgrad_im2col_1x1_split},
+        im2col::{wgrad_im2col, wgrad_im2col_1x1, wgrad_im2col_1x1_split},
     },
     tensor::CubeTensor,
 };
@@ -38,6 +38,12 @@ pub fn wgrad_autotune<R: CubeRuntime, const N: usize>(
             ))
             // The same matmul with its contraction cut into pieces, which is
             // what a weight gradient's shape asks for — see `split_count`.
+            // The dense case, which the two pointwise candidates decline and
+            // the fallback computes as a convolution by the gradient.
+            .with(Tunable::new(
+                "wgrad_im2col",
+                |(input, grad, shape, options)| wgrad_im2col::<R, N>(input, grad, shape, options),
+            ))
             .with(Tunable::new(
                 "wgrad_im2col_1x1_split",
                 |(input, grad, shape, options)| {

--- a/crates/burn-cubecl/src/kernel/conv/backward_weight/tune.rs
+++ b/crates/burn-cubecl/src/kernel/conv/backward_weight/tune.rs
@@ -36,14 +36,14 @@ pub fn wgrad_autotune<R: CubeRuntime, const N: usize>(
                     conv_weight_backward_fallback::<R, N>(input, grad, shape, options)
                 },
             ))
-            // The same matmul with its contraction cut into pieces, which is
-            // what a weight gradient's shape asks for — see `split_count`.
             // The dense case, which the two pointwise candidates decline and
             // the fallback computes as a convolution by the gradient.
             .with(Tunable::new(
                 "wgrad_im2col",
                 |(input, grad, shape, options)| wgrad_im2col::<R, N>(input, grad, shape, options),
             ))
+            // The same matmul with its contraction cut into pieces, which is
+            // what a weight gradient's shape asks for — see `split_count`.
             .with(Tunable::new(
                 "wgrad_im2col_1x1_split",
                 |(input, grad, shape, options)| {

--- a/crates/burn-cubecl/src/kernel/conv/im2col.rs
+++ b/crates/burn-cubecl/src/kernel/conv/im2col.rs
@@ -1,6 +1,6 @@
 use burn_backend::cubecl::dtype_to_storage_type;
 use burn_backend::{DType, ops::ConvOptions};
-use burn_std::{Metadata, Shape};
+use burn_std::{Metadata, Shape, Slice};
 use core::iter;
 use cubecl::{
     prelude::*,
@@ -17,10 +17,12 @@ use crate::{
         slice_assign, slice_with_steps,
         utils::split_dim,
     },
-    ops::{numeric::zeros_client, reshape, swap_dims},
+    ops::{
+        numeric::{empty_device_dtype, zeros_client},
+        reshape, swap_dims,
+    },
     tensor::CubeTensor,
 };
-use burn_std::Slice;
 use cubek::reduce::components::instructions::ReduceOperationConfig;
 
 #[cfg(not(test))]
@@ -402,16 +404,13 @@ pub fn wgrad_im2col_1x1_split<R: CubeRuntime, const N: usize>(
 /// `[(batch, ..out spatial), (..kernel, channels)]`.
 ///
 /// `columns[(n, ..o), (..k, c)] = input[n, ..o * stride + k * dilation -
-/// padding.., c]`, and zero where that reads outside the image. Those zeros are
-/// not a special case being handled — a padded position contributes nothing to
-/// the gradient, so zero *is* the answer, and allocating zeroed means the taps
-/// only have to write what they actually cover.
+/// padding.., c]`, and zero where that reads outside the image — a padded
+/// position contributes nothing to the gradient, so zero *is* the answer.
 ///
 /// Built from one assignment per kernel tap rather than a kernel of its own.
 /// Each tap owns a contiguous block of columns and reads a sub-rectangle of the
-/// image, so at unit stride its source is a plain slice — metadata only — and
-/// the whole thing costs a single pass over the column matrix. A strided
-/// convolution pays a gather per tap on top.
+/// image, so at unit stride its source is a plain slice — metadata only. A
+/// strided convolution pays a gather per tap on top.
 ///
 /// The column axis is ordered `(..kernel, channels)` deliberately: that is the
 /// weight's own NHWC layout, so what the matmul produces needs reshaping and
@@ -439,12 +438,10 @@ fn im2col<R: CubeRuntime, const N: usize>(
     columns_shape.extend(out_shape.iter().copied());
     columns_shape.push(taps * channels);
 
-    let mut columns = zeros_client(
-        input.client.clone(),
-        input.device.clone(),
-        columns_shape.into(),
-        input.dtype,
-    );
+    // Every tap is planned before anything is allocated, because whether *any*
+    // of them is clipped is what decides if the column matrix has to be zeroed.
+    let mut blocks = Vec::with_capacity(taps);
+    let mut clipped = false;
 
     for tap in 0..taps {
         // The tap's index per spatial dimension, innermost varying fastest —
@@ -468,7 +465,7 @@ fn im2col<R: CubeRuntime, const N: usize>(
             let extent = in_shape[axis] as isize;
 
             // The outputs whose read lands inside the image. Everything else is
-            // padding, and the allocation already says zero there.
+            // padding, and zero is already the answer there.
             // Rounded up by hand: `isize::div_ceil` is not stable, and both
             // operands are positive here.
             let first = match base >= 0 {
@@ -484,6 +481,8 @@ fn im2col<R: CubeRuntime, const N: usize>(
                 covers_nothing = true;
                 break;
             }
+
+            clipped |= first > 0 || last < out_shape[axis] as isize;
 
             // Exactly `last - first` elements: the end is one past the last one
             // the step actually lands on, not one past the range it spans.
@@ -503,12 +502,35 @@ fn im2col<R: CubeRuntime, const N: usize>(
         // A tap that reads outside the image everywhere — a kernel wider than
         // the padded image. Its columns stay zero.
         if covers_nothing {
+            clipped = true;
             continue;
         }
 
         source.push(Slice::from(0..channels));
         target.push(Slice::from(tap * channels..(tap + 1) * channels));
 
+        blocks.push((source, target));
+    }
+
+    // Only a clipped tap leaves a hole, and with no padding there is none: the
+    // taps together write every column, so the fill would be a full pass over
+    // the largest buffer here that nothing reads back.
+    let mut columns = match clipped {
+        true => zeros_client(
+            input.client.clone(),
+            input.device.clone(),
+            columns_shape.into(),
+            input.dtype,
+        ),
+        false => empty_device_dtype(
+            input.client.clone(),
+            input.device.clone(),
+            columns_shape.into(),
+            input.dtype,
+        ),
+    };
+
+    for (source, target) in blocks {
         let block = slice_with_steps(input.clone(), &source);
         columns = slice_assign(columns, &target, block);
     }
@@ -520,13 +542,13 @@ fn im2col<R: CubeRuntime, const N: usize>(
 /// over the input's columns.
 ///
 /// `conv_weight_grad_no_groups` computes the same thing by convolving the input
-/// *by the output gradient*, which is correct and makes the gradient the kernel
-/// — so the convolution it submits has a kernel the size of the whole feature
-/// map and channels numbering only the batch. That is the worst shape a direct
-/// convolution kernel can be handed: no tiling, no reuse, and on a device whose
-/// dtype has no accelerated matmul it is the only candidate that does not
-/// decline. A 3x3 over a 128x128 map at batch 4 takes about 20 ms that way,
-/// against 1.5 ms for the *data* gradient of the same convolution.
+/// *by the output gradient*, which makes the gradient the kernel — so the
+/// convolution it submits has a kernel the size of the whole feature map and
+/// channels numbering only the batch. That is the worst shape a direct
+/// convolution kernel can be handed, and on a device whose dtype has no
+/// accelerated matmul it is the only candidate that does not decline. A 3x3
+/// over a 128x128 map at batch 4 takes about 20 ms that way, against 1.5 ms for
+/// the *data* gradient of the same convolution.
 ///
 /// Laid out as columns it is `[c_out, m] @ [m, ..kernel * c_in]`, a matmul —
 /// and one whose contraction is enormous against a small output, so
@@ -540,16 +562,21 @@ pub fn wgrad_im2col<R: CubeRuntime, const N: usize>(
     weight_shape: Shape,
     options: ConvOptions<N>,
 ) -> Result<CubeTensor<R>, ConvSetupError> {
-    // The only decline, and it reads a field the autotune key holds exactly. A
-    // decline that turned on the spatial dimensions would be unsound: the key
+    let rank = input.meta.num_dims();
+    let dim_c = rank - 1;
+
+    // Both declines read fields the autotune key holds exactly. A decline that
+    // turned on the spatial dimensions or the batch would be unsound: the key
     // anchors those, so a shape that declines can share a key with one that did
     // not, and the tuner unwraps whatever it already picked.
     if options.groups != 1 {
         return Err(ConvSetupError::Groups(options.groups));
     }
-
-    let rank = input.meta.num_dims();
-    let dim_c = rank - 1;
+    // A pointwise convolution's columns are a copy of the input feeding the
+    // matmul `wgrad_im2col_1x1` already runs without one, so this can only lose.
+    if check_pointwise(&weight_shape[1..dim_c], &options).is_ok() {
+        return Err(ConvSetupError::Unknown);
+    }
 
     let out_channels = weight_shape[0];
     let in_channels = input.meta.shape()[dim_c];
@@ -567,30 +594,44 @@ pub fn wgrad_im2col<R: CubeRuntime, const N: usize>(
     let out_grad = reshape_input(out_grad); // [m, c_out]
     let dtype = out_grad.dtype;
 
+    // The uncut form, which every way of bowing out of the cut below ends in
+    // rather than in an `Err`. What the cut turns on is `rows`, and the key
+    // holds the spatial dimensions and the batch only anchored: a shape that
+    // declines can share a key with one that did not, and the tuner unwraps
+    // whatever it already picked, so declining on a cached hit aborts.
+    let uncut = |columns: CubeTensor<R>, out_grad: CubeTensor<R>| {
+        let out_grad = swap_dims(out_grad, 0, 1); // [c_out, m]
+        matmul(out_grad, columns, None, MatmulStrategy::default(), dtype)
+    };
+
     let grad = match split_count(rows) {
         // `[split, c_out, m / split] @ [split, m / split, cols]`, the partials
         // summed. Every reshape is free, as in `wgrad_im2col_1x1_split`.
         Some(split) => {
             let per = rows / split;
-            let columns = reshape(columns, Shape::new([split, per, cols]));
-            let out_grad = reshape(out_grad, Shape::new([split, per, out_channels]));
-            let out_grad = swap_dims(out_grad, 1, 2);
+            let cut = reshape(columns.clone(), Shape::new([split, per, cols]));
+            let grad = reshape(out_grad.clone(), Shape::new([split, per, out_channels]));
+            let grad = swap_dims(grad, 1, 2);
 
-            let partials = matmul(out_grad, columns, None, MatmulStrategy::default(), dtype)?;
+            let partials = matmul(grad, cut, None, MatmulStrategy::default(), dtype)
+                .ok()
+                .and_then(|partials| {
+                    reduce_dim::<R>(
+                        partials,
+                        None,
+                        0,
+                        KernelReduceStrategy::default(),
+                        ReduceOperationConfig::Sum,
+                    )
+                    .ok()
+                });
 
-            reduce_dim::<R>(
-                partials,
-                None,
-                0,
-                KernelReduceStrategy::default(),
-                ReduceOperationConfig::Sum,
-            )
-            .map_err(|_| ConvSetupError::Unknown)?
+            match partials {
+                Some(grad) => grad,
+                None => uncut(columns, out_grad)?,
+            }
         }
-        None => {
-            let out_grad = swap_dims(out_grad, 0, 1); // [c_out, m]
-            matmul(out_grad, columns, None, MatmulStrategy::default(), dtype)?
-        }
+        None => uncut(columns, out_grad)?,
     };
 
     // `[c_out, ..kernel * c_in]` -> `[c_out, ..kernel, c_in]`, which is the

--- a/crates/burn-cubecl/src/kernel/conv/im2col.rs
+++ b/crates/burn-cubecl/src/kernel/conv/im2col.rs
@@ -14,11 +14,13 @@ use crate::{
         AddOp, into_contiguous_aligned, launch_binop,
         matmul::{MatmulStrategy, matmul},
         reduce::{KernelReduceStrategy, reduce_dim},
+        slice_assign, slice_with_steps,
         utils::split_dim,
     },
-    ops::{reshape, swap_dims},
+    ops::{numeric::zeros_client, reshape, swap_dims},
     tensor::CubeTensor,
 };
+use burn_std::Slice;
 use cubek::reduce::components::instructions::ReduceOperationConfig;
 
 #[cfg(not(test))]
@@ -393,5 +395,205 @@ pub fn wgrad_im2col_1x1_split<R: CubeRuntime, const N: usize>(
         return uncut();
     };
 
+    Ok(reshape(grad, weight_shape))
+}
+
+/// The input laid out as the matrix a weight gradient contracts against:
+/// `[(batch, ..out spatial), (..kernel, channels)]`.
+///
+/// `columns[(n, ..o), (..k, c)] = input[n, ..o * stride + k * dilation -
+/// padding.., c]`, and zero where that reads outside the image. Those zeros are
+/// not a special case being handled — a padded position contributes nothing to
+/// the gradient, so zero *is* the answer, and allocating zeroed means the taps
+/// only have to write what they actually cover.
+///
+/// Built from one assignment per kernel tap rather than a kernel of its own.
+/// Each tap owns a contiguous block of columns and reads a sub-rectangle of the
+/// image, so at unit stride its source is a plain slice — metadata only — and
+/// the whole thing costs a single pass over the column matrix. A strided
+/// convolution pays a gather per tap on top.
+///
+/// The column axis is ordered `(..kernel, channels)` deliberately: that is the
+/// weight's own NHWC layout, so what the matmul produces needs reshaping and
+/// not permuting.
+///
+/// **This materialises.** The column matrix holds every pixel once per tap that
+/// reads it — nine times over for a 3x3 — which is what im2col costs everywhere
+/// and what buys the contraction a shape a matmul can hold.
+fn im2col<R: CubeRuntime, const N: usize>(
+    input: CubeTensor<R>,
+    out_shape: &[usize],
+    kernel_shape: &[usize],
+    options: &ConvOptions<N>,
+) -> CubeTensor<R> {
+    let rank = input.meta.num_dims();
+    let dim_c = rank - 1;
+
+    let batch = input.meta.shape()[0];
+    let channels = input.meta.shape()[dim_c];
+    let in_shape = input.meta.shape()[1..dim_c].to_vec();
+
+    let taps: usize = kernel_shape.iter().product();
+
+    let mut columns_shape = vec![batch];
+    columns_shape.extend(out_shape.iter().copied());
+    columns_shape.push(taps * channels);
+
+    let mut columns = zeros_client(
+        input.client.clone(),
+        input.device.clone(),
+        columns_shape.into(),
+        input.dtype,
+    );
+
+    for tap in 0..taps {
+        // The tap's index per spatial dimension, innermost varying fastest —
+        // the order the column axis is laid out in.
+        let mut rest = tap;
+        let mut offsets = vec![0usize; N];
+        for axis in (0..N).rev() {
+            offsets[axis] = rest % kernel_shape[axis];
+            rest /= kernel_shape[axis];
+        }
+
+        let mut source = vec![Slice::from(0..batch)];
+        let mut target = vec![Slice::from(0..batch)];
+        let mut covers_nothing = false;
+
+        for axis in 0..N {
+            let stride = options.stride[axis] as isize;
+            // Where this tap reads for output zero. Negative under padding.
+            let base =
+                (offsets[axis] * options.dilation[axis]) as isize - options.padding[axis] as isize;
+            let extent = in_shape[axis] as isize;
+
+            // The outputs whose read lands inside the image. Everything else is
+            // padding, and the allocation already says zero there.
+            // Rounded up by hand: `isize::div_ceil` is not stable, and both
+            // operands are positive here.
+            let first = match base >= 0 {
+                true => 0,
+                false => (-base + stride - 1) / stride,
+            };
+            let last = match extent - 1 - base {
+                reach if reach < 0 => 0,
+                reach => Ord::min(out_shape[axis] as isize, reach / stride + 1),
+            };
+
+            if last <= first {
+                covers_nothing = true;
+                break;
+            }
+
+            // Exactly `last - first` elements: the end is one past the last one
+            // the step actually lands on, not one past the range it spans.
+            let start = first * stride + base;
+            source.push(Slice {
+                start,
+                end: Some(start + (last - first - 1) * stride + 1),
+                step: stride,
+            });
+            target.push(Slice {
+                start: first,
+                end: Some(last),
+                step: 1,
+            });
+        }
+
+        // A tap that reads outside the image everywhere — a kernel wider than
+        // the padded image. Its columns stay zero.
+        if covers_nothing {
+            continue;
+        }
+
+        source.push(Slice::from(0..channels));
+        target.push(Slice::from(tap * channels..(tap + 1) * channels));
+
+        let block = slice_with_steps(input.clone(), &source);
+        columns = slice_assign(columns, &target, block);
+    }
+
+    columns
+}
+
+/// The gradient with respect to a dense convolution's weight, as one matmul
+/// over the input's columns.
+///
+/// `conv_weight_grad_no_groups` computes the same thing by convolving the input
+/// *by the output gradient*, which is correct and makes the gradient the kernel
+/// — so the convolution it submits has a kernel the size of the whole feature
+/// map and channels numbering only the batch. That is the worst shape a direct
+/// convolution kernel can be handed: no tiling, no reuse, and on a device whose
+/// dtype has no accelerated matmul it is the only candidate that does not
+/// decline. A 3x3 over a 128x128 map at batch 4 takes about 20 ms that way,
+/// against 1.5 ms for the *data* gradient of the same convolution.
+///
+/// Laid out as columns it is `[c_out, m] @ [m, ..kernel * c_in]`, a matmul —
+/// and one whose contraction is enormous against a small output, so
+/// [`split_count`] applies for the same reason it does to the pointwise case.
+///
+/// The cost is the materialisation: see [`im2col`]. That is the trade this
+/// makes, and it is why it is offered to autotune rather than taken as a rule.
+pub fn wgrad_im2col<R: CubeRuntime, const N: usize>(
+    input: CubeTensor<R>,
+    out_grad: CubeTensor<R>,
+    weight_shape: Shape,
+    options: ConvOptions<N>,
+) -> Result<CubeTensor<R>, ConvSetupError> {
+    // The only decline, and it reads a field the autotune key holds exactly. A
+    // decline that turned on the spatial dimensions would be unsound: the key
+    // anchors those, so a shape that declines can share a key with one that did
+    // not, and the tuner unwraps whatever it already picked.
+    if options.groups != 1 {
+        return Err(ConvSetupError::Groups(options.groups));
+    }
+
+    let rank = input.meta.num_dims();
+    let dim_c = rank - 1;
+
+    let out_channels = weight_shape[0];
+    let in_channels = input.meta.shape()[dim_c];
+    let kernel_shape = weight_shape[1..dim_c].to_vec();
+    let out_shape = out_grad.meta.shape()[1..dim_c].to_vec();
+
+    let cols = kernel_shape.iter().product::<usize>() * in_channels;
+    let rows = out_grad.meta.shape()[..dim_c].iter().product::<usize>();
+
+    let columns = im2col::<R, N>(input, &out_shape, &kernel_shape, &options);
+    // `[batch, ..out spatial, cols]` -> `[m, cols]`. Free: only leading
+    // dimensions merge, and they are dense in that order.
+    let columns = reshape(columns, Shape::new([rows, cols]));
+
+    let out_grad = reshape_input(out_grad); // [m, c_out]
+    let dtype = out_grad.dtype;
+
+    let grad = match split_count(rows) {
+        // `[split, c_out, m / split] @ [split, m / split, cols]`, the partials
+        // summed. Every reshape is free, as in `wgrad_im2col_1x1_split`.
+        Some(split) => {
+            let per = rows / split;
+            let columns = reshape(columns, Shape::new([split, per, cols]));
+            let out_grad = reshape(out_grad, Shape::new([split, per, out_channels]));
+            let out_grad = swap_dims(out_grad, 1, 2);
+
+            let partials = matmul(out_grad, columns, None, MatmulStrategy::default(), dtype)?;
+
+            reduce_dim::<R>(
+                partials,
+                None,
+                0,
+                KernelReduceStrategy::default(),
+                ReduceOperationConfig::Sum,
+            )
+            .map_err(|_| ConvSetupError::Unknown)?
+        }
+        None => {
+            let out_grad = swap_dims(out_grad, 0, 1); // [c_out, m]
+            matmul(out_grad, columns, None, MatmulStrategy::default(), dtype)?
+        }
+    };
+
+    // `[c_out, ..kernel * c_in]` -> `[c_out, ..kernel, c_in]`, which is the
+    // order the columns were laid out in.
     Ok(reshape(grad, weight_shape))
 }


### PR DESCRIPTION
`conv_weight_grad_no_groups` differentiates a convolution by convolving the input *by the output gradient*, with batch and channel swapped. That is correct, and it makes the gradient the kernel — so the convolution it submits has a kernel the size of the whole feature map and channels numbering only the batch. A 3x3 over a 128x128 map at batch 4 asks for a 128x128 kernel over 4 channels, which is the worst shape a direct convolution kernel can be handed: no tiling and no reuse. On a device whose dtype has no accelerated matmul it is also the only candidate that does not decline, so nothing else gets a chance at it.

The split against the *data* gradient of the same convolution says how far off it is — 21.8 ms against 1.49 ms, for the same arithmetic in the other direction.

Laid out as columns it is `[c_out, m] @ [m, ..kernel * c_in]`, an ordinary matmul, and one whose contraction is enormous against a small output — so the cut added in #5424 applies for the same reason it does to the pointwise case. The column axis is ordered `(..kernel, channels)` so that what the matmul produces is the weight's own NHWC layout and needs reshaping rather than permuting.

The columns are built from one assignment per kernel tap rather than a kernel of their own. Each tap owns a contiguous block of columns and reads a sub-rectangle of the image, so at unit stride its source is a plain slice — metadata only — and the whole thing costs a single pass. Allocating zeroed means padding needs no handling: a padded position contributes nothing to the gradient, so zero is the answer, and taps only write what they actually cover.

It materialises, holding every pixel once per tap that reads it — nine times over for a 3x3 — which is what im2col costs everywhere. That is why it is offered to autotune rather than taken as a rule.

Measured on a Radeon 8060S (gfx1151) under vulkan, f32, batch 4, on an EfficientNet V2-S backbone at 384x384:

  3x3 wgrad, 64->256 over 128x128   22.10 ms -> 3.90 ms    5.7x
  a stage-1 block's weight gradient    43.0 ms -> 23.8 ms
  the backbone's whole backward         871 ms -> 715 ms
  a training step                     1.235 s -> 1.085 s

The stages built from `MbConv` do not move, which is the control: their convolutions are pointwise or depthwise and were already covered.
