### PR TITLE
fix(dispatch): restore autodiff context promotion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4282,7 +4282,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.20",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]

--- a/crates/burn-backend-extension/src/derive.rs
+++ b/crates/burn-backend-extension/src/derive.rs
@@ -181,6 +181,40 @@ fn gen_routing_tensor_arm(case: &DeriveCase, float_only: bool) -> TokenStream {
     quote!(#pattern => #expression,)
 }
 
+/// Generate one arm that merges the contexts of every tensor in the active variant.
+fn gen_autodiff_context_arm(case: &DeriveCase) -> TokenStream {
+    let needed: Vec<_> = case
+        .fields
+        .iter()
+        .enumerate()
+        .filter(|(_, field)| field.is_ext || field.tensor_kind.is_some())
+        .map(|(index, _)| index)
+        .collect();
+    let merges = needed.iter().map(|&index| {
+        let field = &case.fields[index];
+        let bind = &field.bind;
+        if field.is_ext {
+            let dispatch_ty = ir::with_backend(&field.ty, quote!(burn::backend::Dispatch));
+            quote! {
+                let __context = __context.merge(
+                    <#dispatch_ty as burn::backend::ExtensionType<burn::backend::Dispatch>>::autodiff_context(#bind)
+                );
+            }
+        } else {
+            quote!(let __context = __context.merge(#bind.autodiff);)
+        }
+    });
+    let pattern = gen_case_pattern(case, |index| needed.contains(&index));
+
+    quote! {
+        #pattern => {
+            let __context = burn::backend::DispatchAutodiffContext::Disabled;
+            #(#merges)*
+            __context
+        },
+    }
+}
+
 pub(crate) fn expand(input: TokenStream) -> syn::Result<TokenStream> {
     let input: DeriveInput = syn::parse2(input)?;
     let name = &input.ident;
@@ -236,6 +270,7 @@ pub(crate) fn expand(input: TokenStream) -> syn::Result<TokenStream> {
 
     let routing_tensor_arms = cases.iter().map(|case| gen_routing_tensor_arm(case, false));
     let float_routing_tensor_arms = cases.iter().map(|case| gen_routing_tensor_arm(case, true));
+    let autodiff_context_arms = cases.iter().map(gen_autodiff_context_arm);
 
     Ok(quote! {
         impl #impl_generics burn::backend::ExtensionType<B> for #name #ty_generics #where_clause {
@@ -267,6 +302,12 @@ pub(crate) fn expand(input: TokenStream) -> syn::Result<TokenStream> {
 
             fn routing_float_tensor(target: &Self::Target) -> Option<&burn::backend::DispatchTensor> {
                 match target { #(#float_routing_tensor_arms)* }
+            }
+
+            fn autodiff_context(
+                target: &Self::Target,
+            ) -> burn::backend::DispatchAutodiffContext {
+                match target { #(#autodiff_context_arms)* }
             }
         }
     })

--- a/crates/burn-backend-extension/src/dispatch.rs
+++ b/crates/burn-backend-extension/src/dispatch.rs
@@ -138,12 +138,14 @@ fn expand_from_input(operation: &Operation, source: &OperationInput) -> TokenStr
     } else {
         quote!(*__inner)
     };
+    let paths = routing::RoutingPaths::dispatch();
+    let autodiff_context = routing::operation_autodiff_context(operation, &paths);
     expand_backend_match(
         operation,
         Some(source),
         quote! {
-            let __ad_ctx = #name.autodiff;
-            let __burn_selected_context = __ad_ctx;
+            let __burn_selected_context = #name.autodiff;
+            #autodiff_context
         },
         source_kind,
         inner_kind,
@@ -157,12 +159,13 @@ fn expand_from_candidates(operation: &Operation) -> TokenStream {
         &paths,
         "dispatched operation received no tensor input to select a backend from",
     );
+    let autodiff_context = routing::operation_autodiff_context(operation, &paths);
     expand_backend_match(
         operation,
         None,
         quote! {
             #routing_tensor_init
-            let __ad_ctx = __routing_tensor.autodiff;
+            #autodiff_context
         },
         quote!(&__routing_tensor.kind),
         quote!(__inner.as_ref()),

--- a/crates/burn-backend-extension/src/extension.rs
+++ b/crates/burn-backend-extension/src/extension.rs
@@ -415,8 +415,9 @@ fn validate_extension_ty(ty: &Type) -> syn::Result<()> {
 /// Backend identity is nested inside `DispatchTensorKind::Autodiff` for tracked float tensors, and
 /// extension structs can't be destructured in a dispatch-kind match. Therefore we:
 /// 1. Find a routing [`DispatchTensor`] (a bare tensor itself, or a struct's via
-///    `ExtensionType::routing_tensor`) and fold its `.kind`, autodiff context, and float status into
-///    small values. This drops all borrows before any input is moved.
+///    `ExtensionType::routing_tensor`) and fold its `.kind` and float status into small values.
+///    Separately merge every input's autodiff context. This drops all borrows before any input is
+///    moved.
 /// 2. In the matched context/backend arm, unwrap every input and re-wrap the output.
 ///
 /// For an autodiff arm the target backend is `Autodiff<B>`: float tensors/fields unwrap through the
@@ -443,9 +444,10 @@ fn gen_tensor_input_dispatch_body(ir: &Extension, op: &Operation) -> TokenStream
         &paths,
         "backend extension op received no tensor input to select a backend from (e.g. an enum input on a tensor-less variant with no other tensor input)",
     );
+    let autodiff_context = routing::operation_autodiff_context(op, &paths);
 
-    // The routing tensor selects the concrete backend and autodiff context. Whether the active
-    // inputs contain a float decides if an enabled context needs the autodiff implementation.
+    // The routing tensor selects the concrete backend. The merged context and whether the active
+    // inputs contain a float decide if the autodiff implementation is needed.
     let kind_arms = routing::backend_kind_arms(
         &paths,
         &ir.backends.concrete,
@@ -477,7 +479,7 @@ fn gen_tensor_input_dispatch_body(ir: &Extension, op: &Operation) -> TokenStream
             bool,
         ) = {
             #routing_tensor_init
-            let __ad_ctx = __routing_tensor.autodiff;
+            #autodiff_context
             let __backend_tag = match &__routing_tensor.kind {
                 #ad_tag_arm
                 #( #concrete_tag_arms )*

--- a/crates/burn-backend-extension/src/lib.rs
+++ b/crates/burn-backend-extension/src/lib.rs
@@ -63,9 +63,9 @@ pub fn backend_dispatch(attr: TokenStream, item: TokenStream) -> TokenStream {
 
 /// Generates the `Dispatch` implementation for a backend extension trait.
 ///
-/// The backend and autodiff context come from one routing tensor, preferring a float. Every
-/// tensor-bearing input must share that backend and context; generated routing
-/// validates contexts while unwrapping the inputs.
+/// The backend comes from one routing tensor, preferring a float. The autodiff contexts of all
+/// tensor-bearing inputs are merged; disabled inputs act as constants, while enabled inputs must
+/// share a gradient-checkpointing strategy.
 ///
 /// ```rust,ignore
 /// #[backend_extension(Autodiff, Wgpu)]

--- a/crates/burn-backend-extension/src/routing.rs
+++ b/crates/burn-backend-extension/src/routing.rs
@@ -1,11 +1,10 @@
 //! Shared routing code generation for backend dispatch and backend extensions.
 //!
 //! Both attribute macros normalize a method into [`Operation`] and use this module for the routing
-//! contract. Generated code selects a concrete backend and autodiff context from one routing tensor,
-//! unwraps every input for the selected backend, invokes the operation, and wraps its output back
-//! into dispatch tensors. Routing validates every tensor-bearing input against the selected
-//! context while unwrapping it. Backend selection remains an enum match: this layer does not
-//! introduce trait-object dispatch or backend lookup tables.
+//! contract. Generated code selects a concrete backend from one routing tensor, merges the autodiff
+//! context of every input, unwraps the inputs for the resolved backend and context, invokes the
+//! operation, and wraps its output back into dispatch tensors. Backend selection remains an enum
+//! match: this layer does not introduce trait-object dispatch or backend lookup tables.
 //!
 //! A required bare tensor can be matched and extracted directly. Operations containing only
 //! optional, vector, quantization-parameter, or extension inputs first search those inputs for a
@@ -349,6 +348,57 @@ pub(crate) fn operation_routing_tensor(
     )
 }
 
+/// Merge the autodiff contexts of every active tensor input into `__ad_ctx`.
+///
+/// This is separate from backend selection: one tensor supplies the concrete backend tag, while
+/// all tensors participate in choosing whether the operation runs through autodiff.
+pub(crate) fn operation_autodiff_context(
+    operation: &Operation,
+    paths: &RoutingPaths,
+) -> TokenStream {
+    let dispatch_root = &paths.dispatch_root;
+    let extension_trait = &paths.extension_trait;
+    let merges = operation.inputs.iter().filter_map(|input| {
+        let name = &input.name;
+        match &input.kind {
+            InputKind::Tensor { .. } => Some(quote! {
+                __ad_ctx = __ad_ctx.merge(#name.autodiff);
+            }),
+            InputKind::OptionTensor(_) => Some(quote! {
+                if let Some(__tensor) = #name.as_ref() {
+                    __ad_ctx = __ad_ctx.merge(__tensor.autodiff);
+                }
+            }),
+            InputKind::VecTensor(_) => Some(quote! {
+                for __tensor in &#name {
+                    __ad_ctx = __ad_ctx.merge(__tensor.autodiff);
+                }
+            }),
+            InputKind::QuantizationParameters => Some(quote! {
+                __ad_ctx = __ad_ctx.merge(#name.scales.autodiff);
+                if let Some(__tensor) = #name.global.as_ref() {
+                    __ad_ctx = __ad_ctx.merge(__tensor.autodiff);
+                }
+            }),
+            InputKind::Extension(ty) => {
+                let dispatch_backend = quote!(#dispatch_root::Dispatch);
+                let target = ir::with_backend(ty, dispatch_backend.clone());
+                Some(quote! {
+                    __ad_ctx = __ad_ctx.merge(
+                        <#target as #extension_trait<#dispatch_backend>>::autodiff_context(&#name)
+                    );
+                })
+            }
+            InputKind::Other => None,
+        }
+    });
+
+    quote! {
+        let mut __ad_ctx = #dispatch_root::DispatchAutodiffContext::Disabled;
+        #(#merges)*
+    }
+}
+
 fn routing_candidate(
     input: &OperationInput,
     paths: &RoutingPaths,
@@ -588,12 +638,16 @@ fn extract_tensor(
     let ad_cfg = cfg_attr(extraction.autodiff_cfg);
     let accessor = kind.accessor();
     let accessor_ref = format_ident!("as_{accessor}");
-    let validate_context = quote! {
-        assert_eq!(
-            __ad_ctx,
-            #name.autodiff,
-            "Autodiff context mismatch: all tensors in the same operation must share a context"
-        );
+    let context = quote!(#dispatch_root::DispatchAutodiffContext);
+    let validate_enabled_float = quote! {
+        let #context::Enabled(_) = #name.autodiff else {
+            panic!("an autodiff float primitive must have an enabled autodiff context")
+        };
+    };
+    let validate_disabled_float = quote! {
+        let #context::Disabled = #name.autodiff else {
+            panic!("an enabled float tensor must use an autodiff primitive")
+        };
     };
     let invalid_autodiff_float = extraction.has_autodiff_variant.then(|| {
         quote! {
@@ -610,16 +664,17 @@ fn extract_tensor(
         if borrowed {
             let lifted = format_ident!("__lifted_{name}");
             quote! {
-                #validate_context
                 let #lifted;
                 let #name = match &#name.kind {
                     #dispatch_kind::Autodiff(__inner) => {
+                        #validate_enabled_float
                         match __inner.as_ref() {
                             #dispatch_kind::#backend(__inner) => __inner.as_autodiff(),
                             _ => panic!("input tensor `{}` is on the wrong backend", stringify!(#name)),
                         }
                     }
                     #dispatch_kind::#backend(__inner) => {
+                        #validate_disabled_float
                         #lifted = <#backend_alias as #autodiff_trait>::from_inner(__inner.as_float().clone());
                         &#lifted
                     }
@@ -628,15 +683,16 @@ fn extract_tensor(
             }
         } else {
             quote! {
-                #validate_context
                 let #name = match #name.kind {
                     #dispatch_kind::Autodiff(__inner) => {
+                        #validate_enabled_float
                         match *__inner {
                             #dispatch_kind::#backend(__inner) => __inner.autodiff(),
                             _ => panic!("input tensor `{}` is on the wrong backend", stringify!(#name)),
                         }
                     }
                     #dispatch_kind::#backend(__inner) => {
+                        #validate_disabled_float
                         <#backend_alias as #autodiff_trait>::from_inner(__inner.float())
                     }
                     _ => panic!("input tensor `{}` is on the wrong backend", stringify!(#name)),
@@ -646,7 +702,6 @@ fn extract_tensor(
     } else if kind == TensorKind::Float {
         if borrowed {
             quote! {
-                #validate_context
                 let #name = match &#name.kind {
                     #dispatch_kind::#backend(__inner) => __inner.as_float(),
                     #invalid_autodiff_float
@@ -655,7 +710,6 @@ fn extract_tensor(
             }
         } else {
             quote! {
-                #validate_context
                 let #name = match #name.kind {
                     #dispatch_kind::#backend(__inner) => __inner.float(),
                     #invalid_autodiff_float
@@ -665,7 +719,6 @@ fn extract_tensor(
         }
     } else if borrowed {
         quote! {
-            #validate_context
             let #name = match &#name.kind {
                 #dispatch_kind::#backend(__inner) => __inner.#accessor_ref(),
                 #invalid_autodiff_kind
@@ -674,7 +727,6 @@ fn extract_tensor(
         }
     } else {
         quote! {
-            #validate_context
             let #name = match #name.kind {
                 #dispatch_kind::#backend(__inner) => __inner.#accessor(),
                 #invalid_autodiff_kind
@@ -701,31 +753,43 @@ fn extract_extension(
     let mismatch = quote!(panic!("backend extension input is on the wrong backend"));
     if autodiff {
         let target = ir::with_backend(ty, quote!(#backend_alias));
+        let context = quote!(#dispatch_root::DispatchAutodiffContext);
         quote! {
             let #name = <#target as #extension_trait<#backend_alias>>::map_from_dispatch(#name, |__tensor| {
-                assert_eq!(
-                    __ad_ctx,
-                    __tensor.autodiff,
-                    "Autodiff context mismatch: all tensors in the same operation must share a context"
-                );
-                let tensor = match __tensor.kind {
-                    #dispatch_kind::Autodiff(inner) => match *inner {
-                        #dispatch_kind::#backend(tensor) => tensor,
-                        #[allow(unreachable_patterns)]
-                        _ => #mismatch,
+                let __input_context = __tensor.autodiff;
+                match __tensor.kind {
+                    #dispatch_kind::Autodiff(inner) => {
+                        let #context::Enabled(_) = __input_context else {
+                            panic!("an autodiff float primitive must have an enabled autodiff context")
+                        };
+                        let tensor = match *inner {
+                            #dispatch_kind::#backend(tensor) => tensor,
+                            #[allow(unreachable_patterns)]
+                            _ => #mismatch,
+                        };
+                        match tensor {
+                            #backend_tensor::Autodiff(tensor) => #backend_tensor::Float(tensor),
+                            _ => panic!("only float tensors may use an autodiff primitive"),
+                        }
+                    }
+                    #dispatch_kind::#backend(tensor) => match tensor {
+                        #backend_tensor::Float(tensor) => {
+                            let #context::Disabled = __input_context else {
+                                panic!("an enabled float tensor must use an autodiff primitive")
+                            };
+                            #backend_tensor::Float(
+                                <#backend_alias as #autodiff_trait>::from_inner(tensor)
+                            )
+                        }
+                        #backend_tensor::Int(tensor) => #backend_tensor::Int(tensor),
+                        #backend_tensor::Bool(tensor) => #backend_tensor::Bool(tensor),
+                        #backend_tensor::Quantized(tensor) => #backend_tensor::Quantized(tensor),
+                        #backend_tensor::Autodiff(_) => {
+                            panic!("autodiff float input reached concrete dispatch")
+                        }
                     },
-                    #dispatch_kind::#backend(tensor) => tensor,
                     #[allow(unreachable_patterns)]
                     _ => #mismatch,
-                };
-                match tensor {
-                    #backend_tensor::Autodiff(tensor) => #backend_tensor::Float(tensor),
-                    #backend_tensor::Float(tensor) => #backend_tensor::Float(
-                        <#backend_alias as #autodiff_trait>::from_inner(tensor)
-                    ),
-                    #backend_tensor::Int(tensor) => #backend_tensor::Int(tensor),
-                    #backend_tensor::Bool(tensor) => #backend_tensor::Bool(tensor),
-                    #backend_tensor::Quantized(tensor) => #backend_tensor::Quantized(tensor),
                 }
             });
         }
@@ -735,11 +799,6 @@ fn extract_extension(
             let #name = <#target as #extension_trait<#backend_root::#backend>>::map_from_dispatch(
                 #name,
                 |__tensor| {
-                    assert_eq!(
-                        __ad_ctx,
-                        __tensor.autodiff,
-                        "Autodiff context mismatch: all tensors in the same operation must share a context"
-                    );
                     match __tensor.kind {
                         #dispatch_kind::#backend(tensor) => tensor,
                         #[allow(unreachable_patterns)]

--- a/crates/burn-core/src/backend.rs
+++ b/crates/burn-core/src/backend.rs
@@ -17,8 +17,9 @@ pub use burn_dispatch::backends::*;
 /// into a [`DispatchTensor`]; when it takes one as an input, [`map_from_dispatch`](Self::map_from_dispatch)
 /// reconstructs the concrete value and [`routing_tensor`](Self::routing_tensor) /
 /// [`routing_float_tensor`](Self::routing_float_tensor) locate a tensor for dispatch routing and
-/// backend and autodiff-context selection. All tensor fields participating in one operation must
-/// share the routing tensor's context. Nested `#[extension_type]` fields are traversed recursively.
+/// backend selection. [`autodiff_context`](Self::autodiff_context) merges the contexts of all tensor
+/// fields participating in one operation. Nested `#[extension_type]` fields are traversed
+/// recursively.
 ///
 /// Implementations are generated automatically using `#[derive(ExtensionType)]`.
 pub trait ExtensionType<B: Backend> {
@@ -52,7 +53,7 @@ pub trait ExtensionType<B: Backend> {
     /// # Arguments
     ///
     /// * `unwrap_kind` - A closure provided by the dispatch macro that validates the tensor's
-    ///   autodiff context and unwraps its [`DispatchTensorKind`] into the [`BackendTensor`] for the
+    ///   representation and unwraps its [`DispatchTensorKind`] into the [`BackendTensor`] for the
     ///   selected backend `B`, panicking on a backend mismatch.
     fn map_from_dispatch<F>(target: Self::Target, unwrap_kind: F) -> Self
     where
@@ -75,4 +76,17 @@ pub trait ExtensionType<B: Backend> {
     /// [`routing_tensor`](Self::routing_tensor) only when no float tensor exists anywhere in the
     /// inputs.
     fn routing_float_tensor(target: &Self::Target) -> Option<&DispatchTensor>;
+
+    /// Merge the autodiff contexts of every tensor held by the dispatch form.
+    ///
+    /// A tensor-less value returns [`DispatchAutodiffContext::Disabled`]. The default uses the
+    /// routing tensor and is sufficient for single-tensor implementations; implementations that
+    /// can hold multiple tensors must merge every tensor context. The derive handles this
+    /// automatically.
+    #[doc(hidden)]
+    fn autodiff_context(target: &Self::Target) -> DispatchAutodiffContext {
+        Self::routing_tensor(target)
+            .map(|tensor| tensor.autodiff)
+            .unwrap_or_default()
+    }
 }

--- a/crates/burn-dispatch/src/backend.rs
+++ b/crates/burn-dispatch/src/backend.rs
@@ -932,6 +932,10 @@ mod autodiff_context_tests {
         Dispatch::float_from_data(TensorData::from(values), device)
     }
 
+    fn float_2d(values: [[f32; 2]; 2], device: &DispatchDevice) -> DispatchTensor {
+        Dispatch::float_from_data(TensorData::from(values), device)
+    }
+
     fn assert_enabled_float(tensor: &DispatchTensor, strategy: GradientCheckpointingStrategy) {
         assert_eq!(tensor.autodiff, DispatchAutodiffContext::Enabled(strategy));
         assert!(matches!(tensor.kind, DispatchTensorKind::Autodiff(_)));
@@ -1012,7 +1016,7 @@ mod autodiff_context_tests {
         let output = Dispatch::conditional_float_route(int, None);
         assert_eq!(output.autodiff, DispatchAutodiffContext::Enabled(strategy));
 
-        let int = Dispatch::int_from_data(TensorData::from([1i32, 2]), &device(strategy));
+        let int = Dispatch::int_from_data(TensorData::from([1i32, 2]), &inner_device());
         let float = float([1.0, 2.0], &device(strategy));
         let output = Dispatch::conditional_float_route(int, Some(float));
         assert_eq!(output.autodiff, DispatchAutodiffContext::Enabled(strategy));
@@ -1028,7 +1032,7 @@ mod autodiff_context_tests {
     }
 
     #[test]
-    #[should_panic(expected = "Autodiff context mismatch")]
+    #[should_panic(expected = "Gradient checkpointing strategy mismatch")]
     fn fixed_arity_inputs_reject_mismatched_checkpointing_strategies() {
         let lhs = float([1.0, 2.0], &device(GradientCheckpointingStrategy::Balanced));
         let rhs = float([3.0, 4.0], &device(GradientCheckpointingStrategy::Disabled));
@@ -1036,18 +1040,54 @@ mod autodiff_context_tests {
     }
 
     #[test]
-    #[should_panic(expected = "Autodiff context mismatch")]
-    fn disabled_and_enabled_contexts_do_not_promote() {
-        let lhs = Dispatch::int_from_data(TensorData::from([1i32, 2]), &inner_device());
-        let rhs = Dispatch::int_from_data(
-            TensorData::from([3i32, 4]),
-            &device(GradientCheckpointingStrategy::Balanced),
-        );
-        let _ = Dispatch::int_add(lhs, rhs);
+    fn disabled_and_enabled_integer_contexts_merge_in_both_orders() {
+        for strategy in [
+            GradientCheckpointingStrategy::Disabled,
+            GradientCheckpointingStrategy::Balanced,
+        ] {
+            let lhs = Dispatch::int_from_data(TensorData::from([1i32, 2]), &inner_device());
+            let rhs = Dispatch::int_from_data(TensorData::from([3i32, 4]), &device(strategy));
+            let output = Dispatch::int_add(lhs, rhs);
+            assert_eq!(output.autodiff, DispatchAutodiffContext::Enabled(strategy));
+
+            let lhs = Dispatch::int_from_data(TensorData::from([1i32, 2]), &device(strategy));
+            let rhs = Dispatch::int_from_data(TensorData::from([3i32, 4]), &inner_device());
+            let output = Dispatch::int_add(lhs, rhs);
+            assert_eq!(output.autodiff, DispatchAutodiffContext::Enabled(strategy));
+        }
     }
 
     #[test]
-    #[should_panic(expected = "Autodiff context mismatch")]
+    fn disabled_and_enabled_float_contexts_merge_in_both_orders() {
+        for strategy in [
+            GradientCheckpointingStrategy::Disabled,
+            GradientCheckpointingStrategy::Balanced,
+        ] {
+            let enabled = float([1.0, 2.0], &device(strategy));
+            let disabled = float([3.0, 4.0], &inner_device());
+
+            let output = Dispatch::float_add(enabled, disabled);
+            assert_enabled_float(&output, strategy);
+
+            let enabled = float([1.0, 2.0], &device(strategy));
+            let disabled = float([3.0, 4.0], &inner_device());
+            let output = Dispatch::float_add(disabled, enabled);
+            assert_enabled_float(&output, strategy);
+        }
+    }
+
+    #[test]
+    fn disabled_and_enabled_contexts_merge_across_vector_inputs() {
+        let strategy = GradientCheckpointingStrategy::Balanced;
+        let disabled = float([1.0, 2.0], &inner_device());
+        let enabled = float([3.0, 4.0], &device(strategy));
+
+        let output = Dispatch::float_cat(vec![disabled, enabled], 0);
+        assert_enabled_float(&output, strategy);
+    }
+
+    #[test]
+    #[should_panic(expected = "Gradient checkpointing strategy mismatch")]
     fn vector_inputs_reject_mismatched_checkpointing_strategies() {
         let balanced = float([1.0, 2.0], &device(GradientCheckpointingStrategy::Balanced));
         let disabled = float([3.0, 4.0], &device(GradientCheckpointingStrategy::Disabled));
@@ -1055,7 +1095,7 @@ mod autodiff_context_tests {
     }
 
     #[test]
-    #[should_panic(expected = "Autodiff context mismatch")]
+    #[should_panic(expected = "Gradient checkpointing strategy mismatch")]
     fn q_matmul_rejects_mismatched_checkpointing_strategies() {
         let balanced = Dispatch::quantize_dynamic(
             float([1.0, 2.0], &device(GradientCheckpointingStrategy::Balanced)),
@@ -1069,6 +1109,28 @@ mod autodiff_context_tests {
             TensorPrimitive::QFloat(balanced),
             TensorPrimitive::QFloat(disabled),
         );
+    }
+
+    #[test]
+    fn q_matmul_merges_disabled_and_enabled_contexts() {
+        let strategy = GradientCheckpointingStrategy::Balanced;
+        let disabled = Dispatch::quantize_dynamic(
+            float_2d([[1.0, 2.0], [3.0, 4.0]], &inner_device()),
+            &QuantScheme::default(),
+        );
+        let enabled = Dispatch::quantize_dynamic(
+            float_2d([[1.0, 0.0], [0.0, 1.0]], &device(strategy)),
+            &QuantScheme::default(),
+        );
+        let output = Dispatch::q_matmul(
+            TensorPrimitive::QFloat(disabled),
+            TensorPrimitive::QFloat(enabled),
+        );
+        let output = match output {
+            TensorPrimitive::QFloat(output) | TensorPrimitive::Float(output) => output,
+        };
+
+        assert_eq!(output.autodiff, DispatchAutodiffContext::Enabled(strategy));
     }
 
     #[test]

--- a/crates/burn-dispatch/src/ops/qtensor.rs
+++ b/crates/burn-dispatch/src/ops/qtensor.rs
@@ -282,19 +282,12 @@ impl QTensorOps<Self> for Dispatch {
     fn q_matmul(lhs: TensorPrimitive<Self>, rhs: TensorPrimitive<Self>) -> TensorPrimitive<Self> {
         match (lhs, rhs) {
             (TensorPrimitive::QFloat(lhs), TensorPrimitive::QFloat(rhs)) => {
-                assert_eq!(
-                    lhs.autodiff, rhs.autodiff,
-                    "Autodiff context mismatch: all tensors in the same operation must share a context"
-                );
+                let autodiff = lhs.autodiff.merge(rhs.autodiff);
                 // With no float input, the first tensor is the routing tensor.
-                let autodiff = lhs.autodiff;
                 backend_list!(q_matmul_qq_arms, lhs, rhs, autodiff)
             }
             (TensorPrimitive::Float(lhs), TensorPrimitive::QFloat(rhs)) => {
-                assert_eq!(
-                    lhs.autodiff, rhs.autodiff,
-                    "Autodiff context mismatch: all tensors in the same operation must share a context"
-                );
+                let autodiff = lhs.autodiff.merge(rhs.autodiff);
                 #[cfg(feature = "autodiff")]
                 match (
                     matches!(&lhs.kind, DispatchTensorKind::Autodiff(_)),
@@ -309,15 +302,10 @@ impl QTensorOps<Self> for Dispatch {
                         panic!("an enabled float tensor must use an autodiff primitive")
                     }
                 }
-                // Float inputs take precedence for routing.
-                let autodiff = lhs.autodiff;
                 backend_list!(q_matmul_fq_arms, lhs, rhs, autodiff)
             }
             (TensorPrimitive::QFloat(lhs), TensorPrimitive::Float(rhs)) => {
-                assert_eq!(
-                    lhs.autodiff, rhs.autodiff,
-                    "Autodiff context mismatch: all tensors in the same operation must share a context"
-                );
+                let autodiff = lhs.autodiff.merge(rhs.autodiff);
                 #[cfg(feature = "autodiff")]
                 match (
                     matches!(&rhs.kind, DispatchTensorKind::Autodiff(_)),
@@ -332,8 +320,6 @@ impl QTensorOps<Self> for Dispatch {
                         panic!("an enabled float tensor must use an autodiff primitive")
                     }
                 }
-                // Float inputs take precedence for routing.
-                let autodiff = rhs.autodiff;
                 backend_list!(q_matmul_qf_arms, lhs, rhs, autodiff)
             }
             _ => unreachable!(),

--- a/crates/burn-dispatch/src/tensor.rs
+++ b/crates/burn-dispatch/src/tensor.rs
@@ -200,9 +200,9 @@ impl<B: BackendTypes> TensorMetadata for BackendTensor<B> {
 /// This is backend metadata, not a statement that a float tensor requires
 /// gradients. Enabled float tensors may be tracked or untracked by autodiff.
 ///
-/// All tensor inputs to one backend operation must use the same autodiff context.
-/// Dispatch selects the operation context from its routing tensor and validates the remaining
-/// inputs while unwrapping them.
+/// Tensor inputs to one backend operation merge their autodiff contexts. A disabled context is
+/// compatible with an enabled one and is treated as a constant for that operation. Two enabled
+/// contexts must use the same gradient-checkpointing strategy.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum DispatchAutodiffContext {
     /// Route the tensor through its concrete backend.
@@ -210,6 +210,31 @@ pub enum DispatchAutodiffContext {
     Disabled,
     /// Associate the tensor with an autodiff backend using the given strategy.
     Enabled(GradientCheckpointingStrategy),
+}
+
+impl DispatchAutodiffContext {
+    /// Merge two tensor contexts into the context used to execute an operation and wrap its output.
+    ///
+    /// Disabled tensors don't acquire a new context themselves. When combined with an enabled
+    /// tensor, they are treated as constants while the operation and its output use the enabled
+    /// context.
+    ///
+    /// # Panics
+    ///
+    /// Panics when both contexts are enabled with different gradient-checkpointing strategies.
+    #[doc(hidden)]
+    pub fn merge(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Disabled, context) | (context, Self::Disabled) => context,
+            (Self::Enabled(lhs), Self::Enabled(rhs)) => {
+                assert_eq!(
+                    lhs, rhs,
+                    "Gradient checkpointing strategy mismatch: {lhs:?} vs {rhs:?}. Tensors in the same operation must share a strategy."
+                );
+                Self::Enabled(lhs)
+            }
+        }
+    }
 }
 
 /// A tensor that can dispatch operations to any enabled backend at runtime.

--- a/crates/burn-train/src/learner/classification.rs
+++ b/crates/burn-train/src/learner/classification.rs
@@ -32,15 +32,15 @@ impl ItemLazy for ClassificationOutput {
         // No readback: the metrics compute on the device the tensors live on
         // and read back only their final scalars. Flushing dispatches the
         // producing stream's buffered work so the metric thread doesn't wait
-        // on an idle queue; a training item's float tensors come off the
+        // on an idle queue; all tensors in a training item come off the
         // autodiff backend entirely, so the metric thread neither retains the
-        // tape nor pays its dispatch.
+        // tape nor carries its dispatch context.
         self.loss.device().flush();
 
         ClassificationOutput {
             output: self.output.no_grad(),
             loss: self.loss.no_grad(),
-            targets: self.targets,
+            targets: self.targets.no_grad(),
         }
     }
 }
@@ -108,14 +108,14 @@ pub struct MultiLabelClassificationOutput {
 
 impl ItemLazy for MultiLabelClassificationOutput {
     fn sync(self) -> Self {
-        // Same contract as `ClassificationOutput::sync`: flush and take the
-        // floats off the tape, no readback.
+        // Same contract as `ClassificationOutput::sync`: flush and take every
+        // tensor off the autodiff backend, no readback.
         self.loss.device().flush();
 
         MultiLabelClassificationOutput {
             output: self.output.no_grad(),
             loss: self.loss.no_grad(),
-            targets: self.targets,
+            targets: self.targets.no_grad(),
         }
     }
 }

--- a/crates/burn-train/src/learner/sequence.rs
+++ b/crates/burn-train/src/learner/sequence.rs
@@ -54,16 +54,16 @@ impl ItemLazy for SequenceOutput {
         // and read back only their final scalars, which matters here because
         // the logits carry the full vocabulary dimension. Flushing dispatches
         // the producing stream's buffered work so the metric thread doesn't
-        // wait on an idle queue; a training item's float tensors come off the
+        // wait on an idle queue; all tensors in a training item come off the
         // autodiff backend entirely, so the metric thread neither retains the
-        // tape nor pays its dispatch.
+        // tape nor carries its dispatch context.
         self.loss.device().flush();
 
         SequenceOutput {
             logits: self.logits.no_grad(),
             loss: self.loss.no_grad(),
-            targets: self.targets,
-            predictions: self.predictions,
+            targets: self.targets.no_grad(),
+            predictions: self.predictions.map(|tensor| tensor.no_grad()),
         }
     }
 }

--- a/crates/burn-train/src/metric/acc.rs
+++ b/crates/burn-train/src/metric/acc.rs
@@ -109,6 +109,11 @@ impl Numeric for AccuracyMetric {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{
+        ClassificationOutput,
+        metric::{Adaptor, ItemLazy},
+    };
+    use burn_core::tensor::Device;
 
     #[test]
     fn test_accuracy_without_padding() {
@@ -153,5 +158,21 @@ mod tests {
 
         let _entry = metric.update(&input, &MetricMetadata::fake());
         assert_eq!(50.0, metric.value().unwrap().current());
+    }
+
+    #[test]
+    fn test_accuracy_after_syncing_autodiff_classification_output() {
+        let device = Device::flex().autodiff();
+        let mut metric = AccuracyMetric::new();
+        let output = ClassificationOutput::new(
+            Tensor::from_data([0.0], &device),
+            Tensor::from_data([[0.1, 0.9]], &device),
+            Tensor::from_data([1], &device),
+        )
+        .sync();
+        let input = output.adapt();
+
+        let _entry = metric.update(&input, &MetricMetadata::fake());
+        assert_eq!(100.0, metric.value().unwrap().current());
     }
 }

--- a/crates/burn/tests/autodiff_context.rs
+++ b/crates/burn/tests/autodiff_context.rs
@@ -1,0 +1,25 @@
+//! Runtime tests for merging concrete and autodiff dispatch contexts.
+
+#![cfg(all(feature = "autodiff", feature = "flex"))]
+
+use burn::tensor::{Device, Tensor, TensorData};
+
+#[test]
+fn gradient_flows_to_enabled_operand_but_not_disabled_constant() {
+    let x = Tensor::<1>::from_floats([2.0, 3.0], &Device::flex().autodiff()).require_grad();
+    let constant = Tensor::<1>::from_floats([4.0, 5.0], &Device::flex());
+
+    let output = (x.clone() * constant.clone()).sum();
+    assert!(output.device().is_autodiff());
+
+    let grads = output.backward();
+    x.grad(&grads)
+        .expect("the enabled operand should receive a gradient")
+        .into_data()
+        .assert_eq(&TensorData::from([4.0f32, 5.0]), true);
+
+    // Context merging is operation-local: the concrete operand is neither mutated nor added to
+    // the graph, and remains unavailable as a gradient target.
+    assert!(!constant.device().is_autodiff());
+    assert!(!constant.is_require_grad());
+}

--- a/crates/burn/tests/backend_extension_runtime.rs
+++ b/crates/burn/tests/backend_extension_runtime.rs
@@ -299,6 +299,10 @@ mod extension_context_contract {
             .with_gradient_checkpointing_strategy(strategy)
     }
 
+    fn inner_int() -> Tensor<1, Int> {
+        Tensor::from_data([1], &Device::ndarray())
+    }
+
     #[test]
     fn routing_context_propagates_through_nested_fields() {
         let balanced = int(GradientCheckpointingStrategy::Balanced);
@@ -308,6 +312,23 @@ mod extension_context_contract {
                 right: balanced.clone().into_dispatch(),
             },
             choice: IntChoice::Dense(balanced.into_dispatch()),
+        });
+        let output = Tensor::<1, Int>::from_dispatch(output);
+
+        assert_eq!(
+            output.device().gradient_checkpointing_strategy(),
+            GradientCheckpointingStrategy::Balanced
+        );
+    }
+
+    #[test]
+    fn nested_disabled_and_enabled_contexts_merge() {
+        let output = <Dispatch as ContextBackend>::select(NestedInputs {
+            pair: IntPair {
+                left: inner_int().into_dispatch(),
+                right: int(GradientCheckpointingStrategy::Balanced).into_dispatch(),
+            },
+            choice: IntChoice::Empty,
         });
         let output = Tensor::<1, Int>::from_dispatch(output);
 


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

> `cargo run-checks` tests with `Flex` by default. Use `cargo run-checks --backend <backend>` when
> targeting another backend. Consider running additional tests relevant to the crates changed.

### Related Issues/PRs

Fixes #5549
Follow-up to #5520

### Changes

- Add `DispatchAutodiffContext::merge` to resolve an operation’s output context:
  - `Disabled` is compatible with either context and promotes to `Enabled`
  - `Enabled` contexts must use the same checkpointing strategy
- Clear the autodiff backend association from integer targets and predictions during metric synchronization, keeping non-differentiable metric computation on the inner backend and applying the behavior introduced in #5319 consistently across all metric tensors

### Testing

Unit tests + mnist example (uses `AccuracyMetric`)
