### PR TITLE
Fix invalid path filter regex handling

### DIFF
--- a/crates/burn-store/src/burnpack.rs
+++ b/crates/burn-store/src/burnpack.rs
@@ -259,6 +259,10 @@ impl BurnpackStore {
     }
 
     /// Add regex pattern to filter
+    ///
+    /// # Panics
+    ///
+    /// Panics if `pattern` is not a valid regular expression.
     #[cfg(feature = "std")]
     pub fn with_regex(mut self, pattern: &str) -> Self {
         let filter = self.filter.unwrap_or_default();

--- a/crates/burn-store/src/filter.rs
+++ b/crates/burn-store/src/filter.rs
@@ -63,16 +63,22 @@ impl PathFilter {
     }
 
     /// Add a regex pattern for matching paths
+    ///
+    /// # Panics
+    ///
+    /// Panics if `pattern` is not a valid regular expression.
     #[cfg(feature = "std")]
     pub fn with_regex<S: AsRef<str>>(mut self, pattern: S) -> Self {
-        if let Ok(regex) = Regex::new(pattern.as_ref()) {
-            self.regex_patterns.push(regex);
-        }
-        // TODO: Consider returning Result to handle regex compilation errors
+        let regex = Regex::new(pattern.as_ref()).expect("Invalid regex pattern");
+        self.regex_patterns.push(regex);
         self
     }
 
     /// Add multiple regex patterns
+    ///
+    /// # Panics
+    ///
+    /// Panics if any pattern is not a valid regular expression.
     #[cfg(feature = "std")]
     pub fn with_regexes<I, S>(mut self, patterns: I) -> Self
     where
@@ -80,9 +86,8 @@ impl PathFilter {
         S: AsRef<str>,
     {
         for pattern in patterns {
-            if let Ok(regex) = Regex::new(pattern.as_ref()) {
-                self.regex_patterns.push(regex);
-            }
+            let regex = Regex::new(pattern.as_ref()).expect("Invalid regex pattern");
+            self.regex_patterns.push(regex);
         }
         self
     }
@@ -358,6 +363,20 @@ mod tests {
         assert!(filter.matches("decoder.weight"));
         assert!(filter.matches("encoder.weight"));
         assert!(!filter.matches("decoder.bias"));
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    #[should_panic(expected = "Invalid regex pattern")]
+    fn invalid_regex_panics() {
+        let _ = PathFilter::new().with_regex("[");
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    #[should_panic(expected = "Invalid regex pattern")]
+    fn invalid_regex_in_collection_panics() {
+        let _ = PathFilter::new().with_regexes([r"^valid$", "["]);
     }
 
     #[test]

--- a/crates/burn-store/src/filter.rs
+++ b/crates/burn-store/src/filter.rs
@@ -247,6 +247,10 @@ impl PathFilter {
     }
 
     /// Create a filter from regex patterns only
+    ///
+    /// # Panics
+    ///
+    /// Panics if any pattern is not a valid regular expression.
     #[cfg(feature = "std")]
     pub fn from_regex_patterns<I, S>(patterns: I) -> Self
     where

--- a/crates/burn-store/src/pytorch/store.rs
+++ b/crates/burn-store/src/pytorch/store.rs
@@ -139,6 +139,10 @@ impl PytorchStore {
     ///
     /// Multiple patterns can be added and they work with OR logic.
     ///
+    /// # Panics
+    ///
+    /// Panics if `pattern` is not a valid regular expression.
+    ///
     /// # Example
     /// ```rust,no_run
     /// # use burn_store::PytorchStore;
@@ -152,6 +156,10 @@ impl PytorchStore {
     }
 
     /// Add multiple regex patterns to filter tensors.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any pattern is not a valid regular expression.
     pub fn with_regexes<I, S>(mut self, patterns: I) -> Self
     where
         I: IntoIterator<Item = S>,

--- a/crates/burn-store/src/safetensors/store.rs
+++ b/crates/burn-store/src/safetensors/store.rs
@@ -174,6 +174,10 @@ impl SafetensorsStore {
     ///
     /// Multiple patterns can be added and they work with OR logic.
     ///
+    /// # Panics
+    ///
+    /// Panics if `pattern` is not a valid regular expression.
+    ///
     /// # Example
     /// ```rust,no_run
     /// # use burn_store::SafetensorsStore;
@@ -192,6 +196,10 @@ impl SafetensorsStore {
     }
 
     /// Add multiple regex patterns to filter tensors.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any pattern is not a valid regular expression.
     #[cfg(feature = "std")]
     pub fn with_regexes<I, S>(mut self, patterns: I) -> Self
     where


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Closes #5480.

### Changes

`PathFilter::with_regex` and `with_regexes` previously discarded regex compilation errors. A malformed pattern therefore became an empty filter and could silently produce an empty checkpoint.

Compile each pattern eagerly and fail with the existing `Invalid regex pattern` message. This keeps the builder API compatible and matches the behavior already used by the store remapping builders. The panic contract is now documented on both public methods.

Regression tests cover malformed single patterns and malformed patterns in a collection.

### Testing

- `cargo run-checks`
- `cargo test -p burn-store`