### PR TITLE
style(burn-autodiff): apply clippy::pedantic cleanups

### DIFF
--- a/crates/burn-autodiff/src/backend.rs
+++ b/crates/burn-autodiff/src/backend.rs
@@ -52,7 +52,7 @@ impl<B: Backend, C: CheckpointStrategy> Backend for Autodiff<B, C> {
     }
 
     fn seed(device: &B::Device, seed: u64) {
-        B::seed(device, seed)
+        B::seed(device, seed);
     }
 
     fn sync(device: &B::Device) -> Result<(), ExecutionError> {
@@ -72,7 +72,7 @@ impl<B: Backend, C: CheckpointStrategy> Backend for Autodiff<B, C> {
     }
 
     fn memory_cleanup(device: &Self::Device) {
-        B::memory_cleanup(device)
+        B::memory_cleanup(device);
     }
 
     fn memory_install_pools(
@@ -110,7 +110,7 @@ impl<B: Backend, C: CheckpointStrategy> Backend for Autodiff<B, C> {
     }
 
     fn flush(device: &Self::Device) {
-        B::flush(device)
+        B::flush(device);
     }
 }
 

--- a/crates/burn-autodiff/src/checkpoint/base.rs
+++ b/crates/burn-autodiff/src/checkpoint/base.rs
@@ -9,7 +9,7 @@ use alloc::{format, vec, vec::Vec};
 use burn_std::config::{autodiff::AutodiffLogLevel, log_autodiff};
 
 #[derive(new, Debug)]
-/// Links a [NodeId] to its autodiff graph [NodeRef]
+/// Links a [`NodeId`] to its autodiff graph [`NodeRef`]
 pub(crate) struct NodeTree {
     map: HashMap<NodeId, Vec<NodeId>>,
 }
@@ -42,22 +42,22 @@ impl Checkpointer {
             format!("retrieve_node_output {node_id:?}: {num_nodes} node(s) to compute")
         });
 
-        sorted.into_iter().for_each(|node| {
+        for node in sorted {
             log_autodiff(AutodiffLogLevel::Full, move || {
                 format!("execute_retro_forward {node:?}")
             });
             self.retro_forwards
-                .execute_retro_forward(node, &mut self.backward_states)
-        });
+                .execute_retro_forward(node, &mut self.backward_states);
+        }
 
         self.backward_states.get_state::<T>(&node_id)
     }
 
-    /// Sorts the ancestors of NodeId in a way such that all parents come before their children
+    /// Sorts the ancestors of `NodeId` in a way such that all parents come before their children
     /// Useful to avoid recursivity later when mutating the states
     ///
     /// The sort on a compute bound state or a memory bound that is already computed is trivial.
-    /// The match on State::Computed also serves as a stopping criterion for the sort,
+    /// The match on `State::Computed` also serves as a stopping criterion for the sort,
     /// we don't need to look higher than that during recursivity.
     fn topological_sort(&self, node_id: NodeId) -> Vec<NodeId> {
         match self.backward_states.get_state_ref(&node_id) {
@@ -69,7 +69,7 @@ impl Checkpointer {
                         let parent_sorted = self.topological_sort(parent_node);
                         for ps in parent_sorted {
                             if !sorted.contains(&ps) {
-                                sorted.push(ps)
+                                sorted.push(ps);
                             }
                         }
                     }

--- a/crates/burn-autodiff/src/checkpoint/builder.rs
+++ b/crates/burn-autodiff/src/checkpoint/builder.rs
@@ -21,7 +21,7 @@ use super::{
 };
 
 #[derive(Debug)]
-/// Determines if a node should checkpoint its computed output or its retro_forward for recomputation
+/// Determines if a node should checkpoint its computed output or its `retro_forward` for recomputation
 /// The action is normally created by the child of the node, once the node is determined to be needed
 pub enum CheckpointingAction {
     /// The node's already computed output should be saved
@@ -50,8 +50,8 @@ impl CheckpointingAction {
             CheckpointingAction::Computed {
                 node_id: node_ref,
                 state_content: _,
-            } => *node_ref,
-            CheckpointingAction::Recompute {
+            }
+            | CheckpointingAction::Recompute {
                 node_id: node_ref,
                 retro_forward: _,
             } => *node_ref,
@@ -67,7 +67,7 @@ pub struct CheckpointerBuilder {
     backup_actions: Vec<CheckpointingAction>,
 }
 
-/// Determines if a checkpoint should impact the n_required values (Main)
+/// Determines if a checkpoint should impact the `n_required` values (Main)
 /// or if it should just keep the state in case it's required (Backup)
 ///
 pub(crate) enum ActionType {
@@ -75,7 +75,7 @@ pub(crate) enum ActionType {
     Explicit,
     /// Backup actions are not always needed. They exist to save the output of an operation
     /// whose child is memory bound, in case the state is indirectly needed when computing
-    /// the child's retro_forward. If no explicit action ever asks for the child's output, then
+    /// the child's `retro_forward`. If no explicit action ever asks for the child's output, then
     /// the backup output will go out of scope when the checkpointer is built.
     Backup,
 }
@@ -95,23 +95,23 @@ impl CheckpointerBuilder {
                 action_list.push(CheckpointingAction::Computed {
                     node_id: tensor.node.id,
                     state_content: Box::new(tensor.primitive.clone()),
-                })
+                });
             }
             ComputingProperty::MemoryBound { retro_forward } => {
                 action_list.push(CheckpointingAction::Recompute {
                     node_id: tensor.node.id,
                     retro_forward: retro_forward.clone(),
-                })
+                });
             }
         }
     }
 
     pub(crate) fn extend(&mut self, other: CheckpointerBuilder) {
         for other_action in other.explicit_actions {
-            self.explicit_actions.push(other_action)
+            self.explicit_actions.push(other_action);
         }
         for other_unsure in other.backup_actions {
-            self.backup_actions.push(other_unsure)
+            self.backup_actions.push(other_unsure);
         }
     }
 
