### PR TITLE
feat(tensor): support assign updates on Flex, Tch and CubeCL

### DIFF
--- a/crates/burn-backend-tests/tests/autodiff/gather_scatter.rs
+++ b/crates/burn-backend-tests/tests/autodiff/gather_scatter.rs
@@ -63,7 +63,6 @@ fn test_scatter_grad() {
         .assert_eq(&TensorData::from([[19., 19., 19.], [64., 64., 64.]]), false);
 }
 
-#[cfg(feature = "ndarray")]
 #[test]
 fn test_scatter_assign_grad() {
     let device = AutodiffDevice::new();

--- a/crates/burn-backend-tests/tests/autodiff/select.rs
+++ b/crates/burn-backend-tests/tests/autodiff/select.rs
@@ -61,7 +61,6 @@ fn test_select_add_grad() {
         .assert_eq(&TensorData::from([[64., 64., 64.], [19., 19., 19.]]), false);
 }
 
-#[cfg(feature = "ndarray")]
 #[test]
 fn test_select_assign_grad() {
     let device = AutodiffDevice::new();

--- a/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/gather_scatter.rs
@@ -90,7 +90,6 @@ fn should_scatter_add_1d() {
         .assert_eq(&TensorData::from([4.0, 5.0, 3.0]), false);
 }
 
-#[cfg(feature = "ndarray")]
 #[test]
 fn should_scatter_assign_1d() {
     let device = Default::default();
@@ -105,7 +104,6 @@ fn should_scatter_assign_1d() {
         .assert_eq(&TensorData::from([10.0, 7.0, 30.0, 50.0]), false);
 }
 
-#[cfg(feature = "ndarray")]
 #[test]
 fn should_scatter_assign_2d_dim0() {
     let device = Default::default();

--- a/crates/burn-backend-tests/tests/tensor/float/ops/select.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/select.rs
@@ -80,7 +80,6 @@ fn should_select_add_1d() {
     output.into_data().assert_eq(&expected, false);
 }
 
-#[cfg(feature = "ndarray")]
 #[test]
 fn should_select_assign_2d_dim0() {
     let device = Default::default();
@@ -94,7 +93,6 @@ fn should_select_assign_2d_dim0() {
     output.into_data().assert_eq(&expected, false);
 }
 
-#[cfg(feature = "ndarray")]
 #[test]
 fn should_select_assign_2d_dim1() {
     let device = Default::default();

--- a/crates/burn-backend-tests/tests/tensor/int/ops/gather_scatter.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/gather_scatter.rs
@@ -68,7 +68,6 @@ fn should_scatter_add_1d_int() {
         .assert_eq(&TensorData::from([4, 5, 3]), false);
 }
 
-#[cfg(feature = "ndarray")]
 #[test]
 fn should_scatter_assign_1d_int() {
     let device = Default::default();
@@ -83,7 +82,6 @@ fn should_scatter_assign_1d_int() {
         .assert_eq(&TensorData::from([10, 7, 30, 50]), false);
 }
 
-#[cfg(feature = "ndarray")]
 #[test]
 fn should_scatter_assign_2d_dim0_int() {
     let device = Default::default();

--- a/crates/burn-backend-tests/tests/tensor/int/ops/select.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/select.rs
@@ -26,7 +26,6 @@ fn should_select_add_1d_int() {
     output.into_data().assert_eq(&expected, false);
 }
 
-#[cfg(feature = "ndarray")]
 #[test]
 fn should_select_assign_2d_dim0_int() {
     let device = Default::default();
@@ -40,7 +39,6 @@ fn should_select_assign_2d_dim0_int() {
     output.into_data().assert_eq(&expected, false);
 }
 
-#[cfg(feature = "ndarray")]
 #[test]
 fn should_select_assign_2d_dim1_int() {
     let device = Default::default();

--- a/crates/burn-cubecl/src/kernel/index/scatter.rs
+++ b/crates/burn-cubecl/src/kernel/index/scatter.rs
@@ -1,7 +1,7 @@
 use crate::{
     CubeRuntime,
     kernel::{
-        AddOp, BinaryOp, BinaryOpFamily, MulOp, OrOp,
+        AddOp, AssignOp, BinaryOp, BinaryOpFamily, MulOp, OrOp,
         utils::{address_type, shape_divmod},
     },
     tensor::CubeTensor,
@@ -129,4 +129,13 @@ pub(crate) fn scatter_mul<R: CubeRuntime>(
     value: CubeTensor<R>,
 ) -> CubeTensor<R> {
     scatter_op::<R, MulOp>(dim, tensor, indices, value)
+}
+
+pub(crate) fn scatter_assign<R: CubeRuntime>(
+    dim: usize,
+    tensor: CubeTensor<R>,
+    indices: CubeTensor<R>,
+    value: CubeTensor<R>,
+) -> CubeTensor<R> {
+    scatter_op::<R, AssignOp>(dim, tensor, indices, value)
 }

--- a/crates/burn-cubecl/src/kernel/index/select_assign.rs
+++ b/crates/burn-cubecl/src/kernel/index/select_assign.rs
@@ -1,5 +1,5 @@
 use crate::kernel::{
-    AddOp, BinaryOp, BinaryOpFamily, MulOp, OrOp,
+    AddOp, AssignOp, BinaryOp, BinaryOpFamily, MulOp, OrOp,
     utils::{address_type, shape_divmod},
 };
 use crate::{CubeRuntime, tensor::CubeTensor};
@@ -117,4 +117,13 @@ pub(crate) fn select_assign_mul<R: CubeRuntime>(
     value: CubeTensor<R>,
 ) -> CubeTensor<R> {
     select_assign_op::<R, MulOp>(tensor, dim, indices, value)
+}
+
+pub(crate) fn select_assign_replace<R: CubeRuntime>(
+    tensor: CubeTensor<R>,
+    dim: usize,
+    indices: CubeTensor<R>,
+    value: CubeTensor<R>,
+) -> CubeTensor<R> {
+    select_assign_op::<R, AssignOp>(tensor, dim, indices, value)
 }

--- a/crates/burn-cubecl/src/ops/int_tensor.rs
+++ b/crates/burn-cubecl/src/ops/int_tensor.rs
@@ -137,6 +137,9 @@ impl<R: CubeRuntime> IntTensorOps<Self> for CubeBackend<R> {
         update: burn_backend::tensor::IndexingUpdateOp,
     ) -> IntTensor<Self> {
         match update {
+            burn_backend::tensor::IndexingUpdateOp::Assign => {
+                kernel::scatter_assign(dim, tensor, indices, value)
+            }
             burn_backend::tensor::IndexingUpdateOp::Add => {
                 Self::int_scatter_add(dim, tensor, indices, value)
             }
@@ -185,6 +188,9 @@ impl<R: CubeRuntime> IntTensorOps<Self> for CubeBackend<R> {
         update: burn_backend::tensor::IndexingUpdateOp,
     ) -> IntTensor<Self> {
         match update {
+            burn_backend::tensor::IndexingUpdateOp::Assign => {
+                kernel::select_assign_replace(tensor, dim, indices, value)
+            }
             burn_backend::tensor::IndexingUpdateOp::Add => {
                 Self::int_select_add(tensor, dim, indices, value)
             }

--- a/crates/burn-cubecl/src/ops/tensor.rs
+++ b/crates/burn-cubecl/src/ops/tensor.rs
@@ -194,6 +194,9 @@ where
         update: burn_backend::tensor::IndexingUpdateOp,
     ) -> FloatTensor<Self> {
         match update {
+            burn_backend::tensor::IndexingUpdateOp::Assign => {
+                kernel::scatter_assign(dim, tensor, indices, value)
+            }
             burn_backend::tensor::IndexingUpdateOp::Add => {
                 Self::float_scatter_add(dim, tensor, indices, value)
             }
@@ -242,6 +245,9 @@ where
         update: burn_backend::tensor::IndexingUpdateOp,
     ) -> FloatTensor<Self> {
         match update {
+            burn_backend::tensor::IndexingUpdateOp::Assign => {
+                kernel::select_assign_replace(tensor, dim, indices, value)
+            }
             burn_backend::tensor::IndexingUpdateOp::Add => {
                 Self::float_select_add(tensor, dim, indices, value)
             }

--- a/crates/burn-flex/src/ops/float.rs
+++ b/crates/burn-flex/src/ops/float.rs
@@ -313,6 +313,21 @@ impl FloatTensorOps<Flex> for Flex {
         update: burn_backend::tensor::IndexingUpdateOp,
     ) -> FloatTensor<Flex> {
         match update {
+            burn_backend::tensor::IndexingUpdateOp::Assign => match tensor.dtype() {
+                DType::F32 => {
+                    crate::ops::gather_scatter::scatter_assign::<f32>(tensor, dim, indices, value)
+                }
+                DType::F64 => {
+                    crate::ops::gather_scatter::scatter_assign::<f64>(tensor, dim, indices, value)
+                }
+                DType::F16 => {
+                    crate::ops::gather_scatter::scatter_assign::<f16>(tensor, dim, indices, value)
+                }
+                DType::BF16 => {
+                    crate::ops::gather_scatter::scatter_assign::<bf16>(tensor, dim, indices, value)
+                }
+                _ => panic!("float_scatter: unsupported dtype {:?}", tensor.dtype()),
+            },
             burn_backend::tensor::IndexingUpdateOp::Add => {
                 Self::float_scatter_add(dim, tensor, indices, value)
             }
@@ -413,6 +428,24 @@ impl FloatTensorOps<Flex> for Flex {
         update: burn_backend::tensor::IndexingUpdateOp,
     ) -> FloatTensor<Flex> {
         match update {
+            burn_backend::tensor::IndexingUpdateOp::Assign => match tensor.dtype() {
+                DType::F32 => {
+                    crate::ops::gather_scatter::select_assign::<f32>(tensor, dim, indices, value)
+                }
+                DType::F64 => {
+                    crate::ops::gather_scatter::select_assign::<f64>(tensor, dim, indices, value)
+                }
+                DType::F16 => {
+                    crate::ops::gather_scatter::select_assign::<f16>(tensor, dim, indices, value)
+                }
+                DType::BF16 => {
+                    crate::ops::gather_scatter::select_assign::<bf16>(tensor, dim, indices, value)
+                }
+                _ => panic!(
+                    "float_select_assign: unsupported dtype {:?}",
+                    tensor.dtype()
+                ),
+            },
             burn_backend::tensor::IndexingUpdateOp::Add => {
                 Self::float_select_add(tensor, dim, indices, value)
             }

--- a/crates/burn-flex/src/ops/gather_scatter.rs
+++ b/crates/burn-flex/src/ops/gather_scatter.rs
@@ -377,6 +377,23 @@ pub fn scatter_add<E: Element + Pod + Default + Copy + core::ops::AddAssign + Se
     )
 }
 
+/// Scatter assign: replaces tensor values at positions specified by indices.
+pub fn scatter_assign<E: Element + Pod + Default + Copy + Send + Sync>(
+    tensor: FlexTensor,
+    dim: usize,
+    indices: FlexTensor,
+    value: FlexTensor,
+) -> FlexTensor {
+    scatter_update::<E, _>(
+        tensor,
+        dim,
+        indices,
+        value,
+        "scatter_assign",
+        |target, value| *target = value,
+    )
+}
+
 /// Scatter multiply: multiplies values into tensor at positions specified by indices.
 pub fn scatter_mul<E: Element + Pod + Default + Copy + core::ops::Mul<Output = E> + Send + Sync>(
     tensor: FlexTensor,
@@ -800,6 +817,23 @@ pub fn select_add<E: Element + Pod + Default + Copy + core::ops::AddAssign + Sen
         value,
         "select_add",
         |target, value| *target += value,
+    )
+}
+
+/// Select assign: replaces tensor values at positions specified by 1D indices.
+pub fn select_assign<E: Element + Pod + Default + Copy + Send + Sync>(
+    tensor: FlexTensor,
+    dim: usize,
+    indices: FlexTensor,
+    value: FlexTensor,
+) -> FlexTensor {
+    select_update::<E, _>(
+        tensor,
+        dim,
+        indices,
+        value,
+        "select_assign",
+        |target, value| *target = value,
     )
 }
 

--- a/crates/burn-flex/src/ops/int.rs
+++ b/crates/burn-flex/src/ops/int.rs
@@ -175,6 +175,36 @@ impl IntTensorOps<Flex> for Flex {
         update: burn_backend::tensor::IndexingUpdateOp,
     ) -> IntTensor<Flex> {
         match update {
+            burn_backend::tensor::IndexingUpdateOp::Assign => {
+                debug_assert_eq!(tensor.dtype(), value.dtype(), "int_scatter: dtype mismatch");
+                match tensor.dtype() {
+                    DType::I64 => crate::ops::gather_scatter::scatter_assign::<i64>(
+                        tensor, dim, indices, value,
+                    ),
+                    DType::I32 => crate::ops::gather_scatter::scatter_assign::<i32>(
+                        tensor, dim, indices, value,
+                    ),
+                    DType::I16 => crate::ops::gather_scatter::scatter_assign::<i16>(
+                        tensor, dim, indices, value,
+                    ),
+                    DType::I8 => crate::ops::gather_scatter::scatter_assign::<i8>(
+                        tensor, dim, indices, value,
+                    ),
+                    DType::U64 => crate::ops::gather_scatter::scatter_assign::<u64>(
+                        tensor, dim, indices, value,
+                    ),
+                    DType::U32 => crate::ops::gather_scatter::scatter_assign::<u32>(
+                        tensor, dim, indices, value,
+                    ),
+                    DType::U16 => crate::ops::gather_scatter::scatter_assign::<u16>(
+                        tensor, dim, indices, value,
+                    ),
+                    DType::U8 => crate::ops::gather_scatter::scatter_assign::<u8>(
+                        tensor, dim, indices, value,
+                    ),
+                    dt => panic!("int_scatter: unsupported dtype {:?}", dt),
+                }
+            }
             burn_backend::tensor::IndexingUpdateOp::Add => {
                 Self::int_scatter_add(dim, tensor, indices, value)
             }
@@ -332,6 +362,40 @@ impl IntTensorOps<Flex> for Flex {
         update: burn_backend::tensor::IndexingUpdateOp,
     ) -> IntTensor<Flex> {
         match update {
+            burn_backend::tensor::IndexingUpdateOp::Assign => {
+                debug_assert_eq!(
+                    tensor.dtype(),
+                    value.dtype(),
+                    "int_select_assign: dtype mismatch"
+                );
+                match tensor.dtype() {
+                    DType::I64 => crate::ops::gather_scatter::select_assign::<i64>(
+                        tensor, dim, indices, value,
+                    ),
+                    DType::I32 => crate::ops::gather_scatter::select_assign::<i32>(
+                        tensor, dim, indices, value,
+                    ),
+                    DType::I16 => crate::ops::gather_scatter::select_assign::<i16>(
+                        tensor, dim, indices, value,
+                    ),
+                    DType::I8 => {
+                        crate::ops::gather_scatter::select_assign::<i8>(tensor, dim, indices, value)
+                    }
+                    DType::U64 => crate::ops::gather_scatter::select_assign::<u64>(
+                        tensor, dim, indices, value,
+                    ),
+                    DType::U32 => crate::ops::gather_scatter::select_assign::<u32>(
+                        tensor, dim, indices, value,
+                    ),
+                    DType::U16 => crate::ops::gather_scatter::select_assign::<u16>(
+                        tensor, dim, indices, value,
+                    ),
+                    DType::U8 => {
+                        crate::ops::gather_scatter::select_assign::<u8>(tensor, dim, indices, value)
+                    }
+                    dt => panic!("int_select_assign: unsupported dtype {:?}", dt),
+                }
+            }
             burn_backend::tensor::IndexingUpdateOp::Add => {
                 Self::int_select_add(tensor, dim, indices, value)
             }

--- a/crates/burn-tch/src/ops/base.rs
+++ b/crates/burn-tch/src/ops/base.rs
@@ -233,6 +233,20 @@ impl TchOps {
         TchTensor::from_existing(tensor, storage)
     }
 
+    pub fn scatter_assign(
+        dim: usize,
+        tensor: TchTensor,
+        indices: TchTensor,
+        value: TchTensor,
+    ) -> TchTensor {
+        let storage = tensor.storage.clone();
+        let tensor = tensor
+            .tensor
+            .scatter(dim as i64, &indices.tensor, &value.tensor);
+
+        TchTensor::from_existing(tensor, storage)
+    }
+
     pub fn scatter_mul(
         dim: usize,
         tensor: TchTensor,
@@ -356,6 +370,18 @@ impl TchOps {
         tensor.clone().unary_ops(
             |mut tensor| tensor.index_add_(dim as i64, &indices.tensor, &value.tensor),
             |tensor| tensor.index_add(dim as i64, &indices.tensor, &value.tensor),
+        )
+    }
+
+    pub fn select_assign_replace(
+        tensor: TchTensor,
+        dim: usize,
+        indices: TchTensor,
+        value: TchTensor,
+    ) -> TchTensor {
+        tensor.clone().unary_ops(
+            |mut tensor| tensor.index_copy_(dim as i64, &indices.tensor, &value.tensor),
+            |tensor| tensor.index_copy(dim as i64, &indices.tensor, &value.tensor),
         )
     }
 

--- a/crates/burn-tch/src/ops/int_tensor.rs
+++ b/crates/burn-tch/src/ops/int_tensor.rs
@@ -300,6 +300,9 @@ impl IntTensorOps<Self> for LibTorch {
         update: burn_backend::tensor::IndexingUpdateOp,
     ) -> TchTensor {
         match update {
+            burn_backend::tensor::IndexingUpdateOp::Assign => {
+                TchOps::scatter_assign(dim, tensor, indices, value)
+            }
             burn_backend::tensor::IndexingUpdateOp::Add => {
                 TchOps::scatter(dim, tensor, indices, value)
             }
@@ -344,6 +347,9 @@ impl IntTensorOps<Self> for LibTorch {
         update: burn_backend::tensor::IndexingUpdateOp,
     ) -> TchTensor {
         match update {
+            burn_backend::tensor::IndexingUpdateOp::Assign => {
+                TchOps::select_assign_replace(tensor, dim, indices, value)
+            }
             burn_backend::tensor::IndexingUpdateOp::Add => {
                 TchOps::select_assign(tensor, dim, indices, value)
             }

--- a/crates/burn-tch/src/ops/tensor.rs
+++ b/crates/burn-tch/src/ops/tensor.rs
@@ -211,6 +211,9 @@ impl FloatTensorOps<Self> for LibTorch {
         update: burn_backend::tensor::IndexingUpdateOp,
     ) -> TchTensor {
         match update {
+            burn_backend::tensor::IndexingUpdateOp::Assign => {
+                TchOps::scatter_assign(dim, tensor, indices, value)
+            }
             burn_backend::tensor::IndexingUpdateOp::Add => {
                 TchOps::scatter(dim, tensor, indices, value)
             }
@@ -255,6 +258,9 @@ impl FloatTensorOps<Self> for LibTorch {
         update: burn_backend::tensor::IndexingUpdateOp,
     ) -> TchTensor {
         match update {
+            burn_backend::tensor::IndexingUpdateOp::Assign => {
+                TchOps::select_assign_replace(tensor, dim, indices, value)
+            }
             burn_backend::tensor::IndexingUpdateOp::Add => {
                 TchOps::select_assign(tensor, dim, indices, value)
             }


### PR DESCRIPTION
## Motivation
`IndexingUpdateOp::Assign` is already part of the public indexing API and supported by NdArray and autodiff, but regular `scatter` and `select_assign` calls still panic on Flex, Tch, and CubeCL. Supporting overwrite updates consistently removes that backend-dependent limitation.

## Modifications
- add overwrite update paths for float and integer tensors on Flex
- use LibTorch scatter and index-copy primitives for Tch assignment updates
- wire CubeCL indexing kernels to the existing `AssignOp`
- enable the shared forward and autodiff assignment tests for all backends