### PR TITLE
style(burn-std): apply clippy::pedantic cleanups

### DIFF
--- a/crates/burn-std/src/data/tensor/conversion.rs
+++ b/crates/burn-std/src/data/tensor/conversion.rs
@@ -163,7 +163,7 @@ impl TensorData {
                         .map(|e: &f64| e.elem::<E>()),
                 ),
                 // bool is a byte value equal to either 0 or 1
-                DType::Bool(BoolStore::Native) | DType::Bool(BoolStore::U8) => {
+                DType::Bool(BoolStore::Native | BoolStore::U8) => {
                     Box::new(self.bytes.iter().map(|e| e.elem::<E>()))
                 }
                 DType::Bool(BoolStore::U32) => Box::new(

--- a/crates/burn-std/src/tensor/dtype.rs
+++ b/crates/burn-std/src/tensor/dtype.rs
@@ -147,9 +147,11 @@ pub enum FloatDType {
 
 /// Numerical precision properties for a floating-point dtype.
 ///
-/// Equivalent to NumPy's `finfo` / PyTorch's `torch.finfo`. All values are
-/// widened to `f64` so they can be inspected without knowing the concrete
-/// element type at compile time.
+    /// Equivalent to NumPy's [`finfo`] / PyTorch's `torch.finfo`. All values are
+    /// widened to `f64` so they can be inspected without knowing the concrete
+    /// element type at compile time.
+    ///
+    /// [`finfo`]: https://numpy.org/doc/stable/reference/generated/numpy.finfo.html
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct FloatInfo {
     /// Machine epsilon: smallest value such that `1.0 + epsilon != 1.0`.
@@ -182,13 +184,7 @@ impl FloatDType {
             },
             // Flex32 stores as f32 but computes at reduced (f16-like) precision.
             // Use f16 precision limits so stability code stays safe.
-            FloatDType::Flex32 => FloatInfo {
-                epsilon: f16::EPSILON.to_f64_const(),
-                max: f16::MAX.to_f64_const(),
-                min: f16::MIN.to_f64_const(),
-                min_positive: f16::MIN_POSITIVE.to_f64_const(), // ~6.104e-5
-            },
-            FloatDType::F16 => FloatInfo {
+            FloatDType::Flex32 | FloatDType::F16 => FloatInfo {
                 epsilon: f16::EPSILON.to_f64_const(),
                 max: f16::MAX.to_f64_const(),
                 min: f16::MIN.to_f64_const(),

--- a/crates/burn-std/src/tensor/mod.rs
+++ b/crates/burn-std/src/tensor/mod.rs
@@ -242,26 +242,26 @@ pub fn reshape_analysis(
                 && shape_new[0..n_new_batch].iter().all(|it| *it == 1)
             {
                 return ReshapeAnalysis::Broadcasted;
-            } else {
-                let mut dim_prod = 1;
-                let mut old_idx = 0;
-                for dim in shape_new.iter() {
-                    dim_prod *= *dim;
-
-                    // We need to ignore unit dims because they don't affect analysis and break
-                    // things because they match the default `dim_prod`. If we don't do this,
-                    // reshapes like [2, 3] to [2, 3, 1] will panic from out of bounds access.
-                    if *dim == 1 {
-                        continue;
-                    } else if dim_prod == shape[old_idx] {
-                        dim_prod = 1;
-                        old_idx += 1;
-                    } else if dim_prod > shape[old_idx] {
-                        return ReshapeAnalysis::HighlyPermuted;
-                    }
-                }
-                return ReshapeAnalysis::Split;
             }
+
+            let mut dim_prod = 1;
+            let mut old_idx = 0;
+            for dim in shape_new.iter() {
+                dim_prod *= *dim;
+
+                // We need to ignore unit dims because they don't affect analysis and break
+                // things because they match the default `dim_prod`. If we don't do this,
+                // reshapes like [2, 3] to [2, 3, 1] will panic from out of bounds access.
+                if *dim == 1 {
+                    continue;
+                } else if dim_prod == shape[old_idx] {
+                    dim_prod = 1;
+                    old_idx += 1;
+                } else if dim_prod > shape[old_idx] {
+                    return ReshapeAnalysis::HighlyPermuted;
+                }
+            }
+            return ReshapeAnalysis::Split;
         }
 
         false => {


### PR DESCRIPTION
### Description
Applies a small batch of low-risk `clippy::pedantic` fixes to `crates/burn-std/` to reduce lint noise.

### Changes
- `tensor/mod.rs`: remove redundant `else` after an early `return`.
- `data/tensor/conversion.rs`: nest the `Bool` or-pattern (`Bool(Native | U8)`).
- `tensor/dtype.rs`: merge identical `FloatDType::Flex32` and `FloatDType::F16` match arms; add backticks / reference link for `finfo` in docs.

### Notes
Intentionally not addressed (would change public API or require non-trivial doc additions):
- `must_use_candidate`, `missing_panics_doc`, `missing_errors_doc`, `unnecessary_cast`, `cast_ptr_alignment`, etc.

### Testing
- `cargo clippy -p burn-std -- -D warnings` passes.
- `cargo test -p burn-std` passes.
- `cargo build --no-default-features -p burn-std` passes (crate supports `no_std`).