@@ -167,7 +167,7 @@ impl CheckpointerBuilder {
     ) -> HashMap<NodeId, usize> {
         let mut n_required_map = HashMap::<NodeId, usize>::default();
 
-        for action in self.explicit_actions.iter() {
+        for action in &self.explicit_actions {
             match action {
                 CheckpointingAction::Computed {
                     node_id: node_ref,
@@ -181,7 +181,7 @@ impl CheckpointerBuilder {
                         None => {
                             n_required_map.insert(id, 1);
                         }
-                    };
+                    }
                 }
                 CheckpointingAction::Recompute {
                     node_id: node_ref,
@@ -215,29 +215,34 @@ impl CheckpointerBuilder {
             // so we check there first, otherwise it will be in backup.
             // Technically it can be there several times but can never be of both types, so we can assume the first we find is fine
 
-            let action = match self
-                .explicit_actions
-                .iter()
-                .position(|action| action.id() == node_id)
-            {
-                Some(pos) => self.explicit_actions.remove(pos),
-                None => {
+            let action =
+                if let Some(pos) = self
+                    .explicit_actions
+                    .iter()
+                    .position(|action| action.id() == node_id)
+                {
+                    self.explicit_actions.remove(pos)
+                } else {
                     let pos = self
                         .backup_actions
                         .iter()
                         .position(|action| action.id() == node_id);
                     self.backup_actions.remove(pos.unwrap_or_else(|| {
-                        panic!("Node {:?} is needed but never checkpointed", node_id)
+                        panic!("Node {node_id:?} is needed but never checkpointed")
                     }))
-                }
-            };
+                };
 
             match action {
                 CheckpointingAction::Computed {
                     node_id: _,
                     state_content,
                 } => {
-                    self.checkpoint_compute(backward_states_map, node_id, state_content, n_required)
+                    self.checkpoint_compute(
+                        backward_states_map,
+                        node_id,
+                        state_content,
+                        n_required,
+                    );
                 }
                 CheckpointingAction::Recompute {
                     node_id: _,
@@ -249,7 +254,7 @@ impl CheckpointerBuilder {
                     retro_forward,
                     n_required,
                 ),
-            };
+            }
         }
     }
 
@@ -259,23 +264,15 @@ impl CheckpointerBuilder {
         node_tree: &NodeTree,
         stop_nodes: &Vec<NodeId>,
     ) {
-        match n_required_map.remove(&id) {
-            Some(n) => {
-                n_required_map.insert(id, n + 1);
-            }
-            None => {
-                n_required_map.insert(id, 1);
-                if !stop_nodes.contains(&id)
-                    && let Some(parents) = node_tree.parents(&id)
-                {
-                    for p in parents {
-                        Self::update_n_required_of_parents(
-                            p,
-                            n_required_map,
-                            node_tree,
-                            stop_nodes,
-                        );
-                    }
+        if let Some(n) = n_required_map.remove(&id) {
+            n_required_map.insert(id, n + 1);
+        } else {
+            n_required_map.insert(id, 1);
+            if !stop_nodes.contains(&id)
+                && let Some(parents) = node_tree.parents(&id)
+            {
+                for p in parents {
+                    Self::update_n_required_of_parents(p, n_required_map, node_tree, stop_nodes);
                 }
             }
         }

--- a/crates/burn-autodiff/src/checkpoint/mod.rs
+++ b/crates/burn-autodiff/src/checkpoint/mod.rs
@@ -1,9 +1,9 @@
 /// Checkpointer module
 pub mod base;
 pub(crate) mod builder;
-/// RetroForward module
+/// `RetroForward` module
 pub mod retro_forward;
-/// BackwardStates module
+/// `BackwardStates` module
 pub mod state;
-/// CheckpointStrategy module
+/// `CheckpointStrategy` module
 pub mod strategy;

--- a/crates/burn-autodiff/src/checkpoint/retro_forward.rs
+++ b/crates/burn-autodiff/src/checkpoint/retro_forward.rs
@@ -13,21 +13,21 @@ use super::state::{BackwardStates, State};
 
 /// Definition of the forward function of a node, called during retropropagation only.
 /// This is different from the normal forward function because it reads and writes from
-/// the [BackwardStates] map instead of having a clear function signature.
+/// the [`BackwardStates`] map instead of having a clear function signature.
 pub trait RetroForward: Debug + Send + 'static {
     /// Applies the forward pass for retropropagation.
     fn forward(&self, states: &mut BackwardStates, out_node: NodeId);
 }
 
 #[derive(new, Debug)]
-/// Links [NodeId]s to their corresponding [RetroForward]
+/// Links [`NodeId`]s to their corresponding [`RetroForward`]
 pub(crate) struct RetroForwards {
     map: HashMap<NodeId, Arc<dyn RetroForward>>,
 }
 
 impl RetroForwards {
-    /// Executes the [RetroForward] for a given [NodeId] if the node's
-    /// [State] is [State::Recompute], otherwise does nothing.
+    /// Executes the [`RetroForward`] for a given [`NodeId`] if the node's
+    /// [State] is [`State::Recompute`], otherwise does nothing.
     pub(crate) fn execute_retro_forward(
         &mut self,
         node_id: NodeId,
@@ -49,7 +49,7 @@ impl RetroForwards {
 }
 
 #[macro_export]
-/// Creates a RetroForward struct for unary scalar operations
+/// Creates a `RetroForward` struct for unary scalar operations
 macro_rules! retro_unary_scalar {
     (
         $name:ident,
@@ -73,7 +73,7 @@ macro_rules! retro_unary_scalar {
 }
 
 #[macro_export]
-/// Creates a RetroForward struct for unary scalar operations
+/// Creates a `RetroForward` struct for unary scalar operations
 macro_rules! retro_unary {
     (
         $name:ident,
@@ -96,7 +96,7 @@ macro_rules! retro_unary {
 }
 
 #[macro_export]
-/// Creates a RetroForward struct for binary operations
+/// Creates a `RetroForward` struct for binary operations
 macro_rules! retro_binary {
     (
         $name:ident,

--- a/crates/burn-autodiff/src/checkpoint/state.rs
+++ b/crates/burn-autodiff/src/checkpoint/state.rs
@@ -56,8 +56,8 @@ impl State {
     /// Returns the number of time the state is required
     pub(crate) fn n_required(&self) -> usize {
         match self {
-            State::Recompute { n_required } => *n_required,
-            State::Computed {
+            State::Recompute { n_required }
+            | State::Computed {
                 state_content: _,
                 n_required,
             } => *n_required,
@@ -66,13 +66,13 @@ impl State {
 }
 
 #[derive(new, Default, Debug)]
-/// Links [NodeId]s to their current state
+/// Links [`NodeId`]s to their current state
 pub struct BackwardStates {
     map: HashMap<NodeId, State>,
 }
 
 impl BackwardStates {
-    /// Returns the output in the state of the given [NodeId],
+    /// Returns the output in the state of the given [`NodeId`],
     /// and decrements the number of times this state is required.
     /// This function always gives ownership of the output, but will clone it if needed for further uses.
     pub fn get_state<T>(&mut self, node_id: &NodeId) -> T
@@ -118,12 +118,12 @@ impl BackwardStates {
         self.map.get(node_id)
     }
 
-    /// Associates a [State] to its [NodeId]
+    /// Associates a [State] to its [`NodeId`]
     pub(crate) fn insert_state(&mut self, node_id: NodeId, state: State) {
         self.map.insert(node_id, state);
     }
 
-    /// Saves the output to the state of the given [NodeId].
+    /// Saves the output to the state of the given [`NodeId`].
     pub fn save<T>(&mut self, node_id: NodeId, saved_output: T)
     where
         T: Clone + Send + 'static,

--- a/crates/burn-autodiff/src/checkpoint/strategy.rs
+++ b/crates/burn-autodiff/src/checkpoint/strategy.rs
@@ -69,7 +69,7 @@ pub struct BalancedCheckpointing {}
 
 impl CheckpointStrategy for BalancedCheckpointing {
     /// An operation marked as memory bound is memory bound.
-    /// When memory bound, an operation needs to save its RetroForward
+    /// When memory bound, an operation needs to save its `RetroForward`
     fn compute_property<R: RetroForward>(retro_forward: R) -> ComputingProperty {
         ComputingProperty::MemoryBound {
             retro_forward: Arc::new(retro_forward),
@@ -89,7 +89,7 @@ impl CheckpointStrategy for BalancedCheckpointing {
     {
         let mut can_checkpoint = true;
 
-        for tensor in parents.into_iter() {
+        for tensor in parents {
             if let crate::graph::Requirement::None = tensor.node.requirement {
                 can_checkpoint = false;
             } else {

--- a/crates/burn-autodiff/src/grads.rs
+++ b/crates/burn-autodiff/src/grads.rs
@@ -98,12 +98,12 @@ impl Gradients {
             Requirement::Grad => self
                 .container
                 .get::<TensorPrimitive<B>>(&node.id.value)
-                .map(|tensor| tensor.tensor())
+                .map(TensorPrimitive::tensor)
                 .expect("Can't consume the gradients before they are registered at least once."),
             Requirement::GradInBackward => self
                 .container
                 .remove::<TensorPrimitive<B>>(&node.id.value)
-                .map(|tensor| tensor.tensor())
+                .map(TensorPrimitive::tensor)
                 .expect("Can't consume the gradients before they are registered at least once."),
             Requirement::None => panic!("Trying to consume the gradients for an untracked tensor"),
         }
@@ -113,14 +113,14 @@ impl Gradients {
     pub fn remove<B: Backend>(&mut self, tensor: &AutodiffTensor<B>) -> Option<FloatTensor<B>> {
         self.container
             .remove::<TensorPrimitive<B>>(&tensor.node.id.value)
-            .map(|tensor| tensor.tensor())
+            .map(TensorPrimitive::tensor)
     }
 
     /// Gets a grad tensor from the container.
     pub fn get<B: Backend>(&self, tensor: &AutodiffTensor<B>) -> Option<FloatTensor<B>> {
         self.container
             .get::<TensorPrimitive<B>>(&tensor.node.id.value)
-            .map(|tensor| tensor.tensor())
+            .map(TensorPrimitive::tensor)
     }
 
     /// Register a grad tensor in the container.

--- a/crates/burn-autodiff/src/graph/node.rs
+++ b/crates/burn-autodiff/src/graph/node.rs
@@ -27,11 +27,11 @@ pub enum ComputingProperty {
     Ambiguous, // Maybe autotune someday
 }
 
-/// This is safe only because we only call RetroForward on the autodiff server.
+/// This is safe only because we only call `RetroForward` on the autodiff server.
 /// Therefore, the trait will never be used by multiple threads at the same time.
 ///
 /// TODO: Find a way to avoid cloning the compute property, which will remove the need to add the
-/// Arc, which will make (dyn RetroForward) safely implement Send.
+/// Arc, which will make (dyn `RetroForward`) safely implement Send.
 unsafe impl Send for ComputingProperty {}
 /// unsafe Sync is required because Send is only implemented for Arc<Sync>, not Arc<Send>.
 unsafe impl Sync for ComputingProperty {}
@@ -57,9 +57,10 @@ pub struct Parent {
 impl Node {
     /// Returns the [node](Node) only if gradients are required.
     pub fn clone_if_require_grad(self: &Arc<Self>) -> Option<NodeRef> {
-        match self.requirement.is_none() {
-            true => None,
-            false => Some(self.clone()),
+        if self.requirement.is_none() {
+            None
+        } else {
+            Some(self.clone())
         }
     }
 }
@@ -82,9 +83,7 @@ impl NodeId {
     pub fn new() -> Self {
         static COUNTER: AtomicU64 = AtomicU64::new(0);
         let value = COUNTER.fetch_add(1, Ordering::Relaxed);
-        if value == u64::MAX {
-            panic!("NodeId overflowed");
-        }
+        assert!(value != u64::MAX, "NodeId overflowed");
         Self { value }
     }
 }

--- a/crates/burn-autodiff/src/graph/requirement.rs
+++ b/crates/burn-autodiff/src/graph/requirement.rs
@@ -30,9 +30,10 @@ impl Requirement {
     }
 
     fn infer(&self, other: &Self) -> Self {
-        match self.is_none() && other.is_none() {
-            true => Self::None,
-            false => Self::GradInBackward,
+        if self.is_none() && other.is_none() {
+            Self::None
+        } else {
+            Self::GradInBackward
         }
     }
 }

--- a/crates/burn-autodiff/src/graph/traversal.rs
+++ b/crates/burn-autodiff/src/graph/traversal.rs
@@ -38,9 +38,8 @@ impl BreadthFirstSearch {
         callback(root_id, root_step);
 
         while let Some(id) = parents.pop() {
-            let step = match steps.remove(&id) {
-                Some(step) => step,
-                None => continue,
+            let Some(step) = steps.remove(&id) else {
+                continue;
             };
 
             let step_node = step.id();
@@ -52,7 +51,7 @@ impl BreadthFirstSearch {
 
             visited.insert(step_node);
 
-            for id in step_parents.iter() {
+            for id in &step_parents {
                 if !visited.contains(id) {
                     parents.push(*id);
                 }

--- a/crates/burn-autodiff/src/lib.rs
+++ b/crates/burn-autodiff/src/lib.rs
@@ -36,7 +36,7 @@ pub(crate) mod runtime;
 
 pub use backend::*;
 
-/// A facade around for HashMap and HashSet.
+/// A facade around for `HashMap` and `HashSet`.
 /// This avoids elaborate import wrangling having to happen in every module.
 mod collections {
     #[cfg(not(feature = "std"))]

--- a/crates/burn-autodiff/src/ops/backward.rs
+++ b/crates/burn-autodiff/src/ops/backward.rs
@@ -63,12 +63,12 @@ pub fn binary<B, FLhs, FRhs>(
 
     if let Some(node) = node_lhs {
         let grad = func_lhs(grad_4lhs.unwrap());
-        grads.register::<B>(node.id, grad)
+        grads.register::<B>(node.id, grad);
     }
 
     if let Some(node) = node_rhs {
         let grad = func_rhs(grad_4rhs.unwrap());
-        grads.register::<B>(node.id, grad)
+        grads.register::<B>(node.id, grad);
     }
 }
 
@@ -83,6 +83,6 @@ where
 
     if let Some(node) = parent_node {
         let grad = func(grad);
-        grads.register::<B>(node.id, grad)
+        grads.register::<B>(node.id, grad);
     }
 }

--- a/crates/burn-autodiff/src/ops/base.rs
+++ b/crates/burn-autodiff/src/ops/base.rs
@@ -37,7 +37,7 @@ pub struct OpsPrep<Backward, B, S, C, const N: usize, Mode = Init> {
 pub struct Init;
 /// Operation has been tagged as memory bound
 pub struct MemoryBound;
-/// Memory bound operation has received its RetroForward
+/// Memory bound operation has received its `RetroForward`
 pub struct MemoryBoundRetroForward;
 /// Operation's compute property is fixed
 pub struct ComputePropertyDone;
@@ -147,21 +147,22 @@ where
 {
     /// Prepare an operation that requires a state during the backward pass.
     pub fn stateful(self) -> OpsKind<BO, B, S, C, N> {
-        match self.requirement.is_none() {
-            false => OpsKind::Tracked(OpsPrep::new(
+        if self.requirement.is_none() {
+            OpsKind::UnTracked(OpsPrep::new(
                 self.nodes,
                 self.requirement,
                 self.backward,
                 self.compute_property,
                 self.checkpointer_builder,
-            )),
-            true => OpsKind::UnTracked(OpsPrep::new(
+            ))
+        } else {
+            OpsKind::Tracked(OpsPrep::new(
                 self.nodes,
                 self.requirement,
                 self.backward,
                 self.compute_property,
                 self.checkpointer_builder,
-            )),
+            ))
         }
     }
 }
@@ -313,12 +314,13 @@ pub fn broadcast_shape<B: Backend>(mut grad: FloatTensor<B>, shape: &Shape) -> F
 
     for i in 0..ndims {
         if shape_grad[i] != shape[i] {
-            if shape[i] != 1 {
-                panic!(
-                    "Invalid broadcast shapes: Next grad shape {:?}, Previous grad shape {:?}. {}",
-                    shape, shape_grad, "Expected the shape of the next grad to be 1."
-                );
-            }
+            assert!(
+                shape[i] == 1,
+                "Invalid broadcast shapes: Next grad shape {:?}, Previous grad shape {:?}. {}",
+                shape,
+                shape_grad,
+                "Expected the shape of the next grad to be 1."
+            );
             grad = B::float_sum_dim(grad, i);
         }
     }

--- a/crates/burn-autodiff/src/ops/distributed.rs
+++ b/crates/burn-autodiff/src/ops/distributed.rs
@@ -35,7 +35,7 @@ impl<B: Backend, C: CheckpointStrategy> DistributedOps<Self> for Autodiff<B, C> 
 
     fn submit_gradient_sync(tensor: TensorRef<Self>, distributed_params: DistributedParams) {
         let mut tensor = unsafe { (*tensor.0).clone() };
-        B::submit_gradient_sync(TensorRef(&mut tensor.primitive), distributed_params);
+        B::submit_gradient_sync(TensorRef(&raw mut tensor.primitive), distributed_params);
     }
 
     fn all_reduce(

--- a/crates/burn-autodiff/src/ops/module.rs
+++ b/crates/burn-autodiff/src/ops/module.rs
@@ -10,7 +10,11 @@ use crate::tensor::AutodiffTensor;
 
 use burn_backend::TensorMetadata;
 use burn_backend::ops::attention::attention_fallback;
-use burn_backend::ops::*;
+use burn_backend::ops::{
+    AttentionModuleOptions, ConvOptions, ConvTransposeOptions, DeformConv2dBackward,
+    DeformConvOptions, FloatTensorOps, InterpolateOptions, MaxPool1dBackward, MaxPool1dWithIndices,
+    MaxPool2dBackward, MaxPool2dWithIndices, ModuleOps,
+};
 use burn_backend::tensor::{FloatTensor, IntTensor};
 use burn_backend::{Backend, get_device_settings};
 use burn_std::{IntDType, Slice};
@@ -90,15 +94,15 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
 
                 if let Some(node) = node_x {
                     let grad = B::linear_x_backward(weight.unwrap(), grad.clone());
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
                 if let Some(node) = node_weight {
                     let grad = B::linear_weight_backward(x.unwrap(), grad.clone());
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
                 if let Some(node) = node_bias {
                     let grad = B::linear_bias_backward(grad);
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
             }
         }
@@ -123,11 +127,11 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
 
                 if let Some(node) = node_x {
                     let grad = B::linear_x_backward(weight.unwrap(), grad.clone());
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
                 if let Some(node) = node_weight {
                     let grad = B::linear_weight_backward(x.unwrap(), grad);
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
             }
         }
@@ -230,15 +234,15 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                         grad.clone(),
                         options.clone(),
                     );
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
                 if let Some(node) = node_weight {
                     let grad = B::conv1d_weight_backward(x.clone(), weight, grad.clone(), options);
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
                 if let Some(node) = node_bias {
                     let grad = B::conv1d_bias_backward(x, bias, grad);
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
             }
         }
@@ -267,11 +271,11 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                         grad.clone(),
                         options.clone(),
                     );
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
                 if let Some(node) = node_weight {
                     let grad = B::conv1d_weight_backward(x, weight, grad, options);
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
             }
         }
@@ -352,7 +356,7 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                         grad.clone(),
                         options.clone(),
                     );
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
                 if let Some(node) = node_weight {
                     let grad = B::conv_transpose1d_weight_backward(
@@ -361,11 +365,11 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                         grad.clone(),
                         options,
                     );
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
                 if let Some(node) = node_bias {
                     let grad = B::conv_transpose1d_bias_backward(x, bias, grad);
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
             }
         }
@@ -393,11 +397,11 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                         grad.clone(),
                         options.clone(),
                     );
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
                 if let Some(node) = node_weight {
                     let grad = B::conv_transpose1d_weight_backward(x, weight, grad, options);
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
             }
         }
@@ -488,16 +492,16 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                         grad.clone(),
                         options.clone(),
                     );
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
                 if let Some(node) = node_weight {
                     let grad =
                         B::conv2d_weight_backward(x.clone(), weight.clone(), grad.clone(), options);
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
                 if let Some(node) = node_bias {
                     let grad = B::conv2d_bias_backward(x, bias, grad);
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
             }
         }
@@ -526,11 +530,11 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                         grad.clone(),
                         options.clone(),
                     );
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
                 if let Some(node) = node_weight {
                     let grad = B::conv2d_weight_backward(x, weight, grad, options);
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
             }
         }
@@ -619,19 +623,19 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                     B::deform_conv2d_backward(x, offset, weight, mask, bias, grad, options);
 
                 if let Some(node) = node_x {
-                    grads.register::<B>(node.id, backward.x_grad)
+                    grads.register::<B>(node.id, backward.x_grad);
                 }
                 if let Some(node) = node_offset {
-                    grads.register::<B>(node.id, backward.offset_grad)
+                    grads.register::<B>(node.id, backward.offset_grad);
                 }
                 if let Some(node) = node_weight {
-                    grads.register::<B>(node.id, backward.weight_grad)
+                    grads.register::<B>(node.id, backward.weight_grad);
                 }
                 if let Some(node) = node_mask {
-                    grads.register::<B>(node.id, backward.mask_grad.unwrap())
+                    grads.register::<B>(node.id, backward.mask_grad.unwrap());
                 }
                 if let Some(node) = node_bias {
-                    grads.register::<B>(node.id, backward.bias_grad.unwrap())
+                    grads.register::<B>(node.id, backward.bias_grad.unwrap());
                 }
             }
         }
@@ -658,16 +662,16 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                     B::deform_conv2d_backward(x, offset, weight, mask, None, grad, options);
 
                 if let Some(node) = node_x {
-                    grads.register::<B>(node.id, backward.x_grad)
+                    grads.register::<B>(node.id, backward.x_grad);
                 }
                 if let Some(node) = node_offset {
-                    grads.register::<B>(node.id, backward.offset_grad)
+                    grads.register::<B>(node.id, backward.offset_grad);
                 }
                 if let Some(node) = node_weight {
-                    grads.register::<B>(node.id, backward.weight_grad)
+                    grads.register::<B>(node.id, backward.weight_grad);
                 }
                 if let Some(node) = node_mask {
-                    grads.register::<B>(node.id, backward.mask_grad.unwrap())
+                    grads.register::<B>(node.id, backward.mask_grad.unwrap());
                 }
             }
         }
@@ -694,16 +698,16 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                     B::deform_conv2d_backward(x, offset, weight, None, bias, grad, options);
 
                 if let Some(node) = node_x {
-                    grads.register::<B>(node.id, backward.x_grad)
+                    grads.register::<B>(node.id, backward.x_grad);
                 }
                 if let Some(node) = node_offset {
-                    grads.register::<B>(node.id, backward.offset_grad)
+                    grads.register::<B>(node.id, backward.offset_grad);
                 }
                 if let Some(node) = node_weight {
-                    grads.register::<B>(node.id, backward.weight_grad)
+                    grads.register::<B>(node.id, backward.weight_grad);
                 }
                 if let Some(node) = node_bias {
-                    grads.register::<B>(node.id, backward.bias_grad.unwrap())
+                    grads.register::<B>(node.id, backward.bias_grad.unwrap());
                 }
             }
         }
@@ -729,13 +733,13 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                     B::deform_conv2d_backward(x, offset, weight, None, None, grad, options);
 
                 if let Some(node) = node_x {
-                    grads.register::<B>(node.id, backward.x_grad)
+                    grads.register::<B>(node.id, backward.x_grad);
                 }
                 if let Some(node) = node_offset {
-                    grads.register::<B>(node.id, backward.offset_grad)
+                    grads.register::<B>(node.id, backward.offset_grad);
                 }
                 if let Some(node) = node_weight {
-                    grads.register::<B>(node.id, backward.weight_grad)
+                    grads.register::<B>(node.id, backward.weight_grad);
                 }
             }
         }
@@ -950,7 +954,7 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                         grad.clone(),
                         options.clone(),
                     );
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
                 if let Some(node) = node_weight {
                     let grad = B::conv_transpose2d_weight_backward(
@@ -959,11 +963,11 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                         grad.clone(),
                         options,
                     );
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
                 if let Some(node) = node_bias {
                     let grad = B::conv_transpose2d_bias_backward(x, bias, grad);
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
             }
         }
@@ -991,11 +995,11 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                         grad.clone(),
                         options.clone(),
                     );
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
                 if let Some(node) = node_weight {
                     let grad = B::conv_transpose2d_weight_backward(x, weight, grad, options);
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
             }
         }
@@ -1088,16 +1092,16 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                         grad.clone(),
                         options.clone(),
                     );
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
                 if let Some(node) = node_weight {
                     let grad =
                         B::conv3d_weight_backward(x.clone(), weight.clone(), grad.clone(), options);
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
                 if let Some(node) = node_bias {
                     let grad = B::conv3d_bias_backward(x, bias, grad);
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
             }
         }
@@ -1126,11 +1130,11 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                         grad.clone(),
                         options.clone(),
                     );
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
                 if let Some(node) = node_weight {
                     let grad = B::conv3d_weight_backward(x, weight, grad, options);
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
             }
         }
@@ -1213,7 +1217,7 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                         grad.clone(),
                         options.clone(),
                     );
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
                 if let Some(node) = node_weight {
                     let grad = B::conv_transpose3d_weight_backward(
@@ -1222,11 +1226,11 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                         grad.clone(),
                         options,
                     );
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
                 if let Some(node) = node_bias {
                     let grad = B::conv_transpose3d_bias_backward(x, bias, grad);
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
             }
         }
@@ -1254,11 +1258,11 @@ impl<B: Backend, C: CheckpointStrategy> ModuleOps<Autodiff<B, C>> for Autodiff<B
                         grad.clone(),
                         options.clone(),
                     );
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
                 if let Some(node) = node_weight {
                     let grad = B::conv_transpose3d_weight_backward(x, weight, grad, options);
-                    grads.register::<B>(node.id, grad)
+                    grads.register::<B>(node.id, grad);
                 }
             }
         }

--- a/crates/burn-autodiff/src/ops/tensor.rs
+++ b/crates/burn-autodiff/src/ops/tensor.rs
@@ -750,7 +750,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
             fn forward(&self, states: &mut BackwardStates, out_node: NodeId) {
                 let input = states.get_state::<B::FloatTensorPrimitive>(&self.input_id);
                 let out = B::float_swap_dims(input, self.dim1, self.dim2);
-                states.save(out_node, out)
+                states.save(out_node, out);
             }
         }
 
@@ -803,7 +803,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
             fn forward(&self, states: &mut BackwardStates, out_node: NodeId) {
                 let input = states.get_state::<B::FloatTensorPrimitive>(&self.input_id);
                 let out = B::float_permute(input, &self.axes);
-                states.save(out_node, out)
+                states.save(out_node, out);
             }
         }
 
@@ -858,7 +858,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
             fn forward(&self, states: &mut BackwardStates, out_node: NodeId) {
                 let input = states.get_state::<B::FloatTensorPrimitive>(&self.input_id);
                 let out = B::float_flip(input, &self.axes);
-                states.save(out_node, out)
+                states.save(out_node, out);
             }
         }
 
@@ -908,7 +908,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
             fn forward(&self, states: &mut BackwardStates, out_node: NodeId) {
                 let input = states.get_state::<B::FloatTensorPrimitive>(&self.input_id);
                 let out = B::float_reshape(input, self.shape.clone());
-                states.save(out_node, out)
+                states.save(out_node, out);
             }
         }
 
@@ -1491,7 +1491,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
             fn forward(&self, states: &mut BackwardStates, out_node: NodeId) {
                 let input = states.get_state::<B::FloatTensorPrimitive>(&self.input_id);
                 let out = B::float_select(input, self.dim, self.indices.clone());
-                states.save(out_node, out)
+                states.save(out_node, out);
             }
         }
 
@@ -1557,7 +1557,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                 let tensor = states.get_state::<B::FloatTensorPrimitive>(&self.tensor_id);
                 let value = states.get_state::<B::FloatTensorPrimitive>(&self.value_id);
                 let out = B::float_select_add(tensor, self.dim, self.indices.clone(), value);
-                states.save(out_node, out)
+                states.save(out_node, out);
             }
         }
 
@@ -1639,7 +1639,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                             value,
                             IndexingUpdateOp::Assign,
                         );
-                        states.save(out_node, out)
+                        states.save(out_node, out);
                     }
                 }
 
@@ -1731,7 +1731,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
             fn forward(&self, states: &mut BackwardStates, out_node: NodeId) {
                 let tensor = states.get_state::<B::FloatTensorPrimitive>(&self.tensor_id);
                 let out = B::float_slice(tensor, &self.slices);
-                states.save(out_node, out)
+                states.save(out_node, out);
             }
         }
 
@@ -1793,7 +1793,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                 let tensor = states.get_state::<B::FloatTensorPrimitive>(&self.tensor_id);
                 let value = states.get_state::<B::FloatTensorPrimitive>(&self.value_id);
                 let out = B::float_slice_assign(tensor, &self.slices, value);
-                states.save(out_node, out)
+                states.save(out_node, out);
             }
         }
 
