### PR TITLE
style(burn-wgpu): add must_use and doc backticks

### DIFF
--- a/crates/burn-wgpu/src/lib.rs
+++ b/crates/burn-wgpu/src/lib.rs
@@ -69,7 +69,7 @@ type WgpuInner<C> = CubeBackend<cubecl::wgpu::WgpuRuntime<C>>;
 ///
 /// # Notes
 ///
-/// When the `fusion` feature flag is enabled (the default), this backend uses [burn_fusion] to
+/// When the `fusion` feature flag is enabled (the default), this backend uses [`burn_fusion`] to
 /// compile and optimize streams of tensor operations for improved performance. You can disable
 /// the `fusion` feature flag to remove that functionality, which might be necessary on `wasm`
 /// for now.
@@ -78,6 +78,7 @@ pub type Wgpu = WgpuInner<AutoCompiler>;
 /// Measure peak throughput on a wgpu `device` for each of the given `keys`.
 ///
 /// Uses the auto-selected shader compiler, matching the default [`Wgpu`] backend.
+#[must_use]
 pub fn device_throughput(
     device: &WgpuDevice,
     keys: &[ThroughputKey],


### PR DESCRIPTION
### Description
Applies small `clippy::pedantic` cleanups to `crates/burn-wgpu/src/lib.rs`.

### Changes
- Add `#[must_use]` to `device_throughput`.
- Wrap bare `burn_fusion` in the docstring with backticks to satisfy the missing-backticks lint.

### Testing
- `cargo clippy -p burn-wgpu -- -D warnings` passes.
- `cargo clippy -p burn-wgpu -- -W clippy::pedantic` no longer reports warnings in this crate.
- `cargo fmt --check crates/burn-wgpu/src/lib.rs` passes.