### PR TITLE
chore(deps): update cubecl and cubek for fallible throughput probes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -172,7 +172,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2176,7 +2176,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -2193,7 +2193,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -2217,7 +2217,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -2247,7 +2247,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2270,7 +2270,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "bytemuck",
  "crossbeam-utils",
@@ -2292,7 +2292,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2311,7 +2311,7 @@ dependencies = [
 [[package]]
 name = "cubecl-environment"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "async-channel",
  "backtrace",
@@ -2346,7 +2346,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2377,7 +2377,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -2409,7 +2409,7 @@ dependencies = [
 [[package]]
 name = "cubecl-llvm"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "cc",
  "cubecl-core",
@@ -2428,7 +2428,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "cubecl-common",
  "darling 0.24.0",
@@ -2446,7 +2446,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "darling 0.24.0",
  "inflections",
@@ -2458,7 +2458,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2479,7 +2479,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "buildid",
  "bytemuck",
@@ -2509,7 +2509,7 @@ dependencies = [
 [[package]]
 name = "cubecl-spirv"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "bitflags 2.13.1",
  "cubecl-common",
@@ -2532,7 +2532,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2549,7 +2549,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "ash",
  "bytemuck",
@@ -2584,7 +2584,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "derive-new",
  "serde",
@@ -2594,7 +2594,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5158e74ac4d312ea3976e3485e5298e65f60129e#5158e74ac4d312ea3976e3485e5298e65f60129e"
+source = "git+https://github.com/tracel-ai/cubek?rev=b2c3982119bafc46f3785107f00fd0eaf27e2a14#b2c3982119bafc46f3785107f00fd0eaf27e2a14"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2612,7 +2612,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5158e74ac4d312ea3976e3485e5298e65f60129e#5158e74ac4d312ea3976e3485e5298e65f60129e"
+source = "git+https://github.com/tracel-ai/cubek?rev=b2c3982119bafc46f3785107f00fd0eaf27e2a14#b2c3982119bafc46f3785107f00fd0eaf27e2a14"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2626,7 +2626,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5158e74ac4d312ea3976e3485e5298e65f60129e#5158e74ac4d312ea3976e3485e5298e65f60129e"
+source = "git+https://github.com/tracel-ai/cubek?rev=b2c3982119bafc46f3785107f00fd0eaf27e2a14#b2c3982119bafc46f3785107f00fd0eaf27e2a14"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2642,7 +2642,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5158e74ac4d312ea3976e3485e5298e65f60129e#5158e74ac4d312ea3976e3485e5298e65f60129e"
+source = "git+https://github.com/tracel-ai/cubek?rev=b2c3982119bafc46f3785107f00fd0eaf27e2a14#b2c3982119bafc46f3785107f00fd0eaf27e2a14"
 dependencies = [
  "cubecl",
 ]
@@ -2650,7 +2650,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5158e74ac4d312ea3976e3485e5298e65f60129e#5158e74ac4d312ea3976e3485e5298e65f60129e"
+source = "git+https://github.com/tracel-ai/cubek?rev=b2c3982119bafc46f3785107f00fd0eaf27e2a14#b2c3982119bafc46f3785107f00fd0eaf27e2a14"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2663,7 +2663,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5158e74ac4d312ea3976e3485e5298e65f60129e#5158e74ac4d312ea3976e3485e5298e65f60129e"
+source = "git+https://github.com/tracel-ai/cubek?rev=b2c3982119bafc46f3785107f00fd0eaf27e2a14#b2c3982119bafc46f3785107f00fd0eaf27e2a14"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2677,7 +2677,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5158e74ac4d312ea3976e3485e5298e65f60129e#5158e74ac4d312ea3976e3485e5298e65f60129e"
+source = "git+https://github.com/tracel-ai/cubek?rev=b2c3982119bafc46f3785107f00fd0eaf27e2a14#b2c3982119bafc46f3785107f00fd0eaf27e2a14"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2687,7 +2687,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5158e74ac4d312ea3976e3485e5298e65f60129e#5158e74ac4d312ea3976e3485e5298e65f60129e"
+source = "git+https://github.com/tracel-ai/cubek?rev=b2c3982119bafc46f3785107f00fd0eaf27e2a14#b2c3982119bafc46f3785107f00fd0eaf27e2a14"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2699,7 +2699,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5158e74ac4d312ea3976e3485e5298e65f60129e#5158e74ac4d312ea3976e3485e5298e65f60129e"
+source = "git+https://github.com/tracel-ai/cubek?rev=b2c3982119bafc46f3785107f00fd0eaf27e2a14#b2c3982119bafc46f3785107f00fd0eaf27e2a14"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2714,7 +2714,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5158e74ac4d312ea3976e3485e5298e65f60129e#5158e74ac4d312ea3976e3485e5298e65f60129e"
+source = "git+https://github.com/tracel-ai/cubek?rev=b2c3982119bafc46f3785107f00fd0eaf27e2a14#b2c3982119bafc46f3785107f00fd0eaf27e2a14"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2727,7 +2727,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5158e74ac4d312ea3976e3485e5298e65f60129e#5158e74ac4d312ea3976e3485e5298e65f60129e"
+source = "git+https://github.com/tracel-ai/cubek?rev=b2c3982119bafc46f3785107f00fd0eaf27e2a14#b2c3982119bafc46f3785107f00fd0eaf27e2a14"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2736,7 +2736,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=5158e74ac4d312ea3976e3485e5298e65f60129e#5158e74ac4d312ea3976e3485e5298e65f60129e"
+source = "git+https://github.com/tracel-ai/cubek?rev=b2c3982119bafc46f3785107f00fd0eaf27e2a14#b2c3982119bafc46f3785107f00fd0eaf27e2a14"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -4328,7 +4328,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.19",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -9479,7 +9479,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9607,7 +9607,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9896,7 +9896,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook 0.3.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1749,7 +1749,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2176,7 +2176,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -2193,7 +2193,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -2217,7 +2217,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -2247,7 +2247,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2270,7 +2270,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "bytemuck",
  "crossbeam-utils",
@@ -2292,7 +2292,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2311,7 +2311,7 @@ dependencies = [
 [[package]]
 name = "cubecl-environment"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "async-channel",
  "backtrace",
@@ -2346,7 +2346,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2377,7 +2377,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -2409,7 +2409,7 @@ dependencies = [
 [[package]]
 name = "cubecl-llvm"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "cc",
  "cubecl-core",
@@ -2428,7 +2428,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "cubecl-common",
  "darling 0.24.0",
@@ -2446,7 +2446,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "darling 0.24.0",
  "inflections",
@@ -2458,7 +2458,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2479,7 +2479,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "buildid",
  "bytemuck",
@@ -2509,7 +2509,7 @@ dependencies = [
 [[package]]
 name = "cubecl-spirv"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "bitflags 2.13.1",
  "cubecl-common",
@@ -2532,7 +2532,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2549,7 +2549,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "ash",
  "bytemuck",
@@ -2584,7 +2584,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "derive-new",
  "serde",
@@ -2594,7 +2594,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=c7e62f9034da732fe2d98384957f790cb6418bb7#c7e62f9034da732fe2d98384957f790cb6418bb7"
+source = "git+https://github.com/tracel-ai/cubek?rev=8188a6698f1b3f3215ec46374db2cee05cd31842#8188a6698f1b3f3215ec46374db2cee05cd31842"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2612,7 +2612,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=c7e62f9034da732fe2d98384957f790cb6418bb7#c7e62f9034da732fe2d98384957f790cb6418bb7"
+source = "git+https://github.com/tracel-ai/cubek?rev=8188a6698f1b3f3215ec46374db2cee05cd31842#8188a6698f1b3f3215ec46374db2cee05cd31842"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2626,7 +2626,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=c7e62f9034da732fe2d98384957f790cb6418bb7#c7e62f9034da732fe2d98384957f790cb6418bb7"
+source = "git+https://github.com/tracel-ai/cubek?rev=8188a6698f1b3f3215ec46374db2cee05cd31842#8188a6698f1b3f3215ec46374db2cee05cd31842"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2642,7 +2642,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=c7e62f9034da732fe2d98384957f790cb6418bb7#c7e62f9034da732fe2d98384957f790cb6418bb7"
+source = "git+https://github.com/tracel-ai/cubek?rev=8188a6698f1b3f3215ec46374db2cee05cd31842#8188a6698f1b3f3215ec46374db2cee05cd31842"
 dependencies = [
  "cubecl",
 ]
@@ -2650,7 +2650,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=c7e62f9034da732fe2d98384957f790cb6418bb7#c7e62f9034da732fe2d98384957f790cb6418bb7"
+source = "git+https://github.com/tracel-ai/cubek?rev=8188a6698f1b3f3215ec46374db2cee05cd31842#8188a6698f1b3f3215ec46374db2cee05cd31842"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2663,7 +2663,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=c7e62f9034da732fe2d98384957f790cb6418bb7#c7e62f9034da732fe2d98384957f790cb6418bb7"
+source = "git+https://github.com/tracel-ai/cubek?rev=8188a6698f1b3f3215ec46374db2cee05cd31842#8188a6698f1b3f3215ec46374db2cee05cd31842"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2677,7 +2677,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=c7e62f9034da732fe2d98384957f790cb6418bb7#c7e62f9034da732fe2d98384957f790cb6418bb7"
+source = "git+https://github.com/tracel-ai/cubek?rev=8188a6698f1b3f3215ec46374db2cee05cd31842#8188a6698f1b3f3215ec46374db2cee05cd31842"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2687,7 +2687,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=c7e62f9034da732fe2d98384957f790cb6418bb7#c7e62f9034da732fe2d98384957f790cb6418bb7"
+source = "git+https://github.com/tracel-ai/cubek?rev=8188a6698f1b3f3215ec46374db2cee05cd31842#8188a6698f1b3f3215ec46374db2cee05cd31842"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2699,7 +2699,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=c7e62f9034da732fe2d98384957f790cb6418bb7#c7e62f9034da732fe2d98384957f790cb6418bb7"
+source = "git+https://github.com/tracel-ai/cubek?rev=8188a6698f1b3f3215ec46374db2cee05cd31842#8188a6698f1b3f3215ec46374db2cee05cd31842"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2714,7 +2714,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=c7e62f9034da732fe2d98384957f790cb6418bb7#c7e62f9034da732fe2d98384957f790cb6418bb7"
+source = "git+https://github.com/tracel-ai/cubek?rev=8188a6698f1b3f3215ec46374db2cee05cd31842#8188a6698f1b3f3215ec46374db2cee05cd31842"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2727,7 +2727,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=c7e62f9034da732fe2d98384957f790cb6418bb7#c7e62f9034da732fe2d98384957f790cb6418bb7"
+source = "git+https://github.com/tracel-ai/cubek?rev=8188a6698f1b3f3215ec46374db2cee05cd31842#8188a6698f1b3f3215ec46374db2cee05cd31842"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2736,7 +2736,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=c7e62f9034da732fe2d98384957f790cb6418bb7#c7e62f9034da732fe2d98384957f790cb6418bb7"
+source = "git+https://github.com/tracel-ai/cubek?rev=8188a6698f1b3f3215ec46374db2cee05cd31842#8188a6698f1b3f3215ec46374db2cee05cd31842"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -3224,7 +3224,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3580,7 +3580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4084,8 +4084,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -4386,10 +4386,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
@@ -4728,7 +4724,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -6368,7 +6364,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7137,7 +7133,7 @@ dependencies = [
  "combine",
  "downcast-rs",
  "dyn-clone",
- "hashbrown 0.14.5",
+ "hashbrown 0.13.2",
  "hi_sparse_bitset",
  "indexmap",
  "inventory",
@@ -7150,7 +7146,7 @@ dependencies = [
  "rustc_apfloat",
  "slotmap",
  "smallvec",
- "spin 0.12.2",
+ "spin 0.10.1",
  "thiserror 2.0.19",
  "utf8-chars",
 ]
@@ -8159,7 +8155,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8894,7 +8890,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8952,7 +8948,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9103,7 +9099,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9515,6 +9511,9 @@ name = "spin"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spin"
@@ -9874,7 +9873,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9906,7 +9905,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11375,7 +11374,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11851,8 +11850,8 @@ dependencies = [
  "log",
  "serde",
  "thiserror 2.0.19",
- "windows 0.61.3",
- "windows-core 0.61.2",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -172,7 +172,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1749,7 +1749,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2594,7 +2594,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=8188a6698f1b3f3215ec46374db2cee05cd31842#8188a6698f1b3f3215ec46374db2cee05cd31842"
+source = "git+https://github.com/tracel-ai/cubek?rev=5158e74ac4d312ea3976e3485e5298e65f60129e#5158e74ac4d312ea3976e3485e5298e65f60129e"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2612,7 +2612,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=8188a6698f1b3f3215ec46374db2cee05cd31842#8188a6698f1b3f3215ec46374db2cee05cd31842"
+source = "git+https://github.com/tracel-ai/cubek?rev=5158e74ac4d312ea3976e3485e5298e65f60129e#5158e74ac4d312ea3976e3485e5298e65f60129e"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2626,7 +2626,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=8188a6698f1b3f3215ec46374db2cee05cd31842#8188a6698f1b3f3215ec46374db2cee05cd31842"
+source = "git+https://github.com/tracel-ai/cubek?rev=5158e74ac4d312ea3976e3485e5298e65f60129e#5158e74ac4d312ea3976e3485e5298e65f60129e"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2642,7 +2642,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=8188a6698f1b3f3215ec46374db2cee05cd31842#8188a6698f1b3f3215ec46374db2cee05cd31842"
+source = "git+https://github.com/tracel-ai/cubek?rev=5158e74ac4d312ea3976e3485e5298e65f60129e#5158e74ac4d312ea3976e3485e5298e65f60129e"
 dependencies = [
  "cubecl",
 ]
@@ -2650,7 +2650,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=8188a6698f1b3f3215ec46374db2cee05cd31842#8188a6698f1b3f3215ec46374db2cee05cd31842"
+source = "git+https://github.com/tracel-ai/cubek?rev=5158e74ac4d312ea3976e3485e5298e65f60129e#5158e74ac4d312ea3976e3485e5298e65f60129e"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2663,7 +2663,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=8188a6698f1b3f3215ec46374db2cee05cd31842#8188a6698f1b3f3215ec46374db2cee05cd31842"
+source = "git+https://github.com/tracel-ai/cubek?rev=5158e74ac4d312ea3976e3485e5298e65f60129e#5158e74ac4d312ea3976e3485e5298e65f60129e"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2677,7 +2677,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=8188a6698f1b3f3215ec46374db2cee05cd31842#8188a6698f1b3f3215ec46374db2cee05cd31842"
+source = "git+https://github.com/tracel-ai/cubek?rev=5158e74ac4d312ea3976e3485e5298e65f60129e#5158e74ac4d312ea3976e3485e5298e65f60129e"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2687,7 +2687,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=8188a6698f1b3f3215ec46374db2cee05cd31842#8188a6698f1b3f3215ec46374db2cee05cd31842"
+source = "git+https://github.com/tracel-ai/cubek?rev=5158e74ac4d312ea3976e3485e5298e65f60129e#5158e74ac4d312ea3976e3485e5298e65f60129e"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2699,7 +2699,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=8188a6698f1b3f3215ec46374db2cee05cd31842#8188a6698f1b3f3215ec46374db2cee05cd31842"
+source = "git+https://github.com/tracel-ai/cubek?rev=5158e74ac4d312ea3976e3485e5298e65f60129e#5158e74ac4d312ea3976e3485e5298e65f60129e"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2714,7 +2714,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=8188a6698f1b3f3215ec46374db2cee05cd31842#8188a6698f1b3f3215ec46374db2cee05cd31842"
+source = "git+https://github.com/tracel-ai/cubek?rev=5158e74ac4d312ea3976e3485e5298e65f60129e#5158e74ac4d312ea3976e3485e5298e65f60129e"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2727,7 +2727,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=8188a6698f1b3f3215ec46374db2cee05cd31842#8188a6698f1b3f3215ec46374db2cee05cd31842"
+source = "git+https://github.com/tracel-ai/cubek?rev=5158e74ac4d312ea3976e3485e5298e65f60129e#5158e74ac4d312ea3976e3485e5298e65f60129e"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2736,7 +2736,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=8188a6698f1b3f3215ec46374db2cee05cd31842#8188a6698f1b3f3215ec46374db2cee05cd31842"
+source = "git+https://github.com/tracel-ai/cubek?rev=5158e74ac4d312ea3976e3485e5298e65f60129e#5158e74ac4d312ea3976e3485e5298e65f60129e"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -3224,7 +3224,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3580,7 +3580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4084,8 +4084,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -4328,7 +4328,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.19",
- "windows 0.62.2",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4386,6 +4386,10 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hashbrown"
@@ -4724,7 +4728,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -6364,7 +6368,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7133,7 +7137,7 @@ dependencies = [
  "combine",
  "downcast-rs",
  "dyn-clone",
- "hashbrown 0.13.2",
+ "hashbrown 0.14.5",
  "hi_sparse_bitset",
  "indexmap",
  "inventory",
@@ -7146,7 +7150,7 @@ dependencies = [
  "rustc_apfloat",
  "slotmap",
  "smallvec",
- "spin 0.10.1",
+ "spin 0.12.2",
  "thiserror 2.0.19",
  "utf8-chars",
 ]
@@ -8155,7 +8159,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8890,7 +8894,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8948,7 +8952,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9099,7 +9103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9475,7 +9479,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9511,9 +9515,6 @@ name = "spin"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "spin"
@@ -9606,7 +9607,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9873,7 +9874,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9895,7 +9896,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook 0.3.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9905,7 +9906,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11374,7 +11375,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11850,8 +11851,8 @@ dependencies = [
  "log",
  "serde",
  "thiserror 2.0.19",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,11 +222,11 @@ burn-vision = { path = "crates/burn-vision", version = "=0.22.0-pre.3", default-
 burn-wgpu = { path = "crates/burn-wgpu", version = "=0.22.0-pre.3", default-features = false }
 
 ### For the main burn branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "4674dd13da8f3dedb169f5b3d117ea1b22d5b754" }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "4674dd13da8f3dedb169f5b3d117ea1b22d5b754" }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "4674dd13da8f3dedb169f5b3d117ea1b22d5b754" }
-cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "4674dd13da8f3dedb169f5b3d117ea1b22d5b754" }
-cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "5158e74ac4d312ea3976e3485e5298e65f60129e" }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "5a9094b8a6a2083725945365b8be8e18bdd596ba" }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "5a9094b8a6a2083725945365b8be8e18bdd596ba" }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "5a9094b8a6a2083725945365b8be8e18bdd596ba" }
+cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "5a9094b8a6a2083725945365b8be8e18bdd596ba" }
+cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "b2c3982119bafc46f3785107f00fd0eaf27e2a14" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,7 +226,7 @@ cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false
 cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "4674dd13da8f3dedb169f5b3d117ea1b22d5b754" }
 cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "4674dd13da8f3dedb169f5b3d117ea1b22d5b754" }
 cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "4674dd13da8f3dedb169f5b3d117ea1b22d5b754" }
-cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "8188a6698f1b3f3215ec46374db2cee05cd31842" }
+cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "5158e74ac4d312ea3976e3485e5298e65f60129e" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,11 +222,11 @@ burn-vision = { path = "crates/burn-vision", version = "=0.22.0-pre.3", default-
 burn-wgpu = { path = "crates/burn-wgpu", version = "=0.22.0-pre.3", default-features = false }
 
 ### For the main burn branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "a79e7166445969389c08e0baad92ff67a91138ca" }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "a79e7166445969389c08e0baad92ff67a91138ca" }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "a79e7166445969389c08e0baad92ff67a91138ca" }
-cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "a79e7166445969389c08e0baad92ff67a91138ca" }
-cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "c7e62f9034da732fe2d98384957f790cb6418bb7" }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "4674dd13da8f3dedb169f5b3d117ea1b22d5b754" }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "4674dd13da8f3dedb169f5b3d117ea1b22d5b754" }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "4674dd13da8f3dedb169f5b3d117ea1b22d5b754" }
+cubecl-zspace = { git = "https://github.com/tracel-ai/cubecl", default-features = false, rev = "4674dd13da8f3dedb169f5b3d117ea1b22d5b754" }
+cubek = { git = "https://github.com/tracel-ai/cubek", default-features = false, rev = "8188a6698f1b3f3215ec46374db2cee05cd31842" }
 ### For local development. ###
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }

