### PR TITLE
perf(conv): accumulate direct convolution channels in vector registers on CPU

### DIFF
--- a/crates/burn-cubecl/src/kernel/conv/direct.rs
+++ b/crates/burn-cubecl/src/kernel/conv/direct.rs
@@ -365,12 +365,12 @@ pub fn conv_direct<R: CubeRuntime, const N: usize>(
     // Use channels_per_group instead of in_channels to avoid issues here
     let vector_size_in = max_vector_size(&weight);
 
-    // Two things have to hold for a vector accumulator to pay. There has to be a vector: at
-    // one lane, accumulating into it is exactly as serial as accumulating into `sum`, and
-    // only the extra reads are left. And the channel loop has to run more than once, or
-    // there is nothing to amortize the reduction over.
-    let accumulate_lanes =
-        vector_size_in > 1 && weight.meta.shape()[dim_c] > vector_size_in as usize;
+    // The vector accumulator breaks a dependency chain that only a single-unit plane pays in
+    // full: a wide plane hides it behind its other lanes and is left with the extra input read
+    // per output channel. It also needs a vector, and a channel loop that runs more than once.
+    let accumulate_lanes = input.client.properties().hardware.plane_size_max == 1
+        && vector_size_in > 1
+        && weight.meta.shape()[dim_c] > vector_size_in as usize;
 
     let shape_out = output.meta.shape()[1..dim_c]
         .iter()

--- a/crates/burn-cubecl/src/kernel/conv/direct.rs
+++ b/crates/burn-cubecl/src/kernel/conv/direct.rs
@@ -41,6 +41,7 @@ fn direct_conv2d_kernel<E: Numeric, NIn: Size, NOut: Size>(
     shape_out: Sequence<FastDivmod<u32>>,
     shape_out_c: FastDivmod<u32>,
     #[comptime] has_padding: bool,
+    #[comptime] accumulate_lanes: bool,
     #[define(E)] _dtype: ElemType,
 ) {
     if !output.is_in_bounds(ABSOLUTE_POS) {
@@ -104,6 +105,7 @@ fn direct_conv2d_kernel<E: Numeric, NIn: Size, NOut: Size>(
         &loop_params,
         0usize,
         has_padding,
+        accumulate_lanes,
     );
 
     output.write(ABSOLUTE_POS, sum);
@@ -133,6 +135,7 @@ fn kernel_loop<E: Numeric, NIn: Size, NOut: Size>(
     params: &LoopParams,
     #[comptime] kernel_dim: usize,
     #[comptime] has_padding: bool,
+    #[comptime] accumulate_lanes: bool,
 ) {
     if comptime![kernel_dim < params.kernel_shape.len()] {
         let out_idx = *params.out_pos.index(kernel_dim);
@@ -161,6 +164,7 @@ fn kernel_loop<E: Numeric, NIn: Size, NOut: Size>(
                 params,
                 comptime![kernel_dim + 1],
                 has_padding,
+                accumulate_lanes,
             );
         }
     } else {
@@ -173,6 +177,7 @@ fn kernel_loop<E: Numeric, NIn: Size, NOut: Size>(
             weight_offs,
             params.in_c_per_group,
             params.stride_oc,
+            accumulate_lanes,
         );
     }
 }
@@ -187,28 +192,109 @@ fn kernel_loop_inner<E: Numeric, NIn: Size, NOut: Size>(
     weight_offs: usize,
     in_c_per_group: u32,
     stride_oc: usize,
+    #[comptime] accumulate_lanes: bool,
+) {
+    if in_bounds {
+        if accumulate_lanes {
+            accumulate_in_lanes(
+                input,
+                weight,
+                sum,
+                in_offs,
+                weight_offs,
+                in_c_per_group,
+                stride_oc,
+            );
+        } else {
+            accumulate_per_step(
+                input,
+                weight,
+                sum,
+                in_offs,
+                weight_offs,
+                in_c_per_group,
+                stride_oc,
+            );
+        }
+    }
+}
+
+/// Sums a tap's channels in a vector accumulator, one per output channel, and folds the lanes
+/// into `sum` once the channel loop is done.
+///
+/// The adds in the loop are independent, so it is a chain of multiply-adds rather than a
+/// dependency chain the length of the reduction. It reloads the input vector once per output
+/// channel to get there, which the channel loop has to be long enough to pay for.
+#[cube]
+fn accumulate_in_lanes<E: Numeric, NIn: Size, NOut: Size>(
+    input: &Tensor<Vector<E, NIn>>,
+    weight: &Tensor<Vector<E, NIn>>,
+    sum: &mut Vector<E, NOut>,
+    in_offs: usize,
+    weight_offs: usize,
+    in_c_per_group: u32,
+    stride_oc: usize,
 ) {
     let vector_size_in = input.vector_size();
     let vector_size_out = sum.vector_size();
 
-    if in_bounds {
-        for in_c in range_stepped(0, in_c_per_group, vector_size_in as u32) {
-            let in_pos = in_offs + in_c as usize;
-            let mut weight_pos = weight_offs + in_c as usize;
+    #[unroll]
+    for v in 0..vector_size_out {
+        let mut lanes = Vector::<E, NIn>::zero();
+        let weight_offs = weight_offs + v * stride_oc;
 
-            let val = input[in_pos / vector_size_in];
+        for in_c in range_stepped(0, in_c_per_group, vector_size_in as u32) {
+            let val = input[(in_offs + in_c as usize) / vector_size_in];
+
+            lanes += val * weight[(weight_offs + in_c as usize) / vector_size_in];
+        }
+
+        let mut channel = sum.extract(v);
+
+        #[unroll]
+        for i in 0..vector_size_in {
+            channel += lanes.extract(i);
+        }
+
+        sum.insert(v, channel);
+    }
+}
+
+/// Folds each product into `sum` where it is produced, so one read of the input vector serves
+/// every output channel.
+///
+/// A channel loop that runs once has no dependency chain to break and no reduction to amortize,
+/// which leaves that shared read the only thing left to win. Measured on MobileNetV3-Small,
+/// where every depthwise convolution lands here.
+#[cube]
+fn accumulate_per_step<E: Numeric, NIn: Size, NOut: Size>(
+    input: &Tensor<Vector<E, NIn>>,
+    weight: &Tensor<Vector<E, NIn>>,
+    sum: &mut Vector<E, NOut>,
+    in_offs: usize,
+    weight_offs: usize,
+    in_c_per_group: u32,
+    stride_oc: usize,
+) {
+    let vector_size_in = input.vector_size();
+    let vector_size_out = sum.vector_size();
+
+    for in_c in range_stepped(0, in_c_per_group, vector_size_in as u32) {
+        let in_pos = in_offs + in_c as usize;
+        let mut weight_pos = weight_offs + in_c as usize;
+
+        let val = input[in_pos / vector_size_in];
+
+        #[unroll]
+        for v in 0..vector_size_out {
+            let weight = weight[weight_pos / vector_size_in];
+            let val = val * weight;
 
             #[unroll]
-            for v in 0..vector_size_out {
-                let weight = weight[weight_pos / vector_size_in];
-                let val = val * weight;
-
-                #[unroll]
-                for i in 0..vector_size_in {
-                    sum.insert(v, sum.extract(v) + val.extract(i));
-                }
-                weight_pos += stride_oc;
+            for i in 0..vector_size_in {
+                sum.insert(v, sum.extract(v) + val.extract(i));
             }
+            weight_pos += stride_oc;
         }
     }
 }
@@ -279,6 +365,13 @@ pub fn conv_direct<R: CubeRuntime, const N: usize>(
     // Use channels_per_group instead of in_channels to avoid issues here
     let vector_size_in = max_vector_size(&weight);
 
+    // Two things have to hold for a vector accumulator to pay. There has to be a vector: at
+    // one lane, accumulating into it is exactly as serial as accumulating into `sum`, and
+    // only the extra reads are left. And the channel loop has to run more than once, or
+    // there is nothing to amortize the reduction over.
+    let accumulate_lanes =
+        vector_size_in > 1 && weight.meta.shape()[dim_c] > vector_size_in as usize;
+
     let shape_out = output.meta.shape()[1..dim_c]
         .iter()
         .map(|s| *s as u32)
@@ -315,6 +408,7 @@ pub fn conv_direct<R: CubeRuntime, const N: usize>(
             shape_out,
             shape_out_c,
             check_spatial_bounds,
+            accumulate_lanes,
             dtype_to_storage_type(out_dtype),
         )
     };

--- a/crates/burn-cubecl/src/kernel/conv/direct.rs
+++ b/crates/burn-cubecl/src/kernel/conv/direct.rs
@@ -219,12 +219,7 @@ fn kernel_loop_inner<E: Numeric, NIn: Size, NOut: Size>(
     }
 }
 
-/// Sums a tap's channels in a vector accumulator, one per output channel, and folds the lanes
-/// into `sum` once the channel loop is done.
-///
-/// The adds in the loop are independent, so it is a chain of multiply-adds rather than a
-/// dependency chain the length of the reduction. It reloads the input vector once per output
-/// channel to get there, which the channel loop has to be long enough to pay for.
+/// One input read per output channel buys a channel loop with no dependency chain.
 #[cube]
 fn accumulate_in_lanes<E: Numeric, NIn: Size, NOut: Size>(
     input: &Tensor<Vector<E, NIn>>,
@@ -260,12 +255,7 @@ fn accumulate_in_lanes<E: Numeric, NIn: Size, NOut: Size>(
     }
 }
 
-/// Folds each product into `sum` where it is produced, so one read of the input vector serves
-/// every output channel.
-///
-/// A channel loop that runs once has no dependency chain to break and no reduction to amortize,
-/// which leaves that shared read the only thing left to win. Measured on MobileNetV3-Small,
-/// where every depthwise convolution lands here.
+/// One input read serves every output channel, which is all a one-step channel loop can win.
 #[cube]
 fn accumulate_per_step<E: Numeric, NIn: Size, NOut: Size>(
     input: &Tensor<Vector<E, NIn>>,
@@ -365,9 +355,9 @@ pub fn conv_direct<R: CubeRuntime, const N: usize>(
     // Use channels_per_group instead of in_channels to avoid issues here
     let vector_size_in = max_vector_size(&weight);
 
-    // The vector accumulator breaks a dependency chain that only a single-unit plane pays in
-    // full: a wide plane hides it behind its other lanes and is left with the extra input read
-    // per output channel. It also needs a vector, and a channel loop that runs more than once.
+    // Only a single-unit plane pays the dependency chain in full; a wide plane hides it and is
+    // left with the extra input read per output channel. One lane is exactly as serial as `sum`,
+    // and a channel loop of one step has nothing to amortize the fold over.
     let accumulate_lanes = input.client.properties().hardware.plane_size_max == 1
         && vector_size_in > 1
         && weight.meta.shape()[dim_c] > vector_size_in as usize;


### PR DESCRIPTION
The direct convolution's channel loop multiplied a vector of input channels by a vector of
weights and folded the product into `sum` one lane at a time, so every tap ended in `NIn`
adds on the same lane of `sum`. For a 512 channel convolution that is a serial chain as long
as the whole reduction, and the multiply never fuses into an add.

Each output channel now accumulates into its own vector across the channel loop, and the
lanes fold into `sum` once per tap. The adds in the loop are independent, so it becomes a
chain of multiply-adds.

## Where it applies

The accumulating form reads the input vector once per output channel where the old form
shared one read, so it is taken only where the chain it breaks is actually paid:

```rust
let accumulate_lanes = input.client.properties().hardware.plane_size_max == 1
    && vector_size_in > 1
    && weight.meta.shape()[dim_c] > vector_size_in as usize;
```

A plane of one unit has nothing to hide a dependency chain behind. Today that is the CPU
runtime; CUDA, HIP and wgpu report their warp or subgroup size, so every GPU compiles the
same kernel as before. The other two conditions keep the old body for a single lane and for
a channel loop that runs once, which is where stems and depthwise convolutions land.

## Results

cubecl-cpu on a Ryzen 5700X, medians of four runs per arm:

| model | batch | before | after | |
|---|---|---|---|---|
| ResNet-50 | 1 | 165.1 ms | 145.1 ms | -12.1% |
| ResNet-50 | 8 | 818.7 ms | 604.5 ms | -26.2% |
| MobileNetV3-Small | 1 | 37.0 ms | 37.0 ms | flat |
| MobileNetV3-Small | 8 | 64.7 ms | 64.1 ms | flat |

Per layer, on the 5700X and on a Xeon E5-2620 v4, every convolution wider than one vector
runs 2 to 3.5x faster and the gated ones are unchanged. Peak resident memory is unchanged.
Summation order changes, so results move within float rounding: max absolute logit
difference on ResNet-50 is 7.6e-6, the same as before.

## Testing

`conv` and `conv_transpose` suites green on cubecl-cpu, CUDA (Ada and Turing) and Vulkan
(RDNA1 and Intel integrated). The GPU kernels are unchanged, verified by diffing the
compiled CUDA source of the gated variant against main's.
