### PR TITLE
style(burn-tensor): apply clippy::pedantic cleanups

### DIFF
--- a/crates/burn-tensor/src/device.rs
+++ b/crates/burn-tensor/src/device.rs
@@ -171,7 +171,7 @@ impl<D: Into<DispatchDevice>> From<D> for Device {
 }
 
 /// Selector for the hardware index of a backend whose devices are simply
-/// indexed (e.g. CUDA, ROCm).
+/// indexed (e.g. CUDA, `ROCm`).
 ///
 /// Backend factory methods that take an index (`Device::cuda`, `Device::rocm`,
 /// `Device::libtorch_cuda`) accept `impl Into<DeviceIndex>`, so the common
@@ -627,7 +627,7 @@ impl Device {
     /// operations are dispatched instead of sitting idle. Eager backends, which execute each
     /// operation as it is registered, have nothing buffered and treat this as a no-op.
     pub fn flush(&self) {
-        Dispatch::flush(self.as_dispatch())
+        Dispatch::flush(self.as_dispatch());
     }
 
     /// Seeds the random number generator for this device.
@@ -648,7 +648,7 @@ impl Device {
     /// let t = Tensor::<1>::random([8], Distribution::Default, &device);
     /// ```
     pub fn seed(&self, seed: u64) {
-        Dispatch::seed(self.as_dispatch(), seed)
+        Dispatch::seed(self.as_dispatch(), seed);
     }
 
     /// Returns `true` if autodiff (gradient tracking) is enabled on this device.
@@ -879,7 +879,7 @@ impl Device {
 
             #[allow(unreachable_code)] // need to have one backend enabled, so it is reachable
             for device in Dispatch::enumerate(type_id) {
-                devices.push(Device::new(device))
+                devices.push(Device::new(device));
             }
         }
 

--- a/crates/burn-tensor/src/tensor/activation/base.rs
+++ b/crates/burn-tensor/src/tensor/activation/base.rs
@@ -15,7 +15,7 @@ pub fn relu<const D: usize>(tensor: Tensor<D>) -> Tensor<D> {
     tensor.relu()
 }
 
-/// Applies the HardTanh function element-wise, clamping each element to the
+/// Applies the `HardTanh` function element-wise, clamping each element to the
 /// range `[min_val, max_val]` (a cheap, piecewise-linear approximation of tanh).
 ///
 #[cfg_attr(not(doc), doc = "`HardTanh(x) = max(min_val, min(max_val, x))`")]
@@ -30,7 +30,7 @@ pub fn tanhshrink<const D: usize>(tensor: Tensor<D>) -> Tensor<D> {
     tensor.clone().sub(tensor.tanh())
 }
 
-/// Applies the ReLU6 function element-wise, the rectified linear unit clamped to
+/// Applies the `ReLU6` function element-wise, the rectified linear unit clamped to
 /// the range `[0, 6]` (as used in [MobileNetV2](https://arxiv.org/abs/1801.04381)).
 ///
 #[cfg_attr(doc, doc = "$$\\text{ReLU6}\\(x\\) = \\min\\(\\max\\(0, x\\), 6\\)$$")]
@@ -110,7 +110,7 @@ $$
     doc = "`GELU_approx(x) = 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))`"
 )]
 pub fn gelu_approximate<const D: usize>(tensor: Tensor<D>) -> Tensor<D> {
-    /// sqrt(2/π) precomputed as FRAC_2_SQRT_PI * FRAC_1_SQRT_2
+    /// sqrt(2/π) precomputed as `FRAC_2_SQRT_PI` * `FRAC_1_SQRT_2`
     const SQRT_2_OVER_PI: f64 =
         core::f64::consts::FRAC_2_SQRT_PI * core::f64::consts::FRAC_1_SQRT_2;
 
@@ -120,7 +120,7 @@ pub fn gelu_approximate<const D: usize>(tensor: Tensor<D>) -> Tensor<D> {
     (x.clone() * (inner.tanh() + 1)) * 0.5
 }
 
-/// Applies Parametric ReLu activation function as described in the paper
+/// Applies Parametric `ReLu` activation function as described in the paper
 /// [Delving Deep into Rectifiers: Surpassing Human-Level Performance on ImageNet Classification](https://arxiv.org/pdf/1502.01852).
 ///
 /// - The tensor is assumed to be of shape `[batch_size, channels, ...]`.
@@ -233,7 +233,7 @@ fn max_finite_exp_arg(dtype: DType) -> f64 {
     }
 }
 
