### PR TITLE
feat(tensor): replace `no_grad` with explicit autodiff conversions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4328,7 +4328,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.19",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]

--- a/burn-book/src/building-blocks/autodiff.md
+++ b/burn-book/src/building-blocks/autodiff.md
@@ -54,12 +54,13 @@ torch.no_grad():
 ```
 
 With Burn, tensors shouldn't be on an autodiff device for inference, and you can call
-`inner()` to obtain the inner tensor, which is useful for validation.
+`without_autodiff()` to obtain a tensor without autodiff, which is useful for validation. The
+historical `inner()` method is equivalent.
 
 ```rust, ignore
 fn example_validation(tensor: Tensor<2>) {
     debug_assert!(tensor.device().is_autodiff());
-    let inner_tensor = tensor.inner();
+    let inner_tensor = tensor.without_autodiff();
     let _ = inner_tensor + 5;
 }
 

--- a/crates/burn-core/src/module/param/constant.rs
+++ b/crates/burn-core/src/module/param/constant.rs
@@ -135,7 +135,7 @@ impl<const D: usize, K: Basic> ModuleDisplay for Tensor<D, K> {}
 
 impl<const D: usize, K: Autodiff> AutodiffModule for Tensor<D, K> {
     fn valid(&self) -> Self {
-        self.clone().no_grad()
+        self.clone().without_autodiff()
     }
 
     fn from_inner(tensor: Self) -> Self {

--- a/crates/burn-core/src/module/param/running.rs
+++ b/crates/burn-core/src/module/param/running.rs
@@ -217,7 +217,7 @@ impl<const D: usize> AutodiffModule for RunningState<Tensor<D>> {
         self.sync();
         let value = self.value();
 
-        RunningState::with_id(self.id, value.no_grad())
+        RunningState::with_id(self.id, value.without_autodiff())
     }
 
     fn from_inner(module: Self) -> Self {

--- a/crates/burn-core/src/module/param/tensor.rs
+++ b/crates/burn-core/src/module/param/tensor.rs
@@ -347,7 +347,7 @@ impl<const D: usize> AutodiffModule for Param<Tensor<D>> {
         let is_active = self.is_active;
         let mut param = Param::from_mapped_value(
             self.id,
-            self.val().no_grad().set_require_grad(false),
+            self.val().without_autodiff().set_require_grad(false),
             self.param_mapper.clone(),
         );
         param.is_active = is_active;
@@ -373,7 +373,11 @@ impl<const D: usize> AutodiffModule for Param<Tensor<D>> {
 
 impl<const D: usize> AutodiffModule for Param<Tensor<D, Int>> {
     fn valid(&self) -> Self {
-        Param::from_mapped_value(self.id, self.val().no_grad(), self.param_mapper.clone())
+        Param::from_mapped_value(
+            self.id,
+            self.val().without_autodiff(),
+            self.param_mapper.clone(),
+        )
     }
 
     fn from_inner(module: Self) -> Self {
@@ -387,7 +391,11 @@ impl<const D: usize> AutodiffModule for Param<Tensor<D, Int>> {
 
 impl<const D: usize> AutodiffModule for Param<Tensor<D, Bool>> {
     fn valid(&self) -> Self {
-        Param::from_mapped_value(self.id, self.val().no_grad(), self.param_mapper.clone())
+        Param::from_mapped_value(
+            self.id,
+            self.val().without_autodiff(),
+            self.param_mapper.clone(),
+        )
     }
 
     fn from_inner(module: Self) -> Self {

--- a/crates/burn-tensor/src/bridge/ops/autodiff.rs
+++ b/crates/burn-tensor/src/bridge/ops/autodiff.rs
@@ -14,8 +14,8 @@ pub(crate) trait BasicAutodiffOps: BasicOps {
     /// with static dispatch. It is not designed for direct usage by users, and not recommended to import
     /// or use this function directly.
     ///
-    /// Users should prefer the [`Tensor::inner`](crate::Tensor::inner)
-    /// function, which is more high-level and designed for public use.
+    /// Users should prefer [`Tensor::without_autodiff`](crate::Tensor::without_autodiff), or its
+    /// [`Tensor::inner`](crate::Tensor::inner) equivalent, which are designed for public use.
     fn inner(tensor: BridgeTensor) -> BridgeTensor;
 
     /// Convert a tensor to the autodiff backend.
@@ -26,7 +26,8 @@ pub(crate) trait BasicAutodiffOps: BasicOps {
     /// with static dispatch. It is not designed for direct usage by users, and not recommended to import
     /// or use this function directly.
     ///
-    /// Users should prefer the [`Tensor::from_inner`](crate::Tensor::from_inner)
-    /// function, which is more high-level and designed for public use.
+    /// Users should prefer [`Tensor::autodiff`](crate::Tensor::autodiff), or its
+    /// [`Tensor::from_inner`](crate::Tensor::from_inner) equivalent, which are designed for public
+    /// use.
     fn from_inner(inner: BridgeTensor) -> BridgeTensor;
 }

--- a/crates/burn-tensor/src/tensor/api/autodiff.rs
+++ b/crates/burn-tensor/src/tensor/api/autodiff.rs
@@ -98,41 +98,69 @@ fn grad_replace_impl(p: &BridgeTensor, grads: &mut Gradients, grad: BridgeTensor
 }
 
 impl<const D: usize, K: Autodiff> Tensor<D, K> {
-    /// Returns the inner tensor without the autodiff information.
+    /// Returns this tensor without its autodiff association.
+    ///
+    /// If the tensor uses autodiff, this moves it to the inner backend and drops any graph
+    /// reference it carries. If autodiff is already disabled, the tensor is returned unchanged.
+    /// This operation is idempotent.
+    ///
+    /// This is equivalent to [`without_autodiff`](Tensor::without_autodiff). `inner` reflects the
+    /// underlying backend-decorator model, while `without_autodiff` describes the operation in
+    /// terms of the high-level tensor API.
     pub fn inner(self) -> Tensor<D, K> {
-        Tensor::new(K::inner(self.primitive))
+        self.without_autodiff()
     }
 
-    /// Take the tensor off the autodiff backend, dropping any graph reference
-    /// it carries. A tensor that is not on an autodiff backend is returned as
-    /// is.
+    /// Returns this tensor without its autodiff association.
     ///
-    /// Unlike [detach](Tensor::detach), which severs the tensor from the graph
-    /// but leaves it on the autodiff backend, the result lives on the inner
-    /// backend: later operations pay no autodiff dispatch and can never be
-    /// recorded. And unlike [inner](Self::inner), which panics on a tensor
-    /// with no autodiff wrapper, this is safe to call anywhere — batchers,
-    /// metric pipelines, anything that must guarantee a tensor is off the
-    /// tape without knowing where it came from.
-    pub fn no_grad(self) -> Self {
+    /// If the tensor uses autodiff, this moves it to the inner backend and drops any graph
+    /// reference it carries. If autodiff is already disabled, the tensor is returned unchanged.
+    /// This operation is idempotent.
+    ///
+    /// Unlike [`detach`](Tensor::detach), which severs the tensor from its current graph but keeps
+    /// its autodiff association, the returned tensor pays no autodiff dispatch for subsequent
+    /// operations involving only tensors without autodiff. When combined with a tensor that still
+    /// uses autodiff, it is treated as a constant for that operation.
+    pub fn without_autodiff(self) -> Self {
         if self.device().is_autodiff() {
-            self.inner()
+            Tensor::new(K::inner(self.primitive))
         } else {
             self
         }
     }
 
-    /// Convert a tensor to the autodiff backend.
+    /// Returns this tensor with autodiff enabled.
     ///
-    /// # Arguments
+    /// If autodiff is disabled, this associates the tensor with the autodiff backend using the
+    /// default gradient-checkpointing strategy. If autodiff is already enabled, the tensor and its
+    /// current strategy are returned unchanged. This operation is idempotent.
     ///
-    /// * `inner` - The tensor to convert.
+    /// Enabling autodiff does not make a floating-point tensor require gradients. Use
+    /// [`require_grad`](Tensor::require_grad) when its gradient should be retained during the
+    /// backward pass.
+    pub fn autodiff(self) -> Self {
+        if self.device().is_autodiff() {
+            self
+        } else {
+            Self::new(K::from_inner(self.primitive))
+        }
+    }
+
+    /// Returns the provided tensor with autodiff enabled.
     ///
-    /// # Returns
+    /// If the tensor does not yet use autodiff, this associates it with the autodiff backend using
+    /// the default gradient-checkpointing strategy. If autodiff is already enabled, the tensor and
+    /// its current strategy are returned unchanged. This operation is idempotent.
     ///
-    /// The tensor converted to the autodiff backend.
+    /// This is equivalent to [`autodiff`](Tensor::autodiff). `from_inner` reflects the underlying
+    /// backend-decorator model, while `autodiff` describes the operation in terms of the high-level
+    /// tensor API.
+    ///
+    /// Enabling autodiff does not make a floating-point tensor require gradients. Use
+    /// [`require_grad`](Tensor::require_grad) when its gradient should be retained during the
+    /// backward pass.
     pub fn from_inner(inner: Tensor<D, K>) -> Self {
-        Self::new(K::from_inner(inner.primitive))
+        inner.autodiff()
     }
 
     /// Sets the autodiff checkpointing strategy carried by this tensor.
@@ -165,6 +193,3 @@ impl<const D: usize, K: Autodiff> Tensor<D, K> {
         })
     }
 }
-
-// TODO: a lot of the `tensor.inner` / `Tensor::from_inner(...)` are actually scoped to perform some operations
-// so it might be cleaner and easier to manage the device etc. if we provide a method to scope the autodiff?

--- a/crates/burn-train/src/learner/classification.rs
+++ b/crates/burn-train/src/learner/classification.rs
@@ -38,9 +38,9 @@ impl ItemLazy for ClassificationOutput {
         self.loss.device().flush();
 
         ClassificationOutput {
-            output: self.output.no_grad(),
-            loss: self.loss.no_grad(),
-            targets: self.targets.no_grad(),
+            output: self.output.without_autodiff(),
+            loss: self.loss.without_autodiff(),
+            targets: self.targets.without_autodiff(),
         }
     }
 }
@@ -113,9 +113,9 @@ impl ItemLazy for MultiLabelClassificationOutput {
         self.loss.device().flush();
 
         MultiLabelClassificationOutput {
-            output: self.output.no_grad(),
-            loss: self.loss.no_grad(),
-            targets: self.targets.no_grad(),
+            output: self.output.without_autodiff(),
+            loss: self.loss.without_autodiff(),
+            targets: self.targets.without_autodiff(),
         }
     }
 }

--- a/crates/burn-train/src/learner/regression.rs
+++ b/crates/burn-train/src/learner/regression.rs
@@ -32,9 +32,9 @@ impl ItemLazy for RegressionOutput {
         self.loss.device().flush();
 
         RegressionOutput {
-            output: self.output.no_grad(),
-            loss: self.loss.no_grad(),
-            targets: self.targets.no_grad(),
+            output: self.output.without_autodiff(),
+            loss: self.loss.without_autodiff(),
+            targets: self.targets.without_autodiff(),
         }
     }
 }

--- a/crates/burn-train/src/learner/sequence.rs
+++ b/crates/burn-train/src/learner/sequence.rs
@@ -60,10 +60,10 @@ impl ItemLazy for SequenceOutput {
         self.loss.device().flush();
 
         SequenceOutput {
-            logits: self.logits.no_grad(),
-            loss: self.loss.no_grad(),
-            targets: self.targets.no_grad(),
-            predictions: self.predictions.map(|tensor| tensor.no_grad()),
+            logits: self.logits.without_autodiff(),
+            loss: self.loss.without_autodiff(),
+            targets: self.targets.without_autodiff(),
+            predictions: self.predictions.map(|tensor| tensor.without_autodiff()),
         }
     }
 }

--- a/crates/burn/tests/autodiff_context.rs
+++ b/crates/burn/tests/autodiff_context.rs
@@ -2,7 +2,7 @@
 
 #![cfg(all(feature = "autodiff", feature = "flex"))]
 
-use burn::tensor::{Device, Tensor, TensorData};
+use burn::tensor::{Device, GradientCheckpointingStrategy, Tensor, TensorData};
 
 #[test]
 fn gradient_flows_to_enabled_operand_but_not_disabled_constant() {
@@ -22,4 +22,39 @@ fn gradient_flows_to_enabled_operand_but_not_disabled_constant() {
     // the graph, and remains unavailable as a gradient target.
     assert!(!constant.device().is_autodiff());
     assert!(!constant.is_require_grad());
+}
+
+#[test]
+fn tensor_autodiff_conversions_are_idempotent() {
+    let plain = Tensor::<1>::from_floats([1.0, 2.0], &Device::flex());
+
+    let plain = plain.without_autodiff().inner();
+    assert!(!plain.device().is_autodiff());
+
+    let autodiff = plain.autodiff();
+    assert!(autodiff.device().is_autodiff());
+
+    let autodiff = Tensor::from_inner(autodiff);
+    assert!(autodiff.device().is_autodiff());
+
+    let plain = autodiff.without_autodiff().inner();
+    assert!(!plain.device().is_autodiff());
+}
+
+#[test]
+fn enabling_autodiff_twice_preserves_checkpointing_strategy() {
+    let device = Device::flex().autodiff().gradient_checkpointing();
+    let tensor = Tensor::<1>::from_floats([1.0, 2.0], &device);
+
+    let tensor = tensor.autodiff();
+    assert_eq!(
+        tensor.device().gradient_checkpointing_strategy(),
+        GradientCheckpointingStrategy::Balanced
+    );
+
+    let tensor = Tensor::from_inner(tensor);
+    assert_eq!(
+        tensor.device().gradient_checkpointing_strategy(),
+        GradientCheckpointingStrategy::Balanced
+    );
 }


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo run-checks` has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

> `cargo run-checks` tests with `Flex` by default. Use `cargo run-checks --backend <backend>` when
> targeting another backend. Consider running additional tests relevant to the crates changed.

### Related Issues/PRs

Following #5537

### Changes

`Tensor::no_grad()` and `Module::no_grad()` had different semantics despite sharing a name. The module method persistently disables `require_grad` for its parameters, while the tensor method removed the tensor's autodiff association entirely.

- Renamed `Tensor::no_grad` -> `Tensor::without_autodiff`
- Added `Tensor::autodiff` as its counterpart to change a tensor's autodiff context
- `Tensor::inner` and `Tensor::from_inner` are now aliases, preserved mostly for historical reasons
