### PR TITLE
style(burn-derive): apply clippy::pedantic cleanups

### DIFF
--- a/crates/burn-derive/src/config/analyzer_struct.rs
+++ b/crates/burn-derive/src/config/analyzer_struct.rs
@@ -38,15 +38,15 @@ impl ConfigStructAnalyzer {
     fn names(&self) -> Vec<FieldTypeAnalyzer> {
         let mut names = Vec::new();
 
-        for field in self.fields_required.iter() {
+        for field in &self.fields_required {
             names.push(field.clone());
         }
 
-        for field in self.fields_option.iter() {
+        for field in &self.fields_option {
             names.push(field.clone());
         }
 
-        for (field, _) in self.fields_default.iter() {
+        for (field, _) in &self.fields_default {
             names.push(field.clone());
         }
 
@@ -56,7 +56,7 @@ impl ConfigStructAnalyzer {
     fn name_types(&self, names: &[FieldTypeAnalyzer]) -> Vec<TokenStream> {
         let mut name_types = Vec::new();
 
-        for field in names.iter() {
+        for field in names {
             let name = field.ident();
             let ty = &field.field.ty;
 
@@ -187,7 +187,7 @@ impl ConfigAnalyzer for ConfigStructAnalyzer {
             }
         };
 
-        for field in self.fields_required.iter() {
+        for field in &self.fields_required {
             let name = field.ident();
             let ty = &field.field.ty;
             let docs = field.docs();
@@ -206,7 +206,7 @@ impl ConfigAnalyzer for ConfigStructAnalyzer {
             });
         }
 
-        for field in self.fields_option.iter() {
+        for field in &self.fields_option {
             let name = field.ident();
             let docs = field.docs();
 
@@ -223,7 +223,7 @@ impl ConfigAnalyzer for ConfigStructAnalyzer {
             });
         }
 
-        for (field, attribute) in self.fields_default.iter() {
+        for (field, attribute) in &self.fields_default {
             let name = field.ident();
             let value = &attribute.value;
             let docs = field.docs();
@@ -241,7 +241,7 @@ impl ConfigAnalyzer for ConfigStructAnalyzer {
                         #name: #value,
                     });
                 }
-            };
+            }
             docs_header(&mut fn_docs, false, false, true);
             let default_doc = format!("- Defaults to `{}`", quote!(#value));
             let doc_str = format!("###### `{}`\n", quote!(#name));
@@ -268,7 +268,7 @@ impl ConfigAnalyzer for ConfigStructAnalyzer {
     fn gen_builder_fns(&self) -> TokenStream {
         let mut body = quote! {};
 
-        for (field, attribute) in self.fields_default.iter() {
+        for (field, attribute) in &self.fields_default {
             let name = field.ident();
             let ty = &field.field.ty;
             let value = &attribute.value;
@@ -294,14 +294,13 @@ impl ConfigAnalyzer for ConfigStructAnalyzer {
             });
         }
 
-        for field in self.fields_option.iter() {
+        for field in &self.fields_option {
             let name = field.ident();
             let ty = &field.field.ty;
             let docs = field.docs();
             let default_doc = "- Defaults to `None`";
             let doc_str = format!(
-                "Sets the value for the field [`{}`](Self::{0}).\n\n",
-                quote!(#name)
+                "Sets the value for the field [`{name}`](Self::{name}).\n\n",
             );
             let fn_docs = quote! {
                 #[doc = #doc_str]

--- a/crates/burn-derive/src/module/codegen_enum.rs
+++ b/crates/burn-derive/src/module/codegen_enum.rs
@@ -95,7 +95,7 @@ impl ModuleCodegen for EnumModuleCodegen {
 
     fn gen_map(&self) -> TokenStream {
         let enum_name = self.name.to_string();
-        let container_type = format!("Enum:{}", enum_name);
+        let container_type = format!("Enum:{enum_name}");
         let match_body = self.gen_variants_match_fn(|variant| {
             let variant_str = variant.to_string();
             quote! {
@@ -248,14 +248,13 @@ pub(crate) fn parse_variants(
     ast: &syn::DeriveInput,
     generics: &mut ModuleGenerics,
 ) -> syn::Result<Vec<EnumVariant>> {
-    let enum_data = match &ast.data {
-        syn::Data::Enum(data) => data,
-        _ => return Err(syn::Error::new_spanned(ast, "Only enums are supported")),
+    let syn::Data::Enum(enum_data) = &ast.data else {
+        return Err(syn::Error::new_spanned(ast, "Only enums are supported"));
     };
 
     let mut variants = Vec::new();
 
-    for variant in enum_data.variants.iter() {
+    for variant in &enum_data.variants {
         for attr in &variant.attrs {
             if attr.path().is_ident("module") {
                 Err(syn::Error::new_spanned(

--- a/crates/burn-derive/src/module/codegen_struct.rs
+++ b/crates/burn-derive/src/module/codegen_struct.rs
@@ -38,7 +38,7 @@ impl ModuleCodegen for StructModuleCodegen {
 
     fn gen_visit(&self) -> TokenStream {
         let struct_name = self.name.to_string();
-        let container_type = format!("Struct:{}", struct_name);
+        let container_type = format!("Struct:{struct_name}");
         let body = self.gen_fields_fn(|name, field_type| {
             if field_type.is_parameter_module() || field_type.maybe_generic_module() {
                 let name_str = name.to_string();
@@ -121,7 +121,7 @@ impl ModuleCodegen for StructModuleCodegen {
 
     fn gen_map(&self) -> TokenStream {
         let struct_name = self.name.to_string();
-        let container_type = format!("Struct:{}", struct_name);
+        let container_type = format!("Struct:{struct_name}");
         let (names, body) = self.gen_fields_fn_names(|name, field_type| {
             if field_type.is_parameter_module() || field_type.maybe_generic_module() {
                 let name_str = name.to_string();
@@ -248,7 +248,7 @@ impl StructModuleCodegen {
         let mut body = quote! {};
         let mut names = Vec::new();
 
-        for field in self.fields.iter() {
+        for field in &self.fields {
             let name = field.ident();
 
             names.push(name.clone());
@@ -264,7 +264,7 @@ impl StructModuleCodegen {
     {
         let mut body = quote! {};
 
-        for field in self.fields.iter() {
+        for field in &self.fields {
             body.extend(func(field.ident(), &field.field_type));
         }
 
@@ -327,7 +327,7 @@ pub(crate) fn parse_module_fields(
 
     match &ast.data {
         syn::Data::Struct(struct_data) => {
-            for field in struct_data.fields.iter() {
+            for field in &struct_data.fields {
                 let field_type = parse_module_field_type(field, generics)?;
                 if field_type.is_module {
                     module_generics.extend(field_type.generic_idents.iter().cloned());
@@ -337,9 +337,8 @@ pub(crate) fn parse_module_fields(
                 fields.push(ModuleField::new(field.clone(), field_type));
             }
         }
-        syn::Data::Enum(_) => panic!("Only struct can be derived"),
-        syn::Data::Union(_) => panic!("Only struct can be derived"),
-    };
+        syn::Data::Enum(_) | syn::Data::Union(_) => panic!("Only struct can be derived"),
+    }
 
     for ident in module_generics.intersection(&skip_generics) {
         if let Some(param) = ast.generics.params.iter().find_map(|p| match p {
@@ -390,7 +389,7 @@ pub(crate) fn parse_module_field_type(
                     Ok(())
                 } else {
                     let path = meta.path.to_token_stream().to_string();
-                    Err(meta.error(format!("Unsupported module attribute: {}", path)))
+                    Err(meta.error(format!("Unsupported module attribute: {path}")))
                 }?;
 
                 if is_param && field_type.attr.is_some() {
@@ -446,9 +445,8 @@ fn is_primitive_type(ty: &syn::Type) -> bool {
     match ty {
         // e.g. usize, String, or Option<T>
         syn::Type::Path(type_path) => {
-            let segment = match type_path.path.segments.last() {
-                Some(seg) => seg,
-                None => return false,
+            let Some(segment) = type_path.path.segments.last() else {
+                return false;
             };
 
             let ident = segment.ident.to_string();

--- a/crates/burn-derive/src/module/generics.rs
+++ b/crates/burn-derive/src/module/generics.rs
@@ -30,8 +30,7 @@ impl ModuleGenerics {
     pub fn is_bounded_module(&self, ident: &Ident) -> bool {
         self.kinds
             .get(ident)
-            .map(|kind| matches!(kind, GenericKind::Module))
-            .unwrap_or(false)
+            .is_some_and(|kind| matches!(kind, GenericKind::Module))
     }
 
     pub fn update(&mut self, ident: &Ident, kind: GenericKind) {
@@ -107,8 +106,8 @@ pub fn parse_ty_generics(ty: &Type, declared: &ModuleGenerics) -> HashSet<Ident>
         declared: &'a ModuleGenerics,
     }
 
-    impl<'ast, 'a> Visit<'ast> for Collector<'a> {
-        fn visit_type_path(&mut self, type_path: &'ast syn::TypePath) {
+    impl Visit<'_> for Collector<'_> {
+        fn visit_type_path(&mut self, type_path: &syn::TypePath) {
             if type_path.qself.is_none()
                 && let Some(ident) = type_path.path.get_ident()
                 && (self.declared.contains(ident))

--- a/crates/burn-derive/src/shared/field.rs
+++ b/crates/burn-derive/src/shared/field.rs
@@ -29,14 +29,14 @@ impl FieldTypeAnalyzer {
     #[allow(dead_code)]
     pub fn first_generic_field(&self) -> TypePath {
         let err = || panic!("Field {} as no generic", self.field.ident.clone().unwrap());
-        match &self.field.ty {
-            syn::Type::Path(path) => Self::path_generic_argument(path),
-            _ => err(),
-        }
+        let syn::Type::Path(path) = &self.field.ty else {
+            return err();
+        };
+        Self::path_generic_argument(path)
     }
     pub fn path_generic_argument(path: &TypePath) -> TypePath {
         let segment = path.path.segments.last().unwrap();
-        let err = || panic!("Path segment {} has no generic", segment.ident.clone(),);
+        let err = || panic!("Path segment {} has no generic", segment.ident.clone());
         match &segment.arguments {
             syn::PathArguments::None => err(),
             syn::PathArguments::AngleBracketed(param) => {


### PR DESCRIPTION
### Description
Applies a batch of low-risk `clippy::pedantic` fixes to `crates/burn-derive/` to remove noise from future lint runs.

### Changes
- `analyzer_struct.rs`: iterate over references instead of `.iter()`; remove unnecessary semicolon.
- `codegen_enum.rs`: inline `format!` arguments; use `let...else` for enum data extraction; iterate over references.
- `codegen_struct.rs`: inline `format!` arguments; use `let...else`; merge identical match arms; iterate over references; remove unnecessary semicolon.
- `generics.rs`: replace `map(...).unwrap_or(false)` with `is_some_and(...)`; elide redundant lifetimes.
- `shared/field.rs`: use `let...else`; remove unnecessary trailing comma.

### Notes
Intentionally not addressed (would change public/internal APIs or require docs changes):
- `unused_self`, `needless_pass_by_value`, `too_many_lines`, `missing_panics_doc`.

### Testing
- `cargo clippy -p burn-derive -- -D warnings` passes.
- `cargo clippy -p burn-derive -- -W clippy::pedantic` still emits 14 warnings, all in the categories listed above.
- `cargo test -p burn-derive` passes.