-/// Applies the SoftPlus function element-wise.
+/// Applies the `SoftPlus` function element-wise.
 ///
 #[cfg_attr(
     doc,
@@ -245,19 +245,19 @@ $$
 )]
 #[cfg_attr(not(doc), doc = "`softplus(x_i) = log(1 + exp(beta * x_i)) / beta`")]
 ///
-/// The SoftPlus function is a smooth approximation of the ReLU function.
+/// The `SoftPlus` function is a smooth approximation of the `ReLU` function.
 ///
 /// Uses a default threshold of `20.0` for numerical stability. Use
 /// [`softplus_with_threshold`] to pick a different threshold.
 ///
 /// # Arguments
 ///
-/// - `beta`: Controls the sharpness of the approximation to ReLU.
+/// - `beta`: Controls the sharpness of the approximation to `ReLU`.
 pub fn softplus<const D: usize>(tensor: Tensor<D>, beta: f64) -> Tensor<D> {
     softplus_with_threshold(tensor, beta, DEFAULT_SOFTPLUS_THRESHOLD)
 }
 
-/// Applies the SoftPlus function element-wise, with an explicit stability threshold.
+/// Applies the `SoftPlus` function element-wise, with an explicit stability threshold.
 ///
 /// See [`softplus`] for the function itself, which uses the default threshold of `20.0`.
 ///
@@ -267,7 +267,7 @@ pub fn softplus<const D: usize>(tensor: Tensor<D>, beta: f64) -> Tensor<D> {
 ///
 /// # Arguments
 ///
-/// - `beta`: Controls the sharpness of the approximation to ReLU.
+/// - `beta`: Controls the sharpness of the approximation to `ReLU`.
 /// - `threshold`: The value of `beta * x` above which the linear approximation is used.
 pub fn softplus_with_threshold<const D: usize>(
     tensor: Tensor<D>,
@@ -408,7 +408,7 @@ pub fn log_sigmoid<const D: usize>(tensor: Tensor<D>) -> Tensor<D> {
     Tensor::new(log_sigmoid_impl(tensor.primitive))
 }
 
-/// Applies the SiLU function (also known as the swish function) element-wise.
+/// Applies the `SiLU` function (also known as the swish function) element-wise.
 ///
 #[cfg_attr(
     doc,
@@ -641,7 +641,7 @@ pub fn softsign<const D: usize>(tensor: Tensor<D>) -> Tensor<D> {
     tensor.clone().div(tensor.abs() + 1)
 }
 
-/// Applies the HardShrink function element-wise.
+/// Applies the `HardShrink` function element-wise.
 ///
 #[cfg_attr(
     doc,
@@ -667,7 +667,7 @@ pub fn hard_shrink<const D: usize>(tensor: Tensor<D>, lambda: f64) -> Tensor<D> 
     tensor.mask_fill(mask, 0)
 }
 
-/// Applies the SoftShrink function element-wise.
+/// Applies the `SoftShrink` function element-wise.
 ///
 #[cfg_attr(
     doc,

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -1210,7 +1210,7 @@ where
                 "Dimensions must not contain repeats; found {} unique dims and {} total dims",
                 unique_dims.len(),
                 dims.len()
-            )
+            );
         }
 
         let x = self.unchecked_roll_dim(shifts[0], dims[0]);
