### PR TITLE
fix(store): abort instead of double-dropping when a mapper unwinds

### DIFF
--- a/crates/burn-store/src/traits.rs
+++ b/crates/burn-store/src/traits.rs
@@ -11,6 +11,38 @@ use crate::collector::Collector;
 use crate::{ModuleAdapter, PathFilter};
 use burn_core::module::Module;
 
+/// Ends the process if dropped while a panic is unwinding.
+///
+/// [`ModuleSnapshot::apply`] takes the module out of `&mut self` and cannot put one back until
+/// `map` returns. Aborting is the only sound exit from that window: the original module was
+/// consumed by `map`, so there is nothing valid left to restore, and letting the unwind
+/// continue would leave the moved-from value to be dropped a second time by its owner.
+///
+/// The same reasoning is why `take_mut` and `replace_with` abort rather than recover. A
+/// `Default` placeholder would be the alternative, but [`Module`] carries no such bound.
+struct AbortOnUnwind;
+
+impl Drop for AbortOnUnwind {
+    fn drop(&mut self) {
+        // Only reached while unwinding; the success path forgets the guard.
+        #[cfg(feature = "std")]
+        {
+            eprintln!(
+                "burn-store: a panic escaped Module::map during ModuleSnapshot::apply, leaving \
+                 the module moved-from. Aborting rather than dropping it twice."
+            );
+            std::process::abort();
+        }
+        // `abort` needs `std`. A panic raised while another is already unwinding ends the
+        // process the same way, so no-std gets the same guarantee by a different route.
+        #[cfg(not(feature = "std"))]
+        panic!(
+            "burn-store: a panic escaped Module::map during ModuleSnapshot::apply, leaving the \
+             module moved-from"
+        );
+    }
+}
+
 /// Extension trait for modules that provides tensor storage functionality.
 ///
 /// This trait provides convenient methods to collect tensors from any Burn module and apply
@@ -103,11 +135,21 @@ pub trait ModuleSnapshot: Module {
             // Read the module out of self (moves it, leaving self in undefined state)
             let module = core::ptr::read(self as *const Self);
 
+            // From here until the write below, `self` names a value that has been moved from.
+            // `map` runs caller code that can panic (a `ModuleAdapter` implementation, a
+            // backend's `from_data`), and an unwind through this window would hand that
+            // moved-from value back to its owner to be dropped a second time. See
+            // https://github.com/tracel-ai/burn/issues/5477
+            let guard = AbortOnUnwind;
+
             // Map the module to create a new one with updated tensors
             let new_module = module.map(&mut applier);
 
             // Write the new module back to self
             core::ptr::write(self as *mut Self, new_module);
+
+            // `self` holds a whole module again, so the window is closed.
+            core::mem::forget(guard);
         }
 
         applier.into_result()

