### PR TITLE
style(burn-dispatch): apply clippy::pedantic cleanups

### DIFF
--- a/crates/burn-dispatch/src/backend.rs
+++ b/crates/burn-dispatch/src/backend.rs
@@ -130,6 +130,7 @@ use burn_autodiff::grads::Gradients;
 use crate::DispatchDeviceId;
 #[allow(unused)]
 use crate::DispatchTensorKind;
+#[allow(clippy::wildcard_imports)]
 use crate::backends::*;
 use crate::{DispatchDevice, DispatchTensor};
 
@@ -178,7 +179,7 @@ impl Backend for Dispatch {
     }
 
     fn seed(device: &Self::Device, seed: u64) {
-        dispatch_device!(device, |device| B::seed(device, seed))
+        dispatch_device!(device, |device| B::seed(device, seed));
     }
 
     fn sync(device: &Self::Device) -> Result<(), ExecutionError> {
@@ -262,7 +263,7 @@ impl Backend for Dispatch {
     }
 
     fn memory_cleanup(device: &Self::Device) {
-        dispatch_device!(device, |device| B::memory_cleanup(device))
+        dispatch_device!(device, |device| B::memory_cleanup(device));
     }
 
     fn memory_install_pools(
@@ -287,7 +288,7 @@ impl Backend for Dispatch {
     where
         Iter: Iterator<Item = &'a mut burn_backend::TensorData>,
     {
-        dispatch_device!(device, |device| B::staging(data, device))
+        dispatch_device!(device, |device| B::staging(data, device));
     }
 
     fn supports_dtype(device: &Self::Device, dtype: DType) -> bool {
@@ -295,7 +296,7 @@ impl Backend for Dispatch {
     }
 
     fn flush(device: &Self::Device) {
-        dispatch_device!(device, |device| B::flush(device))
+        dispatch_device!(device, |device| B::flush(device));
     }
 }
 
@@ -920,6 +921,7 @@ impl AutodiffBackend for Dispatch {
 
 impl Dispatch {
     /// List all available devices of the specified [type id](DispatchDeviceId).
+    #[must_use]
     pub fn enumerate(type_id: DispatchDeviceId) -> Vec<DispatchDevice> {
         // TODO: right now this assumes `type_id = 0`, but WgpuDevice and LibTorchDevice have other types.
         match type_id {

--- a/crates/burn-dispatch/src/device.rs
+++ b/crates/burn-dispatch/src/device.rs
@@ -1,5 +1,6 @@
 use burn_backend::{DeviceId, DeviceOps, DeviceSettings};
 
+#[allow(clippy::wildcard_imports)]
 use crate::backends::*;
 
 #[cfg(feature = "capture")]
@@ -352,7 +353,7 @@ impl Default for DispatchDevice {
                             "BURN_DEVICE=ndarray requested, but the 'ndarray' feature is not enabled."
                         );
                     }
-                    _ => panic!("Unknown BURN_DEVICE override: '{}'.", device_str),
+                    _ => panic!("Unknown BURN_DEVICE override: '{device_str}'."),
                 }
             }
         }
@@ -469,6 +470,7 @@ impl DispatchDevice {
     }
 
     /// Returns the inner device, without autodiff (when enabled).
+    #[must_use]
     pub fn inner(self) -> Self {
         #[cfg(feature = "autodiff")]
         if let DispatchDevice::Autodiff(device) = self {
@@ -478,7 +480,7 @@ impl DispatchDevice {
         self
     }
 
-    /// Returns a unique number per variant to encode into type_id.
+    /// Returns a unique number per variant to encode into `type_id`.
     fn backend_id(&self) -> DispatchDeviceId {
         match self {
             #[cfg(feature = "cpu")]

--- a/crates/burn-dispatch/src/lib.rs
+++ b/crates/burn-dispatch/src/lib.rs
@@ -22,7 +22,7 @@
 //! | `Cpu`      | `cpu`      | Rust CPU backend (MLIR + LLVM) |
 //! | `Cuda`     | `cuda`     | NVIDIA CUDA backend |
 //! | `Metal`    | `metal`    | Apple Metal backend via `wgpu` (MSL) |
-//! | `Rocm`     | `rocm`     | AMD ROCm backend |
+//! | `Rocm`     | `rocm`     | AMD `ROCm` backend |
 //! | `Vulkan`   | `vulkan`   | Vulkan backend via `wgpu` (SPIR-V) |
 //! | `Wgpu`     | `webgpu`   | WebGPU backend via `wgpu` (WGSL) |
 //! | `Flex`     | `flex`     | Pure Rust CPU backend using `burn-flex` |

--- a/crates/burn-dispatch/src/ops/distributed.rs
+++ b/crates/burn-dispatch/src/ops/distributed.rs
@@ -120,7 +120,7 @@ impl DistributedOps<Self> for Dispatch {
     fn close_communication_server(device: &DispatchDevice) {
         dispatch_device!(@distributed device, |device| {
             B::close_communication_server(device)
-        })
+        });
     }
 
     fn register_sync_parameters(
@@ -130,11 +130,11 @@ impl DistributedOps<Self> for Dispatch {
         dispatch_device!(@distributed device, |device| B::register_sync_parameters(
             device,
             sharded_param_ids,
-        ))
+        ));
     }
 
     fn submit_sync_collective(device: &DispatchDevice) {
-        dispatch_device!(@distributed device, |device| B::submit_sync_collective(device))
+        dispatch_device!(@distributed device, |device| B::submit_sync_collective(device));
     }
 
     fn submit_gradient_sync(_tensor: TensorRef<Self>, _distributed_params: DistributedParams) {
@@ -158,7 +158,7 @@ impl DistributedOps<Self> for Dispatch {
     }
 
     fn sync_collective(device: &DispatchDevice) {
-        dispatch_device!(@distributed device, |device| B::sync_collective(device))
+        dispatch_device!(@distributed device, |device| B::sync_collective(device));
     }
 
     unsafe fn comm_device(_tensor: &TensorRef<Self>) -> DispatchDevice {

--- a/crates/burn-dispatch/src/tensor.rs
+++ b/crates/burn-dispatch/src/tensor.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::wildcard_imports)]
 use crate::{DispatchDevice, backends::*};
 
 #[cfg(feature = "autodiff")]
@@ -35,6 +36,10 @@ pub enum BackendTensor<B: BackendTypes> {
 
 impl<B: Backend> BackendTensor<B> {
     /// Returns the inner float tensor primitive.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the tensor is not a float tensor.
     pub fn float(self) -> B::FloatTensorPrimitive {
         match self {
             BackendTensor::Float(tensor) => tensor,
@@ -46,6 +51,10 @@ impl<B: Backend> BackendTensor<B> {
         }
     }
     /// Returns the inner float tensor primitive.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the tensor is not a float tensor.
     pub fn as_float(&self) -> &B::FloatTensorPrimitive {
         match self {
             BackendTensor::Float(tensor) => tensor,
@@ -58,6 +67,10 @@ impl<B: Backend> BackendTensor<B> {
     }
 
     /// Returns the inner int tensor primitive.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the tensor is not an int tensor.
     pub fn int(self) -> B::IntTensorPrimitive {
         match self {
             BackendTensor::Int(tensor) => tensor,
@@ -70,6 +83,10 @@ impl<B: Backend> BackendTensor<B> {
     }
 
     /// Returns the inner bool tensor primitive.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the tensor is not a bool tensor.
     pub fn bool(self) -> B::BoolTensorPrimitive {
         match self {
             BackendTensor::Bool(tensor) => tensor,
@@ -82,6 +99,10 @@ impl<B: Backend> BackendTensor<B> {
     }
 
     /// Returns the inner quantized tensor primitive.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the tensor is not a quantized tensor.
     pub fn quantized(self) -> B::QuantizedTensorPrimitive {
         match self {
             BackendTensor::Quantized(tensor) => tensor,
@@ -89,8 +110,12 @@ impl<B: Backend> BackendTensor<B> {
         }
     }
 
-    #[cfg(feature = "autodiff")]
     /// Returns the inner autodiff tensor primitive.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the tensor is not an autodiff tensor.
+    #[cfg(feature = "autodiff")]
     pub fn autodiff(self) -> FloatTensor<Autodiff<B>> {
         match self {
             BackendTensor::Autodiff(tensor) => tensor,


### PR DESCRIPTION
### Description
Applies small, low-risk `clippy::pedantic` fixes to `crates/burn-dispatch/src`.

### Changes
- Add backticks to `ROCm` and `type_id` in crate-level docs.
- Add trailing semicolons to macro-expanded `Backend` method bodies for consistent formatting.
- Add `#[must_use]` to `Dispatch::enumerate` and `DispatchDevice::inner`.
- Use inline variable capture in the `panic!` format string for unknown `BURN_DEVICE` overrides.
- Add `# Panics` documentation to `BackendTensor::{float, as_float, int, bool, quantized, autodiff}`.
- Allow `clippy::wildcard_imports` for the existing `crate::backends::*` and `crate::{DispatchDevice, backends::*}` re-exports rather than expanding feature-gated wildcards.
- Add trailing semicolons to `distributed` ops macro calls.

### Not addressed
- `too_many_lines` warnings in `device.rs` and `ops/qtensor.rs` are intentionally left for a focused refactor, since fixing them would require splitting functions and changing logic structure.

### Testing
- `cargo clippy -p burn-dispatch -- -D warnings` passes.
- `cargo clippy -p burn-dispatch -- -W clippy::pedantic` only reports the two intentional `too_many_lines` warnings.
- `cargo fmt --check` passes.