@@ -1697,7 +1697,7 @@ where
 
     /// Update the given tensor with the value tensor where the mask is true.
     ///
-    /// This is similar to [mask_fill](Tensor::mask_fill), however the value is a tensor instead of
+    /// This is similar to [`mask_fill`](Tensor::mask_fill), however the value is a tensor instead of
     /// a scalar.
     ///
     /// # Example
@@ -1723,7 +1723,7 @@ where
 
     /// Update the given tensor with the value where the mask is true.
     ///
-    /// This is similar to [mask_where](Tensor::mask_where), however the value is a scalar instead of
+    /// This is similar to [`mask_where`](Tensor::mask_where), however the value is a scalar instead of
     /// a tensor.
     ///
     /// # Example
@@ -2447,12 +2447,12 @@ where
         Tensor::new(K::not_equal_scalar(self.primitive, other))
     }
 
-    /// Alias for [equal_scalar](Self::equal_scalar).
+    /// Alias for [`equal_scalar`](Self::equal_scalar).
     pub fn equal_elem<E: Element>(self, other: E) -> Tensor<D, Bool> {
         self.equal_scalar(other)
     }
 
-    /// Alias for [not_equal_scalar](Self::not_equal_scalar).
+    /// Alias for [`not_equal_scalar`](Self::not_equal_scalar).
     pub fn not_equal_elem<E: Element>(self, other: E) -> Tensor<D, Bool> {
         self.not_equal_scalar(other)
     }
@@ -3099,7 +3099,7 @@ where
     }
 }
 
-/// Iterator given by (Tensor::iter_dim).
+/// Iterator given by (`Tensor::iter_dim`).
 pub struct DimIter<const D: usize, K>
 where
     K: Basic,

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -177,7 +177,7 @@ impl TensorCheck {
                 .details(format!(
                     "Source dimensions: {source_dims:?}, Destination dimensions: {destination_dims:?}.",
                 )),
-            )
+            );
         }
 
         check
@@ -395,7 +395,7 @@ impl TensorCheck {
             check = check.register(
                 "One Hot",
                 TensorError::new("Can't create a one hot tensor with less than 2 classes"),
-            )
+            );
         }
         check
     }

--- a/crates/burn-tensor/src/tensor/api/float.rs
+++ b/crates/burn-tensor/src/tensor/api/float.rs
@@ -185,7 +185,7 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     ///
     /// The median is not unique for input tensors with an even number of elements
     /// in the reduced dimension. In this case, the lower of the two medians is returned,
-    /// following PyTorch's behavior.
+    /// following `PyTorch`'s behavior.
     ///
     /// # Note
     ///
@@ -246,7 +246,7 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     ///
     /// The median is not unique for input tensors with an even number of elements
     /// in the reduced dimension. In this case, the lower of the two medians is returned,
-    /// following PyTorch's behavior.
+    /// following `PyTorch`'s behavior.
     ///
     /// # Note
     ///
@@ -334,7 +334,7 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
         is_require_grad_impl(&self.primitive)
     }
 
-    /// Mark the tensor as tracked or untracked depending on the require_grad argument.
+    /// Mark the tensor as tracked or untracked depending on the `require_grad` argument.
     /// When tracked, the gradients will be available after the backward pass.
     ///
     /// This function does nothing when autodiff is not enabled.
@@ -629,13 +629,13 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     ///
     /// # Arguments
     ///
-    /// * `grid` - A tensor of locations, with shape (N, H_out, W_out, 2). Values are [-1, 1].
+    /// * `grid` - A tensor of locations, with shape (N, `H_out`, `W_out`, 2). Values are [-1, 1].
     ///   A [x = -1, y = -1] means top-left, and [x = 1, y = 1] means bottom-right
-    /// * `options` - Grid sampling options (mode, padding_mode, align_corners)
+    /// * `options` - Grid sampling options (mode, `padding_mode`, `align_corners`)
     ///
     /// # Returns
     ///
