### PR TITLE
style(burn-cubecl-fusion): apply clippy::pedantic cleanups

### DIFF
--- a/crates/burn-cubecl-fusion/src/engine/codegen/io.rs
+++ b/crates/burn-cubecl-fusion/src/engine/codegen/io.rs
@@ -1,7 +1,13 @@
 //! This module declares input-output primitives to read and write values during kernel expansion.
 use crate::engine::codegen::{DynElem, DynSize};
 
-use super::{ir::*, tensor::GlobalTensor};
+use super::{
+    ir::{
+        FuseArg, FuseBlockConfig, FuseType, GlobalArgs, LayoutInfo, LocalArgs, RefLayout,
+        VirtualLayout,
+    },
+    tensor::GlobalTensor,
+};
 use burn_std::quantization::QuantScheme;
 use cubecl::quant::scheme::QuantStore;
 use cubecl::{
@@ -385,7 +391,7 @@ pub fn read_input_aligned<C: Scalar, N: Size>(
                     comptime![shape.clone()],
                 );
                 let index = reshaped_index_to_original_index(&tensor.tensor, index, config.rank);
-                result.insert(i, C::cast_from(tensor.tensor[index].extract(0usize)))
+                result.insert(i, C::cast_from(tensor.tensor[index].extract(0usize)));
             }
         }
         Some(Transform::SwapDims(dim1, dim2)) => {
@@ -401,7 +407,7 @@ pub fn read_input_aligned<C: Scalar, N: Size>(
             #[unroll]
             for i in 0..config.width {
                 let index = offset + i * stride;
-                result.insert(i, C::cast_from(tensor.tensor[index].extract(0usize)))
+                result.insert(i, C::cast_from(tensor.tensor[index].extract(0usize)));
             }
         }
         None => {
@@ -411,7 +417,7 @@ pub fn read_input_aligned<C: Scalar, N: Size>(
             #[unroll]
             for i in 0..config.width {
                 let index = offset + i * stride;
-                result.insert(i, C::cast_from(tensor.tensor[index].extract(0usize)))
+                result.insert(i, C::cast_from(tensor.tensor[index].extract(0usize)));
             }
         }
     }
@@ -419,7 +425,7 @@ pub fn read_input_aligned<C: Scalar, N: Size>(
     result
 }
 
-/// Computes the offset of the given [GlobalTensor] at on the reference position with a linear
+/// Computes the offset of the given [`GlobalTensor`] at on the reference position with a linear
 /// layout.
 #[cube]
 pub fn get_offset_aligned(
@@ -509,14 +515,14 @@ pub fn write<C: Scalar, N: Size>(
         }
         FuseArg::BlockLocal { .. } => write_scalar::<C, N>(locals, value, arg),
         FuseArg::MultiBlockLocal(key, _) | FuseArg::MultiBlockGlobal(key, _) => {
-            outputs.variables.write(key, Vector::cast_from(value))
+            outputs.variables.write(key, Vector::cast_from(value));
         }
         _ => comptime![panic!("Can't write into inputs and scalars")],
     }
 }
 
-/// Writes a [Vector] value element-by-element to an output tensor whose vector_size
-/// differs from the computation width. Mirrors [read_input_aligned] for the write path.
+/// Writes a [Vector] value element-by-element to an output tensor whose `vector_size`
+/// differs from the computation width. Mirrors [`read_input_aligned`] for the write path.
 #[cube]
 fn write_output_aligned<C: Scalar, N: Size>(
     inputs: &GlobalArgs,
@@ -917,5 +923,5 @@ pub(crate) fn set_polyfill_typed<C: CubePrimitive, Dyn: Scalar, DynSize: Size>()
     intrinsic!(|scope| {
         let elem_type = C::__expand_as_type(scope);
         scope.register_value_type::<Dyn, DynSize>(elem_type);
-    })
+    });
 }

--- a/crates/burn-cubecl-fusion/src/engine/codegen/ir.rs
+++ b/crates/burn-cubecl-fusion/src/engine/codegen/ir.rs
@@ -60,7 +60,7 @@ pub enum FuseArg {
 pub struct MultiBlockPos {
     /// The block position in all blocks included in a fused trace.
     pub block_pos: usize,
-    /// The [FuseArg::BlockLocal] position in the block where the variable is first initialized.
+    /// The [`FuseArg::BlockLocal`] position in the block where the variable is first initialized.
     pub block_local_pos: usize,
 }
 
@@ -247,17 +247,13 @@ impl Display for FuseOp {
                 min,
                 max,
                 out,
-            } => write!(f, "{} = clamp({}, min={}, max={})", out, input, min, max),
+            } => write!(f, "{out} = clamp({input}, min={min}, max={max})"),
             FuseOp::ConditionalAssign {
                 cond,
                 lhs,
                 rhs,
                 out,
-            } => write!(
-                f,
-                "{} = select(cond={}, lhs={}, rhs={})",
-                out, cond, lhs, rhs
-            ),
+            } => write!(f, "{out} = select(cond={cond}, lhs={lhs}, rhs={rhs})"),
             FuseOp::Gather {
                 input,
                 indices,
@@ -265,8 +261,7 @@ impl Display for FuseOp {
                 dim,
             } => write!(
                 f,
-                "{} = gather(input={}, indices={}, dim={})",
-                output, input, indices, dim
+                "{output} = gather(input={input}, indices={indices}, dim={dim})"
             ),
             FuseOp::Select {
                 input,
@@ -275,8 +270,7 @@ impl Display for FuseOp {
                 dim,
             } => write!(
                 f,
-                "{} = select(input={}, indices={}, dim={})",
-                output, input, indices, dim
+                "{output} = select(input={input}, indices={indices}, dim={dim})"
             ),
             FuseOp::Cat {
                 inputs,
@@ -297,11 +291,7 @@ impl Display for FuseOp {
                 params,
                 output,
                 scheme: _,
-            } => write!(
-                f,
-                "{} = dequantize(values={}, params={})",
-                output, values, params
-            ),
+            } => write!(f, "{output} = dequantize(values={values}, params={params})"),
         }
     }
 }