@@ -2723,7 +2723,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
             fn forward(&self, states: &mut BackwardStates, out_node: NodeId) {
                 let lhs = states.get_state::<B::FloatTensorPrimitive>(&self.lhs_id);
                 let out = B::float_powf_scalar(lhs, self.rhs.into());
-                states.save(out_node, out)
+                states.save(out_node, out);
             }
         }
 
@@ -3415,7 +3415,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                 let (shape, device) = ops.state;
                 unary::<B, _>(ops.parents, ops.node, grads, |grad| {
                     B::float_zeros(shape, &device, grad.dtype().into())
-                })
+                });
             }
         }
 
@@ -3451,7 +3451,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                 let (shape, device) = ops.state;
                 unary::<B, _>(ops.parents, ops.node, grads, |grad| {
                     B::float_zeros(shape, &device, grad.dtype().into())
-                })
+                });
             }
         }
 
@@ -3487,7 +3487,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                 let (shape, device) = ops.state;
                 unary::<B, _>(ops.parents, ops.node, grads, |grad| {
                     B::float_zeros(shape, &device, grad.dtype().into())
-                })
+                });
             }
         }
 
@@ -3523,7 +3523,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
                 let (shape, device) = ops.state;
                 unary::<B, _>(ops.parents, ops.node, grads, |grad| {
                     B::float_zeros(shape, &device, grad.dtype().into())
-                })
+                });
             }
         }
 
