### PR TITLE
style(burn-cpu): apply clippy::pedantic cleanups

### DIFF
--- a/crates/burn-cpu/src/lib.rs
+++ b/crates/burn-cpu/src/lib.rs
@@ -16,6 +16,7 @@ pub type Cpu = CubeBackend<CpuRuntime>;
 pub type Cpu = burn_fusion::Fusion<CubeBackend<CpuRuntime>>;
 
 /// Measure peak throughput on a CPU `device` for each of the given `keys`.
+#[must_use]
 pub fn device_throughput(
     device: &CpuDevice,
     keys: &[ThroughputKey],


### PR DESCRIPTION
This PR applies safe mechanical clippy::pedantic cleanups to crates/burn-cpu.

API-affecting/structural lints and numeric cast warnings were intentionally left untouched.