### PR TITLE
style(burn-fusion): apply clippy::pedantic cleanups

### DIFF
--- a/crates/burn-fusion/src/backend.rs
+++ b/crates/burn-fusion/src/backend.rs
@@ -90,7 +90,7 @@ impl<B: FusionBackend> Backend for Fusion<B> {
     }
 
     fn memory_cleanup(device: &Self::Device) {
-        B::memory_cleanup(device)
+        B::memory_cleanup(device);
     }
 
     fn memory_install_pools(
@@ -150,7 +150,7 @@ impl<B: FusionBackend> Backend for Fusion<B> {
     fn flush(device: &Self::Device) {
         let client = GlobalFusionClient::<B::FusionRuntime>::load(device);
         let device = device.clone();
-        client.sync(move || B::flush(&device))
+        client.sync(move || B::flush(&device));
     }
 
     fn graph_prepare(device: &Self::Device) -> Result<(), ExecutionError> {
@@ -218,7 +218,7 @@ pub struct FuserProperties {
 /// the speed and efficiency of the computational graph. It doesn't mean that all registered
 /// operations should be fused, but that another way of executing them is more efficient.
 ///
-/// Also, it is important to return (FuserStatus::Closed) when no more registered operation can
+/// Also, it is important to return (`FuserStatus::Closed`) when no more registered operation can
 /// improve the performance.
 pub trait OperationFuser<O>: Send {
     /// Register a new [tensor operation](OperationIr).

--- a/crates/burn-fusion/src/client.rs
+++ b/crates/burn-fusion/src/client.rs
@@ -419,7 +419,7 @@ where
     {
         // Ensure that all operations are resolved before calling sync_collective.
         self.sync(|| ());
-        B::sync_collective(device)
+        B::sync_collective(device);
     }
 
     /// Ensure that communication between the given devices is initialized.

--- a/crates/burn-fusion/src/lib.rs
+++ b/crates/burn-fusion/src/lib.rs
@@ -29,7 +29,7 @@ mod tensor;
 pub mod inspect;
 
 pub use op::UnfusedOp;
-pub(crate) use server::*;
+pub(crate) use server::{FusionServer, FusionUtilities};
 
 pub use backend::*;
 pub use ops::NoOp;

--- a/crates/burn-fusion/src/op.rs
+++ b/crates/burn-fusion/src/op.rs
@@ -17,18 +17,19 @@ std::thread_local! {
 
 /// An [operation](Operation) that isn't fused.
 ///
-/// This can be executed with [Self::execute].
+/// This can be executed with [`Self::execute`].
 pub struct UnfusedOp<R: FusionRuntime> {
     kind: UnfusedOpKind<R>,
     stream_id: StreamId,
 }
 
 impl<R: FusionRuntime> UnfusedOp<R> {
-    /// Creates a new unfused [operation](Operation) that will execute on the given [StreamId].
+    /// Creates a new unfused [operation](Operation) that will execute on the given [`StreamId`].
     pub fn new<O: Operation<R> + 'static>(op: O, stream_id: StreamId) -> Self {
-        let arena_item = match Arena::accept::<O>() {
-            true => ARENA.with_borrow_mut(|arena| arena.reserve()),
-            false => None,
+        let arena_item = if Arena::accept::<O>() {
+            ARENA.with_borrow_mut(burn_std::arena::Arena::reserve)
+        } else {
+            None
         };
 
         let reserved = match arena_item {
@@ -57,7 +58,7 @@ impl<R: FusionRuntime> UnfusedOp<R> {
         self.stream_id.executes(|| match &self.kind {
             UnfusedOpKind::Arena(o) => o.execute(handles),
             UnfusedOpKind::Alloc(o) => o.execute(handles),
-        })
+        });
     }
 }
 
@@ -88,7 +89,7 @@ fn shim_execute<R: FusionRuntime, O: Operation<R>>(
     ptr_data: *const Data,
     handles: &mut HandleContainer<R::FusionHandle>,
 ) {
-    let operation: &O = unsafe { (ptr_data as *const O).as_ref().unwrap() };
+    let operation: &O = unsafe { ptr_data.cast::<O>().as_ref().unwrap() };
     operation.execute(handles);
 }
 

--- a/crates/burn-fusion/src/ops/bool_tensor.rs
+++ b/crates/burn-fusion/src/ops/bool_tensor.rs
@@ -427,7 +427,10 @@ impl<B: FusionBackend> BoolTensorOps<Self> for Fusion<B> {
         let streams = StreamId::current();
 
         let client = tensors.first().unwrap().client.clone();
-        let tensors = tensors.into_iter().map(|t| t.into_ir()).collect();
+        let tensors = tensors
+            .into_iter()
+            .map(super::super::tensor::FusionTensor::into_ir)
+            .collect();
         let desc = CatOpIr::create(tensors, dim, || client.create_empty_handle());
 
         client

--- a/crates/burn-fusion/src/ops/int_tensor.rs
+++ b/crates/burn-fusion/src/ops/int_tensor.rs
@@ -12,7 +12,15 @@ use burn_backend::{
     ops::IntTensorOps,
     tensor::{BoolTensor, Device, FloatTensor, IndexingUpdateOp, IntTensor},
 };
-use burn_ir::*;
+use burn_ir::{
+    BaseOperationIr, BinaryOpIr, CastOpIr, CatOpIr, ClampOpIr, CreationOpIr, DimOpIr, FlipOpIr,
+    FloatOperationIr, FullOpIr, GatherNdOpIr, GatherOpIr, HandleContainer, InitOperationIr,
+    IntOperationIr, MaskFillOpIr, MaskWhereOpIr, MatmulOpIr, NumericOperationIr, OperationIr,
+    OperationOutput, PermuteOpIr, RandomOpIr, ReduceDimOpIr, ReduceDimWithIndicesOpIr, ReduceOpIr,
+    RepeatDimOpIr, ScalarIr, ScalarOpIr, ScatterNdOpIr, ScatterOpIr, SelectAssignOpIr, SelectOpIr,
+    ShapeOpIr, SliceAssignOpIr, SliceOpIr, SwapDimsOpIr, TensorIr, TopKWithIndicesOpIr, UnaryOpIr,
+    UnfoldOpIr,
+};
 use std::marker::PhantomData;
 
 impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
@@ -645,7 +653,10 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
         let streams = StreamId::current();
 
         let client = tensors.first().unwrap().client.clone();
-        let tensors = tensors.into_iter().map(|t| t.into_ir()).collect();
+        let tensors = tensors
+            .into_iter()
+            .map(super::super::tensor::FusionTensor::into_ir)
+            .collect();
         let desc = CatOpIr::create(tensors, dim, || client.create_empty_handle());
 
         client

--- a/crates/burn-fusion/src/ops/module.rs
+++ b/crates/burn-fusion/src/ops/module.rs
@@ -10,7 +10,19 @@ use burn_backend::{
     },
     tensor::{FloatTensor, IntTensor},
 };
-use burn_ir::*;
+use burn_ir::{
+    AdaptiveAvgPool1dBackwardOpIr, AdaptiveAvgPool1dOpIr, AdaptiveAvgPool2dBackwardOpIr,
+    AdaptiveAvgPool2dOpIr, AdaptiveAvgPool3dBackwardOpIr, AdaptiveAvgPool3dOpIr, AttentionOpIr,
+    AvgPool1dBackwardOpIr, AvgPool1dOpIr, AvgPool2dBackwardOpIr, AvgPool2dOpIr,
+    Conv1dBiasBackwardOpIr, Conv1dOpIr, Conv1dWeightBackwardOpIr, Conv1dXBackwardOpIr,
+    Conv2dBiasBackwardOpIr, Conv2dOpIr, Conv2dWeightBackwardOpIr, Conv2dXBackwardOpIr,
+    Conv3dBiasBackwardOpIr, Conv3dOpIr, Conv3dWeightBackwardOpIr, Conv3dXBackwardOpIr,
+    ConvTranspose1dOpIr, ConvTranspose2dOpIr, ConvTranspose3dOpIr, CtcLossBackwardOpIr,
+    CtcLossOpIr, DeformConv2dBackwardOpIr, DeformConv2dOpIr, HandleContainer, IRfftOpIr,
+    InterpolateBackwardOpIr, InterpolateOpIr, MaxPool1dOpIr, MaxPool1dWithIndicesBackwardOpIr,
+    MaxPool1dWithIndicesOpIr, MaxPool2dOpIr, MaxPool2dWithIndicesBackwardOpIr,
+    MaxPool2dWithIndicesOpIr, ModuleOperationIr, OperationIr, OperationOutput, RfftOpIr,
+};
 use burn_std::IntDType;
 use std::marker::PhantomData;
 
@@ -62,7 +74,7 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
         let desc = Conv1dOpIr::create(
             x.into_ir(),
             weight.into_ir(),
-            bias.map(|bias| bias.into_ir()),
+            bias.map(super::super::tensor::FusionTensor::into_ir),
             options.into(),
             || client.create_empty_handle(),
         );
@@ -218,7 +230,7 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
         let desc = Conv2dOpIr::create(
             x.into_ir(),
             weight.into_ir(),
-            bias.map(|bias| bias.into_ir()),
+            bias.map(super::super::tensor::FusionTensor::into_ir),
             options.into(),
             || client.create_empty_handle(),
         );
@@ -383,8 +395,8 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
             x.into_ir(),
             offset.into_ir(),
             weight.into_ir(),
-            mask.map(|mask| mask.into_ir()),
-            bias.map(|bias| bias.into_ir()),
+            mask.map(super::super::tensor::FusionTensor::into_ir),
+            bias.map(super::super::tensor::FusionTensor::into_ir),
             options.into(),
             || client.create_empty_handle(),
         );
@@ -456,8 +468,8 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
             x.into_ir(),
             offset.into_ir(),
             weight.into_ir(),
-            mask.map(|mask| mask.into_ir()),
-            bias.map(|bias| bias.into_ir()),
+            mask.map(super::super::tensor::FusionTensor::into_ir),
+            bias.map(super::super::tensor::FusionTensor::into_ir),
             output_grad.into_ir(),
             options.into(),
             || client.create_empty_handle(),
@@ -511,7 +523,7 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
         let desc = Conv3dOpIr::create(
             x.into_ir(),
             weight.into_ir(),
-            bias.map(|bias| bias.into_ir()),
+            bias.map(super::super::tensor::FusionTensor::into_ir),
             options.into(),
             || client.create_empty_handle(),
         );
@@ -667,7 +679,7 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
         let desc = ConvTranspose1dOpIr::create(
             x.into_ir(),
             weight.into_ir(),
-            bias.map(|bias| bias.into_ir()),
+            bias.map(super::super::tensor::FusionTensor::into_ir),
             options.into(),
             || client.create_empty_handle(),
         );
@@ -709,7 +721,7 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
         let desc = ConvTranspose2dOpIr::create(
             x.into_ir(),
             weight.into_ir(),
-            bias.map(|bias| bias.into_ir()),
+            bias.map(super::super::tensor::FusionTensor::into_ir),
             options.into(),
             || client.create_empty_handle(),
         );
@@ -751,7 +763,7 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
         let desc = ConvTranspose3dOpIr::create(
             x.into_ir(),
             weight.into_ir(),
-            bias.map(|bias| bias.into_ir()),
+            bias.map(super::super::tensor::FusionTensor::into_ir),
             options.into(),
             || client.create_empty_handle(),
         );
@@ -1577,8 +1589,8 @@ impl<B: FusionBackend> ModuleOps<Fusion<B>> for Fusion<B> {
             query.into_ir(),
             key.into_ir(),
             value.into_ir(),
-            mask.map(|m| m.into_ir()),
-            attn_bias.map(|ab| ab.into_ir()),
+            mask.map(super::super::tensor::FusionTensor::into_ir),
+            attn_bias.map(super::super::tensor::FusionTensor::into_ir),
             options.into(),
             || client.create_empty_handle(),
         );

--- a/crates/burn-fusion/src/ops/qtensor.rs
+++ b/crates/burn-fusion/src/ops/qtensor.rs
@@ -74,7 +74,9 @@ impl<B: FusionBackend> QTensorOps<Self> for Fusion<B> {
         let client = tensor.client.clone();
         let qparams = QuantizationParametersIr {
             scales: qparams.scales.into_ir(),
-            global: qparams.global.map(|global| global.into_ir()),
+            global: qparams
+                .global
+                .map(super::super::tensor::FusionTensor::into_ir),
         };
         let desc = QuantizeOpIr::create(tensor.into_ir(), qparams, *scheme, || {
             client.create_empty_handle()
@@ -426,17 +428,15 @@ impl<B: FusionBackend> QTensorOps<Self> for Fusion<B> {
 
         impl<B: FusionBackend> Operation<B::FusionRuntime> for MatmulOps<B> {
             fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
-                let lhs = match self.lhs_quantized {
-                    true => {
-                        TensorPrimitive::QFloat(handles.get_quantized_tensor::<B>(&self.desc.lhs))
-                    }
-                    false => TensorPrimitive::Float(handles.get_float_tensor::<B>(&self.desc.lhs)),
+                let lhs = if self.lhs_quantized {
+                    TensorPrimitive::QFloat(handles.get_quantized_tensor::<B>(&self.desc.lhs))
+                } else {
+                    TensorPrimitive::Float(handles.get_float_tensor::<B>(&self.desc.lhs))
                 };
-                let rhs = match self.rhs_quantized {
-                    true => {
-                        TensorPrimitive::QFloat(handles.get_quantized_tensor::<B>(&self.desc.rhs))
-                    }
-                    false => TensorPrimitive::Float(handles.get_float_tensor::<B>(&self.desc.rhs)),
+                let rhs = if self.rhs_quantized {
+                    TensorPrimitive::QFloat(handles.get_quantized_tensor::<B>(&self.desc.rhs))
+                } else {
+                    TensorPrimitive::Float(handles.get_float_tensor::<B>(&self.desc.rhs))
                 };
                 let output = B::q_matmul(lhs, rhs);
                 match output {
@@ -483,12 +483,10 @@ impl<B: FusionBackend> QTensorOps<Self> for Fusion<B> {
         };
 
         let lhs = match lhs {
-            TensorPrimitive::Float(lhs) => lhs.into_ir(),
-            TensorPrimitive::QFloat(lhs) => lhs.into_ir(),
+            TensorPrimitive::Float(lhs) | TensorPrimitive::QFloat(lhs) => lhs.into_ir(),
         };
         let rhs = match rhs {
-            TensorPrimitive::Float(rhs) => rhs.into_ir(),
-            TensorPrimitive::QFloat(rhs) => rhs.into_ir(),
+            TensorPrimitive::Float(rhs) | TensorPrimitive::QFloat(rhs) => rhs.into_ir(),
         };
 
         let desc = MatmulOpIr::create_mixed(lhs, rhs, dtype, || client.create_empty_handle());

--- a/crates/burn-fusion/src/ops/tensor.rs
+++ b/crates/burn-fusion/src/ops/tensor.rs
@@ -12,7 +12,15 @@ use burn_backend::{
     ops::{FloatTensorOps, GridSampleOptions},
     tensor::{BoolTensor, Device, FloatTensor, IndexingUpdateOp, IntTensor},
 };
-use burn_ir::*;
+use burn_ir::{
+    BaseOperationIr, BinaryOpIr, CastOpIr, CatOpIr, ClampOpIr, CreationOpIr, CrossOpIr, DimOpIr,
+    FlipOpIr, FloatOperationIr, FullOpIr, GatherNdOpIr, GatherOpIr, GridSample2dOpIr,
+    HandleContainer, InitOperationIr, MaskFillOpIr, MaskWhereOpIr, MatmulOpIr, NumericOperationIr,
+    OperationIr, OperationOutput, PermuteOpIr, RandomOpIr, ReduceDimOpIr, ReduceDimWithIndicesOpIr,
+    ReduceOpIr, RepeatDimOpIr, ScalarIr, ScalarOpIr, ScatterNdOpIr, ScatterOpIr, SelectAssignOpIr,
+    SelectOpIr, ShapeOpIr, SliceAssignOpIr, SliceOpIr, SwapDimsOpIr, TensorIr, TopKWithIndicesOpIr,
+    UnaryOpIr, UnfoldOpIr,
+};
 use std::marker::PhantomData;
 
 impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
@@ -2071,7 +2079,10 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
         let streams = StreamId::current();
 
         let client = tensors.first().unwrap().client.clone();
-        let tensors = tensors.into_iter().map(|t| t.into_ir()).collect();
+        let tensors = tensors
+            .into_iter()
+            .map(super::super::tensor::FusionTensor::into_ir)
+            .collect();
         let desc = CatOpIr::create(tensors, dim, || client.create_empty_handle());
 
         client

--- a/crates/burn-fusion/src/search/block.rs
+++ b/crates/burn-fusion/src/search/block.rs
@@ -19,7 +19,7 @@ pub struct Block<O> {
     produced: HashSet<TensorId>,
     /// Tensor ids consumed by this block but produced elsewhere (external inputs).
     read: HashSet<TensorId>,
-    /// Tensor ids this block reads with [ReadWrite](TensorStatus::ReadWrite) status — i.e. it is
+    /// Tensor ids this block reads with [`ReadWrite`](TensorStatus::ReadWrite) status — i.e. it is
     /// the last use and frees/reuses the buffer in place.
     freed: HashSet<TensorId>,
     /// The original blocks this block subsumes.
@@ -66,7 +66,7 @@ impl<O> Block<O> {
     }
 }
 
-/// A single operation at its stream position, viewed as a [GraphNode].
+/// A single operation at its stream position, viewed as a [`GraphNode`].
 pub struct OperationNode<'a> {
     /// The operation.
     pub operation: &'a OperationIr,
@@ -98,7 +98,7 @@ impl GraphNode for OperationNode<'_> {
 }
 
 /// The dependency edges between blocks are derived from what each block reads, produces, and
-/// frees — see [GraphNode].
+/// frees — see [`GraphNode`].
 impl<O> GraphNode for Block<O> {
     type Resource = TensorId;
 
@@ -289,9 +289,9 @@ impl<O: NumOperations> Block<O> {
     pub fn still_optimizing(&self) -> bool {
         let mut num_stopped = 0;
 
-        for optimization in self.builders.iter() {
+        for optimization in &self.builders {
             if let FuserStatus::Closed = optimization.status() {
-                num_stopped += 1
+                num_stopped += 1;
             }
         }
 
@@ -309,7 +309,7 @@ impl<O: NumOperations> Block<O> {
             self.end_pos = pos + 1;
         }
 
-        for builder in self.builders.iter_mut() {
+        for builder in &mut self.builders {
             builder.fuse(operation);
         }
 
@@ -339,7 +339,7 @@ impl<O: NumOperations> Block<O> {
 impl<O> BlockOptimization<O> {
     /// Maps the ordering of the current block optimization using the given mapping.
     pub fn map_ordering(&mut self, mapping: &[usize]) {
-        for i in self.ordering.iter_mut() {
+        for i in &mut self.ordering {
             *i = mapping[*i];
         }
         self.strategy.map_ordering(mapping);
@@ -402,7 +402,7 @@ impl<O> ExecutionStrategy<O> {
             ExecutionStrategy::Optimization { ordering, .. } => {
                 let mut ordering_mapped = ordering.to_vec();
 
-                for o in ordering_mapped.iter_mut() {
+                for o in &mut ordering_mapped {
                     *o = mapping[*o];
                 }
                 *ordering = Arc::new(ordering_mapped);
@@ -410,7 +410,7 @@ impl<O> ExecutionStrategy<O> {
             ExecutionStrategy::Operations { ordering } => {
                 let mut ordering_mapped = ordering.to_vec();
 
-                for o in ordering_mapped.iter_mut() {
+                for o in &mut ordering_mapped {
                     *o = mapping[*o];
                 }
 
@@ -458,8 +458,8 @@ impl<O> PartialEq for Block<O> {
         // blocks.
         let mut sorted_a = self.ordering.clone();
         let mut sorted_b = other.ordering.clone();
-        sorted_a.sort();
-        sorted_b.sort();
+        sorted_a.sort_unstable();
+        sorted_b.sort_unstable();
 
         sorted_a == sorted_b
     }

--- a/crates/burn-fusion/src/search/graph/dag.rs
+++ b/crates/burn-fusion/src/search/graph/dag.rs
@@ -3,16 +3,16 @@ use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 
 /// A dependency graph over a fixed list of nodes, with edges derived from the nodes' data-flow
-/// sets (see [GraphNode]).
+/// sets (see [`GraphNode`]).
 ///
 /// The graph is not guaranteed to be acyclic — a cycle means the nodes cannot be linearized and
-/// is reported by [topological_order](Self::topological_order) returning `None`.
+/// is reported by [`topological_order`](Self::topological_order) returning `None`.
 pub struct Dag {
     /// `dependencies[i]` = nodes that must execute before node `i` (direct edges only).
     dependencies: Vec<SubGraph>,
     /// `dependents[j]` = nodes that directly depend on node `j` (transpose of `dependencies`).
     dependents: Vec<SubGraph>,
-    /// Tie-break position of each node (see [GraphNode::position]).
+    /// Tie-break position of each node (see [`GraphNode::position`]).
     positions: Vec<usize>,
 }
 
@@ -35,7 +35,7 @@ impl Dag {
         Self {
             dependencies,
             dependents,
-            positions: nodes.iter().map(|n| n.position()).collect(),
+            positions: nodes.iter().map(super::node::GraphNode::position).collect(),
         }
     }
 
@@ -183,7 +183,7 @@ impl Reachability {
 /// Whether `node` must execute after `other`: read-after-write (`node` reads a resource `other`
 /// produces) or write-after-read (`node` frees a resource `other` reads).
 ///
-/// Works directly on the nodes' own data-flow sets through the [GraphNode] membership queries —
+/// Works directly on the nodes' own data-flow sets through the [`GraphNode`] membership queries —
 /// no intermediate collection.
 fn depends_on<N: GraphNode>(node: &N, other: &N) -> bool {
     node.read().any(|r| other.produces(r)) || node.freed().any(|r| other.reads(r))

--- a/crates/burn-fusion/src/search/graph/mod.rs
+++ b/crates/burn-fusion/src/search/graph/mod.rs
@@ -1,6 +1,6 @@
 //! A small, self-contained dependency-graph toolkit used by the fusion search.
 //!
-//! Everything here is generic over the [GraphNode] trait — nothing depends on the tensor IR — so
+//! Everything here is generic over the [`GraphNode`] trait — nothing depends on the tensor IR — so
 //! the algorithms can be unit-tested in isolation and reused at different granularities: fusion
 //! blocks, execution-strategy chunks, or single operations.
 

--- a/crates/burn-fusion/src/search/graph/node.rs
+++ b/crates/burn-fusion/src/search/graph/node.rs
@@ -4,7 +4,7 @@ use core::hash::Hash;
 ///
 /// A node reads and produces resources (tensors, buffers, …) identified by
 /// [Resource](Self::Resource). Dependencies between nodes are never declared explicitly: they are
-/// derived from the resource sets by [Dag::new](super::Dag::new) using two hazard rules.
+/// derived from the resource sets by [`Dag::new`](super::Dag::new) using two hazard rules.
 ///
 /// - **Read-after-write**: a node reading a resource depends on the node producing it.
 /// - **Write-after-read**: a node freeing a resource depends on every other node reading it —

--- a/crates/burn-fusion/src/search/optimization/blocks.rs
+++ b/crates/burn-fusion/src/search/optimization/blocks.rs
@@ -20,7 +20,7 @@ use crate::{
 ///
 /// The contract is that the length of operations executed must include all operations. If we don't
 /// find an optimization that can be executed with that constraint, we return a
-/// [BlocksOptimizerResult::WithHoles].
+/// [`BlocksOptimizerResult::WithHoles`].
 pub struct BlocksOptimizer<O> {
     blocks: Vec<Block<O>>,
     num_ops: usize,
@@ -84,7 +84,7 @@ impl<O: NumOperations> BlocksOptimizer<O> {
 
         for block in blocks {
             let mut block_opt = block.optimize();
-            for pos in block_opt.ordering.iter() {
+            for pos in &block_opt.ordering {
                 resolved[*pos] = true;
             }
             ordering.append(&mut block_opt.ordering);
@@ -94,11 +94,7 @@ impl<O: NumOperations> BlocksOptimizer<O> {
         // An unresolved position is a hole only if some position *after* it
         // is resolved (it's interleaved, not trailing). A trailing run of
         // unresolved positions is a drained tail — left for the processor.
-        let last_resolved_end = resolved
-            .iter()
-            .rposition(|&r| r)
-            .map(|i| i + 1)
-            .unwrap_or(0);
+        let last_resolved_end = resolved.iter().rposition(|&r| r).map_or(0, |i| i + 1);
         let holes: Vec<usize> = (0..last_resolved_end).filter(|i| !resolved[*i]).collect();
 
         let num_strategies = strategies.len();

--- a/crates/burn-fusion/src/search/optimization/stream.rs
+++ b/crates/burn-fusion/src/search/optimization/stream.rs
@@ -42,7 +42,7 @@ impl<O: NumOperations> StreamOptimizer<O> {
 
     /// Register a new [operation](OperationIr) in the optimizer.
     ///
-    /// You can use the function [Self::still_optimizing] to know if the operations are actually
+    /// You can use the function [`Self::still_optimizing`] to know if the operations are actually
     /// being registered.
     pub fn register(&mut self, operation: &OperationIr) {
         if self.stopped {
@@ -125,7 +125,7 @@ impl<O: NumOperations> StreamOptimizer<O> {
 
                     let mut operations_holes = Vec::with_capacity(holes.len());
 
-                    for index in holes.iter() {
+                    for index in &holes {
                         let op = &operations[*index];
                         operations_holes.push(op.clone());
                         search.register(op);
@@ -174,9 +174,9 @@ impl<O: NumOperations> StreamOptimizer<O> {
 
         let mut num_stopped = 0;
 
-        for block in self.blocks.iter() {
+        for block in &self.blocks {
             if !block.still_optimizing() {
-                num_stopped += 1
+                num_stopped += 1;
             }
         }
 
@@ -232,7 +232,7 @@ impl<O: NumOperations> StreamOptimizer<O> {
 
     fn register_inner(&mut self, operation: &OperationIr, force: bool) -> usize {
         let mut added_count = 0;
-        for block in self.blocks.iter_mut() {
+        for block in &mut self.blocks {
             match block.register(operation, self.length, force) {
                 RegistrationResult::Accepted => {
                     added_count += 1;
@@ -283,17 +283,20 @@ impl<O: NumOperations> StreamOptimizer<O> {
             .blocks
             .iter()
             .enumerate()
-            .filter_map(|(i, g)| match block_merges.contains(&i) {
-                true => Some(g),
-                false => None,
+            .filter_map(|(i, g)| {
+                if block_merges.contains(&i) {
+                    Some(g)
+                } else {
+                    None
+                }
             })
             .collect::<Vec<_>>();
 
         let merged = merge_blocks(&blocks_to_merge, false, &guard);
 
         let mut clear_blocks = || {
-            let mut indices = block_merges.to_vec();
-            indices.sort();
+            let mut indices = block_merges.clone();
+            indices.sort_unstable();
 
             for g in indices.into_iter().rev() {
                 self.blocks.remove(g);
@@ -403,7 +406,7 @@ enum MergeBlockStep {
 /// Blocks and re-optimized holes are placed by separate, incremental heuristics that can't see the
 /// whole picture (a hole may depend on another hole spliced later). This final pass treats each
 /// top-level strategy as an atomic [Chunk] node and orders the chunks topologically (see
-/// [GraphNode] for the hazard rules deriving the edges). Ties keep the earliest stream position
+/// [`GraphNode`] for the hazard rules deriving the edges). Ties keep the earliest stream position
 /// first, reproducing the historical order when there are no hazards.
 ///
 /// If the chunk graph has a cycle — the chunking can't be linearized as atomic units — unfused
@@ -444,7 +447,7 @@ fn repair_order<O>(opt: BlockOptimization<O>, operations: &[OperationIr]) -> Blo
     assemble(strategies, &chunks, &order, operations)
 }
 
-/// Retry [repair_order] with every [Operations](ExecutionStrategy::Operations) chunk split into
+/// Retry [`repair_order`] with every [Operations](ExecutionStrategy::Operations) chunk split into
 /// single-operation chunks, keeping fused optimizations atomic. Splitting only removes ordering
 /// constraints, so this resolves any cycle that isn't between fused chunks themselves.
 fn repair_order_split<O>(
@@ -526,7 +529,7 @@ fn unfused_stream_order<O>(mut positions: Vec<usize>) -> BlockOptimization<O> {
 }
 
 /// Whether the execution order respects tensor handle lifetimes: every operation's inputs must be
-/// live when it runs (see [is_valid_execution_order]).
+/// live when it runs (see [`is_valid_execution_order`]).
 fn ordering_is_valid(ordering: &[usize], operations: &[OperationIr]) -> bool {
     is_valid_execution_order(ordering.iter().map(|&position| OperationNode {
         operation: &operations[position],
@@ -543,7 +546,7 @@ fn strategy_len<O>(strategy: &ExecutionStrategy<O>) -> usize {
     }
 }
 
-/// One top-level strategy of a composed optimization, viewed as a single atomic [GraphNode]
+/// One top-level strategy of a composed optimization, viewed as a single atomic [`GraphNode`]
 /// covering the stream positions of its operations.
 struct Chunk {
     positions: Vec<usize>,

--- a/crates/burn-fusion/src/server.rs
+++ b/crates/burn-fusion/src/server.rs
@@ -35,7 +35,7 @@ where
 
     pub fn register(&mut self, stream: StreamId, repr: OperationIr, operation: UnfusedOp<R>) {
         self.streams
-            .register(stream, repr, operation, &mut self.handles)
+            .register(stream, repr, operation, &mut self.handles);
     }
 
     /// Register a `Drop` that originates from a thread other than the tensor's home stream.
@@ -64,11 +64,11 @@ where
 
     pub fn tag_shared_view(&mut self, src_stream: StreamId, src: TensorId, dst: TensorId) {
         self.streams
-            .tag_shared_view(src_stream, src, dst, &mut self.handles)
+            .tag_shared_view(src_stream, src, dst, &mut self.handles);
     }
 
     pub fn drain_stream(&mut self, id: StreamId) {
-        self.streams.drain(&mut self.handles, id)
+        self.streams.drain(&mut self.handles, id);
     }
 
     /// Ready `id`'s stream for reading `tensor` and return the IR the handle

--- a/crates/burn-fusion/src/stream/context.rs
+++ b/crates/burn-fusion/src/stream/context.rs
@@ -1,5 +1,30 @@
 use burn_backend::{Shape, Slice};
-use burn_ir::*;
+use burn_ir::{
+    ActivationOperationIr, AdaptiveAvgPool1dBackwardOpIr, AdaptiveAvgPool1dOpIr,
+    AdaptiveAvgPool2dBackwardOpIr, AdaptiveAvgPool2dOpIr, AdaptiveAvgPool3dBackwardOpIr,
+    AdaptiveAvgPool3dOpIr, AllReduceOpIr, AttentionOpIr, AvgPool1dBackwardOpIr, AvgPool1dOpIr,
+    AvgPool2dBackwardOpIr, AvgPool2dOpIr, BaseOperationIr, BatchNormOpIr, BinaryOpIr,
+    BoolOperationIr, CastOpIr, CatOpIr, ClampOpIr, Conv1dBiasBackwardOpIr, Conv1dOpIr,
+    Conv1dWeightBackwardOpIr, Conv1dXBackwardOpIr, Conv2dBiasBackwardOpIr, Conv2dOpIr,
+    Conv2dWeightBackwardOpIr, Conv2dXBackwardOpIr, Conv3dBiasBackwardOpIr, Conv3dOpIr,
+    Conv3dWeightBackwardOpIr, Conv3dXBackwardOpIr, ConvTranspose1dBiasBackwardOpIr,
+    ConvTranspose1dOpIr, ConvTranspose1dWeightBackwardOpIr, ConvTranspose2dBiasBackwardOpIr,
+    ConvTranspose2dOpIr, ConvTranspose2dWeightBackwardOpIr, ConvTranspose3dBiasBackwardOpIr,
+    ConvTranspose3dOpIr, ConvTranspose3dWeightBackwardOpIr, CreationOpIr, CrossOpIr,
+    CtcLossBackwardOpIr, CtcLossOpIr, CustomOpIr, DeformConv2dBackwardOpIr, DeformConv2dOpIr,
+    DequantizeOpIr, DimOpIr, DistributedOperationIr, EmbeddingBackwardOpIr, EmbeddingOpIr,
+    FlipOpIr, FloatOperationIr, FullOpIr, GatherNdOpIr, GatherOpIr, GridSample2dOpIr,
+    HandleContainer, HardSigmoidOpIr, IRfftOpIr, InitOperationIr, IntOperationIr,
+    InterpolateBackwardOpIr, InterpolateOpIr, LayerNormOpIr, LinearBiasBackwardOpIr, LinearOpIr,
+    LinearWeightBackwardOpIr, LinearXBackwardOpIr, MaskFillOpIr, MaskWhereOpIr, MatmulOpIr,
+    MaxPool1dOpIr, MaxPool1dWithIndicesBackwardOpIr, MaxPool1dWithIndicesOpIr, MaxPool2dOpIr,
+    MaxPool2dWithIndicesBackwardOpIr, MaxPool2dWithIndicesOpIr, ModuleOperationIr,
+    NumericOperationIr, OperationIr, PermuteOpIr, QuantizationParametersIr, QuantizeOpIr,
+    RandomOpIr, ReduceDimOpIr, ReduceDimWithIndicesOpIr, ReduceOpIr, RepeatDimOpIr, RfftOpIr,
+    ScalarIr, ScalarOpIr, ScatterNdOpIr, ScatterOpIr, SelectAssignOpIr, SelectOpIr, ShapeOpIr,
+    SliceAssignOpIr, SliceOpIr, SortOpIr, SortWithIndicesOpIr, SwapDimsOpIr, TensorId, TensorIr,
+    TopKWithIndicesOpIr, UnaryOpIr, Unfold4dOpIr, UnfoldOpIr,
+};
 use hashbrown::HashMap;
 
 /// The context contains the relative graph tensor mapping so that a relative tensor id can be
@@ -29,6 +54,7 @@ impl<H: Clone> Context<H> {
     /// benchmark run a sandbox — mutations stay local until the caller merges new handles
     /// back. `HandleContainer::fork` clones the id→handle map; actual GPU buffers are
     /// refcounted so only the map itself is duplicated.
+    #[must_use]
     pub fn fork(&self) -> Self {
         Self {
             tensors: self.tensors.clone(),

--- a/crates/burn-fusion/src/stream/execution/ordering.rs
+++ b/crates/burn-fusion/src/stream/execution/ordering.rs
@@ -16,6 +16,7 @@ impl<R: FusionRuntime> OrderedExecution<R> {
     ///
     /// This is useful to implement fallback for optimizations.
     #[allow(clippy::borrowed_box)]
+    #[must_use]
     pub fn operation_within_optimization(&self, index: usize) -> UnfusedOp<R> {
         match &self.ordering {
             Some(val) => {
@@ -45,17 +46,16 @@ impl<R: FusionRuntime> OrderedExecution<R> {
         context: &mut Context<R::FusionHandle>,
         ordering: Arc<Vec<usize>>,
     ) {
-        if ordering.len() > self.operations.len() {
-            panic!(
-                "Ordering is bigger than operations: ordering len {}, operations len {}, \
-                 num_executed {}, optimization len {}, ordering {:?}",
-                ordering.len(),
-                self.operations.len(),
-                self.num_executed,
-                optimization.len(),
-                ordering,
-            );
-        }
+        assert!(
+            ordering.len() <= self.operations.len(),
+            "Ordering is bigger than operations: ordering len {}, operations len {}, \
+             num_executed {}, optimization len {}, ordering {:?}",
+            ordering.len(),
+            self.operations.len(),
+            self.num_executed,
+            optimization.len(),
+            ordering,
+        );
         self.ordering = Some(ordering);
         let num_drained = optimization.len();
         optimization.execute(context, self);

--- a/crates/burn-fusion/src/stream/execution/policy.rs
+++ b/crates/burn-fusion/src/stream/execution/policy.rs
@@ -75,11 +75,10 @@ impl<O: core::fmt::Debug> Policy<O> {
         operations: &[OperationIr],
         mode: ExecutionMode,
     ) -> Action {
-        if self.num_operations < operations.len() {
-            panic!(
-                "Internal Error: Can't retrieve the policy action on a list of operations bigger than what is analyzed."
-            );
-        }
+        assert!(
+            self.num_operations >= operations.len(),
+            "Internal Error: Can't retrieve the policy action on a list of operations bigger than what is analyzed."
+        );
 
         if let Some((id, length)) = self.found {
             // A plan covering `length` operations cannot be applied to a shorter
@@ -128,7 +127,7 @@ impl<O: core::fmt::Debug> Policy<O> {
     fn check_candidates(&mut self, store: &ExecutionPlanStore<O>) {
         let mut candidates_to_remove = Vec::new();
 
-        for candidate in self.candidates.iter() {
+        for candidate in &self.candidates {
             match candidate.state {
                 ValidatorState::Found { size } => {
                     let item = store.get_unchecked(candidate.id);
@@ -153,7 +152,7 @@ impl<O: core::fmt::Debug> Policy<O> {
                     candidates_to_remove.push(candidate.id);
                 }
                 ValidatorState::Validating => {}
-            };
+            }
         }
 
         let mut updated_candidates = Vec::new();
@@ -166,8 +165,8 @@ impl<O: core::fmt::Debug> Policy<O> {
     }
 
     fn check_availables(&mut self) {
-        for available in self.availables.iter() {
-            for trigger in available.triggers.iter() {
+        for available in &self.availables {
+            for trigger in &available.triggers {
                 match trigger {
                     TriggerValidator::OnOperations {
                         matching,
@@ -226,12 +225,12 @@ impl<O: core::fmt::Debug> Policy<O> {
             return Action::Defer;
         }
 
-        for available in self.availables.iter() {
+        for available in &self.availables {
             if available.size == operations.len() {
                 return Action::Defer;
             }
 
-            for trigger in available.triggers.iter() {
+            for trigger in &available.triggers {
                 if let TriggerValidator::OnOperations {
                     matching,
                     progress: _,
@@ -247,13 +246,13 @@ impl<O: core::fmt::Debug> Policy<O> {
     }
 
     fn action_sync(&self, operations: &[OperationIr], store: &ExecutionPlanStore<O>) -> Action {
-        for available in self.availables.iter() {
+        for available in &self.availables {
             if available.size == operations.len() {
                 return Action::Execute(available.id);
             }
         }
 
-        for candidate in self.candidates.iter() {
+        for candidate in &self.candidates {
             let item = store.get_unchecked(candidate.id);
 
             if item.operations.len() == operations.len() {

--- a/crates/burn-fusion/src/stream/execution/processor.rs
+++ b/crates/burn-fusion/src/stream/execution/processor.rs
@@ -86,7 +86,7 @@ impl<O: NumOperations> Processor<O> {
                     segment.execute(id, store);
                     self.reset(store, segment.operations());
                 }
-            };
+            }
         }
     }
 
@@ -148,7 +148,7 @@ impl<O: NumOperations> Processor<O> {
         self.policy.reset();
 
         // Reset the policy state with the remaining operations
-        for operation in operations.iter() {
+        for operation in operations {
             self.policy.update(store, operation);
         }
     }
@@ -190,27 +190,23 @@ impl<O: NumOperations> Processor<O> {
                     ExecutionTrigger::OnOperations(next_ops.to_vec())
                 };
 
-                match policy.action(store, relative, ExecutionMode::Sync) {
-                    Action::Execute(id) => {
-                        store.add_trigger(id, trigger);
-                        id
-                    }
-                    _ => {
-                        let plan = ExecutionPlan {
-                            operations: relative.to_vec(),
-                            triggers: vec![trigger],
-                            optimization,
-                        };
-                        store.add(plan)
-                    }
+                if let Action::Execute(id) = policy.action(store, relative, ExecutionMode::Sync) {
+                    store.add_trigger(id, trigger);
+                    id
+                } else {
+                    let plan = ExecutionPlan {
+                        operations: relative.to_vec(),
+                        triggers: vec![trigger],
+                        optimization,
+                    };
+                    store.add(plan)
                 }
             }
-            ExecutionMode::Sync => match policy.action(store, relative, ExecutionMode::Sync) {
-                Action::Execute(id) => {
+            ExecutionMode::Sync => {
+                if let Action::Execute(id) = policy.action(store, relative, ExecutionMode::Sync) {
                     store.add_trigger(id, ExecutionTrigger::OnSync);
                     id
-                }
-                _ => {
+                } else {
                     let plan = ExecutionPlan {
                         operations: relative.to_vec(),
                         triggers: vec![ExecutionTrigger::OnSync],
@@ -218,7 +214,7 @@ impl<O: NumOperations> Processor<O> {
                     };
                     store.add(plan)
                 }
-            },
+            }
         }
     }
 }

--- a/crates/burn-fusion/src/stream/execution/trace.rs
+++ b/crates/burn-fusion/src/stream/execution/trace.rs
@@ -217,7 +217,7 @@ fn debug_head(s: &str) -> &str {
     &s[..end]
 }
 
-/// Produce a "Outer::Inner" kind string for every variant that has an inner enum,
+/// Produce a "`Outer::Inner`" kind string for every variant that has an inner enum,
 /// so the table shows the concrete operation (e.g. `BaseFloat::Reshape`) rather than
 /// just the category.
 pub(crate) fn op_kind(op: &OperationIr) -> String {

--- a/crates/burn-fusion/src/stream/execution/validator.rs
+++ b/crates/burn-fusion/src/stream/execution/validator.rs
@@ -54,15 +54,14 @@ impl<ID> OperationsValidator<ID> {
             ValidatorState::Found { size: _ } => return,
             ValidatorState::Invalidated => return,
             ValidatorState::Validating => {}
-        };
+        }
 
         let item = store.get(self.id);
-        let operation_candidate = match item.get(added_position) {
-            Some(val) => val,
-            None => {
-                self.state = ValidatorState::Invalidated;
-                return;
-            }
+        let operation_candidate = if let Some(val) = item.get(added_position) {
+            val
+        } else {
+            self.state = ValidatorState::Invalidated;
+            return;
         };
 
         if operation_candidate != added {

--- a/crates/burn-fusion/src/stream/multi.rs
+++ b/crates/burn-fusion/src/stream/multi.rs
@@ -225,7 +225,7 @@ impl<R: FusionRuntime> MultiStream<R> {
     ) {
         if !matches!(ir.status, burn_ir::TensorStatus::ReadWrite) {
             return;
-        };
+        }
 
         let stream = match self.streams.get_mut(&id) {
             Some(val) => val,
@@ -362,12 +362,12 @@ impl<R: FusionRuntime> StreamSegment<R::Optimization> for Segment<'_, R> {
     }
 
     fn execute(&mut self, id: ExecutionPlanId, store: &mut ExecutionPlanStore<R::Optimization>) {
-        self.queue.execute(id, self.handles, store, self.id)
+        self.queue.execute(id, self.handles, store, self.id);
     }
 
     fn execute_unfused(&mut self, optimization: BlockOptimization<R::Optimization>) {
         self.queue
-            .execute_unfused(optimization, self.handles, self.id)
+            .execute_unfused(optimization, self.handles, self.id);
     }
 }
 

--- a/crates/burn-fusion/src/stream/queue/execution.rs
+++ b/crates/burn-fusion/src/stream/queue/execution.rs
@@ -102,8 +102,8 @@ impl<R: FusionRuntime> OperationQueue<R> {
             .for_each(|tensor| {
                 if tensor.status == TensorStatus::ReadWrite {
                     self.variables.remove(&tensor.id);
-                };
-                R::free_handle(handles, tensor)
+                }
+                R::free_handle(handles, tensor);
             });
 
         self.global.drain(0..num_drained);
@@ -118,7 +118,7 @@ impl<R: FusionRuntime> OperationQueue<R> {
         self.shapes_assigned.clear();
         self.converter.clear();
 
-        for node in self.global.iter() {
+        for node in &self.global {
             let relative = node.to_relative(&mut self.converter);
             self.relative.push(relative);
             self.shapes_assigned

--- a/crates/burn-fusion/src/stream/store/base.rs
+++ b/crates/burn-fusion/src/stream/store/base.rs
@@ -76,9 +76,10 @@ impl<O: core::fmt::Debug> ExecutionPlanStore<O> {
     }
 
     pub fn add(&mut self, exploration: ExecutionPlan<O>) -> ExecutionPlanId {
-        if exploration.operations.is_empty() {
-            panic!("Can't add an empty optimization.");
-        }
+        assert!(
+            !exploration.operations.is_empty(),
+            "Can't add an empty optimization."
+        );
 
         let id = self.plans.len();
 

--- a/crates/burn-fusion/src/tensor.rs
+++ b/crates/burn-fusion/src/tensor.rs
@@ -267,8 +267,7 @@ impl<R: FusionRuntime> Drop for FusionTensor<R> {
                         .register_foreign_drop(self.stream, ir, DropOp { id: self.id });
                 }
             }
-            TensorStatus::ReadOnly => {}
-            TensorStatus::NotInit => {}
+            TensorStatus::ReadOnly | TensorStatus::NotInit => {}
         }
     }
 }


### PR DESCRIPTION
This PR applies safe mechanical clippy::pedantic cleanups to crates/burn-fusion.

Summary of changes:
- Merge identical match arms in tensor and quantized-tensor operations.
- Remove redundant borrows, unused imports, and verbose syntax.
- Use format! capture and concise iterator patterns.
- Apply formatting fixes.

API-affecting and structural lints (needless_pass_by_value, too_many_lines, items_after_statements, unused_self, missing_fields_in_debug) were intentionally left untouched.