### PR TITLE
docs(pack): clarify tensor thread-safety contract

### DIFF
--- a/crates/burn-pack/src/tensor.rs
+++ b/crates/burn-pack/src/tensor.rs
@@ -14,9 +14,7 @@ use alloc::string::String;
 
 #[cfg(target_has_atomic = "ptr")]
 use alloc::sync::Arc;
-// `alloc::sync` needs atomic CAS. A target without it has no threads to share a tensor
-// across, so neither the atomic pointer nor the `Send + Sync` bound on the provider is
-// needed there, and both are dropped below.
+// `alloc::sync` needs atomic CAS, so use its non-atomic counterpart on targets without it.
 #[cfg(not(target_has_atomic = "ptr"))]
 use alloc::rc::Rc as Arc;
 
@@ -27,15 +25,8 @@ use crate::base::Error;
 /// Shared handle to a deferred tensor's byte provider, kept behind a pointer so [`Tensor`]
 /// stays [`Clone`].
 ///
-/// The provider is `Send + Sync` on targets with threads, because a [`Tensor`] must stay
-/// `Send`: an optimizer record holds a `Vec` of them and crosses threads through burn-train's
-/// async checkpointer, whose `Checkpoint` bound is `Send`. `Sync` follows from sharing the
-/// provider at all (`Arc<T>: Send` requires `T: Send + Sync`). A target without atomic CAS
-/// has no threads and no `alloc::sync`, so neither bound applies or can be met there, and
-/// [`Tensor::deferred`] asks for correspondingly less.
-#[cfg(target_has_atomic = "ptr")]
-type Provider = Arc<dyn Fn() -> Result<Bytes, Error> + Send + Sync>;
-#[cfg(not(target_has_atomic = "ptr"))]
+/// The pointer varies with the target's atomic support, but the provider itself has no
+/// thread-safety requirement.
 type Provider = Arc<dyn Fn() -> Result<Bytes, Error>>;
 
 /// Where a tensor's bytes come from.