-    /// A tensor with shape (N, C, H_out, W_out)
+    /// A tensor with shape (N, C, `H_out`, `W_out`)
     ///
     /// # Example
     ///

--- a/crates/burn-tensor/src/tensor/api/orderable.rs
+++ b/crates/burn-tensor/src/tensor/api/orderable.rs
@@ -531,22 +531,22 @@ where
         Tensor::new(K::lower_equal_scalar(self.primitive, other))
     }
 
-    /// Alias for [greater_scalar](Self::greater_scalar).
+    /// Alias for [`greater_scalar`](Self::greater_scalar).
     pub fn greater_elem<E: ElementConversion>(self, other: E) -> Tensor<D, Bool> {
         self.greater_scalar(other)
     }
 
-    /// Alias for [greater_equal_scalar](Self::greater_equal_scalar).
+    /// Alias for [`greater_equal_scalar`](Self::greater_equal_scalar).
     pub fn greater_equal_elem<E: ElementConversion>(self, other: E) -> Tensor<D, Bool> {
         self.greater_equal_scalar(other)
     }
 
-    /// Alias for [lower_scalar](Self::lower_scalar).
+    /// Alias for [`lower_scalar`](Self::lower_scalar).
     pub fn lower_elem<E: ElementConversion>(self, other: E) -> Tensor<D, Bool> {
         self.lower_scalar(other)
     }
 
-    /// Alias for [lower_equal_scalar](Self::lower_equal_scalar).
+    /// Alias for [`lower_equal_scalar`](Self::lower_equal_scalar).
     pub fn lower_equal_elem<E: ElementConversion>(self, other: E) -> Tensor<D, Bool> {
         self.lower_equal_scalar(other)
     }

--- a/crates/burn-tensor/src/tensor/api/pad.rs
+++ b/crates/burn-tensor/src/tensor/api/pad.rs
@@ -77,7 +77,7 @@ impl<const D: usize> IntoPadding<D> for Vec<(usize, usize)> {
     }
 }
 
-/// Helper to build a range array for slice_assign, selecting a portion of one dimension.
+/// Helper to build a range array for `slice_assign`, selecting a portion of one dimension.
 fn build_slice_ranges<const D: usize>(
     dims: [usize; D],
     target_dim: usize,

--- a/crates/burn-tensor/src/tensor/api/take.rs
+++ b/crates/burn-tensor/src/tensor/api/take.rs
@@ -16,7 +16,7 @@ where
     ///
     /// * `dim` - The dimension along which to select elements. Supports negative indexing.
     /// * `indices` - The indices of elements to select. Can be any dimensionality.
-    ///   Must be valid indices in the range [0, dim_size).
+    ///   Must be valid indices in the range [0, `dim_size`).
     ///
     /// # Example
     ///

--- a/crates/burn-tensor/src/tensor/distributed.rs
+++ b/crates/burn-tensor/src/tensor/distributed.rs
@@ -71,7 +71,7 @@ impl<const D: usize> CollectiveTensor<D> {
     }
 }
 
-/// Performs an all_reduce operation on the input tensor.
+/// Performs an `all_reduce` operation on the input tensor.
 ///
 /// # Arguments
 /// - `input`: The input tensor.
