### PR TITLE
refactor(backend): remove specialized indexing add operations

### DIFF
--- a/crates/burn-autodiff/src/ops/int_tensor.rs
+++ b/crates/burn-autodiff/src/ops/int_tensor.rs
@@ -214,15 +214,6 @@ impl<B: Backend, C: CheckpointStrategy> IntTensorOps<Self> for Autodiff<B, C> {
         B::int_gather(dim, tensor, indices)
     }
 
-    fn int_scatter_add(
-        dim: usize,
-        tensor: IntTensor<B>,
-        indices: IntTensor<B>,
-        value: IntTensor<B>,
-    ) -> IntTensor<B> {
-        B::int_scatter_add(dim, tensor, indices, value)
-    }
-
     fn int_scatter(
         dim: usize,
         tensor: IntTensor<B>,
@@ -244,15 +235,6 @@ impl<B: Backend, C: CheckpointStrategy> IntTensorOps<Self> for Autodiff<B, C> {
 
     fn int_select(tensor: IntTensor<B>, dim: usize, indices: IntTensor<B>) -> IntTensor<B> {
         B::int_select(tensor, dim, indices)
-    }
-
-    fn int_select_add(
-        tensor: IntTensor<B>,
-        dim: usize,
-        indices: IntTensor<B>,
-        value: IntTensor<B>,
-    ) -> IntTensor<B> {
-        B::int_select_add(tensor, dim, indices, value)
     }
 
     fn int_select_assign(

--- a/crates/burn-autodiff/src/ops/maxmin.rs
+++ b/crates/burn-autodiff/src/ops/maxmin.rs
@@ -1,7 +1,7 @@
 use super::{Backward, Ops, unary};
 use crate::{checkpoint::base::Checkpointer, grads::Gradients};
 use burn_backend::{Backend, TensorMetadata};
-use burn_std::Shape;
+use burn_std::{IndexingUpdateOp, Shape};
 
 #[derive(Debug)]
 pub(crate) struct MaxMinDim;
@@ -21,7 +21,7 @@ impl<B: Backend> Backward<B, 1> for MaxMinDim {
             let dtype = grad.dtype();
             let zeros = B::float_zeros(shape, &device, dtype.into());
 
-            B::float_scatter_add(dim, zeros, indices, grad)
+            B::float_scatter(dim, zeros, indices, grad, IndexingUpdateOp::Add)
         });
     }
 }

--- a/crates/burn-autodiff/src/ops/sort.rs
+++ b/crates/burn-autodiff/src/ops/sort.rs
@@ -1,7 +1,7 @@
 use super::{Backward, Ops, unary};
 use crate::{checkpoint::base::Checkpointer, grads::Gradients};
 use burn_backend::{Backend, TensorMetadata};
-use burn_std::Shape;
+use burn_std::{IndexingUpdateOp, Shape};
 
 #[derive(Debug)]
 pub(crate) struct SortDim;
@@ -21,7 +21,7 @@ impl<B: Backend> Backward<B, 1> for SortDim {
             let dtype = grad.dtype();
             let zeros = B::float_zeros(shape, &device, dtype.into());
 
-            B::float_scatter_add(dim, zeros, indices, grad)
+            B::float_scatter(dim, zeros, indices, grad, IndexingUpdateOp::Add)
         });
     }
 }

--- a/crates/burn-autodiff/src/ops/tensor.rs
+++ b/crates/burn-autodiff/src/ops/tensor.rs
@@ -975,7 +975,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
 
                 unary::<B, _>(ops.parents, ops.node, grads, |grad| {
                     let zeros = B::float_zeros(shape, &device, grad.dtype().into());
-                    B::float_scatter_add(dim, zeros, indices, grad)
+                    B::float_scatter(dim, zeros, indices, grad, IndexingUpdateOp::Add)
                 });
             }
         }
@@ -1000,55 +1000,6 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
         }
     }
 
-    fn float_scatter_add(
-        dim: usize,
-        tensor: FloatTensor<Self>,
-        indices: IntTensor<B>,
-        value: FloatTensor<Self>,
-    ) -> FloatTensor<Self> {
-        #[derive(Debug)]
-        struct Scatter;
-
-        impl<B: Backend> Backward<B, 2> for Scatter {
-            type State = (usize, IntTensor<B>);
-
-            fn backward(
-                self,
-                ops: Ops<Self::State, 2>,
-                grads: &mut Gradients,
-                _checkpointer: &mut Checkpointer,
-            ) {
-                let (dim, indices) = ops.state;
-                let [_, indices_4rhs] = duplicate(&ops.parents, Some(indices));
-
-                binary::<B, _, _>(
-                    ops.parents,
-                    ops.node,
-                    grads,
-                    |grad| grad,
-                    |grad| B::float_gather(dim, grad, indices_4rhs.unwrap()),
-                );
-            }
-        }
-
-        match Scatter
-            .prepare::<C>([tensor.node, value.node])
-            .compute_bound()
-            .stateful()
-        {
-            OpsKind::Tracked(prep) => prep.finish(
-                (dim, indices.clone()),
-                B::float_scatter_add(dim, tensor.primitive, indices, value.primitive),
-            ),
-            OpsKind::UnTracked(prep) => prep.finish(B::float_scatter_add(
-                dim,
-                tensor.primitive,
-                indices,
-                value.primitive,
-            )),
-        }
-    }
-
     fn float_scatter(
         dim: usize,
         tensor: FloatTensor<Self>,
@@ -1057,7 +1008,56 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
         update: IndexingUpdateOp,
     ) -> FloatTensor<Self> {
         match update {
-            IndexingUpdateOp::Add => Self::float_scatter_add(dim, tensor, indices, value),
+            IndexingUpdateOp::Add => {
+                #[derive(Debug)]
+                struct Scatter;
+
+                impl<B: Backend> Backward<B, 2> for Scatter {
+                    type State = (usize, IntTensor<B>);
+
+                    fn backward(
+                        self,
+                        ops: Ops<Self::State, 2>,
+                        grads: &mut Gradients,
+                        _checkpointer: &mut Checkpointer,
+                    ) {
+                        let (dim, indices) = ops.state;
+                        let [_, indices_4rhs] = duplicate(&ops.parents, Some(indices));
+
+                        binary::<B, _, _>(
+                            ops.parents,
+                            ops.node,
+                            grads,
+                            |grad| grad,
+                            |grad| B::float_gather(dim, grad, indices_4rhs.unwrap()),
+                        );
+                    }
+                }
+
+                match Scatter
+                    .prepare::<C>([tensor.node, value.node])
+                    .compute_bound()
+                    .stateful()
+                {
+                    OpsKind::Tracked(prep) => prep.finish(
+                        (dim, indices.clone()),
+                        B::float_scatter(
+                            dim,
+                            tensor.primitive,
+                            indices,
+                            value.primitive,
+                            IndexingUpdateOp::Add,
+                        ),
+                    ),
+                    OpsKind::UnTracked(prep) => prep.finish(B::float_scatter(
+                        dim,
+                        tensor.primitive,
+                        indices,
+                        value.primitive,
+                        IndexingUpdateOp::Add,
+                    )),
+                }
+            }
             IndexingUpdateOp::Assign => {
                 #[derive(Debug)]
                 struct ScatterAssign;
@@ -1586,7 +1586,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
 
                 unary::<B, _>(ops.parents, ops.node, grads, |grad| {
                     let zeros = B::float_zeros(shape, &device, grad.dtype().into());
-                    B::float_select_add(zeros, dim, indices, grad)
+                    B::float_select_assign(zeros, dim, indices, grad, IndexingUpdateOp::Add)
                 });
             }
         }
@@ -1613,78 +1613,6 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
         }
     }
 