@@ -3644,11 +3644,11 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
         let mut primitives = Vec::with_capacity(tensors.len());
         let mut dim_sizes = Vec::with_capacity(tensors.len());
 
-        tensors.into_iter().for_each(|tensor| {
+        for tensor in tensors {
             dim_sizes.push(tensor.primitive.shape()[dim]);
             nodes.push(tensor.node);
             primitives.push(tensor.primitive);
-        });
+        }
 
         let requirement = Requirement::from_nodes(&nodes);
 
@@ -3952,7 +3952,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
             fn forward(&self, states: &mut BackwardStates, out_node: NodeId) {
                 let input = states.get_state::<B::FloatTensorPrimitive>(&self.input_id);
                 let out = B::float_expand(input, self.shape.clone());
-                states.save(out_node, out)
+                states.save(out_node, out);
             }
         }
 
@@ -4085,7 +4085,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
             fn forward(&self, states: &mut BackwardStates, out_node: NodeId) {
                 let tensor = states.get_state::<B::FloatTensorPrimitive>(&self.tensor_id);
                 let out = B::float_repeat_dim(tensor, self.dim, self.times);
-                states.save(out_node, out)
+                states.save(out_node, out);
             }
         }
 

--- a/crates/burn-autodiff/src/runtime/graph.rs
+++ b/crates/burn-autodiff/src/runtime/graph.rs
@@ -33,7 +33,7 @@ use spin::{Mutex, MutexGuard};
 ///
 /// # Notes
 ///
