### PR TITLE
Fix ROUGE-L final value panic

### DIFF
--- a/crates/burn-train/src/metric/rouge.rs
+++ b/crates/burn-train/src/metric/rouge.rs
@@ -25,6 +25,8 @@ fn lcs_length(a: &[i32], b: &[i32]) -> usize {
 }
 
 /// ROUGE-L metric based on longest common subsequence.
+///
+/// Reports the macro average of the per-sequence ROUGE-L F1 scores.
 #[derive(Clone)]
 pub struct RougeLScore {
     name: MetricName,

--- a/crates/burn-train/src/metric/rouge.rs
+++ b/crates/burn-train/src/metric/rouge.rs
@@ -162,7 +162,6 @@ impl Metric for RougeLScore {
     }
 }
 
-// TODO: can be computed per batch, but epoch-level value should be aggregated properly (not just mean of each batch)
 impl Numeric for RougeLScore {
     fn value(&self) -> Option<NumericEntry> {
         Some(self.state.current_value())
@@ -173,7 +172,7 @@ impl Numeric for RougeLScore {
     }
 
     fn final_value(&self) -> NumericEntry {
-        todo!()
+        self.state.final_value()
     }
 }
 
@@ -261,6 +260,30 @@ mod tests {
     }
 
     #[test]
+    fn test_rouge_l_final_value_with_unequal_batch_sizes() {
+        let device = Default::default();
+        let mut metric = RougeLScore::new();
+
+        metric.update(
+            &RougeLInput::new(
+                Tensor::from_data([[1, 2]], &device),
+                Tensor::from_data([[1, 2]], &device),
+            ),
+            &MetricMetadata::fake(),
+        );
+        metric.update(
+            &RougeLInput::new(
+                Tensor::from_data([[3, 4], [5, 6], [7, 8]], &device),
+                Tensor::from_data([[3, 4], [9, 10], [11, 12]], &device),
+            ),
+            &MetricMetadata::fake(),
+        );
+
+        // Two perfect matches and two non-matches across all four samples.
+        assert!((metric.final_value().current() - 50.0).abs() < 1e-6);
+    }
+
+    #[test]
     fn test_rouge_l_both_empty() {
         let device = Default::default();
         let mut metric = RougeLScore::new();
@@ -285,5 +308,6 @@ mod tests {
 
         metric.clear();
         assert!(metric.value().unwrap().current().is_nan());
+        assert!(metric.final_value().current().is_nan());
     }
 }


### PR DESCRIPTION
## Checklist

- [x] Confirmed that `cargo run-checks` has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Fixes #5516.

### Changes

- Return the final `NumericMetricState` entry from `RougeLScore::final_value` instead of panicking with `todo!()`.
- Remove the stale aggregation TODO. Each batch value is the mean of per-sequence ROUGE-L F1 scores, and `NumericMetricState` weights it by batch size, producing the dataset-wide macro average.
- Add regression coverage for final values across unequal batch sizes and after clearing state.

### Testing

- `cargo run-checks`
- `cargo test -p burn-train metric::rouge::tests --lib`
- `cargo test -p burn-train --lib`