### PR TITLE
style(xtask): apply clippy::pedantic cleanups

### DIFF
--- a/xtask/src/commands/build.rs
+++ b/xtask/src/commands/build.rs
@@ -94,7 +94,7 @@ pub(crate) fn handle_command(
                 ]);
                 if std::env::var("DISABLE_WGPU").is_ok() {
                     args.exclude.extend(vec!["burn-wgpu".to_string()]);
-                };
+                }
             }
             // Build workspace
             base_commands::build::handle_command(args.try_into().unwrap(), env, context)?;

--- a/xtask/src/commands/test.rs
+++ b/xtask/src/commands/test.rs
@@ -125,7 +125,7 @@ fn handle_wgpu_test(member: &str, args: &TestCmdArgs) -> anyhow::Result<()> {
 
     let workspace_member = WorkspaceMember {
         name: member.into(),
-        path: "".into(), // unused
+        path: String::new(), // unused
     };
 
     if let Err(err) = base_commands::test::run_unit_test(&workspace_member, args) {
@@ -133,8 +133,7 @@ fn handle_wgpu_test(member: &str, args: &TestCmdArgs) -> anyhow::Result<()> {
             .downcast_ref::<ProcessExitError>()
             .filter(filter_err)
             // Failed to execute unit test for '{member}'
-            .map(|e| e.message.contains(member))
-            .unwrap_or(false);
+            .is_some_and(|e| e.message.contains(member));
 
         if should_ignore {
             // Ignore intermittent successful failures
@@ -366,8 +365,7 @@ pub(crate) fn handle_command(
             // 2) Specific additional commands to test specific features
             // ---------------------------------------------------------
             match args.ci {
-                CiTestType::Backends | CiTestType::GithubRunner => (),
-                CiTestType::Examples => (),
+                CiTestType::Backends | CiTestType::GithubRunner | CiTestType::Examples => (),
                 CiTestType::Crates => {
                     // Capture is intentionally opt-in, so workspace-default tests don't compile
                     // the dispatch, tensor, core, or facade integration tests that exercise it.


### PR DESCRIPTION
### Description
Applies a small batch of low-risk `clippy::pedantic` fixes to `xtask/` to reduce lint noise.

### Changes
- `src/commands/build.rs`: remove unnecessary semicolon after `if` block.
- `src/commands/test.rs`: replace `"".into()` with `String::new()`; use `is_some_and(...)` instead of `map(...).unwrap_or(false)`; merge identical `CiTestType` match arms.

### Notes
Intentionally not addressed (would change command function signatures or require larger refactors):
- `needless_pass_by_value` on command arguments, `too_many_lines`, and the formatting suggestion for trailing expression.

### Testing
- `cargo clippy -p xtask -- -D warnings` passes.
- `cargo clippy -p xtask -- -W clippy::pedantic` drops from 12 to 9 warnings.
- `cargo test -p xtask` passes.