### PR TITLE
style(burn-dataset): apply clippy::pedantic cleanups

### DIFF
--- a/crates/burn-dataset/src/dataset/base.rs
+++ b/crates/burn-dataset/src/dataset/base.rs
@@ -16,16 +16,24 @@ where
 {
     /// Gets the item at the given index.
     ///
+    /// # Errors
+    ///
+    /// Returns an error if the item cannot be retrieved for an in-bounds index.
+    ///
     /// # Panics
     ///
     /// Panics if `index >= len()`.
     fn get(&self, index: usize) -> Result<I, E>;
 
-    /// Gets the items at given indexes
+    /// Gets the items at given indexes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any in-bounds item cannot be retrieved.
     ///
     /// # Panics
     ///
-    /// panics if `indexes[i] >= len()`
+    /// Panics if `indexes[i] >= len()`.
     fn get_many(&self, indexes: Vec<usize>) -> Result<Vec<I>, E> {
         let len = self.len();
         let mut items = Vec::new();

--- a/crates/burn-dataset/src/dataset/in_memory.rs
+++ b/crates/burn-dataset/src/dataset/in_memory.rs
@@ -15,6 +15,7 @@ pub struct InMemDataset<I> {
 
 impl<I> InMemDataset<I> {
     /// Creates a new in memory dataset from the given items.
+    #[must_use]
     pub fn new(items: Vec<I>) -> Self {
         InMemDataset { items }
     }
@@ -54,6 +55,14 @@ where
     /// Create from a json rows file (one json per line).
     ///
     /// [Supported field types](https://docs.rs/serde_json/latest/serde_json/value/enum.Value.html)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be read or a line is not valid JSON.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a line cannot be read from the reader or deserialized.
     pub fn from_json_rows<P: AsRef<Path>>(path: P) -> Result<Self, std::io::Error> {
         let file = File::open(path)?;
         let reader = BufReader::new(file);
@@ -78,6 +87,10 @@ where
     /// See:
     /// - [Reading with Serde](https://docs.rs/csv/latest/csv/tutorial/index.html#reading-with-serde)
     /// - [Delimiters, quotes and variable length records](https://docs.rs/csv/latest/csv/tutorial/index.html#delimiters-quotes-and-variable-length-records)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the CSV file cannot be read or a row cannot be deserialized.
     pub fn from_csv<P: AsRef<Path>>(
         path: P,
         builder: &csv::ReaderBuilder,

--- a/crates/burn-dataset/src/dataset/sqlite.rs
+++ b/crates/burn-dataset/src/dataset/sqlite.rs
@@ -11,6 +11,7 @@ use crate::Dataset;
 use gix_tempfile::{
     AutoRemove, ContainingDirectory, Handle,
     handle::{Writable, persist},
+    signal::handler::Mode,
 };
 use r2d2::{Pool, PooledConnection};
 use r2d2_sqlite::{SqliteConnectionManager, rusqlite::OpenFlags};
@@ -106,6 +107,10 @@ pub struct SqliteDataset<I> {
 
 impl<I> SqliteDataset<I> {
     /// Initializes a `SqliteDataset` from a SQLite database file and a split name.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database cannot be opened or the split metadata is invalid.
     pub fn from_db_file<P: AsRef<Path>>(db_file: P, split: &str) -> Result<Self> {
         // Create a connection pool
         let conn_pool = create_conn_pool(&db_file, false)?;
@@ -135,7 +140,7 @@ impl<I> SqliteDataset<I> {
         })
     }
 
-    /// Returns true if table has two columns: row_id (integer) and item (blob).
+    /// Returns true if table has two columns: `row_id` (integer) and item (blob).
     ///
     /// This is used to determine if the table is row serialized or not.
     fn check_if_row_serialized(
@@ -175,23 +180,25 @@ impl<I> SqliteDataset<I> {
             columns.push(column?);
         }
 
-        if columns.len() != 2 {
-            Ok(false)
-        } else {
+        if columns.len() == 2 {
             // Check if the column names and types match the expected values
             Ok(columns[0].name == "row_id"
                 && columns[0].ty == "integer"
                 && columns[1].name == "item"
                 && columns[1].ty == "blob")
+        } else {
+            Ok(false)
         }
     }
 
     /// Get the database file name.
+    #[must_use]
     pub fn db_file(&self) -> PathBuf {
         self.db_file.clone()
     }
 
     /// Get the split name.
+    #[must_use]
     pub fn split(&self) -> &str {
         self.split.as_str()
     }
@@ -368,6 +375,7 @@ impl SqliteDatasetStorage {
     /// # Arguments
     ///
     /// * `name` - A string slice that holds the name of the dataset.
+    #[must_use]
     pub fn from_name(name: &str) -> Self {
         SqliteDatasetStorage {
             name: Some(name.to_string()),
@@ -404,6 +412,7 @@ impl SqliteDatasetStorage {
     /// # Returns
     ///
     /// * A boolean value indicating whether the file exists or not.
+    #[must_use]
     pub fn exists(&self) -> bool {
         self.db_file().exists()
     }
@@ -413,13 +422,13 @@ impl SqliteDatasetStorage {
     /// # Returns
     ///
     /// * A `PathBuf` instance representing the file path.
+    #[must_use]
     pub fn db_file(&self) -> PathBuf {
-        match &self.db_file {
-            Some(db_file) => db_file.clone(),
-            None => {
-                let name = sanitize(self.name.as_ref().expect("Name is not set"));
-                Self::base_dir(self.base_dir.to_owned()).join(format!("{name}.db"))
-            }
+        if let Some(db_file) = &self.db_file {
+            db_file.clone()
+        } else {
+            let name = sanitize(self.name.as_ref().expect("Name is not set"));
+            Self::base_dir(self.base_dir.clone()).join(format!("{name}.db"))
         }
     }
 
@@ -432,6 +441,7 @@ impl SqliteDatasetStorage {
     /// # Returns
     ///
     /// * A `PathBuf` instance representing the base directory.
+    #[must_use]
     pub fn base_dir(base_dir: Option<PathBuf>) -> PathBuf {
         match base_dir {
             Some(base_dir) => base_dir,
@@ -470,9 +480,7 @@ impl SqliteDatasetStorage {
     where
         I: Clone + Send + Sync + Serialize + DeserializeOwned,
     {
-        if !self.exists() {
-            panic!("The database file does not exist");
-        }
+        assert!(self.exists(), "The database file does not exist");
 
         SqliteDataset::from_db_file(self.db_file(), split)
     }
@@ -562,7 +570,7 @@ where
         // Create the temp database file and wrap it with a gix_tempfile::Handle
         // This will ensure that the temp file is deleted when the writer is dropped
         // or when process exits with SIGINT or SIGTERM (tempfile crate does not do this)
-        gix_tempfile::signal::setup(Default::default());
+        gix_tempfile::signal::setup(Mode::default());
         self.db_file_tmp = Some(gix_tempfile::writable_at(
             &db_file_tmp,
             ContainingDirectory::Exists,
@@ -587,6 +595,15 @@ where
     /// # Returns
     ///
     /// * A `Result` containing the index of the inserted row if successful, an error otherwise.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the writer is completed, the split table cannot be created, or the
+    /// insert fails.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal completion lock is poisoned.
     pub fn write(&self, split: &str, item: &I) -> Result<usize> {
         // Acquire the read lock (wont't block other reads)
         let is_completed = self.is_completed.read().unwrap();
@@ -627,6 +644,14 @@ where
     }
 
     /// Marks the dataset as completed and persists the temporary database file.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the temporary database file cannot be persisted.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal completion lock is poisoned or no temporary file is present.
     pub fn set_completed(&mut self) -> Result<()> {
         let mut is_completed = self.is_completed.write().unwrap();
 
@@ -686,7 +711,7 @@ where
 
 /// Runs a pragma update and ignores the `ExecuteReturnedResults` error.
 ///
-/// Sometimes ExecuteReturnedResults is returned when running a pragma update. This is not an error
+/// Sometimes `ExecuteReturnedResults` is returned when running a pragma update. This is not an error
 /// and can be ignored. This function runs the pragma update and ignores the error if it is
 /// `ExecuteReturnedResults`.
 fn pragma_update_with_error_handling(

--- a/crates/burn-dataset/src/source/huggingface/downloader.rs
+++ b/crates/burn-dataset/src/source/huggingface/downloader.rs
@@ -75,6 +75,7 @@ pub struct HuggingfaceDatasetLoader {
 
 impl HuggingfaceDatasetLoader {
     /// Create a huggingface dataset loader.
+    #[must_use]
     pub fn new(name: &str) -> Self {
         Self {
             name: name.to_string(),
@@ -93,6 +94,7 @@ impl HuggingfaceDatasetLoader {
     /// The subset name must be one of the subsets listed in the dataset page.
     ///
     /// If no subset names are listed, then do not use this method.
+    #[must_use]
     pub fn with_subset(mut self, subset: &str) -> Self {
         self.subset = Some(subset.to_string());
         self
@@ -101,6 +103,7 @@ impl HuggingfaceDatasetLoader {
     /// Specify a base directory to store the dataset.
     ///
     /// If not specified, the dataset will be stored in the system cache directory under `burn-dataset`.
+    #[must_use]
     pub fn with_base_dir(mut self, base_dir: &str) -> Self {
         self.base_dir = Some(base_dir.into());
         self
@@ -109,6 +112,7 @@ impl HuggingfaceDatasetLoader {
     /// Specify a huggingface token to download datasets behind authentication.
     ///
     /// You can get a token from [tokens settings](https://huggingface.co/settings/tokens)
+    #[must_use]
     pub fn with_huggingface_token(mut self, huggingface_token: &str) -> Self {
         self.huggingface_token = Some(huggingface_token.to_string());
         self
@@ -117,6 +121,7 @@ impl HuggingfaceDatasetLoader {
     /// Specify a huggingface cache directory to store the downloaded datasets.
     ///
     /// If not specified, the dataset will be stored in the system cache directory under `huggingface/datasets`.
+    #[must_use]
     pub fn with_huggingface_cache_dir(mut self, huggingface_cache_dir: &str) -> Self {
         self.huggingface_cache_dir = Some(huggingface_cache_dir.to_string());
         self
@@ -125,8 +130,9 @@ impl HuggingfaceDatasetLoader {
     /// Specify a relative path to a subset of a dataset. This is used in some datasets for the
     /// manual steps of dataset download process.
     ///
-    /// Unless you've encountered a ManualDownloadError
+    /// Unless you've encountered a `ManualDownloadError`
     /// when loading your dataset you probably don't have to worry about this setting.
+    #[must_use]
     pub fn with_huggingface_data_dir(mut self, huggingface_data_dir: &str) -> Self {
         self.huggingface_data_dir = Some(huggingface_data_dir.to_string());
         self
@@ -135,6 +141,7 @@ impl HuggingfaceDatasetLoader {
     /// Specify whether or not to trust remote code.
     ///
     /// If not specified, trust remote code is set to true.
+    #[must_use]
     pub fn with_trust_remote_code(mut self, trust_remote_code: bool) -> Self {
         self.trust_remote_code = trust_remote_code;
         self
@@ -145,12 +152,17 @@ impl HuggingfaceDatasetLoader {
     /// `python3`'s environment is used.
     ///
     /// If not specified, the virtualenv is used.
+    #[must_use]
     pub fn with_use_python_venv(mut self, use_python_venv: bool) -> Self {
         self.use_python_venv = use_python_venv;
         self
     }
 
     /// Load the dataset.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the dataset cannot be downloaded, imported, or opened.
     pub fn dataset<I: DeserializeOwned + Clone>(
         self,
         split: &str,
@@ -163,6 +175,14 @@ impl HuggingfaceDatasetLoader {
     /// Get the path to the sqlite database file.
     ///
     /// If the database file does not exist, it will be downloaded and imported.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the import process fails.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the cache directory cannot be created.
     pub fn db_file(self) -> Result<PathBuf, ImporterError> {
         // determine (and create if needed) the base directory
         let base_dir = SqliteDatasetStorage::base_dir(self.base_dir);
@@ -189,7 +209,7 @@ impl HuggingfaceDatasetLoader {
                 self.name,
                 self.subset,
                 db_file.clone(),
-                base_dir,
+                &base_dir,
                 self.huggingface_token,
                 self.huggingface_cache_dir,
                 self.huggingface_data_dir,
@@ -208,7 +228,7 @@ fn import(
     name: String,
     subset: Option<String>,
     base_file: PathBuf,
-    base_dir: PathBuf,
+    base_dir: &Path,
     huggingface_token: Option<String>,
     huggingface_cache_dir: Option<String>,
     huggingface_data_dir: Option<String>,
@@ -216,14 +236,14 @@ fn import(
     use_python_venv: bool,
 ) -> Result<(), ImporterError> {
     let python_path = if use_python_venv {
-        install_python_deps(&base_dir)?
+        install_python_deps(base_dir)?
     } else {
         get_python_name()?.into()
     };
 
     let mut command = Command::new(python_path);
 
-    command.arg(importer_script_path(&base_dir));
+    command.arg(importer_script_path(base_dir));
 
     command.arg("--name");
     command.arg(name);
@@ -290,7 +310,7 @@ fn check_python_version_is_3(python: &str) -> bool {
 /// get python3 name `python` `python3` or `py`
 fn get_python_name() -> Result<&'static str, ImporterError> {
     let python_name_list = ["python3", "python", "py"];
-    for python_name in python_name_list.iter() {
+    for python_name in &python_name_list {
         if check_python_version_is_3(python_name) {
             return Ok(python_name);
         }

--- a/crates/burn-dataset/src/transform/composed.rs
+++ b/crates/burn-dataset/src/transform/composed.rs
@@ -15,7 +15,7 @@ where
 {
     fn get(&self, index: usize) -> Result<I, E> {
         let mut current_index = 0;
-        for dataset in self.datasets.iter() {
+        for dataset in &self.datasets {
             if index < dataset.len() + current_index {
                 return dataset.get(index - current_index);
             }
@@ -28,7 +28,7 @@ where
     }
     fn len(&self) -> usize {
         let mut total = 0;
-        for dataset in self.datasets.iter() {
+        for dataset in &self.datasets {
             total += dataset.len();
         }
         total

--- a/crates/burn-dataset/src/transform/options.rs
+++ b/crates/burn-dataset/src/transform/options.rs
@@ -92,6 +92,7 @@ pub enum SizeConfig {
 
 impl SizeConfig {
     /// Construct a source which will have the same size as the source dataset.
+    #[must_use]
     pub fn source() -> Self {
         Self::Default
     }
@@ -105,6 +106,11 @@ impl SizeConfig {
     /// ## Returns
     ///
     /// The resolved size of the wrapper dataset.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a ratio configuration is negative.
+    #[must_use]
     pub fn resolve(self, source_size: usize) -> usize {
         match self {
             SizeConfig::Default => source_size,

--- a/crates/burn-dataset/src/transform/sampler.rs
+++ b/crates/burn-dataset/src/transform/sampler.rs
@@ -5,7 +5,7 @@ use rand::prelude::SliceRandom;
 use rand::{RngExt, distr::Uniform, rngs::StdRng, seq::IteratorRandom};
 use std::{marker::PhantomData, ops::DerefMut, sync::Mutex};
 
-/// Options to configure a [SamplerDataset].
+/// Options to configure a [`SamplerDataset`].
 #[derive(Debug, PartialEq)]
 pub struct SamplerDatasetOptions {
     /// The sampling mode.
@@ -48,6 +48,7 @@ impl From<usize> for SamplerDatasetOptions {
 
 impl SamplerDatasetOptions {
     /// Set the replacement mode.
+    #[must_use]
     pub fn with_replace_samples(self, replace_samples: bool) -> Self {
         Self {
             replace_samples,
@@ -55,17 +56,20 @@ impl SamplerDatasetOptions {
         }
     }
 
-    /// Set the replacement mode to WithReplacement.
+    /// Set the replacement mode to `WithReplacement`.
+    #[must_use]
     pub fn with_replacement(self) -> Self {
         self.with_replace_samples(true)
     }
 
-    /// Set the replacement mode to WithoutReplacement.
+    /// Set the replacement mode to `WithoutReplacement`.
+    #[must_use]
     pub fn without_replacement(self) -> Self {
         self.with_replace_samples(false)
     }
 
     /// Set the size source.
+    #[must_use]
     pub fn with_size<S>(self, source: S) -> Self
     where
         S: Into<SizeConfig>,
@@ -77,21 +81,25 @@ impl SamplerDatasetOptions {
     }
 
     /// Set the size to the size of the source.
+    #[must_use]
     pub fn with_source_size(self) -> Self {
         self.with_size(SizeConfig::Default)
     }
 
     /// Set the size to a fixed size.
+    #[must_use]
     pub fn with_fixed_size(self, size: usize) -> Self {
         self.with_size(size)
     }
 
     /// Set the size to be a multiple of the ration and the source size.
+    #[must_use]
     pub fn with_size_ratio(self, size_ratio: f64) -> Self {
         self.with_size(size_ratio)
     }
 
     /// Set the `RngSource`.
+    #[must_use]
     pub fn with_rng<R>(self, rng: R) -> Self
     where
         R: Into<RngSource>,
@@ -103,11 +111,13 @@ impl SamplerDatasetOptions {
     }
 
     /// Use the system rng.
+    #[must_use]
     pub fn with_system_rng(self) -> Self {
         self.with_rng(RngSource::Default)
     }
 
     /// Use a rng, built from a seed.
+    #[must_use]
     pub fn with_seed(self, seed: u64) -> Self {
         self.with_rng(seed)
     }
@@ -197,9 +207,10 @@ where
         Self {
             dataset,
             size,
-            state: Mutex::new(match options.replace_samples {
-                true => SamplerState::WithReplacement(rng),
-                false => SamplerState::WithoutReplacement(rng, Vec::with_capacity(size)),
+            state: Mutex::new(if options.replace_samples {
+                SamplerState::WithReplacement(rng)
+            } else {
+                SamplerState::WithoutReplacement(rng, Vec::with_capacity(size))
             }),
             input: PhantomData,
         }
@@ -248,6 +259,10 @@ where
     /// # Returns
     /// - `true`: If the sampler is configured to sample with replacement.
     /// - `false`: If the sampler is configured to sample without replacement.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal sampler state mutex is poisoned.
     pub fn is_with_replacement(&self) -> bool {
         match self.state.lock().unwrap().deref_mut() {
             SamplerState::WithReplacement(_) => true,
@@ -268,7 +283,7 @@ where
                         // No need to `.choose_multiple` here because we're using
                         // the entire source range; and `.choose_multiple` will
                         // not return a random sample anyway.
-                        indices.extend(idx_range.clone())
+                        indices.extend(idx_range.clone());
                     }
 
                     // From `choose_multiple` documentation:

--- a/crates/burn-dataset/src/transform/selection.rs
+++ b/crates/burn-dataset/src/transform/selection.rs
@@ -15,7 +15,8 @@ use std::sync::Arc;
 /// # Returns
 ///
 /// A vector containing indices from 0 to size - 1.
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn iota(size: usize) -> Vec<usize> {
     (0..size).collect()
 }
@@ -29,7 +30,7 @@ pub fn iota(size: usize) -> Vec<usize> {
 /// # Returns
 ///
 /// A vector of shuffled indices.
-#[inline(always)]
+#[inline]
 pub fn shuffled_indices(size: usize, rng: &mut StdRng) -> Vec<usize> {
     let mut indices = iota(size);
     indices.shuffle(rng);
@@ -164,7 +165,7 @@ where
         R: Into<RngSource>,
     {
         let mut rng: StdRng = rng_source.into().into();
-        self.indices.shuffle(&mut rng)
+        self.indices.shuffle(&mut rng);
     }
 
     /// Creates a new dataset that is a slice of the current selection dataset.
@@ -179,6 +180,7 @@ where
     /// * `start` - The start of the range.
     /// * `end` - The end of the range (exclusive).
     // TODO: SliceArg in burn-tensor should be lifted to burn-std; this should use SliceArg.
+    #[must_use]
     pub fn slice(&self, start: usize, end: usize) -> Self {
         Self::from_indices_unchecked(self.wrapped.clone(), self.indices[start..end].to_vec())
     }
@@ -196,6 +198,7 @@ where
     /// # Returns
     ///
     /// A vector of `SelectionDataset` instances, each containing a subset of the indices.
+    #[must_use]
     pub fn split(&self, num: usize) -> Vec<Self> {
         let n = self.indices.len();
 

--- a/crates/burn-dataset/src/transform/shuffle.rs
+++ b/crates/burn-dataset/src/transform/shuffle.rs
@@ -3,10 +3,10 @@ use crate::transform::{RngSource, SelectionDataset};
 
 /// A Shuffled a dataset.
 ///
-/// This is a thin wrapper around a [SelectionDataset] which selects and shuffles
+/// This is a thin wrapper around a [`SelectionDataset`] which selects and shuffles
 /// the full indices of the original dataset.
 ///
-/// Consider using [SelectionDataset] if you are only interested in
+/// Consider using [`SelectionDataset`] if you are only interested in
 /// shuffling mechanisms.
 ///
 /// Consider using [sampler dataset](crate::transform::SamplerDataset) if you

--- a/crates/burn-dataset/src/transform/window.rs
+++ b/crates/burn-dataset/src/transform/window.rs
@@ -6,6 +6,10 @@ use crate::{Dataset, DatasetError};
 pub trait Window<I> {
     /// Creates a window of a collection.
     ///
+    /// # Errors
+    ///
+    /// Returns an error if the underlying dataset cannot be queried.
+    ///
     /// # Returns
     ///
     /// A `Vec<I>` representing the window, or `None` if the window doesn't fit within the
@@ -96,7 +100,7 @@ impl<I> Iterator for WindowsIterator<'_, I> {
             self.current += 1;
             match window {
                 Ok(Some(window)) => return Some(Ok(window)),
-                Ok(None) => continue,
+                Ok(None) => {}
                 Err(err) => return Some(Err(err)),
             }
         }
@@ -134,6 +138,10 @@ where
     ///
     /// - `dataset`: The dataset over which windows will be created.
     /// - `size`: The size of the windows.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `size` is 0.
     pub fn new(dataset: D, size: usize) -> Self
     where
         D:,


### PR DESCRIPTION
This PR applies a series of safe  cleanups to .

Summary of changes:
- Add missing  and  documentation sections for public API methods.
- Remove redundant borrows and unused  statements.
- Replace  with a concrete  call to clarify intent.
- Add  to builder-style setter methods in the sampler transform.
- Avoid over-eager  in favor of .
- Apply formatting fixes.

Behavioral cast warnings were intentionally left untouched to keep the diff safe.