### PR TITLE
style(burn-optim): apply clippy::pedantic cleanups

### DIFF
--- a/crates/burn-optim/src/grad_clipping/base.rs
+++ b/crates/burn-optim/src/grad_clipping/base.rs
@@ -18,6 +18,7 @@ impl GradientClippingConfig {
     /// # Returns
     ///
     /// The gradient clipping.
+    #[must_use]
     pub fn init(&self) -> GradientClipping {
         match self {
             GradientClippingConfig::Value(val) => GradientClipping::Value(*val),
@@ -48,6 +49,7 @@ impl GradientClipping {
     /// # Returns
     ///
     /// The clipped gradient.
+    #[must_use]
     pub fn clip_gradient<const D: usize>(&self, grad: Tensor<D>) -> Tensor<D> {
         match self {
             GradientClipping::Value(threshold) => self.clip_by_value(grad, *threshold),

--- a/crates/burn-optim/src/lib.rs
+++ b/crates/burn-optim/src/lib.rs
@@ -23,6 +23,6 @@ pub mod lr_scheduler;
 
 /// Type alias for the learning rate.
 ///
-/// LearningRate also implements [learning rate scheduler](crate::lr_scheduler::LrScheduler) so it
+/// `LearningRate` also implements [learning rate scheduler](crate::lr_scheduler::LrScheduler) so it
 /// can be used for constant learning rate.
 pub type LearningRate = f64; // We could potentially change the type.

--- a/crates/burn-optim/src/lr_scheduler/base.rs
+++ b/crates/burn-optim/src/lr_scheduler/base.rs
@@ -80,11 +80,13 @@ impl DynLrScheduler {
     }
 
     /// Get the current state of the scheduler as a [record](LrSchedulerRecord).
+    #[must_use]
     pub fn to_record(&self) -> LrSchedulerRecord {
         self.scheduler.to_record()
     }
 
     /// Load the state of the scheduler from a [record](LrSchedulerRecord).
+    #[must_use]
     pub fn load_record(mut self, record: LrSchedulerRecord) -> Self {
         self.scheduler.load_record(record);
         self
@@ -115,22 +117,26 @@ pub struct LrSchedulerRecord {
 
 impl LrSchedulerRecord {
     /// Create an empty record.
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Whether the record holds no scalars.
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.scalars.is_empty()
     }
 
     /// Store a scalar under `key`.
+    #[must_use]
     pub fn with_scalar<V: Into<Scalar>>(mut self, key: &str, value: V) -> Self {
         self.scalars.insert(String::from(key), value.into());
         self
     }
 
     /// Read the scalar stored under `key`, if present and of a compatible type.
+    #[must_use]
     pub fn scalar<V: TryFrom<Scalar>>(&self, key: &str) -> Option<V> {
         self.scalars
             .get(key)
@@ -139,6 +145,7 @@ impl LrSchedulerRecord {
     }
 
     /// Merge a child `record`'s scalars under `prefix` (used to compose schedulers).
+    #[must_use]
     pub fn with_record(mut self, prefix: &str, record: LrSchedulerRecord) -> Self {
         for (key, value) in record.scalars {
             self.scalars.insert(join_path(prefix, &key), value);
@@ -147,6 +154,7 @@ impl LrSchedulerRecord {
     }
 
     /// Extract the child record previously merged under `prefix`.
+    #[must_use]
     pub fn record(&self, prefix: &str) -> LrSchedulerRecord {
         let head = join_path(prefix, "");
         let scalars = self
@@ -179,17 +187,26 @@ impl LrSchedulerRecord {
     /// Reconstruct a scheduler [state](RecordState) from this record.
     ///
     /// Uses the default device; scheduler state is scalar-only so no tensor is ever allocated.
+    #[must_use]
     pub fn into_state<S: RecordState>(&self) -> Option<S> {
         let mut source = StateSource::new(self.scalars.clone());
         S::state_unflatten("", &mut source, &Device::default())
     }
 
     /// Serialize the record to an in-memory burnpack byte buffer.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if serialization to the burnpack format fails.
     pub fn into_bytes(self) -> Result<Bytes, RecordError> {
         Ok(self.into_writer().into_bytes()?)
     }
 
     /// Reconstruct a record from an in-memory burnpack byte buffer.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the byte buffer is not a valid burnpack record.
     pub fn from_bytes(bytes: Bytes) -> Result<Self, RecordError> {
         let reader = Reader::from_bytes(bytes)?;
         Ok(Self {
@@ -198,6 +215,10 @@ impl LrSchedulerRecord {
     }
 
     /// Save the record to a burnpack file on disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be written.
     #[cfg(feature = "std")]
     pub fn save<P: AsRef<std::path::Path>>(self, path: P) -> Result<(), RecordError> {
         self.into_writer().write_to_file(path)?;
@@ -205,6 +226,10 @@ impl LrSchedulerRecord {
     }
 
     /// Load the record from a burnpack file on disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be read or is not a valid burnpack record.
     #[cfg(feature = "std")]
     pub fn load<P: AsRef<std::path::Path>>(path: P) -> Result<Self, RecordError> {
         let reader = Reader::from_file(path)?;

--- a/crates/burn-optim/src/lr_scheduler/composed.rs
+++ b/crates/burn-optim/src/lr_scheduler/composed.rs
@@ -43,7 +43,7 @@ impl ComposedLrSchedulerConfig {
     /// Initialize the learning rate scheduler.
     pub(crate) fn build(&self) -> Result<ComposedLrScheduler, String> {
         let mut schedulers: Vec<DynLrScheduler> = Vec::with_capacity(self.schedulers.len());
-        for config in self.schedulers.iter() {
+        for config in &self.schedulers {
             schedulers.push(config.build()?);
         }
 
@@ -55,46 +55,53 @@ impl ComposedLrSchedulerConfig {
 
     /// Initializes a [module learning rate scheduler](ModuleLrScheduler).
     pub fn init(&self) -> Result<ModuleLrScheduler, String> {
-        self.build().map(|s| s.into())
+        self.build().map(std::convert::Into::into)
     }
 
     /// Appends a [constant learning rate](crate::lr_scheduler::constant::ConstantLr).
+    #[must_use]
     pub fn constant(mut self, lr: LearningRate) -> Self {
         self.schedulers.push(LrSchedulerConfig::Constant(lr));
         self
     }
 
     /// Appends a [linear scheduler](crate::lr_scheduler::linear::LinearLrScheduler).
+    #[must_use]
     pub fn linear(mut self, config: LinearLrSchedulerConfig) -> Self {
         self.schedulers.push(LrSchedulerConfig::Linear(config));
         self
     }
 
     /// Appends a [cosine scheduler](ComposedLrSchedulerConfig).
+    #[must_use]
     pub fn cosine(mut self, config: CosineAnnealingLrSchedulerConfig) -> Self {
         self.schedulers.push(LrSchedulerConfig::Cosine(config));
         self
     }
 
     /// Appends an [exponential scheduler](crate::lr_scheduler::exponential::ExponentialLrScheduler).
+    #[must_use]
     pub fn exponential(mut self, config: ExponentialLrSchedulerConfig) -> Self {
         self.schedulers.push(LrSchedulerConfig::Exponential(config));
         self
     }
 
     /// Appends a [noam scheduler](crate::lr_scheduler::noam::NoamLrScheduler).
+    #[must_use]
     pub fn noam(mut self, config: NoamLrSchedulerConfig) -> Self {
         self.schedulers.push(LrSchedulerConfig::Noam(config));
         self
     }
 
     /// Appends a [step scheduler](crate::lr_scheduler::step::StepLrScheduler).
+    #[must_use]
     pub fn step(mut self, config: StepLrSchedulerConfig) -> Self {
         self.schedulers.push(LrSchedulerConfig::Step(config));
         self
     }
 
     /// Appends a [composed scheduler](ComposedLrScheduler).
+    #[must_use]
     pub fn composed(mut self, config: Self) -> Self {
         self.schedulers.push(LrSchedulerConfig::Composed(config));
         self
@@ -118,7 +125,11 @@ impl LrScheduler for ComposedLrScheduler {
         };
         let num_scheduler = self.schedulers.len() as f64;
 
-        for lr in self.schedulers.iter_mut().map(|s| s.step()) {
+        for lr in self
+            .schedulers
+            .iter_mut()
+            .map(super::base::DynLrScheduler::step)
+        {
             step = match self.reduction {
                 SchedulerReduction::Avg => step + (lr / num_scheduler),
                 SchedulerReduction::Sum => step + lr,

--- a/crates/burn-optim/src/lr_scheduler/cosine.rs
+++ b/crates/burn-optim/src/lr_scheduler/cosine.rs
@@ -14,7 +14,7 @@ use burn::config::Config;
 /// `min_lr` over `num_iters` steps. After `num_iters` steps, the learning rate
 /// continues along the cosine curve without restarting.
 ///
-/// This corresponds to PyTorch's `CosineAnnealingLR` and is based on the
+/// This corresponds to `PyTorch`'s `CosineAnnealingLR` and is based on the
 /// closed-form schedule proposed in [SGDR: Stochastic Gradient Descent with Warm
 /// Restarts](https://arxiv.org/abs/1608.03983).
 #[derive(Config, Debug)]
@@ -63,7 +63,7 @@ impl CosineAnnealingLrSchedulerConfig {
     /// * `min_lr` is out of range [0.0, `initial_lr`]
     /// * `num_iters` is 0
     pub fn init(&self) -> Result<ModuleLrScheduler, String> {
-        self.build().map(|s| s.into())
+        self.build().map(std::convert::Into::into)
     }
 }
 
@@ -75,7 +75,7 @@ impl CosineAnnealingLrSchedulerConfig {
 /// restarts. The iteration counter increases monotonically, so the learning
 /// rate continues along the cosine curve past `num_iters` without resetting.
 ///
-/// See [CosineAnnealingLrSchedulerConfig] for configuration options.
+/// See [`CosineAnnealingLrSchedulerConfig`] for configuration options.
 #[derive(Clone, Copy, Debug)]
 pub struct CosineAnnealingLrScheduler {
     min_lr: LearningRate,

--- a/crates/burn-optim/src/lr_scheduler/exponential.rs
+++ b/crates/burn-optim/src/lr_scheduler/exponential.rs
@@ -46,13 +46,13 @@ impl ExponentialLrSchedulerConfig {
     /// * `initial_lr` is out of range (0.0, 1.0]
     /// * `gamma` is out of range (0.0, 1.0]
     pub fn init(&self) -> Result<ModuleLrScheduler, String> {
-        self.build().map(|s| s.into())
+        self.build().map(std::convert::Into::into)
     }
 }
 
 /// A exponential learning rate scheduler.
 ///
-/// See [ExponentialLrSchedulerConfig] for more information.
+/// See [`ExponentialLrSchedulerConfig`] for more information.
 #[derive(Clone, Copy, Debug)]
 pub struct ExponentialLrScheduler {
     // The previous iteration's learning rate.

--- a/crates/burn-optim/src/lr_scheduler/linear.rs
+++ b/crates/burn-optim/src/lr_scheduler/linear.rs
@@ -52,13 +52,13 @@ impl LinearLrSchedulerConfig {
     /// * `final_lr` is out of range [0.0, 1.0]
     /// * `num_iters` is 0
     pub fn init(&self) -> Result<ModuleLrScheduler, String> {
-        self.build().map(|s| s.into())
+        self.build().map(std::convert::Into::into)
     }
 }
 
 /// A linear learning rate scheduler.
 ///
-/// See [LinearLrSchedulerConfig] for more information.
+/// See [`LinearLrSchedulerConfig`] for more information.
 #[derive(Clone, Copy, Debug)]
 pub struct LinearLrScheduler {
     // The final learning rate after the linear changing process stops.
@@ -71,7 +71,7 @@ pub struct LinearLrScheduler {
 
 impl LrScheduler for LinearLrScheduler {
     fn step(&mut self) -> LearningRate {
-        self.remaining_iters -= (self.remaining_iters != 0) as usize;
+        self.remaining_iters -= usize::from(self.remaining_iters != 0);
         self.final_lr - self.step_size * self.remaining_iters as f64
     }
 

--- a/crates/burn-optim/src/lr_scheduler/module_lr_scheduler.rs
+++ b/crates/burn-optim/src/lr_scheduler/module_lr_scheduler.rs
@@ -33,6 +33,7 @@ impl From<LearningRate> for ModuleLearningRate {
 
 impl ModuleLearningRate {
     /// Get the effective learning rate for the given parameter.
+    #[must_use]
     pub fn lr_from_param(&self, id: ParamId, path: Option<&str>) -> LearningRate {
         self.groups
             .iter()
@@ -42,6 +43,7 @@ impl ModuleLearningRate {
     }
 
     /// Get the base learning rate value which's group matches all parameters.
+    #[must_use]
     pub fn base(&self) -> LearningRate {
         self.groups
             .first()
@@ -62,7 +64,7 @@ struct LrSchedulerGroup {
     scheduler: DynLrScheduler,
 }
 
-/// Configuration for a [ModuleLrScheduler].
+/// Configuration for a [`ModuleLrScheduler`].
 #[derive(Config, Debug)]
 pub struct ModuleLrSchedulerConfig {
     base: LrSchedulerConfig,
@@ -90,7 +92,7 @@ impl ModuleLrSchedulerConfig {
             scheduler: base,
         });
 
-        for group in self.scheduler_groups.iter() {
+        for group in &self.scheduler_groups {
             let scheduler = group.scheduler.build()?;
             groups.push(LrSchedulerGroup::new(group.group.clone(), scheduler));
         }
@@ -113,7 +115,7 @@ impl ModuleLrSchedulerConfig {
 }
 
 impl ModuleLrScheduler {
-    /// Create a [ModuleLrScheduler].
+    /// Create a [`ModuleLrScheduler`].
     ///
     /// # Arguments
     ///
@@ -146,6 +148,7 @@ impl ModuleLrScheduler {
     }
 
     /// Get the current state of the schedulers as a [record](LrSchedulerRecord).
+    #[must_use]
     pub fn to_record(&self) -> super::LrSchedulerRecord {
         let mut record = LrSchedulerRecord::new();
         for (index, item) in self.groups.iter().enumerate() {
@@ -157,6 +160,7 @@ impl ModuleLrScheduler {
     }
 
     /// Load the state of the schedulers from a [record](LrSchedulerRecord).
+    #[must_use]
     pub fn load_record(mut self, record: super::LrSchedulerRecord) -> Self {
         self.groups = self
             .groups
@@ -177,6 +181,7 @@ impl ModuleLrScheduler {
     }
 
     /// Add a new parameter group to the scheduler's policy.
+    #[must_use]
     pub fn with_group(mut self, group: ParamGroup, scheduler: impl Into<DynLrScheduler>) -> Self {
         self.groups.push(LrSchedulerGroup {
             group,

--- a/crates/burn-optim/src/lr_scheduler/noam.rs
+++ b/crates/burn-optim/src/lr_scheduler/noam.rs
@@ -58,7 +58,7 @@ impl NoamLrSchedulerConfig {
     /// * `warmup_steps` is 0
     /// * `model_size` is 0
     pub fn init(&self) -> Result<ModuleLrScheduler, String> {
-        self.build().map(|s| s.into())
+        self.build().map(std::convert::Into::into)
     }
 }
 

--- a/crates/burn-optim/src/lr_scheduler/step.rs
+++ b/crates/burn-optim/src/lr_scheduler/step.rs
@@ -69,7 +69,7 @@ impl StepLrSchedulerConfig {
     ///
     /// An error will be returned if `step_size` is 0.
     pub fn init(&self) -> Result<ModuleLrScheduler, String> {
-        self.build().map(|s| s.into())
+        self.build().map(std::convert::Into::into)
     }
 }
 

--- a/crates/burn-optim/src/optim/adagrad.rs
+++ b/crates/burn-optim/src/optim/adagrad.rs
@@ -13,7 +13,7 @@ use super::{
 };
 use crate::{LearningRate, grad_clipping::GradientClippingConfig};
 
-/// AdaGrad configuration.
+/// `AdaGrad` configuration.
 #[derive(Config, Debug)]
 pub struct AdaGradConfig {
     #[config(default = 0.)]
@@ -26,14 +26,14 @@ pub struct AdaGradConfig {
     grad_clipping: Option<GradientClippingConfig>,
 }
 
-/// AdaGrad optimizer
+/// `AdaGrad` optimizer
 #[derive(Clone)]
 pub struct AdaGrad {
     lr_decay: LrDecay,
     weight_decay: Option<WeightDecay>,
 }
 
-/// AdaGrad state.
+/// `AdaGrad` state.
 #[derive(RecordState, Clone, new)]
 pub struct AdaGradState<const D: usize> {
     lr_decay: LrDecayState<D>,
@@ -89,11 +89,12 @@ impl AdaGradConfig {
         }
     }
 
-    /// Initialize AdaGrad optimizer.
+    /// Initialize `AdaGrad` optimizer.
     ///
     /// # Returns
     ///
     /// Returns an optimizer that can be used to optimize a module.
+    #[must_use]
     pub fn init(&self) -> ModuleOptimizer {
         let mut optim = ModuleOptimizer::from(self.build());
         if let Some(config) = &self.grad_clipping {
@@ -151,6 +152,7 @@ impl<const D: usize> LrDecayState<D> {
     /// # Returns
     ///
     /// Returns state moved to device.
+    #[must_use]
     pub fn to_device(mut self, device: &Device) -> Self {
         self.sum = self.sum.to_device(device);
         self

--- a/crates/burn-optim/src/optim/adam.rs
+++ b/crates/burn-optim/src/optim/adam.rs
@@ -29,7 +29,7 @@ pub struct AdamConfig {
     /// A value required for numerical stability.
     #[config(default = 1e-5)]
     epsilon: f32,
-    /// Whether to use AMSGrad algorithm
+    /// Whether to use `AMSGrad` algorithm
     #[config(default = false)]
     amsgrad: bool,
     /// [Weight decay](WeightDecayConfig) config.
@@ -114,6 +114,7 @@ impl AdamConfig {
     /// # Returns
     ///
     /// Returns an optimizer that can be used to optimize a module.
+    #[must_use]
     pub fn init(&self) -> ModuleOptimizer {
         let mut optim = ModuleOptimizer::from(self.build());
         if let Some(config) = &self.grad_clipping {
@@ -132,7 +133,7 @@ pub struct AdaptiveMomentumState<const D: usize> {
     pub moment_1: Tensor<D>,
     /// The second order momentum.
     pub moment_2: Tensor<D>,
-    /// Max of second  order momentum (for AMSGrad)
+    /// Max of second  order momentum (for `AMSGrad`)
     #[new(default)]
     pub max_moment_2: Option<Tensor<D>>,
 }
@@ -221,6 +222,7 @@ impl<const D: usize> AdaptiveMomentumState<D> {
     /// # Returns
     ///
     /// Returns state moved to device.
+    #[must_use]
     pub fn to_device(mut self, device: &Device) -> Self {
         self.moment_1 = self.moment_1.to_device(device);
         self.moment_2 = self.moment_2.to_device(device);

--- a/crates/burn-optim/src/optim/adamw.rs
+++ b/crates/burn-optim/src/optim/adamw.rs
@@ -15,10 +15,10 @@ use num_traits::Float as _;
 /// [`AdamW`] Configuration.
 #[derive(Config, Debug)]
 pub struct AdamWConfig {
-    /// Parameter for AdamW.
+    /// Parameter for `AdamW`.
     #[config(default = 0.9)]
     beta_1: f32,
-    /// Parameter for AdamW.
+    /// Parameter for `AdamW`.
     #[config(default = 0.999)]
     beta_2: f32,
     /// A value required for numerical stability.
@@ -34,14 +34,14 @@ pub struct AdamWConfig {
     #[config(default = false)]
     cautious_weight_decay: bool,
 
-    /// Whether to use AMSGrad algorithm
+    /// Whether to use `AMSGrad` algorithm
     #[config(default = false)]
     amsgrad: bool,
     /// [Gradient Clipping](GradientClippingConfig) config.
     grad_clipping: Option<GradientClippingConfig>,
 }
 
-/// AdamW optimizer.
+/// `AdamW` optimizer.
 ///
 /// See:
 /// - [Decoupled Weight Decay Regularization, Loshchilov and Hutter, 2019](https://arxiv.org/abs/1711.05101).
@@ -56,7 +56,7 @@ pub struct AdamW {
     cautious_weight_decay: bool,
 }
 
-/// AdamW state.
+/// `AdamW` state.
 #[derive(RecordState, Clone, new)]
 pub struct AdamWState<const D: usize> {
     /// Th current adaptive momentum state.
@@ -80,7 +80,7 @@ impl Optimizer for AdamW {
     ) -> (Tensor<D>, Option<Self::State<D>>) {
         let (raw_delta, momentum_state) = self.momentum.transform(grad, state.map(|s| s.momentum));
 
-        let decay_rate = lr * (self.weight_decay as f64);
+        let decay_rate = lr * f64::from(self.weight_decay);
 
         let decayed_tensor = if decay_rate == 0.0 {
             tensor.clone()
@@ -119,6 +119,7 @@ impl AdamWConfig {
     /// [`ModuleOptimizer::with_group`](crate::ModuleOptimizer::with_group) takes to
     /// optimize one parameter group. [`init`](Self::init) is the whole-module
     /// counterpart, and the only one that applies the configured gradient clipping.
+    #[must_use]
     pub fn build(&self) -> AdamW {
         AdamW {
             momentum: AdaptiveMomentumW {
@@ -132,11 +133,12 @@ impl AdamWConfig {
         }
     }
 
-    /// Initialize AdamW optimizer.
+    /// Initialize `AdamW` optimizer.
     ///
     /// # Returns
     ///
     /// Returns an optimizer that can be used to optimize a module.
+    #[must_use]
     pub fn init(&self) -> ModuleOptimizer {
         let mut optim = ModuleOptimizer::from(self.build());
         if let Some(config) = &self.grad_clipping {

--- a/crates/burn-optim/src/optim/adan.rs
+++ b/crates/burn-optim/src/optim/adan.rs
@@ -72,7 +72,7 @@ impl Optimizer for Adan {
     ) -> (Tensor<D>, Option<Self::State<D>>) {
         let (raw_delta, momentum_state) = self.momentum.transform(grad, state.map(|s| s.momentum));
 
-        let decay_rate = lr * (self.weight_decay as f64);
+        let decay_rate = lr * f64::from(self.weight_decay);
         let delta = raw_delta.mul_scalar(lr);
 
         let tensor_updated = if self.no_prox {
@@ -106,6 +106,7 @@ impl AdanConfig {
     /// [`ModuleOptimizer::with_group`](crate::ModuleOptimizer::with_group) takes to
     /// optimize one parameter group. [`init`](Self::init) is the whole-module
     /// counterpart, and the only one that applies the configured gradient clipping.
+    #[must_use]
     pub fn build(&self) -> Adan {
         Adan {
             momentum: AdaptiveNesterovMomentum {
@@ -124,6 +125,7 @@ impl AdanConfig {
     /// # Returns
     ///
     /// Returns an optimizer that can be used to optimize a module.
+    #[must_use]
     pub fn init(&self) -> ModuleOptimizer {
         let mut optim = ModuleOptimizer::from(self.build());
         if let Some(config) = &self.grad_clipping {

--- a/crates/burn-optim/src/optim/base.rs
+++ b/crates/burn-optim/src/optim/base.rs
@@ -9,7 +9,7 @@ use alloc::vec::Vec;
 #[derive(Default)]
 /// Exposes multiple gradients for each parameter.
 pub struct MultiGradientsParams {
-    /// Each [GradientsParams] has its associated [Device].
+    /// Each [`GradientsParams`] has its associated [Device].
     pub grads: Vec<(GradientsParams, Device)>,
 }
 

--- a/crates/burn-optim/src/optim/decay.rs
+++ b/crates/burn-optim/src/optim/decay.rs
@@ -26,6 +26,7 @@ pub struct WeightDecay {
 
 impl WeightDecay {
     /// Creates a new [weight decay](WeightDecay) from a [config](WeightDecayConfig).
+    #[must_use]
     pub fn new(config: &WeightDecayConfig) -> Self {
         Self {
             penalty: config.penalty,
@@ -42,6 +43,7 @@ impl WeightDecay {
     /// # Returns
     ///
     /// * `grad` - Transformed gradient.
+    #[must_use]
     pub fn transform<const D: usize>(&self, grad: Tensor<D>, tensor: Tensor<D>) -> Tensor<D> {
         tensor.mul_scalar(self.penalty).add(grad)
     }
@@ -57,6 +59,7 @@ impl<const D: usize> WeightDecayState<D> {
     /// # Returns
     ///
     /// * `self` - Moved state.
+    #[must_use]
     pub fn to_device(mut self, device: &Device) -> Self {
         self.grad_last_step = self.grad_last_step.to_device(device);
         self

--- a/crates/burn-optim/src/optim/grad_accum.rs
+++ b/crates/burn-optim/src/optim/grad_accum.rs
@@ -7,7 +7,7 @@ use burn::tensor::Tensor;
 
 use super::GradientsParams;
 
-/// Accumulate gradients into a single [GradientsParams] object.
+/// Accumulate gradients into a single [`GradientsParams`] object.
 pub struct GradientsAccumulator<M> {
     grads: GradientsParams,
     phantom: PhantomData<M>,
@@ -21,6 +21,7 @@ impl<M> Default for GradientsAccumulator<M> {
 
 impl<M> GradientsAccumulator<M> {
     /// Create a new gradients accumulator.
+    #[must_use]
     pub fn new() -> Self {
         Self {
             grads: GradientsParams::new(),

--- a/crates/burn-optim/src/optim/grads.rs
+++ b/crates/burn-optim/src/optim/grads.rs
@@ -17,13 +17,14 @@ pub struct GradientsParams {
 
 impl GradientsParams {
     /// Creates a new [GradientsParams](GradientsParams).
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Extract each tensor gradients for the given [module](AutodiffModule).
     ///
-    /// Note: This consumes the gradients. See ['from_module'] to extract gradients only for
+    /// Note: This consumes the gradients. See ['`from_module`'] to extract gradients only for
     ///  a specific module.
     pub fn from_grads<M: AutodiffModule>(grads: Gradients, module: &M) -> Self {
         let mut grads = grads;
@@ -57,6 +58,7 @@ impl GradientsParams {
     ///
     /// You should use [remove](GradientsParams::remove) if you want to get the gradients
     /// only one time.
+    #[must_use]
     pub fn get<const D: usize>(&self, id: ParamId) -> Option<Tensor<D>> {
         self.container.get(&id)
     }
@@ -73,15 +75,17 @@ impl GradientsParams {
     /// If a tensor is already registered for the given [parameter id](ParamId), it will be replaced.
     pub fn register<const D: usize>(&mut self, id: ParamId, value: Tensor<D>) {
         // TODO: always call value.inner() to make sure?
-        self.container.register(id, value)
+        self.container.register(id, value);
     }
 
     /// The number of gradients tensors registered.
+    #[must_use]
     pub fn len(&self) -> usize {
         self.container.len()
     }
 
     /// If any tensor is contained.
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }

--- a/crates/burn-optim/src/optim/lbfgs.rs
+++ b/crates/burn-optim/src/optim/lbfgs.rs
@@ -51,10 +51,10 @@ fn cubic_interpolate(
         };
         min_pos.max(min_bound).min(max_bound)
     } else {
-        (min_bound + max_bound) / 2.0
+        f64::midpoint(min_bound, max_bound)
     }
 }
-/// Auxiliary Struct For Strong_Wolfe
+/// Auxiliary Struct For `Strong_Wolfe`
 struct LineSearchSample {
     // step size
     t: f64,
@@ -258,14 +258,7 @@ where
 
         let armijo_holds = f_new <= (f + c1 * t * gtd) && f_new < bracket[low_idx].f;
 
-        if !armijo_holds {
-            bracket[high_idx] = LineSearchSample {
-                t,
-                f: f_new,
-                g: g_new,
-                gtd: gtd_new,
-            };
-        } else {
+        if armijo_holds {
             if gtd_new.abs() <= -c2 * gtd {
                 return (f_new, g_new, t, ls_func_evals);
             }
@@ -279,6 +272,13 @@ where
                 };
             }
             bracket[low_idx] = LineSearchSample {
+                t,
+                f: f_new,
+                g: g_new,
+                gtd: gtd_new,
+            };
+        } else {
+            bracket[high_idx] = LineSearchSample {
                 t,
                 f: f_new,
                 g: g_new,
@@ -330,10 +330,10 @@ pub struct LBFGSConfig {
     /// Termination tolerance on function value/parameter changes (default: 1e-9).
     #[config(default = 1e-9)]
     pub tolerance_change: f64,
-    /// Maximal number of function evaluations per optimization step (default: max_iter * 1.25).
+    /// Maximal number of function evaluations per optimization step (default: `max_iter` * 1.25).
     #[config(default = "None")]
     pub max_eval: Option<usize>,
-    /// Either ‘strong_wolfe’ or None (default: None).
+    /// Either ‘`strong_wolfe`’ or None (default: None).
     #[config(default = "LineSearchFn::None")]
     pub line_search_fn: LineSearchFn,
 }
@@ -344,6 +344,7 @@ impl LBFGSConfig {
     /// # Returns
     ///
     /// Returns an optimizer that can be used to optimize a module
+    #[must_use]
     pub fn init(&self) -> LBFGS {
         // by default max_eval = max_iter * 5/4
         let max_eval = self.max_eval.unwrap_or(self.max_iter * 5 / 4);
@@ -476,10 +477,11 @@ impl LBFGSState {
             .as_ref()
             .or(self.d.as_ref())
             .or(self.history_s.first())
-            .map(|t| t.device())
+            .map(burn_core::Tensor::device)
     }
 
     /// Moves all historical tensors to the target device.
+    #[must_use]
     pub fn to_device(self, device: &Device) -> Self {
         Self {
             history_s: self
@@ -534,6 +536,7 @@ impl LBFGS {
     ///
     /// L-BFGS keeps a single global state rather than per-parameter state, so its tensors are
     /// named directly (e.g. `history_s.0`) and carry no parameter id.
+    #[must_use]
     pub fn to_record(&self) -> OptimizerRecord {
         let mut sink = StateSink::default();
         RecordState::state_flatten(&self.state, "", &mut sink);
@@ -558,6 +561,7 @@ impl LBFGS {
     ///
     /// State tensors are materialized on the default device; the state is migrated to the gradient
     /// device on the next [`step`](LBFGS::step), so no device argument is needed.
+    #[must_use]
     pub fn load_record(mut self, record: OptimizerRecord) -> Self {
         let device = Device::default();
         let mut source = StateSource::new(record.scalars);
@@ -805,6 +809,7 @@ impl LBFGS {
         (module, loss)
     }
     /// Moves the optimizer state to the specified device.
+    #[must_use]
     pub fn to_device(self, device: &Device) -> Self {
         Self {
             config: self.config,

--- a/crates/burn-optim/src/optim/module/base.rs
+++ b/crates/burn-optim/src/optim/module/base.rs
@@ -62,6 +62,7 @@ impl DynState {
     /// Recover the concrete state by value, moving it out when this is the only handle and
     /// cloning only when the underlying state is still shared. Panics if `T` does not match the
     /// stored type.
+    #[must_use]
     pub fn downcast<T: Clone + Send + Sync + 'static>(self) -> T {
         let state = self
             .state
@@ -71,6 +72,7 @@ impl DynState {
     }
 
     /// Borrow the concrete state without cloning. Panics if `T` does not match the stored type.
+    #[must_use]
     pub fn downcast_ref<T: 'static>(&self) -> &T {
         self.state
             .downcast_ref::<T>()
@@ -78,6 +80,7 @@ impl DynState {
     }
 
     /// The rank of the parameter this state belongs to.
+    #[must_use]
     pub fn rank(&self) -> usize {
         self.rank
     }
@@ -175,7 +178,7 @@ impl<O: Optimizer> DynOptimizer for O {
                 lr,
                 Tensor::<D>::from_bridge(tensor),
                 Tensor::<D>::from_bridge(grad),
-                state.map(|state| state.downcast::<O::State<D>>()),
+                state.map(DynState::downcast::<O::State<D>>),
             );
 
             (tensor.into_bridge(), state.map(|state| DynState::create(state, D)))
@@ -192,7 +195,7 @@ impl<O: Optimizer> DynOptimizer for O {
     fn state_flatten(&self, prefix: &str, state: &DynState, out: &mut StateSink) {
         dispatch_rank!(state.rank(), D => {
             RecordState::state_flatten(state.downcast_ref::<O::State<D>>(), prefix, out);
-        })
+        });
     }
 
     fn state_unflatten(

--- a/crates/burn-optim/src/optim/module/module_optimizer.rs
+++ b/crates/burn-optim/src/optim/module/module_optimizer.rs
@@ -32,7 +32,7 @@ struct OptimizerGroup {
 
 impl OptimizerGroup {
     pub(crate) fn set_gradient_clipping(&mut self, gradient_clipping: GradientClipping) {
-        self.grad_clipping = Some(gradient_clipping)
+        self.grad_clipping = Some(gradient_clipping);
     }
 }
 
@@ -53,7 +53,7 @@ struct OptimizationContext {
 /// `OptimizerConfig::init()`.
 ///
 /// It is possible to use different optimizers for different parameters. To do so, use the
-/// [ModuleOptimizer::with_group] function to add an optimizer for all parameters matching the
+/// [`ModuleOptimizer::with_group`] function to add an optimizer for all parameters matching the
 /// provided group.
 #[derive(Clone)]
 pub struct ModuleOptimizer {
@@ -80,12 +80,14 @@ where
 impl ModuleOptimizer {
     /// Check if the optimizer has gradient clipping.
     /// If there are multiple optimizers, checks if any group has gradient clipping.
+    #[must_use]
     pub fn has_gradient_clipping(&self) -> bool {
         self.optimizers.iter().any(|g| g.grad_clipping.is_some())
     }
 
     /// Access the gradient clipping.
-    /// If there are multiple optimizers, returns the first optimizer's [GradientClipping].
+    /// If there are multiple optimizers, returns the first optimizer's [`GradientClipping`].
+    #[must_use]
     pub fn grad_clipping(&self) -> Option<&GradientClipping> {
         self.optimizers
             .first()
@@ -104,6 +106,7 @@ impl ModuleOptimizer {
     /// # Returns
     ///
     /// The optimizer.
+    #[must_use]
     pub fn with_grad_clipping(mut self, gradient_clipping: GradientClipping) -> Self {
         self.optimizers
             .first_mut()
@@ -196,12 +199,13 @@ impl ModuleOptimizer {
     }
 
     /// Decompose the optimizer state into a serializable [`OptimizerRecord`].
+    #[must_use]
     pub fn to_record(&self) -> OptimizerRecord {
         let mut tensors = Vec::new();
         let mut scalars = BTreeMap::new();
         let mut paths = BTreeMap::new();
 
-        for (id, param_state) in self.param_context.iter() {
+        for (id, param_state) in &self.param_context {
             let prefix = id.val().to_string();
             let mut sink = StateSink::default();
             param_state
@@ -246,6 +250,7 @@ impl ModuleOptimizer {
     /// each parameter's state is migrated to that parameter's (gradient's) device on the next
     /// [`step`](ModuleOptimizer::step) — see the `to_device` call in the step path. The load device
     /// is therefore irrelevant to correctness.
+    #[must_use]
     pub fn load_record(mut self, record: OptimizerRecord) -> Self {
         let device = Device::default();
         let mut ranks: BTreeMap<u64, usize> = BTreeMap::new();
@@ -254,7 +259,7 @@ impl ModuleOptimizer {
         // Recover each parameter's rank from its persisted `__rank` scalar (authoritative). Keys
         // are `"{param_id}.__rank"`, so strip the dotted suffix to recover the id.
         let suffix = alloc::format!(".{RANK_KEY}");
-        for (name, value) in record.scalars.iter() {
+        for (name, value) in &record.scalars {
             if let Some(id_str) = name.strip_suffix(&suffix)
                 && let (Ok(id), Ok(rank)) = (id_str.parse::<u64>(), usize::try_from(*value))
             {
@@ -262,9 +267,9 @@ impl ModuleOptimizer {
             }
         }
 
-        for (name, path) in record.paths.iter() {
+        for (name, path) in &record.paths {
             if let Ok(id) = name.parse::<u64>() {
-                paths.insert(id, path.to_string());
+                paths.insert(id, path.clone());
             }
         }
 
@@ -287,7 +292,7 @@ impl ModuleOptimizer {
             let prefix = id.to_string();
             let path = paths.get(&id);
             let (optim, grad_clipping) =
-                self.optim_from_param(id.into(), path.map(|path| path.as_str()));
+                self.optim_from_param(id.into(), path.map(std::string::String::as_str));
             // Skip parameters whose state can't be reconstructed (truncated/foreign record); they
             // are re-initialized lazily on the next step rather than aborting the load.
             if let Some(state) = optim.state_unflatten(rank, &prefix, &mut source, &device) {
@@ -330,7 +335,7 @@ impl ModuleOptimizer {
     }
 }
 
-/// Wrapper to unify the `remove` method for [GradientsParams] and [MultiGradientsParams].
+/// Wrapper to unify the `remove` method for [`GradientsParams`] and [`MultiGradientsParams`].
 pub enum GradAdaptor {
     /// Wrapper for [`GradientsParams`].
     Single(GradientsParams),
@@ -428,25 +433,25 @@ impl ModuleMapper for ModuleOptimizerMapper<'_> {
 
             let entry = self.states.remove_entry(&id);
             let key = entry.as_ref().map(|(k, _)| *k);
-            let tensor = if tensor.device() != device {
-                tensor.to_device(&device)
-            } else {
+            let tensor = if tensor.device() == device {
                 tensor
+            } else {
+                tensor.to_device(&device)
             };
 
             let path = self.path.join(".");
-            let (optim, grad_clipping, existing_dyn_state) = match entry.map(|(_, s)| s) {
-                Some(OptimizationContext {
-                    optim,
-                    grad_clipping,
-                    state,
-                    ..
-                }) => (optim, grad_clipping, Some(state)),
-                None => {
-                    let (optim, grad_clipping) =
-                        self.optimizer_from_param(id, Some(path.as_str())).clone();
-                    (optim, grad_clipping, None)
-                }
+            let (optim, grad_clipping, existing_dyn_state) = if let Some(OptimizationContext {
+                optim,
+                grad_clipping,
+                state,
+                ..
+            }) = entry.map(|(_, s)| s)
+            {
+                (optim, grad_clipping, Some(state))
+            } else {
+                let (optim, grad_clipping) =
+                    self.optimizer_from_param(id, Some(path.as_str())).clone();
+                (optim, grad_clipping, None)
             };
 
             debug_assert_eq!(
@@ -494,7 +499,7 @@ impl ModuleMapper for ModuleOptimizerMapper<'_> {
             }
             #[cfg(feature = "std")]
             if is_distributed {
-                tensor = tensor.set_distributed(id)
+                tensor = tensor.set_distributed(id);
             }
 
             tensor

--- a/crates/burn-optim/src/optim/module/record/mod.rs
+++ b/crates/burn-optim/src/optim/module/record/mod.rs
@@ -36,11 +36,13 @@ impl core::fmt::Debug for OptimizerRecord {
 
 impl OptimizerRecord {
     /// The number of tensors in the record.
+    #[must_use]
     pub fn len(&self) -> usize {
         self.tensors.len()
     }
 
     /// Whether the record holds no tensors.
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.tensors.is_empty()
     }

--- a/crates/burn-optim/src/optim/momentum.rs
+++ b/crates/burn-optim/src/optim/momentum.rs
@@ -36,6 +36,7 @@ pub struct Momentum {
 
 impl Momentum {
     /// Creates a new [momentum](Momentum) from a [config](MomentumConfig).
+    #[must_use]
     pub fn new(config: &MomentumConfig) -> Self {
         Self {
             momentum: config.momentum.elem(),
@@ -55,6 +56,7 @@ impl Momentum {
     ///
     /// * `grad` - Transformed gradient.
     /// * `state` - State of the optimizer.
+    #[must_use]
     pub fn transform<const D: usize>(
         &self,
         grad: Tensor<D>,
@@ -68,9 +70,10 @@ impl Momentum {
             grad.clone()
         };
 
-        let grad = match self.nesterov {
-            true => velocity.clone().mul_scalar(self.momentum).add(grad),
-            false => velocity.clone(),
+        let grad = if self.nesterov {
+            velocity.clone().mul_scalar(self.momentum).add(grad)
+        } else {
+            velocity.clone()
         };
 
         (grad, MomentumState::new(velocity))
@@ -87,6 +90,7 @@ impl<const D: usize> MomentumState<D> {
     /// # Returns
     ///
     /// * `self` - Moved state.
+    #[must_use]
     pub fn to_device(mut self, device: &Device) -> Self {
         self.velocity = self.velocity.to_device(device);
         self

--- a/crates/burn-optim/src/optim/muon.rs
+++ b/crates/burn-optim/src/optim/muon.rs
@@ -44,8 +44,8 @@ pub enum AdjustLrFn {
 
     /// Moonshot's method: `lr * 0.2 * sqrt(max(A, B))`
     ///
-    /// This method is designed to match AdamW's RMS, allowing Muon to directly reuse
-    /// learning rates and weight decay values tuned for AdamW without retuning.
+    /// This method is designed to match `AdamW`'s RMS, allowing Muon to directly reuse
+    /// learning rates and weight decay values tuned for `AdamW` without retuning.
     ///
     /// # Example
     ///
@@ -89,7 +89,7 @@ impl AdjustLrFn {
 ///
 /// Muon is an optimizer specifically designed for 2D parameters of neural network
 /// hidden layers (weight matrices). Other parameters such as biases and embeddings
-/// should be optimized using a standard method such as AdamW.
+/// should be optimized using a standard method such as `AdamW`.
 ///
 /// # Learning Rate Adjustment
 ///
@@ -99,8 +99,8 @@ impl AdjustLrFn {
 /// - **Original**: Uses `sqrt(max(1, A/B))` where A and B are the first two dimensions.
 ///   This is Keller Jordan's method and is the default.
 ///
-/// - **MatchRmsAdamW**: Uses `0.2 * sqrt(max(A, B))`. This is Moonshot's method
-///   designed to match AdamW's RMS, allowing direct reuse of AdamW hyperparameters.
+/// - **`MatchRmsAdamW`**: Uses `0.2 * sqrt(max(A, B))`. This is Moonshot's method
+///   designed to match `AdamW`'s RMS, allowing direct reuse of `AdamW` hyperparameters.
 ///
 /// # Example
 ///
@@ -166,6 +166,7 @@ impl MuonConfig {
     /// [`ModuleOptimizer::with_group`](crate::ModuleOptimizer::with_group) takes to
     /// optimize one parameter group. [`init`](Self::init) is the whole-module
     /// counterpart.
+    #[must_use]
     pub fn build(&self) -> Muon {
         let momentum = Momentum::new(&self.momentum);
         let weight_decay_penalty = self.weight_decay.as_ref().map(|wd| wd.penalty);
@@ -211,6 +212,7 @@ impl MuonConfig {
     ///     .with_ns_steps(7)
     ///     .init();
     /// ```
+    #[must_use]
     pub fn init(&self) -> ModuleOptimizer {
         ModuleOptimizer::from(self.build())
     }
@@ -245,7 +247,7 @@ impl NewtonSchulzParams {
 ///
 /// # Important Notes
 ///
-/// 1. **Only for 2D+ parameters**: Muon is designed for weight matrices. Use AdamW
+/// 1. **Only for 2D+ parameters**: Muon is designed for weight matrices. Use `AdamW`
 ///    or SGD for biases, embeddings, and layer norms.
 ///
 /// 2. **Learning rate adjustment**: Muon automatically adjusts the learning rate based
@@ -300,8 +302,8 @@ impl Muon {
     ///
     /// # References
     ///
-    /// - Original: https://github.com/KellerJordan/Muon/blob/master/muon.py
-    /// - PyTorch: https://github.com/pytorch/pytorch/blob/main/torch/optim/muon.py
+    /// - Original: <https://github.com/KellerJordan/Muon/blob/master/muon.py>
+    /// - `PyTorch`: <https://github.com/pytorch/pytorch/blob/main/torch/optim/muon.py>
     fn zeropower_via_newtonschulz<const D: usize>(&self, g: Tensor<D>) -> Tensor<D> {
         let shape = g.shape();
         let dim_m2 = shape[D - 2];
@@ -390,8 +392,7 @@ impl Optimizer for Muon {
     ) -> (Tensor<D>, Option<Self::State<D>>) {
         assert!(
             D == 2,
-            "Newton-Schulz iteration requires 2D tensors, got {}D",
-            D
+            "Newton-Schulz iteration requires 2D tensors, got {D}D"
         );
 
         // Step 1: Apply momentum
@@ -407,7 +408,7 @@ impl Optimizer for Muon {
         // Step 4: Apply weight decay (using ORIGINAL lr, not adjusted)
         // Muon applies weight decay AFTER orthogonalization
         let tensor = if let Some(penalty) = self.weight_decay_penalty {
-            let decay_factor = 1.0 - lr * penalty as f64;
+            let decay_factor = 1.0 - lr * f64::from(penalty);
             tensor.mul_scalar(decay_factor)
         } else {
             tensor

--- a/crates/burn-optim/src/optim/rmsprop.rs
+++ b/crates/burn-optim/src/optim/rmsprop.rs
@@ -18,13 +18,13 @@ pub struct RmsPropConfig {
     /// Smoothing constant.
     #[config(default = 0.99)]
     alpha: f32,
-    /// momentum for RmsProp.
+    /// momentum for `RmsProp`.
     #[config(default = 0.9)]
     momentum: f32,
     /// A value required for numerical stability.
     #[config(default = 1e-5)]
     epsilon: f32,
-    /// if True, compute the centered RmsProp, the gradient is normalized by an estimation of its variance
+    /// if True, compute the centered `RmsProp`, the gradient is normalized by an estimation of its variance
     #[config(default = false)]
     centered: bool,
     /// [Weight decay](WeightDecayConfig) config.
@@ -53,11 +53,12 @@ impl RmsPropConfig {
         }
     }
 
-    /// Initialize RmsProp optimizer.
+    /// Initialize `RmsProp` optimizer.
     ///
     /// # Returns
     ///
     /// Returns an optimizer that can be used to optimize a module.
+    #[must_use]
     pub fn init(&self) -> ModuleOptimizer {
         let mut optim = ModuleOptimizer::from(self.build());
         if let Some(config) = &self.grad_clipping {
@@ -158,20 +159,17 @@ pub struct SquareAvgState<const D: usize> {
 }
 
 impl<const D: usize> SquareAvgState<D> {
-    /// transform [SquareAvgState] to the next step
+    /// transform [`SquareAvgState`] to the next step
     fn transform(alpha: f32, grad: Tensor<D>, state: Option<Self>) -> (Tensor<D>, Self) {
-        match state {
-            Some(state) => {
-                let square_avg = state
-                    .square_avg
-                    .mul_scalar(alpha)
-                    .add(grad.clone().square().mul_scalar(1. - alpha));
-                (grad, Self { square_avg })
-            }
-            _ => {
-                let square_avg = grad.clone().square().mul_scalar(1. - alpha);
-                (grad, Self { square_avg })
-            }
+        if let Some(state) = state {
+            let square_avg = state
+                .square_avg
+                .mul_scalar(alpha)
+                .add(grad.clone().square().mul_scalar(1. - alpha));
+            (grad, Self { square_avg })
+        } else {
+            let square_avg = grad.clone().square().mul_scalar(1. - alpha);
+            (grad, Self { square_avg })
         }
     }
 
@@ -184,6 +182,7 @@ impl<const D: usize> SquareAvgState<D> {
     /// # Returns
     ///
     /// * `self` - Moved state.
+    #[must_use]
     pub fn to_device(mut self, device: &Device) -> Self {
         self.square_avg = self.square_avg.to_device(device);
         self
@@ -200,7 +199,7 @@ pub struct CenteredState<const D: usize> {
 }
 
 impl<const D: usize> CenteredState<D> {
-    /// transform [CenteredState] to the next step
+    /// transform [`CenteredState`] to the next step
     fn transform(
         alpha: f32,
         centered: bool,
@@ -252,6 +251,7 @@ impl<const D: usize> CenteredState<D> {
     /// # Returns
     ///
     /// * `self` - Moved state.
+    #[must_use]
     pub fn to_device(mut self, device: &Device) -> Self {
         self.grad_avg = self.grad_avg.map(|grad_avg| grad_avg.to_device(device));
         self.avg = self.avg.to_device(device);
@@ -268,7 +268,7 @@ pub struct RmsPropMomentum {
 }
 
 impl RmsPropMomentum {
-    /// transform [grad](Tensor) and [RmsPropMomentumState] to the next step
+    /// transform [grad](Tensor) and [`RmsPropMomentumState`] to the next step
     fn transform<const D: usize>(
         &self,
         grad: Tensor<D>,
@@ -309,6 +309,7 @@ impl<const D: usize> RmsPropMomentumState<D> {
     /// # Returns
     ///
     /// * `self` - Moved state.
+    #[must_use]
     pub fn to_device(mut self, device: &Device) -> Self {
         self.buf = self.buf.to_device(device);
         self

--- a/crates/burn-optim/src/optim/sgd.rs
+++ b/crates/burn-optim/src/optim/sgd.rs
@@ -53,6 +53,7 @@ impl SgdConfig {
     }
 
     /// Initializes the SGD optimizer from the configuration.
+    #[must_use]
     pub fn init(&self) -> ModuleOptimizer {
         let mut optim = ModuleOptimizer::from(self.build());
         if let Some(config) = &self.gradient_clipping {

--- a/crates/burn-optim/src/optim/state.rs
+++ b/crates/burn-optim/src/optim/state.rs
@@ -24,6 +24,7 @@ pub use burn_derive::RecordState;
 /// Join a `prefix` and a `leaf` into a dot-separated path (`"prefix.leaf"`).
 ///
 /// An empty prefix yields the leaf unchanged, so a top-level call can pass `""`.
+#[must_use]
 pub fn join_path(prefix: &str, leaf: &str) -> String {
     if prefix.is_empty() {
         return String::from(leaf);
@@ -38,6 +39,7 @@ pub fn join_path(prefix: &str, leaf: &str) -> String {
 /// Join a `prefix` and a numeric `index` into a dot-separated path (`"prefix.3"`).
 ///
 /// Used by the derive to name the elements of a `Vec<Tensor>` field.
+#[must_use]
 pub fn join_index(prefix: &str, index: usize) -> String {
     format!("{prefix}.{index}")
 }
@@ -75,6 +77,7 @@ pub struct StateSource {
 
 impl StateSource {
     /// Create a source from an existing scalar map (e.g. the burnpack scalars).
+    #[must_use]
     pub fn new(scalars: BTreeMap<String, Scalar>) -> Self {
         Self {
             tensors: BTreeMap::new(),
@@ -102,6 +105,7 @@ impl StateSource {
     ///
     /// Used by the derive to tell an absent optional nested state (nothing recorded) apart from a
     /// present one whose leaves all happen to be optional.
+    #[must_use]
     pub fn has_under(&self, prefix: &str) -> bool {
         let pat = join_path(prefix, "");
         self.tensors.keys().any(|k| k.starts_with(&pat))


### PR DESCRIPTION
This PR applies safe mechanical  cleanups to .

Summary of changes:
- Add missing  and  documentation sections.
- Add  to builder-style and accessor methods.
- Use  capture and concise closure/ forms.
- Replace unnecessary borrows, redundant imports, and verbose syntax.
- Apply formatting fixes.

Cast-related precision/truncation warnings were intentionally left untouched because they can affect numeric behavior.