### PR TITLE
feat(tensor): apply TensorCheck to remainder, powi, powf, hypot, atan2

### DIFF
--- a/crates/burn-backend-tests/tests/tensor/float/ops/hypot.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/hypot.rs
@@ -2,6 +2,21 @@ use super::*;
 use burn_tensor::{TensorData, Tolerance};
 
 #[test]
+#[should_panic(expected = "The provided tensors have incompatible shapes.")]
+fn should_panic_hypot_incompatible_shapes() {
+    let device = Default::default();
+    // Same rank, but [2, 2] vs [2, 3]: dimension 1 cannot broadcast.
+    let lhs = TestTensor::<2>::from_data(TensorData::from([[3.0, 4.0], [5.0, 12.0]]), &device);
+    let rhs = TestTensor::<2>::from_data(
+        TensorData::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
+        &device,
+    );
+
+    let output = lhs.hypot(rhs);
+    output.into_data();
+}
+
+#[test]
 fn should_support_hypot_basic() {
     let data_a = TensorData::from([[3.0, 4.0], [5.0, 12.0]]);
     let data_b = TensorData::from([[4.0, 3.0], [12.0, 5.0]]);

--- a/crates/burn-backend-tests/tests/tensor/float/ops/powf.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/powf.rs
@@ -63,6 +63,18 @@ fn should_support_neg_values_with_odd_power() {
 }
 
 #[test]
+#[should_panic(expected = "The provided tensors have incompatible shapes.")]
+fn should_panic_powf_incompatible_shapes() {
+    let device = Default::default();
+    // Same rank, but [2, 2] vs [2, 3]: dimension 1 cannot broadcast.
+    let lhs = TestTensor::<2>::from_data([[1.0, 2.0], [3.0, 4.0]], &device);
+    let rhs = TestTensor::<2>::from_data([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], &device);
+
+    let output = lhs.powf(rhs);
+    output.into_data();
+}
+
+#[test]
 fn should_support_powf_broadcasted() {
     let device = Default::default();
     let tensor_1 = TestTensor::<1>::from_data([2.0, 3.0, 4.0], &device);

--- a/crates/burn-backend-tests/tests/tensor/float/ops/remainder.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/remainder.rs
@@ -2,6 +2,38 @@ use super::*;
 use burn_tensor::TensorData;
 use burn_tensor::Tolerance;
 
+#[test]
+fn should_support_remainder_broadcast() {
+    let device = Default::default();
+    let lhs = TestTensor::<2>::from_data(TensorData::from([[3.0, 4.0, 5.0]]), &device);
+    let rhs = TestTensor::<2>::from_data(
+        TensorData::from([[2.0, 2.0, 2.0], [3.0, 3.0, 3.0]]),
+        &device,
+    );
+
+    let output = lhs.remainder(rhs);
+    let expected = TensorData::from([[1.0, 0.0, 1.0], [0.0, 1.0, 2.0]]);
+
+    output
+        .into_data()
+        .assert_approx_eq::<FloatElem>(&expected, Tolerance::default());
+}
+
+#[test]
+#[should_panic(expected = "The provided tensors have incompatible shapes.")]
+fn should_panic_remainder_incompatible_shapes() {
+    let device = Default::default();
+    // Same rank, but [2, 2] vs [2, 3]: dimension 1 cannot broadcast.
+    let lhs = TestTensor::<2>::from_data(TensorData::from([[1.0, 2.0], [3.0, 4.0]]), &device);
+    let rhs = TestTensor::<2>::from_data(
+        TensorData::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
+        &device,
+    );
+
+    let output = lhs.remainder(rhs);
+    output.into_data();
+}
+
 /// From https://pytorch.org/docs/stable/generated/torch.remainder.html
 #[test]
 fn should_support_remainder_basic() {

--- a/crates/burn-backend-tests/tests/tensor/float/ops/trig.rs
+++ b/crates/burn-backend-tests/tests/tensor/float/ops/trig.rs
@@ -218,6 +218,21 @@ fn should_support_atanh_ops() {
 }
 
 #[test]
+#[should_panic(expected = "The provided tensors have incompatible shapes.")]
+fn should_panic_atan2_incompatible_shapes() {
+    let device = Default::default();
+    // Same rank, but [2, 2] vs [2, 3]: dimension 1 cannot broadcast.
+    let y = TestTensor::<2>::from_data(TensorData::from([[0.0, 1.0], [-1.0, -1.0]]), &device);
+    let x = TestTensor::<2>::from_data(
+        TensorData::from([[1.0, 1.0, 0.0], [1.0, 0.0, -1.0]]),
+        &device,
+    );
+
+    let output = y.atan2(x);
+    output.into_data();
+}
+
+#[test]
 fn should_support_atan2_ops() {
     let y = TensorData::from([[0.0, 1.0, 1.0], [-1.0, -1.0, 0.0]]);
     let x = TensorData::from([[1.0, 1.0, 0.0], [1.0, 0.0, -1.0]]);

--- a/crates/burn-backend-tests/tests/tensor/int/ops/mod.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/mod.rs
@@ -31,6 +31,7 @@ mod movedim;
 mod mul;
 mod one_hot;
 mod permute;
+mod powi;
 mod random;
 mod remainder;
 mod repeat;

--- a/crates/burn-backend-tests/tests/tensor/int/ops/powi.rs
+++ b/crates/burn-backend-tests/tests/tensor/int/ops/powi.rs
@@ -1,0 +1,25 @@
+use super::*;
+use burn_tensor::TensorData;
+
+#[test]
+fn should_support_powi_broadcast() {
+    // [1, 3] broadcast against [2, 3]
+    let tensor_1 = TestTensorInt::<2>::from([[1, 2, 3]]);
+    let tensor_2 = TestTensorInt::from([[2, 2, 2], [3, 3, 3]]);
+
+    let output = tensor_1.clone().powi(tensor_2);
+    let expected = TensorData::from([[1, 4, 9], [1, 8, 27]]);
+
+    output.into_data().assert_eq(&expected, false);
+}
+
+#[test]
+#[should_panic(expected = "The provided tensors have incompatible shapes.")]
+fn should_panic_powi_incompatible_shapes() {
+    // Same rank, but [2, 2] vs [2, 3]: dimension 1 cannot broadcast.
+    let tensor_1 = TestTensorInt::<2>::from([[1, 2], [3, 4]]);
+    let tensor_2 = TestTensorInt::from([[2, 2, 2], [3, 3, 3]]);
+
+    let output = tensor_1.powi(tensor_2);
+    output.into_data();
+}

--- a/crates/burn-tensor/src/tensor/api/float.rs
+++ b/crates/burn-tensor/src/tensor/api/float.rs
@@ -57,6 +57,7 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     #[cfg_attr(doc, doc = r#"$y_i = \sqrt{x_i^2 + y_i^2}$"#)]
     #[cfg_attr(not(doc), doc = "`y_i = sqrt(x_i^2 + y_i^2)`")]
     pub fn hypot(self, other: Self) -> Self {
+        check!(TensorCheck::binary_ops_ew("Hypot", &self, &other));
         Self::new(hypot_impl(self.primitive, other.primitive))
     }
 
@@ -701,6 +702,7 @@ $$\text{erf}\(x\) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt$$
     /// // [[1.0, 8.0, 81.0], [5.0, 81.0, 216.0]]
     /// ```
     pub fn powf(self, other: Self) -> Self {
+        check!(TensorCheck::binary_ops_ew("Powf", &self, &other));
         Tensor::new(powf_impl(self.primitive, other.primitive))
     }
 
@@ -1084,6 +1086,7 @@ where
     /// println!("{}", lhs.atan2(rhs)); // [-1.1071,  2.0344, -2.0344]
     /// ```
     pub fn atan2(self, other: Self) -> Self {
+        check!(TensorCheck::binary_ops_ew("Atan2", &self, &other));
         Tensor::new(K::atan2(self.primitive, other.primitive))
     }
 }

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -170,6 +170,7 @@ where
     ///
     /// `y = x2 % x1`
     pub fn remainder(self, other: Self) -> Self {
+        check!(TensorCheck::binary_ops_ew("Remainder", &self, &other));
         Self::new(K::remainder(self.primitive, other.primitive))
     }
 
@@ -711,6 +712,7 @@ where
     /// // [[1, -8, 81], [5, 81, 216]]
     /// ```
     pub fn powi(self, other: Self) -> Self {
+        check!(TensorCheck::binary_ops_ew("Power", &self, &other));
         Self::new(K::powi(self.primitive, other.primitive))
     }
 

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -712,7 +712,7 @@ where
     /// // [[1, -8, 81], [5, 81, 216]]
     /// ```
     pub fn powi(self, other: Self) -> Self {
-        check!(TensorCheck::binary_ops_ew("Power", &self, &other));
+        check!(TensorCheck::binary_ops_ew("Powi", &self, &other));
         Self::new(K::powi(self.primitive, other.primitive))
     }
 


### PR DESCRIPTION
## Summary

Closes #5562. Element-wise binary ops like `add`, `sub`, `mul`, and `div` already validate device and broadcast compatibility via `check!(TensorCheck::binary_ops_ew(...))`. Several others went straight to the backend without that check, so a device or broadcast mismatch fell through to backend-specific panics instead of a consistent `Tensor Operation Error`.

## Change

Add `check!(TensorCheck::binary_ops_ew(...))` to five ops, matching the existing pattern:

- `remainder` (numeric)
- `powi` (numeric, int)
- `powf` (float) — same gap as `powi`, flagged in review
- `hypot` (float)
- `atan2` (float)

## Testing

- Regression test per op asserting the `Tensor Operation Error` message: `should_panic_{remainder,powi,powf,hypot,atan2}_incompatible_shapes`
- **Verified each test fails if the check is removed** (not passing for the wrong reason)
- Verified valid broadcasts still pass (e.g. existing `powf_broadcasted`, new `should_support_remainder_broadcast`)
- `cargo test -p burn-backend-tests --features ndarray --test tensor` — 1819 passed, 0 failed

Ref: #5562