### PR TITLE
style(burn-cpu): add must_use to device_throughput

### DIFF
--- a/crates/burn-cpu/src/lib.rs
+++ b/crates/burn-cpu/src/lib.rs
@@ -16,6 +16,7 @@ pub type Cpu = CubeBackend<CpuRuntime>;
 pub type Cpu = burn_fusion::Fusion<CubeBackend<CpuRuntime>>;
 
 /// Measure peak throughput on a CPU `device` for each of the given `keys`.
+#[must_use]
 pub fn device_throughput(
     device: &CpuDevice,
     keys: &[ThroughputKey],


### PR DESCRIPTION
### Description
Adds `#[must_use]` to `device_throughput` in `crates/burn-cpu/src/lib.rs` to satisfy `clippy::pedantic`.

### Testing
- `cargo clippy -p burn-cpu -- -D warnings` passes.
- `cargo fmt --check crates/burn-cpu/src/lib.rs` passes.

This is a pure annotation change with no behavior impact.