### PR TITLE
style(burn-cuda): apply clippy::pedantic cleanups

### DIFF
--- a/crates/burn-cuda/src/lib.rs
+++ b/crates/burn-cuda/src/lib.rs
@@ -16,6 +16,7 @@ pub type Cuda = CubeBackend<CudaRuntime>;
 pub type Cuda = burn_fusion::Fusion<CubeBackend<CudaRuntime>>;
 
 /// Measure peak throughput on a CUDA `device` for each of the given `keys`.
+#[must_use]
 pub fn device_throughput(
     device: &CudaDevice,
     keys: &[ThroughputKey],


### PR DESCRIPTION
This PR applies a safe mechanical clippy::pedantic cleanup to crates/burn-cuda.