### PR TITLE
style(burn-rocm): add must_use and doc backticks

### DIFF
--- a/crates/burn-rocm/src/lib.rs
+++ b/crates/burn-rocm/src/lib.rs
@@ -16,7 +16,8 @@ pub type Rocm = CubeBackend<HipRuntime>;
 #[cfg(feature = "fusion")]
 pub type Rocm = burn_fusion::Fusion<CubeBackend<HipRuntime>>;
 
-/// Measure peak throughput on a ROCm `device` for each of the given `keys`.
+/// Measure peak throughput on a `ROCm` [`device`](crate::RocmDevice) for each of the given `keys`.
+#[must_use]
 pub fn device_throughput(
     device: &RocmDevice,
     keys: &[ThroughputKey],


### PR DESCRIPTION
### Description
Applies small `clippy::pedantic` cleanups to `crates/burn-rocm/src/lib.rs`.

### Changes
- Add `#[must_use]` to `device_throughput`.
- Wrap bare `ROCm` in the docstring with backticks to satisfy the missing-backticks lint.

### Testing
- `cargo clippy -p burn-rocm -- -D warnings` passes.
- `cargo clippy -p burn-rocm -- -W clippy::pedantic` no longer reports warnings in this crate.
- `cargo fmt --check crates/burn-rocm/src/lib.rs` passes.