@@ -158,23 +149,6 @@ impl Tensor {
     /// result is dropped before the next tensor's is requested. Producing the data there -
     /// reading a parameter back from a device, say - is what bounds a save's peak host memory
     /// by the largest single tensor rather than by the whole model.
-    #[cfg(target_has_atomic = "ptr")]
-    pub fn deferred(
-        name: String,
-        dtype: DType,
-        shape: impl Into<Shape>,
-        param_id: Option<u64>,
-        byte_len: usize,
-        provider: impl Fn() -> Result<Bytes, Error> + Send + Sync + 'static,
-    ) -> Self {
-        Self::with_provider(name, dtype, shape, param_id, byte_len, Arc::new(provider))
-    }
-
-    /// Create a tensor whose bytes are produced on demand.
-    ///
-    /// See the `target_has_atomic = "ptr"` variant for the contract. This one drops the
-    /// `Send + Sync` bound, which nothing on a single-threaded target can satisfy or needs.
-    #[cfg(not(target_has_atomic = "ptr"))]
     pub fn deferred(
         name: String,
         dtype: DType,
@@ -186,7 +160,6 @@ impl Tensor {
         Self::with_provider(name, dtype, shape, param_id, byte_len, Arc::new(provider))
     }
 
-    /// The half of [`deferred`](Self::deferred) that does not vary by target.
     fn with_provider(
         name: String,
         dtype: DType,
@@ -264,12 +237,13 @@ impl core::fmt::Debug for Tensor {
 
 // The counting tests below need `fetch_add`, so the whole module wants atomic CAS. Tests are
 // only ever run on a host anyway; this keeps `--tests` compiling for embedded targets.
-#[cfg(all(test, target_has_atomic = "ptr"))]
+#[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::rc::Rc;
     use alloc::string::ToString;
     use alloc::vec;
-    use core::sync::atomic::{AtomicUsize, Ordering};
+    use core::cell::Cell;
 
     /// `to_bytes` borrows rather than consuming, so the tensor can still be drawn from
     /// afterwards. That is the whole reason it exists next to `into_bytes`.
@@ -291,22 +265,23 @@ mod tests {
     /// paths use `into_parts` instead.
     #[test]
     fn to_bytes_reruns_a_deferred_provider_on_every_call() {
-        let calls = Arc::new(AtomicUsize::new(0));
+        // Capturing `Rc<Cell<_>>` also pins that deferred providers need not be Send or Sync.
+        let calls = Rc::new(Cell::new(0));
         let counter = calls.clone();
 
         let tensor = Tensor::deferred("w".to_string(), DType::U8, vec![2], None, 2, move || {
-            counter.fetch_add(1, Ordering::Relaxed);
+            counter.set(counter.get() + 1);
             Ok(Bytes::from_bytes_vec(vec![7, 8]))
         });
 
         assert_eq!(&tensor.to_bytes().unwrap()[..], &[7, 8]);
         assert_eq!(&tensor.to_bytes().unwrap()[..], &[7, 8]);
-        assert_eq!(calls.load(Ordering::Relaxed), 2);
+        assert_eq!(calls.get(), 2);
 
         // Still usable, and `into_bytes` draws once more.
         assert_eq!(tensor.byte_len(), 2);
         assert_eq!(&tensor.into_bytes().unwrap()[..], &[7, 8]);
-        assert_eq!(calls.load(Ordering::Relaxed), 3);
+        assert_eq!(calls.get(), 3);
     }
 
     /// A provider failure surfaces verbatim. Naming the tensor is `Writer::materialize`'s
@@ -343,14 +318,5 @@ mod tests {
         assert_eq!(shape.to_vec(), vec![2]);
         assert_eq!(param_id, Some(7));
         assert_eq!(&bytes[..], &[7, 8]);
-    }
-
-    /// The `Send + Sync` bound on the provider exists so a `Tensor` can reach burn-train's
-    /// async checkpointer inside an optimizer record. Nothing in burn-pack's own build would
-    /// catch a regression to a non-atomic pointer, so pin it where the type lives.
-    #[test]
-    fn tensor_is_send_and_sync() {
-        fn assert_send_sync<T: Send + Sync>() {}
-        assert_send_sync::<Tensor>();
     }
 }

--- a/crates/burn-pack/src/tensor.rs
+++ b/crates/burn-pack/src/tensor.rs
@@ -14,7 +14,8 @@ use alloc::string::String;
 
 #[cfg(target_has_atomic = "ptr")]
 use alloc::sync::Arc;
-// `alloc::sync` needs atomic CAS, so use its non-atomic counterpart on targets without it.
+// `alloc::sync` needs atomic CAS. Use `Rc` on targets without it, where `Arc` is unavailable;
+// the `Rc`-backed source means `Tensor` cannot be `Send` or `Sync` on those targets.
 #[cfg(not(target_has_atomic = "ptr"))]
 use alloc::rc::Rc as Arc;
 
@@ -25,8 +26,12 @@ use crate::base::Error;
 /// Shared handle to a deferred tensor's byte provider, kept behind a pointer so [`Tensor`]
 /// stays [`Clone`].
 ///
-/// The pointer varies with the target's atomic support, but the provider itself has no
-/// thread-safety requirement.
+/// On targets with pointer atomics, the provider is `Send + Sync` so a deferred source
+/// preserves the same thread-safety properties as a resident one. `Sync` is also required
+/// for a shared provider to be `Send` (`Arc<T>: Send` requires `T: Send + Sync`).
+#[cfg(target_has_atomic = "ptr")]
+type Provider = Arc<dyn Fn() -> Result<Bytes, Error> + Send + Sync>;
+#[cfg(not(target_has_atomic = "ptr"))]
 type Provider = Arc<dyn Fn() -> Result<Bytes, Error>>;
 
 /// Where a tensor's bytes come from.
@@ -103,6 +108,13 @@ impl Source {
 /// [`deferred`](Self::deferred) when it is not. A [`Reader`](crate::Reader) produces resident
 /// tensors, though for a file-backed source the bytes are still only read from disk on
 /// access.
+///
+/// # Thread safety
+///
+/// On targets with pointer-width atomics, `Tensor` is `Send + Sync` whether its bytes are
+/// resident or deferred. Accordingly, [`deferred`](Self::deferred) requires its provider to
+/// be `Send + Sync` on those targets. Without pointer-width atomics, deferred providers are
+/// held in an `Rc`, so `Tensor` implements neither trait.
 #[derive(Clone)]
 pub struct Tensor {
     /// Fully-qualified tensor name (e.g. `"encoder.layer1.weight"`).
@@ -149,6 +161,24 @@ impl Tensor {
     /// result is dropped before the next tensor's is requested. Producing the data there -
     /// reading a parameter back from a device, say - is what bounds a save's peak host memory
     /// by the largest single tensor rather than by the whole model.
+    #[cfg(target_has_atomic = "ptr")]
+    pub fn deferred(
+        name: String,
+        dtype: DType,
+        shape: impl Into<Shape>,
+        param_id: Option<u64>,
+        byte_len: usize,
+        provider: impl Fn() -> Result<Bytes, Error> + Send + Sync + 'static,
+    ) -> Self {
+        Self::with_provider(name, dtype, shape, param_id, byte_len, Arc::new(provider))
+    }
+
+    /// Create a tensor whose bytes are produced on demand.
+    ///
+    /// See the `target_has_atomic = "ptr"` variant for the contract. This one drops the
+    /// `Send + Sync` bound because the resulting `Rc`-backed tensor cannot implement either
+    /// trait regardless of the provider's own bounds.
+    #[cfg(not(target_has_atomic = "ptr"))]
     pub fn deferred(
         name: String,
         dtype: DType,
@@ -160,6 +190,7 @@ impl Tensor {
         Self::with_provider(name, dtype, shape, param_id, byte_len, Arc::new(provider))
     }
 
+    /// The half of [`deferred`](Self::deferred) that does not vary by target.
     fn with_provider(
         name: String,
         dtype: DType,
@@ -237,13 +268,12 @@ impl core::fmt::Debug for Tensor {
 
 // The counting tests below need `fetch_add`, so the whole module wants atomic CAS. Tests are
 // only ever run on a host anyway; this keeps `--tests` compiling for embedded targets.
-#[cfg(test)]
+#[cfg(all(test, target_has_atomic = "ptr"))]
 mod tests {
     use super::*;
-    use alloc::rc::Rc;
     use alloc::string::ToString;
     use alloc::vec;
-    use core::cell::Cell;
+    use core::sync::atomic::{AtomicUsize, Ordering};
 
     /// `to_bytes` borrows rather than consuming, so the tensor can still be drawn from
     /// afterwards. That is the whole reason it exists next to `into_bytes`.
@@ -265,23 +295,22 @@ mod tests {
     /// paths use `into_parts` instead.
     #[test]
     fn to_bytes_reruns_a_deferred_provider_on_every_call() {
-        // Capturing `Rc<Cell<_>>` also pins that deferred providers need not be Send or Sync.
-        let calls = Rc::new(Cell::new(0));
+        let calls = Arc::new(AtomicUsize::new(0));
         let counter = calls.clone();
 
         let tensor = Tensor::deferred("w".to_string(), DType::U8, vec![2], None, 2, move || {
-            counter.set(counter.get() + 1);
+            counter.fetch_add(1, Ordering::Relaxed);
             Ok(Bytes::from_bytes_vec(vec![7, 8]))
         });
 
         assert_eq!(&tensor.to_bytes().unwrap()[..], &[7, 8]);
         assert_eq!(&tensor.to_bytes().unwrap()[..], &[7, 8]);
-        assert_eq!(calls.get(), 2);
+        assert_eq!(calls.load(Ordering::Relaxed), 2);
 
         // Still usable, and `into_bytes` draws once more.
         assert_eq!(tensor.byte_len(), 2);
         assert_eq!(&tensor.into_bytes().unwrap()[..], &[7, 8]);
-        assert_eq!(calls.get(), 3);
+        assert_eq!(calls.load(Ordering::Relaxed), 3);
     }
 
     /// A provider failure surfaces verbatim. Naming the tensor is `Writer::materialize`'s
@@ -318,5 +347,12 @@ mod tests {
         assert_eq!(shape.to_vec(), vec![2]);
         assert_eq!(param_id, Some(7));
         assert_eq!(&bytes[..], &[7, 8]);
+    }
+
+    /// A deferred source must preserve the thread-safety properties of a resident tensor.
+    #[test]
+    fn tensor_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<Tensor>();
     }
 }

--- a/crates/burn-pack/tests/lazy_writer.rs
+++ b/crates/burn-pack/tests/lazy_writer.rs
@@ -2,16 +2,14 @@
 
 mod common;
 
-use std::sync::{Arc, Mutex};
+use std::cell::RefCell;
+use std::rc::Rc;
 
 use burn_pack::{Bytes, DType, Error, Reader, Shape, Tensor, Writer};
 use common::f32_tensor;
 
 /// Records every materialization, in the order it happened.
-///
-/// `Arc<Mutex<_>>` rather than `Rc<RefCell<_>>` because a deferred tensor's provider must be
-/// `Send + Sync`: records holding one cross threads through burn-train's async checkpointer.
-type Log = Arc<Mutex<Vec<String>>>;
+type Log = Rc<RefCell<Vec<String>>>;
 
 /// A tensor whose bytes are produced on demand, with every knob the tests need to bend.
 ///
@@ -67,7 +65,7 @@ impl LazyEntry {
 
         let logged = name.clone();
         Tensor::deferred(name, dtype, shape, None, declared_len, move || {
-            log.lock().unwrap().push(logged.clone());
+            log.borrow_mut().push(logged.clone());
             if fails {
                 return Err(Error::IoError("device read failed".to_string()));
             }
@@ -90,7 +88,7 @@ fn deferred_tensors(entries: Vec<LazyEntry>) -> Vec<Tensor> {
 }
 
 fn materialized(log: &Log) -> Vec<String> {
-    log.lock().unwrap().clone()
+    log.borrow().clone()
 }
 
 #[test]

--- a/crates/burn-pack/tests/lazy_writer.rs
+++ b/crates/burn-pack/tests/lazy_writer.rs
@@ -2,14 +2,16 @@
 
 mod common;
 
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::sync::{Arc, Mutex};
 
 use burn_pack::{Bytes, DType, Error, Reader, Shape, Tensor, Writer};
 use common::f32_tensor;
 
 /// Records every materialization, in the order it happened.
-type Log = Rc<RefCell<Vec<String>>>;
+///
+/// `Arc<Mutex<_>>` keeps the deferred providers `Send + Sync`, preserving [`Tensor`] as a
+/// thread-safe transport type.
+type Log = Arc<Mutex<Vec<String>>>;
 
 /// A tensor whose bytes are produced on demand, with every knob the tests need to bend.
 ///
@@ -65,7 +67,7 @@ impl LazyEntry {
 
         let logged = name.clone();
         Tensor::deferred(name, dtype, shape, None, declared_len, move || {
-            log.borrow_mut().push(logged.clone());
+            log.lock().unwrap().push(logged.clone());
             if fails {
                 return Err(Error::IoError("device read failed".to_string()));
             }
@@ -88,7 +90,7 @@ fn deferred_tensors(entries: Vec<LazyEntry>) -> Vec<Tensor> {
 }
 
 fn materialized(log: &Log) -> Vec<String> {
-    log.borrow().clone()
+    log.lock().unwrap().clone()
 }
 
 #[test]

--- a/crates/burn-store/src/bridge.rs
+++ b/crates/burn-store/src/bridge.rs
@@ -73,6 +73,29 @@ fn guarded(f: impl Fn() -> Result<TensorData, PackError>) -> Result<TensorData, 
     f()
 }
 
+/// The `Send + Sync` bound a data closure carries on a target with pointer-width atomics, and
+/// nothing on one without.
+///
+/// [`PackTensor::deferred`] asks for `Send + Sync` providers only where `alloc::sync` exists so
+/// deferred tensors preserve the thread-safety of resident ones. Without pointer-width atomics,
+/// it uses an `Rc`-backed provider and cannot itself be `Send` or `Sync`, regardless of the
+/// closure's bounds. Naming that difference once keeps every constructor below from having to
+/// be written twice.
+///
+/// Implemented for every type that satisfies it; the blanket impl makes a manual
+/// implementation impossible.
+#[cfg(target_has_atomic = "ptr")]
+pub trait MaybeSendSync: Send + Sync {}
+#[cfg(target_has_atomic = "ptr")]
+impl<T: Send + Sync> MaybeSendSync for T {}
+
+/// Empty on a target without pointer-width atomics, where an `Rc`-backed [`PackTensor`] cannot
+/// be `Send` or `Sync` regardless of the provider's own bounds.
+#[cfg(not(target_has_atomic = "ptr"))]
+pub trait MaybeSendSync {}
+#[cfg(not(target_has_atomic = "ptr"))]
+impl<T> MaybeSendSync for T {}
+
 /// Build a tensor whose data is produced on demand by `data_fn`.
 ///
 /// `dtype` and `shape` describe what `data_fn` will return, and fix the byte length the writer
@@ -85,7 +108,7 @@ pub fn deferred(
     dtype: DType,
     shape: Shape,
     param_id: Option<u64>,
-    data_fn: impl Fn() -> Result<TensorData, PackError> + 'static,
+    data_fn: impl Fn() -> Result<TensorData, PackError> + MaybeSendSync + 'static,
 ) -> PackTensor {
     let byte_len = data_len(dtype, &shape);
     let declared = shape.clone();
@@ -162,7 +185,7 @@ pub fn map_data(
     name: String,
     dtype: DType,
     shape: Shape,
-    f: impl Fn(TensorData) -> TensorData + 'static,
+    f: impl Fn(TensorData) -> TensorData + MaybeSendSync + 'static,
 ) -> PackTensor {
     let param_id = tensor.param_id;
 

--- a/crates/burn-store/src/bridge.rs
+++ b/crates/burn-store/src/bridge.rs
@@ -73,27 +73,6 @@ fn guarded(f: impl Fn() -> Result<TensorData, PackError>) -> Result<TensorData, 
     f()
 }
 
-/// The `Send + Sync` bound a data closure carries on a target with threads, and nothing on one
-/// without.
-///
-/// [`PackTensor::deferred`] asks for `Send + Sync` providers only where `alloc::sync` exists: a
-/// target without atomic CAS has no threads to share a tensor across, and the `Rc`-backed
-/// provider it falls back to could not satisfy the bound anyway. Naming that difference once
-/// keeps every constructor below from having to be written twice.
-///
-/// Implemented for every type that satisfies it; the blanket impl makes a manual
-/// implementation impossible.
-#[cfg(target_has_atomic = "ptr")]
-pub trait MaybeSendSync: Send + Sync {}
-#[cfg(target_has_atomic = "ptr")]
-impl<T: Send + Sync> MaybeSendSync for T {}
-
-/// Empty on a target without atomic CAS, where no provider bound is needed or satisfiable.
-#[cfg(not(target_has_atomic = "ptr"))]
-pub trait MaybeSendSync {}
-#[cfg(not(target_has_atomic = "ptr"))]
-impl<T> MaybeSendSync for T {}
-
 /// Build a tensor whose data is produced on demand by `data_fn`.
 ///
 /// `dtype` and `shape` describe what `data_fn` will return, and fix the byte length the writer
@@ -106,7 +85,7 @@ pub fn deferred(
     dtype: DType,
     shape: Shape,
     param_id: Option<u64>,
-    data_fn: impl Fn() -> Result<TensorData, PackError> + MaybeSendSync + 'static,
+    data_fn: impl Fn() -> Result<TensorData, PackError> + 'static,
 ) -> PackTensor {
     let byte_len = data_len(dtype, &shape);
     let declared = shape.clone();
@@ -183,7 +162,7 @@ pub fn map_data(
     name: String,
     dtype: DType,
     shape: Shape,
-    f: impl Fn(TensorData) -> TensorData + MaybeSendSync + 'static,
+    f: impl Fn(TensorData) -> TensorData + 'static,
 ) -> PackTensor {
     let param_id = tensor.param_id;
 


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

> `cargo run-checks` tests with `Flex` by default. Use `cargo run-checks --backend <backend>` when
> targeting another backend. Consider running additional tests relevant to the crates changed.

### Related Issues/PRs

Follow-up to #5407 

### Changes

`burn_pack::Tensor` remains `Send + Sync` on targets with pointer-width atomics, regardless of whether its bytes are resident or deferred.

Although optimizer records no longer require pack tensors to cross the asynchronous checkpoint boundary, thread safety remains part of the tensor transport contract.

This allows tensors to be moved to a background writer thread for device readback and file I/O. Without these bounds, even resident tensors would be `!Send + !Sync`.

The documentation now states this target-dependent contract explicitly and explains the deferred provider bounds.
