### PR TITLE
fix(no-std): use shared sync primitives across crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,7 +826,6 @@ dependencies = [
  "num-traits",
  "parking_lot",
  "portable-atomic",
- "portable-atomic-util",
  "spin 0.11.1",
  "tracing",
 ]
@@ -844,7 +843,6 @@ dependencies = [
  "num-traits",
  "oneshot",
  "paste",
- "portable-atomic-util",
  "rand 0.10.2",
  "rand_distr 0.6.0",
  "serde",
@@ -940,8 +938,6 @@ dependencies = [
  "hashbrown 0.16.1",
  "log",
  "num-traits",
- "portable-atomic",
- "portable-atomic-util",
  "rand 0.10.2",
  "regex",
  "rstest",
@@ -1089,7 +1085,6 @@ dependencies = [
  "num-traits",
  "once_cell",
  "portable-atomic",
- "portable-atomic-util",
  "rayon",
  "realfft",
 ]
@@ -1115,6 +1110,7 @@ name = "burn-ir"
 version = "0.22.0-pre.3"
 dependencies = [
  "burn-backend",
+ "burn-std",
  "hashbrown 0.16.1",
  "serde",
 ]
@@ -1139,8 +1135,6 @@ dependencies = [
  "num-traits",
  "openblas-src",
  "paste",
- "portable-atomic",
- "portable-atomic-util",
  "rand 0.10.2",
  "rayon",
  "seq-macro",
@@ -1272,7 +1266,6 @@ dependencies = [
  "indicatif 0.18.6",
  "num-traits",
  "paste",
- "portable-atomic-util",
  "rand 0.10.2",
  "rand_distr 0.6.0",
  "reqwest 0.12.28",

--- a/crates/burn-autodiff/Cargo.toml
+++ b/crates/burn-autodiff/Cargo.toml
@@ -36,11 +36,10 @@ parking_lot = { workspace = true, optional = true }
 log = { workspace = true }
 hashbrown = { workspace = true }
 num-traits = { workspace = true }
-portable-atomic = { workspace = true }
 tracing = { workspace = true, optional = true, features = ["default"] }
 
-[target.'cfg(not(target_has_atomic = "ptr"))'.dependencies]
-portable-atomic-util = { workspace = true }
+[target.'cfg(not(target_has_atomic = "64"))'.dependencies]
+portable-atomic = { workspace = true }
 
 [package.metadata.docs.rs]
 features = ["default"]

--- a/crates/burn-autodiff/src/checkpoint/builder.rs
+++ b/crates/burn-autodiff/src/checkpoint/builder.rs
@@ -5,13 +5,8 @@ use crate::{
 };
 use alloc::{boxed::Box, vec::Vec};
 
-#[cfg(target_has_atomic = "ptr")]
-use alloc::sync::Arc;
-
-#[cfg(not(target_has_atomic = "ptr"))]
-use portable_atomic_util::Arc;
-
 use burn_backend::Backend;
+use burn_std::sync::Arc;
 use core::any::Any;
 
 use super::{

--- a/crates/burn-autodiff/src/checkpoint/retro_forward.rs
+++ b/crates/burn-autodiff/src/checkpoint/retro_forward.rs
@@ -1,11 +1,7 @@
 use crate::collections::HashMap;
 use crate::graph::NodeId;
 
-#[cfg(target_has_atomic = "ptr")]
-use alloc::sync::Arc;
-
-#[cfg(not(target_has_atomic = "ptr"))]
-use portable_atomic_util::Arc;
+use burn_std::sync::Arc;
 
 use core::fmt::Debug;
 

--- a/crates/burn-autodiff/src/checkpoint/strategy.rs
+++ b/crates/burn-autodiff/src/checkpoint/strategy.rs
@@ -1,12 +1,7 @@
 use core::fmt::Debug;
 
 use burn_backend::Backend;
-
-#[cfg(target_has_atomic = "ptr")]
-use alloc::sync::Arc;
-
-#[cfg(not(target_has_atomic = "ptr"))]
-use portable_atomic_util::Arc;
+use burn_std::sync::Arc;
 
 use crate::{graph::ComputingProperty, tensor::AutodiffTensor};
 

--- a/crates/burn-autodiff/src/graph/node.rs
+++ b/crates/burn-autodiff/src/graph/node.rs
@@ -7,11 +7,7 @@ use core::sync::atomic::{AtomicU64, Ordering};
 #[cfg(not(target_has_atomic = "64"))]
 use portable_atomic::{AtomicU64, Ordering};
 
-#[cfg(target_has_atomic = "ptr")]
-use alloc::sync::Arc;
-
-#[cfg(not(target_has_atomic = "ptr"))]
-use portable_atomic_util::Arc;
+use burn_std::sync::Arc;
 
 use crate::checkpoint::retro_forward::RetroForward;
 use crate::runtime::AutodiffClientImpl;

--- a/crates/burn-autodiff/src/runtime/graph.rs
+++ b/crates/burn-autodiff/src/runtime/graph.rs
@@ -9,13 +9,8 @@ use crate::{
 };
 use alloc::vec::Vec;
 
-#[cfg(target_has_atomic = "ptr")]
-use alloc::sync::Arc;
-
-#[cfg(not(target_has_atomic = "ptr"))]
-use portable_atomic_util::Arc;
-
 use burn_backend::Backend;
+use burn_std::sync::Arc;
 
 use alloc::collections::BTreeMap;
 use hashbrown::HashSet;

--- a/crates/burn-autodiff/src/runtime/memory_management.rs
+++ b/crates/burn-autodiff/src/runtime/memory_management.rs
@@ -6,11 +6,7 @@ use crate::{
 };
 use alloc::{borrow::ToOwned, vec, vec::Vec};
 
-#[cfg(target_has_atomic = "ptr")]
-use alloc::sync::Arc;
-
-#[cfg(not(target_has_atomic = "ptr"))]
-use portable_atomic_util::Arc;
+use burn_std::sync::Arc;
 
 use core::mem;
 

--- a/crates/burn-autodiff/src/tensor.rs
+++ b/crates/burn-autodiff/src/tensor.rs
@@ -8,12 +8,7 @@ use crate::{
 use crate::{distributed::DistributedGradientRegistration, grads::GradSyncContext};
 use alloc::{boxed::Box, vec};
 use burn_backend::{Backend, BackendTypes, TensorMetadata};
-
-#[cfg(target_has_atomic = "ptr")]
-use alloc::sync::Arc;
-
-#[cfg(not(target_has_atomic = "ptr"))]
-use portable_atomic_util::Arc;
+use burn_std::sync::Arc;
 
 use burn_backend::distributed::{DistributedParamId, DistributedParams};
 

--- a/crates/burn-backend/Cargo.toml
+++ b/crates/burn-backend/Cargo.toml
@@ -48,9 +48,6 @@ serde = { workspace = true }
 oneshot = { version = "0.2.1", optional = true }
 spin = { workspace = true }
 
-[target.'cfg(not(target_has_atomic = "ptr"))'.dependencies]
-portable-atomic-util = { workspace = true }
-
 [dev-dependencies]
 rand = { workspace = true, features = ["thread_rng"] }
 paste = { workspace = true }

--- a/crates/burn-backend/src/backend/device.rs
+++ b/crates/burn-backend/src/backend/device.rs
@@ -2,25 +2,19 @@ pub use burn_std::device::*;
 use burn_std::{BoolDType, DType, FloatDType, IntDType};
 pub use burn_std::{DeviceError, DeviceSettings};
 
-use burn_std::sync::RwLock;
-
-#[cfg(target_has_atomic = "ptr")]
-use alloc::sync::Arc;
-
-#[cfg(not(target_has_atomic = "ptr"))]
-use portable_atomic_util::Arc;
+use burn_std::sync::{Arc, LazyLock, RwLock};
 
 use core::any::TypeId;
 
 #[cfg(feature = "std")]
 pub use std::collections::HashMap;
 #[cfg(feature = "std")]
-use std::sync::{LazyLock, OnceLock};
+use std::sync::OnceLock;
 
 #[cfg(not(feature = "std"))]
 pub use hashbrown::HashMap;
 #[cfg(not(feature = "std"))]
-use spin::{Lazy as LazyLock, Once as OnceLock};
+use spin::Once as OnceLock;
 
 use crate::Backend;
 

--- a/crates/burn-core/Cargo.toml
+++ b/crates/burn-core/Cargo.toml
@@ -125,10 +125,6 @@ regex = { workspace = true, optional = true }
 [target.'cfg(target_has_atomic = "ptr")'.dependencies]
 regex = { workspace = true }
 
-[target.'cfg(not(target_has_atomic = "ptr"))'.dependencies]
-portable-atomic-util = { workspace = true }
-portable-atomic = { workspace = true }
-
 [dev-dependencies]
 burn-dataset = { workspace = true, features = ["fake"] }
 rstest = { workspace = true }

--- a/crates/burn-core/src/module/param/base.rs
+++ b/crates/burn-core/src/module/param/base.rs
@@ -9,15 +9,9 @@ use super::sync_once_cell::SyncOnceCell;
 use alloc::format;
 
 use alloc::boxed::Box;
-use burn_std::sync::RwLock;
+use burn_std::sync::{Arc, RwLock};
 use burn_tensor::{Device, Shape};
 use core::ops::Deref;
-
-#[cfg(target_has_atomic = "ptr")]
-use alloc::sync::Arc;
-
-#[cfg(not(target_has_atomic = "ptr"))]
-use portable_atomic_util::Arc;
 
 #[cfg(target_has_atomic = "ptr")]
 type Mapper<T> = Arc<dyn Fn(T) -> T + Send + Sync>;

--- a/crates/burn-core/src/module/param/group.rs
+++ b/crates/burn-core/src/module/param/group.rs
@@ -1,16 +1,13 @@
 use crate::module::{Module, ModuleVisitor, Param};
 
 use alloc::string::String;
-#[cfg(target_has_atomic = "ptr")]
-use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
-#[cfg(not(target_has_atomic = "ptr"))]
-use portable_atomic_util::Arc;
 #[cfg(feature = "std")]
 use regex::Regex;
 
 use burn_std::id::ParamId;
+use burn_std::sync::Arc;
 use burn_tensor::{Bool, Int, Tensor};
 
 /// Errors tied to [ParamGroup]'s.

--- a/crates/burn-core/src/module/param/running.rs
+++ b/crates/burn-core/src/module/param/running.rs
@@ -7,13 +7,7 @@ use crate::module::{
 use alloc::string::ToString;
 use alloc::vec::Vec;
 
-#[cfg(target_has_atomic = "ptr")]
-use alloc::sync::Arc;
-
-#[cfg(not(target_has_atomic = "ptr"))]
-use portable_atomic_util::Arc;
-
-use burn_std::sync::Mutex;
+use burn_std::sync::{Arc, Mutex};
 use burn_tensor::{Device, Tensor};
 
 #[cfg(feature = "std")]

--- a/crates/burn-flex/Cargo.toml
+++ b/crates/burn-flex/Cargo.toml
@@ -38,7 +38,6 @@ critical-section = [
     "once_cell/critical-section",
     "dep:portable-atomic",
     "portable-atomic/critical-section",
-    "dep:portable-atomic-util",
 ]
 
 [dependencies]
@@ -71,7 +70,6 @@ rayon = { workspace = true, optional = true }
 # no_std targets without atomic CAS (enabled via `critical-section` feature)
 once_cell = { workspace = true, optional = true }
 portable-atomic = { workspace = true, optional = true }
-portable-atomic-util = { workspace = true, optional = true }
 
 [dev-dependencies]
 realfft = { workspace = true }

--- a/crates/burn-flex/src/tensor.rs
+++ b/crates/burn-flex/src/tensor.rs
@@ -1,11 +1,8 @@
-#[cfg(target_has_atomic = "ptr")]
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::fmt;
-#[cfg(not(target_has_atomic = "ptr"))]
-use portable_atomic_util::Arc;
 
 use burn_backend::{DType, Element, TensorData, TensorMetadata};
+use burn_std::sync::Arc;
 use burn_std::{Bytes, Shape, bf16, f16};
 
 use crate::{FlexDevice, layout::Layout};

--- a/crates/burn-ir/Cargo.toml
+++ b/crates/burn-ir/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 
 [features]
 default = ["std"]
-std = ["burn-backend/std"]
+std = ["burn-backend/std", "burn-std/std"]
 doc = ["default"]
 tracing = [
     "burn-backend/tracing",
@@ -27,6 +27,7 @@ serde = { workspace = true }
 hashbrown = { workspace = true } # no_std compatible
 
 burn-backend = { workspace = true }
+burn-std = { workspace = true }
 
 [package.metadata.docs.rs]
 features = ["doc"]

--- a/crates/burn-ir/src/handle.rs
+++ b/crates/burn-ir/src/handle.rs
@@ -1,4 +1,4 @@
-use alloc::sync::Arc;
+use burn_std::sync::Arc;
 use hashbrown::HashMap;
 
 use crate::{BackendIr, TensorHandle, TensorId, TensorIr, TensorStatus};

--- a/crates/burn-ndarray/Cargo.toml
+++ b/crates/burn-ndarray/Cargo.toml
@@ -82,10 +82,6 @@ seq-macro = { version = "0.3", optional = true }
 # Parallel
 rayon = { workspace = true, optional = true }
 
-[target.'cfg(not(target_has_atomic = "ptr"))'.dependencies]
-portable-atomic = { workspace = true }
-portable-atomic-util = { workspace = true }
-
 [dev-dependencies]
 bytes = { workspace = true }
 

--- a/crates/burn-remote/src/lib.rs
+++ b/crates/burn-remote/src/lib.rs
@@ -127,16 +127,16 @@ mod tests {
         // Some random input on device 1.
         let input_shape = [1, 28, 28];
         let input = Tensor::<3>::random(input_shape, Distribution::Default, &device_1);
-        let numbers_expected: Vec<f32> = input.to_data().to_vec().unwrap();
+        let numbers_expected: Vec<f32> = input.to_data().try_into_vec().unwrap();
 
         // Move tensor to device 2.
         let input = input.to_device(&device_2);
-        let numbers: Vec<f32> = input.to_data().to_vec().unwrap();
+        let numbers: Vec<f32> = input.to_data().try_into_vec().unwrap();
         assert_eq!(numbers, numbers_expected);
 
         // Move tensor back to device 1.
         let input = input.to_device(&device_1);
-        let numbers: Vec<f32> = input.to_data().to_vec().unwrap();
+        let numbers: Vec<f32> = input.into_data().try_into_vec().unwrap();
         assert_eq!(numbers, numbers_expected);
 
         rt.shutdown_background();
@@ -367,15 +367,15 @@ mod tests {
 
         let input_shape = [1, 28, 28];
         let input = Tensor::<3>::random(input_shape, Distribution::Default, &device_0);
-        let numbers_expected: Vec<f32> = input.to_data().to_vec().unwrap();
+        let numbers_expected: Vec<f32> = input.to_data().try_into_vec().unwrap();
 
         // Move tensor to the second device on the same host and back.
         let input = input.to_device(&device_1);
-        let numbers: Vec<f32> = input.to_data().to_vec().unwrap();
+        let numbers: Vec<f32> = input.to_data().try_into_vec().unwrap();
         assert_eq!(numbers, numbers_expected);
 
         let input = input.to_device(&device_0);
-        let numbers: Vec<f32> = input.to_data().to_vec().unwrap();
+        let numbers: Vec<f32> = input.into_data().try_into_vec().unwrap();
         assert_eq!(numbers, numbers_expected);
 
         rt.shutdown_background();
@@ -481,7 +481,7 @@ mod tests {
 
         // The enumerated devices are usable: run an op on the last one.
         let input = Tensor::<2>::from_floats([[1.0, 2.0], [3.0, 4.0]], &devices[2]);
-        let numbers: Vec<f32> = (input * 2.0).to_data().to_vec().unwrap();
+        let numbers: Vec<f32> = (input * 2.0).into_data().try_into_vec().unwrap();
         assert_eq!(numbers, vec![2.0, 4.0, 6.0, 8.0]);
 
         rt.shutdown_background();
@@ -529,7 +529,7 @@ mod tests {
 
         // One successful round-trip so the sockets are actually up and the demux task is running.
         let input = Tensor::<2>::from_floats([[1.0, 2.0], [3.0, 4.0]], &device);
-        let warmup: Vec<f32> = (input * 2.0).to_data().to_vec().unwrap();
+        let warmup: Vec<f32> = (input * 2.0).into_data().try_into_vec().unwrap();
         assert_eq!(warmup, vec![2.0, 4.0, 6.0, 8.0]);
 
         // Kill the server: dropping its runtime closes the listener and both client sockets.
@@ -614,7 +614,7 @@ mod tests {
         let finished = finishes_within(std::time::Duration::from_secs(10), || {
             let device = Device::remote_websocket("ws://localhost:3090", 0);
             let input = Tensor::<2>::from_floats([[10.0, 20.0]], &device);
-            let numbers: Vec<f32> = (input * 3.0).to_data().to_vec().unwrap();
+            let numbers: Vec<f32> = (input * 3.0).into_data().try_into_vec().unwrap();
             assert_eq!(numbers, vec![30.0, 60.0]);
         });
         assert!(
@@ -652,7 +652,7 @@ mod tests {
 
         // Move back to local and verify.
         let back = doubled.to_device(&local);
-        let numbers: Vec<f32> = back.to_data().to_vec().unwrap();
+        let numbers: Vec<f32> = back.into_data().try_into_vec().unwrap();
         assert_eq!(numbers, vec![2.0, 4.0, 6.0, 8.0, 10.0, 12.0]);
 
         rt.shutdown_background();

--- a/crates/burn-std/Cargo.toml
+++ b/crates/burn-std/Cargo.toml
@@ -75,7 +75,6 @@ tempfile = { workspace = true }
 # Enable extra-platforms for bytes on targets without native atomics (e.g., thumbv6m-none-eabi)
 [target.'cfg(not(target_has_atomic = "ptr"))'.dependencies]
 bytes = { workspace = true, features = ["extra-platforms"] }
-portable-atomic-util = { workspace = true }
 
 [package.metadata.docs.rs]
 features = ["doc"]


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

> `cargo run-checks` tests with `Flex` by default. Use `cargo run-checks --backend <backend>` when
> targeting another backend. Consider running additional tests relevant to the crates changed.

### Related Issues/PRs

Fixes `burn-ir` no-std usage (and CI)

### Changes

- Replaced `portable_atomic_util::Arc` usage with `burn_std::sync::Arc` (re-exported from `cubecl_environment::sync`)
- Fixed deprecated warnings for `spin::Lazy` and `TensorData::to_vec` usage
