### PR TITLE
feat(tensor)!: add multi-axis vector norm variants and update empty max_abs_dims semantics

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/float/linalg/vector_norm.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/linalg/vector_norm.rs
@@ -497,3 +497,51 @@ fn test_multi_axis_negative_dimensions() {
         .into_data()
         .assert_approx_eq::<FloatElem>(&expected, tolerance);
 }
+
+#[test]
+fn test_empty_dims() {
+    let x = TestTensor::<2>::from([[1., 2.], [3., 4.]]);
+    let expected = x.clone().into_data();
+
+    linalg::vector_norm_dims(x.clone(), linalg::Norm::L2, &[] as &[usize])
+        .into_data()
+        .assert_eq(&expected, true);
+
+    linalg::lp_norm_dims(x.clone(), 2.0, &[] as &[usize])
+        .into_data()
+        .assert_eq(&expected, true);
+
+    linalg::l1_norm_dims(x.clone(), &[] as &[usize])
+        .into_data()
+        .assert_eq(&expected, true);
+
+    linalg::l2_norm_dims(x.clone(), &[] as &[usize])
+        .into_data()
+        .assert_eq(&expected, true);
+
+    linalg::max_abs_norm_dims(x.clone(), &[] as &[usize])
+        .into_data()
+        .assert_eq(&expected, true);
+
+    linalg::min_abs_norm_dims(x.clone(), &[] as &[usize])
+        .into_data()
+        .assert_eq(&expected, true);
+
+    linalg::l0_norm_dims(x, &[] as &[usize])
+        .into_data()
+        .assert_eq(&expected, true);
+}
+
+#[test]
+#[should_panic(expected = "Vector Normalize")]
+fn test_vector_normalize_panic() {
+    let x = TestTensor::<2>::from([[1., 2.], [3., 4.]]);
+    let _ = linalg::vector_normalize(x, 1.0, 5, 1e-5);
+}
+
+#[test]
+#[should_panic(expected = "Vector Norm")]
+fn test_vector_norm_panic() {
+    let x = TestTensor::<2>::from([[1., 2.], [3., 4.]]);
+    let _ = linalg::vector_norm(x, linalg::Norm::L2, 5);
+}

--- a/crates/burn-backend-tests/tests/tensor/float/linalg/vector_norm.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/linalg/vector_norm.rs
@@ -1,4 +1,5 @@
 use super::*;
+use burn_tensor::Shape;
 use burn_tensor::TensorData;
 use burn_tensor::Tolerance;
 use burn_tensor::linalg;