@@ -79,7 +79,7 @@ impl<const D: usize> CollectiveTensor<D> {
 /// - `device_ids`: The list of all devices with which to `all_reduce`
 ///
 /// # Returns
-/// A [CollectiveTensor] containing the handle of the result.
+/// A [`CollectiveTensor`] containing the handle of the result.
 pub fn all_reduce<const D: usize>(
     input: Tensor<D>,
     op: ReduceOperation,

--- a/crates/burn-tensor/src/tensor/grid/affine_grid.rs
+++ b/crates/burn-tensor/src/tensor/grid/affine_grid.rs
@@ -10,12 +10,12 @@ use alloc::vec;
 /// See:
 ///  - [torch.nn.functional.affine_grid](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.affine_grid.html)
 ///
-/// * `transform` - Transformation with shape (batch_size, 2, 3)
-/// * `dims` - dimensions as (batch_size, channels, height, width)
+/// * `transform` - Transformation with shape (`batch_size`, 2, 3)
+/// * `dims` - dimensions as (`batch_size`, channels, height, width)
 ///
 /// # Returns
 ///
-/// Tensor with shape (batch_size, height, width, 2), where dim 2 is (x, y)
+/// Tensor with shape (`batch_size`, height, width, 2), where dim 2 is (x, y)
 /// All coordinates are broadcast on the batch dim
 pub fn affine_grid_2d(transform: Tensor<3>, dims: [usize; 4]) -> Tensor<4> {
     let [batch_size, _c, height, width] = dims;

--- a/crates/burn-tensor/src/tensor/grid/mod.rs
+++ b/crates/burn-tensor/src/tensor/grid/mod.rs
@@ -9,12 +9,12 @@ pub use affine_grid::*;
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GridIndexing {
     /// Dimensions are in the same order as the cardinality of the inputs.
-    /// Equivalent to "ij" indexing in NumPy and PyTorch.
+    /// Equivalent to "ij" indexing in `NumPy` and `PyTorch`.
     #[default]
     Matrix,
 
     /// The same as Matrix, but the first two dimensions are swapped.
-    /// Equivalent to "xy" indexing in NumPy and PyTorch.
+    /// Equivalent to "xy" indexing in `NumPy` and `PyTorch`.
     Cartesian,
 }
 

--- a/crates/burn-tensor/src/tensor/linalg/det.rs
+++ b/crates/burn-tensor/src/tensor/linalg/det.rs
@@ -87,7 +87,7 @@ pub fn det<const D: usize, const D1: usize, const D2: usize>(mut tensor: Tensor<
         working_float_dtype = FloatDType::F32;
         tensor = tensor.cast(working_float_dtype);
     } else {
-        working_float_dtype = original_dtype.into()
+        working_float_dtype = original_dtype.into();
     };
 
     // Compute determinant for base cases (1x1, 2x2, and 3x3 matrices)

--- a/crates/burn-tensor/src/tensor/linalg/lu.rs
+++ b/crates/burn-tensor/src/tensor/linalg/lu.rs
@@ -83,7 +83,7 @@ pub fn lu<const D: usize, const D1: usize>(
     // Upcast f16 and bf16 to f32
     let needs_upcast = original_dtype == DType::F16 || original_dtype == DType::BF16;
     if needs_upcast {
-        tensor = tensor.cast(FloatDType::F32)
+        tensor = tensor.cast(FloatDType::F32);
     }
 
     let (lu_tensor, p_compact) = compute_lu_decomposition::<D, D1>(tensor);
@@ -491,8 +491,8 @@ fn apply_permutations_to_tensor<const D: usize>(
 /// Solves the equation L_{kk} U_{k, k+1:} = A_{k, k+1:}  for  U_{k, k+1:}.
 ///
 /// # Arguments
-/// - `diagonal_l_block`: The L block L_{k, k}, [k_start..k_end, k_start..k_end]
-/// - `row_blocks`: The row blocks A_{k, k+1}, ..., A_{k, N}, [k_start..k_end, k_end..]
+/// - `diagonal_l_block`: The L block L_{k, k}, [`k_start..k_end`, `k_start..k_end`]
+/// - `row_blocks`: The row blocks A_{k, k+1}, ..., A_{k, N}, [`k_start..k_end`, `k_end`..]
 /// - `block_size`: The size of the current block
 fn solve_for_u_blocks<const D: usize>(
     diagonal_l_block: Tensor<D>,

--- a/crates/burn-tensor/src/tensor/linalg/qr.rs
+++ b/crates/burn-tensor/src/tensor/linalg/qr.rs
@@ -7,7 +7,7 @@ use burn_std::Slice;
 /// This function decomposes the input tensor A into two tensors Q, R
 /// such that A = QR, where Q is an orthonormal matrix and R is an upper triangular matrix.
 /// If `reduced` is true then it returns reduced Q, R.
-/// The reduced QR decomposition agrees with the full QR decomposition when n_cols >= n_rows (wide matrix).
+/// The reduced QR decomposition agrees with the full QR decomposition when `n_cols` >= `n_rows` (wide matrix).
 ///
 /// # Arguments
 /// - `tensor` - The input tensor of shape `[..., n_rows, n_cols]`.

--- a/crates/burn-tensor/src/tensor/linalg/vector_norm.rs
+++ b/crates/burn-tensor/src/tensor/linalg/vector_norm.rs
@@ -21,7 +21,7 @@ pub enum Norm {
     /// L:INFINITY norm (maximum absolute value)
     LInf,
 
-    /// L:NEG_INFINITY norm (minimum absolute value)
+    /// `L:NEG_INFINITY` norm (minimum absolute value)
     LNegInf,
 
     /// Lp norm (generalized norm)
@@ -132,8 +132,8 @@ pub fn vector_norm<const D: usize>(
 /// * 1.0
 /// * 2.0
 /// * 2 * N for integral N,
-/// * f64::INFINITY,
-/// * f64::NEG_INFINITY,
+/// * `f64::INFINITY`,
+/// * `f64::NEG_INFINITY`,
 ///
 /// # Arguments
 ///
@@ -279,8 +279,8 @@ fn lp_signed_norm<const D: usize>(x: Tensor<D>, p: u32, dim: usize) -> Tensor<D>
 ///
 /// This uses no specialized implementations and cannot handle:
 /// * 0.0
-/// * f64::INFINITY,
-/// * f64::NEG_INFINITY,
+/// * `f64::INFINITY`,
+/// * `f64::NEG_INFINITY`,
 fn lp_norm_base<const D: usize>(x: Tensor<D>, p: f64, dim: usize) -> Tensor<D> {
     x.abs().powf_scalar(p).sum_dim(dim).powf_scalar(1. / p)
 }
@@ -311,7 +311,7 @@ where
     x.max_abs_dim(dim)
 }
 
-/// Computes the L:NEG_INFINITY norm of a tensor along a specified dimension.
+/// Computes the `L:NEG_INFINITY` norm of a tensor along a specified dimension.
 ///
 /// # Arguments
 ///
@@ -321,7 +321,7 @@ where
 ///
 /// # Returns
 ///
-/// The L:NEG_INFINITY norm of the input tensor.
+/// The `L:NEG_INFINITY` norm of the input tensor.
 pub fn min_abs_norm<const D: usize, K>(x: Tensor<D, K>, dim: impl AsIndex) -> Tensor<D, K>
 where
     K: Ordered,

--- a/crates/burn-tensor/src/tensor/module.rs
+++ b/crates/burn-tensor/src/tensor/module.rs
@@ -273,7 +273,7 @@ pub fn conv_transpose2d(
     )))
 }
 
-/// Applies a 3D transposed convolution](burn_backend::ops::ModuleOps::conv_transpose3d).
+/// Applies a 3D transposed convolution](`burn_backend::ops::ModuleOps::conv_transpose3d`).
 pub fn conv_transpose3d(
     x: Tensor<5>,
     weight: Tensor<5>,
@@ -307,7 +307,7 @@ pub fn unfold4d(x: Tensor<4>, kernel_size: [usize; 2], options: UnfoldOptions) -
 /// Combines an array of sliding local blocks into a large containing tensor, summing the
 /// values of blocks that overlap. This is the operation performed by
 /// [`torch.nn.Fold`](https://pytorch.org/docs/stable/generated/torch.nn.Fold.html), and is the
-/// adjoint of [unfold4d]: it reuses the same one-hot kernel through a [conv_transpose2d].
+/// adjoint of [unfold4d]: it reuses the same one-hot kernel through a [`conv_transpose2d`].
 ///
 /// # Arguments
 ///
@@ -517,8 +517,8 @@ pub fn interpolate(
 ///
 /// # Compatibility
 ///
-/// This function differs from PyTorch's ``torch.nn.functional.linear`` in that it does not
-/// transpose the weight matrix. In PyTorch, the weight matrix is transposed before
+/// This function differs from `PyTorch`'s ``torch.nn.functional.linear`` in that it does not
+/// transpose the weight matrix. In `PyTorch`, the weight matrix is transposed before
 /// multiplication:
 ///
 /// ```math
@@ -582,12 +582,12 @@ fn linear_impl(
     BridgeTensor::float(Dispatch::linear(
         input.into_float(),
         weight.into_float(),
-        bias.map(|b| b.into_float()),
+        bias.map(BridgeTensor::into_float),
     ))
 }
 
 /// Computes scaled dot-product attention: softmax(QKᵗ * scale) · V,
-/// where scale defaults to 1/sqrt(head_dim) (configurable via `options.scale`).
+/// where scale defaults to `1/sqrt(head_dim)` (configurable via `options.scale`).
 /// Optionally applies masking, additive bias, causal masking, and softcap.
 ///
 /// # Arguments
@@ -597,7 +597,7 @@ fn linear_impl(
 /// - `mask`: Optional boolean mask of shape `[batch_size, num_heads, seq_len_q, seq_len_k]`,
 ///   where `true` indicates positions to mask (i.e. set to -inf before softmax).
 /// - `attn_bias`: Optional float tensor of shape `[batch_size, num_heads, seq_len_q, seq_len_k]`
-///   added to the attention scores before softmax (e.g. ALiBi, relative position biases).
+///   added to the attention scores before softmax (e.g. `ALiBi`, relative position biases).
 /// - `options`: Additional attention options (custom scale, softcap, causal masking).
 ///
 /// # Returns
@@ -741,7 +741,7 @@ fn layer_norm_impl(
     BridgeTensor::float(Dispatch::layer_norm(
         input.into_float(),
         gamma.into_float(),
-        beta.map(|b| b.into_float()),
+        beta.map(BridgeTensor::into_float),
         epsilon,
     ))
 }

--- a/crates/burn-tensor/src/tensor/report.rs
+++ b/crates/burn-tensor/src/tensor/report.rs
@@ -1,6 +1,6 @@
 use super::Tensor;
 
-use colored::*;
+use colored::Colorize;
 
 /// Checks the closeness of two tensors and prints the results.
 ///

--- a/crates/burn-tensor/src/tensor/signal/stft.rs
+++ b/crates/burn-tensor/src/tensor/signal/stft.rs
@@ -23,7 +23,7 @@ pub struct StftOptions {
 }
 
 impl StftOptions {
-    /// Construct default options for the given FFT size, matching PyTorch defaults
+    /// Construct default options for the given FFT size, matching `PyTorch` defaults
     /// (`hop_length = n_fft / 4`, `win_length = None`, `center = true`, `onesided = true`).
     pub fn new(n_fft: usize) -> Self {
         Self {


### PR DESCRIPTION
This PR applies safe mechanical clippy::pedantic cleanups to crates/burn-tensor.

Summary of changes:
- Add doc backticks and fix documentation formatting.
- Remove redundant closures and replace wildcard imports with explicit names.
- Add trailing semicolons where appropriate and fix verbose syntax.
- Apply formatting fixes.

API-affecting lints (needless_pass_by_value), structural lints (too_many_lines, items_after_statements), doc-section lints (missing_panics_doc, missing_errors_doc), must_use, similar_names, many_single_char_names, inline_always, and all numeric cast warnings were intentionally left untouched.