### PR TITLE
perf(conv): route strided pointwise convolutions through the matmul path

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/float/module/conv2d.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/module/conv2d.rs
@@ -42,6 +42,31 @@ fn test_conv2d_simple() {
 }
 
 #[test]
+fn test_conv2d_1x1_strided() {
+    let test = Conv2dTestCase {
+        batch_size: 1,
+        channels_in: 2,
+        channels_out: 2,
+        kernel_size_1: 1,
+        kernel_size_2: 1,
+        padding_1: 0,
+        padding_2: 0,
+        stride_1: 2,
+        stride_2: 2,
+        dilation_1: 1,
+        dilation_2: 1,
+        groups: 1,
+        height: 4,
+        width: 4,
+    };
+
+    test.assert_output(TestTensor::from([[
+        [[16., 18.], [24., 26.]],
+        [[49., 59.], [89., 99.]],
+    ]]));
+}
+
+#[test]
 fn test_conv2d_simple_implicit() {
     let test = Conv2dTestCase {
         batch_size: 1,

--- a/crates/burn-cubecl/src/kernel/conv/im2col.rs
+++ b/crates/burn-cubecl/src/kernel/conv/im2col.rs
@@ -1,5 +1,8 @@
 use burn_backend::cubecl::dtype_to_storage_type;
-use burn_backend::{DType, ops::ConvOptions};
+use burn_backend::{
+    DType,
+    ops::{ConvOptions, conv::calculate_conv_output_sizes},
+};
 use burn_std::{Metadata, Shape};
 use core::iter;
 use cubecl::{
@@ -67,11 +70,23 @@ pub fn conv_im2col_1x1<R: CubeRuntime, const N: usize>(
 
     let out_channels = weight.meta.shape()[0];
 
-    check_pointwise(&weight.meta.shape()[1..dim_c], &options)?;
+    check_pointwise_strided(&weight.meta.shape()[1..dim_c], &options)?;
 
-    // A pointwise convolution's output has the input's spatial shape.
+    let out_shape = calculate_conv_output_sizes(
+        &weight.meta.shape()[1..dim_c],
+        &options.stride,
+        &options.padding,
+        &options.dilation,
+        &input.meta.shape()[1..dim_c],
+    );
+
     let mut split_m = vec![input.meta.shape()[0]];
-    split_m.extend(input.meta.shape()[1..dim_c].iter().copied());
+    split_m.extend(out_shape.iter().copied());
+
+    let input = match options.stride.iter().all(|stride| *stride == 1) {
+        true => input,
+        false => strided_spatial_view(input, &out_shape, &options.stride),
+    };
 
     let input = reshape_input(input); // [(NHW), C] : [M, K]
     let dtype = input.dtype;
@@ -168,12 +183,27 @@ fn check_pointwise<const N: usize>(
     kernel_shape: &[usize],
     options: &ConvOptions<N>,
 ) -> Result<(), ConvSetupError> {
+    check_pointwise_strided(kernel_shape, options)?;
+
+    match options.stride.iter().all(|stride| *stride == 1) {
+        true => Ok(()),
+        false => Err(ConvSetupError::Unknown),
+    }
+}
+
+/// The same, minus the stride: a strided pointwise convolution reads a regular
+/// subset of its input, which a view can hold exactly, so the forward pass
+/// still lowers to one matmul. The gradient paths have no such view and keep
+/// [`check_pointwise`].
+fn check_pointwise_strided<const N: usize>(
+    kernel_shape: &[usize],
+    options: &ConvOptions<N>,
+) -> Result<(), ConvSetupError> {
     if options.groups != 1 {
         return Err(ConvSetupError::Groups(options.groups));
     }
 
     let pointwise = kernel_shape.iter().all(|size| *size == 1)
-        && options.stride.iter().all(|stride| *stride == 1)
         && options.padding.iter().all(|padding| *padding == 0)
         && options.dilation.iter().all(|dilation| *dilation == 1);
 
@@ -181,6 +211,26 @@ fn check_pointwise<const N: usize>(
         true => Ok(()),
         false => Err(ConvSetupError::Unknown),
     }
+}
+
+/// The view a strided pointwise convolution actually reads: every `stride`-th
+/// position along each spatial dim. Multiplying the spatial strides leaves the
+/// contiguous copy in [`reshape_input`] to gather exactly those rows.
+fn strided_spatial_view<R: CubeRuntime>(
+    mut input: CubeTensor<R>,
+    out_shape: &[usize],
+    stride: &[usize],
+) -> CubeTensor<R> {
+    let mut shape = input.meta.shape().to_vec();
+    let mut strides = input.meta.strides().to_vec();
+
+    for (dim, (out, step)) in out_shape.iter().zip(stride).enumerate() {
+        shape[dim + 1] = *out;
+        strides[dim + 1] *= *step;
+    }
+
+    *input.meta = Metadata::new(shape, strides);
+    input
 }
 
 /// Drops a pointwise weight's unit kernel dimensions, giving `[C_out, C_in]`.


### PR DESCRIPTION
A strided pointwise convolution had no matmul path. `check_pointwise` requires `stride == 1`, so `conv_im2col_1x1` declined every strided 1x1, and nothing else could take them either: the remaining forward candidates need accelerated tiles. On CPU that left `conv_direct` as the only implementation, and autotune logs exactly one candidate for those keys.

A strided pointwise reads a regular subset of its input, so multiplying the spatial strides gives a view holding precisely the positions it reads. The contiguous copy `reshape_input` already performs then gathers them, and the convolution stays the single matmul it always was. No new kernel.

The gradient paths keep the strict `check_pointwise`; only the forward gets `check_pointwise_strided`, which is the same check minus the stride. Padding still declines, since padded positions are not in the input for a view to reach.

## Measurements

ResNet-50, batch 1, Ryzen 5700X, burn's cubecl CPU backend, fusion and autotune on. Both arms measured on an idle machine with autotune re-run, minutes apart:

| | before | after | |
|---|---|---|---|
| whole forward | 236.71 ms | 219.08 ms | **-7.4%** |
| layer4 group | 49.34 ms | 34.10 ms | -31% |
| downsample 1024→2048 | 15.49 ms | 2.73 ms | **-5.7x** |
| downsample 512→1024 | 4.18 ms | 2.14 ms | -2.0x |
| downsample 256→512 | 2.52 ms | 2.33 ms | -8% |

The whole model re-measured within 1% at the end of each run, so the machine held still.

Autotune's own candidate timings on the 1024→2048 key agree: `conv_im2col_1x1` 2.657 ms against `conv_direct` 15.592 ms.

The gain is shape-dependent, and the same kernel behaves very differently across machines: on a laptop `conv_direct` already tuned that shape at 3.50 ms rather than 15.14, so the win there is 1.5x rather than 5.7x. Autotune picks per shape, so a case where the gather costs more than it saves keeps the direct kernel.

## Correctness

`test_conv2d_1x1_strided` is new: the suite had no 1x1 with a stride, so nothing exercised this path. Run under `autotune-checks`, which compares every candidate's output, the whole `conv2d` module suite passes on the cpu backend (20 tests). Golden-logit parity on a pretrained ResNet-50 is unchanged on both cubecl-cpu and flex.

## One caveat worth knowing

This makes an existing candidate viable rather than adding one, so the tunable set's checksum does not change and **cached autotune results stay valid**. My first benchmark after the change showed no improvement at all, because the cache was still serving the `conv_direct` winner. Anyone upgrading past this keeps the slow kernel until their autotune cache is cleared or re-tuned.