--- a/crates/burn-backend/src/cubecl.rs
+++ b/crates/burn-backend/src/cubecl.rs
@@ -11,7 +11,9 @@
 use burn_std::{BoolStore, DType, QuantScheme, QuantStore, QuantValue};
 use cubecl::ir::{ElemType, FloatKind, IntKind, UIntKind};
 
-pub use cubecl::throughput::{MemoryAccess, ThroughputKey, ThroughputMode, ThroughputValue};
+pub use cubecl::throughput::{
+    MemoryAccess, ThroughputError, ThroughputKey, ThroughputMode, ThroughputValue,
+};
 
 /// Convert a cubecl [`ElemType`] into the corresponding burn [`DType`].
 ///

--- a/crates/burn-cpu/src/lib.rs
+++ b/crates/burn-cpu/src/lib.rs
@@ -21,6 +21,9 @@ pub fn device_throughput(
     keys: &[ThroughputKey],
 ) -> alloc::vec::Vec<ThroughputValue> {
     cubecl::std::throughput::device_throughput::<CpuRuntime>(device, keys)
+        .into_iter()
+        .map(|peak| peak.unwrap_or(ThroughputValue::ZERO))
+        .collect()
 }
 
 #[cfg(test)]

--- a/crates/burn-cpu/src/lib.rs
+++ b/crates/burn-cpu/src/lib.rs
@@ -6,7 +6,7 @@ use burn_cubecl::CubeBackend;
 pub use cubecl::cpu::CpuDevice;
 use cubecl::{
     cpu::CpuRuntime,
-    throughput::{ThroughputKey, ThroughputValue},
+    throughput::{ThroughputError, ThroughputKey, ThroughputValue},
 };
 
 #[cfg(not(feature = "fusion"))]
