### PR TITLE
chore(deps): follow cubecl's collapsed memory throughput modes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,7 +2199,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab#2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -2216,7 +2216,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab#2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -2240,7 +2240,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab#2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -2272,7 +2272,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab#2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2295,7 +2295,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab#2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab"
 dependencies = [
  "bytemuck",
  "crossbeam-utils",
@@ -2317,7 +2317,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab#2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2336,7 +2336,7 @@ dependencies = [
 [[package]]
 name = "cubecl-environment"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab#2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab"
 dependencies = [
  "async-channel",
  "backtrace",
@@ -2371,7 +2371,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab#2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2402,7 +2402,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab#2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -2435,7 +2435,7 @@ dependencies = [
 [[package]]
 name = "cubecl-llvm"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab#2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab"
 dependencies = [
  "cc",
  "cubecl-core",
@@ -2454,7 +2454,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab#2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab"
 dependencies = [
  "cubecl-common",
  "darling 0.24.0",
@@ -2472,7 +2472,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab#2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab"
 dependencies = [
  "darling 0.24.0",
  "inflections",
@@ -2484,7 +2484,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab#2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab#2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab"
 dependencies = [
  "ahash",
  "buildid",
@@ -2542,7 +2542,7 @@ dependencies = [
 [[package]]
 name = "cubecl-spirv"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab#2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab"
 dependencies = [
  "bitflags 2.13.1",
  "cubecl-common",
@@ -2565,7 +2565,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab#2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2582,7 +2582,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab#2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab"
 dependencies = [
  "ash",
  "bytemuck",
@@ -2617,7 +2617,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab#2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab"
 dependencies = [
  "derive-new",
  "serde",
@@ -2627,7 +2627,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=b58c733dd26390856de5e37ebc365e7145e147e0#b58c733dd26390856de5e37ebc365e7145e147e0"
+source = "git+https://github.com/tracel-ai/cubek?rev=c1a1a9eb5e655d8728d92e61b8a44ce0794d9afb#c1a1a9eb5e655d8728d92e61b8a44ce0794d9afb"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2645,7 +2645,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=b58c733dd26390856de5e37ebc365e7145e147e0#b58c733dd26390856de5e37ebc365e7145e147e0"
+source = "git+https://github.com/tracel-ai/cubek?rev=c1a1a9eb5e655d8728d92e61b8a44ce0794d9afb#c1a1a9eb5e655d8728d92e61b8a44ce0794d9afb"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2659,7 +2659,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=b58c733dd26390856de5e37ebc365e7145e147e0#b58c733dd26390856de5e37ebc365e7145e147e0"
+source = "git+https://github.com/tracel-ai/cubek?rev=c1a1a9eb5e655d8728d92e61b8a44ce0794d9afb#c1a1a9eb5e655d8728d92e61b8a44ce0794d9afb"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2676,7 +2676,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=b58c733dd26390856de5e37ebc365e7145e147e0#b58c733dd26390856de5e37ebc365e7145e147e0"
+source = "git+https://github.com/tracel-ai/cubek?rev=c1a1a9eb5e655d8728d92e61b8a44ce0794d9afb#c1a1a9eb5e655d8728d92e61b8a44ce0794d9afb"
 dependencies = [
  "cubecl",
 ]
@@ -2684,7 +2684,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=b58c733dd26390856de5e37ebc365e7145e147e0#b58c733dd26390856de5e37ebc365e7145e147e0"
+source = "git+https://github.com/tracel-ai/cubek?rev=c1a1a9eb5e655d8728d92e61b8a44ce0794d9afb#c1a1a9eb5e655d8728d92e61b8a44ce0794d9afb"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2697,7 +2697,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=b58c733dd26390856de5e37ebc365e7145e147e0#b58c733dd26390856de5e37ebc365e7145e147e0"
+source = "git+https://github.com/tracel-ai/cubek?rev=c1a1a9eb5e655d8728d92e61b8a44ce0794d9afb#c1a1a9eb5e655d8728d92e61b8a44ce0794d9afb"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2711,7 +2711,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=b58c733dd26390856de5e37ebc365e7145e147e0#b58c733dd26390856de5e37ebc365e7145e147e0"
+source = "git+https://github.com/tracel-ai/cubek?rev=c1a1a9eb5e655d8728d92e61b8a44ce0794d9afb#c1a1a9eb5e655d8728d92e61b8a44ce0794d9afb"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2721,7 +2721,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=b58c733dd26390856de5e37ebc365e7145e147e0#b58c733dd26390856de5e37ebc365e7145e147e0"
+source = "git+https://github.com/tracel-ai/cubek?rev=c1a1a9eb5e655d8728d92e61b8a44ce0794d9afb#c1a1a9eb5e655d8728d92e61b8a44ce0794d9afb"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2733,7 +2733,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=b58c733dd26390856de5e37ebc365e7145e147e0#b58c733dd26390856de5e37ebc365e7145e147e0"
+source = "git+https://github.com/tracel-ai/cubek?rev=c1a1a9eb5e655d8728d92e61b8a44ce0794d9afb#c1a1a9eb5e655d8728d92e61b8a44ce0794d9afb"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2748,7 +2748,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=b58c733dd26390856de5e37ebc365e7145e147e0#b58c733dd26390856de5e37ebc365e7145e147e0"
+source = "git+https://github.com/tracel-ai/cubek?rev=c1a1a9eb5e655d8728d92e61b8a44ce0794d9afb#c1a1a9eb5e655d8728d92e61b8a44ce0794d9afb"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2761,7 +2761,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=b58c733dd26390856de5e37ebc365e7145e147e0#b58c733dd26390856de5e37ebc365e7145e147e0"
+source = "git+https://github.com/tracel-ai/cubek?rev=c1a1a9eb5e655d8728d92e61b8a44ce0794d9afb#c1a1a9eb5e655d8728d92e61b8a44ce0794d9afb"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2770,7 +2770,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=b58c733dd26390856de5e37ebc365e7145e147e0#b58c733dd26390856de5e37ebc365e7145e147e0"
+source = "git+https://github.com/tracel-ai/cubek?rev=c1a1a9eb5e655d8728d92e61b8a44ce0794d9afb#c1a1a9eb5e655d8728d92e61b8a44ce0794d9afb"
 dependencies = [
  "bytemuck",
  "cubecl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,7 +2199,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -2216,7 +2216,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -2240,7 +2240,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -2258,6 +2258,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "itertools 0.15.0",
  "log",
+ "num-complex",
  "num-integer",
  "num-traits",
  "paste",
@@ -2271,7 +2272,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2294,8 +2295,9 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
 dependencies = [
+ "bytemuck",
  "crossbeam-utils",
  "cubecl-common",
  "cubecl-core",
@@ -2315,7 +2317,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2334,7 +2336,7 @@ dependencies = [
 [[package]]
 name = "cubecl-environment"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
 dependencies = [
  "async-channel",
  "backtrace",
@@ -2369,7 +2371,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2377,6 +2379,7 @@ dependencies = [
  "cubecl-cpp",
  "cubecl-environment",
  "cubecl-hip-sys",
+ "cubecl-llvm",
  "cubecl-runtime",
  "derive-new",
  "half",
@@ -2399,7 +2402,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -2416,12 +2419,14 @@ dependencies = [
  "internment",
  "itertools 0.15.0",
  "num",
+ "num-complex",
  "num-traits",
  "pliron",
  "pliron-spirv",
  "portable-atomic",
  "rustc_apfloat",
  "serde",
+ "smallvec",
  "spin 0.12.2",
  "thiserror 2.0.19",
  "variadics_please",
@@ -2430,8 +2435,9 @@ dependencies = [
 [[package]]
 name = "cubecl-llvm"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
 dependencies = [
+ "cc",
  "cubecl-core",
  "cubecl-environment",
  "cubecl-opt",
@@ -2441,13 +2447,14 @@ dependencies = [
  "llvm-sys",
  "pliron",
  "pliron-llvm",
+ "thiserror 2.0.19",
  "tracel-llvm-bundler",
 ]
 
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
 dependencies = [
  "cubecl-common",
  "darling 0.24.0",
@@ -2465,7 +2472,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
 dependencies = [
  "darling 0.24.0",
  "inflections",
@@ -2477,29 +2484,33 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
  "cubecl-environment",
  "cubecl-ir",
  "derive-new",
+ "derive_more",
+ "downcast-rs 1.2.1",
  "float-ord",
  "hashbrown 0.17.1",
  "itertools 0.15.0",
  "log",
  "num",
  "pliron",
+ "rustc-hash 2.1.3",
  "smallvec",
  "stable-vec",
  "thiserror 2.0.19",
+ "tynm",
  "type-map",
 ]
 
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
 dependencies = [
  "ahash",
  "buildid",
@@ -2531,7 +2542,7 @@ dependencies = [
 [[package]]
 name = "cubecl-spirv"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
 dependencies = [
  "bitflags 2.13.1",
  "cubecl-common",
@@ -2554,7 +2565,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2571,7 +2582,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
 dependencies = [
  "ash",
  "bytemuck",
@@ -2606,7 +2617,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=45c2777584defbb0087b1e8efacace7be52ac01a#45c2777584defbb0087b1e8efacace7be52ac01a"
 dependencies = [
  "derive-new",
  "serde",
@@ -2616,7 +2627,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5d15ee09ea56502783a5e056bf4b1d36c73a3a26#5d15ee09ea56502783a5e056bf4b1d36c73a3a26"
+source = "git+https://github.com/tracel-ai/cubek?rev=b58c733dd26390856de5e37ebc365e7145e147e0#b58c733dd26390856de5e37ebc365e7145e147e0"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2634,7 +2645,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5d15ee09ea56502783a5e056bf4b1d36c73a3a26#5d15ee09ea56502783a5e056bf4b1d36c73a3a26"
+source = "git+https://github.com/tracel-ai/cubek?rev=b58c733dd26390856de5e37ebc365e7145e147e0#b58c733dd26390856de5e37ebc365e7145e147e0"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2648,7 +2659,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5d15ee09ea56502783a5e056bf4b1d36c73a3a26#5d15ee09ea56502783a5e056bf4b1d36c73a3a26"
+source = "git+https://github.com/tracel-ai/cubek?rev=b58c733dd26390856de5e37ebc365e7145e147e0#b58c733dd26390856de5e37ebc365e7145e147e0"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2665,7 +2676,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5d15ee09ea56502783a5e056bf4b1d36c73a3a26#5d15ee09ea56502783a5e056bf4b1d36c73a3a26"
+source = "git+https://github.com/tracel-ai/cubek?rev=b58c733dd26390856de5e37ebc365e7145e147e0#b58c733dd26390856de5e37ebc365e7145e147e0"
 dependencies = [
  "cubecl",
 ]
@@ -2673,7 +2684,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5d15ee09ea56502783a5e056bf4b1d36c73a3a26#5d15ee09ea56502783a5e056bf4b1d36c73a3a26"
+source = "git+https://github.com/tracel-ai/cubek?rev=b58c733dd26390856de5e37ebc365e7145e147e0#b58c733dd26390856de5e37ebc365e7145e147e0"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2686,7 +2697,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5d15ee09ea56502783a5e056bf4b1d36c73a3a26#5d15ee09ea56502783a5e056bf4b1d36c73a3a26"
+source = "git+https://github.com/tracel-ai/cubek?rev=b58c733dd26390856de5e37ebc365e7145e147e0#b58c733dd26390856de5e37ebc365e7145e147e0"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2700,7 +2711,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5d15ee09ea56502783a5e056bf4b1d36c73a3a26#5d15ee09ea56502783a5e056bf4b1d36c73a3a26"
+source = "git+https://github.com/tracel-ai/cubek?rev=b58c733dd26390856de5e37ebc365e7145e147e0#b58c733dd26390856de5e37ebc365e7145e147e0"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2710,7 +2721,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5d15ee09ea56502783a5e056bf4b1d36c73a3a26#5d15ee09ea56502783a5e056bf4b1d36c73a3a26"
+source = "git+https://github.com/tracel-ai/cubek?rev=b58c733dd26390856de5e37ebc365e7145e147e0#b58c733dd26390856de5e37ebc365e7145e147e0"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2722,7 +2733,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5d15ee09ea56502783a5e056bf4b1d36c73a3a26#5d15ee09ea56502783a5e056bf4b1d36c73a3a26"
+source = "git+https://github.com/tracel-ai/cubek?rev=b58c733dd26390856de5e37ebc365e7145e147e0#b58c733dd26390856de5e37ebc365e7145e147e0"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2737,7 +2748,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5d15ee09ea56502783a5e056bf4b1d36c73a3a26#5d15ee09ea56502783a5e056bf4b1d36c73a3a26"
+source = "git+https://github.com/tracel-ai/cubek?rev=b58c733dd26390856de5e37ebc365e7145e147e0#b58c733dd26390856de5e37ebc365e7145e147e0"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2750,7 +2761,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5d15ee09ea56502783a5e056bf4b1d36c73a3a26#5d15ee09ea56502783a5e056bf4b1d36c73a3a26"
+source = "git+https://github.com/tracel-ai/cubek?rev=b58c733dd26390856de5e37ebc365e7145e147e0#b58c733dd26390856de5e37ebc365e7145e147e0"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2759,7 +2770,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5d15ee09ea56502783a5e056bf4b1d36c73a3a26#5d15ee09ea56502783a5e056bf4b1d36c73a3a26"
+source = "git+https://github.com/tracel-ai/cubek?rev=b58c733dd26390856de5e37ebc365e7145e147e0#b58c733dd26390856de5e37ebc365e7145e147e0"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -3336,6 +3347,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "downcast-rs"
@@ -4422,10 +4439,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
@@ -7199,14 +7212,13 @@ dependencies = [
 [[package]]
 name = "pliron"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e51eb8628227038376c81dcb1752db90a90af24a1e38b27582c7dab235149d7"
+source = "git+https://github.com/pliron-org/pliron.git?rev=6f4e739266c037a69488031a81f4381e62db9ac3#6f4e739266c037a69488031a81f4381e62db9ac3"
 dependencies = [
  "awint",
  "combine",
- "downcast-rs",
+ "downcast-rs 2.0.2",
  "dyn-clone",
- "hashbrown 0.14.5",
+ "hashbrown 0.13.2",
  "hi_sparse_bitset",
  "indexmap",
  "inventory",
@@ -7219,7 +7231,7 @@ dependencies = [
  "rustc_apfloat",
  "slotmap",
  "smallvec",
- "spin 0.11.1",
+ "spin 0.10.1",
  "thiserror 2.0.19",
  "utf8-chars",
 ]
@@ -7227,8 +7239,7 @@ dependencies = [
 [[package]]
 name = "pliron-derive"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f878ccd6bfd39a9373175774b96785daab296dc1870bc72ff7d285151f613a56"
+source = "git+https://github.com/pliron-org/pliron.git?rev=6f4e739266c037a69488031a81f4381e62db9ac3#6f4e739266c037a69488031a81f4381e62db9ac3"
 dependencies = [
  "combine",
  "convert_case 0.11.0",
@@ -7242,8 +7253,7 @@ dependencies = [
 [[package]]
 name = "pliron-llvm"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511535a077e4f72f83c437cde2636a6f525809a370b3078c0d1d5d53612ad052"
+source = "git+https://github.com/pliron-org/pliron.git?rev=6f4e739266c037a69488031a81f4381e62db9ac3#6f4e739266c037a69488031a81f4381e62db9ac3"
 dependencies = [
  "bitflags 2.13.1",
  "llvm-sys",
@@ -7255,8 +7265,7 @@ dependencies = [
 [[package]]
 name = "pliron-spirv"
 version = "0.14.1+sdk-1.4.357.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2919774bd35911798e824286a15c2c3c6fedbfd56d06a33e071dc1af5d5e7030"
+source = "git+https://github.com/tracel-ai/tracel-rspirv.git?rev=e52c4c918585bc02fa413eb6ee4f0b34e1109ae0#e52c4c918585bc02fa413eb6ee4f0b34e1109ae0"
 dependencies = [
  "derive-new",
  "derive_more",
@@ -9591,6 +9600,9 @@ name = "spin"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spin"
@@ -10524,9 +10536,8 @@ dependencies = [
 
 [[package]]
 name = "tracel-llvm-bundler"
-version = "22.1.4-6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de376825263c1a1e0af395cb7e04e82099c2fe16724235d313ab803b33bba87b"
+version = "22.1.4-7"
+source = "git+https://github.com/tracel-ai/tracel-llvm.git?rev=7932ee9e52044e298dacbfd04b1e0476544bb185#7932ee9e52044e298dacbfd04b1e0476544bb185"
 dependencies = [
  "anyhow",
  "bytes",
@@ -10546,8 +10557,7 @@ dependencies = [
 [[package]]
 name = "tracel-rspirv"
 version = "0.14.1+sdk-1.4.357.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1f062140c2875c072de7ab05019970906105a9a2c971af922b8d16bd3b5cbea"
+source = "git+https://github.com/tracel-ai/tracel-rspirv.git?rev=e52c4c918585bc02fa413eb6ee4f0b34e1109ae0#e52c4c918585bc02fa413eb6ee4f0b34e1109ae0"
 dependencies = [
  "bitflags 2.13.1",
  "pliron",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,11 +222,11 @@ burn-vision = { path = "crates/burn-vision", version = "=0.22.0-pre.3", default-
 burn-wgpu = { path = "crates/burn-wgpu", version = "=0.22.0-pre.3", default-features = false }
 
 ### For the main burn branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "45c2777584defbb0087b1e8efacace7be52ac01a" }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "45c2777584defbb0087b1e8efacace7be52ac01a" }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "45c2777584defbb0087b1e8efacace7be52ac01a" }
-cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "45c2777584defbb0087b1e8efacace7be52ac01a" }
-cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "b58c733dd26390856de5e37ebc365e7145e147e0" }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab" }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab" }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab" }
+cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "2f9b71fe04f4bb8f0d9aaad2d2b64b1b35326dab" }
+cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "c1a1a9eb5e655d8728d92e61b8a44ce0794d9afb" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,11 +222,11 @@ burn-vision = { path = "crates/burn-vision", version = "=0.22.0-pre.3", default-
 burn-wgpu = { path = "crates/burn-wgpu", version = "=0.22.0-pre.3", default-features = false }
 
 ### For the main burn branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "a30c2e314f67f47d5591fc1d2ff440c83cb7f99d" }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "a30c2e314f67f47d5591fc1d2ff440c83cb7f99d" }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "a30c2e314f67f47d5591fc1d2ff440c83cb7f99d" }
-cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "a30c2e314f67f47d5591fc1d2ff440c83cb7f99d" }
-cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "5d15ee09ea56502783a5e056bf4b1d36c73a3a26" }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "45c2777584defbb0087b1e8efacace7be52ac01a" }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "45c2777584defbb0087b1e8efacace7be52ac01a" }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "45c2777584defbb0087b1e8efacace7be52ac01a" }
+cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "45c2777584defbb0087b1e8efacace7be52ac01a" }
+cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "b58c733dd26390856de5e37ebc365e7145e147e0" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }

--- a/crates/burn-backend/src/cubecl.rs
+++ b/crates/burn-backend/src/cubecl.rs
@@ -11,7 +11,7 @@
 use burn_std::{BoolStore, DType, QuantScheme, QuantStore, QuantValue};
 use cubecl::ir::{ElemType, FloatKind, IntKind, UIntKind};
 
-pub use cubecl::throughput::{ThroughputKey, ThroughputMode, ThroughputValue};
+pub use cubecl::throughput::{MemoryAccess, ThroughputKey, ThroughputMode, ThroughputValue};
 
 /// Convert a cubecl [`ElemType`] into the corresponding burn [`DType`].
 ///

--- a/crates/burn-cubecl-fusion/src/engine/codegen/ir.rs
+++ b/crates/burn-cubecl-fusion/src/engine/codegen/ir.rs
@@ -906,6 +906,7 @@ impl From<ElemType> for FuseType {
             },
             ElemType::Bool => Self::U32,
             ElemType::Index => Self::U32,
+            ElemType::Complex(_) => panic!("Unsupported type for fusion: {value}"),
         }
     }
 }

--- a/crates/burn-tensor/src/device.rs
+++ b/crates/burn-tensor/src/device.rs
@@ -3,7 +3,7 @@ pub use burn_std::{
 };
 
 #[cfg(feature = "cubecl")]
-pub use burn_backend::cubecl::{ThroughputKey, ThroughputMode, ThroughputValue};
+pub use burn_backend::cubecl::{MemoryAccess, ThroughputKey, ThroughputMode, ThroughputValue};
 use burn_backend::{Backend, DeviceOps};
 pub use burn_backend::{
     InstallMemoryPoolsError, MemoryPoolLayout, MemoryPoolUsage, SlicedPool, SlicedPoolReport,
@@ -939,10 +939,11 @@ fn mode_label(mode: &ThroughputMode) -> &'static str {
     match mode {
         ThroughputMode::ComputeDirect { .. } => "compute-direct",
         ThroughputMode::ComputeCmma { .. } => "compute-cmma",
-        ThroughputMode::Memory => "memory",
-        ThroughputMode::MemoryRead => "memory-read",
-        ThroughputMode::MemoryWrite => "memory-write",
-        ThroughputMode::MemoryWorkingSet { .. } => "memory-working-set",
+        ThroughputMode::Memory(spec) => match spec.access {
+            MemoryAccess::Copy => "memory",
+            MemoryAccess::Read => "memory-read",
+            MemoryAccess::Write => "memory-write",
+        },
         ThroughputMode::Launch => "launch",
     }
 }
@@ -962,11 +963,7 @@ impl core::fmt::Display for ThroughputStat {
             ThroughputMode::ComputeDirect { dtype } | ThroughputMode::ComputeCmma { dtype, .. } => {
                 alloc::format!("{dtype}")
             }
-            ThroughputMode::Memory
-            | ThroughputMode::MemoryRead
-            | ThroughputMode::MemoryWrite
-            | ThroughputMode::MemoryWorkingSet { .. }
-            | ThroughputMode::Launch => alloc::string::String::new(),
+            ThroughputMode::Memory(_) | ThroughputMode::Launch => alloc::string::String::new(),
         };
 
         let value = self.value.format(&self.key);


### PR DESCRIPTION
tracel-ai/cubecl#1559 replaces `Memory`, `MemoryRead`, `MemoryWrite` and `MemoryWorkingSet` with a single `Memory(MemorySpec { access, bytes })`, since the working set is a parameter of every memory probe rather than a fourth kind of one. burn names those variants in exactly one place.

`mode_label` derives the labels from `spec.access`, so "memory", "memory-read" and "memory-write" all survive. "memory-working-set" does not: the size is now orthogonal to the direction, and `ThroughputStat` carries the full key for anyone who needs it.

The four `roofline_bounds` call sites in `burn-cubecl` are untouched. That signature does not change, and cubek's `work()` keeps the semantics it had, so matmul, attention and reduce autotune bounds are unaffected.

## Blocked on two upstreams

This pins two unmerged branches and **cannot merge until both land**:

1. **tracel-ai/cubecl#1559**, pinned here at `c251b2af`.
2. **tracel-ai/cubek#562**, itself pinned to cubecl#1559 and blocked on it. Pinned here at `27209723`.

Then this needs one commit repointing the two revs at their merged shas. Nothing else about it changes.

The cubecl and cubek bumps are not separable: cargo resolves one rev per git source, and a cubek old enough to predate #562 still names `ThroughputMode::Memory` as a unit variant, so a `[patch]` cannot dodge it.

## Verification

Tower, RTX 4070 Ti SUPER, at `d93062461`:

| suite | result |
| --- | --- |
| `burn-tensor --lib` | 18 passed, 0 failed |
| `burn-backend-tests` autodiff | 544 passed, 0 failed, 6 ignored |
| `burn-backend-tests` tensor | 544 passed, 0 failed, 6 ignored |
| `burn-backend-tests --test cubecl` | 215 passed, 1 failed, 1 ignored |

The one failure is `quantization::quantize_dequantize::should_panic_when_shape_cannot_store_quants`, a `should_panic` test that stopped panicking. **It is pre-existing on `main`**: run on the same machine against `main` at its own pins (cubecl `9b01400e`, cubek `0c24cd5a`) it fails identically, same assertion, same line. Consistent with the diff, since every file cubecl#1559 touches is under `throughput/` plus `tune/bounds_generator.rs`, and cubek's `crates/cubek-quant/` is byte-identical between main's pinned rev and this one.

`cargo check --workspace --exclude burn-cuda --exclude burn-hip` clean, and `burn-cubecl` clean with and without `autotune`. `cargo fmt` run.

An earlier revision of this branch carried its own interpolate migration. #5502 landed that work first and better, so it was dropped rather than duplicated.
