### PR TITLE
feat(tensor): validate matmul batch broadcast in TensorCheck

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/float/ops/matmul.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/matmul.rs
@@ -466,26 +466,12 @@ fn float_should_panic_when_inner_dimensions_are_not_equal() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "Tensors are not broadcastable along batch dimension")]
 fn float_should_panic_when_batch_dimensions_are_not_broadcastable() {
     let device = Default::default();
-    // Inner dims match (2 == 2) but batch dims [4, 5] vs [2, 3] cannot broadcast.
-    let tensor_1 = TestTensor::<3>::from_data(
-        [
-            [[1.0, 7.0], [2.0, 3.0], [1.0, 5.0], [2.0, 8.0], [3.0, 4.0]],
-            [[1.0, 7.0], [2.0, 3.0], [1.0, 5.0], [2.0, 8.0], [3.0, 4.0]],
-            [[1.0, 7.0], [2.0, 3.0], [1.0, 5.0], [2.0, 8.0], [3.0, 4.0]],
-            [[1.0, 7.0], [2.0, 3.0], [1.0, 5.0], [2.0, 8.0], [3.0, 4.0]],
-        ],
-        &device,
-    );
-    let tensor_2 = TestTensor::<3>::from_data(
-        [
-            [[4.0, 7.0], [2.0, 3.0], [1.0, 5.0]],
-            [[4.0, 7.0], [2.0, 3.0], [1.0, 5.0]],
-        ],
-        &device,
-    );
+    // Inner dims match (3 == 3) but batch dims [4] vs [2] cannot broadcast.
+    let tensor_1 = TestTensor::<3>::zeros([4, 5, 3], &device);
+    let tensor_2 = TestTensor::<3>::zeros([2, 3, 7], &device);
 
     let tensor_3 = tensor_1.matmul(tensor_2);
     tensor_3.into_data();

--- a/crates/burn-backend-tests/tests/tensor/float/ops/matmul.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/matmul.rs
@@ -464,3 +464,29 @@ fn float_should_panic_when_inner_dimensions_are_not_equal() {
 
     tensor_3.into_data().assert_eq(&expected, false);
 }
+
+#[test]
+#[should_panic]
+fn float_should_panic_when_batch_dimensions_are_not_broadcastable() {
+    let device = Default::default();
+    // Inner dims match (2 == 2) but batch dims [4, 5] vs [2, 3] cannot broadcast.
+    let tensor_1 = TestTensor::<3>::from_data(
+        [
+            [[1.0, 7.0], [2.0, 3.0], [1.0, 5.0], [2.0, 8.0], [3.0, 4.0]],
+            [[1.0, 7.0], [2.0, 3.0], [1.0, 5.0], [2.0, 8.0], [3.0, 4.0]],
+            [[1.0, 7.0], [2.0, 3.0], [1.0, 5.0], [2.0, 8.0], [3.0, 4.0]],
+            [[1.0, 7.0], [2.0, 3.0], [1.0, 5.0], [2.0, 8.0], [3.0, 4.0]],
+        ],
+        &device,
+    );
+    let tensor_2 = TestTensor::<3>::from_data(
+        [
+            [[4.0, 7.0], [2.0, 3.0], [1.0, 5.0]],
+            [[4.0, 7.0], [2.0, 3.0], [1.0, 5.0]],
+        ],
+        &device,
+    );
+
+    let tensor_3 = tensor_1.matmul(tensor_2);
+    tensor_3.into_data();
+}

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -500,6 +500,26 @@ impl TensorCheck {
             );
         }
 
+        // Check batch dimension broadcast compatibility. The last two dimensions
+        // are the matrix dimensions (validated above), the remaining leading
+        // dimensions are the batch dimensions and must be broadcast-compatible.
+        for i in 0..D - 2 {
+            let l = shape_lhs[i];
+            let r = shape_rhs[i];
+            if l != r && l != 1 && r != 1 {
+                check = check.register(
+                    "Matmul",
+                    TensorError::new(format!(
+                        "Tensors are not broadcastable along batch dimension {i}: {l} and {r}."
+                    ))
+                    .details(format!(
+                        "Lhs shape {:?}, rhs shape {:?}.",
+                        shape_lhs, shape_rhs
+                    )),
+                );
+            }
+        }
+
         check
     }
 


### PR DESCRIPTION
## Summary

Follow-up to the closed #5542, addressing the review feedback from #199.

Instead of improving error messages only on the (now deprecated) ndarray backend, this moves the matmul **batch-dimension broadcast** validation into `TensorCheck`, the public tensor API check layer that runs *before* backend dispatch. Every backend (including ndarray) benefits from consistent errors.

## Current gap

`TensorCheck::matmul` only validated:
- device equality, and
- the inner dimension (`lhs[..., K] @ rhs[..., K]`).

An incompatible batch dimension (neither equal nor `1`) was **not** caught at the tensor API layer, so it fell through to backend-specific panics with inconsistent messages.

## Change

In `TensorCheck::matmul`, add a broadcastability loop over the leading `D - 2` batch dimensions, mirroring the existing `cross()` check. On failure it produces a proper `Tensor Operation Error`:

```
Operation: 'Matmul'
  Reason:
    1. Tensors are not broadcastable along batch dimension 0: 4 and 2.
       Lhs shape [4, 5, 3], rhs shape [2, 3, 7].
```

## Testing

- `cargo test -p burn-backend-tests --features ndarray --test tensor` — 1794 passed, 0 failed
- Added regression test `float_should_panic_when_batch_dimensions_are_not_broadcastable` in `burn-backend-tests/tests/tensor/float/ops/matmul.rs`
- Existing broadcast-success cases (`test_float_matmul_broadcast_1`, `test_float_matmul_broadcast_4d`, etc.) still pass, confirming valid broadcasts are unaffected

Ref: #199