### PR TITLE
test(quantization): strengthen quantized layout coverage

### DIFF
--- a/crates/burn-backend-tests/tests/cubecl/quantization/reshape.rs
+++ b/crates/burn-backend-tests/tests/cubecl/quantization/reshape.rs
@@ -148,17 +148,15 @@ fn should_quantize_dequantize_per_block_reshaped_2d_q8s_packed() {
     )
 }
 
-// TODO: add tests for
-// - ND reshape split (validation should panic)
-// - broadcasted
-// - multi-block successful reshape (all current success tests use exactly 1 block, e.g. [4, 32] -> [1, 4, 32] with block_size 32)
-// - packed dimension alignment failure (invalid shape for packed num_quants)
-// - ND-block unsqueeze (should succeed per the is_unsqueeze exemption, but nothing tests it)
-
 /// Reshape correctness isolated from quantization error: dequantize the *same*
 /// quantized tensor via both orders. Any difference is the reshape's doing.
-fn reshape_matches_dequantize_then_reshape(value: QuantValue, block: Option<BlockSize>) {
-    let numel = 32i64;
+fn reshape_matches_dequantize_then_reshape<const D1: usize, const D2: usize>(
+    value: QuantValue,
+    block: Option<BlockSize>,
+    shape: [usize; D1],
+    new_shape: [usize; D2],
+) {
+    let numel = Shape::from(shape).num_elements() as i64;
     let device = Default::default();
     let ref_device = ReferenceDevice::new();
     let scheme = scheme_for(block, value, QuantStore::PackedU32(0));
@@ -166,27 +164,125 @@ fn reshape_matches_dequantize_then_reshape(value: QuantValue, block: Option<Bloc
     let data = TestTensorInt::arange(0..numel, &ref_device)
         .float()
         .div_scalar(numel)
+        .reshape::<D1, _>(shape)
         .into_data();
 
-    let q = TestTensor::<1>::from_data(data, &device).quantize_dynamic(&scheme);
+    let q = TestTensor::<D1>::from_data(data, &device).quantize_dynamic(&scheme);
 
-    let reshaped_then_deq = q.clone().reshape::<2, _>([2, 16]).dequantize().into_data();
-    let deq_then_reshaped = q.dequantize().reshape::<2, _>([2, 16]).into_data();
+    let reshaped_then_deq = q
+        .clone()
+        .reshape::<D2, _>(new_shape)
+        .dequantize()
+        .into_data();
+    let deq_then_reshaped = q.dequantize().reshape::<D2, _>(new_shape).into_data();
 
     reshaped_then_deq.assert_eq(&deq_then_reshaped, true);
 }
 
 #[test]
 fn q8s_reshape_matches_dequantize_then_reshape() {
-    reshape_matches_dequantize_then_reshape(QuantValue::Q8S, None);
+    reshape_matches_dequantize_then_reshape(QuantValue::Q8S, None, [32], [2, 16]);
 }
 
 #[test]
 fn q4s_reshape_matches_dequantize_then_reshape() {
-    reshape_matches_dequantize_then_reshape(QuantValue::Q4S, None);
+    reshape_matches_dequantize_then_reshape(QuantValue::Q4S, None, [32], [2, 16]);
 }
 
 #[test]
 fn q4s_block_reshape_matches_dequantize_then_reshape() {
-    reshape_matches_dequantize_then_reshape(QuantValue::Q4S, Some(BlockSize::new([16])));
+    reshape_matches_dequantize_then_reshape(
+        QuantValue::Q4S,
+        Some(BlockSize::new([16])),
+        [32],
+        [2, 16],
+    );
+}
+
+#[test]
+fn multi_block_reshape_matches_dequantize_then_reshape() {
+    // Four independent blocks make sure the scale grid is reshaped along with the values.
+    reshape_matches_dequantize_then_reshape(
+        QuantValue::Q8S,
+        Some(BlockSize::new([32])),
+        [4, 32],
+        [1, 4, 32],
+    );
+}
+
+#[test]
+fn nd_block_unsqueeze_matches_dequantize_then_reshape() {
+    // Adding a leading unit dimension preserves every two-dimensional block boundary.
+    reshape_matches_dequantize_then_reshape(
+        QuantValue::Q8S,
+        Some(BlockSize::new([2, 4])),
+        [4, 8],
+        [1, 4, 8],
+    );
+}
+
+#[test]
+fn broadcasted_reshape_matches_dequantize_then_reshape() {
+    let shape = [2, 4, 8];
+    let numel = Shape::from(shape).num_elements() as i64;
+    let device = Default::default();
+    let ref_device = ReferenceDevice::new();
+    let scheme = scheme_for(None, QuantValue::Q8S, QuantStore::PackedU32(0));
+
+    let data = TestTensorInt::arange(0..numel, &ref_device)
+        .float()
+        .div_scalar(numel)
+        .reshape(shape)
+        .into_data();
+
+    // Permuting only batch dimensions keeps the packed dimension last while making the tensor
+    // non-contiguous. Prepending a unit dimension then exercises ReshapeAnalysis::Broadcasted.
+    let q = TestTensor::<3>::from_data(data, &device)
+        .quantize_dynamic(&scheme)
+        .permute([1, 0, 2]);
+
+    let reshaped_then_deq = q
+        .clone()
+        .reshape::<4, _>([1, 4, 2, 8])
+        .dequantize()
+        .into_data();
+    let deq_then_reshaped = q.dequantize().reshape::<4, _>([1, 4, 2, 8]).into_data();
+
+    reshaped_then_deq.assert_eq(&deq_then_reshaped, true);
+}
+
+#[test]
+#[should_panic] // "Cannot reshape packed tensor" error is shadowed by the CallError
+fn packed_dimension_alignment_failure_should_panic() {
+    // Q8 packs four values per u32, but the new packed dimension has length six.
+    reshape_matches_dequantize_then_reshape(QuantValue::Q8S, None, [24], [4, 6]);
+}
+
+#[test]
+#[should_panic] // "Split reshape of ND block-quantized tensor" error is shadowed by the CallError
+fn nd_block_split_reshape_should_panic() {
+    let shape = [2, 4, 8];
+    let numel = Shape::from(shape).num_elements() as i64;
+    let device = Default::default();
+    let ref_device = ReferenceDevice::new();
+    let scheme = scheme_for(
+        Some(BlockSize::new([1, 2, 4])),
+        QuantValue::Q8S,
+        QuantStore::PackedU32(0),
+    );
+
+    let data = TestTensorInt::arange(0..numel, &ref_device)
+        .float()
+        .div_scalar(numel)
+        .reshape(shape)
+        .into_data();
+
+    // Make the quantized tensor non-contiguous, then split its first physical dimension while
+    // retaining the packed trailing dimension. This reaches ReshapeAnalysis::Split.
+    let _ = TestTensor::<3>::from_data(data, &device)
+        .quantize_dynamic(&scheme)
+        .permute([1, 0, 2])
+        .reshape::<4, _>([2, 2, 2, 8])
+        .dequantize()
+        .into_data();
 }

--- a/crates/burn-backend-tests/tests/cubecl/quantization/reshape.rs
+++ b/crates/burn-backend-tests/tests/cubecl/quantization/reshape.rs
@@ -148,8 +148,18 @@ fn should_quantize_dequantize_per_block_reshaped_2d_q8s_packed() {
     )
 }
 
-/// Reshape correctness isolated from quantization error: dequantize the *same*
-/// quantized tensor via both orders. Any difference is the reshape's doing.
+/// Compare a view applied to a quantized tensor with the same view applied after dequantization.
+/// Both paths reconstruct from the same quantized values and scales, so they must be bit-exact.
+fn assert_layout_matches_dequantize<const D: usize>(
+    layout_quantized: TestTensor<D>,
+    layout_dequantized: TestTensor<D>,
+) {
+    layout_quantized
+        .dequantize()
+        .into_data()
+        .assert_eq(&layout_dequantized.into_data(), true);
+}
+
 fn reshape_matches_dequantize_then_reshape<const D1: usize, const D2: usize>(
     value: QuantValue,
     block: Option<BlockSize>,
@@ -169,14 +179,10 @@ fn reshape_matches_dequantize_then_reshape<const D1: usize, const D2: usize>(
 
     let q = TestTensor::<D1>::from_data(data, &device).quantize_dynamic(&scheme);
 
-    let reshaped_then_deq = q
-        .clone()
-        .reshape::<D2, _>(new_shape)
-        .dequantize()
-        .into_data();
-    let deq_then_reshaped = q.dequantize().reshape::<D2, _>(new_shape).into_data();
-
-    reshaped_then_deq.assert_eq(&deq_then_reshaped, true);
+    assert_layout_matches_dequantize(
+        q.clone().reshape::<D2, _>(new_shape),
+        q.dequantize().reshape::<D2, _>(new_shape),
+    );
 }
 
 #[test]
@@ -241,14 +247,10 @@ fn broadcasted_reshape_matches_dequantize_then_reshape() {
         .quantize_dynamic(&scheme)
         .permute([1, 0, 2]);
 
-    let reshaped_then_deq = q
-        .clone()
-        .reshape::<4, _>([1, 4, 2, 8])
-        .dequantize()
-        .into_data();
-    let deq_then_reshaped = q.dequantize().reshape::<4, _>([1, 4, 2, 8]).into_data();
-
-    reshaped_then_deq.assert_eq(&deq_then_reshaped, true);
+    assert_layout_matches_dequantize(
+        q.clone().reshape::<4, _>([1, 4, 2, 8]),
+        q.dequantize().reshape::<4, _>([1, 4, 2, 8]),
+    );
 }
 
 #[test]

--- a/crates/burn-backend-tests/tests/tensor/float/quantization/ops/quantize.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/quantization/ops/quantize.rs
@@ -289,7 +289,19 @@ fn two_level_error_should_not_track_weight_magnitude() {
     );
 }
 
-fn should_quantize_transposed<const D: usize>(tensor: Tensor<D>, scheme: QuantScheme) {
+/// Compare a view applied to a quantized tensor with the same view applied after dequantization.
+/// Both paths reconstruct from the same quantized values and scales, so they must be bit-exact.
+fn assert_layout_matches_dequantize<const D: usize>(
+    layout_quantized: Tensor<D>,
+    layout_dequantized: Tensor<D>,
+) {
+    layout_quantized
+        .dequantize()
+        .into_data()
+        .assert_eq(&layout_dequantized.into_data(), true);
+}
+
+fn should_quantize_after_transpose<const D: usize>(tensor: Tensor<D>, scheme: QuantScheme) {
     let tensor_t = tensor.clone().transpose();
 
     let output = tensor_t.quantize_dynamic(&scheme).dequantize().transpose();
@@ -300,22 +312,20 @@ fn should_quantize_transposed<const D: usize>(tensor: Tensor<D>, scheme: QuantSc
     );
 }
 
-fn should_dequantize_transposed<const D: usize>(tensor: Tensor<D>, scheme: QuantScheme) {
-    let output = tensor
-        .clone()
-        .quantize_dynamic(&scheme)
-        .transpose()
-        .dequantize()
-        .transpose();
+fn should_transpose_after_quantize_match_dequantized_layout<const D: usize>(
+    tensor: Tensor<D>,
+    scheme: QuantScheme,
+) {
+    let quantized = tensor.quantize_dynamic(&scheme);
 
-    tensor.into_data().assert_approx_eq::<FloatElem>(
-        &output.into_data(),
-        Tolerance::absolute(1e-1).set_relative(1e-2),
+    assert_layout_matches_dequantize(
+        quantized.clone().transpose(),
+        quantized.dequantize().transpose(),
     );
 }
 
 #[test]
-fn should_quantize_symmetric_int8_transposed_8x32() {
+fn should_quantize_symmetric_int8_after_transpose_8x32() {
     let device = Default::default();
 
     let tensor = TestTensorInt::arange(0..256, &device)
@@ -328,11 +338,11 @@ fn should_quantize_symmetric_int8_transposed_8x32() {
         .quantization
         .scheme
         .with_value(QuantValue::Q8S);
-    should_quantize_transposed(tensor, scheme);
+    should_quantize_after_transpose(tensor, scheme);
 }
 
 #[test]
-fn should_dequantize_symmetric_int8_transposed_8x32() {
+fn should_transpose_symmetric_int8_after_quantize_8x32_match_dequantized_layout() {
     let device = Default::default();
 
     let values = (0..256)
@@ -345,11 +355,11 @@ fn should_dequantize_symmetric_int8_transposed_8x32() {
         .quantization
         .scheme
         .with_value(QuantValue::Q8S);
-    should_dequantize_transposed(tensor, scheme);
+    should_transpose_after_quantize_match_dequantized_layout(tensor, scheme);
 }
 
 #[test]
-fn should_quantize_symmetric_int8_transposed_48x64() {
+fn should_quantize_symmetric_int8_after_transpose_48x64() {
     let device = Default::default();
 
     let tensor = TestTensorInt::arange(0..3072, &device)
@@ -362,11 +372,11 @@ fn should_quantize_symmetric_int8_transposed_48x64() {
         .quantization
         .scheme
         .with_value(QuantValue::Q8S);
-    should_quantize_transposed(tensor, scheme);
+    should_quantize_after_transpose(tensor, scheme);
 }
 
 #[test]
-fn should_quantize_symmetric_per_block_int8_transposed_32x64() {
+fn should_quantize_symmetric_per_block_int8_after_transpose_32x64() {
     let device = Default::default();
 
     let tensor = TestTensorInt::arange(0..2048, &device)
@@ -380,11 +390,11 @@ fn should_quantize_symmetric_per_block_int8_transposed_32x64() {
         .scheme
         .with_value(QuantValue::Q8S)
         .per_block([32], ScaleDtype::F32);
-    should_quantize_transposed(tensor, scheme);
+    should_quantize_after_transpose(tensor, scheme);
 }
 
 #[test]
-fn should_dequantize_symmetric_per_block_int8_transposed_32x64() {
+fn should_transpose_symmetric_per_block_int8_after_quantize_32x64_match_dequantized_layout() {
     let device = Default::default();
 
     let values = (0..2048)
@@ -399,11 +409,11 @@ fn should_dequantize_symmetric_per_block_int8_transposed_32x64() {
         .with_value(QuantValue::Q8S)
         .per_block([32], ScaleDtype::F32);
 
-    should_dequantize_transposed(tensor, scheme);
+    should_transpose_after_quantize_match_dequantized_layout(tensor, scheme);
 }
 
 #[test]
-fn should_dequantize_symmetric_per_block_int8_permuted_2x8x16() {
+fn should_swap_dims_symmetric_per_block_int8_after_quantize_match_dequantized_layout() {
     let device = Default::default();
 
     let values = (0..256)
@@ -417,20 +427,16 @@ fn should_dequantize_symmetric_per_block_int8_permuted_2x8x16() {
         .scheme
         .with_value(QuantValue::Q8S)
         .per_block([1, 2, 16], ScaleDtype::F32);
-    let expected = tensor.clone().permute([1, 2, 0]);
-    let output = tensor
-        .quantize_dynamic(&scheme)
-        .permute([1, 2, 0])
-        .dequantize();
+    let quantized = tensor.quantize_dynamic(&scheme);
 
-    expected.into_data().assert_approx_eq::<FloatElem>(
-        &output.into_data(),
-        Tolerance::absolute(1e-1).set_relative(1e-2),
+    assert_layout_matches_dequantize(
+        quantized.clone().swap_dims(0, 2),
+        quantized.dequantize().swap_dims(0, 2),
     );
 }
 
 #[test]
-fn should_dequantize_symmetric_per_block_int8_permuted_packed_axis_first() {
+fn should_permute_symmetric_per_block_int8_after_quantize_2x8x16_match_dequantized_layout() {
     let device = Default::default();
 
     let values = (0..256)
@@ -444,20 +450,39 @@ fn should_dequantize_symmetric_per_block_int8_permuted_packed_axis_first() {
         .scheme
         .with_value(QuantValue::Q8S)
         .per_block([1, 2, 16], ScaleDtype::F32);
-    let expected = tensor.clone().permute([2, 0, 1]);
-    let output = tensor
-        .quantize_dynamic(&scheme)
-        .permute([2, 0, 1])
-        .dequantize();
+    let quantized = tensor.quantize_dynamic(&scheme);
 
-    expected.into_data().assert_approx_eq::<FloatElem>(
-        &output.into_data(),
-        Tolerance::absolute(1e-1).set_relative(1e-2),
+    assert_layout_matches_dequantize(
+        quantized.clone().permute([1, 2, 0]),
+        quantized.dequantize().permute([1, 2, 0]),
     );
 }
 
 #[test]
-fn should_quantize_symmetric_int8_permuted_batch_dims() {
+fn should_permute_packed_axis_first_after_quantize_match_dequantized_layout() {
+    let device = Default::default();
+
+    let values = (0..256)
+        .map(|value| value as f32 / 256.)
+        .collect::<Vec<_>>();
+    let tensor = TestTensor::<3>::from_data(TensorData::new(values, [2, 8, 16]), &device);
+
+    let scheme = device
+        .settings()
+        .quantization
+        .scheme
+        .with_value(QuantValue::Q8S)
+        .per_block([1, 2, 16], ScaleDtype::F32);
+    let quantized = tensor.quantize_dynamic(&scheme);
+
+    assert_layout_matches_dequantize(
+        quantized.clone().permute([2, 0, 1]),
+        quantized.dequantize().permute([2, 0, 1]),
+    );
+}
+
+#[test]
+fn should_quantize_symmetric_int8_after_permuting_batch_dims() {
     let device = Default::default();
 
     let tensor = TestTensorInt::arange(0..2048, &device)


### PR DESCRIPTION
## Summary

- cover successful and invalid CubeCL quantized reshape layouts
- add a bit-exact same-tensor oracle for transpose, swap_dims, permute, and legal reshape
- distinguish quantize-after-layout tests from layout-after-quantize tests

## Testing

- cargo fmt --all -- --check
- cargo test -p burn-backend-tests --features ndarray --test tensor tensor::float::quantization::ops::quantize
- cargo test -p burn-backend-tests --features wgpu --test tensor match_dequantized_layout
- cargo test -p burn-backend-tests --features wgpu --test cubecl quantization::reshape
- cargo test -p burn-backend-tests --features flex --test tensor --test tensor_f16 match_dequantized_layout