-    fn float_select_add(
-        tensor: FloatTensor<Self>,
-        dim: usize,
-        indices: IntTensor<B>,
-        value: FloatTensor<Self>,
-    ) -> FloatTensor<Self> {
-        #[derive(Debug)]
-        struct IndexSelectDimAssign;
-
-        #[derive(new, Debug)]
-        struct RetroSelectAssign<B: Backend> {
-            tensor_id: NodeId,
-            dim: usize,
-            indices: IntTensor<B>,
-            value_id: NodeId,
-        }
-
-        impl<B: Backend> RetroForward for RetroSelectAssign<B> {
-            fn forward(&self, states: &mut BackwardStates, out_node: NodeId) {
-                let tensor = states.get_state::<B::FloatTensorPrimitive>(&self.tensor_id);
-                let value = states.get_state::<B::FloatTensorPrimitive>(&self.value_id);
-                let out = B::float_select_add(tensor, self.dim, self.indices.clone(), value);
-                states.save(out_node, out)
-            }
-        }
-
-        impl<B: Backend> Backward<B, 2> for IndexSelectDimAssign {
-            type State = (usize, IntTensor<B>);
-
-            fn backward(
-                self,
-                ops: Ops<Self::State, 2>,
-                grads: &mut Gradients,
-                _checkpointer: &mut Checkpointer,
-            ) {
-                let (dim, indices) = ops.state;
-
-                binary::<B, _, _>(
-                    ops.parents,
-                    ops.node,
-                    grads,
-                    |grad| grad,
-                    |grad| B::float_select(grad, dim, indices),
-                );
-            }
-        }
-
-        match IndexSelectDimAssign
-            .prepare::<C>([tensor.node.clone(), value.node.clone()])
-            .memory_bound()
-            .retro_forward(RetroSelectAssign::<B>::new(
-                tensor.node.id,
-                dim,
-                indices.clone(),
-                value.node.id,
-            ))
-            .parents([&tensor, &value])
-            .stateful()
-        {
-            OpsKind::Tracked(prep) => prep.finish(
-                (dim, indices.clone()),
-                B::float_select_add(tensor.primitive, dim, indices, value.primitive),
-            ),
-            OpsKind::UnTracked(prep) => prep.finish(B::float_select_add(
-                tensor.primitive,
-                dim,
-                indices,
-                value.primitive,
-            )),
-        }
-    }
-
     fn float_select_assign(
         tensor: FloatTensor<Self>,
         dim: usize,
@@ -1693,7 +1621,85 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
         update: IndexingUpdateOp,
     ) -> FloatTensor<Self> {
         match update {
-            IndexingUpdateOp::Add => Self::float_select_add(tensor, dim, indices, value),
+            IndexingUpdateOp::Add => {
+                #[derive(Debug)]
+                struct IndexSelectDimAssign;
+
+                #[derive(new, Debug)]
+                struct RetroSelectAssign<B: Backend> {
+                    tensor_id: NodeId,
+                    dim: usize,
+                    indices: IntTensor<B>,
+                    value_id: NodeId,
+                }
+
+                impl<B: Backend> RetroForward for RetroSelectAssign<B> {
+                    fn forward(&self, states: &mut BackwardStates, out_node: NodeId) {
+                        let tensor = states.get_state::<B::FloatTensorPrimitive>(&self.tensor_id);
+                        let value = states.get_state::<B::FloatTensorPrimitive>(&self.value_id);
+                        let out = B::float_select_assign(
+                            tensor,
+                            self.dim,
+                            self.indices.clone(),
+                            value,
+                            IndexingUpdateOp::Add,
+                        );
+                        states.save(out_node, out)
+                    }
+                }
+
+                impl<B: Backend> Backward<B, 2> for IndexSelectDimAssign {
+                    type State = (usize, IntTensor<B>);
+
+                    fn backward(
+                        self,
+                        ops: Ops<Self::State, 2>,
+                        grads: &mut Gradients,
+                        _checkpointer: &mut Checkpointer,
+                    ) {
+                        let (dim, indices) = ops.state;
+
+                        binary::<B, _, _>(
+                            ops.parents,
+                            ops.node,
+                            grads,
+                            |grad| grad,
+                            |grad| B::float_select(grad, dim, indices),
+                        );
+                    }
+                }
+
+                match IndexSelectDimAssign
+                    .prepare::<C>([tensor.node.clone(), value.node.clone()])
+                    .memory_bound()
+                    .retro_forward(RetroSelectAssign::<B>::new(
+                        tensor.node.id,
+                        dim,
+                        indices.clone(),
+                        value.node.id,
+                    ))
+                    .parents([&tensor, &value])
+                    .stateful()
+                {
+                    OpsKind::Tracked(prep) => prep.finish(
+                        (dim, indices.clone()),
+                        B::float_select_assign(
+                            tensor.primitive,
+                            dim,
+                            indices,
+                            value.primitive,
+                            IndexingUpdateOp::Add,
+                        ),
+                    ),
+                    OpsKind::UnTracked(prep) => prep.finish(B::float_select_assign(
+                        tensor.primitive,
+                        dim,
+                        indices,
+                        value.primitive,
+                        IndexingUpdateOp::Add,
+                    )),
+                }
+            }
             IndexingUpdateOp::Assign => {
                 #[derive(Debug)]
                 struct IndexSelectDimAssignReplace;
@@ -2671,7 +2677,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
 
                     // Scatter gradients to source positions (sum reduction)
                     let zeros = B::float_zeros(shape, &device, grad.dtype().into());
-                    B::float_scatter_add(dim, zeros, source_indices, grad)
+                    B::float_scatter(dim, zeros, source_indices, grad, IndexingUpdateOp::Add)
                 });
             }
         }
@@ -2738,7 +2744,7 @@ impl<B: Backend, C: CheckpointStrategy> FloatTensorOps<Self> for Autodiff<B, C> 
 
                     // Scatter gradients to source positions (sum reduction)
                     let zeros = B::float_zeros(shape, &device, grad.dtype().into());
-                    B::float_scatter_add(dim, zeros, source_indices, grad)
+                    B::float_scatter(dim, zeros, source_indices, grad, IndexingUpdateOp::Add)
                 });
             }
         }

