### PR TITLE
fix(router): support rfft and irfft

### DIFF
--- a/crates/burn-remote/src/lib.rs
+++ b/crates/burn-remote/src/lib.rs
@@ -73,7 +73,10 @@ pub use __client::*;
 #[cfg(all(test, feature = "client", feature = "server"))]
 mod tests {
     use burn_flex::Flex;
-    use burn_tensor::{Device, DeviceType, Distribution, Tensor};
+    use burn_tensor::{
+        Device, DeviceType, Distribution, Tensor, TensorData, Tolerance,
+        signal::{irfft, rfft},
+    };
 
     /// Run `body` on a worker thread and fail the test if it doesn't finish within `timeout`.
     ///
@@ -135,6 +138,42 @@ mod tests {
         let input = input.to_device(&device_1);
         let numbers: Vec<f32> = input.to_data().to_vec().unwrap();
         assert_eq!(numbers, numbers_expected);
+
+        rt.shutdown_background();
+    }
+
+    #[test]
+    pub fn test_fft_over_websocket() {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_io()
+            .build()
+            .unwrap();
+
+        rt.spawn(
+            crate::server::RemoteServerBuilder::<Flex>::new(vec![Default::default()])
+                .port(3160)
+                .start_async(),
+        );
+
+        std::thread::sleep(std::time::Duration::from_millis(500));
+
+        let device = Device::remote_websocket("ws://localhost:3160", 0);
+        let signal = Tensor::<1>::from_floats([1.0, 1.0, 1.0, 1.0], &device);
+        let (spectrum_re, spectrum_im) = rfft(signal, 0, None);
+        let reconstructed = irfft(spectrum_re.clone(), spectrum_im.clone(), 0, None);
+
+        spectrum_re.into_data().assert_approx_eq::<f32>(
+            &TensorData::from([4.0, 0.0, 0.0]),
+            Tolerance::absolute(1e-4),
+        );
+        spectrum_im.into_data().assert_approx_eq::<f32>(
+            &TensorData::from([0.0, 0.0, 0.0]),
+            Tolerance::absolute(1e-4),
+        );
+        reconstructed.into_data().assert_approx_eq::<f32>(
+            &TensorData::from([1.0, 1.0, 1.0, 1.0]),
+            Tolerance::absolute(1e-4),
+        );
 
         rt.shutdown_background();
     }

--- a/crates/burn-router/src/ops/module.rs
+++ b/crates/burn-router/src/ops/module.rs
@@ -1106,19 +1106,33 @@ impl<R: RouterChannel> ModuleOps<Self> for BackendRouter<R> {
     }
 
     fn rfft(
-        _signal: FloatTensor<Self>,
-        _dim: usize,
-        _n: Option<usize>,
+        signal: FloatTensor<Self>,
+        dim: usize,
+        n: Option<usize>,
     ) -> (FloatTensor<Self>, FloatTensor<Self>) {
-        todo!("rfft is not supported for backend-router")
+        let client = signal.client.clone();
+        let desc = RfftOpIr::create(signal.into_ir(), dim, n, || client.create_empty_handle());
+
+        let [out_re, out_im] = client
+            .register(OperationIr::Module(ModuleOperationIr::Rfft(desc)))
+            .outputs();
+
+        (out_re, out_im)
     }
 
     fn irfft(
-        _spectrum_re: FloatTensor<Self>,
-        _spectrum_im: FloatTensor<Self>,
-        _dim: usize,
-        _n: Option<usize>,
+        spectrum_re: FloatTensor<Self>,
+        spectrum_im: FloatTensor<Self>,
+        dim: usize,
+        n: Option<usize>,
     ) -> FloatTensor<Self> {
-        todo!("irfft is not supported for backend-router")
+        let client = spectrum_re.client.clone();
+        let desc = IRfftOpIr::create(spectrum_re.into_ir(), spectrum_im.into_ir(), dim, n, || {
+            client.create_empty_handle()
+        });
+
+        client
+            .register(OperationIr::Module(ModuleOperationIr::IRfft(desc)))
+            .output()
     }
 }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that cargo run-checks has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

None.

### Changes

BackendRouter currently panics when rfft or irfft is called even though the corresponding IR operations and server-side execution already exist.

This change registers both operations through the router and returns their output tensors. It also adds an end-to-end WebSocket regression test that verifies the RFFT spectrum and IRFFT reconstruction over RemoteBackend.

### Testing

- cargo run-checks
- cargo test -p burn-router
- cargo test -p burn-remote test_fft_over_websocket -- --nocapture