@@ -279,4 +280,220 @@ fn test_negative_dimension() {
     linalg::min_abs_norm(x, -1)
         .into_data()
         .assert_eq(&expected, true);
+}
+
+#[test]
+fn test_spatial_multi_axis_reduction() {
+    let device = Default::default();
+    let x = TestTensor::<4>::ones([2, 3, 4, 5], &device);
+
+    let out_l1 = linalg::l1_norm_dims(x.clone(), &[2, 3]);
+    assert_eq!(out_l1.shape(), Shape::new([2, 3, 1, 1]));
+
+    let out_l2 = linalg::l2_norm_dims(x.clone(), &[2, 3]);
+    assert_eq!(out_l2.shape(), Shape::new([2, 3, 1, 1]));
+
+    let out_lp = linalg::lp_norm_dims(x.clone(), 3.0, &[2, 3]);
+    assert_eq!(out_lp.shape(), Shape::new([2, 3, 1, 1]));
+
+    let out_max = linalg::max_abs_norm_dims(x.clone(), &[2, 3]);
+    assert_eq!(out_max.shape(), Shape::new([2, 3, 1, 1]));
+
+    let out_min = linalg::min_abs_norm_dims(x.clone(), &[2, 3]);
+    assert_eq!(out_min.shape(), Shape::new([2, 3, 1, 1]));
+
+    let out_l0 = linalg::l0_norm_dims(x.clone(), &[2, 3]);
+    assert_eq!(out_l0.shape(), Shape::new([2, 3, 1, 1]));
+
+    let out_vec = linalg::vector_norm_dims(x, linalg::Norm::L2, &[2, 3]);
+    assert_eq!(out_vec.shape(), Shape::new([2, 3, 1, 1]));
+}
+
+#[test]
+fn test_multi_axis_numerical_equivalence() {
+    let tolerance = Tolerance::relative(1e-5).set_half_precision_relative(2e-3);
+    let x = TestTensor::<3>::from([
+        [
+            [1.0, -2.0, 3.0, -4.0],
+            [5.0, -6.0, 7.0, -8.0],
+            [9.0, -10.0, 11.0, -12.0],
+        ],
+        [
+            [-13.0, 14.0, -15.0, 16.0],
+            [-17.0, 18.0, -19.0, 20.0],
+            [-21.0, 22.0, -23.0, 24.0],
+        ],
+    ]);
+
+    // L1 norm
+    let expected_l1 = x.clone().abs().sum_dims(&[1, 2]).into_data();
+    linalg::l1_norm_dims(x.clone(), &[1, 2])
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected_l1, tolerance);
+    linalg::vector_norm_dims(x.clone(), linalg::Norm::L1, &[1, 2])
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected_l1, tolerance);
+
+    // L2 norm
+    let expected_l2 = x.clone().square().sum_dims(&[1, 2]).sqrt().into_data();
+    linalg::l2_norm_dims(x.clone(), &[1, 2])
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected_l2, tolerance);
+    linalg::vector_norm_dims(x.clone(), linalg::Norm::L2, &[1, 2])
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected_l2, tolerance);
+
+    // Lp norm: even integer p = 4.0
+    let expected_p4 = x
+        .clone()
+        .powi_scalar(4)
+        .sum_dims(&[1, 2])
+        .powf_scalar(1.0 / 4.0)
+        .into_data();
+    linalg::lp_norm_dims(x.clone(), 4.0, &[1, 2])
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected_p4, tolerance);
+    linalg::vector_norm_dims(x.clone(), 4, &[1, 2])
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected_p4, tolerance);
+
+    // Lp norm: odd integer p = 3.0
+    let expected_p3 = x
+        .clone()
+        .abs()
+        .powf_scalar(3.0)
+        .sum_dims(&[1, 2])
+        .powf_scalar(1.0 / 3.0)
+        .into_data();
+    linalg::lp_norm_dims(x.clone(), 3.0, &[1, 2])
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected_p3, tolerance);
+    linalg::vector_norm_dims(x.clone(), 3, &[1, 2])
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected_p3, tolerance);
+
+    // Lp norm: non-integer p = 1.5
+    let expected_p1_5 = x
+        .clone()
+        .abs()
+        .powf_scalar(1.5)
+        .sum_dims(&[1, 2])
+        .powf_scalar(1.0 / 1.5)
+        .into_data();
+    linalg::lp_norm_dims(x.clone(), 1.5, &[1, 2])
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected_p1_5, tolerance);
+    linalg::vector_norm_dims(x.clone(), 1.5, &[1, 2])
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected_p1_5, tolerance);
+
+    // MaxAbs (LInf) norm
+    let expected_max = x.clone().abs().max_dim(1).max_dim(2).into_data();
+    linalg::max_abs_norm_dims(x.clone(), &[1, 2])
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected_max, tolerance);
+    linalg::vector_norm_dims(x.clone(), linalg::Norm::LInf, &[1, 2])
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected_max, tolerance);
+
+    // MinAbs (LNegInf) norm
+    let expected_min = x.clone().abs().min_dim(1).min_dim(2).into_data();
+    linalg::min_abs_norm_dims(x.clone(), &[1, 2])
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected_min, tolerance);
+    linalg::vector_norm_dims(x.clone(), linalg::Norm::LNegInf, &[1, 2])
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected_min, tolerance);
+
+    // L0 norm
+    let expected_l0 = x
+        .clone()
+        .zeros_like()
+        .mask_fill(x.clone().not_equal_scalar(0), 1)
+        .sum_dims(&[1, 2])
+        .into_data();
+    linalg::l0_norm_dims(x.clone(), &[1, 2])
+        .into_data()
+        .assert_eq(&expected_l0, true);
+    linalg::vector_norm_dims(x.clone(), linalg::Norm::L0, &[1, 2])
+        .into_data()
+        .assert_eq(&expected_l0, true);
+}
+
+#[test]
+fn test_single_vs_multi_equivalence() {
+    let tolerance = Tolerance::relative(1e-5).set_half_precision_relative(1e-3);
+    let x = TestTensor::<2>::from([[1., -2.], [3., 4.]]);
+
+    // L1
+    let single = linalg::l1_norm(x.clone(), 1).into_data();
+    let multi = linalg::l1_norm_dims(x.clone(), &[1]).into_data();
+    single.assert_eq(&multi, true);
+
+    // L2
+    let single = linalg::l2_norm(x.clone(), 1).into_data();
+    let multi = linalg::l2_norm_dims(x.clone(), &[1]).into_data();
+    single.assert_approx_eq::<FloatElem>(&multi, tolerance);
+
+    // Lp
+    let single = linalg::lp_norm(x.clone(), 3.0, 1).into_data();
+    let multi = linalg::lp_norm_dims(x.clone(), 3.0, &[1]).into_data();
+    single.assert_approx_eq::<FloatElem>(&multi, tolerance);
+
+    // MaxAbs
+    let single = linalg::max_abs_norm(x.clone(), 1).into_data();
+    let multi = linalg::max_abs_norm_dims(x.clone(), &[1]).into_data();
+    single.assert_eq(&multi, true);
+
+    // MinAbs
+    let single = linalg::min_abs_norm(x.clone(), 1).into_data();
+    let multi = linalg::min_abs_norm_dims(x.clone(), &[1]).into_data();
+    single.assert_eq(&multi, true);
+
+    // L0
+    let single = linalg::l0_norm(x.clone(), 1).into_data();
+    let multi = linalg::l0_norm_dims(x.clone(), &[1]).into_data();
+    single.assert_eq(&multi, true);
+
+    // Vector norm
+    let single = linalg::vector_norm(x.clone(), linalg::Norm::L2, 1).into_data();
+    let multi = linalg::vector_norm_dims(x, linalg::Norm::L2, &[1]).into_data();
+    single.assert_approx_eq::<FloatElem>(&multi, tolerance);
+}
+
+#[test]
+fn test_multi_axis_negative_dimensions() {
+    let tolerance = Tolerance::relative(1e-5).set_half_precision_relative(1e-3);
+    let x = TestTensor::<3>::from([
+        [
+            [1.0, -2.0, 3.0, -4.0],
+            [5.0, -6.0, 7.0, -8.0],
+            [9.0, -10.0, 11.0, -12.0],
+        ],
+        [
+            [-13.0, 14.0, -15.0, 16.0],
+            [-17.0, 18.0, -19.0, 20.0],
+            [-21.0, 22.0, -23.0, 24.0],
+        ],
+    ]);
+
+    let expected = linalg::l2_norm_dims(x.clone(), &[1, 2]).into_data();
+    linalg::l2_norm_dims(x.clone(), &[-2, -1])
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, tolerance);
+
+    let expected = linalg::l1_norm_dims(x.clone(), &[1, 2]).into_data();
+    linalg::l1_norm_dims(x.clone(), &[-2, -1])
+        .into_data()
+        .assert_eq(&expected, true);
+
+    let expected = linalg::max_abs_norm_dims(x.clone(), &[1, 2]).into_data();
+    linalg::max_abs_norm_dims(x.clone(), &[-2, -1])
+        .into_data()
+        .assert_eq(&expected, true);
+
+    let expected = linalg::lp_norm_dims(x.clone(), 3.0, &[1, 2]).into_data();
+    linalg::lp_norm_dims(x, 3.0, &[-2, -1])
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, tolerance);
 }

