### PR TITLE
style(burn-no-std-tests): apply clippy::pedantic cleanups

### DIFF
--- a/crates/burn-no-std-tests/src/burnpack.rs
+++ b/crates/burn-no-std-tests/src/burnpack.rs
@@ -17,6 +17,7 @@ pub struct TestModel {
 }
 
 impl TestModel {
+    #[must_use]
     pub fn new(device: &Device) -> Self {
         Self {
             linear1: nn::LinearConfig::new(10, 20).init(device),
@@ -25,6 +26,7 @@ impl TestModel {
         }
     }
 
+    #[must_use]
     pub fn forward(&self, x: Tensor<2>) -> Tensor<2> {
         let x = self.linear1.forward(x);
         let x = self.linear2.forward(x);
@@ -35,7 +37,11 @@ impl TestModel {
     }
 }
 
-/// Test basic Burnpack save and load in no-std
+/// Test basic Burnpack save and load in no-std.
+///
+/// # Panics
+///
+/// Panics if serialization or deserialization fails, or if tensor loading is unsuccessful.
 pub fn test_burnpack_basic(device: &Device) {
     // Create a model
     let model = TestModel::new(device);
@@ -65,7 +71,11 @@ pub fn test_burnpack_basic(device: &Device) {
     let _output = loaded_model.forward(input);
 }
 
-/// Test Burnpack with filtering in no-std
+/// Test Burnpack with filtering in no-std.
+///
+/// # Panics
+///
+/// Panics if saving the filtered model, reading bytes, or loading the partial model fails.
 pub fn test_burnpack_filtering(device: &Device) {
     let model = TestModel::new(device);
 
@@ -92,7 +102,11 @@ pub fn test_burnpack_filtering(device: &Device) {
     assert!(!result.missing.is_empty(), "Should have missing tensors");
 }
 
-/// Test Burnpack with metadata in no-std
+/// Test Burnpack with metadata in no-std.
+///
+/// # Panics
+///
+/// Panics if saving the model with metadata, reading bytes, or loading it back fails.
 pub fn test_burnpack_metadata(device: &Device) {
     let model = TestModel::new(device);
 
@@ -121,7 +135,11 @@ pub fn test_burnpack_metadata(device: &Device) {
 
 // Note: Regex filtering test is omitted as with_regex requires std feature
 
-/// Test Burnpack with match_all in no-std
+/// Test Burnpack with `match_all` in no-std.
+///
+/// # Panics
+///
+/// Panics if saving the model, reading bytes, or loading it back fails.
 pub fn test_burnpack_match_all(device: &Device) {
     let model = TestModel::new(device);
 

--- a/crates/burn-no-std-tests/src/conv.rs
+++ b/crates/burn-no-std-tests/src/conv.rs
@@ -22,6 +22,7 @@ pub struct ConvBlockConfig {
 }
 
 impl ConvBlock {
+    #[must_use]
     pub fn new(config: &ConvBlockConfig, device: &Device) -> Self {
         let conv = nn::conv::Conv2dConfig::new(config.channels, config.kernel_size)
             .with_padding(nn::PaddingConfig2d::Same)
@@ -39,6 +40,7 @@ impl ConvBlock {
         }
     }
 
+    #[must_use]
     pub fn forward(&self, input: Tensor<4>) -> Tensor<4> {
         let x = self.conv.forward(input.clone());
         let x = self.pool.forward(x);

--- a/crates/burn-no-std-tests/src/mlp.rs
+++ b/crates/burn-no-std-tests/src/mlp.rs
@@ -33,6 +33,7 @@ pub struct Mlp {
 
 impl Mlp {
     /// Create the module from the given configuration.
+    #[must_use]
     pub fn new(config: &MlpConfig, device: &Device) -> Self {
         let mut linears = Vec::with_capacity(config.num_layers);
 
@@ -53,10 +54,11 @@ impl Mlp {
     ///
     /// - input: `[batch_size, d_model]`
     /// - output: `[batch_size, d_model]`
+    #[must_use]
     pub fn forward(&self, input: Tensor<2>) -> Tensor<2> {
         let mut x = input;
 
-        for linear in self.linears.iter() {
+        for linear in &self.linears {
             x = linear.forward(x);
             x = self.dropout.forward(x);
             x = self.activation.forward(x);

--- a/crates/burn-no-std-tests/src/model.rs
+++ b/crates/burn-no-std-tests/src/model.rs
@@ -36,6 +36,7 @@ pub struct Model {
 }
 
 impl Model {
+    #[must_use]
     pub fn new(config: &MnistConfig, device: &Device) -> Self {
         let mlp = Mlp::new(&config.mlp, device);
         let input = nn::LinearConfig::new(config.input_size, config.mlp.d_model).init(device);
@@ -51,6 +52,7 @@ impl Model {
         }
     }
 
+    #[must_use]
     pub fn forward(&self, input: Tensor<3>) -> Tensor<2> {
         let [batch_size, height, width] = input.dims();
 

--- a/crates/burn-no-std-tests/src/safetensors.rs
+++ b/crates/burn-no-std-tests/src/safetensors.rs
@@ -8,7 +8,7 @@ use burn::{
 
 use burn_store::{ModuleSnapshot, SafetensorsStore};
 
-/// Simple model for testing SafeTensors storage
+/// Simple model for testing `SafeTensors` storage
 #[derive(Module, Debug)]
 pub struct TestModel {
     linear1: nn::Linear,
@@ -16,6 +16,7 @@ pub struct TestModel {
 }
 
 impl TestModel {
+    #[must_use]
     pub fn new(device: &Device) -> Self {
         Self {
             linear1: nn::LinearConfig::new(10, 20).init(device),
@@ -23,13 +24,18 @@ impl TestModel {
         }
     }
 
+    #[must_use]
     pub fn forward(&self, x: Tensor<2>) -> Tensor<2> {
         let x = self.linear1.forward(x);
         self.linear2.forward(x)
     }
 }
 
-/// Test basic SafeTensors save and load in no-std
+/// Test basic `SafeTensors` save and load in no-std.
+///
+/// # Panics
+///
+/// Panics if serialization or deserialization fails.
 pub fn test_safetensors_basic(device: &Device) {
     // Create a model
     let model = TestModel::new(device);
@@ -55,7 +61,11 @@ pub fn test_safetensors_basic(device: &Device) {
     let _output = loaded_model.forward(input);
 }
 
-/// Test SafeTensors with filtering in no-std
+/// Test `SafeTensors` with filtering in no-std.
+///
+/// # Panics
+///
+/// Panics if saving the filtered model, reading bytes, or loading the partial model fails.
 pub fn test_safetensors_filtering(device: &Device) {
     let model = TestModel::new(device);
 
@@ -81,7 +91,11 @@ pub fn test_safetensors_filtering(device: &Device) {
     assert!(!result.missing.is_empty(), "Should have missing tensors");
 }
 
-/// Test SafeTensors with metadata in no-std
+/// Test `SafeTensors` with metadata in no-std.
+///
+/// # Panics
+///
+/// Panics if saving the model with metadata, reading bytes, or loading it back fails.
 pub fn test_safetensors_metadata(device: &Device) {
     let model = TestModel::new(device);
 
@@ -103,7 +117,7 @@ pub fn test_safetensors_metadata(device: &Device) {
         .expect("Failed to load model with metadata");
 }
 
-/// Run all SafeTensors no-std tests
+/// Run all `SafeTensors` no-std tests
 pub fn run_all_tests(device: &Device) {
     test_safetensors_basic(device);
     test_safetensors_filtering(device);


### PR DESCRIPTION
This PR applies safe, mechanical `clippy::pedantic` cleanups to the `burn-no-std-tests` crate.

Changes include:
- Add `#[must_use]` to pure query methods.
- Fix doc backticks (e.g. `SafeTensors`, `Burnpack`).
- Add `# Panics` sections to test helper functions that call `.expect(...)`.
- Apply minor formatting and semicolon consistency fixes.

Verification:
- `cargo clippy --lib -p burn-no-std-tests -- -W clippy::pedantic` reports no warnings inside `crates/burn-no-std-tests`.
- `cargo fmt --check` passes.
- Note: `cargo clippy -p burn-no-std-tests -- -D warnings` currently fails on upstream `burn-backend` deprecation errors unrelated to this crate.