### PR TITLE
feat(tensor): add assert_shape! and debug_assert_shape! macros

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -115,6 +115,7 @@ jobs:
   publish-burn-tensor:
     needs:
       - publish-burn-std
+      - publish-burn-derive
       - publish-burn-backend
       - publish-burn-dispatch
       - publish-burn-backend-extension

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,6 +1306,7 @@ name = "burn-tensor"
 version = "0.22.0-pre.3"
 dependencies = [
  "burn-backend",
+ "burn-derive",
  "burn-dispatch",
  "burn-std",
  "colored 3.1.1",

--- a/burn-book/src/building-blocks/module.md
+++ b/burn-book/src/building-blocks/module.md
@@ -62,13 +62,9 @@ available from the prelude, check those sizes at the boundary of a method:
 - `assert_shape!` checks the axes of a tensor. It stays on in release builds.
 - `debug_assert_shape!` is the same check, compiled out unless debug assertions are enabled.
 
-Each takes a tensor and a bracketed pattern with one slot per axis:
-
-| Slot                   | Meaning                                               |
-| ---------------------- | ----------------------------------------------------- |
-| `=expr`                | The axis must equal this in-scope `usize` expression. |
-| `80` (integer literal) | The axis must equal this value.                       |
-| `_`                    | Skip the axis.                                        |
+Each takes a tensor and a bracketed pattern with one slot per axis. A slot is either `_`, which
+skips the axis, or any `usize` expression the axis must equal: a name from `dims()`, a config field,
+a literal.
 
 The pattern length is the expected rank. Since `tensor.dims()` returns `[usize; D]`, a pattern whose
 length differs from `D` is a compile error rather than a runtime panic, and so is passing anything
@@ -94,34 +90,31 @@ impl FeedForward {
     /// - output: `[batch_size, seq_length, d_model]`
     pub fn forward(&self, input: Tensor<3>) -> Tensor<3> {
         let [batch_size, seq_length, _] = input.dims();
-        assert_shape!(input, [_, _, =self.d_model]);
+        assert_shape!(input, [_, _, self.d_model]);
 
         let x = self.linear_inner.forward(input);
-        debug_assert_shape!(x, [=batch_size, =seq_length, =self.d_ff]);
+        debug_assert_shape!(x, [batch_size, seq_length, self.d_ff]);
 
         let x = self.gelu.forward(x);
         let output = self.linear_outer.forward(x);
 
-        assert_shape!(output, [=batch_size, =seq_length, =self.d_model]);
+        assert_shape!(output, [batch_size, seq_length, self.d_model]);
         output
     }
 }
 ```
 
-A failed check panics with the macro call, the axis, the expected and actual sizes, and the full
-dims of the tensor:
+The pattern reads like the `# Shapes` line above it. A failed check panics with the macro call, the
+axis, the expected and actual sizes, and the full dims of the tensor:
 
 ```text
-assert_shape!(output, [=batch_size, =seq_length, =self.d_model]): axis 2 expected 512, got 2048 (dims [8, 128, 2048])
+assert_shape!(output, [batch_size, seq_length, self.d_model]): axis 2 expected 512, got 2048 (dims [8, 128, 2048])
 ```
-
-A bare name in a pattern is a compile error with a hint: write `=name` to check against it, or name
-the axis with `let [..] = tensor.dims()` first.
 
 ### Choosing a macro
 
 - Name the runtime axes once at the top of `forward` with
-  `let [batch_size, seq_length, _] = input.dims();` and refer to them with `=name` in every check.
+  `let [batch_size, seq_length, _] = input.dims();` and use those names in every check.
 - `assert_shape!` is the default for a contract check. A mismatch that reaches a tensor operation
   may fail there with a message about that operation's arguments, or broadcast silently when an axis
   has size 1. The check is a few integer comparisons, so its cost does not matter next to a kernel

--- a/burn-book/src/building-blocks/module.md
+++ b/burn-book/src/building-blocks/module.md
@@ -63,7 +63,8 @@ available from the prelude, check those sizes at the boundary of a method:
 - `debug_assert_shape!` is the same check, compiled out unless debug assertions are enabled.
 
 Each takes a tensor and a bracketed pattern with one slot per axis. A slot is either `_`, which
-skips the axis, or any `usize` expression the axis must equal:
+skips the axis, `..`, which stands for any number of axes and may appear once, or any `usize`
+expression the axis must equal:
 
 ```rust, ignore
 let [batch_size, seq_length, _] = x.dims();
@@ -74,11 +75,21 @@ assert_shape!(flat, [batch_size * seq_length, 256]);   // arithmetic on names
 assert_shape!(patch, [3 * 2, 2]);                      // arithmetic on literals
 assert_shape!(mask, [batch_size, _]);                  // skip an axis
 assert_shape!(hidden, [_, _, self.d_model]);           // a config field
+assert_shape!(hidden, [.., self.d_model]);             // any rank, last axis checked
 ```
 
 The pattern length is the expected rank. Since `tensor.dims()` returns `[usize; D]`, a pattern whose
 length differs from `D` is a compile error rather than a runtime panic, and so is passing anything
-other than a `Tensor`.
+other than a `Tensor`. That makes an exact pattern unusable in a method generic over
+`const D: usize`, like the `PositionWiseFeedForward` at the top of this page. Use `..` there for the
+axes you do not name; the pattern then checks a minimum rank at runtime instead:
+
+```rust, ignore
+pub fn forward<const D: usize>(&self, input: Tensor<D>) -> Tensor<D> {
+    assert_shape!(input, [.., self.d_model]);
+    // ...
+}
+```
 
 ```rust, ignore
 use burn::nn::{Gelu, Linear};

--- a/burn-book/src/building-blocks/module.md
+++ b/burn-book/src/building-blocks/module.md
@@ -96,12 +96,12 @@ impl PositionWiseFeedForward {
         let (batch_size, seq_length) = unpack_shape!(input, [B, T, =self.d_model]);
 
         let x = self.linear_inner.forward(input);
-        assert_shape!(x, [=batch_size, =seq_length, =self.d_ff]);
+        debug_assert_shape!(x, [=batch_size, =seq_length, =self.d_ff]);
 
         let x = self.gelu.forward(x);
         let output = self.linear_outer.forward(x);
 
-        debug_assert_shape!(output, [=batch_size, =seq_length, =self.d_model]);
+        assert_shape!(output, [=batch_size, =seq_length, =self.d_model]);
         output
     }
 }
@@ -114,24 +114,24 @@ A failed check panics with the macro call, the axis, the expected and actual siz
 dims of the tensor:
 
 ```text
-assert_shape!(x, [=batch_size, =seq_length, =self.d_ff]): axis 2 expected 2048, got 512 (dims [8, 128, 512])
+assert_shape!(output, [=batch_size, =seq_length, =self.d_model]): axis 2 expected 512, got 2048 (dims [8, 128, 2048])
 ```
 
-Misuse is caught at compile time: a bare name inside `assert_shape!` or `debug_assert_shape!` is
-rejected with a hint to use `unpack_shape!` or `=`, and an `unpack_shape!` with nothing to bind is
-rejected with a hint to use `assert_shape!`.
+A bare name inside `assert_shape!` or `debug_assert_shape!`, or an `unpack_shape!` with nothing to
+bind, is a compile error with a hint toward the right macro.
 
 ### Choosing a macro
 
-- Start `forward` with `unpack_shape!` on the input. It names the runtime axes once, and every later
-  check refers to them with `=name`.
-- Use `assert_shape!` for the contract itself: the output, and any intermediate whose shape is not
-  obvious from the preceding call. The check is a few integer comparisons next to tensor operations
-  that launch kernels, so its cost does not matter.
-- Use `debug_assert_shape!` inside hot loops, or for internal invariants already implied by an
-  earlier always-on check. Burn's own modules use it in their forward passes: the tensor operations
-  they call validate shapes in every build, so the boundary check only needs to improve the message
-  during development.
+The question for each check is whether a later operation would reject the mismatch anyway.
+
+- `unpack_shape!` at the top of `forward` names the runtime axes once, and every later check refers
+  to them with `=name`.
+- `assert_shape!` is for mismatches nothing else would catch: an output that callers rely on, or an
+  input that a following operation would silently broadcast. The check is a few integer comparisons,
+  so its cost does not matter next to a kernel launch.
+- `debug_assert_shape!` is for checks that only improve the error message, because the following
+  operation already rejects the mismatch in every build. Burn's own modules use it in their forward
+  passes for this reason.
 
 These checks complement the validation Burn performs inside each tensor operation. An operation
 reports a mismatch in terms of its own arguments; a boundary check reports it in terms of the

--- a/burn-book/src/building-blocks/module.md
+++ b/burn-book/src/building-blocks/module.md
@@ -129,7 +129,9 @@ rejected with a hint to use `assert_shape!`.
   obvious from the preceding call. The check is a few integer comparisons next to tensor operations
   that launch kernels, so its cost does not matter.
 - Use `debug_assert_shape!` inside hot loops, or for internal invariants already implied by an
-  earlier always-on check.
+  earlier always-on check. Burn's own modules use it in their forward passes: the tensor operations
+  they call validate shapes in every build, so the boundary check only needs to improve the message
+  during development.
 
 These checks complement the validation Burn performs inside each tensor operation. An operation
 reports a mismatch in terms of its own arguments; a boundary check reports it in terms of the

--- a/burn-book/src/building-blocks/module.md
+++ b/burn-book/src/building-blocks/module.md
@@ -63,8 +63,18 @@ available from the prelude, check those sizes at the boundary of a method:
 - `debug_assert_shape!` is the same check, compiled out unless debug assertions are enabled.
 
 Each takes a tensor and a bracketed pattern with one slot per axis. A slot is either `_`, which
-skips the axis, or any `usize` expression the axis must equal: a name from `dims()`, a config field,
-a literal.
+skips the axis, or any `usize` expression the axis must equal:
+
+```rust, ignore
+let [batch_size, seq_length, _] = x.dims();
+let flat = x.clone().reshape([batch_size * seq_length, 256]);
+
+assert_shape!(x, [batch_size, seq_length, 256]);       // names from dims() and a literal
+assert_shape!(flat, [batch_size * seq_length, 256]);   // arithmetic on names
+assert_shape!(patch, [3 * 2, 2]);                      // arithmetic on literals
+assert_shape!(mask, [batch_size, _]);                  // skip an axis
+assert_shape!(hidden, [_, _, self.d_model]);           // a config field
+```
 
 The pattern length is the expected rank. Since `tensor.dims()` returns `[usize; D]`, a pattern whose
 length differs from `D` is a compile error rather than a runtime panic, and so is passing anything

--- a/burn-book/src/building-blocks/module.md
+++ b/burn-book/src/building-blocks/module.md
@@ -55,24 +55,24 @@ reference for the assertions below.
 ### Enforcing the contract
 
 The rank of a `Tensor<D>` is a type parameter, so a caller cannot pass a `Tensor<4>` where a
-`Tensor<3>` is expected. The size of each axis is only known at runtime. Three macros, available
-from the prelude, check those sizes at the boundary of a method:
+`Tensor<3>` is expected, and `let [batch_size, seq_length, _] = input.dims();` names the axes with
+the rank checked at compile time. The size of each axis is only known at runtime. Two macros,
+available from the prelude, check those sizes at the boundary of a method:
 
-- `unpack_shape!` binds axis sizes to names and checks the remaining axes.
-- `assert_shape!` checks every axis of a tensor. It stays on in release builds.
+- `assert_shape!` checks the axes of a tensor. It stays on in release builds.
 - `debug_assert_shape!` is the same check, compiled out unless debug assertions are enabled.
 
 Each takes a tensor and a bracketed pattern with one slot per axis:
 
 | Slot                   | Meaning                                               |
 | ---------------------- | ----------------------------------------------------- |
-| `B` (bare name)        | Return the axis size. Only valid in `unpack_shape!`.  |
 | `=expr`                | The axis must equal this in-scope `usize` expression. |
 | `80` (integer literal) | The axis must equal this value.                       |
 | `_`                    | Skip the axis.                                        |
 
 The pattern length is the expected rank. Since `tensor.dims()` returns `[usize; D]`, a pattern whose
-length differs from `D` is a compile error rather than a runtime panic.
+length differs from `D` is a compile error rather than a runtime panic, and so is passing anything
+other than a `Tensor`.
 
 ```rust, ignore
 use burn::nn::{Gelu, Linear};
@@ -93,7 +93,8 @@ impl FeedForward {
     /// - input: `[batch_size, seq_length, d_model]`
     /// - output: `[batch_size, seq_length, d_model]`
     pub fn forward(&self, input: Tensor<3>) -> Tensor<3> {
-        let (batch_size, seq_length) = unpack_shape!(input, [B, T, =self.d_model]);
+        let [batch_size, seq_length, _] = input.dims();
+        assert_shape!(input, [_, _, =self.d_model]);
 
         let x = self.linear_inner.forward(input);
         debug_assert_shape!(x, [=batch_size, =seq_length, =self.d_ff]);
@@ -107,10 +108,6 @@ impl FeedForward {
 }
 ```
 
-`unpack_shape!` evaluates to a tuple with one `usize` per bare name, in pattern order. The names are
-labels, not bindings, so `let (c, b) = unpack_shape!(x, [B, _, C]);` swaps the two sizes without
-complaint. A single name still yields a tuple: `let (n,) = unpack_shape!(x, [N]);`.
-
 A failed check panics with the macro call, the axis, the expected and actual sizes, and the full
 dims of the tensor:
 
@@ -118,13 +115,13 @@ dims of the tensor:
 assert_shape!(output, [=batch_size, =seq_length, =self.d_model]): axis 2 expected 512, got 2048 (dims [8, 128, 2048])
 ```
 
-A bare name inside `assert_shape!` or `debug_assert_shape!`, or an `unpack_shape!` with nothing to
-bind, is a compile error with a hint toward the right macro.
+A bare name in a pattern is a compile error with a hint: write `=name` to check against it, or name
+the axis with `let [..] = tensor.dims()` first.
 
 ### Choosing a macro
 
-- `unpack_shape!` at the top of `forward` names the runtime axes once, and every later check refers
-  to them with `=name`.
+- Name the runtime axes once at the top of `forward` with
+  `let [batch_size, seq_length, _] = input.dims();` and refer to them with `=name` in every check.
 - `assert_shape!` is the default for a contract check. A mismatch that reaches a tensor operation
   may fail there with a message about that operation's arguments, or broadcast silently when an axis
   has size 1. The check is a few integer comparisons, so its cost does not matter next to a kernel

--- a/burn-book/src/building-blocks/module.md
+++ b/burn-book/src/building-blocks/module.md
@@ -66,7 +66,7 @@ Each takes a tensor and a bracketed pattern with one slot per axis:
 
 | Slot                   | Meaning                                               |
 | ---------------------- | ----------------------------------------------------- |
-| `B` (bare name)        | Bind the axis size. Only valid in `unpack_shape!`.    |
+| `B` (bare name)        | Return the axis size. Only valid in `unpack_shape!`.  |
 | `=expr`                | The axis must equal this in-scope `usize` expression. |
 | `80` (integer literal) | The axis must equal this value.                       |
 | `_`                    | Skip the axis.                                        |
@@ -79,7 +79,7 @@ use burn::nn::{Gelu, Linear};
 use burn::prelude::*;
 
 #[derive(Module, Debug)]
-pub struct PositionWiseFeedForward {
+pub struct FeedForward {
     linear_inner: Linear,
     linear_outer: Linear,
     gelu: Gelu,
@@ -87,7 +87,7 @@ pub struct PositionWiseFeedForward {
     d_ff: usize,
 }
 
-impl PositionWiseFeedForward {
+impl FeedForward {
     /// # Shapes
     ///
     /// - input: `[batch_size, seq_length, d_model]`
@@ -107,8 +107,9 @@ impl PositionWiseFeedForward {
 }
 ```
 
-`unpack_shape!` evaluates to a tuple with one `usize` per bare name, in pattern order. A single name
-still yields a tuple: `let (n,) = unpack_shape!(x, [N]);`.
+`unpack_shape!` evaluates to a tuple with one `usize` per bare name, in pattern order. The names are
+labels, not bindings, so `let (c, b) = unpack_shape!(x, [B, _, C]);` swaps the two sizes without
+complaint. A single name still yields a tuple: `let (n,) = unpack_shape!(x, [N]);`.
 
 A failed check panics with the macro call, the axis, the expected and actual sizes, and the full
 dims of the tensor:
@@ -122,16 +123,14 @@ bind, is a compile error with a hint toward the right macro.
 
 ### Choosing a macro
 
-The question for each check is whether a later operation would reject the mismatch anyway.
-
 - `unpack_shape!` at the top of `forward` names the runtime axes once, and every later check refers
   to them with `=name`.
-- `assert_shape!` is for mismatches nothing else would catch: an output that callers rely on, or an
-  input that a following operation would silently broadcast. The check is a few integer comparisons,
-  so its cost does not matter next to a kernel launch.
-- `debug_assert_shape!` is for checks that only improve the error message, because the following
-  operation already rejects the mismatch in every build. Burn's own modules use it in their forward
-  passes for this reason.
+- `assert_shape!` is the default for a contract check. A mismatch that reaches a tensor operation
+  may fail there with a message about that operation's arguments, or broadcast silently when an axis
+  has size 1. The check is a few integer comparisons, so its cost does not matter next to a kernel
+  launch. Burn's own modules use it at their boundaries.
+- `debug_assert_shape!` is for hot inner loops, or for internal invariants that an earlier always-on
+  check already implies.
 
 These checks complement the validation Burn performs inside each tensor operation. An operation
 reports a mismatch in terms of its own arguments; a boundary check reports it in terms of the

--- a/burn-book/src/building-blocks/module.md
+++ b/burn-book/src/building-blocks/module.md
@@ -29,6 +29,115 @@ impl PositionWiseFeedForward {
 
 Note that all fields declared in the struct must also implement the `Module` trait.
 
+## Forward Contract
+
+The derive does not constrain `forward`, so a module's shape contract lives in two places: the doc
+comment of the method, and assertions at its boundary.
+
+### Documenting shapes
+
+Modules in `burn::nn` document input and output shapes in a `# Shapes` section, one line per tensor,
+with names for the axes that vary at runtime:
+
+```rust, ignore
+/// Applies the feed-forward block.
+///
+/// # Shapes
+///
+/// - input: `[batch_size, seq_length, d_model]`
+/// - output: `[batch_size, seq_length, d_model]`
+pub fn forward(&self, input: Tensor<3>) -> Tensor<3> {
+```
+
+Use the same convention for your own modules. It is the first thing a caller reads, and it is the
+reference for the assertions below.
+
+### Enforcing the contract
+
+The rank of a `Tensor<D>` is a type parameter, so a caller cannot pass a `Tensor<4>` where a
+`Tensor<3>` is expected. The size of each axis is only known at runtime. Three macros, available
+from the prelude, check those sizes at the boundary of a method:
+
+- `unpack_shape!` binds axis sizes to names and checks the remaining axes.
+- `assert_shape!` checks every axis of a tensor. It stays on in release builds.
+- `debug_assert_shape!` is the same check, compiled out unless debug assertions are enabled.
+
+Each takes a tensor and a bracketed pattern with one slot per axis:
+
+| Slot                   | Meaning                                               |
+| ---------------------- | ----------------------------------------------------- |
+| `B` (bare name)        | Bind the axis size. Only valid in `unpack_shape!`.    |
+| `=expr`                | The axis must equal this in-scope `usize` expression. |
+| `80` (integer literal) | The axis must equal this value.                       |
+| `_`                    | Skip the axis.                                        |
+
+The pattern length is the expected rank. Since `tensor.dims()` returns `[usize; D]`, a pattern whose
+length differs from `D` is a compile error rather than a runtime panic.
+
+```rust, ignore
+use burn::nn::{Gelu, Linear};
+use burn::prelude::*;
+
+#[derive(Module, Debug)]
+pub struct PositionWiseFeedForward {
+    linear_inner: Linear,
+    linear_outer: Linear,
+    gelu: Gelu,
+    d_model: usize,
+    d_ff: usize,
+}
+
+impl PositionWiseFeedForward {
+    /// # Shapes
+    ///
+    /// - input: `[batch_size, seq_length, d_model]`
+    /// - output: `[batch_size, seq_length, d_model]`
+    pub fn forward(&self, input: Tensor<3>) -> Tensor<3> {
+        let (batch_size, seq_length) = unpack_shape!(input, [B, T, =self.d_model]);
+
+        let x = self.linear_inner.forward(input);
+        assert_shape!(x, [=batch_size, =seq_length, =self.d_ff]);
+
+        let x = self.gelu.forward(x);
+        let output = self.linear_outer.forward(x);
+
+        debug_assert_shape!(output, [=batch_size, =seq_length, =self.d_model]);
+        output
+    }
+}
+```
+
+`unpack_shape!` evaluates to a tuple with one `usize` per bare name, in pattern order. A single name
+still yields a tuple: `let (n,) = unpack_shape!(x, [N]);`.
+
+A failed check panics with the macro call, the axis, the expected and actual sizes, and the full
+dims of the tensor:
+
+```text
+assert_shape!(x, [=batch_size, =seq_length, =self.d_ff]): axis 2 expected 2048, got 512 (dims [8, 128, 512])
+```
+
+Misuse is caught at compile time: a bare name inside `assert_shape!` or `debug_assert_shape!` is
+rejected with a hint to use `unpack_shape!` or `=`, and an `unpack_shape!` with nothing to bind is
+rejected with a hint to use `assert_shape!`.
+
+### Choosing a macro
+
+- Start `forward` with `unpack_shape!` on the input. It names the runtime axes once, and every later
+  check refers to them with `=name`.
+- Use `assert_shape!` for the contract itself: the output, and any intermediate whose shape is not
+  obvious from the preceding call. The check is a few integer comparisons next to tensor operations
+  that launch kernels, so its cost does not matter.
+- Use `debug_assert_shape!` inside hot loops, or for internal invariants already implied by an
+  earlier always-on check.
+
+These checks complement the validation Burn performs inside each tensor operation. An operation
+reports a mismatch in terms of its own arguments; a boundary check reports it in terms of the
+module's contract, before any kernel runs.
+
+These macros were inspired by the [`burn-contracts`](https://github.com/crutcher/burn-contracts)
+crate by Crutcher Dunnavant.
+
 ## Tensor
 
 If you want to create your own module that contains tensors, and not just other modules defined with

--- a/burn-book/src/building-blocks/module.md
+++ b/burn-book/src/building-blocks/module.md
@@ -76,6 +76,7 @@ assert_shape!(patch, [3 * 2, 2]);                      // arithmetic on literals
 assert_shape!(mask, [batch_size, _]);                  // skip an axis
 assert_shape!(hidden, [_, _, self.d_model]);           // a config field
 assert_shape!(hidden, [.., self.d_model]);             // any rank, last axis checked
+assert_shape!(image, [_, self.num_channels, ..]);      // channels first, any spatial rank
 ```
 
 The pattern length is the expected rank. Since `tensor.dims()` returns `[usize; D]`, a pattern whose

--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -171,11 +171,12 @@ inplace operations will always be used when available.
 
 ## Shape Assertions
 
-The rank of a tensor is checked by the type system. To check the size of each axis, or to bind axis
-sizes to names, use the shape macros from the prelude:
+The rank of a tensor is checked by the type system, and `let [b, t, c] = x.dims();` names its axes.
+To check the size of each axis, use the shape macros from the prelude:
 
 ```rust, ignore
-let (batch_size, seq_length) = unpack_shape!(x, [B, T, 80]);
+let [batch_size, seq_length, _] = x.dims();
+assert_shape!(x, [_, _, 80]);
 assert_shape!(y, [=batch_size, =seq_length, 256]);
 debug_assert_shape!(z, [=batch_size, _, 256]);
 ```

--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -178,6 +178,7 @@ To check the size of each axis, use the shape macros from the prelude:
 let [batch_size, seq_length, _] = x.dims();
 assert_shape!(x, [_, _, 80]);
 assert_shape!(y, [batch_size, seq_length, 256]);
+assert_shape!(flat, [batch_size * seq_length, 256]);
 debug_assert_shape!(z, [batch_size, _, 256]);
 ```
 

--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -179,6 +179,7 @@ let [batch_size, seq_length, _] = x.dims();
 assert_shape!(x, [_, _, 80]);
 assert_shape!(y, [batch_size, seq_length, 256]);
 assert_shape!(flat, [batch_size * seq_length, 256]);
+assert_shape!(w, [.., 256]); // any rank, last axis checked
 debug_assert_shape!(z, [batch_size, _, 256]);
 ```
 

--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -177,8 +177,8 @@ To check the size of each axis, use the shape macros from the prelude:
 ```rust, ignore
 let [batch_size, seq_length, _] = x.dims();
 assert_shape!(x, [_, _, 80]);
-assert_shape!(y, [=batch_size, =seq_length, 256]);
-debug_assert_shape!(z, [=batch_size, _, 256]);
+assert_shape!(y, [batch_size, seq_length, 256]);
+debug_assert_shape!(z, [batch_size, _, 256]);
 ```
 
 See [Forward Contract](./module.md#forward-contract) for the slot syntax and guidance on which macro

--- a/burn-book/src/building-blocks/tensor.md
+++ b/burn-book/src/building-blocks/tensor.md
@@ -169,6 +169,20 @@ operations into a single kernel ([burn-fusion](https://burn.dev/docs/burn_fusion
 that reason, we don't provide explicit inplace operations. If a tensor is used only one time,
 inplace operations will always be used when available.
 
+## Shape Assertions
+
+The rank of a tensor is checked by the type system. To check the size of each axis, or to bind axis
+sizes to names, use the shape macros from the prelude:
+
+```rust, ignore
+let (batch_size, seq_length) = unpack_shape!(x, [B, T, 80]);
+assert_shape!(y, [=batch_size, =seq_length, 256]);
+debug_assert_shape!(z, [=batch_size, _, 256]);
+```
+
+See [Forward Contract](./module.md#forward-contract) for the slot syntax and guidance on which macro
+to use where.
+
 ## Tensor Operations
 
 Normally with PyTorch, explicit inplace operations aren't supported during the backward pass, making

--- a/crates/burn-core/src/lib.rs
+++ b/crates/burn-core/src/lib.rs
@@ -86,7 +86,7 @@ pub mod prelude {
         module::Module,
         tensor::{
             Bool, Device, DeviceIndex, DeviceKind, ElementConversion, Float, Int, Shape, SliceArg,
-            Tensor, TensorData, assert_shape, cast::ToElement, debug_assert_shape, s, unpack_shape,
+            Tensor, TensorData, assert_shape, cast::ToElement, debug_assert_shape, s,
         },
     };
 }

--- a/crates/burn-core/src/lib.rs
+++ b/crates/burn-core/src/lib.rs
@@ -86,7 +86,7 @@ pub mod prelude {
         module::Module,
         tensor::{
             Bool, Device, DeviceIndex, DeviceKind, ElementConversion, Float, Int, Shape, SliceArg,
-            Tensor, TensorData, cast::ToElement, s,
+            Tensor, TensorData, assert_shape, cast::ToElement, debug_assert_shape, s, unpack_shape,
         },
     };
 }

--- a/crates/burn-derive/src/lib.rs
+++ b/crates/burn-derive/src/lib.rs
@@ -88,65 +88,36 @@ pub fn record_state_derive(input: TokenStream) -> TokenStream {
     record_state::derive_impl(&input)
 }
 
-/// Binds tensor axis sizes to names while checking the rest of the shape.
-///
-/// `unpack_shape!(tensor, [B, T, 80])` evaluates to a tuple with one `usize` per bare
-/// identifier, in pattern order. The other slots are checks: `=expr` compares the axis with an
-/// in-scope `usize` expression, an integer literal compares with that value, and `_` skips
-/// the axis.
-///
-/// The pattern length must equal the tensor rank, otherwise the call does not compile. Axis
-/// checks are always-on runtime assertions; a mismatch panics with the axis, the expected and
-/// actual sizes, and the full dims.
-///
-/// ```ignore
-/// let (b, t) = unpack_shape!(x, [B, T, 80]);
-/// let (t,) = unpack_shape!(mask, [=b, T]);
-/// let (c,) = unpack_shape!(y, [_, _, C]);
-/// ```
-///
-/// Inspired by the `burn-contracts` crate by Crutcher Dunnavant.
+/// Implementation of `burn_tensor::unpack_shape!`. Not part of the public API.
+#[doc(hidden)]
 #[proc_macro]
-pub fn unpack_shape(input: TokenStream) -> TokenStream {
-    let call = input.to_string();
-    let input = syn::parse_macro_input!(input as shape::ShapeInput);
-    shape::expand(input, shape::Mode::Unpack, &call).into()
+pub fn __unpack_shape(input: TokenStream) -> TokenStream {
+    shape_macro(input, shape::Mode::Unpack)
 }
 
-/// Asserts a tensor's rank at compile time and its axis sizes at runtime.
-///
-/// `assert_shape!(tensor, [=b, =t, 256])` accepts `=expr` slots (an in-scope `usize`
-/// expression), integer literals, and `_` to skip an axis. Bare identifiers are rejected: use
-/// [`unpack_shape!`] to bind names.
-///
-/// The pattern length must equal the tensor rank, otherwise the call does not compile. Axis
-/// checks stay enabled in release builds; see [`debug_assert_shape!`] for the debug-only
-/// variant.
-///
-/// ```ignore
-/// assert_shape!(y, [=b, =t, =self.d_model]);
-/// assert_shape!(mask, [=b, _]);
-/// ```
-///
-/// Inspired by the `burn-contracts` crate by Crutcher Dunnavant.
+/// Implementation of `burn_tensor::assert_shape!`. Not part of the public API.
+#[doc(hidden)]
 #[proc_macro]
-pub fn assert_shape(input: TokenStream) -> TokenStream {
-    let call = input.to_string();
-    let input = syn::parse_macro_input!(input as shape::ShapeInput);
-    shape::expand(input, shape::Mode::Assert, &call).into()
+pub fn __assert_shape(input: TokenStream) -> TokenStream {
+    shape_macro(input, shape::Mode::Assert)
 }
 
-/// Same as [`assert_shape!`], but the axis checks compile out unless `debug_assertions` is on.
-///
-/// The rank check is a type check and stays in every build. Like `debug_assert!`, the tensor
-/// expression is not evaluated in release builds.
-///
-/// ```ignore
-/// debug_assert_shape!(hidden, [=b, =t, =self.d_model]);
-/// ```
+/// Implementation of `burn_tensor::debug_assert_shape!`. Not part of the public API.
+#[doc(hidden)]
 #[proc_macro]
-pub fn debug_assert_shape(input: TokenStream) -> TokenStream {
-    let call = input.to_string();
+pub fn __debug_assert_shape(input: TokenStream) -> TokenStream {
+    shape_macro(input, shape::Mode::DebugAssert)
+}
+
+/// The input is `$crate, tensor, [pattern]`, see the wrappers in burn-tensor. Panic messages
+/// echo everything after the crate path, as rendered by the compiler's token printer.
+fn shape_macro(input: TokenStream, mode: shape::Mode) -> TokenStream {
+    let call = input
+        .clone()
+        .into_iter()
+        .skip(2)
+        .collect::<TokenStream>()
+        .to_string();
     let input = syn::parse_macro_input!(input as shape::ShapeInput);
-    shape::expand(input, shape::Mode::DebugAssert, &call).into()
+    shape::expand(input, mode, &call).into()
 }

--- a/crates/burn-derive/src/lib.rs
+++ b/crates/burn-derive/src/lib.rs
@@ -108,8 +108,9 @@ pub fn record_state_derive(input: TokenStream) -> TokenStream {
 /// Inspired by the `burn-contracts` crate by Crutcher Dunnavant.
 #[proc_macro]
 pub fn unpack_shape(input: TokenStream) -> TokenStream {
+    let call = input.to_string();
     let input = syn::parse_macro_input!(input as shape::ShapeInput);
-    shape::expand(input, shape::Mode::Unpack).into()
+    shape::expand(input, shape::Mode::Unpack, &call).into()
 }
 
 /// Asserts a tensor's rank at compile time and its axis sizes at runtime.
@@ -130,8 +131,9 @@ pub fn unpack_shape(input: TokenStream) -> TokenStream {
 /// Inspired by the `burn-contracts` crate by Crutcher Dunnavant.
 #[proc_macro]
 pub fn assert_shape(input: TokenStream) -> TokenStream {
+    let call = input.to_string();
     let input = syn::parse_macro_input!(input as shape::ShapeInput);
-    shape::expand(input, shape::Mode::Assert).into()
+    shape::expand(input, shape::Mode::Assert, &call).into()
 }
 
 /// Same as [`assert_shape!`], but the axis checks compile out unless `debug_assertions` is on.
@@ -144,6 +146,7 @@ pub fn assert_shape(input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro]
 pub fn debug_assert_shape(input: TokenStream) -> TokenStream {
+    let call = input.to_string();
     let input = syn::parse_macro_input!(input as shape::ShapeInput);
-    shape::expand(input, shape::Mode::DebugAssert).into()
+    shape::expand(input, shape::Mode::DebugAssert, &call).into()
 }

--- a/crates/burn-derive/src/lib.rs
+++ b/crates/burn-derive/src/lib.rs
@@ -102,15 +102,8 @@ pub fn __debug_assert_shape(input: TokenStream) -> TokenStream {
     shape_macro(input, shape::Mode::DebugAssert)
 }
 
-/// The input is `$crate, tensor, [pattern]`, see the wrappers in burn-tensor. Panic messages
-/// echo everything after the crate path, as rendered by the compiler's token printer.
+/// The input is `$crate, tensor, [pattern]`, see the wrappers in burn-tensor.
 fn shape_macro(input: TokenStream, mode: shape::Mode) -> TokenStream {
-    let call = input
-        .clone()
-        .into_iter()
-        .skip(2)
-        .collect::<TokenStream>()
-        .to_string();
     let input = syn::parse_macro_input!(input as shape::ShapeInput);
-    shape::expand(input, mode, &call).into()
+    shape::expand(input, mode).into()
 }

--- a/crates/burn-derive/src/lib.rs
+++ b/crates/burn-derive/src/lib.rs
@@ -10,6 +10,7 @@ use proc_macro::TokenStream;
 pub(crate) mod config;
 pub(crate) mod module;
 pub(crate) mod record_state;
+pub(crate) mod shape;
 pub(crate) mod shared;
 
 /// Derive macro for the `Module` trait.
@@ -85,4 +86,64 @@ pub fn config_derive(input: TokenStream) -> TokenStream {
 pub fn record_state_derive(input: TokenStream) -> TokenStream {
     let input = syn::parse(input).unwrap();
     record_state::derive_impl(&input)
+}
+
+/// Binds tensor axis sizes to names while checking the rest of the shape.
+///
+/// `unpack_shape!(tensor, [B, T, 80])` evaluates to a tuple with one `usize` per bare
+/// identifier, in pattern order. The other slots are checks: `=expr` compares the axis with an
+/// in-scope `usize` expression, an integer literal compares with that value, and `_` skips
+/// the axis.
+///
+/// The pattern length must equal the tensor rank, otherwise the call does not compile. Axis
+/// checks are always-on runtime assertions; a mismatch panics with the axis, the expected and
+/// actual sizes, and the full dims.
+///
+/// ```ignore
+/// let (b, t) = unpack_shape!(x, [B, T, 80]);
+/// let (t,) = unpack_shape!(mask, [=b, T]);
+/// let (c,) = unpack_shape!(y, [_, _, C]);
+/// ```
+///
+/// Inspired by the `burn-contracts` crate by Crutcher Dunnavant.
+#[proc_macro]
+pub fn unpack_shape(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as shape::ShapeInput);
+    shape::expand(input, shape::Mode::Unpack).into()
+}
+
+/// Asserts a tensor's rank at compile time and its axis sizes at runtime.
+///
+/// `assert_shape!(tensor, [=b, =t, 256])` accepts `=expr` slots (an in-scope `usize`
+/// expression), integer literals, and `_` to skip an axis. Bare identifiers are rejected: use
+/// [`unpack_shape!`] to bind names.
+///
+/// The pattern length must equal the tensor rank, otherwise the call does not compile. Axis
+/// checks stay enabled in release builds; see [`debug_assert_shape!`] for the debug-only
+/// variant.
+///
+/// ```ignore
+/// assert_shape!(y, [=b, =t, =self.d_model]);
+/// assert_shape!(mask, [=b, _]);
+/// ```
+///
+/// Inspired by the `burn-contracts` crate by Crutcher Dunnavant.
+#[proc_macro]
+pub fn assert_shape(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as shape::ShapeInput);
+    shape::expand(input, shape::Mode::Assert).into()
+}
+
+/// Same as [`assert_shape!`], but the axis checks compile out unless `debug_assertions` is on.
+///
+/// The rank check is a type check and stays in every build. Like `debug_assert!`, the tensor
+/// expression is not evaluated in release builds.
+///
+/// ```ignore
+/// debug_assert_shape!(hidden, [=b, =t, =self.d_model]);
+/// ```
+#[proc_macro]
+pub fn debug_assert_shape(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as shape::ShapeInput);
+    shape::expand(input, shape::Mode::DebugAssert).into()
 }

--- a/crates/burn-derive/src/lib.rs
+++ b/crates/burn-derive/src/lib.rs
@@ -88,13 +88,6 @@ pub fn record_state_derive(input: TokenStream) -> TokenStream {
     record_state::derive_impl(&input)
 }
 
-/// Implementation of `burn_tensor::unpack_shape!`. Not part of the public API.
-#[doc(hidden)]
-#[proc_macro]
-pub fn __unpack_shape(input: TokenStream) -> TokenStream {
-    shape_macro(input, shape::Mode::Unpack)
-}
-
 /// Implementation of `burn_tensor::assert_shape!`. Not part of the public API.
 #[doc(hidden)]
 #[proc_macro]

--- a/crates/burn-derive/src/shape/mod.rs
+++ b/crates/burn-derive/src/shape/mod.rs
@@ -27,7 +27,7 @@ enum Slot {
     /// Bare identifier: bound and returned by `unpack_shape!`; rejected by the assert macros.
     Fresh(Ident),
     /// `=expr` or an integer literal: the axis must equal this `usize` expression.
-    Check(Expr),
+    Check(Box<Expr>),
     /// `_`: neither bound nor checked.
     Wildcard,
 }
@@ -39,13 +39,13 @@ impl Parse for Slot {
             Ok(Slot::Wildcard)
         } else if input.peek(Token![=]) {
             input.parse::<Token![=]>()?;
-            Ok(Slot::Check(input.parse()?))
+            Ok(Slot::Check(Box::new(input.parse()?)))
         } else if input.peek(LitInt) {
             let lit: LitInt = input.parse()?;
-            Ok(Slot::Check(Expr::Lit(ExprLit {
+            Ok(Slot::Check(Box::new(Expr::Lit(ExprLit {
                 attrs: Vec::new(),
                 lit: Lit::Int(lit),
-            })))
+            }))))
         } else if input.peek(Ident) {
             Ok(Slot::Fresh(input.parse()?))
         } else {
@@ -192,8 +192,10 @@ fn pattern_text(slots: &[Slot]) -> String {
         .iter()
         .map(|slot| match slot {
             Slot::Fresh(id) => id.to_string(),
-            Slot::Check(Expr::Lit(lit)) => source_like(lit),
-            Slot::Check(expr) => format!("={}", source_like(expr)),
+            Slot::Check(expr) => match expr.as_ref() {
+                Expr::Lit(lit) => source_like(lit),
+                expr => format!("={}", source_like(expr)),
+            },
             Slot::Wildcard => "_".to_string(),
         })
         .collect();

--- a/crates/burn-derive/src/shape/mod.rs
+++ b/crates/burn-derive/src/shape/mod.rs
@@ -38,6 +38,9 @@ impl Parse for Slot {
 /// the public macro, forwarded by its `macro_rules!` wrapper.
 pub(crate) struct ShapeInput {
     krate: Path,
+    /// Everything after the crate path, as rendered by the compiler's token printer: whitespace
+    /// is normalized and comments are dropped. Echoed in panic messages.
+    call: String,
     tensor: Expr,
     slots: Vec<Slot>,
 }
@@ -46,6 +49,7 @@ impl Parse for ShapeInput {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let krate: Path = input.parse()?;
         input.parse::<Token![,]>()?;
+        let call = input.fork().parse::<TokenStream>()?.to_string();
         let tensor: Expr = input.parse()?;
         input.parse::<Token![,]>()?;
         let content;
@@ -66,6 +70,7 @@ impl Parse for ShapeInput {
         }
         Ok(ShapeInput {
             krate,
+            call,
             tensor,
             slots,
         })
@@ -88,11 +93,10 @@ impl Mode {
     }
 }
 
-/// `call` is the macro input after the crate path, as rendered by the compiler's token
-/// printer: whitespace is normalized and comments are dropped. It is echoed in panic messages.
-pub(crate) fn expand(input: ShapeInput, mode: Mode, call: &str) -> TokenStream {
+pub(crate) fn expand(input: ShapeInput, mode: Mode) -> TokenStream {
     let ShapeInput {
         krate,
+        call,
         tensor,
         slots,
     } = input;
@@ -108,7 +112,7 @@ pub(crate) fn expand(input: ShapeInput, mode: Mode, call: &str) -> TokenStream {
     let call = format!("{}({call})", mode.name());
 
     // A pattern with `..` splits into the axes before it and the axes after it. The latter are
-    // addressed from the end, since the number of axes `..` stands for is only known at runtime.
+    // addressed from the end, since the macro cannot know how many axes `..` stands for.
     let rest = slots.iter().position(|slot| matches!(slot, Slot::Rest(_)));
     let (prefix, suffix): (&[Slot], &[Slot]) = match rest {
         Some(position) => (&slots[..position], &slots[position + 1..]),

--- a/crates/burn-derive/src/shape/mod.rs
+++ b/crates/burn-derive/src/shape/mod.rs
@@ -17,11 +17,15 @@ enum Slot {
     Check(Box<Expr>),
     /// `_`: the axis is not checked.
     Wildcard,
+    /// `..`: any number of axes, none of them checked. At most one per pattern.
+    Rest(Token![..]),
 }
 
 impl Parse for Slot {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        if input.peek(Token![_]) {
+        if input.peek(Token![..]) {
+            Ok(Slot::Rest(input.parse()?))
+        } else if input.peek(Token![_]) {
             input.parse::<Token![_]>()?;
             Ok(Slot::Wildcard)
         } else {
@@ -46,9 +50,20 @@ impl Parse for ShapeInput {
         input.parse::<Token![,]>()?;
         let content;
         bracketed!(content in input);
-        let slots = Punctuated::<Slot, Token![,]>::parse_terminated(&content)?
+        let slots: Vec<Slot> = Punctuated::<Slot, Token![,]>::parse_terminated(&content)?
             .into_iter()
             .collect();
+        let mut rests = slots.iter().filter_map(|slot| match slot {
+            Slot::Rest(token) => Some(token),
+            _ => None,
+        });
+        rests.next();
+        if let Some(second) = rests.next() {
+            return Err(syn::Error::new(
+                second.span(),
+                "at most one `..` per pattern",
+            ));
+        }
         Ok(ShapeInput {
             krate,
             tensor,
@@ -86,40 +101,92 @@ pub(crate) fn expand(input: ShapeInput, mode: Mode, call: &str) -> TokenStream {
     // mentions `__dims` still resolves to the user's own binding.
     let t = Ident::new("__tensor", Span::mixed_site());
     let dims = Ident::new("__dims", Span::mixed_site());
+    let rank = Ident::new("__rank", Span::mixed_site());
+    let axis = Ident::new("__axis", Span::mixed_site());
     let expected = Ident::new("__expected", Span::mixed_site());
 
-    let rank = slots.len();
     let call = format!("{}({call})", mode.name());
 
-    let checks = slots
+    // A pattern with `..` splits into the axes before it and the axes after it. The latter are
+    // addressed from the end, since the number of axes `..` stands for is only known at runtime.
+    let rest = slots.iter().position(|slot| matches!(slot, Slot::Rest(_)));
+    let (prefix, suffix): (&[Slot], &[Slot]) = match rest {
+        Some(position) => (&slots[..position], &slots[position + 1..]),
+        None => (&slots[..], &[]),
+    };
+
+    let check = |index: TokenStream, expr: &Expr| {
+        quote_spanned! { expr.span() =>
+            {
+                let #axis: usize = #index;
+                let #expected: usize = #expr;
+                ::core::assert!(
+                    #dims[#axis] == #expected,
+                    "{}: axis {} expected {}, got {} (dims {:?})",
+                    #call, #axis, #expected, #dims[#axis], #dims
+                );
+            }
+        }
+    };
+    let prefix_checks = prefix
         .iter()
         .enumerate()
-        .filter_map(|(axis, slot)| match slot {
+        .filter_map(|(i, slot)| match slot {
             Slot::Check(expr) => {
-                let index = Literal::usize_unsuffixed(axis);
-                Some(quote_spanned! { expr.span() =>
-                    {
-                        let #expected: usize = #expr;
-                        ::core::assert!(
-                            #dims[#index] == #expected,
-                            "{}: axis {} expected {}, got {} (dims {:?})",
-                            #call, #index, #expected, #dims[#index], #dims
-                        );
-                    }
-                })
+                let index = Literal::usize_unsuffixed(i);
+                Some(check(quote! { #index }, expr))
             }
-            Slot::Wildcard => None,
+            _ => None,
+        });
+    let suffix_checks = suffix
+        .iter()
+        .enumerate()
+        .filter_map(|(j, slot)| match slot {
+            Slot::Check(expr) => {
+                let from_end = Literal::usize_unsuffixed(suffix.len() - j);
+                Some(check(quote! { #rank - #from_end }, expr))
+            }
+            _ => None,
         });
 
-    // The type annotation is the rank check: `Tensor<D>::dims()` returns `[usize; D]`. Calling
+    // Without `..`, the type annotation is the rank check: `Tensor<D>::dims()` returns
+    // `[usize; D]`. With `..`, only a minimum rank is known, so it is checked at runtime. Calling
     // `Tensor::dims` by path rather than as a method makes any other receiver a type error;
     // `Shape::dims::<N>` would infer `N` from the annotation and truncate silently. Going through
     // a reference keeps a `&x` argument free of `clippy::needless_borrow`, which a
     // `(#tensor).dims()` receiver would trigger.
-    let body = quote_spanned! { tensor.span() =>
-        let #t = &#tensor;
-        let #dims: [usize; #rank] = #krate::Tensor::dims(#t);
-        #(#checks)*
+    let rank_check = match rest {
+        None => {
+            let exact = slots.len();
+            quote_spanned! { tensor.span() =>
+                let #t = &#tensor;
+                let #dims: [usize; #exact] = #krate::Tensor::dims(#t);
+            }
+        }
+        Some(_) => {
+            let min = prefix.len() + suffix.len();
+            let min_check = (min > 0).then(|| {
+                quote! {
+                    ::core::assert!(
+                        #rank >= #min,
+                        "{}: expected rank at least {}, got {} (dims {:?})",
+                        #call, #min, #rank, #dims
+                    );
+                }
+            });
+            quote_spanned! { tensor.span() =>
+                let #t = &#tensor;
+                let #dims = #krate::Tensor::dims(#t);
+                let #rank = #dims.len();
+                #min_check
+            }
+        }
+    };
+
+    let body = quote! {
+        #rank_check
+        #(#prefix_checks)*
+        #(#suffix_checks)*
     };
 
     match mode {

--- a/crates/burn-derive/src/shape/mod.rs
+++ b/crates/burn-derive/src/shape/mod.rs
@@ -1,0 +1,217 @@
+//! Shape assertion macros: `unpack_shape!`, `assert_shape!` and `debug_assert_shape!`.
+//!
+//! All three take a tensor expression and a bracketed pattern with one slot per axis:
+//!
+//! - a bare identifier binds the axis size (only in `unpack_shape!`),
+//! - `=expr` checks the axis against an in-scope `usize` expression,
+//! - an integer literal checks the axis against that value,
+//! - `_` skips the axis.
+//!
+//! The pattern length is the expected rank. Since `Tensor::dims()` returns `[usize; D]`,
+//! binding it to `[usize; N]` turns a rank mismatch into a compile error. Axis checks are
+//! runtime assertions.
+//!
+//! Inspired by the `burn-contracts` crate by Crutcher Dunnavant.
+
+use proc_macro2::{Literal, Span, TokenStream};
+use quote::{ToTokens, quote, quote_spanned};
+use syn::{
+    Expr, ExprLit, Ident, Lit, LitInt, Token, bracketed,
+    parse::{Parse, ParseStream},
+    punctuated::Punctuated,
+    spanned::Spanned,
+};
+
+/// One position in a shape pattern.
+enum Slot {
+    /// Bare identifier: bound and returned by `unpack_shape!`; rejected by the assert macros.
+    Fresh(Ident),
+    /// `=expr` or an integer literal: the axis must equal this `usize` expression.
+    Check(Expr),
+    /// `_`: neither bound nor checked.
+    Wildcard,
+}
+
+impl Parse for Slot {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        if input.peek(Token![_]) {
+            input.parse::<Token![_]>()?;
+            Ok(Slot::Wildcard)
+        } else if input.peek(Token![=]) {
+            input.parse::<Token![=]>()?;
+            Ok(Slot::Check(input.parse()?))
+        } else if input.peek(LitInt) {
+            let lit: LitInt = input.parse()?;
+            Ok(Slot::Check(Expr::Lit(ExprLit {
+                attrs: Vec::new(),
+                lit: Lit::Int(lit),
+            })))
+        } else if input.peek(Ident) {
+            Ok(Slot::Fresh(input.parse()?))
+        } else {
+            Err(input.error(
+                "expected a shape slot: a name to bind, `=expr`, an integer literal, or `_`",
+            ))
+        }
+    }
+}
+
+/// Parsed `tensor, [slot, slot, ...]` input.
+pub(crate) struct ShapeInput {
+    tensor: Expr,
+    slots: Vec<Slot>,
+}
+
+impl Parse for ShapeInput {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let tensor: Expr = input.parse()?;
+        input.parse::<Token![,]>()?;
+        let content;
+        bracketed!(content in input);
+        let slots = Punctuated::<Slot, Token![,]>::parse_terminated(&content)?
+            .into_iter()
+            .collect();
+        if !input.is_empty() {
+            return Err(input.error("unexpected tokens after the shape pattern"));
+        }
+        Ok(ShapeInput { tensor, slots })
+    }
+}
+
+/// Which macro is expanding, which decides validation and the emitted assertion.
+#[derive(Clone, Copy)]
+pub(crate) enum Mode {
+    Unpack,
+    Assert,
+    DebugAssert,
+}
+
+impl Mode {
+    fn name(self) -> &'static str {
+        match self {
+            Mode::Unpack => "unpack_shape!",
+            Mode::Assert => "assert_shape!",
+            Mode::DebugAssert => "debug_assert_shape!",
+        }
+    }
+}
+
+pub(crate) fn expand(input: ShapeInput, mode: Mode) -> TokenStream {
+    let ShapeInput { tensor, slots } = input;
+    let name = mode.name();
+
+    match mode {
+        Mode::Unpack => {
+            if !slots.iter().any(|s| matches!(s, Slot::Fresh(_))) {
+                return syn::Error::new(
+                    Span::call_site(),
+                    "`unpack_shape!` needs at least one bare identifier to bind; \
+                     use `assert_shape!` when every axis is a check",
+                )
+                .to_compile_error();
+            }
+        }
+        Mode::Assert | Mode::DebugAssert => {
+            for slot in &slots {
+                if let Slot::Fresh(id) = slot {
+                    return syn::Error::new(
+                        id.span(),
+                        format!(
+                            "`{name}` does not bind new names; bare identifier `{id}` would bind \
+                             a new value. Use `unpack_shape!` to bind, or `=` to check against \
+                             an in-scope value"
+                        ),
+                    )
+                    .to_compile_error();
+                }
+            }
+        }
+    }
+
+    // Mixed-site hygiene: these names are invisible to the caller, so a user `=expr` that
+    // mentions `__dims` still resolves to the user's own binding.
+    let t = Ident::new("__tensor", Span::mixed_site());
+    let dims = Ident::new("__dims", Span::mixed_site());
+    let expected = Ident::new("__expected", Span::mixed_site());
+
+    let rank = slots.len();
+    let call_text = format!("{name}({}, {})", source_like(&tensor), pattern_text(&slots));
+
+    let mut checks = Vec::new();
+    let mut fresh = Vec::new();
+    for (axis, slot) in slots.iter().enumerate() {
+        let index = Literal::usize_unsuffixed(axis);
+        match slot {
+            Slot::Check(expr) => {
+                let msg = format!("{call_text}: axis {axis} expected {{}}, got {{}} (dims {{:?}})");
+                let check = quote_spanned! { expr.span() =>
+                    {
+                        let #expected: usize = #expr;
+                        ::core::assert!(
+                            #dims[#index] == #expected,
+                            #msg, #expected, #dims[#index], #dims
+                        );
+                    }
+                };
+                checks.push(check);
+            }
+            Slot::Fresh(_) => fresh.push(quote! { #dims[#index] }),
+            Slot::Wildcard => {}
+        }
+    }
+
+    // The type annotation is the rank check: `Tensor<D>::dims()` returns `[usize; D]`.
+    let rank_check = if checks.is_empty() && fresh.is_empty() {
+        quote_spanned! { tensor.span() => let _: [usize; #rank] = #t.dims(); }
+    } else {
+        quote_spanned! { tensor.span() => let #dims: [usize; #rank] = #t.dims(); }
+    };
+
+    let tuple = match fresh.len() {
+        0 => TokenStream::new(),
+        1 => quote! { (#(#fresh)*,) },
+        _ => quote! { (#(#fresh),*) },
+    };
+
+    let body = quote! {
+        let #t = &#tensor;
+        #rank_check
+        #(#checks)*
+        #tuple
+    };
+
+    match mode {
+        Mode::DebugAssert => quote! { if ::core::cfg!(debug_assertions) { #body } },
+        Mode::Unpack | Mode::Assert => quote! { { #body } },
+    }
+}
+
+/// Render the pattern back as the user wrote it, for panic messages.
+fn pattern_text(slots: &[Slot]) -> String {
+    let parts: Vec<String> = slots
+        .iter()
+        .map(|slot| match slot {
+            Slot::Fresh(id) => id.to_string(),
+            Slot::Check(Expr::Lit(lit)) => source_like(lit),
+            Slot::Check(expr) => format!("={}", source_like(expr)),
+            Slot::Wildcard => "_".to_string(),
+        })
+        .collect();
+    format!("[{}]", parts.join(", "))
+}
+
+/// Undo the spacing `ToTokens` inserts between every token, then escape braces so the
+/// result can be embedded in a format string.
+fn source_like(tokens: &impl ToTokens) -> String {
+    tokens
+        .to_token_stream()
+        .to_string()
+        .replace(" . ", ".")
+        .replace(" :: ", "::")
+        .replace("& ", "&")
+        .replace("( ", "(")
+        .replace(" )", ")")
+        .replace(" ,", ",")
+        .replace('{', "{{")
+        .replace('}', "}}")
+}

--- a/crates/burn-derive/src/shape/mod.rs
+++ b/crates/burn-derive/src/shape/mod.rs
@@ -1,22 +1,23 @@
 //! Implementation of `unpack_shape!`, `assert_shape!` and `debug_assert_shape!`. The public
-//! documentation lives on the macros in `lib.rs`.
+//! macros and their documentation live in burn-tensor, whose `macro_rules!` wrappers forward
+//! `$crate` so the expansion can name `Tensor::dims` by path.
 
 use proc_macro2::{Literal, Span, TokenStream};
 use quote::{quote, quote_spanned};
 use syn::{
-    Expr, Ident, LitInt, Token, bracketed,
+    Expr, Ident, LitInt, Path, Token, bracketed,
     parse::{Parse, ParseStream},
-    punctuated::Punctuated,
     spanned::Spanned,
 };
 
 /// One position in a shape pattern.
 enum Slot {
-    /// Bare identifier: bound and returned by `unpack_shape!`; rejected by the assert macros.
+    /// Bare identifier: a label for an axis whose size `unpack_shape!` returns, in pattern
+    /// order. The name itself is not bound. Rejected by the assert macros.
     Fresh(Ident),
     /// `=expr` or an integer literal: the axis must equal this `usize` expression.
     Check(Box<Expr>),
-    /// `_`: neither bound nor checked.
+    /// `_`: neither returned nor checked.
     Wildcard,
 }
 
@@ -34,32 +35,51 @@ impl Parse for Slot {
             Ok(Slot::Fresh(input.parse()?))
         } else {
             Err(input.error(
-                "expected a shape slot: a name to bind, `=expr`, an integer literal, or `_`",
+                "expected a shape slot: a name to return, `=expr`, an integer literal, or `_`",
             ))
         }
     }
 }
 
-/// Parsed `tensor, [slot, slot, ...]` input.
+/// Parsed `$crate, tensor, [slot, slot, ...]` input. The leading path is the crate that owns
+/// the public macro, forwarded by its `macro_rules!` wrapper.
 pub(crate) struct ShapeInput {
+    krate: Path,
     tensor: Expr,
     slots: Vec<Slot>,
 }
 
 impl Parse for ShapeInput {
     fn parse(input: ParseStream) -> syn::Result<Self> {
+        let krate: Path = input.parse()?;
+        input.parse::<Token![,]>()?;
         let tensor: Expr = input.parse()?;
         input.parse::<Token![,]>()?;
         let content;
         bracketed!(content in input);
-        let slots = Punctuated::<Slot, Token![,]>::parse_terminated(&content)?
-            .into_iter()
-            .collect();
-        Ok(ShapeInput { tensor, slots })
+        let mut slots = Vec::new();
+        while !content.is_empty() {
+            slots.push(content.parse()?);
+            if content.is_empty() {
+                break;
+            }
+            if !content.peek(Token![,]) {
+                return Err(content.error(
+                    "expected `,`; to check an axis against an expression, prefix it with `=`",
+                ));
+            }
+            content.parse::<Token![,]>()?;
+        }
+        Ok(ShapeInput {
+            krate,
+            tensor,
+            slots,
+        })
     }
 }
 
-/// Which macro is expanding, which decides validation and the emitted assertion.
+/// Which macro is expanding. It decides the validation, the debug gating, and whether a tuple
+/// is returned.
 #[derive(Clone, Copy)]
 pub(crate) enum Mode {
     Unpack,
@@ -77,9 +97,14 @@ impl Mode {
     }
 }
 
-/// `call` is the macro input as the caller wrote it, echoed in panic messages.
+/// `call` is the macro input after the crate path, as rendered by the compiler's token
+/// printer: whitespace is normalized and comments are dropped. It is echoed in panic messages.
 pub(crate) fn expand(input: ShapeInput, mode: Mode, call: &str) -> TokenStream {
-    let ShapeInput { tensor, slots } = input;
+    let ShapeInput {
+        krate,
+        tensor,
+        slots,
+    } = input;
     let name = mode.name();
 
     match mode {
@@ -87,8 +112,8 @@ pub(crate) fn expand(input: ShapeInput, mode: Mode, call: &str) -> TokenStream {
             if !slots.iter().any(|s| matches!(s, Slot::Fresh(_))) {
                 return syn::Error::new(
                     Span::call_site(),
-                    "`unpack_shape!` needs at least one bare identifier to bind; \
-                     use `assert_shape!` when every axis is a check",
+                    "`unpack_shape!` needs at least one bare identifier; \
+                     use `assert_shape!` when there is nothing to return",
                 )
                 .to_compile_error();
             }
@@ -99,9 +124,9 @@ pub(crate) fn expand(input: ShapeInput, mode: Mode, call: &str) -> TokenStream {
                     return syn::Error::new(
                         id.span(),
                         format!(
-                            "`{name}` does not bind new names; bare identifier `{id}` would bind \
-                             a new value. Use `unpack_shape!` to bind, or `=` to check against \
-                             an in-scope value"
+                            "`{name}` does not return axis sizes; bare identifier `{id}` is only \
+                             meaningful in `unpack_shape!`. Use `=` to check the axis against an \
+                             in-scope value, or `_` to skip it"
                         ),
                     )
                     .to_compile_error();
@@ -139,14 +164,17 @@ pub(crate) fn expand(input: ShapeInput, mode: Mode, call: &str) -> TokenStream {
         }
     }
 
-    // The type annotation is the rank check: `Tensor<D>::dims()` returns `[usize; D]`. Going
-    // through a reference keeps the caller's expression unmoved and hides the borrow from lints.
+    // The type annotation is the rank check: `Tensor<D>::dims()` returns `[usize; D]`. Calling
+    // `Tensor::dims` by path rather than as a method makes any other receiver a type error;
+    // `Shape::dims::<N>` would infer `N` from the annotation and truncate silently. Going through
+    // a reference keeps a `&x` argument free of `clippy::needless_borrow`, which a
+    // `(#tensor).dims()` receiver would trigger.
     let rank_check = quote_spanned! { tensor.span() =>
         let #t = &#tensor;
-        let #dims: [usize; #rank] = #t.dims();
+        let #dims: [usize; #rank] = #krate::Tensor::dims(#t);
     };
 
-    // With nothing to bind the block ends in a statement and evaluates to `()` implicitly; an
+    // With nothing to return the block ends in a statement and evaluates to `()` implicitly; an
     // explicit `()` would trip clippy's `unused_unit` at every `assert_shape!` call site.
     let tuple = if fresh.is_empty() {
         TokenStream::new()

--- a/crates/burn-derive/src/shape/mod.rs
+++ b/crates/burn-derive/src/shape/mod.rs
@@ -5,14 +5,15 @@
 use proc_macro2::{Literal, Span, TokenStream};
 use quote::{quote, quote_spanned};
 use syn::{
-    Expr, Ident, LitInt, Path, Token, bracketed,
+    Expr, Ident, Path, Token, bracketed,
     parse::{Parse, ParseStream},
+    punctuated::Punctuated,
     spanned::Spanned,
 };
 
 /// One position in a shape pattern.
 enum Slot {
-    /// `=expr` or an integer literal: the axis must equal this `usize` expression.
+    /// Any expression: the axis must equal this `usize` value.
     Check(Box<Expr>),
     /// `_`: the axis is not checked.
     Wildcard,
@@ -23,23 +24,8 @@ impl Parse for Slot {
         if input.peek(Token![_]) {
             input.parse::<Token![_]>()?;
             Ok(Slot::Wildcard)
-        } else if input.peek(Token![=]) {
-            input.parse::<Token![=]>()?;
-            Ok(Slot::Check(Box::new(input.parse()?)))
-        } else if input.peek(LitInt) {
-            Ok(Slot::Check(Box::new(Expr::Lit(input.parse()?))))
-        } else if input.peek(Ident) {
-            let id: Ident = input.parse()?;
-            Err(syn::Error::new(
-                id.span(),
-                format!(
-                    "bare identifier `{id}` is not a check; use `={id}` to compare the axis \
-                     against an in-scope value, `_` to skip it, or `let [..] = tensor.dims()` \
-                     to name axes"
-                ),
-            ))
         } else {
-            Err(input.error("expected a shape slot: `=expr`, an integer literal, or `_`"))
+            Ok(Slot::Check(Box::new(input.parse()?)))
         }
     }
 }
@@ -60,19 +46,9 @@ impl Parse for ShapeInput {
         input.parse::<Token![,]>()?;
         let content;
         bracketed!(content in input);
-        let mut slots = Vec::new();
-        while !content.is_empty() {
-            slots.push(content.parse()?);
-            if content.is_empty() {
-                break;
-            }
-            if !content.peek(Token![,]) {
-                return Err(content.error(
-                    "expected `,`; to check an axis against an expression, prefix it with `=`",
-                ));
-            }
-            content.parse::<Token![,]>()?;
-        }
+        let slots = Punctuated::<Slot, Token![,]>::parse_terminated(&content)?
+            .into_iter()
+            .collect();
         Ok(ShapeInput {
             krate,
             tensor,
@@ -106,7 +82,7 @@ pub(crate) fn expand(input: ShapeInput, mode: Mode, call: &str) -> TokenStream {
         slots,
     } = input;
 
-    // Mixed-site hygiene: these names are invisible to the caller, so a user `=expr` that
+    // Mixed-site hygiene: these names are invisible to the caller, so a slot expression that
     // mentions `__dims` still resolves to the user's own binding.
     let t = Ident::new("__tensor", Span::mixed_site());
     let dims = Ident::new("__dims", Span::mixed_site());

--- a/crates/burn-derive/src/shape/mod.rs
+++ b/crates/burn-derive/src/shape/mod.rs
@@ -1,6 +1,6 @@
-//! Implementation of `unpack_shape!`, `assert_shape!` and `debug_assert_shape!`. The public
-//! macros and their documentation live in burn-tensor, whose `macro_rules!` wrappers forward
-//! `$crate` so the expansion can name `Tensor::dims` by path.
+//! Implementation of `assert_shape!` and `debug_assert_shape!`. The public macros and their
+//! documentation live in burn-tensor, whose `macro_rules!` wrappers forward `$crate` so the
+//! expansion can name `Tensor::dims` by path.
 
 use proc_macro2::{Literal, Span, TokenStream};
 use quote::{quote, quote_spanned};
@@ -12,12 +12,9 @@ use syn::{
 
 /// One position in a shape pattern.
 enum Slot {
-    /// Bare identifier: a label for an axis whose size `unpack_shape!` returns, in pattern
-    /// order. The name itself is not bound. Rejected by the assert macros.
-    Fresh(Ident),
     /// `=expr` or an integer literal: the axis must equal this `usize` expression.
     Check(Box<Expr>),
-    /// `_`: neither returned nor checked.
+    /// `_`: the axis is not checked.
     Wildcard,
 }
 
@@ -32,11 +29,17 @@ impl Parse for Slot {
         } else if input.peek(LitInt) {
             Ok(Slot::Check(Box::new(Expr::Lit(input.parse()?))))
         } else if input.peek(Ident) {
-            Ok(Slot::Fresh(input.parse()?))
-        } else {
-            Err(input.error(
-                "expected a shape slot: a name to return, `=expr`, an integer literal, or `_`",
+            let id: Ident = input.parse()?;
+            Err(syn::Error::new(
+                id.span(),
+                format!(
+                    "bare identifier `{id}` is not a check; use `={id}` to compare the axis \
+                     against an in-scope value, `_` to skip it, or `let [..] = tensor.dims()` \
+                     to name axes"
+                ),
             ))
+        } else {
+            Err(input.error("expected a shape slot: `=expr`, an integer literal, or `_`"))
         }
     }
 }
@@ -78,11 +81,9 @@ impl Parse for ShapeInput {
     }
 }
 
-/// Which macro is expanding. It decides the validation, the debug gating, and whether a tuple
-/// is returned.
+/// Which macro is expanding. It decides the name in messages and the debug gating.
 #[derive(Clone, Copy)]
 pub(crate) enum Mode {
-    Unpack,
     Assert,
     DebugAssert,
 }
@@ -90,7 +91,6 @@ pub(crate) enum Mode {
 impl Mode {
     fn name(self) -> &'static str {
         match self {
-            Mode::Unpack => "unpack_shape!",
             Mode::Assert => "assert_shape!",
             Mode::DebugAssert => "debug_assert_shape!",
         }
@@ -105,35 +105,6 @@ pub(crate) fn expand(input: ShapeInput, mode: Mode, call: &str) -> TokenStream {
         tensor,
         slots,
     } = input;
-    let name = mode.name();
-
-    match mode {
-        Mode::Unpack => {
-            if !slots.iter().any(|s| matches!(s, Slot::Fresh(_))) {
-                return syn::Error::new(
-                    Span::call_site(),
-                    "`unpack_shape!` needs at least one bare identifier; \
-                     use `assert_shape!` when there is nothing to return",
-                )
-                .to_compile_error();
-            }
-        }
-        Mode::Assert | Mode::DebugAssert => {
-            for slot in &slots {
-                if let Slot::Fresh(id) = slot {
-                    return syn::Error::new(
-                        id.span(),
-                        format!(
-                            "`{name}` does not return axis sizes; bare identifier `{id}` is only \
-                             meaningful in `unpack_shape!`. Use `=` to check the axis against an \
-                             in-scope value, or `_` to skip it"
-                        ),
-                    )
-                    .to_compile_error();
-                }
-            }
-        }
-    }
 
     // Mixed-site hygiene: these names are invisible to the caller, so a user `=expr` that
     // mentions `__dims` still resolves to the user's own binding.
@@ -142,54 +113,41 @@ pub(crate) fn expand(input: ShapeInput, mode: Mode, call: &str) -> TokenStream {
     let expected = Ident::new("__expected", Span::mixed_site());
 
     let rank = slots.len();
-    let call = format!("{name}({call})");
+    let call = format!("{}({call})", mode.name());
 
-    let mut checks = Vec::new();
-    let mut fresh = Vec::new();
-    for (axis, slot) in slots.iter().enumerate() {
-        let index = Literal::usize_unsuffixed(axis);
-        match slot {
-            Slot::Check(expr) => checks.push(quote_spanned! { expr.span() =>
-                {
-                    let #expected: usize = #expr;
-                    ::core::assert!(
-                        #dims[#index] == #expected,
-                        "{}: axis {} expected {}, got {} (dims {:?})",
-                        #call, #index, #expected, #dims[#index], #dims
-                    );
-                }
-            }),
-            Slot::Fresh(_) => fresh.push(quote! { #dims[#index] }),
-            Slot::Wildcard => {}
-        }
-    }
+    let checks = slots
+        .iter()
+        .enumerate()
+        .filter_map(|(axis, slot)| match slot {
+            Slot::Check(expr) => {
+                let index = Literal::usize_unsuffixed(axis);
+                Some(quote_spanned! { expr.span() =>
+                    {
+                        let #expected: usize = #expr;
+                        ::core::assert!(
+                            #dims[#index] == #expected,
+                            "{}: axis {} expected {}, got {} (dims {:?})",
+                            #call, #index, #expected, #dims[#index], #dims
+                        );
+                    }
+                })
+            }
+            Slot::Wildcard => None,
+        });
 
     // The type annotation is the rank check: `Tensor<D>::dims()` returns `[usize; D]`. Calling
     // `Tensor::dims` by path rather than as a method makes any other receiver a type error;
     // `Shape::dims::<N>` would infer `N` from the annotation and truncate silently. Going through
     // a reference keeps a `&x` argument free of `clippy::needless_borrow`, which a
     // `(#tensor).dims()` receiver would trigger.
-    let rank_check = quote_spanned! { tensor.span() =>
+    let body = quote_spanned! { tensor.span() =>
         let #t = &#tensor;
         let #dims: [usize; #rank] = #krate::Tensor::dims(#t);
-    };
-
-    // With nothing to return the block ends in a statement and evaluates to `()` implicitly; an
-    // explicit `()` would trip clippy's `unused_unit` at every `assert_shape!` call site.
-    let tuple = if fresh.is_empty() {
-        TokenStream::new()
-    } else {
-        quote! { (#(#fresh,)*) }
-    };
-
-    let body = quote! {
-        #rank_check
         #(#checks)*
-        #tuple
     };
 
     match mode {
         Mode::DebugAssert => quote! { if ::core::cfg!(debug_assertions) { #body } },
-        Mode::Unpack | Mode::Assert => quote! { { #body } },
+        Mode::Assert => quote! { { #body } },
     }
 }

--- a/crates/burn-derive/src/shape/mod.rs
+++ b/crates/burn-derive/src/shape/mod.rs
@@ -1,22 +1,10 @@
-//! Shape assertion macros: `unpack_shape!`, `assert_shape!` and `debug_assert_shape!`.
-//!
-//! All three take a tensor expression and a bracketed pattern with one slot per axis:
-//!
-//! - a bare identifier binds the axis size (only in `unpack_shape!`),
-//! - `=expr` checks the axis against an in-scope `usize` expression,
-//! - an integer literal checks the axis against that value,
-//! - `_` skips the axis.
-//!
-//! The pattern length is the expected rank. Since `Tensor::dims()` returns `[usize; D]`,
-//! binding it to `[usize; N]` turns a rank mismatch into a compile error. Axis checks are
-//! runtime assertions.
-//!
-//! Inspired by the `burn-contracts` crate by Crutcher Dunnavant.
+//! Implementation of `unpack_shape!`, `assert_shape!` and `debug_assert_shape!`. The public
+//! documentation lives on the macros in `lib.rs`.
 
 use proc_macro2::{Literal, Span, TokenStream};
-use quote::{ToTokens, quote, quote_spanned};
+use quote::{quote, quote_spanned};
 use syn::{
-    Expr, ExprLit, Ident, Lit, LitInt, Token, bracketed,
+    Expr, Ident, LitInt, Token, bracketed,
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
     spanned::Spanned,
@@ -41,11 +29,7 @@ impl Parse for Slot {
             input.parse::<Token![=]>()?;
             Ok(Slot::Check(Box::new(input.parse()?)))
         } else if input.peek(LitInt) {
-            let lit: LitInt = input.parse()?;
-            Ok(Slot::Check(Box::new(Expr::Lit(ExprLit {
-                attrs: Vec::new(),
-                lit: Lit::Int(lit),
-            }))))
+            Ok(Slot::Check(Box::new(Expr::Lit(input.parse()?))))
         } else if input.peek(Ident) {
             Ok(Slot::Fresh(input.parse()?))
         } else {
@@ -71,9 +55,6 @@ impl Parse for ShapeInput {
         let slots = Punctuated::<Slot, Token![,]>::parse_terminated(&content)?
             .into_iter()
             .collect();
-        if !input.is_empty() {
-            return Err(input.error("unexpected tokens after the shape pattern"));
-        }
         Ok(ShapeInput { tensor, slots })
     }
 }
@@ -96,7 +77,8 @@ impl Mode {
     }
 }
 
-pub(crate) fn expand(input: ShapeInput, mode: Mode) -> TokenStream {
+/// `call` is the macro input as the caller wrote it, echoed in panic messages.
+pub(crate) fn expand(input: ShapeInput, mode: Mode, call: &str) -> TokenStream {
     let ShapeInput { tensor, slots } = input;
     let name = mode.name();
 
@@ -135,46 +117,44 @@ pub(crate) fn expand(input: ShapeInput, mode: Mode) -> TokenStream {
     let expected = Ident::new("__expected", Span::mixed_site());
 
     let rank = slots.len();
-    let call_text = format!("{name}({}, {})", source_like(&tensor), pattern_text(&slots));
+    let call = format!("{name}({call})");
 
     let mut checks = Vec::new();
     let mut fresh = Vec::new();
     for (axis, slot) in slots.iter().enumerate() {
         let index = Literal::usize_unsuffixed(axis);
         match slot {
-            Slot::Check(expr) => {
-                let msg = format!("{call_text}: axis {axis} expected {{}}, got {{}} (dims {{:?}})");
-                let check = quote_spanned! { expr.span() =>
-                    {
-                        let #expected: usize = #expr;
-                        ::core::assert!(
-                            #dims[#index] == #expected,
-                            #msg, #expected, #dims[#index], #dims
-                        );
-                    }
-                };
-                checks.push(check);
-            }
+            Slot::Check(expr) => checks.push(quote_spanned! { expr.span() =>
+                {
+                    let #expected: usize = #expr;
+                    ::core::assert!(
+                        #dims[#index] == #expected,
+                        "{}: axis {} expected {}, got {} (dims {:?})",
+                        #call, #index, #expected, #dims[#index], #dims
+                    );
+                }
+            }),
             Slot::Fresh(_) => fresh.push(quote! { #dims[#index] }),
             Slot::Wildcard => {}
         }
     }
 
-    // The type annotation is the rank check: `Tensor<D>::dims()` returns `[usize; D]`.
-    let rank_check = if checks.is_empty() && fresh.is_empty() {
-        quote_spanned! { tensor.span() => let _: [usize; #rank] = #t.dims(); }
-    } else {
-        quote_spanned! { tensor.span() => let #dims: [usize; #rank] = #t.dims(); }
+    // The type annotation is the rank check: `Tensor<D>::dims()` returns `[usize; D]`. Going
+    // through a reference keeps the caller's expression unmoved and hides the borrow from lints.
+    let rank_check = quote_spanned! { tensor.span() =>
+        let #t = &#tensor;
+        let #dims: [usize; #rank] = #t.dims();
     };
 
-    let tuple = match fresh.len() {
-        0 => TokenStream::new(),
-        1 => quote! { (#(#fresh)*,) },
-        _ => quote! { (#(#fresh),*) },
+    // With nothing to bind the block ends in a statement and evaluates to `()` implicitly; an
+    // explicit `()` would trip clippy's `unused_unit` at every `assert_shape!` call site.
+    let tuple = if fresh.is_empty() {
+        TokenStream::new()
+    } else {
+        quote! { (#(#fresh,)*) }
     };
 
     let body = quote! {
-        let #t = &#tensor;
         #rank_check
         #(#checks)*
         #tuple
@@ -184,36 +164,4 @@ pub(crate) fn expand(input: ShapeInput, mode: Mode) -> TokenStream {
         Mode::DebugAssert => quote! { if ::core::cfg!(debug_assertions) { #body } },
         Mode::Unpack | Mode::Assert => quote! { { #body } },
     }
-}
-
-/// Render the pattern back as the user wrote it, for panic messages.
-fn pattern_text(slots: &[Slot]) -> String {
-    let parts: Vec<String> = slots
-        .iter()
-        .map(|slot| match slot {
-            Slot::Fresh(id) => id.to_string(),
-            Slot::Check(expr) => match expr.as_ref() {
-                Expr::Lit(lit) => source_like(lit),
-                expr => format!("={}", source_like(expr)),
-            },
-            Slot::Wildcard => "_".to_string(),
-        })
-        .collect();
-    format!("[{}]", parts.join(", "))
-}
-
-/// Undo the spacing `ToTokens` inserts between every token, then escape braces so the
-/// result can be embedded in a format string.
-fn source_like(tokens: &impl ToTokens) -> String {
-    tokens
-        .to_token_stream()
-        .to_string()
-        .replace(" . ", ".")
-        .replace(" :: ", "::")
-        .replace("& ", "&")
-        .replace("( ", "(")
-        .replace(" )", ")")
-        .replace(" ,", ",")
-        .replace('{', "{{")
-        .replace('}', "}}")
 }

--- a/crates/burn-nn/src/loss/cosine_embedding.rs
+++ b/crates/burn-nn/src/loss/cosine_embedding.rs
@@ -141,8 +141,8 @@ impl CosineEmbeddingLoss {
 
     fn assertions(&self, input1: &Tensor<2>, input2: &Tensor<2>, target: &Tensor<1, Int>) {
         let [batch_size, dim] = input1.dims();
-        assert_shape!(input2, [=batch_size, =dim]);
-        assert_shape!(target, [=batch_size]);
+        assert_shape!(input2, [batch_size, dim]);
+        assert_shape!(target, [batch_size]);
     }
 }
 
@@ -154,9 +154,7 @@ mod tests {
     type FT = f32;
 
     #[test]
-    #[should_panic(
-        expected = "assert_shape!(input2, [=batch_size, =dim]): axis 0 expected 2, got 1"
-    )]
+    #[should_panic(expected = "assert_shape!(input2, [batch_size, dim]): axis 0 expected 2, got 1")]
     fn batch_size_of_inputs_must_match() {
         let device = Default::default();
         let input1 = Tensor::<2>::zeros([2, 3], &device);

--- a/crates/burn-nn/src/loss/cosine_embedding.rs
+++ b/crates/burn-nn/src/loss/cosine_embedding.rs
@@ -154,6 +154,20 @@ mod tests {
     type FT = f32;
 
     #[test]
+    #[should_panic(
+        expected = "assert_shape!(input2, [=batch_size, =dim]): axis 0 expected 2, got 1"
+    )]
+    fn batch_size_of_inputs_must_match() {
+        let device = Default::default();
+        let input1 = Tensor::<2>::zeros([2, 3], &device);
+        let input2 = Tensor::<2>::zeros([1, 3], &device);
+        let target = Tensor::<1, Int>::zeros([2], &device);
+        let _ = CosineEmbeddingLossConfig::new()
+            .init()
+            .forward_no_reduction(input1, input2, target);
+    }
+
+    #[test]
     fn cosine_embedding_loss_positive_target() {
         let device = Default::default();
 

--- a/crates/burn-nn/src/loss/cosine_embedding.rs
+++ b/crates/burn-nn/src/loss/cosine_embedding.rs
@@ -8,7 +8,7 @@ use crate::loss::reduction::Reduction;
 use burn::config::Config;
 use burn::module::Module;
 use burn::module::{Content, DisplaySettings, ModuleDisplay};
-use burn::tensor::{Int, Tensor, activation::relu, assert_shape, unpack_shape};
+use burn::tensor::{Int, Tensor, activation::relu, assert_shape};
 
 /// Configuration for CosineEmbeddingLoss.
 #[derive(Config, Debug)]
@@ -140,7 +140,7 @@ impl CosineEmbeddingLoss {
     }
 
     fn assertions(&self, input1: &Tensor<2>, input2: &Tensor<2>, target: &Tensor<1, Int>) {
-        let (batch_size, dim) = unpack_shape!(input1, [B, D]);
+        let [batch_size, dim] = input1.dims();
         assert_shape!(input2, [=batch_size, =dim]);
         assert_shape!(target, [=batch_size]);
     }

--- a/crates/burn-nn/src/loss/cosine_embedding.rs
+++ b/crates/burn-nn/src/loss/cosine_embedding.rs
@@ -8,7 +8,7 @@ use crate::loss::reduction::Reduction;
 use burn::config::Config;
 use burn::module::Module;
 use burn::module::{Content, DisplaySettings, ModuleDisplay};
-use burn::tensor::{Int, Tensor, activation::relu};
+use burn::tensor::{Int, Tensor, activation::relu, assert_shape, unpack_shape};
 
 /// Configuration for CosineEmbeddingLoss.
 #[derive(Config, Debug)]
@@ -140,24 +140,9 @@ impl CosineEmbeddingLoss {
     }
 
     fn assertions(&self, input1: &Tensor<2>, input2: &Tensor<2>, target: &Tensor<1, Int>) {
-        let [batch_size1, dim1] = input1.dims();
-        let [batch_size2, dim2] = input2.dims();
-        let [batch_size_target] = target.dims();
-
-        assert_eq!(
-            batch_size1, batch_size2,
-            "Batch size of input1 ({batch_size1}) must match batch size of input2 ({batch_size2})"
-        );
-
-        assert_eq!(
-            dim1, dim2,
-            "Embedding dimension of input1 ({dim1}) must match embedding dimension of input2 ({dim2})"
-        );
-
-        assert_eq!(
-            batch_size1, batch_size_target,
-            "Batch size of inputs ({batch_size1}) must match batch size of target ({batch_size_target})"
-        );
+        let (batch_size, dim) = unpack_shape!(input1, [B, D]);
+        assert_shape!(input2, [=batch_size, =dim]);
+        assert_shape!(target, [=batch_size]);
     }
 }
 

--- a/crates/burn-nn/src/loss/cosine_embedding.rs
+++ b/crates/burn-nn/src/loss/cosine_embedding.rs
@@ -166,6 +166,30 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "assert_shape!(input2, [batch_size, dim]): axis 1 expected 3, got 1")]
+    fn embedding_dim_of_inputs_must_match() {
+        let device = Default::default();
+        let input1 = Tensor::<2>::zeros([2, 3], &device);
+        let input2 = Tensor::<2>::zeros([2, 1], &device);
+        let target = Tensor::<1, Int>::zeros([2], &device);
+        let _ = CosineEmbeddingLossConfig::new()
+            .init()
+            .forward_no_reduction(input1, input2, target);
+    }
+
+    #[test]
+    #[should_panic(expected = "assert_shape!(target, [batch_size]): axis 0 expected 2, got 1")]
+    fn target_length_must_match_batch_size() {
+        let device = Default::default();
+        let input1 = Tensor::<2>::zeros([2, 3], &device);
+        let input2 = Tensor::<2>::zeros([2, 3], &device);
+        let target = Tensor::<1, Int>::zeros([1], &device);
+        let _ = CosineEmbeddingLossConfig::new()
+            .init()
+            .forward_no_reduction(input1, input2, target);
+    }
+
+    #[test]
     fn cosine_embedding_loss_positive_target() {
         let device = Default::default();
 

--- a/crates/burn-nn/src/loss/cross_entropy.rs
+++ b/crates/burn-nn/src/loss/cross_entropy.rs
@@ -6,7 +6,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 use burn::module::{Content, DisplaySettings, ModuleDisplay};
 use burn::tensor::activation::log_softmax;
-use burn::tensor::{Bool, Device, Int, Tensor};
+use burn::tensor::{Bool, Device, Int, Tensor, assert_shape, unpack_shape};
 use burn::{config::Config, module::Module};
 
 #[cfg(not(feature = "std"))]
@@ -243,12 +243,8 @@ impl CrossEntropyLoss {
     }
 
     fn assertions(logits: Tensor<2>, targets: Tensor<1, Int>) {
-        let [logits_height, _] = logits.dims();
-        let [targets_height] = targets.dims();
-        assert!(
-            logits_height == targets_height,
-            "Shape of targets ({targets_height}) should correspond to outer shape of logits ({logits_height})."
-        );
+        let (batch_size,) = unpack_shape!(logits, [B, _]);
+        assert_shape!(targets, [=batch_size]);
     }
 }
 

--- a/crates/burn-nn/src/loss/cross_entropy.rs
+++ b/crates/burn-nn/src/loss/cross_entropy.rs
@@ -303,6 +303,17 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "assert_shape!(targets, [=batch_size]): axis 0 expected 4, got 3")]
+    fn test_cross_entropy_loss_targets_must_match_batch_size() {
+        let (logits, _, _) = setup!();
+        let device = logits.device();
+        let targets = Tensor::<1, Int>::from_data(TensorData::from([2, 0, 4]), &device);
+        let _ = CrossEntropyLossConfig::new()
+            .init(&device)
+            .forward(logits, targets);
+    }
+
+    #[test]
     fn test_cross_entropy_loss_with_weights() {
         let (logits, targets, targets_logits) = setup!();
         let weights = vec![1.0, 2., 3., 4., 5.];

--- a/crates/burn-nn/src/loss/cross_entropy.rs
+++ b/crates/burn-nn/src/loss/cross_entropy.rs
@@ -6,7 +6,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 use burn::module::{Content, DisplaySettings, ModuleDisplay};
 use burn::tensor::activation::log_softmax;
-use burn::tensor::{Bool, Device, Int, Tensor, assert_shape, unpack_shape};
+use burn::tensor::{Bool, Device, Int, Tensor, assert_shape};
 use burn::{config::Config, module::Module};
 
 #[cfg(not(feature = "std"))]
@@ -243,7 +243,7 @@ impl CrossEntropyLoss {
     }
 
     fn assertions(logits: Tensor<2>, targets: Tensor<1, Int>) {
-        let (batch_size,) = unpack_shape!(logits, [B, _]);
+        let [batch_size, _] = logits.dims();
         assert_shape!(targets, [=batch_size]);
     }
 }

--- a/crates/burn-nn/src/loss/cross_entropy.rs
+++ b/crates/burn-nn/src/loss/cross_entropy.rs
@@ -244,7 +244,7 @@ impl CrossEntropyLoss {
 
     fn assertions(logits: Tensor<2>, targets: Tensor<1, Int>) {
         let [batch_size, _] = logits.dims();
-        assert_shape!(targets, [=batch_size]);
+        assert_shape!(targets, [batch_size]);
     }
 }
 
@@ -303,7 +303,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "assert_shape!(targets, [=batch_size]): axis 0 expected 4, got 3")]
+    #[should_panic(expected = "assert_shape!(targets, [batch_size]): axis 0 expected 4, got 3")]
     fn test_cross_entropy_loss_targets_must_match_batch_size() {
         let (logits, _, _) = setup!();
         let device = logits.device();

--- a/crates/burn-nn/src/loss/ctc.rs
+++ b/crates/burn-nn/src/loss/ctc.rs
@@ -104,6 +104,11 @@ impl CTCLoss {
     /// - `targets`: `[batch_size, max_target_length]`
     /// - `input_lengths`: `[batch_size]`
     /// - `target_lengths`: `[batch_size]`
+    ///
+    /// # Panics
+    ///
+    /// - If the batch dimension of `targets`, `input_lengths` or `target_lengths` differs from `log_probs`.
+    /// - If `blank` is greater than or equal to `num_classes`.
     pub fn forward(
         &self,
         log_probs: Tensor<3>,

--- a/crates/burn-nn/src/loss/ctc.rs
+++ b/crates/burn-nn/src/loss/ctc.rs
@@ -113,9 +113,9 @@ impl CTCLoss {
     ) -> Tensor<1> {
         let [max_input_length, batch_size, num_classes] = log_probs.dims();
         let [_, max_target_len] = targets.dims();
-        assert_shape!(targets, [=batch_size, _]);
-        assert_shape!(input_lengths, [=batch_size]);
-        assert_shape!(target_lengths, [=batch_size]);
+        assert_shape!(targets, [batch_size, _]);
+        assert_shape!(input_lengths, [batch_size]);
+        assert_shape!(target_lengths, [batch_size]);
         assert!(
             self.blank < num_classes,
             "blank index {} must be less than num_classes {}",
@@ -270,7 +270,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "assert_shape!(targets, [=batch_size, _]): axis 0 expected 2, got 1")]
+    #[should_panic(expected = "assert_shape!(targets, [batch_size, _]): axis 0 expected 2, got 1")]
     fn test_ctc_loss_panics_mismatched_batch_size() {
         let device = Default::default();
         let ctc = CTCLossConfig::new().init();
@@ -287,7 +287,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "assert_shape!(input_lengths, [=batch_size]): axis 0 expected 2, got 1"
+        expected = "assert_shape!(input_lengths, [batch_size]): axis 0 expected 2, got 1"
     )]
     fn test_ctc_loss_panics_input_lengths_mismatch() {
         let device = Default::default();
@@ -306,7 +306,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "assert_shape!(target_lengths, [=batch_size]): axis 0 expected 2, got 1"
+        expected = "assert_shape!(target_lengths, [batch_size]): axis 0 expected 2, got 1"
     )]
     fn test_ctc_loss_panics_target_lengths_mismatch() {
         let device = Default::default();

--- a/crates/burn-nn/src/loss/ctc.rs
+++ b/crates/burn-nn/src/loss/ctc.rs
@@ -3,7 +3,7 @@
 use super::Reduction;
 use burn::config::Config;
 use burn::module::Module;
-use burn::tensor::{Int, Tensor, assert_shape, unpack_shape};
+use burn::tensor::{Int, Tensor, assert_shape};
 use burn_core as burn;
 
 /// Configuration for the [CTC Loss](CTCLoss) module.
@@ -112,7 +112,8 @@ impl CTCLoss {
         target_lengths: Tensor<1, Int>,
     ) -> Tensor<1> {
         let [max_input_length, batch_size, num_classes] = log_probs.dims();
-        let (max_target_len,) = unpack_shape!(targets, [=batch_size, L]);
+        let [_, max_target_len] = targets.dims();
+        assert_shape!(targets, [=batch_size, _]);
         assert_shape!(input_lengths, [=batch_size]);
         assert_shape!(target_lengths, [=batch_size]);
         assert!(
@@ -269,7 +270,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "unpack_shape!(targets, [=batch_size, L]): axis 0 expected 2, got 1")]
+    #[should_panic(expected = "assert_shape!(targets, [=batch_size, _]): axis 0 expected 2, got 1")]
     fn test_ctc_loss_panics_mismatched_batch_size() {
         let device = Default::default();
         let ctc = CTCLossConfig::new().init();

--- a/crates/burn-nn/src/loss/ctc.rs
+++ b/crates/burn-nn/src/loss/ctc.rs
@@ -3,7 +3,7 @@
 use super::Reduction;
 use burn::config::Config;
 use burn::module::Module;
-use burn::tensor::{Int, Tensor};
+use burn::tensor::{Int, Tensor, assert_shape, unpack_shape};
 use burn_core as burn;
 
 /// Configuration for the [CTC Loss](CTCLoss) module.
@@ -112,15 +112,14 @@ impl CTCLoss {
         target_lengths: Tensor<1, Int>,
     ) -> Tensor<1> {
         let [max_input_length, batch_size, num_classes] = log_probs.dims();
-        let max_target_len = targets.dims()[1];
-        let input_lengths_len = input_lengths.dims()[0];
-        let target_lengths_len = target_lengths.dims()[0];
-        self.assertions(
-            batch_size,
-            num_classes,
-            targets.clone(),
-            input_lengths_len,
-            target_lengths_len,
+        let (max_target_len,) = unpack_shape!(targets, [=batch_size, L]);
+        assert_shape!(input_lengths, [=batch_size]);
+        assert_shape!(target_lengths, [=batch_size]);
+        assert!(
+            self.blank < num_classes,
+            "blank index {} must be less than num_classes {}",
+            self.blank,
+            num_classes
         );
         self.length_assertions(
             input_lengths.clone(),
@@ -242,39 +241,6 @@ impl CTCLoss {
             }
         }
     }
-
-    fn assertions(
-        &self,
-        batch_size: usize,
-        num_classes: usize,
-        targets: Tensor<2, Int>,
-        input_lengths_len: usize,
-        target_lengths_len: usize,
-    ) {
-        assert!(
-            self.blank < num_classes,
-            "blank index {} must be less than num_classes {}",
-            self.blank,
-            num_classes
-        );
-        assert_eq!(
-            targets.dims()[0],
-            batch_size,
-            "targets batch dimension {} must equal batch_size {}",
-            targets.dims()[0],
-            batch_size
-        );
-        assert_eq!(
-            input_lengths_len, batch_size,
-            "input_lengths length {} must equal batch_size {}",
-            input_lengths_len, batch_size
-        );
-        assert_eq!(
-            target_lengths_len, batch_size,
-            "target_lengths length {} must equal batch_size {}",
-            target_lengths_len, batch_size
-        );
-    }
 }
 
 #[cfg(test)]
@@ -303,7 +269,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "must equal batch_size")]
+    #[should_panic(expected = "unpack_shape!(targets, [=batch_size, L]): axis 0 expected 2, got 1")]
     fn test_ctc_loss_panics_mismatched_batch_size() {
         let device = Default::default();
         let ctc = CTCLossConfig::new().init();
@@ -319,7 +285,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "input_lengths length")]
+    #[should_panic(
+        expected = "assert_shape!(input_lengths, [=batch_size]): axis 0 expected 2, got 1"
+    )]
     fn test_ctc_loss_panics_input_lengths_mismatch() {
         let device = Default::default();
         let ctc = CTCLossConfig::new().init();
@@ -336,7 +304,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "target_lengths length")]
+    #[should_panic(
+        expected = "assert_shape!(target_lengths, [=batch_size]): axis 0 expected 2, got 1"
+    )]
     fn test_ctc_loss_panics_target_lengths_mismatch() {
         let device = Default::default();
         let ctc = CTCLossConfig::new().init();

--- a/crates/burn-nn/src/loss/rnnt.rs
+++ b/crates/burn-nn/src/loss/rnnt.rs
@@ -253,9 +253,9 @@ impl RNNTLoss {
             self.blank,
             v
         );
-        assert_shape!(targets, [=b, =max_u]);
-        assert_shape!(logit_lengths, [=b]);
-        assert_shape!(target_lengths, [=b]);
+        assert_shape!(targets, [b, max_u]);
+        assert_shape!(logit_lengths, [b]);
+        assert_shape!(target_lengths, [b]);
     }
 
     /// Numerically stable `log(exp(a) + exp(b))`, handling `-inf` inputs.
@@ -304,7 +304,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "assert_shape!(targets, [=b, =max_u]): axis 0 expected 2, got 1")]
+    #[should_panic(expected = "assert_shape!(targets, [b, max_u]): axis 0 expected 2, got 1")]
     fn panics_on_batch_mismatch() {
         let dev = Default::default();
         let rnnt = RNNTLossConfig::new().init();
@@ -317,7 +317,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "assert_shape!(logit_lengths, [=b]): axis 0 expected 2, got 1")]
+    #[should_panic(expected = "assert_shape!(logit_lengths, [b]): axis 0 expected 2, got 1")]
     fn panics_on_logit_lengths_mismatch() {
         let dev = Default::default();
         let rnnt = RNNTLossConfig::new().init();
@@ -330,7 +330,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "assert_shape!(target_lengths, [=b]): axis 0 expected 2, got 1")]
+    #[should_panic(expected = "assert_shape!(target_lengths, [b]): axis 0 expected 2, got 1")]
     fn panics_on_target_lengths_mismatch() {
         let dev = Default::default();
         let rnnt = RNNTLossConfig::new().init();

--- a/crates/burn-nn/src/loss/rnnt.rs
+++ b/crates/burn-nn/src/loss/rnnt.rs
@@ -2,7 +2,7 @@ use super::Reduction;
 use alloc::vec;
 use burn::config::Config;
 use burn::module::Module;
-use burn::tensor::{Bool, Device, Int, Tensor, s};
+use burn::tensor::{Bool, Device, Int, Tensor, assert_shape, s};
 use burn_core as burn;
 use core::f32;
 
@@ -253,34 +253,9 @@ impl RNNTLoss {
             self.blank,
             v
         );
-        assert_eq!(
-            targets.dims()[0],
-            b,
-            "targets batch dimension {} must equal batch_size {}",
-            targets.dims()[0],
-            b
-        );
-        assert_eq!(
-            targets.dims()[1],
-            max_u,
-            "targets length dimension {} must equal max_target_len (max_u) {}",
-            targets.dims()[1],
-            max_u
-        );
-        assert_eq!(
-            logit_lengths.dims()[0],
-            b,
-            "logit_lengths length {} must equal batch_size {}",
-            logit_lengths.dims()[0],
-            b
-        );
-        assert_eq!(
-            target_lengths.dims()[0],
-            b,
-            "target_lengths length {} must equal batch_size {}",
-            target_lengths.dims()[0],
-            b
-        );
+        assert_shape!(targets, [=b, =max_u]);
+        assert_shape!(logit_lengths, [=b]);
+        assert_shape!(target_lengths, [=b]);
     }
 
     /// Numerically stable `log(exp(a) + exp(b))`, handling `-inf` inputs.
@@ -329,7 +304,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "must equal batch_size")]
+    #[should_panic(expected = "assert_shape!(targets, [=b, =max_u]): axis 0 expected 2, got 1")]
     fn panics_on_batch_mismatch() {
         let dev = Default::default();
         let rnnt = RNNTLossConfig::new().init();
@@ -342,7 +317,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "logit_lengths length")]
+    #[should_panic(expected = "assert_shape!(logit_lengths, [=b]): axis 0 expected 2, got 1")]
     fn panics_on_logit_lengths_mismatch() {
         let dev = Default::default();
         let rnnt = RNNTLossConfig::new().init();
@@ -355,7 +330,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "target_lengths length")]
+    #[should_panic(expected = "assert_shape!(target_lengths, [=b]): axis 0 expected 2, got 1")]
     fn panics_on_target_lengths_mismatch() {
         let dev = Default::default();
         let rnnt = RNNTLossConfig::new().init();

--- a/crates/burn-nn/src/loss/rnnt.rs
+++ b/crates/burn-nn/src/loss/rnnt.rs
@@ -317,6 +317,19 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "assert_shape!(targets, [b, max_u]): axis 1 expected 2, got 1")]
+    fn panics_on_target_length_mismatch() {
+        let dev = Default::default();
+        let rnnt = RNNTLossConfig::new().init();
+        rnnt.forward(
+            Tensor::<4>::zeros([2, 3, 3, 3], &dev),
+            Tensor::<2, Int>::from_data([[1_i32], [2]], &dev),
+            Tensor::<1, Int>::from_data([3, 3], &dev),
+            Tensor::<1, Int>::from_data([1, 1], &dev),
+        );
+    }
+
+    #[test]
     #[should_panic(expected = "assert_shape!(logit_lengths, [b]): axis 0 expected 2, got 1")]
     fn panics_on_logit_lengths_mismatch() {
         let dev = Default::default();

--- a/crates/burn-nn/src/modules/attention/cross_attention.rs
+++ b/crates/burn-nn/src/modules/attention/cross_attention.rs
@@ -10,6 +10,7 @@
 use crate::cache::TensorCache;
 use crate::modules::{Linear, LinearConfig};
 use crate::{Dropout, DropoutConfig};
+use burn::tensor::unpack_shape;
 use burn_core as burn;
 
 use burn::{
@@ -164,8 +165,8 @@ impl CrossAttention {
         context: Tensor<3>,
         mask: Option<Tensor<2, Bool>>,
     ) -> Tensor<3> {
-        let [batch, l_q, _] = query.dims();
-        let [_, l_k, _] = context.dims();
+        let (batch, l_q) = unpack_shape!(query, [B, L, _]);
+        let (l_k,) = unpack_shape!(context, [=batch, L, _]);
 
         // 1. Projections
         let q = self.query.forward(query);
@@ -247,20 +248,20 @@ impl CrossAttention {
         mask: Option<Tensor<2, Bool>>,
         cache: &mut CrossAttentionCache,
     ) -> Tensor<3> {
-        let [batch, l_q, _] = query.dims();
+        let (batch, l_q) = unpack_shape!(query, [B, L, _]);
 
         // 1. Projections
         let q = self.query.forward(query);
 
         let k_compute = |context: Tensor<3>| {
-            let [batch, l_k, _] = context.dims();
+            let (l_k,) = unpack_shape!(context, [=batch, L, _]);
             self.key
                 .forward(context)
                 .reshape([batch, l_k, self.n_heads_kv, self.d_head])
                 .swap_dims(1, 2)
         };
         let v_compute = |context: Tensor<3>| {
-            let [batch, l_k, _] = context.dims();
+            let (l_k,) = unpack_shape!(context, [=batch, L, _]);
             self.value
                 .forward(context)
                 .reshape([batch, l_k, self.n_heads_kv, self.d_head])

--- a/crates/burn-nn/src/modules/attention/cross_attention.rs
+++ b/crates/burn-nn/src/modules/attention/cross_attention.rs
@@ -10,7 +10,7 @@
 use crate::cache::TensorCache;
 use crate::modules::{Linear, LinearConfig};
 use crate::{Dropout, DropoutConfig};
-use burn::tensor::unpack_shape;
+use burn::tensor::debug_assert_shape;
 use burn_core as burn;
 
 use burn::{
@@ -165,8 +165,9 @@ impl CrossAttention {
         context: Tensor<3>,
         mask: Option<Tensor<2, Bool>>,
     ) -> Tensor<3> {
-        let (batch, l_q) = unpack_shape!(query, [B, L, _]);
-        let (l_k,) = unpack_shape!(context, [=batch, L, _]);
+        let [batch, l_q, _] = query.dims();
+        let [_, l_k, _] = context.dims();
+        debug_assert_shape!(context, [=batch, _, _]);
 
         // 1. Projections
         let q = self.query.forward(query);
@@ -248,20 +249,22 @@ impl CrossAttention {
         mask: Option<Tensor<2, Bool>>,
         cache: &mut CrossAttentionCache,
     ) -> Tensor<3> {
-        let (batch, l_q) = unpack_shape!(query, [B, L, _]);
+        let [batch, l_q, _] = query.dims();
 
         // 1. Projections
         let q = self.query.forward(query);
 
         let k_compute = |context: Tensor<3>| {
-            let (l_k,) = unpack_shape!(context, [=batch, L, _]);
+            let [_, l_k, _] = context.dims();
+            debug_assert_shape!(context, [=batch, _, _]);
             self.key
                 .forward(context)
                 .reshape([batch, l_k, self.n_heads_kv, self.d_head])
                 .swap_dims(1, 2)
         };
         let v_compute = |context: Tensor<3>| {
-            let (l_k,) = unpack_shape!(context, [=batch, L, _]);
+            let [_, l_k, _] = context.dims();
+            debug_assert_shape!(context, [=batch, _, _]);
             self.value
                 .forward(context)
                 .reshape([batch, l_k, self.n_heads_kv, self.d_head])

--- a/crates/burn-nn/src/modules/attention/cross_attention.rs
+++ b/crates/burn-nn/src/modules/attention/cross_attention.rs
@@ -10,7 +10,7 @@
 use crate::cache::TensorCache;
 use crate::modules::{Linear, LinearConfig};
 use crate::{Dropout, DropoutConfig};
-use burn::tensor::{assert_shape, unpack_shape};
+use burn::tensor::assert_shape;
 use burn_core as burn;
 
 use burn::{
@@ -165,8 +165,9 @@ impl CrossAttention {
         context: Tensor<3>,
         mask: Option<Tensor<2, Bool>>,
     ) -> Tensor<3> {
-        let (batch, l_q) = unpack_shape!(query, [B, L, _]);
-        let (l_k,) = unpack_shape!(context, [=batch, L, _]);
+        let [batch, l_q, _] = query.dims();
+        let [_, l_k, _] = context.dims();
+        assert_shape!(context, [=batch, _, _]);
 
         // 1. Projections
         let q = self.query.forward(query);
@@ -248,7 +249,7 @@ impl CrossAttention {
         mask: Option<Tensor<2, Bool>>,
         cache: &mut CrossAttentionCache,
     ) -> Tensor<3> {
-        let (batch, l_q) = unpack_shape!(query, [B, L, _]);
+        let [batch, l_q, _] = query.dims();
         assert_shape!(context, [=batch, _, _]);
 
         // 1. Projections
@@ -538,7 +539,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "unpack_shape!(context, [=batch, L, _]): axis 0 expected 2, got 1")]
+    #[should_panic(expected = "assert_shape!(context, [=batch, _, _]): axis 0 expected 2, got 1")]
     fn context_batch_must_match_query_batch() {
         let device = Default::default();
         let attn = CrossAttentionConfig::new(16, 16, 2, 2, 8).init(&device);

--- a/crates/burn-nn/src/modules/attention/cross_attention.rs
+++ b/crates/burn-nn/src/modules/attention/cross_attention.rs
@@ -159,6 +159,10 @@ impl CrossAttention {
     /// # Returns
     ///
     /// Output tensor of shape `[batch, seq_len_query, d_model]`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the batch size of `context` differs from `query`.
     pub fn forward(
         &self,
         query: Tensor<3>,
@@ -242,6 +246,10 @@ impl CrossAttention {
     /// # Returns
     ///
     /// Output tensor of shape `[batch, seq_len_query, d_model]`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the batch size of `context` differs from `query`.
     pub fn forward_cache(
         &self,
         query: Tensor<3>,
@@ -546,6 +554,17 @@ mod tests {
         let query = Tensor::zeros([2, 3, 16], &device);
         let context = Tensor::zeros([1, 4, 16], &device);
         let _ = attn.forward(query, context, None);
+    }
+
+    #[test]
+    #[should_panic(expected = "assert_shape!(context, [batch, _, _]): axis 0 expected 2, got 1")]
+    fn cache_context_batch_must_match_query_batch() {
+        let device = Default::default();
+        let attn = CrossAttentionConfig::new(16, 16, 2, 2, 8).init(&device);
+        let mut cache = CrossAttentionCache::new();
+        let query = Tensor::zeros([2, 3, 16], &device);
+        let context = Tensor::zeros([1, 4, 16], &device);
+        let _ = attn.forward_cache(query, context, None, &mut cache);
     }
 
     #[test]

--- a/crates/burn-nn/src/modules/attention/cross_attention.rs
+++ b/crates/burn-nn/src/modules/attention/cross_attention.rs
@@ -167,7 +167,7 @@ impl CrossAttention {
     ) -> Tensor<3> {
         let [batch, l_q, _] = query.dims();
         let [_, l_k, _] = context.dims();
-        assert_shape!(context, [=batch, _, _]);
+        assert_shape!(context, [batch, _, _]);
 
         // 1. Projections
         let q = self.query.forward(query);
@@ -250,7 +250,7 @@ impl CrossAttention {
         cache: &mut CrossAttentionCache,
     ) -> Tensor<3> {
         let [batch, l_q, _] = query.dims();
-        assert_shape!(context, [=batch, _, _]);
+        assert_shape!(context, [batch, _, _]);
 
         // 1. Projections
         let q = self.query.forward(query);
@@ -539,7 +539,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "assert_shape!(context, [=batch, _, _]): axis 0 expected 2, got 1")]
+    #[should_panic(expected = "assert_shape!(context, [batch, _, _]): axis 0 expected 2, got 1")]
     fn context_batch_must_match_query_batch() {
         let device = Default::default();
         let attn = CrossAttentionConfig::new(16, 16, 2, 2, 8).init(&device);

--- a/crates/burn-nn/src/modules/attention/cross_attention.rs
+++ b/crates/burn-nn/src/modules/attention/cross_attention.rs
@@ -10,7 +10,7 @@
 use crate::cache::TensorCache;
 use crate::modules::{Linear, LinearConfig};
 use crate::{Dropout, DropoutConfig};
-use burn::tensor::debug_assert_shape;
+use burn::tensor::{assert_shape, unpack_shape};
 use burn_core as burn;
 
 use burn::{
@@ -165,9 +165,8 @@ impl CrossAttention {
         context: Tensor<3>,
         mask: Option<Tensor<2, Bool>>,
     ) -> Tensor<3> {
-        let [batch, l_q, _] = query.dims();
-        let [_, l_k, _] = context.dims();
-        debug_assert_shape!(context, [=batch, _, _]);
+        let (batch, l_q) = unpack_shape!(query, [B, L, _]);
+        let (l_k,) = unpack_shape!(context, [=batch, L, _]);
 
         // 1. Projections
         let q = self.query.forward(query);
@@ -249,22 +248,21 @@ impl CrossAttention {
         mask: Option<Tensor<2, Bool>>,
         cache: &mut CrossAttentionCache,
     ) -> Tensor<3> {
-        let [batch, l_q, _] = query.dims();
+        let (batch, l_q) = unpack_shape!(query, [B, L, _]);
+        assert_shape!(context, [=batch, _, _]);
 
         // 1. Projections
         let q = self.query.forward(query);
 
         let k_compute = |context: Tensor<3>| {
-            let [_, l_k, _] = context.dims();
-            debug_assert_shape!(context, [=batch, _, _]);
+            let [batch, l_k, _] = context.dims();
             self.key
                 .forward(context)
                 .reshape([batch, l_k, self.n_heads_kv, self.d_head])
                 .swap_dims(1, 2)
         };
         let v_compute = |context: Tensor<3>| {
-            let [_, l_k, _] = context.dims();
-            debug_assert_shape!(context, [=batch, _, _]);
+            let [batch, l_k, _] = context.dims();
             self.value
                 .forward(context)
                 .reshape([batch, l_k, self.n_heads_kv, self.d_head])
@@ -537,6 +535,16 @@ mod tests {
         output_1
             .into_data()
             .assert_approx_eq(&output_2.into_data(), Tolerance::<f32>::default());
+    }
+
+    #[test]
+    #[should_panic(expected = "unpack_shape!(context, [=batch, L, _]): axis 0 expected 2, got 1")]
+    fn context_batch_must_match_query_batch() {
+        let device = Default::default();
+        let attn = CrossAttentionConfig::new(16, 16, 2, 2, 8).init(&device);
+        let query = Tensor::zeros([2, 3, 16], &device);
+        let context = Tensor::zeros([1, 4, 16], &device);
+        let _ = attn.forward(query, context, None);
     }
 
     #[test]

--- a/crates/burn-nn/src/modules/attention/mha.rs
+++ b/crates/burn-nn/src/modules/attention/mha.rs
@@ -211,10 +211,9 @@ impl MultiHeadAttention {
     /// - output: `[batch_size, seq_length_1, d_model]`
     pub fn forward(&self, input: MhaInput) -> MhaOutput {
         let [batch_size, seq_length_1, d_model] = input.query.dims();
-        let [_, seq_length_2, _] = input.key.dims();
         debug_assert_shape!(input.query, [_, _, =self.d_model]);
         debug_assert_shape!(input.key, [=batch_size, _, =self.d_model]);
-        debug_assert_shape!(input.value, [=batch_size, =seq_length_2, =self.d_model]);
+        debug_assert_shape!(input.value, [=batch_size, =input.key.dims()[1], =self.d_model]);
 
         let query = self.attention_linear(input.query, &self.query);
         let key = self.attention_linear(input.key, &self.key);
@@ -242,10 +241,9 @@ impl MultiHeadAttention {
     /// - output: `[batch_size, seq_length_1, d_model]`
     pub fn forward_cache(&self, input: MhaInput, cache: &mut MhaCache) -> MhaOutput {
         let [batch_size, seq_length_1, d_model] = input.query.dims();
-        let [_, seq_length_2, _] = input.key.dims();
         debug_assert_shape!(input.query, [_, _, =self.d_model]);
         debug_assert_shape!(input.key, [=batch_size, _, =self.d_model]);
-        debug_assert_shape!(input.value, [=batch_size, =seq_length_2, =self.d_model]);
+        debug_assert_shape!(input.value, [=batch_size, =input.key.dims()[1], =self.d_model]);
 
         let query = cache
             .query

--- a/crates/burn-nn/src/modules/attention/mha.rs
+++ b/crates/burn-nn/src/modules/attention/mha.rs
@@ -5,7 +5,7 @@ use crate::cache::TensorCache;
 use crate::{Dropout, DropoutConfig, Linear, LinearConfig};
 use burn::config::Config;
 use burn::module::{Content, DisplaySettings, Initializer, Module, ModuleDisplay};
-use burn::tensor::{Bool, Device, Tensor, assert_shape, unpack_shape};
+use burn::tensor::{Bool, Device, Tensor, debug_assert_shape};
 
 use burn::tensor::activation::{quiet_softmax, softmax};
 #[cfg(not(feature = "std"))]
@@ -210,9 +210,11 @@ impl MultiHeadAttention {
     /// - value: `[batch_size, seq_length_2, d_model]`
     /// - output: `[batch_size, seq_length_1, d_model]`
     pub fn forward(&self, input: MhaInput) -> MhaOutput {
-        let (batch_size, seq_length_1) = unpack_shape!(input.query, [B, T, =self.d_model]);
-        let (seq_length_2,) = unpack_shape!(input.key, [=batch_size, T, =self.d_model]);
-        assert_shape!(input.value, [=batch_size, =seq_length_2, =self.d_model]);
+        let [batch_size, seq_length_1, d_model] = input.query.dims();
+        let [_, seq_length_2, _] = input.key.dims();
+        debug_assert_shape!(input.query, [_, _, =self.d_model]);
+        debug_assert_shape!(input.key, [=batch_size, _, =self.d_model]);
+        debug_assert_shape!(input.value, [=batch_size, =seq_length_2, =self.d_model]);
 
         let query = self.attention_linear(input.query, &self.query);
         let key = self.attention_linear(input.key, &self.key);
@@ -224,7 +226,7 @@ impl MultiHeadAttention {
         let context = weights.clone().matmul(value);
         let context = context
             .swap_dims(1, 2)
-            .reshape([batch_size, seq_length_1, self.d_model]);
+            .reshape([batch_size, seq_length_1, d_model]);
         let context = self.output.forward(context);
 
         MhaOutput { weights, context }
@@ -239,9 +241,11 @@ impl MultiHeadAttention {
     /// - value: `[batch_size, seq_length_2, d_model]`
     /// - output: `[batch_size, seq_length_1, d_model]`
     pub fn forward_cache(&self, input: MhaInput, cache: &mut MhaCache) -> MhaOutput {
-        let (batch_size, seq_length_1) = unpack_shape!(input.query, [B, T, =self.d_model]);
-        let (seq_length_2,) = unpack_shape!(input.key, [=batch_size, T, =self.d_model]);
-        assert_shape!(input.value, [=batch_size, =seq_length_2, =self.d_model]);
+        let [batch_size, seq_length_1, d_model] = input.query.dims();
+        let [_, seq_length_2, _] = input.key.dims();
+        debug_assert_shape!(input.query, [_, _, =self.d_model]);
+        debug_assert_shape!(input.key, [=batch_size, _, =self.d_model]);
+        debug_assert_shape!(input.value, [=batch_size, =seq_length_2, =self.d_model]);
 
         let query = cache
             .query
@@ -259,7 +263,7 @@ impl MultiHeadAttention {
         let context = weights.clone().matmul(value);
         let context = context
             .swap_dims(1, 2)
-            .reshape([batch_size, seq_length_1, self.d_model]);
+            .reshape([batch_size, seq_length_1, d_model]);
 
         let context = cache.output.forward(context, |t| self.output.forward(t));
 

--- a/crates/burn-nn/src/modules/attention/mha.rs
+++ b/crates/burn-nn/src/modules/attention/mha.rs
@@ -209,6 +209,12 @@ impl MultiHeadAttention {
     /// - key: `[batch_size, seq_length_2, d_model]`
     /// - value: `[batch_size, seq_length_2, d_model]`
     /// - output: `[batch_size, seq_length_1, d_model]`
+    ///
+    /// # Panics
+    ///
+    /// Panics if the last axis of `query`, `key` or `value` is not `d_model`, if the batch size
+    /// of `key` or `value` differs from `query`, or if the sequence length of `value` differs
+    /// from `key`.
     pub fn forward(&self, input: MhaInput) -> MhaOutput {
         let [batch_size, seq_length_1, d_model] = input.query.dims();
         let [_, seq_length_2, _] = input.key.dims();
@@ -240,6 +246,12 @@ impl MultiHeadAttention {
     /// - key: `[batch_size, seq_length_2, d_model]`
     /// - value: `[batch_size, seq_length_2, d_model]`
     /// - output: `[batch_size, seq_length_1, d_model]`
+    ///
+    /// # Panics
+    ///
+    /// Panics if the last axis of `query`, `key` or `value` is not `d_model`, if the batch size
+    /// of `key` or `value` differs from `query`, or if the sequence length of `value` differs
+    /// from `key`.
     pub fn forward_cache(&self, input: MhaInput, cache: &mut MhaCache) -> MhaOutput {
         let [batch_size, seq_length_1, d_model] = input.query.dims();
         let [_, seq_length_2, _] = input.key.dims();
@@ -390,6 +402,32 @@ mod tests {
         let query = Tensor::zeros([2, 3, 8], &device);
         let key = Tensor::zeros([1, 3, 8], &device);
         let _ = mha.forward(MhaInput::new(query, key.clone(), key));
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "assert_shape!(input.value, [batch_size, seq_length_2, self.d_model]): axis 0 expected 2, got 1"
+    )]
+    fn value_batch_must_match_query_batch() {
+        let device = Default::default();
+        let mha = MultiHeadAttentionConfig::new(8, 2).init(&device);
+        let query = Tensor::zeros([2, 3, 8], &device);
+        let key = Tensor::zeros([2, 3, 8], &device);
+        let value = Tensor::zeros([1, 3, 8], &device);
+        let _ = mha.forward(MhaInput::new(query, key, value));
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "assert_shape!(input.key, [batch_size, _, self.d_model]): axis 0 expected 2, got 1"
+    )]
+    fn cache_key_batch_must_match_query_batch() {
+        let device = Default::default();
+        let mha = MultiHeadAttentionConfig::new(8, 2).init(&device);
+        let mut cache = MhaCache::autoregressive();
+        let query = Tensor::zeros([2, 3, 8], &device);
+        let key = Tensor::zeros([1, 3, 8], &device);
+        let _ = mha.forward_cache(MhaInput::new(query, key.clone(), key), &mut cache);
     }
 
     #[test]

--- a/crates/burn-nn/src/modules/attention/mha.rs
+++ b/crates/burn-nn/src/modules/attention/mha.rs
@@ -212,9 +212,9 @@ impl MultiHeadAttention {
     pub fn forward(&self, input: MhaInput) -> MhaOutput {
         let [batch_size, seq_length_1, d_model] = input.query.dims();
         let [_, seq_length_2, _] = input.key.dims();
-        assert_shape!(input.query, [_, _, =self.d_model]);
-        assert_shape!(input.key, [=batch_size, _, =self.d_model]);
-        assert_shape!(input.value, [=batch_size, =seq_length_2, =self.d_model]);
+        assert_shape!(input.query, [_, _, self.d_model]);
+        assert_shape!(input.key, [batch_size, _, self.d_model]);
+        assert_shape!(input.value, [batch_size, seq_length_2, self.d_model]);
 
         let query = self.attention_linear(input.query, &self.query);
         let key = self.attention_linear(input.key, &self.key);
@@ -243,9 +243,9 @@ impl MultiHeadAttention {
     pub fn forward_cache(&self, input: MhaInput, cache: &mut MhaCache) -> MhaOutput {
         let [batch_size, seq_length_1, d_model] = input.query.dims();
         let [_, seq_length_2, _] = input.key.dims();
-        assert_shape!(input.query, [_, _, =self.d_model]);
-        assert_shape!(input.key, [=batch_size, _, =self.d_model]);
-        assert_shape!(input.value, [=batch_size, =seq_length_2, =self.d_model]);
+        assert_shape!(input.query, [_, _, self.d_model]);
+        assert_shape!(input.key, [batch_size, _, self.d_model]);
+        assert_shape!(input.value, [batch_size, seq_length_2, self.d_model]);
 
         let query = cache
             .query
@@ -382,7 +382,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "assert_shape!(input.key, [=batch_size, _, =self.d_model]): axis 0 expected 2, got 1"
+        expected = "assert_shape!(input.key, [batch_size, _, self.d_model]): axis 0 expected 2, got 1"
     )]
     fn key_batch_must_match_query_batch() {
         let device = Default::default();

--- a/crates/burn-nn/src/modules/attention/mha.rs
+++ b/crates/burn-nn/src/modules/attention/mha.rs
@@ -5,7 +5,7 @@ use crate::cache::TensorCache;
 use crate::{Dropout, DropoutConfig, Linear, LinearConfig};
 use burn::config::Config;
 use burn::module::{Content, DisplaySettings, Initializer, Module, ModuleDisplay};
-use burn::tensor::{Bool, Device, Tensor, assert_shape, unpack_shape};
+use burn::tensor::{Bool, Device, Tensor, assert_shape};
 
 use burn::tensor::activation::{quiet_softmax, softmax};
 #[cfg(not(feature = "std"))]
@@ -210,8 +210,10 @@ impl MultiHeadAttention {
     /// - value: `[batch_size, seq_length_2, d_model]`
     /// - output: `[batch_size, seq_length_1, d_model]`
     pub fn forward(&self, input: MhaInput) -> MhaOutput {
-        let (batch_size, seq_length_1) = unpack_shape!(input.query, [B, T, =self.d_model]);
-        let (seq_length_2,) = unpack_shape!(input.key, [=batch_size, T, =self.d_model]);
+        let [batch_size, seq_length_1, d_model] = input.query.dims();
+        let [_, seq_length_2, _] = input.key.dims();
+        assert_shape!(input.query, [_, _, =self.d_model]);
+        assert_shape!(input.key, [=batch_size, _, =self.d_model]);
         assert_shape!(input.value, [=batch_size, =seq_length_2, =self.d_model]);
 
         let query = self.attention_linear(input.query, &self.query);
@@ -224,7 +226,7 @@ impl MultiHeadAttention {
         let context = weights.clone().matmul(value);
         let context = context
             .swap_dims(1, 2)
-            .reshape([batch_size, seq_length_1, self.d_model]);
+            .reshape([batch_size, seq_length_1, d_model]);
         let context = self.output.forward(context);
 
         MhaOutput { weights, context }
@@ -239,8 +241,10 @@ impl MultiHeadAttention {
     /// - value: `[batch_size, seq_length_2, d_model]`
     /// - output: `[batch_size, seq_length_1, d_model]`
     pub fn forward_cache(&self, input: MhaInput, cache: &mut MhaCache) -> MhaOutput {
-        let (batch_size, seq_length_1) = unpack_shape!(input.query, [B, T, =self.d_model]);
-        let (seq_length_2,) = unpack_shape!(input.key, [=batch_size, T, =self.d_model]);
+        let [batch_size, seq_length_1, d_model] = input.query.dims();
+        let [_, seq_length_2, _] = input.key.dims();
+        assert_shape!(input.query, [_, _, =self.d_model]);
+        assert_shape!(input.key, [=batch_size, _, =self.d_model]);
         assert_shape!(input.value, [=batch_size, =seq_length_2, =self.d_model]);
 
         let query = cache
@@ -259,7 +263,7 @@ impl MultiHeadAttention {
         let context = weights.clone().matmul(value);
         let context = context
             .swap_dims(1, 2)
-            .reshape([batch_size, seq_length_1, self.d_model]);
+            .reshape([batch_size, seq_length_1, d_model]);
 
         let context = cache.output.forward(context, |t| self.output.forward(t));
 
@@ -378,7 +382,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "unpack_shape!(input.key, [=batch_size, T, =self.d_model]): axis 0 expected 2, got 1"
+        expected = "assert_shape!(input.key, [=batch_size, _, =self.d_model]): axis 0 expected 2, got 1"
     )]
     fn key_batch_must_match_query_batch() {
         let device = Default::default();

--- a/crates/burn-nn/src/modules/attention/mha.rs
+++ b/crates/burn-nn/src/modules/attention/mha.rs
@@ -5,7 +5,7 @@ use crate::cache::TensorCache;
 use crate::{Dropout, DropoutConfig, Linear, LinearConfig};
 use burn::config::Config;
 use burn::module::{Content, DisplaySettings, Initializer, Module, ModuleDisplay};
-use burn::tensor::{Bool, Device, Tensor, debug_assert_shape};
+use burn::tensor::{Bool, Device, Tensor, assert_shape, unpack_shape};
 
 use burn::tensor::activation::{quiet_softmax, softmax};
 #[cfg(not(feature = "std"))]
@@ -210,10 +210,9 @@ impl MultiHeadAttention {
     /// - value: `[batch_size, seq_length_2, d_model]`
     /// - output: `[batch_size, seq_length_1, d_model]`
     pub fn forward(&self, input: MhaInput) -> MhaOutput {
-        let [batch_size, seq_length_1, d_model] = input.query.dims();
-        debug_assert_shape!(input.query, [_, _, =self.d_model]);
-        debug_assert_shape!(input.key, [=batch_size, _, =self.d_model]);
-        debug_assert_shape!(input.value, [=batch_size, =input.key.dims()[1], =self.d_model]);
+        let (batch_size, seq_length_1) = unpack_shape!(input.query, [B, T, =self.d_model]);
+        let (seq_length_2,) = unpack_shape!(input.key, [=batch_size, T, =self.d_model]);
+        assert_shape!(input.value, [=batch_size, =seq_length_2, =self.d_model]);
 
         let query = self.attention_linear(input.query, &self.query);
         let key = self.attention_linear(input.key, &self.key);
@@ -225,7 +224,7 @@ impl MultiHeadAttention {
         let context = weights.clone().matmul(value);
         let context = context
             .swap_dims(1, 2)
-            .reshape([batch_size, seq_length_1, d_model]);
+            .reshape([batch_size, seq_length_1, self.d_model]);
         let context = self.output.forward(context);
 
         MhaOutput { weights, context }
@@ -240,10 +239,9 @@ impl MultiHeadAttention {
     /// - value: `[batch_size, seq_length_2, d_model]`
     /// - output: `[batch_size, seq_length_1, d_model]`
     pub fn forward_cache(&self, input: MhaInput, cache: &mut MhaCache) -> MhaOutput {
-        let [batch_size, seq_length_1, d_model] = input.query.dims();
-        debug_assert_shape!(input.query, [_, _, =self.d_model]);
-        debug_assert_shape!(input.key, [=batch_size, _, =self.d_model]);
-        debug_assert_shape!(input.value, [=batch_size, =input.key.dims()[1], =self.d_model]);
+        let (batch_size, seq_length_1) = unpack_shape!(input.query, [B, T, =self.d_model]);
+        let (seq_length_2,) = unpack_shape!(input.key, [=batch_size, T, =self.d_model]);
+        assert_shape!(input.value, [=batch_size, =seq_length_2, =self.d_model]);
 
         let query = cache
             .query
@@ -261,7 +259,7 @@ impl MultiHeadAttention {
         let context = weights.clone().matmul(value);
         let context = context
             .swap_dims(1, 2)
-            .reshape([batch_size, seq_length_1, d_model]);
+            .reshape([batch_size, seq_length_1, self.d_model]);
 
         let context = cache.output.forward(context, |t| self.output.forward(t));
 
@@ -377,6 +375,18 @@ mod tests {
     use burn::tensor::Int;
     use burn::tensor::Tolerance;
     use burn::tensor::{Distribution, Shape};
+
+    #[test]
+    #[should_panic(
+        expected = "unpack_shape!(input.key, [=batch_size, T, =self.d_model]): axis 0 expected 2, got 1"
+    )]
+    fn key_batch_must_match_query_batch() {
+        let device = Default::default();
+        let mha = MultiHeadAttentionConfig::new(8, 2).init(&device);
+        let query = Tensor::zeros([2, 3, 8], &device);
+        let key = Tensor::zeros([1, 3, 8], &device);
+        let _ = mha.forward(MhaInput::new(query, key.clone(), key));
+    }
 
     #[test]
     fn test_enable_bias() {

--- a/crates/burn-nn/src/modules/attention/mha.rs
+++ b/crates/burn-nn/src/modules/attention/mha.rs
@@ -5,7 +5,7 @@ use crate::cache::TensorCache;
 use crate::{Dropout, DropoutConfig, Linear, LinearConfig};
 use burn::config::Config;
 use burn::module::{Content, DisplaySettings, Initializer, Module, ModuleDisplay};
-use burn::tensor::{Bool, Device, Tensor};
+use burn::tensor::{Bool, Device, Tensor, assert_shape, unpack_shape};
 
 use burn::tensor::activation::{quiet_softmax, softmax};
 #[cfg(not(feature = "std"))]
@@ -210,7 +210,9 @@ impl MultiHeadAttention {
     /// - value: `[batch_size, seq_length_2, d_model]`
     /// - output: `[batch_size, seq_length_1, d_model]`
     pub fn forward(&self, input: MhaInput) -> MhaOutput {
-        let [batch_size, seq_length_1, d_model] = input.query.dims();
+        let (batch_size, seq_length_1) = unpack_shape!(input.query, [B, T, =self.d_model]);
+        let (seq_length_2,) = unpack_shape!(input.key, [=batch_size, T, =self.d_model]);
+        assert_shape!(input.value, [=batch_size, =seq_length_2, =self.d_model]);
 
         let query = self.attention_linear(input.query, &self.query);
         let key = self.attention_linear(input.key, &self.key);
@@ -222,7 +224,7 @@ impl MultiHeadAttention {
         let context = weights.clone().matmul(value);
         let context = context
             .swap_dims(1, 2)
-            .reshape([batch_size, seq_length_1, d_model]);
+            .reshape([batch_size, seq_length_1, self.d_model]);
         let context = self.output.forward(context);
 
         MhaOutput { weights, context }
@@ -237,7 +239,9 @@ impl MultiHeadAttention {
     /// - value: `[batch_size, seq_length_2, d_model]`
     /// - output: `[batch_size, seq_length_1, d_model]`
     pub fn forward_cache(&self, input: MhaInput, cache: &mut MhaCache) -> MhaOutput {
-        let [batch_size, seq_length_1, d_model] = input.query.dims();
+        let (batch_size, seq_length_1) = unpack_shape!(input.query, [B, T, =self.d_model]);
+        let (seq_length_2,) = unpack_shape!(input.key, [=batch_size, T, =self.d_model]);
+        assert_shape!(input.value, [=batch_size, =seq_length_2, =self.d_model]);
 
         let query = cache
             .query
@@ -255,7 +259,7 @@ impl MultiHeadAttention {
         let context = weights.clone().matmul(value);
         let context = context
             .swap_dims(1, 2)
-            .reshape([batch_size, seq_length_1, d_model]);
+            .reshape([batch_size, seq_length_1, self.d_model]);
 
         let context = cache.output.forward(context, |t| self.output.forward(t));
 

--- a/crates/burn-nn/src/modules/linear.rs
+++ b/crates/burn-nn/src/modules/linear.rs
@@ -4,7 +4,7 @@ use burn::config::Config;
 use burn::module::Param;
 use burn::module::{Content, DisplaySettings, Initializer, Module, ModuleDisplay};
 use burn::tensor::module::linear;
-use burn::tensor::{Device, Tensor};
+use burn::tensor::{Device, Tensor, assert_shape};
 
 /// Configuration to create a [`Linear`] layer using the [init function](LinearConfig::init).
 #[derive(Config, Debug)]
@@ -125,12 +125,16 @@ impl Linear {
     /// # Returns
     ///
     /// The transformed tensor of shape `[..., d_output]`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the last axis of `input` is not `d_input`.
     pub fn forward<const D: usize>(&self, input: Tensor<D>) -> Tensor<D> {
-        linear(
-            input,
-            self.weight.val(),
-            self.bias.as_ref().map(|b| b.val()),
-        )
+        let weight = self.weight.val();
+        let [d_input, _] = weight.dims();
+        assert_shape!(input, [.., d_input]);
+
+        linear(input, weight, self.bias.as_ref().map(|b| b.val()))
     }
 }
 
@@ -160,6 +164,14 @@ mod tests {
     use burn::tensor::Tolerance;
     use burn::tensor::{Shape, TensorData};
     type FT = f32;
+
+    #[test]
+    #[should_panic(expected = "assert_shape!(input, [.., d_input]): axis 1 expected 4, got 3")]
+    fn input_d_input_must_match() {
+        let device = Default::default();
+        let linear = LinearConfig::new(4, 2).init(&device);
+        let _ = linear.forward(Tensor::<2>::zeros([1, 3], &device));
+    }
 
     #[test]
     fn initializer_default() {

--- a/crates/burn-nn/src/modules/norm/batch.rs
+++ b/crates/burn-nn/src/modules/norm/batch.rs
@@ -86,14 +86,14 @@ impl BatchNorm {
     ///
     /// # Shapes
     ///
-    /// - `input`: ``[batch_size, channels, ...]``
-    /// - `output`: ``[batch_size, channels, ...]``
+    /// - `input`: ``[batch_size, num_features, ...]``
+    /// - `output`: ``[batch_size, num_features, ...]``
     ///
     /// # Panics
     ///
     /// Panics if the input has rank < 2 or its second axis is not `num_features`.
     pub fn forward<const D: usize>(&self, input: Tensor<D>) -> Tensor<D> {
-        let [num_features] = self.gamma.val().dims();
+        let [num_features] = self.gamma.shape().dims();
         assert_shape!(input, [_, num_features, ..]);
 
         // Training behavior is selected by the device *and* the layer state. The device alone
@@ -224,6 +224,16 @@ mod tests_1d {
     use burn::tensor::TensorData;
     use burn::tensor::Tolerance;
     type FT = f32;
+
+    #[test]
+    #[should_panic(
+        expected = "assert_shape!(input, [_, num_features, ..]): expected rank at least 2, got 1"
+    )]
+    fn input_rank_must_be_at_least_two() {
+        let device = Default::default();
+        let module = BatchNormConfig::new(3).init(&device);
+        let _ = module.forward(Tensor::<1>::zeros([4], &device));
+    }
 
     #[test]
     #[should_panic(

--- a/crates/burn-nn/src/modules/norm/batch.rs
+++ b/crates/burn-nn/src/modules/norm/batch.rs
@@ -2,7 +2,7 @@ use burn_core as burn;
 
 use burn::module::{Content, DisplaySettings, ModuleDisplay};
 use burn::module::{Flag, Initializer};
-use burn::tensor::{Device, Tensor};
+use burn::tensor::{Device, Tensor, assert_shape};
 use burn::{
     config::Config,
     module::{Module, Param, RunningState},
@@ -91,17 +91,10 @@ impl BatchNorm {
     ///
     /// # Panics
     ///
-    /// This function will panic if the input tensor has rank < 2.
+    /// Panics if the input has rank < 2 or its second axis is not `num_features`.
     pub fn forward<const D: usize>(&self, input: Tensor<D>) -> Tensor<D> {
-        // Should be move to a compilation error when const generic support that kind of
-        // validation. https://github.com/rust-lang/rust/issues/76560
-        if D < 2 {
-            panic!(
-                "BatchNorm can only be applied on tensors of rank >= 2 with the following shape \
-                 [batch_size, channels, ...], received {}D tensor",
-                D
-            );
-        }
+        let [num_features] = self.gamma.val().dims();
+        assert_shape!(input, [_, num_features, ..]);
 
         // Training behavior is selected by the device *and* the layer state. The device alone
         // says a backward is possible, not that this layer takes part in one: partial finetuning
@@ -231,6 +224,16 @@ mod tests_1d {
     use burn::tensor::TensorData;
     use burn::tensor::Tolerance;
     type FT = f32;
+
+    #[test]
+    #[should_panic(
+        expected = "assert_shape!(input, [_, num_features, ..]): axis 1 expected 3, got 4"
+    )]
+    fn input_channels_must_match() {
+        let device = Default::default();
+        let module = BatchNormConfig::new(3).init(&device);
+        let _ = module.forward(Tensor::<3>::zeros([1, 4, 2], &device));
+    }
 
     #[test]
     fn batch_norm_forward_train() {

--- a/crates/burn-nn/src/modules/norm/group.rs
+++ b/crates/burn-nn/src/modules/norm/group.rs
@@ -8,6 +8,7 @@ use burn::module::{Content, DisplaySettings, ModuleDisplay};
 use burn::tensor::Device;
 use burn::tensor::FloatDType;
 use burn::tensor::Tensor;
+use burn::tensor::assert_shape;
 
 use super::accumulation_dtype;
 
@@ -111,14 +112,12 @@ impl GroupNorm {
     ///
     /// - input: `[batch_size, num_channels, *]`
     /// - output: `[batch_size, num_channels, *]`
+    ///
+    /// # Panics
+    ///
+    /// Panics if the input has rank < 2 or its second axis is not `num_channels`.
     pub fn forward<const D: usize>(&self, input: Tensor<D>) -> Tensor<D> {
-        if input.shape()[1] != self.num_channels {
-            panic!(
-                "The number of channels in the input tensor should be equal to the number of channels in the GroupNorm module. Expected {}, got {}",
-                self.num_channels,
-                input.shape()[1]
-            );
-        }
+        assert_shape!(input, [_, self.num_channels, ..]);
 
         let gamma = self.gamma.as_ref().map(|x| x.val());
         let beta = self.beta.as_ref().map(|x| x.val());
@@ -214,6 +213,16 @@ mod tests {
     use burn::tensor::TensorData;
     use burn::tensor::Tolerance;
     type FT = f32;
+
+    #[test]
+    #[should_panic(
+        expected = "assert_shape!(input, [_, self.num_channels, ..]): axis 1 expected 6, got 4"
+    )]
+    fn input_channels_must_match() {
+        let device = Default::default();
+        let module = GroupNormConfig::new(3, 6).init(&device);
+        let _ = module.forward(Tensor::<3>::zeros([1, 4, 2], &device));
+    }
 
     #[test]
     fn group_norm_forward_affine_false() {

--- a/crates/burn-nn/src/modules/norm/instance.rs
+++ b/crates/burn-nn/src/modules/norm/instance.rs
@@ -5,7 +5,7 @@ use burn::config::Config;
 use burn::module::Initializer;
 use burn::module::{Content, DisplaySettings, ModuleDisplay};
 use burn::module::{Module, Param};
-use burn::tensor::{Device, Tensor};
+use burn::tensor::{Device, Tensor, assert_shape};
 
 /// Configuration to create a [InstanceNorm](InstanceNorm) layer using the [init function](InstanceNormConfig::init).
 #[derive(Debug, Config)]
@@ -87,7 +87,13 @@ impl InstanceNorm {
     ///
     /// - input: `[batch_size, num_channels, *]`
     /// - output: `[batch_size, num_channels, *]`
+    ///
+    /// # Panics
+    ///
+    /// Panics if the input has rank < 2 or its second axis is not `num_channels`.
     pub fn forward<const D: usize>(&self, input: Tensor<D>) -> Tensor<D> {
+        assert_shape!(input, [_, self.num_channels, ..]);
+
         // Instance norm is equivalent to group norm when the number of groups is equal to the number of channels.
         let num_groups = self.num_channels;
 
@@ -105,6 +111,16 @@ mod tests {
     use burn::tensor::TensorData;
     use burn::tensor::Tolerance;
     type FT = f32;
+
+    #[test]
+    #[should_panic(
+        expected = "assert_shape!(input, [_, self.num_channels, ..]): axis 1 expected 6, got 4"
+    )]
+    fn input_channels_must_match() {
+        let device = Default::default();
+        let module = InstanceNormConfig::new(6).init(&device);
+        let _ = module.forward(Tensor::<3>::zeros([1, 4, 2], &device));
+    }
 
     #[test]
     fn instance_norm_forward_affine_false() {

--- a/crates/burn-nn/src/modules/norm/layer.rs
+++ b/crates/burn-nn/src/modules/norm/layer.rs
@@ -1,3 +1,4 @@
+use burn::tensor::assert_shape;
 use burn_core as burn;
 
 use burn::config::Config;
@@ -76,8 +77,14 @@ impl LayerNorm {
     ///
     /// - input: `[..., any, d_model]`
     /// - output: `[..., any, d_model]`
+    ///
+    /// # Panics
+    ///
+    /// Panics if the last axis of `input` is not `d_model`.
     pub fn forward<const D: usize>(&self, input: Tensor<D>) -> Tensor<D> {
         let gamma = self.gamma.val();
+        let [d_model] = gamma.dims();
+        assert_shape!(input, [.., d_model]);
         let beta = self.beta.as_ref().map(|b| b.val());
 
         // Widen when the input dtype cannot hold the sum of squares the
@@ -122,6 +129,14 @@ mod tests {
     use burn::tensor::TensorData;
     use burn::tensor::Tolerance;
     type FT = f32;
+
+    #[test]
+    #[should_panic(expected = "assert_shape!(input, [.., d_model]): axis 1 expected 10, got 3")]
+    fn input_d_model_must_match() {
+        let device = Default::default();
+        let module = LayerNormConfig::new(10).init(&device);
+        let _ = module.forward(Tensor::<2>::zeros([1, 3], &device));
+    }
 
     #[test]
     fn layer_norm_forward() {

--- a/crates/burn-nn/src/modules/norm/local_response.rs
+++ b/crates/burn-nn/src/modules/norm/local_response.rs
@@ -2,9 +2,9 @@ use burn_core as burn;
 
 use burn::config::Config;
 use burn::module::{Content, DisplaySettings, Module, ModuleDisplay};
-use burn::tensor::Tensor;
 use burn::tensor::module::avg_pool1d;
 use burn::tensor::ops::PadMode;
+use burn::tensor::{Tensor, assert_shape};
 
 /// Configuration to create a [LocalResponseNorm](LocalResponseNorm) layer
 /// using the [init function](LocalResponseNormConfig::init).
@@ -78,10 +78,7 @@ impl LocalResponseNorm {
     ///
     /// Panics if the input tensor rank is less than 3.
     pub fn forward<const D: usize>(&self, input: Tensor<D>) -> Tensor<D> {
-        assert!(
-            D >= 3,
-            "LocalResponseNorm requires input rank >= 3, got {D}"
-        );
+        assert_shape!(input, [_, _, _, ..]);
 
         let shape = input.dims();
         let n = shape[0];
@@ -592,7 +589,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "LocalResponseNorm requires input rank >= 3")]
+    #[should_panic(
+        expected = "assert_shape!(input, [_, _, _, ..]): expected rank at least 3, got 2"
+    )]
     fn forward_rank_2_panics() {
         let module = LocalResponseNormConfig::new(3).init();
         let input = Tensor::<2>::zeros([2, 4], &Default::default());

--- a/crates/burn-nn/src/modules/norm/rms.rs
+++ b/crates/burn-nn/src/modules/norm/rms.rs
@@ -74,7 +74,7 @@ impl RmsNorm {
     ///
     /// Panics if the last axis of `x` is not `d_model`.
     pub fn forward<const D: usize>(&self, x: Tensor<D>) -> Tensor<D> {
-        let [d_model] = self.gamma.val().dims();
+        let [d_model] = self.gamma.shape().dims();
         assert_shape!(x, [.., d_model]);
 
         // Calculate the root-mean-square norm of the input tensor along the last dimension

--- a/crates/burn-nn/src/modules/norm/rms.rs
+++ b/crates/burn-nn/src/modules/norm/rms.rs
@@ -1,5 +1,6 @@
 use burn::tensor::DType;
 
+use burn::tensor::assert_shape;
 use burn_core as burn;
 
 use burn::config::Config;
@@ -68,7 +69,14 @@ impl RmsNorm {
     ///
     /// - input: `[..., any, d_model]`
     /// - output: `[..., any, d_model]`
+    ///
+    /// # Panics
+    ///
+    /// Panics if the last axis of `x` is not `d_model`.
     pub fn forward<const D: usize>(&self, x: Tensor<D>) -> Tensor<D> {
+        let [d_model] = self.gamma.val().dims();
+        assert_shape!(x, [.., d_model]);
+
         // Calculate the root-mean-square norm of the input tensor along the last dimension
         let dtype = x.dtype();
         let rms = (x.clone().cast(DType::F32).square().mean_dim(D - 1) + self.epsilon).sqrt();
@@ -99,6 +107,14 @@ mod tests {
     use burn::tensor::TensorData;
     use burn::tensor::Tolerance;
     type FT = f32;
+
+    #[test]
+    #[should_panic(expected = "assert_shape!(x, [.., d_model]): axis 1 expected 3, got 4")]
+    fn input_d_model_must_match() {
+        let device = Default::default();
+        let module = RmsNormConfig::new(3).init(&device);
+        let _ = module.forward(Tensor::<2>::zeros([2, 4], &device));
+    }
 
     #[test]
     fn rms_norm_forward() {

--- a/crates/burn-nn/src/modules/pos_encoding.rs
+++ b/crates/burn-nn/src/modules/pos_encoding.rs
@@ -272,7 +272,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "max_sequence_size(")]
     fn input_length_should_be_less_than_max_len() {
         let d_model = 8;
         let device = Default::default();

--- a/crates/burn-nn/src/modules/pos_encoding.rs
+++ b/crates/burn-nn/src/modules/pos_encoding.rs
@@ -5,7 +5,7 @@ use burn::config::Config;
 use burn::module::{Content, DisplaySettings, Module, ModuleDisplay};
 
 use burn::tensor::TensorData;
-use burn::tensor::{Device, Tensor, debug_assert_shape};
+use burn::tensor::{Device, Tensor, unpack_shape};
 
 #[cfg(not(feature = "std"))]
 #[allow(unused_imports)]
@@ -99,12 +99,10 @@ impl PositionalEncoding {
     /// # Panics
     ///
     /// * Panics if the input sequence length is greater than the maximum sequence size.
-    /// * Panics if the input d_model is not equal to the d_model of the sinusoids (checked in
-    ///   debug builds).
+    /// * Panics if the input d_model is not equal to the d_model of the sinusoids.
     pub fn forward(&self, input: Tensor<3>) -> Tensor<3> {
-        let [_, seq_length, _] = input.dims();
         let [batch_size, max_sequence_size, d_model] = self.sinusoids.dims();
-        debug_assert_shape!(input, [_, _, =d_model]);
+        let (seq_length,) = unpack_shape!(input, [_, T, =d_model]);
 
         assert!(
             max_sequence_size >= seq_length,
@@ -253,12 +251,22 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "unpack_shape!(input, [_, T, =d_model]): axis 2 expected 8, got 10")]
     fn d_model_input_should_match() {
         let d_model = 8;
         let device = Default::default();
         let pe = PositionalEncodingConfig::new(d_model).init(&device);
         let input = Tensor::zeros([1, 5, 10], &device);
+        let _output = pe.forward(input);
+    }
+
+    #[test]
+    #[should_panic(expected = "unpack_shape!(input, [_, T, =d_model]): axis 2 expected 8, got 1")]
+    fn d_model_input_of_one_does_not_broadcast() {
+        let d_model = 8;
+        let device = Default::default();
+        let pe = PositionalEncodingConfig::new(d_model).init(&device);
+        let input = Tensor::zeros([1, 5, 1], &device);
         let _output = pe.forward(input);
     }
 

--- a/crates/burn-nn/src/modules/pos_encoding.rs
+++ b/crates/burn-nn/src/modules/pos_encoding.rs
@@ -103,7 +103,7 @@ impl PositionalEncoding {
     pub fn forward(&self, input: Tensor<3>) -> Tensor<3> {
         let [_, seq_length, _] = input.dims();
         let [batch_size, max_sequence_size, d_model] = self.sinusoids.dims();
-        assert_shape!(input, [_, _, =d_model]);
+        assert_shape!(input, [_, _, d_model]);
 
         assert!(
             max_sequence_size >= seq_length,
@@ -252,7 +252,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "assert_shape!(input, [_, _, =d_model]): axis 2 expected 8, got 10")]
+    #[should_panic(expected = "assert_shape!(input, [_, _, d_model]): axis 2 expected 8, got 10")]
     fn d_model_input_should_match() {
         let d_model = 8;
         let device = Default::default();
@@ -262,7 +262,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "assert_shape!(input, [_, _, =d_model]): axis 2 expected 8, got 1")]
+    #[should_panic(expected = "assert_shape!(input, [_, _, d_model]): axis 2 expected 8, got 1")]
     fn d_model_input_of_one_does_not_broadcast() {
         let d_model = 8;
         let device = Default::default();

--- a/crates/burn-nn/src/modules/pos_encoding.rs
+++ b/crates/burn-nn/src/modules/pos_encoding.rs
@@ -5,7 +5,7 @@ use burn::config::Config;
 use burn::module::{Content, DisplaySettings, Module, ModuleDisplay};
 
 use burn::tensor::TensorData;
-use burn::tensor::{Device, Tensor, unpack_shape};
+use burn::tensor::{Device, Tensor, debug_assert_shape};
 
 #[cfg(not(feature = "std"))]
 #[allow(unused_imports)]
@@ -101,8 +101,9 @@ impl PositionalEncoding {
     /// * Panics if the input sequence length is greater than the maximum sequence size.
     /// * Panics if the input d_model is not equal to the d_model of the sinusoids.
     pub fn forward(&self, input: Tensor<3>) -> Tensor<3> {
+        let [_, seq_length, _] = input.dims();
         let [batch_size, max_sequence_size, d_model] = self.sinusoids.dims();
-        let (seq_length,) = unpack_shape!(input, [_, T, =d_model]);
+        debug_assert_shape!(input, [_, _, =d_model]);
 
         assert!(
             max_sequence_size >= seq_length,

--- a/crates/burn-nn/src/modules/pos_encoding.rs
+++ b/crates/burn-nn/src/modules/pos_encoding.rs
@@ -99,7 +99,8 @@ impl PositionalEncoding {
     /// # Panics
     ///
     /// * Panics if the input sequence length is greater than the maximum sequence size.
-    /// * Panics if the input d_model is not equal to the d_model of the sinusoids.
+    /// * Panics if the input d_model is not equal to the d_model of the sinusoids (checked in
+    ///   debug builds).
     pub fn forward(&self, input: Tensor<3>) -> Tensor<3> {
         let [_, seq_length, _] = input.dims();
         let [batch_size, max_sequence_size, d_model] = self.sinusoids.dims();

--- a/crates/burn-nn/src/modules/pos_encoding.rs
+++ b/crates/burn-nn/src/modules/pos_encoding.rs
@@ -5,7 +5,7 @@ use burn::config::Config;
 use burn::module::{Content, DisplaySettings, Module, ModuleDisplay};
 
 use burn::tensor::TensorData;
-use burn::tensor::{Device, Tensor};
+use burn::tensor::{Device, Tensor, unpack_shape};
 
 #[cfg(not(feature = "std"))]
 #[allow(unused_imports)]
@@ -101,18 +101,12 @@ impl PositionalEncoding {
     /// * Panics if the input sequence length is greater than the maximum sequence size.
     /// * Panics if the input d_model is not equal to the d_model of the sinusoids.
     pub fn forward(&self, input: Tensor<3>) -> Tensor<3> {
-        let [_, seq_length, d_model_input] = input.dims();
-
         let [batch_size, max_sequence_size, d_model] = self.sinusoids.dims();
+        let (seq_length,) = unpack_shape!(input, [_, T, =d_model]);
 
         assert!(
             max_sequence_size >= seq_length,
             "max_sequence_size({max_sequence_size}) must be greater or equal than length({seq_length})"
-        );
-
-        assert!(
-            d_model_input == d_model,
-            "d_model({d_model_input}) of the input must be equal to d_model of encoding({d_model})"
         );
 
         let slices = [0..batch_size, 0..seq_length, 0..d_model];

--- a/crates/burn-nn/src/modules/pos_encoding.rs
+++ b/crates/burn-nn/src/modules/pos_encoding.rs
@@ -5,7 +5,7 @@ use burn::config::Config;
 use burn::module::{Content, DisplaySettings, Module, ModuleDisplay};
 
 use burn::tensor::TensorData;
-use burn::tensor::{Device, Tensor, unpack_shape};
+use burn::tensor::{Device, Tensor, assert_shape};
 
 #[cfg(not(feature = "std"))]
 #[allow(unused_imports)]
@@ -101,8 +101,9 @@ impl PositionalEncoding {
     /// * Panics if the input sequence length is greater than the maximum sequence size.
     /// * Panics if the input d_model is not equal to the d_model of the sinusoids.
     pub fn forward(&self, input: Tensor<3>) -> Tensor<3> {
+        let [_, seq_length, _] = input.dims();
         let [batch_size, max_sequence_size, d_model] = self.sinusoids.dims();
-        let (seq_length,) = unpack_shape!(input, [_, T, =d_model]);
+        assert_shape!(input, [_, _, =d_model]);
 
         assert!(
             max_sequence_size >= seq_length,
@@ -251,7 +252,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "unpack_shape!(input, [_, T, =d_model]): axis 2 expected 8, got 10")]
+    #[should_panic(expected = "assert_shape!(input, [_, _, =d_model]): axis 2 expected 8, got 10")]
     fn d_model_input_should_match() {
         let d_model = 8;
         let device = Default::default();
@@ -261,7 +262,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "unpack_shape!(input, [_, T, =d_model]): axis 2 expected 8, got 1")]
+    #[should_panic(expected = "assert_shape!(input, [_, _, =d_model]): axis 2 expected 8, got 1")]
     fn d_model_input_of_one_does_not_broadcast() {
         let d_model = 8;
         let device = Default::default();

--- a/crates/burn-nn/src/modules/rope_encoding.rs
+++ b/crates/burn-nn/src/modules/rope_encoding.rs
@@ -4,7 +4,7 @@ use alloc::vec;
 use burn::config::Config;
 use burn::module::{Content, DisplaySettings, Module, ModuleDisplay};
 use burn::tensor::Int;
-use burn::tensor::{Device, Tensor};
+use burn::tensor::{Device, Tensor, assert_shape};
 use core::ops::Range;
 
 #[cfg(not(feature = "std"))]
@@ -143,7 +143,7 @@ impl RotaryEncoding {
     /// Output tensor with the same shape as input tensor after applying rotary encoding.
     ///
     /// # Panics
-    /// If the input tensor does not have at least 2 dimensions for sequence length and hidden dimension.
+    /// If the input has fewer than 2 dimensions or its last axis is not `d_model`.
     pub fn forward<const D: usize>(&self, x: Tensor<D>) -> Tensor<D> {
         self.apply(x, 0)
     }
@@ -160,19 +160,17 @@ impl RotaryEncoding {
     /// Output tensor with the same shape as input tensor after applying rotary encoding.
     ///
     /// # Panics
-    /// If the input tensor does not have at least 2 dimensions for sequence length and hidden dimension.
+    /// If the input has fewer than 2 dimensions or its last axis is not `d_model`.
     pub fn apply<const D: usize>(&self, x: Tensor<D>, start: usize) -> Tensor<D> {
-        assert!(
-            D >= 2,
-            "Input tensor must have at least 2 dimensions for sequence length and hidden dimension"
-        );
+        let [_, d_model, _] = self.freq_complex.dims();
+        assert_shape!(x, [.., _, d_model]);
 
         let device = x.device();
         let input_shape = x.shape();
 
         // Extract the sequence length and embedding dimension, other dimensions are kept generic
         // to allow both 3D and 4D tensors i.e. batch_size or (batch_size, num_heads)
-        let (seq_len, d_model) = (x.dims()[D - 2], x.dims()[D - 1]);
+        let seq_len = x.dims()[D - 2];
         let dummy_dim_size = input_shape.num_elements() / (seq_len * d_model);
 
         // Create a dummy tensor with signed ones based on the 2D rotation matrix
@@ -284,6 +282,14 @@ mod tests {
     use super::*;
     use burn::tensor::Tolerance;
     type FT = f32;
+
+    #[test]
+    #[should_panic(expected = "assert_shape!(x, [.., _, d_model]): axis 2 expected 4, got 6")]
+    fn input_d_model_must_match() {
+        let device = Default::default();
+        let rotary_encoding = RotaryEncodingConfig::new(10, 4).init(&device);
+        let _ = rotary_encoding.forward(Tensor::<3>::zeros([1, 5, 6], &device));
+    }
 
     #[test]
     fn test_rotary_encoding_forward() {

--- a/crates/burn-nn/src/modules/rope_encoding.rs
+++ b/crates/burn-nn/src/modules/rope_encoding.rs
@@ -292,6 +292,16 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(
+        expected = "assert_shape!(x, [.., _, d_model]): expected rank at least 2, got 1"
+    )]
+    fn input_rank_must_be_at_least_two() {
+        let device = Default::default();
+        let rotary_encoding = RotaryEncodingConfig::new(10, 4).init(&device);
+        let _ = rotary_encoding.forward(Tensor::<1>::zeros([4], &device));
+    }
+
+    #[test]
     fn test_rotary_encoding_forward() {
         let device = Default::default();
         let rotary_encoding = RotaryEncodingConfig::new(10, 4).init(&device);

--- a/crates/burn-nn/src/modules/transformer/pwff.rs
+++ b/crates/burn-nn/src/modules/transformer/pwff.rs
@@ -100,14 +100,14 @@ impl PositionWiseFeedForward {
     ///
     /// # Shapes
     ///
-    /// - tensor: `[batch_size, seq_length, d_model]`
+    /// - input: `[batch_size, seq_length, d_model]`
     /// - output: `[batch_size, seq_length, d_model]`
     ///
     /// # Panics
     ///
     /// Panics if the last axis of `input` is not `d_model`.
     pub fn forward<const D: usize>(&self, input: Tensor<D>) -> Tensor<D> {
-        let [d_model, _] = self.linear_inner.weight.val().dims();
+        let [d_model, _] = self.linear_inner.weight.shape().dims();
         assert_shape!(input, [.., d_model]);
 
         let x = self.linear_inner.forward(input);

--- a/crates/burn-nn/src/modules/transformer/pwff.rs
+++ b/crates/burn-nn/src/modules/transformer/pwff.rs
@@ -4,7 +4,7 @@ use crate::activation::{Activation, ActivationConfig};
 use crate::{Dropout, DropoutConfig, Linear, LinearConfig};
 use burn::config::Config;
 use burn::module::{Content, DisplaySettings, Initializer, Module, ModuleDisplay};
-use burn::tensor::{Device, Tensor};
+use burn::tensor::{Device, Tensor, assert_shape};
 
 /// Configuration to create a [position-wise feed-forward](PositionWiseFeedForward) layer using the [init function](PositionWiseFeedForwardConfig::init).
 #[derive(Config, Debug)]
@@ -102,7 +102,14 @@ impl PositionWiseFeedForward {
     ///
     /// - tensor: `[batch_size, seq_length, d_model]`
     /// - output: `[batch_size, seq_length, d_model]`
+    ///
+    /// # Panics
+    ///
+    /// Panics if the last axis of `input` is not `d_model`.
     pub fn forward<const D: usize>(&self, input: Tensor<D>) -> Tensor<D> {
+        let [d_model, _] = self.linear_inner.weight.val().dims();
+        assert_shape!(input, [.., d_model]);
+
         let x = self.linear_inner.forward(input);
         let x = self.activation.forward(x);
         let x = self.dropout.forward(x);
@@ -114,6 +121,14 @@ impl PositionWiseFeedForward {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    #[should_panic(expected = "assert_shape!(input, [.., d_model]): axis 2 expected 2, got 3")]
+    fn input_d_model_must_match() {
+        let device = Default::default();
+        let pwff = PositionWiseFeedForwardConfig::new(2, 4).init(&device);
+        let _ = pwff.forward(Tensor::<3>::zeros([1, 5, 3], &device));
+    }
 
     #[test]
     fn display() {

--- a/crates/burn-tensor/Cargo.toml
+++ b/crates/burn-tensor/Cargo.toml
@@ -76,6 +76,7 @@ template = ["burn-dispatch/template"]
 burn-std = { workspace = true }
 burn-backend = { workspace = true }
 burn-dispatch = { workspace = true }
+burn-derive = { workspace = true }
 
 colored = { workspace = true, optional = true }
 derive-new = { workspace = true }

--- a/crates/burn-tensor/src/lib.rs
+++ b/crates/burn-tensor/src/lib.rs
@@ -43,6 +43,43 @@ mod tensor;
 pub(crate) use tensor::check::macros::check;
 pub use tensor::*;
 
+// Shape assertion macros.
+pub use burn_derive::{assert_shape, debug_assert_shape, unpack_shape};
+
+/// Compile-time guarantees of the shape macros, checked as `compile_fail` doctests.
+///
+/// A pattern whose length differs from the tensor rank does not compile:
+///
+/// ```compile_fail
+/// use burn_tensor::{Tensor, assert_shape};
+/// let x = Tensor::<2>::zeros([2, 3], &Default::default());
+/// assert_shape!(x, [2, 3, 1]);
+/// ```
+///
+/// Neither does binding a name inside `assert_shape!` or `debug_assert_shape!`:
+///
+/// ```compile_fail
+/// use burn_tensor::{Tensor, assert_shape};
+/// let x = Tensor::<2>::zeros([2, 3], &Default::default());
+/// assert_shape!(x, [B, 3]);
+/// ```
+///
+/// ```compile_fail
+/// use burn_tensor::{Tensor, debug_assert_shape};
+/// let x = Tensor::<2>::zeros([2, 3], &Default::default());
+/// debug_assert_shape!(x, [B, 3]);
+/// ```
+///
+/// Nor does an `unpack_shape!` with nothing to bind:
+///
+/// ```compile_fail
+/// use burn_tensor::{Tensor, unpack_shape};
+/// let x = Tensor::<2>::zeros([2, 3], &Default::default());
+/// unpack_shape!(x, [2, 3]);
+/// ```
+#[cfg(doctest)]
+pub mod shape_macro_compile_fail {}
+
 // Re-exported types
 #[cfg(feature = "autodiff")]
 pub use burn_dispatch::GradientCheckpointingStrategy;

--- a/crates/burn-tensor/src/lib.rs
+++ b/crates/burn-tensor/src/lib.rs
@@ -43,42 +43,9 @@ mod tensor;
 pub(crate) use tensor::check::macros::check;
 pub use tensor::*;
 
-// Shape assertion macros.
-pub use burn_derive::{assert_shape, debug_assert_shape, unpack_shape};
-
-/// Compile-time guarantees of the shape macros, checked as `compile_fail` doctests.
-///
-/// A pattern whose length differs from the tensor rank does not compile:
-///
-/// ```compile_fail
-/// use burn_tensor::{Tensor, assert_shape};
-/// let x = Tensor::<2>::zeros([2, 3], &Default::default());
-/// assert_shape!(x, [2, 3, 1]);
-/// ```
-///
-/// Neither does binding a name inside `assert_shape!` or `debug_assert_shape!`:
-///
-/// ```compile_fail
-/// use burn_tensor::{Tensor, assert_shape};
-/// let x = Tensor::<2>::zeros([2, 3], &Default::default());
-/// assert_shape!(x, [B, 3]);
-/// ```
-///
-/// ```compile_fail
-/// use burn_tensor::{Tensor, debug_assert_shape};
-/// let x = Tensor::<2>::zeros([2, 3], &Default::default());
-/// debug_assert_shape!(x, [B, 3]);
-/// ```
-///
-/// Nor does an `unpack_shape!` with nothing to bind:
-///
-/// ```compile_fail
-/// use burn_tensor::{Tensor, unpack_shape};
-/// let x = Tensor::<2>::zeros([2, 3], &Default::default());
-/// unpack_shape!(x, [2, 3]);
-/// ```
-#[cfg(doctest)]
-pub mod shape_macro_compile_fail {}
+mod shape_macros;
+#[doc(hidden)]
+pub use burn_derive::{__assert_shape, __debug_assert_shape, __unpack_shape};
 
 // Re-exported types
 #[cfg(feature = "autodiff")]

--- a/crates/burn-tensor/src/lib.rs
+++ b/crates/burn-tensor/src/lib.rs
@@ -45,7 +45,7 @@ pub use tensor::*;
 
 mod shape_macros;
 #[doc(hidden)]
-pub use burn_derive::{__assert_shape, __debug_assert_shape, __unpack_shape};
+pub use burn_derive::{__assert_shape, __debug_assert_shape};
 
 // Re-exported types
 #[cfg(feature = "autodiff")]

--- a/crates/burn-tensor/src/shape_macros.rs
+++ b/crates/burn-tensor/src/shape_macros.rs
@@ -6,9 +6,9 @@
 
 /// Asserts a tensor's rank at compile time and its axis sizes at runtime.
 ///
-/// The pattern has one slot per axis: `=expr` checks the axis against an in-scope `usize`
-/// expression, an integer literal checks it against that value, and `_` skips it. To name axes,
-/// destructure `tensor.dims()` first and refer to the names with `=`.
+/// The pattern has one slot per axis. A slot is either `_`, which skips the axis, or any `usize`
+/// expression the axis must equal: a name from `dims()`, a config field, a literal. To name
+/// axes, destructure `tensor.dims()` first and use the names as slots.
 ///
 /// The pattern length must equal the tensor rank, otherwise the call does not compile. The
 /// tensor is borrowed, not moved, and every expression is evaluated once. Checks stay on in
@@ -24,7 +24,7 @@
 ///
 /// let [batch_size, seq_length, _] = x.dims();
 /// assert_shape!(x, [_, _, 256]);
-/// assert_shape!(mask, [=batch_size, =seq_length]);
+/// assert_shape!(mask, [batch_size, seq_length]);
 /// ```
 ///
 /// A mismatch panics with the call and the offending axis:
@@ -36,8 +36,7 @@
 /// assert_shape!(x, [2, 99]);
 /// ```
 ///
-/// A pattern whose length differs from the rank does not compile, and neither does a bare
-/// identifier:
+/// A pattern whose length differs from the rank does not compile:
 ///
 /// ```compile_fail,E0308
 /// use burn_tensor::{Tensor, assert_shape};
@@ -45,11 +44,12 @@
 /// assert_shape!(x, [2, 3, 1]);
 /// ```
 ///
-/// ```compile_fail
+/// Neither does a slot that is not a `usize`:
+///
+/// ```compile_fail,E0308
 /// use burn_tensor::{Tensor, assert_shape};
 /// let x = Tensor::<2>::zeros([2, 3], &Default::default());
-/// let batch_size = 2;
-/// assert_shape!(x, [batch_size, 3]);
+/// assert_shape!(x, [2i32, 3]);
 /// ```
 ///
 /// Only a `Tensor` is accepted. A `Shape` is a type error rather than a weaker check:
@@ -70,7 +70,7 @@ macro_rules! assert_shape {
 /// is on.
 ///
 /// The rank check is a type check and stays in every build. Like `debug_assert!`, neither the
-/// tensor expression nor the `=expr` slots are evaluated in release builds.
+/// tensor expression nor the slot expressions are evaluated in release builds.
 ///
 /// ```
 /// use burn_tensor::{Tensor, debug_assert_shape};
@@ -87,15 +87,6 @@ macro_rules! assert_shape {
 /// let x = Tensor::<2>::zeros([2, 3], &Default::default());
 /// debug_assert_shape!(x, [2, 99]);
 /// # if !cfg!(debug_assertions) { panic!("compiled out") }
-/// ```
-///
-/// A bare identifier does not compile:
-///
-/// ```compile_fail
-/// use burn_tensor::{Tensor, debug_assert_shape};
-/// let x = Tensor::<2>::zeros([2, 3], &Default::default());
-/// let batch_size = 2;
-/// debug_assert_shape!(x, [batch_size, 3]);
 /// ```
 #[macro_export]
 macro_rules! debug_assert_shape {

--- a/crates/burn-tensor/src/shape_macros.rs
+++ b/crates/burn-tensor/src/shape_macros.rs
@@ -1,0 +1,151 @@
+//! Shape assertion macros. Parsing and expansion live in burn-derive; these wrappers forward
+//! `$crate` so the expansion can name [`Tensor::dims`](crate::Tensor::dims) by path, which
+//! makes anything other than a `Tensor` a type error.
+//!
+//! Inspired by the `burn-contracts` crate by Crutcher Dunnavant.
+
+/// Returns tensor axis sizes by position while checking the rest of the shape.
+///
+/// The pattern has one slot per axis. A bare identifier labels an axis whose size is returned:
+/// the result is a tuple with one `usize` per label, in pattern order, and the label itself is
+/// not bound. `=expr` checks the axis against an in-scope `usize` expression, an integer
+/// literal checks it against that value, and `_` skips it.
+///
+/// The pattern length must equal the tensor rank, otherwise the call does not compile. The
+/// tensor is borrowed, not moved, and every expression is evaluated once. Axis checks stay on
+/// in release builds; a mismatch panics with the call, the axis, the expected and actual
+/// sizes, and the full dims.
+///
+/// ```
+/// use burn_tensor::{Tensor, unpack_shape};
+///
+/// let device = Default::default();
+/// let x = Tensor::<3>::zeros([2, 5, 80], &device);
+/// let mask = Tensor::<2>::zeros([2, 5], &device);
+///
+/// let (batch_size, seq_length) = unpack_shape!(x, [B, T, 80]);
+/// let (n,) = unpack_shape!(mask, [=batch_size, N]);
+/// assert_eq!((batch_size, seq_length, n), (2, 5, 5));
+/// ```
+///
+/// A pattern whose length differs from the rank does not compile:
+///
+/// ```compile_fail,E0308
+/// use burn_tensor::{Tensor, unpack_shape};
+/// let x = Tensor::<2>::zeros([2, 3], &Default::default());
+/// let (b,) = unpack_shape!(x, [B, 3, 1]);
+/// ```
+///
+/// Neither does a pattern with nothing to return; use [`assert_shape!`](crate::assert_shape)
+/// for that:
+///
+/// ```compile_fail
+/// use burn_tensor::{Tensor, unpack_shape};
+/// let x = Tensor::<2>::zeros([2, 3], &Default::default());
+/// unpack_shape!(x, [2, 3]);
+/// ```
+#[macro_export]
+macro_rules! unpack_shape {
+    ($($tt:tt)*) => {
+        $crate::__unpack_shape!($crate, $($tt)*)
+    };
+}
+
+/// Asserts a tensor's rank at compile time and its axis sizes at runtime.
+///
+/// The pattern has one slot per axis: `=expr` checks the axis against an in-scope `usize`
+/// expression, an integer literal checks it against that value, and `_` skips it. Bare
+/// identifiers are rejected; use [`unpack_shape!`](crate::unpack_shape) to get axis sizes
+/// back.
+///
+/// The pattern length must equal the tensor rank, otherwise the call does not compile. The
+/// tensor is borrowed, not moved, and every expression is evaluated once. Checks stay on in
+/// release builds; see [`debug_assert_shape!`](crate::debug_assert_shape) for the debug-only
+/// variant.
+///
+/// ```
+/// use burn_tensor::{Tensor, assert_shape};
+///
+/// let device = Default::default();
+/// let batch_size = 2;
+/// let y = Tensor::<3>::zeros([batch_size, 5, 256], &device);
+/// let mask = Tensor::<2>::zeros([batch_size, 5], &device);
+///
+/// assert_shape!(y, [=batch_size, _, 256]);
+/// assert_shape!(mask, [=batch_size, =y.dims()[1]]);
+/// ```
+///
+/// A mismatch panics with the call and the offending axis:
+///
+/// ```should_panic
+/// use burn_tensor::{Tensor, assert_shape};
+/// let x = Tensor::<2>::zeros([2, 3], &Default::default());
+/// // assert_shape!(x, [2, 99]): axis 1 expected 99, got 3 (dims [2, 3])
+/// assert_shape!(x, [2, 99]);
+/// ```
+///
+/// A pattern whose length differs from the rank does not compile, and neither does a bare
+/// identifier:
+///
+/// ```compile_fail,E0308
+/// use burn_tensor::{Tensor, assert_shape};
+/// let x = Tensor::<2>::zeros([2, 3], &Default::default());
+/// assert_shape!(x, [2, 3, 1]);
+/// ```
+///
+/// ```compile_fail
+/// use burn_tensor::{Tensor, assert_shape};
+/// let x = Tensor::<2>::zeros([2, 3], &Default::default());
+/// assert_shape!(x, [B, 3]);
+/// ```
+///
+/// Only a `Tensor` is accepted. A `Shape` is a type error rather than a weaker check:
+///
+/// ```compile_fail,E0308
+/// use burn_tensor::{Tensor, assert_shape};
+/// let x = Tensor::<3>::zeros([2, 3, 4], &Default::default());
+/// assert_shape!(x.shape(), [2, 3]);
+/// ```
+#[macro_export]
+macro_rules! assert_shape {
+    ($($tt:tt)*) => {
+        $crate::__assert_shape!($crate, $($tt)*)
+    };
+}
+
+/// Same as [`assert_shape!`](crate::assert_shape), but compiled out unless `debug_assertions`
+/// is on.
+///
+/// The rank check is a type check and stays in every build. Like `debug_assert!`, neither the
+/// tensor expression nor the `=expr` slots are evaluated in release builds.
+///
+/// ```
+/// use burn_tensor::{Tensor, debug_assert_shape};
+///
+/// let device = Default::default();
+/// let hidden = Tensor::<3>::zeros([2, 5, 256], &device);
+/// debug_assert_shape!(hidden, [2, _, 256]);
+/// ```
+///
+/// With debug assertions on, a mismatch panics like [`assert_shape!`](crate::assert_shape):
+///
+/// ```should_panic
+/// use burn_tensor::{Tensor, debug_assert_shape};
+/// let x = Tensor::<2>::zeros([2, 3], &Default::default());
+/// debug_assert_shape!(x, [2, 99]);
+/// # if !cfg!(debug_assertions) { panic!("compiled out") }
+/// ```
+///
+/// A bare identifier does not compile:
+///
+/// ```compile_fail
+/// use burn_tensor::{Tensor, debug_assert_shape};
+/// let x = Tensor::<2>::zeros([2, 3], &Default::default());
+/// debug_assert_shape!(x, [B, 3]);
+/// ```
+#[macro_export]
+macro_rules! debug_assert_shape {
+    ($($tt:tt)*) => {
+        $crate::__debug_assert_shape!($crate, $($tt)*)
+    };
+}

--- a/crates/burn-tensor/src/shape_macros.rs
+++ b/crates/burn-tensor/src/shape_macros.rs
@@ -4,7 +4,8 @@
 //!
 //! Inspired by the `burn-contracts` crate by Crutcher Dunnavant.
 
-/// Asserts a tensor's rank at compile time and its axis sizes at runtime.
+/// Asserts a tensor's rank, at compile time unless the pattern has `..`, and its axis sizes at
+/// runtime.
 ///
 /// The pattern has one slot per axis. A slot is either `_`, which skips the axis, or any `usize`
 /// expression the axis must equal: a name from `dims()`, a config field, a literal, arithmetic
@@ -12,10 +13,10 @@
 ///
 /// The pattern length must equal the tensor rank, otherwise the call does not compile. One
 /// slot may be `..`, which stands for any number of axes; the pattern then fixes only a
-/// minimum rank, checked at runtime, and fits a function generic over `const D: usize`. The
-/// tensor is borrowed, not moved, and every expression is evaluated once. Checks stay on in
-/// release builds; see [`debug_assert_shape!`](crate::debug_assert_shape) for the debug-only
-/// variant.
+/// minimum rank, checked at runtime, and fits a function generic over `const D: usize`. A
+/// pattern of just `[..]` checks nothing beyond the argument being a tensor. The tensor is
+/// borrowed, not moved, and every expression is evaluated once. Checks stay on in release
+/// builds; see [`debug_assert_shape!`](crate::debug_assert_shape) for the debug-only variant.
 ///
 /// ```
 /// use burn_tensor::{Tensor, assert_shape};
@@ -104,8 +105,10 @@ macro_rules! assert_shape {
 /// Same as [`assert_shape!`](crate::assert_shape), but compiled out unless `debug_assertions`
 /// is on.
 ///
-/// The rank check is a type check and stays in every build. Like `debug_assert!`, neither the
-/// tensor expression nor the slot expressions are evaluated in release builds.
+/// Without `..` the rank check is a type check and stays in every build; with `..` the
+/// minimum-rank check is a runtime assertion and is compiled out with the axis checks. Like
+/// `debug_assert!`, neither the tensor expression nor the slot expressions are evaluated in
+/// release builds.
 ///
 /// ```
 /// use burn_tensor::{Tensor, debug_assert_shape};

--- a/crates/burn-tensor/src/shape_macros.rs
+++ b/crates/burn-tensor/src/shape_macros.rs
@@ -4,59 +4,11 @@
 //!
 //! Inspired by the `burn-contracts` crate by Crutcher Dunnavant.
 
-/// Returns tensor axis sizes by position while checking the rest of the shape.
-///
-/// The pattern has one slot per axis. A bare identifier labels an axis whose size is returned:
-/// the result is a tuple with one `usize` per label, in pattern order, and the label itself is
-/// not bound. `=expr` checks the axis against an in-scope `usize` expression, an integer
-/// literal checks it against that value, and `_` skips it.
-///
-/// The pattern length must equal the tensor rank, otherwise the call does not compile. The
-/// tensor is borrowed, not moved, and every expression is evaluated once. Axis checks stay on
-/// in release builds; a mismatch panics with the call, the axis, the expected and actual
-/// sizes, and the full dims.
-///
-/// ```
-/// use burn_tensor::{Tensor, unpack_shape};
-///
-/// let device = Default::default();
-/// let x = Tensor::<3>::zeros([2, 5, 80], &device);
-/// let mask = Tensor::<2>::zeros([2, 5], &device);
-///
-/// let (batch_size, seq_length) = unpack_shape!(x, [B, T, 80]);
-/// let (n,) = unpack_shape!(mask, [=batch_size, N]);
-/// assert_eq!((batch_size, seq_length, n), (2, 5, 5));
-/// ```
-///
-/// A pattern whose length differs from the rank does not compile:
-///
-/// ```compile_fail,E0308
-/// use burn_tensor::{Tensor, unpack_shape};
-/// let x = Tensor::<2>::zeros([2, 3], &Default::default());
-/// let (b,) = unpack_shape!(x, [B, 3, 1]);
-/// ```
-///
-/// Neither does a pattern with nothing to return; use [`assert_shape!`](crate::assert_shape)
-/// for that:
-///
-/// ```compile_fail
-/// use burn_tensor::{Tensor, unpack_shape};
-/// let x = Tensor::<2>::zeros([2, 3], &Default::default());
-/// unpack_shape!(x, [2, 3]);
-/// ```
-#[macro_export]
-macro_rules! unpack_shape {
-    ($($tt:tt)*) => {
-        $crate::__unpack_shape!($crate, $($tt)*)
-    };
-}
-
 /// Asserts a tensor's rank at compile time and its axis sizes at runtime.
 ///
 /// The pattern has one slot per axis: `=expr` checks the axis against an in-scope `usize`
-/// expression, an integer literal checks it against that value, and `_` skips it. Bare
-/// identifiers are rejected; use [`unpack_shape!`](crate::unpack_shape) to get axis sizes
-/// back.
+/// expression, an integer literal checks it against that value, and `_` skips it. To name axes,
+/// destructure `tensor.dims()` first and refer to the names with `=`.
 ///
 /// The pattern length must equal the tensor rank, otherwise the call does not compile. The
 /// tensor is borrowed, not moved, and every expression is evaluated once. Checks stay on in
@@ -67,12 +19,12 @@ macro_rules! unpack_shape {
 /// use burn_tensor::{Tensor, assert_shape};
 ///
 /// let device = Default::default();
-/// let batch_size = 2;
-/// let y = Tensor::<3>::zeros([batch_size, 5, 256], &device);
-/// let mask = Tensor::<2>::zeros([batch_size, 5], &device);
+/// let x = Tensor::<3>::zeros([2, 5, 256], &device);
+/// let mask = Tensor::<2>::zeros([2, 5], &device);
 ///
-/// assert_shape!(y, [=batch_size, _, 256]);
-/// assert_shape!(mask, [=batch_size, =y.dims()[1]]);
+/// let [batch_size, seq_length, _] = x.dims();
+/// assert_shape!(x, [_, _, 256]);
+/// assert_shape!(mask, [=batch_size, =seq_length]);
 /// ```
 ///
 /// A mismatch panics with the call and the offending axis:
@@ -96,7 +48,8 @@ macro_rules! unpack_shape {
 /// ```compile_fail
 /// use burn_tensor::{Tensor, assert_shape};
 /// let x = Tensor::<2>::zeros([2, 3], &Default::default());
-/// assert_shape!(x, [B, 3]);
+/// let batch_size = 2;
+/// assert_shape!(x, [batch_size, 3]);
 /// ```
 ///
 /// Only a `Tensor` is accepted. A `Shape` is a type error rather than a weaker check:
@@ -141,7 +94,8 @@ macro_rules! assert_shape {
 /// ```compile_fail
 /// use burn_tensor::{Tensor, debug_assert_shape};
 /// let x = Tensor::<2>::zeros([2, 3], &Default::default());
-/// debug_assert_shape!(x, [B, 3]);
+/// let batch_size = 2;
+/// debug_assert_shape!(x, [batch_size, 3]);
 /// ```
 #[macro_export]
 macro_rules! debug_assert_shape {

--- a/crates/burn-tensor/src/shape_macros.rs
+++ b/crates/burn-tensor/src/shape_macros.rs
@@ -7,8 +7,8 @@
 /// Asserts a tensor's rank at compile time and its axis sizes at runtime.
 ///
 /// The pattern has one slot per axis. A slot is either `_`, which skips the axis, or any `usize`
-/// expression the axis must equal: a name from `dims()`, a config field, a literal. To name
-/// axes, destructure `tensor.dims()` first and use the names as slots.
+/// expression the axis must equal: a name from `dims()`, a config field, a literal, arithmetic
+/// on any of those. To name axes, destructure `tensor.dims()` first and use the names as slots.
 ///
 /// The pattern length must equal the tensor rank, otherwise the call does not compile. The
 /// tensor is borrowed, not moved, and every expression is evaluated once. Checks stay on in
@@ -21,10 +21,15 @@
 /// let device = Default::default();
 /// let x = Tensor::<3>::zeros([2, 5, 256], &device);
 /// let mask = Tensor::<2>::zeros([2, 5], &device);
+/// let patch = Tensor::<2>::zeros([6, 2], &device);
 ///
 /// let [batch_size, seq_length, _] = x.dims();
-/// assert_shape!(x, [_, _, 256]);
-/// assert_shape!(mask, [batch_size, seq_length]);
+/// let flat = x.clone().reshape([batch_size * seq_length, 256]);
+///
+/// assert_shape!(x, [batch_size, seq_length, 256]);     // names from dims() and a literal
+/// assert_shape!(flat, [batch_size * seq_length, 256]); // arithmetic on names
+/// assert_shape!(patch, [3 * 2, 2]);                    // arithmetic on literals
+/// assert_shape!(mask, [batch_size, _]);                // skip an axis
 /// ```
 ///
 /// A mismatch panics with the call and the offending axis:

--- a/crates/burn-tensor/src/shape_macros.rs
+++ b/crates/burn-tensor/src/shape_macros.rs
@@ -10,7 +10,9 @@
 /// expression the axis must equal: a name from `dims()`, a config field, a literal, arithmetic
 /// on any of those. To name axes, destructure `tensor.dims()` first and use the names as slots.
 ///
-/// The pattern length must equal the tensor rank, otherwise the call does not compile. The
+/// The pattern length must equal the tensor rank, otherwise the call does not compile. One
+/// slot may be `..`, which stands for any number of axes; the pattern then fixes only a
+/// minimum rank, checked at runtime, and fits a function generic over `const D: usize`. The
 /// tensor is borrowed, not moved, and every expression is evaluated once. Checks stay on in
 /// release builds; see [`debug_assert_shape!`](crate::debug_assert_shape) for the debug-only
 /// variant.
@@ -30,6 +32,20 @@
 /// assert_shape!(flat, [batch_size * seq_length, 256]); // arithmetic on names
 /// assert_shape!(patch, [3 * 2, 2]);                    // arithmetic on literals
 /// assert_shape!(mask, [batch_size, _]);                // skip an axis
+/// ```
+///
+/// With `..`, the same check works whatever the rank:
+///
+/// ```
+/// use burn_tensor::{Tensor, assert_shape};
+///
+/// fn check_features<const D: usize>(x: &Tensor<D>, d_model: usize) {
+///     assert_shape!(x, [.., d_model]);
+/// }
+///
+/// let device = Default::default();
+/// check_features(&Tensor::<2>::zeros([5, 256], &device), 256);
+/// check_features(&Tensor::<4>::zeros([2, 3, 5, 256], &device), 256);
 /// ```
 ///
 /// A mismatch panics with the call and the offending axis:
@@ -63,6 +79,14 @@
 /// use burn_tensor::{Tensor, assert_shape};
 /// let x = Tensor::<3>::zeros([2, 3, 4], &Default::default());
 /// assert_shape!(x.shape(), [2, 3]);
+/// ```
+///
+/// A pattern may contain `..` only once:
+///
+/// ```compile_fail
+/// use burn_tensor::{Tensor, assert_shape};
+/// let x = Tensor::<3>::zeros([2, 3, 4], &Default::default());
+/// assert_shape!(x, [.., 3, ..]);
 /// ```
 #[macro_export]
 macro_rules! assert_shape {

--- a/crates/burn-tensor/src/shape_macros.rs
+++ b/crates/burn-tensor/src/shape_macros.rs
@@ -43,9 +43,15 @@
 ///     assert_shape!(x, [.., d_model]);
 /// }
 ///
+/// fn check_channels<const D: usize>(x: &Tensor<D>, channels: usize) {
+///     assert_shape!(x, [_, channels, ..]);
+/// }
+///
 /// let device = Default::default();
 /// check_features(&Tensor::<2>::zeros([5, 256], &device), 256);
 /// check_features(&Tensor::<4>::zeros([2, 3, 5, 256], &device), 256);
+/// check_channels(&Tensor::<3>::zeros([2, 16, 100], &device), 16);
+/// check_channels(&Tensor::<5>::zeros([2, 16, 4, 8, 8], &device), 16);
 /// ```
 ///
 /// A mismatch panics with the call and the offending axis:

--- a/crates/burn-tensor/tests/shape_macros.rs
+++ b/crates/burn-tensor/tests/shape_macros.rs
@@ -99,7 +99,9 @@ fn unpack_scope_mismatch_panics() {
 }
 
 #[test]
-#[should_panic(expected = "axis 1 expected 128, got 6")]
+#[should_panic(
+    expected = "unpack_shape!(x, [B, =config.d_model]): axis 1 expected 128, got 6 (dims [2, 6])"
+)]
 fn unpack_expression_mismatch_panics() {
     let x = t([2, 6]);
     let config = Config { d_model: 128 };

--- a/crates/burn-tensor/tests/shape_macros.rs
+++ b/crates/burn-tensor/tests/shape_macros.rs
@@ -1,11 +1,12 @@
 //! Integration tests for `unpack_shape!`, `assert_shape!` and `debug_assert_shape!`.
 //!
-//! Rank mismatches and misuse of the slot kinds are compile errors, covered by the
-//! `compile_fail` doctests in `burn_tensor::shape_macro_compile_fail`. The tests here cover
-//! the runtime behavior: bindings, axis checks, panic messages, and the debug-only gating of
-//! `debug_assert_shape!`.
+//! Rank mismatches, non-tensor arguments and misuse of the slot kinds are compile errors,
+//! covered by the `compile_fail` doctests on the macros themselves. The tests here cover the
+//! runtime behavior: returned sizes, axis checks, panic messages, evaluation counts, hygiene,
+//! and the debug-only gating of `debug_assert_shape!`.
 
 use burn_tensor::{Int, Tensor, assert_shape, debug_assert_shape, unpack_shape};
+use core::cell::Cell;
 
 fn t<const D: usize>(shape: [usize; D]) -> Tensor<D> {
     Tensor::zeros(shape, &Default::default())
@@ -188,4 +189,54 @@ fn debug_assert_mismatch_panics_in_debug() {
 fn debug_assert_mismatch_compiles_out_in_release() {
     let x = t([2, 3]);
     debug_assert_shape!(x, [99, 99]);
+}
+
+#[test]
+fn debug_assert_evaluates_arguments_only_in_debug() {
+    let x = t([2, 3]);
+    let evals = Cell::new(0);
+    debug_assert_shape!(
+        {
+            evals.set(evals.get() + 1);
+            &x
+        },
+        [2, ={
+            evals.set(evals.get() + 1);
+            3
+        }]
+    );
+    assert_eq!(evals.get(), if cfg!(debug_assertions) { 2 } else { 0 });
+}
+
+// ---- grammar, evaluation, hygiene ----
+
+#[test]
+#[rustfmt::skip]
+fn accepts_trailing_comma() {
+    let x = t([2, 3]);
+    let (b, c) = unpack_shape!(x, [B, C,]);
+    assert_shape!(x, [2, 3,]);
+    assert_eq!((b, c), (2, 3));
+}
+
+#[test]
+fn check_expressions_evaluate_once() {
+    let x = t([2, 3]);
+    let evals = Cell::new(0);
+    assert_shape!(x, [2, ={
+        evals.set(evals.get() + 1);
+        3
+    }]);
+    assert_eq!(evals.get(), 1);
+}
+
+#[test]
+fn internals_do_not_shadow_caller_names() {
+    let x = t([2, 3]);
+    let __tensor = 2usize;
+    let __dims = 3usize;
+    let __expected = 3usize;
+    assert_shape!(x, [=__tensor, =__dims]);
+    let (b,) = unpack_shape!(x, [B, =__expected]);
+    assert_eq!(b, 2);
 }

--- a/crates/burn-tensor/tests/shape_macros.rs
+++ b/crates/burn-tensor/tests/shape_macros.rs
@@ -1,9 +1,9 @@
 //! Integration tests for `assert_shape!` and `debug_assert_shape!`.
 //!
-//! Rank mismatches, non-tensor arguments and non-`usize` slots are compile errors, covered by
-//! the `compile_fail` doctests on the macros themselves. The tests here cover the runtime
-//! behavior: axis checks, panic messages, evaluation counts, hygiene, and the debug-only gating
-//! of `debug_assert_shape!`.
+//! Rank mismatches against an exact pattern, non-tensor arguments and non-`usize` slots are
+//! compile errors, covered by the `compile_fail` doctests on the macros themselves. The tests
+//! here cover the runtime behavior: axis checks, panic messages, the `..` rest slot, evaluation
+//! counts, hygiene, and the debug-only gating of `debug_assert_shape!`.
 
 use burn_tensor::{Int, Tensor, assert_shape, debug_assert_shape};
 use core::cell::Cell;
@@ -153,6 +153,45 @@ fn rest_with_too_few_axes_panics() {
 }
 
 #[test]
+#[should_panic(
+    expected = "assert_shape!(x, [.., 99, _]): axis 2 expected 99, got 4 (dims [2, 3, 4, 5])"
+)]
+fn rest_suffix_slot_before_a_wildcard_reports_the_real_axis() {
+    let x = t([2, 3, 4, 5]);
+    assert_shape!(x, [.., 99, _]);
+}
+
+#[test]
+#[should_panic(expected = "assert_shape!(x, [99, .., 5]): axis 0 expected 99, got 2")]
+fn rest_prefix_mismatch_panics() {
+    let x = t([2, 3, 4, 5]);
+    assert_shape!(x, [99, .., 5]);
+}
+
+#[test]
+fn rest_may_match_zero_axes_between_prefix_and_suffix() {
+    let x = t([2, 3, 4, 5]);
+    assert_shape!(x, [2, 3, .., 4, 5]);
+}
+
+#[test]
+#[should_panic(
+    expected = "assert_shape!(x, [.., 2, 3]): expected rank at least 2, got 1 (dims [3])"
+)]
+fn rest_with_fewer_axes_than_the_suffix_panics() {
+    let x = t([3]);
+    assert_shape!(x, [.., 2, 3]);
+}
+
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "debug_assert_shape!(x, [.., 99]): axis 1 expected 99, got 3")]
+fn debug_assert_with_rest_panics_in_debug() {
+    let x = t([2, 3]);
+    debug_assert_shape!(x, [.., 99]);
+}
+
+#[test]
 #[cfg(not(debug_assertions))]
 fn debug_assert_with_rest_compiles_out_in_release() {
     let x = t([2, 3]);
@@ -231,6 +270,9 @@ fn internals_do_not_shadow_caller_names() {
     let __tensor = 2usize;
     let __dims = 3usize;
     let __expected = 3usize;
+    let __rank = 2usize;
+    let __axis = 3usize;
     assert_shape!(x, [__tensor, __dims]);
+    assert_shape!(x, [__rank, .., __axis]);
     debug_assert_shape!(x, [_, __expected]);
 }

--- a/crates/burn-tensor/tests/shape_macros.rs
+++ b/crates/burn-tensor/tests/shape_macros.rs
@@ -1,11 +1,11 @@
-//! Integration tests for `unpack_shape!`, `assert_shape!` and `debug_assert_shape!`.
+//! Integration tests for `assert_shape!` and `debug_assert_shape!`.
 //!
-//! Rank mismatches, non-tensor arguments and misuse of the slot kinds are compile errors,
-//! covered by the `compile_fail` doctests on the macros themselves. The tests here cover the
-//! runtime behavior: returned sizes, axis checks, panic messages, evaluation counts, hygiene,
-//! and the debug-only gating of `debug_assert_shape!`.
+//! Rank mismatches, non-tensor arguments and bare identifiers are compile errors, covered by
+//! the `compile_fail` doctests on the macros themselves. The tests here cover the runtime
+//! behavior: axis checks, panic messages, evaluation counts, hygiene, and the debug-only gating
+//! of `debug_assert_shape!`.
 
-use burn_tensor::{Int, Tensor, assert_shape, debug_assert_shape, unpack_shape};
+use burn_tensor::{Int, Tensor, assert_shape, debug_assert_shape};
 use core::cell::Cell;
 
 fn t<const D: usize>(shape: [usize; D]) -> Tensor<D> {
@@ -14,99 +14,6 @@ fn t<const D: usize>(shape: [usize; D]) -> Tensor<D> {
 
 struct Config {
     d_model: usize,
-}
-
-// ---- unpack_shape!: bindings ----
-
-#[test]
-fn unpack_all_fresh_returns_each_dim() {
-    let x = t([2, 3, 4]);
-    let (b, tlen, c) = unpack_shape!(x, [B, T, C]);
-    assert_eq!((b, tlen, c), (2, 3, 4));
-}
-
-#[test]
-fn unpack_single_fresh_is_a_one_element_tuple() {
-    let x = t([5]);
-    let (n,) = unpack_shape!(x, [N]);
-    assert_eq!(n, 5);
-}
-
-#[test]
-fn unpack_fresh_plus_literal() {
-    let x = t([2, 3, 80]);
-    let (b, tlen) = unpack_shape!(x, [B, T, 80]);
-    assert_eq!((b, tlen), (2, 3));
-}
-
-#[test]
-fn unpack_fresh_plus_scope_check() {
-    let x = t([2, 3, 4]);
-    let b = 2usize;
-    let c = 4usize;
-    let (tlen,) = unpack_shape!(x, [=b, T, =c]);
-    assert_eq!(tlen, 3);
-}
-
-#[test]
-fn unpack_check_accepts_expressions() {
-    let x = t([2, 6, 128]);
-    let config = Config { d_model: 128 };
-    let n = 3usize;
-    let (b,) = unpack_shape!(x, [B, =n * 2, =config.d_model]);
-    assert_eq!(b, 2);
-}
-
-#[test]
-fn unpack_wildcard_skips_axis() {
-    let x = t([2, 3, 4]);
-    let (b, c) = unpack_shape!(x, [B, _, C]);
-    assert_eq!((b, c), (2, 4));
-}
-
-#[test]
-fn unpack_does_not_move_the_tensor() {
-    let x = t([2, 3]);
-    let (b, _) = unpack_shape!(x, [B, T]);
-    let (b_again, _) = unpack_shape!(&x, [B, T]);
-    assert_eq!(b, b_again);
-    assert_eq!(x.dims(), [2, 3]);
-}
-
-#[test]
-fn unpack_works_on_int_tensors() {
-    let x: Tensor<2, Int> = Tensor::zeros([4, 7], &Default::default());
-    let (rows, cols) = unpack_shape!(x, [R, C]);
-    assert_eq!((rows, cols), (4, 7));
-}
-
-// ---- unpack_shape!: mismatch panics ----
-
-#[test]
-#[should_panic(
-    expected = "unpack_shape!(x, [B, T, 80]): axis 2 expected 80, got 4 (dims [2, 3, 4])"
-)]
-fn unpack_literal_mismatch_panics() {
-    let x = t([2, 3, 4]);
-    let _ = unpack_shape!(x, [B, T, 80]);
-}
-
-#[test]
-#[should_panic(expected = "unpack_shape!(x, [=b, T, C]): axis 0 expected 99, got 2")]
-fn unpack_scope_mismatch_panics() {
-    let x = t([2, 3, 4]);
-    let b = 99usize;
-    let _ = unpack_shape!(x, [=b, T, C]);
-}
-
-#[test]
-#[should_panic(
-    expected = "unpack_shape!(x, [B, =config.d_model]): axis 1 expected 128, got 6 (dims [2, 6])"
-)]
-fn unpack_expression_mismatch_panics() {
-    let x = t([2, 6]);
-    let config = Config { d_model: 128 };
-    let _ = unpack_shape!(x, [B, =config.d_model]);
 }
 
 // ---- assert_shape!: happy paths ----
@@ -120,24 +27,37 @@ fn assert_all_literals_match() {
 #[test]
 fn assert_all_scope_idents_match() {
     let x = t([2, 3, 4]);
-    let b = 2usize;
-    let tlen = 3usize;
-    let c = 4usize;
+    let [b, tlen, c] = x.dims();
     assert_shape!(x, [=b, =tlen, =c]);
 }
 
 #[test]
-fn assert_mixed_slots() {
-    let x = t([2, 3, 128]);
-    let b = 2usize;
+fn assert_check_accepts_expressions() {
+    let x = t([2, 6, 128]);
     let config = Config { d_model: 128 };
-    assert_shape!(x, [=b, _, =config.d_model]);
+    let n = 3usize;
+    assert_shape!(x, [2, =n * 2, =config.d_model]);
 }
 
 #[test]
-fn assert_only_wildcards_checks_rank() {
+fn assert_wildcard_skips_axis() {
+    let x = t([2, 3, 4]);
+    let b = 2usize;
+    assert_shape!(x, [=b, _, 4]);
+}
+
+#[test]
+fn assert_only_wildcards_compiles_to_a_rank_check() {
     let x = t([2, 3]);
     assert_shape!(x, [_, _]);
+}
+
+#[test]
+fn assert_does_not_move_the_tensor() {
+    let x = t([2, 3]);
+    assert_shape!(x, [2, 3]);
+    assert_shape!(&x, [2, 3]);
+    assert_eq!(x.dims(), [2, 3]);
 }
 
 #[test]
@@ -146,6 +66,12 @@ fn assert_from_a_reference() {
         assert_shape!(x, [2, 3]);
     }
     check(&t([2, 3]));
+}
+
+#[test]
+fn assert_works_on_int_tensors() {
+    let x: Tensor<2, Int> = Tensor::zeros([4, 7], &Default::default());
+    assert_shape!(x, [4, 7]);
 }
 
 // ---- assert_shape!: mismatch panics ----
@@ -165,6 +91,23 @@ fn assert_scope_mismatch_panics() {
     let x = t([2, 3, 4]);
     let bogus = 99usize;
     assert_shape!(x, [=bogus, 3, 4]);
+}
+
+#[test]
+#[should_panic(
+    expected = "assert_shape!(x, [_, =config.d_model]): axis 1 expected 128, got 6 (dims [2, 6])"
+)]
+fn assert_expression_mismatch_panics() {
+    let x = t([2, 6]);
+    let config = Config { d_model: 128 };
+    assert_shape!(x, [_, =config.d_model]);
+}
+
+#[test]
+#[should_panic(expected = "axis 0 expected 99, got 2")]
+fn assert_reports_the_first_failing_axis() {
+    let x = t([2, 3]);
+    assert_shape!(x, [99, 99]);
 }
 
 // ---- debug_assert_shape! ----
@@ -214,9 +157,8 @@ fn debug_assert_evaluates_arguments_only_in_debug() {
 #[rustfmt::skip]
 fn accepts_trailing_comma() {
     let x = t([2, 3]);
-    let (b, c) = unpack_shape!(x, [B, C,]);
     assert_shape!(x, [2, 3,]);
-    assert_eq!((b, c), (2, 3));
+    debug_assert_shape!(x, [2, _,]);
 }
 
 #[test]
@@ -237,6 +179,5 @@ fn internals_do_not_shadow_caller_names() {
     let __dims = 3usize;
     let __expected = 3usize;
     assert_shape!(x, [=__tensor, =__dims]);
-    let (b,) = unpack_shape!(x, [B, =__expected]);
-    assert_eq!(b, 2);
+    debug_assert_shape!(x, [_, =__expected]);
 }

--- a/crates/burn-tensor/tests/shape_macros.rs
+++ b/crates/burn-tensor/tests/shape_macros.rs
@@ -1,0 +1,189 @@
+//! Integration tests for `unpack_shape!`, `assert_shape!` and `debug_assert_shape!`.
+//!
+//! Rank mismatches and misuse of the slot kinds are compile errors, covered by the
+//! `compile_fail` doctests in `burn_tensor::shape_macro_compile_fail`. The tests here cover
+//! the runtime behavior: bindings, axis checks, panic messages, and the debug-only gating of
+//! `debug_assert_shape!`.
+
+use burn_tensor::{Int, Tensor, assert_shape, debug_assert_shape, unpack_shape};
+
+fn t<const D: usize>(shape: [usize; D]) -> Tensor<D> {
+    Tensor::zeros(shape, &Default::default())
+}
+
+struct Config {
+    d_model: usize,
+}
+
+// ---- unpack_shape!: bindings ----
+
+#[test]
+fn unpack_all_fresh_returns_each_dim() {
+    let x = t([2, 3, 4]);
+    let (b, tlen, c) = unpack_shape!(x, [B, T, C]);
+    assert_eq!((b, tlen, c), (2, 3, 4));
+}
+
+#[test]
+fn unpack_single_fresh_is_a_one_element_tuple() {
+    let x = t([5]);
+    let (n,) = unpack_shape!(x, [N]);
+    assert_eq!(n, 5);
+}
+
+#[test]
+fn unpack_fresh_plus_literal() {
+    let x = t([2, 3, 80]);
+    let (b, tlen) = unpack_shape!(x, [B, T, 80]);
+    assert_eq!((b, tlen), (2, 3));
+}
+
+#[test]
+fn unpack_fresh_plus_scope_check() {
+    let x = t([2, 3, 4]);
+    let b = 2usize;
+    let c = 4usize;
+    let (tlen,) = unpack_shape!(x, [=b, T, =c]);
+    assert_eq!(tlen, 3);
+}
+
+#[test]
+fn unpack_check_accepts_expressions() {
+    let x = t([2, 6, 128]);
+    let config = Config { d_model: 128 };
+    let n = 3usize;
+    let (b,) = unpack_shape!(x, [B, =n * 2, =config.d_model]);
+    assert_eq!(b, 2);
+}
+
+#[test]
+fn unpack_wildcard_skips_axis() {
+    let x = t([2, 3, 4]);
+    let (b, c) = unpack_shape!(x, [B, _, C]);
+    assert_eq!((b, c), (2, 4));
+}
+
+#[test]
+fn unpack_does_not_move_the_tensor() {
+    let x = t([2, 3]);
+    let (b, _) = unpack_shape!(x, [B, T]);
+    let (b_again, _) = unpack_shape!(&x, [B, T]);
+    assert_eq!(b, b_again);
+    assert_eq!(x.dims(), [2, 3]);
+}
+
+#[test]
+fn unpack_works_on_int_tensors() {
+    let x: Tensor<2, Int> = Tensor::zeros([4, 7], &Default::default());
+    let (rows, cols) = unpack_shape!(x, [R, C]);
+    assert_eq!((rows, cols), (4, 7));
+}
+
+// ---- unpack_shape!: mismatch panics ----
+
+#[test]
+#[should_panic(
+    expected = "unpack_shape!(x, [B, T, 80]): axis 2 expected 80, got 4 (dims [2, 3, 4])"
+)]
+fn unpack_literal_mismatch_panics() {
+    let x = t([2, 3, 4]);
+    let _ = unpack_shape!(x, [B, T, 80]);
+}
+
+#[test]
+#[should_panic(expected = "unpack_shape!(x, [=b, T, C]): axis 0 expected 99, got 2")]
+fn unpack_scope_mismatch_panics() {
+    let x = t([2, 3, 4]);
+    let b = 99usize;
+    let _ = unpack_shape!(x, [=b, T, C]);
+}
+
+#[test]
+#[should_panic(expected = "axis 1 expected 128, got 6")]
+fn unpack_expression_mismatch_panics() {
+    let x = t([2, 6]);
+    let config = Config { d_model: 128 };
+    let _ = unpack_shape!(x, [B, =config.d_model]);
+}
+
+// ---- assert_shape!: happy paths ----
+
+#[test]
+fn assert_all_literals_match() {
+    let x = t([2, 3, 80]);
+    assert_shape!(x, [2, 3, 80]);
+}
+
+#[test]
+fn assert_all_scope_idents_match() {
+    let x = t([2, 3, 4]);
+    let b = 2usize;
+    let tlen = 3usize;
+    let c = 4usize;
+    assert_shape!(x, [=b, =tlen, =c]);
+}
+
+#[test]
+fn assert_mixed_slots() {
+    let x = t([2, 3, 128]);
+    let b = 2usize;
+    let config = Config { d_model: 128 };
+    assert_shape!(x, [=b, _, =config.d_model]);
+}
+
+#[test]
+fn assert_only_wildcards_checks_rank() {
+    let x = t([2, 3]);
+    assert_shape!(x, [_, _]);
+}
+
+#[test]
+fn assert_from_a_reference() {
+    fn check(x: &Tensor<2>) {
+        assert_shape!(x, [2, 3]);
+    }
+    check(&t([2, 3]));
+}
+
+// ---- assert_shape!: mismatch panics ----
+
+#[test]
+#[should_panic(
+    expected = "assert_shape!(x, [2, 99, 4]): axis 1 expected 99, got 3 (dims [2, 3, 4])"
+)]
+fn assert_literal_mismatch_panics() {
+    let x = t([2, 3, 4]);
+    assert_shape!(x, [2, 99, 4]);
+}
+
+#[test]
+#[should_panic(expected = "assert_shape!(x, [=bogus, 3, 4]): axis 0 expected 99, got 2")]
+fn assert_scope_mismatch_panics() {
+    let x = t([2, 3, 4]);
+    let bogus = 99usize;
+    assert_shape!(x, [=bogus, 3, 4]);
+}
+
+// ---- debug_assert_shape! ----
+
+#[test]
+fn debug_assert_matching_shape_passes() {
+    let x = t([2, 3]);
+    let b = 2usize;
+    debug_assert_shape!(x, [=b, 3]);
+}
+
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "debug_assert_shape!(x, [2, 99]): axis 1 expected 99, got 3")]
+fn debug_assert_mismatch_panics_in_debug() {
+    let x = t([2, 3]);
+    debug_assert_shape!(x, [2, 99]);
+}
+
+#[test]
+#[cfg(not(debug_assertions))]
+fn debug_assert_mismatch_compiles_out_in_release() {
+    let x = t([2, 3]);
+    debug_assert_shape!(x, [99, 99]);
+}

--- a/crates/burn-tensor/tests/shape_macros.rs
+++ b/crates/burn-tensor/tests/shape_macros.rs
@@ -1,6 +1,6 @@
 //! Integration tests for `assert_shape!` and `debug_assert_shape!`.
 //!
-//! Rank mismatches, non-tensor arguments and bare identifiers are compile errors, covered by
+//! Rank mismatches, non-tensor arguments and non-`usize` slots are compile errors, covered by
 //! the `compile_fail` doctests on the macros themselves. The tests here cover the runtime
 //! behavior: axis checks, panic messages, evaluation counts, hygiene, and the debug-only gating
 //! of `debug_assert_shape!`.
@@ -25,25 +25,26 @@ fn assert_all_literals_match() {
 }
 
 #[test]
-fn assert_all_scope_idents_match() {
+fn assert_names_from_dims_match() {
     let x = t([2, 3, 4]);
+    let y = t([2, 3, 4]);
     let [b, tlen, c] = x.dims();
-    assert_shape!(x, [=b, =tlen, =c]);
+    assert_shape!(y, [b, tlen, c]);
 }
 
 #[test]
-fn assert_check_accepts_expressions() {
+fn assert_accepts_expressions() {
     let x = t([2, 6, 128]);
     let config = Config { d_model: 128 };
     let n = 3usize;
-    assert_shape!(x, [2, =n * 2, =config.d_model]);
+    assert_shape!(x, [2, n * 2, config.d_model]);
 }
 
 #[test]
 fn assert_wildcard_skips_axis() {
     let x = t([2, 3, 4]);
     let b = 2usize;
-    assert_shape!(x, [=b, _, 4]);
+    assert_shape!(x, [b, _, 4]);
 }
 
 #[test]
@@ -86,21 +87,21 @@ fn assert_literal_mismatch_panics() {
 }
 
 #[test]
-#[should_panic(expected = "assert_shape!(x, [=bogus, 3, 4]): axis 0 expected 99, got 2")]
-fn assert_scope_mismatch_panics() {
+#[should_panic(expected = "assert_shape!(x, [bogus, 3, 4]): axis 0 expected 99, got 2")]
+fn assert_name_mismatch_panics() {
     let x = t([2, 3, 4]);
     let bogus = 99usize;
-    assert_shape!(x, [=bogus, 3, 4]);
+    assert_shape!(x, [bogus, 3, 4]);
 }
 
 #[test]
 #[should_panic(
-    expected = "assert_shape!(x, [_, =config.d_model]): axis 1 expected 128, got 6 (dims [2, 6])"
+    expected = "assert_shape!(x, [_, config.d_model]): axis 1 expected 128, got 6 (dims [2, 6])"
 )]
 fn assert_expression_mismatch_panics() {
     let x = t([2, 6]);
     let config = Config { d_model: 128 };
-    assert_shape!(x, [_, =config.d_model]);
+    assert_shape!(x, [_, config.d_model]);
 }
 
 #[test]
@@ -116,7 +117,7 @@ fn assert_reports_the_first_failing_axis() {
 fn debug_assert_matching_shape_passes() {
     let x = t([2, 3]);
     let b = 2usize;
-    debug_assert_shape!(x, [=b, 3]);
+    debug_assert_shape!(x, [b, 3]);
 }
 
 #[test]
@@ -143,7 +144,7 @@ fn debug_assert_evaluates_arguments_only_in_debug() {
             evals.set(evals.get() + 1);
             &x
         },
-        [2, ={
+        [2, {
             evals.set(evals.get() + 1);
             3
         }]
@@ -162,13 +163,16 @@ fn accepts_trailing_comma() {
 }
 
 #[test]
-fn check_expressions_evaluate_once() {
+fn slot_expressions_evaluate_once() {
     let x = t([2, 3]);
     let evals = Cell::new(0);
-    assert_shape!(x, [2, ={
-        evals.set(evals.get() + 1);
-        3
-    }]);
+    assert_shape!(
+        x,
+        [2, {
+            evals.set(evals.get() + 1);
+            3
+        }]
+    );
     assert_eq!(evals.get(), 1);
 }
 
@@ -178,6 +182,6 @@ fn internals_do_not_shadow_caller_names() {
     let __tensor = 2usize;
     let __dims = 3usize;
     let __expected = 3usize;
-    assert_shape!(x, [=__tensor, =__dims]);
-    debug_assert_shape!(x, [_, =__expected]);
+    assert_shape!(x, [__tensor, __dims]);
+    debug_assert_shape!(x, [_, __expected]);
 }

--- a/crates/burn-tensor/tests/shape_macros.rs
+++ b/crates/burn-tensor/tests/shape_macros.rs
@@ -111,6 +111,55 @@ fn assert_reports_the_first_failing_axis() {
     assert_shape!(x, [99, 99]);
 }
 
+// ---- `..` rest slot ----
+
+fn check_last_axis<const D: usize>(x: &Tensor<D>, size: usize) {
+    assert_shape!(x, [.., size]);
+}
+
+#[test]
+fn rest_works_for_any_rank() {
+    check_last_axis(&t([4]), 4);
+    check_last_axis(&t([2, 4]), 4);
+    check_last_axis(&t([2, 3, 5, 4]), 4);
+}
+
+#[test]
+fn rest_in_every_position() {
+    let x = t([2, 3, 4, 5]);
+    assert_shape!(x, [2, ..]);
+    assert_shape!(x, [2, 3, .., 5]);
+    assert_shape!(x, [.., _, 5]);
+    assert_shape!(x, [..]);
+    assert_shape!(x, [2, 3, 4, 5, ..]);
+}
+
+#[test]
+#[should_panic(
+    expected = "assert_shape!(x, [.., _, 99]): axis 3 expected 99, got 5 (dims [2, 3, 4, 5])"
+)]
+fn rest_suffix_mismatch_reports_the_real_axis() {
+    let x = t([2, 3, 4, 5]);
+    assert_shape!(x, [.., _, 99]);
+}
+
+#[test]
+#[should_panic(
+    expected = "assert_shape!(x, [2, 3, .., 5]): expected rank at least 3, got 2 (dims [2, 3])"
+)]
+fn rest_with_too_few_axes_panics() {
+    let x = t([2, 3]);
+    assert_shape!(x, [2, 3, .., 5]);
+}
+
+#[test]
+#[cfg(not(debug_assertions))]
+fn debug_assert_with_rest_compiles_out_in_release() {
+    let x = t([2, 3]);
+    debug_assert_shape!(x, [.., 99]);
+    debug_assert_shape!(x, [1, 2, 3, ..]);
+}
+
 // ---- debug_assert_shape! ----
 
 #[test]

--- a/examples/mnist-inference-web/src/model.rs
+++ b/examples/mnist-inference-web/src/model.rs
@@ -47,7 +47,8 @@ impl Model {
     /// - input: `[batch_size, 28, 28]`
     /// - output: `[batch_size, 10]`
     pub fn forward(&self, input: Tensor<3>) -> Tensor<2> {
-        let (batch_size,) = unpack_shape!(input, [B, =IMAGE_SIZE, =IMAGE_SIZE]);
+        let [batch_size, _, _] = input.dims();
+        assert_shape!(input, [_, =IMAGE_SIZE, =IMAGE_SIZE]);
 
         let x = input
             .reshape([batch_size, 1, IMAGE_SIZE, IMAGE_SIZE])

--- a/examples/mnist-inference-web/src/model.rs
+++ b/examples/mnist-inference-web/src/model.rs
@@ -48,7 +48,7 @@ impl Model {
     /// - output: `[batch_size, 10]`
     pub fn forward(&self, input: Tensor<3>) -> Tensor<2> {
         let [batch_size, _, _] = input.dims();
-        assert_shape!(input, [_, =IMAGE_SIZE, =IMAGE_SIZE]);
+        assert_shape!(input, [_, IMAGE_SIZE, IMAGE_SIZE]);
 
         let x = input
             .reshape([batch_size, 1, IMAGE_SIZE, IMAGE_SIZE])

--- a/examples/mnist-inference-web/src/model.rs
+++ b/examples/mnist-inference-web/src/model.rs
@@ -18,6 +18,7 @@ pub struct Model {
 }
 
 const NUM_CLASSES: usize = 10;
+const IMAGE_SIZE: usize = 28;
 
 impl Model {
     pub fn new(device: &Device) -> Self {
@@ -46,9 +47,11 @@ impl Model {
     /// - input: `[batch_size, 28, 28]`
     /// - output: `[batch_size, 10]`
     pub fn forward(&self, input: Tensor<3>) -> Tensor<2> {
-        let (batch_size,) = unpack_shape!(input, [B, 28, 28]);
+        let (batch_size,) = unpack_shape!(input, [B, =IMAGE_SIZE, =IMAGE_SIZE]);
 
-        let x = input.reshape([batch_size, 1, 28, 28]).detach();
+        let x = input
+            .reshape([batch_size, 1, IMAGE_SIZE, IMAGE_SIZE])
+            .detach();
         let x = self.conv1.forward(x);
         let x = self.conv2.forward(x);
 

--- a/examples/mnist-inference-web/src/model.rs
+++ b/examples/mnist-inference-web/src/model.rs
@@ -41,10 +41,14 @@ impl Model {
         }
     }
 
+    /// # Shapes
+    ///
+    /// - input: `[batch_size, 28, 28]`
+    /// - output: `[batch_size, 10]`
     pub fn forward(&self, input: Tensor<3>) -> Tensor<2> {
-        let [batch_size, height, width] = input.dims();
+        let (batch_size,) = unpack_shape!(input, [B, 28, 28]);
 
-        let x = input.reshape([batch_size, 1, height, width]).detach();
+        let x = input.reshape([batch_size, 1, 28, 28]).detach();
         let x = self.conv1.forward(x);
         let x = self.conv2.forward(x);
 

--- a/examples/mnist/src/model.rs
+++ b/examples/mnist/src/model.rs
@@ -21,6 +21,7 @@ pub struct Model {
 }
 
 const NUM_CLASSES: usize = 10;
+const IMAGE_SIZE: usize = 28;
 
 impl Model {
     pub fn new(device: &Device) -> Self {
@@ -49,9 +50,11 @@ impl Model {
     /// - input: `[batch_size, 28, 28]`
     /// - output: `[batch_size, 10]`
     pub fn forward(&self, input: Tensor<3>) -> Tensor<2> {
-        let (batch_size,) = unpack_shape!(input, [B, 28, 28]);
+        let (batch_size,) = unpack_shape!(input, [B, =IMAGE_SIZE, =IMAGE_SIZE]);
 
-        let x = input.reshape([batch_size, 1, 28, 28]).detach();
+        let x = input
+            .reshape([batch_size, 1, IMAGE_SIZE, IMAGE_SIZE])
+            .detach();
         let x = self.conv1.forward(x);
         let x = self.conv2.forward(x);
 

--- a/examples/mnist/src/model.rs
+++ b/examples/mnist/src/model.rs
@@ -51,7 +51,7 @@ impl Model {
     /// - output: `[batch_size, 10]`
     pub fn forward(&self, input: Tensor<3>) -> Tensor<2> {
         let [batch_size, _, _] = input.dims();
-        assert_shape!(input, [_, =IMAGE_SIZE, =IMAGE_SIZE]);
+        assert_shape!(input, [_, IMAGE_SIZE, IMAGE_SIZE]);
 
         let x = input
             .reshape([batch_size, 1, IMAGE_SIZE, IMAGE_SIZE])

--- a/examples/mnist/src/model.rs
+++ b/examples/mnist/src/model.rs
@@ -50,7 +50,8 @@ impl Model {
     /// - input: `[batch_size, 28, 28]`
     /// - output: `[batch_size, 10]`
     pub fn forward(&self, input: Tensor<3>) -> Tensor<2> {
-        let (batch_size,) = unpack_shape!(input, [B, =IMAGE_SIZE, =IMAGE_SIZE]);
+        let [batch_size, _, _] = input.dims();
+        assert_shape!(input, [_, =IMAGE_SIZE, =IMAGE_SIZE]);
 
         let x = input
             .reshape([batch_size, 1, IMAGE_SIZE, IMAGE_SIZE])

--- a/examples/mnist/src/model.rs
+++ b/examples/mnist/src/model.rs
@@ -44,10 +44,14 @@ impl Model {
         }
     }
 
+    /// # Shapes
+    ///
+    /// - input: `[batch_size, 28, 28]`
+    /// - output: `[batch_size, 10]`
     pub fn forward(&self, input: Tensor<3>) -> Tensor<2> {
-        let [batch_size, height, width] = input.dims();
+        let (batch_size,) = unpack_shape!(input, [B, 28, 28]);
 
-        let x = input.reshape([batch_size, 1, height, width]).detach();
+        let x = input.reshape([batch_size, 1, 28, 28]).detach();
         let x = self.conv1.forward(x);
         let x = self.conv2.forward(x);
 

--- a/examples/remote-inference-web/src/model.rs
+++ b/examples/remote-inference-web/src/model.rs
@@ -47,7 +47,8 @@ impl Model {
     /// - input: `[batch_size, 28, 28]`
     /// - output: `[batch_size, 10]`
     pub fn forward(&self, input: Tensor<3>) -> Tensor<2> {
-        let (batch_size,) = unpack_shape!(input, [B, =IMAGE_SIZE, =IMAGE_SIZE]);
+        let [batch_size, _, _] = input.dims();
+        assert_shape!(input, [_, =IMAGE_SIZE, =IMAGE_SIZE]);
 
         let x = input
             .reshape([batch_size, 1, IMAGE_SIZE, IMAGE_SIZE])

--- a/examples/remote-inference-web/src/model.rs
+++ b/examples/remote-inference-web/src/model.rs
@@ -48,7 +48,7 @@ impl Model {
     /// - output: `[batch_size, 10]`
     pub fn forward(&self, input: Tensor<3>) -> Tensor<2> {
         let [batch_size, _, _] = input.dims();
-        assert_shape!(input, [_, =IMAGE_SIZE, =IMAGE_SIZE]);
+        assert_shape!(input, [_, IMAGE_SIZE, IMAGE_SIZE]);
 
         let x = input
             .reshape([batch_size, 1, IMAGE_SIZE, IMAGE_SIZE])

--- a/examples/remote-inference-web/src/model.rs
+++ b/examples/remote-inference-web/src/model.rs
@@ -18,6 +18,7 @@ pub struct Model {
 }
 
 const NUM_CLASSES: usize = 10;
+const IMAGE_SIZE: usize = 28;
 
 impl Model {
     pub fn new(device: &Device) -> Self {
@@ -46,9 +47,11 @@ impl Model {
     /// - input: `[batch_size, 28, 28]`
     /// - output: `[batch_size, 10]`
     pub fn forward(&self, input: Tensor<3>) -> Tensor<2> {
-        let (batch_size,) = unpack_shape!(input, [B, 28, 28]);
+        let (batch_size,) = unpack_shape!(input, [B, =IMAGE_SIZE, =IMAGE_SIZE]);
 
-        let x = input.reshape([batch_size, 1, 28, 28]).detach();
+        let x = input
+            .reshape([batch_size, 1, IMAGE_SIZE, IMAGE_SIZE])
+            .detach();
         let x = self.conv1.forward(x);
         let x = self.conv2.forward(x);
 

--- a/examples/remote-inference-web/src/model.rs
+++ b/examples/remote-inference-web/src/model.rs
@@ -41,10 +41,14 @@ impl Model {
         }
     }
 
+    /// # Shapes
+    ///
+    /// - input: `[batch_size, 28, 28]`
+    /// - output: `[batch_size, 10]`
     pub fn forward(&self, input: Tensor<3>) -> Tensor<2> {
-        let [batch_size, height, width] = input.dims();
+        let (batch_size,) = unpack_shape!(input, [B, 28, 28]);
 
-        let x = input.reshape([batch_size, 1, height, width]).detach();
+        let x = input.reshape([batch_size, 1, 28, 28]).detach();
         let x = self.conv1.forward(x);
         let x = self.conv2.forward(x);
 

--- a/examples/text-classification/src/model.rs
+++ b/examples/text-classification/src/model.rs
@@ -67,7 +67,9 @@ impl TextClassificationModel {
     // Defines forward pass for training
     pub fn forward(&self, item: TextClassificationTrainingBatch) -> ClassificationOutput {
         // Get batch and sequence length, and the device
-        let [batch_size, seq_length] = item.tokens.dims();
+        let (batch_size, seq_length) = unpack_shape!(item.tokens, [B, T]);
+        assert_shape!(item.mask_pad, [=batch_size, =seq_length]);
+        assert_shape!(item.labels, [=batch_size]);
         let device = &self.embedding_token.devices()[0];
 
         // Move tensors to the correct device
@@ -108,7 +110,8 @@ impl TextClassificationModel {
     /// Defines forward pass for inference
     pub fn infer(&self, item: TextClassificationInferenceBatch) -> Tensor<2> {
         // Get batch and sequence length, and the device
-        let [batch_size, seq_length] = item.tokens.dims();
+        let (batch_size, seq_length) = unpack_shape!(item.tokens, [B, T]);
+        assert_shape!(item.mask_pad, [=batch_size, =seq_length]);
         let device = &self.embedding_token.devices()[0];
 
         // Move tensors to the correct device

--- a/examples/text-classification/src/model.rs
+++ b/examples/text-classification/src/model.rs
@@ -67,7 +67,7 @@ impl TextClassificationModel {
     // Defines forward pass for training
     pub fn forward(&self, item: TextClassificationTrainingBatch) -> ClassificationOutput {
         // Get batch and sequence length, and the device
-        let (batch_size, seq_length) = unpack_shape!(item.tokens, [B, T]);
+        let [batch_size, seq_length] = item.tokens.dims();
         assert_shape!(item.mask_pad, [=batch_size, =seq_length]);
         assert_shape!(item.labels, [=batch_size]);
         let device = &self.embedding_token.devices()[0];
@@ -110,7 +110,7 @@ impl TextClassificationModel {
     /// Defines forward pass for inference
     pub fn infer(&self, item: TextClassificationInferenceBatch) -> Tensor<2> {
         // Get batch and sequence length, and the device
-        let (batch_size, seq_length) = unpack_shape!(item.tokens, [B, T]);
+        let [batch_size, seq_length] = item.tokens.dims();
         assert_shape!(item.mask_pad, [=batch_size, =seq_length]);
         let device = &self.embedding_token.devices()[0];
 

--- a/examples/text-classification/src/model.rs
+++ b/examples/text-classification/src/model.rs
@@ -68,8 +68,8 @@ impl TextClassificationModel {
     pub fn forward(&self, item: TextClassificationTrainingBatch) -> ClassificationOutput {
         // Get batch and sequence length, and the device
         let [batch_size, seq_length] = item.tokens.dims();
-        assert_shape!(item.mask_pad, [=batch_size, =seq_length]);
-        assert_shape!(item.labels, [=batch_size]);
+        assert_shape!(item.mask_pad, [batch_size, seq_length]);
+        assert_shape!(item.labels, [batch_size]);
         let device = &self.embedding_token.devices()[0];
 
         // Move tensors to the correct device
@@ -111,7 +111,7 @@ impl TextClassificationModel {
     pub fn infer(&self, item: TextClassificationInferenceBatch) -> Tensor<2> {
         // Get batch and sequence length, and the device
         let [batch_size, seq_length] = item.tokens.dims();
-        assert_shape!(item.mask_pad, [=batch_size, =seq_length]);
+        assert_shape!(item.mask_pad, [batch_size, seq_length]);
         let device = &self.embedding_token.devices()[0];
 
         // Move tensors to the correct device

--- a/examples/text-generation/src/model.rs
+++ b/examples/text-generation/src/model.rs
@@ -51,7 +51,9 @@ impl TextGenerationModelConfig {
 }
 impl TextGenerationModel {
     pub fn forward_training(&self, item: TrainingTextGenerationBatch) -> ClassificationOutput {
-        let [batch_size, seq_length] = item.tokens_inputs.dims();
+        let (batch_size, seq_length) = unpack_shape!(item.tokens_inputs, [B, T]);
+        assert_shape!(item.targets, [=batch_size, =seq_length]);
+        assert_shape!(item.mask_pad, [=batch_size, =seq_length]);
         let device = &self.devices()[0];
 
         let inputs = item.tokens_inputs.to_device(device);

--- a/examples/text-generation/src/model.rs
+++ b/examples/text-generation/src/model.rs
@@ -52,8 +52,8 @@ impl TextGenerationModelConfig {
 impl TextGenerationModel {
     pub fn forward_training(&self, item: TrainingTextGenerationBatch) -> ClassificationOutput {
         let [batch_size, seq_length] = item.tokens_inputs.dims();
-        assert_shape!(item.targets, [=batch_size, =seq_length]);
-        assert_shape!(item.mask_pad, [=batch_size, =seq_length]);
+        assert_shape!(item.targets, [batch_size, seq_length]);
+        assert_shape!(item.mask_pad, [batch_size, seq_length]);
         let device = &self.devices()[0];
 
         let inputs = item.tokens_inputs.to_device(device);

--- a/examples/text-generation/src/model.rs
+++ b/examples/text-generation/src/model.rs
@@ -51,7 +51,7 @@ impl TextGenerationModelConfig {
 }
 impl TextGenerationModel {
     pub fn forward_training(&self, item: TrainingTextGenerationBatch) -> ClassificationOutput {
-        let (batch_size, seq_length) = unpack_shape!(item.tokens_inputs, [B, T]);
+        let [batch_size, seq_length] = item.tokens_inputs.dims();
         assert_shape!(item.targets, [=batch_size, =seq_length]);
         assert_shape!(item.mask_pad, [=batch_size, =seq_length]);
         let device = &self.devices()[0];


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Inspired by [burn-contracts](https://github.com/crutcher/burn-contracts) by @crutcher. Validated in my own model code before porting.

### Changes

Adds `assert_shape!` and `debug_assert_shape!` to `burn-tensor` and the prelude. Each slot is a `usize` expression the axis must equal, `_`, or one `..` for any number of axes. Rank is checked at compile time through `let dims: [usize; N] = Tensor::dims(..)`, so a wrong rank or a non-tensor argument does not compile; with `..` it becomes a runtime minimum, which is what a method generic over `const D: usize` needs. `debug_assert_shape!` compiles out like `debug_assert!`.

```rust
let [batch_size, seq_length, _] = input.dims();
assert_shape!(input, [_, _, self.d_model]);              // field, `_` skips an axis
assert_shape!(mask, [batch_size, seq_length]);           // names from dims()
assert_shape!(flat, [batch_size * seq_length, 256]);     // any usize expression
assert_shape!(patch, [3 * 2, 2]);                        // literals
assert_shape!(hidden, [.., self.d_model]);               // any rank, works for Tensor<D>
assert_shape!(image, [_, self.num_channels, ..]);        // channels first, any spatial rank
// panics with: assert_shape!(mask, [batch_size, seq_length]): axis 1 expected 128, got 64 (dims [8, 64])
```

The macros are `macro_rules!` wrappers in `burn-tensor` over proc macros in `burn-derive`, which becomes a `burn-tensor` dependency (publish order updated). `burn-nn` losses, attention, positional and rotary encoding, the norm layers, `Linear` and the feed-forward block use them at their boundaries; multi-head attention now requires key and value to share the query's batch size, as documented. Generic-rank losses keep hand-written checks. Examples and the book (new Forward Contract section) follow.

### Testing

27 integration tests in debug and release, 9 doctests with 4 compile-fail cases, new `should_panic` tests in `burn-nn`, and `cargo run-checks`.

