### PR TITLE
chore: deprecate burn-tch backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ Most backends support all operating systems, so we don't mention them in the tab
 | Wasm   | -            | ☑️   | -        |
 | no-std | -            | ☑️   | -        |
 
+> **Note:** The LibTorch backend is deprecated as of `0.22.0` and will be removed in a future
+> release. Use a [CubeCL](https://github.com/tracel-ai/cubecl) backend (CUDA, ROCm, Metal, Vulkan,
+> WebGPU, CPU) for GPU acceleration, or `burn-flex` for pure-Rust CPU execution.
+
 <br />
 
 Compared to other frameworks, Burn has a very different approach to supporting many backends. By

--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ Most backends support all operating systems, so we don't mention them in the tab
 | no-std | -            | ☑️   | -        |
 
 > **Note:** The LibTorch backend is deprecated as of `0.22.0` and will be removed in a future
-> release. Use a [CubeCL](https://github.com/tracel-ai/cubecl) backend (CUDA, ROCm, Metal, Vulkan,
-> WebGPU, CPU) for GPU acceleration, or `burn-flex` for pure-Rust CPU execution.
+> release. For GPU acceleration, use a [CubeCL](https://github.com/tracel-ai/cubecl) backend (CUDA,
+> ROCm, Metal, Vulkan, WebGPU). For CPU execution, use the CubeCL CPU backend or `burn-flex`.
 
 <br />
 

