### PR TITLE
feat(tch): support mul indexing updates

### DIFF
--- a/crates/burn-backend-tests/tests/autodiff/gather_scatter.rs
+++ b/crates/burn-backend-tests/tests/autodiff/gather_scatter.rs
@@ -98,7 +98,7 @@ fn test_scatter_assign_grad() {
         .assert_eq(&TensorData::from([[1., 1.], [1., 1.]]), false);
 }
 
-#[cfg(any(feature = "flex", feature = "ndarray"))]
+#[cfg(any(feature = "flex", feature = "ndarray", feature = "tch"))]
 #[test]
 fn test_scatter_mul_grad() {
     let device = AutodiffDevice::new();

--- a/crates/burn-backend-tests/tests/autodiff/select.rs
+++ b/crates/burn-backend-tests/tests/autodiff/select.rs
@@ -96,7 +96,7 @@ fn test_select_assign_grad() {
         .assert_eq(&TensorData::from([[1., 1.], [1., 1.]]), false);
 }
 
-#[cfg(any(feature = "flex", feature = "ndarray"))]
+#[cfg(any(feature = "flex", feature = "ndarray", feature = "tch"))]
 #[test]
 fn test_select_assign_mul_grad() {
     let device = AutodiffDevice::new();

--- a/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter.rs
@@ -120,7 +120,7 @@ fn should_scatter_assign_2d_dim0() {
         .assert_eq(&TensorData::from([[4.0, 2.0, 6.0], [1.0, 5.0, 3.0]]), false);
 }
 
-#[cfg(any(feature = "flex", feature = "ndarray"))]
+#[cfg(any(feature = "flex", feature = "ndarray", feature = "tch"))]
 #[test]
 fn should_scatter_mul_1d() {
     let device = Default::default();
@@ -135,7 +135,7 @@ fn should_scatter_mul_1d() {
         .assert_eq(&TensorData::from([10.0, 140.0, 30.0, 2000.0]), false);
 }
 
-#[cfg(any(feature = "flex", feature = "ndarray"))]
+#[cfg(any(feature = "flex", feature = "ndarray", feature = "tch"))]
 #[test]
 fn should_scatter_mul_2d_dim0() {
     let device = Default::default();

--- a/crates/burn-backend-tests/tests/tensor/float/ops/select.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/select.rs
@@ -108,7 +108,7 @@ fn should_select_assign_2d_dim1() {
     output.into_data().assert_eq(&expected, false);
 }
 
-#[cfg(any(feature = "flex", feature = "ndarray"))]
+#[cfg(any(feature = "flex", feature = "ndarray", feature = "tch"))]
 #[test]
 fn should_select_assign_mul_2d_dim0() {
     let device = Default::default();
@@ -122,7 +122,7 @@ fn should_select_assign_mul_2d_dim0() {
     output.into_data().assert_eq(&expected, false);
 }
 
-#[cfg(any(feature = "flex", feature = "ndarray"))]
+#[cfg(any(feature = "flex", feature = "ndarray", feature = "tch"))]
 #[test]
 fn should_select_assign_mul_2d_dim1() {
     let device = Default::default();

--- a/crates/burn-backend-tests/tests/tensor/int/ops/gather_scatter.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/gather_scatter.rs
@@ -98,7 +98,7 @@ fn should_scatter_assign_2d_dim0_int() {
         .assert_eq(&TensorData::from([[4, 2, 6], [1, 5, 3]]), false);
 }
 
-#[cfg(any(feature = "flex", feature = "ndarray"))]
+#[cfg(any(feature = "flex", feature = "ndarray", feature = "tch"))]
 #[test]
 fn should_scatter_mul_1d_int() {
     let device = Default::default();
@@ -113,7 +113,7 @@ fn should_scatter_mul_1d_int() {
         .assert_eq(&TensorData::from([10, 140, 30, 2000]), false);
 }
 
-#[cfg(any(feature = "flex", feature = "ndarray"))]
+#[cfg(any(feature = "flex", feature = "ndarray", feature = "tch"))]
 #[test]
 fn should_scatter_mul_2d_dim0_int() {
     let device = Default::default();

--- a/crates/burn-backend-tests/tests/tensor/int/ops/select.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/select.rs
@@ -54,7 +54,7 @@ fn should_select_assign_2d_dim1_int() {
     output.into_data().assert_eq(&expected, false);
 }
 
-#[cfg(any(feature = "flex", feature = "ndarray"))]
+#[cfg(any(feature = "flex", feature = "ndarray", feature = "tch"))]
 #[test]
 fn should_select_assign_mul_2d_dim0_int() {
     let device = Default::default();
@@ -68,7 +68,7 @@ fn should_select_assign_mul_2d_dim0_int() {
     output.into_data().assert_eq(&expected, false);
 }
 
-#[cfg(any(feature = "flex", feature = "ndarray"))]
+#[cfg(any(feature = "flex", feature = "ndarray", feature = "tch"))]
 #[test]
 fn should_select_assign_mul_2d_dim1_int() {
     let device = Default::default();

--- a/crates/burn-tch/src/ops/base.rs
+++ b/crates/burn-tch/src/ops/base.rs
@@ -233,6 +233,24 @@ impl TchOps {
         TchTensor::from_existing(tensor, storage)
     }
 
+    pub fn scatter_mul(
+        dim: usize,
+        tensor: TchTensor,
+        indices: TchTensor,
+        value: TchTensor,
+    ) -> TchTensor {
+        let storage = tensor.storage.clone();
+        let tensor = tensor.tensor.internal_scatter_reduce(
+            dim as i64,
+            &indices.tensor,
+            &value.tensor,
+            "prod",
+            true,
+        );
+
+        TchTensor::from_existing(tensor, storage)
+    }
+
     /// Flatten K-dimensional index tuples into 1D linear offsets, suitable for
     /// use with PyTorch's scatter/gather along dim 0 of a flattened tensor.
     ///
@@ -338,6 +356,20 @@ impl TchOps {
         tensor.clone().unary_ops(
             |mut tensor| tensor.index_add_(dim as i64, &indices.tensor, &value.tensor),
             |tensor| tensor.index_add(dim as i64, &indices.tensor, &value.tensor),
+        )
+    }
+
+    pub fn select_assign_mul(
+        tensor: TchTensor,
+        dim: usize,
+        indices: TchTensor,
+        value: TchTensor,
+    ) -> TchTensor {
+        tensor.clone().unary_ops(
+            |mut tensor| {
+                tensor.index_reduce_(dim as i64, &indices.tensor, &value.tensor, "prod", true)
+            },
+            |tensor| tensor.index_reduce(dim as i64, &indices.tensor, &value.tensor, "prod", true),
         )
     }
 

--- a/crates/burn-tch/src/ops/int_tensor.rs
+++ b/crates/burn-tch/src/ops/int_tensor.rs
@@ -292,6 +292,24 @@ impl IntTensorOps<Self> for LibTorch {
         TchOps::scatter(dim, tensor, indices, value)
     }
 
+    fn int_scatter(
+        dim: usize,
+        tensor: TchTensor,
+        indices: TchTensor,
+        value: TchTensor,
+        update: burn_backend::tensor::IndexingUpdateOp,
+    ) -> TchTensor {
+        match update {
+            burn_backend::tensor::IndexingUpdateOp::Add => {
+                TchOps::scatter(dim, tensor, indices, value)
+            }
+            burn_backend::tensor::IndexingUpdateOp::Mul => {
+                TchOps::scatter_mul(dim, tensor, indices, value)
+            }
+            other => unimplemented!("int_scatter with {other:?} update is not implemented"),
+        }
+    }
+
     fn int_scatter_nd(
         data: TchTensor,
         indices: TchTensor,
@@ -316,6 +334,26 @@ impl IntTensorOps<Self> for LibTorch {
         value: TchTensor,
     ) -> TchTensor {
         TchOps::select_assign(tensor, dim, indices, value)
+    }
+
+    fn int_select_assign(
+        tensor: TchTensor,
+        dim: usize,
+        indices: TchTensor,
+        value: TchTensor,
+        update: burn_backend::tensor::IndexingUpdateOp,
+    ) -> TchTensor {
+        match update {
+            burn_backend::tensor::IndexingUpdateOp::Add => {
+                TchOps::select_assign(tensor, dim, indices, value)
+            }
+            burn_backend::tensor::IndexingUpdateOp::Mul => {
+                TchOps::select_assign_mul(tensor, dim, indices, value)
+            }
+            other => {
+                unimplemented!("int_select_assign with {other:?} update is not implemented")
+            }
+        }
     }
 
     fn int_mask_where(tensor: TchTensor, mask: TchTensor, source: TchTensor) -> TchTensor {

--- a/crates/burn-tch/src/ops/tensor.rs
+++ b/crates/burn-tch/src/ops/tensor.rs
@@ -203,6 +203,24 @@ impl FloatTensorOps<Self> for LibTorch {
         TchOps::scatter(dim, tensor, indices, value)
     }
 
+    fn float_scatter(
+        dim: usize,
+        tensor: TchTensor,
+        indices: TchTensor,
+        value: TchTensor,
+        update: burn_backend::tensor::IndexingUpdateOp,
+    ) -> TchTensor {
+        match update {
+            burn_backend::tensor::IndexingUpdateOp::Add => {
+                TchOps::scatter(dim, tensor, indices, value)
+            }
+            burn_backend::tensor::IndexingUpdateOp::Mul => {
+                TchOps::scatter_mul(dim, tensor, indices, value)
+            }
+            other => unimplemented!("float_scatter with {other:?} update is not implemented"),
+        }
+    }
+
     fn float_scatter_nd(
         data: TchTensor,
         indices: TchTensor,
@@ -227,6 +245,26 @@ impl FloatTensorOps<Self> for LibTorch {
         value: TchTensor,
     ) -> TchTensor {
         TchOps::select_assign(tensor, dim, indices, value)
+    }
+
+    fn float_select_assign(
+        tensor: TchTensor,
+        dim: usize,
+        indices: TchTensor,
+        value: TchTensor,
+        update: burn_backend::tensor::IndexingUpdateOp,
+    ) -> TchTensor {
+        match update {
+            burn_backend::tensor::IndexingUpdateOp::Add => {
+                TchOps::select_assign(tensor, dim, indices, value)
+            }
+            burn_backend::tensor::IndexingUpdateOp::Mul => {
+                TchOps::select_assign_mul(tensor, dim, indices, value)
+            }
+            other => {
+                unimplemented!("float_select_assign with {other:?} update is not implemented")
+            }
+        }
     }
 
     fn float_slice(tensor: TchTensor, slices: &[burn_backend::Slice]) -> TchTensor {


### PR DESCRIPTION
## Motivation

PR #5325 added multiply-style scatter and select updates for NdArray and Flex, but the Tch backend still falls back to the default unsupported implementation. This follow-up brings Tch to parity for float and integer tensors so IndexingUpdateOp::Mul works consistently across these indexed update APIs.

## Modifications

- Implement multiply reductions for Tch scatter using the LibTorch scatter-reduce primitive.
- Implement multiply reductions for Tch select_assign using index_reduce with the existing tensor included in the product.
- Override the float and integer scatter and select_assign dispatch paths for Add and Mul.
- Enable the existing forward and autodiff multiply-update tests for the Tch feature.
