### PR TITLE
fix(store): reject a loaded tensor whose dtype is the wrong kind

### DIFF
--- a/crates/burn-store/src/applier.rs
+++ b/crates/burn-store/src/applier.rs
@@ -18,11 +18,16 @@ use crate::{ModuleAdapter, ModuleContext, PathFilter};
 
 /// The kind of parameter a loaded tensor is going into.
 ///
-/// A loaded parameter keeps whatever dtype the source declared, across every kind. For floats
-/// that is what makes a half-precision save loadable into a module written for full precision
+/// A loaded float or int parameter keeps whatever dtype the source declared. For floats that
+/// is what makes a half-precision save loadable into a module written for full precision
 /// (`dtype_preservation_f64` below pins it); for ints it is what keeps a PyTorch checkpoint's
 /// int64 buffers at int64 rather than narrowing them to the backend's element (pinned by
 /// `pytorch-tests`' `integer_full_precision`, added deliberately in #4854).
+///
+/// Bool is the exception, and is not preserved: `TensorCreationOptions::resolve_dtype` always
+/// resolves a bool tensor to the device's own bool storage, because a `BoolStore` variant is a
+/// backend-specific layout rather than a semantic type and the one a file names may not exist
+/// on this device. A bool source is accepted for its kind and then re-stored.
 ///
 /// What is checked here is only that the source is of the right *kind*. Shape agreement says
 /// nothing about that, so before #5478 float data loaded into an `Int` parameter and left it