@@ -19,11 +19,8 @@ pub type Cpu = burn_fusion::Fusion<CubeBackend<CpuRuntime>>;
 pub fn device_throughput(
     device: &CpuDevice,
     keys: &[ThroughputKey],
-) -> alloc::vec::Vec<ThroughputValue> {
+) -> alloc::vec::Vec<Result<ThroughputValue, ThroughputError>> {
     cubecl::std::throughput::device_throughput::<CpuRuntime>(device, keys)
-        .into_iter()
-        .map(|peak| peak.unwrap_or(ThroughputValue::ZERO))
-        .collect()
 }
 
 #[cfg(test)]

--- a/crates/burn-cuda/src/lib.rs
+++ b/crates/burn-cuda/src/lib.rs
@@ -6,7 +6,7 @@ use burn_cubecl::CubeBackend;
 pub use cubecl::cuda::CudaDevice;
 use cubecl::{
     cuda::CudaRuntime,
-    throughput::{ThroughputKey, ThroughputValue},
+    throughput::{ThroughputError, ThroughputKey, ThroughputValue},
 };
 
 #[cfg(not(feature = "fusion"))]
@@ -19,11 +19,8 @@ pub type Cuda = burn_fusion::Fusion<CubeBackend<CudaRuntime>>;
 pub fn device_throughput(
     device: &CudaDevice,
     keys: &[ThroughputKey],
-) -> alloc::vec::Vec<ThroughputValue> {
+) -> alloc::vec::Vec<Result<ThroughputValue, ThroughputError>> {
     cubecl::std::throughput::device_throughput::<CudaRuntime>(device, keys)
-        .into_iter()
-        .map(|peak| peak.unwrap_or(ThroughputValue::ZERO))
-        .collect()
 }
 
 #[cfg(all(test, not(target_os = "macos")))]

