### PR TITLE
style(burn-remote): apply clippy::pedantic cleanups

### DIFF
--- a/crates/burn-remote/src/client/base.rs
+++ b/crates/burn-remote/src/client/base.rs
@@ -28,7 +28,7 @@ impl RemoteClient {
     /// connect on the service's runner thread, so it can't sit under cubecl's global lock.
     pub(crate) fn ensure_connected(&self) {
         self.handle
-            .submit_blocking(|s| s.ensure_connected())
+            .submit_blocking(super::service::RemoteService::ensure_connected)
             .expect("Service call failed");
     }
 

--- a/crates/burn-remote/src/client/custom_op.rs
+++ b/crates/burn-remote/src/client/custom_op.rs
@@ -39,6 +39,7 @@ pub struct CustomOpClient {
 
 impl CustomOpClient {
     /// Create a client bound to the given remote device.
+    #[must_use]
     pub fn new(device: &RemoteDevice) -> Self {
         #[cfg(not(feature = "fusion"))]
         let inner = burn_router::get_client::<Channel>(device);
@@ -58,6 +59,7 @@ impl CustomOpClient {
     /// [`register`](Self::register). The id is allocated by the same client that registers the op, so
     /// it is consistent with how that client tracks tensors (fusion ids under `fusion`, router ids
     /// otherwise).
+    #[must_use]
     pub fn create_empty_handle(&self) -> TensorId {
         #[cfg(not(feature = "fusion"))]
         {
@@ -71,6 +73,7 @@ impl CustomOpClient {
     }
 
     /// Register a custom op and return its (uninitialized) output tensors.
+    #[must_use]
     pub fn register(&self, op: CustomOpIr) -> Vec<FloatTensor<RemoteBackend>> {
         #[cfg(not(feature = "fusion"))]
         {

--- a/crates/burn-remote/src/client/runner.rs
+++ b/crates/burn-remote/src/client/runner.rs
@@ -99,7 +99,9 @@ impl RouterClient for RemoteClient {
     }
 
     fn flush(&self) {
-        self.handle.submit_blocking(|s| s.flush()).unwrap();
+        self.handle
+            .submit_blocking(super::service::RemoteService::flush)
+            .unwrap();
     }
 
     fn register_and_execute_graph(
@@ -110,7 +112,7 @@ impl RouterClient for RemoteClient {
     ) {
         let stream_id = StreamId::current();
         self.handle.submit(move |s| {
-            s.register_and_execute_graph(stream_id, graph_id, relative_graph, bindings)
+            s.register_and_execute_graph(stream_id, graph_id, relative_graph, bindings);
         });
     }
 
@@ -140,10 +142,11 @@ impl RemoteClient {
 
         if let OperationIr::Distributed(DistributedOperationIr::AllReduce(desc)) = &mut op {
             let local_peer = self.device.peer_id();
-            for id in desc.device_ids.iter_mut() {
-                let (endpoint, device_index) = service::endpoint_for(id.index_id as u32).expect(
-                    "an all_reduce device must be a registered remote device on this process",
-                );
+            for id in &mut desc.device_ids {
+                let (endpoint, device_index) = service::endpoint_for(u32::from(id.index_id))
+                    .expect(
+                        "an all_reduce device must be a registered remote device on this process",
+                    );
                 assert_eq!(
                     endpoint.peer_id(),
                     local_peer,
@@ -152,7 +155,10 @@ impl RemoteClient {
                     endpoint.peer_id(),
                 );
                 id.type_id = 0;
-                id.index_id = device_index as u16;
+                #[allow(clippy::cast_possible_truncation)]
+                {
+                    id.index_id = device_index as u16;
+                }
             }
             log::trace!("All-reduce on {:?} ({local_peer}): {desc:?}", self.device);
         }
@@ -164,7 +170,7 @@ impl RemoteClient {
 #[derive(Clone, Debug)]
 /// A remote compute device identified by its endpoint and device index.
 ///
-/// Two RemoteDevices with the same endpoint but different indices point at distinct devices on
+/// Two `RemoteDevices` with the same endpoint but different indices point at distinct devices on
 /// the same peer; each gets its own registry id and service connection, and transfers between
 /// them take the same-peer fast path.
 pub struct RemoteDevice {
@@ -178,11 +184,13 @@ pub struct RemoteDevice {
 impl RemoteDevice {
     /// Create a legacy WebSocket device from a URL.
     #[cfg(feature = "websocket")]
+    #[must_use]
     pub fn websocket(address: &str, device_index: usize) -> Self {
         let endpoint = RemoteEndpoint::WebSocket {
             address: burn_communication::Address::from(address),
             authorization: Arc::from([]),
         };
+        #[allow(clippy::cast_possible_truncation)]
         let device_index = device_index as u32;
         let id = service::register_endpoint(endpoint.clone(), Executor::capture(), device_index);
         Self {
@@ -196,12 +204,14 @@ impl RemoteDevice {
     ///
     /// The application owns the Iroh endpoint; Burn dials the compute peer from it.
     #[cfg(feature = "iroh")]
+    #[must_use]
     pub fn iroh(endpoint: &iroh::Endpoint, peer: iroh::EndpointAddr, device_index: usize) -> Self {
         Self::iroh_authorized(endpoint, peer, device_index, Vec::new())
     }
 
-    /// Like [`iroh`](Self::iroh), but carries an authorization credential the server's PeerAuthorizer will check.
+    /// Like [`iroh`](Self::iroh), but carries an authorization credential the server's `PeerAuthorizer` will check.
     #[cfg(feature = "iroh")]
+    #[must_use]
     pub fn iroh_authorized(
         endpoint: &iroh::Endpoint,
         peer: iroh::EndpointAddr,
@@ -214,6 +224,7 @@ impl RemoteDevice {
             peer,
             authorization: authorization.into(),
         };
+        #[allow(clippy::cast_possible_truncation)]
         let device_index = device_index as u32;
         let id = service::register_endpoint(endpoint.clone(), Executor::capture(), device_index);
         Self {
@@ -250,21 +261,25 @@ impl RemoteDevice {
     }
 
     /// The stable identity of the compute peer.
+    #[must_use]
     pub fn peer_id(&self) -> PeerId {
         self.endpoint.peer_id()
     }
 
     /// The peer identity plus its current dialing hints.
+    #[must_use]
     pub fn peer_addr(&self) -> PeerAddr {
         self.endpoint.peer_addr()
     }
 
     /// The peer address as a string. Prefer `peer_addr` for typed access.
+    #[must_use]
     pub fn address(&self) -> String {
         self.peer_addr().to_string()
     }
 
     /// The index of this device on its server.
+    #[must_use]
     pub fn device_index(&self) -> usize {
         self.device_index as usize
     }
@@ -272,9 +287,15 @@ impl RemoteDevice {
     /// List every device hosted by the WebSocket server at `address`.
     ///
     /// Connects to index 0 to read the device count from the init handshake, then returns one
-    /// RemoteDevice per index. Remaining indices connect lazily on first use, matching the
+    /// `RemoteDevice` per index. Remaining indices connect lazily on first use, matching the
     /// behavior of [`Device::enumerate`](burn_backend::tensor::Device) for local backends.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the device-count cell for the registry is not populated after connecting to
+    /// index 0. That indicates the server did not complete the init handshake as expected.
     #[cfg(feature = "websocket")]
+    #[must_use]
     pub fn enumerate_websocket(address: &str) -> Vec<Self> {
         // Device 0 always exists (a server must host at least one device); connecting to it
         // populates the device-count cell for its registry id.
@@ -290,8 +311,14 @@ impl RemoteDevice {
     }
 
     /// List every device hosted by an Iroh peer.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the device-count cell for the registry is not populated after connecting to
+    /// index 0. That indicates the peer did not complete the init handshake as expected.
     #[cfg(feature = "iroh")]
-    pub fn enumerate_iroh(endpoint: &iroh::Endpoint, peer: iroh::EndpointAddr) -> Vec<Self> {
+    #[must_use]
+    pub fn enumerate_iroh(endpoint: &iroh::Endpoint, peer: &iroh::EndpointAddr) -> Vec<Self> {
         let device = Self::iroh(endpoint, peer.clone(), 0);
         device.connect();
         let count = service::device_count_for(device.id)
@@ -330,21 +357,23 @@ impl Default for RemoteDevice {
 
 impl burn_std::device::Device for RemoteDevice {
     fn from_id(device_id: DeviceId) -> Self {
-        if device_id.type_id != 0 {
-            panic!("Invalid device id: {device_id} (expected type 0)");
-        }
-        let (endpoint, device_index) = service::endpoint_for(device_id.index_id as u32)
+        assert!(
+            device_id.type_id == 0,
+            "Invalid device id: {device_id} (expected type 0)"
+        );
+        let (endpoint, device_index) = service::endpoint_for(u32::from(device_id.index_id))
             .unwrap_or_else(|| panic!("Invalid device id: {device_id}"));
         Self {
             endpoint,
             device_index,
-            id: device_id.index_id as u32,
+            id: u32::from(device_id.index_id),
         }
     }
 
     fn to_id(&self) -> DeviceId {
         DeviceId {
             type_id: 0,
+            #[allow(clippy::cast_possible_truncation)]
             index_id: self.id as u16,
         }
     }
@@ -383,16 +412,13 @@ static TRANSFER_COUNTER: Mutex<Option<LocalTransferId>> = Mutex::new(None);
 /// concurrency).
 fn get_next_transfer_id() -> LocalTransferId {
     let mut transfer_counter = TRANSFER_COUNTER.lock().unwrap();
-    match transfer_counter.as_mut() {
-        Some(id) => {
-            id.next();
-            *id
-        }
-        None => {
-            let id = LocalTransferId::from(0);
-            *transfer_counter = Some(id);
-            id
-        }
+    if let Some(id) = transfer_counter.as_mut() {
+        id.next();
+        *id
+    } else {
+        let id = LocalTransferId::from(0);
+        *transfer_counter = Some(id);
+        id
     }
 }
 

--- a/crates/burn-remote/src/client/service.rs
+++ b/crates/burn-remote/src/client/service.rs
@@ -136,7 +136,7 @@ impl RemoteService {
     /// Resolve a device id to its registry index, parsed network [`Address`], and the device
     /// index to select on the server.
     fn resolve_endpoint(device_id: DeviceId) -> (u32, RemoteEndpoint, u32) {
-        let id = device_id.index_id as u32;
+        let id = u32::from(device_id.index_id);
         let (endpoint, device_index) = endpoint_for(id)
             .unwrap_or_else(|| panic!("No endpoint registered for device id {device_id}"));
         (id, endpoint, device_index)
@@ -187,11 +187,10 @@ impl RemoteService {
                     device_count,
                     ..
                 }) => {
-                    if version != PROTOCOL_VERSION {
-                        panic!(
-                            "Server uses Burn Remote protocol version {version}, expected {PROTOCOL_VERSION}"
-                        );
-                    }
+                    assert!(
+                        version == PROTOCOL_VERSION,
+                        "Server uses Burn Remote protocol version {version}, expected {PROTOCOL_VERSION}"
+                    );
                     Ok((settings, device_count))
                 }
                 other => panic!("Expected Init response, got {other:?}"),
@@ -521,7 +520,9 @@ impl RemoteService {
         match self.executor.block_on(rx) {
             Ok(TaskResponseContent::DTypeUsage(set)) => set,
             Ok(other) => panic!("Invalid response for DTypeUsage: {other:?}"),
-            Err(_) => panic!("Remote response channel closed before dtype_usage completed"),
+            Err(err) => {
+                panic!("Remote response channel closed before dtype_usage completed: {err}")
+            }
         }
     }
 

--- a/crates/burn-remote/src/lib.rs
+++ b/crates/burn-remote/src/lib.rs
@@ -35,9 +35,9 @@ pub use transport::{PeerAddr, PeerId};
 
 #[cfg(feature = "client")]
 mod __client {
-    use super::*;
-
     use burn_router::BackendRouter;
+
+    pub use crate::client::{CustomOpClient, RemoteChannel, RemoteDevice};
 
     /// The remote backend allows you to run computation on a remote device.
     ///
@@ -59,14 +59,13 @@ mod __client {
     pub type RemoteBackend = BackendRouter<RemoteChannel>;
 
     /// With the `fusion` feature enabled, the remote backend is wrapped in
-    /// [`Fusion`](burn_fusion::Fusion) — exactly like the CubeCL backends — so recurring groups of
+    /// [`Fusion`](burn_fusion::Fusion) — exactly like the [`CubeCL`](crate::ir) backends — so recurring groups of
     /// operations are cached on the server and invoked by id, sending a repeated computation
     /// (e.g. a model block per step) over the network once instead of every step.
     #[cfg(feature = "fusion")]
     pub type RemoteBackend = burn_fusion::Fusion<BackendRouter<RemoteChannel>>;
-
-    pub use client::{CustomOpClient, RemoteChannel, RemoteDevice};
 }
+
 #[cfg(feature = "client")]
 pub use __client::*;
 

--- a/crates/burn-remote/src/metrics.rs
+++ b/crates/burn-remote/src/metrics.rs
@@ -139,6 +139,7 @@ fn format_unfused_by_kind(entries: &[(OpClass, u64)]) -> String {
 
 /// `part` as a percentage of `whole`. Zero when `whole` is 0 (nothing measured yet), so the first
 /// log line can't divide by zero.
+#[allow(clippy::cast_precision_loss)]
 fn percentage(part: u64, whole: u64) -> f64 {
     if whole == 0 {
         0.0

--- a/crates/burn-remote/src/server/builder.rs
+++ b/crates/burn-remote/src/server/builder.rs
@@ -86,6 +86,7 @@ impl<B: BackendIr> RemoteServerBuilder<B> {
     /// `devices` is indexed by the device index a client selects at session init; `devices[0]` is
     /// the default device. Must be non-empty. Defaults to WebSocket on port `3000` (or Iroh when
     /// WebSocket is not compiled in) with no custom ops.
+    #[must_use]
     pub fn new(devices: Vec<Device<B>>) -> Self {
         Self {
             devices,
@@ -95,6 +96,7 @@ impl<B: BackendIr> RemoteServerBuilder<B> {
     }
 
     /// Select the transport (protocol and its configuration).
+    #[must_use]
     pub fn channel(mut self, channel: Channel) -> Self {
         self.channel = channel;
         self
@@ -102,6 +104,7 @@ impl<B: BackendIr> RemoteServerBuilder<B> {
 
     /// Set the port, keeping the WebSocket transport. Convenience over [`channel`](Self::channel).
     #[cfg(feature = "websocket")]
+    #[must_use]
     pub fn port(mut self, port: u16) -> Self {
         self.channel = Channel::WebSocket { port };
         self
@@ -111,6 +114,7 @@ impl<B: BackendIr> RemoteServerBuilder<B> {
     ///
     /// The `id` must match the one the client puts in its [`CustomOpIr`]. Chainable; registering
     /// the same id twice keeps the last handler.
+    #[must_use]
     pub fn custom_op<F>(mut self, id: &str, handler: F) -> Self
     where
         F: Fn(&mut HandleContainer<B::Handle>, &CustomOpIr, &B::Device) + Send + Sync + 'static,
@@ -120,6 +124,7 @@ impl<B: BackendIr> RemoteServerBuilder<B> {
     }
 
     /// Replace the custom-op handlers with a prebuilt [`CustomOpRegistry`].
+    #[must_use]
     pub fn custom_ops(mut self, custom_ops: CustomOpRegistry<B>) -> Self {
         self.custom_ops = custom_ops;
         self
@@ -155,6 +160,10 @@ impl<B: BackendIr> RemoteServerBuilder<B> {
     }
 
     /// Start the server, blocking the current thread until shutdown.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the Tokio runtime cannot be created.
     #[cfg(not(target_family = "wasm"))]
     pub fn start(self) {
         let runtime = tokio::runtime::Runtime::new().expect("Failed to build the tokio runtime");

--- a/crates/burn-remote/src/server/session.rs
+++ b/crates/burn-remote/src/server/session.rs
@@ -203,6 +203,7 @@ where
 
     /// The total number of devices this server hosts. Sent to the client on the init handshake so
     /// it can enumerate every device behind the address (see [`RemoteDevice::enumerate`]).
+    #[allow(clippy::cast_possible_truncation)]
     fn device_count(&self) -> u32 {
         self.devices.len() as u32
     }

--- a/crates/burn-remote/src/server/spawn.rs
+++ b/crates/burn-remote/src/server/spawn.rs
@@ -41,7 +41,7 @@ pub(crate) async fn os_shutdown_signal() {
     let terminate = std::future::pending::<()>();
 
     tokio::select! {
-        _ = ctrl_c => {},
-        _ = terminate => {},
+        () = ctrl_c => (),
+        () = terminate => (),
     }
 }

--- a/crates/burn-remote/src/server/worker.rs
+++ b/crates/burn-remote/src/server/worker.rs
@@ -189,6 +189,7 @@ where
     /// right pending callback on the client. Async work (data-service transfers,
     /// `read_tensor_async`) runs without a stream context — the relevant stream id is captured into
     /// the future at construction time via `executes`.
+    #[allow(clippy::too_many_lines)]
     async fn process_task(&mut self, task: Task) -> Result<(), String> {
         match task {
             Task::RegisterOperation(stream_id, op) => {
@@ -255,22 +256,19 @@ where
                 );
                 let peer = Some(format!("{:?}", remote.peer));
                 self.emit_transfer(peer.clone(), TransferScope::Remote, TransferPhase::Started);
-                let data = match self
+                let data = if let Some(data) = self
                     .transfer
                     .download_tensor(remote.peer.clone(), remote.capability)
                     .await
                 {
-                    Some(data) => {
-                        self.emit_transfer(peer, TransferScope::Remote, TransferPhase::Completed);
-                        data
-                    }
-                    None => {
-                        self.emit_transfer(peer, TransferScope::Remote, TransferPhase::Failed);
-                        return Err(format!(
-                            "Failed to download tensor for transfer {:?} from {:?}",
-                            remote.capability, remote.peer,
-                        ));
-                    }
+                    self.emit_transfer(peer, TransferScope::Remote, TransferPhase::Completed);
+                    data
+                } else {
+                    self.emit_transfer(peer, TransferScope::Remote, TransferPhase::Failed);
+                    return Err(format!(
+                        "Failed to download tensor for transfer {:?} from {:?}",
+                        remote.capability, remote.peer,
+                    ));
                 };
                 // Register on the client stream that will consume `new_id`, carried over the
                 // wire — not the arbitrary tokio worker running this task.

--- a/crates/burn-remote/src/shared/task.rs
+++ b/crates/burn-remote/src/shared/task.rs
@@ -81,7 +81,7 @@ impl SessionId {
     }
 
     /// The underlying numeric identifier.
-    pub fn value(&self) -> u64 {
+    pub fn value(self) -> u64 {
         self.id
     }
 }

--- a/crates/burn-remote/src/telemetry.rs
+++ b/crates/burn-remote/src/telemetry.rs
@@ -93,6 +93,7 @@ impl OpClass {
     ];
 
     /// Stable lowercase label for display and aggregation.
+    #[must_use]
     pub fn label(self) -> &'static str {
         match self {
             OpClass::Matmul => "matmul",
@@ -116,6 +117,7 @@ impl OpClass {
 }
 
 /// Classify an [`OperationIr`] into a coarse [`OpClass`].
+#[must_use]
 pub fn classify(op: &OperationIr) -> OpClass {
     use OperationIr as O;
     match op {
@@ -286,24 +288,23 @@ pub enum TelemetryEvent {
 
 impl TelemetryEvent {
     pub(crate) fn unfused_op(session: SessionId, stream: StreamId, op: &OperationIr) -> Self {
-        match op {
-            OperationIr::Drop(tensor) => TelemetryEvent::TensorDropped {
+        if let OperationIr::Drop(tensor) = op {
+            TelemetryEvent::TensorDropped {
                 session,
                 tensor: tensor.id,
-            },
-            _ => {
-                let GraphOp {
-                    kind,
-                    inputs,
-                    outputs,
-                } = GraphOp::summarize(op);
-                TelemetryEvent::Op {
-                    session,
-                    stream,
-                    kind,
-                    inputs,
-                    outputs,
-                }
+            }
+        } else {
+            let GraphOp {
+                kind,
+                inputs,
+                outputs,
+            } = GraphOp::summarize(op);
+            TelemetryEvent::Op {
+                session,
+                stream,
+                kind,
+                inputs,
+                outputs,
             }
         }
     }
@@ -347,12 +348,14 @@ pub struct TelemetryProbe {
 
 impl TelemetryProbe {
     /// A probe that drops everything. Worker emit points compile to a cheap no-op against it.
+    #[must_use]
     pub fn disabled() -> Self {
         Self { tx: None }
     }
 
     /// Create an active probe with no initial subscription. Subscribers attach later with
     /// [`subscribe`](Self::subscribe); the probe stays inert until at least one is listening.
+    #[must_use]
     pub fn new(capacity: usize) -> Self {
         let (tx, _rx) = broadcast::channel(capacity);
         Self { tx: Some(tx) }
@@ -360,12 +363,14 @@ impl TelemetryProbe {
 
     /// Create an active probe and its first subscription. `capacity` bounds the per-subscriber
     /// backlog; older events are dropped once a subscriber falls that far behind.
+    #[must_use]
     pub fn channel(capacity: usize) -> (Self, TelemetrySubscription) {
         let (tx, rx) = broadcast::channel(capacity);
         (Self { tx: Some(tx) }, TelemetrySubscription { rx })
     }
 
     /// Attach another subscription, or `None` if this probe is disabled.
+    #[must_use]
     pub fn subscribe(&self) -> Option<TelemetrySubscription> {
         self.tx
             .as_ref()
@@ -374,6 +379,7 @@ impl TelemetryProbe {
 
     /// Whether building and emitting an event is worthwhile right now.
     #[inline]
+    #[must_use]
     pub fn is_active(&self) -> bool {
         self.tx.as_ref().is_some_and(|tx| tx.receiver_count() > 0)
     }
@@ -425,7 +431,7 @@ impl TelemetrySubscription {
         loop {
             match self.rx.recv().await {
                 Ok(event) => return Some(event),
-                Err(RecvError::Lagged(_)) => continue,
+                Err(RecvError::Lagged(_)) => {}
                 Err(RecvError::Closed) => return None,
             }
         }
@@ -486,6 +492,7 @@ impl TrafficAggregator {
         }
     }
 
+    #[must_use]
     pub fn snapshot(&self) -> FusionSnapshot {
         FusionSnapshot {
             fused_ops: self.fused_ops,
@@ -496,6 +503,7 @@ impl TrafficAggregator {
     }
 
     /// Unfused-op tally by class, highest first.
+    #[must_use]
     pub fn unfused_by_kind(&self) -> Vec<(OpClass, u64)> {
         let mut entries: Vec<_> = self
             .unfused_by_kind
@@ -516,17 +524,17 @@ pub struct FusionSnapshot {
 
 impl FusionSnapshot {
     /// Baseline a non-fusion peer would have moved, minus what fusion actually moved.
+    #[must_use]
     pub fn saved(&self) -> u64 {
         self.baseline.saturating_sub(self.actual)
     }
 
+    #[must_use]
     pub fn total_ops(&self) -> u64 {
         self.fused_ops + self.unfused_ops
     }
 }
 
 pub(crate) fn serialized_len<T: Serialize>(value: &T) -> usize {
-    rmp_serde::to_vec(value)
-        .map(|bytes| bytes.len())
-        .unwrap_or(0)
+    rmp_serde::to_vec(value).map_or(0, |bytes| bytes.len())
 }

--- a/crates/burn-remote/src/transport/identity.rs
+++ b/crates/burn-remote/src/transport/identity.rs
@@ -61,6 +61,7 @@ pub enum PeerAddr {
 
 impl PeerAddr {
     /// Return the stable peer identity, excluding dialing hints.
+    #[must_use]
     pub fn id(&self) -> PeerId {
         match self {
             #[cfg(feature = "iroh")]
@@ -71,6 +72,7 @@ impl PeerAddr {
     }
 
     /// Return true when this is an Iroh peer.
+    #[must_use]
     pub fn is_iroh(&self) -> bool {
         match self {
             #[cfg(feature = "iroh")]

--- a/crates/burn-remote/src/transport/iroh/link.rs
+++ b/crates/burn-remote/src/transport/iroh/link.rs
@@ -14,6 +14,7 @@ impl FrameSink for SendStream {
         send_frame(self, &frame).await
     }
 
+    #[allow(clippy::unused_async_trait_impl)]
     async fn close(&mut self) -> Result<(), String> {
         self.finish()
             .map_err(|err| format!("Failed to finish Iroh stream: {err}"))

--- a/crates/burn-remote/src/transport/iroh/node.rs
+++ b/crates/burn-remote/src/transport/iroh/node.rs
@@ -223,10 +223,11 @@ pub(crate) async fn send_frame(send: &mut SendStream, bytes: &[u8]) -> Result<()
 pub(crate) async fn recv_frame(recv: &mut RecvStream) -> Result<Option<Vec<u8>>, String> {
     let mut length = [0u8; 8];
     match recv.read_exact(&mut length).await {
-        Ok(_) => {}
+        Ok(()) => {}
         Err(iroh::endpoint::ReadExactError::FinishedEarly(0)) => return Ok(None),
         Err(err) => return Err(format!("Failed to read Iroh frame length: {err}")),
     }
+    #[allow(clippy::cast_possible_truncation)]
     let length = u64::from_le_bytes(length) as usize;
     if length > MAX_FRAME_SIZE {
         return Err(format!(

--- a/crates/burn-remote/src/transport/iroh/protocol.rs
+++ b/crates/burn-remote/src/transport/iroh/protocol.rs
@@ -35,6 +35,10 @@ pub struct AuthorizationRequest<'a> {
 /// Application authorization policy for incoming compute sessions.
 pub trait PeerAuthorizer: Send + Sync + 'static {
     /// Return `Ok(())` to allow the session, or a user-facing rejection reason.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(String)` when the authorization request is rejected.
     fn authorize(&self, request: AuthorizationRequest<'_>) -> Result<(), String>;
 }
 
@@ -77,6 +81,7 @@ impl<B: BackendIr> fmt::Debug for IrohRemoteProtocol<B> {
 
 impl<B: BackendIr> IrohRemoteProtocol<B> {
     /// Create a handler hosting `devices` on `node`.
+    #[allow(clippy::needless_pass_by_value)]
     pub fn new(
         endpoint: Endpoint,
         devices: Vec<Device<B>>,
@@ -88,7 +93,7 @@ impl<B: BackendIr> IrohRemoteProtocol<B> {
         let transfer = Arc::new(IrohTransfer::new(node.clone()));
 
         let sessions = Arc::new(
-            SessionManager::new(devices.to_vec(), transfer.clone())
+            SessionManager::new(devices.clone(), transfer.clone())
                 .with_telemetry(probe.clone())
                 .with_custom_ops(custom_ops.clone()),
         );

--- a/crates/burn-remote/src/transport/iroh/secret.rs
+++ b/crates/burn-remote/src/transport/iroh/secret.rs
@@ -9,21 +9,25 @@ pub struct RemoteSecret(iroh::SecretKey);
 
 impl RemoteSecret {
     /// A fresh random identity. Persist [`to_bytes`](Self::to_bytes) to reuse the same address later.
+    #[must_use]
     pub fn random() -> Self {
         Self(iroh::SecretKey::generate())
     }
 
     /// A deterministic identity from 32 seed bytes (e.g. a hash of an application name).
+    #[must_use]
     pub fn from_bytes(bytes: [u8; 32]) -> Self {
         Self(iroh::SecretKey::from_bytes(&bytes))
     }
 
     /// The raw 32 bytes, to persist and reload a stable identity.
+    #[must_use]
     pub fn to_bytes(&self) -> [u8; 32] {
         self.0.to_bytes()
     }
 
     /// The public identity clients dial.
+    #[must_use]
     pub fn id(&self) -> iroh::EndpointId {
         self.0.public()
     }

--- a/crates/burn-remote/src/transport/iroh/transfer.rs
+++ b/crates/burn-remote/src/transport/iroh/transfer.rs
@@ -106,7 +106,7 @@ impl<B: BackendIr> IrohTransfer<B> {
             }
         })
         .await
-        .map_err(|_| format!("Timed out waiting for tensor transfer {capability:?}"))?
+        .map_err(|()| format!("Timed out waiting for tensor transfer {capability:?}"))?
     }
 
     async fn expose_response(


### PR DESCRIPTION
This PR applies safe, mechanical `clippy::pedantic` cleanups to the `burn-remote` crate.

Changes include:
- Add `#[must_use]` to pure builder/query methods.
- Fix doc backticks, add `# Panics` / `# Errors` sections.
- Remove redundant closures, explicit iteration loops, and redundant `continue`.
- Use `u32::from` for lossless casts and allow intentional device-index truncations.
- Take `EndpointAddr` by reference in `enumerate_iroh` (it is cloned internally).
- Allow `too_many_lines` on `process_task` to avoid a larger refactor.

Verification:
- `cargo clippy -p burn-remote -- -D warnings` passes
- `cargo fmt --check` passes
- `cargo clippy -p burn-remote -- -W clippy::pedantic` reports no warnings inside `crates/burn-remote` (other crates may still emit warnings)