### PR TITLE
style(burn-core): apply clippy::pedantic cleanups

### DIFF
--- a/crates/burn-core/src/module/base.rs
+++ b/crates/burn-core/src/module/base.rs
@@ -115,7 +115,7 @@ pub trait Module: Clone + Send + core::fmt::Debug {
     ///
     /// # Notes
     ///
-    /// This is similar to [to_device](Module::to_device), but it ensures the output module on the
+    /// This is similar to [`to_device`](Module::to_device), but it ensures the output module on the
     /// new device will have its own autodiff graph.
     fn fork(self, device: &Device) -> Self;
 
@@ -146,12 +146,12 @@ pub trait Module: Clone + Send + core::fmt::Debug {
     /// Set `require_grad` to `false` for every parameter in the given group, leaving the rest
     /// of the module untouched.
     ///
-    /// This is the group-scoped counterpart to [no_grad](Module::no_grad): where `no_grad` freezes
+    /// This is the group-scoped counterpart to [`no_grad`](Module::no_grad): where `no_grad` freezes
     /// the whole module tree, `freeze_group` freezes only the parameters matched by `group`.  
     ///
     /// # Warnings
     ///
-    /// Like [no_grad](Module::no_grad), this should not be used for inference; use
+    /// Like [`no_grad`](Module::no_grad), this should not be used for inference; use
     /// [valid](AutodiffModule::valid) with AD modules instead.
     fn freeze_group(self, group: ParamGroup) -> Self {
         module!(
@@ -164,7 +164,7 @@ pub trait Module: Clone + Send + core::fmt::Debug {
     /// Set `require_grad` to `true` for every parameter in the given group, leaving the rest
     /// of the module untouched.
     ///
-    /// The inverse of [freeze_group](Module::freeze_group): it re-enables gradient tracking for the
+    /// The inverse of [`freeze_group`](Module::freeze_group): it re-enables gradient tracking for the
     /// parameters matched by `group`, e.g. to unfreeze a previously frozen module.
     fn unfreeze_group(self, group: ParamGroup) -> Self {
         module!(
@@ -234,7 +234,7 @@ pub trait Module: Clone + Send + core::fmt::Debug {
         self.map(&mut ApplyReparameterization::new(reparameterizer))
     }
 
-    /// Attach LoRA adapters to the module's 2-D weights, freezing the base weights.
+    /// Attach `LoRA` adapters to the module's 2-D weights, freezing the base weights.
     ///
     /// The same module keeps working without any code changes; adapted weights now produce
     /// `base + scale * (a @ b)`, and only the adapter factors are trainable.
@@ -245,7 +245,7 @@ pub trait Module: Clone + Send + core::fmt::Debug {
         self.apply_reparameterization(lora)
     }
 
-    /// Apply QLoRA to the module: quantize the (frozen) base weights and attach trainable LoRA
+    /// Apply `QLoRA` to the module: quantize the (frozen) base weights and attach trainable `LoRA`
     /// adapters to 2-D weights.
     fn apply_qlora(self, qlora: QLora) -> Self
     where
@@ -388,7 +388,7 @@ pub trait ModuleVisitor {
     ///   - For Tuple containers: "Tuple" (name is the index)
     ///   - For Array containers: "Array" (name is the index)
     ///
-    /// Note: Option containers do not call enter_module/exit_module to preserve
+    /// Note: Option containers do not call `enter_module/exit_module` to preserve
     /// the field name in the path (e.g., "bias" instead of "bias.Some")
     #[allow(unused_variables)]
     fn enter_module(&mut self, name: &str, container_type: &str) {}
@@ -404,7 +404,7 @@ pub trait ModuleVisitor {
     ///   - For Tuple containers: "Tuple" (name is the index)
     ///   - For Array containers: "Array" (name is the index)
     ///
-    /// Note: Option containers do not call enter_module/exit_module to preserve
+    /// Note: Option containers do not call `enter_module/exit_module` to preserve
     /// the field name in the path (e.g., "bias" instead of "bias.Some")
     #[allow(unused_variables)]
     fn exit_module(&mut self, name: &str, container_type: &str) {}
@@ -474,7 +474,7 @@ pub trait ModuleMapper {
     ///   - For Tuple containers: "Tuple" (name is the index)
     ///   - For Array containers: "Array" (name is the index)
     ///
-    /// Note: Option containers do not call enter_module/exit_module to preserve
+    /// Note: Option containers do not call `enter_module/exit_module` to preserve
     /// the field name in the path (e.g., "bias" instead of "bias.Some")
     #[allow(unused_variables)]
     fn enter_module(&mut self, name: &str, container_type: &str) {}
@@ -490,7 +490,7 @@ pub trait ModuleMapper {
     ///   - For Tuple containers: "Tuple" (name is the index)
     ///   - For Array containers: "Array" (name is the index)
     ///
-    /// Note: Option containers do not call enter_module/exit_module to preserve
+    /// Note: Option containers do not call `enter_module/exit_module` to preserve
     /// the field name in the path (e.g., "bias" instead of "bias.Some")
     #[allow(unused_variables)]
     fn exit_module(&mut self, name: &str, container_type: &str) {}

--- a/crates/burn-core/src/module/display.rs
+++ b/crates/burn-core/src/module/display.rs
@@ -29,8 +29,8 @@ pub trait ModuleDisplayDefault {
 /// Trait to implement custom display settings for a module.
 ///
 /// In order to implement custom display settings for a module,
-/// 1. Add #[module(custom_display)] attribute to the module struct after #[derive(Module)]
-/// 2. Implement ModuleDisplay trait for the module
+/// 1. Add #[`module(custom_display)`] attribute to the module struct after #[derive(Module)]
+/// 2. Implement `ModuleDisplay` trait for the module
 pub trait ModuleDisplay: ModuleDisplayDefault {
     /// Formats the module with provided display settings.
     ///
@@ -57,7 +57,10 @@ pub trait ModuleDisplay: ModuleDisplayDefault {
 
         // Use custom content if it is implemented and show_all_attributes is false,
         // otherwise use default content
-        let content = if !settings.show_all_attributes() {
+        let content = if settings.show_all_attributes() {
+            self.content(Content::new(settings.clone()))
+                .unwrap_or_else(|| panic!("Default content should be implemented for {self_type}."))
+        } else {
             self.custom_content(Content::new(settings.clone()))
                 .unwrap_or_else(|| {
                     self.content(Content::new(settings.clone()))
@@ -65,9 +68,6 @@ pub trait ModuleDisplay: ModuleDisplayDefault {
                             panic!("Default content should be implemented for {self_type}.")
                         })
                 })
-        } else {
-            self.content(Content::new(settings.clone()))
-                .unwrap_or_else(|| panic!("Default content should be implemented for {self_type}."))
         };
 
         let top_level_type = if let Some(top_level_type) = content.top_level_type {
@@ -297,7 +297,7 @@ impl DisplaySettings {
         updated
     }
 
-    /// A convenience method to wrap the DisplaySettings struct in an option.
+    /// A convenience method to wrap the `DisplaySettings` struct in an option.
     ///
     /// # Returns
     ///

--- a/crates/burn-core/src/module/initializer.rs
+++ b/crates/burn-core/src/module/initializer.rs
@@ -72,8 +72,8 @@ pub enum Initializer {
         gain: f64,
     },
     /// Fills tensor with values according to the (semi) orthogonal initialization
-    /// described in [Exact solutions to the nonlinear dynamics of learning in deep linear neural networks`
-    ///  - [Saxe, A. et al. (2013)](https://arxiv.org/abs/1312.6120)
+    /// described in [Exact solutions to the nonlinear dynamics of learning in deep linear neural
+    /// networks - [Saxe, A. et al. (2013)](https://arxiv.org/abs/1312.6120)]
     Orthogonal {
         /// The gain to use in initialization formula
         gain: f64,

--- a/crates/burn-core/src/module/lora.rs
+++ b/crates/burn-core/src/module/lora.rs
@@ -2,12 +2,12 @@ use burn_tensor::{Distribution, FloatDType, Tensor};
 
 use crate::module::{LoraAdapter, Param, ParamGroup, Quantizer, Reparameterizer};
 
-/// A [`Reparameterizer`] that attaches LoRA adapters to 2-D weight parameters.
+/// A [`Reparameterizer`] that attaches `LoRA` adapters to 2-D weight parameters.
 ///
 /// It is applied via [`Module::apply_lora`](crate::module::Module::apply_lora).
 ///
 /// All existing floating-point parameters are frozen. Matching rank-2 parameters receive
-/// trainable LoRA [adapter](LoraAdapter)s; other parameters remain frozen without adapters. No
+/// trainable `LoRA` [adapter](LoraAdapter)s; other parameters remain frozen without adapters. No
 /// model or layer code needs to change—the same `Linear` (and any other module) keeps working, now
 /// producing `base + scale * (a @ b)` for adapted weights.
 #[derive(Debug, Clone)]
@@ -23,12 +23,12 @@ pub struct Lora {
     /// half precision over a packed base must say so here — the factors meet
     /// its activations and gradients in elementwise ops that do not promote.
     pub dtype: Option<FloatDType>,
-    /// The parameter group on which to apply the LoRA.
+    /// The parameter group on which to apply the `LoRA`.
     pub param_group: ParamGroup,
 }
 
 impl Lora {
-    /// Create a new LoRA reparameterizer with the given rank and alpha.
+    /// Create a new `LoRA` reparameterizer with the given rank and alpha.
     pub fn new(rank: usize, alpha: f64) -> Self {
         Self {
             rank,
@@ -39,7 +39,7 @@ impl Lora {
         }
     }
 
-    /// Set the parameter group on which to apply LoRA adapters.
+    /// Set the parameter group on which to apply `LoRA` adapters.
     pub fn set_param_group(mut self, group: ParamGroup) -> Self {
         self.param_group = group;
         self
@@ -121,8 +121,8 @@ impl Reparameterizer for Lora {
     }
 }
 
-/// A [`Reparameterizer`] implementing QLoRA: it quantizes the (frozen) base weights and
-/// attaches full-precision trainable LoRA adapters to 2-D weights.
+/// A [`Reparameterizer`] implementing `QLoRA`: it quantizes the (frozen) base weights and
+/// attaches full-precision trainable `LoRA` adapters to 2-D weights.
 ///
 /// It is applied via [`Module::apply_qlora`](crate::module::Module::apply_qlora).
 ///
@@ -134,7 +134,7 @@ pub struct QLora {
 }
 
 impl QLora {
-    /// Create a new QLoRA reparameterizer from LoRA settings and a quantizer.
+    /// Create a new `QLoRA` reparameterizer from `LoRA` settings and a quantizer.
     pub fn new(lora: Lora, quantizer: Quantizer) -> Self {
         Self { lora, quantizer }
     }

--- a/crates/burn-core/src/module/param/base.rs
+++ b/crates/burn-core/src/module/param/base.rs
@@ -61,7 +61,7 @@ fn new_init_fn<P: Parameter, F: FnOnce(&Device, bool) -> P + Send + Sync + 'stat
 /// The transition from uninitialized to initialized happens exactly once and is synchronized
 /// across all clones.
 pub(crate) struct LazyInitState<T: Parameter> {
-    /// The SyncOnceCell holding the initialized parameter value.
+    /// The `SyncOnceCell` holding the initialized parameter value.
     /// Empty for uninitialized parameters, populated after first access or explicit initialization.
     pub value: SyncOnceCell<T>,
     /// The deferred initialization state for lazy parameters.
@@ -259,7 +259,7 @@ pub(crate) struct Uninitialized<P: Parameter> {
 impl<P: Parameter> Uninitialized<P> {
     /// Runs the initialization function.
     ///
-    /// This is called by [Param::val] when accessing an uninitialized parameter for the first time.
+    /// This is called by [`Param::val`] when accessing an uninitialized parameter for the first time.
     /// The function is given the stored device and gradient requirement, and returns the initialized parameter.
     fn initialize(self) -> P {
         (self.init)(&self.device, self.is_require_grad)
@@ -334,7 +334,7 @@ impl<T: Parameter> Param<T> {
         self.reparameterization_dyn()?.as_any().downcast_ref()
     }
 
-    /// The LoRA [adapter](LoraAdapter) attached to this parameter, if any.
+    /// The `LoRA` [adapter](LoraAdapter) attached to this parameter, if any.
     pub fn adapter(&self) -> Option<&LoraAdapter> {
         self.reparameterization()
     }
@@ -404,7 +404,7 @@ impl<T: Parameter> Param<T> {
     /// Create an initialized parameter with the given id, value, and param mapper.
     ///
     /// This is a helper method for creating parameters while preserving the param mapper,
-    /// typically used in ModuleMapper implementations.
+    /// typically used in `ModuleMapper` implementations.
     pub fn from_mapped_value(id: ParamId, value: T, param_mapper: ParamMapper<T>) -> Self {
         let require_grad = value.is_require_grad();
         Self {
@@ -485,7 +485,7 @@ impl<T: Parameter> Param<T> {
     /// we need to know the target device to move the loaded tensor appropriately, but we don't want to
     /// trigger the initialization function (which would allocate an unnecessary tensor).
     ///
-    /// Use this instead of [crate::tensor::Tensor::device] when you need the device but want to
+    /// Use this instead of [`crate::tensor::Tensor::device`] when you need the device but want to
     /// preserve lazy initialization.
     pub fn lazy_device(&self) -> Device {
         let initialization = match &self.state.initialization {
@@ -503,7 +503,7 @@ impl<T: Parameter> Param<T> {
 
     /// The gradient requirement on which the parameter is or will be initialized, **without triggering initialization**.
     ///
-    /// Similar to [lazy_device](Self::lazy_device), this is critical for the load optimization.
+    /// Similar to [`lazy_device`](Self::lazy_device), this is critical for the load optimization.
     /// When loading tensors into an uninitialized parameter, we need to apply the correct gradient
     /// setting to the loaded tensor without triggering the initialization function.
     ///
@@ -556,7 +556,7 @@ impl<T: Parameter> Param<T> {
     /// uninitialized parameter, we need to validate the shape without triggering the
     /// initialization function (which would allocate an unnecessary tensor).
     ///
-    /// Use this instead of [crate::tensor::Tensor::shape] when you need the shape but want to
+    /// Use this instead of [`crate::tensor::Tensor::shape`] when you need the shape but want to
     /// preserve lazy initialization.
     pub fn lazy_shape(&self) -> burn_tensor::Shape {
         let initialization = match &self.state.initialization {
@@ -576,7 +576,7 @@ impl<T: Parameter> Param<T> {
     ///
     /// This method is used to restore a parameter from a tensor (typically during deserialization).
     /// It ensures the tensor is moved to the expected device, applies the param mapper's
-    /// `on_load` transformation, and preserves the autodiff settings (require_grad).
+    /// `on_load` transformation, and preserves the autodiff settings (`require_grad`).
     pub fn transform_for_load(self, tensor: T, param_id: ParamId) -> Self {
         let mut new_tensor = tensor;
 

--- a/crates/burn-core/src/module/param/constant.rs
+++ b/crates/burn-core/src/module/param/constant.rs
@@ -117,7 +117,7 @@ impl<const D: usize, K: Basic> Module for Tensor<D, K> {
         let device = self.device();
 
         if !devices.contains(&device) {
-            devices.push(device)
+            devices.push(device);
         }
 
         devices

--- a/crates/burn-core/src/module/param/group.rs
+++ b/crates/burn-core/src/module/param/group.rs
@@ -13,7 +13,7 @@ use regex::Regex;
 use burn_std::id::ParamId;
 use burn_tensor::{Bool, Int, Tensor};
 
-/// Errors tied to [ParamGroup]'s.
+/// Errors tied to [`ParamGroup`]'s.
 #[derive(Debug)]
 pub enum ParamGroupError {
     /// Use of an invalid Regex pattern.
@@ -85,7 +85,7 @@ impl ParamGroup {
     pub fn from_paths(paths: Vec<impl Into<String>>) -> Self {
         Self {
             matcher: ParamGroupMatcher::Path(Arc::new(PathMatcher::Exact(
-                paths.into_iter().map(|p| p.into()).collect(),
+                paths.into_iter().map(std::convert::Into::into).collect(),
             ))),
             excludes: None,
         }
@@ -101,7 +101,7 @@ impl ParamGroup {
     pub fn from_predicates(paths: Vec<impl Into<String>>) -> Self {
         Self {
             matcher: ParamGroupMatcher::Path(Arc::new(PathMatcher::Include(
-                paths.into_iter().map(|p| p.into()).collect(),
+                paths.into_iter().map(std::convert::Into::into).collect(),
             ))),
             excludes: None,
         }
@@ -123,9 +123,9 @@ impl ParamGroup {
             };
         };
 
-        matchers
-            .iter()
-            .for_each(|m| main_matcher = main_matcher.clone().fuse(m));
+        for m in &matchers {
+            main_matcher = main_matcher.clone().fuse(m);
+        }
 
         Self {
             matcher: main_matcher,
@@ -137,7 +137,7 @@ impl ParamGroup {
     /// Matches parameters by regex pattern (e.g., "^model\.layer\.\d+$")
     ///
     /// # Errors
-    /// Returns a [ParamGroupError::InvalidPatternError] if the string cannot be compiled into a valid regex.
+    /// Returns a [`ParamGroupError::InvalidPatternError`] if the string cannot be compiled into a valid regex.
     pub fn from_regex<S: AsRef<str>>(pattern: S) -> Result<Self, ParamGroupError> {
         ParamGroup::from_regexes(vec![pattern])
     }
@@ -147,7 +147,7 @@ impl ParamGroup {
     /// (e.g., "^encoder\.layer\.\d+", and "bias$" )
     ///
     /// # Errors
-    /// Returns a [ParamGroupError::InvalidPatternError] if the strings cannot be compiled into a valid regex.
+    /// Returns a [`ParamGroupError::InvalidPatternError`] if the strings cannot be compiled into a valid regex.
     pub fn from_regexes<S: AsRef<str>>(patterns: Vec<S>) -> Result<Self, ParamGroupError> {
         let mut new_patterns = vec![];
         for pattern in patterns {
@@ -171,7 +171,7 @@ impl ParamGroup {
     /// (e.g., "^encoder\.layer\.\d+$", or "^decoder\.layer\.\d+$" )
     ///
     /// # Errors
-    /// Returns a [ParamGroupError::InvalidPatternError] if the strings cannot be compiled into a valid regex.
+    /// Returns a [`ParamGroupError::InvalidPatternError`] if the strings cannot be compiled into a valid regex.
     pub fn from_any_regexes<S: AsRef<str>>(patterns: Vec<S>) -> Result<Self, ParamGroupError> {
         let mut matchers = vec![];
         for pattern in patterns {
@@ -179,7 +179,7 @@ impl ParamGroup {
                 Ok(re) => {
                     matchers.push(ParamGroupMatcher::Path(Arc::new(PathMatcher::Regex(vec![
                         re,
-                    ]))))
+                    ]))));
                 }
                 Err(e) => {
                     return Err(ParamGroupError::InvalidPatternError(format!(
@@ -198,9 +198,9 @@ impl ParamGroup {
             });
         };
 
-        matchers
-            .iter()
-            .for_each(|m| main_matcher = main_matcher.clone().fuse(m));
+        for m in &matchers {
+            main_matcher = main_matcher.clone().fuse(m);
+        }
 
         Ok(Self {
             matcher: main_matcher,
@@ -350,7 +350,7 @@ mod regex_serde {
     where
         S: Serializer,
     {
-        let v: Vec<&str> = regexes.iter().map(|r| r.as_str()).collect();
+        let v: Vec<&str> = regexes.iter().map(regex::Regex::as_str).collect();
         v.serialize(serializer)
     }
 

--- a/crates/burn-core/src/module/param/lora.rs
+++ b/crates/burn-core/src/module/param/lora.rs
@@ -3,7 +3,7 @@ use crate as burn;
 use crate::module::Module;
 use burn_tensor::Tensor;
 
-/// A LoRA (Low-Rank Adaptation) adapter attached to a frozen weight [parameter](Param).
+/// A `LoRA` (Low-Rank Adaptation) adapter attached to a frozen weight [parameter](Param).
 ///
 /// When present on a `Param<Tensor<2>>`, the parameter materializes its effective value as
 /// `base + scale * (a @ b)`, where `base` is the frozen (and optionally quantized) weight and

--- a/crates/burn-core/src/module/param/primitive.rs
+++ b/crates/burn-core/src/module/param/primitive.rs
@@ -14,7 +14,7 @@ where
 {
     fn visit<V: ModuleVisitor>(&self, visitor: &mut V) {
         if let Some(module) = self {
-            module.visit(visitor)
+            module.visit(visitor);
         }
     }
 
@@ -55,7 +55,7 @@ where
     T: AutodiffModule + Debug + Send + Clone,
 {
     fn valid(&self) -> Self {
-        self.as_ref().map(|module| module.valid())
+        self.as_ref().map(super::super::base::AutodiffModule::valid)
     }
 
     fn from_inner(module: Self) -> Self {
@@ -69,7 +69,7 @@ where
 {
     fn num_params(&self) -> usize {
         let mut num_params = 0;
-        for module in self.iter() {
+        for module in self {
             num_params += module.num_params();
         }
 
@@ -78,7 +78,7 @@ where
 
     fn visit<V: ModuleVisitor>(&self, visitor: &mut V) {
         for (i, module) in self.iter().enumerate() {
-            let index_str = alloc::format!("{}", i);
+            let index_str = alloc::format!("{i}");
             visitor.enter_module(&index_str, "Vec");
             module.visit(visitor);
             visitor.exit_module(&index_str, "Vec");
@@ -89,7 +89,7 @@ where
         self.into_iter()
             .enumerate()
             .map(|(i, module)| {
-                let index_str = alloc::format!("{}", i);
+                let index_str = alloc::format!("{i}");
                 mapper.enter_module(&index_str, "Vec");
                 let mapped = module.map(mapper);
                 mapper.exit_module(&index_str, "Vec");
@@ -109,7 +109,7 @@ where
     }
 
     fn collect_devices(&self, mut devices: Vec<Device>) -> Vec<Device> {
-        for module in self.iter() {
+        for module in self {
             devices = module.collect_devices(devices);
         }
 
@@ -137,7 +137,9 @@ where
     T: AutodiffModule + Debug + Send + Clone,
 {
     fn valid(&self) -> Self {
-        self.iter().map(|module| module.valid()).collect()
+        self.iter()
+            .map(super::super::base::AutodiffModule::valid)
+            .collect()
     }
 
     fn from_inner(module: Self) -> Self {
@@ -153,7 +155,7 @@ where
     T: Module + Debug + Send + Clone,
 {
     fn collect_devices(&self, mut devices: Vec<Device>) -> Vec<Device> {
-        for module in self.iter() {
+        for module in self {
             devices = module.collect_devices(devices);
         }
 
@@ -162,7 +164,7 @@ where
 
     fn num_params(&self) -> usize {
         let mut num_params = 0;
-        for module in self.iter() {
+        for module in self {
             num_params += module.num_params();
         }
 
@@ -171,7 +173,7 @@ where
 
     fn visit<V: ModuleVisitor>(&self, visitor: &mut V) {
         for (i, module) in self.iter().enumerate() {
-            let index_str = alloc::format!("{}", i);
+            let index_str = alloc::format!("{i}");
             visitor.enter_module(&index_str, "Array");
             module.visit(visitor);
             visitor.exit_module(&index_str, "Array");
@@ -181,7 +183,7 @@ where
     fn map<M: ModuleMapper>(self, mapper: &mut M) -> Self {
         let mut result = Vec::with_capacity(N);
         for (i, module) in IntoIterator::into_iter(self).enumerate() {
-            let index_str = alloc::format!("{}", i);
+            let index_str = alloc::format!("{i}");
             mapper.enter_module(&index_str, "Array");
             let mapped = module.map(mapper);
             mapper.exit_module(&index_str, "Array");

--- a/crates/burn-core/src/module/param/reparameterization_dyn.rs
+++ b/crates/burn-core/src/module/param/reparameterization_dyn.rs
@@ -304,19 +304,19 @@ impl<V: ModuleVisitor> DynModuleVisitor for DynVisitor<'_, V> {
     fn visit_float(&mut self, param: DynParamRef<'_>) {
         dispatch_rank!(param.rank, D => {
             self.visitor.visit_float(param.value.downcast_ref::<Param<Tensor<D>>>().unwrap());
-        })
+        });
     }
 
     fn visit_int(&mut self, param: DynParamRef<'_>) {
         dispatch_rank!(param.rank, D => {
             self.visitor.visit_int(param.value.downcast_ref::<Param<Tensor<D, Int>>>().unwrap());
-        })
+        });
     }
 
     fn visit_bool(&mut self, param: DynParamRef<'_>) {
         dispatch_rank!(param.rank, D => {
             self.visitor.visit_bool(param.value.downcast_ref::<Param<Tensor<D, Bool>>>().unwrap());
-        })
+        });
     }
 
     fn enter_module(&mut self, name: &str, container_type: &str) {

--- a/crates/burn-core/src/module/param/running.rs
+++ b/crates/burn-core/src/module/param/running.rs
@@ -75,7 +75,7 @@ impl<const D: usize> Module for RunningState<Tensor<D>> {
     fn visit<V: ModuleVisitor>(&self, visitor: &mut V) {
         let tensor = self.value.lock();
         let param = Param::initialized(self.id, tensor.clone());
-        visitor.visit_float(&param)
+        visitor.visit_float(&param);
     }
 
     fn map<M: ModuleMapper>(self, mapper: &mut M) -> Self {
@@ -108,7 +108,7 @@ impl<const D: usize> Module for RunningState<Tensor<D>> {
         let device = self.value.lock().device();
 
         if !devices.contains(&device) {
-            devices.push(device)
+            devices.push(device);
         }
 
         devices

--- a/crates/burn-core/src/module/param/tensor.rs
+++ b/crates/burn-core/src/module/param/tensor.rs
@@ -4,7 +4,7 @@ use crate::module::{
     AutodiffModule, Content, Module, ModuleDisplay, ModuleDisplayDefault, ModuleMapper,
     ModuleVisitor,
 };
-use alloc::{boxed::Box, format, string::ToString, vec::Vec};
+use alloc::{boxed::Box, format, string::String, vec::Vec};
 use burn_tensor::{Bool, Device, Float, Int, Tensor, TensorData};
 
 impl<const D: usize> super::sealed::Sealed for Tensor<D, Float> {
@@ -36,10 +36,10 @@ impl<const D: usize> Parameter for Tensor<D, Float> {
     }
 
     fn load_to_device(self, device: &Device) -> Self {
-        if self.device() != *device {
-            Tensor::to_device(self, device).detach()
-        } else {
+        if self.device() == *device {
             self
+        } else {
+            Tensor::to_device(self, device).detach()
         }
     }
 }
@@ -62,10 +62,10 @@ impl<const D: usize> Parameter for Tensor<D, Int> {
     }
 
     fn load_to_device(self, device: &Device) -> Self {
-        if self.device() != *device {
-            Tensor::to_device(self, device)
-        } else {
+        if self.device() == *device {
             self
+        } else {
+            Tensor::to_device(self, device)
         }
     }
 }
@@ -88,10 +88,10 @@ impl<const D: usize> Parameter for Tensor<D, Bool> {
     }
 
     fn load_to_device(self, device: &Device) -> Self {
-        if self.device() != *device {
-            Tensor::to_device(self, device)
-        } else {
+        if self.device() == *device {
             self
+        } else {
+            Tensor::to_device(self, device)
         }
     }
 }
@@ -101,7 +101,7 @@ impl<const D: usize> Param<Tensor<D>> {
     ///
     /// # Warnings
     ///
-    /// We strongly recommend using [Param::uninitialized] if you are using this method to
+    /// We strongly recommend using [`Param::uninitialized`] if you are using this method to
     /// initialize parameters inside a module, since the tensor initialization will be lazy,
     /// making the loading of weights more performant.
     pub fn from_tensor(value: Tensor<D>) -> Self {
@@ -195,7 +195,7 @@ impl<const D: usize> Module for Param<Tensor<D>> {
         let device = self.base().device();
 
         if !devices.contains(&device) {
-            devices.push(device)
+            devices.push(device);
         }
 
         if let Some(reparameterization) = self.reparameterization_dyn() {
@@ -211,7 +211,7 @@ impl<const D: usize> ModuleDisplayDefault for Param<Tensor<D>> {
         let id = if content.display_settings.show_param_id() {
             format!(", id: {}", self.id)
         } else {
-            "".to_string()
+            String::new()
         };
         let string = format!(
             "ParamTensor {{rank: {D}, shape: {:?}, kind: float{id}}}",
@@ -224,7 +224,7 @@ impl<const D: usize> ModuleDisplay for Param<Tensor<D>> {}
 
 impl<const D: usize> Module for Param<Tensor<D, Int>> {
     fn visit<V: ModuleVisitor>(&self, visitor: &mut V) {
-        visitor.visit_int(self)
+        visitor.visit_int(self);
     }
 
     fn map<M: ModuleMapper>(self, mapper: &mut M) -> Self {
@@ -243,7 +243,7 @@ impl<const D: usize> Module for Param<Tensor<D, Int>> {
         let device = self.val().device();
 
         if !devices.contains(&device) {
-            devices.push(device)
+            devices.push(device);
         }
 
         devices
@@ -255,7 +255,7 @@ impl<const D: usize> ModuleDisplayDefault for Param<Tensor<D, Int>> {
         let id = if content.display_settings.show_param_id() {
             format!(", id: {}", self.id)
         } else {
-            "".to_string()
+            String::new()
         };
         let string = format!(
             "ParamTensor {{rank: {D}, shape: {:?}, kind: int{id}}}",
@@ -268,7 +268,7 @@ impl<const D: usize> ModuleDisplay for Param<Tensor<D, Int>> {}
 
 impl<const D: usize> Module for Param<Tensor<D, Bool>> {
     fn visit<V: ModuleVisitor>(&self, visitor: &mut V) {
-        visitor.visit_bool(self)
+        visitor.visit_bool(self);
     }
 
     fn map<M: ModuleMapper>(self, mapper: &mut M) -> Self {
@@ -287,7 +287,7 @@ impl<const D: usize> Module for Param<Tensor<D, Bool>> {
         let device = self.val().device();
 
         if !devices.contains(&device) {
-            devices.push(device)
+            devices.push(device);
         }
 
         devices
@@ -299,7 +299,7 @@ impl<const D: usize> ModuleDisplayDefault for Param<Tensor<D, Bool>> {
         let id = if content.display_settings.show_param_id() {
             format!(", id: {}", self.id)
         } else {
-            "".to_string()
+            String::new()
         };
 
         let string = format!(

--- a/crates/burn-core/src/module/quantize.rs
+++ b/crates/burn-core/src/module/quantize.rs
@@ -34,7 +34,7 @@ impl Quantizer {
 
     /// Set the parameter group to quantize.
     pub fn set_param_group(&mut self, group: ParamGroup) {
-        self.group = group
+        self.group = group;
     }
 
     pub(crate) fn map_float_at_path<const D: usize>(

--- a/crates/burn-core/src/store/mod.rs
+++ b/crates/burn-core/src/store/mod.rs
@@ -324,7 +324,7 @@ impl ModuleVisitor for Collector {
 /// save/load cycles.
 struct ModuleRecordMapper {
     path: Vec<String>,
-    /// Map from module path to (persisted ParamId, tensor data).
+    /// Map from module path to (persisted `ParamId`, tensor data).
     tensors: HashMap<String, (ParamId, TensorData)>,
     dtype_policy: DTypePolicy,
     missing: Vec<String>,


### PR DESCRIPTION
This PR applies safe mechanical clippy::pedantic cleanups to crates/burn-core.

Summary of changes:
- Add doc backticks and fix documentation formatting.
- Remove unnecessary semicolons and simplify verbose syntax.
- Replace verbose iteration and match patterns with idiomatic equivalents.
- Apply formatting fixes.

API-affecting and structural lints (needless_pass_by_value, trivially_copy_pass_by_ref, unused_self, items_after_statements, too_many_lines, missing_fields_in_debug, must_use_candidate, return_self_not_must_use, missing_panics_doc, missing_errors_doc, similar_names) and numeric cast warnings were intentionally left untouched.