@@ -599,7 +589,7 @@ pub struct LocalArgs {
 
 #[cube]
 impl LocalArgs {
-    /// Creates a new [LocalArgs] container.
+    /// Creates a new [`LocalArgs`] container.
     pub fn new(
         ref_shape: &[usize],
         ref_strides: &[usize],
@@ -645,7 +635,7 @@ pub struct BinaryFuseArgs {
 )]
 /// Precisions supported by [element wise operations](ElemwiseOp).
 ///
-/// This is a custom type instead of [ElemType] so it can implement [CubeType]
+/// This is a custom type instead of [`ElemType`] so it can implement [`CubeType`]
 /// and restricts the supported types for fusion.
 pub enum FuseType {
     F64,
@@ -691,7 +681,7 @@ impl AsRefExpand for FuseBlockConfig {
 
 impl FuseBlockConfig {
     pub fn multi_block_variables(&self, registers: &mut Vec<(MultiBlockPos, ElemType)>) {
-        for op in self.ops.iter() {
+        for op in &self.ops {
             op.multi_block_variables(registers);
         }
     }
@@ -704,10 +694,10 @@ impl FuseArg {
                 // TODO: we need to init the multi-block local, but at some point we could avoid
                 // that for performance (easier for the underlying compiler).
             | FuseArg::MultiBlockLocal(arg, fuse_type) => {
-                registers.push((arg.clone(), fuse_type.into_storage_type()))
+                registers.push((arg.clone(), fuse_type.into_storage_type()));
             }
             _ => {}
-        };
+        }
     }
 }
 
@@ -926,7 +916,7 @@ impl FuseType {
 
     /// The type quantized values are read as, or `None` when fusion can't read that scheme.
     ///
-    /// Same contract as [Self::from_scale_dtype]: callers must decline to fuse on `None`.
+    /// Same contract as [`Self::from_scale_dtype`]: callers must decline to fuse on `None`.
     pub fn from_quant_scheme(scheme: QuantScheme) -> Option<Self> {
         // No fused kernel applies a per-tensor scale.
         if global_scale_dtype(&scheme).is_some() {

--- a/crates/burn-cubecl-fusion/src/engine/codegen/kernel.rs
+++ b/crates/burn-cubecl-fusion/src/engine/codegen/kernel.rs
@@ -1,6 +1,16 @@
 use crate::engine::codegen::{DynElem, DynSize};
 
-use super::{io::*, ir::*};
+use super::{
+    io::{
+        global_offset, global_shape, global_stride, input_as_scales_view, read, read_input,
+        read_quantized, read_quantized_scalar, read_scalar_shape, reverse_index,
+        set_polyfill_typed, swap_dims_transform, write,
+    },
+    ir::{
+        BinaryFuseArgs, FuseArg, FuseBlockConfig, FuseOp, GlobalArgs, LayoutInfo, LocalArgs,
+        RefLayout, UnaryFuseArgs, VirtualLayout,
+    },
+};
 use burn_std::quantization::{QuantScheme, QuantStore, QuantValue};
 use cubecl::{
     ir::{ElemType, FloatKind, UIntKind},
@@ -100,7 +110,7 @@ fn normalize_reference_stride(shape: usize, stride: usize) -> usize {
 }
 
 #[cube]
-/// Initializes [LocalArgs] given the input and output [arguments](GlobalArgs) with the [FuseBlockConfig].
+/// Initializes [`LocalArgs`] given the input and output [arguments](GlobalArgs) with the [`FuseBlockConfig`].
 ///
 /// # Notes
 ///
@@ -252,7 +262,7 @@ pub fn init_locals(
 }
 
 #[cube]
-/// Expands all [operations](FuseOp) registered in the [block config](FuseBlockConfig].
+/// Expands all [operations](FuseOp) registered in the [block config](`FuseBlockConfig`].
 fn fuse(
     inputs: &GlobalArgs,
     outputs: &mut GlobalArgs,
@@ -286,7 +296,7 @@ fn fuse(
             FuseOp::Equal(op) => equal::<E, N>(inputs, outputs, locals, pos, op, config),
             FuseOp::Greater(op) => greater::<E, N>(inputs, outputs, locals, pos, op, config),
             FuseOp::GreaterEqual(op) => {
-                greater_equal::<E, N>(inputs, outputs, locals, pos, op, config)
+                greater_equal::<E, N>(inputs, outputs, locals, pos, op, config);
             }
             FuseOp::Lower(op) => lower::<E, N>(inputs, outputs, locals, pos, op, config),
             FuseOp::LowerEqual(op) => lower_equal::<E, N>(inputs, outputs, locals, pos, op, config),
@@ -294,10 +304,10 @@ fn fuse(
             FuseOp::BitwiseOr(op) => bitwise_or::<E, N>(inputs, outputs, locals, pos, op, config),
             FuseOp::BitwiseXor(op) => bitwise_xor::<E, N>(inputs, outputs, locals, pos, op, config),
             FuseOp::BitwiseLeftShift(op) => {
-                bitwise_left_shift::<E, N>(inputs, outputs, locals, pos, op, config)
+                bitwise_left_shift::<E, N>(inputs, outputs, locals, pos, op, config);
             }
             FuseOp::BitwiseRightShift(op) => {
-                bitwise_right_shift::<E, N>(inputs, outputs, locals, pos, op, config)
+                bitwise_right_shift::<E, N>(inputs, outputs, locals, pos, op, config);
             }
             FuseOp::BitwiseNot(op) => bitwise_not::<E, N>(inputs, outputs, locals, pos, op, config),
             FuseOp::ConditionalAssign {

--- a/crates/burn-cubecl-fusion/src/engine/codegen/tensor.rs
+++ b/crates/burn-cubecl-fusion/src/engine/codegen/tensor.rs
@@ -10,7 +10,7 @@ use std::hash::Hash;
 ///
 /// # Warning
 ///
-/// The `tensor` field type [Vector<NumericExpand<DYN_ELEM_ID>>] must be set using polyfill before
+/// The `tensor` field type [Vector<`NumericExpand`<`DYN_ELEM_ID`>>] must be set using polyfill before
 /// use.
 #[derive(CubeType, Clone)]
 #[expand(derive(Clone))]

--- a/crates/burn-cubecl-fusion/src/engine/codegen/view.rs
+++ b/crates/burn-cubecl-fusion/src/engine/codegen/view.rs
@@ -324,7 +324,7 @@ impl<E: CubePrimitive> ViewOperationsMutExpand<E, Coords1d> for FusedOutputExpan
             ViewOperationsExpand::<E, Coords1d>::__expand_is_in_bounds_method(self, scope, pos);
         if_expand(scope, in_bounds, |scope| {
             ViewOperationsMutExpand::<E, Coords1d>::__expand_write_method(self, scope, pos, value);
-        })
+        });
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/burn-cubecl-fusion/src/engine/fuser.rs
+++ b/crates/burn-cubecl-fusion/src/engine/fuser.rs
@@ -27,8 +27,8 @@ use cubecl::ir::ElemType;
 ///
 /// # Notes
 ///
-/// It is responsible to translate [OperationIr] into [FuseOp] and it uses the [TraceFuser]
-/// to actually fuse the [FuseOp] when possible.
+/// It is responsible to translate [`OperationIr`] into [`FuseOp`] and it uses the [`TraceFuser`]
+/// to actually fuse the [`FuseOp`] when possible.
 #[derive(Debug, Clone)]
 pub(crate) struct TraceOperationFuser {
     pub(crate) fuser: TryTraceFuser,
@@ -147,7 +147,7 @@ impl OperationFuser<FuseTrace> for TraceOperationFuser {
                 self.log_closed(op, prev_num_ops, "unsupported op variant");
                 return;
             }
-        };
+        }
 
         self.status = FuserStatus::Open;
         self.scoring.register(op);
@@ -256,7 +256,7 @@ impl TraceOperationFuser {
     /// # Arguments
     ///
     /// - arguments: Tensors that are logical outputs of the current block and inputs of the following blocks.
-    /// - settings: [FuseSettings] to be used by the next block.
+    /// - settings: [`FuseSettings`] to be used by the next block.
     ///
     /// # Returns
     ///
@@ -426,7 +426,7 @@ impl TraceOperationFuser {
                 self.fuser.fuse(|build| {
                     let mut tensors = Vec::with_capacity(desc.tensors.len());
 
-                    for tensor in desc.tensors.iter() {
+                    for tensor in &desc.tensors {
                         tensors.push(build.input_indexed(tensor)?);
                     }
 

--- a/crates/burn-cubecl-fusion/src/engine/launch/base.rs
+++ b/crates/burn-cubecl-fusion/src/engine/launch/base.rs
@@ -13,7 +13,7 @@ use burn_fusion::stream::Context;
 use cubecl::{Runtime, client::ComputeClient};
 use std::marker::PhantomData;
 
-/// The launcher is responsible to launch a fused kernel using the [TraceRunner] and a [FuseTrace].
+/// The launcher is responsible to launch a fused kernel using the [`TraceRunner`] and a [`FuseTrace`].
 ///
 /// TODO: We can reuse the same launcher between runs and avoid a lot of allocation, by simply
 /// resetting the state.
@@ -88,7 +88,7 @@ impl<'a, R: Runtime, Runner: TraceRunner<R>> FuseTraceLauncher<'a, R, Runner> {
                 HandleInput::QuantParams(_) => {
                     // The scales are part of the quant data handle.
                 }
-            };
+            }
         }
         for output in handle_outputs {
             if let HandleOutput::Owned {

--- a/crates/burn-cubecl-fusion/src/engine/launch/executor.rs
+++ b/crates/burn-cubecl-fusion/src/engine/launch/executor.rs
@@ -52,7 +52,7 @@ impl<'a, R: Runtime> LaunchPlanExecutor<'a, R> {
         plan: LaunchPlan<'a, R>,
     ) -> Result<TuneOutput<R>, ExecutionError<R, Runner>> {
         let mut num_writes = 0;
-        for b in plan.blocks.iter() {
+        for b in &plan.blocks {
             for writes in b.writes.values() {
                 num_writes += writes.len();
             }
@@ -160,7 +160,7 @@ impl<'a, R: Runtime> LaunchPlanExecutor<'a, R> {
                 }
             }
 
-            for op in block.ops.iter() {
+            for op in &block.ops {
                 ops.push(op.clone());
             }
 
@@ -313,7 +313,7 @@ fn register_scalars<'h, R: Runtime>(
                 ScalarIr::Float(val) => inputs.scalars.push(InputScalar::new(*val, dtype)),
                 ScalarIr::Int(val) => inputs.scalars.push(InputScalar::new(*val, dtype)),
                 ScalarIr::UInt(val) => inputs.scalars.push(InputScalar::new(*val, dtype)),
-                ScalarIr::Bool(val) => inputs.scalars.push(InputScalar::new(*val as u8, dtype)),
+                ScalarIr::Bool(val) => inputs.scalars.push(InputScalar::new(u8::from(*val), dtype)),
             },
             None => panic!("Scalar ID not found"),
         }

--- a/crates/burn-cubecl-fusion/src/engine/launch/input.rs
+++ b/crates/burn-cubecl-fusion/src/engine/launch/input.rs
@@ -119,7 +119,7 @@ impl<'a, R: Runtime> InputPlanner<'a, R> {
         {
             let mut is_a_view = false;
             // For each view we try to see if it's not possible to set it as a reference input.
-            for view in self.resources.views.iter() {
+            for view in &self.resources.views {
                 for (block_plan, block) in plan.blocks.iter_mut().zip(self.blocks) {
                     is_a_view = is_a_view
                         || Self::analyze_view(pos, tensor_relative, block, block_plan, view);
@@ -248,7 +248,7 @@ impl<'a, R: Runtime> InputPlanner<'a, R> {
             TensorView::NhwcStrides { .. } => {
                 return false;
             }
-        };
+        }
 
         false
     }

--- a/crates/burn-cubecl-fusion/src/engine/launch/layout.rs
+++ b/crates/burn-cubecl-fusion/src/engine/launch/layout.rs
@@ -72,11 +72,11 @@ pub fn dim_order(shape: &[usize], strides: &[usize]) -> Option<DimOrder> {
 /// across trailing degenerate dimensions, which a contiguous layout gives stride
 /// one. Answering `None` there rather than an axis of our own leaves every such
 /// block behaving exactly as it did, and keeps the two callers — the
-/// [vector_axis](crate::engine::codegen::ir::FuseBlockConfig::vector_axis) a kernel
+/// [`vector_axis`](crate::engine::codegen::ir::FuseBlockConfig::vector_axis) a kernel
 /// steps by and the axis the vectorization pass sizes against — from disagreeing
 /// about what a vector is.
 ///
-/// For a permuted order it is the innermost dimension of [dim_order], except that
+/// For a permuted order it is the innermost dimension of [`dim_order`], except that
 /// degenerate dimensions are skipped. Their position in the order is arbitrary —
 /// nothing distinguishes them, since density says nothing about their stride —
 /// and their stride is arbitrary with it: a broadcast dimension carries stride
@@ -96,7 +96,7 @@ pub fn permuted_innermost_axis(shape: &[usize], strides: &[usize]) -> Option<usi
 /// The strides a tensor of this shape has when laid out in the given dimension
 /// order.
 ///
-/// The inverse of [dim_order] for dense tensors: `strides_for(shape,
+/// The inverse of [`dim_order`] for dense tensors: `strides_for(shape,
 /// dim_order(shape, strides))` reproduces `strides` up to the arbitrary strides
 /// of size-one dimensions.
 pub fn strides_for(shape: &[usize], order: &[usize]) -> Strides {

--- a/crates/burn-cubecl-fusion/src/engine/launch/output.rs
+++ b/crates/burn-cubecl-fusion/src/engine/launch/output.rs
@@ -107,7 +107,7 @@ impl<'a, R: Runtime> OutputPlanner<'a, R> {
         let mut outputs = Vec::new();
         core::mem::swap(&mut outputs, &mut self.outputs_sorted);
 
-        for output in outputs.into_iter() {
+        for output in outputs {
             let tensor_global = context
                 .tensors
                 .get(&output.tensor_relative.id)
@@ -194,45 +194,42 @@ impl<'a, R: Runtime> OutputPlanner<'a, R> {
         }
 
         for i in 0..plan.blocks.len() {
-            if !plan.blocks[i].reference.is_found() {
-                match self.blocks[i].settings.ref_layout {
-                    RefLayoutSetting::SameAsBlock { block_pos } => {
-                        plan.blocks[i].reference =
-                            plan.blocks[block_pos as usize].reference.clone();
-                    }
-                    _ => {
-                        let new_runtime = Self::select_reference_from_inputs(
-                            &self.blocks[i],
-                            &mut plan.blocks[i],
-                            &plan.handle_inputs,
-                        );
-
-                        if let Some(shape) = new_runtime {
-                            let pos = plan.runtime_layouts.len();
-                            let mut shape_global = shape.clone();
-                            for (i, s) in shape.iter().enumerate() {
-                                shape_global[i] = *context.shapes_relative2global.get(s).expect(
-                                    "reference shape ids to be assigned by the running stream",
-                                );
-                            }
-
-                            let strides = strides_dyn_rank(&shape_global);
-
-                            plan.blocks[i].reference = ReferenceSelection::Runtime { pos };
-                            plan.runtime_layouts.push(RuntimeLayout {
-                                shape: shape_global,
-                                strides,
-                            });
-                        }
-                    }
-                };
-            } else {
+            if plan.blocks[i].reference.is_found() {
                 Self::add_layout_info_inputs(&mut plan.blocks[i], &plan.handle_inputs);
+            } else if let RefLayoutSetting::SameAsBlock { block_pos } =
+                self.blocks[i].settings.ref_layout
+            {
+                plan.blocks[i].reference = plan.blocks[block_pos as usize].reference.clone();
+            } else {
+                let new_runtime = Self::select_reference_from_inputs(
+                    &self.blocks[i],
+                    &mut plan.blocks[i],
+                    &plan.handle_inputs,
+                );
+
+                if let Some(shape) = new_runtime {
+                    let pos = plan.runtime_layouts.len();
+                    let mut shape_global = shape.clone();
+                    for (i, s) in shape.iter().enumerate() {
+                        shape_global[i] = *context
+                            .shapes_relative2global
+                            .get(s)
+                            .expect("reference shape ids to be assigned by the running stream");
+                    }
+
+                    let strides = strides_dyn_rank(&shape_global);
+
+                    plan.blocks[i].reference = ReferenceSelection::Runtime { pos };
+                    plan.runtime_layouts.push(RuntimeLayout {
+                        shape: shape_global,
+                        strides,
+                    });
+                }
             }
         }
 
         // Make sure dropped are correctly executed.
-        for id in self.resources.dropped.iter() {
+        for id in &self.resources.dropped {
             if let Some(tensor_global) = context.tensors.get(id) {
                 context.handles.remove_handle(tensor_global.id);
             }
@@ -283,9 +280,9 @@ impl<'a, R: Runtime> OutputPlanner<'a, R> {
                             // buffer: the launch is sized from the logical element count while a
                             // position indexes the buffer.
                             if is_dense(&reference.global_ir.shape, &reference.handle.strides) {
-                                set_ref_as_concrete(block_plan)
+                                set_ref_as_concrete(block_plan);
                             } else {
-                                set_ref_as_virtual(block_plan)
+                                set_ref_as_virtual(block_plan);
                             }
                         }
                         RefLayoutSetting::SameAsBlock { .. } => {
@@ -294,9 +291,9 @@ impl<'a, R: Runtime> OutputPlanner<'a, R> {
                         RefLayoutSetting::OnlyContiguous => {
                             if is_contiguous(&reference.global_ir.shape, &reference.handle.strides)
                             {
-                                set_ref_as_concrete(block_plan)
+                                set_ref_as_concrete(block_plan);
                             } else {
-                                set_ref_as_virtual(block_plan)
+                                set_ref_as_virtual(block_plan);
                             }
                         }
                     }
@@ -321,7 +318,7 @@ impl<'a, R: Runtime> OutputPlanner<'a, R> {
                 InputReference::Reshaped { reshape_pos } => {
                     block_plan.reference = ReferenceSelection::Reshaped { reshape_pos };
                 }
-            };
+            }
             None
         } else {
             Some(block.shape_ref.clone())
@@ -449,21 +446,21 @@ impl<'a, R: Runtime> OutputPlanner<'a, R> {
             // the whole of the traffic a concatenation moves. Without this a
             // concatenation has no voters at all and keeps the contiguous order by
             // default, which is what its consumer then transposes.
-            let voter_shape = match concatenated.get(&pos) {
-                Some(axis) => match joined_only_along(shape, &input.global_ir.shape, *axis) {
-                    true => &input.global_ir.shape,
-                    false => continue,
-                },
-                None => {
-                    if !block.reads.contains_key(&input.relative_id)
-                        || self.resources.indexed.contains_key(&input.relative_id)
-                        || self.resources.inputs_unhandled.contains(&input.relative_id)
-                        || &input.global_ir.shape != shape
-                    {
-                        continue;
-                    }
-                    shape
+            let voter_shape = if let Some(axis) = concatenated.get(&pos) {
+                if joined_only_along(shape, &input.global_ir.shape, *axis) {
+                    &input.global_ir.shape
+                } else {
+                    continue;
                 }
+            } else {
+                if !block.reads.contains_key(&input.relative_id)
+                    || self.resources.indexed.contains_key(&input.relative_id)
+                    || self.resources.inputs_unhandled.contains(&input.relative_id)
+                    || &input.global_ir.shape != shape
+                {
+                    continue;
+                }
+                shape
             };
 
             let Some(order) = dim_order(voter_shape, &input.handle.strides) else {
@@ -487,9 +484,10 @@ impl<'a, R: Runtime> OutputPlanner<'a, R> {
             (*bytes, is_contiguous_order(order))
         })?;
 
-        match is_contiguous_order(&winner.0) {
-            true => None,
-            false => Some(winner.0),
+        if is_contiguous_order(&winner.0) {
+            None
+        } else {
+            Some(winner.0)
         }
     }
 
@@ -560,8 +558,9 @@ impl<'a, R: Runtime> OutputPlanner<'a, R> {
                             && is_contiguous(&tensor_global.shape, &pi.strides)
                     }
             })
-            .map(|(pos, _)| OutputKind::Inplace { input_pos: pos })
-            .unwrap_or(OutputKind::Normal);
+            .map_or(OutputKind::Normal, |(pos, _)| OutputKind::Inplace {
+                input_pos: pos,
+            });
 
         (kind, block_idx)
     }
@@ -599,7 +598,17 @@ impl<'a, R: Runtime> OutputPlanner<'a, R> {
             "inplace alias selected for a `SameAsBlock` block without a validated reference",
         );
 
-        if !block.reference.is_found() {
+        if block.reference.is_found() {
+            // Already validated, necessary for correctness.
+            if let Some(ops) = block.writes.get_mut(&output.tensor_relative.id) {
+                for op in ops {
+                    if let FuseOp::Assign(op) = op {
+                        op.out.add_layout_info(LayoutInfo::SameAsRef);
+                        break;
+                    }
+                }
+            }
+        } else {
             // The aliased output shares the input's buffer and layout, so the reference
             // is expressed with the output argument. Runners assume references are
             // either output-concrete or virtual; an input-concrete reference here would
@@ -615,7 +624,7 @@ impl<'a, R: Runtime> OutputPlanner<'a, R> {
                     if let FuseOp::Assign(op) = op {
                         op.input.add_layout_info(LayoutInfo::IsRef);
                         break;
-                    };
+                    }
                 }
             }
 
@@ -626,17 +635,7 @@ impl<'a, R: Runtime> OutputPlanner<'a, R> {
                         break;
                     }
                 }
-            };
-        } else {
-            // Already validated, necessary for correctness.
-            if let Some(ops) = block.writes.get_mut(&output.tensor_relative.id) {
-                for op in ops {
-                    if let FuseOp::Assign(op) = op {
-                        op.out.add_layout_info(LayoutInfo::SameAsRef);
-                        break;
-                    }
-                }
-            };
+            }
         }
 
         context
@@ -700,7 +699,7 @@ impl<'a, R: Runtime> OutputPlanner<'a, R> {
                         break;
                     }
                 }
-            };
+            }
         } else if let ReferenceSelection::Concrete {
             shape: ref_shape,
             strides: ref_strides,
@@ -716,7 +715,7 @@ impl<'a, R: Runtime> OutputPlanner<'a, R> {
                     break;
                 }
             }
-        };
+        }
 
         let dtype = tensor_global.dtype;
         let size =
@@ -924,10 +923,13 @@ impl<'a, R: Runtime> OutputPlanner<'a, R> {
             .iter()
             .enumerate()
             .find_map(|(pi, handle)| match handle {
-                HandleInput::Normal(handle) => match handle.relative_id == original {
-                    true => Some((pi, handle)),
-                    false => None,
-                },
+                HandleInput::Normal(handle) => {
+                    if handle.relative_id == original {
+                        Some((pi, handle))
+                    } else {
+                        None
+                    }
+                }
                 _ => None, // Quant tensor can't be reshaped.
             })
             .unwrap()
@@ -947,14 +949,14 @@ impl<'a, R: Runtime> OutputPlanner<'a, R> {
 /// The matmul one does not: it describes its output to the matmul algorithm as
 /// row-major while building the output view from the reference's last two strides,
 /// so a permuted reference has it writing lines that are not contiguous along the
-/// column. That is what [FuseSettings::choose_output_layout] gates.
+/// column. That is what [`FuseSettings::choose_output_layout`] gates.
 ///
 /// And the block must contain no operation that indexes its operands against the
 /// last dimension directly rather than through the reference. `gather` walks its
 /// lanes with the stride of `rank - 1`; it agrees with the rest of the kernel only
 /// while the reference is contiguous. `concat` used to be counted here and no
 /// longer is — it reaches the vectorization axis through
-/// [FuseBlockConfig::vector_axis](crate::engine::codegen::FuseBlockConfig::vector_axis),
+/// [`FuseBlockConfig::vector_axis`](crate::engine::codegen::FuseBlockConfig::vector_axis),
 /// which follows a permuted reference.
 fn may_permute_layout(settings: &FuseSettings, ops: &[FuseOp]) -> bool {
     if !matches!(settings.ref_layout, RefLayoutSetting::Any) || !settings.choose_output_layout {

--- a/crates/burn-cubecl-fusion/src/engine/launch/plan.rs
+++ b/crates/burn-cubecl-fusion/src/engine/launch/plan.rs
@@ -107,7 +107,7 @@ impl<R: Runtime> LaunchPlan<'_, R> {
         let mut rank = 0;
         let mut blocks = Vec::with_capacity(fuse_blocks.len());
 
-        for b in fuse_blocks.iter() {
+        for b in fuse_blocks {
             rank = usize::max(b.shape_ref.len(), rank);
             let block = BlockPlan {
                 reference: ReferenceSelection::Searching,

--- a/crates/burn-cubecl-fusion/src/engine/launch/runner.rs
+++ b/crates/burn-cubecl-fusion/src/engine/launch/runner.rs
@@ -37,7 +37,7 @@ pub enum VectorizationHandle<'a, R: Runtime> {
     QuantParams,
 }
 
-impl<'a, R: Runtime> VectorizationHandle<'a, R> {
+impl<R: Runtime> VectorizationHandle<'_, R> {
     /// Returns if the current vectorization handle is from the given tensor id.
     pub fn is_from_tensor(&self, id: TensorId) -> bool {
         match self {
@@ -91,6 +91,6 @@ pub trait Vectorization<R: Runtime> {
             &Default::default(),
             max,
             &axis,
-        )
+        );
     }
 }

--- a/crates/burn-cubecl-fusion/src/engine/launch/vectorization/axis.rs
+++ b/crates/burn-cubecl-fusion/src/engine/launch/vectorization/axis.rs
@@ -8,8 +8,8 @@
 //! Every tensor a block touches has to be measured along the *same* axis the
 //! block iterates along, or a vector of the reference and a vector of that tensor
 //! cover different elements. So the facts are gathered per tensor
-//! ([VectorAxisAnalysis]), a rule turns them into a decision
-//! ([VectorAxisPolicy]), and the decision is applied ([VectorAxisAction]).
+//! ([`VectorAxisAnalysis`]), a rule turns them into a decision
+//! ([`VectorAxisPolicy`]), and the decision is applied ([`VectorAxisAction`]).
 
 use super::super::{
     HandleOutput, LaunchPlan, ReferenceSelection,
@@ -46,9 +46,10 @@ impl VectorAxisAction {
     /// that is not its own. A refusal therefore absorbs whatever is merged into
     /// it, which matters because blocks are analysed in whatever order they come.
     pub fn merged_with(self, other: Self) -> Self {
-        match self == other {
-            true => self,
-            false => VectorAxisAction::Refuse,
+        if self == other {
+            self
+        } else {
+            VectorAxisAction::Refuse
         }
     }
 }
@@ -68,7 +69,7 @@ pub struct VectorAxisAnalysis {
 impl VectorAxisAnalysis {
     /// The facts for a tensor the block reads.
     ///
-    /// No stride: [vectorization_input](super::base) makes that check itself, and
+    /// No stride: [`vectorization_input`](super::base) makes that check itself, and
     /// unlike this analysis it tells a broadcast dimension from one it merely
     /// cannot line up — a distinction worth keeping, since a broadcast operand
     /// does not constrain the block's width and a refused one does.
@@ -82,7 +83,7 @@ impl VectorAxisAnalysis {
 
     /// The facts for a tensor the block writes.
     ///
-    /// [vectorization_output](super::base) is handed a shape and never sees a
+    /// [`vectorization_output`](super::base) is handed a shape and never sees a
     /// stride, so an output allocated in an order its block does not iterate in
     /// has to be caught here or not at all.
     pub fn written(reference: &ReferenceSelection, rank: usize, strides: &[usize]) -> Self {
@@ -118,13 +119,14 @@ impl VectorAxisPolicy {
     /// Unless some block iterates in a permuted order there is nothing to decide,
     /// and saying so up front skips the whole analysis.
     pub fn of_plan<R: Runtime>(plan: &LaunchPlan<'_, R>) -> Self {
-        match plan
+        if plan
             .blocks
             .iter()
             .any(|block| block_axis(&block.reference).is_some())
         {
-            true => VectorAxisPolicy::LineUpWithBlock,
-            false => VectorAxisPolicy::AlwaysDefault,
+            VectorAxisPolicy::LineUpWithBlock
+        } else {
+            VectorAxisPolicy::AlwaysDefault
         }
     }
 
@@ -163,7 +165,7 @@ pub struct VectorAxes {
     refused: Refusals,
 }
 
-/// The tensors [VectorAxisAction::Refuse] applies to, pinned to a vector size of
+/// The tensors [`VectorAxisAction::Refuse`] applies to, pinned to a vector size of
 /// one once the vectorization pass has run — it cannot see what refused them.
 /// Usually empty.
 #[derive(Default)]
@@ -230,7 +232,7 @@ impl Refusals {
     /// element either way, and calling it aligned would drag the whole block's
     /// width down with it.
     pub fn apply(&self, vectorizations: &mut BTreeMap<TensorId, Vect>) {
-        for id in self.ids.iter() {
+        for id in &self.ids {
             if !matches!(vectorizations.get(id), Some(Vect::Broadcasted)) {
                 vectorizations.insert(*id, Vect::Aligned(1));
             }
@@ -265,8 +267,8 @@ impl Actions {
             per_tensor: HashMap::new(),
         };
 
-        for block in plan.blocks.iter() {
-            for input in plan.handle_inputs.iter() {
+        for block in &plan.blocks {
+            for input in &plan.handle_inputs {
                 if let Some(input) = input.as_normal()
                     && block.reads.contains_key(&input.relative_id)
                 {
@@ -281,7 +283,7 @@ impl Actions {
                 }
             }
 
-            for output in plan.handle_outputs.iter() {
+            for output in &plan.handle_outputs {
                 if let HandleOutput::Owned {
                     handle,
                     global_id,
@@ -309,7 +311,7 @@ impl Actions {
         // same mapping [read_input_aligned](crate::engine::codegen::io) applies. Both
         // go wrong only when handed the default while the block iterates elsewhere,
         // and nothing votes for a view's id unless it is done here.
-        for view in resources.views.iter() {
+        for view in &resources.views {
             let (view_id, original_id) = match view {
                 TensorView::Reshape {
                     reshaped, original, ..
@@ -328,7 +330,7 @@ impl Actions {
                 continue;
             };
 
-            for block in plan.blocks.iter() {
+            for block in &plan.blocks {
                 if !block.reads.contains_key(original_id) {
                     continue;
                 }

--- a/crates/burn-cubecl-fusion/src/engine/launch/vectorization/base.rs
+++ b/crates/burn-cubecl-fusion/src/engine/launch/vectorization/base.rs
@@ -36,12 +36,11 @@ pub struct VectorSizeOverrides {
 #[allow(unused)]
 impl VectorSizeOverrides {
     pub fn overrides(&mut self, tensor_id: &TensorId, vector_sizes: Vec<VectorSize>) {
-        let map = match &mut self.state {
-            Some(val) => val,
-            None => {
-                self.state = Some(BTreeMap::new());
-                self.state.as_mut().unwrap()
-            }
+        let map = if let Some(val) = &mut self.state {
+            val
+        } else {
+            self.state = Some(BTreeMap::new());
+            self.state.as_mut().unwrap()
         };
 
         map.insert(*tensor_id, vector_sizes);
@@ -55,7 +54,7 @@ impl VectorSizeOverrides {
             Some(state) => {
                 let mut state_new = BTreeMap::new();
 
-                for (k, v) in state.iter() {
+                for (k, v) in state {
                     let global = context.tensors.get(k).unwrap();
                     state_new.insert(global.id, v.clone());
                 }
@@ -154,7 +153,7 @@ pub(crate) fn vectorization_default<'a, R: Runtime>(
                 VectorizationHandle::QuantParams => {
                     // Doesn't have vectorization for now.
                 }
-            };
+            }
         }
     }
 
@@ -188,7 +187,7 @@ fn multi_reads_vectorization_update(
     original: TensorId,
     vect: Vect,
 ) {
-    if let Some(ori_vect) = vectorizations.get(&original).cloned() {
+    if let Some(ori_vect) = vectorizations.get(&original).copied() {
         match ori_vect {
             Vect::Broadcasted => {
                 // keep the original as is.
@@ -198,11 +197,11 @@ fn multi_reads_vectorization_update(
                     vectorizations.insert(original, Vect::Aligned(1));
                 }
                 Vect::Aligned(new) => {
-                    let val = if new != ori { 1 } else { new };
+                    let val = if new == ori { new } else { 1 };
                     vectorizations.insert(original, Vect::Aligned(val));
                 }
             },
-        };
+        }
     } else {
         vectorizations.insert(original, vect);
     }
@@ -243,7 +242,7 @@ fn vectorization_input<R: Runtime>(
     // vectorization by the num_quants, we need to adapt the stride check accordingly.
     if let burn_std::DType::QFloat(quant_scheme) = handle.dtype {
         next_stride *= quant_scheme.num_quants();
-    };
+    }
 
     let inner = |s: VectorSize| {
         // The last dimension should be a multiple of the vector size or broadcated.
@@ -338,14 +337,7 @@ fn vectorization_reshape(
     }
 
     let inner = |s: VectorSize| {
-        if !multi_reads {
-            // The last dimension should be a multiple of the vector size or broadcated.
-            if reshape_shape_axis.is_multiple_of(s) && s <= max {
-                Some(Vect::Aligned(s))
-            } else {
-                None
-            }
-        } else {
+        if multi_reads {
             // Since the original tensor must share the same vectorization factor as the
             // reshaped tensor, they must have compatible shapes when both are access
             // independently.
@@ -353,6 +345,13 @@ fn vectorization_reshape(
                 && original_shape_axis.is_multiple_of(s)
                 && s <= max
             {
+                Some(Vect::Aligned(s))
+            } else {
+                None
+            }
+        } else {
+            // The last dimension should be a multiple of the vector size or broadcated.
+            if reshape_shape_axis.is_multiple_of(s) && s <= max {
                 Some(Vect::Aligned(s))
             } else {
                 None
@@ -435,7 +434,7 @@ fn vectorization_swapped<R: Runtime>(
     // vectorization by the num_quants, we need to adapt the stride check accordingly.
     if let burn_std::DType::QFloat(quant_scheme) = handle.dtype {
         next_stride *= quant_scheme.num_quants();
-    };
+    }
 
     let inner = |s: VectorSize| {
         // The last dimension should be a multiple of the vector size or broadcated.

--- a/crates/burn-cubecl-fusion/src/engine/launch/vectorization/planner.rs
+++ b/crates/burn-cubecl-fusion/src/engine/launch/vectorization/planner.rs
@@ -53,8 +53,8 @@ impl<'a, R: Runtime> VectorizationPlanner<'a, R> {
     ) {
         let has_multiple_read = |tensor: &TensorId| {
             let mut read_count = 0;
-            for block in plan.blocks.iter() {
-                read_count += block.reads.get(tensor).map(|a| a.len()).unwrap_or(0);
+            for block in &plan.blocks {
+                read_count += block.reads.get(tensor).map_or(0, std::vec::Vec::len);
             }
             read_count > 1
         };
@@ -88,7 +88,7 @@ impl<'a, R: Runtime> VectorizationPlanner<'a, R> {
         let mut ref_elem = (ElemType::UInt(UIntKind::U64), 8);
         let mut quants_vector_sizes: Option<Vec<VectorSize>> = None;
 
-        for input in plan.handle_inputs.iter() {
+        for input in &plan.handle_inputs {
             let elem: ElemType = match input {
                 HandleInput::Normal(h) => dtype_to_storage_type(h.global_ir.dtype),
                 HandleInput::QuantValues(handle) => match handle.global_ir.dtype {
@@ -106,7 +106,7 @@ impl<'a, R: Runtime> VectorizationPlanner<'a, R> {
                 ref_elem = (elem, elem_size);
             }
         }
-        for r in plan.global_outputs.iter() {
+        for r in &plan.global_outputs {
             let elem: ElemType = dtype_to_storage_type(r.dtype);
             let elem_size = elem.size();
 
@@ -121,8 +121,7 @@ impl<'a, R: Runtime> VectorizationPlanner<'a, R> {
             .map(|item| {
                 item.as_normal()
                     // Filter out indexed resources.
-                    .map(|item| !self.resources.indexed.contains_key(&item.relative_id))
-                    .unwrap_or(true)
+                    .is_none_or(|item| !self.resources.indexed.contains_key(&item.relative_id))
             })
             .collect::<Vec<_>>();
 
@@ -171,7 +170,7 @@ impl<'a, R: Runtime> VectorizationPlanner<'a, R> {
             plan.vectorizations.insert(global.id, Vect::Aligned(1));
         }
 
-        for view in self.resources.views.iter() {
+        for view in &self.resources.views {
             if let TensorView::NhwcStrides { id, .. } = view {
                 let global = context.tensors.get(id).unwrap();
                 plan.vectorizations.insert(global.id, Vect::Aligned(1));
@@ -238,7 +237,7 @@ impl<'a, R: Runtime> VectorizationPlanner<'a, R> {
         // vectorizations in blocks.
         //
         // Unhandled Outputs are correctly vectorized, so this is only necessary for inputs.
-        for input in self.resources.inputs_unhandled.iter() {
+        for input in &self.resources.inputs_unhandled {
             let pos = self
                 .resources
                 .inputs
@@ -428,7 +427,7 @@ fn vector_sizes_quants<R: Runtime>(
                 .io_optimized_vector_sizes(size_of::<u32>())
                 .collect::<Vec<_>>();
 
-            for val in vector_sizes.iter_mut() {
+            for val in &mut vector_sizes {
                 *val *= scheme.num_quants();
             }
 
@@ -469,5 +468,5 @@ fn vector_sizes_quants<R: Runtime>(
         QuantStore::PackedNative(_) => {
             panic!("Not yet supported")
         }
-    };
+    }
 }

--- a/crates/burn-cubecl-fusion/src/engine/scoring.rs
+++ b/crates/burn-cubecl-fusion/src/engine/scoring.rs
@@ -34,7 +34,7 @@ impl Scoring {
         let mut num_writes_fused = 0;
         let mut num_penalty = 0;
 
-        for b in trace.blocks.iter() {
+        for b in &trace.blocks {
             // Count reads in block
             for ops in b.reads.values() {
                 let result = self.count_fused_io(ops, |args| &args.input);
@@ -62,9 +62,10 @@ impl Scoring {
         let num_fused = reads_fused + writes_fused;
         let num_unfused = self.num_reads + self.num_writes;
 
-        let score_io = match num_fused >= num_unfused {
-            true => 0,
-            false => (num_unfused - num_fused) as u64 * FACTOR_IO,
+        let score_io = if num_fused >= num_unfused {
+            0
+        } else {
+            (num_unfused - num_fused) as u64 * FACTOR_IO
         };
 
         // We minus 1 since at least one kernel launch is necessary.
@@ -82,18 +83,18 @@ impl Scoring {
         let mut num_io = 0;
         let mut penalty = 0;
 
-        for op in ops.iter() {
+        for op in ops {
             let FuseOp::Assign(args) = op else {
                 unreachable!()
             };
-            let count_normal = matches!(
+            let count_normal = usize::from(matches!(
                 arg_extractor(args),
                 FuseArg::Input(..) | FuseArg::Output(..)
-            ) as usize;
-            let count_view = matches!(
+            ));
+            let count_view = usize::from(matches!(
                 arg_extractor(args),
                 FuseArg::InputReshaped { .. } | FuseArg::InputSwapDims { .. }
-            ) as usize;
+            ));
             num_io += count_normal + count_view;
             penalty += count_view;
         }

--- a/crates/burn-cubecl-fusion/src/engine/settings.rs
+++ b/crates/burn-cubecl-fusion/src/engine/settings.rs
@@ -21,7 +21,7 @@ pub struct FuseSettings {
     /// Writing an output in any dense layout costs the same, so a block whose
     /// inputs are permuted — everything downstream of a convolution, which hands
     /// over an NCHW view of NHWC memory — is better off adopting their order than
-    /// reading them strided. Only meaningful together with [RefLayoutSetting::Any];
+    /// reading them strided. Only meaningful together with [`RefLayoutSetting::Any`];
     /// the settings that constrain the reference already rule a permuted layout out.
     ///
     /// Off by default, because it is only safe for a runner that reads and writes
@@ -48,9 +48,9 @@ impl Default for FuseSettings {
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 /// How vectorization is handled during fusion.
 pub enum VectorizationSetting {
-    /// The biggest vector_size possible will be used.
+    /// The biggest `vector_size` possible will be used.
     Activated,
-    /// Equivalent to using vector_size of one.
+    /// Equivalent to using `vector_size` of one.
     Deactivated,
     /// This is a good setting when a block processes values calculated from a previous block.
     SmallerOrEqualThanPreviousBlock { block_pos: usize },

--- a/crates/burn-cubecl-fusion/src/engine/trace/base.rs
+++ b/crates/burn-cubecl-fusion/src/engine/trace/base.rs
@@ -41,18 +41,18 @@ impl FuseTrace {
 impl core::fmt::Display for FuseTrace {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "FuseTrace")?;
-        for b in self.blocks.iter() {
+        for b in &self.blocks {
             writeln!(f, " - Block shape={:?}", b.shape_ref)?;
-            for (tensor, ops) in b.reads.iter() {
-                for op in ops.iter() {
+            for (tensor, ops) in &b.reads {
+                for op in ops {
                     writeln!(f, "   - {op} <== {tensor}")?;
                 }
             }
-            for op in b.ops.iter() {
+            for op in &b.ops {
                 writeln!(f, "   - {op}")?;
             }
-            for (tensor, ops) in b.writes.iter() {
-                for op in ops.iter() {
+            for (tensor, ops) in &b.writes {
+                for op in ops {
                     writeln!(f, "   - {op} <== {tensor}")?;
                 }
             }
@@ -385,7 +385,7 @@ impl RegisteredTensors {
             _ => false,
         }) && let RegisterTensor::Normal(tensor_ir, _) = entry
         {
-            tensor_ir.status = tensor.status
+            tensor_ir.status = tensor.status;
         }
     }
 }

--- a/crates/burn-cubecl-fusion/src/engine/trace/block.rs
+++ b/crates/burn-cubecl-fusion/src/engine/trace/block.rs
@@ -83,16 +83,15 @@ impl FuseBlockBuilder {
         }
         let precision = tensor.dtype.into();
 
-        let out = match self.locals.get(precision, tensor.id) {
-            Some(local) => local,
-            None => {
-                let out = self.locals.create(precision, tensor.id);
+        let out = if let Some(local) = self.locals.get(precision, tensor.id) {
+            local
+        } else {
+            let out = self.locals.create(precision, tensor.id);
 
-                self.outputs.insert(precision, tensor.clone());
-                resources.outputs.insert(precision, tensor.clone());
+            self.outputs.insert(precision, tensor.clone());
+            resources.outputs.insert(precision, tensor.clone());
 
-                out
-            }
+            out
         };
 
         Some(out)
@@ -136,12 +135,11 @@ impl FuseBlockBuilder {
             )
         };
 
-        let ops = match self.writes.get_mut(&tensor.id) {
-            Some(ops) => ops,
-            None => {
-                self.writes.insert(tensor.id, Vec::new());
-                self.writes.get_mut(&tensor.id).unwrap()
-            }
+        let ops = if let Some(ops) = self.writes.get_mut(&tensor.id) {
+            ops
+        } else {
+            self.writes.insert(tensor.id, Vec::new());
+            self.writes.get_mut(&tensor.id).unwrap()
         };
         ops.push(FuseOp::Assign(UnaryFuseArgs {
             input: val,
@@ -166,41 +164,38 @@ impl FuseBlockBuilder {
             return Some(val.clone());
         }
 
-        let arg = match self.locals.get(precision, tensor.id) {
-            Some(local) => {
-                resources.inputs.update(tensor);
+        let arg = if let Some(local) = self.locals.get(precision, tensor.id) {
+            resources.inputs.update(tensor);
 
-                local
-            }
-            None => {
-                let input = if resources.outputs.get_index(tensor.id).is_some() {
-                    if let Some(val) = resources.registers.get(&tensor.id) {
-                        return Some(val.clone());
-                    };
+            local
+        } else {
+            let input = if resources.outputs.get_index(tensor.id).is_some() {
+                if let Some(val) = resources.registers.get(&tensor.id) {
+                    return Some(val.clone());
+                }
 
-                    let pos = resources.buffers.insert(precision, tensor.clone());
-                    FuseArg::Output(pos, precision, LayoutInfo::Unknown)
-                } else {
-                    let pos = resources.inputs.insert(precision, tensor.clone());
-                    FuseArg::Input(pos, precision, LayoutInfo::Unknown)
-                };
+                let pos = resources.buffers.insert(precision, tensor.clone());
+                FuseArg::Output(pos, precision, LayoutInfo::Unknown)
+            } else {
+                let pos = resources.inputs.insert(precision, tensor.clone());
+                FuseArg::Input(pos, precision, LayoutInfo::Unknown)
+            };
 
-                let out = self.locals.create(precision, tensor.id);
+            let out = self.locals.create(precision, tensor.id);
 
-                let reads = if let Entry::Vacant(e) = self.reads.entry(tensor.id) {
-                    e.insert(Vec::with_capacity(1));
-                    self.reads.get_mut(&tensor.id).unwrap()
-                } else {
-                    self.reads.get_mut(&tensor.id).unwrap()
-                };
+            let reads = if let Entry::Vacant(e) = self.reads.entry(tensor.id) {
+                e.insert(Vec::with_capacity(1));
+                self.reads.get_mut(&tensor.id).unwrap()
+            } else {
+                self.reads.get_mut(&tensor.id).unwrap()
+            };
 
-                reads.push(FuseOp::Assign(UnaryFuseArgs {
-                    input,
-                    out: out.clone(),
-                }));
+            reads.push(FuseOp::Assign(UnaryFuseArgs {
+                input,
+                out: out.clone(),
+            }));
 
-                out
-            }
+            out
         };
 
         Some(arg)
@@ -224,25 +219,22 @@ impl FuseBlockBuilder {
             _ => return None,
         };
 
-        let arg = match self.locals.get(precision, tensor.id) {
-            Some(local) => {
-                resources.inputs.update(tensor);
-                QuantInput::AlreadyDequantized { local }
+        let arg = if let Some(local) = self.locals.get(precision, tensor.id) {
+            resources.inputs.update(tensor);
+            QuantInput::AlreadyDequantized { local }
+        } else {
+            let (new_input, q_index) = resources.inputs.insert_quant(tensor.clone());
+            let input = FuseArg::Input(new_input, precision, LayoutInfo::Unknown);
+            let scales = FuseArg::Input(q_index, precision_scales, LayoutInfo::Unknown);
+
+            // Important to flag that there is a read, even if no operation is registered.
+            if let Entry::Vacant(e) = self.reads.entry(tensor.id) {
+                e.insert(Vec::new());
             }
-            None => {
-                let (new_input, q_index) = resources.inputs.insert_quant(tensor.clone());
-                let input = FuseArg::Input(new_input, precision, LayoutInfo::Unknown);
-                let scales = FuseArg::Input(q_index, precision_scales, LayoutInfo::Unknown);
 
-                // Important to flag that there is a read, even if no operation is registered.
-                if let Entry::Vacant(e) = self.reads.entry(tensor.id) {
-                    e.insert(Vec::new());
-                };
-
-                QuantInput::Quantized {
-                    values: input,
-                    params: scales,
-                }
+            QuantInput::Quantized {
+                values: input,
+                params: scales,
             }
         };
 
@@ -421,12 +413,11 @@ impl FuseBlockBuilder {
             if let Some(local) = self.locals.get_any_precision(tensor.id) {
                 let out_index = outputs.insert(*precision, tensor.clone());
 
-                let ops = match writes.get_mut(&tensor.id) {
-                    Some(ops) => ops,
-                    None => {
-                        writes.insert(tensor.id, Vec::new());
-                        writes.get_mut(&tensor.id).unwrap()
-                    }
+                let ops = if let Some(ops) = writes.get_mut(&tensor.id) {
+                    ops
+                } else {
+                    writes.insert(tensor.id, Vec::new());
+                    writes.get_mut(&tensor.id).unwrap()
                 };
 
                 ops.push(FuseOp::Assign(UnaryFuseArgs {
@@ -502,7 +493,7 @@ impl LocalVariablePool {
     }
 
     fn get_any_precision(&self, tensor_id: TensorId) -> Option<FuseArg> {
-        for (precision, indexes) in self.values.iter() {
+        for (precision, indexes) in &self.values {
             if let Some(index) = indexes.get(&tensor_id) {
                 return Some(FuseArg::BlockLocal {
                     pos: *index,

--- a/crates/burn-cubecl-fusion/src/engine/trace/fuser.rs
+++ b/crates/burn-cubecl-fusion/src/engine/trace/fuser.rs
@@ -31,8 +31,8 @@ impl TraceFuser {
         Self {
             settings,
             block_current: FuseBlockBuilder::new(settings),
-            blocks_previous: Default::default(),
-            resources: Default::default(),
+            blocks_previous: Vec::default(),
+            resources: FuseResources::default(),
         }
     }
 
@@ -57,7 +57,7 @@ impl TraceFuser {
     pub fn num_ops_fused(&self) -> u32 {
         let mut num_ops_fused = 0;
 
-        for block in self.blocks_previous.iter() {
+        for block in &self.blocks_previous {
             num_ops_fused += block.ops.len();
         }
 
@@ -81,7 +81,7 @@ impl TraceFuser {
         let mut estimation = 1; // Metadata takes one.
 
         // We assume we are not going to write multiple times in the same output buffer.
-        for b in self.blocks_previous.iter() {
+        for b in &self.blocks_previous {
             estimation += b.tensor_writes(&self.resources, &mut buffers).len() as u32;
         }
 
@@ -113,15 +113,14 @@ impl TraceFuser {
     ) -> FuseArg {
         let block = &mut self.blocks_previous[block_pos];
 
-        let src_arg = match block.multi_block_variable(block_pos, tensor, global) {
-            Some(val) => val,
-            None => {
-                // We try to read the input if not present.
-                block.input(tensor, &mut self.resources);
-                block
-                    .multi_block_variable(block_pos, tensor, global)
-                    .unwrap()
-            }
+        let src_arg = if let Some(val) = block.multi_block_variable(block_pos, tensor, global) {
+            val
+        } else {
+            // We try to read the input if not present.
+            block.input(tensor, &mut self.resources);
+            block
+                .multi_block_variable(block_pos, tensor, global)
+                .unwrap()
         };
 
         self.resources.outputs.update(tensor);
@@ -169,9 +168,10 @@ impl TraceFuser {
     ///
     /// It is therefore the responsibility of the operation to read the given tensor.
     pub fn input_unhandled(&mut self, tensor: &TensorIr) -> FuseArg {
-        if self.resources.indexed.contains_key(&tensor.id) {
-            panic!("Can't add a new input that is already used in an index operation");
-        }
+        assert!(
+            !self.resources.indexed.contains_key(&tensor.id),
+            "Can't add a new input that is already used in an index operation"
+        );
 
         self.resources.outputs.update(tensor);
 
@@ -185,9 +185,10 @@ impl TraceFuser {
 
     /// Register an input tensor.
     pub fn input_quantized_unhandled(&mut self, tensor: &TensorIr) -> Option<(FuseArg, FuseArg)> {
-        if self.resources.indexed.contains_key(&tensor.id) {
-            panic!("Can't add a new input that is already used in an index operation");
-        }
+        assert!(
+            !self.resources.indexed.contains_key(&tensor.id),
+            "Can't add a new input that is already used in an index operation"
+        );
 
         let (precision, precision_scales) = match tensor.dtype {
             DType::QFloat(scheme) => (
@@ -241,7 +242,7 @@ impl TraceFuser {
         if let Some(val) = self.resources.indexed.get(&tensor.id) {
             self.resources.outputs.update(tensor);
             return Some(val.clone());
-        };
+        }
 
         if self.resources.inputs.get(tensor.id).is_some() {
             return None;
@@ -317,7 +318,7 @@ impl TraceFuser {
             blocks.push(block);
         };
 
-        for block in self.blocks_previous.iter() {
+        for block in &self.blocks_previous {
             register_block(block);
         }
         self.block_current.shape_ref = shape_ref;

--- a/crates/burn-cubecl-fusion/src/optim/base.rs
+++ b/crates/burn-cubecl-fusion/src/optim/base.rs
@@ -60,11 +60,13 @@ impl<R: Runtime> CubeOptimization<R> {
     }
 
     /// The optimization's [name](FusedOperation::NAME).
+    #[must_use]
     pub fn name(&self) -> &'static str {
         self.optimization.name()
     }
 
     /// The number of operations fused.
+    #[must_use]
     pub fn num_ops_fused(&self) -> usize {
         self.optimization.num_ops_fused()
     }
@@ -75,11 +77,12 @@ impl<R: Runtime> CubeOptimization<R> {
         context: &mut Context<CubeFusionHandle<R>>,
         fallback: &dyn Fn(usize) -> Box<dyn FallbackOperation<R>>,
     ) {
-        self.optimization.run(context, fallback)
+        self.optimization.run(context, fallback);
     }
 
     /// Serialize the optimization: its name plus its
     /// [state](FusedOperation::to_state) encoded as bytes.
+    #[must_use]
     pub fn to_state(&self) -> CubeOptimizationState {
         self.optimization.to_state()
     }
@@ -138,7 +141,7 @@ impl<R: Runtime, O: FusedOperation<R>> DynFusedOperation<R> for O {
         context: &mut Context<CubeFusionHandle<R>>,
         fallback: &dyn Fn(usize) -> Box<dyn FallbackOperation<R>>,
     ) {
-        FusedOperation::run(self, context, fallback)
+        FusedOperation::run(self, context, fallback);
     }
 
     fn to_state(&self) -> CubeOptimizationState {
@@ -173,6 +176,7 @@ impl CubeOptimizationState {
     ///
     /// When the bytes don't decode as `T` — the state was produced by a
     /// different optimization sharing the name, or by an incompatible version.
+    #[must_use]
     pub fn decode<T: DeserializeOwned>(&self) -> T {
         rmp_serde::from_slice(&self.state).unwrap_or_else(|err| {
             panic!(

--- a/crates/burn-cubecl-fusion/src/optim/elemwise/fuser.rs
+++ b/crates/burn-cubecl-fusion/src/optim/elemwise/fuser.rs
@@ -68,7 +68,7 @@ impl<R: Runtime> OperationFuser<CubeOptimization<R>> for ElementWiseFuser<R> {
     }
 
     fn reset(&mut self) {
-        self.fuser.reset()
+        self.fuser.reset();
     }
 
     fn status(&self) -> burn_fusion::FuserStatus {

--- a/crates/burn-cubecl-fusion/src/optim/elemwise/optimization.rs
+++ b/crates/burn-cubecl-fusion/src/optim/elemwise/optimization.rs
@@ -137,7 +137,7 @@ fn elemwise_fuse(
     let length = ref_len(inputs, &*outputs, &locals, &config);
 
     if pos < length {
-        fuse_on_write::<f32, DynSize>(inputs, outputs, &mut locals, pos, values, args, &config)
+        fuse_on_write::<f32, DynSize>(inputs, outputs, &mut locals, pos, values, args, &config);
     }
 }
 
@@ -161,7 +161,7 @@ impl<R: Runtime> FusedOperation<R> for ElemwiseOptimization<R> {
         context: &mut Context<CubeFusionHandle<R>>,
         _fallback: &dyn Fn(usize) -> Box<dyn FallbackOperation<R>>,
     ) {
-        Self::execute(self, context)
+        Self::execute(self, context);
     }
 
     fn to_state(&self) -> Self::State {

--- a/crates/burn-cubecl-fusion/src/optim/matmul/args.rs
+++ b/crates/burn-cubecl-fusion/src/optim/matmul/args.rs
@@ -264,7 +264,7 @@ fn global_view<E: CubePrimitive>(
         match comptime![layout_config.matrix_layout] {
             MatrixLayout::RowMajor => shape_col *= num_quants,
             MatrixLayout::ColMajor => shape_row *= num_quants,
-        };
+        }
     }
 
     let shape = (shape_row, shape_col);
@@ -323,7 +323,7 @@ fn global_view<E: CubePrimitive>(
                     GlobalScaleLayout::new_BlockScaled(BlockScaledLayout::new(
                         shape,
                         scales_layout,
-                        comptime![(block_size[0] as u32, block_size[1] as u32)],
+                        comptime![(u32::from(block_size[0]), u32::from(block_size[1]))],
                     ))
                 }
             };
@@ -418,7 +418,7 @@ struct CreateQuantView<'a, E: Numeric, N: Size> {
     _ty: PhantomData<(E, N)>,
 }
 
-impl<'a, E: Numeric, N: Size> RunWithQuantType for CreateQuantView<'a, E, N> {
+impl<E: Numeric, N: Size> RunWithQuantType for CreateQuantView<'_, E, N> {
     type Output = ViewExpand<'static, Vector<E, N>, BatchedCoords>;
 
     fn execute<Q: Scalar, S: Scalar>(self) -> Self::Output {

--- a/crates/burn-cubecl-fusion/src/optim/matmul/fuser.rs
+++ b/crates/burn-cubecl-fusion/src/optim/matmul/fuser.rs
@@ -76,22 +76,19 @@ impl<R: Runtime> OperationFuser<CubeOptimization<R>> for MatmulFuser<R> {
                 let lhs = self.matmul_arg(&op.lhs, op.out.dtype);
                 let rhs = self.matmul_arg(&op.rhs, op.out.dtype);
 
-                match (lhs, rhs) {
-                    (Some(lhs), Some(rhs)) => {
-                        let out = self.fuser.output_unhandled(&op.out);
+                if let (Some(lhs), Some(rhs)) = (lhs, rhs) {
+                    let out = self.fuser.output_unhandled(&op.out);
 
-                        self.matmul = Some(FusedMatmul::new(
-                            lhs,
-                            rhs,
-                            out,
-                            op.clone().into(),
-                            Default::default(),
-                        ));
-                    }
-                    _ => {
-                        self.fuser.close();
-                        self.fuser_fallback.close();
-                    }
+                    self.matmul = Some(FusedMatmul::new(
+                        lhs,
+                        rhs,
+                        out,
+                        op.clone().into(),
+                        Default::default(),
+                    ));
+                } else {
+                    self.fuser.close();
+                    self.fuser_fallback.close();
                 }
             } else {
                 self.fuser.close();
@@ -101,16 +98,13 @@ impl<R: Runtime> OperationFuser<CubeOptimization<R>> for MatmulFuser<R> {
             let can_register =
                 self.fuser.can_fuse(operation) && self.fuser_fallback.can_fuse(operation);
 
-            match can_register {
-                true => {
-                    self.fuser.fuse(operation);
-                    self.fuser_fallback.fuse(operation);
-                }
-                false => {
-                    self.fuser.close();
-                    self.fuser_fallback.close();
-                }
-            };
+            if can_register {
+                self.fuser.fuse(operation);
+                self.fuser_fallback.fuse(operation);
+            } else {
+                self.fuser.close();
+                self.fuser_fallback.close();
+            }
         }
     }
 

--- a/crates/burn-cubecl-fusion/src/optim/matmul/optimization.rs
+++ b/crates/burn-cubecl-fusion/src/optim/matmul/optimization.rs
@@ -189,6 +189,7 @@ impl<R: Runtime> MatmulOptimization<R> {
     }
 
     /// Number of operations fused.
+    #[must_use]
     pub fn num_ops_fused(&self) -> usize {
         self.info.num_ops_fused()
     }
@@ -210,6 +211,7 @@ impl<R: Runtime> MatmulOptimization<R> {
     }
 
     /// Convert the optimization to its [state](MatmulOptimizationState).
+    #[must_use]
     pub fn to_state(&self) -> MatmulOptimizationState {
         MatmulOptimizationState {
             trace: self.info.trace.clone(),
@@ -243,6 +245,7 @@ pub enum FusedMatmulSelector {
 
 impl FusedMatmulSelector {
     /// Not efficient, but only called once when initializing the tunables.
+    #[must_use]
     pub fn name(&self) -> String {
         let name = match self {
             FusedMatmulSelector::Simple {
@@ -310,7 +313,7 @@ impl From<MatmulSetupError> for FusedMatmulError {
     }
 }
 
-impl<'a, R: Runtime> Vectorization<R> for FusedMatmulLaunch<'a> {
+impl<R: Runtime> Vectorization<R> for FusedMatmulLaunch<'_> {
     fn axis(&self, plan: &LaunchPlan<'_, R>) -> VectorizationAxis {
         let lhs_id = self.matmul.op.lhs.id;
         let rhs_id = self.matmul.op.rhs.id;
@@ -318,7 +321,7 @@ impl<'a, R: Runtime> Vectorization<R> for FusedMatmulLaunch<'a> {
         let mut tensor_lhs = None;
         let mut tensor_rhs = None;
 
-        for input in plan.handle_inputs.iter() {
+        for input in &plan.handle_inputs {
             match input {
                 HandleInput::Normal(input) => {
                     if input.relative_id == lhs_id {
@@ -492,7 +495,7 @@ impl FusedMatmulLaunch<'_> {
                     vector_sizes,
                     &BlueprintStrategy::Inferred(args),
                 ) {
-                    Ok(_) => Ok(()),
+                    Ok(()) => Ok(()),
                     Err(err) => Err(FusedMatmulError::LaunchError(err)),
                 }
             }
@@ -524,7 +527,7 @@ impl FusedMatmulLaunch<'_> {
                     vector_sizes,
                     &BlueprintStrategy::Inferred(args),
                 ) {
-                    Ok(_) => Ok(()),
+                    Ok(()) => Ok(()),
                     Err(err) => Err(FusedMatmulError::LaunchError(err)),
                 }
             }
@@ -560,7 +563,7 @@ impl FusedMatmulLaunch<'_> {
                     vector_sizes,
                     &BlueprintStrategy::Inferred(args),
                 ) {
-                    Ok(_) => Ok(()),
+                    Ok(()) => Ok(()),
                     Err(err) => Err(FusedMatmulError::LaunchError(err)),
                 }
             }
@@ -581,7 +584,7 @@ impl FusedMatmulLaunch<'_> {
                     vector_sizes,
                     &Default::default(),
                 ) {
-                    Ok(_) => Ok(()),
+                    Ok(()) => Ok(()),
                     Err(err) => Err(FusedMatmulError::LaunchError(err)),
                 }
             }
@@ -602,7 +605,7 @@ impl FusedMatmulLaunch<'_> {
                     vector_sizes,
                     &Default::default(),
                 ) {
-                    Ok(_) => Ok(()),
+                    Ok(()) => Ok(()),
                     Err(err) => Err(FusedMatmulError::LaunchError(err)),
                 }
             }
@@ -623,7 +626,7 @@ impl FusedMatmulLaunch<'_> {
                     vector_sizes,
                     &Default::default(),
                 ) {
-                    Ok(_) => Ok(()),
+                    Ok(()) => Ok(()),
                     Err(err) => Err(FusedMatmulError::LaunchError(err)),
                 }
             }
@@ -644,7 +647,7 @@ impl FusedMatmulLaunch<'_> {
                     vector_sizes,
                     &Default::default(),
                 ) {
-                    Ok(_) => Ok(()),
+                    Ok(()) => Ok(()),
                     Err(err) => Err(FusedMatmulError::LaunchError(err)),
                 }
             }
@@ -665,7 +668,7 @@ impl FusedMatmulLaunch<'_> {
                     vector_sizes,
                     &Default::default(),
                 ) {
-                    Ok(_) => Ok(()),
+                    Ok(()) => Ok(()),
                     Err(err) => Err(FusedMatmulError::LaunchError(err)),
                 }
             }
@@ -686,7 +689,7 @@ impl FusedMatmulLaunch<'_> {
                     vector_sizes,
                     &Default::default(),
                 ) {
-                    Ok(_) => Ok(()),
+                    Ok(()) => Ok(()),
                     Err(err) => Err(FusedMatmulError::LaunchError(err)),
                 }
             }
@@ -739,7 +742,7 @@ impl<R: Runtime> FusedOperation<R> for MatmulOptimization<R> {
         context: &mut Context<CubeFusionHandle<R>>,
         fallback: &dyn Fn(usize) -> Box<dyn FallbackOperation<R>>,
     ) {
-        Self::execute(self, context, |index| fallback(index))
+        Self::execute(self, context, |index| fallback(index));
     }
 
     fn to_state(&self) -> Self::State {

--- a/crates/burn-cubecl-fusion/src/optim/matmul/tune.rs
+++ b/crates/burn-cubecl-fusion/src/optim/matmul/tune.rs
@@ -180,9 +180,12 @@ pub fn fused_matmul_autotune<R: Runtime>(
                 Tunable::new(&selector.name(), move |input| {
                     tune_fused::<R>(input, selector)
                 })
-                .group(&gemv, move |key| match double_buf {
-                    false => PRIORITY_MAX,
-                    true => double_buffering_priority(key, PRIORITY_MAX, PRIORITY_HIGH),
+                .group(&gemv, move |key| {
+                    if double_buf {
+                        double_buffering_priority(key, PRIORITY_MAX, PRIORITY_HIGH)
+                    } else {
+                        PRIORITY_MAX
+                    }
                 }),
             );
         }
@@ -196,9 +199,12 @@ pub fn fused_matmul_autotune<R: Runtime>(
                 Tunable::new(&selector.name(), move |input| {
                     tune_fused::<R>(input, selector)
                 })
-                .group(&unit, move |key| match double_buf {
-                    false => PRIORITY_MAX,
-                    true => double_buffering_priority(key, PRIORITY_MAX, PRIORITY_HIGH),
+                .group(&unit, move |key| {
+                    if double_buf {
+                        double_buffering_priority(key, PRIORITY_MAX, PRIORITY_HIGH)
+                    } else {
+                        PRIORITY_MAX
+                    }
                 }),
             );
         }
@@ -258,9 +264,10 @@ pub fn fused_matmul_autotune<R: Runtime>(
                             return PRIORITY_MIN;
                         }
 
-                        match double_buf {
-                            false => PRIORITY_MAX,
-                            true => double_buffering_priority(key, PRIORITY_MAX, PRIORITY_HIGH),
+                        if double_buf {
+                            double_buffering_priority(key, PRIORITY_MAX, PRIORITY_HIGH)
+                        } else {
+                            PRIORITY_MAX
                         }
                     };
 

--- a/crates/burn-cubecl-fusion/src/optim/nhwc_relayout/fuser.rs
+++ b/crates/burn-cubecl-fusion/src/optim/nhwc_relayout/fuser.rs
@@ -35,7 +35,10 @@ fn permutation(rank: usize) -> Shape {
 
 /// Collect tensor that should be relayed out to NHWC for a given module operation.
 fn nhwc_relayout_tensor(ir: &ModuleOperationIr) -> Option<&TensorIr> {
-    use ModuleOperationIr::*;
+    use ModuleOperationIr::{
+        AdaptiveAvgPool1d, AdaptiveAvgPool2d, AvgPool1d, AvgPool2d, Interpolate, MaxPool1d,
+        MaxPool1dWithIndices, MaxPool2d, MaxPool2dWithIndices,
+    };
 
     match ir {
         AvgPool1d(op) => Some(&op.x),
@@ -106,7 +109,7 @@ impl<R: Runtime> OperationFuser<CubeOptimization<R>> for NHWCRelayoutFuser<R> {
                 self.fuser.fuse(operation);
                 self.status = self.fuser.status();
             }
-        };
+        }
     }
 
     fn finish(&mut self) -> CubeOptimization<R> {

--- a/crates/burn-cubecl-fusion/src/optim/nhwc_relayout/optimization.rs
+++ b/crates/burn-cubecl-fusion/src/optim/nhwc_relayout/optimization.rs
@@ -83,7 +83,7 @@ impl<R: Runtime> FusedOperation<R> for NHWCRelayoutOptimization<R> {
         context: &mut Context<CubeFusionHandle<R>>,
         fallback: &dyn Fn(usize) -> Box<dyn FallbackOperation<R>>,
     ) {
-        Self::execute(self, context, |index| fallback(index))
+        Self::execute(self, context, |index| fallback(index));
     }
 
     fn to_state(&self) -> Self::State {

--- a/crates/burn-cubecl-fusion/src/optim/reduce/fuser.rs
+++ b/crates/burn-cubecl-fusion/src/optim/reduce/fuser.rs
@@ -82,20 +82,17 @@ impl<R: Runtime> ReduceFuser<R> {
     }
 
     pub fn reduce_info(&self) -> ReduceFuserInfo {
-        match &self.reduce {
-            Some(reduce) => {
-                let shape_input_id = reduce.op.input.shape.clone();
-                let axis = reduce.axis;
+        if let Some(reduce) = &self.reduce {
+            let shape_input_id = reduce.op.input.shape.clone();
+            let axis = reduce.axis;
 
-                ReduceFuserInfo::FusedReduce {
-                    shape_input_id,
-                    axis,
-                }
+            ReduceFuserInfo::FusedReduce {
+                shape_input_id,
+                axis,
             }
-            None => {
-                let shape_id = self.fuser_read_fallback.current_output_shape.clone();
-                ReduceFuserInfo::FusedElemwise { shape_id }
-            }
+        } else {
+            let shape_id = self.fuser_read_fallback.current_output_shape.clone();
+            ReduceFuserInfo::FusedElemwise { shape_id }
         }
     }
 
@@ -163,32 +160,26 @@ impl<R: Runtime> ReduceFuser<R> {
         let can_register =
             self.fuser.can_fuse(operation) && self.fuser_read_fallback.can_fuse(operation);
 
-        match can_register {
-            true => {
-                self.fuser.fuse(operation);
-                self.fuser_read_fallback.fuse(operation);
-            }
-            false => {
-                self.fuser.close();
-                self.fuser_read_fallback.close();
-            }
-        };
+        if can_register {
+            self.fuser.fuse(operation);
+            self.fuser_read_fallback.fuse(operation);
+        } else {
+            self.fuser.close();
+            self.fuser_read_fallback.close();
+        }
     }
 
     fn on_elemwise_write(&mut self, operation: &OperationIr) {
         let can_register =
             self.fuser.can_fuse(operation) && self.fuser_write_fallback.can_fuse(operation);
 
-        match can_register {
-            true => {
-                self.fuser.fuse(operation);
-                self.fuser_write_fallback.fuse(operation);
-            }
-            false => {
-                self.fuser.close();
-                self.fuser_write_fallback.close();
-            }
-        };
+        if can_register {
+            self.fuser.fuse(operation);
+            self.fuser_write_fallback.fuse(operation);
+        } else {
+            self.fuser.close();
+            self.fuser_write_fallback.close();
+        }
     }
 
     /// Build the reduce optimization from the fused operations. The typed
@@ -251,7 +242,7 @@ impl<R: Runtime> OperationFuser<CubeOptimization<R>> for ReduceFuser<R> {
                     _ => {
                         self.on_elemwise_read(operation);
                     }
-                };
+                }
             } else if let OperationIr::NumericInt(_, op) = operation {
                 match op {
                     NumericOperationIr::SumDim(op) => {
@@ -281,7 +272,7 @@ impl<R: Runtime> OperationFuser<CubeOptimization<R>> for ReduceFuser<R> {
                     _ => {
                         self.on_elemwise_read(operation);
                     }
-                };
+                }
             } else if let OperationIr::BaseBool(op)
             | OperationIr::BaseFloat(op)
             | OperationIr::BaseInt(op) = operation
@@ -327,7 +318,7 @@ impl<R: Runtime> OperationFuser<CubeOptimization<R>> for ReduceFuser<R> {
     }
 
     fn len(&self) -> usize {
-        self.fuser.len() + if self.reduce.is_some() { 1 } else { 0 }
+        self.fuser.len() + usize::from(self.reduce.is_some())
     }
 
     fn clone_dyn(&self) -> Box<dyn OperationFuser<CubeOptimization<R>>> {

--- a/crates/burn-cubecl-fusion/src/optim/reduce/optimization.rs
+++ b/crates/burn-cubecl-fusion/src/optim/reduce/optimization.rs
@@ -89,7 +89,7 @@ impl<R: Runtime> ReduceOptimizationInfo<R> {
 pub enum ReduceSettings {
     Always,
     /// We only activate fuse-on-write when the reduction isn't on the last dimension, otherwise
-    /// vectorization is impossible. Only [VectorizationMode::Perpendicular] supports vectorization.
+    /// vectorization is impossible. Only [`VectorizationMode::Perpendicular`] supports vectorization.
     ///
     /// We could still fuse some output operations, but it would probably lead to worse performance.
     OnlyParallel,
@@ -280,10 +280,12 @@ impl<R: Runtime> ReduceOptimization<R> {
         }
     }
 
+    #[must_use]
     pub fn num_output_buffers(&self) -> usize {
         self.info.trace_read_fallback.resources.outputs.len()
     }
 
+    #[must_use]
     pub fn to_state(&self) -> ReduceOptimizationState {
         ReduceOptimizationState {
             trace: self.info.trace.clone(),
@@ -317,6 +319,7 @@ impl<R: Runtime> ReduceOptimization<R> {
     }
 
     /// Returns the number of output buffers added by fusion.
+    #[must_use]
     pub fn num_ops_fused(&self) -> usize {
         self.info.len
     }
@@ -348,9 +351,10 @@ impl<R: Runtime> TraceRunner<R> for FusedReduceLaunch<'_> {
             .map(|(i, s)| if i == self.reduce.axis { 1 } else { *s })
             .product();
 
-        let vectorization_mode = match self.reduce.axis == config_read.rank - 1 {
-            true => VectorizationMode::Parallel,
-            false => VectorizationMode::Perpendicular,
+        let vectorization_mode = if self.reduce.axis == config_read.rank - 1 {
+            VectorizationMode::Parallel
+        } else {
+            VectorizationMode::Perpendicular
         };
         let address_type = inputs
             .required_address_type()
@@ -423,7 +427,7 @@ impl<R: Runtime> TraceRunner<R> for FusedReduceLaunch<'_> {
         );
 
         match result {
-            Ok(_) => Ok(()),
+            Ok(()) => Ok(()),
             Err(err) => Err(FusedReduceError::Reduce(ReduceError::Launch(err))),
         }
     }
@@ -493,7 +497,7 @@ fn launch_reduce<Run: Runtime>(
             dtype_to_storage_type(dtype_input),
             dtype_to_storage_type(dtype_output),
             dtype_to_storage_type(dtype_acc),
-        )
+        );
     };
 
     Ok(())
@@ -561,7 +565,7 @@ impl<R: Runtime> FusedOperation<R> for ReduceOptimization<R> {
         context: &mut Context<CubeFusionHandle<R>>,
         fallback: &dyn Fn(usize) -> Box<dyn FallbackOperation<R>>,
     ) {
-        Self::execute(self, context, |index| fallback(index))
+        Self::execute(self, context, |index| fallback(index));
     }
 
     fn to_state(&self) -> Self::State {

--- a/crates/burn-cubecl-fusion/src/optim/reduce_broadcasted/fuser/base.rs
+++ b/crates/burn-cubecl-fusion/src/optim/reduce_broadcasted/fuser/base.rs
@@ -78,7 +78,7 @@ impl<R: Runtime> ReduceBroadcastedFuser<R> {
 
         let mut num_ops_fallback = 0;
 
-        for f in fallbacks.iter() {
+        for f in &fallbacks {
             num_ops_fallback += match f {
                 ReduceBlockOptimInfo::Reduce(info) => info.len,
                 ReduceBlockOptimInfo::Elemwise(info) => info.num_ops_fused(),
@@ -122,13 +122,13 @@ impl<R: Runtime> ReduceBroadcastedFuser<R> {
                 axis,
             } => {
                 // Only support last axis for now.
-                if axis != shape_input_id.len() - 1 {
-                    self.state = ReduceBroadcastedStatus::Abort;
-                } else {
+                if axis == shape_input_id.len() - 1 {
                     self.state = ReduceBroadcastedStatus::Init {
                         shape_id: shape_input_id,
                         axis,
                     };
+                } else {
+                    self.state = ReduceBroadcastedStatus::Abort;
                 }
             }
             ReduceFuserInfo::FusedElemwise { .. } => {}
@@ -191,7 +191,7 @@ impl<R: Runtime> OperationFuser<CubeOptimization<R>> for ReduceBroadcastedFuser<
                 return FuserStatus::Closed;
             }
             _ => {}
-        };
+        }
 
         let fuser = self.blocks.last().unwrap();
         fuser.fuser.status()
@@ -206,7 +206,7 @@ impl<R: Runtime> OperationFuser<CubeOptimization<R>> for ReduceBroadcastedFuser<
             _ => true,
         };
         let mut props = FuserProperties { score: 0, ready };
-        for block in self.blocks.iter() {
+        for block in &self.blocks {
             let p = block.properties();
             props.score += p.score;
             props.ready = p.ready && props.ready;

--- a/crates/burn-cubecl-fusion/src/optim/reduce_broadcasted/fuser/block.rs
+++ b/crates/burn-cubecl-fusion/src/optim/reduce_broadcasted/fuser/block.rs
@@ -14,12 +14,12 @@ use std::sync::Arc;
 /// When the block kind is reduce, it supports fuse-on-read and fuse-on-write fusion.
 /// Broadcasting isn't supported; another block should handle it instead.
 pub struct ReduceBlockFuser<R: Runtime> {
-    /// We use [ReduceFuser] for both elementwise and reduce blocks, keeping only the
+    /// We use [`ReduceFuser`] for both elementwise and reduce blocks, keeping only the
     /// fuse-on-read trace if the block is tagged as elementwise.
     ///
     /// # Notes
     ///
-    /// A single elementwise block can only exist at the end of a full [ReduceBlockFuser],
+    /// A single elementwise block can only exist at the end of a full [`ReduceBlockFuser`],
     /// otherwise the optimization will be included in the reduce fusion block.
     pub fuser: ReduceFuser<R>,
     pub(crate) ops: Vec<OperationIr>,
@@ -43,10 +43,10 @@ pub enum ReduceBroadcastedStatus {
     Abort,
 }
 
-/// The [ReduceBlockFuser] capacity to accept an [OperationIr].
+/// The [`ReduceBlockFuser`] capacity to accept an [`OperationIr`].
 #[derive(Clone, Copy, Debug)]
 pub enum ReduceBlockFusionAnalysis {
-    /// The operation can be fused; call [ReduceBlockFuser::fuse()].
+    /// The operation can be fused; call [`ReduceBlockFuser::fuse()`].
     Accept,
     /// The operation cannot be fused; the optimization should close.
     Refuse,
@@ -152,7 +152,7 @@ impl<R: Runtime> ReduceBlockFuser<R> {
     ///
     /// # Warning
     ///
-    /// Ensure [Self::analyze()] is called before this function to confirm the operation is accepted.
+    /// Ensure [`Self::analyze()`] is called before this function to confirm the operation is accepted.
     pub fn fuse(&mut self, op: &OperationIr) {
         self.fuser.fuse(op);
         self.ops.push(op.clone());

--- a/crates/burn-cubecl-fusion/src/optim/reduce_broadcasted/fuser/full.rs
+++ b/crates/burn-cubecl-fusion/src/optim/reduce_broadcasted/fuser/full.rs
@@ -63,7 +63,7 @@ impl ReduceBroadcastedFullFuser {
     pub fn num_ops_fused(&self) -> usize {
         let mut fused = self.fuser.num_ops;
 
-        for block in self.blocks.iter() {
+        for block in &self.blocks {
             match block {
                 ReduceBlockKind::Elemwise => {}
                 // The base fuser doesn't hold the reduce ops.
@@ -79,7 +79,7 @@ impl ReduceBroadcastedFullFuser {
         let mut reduce_axis = 0;
         let mut blocks = Vec::new();
 
-        for block in self.blocks.iter() {
+        for block in &self.blocks {
             match block {
                 ReduceBlockKind::Elemwise => {}
                 ReduceBlockKind::Reduce { reduce, .. } => {
@@ -116,7 +116,7 @@ impl ReduceBroadcastedFullFuser {
         }
     }
 
-    /// Registers a [ReduceBlockFuser] to build the trace.
+    /// Registers a [`ReduceBlockFuser`] to build the trace.
     pub fn register<R: Runtime>(&mut self, block: &ReduceBlockFuser<R>) {
         // Helper to close previous blocks if necessary
         if !self.fuser.is_empty() {

--- a/crates/burn-cubecl-fusion/src/optim/reduce_broadcasted/fuser/full_analyzer.rs
+++ b/crates/burn-cubecl-fusion/src/optim/reduce_broadcasted/fuser/full_analyzer.rs
@@ -14,7 +14,7 @@ impl FullFuserAnalyzer {
     pub fn new<R: Runtime>(blocks: &[ReduceBlockFuser<R>]) -> Self {
         let mut state = AnalysisState::default();
 
-        for block in blocks.iter() {
+        for block in blocks {
             for (pos, op) in block.ops.iter().enumerate() {
                 let potential_from_previous_blocks = op.inputs();
                 let potential_to_next_blocks = op.outputs();

--- a/crates/burn-cubecl-fusion/src/optim/reduce_broadcasted/launch.rs
+++ b/crates/burn-cubecl-fusion/src/optim/reduce_broadcasted/launch.rs
@@ -120,11 +120,12 @@ impl<R: Runtime> TraceRunner<R> for FusedReduceBroadcastedLaunch<'_> {
             blocks.push(arg);
         }
 
-        let block_end = match configs.len() > index {
-            true => ComptimeOptionArgs::Some(ElemwiseFuseBlockLaunch::new(
+        let block_end = if configs.len() > index {
+            ComptimeOptionArgs::Some(ElemwiseFuseBlockLaunch::new(
                 configs.last().cloned().unwrap(),
-            )),
-            false => ComptimeOptionArgs::None,
+            ))
+        } else {
+            ComptimeOptionArgs::None
         };
 
         let out_vec_axis = output_vectorization_axis(

--- a/crates/burn-cubecl-fusion/src/optim/reduce_broadcasted/optimization.rs
+++ b/crates/burn-cubecl-fusion/src/optim/reduce_broadcasted/optimization.rs
@@ -127,11 +127,11 @@ impl<R: Runtime> ReduceBroadcastedOptimizationTuneArg<R> {
 
         launcher
             .launch(&self.client, &self.device, context)
-            .map_err(|err| TraceError::RunnerError(format!("{:?}", err)))
+            .map_err(|err| TraceError::RunnerError(format!("{err:?}")))
     }
 
     pub fn execute_fallback(&self, context: &mut Context<CubeFusionHandle<R>>) {
-        for fallback in self.fallbacks.iter() {
+        for fallback in &self.fallbacks {
             fallback.execute_fallback(context);
         }
     }
@@ -186,13 +186,14 @@ impl<R: Runtime> ReduceBroadcastedOptimization<R> {
         arg.execute_fallback(context);
     }
 
+    #[must_use]
     pub fn to_state(&self) -> ReduceBroadcastedOptimizationState {
         ReduceBroadcastedOptimizationState {
             fallbacks: self
                 .info
                 .fallbacks
                 .iter()
-                .map(|info| info.to_state())
+                .map(ReduceBlockOptimInfo::to_state)
                 .collect(),
             broadcasted: self.info.broadcasted.as_ref().clone(),
             num_ops: self.num_ops,
@@ -214,6 +215,7 @@ impl<R: Runtime> ReduceBroadcastedOptimization<R> {
     }
 
     /// Returns the number of output buffers added by fusion.
+    #[must_use]
     pub fn num_ops_fused(&self) -> usize {
         self.num_ops
     }
@@ -256,7 +258,7 @@ impl<R: Runtime> FusedOperation<R> for ReduceBroadcastedOptimization<R> {
         context: &mut Context<CubeFusionHandle<R>>,
         fallback: &dyn Fn(usize) -> Box<dyn FallbackOperation<R>>,
     ) {
-        Self::execute(self, context, |index| fallback(index))
+        Self::execute(self, context, |index| fallback(index));
     }
 
     fn to_state(&self) -> Self::State {

--- a/crates/burn-cubecl-fusion/src/optim/reduce_broadcasted/tune.rs
+++ b/crates/burn-cubecl-fusion/src/optim/reduce_broadcasted/tune.rs
@@ -104,7 +104,7 @@ pub(crate) fn create_key<R: Runtime>(
     // Sum up complexity metrics across all blocks in the fused trace.
     let (mut num_reads, mut num_writes, mut num_ops) = (0, 0, 0);
 
-    for block in opt.broadcasted.trace.blocks.iter() {
+    for block in &opt.broadcasted.trace.blocks {
         num_reads += block.reads.len();
         num_writes += block.writes.len();
         num_ops += block.ops.len();

--- a/crates/burn-cubecl-fusion/src/optim/reduce_broadcasted/unit.rs
+++ b/crates/burn-cubecl-fusion/src/optim/reduce_broadcasted/unit.rs
@@ -191,7 +191,7 @@ fn reduce_many(
                 values,
                 args,
                 &block.config.clone(),
-            )
+            );
         }
     }
 }

--- a/crates/burn-cubecl-fusion/src/tune.rs
+++ b/crates/burn-cubecl-fusion/src/tune.rs
@@ -163,7 +163,7 @@ impl<'a, R: Runtime, O> TuneInput<'a, R, O> {
     }
 }
 
-impl<'a, R: Runtime, O> Clone for TuneInput<'a, R, O> {
+impl<R: Runtime, O> Clone for TuneInput<'_, R, O> {
     fn clone(&self) -> Self {
         // `Original` clones come from the wasm fallback path (`operations.fastest(i)
         // .execute(inputs.clone())`) and must track outputs. `Fork` clones inherit the
@@ -182,7 +182,7 @@ impl<'a, R: Runtime, O> Clone for TuneInput<'a, R, O> {
     }
 }
 
-impl<'a, R: Runtime, O> Drop for TuneInput<'a, R, O> {
+impl<R: Runtime, O> Drop for TuneInput<'_, R, O> {
     fn drop(&mut self) {
         match &mut self.state {
             TuneState::Original {


### PR DESCRIPTION
This PR applies safe mechanical clippy::pedantic cleanups to crates/burn-cubecl-fusion.

Summary of changes:
- Replace verbose Default::default() with explicit Vec::default() / FuseResources::default().
- Remove redundant borrows and simplify patterns.
- Merge identical match arms where safe.
- Apply formatting fixes.

Cast truncation warnings and API-affecting lints were intentionally left untouched.