### PR TITLE
perf(cubecl): offer `Gemm` on CPU for general matmuls

### DIFF
--- a/crates/burn-cubecl/src/kernel/matmul/tune/base.rs
+++ b/crates/burn-cubecl/src/kernel/matmul/tune/base.rs
@@ -326,9 +326,9 @@ pub fn matmul_autotune<R: CubeRuntime>(
             .group(&unit, move |_key| PRIORITY_MAX),
         );
 
-        // `Gemm` is not a vector routine, so restricting the gemv group to vector kinds left
-        // CPU without it. Registered again rather than grouped again: a group answering
-        // `PRIORITY_NEVER` drops the candidate whatever another group says.
+        // `Gemm` is not a vector routine, so restricting the gemv group to vector kinds removed
+        // it from general CPU matmuls. Register it independently for those workloads while
+        // keeping the gemv group vector-specific
         let cpu_gemm_general = Strategy::Gemm(BlueprintStrategy::Inferred(Default::default()));
         set = set.with(
             Tunable::new("gemm_cpu_general", move |(lhs, rhs, out)| {

--- a/crates/burn-cubecl/src/kernel/matmul/tune/base.rs
+++ b/crates/burn-cubecl/src/kernel/matmul/tune/base.rs
@@ -163,11 +163,11 @@ pub fn matmul_autotune<R: CubeRuntime>(
         });
 
         let gemv = TuneGroup::<MatmulAutotuneKey>::new("gemv", move |key| {
-            if num_cpu_cores.is_some() {
-                return PRIORITY_MAX;
-            }
-
             if matches!(key.analysis.kind, MatmulKind::MatVec) {
+                if num_cpu_cores.is_some() {
+                    return PRIORITY_MAX;
+                }
+
                 // LHS is the matrix
                 match key.definition.matrix_layout_lhs {
                     MatrixBatchLayout::Contiguous => PRIORITY_MAX,
@@ -184,6 +184,10 @@ pub fn matmul_autotune<R: CubeRuntime>(
                     MatrixBatchLayout::HighlyPermuted => PRIORITY_MAX,
                 }
             } else if matches!(key.analysis.kind, MatmulKind::VecMat) {
+                if num_cpu_cores.is_some() {
+                    return PRIORITY_MAX;
+                }
+
                 // RHS is the matrix
                 match key.definition.matrix_layout_rhs {
                     // We don't have good algos for row major vecmat.
@@ -320,6 +324,25 @@ pub fn matmul_autotune<R: CubeRuntime>(
                 },
             )
             .group(&unit, move |_key| PRIORITY_MAX),
+        );
+
+        // `Gemm` is not a vector routine, so the `gemv` group offers it only for the kinds
+        // that group serves. On CPU it is the fastest choice for the flat shapes pointwise
+        // convolutions produce, which are `General`, so it is offered there too.
+        //
+        // A second registration rather than a second group on the one above: a group
+        // answering `PRIORITY_NEVER` drops the candidate whatever another group says, and
+        // `gemv` answers that for every kind but its own.
+        let cpu_gemm_general = Strategy::Gemm(BlueprintStrategy::Inferred(Default::default()));
+        set = set.with(
+            Tunable::new("gemm_cpu_general", move |(lhs, rhs, out)| {
+                launch_matmul::<R, _>(&cpu_gemm_general, lhs, rhs, out)
+                    .map_err(|err| std::format!("{err:?}"))
+            })
+            .group(&cpu, move |key| match key.analysis.kind {
+                MatmulKind::General => PRIORITY_MAX,
+                _ => PRIORITY_NEVER,
+            }),
         );
 
         // CPU GEMM (CPU-only via the `cpu` group; the size limit is specific to this strategy).

--- a/crates/burn-cubecl/src/kernel/matmul/tune/base.rs
+++ b/crates/burn-cubecl/src/kernel/matmul/tune/base.rs
@@ -326,13 +326,9 @@ pub fn matmul_autotune<R: CubeRuntime>(
             .group(&unit, move |_key| PRIORITY_MAX),
         );
 
-        // `Gemm` is not a vector routine, so the `gemv` group offers it only for the kinds
-        // that group serves. On CPU it is the fastest choice for the flat shapes pointwise
-        // convolutions produce, which are `General`, so it is offered there too.
-        //
-        // A second registration rather than a second group on the one above: a group
-        // answering `PRIORITY_NEVER` drops the candidate whatever another group says, and
-        // `gemv` answers that for every kind but its own.
+        // `Gemm` is not a vector routine, so restricting the gemv group to vector kinds left
+        // CPU without it. Registered again rather than grouped again: a group answering
+        // `PRIORITY_NEVER` drops the candidate whatever another group says.
         let cpu_gemm_general = Strategy::Gemm(BlueprintStrategy::Inferred(Default::default()));
         set = set.with(
             Tunable::new("gemm_cpu_general", move |(lhs, rhs, out)| {

--- a/crates/burn-cubecl/src/kernel/matmul/tune/base.rs
+++ b/crates/burn-cubecl/src/kernel/matmul/tune/base.rs
@@ -163,11 +163,11 @@ pub fn matmul_autotune<R: CubeRuntime>(
         });
 
         let gemv = TuneGroup::<MatmulAutotuneKey>::new("gemv", move |key| {
-            if matches!(key.analysis.kind, MatmulKind::MatVec) {
-                if num_cpu_cores.is_some() {
-                    return PRIORITY_MAX;
-                }
+            if num_cpu_cores.is_some() {
+                return PRIORITY_MAX;
+            }
 
+            if matches!(key.analysis.kind, MatmulKind::MatVec) {
                 // LHS is the matrix
                 match key.definition.matrix_layout_lhs {
                     MatrixBatchLayout::Contiguous => PRIORITY_MAX,
@@ -184,10 +184,6 @@ pub fn matmul_autotune<R: CubeRuntime>(
                     MatrixBatchLayout::HighlyPermuted => PRIORITY_MAX,
                 }
             } else if matches!(key.analysis.kind, MatmulKind::VecMat) {
-                if num_cpu_cores.is_some() {
-                    return PRIORITY_MAX;
-                }
-
                 // RHS is the matrix
                 match key.definition.matrix_layout_rhs {
                     // We don't have good algos for row major vecmat.


### PR DESCRIPTION
Gives `Strategy::Gemm` a CPU priority for `General` matmuls. #5423 stays as it is.

#5423 restricted the gemv tune group to `MatVec` and `VecMat`, which is right for the
vector routines that group serves. `Gemm` is registered in it too and is not one of them,
so the restriction dropped it for general shapes along with them.

`Gemm` is registered a second time, in the `unit` group, and that does not rescue it. The
tuner benchmarks the first batch that lands a successful launch and then stops. Batches go
by group priority, the `cpu` group answers `PRIORITY_MAX` for every key, and `cpu_gemm`
declines nothing, so the top batch always succeeds and `unit` is never reached on CPU. The
gemv registration was reaching general shapes only because that group also answered
`PRIORITY_MAX` on CPU, which put it in the same top batch. Registering inside the `cpu`
group is therefore what makes a candidate reachable there.

That is worth stating plainly: on CPU the `cpu` group is winner-take-all, so `matmul_naive`,
`SimpleUnit` and `DoubleUnit` are never benchmarked either, under any kind. This PR fixes
the shape class that regressed rather than that, since letting the two groups batch together
is a behaviour change for every CPU matmul and wants its own measurements.

Pointwise convolutions produce flat shapes, and #5429 routes them through matmul, so
resnet50 meets several per bottleneck block. Logging the tuner over a resnet50 inference,
all 15 shapes it tunes pick `Gemm` when it is offered, and fall back to `cpu_gemm` when
it is not: 1024x128x512, 1024x256x512, 1024x512x128, 1024x512x256, 256x1024x256,
256x1024x512, 256x256x1024, 256x512x1024, 4096x128x256, 4096x256x64, 4096x64x256,
4096x64x64, 64x2048x1024, 64x2048x512, 64x512x2048.

`cpu_gemm` is not always the loser, it wins other shapes I measured, so this adds a
candidate rather than replacing one. End to end on cubecl-cpu, median of 3, fresh
autotune environment per binary:

| workload | main | this branch |
|---|---|---|
| mobilenetv3-small b1 | 40.1 ms | 39.1 ms |
| resnet50 b1 | 254.6 ms | 178.6 ms (-30%) |
| resnet50 b8 | 1477.7 ms | 873.7 ms (-41%) |

## The crash the guard was added for is already fixed

I started from the revert, so I checked what #5419's stack overflow actually was before
touching the guard. Two things came out of it, and they are why this PR is narrow rather
than a revert.

The overflow is stack consumption equal to the input size, not the "task partition
bisection" the issue names: there is no recursion or task partitioning in the CPU
threadpool, and a multi million cube launch is one native call walking the whole grid on
one worker's fixed stack. On burn 0.21 it crashes at n = 5,592,405 with the default
64 MiB stack and at n = 1,400,000 with a 16 MiB one, which is 64 MiB and 16 MiB of data
respectively.

That size dependence is gone on main. At the 16 MiB stack floor, main passes 16,777,216
rows, 192 MiB of data on twelve times less stack. If the mechanism survived in any form,
quartering the stack would pull the crash down to about 1.4M rows the way it does on
0.21. Confirmed on two machines.

Bisecting at 16,777,216 rows against a 16 MiB stack, reading the whole output the way the
reporter's program does:

| burn | date | result |
|---|---|---|
| v0.21.0 | 05-08 | crashes |
| `b9c6bdb3d` | 05-20 | crashes |
| `d5e145f7f` | 05-22 | clean |
| `bbb4ffc68` 0.22.0-pre.2 | 08-10 | crashes again |
| `5828a3a18` Migrate to pliron (#5324) | 08-12 | clean |
| `13f0a12b7`, the commit before #5423 | 08-25 | clean |

So it was fixed twice. Something in May changed which kernel the tall shape lands on
while the leak survived underneath, routing moved back onto the leaky path by
0.22.0-pre.2, and #5324 removed the leak itself, two weeks before #5423 landed.

With the guard removed, the tall shape's autotune still selects and runs the kernel that
used to overflow (`vecmat_unit_perpendicular`, 464 ms, no crash), and `cpu_gemm` wins it
at 7.19 ms either way. So the guard is not what keeps that shape working, and removing it
would not make it slow.

I am not proposing the revert anyway: this PR reaches the same kernel on all 15 shapes
while leaving the gemv group, the GPU groups and every other kind alone, so the narrow
form gives nothing up. #5423's dispatch argument and its two regression tests stand.

Unrelated, found while measuring, and not addressed here:

- `cubecl-cpu` advertises `max_cube_count = (u32::MAX, u32::MAX, u32::MAX)`, so nothing
  ever splits an enormous launch even though a single thread walks the whole grid. GPU
  backends report real limits, which forces tiling.
- `MAX_STACK_SIZE` in the CPU scheduler is applied as a floor via `.max()` despite its
  name, so there is no upper bound on worker stack size.
- On a tall `[N,3] x [3,3]` the calculated autotune bound was 2.14 ms while candidates
  ran 464 ms, so the early short circuit never fired.