@@ -37,16 +42,16 @@ enum TargetDType {
 impl TargetDType {
     /// Whether a source of `dtype` can be loaded into a parameter of this kind.
     fn accepts(self, dtype: DType) -> bool {
-        // `is_int` covers only signed integers, so unsigned needs asking for separately.
-        let integral = dtype.is_int() || dtype.is_uint();
-
         match self {
             // Quantized data is a float tensor's packed form, so it belongs to this kind too.
             Self::Float => dtype.is_float() || matches!(dtype, DType::QFloat(_)),
-            Self::Int => integral,
+            // `is_int` covers only signed integers, so unsigned needs asking for separately.
+            Self::Int => dtype.is_int() || dtype.is_uint(),
             // An integer source is how bools survive a format with no boolean dtype:
-            // SafeTensors stores `Bool(U32)` as `U32` and reads it back as an integer.
-            Self::Bool => integral || dtype.is_bool(),
+            // SafeTensors stores `Bool(U32)` as `U32` and reads it back as an integer. Only
+            // the widths `BoolStore` actually uses qualify: accepting any integer would let
+            // an I64 tensor land in a bool parameter unremarked.
+            Self::Bool => dtype.is_bool() || matches!(dtype, DType::U8 | DType::U32),
         }
     }
 
@@ -257,9 +262,26 @@ impl Applier {
             return None;
         }
 
+        // Validate the dtype's kind. Shape agreement alone is not enough: it says nothing
+        // about whether the bytes mean what the parameter's element type says they mean. The
+        // width is left alone on purpose, so a half-precision or int64 source still loads as
+        // itself; only a source of the wrong kind entirely is refused.
+        //
+        // Checked before the load rather than after, since the kind is already in the
+        // descriptor: a rejected tensor is then never read, which for a file-backed source
+        // would be the whole thing off disk.
+        let dtype = tensor.dtype;
+        if !target_dtype.accepts(dtype) {
+            self.errors.push(ApplyError::DTypeMismatch {
+                path: path.clone(),
+                expected: target_dtype.expected(target_device),
+                found: dtype,
+            });
+            return None; // Signal caller to fall back to initialization
+        }
+
         // Load tensor data. The tensor is not needed afterwards, so take its bytes rather
         // than copying them out.
-        let dtype = tensor.dtype;
         let data = match bridge::into_data(tensor) {
             Ok(data) => data,
             Err(e) => {
@@ -277,19 +299,6 @@ impl Applier {
                 path: path.clone(),
                 expected: target_shape,
                 found: data.shape,
-            });
-            return None; // Signal caller to fall back to initialization
-        }
-
-        // Validate the dtype's kind. Shape agreement alone is not enough: it says nothing
-        // about whether the bytes mean what the parameter's element type says they mean. The
-        // width is left alone on purpose, so a half-precision or int64 source still loads as
-        // itself; only a source of the wrong kind entirely is refused.
-        if !target_dtype.accepts(dtype) {
-            self.errors.push(ApplyError::DTypeMismatch {
-                path: path.clone(),
-                expected: target_dtype.expected(target_device),
-                found: dtype,
             });
             return None; // Signal caller to fall back to initialization
         }

--- a/crates/burn-store/src/applier.rs
+++ b/crates/burn-store/src/applier.rs
@@ -8,13 +8,62 @@ use alloc::vec::Vec;
 use hashbrown::{HashMap, HashSet};
 
 use burn_core::module::{ModuleMapper, Param, ParamId};
-use burn_core::tensor::{Bool, Device, Int, Shape, Tensor};
+use burn_core::tensor::{Bool, DType, Device, Int, Shape, Tensor};
 
 use burn_pack::Tensor as PackTensor;
 
 use crate::apply_result::{ApplyError, ApplyResult};
 use crate::bridge;
 use crate::{ModuleAdapter, ModuleContext, PathFilter};
+
+/// The kind of parameter a loaded tensor is going into.
+///
+/// A loaded parameter keeps whatever dtype the source declared, across every kind. For floats
+/// that is what makes a half-precision save loadable into a module written for full precision
+/// (`dtype_preservation_f64` below pins it); for ints it is what keeps a PyTorch checkpoint's
+/// int64 buffers at int64 rather than narrowing them to the backend's element (pinned by
+/// `pytorch-tests`' `integer_full_precision`, added deliberately in #4854).
+///
+/// What is checked here is only that the source is of the right *kind*. Shape agreement says
+/// nothing about that, so before #5478 float data loaded into an `Int` parameter and left it
+/// holding `F32` - a tensor whose declared element type cannot read its own data.
+#[derive(Clone, Copy)]
+enum TargetDType {
+    Float,
+    Int,
+    Bool,
+}
+
+impl TargetDType {
+    /// Whether a source of `dtype` can be loaded into a parameter of this kind.
+    fn accepts(self, dtype: DType) -> bool {
+        // `is_int` covers only signed integers, so unsigned needs asking for separately.
+        let integral = dtype.is_int() || dtype.is_uint();
+
+        match self {
+            // Quantized data is a float tensor's packed form, so it belongs to this kind too.
+            Self::Float => dtype.is_float() || matches!(dtype, DType::QFloat(_)),
+            Self::Int => integral,
+            // An integer source is how bools survive a format with no boolean dtype:
+            // SafeTensors stores `Bool(U32)` as `U32` and reads it back as an integer.
+            Self::Bool => integral || dtype.is_bool(),
+        }
+    }
+
+    /// What to name as expected when [`accepts`](Self::accepts) turns a source away.
+    ///
+    /// The device's own element for this kind, which is the best available stand-in: there is
+    /// no `lazy_dtype` on [`Param`] to ask a lazily-initialized parameter for its dtype
+    /// without forcing it to materialize. Only the kind is load-bearing in the message.
+    fn expected(self, device: &Device) -> DType {
+        let settings = device.settings();
+        match self {
+            Self::Float => settings.float_dtype.into(),
+            Self::Int => settings.int_dtype.into(),
+            Self::Bool => settings.bool_dtype.into(),
+        }
+    }
+}
 
 /// Applier that applies loaded tensors to module parameters
 /// with proper adapter support using container type information
@@ -155,6 +204,7 @@ impl Applier {
         &mut self,
         target_device: &Device,
         target_shape: Shape,
+        target_dtype: TargetDType,
     ) -> Option<(Tensor<D, K>, Option<ParamId>)>
     where
         K: burn_core::tensor::kind::Basic,
@@ -231,6 +281,19 @@ impl Applier {
             return None; // Signal caller to fall back to initialization
         }
 
+        // Validate the dtype's kind. Shape agreement alone is not enough: it says nothing
+        // about whether the bytes mean what the parameter's element type says they mean. The
+        // width is left alone on purpose, so a half-precision or int64 source still loads as
+        // itself; only a source of the wrong kind entirely is refused.
+        if !target_dtype.accepts(dtype) {
+            self.errors.push(ApplyError::DTypeMismatch {
+                path: path.clone(),
+                expected: target_dtype.expected(target_device),
+                found: dtype,
+            });
+            return None; // Signal caller to fall back to initialization
+        }
+
         self.applied.push(path);
         Some((Tensor::from_data(data, (target_device, dtype)), source_id))
     }
@@ -263,7 +326,7 @@ impl ModuleMapper for Applier {
         let target_shape = param.lazy_shape();
 
         // Try to apply the loaded tensor with shape validation
-        match self.apply_tensor(&target_device, target_shape) {
+        match self.apply_tensor(&target_device, target_shape, TargetDType::Float) {
             Some((tensor, source_id)) => {
                 // Prefer the source's persisted ParamId so optimizer state (keyed by ParamId)
                 // survives save/load cycles, but keep the target's id when the source format
@@ -283,7 +346,7 @@ impl ModuleMapper for Applier {
         let target_shape = param.lazy_shape();
 
         // Try to apply the loaded tensor with shape validation
-        match self.apply_tensor(&target_device, target_shape) {
+        match self.apply_tensor(&target_device, target_shape, TargetDType::Int) {
             Some((tensor, source_id)) => {
                 param.transform_for_load(tensor, source_id.unwrap_or(param_id))
             }
@@ -303,7 +366,7 @@ impl ModuleMapper for Applier {
         let target_shape = param.lazy_shape();
 
         // Try to apply the loaded tensor with shape validation
-        match self.apply_tensor(&target_device, target_shape) {
+        match self.apply_tensor(&target_device, target_shape, TargetDType::Bool) {
             Some((tensor, source_id)) => {
                 param.transform_for_load(tensor, source_id.unwrap_or(param_id))
             }

--- a/crates/burn-store/tests/apply_dtype.rs
+++ b/crates/burn-store/tests/apply_dtype.rs
@@ -190,3 +190,79 @@ fn float_data_is_refused_by_a_bool_parameter() {
         result.errors
     );
 }
+
+/// A `BoolStore` is only ever `Native`, `U8` or `U32`, so those are the widths an integer
+/// source can plausibly be carrying a bool in. Accepting any integer would let an I64 tensor
+/// land in a bool parameter unremarked, which is the silent wrong-kind load this check exists
+/// to stop.
+#[test]
+fn a_wide_integer_source_is_refused_by_a_bool_parameter() {
+    let device: Device = Default::default();
+
+    for data in [
+        TensorData::from([1i64, 0]),
+        TensorData::from([1i32, 0]),
+        TensorData::from([1i8, 0]),
+        TensorData::from([1u64, 0]),
+        TensorData::from([1u16, 0]),
+    ] {
+        let dtype = data.dtype;
+        let mut model = BoolModel {
+            mask: Param::initialized(
+                ParamId::new(),
+                Tensor::<1, Bool>::from_data([true, true], &device),
+            ),
+        };
+
+        let result = model.apply(vec![source(data, "mask")], None, None, false);
+
+        assert!(
+            result.applied.is_empty(),
+            "{dtype:?} should not load into a bool parameter"
+        );
+        assert!(
+            matches!(result.errors.as_slice(), [ApplyError::DTypeMismatch { .. }]),
+            "{dtype:?} got {:?}",
+            result.errors
+        );
+        assert_eq!(
+            model.mask.val().to_data().try_to_vec::<bool>().unwrap(),
+            vec![true, true],
+            "{dtype:?} must leave the parameter untouched"
+        );
+    }
+}
+
+/// The other half of the same rule: the two widths a `BoolStore` does use are still accepted.
+#[test]
+fn the_bool_store_widths_are_accepted_by_a_bool_parameter() {
+    let device: Device = Default::default();
+
+    for data in [
+        TensorData::from([1u8, 0]),
+        TensorData::from([1u32, 0]),
+        TensorData::from([true, false]),
+    ] {
+        let dtype = data.dtype;
+        let mut model = BoolModel {
+            mask: Param::initialized(
+                ParamId::new(),
+                Tensor::<1, Bool>::from_data([false, false], &device),
+            ),
+        };
+
+        let result = model.apply(vec![source(data, "mask")], None, None, false);
+
+        assert_eq!(result.applied, vec!["mask".to_string()], "{dtype:?}");
+        assert!(
+            result.errors.is_empty(),
+            "{dtype:?} got {:?}",
+            result.errors
+        );
+        assert_eq!(
+            model.mask.val().to_data().try_to_vec::<bool>().unwrap(),
+            vec![true, false],
+            "{dtype:?}"
+        );
+    }
+}

--- a/crates/burn-store/tests/apply_dtype.rs
+++ b/crates/burn-store/tests/apply_dtype.rs
@@ -1,0 +1,192 @@
+//! The applier checks that a loaded tensor's dtype is of the right *kind* for the parameter
+//! it is going into, not only that the shapes agree. Widths are deliberately left alone, so a
+//! half-precision or int64 source still loads as itself. Regression tests for #5478.
+
+#![cfg(feature = "std")]
+
+// The `Module` derive expands to `::burn::...` paths.
+use burn_core as burn;
+
+use burn_core::module::{Module, Param, ParamId};
+use burn_core::tensor::{Bool, DType, Device, Int, Tensor, TensorData};
+use burn_store::{ApplyError, ModuleSnapshot};
+
+#[derive(Module, Debug)]
+struct IntModel {
+    ids: Param<Tensor<1, Int>>,
+}
+
+#[derive(Module, Debug)]
+struct BoolModel {
+    mask: Param<Tensor<1, Bool>>,
+}
+
+#[derive(Module, Debug)]
+struct FloatModel {
+    w: Param<Tensor<1>>,
+}
+
+fn int_model(device: &Device) -> IntModel {
+    IntModel {
+        ids: Param::initialized(
+            ParamId::new(),
+            Tensor::<1, Int>::from_data([1, 2, 3], device),
+        ),
+    }
+}
+
+fn source(data: TensorData, name: &str) -> burn_pack::Tensor {
+    burn_store::bridge::from_data(data, name.to_string(), None)
+}
+
+/// PyTorch writes integer buffers as int64, and the loaded parameter keeps that width rather
+/// than narrowing to the backend's element. Pinned deliberately in #4854; the kind check must
+/// not change it.
+#[test]
+fn an_int_source_keeps_its_own_width() {
+    let device: Device = Default::default();
+    let mut model = int_model(&device);
+
+    let result = model.apply(
+        vec![source(TensorData::from([9i64, 8, 7]), "ids")],
+        None,
+        None,
+        false,
+    );
+
+    assert_eq!(result.applied, vec!["ids".to_string()]);
+    assert!(result.errors.is_empty(), "{:?}", result.errors);
+
+    let data = model.ids.val().to_data();
+    assert_eq!(data.dtype, DType::I64);
+    assert_eq!(data.try_to_vec::<i64>().unwrap(), vec![9, 8, 7]);
+}
+
+/// Float data in an int parameter is not a width difference, it is the wrong kind. Shape
+/// agreement says nothing about it, so before #5478 it loaded and left the parameter F32.
+#[test]
+fn float_data_is_refused_by_an_int_parameter() {
+    let device: Device = Default::default();
+    let mut model = int_model(&device);
+    let before = model.ids.val().to_data();
+
+    let result = model.apply(
+        vec![source(TensorData::from([9.0f32, 8.0, 7.0]), "ids")],
+        None,
+        None,
+        false,
+    );
+
+    assert!(result.applied.is_empty(), "{:?}", result.applied);
+    assert!(
+        matches!(
+            result.errors.as_slice(),
+            [ApplyError::DTypeMismatch { path, found, .. }]
+                if path == "ids" && *found == DType::F32
+        ),
+        "expected a DTypeMismatch naming the source dtype, got {:?}",
+        result.errors
+    );
+
+    let after = model.ids.val().to_data();
+    assert_eq!(after.dtype, before.dtype, "the parameter was modified");
+    assert_eq!(after.try_to_vec::<i32>().unwrap(), vec![1, 2, 3]);
+}
+
+/// The mirror case: integer data in a float parameter.
+#[test]
+fn int_data_is_refused_by_a_float_parameter() {
+    let device: Device = Default::default();
+    let mut model = FloatModel {
+        w: Param::initialized(ParamId::new(), Tensor::<1>::from_data([1.0, 2.0], &device)),
+    };
+
+    let result = model.apply(
+        vec![source(TensorData::from([7i64, 6]), "w")],
+        None,
+        None,
+        false,
+    );
+
+    assert!(result.applied.is_empty());
+    assert!(
+        matches!(result.errors.as_slice(), [ApplyError::DTypeMismatch { .. }]),
+        "got {:?}",
+        result.errors
+    );
+    assert_eq!(
+        model.w.val().to_data().try_to_vec::<f32>().unwrap(),
+        vec![1.0, 2.0]
+    );
+}
+
+/// A half-precision save must still load into a full-precision module, so float parameters
+/// keep the source's dtype. This is the behaviour `dtype_preservation_f64` already pinned and
+/// the dtype check must not break.
+#[test]
+fn a_float_parameter_still_keeps_the_sources_precision() {
+    let device: Device = Default::default();
+    let mut model = FloatModel {
+        w: Param::initialized(ParamId::new(), Tensor::<1>::from_data([1.0, 2.0], &device)),
+    };
+
+    let half = TensorData::from([3.0f32, 4.0]).convert_dtype(DType::F16);
+    let result = model.apply(vec![source(half, "w")], None, None, false);
+
+    assert_eq!(result.applied, vec!["w".to_string()]);
+    assert!(result.errors.is_empty(), "{:?}", result.errors);
+    assert_eq!(model.w.val().to_data().dtype, DType::F16);
+}
+
+/// SafeTensors has no boolean dtype for the non-native bool stores, so it writes `Bool(U32)`
+/// as `U32` and reads it back as an integer. A bool parameter has to accept that.
+#[test]
+fn an_integer_source_still_loads_into_a_bool_parameter() {
+    let device: Device = Default::default();
+    let mut model = BoolModel {
+        mask: Param::initialized(
+            ParamId::new(),
+            Tensor::<1, Bool>::from_data([false, false, false, false], &device),
+        ),
+    };
+
+    let result = model.apply(
+        vec![source(TensorData::from([1u32, 0, 1, 0]), "mask")],
+        None,
+        None,
+        false,
+    );
+
+    assert_eq!(result.applied, vec!["mask".to_string()]);
+    assert!(result.errors.is_empty(), "{:?}", result.errors);
+    assert_eq!(
+        model.mask.val().to_data().try_to_vec::<bool>().unwrap(),
+        vec![true, false, true, false]
+    );
+}
+
+/// Float data in a bool parameter is still the wrong kind.
+#[test]
+fn float_data_is_refused_by_a_bool_parameter() {
+    let device: Device = Default::default();
+    let mut model = BoolModel {
+        mask: Param::initialized(
+            ParamId::new(),
+            Tensor::<1, Bool>::from_data([true, true], &device),
+        ),
+    };
+
+    let result = model.apply(
+        vec![source(TensorData::from([1.0f32, 0.0]), "mask")],
+        None,
+        None,
+        false,
+    );
+
+    assert!(result.applied.is_empty());
+    assert!(
+        matches!(result.errors.as_slice(), [ApplyError::DTypeMismatch { .. }]),
+        "got {:?}",
+        result.errors
+    );
+}


### PR DESCRIPTION
Fixes #5478.

`Applier::apply_tensor` validated shape and then built the parameter with the source's dtype, never checking the two agreed on kind. Float data applied to an `Int` parameter left it holding `F32`, reported as applied with no errors; reading it back at the declared element type then failed. `ApplyError::DTypeMismatch` was declared for exactly this and never constructed.

The kind is now checked before loading, and a disagreement reports `DTypeMismatch`.

Widths are deliberately left alone. #5478 as filed also proposed narrowing int sources to the backend's element, and that is wrong: `pytorch-tests` pins the opposite in #4854, with a comment naming that cast as the regression to catch. A half-precision source still loads as F16 and a PyTorch int64 buffer still loads as I64. `an_int_source_keeps_its_own_width` now pins it from burn-store's side too, so the next person gets a failing test rather than reaching the same wrong conclusion I did.

Bool parameters still accept integer sources, which is how bools survive SafeTensors (`Bool(U32)` is written as `U32` and read back as an integer).

Open question, deliberately not decided here: whether #4854 should be revisited so int sources narrow to the backend element. That is a change to loading semantics, not a bug fix.