### PR TITLE
style(burn-communication): apply clippy::pedantic cleanups

### DIFF
--- a/crates/burn-communication/src/base.rs
+++ b/crates/burn-communication/src/base.rs
@@ -24,16 +24,19 @@ pub struct Address {
 
 impl Address {
     /// The scheme component (e.g. `ws`), lowercased. Defaults to `ws` when none was given.
+    #[must_use]
     pub fn scheme(&self) -> &str {
         &self.scheme
     }
 
     /// The host component (host name or IP literal), exactly as written.
+    #[must_use]
     pub fn host(&self) -> &str {
         &self.host
     }
 
     /// The port component, if one was specified.
+    #[must_use]
     pub fn port(&self) -> Option<u16> {
         self.port
     }
@@ -138,6 +141,7 @@ pub trait ProtocolServer: Sized + Send + Sync + 'static {
 
     /// Defines an endpoint with the function that responds.
     /// TODO Docs: does it need a slash?
+    #[must_use]
     fn route<C, Fut>(self, path: &str, callback: C) -> Self
     where
         C: FnOnce(Self::Channel) -> Fut + Clone + Send + Sync + 'static,

--- a/crates/burn-communication/src/util.rs
+++ b/crates/burn-communication/src/util.rs
@@ -1,4 +1,8 @@
 /// Utilities to help handle communication termination.
+///
+/// # Panics
+///
+/// Panics if the OS signal handlers (Ctrl-C or terminate) cannot be installed.
 pub async fn os_shutdown_signal() {
     let ctrl_c = async {
         tokio::signal::ctrl_c()
@@ -18,7 +22,7 @@ pub async fn os_shutdown_signal() {
     let terminate = std::future::pending::<()>();
 
     tokio::select! {
-        _ = ctrl_c => {},
-        _ = terminate => {},
+        () = ctrl_c => (),
+        () = terminate => (),
     }
 }


### PR DESCRIPTION
### Description
Applies small, low-risk `clippy::pedantic` fixes to `crates/burn-communication/src/base.rs` and `src/util.rs`.

### Changes
- Add `#[must_use]` to `Address::scheme`, `Address::host`, `Address::port`, and `ProtocolServer::route`.
- Add `# Panics` documentation to `os_shutdown_signal`.
- Use explicit `()` patterns in `tokio::select!` arms.

### Testing
- `cargo clippy -p burn-communication -- -D warnings` passes.
- `cargo clippy -p burn-communication -- -W clippy::pedantic` no longer reports warnings in this crate.
- `cargo fmt --check` passes.