--- a/crates/burn-store/tests/apply_unwind.rs
+++ b/crates/burn-store/tests/apply_unwind.rs
@@ -1,0 +1,100 @@
+//! `ModuleSnapshot::apply` moves the module out of `&mut self` and writes a mapped one back.
+//! A panic in between leaves `self` moved-from, so it must end the process rather than return
+//! and let the owner drop that value a second time.
+//!
+//! The abort is only observable from outside, so the test re-runs itself in a child process
+//! and inspects how that child died. Regression test for #5477.
+
+#![cfg(feature = "std")]
+
+// The `Module` derive expands to `::burn::...` paths.
+use burn_core as burn;
+
+use burn_core::module::{Module, Param, ParamId};
+use burn_core::tensor::{Device, Tensor, TensorData};
+use burn_pack::Tensor as PackTensor;
+use burn_store::{ModuleAdapter, ModuleContext, ModuleSnapshot};
+
+/// Set only in the child, which is the process that actually runs the panicking apply.
+const CHILD: &str = "BURN_STORE_APPLY_UNWIND_CHILD";
+
+/// What a test binary exits with when the harness catches an ordinary panic. Seeing this
+/// instead of an abort is exactly the pre-fix behaviour, so the test distinguishes the two.
+const HARNESS_TEST_FAILED: i32 = 101;
+
+#[derive(Module, Debug)]
+struct Model {
+    w: Param<Tensor<1>>,
+}
+
+/// Stands in for any caller code that can panic inside `map`: an adapter, or a backend's
+/// `from_data`. `ModuleAdapter` is a public trait, so this is ordinary safe code.
+#[derive(Debug, Clone, Default)]
+struct PanickingAdapter;
+
+impl ModuleAdapter for PanickingAdapter {
+    fn adapt(&self, _tensor: PackTensor, _ctx: ModuleContext<'_>) -> PackTensor {
+        panic!("adapter panicked mid-map");
+    }
+
+    fn clone_box(&self) -> Box<dyn ModuleAdapter> {
+        Box::new(self.clone())
+    }
+}
+
+#[test]
+fn a_panic_inside_map_aborts_instead_of_double_dropping() {
+    if std::env::var_os(CHILD).is_some() {
+        let device: Device = Default::default();
+        let mut model = Model {
+            w: Param::initialized(ParamId::new(), Tensor::<1>::from_data([1.0, 2.0], &device)),
+        };
+        let tensor =
+            burn_store::bridge::from_data(TensorData::from([9.0f32, 8.0]), "w".into(), None);
+
+        // Catching here is what a caller trying to recover would do, and is what made the
+        // double drop reachable: without the guard this returns and `model` is dropped again.
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            model.apply(vec![tensor], None, Some(Box::new(PanickingAdapter)), false)
+        }));
+
+        unreachable!("the abort guard should have ended the process before reaching here");
+    }
+
+    let output = std::process::Command::new(
+        std::env::current_exe().expect("the test binary should know its own path"),
+    )
+    .args([
+        "a_panic_inside_map_aborts_instead_of_double_dropping",
+        "--exact",
+        "--nocapture",
+    ])
+    .env(CHILD, "1")
+    .output()
+    .expect("re-running the test binary should succeed");
+
+    assert!(
+        !output.status.success(),
+        "the child returned from a panicking apply instead of aborting"
+    );
+    assert_ne!(
+        output.status.code(),
+        Some(HARNESS_TEST_FAILED),
+        "the child unwound and let the harness catch the panic, which means it returned \
+         through the window where the module is moved-from"
+    );
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+
+        // SIGABRT. Spelled out rather than pulled from `libc`, which is not a dependency here.
+        const SIGABRT: i32 = 6;
+        assert_eq!(
+            output.status.signal(),
+            Some(SIGABRT),
+            "expected the child to abort, got {:?}",
+            output.status
+        );
+    }
+}


### PR DESCRIPTION
Fixes #5477.

`ModuleSnapshot::apply` reads the module out of `&mut self` with `ptr::read`, maps it, and writes the result back. Nothing guarded the gap, so a panic inside `Module::map` left `self` moved-from and dropped a second time by its owner.

`map` runs caller code before the write is reached - a `ModuleAdapter` implementation, or a backend `from_data` - and `apply` is a safe method on a public trait, so the double free was reachable without any `unsafe`.

The window is now covered by a guard that aborts if dropped while unwinding, the same answer `take_mut` and `replace_with` give: the original module was consumed by `map`, so there is nothing valid left to restore. Without `std` it panics instead, which during an unwind ends the process the same way.

The regression test re-runs itself in a child process and asserts SIGABRT, since an abort is not observable in-process. Against the old code the child exits 101 (the harness caught the panic and returned, which is the bug).

Considered and rejected: changing `apply` to take `self` by value and return `(Self, ApplyResult)`, which removes the `unsafe` entirely. That is a breaking change to a public trait and its two `ModuleStore` callers, so it belongs in its own discussion rather than a fix.