### PR TITLE
style(burn-rocm): apply clippy::pedantic cleanups

### DIFF
--- a/crates/burn-rocm/src/lib.rs
+++ b/crates/burn-rocm/src/lib.rs
@@ -16,7 +16,8 @@ pub type Rocm = CubeBackend<HipRuntime>;
 #[cfg(feature = "fusion")]
 pub type Rocm = burn_fusion::Fusion<CubeBackend<HipRuntime>>;
 
-/// Measure peak throughput on a ROCm `device` for each of the given `keys`.
+/// Measure peak throughput on a `ROCm` [`device`](crate::RocmDevice) for each of the given `keys`.
+#[must_use]
 pub fn device_throughput(
     device: &RocmDevice,
     keys: &[ThroughputKey],


### PR DESCRIPTION
This PR applies safe mechanical clippy::pedantic cleanups to crates/burn-rocm.

API-affecting/structural lints and numeric cast warnings were intentionally left untouched.