### PR TITLE
Validate CubeCL complex cast lowering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,7 +2199,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tensor4all/cubecl?rev=e48ede43d0c03e361f54ec895c7bfe395474fb72#e48ede43d0c03e361f54ec895c7bfe395474fb72"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -2216,7 +2216,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tensor4all/cubecl?rev=e48ede43d0c03e361f54ec895c7bfe395474fb72#e48ede43d0c03e361f54ec895c7bfe395474fb72"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -2240,7 +2240,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tensor4all/cubecl?rev=e48ede43d0c03e361f54ec895c7bfe395474fb72#e48ede43d0c03e361f54ec895c7bfe395474fb72"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -2258,6 +2258,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "itertools 0.15.0",
  "log",
+ "num-complex",
  "num-integer",
  "num-traits",
  "paste",
@@ -2271,7 +2272,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tensor4all/cubecl?rev=e48ede43d0c03e361f54ec895c7bfe395474fb72#e48ede43d0c03e361f54ec895c7bfe395474fb72"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2294,8 +2295,9 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tensor4all/cubecl?rev=e48ede43d0c03e361f54ec895c7bfe395474fb72#e48ede43d0c03e361f54ec895c7bfe395474fb72"
 dependencies = [
+ "bytemuck",
  "crossbeam-utils",
  "cubecl-common",
  "cubecl-core",
@@ -2315,7 +2317,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tensor4all/cubecl?rev=e48ede43d0c03e361f54ec895c7bfe395474fb72#e48ede43d0c03e361f54ec895c7bfe395474fb72"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2334,7 +2336,7 @@ dependencies = [
 [[package]]
 name = "cubecl-environment"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tensor4all/cubecl?rev=e48ede43d0c03e361f54ec895c7bfe395474fb72#e48ede43d0c03e361f54ec895c7bfe395474fb72"
 dependencies = [
  "async-channel",
  "backtrace",
@@ -2369,7 +2371,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tensor4all/cubecl?rev=e48ede43d0c03e361f54ec895c7bfe395474fb72#e48ede43d0c03e361f54ec895c7bfe395474fb72"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2377,6 +2379,7 @@ dependencies = [
  "cubecl-cpp",
  "cubecl-environment",
  "cubecl-hip-sys",
+ "cubecl-llvm",
  "cubecl-runtime",
  "derive-new",
  "half",
@@ -2399,7 +2402,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tensor4all/cubecl?rev=e48ede43d0c03e361f54ec895c7bfe395474fb72#e48ede43d0c03e361f54ec895c7bfe395474fb72"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -2416,12 +2419,14 @@ dependencies = [
  "internment",
  "itertools 0.15.0",
  "num",
+ "num-complex",
  "num-traits",
  "pliron",
  "pliron-spirv",
  "portable-atomic",
  "rustc_apfloat",
  "serde",
+ "smallvec",
  "spin 0.12.2",
  "thiserror 2.0.19",
  "variadics_please",
@@ -2430,8 +2435,9 @@ dependencies = [
 [[package]]
 name = "cubecl-llvm"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tensor4all/cubecl?rev=e48ede43d0c03e361f54ec895c7bfe395474fb72#e48ede43d0c03e361f54ec895c7bfe395474fb72"
 dependencies = [
+ "cc",
  "cubecl-core",
  "cubecl-environment",
  "cubecl-opt",
@@ -2441,13 +2447,14 @@ dependencies = [
  "llvm-sys",
  "pliron",
  "pliron-llvm",
+ "thiserror 2.0.19",
  "tracel-llvm-bundler",
 ]
 
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tensor4all/cubecl?rev=e48ede43d0c03e361f54ec895c7bfe395474fb72#e48ede43d0c03e361f54ec895c7bfe395474fb72"
 dependencies = [
  "cubecl-common",
  "darling 0.24.0",
@@ -2465,7 +2472,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tensor4all/cubecl?rev=e48ede43d0c03e361f54ec895c7bfe395474fb72#e48ede43d0c03e361f54ec895c7bfe395474fb72"
 dependencies = [
  "darling 0.24.0",
  "inflections",
@@ -2477,29 +2484,33 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tensor4all/cubecl?rev=e48ede43d0c03e361f54ec895c7bfe395474fb72#e48ede43d0c03e361f54ec895c7bfe395474fb72"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
  "cubecl-environment",
  "cubecl-ir",
  "derive-new",
+ "derive_more",
+ "downcast-rs 1.2.1",
  "float-ord",
  "hashbrown 0.17.1",
  "itertools 0.15.0",
  "log",
  "num",
  "pliron",
+ "rustc-hash 2.1.3",
  "smallvec",
  "stable-vec",
  "thiserror 2.0.19",
+ "tynm",
  "type-map",
 ]
 
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tensor4all/cubecl?rev=e48ede43d0c03e361f54ec895c7bfe395474fb72#e48ede43d0c03e361f54ec895c7bfe395474fb72"
 dependencies = [
  "ahash",
  "buildid",
@@ -2531,7 +2542,7 @@ dependencies = [
 [[package]]
 name = "cubecl-spirv"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tensor4all/cubecl?rev=e48ede43d0c03e361f54ec895c7bfe395474fb72#e48ede43d0c03e361f54ec895c7bfe395474fb72"
 dependencies = [
  "bitflags 2.13.1",
  "cubecl-common",
@@ -2554,7 +2565,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tensor4all/cubecl?rev=e48ede43d0c03e361f54ec895c7bfe395474fb72#e48ede43d0c03e361f54ec895c7bfe395474fb72"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2571,7 +2582,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tensor4all/cubecl?rev=e48ede43d0c03e361f54ec895c7bfe395474fb72#e48ede43d0c03e361f54ec895c7bfe395474fb72"
 dependencies = [
  "ash",
  "bytemuck",
@@ -2606,7 +2617,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30c2e314f67f47d5591fc1d2ff440c83cb7f99d#a30c2e314f67f47d5591fc1d2ff440c83cb7f99d"
+source = "git+https://github.com/tensor4all/cubecl?rev=e48ede43d0c03e361f54ec895c7bfe395474fb72#e48ede43d0c03e361f54ec895c7bfe395474fb72"
 dependencies = [
  "derive-new",
  "serde",
@@ -2616,7 +2627,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5d15ee09ea56502783a5e056bf4b1d36c73a3a26#5d15ee09ea56502783a5e056bf4b1d36c73a3a26"
+source = "git+https://github.com/tensor4all/cubek?rev=930410e49ae97913a547a66e05e66cdef15860ab#930410e49ae97913a547a66e05e66cdef15860ab"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2634,7 +2645,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5d15ee09ea56502783a5e056bf4b1d36c73a3a26#5d15ee09ea56502783a5e056bf4b1d36c73a3a26"
+source = "git+https://github.com/tensor4all/cubek?rev=930410e49ae97913a547a66e05e66cdef15860ab#930410e49ae97913a547a66e05e66cdef15860ab"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2648,7 +2659,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5d15ee09ea56502783a5e056bf4b1d36c73a3a26#5d15ee09ea56502783a5e056bf4b1d36c73a3a26"
+source = "git+https://github.com/tensor4all/cubek?rev=930410e49ae97913a547a66e05e66cdef15860ab#930410e49ae97913a547a66e05e66cdef15860ab"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2665,7 +2676,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5d15ee09ea56502783a5e056bf4b1d36c73a3a26#5d15ee09ea56502783a5e056bf4b1d36c73a3a26"
+source = "git+https://github.com/tensor4all/cubek?rev=930410e49ae97913a547a66e05e66cdef15860ab#930410e49ae97913a547a66e05e66cdef15860ab"
 dependencies = [
  "cubecl",
 ]
@@ -2673,7 +2684,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5d15ee09ea56502783a5e056bf4b1d36c73a3a26#5d15ee09ea56502783a5e056bf4b1d36c73a3a26"
+source = "git+https://github.com/tensor4all/cubek?rev=930410e49ae97913a547a66e05e66cdef15860ab#930410e49ae97913a547a66e05e66cdef15860ab"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2686,7 +2697,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5d15ee09ea56502783a5e056bf4b1d36c73a3a26#5d15ee09ea56502783a5e056bf4b1d36c73a3a26"
+source = "git+https://github.com/tensor4all/cubek?rev=930410e49ae97913a547a66e05e66cdef15860ab#930410e49ae97913a547a66e05e66cdef15860ab"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2700,7 +2711,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5d15ee09ea56502783a5e056bf4b1d36c73a3a26#5d15ee09ea56502783a5e056bf4b1d36c73a3a26"
+source = "git+https://github.com/tensor4all/cubek?rev=930410e49ae97913a547a66e05e66cdef15860ab#930410e49ae97913a547a66e05e66cdef15860ab"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2710,7 +2721,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5d15ee09ea56502783a5e056bf4b1d36c73a3a26#5d15ee09ea56502783a5e056bf4b1d36c73a3a26"
+source = "git+https://github.com/tensor4all/cubek?rev=930410e49ae97913a547a66e05e66cdef15860ab#930410e49ae97913a547a66e05e66cdef15860ab"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2722,7 +2733,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5d15ee09ea56502783a5e056bf4b1d36c73a3a26#5d15ee09ea56502783a5e056bf4b1d36c73a3a26"
+source = "git+https://github.com/tensor4all/cubek?rev=930410e49ae97913a547a66e05e66cdef15860ab#930410e49ae97913a547a66e05e66cdef15860ab"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2737,7 +2748,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5d15ee09ea56502783a5e056bf4b1d36c73a3a26#5d15ee09ea56502783a5e056bf4b1d36c73a3a26"
+source = "git+https://github.com/tensor4all/cubek?rev=930410e49ae97913a547a66e05e66cdef15860ab#930410e49ae97913a547a66e05e66cdef15860ab"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2750,7 +2761,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5d15ee09ea56502783a5e056bf4b1d36c73a3a26#5d15ee09ea56502783a5e056bf4b1d36c73a3a26"
+source = "git+https://github.com/tensor4all/cubek?rev=930410e49ae97913a547a66e05e66cdef15860ab#930410e49ae97913a547a66e05e66cdef15860ab"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2759,7 +2770,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5d15ee09ea56502783a5e056bf4b1d36c73a3a26#5d15ee09ea56502783a5e056bf4b1d36c73a3a26"
+source = "git+https://github.com/tensor4all/cubek?rev=930410e49ae97913a547a66e05e66cdef15860ab#930410e49ae97913a547a66e05e66cdef15860ab"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -3336,6 +3347,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "downcast-rs"
@@ -4422,10 +4439,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
@@ -7199,14 +7212,13 @@ dependencies = [
 [[package]]
 name = "pliron"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e51eb8628227038376c81dcb1752db90a90af24a1e38b27582c7dab235149d7"
+source = "git+https://github.com/pliron-org/pliron.git?rev=6f4e739266c037a69488031a81f4381e62db9ac3#6f4e739266c037a69488031a81f4381e62db9ac3"
 dependencies = [
  "awint",
  "combine",
- "downcast-rs",
+ "downcast-rs 2.0.2",
  "dyn-clone",
- "hashbrown 0.14.5",
+ "hashbrown 0.13.2",
  "hi_sparse_bitset",
  "indexmap",
  "inventory",
@@ -7219,7 +7231,7 @@ dependencies = [
  "rustc_apfloat",
  "slotmap",
  "smallvec",
- "spin 0.11.1",
+ "spin 0.10.1",
  "thiserror 2.0.19",
  "utf8-chars",
 ]
@@ -7227,8 +7239,7 @@ dependencies = [
 [[package]]
 name = "pliron-derive"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f878ccd6bfd39a9373175774b96785daab296dc1870bc72ff7d285151f613a56"
+source = "git+https://github.com/pliron-org/pliron.git?rev=6f4e739266c037a69488031a81f4381e62db9ac3#6f4e739266c037a69488031a81f4381e62db9ac3"
 dependencies = [
  "combine",
  "convert_case 0.11.0",
@@ -7242,8 +7253,7 @@ dependencies = [
 [[package]]
 name = "pliron-llvm"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511535a077e4f72f83c437cde2636a6f525809a370b3078c0d1d5d53612ad052"
+source = "git+https://github.com/pliron-org/pliron.git?rev=6f4e739266c037a69488031a81f4381e62db9ac3#6f4e739266c037a69488031a81f4381e62db9ac3"
 dependencies = [
  "bitflags 2.13.1",
  "llvm-sys",
@@ -7255,8 +7265,7 @@ dependencies = [
 [[package]]
 name = "pliron-spirv"
 version = "0.14.1+sdk-1.4.357.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2919774bd35911798e824286a15c2c3c6fedbfd56d06a33e071dc1af5d5e7030"
+source = "git+https://github.com/tracel-ai/tracel-rspirv.git?rev=e52c4c918585bc02fa413eb6ee4f0b34e1109ae0#e52c4c918585bc02fa413eb6ee4f0b34e1109ae0"
 dependencies = [
  "derive-new",
  "derive_more",
@@ -9591,6 +9600,9 @@ name = "spin"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spin"
@@ -10524,9 +10536,8 @@ dependencies = [
 
 [[package]]
 name = "tracel-llvm-bundler"
-version = "22.1.4-6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de376825263c1a1e0af395cb7e04e82099c2fe16724235d313ab803b33bba87b"
+version = "22.1.4-7"
+source = "git+https://github.com/tracel-ai/tracel-llvm.git?rev=7932ee9e52044e298dacbfd04b1e0476544bb185#7932ee9e52044e298dacbfd04b1e0476544bb185"
 dependencies = [
  "anyhow",
  "bytes",
@@ -10546,8 +10557,7 @@ dependencies = [
 [[package]]
 name = "tracel-rspirv"
 version = "0.14.1+sdk-1.4.357.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1f062140c2875c072de7ab05019970906105a9a2c971af922b8d16bd3b5cbea"
+source = "git+https://github.com/tracel-ai/tracel-rspirv.git?rev=e52c4c918585bc02fa413eb6ee4f0b34e1109ae0#e52c4c918585bc02fa413eb6ee4f0b34e1109ae0"
 dependencies = [
  "bitflags 2.13.1",
  "pliron",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,11 +222,11 @@ burn-vision = { path = "crates/burn-vision", version = "=0.22.0-pre.3", default-
 burn-wgpu = { path = "crates/burn-wgpu", version = "=0.22.0-pre.3", default-features = false }
 
 ### For the main burn branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "a30c2e314f67f47d5591fc1d2ff440c83cb7f99d" }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "a30c2e314f67f47d5591fc1d2ff440c83cb7f99d" }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "a30c2e314f67f47d5591fc1d2ff440c83cb7f99d" }
-cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "a30c2e314f67f47d5591fc1d2ff440c83cb7f99d" }
-cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "5d15ee09ea56502783a5e056bf4b1d36c73a3a26" }
+cubecl = { git = "https://github.com/tensor4all/cubecl", default-features = false, rev = "e48ede43d0c03e361f54ec895c7bfe395474fb72" }
+cubecl-common = { git = "https://github.com/tensor4all/cubecl", default-features = false, rev = "e48ede43d0c03e361f54ec895c7bfe395474fb72" }
+cubecl-environment = { git = "https://github.com/tensor4all/cubecl", default-features = false, rev = "e48ede43d0c03e361f54ec895c7bfe395474fb72" }
+cubecl-zspace = { git = "https://github.com/tensor4all/cubecl", default-features = false, rev = "e48ede43d0c03e361f54ec895c7bfe395474fb72" }
+cubek = { git = "https://github.com/tensor4all/cubek", default-features = false, rev = "930410e49ae97913a547a66e05e66cdef15860ab" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }

--- a/crates/burn-backend/src/cubecl.rs
+++ b/crates/burn-backend/src/cubecl.rs
@@ -11,7 +11,9 @@
 use burn_std::{BoolStore, DType, QuantScheme, QuantStore, QuantValue};
 use cubecl::ir::{ElemType, FloatKind, IntKind, UIntKind};
 
-pub use cubecl::throughput::{ThroughputKey, ThroughputMode, ThroughputValue};
+pub use cubecl::throughput::{
+    MemoryAccess, MemorySpec, ThroughputKey, ThroughputMode, ThroughputValue,
+};
 
 /// Convert a cubecl [`ElemType`] into the corresponding burn [`DType`].
 ///

--- a/crates/burn-cubecl-fusion/src/engine/codegen/ir.rs
+++ b/crates/burn-cubecl-fusion/src/engine/codegen/ir.rs
@@ -906,6 +906,7 @@ impl From<ElemType> for FuseType {
             },
             ElemType::Bool => Self::U32,
             ElemType::Index => Self::U32,
+            ElemType::Complex(_) => panic!("Unsupported precision for fusion: {value}"),
         }
     }
 }

--- a/crates/burn-tensor/src/device.rs
+++ b/crates/burn-tensor/src/device.rs
@@ -3,7 +3,9 @@ pub use burn_std::{
 };
 
 #[cfg(feature = "cubecl")]
-pub use burn_backend::cubecl::{ThroughputKey, ThroughputMode, ThroughputValue};
+pub use burn_backend::cubecl::{
+    MemoryAccess, MemorySpec, ThroughputKey, ThroughputMode, ThroughputValue,
+};
 use burn_backend::{Backend, DeviceOps};
 pub use burn_backend::{
     InstallMemoryPoolsError, MemoryPoolLayout, MemoryPoolUsage, SlicedPool, SlicedPoolReport,
@@ -939,10 +941,14 @@ fn mode_label(mode: &ThroughputMode) -> &'static str {
     match mode {
         ThroughputMode::ComputeDirect { .. } => "compute-direct",
         ThroughputMode::ComputeCmma { .. } => "compute-cmma",
-        ThroughputMode::Memory => "memory",
-        ThroughputMode::MemoryRead => "memory-read",
-        ThroughputMode::MemoryWrite => "memory-write",
-        ThroughputMode::MemoryWorkingSet { .. } => "memory-working-set",
+        ThroughputMode::Memory(spec) if spec.bytes != spec.access.default_working_set() => {
+            "memory-working-set"
+        }
+        ThroughputMode::Memory(spec) => match spec.access {
+            MemoryAccess::Copy => "memory",
+            MemoryAccess::Read => "memory-read",
+            MemoryAccess::Write => "memory-write",
+        },
         ThroughputMode::Launch => "launch",
     }
 }
@@ -962,11 +968,7 @@ impl core::fmt::Display for ThroughputStat {
             ThroughputMode::ComputeDirect { dtype } | ThroughputMode::ComputeCmma { dtype, .. } => {
                 alloc::format!("{dtype}")
             }
-            ThroughputMode::Memory
-            | ThroughputMode::MemoryRead
-            | ThroughputMode::MemoryWrite
-            | ThroughputMode::MemoryWorkingSet { .. }
-            | ThroughputMode::Launch => alloc::string::String::new(),
+            ThroughputMode::Memory(_) | ThroughputMode::Launch => alloc::string::String::new(),
         };
 
         let value = self.value.format(&self.key);
@@ -1314,6 +1316,34 @@ mod autodiff_move_tests {
         assert_eq!(
             moved.try_into_vec_as::<f32>().unwrap(),
             vec![1.0, 2.0, 3.0, 4.0]
+        );
+    }
+}
+
+#[cfg(all(test, feature = "cubecl"))]
+mod throughput_mode_tests {
+    use super::*;
+
+    #[test]
+    fn memory_labels_include_access_and_custom_working_sets() {
+        assert_eq!(
+            mode_label(&ThroughputMode::memory(MemoryAccess::Copy)),
+            "memory"
+        );
+        assert_eq!(
+            mode_label(&ThroughputMode::memory(MemoryAccess::Read)),
+            "memory-read"
+        );
+        assert_eq!(
+            mode_label(&ThroughputMode::memory(MemoryAccess::Write)),
+            "memory-write"
+        );
+        assert_eq!(
+            mode_label(&ThroughputMode::Memory(MemorySpec::new(
+                MemoryAccess::Copy,
+                1
+            ))),
+            "memory-working-set"
         );
     }
 }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ ] Confirmed that `cargo run-checks --backend cuda` has completed successfully.
- [x] Made sure the book is up to date with changes in this PR (no documentation behavior changed).

### Related Issues/PRs

- tracel-ai/cubecl#1581
- tracel-ai/cubek#586

### Changes

Pins CubeCL and cubek to the downstream-validation commits for CubeCL complex cast lowering.

The newer CubeCL revision also requires two compatibility updates in Burn:

- reject CubeCL complex element types explicitly in fusion, which does not support them yet
- adapt throughput display labels to CubeCL's unified `ThroughputMode::Memory(MemorySpec)` API while preserving the existing read, write, copy, and custom-working-set labels

### Testing

- workspace formatting, typo, audit, clippy, and no-std checks passed through `cargo run-checks --backend cuda`
- CUDA backend test suite compiled and started successfully; the full local suite exceeded the bounded local run and is left to CI
- `cargo test -p burn-tensor --features cubecl memory_labels_include_access --lib`
- focused clippy for `burn-backend`, `burn-tensor`, and `burn-cubecl-fusion`