-/// The [AutodiffServer] fully supports multiple graphs with sharing nodes, however those type of
+/// The [`AutodiffServer`] fully supports multiple graphs with sharing nodes, however those type of
 /// graphs will be stored under a single mutex-protected graph by the client, limiting
 /// parallelisation.
 #[derive(Clone, new, Debug)]
@@ -58,7 +58,7 @@ pub struct GraphLocator {
 
 /// Represents a single computation graph with a mutex-protected server.
 ///
-/// Each `Graph` contains an [AutodiffServer] and the original [NodeId] where the server was
+/// Each `Graph` contains an [`AutodiffServer`] and the original [`NodeId`] where the server was
 /// first created.
 pub(crate) struct Graph {
     origin: NodeId,
@@ -81,7 +81,7 @@ impl core::fmt::Debug for Graph {
 static STATE: Mutex<Option<GraphLocator>> = Mutex::new(None);
 
 impl GraphMutexClient {
-    /// Retrieves or creates a graph for the given [NodeId] and parent dependencies.
+    /// Retrieves or creates a graph for the given [`NodeId`] and parent dependencies.
     ///
     /// # Parameters
     /// - `node`: The unique identifier for the stream.
@@ -92,14 +92,13 @@ impl GraphMutexClient {
     fn graph(node: NodeId, parents: &[Parent]) -> Arc<Graph> {
         let mut state = STATE.lock();
 
-        match state.as_mut() {
-            Some(locator) => locator.select(node, parents),
-            None => {
-                let mut locator = GraphLocator::default();
-                let stream = locator.select(node, parents);
-                *state = Some(locator);
-                stream
-            }
+        if let Some(locator) = state.as_mut() {
+            locator.select(node, parents)
+        } else {
+            let mut locator = GraphLocator::default();
+            let stream = locator.select(node, parents);
+            *state = Some(locator);
+            stream
         }
     }
 }
@@ -134,7 +133,7 @@ struct GraphCleaner<'a> {
     guard: MutexGuard<'a, Option<GraphLocator>>,
 }
 
-impl<'a> GraphCleaner<'a> {
+impl GraphCleaner<'_> {
     fn cleanup_orphaned_entries() {
         let graphs = {
             // Get the available graphs and release the lock
@@ -177,7 +176,7 @@ impl<'a> GraphCleaner<'a> {
     }
 }
 
-impl<'a> NodeCleaner for GraphCleaner<'a> {
+impl NodeCleaner for GraphCleaner<'_> {
     fn init() -> Self {
         let guard = STATE.lock();
         Self { guard }
@@ -191,7 +190,7 @@ impl<'a> NodeCleaner for GraphCleaner<'a> {
 }
 
 impl GraphLocator {
-    /// Selects a single graph for the given [NodeId], considering parent dependencies.
+    /// Selects a single graph for the given [`NodeId`], considering parent dependencies.
     ///
     /// If multiple graphs are found, they are merged into a single one.
     ///
@@ -225,7 +224,7 @@ impl GraphLocator {
                 None => self.new_graph(node),
             };
             return GraphAnalysis::NoCollision(graph);
-        };
+        }
 
         // We collect all graphs of parents and of the current node based on their origin node id.
         let mut graphs = BTreeMap::<NodeId, Arc<Graph>>::new();
@@ -301,7 +300,7 @@ impl GraphLocator {
 
         // Move all keys (node IDs) from the merged graph to the main graph
         if let Some(locator_keys) = self.keys.remove(&merged.origin) {
-            for k in locator_keys.iter() {
+            for k in &locator_keys {
                 self.graphs.insert(*k, main.clone());
             }
 

--- a/crates/burn-autodiff/src/runtime/memory_management.rs
+++ b/crates/burn-autodiff/src/runtime/memory_management.rs
@@ -39,7 +39,7 @@ impl GraphMemoryManagement {
     pub fn register(&mut self, node: NodeRefCount, parents: &[Parent]) {
         let node_id = *node.as_ref();
 
-        for parent in parents.iter() {
+        for parent in parents {
             self.leaves.remove(&parent.id);
         }
 
@@ -92,7 +92,7 @@ impl GraphMemoryManagement {
         self.statuses.clear();
         for node_to_delete in deletables {
             self.nodes.remove(&node_to_delete);
-            on_free_graph(&node_to_delete)
+            on_free_graph(&node_to_delete);
         }
     }
 
@@ -107,7 +107,7 @@ impl GraphMemoryManagement {
     }
 
     fn clear_unused_roots(&self, to_delete: &mut Vec<NodeId>) {
-        for (id, parents) in self.nodes.iter() {
+        for (id, parents) in &self.nodes {
             let is_useful = matches!(
                 self.statuses.get(id.as_ref()),
                 Some(NodeMemoryStatus::Useful)
@@ -117,7 +117,7 @@ impl GraphMemoryManagement {
             let parents_absent = parents.iter().all(|p| !self.nodes.contains_key(p));
 
             if !is_useful && Arc::strong_count(id) == 1 && parents_absent {
-                to_delete.push(*id.as_ref())
+                to_delete.push(*id.as_ref());
             }
         }
     }
@@ -128,27 +128,24 @@ impl GraphMemoryManagement {
             return status.clone();
         }
 
-        match self.nodes.get(&node_id).cloned() {
+        if let Some(parents) = self.nodes.get(&node_id).cloned() {
             // If node exists and any of its parents is unavailable, it is unavailable as well
             // If node exists but the parents vec is empty, it is a tensor that never had parents;
             //  the status remains unknown
-            Some(parents) => {
-                let mut node_status = NodeMemoryStatus::Unknown;
-                for parent in parents {
-                    let parent_status = self.unavailable_propagation(parent);
-                    if let NodeMemoryStatus::Unavailable = parent_status {
-                        node_status = NodeMemoryStatus::Unavailable;
-                    }
+            let mut node_status = NodeMemoryStatus::Unknown;
+            for parent in parents {
+                let parent_status = self.unavailable_propagation(parent);
+                if let NodeMemoryStatus::Unavailable = parent_status {
+                    node_status = NodeMemoryStatus::Unavailable;
                 }
-                self.statuses.insert(node_id, node_status.clone());
-                node_status
             }
+            self.statuses.insert(node_id, node_status.clone());
+            node_status
+        } else {
             // If node does not exist, it was
             // deleted, so this and all its descendants are unavailable
-            None => {
-                self.statuses.insert(node_id, NodeMemoryStatus::Unavailable);
-                NodeMemoryStatus::Unavailable
-            }
+            self.statuses.insert(node_id, NodeMemoryStatus::Unavailable);
+            NodeMemoryStatus::Unavailable
         }
     }
 
@@ -183,9 +180,10 @@ impl GraphMemoryManagement {
                             .to_owned();
 
                         if let NodeMemoryStatus::Unknown = node_status {
-                            match self.is_referenced(node_id) {
-                                true => (node_id, NodeMemoryStatus::Useful),
-                                false => (node_id, NodeMemoryStatus::Unknown),
+                            if self.is_referenced(node_id) {
+                                (node_id, NodeMemoryStatus::Useful)
+                            } else {
+                                (node_id, NodeMemoryStatus::Unknown)
                             }
                         } else {
                             (node_id, node_status)
@@ -198,22 +196,19 @@ impl GraphMemoryManagement {
                 },
             };
 
-            match status {
-                NodeMemoryStatus::Useful => {
-                    tagged_useful.insert(node_id);
-                    for parent in parents(node_id) {
-                        // The node can be explored, as long as it's not already tagged useful
-                        if !(tagged_useful.contains(&parent) || to_tag_useful.contains(&parent)) {
-                            to_tag_useful.insert(parent);
-                        }
+            if status == NodeMemoryStatus::Useful {
+                tagged_useful.insert(node_id);
+                for parent in parents(node_id) {
+                    // The node can be explored, as long as it's not already tagged useful
+                    if !(tagged_useful.contains(&parent) || to_tag_useful.contains(&parent)) {
+                        to_tag_useful.insert(parent);
                     }
                 }
-                _ => {
-                    explored.insert(node_id);
-                    for parent in parents(node_id) {
-                        if !(explored.contains(&parent) || to_explore.contains(&parent)) {
-                            to_explore.insert(parent);
-                        }
+            } else {
+                explored.insert(node_id);
+                for parent in parents(node_id) {
+                    if !(explored.contains(&parent) || to_explore.contains(&parent)) {
+                        to_explore.insert(parent);
                     }
                 }
             }
@@ -234,30 +229,22 @@ impl GraphMemoryManagement {
         while let Some(node_id) = to_visit.pop() {
             visited.insert(node_id);
 
-            match self
+            if self
                 .statuses
                 .get(&node_id)
                 .expect("Node should have status")
+                == &NodeMemoryStatus::Useful
             {
-                NodeMemoryStatus::Useful => {
-                    new_leaves.insert(node_id);
-                }
-                _ => {
-                    to_delete.push(node_id);
+                new_leaves.insert(node_id);
+            } else {
+                to_delete.push(node_id);
 
-                    for parent in self
-                        .nodes
-                        .get(&node_id)
-                        .cloned()
-                        .unwrap_or_default()
-                        .into_iter()
-                    {
-                        if !visited.contains(&parent) {
-                            to_visit.push(parent);
-                        }
+                for parent in self.nodes.get(&node_id).cloned().unwrap_or_default() {
+                    if !visited.contains(&parent) {
+                        to_visit.push(parent);
                     }
                 }
-            };
+            }
         }
     }
 
@@ -280,7 +267,6 @@ struct PopNodeSet {
 }
 
 impl PopNodeSet {
-    #[inline(always)]
     fn pop(&mut self) -> Option<NodeId> {
         self.hash_set
             .iter()
@@ -289,12 +275,10 @@ impl PopNodeSet {
             .and_then(|node_id| self.hash_set.take(&node_id))
     }
 
-    #[inline(always)]
     fn contains(&self, node_id: &NodeId) -> bool {
         self.hash_set.contains(node_id)
     }
 
-    #[inline(always)]
     fn insert(&mut self, node_id: NodeId) {
         self.hash_set.insert(node_id);
     }

--- a/crates/burn-autodiff/src/runtime/server.rs
+++ b/crates/burn-autodiff/src/runtime/server.rs
@@ -100,7 +100,7 @@ impl AutodiffServer {
                 NC::clean(&mut cleaner, node_id);
             });
         for node_id in consumed {
-            cleaner.clean(node_id)
+            cleaner.clean(node_id);
         }
     }
 
@@ -119,7 +119,7 @@ impl AutodiffServer {
         mut builder: CheckpointerBuilder,
         consumed: &mut Vec<NodeId>,
     ) -> TapeResult {
-        let mut tape = (0..node_step.depth() + 1)
+        let mut tape = (0..=node_step.depth())
             .map(|_| Vec::with_capacity(1))
             .collect::<Vec<_>>();
 
@@ -182,11 +182,11 @@ impl AutodiffServer {
         mut grads: Gradients,
         mut checkpointer: Checkpointer,
     ) -> Gradients {
-        tape.into_iter().rev().for_each(|steps| {
-            steps
-                .into_iter()
-                .for_each(|step| step.step(&mut grads, &mut checkpointer))
-        });
+        for steps in tape.into_iter().rev() {
+            for step in steps {
+                step.step(&mut grads, &mut checkpointer);
+            }
+        }
 
         // For checkpointing tests
         #[cfg(feature = "export_tests")]

--- a/crates/burn-autodiff/src/tensor.rs
+++ b/crates/burn-autodiff/src/tensor.rs
@@ -148,13 +148,12 @@ impl<B: Backend> AutodiffTensor<B> {
 
         let client = parent_nodes
             .first()
-            .map(|node| node.client.clone())
-            .unwrap_or_else(AutodiffClientImpl::new);
+            .map_or_else(AutodiffClientImpl::new, |node| node.client.clone());
 
         let node: NodeRef = Node::new(
             parent_nodes
                 .iter()
-                .filter_map(|node| node.clone_if_require_grad())
+                .filter_map(Node::clone_if_require_grad)
                 .map(|node| Parent::new(node.id))
                 .collect(),
             order,


### PR DESCRIPTION
This PR applies safe mechanical clippy::pedantic cleanups to crates/burn-autodiff.

Summary of changes:
- Add doc backticks, elide lifetimes, and remove unnecessary semicolons.
- Replace verbose iteration and match patterns with idiomatic equivalents.
- Apply formatting fixes.

API-affecting lints (needless_pass_by_value, trivially_copy_pass_by_ref, unused_self), structural lints (too_many_lines, items_after_statements), doc-section lints (missing_panics_doc, missing_errors_doc), must_use, similar_names, missing_fields_in_debug, and numeric cast warnings were intentionally left untouched.