### PR TITLE
feat(cubecl): support mul indexing updates

### DIFF
--- a/crates/burn-backend-tests/tests/autodiff/gather_scatter.rs
+++ b/crates/burn-backend-tests/tests/autodiff/gather_scatter.rs
@@ -98,7 +98,7 @@ fn test_scatter_assign_grad() {
         .assert_eq(&TensorData::from([[1., 1.], [1., 1.]]), false);
 }
 
-#[cfg(any(feature = "flex", feature = "ndarray"))]
+#[cfg(any(feature = "cube", feature = "flex", feature = "ndarray"))]
 #[test]
 fn test_scatter_mul_grad() {
     let device = AutodiffDevice::new();

--- a/crates/burn-backend-tests/tests/autodiff/select.rs
+++ b/crates/burn-backend-tests/tests/autodiff/select.rs
@@ -96,7 +96,7 @@ fn test_select_assign_grad() {
         .assert_eq(&TensorData::from([[1., 1.], [1., 1.]]), false);
 }
 
-#[cfg(any(feature = "flex", feature = "ndarray"))]
+#[cfg(any(feature = "cube", feature = "flex", feature = "ndarray"))]
 #[test]
 fn test_select_assign_mul_grad() {
     let device = AutodiffDevice::new();

--- a/crates/burn-backend-tests/tests/cubecl/scatter.rs
+++ b/crates/burn-backend-tests/tests/cubecl/scatter.rs
@@ -32,6 +32,16 @@ fn scatter_should_work_with_multiple_workgroups_diff_shapes() {
     same_as_reference_diff_shape(1, [32, 128], [32, 1]);
 }
 
+#[test]
+fn scatter_mul_should_work_with_multiple_workgroups_2d_dim0() {
+    mul_same_as_reference(0, [256, 32]);
+}
+
+#[test]
+fn scatter_mul_should_work_with_multiple_workgroups_2d_dim1() {
+    mul_same_as_reference(1, [32, 256]);
+}
+
 fn same_as_reference_diff_shape<const D: usize>(
     dim: usize,
     shape1: [usize; D],
@@ -65,4 +75,37 @@ fn same_as_reference_diff_shape<const D: usize>(
 
 fn same_as_reference_same_shape<const D: usize>(dim: usize, shape: [usize; D]) {
     same_as_reference_diff_shape(dim, shape, shape);
+}
+
+fn mul_same_as_reference<const D: usize>(dim: usize, shape: [usize; D]) {
+    let device = Device::default();
+    let ref_device = ReferenceDevice::new();
+
+    device.seed(0);
+
+    let tensor = TestTensor::<D>::random(shape, Distribution::Default, &device);
+    let value = TestTensor::<D>::random(shape, Distribution::Default, &device);
+
+    // Keep indices unique along the updated dimension because duplicate-index behavior for
+    // multiplicative updates is intentionally unspecified.
+    let mut index_shape = [1; D];
+    index_shape[dim] = shape[dim];
+    let mut indices: TestTensorInt<D> =
+        TestTensorInt::<1>::arange(0..shape[dim] as i64, &device).reshape(index_shape);
+    for axis in 0..D {
+        if axis != dim {
+            indices = indices.repeat_dim(axis, shape[axis]);
+        }
+    }
+
+    let tensor_ref = TestTensor::<D>::from_data(tensor.to_data(), &ref_device);
+    let value_ref = TestTensor::<D>::from_data(value.to_data(), &ref_device);
+    let indices_ref = TestTensorInt::<D>::from_data(indices.to_data(), &ref_device);
+
+    let actual = tensor.scatter(dim, indices, value, IndexingUpdateOp::Mul);
+    let expected = tensor_ref.scatter(dim, indices_ref, value_ref, IndexingUpdateOp::Mul);
+
+    expected
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&actual.into_data(), Tolerance::default());
 }

--- a/crates/burn-backend-tests/tests/cubecl/select_assign.rs
+++ b/crates/burn-backend-tests/tests/cubecl/select_assign.rs
@@ -27,6 +27,16 @@ fn select_add_should_work_with_multiple_workgroups_3d_dim2() {
     select_add_same_as_ref(2, [6, 6, 256]);
 }
 
+#[test]
+fn select_mul_should_work_with_multiple_workgroups_2d_dim0() {
+    select_mul_same_as_ref(0, [256, 6]);
+}
+
+#[test]
+fn select_mul_should_work_with_multiple_workgroups_2d_dim1() {
+    select_mul_same_as_ref(1, [6, 256]);
+}
+
 fn select_add_same_as_ref<const D: usize>(dim: usize, shape: [usize; D]) {
     let device = Device::default();
     let ref_device = ReferenceDevice::new();
@@ -46,6 +56,28 @@ fn select_add_same_as_ref<const D: usize>(dim: usize, shape: [usize; D]) {
 
     let actual = tensor.select_assign(dim, indices, value, IndexingUpdateOp::Add);
     let expected = tensor_ref.select_assign(dim, indices_ref, value_ref, IndexingUpdateOp::Add);
+
+    expected
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&actual.into_data(), Tolerance::default());
+}
+
+fn select_mul_same_as_ref<const D: usize>(dim: usize, shape: [usize; D]) {
+    let device = Device::default();
+    let ref_device = ReferenceDevice::new();
+
+    device.seed(0);
+
+    let tensor = TestTensor::<D>::random(shape, Distribution::Default, &device);
+    let value = TestTensor::<D>::random(shape, Distribution::Default, &device);
+    let indices = TestTensorInt::<1>::arange(0..shape[dim] as i64, &device);
+
+    let tensor_ref = TestTensor::<D>::from_data(tensor.to_data(), &ref_device);
+    let value_ref = TestTensor::<D>::from_data(value.to_data(), &ref_device);
+    let indices_ref = TestTensorInt::<1>::from_data(indices.to_data(), &ref_device);
+
+    let actual = tensor.select_assign(dim, indices, value, IndexingUpdateOp::Mul);
+    let expected = tensor_ref.select_assign(dim, indices_ref, value_ref, IndexingUpdateOp::Mul);
 
     expected
         .into_data()

--- a/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter.rs
@@ -120,7 +120,7 @@ fn should_scatter_assign_2d_dim0() {
         .assert_eq(&TensorData::from([[4.0, 2.0, 6.0], [1.0, 5.0, 3.0]]), false);
 }
 
-#[cfg(any(feature = "flex", feature = "ndarray"))]
+#[cfg(any(feature = "cube", feature = "flex", feature = "ndarray"))]
 #[test]
 fn should_scatter_mul_1d() {
     let device = Default::default();
@@ -135,7 +135,7 @@ fn should_scatter_mul_1d() {
         .assert_eq(&TensorData::from([10.0, 140.0, 30.0, 2000.0]), false);
 }
 
-#[cfg(any(feature = "flex", feature = "ndarray"))]
+#[cfg(any(feature = "cube", feature = "flex", feature = "ndarray"))]
 #[test]
 fn should_scatter_mul_2d_dim0() {
     let device = Default::default();

--- a/crates/burn-backend-tests/tests/tensor/float/ops/select.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/select.rs
@@ -108,7 +108,7 @@ fn should_select_assign_2d_dim1() {
     output.into_data().assert_eq(&expected, false);
 }
 
-#[cfg(any(feature = "flex", feature = "ndarray"))]
+#[cfg(any(feature = "cube", feature = "flex", feature = "ndarray"))]
 #[test]
 fn should_select_assign_mul_2d_dim0() {
     let device = Default::default();
@@ -122,7 +122,7 @@ fn should_select_assign_mul_2d_dim0() {
     output.into_data().assert_eq(&expected, false);
 }
 
-#[cfg(any(feature = "flex", feature = "ndarray"))]
+#[cfg(any(feature = "cube", feature = "flex", feature = "ndarray"))]
 #[test]
 fn should_select_assign_mul_2d_dim1() {
     let device = Default::default();

--- a/crates/burn-backend-tests/tests/tensor/int/ops/gather_scatter.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/gather_scatter.rs
@@ -98,7 +98,7 @@ fn should_scatter_assign_2d_dim0_int() {
         .assert_eq(&TensorData::from([[4, 2, 6], [1, 5, 3]]), false);
 }
 
-#[cfg(any(feature = "flex", feature = "ndarray"))]
+#[cfg(any(feature = "cube", feature = "flex", feature = "ndarray"))]
 #[test]
 fn should_scatter_mul_1d_int() {
     let device = Default::default();
@@ -113,7 +113,7 @@ fn should_scatter_mul_1d_int() {
         .assert_eq(&TensorData::from([10, 140, 30, 2000]), false);
 }
 
-#[cfg(any(feature = "flex", feature = "ndarray"))]
+#[cfg(any(feature = "cube", feature = "flex", feature = "ndarray"))]
 #[test]
 fn should_scatter_mul_2d_dim0_int() {
     let device = Default::default();

--- a/crates/burn-backend-tests/tests/tensor/int/ops/select.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/select.rs
@@ -54,7 +54,7 @@ fn should_select_assign_2d_dim1_int() {
     output.into_data().assert_eq(&expected, false);
 }
 
-#[cfg(any(feature = "flex", feature = "ndarray"))]
+#[cfg(any(feature = "cube", feature = "flex", feature = "ndarray"))]
 #[test]
 fn should_select_assign_mul_2d_dim0_int() {
     let device = Default::default();
@@ -68,7 +68,7 @@ fn should_select_assign_mul_2d_dim0_int() {
     output.into_data().assert_eq(&expected, false);
 }
 
-#[cfg(any(feature = "flex", feature = "ndarray"))]
+#[cfg(any(feature = "cube", feature = "flex", feature = "ndarray"))]
 #[test]
 fn should_select_assign_mul_2d_dim1_int() {
     let device = Default::default();

--- a/crates/burn-backend-tests/tests/tensor/int/ops/select.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/select.rs
@@ -54,11 +54,6 @@ fn should_select_assign_2d_dim1_int() {
     output.into_data().assert_eq(&expected, false);
 }
 
-<<<<<<< HEAD
-#[cfg(any(feature = "cube", feature = "flex", feature = "ndarray"))]
-=======
-#[cfg(any(feature = "flex", feature = "ndarray", feature = "tch"))]
->>>>>>> upstream/main
 #[test]
 fn should_select_assign_mul_2d_dim0_int() {
     let device = Default::default();
@@ -72,11 +67,6 @@ fn should_select_assign_mul_2d_dim0_int() {
     output.into_data().assert_eq(&expected, false);
 }
 
-<<<<<<< HEAD
-#[cfg(any(feature = "cube", feature = "flex", feature = "ndarray"))]
-=======
-#[cfg(any(feature = "flex", feature = "ndarray", feature = "tch"))]
->>>>>>> upstream/main
 #[test]
 fn should_select_assign_mul_2d_dim1_int() {
     let device = Default::default();

--- a/crates/burn-cubecl/src/kernel/index/scatter.rs
+++ b/crates/burn-cubecl/src/kernel/index/scatter.rs
@@ -1,7 +1,7 @@
 use crate::{
     CubeRuntime,
     kernel::{
-        AddOp, BinaryOp, BinaryOpFamily, OrOp,
+        AddOp, BinaryOp, BinaryOpFamily, MulOp, OrOp,
         utils::{address_type, shape_divmod},
     },
     tensor::CubeTensor,
@@ -70,12 +70,11 @@ fn scatter_kernel<T: Numeric, I: Int, Op: BinaryOpFamily>(
     }
 }
 
-pub(crate) fn scatter<R: CubeRuntime>(
+fn scatter_op<R: CubeRuntime, Op: BinaryOpFamily>(
     dim: usize,
     tensor: CubeTensor<R>,
     indices: CubeTensor<R>,
     value: CubeTensor<R>,
-    is_bool: bool,
 ) -> CubeTensor<R> {
     let tensor = match tensor.can_mut() && tensor.is_nonoverlapping() {
         true => tensor,
@@ -88,15 +87,10 @@ pub(crate) fn scatter<R: CubeRuntime>(
     let cube_dim = CubeDim::new(&indices.client, working_units);
     let cube_count = calculate_cube_count_elemwise(&indices.client, working_units, cube_dim);
 
-    let launch = match is_bool {
-        true => scatter_kernel::launch_unchecked::<OrOp, R>,
-        false => scatter_kernel::launch_unchecked::<AddOp, R>,
-    };
-
     let (tensor_dtype, indices_dtype) = (tensor.dtype, indices.dtype);
 
     unsafe {
-        launch(
+        scatter_kernel::launch_unchecked::<Op, R>(
             &tensor.client.clone(),
             cube_count,
             cube_dim,
@@ -113,4 +107,26 @@ pub(crate) fn scatter<R: CubeRuntime>(
         )
     }
     tensor
+}
+
+pub(crate) fn scatter<R: CubeRuntime>(
+    dim: usize,
+    tensor: CubeTensor<R>,
+    indices: CubeTensor<R>,
+    value: CubeTensor<R>,
+    is_bool: bool,
+) -> CubeTensor<R> {
+    match is_bool {
+        true => scatter_op::<R, OrOp>(dim, tensor, indices, value),
+        false => scatter_op::<R, AddOp>(dim, tensor, indices, value),
+    }
+}
+
+pub(crate) fn scatter_mul<R: CubeRuntime>(
+    dim: usize,
+    tensor: CubeTensor<R>,
+    indices: CubeTensor<R>,
+    value: CubeTensor<R>,
+) -> CubeTensor<R> {
+    scatter_op::<R, MulOp>(dim, tensor, indices, value)
 }

--- a/crates/burn-cubecl/src/kernel/index/select_assign.rs
+++ b/crates/burn-cubecl/src/kernel/index/select_assign.rs
@@ -1,5 +1,5 @@
 use crate::kernel::{
-    AddOp, BinaryOp, BinaryOpFamily, OrOp,
+    AddOp, BinaryOp, BinaryOpFamily, MulOp, OrOp,
     utils::{address_type, shape_divmod},
 };
 use crate::{CubeRuntime, tensor::CubeTensor};
@@ -59,12 +59,11 @@ fn select_assign_kernel<F: Numeric, I: Numeric, Op: BinaryOpFamily>(
     }
 }
 
-pub(crate) fn select_assign<R: CubeRuntime>(
+fn select_assign_op<R: CubeRuntime, Op: BinaryOpFamily>(
     tensor: CubeTensor<R>,
     dim: usize,
     indices: CubeTensor<R>,
     value: CubeTensor<R>,
-    is_bool: bool,
 ) -> CubeTensor<R> {
     let tensor = match tensor.can_mut() && tensor.is_nonoverlapping() {
         true => tensor,
@@ -75,15 +74,10 @@ pub(crate) fn select_assign<R: CubeRuntime>(
     let cube_dim = CubeDim::new(&indices.client, working_units);
     let cube_count = calculate_cube_count_elemwise(&indices.client, working_units, cube_dim);
 
-    let launch = match is_bool {
-        true => select_assign_kernel::launch::<OrOp, R>,
-        false => select_assign_kernel::launch::<AddOp, R>,
-    };
-
     let (tensor_dtype, indices_dtype) = (tensor.dtype, indices.dtype);
 
     let shape = shape_divmod(&value);
-    launch(
+    select_assign_kernel::launch::<Op, R>(
         &tensor.client,
         cube_count,
         cube_dim,
@@ -101,4 +95,26 @@ pub(crate) fn select_assign<R: CubeRuntime>(
     );
 
     tensor
+}
+
+pub(crate) fn select_assign<R: CubeRuntime>(
+    tensor: CubeTensor<R>,
+    dim: usize,
+    indices: CubeTensor<R>,
+    value: CubeTensor<R>,
+    is_bool: bool,
+) -> CubeTensor<R> {
+    match is_bool {
+        true => select_assign_op::<R, OrOp>(tensor, dim, indices, value),
+        false => select_assign_op::<R, AddOp>(tensor, dim, indices, value),
+    }
+}
+
+pub(crate) fn select_assign_mul<R: CubeRuntime>(
+    tensor: CubeTensor<R>,
+    dim: usize,
+    indices: CubeTensor<R>,
+    value: CubeTensor<R>,
+) -> CubeTensor<R> {
+    select_assign_op::<R, MulOp>(tensor, dim, indices, value)
 }

--- a/crates/burn-cubecl/src/ops/int_tensor.rs
+++ b/crates/burn-cubecl/src/ops/int_tensor.rs
@@ -129,6 +129,24 @@ impl<R: CubeRuntime> IntTensorOps<Self> for CubeBackend<R> {
         kernel::scatter(dim, tensor, indices, value, false)
     }
 
+    fn int_scatter(
+        dim: usize,
+        tensor: IntTensor<Self>,
+        indices: IntTensor<Self>,
+        value: IntTensor<Self>,
+        update: burn_backend::tensor::IndexingUpdateOp,
+    ) -> IntTensor<Self> {
+        match update {
+            burn_backend::tensor::IndexingUpdateOp::Add => {
+                Self::int_scatter_add(dim, tensor, indices, value)
+            }
+            burn_backend::tensor::IndexingUpdateOp::Mul => {
+                kernel::scatter_mul(dim, tensor, indices, value)
+            }
+            other => unimplemented!("int_scatter with {other:?} update is not implemented"),
+        }
+    }
+
     fn int_scatter_nd(
         data: IntTensor<Self>,
         indices: IntTensor<Self>,
@@ -157,6 +175,26 @@ impl<R: CubeRuntime> IntTensorOps<Self> for CubeBackend<R> {
         value: IntTensor<Self>,
     ) -> IntTensor<Self> {
         kernel::select_assign(tensor, dim, indices, value, false)
+    }
+
+    fn int_select_assign(
+        tensor: IntTensor<Self>,
+        dim: usize,
+        indices: IntTensor<Self>,
+        value: IntTensor<Self>,
+        update: burn_backend::tensor::IndexingUpdateOp,
+    ) -> IntTensor<Self> {
+        match update {
+            burn_backend::tensor::IndexingUpdateOp::Add => {
+                Self::int_select_add(tensor, dim, indices, value)
+            }
+            burn_backend::tensor::IndexingUpdateOp::Mul => {
+                kernel::select_assign_mul(tensor, dim, indices, value)
+            }
+            other => {
+                unimplemented!("int_select_assign with {other:?} update is not implemented")
+            }
+        }
     }
 
     fn int_equal(

--- a/crates/burn-cubecl/src/ops/tensor.rs
+++ b/crates/burn-cubecl/src/ops/tensor.rs
@@ -186,6 +186,24 @@ where
         kernel::scatter(dim, tensor, indices, value, false)
     }
 
+    fn float_scatter(
+        dim: usize,
+        tensor: FloatTensor<Self>,
+        indices: IntTensor<Self>,
+        value: FloatTensor<Self>,
+        update: burn_backend::tensor::IndexingUpdateOp,
+    ) -> FloatTensor<Self> {
+        match update {
+            burn_backend::tensor::IndexingUpdateOp::Add => {
+                Self::float_scatter_add(dim, tensor, indices, value)
+            }
+            burn_backend::tensor::IndexingUpdateOp::Mul => {
+                kernel::scatter_mul(dim, tensor, indices, value)
+            }
+            other => unimplemented!("float_scatter with {other:?} update is not implemented"),
+        }
+    }
+
     fn float_scatter_nd(
         data: FloatTensor<Self>,
         indices: IntTensor<Self>,
@@ -214,6 +232,26 @@ where
         value: FloatTensor<Self>,
     ) -> FloatTensor<Self> {
         kernel::select_assign(tensor, dim, indices, value, false)
+    }
+
+    fn float_select_assign(
+        tensor: FloatTensor<Self>,
+        dim: usize,
+        indices: IntTensor<Self>,
+        value: FloatTensor<Self>,
+        update: burn_backend::tensor::IndexingUpdateOp,
+    ) -> FloatTensor<Self> {
+        match update {
+            burn_backend::tensor::IndexingUpdateOp::Add => {
+                Self::float_select_add(tensor, dim, indices, value)
+            }
+            burn_backend::tensor::IndexingUpdateOp::Mul => {
+                kernel::select_assign_mul(tensor, dim, indices, value)
+            }
+            other => {
+                unimplemented!("float_select_assign with {other:?} update is not implemented")
+            }
+        }
     }
 
     fn float_slice(tensor: FloatTensor<Self>, slices: &[Slice]) -> FloatTensor<Self> {


### PR DESCRIPTION
## Motivation

PR #5325 added multiply-style scatter and select updates for NdArray and Flex, but CubeCL still supports only additive numeric updates for these APIs. CubeCL already has a reusable MulOp and uses it for scatter_nd, so the regular indexed update kernels can support IndexingUpdateOp::Mul without introducing new kernel math.

This brings CubeCL backends to parity for float and integer tensors while preserving the existing boolean OR behavior.

## Modifications

- Share the CubeCL scatter and select_assign launch paths across binary operation families.
- Dispatch MulOp for float and integer scatter and select_assign updates.
- Preserve the existing AddOp and boolean OrOp paths.
- Enable the shared forward and autodiff multiply-update tests for CubeCL backends.
- Add CubeCL reference tests for multiply updates across multiple workgroups using unique indices.