### PR TITLE
fix(pack): validate size from aligned data offset

### DIFF
--- a/crates/burn-pack/src/reader.rs
+++ b/crates/burn-pack/src/reader.rs
@@ -114,13 +114,13 @@ impl Reader {
         source: Source,
         available: usize,
     ) -> Result<Self, Error> {
-        let metadata_end = HEADER_SIZE + header.metadata_size as usize;
-        validate_total_size(&metadata, metadata_end, available)?;
+        let data_offset = aligned_data_section_start(header.metadata_size as usize);
+        validate_total_size(&metadata, data_offset, available)?;
 
         Ok(Self {
             metadata,
             source,
-            data_offset: aligned_data_section_start(header.metadata_size as usize),
+            data_offset,
         })
     }
 
@@ -284,7 +284,7 @@ fn parse_metadata(bytes: &[u8]) -> Result<Metadata, Error> {
 /// Ensure the available bytes can hold every tensor the metadata claims.
 fn validate_total_size(
     metadata: &Metadata,
-    metadata_end: usize,
+    data_offset: usize,
     available: usize,
 ) -> Result<(), Error> {
     if metadata.tensors.is_empty() {
@@ -299,7 +299,7 @@ fn validate_total_size(
     let max_offset: usize = max_offset.try_into().map_err(|_| {
         Error::ValidationError(format!("Data offset {max_offset} exceeds platform maximum"))
     })?;
-    let min_size = metadata_end
+    let min_size = data_offset
         .checked_add(max_offset)
         .ok_or_else(|| Error::ValidationError("File size calculation overflow".into()))?;
     if available < min_size {

--- a/crates/burn-pack/tests/errors.rs
+++ b/crates/burn-pack/tests/errors.rs
@@ -3,7 +3,8 @@
 mod common;
 
 use burn_pack::{
-    Bytes, Error, FORMAT_VERSION, Header, MAGIC_NUMBER, MAX_METADATA_SIZE, Reader, Writer,
+    Bytes, Error, FORMAT_VERSION, HEADER_SIZE, Header, MAGIC_NUMBER, MAX_METADATA_SIZE, Reader,
+    Writer,
 };
 use common::f32_tensor;
 
@@ -91,5 +92,23 @@ fn rejects_truncated_data_section() {
     assert!(matches!(
         Reader::from_bytes(Bytes::from_bytes_vec(bytes)),
         Err(Error::ValidationError(_))
+    ));
+}
+
+#[test]
+fn rejects_data_truncated_into_alignment_padding() {
+    let packed = Writer::new(vec![f32_tensor("w", &[1.0, 2.0, 3.0, 4.0], &[4], None)])
+        .into_bytes()
+        .unwrap();
+    let header = Header::from_bytes(&packed[..HEADER_SIZE]).unwrap();
+    let metadata_end = HEADER_SIZE + header.metadata_size as usize;
+
+    // This is large enough only when tensor offsets are incorrectly measured from metadata_end.
+    let mut bytes = packed.to_vec();
+    bytes.truncate(metadata_end + 4 * core::mem::size_of::<f32>());
+
+    assert!(matches!(
+        Reader::from_bytes(Bytes::from_bytes_vec(bytes)),
+        Err(Error::ValidationError(message)) if message.starts_with("File truncated:")
     ));
 }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo run-checks` has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Fixes #5485.

### Changes

Use the aligned tensor data-section offset when validating the minimum burnpack size. The reader now computes this offset once and reuses it for validation and tensor access, preventing truncated containers from passing initial validation.

Adds a regression test covering a file truncated within the alignment-padding gap.

### Testing

- `cargo run-checks`
- `cargo test -p burn-pack`