### PR TITLE
fix(burn-backend): use non-deprecated spin::LazyLock alias

### DIFF
--- a/crates/burn-backend/src/backend/device.rs
+++ b/crates/burn-backend/src/backend/device.rs
@@ -20,7 +20,7 @@ use std::sync::{LazyLock, OnceLock};
 #[cfg(not(feature = "std"))]
 pub use hashbrown::HashMap;
 #[cfg(not(feature = "std"))]
-use spin::{Lazy as LazyLock, Once as OnceLock};
+use spin::{LazyLock, Once as OnceLock};
 
 use crate::Backend;
 


### PR DESCRIPTION
### Description
Replaces the deprecated `spin::Lazy` import with `spin::LazyLock` in the `no_std` path of `crates/burn-backend/src/backend/device.rs`.

`spin` deprecated the `Lazy` alias in favor of `LazyLock` (mirroring `std::sync::LazyLock`). The existing code compiled with a deprecation warning on newer `spin` versions, which becomes a hard error under `cargo clippy -- -D warnings`.

### Changes
- `crates/burn-backend/src/backend/device.rs`: changed `use spin::{Lazy as LazyLock, Once as OnceLock}` to `use spin::{LazyLock, Once as OnceLock}`.

### Testing
- `cargo clippy -p burn-backend -- -D warnings` passes.
- `cargo test -p burn-backend` passes.