--- a/crates/burn-backend-tests/tests/tensor/float/linalg/vector_norm.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/linalg/vector_norm.rs
@@ -500,36 +500,75 @@ fn test_multi_axis_negative_dimensions() {
 
 #[test]
 fn test_empty_dims() {
-    let x = TestTensor::<2>::from([[1., 2.], [3., 4.]]);
-    let expected = x.clone().into_data();
+    let tolerance = Tolerance::relative(1e-5).set_half_precision_relative(1e-3);
+    let x = TestTensor::<1>::from([-2.0, 0.0, 3.0]);
+    let expected_abs = TestTensor::<1>::from([2.0, 0.0, 3.0]).into_data();
+    let expected_l0 = TestTensor::<1>::from([1.0, 0.0, 1.0]).into_data();
 
-    linalg::vector_norm_dims(x.clone(), linalg::Norm::L2, &[] as &[usize])
-        .into_data()
-        .assert_eq(&expected, true);
-
-    linalg::lp_norm_dims(x.clone(), 2.0, &[] as &[usize])
-        .into_data()
-        .assert_eq(&expected, true);
-
+    // L1 norm: elementwise absolute value
     linalg::l1_norm_dims(x.clone(), &[] as &[usize])
         .into_data()
-        .assert_eq(&expected, true);
+        .assert_eq(&expected_abs, true);
 
+    // L2 norm: elementwise absolute value
     linalg::l2_norm_dims(x.clone(), &[] as &[usize])
         .into_data()
-        .assert_eq(&expected, true);
+        .assert_approx_eq::<FloatElem>(&expected_abs, tolerance);
 
+    // L_infinity norm: elementwise absolute value
     linalg::max_abs_norm_dims(x.clone(), &[] as &[usize])
         .into_data()
-        .assert_eq(&expected, true);
+        .assert_eq(&expected_abs, true);
 
+    // L_neg_infinity norm: elementwise absolute value
     linalg::min_abs_norm_dims(x.clone(), &[] as &[usize])
         .into_data()
-        .assert_eq(&expected, true);
+        .assert_eq(&expected_abs, true);
 
-    linalg::l0_norm_dims(x, &[] as &[usize])
+    // Lp norm (odd and even p): elementwise absolute value
+    linalg::lp_norm_dims(x.clone(), 3.0, &[] as &[usize])
         .into_data()
-        .assert_eq(&expected, true);
+        .assert_approx_eq::<FloatElem>(&expected_abs, tolerance);
+    linalg::lp_norm_dims(x.clone(), 4.0, &[] as &[usize])
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected_abs, tolerance);
+
+    // Vector norm dispatch
+    linalg::vector_norm_dims(x.clone(), linalg::Norm::L1, &[] as &[usize])
+        .into_data()
+        .assert_eq(&expected_abs, true);
+    linalg::vector_norm_dims(x.clone(), linalg::Norm::L2, &[] as &[usize])
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected_abs, tolerance);
+    linalg::vector_norm_dims(x.clone(), linalg::Norm::LInf, &[] as &[usize])
+        .into_data()
+        .assert_eq(&expected_abs, true);
+
+    // L0 norm: elementwise non-zero indicator mask
+    linalg::l0_norm_dims(x.clone(), &[] as &[usize])
+        .into_data()
+        .assert_eq(&expected_l0, true);
+    linalg::vector_norm_dims(x, linalg::Norm::L0, &[] as &[usize])
+        .into_data()
+        .assert_eq(&expected_l0, true);
+
+    // Multi-dimensional tensor with empty dims
+    let x_2d = TestTensor::<2>::from([[-2.0, 0.0], [3.0, -4.0]]);
+    let expected_abs_2d = TestTensor::<2>::from([[2.0, 0.0], [3.0, 4.0]]).into_data();
+    let expected_l0_2d = TestTensor::<2>::from([[1.0, 0.0], [1.0, 1.0]]).into_data();
+
+    linalg::l1_norm_dims(x_2d.clone(), &[] as &[usize])
+        .into_data()
+        .assert_eq(&expected_abs_2d, true);
+    linalg::l2_norm_dims(x_2d.clone(), &[] as &[usize])
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected_abs_2d, tolerance);
+    linalg::max_abs_norm_dims(x_2d.clone(), &[] as &[usize])
+        .into_data()
+        .assert_eq(&expected_abs_2d, true);
+    linalg::l0_norm_dims(x_2d, &[] as &[usize])
+        .into_data()
+        .assert_eq(&expected_l0_2d, true);
 }
 
 #[test]

--- a/crates/burn-tensor/src/tensor/api/orderable.rs
+++ b/crates/burn-tensor/src/tensor/api/orderable.rs
@@ -774,6 +774,9 @@ where
     /// // [[9.0]]
     /// ```
     pub fn max_abs_dims<I: AsIndex>(self, dims: &[I]) -> Self {
+        if dims.is_empty() {
+            return self.abs();
+        }
         dims.iter()
             .fold(self, |tensor, &dim| tensor.max_abs_dim(dim))
     }

--- a/crates/burn-tensor/src/tensor/api/orderable.rs
+++ b/crates/burn-tensor/src/tensor/api/orderable.rs
@@ -773,6 +773,13 @@ where
     /// println!("{tensor}");
     /// // [[9.0]]
     /// ```