--- a/crates/burn-backend/src/backend/ops/int_tensor.rs
+++ b/crates/burn-backend/src/backend/ops/int_tensor.rs
@@ -190,40 +190,14 @@ pub trait IntTensorOps<B: Backend> {
     /// * `indices` - The indices.
     fn int_gather(dim: usize, tensor: IntTensor<B>, indices: IntTensor<B>) -> IntTensor<B>;
 
-    /// Scatter a given value to the tensor at the given indices using sum reduction.
-    ///
-    /// # Arguments
-    ///
-    /// * `dim` - The dimension to scatter to.
-    /// * `tensor` - The tensor.
-    /// * `indices` - The indices.
-    /// * `value` - The value.
-    ///
-    /// # Returns
-    ///
-    /// The tensor with the values scattered.
-    fn int_scatter_add(
-        dim: usize,
-        tensor: IntTensor<B>,
-        indices: IntTensor<B>,
-        value: IntTensor<B>,
-    ) -> IntTensor<B>;
-
     /// Scatter elements into a tensor using the specified update operation.
-    ///
-    /// Backend implementations may override this to support operations beyond add.
     fn int_scatter(
         dim: usize,
         tensor: IntTensor<B>,
         indices: IntTensor<B>,
         value: IntTensor<B>,
         update: IndexingUpdateOp,
-    ) -> IntTensor<B> {
-        match update {
-            IndexingUpdateOp::Add => Self::int_scatter_add(dim, tensor, indices, value),
-            other => unimplemented!("int_scatter with {other:?} update is not implemented"),
-        }
-    }
+    ) -> IntTensor<B>;
 
     /// Multi-dimensional scatter for int tensors.
     fn int_scatter_nd(
@@ -253,41 +227,14 @@ pub trait IntTensorOps<B: Backend> {
     /// The tensor with the selected elements.
     fn int_select(tensor: IntTensor<B>, dim: usize, indices: IntTensor<B>) -> IntTensor<B>;
 
-    /// Assign the selected elements along the given dimension corresponding to the given indices
-    /// to the given value using sum reduction.
-    ///
-    /// # Arguments
-    ///
-    /// * `tensor` - The tensor.
-    /// * `dim` - The dimension to select from.
-    /// * `indices` - The indices.
-    /// * `value` - The value.
-    ///
-    /// # Returns
-    ///
-    /// The tensor with the selected elements assigned to the given value.
-    fn int_select_add(
-        tensor: IntTensor<B>,
-        dim: usize,
-        indices: IntTensor<B>,
-        value: IntTensor<B>,
-    ) -> IntTensor<B>;
-
     /// Assign selected elements along a dimension using the specified update operation.
-    ///
-    /// Backend implementations may override this to support operations beyond add.
     fn int_select_assign(
         tensor: IntTensor<B>,
         dim: usize,
         indices: IntTensor<B>,
         value: IntTensor<B>,
         update: IndexingUpdateOp,
-    ) -> IntTensor<B> {
-        match update {
-            IndexingUpdateOp::Add => Self::int_select_add(tensor, dim, indices, value),
-            other => unimplemented!("int_select_assign with {other:?} update is not implemented"),
-        }
-    }
+    ) -> IntTensor<B>;
 
     /// Repeats the tensor along the given dimension the given number of times.
     ///

--- a/crates/burn-backend/src/backend/ops/modules/base.rs
+++ b/crates/burn-backend/src/backend/ops/modules/base.rs
@@ -7,7 +7,7 @@ pub use burn_std::ops::{
     GridSampleOptions, GridSamplePaddingMode, InterpolateMode, InterpolateOptions, PadMode,
     PaddedConvOptions, UnfoldOptions,
 };
-use burn_std::{IntDType, Shape};
+use burn_std::{IndexingUpdateOp, IntDType, Shape};
 
 /// Gradient computed during the backward pass for each tensor used by [conv2d](ModuleOps::conv2d).
 #[derive(new)]
@@ -173,7 +173,7 @@ pub trait ModuleOps<B: Backend> {
             B::float_reshape(output_grad, Shape::new([batch_size * seq_length, d_model]));
         let grad = B::float_zeros(Shape::new([n_embeddings, d_model]), &device, dtype.into());
 
-        B::float_select_add(grad, 0, indices, output_grad)
+        B::float_select_assign(grad, 0, indices, output_grad, IndexingUpdateOp::Add)
     }
 
     /// Linear transformation.

--- a/crates/burn-backend/src/backend/ops/modules/ctc.rs
+++ b/crates/burn-backend/src/backend/ops/modules/ctc.rs
@@ -1,4 +1,4 @@
-use burn_std::{Shape, Slice};
+use burn_std::{IndexingUpdateOp, Shape, Slice};
 
 use crate::{
     Backend, TensorMetadata, get_device_settings,
@@ -137,7 +137,7 @@ pub fn ctc_grad_from_alpha_beta_default<B: Backend>(
     );
     let scatter_value = B::float_neg(B::float_mul(B::float_exp(log_post), grad_loss_post));
 
-    grad = B::float_scatter_add(2, grad, indices_3d, scatter_value);
+    grad = B::float_scatter(2, grad, indices_3d, scatter_value, IndexingUpdateOp::Add);
 
     // Mask out timesteps where t >= input_lengths[n].
     let t_indices = B::int_arange(0..max_input_length as i64, &device, int_dtype);

--- a/crates/burn-backend/src/backend/ops/tensor.rs
+++ b/crates/burn-backend/src/backend/ops/tensor.rs
@@ -434,40 +434,14 @@ pub trait FloatTensorOps<B: Backend> {
     /// The gathered elements.
     fn float_gather(dim: usize, tensor: FloatTensor<B>, indices: IntTensor<B>) -> FloatTensor<B>;
 
-    /// Scatter elements into a tensor using sum reduction.
-    ///
-    /// # Arguments
-    ///
-    /// * `dim` - The dimension to scatter into.
-    /// * `tensor` - The tensor to scatter into.
-    /// * `indices` - The indices to scatter into.
-    /// * `value` - The value to scatter.
-    ///
-    /// # Returns
-    ///
-    /// The tensor with the scattered elements.
-    fn float_scatter_add(
-        dim: usize,
-        tensor: FloatTensor<B>,
-        indices: IntTensor<B>,
-        value: FloatTensor<B>,
-    ) -> FloatTensor<B>;
-
     /// Scatter elements into a tensor using the specified update operation.
-    ///
-    /// Backend implementations may override this to support operations beyond add.
     fn float_scatter(
         dim: usize,
         tensor: FloatTensor<B>,
         indices: IntTensor<B>,
         value: FloatTensor<B>,
         update: IndexingUpdateOp,
-    ) -> FloatTensor<B> {
-        match update {
-            IndexingUpdateOp::Add => Self::float_scatter_add(dim, tensor, indices, value),
-            other => unimplemented!("float_scatter with {other:?} update is not implemented"),
-        }
-    }
+    ) -> FloatTensor<B>;
 
     /// Multi-dimensional scatter: update `data` at locations specified by `indices` with `values`.
     ///
@@ -517,43 +491,14 @@ pub trait FloatTensorOps<B: Backend> {
     /// The selected elements.
     fn float_select(tensor: FloatTensor<B>, dim: usize, indices: IntTensor<B>) -> FloatTensor<B>;
 
-    /// Assign the selected elements along the given dimension corresponding for the given indices
-    /// to the given value using sum reduction.
-    ///
-    /// # Arguments
-    ///
-    /// * `tensor` - The tensor to select from.
-    /// * `dim` - The dimension to select from.
-    /// * `indices` - The indices to select.
-    /// * `value` - The value to assign.
-    ///
-    /// # Returns
-    ///
-    /// The tensor with the selected elements assigned to the given value.
-    fn float_select_add(
-        tensor: FloatTensor<B>,
-        dim: usize,
-        indices: IntTensor<B>,
-        value: FloatTensor<B>,
-    ) -> FloatTensor<B>;
-
     /// Assign selected elements along a dimension using the specified update operation.
-    ///
-    /// Backend implementations may override this to support operations beyond add.
     fn float_select_assign(
         tensor: FloatTensor<B>,
         dim: usize,
         indices: IntTensor<B>,
         value: FloatTensor<B>,
         update: IndexingUpdateOp,
-    ) -> FloatTensor<B> {
-        match update {
-            IndexingUpdateOp::Add => Self::float_select_add(tensor, dim, indices, value),
-            other => {
-                unimplemented!("float_select_assign with {other:?} update is not implemented")
-            }
-        }
-    }
+    ) -> FloatTensor<B>;
 
     /// Select tensor elements corresponding to the given slices.
     ///

--- a/crates/burn-cubecl/src/ops/int_tensor.rs
+++ b/crates/burn-cubecl/src/ops/int_tensor.rs
@@ -120,15 +120,6 @@ impl<R: CubeRuntime> IntTensorOps<Self> for CubeBackend<R> {
         kernel::gather(dim, tensor, indices)
     }
 
-    fn int_scatter_add(
-        dim: usize,
-        tensor: IntTensor<Self>,
-        indices: IntTensor<Self>,
-        value: IntTensor<Self>,
-    ) -> IntTensor<Self> {
-        kernel::scatter(dim, tensor, indices, value, false)
-    }
-
     fn int_scatter(
         dim: usize,
         tensor: IntTensor<Self>,
@@ -138,7 +129,7 @@ impl<R: CubeRuntime> IntTensorOps<Self> for CubeBackend<R> {
     ) -> IntTensor<Self> {
         match update {
             burn_backend::tensor::IndexingUpdateOp::Add => {
-                Self::int_scatter_add(dim, tensor, indices, value)
+                kernel::scatter(dim, tensor, indices, value, false)
             }
             burn_backend::tensor::IndexingUpdateOp::Mul => {
                 kernel::scatter_mul(dim, tensor, indices, value)
@@ -168,15 +159,6 @@ impl<R: CubeRuntime> IntTensorOps<Self> for CubeBackend<R> {
         kernel::select(tensor, dim, indices)
     }
 
-    fn int_select_add(
-        tensor: IntTensor<Self>,
-        dim: usize,
-        indices: IntTensor<Self>,
-        value: IntTensor<Self>,
-    ) -> IntTensor<Self> {
-        kernel::select_assign(tensor, dim, indices, value, false)
-    }
-
     fn int_select_assign(
         tensor: IntTensor<Self>,
         dim: usize,
@@ -186,7 +168,7 @@ impl<R: CubeRuntime> IntTensorOps<Self> for CubeBackend<R> {
     ) -> IntTensor<Self> {
         match update {
             burn_backend::tensor::IndexingUpdateOp::Add => {
-                Self::int_select_add(tensor, dim, indices, value)
+                kernel::select_assign(tensor, dim, indices, value, false)
             }
             burn_backend::tensor::IndexingUpdateOp::Mul => {
                 kernel::select_assign_mul(tensor, dim, indices, value)

--- a/crates/burn-cubecl/src/ops/tensor.rs
+++ b/crates/burn-cubecl/src/ops/tensor.rs
@@ -177,15 +177,6 @@ where
         kernel::gather(dim, tensor, indices)
     }
 
-    fn float_scatter_add(
-        dim: usize,
-        tensor: FloatTensor<Self>,
-        indices: IntTensor<Self>,
-        value: FloatTensor<Self>,
-    ) -> FloatTensor<Self> {
-        kernel::scatter(dim, tensor, indices, value, false)
-    }
-
     fn float_scatter(
         dim: usize,
         tensor: FloatTensor<Self>,
@@ -195,7 +186,7 @@ where
     ) -> FloatTensor<Self> {
         match update {
             burn_backend::tensor::IndexingUpdateOp::Add => {
-                Self::float_scatter_add(dim, tensor, indices, value)
+                kernel::scatter(dim, tensor, indices, value, false)
             }
             burn_backend::tensor::IndexingUpdateOp::Mul => {
                 kernel::scatter_mul(dim, tensor, indices, value)
@@ -225,15 +216,6 @@ where
         kernel::select(tensor, dim, indices)
     }
 
-    fn float_select_add(
-        tensor: FloatTensor<Self>,
-        dim: usize,
-        indices: IntTensor<Self>,
-        value: FloatTensor<Self>,
-    ) -> FloatTensor<Self> {
-        kernel::select_assign(tensor, dim, indices, value, false)
-    }
-
     fn float_select_assign(
         tensor: FloatTensor<Self>,
         dim: usize,
@@ -243,7 +225,7 @@ where
     ) -> FloatTensor<Self> {
         match update {
             burn_backend::tensor::IndexingUpdateOp::Add => {
-                Self::float_select_add(tensor, dim, indices, value)
+                kernel::select_assign(tensor, dim, indices, value, false)
             }
             burn_backend::tensor::IndexingUpdateOp::Mul => {
                 kernel::select_assign_mul(tensor, dim, indices, value)

--- a/crates/burn-dispatch/src/ops/int_tensor.rs
+++ b/crates/burn-dispatch/src/ops/int_tensor.rs
@@ -86,18 +86,6 @@ impl IntTensorOps<Self> for Dispatch {
         binary_op!((tensor, int), (indices, int), |tensor, indices| B::int_gather(dim, tensor, indices) => Int)
     }
 
-    fn int_scatter_add(
-        dim: usize,
-        tensor: IntTensor<Self>,
-        indices: IntTensor<Self>,
-        value: IntTensor<Self>,
-    ) -> IntTensor<Self> {
-        multi_op!(
-            inputs[(tensor, int), (indices, int), (value, int)], => Int,
-            B::int_scatter_add(dim, tensor, indices, value)
-        )
-    }
-
     fn int_scatter(
         dim: usize,
         tensor: IntTensor<Self>,
@@ -133,18 +121,6 @@ impl IntTensorOps<Self> for Dispatch {
         indices: IntTensor<Self>,
     ) -> IntTensor<Self> {
         binary_op!((tensor, int), (indices, int), |tensor, indices| B::int_select(tensor, dim, indices) => Int)
-    }
-
-    fn int_select_add(
-        tensor: IntTensor<Self>,
-        dim: usize,
-        indices: IntTensor<Self>,
-        value: IntTensor<Self>,
-    ) -> IntTensor<Self> {
-        multi_op!(
-            inputs[(tensor, int), (indices, int), (value, int)], => Int,
-            B::int_select_add(tensor, dim, indices, value)
-        )
     }
 
     fn int_select_assign(

--- a/crates/burn-dispatch/src/ops/tensor.rs
+++ b/crates/burn-dispatch/src/ops/tensor.rs
@@ -153,18 +153,6 @@ impl FloatTensorOps<Self> for Dispatch {
         binary_float!((tensor, float), (indices, int), |tensor, indices| B::float_gather(dim, tensor, indices) => Float)
     }
 
-    fn float_scatter_add(
-        dim: usize,
-        tensor: FloatTensor<Self>,
-        indices: IntTensor<Self>,
-        value: FloatTensor<Self>,
-    ) -> FloatTensor<Self> {
-        multi_op!(
-            inputs[(tensor, float), (indices, int), (value, float)], => Float,
-            B::float_scatter_add(dim, tensor, indices, value)
-        )
-    }
-
     fn float_scatter(
         dim: usize,
         tensor: FloatTensor<Self>,
@@ -200,18 +188,6 @@ impl FloatTensorOps<Self> for Dispatch {
         indices: IntTensor<Self>,
     ) -> FloatTensor<Self> {
         binary_float!((tensor, float), (indices, int), |tensor, indices| B::float_select(tensor, dim, indices) => Float)
-    }
-
-    fn float_select_add(
-        tensor: FloatTensor<Self>,
-        dim: usize,
-        indices: IntTensor<Self>,
-        value: FloatTensor<Self>,
-    ) -> FloatTensor<Self> {
-        multi_op!(
-            inputs[(tensor, float), (indices, int), (value, float)], => Float,
-            B::float_select_add(tensor, dim, indices, value)
-        )
     }
 
     fn float_select_assign(

--- a/crates/burn-flex/src/ops/float.rs
+++ b/crates/burn-flex/src/ops/float.rs
@@ -282,29 +282,6 @@ impl FloatTensorOps<Flex> for Flex {
         }
     }
 
-    fn float_scatter_add(
-        dim: usize,
-        tensor: FloatTensor<Flex>,
-        indices: IntTensor<Flex>,
-        value: FloatTensor<Flex>,
-    ) -> FloatTensor<Flex> {
-        match tensor.dtype() {
-            DType::F32 => {
-                crate::ops::gather_scatter::scatter_add::<f32>(tensor, dim, indices, value)
-            }
-            DType::F64 => {
-                crate::ops::gather_scatter::scatter_add::<f64>(tensor, dim, indices, value)
-            }
-            DType::F16 => {
-                crate::ops::gather_scatter::scatter_add::<f16>(tensor, dim, indices, value)
-            }
-            DType::BF16 => {
-                crate::ops::gather_scatter::scatter_add::<bf16>(tensor, dim, indices, value)
-            }
-            _ => panic!("float_scatter_add: unsupported dtype {:?}", tensor.dtype()),
-        }
-    }
-
     fn float_scatter(
         dim: usize,
         tensor: FloatTensor<Flex>,
@@ -313,9 +290,21 @@ impl FloatTensorOps<Flex> for Flex {
         update: burn_backend::tensor::IndexingUpdateOp,
     ) -> FloatTensor<Flex> {
         match update {
-            burn_backend::tensor::IndexingUpdateOp::Add => {
-                Self::float_scatter_add(dim, tensor, indices, value)
-            }
+            burn_backend::tensor::IndexingUpdateOp::Add => match tensor.dtype() {
+                DType::F32 => {
+                    crate::ops::gather_scatter::scatter_add::<f32>(tensor, dim, indices, value)
+                }
+                DType::F64 => {
+                    crate::ops::gather_scatter::scatter_add::<f64>(tensor, dim, indices, value)
+                }
+                DType::F16 => {
+                    crate::ops::gather_scatter::scatter_add::<f16>(tensor, dim, indices, value)
+                }
+                DType::BF16 => {
+                    crate::ops::gather_scatter::scatter_add::<bf16>(tensor, dim, indices, value)
+                }
+                _ => panic!("float_scatter: unsupported dtype {:?}", tensor.dtype()),
+            },
             burn_backend::tensor::IndexingUpdateOp::Mul => match tensor.dtype() {
                 DType::F32 => {
                     crate::ops::gather_scatter::scatter_mul::<f32>(tensor, dim, indices, value)
@@ -382,29 +371,6 @@ impl FloatTensorOps<Flex> for Flex {
         }
     }
 
-    fn float_select_add(
-        tensor: FloatTensor<Flex>,
-        dim: usize,
-        indices: IntTensor<Flex>,
-        value: FloatTensor<Flex>,
-    ) -> FloatTensor<Flex> {
-        match tensor.dtype() {
-            DType::F32 => {
-                crate::ops::gather_scatter::select_add::<f32>(tensor, dim, indices, value)
-            }
-            DType::F64 => {
-                crate::ops::gather_scatter::select_add::<f64>(tensor, dim, indices, value)
-            }
-            DType::F16 => {
-                crate::ops::gather_scatter::select_add::<f16>(tensor, dim, indices, value)
-            }
-            DType::BF16 => {
-                crate::ops::gather_scatter::select_add::<bf16>(tensor, dim, indices, value)
-            }
-            _ => panic!("float_select_add: unsupported dtype {:?}", tensor.dtype()),
-        }
-    }
-
     fn float_select_assign(
         tensor: FloatTensor<Flex>,
         dim: usize,
@@ -413,9 +379,24 @@ impl FloatTensorOps<Flex> for Flex {
         update: burn_backend::tensor::IndexingUpdateOp,
     ) -> FloatTensor<Flex> {
         match update {
-            burn_backend::tensor::IndexingUpdateOp::Add => {
-                Self::float_select_add(tensor, dim, indices, value)
-            }
+            burn_backend::tensor::IndexingUpdateOp::Add => match tensor.dtype() {
+                DType::F32 => {
+                    crate::ops::gather_scatter::select_add::<f32>(tensor, dim, indices, value)
+                }
+                DType::F64 => {
+                    crate::ops::gather_scatter::select_add::<f64>(tensor, dim, indices, value)
+                }
+                DType::F16 => {
+                    crate::ops::gather_scatter::select_add::<f16>(tensor, dim, indices, value)
+                }
+                DType::BF16 => {
+                    crate::ops::gather_scatter::select_add::<bf16>(tensor, dim, indices, value)
+                }
+                _ => panic!(
+                    "float_select_assign: unsupported dtype {:?}",
+                    tensor.dtype()
+                ),
+            },
             burn_backend::tensor::IndexingUpdateOp::Mul => match tensor.dtype() {
                 DType::F32 => {
                     crate::ops::gather_scatter::select_mul::<f32>(tensor, dim, indices, value)

--- a/crates/burn-flex/src/ops/gather_scatter.rs
+++ b/crates/burn-flex/src/ops/gather_scatter.rs
@@ -41,8 +41,8 @@ use crate::{FlexTensor, Layout};
 ///
 /// # History
 ///
-/// Earlier versions of `int_gather`, `int_scatter_add`, `int_select`, and
-/// `int_select_add` carried a `debug_assert_eq!(indices.dtype(), DType::I64,
+/// Earlier versions of `int_gather`, `int_scatter`, `int_select`, and
+/// `int_select_assign` carried a `debug_assert_eq!(indices.dtype(), DType::I64,
 /// ..)` that contradicted this helper's contract. The asserts were dropped
 /// in tracel-ai/burn#4776 once it was confirmed that `read_indices` had
 /// always handled every supported width correctly at runtime. If you're

--- a/crates/burn-flex/src/ops/int.rs
+++ b/crates/burn-flex/src/ops/int.rs
@@ -126,47 +126,6 @@ impl IntTensorOps<Flex> for Flex {
         }
     }
 
-    /// Scatter-add int values at the given indices along `dim`.
-    ///
-    /// `tensor` and `value` must share the same int dtype; `indices` may be
-    /// any supported int width. See [`int_gather`](Self::int_gather) for the
-    /// full index-width policy.
-    fn int_scatter_add(
-        dim: usize,
-        tensor: IntTensor<Flex>,
-        indices: IntTensor<Flex>,
-        value: IntTensor<Flex>,
-    ) -> IntTensor<Flex> {
-        debug_assert_eq!(
-            tensor.dtype(),
-            value.dtype(),
-            "int_scatter_add: dtype mismatch"
-        );
-        match tensor.dtype() {
-            DType::I64 => {
-                crate::ops::gather_scatter::scatter_add::<i64>(tensor, dim, indices, value)
-            }
-            DType::I32 => {
-                crate::ops::gather_scatter::scatter_add::<i32>(tensor, dim, indices, value)
-            }
-            DType::I16 => {
-                crate::ops::gather_scatter::scatter_add::<i16>(tensor, dim, indices, value)
-            }
-            DType::I8 => crate::ops::gather_scatter::scatter_add::<i8>(tensor, dim, indices, value),
-            DType::U64 => {
-                crate::ops::gather_scatter::scatter_add::<u64>(tensor, dim, indices, value)
-            }
-            DType::U32 => {
-                crate::ops::gather_scatter::scatter_add::<u32>(tensor, dim, indices, value)
-            }
-            DType::U16 => {
-                crate::ops::gather_scatter::scatter_add::<u16>(tensor, dim, indices, value)
-            }
-            DType::U8 => crate::ops::gather_scatter::scatter_add::<u8>(tensor, dim, indices, value),
-            dt => panic!("int_scatter_add: unsupported dtype {:?}", dt),
-        }
-    }
-
     fn int_scatter(
         dim: usize,
         tensor: IntTensor<Flex>,
@@ -176,7 +135,34 @@ impl IntTensorOps<Flex> for Flex {
     ) -> IntTensor<Flex> {
         match update {
             burn_backend::tensor::IndexingUpdateOp::Add => {
-                Self::int_scatter_add(dim, tensor, indices, value)
+                debug_assert_eq!(tensor.dtype(), value.dtype(), "int_scatter: dtype mismatch");
+                match tensor.dtype() {
+                    DType::I64 => {
+                        crate::ops::gather_scatter::scatter_add::<i64>(tensor, dim, indices, value)
+                    }
+                    DType::I32 => {
+                        crate::ops::gather_scatter::scatter_add::<i32>(tensor, dim, indices, value)
+                    }
+                    DType::I16 => {
+                        crate::ops::gather_scatter::scatter_add::<i16>(tensor, dim, indices, value)
+                    }
+                    DType::I8 => {
+                        crate::ops::gather_scatter::scatter_add::<i8>(tensor, dim, indices, value)
+                    }
+                    DType::U64 => {
+                        crate::ops::gather_scatter::scatter_add::<u64>(tensor, dim, indices, value)
+                    }
+                    DType::U32 => {
+                        crate::ops::gather_scatter::scatter_add::<u32>(tensor, dim, indices, value)
+                    }
+                    DType::U16 => {
+                        crate::ops::gather_scatter::scatter_add::<u16>(tensor, dim, indices, value)
+                    }
+                    DType::U8 => {
+                        crate::ops::gather_scatter::scatter_add::<u8>(tensor, dim, indices, value)
+                    }
+                    dt => panic!("int_scatter: unsupported dtype {:?}", dt),
+                }
             }
             burn_backend::tensor::IndexingUpdateOp::Mul => {
                 debug_assert_eq!(tensor.dtype(), value.dtype(), "int_scatter: dtype mismatch");
@@ -283,47 +269,6 @@ impl IntTensorOps<Flex> for Flex {
         }
     }
 
-    /// Select-add int values at a 1D index tensor along `dim`.
-    ///
-    /// `tensor` and `value` must share the same int dtype; `indices` may be
-    /// any supported int width. See [`int_gather`](Self::int_gather) for the
-    /// full index-width policy.
-    fn int_select_add(
-        tensor: IntTensor<Flex>,
-        dim: usize,
-        indices: IntTensor<Flex>,
-        value: IntTensor<Flex>,
-    ) -> IntTensor<Flex> {
-        debug_assert_eq!(
-            tensor.dtype(),
-            value.dtype(),
-            "int_select_add: dtype mismatch"
-        );
-        match tensor.dtype() {
-            DType::I64 => {
-                crate::ops::gather_scatter::select_add::<i64>(tensor, dim, indices, value)
-            }
-            DType::I32 => {
-                crate::ops::gather_scatter::select_add::<i32>(tensor, dim, indices, value)
-            }
-            DType::I16 => {
-                crate::ops::gather_scatter::select_add::<i16>(tensor, dim, indices, value)
-            }
-            DType::I8 => crate::ops::gather_scatter::select_add::<i8>(tensor, dim, indices, value),
-            DType::U64 => {
-                crate::ops::gather_scatter::select_add::<u64>(tensor, dim, indices, value)
-            }
-            DType::U32 => {
-                crate::ops::gather_scatter::select_add::<u32>(tensor, dim, indices, value)
-            }
-            DType::U16 => {
-                crate::ops::gather_scatter::select_add::<u16>(tensor, dim, indices, value)
-            }
-            DType::U8 => crate::ops::gather_scatter::select_add::<u8>(tensor, dim, indices, value),
-            dt => panic!("int_select_add: unsupported dtype {:?}", dt),
-        }
-    }
-
     fn int_select_assign(
         tensor: IntTensor<Flex>,
         dim: usize,
@@ -333,7 +278,38 @@ impl IntTensorOps<Flex> for Flex {
     ) -> IntTensor<Flex> {
         match update {
             burn_backend::tensor::IndexingUpdateOp::Add => {
-                Self::int_select_add(tensor, dim, indices, value)
+                debug_assert_eq!(
+                    tensor.dtype(),
+                    value.dtype(),
+                    "int_select_assign: dtype mismatch"
+                );
+                match tensor.dtype() {
+                    DType::I64 => {
+                        crate::ops::gather_scatter::select_add::<i64>(tensor, dim, indices, value)
+                    }
+                    DType::I32 => {
+                        crate::ops::gather_scatter::select_add::<i32>(tensor, dim, indices, value)
+                    }
+                    DType::I16 => {
+                        crate::ops::gather_scatter::select_add::<i16>(tensor, dim, indices, value)
+                    }
+                    DType::I8 => {
+                        crate::ops::gather_scatter::select_add::<i8>(tensor, dim, indices, value)
+                    }
+                    DType::U64 => {
+                        crate::ops::gather_scatter::select_add::<u64>(tensor, dim, indices, value)
+                    }
+                    DType::U32 => {
+                        crate::ops::gather_scatter::select_add::<u32>(tensor, dim, indices, value)
+                    }
+                    DType::U16 => {
+                        crate::ops::gather_scatter::select_add::<u16>(tensor, dim, indices, value)
+                    }
+                    DType::U8 => {
+                        crate::ops::gather_scatter::select_add::<u8>(tensor, dim, indices, value)
+                    }
+                    dt => panic!("int_select_assign: unsupported dtype {:?}", dt),
+                }
             }
             burn_backend::tensor::IndexingUpdateOp::Mul => {
                 debug_assert_eq!(
@@ -1425,7 +1401,13 @@ mod tests {
         let t = FlexTensor::from_data(TensorData::new(vec![0i32, 0, 0], [1, 3]));
         let indices = FlexTensor::from_data(TensorData::new(vec![0i64, 2, 1], [1, 3]));
         let values = FlexTensor::from_data(TensorData::new(vec![10i32, 20, 30], [1, 3]));
-        let result = Flex::int_scatter_add(1, t, indices, values);
+        let result = Flex::int_scatter(
+            1,
+            t,
+            indices,
+            values,
+            burn_backend::tensor::IndexingUpdateOp::Add,
+        );
         let data: Vec<i32> = result.into_data().try_into_vec().unwrap();
         assert_eq!(data, vec![10, 30, 20]);
     }
@@ -1435,7 +1417,13 @@ mod tests {
         let t = FlexTensor::from_data(TensorData::new(vec![1u8, 2, 3], [3]));
         let indices = FlexTensor::from_data(TensorData::new(vec![0i64, 2], [2]));
         let values = FlexTensor::from_data(TensorData::new(vec![10u8, 20], [2]));
-        let result = Flex::int_select_add(t, 0, indices, values);
+        let result = Flex::int_select_assign(
+            t,
+            0,
+            indices,
+            values,
+            burn_backend::tensor::IndexingUpdateOp::Add,
+        );
         let data: Vec<u8> = result.into_data().try_into_vec().unwrap();
         assert_eq!(data, vec![11, 2, 23]);
     }

--- a/crates/burn-flex/src/ops/module.rs
+++ b/crates/burn-flex/src/ops/module.rs
@@ -797,6 +797,12 @@ impl ModuleOps<Flex> for Flex {
             &Default::default(),
             dtype.into(),
         );
-        Flex::float_select_add(grad, 0, indices, output_grad)
+        Flex::float_select_assign(
+            grad,
+            0,
+            indices,
+            output_grad,
+            burn_backend::tensor::IndexingUpdateOp::Add,
+        )
     }
 }

--- a/crates/burn-fusion/src/ops/int_tensor.rs
+++ b/crates/burn-fusion/src/ops/int_tensor.rs
@@ -354,51 +354,6 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
             .output()
     }
 
-    fn int_scatter_add(
-        dim: usize,
-        tensor: IntTensor<Self>,
-        indices: IntTensor<Self>,
-        value: IntTensor<Self>,
-    ) -> IntTensor<Self> {
-        #[derive(new, Debug)]
-        struct ScatterOps<B: FusionBackend> {
-            desc: ScatterOpIr,
-            _b: PhantomData<B>,
-        }
-
-        impl<B: FusionBackend> Operation<B::FusionRuntime> for ScatterOps<B> {
-            fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
-                let tensor = handles.get_int_tensor::<B>(&self.desc.tensor);
-                let indices = handles.get_int_tensor::<B>(&self.desc.indices);
-                let value = handles.get_int_tensor::<B>(&self.desc.value);
-
-                let output = B::int_scatter_add(self.desc.dim, tensor, indices, value);
-
-                handles.register_int_tensor::<B>(&self.desc.out.id, output);
-            }
-        }
-
-        let streams = StreamId::current();
-
-        let client = tensor.client.clone();
-        let desc = ScatterOpIr::create(
-            tensor.into_ir(),
-            dim,
-            indices.into_ir(),
-            value.into_ir(),
-            IndexingUpdateOp::Add,
-            || client.create_empty_handle(),
-        );
-
-        client
-            .register(
-                streams,
-                OperationIr::BaseInt(BaseOperationIr::Scatter(desc.clone())),
-                ScatterOps::<B>::new(desc),
-            )
-            .output()
-    }
-
     fn int_scatter(
         dim: usize,
         tensor: IntTensor<Self>,
@@ -557,51 +512,6 @@ impl<B: FusionBackend> IntTensorOps<Self> for Fusion<B> {
                 streams,
                 OperationIr::BaseInt(BaseOperationIr::Select(desc.clone())),
                 SelectOps::<B>::new(desc),
-            )
-            .output()
-    }
-
-    fn int_select_add(
-        tensor: IntTensor<Self>,
-        dim: usize,
-        indices: IntTensor<Self>,
-        value: IntTensor<Self>,
-    ) -> IntTensor<Self> {
-        #[derive(new, Debug)]
-        struct SelectAssignOps<B: FusionBackend> {
-            desc: SelectAssignOpIr,
-            _b: PhantomData<B>,
-        }
-
-        impl<B: FusionBackend> Operation<B::FusionRuntime> for SelectAssignOps<B> {
-            fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
-                let tensor = handles.get_int_tensor::<B>(&self.desc.tensor);
-                let indices = handles.get_int_tensor::<B>(&self.desc.indices);
-                let value = handles.get_int_tensor::<B>(&self.desc.value);
-
-                let output = B::int_select_add(tensor, self.desc.dim, indices, value);
-
-                handles.register_int_tensor::<B>(&self.desc.out.id, output);
-            }
-        }
-
-        let streams = StreamId::current();
-
-        let client = tensor.client.clone();
-        let desc = SelectAssignOpIr::create(
-            tensor.into_ir(),
-            dim,
-            indices.into_ir(),
-            value.into_ir(),
-            IndexingUpdateOp::Add,
-            || client.create_empty_handle(),
-        );
-
-        client
-            .register(
-                streams,
-                OperationIr::BaseInt(BaseOperationIr::SelectAssign(desc.clone())),
-                SelectAssignOps::<B>::new(desc),
             )
             .output()
     }

--- a/crates/burn-fusion/src/ops/tensor.rs
+++ b/crates/burn-fusion/src/ops/tensor.rs
@@ -689,51 +689,6 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
             .output()
     }
 
-    fn float_scatter_add(
-        dim: usize,
-        tensor: FloatTensor<Self>,
-        indices: IntTensor<Self>,
-        value: FloatTensor<Self>,
-    ) -> FloatTensor<Self> {
-        #[derive(new, Debug)]
-        struct ScatterOps<B: FusionBackend> {
-            desc: ScatterOpIr,
-            _b: PhantomData<B>,
-        }
-
-        impl<B: FusionBackend> Operation<B::FusionRuntime> for ScatterOps<B> {
-            fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
-                let tensor = handles.get_float_tensor::<B>(&self.desc.tensor);
-                let indices = handles.get_int_tensor::<B>(&self.desc.indices);
-                let value = handles.get_float_tensor::<B>(&self.desc.value);
-
-                let output = B::float_scatter_add(self.desc.dim, tensor, indices, value);
-
-                handles.register_float_tensor::<B>(&self.desc.out.id, output);
-            }
-        }
-
-        let streams = StreamId::current();
-
-        let client = tensor.client.clone();
-        let desc = ScatterOpIr::create(
-            tensor.into_ir(),
-            dim,
-            indices.into_ir(),
-            value.into_ir(),
-            IndexingUpdateOp::Add,
-            || client.create_empty_handle(),
-        );
-
-        client
-            .register(
-                streams,
-                OperationIr::BaseFloat(BaseOperationIr::Scatter(desc.clone())),
-                ScatterOps::<B>::new(desc),
-            )
-            .output()
-    }
-
     fn float_scatter(
         dim: usize,
         tensor: FloatTensor<Self>,
@@ -892,51 +847,6 @@ impl<B: FusionBackend> FloatTensorOps<Self> for Fusion<B> {
                 streams,
                 OperationIr::BaseFloat(BaseOperationIr::Select(desc.clone())),
                 SelectOps::<B>::new(desc),
-            )
-            .output()
-    }
-
-    fn float_select_add(
-        tensor: FloatTensor<Self>,
-        dim: usize,
-        indices: IntTensor<Self>,
-        value: FloatTensor<Self>,
-    ) -> FloatTensor<Self> {
-        #[derive(new, Debug)]
-        struct SelectAssignOps<B: FusionBackend> {
-            desc: SelectAssignOpIr,
-            _b: PhantomData<B>,
-        }
-
-        impl<B: FusionBackend> Operation<B::FusionRuntime> for SelectAssignOps<B> {
-            fn execute(&self, handles: &mut HandleContainer<B::Handle>) {
-                let tensor = handles.get_float_tensor::<B>(&self.desc.tensor);
-                let indices = handles.get_int_tensor::<B>(&self.desc.indices);
-                let value = handles.get_float_tensor::<B>(&self.desc.value);
-
-                let output = B::float_select_add(tensor, self.desc.dim, indices, value);
-
-                handles.register_float_tensor::<B>(&self.desc.out.id, output);
-            }
-        }
-
-        let streams = StreamId::current();
-
-        let client = tensor.client.clone();
-        let desc = SelectAssignOpIr::create(
-            tensor.into_ir(),
-            dim,
-            indices.into_ir(),
-            value.into_ir(),
-            IndexingUpdateOp::Add,
-            || client.create_empty_handle(),
-        );
-
-        client
-            .register(
-                streams,
-                OperationIr::BaseFloat(BaseOperationIr::SelectAssign(desc.clone())),
-                SelectAssignOps::<B>::new(desc),
             )
             .output()
     }

--- a/crates/burn-ir/src/operation.rs
+++ b/crates/burn-ir/src/operation.rs
@@ -438,8 +438,8 @@ pub enum BaseOperationIr {
     Gather(GatherOpIr),
     /// Operation corresponding to:
     ///
-    /// Float => [scatter](burn_backend::ops::FloatTensorOps::float_scatter_add).
-    /// Int => [scatter](burn_backend::ops::IntTensorOps::int_scatter_add).
+    /// Float => [scatter](burn_backend::ops::FloatTensorOps::float_scatter).
+    /// Int => [scatter](burn_backend::ops::IntTensorOps::int_scatter).
     /// Bool => [scatter](burn_backend::ops::BoolTensorOps::bool_scatter_or).
     Scatter(ScatterOpIr),
     /// Multi-dimensional scatter operation.

--- a/crates/burn-ndarray/src/ops/int_tensor.rs
+++ b/crates/burn-ndarray/src/ops/int_tensor.rs
@@ -266,19 +266,6 @@ impl IntTensorOps<Self> for NdArray {
         })
     }
 
-    fn int_scatter_add(
-        dim: usize,
-        tensor: NdArrayTensor,
-        indices: NdArrayTensor,
-        value: NdArrayTensor,
-    ) -> NdArrayTensor {
-        execute_with_int_dtype!((tensor, value), I, |tensor, value| -> NdArrayTensor {
-            execute_with_int_dtype!(indices, |idx_array| NdArrayOps::<I>::scatter(
-                dim, tensor, idx_array, value
-            ))
-        })
-    }
-
     fn int_scatter(
         dim: usize,
         tensor: NdArrayTensor,
@@ -288,7 +275,11 @@ impl IntTensorOps<Self> for NdArray {
     ) -> NdArrayTensor {
         match update {
             burn_backend::tensor::IndexingUpdateOp::Add => {
-                Self::int_scatter_add(dim, tensor, indices, value)
+                execute_with_int_dtype!((tensor, value), I, |tensor, value| -> NdArrayTensor {
+                    execute_with_int_dtype!(indices, |idx_array| NdArrayOps::<I>::scatter(
+                        dim, tensor, idx_array, value
+                    ))
+                })
             }
             burn_backend::tensor::IndexingUpdateOp::Assign => {
                 execute_with_int_dtype!((tensor, value), I, |tensor, value| -> NdArrayTensor {
@@ -335,19 +326,6 @@ impl IntTensorOps<Self> for NdArray {
         })
     }
 
-    fn int_select_add(
-        tensor: NdArrayTensor,
-        dim: usize,
-        indices: NdArrayTensor,
-        value: NdArrayTensor,
-    ) -> NdArrayTensor {
-        execute_with_int_dtype!((tensor, value), I, |tensor, value| -> NdArrayTensor {
-            execute_with_int_dtype!(indices, |idx_array| NdArrayMathOps::<I>::select_assign(
-                tensor, dim, idx_array, value
-            ))
-        })
-    }
-
     fn int_select_assign(
         tensor: NdArrayTensor,
         dim: usize,
@@ -357,7 +335,11 @@ impl IntTensorOps<Self> for NdArray {
     ) -> NdArrayTensor {
         match update {
             burn_backend::tensor::IndexingUpdateOp::Add => {
-                Self::int_select_add(tensor, dim, indices, value)
+                execute_with_int_dtype!((tensor, value), I, |tensor, value| -> NdArrayTensor {
+                    execute_with_int_dtype!(indices, |idx_array| {
+                        NdArrayMathOps::<I>::select_assign(tensor, dim, idx_array, value)
+                    })
+                })
             }
             burn_backend::tensor::IndexingUpdateOp::Assign => {
                 execute_with_int_dtype!((tensor, value), I, |tensor, value| -> NdArrayTensor {

--- a/crates/burn-ndarray/src/ops/tensor.rs
+++ b/crates/burn-ndarray/src/ops/tensor.rs
@@ -179,23 +179,6 @@ impl FloatTensorOps<Self> for NdArray {
         )
     }
 
-    fn float_scatter_add(
-        dim: usize,
-        tensor: FloatTensor<Self>,
-        indices: NdArrayTensor,
-        value: FloatTensor<Self>,
-    ) -> FloatTensor<Self> {
-        execute_with_int_dtype!(
-            indices,
-            IntElem,
-            |idx_array: SharedArray<IntElem>| -> NdArrayTensor {
-                execute_with_float_dtype!((tensor, value), |tensor, value| NdArrayOps::scatter(
-                    dim, tensor, idx_array, value
-                ))
-            }
-        )
-    }
-
     fn float_scatter(
         dim: usize,
         tensor: FloatTensor<Self>,
@@ -205,7 +188,15 @@ impl FloatTensorOps<Self> for NdArray {
     ) -> FloatTensor<Self> {
         match update {
             burn_backend::tensor::IndexingUpdateOp::Add => {
-                Self::float_scatter_add(dim, tensor, indices, value)
+                execute_with_int_dtype!(
+                    indices,
+                    IntElem,
+                    |idx_array: SharedArray<IntElem>| -> NdArrayTensor {
+                        execute_with_float_dtype!((tensor, value), |tensor, value| {
+                            NdArrayOps::scatter(dim, tensor, idx_array, value)
+                        })
+                    }
+                )
             }
             burn_backend::tensor::IndexingUpdateOp::Assign => {
                 execute_with_int_dtype!(
@@ -278,23 +269,6 @@ impl FloatTensorOps<Self> for NdArray {
         )
     }
 
-    fn float_select_add(
-        tensor: FloatTensor<Self>,
-        dim: usize,
-        indices: NdArrayTensor,
-        value: FloatTensor<Self>,
-    ) -> FloatTensor<Self> {
-        execute_with_int_dtype!(
-            indices,
-            IntElem,
-            |idx_array: SharedArray<IntElem>| -> NdArrayTensor {
-                execute_with_float_dtype!((tensor, value), |tensor, value| {
-                    NdArrayMathOps::select_assign(tensor, dim, idx_array, value)
-                })
-            }
-        )
-    }
-
     fn float_select_assign(
         tensor: FloatTensor<Self>,
         dim: usize,
@@ -304,7 +278,15 @@ impl FloatTensorOps<Self> for NdArray {
     ) -> FloatTensor<Self> {
         match update {
             burn_backend::tensor::IndexingUpdateOp::Add => {
-                Self::float_select_add(tensor, dim, indices, value)
+                execute_with_int_dtype!(
+                    indices,
+                    IntElem,
+                    |idx_array: SharedArray<IntElem>| -> NdArrayTensor {
+                        execute_with_float_dtype!((tensor, value), |tensor, value| {
+                            NdArrayMathOps::select_assign(tensor, dim, idx_array, value)
+                        })
+                    }
+                )
             }
             burn_backend::tensor::IndexingUpdateOp::Assign => {
                 execute_with_int_dtype!(

--- a/crates/burn-router/src/ops/int_tensor.rs
+++ b/crates/burn-router/src/ops/int_tensor.rs
@@ -163,27 +163,6 @@ impl<R: RouterChannel> IntTensorOps<Self> for BackendRouter<R> {
             .output()
     }
 
-    fn int_scatter_add(
-        dim: usize,
-        tensor: IntTensor<Self>,
-        indices: IntTensor<Self>,
-        value: IntTensor<Self>,
-    ) -> IntTensor<Self> {
-        let client = tensor.client.clone();
-        let desc = ScatterOpIr::create(
-            tensor.into_ir(),
-            dim,
-            indices.into_ir(),
-            value.into_ir(),
-            IndexingUpdateOp::Add,
-            || client.create_empty_handle(),
-        );
-
-        client
-            .register(OperationIr::BaseInt(BaseOperationIr::Scatter(desc)))
-            .output()
-    }
-
     fn int_scatter(
         dim: usize,
         tensor: IntTensor<Self>,
@@ -249,27 +228,6 @@ impl<R: RouterChannel> IntTensorOps<Self> for BackendRouter<R> {
 
         client
             .register(OperationIr::BaseInt(BaseOperationIr::Select(desc)))
-            .output()
-    }
-
-    fn int_select_add(
-        tensor: IntTensor<Self>,
-        dim: usize,
-        indices: IntTensor<Self>,
-        value: IntTensor<Self>,
-    ) -> IntTensor<Self> {
-        let client = tensor.client.clone();
-        let desc = SelectAssignOpIr::create(
-            tensor.into_ir(),
-            dim,
-            indices.into_ir(),
-            value.into_ir(),
-            IndexingUpdateOp::Add,
-            || client.create_empty_handle(),
-        );
-
-        client
-            .register(OperationIr::BaseInt(BaseOperationIr::SelectAssign(desc)))
             .output()
     }
 

--- a/crates/burn-router/src/ops/tensor.rs
+++ b/crates/burn-router/src/ops/tensor.rs
@@ -372,27 +372,6 @@ impl<R: RouterChannel> FloatTensorOps<Self> for BackendRouter<R> {
             .output()
     }
 
-    fn float_scatter_add(
-        dim: usize,
-        tensor: FloatTensor<Self>,
-        indices: IntTensor<Self>,
-        value: FloatTensor<Self>,
-    ) -> FloatTensor<Self> {
-        let client = tensor.client.clone();
-        let desc = ScatterOpIr::create(
-            tensor.into_ir(),
-            dim,
-            indices.into_ir(),
-            value.into_ir(),
-            IndexingUpdateOp::Add,
-            || client.create_empty_handle(),
-        );
-
-        client
-            .register(OperationIr::BaseFloat(BaseOperationIr::Scatter(desc)))
-            .output()
-    }
-
     fn float_scatter(
         dim: usize,
         tensor: FloatTensor<Self>,
@@ -458,27 +437,6 @@ impl<R: RouterChannel> FloatTensorOps<Self> for BackendRouter<R> {
 
         client
             .register(OperationIr::BaseFloat(BaseOperationIr::Select(desc)))
-            .output()
-    }
-
-    fn float_select_add(
-        tensor: FloatTensor<Self>,
-        dim: usize,
-        indices: IntTensor<Self>,
-        value: FloatTensor<Self>,
-    ) -> FloatTensor<Self> {
-        let client = tensor.client.clone();
-        let desc = SelectAssignOpIr::create(
-            tensor.into_ir(),
-            dim,
-            indices.into_ir(),
-            value.into_ir(),
-            IndexingUpdateOp::Add,
-            || client.create_empty_handle(),
-        );
-
-        client
-            .register(OperationIr::BaseFloat(BaseOperationIr::SelectAssign(desc)))
             .output()
     }
 

--- a/crates/burn-tch/src/ops/int_tensor.rs
+++ b/crates/burn-tch/src/ops/int_tensor.rs
@@ -283,15 +283,6 @@ impl IntTensorOps<Self> for LibTorch {
         TchOps::gather(dim, tensor, indices)
     }
 
-    fn int_scatter_add(
-        dim: usize,
-        tensor: TchTensor,
-        indices: TchTensor,
-        value: TchTensor,
-    ) -> TchTensor {
-        TchOps::scatter(dim, tensor, indices, value)
-    }
-
     fn int_scatter(
         dim: usize,
         tensor: TchTensor,
@@ -325,15 +316,6 @@ impl IntTensorOps<Self> for LibTorch {
 
     fn int_select(tensor: TchTensor, dim: usize, indices: TchTensor) -> TchTensor {
         TchOps::index_select_dim(tensor, dim, indices)
-    }
-
-    fn int_select_add(
-        tensor: TchTensor,
-        dim: usize,
-        indices: TchTensor,
-        value: TchTensor,
-    ) -> TchTensor {
-        TchOps::select_assign(tensor, dim, indices, value)
     }
 
     fn int_select_assign(

--- a/crates/burn-tch/src/ops/tensor.rs
+++ b/crates/burn-tch/src/ops/tensor.rs
@@ -194,15 +194,6 @@ impl FloatTensorOps<Self> for LibTorch {
         TchOps::gather(dim, tensor, indices)
     }
 
-    fn float_scatter_add(
-        dim: usize,
-        tensor: TchTensor,
-        indices: TchTensor,
-        value: TchTensor,
-    ) -> TchTensor {
-        TchOps::scatter(dim, tensor, indices, value)
-    }
-
     fn float_scatter(
         dim: usize,
         tensor: TchTensor,
@@ -236,15 +227,6 @@ impl FloatTensorOps<Self> for LibTorch {
 
     fn float_select(tensor: TchTensor, dim: usize, indices: TchTensor) -> TchTensor {
         TchOps::index_select_dim(tensor, dim, indices)
-    }
-
-    fn float_select_add(
-        tensor: TchTensor,
-        dim: usize,
-        indices: TchTensor,
-        value: TchTensor,
-    ) -> TchTensor {
-        TchOps::select_assign(tensor, dim, indices, value)
     }
 
     fn float_select_assign(


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

> `cargo run-checks` tests with `Flex` by default. Use `cargo run-checks --backend <backend>` when
> targeting another backend. Consider running additional tests relevant to the crates changed.

### Related Issues/PRs

Closes #5508

### Changes

Removed `float/int_select_add` and `float/int_scatter_add` specialized indexing add operations. These predated the more general `select_assign` / `scatter` ops, which take an `IndexingUpdateOp`.