--- a/crates/burn-cuda/src/lib.rs
+++ b/crates/burn-cuda/src/lib.rs
@@ -21,6 +21,9 @@ pub fn device_throughput(
     keys: &[ThroughputKey],
 ) -> alloc::vec::Vec<ThroughputValue> {
     cubecl::std::throughput::device_throughput::<CudaRuntime>(device, keys)
+        .into_iter()
+        .map(|peak| peak.unwrap_or(ThroughputValue::ZERO))
+        .collect()
 }
 
 #[cfg(all(test, not(target_os = "macos")))]

--- a/crates/burn-dispatch/src/device.rs
+++ b/crates/burn-dispatch/src/device.rs
@@ -13,7 +13,7 @@ use alloc::boxed::Box;
 #[cfg(feature = "cubecl")]
 use alloc::vec::Vec;
 #[cfg(feature = "cubecl")]
-use burn_backend::cubecl::{ThroughputKey, ThroughputValue};
+use burn_backend::cubecl::{ThroughputError, ThroughputKey, ThroughputValue};
 
 /// Represents a device for the [`Dispatch`](crate::Dispatch).
 ///
@@ -91,9 +91,13 @@ impl DispatchDevice {
     ///
     /// Only cubecl-backed devices can measure throughput; other backends
     /// (ndarray, libtorch, remote, ...) return an empty vector. An autodiff
-    /// device reports the peaks of the device it wraps. Each returned
-    /// [`ThroughputValue`] corresponds positionally to the key at the same index.
-    pub fn performance_stats(&self, keys: &[ThroughputKey]) -> Vec<ThroughputValue> {
+    /// device reports the peaks of the device it wraps. Each returned result
+    /// corresponds positionally to the key at the same index, and carries a
+    /// [`ThroughputError`] where the device has no peak for that key.
+    pub fn performance_stats(
+        &self,
+        keys: &[ThroughputKey],
+    ) -> Vec<Result<ThroughputValue, ThroughputError>> {
         // No catch-all arm: a new backend must fail to compile here rather
         // than silently report no peaks.
         match self {

--- a/crates/burn-rocm/src/lib.rs
+++ b/crates/burn-rocm/src/lib.rs
@@ -7,7 +7,7 @@ pub use cubecl::hip::AmdDevice as RocmDevice;
 
 use cubecl::{
     hip::HipRuntime,
-    throughput::{ThroughputKey, ThroughputValue},
+    throughput::{ThroughputError, ThroughputKey, ThroughputValue},
 };
 
 #[cfg(not(feature = "fusion"))]
@@ -20,9 +20,6 @@ pub type Rocm = burn_fusion::Fusion<CubeBackend<HipRuntime>>;
 pub fn device_throughput(
     device: &RocmDevice,
     keys: &[ThroughputKey],
-) -> alloc::vec::Vec<ThroughputValue> {
+) -> alloc::vec::Vec<Result<ThroughputValue, ThroughputError>> {
     cubecl::std::throughput::device_throughput::<HipRuntime>(device, keys)
-        .into_iter()
-        .map(|peak| peak.unwrap_or(ThroughputValue::ZERO))
-        .collect()
 }

--- a/crates/burn-rocm/src/lib.rs
+++ b/crates/burn-rocm/src/lib.rs
@@ -22,4 +22,7 @@ pub fn device_throughput(
     keys: &[ThroughputKey],
 ) -> alloc::vec::Vec<ThroughputValue> {
     cubecl::std::throughput::device_throughput::<HipRuntime>(device, keys)
+        .into_iter()
+        .map(|peak| peak.unwrap_or(ThroughputValue::ZERO))
+        .collect()
 }

--- a/crates/burn-tensor/src/device.rs
+++ b/crates/burn-tensor/src/device.rs
@@ -3,7 +3,9 @@ pub use burn_std::{
 };
 
 #[cfg(feature = "cubecl")]
-pub use burn_backend::cubecl::{MemoryAccess, ThroughputKey, ThroughputMode, ThroughputValue};
+pub use burn_backend::cubecl::{
+    MemoryAccess, ThroughputError, ThroughputKey, ThroughputMode, ThroughputValue,
+};
 use burn_backend::{Backend, DeviceOps};
 pub use burn_backend::{
     InstallMemoryPoolsError, MemoryPoolLayout, MemoryPoolUsage, SlicedPool, SlicedPoolReport,
@@ -929,8 +931,8 @@ impl Device {
 pub struct ThroughputStat {
     /// The measurement key (mode + dtype) that was benchmarked.
     pub key: ThroughputKey,
-    /// The measured throughput for that key.
-    pub value: ThroughputValue,
+    /// The measured throughput for that key, or why the device has none.
+    pub value: Result<ThroughputValue, ThroughputError>,
 }
 
 /// Short, column-friendly name for a throughput mode.
@@ -966,7 +968,10 @@ impl core::fmt::Display for ThroughputStat {
             ThroughputMode::Memory(_) | ThroughputMode::Launch => alloc::string::String::new(),
         };
 
-        let value = self.value.format(&self.key);
+        let value = match &self.value {
+            Ok(value) => value.format(&self.key),
+            Err(error) => alloc::format!("{error}"),
+        };
 
         write!(f, "{mode:<14} {dtype:<5} {value}")
     }

--- a/crates/burn-wgpu/src/lib.rs
+++ b/crates/burn-wgpu/src/lib.rs
@@ -85,6 +85,9 @@ pub fn device_throughput(
     cubecl::std::throughput::device_throughput::<cubecl::wgpu::WgpuRuntime<AutoCompiler>>(
         device, keys,
     )
+    .into_iter()
+    .map(|peak| peak.unwrap_or(ThroughputValue::ZERO))
+    .collect()
 }
 
 /// Tensor backend that leverages the Vulkan graphics API to execute GPU compute shaders compiled to SPIR-V.

--- a/crates/burn-wgpu/src/lib.rs
+++ b/crates/burn-wgpu/src/lib.rs
@@ -13,7 +13,7 @@ pub use burn_cubecl::{BoolElement, FloatElement, IntElement};
 pub use burn_cubecl::{CubeBackend, tensor::CubeTensor};
 pub use cubecl::CubeDim;
 pub use cubecl::flex32;
-use cubecl::throughput::{ThroughputKey, ThroughputValue};
+use cubecl::throughput::{ThroughputError, ThroughputKey, ThroughputValue};
 
 #[cfg(feature = "metal")]
 use cubecl::wgpu::MslCompiler;
@@ -81,13 +81,10 @@ pub type Wgpu = WgpuInner<AutoCompiler>;
 pub fn device_throughput(
     device: &WgpuDevice,
     keys: &[ThroughputKey],
-) -> alloc::vec::Vec<ThroughputValue> {
+) -> alloc::vec::Vec<Result<ThroughputValue, ThroughputError>> {
     cubecl::std::throughput::device_throughput::<cubecl::wgpu::WgpuRuntime<AutoCompiler>>(
         device, keys,
     )
-    .into_iter()
-    .map(|peak| peak.unwrap_or(ThroughputValue::ZERO))
-    .collect()
 }
 
 /// Tensor backend that leverages the Vulkan graphics API to execute GPU compute shaders compiled to SPIR-V.


### PR DESCRIPTION
Follows tracel-ai/cubecl#1598 and its cubek companion, tracel-ai/cubek#604. `device_throughput` returns one `Result` per key, and the result travels through `DispatchDevice::performance_stats` to `ThroughputStat`, whose `Display` prints `unsupported` or `no timing` in the column that read `N/A` for both. `ThroughputError` is re-exported next to `ThroughputValue`.

## Pull Request Template

### Checklist

- [ ] Confirmed that `cargo run-checks` has been executed.
- [ ] Made sure the book is up to date with changes in this PR.

> `cargo run-checks` tests with `Flex` by default. Use `cargo run-checks --backend <backend>` when
> targeting another backend. Consider running additional tests relevant to the crates changed.

### Related Issues/PRs

_Provide links to relevant issues and dependent PRs._

### Changes

_Summarize the problem being addressed and your solution._

### Testing

_Describe how these changes have been tested._