--- a/burn-book/src/advanced/backend-extension/README.md
+++ b/burn-book/src/advanced/backend-extension/README.md
@@ -30,9 +30,9 @@ pub trait Backend: burn::backend::Backend {
 You can then implement your new custom backend trait for any backend that you want to support:
 
 ```rust, ignore
-impl Backend for burn_tch::LibTorch {
-   fn my_new_function(tensor: TchTensor) -> TchTensor {
-      // My Tch implementation
+impl Backend for burn_wgpu::Wgpu {
+   fn my_new_function(tensor: FloatTensor<Self>) -> FloatTensor<Self> {
+      // My wgpu implementation
    }
 }
 
@@ -59,7 +59,7 @@ impl<B: Backend> Backend for burn_autodiff::Autodiff<B> {
    }
 }
 
-impl Backend for burn_autodiff::Autodiff<burn_tch::LibTorch> {
+impl Backend for burn_autodiff::Autodiff<burn_wgpu::Wgpu> {
    fn my_new_function(tensor: AutodiffTensor) -> AutodiffTensor {
       // My own backward implementation, generic over a backend implementation.
       //

--- a/burn-book/src/building-blocks/backend.md
+++ b/burn-book/src/building-blocks/backend.md
@@ -22,23 +22,23 @@ and `cuda` features make `Device::wgpu` and `Device::cuda` available.
 
 `Device` provides constructors for the backends enabled in your build. Common choices include:
 
-| Constructor                                | Target                             |
-| ------------------------------------------ | ---------------------------------- |
-| `Device::wgpu(Default::default())`         | Best WGPU adapter available        |
-| `Device::wgpu(DeviceKind::DiscreteGpu(0))` | First discrete GPU through WGPU    |
-| `Device::vulkan(Default::default())`       | Best Vulkan adapter                |
-| `Device::metal(Default::default())`        | Best Metal adapter                 |
-| `Device::webgpu(Default::default())`       | Browser WebGPU device              |
-| `Device::cuda(0)`                          | CUDA GPU at index 0                |
-| `Device::cuda(DeviceIndex::Default)`       | Backend-selected CUDA GPU          |
-| `Device::rocm(0)`                          | ROCm/HIP GPU at index 0            |
-| `Device::cpu()`                            | CubeCL CPU backend                 |
-| `Device::flex()`                           | Flex CPU backend                   |
-| `Device::ndarray()`                        | NdArray CPU backend (deprecated)   |
-| `Device::libtorch()`                       | LibTorch CPU backend               |
-| `Device::libtorch_cuda(0)`                 | LibTorch CUDA GPU at index 0       |
-| `Device::libtorch_mps()`                   | LibTorch Metal Performance Shaders |
-| `Device::libtorch_vulkan()`                | LibTorch Vulkan device             |
+| Constructor                                | Target                                          |
+| ------------------------------------------ | ----------------------------------------------- |
+| `Device::wgpu(Default::default())`         | Best WGPU adapter available                     |
+| `Device::wgpu(DeviceKind::DiscreteGpu(0))` | First discrete GPU through WGPU                 |
+| `Device::vulkan(Default::default())`       | Best Vulkan adapter                             |
+| `Device::metal(Default::default())`        | Best Metal adapter                              |
+| `Device::webgpu(Default::default())`       | Browser WebGPU device                           |
+| `Device::cuda(0)`                          | CUDA GPU at index 0                             |
+| `Device::cuda(DeviceIndex::Default)`       | Backend-selected CUDA GPU                       |
+| `Device::rocm(0)`                          | ROCm/HIP GPU at index 0                         |
+| `Device::cpu()`                            | CubeCL CPU backend                              |
+| `Device::flex()`                           | Flex CPU backend                                |
+| `Device::ndarray()`                        | NdArray CPU backend (deprecated)                |
+| `Device::libtorch()`                       | LibTorch CPU backend (deprecated)               |
+| `Device::libtorch_cuda(0)`                 | LibTorch CUDA GPU at index 0 (deprecated)       |
+| `Device::libtorch_mps()`                   | LibTorch Metal Performance Shaders (deprecated) |
+| `Device::libtorch_vulkan()`                | LibTorch Vulkan device (deprecated)             |
 
 Indexed devices accept either an integer or `DeviceIndex`. WGPU-family constructors accept a
 `DeviceKind`, which can select a discrete, integrated, or virtual GPU, a CPU adapter, or the best

--- a/contributor-book/src/guides/adding-a-new-operation-to-burn.md
+++ b/contributor-book/src/guides/adding-a-new-operation-to-burn.md
@@ -153,14 +153,11 @@ For testing the `autodiff` operations, please refer to
 ## Adding the Op to other backends
 
 Most of these are fairly straightforward implementations. For reference here's pow's float
-implementation for torch and flex backends:
+implementation for the flex backend:
+[crates/burn-flex/src/ops/float.rs](https://github.com/tracel-ai/burn/blob/main/crates/burn-flex/src/ops/float.rs).
 
-1. Torch implementation in
-   [crates/burn-tch/src/ops/tensor.rs](https://github.com/tracel-ai/burn/blob/0ee2021567b3725907df5fd1a905ce60b1aca096/crates/burn-tch/src/ops/tensor.rs#L467)
-   and the Op used in
-   [crates/burn-tch/src/ops/base.rs](https://github.com/tracel-ai/burn/blob/0ee2021567b3725907df5fd1a905ce60b1aca096/crates/burn-tch/src/ops/base.rs#L481)
-2. Flex in
-   [crates/burn-flex/src/ops/float.rs](https://github.com/tracel-ai/burn/blob/main/crates/burn-flex/src/ops/float.rs)
+`burn-tch` is deprecated and will be removed in a future release, so new ops do not need a LibTorch
+implementation.
 
 This is where any calculation happens currently. Playing a guessing game with method names and
 seeing what completions are suggested will take you far. If you are having trouble figuring out how

--- a/crates/burn-dispatch/src/lib.rs
+++ b/crates/burn-dispatch/src/lib.rs
@@ -2,14 +2,15 @@
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![recursion_limit = "138"]
-// Wiring up the deprecated `NdArray` backend is this crate's job, and the backend registry macros
-// expand it into every dispatch impl, so the warnings land on `macros.rs` rather than on any site
-// we could annotate individually. `allow(deprecated)` is a lint level scoped to this crate, and
-// lint levels never propagate to dependents, so downstream code naming `NdArray` (directly or via
-// our re-export) still gets the warning. The `cfg_attr` keeps this confined to the ndarray-enabled
-// build: `ndarray` is not a default feature, so the default build that CI lints with
-// `--deny warnings` retains full deprecation signal for every other dependency.
-#![cfg_attr(feature = "ndarray", allow(deprecated))]
+// Wiring up the deprecated `NdArray` and `LibTorch` backends is this crate's job, and the backend
+// registry macros expand them into every dispatch impl, so the warnings land on `macros.rs` rather
+// than on any site we could annotate individually. `allow(deprecated)` is a lint level scoped to
+// this crate, and lint levels never propagate to dependents, so downstream code naming `NdArray` or
+// `LibTorch` (directly or via our re-export) still gets the warning. The `cfg_attr` keeps this
+// confined to the builds that enable them: neither `ndarray` nor `tch` is a default feature, so the
+// default build that CI lints with `--deny warnings` retains full deprecation signal for every
+// other dependency.
+#![cfg_attr(any(feature = "ndarray", feature = "tch"), allow(deprecated))]
 
 //! Burn multi-backend dispatch.
 //!
@@ -27,7 +28,7 @@
 //! | `Wgpu`     | `webgpu`   | WebGPU backend via `wgpu` (WGSL) |
 //! | `Flex`     | `flex`     | Pure Rust CPU backend using `burn-flex` |
 //! | `NdArray`  | `ndarray`  | Pure Rust CPU backend using `ndarray` (deprecated - use `flex`) |
-//! | `LibTorch` | `tch`      | Libtorch backend via `tch` |
+//! | `LibTorch` | `tch`      | Libtorch backend via `tch` (deprecated - use a CubeCL backend) |
 //! | `Autodiff` | `autodiff` | Autodiff-enabled backend (used in combination with any of the backends above) |
 //!
 //! **Note:** All backends, including the WGPU-based ones (`wgpu`, `metal`, `vulkan`, `webgpu`),

--- a/crates/burn-store/benches/unified_loading.rs
+++ b/crates/burn-store/benches/unified_loading.rs
@@ -1,4 +1,6 @@
 #![recursion_limit = "256"]
+// The LibTorch bench group exists to compare against the deprecated backend.
+#![cfg_attr(feature = "tch", allow(deprecated))]
 
 //! Unified benchmark comparing all loading methods:
 //! - BurnpackStore (new native format)

--- a/crates/burn-store/benches/unified_saving.rs
+++ b/crates/burn-store/benches/unified_saving.rs
@@ -1,4 +1,6 @@
 #![recursion_limit = "256"]
+// The LibTorch bench group exists to compare against the deprecated backend.
+#![cfg_attr(feature = "tch", allow(deprecated))]
 
 //! Unified benchmark comparing all saving methods:
 //! - BurnpackStore (new native format)

--- a/crates/burn-store/benches/zero_copy_loading.rs
+++ b/crates/burn-store/benches/zero_copy_loading.rs
@@ -1,4 +1,6 @@
 #![recursion_limit = "256"]
+// The LibTorch bench group exists to compare against the deprecated backend.
+#![cfg_attr(feature = "tch", allow(deprecated))]
 
 //! Benchmark comparing different loading modes for BurnpackStore.
 //!

--- a/crates/burn-tch/Cargo.toml
+++ b/crates/burn-tch/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["nathanielsimard <nathaniel.simard.42@gmail.com>"]
 categories = ["science"]
-description = "LibTorch backend for the Burn framework using the tch bindings."
+description = "[Deprecated] LibTorch backend for the Burn framework - use burn-cuda, burn-rocm, burn-wgpu, burn-cpu, or burn-flex instead"
 documentation = "https://docs.rs/burn-tch"
 edition.workspace = true
 keywords = ["deep-learning", "machine-learning", "data"]

--- a/crates/burn-tch/README.md
+++ b/crates/burn-tch/README.md
@@ -5,6 +5,16 @@
 [![Current Crates.io Version](https://img.shields.io/crates/v/burn-tch.svg)](https://crates.io/crates/burn-tch)
 [![license](https://shields.io/badge/license-MIT%2FApache--2.0-blue)](https://github.com/tracel-ai/burn-tch/blob/master/README.md)
 
+> **Deprecated:** This crate is deprecated as of `0.22.0` and will be removed in a future release.
+> Please migrate to one of the actively maintained backends:
+>
+> - **CubeCL GPU backends** for GPU acceleration: [`burn-cuda`](https://crates.io/crates/burn-cuda)
+>   (NVIDIA), [`burn-rocm`](https://crates.io/crates/burn-rocm) (AMD), and
+>   [`burn-wgpu`](https://crates.io/crates/burn-wgpu) (Metal, Vulkan, WebGPU).
+> - **CPU backends**: [`burn-cpu`](https://crates.io/crates/burn-cpu) (CubeCL) or
+>   [`burn-flex`](https://crates.io/crates/burn-flex) for portable pure-Rust CPU execution (std,
+>   no_std, WebAssembly).
+
 This crate provides a Torch backend for [Burn](https://github.com/tracel-ai/burn) utilizing the
 [`tch-rs`](https://github.com/LaurentMazare/tch-rs) crate, which offers a Rust interface to the
 [PyTorch](https://pytorch.org/) C++ API.

--- a/crates/burn-tch/src/bin/cpu.rs
+++ b/crates/burn-tch/src/bin/cpu.rs
@@ -1,3 +1,6 @@
+// This sample exists to validate a burn-tch install, so naming the deprecated crate is the point.
+#![allow(deprecated)]
+
 use burn_backend::{TensorMetadata, ops::FloatTensorOps};
 use burn_tch::{LibTorch, LibTorchDevice};
 

--- a/crates/burn-tch/src/bin/cuda.rs
+++ b/crates/burn-tch/src/bin/cuda.rs
@@ -1,3 +1,6 @@
+// This sample exists to validate a burn-tch install, so naming the deprecated crate is the point.
+#![allow(deprecated)]
+
 use burn_backend::{TensorMetadata, ops::FloatTensorOps};
 use burn_tch::{LibTorch, LibTorchDevice};
 

--- a/crates/burn-tch/src/bin/mps.rs
+++ b/crates/burn-tch/src/bin/mps.rs
@@ -1,3 +1,6 @@
+// This sample exists to validate a burn-tch install, so naming the deprecated crate is the point.
+#![allow(deprecated)]
+
 use burn_backend::{TensorMetadata, ops::FloatTensorOps};
 use burn_tch::{LibTorch, LibTorchDevice};
 

--- a/crates/burn-tch/src/lib.rs
+++ b/crates/burn-tch/src/lib.rs
@@ -1,8 +1,18 @@
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::single_range_in_vec_init)]
+#![deprecated(
+    since = "0.22.0",
+    note = "burn-tch is deprecated and will be removed in a future release. Use a CubeCL backend (burn-cuda, burn-rocm, burn-wgpu, burn-cpu) for GPU acceleration, or burn-flex for pure-Rust CPU execution."
+)]
 
 //! Burn Tch Backend
+//!
+//! **Deprecated:** This backend is deprecated and will be removed in a future release.
+//! Please migrate to one of the actively maintained backends:
+//! - CubeCL GPU backends: `burn-cuda` (NVIDIA), `burn-rocm` (AMD), `burn-wgpu` (Metal, Vulkan,
+//!   WebGPU)
+//! - CPU backends: `burn-cpu` (CubeCL) or `burn-flex` (pure Rust, std/no_std/WASM)
 
 mod backend;
 mod element;

--- a/crates/burn-tch/src/lib.rs
+++ b/crates/burn-tch/src/lib.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::single_range_in_vec_init)]
 #![deprecated(
     since = "0.22.0",
-    note = "burn-tch is deprecated and will be removed in a future release. Use a CubeCL backend (burn-cuda, burn-rocm, burn-wgpu, burn-cpu) for GPU acceleration, or burn-flex for pure-Rust CPU execution."
+    note = "burn-tch is deprecated and will be removed in a future release. For GPU acceleration use a CubeCL backend: burn-cuda (NVIDIA), burn-rocm (AMD), or burn-wgpu (Metal, Vulkan, WebGPU). For CPU execution use burn-cpu (CubeCL) or burn-flex (pure Rust)."
 )]
 
 //! Burn Tch Backend

--- a/crates/burn-tensor/src/device.rs
+++ b/crates/burn-tensor/src/device.rs
@@ -357,12 +357,22 @@ impl Device {
 
     /// LibTorch CPU device.
     #[cfg(feature = "tch")]
+    #[deprecated(
+        since = "0.22.0",
+        note = "burn-tch is deprecated and will be removed in a future release. Use a CubeCL backend (`Device::cuda`, `Device::rocm`, `Device::metal`, `Device::vulkan`, `Device::cpu`) or `Device::flex()` instead."
+    )]
+    #[allow(deprecated)] // constructing the deprecated device is this constructor's job
     pub fn libtorch() -> Self {
         Self::new(burn_dispatch::devices::LibTorchDevice::Cpu)
     }
 
     /// LibTorch CUDA device at the given hardware index.
     #[cfg(feature = "tch")]
+    #[deprecated(
+        since = "0.22.0",
+        note = "burn-tch is deprecated and will be removed in a future release. Use a CubeCL backend (`Device::cuda`, `Device::rocm`, `Device::metal`, `Device::vulkan`, `Device::cpu`) or `Device::flex()` instead."
+    )]
+    #[allow(deprecated)] // constructing the deprecated device is this constructor's job
     pub fn libtorch_cuda(index: impl Into<DeviceIndex>) -> Self {
         Self::new(burn_dispatch::devices::LibTorchDevice::Cuda(
             index.into().resolve(),
@@ -371,12 +381,22 @@ impl Device {
 
     /// LibTorch Metal Performance Shaders (MPS) device.
     #[cfg(feature = "tch")]
+    #[deprecated(
+        since = "0.22.0",
+        note = "burn-tch is deprecated and will be removed in a future release. Use a CubeCL backend (`Device::cuda`, `Device::rocm`, `Device::metal`, `Device::vulkan`, `Device::cpu`) or `Device::flex()` instead."
+    )]
+    #[allow(deprecated)] // constructing the deprecated device is this constructor's job
     pub fn libtorch_mps() -> Self {
         Self::new(burn_dispatch::devices::LibTorchDevice::Mps)
     }
 
     /// LibTorch Vulkan device.
     #[cfg(feature = "tch")]
+    #[deprecated(
+        since = "0.22.0",
+        note = "burn-tch is deprecated and will be removed in a future release. Use a CubeCL backend (`Device::cuda`, `Device::rocm`, `Device::metal`, `Device::vulkan`, `Device::cpu`) or `Device::flex()` instead."
+    )]
+    #[allow(deprecated)] // constructing the deprecated device is this constructor's job
     pub fn libtorch_vulkan() -> Self {
         Self::new(burn_dispatch::devices::LibTorchDevice::Vulkan)
     }

--- a/crates/burn-vision/src/lib.rs
+++ b/crates/burn-vision/src/lib.rs
@@ -12,6 +12,11 @@
 //!
 
 #![warn(missing_docs)]
+// Implementing the vision ops for the deprecated `LibTorch` backend is this crate's job, and the
+// `backend_extension` macro expands it into every generated impl, so the warnings cannot be
+// attributed to individual sites. Lint levels do not propagate to dependents, so downstream code
+// naming `LibTorch` still gets the warning, and `tch` is not a default feature.
+#![cfg_attr(feature = "tch", allow(deprecated))]
 
 extern crate alloc;
 

--- a/crates/burn-vision/tests/common/mod.rs
+++ b/crates/burn-vision/tests/common/mod.rs
@@ -13,7 +13,7 @@ pub type TestDevice = burn_core::backend::CudaDevice;
 #[cfg(all(test, feature = "rocm", not(feature = "cuda")))]
 pub type TestDevice = burn_core::backend::RocmDevice;
 
-#[allow(unused)]
+#[allow(unused, deprecated)]
 #[cfg(all(test, feature = "tch", not(any(feature = "cuda", feature = "rocm"))))]
 pub type TestDevice = burn_core::backend::LibTorchDevice;
 

--- a/crates/burn/src/lib.rs
+++ b/crates/burn/src/lib.rs
@@ -41,7 +41,7 @@
 //! autodifferentiation and automatic kernel fusion.
 //!
 //! - WGPU (WebGPU): Cross-Platform GPU Backend
-//! - LibTorch: Backend using the LibTorch bindings
+//! - LibTorch: Backend using the LibTorch bindings (deprecated)
 //! - Flex: Pure-Rust CPU backend (std, no_std, WebAssembly)
 //! - Autodiff: Backend decorator that brings backpropagation to any backend
 //! - Fusion: Backend decorator that brings kernel fusion to backends that support it
@@ -95,7 +95,7 @@
 //!   - `metal`: Makes available the Metal backend
 //!   - `rocm`: Makes available the ROCm backend
 //!   - `cpu`: Makes available the CubeCL CPU backend
-//!   - `tch`: Makes available the LibTorch backend
+//!   - `tch`: Makes available the LibTorch backend (deprecated - use a CubeCL backend instead)
 //!   - `flex`: Makes available the Flex backend (pure-Rust CPU, std/no_std/WASM)
 //!   - `ndarray`: Makes available the NdArray backend (deprecated - use `flex` instead)
 //! - Backend specifications


### PR DESCRIPTION
Marks `burn-tch` as deprecated, following the same approach as #5344 for `burn-ndarray`. Nothing changes about what is built, tested or published - the crate stays supported for the deprecation window.

- `#![deprecated]` on the crate root, with migration notes in the crate docs, README and crates.io description
- `#[deprecated]` on `Device::libtorch`, `libtorch_cuda`, `libtorch_mps` and `libtorch_vulkan`
- `tch` marked deprecated in the burn feature list, the burn-dispatch backend table, the book's device table and the README backend matrices
- `burn-dispatch` and `burn-vision` take a cfg'd `allow(deprecated)`: the backend registry and `backend_extension` macros expand `LibTorch` into every generated impl, so the warnings land on the macro definition rather than on any site that could be annotated individually. Lint levels do not propagate to dependents, so downstream code naming `LibTorch` still gets the warning.
- The contributor book's new-operation guide no longer tells contributors to implement each op in `burn-tch`; flex is now the reference implementation.

Examples are deliberately left warning under `tch-cpu`/`tch-gpu` - that is the migration signal a user opting into the backend should see.

Users should migrate to a CubeCL backend (`burn-cuda`, `burn-rocm`, `burn-wgpu`, `burn-cpu`), or to `burn-flex` for pure-Rust CPU execution.