### PR TITLE
Fix unfold window-count documentation

### DIFF
--- a/crates/burn-backend/src/backend/ops/bool_tensor.rs
+++ b/crates/burn-backend/src/backend/ops/bool_tensor.rs
@@ -589,7 +589,8 @@ pub trait BoolTensorOps<B: Backend> {
     /// Returns a view of the tensor with all complete windows of size `size` in dimension `dim`;
     /// where windows are advanced by `step` at each index.
     ///
-    /// The number of windows is `max(0, (shape[dim] - size).ceil_div(step))`.
+    /// The number of windows is `0` when `shape[dim] < size`, and otherwise
+    /// `(shape[dim] - size) / step + 1`.
     ///
     /// # Arguments
     ///

--- a/crates/burn-backend/src/backend/ops/int_tensor.rs
+++ b/crates/burn-backend/src/backend/ops/int_tensor.rs
@@ -1506,7 +1506,8 @@ pub trait IntTensorOps<B: Backend> {
     /// Returns a view of the tensor with all complete windows of size `size` in dimension `dim`;
     /// where windows are advanced by `step` at each index.
     ///
-    /// The number of windows is `max(0, (shape[dim] - size).ceil_div(step))`.
+    /// The number of windows is `0` when `shape[dim] < size`, and otherwise
+    /// `(shape[dim] - size) / step + 1`.
     ///
     /// # Arguments
     ///

--- a/crates/burn-backend/src/backend/ops/modules/unfold.rs
+++ b/crates/burn-backend/src/backend/ops/modules/unfold.rs
@@ -90,7 +90,8 @@ pub fn calculate_unfold_windows(dim_size: usize, window_size: usize, step_size: 
 /// The operation yields a view with all complete windows of size `size` in dimension `dim`;
 /// where windows are advanced by `step` at each index.
 ///
-/// The number of windows is `max(0, (shape[dim] - size).ceil_div(step))`.
+/// The number of windows is `0` when `shape[dim] < size`, and otherwise
+/// `(shape[dim] - size) / step + 1`.
 ///
 /// # Arguments
 ///

--- a/crates/burn-backend/src/backend/ops/tensor.rs
+++ b/crates/burn-backend/src/backend/ops/tensor.rs
@@ -1942,7 +1942,8 @@ pub trait FloatTensorOps<B: Backend> {
     /// Returns a view of the tensor with all complete windows of size `size` in dimension `dim`;
     /// where windows are advanced by `step` at each index.
     ///
-    /// The number of windows is `max(0, (shape[dim] - size).ceil_div(step))`.
+    /// The number of windows is `0` when `shape[dim] < size`, and otherwise
+    /// `(shape[dim] - size) / step + 1`.
     ///
     /// # Arguments
     ///

--- a/crates/burn-cubecl/src/ops/base.rs
+++ b/crates/burn-cubecl/src/ops/base.rs
@@ -476,7 +476,8 @@ pub(crate) fn max_vector_size_many<R: CubeRuntime>(
 /// Returns a view of the tensor with all complete windows of size `size` in dimension `dim`;
 /// where windows are advanced by `step` at each index.
 ///
-/// The number of windows is `max(0, (shape[dim] - size).ceil_div(step))`.
+/// The number of windows is `0` when `shape[dim] < size`, and otherwise
+/// `(shape[dim] - size) / step + 1`.
 ///
 /// The new view will have the unfolded dimension replaced by two dimensions;
 /// one in the position of the original dimension, with size equal to the number of windows,

--- a/crates/burn-ndarray/src/ops/base.rs
+++ b/crates/burn-ndarray/src/ops/base.rs
@@ -591,7 +591,8 @@ where
     /// Returns a copy of the tensor with all complete windows of size `size` in dimension `dim`;
     /// where windows are advanced by `step` at each index.
     ///
-    /// The number of windows is `max(0, (shape[dim] - size).ceil_div(step))`.
+    /// The number of windows is `0` when `shape[dim] < size`, and otherwise
+    /// `(shape[dim] - size) / step + 1`.
     ///
     /// # Arguments
     ///

--- a/crates/burn-tensor/src/bridge/ops/base.rs
+++ b/crates/burn-tensor/src/bridge/ops/base.rs
@@ -731,7 +731,8 @@ pub(crate) trait BasicOps: TensorKind {
     /// Returns a view of the tensor with all complete windows of size `size` in dimension `dim`;
     /// where windows are advanced by `step` at each index.
     ///
-    /// The number of windows is `max(0, (shape[dim] - size).ceil_div(step))`.
+    /// The number of windows is `0` when `shape[dim] < size`, and otherwise
+    /// `(shape[dim] - size) / step + 1`.
     ///
     /// # Warning
     ///

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -3081,7 +3081,8 @@ where
     /// Returns a view of the tensor with all complete windows of size `size` in dimension `dim`;
     /// where windows are advanced by `step` at each index.
     ///
-    /// The number of windows is `max(0, (shape[dim] - size).ceil_div(step))`.
+    /// The number of windows is `0` when `shape[dim] < size`, and otherwise
+    /// `(shape[dim] - size) / step + 1`.
     ///
     /// The new view will have the unfolded dimension replaced by two dimensions;
     /// one in the position of the original dimension, with size equal to the number of windows,


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo run-checks` has been executed.
- [x] Made sure the book is up to date with changes in this PR.

### Related Issues/PRs

Closes #5341.

### Changes

Correct the documented number of windows produced by `unfold`.

The previous `ceil_div` formula was one too low whenever the input remainder was exactly divisible by the step. The documentation now states the boundary case explicitly and uses `(shape[dim] - size) / step + 1` otherwise.

Updated all eight copies of the public API documentation so backend and tensor-level docs remain consistent. This PR changes documentation only.

### Testing

- `cargo run-checks`