### PR TITLE
test(cubecl): rename indexing tests to reflect observable behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -172,7 +172,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1772,7 +1772,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3250,7 +3250,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3606,7 +3606,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4119,8 +4119,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -4363,7 +4363,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.19",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -4421,10 +4421,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
@@ -4763,7 +4759,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -6411,7 +6407,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7205,7 +7201,7 @@ dependencies = [
  "combine",
  "downcast-rs",
  "dyn-clone",
- "hashbrown 0.14.5",
+ "hashbrown 0.13.2",
  "hi_sparse_bitset",
  "indexmap",
  "inventory",
@@ -7218,7 +7214,7 @@ dependencies = [
  "rustc_apfloat",
  "slotmap",
  "smallvec",
- "spin 0.11.1",
+ "spin 0.10.1",
  "thiserror 2.0.19",
  "utf8-chars",
 ]
@@ -8231,7 +8227,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8968,7 +8964,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9026,7 +9022,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9178,7 +9174,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9554,7 +9550,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9590,6 +9586,9 @@ name = "spin"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spin"
@@ -9698,7 +9697,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9979,7 +9978,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10001,7 +10000,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook 0.3.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10011,7 +10010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11493,7 +11492,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11969,8 +11968,8 @@ dependencies = [
  "log",
  "serde",
  "thiserror 2.0.19",
- "windows 0.61.3",
- "windows-core 0.61.2",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]

--- a/crates/burn-backend-tests/tests/cubecl/scatter.rs
+++ b/crates/burn-backend-tests/tests/cubecl/scatter.rs
@@ -3,46 +3,46 @@ use burn_tensor::Distribution;
 use burn_tensor::{Device, IndexingUpdateOp, Tolerance};
 
 #[test]
-fn scatter_should_work_with_multiple_workgroups_2d_dim0() {
-    same_as_reference_same_shape(0, [256, 32]);
+fn scatter_add_should_match_reference_2d_dim0() {
+    scatter_add_matches_reference_same_shape(0, [256, 32]);
 }
 
 #[test]
-fn scatter_should_work_with_multiple_workgroups_2d_dim1() {
-    same_as_reference_same_shape(1, [32, 256]);
+fn scatter_add_should_match_reference_2d_dim1() {
+    scatter_add_matches_reference_same_shape(1, [32, 256]);
 }
 
 #[test]
-fn scatter_should_work_with_multiple_workgroups_3d_dim0() {
-    same_as_reference_same_shape(0, [256, 6, 6]);
+fn scatter_add_should_match_reference_3d_dim0() {
+    scatter_add_matches_reference_same_shape(0, [256, 6, 6]);
 }
 
 #[test]
-fn scatter_should_work_with_multiple_workgroups_3d_dim1() {
-    same_as_reference_same_shape(1, [6, 256, 6]);
+fn scatter_add_should_match_reference_3d_dim1() {
+    scatter_add_matches_reference_same_shape(1, [6, 256, 6]);
 }
 
 #[test]
-fn scatter_should_work_with_multiple_workgroups_3d_dim2() {
-    same_as_reference_same_shape(2, [6, 6, 256]);
+fn scatter_add_should_match_reference_3d_dim2() {
+    scatter_add_matches_reference_same_shape(2, [6, 6, 256]);
 }
 
 #[test]
-fn scatter_should_work_with_multiple_workgroups_diff_shapes() {
-    same_as_reference_diff_shape(1, [32, 128], [32, 1]);
+fn scatter_add_should_match_reference_with_different_shapes() {
+    scatter_add_matches_reference(1, [32, 128], [32, 1]);
 }
 
 #[test]
-fn scatter_mul_should_work_with_multiple_workgroups_2d_dim0() {
-    mul_same_as_reference(0, [256, 32]);
+fn scatter_mul_should_match_reference_2d_dim0() {
+    scatter_mul_matches_reference(0, [256, 32]);
 }
 
 #[test]
-fn scatter_mul_should_work_with_multiple_workgroups_2d_dim1() {
-    mul_same_as_reference(1, [32, 256]);
+fn scatter_mul_should_match_reference_2d_dim1() {
+    scatter_mul_matches_reference(1, [32, 256]);
 }
 
-fn same_as_reference_diff_shape<const D: usize>(
+fn scatter_add_matches_reference<const D: usize>(
     dim: usize,
     shape1: [usize; D],
     shape2: [usize; D],
@@ -73,11 +73,11 @@ fn same_as_reference_diff_shape<const D: usize>(
         .assert_approx_eq::<FloatElem>(&actual.into_data(), Tolerance::default());
 }
 
-fn same_as_reference_same_shape<const D: usize>(dim: usize, shape: [usize; D]) {
-    same_as_reference_diff_shape(dim, shape, shape);
+fn scatter_add_matches_reference_same_shape<const D: usize>(dim: usize, shape: [usize; D]) {
+    scatter_add_matches_reference(dim, shape, shape);
 }
 
-fn mul_same_as_reference<const D: usize>(dim: usize, shape: [usize; D]) {
+fn scatter_mul_matches_reference<const D: usize>(dim: usize, shape: [usize; D]) {
     let device = Device::default();
     let ref_device = ReferenceDevice::new();
 

--- a/crates/burn-backend-tests/tests/cubecl/select_assign.rs
+++ b/crates/burn-backend-tests/tests/cubecl/select_assign.rs
@@ -3,41 +3,41 @@ use burn_tensor::Distribution;
 use burn_tensor::{Device, IndexingUpdateOp, Tolerance};
 
 #[test]
-fn select_add_should_work_with_multiple_workgroups_2d_dim0() {
-    select_add_same_as_ref(0, [256, 6]);
+fn select_add_should_match_reference_2d_dim0() {
+    select_add_matches_reference(0, [256, 6]);
 }
 
 #[test]
-fn select_add_should_work_with_multiple_workgroups_2d_dim1() {
-    select_add_same_as_ref(1, [6, 256]);
+fn select_add_should_match_reference_2d_dim1() {
+    select_add_matches_reference(1, [6, 256]);
 }
 
 #[test]
-fn select_add_should_work_with_multiple_workgroups_3d_dim0() {
-    select_add_same_as_ref(0, [256, 6, 6]);
+fn select_add_should_match_reference_3d_dim0() {
+    select_add_matches_reference(0, [256, 6, 6]);
 }
 
 #[test]
-fn select_add_should_work_with_multiple_workgroups_3d_dim1() {
-    select_add_same_as_ref(1, [6, 256, 6]);
+fn select_add_should_match_reference_3d_dim1() {
+    select_add_matches_reference(1, [6, 256, 6]);
 }
 
 #[test]
-fn select_add_should_work_with_multiple_workgroups_3d_dim2() {
-    select_add_same_as_ref(2, [6, 6, 256]);
+fn select_add_should_match_reference_3d_dim2() {
+    select_add_matches_reference(2, [6, 6, 256]);
 }
 
 #[test]
-fn select_mul_should_work_with_multiple_workgroups_2d_dim0() {
-    select_mul_same_as_ref(0, [256, 6]);
+fn select_mul_should_match_reference_2d_dim0() {
+    select_mul_matches_reference(0, [256, 6]);
 }
 
 #[test]
-fn select_mul_should_work_with_multiple_workgroups_2d_dim1() {
-    select_mul_same_as_ref(1, [6, 256]);
+fn select_mul_should_match_reference_2d_dim1() {
+    select_mul_matches_reference(1, [6, 256]);
 }
 
-fn select_add_same_as_ref<const D: usize>(dim: usize, shape: [usize; D]) {
+fn select_add_matches_reference<const D: usize>(dim: usize, shape: [usize; D]) {
     let device = Device::default();
     let ref_device = ReferenceDevice::new();
 
@@ -62,7 +62,7 @@ fn select_add_same_as_ref<const D: usize>(dim: usize, shape: [usize; D]) {
         .assert_approx_eq::<FloatElem>(&actual.into_data(), Tolerance::default());
 }
 
-fn select_mul_same_as_ref<const D: usize>(dim: usize, shape: [usize; D]) {
+fn select_mul_matches_reference<const D: usize>(dim: usize, shape: [usize; D]) {
     let device = Device::default();
     let ref_device = ReferenceDevice::new();
 


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

> `cargo run-checks` tests with `Flex` by default. Use `cargo run-checks --backend <backend>` when
> targeting another backend. Consider running additional tests relevant to the crates changed.

### Related Issues/PRs

Noticed the naming was inconsistent when reviewing #5512

### Changes

Renamed cubecl indexing tests around observable behavior.

The test names predate CubeCL :sweat_smile: they were added way back when we only had the wgpu backend with 
WGSL shaders, hence the "workgroups" naming. The strategy for these kernels has shifted greatly since.

/edit: also fixed the windows deps in the Cargo.lock