+    ///
+    /// # Empty dimensions
+    ///
+    /// Unlike ordinary reductions such as [`Tensor::max_dims`], this is a composite
+    /// operation equivalent to `self.abs().max_dims(dims)`. If `dims` is empty, no
+    /// reduction is performed, but the elementwise absolute-value operation is
+    /// still applied.
     pub fn max_abs_dims<I: AsIndex>(self, dims: &[I]) -> Self {
         if dims.is_empty() {
             return self.abs();

--- a/crates/burn-tensor/src/tensor/linalg/cosine_similarity.rs
+++ b/crates/burn-tensor/src/tensor/linalg/cosine_similarity.rs
@@ -38,8 +38,8 @@ pub fn cosine_similarity<const D: usize>(
     let dot_product = (x1.clone() * x2.clone()).sum_dim(dim);
 
     // Compute L2 norms: ||x1|| and ||x2||
-    let norm_x1 = l2_norm_impl(x1, dim);
-    let norm_x2 = l2_norm_impl(x2, dim);
+    let norm_x1 = l2_norm_impl(x1, &[dim]);
+    let norm_x2 = l2_norm_impl(x2, &[dim]);
 
     // Calculate the denominator (product of the norms) with epsilon to avoid division by zero
     let denominator = norm_x1.clamp_min(eps) * norm_x2.clamp_min(eps);

--- a/crates/burn-tensor/src/tensor/linalg/vector_norm.rs
+++ b/crates/burn-tensor/src/tensor/linalg/vector_norm.rs
@@ -4,6 +4,7 @@ use crate::{
     AsIndex, ElementConversion,
     kind::{Numeric, Ordered},
 };
+use alloc::vec::Vec;
 #[allow(unused_imports)]
 use num_traits::float::Float;
 /// Specifies the type of norm to compute.
@@ -98,6 +99,36 @@ impl From<f64> for Norm {
     }
 }
 
+/// Computes the vector norm of a tensor along specified dimensions.
+///
+/// Generic dispatch wrapper over specialized / optimized norms.
+///
+/// See:
+/// - [torch.linalg.vector_norm](https://pytorch.org/docs/stable/generated/torch.linalg.vector_norm.html)
+/// - [numpy.linalg.vector_norm](https://numpy.org/doc/stable/reference/generated/numpy.linalg.vector_norm.html)
+///
+/// # Arguments
+///
+/// * `x` - The input tensor.
+/// * `norm` - The selected norm.
+/// * `dims` - The dimensions to compute the norm over.
+///   Negative dimensions are supported and count from the end.
+///
+/// # Returns
+///
+/// The vector norm of the input tensor.
+pub fn vector_norm_dims<const D: usize, I: AsIndex>(
+    x: Tensor<D>,
+    norm: impl Into<Norm>,
+    dims: &[I],
+) -> Tensor<D> {
+    let dims: Vec<usize> = dims
+        .iter()
+        .map(|&d| unwrap_dim_index(d.try_dim_index(D), "Vector Norm"))
+        .collect();
+    vector_norm_impl(x, norm, &dims)
+}
+
 /// Computes the vector norm of a tensor along a specified dimension.
 ///
 /// Generic dispatch wrapper over specialized / optimized norms.
@@ -121,8 +152,43 @@ pub fn vector_norm<const D: usize>(
     norm: impl Into<Norm>,
     dim: impl AsIndex,
 ) -> Tensor<D> {
-    let dim = unwrap_dim_index(dim.try_dim_index(D), "Vector Norm");
-    lp_norm_impl(x, norm.into().to_exponent(), dim)
+    vector_norm_dims(x, norm, &[dim])
+}
+
+fn vector_norm_impl<const D: usize>(
+    x: Tensor<D>,
+    norm: impl Into<Norm>,
+    dims: &[usize],
+) -> Tensor<D> {
+    lp_norm_impl(x, norm.into().to_exponent(), dims)
+}
+
+/// Computes the general ``L(p)`` norm of a tensor along specified dimensions.
+///
+/// Uses the specialized implementations for:
+/// * 0.0
+/// * 1.0
+/// * 2.0
+/// * 2 * N for integral N,
+/// * f64::INFINITY,
+/// * f64::NEG_INFINITY,
+///
+/// # Arguments
+///
+/// * `x` - The input tensor.
+/// * `p` - The exponent of the Lp norm.
+/// * `dims` - The dimensions to compute the norm over.
+///   Negative dimensions are supported and count from the end.
+///
+/// # Returns
+///
+/// The ``L(p)`` norm of the input tensor.
+pub fn lp_norm_dims<const D: usize, I: AsIndex>(x: Tensor<D>, p: f64, dims: &[I]) -> Tensor<D> {
+    let dims: Vec<usize> = dims
+        .iter()
+        .map(|&d| unwrap_dim_index(d.try_dim_index(D), "Lp Norm"))
+        .collect();
+    lp_norm_impl(x, p, &dims)
 }
 
 /// Computes the general ``L(p)`` norm of a tensor along a specified dimension.
@@ -146,19 +212,18 @@ pub fn vector_norm<const D: usize>(
 ///
 /// The ``L(p)`` norm of the input tensor.
 pub fn lp_norm<const D: usize>(x: Tensor<D>, p: f64, dim: impl AsIndex) -> Tensor<D> {
-    let dim = unwrap_dim_index(dim.try_dim_index(D), "Lp Norm");
-    lp_norm_impl(x, p, dim)
+    lp_norm_dims(x, p, &[dim])
 }
 
-fn lp_norm_impl<const D: usize>(x: Tensor<D>, p: f64, dim: usize) -> Tensor<D> {
+fn lp_norm_impl<const D: usize>(x: Tensor<D>, p: f64, dims: &[usize]) -> Tensor<D> {
     match p {
-        0.0 => l0_norm_impl(x, dim),
-        1.0 => l1_norm_impl(x, dim),
-        2.0 => l2_norm_impl(x, dim),
-        p if is_even_integer(p) => lp_signed_norm(x, p as u32, dim),
-        f64::INFINITY => max_abs_norm_impl(x, dim),
-        f64::NEG_INFINITY => min_abs_norm_impl(x, dim),
-        _ => lp_norm_base(x, p, dim),
+        0.0 => l0_norm_impl(x, dims),
+        1.0 => l1_norm_impl(x, dims),
+        2.0 => l2_norm_impl(x, dims),
+        p if is_even_integer(p) => lp_signed_norm(x, p as u32, dims),
+        f64::INFINITY => max_abs_norm_impl(x, dims),
+        f64::NEG_INFINITY => min_abs_norm_impl(x, dims),
+        _ => lp_norm_base(x, p, dims),
     }
 }
 
@@ -183,9 +248,30 @@ pub fn vector_normalize<const D: usize, E: ElementConversion>(
     dim: impl AsIndex,
     eps: E,
 ) -> Tensor<D> {
-    let dim = unwrap_dim_index(dim.try_dim_index(D), "Vector Normalize");
-    let norm = lp_norm_impl(x.clone(), norm.into().to_exponent(), dim).clamp_min(eps);
+    let norm = vector_norm(x.clone(), norm, dim).clamp_min(eps);
     x / norm
+}
+
+/// Computes the L0 norm of a tensor along specified dimensions.
+///
+/// # Arguments
+///
+/// * `x` - The input tensor.
+/// * `dims` - The dimensions to compute the norm over.
+///   Negative dimensions are supported and count from the end.
+///
+/// # Returns
+///
+/// The L0 norm of the input tensor.
+pub fn l0_norm_dims<const D: usize, K, I: AsIndex>(x: Tensor<D, K>, dims: &[I]) -> Tensor<D, K>
+where
+    K: Numeric,
+{
+    let dims: Vec<usize> = dims
+        .iter()
+        .map(|&d| unwrap_dim_index(d.try_dim_index(D), "L0 Norm"))
+        .collect();
+    l0_norm_impl(x, &dims)
 }
 
 /// Computes the L0 norm of a tensor along a specified dimension.
@@ -203,17 +289,40 @@ pub fn l0_norm<const D: usize, K>(x: Tensor<D, K>, dim: impl AsIndex) -> Tensor<
 where
     K: Numeric,
 {
-    let dim = unwrap_dim_index(dim.try_dim_index(D), "L0 Norm");
-    l0_norm_impl(x, dim)
+    l0_norm_dims(x, &[dim])
 }
 
-fn l0_norm_impl<const D: usize, K>(x: Tensor<D, K>, dim: usize) -> Tensor<D, K>
+fn l0_norm_impl<const D: usize, K>(x: Tensor<D, K>, dims: &[usize]) -> Tensor<D, K>
 where
     K: Numeric,
 {
     x.zeros_like()
         .mask_fill(x.not_equal_scalar(0), 1)
-        .sum_dim(dim)
+        .sum_dims(dims)
+}
+
+/// Computes the L1 norm of a tensor along specified dimensions.
+///
+/// This is a convenience function that wraps `vector_norm_dims` with `p = 1.0`.
+///
+/// # Arguments
+///
+/// * `x` - The input tensor.
+/// * `dims` - The dimensions to compute the norm over.
+///   Negative dimensions are supported and count from the end.
+///
+/// # Returns
+///
+/// The L1 norm of the input tensor.
+pub fn l1_norm_dims<const D: usize, K, I: AsIndex>(x: Tensor<D, K>, dims: &[I]) -> Tensor<D, K>
+where
+    K: Numeric,
+{
+    let dims: Vec<usize> = dims
+        .iter()
+        .map(|&d| unwrap_dim_index(d.try_dim_index(D), "L1 Norm"))
+        .collect();
+    l1_norm_impl(x, &dims)
 }
 
 /// Computes the L1 norm of a tensor along a specified dimension.
@@ -233,15 +342,33 @@ pub fn l1_norm<const D: usize, K>(x: Tensor<D, K>, dim: impl AsIndex) -> Tensor<
 where
     K: Numeric,
 {
-    let dim = unwrap_dim_index(dim.try_dim_index(D), "L1 Norm");
-    l1_norm_impl(x, dim)
+    l1_norm_dims(x, &[dim])
 }
 
-fn l1_norm_impl<const D: usize, K>(x: Tensor<D, K>, dim: usize) -> Tensor<D, K>
+fn l1_norm_impl<const D: usize, K>(x: Tensor<D, K>, dims: &[usize]) -> Tensor<D, K>
 where
     K: Numeric,
 {
-    x.abs().sum_dim(dim)
+    x.abs().sum_dims(dims)
+}
+
+/// Computes the L2 norm of a tensor along specified dimensions.
+///
+/// # Arguments
+///
+/// * `x` - The input tensor.
+/// * `dims` - The dimensions to compute the norm over.
+///   Negative dimensions are supported and count from the end.
+///
+/// # Returns
+///
+/// The L2 norm of the input tensor.
+pub fn l2_norm_dims<const D: usize, I: AsIndex>(x: Tensor<D>, dims: &[I]) -> Tensor<D> {
+    let dims: Vec<usize> = dims
+        .iter()
+        .map(|&d| unwrap_dim_index(d.try_dim_index(D), "L2 Norm"))
+        .collect();
+    l2_norm_impl(x, &dims)
 }
 
 /// Computes the L2 norm of a tensor along a specified dimension.
@@ -256,12 +383,11 @@ where
 ///
 /// The L2 norm of the input tensor.
 pub fn l2_norm<const D: usize>(x: Tensor<D>, dim: impl AsIndex) -> Tensor<D> {
-    let dim = unwrap_dim_index(dim.try_dim_index(D), "L2 Norm");
-    l2_norm_impl(x, dim)
+    l2_norm_dims(x, &[dim])
 }
 
-pub(super) fn l2_norm_impl<const D: usize>(x: Tensor<D>, dim: usize) -> Tensor<D> {
-    x.square().sum_dim(dim).sqrt()
+pub(super) fn l2_norm_impl<const D: usize>(x: Tensor<D>, dims: &[usize]) -> Tensor<D> {
+    x.square().sum_dims(dims).sqrt()
 }
 
 fn is_even_integer(x: f64) -> bool {
@@ -271,8 +397,8 @@ fn is_even_integer(x: f64) -> bool {
 /// Computes ``L(2*n)`` for even integer ``n``.
 ///
 /// This lets us skip the abs.
-fn lp_signed_norm<const D: usize>(x: Tensor<D>, p: u32, dim: usize) -> Tensor<D> {
-    x.powi_scalar(p).sum_dim(dim).powf_scalar(1. / (p as f64))
+fn lp_signed_norm<const D: usize>(x: Tensor<D>, p: u32, dims: &[usize]) -> Tensor<D> {
+    x.powi_scalar(p).sum_dims(dims).powf_scalar(1. / (p as f64))
 }
 
 /// Computes the general ``L(p)`` using the generalized method.
@@ -281,8 +407,30 @@ fn lp_signed_norm<const D: usize>(x: Tensor<D>, p: u32, dim: usize) -> Tensor<D>
 /// * 0.0
 /// * f64::INFINITY,
 /// * f64::NEG_INFINITY,
-fn lp_norm_base<const D: usize>(x: Tensor<D>, p: f64, dim: usize) -> Tensor<D> {
-    x.abs().powf_scalar(p).sum_dim(dim).powf_scalar(1. / p)
+fn lp_norm_base<const D: usize>(x: Tensor<D>, p: f64, dims: &[usize]) -> Tensor<D> {
+    x.abs().powf_scalar(p).sum_dims(dims).powf_scalar(1. / p)
+}
+
+/// Computes the L:INFINITY norm of a tensor along specified dimensions.
+///
+/// # Arguments
+///
+/// * `x` - The input tensor.
+/// * `dims` - The dimensions to compute the norm over.
+///   Negative dimensions are supported and count from the end.
+///
+/// # Returns
+///
+/// The L:INFINITY norm of the input tensor.
+pub fn max_abs_norm_dims<const D: usize, K, I: AsIndex>(x: Tensor<D, K>, dims: &[I]) -> Tensor<D, K>
+where
+    K: Ordered,
+{
+    let dims: Vec<usize> = dims
+        .iter()
+        .map(|&d| unwrap_dim_index(d.try_dim_index(D), "Max Abs Norm"))
+        .collect();
+    max_abs_norm_impl(x, &dims)
 }
 
 /// Computes the L:INFINITY norm of a tensor along a specified dimension.
@@ -300,15 +448,37 @@ pub fn max_abs_norm<const D: usize, K>(x: Tensor<D, K>, dim: impl AsIndex) -> Te
 where
     K: Ordered,
 {
-    let dim = unwrap_dim_index(dim.try_dim_index(D), "Max Abs Norm");
-    max_abs_norm_impl(x, dim)
+    max_abs_norm_dims(x, &[dim])
 }
 
-fn max_abs_norm_impl<const D: usize, K>(x: Tensor<D, K>, dim: usize) -> Tensor<D, K>
+fn max_abs_norm_impl<const D: usize, K>(x: Tensor<D, K>, dims: &[usize]) -> Tensor<D, K>
 where
     K: Ordered,
 {
-    x.max_abs_dim(dim)
+    dims.iter()
+        .fold(x.abs(), |tensor, &dim| tensor.max_dim(dim))
+}
+
+/// Computes the L:NEG_INFINITY norm of a tensor along specified dimensions.
+///
+/// # Arguments
+///
+/// * `x` - The input tensor.
+/// * `dims` - The dimensions to compute the norm over.
+///   Negative dimensions are supported and count from the end.
+///
+/// # Returns
+///
+/// The L:NEG_INFINITY norm of the input tensor.
+pub fn min_abs_norm_dims<const D: usize, K, I: AsIndex>(x: Tensor<D, K>, dims: &[I]) -> Tensor<D, K>
+where
+    K: Ordered,
+{
+    let dims: Vec<usize> = dims
+        .iter()
+        .map(|&d| unwrap_dim_index(d.try_dim_index(D), "Min Abs Norm"))
+        .collect();
+    min_abs_norm_impl(x, &dims)
 }
 
 /// Computes the L:NEG_INFINITY norm of a tensor along a specified dimension.
@@ -326,13 +496,13 @@ pub fn min_abs_norm<const D: usize, K>(x: Tensor<D, K>, dim: impl AsIndex) -> Te
 where
     K: Ordered,
 {
-    let dim = unwrap_dim_index(dim.try_dim_index(D), "Min Abs Norm");
-    min_abs_norm_impl(x, dim)
+    min_abs_norm_dims(x, &[dim])
 }
 
-fn min_abs_norm_impl<const D: usize, K>(x: Tensor<D, K>, dim: usize) -> Tensor<D, K>
+fn min_abs_norm_impl<const D: usize, K>(x: Tensor<D, K>, dims: &[usize]) -> Tensor<D, K>
 where
     K: Ordered,
 {
-    x.abs().min_dim(dim)
+    dims.iter()
+        .fold(x.abs(), |tensor, &dim| tensor.min_dim(dim))
 }

--- a/crates/burn-tensor/src/tensor/linalg/vector_norm.rs
+++ b/crates/burn-tensor/src/tensor/linalg/vector_norm.rs
@@ -103,6 +103,9 @@ impl From<f64> for Norm {
 ///
 /// Generic dispatch wrapper over specialized / optimized norms.
 ///
+/// If `dims` is empty, no dimensions are reduced, matching ONNX `noop_with_empty_axes=true`
+/// semantics (the norm transformation is applied elementwise without collapsing axes).
+///
 /// See:
 /// - [torch.linalg.vector_norm](https://pytorch.org/docs/stable/generated/torch.linalg.vector_norm.html)
 /// - [numpy.linalg.vector_norm](https://numpy.org/doc/stable/reference/generated/numpy.linalg.vector_norm.html)
@@ -122,9 +125,6 @@ pub fn vector_norm_dims<const D: usize, I: AsIndex>(
     norm: impl Into<Norm>,
     dims: &[I],
 ) -> Tensor<D> {
-    if dims.is_empty() {
-        return x;
-    }
     if dims.len() == 1 {
         let dim = unwrap_dim_index(dims[0].try_dim_index(D), "Vector Norm");
         return vector_norm_impl(x, norm, &[dim]);
@@ -173,6 +173,9 @@ fn vector_norm_impl<const D: usize>(
 
 /// Computes the general ``L(p)`` norm of a tensor along specified dimensions.
 ///
+/// If `dims` is empty, no dimensions are reduced, matching ONNX `noop_with_empty_axes=true`
+/// semantics (the norm transformation is applied elementwise without collapsing axes).
+///
 /// Uses the specialized implementations for:
 /// * 0.0
 /// * 1.0
@@ -192,9 +195,6 @@ fn vector_norm_impl<const D: usize>(
 ///
 /// The ``L(p)`` norm of the input tensor.
 pub fn lp_norm_dims<const D: usize, I: AsIndex>(x: Tensor<D>, p: f64, dims: &[I]) -> Tensor<D> {
-    if dims.is_empty() {
-        return x;
-    }
     if dims.len() == 1 {
         let dim = unwrap_dim_index(dims[0].try_dim_index(D), "Lp Norm");
         return lp_norm_impl(x, p, &[dim]);
@@ -271,6 +271,9 @@ pub fn vector_normalize<const D: usize, E: ElementConversion>(
 
 /// Computes the L0 norm of a tensor along specified dimensions.
 ///
+/// If `dims` is empty, no dimensions are reduced, matching ONNX `noop_with_empty_axes=true`
+/// semantics (the norm transformation is applied elementwise without collapsing axes).
+///
 /// # Arguments
 ///
 /// * `x` - The input tensor.
@@ -284,9 +287,6 @@ pub fn l0_norm_dims<const D: usize, K, I: AsIndex>(x: Tensor<D, K>, dims: &[I]) 
 where
     K: Numeric,
 {
-    if dims.is_empty() {
-        return x;
-    }
     if dims.len() == 1 {
         let dim = unwrap_dim_index(dims[0].try_dim_index(D), "L0 Norm");
         return l0_norm_impl(x, &[dim]);
@@ -328,6 +328,9 @@ where
 
 /// Computes the L1 norm of a tensor along specified dimensions.
 ///
+/// If `dims` is empty, no dimensions are reduced, matching ONNX `noop_with_empty_axes=true`
+/// semantics (the norm transformation is applied elementwise without collapsing axes).
+///
 /// This is a convenience function that wraps `vector_norm_dims` with `p = 1.0`.
 ///
 /// # Arguments
@@ -343,9 +346,6 @@ pub fn l1_norm_dims<const D: usize, K, I: AsIndex>(x: Tensor<D, K>, dims: &[I]) 
 where
     K: Numeric,
 {
-    if dims.is_empty() {
-        return x;
-    }
     if dims.len() == 1 {
         let dim = unwrap_dim_index(dims[0].try_dim_index(D), "L1 Norm");
         return l1_norm_impl(x, &[dim]);
@@ -387,6 +387,9 @@ where
 
 /// Computes the L2 norm of a tensor along specified dimensions.
 ///
+/// If `dims` is empty, no dimensions are reduced, matching ONNX `noop_with_empty_axes=true`
+/// semantics (the norm transformation is applied elementwise without collapsing axes).
+///
 /// # Arguments
 ///
 /// * `x` - The input tensor.
@@ -397,9 +400,6 @@ where
 ///
 /// The L2 norm of the input tensor.
 pub fn l2_norm_dims<const D: usize, I: AsIndex>(x: Tensor<D>, dims: &[I]) -> Tensor<D> {
-    if dims.is_empty() {
-        return x;
-    }
     if dims.len() == 1 {
         let dim = unwrap_dim_index(dims[0].try_dim_index(D), "L2 Norm");
         return l2_norm_impl(x, &[dim]);
@@ -454,6 +454,9 @@ fn lp_norm_base<const D: usize>(x: Tensor<D>, p: f64, dims: &[usize]) -> Tensor<
 
 /// Computes the L:INFINITY norm of a tensor along specified dimensions.
 ///
+/// If `dims` is empty, no dimensions are reduced, matching ONNX `noop_with_empty_axes=true`
+/// semantics (the norm transformation is applied elementwise without collapsing axes).
+///
 /// # Arguments
 ///
 /// * `x` - The input tensor.
@@ -467,9 +470,6 @@ pub fn max_abs_norm_dims<const D: usize, K, I: AsIndex>(x: Tensor<D, K>, dims: &
 where
     K: Ordered,
 {
-    if dims.is_empty() {
-        return x;
-    }
     if dims.len() == 1 {
         let dim = unwrap_dim_index(dims[0].try_dim_index(D), "Max Abs Norm");
         return max_abs_norm_impl(x, &[dim]);
@@ -504,11 +504,13 @@ fn max_abs_norm_impl<const D: usize, K>(x: Tensor<D, K>, dims: &[usize]) -> Tens
 where
     K: Ordered,
 {
-    dims.iter()
-        .fold(x.abs(), |tensor, &dim| tensor.max_dim(dim))
+    x.max_abs_dims(dims)
 }
 
 /// Computes the L:NEG_INFINITY norm of a tensor along specified dimensions.
+///
+/// If `dims` is empty, no dimensions are reduced, matching ONNX `noop_with_empty_axes=true`
+/// semantics (the norm transformation is applied elementwise without collapsing axes).
 ///
 /// # Arguments
 ///
@@ -523,9 +525,6 @@ pub fn min_abs_norm_dims<const D: usize, K, I: AsIndex>(x: Tensor<D, K>, dims: &
 where
     K: Ordered,
 {
-    if dims.is_empty() {
-        return x;
-    }
     if dims.len() == 1 {
         let dim = unwrap_dim_index(dims[0].try_dim_index(D), "Min Abs Norm");
         return min_abs_norm_impl(x, &[dim]);

--- a/crates/burn-tensor/src/tensor/linalg/vector_norm.rs
+++ b/crates/burn-tensor/src/tensor/linalg/vector_norm.rs
@@ -122,6 +122,13 @@ pub fn vector_norm_dims<const D: usize, I: AsIndex>(
     norm: impl Into<Norm>,
     dims: &[I],
 ) -> Tensor<D> {
+    if dims.is_empty() {
+        return x;
+    }
+    if dims.len() == 1 {
+        let dim = unwrap_dim_index(dims[0].try_dim_index(D), "Vector Norm");
+        return vector_norm_impl(x, norm, &[dim]);
+    }
     let dims: Vec<usize> = dims
         .iter()
         .map(|&d| unwrap_dim_index(d.try_dim_index(D), "Vector Norm"))
@@ -152,7 +159,8 @@ pub fn vector_norm<const D: usize>(
     norm: impl Into<Norm>,
     dim: impl AsIndex,
 ) -> Tensor<D> {
-    vector_norm_dims(x, norm, &[dim])
+    let dim = unwrap_dim_index(dim.try_dim_index(D), "Vector Norm");
+    vector_norm_impl(x, norm, &[dim])
 }
 
 fn vector_norm_impl<const D: usize>(
@@ -184,6 +192,13 @@ fn vector_norm_impl<const D: usize>(
 ///
 /// The ``L(p)`` norm of the input tensor.
 pub fn lp_norm_dims<const D: usize, I: AsIndex>(x: Tensor<D>, p: f64, dims: &[I]) -> Tensor<D> {
+    if dims.is_empty() {
+        return x;
+    }
+    if dims.len() == 1 {
+        let dim = unwrap_dim_index(dims[0].try_dim_index(D), "Lp Norm");
+        return lp_norm_impl(x, p, &[dim]);
+    }
     let dims: Vec<usize> = dims
         .iter()
         .map(|&d| unwrap_dim_index(d.try_dim_index(D), "Lp Norm"))
@@ -212,7 +227,8 @@ pub fn lp_norm_dims<const D: usize, I: AsIndex>(x: Tensor<D>, p: f64, dims: &[I]
 ///
 /// The ``L(p)`` norm of the input tensor.
 pub fn lp_norm<const D: usize>(x: Tensor<D>, p: f64, dim: impl AsIndex) -> Tensor<D> {
-    lp_norm_dims(x, p, &[dim])
+    let dim = unwrap_dim_index(dim.try_dim_index(D), "Lp Norm");
+    lp_norm_impl(x, p, &[dim])
 }
 
 fn lp_norm_impl<const D: usize>(x: Tensor<D>, p: f64, dims: &[usize]) -> Tensor<D> {
@@ -248,8 +264,9 @@ pub fn vector_normalize<const D: usize, E: ElementConversion>(
     dim: impl AsIndex,
     eps: E,
 ) -> Tensor<D> {
-    let norm = vector_norm(x.clone(), norm, dim).clamp_min(eps);
-    x / norm
+    let dim = unwrap_dim_index(dim.try_dim_index(D), "Vector Normalize");
+    let norm_tensor = lp_norm_impl(x.clone(), norm.into().to_exponent(), &[dim]).clamp_min(eps);
+    x / norm_tensor
 }
 
 /// Computes the L0 norm of a tensor along specified dimensions.
@@ -267,6 +284,13 @@ pub fn l0_norm_dims<const D: usize, K, I: AsIndex>(x: Tensor<D, K>, dims: &[I]) 
 where
     K: Numeric,
 {
+    if dims.is_empty() {
+        return x;
+    }
+    if dims.len() == 1 {
+        let dim = unwrap_dim_index(dims[0].try_dim_index(D), "L0 Norm");
+        return l0_norm_impl(x, &[dim]);
+    }
     let dims: Vec<usize> = dims
         .iter()
         .map(|&d| unwrap_dim_index(d.try_dim_index(D), "L0 Norm"))
@@ -289,7 +313,8 @@ pub fn l0_norm<const D: usize, K>(x: Tensor<D, K>, dim: impl AsIndex) -> Tensor<
 where
     K: Numeric,
 {
-    l0_norm_dims(x, &[dim])
+    let dim = unwrap_dim_index(dim.try_dim_index(D), "L0 Norm");
+    l0_norm_impl(x, &[dim])
 }
 
 fn l0_norm_impl<const D: usize, K>(x: Tensor<D, K>, dims: &[usize]) -> Tensor<D, K>
@@ -318,6 +343,13 @@ pub fn l1_norm_dims<const D: usize, K, I: AsIndex>(x: Tensor<D, K>, dims: &[I]) 
 where
     K: Numeric,
 {
+    if dims.is_empty() {
+        return x;
+    }
+    if dims.len() == 1 {
+        let dim = unwrap_dim_index(dims[0].try_dim_index(D), "L1 Norm");
+        return l1_norm_impl(x, &[dim]);
+    }
     let dims: Vec<usize> = dims
         .iter()
         .map(|&d| unwrap_dim_index(d.try_dim_index(D), "L1 Norm"))
@@ -342,7 +374,8 @@ pub fn l1_norm<const D: usize, K>(x: Tensor<D, K>, dim: impl AsIndex) -> Tensor<
 where
     K: Numeric,
 {
-    l1_norm_dims(x, &[dim])
+    let dim = unwrap_dim_index(dim.try_dim_index(D), "L1 Norm");
+    l1_norm_impl(x, &[dim])
 }
 
 fn l1_norm_impl<const D: usize, K>(x: Tensor<D, K>, dims: &[usize]) -> Tensor<D, K>
@@ -364,6 +397,13 @@ where
 ///
 /// The L2 norm of the input tensor.
 pub fn l2_norm_dims<const D: usize, I: AsIndex>(x: Tensor<D>, dims: &[I]) -> Tensor<D> {
+    if dims.is_empty() {
+        return x;
+    }
+    if dims.len() == 1 {
+        let dim = unwrap_dim_index(dims[0].try_dim_index(D), "L2 Norm");
+        return l2_norm_impl(x, &[dim]);
+    }
     let dims: Vec<usize> = dims
         .iter()
         .map(|&d| unwrap_dim_index(d.try_dim_index(D), "L2 Norm"))
@@ -383,7 +423,8 @@ pub fn l2_norm_dims<const D: usize, I: AsIndex>(x: Tensor<D>, dims: &[I]) -> Ten
 ///
 /// The L2 norm of the input tensor.
 pub fn l2_norm<const D: usize>(x: Tensor<D>, dim: impl AsIndex) -> Tensor<D> {
-    l2_norm_dims(x, &[dim])
+    let dim = unwrap_dim_index(dim.try_dim_index(D), "L2 Norm");
+    l2_norm_impl(x, &[dim])
 }
 
 pub(super) fn l2_norm_impl<const D: usize>(x: Tensor<D>, dims: &[usize]) -> Tensor<D> {
@@ -426,6 +467,13 @@ pub fn max_abs_norm_dims<const D: usize, K, I: AsIndex>(x: Tensor<D, K>, dims: &
 where
     K: Ordered,
 {
+    if dims.is_empty() {
+        return x;
+    }
+    if dims.len() == 1 {
+        let dim = unwrap_dim_index(dims[0].try_dim_index(D), "Max Abs Norm");
+        return max_abs_norm_impl(x, &[dim]);
+    }
     let dims: Vec<usize> = dims
         .iter()
         .map(|&d| unwrap_dim_index(d.try_dim_index(D), "Max Abs Norm"))
@@ -448,7 +496,8 @@ pub fn max_abs_norm<const D: usize, K>(x: Tensor<D, K>, dim: impl AsIndex) -> Te
 where
     K: Ordered,
 {
-    max_abs_norm_dims(x, &[dim])
+    let dim = unwrap_dim_index(dim.try_dim_index(D), "Max Abs Norm");
+    max_abs_norm_impl(x, &[dim])
 }
 
 fn max_abs_norm_impl<const D: usize, K>(x: Tensor<D, K>, dims: &[usize]) -> Tensor<D, K>
@@ -474,6 +523,13 @@ pub fn min_abs_norm_dims<const D: usize, K, I: AsIndex>(x: Tensor<D, K>, dims: &
 where
     K: Ordered,
 {
+    if dims.is_empty() {
+        return x;
+    }
+    if dims.len() == 1 {
+        let dim = unwrap_dim_index(dims[0].try_dim_index(D), "Min Abs Norm");
+        return min_abs_norm_impl(x, &[dim]);
+    }
     let dims: Vec<usize> = dims
         .iter()
         .map(|&d| unwrap_dim_index(d.try_dim_index(D), "Min Abs Norm"))
@@ -496,7 +552,8 @@ pub fn min_abs_norm<const D: usize, K>(x: Tensor<D, K>, dim: impl AsIndex) -> Te
 where
     K: Ordered,
 {
-    min_abs_norm_dims(x, &[dim])
+    let dim = unwrap_dim_index(dim.try_dim_index(D), "Min Abs Norm");
+    min_abs_norm_impl(x, &[dim])
 }
 
 fn min_abs_norm_impl<const D: usize, K>(x: Tensor<D, K>, dims: &[usize]) -> Tensor<D, K>


### PR DESCRIPTION
## Description
Closes #5527.

This PR adds multi-axis variants for all vector norm operations in `burn::tensor::linalg`, following the `sum_dim` / `sum_dims` convention in `numeric.rs`. This enables multi-axis norm reductions while preserving reduced dimensions at size 1 (`keepdim = true`), unblocking multi-axis pooling operations in `burn-onnx` (such as `GlobalLpPool`).

Additionally, empty dimension reductions (`dims = &[]`) follow ONNX `noop_with_empty_axes=true` semantics, ensuring elementwise norm transformations (such as $|x|$ for $L_1/L_2/L_\infty$ or non-zero indicators for $L_0$) execute without collapsing axes.

## Changes
- **`crates/burn-tensor`**:
  - Refactored internal `*_impl` functions (`l0_norm_impl`, `l1_norm_impl`, `l2_norm_impl`, `lp_signed_norm`, `lp_norm_base`, `max_abs_norm_impl`, `min_abs_norm_impl`, `lp_norm_impl`, `vector_norm_impl`) to operate over `dims: &[usize]`.
  - Replaced manual fold reduction in `max_abs_norm_impl` with `x.max_abs_dims(dims)`.
  - Updated `max_abs_dims` in `api/orderable.rs` to return `self.abs()` when `dims.is_empty()`.
  - Ensured empty dimension slices (`dims: &[]`) execute elementwise norm transformations without collapsing dimensions (matching ONNX `noop_with_empty_axes=true` semantics), and documented this across all `*_dims` docstrings.
  - Added public multi-axis APIs: `vector_norm_dims`, `lp_norm_dims`, `l0_norm_dims`, `l1_norm_dims`, `l2_norm_dims`, `max_abs_norm_dims`, and `min_abs_norm_dims`.
  - Converted existing single-axis functions to zero-cost forwarders calling their corresponding `*_dims` variants with `&[dim]`.
  - Updated `cosine_similarity.rs` and re-exports in `linalg/mod.rs`.
- **`crates/burn-backend-tests`**:
  - Added integration tests covering spatial multi-axis reduction shape retention (`[2, 3, 4, 5]` -> `[2, 3, 1, 1]`), even integer $p$ specialization without `abs`, non-integer and odd integer $p$, negative dimensions indexing (`&[-2, -1]`), and single-vs-multi parity.
  - Added regression test cases for empty axes (`&[]`) covering negative values, zeros, odd/even $p$-norms, and multi-dimensional shapes.

## Validation
- `cargo check -p burn-tensor` (clean)
- `cargo test -p burn-tensor --lib linalg` (clean)
- `cargo test --package burn-backend-tests --test tensor -- float::linalg::vector_norm` (14 passed)
- `cargo fmt --check` (clean)
- `cargo clippy -p burn-tensor -p burn-backend-tests --all-targets -- -D warnings` (clean)